### PR TITLE
Introduce fallback ZooKeeper sessions

### DIFF
--- a/docs/en/operations/server-configuration-parameters/settings.md
+++ b/docs/en/operations/server-configuration-parameters/settings.md
@@ -2164,6 +2164,8 @@ This section contains the following parameters:
 - `session_timeout_ms` — Maximum timeout for the client session in milliseconds.
 - `operation_timeout_ms` — Maximum timeout for one operation in milliseconds.
 - `root` — The [znode](http://zookeeper.apache.org/doc/r3.5.5/zookeeperOver.html#Nodes+and+ephemeral+nodes) that is used as the root for znodes used by the ClickHouse server. Optional.
+- `fallback_session_lifetime.min` - If the first zookeeper host resolved by zookeeper_load_balancing strategy is unavailable, limit the lifetime of a zookeeper session to the fallback node. This is done for load-balancing purposes to avoid excessive load on one of zookeeper hosts. This setting sets the minimal duration of the fallback session. Set in seconds. Optional. Default is 3 hours.
+- `fallback_session_lifetime.max` - If the first zookeeper host resolved by zookeeper_load_balancing strategy is unavailable, limit the lifetime of a zookeeper session to the fallback node. This is done for load-balancing purposes to avoid excessive load on one of zookeeper hosts. This setting sets the maximum duration of the fallback session. Set in seconds. Optional. Default is 6 hours.
 - `identity` — User and password, that can be required by ZooKeeper to give access to requested znodes. Optional.
 - zookeeper_load_balancing - Specifies the algorithm of ZooKeeper node selection.
   * random - randomly selects one of ZooKeeper nodes.

--- a/src/Common/ZooKeeper/IKeeper.h
+++ b/src/Common/ZooKeeper/IKeeper.h
@@ -490,8 +490,6 @@ public:
     /// Useful to check owner of ephemeral node.
     virtual int64_t getSessionID() const = 0;
 
-    virtual Poco::Net::SocketAddress getConnectedAddress() const = 0;
-
     /// If the method will throw an exception, callbacks won't be called.
     ///
     /// After the method is executed successfully, you must wait for callbacks

--- a/src/Common/ZooKeeper/IKeeper.h
+++ b/src/Common/ZooKeeper/IKeeper.h
@@ -562,6 +562,10 @@ public:
 
     virtual const DB::KeeperFeatureFlags * getKeeperFeatureFlags() const { return nullptr; }
 
+    /// A ZooKeeper session can have an optional deadline set on it.
+    /// After it has been reached, the session needs to be finalized.
+    virtual bool hasReachedDeadline() const = 0;
+
     /// Expire session and finish all pending requests
     virtual void finalize(const String & reason) = 0;
 };

--- a/src/Common/ZooKeeper/TestKeeper.h
+++ b/src/Common/ZooKeeper/TestKeeper.h
@@ -39,6 +39,7 @@ public:
     ~TestKeeper() override;
 
     bool isExpired() const override { return expired; }
+    bool hasReachedDeadline() const override { return false; }
     int64_t getSessionID() const override { return 0; }
 
 

--- a/src/Common/ZooKeeper/TestKeeper.h
+++ b/src/Common/ZooKeeper/TestKeeper.h
@@ -40,7 +40,6 @@ public:
 
     bool isExpired() const override { return expired; }
     int64_t getSessionID() const override { return 0; }
-    Poco::Net::SocketAddress getConnectedAddress() const override { return connected_zk_address; }
 
 
     void create(
@@ -134,8 +133,6 @@ private:
     Container container;
 
     zkutil::ZooKeeperArgs args;
-
-    Poco::Net::SocketAddress connected_zk_address;
 
     std::mutex push_request_mutex;
     std::atomic<bool> expired{false};

--- a/src/Common/ZooKeeper/ZooKeeper.cpp
+++ b/src/Common/ZooKeeper/ZooKeeper.cpp
@@ -112,31 +112,17 @@ void ZooKeeper::init(ZooKeeperArgs args_)
                 throw KeeperException("Cannot use any of provided ZooKeeper nodes", Coordination::Error::ZCONNECTIONLOSS);
         }
 
-        impl = std::make_unique<Coordination::ZooKeeper>(nodes, args, zk_log);
+        impl = std::make_unique<Coordination::ZooKeeper>(nodes, args, zk_log, [this](size_t node_idx, const Coordination::ZooKeeper::Node & node)
+        {
+            connected_zk_host = node.address.host().toString();
+            connected_zk_port = node.address.port();
+            connected_zk_index = node_idx;
+        });
 
         if (args.chroot.empty())
             LOG_TRACE(log, "Initialized, hosts: {}", fmt::join(args.hosts, ","));
         else
             LOG_TRACE(log, "Initialized, hosts: {}, chroot: {}", fmt::join(args.hosts, ","), args.chroot);
