### PR TITLE
Don't replicate delete through DDL worker if there is just 1 shard

### DIFF
--- a/src/Databases/DatabaseReplicated.cpp
+++ b/src/Databases/DatabaseReplicated.cpp
@@ -1455,7 +1455,16 @@ bool DatabaseReplicated::shouldReplicateQuery(const ContextPtr & query_context, 
     }
 
     if (query_ptr->as<const ASTDeleteQuery>() != nullptr)
-        return !is_keeper_map_table(query_ptr);
+    {
+        if (is_keeper_map_table(query_ptr))
+            return false;
+
+        /// If there is only 1 shard then there is no need to replicate DELETE query.
+        auto current_cluster = tryGetCluster();
+        return
+            !current_cluster || /// Couldn't get the cluster, so we don't know how many shards there are.
+            current_cluster->getShardsInfo().size() > 1;
+    }
 
     return true;
 }


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):