### PR TITLE
Fix reconnecting of HTTPS session when target host IP was changed

### DIFF
--- a/base/poco/Net/include/Poco/Net/HTTPClientSession.h
+++ b/base/poco/Net/include/Poco/Net/HTTPClientSession.h
@@ -127,6 +127,9 @@ namespace Net
 
         void setResolvedHost(std::string resolved_host) { _resolved_host.swap(resolved_host); }
 
+        std::string getResolvedHost() const { return _resolved_host; }
+        /// Returns the resolved IP address of the target HTTP server.
+
         Poco::UInt16 getPort() const;
         /// Returns the port number of the target HTTP server.
 

--- a/tests/integration/test_https_replication/configs/listen_host.xml
+++ b/tests/integration/test_https_replication/configs/listen_host.xml
@@ -1,0 +1,3 @@
+<clickhouse>
+    <listen_host>::</listen_host>
+</clickhouse>

--- a/tests/integration/test_https_replication/test_change_ip.py
+++ b/tests/integration/test_https_replication/test_change_ip.py
@@ -1,0 +1,96 @@
+import pytest
+from helpers.cluster import ClickHouseCluster
+from helpers.test_tools import assert_eq_with_retry
+
+"""
+Both ssl_conf.xml and no_ssl_conf.xml have the same port
+"""
+
+
+def _fill_nodes(nodes, shard):
+    for node in nodes:
+        node.query(
+            """
+                CREATE DATABASE test;
+    
+                CREATE TABLE test_table(date Date, id UInt32)
+                ENGINE = ReplicatedMergeTree('/clickhouse/tables/test{shard}/replicated', '{replica}') PARTITION BY toYYYYMM(date) ORDER BY id;
+            """.format(
+                shard=shard, replica=node.name
+            )
+        )
+
+
+cluster = ClickHouseCluster(__file__)
+node1 = cluster.add_instance(
+    "node1",
+    main_configs=[
+        "configs/remote_servers.xml",
+        "configs/listen_host.xml",
+        "configs/ssl_conf.xml",
+        "configs/server.crt",
+        "configs/server.key",
+        "configs/dhparam.pem",
+    ],
+    with_zookeeper=True,
+    ipv6_address="2001:3984:3989::1:1111",
+)
+node2 = cluster.add_instance(
+    "node2",
+    main_configs=[
+        "configs/remote_servers.xml",
+        "configs/listen_host.xml",
+        "configs/ssl_conf.xml",
+        "configs/server.crt",
+        "configs/server.key",
+        "configs/dhparam.pem",
+    ],
+    with_zookeeper=True,
+    ipv6_address="2001:3984:3989::1:1112",
+)
+
+
+@pytest.fixture(scope="module")
+def both_https_cluster():
+    try:
+        cluster.start()
+
+        _fill_nodes([node1, node2], 1)
+
+        yield cluster
+
+    finally:
+        cluster.shutdown()
+
+
+def test_replication_when_node_ip_changed(both_https_cluster):
+    """
+    Test for a bug when replication over HTTPS stops working when the IP of the source replica was changed.
+
+    node1 is a source node
+    node2 fethes data from node1
+    """
+    node1.query("truncate table test_table")
+    node2.query("truncate table test_table")
+
+    # First we check, that normal replication works
+    node1.query(
+        "INSERT INTO test_table VALUES ('2022-10-01', 1), ('2022-10-02', 2), ('2022-10-03', 3)"
+    )
+    assert node1.query("SELECT count(*) from test_table") == "3\n"
+    assert_eq_with_retry(node2, "SELECT count(*) from test_table", "3")
+
+    # We change source node ip
+    cluster.restart_instance_with_ip_change(node1, "2001:3984:3989::1:7777")
+
+    # Put some data to source node1
+    node1.query(
+        "INSERT INTO test_table VALUES ('2018-10-01', 4), ('2018-10-02', 4), ('2018-10-03', 6)"
+    )
+    # Check that data is placed on node1
+    assert node1.query("SELECT count(*) from test_table") == "6\n"
+
+    # drop DNS cache
+    node2.query("SYSTEM DROP DNS CACHE")
+    # Data is fetched
+    assert_eq_with_retry(node2, "SELECT count(*) from test_table", "6")


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix an issue when replication over HTTPS stops working when IP of replica was changed

