### PR TITLE
Add proper escaping for DDL OpenTelemetry context serialization

### DIFF
--- a/src/Common/OpenTelemetryTraceContext.cpp
+++ b/src/Common/OpenTelemetryTraceContext.cpp
@@ -5,7 +5,8 @@
 #include <Common/Exception.h>
 #include <base/hex.h>
 #include <Core/Settings.h>
-#include <IO/Operators.h>
+#include <IO/ReadHelpers.h>
+#include <IO/WriteHelpers.h>
 
 #include <Common/AsyncTaskExecutor.h>
 
@@ -249,26 +250,26 @@ String TracingContext::composeTraceparentHeader() const
 
 void TracingContext::deserialize(ReadBuffer & buf)
 {
-    buf >> this->trace_id
-        >> "\n"
-        >> this->span_id
-        >> "\n"
-        >> this->tracestate
-        >> "\n"
-        >> this->trace_flags
-        >> "\n";
+    readUUIDText(trace_id, buf);
+    assertChar('\n', buf);
+    readIntText(span_id, buf);
+    assertChar('\n', buf);
+    readString(tracestate, buf);
+    assertChar('\n', buf);
+    readIntText(trace_flags, buf);
+    assertChar('\n', buf);
 }
 
 void TracingContext::serialize(WriteBuffer & buf) const
 {
-    buf << this->trace_id
-        << "\n"
-        << this->span_id
-        << "\n"
-        << this->tracestate
-        << "\n"
-        << this->trace_flags
-        << "\n";
+    writeUUIDText(trace_id, buf);
+    writeChar('\n', buf);
+    writeIntText(span_id, buf);
+    writeChar('\n', buf);
+    writeString(tracestate, buf);
+    writeChar('\n', buf);
+    writeIntText(trace_flags, buf);
+    writeChar('\n', buf);
 }
 
 const TracingContextOnThread & CurrentContext()

--- a/src/Common/OpenTelemetryTraceContext.cpp
+++ b/src/Common/OpenTelemetryTraceContext.cpp
@@ -254,7 +254,7 @@ void TracingContext::deserialize(ReadBuffer & buf)
     assertChar('\n', buf);
     readIntText(span_id, buf);
     assertChar('\n', buf);
-    readString(tracestate, buf);
+    readEscapedString(tracestate, buf);
     assertChar('\n', buf);
     readIntText(trace_flags, buf);
     assertChar('\n', buf);
@@ -266,7 +266,7 @@ void TracingContext::serialize(WriteBuffer & buf) const
     writeChar('\n', buf);
     writeIntText(span_id, buf);
     writeChar('\n', buf);
-    writeString(tracestate, buf);
+    writeEscapedString(tracestate, buf);
     writeChar('\n', buf);
     writeIntText(trace_flags, buf);
     writeChar('\n', buf);

--- a/tests/queries/0_stateless/02423_ddl_for_opentelemetry.sh
+++ b/tests/queries/0_stateless/02423_ddl_for_opentelemetry.sh
@@ -15,13 +15,15 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # $3 - Query Settings
 function execute_query()
 {
-    # Some queries are supposed to fail, use -f to suppress error messages
-    echo $2 | ${CLICKHOUSE_CURL_COMMAND} -q -s --max-time 180 \
-                -X POST \
-                -H "traceparent: 00-$1-5150000000000515-01" \
-                -H "tracestate: a\nb cd" \
-                "${CLICKHOUSE_URL}&${3}" \
-                --data @-
+    local trace_id=$1 && shift
+    local ddl_version=$1 && shift
+    local opts=(
+        --opentelemetry-traceparent "00-$trace_id-5150000000000515-01"
+        --opentelemetry-tracestate "a\nb cd"
+        --distributed_ddl_output_mode "none"
+        --distributed_ddl_entry_format_version "$ddl_version"
+    )
+    ${CLICKHOUSE_CLIENT} "${opts[@]}" "$@"
 }
 
 # This function takes following argument:
@@ -82,9 +84,9 @@ for ddl_version in 3 4; do
     echo "===ddl_format_version ${ddl_version}===="
 
     trace_id=$(${CLICKHOUSE_CLIENT} -q "select lower(hex(generateUUIDv4()))");
