### PR TITLE
Support dynamic adjustment of log level in Keeper

### DIFF
--- a/programs/keeper/Keeper.cpp
+++ b/programs/keeper/Keeper.cpp
@@ -485,6 +485,8 @@ try
         unused_event,
         [&](ConfigurationPtr config, bool /* initial_loading */)
         {
+            updateLevels(*config, logger());
+
             if (config->has("keeper_server"))
                 global_context->updateKeeperConfiguration(*config);
 

--- a/tests/integration/test_keeper_dynamic_log_level/configs/keeper_config.xml
+++ b/tests/integration/test_keeper_dynamic_log_level/configs/keeper_config.xml
@@ -1,0 +1,25 @@
+<clickhouse>
+    <keeper_server>
+        <tcp_port>9181</tcp_port>
+        <server_id>1</server_id>
+        <log_storage_path>/var/lib/clickhouse/coordination/log</log_storage_path>
+        <snapshot_storage_path>/var/lib/clickhouse/coordination/snapshots</snapshot_storage_path>
+        <four_letter_word_white_list>*</four_letter_word_white_list>
+
+        <coordination_settings>
+            <operation_timeout_ms>5000</operation_timeout_ms>
+            <session_timeout_ms>10000</session_timeout_ms>
+            <min_session_timeout_ms>5000</min_session_timeout_ms>
+            <snapshot_distance>75</snapshot_distance>
+            <raft_logs_level>trace</raft_logs_level>
+        </coordination_settings>
+
+        <raft_configuration>
+            <server>
+                <id>1</id>
+                <hostname>localhost</hostname>
+                <port>9234</port>
+            </server>
+        </raft_configuration>
+    </keeper_server>
+</clickhouse>

--- a/tests/integration/test_keeper_dynamic_log_level/configs/logger.xml
+++ b/tests/integration/test_keeper_dynamic_log_level/configs/logger.xml
@@ -1,0 +1,10 @@
+<clickhouse>
+    <logger>
+        <level>warning</level>
+        <log>/var/log/clickhouse-keeper.log</log>
+        <errorlog_level>error</errorlog_level>
+        <errorlog>/var/log/clickhouse-keeper.err.log</errorlog>
+        <size>200M</size>
+        <count>10</count>
+    </logger>
+</clickhouse>

--- a/tests/integration/test_keeper_dynamic_log_level/configs/logger.xml
+++ b/tests/integration/test_keeper_dynamic_log_level/configs/logger.xml
@@ -1,10 +1,11 @@
 <clickhouse>
     <logger>
         <level>warning</level>
-        <log>/var/log/clickhouse-keeper.log</log>
+        <log>/var/log/clickhouse-server/clickhouse-server.log</log>
         <errorlog_level>error</errorlog_level>
-        <errorlog>/var/log/clickhouse-keeper.err.log</errorlog>
+        <errorlog>/var/log/clickhouse-server/clickhouse-server.err.log</errorlog>
         <size>200M</size>
         <count>10</count>
     </logger>
 </clickhouse>
+

--- a/tests/integration/test_keeper_dynamic_log_level/test.py
+++ b/tests/integration/test_keeper_dynamic_log_level/test.py
@@ -60,7 +60,8 @@ def test_adjust_log_level(start_cluster):
             """,
         ]
     )
-    time.sleep(2)
+    time.sleep(3)
+    node.query("SELECT * FROM system.zookeeper SETTINGS allow_unrestricted_reads_from_keeper = 'true'")
     node.exec_in_container(
         [
             "bash",

--- a/tests/integration/test_keeper_dynamic_log_level/test.py
+++ b/tests/integration/test_keeper_dynamic_log_level/test.py
@@ -36,7 +36,8 @@ def test_adjust_log_level(start_cluster):
                 privileged=True,
                 user="root",
             )
-        ) == 0
+        )
+        == 0
     )
 
     # Adjust log level.
@@ -80,6 +81,7 @@ def test_adjust_log_level(start_cluster):
                 privileged=True,
                 user="root",
             )
-        ) >= 1
+        )
+        >= 1
     )
 

--- a/tests/integration/test_keeper_dynamic_log_level/test.py
+++ b/tests/integration/test_keeper_dynamic_log_level/test.py
@@ -1,0 +1,85 @@
+import pytest
+import time
+import sys
+
+from helpers.cluster import ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__)
+node = cluster.add_instance(
+    "node",
+    main_configs=[
+        "configs/keeper_config.xml",
+        "configs/logger.xml",
+    ],
+    stay_alive=True,
+)
+
+
+@pytest.fixture(scope="module")
+def start_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def test_adjust_log_level(start_cluster):
+    assert (
+        int(
+            node.exec_in_container(
+                [
+                    "bash",
+                    "-c",
+                    "grep '<Trace>' /var/log/clickhouse-keeper.log | wc -l",
+                ],
+                privileged=True,
+                user="root",
+            )
+        ) == 0
+    )
+
+    # Adjust log level.
+    node.exec_in_container(
+        [
+            "bash",
+            "-c",
+            """echo "
+<clickhouse>
+    <logger>
+        <level>trace</level>
+        <log>/var/log/clickhouse-keeper.log</log>
+        <errorlog_level>error</errorlog_level>
+        <errorlog>/var/log/clickhouse-keeper.err.log</errorlog>
+        <size>200M</size>
+        <count>10</count>
+    </logger>
+</clickhouse>
+            " > /etc/clickhouse-server/config.d/logger.xml
+            """,
+        ]
+    )
+    time.sleep(3)
+    node.exec_in_container(
+        [
+            "bash",
+            "-c",
+            "sync",
+        ],
+        privileged=True,
+        user="root",
+    )
+    assert (
+        int(
+            node.exec_in_container(
+                [
+                    "bash",
+                    "-c",
+                    "grep '<Trace>' /var/log/clickhouse-keeper.log | wc -l",
+                ],
+                privileged=True,
+                user="root",
+            )
+        ) >= 1
+    )
+

--- a/tests/integration/test_keeper_dynamic_log_level/test.py
+++ b/tests/integration/test_keeper_dynamic_log_level/test.py
@@ -84,4 +84,3 @@ def test_adjust_log_level(start_cluster):
         )
         >= 1
     )
-

--- a/tests/integration/test_keeper_dynamic_log_level/test.py
+++ b/tests/integration/test_keeper_dynamic_log_level/test.py
@@ -31,7 +31,7 @@ def test_adjust_log_level(start_cluster):
                 [
                     "bash",
                     "-c",
-                    "grep '<Trace>' /var/log/clickhouse-keeper.log | wc -l",
+                    "grep '<Trace>' /var/log/clickhouse-server/clickhouse-server.log | wc -l",
                 ],
                 privileged=True,
                 user="root",
@@ -49,9 +49,9 @@ def test_adjust_log_level(start_cluster):
 <clickhouse>
     <logger>
         <level>trace</level>
-        <log>/var/log/clickhouse-keeper.log</log>
+        <log>/var/log/clickhouse-server/clickhouse-server.log</log>
         <errorlog_level>error</errorlog_level>
-        <errorlog>/var/log/clickhouse-keeper.err.log</errorlog>
+        <errorlog>/var/log/clickhouse-server/clickhouse-server.err.log</errorlog>
         <size>200M</size>
         <count>10</count>
     </logger>
@@ -60,7 +60,7 @@ def test_adjust_log_level(start_cluster):
             """,
         ]
     )
-    time.sleep(3)
+    time.sleep(2)
     node.exec_in_container(
         [
             "bash",
@@ -76,7 +76,7 @@ def test_adjust_log_level(start_cluster):
                 [
                     "bash",
                     "-c",
-                    "grep '<Trace>' /var/log/clickhouse-keeper.log | wc -l",
+                    "grep '<Trace>' /var/log/clickhouse-server/clickhouse-server.log | wc -l",
                 ],
                 privileged=True,
                 user="root",

--- a/tests/integration/test_keeper_dynamic_log_level/test.py
+++ b/tests/integration/test_keeper_dynamic_log_level/test.py
@@ -61,7 +61,9 @@ def test_adjust_log_level(start_cluster):
         ]
     )
     time.sleep(3)
-    node.query("SELECT * FROM system.zookeeper SETTINGS allow_unrestricted_reads_from_keeper = 'true'")
+    node.query(
+        "SELECT * FROM system.zookeeper SETTINGS allow_unrestricted_reads_from_keeper = 'true'"
+    )
     node.exec_in_container(
         [
             "bash",


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
The Keeper dynamically adjusts log levels.
