### PR TITLE
Improve `grace_hash` join by reserving hash table's size

### DIFF
--- a/src/Interpreters/GraceHashJoin.cpp
+++ b/src/Interpreters/GraceHashJoin.cpp
@@ -572,13 +572,12 @@ IBlocksStreamPtr GraceHashJoin::getDelayedBlocks()
     size_t bucket_idx = current_bucket->idx;
 
     size_t prev_keys_num = 0;
-    if (hash_join)
+    // If there is only one bucket, don't take this check.
+    if (hash_join && buckets.size() > 1)
     {
         // Use previous hash_join's keys number to estimate next hash_join's size is reasonable.
         prev_keys_num = hash_join->getTotalRowCount();
     }
-
-    hash_join = makeInMemoryJoin(prev_keys_num);
 
     for (bucket_idx = bucket_idx + 1; bucket_idx < buckets.size(); ++bucket_idx)
     {
@@ -592,6 +591,7 @@ IBlocksStreamPtr GraceHashJoin::getDelayedBlocks()
             continue;
         }
 
+        hash_join = makeInMemoryJoin(prev_keys_num);
         auto right_reader = current_bucket->startJoining();
         size_t num_rows = 0; /// count rows that were written and rehashed
         while (Block block = right_reader.read())

--- a/src/Interpreters/GraceHashJoin.h
+++ b/src/Interpreters/GraceHashJoin.h
@@ -90,7 +90,8 @@ public:
 private:
     void initBuckets();
     /// Create empty join for in-memory processing.
-    InMemoryJoinPtr makeInMemoryJoin();
+    /// reserve_num for reserving space in hash table.
+    InMemoryJoinPtr makeInMemoryJoin(size_t reserve_num = 0);
 
     /// Add right table block to the @join. Calls @rehash on overflow.
     void addJoinedBlockImpl(Block block);

--- a/src/Interpreters/HashJoin.cpp
+++ b/src/Interpreters/HashJoin.cpp
@@ -27,7 +27,6 @@
 #include <Common/Exception.h>
 #include <Common/typeid_cast.h>
 #include <Common/assert_cast.h>
-#include "joinDispatch.h"
 
 namespace DB
 {
@@ -2124,34 +2123,10 @@ BlocksList HashJoin::releaseJoinedBlocks(bool restructure)
     return restored_blocks;
 }
 
-const BlocksList & HashJoin::getJoinedBlocks() const
-{
-    return data->blocks;
-}
-
 const ColumnWithTypeAndName & HashJoin::rightAsofKeyColumn() const
 {
     /// It should be nullable when right side is nullable
     return savedBlockSample().getByName(table_join->getOnlyClause().key_names_right.back());
-}
-
-void HashJoin::clear()
-{
-    used_flags.clear();
-    data->clear(kind, strictness);
-}
-
-void HashJoin::RightTableData::clear(JoinKind kind_, JoinStrictness strictness_)
-{
-    blocks.clear();
-    blocks_nullmaps.clear();
-    blocks_allocated_size = 0;
-    blocks_nullmaps_allocated_size = 0;
-    for (auto & map : maps)
-    {
-        joinDispatch(kind_, strictness_, map, [&](auto, auto, auto & map_) { map_.clear(type); });
-    }
-
 }
 
 }

--- a/src/Interpreters/HashJoin.cpp
+++ b/src/Interpreters/HashJoin.cpp
@@ -217,7 +217,7 @@ static void correctNullabilityInplace(ColumnWithTypeAndName & column, bool nulla
         JoinCommon::removeColumnNullability(column);
 }
 
-HashJoin::HashJoin(std::shared_ptr<TableJoin> table_join_, const Block & right_sample_block_, bool any_take_last_row_)
+HashJoin::HashJoin(std::shared_ptr<TableJoin> table_join_, const Block & right_sample_block_, bool any_take_last_row_, size_t reserve_num)
     : table_join(table_join_)
     , kind(table_join->kind())
     , strictness(table_join->strictness())
@@ -302,7 +302,7 @@ HashJoin::HashJoin(std::shared_ptr<TableJoin> table_join_, const Block & right_s
     }
 
     for (auto & maps : data->maps)
-        dataMapInit(maps);
+        dataMapInit(maps, reserve_num);
 }
 
 HashJoin::Type HashJoin::chooseMethod(JoinKind kind, const ColumnRawPtrs & key_columns, Sizes & key_sizes)
@@ -454,13 +454,15 @@ struct KeyGetterForType
     using Type = typename KeyGetterForTypeImpl<type, Value, Mapped>::Type;
 };
 
-void HashJoin::dataMapInit(MapsVariant & map)
+void HashJoin::dataMapInit(MapsVariant & map, size_t reserve_num)
 {
 
     if (kind == JoinKind::Cross)
         return;
     joinDispatchInit(kind, strictness, map);
     joinDispatch(kind, strictness, map, [&](auto, auto, auto & map_) { map_.create(data->type); });
+    if (reserve_num)
+        joinDispatch(kind, strictness, map, [&](auto, auto, auto & map_) { map_.reserve(data->type, reserve_num); });
 }
 
 bool HashJoin::empty() const

