### PR TITLE
Introduce a limitation of async calls inside s3 write buffer, make a test that memory is bounded even when s3 is slow

### DIFF
--- a/docs/en/engines/table-engines/integrations/s3.md
+++ b/docs/en/engines/table-engines/integrations/s3.md
@@ -139,6 +139,7 @@ The following settings can be set before query execution or placed into configur
 - `s3_max_put_burst` — Max number of requests that can be issued simultaneously before hitting request per second limit. By default (`0` value) equals to `s3_max_put_rps`.
 - `s3_max_get_rps` — Maximum GET requests per second rate before throttling. Default value is `0` (unlimited).
 - `s3_max_get_burst` — Max number of requests that can be issued simultaneously before hitting request per second limit. By default (`0` value) equals to `s3_max_get_rps`.
+- `s3_max_inflight_parts_for_one_file` - Limits the number of put requests that can be run concurenly for one object. The value `0` means unlimited. Default value is `20`.
 
 Security consideration: if malicious user can specify arbitrary S3 URLs, `s3_max_redirects` must be set to zero to avoid [SSRF](https://en.wikipedia.org/wiki/Server-side_request_forgery) attacks; or alternatively, `remote_host_filter` must be specified in server configuration.
 

--- a/docs/en/engines/table-engines/integrations/s3.md
+++ b/docs/en/engines/table-engines/integrations/s3.md
@@ -131,15 +131,17 @@ CREATE TABLE table_with_asterisk (name String, value UInt32)
 
 The following settings can be set before query execution or placed into configuration file.
 
-- `s3_max_single_part_upload_size` — The maximum size of object to upload using singlepart upload to S3. Default value is `64Mb`.
-- `s3_min_upload_part_size` — The minimum size of part to upload during multipart upload to [S3 Multipart upload](https://docs.aws.amazon.com/AmazonS3/latest/dev/uploadobjusingmpu.html). Default value is `512Mb`.
+- `s3_max_single_part_upload_size` — The maximum size of object to upload using singlepart upload to S3. Default value is `32Mb`.
+- `s3_min_upload_part_size` — The minimum size of part to upload during multipart upload to [S3 Multipart upload](https://docs.aws.amazon.com/AmazonS3/latest/dev/uploadobjusingmpu.html). Default value is `16Mb`.
 - `s3_max_redirects` — Max number of S3 redirects hops allowed. Default value is `10`.
 - `s3_single_read_retries` — The maximum number of attempts during single read. Default value is `4`.
 - `s3_max_put_rps` — Maximum PUT requests per second rate before throttling. Default value is `0` (unlimited).
 - `s3_max_put_burst` — Max number of requests that can be issued simultaneously before hitting request per second limit. By default (`0` value) equals to `s3_max_put_rps`.
 - `s3_max_get_rps` — Maximum GET requests per second rate before throttling. Default value is `0` (unlimited).
 - `s3_max_get_burst` — Max number of requests that can be issued simultaneously before hitting request per second limit. By default (`0` value) equals to `s3_max_get_rps`.
-- `s3_max_inflight_parts_for_one_file` - Limits the number of put requests that can be run concurenly for one object. The value `0` means unlimited. Default value is `20`.
+- `s3_upload_part_size_multiply_factor` - Multiply `s3_min_upload_part_size` by this factor each time `s3_multiply_parts_count_threshold` parts were uploaded from a single write to S3. Default values is `2`.
+- `s3_upload_part_size_multiply_parts_count_threshold` - Each time this number of parts was uploaded to S3 `s3_min_upload_part_size multiplied` by `s3_upload_part_size_multiply_factor`. DEfault value us `500`.
+- `s3_max_inflight_parts_for_one_file` - Limits the number of put requests that can be run concurenly for one object. Its number should be limited. The value `0` means unlimited. Default value is `20`. Each inflight part has a buffer with size `s3_min_upload_part_size` for the first `s3_upload_part_size_multiply_factor` parts and more when file is big enought, see `upload_part_size_multiply_factor`. With default settings one uploaded file consumes not more than `320Mb` for a file which is less than `8G`. The consumption is greater for a larger file.
 
 Security consideration: if malicious user can specify arbitrary S3 URLs, `s3_max_redirects` must be set to zero to avoid [SSRF](https://en.wikipedia.org/wiki/Server-side_request_forgery) attacks; or alternatively, `remote_host_filter` must be specified in server configuration.
 

--- a/docs/en/engines/table-engines/mergetree-family/mergetree.md
+++ b/docs/en/engines/table-engines/mergetree-family/mergetree.md
@@ -1219,11 +1219,12 @@ Authentication parameters (the disk will try all available methods **and** Manag
 * `account_name` and `account_key` - For authentication using Shared Key.
 
 Limit parameters (mainly for internal usage):
-* `max_single_part_upload_size` - Limits the size of a single block upload to Blob Storage.
+* `s3_max_single_part_upload_size` - Limits the size of a single block upload to Blob Storage.
 * `min_bytes_for_seek` - Limits the size of a seekable region.
 * `max_single_read_retries` - Limits the number of attempts to read a chunk of data from Blob Storage.
 * `max_single_download_retries` - Limits the number of attempts to download a readable buffer from Blob Storage.
 * `thread_pool_size` - Limits the number of threads with which `IDiskRemote` is instantiated.
+* `s3_max_inflight_parts_for_one_file` - Limits the number of put requests that can be run concurenly for one object.
 
 Other parameters:
 * `metadata_path` - Path on local FS to store metadata files for Blob Storage. Default value is `/var/lib/clickhouse/disks/<disk_name>/`.

--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -366,7 +366,7 @@ The server successfully detected this situation and will download merged part fr
     M(WriteBufferFromS3Microseconds, "Time spent on writing to S3.") \
     M(WriteBufferFromS3Bytes, "Bytes written to S3.") \
     M(WriteBufferFromS3RequestsErrors, "Number of exceptions while writing to S3.") \
-    \
+    M(WriteBufferFromS3WaitInflightLimitMicroseconds, "Time spent on waiting while some of the current requests are done when its number reached the limit defined by s3_max_inflight_parts_for_one_file.") \
     M(QueryMemoryLimitExceeded, "Number of times when memory limit exceeded for query.") \
     \
     M(CachedReadBufferReadFromSourceMicroseconds, "Time reading from filesystem cache source (from remote filesystem, etc)") \

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -78,7 +78,7 @@ class IColumn;
     M(UInt64, s3_max_upload_part_size, 5ull*1024*1024*1024, "The maximum size of part to upload during multipart upload to S3.", 0) \
     M(UInt64, s3_upload_part_size_multiply_factor, 2, "Multiply s3_min_upload_part_size by this factor each time s3_multiply_parts_count_threshold parts were uploaded from a single write to S3.", 0) \
     M(UInt64, s3_upload_part_size_multiply_parts_count_threshold, 500, "Each time this number of parts was uploaded to S3 s3_min_upload_part_size multiplied by s3_upload_part_size_multiply_factor.", 0) \
-    M(UInt64, s3_max_inflight_parts_for_one_file, 20, "The maximum number of a concurrent loaded parts in multipart upload request. 0 means unlimited.", 0) \
+    M(UInt64, s3_max_inflight_parts_for_one_file, 20, "The maximum number of a concurrent loaded parts in multipart upload request. 0 means unlimited. You ", 0) \
     M(UInt64, s3_max_single_part_upload_size, 32*1024*1024, "The maximum size of object to upload using singlepart upload to S3.", 0) \
     M(UInt64, s3_max_single_read_retries, 4, "The maximum number of retries during single S3 read.", 0) \
     M(UInt64, s3_max_unexpected_write_error_retries, 4, "The maximum number of retries in case of unexpected errors during S3 write.", 0) \

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -94,6 +94,7 @@ class IColumn;
     M(Bool, s3_check_objects_after_upload, false, "Check each uploaded object to s3 with head request to be sure that upload was successful", 0) \
     M(Bool, s3_allow_parallel_part_upload, true, "Use multiple threads for s3 multipart upload. It may lead to slightly higher memory usage", 0) \
     M(Bool, s3_throw_on_zero_files_match, false, "Throw an error, when ListObjects request cannot match any files", 0) \
+    M(UInt64, s3_retry_attempts, 10, "Setting for Aws::Client::RetryStrategy, Aws::Client does retries itself, 0 means no retries", 0) \
     M(Bool, enable_s3_requests_logging, false, "Enable very explicit logging of S3 requests. Makes sense for debug only.", 0) \
     M(UInt64, hdfs_replication, 0, "The actual number of replications can be specified when the hdfs file is created.", 0) \
     M(Bool, hdfs_truncate_on_insert, false, "Enables or disables truncate before insert in s3 engine tables", 0) \

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -78,6 +78,7 @@ class IColumn;
     M(UInt64, s3_max_upload_part_size, 5ull*1024*1024*1024, "The maximum size of part to upload during multipart upload to S3.", 0) \
     M(UInt64, s3_upload_part_size_multiply_factor, 2, "Multiply s3_min_upload_part_size by this factor each time s3_multiply_parts_count_threshold parts were uploaded from a single write to S3.", 0) \
     M(UInt64, s3_upload_part_size_multiply_parts_count_threshold, 500, "Each time this number of parts was uploaded to S3 s3_min_upload_part_size multiplied by s3_upload_part_size_multiply_factor.", 0) \
+    M(UInt64, s3_max_inflight_parts_for_one_file, 20, "The maximum number of a concurrent loaded parts in multipart upload request. 0 means unlimited.", 0) \
     M(UInt64, s3_max_single_part_upload_size, 32*1024*1024, "The maximum size of object to upload using singlepart upload to S3.", 0) \
     M(UInt64, s3_max_single_read_retries, 4, "The maximum number of retries during single S3 read.", 0) \
     M(UInt64, s3_max_unexpected_write_error_retries, 4, "The maximum number of retries in case of unexpected errors during S3 write.", 0) \

--- a/src/Disks/IDisk.cpp
+++ b/src/Disks/IDisk.cpp
@@ -188,12 +188,12 @@ try
         try
         {
             file->write(payload.data(), payload.size());
+            file->finalize();
         }
         catch (...)
         {
             /// Log current exception, because finalize() can throw a different exception.
             tryLogCurrentException(__PRETTY_FUNCTION__);
-            file->finalize();
             throw;
         }
     }

--- a/src/Disks/ObjectStorages/S3/diskSettings.cpp
+++ b/src/Disks/ObjectStorages/S3/diskSettings.cpp
@@ -146,7 +146,8 @@ std::unique_ptr<S3::Client> getClient(
     S3::ServerSideEncryptionKMSConfig sse_kms_config = S3::getSSEKMSConfig(config_prefix, config);
 
     client_configuration.retryStrategy
-        = std::make_shared<Aws::Client::DefaultRetryStrategy>(config.getUInt(config_prefix + ".retry_attempts", 10));
+        = std::make_shared<Aws::Client::DefaultRetryStrategy>(
+            config.getUInt64(config_prefix + ".retry_attempts", settings.request_settings.retry_attempts));
 
     return S3::ClientFactory::instance().create(
         client_configuration,

--- a/src/IO/WriteBufferFromS3.cpp
+++ b/src/IO/WriteBufferFromS3.cpp
@@ -96,7 +96,7 @@ WriteBufferFromS3::WriteBufferFromS3(
     , task_tracker(
           std::make_unique<WriteBufferFromS3::TaskTracker>(
               std::move(schedule_),
-              upload_settings.s3_max_inflight_parts_for_one_file))
+              upload_settings.max_inflight_parts_for_one_file))
 {
     LOG_TRACE(log, "Create WriteBufferFromS3, {}", getLogDetails());
 

--- a/src/IO/WriteBufferFromS3.cpp
+++ b/src/IO/WriteBufferFromS3.cpp
@@ -137,6 +137,9 @@ void WriteBufferFromS3::preFinalize()
 
     LOG_TRACE(log, "preFinalize WriteBufferFromS3. {}", getLogDetails());
 
+    /// This function should not be run again if an exception has occurred
+    is_prefinalized = true;
+
     hidePartialData();
 
     if (hidden_size > 0)
@@ -167,8 +170,6 @@ void WriteBufferFromS3::preFinalize()
     {
         writeMultipartUpload();
     }
-
-    is_prefinalized = true;
 }
 
 void WriteBufferFromS3::finalizeImpl()

--- a/src/IO/WriteBufferFromS3.cpp
+++ b/src/IO/WriteBufferFromS3.cpp
@@ -217,8 +217,8 @@ String WriteBufferFromS3::getLogDetails() const
         multipart_upload_details = fmt::format(", upload id {}, upload has finished {}"
                                        , multipart_upload_id, multipart_upload_finished);
 
-    return fmt::format("Details: bucket {}, key {}, total size {}, count {}, hidden_size {}, offset {}, with pool: {}, finalized {}{}",
-                       bucket, key, total_size, count(), hidden_size, offset(), task_tracker->isAsync(), finalized, multipart_upload_details);
+    return fmt::format("Details: bucket {}, key {}, total size {}, count {}, hidden_size {}, offset {}, with pool: {}, prefinalized {}, finalized {}{}",
+                       bucket, key, total_size, count(), hidden_size, offset(), task_tracker->isAsync(), is_prefinalized, finalized, multipart_upload_details);
 }
 
 void WriteBufferFromS3::tryToAbortMultipartUpload()

--- a/src/IO/WriteBufferFromS3TaskTracker.cpp
+++ b/src/IO/WriteBufferFromS3TaskTracker.cpp
@@ -46,6 +46,8 @@ size_t WriteBufferFromS3::TaskTracker::consumeReady()
             }
             catch (...)
             {
+                futures.erase(it);
+
                 tryLogCurrentException(__PRETTY_FUNCTION__);
                 throw;
             }

--- a/src/IO/WriteBufferFromS3TaskTracker.cpp
+++ b/src/IO/WriteBufferFromS3TaskTracker.cpp
@@ -34,40 +34,6 @@ ThreadPoolCallbackRunner<void> WriteBufferFromS3::TaskTracker::syncRunner()
     };
 }
 
-size_t WriteBufferFromS3::TaskTracker::consumeReady()
-{
-    LOG_TEST(log, "consumeReady, in queue {}", futures.size());
-
-    size_t consumed = 0;
-
-    {
-        std::unique_lock lock(mutex);
-
-        for (auto it : finished_futures)
-        {
-            try
-            {
-                it->get();
-            }
-            catch (...)
-            {
-                futures.erase(it);
-
-                tryLogCurrentException(__PRETTY_FUNCTION__);
-                throw;
-            }
-
-            futures.erase(it);
-        }
-
-        consumed = finished_futures.size();
-        finished_futures.clear();
-    }
-
-    LOG_TEST(log, "consumeReady ended, in queue {}", futures.size());
-    return consumed;
-}
-
 void WriteBufferFromS3::TaskTracker::waitAll()
 {
     LOG_TEST(log, "waitAll, in queue {}", futures.size());
@@ -75,18 +41,11 @@ void WriteBufferFromS3::TaskTracker::waitAll()
     /// Exceptions are propagated
     for (auto & future : futures)
     {
-        try
-        {
-            future.get();
-        } catch (...)
-        {
-            tryLogCurrentException(__PRETTY_FUNCTION__);
-            throw;
-        }
+        future.get();
     }
     futures.clear();
 
-    /// no concurrent tasks, no mutex required
+    std::lock_guard lock(mutex);
     finished_futures.clear();
 }
 
@@ -94,55 +53,72 @@ void WriteBufferFromS3::TaskTracker::safeWaitAll()
 {
     LOG_TEST(log, "safeWaitAll, wait in queue {}", futures.size());
 
-    /// Exceptions are not propagated
-    for (auto & future : futures)
-    {
-        LOG_TEST(log, "safeWaitAll, wait future");
-
-        if (future.valid())
-            future.wait();
-    }
-
-    LOG_TEST(log, "safeWaitAll, get in queue {}", futures.size());
-
     for (auto & future : futures)
     {
         if (future.valid())
         {
             try
             {
+                /// Exceptions are not propagated
                 future.get();
             } catch (...)
             {
+                /// But at least they are printed
                 tryLogCurrentException(__PRETTY_FUNCTION__);
             }
         }
     }
     futures.clear();
 
-    /// no concurrent tasks, no mutex required
+    std::lock_guard lock(mutex);
     finished_futures.clear();
-
-    LOG_TEST(log, "safeWaitAll ended, get in queue {}", futures.size());
 }
 
-void WriteBufferFromS3::TaskTracker::waitAny()
+void WriteBufferFromS3::TaskTracker::waitIfAny()
 {
-    LOG_TEST(log, "waitAny, in queue {}", futures.size());
+    LOG_TEST(log, "waitIfAny, in queue {}", futures.size());
+    if (futures.empty())
+        return;
 
-    while (!futures.empty() && consumeReady() == 0)
+    Stopwatch watch;
+
     {
-            std::unique_lock lock(mutex);
-            cond_var.wait(lock, [&] () { return !finished_futures.empty(); });
+        std::lock_guard lock(mutex);
+        for (auto & it : finished_futures)
+        {
+            /// actually that call might lock this thread until the future is set finally
+            /// however that won't lock us for long, the task is about to finish when the pointer appears in the `finished_futures`
+            it->get();
+
+            /// in case of exception in `it->get()`
+            /// it it not necessary to remove `it` from list `futures`
+            /// `TaskTracker` has to be destroyed after any exception occurs, for this `safeWaitAll` is called.
+            /// `safeWaitAll` handles invalid futures in the list `futures`
+            futures.erase(it);
+        }
+        finished_futures.clear();
     }
 
-    LOG_TEST(log, "waitAny ended, in queue {}", futures.size());
+    watch.stop();
+    ProfileEvents::increment(ProfileEvents::WriteBufferFromS3WaitInflightLimitMicroseconds, watch.elapsedMicroseconds());
+
+    LOG_TEST(log, "waitIfAny ended, in queue {}", futures.size());
 }
 
 void WriteBufferFromS3::TaskTracker::add(Callback && func)
 {
+    /// All this fuzz is about 2 things. This is the most critical place of TaskTracker.
+    /// The first is not to fail insertion in the list `futures`.
+    /// In order to face it, the element is allocated at the end of the list `futures` in advance.
+    /// The second is not to fail the notification of the task.
+    /// In order to face it, the list element, which would be inserted to the list `finished_futures`,
+    /// is allocated in advance as an other list `pre_allocated_finished` with one element inside.
+
+    /// preallocation for the first issue
     futures.emplace_back();
     auto future_placeholder = std::prev(futures.end());
+
+    /// preallocation for the second issue
     FinishedList pre_allocated_finished {future_placeholder};
 
     Callback func_with_notification = [&, func=std::move(func), pre_allocated_finished=std::move(pre_allocated_finished)] () mutable
@@ -150,39 +126,53 @@ void WriteBufferFromS3::TaskTracker::add(Callback && func)
         SCOPE_EXIT({
             DENY_ALLOCATIONS_IN_SCOPE;
 
-            std::unique_lock lock(mutex);
-            finished_futures.splice(finished_futures.end(), pre_allocated_finished, pre_allocated_finished.begin());
-            cond_var.notify_one();
+            std::lock_guard lock(mutex);
+            finished_futures.splice(finished_futures.end(), pre_allocated_finished);
+            has_finished.notify_one();
         });
 
         func();
     };
 
+    /// this move is nothrow
     *future_placeholder = scheduler(std::move(func_with_notification), Priority{});
 
     LOG_TEST(log, "add ended, in queue {}, limit {}", futures.size(), max_tasks_inflight);
 
-    waitInFlight();
+    waitTilInflightShrink();
 }
 
