### PR TITLE
Fix 02735_system_zookeeper_connection for DatabaseReplicated

### DIFF
--- a/tests/queries/0_stateless/02735_system_zookeeper_connection.sql
+++ b/tests/queries/0_stateless/02735_system_zookeeper_connection.sql
@@ -1,4 +1,4 @@
--- Tags: no-fasttest
+-- Tags: no-fasttest, no-replicated-database
 
 DROP TABLE IF EXISTS test_zk_connection_table;
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

CI: https://s3.amazonaws.com/clickhouse-test-reports/50045/82054d40a56645e2386452bd4828805d5b4c3a23/stateless_tests__release__databasereplicated__[1_4].html

Follow-up for:  #45245 (cc @tavplubix @mateng0915 )