### PR TITLE
Fix UB for INTO OUTFILE extensions (APPEND / AND STDOUT) and WATCH EVENTS

### DIFF
--- a/src/Parsers/ASTColumnDeclaration.h
+++ b/src/Parsers/ASTColumnDeclaration.h
@@ -16,7 +16,7 @@ public:
     std::optional<bool> null_modifier;
     String default_specifier;
     ASTPtr default_expression;
-    bool ephemeral_default;
+    bool ephemeral_default = false;
     ASTPtr comment;
     ASTPtr codec;
     ASTPtr ttl;

--- a/src/Parsers/ASTDictionaryAttributeDeclaration.h
+++ b/src/Parsers/ASTDictionaryAttributeDeclaration.h
@@ -19,13 +19,13 @@ public:
     /// Attribute expression
     ASTPtr expression;
     /// Is attribute mirrored to the parent identifier
-    bool hierarchical;
+    bool hierarchical = false;
     /// Is hierarchical attribute bidirectional
-    bool bidirectional;
+    bool bidirectional = false;
     /// Flag that shows whether the id->attribute image is injective
-    bool injective;
+    bool injective = false;
     /// MongoDB object ID
-    bool is_object_id;
+    bool is_object_id = false;
 
     String getID(char delim) const override { return "DictionaryAttributeDeclaration" + (delim + name); }
 

