### PR TITLE
Remove legacy install scripts superseded by universal.sh

### DIFF
--- a/docs/_includes/install/arm.sh
+++ b/docs/_includes/install/arm.sh
@@ -1,6 +1,0 @@
-# ARM (AArch64) build works on Amazon Graviton, Oracle Cloud, Huawei Cloud ARM machines.
-# The support for AArch64 is pre-production ready.
-
-wget 'https://builds.clickhouse.com/master/aarch64/clickhouse'
-chmod a+x ./clickhouse
-sudo ./clickhouse install

--- a/docs/_includes/install/freebsd.sh
+++ b/docs/_includes/install/freebsd.sh
@@ -1,3 +1,0 @@
-fetch 'https://builds.clickhouse.com/master/freebsd/clickhouse'
-chmod a+x ./clickhouse
-su -m root -c './clickhouse install'

--- a/docs/_includes/install/mac-arm.sh
+++ b/docs/_includes/install/mac-arm.sh
@@ -1,3 +1,0 @@
-wget 'https://builds.clickhouse.com/master/macos-aarch64/clickhouse'
-chmod a+x ./clickhouse
-./clickhouse

--- a/docs/_includes/install/mac-x86.sh
+++ b/docs/_includes/install/mac-x86.sh
@@ -1,3 +1,0 @@
-wget 'https://builds.clickhouse.com/master/macos/clickhouse'
-chmod a+x ./clickhouse
-./clickhouse


### PR DESCRIPTION
universal.sh is a replacement for the platform-specific install scripts.

Not 100% sure that nothing will break but I could not find further references. Let's try it 😄 

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)