### PR TITLE
Fixes for WITH FILL grouped by sorting prefix

### DIFF
--- a/docs/en/sql-reference/statements/select/order-by.md
+++ b/docs/en/sql-reference/statements/select/order-by.md
@@ -544,10 +544,10 @@ Result:
 └─────┴──────────┴───────┘
 ```
 
-##Filling grouped by sorting prefix
+## Filling grouped by sorting prefix
 
 It can be useful to fill rows which have the same values in particular columns independently, - a good example is filling missing values in time series.
-Assume there is the following time series table
+Assume there is the following time series table:
 ``` sql
 CREATE TABLE timeseries
 (
@@ -567,7 +567,7 @@ SELECT * FROM timeseries;
 └───────────┴─────────────────────────┴───────┘
 ```
 And we'd like to fill missing values for each sensor independently with 1 second interval.
-The way to achieve it is to use `sensor_id` column as sorting prefix for filling column `timestamp`
+The way to achieve it is to use `sensor_id` column as sorting prefix for filling column `timestamp`:
 ```
 SELECT *
 FROM timeseries
@@ -589,7 +589,7 @@ INTERPOLATE ( value AS 9999 )
 │       432 │ 2021-12-01 00:00:05.000 │     5 │
 └───────────┴─────────────────────────┴───────┘
 ```
-Here, the `value` column was interpolated with `9999` just to make filled rows more noticeable
+Here, the `value` column was interpolated with `9999` just to make filled rows more noticeable.
 This behavior is controlled by setting `use_with_fill_by_sorting_prefix` (enabled by default)
 
 ## Related content


### PR DESCRIPTION
Minor fixes in the documentation

### Changelog category (leave one):
- Documentation (changelog entry is not required)
