### PR TITLE
Fix flakiness of test_distributed_load_balancing test

### DIFF
--- a/tests/integration/test_distributed_load_balancing/test.py
+++ b/tests/integration/test_distributed_load_balancing/test.py
@@ -29,23 +29,19 @@ nodes = len(cluster.instances)
 queries = nodes * 10
 
 
+# SYSTEM RELOAD CONFIG will reset some attributes of the nodes in cluster
+# - error_count
+# - last_used (round_robing)
+#
+# This is required to avoid interference results of one test to another
+@pytest.fixture(scope="function", autouse=True)
+def test_setup():
+    for n in list(cluster.instances.values()):
+        n.query("SYSTEM RELOAD CONFIG")
+
+
 def bootstrap():
     for n in list(cluster.instances.values()):
-        # At startup, server loads configuration files.
-        #
-        # However ConfigReloader does not know about already loaded files
-        # (files is empty()), hence it will always reload the configuration
-        # just after server starts (+ 2 seconds, reload timeout).
-        #
-        # And on configuration reload the clusters will be re-created, so some
-        # internal stuff will be reset:
-        # - error_count
-        # - last_used (round_robing)
-        #
-        # And if the reload will happen during round_robin test it will start
-        # querying from the beginning, so let's issue config reload just after
-        # start to avoid reload in the middle of the test execution.
-        n.query("SYSTEM RELOAD CONFIG")
         n.query("DROP TABLE IF EXISTS data")
         n.query("DROP TABLE IF EXISTS dist")
         n.query("CREATE TABLE data (key Int) Engine=Memory()")

--- a/tests/integration/test_distributed_load_balancing/test.py
+++ b/tests/integration/test_distributed_load_balancing/test.py
@@ -109,19 +109,14 @@ def get_node(query_node, table="dist", *args, **kwargs):
 
     rows = query_node.query(
         """
-    SELECT c.host_name
-    FROM (
-        SELECT _shard_num
-        FROM cluster(shards_cluster, system.query_log)
-        WHERE
-            initial_query_id = '{query_id}' AND
-            is_initial_query = 0 AND
-            type = 'QueryFinish'
-        ORDER BY event_date DESC, event_time DESC
-        LIMIT 1
-    ) a
-    JOIN system.clusters c
-    ON a._shard_num = c.shard_num WHERE cluster = 'shards_cluster'
+    SELECT hostName()
+    FROM cluster(shards_cluster, system.query_log)
+    WHERE
+        initial_query_id = '{query_id}' AND
+        is_initial_query = 0 AND
+        type = 'QueryFinish'
+    ORDER BY event_date DESC, event_time DESC
+    LIMIT 1
     """.format(
             query_id=query_id
         )


### PR DESCRIPTION
I saw the following in the logs for the failed test:

    2023.05.16 07:12:12.894051 [ 262 ] {74575ac0-b296-4fdc-bc8e-3476a305e6ea} <Warning> ConnectionPoolWithFailover: Connection failed at try №1, reason: Timeout exceeded while reading from socket (socket (172.16.3.2:9000), receive timeout 2000 ms)

And I think that the culprit is the
test_distributed_replica_max_ignored_errors for which it is normal,
however not for others, and this should not affect other tests.

So fix this by calling SYSTEM RELOAD CONFIG, which should reset error
count.

CI: https://s3.amazonaws.com/clickhouse-test-reports/49380/5abc1a1c68ee204c9024493be1d19835cf5630f7/integration_tests__release__[3_4].html

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)