### PR TITLE
Mark the builds without results as pending

### DIFF
--- a/tests/ci/build_report_check.py
+++ b/tests/ci/build_report_check.py
@@ -23,6 +23,7 @@ from get_robot_token import get_best_robot_token
 from pr_info import NeedsDataType, PRInfo
 from commit_status_helper import (
     RerunHelper,
+    format_description,
     get_commit,
     post_commit_status,
     update_mergeable_check,
@@ -269,14 +270,20 @@ def main():
         if build_result.status == "success":
             ok_groups += 1
 
-    if ok_groups == 0 or some_builds_are_missing:
-        summary_status = "error"
+    # Check if there are no builds at all, do not override bad status
+    if summary_status == "success":
+        if some_builds_are_missing:
+            summary_status = "pending"
+        elif ok_groups == 0:
+            summary_status = "error"
 
     addition = ""
     if some_builds_are_missing:
-        addition = f"({len(build_reports)} of {required_builds} builds are OK)"
+        addition = f" ({len(build_reports)} of {required_builds} builds are OK)"
 
-    description = f"{ok_groups}/{total_groups} artifact groups are OK {addition}"
+    description = format_description(
+        f"{ok_groups}/{total_groups} artifact groups are OK{addition}"
+    )
 
     post_commit_status(
         commit, summary_status, url, description, build_check_name, pr_info


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
The workflows with killed runners will have the Build Report marked as `pending`. It should be safe since the Mergeable check will be still red.