### PR TITLE
Enable few slow clang-tidy checks for clangd

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,16 @@
+Diagnostics:
+    # clangd does parse .clang-tidy, but some checks are too slow to run in
+    # clang-tidy build, so let's enable them explicitly for clangd at least.
+    ClangTidy:
+        # The following checks had been disabled due to slowliness with C++23,
+        # for more details see [1].
+        #
+        #   [1]: https://github.com/llvm/llvm-project/issues/61418
+        #
+        # But the code base had been written in a style that had been checked
+        # by this check, so at least, let's enable it for clangd.
+        Add: [
+            # configured in .clang-tidy
+            readability-identifier-naming,
+            bugprone-reserved-identifier,
+        ]

--- a/.gitignore
+++ b/.gitignore
@@ -129,7 +129,6 @@ website/package-lock.json
 /.ccls-cache
 
 # clangd cache
-/.clangd
 /.cache
 
 /compile_commands.json


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Enable few slow clang-tidy checks for clangd

In #47424 the readability-identifier-naming had been disabled for clang-tidy builds, but the code base is already uses this notations, so at least, let's enable it for clangd, so that developers who are using editor/IDE with clangd will be warned.

FWIW clangd does not think that this check is slow [1], but I guess this file hadn't been updated for quite a while.

  [1]: https://github.com/llvm/llvm-project/blob/main/clang-tools-extra/clangd/TidyFastChecks.inc

Cc: @rschu1ze 