### PR TITLE
Accept key value delimiter as part of value

### DIFF
--- a/src/Functions/keyvaluepair/impl/NeedleFactory.h
+++ b/src/Functions/keyvaluepair/impl/NeedleFactory.h
@@ -38,7 +38,7 @@ public:
         return SearchSymbols {std::string{needles.data(), needles.size()}};
     }
 
-    SearchSymbols getReadNeedles(const Configuration & extractor_configuration)
+    SearchSymbols getReadKeyNeedles(const Configuration & extractor_configuration)
     {
         const auto & [key_value_delimiter, quoting_character, pair_delimiters]
             = extractor_configuration;
@@ -57,6 +57,26 @@ public:
 
         return SearchSymbols {std::string{needles.data(), needles.size()}};
     }
+
+    SearchSymbols getReadValueNeedles(const Configuration & extractor_configuration)
+    {
+        const auto & [key_value_delimiter, quoting_character, pair_delimiters]
+            = extractor_configuration;
+
+        std::vector<char> needles;
+
+        needles.push_back(quoting_character);
+
+        std::copy(pair_delimiters.begin(), pair_delimiters.end(), std::back_inserter(needles));
+
+        if constexpr (WITH_ESCAPING)
+        {
+            needles.push_back('\\');
+        }
+
+        return SearchSymbols {std::string{needles.data(), needles.size()}};
+    }
+
     SearchSymbols getReadQuotedNeedles(const Configuration & extractor_configuration)
     {
         const auto quoting_character = extractor_configuration.quoting_character;

--- a/src/Functions/keyvaluepair/impl/StateHandlerImpl.h
+++ b/src/Functions/keyvaluepair/impl/StateHandlerImpl.h
@@ -41,7 +41,8 @@ public:
         NeedleFactory<WITH_ESCAPING> needle_factory;
 
         wait_needles = needle_factory.getWaitNeedles(configuration);
-        read_needles = needle_factory.getReadNeedles(configuration);
+        read_key_needles = needle_factory.getReadKeyNeedles(configuration);
+        read_value_needles = needle_factory.getReadValueNeedles(configuration);
         read_quoted_needles = needle_factory.getReadQuotedNeedles(configuration);
     }
 
@@ -77,7 +78,7 @@ public:
 
         size_t pos = 0;
 
