### PR TITLE
optimize parquet write performance for parallel threads

### DIFF
--- a/src/Processors/Formats/Impl/ArrowBlockOutputFormat.cpp
+++ b/src/Processors/Formats/Impl/ArrowBlockOutputFormat.cpp
@@ -58,7 +58,9 @@ void ArrowBlockOutputFormat::consume(Chunk chunk)
             format_settings.arrow.output_fixed_string_as_fixed_byte_array);
     }
 
-    ch_column_to_arrow_column->chChunkToArrowTable(arrow_table, chunk, columns_num);
+    auto chunks = std::vector<Chunk>();
+    chunks.push_back(std::move(chunk));
+    ch_column_to_arrow_column->chChunkToArrowTable(arrow_table, chunks, columns_num);
 
     if (!writer)
         prepareWriter(arrow_table->schema());

--- a/src/Processors/Formats/Impl/CHColumnToArrowColumn.cpp
+++ b/src/Processors/Formats/Impl/CHColumnToArrowColumn.cpp
@@ -976,56 +976,75 @@ namespace DB
 
     void CHColumnToArrowColumn::chChunkToArrowTable(
         std::shared_ptr<arrow::Table> & res,
-        const Chunk & chunk,
+        const std::vector<Chunk> & chunks,
         size_t columns_num)
     {
-        /// For arrow::Schema and arrow::Table creation
-        std::vector<std::shared_ptr<arrow::Array>> arrow_arrays;
-        arrow_arrays.reserve(columns_num);
-        for (size_t column_i = 0; column_i < columns_num; ++column_i)
+        std::shared_ptr<arrow::Schema> arrow_schema;
+        std::vector<arrow::ArrayVector> table_data(columns_num);
+
+        for (const auto & chunk : chunks)
         {
-            const ColumnWithTypeAndName & header_column = header_columns[column_i];
-            auto column = chunk.getColumns()[column_i];
-
-            if (!low_cardinality_as_dictionary)
-                column = recursiveRemoveLowCardinality(column);
-
-            if (!is_arrow_fields_initialized)
+            /// For arrow::Schema and arrow::Table creation
+            for (size_t column_i = 0; column_i < columns_num; ++column_i)
             {
-                bool is_column_nullable = false;
-                auto arrow_type = getArrowType(header_column.type, column, header_column.name, format_name, output_string_as_string, output_fixed_string_as_fixed_byte_array, &is_column_nullable);
-                arrow_fields.emplace_back(std::make_shared<arrow::Field>(header_column.name, arrow_type, is_column_nullable));
+                const ColumnWithTypeAndName & header_column = header_columns[column_i];
+                auto column = chunk.getColumns()[column_i];
+
+                if (!low_cardinality_as_dictionary)
+                    column = recursiveRemoveLowCardinality(column);
+
+                if (!is_arrow_fields_initialized)
+                {
+                    bool is_column_nullable = false;
+                    auto arrow_type = getArrowType(
+                        header_column.type,
+                        column,
+                        header_column.name,
+                        format_name,
+                        output_string_as_string,
+                        output_fixed_string_as_fixed_byte_array,
+                        &is_column_nullable);
+                    arrow_fields.emplace_back(std::make_shared<arrow::Field>(header_column.name, arrow_type, is_column_nullable));
+                }
+
+                arrow::MemoryPool * pool = arrow::default_memory_pool();
+                std::unique_ptr<arrow::ArrayBuilder> array_builder;
+                arrow::Status status = MakeBuilder(pool, arrow_fields[column_i]->type(), &array_builder);
+                checkStatus(status, column->getName(), format_name);
+
+                fillArrowArray(
+                    header_column.name,
+                    column,
+                    header_column.type,
+                    nullptr,
+                    array_builder.get(),
+                    format_name,
+                    0,
+                    column->size(),
+                    output_string_as_string,
+                    output_fixed_string_as_fixed_byte_array,
+                    dictionary_values);
+
+                std::shared_ptr<arrow::Array> arrow_array;
+                status = array_builder->Finish(&arrow_array);
+                checkStatus(status, column->getName(), format_name);
+
+                table_data.at(column_i).emplace_back(std::move(arrow_array));
             }
 
-            arrow::MemoryPool* pool = arrow::default_memory_pool();
-            std::unique_ptr<arrow::ArrayBuilder> array_builder;
-            arrow::Status status = MakeBuilder(pool, arrow_fields[column_i]->type(), &array_builder);
-            checkStatus(status, column->getName(), format_name);
-
-            fillArrowArray(
-                header_column.name,
-                column,
-                header_column.type,
-                nullptr,
-                array_builder.get(),
-                format_name,
-                0,
-                column->size(),
-                output_string_as_string,
-                output_fixed_string_as_fixed_byte_array,
-                dictionary_values);
-
-            std::shared_ptr<arrow::Array> arrow_array;
-            status = array_builder->Finish(&arrow_array);
-            checkStatus(status, column->getName(), format_name);
-            arrow_arrays.emplace_back(std::move(arrow_array));
+            is_arrow_fields_initialized = true;
+            if (!arrow_schema)
+                arrow_schema = std::make_shared<arrow::Schema>(arrow_fields);
         }
 
-        std::shared_ptr<arrow::Schema> arrow_schema = std::make_shared<arrow::Schema>(arrow_fields);
+        std::vector<std::shared_ptr<arrow::ChunkedArray>> columns;
+        columns.reserve(columns_num);
+        for (size_t column_i = 0; column_i < columns_num; ++column_i)
+            columns.emplace_back(std::make_shared<arrow::ChunkedArray>(table_data.at(column_i)));
 
-        res = arrow::Table::Make(arrow_schema, arrow_arrays);
-        is_arrow_fields_initialized = true;
+        res = arrow::Table::Make(arrow_schema, columns);
     }
