### PR TITLE
Delay AsyncInsertQueue push to avoid some spurious failures and improve code documentation

### DIFF
--- a/src/Interpreters/AsynchronousInsertQueue.h
+++ b/src/Interpreters/AsynchronousInsertQueue.h
@@ -30,15 +30,25 @@ public:
 
         Status status;
 
-        /// Future that allows to wait until the query is flushed.
-        std::future<void> future;
-
         /// Read buffer that contains extracted
         /// from query data in case of too much data.
         std::unique_ptr<ReadBuffer> insert_data_buffer;
+
+        // Data extracted from query that should be passed
+        // to pushNoCheck
+        String bytes;
     };
 
-    PushResult push(ASTPtr query, ContextPtr query_context);
+    // Checks whether a certain async insert query can
+    // actually be performed asynchronously or not.
+    PushResult pushCheckOnly(ASTPtr query, ContextPtr query_context);
+
+    // Push a query to the async insert queue.
+    // pushCheckOnly should be used before this call and
+    // the bytes field from its return structure should be passed here.
+    // The return value can be used to wait for the query completion.
+    std::future<void> pushNoCheck(ASTPtr query, ContextPtr query_context, String && bytes);
+
     size_t getPoolSize() const { return pool_size; }
 
 private:

--- a/src/Processors/Sources/WaitForAsyncInsertSource.cpp
+++ b/src/Processors/Sources/WaitForAsyncInsertSource.cpp
@@ -1,0 +1,30 @@
+#include "WaitForAsyncInsertSource.h"
+
+#include <Interpreters/AsynchronousInsertQueue.h>
+#include <Interpreters/Context.h>
+#include <Parsers/IAST_fwd.h>
+#include <Processors/ISource.h>
+
+#include <future>
+
+namespace DB
+{
+
+Chunk WaitForAsyncInsertSource::generate()
+{
+    auto query_context = context.lock();
+    auto * queue = query_context->getAsynchronousInsertQueue();
+    auto insert_future = queue->pushNoCheck(query, query_context, std::move(bytes));
+    if (wait)
+    {
+        auto status = insert_future.wait_for(std::chrono::milliseconds(timeout_ms));
+        if (status == std::future_status::deferred)
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "Logical error: got future in deferred state");
+
+        if (status == std::future_status::timeout)
+            throw Exception(ErrorCodes::TIMEOUT_EXCEEDED, "Wait for async insert timeout ({} ms) exceeded)", timeout_ms);
+        insert_future.get();
+    }
+    return Chunk();
+}
+}


### PR DESCRIPTION
If an exception is thrown after the query is pushed into the queue,
the user may receive and error even if the insert succeeded or if it is
still in the queue.
This would be even more problematic when the fix for #47593 will be
implemented, because, once you give up control of the socket to the bg
thread, the original thread can't send errors to the user anymore.
This commit doesn't completely solve the issue, the callers of executeQuery
should be modified too to avoid throwing issues after the push.
It will be improved more with the fix for #47593 and other future PRs.
But it should be easier to review it, if I submit it separately.

Also improve the description of one of the overloads of executeQuery, which
didn't reflect perfectly its behaviour when dealing with async inserts. 


### Changelog category (leave one):
- Not for changelog (changelog entry is not required)