-        while (const auto * p = find_first_symbols_or_null({file.begin() + pos, file.end()}, read_needles))
+        while (const auto * p = find_first_symbols_or_null({file.begin() + pos, file.end()}, read_key_needles))
         {
             auto character_position = p - file.begin();
             size_t next_pos = character_position + 1u;
@@ -191,10 +192,6 @@ public:
             {
                 return {pos + 1u, State::READING_QUOTED_VALUE};
             }
-            else if (isKeyValueDelimiter(current_character))
-            {
-                return {pos, State::WAITING_KEY};
-            }
 
             if constexpr (WITH_ESCAPING)
             {
@@ -218,7 +215,7 @@ public:
 
         size_t pos = 0;
 
-        while (const auto * p = find_first_symbols_or_null({file.begin() + pos, file.end()}, read_needles))
+        while (const auto * p = find_first_symbols_or_null({file.begin() + pos, file.end()}, read_value_needles))
         {
             const size_t character_position = p - file.begin();
             size_t next_pos = character_position + 1u;
@@ -236,10 +233,6 @@ public:
                         return {next_pos, State::FLUSH_PAIR};
                     }
                 }
-            }
-            else if (isKeyValueDelimiter(*p))
-            {
-                return {next_pos, State::WAITING_KEY};
             }
             else if (isPairDelimiter(*p))
             {
@@ -300,7 +293,8 @@ public:
 
 private:
     SearchSymbols wait_needles;
-    SearchSymbols read_needles;
+    SearchSymbols read_key_needles;
+    SearchSymbols read_value_needles;
     SearchSymbols read_quoted_needles;
 
     /*

--- a/tests/queries/0_stateless/02499_extract_key_value_pairs_multiple_input.reference
+++ b/tests/queries/0_stateless/02499_extract_key_value_pairs_multiple_input.reference
@@ -304,7 +304,7 @@ WITH
 SELECT
     x;
 {}
--- key value delimiter should be considered valid part of value, char2 has a problem with ==
+-- key value delimiter should be considered valid part of value
 WITH
     extractKeyValuePairs('formula=1+2=3 argument1=1 argument2=2 result=3, char="=" char2== string="foo=bar"', '=') AS s_map,
     CAST(

--- a/tests/queries/0_stateless/02499_extract_key_value_pairs_multiple_input.reference
+++ b/tests/queries/0_stateless/02499_extract_key_value_pairs_multiple_input.reference
@@ -123,7 +123,7 @@ SELECT
 -- semi-colon as pair delimiter
 -- expected output: {'age':'31','name':'neymar','team':'psg'}
 WITH
-    extractKeyValuePairs('name:neymar;age:31;team:psg;invalid1:invalid1,invalid2:invalid2', ':', ';') AS s_map,
+    extractKeyValuePairs('name:neymar;age:31;team:psg;random_key:value_with_comma,still_part_of_value:still_part_of_value', ':', ';') AS s_map,
     CAST(
         arrayMap(
             (x) -> (x, s_map[x]), arraySort(mapKeys(s_map))
@@ -132,7 +132,7 @@ WITH
     ) AS x
 SELECT
     x;
-{'age':'31','name':'neymar','team':'psg'}
+{'age':'31','name':'neymar','random_key':'value_with_comma,still_part_of_value:still_part_of_value','team':'psg'}
 -- both comma and semi-colon as pair delimiters
 -- expected output: {'age':'31','last_key':'last_value','name':'neymar','nationality':'brazil','team':'psg'}
 WITH
@@ -304,6 +304,18 @@ WITH
 SELECT
     x;
 {}
+-- key value delimiter should be considered valid part of value, char2 has a problem with ==
+WITH
+    extractKeyValuePairs('formula=1+2=3 argument1=1 argument2=2 result=3, char="=" char2== string="foo=bar"', '=') AS s_map,
+    CAST(
+            arrayMap(
+                    (x) -> (x, s_map[x]), arraySort(mapKeys(s_map))
+                ),
+            'Map(String,String)'
+        ) AS x
+SELECT
+    x;
+{'argument1':'1','argument2':'2','char':'=','char2':'=','formula':'1+2=3','result':'3','string':'foo=bar'}
 -- check str_to_map alias (it is case-insensitive)
 WITH
     sTr_tO_mAp('name:neymar, age:31 team:psg,nationality:brazil') AS s_map,

--- a/tests/queries/0_stateless/02499_extract_key_value_pairs_multiple_input.reference
+++ b/tests/queries/0_stateless/02499_extract_key_value_pairs_multiple_input.reference
@@ -121,9 +121,9 @@ SELECT
     x;
 {}
 -- semi-colon as pair delimiter
--- expected output: {'age':'31','name':'neymar','team':'psg'}
+-- expected output: {'age':'31','anotherkey':'anothervalue','name':'neymar','random_key':'value_with_comma,still_part_of_value:still_part_of_value','team':'psg'}
 WITH
-    extractKeyValuePairs('name:neymar;age:31;team:psg;random_key:value_with_comma,still_part_of_value:still_part_of_value', ':', ';') AS s_map,
+    extractKeyValuePairs('name:neymar;age:31;team:psg;random_key:value_with_comma,still_part_of_value:still_part_of_value;anotherkey:anothervalue', ':', ';') AS s_map,
     CAST(
         arrayMap(
             (x) -> (x, s_map[x]), arraySort(mapKeys(s_map))
@@ -132,7 +132,7 @@ WITH
     ) AS x
 SELECT
     x;
-{'age':'31','name':'neymar','random_key':'value_with_comma,still_part_of_value:still_part_of_value','team':'psg'}
+{'age':'31','anotherkey':'anothervalue','name':'neymar','random_key':'value_with_comma,still_part_of_value:still_part_of_value','team':'psg'}
 -- both comma and semi-colon as pair delimiters
 -- expected output: {'age':'31','last_key':'last_value','name':'neymar','nationality':'brazil','team':'psg'}
 WITH

--- a/tests/queries/0_stateless/02499_extract_key_value_pairs_multiple_input.sql
+++ b/tests/queries/0_stateless/02499_extract_key_value_pairs_multiple_input.sql
@@ -123,7 +123,7 @@ SELECT
 -- semi-colon as pair delimiter
 -- expected output: {'age':'31','name':'neymar','team':'psg'}
 WITH
-    extractKeyValuePairs('name:neymar;age:31;team:psg;invalid1:invalid1,invalid2:invalid2', ':', ';') AS s_map,
+    extractKeyValuePairs('name:neymar;age:31;team:psg;random_key:value_with_comma,still_part_of_value:still_part_of_value', ':', ';') AS s_map,
     CAST(
         arrayMap(
             (x) -> (x, s_map[x]), arraySort(mapKeys(s_map))
@@ -418,6 +418,18 @@ SELECT
 -- should not fail because pair delimiters contains 8 characters, which is within the limit
 WITH
     extractKeyValuePairs('not_important', ':', '12345678', '\'') AS s_map,
+    CAST(
+            arrayMap(
+                    (x) -> (x, s_map[x]), arraySort(mapKeys(s_map))
+                ),
+            'Map(String,String)'
+        ) AS x
+SELECT
+    x;
+
+-- key value delimiter should be considered valid part of value, char2 has a problem with ==
+WITH
+    extractKeyValuePairs('formula=1+2=3 argument1=1 argument2=2 result=3, char="=" char2== string="foo=bar"', '=') AS s_map,
     CAST(
             arrayMap(
                     (x) -> (x, s_map[x]), arraySort(mapKeys(s_map))

--- a/tests/queries/0_stateless/02499_extract_key_value_pairs_multiple_input.sql
+++ b/tests/queries/0_stateless/02499_extract_key_value_pairs_multiple_input.sql
@@ -121,9 +121,9 @@ SELECT
     x;
 
 -- semi-colon as pair delimiter
--- expected output: {'age':'31','name':'neymar','team':'psg'}
+-- expected output: {'age':'31','anotherkey':'anothervalue','name':'neymar','random_key':'value_with_comma,still_part_of_value:still_part_of_value','team':'psg'}
 WITH
-    extractKeyValuePairs('name:neymar;age:31;team:psg;random_key:value_with_comma,still_part_of_value:still_part_of_value', ':', ';') AS s_map,
+    extractKeyValuePairs('name:neymar;age:31;team:psg;random_key:value_with_comma,still_part_of_value:still_part_of_value;anotherkey:anothervalue', ':', ';') AS s_map,
     CAST(
         arrayMap(
             (x) -> (x, s_map[x]), arraySort(mapKeys(s_map))

--- a/tests/queries/0_stateless/02499_extract_key_value_pairs_multiple_input.sql
+++ b/tests/queries/0_stateless/02499_extract_key_value_pairs_multiple_input.sql
@@ -427,7 +427,7 @@ WITH
 SELECT
     x;
 
--- key value delimiter should be considered valid part of value, char2 has a problem with ==
+-- key value delimiter should be considered valid part of value
 WITH
     extractKeyValuePairs('formula=1+2=3 argument1=1 argument2=2 result=3, char="=" char2== string="foo=bar"', '=') AS s_map,
     CAST(


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Improve the "best-effort" parsing logic to accept `key_value_delimiter` as a valid part of the value. This also simplifies branching and might even speed up things a bit.

### Documentation entry for user-facing changes
Improve the "best-effort" parsing logic to accept `key_value_delimiter` as a valid part of the value. This also simplifies branching and might even speed up things a bit.


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
