### PR TITLE
Ignore QEMU logging regarding IFA

### DIFF
--- a/tests/queries/0_stateless/01103_check_cpu_instructions_at_startup.sh
+++ b/tests/queries/0_stateless/01103_check_cpu_instructions_at_startup.sh
@@ -19,7 +19,9 @@ fi
 
 function run_with_cpu()
 {
-    qemu-x86_64-static -cpu "$@" "$command" --query "SELECT 1" 2>&1 | grep -v -F "warning: TCG doesn't support requested feature" ||:
+    qemu-x86_64-static -cpu "$@" "$command" --query "SELECT 1" 2>&1 | \
+      grep -v -F "warning: TCG doesn't support requested feature" | \
+      grep -v -F 'Unknown host IFA type' ||:
 }
 
 run_with_cpu qemu64


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix strange additional QEMU logging after #47151, see https://s3.amazonaws.com/clickhouse-test-reports/50078/a4743996ee4f3583884d07bcd6501df0cfdaa346/stateless_tests__release__databasereplicated__[3_4].html