### PR TITLE
Trying to fix race in GraceHashJoin::initialize

### DIFF
--- a/src/Interpreters/GraceHashJoin.cpp
+++ b/src/Interpreters/GraceHashJoin.cpp
@@ -281,7 +281,6 @@ GraceHashJoin::GraceHashJoin(
 
 void GraceHashJoin::initBuckets()
 {
-    std::lock_guard current_bucket_lock(current_bucket_mutex);
 
     if (!buckets.empty())
         return;

--- a/src/Interpreters/GraceHashJoin.cpp
+++ b/src/Interpreters/GraceHashJoin.cpp
@@ -318,6 +318,9 @@ bool GraceHashJoin::addJoinedBlock(const Block & block, bool /*check_limits*/)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "GraceHashJoin is not initialized");
 
     Block materialized = materializeBlock(block);
+
+    std::lock_guard current_bucket_lock(current_bucket_mutex);
+
     addJoinedBlockImpl(std::move(materialized));
     return true;
 }

--- a/src/Interpreters/HashJoin.cpp
+++ b/src/Interpreters/HashJoin.cpp
@@ -1851,7 +1851,7 @@ public:
         : parent(parent_), max_block_size(max_block_size_), current_block_start(0)
     {
         if (parent.data == nullptr)
-            throw Exception(ErrorCodes::LOGICAL_ERROR, "({}) Cannot join after data has been released", fmt::ptr(parent));
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "({}) Cannot join after data has been released", fmt::ptr(&parent));
     }
 
     Block getEmptyBlock() override { return parent.savedBlockSample().cloneEmpty(); }

--- a/src/Interpreters/HashJoin.cpp
+++ b/src/Interpreters/HashJoin.cpp
@@ -715,7 +715,7 @@ Block HashJoin::prepareRightBlock(const Block & block) const
 bool HashJoin::addJoinedBlock(const Block & source_block_, bool check_limits)
 {
     if (!data)
-        throw Exception(ErrorCodes::LOGICAL_ERROR, "Join data was released");
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "({}) Join data was released", fmt::ptr(this));
 
     /// RowRef::SizeT is uint32_t (not size_t) for hash table Cell memory efficiency.
     /// It's possible to split bigger blocks and insert them by parts here. But it would be a dead code.
@@ -1753,7 +1753,7 @@ void HashJoin::checkTypesOfKeys(const Block & block) const
 void HashJoin::joinBlock(Block & block, ExtraBlockPtr & not_processed)
 {
     if (!data)
-        throw Exception(ErrorCodes::LOGICAL_ERROR, "Cannot join after data has been released");
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "({}) Cannot join after data has been released", fmt::ptr(this));
 
     for (const auto & onexpr : table_join->getClauses())
     {
@@ -1851,7 +1851,7 @@ public:
         : parent(parent_), max_block_size(max_block_size_), current_block_start(0)
     {
         if (parent.data == nullptr)
-            throw Exception(ErrorCodes::LOGICAL_ERROR, "Cannot join after data has been released");
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "({}) Cannot join after data has been released", fmt::ptr(parent));
     }
 
     Block getEmptyBlock() override { return parent.savedBlockSample().cloneEmpty(); }


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

Can't yet reproduce https://github.com/ClickHouse/ClickHouse/issues/50220 
~~Mutexes `hash_join_mutex` and `current_bucket_mutex` protects the same `hash_join` but on different stages of query. So, they should not overlap..~~


<details>
<summary>Logs</summary>

