### PR TITLE
Avoid deadlock when starting table in attach thread of `ReplicatedMergeTree`

### DIFF
--- a/src/Storages/MergeTree/ReplicatedMergeTreeRestartingThread.h
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeRestartingThread.h
@@ -29,6 +29,7 @@ public:
 
     void shutdown(bool part_of_full_shutdown);
 
+    void run();
 private:
     StorageReplicatedMergeTree & storage;
     String log_name;
@@ -42,8 +43,6 @@ private:
     Int64 check_period_ms;                  /// The frequency of checking expiration of session in ZK.
     UInt32 consecutive_check_failures = 0;  /// How many consecutive checks have failed
     bool first_time = true;                 /// Activate replica for the first time.
-
-    void run();
 
     /// Restarts table if needed, returns false if it failed to restart replica.
     bool runImpl();

--- a/src/Storages/MergeTree/ReplicatedMergeTreeRestartingThread.h
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeRestartingThread.h
@@ -23,7 +23,13 @@ class ReplicatedMergeTreeRestartingThread
 public:
     explicit ReplicatedMergeTreeRestartingThread(StorageReplicatedMergeTree & storage_);
 
-    void start() { task->activateAndSchedule(); }
+    void start(bool schedule = true)
+    {
+        if (schedule)
+            task->activateAndSchedule();
+        else
+            task->activate();
+    }
 
     void wakeup() { task->schedule(); }
 

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -4416,20 +4416,29 @@ void StorageReplicatedMergeTree::startupImpl(bool from_attach_thread)
 
         startBeingLeader();
 
-        /// In this thread replica will be activated.
-        restarting_thread.start();
+        if (from_attach_thread)
+        {
+            /// Try activating replica in current thread.
+            restarting_thread.run();
+        }
+        else
+        {
+            /// Activate replica in a seperate thread.
+            restarting_thread.start();
+
+            /// Wait while restarting_thread finishing initialization.
+            /// NOTE It does not mean that replication is actually started after receiving this event.
+            /// It only means that an attempt to startup replication was made.
+            /// Table may be still in readonly mode if this attempt failed for any reason.
+            startup_event.wait();
+        }
+
         /// And this is just a callback
         session_expired_callback_handler = EventNotifier::instance().subscribe(Coordination::Error::ZSESSIONEXPIRED, [this]()
         {
             LOG_TEST(log, "Received event for expired session. Waking up restarting thread");
             restarting_thread.start();
         });
-
-        /// Wait while restarting_thread finishing initialization.
-        /// NOTE It does not mean that replication is actually started after receiving this event.
-        /// It only means that an attempt to startup replication was made.
-        /// Table may be still in readonly mode if this attempt failed for any reason.
-        startup_event.wait();
 
         startBackgroundMovesIfNeeded();
 

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -4416,6 +4416,9 @@ void StorageReplicatedMergeTree::startupImpl(bool from_attach_thread)
 
         startBeingLeader();
 
