### PR TITLE
Fix skipping spaces at end of row in CustomSeparatedIgnoreSpaces format

### DIFF
--- a/src/Processors/Formats/Impl/CustomSeparatedRowInputFormat.h
+++ b/src/Processors/Formats/Impl/CustomSeparatedRowInputFormat.h
@@ -76,7 +76,7 @@ public:
 
     bool checkEndOfRow();
     bool checkForSuffixImpl(bool check_eof);
-    inline void skipSpaces() { if (ignore_spaces) skipWhitespaceIfAny(*buf); }
+    inline void skipSpaces() { if (ignore_spaces) skipWhitespaceIfAny(*buf, true); }
 
     EscapingRule getEscapingRule() const override { return format_settings.custom.escaping_rule; }
 

--- a/tests/queries/0_stateless/02752_custom_separated_ignore_spaces_bug.reference
+++ b/tests/queries/0_stateless/02752_custom_separated_ignore_spaces_bug.reference
@@ -1,0 +1,1 @@
+unquoted_string

--- a/tests/queries/0_stateless/02752_custom_separated_ignore_spaces_bug.sql
+++ b/tests/queries/0_stateless/02752_custom_separated_ignore_spaces_bug.sql
@@ -1,0 +1,1 @@
+select * from format(CustomSeparatedIgnoreSpaces, 'x String', ' unquoted_string\n') settings format_custom_escaping_rule='CSV';


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix skipping spaces at end of row in CustomSeparatedIgnoreSpaces format

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
