### PR TITLE
Change fields destruction order in AsyncTaskExecutor

### DIFF
--- a/src/Common/AsyncTaskExecutor.h
+++ b/src/Common/AsyncTaskExecutor.h
@@ -113,8 +113,8 @@ private:
     void createFiber();
     void destroyFiber();
 
-    Fiber fiber;
     FiberStack fiber_stack;
+    Fiber fiber;
     std::mutex fiber_lock;
     std::exception_ptr exception;
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Not sure, but it may be the cause of failures in tsan like https://github.com/ClickHouse/ClickHouse/pull/49673#issuecomment-1539201910. Let's try it and see if it helps