+        /// Activate replica in a separate thread if we are not calling from attach thread
+        restarting_thread.start(/*schedule=*/!from_attach_thread);
+
         if (from_attach_thread)
         {
             /// Try activating replica in current thread.
@@ -4423,9 +4426,6 @@ void StorageReplicatedMergeTree::startupImpl(bool from_attach_thread)
         }
         else
         {
-            /// Activate replica in a separate thread.
-            restarting_thread.start();
-
             /// Wait while restarting_thread finishing initialization.
             /// NOTE It does not mean that replication is actually started after receiving this event.
             /// It only means that an attempt to startup replication was made.

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -4423,7 +4423,7 @@ void StorageReplicatedMergeTree::startupImpl(bool from_attach_thread)
         }
         else
         {
-            /// Activate replica in a seperate thread.
+            /// Activate replica in a separate thread.
             restarting_thread.start();
 
             /// Wait while restarting_thread finishing initialization.

--- a/tests/integration/test_replicated_table_attach/configs/config.xml
+++ b/tests/integration/test_replicated_table_attach/configs/config.xml
@@ -1,0 +1,3 @@
+<clickhouse>
+    <background_schedule_pool_size>1</background_schedule_pool_size>
+</clickhouse>

--- a/tests/integration/test_replicated_table_attach/configs/config.xml
+++ b/tests/integration/test_replicated_table_attach/configs/config.xml
@@ -1,3 +1,6 @@
 <clickhouse>
     <background_schedule_pool_size>1</background_schedule_pool_size>
+    <merge_tree>
+        <initialization_retry_period>5</initialization_retry_period>
+    </merge_tree>
 </clickhouse>

--- a/tests/integration/test_replicated_table_attach/test.py
+++ b/tests/integration/test_replicated_table_attach/test.py
@@ -57,4 +57,7 @@ def test_startup_with_small_bg_pool_partitioned(started_cluster):
         node.restart_clickhouse(stop_start_wait_sec=20)
         assert_values()
 
+    # check that we activate it in the end
+    node.query_with_retry("INSERT INTO replicated_table_partitioned VALUES(20, 30)")
+
     node.query("DROP TABLE replicated_table_partitioned SYNC")

--- a/tests/integration/test_replicated_table_attach/test.py
+++ b/tests/integration/test_replicated_table_attach/test.py
@@ -1,0 +1,58 @@
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+from helpers.network import PartitionManager
+
+
+cluster = ClickHouseCluster(__file__)
+
+node = cluster.add_instance(
+    "node",
+    main_configs=["configs/config.xml"],
+    with_zookeeper=True,
+    stay_alive=True,
+)
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+        yield cluster
+
+    finally:
+        cluster.shutdown()
+
+
+def test_startup_with_small_bg_pool(started_cluster):
+    node.query(
+        "CREATE TABLE replicated_table (k UInt64, i32 Int32) ENGINE=ReplicatedMergeTree('/clickhouse/replicated_table', 'r1') ORDER BY k"
+    )
+
+    node.query("INSERT INTO replicated_table VALUES(20, 30)")
+
+    def assert_values():
+        assert node.query("SELECT * FROM replicated_table") == "20\t30\n"
+
+    assert_values()
+    node.restart_clickhouse(stop_start_wait_sec=10)
+    assert_values()
+
+    node.query("DROP TABLE replicated_table SYNC")
+
+def test_startup_with_small_bg_pool_partitioned(started_cluster):
+    node.query(
+        "CREATE TABLE replicated_table_partitioned (k UInt64, i32 Int32) ENGINE=ReplicatedMergeTree('/clickhouse/replicated_table_partitioned', 'r1') ORDER BY k"
+    )
+
+    node.query("INSERT INTO replicated_table_partitioned VALUES(20, 30)")
+
+    def assert_values():
+        assert node.query("SELECT * FROM replicated_table_partitioned") == "20\t30\n"
+
+    assert_values()
+    with PartitionManager() as pm:
+        pm.drop_instance_zk_connections(node)
+        node.restart_clickhouse(stop_start_wait_sec=20)
+        assert_values()
+
+    node.query("DROP TABLE replicated_table_partitioned SYNC")

--- a/tests/integration/test_replicated_table_attach/test.py
+++ b/tests/integration/test_replicated_table_attach/test.py
@@ -13,6 +13,7 @@ node = cluster.add_instance(
     stay_alive=True,
 )
 
+
 @pytest.fixture(scope="module")
 def started_cluster():
     try:
@@ -38,6 +39,7 @@ def test_startup_with_small_bg_pool(started_cluster):
     assert_values()
 
     node.query("DROP TABLE replicated_table SYNC")
+
 
 def test_startup_with_small_bg_pool_partitioned(started_cluster):
     node.query(


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Avoid deadlock when starting `ReplicatedMergeTree` tables. Tables could end up in deadlock if background threadpool size was lower than the number of tables.

Fix https://github.com/ClickHouse/ClickHouse/issues/49962

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