-    execute_query $trace_id "CREATE TABLE ${CLICKHOUSE_DATABASE}.ddl_test_for_opentelemetry ON CLUSTER ${cluster_name} (id UInt64) Engine=MergeTree ORDER BY id" "distributed_ddl_output_mode=none&distributed_ddl_entry_format_version=${ddl_version}"
+    execute_query $trace_id $ddl_version -q "CREATE TABLE ${CLICKHOUSE_DATABASE}.ddl_test_for_opentelemetry ON CLUSTER ${cluster_name} (id UInt64) Engine=MergeTree ORDER BY id"
 
-    check_span 1 $trace_id "HTTPHandler"
+    check_span 1 $trace_id "TCPHandler"
 
     if [ $cluster_name = "test_shard_localhost" ]; then
         check_span 1 $trace_id "%executeDDLQueryOnCluster%" "attribute['clickhouse.cluster']='${cluster_name}'"
@@ -106,7 +108,7 @@ for ddl_version in 3 4; do
     check_span $expected $trace_id "%DDLWorker::processTask%"
     
     # For queries that tracing are enabled(format version is 4 or Replicated database engine), there should be two 'query' spans,
-    # one is for the HTTPHandler, the other is for the DDL executing in DDLWorker.
+    # one is for the TCPHandler, the other is for the DDL executing in DDLWorker.
     #
     # For other format, there should be only one 'query' span
     if [ $cluster_name = "test_shard_localhost" ]; then
@@ -134,9 +136,9 @@ done
 echo "===exception===="
 
 trace_id=$(${CLICKHOUSE_CLIENT} -q "select lower(hex(generateUUIDv4()))");
-execute_query $trace_id "DROP TABLE ${CLICKHOUSE_DATABASE}.ddl_test_for_opentelemetry_non_exist ON CLUSTER ${cluster_name}" "distributed_ddl_output_mode=none&distributed_ddl_entry_format_version=4" 2>&1| grep -Fv "UNKNOWN_TABLE"
+execute_query $trace_id 4 -q "DROP TABLE ${CLICKHOUSE_DATABASE}.ddl_test_for_opentelemetry_non_exist ON CLUSTER ${cluster_name}" 2>&1 | grep 'DB::Exception ' | grep -Fv "UNKNOWN_TABLE"
 
-check_span 1 $trace_id "HTTPHandler"
+check_span 1 $trace_id "TCPHandler"
 
 if [ $cluster_name = "test_shard_localhost" ]; then
     expected=1
@@ -148,7 +150,7 @@ check_span $expected $trace_id "%executeDDLQueryOnCluster%" "attribute['clickhou
 check_span $expected $trace_id "%DDLWorker::processTask%" "kind = 'CONSUMER'"
 
 if [ $cluster_name = "test_shard_localhost" ]; then
-    # There should be two 'query' spans, one is for the HTTPHandler, the other is for the DDL executing in DDLWorker.
+    # There should be two 'query' spans, one is for the TCPHandler, the other is for the DDL executing in DDLWorker.
     # Both of these two spans contain exception
     expected=2
 else

--- a/tests/queries/0_stateless/02423_ddl_for_opentelemetry.sh
+++ b/tests/queries/0_stateless/02423_ddl_for_opentelemetry.sh
@@ -19,7 +19,7 @@ function execute_query()
     local ddl_version=$1 && shift
     local opts=(
         --opentelemetry-traceparent "00-$trace_id-5150000000000515-01"
-        --opentelemetry-tracestate "a\nb cd"
+        --opentelemetry-tracestate $'a\nb cd'
         --distributed_ddl_output_mode "none"
         --distributed_ddl_entry_format_version "$ddl_version"
     )


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add proper escaping for DDL OpenTelemetry context serialization

Before you was able to break the format by using "\n" or "\t", that will
simply lead to DDL hang, because DDLWorker will simply log the error and
do nothing more:

    <Error> DDLWorker: Cannot parse DDL task query-0000000056: Incorrect task format. Will try to send error status: Code: 27. DB::ParsingException: Cannot parse input: expected '\n' before: 'bar\n1\n'. (CANNOT_PARSE_INPUT_ASSERTION_FAILED) (version 23.5.1.1)

Fix this by adding proper escaping.

And also add a proper test that indeed check `\n`.

Follow-up for: #41484 (@FrankChen021 )

_Note: to enable this feature you need to manually set `distributed_ddl_entry_format_version=4`, I guess there were not a lot of such users, and even less, who uses symbols that should be escaped in `tracestate`_