### PR TITLE
Fix codebrowser by using clang-15 image

### DIFF
--- a/tests/ci/codebrowser_check.py
+++ b/tests/ci/codebrowser_check.py
@@ -59,6 +59,9 @@ def main():
         os.makedirs(temp_path)
 
     docker_image = get_image_with_version(IMAGES_PATH, "clickhouse/codebrowser")
+    # FIXME: the codebrowser is broken with clang-16, workaround with clang-15
+    # See https://github.com/ClickHouse/ClickHouse/issues/50077
+    docker_image.version = "49701-4dcdcf4c11b5604f1c5d3121c9c6fea3e957b605"
     s3_helper = S3Helper()
 
     result_path = temp_path / "result_path"


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Temporary address #50077 