+
 }
 
 #endif

--- a/src/Processors/Formats/Impl/CHColumnToArrowColumn.h
+++ b/src/Processors/Formats/Impl/CHColumnToArrowColumn.h
@@ -16,7 +16,7 @@ class CHColumnToArrowColumn
 public:
     CHColumnToArrowColumn(const Block & header, const std::string & format_name_, bool low_cardinality_as_dictionary_, bool output_string_as_string_, bool output_fixed_string_as_fixed_byte_array_);
 
-    void chChunkToArrowTable(std::shared_ptr<arrow::Table> & res, const Chunk & chunk, size_t columns_num);
+    void chChunkToArrowTable(std::shared_ptr<arrow::Table> & res, const std::vector<Chunk> & chunk, size_t columns_num);
 
 private:
     ColumnsWithTypeAndName header_columns;

--- a/src/Processors/Formats/Impl/ParquetBlockOutputFormat.cpp
+++ b/src/Processors/Formats/Impl/ParquetBlockOutputFormat.cpp
@@ -20,47 +20,47 @@ namespace ErrorCodes
 namespace
 {
 
-parquet::ParquetVersion::type getParquetVersion(const FormatSettings & settings)
-{
-    switch (settings.parquet.output_version)
+    parquet::ParquetVersion::type getParquetVersion(const FormatSettings & settings)
     {
-        case FormatSettings::ParquetVersion::V1_0:
-            return parquet::ParquetVersion::PARQUET_1_0;
-        case FormatSettings::ParquetVersion::V2_4:
-            return parquet::ParquetVersion::PARQUET_2_4;
-        case FormatSettings::ParquetVersion::V2_6:
-            return parquet::ParquetVersion::PARQUET_2_6;
-        case FormatSettings::ParquetVersion::V2_LATEST:
-            return parquet::ParquetVersion::PARQUET_2_LATEST;
+        switch (settings.parquet.output_version)
+        {
+            case FormatSettings::ParquetVersion::V1_0:
+                return parquet::ParquetVersion::PARQUET_1_0;
+            case FormatSettings::ParquetVersion::V2_4:
+                return parquet::ParquetVersion::PARQUET_2_4;
+            case FormatSettings::ParquetVersion::V2_6:
+                return parquet::ParquetVersion::PARQUET_2_6;
+            case FormatSettings::ParquetVersion::V2_LATEST:
+                return parquet::ParquetVersion::PARQUET_2_LATEST;
+        }
     }
-}
 
-parquet::Compression::type getParquetCompression(FormatSettings::ParquetCompression method)
-{
-    if (method == FormatSettings::ParquetCompression::NONE)
-        return parquet::Compression::type::UNCOMPRESSED;
+    parquet::Compression::type getParquetCompression(FormatSettings::ParquetCompression method)
+    {
+        if (method == FormatSettings::ParquetCompression::NONE)
+            return parquet::Compression::type::UNCOMPRESSED;
 
 #if USE_SNAPPY
-    if (method == FormatSettings::ParquetCompression::SNAPPY)
-        return parquet::Compression::type::SNAPPY;
+        if (method == FormatSettings::ParquetCompression::SNAPPY)
+            return parquet::Compression::type::SNAPPY;
 #endif
 
 #if USE_BROTLI
-    if (method == FormatSettings::ParquetCompression::BROTLI)
-        return parquet::Compression::type::BROTLI;
+        if (method == FormatSettings::ParquetCompression::BROTLI)
+            return parquet::Compression::type::BROTLI;
 #endif
 
-    if (method == FormatSettings::ParquetCompression::ZSTD)
-        return parquet::Compression::type::ZSTD;
+        if (method == FormatSettings::ParquetCompression::ZSTD)
+            return parquet::Compression::type::ZSTD;
 
-    if (method == FormatSettings::ParquetCompression::LZ4)
-        return parquet::Compression::type::LZ4;
+        if (method == FormatSettings::ParquetCompression::LZ4)
+            return parquet::Compression::type::LZ4;
 
-    if (method == FormatSettings::ParquetCompression::GZIP)
-        return parquet::Compression::type::GZIP;
+        if (method == FormatSettings::ParquetCompression::GZIP)
+            return parquet::Compression::type::GZIP;
 
-    throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Unsupported compression method");
-}
+        throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Unsupported compression method");
+    }
 
 }
 
