### PR TITLE
test for #42610

### DIFF
--- a/tests/queries/0_stateless/01910_view_dictionary_check_refresh.reference
+++ b/tests/queries/0_stateless/01910_view_dictionary_check_refresh.reference
@@ -1,0 +1,4 @@
+view	1	2022-10-20	first
+dict	1	2022-10-20	first
+view	1	2022-10-21	second
+dict	1	2022-10-21	second

--- a/tests/queries/0_stateless/01910_view_dictionary_check_refresh.sql
+++ b/tests/queries/0_stateless/01910_view_dictionary_check_refresh.sql
@@ -1,0 +1,54 @@
+-- Tags: long
+
+DROP DICTIONARY IF EXISTS TestTblDict;
+DROP VIEW IF EXISTS TestTbl_view;
+DROP TABLE IF EXISTS TestTbl;
+
+CREATE TABLE TestTbl
+(
+    `id` UInt16,
+    `dt` Date,
+    `val` String
+)
+ENGINE = MergeTree
+PARTITION BY dt
+ORDER BY (id);
+
+CREATE VIEW TestTbl_view
+AS
+SELECT *
+FROM TestTbl
+WHERE dt = ( SELECT max(dt) FROM TestTbl );
+
+CREATE DICTIONARY IF NOT EXISTS TestTblDict
+(
+    `id` UInt16,
+    `dt` Date,
+    `val` String
+)
+PRIMARY KEY id
+SOURCE(CLICKHOUSE(TABLE TestTbl_view DB currentDatabase()))
+LIFETIME(1)
+LAYOUT(COMPLEX_KEY_HASHED());
+
+select 'view' src,* FROM TestTbl_view;
+select 'dict' src,* FROM TestTblDict ;
+
+insert into TestTbl values(1, '2022-10-20', 'first');
+
+SELECT sleep(3) from numbers(4) settings max_block_size= 1 format Null;
+
+select 'view' src,* FROM TestTbl_view;
+select 'dict' src,* FROM TestTblDict ;
+
+insert into TestTbl values(1, '2022-10-21', 'second');
+
+SELECT sleep(3) from numbers(4) settings max_block_size= 1 format Null;
+
+select 'view' src,* FROM TestTbl_view;
+select 'dict' src,* FROM TestTblDict ;
+
+DROP DICTIONARY IF EXISTS TestTblDict;
+DROP VIEW IF EXISTS TestTbl_view;
+DROP TABLE IF EXISTS TestTbl;
+


### PR DESCRIPTION
closes: #42610

for some reason a dictionary has not updated if a view with a subquery is used as a source.
It's magically fixed in 21.10, no idea why

21.9 https://fiddle.clickhouse.com/c3c745bf-5014-4680-ac41-5eb28f06ae09
21.10 https://fiddle.clickhouse.com/7f59f55a-3c30-4c33-88ef-bd816bfc3fc4

Can be flaky because dictionary updates itself unpredictably, lifetime=1 means really <=5.
Probably it has sense to increase the sleep if flaky (now it sleeps 3*4 = 12 seconds * 2 iterations)

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
