### PR TITLE
Don't send head request for all keys in Iceberg schema inference

### DIFF
--- a/src/Storages/StorageS3.cpp
+++ b/src/Storages/StorageS3.cpp
@@ -424,7 +424,6 @@ public:
         , bucket(bucket_)
         , query(query_)
         , virtual_header(virtual_header_)
-
     {
         Strings all_keys = keys_;
 

--- a/src/Storages/StorageS3.cpp
+++ b/src/Storages/StorageS3.cpp
@@ -418,11 +418,13 @@ public:
         ASTPtr query_,
         const Block & virtual_header_,
         ContextPtr context_,
+        bool need_total_size,
         KeysWithInfo * read_keys_)
         : WithContext(context_)
         , bucket(bucket_)
         , query(query_)
         , virtual_header(virtual_header_)
+
     {
         Strings all_keys = keys_;
 
@@ -458,8 +460,13 @@ public:
 
         for (auto && key : all_keys)
         {
-            auto info = S3::getObjectInfo(client_, bucket, key, version_id_, request_settings_);
-            total_size += info.size;
+            std::optional<S3::ObjectInfo> info;
+            if (need_total_size)
+            {
+                info = S3::getObjectInfo(client_, bucket, key, version_id_, request_settings_);
+                total_size += info->size;
+            }
+
             keys.emplace_back(std::move(key), std::move(info));
         }
 
@@ -501,10 +508,11 @@ StorageS3Source::KeysIterator::KeysIterator(
     ASTPtr query,
     const Block & virtual_header,
     ContextPtr context,
+    bool need_total_size,
     KeysWithInfo * read_keys)
     : pimpl(std::make_shared<StorageS3Source::KeysIterator::Impl>(
         client_, version_id_, keys_, bucket_, request_settings_,
-        query, virtual_header, context, read_keys))
+        query, virtual_header, context, need_total_size, read_keys))
 {
 }
 
@@ -979,6 +987,7 @@ std::shared_ptr<StorageS3Source::IIterator> StorageS3::createFileIterator(
     ContextPtr local_context,
     ASTPtr query,
     const Block & virtual_block,
+    bool need_total_size,
     KeysWithInfo * read_keys)
 {
     if (distributed_processing)
@@ -997,7 +1006,7 @@ std::shared_ptr<StorageS3Source::IIterator> StorageS3::createFileIterator(
         return std::make_shared<StorageS3Source::KeysIterator>(
             *configuration.client, configuration.url.version_id, configuration.keys,
             configuration.url.bucket, configuration.request_settings, query,
-            virtual_block, local_context, read_keys);
+            virtual_block, local_context, need_total_size, read_keys);
     }
 }
 
@@ -1442,7 +1451,7 @@ ColumnsDescription StorageS3::getTableStructureFromDataImpl(
 {
     KeysWithInfo read_keys;
 
-    auto file_iterator = createFileIterator(configuration, false, ctx, nullptr, {}, &read_keys);
+    auto file_iterator = createFileIterator(configuration, false, ctx, nullptr, {}, false, &read_keys);
 
     std::optional<ColumnsDescription> columns_from_cache;
     size_t prev_read_keys_size = read_keys.size();

--- a/src/Storages/StorageS3.h
+++ b/src/Storages/StorageS3.h
@@ -95,6 +95,7 @@ public:
             ASTPtr query,
             const Block & virtual_header,
             ContextPtr context,
+            bool need_total_size = true,
             KeysWithInfo * read_keys = nullptr);
 
         KeyWithInfo next() override;
@@ -354,6 +355,7 @@ private:
         ContextPtr local_context,
         ASTPtr query,
         const Block & virtual_block,
+        bool need_total_size = true,
         KeysWithInfo * read_keys = nullptr);
 
     static ColumnsDescription getTableStructureFromDataImpl(

--- a/tests/integration/test_storage_s3/test.py
+++ b/tests/integration/test_storage_s3/test.py
@@ -1636,7 +1636,7 @@ def test_ast_auth_headers(started_cluster):
     filename = "test.csv"
 
     result = instance.query_and_get_error(
-        f"select count() from s3('http://resolver:8080/{bucket}/{filename}', 'CSV')"
+        f"select count() from s3('http://resolver:8080/{bucket}/{filename}', 'CSV', 'dummy String')"
     )
 
     assert "HTTP response code: 403" in result


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Don't send head request for all keys in Iceberg schema inference, only for keys that are used for reaing data.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
