### PR TITLE
Fix reporting broken projection parts

### DIFF
--- a/src/Storages/MergeTree/DataPartsExchange.cpp
+++ b/src/Storages/MergeTree/DataPartsExchange.cpp
@@ -130,12 +130,7 @@ void Service::processQuery(const HTMLForm & params, ReadBuffer & /*body*/, Write
 
     auto report_broken_part = [&]()
     {
-        if (part && part->isProjectionPart())
-        {
-            auto parent_part = part->getParentPart()->shared_from_this();
-            data.reportBrokenPart(parent_part);
-        }
-        else if (part)
+        if (part)
             data.reportBrokenPart(part);
         else
             LOG_TRACE(log, "Part {} was not found, do not report it as broken", part_name);

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -7420,8 +7420,14 @@ Strings MergeTreeData::getDataPaths() const
 }
 
 
-void MergeTreeData::reportBrokenPart(MergeTreeData::DataPartPtr & data_part) const
+void MergeTreeData::reportBrokenPart(MergeTreeData::DataPartPtr data_part) const
 {
+    if (!data_part)
+        return;
+
+    if (data_part->isProjectionPart())
+        data_part = data_part->getParentPart()->shared_from_this();
+
     if (data_part->getDataPartStorage().isBroken())
     {
         auto parts = getDataPartsForInternalUsage();
@@ -7433,7 +7439,7 @@ void MergeTreeData::reportBrokenPart(MergeTreeData::DataPartPtr & data_part) con
                 broken_part_callback(part->name);
         }
     }
-    else if (data_part && data_part->getState() == MergeTreeDataPartState::Active)
+    else if (data_part->getState() == MergeTreeDataPartState::Active)
         broken_part_callback(data_part->name);
     else
         LOG_DEBUG(log, "Will not check potentially broken part {} because it's not active", data_part->getNameWithState());

--- a/src/Storages/MergeTree/MergeTreeData.h
+++ b/src/Storages/MergeTree/MergeTreeData.h
@@ -718,7 +718,7 @@ public:
     /// Should be called if part data is suspected to be corrupted.
     /// Has the ability to check all other parts
     /// which reside on the same disk of the suspicious part.
-    void reportBrokenPart(MergeTreeData::DataPartPtr & data_part) const;
+    void reportBrokenPart(MergeTreeData::DataPartPtr data_part) const;
 
     /// TODO (alesap) Duplicate method required for compatibility.
     /// Must be removed.

--- a/tests/integration/test_projection_report_broken_part/configs/testkeeper.xml
+++ b/tests/integration/test_projection_report_broken_part/configs/testkeeper.xml
@@ -1,0 +1,6 @@
+<clickhouse>
+    <zookeeper>
+        <!-- Don't need real [Zoo]Keeper for this test -->
+        <implementation>testkeeper</implementation>
+    </zookeeper>
+</clickhouse>

--- a/tests/integration/test_projection_report_broken_part/test.py
+++ b/tests/integration/test_projection_report_broken_part/test.py
@@ -16,6 +16,7 @@ node = cluster.add_instance(
     ],
 )
 
+
 @pytest.fixture(scope="module", autouse=True)
 def start_cluster():
     try:
@@ -23,6 +24,7 @@ def start_cluster():
         yield cluster
     finally:
         cluster.shutdown()
+
 
 def test_projection_broken_part():
     node.query(
@@ -57,4 +59,7 @@ def test_projection_broken_part():
 
     time.sleep(2)
 
-    assert int(node.query("select sum(b) from test_projection_broken_parts_1 group by a")) == 6
+    assert (
+        int(node.query("select sum(b) from test_projection_broken_parts_1 group by a"))
+        == 6
+    )

--- a/tests/integration/test_projection_report_broken_part/test.py
+++ b/tests/integration/test_projection_report_broken_part/test.py
@@ -1,0 +1,60 @@
+# pylint: disable=unused-argument
+# pylint: disable=redefined-outer-name
+# pylint: disable=line-too-long
+
+import pytest
+import time
+
+from helpers.client import QueryRuntimeException
+from helpers.cluster import ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__)
+node = cluster.add_instance(
+    "node",
+    main_configs=[
+        "configs/testkeeper.xml",
+    ],
+)
+
+@pytest.fixture(scope="module", autouse=True)
+def start_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+def test_projection_broken_part():
+    node.query(
+        """
+        create table test_projection_broken_parts_1 (a int, b int, projection ab (select a, sum(b) group by a))
+        engine = ReplicatedMergeTree('/clickhouse-tables/test_projection_broken_parts', 'r1')
+        order by a settings index_granularity = 1;
+
+        create table test_projection_broken_parts_2 (a int, b int, projection ab (select a, sum(b) group by a))
+        engine ReplicatedMergeTree('/clickhouse-tables/test_projection_broken_parts', 'r2')
+        order by a settings index_granularity = 1;
+
+        insert into test_projection_broken_parts_1 values (1, 1), (1, 2), (1, 3);
+
+        system sync replica test_projection_broken_parts_2;
+    """
+    )
+
+    # break projection part
+    node.exec_in_container(
+        [
+            "bash",
+            "-c",
+            "rm /var/lib/clickhouse/data/default/test_projection_broken_parts_1/all_0_0_0/ab.proj/data.bin",
+        ]
+    )
+
+    expected_error = "No such file or directory"
+    assert expected_error in node.query_and_get_error(
+        "select sum(b) from test_projection_broken_parts_1 group by a"
+    )
+
+    time.sleep(2)
+
+    assert int(node.query("select sum(b) from test_projection_broken_parts_1 group by a")) == 6


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix incorrect reporting of broken projection parts which can lead to incorrect query result and replication stuck. This fixes #49913. This fixes #46413.