### PR TITLE
[WIP] Use loading dependencies during a replicated database's lost-replica recovery process

### DIFF
--- a/src/Databases/DatabaseReplicated.cpp
+++ b/src/Databases/DatabaseReplicated.cpp
@@ -14,7 +14,7 @@
 #include <Common/ZooKeeper/ZooKeeper.h>
 #include <Databases/DatabaseReplicated.h>
 #include <Databases/DatabaseReplicatedWorker.h>
-#include <Databases/DDLDependencyVisitor.h>
+#include <Databases/DDLLoadingDependencyVisitor.h>
 #include <Databases/TablesDependencyGraph.h>
 #include <Interpreters/Cluster.h>
 #include <Interpreters/Context.h>
@@ -962,7 +962,7 @@ void DatabaseReplicated::recoverLostReplica(const ZooKeeperPtr & current_zookeep
         /// And QualifiedTableName::parseFromString doesn't handle this.
         auto qualified_name = QualifiedTableName{.database = getDatabaseName(), .table = table_name};
         auto query_ast = parseQueryFromMetadataInZooKeeper(table_name, create_table_query);
-        tables_dependencies.addDependencies(qualified_name, getDependenciesFromCreateQuery(getContext(), qualified_name, query_ast));
+        tables_dependencies.addDependencies(qualified_name, getLoadingDependenciesFromCreateQuery(getContext(), qualified_name, query_ast));
     }
 
     tables_dependencies.checkNoCyclicDependencies();


### PR DESCRIPTION
### Changelog category:
- Improvement

### Changelog entry:
Use loading dependencies during a replicated database's lost-replica recovery process.
This PR fixes https://github.com/ClickHouse/ClickHouse/issues/50222.
See also https://github.com/ClickHouse/ClickHouse/pull/44697