### PR TITLE
Update SAMPLE clause documentation links

### DIFF
--- a/docs/en/sql-reference/statements/select/sample.md
+++ b/docs/en/sql-reference/statements/select/sample.md
@@ -34,7 +34,7 @@ For the `SAMPLE` clause the following syntax is supported:
 | `SAMPLE k OFFSET m`  |  Here `k` and `m` are the numbers from 0 to 1. The query is executed on a sample of `k` fraction of the data. The data used for the sample is offset by `m` fraction. [Read more](#select-sample-offset)  |
 
 
-## SAMPLE K
+## SAMPLE K {#select-sample-k}
 
 Here `k` is the number from 0 to 1 (both fractional and decimal notations are supported). For example, `SAMPLE 1/2` or `SAMPLE 0.5`.
 
@@ -54,7 +54,7 @@ ORDER BY PageViews DESC LIMIT 1000
 
 In this example, the query is executed on a sample from 0.1 (10%) of data. Values of aggregate functions are not corrected automatically, so to get an approximate result, the value `count()` is manually multiplied by 10.
 
-## SAMPLE N
+## SAMPLE N {#select-sample-n}
 
 Here `n` is a sufficiently large integer. For example, `SAMPLE 10000000`.
 
@@ -90,7 +90,7 @@ FROM visits
 SAMPLE 10000000
 ```
 
-## SAMPLE K OFFSET M
+## SAMPLE K OFFSET M {#select-sample-offset}
 
 Here `k` and `m` are numbers from 0 to 1. Examples are shown below.
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
Hi clickhouse team ✌️ 
Thank you for such a great and powerful DB engine 🙇 

While reading through the [SAMPLE Clause](https://clickhouse.com/docs/en/sql-reference/statements/select/sample) docs I noticed that **links in the summary table are leading to the wrong sections** so **this PR adds the right ids** (same as in [zh](https://github.com/ClickHouse/ClickHouse/blob/master/docs/zh/sql-reference/statements/select/sample.md) and [ru](https://github.com/ClickHouse/ClickHouse/blob/master/docs/ru/sql-reference/statements/select/sample.md) versions).

### Changelog category:
- Documentation (changelog entry is not required)