--- a/src/Interpreters/HashJoin.cpp
+++ b/src/Interpreters/HashJoin.cpp
@@ -27,6 +27,7 @@
 #include <Common/Exception.h>
 #include <Common/typeid_cast.h>
 #include <Common/assert_cast.h>
+#include "joinDispatch.h"
 
 namespace DB
 {
@@ -2123,10 +2124,34 @@ BlocksList HashJoin::releaseJoinedBlocks(bool restructure)
     return restored_blocks;
 }
 
+const BlocksList & HashJoin::getJoinedBlocks() const
+{
+    return data->blocks;
+}
+
 const ColumnWithTypeAndName & HashJoin::rightAsofKeyColumn() const
 {
     /// It should be nullable when right side is nullable
     return savedBlockSample().getByName(table_join->getOnlyClause().key_names_right.back());
+}
+
+void HashJoin::clear()
+{
+    used_flags.clear();
+    data->clear(kind, strictness);
+}
+
+void HashJoin::RightTableData::clear(JoinKind kind_, JoinStrictness strictness_)
+{
+    blocks.clear();
+    blocks_nullmaps.clear();
+    blocks_allocated_size = 0;
+    blocks_nullmaps_allocated_size = 0;
+    for (auto & map : maps)
+    {
+        joinDispatch(kind_, strictness_, map, [&](auto, auto, auto & map_) { map_.clear(type); });
+    }
+
 }
 
 }

--- a/src/Interpreters/HashJoin.h
+++ b/src/Interpreters/HashJoin.h
@@ -290,8 +290,6 @@ public:
                 APPLY_FOR_HASH_JOIN_VARIANTS(M)
             #undef M
             }
-
-
         }
 
         size_t getTotalRowCount(Type which) const

--- a/src/Interpreters/HashJoin.h
+++ b/src/Interpreters/HashJoin.h
@@ -146,7 +146,7 @@ public:
 class HashJoin : public IJoin
 {
 public:
-    HashJoin(std::shared_ptr<TableJoin> table_join_, const Block & right_sample_block, bool any_take_last_row_ = false);
+    HashJoin(std::shared_ptr<TableJoin> table_join_, const Block & right_sample_block, bool any_take_last_row_ = false, size_t reserve_num = 0);
 
     ~HashJoin() override;
 
@@ -217,6 +217,16 @@ public:
         M(keys256)                     \
         M(hashed)
 
+    /// Only for maps using hash table.
+    #define APPLY_FOR_HASH_JOIN_VARIANTS(M) \
+        M(key32)                            \
+        M(key64)                            \
+        M(key_string)                       \
+        M(key_fixed_string)                 \
+        M(keys128)                          \
+        M(keys256)                          \
+        M(hashed)
+
 
     /// Used for reading from StorageJoin and applying joinGet function
     #define APPLY_FOR_JOIN_VARIANTS_LIMITED(M) \
@@ -264,6 +274,24 @@ public:
                 APPLY_FOR_JOIN_VARIANTS(M)
             #undef M
             }
+        }
+
+        void reserve(Type which, size_t num)
+        {
+            switch (which)
+            {
+                case Type::EMPTY:            break;
+                case Type::CROSS:            break;
+                case Type::key8:             break;
+                case Type::key16:            break;
+
+            #define M(NAME) \
+                case Type::NAME: NAME->reserve(num); break;
+                APPLY_FOR_HASH_JOIN_VARIANTS(M)
+            #undef M
+            }
+
+
         }
 
         size_t getTotalRowCount(Type which) const
@@ -409,7 +437,7 @@ private:
     /// If set HashJoin instance is not available for modification (addJoinedBlock)
     TableLockHolder storage_join_lock = nullptr;
 
-    void dataMapInit(MapsVariant &);
+    void dataMapInit(MapsVariant &, size_t);
 
     void initRightBlockStructure(Block & saved_block_sample);
 

--- a/src/Interpreters/HashJoin.h
+++ b/src/Interpreters/HashJoin.h
@@ -71,6 +71,8 @@ public:
 
     template <bool use_flags, bool multiple_disjuncts, typename T>
     bool setUsedOnce(const T & f);
+
+    void clear() { flags.clear(); }
 };
 
 }
@@ -276,6 +278,20 @@ public:
             }
         }
 
+        void clear(Type which)
+        {
+            switch (which)
+            {
+                case Type::EMPTY:            break;
+                case Type::CROSS:            break;
+
+            #define M(NAME) \
+                case Type::NAME: NAME->clear(); break;
+                APPLY_FOR_JOIN_VARIANTS(M)
+            #undef M
+            }
+        }
+
         void reserve(Type which, size_t num)
         {
             switch (which)
@@ -367,6 +383,8 @@ public:
 
         size_t blocks_allocated_size = 0;
         size_t blocks_nullmaps_allocated_size = 0;
+
+        void clear(JoinKind kind, JoinStrictness strictness);
     };
 
     using RightTableDataPtr = std::shared_ptr<RightTableData>;
