### PR TITLE
Fix: use init-capture for consistency and to avoid compilation error with clang 15

### DIFF
--- a/src/Coordination/KeeperStorage.cpp
+++ b/src/Coordination/KeeperStorage.cpp
@@ -363,7 +363,7 @@ void KeeperStorage::UncommittedState::applyDelta(const Delta & delta)
             {
                 assert(my_node);
                 my_node->invalidateDigestCache();
-                operation.update_fn(*node);
+                operation.update_fn(*my_node);
                 my_last_applied_zxid = delta.zxid;
             }
             else if constexpr (std::same_as<DeltaType, SetACLDelta>)


### PR DESCRIPTION
The `KeeperStorage.cpp` compilation failed due to direct structure binding usage in lambda (clang 15.07, saw it after updating to recent master). Use already existed _init_-capture to fix it, also for consistency. Yes, we switched to clang 16 where it compiled but still, the current code is not consistent regarding usage of `my_node`, not `node`, in the lambda.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
