### PR TITLE
Docs: remove needless minus sign

### DIFF
--- a/docs/ru/faq/integration/json-import.md
+++ b/docs/ru/faq/integration/json-import.md
@@ -19,7 +19,7 @@ $ echo '{"foo":"bar"}' | curl 'http://localhost:8123/?query=INSERT%20INTO%20test
 При помощи [интефейса CLI](../../interfaces/cli.md):
 
 ``` bash
-$ echo '{"foo":"bar"}'  | clickhouse-client ---query="INSERT INTO test FORMAT JSONEachRow"
+$ echo '{"foo":"bar"}'  | clickhouse-client --query="INSERT INTO test FORMAT JSONEachRow"
 ```
 
 Чтобы не вставлять данные вручную, используйте одну из [готовых библиотек](../../interfaces/index.md).


### PR DESCRIPTION
A quick fix of an annoying misprint: `--query` option in the code example has three minus signs, which isn't correct. One has to fix it every time when copying and pasting.

The newline at the end was added automatically by my editor, according to the project's `.editorconfig`.

### Changelog category (leave one):
- Documentation (changelog entry is not required)
