### PR TITLE
Log with warning if the server was terminated forcefully

### DIFF
--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -1872,7 +1872,7 @@ try
             }
 
             if (current_connections)
-                LOG_INFO(log, "Closed all listening sockets. Waiting for {} outstanding connections.", current_connections);
+                LOG_WARNING(log, "Closed all listening sockets. Waiting for {} outstanding connections.", current_connections);
             else
                 LOG_INFO(log, "Closed all listening sockets.");
 
@@ -1884,7 +1884,7 @@ try
                 current_connections = waitServersToFinish(servers, config().getInt("shutdown_wait_unfinished", 5));
 
             if (current_connections)
-                LOG_INFO(log, "Closed connections. But {} remain."
+                LOG_WARNING(log, "Closed connections. But {} remain."
                     " Tip: To increase wait time add to config: <shutdown_wait_unfinished>60</shutdown_wait_unfinished>", current_connections);
             else
                 LOG_INFO(log, "Closed connections.");
@@ -1900,7 +1900,7 @@ try
 
                 /// Dump coverage here, because std::atexit callback would not be called.
                 dumpCoverageReportIfPossible();
-                LOG_INFO(log, "Will shutdown forcefully.");
+                LOG_WARNING(log, "Will shutdown forcefully.");
                 safeExit(0);
             }
         });


### PR DESCRIPTION
In case of it is terminated forcefully it will not be terminated gracefully (i.e. run dtors and stuff), and by using warning log level those messages will go to clickhouse-server.err.log, in which messages are kept for a longer period then in clickhouse-server.log (at least because it contains only warnings, errors and fatals only).

This will help with investigating some obscure issues.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Log with warning if the server was terminated forcefully