### PR TITLE
Reset vectorscan reference to an "official" repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -265,6 +265,9 @@
 [submodule "contrib/nats-io"]
 	path = contrib/nats-io
 	url = https://github.com/ClickHouse/nats.c
+[submodule "contrib/vectorscan"]
+	path = contrib/vectorscan
+	url = https://github.com/ClickHouse/vectorscan.git
 [submodule "contrib/c-ares"]
 	path = contrib/c-ares
 	url = https://github.com/ClickHouse/c-ares
@@ -341,6 +344,3 @@
 [submodule "contrib/isa-l"]
 	path = contrib/isa-l
 	url = https://github.com/ClickHouse/isa-l.git
-[submodule "contrib/vectorscan"]
-	path = contrib/vectorscan
-	url = https://github.com/ClickHouse/vectorscan.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -265,12 +265,6 @@
 [submodule "contrib/nats-io"]
 	path = contrib/nats-io
 	url = https://github.com/ClickHouse/nats.c
-[submodule "contrib/vectorscan"]
-	path = contrib/vectorscan
-	# FIXME: update once upstream fixes will be merged:
-	# - https://github.com/VectorCamp/vectorscan/pull/148
-	# - https://github.com/VectorCamp/vectorscan/pull/149
-	url = https://github.com/azat-ch/vectorscan
 [submodule "contrib/c-ares"]
 	path = contrib/c-ares
 	url = https://github.com/ClickHouse/c-ares

--- a/.gitmodules
+++ b/.gitmodules
@@ -341,3 +341,6 @@
 [submodule "contrib/isa-l"]
 	path = contrib/isa-l
 	url = https://github.com/ClickHouse/isa-l.git
+[submodule "contrib/vectorscan"]
+	path = contrib/vectorscan
+	url = https://github.com/ClickHouse/vectorscan.git


### PR DESCRIPTION
Follow-up to https://github.com/ClickHouse/ClickHouse/pull/49678/files#r1192598556

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)