### PR TITLE
Revert "Revert "less logs in WriteBufferFromS3" (#50390)"

### DIFF
--- a/src/IO/WriteBufferFromS3.cpp
+++ b/src/IO/WriteBufferFromS3.cpp
@@ -195,18 +195,14 @@ void WriteBufferFromS3::finalizeImpl()
 
     if (request_settings.check_objects_after_upload)
     {
-        LOG_TRACE(log, "Checking object {} exists after upload", key);
         S3::checkObjectExists(*client_ptr, bucket, key, {}, request_settings, /* for_disk_s3= */ write_settings.for_object_storage, "Immediately after upload");
 
-        LOG_TRACE(log, "Checking object {} has size as expected {}", key, total_size);
         size_t actual_size = S3::getObjectSize(*client_ptr, bucket, key, {}, request_settings, /* for_disk_s3= */ write_settings.for_object_storage);
         if (actual_size != total_size)
             throw Exception(
                     ErrorCodes::S3_ERROR,
                     "Object {} from bucket {} has unexpected size {} after upload, expected size {}, it's a bug in S3 or S3 API.",
                     key, bucket, actual_size, total_size);
-
-        LOG_TRACE(log, "Object {} exists after upload", key);
     }
 }
 
@@ -292,8 +288,6 @@ void WriteBufferFromS3::reallocateFirstBuffer()
     WriteBuffer::set(memory.data() + hidden_size, memory.size() - hidden_size);
 
     chassert(offset() == 0);
-
-    LOG_TRACE(log, "Reallocated first buffer with size {}. {}", memory.size(), getLogDetails());
 }
 
 void WriteBufferFromS3::detachBuffer()
@@ -316,8 +310,6 @@ void WriteBufferFromS3::allocateFirstBuffer()
     const auto size = std::min(size_t(DBMS_DEFAULT_BUFFER_SIZE), max_first_buffer);
     memory = Memory(size);
     WriteBuffer::set(memory.data(), memory.size());
-
-    LOG_TRACE(log, "Allocated first buffer with size {}. {}", memory.size(), getLogDetails());
 }
 
 void WriteBufferFromS3::allocateBuffer()

--- a/src/IO/WriteBufferFromS3TaskTracker.cpp
+++ b/src/IO/WriteBufferFromS3TaskTracker.cpp
@@ -36,8 +36,6 @@ ThreadPoolCallbackRunner<void> WriteBufferFromS3::TaskTracker::syncRunner()
 
 void WriteBufferFromS3::TaskTracker::waitAll()
 {
-    LOG_TEST(log, "waitAll, in queue {}", futures.size());
-
     /// Exceptions are propagated
     for (auto & future : futures)
     {
@@ -51,8 +49,6 @@ void WriteBufferFromS3::TaskTracker::waitAll()
 
 void WriteBufferFromS3::TaskTracker::safeWaitAll()
 {
-    LOG_TEST(log, "safeWaitAll, wait in queue {}", futures.size());
-
     for (auto & future : futures)
     {
         if (future.valid())
@@ -76,7 +72,6 @@ void WriteBufferFromS3::TaskTracker::safeWaitAll()
 
 void WriteBufferFromS3::TaskTracker::waitIfAny()
 {
-    LOG_TEST(log, "waitIfAny, in queue {}", futures.size());
     if (futures.empty())
         return;
 
@@ -101,8 +96,6 @@ void WriteBufferFromS3::TaskTracker::waitIfAny()
 
     watch.stop();
     ProfileEvents::increment(ProfileEvents::WriteBufferFromS3WaitInflightLimitMicroseconds, watch.elapsedMicroseconds());
-
-    LOG_TEST(log, "waitIfAny ended, in queue {}", futures.size());
 }
 
 void WriteBufferFromS3::TaskTracker::add(Callback && func)
@@ -147,8 +140,6 @@ void WriteBufferFromS3::TaskTracker::waitTilInflightShrink()
     if (!max_tasks_inflight)
         return;
 
-    LOG_TEST(log, "waitTilInflightShrink, in queue {}", futures.size());
-
     Stopwatch watch;
 
     /// Alternative approach is to wait until at least futures.size() - max_tasks_inflight element are finished
@@ -171,8 +162,6 @@ void WriteBufferFromS3::TaskTracker::waitTilInflightShrink()
 
     watch.stop();
     ProfileEvents::increment(ProfileEvents::WriteBufferFromS3WaitInflightLimitMicroseconds, watch.elapsedMicroseconds());
-
-    LOG_TEST(log, "waitTilInflightShrink ended, in queue {}", futures.size());
 }
 
 bool WriteBufferFromS3::TaskTracker::isAsync() const


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

This reverts commit 4d4112ff536f819514973dfd0cb8274cf044bb3e.

This is the second try to commit this https://github.com/ClickHouse/ClickHouse/pull/50347
After it was reverted here https://github.com/ClickHouse/ClickHouse/pull/50390

The failed test was rewritten here https://github.com/ClickHouse/ClickHouse/pull/50408

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