@@ -69,70 +69,9 @@ ParquetBlockOutputFormat::ParquetBlockOutputFormat(WriteBuffer & out_, const Blo
 {
 }
 
-void ParquetBlockOutputFormat::consume(Chunk chunk)
+void ParquetBlockOutputFormat::consumeStaged()
 {
-    /// Do something like SquashingTransform to produce big enough row groups.
-    /// Because the real SquashingTransform is only used for INSERT, not for SELECT ... INTO OUTFILE.
-    /// The latter doesn't even have a pipeline where a transform could be inserted, so it's more
-    /// convenient to do the squashing here.
-
-    appendToAccumulatedChunk(std::move(chunk));
-
-    if (!accumulated_chunk)
-        return;
-
-    const size_t target_rows = std::max(static_cast<UInt64>(1), format_settings.parquet.row_group_rows);
-
-    if (accumulated_chunk.getNumRows() < target_rows &&
-        accumulated_chunk.bytes() < format_settings.parquet.row_group_bytes)
-        return;
-
-    /// Increase row group size slightly (by < 2x) to avoid adding a small row groups for the
-    /// remainder of the new chunk.
-    /// E.g. suppose input chunks are 70K rows each, and max_rows = 1M. Then we'll have
-    /// getNumRows() = 1.05M. We want to write all 1.05M as one row group instead of 1M and 0.05M.
-    size_t num_row_groups = std::max(static_cast<UInt64>(1), accumulated_chunk.getNumRows() / target_rows);
-    size_t row_group_size = (accumulated_chunk.getNumRows() - 1) / num_row_groups + 1; // round up
-
-    write(std::move(accumulated_chunk), row_group_size);
-    accumulated_chunk.clear();
-}
-
-void ParquetBlockOutputFormat::finalizeImpl()
-{
-    if (accumulated_chunk)
-        write(std::move(accumulated_chunk), format_settings.parquet.row_group_rows);
-
-    if (!file_writer)
-    {
-        Block header = materializeBlock(getPort(PortKind::Main).getHeader());
-        write(Chunk(header.getColumns(), 0), 1);
-    }
-
-    auto status = file_writer->Close();
-    if (!status.ok())
-        throw Exception(ErrorCodes::UNKNOWN_EXCEPTION, "Error while closing a table: {}", status.ToString());
-}
-
-void ParquetBlockOutputFormat::resetFormatterImpl()
-{
-    file_writer.reset();
-}
-
-void ParquetBlockOutputFormat::appendToAccumulatedChunk(Chunk chunk)
-{
-    if (!accumulated_chunk)
-    {
-        accumulated_chunk = std::move(chunk);
-        return;
-    }
-    chassert(accumulated_chunk.getNumColumns() == chunk.getNumColumns());
-    accumulated_chunk.append(chunk);
-}
-
-void ParquetBlockOutputFormat::write(Chunk chunk, size_t row_group_size)
-{
-    const size_t columns_num = chunk.getNumColumns();
+    const size_t columns_num = staging_chunks.at(0).getNumColumns();
     std::shared_ptr<arrow::Table> arrow_table;
 
     if (!ch_column_to_arrow_column)
@@ -146,7 +85,7 @@ void ParquetBlockOutputFormat::write(Chunk chunk, size_t row_group_size)
             format_settings.parquet.output_fixed_string_as_fixed_byte_array);
     }
 
-    ch_column_to_arrow_column->chChunkToArrowTable(arrow_table, chunk, columns_num);
+    ch_column_to_arrow_column->chChunkToArrowTable(arrow_table, staging_chunks, columns_num);
 
     if (!file_writer)
     {
@@ -173,10 +112,64 @@ void ParquetBlockOutputFormat::write(Chunk chunk, size_t row_group_size)
         file_writer = std::move(result.ValueOrDie());
     }
 
