### PR TITLE
Attach gdb in stateless tests

### DIFF
--- a/docker/test/stateless/run.sh
+++ b/docker/test/stateless/run.sh
@@ -15,6 +15,7 @@ dpkg -i package_folder/clickhouse-client_*.deb
 
 ln -s /usr/share/clickhouse-test/clickhouse-test /usr/bin/clickhouse-test
 
+# shellcheck disable=SC1091
 source /usr/share/clickhouse-test/ci/attach_gdb.lib
 
 # install test configs

--- a/docker/test/stateless/run.sh
+++ b/docker/test/stateless/run.sh
@@ -15,6 +15,8 @@ dpkg -i package_folder/clickhouse-client_*.deb
 
 ln -s /usr/share/clickhouse-test/clickhouse-test /usr/bin/clickhouse-test
 
+source /usr/share/clickhouse-test/ci/attach_gdb.lib
+
 # install test configs
 /usr/share/clickhouse-test/config/install.sh
 
@@ -85,44 +87,7 @@ fi
 
 sleep 5
 
-# Set follow-fork-mode to parent, because we attach to clickhouse-server, not to watchdog
-# and clickhouse-server can do fork-exec, for example, to run some bridge.
-# Do not set nostop noprint for all signals, because some it may cause gdb to hang,
-# explicitly ignore non-fatal signals that are used by server.
-# Number of SIGRTMIN can be determined only in runtime.
-RTMIN=$(kill -l SIGRTMIN)
-echo "
-set follow-fork-mode parent
-handle SIGHUP nostop noprint pass
-handle SIGINT nostop noprint pass
-handle SIGQUIT nostop noprint pass
-handle SIGPIPE nostop noprint pass
-handle SIGTERM nostop noprint pass
-handle SIGUSR1 nostop noprint pass
-handle SIGUSR2 nostop noprint pass
-handle SIG$RTMIN nostop noprint pass
-info signals
-continue
-backtrace full
-thread apply all backtrace full
-info registers
-disassemble /s
-up
-disassemble /s
-up
-disassemble /s
-p \"done\"
-detach
-quit
-" > script.gdb
-
-# FIXME Hung check may work incorrectly because of attached gdb
-# 1. False positives are possible
-# 2. We cannot attach another gdb to get stacktraces if some queries hung
-gdb -batch -command script.gdb -p "$(cat /var/run/clickhouse-server/clickhouse-server.pid)" | ts '%Y-%m-%d %H:%M:%S' >> /test_output/gdb.log &
-sleep 5
-# gdb will send SIGSTOP, spend some time loading debug info and then send SIGCONT, wait for it (up to send_timeout, 300s)
-time clickhouse-client --query "SELECT 'Connected to clickhouse-server after attaching gdb'" ||:
+attach_gdb_to_clickhouse
 
 function run_tests()
 {

--- a/docker/test/stateless/run.sh
+++ b/docker/test/stateless/run.sh
@@ -85,6 +85,45 @@ fi
 
 sleep 5
 
+# Set follow-fork-mode to parent, because we attach to clickhouse-server, not to watchdog
+# and clickhouse-server can do fork-exec, for example, to run some bridge.
+# Do not set nostop noprint for all signals, because some it may cause gdb to hang,
+# explicitly ignore non-fatal signals that are used by server.
+# Number of SIGRTMIN can be determined only in runtime.
+RTMIN=$(kill -l SIGRTMIN)
+echo "
+set follow-fork-mode parent
+handle SIGHUP nostop noprint pass
+handle SIGINT nostop noprint pass
+handle SIGQUIT nostop noprint pass
+handle SIGPIPE nostop noprint pass
+handle SIGTERM nostop noprint pass
+handle SIGUSR1 nostop noprint pass
+handle SIGUSR2 nostop noprint pass
+handle SIG$RTMIN nostop noprint pass
+info signals
+continue
+backtrace full
+thread apply all backtrace full
+info registers
+disassemble /s
+up
+disassemble /s
+up
+disassemble /s
+p \"done\"
+detach
+quit
+" > script.gdb
+
+# FIXME Hung check may work incorrectly because of attached gdb
+# 1. False positives are possible
+# 2. We cannot attach another gdb to get stacktraces if some queries hung
+gdb -batch -command script.gdb -p "$(cat /var/run/clickhouse-server/clickhouse-server.pid)" | ts '%Y-%m-%d %H:%M:%S' >> /test_output/gdb.log &
+sleep 5
+# gdb will send SIGSTOP, spend some time loading debug info and then send SIGCONT, wait for it (up to send_timeout, 300s)
+time clickhouse-client --query "SELECT 'Connected to clickhouse-server after attaching gdb'" ||:
+
 function run_tests()
 {
     set -x

--- a/tests/ci/attach_gdb.lib
+++ b/tests/ci/attach_gdb.lib
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+function attach_gdb_to_clickhouse()
+{
+    # Set follow-fork-mode to parent, because we attach to clickhouse-server, not to watchdog
+    # and clickhouse-server can do fork-exec, for example, to run some bridge.
+    # Do not set nostop noprint for all signals, because some it may cause gdb to hang,
+    # explicitly ignore non-fatal signals that are used by server.
+    # Number of SIGRTMIN can be determined only in runtime.
+    RTMIN=$(kill -l SIGRTMIN)
+  echo "
+set follow-fork-mode parent
+handle SIGHUP nostop noprint pass
+handle SIGINT nostop noprint pass
+handle SIGQUIT nostop noprint pass
+handle SIGPIPE nostop noprint pass
+handle SIGTERM nostop noprint pass
+handle SIGUSR1 nostop noprint pass
+handle SIGUSR2 nostop noprint pass
+handle SIG$RTMIN nostop noprint pass
+info signals
+continue
+backtrace full
+thread apply all backtrace full
+info registers
+disassemble /s
+up
+disassemble /s
+up
+disassemble /s
+p \"done\"
+detach
+quit
+" > script.gdb
+
+    # FIXME Hung check may work incorrectly because of attached gdb
+    # We cannot attach another gdb to get stacktraces if some queries hung
+    gdb -batch -command script.gdb -p "$(cat /var/run/clickhouse-server/clickhouse-server.pid)" | ts '%Y-%m-%d %H:%M:%S' >> /test_output/gdb.log &
+    sleep 5
+    # gdb will send SIGSTOP, spend some time loading debug info and then send SIGCONT, wait for it (up to send_timeout, 300s)
+    time clickhouse-client --query "SELECT 'Connected to clickhouse-server after attaching gdb'" ||:
+}

--- a/tests/ci/stress_tests.lib
+++ b/tests/ci/stress_tests.lib
@@ -9,6 +9,8 @@ FAIL="\tFAIL\t\\N\t"
 FAILURE_CONTEXT_LINES=100
 FAILURE_CONTEXT_MAX_LINE_WIDTH=300
 
+source attach_gdb.lib
+
 function escaped()
 {
     # That's the simplest way I found to escape a string in bash. Yep, bash is the most convenient programming language.
@@ -184,44 +186,7 @@ function start()
         counter=$((counter + 1))
     done
 
-    # Set follow-fork-mode to parent, because we attach to clickhouse-server, not to watchdog
-    # and clickhouse-server can do fork-exec, for example, to run some bridge.
-    # Do not set nostop noprint for all signals, because some it may cause gdb to hang,
-    # explicitly ignore non-fatal signals that are used by server.
-    # Number of SIGRTMIN can be determined only in runtime.
-    RTMIN=$(kill -l SIGRTMIN)
-    echo "
-set follow-fork-mode parent
-handle SIGHUP nostop noprint pass
-handle SIGINT nostop noprint pass
-handle SIGQUIT nostop noprint pass
-handle SIGPIPE nostop noprint pass
-handle SIGTERM nostop noprint pass
-handle SIGUSR1 nostop noprint pass
-handle SIGUSR2 nostop noprint pass
-handle SIG$RTMIN nostop noprint pass
-info signals
-continue
-backtrace full
-thread apply all backtrace full
-info registers
-disassemble /s
-up
-disassemble /s
-up
-disassemble /s
-p \"done\"
-detach
-quit
-" > script.gdb
-
-    # FIXME Hung check may work incorrectly because of attached gdb
-    # 1. False positives are possible
-    # 2. We cannot attach another gdb to get stacktraces if some queries hung
-    gdb -batch -command script.gdb -p "$(cat /var/run/clickhouse-server/clickhouse-server.pid)" | ts '%Y-%m-%d %H:%M:%S' >> /test_output/gdb.log &
-    sleep 5
-    # gdb will send SIGSTOP, spend some time loading debug info and then send SIGCONT, wait for it (up to send_timeout, 300s)
-    time clickhouse-client --query "SELECT 'Connected to clickhouse-server after attaching gdb'" ||:
+    attach_gdb_to_clickhouse
 }
 
 function check_server_start()

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -349,9 +349,10 @@ def kill_gdb_if_any():
     for i in range(5):
         code = subprocess.call("kill -TERM $(pidof gdb)", shell=True, timeout=30)
         if code != 0:
-            time.sleep(i)
+            sleep(i)
         else:
             break
+
 
 # collect server stacktraces using gdb
 def get_stacktraces_from_gdb(server_pid):

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -340,9 +340,14 @@ def get_transactions_list(args):
         return f"Cannot get list of transactions: {e}"
 
 
-def kill_gdb():
+def kill_gdb_if_any():
+    # Check if we have running gdb.
+    code = subprocess.call("pidof gdb", shell=True)
+    if code != 0:
+        return
+
     for i in range(5):
-        code = subprocess.call("kill -TERM $(pidof gdb)", shell=True, stderr=subprocess.STDOUT, timeout=30)
+        code = subprocess.call("kill -TERM $(pidof gdb)", shell=True, timeout=30)
         if code != 0:
             time.sleep(i)
         else:
@@ -354,7 +359,7 @@ def get_stacktraces_from_gdb(server_pid):
         # We could attach gdb to clickhouse-server before running some tests
         # to print stacktraces of all crashes even if clickhouse cannot print it for some reason.
         # We should kill existing gdb if any before starting new one.
-        kill_gdb()
+        kill_gdb_if_any()
 
         cmd = f"gdb -batch -ex 'thread apply all backtrace' -p {server_pid}"
         return subprocess.check_output(cmd, shell=True).decode("utf-8")

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -340,9 +340,22 @@ def get_transactions_list(args):
         return f"Cannot get list of transactions: {e}"
 
 
+def kill_gdb():
+    for i in range(5):
+        code = subprocess.call("kill -TERM $(pidof gdb)", shell=True, stderr=subprocess.STDOUT, timeout=30)
+        if code != 0:
+            time.sleep(i)
+        else:
+            break
+
 # collect server stacktraces using gdb
 def get_stacktraces_from_gdb(server_pid):
     try:
+        # We could attach gdb to clickhouse-server before running some tests
+        # to print stacktraces of all crashes even if clickhouse cannot print it for some reason.
+        # We should kill existing gdb if any before starting new one.
+        kill_gdb()
+
         cmd = f"gdb -batch -ex 'thread apply all backtrace' -p {server_pid}"
         return subprocess.check_output(cmd, shell=True).decode("utf-8")
     except Exception as e:


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Bug with fibers and tsan stopped reproducing in stress tests, but started in stateless tests where we don't have gdb log with segfault stacktrace. Let's try to attach gdb in stateless tests in this PR and rerun CI until bug reproduces (not sure we want attached gdb in stateless tests in CI, maybe I will add it only for tsan for some time if I won't reproduce it in this PR).
