### PR TITLE
Update first_value.md:remove redundant 's'

### DIFF
--- a/docs/en/sql-reference/aggregate-functions/reference/first_value.md
+++ b/docs/en/sql-reference/aggregate-functions/reference/first_value.md
@@ -29,7 +29,7 @@ select first_value(b) from test_data
 ### example2
 The NULL value is ignored.
 ```sql
-select first_value(b) ignore nulls sfrom test_data
+select first_value(b) ignore nulls from test_data
 ```
 
 ```text


### PR DESCRIPTION
remove redundant 's'

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
- Documentation (changelog entry is not required)

- [ ] Documentation is written (mandatory for new features)

There is an extra letter s in this sql sentence：
select first_value(b) ignore nulls sfrom test_data

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
