### PR TITLE
Preserve initial_query_id for ON CLUSTER queries

### DIFF
--- a/src/Interpreters/Context.h
+++ b/src/Interpreters/Context.h
@@ -3,7 +3,6 @@
 #include <base/types.h>
 #include <Common/isLocalAddress.h>
 #include <Common/MultiVersion.h>
-#include <Common/OpenTelemetryTraceContext.h>
 #include <Common/RemoteHostFilter.h>
 #include <Common/ThreadPool_fwd.h>
 #include <Common/Throttler_fwd.h>

--- a/src/Interpreters/DDLTask.cpp
+++ b/src/Interpreters/DDLTask.cpp
@@ -104,6 +104,14 @@ String DDLLogEntry::toString() const
 
     if (version >= OPENTELEMETRY_ENABLED_VERSION)
         wb << "tracing: " << this->tracing_context;
+    /// NOTE: OPENTELEMETRY_ENABLED_VERSION has new line in TracingContext::serialize(), so no need to add one more
+
+    if (version >= PRESERVE_INITIAL_QUERY_ID_VERSION)
+    {
+        writeString("initial_query_id: ", wb);
+        writeEscapedString(initial_query_id, wb);
+        writeChar('\n', wb);
+    }
 
     return wb.str();
 }
@@ -149,6 +157,14 @@ void DDLLogEntry::parse(const String & data)
         if (!rb.eof() && *rb.position() == 't')
             rb >> "tracing: " >> this->tracing_context;
     }
+
+    if (version >= PRESERVE_INITIAL_QUERY_ID_VERSION)
+    {
+        checkString("initial_query_id: ", rb);
+        readEscapedString(initial_query_id, rb);
+        checkChar('\n', rb);
+    }
+
 
     assertEOF(rb);
 

--- a/src/Interpreters/DDLTask.h
+++ b/src/Interpreters/DDLTask.h
@@ -71,10 +71,11 @@ struct DDLLogEntry
     static constexpr const UInt64 SETTINGS_IN_ZK_VERSION = 2;
     static constexpr const UInt64 NORMALIZE_CREATE_ON_INITIATOR_VERSION = 3;
     static constexpr const UInt64 OPENTELEMETRY_ENABLED_VERSION = 4;
+    static constexpr const UInt64 PRESERVE_INITIAL_QUERY_ID_VERSION = 5;
     /// Add new version here
 
     /// Remember to update the value below once new version is added
-    static constexpr const UInt64 DDL_ENTRY_FORMAT_MAX_VERSION = 4;
+    static constexpr const UInt64 DDL_ENTRY_FORMAT_MAX_VERSION = 5;
 
     UInt64 version = 1;
     String query;
@@ -82,6 +83,7 @@ struct DDLLogEntry
     String initiator; // optional
     std::optional<SettingsChanges> settings;
     OpenTelemetry::TracingContext tracing_context;
+    String initial_query_id;
 
     void setSettingsIfRequired(ContextPtr context);
     String toString() const;

--- a/src/Interpreters/DDLWorker.cpp
+++ b/src/Interpreters/DDLWorker.cpp
@@ -476,6 +476,8 @@ bool DDLWorker::tryExecuteQuery(DDLTaskBase & task, const ZooKeeperPtr & zookeep
             query_context->setSetting("implicit_transaction", Field{0});
         }
 
+        query_context->getClientInfo().initial_query_id = task.entry.initial_query_id;
+
         if (!task.is_initial_query)
             query_scope.emplace(query_context);
         executeQuery(istr, ostr, !task.is_initial_query, query_context, {});

--- a/src/Interpreters/executeDDLQueryOnCluster.cpp
+++ b/src/Interpreters/executeDDLQueryOnCluster.cpp
@@ -184,6 +184,7 @@ BlockIO executeDDLQueryOnCluster(const ASTPtr & query_ptr_, ContextPtr context, 
     entry.initiator = ddl_worker.getCommonHostID();
     entry.setSettingsIfRequired(context);
     entry.tracing_context = OpenTelemetry::CurrentContext();
+    entry.initial_query_id = context->getClientInfo().initial_query_id;
     String node_path = ddl_worker.enqueueQuery(entry);
 
     return getDistributedDDLStatus(node_path, entry, context, /* hosts_to_wait */ nullptr);

--- a/tests/queries/0_stateless/02761_ddl_initial_query_id.reference
+++ b/tests/queries/0_stateless/02761_ddl_initial_query_id.reference
@@ -1,0 +1,5 @@
+default distributed_ddl_entry_format_version
+DROP TABLE IF EXISTS foo ON CLUSTER test_shard_localhost
+distributed_ddl_entry_format_version=PRESERVE_INITIAL_QUERY_ID_VERSION
+DROP TABLE IF EXISTS default.foo
+DROP TABLE IF EXISTS foo ON CLUSTER test_shard_localhost

--- a/tests/queries/0_stateless/02761_ddl_initial_query_id.sh
+++ b/tests/queries/0_stateless/02761_ddl_initial_query_id.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+echo "default distributed_ddl_entry_format_version"
+query_id="$(random_str 10)"
+$CLICKHOUSE_CLIENT --query_id "$query_id" --distributed_ddl_output_mode=none -q "DROP TABLE IF EXISTS foo ON CLUSTER test_shard_localhost"
+$CLICKHOUSE_CLIENT -q "SYSTEM FLUSH LOGS"
+$CLICKHOUSE_CLIENT -q "SELECT query FROM system.query_log WHERE initial_query_id = '$query_id' AND type != 'QueryStart'"
+
+echo "distributed_ddl_entry_format_version=PRESERVE_INITIAL_QUERY_ID_VERSION"
+PRESERVE_INITIAL_QUERY_ID_VERSION=5
+query_id="$(random_str 10)"
+# Check that serialization will not be broken with new lines in initial_query_id
+query_id+=$'\nfoo'
+$CLICKHOUSE_CLIENT --distributed_ddl_entry_format_version=$PRESERVE_INITIAL_QUERY_ID_VERSION --query_id "$query_id" --distributed_ddl_output_mode=none -q "DROP TABLE IF EXISTS foo ON CLUSTER test_shard_localhost"
+$CLICKHOUSE_CLIENT -q "SYSTEM FLUSH LOGS"
+# - normalizeQuery() is required to strip out DDL comment
+# - replace() is required to avoid non deterministic behaviour of
+#   normalizeQuery() that replaces the identifier with "?" only if it has more
+#   then two numbers.
+$CLICKHOUSE_CLIENT -q "SELECT normalizeQuery(replace(query, currentDatabase(), 'default')) FROM system.query_log WHERE initial_query_id = '$query_id' AND type != 'QueryStart' ORDER BY event_time_microseconds"


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Preserve initial_query_id for ON CLUSTER queries, which is useful for introspection (under `distributed_ddl_entry_format_version=5`)

_Note: let's change the setting defaults later, since it already misses opentelemetry #41484_