-void WriteBufferFromS3::TaskTracker::waitInFlight()
+void WriteBufferFromS3::TaskTracker::waitTilInflightShrink()
 {
     if (!max_tasks_inflight)
         return;
 
-    LOG_TEST(log, "waitInFlight, in queue {}", futures.size());
+    LOG_TEST(log, "waitTilInflightShrink, in queue {}", futures.size());
 
     Stopwatch watch;
 
+    /// Alternative approach is to wait until at least futures.size() - max_tasks_inflight element are finished
+    /// However the faster finished task is collected the faster CH checks if there is an exception
+    /// The faster an exception is propagated the lesser time is spent for cancellation
     while (futures.size() >= max_tasks_inflight)
     {
-        waitAny();
+        std::unique_lock lock(mutex);
+
+        has_finished.wait(lock, [this] () TSA_REQUIRES(mutex) { return !finished_futures.empty(); });
+
+        for (auto & it : finished_futures)
+        {
+            it->get();
+            futures.erase(it);
+        }
+
+        finished_futures.clear();
     }
 
     watch.stop();
     ProfileEvents::increment(ProfileEvents::WriteBufferFromS3WaitInflightLimitMicroseconds, watch.elapsedMicroseconds());
 
-    LOG_TEST(log, "waitInFlight ended, in queue {}", futures.size());
+    LOG_TEST(log, "waitTilInflightShrink ended, in queue {}", futures.size());
 }
 
 bool WriteBufferFromS3::TaskTracker::isAsync() const

