### PR TITLE
Fix bitShift* functions with both constant arguments

### DIFF
--- a/src/Functions/FunctionBinaryArithmetic.h
+++ b/src/Functions/FunctionBinaryArithmetic.h
@@ -1741,7 +1741,7 @@ ColumnPtr executeStringInteger(const ColumnsWithTypeAndName & arguments, const A
                 OpImpl::template processString<OpCase::Vector>(in_vec.data(), col_left->getOffsets().data(), &value, out_vec, out_offsets, 1);
             }
 
-            return ColumnConst::create(std::move(col_res), col_left->size());
+            return ColumnConst::create(std::move(col_res), col_left_const->size());
         }
         else if (!col_left_const && !col_right_const && col_right)
         {

--- a/tests/queries/0_stateless/02766_bitshift_with_const_arguments.reference
+++ b/tests/queries/0_stateless/02766_bitshift_with_const_arguments.reference
@@ -1,0 +1,7 @@
+\0hdhdfhp
+\0hdhdfhp
+\0hdhdfhp
+\0hdhdfhp
+\0hdhdfhp
+\0bdf
+13000

--- a/tests/queries/0_stateless/02766_bitshift_with_const_arguments.sql
+++ b/tests/queries/0_stateless/02766_bitshift_with_const_arguments.sql
@@ -1,0 +1,22 @@
+SELECT bitShiftLeft(if(number = NULL, '14342', '4242348'), 1) FROM numbers(1);
+SELECT bitShiftLeft(if(number = NULL, '14342', '4242348'), 1) FROM numbers(3);
+SELECT bitShiftLeft(if(materialize(NULL), '14342', '4242348'), 1) FROM numbers(1);
+SELECT bitShiftLeft(if(materialize(1), '123', '123'), 1)  from numbers(1);
+
+
+-- The next queries are from fuzzer that found the bug:
+DROP TABLE IF EXISTS t0;
+DROP TABLE IF EXISTS t1;
+CREATE TABLE t0 (vkey UInt32, pkey UInt32, c0 UInt32) engine = TinyLog;
+CREATE TABLE t1 (vkey UInt32) ENGINE = AggregatingMergeTree  ORDER BY vkey;
+INSERT INTO t0 VALUES (15, 25000, 58);
+SELECT ref_5.pkey AS c_2_c2392_6 FROM t0 AS ref_5 WHERE 'J[' < multiIf(ref_5.pkey IN ( SELECT 1 ), bitShiftLeft(multiIf(ref_5.c0 > NULL, '1', ')'), 40), NULL);
+DROP TABLE t0;
+DROP TABLE t1;
+
+DROP TABLE IF EXISTS t5;
+CREATE TABLE t5 (vkey UInt32, pkey UInt32, c18 Float32, c19 UInt32) ENGINE = Log;
+INSERT INTO t5 VALUES (3, 13000, 73.90, 83);
+SELECT subq_0.pkey as c_1_c1193_15 FROM t5 AS subq_0 WHERE sipHash128(0, subq_0.c18, bitShiftRight(case when false then (sipHash128(subq_0.pkey, subq_0.c18, 'S')) else '1' end, 0)) is not null;
+DROP TABLE t5;
+


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix bitShift* functions with both constant arguments.
Closes https://github.com/ClickHouse/ClickHouse/issues/50236
Closes https://github.com/ClickHouse/ClickHouse/issues/50266
Closes https://github.com/ClickHouse/ClickHouse/issues/50282

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
