### PR TITLE
Fix broken index analysis when binary operator contains a null constant argument

### DIFF
--- a/src/Storages/MergeTree/KeyCondition.cpp
+++ b/src/Storages/MergeTree/KeyCondition.cpp
@@ -1334,6 +1334,10 @@ bool KeyCondition::isKeyPossiblyWrappedByMonotonicFunctions(
                 arguments.push_back(const_arg);
                 kind = FunctionWithOptionalConstArg::Kind::RIGHT_CONST;
             }
+
+            /// If constant arg of binary operator is NULL, there will be no monotonicity.
+            if (const_arg.column->isNullAt(0))
+                return false;
         }
         else
             arguments.push_back({ nullptr, key_column_type, "" });

--- a/tests/queries/0_stateless/02746_index_analysis_binary_operator_with_null.sql
+++ b/tests/queries/0_stateless/02746_index_analysis_binary_operator_with_null.sql
@@ -1,0 +1,12 @@
+drop table if exists tab;
+
+create table tab (x DateTime) engine MergeTree order by x;
+
+SELECT toDateTime(65537, toDateTime(NULL), NULL)
+FROM tab
+WHERE ((x + CAST('1', 'Nullable(UInt8)')) <= 2) AND ((x + CAST('', 'Nullable(UInt8)')) <= 256)
+ORDER BY
+    toDateTime(toDateTime(-2, NULL, NULL) + 100.0001, NULL, -2, NULL) DESC NULLS LAST,
+    x ASC NULLS LAST;
+
+drop table tab;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix broken index analysis when binary operator contains a null constant argument. This fixes #50094