--- a/src/IO/WriteBufferFromS3TaskTracker.cpp
+++ b/src/IO/WriteBufferFromS3TaskTracker.cpp
@@ -162,8 +162,15 @@ void WriteBufferFromS3::TaskTracker::waitTilInflightShrink()
 
         for (auto & it : finished_futures)
         {
+            SCOPE_EXIT({
+                /// According to basic exception safety TaskTracker has to be destroyed after exception
+                /// If it would be true than this SCOPE_EXIT is superfluous
+                /// However WriteBufferWithFinalizeCallback, WriteBufferFromFileDecorator do call finalize in d-tor
+                /// TaskTracker has to cope this until the issue with finalizing in d-tor is addressed in #50274
+                futures.erase(it);
+            });
+
             it->get();
-            futures.erase(it);
         }
 
         finished_futures.clear();

--- a/src/IO/WriteBufferFromS3TaskTracker.cpp
+++ b/src/IO/WriteBufferFromS3TaskTracker.cpp
@@ -153,7 +153,7 @@ void WriteBufferFromS3::TaskTracker::add(Callback && func)
 
     *future_placeholder = scheduler(std::move(func_with_notification), Priority{});
 
-    LOG_TEST(log, "add ended, in queue {}", futures.size());
+    LOG_TEST(log, "add ended, in queue {}, limit {}", futures.size(), max_tasks_inflight);
 
     waitInFlight();
 }

--- a/src/IO/WriteBufferFromS3TaskTracker.h
+++ b/src/IO/WriteBufferFromS3TaskTracker.h
@@ -36,11 +36,11 @@ public:
     /// There could be no finished tasks yet, so waitIfAny do nothing useful in that case
     /// the first exception is thrown if any task has failed
     void waitIfAny();