@@ -382,6 +400,8 @@ public:
 
     RightTableDataPtr getJoinedData() const { return data; }
     BlocksList releaseJoinedBlocks(bool restructure = false);
+    // Get joined blocks without releasing them
+    const BlocksList & getJoinedBlocks() const;
 
     /// Modify right block (update structure according to sample block) to save it in block list
     static Block prepareRightBlock(const Block & block, const Block & saved_block_sample_);
@@ -393,6 +413,9 @@ public:
     bool isUsed(const Block * block_ptr, size_t row_idx) const { return used_flags.getUsedSafe(block_ptr, row_idx); }
 
     void debugKeys() const;
+
+    // make a clear for reuse.
+    void clear();
 
 private:
     template<bool> friend class NotJoinedHash;

--- a/src/Interpreters/HashJoin.h
+++ b/src/Interpreters/HashJoin.h
@@ -71,8 +71,6 @@ public:
 
     template <bool use_flags, bool multiple_disjuncts, typename T>
     bool setUsedOnce(const T & f);
-
-    void clear() { flags.clear(); }
 };
 
 }
@@ -278,20 +276,6 @@ public:
             }
         }
 
-        void clear(Type which)
-        {
-            switch (which)
-            {
-                case Type::EMPTY:            break;
-                case Type::CROSS:            break;
-
-            #define M(NAME) \
-                case Type::NAME: NAME->clear(); break;
-                APPLY_FOR_JOIN_VARIANTS(M)
-            #undef M
-            }
-        }
-
         void reserve(Type which, size_t num)
         {
             switch (which)
@@ -383,8 +367,6 @@ public:
 
         size_t blocks_allocated_size = 0;
         size_t blocks_nullmaps_allocated_size = 0;
-
-        void clear(JoinKind kind, JoinStrictness strictness);
     };
 
     using RightTableDataPtr = std::shared_ptr<RightTableData>;
@@ -400,8 +382,6 @@ public:
 
     RightTableDataPtr getJoinedData() const { return data; }
     BlocksList releaseJoinedBlocks(bool restructure = false);
-    // Get joined blocks without releasing them
-    const BlocksList & getJoinedBlocks() const;
 
     /// Modify right block (update structure according to sample block) to save it in block list
     static Block prepareRightBlock(const Block & block, const Block & saved_block_sample_);
@@ -413,9 +393,6 @@ public:
     bool isUsed(const Block * block_ptr, size_t row_idx) const { return used_flags.getUsedSafe(block_ptr, row_idx); }
 
     void debugKeys() const;
-
-    // make a clear for reuse.
-    void clear();
 
 private:
     template<bool> friend class NotJoinedHash;

--- a/tests/queries/0_stateless/02275_full_sort_join_long.sql.j2
+++ b/tests/queries/0_stateless/02275_full_sort_join_long.sql.j2
@@ -25,7 +25,7 @@ INSERT INTO t2
 
 {% for join_algorithm in ['full_sorting_merge', 'grace_hash'] -%}
 
-SET max_bytes_in_join = '{% if join_algorithm == 'grace_hash' %}1M{% else %}0{% endif %}';
+SET max_bytes_in_join = '{% if join_algorithm == 'grace_hash' %}10M{% else %}0{% endif %}';
 
 SELECT '-- {{ join_algorithm }} --';
 SET join_algorithm = '{{ join_algorithm }}';

--- a/tests/queries/0_stateless/02275_full_sort_join_long.sql.j2
+++ b/tests/queries/0_stateless/02275_full_sort_join_long.sql.j2
@@ -25,7 +25,7 @@ INSERT INTO t2
 
 {% for join_algorithm in ['full_sorting_merge', 'grace_hash'] -%}
 
-SET max_bytes_in_join = '{% if join_algorithm == 'grace_hash' %}10M{% else %}0{% endif %}';
+SET max_bytes_in_join = '{% if join_algorithm == 'grace_hash' %}1M{% else %}0{% endif %}';
 
 SELECT '-- {{ join_algorithm }} --';
 SET join_algorithm = '{{ join_algorithm }}';


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Performance Improvement



### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Try to reserve hash table's size in `grace_hash` join.

for following query
```SQL
CREATE TABLE t1 (key UInt32, s String) engine = TinyLog;
CREATE TABLE t2 (key UInt32, s String) engine = TinyLog;


insert into t1 select number as key, toString(number) as s from numbers(20000000);
insert into t2 select number as key, toString(number/3) as s from numbers(20000000);
select count(1) from (SELECT key FROM t1 AS t1 ALL LEFT JOIN t2 AS t2 USING (key) )t1 settings join_algorithm='grace_hash', max_rows_in_join=1000000;
```
before
```
1 row in set. Elapsed: 20.685 sec. Processed 40.00 million rows, 160.00 MB (1.93 million rows/s., 7.74 MB/s.)
```
after
```
1 row in set. Elapsed: 16.146 sec. Processed 40.00 million rows, 160.00 MB (2.48 million rows/s., 9.91 MB/s.)
```

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