-    auto status = file_writer->WriteTable(*arrow_table, row_group_size);
+    // TODO: calculate row_group_size depending on a number of rows and table size
+
+    // allow slightly bigger than row_group_size to avoid a very small tail row group
+    auto status = file_writer->WriteTable(*arrow_table, std::max<size_t>(format_settings.parquet.row_group_rows, staging_rows));
 
     if (!status.ok())
         throw Exception(ErrorCodes::UNKNOWN_EXCEPTION, "Error while writing a table: {}", status.ToString());
+}
+
+void ParquetBlockOutputFormat::consume(Chunk chunk)
+{
+    /// Do something like SquashingTransform to produce big enough row groups.
+    /// Because the real SquashingTransform is only used for INSERT, not for SELECT ... INTO OUTFILE.
+    /// The latter doesn't even have a pipeline where a transform could be inserted, so it's more
+    /// convenient to do the squashing here.
+    staging_rows += chunk.getNumRows();
+    staging_bytes += chunk.bytes();
+    staging_chunks.push_back(std::move(chunk));
+    chassert(staging_chunks.back().getNumColumns() == staging_chunks.front().getNumColumns());
+    if (staging_rows < format_settings.parquet.row_group_rows &&
+        staging_bytes < format_settings.parquet.row_group_bytes)
+    {
+        return;
+    }
+    else
+    {
+        consumeStaged();
+        staging_chunks.clear();
+        staging_rows = 0;
+        staging_bytes = 0;
+    }
+}
+
+void ParquetBlockOutputFormat::finalizeImpl()
+{
+    if (!file_writer && staging_chunks.empty())
+    {
+        Block header = materializeBlock(getPort(PortKind::Main).getHeader());
+
+        consume(Chunk(header.getColumns(), 0)); // this will make staging_chunks non-empty
+    }
+
+    if (!staging_chunks.empty())
+    {
+        consumeStaged();
+        staging_chunks.clear();
+        staging_rows = 0;
+        staging_bytes = 0;
+    }
+
+    auto status = file_writer->Close();
+    if (!status.ok())
+        throw Exception(ErrorCodes::UNKNOWN_EXCEPTION, "Error while closing a table: {}", status.ToString());
+}
+
+void ParquetBlockOutputFormat::resetFormatterImpl()
+{
+    file_writer.reset();
 }
 
 void registerOutputFormatParquet(FormatFactory & factory)

--- a/src/Processors/Formats/Impl/ParquetBlockOutputFormat.h
+++ b/src/Processors/Formats/Impl/ParquetBlockOutputFormat.h
@@ -34,18 +34,19 @@ public:
     String getContentType() const override { return "application/octet-stream"; }
 
 private:
+    void consumeStaged();
     void consume(Chunk) override;
-    void appendToAccumulatedChunk(Chunk chunk);
-    void write(Chunk chunk, size_t row_group_size);
     void finalizeImpl() override;
     void resetFormatterImpl() override;
+
+    std::vector<Chunk> staging_chunks;
+    size_t staging_rows = 0;
+    size_t staging_bytes = 0;
 
     const FormatSettings format_settings;
 
     std::unique_ptr<parquet::arrow::FileWriter> file_writer;
     std::unique_ptr<CHColumnToArrowColumn> ch_column_to_arrow_column;
-
-    Chunk accumulated_chunk;
 };
 
 }


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):

- Performance Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

optimize parquet write performance for parallel threads

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

###  Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

In https://github.com/ClickHouse/ClickHouse/commit/eb3b774ad048e3cb6db34511950c75df27679739 , a Chunk buffer is introduced for staging small chunks until they accumulated to bigger than row group size. The cost of memory copy in the chunk buffer can be significant, especially when multiple threads are writing parquet files simultaneously.

This PR improves the chunk buffer by avoiding unnecessary memcpy.  My local experiments show a ~30% improvement for parallel writing with 31 threads on a 32-core CPU.

###  Experiments

```shell
for i in {10..40}                                                                                        
do
  nohup time /data0/hongbin/code/vanilla/ClickHouse/cmake-build-release/programs/clickhouse local "--query=INSERT INTO table function file('/data0/tmp/test_write2_$i.parquet',Parquet) select * from file('/data0/tpch100_zhichao/parquet/lineitem/part-000$i-*.parquet',Parquet)" > myoutput${i}.log 2>&1 &
done

cat myoutput* | grep "elapsed" | awk -F '[ :e]' '{sum+=$6}END{print sum/31}'
``` 
The above shell script first launches 31 threads to read&write 31 parquet files(each about 200+M) at the same time. After the threads are done, the last command collects the elapsed time and calculates the average time. The result is 12.7671 (this PR) vs. 17.8435(current master HEAD), showing a nearly 30% improvement
