### PR TITLE
Fix PostgreSQLSource reading all unread the data in onFinish

### DIFF
--- a/src/Processors/Sources/PostgreSQLSource.cpp
+++ b/src/Processors/Sources/PostgreSQLSource.cpp
@@ -176,12 +176,10 @@ template<typename T>
 void PostgreSQLSource<T>::onFinish()
 {
     if (stream)
-    {
-        stream->complete();
+        stream->close();
 
-        if (auto_commit)
-            tx->commit();
-    }
+    if (tx && auto_commit)
+        tx->commit();
 }
 
 template

--- a/tests/integration/test_storage_postgresql/test.py
+++ b/tests/integration/test_storage_postgresql/test.py
@@ -62,6 +62,16 @@ def test_postgres_select_insert(started_cluster):
     # for i in range(1, 1000):
     #     assert (node1.query(check1)).rstrip() == '10000', f"Failed on {i}"
 
+    result = node1.query(
+        f"""
+        INSERT INTO TABLE FUNCTION {table}
+        SELECT number, concat('name_', toString(number)), 3 from numbers(1000000)"""
+    )
+    check1 = f"SELECT count() FROM {table}"
+    check2 = f"SELECT count() FROM (SELECT * FROM {table} LIMIT 10)"
+    assert (node1.query(check1)).rstrip() == "1010000"
+    assert (node1.query(check2)).rstrip() == "10"
+
     cursor.execute(f"DROP TABLE {table_name} ")
 
 


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement



### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix PostgreSQL reading all the data even though `LIMIT n` could be specified.


