### PR TITLE
Optimization for `grace hash join`'s spilling

### DIFF
--- a/src/Interpreters/GraceHashJoin.h
+++ b/src/Interpreters/GraceHashJoin.h
@@ -51,6 +51,8 @@ class GraceHashJoin final : public IJoin
 public:
     using BucketPtr = std::shared_ptr<FileBucket>;
     using Buckets = std::vector<BucketPtr>;
+    using TemporaryFileStreamImpl = ThreadSafeTemporaryFileStream;
+    using TemporaryFileStreamImplPtr = std::shared_ptr<TemporaryFileStreamImpl>;
 
     GraceHashJoin(
         ContextPtr context_, std::shared_ptr<TableJoin> table_join_,

--- a/src/Interpreters/GraceHashJoin.h
+++ b/src/Interpreters/GraceHashJoin.h
@@ -51,8 +51,7 @@ class GraceHashJoin final : public IJoin
 public:
     using BucketPtr = std::shared_ptr<FileBucket>;
     using Buckets = std::vector<BucketPtr>;
-    using TemporaryFileStreamImpl = ThreadSafeTemporaryFileStream;
-    using TemporaryFileStreamImplPtr = std::shared_ptr<TemporaryFileStreamImpl>;
+    using ThreadSafeTemporaryFileStreamPtr = std::shared_ptr<ThreadSafeTemporaryFileStream>;
 
     GraceHashJoin(
         ContextPtr context_, std::shared_ptr<TableJoin> table_join_,

--- a/src/Interpreters/TemporaryDataOnDisk.cpp
+++ b/src/Interpreters/TemporaryDataOnDisk.cpp
@@ -428,7 +428,7 @@ bool ThreadSafeTemporaryFileStream::isEof() const
     return write_finished && file_in_buf && file_in_buf->eof();
 }
 
-void ThreadSafeTemporaryFileStream::write(const Block & block)
+void ThreadSafeTemporaryFileStream::write(Block && block)
 {
     if (write_finished) [[unlikely]]
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Writing a finished file");
@@ -438,7 +438,7 @@ void ThreadSafeTemporaryFileStream::write(const Block & block)
     {
         std::lock_guard pending_blocks_lock(pending_blocks_mutex);
         pending_rows += block.rows();
-        pending_blocks.push_back(block);
+        pending_blocks.emplace_back(std::move(block));
         if (pending_rows >= max_block_size)
         {
             need_flush = true;

--- a/src/Interpreters/TemporaryDataOnDisk.h
+++ b/src/Interpreters/TemporaryDataOnDisk.h
@@ -186,7 +186,7 @@ public:
     void finishWriting();
     bool isWriteFinished() const;
     bool isEof() const;
-    void write(const Block & block);
+    void write(Block && block);
     Block read();
 
 private:


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Performance Improvement



### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

optimize `grace hash join` spilling.
1. minimize the lock scope for bucket file reading/writing
2. optimize `GraceHashJoin::getDelayedBlocks`, load the right side file parallely.




> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
