### PR TITLE
[RFC] Mark joinGet() as non deterministic (so as dictGet)

### DIFF
--- a/src/Functions/FunctionJoinGet.h
+++ b/src/Functions/FunctionJoinGet.h
@@ -88,6 +88,7 @@ public:
 
     explicit JoinGetOverloadResolver(ContextPtr context_) : WithContext(context_) {}
 
+    bool isDeterministic() const override { return false; }
     String getName() const override { return name; }
 
     FunctionBasePtr buildImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr &) const override;

--- a/tests/queries/0_stateless/01017_mutations_with_nondeterministic_functions_zookeeper.sh
+++ b/tests/queries/0_stateless/01017_mutations_with_nondeterministic_functions_zookeeper.sh
@@ -60,7 +60,7 @@ ${CLICKHOUSE_CLIENT} --query "ALTER TABLE $T1 UPDATE y = y + rand() % 1 WHERE no
 
 # hm... it looks like joinGet condidered determenistic
 ${CLICKHOUSE_CLIENT} --query "ALTER TABLE $R1 UPDATE y = joinGet('${CLICKHOUSE_DATABASE}.lookup_table', 'y_new', y) WHERE x=1" 2>&1 \
-&& echo 'OK' || echo 'FAIL'
+| grep -F -q "must use only deterministic functions" && echo 'OK' || echo 'FAIL'
 
 ${CLICKHOUSE_CLIENT} --query "ALTER TABLE $R1 DELETE WHERE dictHas('${CLICKHOUSE_DATABASE}.dict1', toUInt64(x))" 2>&1 \
 | grep -F -q "must use only deterministic functions" && echo 'OK' || echo 'FAIL'


### PR DESCRIPTION
### Changelog category (leave one):
- Backward Incompatible Change

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Mark joinGet() as non deterministic (so as dictGet)

joinGet() should not be considered as deterministic function, since shards could have different data in tables.

Also since now there is allow_nondeterministic_mutations, it could be used as a workaround for this backward incompatible change.

Cc: @filimonov 
Follow-up for: #10186