### PR TITLE
Fix test_insert_same_partition_and_merge failing if one Azure request attempt fails

### DIFF
--- a/src/Disks/IO/WriteBufferFromAzureBlobStorage.cpp
+++ b/src/Disks/IO/WriteBufferFromAzureBlobStorage.cpp
@@ -51,7 +51,7 @@ void WriteBufferFromAzureBlobStorage::execWithRetry(std::function<void()> func, 
         if (i == num_tries - 1)
             throw;
 
-        LOG_DEBUG(log, "Write at attempt {} for blob `{}` failed: {}", i + 1, blob_path, e.Message);
+        LOG_DEBUG(log, "Write at attempt {} for blob `{}` failed: {} {}", i + 1, blob_path, e.what(), e.Message);
     };
 
     for (size_t i = 0; i < num_tries; ++i)

--- a/tests/integration/test_merge_tree_azure_blob_storage/test.py
+++ b/tests/integration/test_merge_tree_azure_blob_storage/test.py
@@ -203,7 +203,7 @@ def test_insert_same_partition_and_merge(cluster, merge_vertical):
     node.query(f"SYSTEM START MERGES {TABLE_NAME}")
 
     # Wait for merges and old parts deletion
-    for attempt in range(0, 10):
+    for attempt in range(0, 60):
         parts_count = azure_query(
             node,
             f"SELECT COUNT(*) FROM system.parts WHERE table = '{TABLE_NAME}' FORMAT Values",
@@ -211,7 +211,7 @@ def test_insert_same_partition_and_merge(cluster, merge_vertical):
         if parts_count == "(1)":
             break
 
-        if attempt == 9:
+        if attempt == 59:
             assert parts_count == "(1)"
 
         time.sleep(1)

--- a/tests/integration/test_merge_tree_s3/test.py
+++ b/tests/integration/test_merge_tree_s3/test.py
@@ -232,7 +232,7 @@ def test_insert_same_partition_and_merge(cluster, merge_vertical, node_name):
     node.query("SYSTEM START MERGES s3_test")
 
     # Wait for merges and old parts deletion
-    for attempt in range(0, 10):
+    for attempt in range(0, 60):
         parts_count = node.query(
             "SELECT COUNT(*) FROM system.parts WHERE table = 's3_test' and active = 1 FORMAT Values"
         )
@@ -240,7 +240,7 @@ def test_insert_same_partition_and_merge(cluster, merge_vertical, node_name):
         if parts_count == "(1)":
             break
 
-        if attempt == 9:
+        if attempt == 59:
             assert parts_count == "(1)"
 
         time.sleep(1)


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Saw it fail like this:
```
            if attempt == 9:
>               assert parts_count == "(1)"
E               AssertionError: assert '(6)' == '(1)'
E                 - (1)
E                 + (6)
```

I.e. it expected a merge to happen within 10 seconds, but it didn't happen.

Server log says the merge ran, but one of the Azure blob writes failed on first attempt:
```
{f6fcc202-d1c1-4cd4-b872-15c38696f34b::20200103_1_6_1} <Debug> WriteBufferFromAzureBlobStorage: Write at attempt 1 for blob `hryujaikuhmghvmdieeaolsochtdeuqt` failed:
```

This was logged ~30s after the merge started. I guess 30s is the timeout (?). So the 10s timeout in the test is not enough even for 2 attempts. Increased to 60s.