### PR TITLE
Fix crashing in case of Replicated database without arguments

### DIFF
--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -227,7 +227,7 @@ BlockIO InterpreterCreateQuery::createDatabase(ASTCreateQuery & create)
         metadata_path = metadata_path / "metadata" / database_name_escaped;
     }
 
-    if (create.storage->engine->name == "Replicated" && !internal && !create.attach)
+    if (create.storage->engine->name == "Replicated" && !internal && !create.attach && create.storage->engine->arguments)
     {
         /// Fill in default parameters
         if (create.storage->engine->arguments->children.size() == 1)

--- a/tests/queries/0_stateless/02762_replicated_database_no_args.sql
+++ b/tests/queries/0_stateless/02762_replicated_database_no_args.sql
@@ -1,0 +1,4 @@
+-- Tags: no-parallel
+
+set allow_experimental_database_replicated=1;
+create database replicated_db_no_args engine=Replicated; -- { serverError BAD_ARGUMENTS }


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix crashing in case of Replicated database without arguments

Cc: @tavplubix 