### PR TITLE
Fix processing pending batch for Distributed async INSERT after restart

### DIFF
--- a/src/Storages/Distributed/DistributedAsyncInsertBatch.cpp
+++ b/src/Storages/Distributed/DistributedAsyncInsertBatch.cpp
@@ -201,6 +201,14 @@ void DistributedAsyncInsertBatch::sendBatch()
     {
         for (const auto & file : files)
         {
+            /// In case of recovery it is possible that some of files will be
+            /// missing, if server had been restarted abnormally
+            if (recovered && !fs::exists(file))
+            {
+                LOG_WARNING(parent.log, "File {} does not exists, likely due abnormal shutdown", file);
+                continue;
+            }
+
             ReadBufferFromFile in(file);
             const auto & distributed_header = DistributedAsyncInsertHeader::read(in, parent.log);
 


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix processing pending batch for Distributed async INSERT after restart (previously it was possible to starve the processing of data that was stored for async INSERT after abnormal server shutdown)

After abnormal server restart current_batch.txt (that contains list of files to send to the remote shard), may not have all files, if it was terminated between unlink .bin files and truncation of current_batch.txt

But it should be fixed in a more reliable way, though to backport the patch I kept it simple.

Fixes: #45491 (cc @hanfei1991 )