```
2023.05.25 01:41:52.502395 [ 27782 ] {bb77d854-7683-4084-872a-36417208b5f6} <Debug> executeQuery: (from [::1]:41322) (comment: 02273_full_sort_join.gen.sql) SELECT t1.key1, t1.key2, t1.key3, t2.key1, t2.key2, t2.key3, empty(t1.s), empty(t2.s) FROM t1 ALL INNER JOIN t2 ON t1.key1 == t2.key1 AND t1.key2 == t2.key2 AND t1.key3 == t2.key3 AND t1.key1 == t2.key3 ORDER BY t1.key1, t1.key2, t1.key3, t2.key1, t2.key2, t2.key3 ; (stage: Complete)
2023.05.25 01:41:52.504496 [ 27782 ] {bb77d854-7683-4084-872a-36417208b5f6} <Trace> ContextAccess (default): Access granted: SELECT(key1, key2, key3, s) ON test_25.t2
2023.05.25 01:41:52.504882 [ 27782 ] {bb77d854-7683-4084-872a-36417208b5f6} <Trace> InterpreterSelectQuery: FetchColumns -> Complete
2023.05.25 01:41:52.505096 [ 27782 ] {bb77d854-7683-4084-872a-36417208b5f6} <Debug> TableJoin: Left JOIN converting actions: empty
2023.05.25 01:41:52.505113 [ 27782 ] {bb77d854-7683-4084-872a-36417208b5f6} <Debug> TableJoin: Right JOIN converting actions: empty
2023.05.25 01:41:52.505189 [ 27782 ] {bb77d854-7683-4084-872a-36417208b5f6} <Debug> HashJoin: (0x7ff455bce7f0) Datatype: EMPTY, kind: Inner, strictness: All, right header: t2.key1 UInt32 UInt32(size = 0), t2.key2 UInt32 UInt32(size = 0), t2.key3 Nullable(UInt32) Nullable(size = 0, UInt32(size = 0), UInt8(size = 0)), t2.s String String(size = 0)
2023.05.25 01:41:52.505214 [ 27782 ] {bb77d854-7683-4084-872a-36417208b5f6} <Debug> HashJoin: (0x7ff455bce7f0) Keys: [(key1, key2, key3, key1) = (t2.key1, t2.key2, t2.key3, t2.key3)]
2023.05.25 01:41:52.505561 [ 27782 ] {bb77d854-7683-4084-872a-36417208b5f6} <Trace> ContextAccess (default): Access granted: SELECT(key1, key2, key3, s) ON test_25.t1
2023.05.25 01:41:52.505897 [ 27782 ] {bb77d854-7683-4084-872a-36417208b5f6} <Trace> InterpreterSelectQuery: FetchColumns -> Complete
2023.05.25 01:41:52.505997 [ 27782 ] {bb77d854-7683-4084-872a-36417208b5f6} <Debug> JoiningTransform: Before join block: 'key1 UInt32 UInt32(size = 0), key2 Nullable(UInt32) Nullable(size = 0, UInt32(size = 0), UInt8(size = 0)), key3 UInt32 UInt32(size = 0), s String String(size = 0)'
2023.05.25 01:41:52.506591 [ 27782 ] {bb77d854-7683-4084-872a-36417208b5f6} <Test> TemporaryFileStream: Writing to temporary file /var/lib/clickhouse/tmp/1672xycaaa
2023.05.25 01:41:52.515273 [ 27782 ] {bb77d854-7683-4084-872a-36417208b5f6} <Test> TemporaryFileStream: Writing to temporary file /var/lib/clickhouse/tmp/1672yycaaa
2023.05.25 01:41:52.515299 [ 27782 ] {bb77d854-7683-4084-872a-36417208b5f6} <Trace> GraceHashJoin: Initialize 1 bucket
2023.05.25 01:41:52.515329 [ 27782 ] {bb77d854-7683-4084-872a-36417208b5f6} <Trace> GraceHashJoin: Joining file bucket 0
2023.05.25 01:41:52.515512 [ 27782 ] {bb77d854-7683-4084-872a-36417208b5f6} <Debug> JoiningTransform: After join block: 'key1 UInt32 UInt32(size = 0), key2 Nullable(UInt32) Nullable(size = 0, UInt32(size = 0), UInt8(size = 0)), key3 UInt32 UInt32(size = 0), s String String(size = 0), t2.s String String(size = 0), t2.key1 UInt32 UInt32(size = 0), t2.key2 UInt32 UInt32(size = 0), t2.key3 Nullable(UInt32) Nullable(size = 0, UInt32(size = 0), UInt8(size = 0))'
2023.05.25 01:41:52.520275 [ 27782 ] {bb77d854-7683-4084-872a-36417208b5f6} <Debug> JoiningTransform: Before join block: 'key1 UInt32 UInt32(size = 0), key2 Nullable(UInt32) Nullable(size = 0, UInt32(size = 0), UInt8(size = 0)), key3 UInt32 UInt32(size = 0), s String String(size = 0)'
2023.05.25 01:41:52.520498 [ 27782 ] {bb77d854-7683-4084-872a-36417208b5f6} <Debug> JoiningTransform: After join block: 'key1 UInt32 UInt32(size = 0), key2 Nullable(UInt32) Nullable(size = 0, UInt32(size = 0), UInt8(size = 0)), key3 UInt32 UInt32(size = 0), s String String(size = 0), t2.s String String(size = 0), t2.key1 UInt32 UInt32(size = 0), t2.key2 UInt32 UInt32(size = 0), t2.key3 Nullable(UInt32) Nullable(size = 0, UInt32(size = 0), UInt8(size = 0))'
2023.05.25 01:41:52.553748 [ 48736 ] {bb77d854-7683-4084-872a-36417208b5f6} <Trace> GraceHashJoin: Memory overflow, size exceeded 74.75 KiB / 9.77 KiB bytes, 2 / 0 rows
2023.05.25 01:41:52.553779 [ 48736 ] {bb77d854-7683-4084-872a-36417208b5f6} <Trace> HashJoin: (0x7ff455bce7f0) Join data is being released, 76544 bytes and 2 rows in hash table
2023.05.25 01:41:52.553817 [ 48736 ] {bb77d854-7683-4084-872a-36417208b5f6} <Trace> GraceHashJoin: Rehashing from 1 to 2
2023.05.25 01:41:53.542441 [ 28412 ] {bb77d854-7683-4084-872a-36417208b5f6} <Fatal> : Logical error: 'Join data was released'.
```


</details>

~~No logs for this query and thread `28412` before error, unclear where it comes from.~~

@lgbo-ustc do you have any thoughts since you are also working with this code? 


UPD: looks like race in `initialize`
