### PR TITLE
Add python linter (ruff) for integration test

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -43,6 +43,11 @@ jobs:
         uses: ClickHouse/checkout@v1
         with:
           clear-repository: true
+      - name: Python linter (ruff)
+        uses: chartboost/ruff-action@v1
+        with:
+          src: "$GITHUB_WORKSPACE/tests/integration"
+          args: --config $GITHUB_WORKSPACE/tests/integration/ruff.toml
       - name: Python unit tests
         run: |
           cd "$GITHUB_WORKSPACE/tests/ci"

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -2,7 +2,6 @@ from helpers.cluster import run_and_check
 import pytest
 import logging
 import os
-from helpers.test_tools import TSV
 from helpers.network import _NetworkManager
 
 
@@ -16,7 +15,7 @@ logging.raiseExceptions = False
 def cleanup_environment():
     try:
         if int(os.environ.get("PYTEST_CLEANUP_CONTAINERS", 0)) == 1:
-            logging.debug(f"Cleaning all iptables rules")
+            logging.debug("Cleaning all iptables rules")
             _NetworkManager.clean_all_user_iptables_rules()
         result = run_and_check(["docker ps | wc -l"], shell=True)
         if int(result) > 1:
@@ -28,12 +27,12 @@ def cleanup_environment():
             else:
                 logging.debug("Trying to kill unstopped containers...")
                 run_and_check(
-                    [f"docker kill $(docker container list  --all  --quiet)"],
+                    ["docker kill $(docker container list  --all  --quiet)"],
                     shell=True,
                     nothrow=True,
                 )
                 run_and_check(
-                    [f"docker rm $docker container list  --all  --quiet)"],
+                    ["docker rm $docker container list  --all  --quiet)"],
                     shell=True,
                     nothrow=True,
                 )
@@ -41,7 +40,7 @@ def cleanup_environment():
                 r = run_and_check(["docker-compose", "ps", "--services", "--all"])
                 logging.debug(f"Docker ps before start:{r.stdout}")
         else:
-            logging.debug(f"No running containers")
+            logging.debug("No running containers")
     except Exception as e:
         logging.exception(f"cleanup_environment:{str(e)}")
         pass

--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -44,7 +44,7 @@ from kazoo.client import KazooClient
 from kazoo.exceptions import KazooException
 from minio import Minio
 
-from helpers.test_tools import assert_eq_with_retry, exec_query_with_retry
+from helpers.test_tools import exec_query_with_retry
 from helpers import pytest_xdist_logging_to_separate_files
 from helpers.client import QueryRuntimeException
 
@@ -742,7 +742,7 @@ class ClickHouseCluster:
                 if unstopped_containers:
                     logging.debug(f"Left unstopped containers: {unstopped_containers}")
                 else:
-                    logging.debug(f"Unstopped containers killed.")
+                    logging.debug("Unstopped containers killed.")
             else:
                 logging.debug(f"No running containers for project: {self.project_name}")
         except Exception as ex:
@@ -761,7 +761,7 @@ class ClickHouseCluster:
                 logging.debug(f"Trying to remove networks: {list_networks}")
                 run_and_check(f"docker network rm {' '.join(list_networks)}")
                 logging.debug(f"Networks removed: {list_networks}")
-        except:
+        except Exception:
             pass
 
         # Remove unused images
@@ -770,7 +770,7 @@ class ClickHouseCluster:
 
             run_and_check(["docker", "image", "prune", "-f"])
             logging.debug("Images pruned")
-        except:
+        except Exception:
             pass
 
         # Remove unused volumes
@@ -781,7 +781,7 @@ class ClickHouseCluster:
             if int(result > 0):
                 run_and_check(["docker", "volume", "prune", "-f"])
             logging.debug(f"Volumes pruned: {result}")
-        except:
+        except Exception:
             pass
 
     def get_docker_handle(self, docker_id):
@@ -2326,7 +2326,7 @@ class ClickHouseCluster:
                 subprocess.check_call(  # STYLE_CHECK_ALLOW_SUBPROCESS_CHECK_CALL
                     self.base_kafka_cmd + ["logs"], stdout=f
                 )
-        except Exception as e:
+        except Exception:
             logging.debug("Unable to get logs from docker.")
         raise Exception("Kafka is not available")
 
@@ -2448,7 +2448,7 @@ class ClickHouseCluster:
                 subprocess.check_call(  # STYLE_CHECK_ALLOW_SUBPROCESS_CHECK_CALL
                     self.base_minio_cmd + ["logs"], stdout=f
                 )
-        except Exception as e:
+        except Exception:
             logging.debug("Unable to get logs from docker.")
 
         raise Exception("Can't wait Minio to start")
@@ -2502,7 +2502,7 @@ class ClickHouseCluster:
                 logging.info(
                     f"Check Cassandra Online {self.cassandra_id} {self.cassandra_ip} {self.cassandra_port}"
                 )