-
-        Poco::Net::SocketAddress address = impl->getConnectedAddress();
-
-        connected_zk_host = address.host().toString();
-        connected_zk_port = address.port();
-
-        connected_zk_index = 0;
-
-        if (args.hosts.size() > 1)
-        {
-            for (size_t i = 0; i < args.hosts.size(); i++)
-            {
-                if (args.hosts[i] == address.toString())
-                {
-                    connected_zk_index = i;
-                    break;
-                }
-            }
-        }
     }
     else if (args.implementation == "testkeeper")
     {

--- a/src/Common/ZooKeeper/ZooKeeper.h
+++ b/src/Common/ZooKeeper/ZooKeeper.h
@@ -521,6 +521,7 @@ public:
     void setZooKeeperLog(std::shared_ptr<DB::ZooKeeperLog> zk_log_);
 
     UInt32 getSessionUptime() const { return static_cast<UInt32>(session_uptime.elapsedSeconds()); }
+    bool hasReachedDeadline() const { return impl->hasReachedDeadline(); }
 
     void setServerCompletelyStarted();
 

--- a/src/Common/ZooKeeper/ZooKeeperArgs.cpp
+++ b/src/Common/ZooKeeper/ZooKeeperArgs.cpp
@@ -204,6 +204,14 @@ void ZooKeeperArgs::initFromKeeperSection(const Poco::Util::AbstractConfiguratio
                 throw DB::Exception(DB::ErrorCodes::BAD_ARGUMENTS, "Unknown load balancing: {}", load_balancing_str);
             get_priority_load_balancing.load_balancing = *load_balancing;
         }
+        else if (key == "fallback_session_lifetime")
+        {
+            fallback_session_lifetime = SessionLifetimeConfiguration
+            {
+                .min_sec = config.getUInt(config_name + "." + key + ".min"),
+                .max_sec = config.getUInt(config_name + "." + key + ".max"),
+            };
+        }
         else
             throw KeeperException(std::string("Unknown key ") + key + " in config file", Coordination::Error::ZBADARGUMENTS);
     }

--- a/src/Common/ZooKeeper/ZooKeeperArgs.h
+++ b/src/Common/ZooKeeper/ZooKeeperArgs.h
@@ -11,8 +11,17 @@ namespace Poco::Util
 namespace zkutil
 {
 
+constexpr UInt32 ZK_MIN_FALLBACK_SESSION_DEADLINE_SEC = 3 * 60 * 60;
+constexpr UInt32 ZK_MAX_FALLBACK_SESSION_DEADLINE_SEC = 6 * 60 * 60;
+
 struct ZooKeeperArgs
 {
+    struct SessionLifetimeConfiguration
+    {
+        UInt32 min_sec = ZK_MIN_FALLBACK_SESSION_DEADLINE_SEC;
+        UInt32 max_sec = ZK_MAX_FALLBACK_SESSION_DEADLINE_SEC;
+        bool operator == (const SessionLifetimeConfiguration &) const = default;
+    };
     ZooKeeperArgs(const Poco::Util::AbstractConfiguration & config, const String & config_name);
 
     /// hosts_string -- comma separated [secure://]host:port list
@@ -36,6 +45,7 @@ struct ZooKeeperArgs
     UInt64 send_sleep_ms = 0;
     UInt64 recv_sleep_ms = 0;
 
+    SessionLifetimeConfiguration fallback_session_lifetime = {};
     DB::GetPriorityForLoadBalancing get_priority_load_balancing;
 
 private:

--- a/src/Common/ZooKeeper/ZooKeeperImpl.h
+++ b/src/Common/ZooKeeper/ZooKeeperImpl.h
@@ -125,6 +125,10 @@ public:
     /// If expired, you can only destroy the object. All other methods will throw exception.
     bool isExpired() const override { return requests_queue.isFinished(); }
 
+    /// A ZooKeeper session can have an optional deadline set on it.
+    /// After it has been reached, the session needs to be finalized.
+    bool hasReachedDeadline() const override;
+
     /// Useful to check owner of ephemeral node.
     int64_t getSessionID() const override { return session_id; }
 
@@ -252,6 +256,7 @@ private:
         clock::time_point time;
     };
 
+    std::optional<clock::time_point> client_session_deadline {};
     using RequestsQueue = ConcurrentBoundedQueue<RequestInfo>;
 
     RequestsQueue requests_queue{1024};
@@ -323,6 +328,8 @@ private:
     void logOperationIfNeeded(const ZooKeeperRequestPtr & request, const ZooKeeperResponsePtr & response = nullptr, bool finalize = false, UInt64 elapsed_ms = 0);
 
     void initFeatureFlags();
+
+    void checkSessionDeadline() const;
 
     CurrentMetrics::Increment active_session_metric_increment{CurrentMetrics::ZooKeeperSession};
     std::shared_ptr<ZooKeeperLog> zk_log;

--- a/src/Common/ZooKeeper/ZooKeeperImpl.h
+++ b/src/Common/ZooKeeper/ZooKeeperImpl.h
@@ -107,6 +107,7 @@ public:
     };
 
     using Nodes = std::vector<Node>;