We get the following messages in the log indefinitely until the server is rebooted. 
Backport is needed. But it might have to be done manually for some versions.
```
2023.03.04 11:31:04.232585 [ 2310875 ] {} <Error> stat.MasterReportPIStat: auto DB::StorageReplicatedMergeTree::processQueueEntry(ReplicatedMergeTreeQueue::SelectedEntryPtr)::(anonymous class)::operator()(DB::StorageReplicatedMergeTree::LogEntryPtr &) const: Poco::Exception. Code: 1000, e.code() = 0, Timeout: connect timed out: [2a02:6b8:c33:414e:0:1589:43b1:2f6]:9010, Stack trace (when copying this message, always include the lines below):

0. Poco::Net::SocketImpl::connect(Poco::Net::SocketAddress const&, Poco::Timespan const&) @ 0x18a10779 in /usr/bin/clickhouse
1. Poco::Net::SecureSocketImpl::connect(Poco::Net::SocketAddress const&, Poco::Timespan const&, bool) @ 0x189c340a in /usr/bin/clickhouse
2. Poco::Net::SecureStreamSocketImpl::connect(Poco::Net::SocketAddress const&, Poco::Timespan const&) @ 0x189c7a99 in /usr/bin/clickhouse
3. Poco::Net::HTTPSClientSession::connect(Poco::Net::SocketAddress const&) @ 0x189c0223 in /usr/bin/clickhouse
4. Poco::Net::HTTPClientSession::reconnect() @ 0x189de8a1 in /usr/bin/clickhouse
5. Poco::Net::HTTPClientSession::sendRequest(Poco::Net::HTTPRequest&) @ 0x189dd659 in /usr/bin/clickhouse
6. DB::detail::ReadWriteBufferFromHTTPBase<std::__1::shared_ptr<DB::UpdatablePooledSession> >::callImpl(Poco::URI, Poco::Net::HTTPResponse&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) @ 0x157eeec3 in /usr/bin/clickhouse
7. DB::detail::ReadWriteBufferFromHTTPBase<std::__1::shared_ptr<DB::UpdatablePooledSession> >::call(Poco::Net::HTTPResponse&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, bool) @ 0x157ea90c in /usr/bin/clickhouse
8. DB::detail::ReadWriteBufferFromHTTPBase<std::__1::shared_ptr<DB::UpdatablePooledSession> >::initialize() @ 0x157e9422 in /usr/bin/clickhouse
9. DB::detail::ReadWriteBufferFromHTTPBase<std::__1::shared_ptr<DB::UpdatablePooledSession> >::ReadWriteBufferFromHTTPBase(std::__1::shared_ptr<DB::UpdatablePooledSession>, Poco::URI, Poco::Net::HTTPBasicCredentials const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::function<void (std::__1::basic_ostream<char, std::__1::char_traits<char> >&)>, unsigned long, DB::ReadSettings const&, std::__1::vector<std::__1::tuple<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::allocator<std::__1::tuple<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > >, DB::detail::ReadWriteBufferFromHTTPBase<std::__1::shared_ptr<DB::UpdatablePooledSession> >::Range, DB::RemoteHostFilter const*, bool, bool, bool) @ 0x157e6f47 in /usr/bin/clickhouse
10. DB::PooledReadWriteBufferFromHTTP::PooledReadWriteBufferFromHTTP(Poco::URI, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::function<void (std::__1::basic_ostream<char, std::__1::char_traits<char> >&)>, DB::ConnectionTimeouts const&, Poco::Net::HTTPBasicCredentials const&, unsigned long, unsigned long, unsigned long) @ 0x157e6714 in /usr/bin/clickhouse
11. DB::DataPartsExchange::Fetcher::fetchPart(std::__1::shared_ptr<DB::StorageInMemoryMetadata const> const&, std::__1::shared_ptr<DB::Context const>, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int, DB::ConnectionTimeouts const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::shared_ptr<DB::Throttler>, bool, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::optional<DB::CurrentlySubmergingEmergingTagger>*, bool, std::__1::shared_ptr<DB::IDisk>) @ 0x157cce93 in /usr/bin/clickhouse
12. ? @ 0x155fffe2 in /usr/bin/clickhouse
13. DB::StorageReplicatedMergeTree::fetchPart(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::shared_ptr<DB::StorageInMemoryMetadata const> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, bool, unsigned long, std::__1::shared_ptr<zkutil::ZooKeeper>, bool) @ 0x15536cb6 in /usr/bin/clickhouse
14. DB::StorageReplicatedMergeTree::executeFetch(DB::ReplicatedMergeTreeLogEntry&, bool) @ 0x15527e42 in /usr/bin/clickhouse
15. DB::StorageReplicatedMergeTree::executeLogEntry(DB::ReplicatedMergeTreeLogEntry&) @ 0x15515a80 in /usr/bin/clickhouse
16. ? @ 0x155fd9df in /usr/bin/clickhouse
17. DB::ReplicatedMergeTreeQueue::processEntry(std::__1::function<std::__1::shared_ptr<zkutil::ZooKeeper> ()>, std::__1::shared_ptr<DB::ReplicatedMergeTreeLogEntry>&, std::__1::function<bool (std::__1::shared_ptr<DB::ReplicatedMergeTreeLogEntry>&)>) @ 0x15a9bc05 in /usr/bin/clickhouse
18. DB::StorageReplicatedMergeTree::processQueueEntry(std::__1::shared_ptr<DB::ReplicatedMergeTreeQueue::SelectedEntry>) @ 0x1555f5dc in /usr/bin/clickhouse
19. DB::ExecutableLambdaAdapter::executeStep() @ 0x155fe671 in /usr/bin/clickhouse
20. DB::MergeTreeBackgroundExecutor<DB::OrdinaryRuntimeQueue>::routine(std::__1::shared_ptr<DB::TaskRuntimeData>) @ 0xa3c909b in /usr/bin/clickhouse
21. DB::MergeTreeBackgroundExecutor<DB::OrdinaryRuntimeQueue>::threadFunction() @ 0xa3c8d10 in /usr/bin/clickhouse
22. ThreadPoolImpl<ThreadFromGlobalPool>::worker(std::__1::__list_iterator<ThreadFromGlobalPool, void*>) @ 0xa4bf9e6 in /usr/bin/clickhouse
23. void std::__1::__function::__policy_invoker<void ()>::__call_impl<std::__1::__function::__default_alloc_func<ThreadFromGlobalPool::ThreadFromGlobalPool<void ThreadPoolImpl<ThreadFromGlobalPool>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda0'()>(void&&)::'lambda'(), void ()> >(std::__1::__function::__policy_storage const*) @ 0xa4c1337 in /usr/bin/clickhouse
24. ThreadPoolImpl<std::__1::thread>::worker(std::__1::__list_iterator<std::__1::thread, void*>) @ 0xa4bd308 in /usr/bin/clickhouse
25. ? @ 0xa4c051d in /usr/bin/clickhouse
26. start_thread @ 0x76db in /lib/x86_64-linux-gnu/libpthread-2.27.so
27. __clone @ 0x12161f in /lib/x86_64-linux-gnu/libc-2.27.so
 (version 22.8.13.20 (official build))
```

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
