### PR TITLE
Proper mutation of skip indices and projections

### DIFF
--- a/src/Interpreters/MutationsInterpreter.cpp
+++ b/src/Interpreters/MutationsInterpreter.cpp
@@ -901,6 +901,11 @@ void MutationsInterpreter::prepare(bool dry_run)
         }
     }
 
+    /// Stages might be empty when we materialize skip indices or projections which don't add any
+    /// column dependencies.
+    if (stages.empty())
+        stages.emplace_back(context);
+
     is_prepared = true;
     prepareMutationStages(stages, dry_run);
 }

--- a/src/Interpreters/MutationsInterpreter.h
+++ b/src/Interpreters/MutationsInterpreter.h
@@ -120,6 +120,7 @@ public:
         bool supportsLightweightDelete() const;
         bool hasLightweightDeleteMask() const;
         bool materializeTTLRecalculateOnly() const;
+        bool hasIndexOrProjection(const String & file_name) const;
 
         void read(
             Stage & first_stage,

--- a/src/Storages/MergeTree/IMergeTreeDataPart.cpp
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.cpp
@@ -632,7 +632,7 @@ void IMergeTreeDataPart::loadColumnsChecksumsIndexes(bool require_columns_checks
         if (!parent_part)
         {
             loadTTLInfos();
-            loadProjections(require_columns_checksums, check_consistency);
+            loadProjections(require_columns_checksums, check_consistency, false /* if_not_loaded */);
         }
 
         if (check_consistency)
@@ -690,13 +690,13 @@ void IMergeTreeDataPart::addProjectionPart(
     const String & projection_name,
     std::shared_ptr<IMergeTreeDataPart> && projection_part)
 {
-    /// Here should be a check that projection we are trying to add
-    /// does not exist, but unfortunately this check fails in tests.
-    /// TODO: fix.
+    if (hasProjection(projection_name))
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Projection part {} in part {} is already loaded. This is a bug", projection_name, name);
+
     projection_parts[projection_name] = std::move(projection_part);
 }
 
-void IMergeTreeDataPart::loadProjections(bool require_columns_checksums, bool check_consistency)
+void IMergeTreeDataPart::loadProjections(bool require_columns_checksums, bool check_consistency, bool if_not_loaded)
 {
     auto metadata_snapshot = storage.getInMemoryMetadataPtr();
     for (const auto & projection : metadata_snapshot->projections)
@@ -704,9 +704,18 @@ void IMergeTreeDataPart::loadProjections(bool require_columns_checksums, bool ch
         auto path = projection.name + ".proj";
         if (getDataPartStorage().exists(path))
         {
-            auto part = getProjectionPartBuilder(projection.name).withPartFormatFromDisk().build();
-            part->loadColumnsChecksumsIndexes(require_columns_checksums, check_consistency);
-            addProjectionPart(projection.name, std::move(part));
+            if (hasProjection(projection.name))
+            {
+                if (!if_not_loaded)
+                    throw Exception(
+                        ErrorCodes::LOGICAL_ERROR, "Projection part {} in part {} is already loaded. This is a bug", projection.name, name);
+            }
+            else
+            {
+                auto part = getProjectionPartBuilder(projection.name).withPartFormatFromDisk().build();
+                part->loadColumnsChecksumsIndexes(require_columns_checksums, check_consistency);
+                addProjectionPart(projection.name, std::move(part));
+            }
         }
     }
 }

--- a/src/Storages/MergeTree/IMergeTreeDataPart.h
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.h
@@ -388,7 +388,7 @@ public:
 
     bool hasProjection(const String & projection_name) const { return projection_parts.contains(projection_name); }
 
-    void loadProjections(bool require_columns_checksums, bool check_consistency);
+    void loadProjections(bool require_columns_checksums, bool check_consistency, bool if_not_loaded = false);
 
     /// Return set of metadata file names without checksums. For example,
     /// columns.txt or checksums.txt itself.

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -605,14 +605,14 @@ namespace
 
 ExpressionActionsPtr getCombinedIndicesExpression(
     const KeyDescription & key,
-    const IndicesDescription & indices,
+    const MergeTreeIndices & indices,
     const ColumnsDescription & columns,
     ContextPtr context)
 {
     ASTPtr combined_expr_list = key.expression_list_ast->clone();
 
     for (const auto & index : indices)
-        for (const auto & index_expr : index.expression_list_ast->children)
+        for (const auto & index_expr : index->index.expression_list_ast->children)
             combined_expr_list->children.push_back(index_expr->clone());
 
     auto syntax_result = TreeRewriter(context).analyze(combined_expr_list, columns.getAllPhysical());
@@ -644,14 +644,16 @@ DataTypes MergeTreeData::getMinMaxColumnsTypes(const KeyDescription & partition_
     return {};
 }
 
-ExpressionActionsPtr MergeTreeData::getPrimaryKeyAndSkipIndicesExpression(const StorageMetadataPtr & metadata_snapshot) const
+ExpressionActionsPtr
+MergeTreeData::getPrimaryKeyAndSkipIndicesExpression(const StorageMetadataPtr & metadata_snapshot, const MergeTreeIndices & indices) const
 {
-    return getCombinedIndicesExpression(metadata_snapshot->getPrimaryKey(), metadata_snapshot->getSecondaryIndices(), metadata_snapshot->getColumns(), getContext());
+    return getCombinedIndicesExpression(metadata_snapshot->getPrimaryKey(), indices, metadata_snapshot->getColumns(), getContext());
 }
 
-ExpressionActionsPtr MergeTreeData::getSortingKeyAndSkipIndicesExpression(const StorageMetadataPtr & metadata_snapshot) const
+ExpressionActionsPtr
+MergeTreeData::getSortingKeyAndSkipIndicesExpression(const StorageMetadataPtr & metadata_snapshot, const MergeTreeIndices & indices) const
 {
-    return getCombinedIndicesExpression(metadata_snapshot->getSortingKey(), metadata_snapshot->getSecondaryIndices(), metadata_snapshot->getColumns(), getContext());
+    return getCombinedIndicesExpression(metadata_snapshot->getSortingKey(), indices, metadata_snapshot->getColumns(), getContext());
 }
 
 

--- a/src/Storages/MergeTree/MergeTreeData.h
+++ b/src/Storages/MergeTree/MergeTreeData.h
@@ -956,8 +956,10 @@ public:
     /// Get column types required for partition key
     static DataTypes getMinMaxColumnsTypes(const KeyDescription & partition_key);
 
-    ExpressionActionsPtr getPrimaryKeyAndSkipIndicesExpression(const StorageMetadataPtr & metadata_snapshot) const;
-    ExpressionActionsPtr getSortingKeyAndSkipIndicesExpression(const StorageMetadataPtr & metadata_snapshot) const;
+    ExpressionActionsPtr
+    getPrimaryKeyAndSkipIndicesExpression(const StorageMetadataPtr & metadata_snapshot, const MergeTreeIndices & indices) const;
+    ExpressionActionsPtr
+    getSortingKeyAndSkipIndicesExpression(const StorageMetadataPtr & metadata_snapshot, const MergeTreeIndices & indices) const;
 
     /// Get compression codec for part according to TTL rules and <compression>
     /// section from config.xml.

--- a/src/Storages/MergeTree/MergeTreeDataWriter.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataWriter.cpp
@@ -398,9 +398,11 @@ MergeTreeDataWriter::TemporaryPart MergeTreeDataWriter::writeTempPartImpl(
 
     temp_part.temporary_directory_lock = data.getTemporaryPartDirectoryHolder(part_dir);
 
+    auto indices = MergeTreeIndexFactory::instance().getMany(metadata_snapshot->getSecondaryIndices());
+
     /// If we need to calculate some columns to sort.
     if (metadata_snapshot->hasSortingKey() || metadata_snapshot->hasSecondaryIndices())
-        data.getSortingKeyAndSkipIndicesExpression(metadata_snapshot)->execute(block);
+        data.getSortingKeyAndSkipIndicesExpression(metadata_snapshot, indices)->execute(block);
 
     Names sort_columns = metadata_snapshot->getSortingKeyColumns();
     SortDescription sort_description;
@@ -517,10 +519,16 @@ MergeTreeDataWriter::TemporaryPart MergeTreeDataWriter::writeTempPartImpl(
     ///  either default lz4 or compression method with zero thresholds on absolute and relative part size.
     auto compression_codec = data.getContext()->chooseCompressionCodec(0, 0);
 
-    const auto & index_factory = MergeTreeIndexFactory::instance();
-    auto out = std::make_unique<MergedBlockOutputStream>(new_data_part, metadata_snapshot, columns,
-        index_factory.getMany(metadata_snapshot->getSecondaryIndices()), compression_codec,
-        context->getCurrentTransaction(), false, false, context->getWriteSettings());
+    auto out = std::make_unique<MergedBlockOutputStream>(
+        new_data_part,
+        metadata_snapshot,
+        columns,
+        indices,
+        compression_codec,
+        context->getCurrentTransaction(),
+        false,
+        false,
+        context->getWriteSettings());
 
     out->writeWithPermutation(block, perm_ptr);
 
@@ -606,7 +614,7 @@ MergeTreeDataWriter::TemporaryPart MergeTreeDataWriter::writeProjectionPartImpl(
 
     /// If we need to calculate some columns to sort.
     if (metadata_snapshot->hasSortingKey() || metadata_snapshot->hasSecondaryIndices())
-        data.getSortingKeyAndSkipIndicesExpression(metadata_snapshot)->execute(block);
+        data.getSortingKeyAndSkipIndicesExpression(metadata_snapshot, {})->execute(block);
 
     Names sort_columns = metadata_snapshot->getSortingKeyColumns();
     SortDescription sort_description;

--- a/src/Storages/MergeTree/MutateTask.cpp
+++ b/src/Storages/MergeTree/MutateTask.cpp
@@ -200,8 +200,7 @@ static void splitAndModifyMutationCommands(
             {
                 for_file_renames.push_back(command);
             }
-            /// If we don't have this column in source part, than we don't need
-            /// to materialize it
+            /// If we don't have this column in source part, we don't need to materialize it.
             else if (part_columns.has(command.column_name))
             {
                 if (command.type == MutationCommand::Type::READ_COLUMN)
@@ -438,51 +437,13 @@ static ExecuteTTLType shouldExecuteTTL(const StorageMetadataPtr & metadata_snaps
 }
 
 
-/// Get skip indices, that should exists in the resulting data part.
-static MergeTreeIndices getIndicesForNewDataPart(
-    const IndicesDescription & all_indices,
-    const MutationCommands & commands_for_removes)
-{
-    NameSet removed_indices;
-    for (const auto & command : commands_for_removes)
-        if (command.type == MutationCommand::DROP_INDEX)
-            removed_indices.insert(command.column_name);
-
-    MergeTreeIndices new_indices;
-    for (const auto & index : all_indices)
-        if (!removed_indices.contains(index.name))
-            new_indices.push_back(MergeTreeIndexFactory::instance().get(index));
-
-    return new_indices;
-}
-
-static std::vector<ProjectionDescriptionRawPtr> getProjectionsForNewDataPart(
-    const ProjectionsDescription & all_projections,
-    const MutationCommands & commands_for_removes)
-{
-    NameSet removed_projections;
-    for (const auto & command : commands_for_removes)
-        if (command.type == MutationCommand::DROP_PROJECTION)
-            removed_projections.insert(command.column_name);
-
-    std::vector<ProjectionDescriptionRawPtr> new_projections;
-    for (const auto & projection : all_projections)
-        if (!removed_projections.contains(projection.name))
-            new_projections.push_back(&projection);
-
-    return new_projections;
-}
-
-
 /// Return set of indices which should be recalculated during mutation also
 /// wraps input stream into additional expression stream
 static std::set<MergeTreeIndexPtr> getIndicesToRecalculate(
     QueryPipelineBuilder & builder,
-    const NameSet & updated_columns,
     const StorageMetadataPtr & metadata_snapshot,
     ContextPtr context,
-    const NameSet & materialized_indices,
-    const MergeTreeData::DataPartPtr & source_part)
+    const NameSet & materialized_indices)
 {
     /// Checks if columns used in skipping indexes modified.
     const auto & index_factory = MergeTreeIndexFactory::instance();
@@ -492,33 +453,9 @@ static std::set<MergeTreeIndexPtr> getIndicesToRecalculate(
 
     for (const auto & index : indices)
     {
-        bool has_index =
-            source_part->checksums.has(INDEX_FILE_PREFIX + index.name + ".idx") ||
-            source_part->checksums.has(INDEX_FILE_PREFIX + index.name + ".idx2");
-        // If we ask to materialize and it already exists
-        if (!has_index && materialized_indices.contains(index.name))
+        if (materialized_indices.contains(index.name))
         {
             if (indices_to_recalc.insert(index_factory.get(index)).second)
-            {
-                ASTPtr expr_list = index.expression_list_ast->clone();
-                for (const auto & expr : expr_list->children)
-                    indices_recalc_expr_list->children.push_back(expr->clone());
-            }
-        }
-        // If some dependent columns gets mutated
-        else
-        {
-            bool mutate = false;
-            const auto & index_cols = index.expression->getRequiredColumns();
-            for (const auto & col : index_cols)
-            {
-                if (updated_columns.contains(col))
-                {
-                    mutate = true;
-                    break;
-                }
-            }
-            if (mutate && indices_to_recalc.insert(index_factory.get(index)).second)
             {
                 ASTPtr expr_list = index.expression_list_ast->clone();
                 for (const auto & expr : expr_list->children)
@@ -545,37 +482,15 @@ static std::set<MergeTreeIndexPtr> getIndicesToRecalculate(
     return indices_to_recalc;
 }
 
-std::set<ProjectionDescriptionRawPtr> getProjectionsToRecalculate(
-    const NameSet & updated_columns,
+static std::set<ProjectionDescriptionRawPtr> getProjectionsToRecalculate(
     const StorageMetadataPtr & metadata_snapshot,
-    const NameSet & materialized_projections,
-    const MergeTreeData::DataPartPtr & source_part)
+    const NameSet & materialized_projections)
 {
-    /// Checks if columns used in projections modified.
     std::set<ProjectionDescriptionRawPtr> projections_to_recalc;
     for (const auto & projection : metadata_snapshot->getProjections())
     {
-        // If we ask to materialize and it doesn't exist
-        if (!source_part->checksums.has(projection.name + ".proj") && materialized_projections.contains(projection.name))
-        {
+        if (materialized_projections.contains(projection.name))
             projections_to_recalc.insert(&projection);
-        }
-        else
-        {
-            // If some dependent columns gets mutated
-            bool mutate = false;
-            const auto & projection_cols = projection.required_columns;
-            for (const auto & col : projection_cols)
-            {
-                if (updated_columns.contains(col))
-                {
-                    mutate = true;
-                    break;
-                }
-            }
-            if (mutate)
-                projections_to_recalc.insert(&projection);
-        }
     }
     return projections_to_recalc;
 }
@@ -618,33 +533,6 @@ static NameSet collectFilesToSkip(
     /// Do not hardlink this file because it's always rewritten at the end of mutation.
     files_to_skip.insert(IMergeTreeDataPart::SERIALIZATION_FILE_NAME);
 
-    auto new_stream_counts = getStreamCounts(new_part, new_part->getColumns().getNames());
-    auto source_updated_stream_counts = getStreamCounts(source_part, updated_header.getNames());
-    auto new_updated_stream_counts = getStreamCounts(new_part, updated_header.getNames());
-
-    /// Skip all modified files in new part.
-    for (const auto & [stream_name, _] : new_updated_stream_counts)
-    {
-        files_to_skip.insert(stream_name + ".bin");
-        files_to_skip.insert(stream_name + mrk_extension);
-    }
-
-    /// Skip files that we read from source part and do not write in new part.
-    /// E.g. ALTER MODIFY from LowCardinality(String) to String.
-    for (const auto & [stream_name, _] : source_updated_stream_counts)
-    {
-        /// If we read shared stream and do not write it
-        /// (e.g. while ALTER MODIFY COLUMN from array of Nested type to String),
-        /// we need to hardlink its files, because they will be lost otherwise.
-        bool need_hardlink = new_updated_stream_counts[stream_name] == 0 && new_stream_counts[stream_name] != 0;
-
-        if (!need_hardlink)
-        {
-            files_to_skip.insert(stream_name + ".bin");
-            files_to_skip.insert(stream_name + mrk_extension);
-        }
-    }
-
     for (const auto & index : indices_to_recalc)
     {
         /// Since MinMax index has .idx2 extension, we need to add correct extension.
@@ -654,6 +542,36 @@ static NameSet collectFilesToSkip(
 
     for (const auto & projection : projections_to_recalc)
         files_to_skip.insert(projection->getDirectoryName());
+
+    if (isWidePart(source_part))
+    {
+        auto new_stream_counts = getStreamCounts(new_part, new_part->getColumns().getNames());
+        auto source_updated_stream_counts = getStreamCounts(source_part, updated_header.getNames());
+        auto new_updated_stream_counts = getStreamCounts(new_part, updated_header.getNames());
+
+        /// Skip all modified files in new part.
+        for (const auto & [stream_name, _] : new_updated_stream_counts)
+        {
+            files_to_skip.insert(stream_name + ".bin");
+            files_to_skip.insert(stream_name + mrk_extension);
+        }
+
+        /// Skip files that we read from source part and do not write in new part.
+        /// E.g. ALTER MODIFY from LowCardinality(String) to String.
+        for (const auto & [stream_name, _] : source_updated_stream_counts)
+        {
+            /// If we read shared stream and do not write it
+            /// (e.g. while ALTER MODIFY COLUMN from array of Nested type to String),
+            /// we need to hardlink its files, because they will be lost otherwise.
+            bool need_hardlink = new_updated_stream_counts[stream_name] == 0 && new_stream_counts[stream_name] != 0;
+
+            if (!need_hardlink)
+            {
+                files_to_skip.insert(stream_name + ".bin");
+                files_to_skip.insert(stream_name + mrk_extension);
+            }
+        }
+    }
 
     return files_to_skip;
 }
@@ -701,57 +619,60 @@ static NameToNameVector collectFilesForRenames(
             if (source_part->checksums.has(command.column_name + ".proj"))
                 add_rename(command.column_name + ".proj", "");
         }
-        else if (command.type == MutationCommand::Type::DROP_COLUMN)
+        else if (isWidePart(source_part))
         {
-            ISerialization::StreamCallback callback = [&](const ISerialization::SubstreamPath & substream_path)
+            if (command.type == MutationCommand::Type::DROP_COLUMN)
             {
-                String stream_name = ISerialization::getFileNameForStream({command.column_name, command.data_type}, substream_path);
-                /// Delete files if they are no longer shared with another column.
-                if (--stream_counts[stream_name] == 0)
+                ISerialization::StreamCallback callback = [&](const ISerialization::SubstreamPath & substream_path)
                 {
-                    add_rename(stream_name + ".bin", "");
-                    add_rename(stream_name + mrk_extension, "");
-                }
-            };
+                    String stream_name = ISerialization::getFileNameForStream({command.column_name, command.data_type}, substream_path);
+                    /// Delete files if they are no longer shared with another column.
+                    if (--stream_counts[stream_name] == 0)
+                    {
+                        add_rename(stream_name + ".bin", "");
+                        add_rename(stream_name + mrk_extension, "");
+                    }
+                };
 
-            if (auto serialization = source_part->tryGetSerialization(command.column_name))
-                serialization->enumerateStreams(callback);
-        }
-        else if (command.type == MutationCommand::Type::RENAME_COLUMN)
-        {
-            String escaped_name_from = escapeForFileName(command.column_name);
-            String escaped_name_to = escapeForFileName(command.rename_to);
-
-            ISerialization::StreamCallback callback = [&](const ISerialization::SubstreamPath & substream_path)
+                if (auto serialization = source_part->tryGetSerialization(command.column_name))
+                    serialization->enumerateStreams(callback);
+            }
+            else if (command.type == MutationCommand::Type::RENAME_COLUMN)
             {
-                String stream_from = ISerialization::getFileNameForStream(command.column_name, substream_path);
-                String stream_to = boost::replace_first_copy(stream_from, escaped_name_from, escaped_name_to);
+                String escaped_name_from = escapeForFileName(command.column_name);
+                String escaped_name_to = escapeForFileName(command.rename_to);
 
-                if (stream_from != stream_to)
+                ISerialization::StreamCallback callback = [&](const ISerialization::SubstreamPath & substream_path)
                 {
-                    add_rename(stream_from + ".bin", stream_to + ".bin");
-                    add_rename(stream_from + mrk_extension, stream_to + mrk_extension);
-                }
-            };
+                    String stream_from = ISerialization::getFileNameForStream(command.column_name, substream_path);
+                    String stream_to = boost::replace_first_copy(stream_from, escaped_name_from, escaped_name_to);
 
-            if (auto serialization = source_part->tryGetSerialization(command.column_name))
-                serialization->enumerateStreams(callback);
-        }
-        else if (command.type == MutationCommand::Type::READ_COLUMN)
-        {
-            /// Remove files for streams that exist in source_part,
-            /// but were removed in new_part by MODIFY COLUMN from
-            /// type with higher number of streams (e.g. LowCardinality -> String).
+                    if (stream_from != stream_to)
+                    {
+                        add_rename(stream_from + ".bin", stream_to + ".bin");
+                        add_rename(stream_from + mrk_extension, stream_to + mrk_extension);
+                    }
+                };
 
-            auto old_streams = getStreamCounts(source_part, source_part->getColumns().getNames());
-            auto new_streams = getStreamCounts(new_part, source_part->getColumns().getNames());
-
-            for (const auto & [old_stream, _] : old_streams)
+                if (auto serialization = source_part->tryGetSerialization(command.column_name))
+                    serialization->enumerateStreams(callback);
+            }
+            else if (command.type == MutationCommand::Type::READ_COLUMN)
             {
-                if (!new_streams.contains(old_stream) && --stream_counts[old_stream] == 0)
+                /// Remove files for streams that exist in source_part,
+                /// but were removed in new_part by MODIFY COLUMN from
+                /// type with higher number of streams (e.g. LowCardinality -> String).
+
+                auto old_streams = getStreamCounts(source_part, source_part->getColumns().getNames());
+                auto new_streams = getStreamCounts(new_part, source_part->getColumns().getNames());
+
+                for (const auto & [old_stream, _] : old_streams)
                 {
-                    add_rename(old_stream + ".bin", "");
-                    add_rename(old_stream + mrk_extension, "");
+                    if (!new_streams.contains(old_stream) && --stream_counts[old_stream] == 0)
+                    {
+                        add_rename(old_stream + ".bin", "");
+                        add_rename(old_stream + mrk_extension, "");
+                    }
                 }
             }
         }
@@ -851,11 +772,8 @@ void finalizeMutatedPart(
     new_data_part->minmax_idx = source_part->minmax_idx;
     new_data_part->modification_time = time(nullptr);
 
-    /// This line should not be here because at that moment
-    /// of executing of mutation all projections should be loaded.
-    /// But unfortunately without it some tests fail.
-    /// TODO: fix.
-    new_data_part->loadProjections(false, false);
+    /// Load rest projections which are hardlinked
+    new_data_part->loadProjections(false, false, true /* if_not_loaded */);
 
     /// All information about sizes is stored in checksums.
     /// It doesn't make sense to touch filesystem for sizes.
@@ -917,9 +835,9 @@ struct MutationContext
     std::vector<ProjectionDescriptionRawPtr> projections_to_build;
     IMergeTreeDataPart::MinMaxIndexPtr minmax_idx{nullptr};
 
-    NameSet updated_columns;
     std::set<MergeTreeIndexPtr> indices_to_recalc;
     std::set<ProjectionDescriptionRawPtr> projections_to_recalc;
+    MergeTreeData::DataPart::Checksums existing_indices_checksums;
     NameSet files_to_skip;
     NameToNameVector files_to_rename;
 
@@ -1331,10 +1249,102 @@ private:
         /// (which is locked in shared mode when input streams are created) and when inserting new data
         /// the order is reverse. This annoys TSan even though one lock is locked in shared mode and thus
         /// deadlock is impossible.
-        ctx->compression_codec = ctx->data->getCompressionCodecForPart(ctx->source_part->getBytesOnDisk(), ctx->source_part->ttl_infos, ctx->time_of_mutation);
+        ctx->compression_codec
+            = ctx->data->getCompressionCodecForPart(ctx->source_part->getBytesOnDisk(), ctx->source_part->ttl_infos, ctx->time_of_mutation);
 
-        auto skip_part_indices = MutationHelpers::getIndicesForNewDataPart(ctx->metadata_snapshot->getSecondaryIndices(), ctx->for_file_renames);
-        ctx->projections_to_build = MutationHelpers::getProjectionsForNewDataPart(ctx->metadata_snapshot->getProjections(), ctx->for_file_renames);
+        NameSet entries_to_hardlink;
+
+        NameSet removed_indices;
+        for (const auto & command : ctx->for_file_renames)
+        {
+            if (command.type == MutationCommand::DROP_INDEX)
+                removed_indices.insert(command.column_name);
+        }
+
+        const auto & indices = ctx->metadata_snapshot->getSecondaryIndices();
+        MergeTreeIndices skip_indices;
+        for (const auto & idx : indices)
+        {
+            if (removed_indices.contains(idx.name))
+                continue;
+
+            if (ctx->materialized_indices.contains(idx.name))
+                skip_indices.push_back(MergeTreeIndexFactory::instance().get(idx));
+
+            auto hardlink_index = [&](const String & idx_name)
+            {
+                if (ctx->source_part->checksums.has(idx_name))
+                {
+                    auto it = ctx->source_part->checksums.files.find(idx_name);
+                    if (it != ctx->source_part->checksums.files.end())
+                    {
+                        entries_to_hardlink.insert(idx_name);
+                        ctx->existing_indices_checksums.addFile(idx_name, it->second.file_size, it->second.file_hash);
+                    }
+                }
+            };
+            hardlink_index(INDEX_FILE_PREFIX + idx.name + ".idx");
+            hardlink_index(INDEX_FILE_PREFIX + idx.name + ".idx2");
+        }
+
+        NameSet removed_projections;
+        for (const auto & command : ctx->for_file_renames)
+        {
+            if (command.type == MutationCommand::DROP_PROJECTION)
+                removed_projections.insert(command.column_name);
+        }
+
+        const auto & projections = ctx->metadata_snapshot->getProjections();
+        for (const auto & projection : projections)
+        {
+            if (removed_projections.contains(projection.name))
+                continue;
+
+            if (ctx->materialized_projections.contains(projection.name))
+                ctx->projections_to_build.push_back(&projection);
+
+            if (ctx->source_part->checksums.has(projection.getDirectoryName()))
+                entries_to_hardlink.insert(projection.getDirectoryName());
+        }
+
+        NameSet hardlinked_files;
+        /// Create hardlinks for unchanged files
+        for (auto it = ctx->source_part->getDataPartStorage().iterate(); it->isValid(); it->next())
+        {
+            if (!entries_to_hardlink.contains(it->name()))
+                continue;
+
+            if (it->isFile())
+            {
+                ctx->new_data_part->getDataPartStorage().createHardLinkFrom(
+                    ctx->source_part->getDataPartStorage(), it->name(), it->name());
+                hardlinked_files.insert(it->name());
+            }
+            else
+            {
+                // it's a projection part directory
+                ctx->new_data_part->getDataPartStorage().createProjection(it->name());
+
+                auto projection_data_part_storage_src = ctx->source_part->getDataPartStorage().getProjection(it->name());
+                auto projection_data_part_storage_dst = ctx->new_data_part->getDataPartStorage().getProjection(it->name());
+
+                for (auto p_it = projection_data_part_storage_src->iterate(); p_it->isValid(); p_it->next())
+                {
+                    projection_data_part_storage_dst->createHardLinkFrom(
+                        *projection_data_part_storage_src, p_it->name(), p_it->name());
+
+                    auto file_name_with_projection_prefix = fs::path(projection_data_part_storage_src->getPartDirectory()) / p_it->name();
+                    hardlinked_files.insert(file_name_with_projection_prefix);
+                }
+            }
+        }
+
+        /// Tracking of hardlinked files required for zero-copy replication.
+        /// We don't remove them when we delete last copy of source part because
+        /// new part can use them.
+        ctx->hardlinked_files.source_table_shared_id = ctx->source_part->storage.getTableSharedID();
+        ctx->hardlinked_files.source_part_name = ctx->source_part->name;
+        ctx->hardlinked_files.hardlinks_from_source_part = std::move(hardlinked_files);
 
         if (!ctx->mutating_pipeline_builder.initialized())
             throw Exception(ErrorCodes::LOGICAL_ERROR, "Cannot mutate part columns with uninitialized mutations stream. It's a bug");
@@ -1343,8 +1353,8 @@ private:
 
         if (ctx->metadata_snapshot->hasPrimaryKey() || ctx->metadata_snapshot->hasSecondaryIndices())
         {
-            builder.addTransform(
-                std::make_shared<ExpressionTransform>(builder.getHeader(), ctx->data->getPrimaryKeyAndSkipIndicesExpression(ctx->metadata_snapshot)));
+            builder.addTransform(std::make_shared<ExpressionTransform>(
+                            builder.getHeader(), ctx->data->getPrimaryKeyAndSkipIndicesExpression(ctx->metadata_snapshot, skip_indices)));
 
             builder.addTransform(std::make_shared<MaterializingTransform>(builder.getHeader()));
         }
@@ -1361,7 +1371,7 @@ private:
             ctx->new_data_part,
             ctx->metadata_snapshot,
             ctx->new_data_part->getColumns(),
-            skip_part_indices,
+            skip_indices,
             ctx->compression_codec,
             ctx->txn,
             /*reset_columns=*/ true,
@@ -1381,10 +1391,12 @@ private:
     void finalize()
     {
         ctx->new_data_part->minmax_idx = std::move(ctx->minmax_idx);
+        ctx->new_data_part->loadProjections(false, false, true /* if_not_loaded */);
         ctx->mutating_executor.reset();
         ctx->mutating_pipeline.reset();
 
-        static_pointer_cast<MergedBlockOutputStream>(ctx->out)->finalizePart(ctx->new_data_part, ctx->need_sync);
+        static_pointer_cast<MergedBlockOutputStream>(ctx->out)->finalizePart(
+            ctx->new_data_part, ctx->need_sync, nullptr, &ctx->existing_indices_checksums);
         ctx->out.reset();
     }
 
@@ -1530,7 +1542,7 @@ private:
         /// new part can use them.
         ctx->hardlinked_files.source_table_shared_id = ctx->source_part->storage.getTableSharedID();
         ctx->hardlinked_files.source_part_name = ctx->source_part->name;
-        ctx->hardlinked_files.hardlinks_from_source_part = hardlinked_files;
+        ctx->hardlinked_files.hardlinks_from_source_part = std::move(hardlinked_files);
 
         (*ctx->mutate_entry)->columns_written = ctx->storage_columns.size() - ctx->updated_header.columns();
 
@@ -1878,14 +1890,10 @@ bool MutateTask::prepare()
     }
     else /// TODO: check that we modify only non-key columns in this case.
     {
-        /// We will modify only some of the columns. Other columns and key values can be copied as-is.
-        for (const auto & name_type : ctx->updated_header.getNamesAndTypesList())
-            ctx->updated_columns.emplace(name_type.name);
-
         ctx->indices_to_recalc = MutationHelpers::getIndicesToRecalculate(
-            ctx->mutating_pipeline_builder, ctx->updated_columns, ctx->metadata_snapshot, ctx->context, ctx->materialized_indices, ctx->source_part);
-        ctx->projections_to_recalc = MutationHelpers::getProjectionsToRecalculate(
-            ctx->updated_columns, ctx->metadata_snapshot, ctx->materialized_projections, ctx->source_part);
+            ctx->mutating_pipeline_builder, ctx->metadata_snapshot, ctx->context, ctx->materialized_indices);
+
+        ctx->projections_to_recalc = MutationHelpers::getProjectionsToRecalculate(ctx->metadata_snapshot, ctx->materialized_projections);
 
         ctx->files_to_skip = MutationHelpers::collectFilesToSkip(
             ctx->source_part,

--- a/src/Storages/StorageInMemoryMetadata.h
+++ b/src/Storages/StorageInMemoryMetadata.h
@@ -147,9 +147,12 @@ struct StorageInMemoryMetadata
     TTLDescriptions getGroupByTTLs() const;
     bool hasAnyGroupByTTL() const;
 
-    /// Returns columns, which will be needed to calculate dependencies (skip
-    /// indices, TTL expressions) if we update @updated_columns set of columns.
-    ColumnDependencies getColumnDependencies(const NameSet & updated_columns, bool include_ttl_target) const;
+    /// Returns columns, which will be needed to calculate dependencies (skip indices, projections,
+    /// TTL expressions) if we update @updated_columns set of columns.
+    ColumnDependencies getColumnDependencies(
+        const NameSet & updated_columns,
+        bool include_ttl_target,
+        const std::function<bool(const String & file_name)> & has_indice_or_projection) const;
 
     /// Block with ordinary + materialized columns.
     Block getSampleBlock() const;

--- a/tests/queries/0_stateless/02763_mutate_compact_part_with_skip_indices_and_projections.sql
+++ b/tests/queries/0_stateless/02763_mutate_compact_part_with_skip_indices_and_projections.sql
@@ -1,0 +1,31 @@
+DROP TABLE IF EXISTS test;
+
+CREATE TABLE test ( col1 Int64, dt Date ) ENGINE = MergeTree PARTITION BY dt ORDER BY tuple();
+
+INSERT INTO test FORMAT Values (1, today());
+
+ALTER TABLE test ADD COLUMN col2 String;
+
+ALTER TABLE test ADD INDEX i1 (col1, col2) TYPE set(100) GRANULARITY 1;
+
+ALTER TABLE test MATERIALIZE INDEX i1;
+
+ALTER TABLE test ADD COLUMN col3 String;
+
+ALTER TABLE test DROP COLUMN col3;
+
+DROP TABLE IF EXISTS test;
+
+CREATE TABLE test ( col1 Int64, dt Date ) ENGINE = MergeTree PARTITION BY dt ORDER BY tuple();
+
+INSERT INTO test FORMAT Values (1, today());
+
+ALTER TABLE test ADD COLUMN col2 String;
+
+ALTER TABLE test ADD PROJECTION p1 ( SELECT col2, sum(col1) GROUP BY col2 );
+
+ALTER TABLE test MATERIALIZE PROJECTION p1;
+
+ALTER TABLE test ADD COLUMN col3 String;
+
+ALTER TABLE test DROP COLUMN col3;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix inappropriate materialization of skip indices and projections during mutations. This fixes #43107. This fixes #47549.

This PR also improves dependency calculation of columns related to skip indices and projections, which helps avoid unneeded materialization.

This PR also utilizes hardlinks when mutating Compact parts, because it's allowed to do that for skip indices and projections.
