### PR TITLE
Check return value of `ftruncate` in Keeper

### DIFF
--- a/src/Coordination/Changelog.cpp
+++ b/src/Coordination/Changelog.cpp
@@ -284,7 +284,8 @@ private:
             do
             {
                 res = ftruncate(file_buffer->getFD(), initial_file_size + file_buffer->count());
-            } while (res < 0 && errno == EINTR);
+            } 
+            while (res < 0 && errno == EINTR);
 
             if (res != 0)
                 LOG_WARNING(log, "Could not ftruncate file. Error: {}, errno: {}", errnoToString(), errno);

--- a/src/Coordination/Changelog.cpp
+++ b/src/Coordination/Changelog.cpp
@@ -284,7 +284,7 @@ private:
             do
             {
                 res = ftruncate(file_buffer->getFD(), initial_file_size + file_buffer->count());
-            } 
+            }
             while (res < 0 && errno == EINTR);
 
             if (res != 0)

--- a/src/Coordination/Changelog.cpp
+++ b/src/Coordination/Changelog.cpp
@@ -279,7 +279,16 @@ private:
         flush();
 
         if (log_file_settings.max_size != 0)
-            ftruncate(file_buffer->getFD(), initial_file_size + file_buffer->count());
+        {
+            int res = -1;
+            do
+            {
+                res = ftruncate(file_buffer->getFD(), initial_file_size + file_buffer->count());
+            } while (res < 0 && errno == EINTR);
+
+            if (res != 0)
+                LOG_WARNING(log, "Could not ftruncate file. Error: {}, errno: {}", errnoToString(), errno);
+        }
 
         if (log_file_settings.compress_logs)
             compressed_buffer.reset();


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Trying to make it less offensive  https://github.com/ClickHouse/ClickHouse/issues/49988#issuecomment-1554151215

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