-
-    /// Well, waitAll waits all the tasks until they finish and collects they statuses
+    
+    /// Well, waitAll waits all the tasks until they finish and collects their statuses
     void waitAll();
 
-    /// safeWaitAll do the same as waitAll but do not rethrow the exceptions
+    /// safeWaitAll does the same as waitAll but mutes the exceptions
     void safeWaitAll();
 
     void add(Callback && func);

--- a/src/IO/WriteBufferFromS3TaskTracker.h
+++ b/src/IO/WriteBufferFromS3TaskTracker.h
@@ -36,7 +36,7 @@ public:
     /// There could be no finished tasks yet, so waitIfAny do nothing useful in that case
     /// the first exception is thrown if any task has failed
     void waitIfAny();
-    
+
     /// Well, waitAll waits all the tasks until they finish and collects their statuses
     void waitAll();
 

--- a/src/IO/WriteBufferFromS3TaskTracker.h
+++ b/src/IO/WriteBufferFromS3TaskTracker.h
@@ -14,28 +14,40 @@ namespace DB
 /// That class is used only in WriteBufferFromS3 for now.
 /// Therefore it declared as a part of  WriteBufferFromS3.
 /// TaskTracker takes a Callback which is run by scheduler in some external shared ThreadPool.
-/// TaskTracker brings the methods waitReady, waitAll/safeWaitAll
+/// TaskTracker brings the methods waitIfAny, waitAll/safeWaitAll
 /// to help with coordination of the running tasks.
+
+/// Basic exception safety is provided. If exception occurred the object has to be destroyed.
+/// No thread safety is provided. Use this object with no concurrency.
 
 class WriteBufferFromS3::TaskTracker
 {
 public:
     using Callback = std::function<void()>;
 
-    explicit TaskTracker(ThreadPoolCallbackRunner<void> scheduler_, size_t max_tasks_inflight_ = 0);
+    TaskTracker(ThreadPoolCallbackRunner<void> scheduler_, size_t max_tasks_inflight_);
     ~TaskTracker();
 
     static ThreadPoolCallbackRunner<void> syncRunner();
 
     bool isAsync() const;
-    size_t consumeReady();
-    void waitAny();
+
+    /// waitIfAny collects statuses from already finished tasks
+    /// There could be no finished tasks yet, so waitIfAny do nothing useful in that case
+    /// the first exception is thrown if any task has failed
+    void waitIfAny();
+
+    /// Well, waitAll waits all the tasks until they finish and collects they statuses
     void waitAll();
+
+    /// safeWaitAll do the same as waitAll but do not rethrow the exceptions
     void safeWaitAll();
+
     void add(Callback && func);
 
 private:
-    void waitInFlight();
+    /// waitTilInflightShrink waits til the number of in-flight tasks beyond the limit `max_tasks_inflight`.
+    void waitTilInflightShrink() TSA_NO_THREAD_SAFETY_ANALYSIS;
 
     const bool is_async;
     ThreadPoolCallbackRunner<void> scheduler;
@@ -46,9 +58,9 @@ private:
     Poco::Logger * log = &Poco::Logger::get("TaskTracker");
 
     std::mutex mutex;
-    std::condition_variable cond_var;
+    std::condition_variable has_finished TSA_GUARDED_BY(mutex);
     using FinishedList = std::list<FutureList::iterator>;
-    FinishedList finished_futures;
+    FinishedList finished_futures TSA_GUARDED_BY(mutex);
 };
 
 }

--- a/src/Storages/StorageS3.cpp
+++ b/src/Storages/StorageS3.cpp
@@ -1263,6 +1263,11 @@ void StorageS3::Configuration::connect(ContextPtr context)
     if (!headers_from_ast.empty())
         headers.insert(headers.end(), headers_from_ast.begin(), headers_from_ast.end());
 
+    client_configuration.requestTimeoutMs = request_settings.request_timeout_ms;
+
+    client_configuration.retryStrategy
+        = std::make_shared<Aws::Client::DefaultRetryStrategy>(request_settings.retry_attempts);
+
     auto credentials = Aws::Auth::AWSCredentials(auth_settings.access_key_id, auth_settings.secret_access_key);
     client = S3::ClientFactory::instance().create(
         client_configuration,
@@ -1273,11 +1278,11 @@ void StorageS3::Configuration::connect(ContextPtr context)
         auth_settings.server_side_encryption_kms_config,
         std::move(headers),
         S3::CredentialsConfiguration{
-        auth_settings.use_environment_credentials.value_or(context->getConfigRef().getBool("s3.use_environment_credentials", true)),
-        auth_settings.use_insecure_imds_request.value_or(context->getConfigRef().getBool("s3.use_insecure_imds_request", false)),
-        auth_settings.expiration_window_seconds.value_or(
-            context->getConfigRef().getUInt64("s3.expiration_window_seconds", S3::DEFAULT_EXPIRATION_WINDOW_SECONDS)),
-        auth_settings.no_sign_request.value_or(context->getConfigRef().getBool("s3.no_sign_request", false)),
+            auth_settings.use_environment_credentials.value_or(context->getConfigRef().getBool("s3.use_environment_credentials", true)),
+            auth_settings.use_insecure_imds_request.value_or(context->getConfigRef().getBool("s3.use_insecure_imds_request", false)),
+            auth_settings.expiration_window_seconds.value_or(
+                context->getConfigRef().getUInt64("s3.expiration_window_seconds", S3::DEFAULT_EXPIRATION_WINDOW_SECONDS)),
+                auth_settings.no_sign_request.value_or(context->getConfigRef().getBool("s3.no_sign_request", false)),
         });
 }
 

