### PR TITLE
fix flaky test 02504_regexp_dictionary_ua_parser

### DIFF
--- a/tests/queries/0_stateless/02504_regexp_dictionary_ua_parser.reference
+++ b/tests/queries/0_stateless/02504_regexp_dictionary_ua_parser.reference
@@ -1,793 +1,793 @@
-AppleTV	Other 0.0	ATV OS X 0.0.0
-LG-M150	Firefox Mobile 68.0	Android 7.0.0
-Generic Smartphone	Firefox Mobile 68.0	Android 8.0.0
-Generic Tablet	Firefox Mobile 68.0	Android 8.1.0
-Generic Smartphone	Firefox Mobile 68.0	Android 9.0.0
-PH-1	Chrome Mobile 77.0	Android 10.0.0
-Pixel 2 XL	Chrome Mobile 77.0	Android 10.0.0
-Pixel 2	Chrome Mobile 77.0	Android 10.0.0
-Pixel 3	Facebook 240.0	Android 10.0.0
-Pixel XL	Chrome Mobile WebView 77.0	Android 10.0.0
-Pixel XL	Chrome Mobile 77.0	Android 10.0.0
-HTC Sensation 4G	Chrome Mobile 42.0	Android 4.0.3
-Kindle	Amazon Silk 73.7	Android 4.0.3
-Samsung GT-I9152 	Chrome Mobile 42.0	Android 4.2.2
-Samsung GT-N5110	Chrome 76.0	Android 4.4.2
-RCT6773W22	Chrome 77.0	Android 4.4.2
-Samsung SM-T217S	Chrome 77.0	Android 4.4.2
-Samsung SM-T530NU	Chrome 77.0	Android 4.4.2
-TegraNote-P1640	Chrome 69.0	Android 4.4.2
-Kindle	Amazon Silk 76.3	Android 4.4.3
-Samsung SM-A500H	Chrome Mobile 73.0	Android 5.0.2
-Samsung SM-T357T	Chrome 77.0	Android 5.0.2
-Samsung SM-T530NU	Chrome 76.0	Android 5.0.2
-Samsung SM-T530NU	Chrome 77.0	Android 5.0.2
-RCT6213W87DK	Yandex Browser 19.4	Android 5.0.0
-Samsung SM-N900T	Facebook 229.0	Android 5.0.0
-Generic Smartphone	Chrome Mobile WebView 70.0	Android 5.1.1
-Kindle	Amazon Silk 76.3	Android 5.1.1
-AFTT	Chrome Mobile WebView 70.0	Android 5.1.1
-Kindle	Amazon Silk 76.3	Android 5.1.1
-Kindle	Amazon Silk 76.3	Android 5.1.1
-Kindle	Amazon Silk 71.2	Android 5.1.1
-Kindle	Amazon Silk 76.3	Android 5.1.1
-Kindle	Amazon Silk 76.3	Android 5.1.1
-Kindle	Amazon Silk 76.3	Android 5.1.1
-Kindle	Amazon Silk 76.3	Android 5.1.1
-Kindle	Amazon Silk 77.1	Android 5.1.1
-LG-AS330	Chrome Mobile 77.0	Android 5.1.1
-LGL43AL	Chrome Mobile 77.0	Android 5.1.1
-Samsung SM-G530R7	Samsung Internet 9.2	Android 5.1.1
-Samsung SM-T377P	Samsung Internet 10.1	Android 5.1.1
-Samsung SM-T900	Samsung Internet 10.1	Android 5.1.1
-Samsung SM-T337A	Chrome 69.0	Android 5.1.1
-Samsung SM-G360T1	Chrome Mobile 67.0	Android 5.1.1
-Samsung SM-J320FN	Chrome Mobile 74.0	Android 5.1.1
-SM-T280	Chrome 74.0	Android 5.1.1
-Samsung SM-T330NU	Chrome 71.0	Android 5.1.1
-SM-T670	Chrome 76.0	Android 5.1.1
-SM-T670	Chrome 77.0	Android 5.1.1
-Vodafone Smart ultra 6	Chrome Mobile WebView 74.0	Android 5.1.1
-BLU Advance 5.0	Chrome Mobile 66.0	Android 5.1.0
-HTC Desire 626s	Chrome Mobile 77.0	Android 5.1.0
-HUAWEI LUA-L22	Chrome Mobile 50.0	Android 5.1.0
-NX16A11264	Chrome 77.0	Android 5.1.0
-XT1526	Chrome Mobile 73.0	Android 5.1.0
-Oppo CPH1613	Chrome Mobile 77.0	Android 6.0.1
-LG-M153 	Chrome Mobile WebView 55.0	Android 6.0.1
-LG-M153	Chrome Mobile 77.0	Android 6.0.1
-LGLS676	Chrome Mobile 77.0	Android 6.0.1
-N9136	Chrome Mobile 74.0	Android 6.0.1
-Asus Nexus 7	Chrome 44.0	Android 6.0.1
-Samsung SM-G900I	Samsung Internet 10.1	Android 6.0.1
-Samsung SM-G900P	Samsung Internet 7.2	Android 6.0.1
-Samsung SM-J700M	Samsung Internet 10.1	Android 6.0.1
-Samsung SM-S327VL	Samsung Internet 10.1	Android 6.0.1
-Samsung SM-T377A	Chrome 77.0	Android 6.0.1
-Samsung SM-G532M	Chrome Mobile 55.0	Android 6.0.1
-Samsung SM-G532M	Facebook 240.0	Android 6.0.1
-Samsung SM-G532M	Chrome Mobile 77.0	Android 6.0.1
-Samsung SM-G550T	Chrome Mobile 76.0	Android 6.0.1
-Samsung SM-G550T	Chrome Mobile 77.0	Android 6.0.1
-Samsung SM-G550T1	Chrome Mobile 76.0	Android 6.0.1
-Samsung SM-G900V	Chrome Mobile 73.0	Android 6.0.1
-Samsung SM-G920A	Chrome Mobile 77.0	Android 6.0.1
-Samsung SM-J327P	Chrome Mobile 77.0	Android 6.0.1
-Samsung SM-N910S	Chrome Mobile 75.0	Android 6.0.1
-Samsung SM-N920V	Chrome Mobile 76.0	Android 6.0.1
-Samsung SM-T350	Chrome 59.0	Android 6.0.1
-Samsung SM-T560NU	Chrome 77.0	Android 6.0.1
-SM-T800	Chrome 77.0	Android 6.0.1
-XT1254	Chrome Mobile 77.0	Android 6.0.1
-Z798BL	Chrome Mobile 67.0	Android 6.0.1
-Z799VL	Chrome Mobile WebView 45.0	Android 6.0.1
-5010X	Chrome Mobile 76.0	Android 6.0.0
-Huawei CAM-L21	Chrome Mobile 77.0	Android 6.0.0
-F3313	Chrome Mobile 77.0	Android 6.0.0
-RCT6603W47M7	Chrome 77.0	Android 6.0.0
-5049Z	Chrome Mobile 56.0	Android 7.0.0
-Asus A002A	Chrome Mobile 77.0	Android 7.0.0
-Alcatel_5044C	Chrome Mobile 77.0	Android 7.0.0
-Astra Young Pro	Chrome Mobile WebView 59.0	Android 7.0.0
-Infinix X571	Chrome Mobile 77.0	Android 7.0.0
-LG-H872 	Chrome Mobile 64.0	Android 7.0.0
-LG-K425 	Chrome Mobile 55.0	Android 7.0.0
-LG-LS777	Chrome Mobile 77.0	Android 7.0.0
-LG-M210	Chrome Mobile 77.0	Android 7.0.0
-LG-M430	Chrome Mobile 77.0	Android 7.0.0
-LG-TP260 	Chrome Mobile WebView 64.0	Android 7.0.0
-LG-TP260	Chrome Mobile 77.0	Android 7.0.0
-LG-TP450 	Chrome Mobile 64.0	Android 7.0.0
-LG-V521	Chrome 75.0	Android 7.0.0
-LG-V521	Chrome 77.0	Android 7.0.0
-LGMP260	Chrome Mobile 58.0	Android 7.0.0
-LGMS210	Chrome Mobile 55.0	Android 7.0.0
-LGMS210	Chrome Mobile 77.0	Android 7.0.0
-P00I	Chrome 77.0	Android 7.0.0
-RS988	Chrome Mobile 77.0	Android 7.0.0
-Samsung SM-J701F	Samsung Internet 10.1	Android 7.0.0
-Samsung SM-J710F	Samsung Internet 10.1	Android 7.0.0
-Samsung SM-N920T	Samsung Internet 9.2	Android 7.0.0
-Samsung SM-G920A	Chrome Mobile 77.0	Android 7.0.0
-Samsung SM-G920P	Flipboard 4.2	Android 7.0.0
-Samsung SM-G920V	Chrome Mobile 76.0	Android 7.0.0
-Samsung SM-G928V	Chrome Mobile 77.0	Android 7.0.0
-Samsung SM-G950U	Chrome Mobile 77.0	Android 7.0.0
-Samsung SM-G955U	Chrome Mobile 77.0	Android 7.0.0
-Samsung SM-J327T	Chrome Mobile 74.0	Android 7.0.0
-Samsung SM-J327T	Chrome Mobile 77.0	Android 7.0.0
-Samsung SM-J327T1	Chrome Mobile 64.0	Android 7.0.0
-Samsung SM-J327T1	Chrome Mobile 75.0	Android 7.0.0
-Samsung SM-J327T1	Chrome Mobile 77.0	Android 7.0.0
-Samsung SM-N9208	Chrome Mobile 73.0	Android 7.0.0
-Samsung SM-N920P	Chrome Mobile 74.0	Android 7.0.0
-Samsung SM-N920T	Chrome Mobile 77.0	Android 7.0.0
-SM-T585	Chrome 77.0	Android 7.0.0
-SM-T810	Chrome 75.0	Android 7.0.0
-SM-T810	Chrome 76.0	Android 7.0.0
-SM-T810	Chrome 77.0	Android 7.0.0
-SM-T813	Chrome 76.0	Android 7.0.0
-SM-T813	Chrome 76.0	Android 7.0.0
-Trekstor ST1009X	Chrome 75.0	Android 7.0.0
-XT1663	Chrome Mobile 77.0	Android 7.0.0
-Generic Smartphone	Chrome Mobile 58.0	Android 7.0.0
-A574BL	Chrome Mobile WebView 77.0	Android 7.1.1
-A574BL	Chrome Mobile 77.0	Android 7.1.1
-Oppo CPH1729	Facebook 240.0	Android 7.1.1
-3632A	Chrome Mobile 74.0	Android 7.1.1
-General Mobile 4G Dual	Chrome Mobile 77.0	Android 7.1.1
-Moto E (4) Plus	Chrome Mobile WebView 76.0	Android 7.1.1
-Moto E (4)	Chrome Mobile 70.0	Android 7.1.1
-Moto E (4)	Chrome Mobile 76.0	Android 7.1.1
-Moto E (4)	Chrome Mobile 77.0	Android 7.1.1
-Moto E (4)	Chrome Mobile 77.0	Android 7.1.1
-NX591J	Chrome Mobile 77.0	Android 7.1.1
-REVVLPLUS C3701A	Chrome Mobile 64.0	Android 7.1.1
-Samsung SM-J320A	Samsung Internet 10.1	Android 7.1.1
-Samsung SM-T550	Samsung Internet 10.1	Android 7.1.1
-Samsung SM-T377A	Chrome 64.0	Android 7.1.1
-Samsung SM-J250F	Chrome Mobile 76.0	Android 7.1.1
-Samsung SM-J700T	Chrome Mobile 77.0	Android 7.1.1
-SM-T350	Chrome 77.0	Android 7.1.1
-Samsung SM-T377T	Chrome 77.0	Android 7.1.1
-Samsung SM-T550	Chrome 69.0	Android 7.1.1
-SM-T550	Chrome 77.0	Android 7.1.1
-Samsung SM-T560NU	Chrome 77.0	Android 7.1.1
-X20	Chrome Mobile WebView 52.0	Android 7.1.1
-Z851M	Chrome Mobile 58.0	Android 7.1.1
-Z899VL	Chrome Mobile WebView 74.0	Android 7.1.1
-Z982	Chrome Mobile WebView 75.0	Android 7.1.1
-Z982	Chrome Mobile 77.0	Android 7.1.1
-Generic Smartphone	Chrome Mobile WebView 70.0	Android 7.1.2
-AFTKMST12	Chrome Mobile WebView 70.0	Android 7.1.2
-Kindle	Amazon Silk 76.3	Android 7.1.2
-AFTMM	Chrome Mobile WebView 70.0	Android 7.1.2
-AFTN	Chrome Mobile WebView 70.0	Android 7.1.2
-KFKAWI	Chrome Mobile WebView 59.0	Android 7.1.2
-Kindle	Amazon Silk 76.3	Android 7.1.2
-Kindle	Amazon Silk 76.3	Android 7.1.2
-LG-SP200	Chrome Mobile 75.0	Android 7.1.2
-LG-SP200	Chrome Mobile 76.0	Android 7.1.2
-LM-X210(G)	Chrome Mobile 76.0	Android 7.1.2
-LM-X210	Chrome Mobile 76.0	Android 7.1.2
-RCT6973W43R	Chrome 77.0	Android 7.1.2
-XiaoMi Redmi 4	Chrome Mobile 77.0	Android 7.1.2
-Generic Smartphone	Chrome Mobile WebView 76.0	Android 8.0.0
-Asus Z01FD	Chrome Mobile 77.0	Android 8.0.0
-Huawei AUM-L29	Chrome Mobile 77.0	Android 8.0.0
-BRAVIA 4K GB	Chrome Mobile WebView 77.0	Android 8.0.0
-CMR-W09	Chrome 77.0	Android 8.0.0
-EVA-AL00	Chrome Mobile 77.0	Android 8.0.0
-G3223	Chrome Mobile 77.0	Android 8.0.0
-LG-H910	Chrome Mobile 77.0	Android 8.0.0
-LG-H931	Chrome Mobile 76.0	Android 8.0.0
-LG-H932	Chrome Mobile 77.0	Android 8.0.0
-Samsung SM-A520F	Samsung Internet 10.1	Android 8.0.0
-Samsung SM-G891A	Samsung Internet 8.2	Android 8.0.0
-Samsung SM-G935T	Samsung Internet 10.1	Android 8.0.0
-Samsung SM-G955U	Samsung Internet 10.1	Android 8.0.0
-Samsung SM-J337T	Samsung Internet 9.2	Android 8.0.0
-Samsung SM-J737P	Samsung Internet 10.1	Android 8.0.0
-Samsung SM-N950F	Samsung Internet 10.1	Android 8.0.0
-Samsung SM-G891A	Chrome Mobile 72.0	Android 8.0.0
-Samsung SM-G935A	Chrome Mobile 76.0	Android 8.0.0
-Samsung SM-A720F	Chrome Mobile 77.0	Android 8.0.0
-Samsung SM-G570F	Facebook 231.0	Android 8.0.0
-Samsung SM-G570Y	Chrome Mobile 77.0	Android 8.0.0
-Samsung SM-G930T	Chrome Mobile WebView 77.0	Android 8.0.0
-Samsung SM-G930V	Chrome Mobile 64.0	Android 8.0.0
-Samsung SM-G930VL	Chrome Mobile 74.0	Android 8.0.0
-Samsung SM-G935F	Chrome Mobile 75.0	Android 8.0.0
-Samsung SM-G935P	Chrome Mobile 77.0	Android 8.0.0
-Samsung SM-G935T	Facebook 240.0	Android 8.0.0
-Samsung SM-G935T	Chrome Mobile 77.0	Android 8.0.0
-Samsung SM-G950U	Chrome Mobile 77.0	Android 8.0.0
-Samsung SM-G955U	Chrome Mobile 74.0	Android 8.0.0
-Samsung SM-G955U	Chrome Mobile 77.0	Android 8.0.0
-Samsung SM-J330G	Chrome Mobile 77.0	Android 8.0.0
-Samsung SM-J337T	Chrome Mobile 77.0	Android 8.0.0
-Samsung SM-J737A	Chrome Mobile 77.0	Android 8.0.0
-Samsung SM-J737T1	Chrome Mobile 66.0	Android 8.0.0
-Samsung SM-J737T1	Chrome Mobile 77.0	Android 8.0.0
-Samsung SM-N950F	Chrome Mobile 66.0	Android 8.0.0
-Samsung SM-N950U	Chrome Mobile 76.0	Android 8.0.0
-Samsung SM-N950U	Chrome Mobile 77.0	Android 8.0.0
-Samsung SM-N950U1	Chrome Mobile 77.0	Android 8.0.0
-Samsung SM-S367VL	Chrome Mobile 77.0	Android 8.0.0
-VS995	Chrome Mobile 77.0	Android 8.0.0
-XT1635-02	Chrome Mobile 77.0	Android 8.0.0
-moto e5 play	Chrome Mobile 76.0	Android 8.0.0
-moto e5 play	Chrome Mobile 77.0	Android 8.0.0
-moto e5 supra	Chrome Mobile 76.0	Android 8.0.0
-moto g(6)	Chrome Mobile 77.0	Android 8.0.0
-5041C	Chrome Mobile 77.0	Android 8.1.0
-6062W	Chrome Mobile 77.0	Android 8.1.0
-A502DL	Chrome Mobile 67.0	Android 8.1.0
-A502DL	Chrome Mobile 76.0	Android 8.1.0
-Huawei BKK-LX2	Chrome Mobile 76.0	Android 8.1.0
-C4	Chrome Mobile 70.0	Android 8.1.0
-3310A	Chrome Mobile 77.0	Android 8.1.0
-Infinix X604	Chrome Mobile 64.0	Android 8.1.0
-Joy 1	Chrome Mobile 77.0	Android 8.1.0
-LAVA LE9820	Chrome Mobile 77.0	Android 8.1.0
-LG-Q710AL	Chrome Mobile 77.0	Android 8.1.0
-LM-Q610(FGN)	Chrome Mobile 77.0	Android 8.1.0
-LM-Q710(FGN)	Facebook 235.0	Android 8.1.0
-LM-Q710(FGN)	Chrome Mobile 70.0	Android 8.1.0
-LM-Q710(FGN)	Chrome Mobile 76.0	Android 8.1.0
-LM-Q710(FGN)	Chrome Mobile 76.0	Android 8.1.0
-LM-Q710(FGN)	Chrome Mobile 77.0	Android 8.1.0
-LM-V405	Chrome Mobile 77.0	Android 8.1.0
-LM-X210(G)	UC Browser 11.6	Android 8.1.0
-LM-X210(G)	Chrome Mobile 70.0	Android 8.1.0
-LM-X210(G)	Chrome Mobile 72.0	Android 8.1.0
-LM-X210(G)	Chrome Mobile 77.0	Android 8.1.0
-LM-X212(G)	Chrome Mobile 77.0	Android 8.1.0
-LM-X220	Chrome Mobile 70.0	Android 8.1.0
-LM-X220	Chrome Mobile 76.0	Android 8.1.0
-LM-X220PM	Chrome Mobile WebView 77.0	Android 8.1.0
-LM-X410(FG)	Chrome Mobile 70.0	Android 8.1.0
-LM-X410(FG)	Chrome Mobile 76.0	Android 8.1.0
-LM-X410(FG)	Chrome Mobile 77.0	Android 8.1.0
-LM-X410.FGN	Chrome Mobile 68.0	Android 8.1.0
-LML414DL	Chrome Mobile 76.0	Android 8.1.0
-LML713DL	Chrome Mobile 77.0	Android 8.1.0
-Moto G (5S) Plus	Chrome Mobile 77.0	Android 8.1.0
-HTC One	Chrome Mobile WebView 70.0	Android 8.1.0
-RCT6873W42BMF8KC	Chrome Mobile 77.0	Android 8.1.0
-REVVL 2	Chrome Mobile 67.0	Android 8.1.0
-REVVL 2	Chrome Mobile 76.0	Android 8.1.0
-Samsung SM-J727T	Samsung Internet 10.1	Android 8.1.0
-Samsung SM-J727T1	Samsung Internet 9.4	Android 8.1.0
-Samsung SM-J727T1	Samsung Internet 10.1	Android 8.1.0
-Samsung SM-T580	Samsung Internet 9.4	Android 8.1.0
-Samsung SM-J727A	Facebook 240.0	Android 8.1.0
-Samsung SM-G610F	Chrome Mobile 77.0	Android 8.1.0
-Samsung SM-J260T1	Chrome Mobile 76.0	Android 8.1.0
-Samsung SM-J260T1	Chrome Mobile 76.0	Android 8.1.0
-Samsung SM-J260T1	Chrome Mobile 77.0	Android 8.1.0
-Samsung SM-J410F	Chrome Mobile 77.0	Android 8.1.0
-Samsung SM-J727P	Chrome Mobile 68.0	Android 8.1.0
-Samsung SM-J727T	Chrome Mobile 66.0	Android 8.1.0
-Samsung SM-J727T1	Chrome Mobile 76.0	Android 8.1.0
-Samsung SM-J727T1	Chrome Mobile 77.0	Android 8.1.0
-Samsung SM-J727T1	Chrome Mobile 77.0	Android 8.1.0
-Samsung SM-J727V	Chrome Mobile 70.0	Android 8.1.0
-Samsung SM-J727V	Chrome Mobile 77.0	Android 8.1.0
-SM-P580	Chrome 77.0	Android 8.1.0
-SM-T380	Chrome 75.0	Android 8.1.0
-SM-T580	Edge Mobile 42.0	Android 8.1.0
-SM-T580	Chrome 76.0	Android 8.1.0
-SM-T580	Chrome 76.0	Android 8.1.0
-SM-T580	Chrome 77.0	Android 8.1.0
-Samsung SM-T837T	Chrome 77.0	Android 8.1.0
-TECNO CF8	Facebook 239.0	Android 8.1.0
-V1818CA	Chrome Mobile 75.0	Android 8.1.0
-meizu C9	Chrome Mobile 68.0	Android 8.1.0
-vivo 1724	Chrome Mobile 76.0	Android 8.1.0
-vivo 1814	Chrome Mobile 77.0	Android 8.1.0
-Generic Smartphone	DuckDuckGo Mobile 5.0	Android 9.0.0
-1825	Chrome Mobile 70.0	Android 9.0.0
-ANE-LX2	Facebook 236.0	Android 9.0.0
-BLA-A09	Chrome Mobile 77.0	Android 9.0.0
-Huawei CLT-L04	Chrome Mobile 77.0	Android 9.0.0
-Oppo CPH1911	Facebook 239.0	Android 9.0.0
-Oppo CPH1923	Chrome Mobile WebView 76.0	Android 9.0.0
-Huawei ELE-L29	Chrome Mobile 77.0	Android 9.0.0
-G8142	Chrome Mobile 77.0	Android 9.0.0
-GM1911	Chrome Mobile 76.0	Android 9.0.0
-GM1917	Chrome Mobile 77.0	Android 9.0.0
-Huawei INE-LX2	Chrome Mobile 76.0	Android 9.0.0
-LM-G710	Chrome Mobile WebView 77.0	Android 9.0.0
-LM-Q720	Chrome Mobile 77.0	Android 9.0.0
-LM-V405	Chrome Mobile WebView 77.0	Android 9.0.0
-LM-V405	Chrome Mobile 76.0	Android 9.0.0
-LM-V500N	Chrome Mobile 77.0	Android 9.0.0
-LM-X420	Chrome Mobile 72.0	Android 9.0.0
-LM-X420	Chrome Mobile 77.0	Android 9.0.0
-MAR-LX1A	Chrome Mobile 77.0	Android 9.0.0
-XiaoMi MI 9	Chrome Mobile 77.0	Android 9.0.0
-XiaoMi Mi A2	Chrome Mobile 77.0	Android 9.0.0
-Moto Z (2)	Chrome Mobile 77.0	Android 9.0.0
-Nokia 6	Chrome Mobile 77.0	Android 9.0.0
-OnePlus ONEPLUS A6000	Chrome Mobile 77.0	Android 9.0.0
-OnePlus ONEPLUS A6003	Chrome Mobile 77.0	Android 9.0.0
-OnePlus ONEPLUS A6013	Chrome Mobile WebView 77.0	Android 9.0.0
-OnePlus ONEPLUS A6013	Chrome Mobile 74.0	Android 9.0.0
-OnePlus ONEPLUS A6013	Chrome Mobile 77.0	Android 9.0.0
-PAR-AL00	Facebook 235.0	Android 9.0.0
-Pixel 2 XL	Chrome Mobile 77.0	Android 9.0.0
-Pixel 3	Chrome Mobile WebView 77.0	Android 9.0.0
-Pixel 3	Chrome Mobile 76.0	Android 9.0.0
-Pixel 3	Chrome Mobile 77.0	Android 9.0.0
-Pixel 3a XL	Chrome Mobile 77.0	Android 9.0.0
-REVVLRY 	Chrome Mobile 73.0	Android 9.0.0
-Oppo RMX1801	Chrome Mobile 75.0	Android 9.0.0
-XiaoMi Redmi 7	Chrome Mobile 77.0	Android 9.0.0
-XiaoMi Redmi Note 7	Chrome Mobile 76.0	Android 9.0.0
-Samsung SM-A102U	Samsung Internet 10.1	Android 9.0.0
-Samsung SM-A505FN	Samsung Internet 10.1	Android 9.0.0
-Samsung SM-A505GN	Samsung Internet 10.1	Android 9.0.0
-Samsung SM-G892U	Samsung Internet 10.1	Android 9.0.0
-Samsung SM-G950U	Samsung Internet 10.1	Android 9.0.0
-Samsung SM-G955F	Samsung Internet 9.4	Android 9.0.0
-Samsung SM-G955U	Samsung Internet 10.1	Android 9.0.0
-Samsung SM-G9600	Samsung Internet 9.4	Android 9.0.0
-Samsung SM-G960U	Samsung Internet 10.1	Android 9.0.0
-Samsung SM-G965U	Samsung Internet 10.1	Android 9.0.0
-Samsung SM-G970F	Samsung Internet 10.1	Android 9.0.0
-Samsung SM-G970U	Samsung Internet 10.1	Android 9.0.0
-Samsung SM-G973U	Samsung Internet 9.4	Android 9.0.0
-Samsung SM-G973U	Samsung Internet 10.1	Android 9.0.0
-Samsung SM-G975U	Samsung Internet 10.1	Android 9.0.0
-Samsung SM-J415F	Samsung Internet 10.1	Android 9.0.0
-Samsung SM-J730F	Samsung Internet 10.1	Android 9.0.0
-Samsung SM-J737P	Samsung Internet 10.1	Android 9.0.0
-Samsung SM-J737T	Samsung Internet 9.0	Android 9.0.0
-Samsung SM-N950U	Samsung Internet 10.1	Android 9.0.0
-Samsung SM-N960F	Samsung Internet 10.1	Android 9.0.0
-Samsung SM-N960U	Samsung Internet 10.1	Android 9.0.0
-Samsung SM-N960U1	Samsung Internet 9.2	Android 9.0.0
-Samsung SM-N970U	Samsung Internet 10.1	Android 9.0.0
-Samsung SM-N975U	Samsung Internet 10.1	Android 9.0.0
-Samsung SM-N975U1	Samsung Internet 10.1	Android 9.0.0
-Samsung SM-T510	Samsung Internet 10.1	Android 9.0.0
-Samsung SM-T720	Samsung Internet 10.1	Android 9.0.0
-SHIELD Android TV	Chrome Mobile WebView 77.0	Android 9.0.0
-Samsung SM-A102U	Chrome Mobile 72.0	Android 9.0.0
-Samsung SM-A102U	Chrome Mobile 77.0	Android 9.0.0
-Samsung SM-A105M	Facebook 237.0	Android 9.0.0
-Samsung SM-A205G	Chrome Mobile 77.0	Android 9.0.0
-Samsung SM-A205U	Chrome Mobile 77.0	Android 9.0.0
-Samsung SM-A505F	Chrome Mobile 77.0	Android 9.0.0
-Samsung SM-A530F	Facebook 240.0	Android 9.0.0
-Samsung SM-A530N	Chrome Mobile WebView 77.0	Android 9.0.0
-Samsung SM-A600T	Chrome Mobile 77.0	Android 9.0.0
-Samsung SM-A605F	Chrome Mobile 77.0	Android 9.0.0
-Samsung SM-A920F	Chrome Mobile 77.0	Android 9.0.0
-Samsung SM-G892A	Chrome Mobile 74.0	Android 9.0.0
-Samsung SM-G950F	Chrome Mobile 77.0	Android 9.0.0
-Samsung SM-G950U	Chrome Mobile WebView 77.0	Android 9.0.0
-Samsung SM-G950U	Chrome Mobile 71.0	Android 9.0.0
-Samsung SM-G950U	Chrome Mobile 76.0	Android 9.0.0
-Samsung SM-G950U	Chrome Mobile 76.0	Android 9.0.0
-Samsung SM-G950U	Chrome Mobile 77.0	Android 9.0.0
-Samsung SM-G950U1	Chrome Mobile 77.0	Android 9.0.0
-Samsung SM-G955F	Chrome Mobile 77.0	Android 9.0.0
-Samsung SM-G955U	Facebook 240.0	Android 9.0.0
-Samsung SM-G955U	Chrome Mobile 77.0	Android 9.0.0
-Samsung SM-G9600	Chrome Mobile 77.0	Android 9.0.0
-Samsung SM-G960U	Facebook 233.0	Android 9.0.0
-Samsung SM-G960U	Chrome Mobile WebView 77.0	Android 9.0.0
-Samsung SM-G960U	Chrome Mobile 71.0	Android 9.0.0
-Samsung SM-G960U	Chrome Mobile 74.0	Android 9.0.0
-Samsung SM-G960U	Chrome Mobile 77.0	Android 9.0.0
-Samsung SM-G960U1	Facebook 240.0	Android 9.0.0
-Samsung SM-G960U1	Chrome Mobile 77.0	Android 9.0.0
-Samsung SM-G965F	Chrome Mobile 77.0	Android 9.0.0
-Samsung SM-G965U	Chrome Mobile 74.0	Android 9.0.0
-Samsung SM-G965U	Chrome Mobile 77.0	Android 9.0.0
-Samsung SM-G965U	Chrome Mobile 79.0	Android 9.0.0
-Samsung SM-G965U1	Chrome Mobile 77.0	Android 9.0.0
-Samsung SM-G970U	Facebook 240.0	Android 9.0.0
-Samsung SM-G970U	Chrome Mobile 75.0	Android 9.0.0
-Samsung SM-G970U	Chrome Mobile 77.0	Android 9.0.0
-Samsung SM-G970U1	Chrome Mobile WebView 77.0	Android 9.0.0
-Samsung SM-G973U	Chrome Mobile 74.0	Android 9.0.0
-Samsung SM-G973U	Chrome Mobile 77.0	Android 9.0.0
-Samsung SM-G973U1	Chrome Mobile 77.0	Android 9.0.0
-Samsung SM-G975U	Chrome Mobile 75.0	Android 9.0.0
-Samsung SM-G975U	Chrome Mobile 76.0	Android 9.0.0
-Samsung SM-G975U	Chrome Mobile 77.0	Android 9.0.0
-Samsung SM-G975U1	Chrome Mobile 77.0	Android 9.0.0
-Samsung SM-J260A	Chrome Mobile 77.0	Android 9.0.0
-Samsung SM-J337P	Chrome Mobile 76.0	Android 9.0.0
-Samsung SM-J600FN	Chrome Mobile 75.0	Android 9.0.0
-Samsung SM-J600G	Facebook 238.0	Android 9.0.0
-Samsung SM-J730F	Chrome Mobile 77.0	Android 9.0.0
-Samsung SM-J737A	Chrome Mobile WebView 77.0	Android 9.0.0
-Samsung SM-J737A	Chrome Mobile 74.0	Android 9.0.0
-Samsung SM-J737V	Pinterest 0.0	Android 9.0.0
-Samsung SM-J737V	Chrome Mobile 77.0	Android 9.0.0
-Samsung SM-J810M	Chrome Mobile 77.0	Android 9.0.0
-Samsung SM-N950U	Facebook 240.0	Android 9.0.0
-Samsung SM-N950U	Chrome Mobile 72.0	Android 9.0.0
-Samsung SM-N950U	Chrome Mobile 75.0	Android 9.0.0
-Samsung SM-N950U	Chrome Mobile 77.0	Android 9.0.0
-Samsung SM-N950U	Chrome Mobile 77.0	Android 9.0.0
-Samsung SM-N960F	Chrome Mobile 76.0	Android 9.0.0
-Samsung SM-N960U	Facebook 240.0	Android 9.0.0
-Samsung SM-N960U	Chrome Mobile WebView 77.0	Android 9.0.0
-Samsung SM-N960U	Chrome Mobile 74.0	Android 9.0.0
-Samsung SM-N960U	Chrome Mobile 75.0	Android 9.0.0
-Samsung SM-N960U	Chrome Mobile 76.0	Android 9.0.0
-Samsung SM-N960U	Chrome Mobile 77.0	Android 9.0.0
-Samsung SM-N960U1	Chrome Mobile 77.0	Android 9.0.0
-Samsung SM-N975U	Chrome Mobile WebView 77.0	Android 9.0.0
-Samsung SM-N975U	Chrome Mobile WebView 77.0	Android 9.0.0
-Samsung SM-N975U	Chrome Mobile 77.0	Android 9.0.0
-Samsung SM-N976V	Facebook 240.0	Android 9.0.0
-Samsung SM-S367VL	Chrome Mobile 77.0	Android 9.0.0
-Samsung SM-S767VL	Chrome Mobile 76.0	Android 9.0.0
-Samsung SM-T597P	Chrome 77.0	Android 9.0.0
-SM-T720	Chrome 77.0	Android 9.0.0
-TECNO KC8	Chrome Mobile 77.0	Android 9.0.0
-Huawei VOG-L29	Chrome Mobile 77.0	Android 9.0.0
-cp3705A	Chrome Mobile 74.0	Android 9.0.0
-moto g(6)	Chrome Mobile WebView 77.0	Android 9.0.0
-moto g(6) play	Chrome Mobile 77.0	Android 9.0.0
-moto g(7) play	Facebook 235.0	Android 9.0.0
-moto g(7) play	Chrome Mobile 70.0	Android 9.0.0
-moto g(7) power	Chrome Mobile 75.0	Android 9.0.0
-moto g(7) power	Chrome Mobile 77.0	Android 9.0.0
-moto z4	Chrome Mobile 73.0	Android 9.0.0
-moto z4	Chrome Mobile 77.0	Android 9.0.0
-Samsung GT-P3113 	Android 4.1	Android 4.1.1
-Samsung GT-I8160 	Android 4.1	Android 4.1.2
-Asus Nexus 7	Android 4.2	Android 4.2.2
-Samsung SM-E500H	Android 4.4	Android 4.4.0
-LGMS550	Chrome Mobile WebView 43.0	Android 6.0.1
-Samsung SM-J737T1	Chrome Mobile WebView 43.0	Android 6.0.1
-TECNO CA6	Opera Mobile 5.3	Android 7.0.0
-XiaoMi Redmi 5A	MiuiBrowser 9.5	Android 7.1.2
-Oppo CPH1911	Chrome Mobile WebView 70.0	Android 9.0.0
-vivo 1904	Opera Mobile 44.1	Android 9.0.0
-Mac	Firefox 68.0	Mac OS X 10.11.0
-Mac	Firefox 69.0	Mac OS X 10.13.0
-Mac	Firefox 67.0	Mac OS X 10.14.0
-Mac	Firefox 68.0	Mac OS X 10.14.0
-Mac	Firefox 69.0	Mac OS X 10.14.0
-Mac	Firefox 70.0	Mac OS X 10.14.0
-Mac	Chrome 76.0	Mac OS X 10.10.5
-Mac	Chrome 77.0	Mac OS X 10.10.5
-Mac	Safari 10.1	Mac OS X 10.10.5
-Mac	Chrome 76.0	Mac OS X 10.11.4
-Mac	Chrome 72.0	Mac OS X 10.11.6
-Mac	Chrome 76.0	Mac OS X 10.11.6
-Mac	Chrome 76.0	Mac OS X 10.11.6
-Mac	Chrome 77.0	Mac OS X 10.11.6
-Mac	Safari 9.1	Mac OS X 10.11.6
-Mac	Safari 10.0	Mac OS X 10.11.6
-Mac	Safari 11.1	Mac OS X 10.11.6
-Mac	Chrome 77.0	Mac OS X 10.12.1
-Mac	Safari 10.0	Mac OS X 10.12.3
-Mac	Chrome 75.0	Mac OS X 10.12.6
-Mac	Chrome 76.0	Mac OS X 10.12.6
-Mac	Chrome 76.0	Mac OS X 10.12.6
-Mac	Chrome 77.0	Mac OS X 10.12.6
-Mac	Safari 12.1	Mac OS X 10.12.6
-Mac	Safari 11.0	Mac OS X 10.13.0
-Mac	Chrome 77.0	Mac OS X 10.13.1
-Mac	Chrome 77.0	Mac OS X 10.13.2
-Mac	Chrome 76.0	Mac OS X 10.13.4
-Mac	Chrome 76.0	Mac OS X 10.13.4
-Mac	Chrome 76.0	Mac OS X 10.13.5
-Mac	Chrome 75.0	Mac OS X 10.13.6
-Mac	Chrome 76.0	Mac OS X 10.13.6
-Mac	Chrome 77.0	Mac OS X 10.13.6
-Mac	Safari 12.0	Mac OS X 10.13.6
-Mac	Safari 12.1	Mac OS X 10.13.6
-Mac	Safari 12.1	Mac OS X 10.13.6
-Mac	Safari 13.0	Mac OS X 10.13.6
-Mac	Safari 13.0	Mac OS X 10.13.6
-Mac	Chrome 75.0	Mac OS X 10.14.0
-Mac	Chrome 76.0	Mac OS X 10.14.0
-Mac	Chrome 77.0	Mac OS X 10.14.0
-Mac	Chrome 77.0	Mac OS X 10.14.1
-Mac	Chrome 76.0	Mac OS X 10.14.2
-Mac	Chrome 69.0	Mac OS X 10.14.3
-Mac	Safari 12.0	Mac OS X 10.14.3
-Mac	Chrome 75.0	Mac OS X 10.14.4
-Mac	Chrome 77.0	Mac OS X 10.14.4
-Mac	Safari 12.1	Mac OS X 10.14.4
-Mac	Chrome 76.0	Mac OS X 10.14.5
-Mac	Chrome 77.0	Mac OS X 10.14.5
-Mac	Safari 12.1	Mac OS X 10.14.5
-Mac	Chrome 75.0	Mac OS X 10.14.6
-Mac	Chrome 76.0	Mac OS X 10.14.6
-Mac	Chrome 76.0	Mac OS X 10.14.6
-Mac	Chrome 77.0	Mac OS X 10.14.6
-Mac	Chrome 77.0	Mac OS X 10.14.6
-Mac	Safari 12.1	Mac OS X 10.14.6
-Mac	Safari 13.0	Mac OS X 10.14.6
-Mac	Chrome 65.0	Mac OS X 10.9.5
-Mac	Chrome 66.0	Mac OS X 10.9.5
-Mac	Chrome 67.0	Mac OS X 10.9.5
-PlayStation 4	Apple Mail 605.1	Other 0.0.0
-Samsung SMART-TV	Safari 3.0	Tizen 3.0.0
-Samsung SMART-TV	Samsung Internet 2.0	Tizen 3.0.0
-Samsung SMART-TV	Samsung Internet 2.1	Tizen 4.0.0
-Samsung SMART-TV	Samsung Internet 2.2	Tizen 5.0.0
-Other	Edge 17.17134	Windows 10.0.0
-Other	Edge 18.17763	Windows 10.0.0
-Other	Chrome 77.0	Windows 10.0.0
-Other	Maxthon 5.2	Windows 10.0.0
-Other	Chrome 73.1	Windows 10.0.0
-Other	Chrome 76.0	Windows 10.0.0
-Other	Opera 63.0	Windows 10.0.0
-Other	Chrome 77.0	Windows 10.0.0
-Other	Chrome 77.0	Windows 10.0.0
-Other	Coc Coc 82.0	Windows 10.0.0
-Other	IE 11.0	Windows 10.0.0
-Other	Firefox 59.0	Windows 10.0.0
-Other	Firefox 60.0	Windows 10.0.0
-Other	Edge 15.15063	Windows 10.0.0
-Other	Edge 16.16299	Windows 10.0.0
-Other	Edge 17.17134	Windows 10.0.0
-Other	Edge 18.17763	Windows 10.0.0
-Other	Chrome 65.0	Windows 10.0.0
-Other	Chrome 70.0	Windows 10.0.0
-Other	Edge 18.18362	Windows 10.0.0
-Other	Edge 18.18995	Windows 10.0.0
-Other	Edge 18.19493	Windows 10.0.0
-Other	Chrome 70.0	Windows 10.0.0
-Other	Chrome 71.0	Windows 10.0.0
-Other	Chrome 73.0	Windows 10.0.0
-Other	Chrome 74.0	Windows 10.0.0
-Other	Chrome 75.0	Windows 10.0.0
-Other	Chrome 76.0	Windows 10.0.0
-Other	Vivaldi 2.7	Windows 10.0.0
-Other	Chrome 76.0	Windows 10.0.0
-Other	Opera 63.0	Windows 10.0.0
-Other	Chrome 77.0	Windows 10.0.0
-Other	Chrome 77.0	Windows 10.0.0
-Other	Edge 79.0	Windows 10.0.0
-Other	Edge 18.18362	Windows 10.0.0
-Other	Edge 18.18363	Windows 10.0.0
-Other	Edge 18.18362	Windows 10.0.0
-Other	Firefox 61.0	Windows 10.0.0
-Other	Firefox 63.0	Windows 10.0.0
-Other	Firefox 67.0	Windows 10.0.0
-Other	Firefox 68.0	Windows 10.0.0
-Other	Firefox 69.0	Windows 10.0.0
-Other	Firefox 69.0	Windows 10.0.0
-Other	Chrome 49.0	Windows XP.0.0
-Other	Chrome 49.0	Windows Vista.0.0
-Other	Chrome 49.0	Windows Vista.0.0
-Other	Chrome 76.0	Windows 7.0.0
-Other	Chrome 77.0	Windows 7.0.0
-Other	Chrome 77.0	Windows 7.0.0
-Other	Coc Coc 80.0	Windows 7.0.0
-Other	Coc Coc 82.0	Windows 7.0.0
-Other	IE 11.0	Windows 7.0.0
-Other	Chrome 67.0	Windows 7.0.0
-Other	Chrome 70.0	Windows 7.0.0
-Other	Chrome 72.0	Windows 7.0.0
-Other	Chrome 74.0	Windows 7.0.0
-Other	Chrome 75.0	Windows 7.0.0
-Other	Chrome 76.0	Windows 7.0.0
-Other	Chrome 76.0	Windows 7.0.0
-Other	Chrome 77.0	Windows 7.0.0
-Other	Waterfox 56.2	Windows 7.0.0
-Other	Firefox 60.0	Windows 7.0.0
-Other	Firefox 63.0	Windows 7.0.0
-Other	Firefox 68.0	Windows 7.0.0
-Other	Firefox 69.0	Windows 7.0.0
-Other	Firefox 69.0	Windows 7.0.0
-Other	Chrome 77.0	Windows 8.0.0
-Other	Firefox 69.0	Windows 8.0.0
-Other	Chrome 77.0	Windows 8.1.0
-Other	IE 11.0	Windows RT 8.1.0
-Other	IE 11.0	Windows 8.1.0
-Other	IE 11.0	Windows 8.1.0
-Other	Chrome 63.0	Windows 8.1.0
-Other	Chrome 64.0	Windows 8.1.0
-Other	Chrome 76.0	Windows 8.1.0
-Other	Chrome 76.0	Windows 8.1.0
-Other	Chrome 77.0	Windows 8.1.0
-Other	Firefox 69.0	Windows 8.1.0
-Other	Firefox 69.0	Windows 8.1.0
-Other	Chrome 72.0	Windows 10.0.0
-Other	Chrome 77.0	Chrome OS 12371.75.0
-Other	Chrome 76.0	Chrome OS 12239.92.0
-Other	Chrome 69.0	Chrome OS 10895.78.0
-Other	Chrome 70.0	Chrome OS 11021.81.0
-Other	Chrome 74.0	Chrome OS 11895.118.0
-Other	Chrome 76.0	Chrome OS 12239.92.0
-Other	Chrome 76.0	Chrome OS 12239.92.1
-Other	Chrome 76.0	Chrome OS 12239.92.4
-Other	Chrome 77.0	Chrome OS 12371.46.0
-Other	Chrome 77.0	Chrome OS 12371.65.0
-Other	Chrome 75.0	Linux 0.0.0
-Other	Chrome 77.0	Linux 0.0.0
-Other	Samsung Internet 10.1	Linux 0.0.0
-Other	Chrome 66.0	Linux 0.0.0
-Other	Chrome 66.0	Linux 0.0.0
-Other	Chrome 66.0	Linux 0.0.0
-Other	Chrome 66.0	Linux 0.0.0
-Other	Chrome 66.0	Linux 0.0.0
-Other	Firefox 65.0	Ubuntu 0.0.0
-Other	Firefox 66.0	Ubuntu 0.0.0
-Other	Firefox 67.0	Ubuntu 0.0.0
-iPad	Google 22.0	iOS 10.3.3
-iPad	Chrome Mobile iOS 71.0	iOS 10.3.3
-iPad	Firefox iOS 14.0	iOS 10.3.3
-iPad	Mobile Safari UI/WKWebView 0.0	iOS 10.3.3
-iPad	Facebook 240.0	iOS 10.3.3
-iPad	Mobile Safari 10.0	iOS 10.3.3
-iPad	Mobile Safari 10.0	iOS 10.3.4
-iPad	Chrome Mobile iOS 76.0	iOS 11.1.0
-iPad	Chrome Mobile iOS 76.0	iOS 11.1.2
-iPad	Mobile Safari 11.0	iOS 11.2.1
-iPad	Mobile Safari 11.0	iOS 11.2.2
-iPad	Mobile Safari 11.0	iOS 11.2.6
-iPad	Mobile Safari 11.0	iOS 11.3.0
-iPad	Mobile Safari 11.0	iOS 11.4.0
-iPad	Mobile Safari UI/WKWebView 0.0	iOS 11.4.1
-iPad	Mobile Safari 11.0	iOS 11.4.1
-iPad	Google 83.0	iOS 12.0.0
-iPad	Mobile Safari 12.0	iOS 12.0.0
-iPad	Chrome Mobile iOS 75.0	iOS 12.1.0
-iPad	Chrome Mobile iOS 76.0	iOS 12.1.0
-iPad	Mobile Safari UI/WKWebView 0.0	iOS 12.1.0
-iPad	Mobile Safari 12.0	iOS 12.1.0
-iPad	Mobile Safari 12.0	iOS 12.1.1
-iPad	Google 48.0	iOS 12.1.4
-iPad	Mobile Safari UI/WKWebView 0.0	iOS 12.1.4
-iPad	Mobile Safari 12.0	iOS 12.1.4
-iPad	Chrome Mobile iOS 76.0	iOS 12.2.0
-iPad	Mobile Safari UI/WKWebView 0.0	iOS 12.2.0
-iPad	Mobile Safari 12.1	iOS 12.2.0
-iPad	Chrome Mobile iOS 77.0	iOS 12.3.0
-iPad	Google 83.0	iOS 12.3.0
-iPad	Mobile Safari 12.1	iOS 12.3.0
-iPad	Mobile Safari UI/WKWebView 0.0	iOS 12.3.1
-iPad	Mobile Safari 12.1	iOS 12.3.1
-iPad	Chrome Mobile iOS 76.0	iOS 12.4.0
-iPad	Chrome Mobile iOS 76.0	iOS 12.4.0
-iPad	Chrome Mobile iOS 77.0	iOS 12.4.0
-iPad	Chrome Mobile iOS 77.0	iOS 12.4.0
-iPad	Chrome Mobile iOS 77.0	iOS 12.4.0
-iPad	Google 74.0	iOS 12.4.0
-iPad	Google 83.0	iOS 12.4.0
-iPad	Mobile Safari UI/WKWebView 0.0	iOS 12.4.0
-iPad	Mobile Safari 12.1	iOS 12.4.0
-iPad	Chrome Mobile iOS 67.0	iOS 12.4.1
-iPad	Firefox iOS 19.0	iOS 12.4.1
-iPad	Mobile Safari UI/WKWebView 0.0	iOS 12.4.1
-iPad	Facebook 0.0	iOS 12.4.1
-iPad	Facebook 0.0	iOS 12.4.1
-iPad	Facebook 0.0	iOS 12.4.1
-iPad	Facebook 0.0	iOS 12.4.1
-iPad	Mobile Safari 12.1	iOS 12.4.1
-iPad	Mobile Safari 6.0	iOS 6.1.3
-iPad	Mobile Safari 8.0	iOS 8.0.0
-iPad	Mobile Safari 8.0	iOS 8.2.0
-iPad	Google 23.1	iOS 8.4.0
-iPad	Mobile Safari 9.0	iOS 9.3.2
-iPad	Mobile Safari 9.0	iOS 9.3.5
-iPhone	Mobile Safari 10.0	iOS 10.2.0
-iPhone	Facebook 0.0	iOS 10.3.3
-iPhone	Google 68.0	iOS 10.3.4
-iPhone	Mobile Safari 10.0	iOS 10.3.4
-iPhone	Mobile Safari 11.0	iOS 11.0.3
-iPhone	Mobile Safari 11.0	iOS 11.1.1
-iPhone	Mobile Safari 11.0	iOS 11.1.2
-iPhone	Mobile Safari 11.0	iOS 11.2.1
-iPhone	Facebook 207.0	iOS 11.2.6
-iPhone	Chrome Mobile iOS 76.0	iOS 11.3.0
-iPhone	Facebook 0.0	iOS 11.3.0
-iPhone	Mobile Safari 11.0	iOS 11.3.0
-iPhone	Google 83.0	iOS 11.4.0
-iPhone	Mobile Safari 11.0	iOS 11.4.0
-iPhone	Google 74.1	iOS 11.4.1
-iPhone	Mobile Safari 11.0	iOS 11.4.1
-iPhone	Mobile Safari 12.0	iOS 12.0.0
-iPhone	Mobile Safari 12.0	iOS 12.1.0
-iPhone	Mobile Safari 12.0	iOS 12.1.1
-iPhone	Google 74.1	iOS 12.1.2
-iPhone	Facebook 0.0	iOS 12.1.2
-iPhone	Mobile Safari 12.0	iOS 12.1.2
-iPhone	Mobile Safari 12.0	iOS 12.1.3
-iPhone	Google 74.1	iOS 12.1.4
-iPhone	Mobile Safari 12.0	iOS 12.1.4
-iPhone	Chrome Mobile iOS 72.0	iOS 12.2.0
-iPhone	Chrome Mobile iOS 76.0	iOS 12.2.0
-iPhone	Chrome Mobile iOS 77.0	iOS 12.2.0
-iPhone	Facebook 0.0	iOS 12.2.0
-iPhone	Facebook 0.0	iOS 12.2.0
-iPhone	Mobile Safari 12.1	iOS 12.2.0
-iPhone	Chrome Mobile iOS 77.0	iOS 12.3.0
-iPhone	Google 83.0	iOS 12.3.0
-iPhone	Mobile Safari 12.1	iOS 12.3.0
-iPhone	Google 79.0	iOS 12.3.1
-iPhone	Mobile Safari UI/WKWebView 0.0	iOS 12.3.1
-iPhone	DuckDuckGo Mobile 7.0	iOS 12.3.1
-iPhone	Facebook 0.0	iOS 12.3.1
-iPhone	Facebook 0.0	iOS 12.3.1
-iPhone	Facebook 0.0	iOS 12.3.1
-iPhone	Mobile Safari 12.1	iOS 12.3.1
-iPhone	Mobile Safari 12.1	iOS 12.3.2
-iPhone	Chrome Mobile iOS 69.0	iOS 12.4.0
-iPhone	Chrome Mobile iOS 73.0	iOS 12.4.0
-iPhone	Chrome Mobile iOS 75.0	iOS 12.4.0
-iPhone	Chrome Mobile iOS 76.0	iOS 12.4.0
-iPhone	Chrome Mobile iOS 77.0	iOS 12.4.0
-iPhone	Chrome Mobile iOS 77.0	iOS 12.4.0
-iPhone	Google 81.0	iOS 12.4.0
-iPhone	Google 82.1	iOS 12.4.0
-iPhone	Google 83.0	iOS 12.4.0
-iPhone	Facebook 0.0	iOS 12.4.0
-iPhone	Facebook 0.0	iOS 12.4.0
-iPhone	Facebook 0.0	iOS 12.4.0
-iPhone	Facebook 0.0	iOS 12.4.0
-iPhone	Mobile Safari 12.1	iOS 12.4.0
-iPhone	Google 74.1	iOS 12.4.1
-iPhone	Mobile Safari UI/WKWebView 0.0	iOS 12.4.1
-iPhone	Instagram 89.0	iOS 12.4.1
-iPhone	Facebook 240.0	iOS 12.4.1
-iPhone	Facebook 0.0	iOS 12.4.1
-iPhone	Facebook 0.0	iOS 12.4.1
-iPhone	Facebook 0.0	iOS 12.4.1
-iPhone	Facebook 0.0	iOS 12.4.1
-iPhone	Facebook 0.0	iOS 12.4.1
-iPhone	Facebook 0.0	iOS 12.4.1
-iPhone	Facebook 0.0	iOS 12.4.1
-iPhone	Facebook 0.0	iOS 12.4.1
-iPhone	Facebook 0.0	iOS 12.4.1
-iPhone	Facebook 0.0	iOS 12.4.1
-iPhone	Facebook 0.0	iOS 12.4.1
-iPhone	Facebook 0.0	iOS 12.4.1
-iPhone	Facebook 0.0	iOS 12.4.1
-iPhone	Facebook 0.0	iOS 12.4.1
-iPhone	Facebook 0.0	iOS 12.4.1
-iPhone	Facebook 0.0	iOS 12.4.1
-iPhone	Facebook 0.0	iOS 12.4.1
-iPhone	Facebook 0.0	iOS 12.4.1
-iPhone	Facebook 0.0	iOS 12.4.1
-iPhone	Facebook 0.0	iOS 12.4.1
-iPhone	Facebook 0.0	iOS 12.4.1
-iPhone	Mobile Safari 12.1	iOS 12.4.1
-iPhone	Mobile Safari 12.4	iOS 12.4.1
-iPhone	Mobile Safari UI/WKWebView 0.0	iOS 12.4.2
-iPhone	Mobile Safari 12.1	iOS 12.4.2
-iPhone	Chrome Mobile iOS 77.0	iOS 13.0.0
-iPhone	Facebook 0.0	iOS 13.0.0
-iPhone	Facebook 0.0	iOS 13.0.0
-iPhone	Facebook 0.0	iOS 13.0.0
-iPhone	Facebook 0.0	iOS 13.0.0
-iPhone	Facebook 0.0	iOS 13.0.0
-iPhone	Facebook 0.0	iOS 13.0.0
-iPhone	Mobile Safari 13.0	iOS 13.0.0
-iPhone	Chrome Mobile iOS 76.0	iOS 13.1.0
-iPhone	Chrome Mobile iOS 77.0	iOS 13.1.0
-iPhone	Chrome Mobile iOS 77.0	iOS 13.1.0
-iPhone	Firefox iOS 8.1	iOS 13.1.0
-iPhone	Google 83.0	iOS 13.1.0
-iPhone	Mobile Safari UI/WKWebView 0.0	iOS 13.1.0
-iPhone	DuckDuckGo Mobile 7.0	iOS 13.1.0
-iPhone	Facebook 0.0	iOS 13.1.0
-iPhone	Facebook 0.0	iOS 13.1.0
-iPhone	Facebook 0.0	iOS 13.1.0
-iPhone	Facebook 0.0	iOS 13.1.0
-iPhone	Facebook 0.0	iOS 13.1.0
-iPhone	Mobile Safari 13.0	iOS 13.1.0
-iPhone	Mobile Safari UI/WKWebView 0.0	iOS 13.1.1
-iPhone	Facebook 0.0	iOS 13.1.1
-iPhone	Facebook 0.0	iOS 13.1.1
-iPhone	Facebook 0.0	iOS 13.1.1
-iPhone	Facebook 0.0	iOS 13.1.1
-iPhone	Mobile Safari 13.0	iOS 13.1.1
-iPhone	Mobile Safari UI/WKWebView 0.0	iOS 13.1.2
-iPhone	Facebook 0.0	iOS 13.1.2
-iPhone	Mobile Safari 13.0	iOS 13.1.2
+AppleCoreMedia/1.0.0.12B466 (Apple TV; U; CPU OS 8_1_3 like Mac OS X; en_us)	AppleTV	Other 0.0	ATV OS X 0.0.0
+Mozilla/5.0 (Android 7.0; Mobile; LG-M150; rv:68.0) Gecko/68.0 Firefox/68.0	LG-M150	Firefox Mobile 68.0	Android 7.0.0
+Mozilla/5.0 (Android 8.0.0; Mobile; rv:68.0) Gecko/68.0 Firefox/68.0	Generic Smartphone	Firefox Mobile 68.0	Android 8.0.0
+Mozilla/5.0 (Android 8.1.0; Tablet; rv:68.0) Gecko/68.0 Firefox/68.0	Generic Tablet	Firefox Mobile 68.0	Android 8.1.0
+Mozilla/5.0 (Android 9; Mobile; rv:68.0) Gecko/68.0 Firefox/68.0	Generic Smartphone	Firefox Mobile 68.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 10; PH-1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	PH-1	Chrome Mobile 77.0	Android 10.0.0
+Mozilla/5.0 (Linux; Android 10; Pixel 2 XL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	Pixel 2 XL	Chrome Mobile 77.0	Android 10.0.0
+Mozilla/5.0 (Linux; Android 10; Pixel 2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	Pixel 2	Chrome Mobile 77.0	Android 10.0.0
+Mozilla/5.0 (Linux; Android 10; Pixel 3 Build/QP1A.190711.020.C3; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/77.0.3865.92 Mobile Safari/537.36 [FB_IAB/FB4A;FBAV/240.0.0.38.121;]	Pixel 3	Facebook 240.0	Android 10.0.0
+Mozilla/5.0 (Linux; Android 10; Pixel XL Build/QP1A.190711.020; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/77.0.3865.92 Mobile Safari/537.36	Pixel XL	Chrome Mobile WebView 77.0	Android 10.0.0
+Mozilla/5.0 (Linux; Android 10; Pixel XL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	Pixel XL	Chrome Mobile 77.0	Android 10.0.0
+Mozilla/5.0 (Linux; Android 4.0.3; HTC Sensation 4G Build/IML74K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.111 Mobile Safari/537.36	HTC Sensation 4G	Chrome Mobile 42.0	Android 4.0.3
+Mozilla/5.0 (Linux; Android 4.0.3; KFTT) AppleWebKit/537.36 (KHTML, like Gecko) Silk/73.7.5 like Chrome/73.0.3683.90 Safari/537.36	Kindle	Amazon Silk 73.7	Android 4.0.3
+Mozilla/5.0 (Linux; Android 4.2.2; GT-I9152 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.111 Mobile Safari/537.36	Samsung GT-I9152 	Chrome Mobile 42.0	Android 4.2.2
+Mozilla/5.0 (Linux; Android 4.4.2; GT-N5110) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Safari/537.36	Samsung GT-N5110	Chrome 76.0	Android 4.4.2
+Mozilla/5.0 (Linux; Android 4.4.2; RCT6773W22) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Safari/537.36	RCT6773W22	Chrome 77.0	Android 4.4.2
+Mozilla/5.0 (Linux; Android 4.4.2; SM-T217S) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Safari/537.36	Samsung SM-T217S	Chrome 77.0	Android 4.4.2
+Mozilla/5.0 (Linux; Android 4.4.2; SM-T530NU) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Safari/537.36	Samsung SM-T530NU	Chrome 77.0	Android 4.4.2
+Mozilla/5.0 (Linux; Android 4.4.2; TegraNote-P1640 Build/KOT49H; en-us) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Safari/537.36	TegraNote-P1640	Chrome 69.0	Android 4.4.2
+Mozilla/5.0 (Linux; Android 4.4.3; KFTHWI) AppleWebKit/537.36 (KHTML, like Gecko) Silk/76.3.6 like Chrome/76.0.3809.132 Safari/537.36	Kindle	Amazon Silk 76.3	Android 4.4.3
+Mozilla/5.0 (Linux; Android 5.0.2; SM-A500H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.90 Mobile Safari/537.36	Samsung SM-A500H	Chrome Mobile 73.0	Android 5.0.2
+Mozilla/5.0 (Linux; Android 5.0.2; SM-T357T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Safari/537.36	Samsung SM-T357T	Chrome 77.0	Android 5.0.2
+Mozilla/5.0 (Linux; Android 5.0.2; SM-T530NU) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Safari/537.36	Samsung SM-T530NU	Chrome 76.0	Android 5.0.2
+Mozilla/5.0 (Linux; Android 5.0.2; SM-T530NU) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Safari/537.36	Samsung SM-T530NU	Chrome 77.0	Android 5.0.2
+Mozilla/5.0 (Linux; Android 5.0; RCT6213W87DK) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.103 YaBrowser/19.4.1.454.01 Safari/537.36	RCT6213W87DK	Yandex Browser 19.4	Android 5.0.0
+Mozilla/5.0 (Linux; Android 5.0; SM-N900T Build/LRX21V; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/77.0.3865.92 Mobile Safari/537.36 [FB_IAB/FB4A;FBAV/229.0.0.35.117;]	Samsung SM-N900T	Facebook 229.0	Android 5.0.0
+Mozilla/5.0 (Linux; Android 5.1.1) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Focus/4.4.1 Chrome/70.0.3538.110 Mobile Safari/537.36	Generic Smartphone	Chrome Mobile WebView 70.0	Android 5.1.1
+Mozilla/5.0 (Linux; Android 5.1.1; AFTB) AppleWebKit/537.36 (KHTML, like Gecko) Silk/76.3.16 like Chrome/76.0.3809.132 Safari/537.36	Kindle	Amazon Silk 76.3	Android 5.1.1
+Mozilla/5.0 (Linux; Android 5.1.1; AFTT Build/LVY48F; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/70.0.3538.110 Mobile Safari/537.36;dailymotion-player-sdk-android 0.1.26	AFTT	Chrome Mobile WebView 70.0	Android 5.1.1
+Mozilla/5.0 (Linux; Android 5.1.1; AFTT) AppleWebKit/537.36 (KHTML, like Gecko) Silk/76.3.16 like Chrome/76.0.3809.132 Safari/537.36	Kindle	Amazon Silk 76.3	Android 5.1.1
+Mozilla/5.0 (Linux; Android 5.1.1; KFAUWI) AppleWebKit/537.36 (KHTML, like Gecko) Silk/76.3.6 like Chrome/76.0.3809.132 Safari/537.36	Kindle	Amazon Silk 76.3	Android 5.1.1
+Mozilla/5.0 (Linux; Android 5.1.1; KFDOWI) AppleWebKit/537.36 (KHTML, like Gecko) Silk/71.2.4 like Chrome/71.0.3578.98 Safari/537.36	Kindle	Amazon Silk 71.2	Android 5.1.1
+Mozilla/5.0 (Linux; Android 5.1.1; KFDOWI) AppleWebKit/537.36 (KHTML, like Gecko) Silk/76.3.6 like Chrome/76.0.3809.132 Safari/537.36	Kindle	Amazon Silk 76.3	Android 5.1.1
+Mozilla/5.0 (Linux; Android 5.1.1; KFFOWI) AppleWebKit/537.36 (KHTML, like Gecko) Silk/76.3.6 like Chrome/76.0.3809.132 Safari/537.36	Kindle	Amazon Silk 76.3	Android 5.1.1
+Mozilla/5.0 (Linux; Android 5.1.1; KFGIWI) AppleWebKit/537.36 (KHTML, like Gecko) Silk/76.3.6 like Chrome/76.0.3809.132 Safari/537.36	Kindle	Amazon Silk 76.3	Android 5.1.1
+Mozilla/5.0 (Linux; Android 5.1.1; KFSUWI) AppleWebKit/537.36 (KHTML, like Gecko) Silk/76.3.6 like Chrome/76.0.3809.132 Safari/537.36	Kindle	Amazon Silk 76.3	Android 5.1.1
+Mozilla/5.0 (Linux; Android 5.1.1; KFSUWI) AppleWebKit/537.36 (KHTML, like Gecko) Silk/77.1.127 like Chrome/77.0.3865.92 Safari/537.36	Kindle	Amazon Silk 77.1	Android 5.1.1
+Mozilla/5.0 (Linux; Android 5.1.1; LG-AS330) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	LG-AS330	Chrome Mobile 77.0	Android 5.1.1
+Mozilla/5.0 (Linux; Android 5.1.1; LGL43AL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	LGL43AL	Chrome Mobile 77.0	Android 5.1.1
+Mozilla/5.0 (Linux; Android 5.1.1; SAMSUNG SM-G530R7 Build/LMY47X) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/9.2 Chrome/67.0.3396.87 Mobile Safari/537.36	Samsung SM-G530R7	Samsung Internet 9.2	Android 5.1.1
+Mozilla/5.0 (Linux; Android 5.1.1; SAMSUNG SM-T377P) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.1 Chrome/71.0.3578.99 Safari/537.36	Samsung SM-T377P	Samsung Internet 10.1	Android 5.1.1
+Mozilla/5.0 (Linux; Android 5.1.1; SAMSUNG SM-T900) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.1 Chrome/71.0.3578.99 Safari/537.36	Samsung SM-T900	Samsung Internet 10.1	Android 5.1.1
+Mozilla/5.0 (Linux; Android 5.1.1; SAMSUNG-SM-T337A Build/LMY47X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Safari/537.36	Samsung SM-T337A	Chrome 69.0	Android 5.1.1
+Mozilla/5.0 (Linux; Android 5.1.1; SM-G360T1 Build/LMY47X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.81 Mobile Safari/537.36	Samsung SM-G360T1	Chrome Mobile 67.0	Android 5.1.1
+Mozilla/5.0 (Linux; Android 5.1.1; SM-J320FN) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Mobile Safari/537.36	Samsung SM-J320FN	Chrome Mobile 74.0	Android 5.1.1
+Mozilla/5.0 (Linux; Android 5.1.1; SM-T280) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Safari/537.36	SM-T280	Chrome 74.0	Android 5.1.1
+Mozilla/5.0 (Linux; Android 5.1.1; SM-T330NU) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.98 Safari/537.36	Samsung SM-T330NU	Chrome 71.0	Android 5.1.1
+Mozilla/5.0 (Linux; Android 5.1.1; SM-T670) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Safari/537.36	SM-T670	Chrome 76.0	Android 5.1.1
+Mozilla/5.0 (Linux; Android 5.1.1; SM-T670) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Safari/537.36	SM-T670	Chrome 77.0	Android 5.1.1
+Mozilla/5.0 (Linux; Android 5.1.1; Vodafone Smart ultra 6 Build/LMY47V; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/74.0.3729.136 Mobile Safari/537.36	Vodafone Smart ultra 6	Chrome Mobile WebView 74.0	Android 5.1.1
+Mozilla/5.0 (Linux; Android 5.1; BLU Advance 5.0 Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.158 Mobile Safari/537.36	BLU Advance 5.0	Chrome Mobile 66.0	Android 5.1.0
+Mozilla/5.0 (Linux; Android 5.1; HTC Desire 626s) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	HTC Desire 626s	Chrome Mobile 77.0	Android 5.1.0
+Mozilla/5.0 (Linux; Android 5.1; HUAWEI LUA-L22 Build/HUAWEILUA-L22) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.89 Mobile Safari/537.36	HUAWEI LUA-L22	Chrome Mobile 50.0	Android 5.1.0
+Mozilla/5.0 (Linux; Android 5.1; NX16A11264) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Safari/537.36	NX16A11264	Chrome 77.0	Android 5.1.0
+Mozilla/5.0 (Linux; Android 5.1; XT1526) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.90 Mobile Safari/537.36	XT1526	Chrome Mobile 73.0	Android 5.1.0
+Mozilla/5.0 (Linux; Android 6.0.1; CPH1613) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	Oppo CPH1613	Chrome Mobile 77.0	Android 6.0.1
+Mozilla/5.0 (Linux; Android 6.0.1; LG-M153 Build/MXB48T; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/55.0.2883.91 Mobile Safari/537.36	LG-M153 	Chrome Mobile WebView 55.0	Android 6.0.1
+Mozilla/5.0 (Linux; Android 6.0.1; LG-M153) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	LG-M153	Chrome Mobile 77.0	Android 6.0.1
+Mozilla/5.0 (Linux; Android 6.0.1; LGLS676) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	LGLS676	Chrome Mobile 77.0	Android 6.0.1
+Mozilla/5.0 (Linux; Android 6.0.1; N9136) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Mobile Safari/537.36	N9136	Chrome Mobile 74.0	Android 6.0.1
+Mozilla/5.0 (Linux; Android 6.0.1; Nexus 7 Build/MOB30X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/44.0.2403.133 Safari/537.36	Asus Nexus 7	Chrome 44.0	Android 6.0.1
+Mozilla/5.0 (Linux; Android 6.0.1; SAMSUNG SM-G900I) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.1 Chrome/71.0.3578.99 Mobile Safari/537.36	Samsung SM-G900I	Samsung Internet 10.1	Android 6.0.1
+Mozilla/5.0 (Linux; Android 6.0.1; SAMSUNG SM-G900P Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/7.2 Chrome/59.0.3071.125 Mobile Safari/537.36	Samsung SM-G900P	Samsung Internet 7.2	Android 6.0.1
+Mozilla/5.0 (Linux; Android 6.0.1; SAMSUNG SM-J700M) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.1 Chrome/71.0.3578.99 Mobile Safari/537.36	Samsung SM-J700M	Samsung Internet 10.1	Android 6.0.1
+Mozilla/5.0 (Linux; Android 6.0.1; SAMSUNG SM-S327VL) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.1 Chrome/71.0.3578.99 Mobile Safari/537.36	Samsung SM-S327VL	Samsung Internet 10.1	Android 6.0.1
+Mozilla/5.0 (Linux; Android 6.0.1; SAMSUNG-SM-T377A) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Safari/537.36	Samsung SM-T377A	Chrome 77.0	Android 6.0.1
+Mozilla/5.0 (Linux; Android 6.0.1; SM-G532M Build/MMB29T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36	Samsung SM-G532M	Chrome Mobile 55.0	Android 6.0.1
+Mozilla/5.0 (Linux; Android 6.0.1; SM-G532M Build/MMB29T; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/75.0.3770.101 Mobile Safari/537.36 [FB_IAB/FB4A;FBAV/240.0.0.38.121;]	Samsung SM-G532M	Facebook 240.0	Android 6.0.1
+Mozilla/5.0 (Linux; Android 6.0.1; SM-G532M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	Samsung SM-G532M	Chrome Mobile 77.0	Android 6.0.1
+Mozilla/5.0 (Linux; Android 6.0.1; SM-G550T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Mobile Safari/537.36	Samsung SM-G550T	Chrome Mobile 76.0	Android 6.0.1
+Mozilla/5.0 (Linux; Android 6.0.1; SM-G550T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	Samsung SM-G550T	Chrome Mobile 77.0	Android 6.0.1
+Mozilla/5.0 (Linux; Android 6.0.1; SM-G550T1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Mobile Safari/537.36	Samsung SM-G550T1	Chrome Mobile 76.0	Android 6.0.1
+Mozilla/5.0 (Linux; Android 6.0.1; SM-G900V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.75 Mobile Safari/537.36	Samsung SM-G900V	Chrome Mobile 73.0	Android 6.0.1
+Mozilla/5.0 (Linux; Android 6.0.1; SM-G920A) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	Samsung SM-G920A	Chrome Mobile 77.0	Android 6.0.1
+Mozilla/5.0 (Linux; Android 6.0.1; SM-J327P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	Samsung SM-J327P	Chrome Mobile 77.0	Android 6.0.1
+Mozilla/5.0 (Linux; Android 6.0.1; SM-N910S) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36	Samsung SM-N910S	Chrome Mobile 75.0	Android 6.0.1
+Mozilla/5.0 (Linux; Android 6.0.1; SM-N920V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.89 Mobile Safari/537.36	Samsung SM-N920V	Chrome Mobile 76.0	Android 6.0.1
+Mozilla/5.0 (Linux; Android 6.0.1; SM-T350 Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Safari/537.36	Samsung SM-T350	Chrome 59.0	Android 6.0.1
+Mozilla/5.0 (Linux; Android 6.0.1; SM-T560NU) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Safari/537.36	Samsung SM-T560NU	Chrome 77.0	Android 6.0.1
+Mozilla/5.0 (Linux; Android 6.0.1; SM-T800) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Safari/537.36	SM-T800	Chrome 77.0	Android 6.0.1
+Mozilla/5.0 (Linux; Android 6.0.1; XT1254) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	XT1254	Chrome Mobile 77.0	Android 6.0.1
+Mozilla/5.0 (Linux; Android 6.0.1; Z798BL Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36	Z798BL	Chrome Mobile 67.0	Android 6.0.1
+Mozilla/5.0 (Linux; Android 6.0.1; Z799VL Build/MMB29M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/45.0.2454.95 Mobile Safari/537.36	Z799VL	Chrome Mobile WebView 45.0	Android 6.0.1
+Mozilla/5.0 (Linux; Android 6.0; 5010X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.89 Mobile Safari/537.36	5010X	Chrome Mobile 76.0	Android 6.0.0
+Mozilla/5.0 (Linux; Android 6.0; CAM-L21) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	Huawei CAM-L21	Chrome Mobile 77.0	Android 6.0.0
+Mozilla/5.0 (Linux; Android 6.0; F3313) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	F3313	Chrome Mobile 77.0	Android 6.0.0
+Mozilla/5.0 (Linux; Android 6.0; RCT6603W47M7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Safari/537.36	RCT6603W47M7	Chrome 77.0	Android 6.0.0
+Mozilla/5.0 (Linux; Android 7.0; 5049Z Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Mobile Safari/537.36	5049Z	Chrome Mobile 56.0	Android 7.0.0
+Mozilla/5.0 (Linux; Android 7.0; ASUS_A002A) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	Asus A002A	Chrome Mobile 77.0	Android 7.0.0
+Mozilla/5.0 (Linux; Android 7.0; Alcatel_5044C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	Alcatel_5044C	Chrome Mobile 77.0	Android 7.0.0
+Mozilla/5.0 (Linux; Android 7.0; Astra Young Pro Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/59.0.3071.125 Mobile Safari/537.36	Astra Young Pro	Chrome Mobile WebView 59.0	Android 7.0.0
+Mozilla/5.0 (Linux; Android 7.0; Infinix X571) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	Infinix X571	Chrome Mobile 77.0	Android 7.0.0
+Mozilla/5.0 (Linux; Android 7.0; LG-H872 Build/NRD90U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.123 Mobile Safari/537.36	LG-H872 	Chrome Mobile 64.0	Android 7.0.0
+Mozilla/5.0 (Linux; Android 7.0; LG-K425 Build/NRD90U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36	LG-K425 	Chrome Mobile 55.0	Android 7.0.0
+Mozilla/5.0 (Linux; Android 7.0; LG-LS777) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	LG-LS777	Chrome Mobile 77.0	Android 7.0.0
+Mozilla/5.0 (Linux; Android 7.0; LG-M210) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	LG-M210	Chrome Mobile 77.0	Android 7.0.0
+Mozilla/5.0 (Linux; Android 7.0; LG-M430) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	LG-M430	Chrome Mobile 77.0	Android 7.0.0
+Mozilla/5.0 (Linux; Android 7.0; LG-TP260 Build/NRD90U; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/64.0.3282.137 Mobile Safari/537.36;dailymotion-player-sdk-android 0.1.31	LG-TP260 	Chrome Mobile WebView 64.0	Android 7.0.0
+Mozilla/5.0 (Linux; Android 7.0; LG-TP260) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	LG-TP260	Chrome Mobile 77.0	Android 7.0.0
+Mozilla/5.0 (Linux; Android 7.0; LG-TP450 Build/NRD90U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36	LG-TP450 	Chrome Mobile 64.0	Android 7.0.0
+Mozilla/5.0 (Linux; Android 7.0; LG-V521) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Safari/537.36	LG-V521	Chrome 75.0	Android 7.0.0
+Mozilla/5.0 (Linux; Android 7.0; LG-V521) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Safari/537.36	LG-V521	Chrome 77.0	Android 7.0.0
+Mozilla/5.0 (Linux; Android 7.0; LGMP260 Build/NRD90U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Mobile Safari/537.36	LGMP260	Chrome Mobile 58.0	Android 7.0.0
+Mozilla/5.0 (Linux; Android 7.0; LGMS210 Build/NRD90U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36	LGMS210	Chrome Mobile 55.0	Android 7.0.0
+Mozilla/5.0 (Linux; Android 7.0; LGMS210) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	LGMS210	Chrome Mobile 77.0	Android 7.0.0
+Mozilla/5.0 (Linux; Android 7.0; P00I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Safari/537.36	P00I	Chrome 77.0	Android 7.0.0
+Mozilla/5.0 (Linux; Android 7.0; RS988) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	RS988	Chrome Mobile 77.0	Android 7.0.0
+Mozilla/5.0 (Linux; Android 7.0; SAMSUNG SM-J701F) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.1 Chrome/71.0.3578.99 Mobile Safari/537.36	Samsung SM-J701F	Samsung Internet 10.1	Android 7.0.0
+Mozilla/5.0 (Linux; Android 7.0; SAMSUNG SM-J710F) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.1 Chrome/71.0.3578.99 Mobile Safari/537.36	Samsung SM-J710F	Samsung Internet 10.1	Android 7.0.0
+Mozilla/5.0 (Linux; Android 7.0; SAMSUNG SM-N920T Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/9.2 Chrome/67.0.3396.87 Mobile Safari/537.36	Samsung SM-N920T	Samsung Internet 9.2	Android 7.0.0
+Mozilla/5.0 (Linux; Android 7.0; SAMSUNG-SM-G920A) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	Samsung SM-G920A	Chrome Mobile 77.0	Android 7.0.0
+Mozilla/5.0 (Linux; Android 7.0; SM-G920P Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/77.0.3865.92 Mobile Safari/537.36 Flipboard/4.2.23/4722,4.2.23.4722	Samsung SM-G920P	Flipboard 4.2	Android 7.0.0
+Mozilla/5.0 (Linux; Android 7.0; SM-G920V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Mobile Safari/537.36	Samsung SM-G920V	Chrome Mobile 76.0	Android 7.0.0
+Mozilla/5.0 (Linux; Android 7.0; SM-G928V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	Samsung SM-G928V	Chrome Mobile 77.0	Android 7.0.0
+Mozilla/5.0 (Linux; Android 7.0; SM-G950U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	Samsung SM-G950U	Chrome Mobile 77.0	Android 7.0.0
+Mozilla/5.0 (Linux; Android 7.0; SM-G955U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	Samsung SM-G955U	Chrome Mobile 77.0	Android 7.0.0
+Mozilla/5.0 (Linux; Android 7.0; SM-J327T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Mobile Safari/537.36	Samsung SM-J327T	Chrome Mobile 74.0	Android 7.0.0
+Mozilla/5.0 (Linux; Android 7.0; SM-J327T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	Samsung SM-J327T	Chrome Mobile 77.0	Android 7.0.0
+Mozilla/5.0 (Linux; Android 7.0; SM-J327T1 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36	Samsung SM-J327T1	Chrome Mobile 64.0	Android 7.0.0
+Mozilla/5.0 (Linux; Android 7.0; SM-J327T1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.101 Mobile Safari/537.36	Samsung SM-J327T1	Chrome Mobile 75.0	Android 7.0.0
+Mozilla/5.0 (Linux; Android 7.0; SM-J327T1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	Samsung SM-J327T1	Chrome Mobile 77.0	Android 7.0.0
+Mozilla/5.0 (Linux; Android 7.0; SM-N9208) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.90 Mobile Safari/537.36	Samsung SM-N9208	Chrome Mobile 73.0	Android 7.0.0
+Mozilla/5.0 (Linux; Android 7.0; SM-N920P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Mobile Safari/537.36	Samsung SM-N920P	Chrome Mobile 74.0	Android 7.0.0
+Mozilla/5.0 (Linux; Android 7.0; SM-N920T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	Samsung SM-N920T	Chrome Mobile 77.0	Android 7.0.0
+Mozilla/5.0 (Linux; Android 7.0; SM-T585) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Safari/537.36	SM-T585	Chrome 77.0	Android 7.0.0
+Mozilla/5.0 (Linux; Android 7.0; SM-T810) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Safari/537.36	SM-T810	Chrome 75.0	Android 7.0.0
+Mozilla/5.0 (Linux; Android 7.0; SM-T810) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.111 Safari/537.36	SM-T810	Chrome 76.0	Android 7.0.0
+Mozilla/5.0 (Linux; Android 7.0; SM-T810) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Safari/537.36	SM-T810	Chrome 77.0	Android 7.0.0
+Mozilla/5.0 (Linux; Android 7.0; SM-T813) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.111 Safari/537.36	SM-T813	Chrome 76.0	Android 7.0.0
+Mozilla/5.0 (Linux; Android 7.0; SM-T813) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Safari/537.36	SM-T813	Chrome 76.0	Android 7.0.0
+Mozilla/5.0 (Linux; Android 7.0; ST1009X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Safari/537.36	Trekstor ST1009X	Chrome 75.0	Android 7.0.0
+Mozilla/5.0 (Linux; Android 7.0; XT1663) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	XT1663	Chrome Mobile 77.0	Android 7.0.0
+Mozilla/5.0 (Linux; Android 7.0;) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.96 Mobile Safari/537.36	Generic Smartphone	Chrome Mobile 58.0	Android 7.0.0
+Mozilla/5.0 (Linux; Android 7.1.1; A574BL Build/NMF26F; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/77.0.3865.92 Mobile Safari/537.36;dailymotion-player-sdk-android 0.1.31	A574BL	Chrome Mobile WebView 77.0	Android 7.1.1
+Mozilla/5.0 (Linux; Android 7.1.1; A574BL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	A574BL	Chrome Mobile 77.0	Android 7.1.1
+Mozilla/5.0 (Linux; Android 7.1.1; CPH1729 Build/N6F26Q; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/77.0.3865.92 Mobile Safari/537.36 [FB_IAB/FB4A;FBAV/240.0.0.38.121;]	Oppo CPH1729	Facebook 240.0	Android 7.1.1
+Mozilla/5.0 (Linux; Android 7.1.1; Coolpad 3632A) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Mobile Safari/537.36	3632A	Chrome Mobile 74.0	Android 7.1.1
+Mozilla/5.0 (Linux; Android 7.1.1; General Mobile 4G Dual) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	General Mobile 4G Dual	Chrome Mobile 77.0	Android 7.1.1
+Mozilla/5.0 (Linux; Android 7.1.1; Moto E (4) Plus Build/NCRS26.58-44-20; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.111 Mobile Safari/537.36;dailymotion-player-sdk-android 0.1.31	Moto E (4) Plus	Chrome Mobile WebView 76.0	Android 7.1.1
+Mozilla/5.0 (Linux; Android 7.1.1; Moto E (4)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Mobile Safari/537.36	Moto E (4)	Chrome Mobile 70.0	Android 7.1.1
+Mozilla/5.0 (Linux; Android 7.1.1; Moto E (4)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Mobile Safari/537.36	Moto E (4)	Chrome Mobile 76.0	Android 7.1.1
+Mozilla/5.0 (Linux; Android 7.1.1; Moto E (4)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.73 Mobile Safari/537.36	Moto E (4)	Chrome Mobile 77.0	Android 7.1.1
+Mozilla/5.0 (Linux; Android 7.1.1; Moto E (4)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	Moto E (4)	Chrome Mobile 77.0	Android 7.1.1
+Mozilla/5.0 (Linux; Android 7.1.1; NX591J) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	NX591J	Chrome Mobile 77.0	Android 7.1.1
+Mozilla/5.0 (Linux; Android 7.1.1; REVVLPLUS C3701A Build/143.54.190611.3701A-TMO) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36	REVVLPLUS C3701A	Chrome Mobile 64.0	Android 7.1.1
+Mozilla/5.0 (Linux; Android 7.1.1; SAMSUNG SM-J320A) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.1 Chrome/71.0.3578.99 Mobile Safari/537.36	Samsung SM-J320A	Samsung Internet 10.1	Android 7.1.1
+Mozilla/5.0 (Linux; Android 7.1.1; SAMSUNG SM-T550) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.1 Chrome/71.0.3578.99 Safari/537.36	Samsung SM-T550	Samsung Internet 10.1	Android 7.1.1
+Mozilla/5.0 (Linux; Android 7.1.1; SAMSUNG-SM-T377A Build/NMF26X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Safari/537.36	Samsung SM-T377A	Chrome 64.0	Android 7.1.1
+Mozilla/5.0 (Linux; Android 7.1.1; SM-J250F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Mobile Safari/537.36	Samsung SM-J250F	Chrome Mobile 76.0	Android 7.1.1
+Mozilla/5.0 (Linux; Android 7.1.1; SM-J700T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	Samsung SM-J700T	Chrome Mobile 77.0	Android 7.1.1
+Mozilla/5.0 (Linux; Android 7.1.1; SM-T350) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Safari/537.36	SM-T350	Chrome 77.0	Android 7.1.1
+Mozilla/5.0 (Linux; Android 7.1.1; SM-T377T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.73 Safari/537.36	Samsung SM-T377T	Chrome 77.0	Android 7.1.1
+Mozilla/5.0 (Linux; Android 7.1.1; SM-T550 Build/NMF26X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Safari/537.36	Samsung SM-T550	Chrome 69.0	Android 7.1.1
+Mozilla/5.0 (Linux; Android 7.1.1; SM-T550) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Safari/537.36	SM-T550	Chrome 77.0	Android 7.1.1
+Mozilla/5.0 (Linux; Android 7.1.1; SM-T560NU) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Safari/537.36	Samsung SM-T560NU	Chrome 77.0	Android 7.1.1
+Mozilla/5.0 (Linux; Android 7.1.1; X20 Build/N6F26Q; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/52.0.2743.100 Mobile Safari/537.36	X20	Chrome Mobile WebView 52.0	Android 7.1.1
+Mozilla/5.0 (Linux; Android 7.1.1; Z851M Build/NMF26V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Mobile Safari/537.36	Z851M	Chrome Mobile 58.0	Android 7.1.1
+Mozilla/5.0 (Linux; Android 7.1.1; Z899VL Build/NMF26V; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/74.0.3729.136 Mobile Safari/537.36;dailymotion-player-sdk-android 0.1.31	Z899VL	Chrome Mobile WebView 74.0	Android 7.1.1
+Mozilla/5.0 (Linux; Android 7.1.1; Z982 Build/NMF26V; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/75.0.3770.143 Mobile Safari/537.36;dailymotion-player-sdk-android 0.1.31	Z982	Chrome Mobile WebView 75.0	Android 7.1.1
+Mozilla/5.0 (Linux; Android 7.1.1; Z982) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	Z982	Chrome Mobile 77.0	Android 7.1.1
+Mozilla/5.0 (Linux; Android 7.1.2) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Focus/4.4.1 Chrome/70.0.3538.110 Mobile Safari/537.36	Generic Smartphone	Chrome Mobile WebView 70.0	Android 7.1.2
+Mozilla/5.0 (Linux; Android 7.1.2; AFTKMST12 Build/NS6265; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/70.0.3538.110 Mobile Safari/537.36;dailymotion-player-sdk-android 0.1.26	AFTKMST12	Chrome Mobile WebView 70.0	Android 7.1.2
+Mozilla/5.0 (Linux; Android 7.1.2; AFTKMST12) AppleWebKit/537.36 (KHTML, like Gecko) Silk/76.3.16 like Chrome/76.0.3809.132 Safari/537.36	Kindle	Amazon Silk 76.3	Android 7.1.2
+Mozilla/5.0 (Linux; Android 7.1.2; AFTMM Build/NS6265; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/70.0.3538.110 Mobile Safari/537.36;dailymotion-player-sdk-android 0.1.26	AFTMM	Chrome Mobile WebView 70.0	Android 7.1.2
+Mozilla/5.0 (Linux; Android 7.1.2; AFTN Build/NS6265; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/70.0.3538.110 Mobile Safari/537.36;dailymotion-player-sdk-android 0.1.26	AFTN	Chrome Mobile WebView 70.0	Android 7.1.2
+Mozilla/5.0 (Linux; Android 7.1.2; KFKAWI Build/NS6301; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/59.0.3071.125 Safari/537.36	KFKAWI	Chrome Mobile WebView 59.0	Android 7.1.2
+Mozilla/5.0 (Linux; Android 7.1.2; KFKAWI) AppleWebKit/537.36 (KHTML, like Gecko) Silk/76.3.6 like Chrome/76.0.3809.132 Safari/537.36	Kindle	Amazon Silk 76.3	Android 7.1.2
+Mozilla/5.0 (Linux; Android 7.1.2; KFMUWI) AppleWebKit/537.36 (KHTML, like Gecko) Silk/76.3.6 like Chrome/76.0.3809.132 Safari/537.36	Kindle	Amazon Silk 76.3	Android 7.1.2
+Mozilla/5.0 (Linux; Android 7.1.2; LG-SP200) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36	LG-SP200	Chrome Mobile 75.0	Android 7.1.2
+Mozilla/5.0 (Linux; Android 7.1.2; LG-SP200) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Mobile Safari/537.36	LG-SP200	Chrome Mobile 76.0	Android 7.1.2
+Mozilla/5.0 (Linux; Android 7.1.2; LM-X210(G)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.111 Mobile Safari/537.36	LM-X210(G)	Chrome Mobile 76.0	Android 7.1.2
+Mozilla/5.0 (Linux; Android 7.1.2; LM-X210) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Mobile Safari/537.36	LM-X210	Chrome Mobile 76.0	Android 7.1.2
+Mozilla/5.0 (Linux; Android 7.1.2; RCT6973W43R) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Safari/537.36	RCT6973W43R	Chrome 77.0	Android 7.1.2
+Mozilla/5.0 (Linux; Android 7.1.2; Redmi 4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	XiaoMi Redmi 4	Chrome Mobile 77.0	Android 7.1.2
+Mozilla/5.0 (Linux; Android 8.0.0) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.132 Mobile Safari/537.36	Generic Smartphone	Chrome Mobile WebView 76.0	Android 8.0.0
+Mozilla/5.0 (Linux; Android 8.0.0; ASUS_Z01FD) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	Asus Z01FD	Chrome Mobile 77.0	Android 8.0.0
+Mozilla/5.0 (Linux; Android 8.0.0; AUM-L29) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	Huawei AUM-L29	Chrome Mobile 77.0	Android 8.0.0
+Mozilla/5.0 (Linux; Android 8.0.0; BRAVIA 4K GB Build/OPR2.170623.027.S25; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/77.0.3865.92 Mobile Safari/537.36;dailymotion-player-sdk-android 0.1.31	BRAVIA 4K GB	Chrome Mobile WebView 77.0	Android 8.0.0
+Mozilla/5.0 (Linux; Android 8.0.0; CMR-W09) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Safari/537.36	CMR-W09	Chrome 77.0	Android 8.0.0
+Mozilla/5.0 (Linux; Android 8.0.0; EVA-AL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.73 Mobile Safari/537.36	EVA-AL00	Chrome Mobile 77.0	Android 8.0.0
+Mozilla/5.0 (Linux; Android 8.0.0; G3223) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	G3223	Chrome Mobile 77.0	Android 8.0.0
+Mozilla/5.0 (Linux; Android 8.0.0; LG-H910) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	LG-H910	Chrome Mobile 77.0	Android 8.0.0
+Mozilla/5.0 (Linux; Android 8.0.0; LG-H931) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Mobile Safari/537.36	LG-H931	Chrome Mobile 76.0	Android 8.0.0
+Mozilla/5.0 (Linux; Android 8.0.0; LG-H932) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	LG-H932	Chrome Mobile 77.0	Android 8.0.0
+Mozilla/5.0 (Linux; Android 8.0.0; SAMSUNG SM-A520F) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.1 Chrome/71.0.3578.99 Mobile Safari/537.36	Samsung SM-A520F	Samsung Internet 10.1	Android 8.0.0
+Mozilla/5.0 (Linux; Android 8.0.0; SAMSUNG SM-G891A Build/R16NW) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/8.2 Chrome/63.0.3239.111 Mobile Safari/537.36	Samsung SM-G891A	Samsung Internet 8.2	Android 8.0.0
+Mozilla/5.0 (Linux; Android 8.0.0; SAMSUNG SM-G935T) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.1 Chrome/71.0.3578.99 Mobile Safari/537.36	Samsung SM-G935T	Samsung Internet 10.1	Android 8.0.0
+Mozilla/5.0 (Linux; Android 8.0.0; SAMSUNG SM-G955U) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.1 Chrome/71.0.3578.99 Mobile Safari/537.36	Samsung SM-G955U	Samsung Internet 10.1	Android 8.0.0
+Mozilla/5.0 (Linux; Android 8.0.0; SAMSUNG SM-J337T Build/R16NW) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/9.2 Chrome/67.0.3396.87 Mobile Safari/537.36	Samsung SM-J337T	Samsung Internet 9.2	Android 8.0.0
+Mozilla/5.0 (Linux; Android 8.0.0; SAMSUNG SM-J737P) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.1 Chrome/71.0.3578.99 Mobile Safari/537.36	Samsung SM-J737P	Samsung Internet 10.1	Android 8.0.0
+Mozilla/5.0 (Linux; Android 8.0.0; SAMSUNG SM-N950F) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.1 Chrome/71.0.3578.99 Mobile Safari/537.36	Samsung SM-N950F	Samsung Internet 10.1	Android 8.0.0
+Mozilla/5.0 (Linux; Android 8.0.0; SAMSUNG-SM-G891A) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.121 Mobile Safari/537.36	Samsung SM-G891A	Chrome Mobile 72.0	Android 8.0.0
+Mozilla/5.0 (Linux; Android 8.0.0; SAMSUNG-SM-G935A) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Mobile Safari/537.36	Samsung SM-G935A	Chrome Mobile 76.0	Android 8.0.0
+Mozilla/5.0 (Linux; Android 8.0.0; SM-A720F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	Samsung SM-A720F	Chrome Mobile 77.0	Android 8.0.0
+Mozilla/5.0 (Linux; Android 8.0.0; SM-G570F Build/R16NW; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/73.0.3683.90 Mobile Safari/537.36 [FB_IAB/FB4A;FBAV/231.0.0.39.113;]	Samsung SM-G570F	Facebook 231.0	Android 8.0.0
+Mozilla/5.0 (Linux; Android 8.0.0; SM-G570Y) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	Samsung SM-G570Y	Chrome Mobile 77.0	Android 8.0.0
+Mozilla/5.0 (Linux; Android 8.0.0; SM-G930T Build/R16NW; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/77.0.3865.92 Mobile Safari/537.36;dailymotion-player-sdk-android 0.1.31	Samsung SM-G930T	Chrome Mobile WebView 77.0	Android 8.0.0
+Mozilla/5.0 (Linux; Android 8.0.0; SM-G930V Build/R16NW) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36	Samsung SM-G930V	Chrome Mobile 64.0	Android 8.0.0
+Mozilla/5.0 (Linux; Android 8.0.0; SM-G930VL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Mobile Safari/537.36	Samsung SM-G930VL	Chrome Mobile 74.0	Android 8.0.0
+Mozilla/5.0 (Linux; Android 8.0.0; SM-G935F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36	Samsung SM-G935F	Chrome Mobile 75.0	Android 8.0.0
+Mozilla/5.0 (Linux; Android 8.0.0; SM-G935P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	Samsung SM-G935P	Chrome Mobile 77.0	Android 8.0.0
+Mozilla/5.0 (Linux; Android 8.0.0; SM-G935T Build/R16NW; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/77.0.3865.92 Mobile Safari/537.36 [FB_IAB/FB4A;FBAV/240.0.0.38.121;]	Samsung SM-G935T	Facebook 240.0	Android 8.0.0
+Mozilla/5.0 (Linux; Android 8.0.0; SM-G935T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	Samsung SM-G935T	Chrome Mobile 77.0	Android 8.0.0
+Mozilla/5.0 (Linux; Android 8.0.0; SM-G950U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	Samsung SM-G950U	Chrome Mobile 77.0	Android 8.0.0
+Mozilla/5.0 (Linux; Android 8.0.0; SM-G955U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.112 Mobile Safari/537.36	Samsung SM-G955U	Chrome Mobile 74.0	Android 8.0.0
+Mozilla/5.0 (Linux; Android 8.0.0; SM-G955U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	Samsung SM-G955U	Chrome Mobile 77.0	Android 8.0.0
+Mozilla/5.0 (Linux; Android 8.0.0; SM-J330G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	Samsung SM-J330G	Chrome Mobile 77.0	Android 8.0.0
+Mozilla/5.0 (Linux; Android 8.0.0; SM-J337T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	Samsung SM-J337T	Chrome Mobile 77.0	Android 8.0.0
+Mozilla/5.0 (Linux; Android 8.0.0; SM-J737A) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	Samsung SM-J737A	Chrome Mobile 77.0	Android 8.0.0
+Mozilla/5.0 (Linux; Android 8.0.0; SM-J737T1 Build/R16NW) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.126 Mobile Safari/537.36	Samsung SM-J737T1	Chrome Mobile 66.0	Android 8.0.0
+Mozilla/5.0 (Linux; Android 8.0.0; SM-J737T1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	Samsung SM-J737T1	Chrome Mobile 77.0	Android 8.0.0
+Mozilla/5.0 (Linux; Android 8.0.0; SM-N950F Build/R16NW) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.126 Mobile Safari/537.36	Samsung SM-N950F	Chrome Mobile 66.0	Android 8.0.0
+Mozilla/5.0 (Linux; Android 8.0.0; SM-N950U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Mobile Safari/537.36	Samsung SM-N950U	Chrome Mobile 76.0	Android 8.0.0
+Mozilla/5.0 (Linux; Android 8.0.0; SM-N950U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	Samsung SM-N950U	Chrome Mobile 77.0	Android 8.0.0
+Mozilla/5.0 (Linux; Android 8.0.0; SM-N950U1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	Samsung SM-N950U1	Chrome Mobile 77.0	Android 8.0.0
+Mozilla/5.0 (Linux; Android 8.0.0; SM-S367VL Build/R16NW) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36 OPT/1.22.80	Samsung SM-S367VL	Chrome Mobile 77.0	Android 8.0.0
+Mozilla/5.0 (Linux; Android 8.0.0; VS995) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	VS995	Chrome Mobile 77.0	Android 8.0.0
+Mozilla/5.0 (Linux; Android 8.0.0; XT1635-02) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	XT1635-02	Chrome Mobile 77.0	Android 8.0.0
+Mozilla/5.0 (Linux; Android 8.0.0; moto e5 play) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.111 Mobile Safari/537.36	moto e5 play	Chrome Mobile 76.0	Android 8.0.0
+Mozilla/5.0 (Linux; Android 8.0.0; moto e5 play) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	moto e5 play	Chrome Mobile 77.0	Android 8.0.0
+Mozilla/5.0 (Linux; Android 8.0.0; moto e5 supra) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Mobile Safari/537.36	moto e5 supra	Chrome Mobile 76.0	Android 8.0.0
+Mozilla/5.0 (Linux; Android 8.0.0; moto g(6)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	moto g(6)	Chrome Mobile 77.0	Android 8.0.0
+Mozilla/5.0 (Linux; Android 8.1.0; 5041C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	5041C	Chrome Mobile 77.0	Android 8.1.0
+Mozilla/5.0 (Linux; Android 8.1.0; 6062W) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	6062W	Chrome Mobile 77.0	Android 8.1.0
+Mozilla/5.0 (Linux; Android 8.1.0; A502DL Build/OPM1.171019.011) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36	A502DL	Chrome Mobile 67.0	Android 8.1.0
+Mozilla/5.0 (Linux; Android 8.1.0; A502DL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Mobile Safari/537.36	A502DL	Chrome Mobile 76.0	Android 8.1.0
+Mozilla/5.0 (Linux; Android 8.1.0; BKK-LX2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Mobile Safari/537.36	Huawei BKK-LX2	Chrome Mobile 76.0	Android 8.1.0
+Mozilla/5.0 (Linux; Android 8.1.0; C4 Build/OPM2.171019.012) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36	C4	Chrome Mobile 70.0	Android 8.1.0
+Mozilla/5.0 (Linux; Android 8.1.0; Coolpad 3310A Build/3310A.SPRINT.190213.0S) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	3310A	Chrome Mobile 77.0	Android 8.1.0
+Mozilla/5.0 (Linux; Android 8.1.0; Infinix X604 Build/O11019) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36	Infinix X604	Chrome Mobile 64.0	Android 8.1.0
+Mozilla/5.0 (Linux; Android 8.1.0; Joy 1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	Joy 1	Chrome Mobile 77.0	Android 8.1.0
+Mozilla/5.0 (Linux; Android 8.1.0; LAVA LE9820) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	LAVA LE9820	Chrome Mobile 77.0	Android 8.1.0
+Mozilla/5.0 (Linux; Android 8.1.0; LG-Q710AL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	LG-Q710AL	Chrome Mobile 77.0	Android 8.1.0
+Mozilla/5.0 (Linux; Android 8.1.0; LM-Q610(FGN)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	LM-Q610(FGN)	Chrome Mobile 77.0	Android 8.1.0
+Mozilla/5.0 (Linux; Android 8.1.0; LM-Q710(FGN) Build/OPM1.171019.019; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/77.0.3865.92 Mobile Safari/537.36 [FB_IAB/FB4A;FBAV/235.0.0.38.118;]	LM-Q710(FGN)	Facebook 235.0	Android 8.1.0
+Mozilla/5.0 (Linux; Android 8.1.0; LM-Q710(FGN)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36	LM-Q710(FGN)	Chrome Mobile 70.0	Android 8.1.0
+Mozilla/5.0 (Linux; Android 8.1.0; LM-Q710(FGN)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.111 Mobile Safari/537.36	LM-Q710(FGN)	Chrome Mobile 76.0	Android 8.1.0
+Mozilla/5.0 (Linux; Android 8.1.0; LM-Q710(FGN)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Mobile Safari/537.36	LM-Q710(FGN)	Chrome Mobile 76.0	Android 8.1.0
+Mozilla/5.0 (Linux; Android 8.1.0; LM-Q710(FGN)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	LM-Q710(FGN)	Chrome Mobile 77.0	Android 8.1.0
+Mozilla/5.0 (Linux; Android 8.1.0; LM-V405) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	LM-V405	Chrome Mobile 77.0	Android 8.1.0
+Mozilla/5.0 (Linux; Android 8.1.0; LM-X210(G) Build/OPM1.171019.026; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/77.0.3865.92 Mobile Safari/537.36 agentweb/4.0.2  UCBrowser/11.6.4.950	LM-X210(G)	UC Browser 11.6	Android 8.1.0
+Mozilla/5.0 (Linux; Android 8.1.0; LM-X210(G)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36	LM-X210(G)	Chrome Mobile 70.0	Android 8.1.0
+Mozilla/5.0 (Linux; Android 8.1.0; LM-X210(G)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.105 Mobile Safari/537.36	LM-X210(G)	Chrome Mobile 72.0	Android 8.1.0
+Mozilla/5.0 (Linux; Android 8.1.0; LM-X210(G)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	LM-X210(G)	Chrome Mobile 77.0	Android 8.1.0
+Mozilla/5.0 (Linux; Android 8.1.0; LM-X212(G)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	LM-X212(G)	Chrome Mobile 77.0	Android 8.1.0
+Mozilla/5.0 (Linux; Android 8.1.0; LM-X220) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36	LM-X220	Chrome Mobile 70.0	Android 8.1.0
+Mozilla/5.0 (Linux; Android 8.1.0; LM-X220) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Mobile Safari/537.36	LM-X220	Chrome Mobile 76.0	Android 8.1.0
+Mozilla/5.0 (Linux; Android 8.1.0; LM-X220PM Build/O11019; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/77.0.3865.92 Mobile Safari/537.36;dailymotion-player-sdk-android 0.1.31	LM-X220PM	Chrome Mobile WebView 77.0	Android 8.1.0
+Mozilla/5.0 (Linux; Android 8.1.0; LM-X410(FG)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36	LM-X410(FG)	Chrome Mobile 70.0	Android 8.1.0
+Mozilla/5.0 (Linux; Android 8.1.0; LM-X410(FG)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.111 Mobile Safari/537.36	LM-X410(FG)	Chrome Mobile 76.0	Android 8.1.0
+Mozilla/5.0 (Linux; Android 8.1.0; LM-X410(FG)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	LM-X410(FG)	Chrome Mobile 77.0	Android 8.1.0
+Mozilla/5.0 (Linux; Android 8.1.0; LM-X410.FGN Build/OPM1.171019.019) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36	LM-X410.FGN	Chrome Mobile 68.0	Android 8.1.0
+Mozilla/5.0 (Linux; Android 8.1.0; LML414DL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Mobile Safari/537.36	LML414DL	Chrome Mobile 76.0	Android 8.1.0
+Mozilla/5.0 (Linux; Android 8.1.0; LML713DL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	LML713DL	Chrome Mobile 77.0	Android 8.1.0
+Mozilla/5.0 (Linux; Android 8.1.0; Moto G (5S) Plus) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	Moto G (5S) Plus	Chrome Mobile 77.0	Android 8.1.0
+Mozilla/5.0 (Linux; Android 8.1.0; One) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/70.0.3538.110 Mobile Safari/537.36/TansoDL	HTC One	Chrome Mobile WebView 70.0	Android 8.1.0
+Mozilla/5.0 (Linux; Android 8.1.0; RCT6873W42BMF8KC Build/O11019) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	RCT6873W42BMF8KC	Chrome Mobile 77.0	Android 8.1.0
+Mozilla/5.0 (Linux; Android 8.1.0; REVVL 2 Build/OPM1.171019.011) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36	REVVL 2	Chrome Mobile 67.0	Android 8.1.0
+Mozilla/5.0 (Linux; Android 8.1.0; REVVL 2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Mobile Safari/537.36	REVVL 2	Chrome Mobile 76.0	Android 8.1.0
+Mozilla/5.0 (Linux; Android 8.1.0; SAMSUNG SM-J727T) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.1 Chrome/71.0.3578.99 Mobile Safari/537.36	Samsung SM-J727T	Samsung Internet 10.1	Android 8.1.0
+Mozilla/5.0 (Linux; Android 8.1.0; SAMSUNG SM-J727T1 Build/M1AJQ) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/9.4 Chrome/67.0.3396.87 Mobile Safari/537.36	Samsung SM-J727T1	Samsung Internet 9.4	Android 8.1.0
+Mozilla/5.0 (Linux; Android 8.1.0; SAMSUNG SM-J727T1) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.1 Chrome/71.0.3578.99 Mobile Safari/537.36	Samsung SM-J727T1	Samsung Internet 10.1	Android 8.1.0
+Mozilla/5.0 (Linux; Android 8.1.0; SAMSUNG SM-T580 Build/M1AJQ) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/9.4 Chrome/67.0.3396.87 Safari/537.36	Samsung SM-T580	Samsung Internet 9.4	Android 8.1.0
+Mozilla/5.0 (Linux; Android 8.1.0; SAMSUNG-SM-J727A Build/M1AJQ; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/77.0.3865.92 Mobile Safari/537.36 [FB_IAB/FB4A;FBAV/240.0.0.38.121;]	Samsung SM-J727A	Facebook 240.0	Android 8.1.0
+Mozilla/5.0 (Linux; Android 8.1.0; SM-G610F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	Samsung SM-G610F	Chrome Mobile 77.0	Android 8.1.0
+Mozilla/5.0 (Linux; Android 8.1.0; SM-J260T1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.111 Mobile Safari/537.36	Samsung SM-J260T1	Chrome Mobile 76.0	Android 8.1.0
+Mozilla/5.0 (Linux; Android 8.1.0; SM-J260T1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Mobile Safari/537.36	Samsung SM-J260T1	Chrome Mobile 76.0	Android 8.1.0
+Mozilla/5.0 (Linux; Android 8.1.0; SM-J260T1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	Samsung SM-J260T1	Chrome Mobile 77.0	Android 8.1.0
+Mozilla/5.0 (Linux; Android 8.1.0; SM-J410F Build/M1AJB) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	Samsung SM-J410F	Chrome Mobile 77.0	Android 8.1.0
+Mozilla/5.0 (Linux; Android 8.1.0; SM-J727P Build/M1AJQ) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36	Samsung SM-J727P	Chrome Mobile 68.0	Android 8.1.0
+Mozilla/5.0 (Linux; Android 8.1.0; SM-J727T Build/M1AJQ) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.126 Mobile Safari/537.36	Samsung SM-J727T	Chrome Mobile 66.0	Android 8.1.0
+Mozilla/5.0 (Linux; Android 8.1.0; SM-J727T1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.111 Mobile Safari/537.36	Samsung SM-J727T1	Chrome Mobile 76.0	Android 8.1.0
+Mozilla/5.0 (Linux; Android 8.1.0; SM-J727T1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.73 Mobile Safari/537.36	Samsung SM-J727T1	Chrome Mobile 77.0	Android 8.1.0
+Mozilla/5.0 (Linux; Android 8.1.0; SM-J727T1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	Samsung SM-J727T1	Chrome Mobile 77.0	Android 8.1.0
+Mozilla/5.0 (Linux; Android 8.1.0; SM-J727V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36	Samsung SM-J727V	Chrome Mobile 70.0	Android 8.1.0
+Mozilla/5.0 (Linux; Android 8.1.0; SM-J727V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	Samsung SM-J727V	Chrome Mobile 77.0	Android 8.1.0
+Mozilla/5.0 (Linux; Android 8.1.0; SM-P580) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Safari/537.36	SM-P580	Chrome 77.0	Android 8.1.0
+Mozilla/5.0 (Linux; Android 8.1.0; SM-T380) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Safari/537.36	SM-T380	Chrome 75.0	Android 8.1.0
+Mozilla/5.0 (Linux; Android 8.1.0; SM-T580) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.90 Safari/537.36 EdgA/42.0.2.3928	SM-T580	Edge Mobile 42.0	Android 8.1.0
+Mozilla/5.0 (Linux; Android 8.1.0; SM-T580) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Safari/537.36	SM-T580	Chrome 76.0	Android 8.1.0
+Mozilla/5.0 (Linux; Android 8.1.0; SM-T580) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.89 Safari/537.36	SM-T580	Chrome 76.0	Android 8.1.0
+Mozilla/5.0 (Linux; Android 8.1.0; SM-T580) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Safari/537.36	SM-T580	Chrome 77.0	Android 8.1.0
+Mozilla/5.0 (Linux; Android 8.1.0; SM-T837T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Safari/537.36	Samsung SM-T837T	Chrome 77.0	Android 8.1.0
+Mozilla/5.0 (Linux; Android 8.1.0; TECNO CF8 Build/O11019; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/77.0.3865.92 Mobile Safari/537.36 [FB_IAB/FB4A;FBAV/239.0.0.41.152;]	TECNO CF8	Facebook 239.0	Android 8.1.0
+Mozilla/5.0 (Linux; Android 8.1.0; V1818CA) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.101 Mobile Safari/537.36	V1818CA	Chrome Mobile 75.0	Android 8.1.0
+Mozilla/5.0 (Linux; Android 8.1.0; meizu C9 Build/OPM2.171019.012) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36	meizu C9	Chrome Mobile 68.0	Android 8.1.0
+Mozilla/5.0 (Linux; Android 8.1.0; vivo 1724) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Mobile Safari/537.36	vivo 1724	Chrome Mobile 76.0	Android 8.1.0
+Mozilla/5.0 (Linux; Android 8.1.0; vivo 1814) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	vivo 1814	Chrome Mobile 77.0	Android 8.1.0
+Mozilla/5.0 (Linux; Android 9) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/77.0.3865.92 Mobile Safari/537.36 DuckDuckGo/5	Generic Smartphone	DuckDuckGo Mobile 5.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; 1825) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36	1825	Chrome Mobile 70.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; ANE-LX2 Build/HUAWEIANE-L22; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.132 Mobile Safari/537.36 [FB_IAB/FB4A;FBAV/236.0.0.40.117;]	ANE-LX2	Facebook 236.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; BLA-A09) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	BLA-A09	Chrome Mobile 77.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; CLT-L04) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	Huawei CLT-L04	Chrome Mobile 77.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; CPH1911 Build/PPR1.180610.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/77.0.3865.92 Mobile Safari/537.36 [FB_IAB/FB4A;FBAV/239.0.0.41.152;]	Oppo CPH1911	Facebook 239.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; CPH1923 Build/PPR1.180610.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.111 Mobile Safari/537.36	Oppo CPH1923	Chrome Mobile WebView 76.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; ELE-L29) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	Huawei ELE-L29	Chrome Mobile 77.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; G8142) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	G8142	Chrome Mobile 77.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; GM1911) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.111 Mobile Safari/537.36	GM1911	Chrome Mobile 76.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; GM1917) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	GM1917	Chrome Mobile 77.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; INE-LX2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.111 Mobile Safari/537.36	Huawei INE-LX2	Chrome Mobile 76.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; LM-G710 Build/PKQ1.181105.001; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/77.0.3865.92 Mobile Safari/537.36	LM-G710	Chrome Mobile WebView 77.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; LM-Q720) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	LM-Q720	Chrome Mobile 77.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; LM-V405 Build/PKQ1.190202.001; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/77.0.3865.92 Mobile Safari/537.36;dailymotion-player-sdk-android 0.1.15	LM-V405	Chrome Mobile WebView 77.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; LM-V405) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.111 Mobile Safari/537.36	LM-V405	Chrome Mobile 76.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; LM-V500N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	LM-V500N	Chrome Mobile 77.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; LM-X420) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.121 Mobile Safari/537.36	LM-X420	Chrome Mobile 72.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; LM-X420) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	LM-X420	Chrome Mobile 77.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; MAR-LX1A) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	MAR-LX1A	Chrome Mobile 77.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; MI 9) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	XiaoMi MI 9	Chrome Mobile 77.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; Mi A2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	XiaoMi Mi A2	Chrome Mobile 77.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; Moto Z (2)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	Moto Z (2)	Chrome Mobile 77.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; Nokia 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	Nokia 6	Chrome Mobile 77.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; ONEPLUS A6000) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	OnePlus ONEPLUS A6000	Chrome Mobile 77.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; ONEPLUS A6003) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	OnePlus ONEPLUS A6003	Chrome Mobile 77.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; ONEPLUS A6013 Build/PKQ1.180716.001; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/77.0.3865.92 Mobile Safari/537.36	OnePlus ONEPLUS A6013	Chrome Mobile WebView 77.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; ONEPLUS A6013) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Mobile Safari/537.36	OnePlus ONEPLUS A6013	Chrome Mobile 74.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; ONEPLUS A6013) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	OnePlus ONEPLUS A6013	Chrome Mobile 77.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; PAR-AL00 Build/HUAWEIPAR-AL00; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/77.0.3865.92 Mobile Safari/537.36 [FB_IAB/FB4A;FBAV/235.0.0.38.118;]	PAR-AL00	Facebook 235.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; Pixel 2 XL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	Pixel 2 XL	Chrome Mobile 77.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; Pixel 3 Build/PQ1A.190105.004; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/77.0.3865.92 Mobile Safari/537.36	Pixel 3	Chrome Mobile WebView 77.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; Pixel 3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.111 Mobile Safari/537.36	Pixel 3	Chrome Mobile 76.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; Pixel 3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	Pixel 3	Chrome Mobile 77.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; Pixel 3a XL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	Pixel 3a XL	Chrome Mobile 77.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; REVVLRY ) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.90 Mobile Safari/537.36	REVVLRY 	Chrome Mobile 73.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; RMX1801) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.101 Mobile Safari/537.36	Oppo RMX1801	Chrome Mobile 75.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; Redmi 7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	XiaoMi Redmi 7	Chrome Mobile 77.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; Redmi Note 7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.89 Mobile Safari/537.36	XiaoMi Redmi Note 7	Chrome Mobile 76.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-A102U) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.1 Chrome/71.0.3578.99 Mobile Safari/537.36	Samsung SM-A102U	Samsung Internet 10.1	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-A505FN) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.1 Chrome/71.0.3578.99 Mobile Safari/537.36	Samsung SM-A505FN	Samsung Internet 10.1	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-A505GN) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.1 Chrome/71.0.3578.99 Mobile Safari/537.36	Samsung SM-A505GN	Samsung Internet 10.1	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-G892U) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.1 Chrome/71.0.3578.99 Mobile Safari/537.36	Samsung SM-G892U	Samsung Internet 10.1	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-G950U) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.1 Chrome/71.0.3578.99 Mobile Safari/537.36	Samsung SM-G950U	Samsung Internet 10.1	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-G955F Build/PPR1.180610.011) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/9.4 Chrome/67.0.3396.87 Mobile Safari/537.36	Samsung SM-G955F	Samsung Internet 9.4	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-G955U) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.1 Chrome/71.0.3578.99 Mobile Safari/537.36	Samsung SM-G955U	Samsung Internet 10.1	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-G9600 Build/PPR1.180610.011) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/9.4 Chrome/67.0.3396.87 Mobile Safari/537.36	Samsung SM-G9600	Samsung Internet 9.4	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-G960U) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.1 Chrome/71.0.3578.99 Mobile Safari/537.36	Samsung SM-G960U	Samsung Internet 10.1	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-G965U) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.1 Chrome/71.0.3578.99 Mobile Safari/537.36	Samsung SM-G965U	Samsung Internet 10.1	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-G970F) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.1 Chrome/71.0.3578.99 Mobile Safari/537.36	Samsung SM-G970F	Samsung Internet 10.1	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-G970U) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.1 Chrome/71.0.3578.99 Mobile Safari/537.36	Samsung SM-G970U	Samsung Internet 10.1	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-G973U Build/PPR1.180610.011) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/9.4 Chrome/67.0.3396.87 Mobile Safari/537.36	Samsung SM-G973U	Samsung Internet 9.4	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-G973U) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.1 Chrome/71.0.3578.99 Mobile Safari/537.36	Samsung SM-G973U	Samsung Internet 10.1	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-G975U) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.1 Chrome/71.0.3578.99 Mobile Safari/537.36	Samsung SM-G975U	Samsung Internet 10.1	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-J415F) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.1 Chrome/71.0.3578.99 Mobile Safari/537.36	Samsung SM-J415F	Samsung Internet 10.1	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-J730F) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.1 Chrome/71.0.3578.99 Mobile Safari/537.36	Samsung SM-J730F	Samsung Internet 10.1	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-J737P) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.1 Chrome/71.0.3578.99 Mobile Safari/537.36	Samsung SM-J737P	Samsung Internet 10.1	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-J737T Build/PPR1.180610.011) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/9.0 Chrome/67.0.3396.87 Mobile Safari/537.36	Samsung SM-J737T	Samsung Internet 9.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-N950U) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.1 Chrome/71.0.3578.99 Mobile Safari/537.36	Samsung SM-N950U	Samsung Internet 10.1	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-N960F) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.1 Chrome/71.0.3578.99 Mobile Safari/537.36	Samsung SM-N960F	Samsung Internet 10.1	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-N960U) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.1 Chrome/71.0.3578.99 Mobile Safari/537.36	Samsung SM-N960U	Samsung Internet 10.1	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-N960U1 Build/PPR1.180610.011) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/9.2 Chrome/67.0.3396.87 Mobile Safari/537.36	Samsung SM-N960U1	Samsung Internet 9.2	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-N970U) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.1 Chrome/71.0.3578.99 Mobile Safari/537.36	Samsung SM-N970U	Samsung Internet 10.1	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-N975U) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.1 Chrome/71.0.3578.99 Mobile Safari/537.36	Samsung SM-N975U	Samsung Internet 10.1	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-N975U1) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.1 Chrome/71.0.3578.99 Mobile Safari/537.36	Samsung SM-N975U1	Samsung Internet 10.1	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-T510) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.1 Chrome/71.0.3578.99 Safari/537.36	Samsung SM-T510	Samsung Internet 10.1	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-T720) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.1 Chrome/71.0.3578.99 Safari/537.36	Samsung SM-T720	Samsung Internet 10.1	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SHIELD Android TV Build/PPR1.180610.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/77.0.3865.92 Mobile Safari/537.36;dailymotion-player-sdk-android 0.1.31	SHIELD Android TV	Chrome Mobile WebView 77.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SM-A102U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.121 Mobile Safari/537.36	Samsung SM-A102U	Chrome Mobile 72.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SM-A102U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	Samsung SM-A102U	Chrome Mobile 77.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SM-A105M Build/PPR1.180610.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/77.0.3865.92 Mobile Safari/537.36 [FB_IAB/FB4A;FBAV/237.0.0.44.120;]	Samsung SM-A105M	Facebook 237.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SM-A205G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	Samsung SM-A205G	Chrome Mobile 77.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SM-A205U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	Samsung SM-A205U	Chrome Mobile 77.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SM-A505F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	Samsung SM-A505F	Chrome Mobile 77.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SM-A530F Build/PPR1.180610.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/77.0.3865.92 Mobile Safari/537.36 [FB_IAB/FB4A;FBAV/240.0.0.38.121;]	Samsung SM-A530F	Facebook 240.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SM-A530N Build/PPR1.180610.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/77.0.3865.92 Mobile Safari/537.36;KAKAOTALK 1908560	Samsung SM-A530N	Chrome Mobile WebView 77.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SM-A600T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	Samsung SM-A600T	Chrome Mobile 77.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SM-A605F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	Samsung SM-A605F	Chrome Mobile 77.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SM-A920F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	Samsung SM-A920F	Chrome Mobile 77.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SM-G892A) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.136 Mobile Safari/537.36	Samsung SM-G892A	Chrome Mobile 74.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SM-G950F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	Samsung SM-G950F	Chrome Mobile 77.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SM-G950U Build/PPR1.180610.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/77.0.3865.92 Mobile Safari/537.36;dailymotion-player-sdk-android 0.1.31	Samsung SM-G950U	Chrome Mobile WebView 77.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SM-G950U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36	Samsung SM-G950U	Chrome Mobile 71.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SM-G950U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.111 Mobile Safari/537.36	Samsung SM-G950U	Chrome Mobile 76.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SM-G950U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Mobile Safari/537.36	Samsung SM-G950U	Chrome Mobile 76.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SM-G950U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	Samsung SM-G950U	Chrome Mobile 77.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SM-G950U1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	Samsung SM-G950U1	Chrome Mobile 77.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SM-G955F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	Samsung SM-G955F	Chrome Mobile 77.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SM-G955U Build/PPR1.180610.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/77.0.3865.73 Mobile Safari/537.36 [FB_IAB/FB4A;FBAV/240.0.0.38.121;]	Samsung SM-G955U	Facebook 240.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SM-G955U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	Samsung SM-G955U	Chrome Mobile 77.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SM-G9600) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	Samsung SM-G9600	Chrome Mobile 77.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SM-G960U Build/PPR1.180610.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/73.0.3683.90 Mobile Safari/537.36 [FB_IAB/FB4A;FBAV/233.0.0.36.117;]	Samsung SM-G960U	Facebook 233.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SM-G960U Build/PPR1.180610.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/77.0.3865.92 Mobile Safari/537.36;dailymotion-player-sdk-android 0.1.31	Samsung SM-G960U	Chrome Mobile WebView 77.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SM-G960U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36	Samsung SM-G960U	Chrome Mobile 71.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SM-G960U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.136 Mobile Safari/537.36	Samsung SM-G960U	Chrome Mobile 74.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SM-G960U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	Samsung SM-G960U	Chrome Mobile 77.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SM-G960U1 Build/PPR1.180610.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/77.0.3865.92 Mobile Safari/537.36 [FB_IAB/FB4A;FBAV/240.0.0.38.121;]	Samsung SM-G960U1	Facebook 240.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SM-G960U1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	Samsung SM-G960U1	Chrome Mobile 77.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SM-G965F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	Samsung SM-G965F	Chrome Mobile 77.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SM-G965U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.136 Mobile Safari/537.36	Samsung SM-G965U	Chrome Mobile 74.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SM-G965U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	Samsung SM-G965U	Chrome Mobile 77.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SM-G965U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3921.2 Mobile Safari/537.36	Samsung SM-G965U	Chrome Mobile 79.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SM-G965U1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	Samsung SM-G965U1	Chrome Mobile 77.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SM-G970U Build/PPR1.180610.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/77.0.3865.92 Mobile Safari/537.36 [FB_IAB/FB4A;FBAV/240.0.0.38.121;]	Samsung SM-G970U	Facebook 240.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SM-G970U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.101 Mobile Safari/537.36	Samsung SM-G970U	Chrome Mobile 75.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SM-G970U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	Samsung SM-G970U	Chrome Mobile 77.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SM-G970U1 Build/PPR1.180610.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/77.0.3865.92 Mobile Safari/537.36	Samsung SM-G970U1	Chrome Mobile WebView 77.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SM-G973U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.136 Mobile Safari/537.36	Samsung SM-G973U	Chrome Mobile 74.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SM-G973U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	Samsung SM-G973U	Chrome Mobile 77.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SM-G973U1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	Samsung SM-G973U1	Chrome Mobile 77.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SM-G975U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.101 Mobile Safari/537.36	Samsung SM-G975U	Chrome Mobile 75.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SM-G975U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Mobile Safari/537.36	Samsung SM-G975U	Chrome Mobile 76.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SM-G975U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	Samsung SM-G975U	Chrome Mobile 77.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SM-G975U1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	Samsung SM-G975U1	Chrome Mobile 77.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SM-J260A) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	Samsung SM-J260A	Chrome Mobile 77.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SM-J337P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Mobile Safari/537.36	Samsung SM-J337P	Chrome Mobile 76.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SM-J600FN) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.89 Mobile Safari/537.36	Samsung SM-J600FN	Chrome Mobile 75.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SM-J600G Build/PPR1.180610.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/77.0.3865.73 Mobile Safari/537.36 [FB_IAB/FB4A;FBAV/238.0.0.41.116;]	Samsung SM-J600G	Facebook 238.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SM-J730F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	Samsung SM-J730F	Chrome Mobile 77.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SM-J737A Build/PPR1.180610.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/77.0.3865.92 Mobile Safari/537.36;dailymotion-player-sdk-android 0.1.31	Samsung SM-J737A	Chrome Mobile WebView 77.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SM-J737A) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.136 Mobile Safari/537.36	Samsung SM-J737A	Chrome Mobile 74.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SM-J737V Build/PPR1.180610.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/75.0.3770.101 Mobile Safari/537.36 [Pinterest/Android]	Samsung SM-J737V	Pinterest 0.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SM-J737V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	Samsung SM-J737V	Chrome Mobile 77.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SM-J810M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	Samsung SM-J810M	Chrome Mobile 77.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SM-N950U Build/PPR1.180610.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/77.0.3865.92 Mobile Safari/537.36 [FB_IAB/FB4A;FBAV/240.0.0.38.121;]	Samsung SM-N950U	Facebook 240.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SM-N950U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.121 Mobile Safari/537.36	Samsung SM-N950U	Chrome Mobile 72.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SM-N950U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.101 Mobile Safari/537.36	Samsung SM-N950U	Chrome Mobile 75.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SM-N950U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.73 Mobile Safari/537.36	Samsung SM-N950U	Chrome Mobile 77.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SM-N950U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	Samsung SM-N950U	Chrome Mobile 77.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SM-N960F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Mobile Safari/537.36	Samsung SM-N960F	Chrome Mobile 76.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SM-N960U Build/PPR1.180610.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/74.0.3729.136 Mobile Safari/537.36 [FB_IAB/FB4A;FBAV/240.0.0.38.121;]	Samsung SM-N960U	Facebook 240.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SM-N960U Build/PPR1.180610.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/77.0.3865.92 Mobile Safari/537.36;dailymotion-player-sdk-android 0.1.31	Samsung SM-N960U	Chrome Mobile WebView 77.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SM-N960U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Mobile Safari/537.36	Samsung SM-N960U	Chrome Mobile 74.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SM-N960U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36	Samsung SM-N960U	Chrome Mobile 75.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SM-N960U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Mobile Safari/537.36	Samsung SM-N960U	Chrome Mobile 76.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SM-N960U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	Samsung SM-N960U	Chrome Mobile 77.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SM-N960U1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	Samsung SM-N960U1	Chrome Mobile 77.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SM-N975U Build/PPR1.180610.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/77.0.3865.73 Mobile Safari/537.36;dailymotion-player-sdk-android 0.1.31	Samsung SM-N975U	Chrome Mobile WebView 77.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SM-N975U Build/PPR1.180610.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/77.0.3865.92 Mobile Safari/537.36;dailymotion-player-sdk-android 0.1.31	Samsung SM-N975U	Chrome Mobile WebView 77.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SM-N975U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	Samsung SM-N975U	Chrome Mobile 77.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SM-N976V Build/PPR1.180610.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/77.0.3865.92 Mobile Safari/537.36 [FB_IAB/FB4A;FBAV/240.0.0.38.121;]	Samsung SM-N976V	Facebook 240.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SM-S367VL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	Samsung SM-S367VL	Chrome Mobile 77.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SM-S767VL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Mobile Safari/537.36	Samsung SM-S767VL	Chrome Mobile 76.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SM-T597P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Safari/537.36	Samsung SM-T597P	Chrome 77.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; SM-T720) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Safari/537.36	SM-T720	Chrome 77.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; TECNO KC8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	TECNO KC8	Chrome Mobile 77.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; VOG-L29) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	Huawei VOG-L29	Chrome Mobile 77.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; cp3705A) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.136 Mobile Safari/537.36	cp3705A	Chrome Mobile 74.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; moto g(6) Build/PPS29.118-15-11; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/77.0.3865.92 Mobile Safari/537.36;dailymotion-player-sdk-android 0.1.31	moto g(6)	Chrome Mobile WebView 77.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; moto g(6) play) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	moto g(6) play	Chrome Mobile 77.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; moto g(7) play Build/PCYS29.105-134-1; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.132 Mobile Safari/537.36 [FB_IAB/FB4A;FBAV/235.0.0.38.118;]	moto g(7) play	Facebook 235.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; moto g(7) play) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Mobile Safari/537.36	moto g(7) play	Chrome Mobile 70.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; moto g(7) power) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.101 Mobile Safari/537.36	moto g(7) power	Chrome Mobile 75.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; moto g(7) power) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36	moto g(7) power	Chrome Mobile 77.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; moto z4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.90 Mobile Safari/537.36	moto z4	Chrome Mobile 73.0	Android 9.0.0
+Mozilla/5.0 (Linux; Android 9; moto z4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.73 Mobile Safari/537.36	moto z4	Chrome Mobile 77.0	Android 9.0.0
+Mozilla/5.0 (Linux; U; Android 4.1.1; en-us; GT-P3113 Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30	Samsung GT-P3113 	Android 4.1	Android 4.1.1
+Mozilla/5.0 (Linux; U; Android 4.1.2; ar-ae; GT-I8160 Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30	Samsung GT-I8160 	Android 4.1	Android 4.1.2
+Mozilla/5.0 (Linux; U; Android 4.2.2; en-us; Nexus 7 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30; DailymotionEmbedSDK 1.0	Asus Nexus 7	Android 4.2	Android 4.2.2
+Mozilla/5.0 (Linux; U; Android 4.4; en-us; SM-E500H Build/JOP24G) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30	Samsung SM-E500H	Android 4.4	Android 4.4.0
+Mozilla/5.0 (Linux; U; Android 6.0.1; en-us; LGMS550 Build/JOP24G) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Chrome/43.0.2357.65 Mobile Safari/534.30	LGMS550	Chrome Mobile WebView 43.0	Android 6.0.1
+Mozilla/5.0 (Linux; U; Android 6.0.1; en-us; SM-J737T1 Build/JOP24G) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Chrome/43.0.2357.65 Mobile Safari/534.30	Samsung SM-J737T1	Chrome Mobile WebView 43.0	Android 6.0.1
+Mozilla/5.0 (Linux; U; Android 7.0; TECNO CA6 Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/64.0.3282.137 Mobile Safari/537.36 OPR/5.3.2254.135058	TECNO CA6	Opera Mobile 5.3	Android 7.0.0
+Mozilla/5.0 (Linux; U; Android 7.1.2; id-id; Redmi 5A Build/N2G47H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/53.0.2785.146 Mobile Safari/537.36 XiaoMi/MiuiBrowser/9.5.6	XiaoMi Redmi 5A	MiuiBrowser 9.5	Android 7.1.2
+Mozilla/5.0 (Linux; U; Android 9; in-id; CPH1911 Build/PPR1.180610.011) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/70.0.3538.80 Mobile Safari/537.36 OppoBrowser/25.6.0.0.5beta	Oppo CPH1911	Chrome Mobile WebView 70.0	Android 9.0.0
+Mozilla/5.0 (Linux; U; Android 9; vivo 1904 Build/PPR1.180610.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/74.0.3729.136 Mobile Safari/537.36 OPR/44.1.2254.143214	vivo 1904	Opera Mobile 44.1	Android 9.0.0
+Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:68.0) Gecko/20100101 Firefox/68.0	Mac	Firefox 68.0	Mac OS X 10.11.0
+Mozilla/5.0 (Macintosh; Intel Mac OS X 10.13; rv:69.0) Gecko/20100101 Firefox/69.0	Mac	Firefox 69.0	Mac OS X 10.13.0
+Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:67.0) Gecko/20100101 Firefox/67.0	Mac	Firefox 67.0	Mac OS X 10.14.0
+Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:68.0) Gecko/20100101 Firefox/68.0	Mac	Firefox 68.0	Mac OS X 10.14.0
+Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:69.0) Gecko/20100101 Firefox/69.0	Mac	Firefox 69.0	Mac OS X 10.14.0
+Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:70.0) Gecko/20100101 Firefox/70.0	Mac	Firefox 70.0	Mac OS X 10.14.0
+Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Safari/537.36	Mac	Chrome 76.0	Mac OS X 10.10.5
+Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36	Mac	Chrome 77.0	Mac OS X 10.10.5
+Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/603.3.8 (KHTML, like Gecko) Version/10.1.2 Safari/603.3.8	Mac	Safari 10.1	Mac OS X 10.10.5
+Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.100 Safari/537.36	Mac	Chrome 76.0	Mac OS X 10.11.4
+Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.119 Safari/537.36	Mac	Chrome 72.0	Mac OS X 10.11.6
+Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.100 Safari/537.36	Mac	Chrome 76.0	Mac OS X 10.11.6
+Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Safari/537.36	Mac	Chrome 76.0	Mac OS X 10.11.6
+Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36	Mac	Chrome 77.0	Mac OS X 10.11.6
+Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/601.7.7 (KHTML, like Gecko) Version/9.1.2 Safari/601.7.7	Mac	Safari 9.1	Mac OS X 10.11.6
+Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/602.2.14 (KHTML, like Gecko) Version/10.0.1 Safari/602.2.14	Mac	Safari 10.0	Mac OS X 10.11.6
+Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/11.1.2 Safari/605.1.15	Mac	Safari 11.1	Mac OS X 10.11.6
+Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36	Mac	Chrome 77.0	Mac OS X 10.12.1
+Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/602.4.8 (KHTML, like Gecko) Version/10.0.3 Safari/602.4.8	Mac	Safari 10.0	Mac OS X 10.12.3
+Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.100 Safari/537.36	Mac	Chrome 75.0	Mac OS X 10.12.6
+Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.100 Safari/537.36	Mac	Chrome 76.0	Mac OS X 10.12.6
+Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Safari/537.36	Mac	Chrome 76.0	Mac OS X 10.12.6
+Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36	Mac	Chrome 77.0	Mac OS X 10.12.6
+Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.1.2 Safari/605.1.15	Mac	Safari 12.1	Mac OS X 10.12.6
+Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Safari/604.1.38	Mac	Safari 11.0	Mac OS X 10.13.0
+Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36	Mac	Chrome 77.0	Mac OS X 10.13.1
+Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36	Mac	Chrome 77.0	Mac OS X 10.13.2
+Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.100 Safari/537.36	Mac	Chrome 76.0	Mac OS X 10.13.4
+Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Safari/537.36	Mac	Chrome 76.0	Mac OS X 10.13.4
+Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.100 Safari/537.36	Mac	Chrome 76.0	Mac OS X 10.13.5
+Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.142 Safari/537.36	Mac	Chrome 75.0	Mac OS X 10.13.6
+Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Safari/537.36	Mac	Chrome 76.0	Mac OS X 10.13.6
+Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36	Mac	Chrome 77.0	Mac OS X 10.13.6
+Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0.3 Safari/605.1.15	Mac	Safari 12.0	Mac OS X 10.13.6
+Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.1.1 Safari/605.1.15	Mac	Safari 12.1	Mac OS X 10.13.6
+Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.1.2 Safari/605.1.15	Mac	Safari 12.1	Mac OS X 10.13.6
+Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0 Safari/605.1.15	Mac	Safari 13.0	Mac OS X 10.13.6
+Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.1 Safari/605.1.15	Mac	Safari 13.0	Mac OS X 10.13.6
+Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.142 Safari/537.36	Mac	Chrome 75.0	Mac OS X 10.14.0
+Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Safari/537.36	Mac	Chrome 76.0	Mac OS X 10.14.0
+Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36	Mac	Chrome 77.0	Mac OS X 10.14.0
+Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36	Mac	Chrome 77.0	Mac OS X 10.14.1
+Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Safari/537.36	Mac	Chrome 76.0	Mac OS X 10.14.2
+Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Safari/537.36	Mac	Chrome 69.0	Mac OS X 10.14.3
+Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_3) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0.3 Safari/605.1.15	Mac	Safari 12.0	Mac OS X 10.14.3
+Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.142 Safari/537.36	Mac	Chrome 75.0	Mac OS X 10.14.4
+Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36	Mac	Chrome 77.0	Mac OS X 10.14.4
+Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_4) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.1 Safari/605.1.15	Mac	Safari 12.1	Mac OS X 10.14.4
+Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Safari/537.36	Mac	Chrome 76.0	Mac OS X 10.14.5
+Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36	Mac	Chrome 77.0	Mac OS X 10.14.5
+Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.1.1 Safari/605.1.15	Mac	Safari 12.1	Mac OS X 10.14.5
+Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.142 Safari/537.36	Mac	Chrome 75.0	Mac OS X 10.14.6
+Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.100 Safari/537.36	Mac	Chrome 76.0	Mac OS X 10.14.6
+Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Safari/537.36	Mac	Chrome 76.0	Mac OS X 10.14.6
+Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.75 Safari/537.36	Mac	Chrome 77.0	Mac OS X 10.14.6
+Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36	Mac	Chrome 77.0	Mac OS X 10.14.6
+Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.1.2 Safari/605.1.15	Mac	Safari 12.1	Mac OS X 10.14.6
+Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.1 Safari/605.1.15	Mac	Safari 13.0	Mac OS X 10.14.6
+Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.181 Safari/537.36	Mac	Chrome 65.0	Mac OS X 10.9.5
+Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.181 Safari/537.36	Mac	Chrome 66.0	Mac OS X 10.9.5
+Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Safari/537.36	Mac	Chrome 67.0	Mac OS X 10.9.5
+Mozilla/5.0 (PlayStation 4 6.72) AppleWebKit/605.1.15 (KHTML, like Gecko)	PlayStation 4	Apple Mail 605.1	Other 0.0.0
+Mozilla/5.0 (SMART-TV; LINUX; Tizen 3.0) AppleWebKit/538.1 (KHTML, like Gecko) Version/3.0 TV Safari/538.1	Samsung SMART-TV	Safari 3.0	Tizen 3.0.0
+Mozilla/5.0 (SMART-TV; Linux; Tizen 3.0) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/2.0 Chrome/47.0.2526.69 TV safari/537.36	Samsung SMART-TV	Samsung Internet 2.0	Tizen 3.0.0
+Mozilla/5.0 (SMART-TV; Linux; Tizen 4.0) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/2.1 Chrome/56.0.2924.0 TV Safari/537.36	Samsung SMART-TV	Samsung Internet 2.1	Tizen 4.0.0
+Mozilla/5.0 (SMART-TV; Linux; Tizen 5.0) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/2.2 Chrome/63.0.3239.84 TV Safari/537.36	Samsung SMART-TV	Samsung Internet 2.2	Tizen 5.0.0
+Mozilla/5.0 (Windows NT 10.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.140 Safari/537.36 Edge/17.17134	Other	Edge 17.17134	Windows 10.0.0
+Mozilla/5.0 (Windows NT 10.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.140 Safari/537.36 Edge/18.17763	Other	Edge 18.17763	Windows 10.0.0
+Mozilla/5.0 (Windows NT 10.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.75 Safari/537.36	Other	Chrome 77.0	Windows 10.0.0
+Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.79 Safari/537.36 Maxthon/5.2.7.5000	Other	Maxthon 5.2	Windows 10.0.0
+Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.1.3683.41 Safari/537.36	Other	Chrome 73.1	Windows 10.0.0
+Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.100 Safari/537.36	Other	Chrome 76.0	Windows 10.0.0
+Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Safari/537.36 OPR/63.0.3368.94	Other	Opera 63.0	Windows 10.0.0
+Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.75 Safari/537.36	Other	Chrome 77.0	Windows 10.0.0
+Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36	Other	Chrome 77.0	Windows 10.0.0
+Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) coc_coc_browser/82.0.144 Chrome/76.0.3809.144 Safari/537.36	Other	Coc Coc 82.0	Windows 10.0.0
+Mozilla/5.0 (Windows NT 10.0; WOW64; Trident/7.0; rv:11.0) like Gecko	Other	IE 11.0	Windows 10.0.0
+Mozilla/5.0 (Windows NT 10.0; WOW64; rv:59.0) Gecko/20100101 Firefox/59.0	Other	Firefox 59.0	Windows 10.0.0
+Mozilla/5.0 (Windows NT 10.0; WOW64; rv:60.0) Gecko/20100101 Firefox/60.0	Other	Firefox 60.0	Windows 10.0.0
+Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.116 Safari/537.36 Edge/15.15063	Other	Edge 15.15063	Windows 10.0.0
+Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.36 Edge/16.16299	Other	Edge 16.16299	Windows 10.0.0
+Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.140 Safari/537.36 Edge/17.17134	Other	Edge 17.17134	Windows 10.0.0
+Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.140 Safari/537.36 Edge/18.17763	Other	Edge 18.17763	Windows 10.0.0
+Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.162 Safari/537.36	Other	Chrome 65.0	Windows 10.0.0
+Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.102 Safari/537.36	Other	Chrome 70.0	Windows 10.0.0
+Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.102 Safari/537.36 Edge/18.18362	Other	Edge 18.18362	Windows 10.0.0
+Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.102 Safari/537.36 Edge/18.18995	Other	Edge 18.18995	Windows 10.0.0
+Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.102 Safari/537.36 Edge/18.19493	Other	Edge 18.19493	Windows 10.0.0
+Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.77 Safari/537.36	Other	Chrome 70.0	Windows 10.0.0
+Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.98 Safari/537.36	Other	Chrome 71.0	Windows 10.0.0
+Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.75 Safari/537.36	Other	Chrome 73.0	Windows 10.0.0
+Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36	Other	Chrome 74.0	Windows 10.0.0
+Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.80 Safari/537.36	Other	Chrome 75.0	Windows 10.0.0
+Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.100 Safari/537.36	Other	Chrome 76.0	Windows 10.0.0
+Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.110 Safari/537.36 Vivaldi/2.7.1628.30	Other	Vivaldi 2.7	Windows 10.0.0
+Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Safari/537.36	Other	Chrome 76.0	Windows 10.0.0
+Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Safari/537.36 OPR/63.0.3368.94	Other	Opera 63.0	Windows 10.0.0
+Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.75 Safari/537.36	Other	Chrome 77.0	Windows 10.0.0
+Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36	Other	Chrome 77.0	Windows 10.0.0
+Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3907.0 Safari/537.36 Edg/79.0.279.0	Other	Edge 79.0	Windows 10.0.0
+Mozilla/5.0 (Windows NT 10.0; Win64; x64; Xbox; Xbox One) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.102 Safari/537.36 Edge/18.18362	Other	Edge 18.18362	Windows 10.0.0
+Mozilla/5.0 (Windows NT 10.0; Win64; x64; Xbox; Xbox One) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.102 Safari/537.36 Edge/18.18363	Other	Edge 18.18363	Windows 10.0.0
+Mozilla/5.0 (Windows NT 10.0; Win64; x64; Xbox; Xbox One; WebView/3.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.102 Safari/537.36 Edge/18.18362	Other	Edge 18.18362	Windows 10.0.0
+Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:61.0) Gecko/20100101 Firefox/61.0	Other	Firefox 61.0	Windows 10.0.0
+Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:63.0) Gecko/20100101 Firefox/63.0	Other	Firefox 63.0	Windows 10.0.0
+Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:67.0) Gecko/20100101 Firefox/67.0	Other	Firefox 67.0	Windows 10.0.0
+Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:68.0) Gecko/20100101 Firefox/68.0	Other	Firefox 68.0	Windows 10.0.0
+Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:69.0) Gecko/20100101 Firefox/69.0	Other	Firefox 69.0	Windows 10.0.0
+Mozilla/5.0 (Windows NT 10.0; rv:69.0) Gecko/20100101 Firefox/69.0	Other	Firefox 69.0	Windows 10.0.0
+Mozilla/5.0 (Windows NT 5.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.2623.112 Safari/537.36	Other	Chrome 49.0	Windows XP.0.0
+Mozilla/5.0 (Windows NT 6.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.2623.112 Safari/537.36	Other	Chrome 49.0	Windows Vista.0.0
+Mozilla/5.0 (Windows NT 6.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.2623.112 Safari/537.36	Other	Chrome 49.0	Windows Vista.0.0
+Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Safari/537.36	Other	Chrome 76.0	Windows 7.0.0
+Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36	Other	Chrome 77.0	Windows 7.0.0
+Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36	Other	Chrome 77.0	Windows 7.0.0
+Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) coc_coc_browser/80.0.180 Chrome/74.0.3729.180 Safari/537.36	Other	Coc Coc 80.0	Windows 7.0.0
+Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) coc_coc_browser/82.0.144 Chrome/76.0.3809.144 Safari/537.36	Other	Coc Coc 82.0	Windows 7.0.0
+Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; rv:11.0) like Gecko	Other	IE 11.0	Windows 7.0.0
+Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.99 Safari/537.36	Other	Chrome 67.0	Windows 7.0.0
+Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.77 Safari/537.36	Other	Chrome 70.0	Windows 7.0.0
+Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.121 Safari/537.36	Other	Chrome 72.0	Windows 7.0.0
+Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.131 Safari/537.36	Other	Chrome 74.0	Windows 7.0.0
+Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.100 Safari/537.36	Other	Chrome 75.0	Windows 7.0.0
+Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.100 Safari/537.36	Other	Chrome 76.0	Windows 7.0.0
+Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Safari/537.36	Other	Chrome 76.0	Windows 7.0.0
+Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36	Other	Chrome 77.0	Windows 7.0.0
+Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:56.0) Gecko/20100101 Firefox/56.0 Waterfox/56.2.14	Other	Waterfox 56.2	Windows 7.0.0
+Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:60.0) Gecko/20100101 Firefox/60.0	Other	Firefox 60.0	Windows 7.0.0
+Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:63.0) Gecko/20100101 Firefox/63.0	Other	Firefox 63.0	Windows 7.0.0
+Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:68.0) Gecko/20100101 Firefox/68.0	Other	Firefox 68.0	Windows 7.0.0
+Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:69.0) Gecko/20100101 Firefox/69.0	Other	Firefox 69.0	Windows 7.0.0
+Mozilla/5.0 (Windows NT 6.1; rv:69.0) Gecko/20100101 Firefox/69.0	Other	Firefox 69.0	Windows 7.0.0
+Mozilla/5.0 (Windows NT 6.2; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36	Other	Chrome 77.0	Windows 8.0.0
+Mozilla/5.0 (Windows NT 6.2; Win64; x64; rv:69.0) Gecko/20100101 Firefox/69.0	Other	Firefox 69.0	Windows 8.0.0
+Mozilla/5.0 (Windows NT 6.3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36	Other	Chrome 77.0	Windows 8.1.0
+Mozilla/5.0 (Windows NT 6.3; ARM; Trident/7.0; Touch; rv:11.0) like Gecko	Other	IE 11.0	Windows RT 8.1.0
+Mozilla/5.0 (Windows NT 6.3; Trident/7.0; Touch; rv:11.0) like Gecko	Other	IE 11.0	Windows 8.1.0
+Mozilla/5.0 (Windows NT 6.3; WOW64; Trident/7.0; rv:11.0) like Gecko	Other	IE 11.0	Windows 8.1.0
+Mozilla/5.0 (Windows NT 6.3; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.132 Safari/537.36	Other	Chrome 63.0	Windows 8.1.0
+Mozilla/5.0 (Windows NT 6.3; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.186 Safari/537.36	Other	Chrome 64.0	Windows 8.1.0
+Mozilla/5.0 (Windows NT 6.3; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.100 Safari/537.36	Other	Chrome 76.0	Windows 8.1.0
+Mozilla/5.0 (Windows NT 6.3; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Safari/537.36	Other	Chrome 76.0	Windows 8.1.0
+Mozilla/5.0 (Windows NT 6.3; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36	Other	Chrome 77.0	Windows 8.1.0
+Mozilla/5.0 (Windows NT 6.3; Win64; x64; rv:69.0) Gecko/20100101 Firefox/69.0	Other	Firefox 69.0	Windows 8.1.0
+Mozilla/5.0 (Windows NT 6.3; rv:69.0) Gecko/20100101 Firefox/69.0	Other	Firefox 69.0	Windows 8.1.0
+Mozilla/5.0 (Windows; U; Windows NT 10.0; en-US; Valve Steam GameOverlay/1568860339; ) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.121 Safari/537.36	Other	Chrome 72.0	Windows 10.0.0
+Mozilla/5.0 (X11; CrOS aarch64 12371.75.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.105 Safari/537.36	Other	Chrome 77.0	Chrome OS 12371.75.0
+Mozilla/5.0 (X11; CrOS armv7l 12239.92.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.136 Safari/537.36	Other	Chrome 76.0	Chrome OS 12239.92.0
+Mozilla/5.0 (X11; CrOS x86_64 10895.78.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.120 Safari/537.36	Other	Chrome 69.0	Chrome OS 10895.78.0
+Mozilla/5.0 (X11; CrOS x86_64 11021.81.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Safari/537.36	Other	Chrome 70.0	Chrome OS 11021.81.0
+Mozilla/5.0 (X11; CrOS x86_64 11895.118.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.159 Safari/537.36	Other	Chrome 74.0	Chrome OS 11895.118.0
+Mozilla/5.0 (X11; CrOS x86_64 12239.92.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.136 Safari/537.36	Other	Chrome 76.0	Chrome OS 12239.92.0
+Mozilla/5.0 (X11; CrOS x86_64 12239.92.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.136 Safari/537.36	Other	Chrome 76.0	Chrome OS 12239.92.1
+Mozilla/5.0 (X11; CrOS x86_64 12239.92.4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.136 Safari/537.36	Other	Chrome 76.0	Chrome OS 12239.92.4
+Mozilla/5.0 (X11; CrOS x86_64 12371.46.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.63 Safari/537.36	Other	Chrome 77.0	Chrome OS 12371.46.0
+Mozilla/5.0 (X11; CrOS x86_64 12371.65.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.93 Safari/537.36	Other	Chrome 77.0	Chrome OS 12371.65.0
+Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.100 Safari/537.36	Other	Chrome 75.0	Linux 0.0.0
+Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.75 Safari/537.36	Other	Chrome 77.0	Linux 0.0.0
+Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.1 Chrome/71.0.3578.99 Safari/537.36	Other	Samsung Internet 10.1	Linux 0.0.0
+Mozilla/5.0 (X11; U; U; Linux x86_64; in-id) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.139 Safari/537.36	Other	Chrome 66.0	Linux 0.0.0
+Mozilla/5.0 (X11; U; U; Linux x86_64; pt-pt) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.139 Safari/537.36	Other	Chrome 66.0	Linux 0.0.0
+Mozilla/5.0 (X11; U; U; Linux x86_64; th-th) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.139 Safari/537.36	Other	Chrome 66.0	Linux 0.0.0
+Mozilla/5.0 (X11; U; U; Linux x86_64; vi-vn) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.139 Safari/537.36	Other	Chrome 66.0	Linux 0.0.0
+Mozilla/5.0 (X11; U; U; Linux x86_64; zh-cn) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.139 Safari/537.36	Other	Chrome 66.0	Linux 0.0.0
+Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:65.0) Gecko/20100101 Firefox/65.0	Other	Firefox 65.0	Ubuntu 0.0.0
+Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:66.0) Gecko/20100101 Firefox/66.0	Other	Firefox 66.0	Ubuntu 0.0.0
+Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:67.0) Gecko/20100101 Firefox/67.0	Other	Firefox 67.0	Ubuntu 0.0.0
+Mozilla/5.0 (iPad; CPU OS 10_3_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) GSA/22.0.141836113 Mobile/14G60 Safari/600.1.4	iPad	Google 22.0	iOS 10.3.3
+Mozilla/5.0 (iPad; CPU OS 10_3_3 like Mac OS X) AppleWebKit/603.1.30 (KHTML, like Gecko) CriOS/71.0.3578.89 Mobile/14G60 Safari/602.1	iPad	Chrome Mobile iOS 71.0	iOS 10.3.3
+Mozilla/5.0 (iPad; CPU OS 10_3_3 like Mac OS X) AppleWebKit/603.3.8 (KHTML, like Gecko) FxiOS/14.0b12646 Mobile/14G60 Safari/603.3.8	iPad	Firefox iOS 14.0	iOS 10.3.3
+Mozilla/5.0 (iPad; CPU OS 10_3_3 like Mac OS X) AppleWebKit/603.3.8 (KHTML, like Gecko) Mobile/14G60	iPad	Mobile Safari UI/WKWebView 0.0	iOS 10.3.3
+Mozilla/5.0 (iPad; CPU OS 10_3_3 like Mac OS X) AppleWebKit/603.3.8 (KHTML, like Gecko) Mobile/14G60 [FBAN/FBIOS;FBAV/240.0.0.55.117;FBBV/174195427;FBDV/iPad5,3;FBMD/iPad;FBSN/iOS;FBSV/10.3.3;FBSS/2;FBID/tablet;FBLC/zh_TW;FBOP/5;FBRV/175353135;FBCR/]	iPad	Facebook 240.0	iOS 10.3.3
+Mozilla/5.0 (iPad; CPU OS 10_3_3 like Mac OS X) AppleWebKit/603.3.8 (KHTML, like Gecko) Version/10.0 Mobile/14G60 Safari/602.1	iPad	Mobile Safari 10.0	iOS 10.3.3
+Mozilla/5.0 (iPad; CPU OS 10_3_4 like Mac OS X) AppleWebKit/603.3.8 (KHTML, like Gecko) Version/10.0 Mobile/14G61 Safari/602.1	iPad	Mobile Safari 10.0	iOS 10.3.4
+Mozilla/5.0 (iPad; CPU OS 11_1 like Mac OS X) AppleWebKit/604.1.34 (KHTML, like Gecko) CriOS/76.0.3809.123 Mobile/15B101 Safari/604.1	iPad	Chrome Mobile iOS 76.0	iOS 11.1.0
+Mozilla/5.0 (iPad; CPU OS 11_1_2 like Mac OS X) AppleWebKit/604.1.34 (KHTML, like Gecko) CriOS/76.0.3809.123 Mobile/15B202 Safari/604.1	iPad	Chrome Mobile iOS 76.0	iOS 11.1.2
+Mozilla/5.0 (iPad; CPU OS 11_2_1 like Mac OS X) AppleWebKit/604.4.7 (KHTML, like Gecko) Version/11.0 Mobile/15C153 Safari/604.1	iPad	Mobile Safari 11.0	iOS 11.2.1
+Mozilla/5.0 (iPad; CPU OS 11_2_2 like Mac OS X) AppleWebKit/604.4.7 (KHTML, like Gecko) Version/11.0 Mobile/15C202 Safari/604.1	iPad	Mobile Safari 11.0	iOS 11.2.2
+Mozilla/5.0 (iPad; CPU OS 11_2_6 like Mac OS X) AppleWebKit/604.5.6 (KHTML, like Gecko) Version/11.0 Mobile/15D100 Safari/604.1	iPad	Mobile Safari 11.0	iOS 11.2.6
+Mozilla/5.0 (iPad; CPU OS 11_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/11.0 Mobile/15E148 Safari/604.1	iPad	Mobile Safari 11.0	iOS 11.3.0
+Mozilla/5.0 (iPad; CPU OS 11_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/11.0 Mobile/15E148 Safari/604.1	iPad	Mobile Safari 11.0	iOS 11.4.0
+Mozilla/5.0 (iPad; CPU OS 11_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15G77	iPad	Mobile Safari UI/WKWebView 0.0	iOS 11.4.1
+Mozilla/5.0 (iPad; CPU OS 11_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/11.0 Mobile/15E148 Safari/604.1	iPad	Mobile Safari 11.0	iOS 11.4.1
+Mozilla/5.0 (iPad; CPU OS 12_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) GSA/83.0.268992909 Mobile/15E148 Safari/605.1	iPad	Google 83.0	iOS 12.0.0
+Mozilla/5.0 (iPad; CPU OS 12_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1	iPad	Mobile Safari 12.0	iOS 12.0.0
+Mozilla/5.0 (iPad; CPU OS 12_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/75.0.3770.103 Mobile/15E148 Safari/605.1	iPad	Chrome Mobile iOS 75.0	iOS 12.1.0
+Mozilla/5.0 (iPad; CPU OS 12_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/76.0.3809.123 Mobile/15E148 Safari/605.1	iPad	Chrome Mobile iOS 76.0	iOS 12.1.0
+Mozilla/5.0 (iPad; CPU OS 12_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/16B92	iPad	Mobile Safari UI/WKWebView 0.0	iOS 12.1.0
+Mozilla/5.0 (iPad; CPU OS 12_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1	iPad	Mobile Safari 12.0	iOS 12.1.0
+Mozilla/5.0 (iPad; CPU OS 12_1_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1	iPad	Mobile Safari 12.0	iOS 12.1.1
+Mozilla/5.0 (iPad; CPU OS 12_1_4 like Mac OS X) AppleWebKit/604.1.34 (KHTML, like Gecko) GSA/48.0.193557427 Mobile/16D57 Safari/604.1	iPad	Google 48.0	iOS 12.1.4
+Mozilla/5.0 (iPad; CPU OS 12_1_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/16D57	iPad	Mobile Safari UI/WKWebView 0.0	iOS 12.1.4
+Mozilla/5.0 (iPad; CPU OS 12_1_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1	iPad	Mobile Safari 12.0	iOS 12.1.4
+Mozilla/5.0 (iPad; CPU OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/76.0.3809.123 Mobile/15E148 Safari/605.1	iPad	Chrome Mobile iOS 76.0	iOS 12.2.0
+Mozilla/5.0 (iPad; CPU OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148	iPad	Mobile Safari UI/WKWebView 0.0	iOS 12.2.0
+Mozilla/5.0 (iPad; CPU OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.1 Mobile/15E148 Safari/604.1	iPad	Mobile Safari 12.1	iOS 12.2.0
+Mozilla/5.0 (iPad; CPU OS 12_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/77.0.3865.93 Mobile/15E148 Safari/605.1	iPad	Chrome Mobile iOS 77.0	iOS 12.3.0
+Mozilla/5.0 (iPad; CPU OS 12_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) GSA/83.0.268992909 Mobile/15E148 Safari/605.1	iPad	Google 83.0	iOS 12.3.0
+Mozilla/5.0 (iPad; CPU OS 12_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.1.1 Mobile/15E148 Safari/604.1	iPad	Mobile Safari 12.1	iOS 12.3.0
+Mozilla/5.0 (iPad; CPU OS 12_3_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148	iPad	Mobile Safari UI/WKWebView 0.0	iOS 12.3.1
+Mozilla/5.0 (iPad; CPU OS 12_3_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.1.1 Mobile/15E148 Safari/604.1	iPad	Mobile Safari 12.1	iOS 12.3.1
+Mozilla/5.0 (iPad; CPU OS 12_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/76.0.3809.123 Mobile/15E148 Safari/605.1	iPad	Chrome Mobile iOS 76.0	iOS 12.4.0
+Mozilla/5.0 (iPad; CPU OS 12_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/76.0.3809.81 Mobile/15E148 Safari/605.1	iPad	Chrome Mobile iOS 76.0	iOS 12.4.0
+Mozilla/5.0 (iPad; CPU OS 12_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/77.0.3865.103 Mobile/15E148 Safari/605.1	iPad	Chrome Mobile iOS 77.0	iOS 12.4.0
+Mozilla/5.0 (iPad; CPU OS 12_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/77.0.3865.69 Mobile/15E148 Safari/605.1	iPad	Chrome Mobile iOS 77.0	iOS 12.4.0
+Mozilla/5.0 (iPad; CPU OS 12_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/77.0.3865.93 Mobile/15E148 Safari/605.1	iPad	Chrome Mobile iOS 77.0	iOS 12.4.0
+Mozilla/5.0 (iPad; CPU OS 12_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) GSA/74.0.248026584 Mobile/15E148 Safari/605.1	iPad	Google 74.0	iOS 12.4.0
+Mozilla/5.0 (iPad; CPU OS 12_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) GSA/83.0.268992909 Mobile/15E148 Safari/605.1	iPad	Google 83.0	iOS 12.4.0
+Mozilla/5.0 (iPad; CPU OS 12_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148	iPad	Mobile Safari UI/WKWebView 0.0	iOS 12.4.0
+Mozilla/5.0 (iPad; CPU OS 12_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.1.2 Mobile/15E148 Safari/604.1	iPad	Mobile Safari 12.1	iOS 12.4.0
+Mozilla/5.0 (iPad; CPU OS 12_4_1 like Mac OS X) AppleWebKit/604.1.34 (KHTML, like Gecko) CriOS/67.0.3396.87 Mobile/16G102 Safari/604.1	iPad	Chrome Mobile iOS 67.0	iOS 12.4.1
+Mozilla/5.0 (iPad; CPU OS 12_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) FxiOS/19.0b16042 Mobile/15E148 Safari/605.1.15	iPad	Firefox iOS 19.0	iOS 12.4.1
+Mozilla/5.0 (iPad; CPU OS 12_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148	iPad	Mobile Safari UI/WKWebView 0.0	iOS 12.4.1
+Mozilla/5.0 (iPad; CPU OS 12_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 [FBAN/FBIOS;FBDV/iPad4,7;FBMD/iPad;FBSN/iOS;FBSV/12.4.1;FBSS/2;FBID/tablet;FBLC/vi_VN;FBOP/5;FBCR/]	iPad	Facebook 0.0	iOS 12.4.1
+Mozilla/5.0 (iPad; CPU OS 12_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 [FBAN/FBIOS;FBDV/iPad5,1;FBMD/iPad;FBSN/iOS;FBSV/12.4.1;FBSS/2;FBCR/;FBID/tablet;FBLC/en_US;FBOP/5]	iPad	Facebook 0.0	iOS 12.4.1
+Mozilla/5.0 (iPad; CPU OS 12_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 [FBAN/FBIOS;FBDV/iPad6,11;FBMD/iPad;FBSN/iOS;FBSV/12.4.1;FBSS/2;FBID/tablet;FBLC/en_US;FBOP/5;FBCR/]	iPad	Facebook 0.0	iOS 12.4.1
+Mozilla/5.0 (iPad; CPU OS 12_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 [FBAN/FBIOS;FBDV/iPad7,5;FBMD/iPad;FBSN/iOS;FBSV/12.4.1;FBSS/2;FBID/tablet;FBLC/en_US;FBOP/5;FBCR/]	iPad	Facebook 0.0	iOS 12.4.1
+Mozilla/5.0 (iPad; CPU OS 12_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.1.2 Mobile/15E148 Safari/604.1	iPad	Mobile Safari 12.1	iOS 12.4.1
+Mozilla/5.0 (iPad; CPU OS 6_1_3 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Version/6.0 Mobile/10B329 Safari/8536.25	iPad	Mobile Safari 6.0	iOS 6.1.3
+Mozilla/5.0 (iPad; CPU OS 8_0 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Version/8.0 Mobile/12A365 Safari/600.1.4	iPad	Mobile Safari 8.0	iOS 8.0.0
+Mozilla/5.0 (iPad; CPU OS 8_2 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Version/8.0 Mobile/12D508 Safari/600.1.4	iPad	Mobile Safari 8.0	iOS 8.2.0
+Mozilla/5.0 (iPad; CPU OS 8_4 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) GSA/23.1.148956103 Mobile/12H143 Safari/600.1.4	iPad	Google 23.1	iOS 8.4.0
+Mozilla/5.0 (iPad; CPU OS 9_3_2 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13F69 Safari/601.1	iPad	Mobile Safari 9.0	iOS 9.3.2
+Mozilla/5.0 (iPad; CPU OS 9_3_5 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13G36 Safari/601.1	iPad	Mobile Safari 9.0	iOS 9.3.5
+Mozilla/5.0 (iPhone; CPU iPhone OS 10_2 like Mac OS X) AppleWebKit/602.3.12 (KHTML, like Gecko) Version/10.0 Mobile/14C92 Safari/602.1	iPhone	Mobile Safari 10.0	iOS 10.2.0
+Mozilla/5.0 (iPhone; CPU iPhone OS 10_3_3 like Mac OS X) AppleWebKit/603.3.8 (KHTML, like Gecko) Mobile/14G60 [FBAN/FBIOS;FBDV/iPhone7,1;FBMD/iPhone;FBSN/iOS;FBSV/10.3.3;FBSS/3;FBID/phone;FBLC/en_US;FBOP/5;FBCR/Verizon]	iPhone	Facebook 0.0	iOS 10.3.3
+Mozilla/5.0 (iPhone; CPU iPhone OS 10_3_4 like Mac OS X) AppleWebKit/603.1.30 (KHTML, like Gecko) GSA/68.0.234683655 Mobile/14G61 Safari/602.1	iPhone	Google 68.0	iOS 10.3.4
+Mozilla/5.0 (iPhone; CPU iPhone OS 10_3_4 like Mac OS X) AppleWebKit/603.3.8 (KHTML, like Gecko) Version/10.0 Mobile/14G61 Safari/602.1	iPhone	Mobile Safari 10.0	iOS 10.3.4
+Mozilla/5.0 (iPhone; CPU iPhone OS 11_0_3 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A432 Safari/604.1	iPhone	Mobile Safari 11.0	iOS 11.0.3
+Mozilla/5.0 (iPhone; CPU iPhone OS 11_1_1 like Mac OS X) AppleWebKit/604.3.5 (KHTML, like Gecko) Version/11.0 Mobile/15B150 Safari/604.1	iPhone	Mobile Safari 11.0	iOS 11.1.1
+Mozilla/5.0 (iPhone; CPU iPhone OS 11_1_2 like Mac OS X) AppleWebKit/604.3.5 (KHTML, like Gecko) Version/11.0 Mobile/15B202 Safari/604.1	iPhone	Mobile Safari 11.0	iOS 11.1.2
+Mozilla/5.0 (iPhone; CPU iPhone OS 11_2_1 like Mac OS X) AppleWebKit/604.4.7 (KHTML, like Gecko) Version/11.0 Mobile/15C153 Safari/604.1	iPhone	Mobile Safari 11.0	iOS 11.2.1
+Mozilla/5.0 (iPhone; CPU iPhone OS 11_2_6 like Mac OS X) AppleWebKit/604.5.6 (KHTML, like Gecko) Mobile/15D100 [FBAN/FBIOS;FBAV/207.0.0.48.100;FBBV/141048683;FBDV/iPhone9,3;FBMD/iPhone;FBSN/iOS;FBSV/11.2.6;FBSS/2;FBCR/SFR;FBID/phone;FBLC/fr_FR;FBOP/5;FBRV/142061404]	iPhone	Facebook 207.0	iOS 11.2.6
+Mozilla/5.0 (iPhone; CPU iPhone OS 11_3 like Mac OS X) AppleWebKit/604.1.34 (KHTML, like Gecko) CriOS/76.0.3809.123 Mobile/15E148 Safari/604.1	iPhone	Chrome Mobile iOS 76.0	iOS 11.3.0
+Mozilla/5.0 (iPhone; CPU iPhone OS 11_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E302 [FBAN/FBIOS;FBDV/iPhone7,2;FBMD/iPhone;FBSN/iOS;FBSV/11.3.1;FBSS/2;FBID/phone;FBLC/fr_FR;FBOP/5;FBCR/VINI]	iPhone	Facebook 0.0	iOS 11.3.0
+Mozilla/5.0 (iPhone; CPU iPhone OS 11_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/11.0 Mobile/15E148 Safari/604.1	iPhone	Mobile Safari 11.0	iOS 11.3.0
+Mozilla/5.0 (iPhone; CPU iPhone OS 11_4 like Mac OS X) AppleWebKit/604.1.34 (KHTML, like Gecko) GSA/83.0.268992909 Mobile/15E148 Safari/604.1	iPhone	Google 83.0	iOS 11.4.0
+Mozilla/5.0 (iPhone; CPU iPhone OS 11_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/11.0 Mobile/15E148 Safari/604.1	iPhone	Mobile Safari 11.0	iOS 11.4.0
+Mozilla/5.0 (iPhone; CPU iPhone OS 11_4_1 like Mac OS X) AppleWebKit/604.1.34 (KHTML, like Gecko) GSA/74.1.250942683 Mobile/15G77 Safari/604.1	iPhone	Google 74.1	iOS 11.4.1
+Mozilla/5.0 (iPhone; CPU iPhone OS 11_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/11.0 Mobile/15E148 Safari/604.1	iPhone	Mobile Safari 11.0	iOS 11.4.1
+Mozilla/5.0 (iPhone; CPU iPhone OS 12_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1	iPhone	Mobile Safari 12.0	iOS 12.0.0
+Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1	iPhone	Mobile Safari 12.0	iOS 12.1.0
+Mozilla/5.0 (iPhone; CPU iPhone OS 12_1_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1	iPhone	Mobile Safari 12.0	iOS 12.1.1
+Mozilla/5.0 (iPhone; CPU iPhone OS 12_1_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) GSA/74.1.250942683 Mobile/16C101 Safari/604.1	iPhone	Google 74.1	iOS 12.1.2
+Mozilla/5.0 (iPhone; CPU iPhone OS 12_1_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/16C101 [FBAN/FBIOS;FBDV/iPhone9,3;FBMD/iPhone;FBSN/iOS;FBSV/12.1.2;FBSS/2;FBCR/Free;FBID/phone;FBLC/fr_FR;FBOP/5]	iPhone	Facebook 0.0	iOS 12.1.2
+Mozilla/5.0 (iPhone; CPU iPhone OS 12_1_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1	iPhone	Mobile Safari 12.0	iOS 12.1.2
+Mozilla/5.0 (iPhone; CPU iPhone OS 12_1_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1	iPhone	Mobile Safari 12.0	iOS 12.1.3
+Mozilla/5.0 (iPhone; CPU iPhone OS 12_1_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) GSA/74.1.250942683 Mobile/16D57 Safari/604.1	iPhone	Google 74.1	iOS 12.1.4
+Mozilla/5.0 (iPhone; CPU iPhone OS 12_1_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1	iPhone	Mobile Safari 12.0	iOS 12.1.4
+Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/72.0.3626.101 Mobile/15E148 Safari/605.1	iPhone	Chrome Mobile iOS 72.0	iOS 12.2.0
+Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/76.0.3809.123 Mobile/15E148 Safari/605.1	iPhone	Chrome Mobile iOS 76.0	iOS 12.2.0
+Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/77.0.3865.69 Mobile/15E148 Safari/605.1	iPhone	Chrome Mobile iOS 77.0	iOS 12.2.0
+Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 [FBAN/FBIOS;FBDV/iPhone10,2;FBMD/iPhone;FBSN/iOS;FBSV/12.2;FBSS/3;FBID/phone;FBLC/en_US;FBOP/5;FBCR/T-Mobile]	iPhone	Facebook 0.0	iOS 12.2.0
+Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 [FBAN/FBIOS;FBDV/iPhone10,5;FBMD/iPhone;FBSN/iOS;FBSV/12.2;FBSS/3;FBCR/AT&T;FBID/phone;FBLC/en_US;FBOP/5]	iPhone	Facebook 0.0	iOS 12.2.0
+Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.1 Mobile/15E148 Safari/604.1	iPhone	Mobile Safari 12.1	iOS 12.2.0
+Mozilla/5.0 (iPhone; CPU iPhone OS 12_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/77.0.3865.69 Mobile/15E148 Safari/605.1	iPhone	Chrome Mobile iOS 77.0	iOS 12.3.0
+Mozilla/5.0 (iPhone; CPU iPhone OS 12_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) GSA/83.0.268992909 Mobile/15E148 Safari/605.1	iPhone	Google 83.0	iOS 12.3.0
+Mozilla/5.0 (iPhone; CPU iPhone OS 12_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.1.1 Mobile/15E148 Safari/604.1	iPhone	Mobile Safari 12.1	iOS 12.3.0
+Mozilla/5.0 (iPhone; CPU iPhone OS 12_3_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) GSA/79.0.259819395 Mobile/16F203 Safari/604.1	iPhone	Google 79.0	iOS 12.3.1
+Mozilla/5.0 (iPhone; CPU iPhone OS 12_3_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148	iPhone	Mobile Safari UI/WKWebView 0.0	iOS 12.3.1
+Mozilla/5.0 (iPhone; CPU iPhone OS 12_3_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 DuckDuckGo/7	iPhone	DuckDuckGo Mobile 7.0	iOS 12.3.1
+Mozilla/5.0 (iPhone; CPU iPhone OS 12_3_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 [FBAN/FBIOS;FBDV/iPhone10,6;FBMD/iPhone;FBSN/iOS;FBSV/12.3.1;FBSS/3;FBID/phone;FBLC/en_US;FBOP/5;FBCR/AT&T]	iPhone	Facebook 0.0	iOS 12.3.1
+Mozilla/5.0 (iPhone; CPU iPhone OS 12_3_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 [FBAN/FBIOS;FBDV/iPhone11,6;FBMD/iPhone;FBSN/iOS;FBSV/12.3.1;FBSS/3;FBID/phone;FBLC/en_US;FBOP/5;FBCR/AT&T]	iPhone	Facebook 0.0	iOS 12.3.1
+Mozilla/5.0 (iPhone; CPU iPhone OS 12_3_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 [FBAN/FBIOS;FBDV/iPhone9,3;FBMD/iPhone;FBSN/iOS;FBSV/12.3.1;FBSS/2;FBID/phone;FBLC/es_LA;FBOP/5;FBCR/AT&T]	iPhone	Facebook 0.0	iOS 12.3.1
+Mozilla/5.0 (iPhone; CPU iPhone OS 12_3_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.1.1 Mobile/15E148 Safari/604.1	iPhone	Mobile Safari 12.1	iOS 12.3.1
+Mozilla/5.0 (iPhone; CPU iPhone OS 12_3_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.1.1 Mobile/15E148 Safari/604.1	iPhone	Mobile Safari 12.1	iOS 12.3.2
+Mozilla/5.0 (iPhone; CPU iPhone OS 12_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/69.0.3497.105 Mobile/15E148 Safari/605.1	iPhone	Chrome Mobile iOS 69.0	iOS 12.4.0
+Mozilla/5.0 (iPhone; CPU iPhone OS 12_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/73.0.3683.68 Mobile/15E148 Safari/605.1	iPhone	Chrome Mobile iOS 73.0	iOS 12.4.0
+Mozilla/5.0 (iPhone; CPU iPhone OS 12_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/75.0.3770.103 Mobile/15E148 Safari/605.1	iPhone	Chrome Mobile iOS 75.0	iOS 12.4.0
+Mozilla/5.0 (iPhone; CPU iPhone OS 12_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/76.0.3809.123 Mobile/15E148 Safari/605.1	iPhone	Chrome Mobile iOS 76.0	iOS 12.4.0
+Mozilla/5.0 (iPhone; CPU iPhone OS 12_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/77.0.3865.103 Mobile/15E148 Safari/605.1	iPhone	Chrome Mobile iOS 77.0	iOS 12.4.0
+Mozilla/5.0 (iPhone; CPU iPhone OS 12_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/77.0.3865.69 Mobile/15E148 Safari/605.1	iPhone	Chrome Mobile iOS 77.0	iOS 12.4.0
+Mozilla/5.0 (iPhone; CPU iPhone OS 12_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) GSA/81.0.264749124 Mobile/15E148 Safari/605.1	iPhone	Google 81.0	iOS 12.4.0
+Mozilla/5.0 (iPhone; CPU iPhone OS 12_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) GSA/82.1.267240167 Mobile/15E148 Safari/605.1	iPhone	Google 82.1	iOS 12.4.0
+Mozilla/5.0 (iPhone; CPU iPhone OS 12_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) GSA/83.0.268992909 Mobile/15E148 Safari/605.1	iPhone	Google 83.0	iOS 12.4.0
+Mozilla/5.0 (iPhone; CPU iPhone OS 12_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 [FBAN/FBIOS;FBDV/iPhone10,1;FBMD/iPhone;FBSN/iOS;FBSV/12.4;FBSS/2;FBID/phone;FBLC/en_US;FBOP/5;FBCR/Verizon]	iPhone	Facebook 0.0	iOS 12.4.0
+Mozilla/5.0 (iPhone; CPU iPhone OS 12_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 [FBAN/FBIOS;FBDV/iPhone10,5;FBMD/iPhone;FBSN/iOS;FBSV/12.4;FBSS/3;FBID/phone;FBLC/en_US;FBOP/5;FBCR/T-Mobile]	iPhone	Facebook 0.0	iOS 12.4.0
+Mozilla/5.0 (iPhone; CPU iPhone OS 12_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 [FBAN/FBIOS;FBDV/iPhone11,6;FBMD/iPhone;FBSN/iOS;FBSV/12.4;FBSS/3;FBID/phone;FBLC/en_US;FBOP/5;FBCR/Sprint]	iPhone	Facebook 0.0	iOS 12.4.0
+Mozilla/5.0 (iPhone; CPU iPhone OS 12_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 [FBAN/FBIOS;FBDV/iPhone9,4;FBMD/iPhone;FBSN/iOS;FBSV/12.4;FBSS/3;FBID/phone;FBLC/en_US;FBOP/5;FBCR/T-Mobile]	iPhone	Facebook 0.0	iOS 12.4.0
+Mozilla/5.0 (iPhone; CPU iPhone OS 12_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.1.2 Mobile/15E148 Safari/604.1	iPhone	Mobile Safari 12.1	iOS 12.4.0
+Mozilla/5.0 (iPhone; CPU iPhone OS 12_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) GSA/74.1.250942683 Mobile/16G102 Safari/604.1	iPhone	Google 74.1	iOS 12.4.1
+Mozilla/5.0 (iPhone; CPU iPhone OS 12_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148	iPhone	Mobile Safari UI/WKWebView 0.0	iOS 12.4.1
+Mozilla/5.0 (iPhone; CPU iPhone OS 12_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 Instagram 89.0.0.14.100 (iPhone11,6; iOS 12_4_1; en_US; en-US; scale=3.00; gamut=normal; 1242x2688; 149781277)	iPhone	Instagram 89.0	iOS 12.4.1
+Mozilla/5.0 (iPhone; CPU iPhone OS 12_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 [FBAN/FBIOS;FBAV/240.0.0.55.117;FBBV/174195427;FBDV/iPhone7,2;FBMD/iPhone;FBSN/iOS;FBSV/12.4.1;FBSS/2;FBID/phone;FBLC/es_LA;FBOP/5;FBRV/175040728;FBCR/AT&T]	iPhone	Facebook 240.0	iOS 12.4.1
+Mozilla/5.0 (iPhone; CPU iPhone OS 12_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 [FBAN/FBIOS;FBDV/iPhone10,2;FBMD/iPhone;FBSN/iOS;FBSV/12.4.1;FBSS/3;FBID/phone;FBLC/en_US;FBOP/5;FBCR/Sprint]	iPhone	Facebook 0.0	iOS 12.4.1
+Mozilla/5.0 (iPhone; CPU iPhone OS 12_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 [FBAN/FBIOS;FBDV/iPhone10,3;FBMD/iPhone;FBSN/iOS;FBSV/12.4.1;FBSS/3;FBID/phone;FBLC/en_US;FBOP/5;FBCR/T-Mobile]	iPhone	Facebook 0.0	iOS 12.4.1
+Mozilla/5.0 (iPhone; CPU iPhone OS 12_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 [FBAN/FBIOS;FBDV/iPhone10,3;FBMD/iPhone;FBSN/iOS;FBSV/12.4.1;FBSS/3;FBID/phone;FBLC/en_US;FBOP/5;FBCR/Verizon]	iPhone	Facebook 0.0	iOS 12.4.1
+Mozilla/5.0 (iPhone; CPU iPhone OS 12_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 [FBAN/FBIOS;FBDV/iPhone10,4;FBMD/iPhone;FBSN/iOS;FBSV/12.4.1;FBSS/2;FBID/phone;FBLC/es_LA;FBOP/5;FBCR/T-Mobile]	iPhone	Facebook 0.0	iOS 12.4.1
+Mozilla/5.0 (iPhone; CPU iPhone OS 12_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 [FBAN/FBIOS;FBDV/iPhone10,4;FBMD/iPhone;FBSN/iOS;FBSV/12.4.1;FBSS/2;FBID/phone;FBLC/fr_FR;FBOP/5;FBCR/AT&T]	iPhone	Facebook 0.0	iOS 12.4.1
+Mozilla/5.0 (iPhone; CPU iPhone OS 12_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 [FBAN/FBIOS;FBDV/iPhone10,5;FBMD/iPhone;FBSN/iOS;FBSV/12.4.1;FBSS/3;FBCR/T-Mobile;FBID/phone;FBLC/es_LA;FBOP/5]	iPhone	Facebook 0.0	iOS 12.4.1
+Mozilla/5.0 (iPhone; CPU iPhone OS 12_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 [FBAN/FBIOS;FBDV/iPhone10,5;FBMD/iPhone;FBSN/iOS;FBSV/12.4.1;FBSS/3;FBID/phone;FBLC/en_US;FBOP/5;FBCR/T-Mobile]	iPhone	Facebook 0.0	iOS 12.4.1
+Mozilla/5.0 (iPhone; CPU iPhone OS 12_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 [FBAN/FBIOS;FBDV/iPhone10,5;FBMD/iPhone;FBSN/iOS;FBSV/12.4.1;FBSS/3;FBID/phone;FBLC/es_LA;FBOP/5;FBCR/T-Mobile]	iPhone	Facebook 0.0	iOS 12.4.1
+Mozilla/5.0 (iPhone; CPU iPhone OS 12_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 [FBAN/FBIOS;FBDV/iPhone10,6;FBMD/iPhone;FBSN/iOS;FBSV/12.4.1;FBSS/3;FBID/phone;FBLC/en_US;FBOP/5;FBCR/AT&T]	iPhone	Facebook 0.0	iOS 12.4.1
+Mozilla/5.0 (iPhone; CPU iPhone OS 12_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 [FBAN/FBIOS;FBDV/iPhone11,2;FBMD/iPhone;FBSN/iOS;FBSV/12.4.1;FBSS/3;FBID/phone;FBLC/en_US;FBOP/5;FBCR/Verizon]	iPhone	Facebook 0.0	iOS 12.4.1
+Mozilla/5.0 (iPhone; CPU iPhone OS 12_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 [FBAN/FBIOS;FBDV/iPhone11,6;FBMD/iPhone;FBSN/iOS;FBSV/12.4.1;FBSS/3;FBID/phone;FBLC/en_US;FBOP/5;FBCR/AT&T]	iPhone	Facebook 0.0	iOS 12.4.1
+Mozilla/5.0 (iPhone; CPU iPhone OS 12_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 [FBAN/FBIOS;FBDV/iPhone11,6;FBMD/iPhone;FBSN/iOS;FBSV/12.4.1;FBSS/3;FBID/phone;FBLC/en_US;FBOP/5;FBCR/Verizon]	iPhone	Facebook 0.0	iOS 12.4.1
+Mozilla/5.0 (iPhone; CPU iPhone OS 12_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 [FBAN/FBIOS;FBDV/iPhone11,6;FBMD/iPhone;FBSN/iOS;FBSV/12.4.1;FBSS/3;FBID/phone;FBLC/fr_FR;FBOP/5;FBCR/SFR]	iPhone	Facebook 0.0	iOS 12.4.1
+Mozilla/5.0 (iPhone; CPU iPhone OS 12_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 [FBAN/FBIOS;FBDV/iPhone11,8;FBMD/iPhone;FBSN/iOS;FBSV/12.4.1;FBSS/2;FBID/phone;FBLC/en_US;FBOP/5;FBCR/AT&T]	iPhone	Facebook 0.0	iOS 12.4.1
+Mozilla/5.0 (iPhone; CPU iPhone OS 12_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 [FBAN/FBIOS;FBDV/iPhone11,8;FBMD/iPhone;FBSN/iOS;FBSV/12.4.1;FBSS/2;FBID/phone;FBLC/en_US;FBOP/5;FBCR/Verizon]	iPhone	Facebook 0.0	iOS 12.4.1
+Mozilla/5.0 (iPhone; CPU iPhone OS 12_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 [FBAN/FBIOS;FBDV/iPhone11,8;FBMD/iPhone;FBSN/iOS;FBSV/12.4.1;FBSS/2;FBID/phone;FBLC/fr_FR;FBOP/5;FBCR/Carrier]	iPhone	Facebook 0.0	iOS 12.4.1
+Mozilla/5.0 (iPhone; CPU iPhone OS 12_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 [FBAN/FBIOS;FBDV/iPhone7,2;FBMD/iPhone;FBSN/iOS;FBSV/12.4.1;FBSS/2;FBID/phone;FBLC/en_US;FBOP/5;FBCR/T-Mobile]	iPhone	Facebook 0.0	iOS 12.4.1
+Mozilla/5.0 (iPhone; CPU iPhone OS 12_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 [FBAN/FBIOS;FBDV/iPhone8,1;FBMD/iPhone;FBSN/iOS;FBSV/12.4.1;FBSS/2;FBID/phone;FBLC/en_US;FBOP/5;FBCR/MetroPCS]	iPhone	Facebook 0.0	iOS 12.4.1
+Mozilla/5.0 (iPhone; CPU iPhone OS 12_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 [FBAN/FBIOS;FBDV/iPhone9,2;FBMD/iPhone;FBSN/iOS;FBSV/12.4.1;FBSS/3;FBID/phone;FBLC/en_US;FBOP/5;FBCR/cricket]	iPhone	Facebook 0.0	iOS 12.4.1
+Mozilla/5.0 (iPhone; CPU iPhone OS 12_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 [FBAN/FBIOS;FBDV/iPhone9,4;FBMD/iPhone;FBSN/iOS;FBSV/12.4.1;FBSS/3;FBID/phone;FBLC/en_US;FBOP/5;FBCR/AT&T]	iPhone	Facebook 0.0	iOS 12.4.1
+Mozilla/5.0 (iPhone; CPU iPhone OS 12_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 [FBAN/FBIOS;FBDV/iPhone9,4;FBMD/iPhone;FBSN/iOS;FBSV/12.4.1;FBSS/3;FBID/phone;FBLC/fr_FR;FBOP/5;FBCR/T-Mobile]	iPhone	Facebook 0.0	iOS 12.4.1
+Mozilla/5.0 (iPhone; CPU iPhone OS 12_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.1.2 Mobile/15E148 Safari/604.1	iPhone	Mobile Safari 12.1	iOS 12.4.1
+Mozilla/5.0 (iPhone; CPU iPhone OS 12_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.4.1 Mobile/15E148 Safari/605.1.15	iPhone	Mobile Safari 12.4	iOS 12.4.1
+Mozilla/5.0 (iPhone; CPU iPhone OS 12_4_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148	iPhone	Mobile Safari UI/WKWebView 0.0	iOS 12.4.2
+Mozilla/5.0 (iPhone; CPU iPhone OS 12_4_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.1.2 Mobile/15E148 Safari/604.1	iPhone	Mobile Safari 12.1	iOS 12.4.2
+Mozilla/5.0 (iPhone; CPU iPhone OS 13_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/77.0.3865.69 Mobile/15E148 Safari/605.1	iPhone	Chrome Mobile iOS 77.0	iOS 13.0.0
+Mozilla/5.0 (iPhone; CPU iPhone OS 13_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 [FBAN/FBIOS;FBDV/iPhone10,5;FBMD/iPhone;FBSN/iOS;FBSV/13.0;FBSS/3;FBID/phone;FBLC/en_US;FBOP/5;FBCR/AT&T]	iPhone	Facebook 0.0	iOS 13.0.0
+Mozilla/5.0 (iPhone; CPU iPhone OS 13_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 [FBAN/FBIOS;FBDV/iPhone10,6;FBMD/iPhone;FBSN/iOS;FBSV/13.0;FBSS/3;FBID/phone;FBLC/en_US;FBOP/5;FBCR/T-Mobile]	iPhone	Facebook 0.0	iOS 13.0.0
+Mozilla/5.0 (iPhone; CPU iPhone OS 13_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 [FBAN/FBIOS;FBDV/iPhone11,2;FBMD/iPhone;FBSN/iOS;FBSV/13.0;FBSS/3;FBID/phone;FBLC/en_US;FBOP/5;FBCR/Verizon]	iPhone	Facebook 0.0	iOS 13.0.0
+Mozilla/5.0 (iPhone; CPU iPhone OS 13_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 [FBAN/FBIOS;FBDV/iPhone11,8;FBMD/iPhone;FBSN/iOS;FBSV/13.0;FBSS/2;FBID/phone;FBLC/en_US;FBOP/5;FBCR/T-Mobile]	iPhone	Facebook 0.0	iOS 13.0.0
+Mozilla/5.0 (iPhone; CPU iPhone OS 13_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 [FBAN/FBIOS;FBDV/iPhone11,8;FBMD/iPhone;FBSN/iOS;FBSV/13.0;FBSS/2;FBID/phone;FBLC/en_US;FBOP/5;FBCR/Verizon]	iPhone	Facebook 0.0	iOS 13.0.0
+Mozilla/5.0 (iPhone; CPU iPhone OS 13_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 [FBAN/FBIOS;FBDV/iPhone9,4;FBMD/iPhone;FBSN/iOS;FBSV/13.0;FBSS/3;FBID/phone;FBLC/fr_FR;FBOP/5;FBCR/Orange France]	iPhone	Facebook 0.0	iOS 13.0.0
+Mozilla/5.0 (iPhone; CPU iPhone OS 13_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0 Mobile/15E148 Safari/604.1	iPhone	Mobile Safari 13.0	iOS 13.0.0
+Mozilla/5.0 (iPhone; CPU iPhone OS 13_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/76.0.3809.123 Mobile/15E148 Safari/605.1	iPhone	Chrome Mobile iOS 76.0	iOS 13.1.0
+Mozilla/5.0 (iPhone; CPU iPhone OS 13_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/77.0.3865.69 Mobile/15E148 Safari/605.1	iPhone	Chrome Mobile iOS 77.0	iOS 13.1.0
+Mozilla/5.0 (iPhone; CPU iPhone OS 13_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/77.0.3865.93 Mobile/15E148 Safari/605.1	iPhone	Chrome Mobile iOS 77.0	iOS 13.1.0
+Mozilla/5.0 (iPhone; CPU iPhone OS 13_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) FxiOS/8.1.3 Mobile/15E148 Safari/605.1.15	iPhone	Firefox iOS 8.1	iOS 13.1.0
+Mozilla/5.0 (iPhone; CPU iPhone OS 13_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) GSA/83.0.268992909 Mobile/15E148 Safari/605.1	iPhone	Google 83.0	iOS 13.1.0
+Mozilla/5.0 (iPhone; CPU iPhone OS 13_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148	iPhone	Mobile Safari UI/WKWebView 0.0	iOS 13.1.0
+Mozilla/5.0 (iPhone; CPU iPhone OS 13_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 DuckDuckGo/7	iPhone	DuckDuckGo Mobile 7.0	iOS 13.1.0
+Mozilla/5.0 (iPhone; CPU iPhone OS 13_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 [FBAN/FBIOS;FBDV/iPhone10,1;FBMD/iPhone;FBSN/iOS;FBSV/13.1;FBSS/2;FBID/phone;FBLC/en_US;FBOP/5;FBCR/AT&T]	iPhone	Facebook 0.0	iOS 13.1.0
+Mozilla/5.0 (iPhone; CPU iPhone OS 13_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 [FBAN/FBIOS;FBDV/iPhone10,6;FBMD/iPhone;FBSN/iOS;FBSV/13.1;FBSS/3;FBID/phone;FBLC/en_US;FBOP/5;FBCR/AT&T]	iPhone	Facebook 0.0	iOS 13.1.0
+Mozilla/5.0 (iPhone; CPU iPhone OS 13_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 [FBAN/FBIOS;FBDV/iPhone10,6;FBMD/iPhone;FBSN/iOS;FBSV/13.1;FBSS/3;FBID/phone;FBLC/en_US;FBOP/5;FBCR/T-Mobile]	iPhone	Facebook 0.0	iOS 13.1.0
+Mozilla/5.0 (iPhone; CPU iPhone OS 13_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 [FBAN/FBIOS;FBDV/iPhone11,8;FBMD/iPhone;FBSN/iOS;FBSV/13.1;FBSS/2;FBID/phone;FBLC/en_US;FBOP/5;FBCR/AT&T]	iPhone	Facebook 0.0	iOS 13.1.0
+Mozilla/5.0 (iPhone; CPU iPhone OS 13_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 [FBAN/FBIOS;FBDV/iPhone9,4;FBMD/iPhone;FBSN/iOS;FBSV/13.1;FBSS/3;FBID/phone;FBLC/es_LA;FBOP/5;FBCR/Telcel]	iPhone	Facebook 0.0	iOS 13.1.0
+Mozilla/5.0 (iPhone; CPU iPhone OS 13_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.1 Mobile/15E148 Safari/604.1	iPhone	Mobile Safari 13.0	iOS 13.1.0
+Mozilla/5.0 (iPhone; CPU iPhone OS 13_1_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148	iPhone	Mobile Safari UI/WKWebView 0.0	iOS 13.1.1
+Mozilla/5.0 (iPhone; CPU iPhone OS 13_1_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 [FBAN/FBIOS;FBDV/iPhone10,1;FBMD/iPhone;FBSN/iOS;FBSV/13.1.1;FBSS/2;FBID/phone;FBLC/en_US;FBOP/5;FBCR/Union]	iPhone	Facebook 0.0	iOS 13.1.1
+Mozilla/5.0 (iPhone; CPU iPhone OS 13_1_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 [FBAN/FBIOS;FBDV/iPhone10,3;FBMD/iPhone;FBSN/iOS;FBSV/13.1.1;FBSS/3;FBID/phone;FBLC/en_US;FBOP/5;FBCR/Verizon]	iPhone	Facebook 0.0	iOS 13.1.1
+Mozilla/5.0 (iPhone; CPU iPhone OS 13_1_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 [FBAN/FBIOS;FBDV/iPhone11,6;FBMD/iPhone;FBSN/iOS;FBSV/13.1.1;FBSS/3;FBID/phone;FBLC/en_US;FBOP/5;FBCR/T-Mobile]	iPhone	Facebook 0.0	iOS 13.1.1
+Mozilla/5.0 (iPhone; CPU iPhone OS 13_1_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 [FBAN/FBIOS;FBDV/iPhone11,6;FBMD/iPhone;FBSN/iOS;FBSV/13.1.1;FBSS/3;FBID/phone;FBLC/en_US;FBOP/5;FBCR/Verizon]	iPhone	Facebook 0.0	iOS 13.1.1
+Mozilla/5.0 (iPhone; CPU iPhone OS 13_1_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.1 Mobile/15E148 Safari/604.1	iPhone	Mobile Safari 13.0	iOS 13.1.1
+Mozilla/5.0 (iPhone; CPU iPhone OS 13_1_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148	iPhone	Mobile Safari UI/WKWebView 0.0	iOS 13.1.2
+Mozilla/5.0 (iPhone; CPU iPhone OS 13_1_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 [FBAN/FBIOS;FBDV/iPhone11,2;FBMD/iPhone;FBSN/iOS;FBSV/13.1.2;FBSS/3;FBID/phone;FBLC/en_US;FBOP/5;FBCR/AT&T]	iPhone	Facebook 0.0	iOS 13.1.2
+Mozilla/5.0 (iPhone; CPU iPhone OS 13_1_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.1 Mobile/15E148 Safari/604.1	iPhone	Mobile Safari 13.0	iOS 13.1.2

--- a/tests/queries/0_stateless/02504_regexp_dictionary_ua_parser.sh
+++ b/tests/queries/0_stateless/02504_regexp_dictionary_ua_parser.sh
@@ -68,13 +68,13 @@ $CLICKHOUSE_CLIENT -n --query="
 insert into user_agents select ua from input('ua String') FORMAT LineAsString" < $CURDIR/data_ua_parser/useragents.txt
 
 $CLICKHOUSE_CLIENT -n --query="
-select device,
+select ua, device,
 concat(tupleElement(browser, 1), ' ', tupleElement(browser, 2), '.', tupleElement(browser, 3)) as browser ,
 concat(tupleElement(os, 1), ' ', tupleElement(os, 2), '.', tupleElement(os, 3), '.', tupleElement(os, 4)) as os
 from (
-     select dictGet('regexp_os', ('os_replacement', 'os_v1_replacement', 'os_v2_replacement', 'os_v3_replacement'), ua) os,
+     select ua, dictGet('regexp_os', ('os_replacement', 'os_v1_replacement', 'os_v2_replacement', 'os_v3_replacement'), ua) os,
      dictGet('regexp_browser', ('family_replacement', 'v1_replacement', 'v2_replacement'), ua) as browser,
-     dictGet('regexp_device', 'device_replacement', ua) device from user_agents);
+     dictGet('regexp_device', 'device_replacement', ua) device from user_agents) order by ua;
 "
 
 $CLICKHOUSE_CLIENT -n --query="


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
test 02504_regexp_dictionary_ua_parser is flaky. As I observed, the content is the same but orders is unstable. So here I add `order by` statement for stable output.

Don't be scared by the lines of diff. The only change is adding an `order by` and output original ua strings.
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