-                check = self.exec_in_container(
+                self.exec_in_container(
                     self.cassandra_id,
                     [
                         "bash",
@@ -2538,7 +2538,7 @@ class ClickHouseCluster:
 
         try:
             self.cleanup()
-        except Exception as e:
+        except Exception:
             logging.warning("Cleanup failed:{e}")
 
         try:
@@ -2905,7 +2905,7 @@ class ClickHouseCluster:
                     subprocess.check_call(  # STYLE_CHECK_ALLOW_SUBPROCESS_CHECK_CALL
                         self.base_cmd + ["logs"], stdout=f
                     )
-                except Exception as e:
+                except Exception:
                     logging.debug("Unable to get logs from docker.")
                 f.seek(0)
                 for line in f:
@@ -3354,7 +3354,7 @@ class ClickHouseInstance:
                 if check_callback(result):
                     return result
                 time.sleep(sleep_time)
-            except Exception as ex:
+            except Exception:
                 # logging.debug("Retry {} got exception {}".format(i + 1, ex))
                 time.sleep(sleep_time)
 
@@ -3421,7 +3421,7 @@ class ClickHouseInstance:
 
         if result is not None:
             return result
-        raise Exception("Query {sql} did not fail".format(sql))
+        raise Exception("Query {} did not fail".format(sql))
 
     # The same as query_and_get_error but ignores successful query.
     def query_and_get_answer_with_error(
@@ -3646,7 +3646,7 @@ class ClickHouseInstance:
                 try:
                     self.wait_start(start_wait_sec + start_time - time.time())
                     return
-                except Exception as e:
+                except Exception:
                     logging.warning(
                         f"Current start attempt failed. Will kill {pid} just in case."
                     )
@@ -3679,7 +3679,7 @@ class ClickHouseInstance:
             if time.time() > start_time + start_wait_sec:
                 break
         logging.error(
-            f"No time left to start. But process is still running. Will dump threads."
+            "No time left to start. But process is still running. Will dump threads."
         )
         ps_clickhouse = self.exec_in_container(
             ["bash", "-c", "ps -C clickhouse"], nothrow=True, user="root"
@@ -3734,7 +3734,7 @@ class ClickHouseInstance:
     def grep_in_log(
         self, substring, from_host=False, filename="clickhouse-server.log", after=None
     ):
-        logging.debug(f"grep in log called %s", substring)
+        logging.debug("grep in log called %s", substring)
         if after is not None:
             after_opt = "-A{}".format(after)
         else:
@@ -3850,7 +3850,7 @@ class ClickHouseInstance:
             try:
                 pid = int(output.split("\n")[0].strip())
                 return pid
-            except:
+            except Exception:
                 return None
         return None
 
@@ -3906,7 +3906,7 @@ class ClickHouseInstance:
         # wait start
         time_left = begin_time + stop_start_wait_sec - time.time()
         if time_left <= 0:
-            raise Exception(f"No time left during restart")
+            raise Exception("No time left during restart")
         else:
             self.wait_start(time_left)
 
@@ -3987,7 +3987,7 @@ class ClickHouseInstance:
         # wait start
         time_left = begin_time + stop_start_wait_sec - time.time()
         if time_left <= 0:
-            raise Exception(f"No time left during restart")
+            raise Exception("No time left during restart")
         else:
             self.wait_start(time_left)
 

--- a/tests/integration/helpers/dictionary.py
+++ b/tests/integration/helpers/dictionary.py
@@ -267,7 +267,6 @@ class DictionaryStructure(object):
             or_default = ""
             field_name = ""
             date_expr = ""
-            def_for_get = ""
         else:
             what = "Get"
 
@@ -400,8 +399,6 @@ class Dictionary(object):
                 </dictionary>
                 </clickhouse>
                 """.format(
-                        min_lifetime=self.min_lifetime,
-                        max_lifetime=self.max_lifetime,
                         name=self.name,
                         structure=self.structure.get_structure_str(),
                         source=self.source.get_source_str(self.table_name),

--- a/tests/integration/helpers/external_sources.py
+++ b/tests/integration/helpers/external_sources.py
@@ -243,7 +243,7 @@ class SourceMongo(ExternalSource):
                 row_dict[cell_name] = self.converters[cell_name](cell_value)
             to_insert.append(row_dict)
 
-        result = tbl.insert_many(to_insert)
+        tbl.insert_many(to_insert)
 
 
 class SourceMongoURI(SourceMongo):

--- a/tests/integration/helpers/hdfs_api.py
+++ b/tests/integration/helpers/hdfs_api.py
@@ -214,7 +214,7 @@ class HDFSApi(object):
                 ip=self.hdfs_ip,
                 port=self.proxy_port,
                 path=path,
-                ),
+            ),
             allow_redirects=False,
             headers={"host": str(self.hdfs_ip)},
             params={"overwrite": "true"},

--- a/tests/integration/helpers/hdfs_api.py
+++ b/tests/integration/helpers/hdfs_api.py
@@ -6,7 +6,6 @@ import time
 from tempfile import NamedTemporaryFile
 import requests
 import requests_kerberos as reqkerb
-import socket
 import tempfile
 import logging
 import os
@@ -92,7 +91,6 @@ class HDFSApi(object):
             os.environ["KRB5_CONFIG"] = instantiated_krb_conf
 
             cmd = "(kinit -R -t {keytab} -k {principal} || (sleep 5 && kinit -R -t {keytab} -k {principal})) ; klist".format(
-                instantiated_krb_conf=instantiated_krb_conf,
                 keytab=self.keytab,
                 principal=self.principal,
             )
@@ -110,10 +108,10 @@ class HDFSApi(object):
                         logging.debug(
                             "Stdout:\n{}\n".format(res.stdout.decode("utf-8"))
                         )
-                        logging.debug("Env:\n{}\n".format(env))
+                        logging.debug("Env:\n{}\n".format(os.environ))
                         raise Exception(
                             "Command {} return non-zero code {}: {}".format(
-                                args, res.returncode, res.stderr.decode("utf-8")
+                                cmd, res.returncode, res.stderr.decode("utf-8")
                             )
                         )
 
@@ -216,8 +214,7 @@ class HDFSApi(object):
                 ip=self.hdfs_ip,
                 port=self.proxy_port,
                 path=path,
-                user=self.user,
-            ),
+                ),
             allow_redirects=False,
             headers={"host": str(self.hdfs_ip)},
             params={"overwrite": "true"},
@@ -240,7 +237,6 @@ class HDFSApi(object):
 
         with open(fpath, mode="rb") as fh:
             file_data = fh.read()
-            protocol = "http"  # self.protocol
             response = self.req_wrapper(
                 requests.put,
                 201,

--- a/tests/integration/helpers/network.py
+++ b/tests/integration/helpers/network.py
@@ -259,7 +259,7 @@ class _NetworkManager:
                             "docker pull clickhouse/integration-helper", shell=True
                         )
                         break
-                    except:
+                    except Exception:
                         time.sleep(i)
                 else:
                     raise Exception("Cannot pull clickhouse/integration-helper image")
@@ -331,7 +331,7 @@ class NetThroughput(object):
                         ]
                     ).strip()
                     break
-                except Exception as ex:
+                except Exception:
                     print(f"No interface eth{i}")
             else:
                 raise Exception(
@@ -346,7 +346,7 @@ class NetThroughput(object):
                 raise Exception(
                     f"No such interface {self.interface} found in /proc/net/dev"
                 )
-        except:
+        except Exception:
             logging.error(
                 "All available interfaces %s",
                 self.node.exec_in_container(["bash", "-c", "cat /proc/net/dev"]),
@@ -368,14 +368,14 @@ class NetThroughput(object):
                     f'awk "/^ *{self.interface}:/"\' {{ if ($1 ~ /.*:[0-9][0-9]*/) {{ sub(/^.*:/, "") ; print $1 }} else {{ print $2 }} }}\' /proc/net/dev',
                 ]
             )
-        except:
+        except Exception:
             raise Exception(
                 f"Cannot receive in bytes from /proc/net/dev for interface {self.interface}"
             )
 
         try:
             return int(result)
-        except:
+        except Exception:
             raise Exception(
                 f"Got non-numeric in bytes '{result}' from /proc/net/dev for interface {self.interface}"
             )
@@ -389,14 +389,14 @@ class NetThroughput(object):
                     f"awk \"/^ *{self.interface}:/\"' {{ if ($1 ~ /.*:[0-9][0-9]*/) {{ print $9 }} else {{ print $10 }} }}' /proc/net/dev",
                 ]
             )
-        except:
+        except Exception:
             raise Exception(
                 f"Cannot receive out bytes from /proc/net/dev for interface {self.interface}"
             )
 
         try:
             return int(result)
-        except:
+        except Exception:
             raise Exception(
                 f"Got non-numeric out bytes '{result}' from /proc/net/dev for interface {self.interface}"
             )

--- a/tests/integration/helpers/postgres_utility.py
+++ b/tests/integration/helpers/postgres_utility.py
@@ -32,7 +32,7 @@ def get_postgres_conn(
     database_name="postgres_database",
     replication=False,
 ):
-    if database == True:
+    if database is True:
         conn_string = f"host={ip} port={port} dbname='{database_name}' user='postgres' password='mysecretpassword'"
     else:
         conn_string = (

--- a/tests/integration/helpers/s3_tools.py
+++ b/tests/integration/helpers/s3_tools.py
@@ -1,4 +1,3 @@
-from minio import Minio
 import glob
 import os
 import json

--- a/tests/integration/helpers/test_tools.py
+++ b/tests/integration/helpers/test_tools.py
@@ -14,7 +14,9 @@ class TSV:
             raw_lines = contents.splitlines(True)
         elif isinstance(contents, list):
             raw_lines = [
-                "\t".join(map(str, content)) if isinstance(content, list) else str(content)
+                "\t".join(map(str, content))
+                if isinstance(content, list)
+                else str(content)
                 for content in contents
             ]
         elif isinstance(contents, TSV):

--- a/tests/integration/helpers/test_tools.py
+++ b/tests/integration/helpers/test_tools.py
@@ -14,8 +14,8 @@ class TSV:
             raw_lines = contents.splitlines(True)
         elif isinstance(contents, list):
             raw_lines = [
-                "\t".join(map(str, l)) if isinstance(l, list) else str(l)
-                for l in contents
+                "\t".join(map(str, content)) if isinstance(content, list) else str(content)
+                for content in contents
             ]
         elif isinstance(contents, TSV):
             self.lines = contents.lines
@@ -25,7 +25,7 @@ class TSV:
                 "contents must be either file or string or list, actual type: "
                 + type(contents).__name__
             )
-        self.lines = [l.strip() for l in raw_lines if l.strip()]
+        self.lines = [content.strip() for content in raw_lines if content.strip()]
 
     def __eq__(self, other):
         if not isinstance(other, TSV):

--- a/tests/integration/helpers/uclient.py
+++ b/tests/integration/helpers/uclient.py
@@ -1,12 +1,11 @@
 import os
 import sys
 import time
+from . import uexpect
 
 CURDIR = os.path.dirname(os.path.realpath(__file__))
 
 sys.path.insert(0, os.path.join(CURDIR))
-
-from . import uexpect
 
 prompt = ":\) "
 end_of_block = r".*\r\n.*\r\n"

--- a/tests/integration/helpers/wait_for_helpers.py
+++ b/tests/integration/helpers/wait_for_helpers.py
@@ -1,4 +1,3 @@
-import time
 from helpers.test_tools import assert_eq_with_retry
 
 

--- a/tests/integration/ruff.toml
+++ b/tests/integration/ruff.toml
@@ -1,0 +1,8 @@
+# Never enforce `E501` (line too long).
+# Never enforce `F403` ('from module import *' used; unable to detect undefined names).
+# Never enforce `F405` (name may be undefined, or defined from star imports).
+ignore = ["E501", "F403", "F405"]
+
+# Never enforce `F821` on protobuf generated files (undefined name).
+[per-file-ignores]
+"*_pb2.py" = ["F821"]

--- a/tests/integration/test_attach_backup_from_s3_plain/test.py
+++ b/tests/integration/test_attach_backup_from_s3_plain/test.py
@@ -63,7 +63,7 @@ def test_attach_part(table_name, backup_name, storage_policy, min_bytes_for_wide
     assert int(node.query(f"select count() from ordinary_db.{table_name}")) == 100
 
     node.query(
-        f"""
+        """
     -- NOTE: DROP DATABASE cannot be done w/o this due to metadata leftovers
     set force_remove_data_recursively_on_drop=1;
     drop database ordinary_db sync;

--- a/tests/integration/test_attach_without_fetching/test.py
+++ b/tests/integration/test_attach_without_fetching/test.py
@@ -1,4 +1,3 @@
-import time
 import pytest
 import logging
 

--- a/tests/integration/test_backup_restore_new/test.py
+++ b/tests/integration/test_backup_restore_new/test.py
@@ -1,5 +1,4 @@
 import pytest
-import asyncio
 import glob
 import re
 import random
@@ -371,18 +370,14 @@ def test_incremental_backup_after_renaming_table():
     # Files in a base backup can be searched by checksum, so an incremental backup with a renamed table actually
     # contains only its changed metadata.
     assert (
-        os.path.isdir(os.path.join(get_path_to_backup(backup_name), "metadata")) == True
+        os.path.isdir(os.path.join(get_path_to_backup(backup_name), "metadata")) is True
     )
-    assert os.path.isdir(os.path.join(get_path_to_backup(backup_name), "data")) == True
+    assert os.path.isdir(os.path.join(get_path_to_backup(backup_name), "data")) is True
     assert (
-        os.path.isdir(
-            os.path.join(get_path_to_backup(incremental_backup_name), "metadata")
-        )
-        == True
+        os.path.isdir(os.path.join(get_path_to_backup(incremental_backup_name), "metadata")) is True
     )
     assert (
-        os.path.isdir(os.path.join(get_path_to_backup(incremental_backup_name), "data"))
-        == False
+        os.path.isdir(os.path.join(get_path_to_backup(incremental_backup_name), "data")) is False
     )
 
     instance.query("DROP TABLE test.table2")
@@ -518,7 +513,7 @@ def test_backup_not_found_or_already_exists():
 
 
 def test_file_engine():
-    backup_name = f"File('/backups/file/')"
+    backup_name = "File('/backups/file/')"
     create_and_fill_table()
 
     assert instance.query("SELECT count(), sum(x) FROM test.table") == "100\t4950\n"
@@ -549,7 +544,7 @@ def test_database():
 
 
 def test_zip_archive():
-    backup_name = f"Disk('backups', 'archive.zip')"
+    backup_name = "Disk('backups', 'archive.zip')"
     create_and_fill_table()
 
     assert instance.query("SELECT count(), sum(x) FROM test.table") == "100\t4950\n"
@@ -565,7 +560,7 @@ def test_zip_archive():
 
 
 def test_zip_archive_with_settings():
-    backup_name = f"Disk('backups', 'archive_with_settings.zip')"
+    backup_name = "Disk('backups', 'archive_with_settings.zip')"
     create_and_fill_table()
 
     assert instance.query("SELECT count(), sum(x) FROM test.table") == "100\t4950\n"
@@ -583,7 +578,7 @@ def test_zip_archive_with_settings():
 
 
 def test_zip_archive_with_bad_compression_method():
-    backup_name = f"Disk('backups', 'archive_with_bad_compression_method.zip')"
+    backup_name = "Disk('backups', 'archive_with_bad_compression_method.zip')"
     create_and_fill_table()
 
     assert instance.query("SELECT count(), sum(x) FROM test.table") == "100\t4950\n"
@@ -1108,7 +1103,7 @@ def test_projection():
     create_and_fill_table(n=3)
 
     instance.query("ALTER TABLE test.table ADD PROJECTION prjmax (SELECT MAX(x))")
-    instance.query(f"INSERT INTO test.table VALUES (100, 'a'), (101, 'b')")
+    instance.query("INSERT INTO test.table VALUES (100, 'a'), (101, 'b')")
 
     assert (
         instance.query(
@@ -1301,7 +1296,7 @@ def test_operation_id():
 
     assert_eq_with_retry(
         instance,
-        f"SELECT status, error FROM system.backups WHERE id='first'",
+        "SELECT status, error FROM system.backups WHERE id='first'",
         TSV([["BACKUP_CREATED", ""]]),
     )
 
@@ -1316,7 +1311,7 @@ def test_operation_id():
 
     assert_eq_with_retry(
         instance,
-        f"SELECT status, error FROM system.backups WHERE id='second'",
+        "SELECT status, error FROM system.backups WHERE id='second'",
         TSV([["RESTORED", ""]]),
     )
 

--- a/tests/integration/test_backup_restore_new/test.py
+++ b/tests/integration/test_backup_restore_new/test.py
@@ -374,10 +374,14 @@ def test_incremental_backup_after_renaming_table():
     )
     assert os.path.isdir(os.path.join(get_path_to_backup(backup_name), "data")) is True
     assert (
-        os.path.isdir(os.path.join(get_path_to_backup(incremental_backup_name), "metadata")) is True
+        os.path.isdir(
+            os.path.join(get_path_to_backup(incremental_backup_name), "metadata")
+        )
+        is True
     )
     assert (
-        os.path.isdir(os.path.join(get_path_to_backup(incremental_backup_name), "data")) is False
+        os.path.isdir(os.path.join(get_path_to_backup(incremental_backup_name), "data"))
+        is False
     )
 
     instance.query("DROP TABLE test.table2")

--- a/tests/integration/test_backup_restore_on_cluster/test.py
+++ b/tests/integration/test_backup_restore_on_cluster/test.py
@@ -1,4 +1,3 @@
-from time import sleep
 import pytest
 import re
 import os.path
@@ -107,7 +106,7 @@ def test_replicated_table():
     )
 
     # Drop table on both nodes.
-    node1.query(f"DROP TABLE tbl ON CLUSTER 'cluster' SYNC")
+    node1.query("DROP TABLE tbl ON CLUSTER 'cluster' SYNC")
 
     # Restore from backup on node2.
     node2.query(f"RESTORE TABLE tbl ON CLUSTER 'cluster' FROM {backup_name}")
@@ -138,7 +137,7 @@ def test_empty_replicated_table():
     )
 
     # Drop table on both nodes.
-    node1.query(f"DROP TABLE tbl ON CLUSTER 'cluster' SYNC")
+    node1.query("DROP TABLE tbl ON CLUSTER 'cluster' SYNC")
 
     # Restore from backup on node2.
     node1.query(f"RESTORE TABLE tbl ON CLUSTER 'cluster' FROM {backup_name}")
@@ -295,7 +294,7 @@ def test_replicated_table_with_not_synced_insert():
     backup_name = new_backup_name()
     node1.query(f"BACKUP TABLE tbl ON CLUSTER 'cluster' TO {backup_name}")
 
-    node1.query(f"DROP TABLE tbl ON CLUSTER 'cluster' SYNC")
+    node1.query("DROP TABLE tbl ON CLUSTER 'cluster' SYNC")
 
     node1.query(f"RESTORE TABLE tbl ON CLUSTER 'cluster' FROM {backup_name}")
     node1.query("SYSTEM SYNC REPLICA ON CLUSTER 'cluster' tbl")
@@ -325,7 +324,7 @@ def test_replicated_table_with_not_synced_merge():
     backup_name = new_backup_name()
     node1.query(f"BACKUP TABLE tbl ON CLUSTER 'cluster' TO {backup_name}")
 
-    node1.query(f"DROP TABLE tbl ON CLUSTER 'cluster' SYNC")
+    node1.query("DROP TABLE tbl ON CLUSTER 'cluster' SYNC")
 
     node1.query(f"RESTORE TABLE tbl ON CLUSTER 'cluster' FROM {backup_name}")
     node1.query("SYSTEM SYNC REPLICA ON CLUSTER 'cluster' tbl")
@@ -454,7 +453,7 @@ def test_keeper_value_max_size():
         settings={"backup_restore_keeper_value_max_size": 50},
     )
 
-    node1.query(f"DROP TABLE tbl ON CLUSTER 'cluster' SYNC")
+    node1.query("DROP TABLE tbl ON CLUSTER 'cluster' SYNC")
 
     node1.query(f"RESTORE TABLE tbl ON CLUSTER 'cluster' FROM {backup_name}")
     node1.query("SYSTEM SYNC REPLICA ON CLUSTER 'cluster' tbl")
@@ -568,7 +567,7 @@ def test_required_privileges():
     node1.query("GRANT BACKUP ON tbl TO u1")
     node1.query(f"BACKUP TABLE tbl ON CLUSTER 'cluster' TO {backup_name}", user="u1")
 
-    node1.query(f"DROP TABLE tbl ON CLUSTER 'cluster' SYNC")
+    node1.query("DROP TABLE tbl ON CLUSTER 'cluster' SYNC")
 
     expected_error = "necessary to have grant INSERT, CREATE TABLE ON default.tbl2"
     assert expected_error in node1.query_and_get_error(
@@ -582,7 +581,7 @@ def test_required_privileges():
 
     assert node2.query("SELECT * FROM tbl2") == "100\n"
 
-    node1.query(f"DROP TABLE tbl2 ON CLUSTER 'cluster' SYNC")
+    node1.query("DROP TABLE tbl2 ON CLUSTER 'cluster' SYNC")
     node1.query("REVOKE ALL FROM u1")
 
     expected_error = "necessary to have grant INSERT, CREATE TABLE ON default.tbl"
@@ -688,10 +687,10 @@ def test_projection():
         "CREATE TABLE tbl ON CLUSTER 'cluster' (x UInt32, y String) ENGINE=ReplicatedMergeTree('/clickhouse/tables/tbl/', '{replica}') "
         "ORDER BY y PARTITION BY x%10"
     )
-    node1.query(f"INSERT INTO tbl SELECT number, toString(number) FROM numbers(3)")
+    node1.query("INSERT INTO tbl SELECT number, toString(number) FROM numbers(3)")
 
     node1.query("ALTER TABLE tbl ADD PROJECTION prjmax (SELECT MAX(x))")
-    node1.query(f"INSERT INTO tbl VALUES (100, 'a'), (101, 'b')")
+    node1.query("INSERT INTO tbl VALUES (100, 'a'), (101, 'b')")
 
     assert (
         node1.query(
@@ -703,7 +702,7 @@ def test_projection():
     backup_name = new_backup_name()
     node1.query(f"BACKUP TABLE tbl ON CLUSTER 'cluster' TO {backup_name}")
 
-    node1.query(f"DROP TABLE tbl ON CLUSTER 'cluster' SYNC")
+    node1.query("DROP TABLE tbl ON CLUSTER 'cluster' SYNC")
 
     assert (
         node1.query(

--- a/tests/integration/test_backup_restore_on_cluster/test_concurrency.py
+++ b/tests/integration/test_backup_restore_on_cluster/test_concurrency.py
@@ -95,7 +95,7 @@ def test_replicated_table():
     backup_name = new_backup_name()
     node0.query(f"BACKUP TABLE tbl ON CLUSTER 'cluster' TO {backup_name}")
 
-    node0.query(f"DROP TABLE tbl ON CLUSTER 'cluster' SYNC")
+    node0.query("DROP TABLE tbl ON CLUSTER 'cluster' SYNC")
     node0.query(f"RESTORE TABLE tbl ON CLUSTER 'cluster' FROM {backup_name}")
     node0.query("SYSTEM SYNC REPLICA ON CLUSTER 'cluster' tbl")
 
@@ -131,7 +131,7 @@ def test_concurrent_backups_on_same_node():
     ) == TSV([["BACKUP_CREATED", ""]] * num_concurrent_backups)
 
     for backup_name in backup_names:
-        node0.query(f"DROP TABLE tbl ON CLUSTER 'cluster' SYNC")
+        node0.query("DROP TABLE tbl ON CLUSTER 'cluster' SYNC")
         node0.query(f"RESTORE TABLE tbl ON CLUSTER 'cluster' FROM {backup_name}")
         node0.query("SYSTEM SYNC REPLICA ON CLUSTER 'cluster' tbl")
         for i in range(num_nodes):
@@ -166,7 +166,7 @@ def test_concurrent_backups_on_different_nodes():
         ) == TSV([["BACKUP_CREATED", ""]])
 
     for i in range(num_concurrent_backups):
-        nodes[i].query(f"DROP TABLE tbl ON CLUSTER 'cluster' SYNC")
+        nodes[i].query("DROP TABLE tbl ON CLUSTER 'cluster' SYNC")
         nodes[i].query(f"RESTORE TABLE tbl ON CLUSTER 'cluster' FROM {backup_names[i]}")
         nodes[i].query("SYSTEM SYNC REPLICA ON CLUSTER 'cluster' tbl")
         for j in range(num_nodes):
@@ -320,8 +320,8 @@ def test_kill_mutation_during_backup():
             TSV([["BACKUP_CREATED", ""]]),
         )
 
-        node0.query(f"DROP TABLE tbl ON CLUSTER 'cluster' SYNC")
+        node0.query("DROP TABLE tbl ON CLUSTER 'cluster' SYNC")
         node0.query(f"RESTORE TABLE tbl ON CLUSTER 'cluster' FROM {backup_name}")
 
         if n != repeat_count - 1:
-            node0.query(f"DROP TABLE tbl ON CLUSTER 'cluster' SYNC")
+            node0.query("DROP TABLE tbl ON CLUSTER 'cluster' SYNC")

--- a/tests/integration/test_backup_restore_on_cluster/test_disallow_concurrency.py
+++ b/tests/integration/test_backup_restore_on_cluster/test_disallow_concurrency.py
@@ -1,10 +1,7 @@
-from random import randint
 import pytest
 import os.path
-import time
-import concurrent
 from helpers.cluster import ClickHouseCluster
-from helpers.test_tools import TSV, assert_eq_with_retry
+from helpers.test_tools import assert_eq_with_retry
 
 
 cluster = ClickHouseCluster(__file__)
@@ -108,7 +105,7 @@ def create_and_fill_table():
         "ORDER BY x"
     )
     for i in range(num_nodes):
-        nodes[i].query(f"INSERT INTO tbl SELECT number FROM numbers(40000000)")
+        nodes[i].query("INSERT INTO tbl SELECT number FROM numbers(40000000)")
 
 
 # All the tests have concurrent backup/restores with same backup names
@@ -154,7 +151,7 @@ def test_concurrent_backups_on_same_node():
     # This restore part is added to confirm creating an internal backup & restore work
     # even when a concurrent backup is stopped
     nodes[0].query(
-        f"DROP TABLE tbl ON CLUSTER 'cluster' SYNC",
+        "DROP TABLE tbl ON CLUSTER 'cluster' SYNC",
         settings={
             "distributed_ddl_task_timeout": 360,
         },
@@ -206,7 +203,7 @@ def test_concurrent_restores_on_same_node():
     nodes[0].query(f"BACKUP TABLE tbl ON CLUSTER 'cluster' TO {backup_name}")
 
     nodes[0].query(
-        f"DROP TABLE tbl ON CLUSTER 'cluster' SYNC",
+        "DROP TABLE tbl ON CLUSTER 'cluster' SYNC",
         settings={
             "distributed_ddl_task_timeout": 360,
         },
@@ -251,7 +248,7 @@ def test_concurrent_restores_on_different_node():
     nodes[0].query(f"BACKUP TABLE tbl ON CLUSTER 'cluster' TO {backup_name}")
 
     nodes[0].query(
-        f"DROP TABLE tbl ON CLUSTER 'cluster' SYNC",
+        "DROP TABLE tbl ON CLUSTER 'cluster' SYNC",
         settings={
             "distributed_ddl_task_timeout": 360,
         },

--- a/tests/integration/test_backward_compatibility/test_convert_ordinary.py
+++ b/tests/integration/test_backward_compatibility/test_convert_ordinary.py
@@ -180,24 +180,24 @@ def check_convert_all_dbs_to_atomic():
 
     # 6 tables, MVs contain 2 rows (inner tables does not match regexp)
     assert "8\t{}\n".format(8 * len("atomic")) == node.query(
-        "SELECT count(), sum(n) FROM atomic.merge".format(db)
+        "SELECT count(), sum(n) FROM atomic.merge".format()
     )
 
     node.query("DETACH TABLE ordinary.detached PERMANENTLY")
 
     node.exec_in_container(
-        ["bash", "-c", f"touch /var/lib/clickhouse/flags/convert_ordinary_to_atomic"]
+        ["bash", "-c", "touch /var/lib/clickhouse/flags/convert_ordinary_to_atomic"]
     )
     node.stop_clickhouse()
     cannot_start = False
     try:
         node.start_clickhouse()
-    except:
+    except Exception:
         cannot_start = True
     assert cannot_start
 
     node.exec_in_container(
-        ["bash", "-c", f"rm /var/lib/clickhouse/flags/convert_ordinary_to_atomic"]
+        ["bash", "-c", "rm /var/lib/clickhouse/flags/convert_ordinary_to_atomic"]
     )
     node.start_clickhouse()
 
@@ -207,7 +207,7 @@ def check_convert_all_dbs_to_atomic():
     node.query("ATTACH TABLE ordinary.detached")
 
     node.exec_in_container(
-        ["bash", "-c", f"touch /var/lib/clickhouse/flags/convert_ordinary_to_atomic"]
+        ["bash", "-c", "touch /var/lib/clickhouse/flags/convert_ordinary_to_atomic"]
     )
     node.restart_clickhouse()
 

--- a/tests/integration/test_backward_compatibility/test_functions.py
+++ b/tests/integration/test_backward_compatibility/test_functions.py
@@ -93,7 +93,7 @@ def test_aggregate_states(start_cluster):
                 logging.info("Skipping %s", aggregate_function)
                 skipped += 1
                 continue
-            logging.exception("Failed %s", function)
+            logging.exception("Failed %s", aggregate_function)
             failed += 1
             continue
 

--- a/tests/integration/test_broken_part_during_merge/test.py
+++ b/tests/integration/test_broken_part_during_merge/test.py
@@ -3,7 +3,6 @@ import pytest
 from helpers.cluster import ClickHouseCluster
 from multiprocessing.dummy import Pool
 from helpers.corrupt_part_data_on_disk import corrupt_part_data_on_disk
-import time
 
 cluster = ClickHouseCluster(__file__)
 

--- a/tests/integration/test_catboost_evaluate/test.py
+++ b/tests/integration/test_catboost_evaluate/test.py
@@ -1,13 +1,10 @@
 import os
 import sys
-import time
-
 import pytest
+from helpers.cluster import ClickHouseCluster
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
-
-from helpers.cluster import ClickHouseCluster
 
 cluster = ClickHouseCluster(__file__)
 
@@ -78,7 +75,7 @@ def testModelPathIsNotAConstString(ch_cluster):
     if instance.is_built_with_memory_sanitizer():
         pytest.skip("Memory Sanitizer cannot work with third-party shared libraries")
 
-    result = instance.query("system reload models")
+    instance.query("system reload models")
 
     err = instance.query_and_get_error(
         "select catboostEvaluate(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);"
@@ -104,7 +101,7 @@ def testWrongNumberOfFeatureArguments(ch_cluster):
     if instance.is_built_with_memory_sanitizer():
         pytest.skip("Memory Sanitizer cannot work with third-party shared libraries")
 
-    result = instance.query("system reload models")
+    instance.query("system reload models")
 
     err = instance.query_and_get_error(
         "select catboostEvaluate('/etc/clickhouse-server/model/simple_model.bin');"
@@ -124,7 +121,7 @@ def testFloatFeatureMustBeNumeric(ch_cluster):
     if instance.is_built_with_memory_sanitizer():
         pytest.skip("Memory Sanitizer cannot work with third-party shared libraries")
 
-    result = instance.query("system reload models")
+    instance.query("system reload models")
 
     err = instance.query_and_get_error(
         "select catboostEvaluate('/etc/clickhouse-server/model/simple_model.bin', 1.0, 'a', 3, 4, 5, 6, 7, 8, 9, 10, 11);"
@@ -136,7 +133,7 @@ def testCategoricalFeatureMustBeNumericOrString(ch_cluster):
     if instance.is_built_with_memory_sanitizer():
         pytest.skip("Memory Sanitizer cannot work with third-party shared libraries")
 
-    result = instance.query("system reload models")
+    instance.query("system reload models")
 
     err = instance.query_and_get_error(
         "select catboostEvaluate('/etc/clickhouse-server/model/simple_model.bin', 1.0, 2.0, 3, 4, 5, 6, 7, tuple(8), 9, 10, 11);"
@@ -181,7 +178,7 @@ def testInvalidLibraryPath(ch_cluster):
     if instance.is_built_with_memory_sanitizer():
         pytest.skip("Memory Sanitizer cannot work with third-party shared libraries")
 
-    result = instance.query("system reload models")
+    instance.query("system reload models")
 
     # temporarily move library elsewhere
     instance.exec_in_container(
@@ -214,7 +211,7 @@ def testInvalidModelPath(ch_cluster):
     if instance.is_built_with_memory_sanitizer():
         pytest.skip("Memory Sanitizer cannot work with third-party shared libraries")
 
-    result = instance.query("system reload models")
+    instance.query("system reload models")
 
     err = instance.query_and_get_error(
         "select catboostEvaluate('', 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);"

--- a/tests/integration/test_cgroup_limit/test.py
+++ b/tests/integration/test_cgroup_limit/test.py
@@ -3,8 +3,6 @@
 import os
 import math
 import subprocess
-from tempfile import NamedTemporaryFile
-import pytest
 
 
 def run_command_in_container(cmd, *args):

--- a/tests/integration/test_checking_s3_blobs_paranoid/test.py
+++ b/tests/integration/test_checking_s3_blobs_paranoid/test.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python3
 
 import logging
-import os
-import time
 
 
 from helpers.cluster import ClickHouseCluster

--- a/tests/integration/test_cleanup_after_start/test.py
+++ b/tests/integration/test_cleanup_after_start/test.py
@@ -3,7 +3,6 @@
 import pytest
 from helpers.cluster import ClickHouseCluster
 from helpers.test_tools import assert_logs_contain_with_retry
-import os
 
 cluster = ClickHouseCluster(__file__)
 node1 = cluster.add_instance("node1", with_zookeeper=True, stay_alive=True)

--- a/tests/integration/test_cleanup_dir_after_bad_zk_conn/test.py
+++ b/tests/integration/test_cleanup_dir_after_bad_zk_conn/test.py
@@ -95,7 +95,7 @@ def test_attach_without_zk(start_cluster):
         )
         try:
             node1.query("ATTACH TABLE test4_r1")
-        except:
+        except Exception:
             pass
     node1.query("ATTACH TABLE IF NOT EXISTS test4_r1")
     node1.query("SELECT * FROM test4_r1")

--- a/tests/integration/test_cluster_copier/test.py
+++ b/tests/integration/test_cluster_copier/test.py
@@ -1,16 +1,13 @@
 import os
-import random
 import sys
 import time
 import kazoo
 import pytest
-import string
 import random
-from contextlib import contextmanager
+import string
 from helpers.cluster import ClickHouseCluster
 from helpers.test_tools import TSV
 
-import docker
 
 CURRENT_TEST_DIR = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, os.path.dirname(CURRENT_TEST_DIR))
@@ -29,8 +26,8 @@ def generateRandomString(count):
 
 def check_all_hosts_sucesfully_executed(tsv_content, num_hosts):
     M = TSV.toMat(tsv_content)
-    hosts = [(l[0], l[1]) for l in M]  # (host, port)
-    codes = [l[2] for l in M]
+    hosts = [(m[0], m[1]) for m in M]  # (host, port)
+    codes = [m[2] for m in M]
 
     assert len(hosts) == num_hosts and len(set(hosts)) == num_hosts, "\n" + tsv_content
     assert len(set(codes)) == 1, "\n" + tsv_content

--- a/tests/integration/test_cluster_copier/test_three_nodes.py
+++ b/tests/integration/test_cluster_copier/test_three_nodes.py
@@ -7,7 +7,6 @@ import pytest
 from helpers.cluster import ClickHouseCluster
 from helpers.test_tools import TSV
 
-import docker
 
 CURRENT_TEST_DIR = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, os.path.dirname(CURRENT_TEST_DIR))

--- a/tests/integration/test_cluster_copier/test_trivial.py
+++ b/tests/integration/test_cluster_copier/test_trivial.py
@@ -9,7 +9,6 @@ from helpers.test_tools import TSV
 
 import kazoo
 import pytest
-import docker
 
 
 CURRENT_TEST_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -33,7 +32,7 @@ def started_cluster():
     global cluster
     try:
         for name in ["first_trivial", "second_trivial"]:
-            instance = cluster.add_instance(
+            cluster.add_instance(
                 name,
                 main_configs=["configs/conf.d/clusters_trivial.xml"],
                 user_configs=["configs_two_nodes/users.xml"],

--- a/tests/integration/test_cluster_copier/test_two_nodes.py
+++ b/tests/integration/test_cluster_copier/test_two_nodes.py
@@ -7,7 +7,6 @@ import pytest
 from helpers.cluster import ClickHouseCluster
 from helpers.test_tools import TSV
 
-import docker
 
 CURRENT_TEST_DIR = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, os.path.dirname(CURRENT_TEST_DIR))

--- a/tests/integration/test_codec_encrypted/test.py
+++ b/tests/integration/test_codec_encrypted/test.py
@@ -1,7 +1,5 @@
 import pytest
 from helpers.cluster import ClickHouseCluster
-from helpers.client import QueryRuntimeException
-from helpers.test_tools import assert_eq_with_retry
 
 cluster = ClickHouseCluster(__file__)
 

--- a/tests/integration/test_composable_protocols/test.py
+++ b/tests/integration/test_composable_protocols/test.py
@@ -1,12 +1,11 @@
 import ssl
 import pytest
-import os.path as p
 import os
+import socket
+import urllib.request
+import urllib.parse
 from helpers.cluster import ClickHouseCluster
 from helpers.client import Client
-import urllib.request, urllib.parse
-import subprocess
-import socket
 
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 

--- a/tests/integration/test_compression_codec_read/test.py
+++ b/tests/integration/test_compression_codec_read/test.py
@@ -1,7 +1,6 @@
 import pytest
 
 from helpers.cluster import ClickHouseCluster
-from helpers.test_tools import assert_eq_with_retry
 
 cluster = ClickHouseCluster(__file__)
 

--- a/tests/integration/test_compression_nested_columns/test.py
+++ b/tests/integration/test_compression_nested_columns/test.py
@@ -1,5 +1,3 @@
-import random
-import string
 
 import pytest
 from helpers.cluster import ClickHouseCluster

--- a/tests/integration/test_compression_nested_columns/test.py
+++ b/tests/integration/test_compression_nested_columns/test.py
@@ -1,4 +1,3 @@
-
 import pytest
 from helpers.cluster import ClickHouseCluster
 

--- a/tests/integration/test_concurrent_backups_s3/test.py
+++ b/tests/integration/test_concurrent_backups_s3/test.py
@@ -1,11 +1,8 @@
 #!/usr/bin/env python3
 import pytest
-import re
-import os.path
 from multiprocessing.dummy import Pool
 from helpers.cluster import ClickHouseCluster
 from helpers.test_tools import assert_eq_with_retry
-import time
 
 cluster = ClickHouseCluster(__file__)
 node = cluster.add_instance(

--- a/tests/integration/test_concurrent_queries_restriction_by_query_kind/test.py
+++ b/tests/integration/test_concurrent_queries_restriction_by_query_kind/test.py
@@ -1,5 +1,4 @@
 import time
-from multiprocessing.dummy import Pool
 
 import pytest
 from helpers.cluster import ClickHouseCluster

--- a/tests/integration/test_config_xml_full/test.py
+++ b/tests/integration/test_config_xml_full/test.py
@@ -1,10 +1,4 @@
-import time
-import threading
-from os import path as p, unlink
-from tempfile import NamedTemporaryFile
 
-import helpers
-import pytest
 from helpers.cluster import ClickHouseCluster
 
 

--- a/tests/integration/test_config_xml_full/test.py
+++ b/tests/integration/test_config_xml_full/test.py
@@ -1,4 +1,3 @@
-
 from helpers.cluster import ClickHouseCluster
 
 

--- a/tests/integration/test_config_xml_main/test.py
+++ b/tests/integration/test_config_xml_main/test.py
@@ -1,10 +1,4 @@
-import time
-import threading
-from os import path as p, unlink
-from tempfile import NamedTemporaryFile
 
-import helpers
-import pytest
 from helpers.cluster import ClickHouseCluster
 
 

--- a/tests/integration/test_config_xml_main/test.py
+++ b/tests/integration/test_config_xml_main/test.py
@@ -1,4 +1,3 @@
-
 from helpers.cluster import ClickHouseCluster
 
 

--- a/tests/integration/test_config_xml_yaml_mix/test.py
+++ b/tests/integration/test_config_xml_yaml_mix/test.py
@@ -1,10 +1,4 @@
-import time
-import threading
-from os import path as p, unlink
-from tempfile import NamedTemporaryFile
 
-import helpers
-import pytest
 from helpers.cluster import ClickHouseCluster
 
 

--- a/tests/integration/test_config_xml_yaml_mix/test.py
+++ b/tests/integration/test_config_xml_yaml_mix/test.py
@@ -1,4 +1,3 @@
-
 from helpers.cluster import ClickHouseCluster
 
 

--- a/tests/integration/test_config_yaml_full/test.py
+++ b/tests/integration/test_config_yaml_full/test.py
@@ -1,10 +1,4 @@
-import time
-import threading
-from os import path as p, unlink
-from tempfile import NamedTemporaryFile
 
-import helpers
-import pytest
 from helpers.cluster import ClickHouseCluster
 
 

--- a/tests/integration/test_config_yaml_full/test.py
+++ b/tests/integration/test_config_yaml_full/test.py
@@ -1,4 +1,3 @@
-
 from helpers.cluster import ClickHouseCluster
 
 

--- a/tests/integration/test_config_yaml_main/test.py
+++ b/tests/integration/test_config_yaml_main/test.py
@@ -1,10 +1,4 @@
-import time
-import threading
-from os import path as p, unlink
-from tempfile import NamedTemporaryFile
 
-import helpers
-import pytest
 from helpers.cluster import ClickHouseCluster
 
 

--- a/tests/integration/test_config_yaml_main/test.py
+++ b/tests/integration/test_config_yaml_main/test.py
@@ -1,4 +1,3 @@
-
 from helpers.cluster import ClickHouseCluster
 
 

--- a/tests/integration/test_create_query_constraints/test.py
+++ b/tests/integration/test_create_query_constraints/test.py
@@ -1,10 +1,5 @@
 import pytest
-import asyncio
-import re
-import random
-import os.path
 from helpers.cluster import ClickHouseCluster
-from helpers.test_tools import assert_eq_with_retry, TSV
 
 cluster = ClickHouseCluster(__file__)
 instance = cluster.add_instance(

--- a/tests/integration/test_create_user_and_login/test.py
+++ b/tests/integration/test_create_user_and_login/test.py
@@ -96,7 +96,7 @@ EOF""",
                 logging.debug(f"Got error '{found_error}' just as expected")
                 break
             if out == "1\n":
-                logging.debug(f"Got output '1', retrying...")
+                logging.debug("Got output '1', retrying...")
                 time.sleep(0.5)
                 continue
             raise Exception(

--- a/tests/integration/test_ddl_worker_non_leader/test.py
+++ b/tests/integration/test_ddl_worker_non_leader/test.py
@@ -2,7 +2,6 @@ import pytest
 import time
 from helpers.cluster import ClickHouseCluster
 from helpers.network import PartitionManager
-from helpers.client import QueryRuntimeException
 
 cluster = ClickHouseCluster(__file__)
 node1 = cluster.add_instance(

--- a/tests/integration/test_default_compression_codec/test.py
+++ b/tests/integration/test_default_compression_codec/test.py
@@ -2,7 +2,6 @@ import random
 import string
 import logging
 import pytest
-import time
 from helpers.cluster import ClickHouseCluster
 
 cluster = ClickHouseCluster(__file__)

--- a/tests/integration/test_delayed_replica_failover/test.py
+++ b/tests/integration/test_delayed_replica_failover/test.py
@@ -1,13 +1,11 @@
 import os
 import sys
 import time
-
 import pytest
-
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-
 from helpers.cluster import ClickHouseCluster
 from helpers.network import PartitionManager
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 cluster = ClickHouseCluster(__file__)
 
@@ -103,7 +101,7 @@ SELECT sum(x) FROM distributed WITH TOTALS SETTINGS
             try:
                 node_2_2.query("SELECT * FROM system.zookeeper where path = '/'")
                 time.sleep(0.5)
-            except:
+            except Exception:
                 break
         else:
             raise Exception("Connection with zookeeper was not lost")
@@ -145,7 +143,7 @@ SELECT count() FROM distributed SETTINGS
 """
                 )
                 time.sleep(0.5)
-            except:
+            except Exception:
                 break
         else:
             raise Exception("Didn't raise when stale replicas are not allowed")

--- a/tests/integration/test_detached_parts_metrics/test.py
+++ b/tests/integration/test_detached_parts_metrics/test.py
@@ -1,8 +1,6 @@
-import time
 import pytest
 from helpers.cluster import ClickHouseCluster
 from helpers.test_tools import assert_eq_with_retry
-from helpers.wait_for_helpers import wait_for_delete_inactive_parts
 from helpers.wait_for_helpers import wait_for_delete_empty_parts
 
 

--- a/tests/integration/test_dictionaries_all_layouts_separate_sources/test_cassandra.py
+++ b/tests/integration/test_dictionaries_all_layouts_separate_sources/test_cassandra.py
@@ -1,17 +1,13 @@
 import os
-import math
 import pytest
+from .common import *
+from helpers.cluster import ClickHouseCluster
+from helpers.external_sources import SourceCassandra
 
 # FIXME This test is too flaky
 # https://github.com/ClickHouse/ClickHouse/issues/33006
 
 pytestmark = pytest.mark.skip
-
-from .common import *
-
-from helpers.cluster import ClickHouseCluster
-from helpers.dictionary import Field, Row, Dictionary, DictionaryStructure, Layout
-from helpers.external_sources import SourceCassandra
 
 SOURCE = None
 cluster = None

--- a/tests/integration/test_dictionaries_all_layouts_separate_sources/test_clickhouse_local.py
+++ b/tests/integration/test_dictionaries_all_layouts_separate_sources/test_clickhouse_local.py
@@ -1,11 +1,9 @@
 import os
-import math
 import pytest
 
 from .common import *
 
 from helpers.cluster import ClickHouseCluster
-from helpers.dictionary import Field, Row, Dictionary, DictionaryStructure, Layout
 from helpers.external_sources import SourceClickHouse
 
 SOURCE = SourceClickHouse(

--- a/tests/integration/test_dictionaries_all_layouts_separate_sources/test_clickhouse_remote.py
+++ b/tests/integration/test_dictionaries_all_layouts_separate_sources/test_clickhouse_remote.py
@@ -1,11 +1,9 @@
 import os
-import math
 import pytest
 
 from .common import *
 
 from helpers.cluster import ClickHouseCluster
-from helpers.dictionary import Field, Row, Dictionary, DictionaryStructure, Layout
 from helpers.external_sources import SourceClickHouse
 
 SOURCE = SourceClickHouse(

--- a/tests/integration/test_dictionaries_all_layouts_separate_sources/test_executable_cache.py
+++ b/tests/integration/test_dictionaries_all_layouts_separate_sources/test_executable_cache.py
@@ -1,11 +1,9 @@
 import os
-import math
 import pytest
 
 from .common import *
 
 from helpers.cluster import ClickHouseCluster
-from helpers.dictionary import Field, Row, Dictionary, DictionaryStructure, Layout
 from helpers.external_sources import SourceExecutableCache
 
 SOURCE = SourceExecutableCache(

--- a/tests/integration/test_dictionaries_all_layouts_separate_sources/test_executable_hashed.py
+++ b/tests/integration/test_dictionaries_all_layouts_separate_sources/test_executable_hashed.py
@@ -1,11 +1,9 @@
 import os
-import math
 import pytest
 
 from .common import *
 
 from helpers.cluster import ClickHouseCluster
-from helpers.dictionary import Field, Row, Dictionary, DictionaryStructure, Layout
 from helpers.external_sources import SourceExecutableHashed
 
 SOURCE = SourceExecutableHashed(

--- a/tests/integration/test_dictionaries_all_layouts_separate_sources/test_file.py
+++ b/tests/integration/test_dictionaries_all_layouts_separate_sources/test_file.py
@@ -1,11 +1,9 @@
 import os
-import math
 import pytest
 
 from .common import *
 
 from helpers.cluster import ClickHouseCluster
-from helpers.dictionary import Field, Row, Dictionary, DictionaryStructure, Layout
 from helpers.external_sources import SourceFile
 
 SOURCE = SourceFile("File", "localhost", "9000", "file_node", "9000", "", "")

--- a/tests/integration/test_dictionaries_all_layouts_separate_sources/test_http.py
+++ b/tests/integration/test_dictionaries_all_layouts_separate_sources/test_http.py
@@ -1,11 +1,9 @@
 import os
-import math
 import pytest
 
 from .common import *
 
 from helpers.cluster import ClickHouseCluster
-from helpers.dictionary import Field, Row, Dictionary, DictionaryStructure, Layout
 from helpers.external_sources import SourceHTTP
 
 SOURCE = SourceHTTP("SourceHTTP", "localhost", "9000", "clickhouse_h", "9000", "", "")

--- a/tests/integration/test_dictionaries_all_layouts_separate_sources/test_https.py
+++ b/tests/integration/test_dictionaries_all_layouts_separate_sources/test_https.py
@@ -1,11 +1,9 @@
 import os
-import math
 import pytest
 
 from .common import *
 
 from helpers.cluster import ClickHouseCluster
-from helpers.dictionary import Field, Row, Dictionary, DictionaryStructure, Layout
 from helpers.external_sources import SourceHTTPS
 
 SOURCE = SourceHTTPS(

--- a/tests/integration/test_dictionaries_all_layouts_separate_sources/test_mongo.py
+++ b/tests/integration/test_dictionaries_all_layouts_separate_sources/test_mongo.py
@@ -1,11 +1,9 @@
 import os
-import math
 import pytest
 
 from .common import *
 
 from helpers.cluster import ClickHouseCluster
-from helpers.dictionary import Field, Row, Dictionary, DictionaryStructure, Layout
 from helpers.external_sources import SourceMongo
 
 SOURCE = None
@@ -82,7 +80,7 @@ def started_cluster(
     ranged_tester,
     complex_tester,
 ):
-    SOURCE = SourceMongo(
+    SourceMongo(
         "MongoDB",
         "localhost",
         cluster.mongo_port,
@@ -94,7 +92,7 @@ def started_cluster(
     )
     dictionaries = simple_tester.list_dictionaries()
 
-    node = cluster.add_instance(
+    cluster.add_instance(
         "node",
         main_configs=main_config,
         dictionaries=dictionaries,

--- a/tests/integration/test_dictionaries_all_layouts_separate_sources/test_mongo_uri.py
+++ b/tests/integration/test_dictionaries_all_layouts_separate_sources/test_mongo_uri.py
@@ -1,11 +1,9 @@
 import os
-import math
 import pytest
 
 from .common import *
 
 from helpers.cluster import ClickHouseCluster
-from helpers.dictionary import Field, Row, Dictionary, DictionaryStructure, Layout
 from helpers.external_sources import SourceMongoURI
 
 test_name = "mongo_uri"
@@ -57,7 +55,7 @@ def main_config(secure_connection):
 def started_cluster(secure_connection, cluster, main_config, simple_tester):
     dictionaries = simple_tester.list_dictionaries()
 
-    node = cluster.add_instance(
+    cluster.add_instance(
         "uri_node",
         main_configs=main_config,
         dictionaries=dictionaries,

--- a/tests/integration/test_dictionaries_all_layouts_separate_sources/test_mysql.py
+++ b/tests/integration/test_dictionaries_all_layouts_separate_sources/test_mysql.py
@@ -1,11 +1,9 @@
 import os
-import math
 import pytest
 
 from .common import *
 
 from helpers.cluster import ClickHouseCluster
-from helpers.dictionary import Field, Row, Dictionary, DictionaryStructure, Layout
 from helpers.external_sources import SourceMySQL
 
 SOURCE = None

--- a/tests/integration/test_dictionaries_config_reload/test.py
+++ b/tests/integration/test_dictionaries_config_reload/test.py
@@ -1,13 +1,11 @@
 import os
 import sys
 import time
-import logging
 import pytest
+from helpers.cluster import ClickHouseCluster
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
-
-from helpers.cluster import ClickHouseCluster
 
 cluster = ClickHouseCluster(__file__)
 node = cluster.add_instance(

--- a/tests/integration/test_dictionaries_postgresql/test.py
+++ b/tests/integration/test_dictionaries_postgresql/test.py
@@ -1,12 +1,9 @@
 import pytest
 import time
 import logging
-import psycopg2
-from multiprocessing.dummy import Pool
 
 from helpers.cluster import ClickHouseCluster
 from helpers.postgres_utility import get_postgres_conn
-from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
 
 cluster = ClickHouseCluster(__file__)
 node1 = cluster.add_instance(
@@ -511,7 +508,7 @@ def test_bad_configuration(started_cluster):
         port=started_cluster.postgres_port,
         database=True,
     )
-    cursor = conn.cursor()
+    conn.cursor()
 
     node1.query(
         """

--- a/tests/integration/test_dictionaries_redis/test.py
+++ b/tests/integration/test_dictionaries_redis/test.py
@@ -135,7 +135,7 @@ def generate_dict_configs():
         logging.debug(f"Found dictionary {path}")
         dictionaries.append(path)
 
-    node = cluster.add_instance(
+    cluster.add_instance(
         "node", main_configs=main_configs, dictionaries=dictionaries, with_redis=True
     )
 

--- a/tests/integration/test_dictionary_allow_read_expired_keys/test_default_reading.py
+++ b/tests/integration/test_dictionary_allow_read_expired_keys/test_default_reading.py
@@ -40,9 +40,7 @@ def started_cluster():
 
 # @pytest.mark.skip(reason="debugging")
 def test_default_reading(started_cluster):
-    assert None != dictionary_node.get_process_pid(
-        "clickhouse"
-    ), "ClickHouse must be alive"
+    assert None is not dictionary_node.get_process_pid("clickhouse"), "ClickHouse must be alive"
 
     # Key 0 is not in dictionary, so default value will be returned
 
@@ -99,9 +97,7 @@ def test_default_reading(started_cluster):
     test_helper()
 
     with PartitionManager() as pm, ClickHouseKiller(dictionary_node):
-        assert None == dictionary_node.get_process_pid(
-            "clickhouse"
-        ), "ClickHouse must be alive"
+        assert None is dictionary_node.get_process_pid("clickhouse"), "ClickHouse must be alive"
 
         # Remove connection between main_node and dictionary for sure
         pm.heal_all()

--- a/tests/integration/test_dictionary_allow_read_expired_keys/test_default_reading.py
+++ b/tests/integration/test_dictionary_allow_read_expired_keys/test_default_reading.py
@@ -40,7 +40,9 @@ def started_cluster():
 
 # @pytest.mark.skip(reason="debugging")
 def test_default_reading(started_cluster):
-    assert None is not dictionary_node.get_process_pid("clickhouse"), "ClickHouse must be alive"
+    assert None is not dictionary_node.get_process_pid(
+        "clickhouse"
+    ), "ClickHouse must be alive"
 
     # Key 0 is not in dictionary, so default value will be returned
 
@@ -97,7 +99,9 @@ def test_default_reading(started_cluster):
     test_helper()
 
     with PartitionManager() as pm, ClickHouseKiller(dictionary_node):
-        assert None is dictionary_node.get_process_pid("clickhouse"), "ClickHouse must be alive"
+        assert None is dictionary_node.get_process_pid(
+            "clickhouse"
+        ), "ClickHouse must be alive"
 
         # Remove connection between main_node and dictionary for sure
         pm.heal_all()

--- a/tests/integration/test_dictionary_allow_read_expired_keys/test_default_string.py
+++ b/tests/integration/test_dictionary_allow_read_expired_keys/test_default_string.py
@@ -54,7 +54,9 @@ def started_cluster():
 
 # @pytest.mark.skip(reason="debugging")
 def test_return_real_values(started_cluster):
-    assert None is not dictionary_node.get_process_pid("clickhouse"), "ClickHouse must be alive"
+    assert None is not dictionary_node.get_process_pid(
+        "clickhouse"
+    ), "ClickHouse must be alive"
 
     first_batch = """
     SELECT count(*)

--- a/tests/integration/test_dictionary_allow_read_expired_keys/test_default_string.py
+++ b/tests/integration/test_dictionary_allow_read_expired_keys/test_default_string.py
@@ -1,4 +1,3 @@
-import os
 import random
 import string
 import time
@@ -55,9 +54,7 @@ def started_cluster():
 
 # @pytest.mark.skip(reason="debugging")
 def test_return_real_values(started_cluster):
-    assert None != dictionary_node.get_process_pid(
-        "clickhouse"
-    ), "ClickHouse must be alive"
+    assert None is not dictionary_node.get_process_pid("clickhouse"), "ClickHouse must be alive"
 
     first_batch = """
     SELECT count(*)

--- a/tests/integration/test_dictionary_allow_read_expired_keys/test_dict_get.py
+++ b/tests/integration/test_dictionary_allow_read_expired_keys/test_dict_get.py
@@ -40,7 +40,9 @@ def started_cluster():
 
 # @pytest.mark.skip(reason="debugging")
 def test_simple_dict_get(started_cluster):
-    assert None is not dictionary_node.get_process_pid("clickhouse"), "ClickHouse must be alive"
+    assert None is not dictionary_node.get_process_pid(
+        "clickhouse"
+    ), "ClickHouse must be alive"
 
     def test_helper():
         assert (

--- a/tests/integration/test_dictionary_allow_read_expired_keys/test_dict_get.py
+++ b/tests/integration/test_dictionary_allow_read_expired_keys/test_dict_get.py
@@ -40,9 +40,7 @@ def started_cluster():
 
 # @pytest.mark.skip(reason="debugging")
 def test_simple_dict_get(started_cluster):
-    assert None != dictionary_node.get_process_pid(
-        "clickhouse"
-    ), "ClickHouse must be alive"
+    assert None is not dictionary_node.get_process_pid("clickhouse"), "ClickHouse must be alive"
 
     def test_helper():
         assert (
@@ -97,7 +95,7 @@ def test_simple_dict_get(started_cluster):
     test_helper()
 
     with PartitionManager() as pm, ClickHouseKiller(dictionary_node):
-        assert None == dictionary_node.get_process_pid("clickhouse")
+        assert None is dictionary_node.get_process_pid("clickhouse")
 
         # Remove connection between main_node and dictionary for sure
         pm.heal_all()

--- a/tests/integration/test_dictionary_allow_read_expired_keys/test_dict_get_or_default.py
+++ b/tests/integration/test_dictionary_allow_read_expired_keys/test_dict_get_or_default.py
@@ -40,9 +40,7 @@ def started_cluster():
 
 # @pytest.mark.skip(reason="debugging")
 def test_simple_dict_get_or_default(started_cluster):
-    assert None != dictionary_node.get_process_pid(
-        "clickhouse"
-    ), "ClickHouse must be alive"
+    assert None is not dictionary_node.get_process_pid("clickhouse"), "ClickHouse must be alive"
 
     def test_helper():
         assert (
@@ -97,7 +95,7 @@ def test_simple_dict_get_or_default(started_cluster):
     test_helper()
 
     with PartitionManager() as pm, ClickHouseKiller(dictionary_node):
-        assert None == dictionary_node.get_process_pid("clickhouse")
+        assert None is dictionary_node.get_process_pid("clickhouse")
 
         # Remove connection between main_node and dictionary for sure
         pm.partition_instances(main_node, dictionary_node)

--- a/tests/integration/test_dictionary_allow_read_expired_keys/test_dict_get_or_default.py
+++ b/tests/integration/test_dictionary_allow_read_expired_keys/test_dict_get_or_default.py
@@ -40,7 +40,9 @@ def started_cluster():
 
 # @pytest.mark.skip(reason="debugging")
 def test_simple_dict_get_or_default(started_cluster):
-    assert None is not dictionary_node.get_process_pid("clickhouse"), "ClickHouse must be alive"
+    assert None is not dictionary_node.get_process_pid(
+        "clickhouse"
+    ), "ClickHouse must be alive"
 
     def test_helper():
         assert (

--- a/tests/integration/test_disabled_access_control_improvements/test_select_from_system_tables.py
+++ b/tests/integration/test_disabled_access_control_improvements/test_select_from_system_tables.py
@@ -1,7 +1,5 @@
-import os
 import pytest
 from helpers.cluster import ClickHouseCluster
-from helpers.test_tools import TSV
 
 cluster = ClickHouseCluster(__file__)
 node = cluster.add_instance(

--- a/tests/integration/test_disabled_mysql_server/test.py
+++ b/tests/integration/test_disabled_mysql_server/test.py
@@ -1,12 +1,8 @@
-import time
 import contextlib
 import pymysql.cursors
 import pytest
-import os
-import subprocess
 
-from helpers.client import QueryRuntimeException
-from helpers.cluster import ClickHouseCluster, get_docker_compose_path
+from helpers.cluster import ClickHouseCluster
 from helpers.network import PartitionManager
 
 cluster = ClickHouseCluster(__file__)

--- a/tests/integration/test_disk_configuration/test.py
+++ b/tests/integration/test_disk_configuration/test.py
@@ -1,5 +1,4 @@
 import pytest
-from helpers.client import QueryRuntimeException
 from helpers.cluster import ClickHouseCluster
 
 cluster = ClickHouseCluster(__file__)

--- a/tests/integration/test_disk_over_web_server/test.py
+++ b/tests/integration/test_disk_over_web_server/test.py
@@ -99,8 +99,7 @@ def test_usage(cluster, node_name):
             (id Int32) ENGINE = MergeTree() ORDER BY id
             SETTINGS storage_policy = 'web';
         """.format(
-                i, uuids[i], i, i
-            )
+                i, uuids[i], )
         )
 
         result = node2.query("SELECT * FROM test{} settings max_threads=20".format(i))
@@ -135,7 +134,7 @@ def test_usage(cluster, node_name):
 
 
 def test_incorrect_usage(cluster):
-    node1 = cluster.instances["node1"]
+    cluster.instances["node1"]
     node2 = cluster.instances["node3"]
     global uuids
     node2.query(
@@ -177,8 +176,7 @@ def test_cache(cluster, node_name):
             (id Int32) ENGINE = MergeTree() ORDER BY id
             SETTINGS storage_policy = 'cached_web';
         """.format(
-                i, uuids[i], i, i
-            )
+                i, uuids[i], )
         )
 
         result = node2.query(

--- a/tests/integration/test_disk_over_web_server/test.py
+++ b/tests/integration/test_disk_over_web_server/test.py
@@ -99,7 +99,9 @@ def test_usage(cluster, node_name):
             (id Int32) ENGINE = MergeTree() ORDER BY id
             SETTINGS storage_policy = 'web';
         """.format(
-                i, uuids[i], )
+                i,
+                uuids[i],
+            )
         )
 
         result = node2.query("SELECT * FROM test{} settings max_threads=20".format(i))
@@ -176,7 +178,9 @@ def test_cache(cluster, node_name):
             (id Int32) ENGINE = MergeTree() ORDER BY id
             SETTINGS storage_policy = 'cached_web';
         """.format(
-                i, uuids[i], )
+                i,
+                uuids[i],
+            )
         )
 
         result = node2.query(

--- a/tests/integration/test_distributed_ddl/cluster.py
+++ b/tests/integration/test_distributed_ddl/cluster.py
@@ -1,12 +1,11 @@
 import os
 import os.path as p
 import sys
-
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-
 from helpers.cluster import ClickHouseCluster
 from helpers.network import PartitionManager
 from helpers.test_tools import TSV
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 
 class ClickHouseClusterWithDDLHelpers(ClickHouseCluster):
@@ -107,9 +106,9 @@ class ClickHouseClusterWithDDLHelpers(ClickHouseCluster):
             num_hosts = len(self.instances)
 
         M = TSV.toMat(tsv_content)
-        hosts = [(l[0], l[1]) for l in M]  # (host, port)
-        codes = [l[2] for l in M]
-        messages = [l[3] for l in M]
+        hosts = [(m[0], m[1]) for m in M]  # (host, port)
+        codes = [m[2] for m in M]
+        [m[3] for m in M]
 
         assert len(hosts) == num_hosts and len(set(hosts)) == num_hosts, (
             "\n" + tsv_content

--- a/tests/integration/test_distributed_ddl/test.py
+++ b/tests/integration/test_distributed_ddl/test.py
@@ -1,14 +1,12 @@
 import os
 import sys
 import time
-from contextlib import contextmanager
-
 import pytest
-
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-
+from contextlib import contextmanager
 from helpers.test_tools import TSV
 from .cluster import ClickHouseClusterWithDDLHelpers
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 
 @pytest.fixture(scope="module", params=["configs", "configs_secure"])

--- a/tests/integration/test_distributed_ddl/test_replicated_alter.py
+++ b/tests/integration/test_distributed_ddl/test_replicated_alter.py
@@ -1,13 +1,11 @@
 import os
 import sys
 import time
-
 import pytest
-
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-
 from helpers.test_tools import TSV
 from .cluster import ClickHouseClusterWithDDLHelpers
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 
 @pytest.fixture(scope="module", params=["configs", "configs_secure"])

--- a/tests/integration/test_distributed_default_database/test.py
+++ b/tests/integration/test_distributed_default_database/test.py
@@ -5,9 +5,7 @@ in this test we write into per-node tables and read from the distributed table.
 The default database in the distributed table definition is left empty on purpose to test
 default database deduction.
 """
-import pytest
 
-from helpers.client import QueryRuntimeException
 from helpers.cluster import ClickHouseCluster
 from helpers.test_tools import TSV
 

--- a/tests/integration/test_distributed_insert_backward_compatibility/test.py
+++ b/tests/integration/test_distributed_insert_backward_compatibility/test.py
@@ -1,7 +1,6 @@
 import pytest
 
 from helpers.cluster import ClickHouseCluster
-from helpers.client import QueryRuntimeException
 
 cluster = ClickHouseCluster(__file__)
 

--- a/tests/integration/test_dotnet_client/test.py
+++ b/tests/integration/test_dotnet_client/test.py
@@ -1,14 +1,9 @@
 # coding: utf-8
 
-import datetime
-import math
 import os
-import time
 
-import logging
 import docker
 import pytest
-from docker.models.containers import Container
 from helpers.cluster import ClickHouseCluster, get_docker_compose_path, run_and_check
 
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))

--- a/tests/integration/test_drop_is_lock_free/test.py
+++ b/tests/integration/test_drop_is_lock_free/test.py
@@ -1,7 +1,6 @@
 import time
 import pytest
 import logging
-from contextlib import contextmanager
 from helpers.cluster import ClickHouseCluster
 from helpers.test_tools import assert_eq_with_retry
 

--- a/tests/integration/test_drop_replica/test.py
+++ b/tests/integration/test_drop_replica/test.py
@@ -1,4 +1,3 @@
-import time
 
 import pytest
 from helpers.cluster import ClickHouseCluster
@@ -169,7 +168,7 @@ def test_drop_replica(start_cluster):
             shard=1, replica="node_1_1"
         ),
     )
-    assert exists_replica_1_1 != None
+    assert exists_replica_1_1 is not None
 
     ## If you want to drop a inactive/stale replicate table that does not have a local replica, you can following syntax(ZKPATH):
     node_1_3.query(
@@ -183,7 +182,7 @@ def test_drop_replica(start_cluster):
             shard=1, replica="node_1_1"
         ),
     )
-    assert exists_replica_1_1 == None
+    assert exists_replica_1_1 is None
 
     node_1_2.query("SYSTEM DROP REPLICA 'node_1_1' FROM TABLE test.test_table")
     exists_replica_1_1 = check_exists(
@@ -192,7 +191,7 @@ def test_drop_replica(start_cluster):
             shard=1, replica="node_1_1"
         ),
     )
-    assert exists_replica_1_1 == None
+    assert exists_replica_1_1 is None
 
     node_1_2.query("SYSTEM DROP REPLICA 'node_1_1' FROM DATABASE test1")
     exists_replica_1_1 = check_exists(
@@ -201,7 +200,7 @@ def test_drop_replica(start_cluster):
             shard=1, replica="node_1_1"
         ),
     )
-    assert exists_replica_1_1 == None
+    assert exists_replica_1_1 is None
 
     node_1_3.query(
         "SYSTEM DROP REPLICA 'node_1_1' FROM ZKPATH '/clickhouse/tables/test3/{shard}/replicated/test_table'".format(
@@ -214,7 +213,7 @@ def test_drop_replica(start_cluster):
             shard=1, replica="node_1_1"
         ),
     )
-    assert exists_replica_1_1 == None
+    assert exists_replica_1_1 is None
 
     node_1_2.query("SYSTEM DROP REPLICA 'node_1_1'")
     exists_replica_1_1 = check_exists(
@@ -223,4 +222,4 @@ def test_drop_replica(start_cluster):
             shard=1, replica="node_1_1"
         ),
     )
-    assert exists_replica_1_1 == None
+    assert exists_replica_1_1 is None

--- a/tests/integration/test_drop_replica/test.py
+++ b/tests/integration/test_drop_replica/test.py
@@ -1,4 +1,3 @@
-
 import pytest
 from helpers.cluster import ClickHouseCluster
 

--- a/tests/integration/test_drop_replica_with_auxiliary_zookeepers/test.py
+++ b/tests/integration/test_drop_replica_with_auxiliary_zookeepers/test.py
@@ -1,10 +1,7 @@
 import time
 
-import helpers.client as client
 import pytest
 from helpers.cluster import ClickHouseCluster
-from helpers.client import QueryRuntimeException
-from helpers.test_tools import TSV
 
 cluster = ClickHouseCluster(__file__)
 node1 = cluster.add_instance(

--- a/tests/integration/test_endpoint_macro_substitution/test.py
+++ b/tests/integration/test_endpoint_macro_substitution/test.py
@@ -33,7 +33,7 @@ def cluster():
 
 def test_different_types(cluster):
     node = cluster.instances["node"]
-    fs = HdfsClient(hosts=cluster.hdfs_ip)
+    HdfsClient(hosts=cluster.hdfs_ip)
 
     response = TSV.toMat(node.query("SELECT * FROM system.disks FORMAT TSVWithNames"))
 
@@ -60,7 +60,7 @@ def test_different_types(cluster):
 
 def test_select_by_type(cluster):
     node = cluster.instances["node"]
-    fs = HdfsClient(hosts=cluster.hdfs_ip)
+    HdfsClient(hosts=cluster.hdfs_ip)
 
     for name, disk_type in list(disk_types.items()):
         if disk_type != "s3":

--- a/tests/integration/test_executable_dictionary/test.py
+++ b/tests/integration/test_executable_dictionary/test.py
@@ -1,13 +1,11 @@
 import os
 import sys
 import time
-
 import pytest
+from helpers.cluster import ClickHouseCluster
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
-
-from helpers.cluster import ClickHouseCluster
 
 cluster = ClickHouseCluster(__file__)
 node = cluster.add_instance("node", stay_alive=True, main_configs=[])
@@ -244,26 +242,6 @@ def test_executable_implicit_input_signalled_python(started_cluster):
             "SELECT dictGet('executable_implicit_input_signalled_pool_python', 'result', toUInt64(1))"
         )
         == "Default result\n"
-    )
-
-
-def test_executable_input_slow_python(started_cluster):
-    skip_test_msan(node)
-    assert node.query_and_get_error(
-        "SELECT dictGet('executable_input_slow_python', 'result', toUInt64(1))"
-    )
-    assert node.query_and_get_error(
-        "SELECT dictGet('executable_input_slow_pool_python', 'result', toUInt64(1))"
-    )
-
-
-def test_executable_implicit_input_slow_python(started_cluster):
-    skip_test_msan(node)
-    assert node.query_and_get_error(
-        "SELECT dictGet('executable_implicit_input_slow_python', 'result', toUInt64(1))"
-    )
-    assert node.query_and_get_error(
-        "SELECT dictGet('executable_implicit_input_slow_pool_python', 'result', toUInt64(1))"
     )
 
 

--- a/tests/integration/test_executable_dictionary/user_scripts/input.py
+++ b/tests/integration/test_executable_dictionary/user_scripts/input.py
@@ -1,8 +1,6 @@
 #!/usr/bin/python3
 
 import sys
-import os
-import signal
 
 if __name__ == "__main__":
     for line in sys.stdin:

--- a/tests/integration/test_executable_dictionary/user_scripts/input_implicit_signalled.py
+++ b/tests/integration/test_executable_dictionary/user_scripts/input_implicit_signalled.py
@@ -3,7 +3,6 @@
 import sys
 import os
 import signal
-import time
 
 if __name__ == "__main__":
     for line in sys.stdin:

--- a/tests/integration/test_executable_dictionary/user_scripts/input_implicit_slow.py
+++ b/tests/integration/test_executable_dictionary/user_scripts/input_implicit_slow.py
@@ -1,8 +1,6 @@
 #!/usr/bin/python3
 
 import sys
-import os
-import signal
 import time
 
 if __name__ == "__main__":

--- a/tests/integration/test_executable_dictionary/user_scripts/input_signalled.py
+++ b/tests/integration/test_executable_dictionary/user_scripts/input_signalled.py
@@ -3,7 +3,6 @@
 import sys
 import os
 import signal
-import time
 
 if __name__ == "__main__":
     for line in sys.stdin:

--- a/tests/integration/test_executable_dictionary/user_scripts/input_slow.py
+++ b/tests/integration/test_executable_dictionary/user_scripts/input_slow.py
@@ -1,8 +1,6 @@
 #!/usr/bin/python3
 
 import sys
-import os
-import signal
 import time
 
 if __name__ == "__main__":

--- a/tests/integration/test_executable_table_function/test.py
+++ b/tests/integration/test_executable_table_function/test.py
@@ -1,12 +1,10 @@
 import os
 import sys
-
 import pytest
+from helpers.cluster import ClickHouseCluster
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
-
-from helpers.cluster import ClickHouseCluster
 
 cluster = ClickHouseCluster(__file__)
 node = cluster.add_instance("node", stay_alive=True, main_configs=[])
@@ -301,7 +299,7 @@ def test_executable_storage_input_slow_python(started_cluster):
     node.query("DROP TABLE test_table")
 
 
-def test_executable_function_input_multiple_pipes_python(started_cluster):
+def test_executable_storage_input_multiple_pipes_python(started_cluster):
     skip_test_msan(node)
 
     query = "CREATE TABLE test_table (value String) ENGINE=Executable('input_multiple_pipes.py', 'TabSeparated', {source})"

--- a/tests/integration/test_executable_user_defined_function/test.py
+++ b/tests/integration/test_executable_user_defined_function/test.py
@@ -1,13 +1,10 @@
 import os
 import sys
-import time
-
 import pytest
+from helpers.cluster import ClickHouseCluster
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
-
-from helpers.cluster import ClickHouseCluster
 
 cluster = ClickHouseCluster(__file__)
 node = cluster.add_instance("node", stay_alive=True, main_configs=[])

--- a/tests/integration/test_executable_user_defined_function/user_scripts/input_signalled.py
+++ b/tests/integration/test_executable_user_defined_function/user_scripts/input_signalled.py
@@ -3,7 +3,6 @@
 import sys
 import os
 import signal
-import time
 
 if __name__ == "__main__":
     for line in sys.stdin:

--- a/tests/integration/test_executable_user_defined_function/user_scripts/input_slow.py
+++ b/tests/integration/test_executable_user_defined_function/user_scripts/input_slow.py
@@ -1,8 +1,6 @@
 #!/usr/bin/python3
 
 import sys
-import os
-import signal
 import time
 
 if __name__ == "__main__":

--- a/tests/integration/test_executable_user_defined_functions_config_reload/test.py
+++ b/tests/integration/test_executable_user_defined_functions_config_reload/test.py
@@ -1,13 +1,11 @@
 import os
 import sys
 import time
-import logging
 import pytest
+from helpers.cluster import ClickHouseCluster
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
-
-from helpers.cluster import ClickHouseCluster
 
 cluster = ClickHouseCluster(__file__)
 node = cluster.add_instance(

--- a/tests/integration/test_failed_async_inserts/test.py
+++ b/tests/integration/test_failed_async_inserts/test.py
@@ -1,10 +1,5 @@
-import logging
-from time import sleep
 
 import pytest
-from helpers.cluster import ClickHouseCluster
-
-
 from helpers.cluster import ClickHouseCluster
 
 cluster = ClickHouseCluster(__file__)

--- a/tests/integration/test_failed_async_inserts/test.py
+++ b/tests/integration/test_failed_async_inserts/test.py
@@ -1,4 +1,3 @@
-
 import pytest
 from helpers.cluster import ClickHouseCluster
 

--- a/tests/integration/test_fetch_partition_should_reset_mutation/test.py
+++ b/tests/integration/test_fetch_partition_should_reset_mutation/test.py
@@ -1,5 +1,4 @@
 import pytest
-from helpers.client import QueryRuntimeException
 from helpers.cluster import ClickHouseCluster
 from helpers.test_tools import TSV
 

--- a/tests/integration/test_fetch_partition_with_outdated_parts/test.py
+++ b/tests/integration/test_fetch_partition_with_outdated_parts/test.py
@@ -1,7 +1,5 @@
 from __future__ import print_function
 from helpers.cluster import ClickHouseCluster
-from helpers.client import QueryRuntimeException
-import helpers
 import pytest
 
 

--- a/tests/integration/test_format_avro_confluent/test.py
+++ b/tests/integration/test_format_avro_confluent/test.py
@@ -7,7 +7,7 @@ from confluent_kafka.avro.cached_schema_registry_client import (
     CachedSchemaRegistryClient,
 )
 from confluent_kafka.avro.serializer.message_serializer import MessageSerializer
-from helpers.cluster import ClickHouseCluster, ClickHouseInstance
+from helpers.cluster import ClickHouseCluster
 
 
 @pytest.fixture(scope="module")

--- a/tests/integration/test_graphite_merge_tree_typed/test.py
+++ b/tests/integration/test_graphite_merge_tree_typed/test.py
@@ -2,9 +2,7 @@ import datetime
 import os.path as p
 import time
 
-import sys
 import pytest
-from helpers.client import QueryRuntimeException
 from helpers.cluster import ClickHouseCluster
 from helpers.test_tools import TSV
 from helpers.test_tools import csv_compare

--- a/tests/integration/test_grpc_protocol_ssl/test.py
+++ b/tests/integration/test_grpc_protocol_ssl/test.py
@@ -2,6 +2,8 @@ import os
 import pytest
 import sys
 import grpc
+import clickhouse_grpc_pb2
+import clickhouse_grpc_pb2_grpc
 from helpers.cluster import ClickHouseCluster, run_and_check
 
 # The test cluster is configured with certificate for that host name, see 'server-ext.cnf'.
@@ -10,7 +12,6 @@ SSL_HOST = "integration-tests.clickhouse.com"
 GRPC_PORT = 9100
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 DEFAULT_ENCODING = "utf-8"
-
 
 # Use grpcio-tools to generate *pb2.py files from *.proto.
 
@@ -24,11 +25,7 @@ run_and_check(
     ),
     shell=True,
 )
-
 sys.path.append(gen_dir)
-import clickhouse_grpc_pb2
-import clickhouse_grpc_pb2_grpc
-
 
 # Utilities
 

--- a/tests/integration/test_hedged_requests/test.py
+++ b/tests/integration/test_hedged_requests/test.py
@@ -1,13 +1,11 @@
 import os
 import sys
 import time
-
 import pytest
-
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-
 from helpers.cluster import ClickHouseCluster
 from helpers.test_tools import TSV
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 cluster = ClickHouseCluster(__file__)
 NODES = {"node_" + str(i): None for i in (1, 2, 3)}

--- a/tests/integration/test_hedged_requests_parallel/test.py
+++ b/tests/integration/test_hedged_requests_parallel/test.py
@@ -1,12 +1,10 @@
 import os
 import sys
 import time
-
 import pytest
+from helpers.cluster import ClickHouseCluster
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-
-from helpers.cluster import ClickHouseCluster
 
 cluster = ClickHouseCluster(__file__)
 

--- a/tests/integration/test_hive_query/test.py
+++ b/tests/integration/test_hive_query/test.py
@@ -1,16 +1,13 @@
+import os
+import time
+import logging
 import pytest
+from helpers.cluster import ClickHouseCluster
 
 # FIXME This test is too flaky
 # https://github.com/ClickHouse/ClickHouse/issues/43541
 
 pytestmark = pytest.mark.skip
-
-import logging
-import os
-
-import time
-from helpers.cluster import ClickHouseCluster
-from helpers.test_tools import TSV
 
 logging.getLogger().setLevel(logging.INFO)
 logging.getLogger().addHandler(logging.StreamHandler())

--- a/tests/integration/test_host_regexp_hosts_file_resolution/test.py
+++ b/tests/integration/test_host_regexp_hosts_file_resolution/test.py
@@ -1,5 +1,5 @@
 import pytest
-from helpers.cluster import ClickHouseCluster, get_docker_compose_path, run_and_check
+from helpers.cluster import ClickHouseCluster, get_docker_compose_path
 import os
 
 DOCKER_COMPOSE_PATH = get_docker_compose_path()

--- a/tests/integration/test_host_regexp_multiple_ptr_records_concurrent/test.py
+++ b/tests/integration/test_host_regexp_multiple_ptr_records_concurrent/test.py
@@ -1,6 +1,5 @@
 import pytest
 from helpers.cluster import ClickHouseCluster, get_docker_compose_path, run_and_check
-from time import sleep
 import os
 
 DOCKER_COMPOSE_PATH = get_docker_compose_path()
@@ -68,4 +67,4 @@ def test_host_regexp_multiple_ptr_v4(started_cluster):
         os.path.join(current_dir, "scripts", "stress_test.py"), "stress_test.py"
     )
 
-    client.exec_in_container(["python3", f"stress_test.py", client_ip, server_ip])
+    client.exec_in_container(["python3", "stress_test.py", client_ip, server_ip])

--- a/tests/integration/test_http_handlers_config/test.py
+++ b/tests/integration/test_http_handlers_config/test.py
@@ -1,7 +1,8 @@
 import contextlib
 import os
-import urllib.request, urllib.parse, urllib.error
-
+import urllib.request
+import urllib.parse
+import urllib.error
 from helpers.cluster import ClickHouseCluster
 
 

--- a/tests/integration/test_insert_into_distributed_sync_async/test.py
+++ b/tests/integration/test_insert_into_distributed_sync_async/test.py
@@ -1,13 +1,12 @@
 import os
 import sys
-from contextlib import contextmanager
-
 import pytest
-
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from contextlib import contextmanager
 from helpers.test_tools import TSV
 from helpers.cluster import ClickHouseCluster
 from helpers.client import QueryRuntimeException, QueryTimeoutExceedException
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 cluster = ClickHouseCluster(__file__)
 

--- a/tests/integration/test_inserts_with_keeper_retries/test.py
+++ b/tests/integration/test_inserts_with_keeper_retries/test.py
@@ -7,7 +7,6 @@ from helpers.cluster import ClickHouseCluster
 from multiprocessing.dummy import Pool
 from helpers.network import PartitionManager
 from helpers.client import QueryRuntimeException
-from helpers.test_tools import assert_eq_with_retry
 
 cluster = ClickHouseCluster(__file__)
 

--- a/tests/integration/test_interserver_dns_retires/test.py
+++ b/tests/integration/test_interserver_dns_retires/test.py
@@ -25,13 +25,13 @@ def bootstrap(cluster: ClickHouseCluster):
             user="root",
         )
 
-        node.query(f"CREATE DATABASE IF NOT EXISTS r0")
-        node.query(f"CREATE TABLE r0.test_data(v UInt64) ENGINE = Memory()")
+        node.query("CREATE DATABASE IF NOT EXISTS r0")
+        node.query("CREATE TABLE r0.test_data(v UInt64) ENGINE = Memory()")
         node.query(
             f"INSERT INTO r0.test_data SELECT number + {node_number} * 10 FROM numbers(10)"
         )
         node.query(
-            f"""CREATE TABLE default.test AS r0.test_data ENGINE = Distributed(cluster_missing_replica, 'r0', test_data, rand())"""
+            """CREATE TABLE default.test AS r0.test_data ENGINE = Distributed(cluster_missing_replica, 'r0', test_data, rand())"""
         )
 
 

--- a/tests/integration/test_jbod_balancer/test.py
+++ b/tests/integration/test_jbod_balancer/test.py
@@ -1,13 +1,7 @@
-import json
-import random
-import re
-import string
-import threading
 import time
 from multiprocessing.dummy import Pool
 
 import pytest
-from helpers.client import QueryRuntimeException
 from helpers.cluster import ClickHouseCluster
 
 cluster = ClickHouseCluster(__file__)
@@ -115,9 +109,9 @@ def test_jbod_balanced_merge(start_cluster):
         check_balance(node1, "tbl")
 
     finally:
-        node1.query(f"DROP TABLE IF EXISTS tbl SYNC")
-        node1.query(f"DROP TABLE IF EXISTS tmp1 SYNC")
-        node1.query(f"DROP TABLE IF EXISTS tmp2 SYNC")
+        node1.query("DROP TABLE IF EXISTS tbl SYNC")
+        node1.query("DROP TABLE IF EXISTS tmp1 SYNC")
+        node1.query("DROP TABLE IF EXISTS tmp2 SYNC")
 
 
 def test_replicated_balanced_merge_fetch(start_cluster):

--- a/tests/integration/test_jbod_ha/test.py
+++ b/tests/integration/test_jbod_ha/test.py
@@ -1,13 +1,6 @@
-import json
-import random
-import re
-import string
-import threading
 import time
-from multiprocessing.dummy import Pool
 
 import pytest
-from helpers.client import QueryRuntimeException
 from helpers.cluster import ClickHouseCluster
 
 cluster = ClickHouseCluster(__file__)

--- a/tests/integration/test_jbod_load_balancing/test.py
+++ b/tests/integration/test_jbod_load_balancing/test.py
@@ -54,7 +54,7 @@ def test_jbod_load_balancing_round_robin(start_cluster):
         ORDER BY disk_name
         """
         )
-        parts = [l.split("\t") for l in parts.strip().split("\n")]
+        parts = [part.split("\t") for part in parts.strip().split("\n")]
         assert parts == [
             ["2", "jbod1"],
             ["1", "jbod2"],
@@ -91,7 +91,7 @@ def test_jbod_load_balancing_least_used(start_cluster):
         ORDER BY disk_name
         """
         )
-        parts = [l.split("\t") for l in parts.strip().split("\n")]
+        parts = [part.split("\t") for part in parts.strip().split("\n")]
         assert parts == [
             ["4", "jbod3"],
         ]
@@ -127,7 +127,7 @@ def test_jbod_load_balancing_least_used_next_disk(start_cluster):
         ORDER BY disk_name
         """
         )
-        parts = [l.split("\t") for l in parts.strip().split("\n")]
+        parts = [part.split("\t") for part in parts.strip().split("\n")]
         assert parts == [
             ["1", "jbod2"],
             ["2", "jbod3"],

--- a/tests/integration/test_jdbc_bridge/test.py
+++ b/tests/integration/test_jdbc_bridge/test.py
@@ -153,7 +153,8 @@ def test_jdbc_delete(started_cluster):
     expected = records - 1
     actual = instance.query(
         "SELECT Str FROM jdbc('{}', 'SELECT * FROM test.test_delete')".format(
-            datasource, )
+            datasource,
+        )
     )
     assert int(actual) == expected, "expecting {} but got {}".format(expected, actual)
 

--- a/tests/integration/test_jdbc_bridge/test.py
+++ b/tests/integration/test_jdbc_bridge/test.py
@@ -1,11 +1,9 @@
 import logging
-import os.path as p
 import pytest
 import uuid
 
 from helpers.cluster import ClickHouseCluster
 from helpers.test_tools import TSV
-from string import Template
 
 cluster = ClickHouseCluster(__file__)
 instance = cluster.add_instance(
@@ -155,8 +153,7 @@ def test_jdbc_delete(started_cluster):
     expected = records - 1
     actual = instance.query(
         "SELECT Str FROM jdbc('{}', 'SELECT * FROM test.test_delete')".format(
-            datasource, records
-        )
+            datasource, )
     )
     assert int(actual) == expected, "expecting {} but got {}".format(expected, actual)
 

--- a/tests/integration/test_join_set_family_s3/test.py
+++ b/tests/integration/test_join_set_family_s3/test.py
@@ -1,5 +1,4 @@
 import logging
-import sys
 
 import pytest
 from helpers.cluster import ClickHouseCluster

--- a/tests/integration/test_kafka_bad_messages/test.py
+++ b/tests/integration/test_kafka_bad_messages/test.py
@@ -3,7 +3,7 @@ import logging
 import pytest
 
 from helpers.cluster import ClickHouseCluster
-from kafka import KafkaAdminClient, KafkaProducer, KafkaConsumer, BrokerConnection
+from kafka import KafkaAdminClient, KafkaProducer
 from kafka.admin import NewTopic
 
 cluster = ClickHouseCluster(__file__)
@@ -241,7 +241,7 @@ struct Message
 
     instance.create_format_schema("schema_test_errors.capnp", capn_proto_schema)
     instance.query(
-        f"""
+        """
             DROP TABLE IF EXISTS view;
             DROP TABLE IF EXISTS kafka;
     

--- a/tests/integration/test_keeper_auth/test.py
+++ b/tests/integration/test_keeper_auth/test.py
@@ -1,8 +1,8 @@
 import pytest
 import time
 from helpers.cluster import ClickHouseCluster
-from kazoo.client import KazooClient, KazooState
-from kazoo.security import ACL, make_digest_acl, make_acl
+from kazoo.client import KazooClient
+from kazoo.security import make_acl
 from kazoo.exceptions import (
     AuthFailedError,
     InvalidACLError,

--- a/tests/integration/test_keeper_back_to_back/test.py
+++ b/tests/integration/test_keeper_back_to_back/test.py
@@ -1,10 +1,11 @@
 import pytest
-from helpers.cluster import ClickHouseCluster
 import random
 import string
 import os
 import time
+from helpers.cluster import ClickHouseCluster
 from multiprocessing.dummy import Pool
+from kazoo.client import KazooClient, KazooState
 
 cluster = ClickHouseCluster(__file__)
 node = cluster.add_instance(
@@ -13,7 +14,6 @@ node = cluster.add_instance(
     with_zookeeper=True,
     use_keeper=False,
 )
-from kazoo.client import KazooClient, KazooState, KeeperState
 
 
 def get_genuine_zk():
@@ -53,7 +53,7 @@ def stop_zk(zk):
         if zk:
             zk.stop()
             zk.close()
-    except:
+    except Exception:
         pass
 
 
@@ -119,16 +119,16 @@ def test_sequential_nodes(started_cluster):
         fake_throw = False
         try:
             genuine_zk.create("/test_sequential_nodes_1/a", sequence=True)
-        except Exception as ex:
+        except Exception:
             genuine_throw = True
 
         try:
             fake_zk.create("/test_sequential_nodes_1/a", sequence=True)
-        except Exception as ex:
+        except Exception:
             fake_throw = True
 
-        assert genuine_throw == True
-        assert fake_throw == True
+        assert genuine_throw is True
+        assert fake_throw is True
 
         genuine_childs_1 = list(
             sorted(genuine_zk.get_children("/test_sequential_nodes_1"))
@@ -276,8 +276,8 @@ def test_watchers(started_cluster):
 
         time.sleep(3)
 
-        assert genuine_children == None
-        assert fake_children == None
+        assert genuine_children is None
+        assert fake_children is None
 
         print("Calling genuine child")
         genuine_zk.create("/test_data_watches/child_new", b"b")
@@ -705,7 +705,7 @@ def test_concurrent_watches(started_cluster):
             fake_zk.set(global_path + "/" + str(i), b"somevalue")
             try:
                 existing_path.remove(i)
-            except:
+            except Exception:
                 pass
 
         def call(total):
@@ -715,13 +715,13 @@ def test_concurrent_watches(started_cluster):
                 try:
                     rand_num = random.choice(existing_path)
                     trigger_watch(rand_num)
-                except:
+                except Exception:
                     pass
             while existing_path:
                 try:
                     rand_num = random.choice(existing_path)
                     trigger_watch(rand_num)
-                except:
+                except Exception:
                     pass
 
         p = Pool(10)

--- a/tests/integration/test_keeper_force_recovery/test.py
+++ b/tests/integration/test_keeper_force_recovery/test.py
@@ -1,11 +1,8 @@
 import os
 import pytest
-import socket
-from helpers.cluster import ClickHouseCluster
-import helpers.keeper_utils as keeper_utils
 import time
-
-
+import helpers.keeper_utils as keeper_utils
+from helpers.cluster import ClickHouseCluster
 from kazoo.client import KazooClient, KazooRetry
 
 CLUSTER_SIZE = 5
@@ -24,7 +21,7 @@ def get_nodes():
                 f"node{i+1}",
                 main_configs=[
                     f"configs/enable_keeper{i+1}.xml",
-                    f"configs/use_keeper.xml",
+                    "configs/use_keeper.xml",
                 ],
                 stay_alive=True,
             )
@@ -203,5 +200,5 @@ def test_cluster_recovery(started_cluster):
         try:
             for zk_conn in node_zks:
                 close_zk(zk_conn)
-        except:
+        except Exception:
             pass

--- a/tests/integration/test_keeper_force_recovery_single_node/test.py
+++ b/tests/integration/test_keeper_force_recovery_single_node/test.py
@@ -1,6 +1,5 @@
 import os
 import pytest
-import socket
 from helpers.cluster import ClickHouseCluster
 import helpers.keeper_utils as keeper_utils
 import time
@@ -22,7 +21,7 @@ def get_nodes():
                 f"node{i+1}",
                 main_configs=[
                     f"configs/enable_keeper{i+1}.xml",
-                    f"configs/use_keeper.xml",
+                    "configs/use_keeper.xml",
                 ],
                 stay_alive=True,
             )
@@ -133,5 +132,5 @@ def test_cluster_recovery(started_cluster):
         try:
             for zk_conn in node_zks:
                 close_zk(zk_conn)
-        except:
+        except Exception:
             pass

--- a/tests/integration/test_keeper_four_word_command/test.py
+++ b/tests/integration/test_keeper_four_word_command/test.py
@@ -1,9 +1,12 @@
+#!/usr/bin/env python3
+
 import pytest
-from helpers.cluster import ClickHouseCluster
-import helpers.keeper_utils as keeper_utils
 import time
 import csv
 import re
+import helpers.keeper_utils as keeper_utils
+from helpers.cluster import ClickHouseCluster
+from kazoo.client import KazooClient
 
 cluster = ClickHouseCluster(__file__)
 node1 = cluster.add_instance(
@@ -15,8 +18,6 @@ node2 = cluster.add_instance(
 node3 = cluster.add_instance(
     "node3", main_configs=["configs/enable_keeper3.xml"], stay_alive=True
 )
-
-from kazoo.client import KazooClient
 
 
 def wait_nodes():
@@ -39,7 +40,7 @@ def destroy_zk_client(zk):
         if zk:
             zk.stop()
             zk.close()
-    except:
+    except Exception:
         pass
 
 

--- a/tests/integration/test_keeper_four_word_command/test_allow_list.py
+++ b/tests/integration/test_keeper_four_word_command/test_allow_list.py
@@ -1,7 +1,8 @@
 import socket
 import pytest
-from helpers.cluster import ClickHouseCluster
 import time
+from helpers.cluster import ClickHouseCluster
+from kazoo.client import KazooClient
 
 cluster = ClickHouseCluster(__file__)
 node1 = cluster.add_instance(
@@ -17,8 +18,6 @@ node3 = cluster.add_instance(
     main_configs=["configs/keeper_config_with_allow_list_all.xml"],
     stay_alive=True,
 )
-
-from kazoo.client import KazooClient, KazooState
 
 
 @pytest.fixture(scope="module")
@@ -37,7 +36,7 @@ def destroy_zk_client(zk):
         if zk:
             zk.stop()
             zk.close()
-    except:
+    except Exception:
         pass
 
 

--- a/tests/integration/test_keeper_internal_secure/test.py
+++ b/tests/integration/test_keeper_internal_secure/test.py
@@ -2,10 +2,7 @@
 
 import pytest
 from helpers.cluster import ClickHouseCluster
-import random
-import string
-import os
-import time
+from kazoo.client import KazooClient
 
 cluster = ClickHouseCluster(__file__)
 node1 = cluster.add_instance(
@@ -38,8 +35,6 @@ node3 = cluster.add_instance(
         "configs/rootCA.pem",
     ],
 )
-
-from kazoo.client import KazooClient, KazooState
 
 
 @pytest.fixture(scope="module")
@@ -79,5 +74,5 @@ def test_secure_raft_works(started_cluster):
             for zk_conn in [node1_zk, node2_zk, node3_zk]:
                 zk_conn.stop()
                 zk_conn.close()
-        except:
+        except Exception:
             pass

--- a/tests/integration/test_keeper_mntr_data_size/test.py
+++ b/tests/integration/test_keeper_mntr_data_size/test.py
@@ -1,12 +1,11 @@
 #!/usr/bin/env python3
 
 import pytest
-from helpers.cluster import ClickHouseCluster
-import helpers.keeper_utils as keeper_utils
 import random
 import string
-from kazoo.client import KazooClient, KazooState
-
+import helpers.keeper_utils as keeper_utils
+from helpers.cluster import ClickHouseCluster
+from kazoo.client import KazooClient
 
 cluster = ClickHouseCluster(__file__)
 
@@ -77,7 +76,7 @@ def test_mntr_data_size_after_restart(started_cluster):
             get_line_from_mntr(mntr_result, "zk_ephemerals_count")
             == "zk_ephemerals_count\t0"
         )
-        assert line_size_before != None
+        assert line_size_before is not None
 
         restart_clickhouse()
 
@@ -103,5 +102,5 @@ def test_mntr_data_size_after_restart(started_cluster):
             if node_zk is not None:
                 node_zk.stop()
                 node_zk.close()
-        except:
+        except Exception:
             pass

--- a/tests/integration/test_keeper_mntr_pressure/test.py
+++ b/tests/integration/test_keeper_mntr_pressure/test.py
@@ -3,15 +3,8 @@
 from helpers.cluster import ClickHouseCluster
 import helpers.keeper_utils as keeper_utils
 import pytest
-import random
-import string
-import os
-import time
-from io import StringIO
-import socket
 import threading
 
-from helpers.network import PartitionManager
 
 cluster = ClickHouseCluster(__file__)
 node1 = cluster.add_instance(

--- a/tests/integration/test_keeper_multinode_simple/test.py
+++ b/tests/integration/test_keeper_multinode_simple/test.py
@@ -1,15 +1,13 @@
 import pytest
-from helpers.cluster import ClickHouseCluster
-import helpers.keeper_utils as keeper_utils
-import random
-import string
-import os
 import time
-from multiprocessing.dummy import Pool
+import helpers.keeper_utils as keeper_utils
+from helpers.cluster import ClickHouseCluster
 from helpers.network import PartitionManager
 from helpers.test_tools import assert_eq_with_retry
+from kazoo.client import KazooClient
 
 cluster = ClickHouseCluster(__file__)
+
 node1 = cluster.add_instance(
     "node1",
     main_configs=["configs/enable_keeper1.xml", "configs/use_keeper.xml"],
@@ -25,8 +23,6 @@ node3 = cluster.add_instance(
     main_configs=["configs/enable_keeper3.xml", "configs/use_keeper.xml"],
     stay_alive=True,
 )
-
-from kazoo.client import KazooClient, KazooState
 
 
 @pytest.fixture(scope="module")
@@ -64,7 +60,7 @@ def test_read_write_multinode(started_cluster):
         node3_zk = get_fake_zk("node3")
 
         # Cleanup
-        if node1_zk.exists("/test_read_write_multinode_node1") != None:
+        if node1_zk.exists("/test_read_write_multinode_node1") is not None:
             node1_zk.delete("/test_read_write_multinode_node1")
 
         node1_zk.create("/test_read_write_multinode_node1", b"somedata1")
@@ -98,7 +94,7 @@ def test_read_write_multinode(started_cluster):
             for zk_conn in [node1_zk, node2_zk, node3_zk]:
                 zk_conn.stop()
                 zk_conn.close()
-        except:
+        except Exception:
             pass
 
 
@@ -110,7 +106,7 @@ def test_watch_on_follower(started_cluster):
         node3_zk = get_fake_zk("node3")
 
         # Cleanup
-        if node1_zk.exists("/test_data_watches") != None:
+        if node1_zk.exists("/test_data_watches") is not None:
             node1_zk.delete("/test_data_watches")
 
         node1_zk.create("/test_data_watches")
@@ -159,7 +155,7 @@ def test_watch_on_follower(started_cluster):
             for zk_conn in [node1_zk, node2_zk, node3_zk]:
                 zk_conn.stop()
                 zk_conn.close()
-        except:
+        except Exception:
             pass
 
 
@@ -172,7 +168,7 @@ def test_session_expiration(started_cluster):
         print("Node3 session id", node3_zk._session_id)
 
         # Cleanup
-        if node3_zk.exists("/test_ephemeral_node") != None:
+        if node3_zk.exists("/test_ephemeral_node") is not None:
             node3_zk.delete("/test_ephemeral_node")
 
         node3_zk.create("/test_ephemeral_node", b"world", ephemeral=True)
@@ -203,9 +199,9 @@ def test_session_expiration(started_cluster):
                 try:
                     zk_conn.stop()
                     zk_conn.close()
-                except:
+                except Exception:
                     pass
-        except:
+        except Exception:
             pass
 
 
@@ -216,7 +212,7 @@ def test_follower_restart(started_cluster):
         node3_zk = get_fake_zk("node3")
 
         # Cleanup
-        if node1_zk.exists("/test_restart_node") != None:
+        if node1_zk.exists("/test_restart_node") is not None:
             node1_zk.delete("/test_restart_node")
 
         node1_zk.create("/test_restart_node", b"hello")
@@ -234,9 +230,9 @@ def test_follower_restart(started_cluster):
                 try:
                     zk_conn.stop()
                     zk_conn.close()
-                except:
+                except Exception:
                     pass
-        except:
+        except Exception:
             pass
 
 

--- a/tests/integration/test_keeper_nodes_add/test.py
+++ b/tests/integration/test_keeper_nodes_add/test.py
@@ -3,13 +3,10 @@
 import pytest
 from helpers.cluster import ClickHouseCluster
 import helpers.keeper_utils as keeper_utils
-import random
-import string
 import os
 import time
 from multiprocessing.dummy import Pool
-from helpers.test_tools import assert_eq_with_retry
-from kazoo.client import KazooClient, KazooState
+from kazoo.client import KazooClient
 
 cluster = ClickHouseCluster(__file__)
 CONFIG_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "configs")

--- a/tests/integration/test_keeper_nodes_move/test.py
+++ b/tests/integration/test_keeper_nodes_move/test.py
@@ -5,14 +5,11 @@
 
 import pytest
 from helpers.cluster import ClickHouseCluster
-import random
-import string
 import os
 import time
 from multiprocessing.dummy import Pool
-from helpers.test_tools import assert_eq_with_retry
 import helpers.keeper_utils as keeper_utils
-from kazoo.client import KazooClient, KazooState
+from kazoo.client import KazooClient
 
 cluster = ClickHouseCluster(__file__)
 CONFIG_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "configs")

--- a/tests/integration/test_keeper_nodes_remove/test.py
+++ b/tests/integration/test_keeper_nodes_remove/test.py
@@ -4,7 +4,7 @@ import pytest
 from helpers.cluster import ClickHouseCluster
 import time
 import os
-from kazoo.client import KazooClient, KazooState
+from kazoo.client import KazooClient
 
 cluster = ClickHouseCluster(__file__)
 CONFIG_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "configs")

--- a/tests/integration/test_keeper_persistent_log/test.py
+++ b/tests/integration/test_keeper_persistent_log/test.py
@@ -1,12 +1,11 @@
 #!/usr/bin/env python3
+
 import pytest
-from helpers.cluster import ClickHouseCluster
 import random
 import string
 import os
-import time
-from kazoo.client import KazooClient, KazooState
-
+from helpers.cluster import ClickHouseCluster
+from kazoo.client import KazooClient
 
 cluster = ClickHouseCluster(__file__)
 
@@ -94,7 +93,7 @@ def test_state_after_restart(started_cluster):
             if node_zk2 is not None:
                 node_zk2.stop()
                 node_zk2.close()
-        except:
+        except Exception:
             pass
 
 
@@ -156,8 +155,7 @@ def test_state_duplicate_restart(started_cluster):
             if node_zk3 is not None:
                 node_zk3.stop()
                 node_zk3.close()
-
-        except:
+        except Exception:
             pass
 
 
@@ -209,5 +207,5 @@ def test_ephemeral_after_restart(started_cluster):
             if node_zk2 is not None:
                 node_zk2.stop()
                 node_zk2.close()
-        except:
+        except Exception:
             pass

--- a/tests/integration/test_keeper_persistent_log_multinode/test.py
+++ b/tests/integration/test_keeper_persistent_log_multinode/test.py
@@ -1,13 +1,12 @@
 #!/usr/bin/env python3
+
 import pytest
-from helpers.cluster import ClickHouseCluster
 import helpers.keeper_utils as keeper_utils
-import random
-import string
-import os
-import time
+from helpers.cluster import ClickHouseCluster
+from kazoo.client import KazooClient
 
 cluster = ClickHouseCluster(__file__)
+
 node1 = cluster.add_instance(
     "node1",
     main_configs=["configs/enable_keeper1.xml", "configs/use_keeper.xml"],
@@ -23,8 +22,6 @@ node3 = cluster.add_instance(
     main_configs=["configs/enable_keeper3.xml", "configs/use_keeper.xml"],
     stay_alive=True,
 )
-
-from kazoo.client import KazooClient, KazooState
 
 
 def wait_nodes():
@@ -56,7 +53,7 @@ def stop_zk(zk):
         if zk:
             zk.stop()
             zk.close()
-    except:
+    except Exception:
         pass
 
 

--- a/tests/integration/test_keeper_restore_from_snapshot/test.py
+++ b/tests/integration/test_keeper_restore_from_snapshot/test.py
@@ -1,13 +1,12 @@
 #!/usr/bin/env python3
+
 import pytest
-from helpers.cluster import ClickHouseCluster
 import helpers.keeper_utils as keeper_utils
-import random
-import string
-import os
-import time
+from helpers.cluster import ClickHouseCluster
+from kazoo.client import KazooClient
 
 cluster = ClickHouseCluster(__file__)
+
 node1 = cluster.add_instance(
     "node1", main_configs=["configs/enable_keeper1.xml"], stay_alive=True
 )
@@ -17,8 +16,6 @@ node2 = cluster.add_instance(
 node3 = cluster.add_instance(
     "node3", main_configs=["configs/enable_keeper3.xml"], stay_alive=True
 )
-
-from kazoo.client import KazooClient, KazooState
 
 
 @pytest.fixture(scope="module")
@@ -45,7 +42,7 @@ def stop_zk(zk):
         if zk:
             zk.stop()
             zk.close()
-    except:
+    except Exception:
         pass
 
 
@@ -77,7 +74,6 @@ def test_recover_from_snapshot(started_cluster):
         for i in range(435):
             if i % 10 == 0:
                 node1_zk.delete("/test_snapshot_multinode_recover" + str(i))
-
     finally:
         for zk in [node1_zk, node2_zk, node3_zk]:
             stop_zk(zk)

--- a/tests/integration/test_keeper_s3_snapshot/test.py
+++ b/tests/integration/test_keeper_s3_snapshot/test.py
@@ -1,12 +1,12 @@
-import pytest
-from helpers.cluster import ClickHouseCluster
-from time import sleep
+#!/usr/bin/env python3
 
+import pytest
+from time import sleep
+from helpers.cluster import ClickHouseCluster
 from kazoo.client import KazooClient
 
-# from kazoo.protocol.serialization import Connect, read_buffer, write_buffer
-
 cluster = ClickHouseCluster(__file__)
+
 node1 = cluster.add_instance(
     "node1",
     main_configs=["configs/keeper_config1.xml"],
@@ -53,7 +53,7 @@ def destroy_zk_client(zk):
         if zk:
             zk.stop()
             zk.close()
-    except:
+    except Exception:
         pass
 
 

--- a/tests/integration/test_keeper_secure_client/test.py
+++ b/tests/integration/test_keeper_secure_client/test.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python3
+
 import pytest
 from helpers.cluster import ClickHouseCluster
-import string
-import os
-import time
 
 cluster = ClickHouseCluster(__file__)
+
 node1 = cluster.add_instance(
     "node1",
     main_configs=[

--- a/tests/integration/test_keeper_session/test.py
+++ b/tests/integration/test_keeper_session/test.py
@@ -1,15 +1,14 @@
+#!/usr/bin/env python3
+
 import pytest
-from helpers.cluster import ClickHouseCluster
-import helpers.keeper_utils as keeper_utils
-import time
 import socket
 import struct
-
+import helpers.keeper_utils as keeper_utils
+from helpers.cluster import ClickHouseCluster
 from kazoo.client import KazooClient
 
-# from kazoo.protocol.serialization import Connect, read_buffer, write_buffer
-
 cluster = ClickHouseCluster(__file__)
+
 node1 = cluster.add_instance(
     "node1", main_configs=["configs/keeper_config1.xml"], stay_alive=True
 )
@@ -49,7 +48,7 @@ def destroy_zk_client(zk):
         if zk:
             zk.stop()
             zk.close()
-    except:
+    except Exception:
         pass
 
 
@@ -168,11 +167,11 @@ def test_session_close_shutdown(started_cluster):
     eph_node = "/test_node"
     node2_zk.create(eph_node, ephemeral=True)
     node1_zk.sync(eph_node)
-    assert node1_zk.exists(eph_node) != None
+    assert node1_zk.exists(eph_node) is not None
 
     # shutdown while session is active
     node2.stop_clickhouse()
 
-    assert node1_zk.exists(eph_node) == None
+    assert node1_zk.exists(eph_node) is None
 
     node2.start_clickhouse()

--- a/tests/integration/test_keeper_snapshot_small_distance/test.py
+++ b/tests/integration/test_keeper_snapshot_small_distance/test.py
@@ -7,7 +7,6 @@ from multiprocessing.dummy import Pool
 from kazoo.client import KazooClient, KazooRetry
 from kazoo.handlers.threading import KazooTimeoutError
 import random
-import string
 import os
 import time
 
@@ -30,7 +29,7 @@ def start_zookeeper(node):
 def stop_zookeeper(node):
     node.exec_in_container(["bash", "-c", "/opt/zookeeper/bin/zkServer.sh stop"])
     timeout = time.time() + 60
-    while node.get_process_pid("zookeeper") != None:
+    while node.get_process_pid("zookeeper") is not None:
         if time.time() > timeout:
             raise Exception("Failed to stop ZooKeeper in 60 secs")
         time.sleep(0.2)

--- a/tests/integration/test_keeper_snapshots/test.py
+++ b/tests/integration/test_keeper_snapshots/test.py
@@ -1,15 +1,12 @@
 #!/usr/bin/env python3
 
-#!/usr/bin/env python3
 import pytest
-from helpers.cluster import ClickHouseCluster
-import helpers.keeper_utils as keeper_utils
 import random
 import string
 import os
-import time
-from kazoo.client import KazooClient, KazooState
-
+import helpers.keeper_utils as keeper_utils
+from helpers.cluster import ClickHouseCluster
+from kazoo.client import KazooClient
 
 cluster = ClickHouseCluster(__file__)
 
@@ -104,7 +101,7 @@ def test_state_after_restart(started_cluster):
             if node_zk2 is not None:
                 node_zk2.stop()
                 node_zk2.close()
-        except:
+        except Exception:
             pass
 
 
@@ -159,5 +156,5 @@ def test_ephemeral_after_restart(started_cluster):
             if node_zk2 is not None:
                 node_zk2.stop()
                 node_zk2.close()
-        except:
+        except Exception:
             pass

--- a/tests/integration/test_keeper_snapshots_multinode/test.py
+++ b/tests/integration/test_keeper_snapshots_multinode/test.py
@@ -1,13 +1,12 @@
 #!/usr/bin/env python3
+
 import pytest
-from helpers.cluster import ClickHouseCluster
 import helpers.keeper_utils as keeper_utils
-import random
-import string
-import os
-import time
+from helpers.cluster import ClickHouseCluster
+from kazoo.client import KazooClient
 
 cluster = ClickHouseCluster(__file__)
+
 node1 = cluster.add_instance(
     "node1", main_configs=["configs/enable_keeper1.xml"], stay_alive=True
 )
@@ -17,8 +16,6 @@ node2 = cluster.add_instance(
 node3 = cluster.add_instance(
     "node3", main_configs=["configs/enable_keeper3.xml"], stay_alive=True
 )
-
-from kazoo.client import KazooClient, KazooState
 
 
 def wait_nodes():
@@ -49,7 +46,7 @@ def stop_zk(zk):
         if zk:
             zk.stop()
             zk.close()
-    except:
+    except Exception:
         pass
 
 

--- a/tests/integration/test_keeper_three_nodes_start/test.py
+++ b/tests/integration/test_keeper_three_nodes_start/test.py
@@ -1,15 +1,8 @@
 #!/usr/bin/env python3
 
 #!/usr/bin/env python3
-import pytest
 from helpers.cluster import ClickHouseCluster
-import random
-import string
-import os
-import time
-from multiprocessing.dummy import Pool
-from helpers.test_tools import assert_eq_with_retry
-from kazoo.client import KazooClient, KazooState
+from kazoo.client import KazooClient
 
 cluster = ClickHouseCluster(__file__)
 node1 = cluster.add_instance(

--- a/tests/integration/test_keeper_three_nodes_two_alive/test.py
+++ b/tests/integration/test_keeper_three_nodes_two_alive/test.py
@@ -1,16 +1,14 @@
 #!/usr/bin/env python3
+
 import pytest
-from helpers.cluster import ClickHouseCluster
-import helpers.keeper_utils as keeper_utils
-import random
-import string
-import os
 import time
+import helpers.keeper_utils as keeper_utils
+from helpers.cluster import ClickHouseCluster
 from multiprocessing.dummy import Pool
-from helpers.test_tools import assert_eq_with_retry
-from kazoo.client import KazooClient, KazooState
+from kazoo.client import KazooClient
 
 cluster = ClickHouseCluster(__file__)
+
 node1 = cluster.add_instance(
     "node1",
     main_configs=["configs/enable_keeper1.xml", "configs/keeper_conf.xml"],
@@ -59,7 +57,7 @@ def delete_with_retry(node_name, path):
             zk = get_fake_zk(node_name)
             zk.delete(path)
             return
-        except:
+        except Exception:
             time.sleep(0.5)
         finally:
             zk.stop()

--- a/tests/integration/test_keeper_two_nodes_cluster/test.py
+++ b/tests/integration/test_keeper_two_nodes_cluster/test.py
@@ -1,17 +1,14 @@
 #!/usr/bin/env python3
 
 import pytest
-from helpers.cluster import ClickHouseCluster
-import helpers.keeper_utils as keeper_utils
-import random
-import string
-import os
 import time
-from multiprocessing.dummy import Pool
+import helpers.keeper_utils as keeper_utils
+from helpers.cluster import ClickHouseCluster
 from helpers.network import PartitionManager
-from helpers.test_tools import assert_eq_with_retry
+from kazoo.client import KazooClient
 
 cluster = ClickHouseCluster(__file__)
+
 node1 = cluster.add_instance(
     "node1",
     main_configs=["configs/enable_keeper1.xml", "configs/use_keeper.xml"],
@@ -22,8 +19,6 @@ node2 = cluster.add_instance(
     main_configs=["configs/enable_keeper2.xml", "configs/use_keeper.xml"],
     stay_alive=True,
 )
-
-from kazoo.client import KazooClient, KazooState
 
 
 @pytest.fixture(scope="module")
@@ -81,7 +76,7 @@ def test_read_write_two_nodes(started_cluster):
             for zk_conn in [node1_zk, node2_zk]:
                 zk_conn.stop()
                 zk_conn.close()
-        except:
+        except Exception:
             pass
 
 
@@ -110,14 +105,14 @@ def test_read_write_two_nodes_with_blocade(started_cluster):
                 node1_zk = get_fake_zk("node1")
                 node2_zk = get_fake_zk("node2")
                 break
-            except:
+            except Exception:
                 time.sleep(0.5)
 
         for i in range(100):
             try:
                 node1_zk.create("/test_after_block1", b"somedata12")
                 break
-            except:
+            except Exception:
                 time.sleep(0.1)
         else:
             raise Exception("node1 cannot recover after blockade")
@@ -128,7 +123,7 @@ def test_read_write_two_nodes_with_blocade(started_cluster):
             try:
                 node2_zk.create("/test_after_block2", b"somedata12")
                 break
-            except:
+            except Exception:
                 time.sleep(0.1)
         else:
             raise Exception("node2 cannot recover after blockade")
@@ -153,5 +148,5 @@ def test_read_write_two_nodes_with_blocade(started_cluster):
             for zk_conn in [node1_zk, node2_zk]:
                 zk_conn.stop()
                 zk_conn.close()
-        except:
+        except Exception:
             pass

--- a/tests/integration/test_keeper_znode_time/test.py
+++ b/tests/integration/test_keeper_znode_time/test.py
@@ -1,14 +1,12 @@
+#!/usr/bin/env python3
+
 import pytest
-from helpers.cluster import ClickHouseCluster
 import helpers.keeper_utils as keeper_utils
-import random
-import string
-import os
-import time
-from multiprocessing.dummy import Pool
-from helpers.test_tools import assert_eq_with_retry
+from helpers.cluster import ClickHouseCluster
+from kazoo.client import KazooClient
 
 cluster = ClickHouseCluster(__file__)
+
 node1 = cluster.add_instance(
     "node1",
     main_configs=["configs/enable_keeper1.xml", "configs/use_keeper.xml"],
@@ -24,8 +22,6 @@ node3 = cluster.add_instance(
     main_configs=["configs/enable_keeper3.xml", "configs/use_keeper.xml"],
     stay_alive=True,
 )
-
-from kazoo.client import KazooClient, KazooState
 
 
 @pytest.fixture(scope="module")
@@ -92,7 +88,7 @@ def test_between_servers(started_cluster):
             for zk_conn in [node1_zk, node2_zk, node3_zk]:
                 zk_conn.stop()
                 zk_conn.close()
-        except:
+        except Exception:
             pass
 
 
@@ -125,5 +121,5 @@ def test_server_restart(started_cluster):
             for zk_conn in [node1_zk, node2_zk, node3_zk]:
                 zk_conn.stop()
                 zk_conn.close()
-        except:
+        except Exception:
             pass

--- a/tests/integration/test_keeper_zookeeper_converter/test.py
+++ b/tests/integration/test_keeper_zookeeper_converter/test.py
@@ -25,7 +25,7 @@ def start_zookeeper():
 def stop_zookeeper():
     node.exec_in_container(["bash", "-c", "/opt/zookeeper/bin/zkServer.sh stop"])
     timeout = time.time() + 60
-    while node.get_process_pid("zookeeper") != None:
+    while node.get_process_pid("zookeeper") is not None:
         if time.time() > timeout:
             raise Exception("Failed to stop ZooKeeper in 60 secs")
         time.sleep(0.2)

--- a/tests/integration/test_library_bridge/test.py
+++ b/tests/integration/test_library_bridge/test.py
@@ -1,10 +1,8 @@
-import os
-import os.path as p
-import pytest
-import time
-import logging
+#!/usr/bin/env python3
 
-from helpers.cluster import ClickHouseCluster, run_and_check
+import os
+import pytest
+from helpers.cluster import ClickHouseCluster
 
 cluster = ClickHouseCluster(__file__)
 
@@ -38,9 +36,6 @@ def ch_cluster():
     try:
         cluster.start()
         instance.query("CREATE DATABASE test")
-        container_lib_path = (
-            "/etc/clickhouse-server/config.d/dictionarites_lib/dict_lib.cpp"
-        )
 
         instance.copy_file_to_container(
             os.path.join(

--- a/tests/integration/test_library_bridge/test_exiled.py
+++ b/tests/integration/test_library_bridge/test_exiled.py
@@ -1,10 +1,10 @@
+#!/usr/bin/env python3
+
 import os
-import os.path as p
 import pytest
 import time
 import logging
-
-from helpers.cluster import ClickHouseCluster, run_and_check
+from helpers.cluster import ClickHouseCluster
 from test_library_bridge.test import create_dict_simple
 
 cluster = ClickHouseCluster(__file__)
@@ -67,7 +67,7 @@ def test_bridge_dies_with_parent(ch_cluster):
         instance.exec_in_container(
             ["kill", str(clickhouse_pid)], privileged=True, user="root"
         )
-    except:
+    except Exception:
         pass
 
     for i in range(30):

--- a/tests/integration/test_log_family_hdfs/test.py
+++ b/tests/integration/test_log_family_hdfs/test.py
@@ -1,5 +1,4 @@
 import logging
-import sys
 
 import pytest
 from helpers.cluster import ClickHouseCluster

--- a/tests/integration/test_log_family_s3/test.py
+++ b/tests/integration/test_log_family_s3/test.py
@@ -1,5 +1,4 @@
 import logging
-import sys
 
 import pytest
 from helpers.cluster import ClickHouseCluster

--- a/tests/integration/test_log_lz4_streaming/test.py
+++ b/tests/integration/test_log_lz4_streaming/test.py
@@ -1,5 +1,4 @@
 import pytest
-import time
 
 from helpers.cluster import ClickHouseCluster
 

--- a/tests/integration/test_mask_sensitive_info/test.py
+++ b/tests/integration/test_mask_sensitive_info/test.py
@@ -1,9 +1,13 @@
+#!/usr/bin/env python3
+
 import pytest
-import random, string
+import random
+import string
 from helpers.cluster import ClickHouseCluster
 from helpers.test_tools import TSV
 
 cluster = ClickHouseCluster(__file__)
+
 node = cluster.add_instance(
     "node",
     main_configs=[
@@ -134,14 +138,14 @@ def test_create_table():
         f"MySQL('mysql57:3306', 'mysql_db', 'mysql_table', 'mysql_user', '{password}')",
         f"PostgreSQL('postgres1:5432', 'postgres_db', 'postgres_table', 'postgres_user', '{password}')",
         f"MongoDB('mongo1:27017', 'mongo_db', 'mongo_col', 'mongo_user', '{password}')",
-        f"S3('http://minio1:9001/root/data/test1.csv')",
-        f"S3('http://minio1:9001/root/data/test2.csv', 'CSV')",
-        f"S3('http://minio1:9001/root/data/test3.csv.gz', 'CSV', 'gzip')",
+        "S3('http://minio1:9001/root/data/test1.csv')",
+        "S3('http://minio1:9001/root/data/test2.csv', 'CSV')",
+        "S3('http://minio1:9001/root/data/test3.csv.gz', 'CSV', 'gzip')",
         f"S3('http://minio1:9001/root/data/test4.csv', 'minio', '{password}', 'CSV')",
         f"S3('http://minio1:9001/root/data/test5.csv.gz', 'minio', '{password}', 'CSV', 'gzip')",
         f"MySQL(named_collection_1, host = 'mysql57', port = 3306, database = 'mysql_db', table = 'mysql_table', user = 'mysql_user', password = '{password}')",
         f"MySQL(named_collection_2, database = 'mysql_db', host = 'mysql57', port = 3306, password = '{password}', table = 'mysql_table', user = 'mysql_user')",
-        f"MySQL(named_collection_3, database = 'mysql_db', host = 'mysql57', port = 3306, table = 'mysql_table')",
+        "MySQL(named_collection_3, database = 'mysql_db', host = 'mysql57', port = 3306, table = 'mysql_table')",
         f"PostgreSQL(named_collection_4, host = 'postgres1', port = 5432, database = 'postgres_db', table = 'postgres_table', user = 'postgres_user', password = '{password}')",
         f"MongoDB(named_collection_5, host = 'mongo1', port = 5432, db = 'mongo_db', collection = 'mongo_col', user = 'mongo_user', password = '{password}')",
         f"S3(named_collection_6, url = 'http://minio1:9001/root/data/test8.csv', access_key_id = 'minio', secret_access_key = '{password}', format = 'CSV')",
@@ -232,28 +236,28 @@ def test_table_functions():
         f"mysql('mysql57:3306', 'mysql_db', 'mysql_table', 'mysql_user', '{password}')",
         f"postgresql('postgres1:5432', 'postgres_db', 'postgres_table', 'postgres_user', '{password}')",
         f"mongodb('mongo1:27017', 'mongo_db', 'mongo_col', 'mongo_user', '{password}', 'x int')",
-        f"s3('http://minio1:9001/root/data/test1.csv')",
-        f"s3('http://minio1:9001/root/data/test2.csv', 'CSV')",
+        "s3('http://minio1:9001/root/data/test1.csv')",
+        "s3('http://minio1:9001/root/data/test2.csv', 'CSV')",
         f"s3('http://minio1:9001/root/data/test3.csv', 'minio', '{password}')",
-        f"s3('http://minio1:9001/root/data/test4.csv', 'CSV', 'x int')",
-        f"s3('http://minio1:9001/root/data/test5.csv.gz', 'CSV', 'x int', 'gzip')",
+        "s3('http://minio1:9001/root/data/test4.csv', 'CSV', 'x int')",
+        "s3('http://minio1:9001/root/data/test5.csv.gz', 'CSV', 'x int', 'gzip')",
         f"s3('http://minio1:9001/root/data/test6.csv', 'minio', '{password}', 'CSV')",
         f"s3('http://minio1:9001/root/data/test7.csv', 'minio', '{password}', 'CSV', 'x int')",
         f"s3('http://minio1:9001/root/data/test8.csv.gz', 'minio', '{password}', 'CSV', 'x int', 'gzip')",
         f"s3Cluster('test_shard_localhost', 'http://minio1:9001/root/data/test1.csv', 'minio', '{password}')",
-        f"s3Cluster('test_shard_localhost', 'http://minio1:9001/root/data/test2.csv', 'CSV', 'x int')",
+        "s3Cluster('test_shard_localhost', 'http://minio1:9001/root/data/test2.csv', 'CSV', 'x int')",
         f"s3Cluster('test_shard_localhost', 'http://minio1:9001/root/data/test3.csv', 'minio', '{password}', 'CSV')",
-        f"remote('127.{{2..11}}', default.remote_table)",
-        f"remote('127.{{2..11}}', default.remote_table, rand())",
-        f"remote('127.{{2..11}}', default.remote_table, 'remote_user')",
+        "remote('127.{2..11}', default.remote_table)",
+        "remote('127.{2..11}', default.remote_table, rand())",
+        "remote('127.{2..11}', default.remote_table, 'remote_user')",
         f"remote('127.{{2..11}}', default.remote_table, 'remote_user', '{password}')",
-        f"remote('127.{{2..11}}', default.remote_table, 'remote_user', rand())",
+        "remote('127.{2..11}', default.remote_table, 'remote_user', rand())",
         f"remote('127.{{2..11}}', default.remote_table, 'remote_user', '{password}', rand())",
         f"remote('127.{{2..11}}', 'default.remote_table', 'remote_user', '{password}', rand())",
         f"remote('127.{{2..11}}', 'default', 'remote_table', 'remote_user', '{password}', rand())",
         f"remote('127.{{2..11}}', numbers(10), 'remote_user', '{password}', rand())",
         f"remoteSecure('127.{{2..11}}', 'default', 'remote_table', 'remote_user', '{password}')",
-        f"remoteSecure('127.{{2..11}}', 'default', 'remote_table', 'remote_user', rand())",
+        "remoteSecure('127.{2..11}', 'default', 'remote_table', 'remote_user', rand())",
         f"mysql(named_collection_1, host = 'mysql57', port = 3306, database = 'mysql_db', table = 'mysql_table', user = 'mysql_user', password = '{password}')",
         f"postgresql(named_collection_2, password = '{password}', host = 'postgres1', port = 5432, database = 'postgres_db', table = 'postgres_table', user = 'postgres_user')",
         f"s3(named_collection_2, url = 'http://minio1:9001/root/data/test4.csv', access_key_id = 'minio', secret_access_key = '{password}')",

--- a/tests/integration/test_materialized_mysql_database/materialize_with_ddl.py
+++ b/tests/integration/test_materialized_mysql_database/materialize_with_ddl.py
@@ -5,11 +5,8 @@ import pytest
 from helpers.network import PartitionManager
 import logging
 from helpers.client import QueryRuntimeException
-from helpers.cluster import get_docker_compose_path, run_and_check
-import random
 
 import threading
-from multiprocessing.dummy import Pool
 from helpers.test_tools import assert_eq_with_retry
 
 
@@ -1348,7 +1345,7 @@ def mysql_killed_while_insert(clickhouse_node, mysql_node, service_name):
 
         clickhouse_node.cluster.restart_service(service_name)
     finally:
-        with pytest.raises(QueryRuntimeException) as exception:
+        with pytest.raises(QueryRuntimeException):
             time.sleep(2)
             clickhouse_node.query("SELECT count() FROM kill_mysql_while_insert.test")
 

--- a/tests/integration/test_materialized_mysql_database/test.py
+++ b/tests/integration/test_materialized_mysql_database/test.py
@@ -1,17 +1,11 @@
-import os
-import os.path as p
 import time
-import pwd
-import re
 import pymysql.cursors
 import pytest
 from helpers.cluster import (
     ClickHouseCluster,
     ClickHouseInstance,
     get_docker_compose_path,
-    run_and_check,
 )
-import docker
 import logging
 
 from . import materialize_with_ddl

--- a/tests/integration/test_merge_tree_azure_blob_storage/test.py
+++ b/tests/integration/test_merge_tree_azure_blob_storage/test.py
@@ -5,8 +5,7 @@ import os
 import pytest
 
 from helpers.cluster import ClickHouseCluster
-from helpers.utility import generate_values, replace_config, SafeThread
-from azure.storage.blob import BlobServiceClient
+from helpers.utility import generate_values, replace_config
 
 
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))

--- a/tests/integration/test_merge_tree_hdfs/test.py
+++ b/tests/integration/test_merge_tree_hdfs/test.py
@@ -157,7 +157,7 @@ def test_alter_table_columns(cluster):
     create_table(cluster, "hdfs_test")
 
     node = cluster.instances["node"]
-    fs = HdfsClient(hosts=cluster.hdfs_ip)
+    HdfsClient(hosts=cluster.hdfs_ip)
 
     node.query(
         "INSERT INTO hdfs_test VALUES {}".format(generate_values("2020-01-03", 4096))

--- a/tests/integration/test_merge_tree_s3/test.py
+++ b/tests/integration/test_merge_tree_s3/test.py
@@ -1,11 +1,12 @@
+#!/usr/bin/env python3
+
 import logging
 import time
 import os
-
 import pytest
 from helpers.cluster import ClickHouseCluster
 from helpers.mock_servers import start_mock_servers
-from helpers.utility import generate_values, replace_config, SafeThread
+from helpers.utility import generate_values, replace_config
 from helpers.wait_for_helpers import wait_for_delete_inactive_parts
 from helpers.wait_for_helpers import wait_for_delete_empty_parts
 from helpers.wait_for_helpers import wait_for_merges
@@ -132,7 +133,7 @@ def clear_minio(cluster):
         # CH do some writes to the S3 at start. For example, file data/clickhouse_access_check_{server_uuid}.
         # Set the timeout there as 10 sec in order to resolve the race with that file exists.
         wait_for_delete_s3_objects(cluster, 0, timeout=10)
-    except:
+    except Exception:
         # Remove extra objects to prevent tests cascade failing
         remove_all_s3_objects(cluster)
 
@@ -169,7 +170,6 @@ def test_simple_insert_select(
 ):
     node = cluster.instances[node_name]
     create_table(node, "s3_test", min_rows_for_wide_part=min_rows_for_wide_part)
-    minio = cluster.minio_client
 
     values1 = generate_values("2020-01-03", 4096)
     node.query("INSERT INTO s3_test VALUES {}".format(values1))
@@ -721,7 +721,7 @@ def test_cache_with_full_disk_space(cluster, node_name):
     node.query(
         "INSERT INTO s3_test SELECT number, toString(number) FROM numbers(100000000)"
     )
-    out = node.exec_in_container(
+    node.exec_in_container(
         [
             "/usr/bin/clickhouse",
             "benchmark",

--- a/tests/integration/test_merge_tree_s3/test.py
+++ b/tests/integration/test_merge_tree_s3/test.py
@@ -10,7 +10,6 @@ from helpers.utility import generate_values, replace_config
 from helpers.wait_for_helpers import wait_for_delete_inactive_parts
 from helpers.wait_for_helpers import wait_for_delete_empty_parts
 from helpers.wait_for_helpers import wait_for_merges
-from helpers.test_tools import assert_eq_with_retry
 
 
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
@@ -144,7 +143,7 @@ def clear_minio(cluster):
 def reset_mock_broken_s3(cluster):
     response = cluster.exec_in_container(
         cluster.get_container_id("resolver"),
-        ["curl", "-s", f"http://localhost:8083/mock_settings/reset"],
+        ["curl", "-s", "http://localhost:8083/mock_settings/reset"],
         nothrow=True,
     )
     assert response == "OK"
@@ -891,7 +890,7 @@ def test_merge_canceled_by_s3_errors(cluster, node_name):
         [
             "curl",
             "-s",
-            f"http://localhost:8083/mock_settings/error_at_put?when_length_bigger=50000",
+            "http://localhost:8083/mock_settings/error_at_put?when_length_bigger=50000",
         ],
         nothrow=True,
     )
@@ -943,7 +942,7 @@ def test_merge_canceled_by_s3_errors_when_move(cluster, node_name):
         [
             "curl",
             "-s",
-            f"http://localhost:8083/mock_settings/error_at_put?when_length_bigger=10000",
+            "http://localhost:8083/mock_settings/error_at_put?when_length_bigger=10000",
         ],
         nothrow=True,
     )

--- a/tests/integration/test_merge_tree_s3_failover/s3_endpoint/endpoint.py
+++ b/tests/integration/test_merge_tree_s3_failover/s3_endpoint/endpoint.py
@@ -21,7 +21,7 @@ def fail_request(_request_number):
 
 
 @route("/throttle_request/<_request_number>")
-def fail_request(_request_number):
+def throttle_request(_request_number):
     request_number = int(_request_number)
     if request_number > 0:
         cache["throttle_request_number"] = request_number

--- a/tests/integration/test_merge_tree_s3_failover/test.py
+++ b/tests/integration/test_merge_tree_s3_failover/test.py
@@ -1,9 +1,9 @@
+#!/usr/bin/env python3
+
 import logging
 import os
 import time
-
 import pytest
-
 from helpers.client import QueryRuntimeException
 from helpers.cluster import ClickHouseCluster
 

--- a/tests/integration/test_merge_tree_settings_constraints/test.py
+++ b/tests/integration/test_merge_tree_settings_constraints/test.py
@@ -1,10 +1,5 @@
 import pytest
-import asyncio
-import re
-import random
-import os.path
 from helpers.cluster import ClickHouseCluster
-from helpers.test_tools import assert_eq_with_retry, TSV
 
 cluster = ClickHouseCluster(__file__)
 instance = cluster.add_instance("instance", user_configs=["users.xml"])
@@ -21,27 +16,27 @@ def start_cluster():
 
 def test_merge_tree_settings_constraints():
     assert "Setting storage_policy should not be changed" in instance.query_and_get_error(
-        f"CREATE TABLE wrong_table (number Int64) engine = MergeTree() ORDER BY number SETTINGS storage_policy = 'secret_policy'"
+        "CREATE TABLE wrong_table (number Int64) engine = MergeTree() ORDER BY number SETTINGS storage_policy = 'secret_policy'"
     )
 
     expected_error = "Setting min_bytes_for_wide_part should"
 
     assert expected_error in instance.query_and_get_error(
-        f"CREATE TABLE wrong_table (number Int64) engine = MergeTree() ORDER BY number SETTINGS min_bytes_for_wide_part = 100"
+        "CREATE TABLE wrong_table (number Int64) engine = MergeTree() ORDER BY number SETTINGS min_bytes_for_wide_part = 100"
     )
 
     assert expected_error in instance.query_and_get_error(
-        f"CREATE TABLE wrong_table (number Int64) engine = MergeTree() ORDER BY number SETTINGS min_bytes_for_wide_part = 1000000000"
+        "CREATE TABLE wrong_table (number Int64) engine = MergeTree() ORDER BY number SETTINGS min_bytes_for_wide_part = 1000000000"
     )
 
     instance.query(
-        f"CREATE TABLE good_table (number Int64) engine = MergeTree() ORDER BY number SETTINGS min_bytes_for_wide_part = 10000000"
+        "CREATE TABLE good_table (number Int64) engine = MergeTree() ORDER BY number SETTINGS min_bytes_for_wide_part = 10000000"
     )
 
     assert expected_error in instance.query_and_get_error(
-        f"ALTER TABLE good_table MODIFY SETTING min_bytes_for_wide_part = 100"
+        "ALTER TABLE good_table MODIFY SETTING min_bytes_for_wide_part = 100"
     )
 
     assert expected_error in instance.query_and_get_error(
-        f"ALTER TABLE good_table MODIFY SETTING min_bytes_for_wide_part = 1000000000"
+        "ALTER TABLE good_table MODIFY SETTING min_bytes_for_wide_part = 1000000000"
     )

--- a/tests/integration/test_multiple_disks/test.py
+++ b/tests/integration/test_multiple_disks/test.py
@@ -1,12 +1,12 @@
+#!/usr/bin/env python3
+
 import json
 import random
 import re
-import string
 import threading
 import time
-from multiprocessing.dummy import Pool
-
 import pytest
+from multiprocessing.dummy import Pool
 from helpers.client import QueryRuntimeException
 from helpers.cluster import ClickHouseCluster
 
@@ -1161,7 +1161,7 @@ def produce_alter_move(node, name):
                 name, mt=move_type, mp=move_part, md=move_disk, mv=move_volume
             )
         )
-    except QueryRuntimeException as ex:
+    except QueryRuntimeException:
         pass
 
 
@@ -1495,7 +1495,7 @@ def test_concurrent_alter_modify(start_cluster, name, engine):
                             name, column_type
                         )
                     )
-                except:
+                except Exception:
                     if "Replicated" not in engine:
                         raise
 
@@ -1631,7 +1631,7 @@ def test_download_appropriate_disk(start_cluster):
                     "SYSTEM SYNC REPLICA replicated_table_for_download"
                 )
                 break
-            except:
+            except Exception:
                 time.sleep(0.5)
 
         disks2 = get_used_disks_for_table(node2, "replicated_table_for_download")
@@ -1765,7 +1765,6 @@ def test_kill_while_insert(start_cluster):
         )
 
         data = []
-        dates = []
         for i in range(10):
             data.append(get_random_string(1024 * 1024))  # 1MB value
         node1.query(
@@ -1780,7 +1779,7 @@ def test_kill_while_insert(start_cluster):
         def ignore_exceptions(f, *args):
             try:
                 f(*args)
-            except:
+            except Exception:
                 """(っಠ‿ಠ)っ"""
 
         start_time = time.time()
@@ -1802,7 +1801,7 @@ def test_kill_while_insert(start_cluster):
 
         try:
             long_select.join()
-        except:
+        except Exception:
             """"""
 
         assert node1.query(
@@ -1812,7 +1811,7 @@ def test_kill_while_insert(start_cluster):
     finally:
         try:
             node1.query(f"DROP TABLE IF EXISTS {name} SYNC")
-        except:
+        except Exception:
             """ClickHouse may be inactive at this moment and we don't want to mask a meaningful exception."""
 
 
@@ -2035,7 +2034,7 @@ def _check_merges_are_working(node, storage_policy, volume, shall_work):
                         name=name, volume=volume
                     )
                 )
-            except:
+            except Exception:
                 """Ignore 'nothing to move'."""
 
         expected_disks = set(

--- a/tests/integration/test_mutations_hardlinks/test.py
+++ b/tests/integration/test_mutations_hardlinks/test.py
@@ -1,8 +1,9 @@
+#!/usr/bin/env python3
+
 import os
 import time
-from multiprocessing.dummy import Pool
-
 import pytest
+from multiprocessing.dummy import Pool
 from helpers.cluster import ClickHouseCluster
 from helpers.test_tools import assert_eq_with_retry
 
@@ -166,7 +167,7 @@ def test_delete_and_drop_mutation(started_cluster):
         try:
             if int(result.strip()) == 2:
                 break
-        except:
+        except Exception:
             print("Result", result)
             pass
 

--- a/tests/integration/test_mutations_with_merge_tree/test.py
+++ b/tests/integration/test_mutations_with_merge_tree/test.py
@@ -224,7 +224,7 @@ def test_mutations_will_not_hang_for_non_existing_parts_sync(started_cluster):
         assert count() == [f"{numbers}"]
         assert instance_test_mutations.query(
             f"SELECT count(), sum(is_done) FROM system.mutations WHERE table = '{name}' SETTINGS force_index_by_date = 0, force_primary_key = 0 FORMAT CSV"
-        ).splitlines() == [f"34,34"]
+        ).splitlines() == ["34,34"]
 
     finally:
         instance_test_mutations.query(f"""DROP TABLE {name}""")
@@ -258,14 +258,12 @@ def test_mutations_will_not_hang_for_non_existing_parts_async(started_cluster):
                 f"SELECT count(), sum(is_done) FROM system.mutations WHERE table = '{name}' SETTINGS force_index_by_date = 0, force_primary_key = 0 FORMAT CSV"
             ).splitlines()
 
-        all_done = False
         for wait_times_for_mutation in range(
             100
         ):  # wait for replication 80 seconds max
             time.sleep(0.8)
 
             if count_and_sum_is_done() == ["34,34"]:
-                all_done = True
                 break
 
         print(

--- a/tests/integration/test_mutations_with_projection/test.py
+++ b/tests/integration/test_mutations_with_projection/test.py
@@ -81,8 +81,8 @@ def test_mutations_with_multi_level_merge_of_projections(started_cluster):
 
         assert (count_and_changed(), all_done) == (["500000,500000"], True)
         assert instance_test_mutations.query(
-            f"SELECT DISTINCT arraySort(projections) FROM system.parts WHERE table = 'video_log' SETTINGS force_index_by_date = 0, force_primary_key = 0 FORMAT TSVRaw"
+            "SELECT DISTINCT arraySort(projections) FROM system.parts WHERE table = 'video_log' SETTINGS force_index_by_date = 0, force_primary_key = 0 FORMAT TSVRaw"
         ).splitlines() == ["['p_agg','p_norm']"]
 
     finally:
-        instance_test_mutations.query(f"""DROP TABLE video_log""")
+        instance_test_mutations.query("""DROP TABLE video_log""")

--- a/tests/integration/test_mysql_protocol/test.py
+++ b/tests/integration/test_mysql_protocol/test.py
@@ -502,8 +502,7 @@ def test_mysql_federated(started_cluster):
             mysql
             -e "CREATE TABLE mysql_federated.test(`col` int UNSIGNED) ENGINE=FEDERATED CONNECTION='clickhouse';"
             -e "SELECT * FROM mysql_federated.test ORDER BY col;"
-        """.format(
-                ),
+        """.format(),
             demux=True,
         )
 
@@ -522,8 +521,7 @@ def test_mysql_federated(started_cluster):
             mysql
             -e "INSERT INTO mysql_federated.test VALUES (0), (1), (5);"
             -e "SELECT * FROM mysql_federated.test ORDER BY col;"
-        """.format(
-                ),
+        """.format(),
             demux=True,
         )
 

--- a/tests/integration/test_mysql_protocol/test.py
+++ b/tests/integration/test_mysql_protocol/test.py
@@ -10,7 +10,6 @@ import logging
 import docker
 import pymysql.connections
 import pytest
-from docker.models.containers import Container
 from helpers.cluster import ClickHouseCluster, get_docker_compose_path, run_and_check
 
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
@@ -504,8 +503,7 @@ def test_mysql_federated(started_cluster):
             -e "CREATE TABLE mysql_federated.test(`col` int UNSIGNED) ENGINE=FEDERATED CONNECTION='clickhouse';"
             -e "SELECT * FROM mysql_federated.test ORDER BY col;"
         """.format(
-                host=started_cluster.get_instance_ip("node"), port=server_port
-            ),
+                ),
             demux=True,
         )
 
@@ -525,8 +523,7 @@ def test_mysql_federated(started_cluster):
             -e "INSERT INTO mysql_federated.test VALUES (0), (1), (5);"
             -e "SELECT * FROM mysql_federated.test ORDER BY col;"
         """.format(
-                host=started_cluster.get_instance_ip("node"), port=server_port
-            ),
+                ),
             demux=True,
         )
 

--- a/tests/integration/test_named_collections/test.py
+++ b/tests/integration/test_named_collections/test.py
@@ -1,7 +1,6 @@
 import logging
 import pytest
 import os
-import time
 from helpers.cluster import ClickHouseCluster
 
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
@@ -87,7 +86,7 @@ def test_default_access(cluster):
         node, "named_collection_control>1", "named_collection_control>0"
     )
     assert "named_collection_control>0" in node.exec_in_container(
-        ["bash", "-c", f"cat /etc/clickhouse-server/users.d/users.xml"]
+        ["bash", "-c", "cat /etc/clickhouse-server/users.d/users.xml"]
     )
     node.restart_clickhouse()
     assert 0 == int(node.query("select count() from system.named_collections"))
@@ -96,7 +95,7 @@ def test_default_access(cluster):
         node, "named_collection_control>0", "named_collection_control>1"
     )
     assert "named_collection_control>1" in node.exec_in_container(
-        ["bash", "-c", f"cat /etc/clickhouse-server/users.d/users.xml"]
+        ["bash", "-c", "cat /etc/clickhouse-server/users.d/users.xml"]
     )
     node.restart_clickhouse()
     assert (
@@ -109,7 +108,7 @@ def test_default_access(cluster):
         node, "show_named_collections_secrets>1", "show_named_collections_secrets>0"
     )
     assert "show_named_collections_secrets>0" in node.exec_in_container(
-        ["bash", "-c", f"cat /etc/clickhouse-server/users.d/users.xml"]
+        ["bash", "-c", "cat /etc/clickhouse-server/users.d/users.xml"]
     )
     node.restart_clickhouse()
     assert (
@@ -122,7 +121,7 @@ def test_default_access(cluster):
         node, "show_named_collections_secrets>0", "show_named_collections_secrets>1"
     )
     assert "show_named_collections_secrets>1" in node.exec_in_container(
-        ["bash", "-c", f"cat /etc/clickhouse-server/users.d/users.xml"]
+        ["bash", "-c", "cat /etc/clickhouse-server/users.d/users.xml"]
     )
     node.restart_clickhouse()
     assert (

--- a/tests/integration/test_odbc_interaction/test.py
+++ b/tests/integration/test_odbc_interaction/test.py
@@ -858,9 +858,7 @@ def test_concurrent_queries(started_cluster):
                 "INSERT INTO test_pg_table SELECT number, number FROM numbers(1000)",
                 user="default",
             )
-            node1.query(
-                "SELECT * FROM test_pg_table LIMIT 100", user="default"
-            )
+            node1.query("SELECT * FROM test_pg_table LIMIT 100", user="default")
 
     busy_pool = Pool(5)
     p = busy_pool.map_async(node_insert_select, range(5))

--- a/tests/integration/test_odbc_interaction/test.py
+++ b/tests/integration/test_odbc_interaction/test.py
@@ -1,16 +1,15 @@
 import time
-
 import psycopg2
 import pymysql.cursors
 import pytest
 import logging
-
 from helpers.cluster import ClickHouseCluster
 from helpers.test_tools import assert_eq_with_retry
 from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
 from multiprocessing.dummy import Pool
 
 cluster = ClickHouseCluster(__file__)
+
 node1 = cluster.add_instance(
     "node1",
     with_odbc_drivers=True,
@@ -855,11 +854,11 @@ def test_concurrent_queries(started_cluster):
 
     def node_insert_select(_):
         for i in range(5):
-            result = node1.query(
+            node1.query(
                 "INSERT INTO test_pg_table SELECT number, number FROM numbers(1000)",
                 user="default",
             )
-            result = node1.query(
+            node1.query(
                 "SELECT * FROM test_pg_table LIMIT 100", user="default"
             )
 

--- a/tests/integration/test_odbc_interaction/test_exiled.py
+++ b/tests/integration/test_odbc_interaction/test_exiled.py
@@ -1,17 +1,14 @@
 import time
 import logging
 import pytest
-
 from helpers.cluster import ClickHouseCluster, assert_eq_with_retry
 from test_odbc_interaction.test import (
-    create_mysql_db,
-    create_mysql_table,
-    get_mysql_conn,
     skip_test_msan,
 )
 
 
 cluster = ClickHouseCluster(__file__)
+
 node1 = cluster.add_instance(
     "node1",
     with_odbc_drivers=True,
@@ -81,7 +78,7 @@ def test_bridge_dies_with_parent(started_cluster):
         node1.exec_in_container(
             ["kill", str(clickhouse_pid)], privileged=True, user="root"
         )
-    except:
+    except Exception:
         pass
 
     for _ in range(30):

--- a/tests/integration/test_old_parts_finally_removed/test.py
+++ b/tests/integration/test_old_parts_finally_removed/test.py
@@ -3,7 +3,6 @@
 import os
 import time
 
-import helpers.client as client
 import pytest
 from helpers.cluster import ClickHouseCluster
 

--- a/tests/integration/test_optimize_on_insert/test.py
+++ b/tests/integration/test_optimize_on_insert/test.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 import pytest
-from helpers.client import QueryRuntimeException
 from helpers.cluster import ClickHouseCluster
 
 cluster = ClickHouseCluster(__file__)

--- a/tests/integration/test_overcommit_tracker/test.py
+++ b/tests/integration/test_overcommit_tracker/test.py
@@ -37,11 +37,10 @@ def test_user_overcommit():
         else:
             responses_B.append(node.get_query_request(USER_TEST_QUERY_B, user="A"))
 
-    overcommited_killed = False
     for response in responses_A:
         _, err = response.get_answer_and_error()
         if "MEMORY_LIMIT_EXCEEDED" in err:
-            overcommited_killed = True
+            pass
     finished = False
     for response in responses_B:
         _, err = response.get_answer_and_error()

--- a/tests/integration/test_partition/test.py
+++ b/tests/integration/test_partition/test.py
@@ -1,5 +1,4 @@
 import pytest
-import logging
 from helpers.cluster import ClickHouseCluster
 from helpers.test_tools import TSV
 from helpers.test_tools import assert_eq_with_retry

--- a/tests/integration/test_polymorphic_parts/test.py
+++ b/tests/integration/test_polymorphic_parts/test.py
@@ -417,8 +417,6 @@ def start_cluster_diff_versions():
 def test_polymorphic_parts_diff_versions(start_cluster_diff_versions):
     # Check that replication with Wide parts works between different versions.
 
-    node_old = node7
-    node_new = node8
 
     insert_random_data("polymorphic_table", node7, 100)
     node8.query("SYSTEM SYNC REPLICA polymorphic_table", timeout=20)

--- a/tests/integration/test_polymorphic_parts/test.py
+++ b/tests/integration/test_polymorphic_parts/test.py
@@ -6,7 +6,6 @@ import struct
 import pytest
 from helpers.cluster import ClickHouseCluster
 from helpers.test_tools import TSV
-from helpers.test_tools import assert_eq_with_retry, exec_query_with_retry
 
 cluster = ClickHouseCluster(__file__)
 
@@ -416,7 +415,6 @@ def start_cluster_diff_versions():
 @pytest.mark.skip(reason="compatability is temporary broken")
 def test_polymorphic_parts_diff_versions(start_cluster_diff_versions):
     # Check that replication with Wide parts works between different versions.
-
 
     insert_random_data("polymorphic_table", node7, 100)
     node8.query("SYSTEM SYNC REPLICA polymorphic_table", timeout=20)

--- a/tests/integration/test_postgresql_database_engine/test.py
+++ b/tests/integration/test_postgresql_database_engine/test.py
@@ -1,10 +1,7 @@
 import pytest
-import psycopg2
 
 from helpers.cluster import ClickHouseCluster
-from helpers.test_tools import assert_eq_with_retry
 from helpers.postgres_utility import get_postgres_conn
-from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
 
 cluster = ClickHouseCluster(__file__)
 node1 = cluster.add_instance(
@@ -273,8 +270,8 @@ def test_postgresql_database_with_schema(started_cluster):
 
 def test_predefined_connection_configuration(started_cluster):
     cursor = started_cluster.postgres_conn.cursor()
-    cursor.execute(f"DROP TABLE IF EXISTS test_table")
-    cursor.execute(f"CREATE TABLE test_table (a integer PRIMARY KEY, b integer)")
+    cursor.execute("DROP TABLE IF EXISTS test_table")
+    cursor.execute("CREATE TABLE test_table (a integer PRIMARY KEY, b integer)")
 
     node1.query("DROP DATABASE IF EXISTS postgres_database")
     node1.query("CREATE DATABASE postgres_database ENGINE = PostgreSQL(postgres1)")
@@ -291,7 +288,7 @@ def test_predefined_connection_configuration(started_cluster):
         "INSERT INTO postgres_database.test_table SELECT number, number from numbers(100)"
     )
     assert (
-        node1.query(f"SELECT count() FROM postgres_database.test_table").rstrip()
+        node1.query("SELECT count() FROM postgres_database.test_table").rstrip()
         == "100"
     )
 
@@ -306,7 +303,7 @@ def test_predefined_connection_configuration(started_cluster):
         "INSERT INTO postgres_database.test_table SELECT number from numbers(200)"
     )
     assert (
-        node1.query(f"SELECT count() FROM postgres_database.test_table").rstrip()
+        node1.query("SELECT count() FROM postgres_database.test_table").rstrip()
         == "200"
     )
 
@@ -324,7 +321,7 @@ def test_predefined_connection_configuration(started_cluster):
         "CREATE DATABASE postgres_database ENGINE = PostgreSQL(postgres3, port=5432)"
     )
     assert (
-        node1.query(f"SELECT count() FROM postgres_database.test_table").rstrip()
+        node1.query("SELECT count() FROM postgres_database.test_table").rstrip()
         == "100"
     )
     node1.query(
@@ -334,13 +331,13 @@ def test_predefined_connection_configuration(started_cluster):
         """
     )
     assert (
-        node1.query(f"SELECT count() FROM postgres_database.test_table").rstrip()
+        node1.query("SELECT count() FROM postgres_database.test_table").rstrip()
         == "100"
     )
     assert node1.contains_in_log("Cached table `test_table`")
 
     node1.query("DROP DATABASE postgres_database")
-    cursor.execute(f"DROP TABLE test_table ")
+    cursor.execute("DROP TABLE test_table ")
     cursor.execute("DROP SCHEMA IF EXISTS test_schema CASCADE")
 
 
@@ -357,7 +354,7 @@ def test_postgres_database_old_syntax(started_cluster):
     )
     create_postgres_table(cursor, "test_table")
     assert "test_table" in node1.query("SHOW TABLES FROM postgres_database")
-    cursor.execute(f"DROP TABLE test_table")
+    cursor.execute("DROP TABLE test_table")
     node1.query("DROP DATABASE IF EXISTS postgres_database;")
 
 
@@ -380,7 +377,7 @@ def test_postgresql_fetch_tables(started_cluster):
     assert node1.query("SHOW TABLES FROM postgres_database") == "table3\n"
     assert not node1.contains_in_log("PostgreSQL table table1 does not exist")
 
-    cursor.execute(f"DROP TABLE table3")
+    cursor.execute("DROP TABLE table3")
     cursor.execute("DROP SCHEMA IF EXISTS test_schema CASCADE")
 
 

--- a/tests/integration/test_postgresql_protocol/test.py
+++ b/tests/integration/test_postgresql_protocol/test.py
@@ -9,7 +9,7 @@ import logging
 import psycopg2 as py_psql
 import psycopg2.extras
 import pytest
-from helpers.cluster import ClickHouseCluster, get_docker_compose_path, run_and_check
+from helpers.cluster import ClickHouseCluster, get_docker_compose_path
 
 psycopg2.extras.register_uuid()
 

--- a/tests/integration/test_postgresql_replica_database_engine_1/test.py
+++ b/tests/integration/test_postgresql_replica_database_engine_1/test.py
@@ -1,31 +1,23 @@
 import pytest
 
 import time
-import os.path as p
 import random
 
 from helpers.cluster import ClickHouseCluster
-from helpers.test_tools import assert_eq_with_retry
-from helpers.test_tools import TSV
 
-from random import randrange
 import threading
 
 from helpers.postgres_utility import get_postgres_conn
 from helpers.postgres_utility import PostgresManager
 
 from helpers.postgres_utility import create_replication_slot, drop_replication_slot
-from helpers.postgres_utility import create_postgres_schema, drop_postgres_schema
-from helpers.postgres_utility import create_postgres_table, drop_postgres_table
+from helpers.postgres_utility import create_postgres_table
 from helpers.postgres_utility import check_tables_are_synchronized
 from helpers.postgres_utility import check_several_tables_are_synchronized
 from helpers.postgres_utility import assert_nested_table_is_created
-from helpers.postgres_utility import assert_number_of_columns
 from helpers.postgres_utility import (
-    postgres_table_template,
     postgres_table_template_2,
     postgres_table_template_3,
-    postgres_table_template_4,
 )
 from helpers.postgres_utility import queries
 
@@ -127,7 +119,7 @@ def test_replicating_dml(started_cluster):
             )
         )
         cursor.execute(
-            "DELETE FROM postgresql_replica_{} WHERE key % 7 = 1;".format(i, i)
+            "DELETE FROM postgresql_replica_{} WHERE key % 7 = 1;".format(i, )
         )
     check_several_tables_are_synchronized(instance, NUM_TABLES)
 
@@ -191,7 +183,7 @@ def test_different_data_types(started_cluster):
         col = random.choice(["a", "b", "c"])
         cursor.execute("UPDATE test_data_types SET {} = {};".format(col, i))
         cursor.execute(
-            """UPDATE test_data_types SET i = '2020-12-12';""".format(col, i)
+            "UPDATE test_data_types SET i = '2020-12-12';".format()
         )
 
     check_tables_are_synchronized(instance, "test_data_types", "id")
@@ -400,7 +392,7 @@ def test_table_schema_changes(started_cluster):
 
     check_several_tables_are_synchronized(instance, NUM_TABLES)
 
-    expected = instance.query(
+    instance.query(
         "SELECT key, value1, value3 FROM test_database.postgresql_replica_3 ORDER BY key"
     )
 

--- a/tests/integration/test_postgresql_replica_database_engine_1/test.py
+++ b/tests/integration/test_postgresql_replica_database_engine_1/test.py
@@ -119,7 +119,9 @@ def test_replicating_dml(started_cluster):
             )
         )
         cursor.execute(
-            "DELETE FROM postgresql_replica_{} WHERE key % 7 = 1;".format(i, )
+            "DELETE FROM postgresql_replica_{} WHERE key % 7 = 1;".format(
+                i,
+            )
         )
     check_several_tables_are_synchronized(instance, NUM_TABLES)
 
@@ -182,9 +184,7 @@ def test_different_data_types(started_cluster):
     for i in range(10):
         col = random.choice(["a", "b", "c"])
         cursor.execute("UPDATE test_data_types SET {} = {};".format(col, i))
-        cursor.execute(
-            "UPDATE test_data_types SET i = '2020-12-12';".format()
-        )
+        cursor.execute("UPDATE test_data_types SET i = '2020-12-12';".format())
 
     check_tables_are_synchronized(instance, "test_data_types", "id")
 

--- a/tests/integration/test_profile_events_s3/test.py
+++ b/tests/integration/test_profile_events_s3/test.py
@@ -111,20 +111,20 @@ def get_minio_stat(cluster):
     ).text.split("\n")
     for line in stat:
         x = re.search(r"s3_requests_total(\{.*\})?\s(\d+)(\s.*)?", line)
-        if x != None:
+        if x is not None:
             y = re.search('.*api="(get|list|head|select).*', x.group(1))
-            if y != None:
+            if y is not None:
                 result["get_requests"] += int(x.group(2))
             else:
                 result["set_requests"] += int(x.group(2))
         x = re.search(r"s3_errors_total(\{.*\})?\s(\d+)(\s.*)?", line)
-        if x != None:
+        if x is not None:
             result["errors"] += int(x.group(2))
         x = re.search(r"s3_rx_bytes_total(\{.*\})?\s([\d\.e\+\-]+)(\s.*)?", line)
-        if x != None:
+        if x is not None:
             result["tx_bytes"] += float(x.group(2))
         x = re.search(r"s3_tx_bytes_total(\{.*\})?\s([\d\.e\+\-]+)(\s.*)?", line)
-        if x != None:
+        if x is not None:
             result["rx_bytes"] += float(x.group(2))
     return result
 
@@ -234,7 +234,7 @@ def test_profile_events(cluster):
         metrics3["S3WriteRequestsCount"] - metrics2["S3WriteRequestsCount"]
         == minio3["set_requests"] - minio2["set_requests"]
     )
-    stat3 = get_query_stat(instance, query3)
+    get_query_stat(instance, query3)
 
     # With async reads profile events are not updated fully because reads are done in a separate thread.
     # for metric in stat3:

--- a/tests/integration/test_profile_settings_and_constraints_order/test.py
+++ b/tests/integration/test_profile_settings_and_constraints_order/test.py
@@ -1,6 +1,5 @@
 import pytest
 
-from helpers.client import QueryRuntimeException
 from helpers.cluster import ClickHouseCluster
 from helpers.test_tools import TSV
 

--- a/tests/integration/test_prometheus_endpoint/test.py
+++ b/tests/integration/test_prometheus_endpoint/test.py
@@ -1,11 +1,11 @@
 import re
 import time
-
 import pytest
 import requests
 from helpers.cluster import ClickHouseCluster
 
 cluster = ClickHouseCluster(__file__)
+
 node = cluster.add_instance("node", main_configs=["configs/prom_conf.xml"])
 
 
@@ -46,7 +46,7 @@ def get_and_check_metrics(retries):
                 response.raise_for_status()
 
             break
-        except:
+        except Exception:
             if retries >= 0:
                 retries -= 1
                 time.sleep(0.5)

--- a/tests/integration/test_random_inserts/test.py
+++ b/tests/integration/test_random_inserts/test.py
@@ -47,7 +47,7 @@ def test_random_inserts(started_cluster):
         ENGINE = ReplicatedMergeTree('/clickhouse/tables/{shard}/simple', '{replica}') PARTITION BY toYYYYMM(date) ORDER BY i"""
     )
 
-    with PartitionManager() as pm_random_drops:
+    with PartitionManager():
         for sacrifice in nodes:
             pass  # This test doesn't work with partition problems still
             # pm_random_drops._add_rule({'probability': 0.01, 'destination': sacrifice.ip_address, 'source_port': 2181, 'action': 'REJECT --reject-with tcp-reset'})

--- a/tests/integration/test_read_only_table/test.py
+++ b/tests/integration/test_read_only_table/test.py
@@ -4,7 +4,6 @@ import logging
 
 import pytest
 from helpers.cluster import ClickHouseCluster
-from helpers.test_tools import assert_eq_with_retry
 
 NUM_TABLES = 10
 

--- a/tests/integration/test_recompression_ttl/test.py
+++ b/tests/integration/test_recompression_ttl/test.py
@@ -1,9 +1,9 @@
 import time
-
 import pytest
 from helpers.cluster import ClickHouseCluster
 
 cluster = ClickHouseCluster(__file__)
+
 node1 = cluster.add_instance(
     "node1", main_configs=["configs/background_pool_config.xml"], with_zookeeper=True
 )
@@ -48,7 +48,7 @@ def optimize_final_table_until_success(node, table_name, retries=40):
                 settings={"optimize_throw_if_noop": "1"},
             )
             return True
-        except:
+        except Exception:
             time.sleep(0.5)
     else:
         return False

--- a/tests/integration/test_recovery_replica/test.py
+++ b/tests/integration/test_recovery_replica/test.py
@@ -1,4 +1,3 @@
-import time
 
 import pytest
 from helpers.cluster import ClickHouseCluster

--- a/tests/integration/test_recovery_replica/test.py
+++ b/tests/integration/test_recovery_replica/test.py
@@ -1,4 +1,3 @@
-
 import pytest
 from helpers.cluster import ClickHouseCluster
 from helpers.test_tools import assert_eq_with_retry

--- a/tests/integration/test_redirect_url_storage/test.py
+++ b/tests/integration/test_redirect_url_storage/test.py
@@ -132,7 +132,6 @@ result = ""
 
 
 def test_url_reconnect(started_cluster):
-
     with PartitionManager() as pm:
         node1.query(
             "insert into table function hdfs('hdfs://hdfs1:9000/storage_big', 'TSV', 'id Int32') select number from numbers(500000)"

--- a/tests/integration/test_reload_auxiliary_zookeepers/test.py
+++ b/tests/integration/test_reload_auxiliary_zookeepers/test.py
@@ -1,10 +1,8 @@
 import time
 import pytest
-import os
 
 from helpers.cluster import ClickHouseCluster
 from helpers.client import QueryRuntimeException
-from helpers.test_tools import assert_eq_with_retry
 
 cluster = ClickHouseCluster(__file__)
 node = cluster.add_instance("node", with_zookeeper=True)

--- a/tests/integration/test_reload_certificate/test.py
+++ b/tests/integration/test_reload_certificate/test.py
@@ -104,7 +104,7 @@ def check_certificate_switch(
             ]
         )
         assert False
-    except:
+    except Exception:
         assert True
 
     # Change to other key
@@ -139,7 +139,7 @@ def check_certificate_switch(
             ]
         )
         assert False
-    except:
+    except Exception:
         assert True
 
 

--- a/tests/integration/test_reload_clusters_config/test.py
+++ b/tests/integration/test_reload_clusters_config/test.py
@@ -1,15 +1,12 @@
 import os
 import sys
-import time
-
 import pytest
+from helpers.cluster import ClickHouseCluster
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from helpers.cluster import ClickHouseCluster
-from helpers.test_tools import TSV
-
 cluster = ClickHouseCluster(__file__)
+
 node = cluster.add_instance(
     "node", with_zookeeper=True, main_configs=["configs/remote_servers.xml"]
 )

--- a/tests/integration/test_reload_zookeeper/test.py
+++ b/tests/integration/test_reload_zookeeper/test.py
@@ -1,6 +1,5 @@
 import time
 import pytest
-import os
 
 from helpers.cluster import ClickHouseCluster
 from helpers.client import QueryRuntimeException

--- a/tests/integration/test_reloading_storage_configuration/test.py
+++ b/tests/integration/test_reloading_storage_configuration/test.py
@@ -3,13 +3,11 @@ import os
 import re
 import shutil
 import time
-import xml.etree.ElementTree as ET
-
+import pytest
 import helpers.client
 import helpers.cluster
+import xml.etree.ElementTree as ET
 from helpers.test_tools import TSV
-import pytest
-
 
 cluster = helpers.cluster.ClickHouseCluster(__file__)
 
@@ -74,7 +72,7 @@ def start_over():
         )
         try:
             os.remove(separate_configuration_path)
-        except:
+        except Exception:
             """"""
 
 
@@ -90,7 +88,7 @@ def add_disk(node, name, path, separate_file=False):
             tree = ET.parse(
                 os.path.join(node.config_d_dir, "storage_configuration.xml")
             )
-    except:
+    except Exception:
         tree = ET.ElementTree(
             ET.fromstring(
                 "<clickhouse><storage_configuration><disks/><policies/></storage_configuration></clickhouse>"
@@ -120,7 +118,7 @@ def update_disk(node, name, path, keep_free_space_bytes, separate_file=False):
             tree = ET.parse(
                 os.path.join(node.config_d_dir, "storage_configuration.xml")
             )
-    except:
+    except Exception:
         tree = ET.ElementTree(
             ET.fromstring(
                 "<clickhouse><storage_configuration><disks/><policies/></storage_configuration></clickhouse>"
@@ -194,7 +192,7 @@ def test_add_disk(started_cluster):
     finally:
         try:
             node1.query("DROP TABLE IF EXISTS {}".format(name))
-        except:
+        except Exception:
             """"""
 
 
@@ -232,7 +230,7 @@ def test_update_disk(started_cluster):
     finally:
         try:
             node1.query("DROP TABLE IF EXISTS {}".format(name))
-        except:
+        except Exception:
             """"""
 
 
@@ -270,7 +268,7 @@ def test_add_disk_to_separate_config(started_cluster):
     finally:
         try:
             node1.query("DROP TABLE IF EXISTS {}".format(name))
-        except:
+        except Exception:
             """"""
 
 
@@ -300,7 +298,7 @@ def test_add_policy(started_cluster):
         add_policy(node1, "cool_policy", {"volume1": ["jbod3", "jbod4"]})
         node1.query("SYSTEM RELOAD CONFIG")
 
-        disks = set(node1.query("SELECT name FROM system.disks").splitlines())
+        set(node1.query("SELECT name FROM system.disks").splitlines())
         assert "cool_policy" in set(
             node1.query("SELECT policy_name FROM system.storage_policies").splitlines()
         )
@@ -318,7 +316,7 @@ def test_add_policy(started_cluster):
     finally:
         try:
             node1.query("DROP TABLE IF EXISTS {}".format(name))
-        except:
+        except Exception:
             """"""
 
 
@@ -399,7 +397,7 @@ def test_new_policy_works(started_cluster):
     finally:
         try:
             node1.query("DROP TABLE IF EXISTS {}".format(name))
-        except:
+        except Exception:
             """"""
 
 
@@ -453,7 +451,7 @@ def test_add_volume_to_policy(started_cluster):
     finally:
         try:
             node1.query("DROP TABLE IF EXISTS {}".format(name))
-        except:
+        except Exception:
             """"""
 
 
@@ -503,7 +501,7 @@ def test_add_disk_to_policy(started_cluster):
     finally:
         try:
             node1.query("DROP TABLE IF EXISTS {}".format(name))
-        except:
+        except Exception:
             """"""
 
 
@@ -543,7 +541,7 @@ def test_remove_disk(started_cluster):
     finally:
         try:
             node1.query("DROP TABLE IF EXISTS {}".format(name))
-        except:
+        except Exception:
             """"""
 
 
@@ -588,7 +586,7 @@ def test_remove_policy(started_cluster):
     finally:
         try:
             node1.query("DROP TABLE IF EXISTS {}".format(name))
-        except:
+        except Exception:
             """"""
 
 
@@ -658,7 +656,7 @@ def test_remove_volume_from_policy(started_cluster):
     finally:
         try:
             node1.query("DROP TABLE IF EXISTS {}".format(name))
-        except:
+        except Exception:
             """"""
 
 
@@ -728,5 +726,5 @@ def test_remove_disk_from_policy(started_cluster):
     finally:
         try:
             node1.query("DROP TABLE IF EXISTS {}".format(name))
-        except:
+        except Exception:
             """"""

--- a/tests/integration/test_rename_column/test.py
+++ b/tests/integration/test_rename_column/test.py
@@ -177,7 +177,7 @@ def insert(
                     )
                 )
             node.query(";\n".join(query))
-        except QueryRuntimeException as ex:
+        except QueryRuntimeException:
             if not ignore_exception:
                 raise
 
@@ -216,7 +216,7 @@ def select(
                     ):
                         continue
                     assert r == expected_result
-            except QueryRuntimeException as ex:
+            except QueryRuntimeException:
                 if not ignore_exception:
                     raise
             break
@@ -232,7 +232,7 @@ def rename_column(
                     table_name=table_name, name=name, new_name=new_name
                 )
             )
-        except QueryRuntimeException as ex:
+        except QueryRuntimeException:
             if not ignore_exception:
                 raise
 
@@ -247,7 +247,7 @@ def rename_column_on_cluster(
                     table_name=table_name, name=name, new_name=new_name
                 )
             )
-        except QueryRuntimeException as ex:
+        except QueryRuntimeException:
             if not ignore_exception:
                 raise
 
@@ -262,7 +262,7 @@ def alter_move(node, table_name, iterations=1, ignore_exception=False):
                     table_name=table_name, move_part=move_part, move_volume=move_volume
                 )
             )
-        except QueryRuntimeException as ex:
+        except QueryRuntimeException:
             if not ignore_exception:
                 raise
 

--- a/tests/integration/test_replica_is_active/test.py
+++ b/tests/integration/test_replica_is_active/test.py
@@ -1,5 +1,4 @@
 import pytest
-from helpers.client import QueryRuntimeException
 from helpers.cluster import ClickHouseCluster
 from ast import literal_eval
 

--- a/tests/integration/test_replicated_database/test.py
+++ b/tests/integration/test_replicated_database/test.py
@@ -62,7 +62,8 @@ uuid_regex = re.compile("[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f
 
 
 def assert_create_query(nodes, table_name, expected):
-    replace_uuid = lambda x: re.sub(uuid_regex, "uuid", x)
+    def replace_uuid(x):
+        return re.sub(uuid_regex, "uuid", x)
     query = "show create table {}".format(table_name)
     for node in nodes:
         assert_eq_with_retry(node, query, expected, get_result=replace_uuid)
@@ -169,7 +170,7 @@ def test_simple_alter_table(started_cluster, engine):
 
     full_engine = (
         engine
-        if not "Replicated" in engine
+        if "Replicated" not in engine
         else engine + "(\\'/clickhouse/tables/{uuid}/{shard}\\', \\'{replica}\\')"
     )
     expected = (
@@ -196,7 +197,7 @@ def test_simple_alter_table(started_cluster, engine):
 
     full_engine = (
         engine
-        if not "Replicated" in engine
+        if "Replicated" not in engine
         else engine + "(\\'/clickhouse/tables/{uuid}/{shard}\\', \\'{replica}\\')"
     )
     expected = (
@@ -239,7 +240,7 @@ def test_delete_from_table(started_cluster, engine):
     expected = "1\taaaa\n1\tbbbb"
 
     table_for_select = name
-    if not "Replicated" in engine:
+    if "Replicated" not in engine:
         table_for_select = "cluster('delete_from_table', {})".format(name)
     for node in [main_node, dummy_node]:
         assert_eq_with_retry(
@@ -260,13 +261,13 @@ def get_table_uuid(database, name):
 
 @pytest.fixture(scope="module", name="attachable_part")
 def fixture_attachable_part(started_cluster):
-    main_node.query(f"CREATE DATABASE testdb_attach_atomic ENGINE = Atomic")
+    main_node.query("CREATE DATABASE testdb_attach_atomic ENGINE = Atomic")
     main_node.query(
-        f"CREATE TABLE testdb_attach_atomic.test (CounterID UInt32) ENGINE = MergeTree ORDER BY (CounterID)"
+        "CREATE TABLE testdb_attach_atomic.test (CounterID UInt32) ENGINE = MergeTree ORDER BY (CounterID)"
     )
-    main_node.query(f"INSERT INTO testdb_attach_atomic.test VALUES (123)")
+    main_node.query("INSERT INTO testdb_attach_atomic.test VALUES (123)")
     main_node.query(
-        f"ALTER TABLE testdb_attach_atomic.test FREEZE WITH NAME 'test_attach'"
+        "ALTER TABLE testdb_attach_atomic.test FREEZE WITH NAME 'test_attach'"
     )
     table_uuid = get_table_uuid("testdb_attach_atomic", "test")
     return os.path.join(

--- a/tests/integration/test_replicated_database/test.py
+++ b/tests/integration/test_replicated_database/test.py
@@ -64,6 +64,7 @@ uuid_regex = re.compile("[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f
 def assert_create_query(nodes, table_name, expected):
     def replace_uuid(x):
         return re.sub(uuid_regex, "uuid", x)
+
     query = "show create table {}".format(table_name)
     for node in nodes:
         assert_eq_with_retry(node, query, expected, get_result=replace_uuid)

--- a/tests/integration/test_replicated_fetches_bandwidth/test.py
+++ b/tests/integration/test_replicated_fetches_bandwidth/test.py
@@ -4,7 +4,6 @@ import pytest
 import random
 import string
 from helpers.network import NetThroughput
-import subprocess
 import time
 import statistics
 

--- a/tests/integration/test_replicated_merge_tree_compatibility/test.py
+++ b/tests/integration/test_replicated_merge_tree_compatibility/test.py
@@ -67,7 +67,7 @@ def test_replicated_merge_tree_defaults_compatibility(started_cluster):
 
     zk = cluster.get_kazoo_client("zoo1")
     exists_replica_1 = zk.exists("/clickhouse/tables/test/table/replicas/node1")
-    assert exists_replica_1 == None
+    assert exists_replica_1 is None
 
     node1.restart_with_latest_version()
     node2.restart_with_latest_version()

--- a/tests/integration/test_replicated_merge_tree_encrypted_disk/test.py
+++ b/tests/integration/test_replicated_merge_tree_encrypted_disk/test.py
@@ -1,6 +1,6 @@
 import pytest
 from helpers.cluster import ClickHouseCluster
-from helpers.test_tools import assert_eq_with_retry, TSV
+from helpers.test_tools import TSV
 import os
 
 

--- a/tests/integration/test_replicated_merge_tree_encryption_codec/test.py
+++ b/tests/integration/test_replicated_merge_tree_encryption_codec/test.py
@@ -1,6 +1,6 @@
 import pytest
 from helpers.cluster import ClickHouseCluster
-from helpers.test_tools import assert_eq_with_retry, TSV
+from helpers.test_tools import TSV
 import os
 
 

--- a/tests/integration/test_replicated_merge_tree_hdfs_zero_copy/test.py
+++ b/tests/integration/test_replicated_merge_tree_hdfs_zero_copy/test.py
@@ -1,18 +1,15 @@
 import pytest
+import logging
+import time
+from pyhdfs import HdfsClient
+from string import Template
+from helpers.cluster import ClickHouseCluster
+from helpers.test_tools import assert_eq_with_retry
 
 # FIXME This test is too flaky
 # https://github.com/ClickHouse/ClickHouse/issues/42561
 
 pytestmark = pytest.mark.skip
-
-import logging
-from string import Template
-import time
-
-from helpers.cluster import ClickHouseCluster
-from helpers.test_tools import assert_eq_with_retry
-
-from pyhdfs import HdfsClient
 
 SHARDS = 2
 FILES_OVERHEAD_PER_TABLE = 1  # format_version.txt

--- a/tests/integration/test_replicated_merge_tree_with_auxiliary_zookeepers/test.py
+++ b/tests/integration/test_replicated_merge_tree_with_auxiliary_zookeepers/test.py
@@ -1,6 +1,5 @@
 import time
 
-import helpers.client as client
 import pytest
 from helpers.cluster import ClickHouseCluster
 from helpers.client import QueryRuntimeException

--- a/tests/integration/test_restore_replica/test.py
+++ b/tests/integration/test_restore_replica/test.py
@@ -1,8 +1,6 @@
-import time
 import pytest
 
 from helpers.cluster import ClickHouseCluster
-from helpers.cluster import ClickHouseKiller
 from helpers.test_tools import assert_eq_with_retry
 
 

--- a/tests/integration/test_reverse_dns_query/test.py
+++ b/tests/integration/test_reverse_dns_query/test.py
@@ -1,6 +1,5 @@
 import pytest
-from helpers.cluster import ClickHouseCluster, get_docker_compose_path, run_and_check
-from time import sleep
+from helpers.cluster import ClickHouseCluster, get_docker_compose_path
 import os
 
 DOCKER_COMPOSE_PATH = get_docker_compose_path()

--- a/tests/integration/test_s3_aws_sdk_has_slightly_unreliable_behaviour/test.py
+++ b/tests/integration/test_s3_aws_sdk_has_slightly_unreliable_behaviour/test.py
@@ -7,7 +7,6 @@ import time
 
 import pytest
 
-from helpers.client import QueryRuntimeException
 from helpers.cluster import ClickHouseCluster
 
 

--- a/tests/integration/test_s3_cluster/test.py
+++ b/tests/integration/test_s3_cluster/test.py
@@ -1,9 +1,7 @@
-from email.errors import HeaderParseError
 import logging
 import os
 import csv
 import shutil
-import time
 
 import pytest
 from helpers.cluster import ClickHouseCluster

--- a/tests/integration/test_s3_storage_class/test.py
+++ b/tests/integration/test_s3_storage_class/test.py
@@ -1,4 +1,3 @@
-import os
 import logging
 
 import pytest

--- a/tests/integration/test_s3_zero_copy_ttl/test_ttl_move_memory_usage.py
+++ b/tests/integration/test_s3_zero_copy_ttl/test_ttl_move_memory_usage.py
@@ -1,14 +1,12 @@
 #!/usr/bin/env python3
-import time
 
 import pytest
+from helpers.cluster import ClickHouseCluster
 
 # FIXME This test is too flaky
 # https://github.com/ClickHouse/ClickHouse/issues/45887
 
 pytestmark = pytest.mark.skip
-
-from helpers.cluster import ClickHouseCluster
 
 
 single_node_cluster = ClickHouseCluster(__file__)

--- a/tests/integration/test_s3_zero_copy_ttl/test_vertical_merge_memory_usage.py
+++ b/tests/integration/test_s3_zero_copy_ttl/test_vertical_merge_memory_usage.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-import time
 
 import pytest
 from helpers.cluster import ClickHouseCluster

--- a/tests/integration/test_secure_socket/test.py
+++ b/tests/integration/test_secure_socket/test.py
@@ -1,9 +1,7 @@
-import os.path
 import time
 
 import pytest
 from helpers.cluster import ClickHouseCluster
-from helpers.test_tools import TSV
 
 cluster = ClickHouseCluster(__file__)
 

--- a/tests/integration/test_select_access_rights/test_from_system_tables.py
+++ b/tests/integration/test_select_access_rights/test_from_system_tables.py
@@ -1,7 +1,5 @@
-import os
 import pytest
 from helpers.cluster import ClickHouseCluster
-from helpers.test_tools import TSV
 
 cluster = ClickHouseCluster(__file__)
 node = cluster.add_instance(

--- a/tests/integration/test_select_access_rights/test_main.py
+++ b/tests/integration/test_select_access_rights/test_main.py
@@ -1,6 +1,5 @@
 import pytest
 from helpers.cluster import ClickHouseCluster
-from helpers.test_tools import TSV
 
 cluster = ClickHouseCluster(__file__)
 instance = cluster.add_instance("instance")

--- a/tests/integration/test_send_crash_reports/test.py
+++ b/tests/integration/test_send_crash_reports/test.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # pylint: disable=redefined-outer-name
 # pylint: disable=unused-argument
 # pylint: disable=line-too-long
@@ -6,10 +8,8 @@
 import os
 import time
 import pytest
-
 import helpers.cluster
 import helpers.test_tools
-
 from . import fake_sentry_server
 
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
@@ -31,7 +31,7 @@ def started_node():
         # It will print Fatal message after pkill -SEGV, suppress it
         try:
             cluster.shutdown()
-        except:
+        except Exception:
             pass
 
 

--- a/tests/integration/test_server_initialization/test.py
+++ b/tests/integration/test_server_initialization/test.py
@@ -7,13 +7,13 @@ from helpers.cluster import ClickHouseCluster
 def started_cluster():
     try:
         cluster = ClickHouseCluster(__file__)
-        instance = cluster.add_instance(
+        cluster.add_instance(
             "dummy", clickhouse_path_dir="clickhouse_path", stay_alive=True
         )
         cluster.start()
 
         cluster_fail = ClickHouseCluster(__file__, name="fail")
-        instance_fail = cluster_fail.add_instance(
+        cluster_fail.add_instance(
             "dummy_fail", clickhouse_path_dir="clickhouse_path_fail"
         )
         with pytest.raises(Exception):

--- a/tests/integration/test_server_reload/test.py
+++ b/tests/integration/test_server_reload/test.py
@@ -15,6 +15,8 @@ import sys
 import os
 import time
 import logging
+import clickhouse_grpc_pb2
+import clickhouse_grpc_pb2_grpc
 from helpers.cluster import ClickHouseCluster, run_and_check
 from helpers.client import Client, QueryRuntimeException
 from kazoo.exceptions import NodeExistsError
@@ -56,8 +58,6 @@ run_and_check(
 )
 
 sys.path.append(str(gen_dir))
-import clickhouse_grpc_pb2
-import clickhouse_grpc_pb2_grpc
 
 
 @pytest.fixture(name="cluster", scope="module")

--- a/tests/integration/test_server_start_and_ip_conversions/test.py
+++ b/tests/integration/test_server_start_and_ip_conversions/test.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-import logging
 import pytest
 from helpers.cluster import ClickHouseCluster
 

--- a/tests/integration/test_sharding_key_from_default_column/test.py
+++ b/tests/integration/test_sharding_key_from_default_column/test.py
@@ -1,5 +1,4 @@
 import pytest
-import itertools
 from helpers.cluster import ClickHouseCluster
 from helpers.test_tools import TSV
 

--- a/tests/integration/test_ssl_cert_authentication/test.py
+++ b/tests/integration/test_ssl_cert_authentication/test.py
@@ -1,11 +1,12 @@
 import pytest
+import ssl
+import os.path
+import urllib.request
+import urllib.parse
+from os import remove
 from helpers.client import Client
 from helpers.cluster import ClickHouseCluster
 from helpers.ssl_context import WrapSSLContextWithSNI
-import urllib.request, urllib.parse
-import ssl
-import os.path
-from os import remove
 
 
 # The test cluster is configured with certificate for that host name, see 'server-ext.cnf'.

--- a/tests/integration/test_storage_delta/test.py
+++ b/tests/integration/test_storage_delta/test.py
@@ -1,4 +1,3 @@
-import helpers.client
 from helpers.cluster import ClickHouseCluster
 from helpers.test_tools import TSV
 
@@ -6,11 +5,8 @@ import pytest
 import logging
 import os
 import json
-import time
-import glob
 
 import pyspark
-import delta
 from delta import *
 from pyspark.sql.types import (
     StructType,
@@ -18,11 +14,9 @@ from pyspark.sql.types import (
     StringType,
     IntegerType,
     DateType,
-    TimestampType,
     BooleanType,
     ArrayType,
 )
-from pyspark.sql.functions import current_timestamp
 from datetime import datetime
 from pyspark.sql.functions import monotonically_increasing_id, row_number
 from pyspark.sql.window import Window
@@ -335,7 +329,7 @@ def test_types(started_cluster):
     spark = started_cluster.spark_session
     result_file = f"{TABLE_NAME}_result_2"
 
-    delta_table = (
+    (
         DeltaTable.create(spark)
         .tableName(TABLE_NAME)
         .location(f"/{result_file}")

--- a/tests/integration/test_storage_dict/test.py
+++ b/tests/integration/test_storage_dict/test.py
@@ -23,24 +23,24 @@ def cluster():
 def test_storage_dict(cluster):
     node1 = cluster.instances["node1"]
 
-    node1.query(f"insert into table function url(urldb) values ('foo', 'bar')")
-    result = node1.query(f"select * from url(urldb)")
+    node1.query("insert into table function url(urldb) values ('foo', 'bar')")
+    result = node1.query("select * from url(urldb)")
     assert result.strip() == "foo\tbar"
 
     node1.query(
-        f"create dictionary dict (k String, v String) primary key k source(http(name urldict)) layout(complex_key_hashed()) lifetime(min 0 max 100)"
+        "create dictionary dict (k String, v String) primary key k source(http(name urldict)) layout(complex_key_hashed()) lifetime(min 0 max 100)"
     )
-    result = node1.query(f"select * from dict")
+    result = node1.query("select * from dict")
     assert result.strip() == "foo\tbar"
 
     node1.query(
-        f"create dictionary dict1 (k String, v String) primary key k source(http(name urldict1 format TabSeparated)) layout(complex_key_hashed()) lifetime(min 0 max 100)"
+        "create dictionary dict1 (k String, v String) primary key k source(http(name urldict1 format TabSeparated)) layout(complex_key_hashed()) lifetime(min 0 max 100)"
     )
-    result = node1.query(f"select * from dict1")
+    result = node1.query("select * from dict1")
     assert result.strip() == "foo\tbar"
 
     node1.query(
-        f"create dictionary dict2 (k String, v String) primary key k source(http(name urldict2 format TabSeparated)) layout(complex_key_hashed()) lifetime(min 0 max 100)"
+        "create dictionary dict2 (k String, v String) primary key k source(http(name urldict2 format TabSeparated)) layout(complex_key_hashed()) lifetime(min 0 max 100)"
     )
-    result = node1.query(f"select * from dict2")
+    result = node1.query("select * from dict2")
     assert result.strip() == "foo\tbar"

--- a/tests/integration/test_storage_hdfs/test.py
+++ b/tests/integration/test_storage_hdfs/test.py
@@ -1,4 +1,3 @@
-
 import pytest
 import time
 from helpers.cluster import ClickHouseCluster
@@ -335,7 +334,6 @@ def test_truncate_table(started_cluster):
 
 
 def test_partition_by(started_cluster):
-
     table_format = "column1 UInt32, column2 UInt32, column3 UInt32"
     file_name = "test_{_partition_id}"
     partition_by = "column3"
@@ -378,10 +376,7 @@ def test_partition_by(started_cluster):
 
 
 def test_seekable_formats(started_cluster):
-
-    table_function = (
-        "hdfs('hdfs://hdfs1:9000/parquet', 'Parquet', 'a Int32, b String')"
-    )
+    table_function = "hdfs('hdfs://hdfs1:9000/parquet', 'Parquet', 'a Int32, b String')"
     node1.query(
         f"insert into table function {table_function} SELECT number, randomString(100) FROM numbers(5000000)"
     )
@@ -469,7 +464,6 @@ def test_hdfs_directory_not_exist(started_cluster):
 
 
 def test_overwrite(started_cluster):
-
     table_function = "hdfs('hdfs://hdfs1:9000/data', 'Parquet', 'a Int32, b String')"
     node1.query(f"create table test_overwrite as {table_function}")
     node1.query(
@@ -487,7 +481,6 @@ def test_overwrite(started_cluster):
 
 
 def test_multiple_inserts(started_cluster):
-
     table_function = "hdfs('hdfs://hdfs1:9000/data_multiple_inserts', 'Parquet', 'a Int32, b String')"
     node1.query(f"create table test_multiple_inserts as {table_function}")
     node1.query(
@@ -611,7 +604,6 @@ def test_cluster_macro(started_cluster):
 
 
 def test_virtual_columns_2(started_cluster):
-
     table_function = (
         "hdfs('hdfs://hdfs1:9000/parquet_2', 'Parquet', 'a Int32, b String')"
     )

--- a/tests/integration/test_storage_hdfs/test.py
+++ b/tests/integration/test_storage_hdfs/test.py
@@ -1,4 +1,3 @@
-import os
 
 import pytest
 import time
@@ -336,7 +335,6 @@ def test_truncate_table(started_cluster):
 
 
 def test_partition_by(started_cluster):
-    hdfs_api = started_cluster.hdfs_api
 
     table_format = "column1 UInt32, column2 UInt32, column3 UInt32"
     file_name = "test_{_partition_id}"
@@ -380,10 +378,9 @@ def test_partition_by(started_cluster):
 
 
 def test_seekable_formats(started_cluster):
-    hdfs_api = started_cluster.hdfs_api
 
     table_function = (
-        f"hdfs('hdfs://hdfs1:9000/parquet', 'Parquet', 'a Int32, b String')"
+        "hdfs('hdfs://hdfs1:9000/parquet', 'Parquet', 'a Int32, b String')"
     )
     node1.query(
         f"insert into table function {table_function} SELECT number, randomString(100) FROM numbers(5000000)"
@@ -392,7 +389,7 @@ def test_seekable_formats(started_cluster):
     result = node1.query(f"SELECT count() FROM {table_function}")
     assert int(result) == 5000000
 
-    table_function = f"hdfs('hdfs://hdfs1:9000/orc', 'ORC', 'a Int32, b String')"
+    table_function = "hdfs('hdfs://hdfs1:9000/orc', 'ORC', 'a Int32, b String')"
     node1.query(
         f"insert into table function {table_function} SELECT number, randomString(100) FROM numbers(5000000)"
     )
@@ -418,24 +415,24 @@ def test_read_table_with_default(started_cluster):
 
 def test_schema_inference(started_cluster):
     node1.query(
-        f"insert into table function hdfs('hdfs://hdfs1:9000/native', 'Native', 'a Int32, b String') SELECT number, randomString(100) FROM numbers(5000000)"
+        "insert into table function hdfs('hdfs://hdfs1:9000/native', 'Native', 'a Int32, b String') SELECT number, randomString(100) FROM numbers(5000000)"
     )
 
-    result = node1.query(f"desc hdfs('hdfs://hdfs1:9000/native', 'Native')")
+    result = node1.query("desc hdfs('hdfs://hdfs1:9000/native', 'Native')")
     assert result == "a\tInt32\t\t\t\t\t\nb\tString\t\t\t\t\t\n"
 
     result = node1.query(
-        f"select count(*) from hdfs('hdfs://hdfs1:9000/native', 'Native')"
+        "select count(*) from hdfs('hdfs://hdfs1:9000/native', 'Native')"
     )
     assert int(result) == 5000000
 
     node1.query(
-        f"create table schema_inference engine=HDFS('hdfs://hdfs1:9000/native', 'Native')"
+        "create table schema_inference engine=HDFS('hdfs://hdfs1:9000/native', 'Native')"
     )
-    result = node1.query(f"desc schema_inference")
+    result = node1.query("desc schema_inference")
     assert result == "a\tInt32\t\t\t\t\t\nb\tString\t\t\t\t\t\n"
 
-    result = node1.query(f"select count(*) from schema_inference")
+    result = node1.query("select count(*) from schema_inference")
     assert int(result) == 5000000
 
 
@@ -472,87 +469,85 @@ def test_hdfs_directory_not_exist(started_cluster):
 
 
 def test_overwrite(started_cluster):
-    hdfs_api = started_cluster.hdfs_api
 
-    table_function = f"hdfs('hdfs://hdfs1:9000/data', 'Parquet', 'a Int32, b String')"
+    table_function = "hdfs('hdfs://hdfs1:9000/data', 'Parquet', 'a Int32, b String')"
     node1.query(f"create table test_overwrite as {table_function}")
     node1.query(
-        f"insert into test_overwrite select number, randomString(100) from numbers(5)"
+        "insert into test_overwrite select number, randomString(100) from numbers(5)"
     )
     node1.query_and_get_error(
-        f"insert into test_overwrite select number, randomString(100) FROM numbers(10)"
+        "insert into test_overwrite select number, randomString(100) FROM numbers(10)"
     )
     node1.query(
-        f"insert into test_overwrite select number, randomString(100) from numbers(10) settings hdfs_truncate_on_insert=1"
+        "insert into test_overwrite select number, randomString(100) from numbers(10) settings hdfs_truncate_on_insert=1"
     )
 
-    result = node1.query(f"select count() from test_overwrite")
+    result = node1.query("select count() from test_overwrite")
     assert int(result) == 10
 
 
 def test_multiple_inserts(started_cluster):
-    hdfs_api = started_cluster.hdfs_api
 
-    table_function = f"hdfs('hdfs://hdfs1:9000/data_multiple_inserts', 'Parquet', 'a Int32, b String')"
+    table_function = "hdfs('hdfs://hdfs1:9000/data_multiple_inserts', 'Parquet', 'a Int32, b String')"
     node1.query(f"create table test_multiple_inserts as {table_function}")
     node1.query(
-        f"insert into test_multiple_inserts select number, randomString(100) from numbers(10)"
+        "insert into test_multiple_inserts select number, randomString(100) from numbers(10)"
     )
     node1.query(
-        f"insert into test_multiple_inserts select number, randomString(100) from numbers(20) settings hdfs_create_new_file_on_insert=1"
+        "insert into test_multiple_inserts select number, randomString(100) from numbers(20) settings hdfs_create_new_file_on_insert=1"
     )
     node1.query(
-        f"insert into test_multiple_inserts select number, randomString(100) from numbers(30) settings hdfs_create_new_file_on_insert=1"
+        "insert into test_multiple_inserts select number, randomString(100) from numbers(30) settings hdfs_create_new_file_on_insert=1"
     )
 
-    result = node1.query(f"select count() from test_multiple_inserts")
+    result = node1.query("select count() from test_multiple_inserts")
     assert int(result) == 60
 
-    result = node1.query(f"drop table test_multiple_inserts")
+    result = node1.query("drop table test_multiple_inserts")
 
-    table_function = f"hdfs('hdfs://hdfs1:9000/data_multiple_inserts.gz', 'Parquet', 'a Int32, b String')"
+    table_function = "hdfs('hdfs://hdfs1:9000/data_multiple_inserts.gz', 'Parquet', 'a Int32, b String')"
     node1.query(f"create table test_multiple_inserts as {table_function}")
     node1.query(
-        f"insert into test_multiple_inserts select number, randomString(100) FROM numbers(10)"
+        "insert into test_multiple_inserts select number, randomString(100) FROM numbers(10)"
     )
     node1.query(
-        f"insert into test_multiple_inserts select number, randomString(100) FROM numbers(20) settings hdfs_create_new_file_on_insert=1"
+        "insert into test_multiple_inserts select number, randomString(100) FROM numbers(20) settings hdfs_create_new_file_on_insert=1"
     )
     node1.query(
-        f"insert into test_multiple_inserts select number, randomString(100) FROM numbers(30) settings hdfs_create_new_file_on_insert=1"
+        "insert into test_multiple_inserts select number, randomString(100) FROM numbers(30) settings hdfs_create_new_file_on_insert=1"
     )
 
-    result = node1.query(f"select count() from test_multiple_inserts")
+    result = node1.query("select count() from test_multiple_inserts")
     assert int(result) == 60
 
 
 def test_format_detection(started_cluster):
     node1.query(
-        f"create table arrow_table (x UInt64) engine=HDFS('hdfs://hdfs1:9000/data.arrow')"
+        "create table arrow_table (x UInt64) engine=HDFS('hdfs://hdfs1:9000/data.arrow')"
     )
-    node1.query(f"insert into arrow_table select 1")
-    result = node1.query(f"select * from hdfs('hdfs://hdfs1:9000/data.arrow')")
+    node1.query("insert into arrow_table select 1")
+    result = node1.query("select * from hdfs('hdfs://hdfs1:9000/data.arrow')")
     assert int(result) == 1
 
 
 def test_schema_inference_with_globs(started_cluster):
     node1.query(
-        f"insert into table function hdfs('hdfs://hdfs1:9000/data1.jsoncompacteachrow', 'JSONCompactEachRow', 'x Nullable(UInt32)') select NULL"
+        "insert into table function hdfs('hdfs://hdfs1:9000/data1.jsoncompacteachrow', 'JSONCompactEachRow', 'x Nullable(UInt32)') select NULL"
     )
     node1.query(
-        f"insert into table function hdfs('hdfs://hdfs1:9000/data2.jsoncompacteachrow', 'JSONCompactEachRow', 'x Nullable(UInt32)') select 0"
+        "insert into table function hdfs('hdfs://hdfs1:9000/data2.jsoncompacteachrow', 'JSONCompactEachRow', 'x Nullable(UInt32)') select 0"
     )
 
-    result = node1.query(f"desc hdfs('hdfs://hdfs1:9000/data*.jsoncompacteachrow')")
+    result = node1.query("desc hdfs('hdfs://hdfs1:9000/data*.jsoncompacteachrow')")
     assert result.strip() == "c1\tNullable(Int64)"
 
     result = node1.query(
-        f"select * from hdfs('hdfs://hdfs1:9000/data*.jsoncompacteachrow')"
+        "select * from hdfs('hdfs://hdfs1:9000/data*.jsoncompacteachrow')"
     )
     assert sorted(result.split()) == ["0", "\\N"]
 
     node1.query(
-        f"insert into table function hdfs('hdfs://hdfs1:9000/data3.jsoncompacteachrow', 'JSONCompactEachRow', 'x Nullable(UInt32)') select NULL"
+        "insert into table function hdfs('hdfs://hdfs1:9000/data3.jsoncompacteachrow', 'JSONCompactEachRow', 'x Nullable(UInt32)') select NULL"
     )
 
     filename = "data{1,3}.jsoncompacteachrow"
@@ -564,11 +559,11 @@ def test_schema_inference_with_globs(started_cluster):
     assert "All attempts to extract table structure from files failed" in result
 
     node1.query(
-        f"insert into table function hdfs('hdfs://hdfs1:9000/data0.jsoncompacteachrow', 'TSV', 'x String') select '[123;]'"
+        "insert into table function hdfs('hdfs://hdfs1:9000/data0.jsoncompacteachrow', 'TSV', 'x String') select '[123;]'"
     )
 
     result = node1.query_and_get_error(
-        f"desc hdfs('hdfs://hdfs1:9000/data*.jsoncompacteachrow') settings schema_inference_use_cache_for_hdfs=0"
+        "desc hdfs('hdfs://hdfs1:9000/data*.jsoncompacteachrow') settings schema_inference_use_cache_for_hdfs=0"
     )
 
     assert (
@@ -578,13 +573,13 @@ def test_schema_inference_with_globs(started_cluster):
 
 def test_insert_select_schema_inference(started_cluster):
     node1.query(
-        f"insert into table function hdfs('hdfs://hdfs1:9000/test.native.zst') select toUInt64(1) as x"
+        "insert into table function hdfs('hdfs://hdfs1:9000/test.native.zst') select toUInt64(1) as x"
     )
 
-    result = node1.query(f"desc hdfs('hdfs://hdfs1:9000/test.native.zst')")
+    result = node1.query("desc hdfs('hdfs://hdfs1:9000/test.native.zst')")
     assert result.strip() == "x\tUInt64"
 
-    result = node1.query(f"select * from hdfs('hdfs://hdfs1:9000/test.native.zst')")
+    result = node1.query("select * from hdfs('hdfs://hdfs1:9000/test.native.zst')")
     assert int(result) == 1
 
 
@@ -616,10 +611,9 @@ def test_cluster_macro(started_cluster):
 
 
 def test_virtual_columns_2(started_cluster):
-    hdfs_api = started_cluster.hdfs_api
 
     table_function = (
-        f"hdfs('hdfs://hdfs1:9000/parquet_2', 'Parquet', 'a Int32, b String')"
+        "hdfs('hdfs://hdfs1:9000/parquet_2', 'Parquet', 'a Int32, b String')"
     )
     node1.query(f"insert into table function {table_function} SELECT 1, 'kek'")
 
@@ -627,7 +621,7 @@ def test_virtual_columns_2(started_cluster):
     assert result.strip() == "hdfs://hdfs1:9000/parquet_2"
 
     table_function = (
-        f"hdfs('hdfs://hdfs1:9000/parquet_3', 'Parquet', 'a Int32, _path String')"
+        "hdfs('hdfs://hdfs1:9000/parquet_3', 'Parquet', 'a Int32, _path String')"
     )
     node1.query(f"insert into table function {table_function} SELECT 1, 'kek'")
 
@@ -702,7 +696,7 @@ def run_describe_query(node, file):
 def test_schema_inference_cache(started_cluster):
     node1.query("system drop schema cache")
     node1.query(
-        f"insert into function hdfs('hdfs://hdfs1:9000/test_cache0.jsonl') select * from numbers(100) settings hdfs_truncate_on_insert=1"
+        "insert into function hdfs('hdfs://hdfs1:9000/test_cache0.jsonl') select * from numbers(100) settings hdfs_truncate_on_insert=1"
     )
     time.sleep(1)
 
@@ -714,7 +708,7 @@ def test_schema_inference_cache(started_cluster):
     check_cache_hits(node1, "test_cache0.jsonl")
 
     node1.query(
-        f"insert into function hdfs('hdfs://hdfs1:9000/test_cache0.jsonl') select * from numbers(100) settings hdfs_truncate_on_insert=1"
+        "insert into function hdfs('hdfs://hdfs1:9000/test_cache0.jsonl') select * from numbers(100) settings hdfs_truncate_on_insert=1"
     )
     time.sleep(1)
 
@@ -722,7 +716,7 @@ def test_schema_inference_cache(started_cluster):
     check_cache_invalidations(node1, "test_cache0.jsonl")
 
     node1.query(
-        f"insert into function hdfs('hdfs://hdfs1:9000/test_cache1.jsonl') select * from numbers(100) settings hdfs_truncate_on_insert=1"
+        "insert into function hdfs('hdfs://hdfs1:9000/test_cache1.jsonl') select * from numbers(100) settings hdfs_truncate_on_insert=1"
     )
     time.sleep(1)
 
@@ -734,7 +728,7 @@ def test_schema_inference_cache(started_cluster):
     check_cache_hits(node1, "test_cache1.jsonl")
 
     node1.query(
-        f"insert into function hdfs('hdfs://hdfs1:9000/test_cache2.jsonl') select * from numbers(100) settings hdfs_truncate_on_insert=1"
+        "insert into function hdfs('hdfs://hdfs1:9000/test_cache2.jsonl') select * from numbers(100) settings hdfs_truncate_on_insert=1"
     )
     time.sleep(1)
 
@@ -766,7 +760,7 @@ def test_schema_inference_cache(started_cluster):
     check_cache_hits(node1, "test_cache0.jsonl")
 
     node1.query(
-        f"insert into function hdfs('hdfs://hdfs1:9000/test_cache3.jsonl') select * from numbers(100) settings hdfs_truncate_on_insert=1"
+        "insert into function hdfs('hdfs://hdfs1:9000/test_cache3.jsonl') select * from numbers(100) settings hdfs_truncate_on_insert=1"
     )
     time.sleep(1)
 
@@ -774,7 +768,7 @@ def test_schema_inference_cache(started_cluster):
     run_describe_query(node1, files)
     check_cache_hits(node1, files)
 
-    node1.query(f"system drop schema cache for hdfs")
+    node1.query("system drop schema cache for hdfs")
     check_cache(node1, [])
 
     run_describe_query(node1, files)
@@ -790,7 +784,7 @@ def test_schema_inference_cache(started_cluster):
 def test_hdfsCluster_skip_unavailable_shards(started_cluster):
     # Although skip_unavailable_shards is not set, cluster table functions should always skip unavailable shards.
     hdfs_api = started_cluster.hdfs_api
-    node = started_cluster.instances["node1"]
+    started_cluster.instances["node1"]
     data = "1\tSerialize\t555.222\n2\tData\t777.333\n"
     hdfs_api.write_data("/skip_unavailable_shards", data)
 
@@ -804,7 +798,7 @@ def test_hdfsCluster_skip_unavailable_shards(started_cluster):
 
 def test_hdfsCluster_unset_skip_unavailable_shards(started_cluster):
     hdfs_api = started_cluster.hdfs_api
-    node = started_cluster.instances["node1"]
+    started_cluster.instances["node1"]
     data = "1\tSerialize\t555.222\n2\tData\t777.333\n"
     hdfs_api.write_data("/unskip_unavailable_shards", data)
 

--- a/tests/integration/test_storage_hudi/test.py
+++ b/tests/integration/test_storage_hudi/test.py
@@ -1,12 +1,10 @@
 import logging
 import pytest
 import os
-import json
 
-import helpers.client
 from helpers.cluster import ClickHouseCluster
 from helpers.test_tools import TSV
-from helpers.s3_tools import prepare_s3_bucket, upload_directory, get_file_contents
+from helpers.s3_tools import prepare_s3_bucket, upload_directory
 
 import pyspark
 from pyspark.sql.types import (
@@ -15,11 +13,9 @@ from pyspark.sql.types import (
     StringType,
     IntegerType,
     DateType,
-    TimestampType,
     BooleanType,
     ArrayType,
 )
-from pyspark.sql.functions import current_timestamp
 from datetime import datetime
 from pyspark.sql.functions import monotonically_increasing_id, row_number
 from pyspark.sql.window import Window
@@ -79,7 +75,7 @@ def run_query(instance, query, stdin=None, settings=None):
 
 
 def write_hudi_from_df(spark, table_name, df, result_path, mode="overwrite"):
-    if mode is "overwrite":
+    if mode == "overwrite":
         hudi_write_mode = "insert_overwrite"
     else:
         hudi_write_mode = "upsert"

--- a/tests/integration/test_storage_iceberg/test.py
+++ b/tests/integration/test_storage_iceberg/test.py
@@ -1,14 +1,10 @@
-import helpers.client
 from helpers.cluster import ClickHouseCluster
 from helpers.test_tools import TSV
 
 import pyspark
 import logging
 import os
-import json
 import pytest
-import time
-import glob
 
 from pyspark.sql.types import (
     StructType,
@@ -16,17 +12,14 @@ from pyspark.sql.types import (
     StringType,
     IntegerType,
     DateType,
-    TimestampType,
     BooleanType,
     ArrayType,
 )
-from pyspark.sql.functions import current_timestamp
 from datetime import datetime
 from pyspark.sql.functions import monotonically_increasing_id, row_number
 from pyspark.sql.window import Window
-from pyspark.sql.readwriter import DataFrameWriter, DataFrameWriterV2
 
-from helpers.s3_tools import prepare_s3_bucket, upload_directory, get_file_contents
+from helpers.s3_tools import prepare_s3_bucket, upload_directory
 
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 
@@ -173,7 +166,7 @@ def test_single_iceberg_file(started_cluster, format_version):
         spark, parquet_data_path, TABLE_NAME, format_version=format_version
     )
 
-    files = upload_directory(
+    upload_directory(
         minio_client, bucket, f"/iceberg_data/default/{TABLE_NAME}/", ""
     )
 

--- a/tests/integration/test_storage_iceberg/test.py
+++ b/tests/integration/test_storage_iceberg/test.py
@@ -166,9 +166,7 @@ def test_single_iceberg_file(started_cluster, format_version):
         spark, parquet_data_path, TABLE_NAME, format_version=format_version
     )
 
-    upload_directory(
-        minio_client, bucket, f"/iceberg_data/default/{TABLE_NAME}/", ""
-    )
+    upload_directory(minio_client, bucket, f"/iceberg_data/default/{TABLE_NAME}/", "")
 
     create_iceberg_table(instance, TABLE_NAME)
     assert instance.query(f"SELECT * FROM {TABLE_NAME}") == instance.query(

--- a/tests/integration/test_storage_kafka/kafka_pb2.py
+++ b/tests/integration/test_storage_kafka/kafka_pb2.py
@@ -20,7 +20,7 @@ _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, globals())
 _builder.BuildTopDescriptorsAndMessages(
     DESCRIPTOR, "clickhouse_path.format_schemas.kafka_pb2", globals()
 )
-if _descriptor._USE_C_DESCRIPTORS == False:
+if _descriptor._USE_C_DESCRIPTORS is False:
     DESCRIPTOR._options = None
     _KEYVALUEPAIR._serialized_start = 46
     _KEYVALUEPAIR._serialized_end = 88

--- a/tests/integration/test_storage_kafka/message_with_repeated_pb2.py
+++ b/tests/integration/test_storage_kafka/message_with_repeated_pb2.py
@@ -20,7 +20,7 @@ _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, globals())
 _builder.BuildTopDescriptorsAndMessages(
     DESCRIPTOR, "clickhouse_path.format_schemas.message_with_repeated_pb2", globals()
 )
-if _descriptor._USE_C_DESCRIPTORS == False:
+if _descriptor._USE_C_DESCRIPTORS is False:
     DESCRIPTOR._options = None
     DESCRIPTOR._serialized_options = b"H\001"
     _MESSAGE._serialized_start = 62

--- a/tests/integration/test_storage_kafka/social_pb2.py
+++ b/tests/integration/test_storage_kafka/social_pb2.py
@@ -20,7 +20,7 @@ _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, globals())
 _builder.BuildTopDescriptorsAndMessages(
     DESCRIPTOR, "clickhouse_path.format_schemas.social_pb2", globals()
 )
-if _descriptor._USE_C_DESCRIPTORS == False:
+if _descriptor._USE_C_DESCRIPTORS is False:
     DESCRIPTOR._options = None
     _USER._serialized_start = 47
     _USER._serialized_end = 90

--- a/tests/integration/test_storage_kafka/test.py
+++ b/tests/integration/test_storage_kafka/test.py
@@ -197,7 +197,6 @@ def kafka_produce_protobuf_messages(kafka_cluster, topic, start_index, num_messa
 def kafka_produce_protobuf_messages_no_delimeters(
     kafka_cluster, topic, start_index, num_messages
 ):
-    data = ""
     producer = KafkaProducer(
         bootstrap_servers="localhost:{}".format(kafka_cluster.kafka_port)
     )
@@ -2280,7 +2279,7 @@ def test_kafka_virtual_columns2(kafka_cluster):
         "kafka.*Committed offset 2.*virt2_[01]", repetitions=4, look_behind_lines=6000
     )
 
-    members = describe_consumer_group(kafka_cluster, "virt2")
+    describe_consumer_group(kafka_cluster, "virt2")
     # pprint.pprint(members)
     # members[0]['client_id'] = 'ClickHouse-instance-test-kafka-0'
     # members[1]['client_id'] = 'ClickHouse-instance-test-kafka-1'
@@ -3695,7 +3694,7 @@ def test_kafka_formats_with_broken_message(kafka_cluster):
         # prepend empty value when supported
         if format_opts.get("supports_empty_value", False):
             data_prefix = data_prefix + [""]
-        if format_opts.get("printable", False) == False:
+        if format_opts.get("printable", False) is False:
             raw_message = "hex(_raw_message)"
         kafka_produce(kafka_cluster, topic_name, data_prefix + data_sample)
         instance.query(
@@ -4011,7 +4010,7 @@ def test_kafka_predefined_configuration(kafka_cluster):
     kafka_produce(kafka_cluster, topic_name, messages)
 
     instance.query(
-        f"""
+        """
         CREATE TABLE test.kafka (key UInt64, value UInt64) ENGINE = Kafka(kafka1, kafka_format='CSV');
         """
     )

--- a/tests/integration/test_storage_kerberized_hdfs/test.py
+++ b/tests/integration/test_storage_kerberized_hdfs/test.py
@@ -1,10 +1,8 @@
 import time
 import pytest
 
-import os
 
 from helpers.cluster import ClickHouseCluster
-import subprocess
 
 cluster = ClickHouseCluster(__file__)
 node1 = cluster.add_instance(
@@ -77,7 +75,6 @@ def test_write_storage_not_expired(started_cluster):
 
 
 def test_two_users(started_cluster):
-    hdfs_api = started_cluster.hdfs_api
 
     node1.query(
         "create table HDFSStorOne (id UInt32, name String, weight Float64) ENGINE = HDFS('hdfs://kerberizedhdfs1:9010/storage_user_one', 'TSV')"
@@ -89,11 +86,11 @@ def test_two_users(started_cluster):
     )
     node1.query("insert into HDFSStorTwo values (1, 'Ideal', 74.00)")
 
-    select_read_1 = node1.query(
+    node1.query(
         "select * from hdfs('hdfs://kerberizedhdfs1:9010/user/specuser/storage_user_two', 'TSV', 'id UInt64, text String, number Float64')"
     )
 
-    select_read_2 = node1.query(
+    node1.query(
         "select * from hdfs('hdfs://suser@kerberizedhdfs1:9010/storage_user_one', 'TSV', 'id UInt64, text String, number Float64')"
     )
 
@@ -108,7 +105,7 @@ def test_read_table_expired(started_cluster):
     time.sleep(15)
 
     try:
-        select_read = node1.query(
+        node1.query(
             "select * from hdfs('hdfs://reloginuser&kerberizedhdfs1:9010/simple_table_function', 'TSV', 'id UInt64, text String, number Float64')"
         )
         assert False, "Exception have to be thrown"

--- a/tests/integration/test_storage_kerberized_hdfs/test.py
+++ b/tests/integration/test_storage_kerberized_hdfs/test.py
@@ -75,7 +75,6 @@ def test_write_storage_not_expired(started_cluster):
 
 
 def test_two_users(started_cluster):
-
     node1.query(
         "create table HDFSStorOne (id UInt32, name String, weight Float64) ENGINE = HDFS('hdfs://kerberizedhdfs1:9010/storage_user_one', 'TSV')"
     )

--- a/tests/integration/test_storage_kerberized_kafka/test.py
+++ b/tests/integration/test_storage_kerberized_kafka/test.py
@@ -1,22 +1,11 @@
-import os.path as p
-import random
-import threading
 import time
 import pytest
 import logging
 
 from helpers.cluster import ClickHouseCluster
 from helpers.test_tools import TSV
-from helpers.client import QueryRuntimeException
 
-import json
-import subprocess
-import kafka.errors
-from kafka import KafkaAdminClient, KafkaProducer, KafkaConsumer, BrokerConnection
-from kafka.admin import NewTopic
-from kafka.protocol.admin import DescribeGroupsResponse_v1, DescribeGroupsRequest_v1
-from kafka.protocol.group import MemberAssignment
-import socket
+from kafka import KafkaProducer
 
 cluster = ClickHouseCluster(__file__)
 instance = cluster.add_instance(

--- a/tests/integration/test_storage_meilisearch/test.py
+++ b/tests/integration/test_storage_meilisearch/test.py
@@ -15,7 +15,7 @@ SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 def started_cluster(request):
     try:
         cluster = ClickHouseCluster(__file__)
-        node = cluster.add_instance(
+        cluster.add_instance(
             "meili", main_configs=["configs/named_collection.xml"], with_meili=True
         )
         cluster.start()

--- a/tests/integration/test_storage_mongodb/test.py
+++ b/tests/integration/test_storage_mongodb/test.py
@@ -168,45 +168,45 @@ def test_arrays(started_cluster):
         )
 
     assert (
-        node.query(f"SELECT arr_date FROM arrays_mongo_table WHERE key = 42")
+        node.query("SELECT arr_date FROM arrays_mongo_table WHERE key = 42")
         == "['2002-10-27','2024-01-08']\n"
     )
 
     assert (
-        node.query(f"SELECT arr_datetime FROM arrays_mongo_table WHERE key = 42")
+        node.query("SELECT arr_datetime FROM arrays_mongo_table WHERE key = 42")
         == "['2023-03-31 06:03:12','1999-02-28 12:46:34']\n"
     )
 
     assert (
-        node.query(f"SELECT arr_string FROM arrays_mongo_table WHERE key = 42")
+        node.query("SELECT arr_string FROM arrays_mongo_table WHERE key = 42")
         == "['43','44','45']\n"
     )
 
     assert (
-        node.query(f"SELECT arr_uuid FROM arrays_mongo_table WHERE key = 42")
+        node.query("SELECT arr_uuid FROM arrays_mongo_table WHERE key = 42")
         == "['f0e77736-91d1-48ce-8f01-15123ca1c7ed','93376a07-c044-4281-a76e-ad27cf6973c5']\n"
     )
 
     assert (
-        node.query(f"SELECT arr_arr_bool FROM arrays_mongo_table WHERE key = 42")
+        node.query("SELECT arr_arr_bool FROM arrays_mongo_table WHERE key = 42")
         == "[[true,false,true],[true],[],[],[false],[false]]\n"
     )
 
     assert (
-        node.query(f"SELECT arr_empty FROM arrays_mongo_table WHERE key = 42") == "[]\n"
+        node.query("SELECT arr_empty FROM arrays_mongo_table WHERE key = 42") == "[]\n"
     )
 
     assert (
-        node.query(f"SELECT arr_null FROM arrays_mongo_table WHERE key = 42") == "[]\n"
+        node.query("SELECT arr_null FROM arrays_mongo_table WHERE key = 42") == "[]\n"
     )
 
     assert (
-        node.query(f"SELECT arr_arr_null FROM arrays_mongo_table WHERE key = 42")
+        node.query("SELECT arr_arr_null FROM arrays_mongo_table WHERE key = 42")
         == "[]\n"
     )
 
     assert (
-        node.query(f"SELECT arr_nullable FROM arrays_mongo_table WHERE key = 42")
+        node.query("SELECT arr_nullable FROM arrays_mongo_table WHERE key = 42")
         == "[]\n"
     )
 

--- a/tests/integration/test_storage_mongodb/test.py
+++ b/tests/integration/test_storage_mongodb/test.py
@@ -11,7 +11,7 @@ import datetime
 def started_cluster(request):
     try:
         cluster = ClickHouseCluster(__file__)
-        node = cluster.add_instance(
+        cluster.add_instance(
             "node",
             main_configs=[
                 "configs_secure/config.d/ssl_conf.xml",

--- a/tests/integration/test_storage_mysql/test.py
+++ b/tests/integration/test_storage_mysql/test.py
@@ -571,7 +571,7 @@ def test_predefined_connection_configuration(started_cluster):
     node1.query(
         "INSERT INTO test_table (id, name, money) select number, toString(number), number from numbers(100)"
     )
-    assert node1.query(f"SELECT count() FROM test_table").rstrip() == "100"
+    assert node1.query("SELECT count() FROM test_table").rstrip() == "100"
 
     node1.query(
         """
@@ -586,7 +586,7 @@ def test_predefined_connection_configuration(started_cluster):
     node1.query(
         "INSERT INTO test_table (id, name, money) select number, toString(number), number from numbers(100)"
     )
-    assert node1.query(f"SELECT count() FROM test_table").rstrip() == "100"
+    assert node1.query("SELECT count() FROM test_table").rstrip() == "100"
 
     node1.query_and_get_error(
         """
@@ -624,7 +624,7 @@ def test_predefined_connection_configuration(started_cluster):
         ENGINE MySQL(mysql3, port=3306);
     """
     )
-    assert node1.query(f"SELECT count() FROM test_table").rstrip() == "100"
+    assert node1.query("SELECT count() FROM test_table").rstrip() == "100"
 
     assert "Connection pool cannot have zero size" in node1.query_and_get_error(
         "SELECT count() FROM mysql(mysql1, table='test_table', connection_pool_size=0)"
@@ -777,7 +777,7 @@ def test_settings(started_cluster):
 
     rw_timeout = 20123001
     connect_timeout = 20123002
-    node1.query(f"SELECT * FROM mysql(mysql_with_settings, table='test_settings')")
+    node1.query("SELECT * FROM mysql(mysql_with_settings, table='test_settings')")
     assert node1.contains_in_log(
         f"with settings: connect_timeout={connect_timeout}, read_write_timeout={rw_timeout}"
     )

--- a/tests/integration/test_storage_nats/nats_pb2.py
+++ b/tests/integration/test_storage_nats/nats_pb2.py
@@ -30,7 +30,7 @@ ProtoKeyValue = _reflection.GeneratedProtocolMessageType(
 )
 _sym_db.RegisterMessage(ProtoKeyValue)
 
-if _descriptor._USE_C_DESCRIPTORS == False:
+if _descriptor._USE_C_DESCRIPTORS is False:
     DESCRIPTOR._options = None
     _PROTOKEYVALUE._serialized_start = 45
     _PROTOKEYVALUE._serialized_end = 88

--- a/tests/integration/test_storage_nats/test.py
+++ b/tests/integration/test_storage_nats/test.py
@@ -1,10 +1,4 @@
 import pytest
-
-# FIXME This test is too flaky
-# https://github.com/ClickHouse/ClickHouse/issues/39185
-
-pytestmark = pytest.mark.skip
-
 import json
 import os.path as p
 import random
@@ -12,18 +6,20 @@ import subprocess
 import threading
 import logging
 import time
-from random import randrange
-import math
-
 import asyncio
 from google.protobuf.internal.encoder import _VarintBytes
 from helpers.client import QueryRuntimeException
 from helpers.cluster import ClickHouseCluster, check_nats_is_available, nats_connect_ssl
 from helpers.test_tools import TSV
-
 from . import nats_pb2
 
+# FIXME This test is too flaky
+# https://github.com/ClickHouse/ClickHouse/issues/39185
+
+pytestmark = pytest.mark.skip
+
 cluster = ClickHouseCluster(__file__)
+
 instance = cluster.add_instance(
     "instance",
     main_configs=[

--- a/tests/integration/test_storage_policies/test.py
+++ b/tests/integration/test_storage_policies/test.py
@@ -1,7 +1,6 @@
 import os
 
 import pytest
-from helpers.test_tools import TSV
 from helpers.cluster import ClickHouseCluster
 
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))

--- a/tests/integration/test_storage_postgresql/test.py
+++ b/tests/integration/test_storage_postgresql/test.py
@@ -44,7 +44,7 @@ def test_postgres_select_insert(started_cluster):
     cursor.execute(f"DROP TABLE IF EXISTS {table_name}")
     cursor.execute(f"CREATE TABLE {table_name} (a integer, b text, c integer)")
 
-    result = node1.query(
+    node1.query(
         f"""
         INSERT INTO TABLE FUNCTION {table}
         SELECT number, concat('name_', toString(number)), 3 from numbers(10000)"""
@@ -67,8 +67,8 @@ def test_postgres_select_insert(started_cluster):
 
 def test_postgres_conversions(started_cluster):
     cursor = started_cluster.postgres_conn.cursor()
-    cursor.execute(f"DROP TABLE IF EXISTS test_types")
-    cursor.execute(f"DROP TABLE IF EXISTS test_array_dimensions")
+    cursor.execute("DROP TABLE IF EXISTS test_types")
+    cursor.execute("DROP TABLE IF EXISTS test_array_dimensions")
 
     cursor.execute(
         """CREATE TABLE test_types (
@@ -169,8 +169,8 @@ def test_postgres_conversions(started_cluster):
     )
     assert result == expected
 
-    cursor.execute(f"DROP TABLE test_types")
-    cursor.execute(f"DROP TABLE test_array_dimensions")
+    cursor.execute("DROP TABLE test_types")
+    cursor.execute("DROP TABLE test_array_dimensions")
 
 
 def test_non_default_scema(started_cluster):
@@ -264,22 +264,22 @@ def test_concurrent_queries(started_cluster):
 
     def node_select(_):
         for i in range(20):
-            result = node1.query("SELECT * FROM test.test_table", user="default")
+            node1.query("SELECT * FROM test.test_table", user="default")
 
     def node_insert(_):
         for i in range(20):
-            result = node1.query(
+            node1.query(
                 "INSERT INTO test.test_table SELECT number, number FROM numbers(1000)",
                 user="default",
             )
 
     def node_insert_select(_):
         for i in range(20):
-            result = node1.query(
+            node1.query(
                 "INSERT INTO test.test_table SELECT number, number FROM numbers(1000)",
                 user="default",
             )
-            result = node1.query(
+            node1.query(
                 "SELECT * FROM test.test_table LIMIT 100", user="default"
             )
 
@@ -510,8 +510,8 @@ def test_postgres_on_conflict(started_cluster):
 
 def test_predefined_connection_configuration(started_cluster):
     cursor = started_cluster.postgres_conn.cursor()
-    cursor.execute(f"DROP TABLE IF EXISTS test_table")
-    cursor.execute(f"CREATE TABLE test_table (a integer PRIMARY KEY, b integer)")
+    cursor.execute("DROP TABLE IF EXISTS test_table")
+    cursor.execute("CREATE TABLE test_table (a integer PRIMARY KEY, b integer)")
 
     node1.query(
         """
@@ -521,9 +521,9 @@ def test_predefined_connection_configuration(started_cluster):
     """
     )
     node1.query(
-        f""" INSERT INTO test.test_table SELECT number, number from numbers(100)"""
+        """ INSERT INTO test.test_table SELECT number, number from numbers(100)"""
     )
-    assert node1.query(f"SELECT count() FROM test.test_table").rstrip() == "100"
+    assert node1.query("SELECT count() FROM test.test_table").rstrip() == "100"
 
     node1.query(
         """
@@ -533,12 +533,12 @@ def test_predefined_connection_configuration(started_cluster):
     """
     )
     node1.query(
-        f""" INSERT INTO test.test_table SELECT number, number from numbers(100)"""
+        """ INSERT INTO test.test_table SELECT number, number from numbers(100)"""
     )
     node1.query(
-        f""" INSERT INTO test.test_table SELECT number, number from numbers(100)"""
+        """ INSERT INTO test.test_table SELECT number, number from numbers(100)"""
     )
-    assert node1.query(f"SELECT count() FROM test.test_table").rstrip() == "100"
+    assert node1.query("SELECT count() FROM test.test_table").rstrip() == "100"
 
     node1.query("DROP TABLE test.test_table;")
     node1.query_and_get_error(
@@ -566,7 +566,7 @@ def test_predefined_connection_configuration(started_cluster):
         ENGINE PostgreSQL(postgres1, port=5432, database='postgres', table='test_table');
     """
     )
-    assert node1.query(f"SELECT count() FROM test.test_table").rstrip() == "100"
+    assert node1.query("SELECT count() FROM test.test_table").rstrip() == "100"
 
     node1.query(
         """
@@ -575,13 +575,13 @@ def test_predefined_connection_configuration(started_cluster):
         ENGINE PostgreSQL(postgres3, port=5432);
     """
     )
-    assert node1.query(f"SELECT count() FROM test.test_table").rstrip() == "100"
+    assert node1.query("SELECT count() FROM test.test_table").rstrip() == "100"
 
-    assert node1.query(f"SELECT count() FROM postgresql(postgres1)").rstrip() == "100"
+    assert node1.query("SELECT count() FROM postgresql(postgres1)").rstrip() == "100"
     node1.query(
         "INSERT INTO TABLE FUNCTION postgresql(postgres1, on_conflict='ON CONFLICT DO NOTHING') SELECT number, number from numbers(100)"
     )
-    assert node1.query(f"SELECT count() FROM postgresql(postgres1)").rstrip() == "100"
+    assert node1.query("SELECT count() FROM postgresql(postgres1)").rstrip() == "100"
 
     cursor.execute("DROP SCHEMA IF EXISTS test_schema CASCADE")
     cursor.execute("CREATE SCHEMA test_schema")
@@ -591,13 +591,13 @@ def test_predefined_connection_configuration(started_cluster):
     )
     assert (
         node1.query(
-            f"SELECT count() FROM postgresql(postgres1, schema='test_schema')"
+            "SELECT count() FROM postgresql(postgres1, schema='test_schema')"
         ).rstrip()
         == "200"
     )
 
     cursor.execute("DROP SCHEMA test_schema CASCADE")
-    cursor.execute(f"DROP TABLE test_table ")
+    cursor.execute("DROP TABLE test_table ")
 
 
 def test_where_false(started_cluster):
@@ -669,12 +669,12 @@ def test_auto_close_connection(started_cluster):
     """
     )
 
-    result = node2.query(
+    node2.query(
         "INSERT INTO test.test_table SELECT number, number FROM numbers(1000)",
         user="default",
     )
 
-    result = node2.query("SELECT * FROM test.test_table LIMIT 100", user="default")
+    node2.query("SELECT * FROM test.test_table LIMIT 100", user="default")
 
     node2.query(
         f"""

--- a/tests/integration/test_storage_postgresql/test.py
+++ b/tests/integration/test_storage_postgresql/test.py
@@ -279,9 +279,7 @@ def test_concurrent_queries(started_cluster):
                 "INSERT INTO test.test_table SELECT number, number FROM numbers(1000)",
                 user="default",
             )
-            node1.query(
-                "SELECT * FROM test.test_table LIMIT 100", user="default"
-            )
+            node1.query("SELECT * FROM test.test_table LIMIT 100", user="default")
 
     busy_pool = Pool(30)
     p = busy_pool.map_async(node_select, range(30))

--- a/tests/integration/test_storage_rabbitmq/rabbitmq_pb2.py
+++ b/tests/integration/test_storage_rabbitmq/rabbitmq_pb2.py
@@ -20,7 +20,7 @@ _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, globals())
 _builder.BuildTopDescriptorsAndMessages(
     DESCRIPTOR, "clickhouse_path.format_schemas.rabbitmq_pb2", globals()
 )
-if _descriptor._USE_C_DESCRIPTORS == False:
+if _descriptor._USE_C_DESCRIPTORS is False:
     DESCRIPTOR._options = None
     _KEYVALUEPROTO._serialized_start = 49
     _KEYVALUEPROTO._serialized_end = 92

--- a/tests/integration/test_storage_rabbitmq/test.py
+++ b/tests/integration/test_storage_rabbitmq/test.py
@@ -2411,9 +2411,7 @@ def test_rabbitmq_drop_table_properly(rabbitmq_cluster):
     time.sleep(30)
 
     try:
-        exists = channel.queue_declare(
-            queue="rabbit_queue_drop", passive=True
-        )
+        exists = channel.queue_declare(queue="rabbit_queue_drop", passive=True)
     except Exception:
         exists = False
 

--- a/tests/integration/test_storage_s3/s3_mocks/unstable_server.py
+++ b/tests/integration/test_storage_s3/s3_mocks/unstable_server.py
@@ -1,8 +1,6 @@
 import http.server
 import random
 import re
-import socket
-import struct
 import sys
 
 

--- a/tests/integration/test_storage_s3/test.py
+++ b/tests/integration/test_storage_s3/test.py
@@ -229,17 +229,20 @@ def test_get_file_with_special(started_cluster, special):
 
     get_query = f"SELECT * FROM s3('http://{started_cluster.minio_host}:{started_cluster.minio_port}/{bucket}/get_file_with_{special}_{urlsafe_symbol}two.csv', {auth}'CSV', '{table_format}') FORMAT TSV"
     assert [
-        list(map(int, line.split())) for line in run_query(instance, get_query).splitlines()
+        list(map(int, line.split()))
+        for line in run_query(instance, get_query).splitlines()
     ] == values
 
     get_query = f"SELECT * FROM s3('http://{started_cluster.minio_host}:{started_cluster.minio_port}/{bucket}/get_file_with_{special}*.csv', {auth}'CSV', '{table_format}') FORMAT TSV"
     assert [
-        list(map(int, line.split())) for line in run_query(instance, get_query).splitlines()
+        list(map(int, line.split()))
+        for line in run_query(instance, get_query).splitlines()
     ] == values
 
     get_query = f"SELECT * FROM s3('http://{started_cluster.minio_host}:{started_cluster.minio_port}/{bucket}/get_file_with_{special}_{urlsafe_symbol}*.csv', {auth}'CSV', '{table_format}') FORMAT TSV"
     assert [
-        list(map(int, line.split())) for line in run_query(instance, get_query).splitlines()
+        list(map(int, line.split()))
+        for line in run_query(instance, get_query).splitlines()
     ] == values
 
 

--- a/tests/integration/test_storage_s3/test_invalid_env_credentials.py
+++ b/tests/integration/test_storage_s3/test_invalid_env_credentials.py
@@ -5,7 +5,7 @@ import logging
 import helpers.client
 from helpers.mock_servers import start_mock_servers
 import pytest
-from helpers.cluster import ClickHouseCluster, ClickHouseInstance
+from helpers.cluster import ClickHouseCluster
 
 MINIO_INTERNAL_PORT = 9001
 
@@ -140,7 +140,7 @@ def test_no_sign_named_collections(started_cluster):
     bucket = started_cluster.minio_bucket
 
     instance.query(
-        f"insert into function s3(s3_json_no_sign) select * from numbers(100) settings s3_truncate_on_insert=1"
+        "insert into function s3(s3_json_no_sign) select * from numbers(100) settings s3_truncate_on_insert=1"
     )
 
     with pytest.raises(helpers.client.QueryRuntimeException) as ei:
@@ -151,4 +151,4 @@ def test_no_sign_named_collections(started_cluster):
         assert ei.value.returncode == 243
         assert "HTTP response code: 403" in ei.value.stderr
 
-    assert "100" == instance.query(f"select count() from s3(s3_json_no_sign)").strip()
+    assert "100" == instance.query("select count() from s3(s3_json_no_sign)").strip()

--- a/tests/integration/test_storage_url/test.py
+++ b/tests/integration/test_storage_url/test.py
@@ -22,15 +22,15 @@ def setup_node():
 
 def test_partition_by():
     result = node1.query(
-        f"select * from url('http://nginx:80/test_1', 'TSV', 'column1 UInt32, column2 UInt32, column3 UInt32')"
+        "select * from url('http://nginx:80/test_1', 'TSV', 'column1 UInt32, column2 UInt32, column3 UInt32')"
     )
     assert result.strip() == "3\t2\t1"
     result = node1.query(
-        f"select * from url('http://nginx:80/test_2', 'TSV', 'column1 UInt32, column2 UInt32, column3 UInt32')"
+        "select * from url('http://nginx:80/test_2', 'TSV', 'column1 UInt32, column2 UInt32, column3 UInt32')"
     )
     assert result.strip() == "1\t3\t2"
     result = node1.query(
-        f"select * from url('http://nginx:80/test_3', 'TSV', 'column1 UInt32, column2 UInt32, column3 UInt32')"
+        "select * from url('http://nginx:80/test_3', 'TSV', 'column1 UInt32, column2 UInt32, column3 UInt32')"
     )
     assert result.strip() == "1\t2\t3"
 
@@ -40,33 +40,33 @@ def test_table_function_url_access_rights():
 
     expected_error = "necessary to have grant CREATE TEMPORARY TABLE, URL ON *.*"
     assert expected_error in node1.query_and_get_error(
-        f"SELECT * FROM url('http://nginx:80/test_1', 'TSV', 'column1 UInt32, column2 UInt32, column3 UInt32')",
+        "SELECT * FROM url('http://nginx:80/test_1', 'TSV', 'column1 UInt32, column2 UInt32, column3 UInt32')",
         user="u1",
     )
 
     expected_error = "necessary to have grant CREATE TEMPORARY TABLE, URL ON *.*"
     assert expected_error in node1.query_and_get_error(
-        f"SELECT * FROM url('http://nginx:80/test_1', 'TSV')", user="u1"
+        "SELECT * FROM url('http://nginx:80/test_1', 'TSV')", user="u1"
     )
 
     assert node1.query(
-        f"DESCRIBE TABLE url('http://nginx:80/test_1', 'TSV', 'column1 UInt32, column2 UInt32, column3 UInt32')",
+        "DESCRIBE TABLE url('http://nginx:80/test_1', 'TSV', 'column1 UInt32, column2 UInt32, column3 UInt32')",
         user="u1",
     ) == TSV([["column1", "UInt32"], ["column2", "UInt32"], ["column3", "UInt32"]])
 
     assert node1.query(
-        f"DESCRIBE TABLE url('http://nginx:80/not-exist', 'TSV', 'column1 UInt32, column2 UInt32, column3 UInt32')",
+        "DESCRIBE TABLE url('http://nginx:80/not-exist', 'TSV', 'column1 UInt32, column2 UInt32, column3 UInt32')",
         user="u1",
     ) == TSV([["column1", "UInt32"], ["column2", "UInt32"], ["column3", "UInt32"]])
 
     expected_error = "necessary to have grant URL ON *.*"
     assert expected_error in node1.query_and_get_error(
-        f"DESCRIBE TABLE url('http://nginx:80/test_1', 'TSV')", user="u1"
+        "DESCRIBE TABLE url('http://nginx:80/test_1', 'TSV')", user="u1"
     )
 
     node1.query("GRANT URL ON *.* TO u1")
     assert node1.query(
-        f"DESCRIBE TABLE url('http://nginx:80/test_1', 'TSV')",
+        "DESCRIBE TABLE url('http://nginx:80/test_1', 'TSV')",
         user="u1",
     ) == TSV(
         [

--- a/tests/integration/test_storage_url_http_headers/test.py
+++ b/tests/integration/test_storage_url_http_headers/test.py
@@ -1,6 +1,5 @@
 import pytest
 import os
-import time
 
 from . import http_headers_echo_server
 
@@ -30,7 +29,7 @@ def run_echo_server():
 
     for _ in range(0, 10):
         ping_response = server.exec_in_container(
-            ["curl", "-s", f"http://localhost:8000/"],
+            ["curl", "-s", "http://localhost:8000/"],
             nothrow=True,
         )
 

--- a/tests/integration/test_structured_logging_json/test.py
+++ b/tests/integration/test_structured_logging_json/test.py
@@ -27,7 +27,7 @@ def start_cluster():
 def is_json(log_json):
     try:
         json.loads(log_json)
-    except ValueError as e:
+    except ValueError:
         return False
     return True
 
@@ -62,7 +62,7 @@ def validate_log_config_relation(config, logs, config_type):
             for config_key in keys_in_config:
                 if config_key not in keys_in_log:
                     return False
-    except ValueError as e:
+    except ValueError:
         return False
     return True
 
@@ -94,8 +94,8 @@ def test_structured_logging_json_format(start_cluster):
         ["cat", "/etc/clickhouse-server/config.d/config_no_keys_json.xml"]
     )
 
-    assert valiade_everything(config_all_keys, node_all_keys, "config_all_keys") == True
+    assert valiade_everything(config_all_keys, node_all_keys, "config_all_keys") is True
     assert (
-        valiade_everything(config_some_keys, node_some_keys, "config_some_keys") == True
+        valiade_everything(config_some_keys, node_some_keys, "config_some_keys") is True
     )
-    assert valiade_everything(config_no_keys, node_no_keys, "config_no_keys") == True
+    assert valiade_everything(config_no_keys, node_no_keys, "config_no_keys") is True

--- a/tests/integration/test_system_clusters_actual_information/test.py
+++ b/tests/integration/test_system_clusters_actual_information/test.py
@@ -1,14 +1,13 @@
 import os
 import sys
 import time
-
 import pytest
+from helpers.cluster import ClickHouseCluster
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from helpers.cluster import ClickHouseCluster
-
 cluster = ClickHouseCluster(__file__)
+
 node = cluster.add_instance(
     "node", with_zookeeper=True, main_configs=["configs/remote_servers.xml"]
 )

--- a/tests/integration/test_system_logs_comment/test.py
+++ b/tests/integration/test_system_logs_comment/test.py
@@ -23,7 +23,7 @@ def test_system_logs_comment():
         [
             "bash",
             "-c",
-            f"""echo "
+            """echo "
         <clickhouse>
             <query_log>
                 <engine>ENGINE = MergeTree

--- a/tests/integration/test_system_logs_recreate/test.py
+++ b/tests/integration/test_system_logs_recreate/test.py
@@ -157,7 +157,7 @@ def test_drop_system_log():
         [
             "bash",
             "-c",
-            f"""echo "
+            """echo "
         <clickhouse>
             <query_log>
                 <flush_interval_milliseconds replace=\\"replace\\">1000000</flush_interval_milliseconds>
@@ -178,6 +178,6 @@ def test_drop_system_log():
     node.query("system flush logs")
     assert node.query("select count() > 0 from system.query_log") == "1\n"
     node.exec_in_container(
-        ["rm", f"/etc/clickhouse-server/config.d/yyy-override-query_log.xml"]
+        ["rm", "/etc/clickhouse-server/config.d/yyy-override-query_log.xml"]
     )
     node.restart_clickhouse()

--- a/tests/integration/test_system_merges/test.py
+++ b/tests/integration/test_system_merges/test.py
@@ -1,5 +1,4 @@
 import threading
-import time
 
 import pytest
 from helpers.cluster import ClickHouseCluster

--- a/tests/integration/test_system_metrics/test.py
+++ b/tests/integration/test_system_metrics/test.py
@@ -1,4 +1,3 @@
-import time
 
 import pytest
 from helpers.cluster import ClickHouseCluster

--- a/tests/integration/test_system_metrics/test.py
+++ b/tests/integration/test_system_metrics/test.py
@@ -1,4 +1,3 @@
-
 import pytest
 from helpers.cluster import ClickHouseCluster
 from helpers.test_tools import assert_eq_with_retry

--- a/tests/integration/test_system_queries/test.py
+++ b/tests/integration/test_system_queries/test.py
@@ -1,14 +1,13 @@
 import os
 import sys
 import time
-from contextlib import contextmanager
-
 import pytest
-
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from contextlib import contextmanager
 from helpers.cluster import ClickHouseCluster
 from helpers.test_tools import TSV
 from helpers.client import QueryRuntimeException
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 
 @pytest.fixture(scope="module")

--- a/tests/integration/test_system_replicated_fetches/test.py
+++ b/tests/integration/test_system_replicated_fetches/test.py
@@ -5,7 +5,6 @@ import pytest
 import time
 from helpers.cluster import ClickHouseCluster
 from helpers.network import PartitionManager
-from helpers.test_tools import assert_eq_with_retry
 import random
 import string
 import json

--- a/tests/integration/test_table_function_mongodb/test.py
+++ b/tests/integration/test_table_function_mongodb/test.py
@@ -10,7 +10,7 @@ from helpers.cluster import ClickHouseCluster
 def started_cluster(request):
     try:
         cluster = ClickHouseCluster(__file__)
-        node = cluster.add_instance(
+        cluster.add_instance(
             "node",
             with_mongo=True,
             main_configs=[

--- a/tests/integration/test_table_functions_access_rights/test.py
+++ b/tests/integration/test_table_functions_access_rights/test.py
@@ -1,6 +1,5 @@
 import pytest
 from helpers.cluster import ClickHouseCluster
-from helpers.test_tools import TSV
 
 cluster = ClickHouseCluster(__file__)
 instance = cluster.add_instance("instance")

--- a/tests/integration/test_tcp_handler_http_responses/test_case.py
+++ b/tests/integration/test_tcp_handler_http_responses/test_case.py
@@ -1,5 +1,4 @@
 """Test HTTP responses given by the TCP Handler."""
-from pathlib import Path
 import pytest
 from helpers.cluster import ClickHouseCluster
 import requests

--- a/tests/integration/test_tcp_handler_interserver_listen_host/test_case.py
+++ b/tests/integration/test_tcp_handler_interserver_listen_host/test_case.py
@@ -1,9 +1,7 @@
 """Test Interserver responses on configured IP."""
-from pathlib import Path
 import pytest
 from helpers.cluster import ClickHouseCluster
 import requests
-import socket
 import time
 
 cluster = ClickHouseCluster(__file__)
@@ -47,7 +45,7 @@ def requests_get(url, attempts=10, sleep=0.5):
         attempt += 1
         try:
             return requests.get(url)
-        except requests.exceptions.ConnectionError as e:
+        except requests.exceptions.ConnectionError:
             if attempt >= attempts:
                 raise
         time.sleep(sleep)

--- a/tests/integration/test_temporary_data_in_cache/test.py
+++ b/tests/integration/test_temporary_data_in_cache/test.py
@@ -26,14 +26,10 @@ def start_cluster():
 
 def test_cache_evicted_by_temporary_data(start_cluster):
     q = node.query
-    get_free_space = lambda: int(
-        q(
-            "SELECT free_space FROM system.disks WHERE name = 'tiny_local_cache_local_disk'"
-        ).strip()
-    )
-    get_cache_size = lambda: int(
-        q("SELECT sum(size) FROM system.filesystem_cache").strip()
-    )
+    def get_free_space():
+        return int(q("SELECT free_space FROM system.disks WHERE name = 'tiny_local_cache_local_disk'").strip())
+    def get_cache_size():
+        return int(q("SELECT sum(size) FROM system.filesystem_cache").strip())
 
     assert get_cache_size() == 0
 

--- a/tests/integration/test_temporary_data_in_cache/test.py
+++ b/tests/integration/test_temporary_data_in_cache/test.py
@@ -26,8 +26,14 @@ def start_cluster():
 
 def test_cache_evicted_by_temporary_data(start_cluster):
     q = node.query
+
     def get_free_space():
-        return int(q("SELECT free_space FROM system.disks WHERE name = 'tiny_local_cache_local_disk'").strip())
+        return int(
+            q(
+                "SELECT free_space FROM system.disks WHERE name = 'tiny_local_cache_local_disk'"
+            ).strip()
+        )
+
     def get_cache_size():
         return int(q("SELECT sum(size) FROM system.filesystem_cache").strip())
 

--- a/tests/integration/test_tlsv1_3/test.py
+++ b/tests/integration/test_tlsv1_3/test.py
@@ -1,9 +1,10 @@
 import pytest
-from helpers.cluster import ClickHouseCluster
-from helpers.ssl_context import WrapSSLContextWithSNI
-import urllib.request, urllib.parse
 import ssl
 import os.path
+import urllib.request
+import urllib.parse
+from helpers.cluster import ClickHouseCluster
+from helpers.ssl_context import WrapSSLContextWithSNI
 
 
 # The test cluster is configured with certificate for that host name, see 'server-ext.cnf'.

--- a/tests/integration/test_ttl_move/test.py
+++ b/tests/integration/test_ttl_move/test.py
@@ -1,5 +1,4 @@
 import random
-import string
 import threading
 import time
 from multiprocessing.dummy import Pool
@@ -254,7 +253,7 @@ def test_inserts_to_disk_work(started_cluster, name, engine, positive):
     finally:
         try:
             node1.query("DROP TABLE IF EXISTS {} SYNC".format(name))
-        except:
+        except Exception:
             pass
 
 
@@ -303,7 +302,6 @@ def test_moves_work_after_storage_policy_change(started_cluster, name, engine):
         )
 
         wait_expire_1 = 12
-        wait_expire_2 = 4
         time_1 = time.time() + wait_expire_1
 
         data = []  # 10MB in total
@@ -703,7 +701,7 @@ def test_replicated_download_ttl_info(started_cluster):
         for node in (node1, node2):
             try:
                 node.query("DROP TABLE IF EXISTS {} SYNC".format(name))
-            except:
+            except Exception:
                 continue
 
 
@@ -1475,7 +1473,7 @@ def test_concurrent_alter_with_ttl_move(started_cluster, name, engine):
                     node1.query(
                         "ALTER TABLE {} UPDATE number = number + 1 WHERE 1".format(name)
                     )
-                except:
+                except Exception:
                     pass
 
         def alter_modify_ttl(num):
@@ -1508,7 +1506,7 @@ def test_concurrent_alter_with_ttl_move(started_cluster, name, engine):
                         settings={"optimize_throw_if_noop": "1"},
                     )
                     break
-                except:
+                except Exception:
                     pass
 
         p = Pool(15)
@@ -1679,7 +1677,7 @@ def test_alter_with_merge_work(started_cluster, name, engine, positive):
                         settings={"optimize_throw_if_noop": "1"},
                     )
                     break
-                except:
+                except Exception:
                     pass
 
         for p in range(3):
@@ -1827,7 +1825,7 @@ def test_disabled_ttl_move_on_insert(started_cluster, name, dest_type, engine):
     finally:
         try:
             node1.query("DROP TABLE IF EXISTS {} SYNC".format(name))
-        except:
+        except Exception:
             pass
 
 
@@ -1911,5 +1909,5 @@ def test_ttl_move_if_exists(started_cluster, name, dest_type):
         try:
             node1.query("DROP TABLE IF EXISTS {} SYNC".format(name))
             node2.query("DROP TABLE IF EXISTS {} SYNC".format(name))
-        except:
+        except Exception:
             pass

--- a/tests/integration/test_ttl_replicated/test.py
+++ b/tests/integration/test_ttl_replicated/test.py
@@ -8,18 +8,9 @@ from helpers.wait_for_helpers import wait_for_delete_empty_parts
 
 cluster = ClickHouseCluster(__file__)
 
-node1 = cluster.add_instance(
-    "node1",
-    with_zookeeper=True
-)
-node2 = cluster.add_instance(
-    "node2",
-    with_zookeeper=True
-)
-node3 = cluster.add_instance(
-    "node3",
-    with_zookeeper=True
-)
+node1 = cluster.add_instance("node1", with_zookeeper=True)
+node2 = cluster.add_instance("node2", with_zookeeper=True)
+node3 = cluster.add_instance("node3", with_zookeeper=True)
 node4 = cluster.add_instance(
     "node4",
     with_zookeeper=True,

--- a/tests/integration/test_ttl_replicated/test.py
+++ b/tests/integration/test_ttl_replicated/test.py
@@ -1,17 +1,25 @@
 import time
-
-import helpers.client as client
 import pytest
+import helpers.client as client
 from helpers.cluster import ClickHouseCluster
 from helpers.test_tools import TSV, exec_query_with_retry
 from helpers.wait_for_helpers import wait_for_delete_inactive_parts
 from helpers.wait_for_helpers import wait_for_delete_empty_parts
 
 cluster = ClickHouseCluster(__file__)
-node1 = cluster.add_instance("node1", with_zookeeper=True)
-node2 = cluster.add_instance("node2", with_zookeeper=True)
 
-node3 = cluster.add_instance("node3", with_zookeeper=True)
+node1 = cluster.add_instance(
+    "node1",
+    with_zookeeper=True
+)
+node2 = cluster.add_instance(
+    "node2",
+    with_zookeeper=True
+)
+node3 = cluster.add_instance(
+    "node3",
+    with_zookeeper=True
+)
 node4 = cluster.add_instance(
     "node4",
     with_zookeeper=True,
@@ -20,7 +28,6 @@ node4 = cluster.add_instance(
     stay_alive=True,
     with_installed_binary=True,
 )
-
 node5 = cluster.add_instance(
     "node5",
     with_zookeeper=True,
@@ -312,7 +319,7 @@ def test_ttl_double_delete_rule_returns_error(started_cluster):
         assert False
     except client.QueryRuntimeException:
         pass
-    except:
+    except Exception:
         assert False
 
 
@@ -326,7 +333,7 @@ def optimize_with_retry(node, table_name, retry=20):
                 settings={"optimize_throw_if_noop": "1"},
             )
             break
-        except e:
+        except Exception:
             time.sleep(0.5)
 
 

--- a/tests/integration/test_user_ip_restrictions/test.py
+++ b/tests/integration/test_user_ip_restrictions/test.py
@@ -82,7 +82,7 @@ def test_ipv4(setup_cluster):
             privileged=True,
             user="root",
         )
-    except Exception as ex:
+    except Exception:
         assert (
             False
         ), "allowed client with 10.5.172.10 cannot connect to server with allowed mask '10.5.172.0/24'"
@@ -97,7 +97,7 @@ def test_ipv4(setup_cluster):
             privileged=True,
             user="root",
         )
-    except Exception as ex:
+    except Exception:
         assert (
             False
         ), "allowed client with 10.5.173.1 cannot connect to server with allowed ip '10.5.173.1'"
@@ -112,7 +112,7 @@ def test_ipv4(setup_cluster):
             privileged=True,
             user="root",
         )
-    except Exception as ex:
+    except Exception:
         assert (
             False
         ), "allowed client with 10.5.175.77 cannot connect to server with allowed ip '10.5.175.0/255.255.255.0'"
@@ -163,7 +163,7 @@ def test_ipv6(setup_cluster):
             privileged=True,
             user="root",
         )
-    except Exception as ex:
+    except Exception:
         assert (
             False
         ), "allowed client with 2001:3984:3989:0:0:0:1:1111 cannot connect to server with allowed ip '2001:3984:3989:0:0:0:1:1111'"

--- a/tests/integration/test_user_zero_database_access/test_user_zero_database_access.py
+++ b/tests/integration/test_user_zero_database_access/test_user_zero_database_access.py
@@ -41,7 +41,7 @@ def test_user_zero_database_access(start_cluster):
             ],
             user="root",
         )
-    except Exception as ex:
+    except Exception:
         assert False, "user with access rights can't drop database test"
 
     try:
@@ -53,7 +53,7 @@ def test_user_zero_database_access(start_cluster):
             ],
             user="root",
         )
-    except Exception as ex:
+    except Exception:
         assert False, "user with access rights can't create database test"
 
     try:
@@ -97,7 +97,7 @@ def test_user_zero_database_access(start_cluster):
             ],
             user="root",
         )
-    except Exception as ex:
+    except Exception:
         assert False, "user with full access rights can't create database test2"
 
     try:
@@ -109,7 +109,7 @@ def test_user_zero_database_access(start_cluster):
             ],
             user="root",
         )
-    except Exception as ex:
+    except Exception:
         assert False, "user with full access rights can't drop database test2"
 
     try:
@@ -122,7 +122,7 @@ def test_user_zero_database_access(start_cluster):
             user="root",
         )
         assert name.strip() == "env_user_not_with_password"
-    except Exception as ex:
+    except Exception:
         assert False, "set env CLICKHOUSE_USER can not connect server"
 
     try:
@@ -135,7 +135,7 @@ def test_user_zero_database_access(start_cluster):
             user="root",
         )
         assert name.strip() == "env_user_with_password"
-    except Exception as ex:
+    except Exception:
         assert (
             False
         ), "set env CLICKHOUSE_USER CLICKHOUSE_PASSWORD can not connect server"

--- a/tests/integration/test_version_update/test.py
+++ b/tests/integration/test_version_update/test.py
@@ -1,7 +1,6 @@
 import pytest
 
 from helpers.cluster import ClickHouseCluster
-from helpers.test_tools import assert_eq_with_retry, exec_query_with_retry
 
 cluster = ClickHouseCluster(__file__)
 

--- a/tests/integration/test_version_update_after_mutation/test.py
+++ b/tests/integration/test_version_update_after_mutation/test.py
@@ -1,5 +1,4 @@
 import pytest
-import time
 
 from helpers.cluster import ClickHouseCluster
 from helpers.test_tools import assert_eq_with_retry, exec_query_with_retry

--- a/tests/integration/test_zero_copy_fetch/test.py
+++ b/tests/integration/test_zero_copy_fetch/test.py
@@ -1,8 +1,5 @@
 #!/usr/bin/env python3
 
-import logging
-import random
-import string
 import time
 
 from multiprocessing.dummy import Pool

--- a/tests/integration/test_zero_copy_replication_drop_detached_part/test.py
+++ b/tests/integration/test_zero_copy_replication_drop_detached_part/test.py
@@ -1,12 +1,7 @@
 #!/usr/bin/env python3
 
-import logging
-import random
-import string
-import time
 import os
 
-from multiprocessing.dummy import Pool
 import pytest
 from helpers.cluster import ClickHouseCluster
 
@@ -46,7 +41,6 @@ ORDER BY (CounterID, EventDate)"""
     node1.query("ALTER TABLE test1 DETACH PART 'all_0_0_0'")
 
     def get_path_to_detached_part(query_result):
-        part_to_disk = {}
         for row in query_result.strip().split("\n"):
             print(row)
             return row

--- a/tests/integration/test_zookeeper_config/test_password.py
+++ b/tests/integration/test_zookeeper_config/test_password.py
@@ -1,4 +1,3 @@
-import time
 import pytest
 from helpers.cluster import ClickHouseCluster
 

--- a/tests/integration/test_zookeeper_config/test_secure.py
+++ b/tests/integration/test_zookeeper_config/test_secure.py
@@ -1,6 +1,5 @@
 import threading
 import os
-from tempfile import NamedTemporaryFile
 
 import pytest
 from helpers.cluster import ClickHouseCluster


### PR DESCRIPTION
[Ruff](https://beta.ruff.rs/) has been the state of the art in python linter ecosystem and since we aren't using any, I think we should adopt it for all our python based scripting.

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)