### PR TITLE
Fix hashed/sparse_hashed dictionaries max_load_factor upper range

### DIFF
--- a/src/Dictionaries/HashedDictionary.cpp
+++ b/src/Dictionaries/HashedDictionary.cpp
@@ -1163,7 +1163,7 @@ void registerDictionaryHashed(DictionaryFactory & factory)
             throw Exception(ErrorCodes::BAD_ARGUMENTS,"{}: SHARD_LOAD_QUEUE_BACKLOG parameter should be greater then zero", full_name);
 
         float max_load_factor = static_cast<float>(config.getDouble(config_prefix + dictionary_layout_prefix + ".max_load_factor", 0.5));
-        if (max_load_factor < 0.5 || max_load_factor > 0.99)
+        if (max_load_factor < 0.5f || max_load_factor > 0.99f)
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "{}: max_load_factor parameter should be within [0.5, 0.99], got {}", full_name, max_load_factor);
 
         HashedDictionaryConfiguration configuration{


### PR DESCRIPTION
Comparison of floats with doubles is not intuitive:

    (lldb) p (float)0.99 > (float)0.99
    (bool) $0 = false
    (lldb) p (float)0.99 > (double)0.99
    (bool) $1 = true

This should fix performance tests errors on CI:

    clickhouse_driver.errors.ServerException: Code: 36.
    DB::Exception: default.simple_key_HASHED_dictionary_l0_99: max_load_factor parameter should be within [0.5, 0.99], got 0.99. Stack trace:

Follow-up for: #49380  (Cc: @rschu1ze )

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)