### PR TITLE
Fix undefined behavior when condition of if is nothing

### DIFF
--- a/src/Functions/if.cpp
+++ b/src/Functions/if.cpp
@@ -734,10 +734,12 @@ private:
         const auto & column1 = arguments[1];
         const auto & column2 = arguments[2];
 
-        if (cond_is_true)
-            return castColumn(column1, result_type);
-        else if (cond_is_false || cond_is_null)
-            return castColumn(column2, result_type);
+        auto res = cond_is_true ? column1 : ((cond_is_false || cond_is_null) ? column2 : ColumnWithTypeAndName());
+        if (res.column)
+        {
+            res.column = materializeColumnIfConst(res.column);
+            return castColumn(res, result_type);
+        }
 
         if (const auto * nullable = checkAndGetColumn<ColumnNullable>(*not_const_condition))
         {

--- a/tests/queries/0_stateless/02766_if_with_nothing_cond.reference
+++ b/tests/queries/0_stateless/02766_if_with_nothing_cond.reference
@@ -1,0 +1,5 @@
+\0hdhdfhp
+\0hdhdfhp
+\0hdhdfhp
+\0hdhdfhp
+\0hdhdfhp

--- a/tests/queries/0_stateless/02766_if_with_nothing_cond.sql
+++ b/tests/queries/0_stateless/02766_if_with_nothing_cond.sql
@@ -1,0 +1,8 @@
+SELECT bitShiftLeft(If(number = NULL, '14342', '4242348'), 1) FROM numbers(1);
+SELECT bitShiftLeft(If(number = NULL, '14342', '4242348'), 1) FROM numbers(3);
+SELECT bitShiftLeft(If(materialize(NULL), '14342', '4242348'), 1) FROM numbers(1);
+
+CREATE TABLE t0 (vkey UInt32, pkey UInt32, c0 UInt32) engine = TinyLog;
+CREATE TABLE t1 (vkey UInt32) ENGINE = AggregatingMergeTree  ORDER BY vkey;
+INSERT INTO t0 VALUES (15, 25000, 58);
+SELECT ref_5.pkey AS c_2_c2392_6 FROM t0 AS ref_5 WHERE 'J[' < multiIf(ref_5.pkey IN ( SELECT 1 ), bitShiftLeft(multiIf(ref_5.c0 > NULL, '1', ')'), 40), NULL);


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Fix undefined behavior when condition of if is nothing

`If` expects to return a full column but when condition is `Nothing`, it can return a const column, which leads to some undefined behavior as in #50236. 

Close #50236.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