--- a/src/Storages/StorageS3Settings.cpp
+++ b/src/Storages/StorageS3Settings.cpp
@@ -37,6 +37,7 @@ S3Settings::RequestSettings::PartUploadSettings::PartUploadSettings(
     max_upload_part_size = config.getUInt64(key + "max_upload_part_size", max_upload_part_size);
     upload_part_size_multiply_factor = config.getUInt64(key + "upload_part_size_multiply_factor", upload_part_size_multiply_factor);
     upload_part_size_multiply_parts_count_threshold = config.getUInt64(key + "upload_part_size_multiply_parts_count_threshold", upload_part_size_multiply_parts_count_threshold);
+    s3_max_inflight_parts_for_one_file = config.getUInt64(key + "s3_max_inflight_parts_for_one_file", s3_max_inflight_parts_for_one_file);
     max_part_number = config.getUInt64(key + "max_part_number", max_part_number);
     max_single_part_upload_size = config.getUInt64(key + "max_single_part_upload_size", max_single_part_upload_size);
     max_single_operation_copy_size = config.getUInt64(key + "max_single_operation_copy_size", max_single_operation_copy_size);
@@ -55,6 +56,7 @@ S3Settings::RequestSettings::PartUploadSettings::PartUploadSettings(const NamedC
     max_single_part_upload_size = collection.getOrDefault<UInt64>("max_single_part_upload_size", max_single_part_upload_size);
     upload_part_size_multiply_factor = collection.getOrDefault<UInt64>("upload_part_size_multiply_factor", upload_part_size_multiply_factor);
     upload_part_size_multiply_parts_count_threshold = collection.getOrDefault<UInt64>("upload_part_size_multiply_parts_count_threshold", upload_part_size_multiply_parts_count_threshold);
+    s3_max_inflight_parts_for_one_file = collection.getOrDefault<UInt64>("s3_max_inflight_parts_for_one_file", s3_max_inflight_parts_for_one_file);
 
     /// This configuration is only applicable to s3. Other types of object storage are not applicable or have different meanings.
     storage_class_name = collection.getOrDefault<String>("s3_storage_class", storage_class_name);
@@ -79,6 +81,9 @@ void S3Settings::RequestSettings::PartUploadSettings::updateFromSettingsImpl(con
 
     if (!if_changed || settings.s3_upload_part_size_multiply_parts_count_threshold.changed)
         upload_part_size_multiply_parts_count_threshold = settings.s3_upload_part_size_multiply_parts_count_threshold;
+
+    if (!if_changed || settings.s3_max_inflight_parts_for_one_file.changed)
+        s3_max_inflight_parts_for_one_file = settings.s3_max_inflight_parts_for_one_file;
 
     if (!if_changed || settings.s3_max_single_part_upload_size.changed)
         max_single_part_upload_size = settings.s3_max_single_part_upload_size;

--- a/src/Storages/StorageS3Settings.cpp
+++ b/src/Storages/StorageS3Settings.cpp
@@ -37,7 +37,7 @@ S3Settings::RequestSettings::PartUploadSettings::PartUploadSettings(
     max_upload_part_size = config.getUInt64(key + "max_upload_part_size", max_upload_part_size);
     upload_part_size_multiply_factor = config.getUInt64(key + "upload_part_size_multiply_factor", upload_part_size_multiply_factor);
     upload_part_size_multiply_parts_count_threshold = config.getUInt64(key + "upload_part_size_multiply_parts_count_threshold", upload_part_size_multiply_parts_count_threshold);
-    s3_max_inflight_parts_for_one_file = config.getUInt64(key + "s3_max_inflight_parts_for_one_file", s3_max_inflight_parts_for_one_file);
+    max_inflight_parts_for_one_file = config.getUInt64(key + "max_inflight_parts_for_one_file", max_inflight_parts_for_one_file);
     max_part_number = config.getUInt64(key + "max_part_number", max_part_number);
     max_single_part_upload_size = config.getUInt64(key + "max_single_part_upload_size", max_single_part_upload_size);
     max_single_operation_copy_size = config.getUInt64(key + "max_single_operation_copy_size", max_single_operation_copy_size);
@@ -56,7 +56,7 @@ S3Settings::RequestSettings::PartUploadSettings::PartUploadSettings(const NamedC
     max_single_part_upload_size = collection.getOrDefault<UInt64>("max_single_part_upload_size", max_single_part_upload_size);
     upload_part_size_multiply_factor = collection.getOrDefault<UInt64>("upload_part_size_multiply_factor", upload_part_size_multiply_factor);
     upload_part_size_multiply_parts_count_threshold = collection.getOrDefault<UInt64>("upload_part_size_multiply_parts_count_threshold", upload_part_size_multiply_parts_count_threshold);
-    s3_max_inflight_parts_for_one_file = collection.getOrDefault<UInt64>("s3_max_inflight_parts_for_one_file", s3_max_inflight_parts_for_one_file);
+    max_inflight_parts_for_one_file = collection.getOrDefault<UInt64>("max_inflight_parts_for_one_file", max_inflight_parts_for_one_file);
 
     /// This configuration is only applicable to s3. Other types of object storage are not applicable or have different meanings.
     storage_class_name = collection.getOrDefault<String>("s3_storage_class", storage_class_name);
@@ -83,7 +83,7 @@ void S3Settings::RequestSettings::PartUploadSettings::updateFromSettingsImpl(con
         upload_part_size_multiply_parts_count_threshold = settings.s3_upload_part_size_multiply_parts_count_threshold;
 
     if (!if_changed || settings.s3_max_inflight_parts_for_one_file.changed)
-        s3_max_inflight_parts_for_one_file = settings.s3_max_inflight_parts_for_one_file;
+        max_inflight_parts_for_one_file = settings.s3_max_inflight_parts_for_one_file;
 
     if (!if_changed || settings.s3_max_single_part_upload_size.changed)
         max_single_part_upload_size = settings.s3_max_single_part_upload_size;
@@ -198,6 +198,8 @@ S3Settings::RequestSettings::RequestSettings(
     check_objects_after_upload = config.getBool(key + "check_objects_after_upload", settings.s3_check_objects_after_upload);
     list_object_keys_size = config.getUInt64(key + "list_object_keys_size", settings.s3_list_object_keys_size);
     throw_on_zero_files_match = config.getBool(key + "throw_on_zero_files_match", settings.s3_throw_on_zero_files_match);
+    retry_attempts = config.getUInt64(key + "retry_attempts", settings.s3_retry_attempts);
+    request_timeout_ms = config.getUInt64(key + "request_timeout_ms", request_timeout_ms);
 
     /// NOTE: it would be better to reuse old throttlers to avoid losing token bucket state on every config reload,
     /// which could lead to exceeding limit for short time. But it is good enough unless very high `burst` values are used.
@@ -248,8 +250,11 @@ void S3Settings::RequestSettings::updateFromSettingsImpl(const Settings & settin
         put_request_throttler = std::make_shared<Throttler>(
             settings.s3_max_put_rps, settings.s3_max_put_burst ? settings.s3_max_put_burst : Throttler::default_burst_seconds * settings.s3_max_put_rps);
 
-    if (!if_changed || settings.s3_throw_on_zero_files_match)
+    if (!if_changed || settings.s3_throw_on_zero_files_match.changed)
         throw_on_zero_files_match = settings.s3_throw_on_zero_files_match;
+
+    if (!if_changed || settings.s3_retry_attempts.changed)
+        retry_attempts = settings.s3_retry_attempts;
 }
 
 void S3Settings::RequestSettings::updateFromSettings(const Settings & settings)

--- a/src/Storages/StorageS3Settings.h
+++ b/src/Storages/StorageS3Settings.h
@@ -33,7 +33,7 @@ struct S3Settings
             size_t max_upload_part_size = 5ULL * 1024 * 1024 * 1024;
             size_t upload_part_size_multiply_factor = 2;
             size_t upload_part_size_multiply_parts_count_threshold = 500;
-            size_t s3_max_inflight_parts_for_one_file = 20;
+            size_t max_inflight_parts_for_one_file = 20;
             size_t max_part_number = 10000;
             size_t max_single_part_upload_size = 32 * 1024 * 1024;
             size_t max_single_operation_copy_size = 5ULL * 1024 * 1024 * 1024;
@@ -68,6 +68,8 @@ struct S3Settings
         size_t list_object_keys_size = 1000;
         ThrottlerPtr get_request_throttler;
         ThrottlerPtr put_request_throttler;
+        size_t retry_attempts = 10;
+        size_t request_timeout_ms = 30000;
 
         bool throw_on_zero_files_match = false;
 

--- a/src/Storages/StorageS3Settings.h
+++ b/src/Storages/StorageS3Settings.h
@@ -33,6 +33,7 @@ struct S3Settings
             size_t max_upload_part_size = 5ULL * 1024 * 1024 * 1024;
             size_t upload_part_size_multiply_factor = 2;
             size_t upload_part_size_multiply_parts_count_threshold = 500;
+            size_t s3_max_inflight_parts_for_one_file = 20;
             size_t max_part_number = 10000;
             size_t max_single_part_upload_size = 32 * 1024 * 1024;
             size_t max_single_operation_copy_size = 5ULL * 1024 * 1024 * 1024;

--- a/tests/integration/test_merge_tree_s3/configs/config.d/storage_conf.xml
+++ b/tests/integration/test_merge_tree_s3/configs/config.d/storage_conf.xml
@@ -29,6 +29,8 @@
                 <secret_access_key>minio123</secret_access_key>
                 <s3_retry_attempts>1</s3_retry_attempts>
                 <connect_timeout_ms>20000</connect_timeout_ms>
+                <request_timeout_ms>30000</request_timeout_ms>
+                <skip_access_check>true</skip_access_check>
             </broken_s3>
             <hdd>
                 <type>local</type>

--- a/tests/integration/test_merge_tree_s3/configs/config.d/storage_conf.xml
+++ b/tests/integration/test_merge_tree_s3/configs/config.d/storage_conf.xml
@@ -27,10 +27,10 @@
                 <endpoint>http://resolver:8083/root/data/</endpoint>
                 <access_key_id>minio</access_key_id>
                 <secret_access_key>minio123</secret_access_key>
-                <s3_retry_attempts>1</s3_retry_attempts>
+                <retry_attempts>0</retry_attempts>
                 <connect_timeout_ms>20000</connect_timeout_ms>
-                <request_timeout_ms>30000</request_timeout_ms>
-                <skip_access_check>true</skip_access_check>
+                <request_timeout_ms>20000</request_timeout_ms>
+                <s3_max_inflight_parts_for_one_file>1</s3_max_inflight_parts_for_one_file>
             </broken_s3>
             <hdd>
                 <type>local</type>

--- a/tests/integration/test_merge_tree_s3/configs/config.d/storage_conf.xml
+++ b/tests/integration/test_merge_tree_s3/configs/config.d/storage_conf.xml
@@ -27,6 +27,7 @@
                 <endpoint>http://resolver:8083/root/data/</endpoint>
                 <access_key_id>minio</access_key_id>
                 <secret_access_key>minio123</secret_access_key>
+                <skip_access_check>true</skip_access_check>
                 <retry_attempts>0</retry_attempts>
                 <connect_timeout_ms>20000</connect_timeout_ms>
                 <request_timeout_ms>20000</request_timeout_ms>

--- a/tests/integration/test_merge_tree_s3/configs/config.d/users.xml
+++ b/tests/integration/test_merge_tree_s3/configs/config.d/users.xml
@@ -1,0 +1,8 @@
+<clickhouse>
+    <profiles>
+        <default>
+            <enable_s3_requests_logging>1</enable_s3_requests_logging>
+            <s3_max_inflight_parts_for_one_file>20</s3_max_inflight_parts_for_one_file>
+        </default>
+    </profiles>
+</clickhouse>

--- a/tests/integration/test_merge_tree_s3/configs/config.xml
+++ b/tests/integration/test_merge_tree_s3/configs/config.xml
@@ -1,14 +1,11 @@
 <clickhouse>
-    <profiles>
-        <default>
-            <s3_check_objects_after_upload> 1 </s3_check_objects_after_upload>
-            <enable_s3_requests_logging> 1 </enable_s3_requests_logging>
-            <http_send_timeout>60</http_send_timeout>
-            <http_receive_timeout>60</http_receive_timeout>
-            <send_timeout>60</send_timeout>
-            <receive_timeout>60</receive_timeout>
-        </default>
-    </profiles>
+    <s3>
+        <broken_s3>
+            <endpoint>http://resolver:8083/root/data/</endpoint>
+            <retry_attempts>0</retry_attempts>
+            <request_timeout_ms>20000</request_timeout_ms>
+        </broken_s3>
+    </s3>
 
     <enable_system_unfreeze>true</enable_system_unfreeze>
 </clickhouse>

--- a/tests/integration/test_merge_tree_s3/configs/config.xml
+++ b/tests/integration/test_merge_tree_s3/configs/config.xml
@@ -1,3 +1,14 @@
 <clickhouse>
+    <profiles>
+        <default>
+            <s3_check_objects_after_upload> 1 </s3_check_objects_after_upload>
+            <enable_s3_requests_logging> 1 </enable_s3_requests_logging>
+            <http_send_timeout>60</http_send_timeout>
+            <http_receive_timeout>60</http_receive_timeout>
+            <send_timeout>60</send_timeout>
+            <receive_timeout>60</receive_timeout>
+        </default>
+    </profiles>
+
     <enable_system_unfreeze>true</enable_system_unfreeze>
 </clickhouse>

--- a/tests/integration/test_merge_tree_s3/s3_mocks/broken_s3.py
+++ b/tests/integration/test_merge_tree_s3/s3_mocks/broken_s3.py
@@ -1,4 +1,8 @@
+import logging
 import sys
+import threading
+import random
+import time
 import urllib.parse
 import http.server
 import socketserver
@@ -9,14 +13,64 @@ UPSTREAM_PORT = 9001
 
 
 class ServerRuntime:
+    class SlowPut:
+        def __init__(
+            self, probability_=None, timeout_=None, minimal_length_=None, count_=None
+        ):
+            self.probability = probability_ if probability_ is not None else 1
+            self.timeout = timeout_ if timeout_ is not None else 0.1
+            self.minimal_length = minimal_length_ if minimal_length_ is not None else 0
+            self.count = count_ if count_ is not None else 2**32
+
+        def __str__(self):
+            return (
+                f"probability:{self.probability}"
+                f" timeout:{self.timeout}"
+                f" minimal_length:{self.minimal_length}"
+                f" count:{self.count}"
+            )
+
+        def get_timeout(self, content_length):
+            if content_length > self.minimal_length:
+                if self.count > 0:
+                    if (
+                        runtime.slow_put.probability == 1
+                        or random.random() <= runtime.slow_put.probability
+                    ):
+                        self.count -= 1
+                        return runtime.slow_put.timeout
+            return None
+
     def __init__(self):
+        self.lock = threading.Lock()
         self.error_at_put_when_length_bigger = None
+        self.fake_put_when_length_bigger = None
+        self.fake_uploads = dict()
+        self.slow_put = None
+
+    def register_fake_upload(self, upload_id, key):
+        with self.lock:
+            self.fake_uploads[upload_id] = key
+
+    def is_fake_upload(self, upload_id, key):
+        with self.lock:
+            if upload_id in self.fake_uploads:
+                return self.fake_uploads[upload_id] == key
+        return False
 
     def reset(self):
         self.error_at_put_when_length_bigger = None
+        self.fake_put_when_length_bigger = None
+        self.fake_uploads = dict()
+        self.slow_put = None
 
 
 runtime = ServerRuntime()
+
+
+def and_then(value, func):
+    assert callable(func)
+    return None if value is None else func(value)
 
 
 class RequestHandler(http.server.BaseHTTPRequestHandler):
@@ -55,51 +109,124 @@ class RequestHandler(http.server.BaseHTTPRequestHandler):
         self.send_response(500)
         self.send_header("Content-Type", "text/xml")
         self.end_headers()
-        self.wfile.write(data)
+        self.wfile.write(bytes(data, "UTF-8"))
+
+    def _fake_put_ok(self):
+        self._read_out()
+
+        self.send_response(200)
+        self.send_header("Content-Type", "text/xml")
+        self.send_header("ETag", "b54357faf0632cce46e942fa68356b38")
+        self.send_header("Content-Length", 0)
+        self.end_headers()
+
+    def _fake_post_ok(self, path):
+        self._read_out()
+
+        parts = [x for x in path.split("/") if x]
+        bucket = parts[0]
+        key = "/".join(parts[1:])
+        location = "http://Example-Bucket.s3.Region.amazonaws.com/" + path
+        data = (
+            '<?xml version="1.0" encoding="UTF-8"?>\n'
+            "<CompleteMultipartUploadResult>\n"
+            f"<Location>{location}</Location>\n"
+            f"<Bucket>{bucket}</Bucket>\n"
+            f"<Key>{key}</Key>\n"
+            f'<ETag>"3858f62230ac3c915f300c664312c11f-9"</ETag>\n'
+            f"</CompleteMultipartUploadResult>\n"
+        )
+
+        self.send_response(200)
+        self.send_header("Content-Type", "text/xml")
+        self.send_header("Content-Length", len(data))
+        self.end_headers()
+
+        self.wfile.write(bytes(data, "UTF-8"))
 
     def _mock_settings(self):
         parts = urllib.parse.urlsplit(self.path)
         path = [x for x in parts.path.split("/") if x]
         assert path[0] == "mock_settings", path
+        if len(path) < 2:
+            return self._error("_mock_settings: wrong command")
+
         if path[1] == "error_at_put":
             params = urllib.parse.parse_qs(parts.query, keep_blank_values=False)
             runtime.error_at_put_when_length_bigger = int(
                 params.get("when_length_bigger", [1024 * 1024])[0]
             )
-            self._ok()
-        elif path[1] == "reset":
+            return self._ok()
+        if path[1] == "fake_put":
+            params = urllib.parse.parse_qs(parts.query, keep_blank_values=False)
+            runtime.fake_put_when_length_bigger = int(
+                params.get("when_length_bigger", [1024 * 1024])[0]
+            )
+            return self._ok()
+        if path[1] == "slow_put":
+            params = urllib.parse.parse_qs(parts.query, keep_blank_values=False)
+            runtime.slow_put = ServerRuntime.SlowPut(
+                minimal_length_=and_then(params.get("minimal_length", [None])[0], int),
+                probability_=and_then(params.get("probability", [None])[0], float),
+                timeout_=and_then(params.get("timeout", [None])[0], float),
+                count_=and_then(params.get("count", [None])[0], int),
+            )
+            self.log_message("set slow put %s", runtime.slow_put)
+            return self._ok()
+        if path[1] == "reset":
             runtime.reset()
-            self._ok()
-        else:
-            self._error("_mock_settings: wrong command")
+            return self._ok()
+
+        return self._error("_mock_settings: wrong command")
 
     def do_GET(self):
         if self.path == "/":
-            self._ping()
-        elif self.path.startswith("/mock_settings"):
-            self._mock_settings()
-        else:
-            self._redirect()
+            return self._ping()
+
+        if self.path.startswith("/mock_settings"):
+            return self._mock_settings()
+
+        return self._redirect()
 
     def do_PUT(self):
+        content_length = int(self.headers.get("Content-Length", 0))
+
+        if runtime.slow_put is not None:
+            timeout = runtime.slow_put.get_timeout(content_length)
+            if timeout is not None:
+                self.log_message("slow put %s", timeout)
+                time.sleep(timeout)
+
         if runtime.error_at_put_when_length_bigger is not None:
-            content_length = int(self.headers.get("Content-Length", 0))
             if content_length > runtime.error_at_put_when_length_bigger:
-                self._error(
-                    b'<?xml version="1.0" encoding="UTF-8"?>'
-                    b"<Error>"
-                    b"<Code>ExpectedError</Code>"
-                    b"<Message>mock s3 injected error</Message>"
-                    b"<RequestId>txfbd566d03042474888193-00608d7537</RequestId>"
-                    b"</Error>"
+                return self._error(
+                    '<?xml version="1.0" encoding="UTF-8"?>'
+                    "<Error>"
+                    "<Code>ExpectedError</Code>"
+                    "<Message>mock s3 injected error</Message>"
+                    "<RequestId>txfbd566d03042474888193-00608d7537</RequestId>"
+                    "</Error>"
                 )
-            else:
-                self._redirect()
-        else:
-            self._redirect()
+
+        parts = urllib.parse.urlsplit(self.path)
+        params = urllib.parse.parse_qs(parts.query, keep_blank_values=False)
+        upload_id = params.get("uploadId", [None])[0]
+        if runtime.fake_put_when_length_bigger is not None and upload_id is not None:
+            if content_length > runtime.fake_put_when_length_bigger:
+                runtime.register_fake_upload(upload_id, parts.path)
+                return self._fake_put_ok()
+
+        return self._redirect()
 
     def do_POST(self):
-        self._redirect()
+        parts = urllib.parse.urlsplit(self.path)
+        params = urllib.parse.parse_qs(parts.query, keep_blank_values=False)
+        upload_id = params.get("uploadId", [None])[0]
+
+        if runtime.is_fake_upload(upload_id, parts.path):
+            return self._fake_post_ok(parts.path)
+
+        return self._redirect()
 
     def do_HEAD(self):
         self._redirect()

--- a/tests/integration/test_merge_tree_s3/test.py
+++ b/tests/integration/test_merge_tree_s3/test.py
@@ -1048,8 +1048,8 @@ def test_s3_engine_heavy_write_check_mem(cluster, node_name, in_flight_memory):
         "   AND type!='QueryStart'"
     )
 
-    assert int(result) < 1.01 * memory
-    assert int(result) > 0.99 * memory
+    assert int(result) < 1.1 * memory
+    assert int(result) > 0.9 * memory
 
     check_no_objects_after_drop(cluster, node_name=node_name)
 
@@ -1094,7 +1094,7 @@ def test_s3_disk_heavy_write_check_mem(cluster, node_name):
         "   AND type!='QueryStart'"
     )
 
-    assert int(result) < 1.01 * memory
-    assert int(result) > 0.99 * memory
+    assert int(result) < 1.1 * memory
+    assert int(result) > 0.9 * memory
 
     check_no_objects_after_drop(cluster, node_name=node_name)

--- a/tests/integration/test_merge_tree_s3/test.py
+++ b/tests/integration/test_merge_tree_s3/test.py
@@ -26,6 +26,9 @@ def cluster():
                 "configs/config.d/storage_conf.xml",
                 "configs/config.d/bg_processing_pool_conf.xml",
             ],
+            user_configs=[
+                "configs/config.d/users.xml",
+            ],
             stay_alive=True,
             with_minio=True,
         )
@@ -139,14 +142,76 @@ def clear_minio(cluster):
     yield
 
 
+class BrokenS3:
+    @staticmethod
+    def reset(cluster):
+        response = cluster.exec_in_container(
+            cluster.get_container_id("resolver"),
+            [
+                "curl",
+                "-s",
+                f"http://localhost:8083/mock_settings/reset",
+            ],
+            nothrow=True,
+        )
+        assert response == "OK"
+
+    @staticmethod
+    def setup_fail_upload(cluster, part_length):
+        response = cluster.exec_in_container(
+            cluster.get_container_id("resolver"),
+            [
+                "curl",
+                "-s",
+                f"http://localhost:8083/mock_settings/error_at_put?when_length_bigger={part_length}",
+            ],
+            nothrow=True,
+        )
+        assert response == "OK"
+
+    @staticmethod
+    def setup_fake_upload(cluster, part_length):
+        response = cluster.exec_in_container(
+            cluster.get_container_id("resolver"),
+            [
+                "curl",
+                "-s",
+                f"http://localhost:8083/mock_settings/fake_put?when_length_bigger={part_length}",
+            ],
+            nothrow=True,
+        )
+        assert response == "OK"
+
+    @staticmethod
+    def setup_slow_answers(
+        cluster, minimal_length=0, timeout=None, probability=None, count=None
+    ):
+        url = (
+            f"http://localhost:8083/"
+            f"mock_settings/slow_put"
+            f"?minimal_length={minimal_length}"
+        )
+
+        if timeout is not None:
+            url += f"&timeout={timeout}"
+
+        if probability is not None:
+            url += f"&probability={probability}"
+
+        if count is not None:
+            url += f"&count={count}"
+
+        response = cluster.exec_in_container(
+            cluster.get_container_id("resolver"),
+            ["curl", "-s", url],
+            nothrow=True,
+        )
+        assert response == "OK"
+
+
 @pytest.fixture(autouse=True, scope="function")
-def reset_mock_broken_s3(cluster):
-    response = cluster.exec_in_container(
-        cluster.get_container_id("resolver"),
-        ["curl", "-s", f"http://localhost:8083/mock_settings/reset"],
-        nothrow=True,
-    )
-    assert response == "OK"
+def reset_broken_s3(cluster):
+    BrokenS3.reset(cluster)
 
     yield
 
@@ -886,16 +951,7 @@ def test_merge_canceled_by_s3_errors(cluster, node_name):
     min_key = node.query("SELECT min(key) FROM test_merge_canceled_by_s3_errors")
     assert int(min_key) == 0, min_key
 
-    response = cluster.exec_in_container(
-        cluster.get_container_id("resolver"),
-        [
-            "curl",
-            "-s",
-            f"http://localhost:8083/mock_settings/error_at_put?when_length_bigger=50000",
-        ],
-        nothrow=True,
-    )
-    assert response == "OK"
+    BrokenS3.setup_fail_upload(cluster, 50000)
 
     node.query("SYSTEM START MERGES test_merge_canceled_by_s3_errors")
 
@@ -938,16 +994,7 @@ def test_merge_canceled_by_s3_errors_when_move(cluster, node_name):
         settings={"materialize_ttl_after_modify": 0},
     )
 
-    response = cluster.exec_in_container(
-        cluster.get_container_id("resolver"),
-        [
-            "curl",
-            "-s",
-            f"http://localhost:8083/mock_settings/error_at_put?when_length_bigger=10000",
-        ],
-        nothrow=True,
-    )
-    assert response == "OK"
+    BrokenS3.setup_fail_upload(cluster, 10000)
 
     node.query("SYSTEM START MERGES merge_canceled_by_s3_errors_when_move")
 
@@ -963,75 +1010,11 @@ def test_merge_canceled_by_s3_errors_when_move(cluster, node_name):
     )
 
 
-def value_or(value, default):
-    assert default is not None
-    return value if value is not None else default
-
-
-class BrokenS3:
-    @staticmethod
-    def reset(cluster):
-        response = cluster.exec_in_container(
-            cluster.get_container_id("resolver"),
-            [
-                "curl",
-                "-s",
-                f"http://localhost:8083/mock_settings/reset",
-            ],
-            nothrow=True,
-        )
-        assert response == "OK"
-
-    @staticmethod
-    def setup_fake_upload(cluster, part_length):
-        response = cluster.exec_in_container(
-            cluster.get_container_id("resolver"),
-            [
-                "curl",
-                "-s",
-                f"http://localhost:8083/mock_settings/fake_put?when_length_bigger={part_length}",
-            ],
-            nothrow=True,
-        )
-        assert response == "OK"
-
-    @staticmethod
-    def setup_slow_answers(
-        cluster, minimal_length=0, timeout=None, probability=None, count=None
-    ):
-        url = f"http://localhost:8083/" \
-              f"mock_settings/slow_put" \
-              f"?minimal_length={minimal_length}"
-
-        if timeout is not None:
-            url += f"&timeout={timeout}"
-
-        if probability is not None:
-            url += f"&probability={probability}"
-
-        if count is not None:
-            url += f"&count={count}"
-
-        response = cluster.exec_in_container(
-            cluster.get_container_id("resolver"),
-            ["curl", "-s", url],
-            nothrow=True,
-        )
-        assert response == "OK"
-
-
-@pytest.fixture(autouse=True, scope="function")
-def reset_broken_s3(cluster):
-    BrokenS3.reset(cluster)
-
-    yield
-
-
 @pytest.mark.parametrize("node_name", ["node"])
 @pytest.mark.parametrize(
     "in_flight_memory", [(10, 245918115), (5, 156786752), (1, 106426187)]
 )
-def test_heavy_write_check_mem(cluster, node_name, in_flight_memory):
+def test_s3_engine_heavy_write_check_mem(cluster, node_name, in_flight_memory):
     in_flight = in_flight_memory[0]
     memory = in_flight_memory[1]
 
@@ -1046,12 +1029,13 @@ def test_heavy_write_check_mem(cluster, node_name, in_flight_memory):
     )
 
     BrokenS3.setup_fake_upload(cluster, 1000)
-    BrokenS3.setup_slow_answers(cluster, 10 * 1024 * 1024, timeout=10, count=10)
+    BrokenS3.setup_slow_answers(cluster, 10 * 1024 * 1024, timeout=15, count=10)
 
-    query_id = f"INSERT_INTO_S3_QUERY_ID_{in_flight}"
+    query_id = f"INSERT_INTO_S3_ENGINE_QUERY_ID_{in_flight}"
     node.query(
         "INSERT INTO s3_test SELECT number, toString(number) FROM numbers(50000000)"
-        f" SETTINGS max_memory_usage={2*memory}, s3_max_inflight_parts_for_one_file={in_flight}",
+        f" SETTINGS max_memory_usage={2*memory}"
+        f", s3_max_inflight_parts_for_one_file={in_flight}",
         query_id=query_id,
     )
 
@@ -1064,7 +1048,53 @@ def test_heavy_write_check_mem(cluster, node_name, in_flight_memory):
         "   AND type!='QueryStart'"
     )
 
