### PR TITLE
fix when the offset of substring is 0 and the processed objects are c…

### DIFF
--- a/src/Functions/GatherUtils/Algorithms.h
+++ b/src/Functions/GatherUtils/Algorithms.h
@@ -15,6 +15,7 @@ namespace DB::ErrorCodes
 {
     extern const int LOGICAL_ERROR;
     extern const int TOO_LARGE_ARRAY_SIZE;
+    extern const int ZERO_ARRAY_OR_TUPLE_INDEX;
 }
 
 namespace DB::GatherUtils
@@ -404,6 +405,8 @@ static void sliceDynamicOffsetBoundedImpl(Source && src, Sink && sink, const ICo
             }
 
             writeSlice(slice, sink);
+        }else if(offset == 0){
+            throw Exception(ErrorCodes::ZERO_ARRAY_OR_TUPLE_INDEX, "Indices in strings are 1-based");
         }
 
         sink.next();

--- a/tests/queries/0_stateless/00970_substring_arg_validation.sql
+++ b/tests/queries/0_stateless/00970_substring_arg_validation.sql
@@ -2,3 +2,4 @@ SELECT substring('hello', []); -- { serverError 43 }
 SELECT substring('hello', 1, []); -- { serverError 43 }
 SELECT substring(materialize('hello'), -1, -1);
 SELECT substring(materialize('hello'), 0); -- { serverError 135 }
+SELECT substring(materialize('hello'), 0, rand()) -- { serverError 135 }


### PR DESCRIPTION
…onstants and variables, the behavior is inconsistent

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

![图片](https://github.com/ClickHouse/ClickHouse/assets/11885617/e44426b8-5bae-4e32-aa12-d108e98a149b)
When the offset of substring is 0 and the processed objects are constants and variables, the behavior is inconsistent
maybe we should throw an exception when we handle offset is variables?

can we set offset=1 when offset is 0 when use substring, not throw exception, like spark?
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