--- a/src/Parsers/ASTOrderByElement.h
+++ b/src/Parsers/ASTOrderByElement.h
@@ -11,14 +11,14 @@ namespace DB
 class ASTOrderByElement : public IAST
 {
 public:
-    int direction; /// 1 for ASC, -1 for DESC
-    int nulls_direction; /// Same as direction for NULLS LAST, opposite for NULLS FIRST.
-    bool nulls_direction_was_explicitly_specified;
+    int direction = 0; /// 1 for ASC, -1 for DESC
+    int nulls_direction = 0; /// Same as direction for NULLS LAST, opposite for NULLS FIRST.
+    bool nulls_direction_was_explicitly_specified = false;
 
     /** Collation for locale-specific string comparison. If empty, then sorting done by bytes. */
     ASTPtr collation;
 
-    bool with_fill;
+    bool with_fill = false;
     ASTPtr fill_from;
     ASTPtr fill_to;
     ASTPtr fill_step;

--- a/src/Parsers/ASTQueryWithOutput.cpp
+++ b/src/Parsers/ASTQueryWithOutput.cpp
@@ -35,6 +35,13 @@ void ASTQueryWithOutput::formatImpl(const FormatSettings & s, FormatState & stat
     {
         s.ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << indent_str << "INTO OUTFILE " << (s.hilite ? hilite_none : "");
         out_file->formatImpl(s, state, frame);
+
+        s.ostr << (s.hilite ? hilite_keyword : "");
+        if (is_outfile_append)
+            s.ostr << " APPEND";
+        if (is_into_outfile_with_stdout)
+            s.ostr << " AND STDOUT";
+        s.ostr << (s.hilite ? hilite_none : "");
     }
 
     if (format)

--- a/src/Parsers/ASTQueryWithOutput.h
+++ b/src/Parsers/ASTQueryWithOutput.h
@@ -15,8 +15,8 @@ class ASTQueryWithOutput : public IAST
 {
 public:
     ASTPtr out_file;
-    bool is_into_outfile_with_stdout;
-    bool is_outfile_append;
+    bool is_into_outfile_with_stdout = false;
+    bool is_outfile_append = false;
     ASTPtr format;
     ASTPtr settings_ast;
     ASTPtr compression;

--- a/src/Parsers/ASTWatchQuery.h
+++ b/src/Parsers/ASTWatchQuery.h
@@ -23,7 +23,7 @@ class ASTWatchQuery : public ASTQueryWithTableAndOutput
 
 public:
     ASTPtr limit_length;
-    bool is_watch_events;
+    bool is_watch_events = false;
 
     ASTWatchQuery() = default;
     String getID(char) const override { return "WatchQuery_" + getDatabase() + "_" + getTable(); }

--- a/tests/queries/0_stateless/02767_into_outfile_extensions_msan.reference
+++ b/tests/queries/0_stateless/02767_into_outfile_extensions_msan.reference
@@ -1,0 +1,2 @@
+Expression ((Projection + Before ORDER BY))
+  ReadFromStorage (SystemNumbers)

--- a/tests/queries/0_stateless/02767_into_outfile_extensions_msan.sh
+++ b/tests/queries/0_stateless/02767_into_outfile_extensions_msan.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+out="explain1.$CLICKHOUSE_TEST_UNIQUE_NAME.out"
+# only EXPLAIN triggers the problem under MSan
+$CLICKHOUSE_CLIENT -q "explain select * from numbers(1) into outfile '$out'"
+cat "$out"
+rm -f "$out"

--- a/tests/queries/0_stateless/02768_into_outfile_extensions_format.reference
+++ b/tests/queries/0_stateless/02768_into_outfile_extensions_format.reference
@@ -1,0 +1,20 @@
+SELECT *
+FROM numbers(1)
+INTO OUTFILE '/dev/null'
+;
+
+SELECT *
+FROM numbers(1)
+INTO OUTFILE '/dev/null' AND STDOUT
+;
+
+SELECT *
+FROM numbers(1)
+INTO OUTFILE '/dev/null' APPEND
+;
+
+SELECT *
+FROM numbers(1)
+INTO OUTFILE '/dev/null' APPEND AND STDOUT
+;
+

--- a/tests/queries/0_stateless/02768_into_outfile_extensions_format.sh
+++ b/tests/queries/0_stateless/02768_into_outfile_extensions_format.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+echo "
+select * from numbers(1) into outfile '/dev/null';
+select * from numbers(1) into outfile '/dev/null' and stdout;
+select * from numbers(1) into outfile '/dev/null' append;
+select * from numbers(1) into outfile '/dev/null' append and stdout;
+" | clickhouse-format -n


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix UB for INTO OUTFILE extensions (APPEND / AND STDOUT) and WATCH EVENTS. Fix formatting of INTO OUTFILE extensions. Use default initialization for POD members of ASTs (for safety, problems was only with the queries that had been enumerated before).

MSan does not report any errors due to optimizations, but you will likely hit the problem with `explain select 1into outfile '/tmp/foo'`, it will try to open fd with `O_APPEND` instead of `O_CREAT`. Plus for `EXPLAIN SELECT INTO OUTFILE` MSan does shows the error, but not for regular `SELECT INTO OUTFILE`

<details>

<summary>Example of MSAn report</summary>

==38627==WARNING: MemorySanitizer: use-of-uninitialized-value
    0 0x555599f5e114 in std::__1::__unique_if<DB::WriteBufferFromFile>::__unique_single std::__1::make_unique[abi:v15000]<> build_docker/./contrib/llvm-project/libcxx/include/__memory/unique_ptr.h:714:32
    1 0x555599f5e114 in DB::ClientBase::initOutputFormat() build_docker/./src/Client/ClientBase.cpp:604:21
    2 0x555599f590a8 in DB::ClientBase::onData() build_docker/./src/Client/ClientBase.cpp:446:5
    3 0x555599f6f36e in DB::ClientBase::receiveAndProcessPacket() build_docker/./src/Client/ClientBase.cpp:1019:17
    4 0x555599f6e863 in DB::ClientBase::receiveResult() build_docker/./src/Client/ClientBase.cpp:987:18
    5 0x555599f6c05b in DB::ClientBase::processOrdinaryQuery() build_docker/./src/Client/ClientBase.cpp:905:13
    6 0x555599f67e05 in DB::ClientBase::processParsedSingleQuery() build_docker/./src/Client/ClientBase.cpp:1711:13
    7 0x555599f86fb6 in DB::ClientBase::executeMultiQuery(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) build_docker/./src/Client/ClientBase.cpp:1975:21

  Uninitialized value was created by a heap allocation
    8 0x55559bd3e038 in DB::ParserExplainQuery::parseImpl(DB::IParser::Pos&, std::__1::shared_ptr<DB::IAST>&, DB::Expected&) build_docker/./src/Parsers/ParserExplainQuery.cpp:53:26
    9 0x55559bce31f4 in DB::IParserBase::parse(DB::IParser::Pos&, std::__1::shared_ptr<DB::IAST>&, DB::Expected&)::$_0::operator()() const build_docker/./src/Parsers/IParserBase.cpp:13:20
    ..
    21 0x55559be13b5c in DB::parseQueryAndMovePosition(DB::IParser&, char const*&, char const*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, bool, unsigned long, unsigned long) build_docker/./src/Parsers/parseQuery.cpp:357:18
    22 0x555599f5673a in DB::ClientBase::parseQuery(char const*&, char const*, bool) const build_docker/./src/Client/ClientBase.cpp:362:15
    23 0x555599f84a4f in DB::ClientBase::analyzeMultiQueryText() build_docker/./src/Client/ClientBase.cpp:1821:24
    24 0x555599f867b3 in DB::ClientBase::executeMultiQuery(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) build_docker/./src/Client/ClientBase.cpp:1910:22
    25 0x555599f8a2fd in DB::ClientBase::processQueryText(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) build_docker/./src/Client/ClientBase.cpp:2120:12
    26 0x555599f94aee in DB::ClientBase::runNonInteractive() build_docker/./src/Client/ClientBase.cpp:2403:9

</details>

Follow-up for: #48880 (cc @alekar)
Follow-up for: #39054 (cc @SmitaRKulkarni)