-    assert int(result) < 1.1 * memory
-    assert int(result) > 0.9 * memory
+    assert int(result) < 1.01 * memory
+    assert int(result) > 0.99 * memory
+
+    check_no_objects_after_drop(cluster, node_name=node_name)
+
+
+@pytest.mark.parametrize("node_name", ["node"])
+def test_s3_disk_heavy_write_check_mem(cluster, node_name):
+    memory = 2279055040
+
+    node = cluster.instances[node_name]
+    node.query("DROP TABLE IF EXISTS s3_test SYNC")
+    node.query(
+        "CREATE TABLE s3_test"
+        " ("
+        "   key UInt32, value String"
+        " )"
+        " ENGINE=MergeTree()"
+        " ORDER BY key"
+        " SETTINGS"
+        " storage_policy='broken_s3'",
+    )
+    node.query("SYSTEM STOP MERGES s3_test")
+
+    BrokenS3.setup_fake_upload(cluster, 1000)
+    BrokenS3.setup_slow_answers(cluster, 10 * 1024 * 1024, timeout=10, count=50)
+
+    query_id = f"INSERT_INTO_S3_DISK_QUERY_ID"
+    node.query(
+        "INSERT INTO s3_test SELECT number, toString(number) FROM numbers(50000000)"
+        f" SETTINGS max_memory_usage={2*memory}"
+        f", max_insert_block_size=50000000"
+        f", min_insert_block_size_rows=50000000"
+        f", min_insert_block_size_bytes=1000000000000",
+        query_id=query_id,
+    )
+
+    node.query("SYSTEM FLUSH LOGS")
+
+    result = node.query(
+        "SELECT memory_usage"
+        " FROM system.query_log"
+        f" WHERE query_id='{query_id}'"
+        "   AND type!='QueryStart'"
+    )
+
+    assert int(result) < 1.01 * memory
+    assert int(result) > 0.99 * memory
 
     check_no_objects_after_drop(cluster, node_name=node_name)

--- a/tests/integration/test_merge_tree_s3_failover/configs/config.d/storage_conf.xml
+++ b/tests/integration/test_merge_tree_s3_failover/configs/config.d/storage_conf.xml
@@ -32,7 +32,7 @@
                 <!-- ClickHouse starts earlier than custom S3 endpoint. Skip access check to avoid fail on start-up -->
                 <skip_access_check>true</skip_access_check>
                 <!-- Avoid extra retries to speed up tests -->
-                <s3_retry_attempts>1</s3_retry_attempts>
+                <retry_attempts>1</retry_attempts>
                 <s3_max_single_read_retries>1</s3_max_single_read_retries>
                 <connect_timeout_ms>20000</connect_timeout_ms>
             </s3_no_retries>


### PR DESCRIPTION
### Changelog category (leave one):
- New Feature


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
new setting s3_max_inflight_parts_for_one_file sets the limit of concurrently loaded parts with multipart upload request in scope of one file.

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
