### PR TITLE
fix Keeper deadlock on exception when preprocessing requests

### DIFF
--- a/src/Coordination/KeeperStateMachine.cpp
+++ b/src/Coordination/KeeperStateMachine.cpp
@@ -272,7 +272,8 @@ bool KeeperStateMachine::preprocess(const KeeperStorage::RequestForSession & req
     }
     catch (...)
     {
-        rollbackRequest(request_for_session, true);
+        tryLogCurrentException(__PRETTY_FUNCTION__);
+        rollbackRequestNoLock(request_for_session, true);
         throw;
     }
 
@@ -403,6 +404,15 @@ void KeeperStateMachine::rollback(uint64_t log_idx, nuraft::buffer & data)
 }
 
 void KeeperStateMachine::rollbackRequest(const KeeperStorage::RequestForSession & request_for_session, bool allow_missing)
+{
+    if (request_for_session.request->getOpNum() == Coordination::OpNum::SessionID)
+        return;
+
+    std::lock_guard lock(storage_and_responses_lock);
+    storage->rollbackRequest(request_for_session.zxid, allow_missing);
+}
+
+void KeeperStateMachine::rollbackRequestNoLock(const KeeperStorage::RequestForSession & request_for_session, bool allow_missing)
 {
     if (request_for_session.request->getOpNum() == Coordination::OpNum::SessionID)
         return;

--- a/src/Coordination/KeeperStateMachine.h
+++ b/src/Coordination/KeeperStateMachine.h
@@ -68,6 +68,8 @@ public:
     // (can happen in case of exception during preprocessing)
     void rollbackRequest(const KeeperStorage::RequestForSession & request_for_session, bool allow_missing);
 
+    void rollbackRequestNoLock(const KeeperStorage::RequestForSession & request_for_session, bool allow_missing);
+
     uint64_t last_commit_index() override { return last_committed_idx; }
 
     /// Apply preliminarily saved (save_logical_snp_obj) snapshot to our state.


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix Keeper deadlock on exception when preprocessing requests.
