### PR TITLE
Fix 02767_into_outfile_extensions_msan under analyzer

### DIFF
--- a/tests/queries/0_stateless/02767_into_outfile_extensions_msan.sh
+++ b/tests/queries/0_stateless/02767_into_outfile_extensions_msan.sh
@@ -6,6 +6,6 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 out="explain1.$CLICKHOUSE_TEST_UNIQUE_NAME.out"
 # only EXPLAIN triggers the problem under MSan
-$CLICKHOUSE_CLIENT -q "explain select * from numbers(1) into outfile '$out'"
+$CLICKHOUSE_CLIENT --allow_experimental_analyzer=0 -q "explain select * from numbers(1) into outfile '$out'"
 cat "$out"
 rm -f "$out"


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix 02767_into_outfile_extensions_msan under analyzer

CI: https://s3.amazonaws.com/clickhouse-test-reports/50204/2e347007a2d220f332e86cd985b2b5a41290cfa8/stateless_tests__release__analyzer_.html