### PR TITLE
Fix excessive memory usage for FINAL (due to too much streams usage)

### DIFF
--- a/tests/queries/0_stateless/02780_final_streams_data_skipping_index.reference
+++ b/tests/queries/0_stateless/02780_final_streams_data_skipping_index.reference
@@ -1,0 +1,43 @@
+-- { echoOn }
+EXPLAIN PIPELINE SELECT * FROM data FINAL WHERE v1 >= now() - INTERVAL 180 DAY
+SETTINGS max_threads=2, max_final_threads=2, force_data_skipping_indices='v1_index', use_skip_indexes_if_final=1
+FORMAT LineAsString;
+(Expression)
+ExpressionTransform × 2
+  (Filter)
+  FilterTransform × 2
+    (ReadFromMergeTree)
+    ExpressionTransform × 2
+      AggregatingSortedTransform 2 → 1
+        ExpressionTransform × 2
+          FilterSortedStreamByRange × 2
+          Description: filter values in [(999424), +inf)
+            ExpressionTransform × 2
+              MergeTreeInOrder × 2 0 → 1
+                AggregatingSortedTransform
+                  ExpressionTransform
+                    FilterSortedStreamByRange
+                    Description: filter values in [-inf, (999424))
+                      ExpressionTransform
+                        MergeTreeInOrder 0 → 1
+EXPLAIN PIPELINE SELECT * FROM data FINAL WHERE v1 >= now() - INTERVAL 180 DAY
+SETTINGS max_threads=2, max_final_threads=2, force_data_skipping_indices='v1_index', use_skip_indexes_if_final=0
+FORMAT LineAsString;
+(Expression)
+ExpressionTransform × 2
+  (Filter)
+  FilterTransform × 2
+    (ReadFromMergeTree)
+    ExpressionTransform × 2
+      AggregatingSortedTransform 2 → 1
+        ExpressionTransform × 2
+          FilterSortedStreamByRange × 2
+          Description: filter values in [(999424), +inf)
+            ExpressionTransform × 2
+              MergeTreeInOrder × 2 0 → 1
+                AggregatingSortedTransform
+                  ExpressionTransform
+                    FilterSortedStreamByRange
+                    Description: filter values in [-inf, (999424))
+                      ExpressionTransform
+                        MergeTreeInOrder 0 → 1

--- a/tests/queries/0_stateless/02780_final_streams_data_skipping_index.sql
+++ b/tests/queries/0_stateless/02780_final_streams_data_skipping_index.sql
@@ -1,0 +1,28 @@
+-- Tags: no-random-merge-tree-settings, no-random-settings
+
+DROP TABLE IF EXISTS data;
+
+CREATE TABLE data
+(
+    key  Int,
+    v1   DateTime,
+    INDEX v1_index v1 TYPE minmax GRANULARITY 1
+) ENGINE=AggregatingMergeTree()
+ORDER BY key
+SETTINGS index_granularity=8192, min_bytes_for_wide_part=0, min_rows_for_wide_part=0;
+
+SYSTEM STOP MERGES data;
+
+-- generate 50% of marks that cannot be skipped with v1_index
+-- this will create a gap in marks
+INSERT INTO data SELECT number,     if(number/8192 % 2 == 0, now(), now() - INTERVAL 200 DAY) FROM numbers(1e6);
+INSERT INTO data SELECT number+1e6, if(number/8192 % 2 == 0, now(), now() - INTERVAL 200 DAY) FROM numbers(1e6);
+
+-- { echoOn }
+EXPLAIN PIPELINE SELECT * FROM data FINAL WHERE v1 >= now() - INTERVAL 180 DAY
+SETTINGS max_threads=2, max_final_threads=2, force_data_skipping_indices='v1_index', use_skip_indexes_if_final=1
+FORMAT LineAsString;
+
+EXPLAIN PIPELINE SELECT * FROM data FINAL WHERE v1 >= now() - INTERVAL 180 DAY
+SETTINGS max_threads=2, max_final_threads=2, force_data_skipping_indices='v1_index', use_skip_indexes_if_final=0
+FORMAT LineAsString;


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix excessive memory usage for FINAL (due to too much streams usage)

Previously it could create MergeTreeInOrder for each mark, however this could be very suboptimal, due to each MergeTreeInOrder has some memory overhead.

Now, by collapsing all marks for one part together it is more memory effiecient.

I've tried the query from the altinity wiki [1] and it decreases memory usage twice:

    SELECT * FROM repl_tbl FINAL WHERE key IN (SELECT toUInt32(number) FROM numbers(1000000) WHERE number % 50000 = 0) FORMAT Null

- upstream: MemoryTracker: Peak memory usage (for query): 520.27 MiB.
- patched:  MemoryTracker: Peak memory usage (for query): 260.95 MiB.

  [1]: https://kb.altinity.com/engines/mergetree-table-engine-family/replacingmergetree/#multiple-keys

And it could be not 2x and even more or less, it depends on the gaps in marks for reading (for example in my setup the memory usage increased a lot, from ~16GiB of RAM to >64GiB due to lots of marks and gaps).

Cc: @nickitat 
Cc: @UnamedRus (you may want to run your queries)

_Note: this pops up after a proper marks skipping for FINAL in #47801_

_P.S. Marked as bug fix to run tests on previous version._