### PR TITLE
Enable pylint for all python tests

### DIFF
--- a/tests/integration/ci-runner.py
+++ b/tests/integration/ci-runner.py
@@ -382,7 +382,9 @@ class ClickhouseIntegrationTestsRunner:
                         if retcode == 0:
                             logging.info("Installation of %s successfull", full_path)
                         else:
-                            raise Exception("Installation of {} failed".format(full_path))
+                            raise Exception(
+                                "Installation of {} failed".format(full_path)
+                            )
                     break
             else:
                 raise Exception("Package with {} not found".format(package))

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,7 +1,9 @@
-from helpers.cluster import run_and_check
+#!/usr/bin/env python3
+
 import pytest
 import logging
 import os
+from helpers.cluster import run_and_check
 from helpers.test_tools import TSV
 from helpers.network import _NetworkManager
 

--- a/utils/check-style/check-style
+++ b/utils/check-style/check-style
@@ -155,8 +155,7 @@ find $ROOT_PATH/{src,base,programs,utils} -name '*.xml' |
     grep -vP $EXCLUDE_DIRS |
     xargs xmllint --noout --nonet
 
-# FIXME: for now only clickhouse-test
-pylint --rcfile=$ROOT_PATH/.pylintrc --persistent=no --score=n $ROOT_PATH/tests/clickhouse-test $ROOT_PATH/tests/ci/*.py
+pylint --rcfile=$ROOT_PATH/.pylintrc --persistent=no --score=n $ROOT_PATH/tests/clickhouse-test $ROOT_PATH/tests/**/*.py
 
 find $ROOT_PATH -not -path $ROOT_PATH'/contrib*' \( -name '*.yaml' -or -name '*.yml' \) -type f |
     grep -vP $EXCLUDE_DIRS |


### PR DESCRIPTION
### Description

- As part of https://github.com/ClickHouse/ClickHouse/pull/49869 we noticed that we already use pylint, just that it wasn't enabled for integration tests.
- Adding myself to trusted contributor.

### Changelog category (leave one):

- Not for changelog (changelog entry is not required)