+    using ConnectedCallback = std::function<void(size_t, const Node&)>;
 
     /** Connection to nodes is performed in order. If you want, shuffle them manually.
       * Operation timeout couldn't be greater than session timeout.
@@ -115,7 +116,8 @@ public:
     ZooKeeper(
         const Nodes & nodes,
         const zkutil::ZooKeeperArgs & args_,
-        std::shared_ptr<ZooKeeperLog> zk_log_);
+        std::shared_ptr<ZooKeeperLog> zk_log_,
+        std::optional<ConnectedCallback> && connected_callback_ = {});
 
     ~ZooKeeper() override;
 
@@ -125,8 +127,6 @@ public:
 
     /// Useful to check owner of ephemeral node.
     int64_t getSessionID() const override { return session_id; }
-
-    Poco::Net::SocketAddress getConnectedAddress() const override { return connected_zk_address; }
 
     void executeGenericRequest(
         const ZooKeeperRequestPtr & request,
@@ -213,9 +213,9 @@ public:
 
 private:
     ACLs default_acls;
-    Poco::Net::SocketAddress connected_zk_address;
 
     zkutil::ZooKeeperArgs args;
+    std::optional<ConnectedCallback> connected_callback = {};
 
     /// Fault injection
     void maybeInjectSendFault();

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -2695,7 +2695,10 @@ zkutil::ZooKeeperPtr Context::getZooKeeper() const
     const auto & config = shared->zookeeper_config ? *shared->zookeeper_config : getConfigRef();
     if (!shared->zookeeper)
         shared->zookeeper = std::make_shared<zkutil::ZooKeeper>(config, zkutil::getZooKeeperConfigName(config), getZooKeeperLog());
-    else if (shared->zookeeper->expired())
+    else if (shared->zookeeper->hasReachedDeadline())
+        shared->zookeeper->finalize("ZooKeeper session has reached its deadline");
+
+    if (shared->zookeeper->expired())
     {
         Stopwatch watch;
         LOG_DEBUG(shared->log, "Trying to establish a new connection with ZooKeeper");

--- a/tests/integration/parallel_skip.json
+++ b/tests/integration/parallel_skip.json
@@ -48,6 +48,7 @@
   "test_system_metrics/test.py::test_readonly_metrics",
   "test_system_replicated_fetches/test.py::test_system_replicated_fetches",
   "test_zookeeper_config_load_balancing/test.py::test_round_robin",
+  "test_zookeeper_fallback_session/test.py::test_fallback_session",
 
   "test_global_overcommit_tracker/test.py::test_global_overcommit",
 

--- a/tests/integration/test_zookeeper_fallback_session/configs/remote_servers.xml
+++ b/tests/integration/test_zookeeper_fallback_session/configs/remote_servers.xml
@@ -1,0 +1,23 @@
+<clickhouse>
+    <remote_servers>
+        <test_cluster>
+            <shard>
+                <replica>
+                    <host>node1</host>
+                    <port>9000</port>
+                </replica>
+
+                <replica>
+                    <host>node2</host>
+                    <port>9000</port>
+                </replica>
+
+                <replica>
+                    <host>node3</host>
+                    <port>9000</port>
+                </replica>
+
+            </shard>
+        </test_cluster>
+    </remote_servers>
+</clickhouse>

--- a/tests/integration/test_zookeeper_fallback_session/configs/zookeeper_load_balancing.xml
+++ b/tests/integration/test_zookeeper_fallback_session/configs/zookeeper_load_balancing.xml
@@ -1,0 +1,23 @@
+<clickhouse>
+    <zookeeper>
+        <!--<zookeeper_load_balancing> random / in_order / nearest_hostname / first_or_random / round_robin </zookeeper_load_balancing>-->
+        <zookeeper_load_balancing>in_order</zookeeper_load_balancing>
+        <fallback_session_lifetime>
+            <min>2</min>
+            <max>4</max>
+        </fallback_session_lifetime>
+        <node index="1">
+            <host>zoo1</host>
+            <port>2181</port>
+        </node>
+        <node index="2">
+            <host>zoo2</host>
+            <port>2181</port>
+        </node>
+        <node index="3">
+            <host>zoo3</host>
+            <port>2181</port>
+        </node>
+        <session_timeout_ms>500</session_timeout_ms>
+    </zookeeper>
+</clickhouse>

--- a/tests/integration/test_zookeeper_fallback_session/test.py
+++ b/tests/integration/test_zookeeper_fallback_session/test.py
@@ -1,0 +1,101 @@
+import pytest
+from helpers.cluster import ClickHouseCluster, ClickHouseInstance
+from helpers.network import PartitionManager
+
+
+cluster = ClickHouseCluster(
+    __file__, zookeeper_config_path="configs/zookeeper_load_balancing.xml"
+)
+
+node1 = cluster.add_instance(
+    "node1",
+    with_zookeeper=True,
+    main_configs=["configs/remote_servers.xml", "configs/zookeeper_load_balancing.xml"],
+)
+node2 = cluster.add_instance(
+    "node2",
+    with_zookeeper=True,
+    main_configs=["configs/remote_servers.xml", "configs/zookeeper_load_balancing.xml"],
+)
+node3 = cluster.add_instance(
+    "node3",
+    with_zookeeper=True,
+    main_configs=["configs/remote_servers.xml", "configs/zookeeper_load_balancing.xml"],
+)
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+        for node in [node1, node2, node3]:
+            node.query("DROP TABLE IF EXISTS simple SYNC")
+            node.query(
+                """
+            CREATE TABLE simple (date Date, id UInt32)
+            ENGINE = ReplicatedMergeTree('/clickhouse/tables/0/simple', '{replica}') PARTITION BY toYYYYMM(date) ORDER BY id;
+            """.format(
+                    replica=node.name
+                )
+            )
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def assert_uses_zk_node(node: ClickHouseInstance, zk_node):
+    def check_callback(host):
+        return host.strip() == expected_zk_ip_addr
+
+    expected_zk_ip_addr = node.cluster.get_instance_ip(zk_node)
+
+    host = node.query_with_retry(
+        "select host from system.zookeeper_connection", check_callback=check_callback
+    )
+    assert host.strip() == expected_zk_ip_addr
+
+
+def test_fallback_session(started_cluster: ClickHouseCluster):
+    # only leave connecting to zoo3 possible
+    with PartitionManager() as pm:
+        for node in started_cluster.instances.values():
+            for zk in ["zoo1", "zoo2"]:
+                pm._add_rule(
+                    {
+                        "source": node.ip_address,
+                        "destination": cluster.get_instance_ip(zk),
+                        "action": "REJECT --reject-with tcp-reset",
+                    }
+                )
+
+        for node in [node1, node2, node3]:
+            # all nodes will have to switch to zoo3
+            assert_uses_zk_node(node, "zoo3")
+
+        node1.query_with_retry("INSERT INTO simple VALUES ({0}, {0})".format(1))
+
+        # and replication still works
+        for node in [node2, node3]:
+            assert (
+                node.query_with_retry(
+                    "SELECT count() from simple",
+                    check_callback=lambda count: count.strip() == "1",
+                )
+                == "1\n"
+            )
+
+    # at this point network partitioning has been reverted.
+    # the nodes should switch to zoo1 automatically because of `in_order` load-balancing.
+    # otherwise they would connect to a random replica
+    for node in [node1, node2, node3]:
+        assert_uses_zk_node(node, "zoo1")
+
+    node1.query_with_retry("INSERT INTO simple VALUES ({0}, {0})".format(2))
+    for node in [node2, node3]:
+        assert (
+            node.query_with_retry(
+                "SELECT count() from simple",
+                check_callback=lambda count: count.strip() == "2",
+            )
+            == "2\n"
+        )


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Introduce fallback ZooKeeper sessions which are time-bound. Fixed `index` column in system.zookeeper_connection for DNS addresses.

### Documentation entry for user-facing changes
- [x] Documentation is written (mandatory for new features)

This change allows users to limit lifetime of ZooKeeper sessions. It's useful to balance load between ZooKeeper replicas over long periods of time. A hypothetical situation where this may be useful (please see the integration test in the PR):
- A cluster of N CH nodes is connected to 3 Keeper replicas.
- Each Keeper replica is seeing N/3 connections if random load_balancing is used
- One of the Keeper replicas goes down / loses connectivity
- Clickhouse nodes detect that and re-connect to other replicas.
- 2 remaining Keeper nodes are receiving N/2 connections each
- The Keeper node comes up
- Without the proposed change, the node that just came up will not get new connections, while the other two will see N/2, unless CH nodes are restarted;
- With the proposed change, the ZK sessions will expire automatically and the load balance will be restored.

I believe this will help the scenario described in https://github.com/ClickHouse/ClickHouse/issues/29617#issuecomment-1161194175 as well as https://github.com/ClickHouse/ClickHouse/issues/51524
