### PR TITLE
Cleanup moving parts

### DIFF
--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -7864,7 +7864,7 @@ MovePartsOutcome MergeTreeData::moveParts(const CurrentlyMovingPartsTaggerPtr & 
                         if (lock->isLocked())
                         {
                             cloned_part = parts_mover.clonePart(moving_part);
-                            parts_mover.swapClonedPart(cloned_part.part);
+                            parts_mover.swapClonedPart(cloned_part);
                             break;
                         }
                         else if (wait_for_move_if_zero_copy)
@@ -7891,7 +7891,7 @@ MovePartsOutcome MergeTreeData::moveParts(const CurrentlyMovingPartsTaggerPtr & 
             else /// Ordinary move as it should be
             {
                 cloned_part = parts_mover.clonePart(moving_part);
-                parts_mover.swapClonedPart(cloned_part.part);
+                parts_mover.swapClonedPart(cloned_part);
             }
             write_part_log({});
         }

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -7898,9 +7898,6 @@ MovePartsOutcome MergeTreeData::moveParts(const CurrentlyMovingPartsTaggerPtr & 
         catch (...)
         {
             write_part_log(ExecutionStatus::fromCurrentException("", true));
-            if (cloned_part.part)
-                cloned_part.part->remove();
-
             throw;
         }
     }

--- a/src/Storages/MergeTree/MergeTreeData.h
+++ b/src/Storages/MergeTree/MergeTreeData.h
@@ -676,6 +676,7 @@ public:
     /// Delete all directories which names begin with "tmp"
     /// Must be called with locked lockForShare() because it's using relative_data_path.
     size_t clearOldTemporaryDirectories(size_t custom_directories_lifetime_seconds, const NameSet & valid_prefixes = {"tmp_", "tmp-fetch_"});
+    size_t clearOldTemporaryDirectories(const String & root_path, size_t custom_directories_lifetime_seconds, const NameSet & valid_prefixes);
 
     size_t clearEmptyParts();
 

--- a/src/Storages/MergeTree/MergeTreeData.h
+++ b/src/Storages/MergeTree/MergeTreeData.h
@@ -1060,6 +1060,9 @@ public:
     void waitForOutdatedPartsToBeLoaded() const;
     bool canUsePolymorphicParts() const;
 
+    /// TODO: make enabled by default in the next release if no problems found.
+    bool allowRemoveStaleMovingParts() const;
+
 protected:
     friend class IMergeTreeDataPart;
     friend class MergeTreeDataMergerMutator;

--- a/src/Storages/MergeTree/MergeTreePartsMover.cpp
+++ b/src/Storages/MergeTree/MergeTreePartsMover.cpp
@@ -255,10 +255,10 @@ MergeTreePartsMover::TemporaryClonedPart MergeTreePartsMover::clonePart(const Me
 
     LOG_TRACE(log, "Part {} was cloned to {}", part->name, data_part_directory);
 
+    cloned_part.part->is_temp = true;
     cloned_part.part->loadColumnsChecksumsIndexes(true, true);
     cloned_part.part->loadVersionMetadata();
     cloned_part.part->modification_time = cloned_part.part->getDataPartStorage().getLastModified().epochTime();
-    cloned_part.part->is_temp = true;
     return cloned_part;
 }
 

--- a/src/Storages/MergeTree/MergeTreePartsMover.cpp
+++ b/src/Storages/MergeTree/MergeTreePartsMover.cpp
@@ -250,7 +250,7 @@ MergeTreePartsMover::TemporaryClonedPart MergeTreePartsMover::clonePart(const Me
     cloned_part.part = std::move(builder).withPartFormatFromDisk().build();
     LOG_TRACE(log, "Part {} was cloned to {}", part->name, cloned_part.part->getDataPartStorage().getFullPath());
 
-    cloned_part.part->is_temp = true;
+    cloned_part.part->is_temp = data->allowRemoveStaleMovingParts();
     cloned_part.part->loadColumnsChecksumsIndexes(true, true);
     cloned_part.part->loadVersionMetadata();
     cloned_part.part->modification_time = cloned_part.part->getDataPartStorage().getLastModified().epochTime();
@@ -270,10 +270,11 @@ void MergeTreePartsMover::swapClonedPart(TemporaryClonedPart & cloned_part) cons
     {
         LOG_INFO(log,
             "Failed to swap {}. Active part doesn't exist (containing part {}). "
-            "Possible it was merged or mutated. Will remove copy on path '{}'",
+            "Possible it was merged or mutated. Part on path '{}' {}",
             cloned_part.part->name,
             active_part ? active_part->name : "doesn't exist",
-            cloned_part.part->getDataPartStorage().getFullPath());
+            cloned_part.part->getDataPartStorage().getFullPath(),
+            data->allowRemoveStaleMovingParts() ? "will be removed" : "will remain intact (set <allow_remove_stale_moving_parts> in config.xml, exercise caution when using)");
         return;
     }
 

--- a/src/Storages/MergeTree/MergeTreePartsMover.h
+++ b/src/Storages/MergeTree/MergeTreePartsMover.h
@@ -72,7 +72,7 @@ public:
     /// IMergeTreeDataPart called. If replacing part doesn't exists or not active (committed) than
     /// cloned part will be removed and log message will be reported. It may happen in case of concurrent
     /// merge or mutation.
-    void swapClonedPart(const MergeTreeMutableDataPartPtr & cloned_parts) const;
+    void swapClonedPart(TemporaryClonedPart & cloned_part) const;
 
     /// Can stop background moves and moves from queries
     ActionBlocker moves_blocker;

--- a/tests/integration/test_alter_moving_garbage/configs/config.d/remote_servers.xml
+++ b/tests/integration/test_alter_moving_garbage/configs/config.d/remote_servers.xml
@@ -1,0 +1,16 @@
+<clickhouse>
+    <remote_servers>
+        <test_cluster>
+            <shard>
+                <replica>
+                    <host>node1</host>
+                    <port>9000</port>
+                </replica>
+                <replica>
+                    <host>node2</host>
+                    <port>9000</port>
+                </replica>
+            </shard>
+        </test_cluster>
+    </remote_servers>
+</clickhouse>

--- a/tests/integration/test_alter_moving_garbage/configs/config.d/storage_conf.xml
+++ b/tests/integration/test_alter_moving_garbage/configs/config.d/storage_conf.xml
@@ -1,0 +1,26 @@
+<clickhouse>
+    <!-- allow_remote_fs_zero_copy_replication -->
+
+    <storage_configuration>
+        <disks>
+            <s3>
+                <type>s3</type>
+                <endpoint>http://minio1:9001/root/data/</endpoint>
+                <access_key_id>minio</access_key_id>
+                <secret_access_key>minio123</secret_access_key>
+            </s3>
+        </disks>
+        <policies>
+            <two_disks>
+                <volumes>
+                    <default>
+                        <disk>default</disk>
+                    </default>
+                    <external>
+                        <disk>s3</disk>
+                    </external>
+                </volumes>
+            </two_disks>
+        </policies>
+    </storage_configuration>
+</clickhouse>

--- a/tests/integration/test_alter_moving_garbage/configs/config.d/storage_conf.xml
+++ b/tests/integration/test_alter_moving_garbage/configs/config.d/storage_conf.xml
@@ -1,6 +1,4 @@
 <clickhouse>
-    <!-- allow_remote_fs_zero_copy_replication -->
-
     <storage_configuration>
         <disks>
             <s3>

--- a/tests/integration/test_alter_moving_garbage/configs/config.d/storage_conf.xml
+++ b/tests/integration/test_alter_moving_garbage/configs/config.d/storage_conf.xml
@@ -21,4 +21,6 @@
             </two_disks>
         </policies>
     </storage_configuration>
+
+    <allow_remove_stale_moving_parts>true</allow_remove_stale_moving_parts>
 </clickhouse>

--- a/tests/integration/test_alter_moving_garbage/configs/config.xml
+++ b/tests/integration/test_alter_moving_garbage/configs/config.xml
@@ -1,0 +1,7 @@
+<clickhouse>
+    <tcp_port>9000</tcp_port>
+    <listen_host>127.0.0.1</listen_host>
+    <max_concurrent_queries>500</max_concurrent_queries>
+    <path>./clickhouse/</path>
+    <users_config>users.xml</users_config>
+</clickhouse>

--- a/tests/integration/test_alter_moving_garbage/test.py
+++ b/tests/integration/test_alter_moving_garbage/test.py
@@ -1,0 +1,90 @@
+import logging
+import time
+
+import pytest
+import threading
+
+from helpers.client import QueryRuntimeException
+from helpers.cluster import ClickHouseCluster
+
+
+@pytest.fixture(scope="module")
+def cluster():
+    try:
+        cluster = ClickHouseCluster(__file__)
+        cluster.add_instance(
+            "node1",
+            main_configs=[
+                "configs/config.d/storage_conf.xml",
+            ],
+            with_minio=True,
+        )
+        logging.info("Starting cluster...")
+        cluster.start()
+        logging.info("Cluster started")
+
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def create_table(node, table_name, **additional_settings):
+    settings = {
+        "storage_policy": "two_disks",
+        "old_parts_lifetime": 1,
+        "index_granularity": 512,
+        "temporary_directories_lifetime": 0,
+        "merge_tree_clear_old_temporary_directories_interval_seconds": 1,
+    }
+    settings.update(additional_settings)
+
+    create_table_statement = f"""
+        CREATE TABLE {table_name} (
+            dt Date,
+            id Int64,
+            data String,
+            INDEX min_max (id) TYPE minmax GRANULARITY 3
+        ) ENGINE=MergeTree()
+        PARTITION BY dt
+        ORDER BY (dt, id)
+        SETTINGS {",".join((k+"="+repr(v) for k, v in settings.items()))}"""
+
+    node.query(create_table_statement)
+
+
+def test_create_table(cluster):
+    node = cluster.instances["node1"]
+    create_table(node, "test_table")
+    node.query(
+        "INSERT INTO test_table SELECT toDate('2021-01-01') + INTERVAL number % 10 DAY, number, toString(sipHash64(number)) FROM numbers(100_000)"
+    )
+
+    stop_alter = False
+
+    def alter():
+        d = 0
+        node.query(f"ALTER TABLE test_table ADD COLUMN col0 String")
+        while not stop_alter:
+            d = d + 1
+            node.query(f"DELETE FROM test_table WHERE id < {d}")
+            time.sleep(0.1)
+
+    alter_thread = threading.Thread(target=alter)
+    alter_thread.start()
+
+    for i in range(1, 10):
+        partition = f"2021-01-{i:02d}"
+        try:
+            node.query(
+                f"ALTER TABLE test_table MOVE PARTITION '{partition}' TO DISK 's3'",
+            )
+        except QueryRuntimeException as e:
+            # PART_IS_TEMPORARILY_LOCKED
+            assert 384 == e.returncode
+            continue
+
+        # clear old temporary directories wakes up every 1 second
+        time.sleep(0.5)
+
+    stop_alter = True
+    alter_thread.join()

--- a/tests/integration/test_consistant_parts_after_move_partition/configs/remote_servers.xml
+++ b/tests/integration/test_consistant_parts_after_move_partition/configs/remote_servers.xml
@@ -16,4 +16,5 @@
             </shard>
         </test_cluster>
     </remote_servers>
+    <allow_remove_stale_moving_parts>true</allow_remove_stale_moving_parts>
 </clickhouse>

--- a/tests/integration/test_consistant_parts_after_move_partition/test.py
+++ b/tests/integration/test_consistant_parts_after_move_partition/test.py
@@ -18,7 +18,7 @@ def initialize_database(nodes, shard):
             CREATE TABLE `{database}`.dest (p UInt64, d UInt64)
             ENGINE = ReplicatedMergeTree('/clickhouse/{database}/tables/test_consistent_shard2{shard}/replicated', '{replica}')
             ORDER BY d PARTITION BY p
-            SETTINGS min_replicated_logs_to_keep=3, max_replicated_logs_to_keep=5, cleanup_delay_period=0, cleanup_delay_period_random_add=0;
+            SETTINGS min_replicated_logs_to_keep=3, max_replicated_logs_to_keep=5, cleanup_delay_period=0, cleanup_delay_period_random_add=0, temporary_directories_lifetime=1;
         """.format(
                 shard=shard, replica=node.name, database=CLICKHOUSE_DATABASE
             )

--- a/tests/integration/test_encrypted_disk/configs/storage.xml
+++ b/tests/integration/test_encrypted_disk/configs/storage.xml
@@ -105,4 +105,5 @@
             </s3_encrypted_cache_policy>
          </policies>
     </storage_configuration>
+    <allow_remove_stale_moving_parts>true</allow_remove_stale_moving_parts>
 </clickhouse>

--- a/tests/integration/test_encrypted_disk/test.py
+++ b/tests/integration/test_encrypted_disk/test.py
@@ -96,7 +96,7 @@ def test_part_move(policy, destination_disks):
             data String
         ) ENGINE=MergeTree()
         ORDER BY id
-        SETTINGS storage_policy='{}'
+        SETTINGS storage_policy='{}', temporary_directories_lifetime=1
         """.format(
             policy
         )

--- a/tests/integration/test_merge_tree_azure_blob_storage/configs/config.xml
+++ b/tests/integration/test_merge_tree_azure_blob_storage/configs/config.xml
@@ -15,4 +15,5 @@
     <max_concurrent_queries>500</max_concurrent_queries>
     <path>./clickhouse/</path>
     <users_config>users.xml</users_config>
+    <allow_remove_stale_moving_parts>true</allow_remove_stale_moving_parts>
 </clickhouse>

--- a/tests/integration/test_merge_tree_azure_blob_storage/test.py
+++ b/tests/integration/test_merge_tree_azure_blob_storage/test.py
@@ -66,6 +66,7 @@ def create_table(node, table_name, **additional_settings):
         "storage_policy": "blob_storage_policy",
         "old_parts_lifetime": 1,
         "index_granularity": 512,
+        "temporary_directories_lifetime": 1,
     }
     settings.update(additional_settings)
 

--- a/tests/integration/test_merge_tree_hdfs/configs/config.d/storage_conf.xml
+++ b/tests/integration/test_merge_tree_hdfs/configs/config.d/storage_conf.xml
@@ -29,4 +29,5 @@
     <merge_tree>
         <min_bytes_for_wide_part>0</min_bytes_for_wide_part>
     </merge_tree>
+    <allow_remove_stale_moving_parts>true</allow_remove_stale_moving_parts>
 </clickhouse>

--- a/tests/integration/test_merge_tree_hdfs/test.py
+++ b/tests/integration/test_merge_tree_hdfs/test.py
@@ -29,7 +29,8 @@ def create_table(cluster, table_name, additional_settings=None):
         SETTINGS
             storage_policy='hdfs',
             old_parts_lifetime=0,
-            index_granularity=512
+            index_granularity=512,
+            temporary_directories_lifetime=1
         """.format(
         table_name
     )

--- a/tests/integration/test_merge_tree_s3/configs/config.xml
+++ b/tests/integration/test_merge_tree_s3/configs/config.xml
@@ -8,4 +8,5 @@
     </s3>
 
     <enable_system_unfreeze>true</enable_system_unfreeze>
+    <allow_remove_stale_moving_parts>true</allow_remove_stale_moving_parts>
 </clickhouse>

--- a/tests/integration/test_merge_tree_s3/test.py
+++ b/tests/integration/test_merge_tree_s3/test.py
@@ -75,6 +75,7 @@ def create_table(node, table_name, **additional_settings):
         "storage_policy": "s3",
         "old_parts_lifetime": 0,
         "index_granularity": 512,
+        "temporary_directories_lifetime": 1,
     }
     settings.update(additional_settings)
 

--- a/tests/integration/test_move_partition_to_disk_on_cluster/configs/config.d/storage_configuration.xml
+++ b/tests/integration/test_move_partition_to_disk_on_cluster/configs/config.d/storage_configuration.xml
@@ -24,5 +24,6 @@
     </policies>
 
 </storage_configuration>
+<allow_remove_stale_moving_parts>true</allow_remove_stale_moving_parts>
 
 </clickhouse>

--- a/tests/integration/test_move_partition_to_disk_on_cluster/test.py
+++ b/tests/integration/test_move_partition_to_disk_on_cluster/test.py
@@ -46,7 +46,7 @@ def test_move_partition_to_disk_on_cluster(start_cluster):
             "(x UInt64) "
             "ENGINE=ReplicatedMergeTree('/clickhouse/tables/test_local_table', '{replica}') "
             "ORDER BY tuple()"
-            "SETTINGS storage_policy = 'jbod_with_external';",
+            "SETTINGS storage_policy = 'jbod_with_external', temporary_directories_lifetime=1;",
         )
 
     node1.query("INSERT INTO test_local_table VALUES (0)")

--- a/tests/integration/test_multiple_disks/configs/config.d/storage_configuration.xml
+++ b/tests/integration/test_multiple_disks/configs/config.d/storage_configuration.xml
@@ -123,4 +123,8 @@
 
 </storage_configuration>
 
+<merge_tree>
+    <temporary_directories_lifetime>1</temporary_directories_lifetime>
+</merge_tree>
+
 </clickhouse>

--- a/tests/integration/test_multiple_disks/configs/config.d/storage_configuration.xml
+++ b/tests/integration/test_multiple_disks/configs/config.d/storage_configuration.xml
@@ -122,6 +122,7 @@
     </policies>
 
 </storage_configuration>
+<allow_remove_stale_moving_parts>true</allow_remove_stale_moving_parts>
 
 <merge_tree>
     <temporary_directories_lifetime>1</temporary_directories_lifetime>

--- a/tests/integration/test_rename_column/configs/config.d/storage_configuration.xml
+++ b/tests/integration/test_rename_column/configs/config.d/storage_configuration.xml
@@ -29,5 +29,6 @@
     <min_bytes_for_wide_part>0</min_bytes_for_wide_part>
     <temporary_directories_lifetime>1</temporary_directories_lifetime>
 </merge_tree>
+<allow_remove_stale_moving_parts>true</allow_remove_stale_moving_parts>
 
 </clickhouse>

--- a/tests/integration/test_rename_column/configs/config.d/storage_configuration.xml
+++ b/tests/integration/test_rename_column/configs/config.d/storage_configuration.xml
@@ -24,9 +24,10 @@
         </default_with_external>
     </policies>
 </storage_configuration>
-    
+
 <merge_tree>
     <min_bytes_for_wide_part>0</min_bytes_for_wide_part>
+    <temporary_directories_lifetime>1</temporary_directories_lifetime>
 </merge_tree>
 
 </clickhouse>

--- a/tests/integration/test_replicated_merge_tree_hdfs_zero_copy/configs/config.d/storage_conf.xml
+++ b/tests/integration/test_replicated_merge_tree_hdfs_zero_copy/configs/config.d/storage_conf.xml
@@ -89,4 +89,5 @@
         <cluster>test_cluster</cluster>
         <shard>1</shard>
     </macros>
+    <allow_remove_stale_moving_parts>true</allow_remove_stale_moving_parts>
 </clickhouse>

--- a/tests/integration/test_replicated_merge_tree_hdfs_zero_copy/test.py
+++ b/tests/integration/test_replicated_merge_tree_hdfs_zero_copy/test.py
@@ -128,7 +128,7 @@ def test_hdfs_zero_copy_replication_single_move(cluster, storage_policy, init_ob
             CREATE TABLE single_node_move_test (dt DateTime, id Int64)
             ENGINE=ReplicatedMergeTree('/clickhouse/tables/{cluster}/{shard}/single_node_move_test', '{replica}')
             ORDER BY (dt, id)
-            SETTINGS storage_policy='$policy'
+            SETTINGS storage_policy='$policy',temporary_directories_lifetime=1
             """
             ).substitute(policy=storage_policy)
         )

--- a/tests/integration/test_s3_zero_copy_replication/configs/config.d/s3.xml
+++ b/tests/integration/test_s3_zero_copy_replication/configs/config.d/s3.xml
@@ -93,4 +93,5 @@
         <cluster>test_cluster</cluster>
     </macros>
 
+    <allow_remove_stale_moving_parts>true</allow_remove_stale_moving_parts>
 </clickhouse>

--- a/tests/integration/test_s3_zero_copy_replication/test.py
+++ b/tests/integration/test_s3_zero_copy_replication/test.py
@@ -163,7 +163,7 @@ def test_s3_zero_copy_on_hybrid_storage(started_cluster):
         CREATE TABLE hybrid_test ON CLUSTER test_cluster (id UInt32, value String)
         ENGINE=ReplicatedMergeTree('/clickhouse/tables/hybrid_test', '{}')
         ORDER BY id
-        SETTINGS storage_policy='hybrid'
+        SETTINGS storage_policy='hybrid',temporary_directories_lifetime=1
         """.format(
             "{replica}"
         )

--- a/tests/integration/test_ttl_move/configs/config.d/storage_configuration.xml
+++ b/tests/integration/test_ttl_move/configs/config.d/storage_configuration.xml
@@ -107,4 +107,5 @@
 
 </storage_configuration>
 
+<allow_remove_stale_moving_parts>true</allow_remove_stale_moving_parts>
 </clickhouse>

--- a/tests/integration/test_ttl_move/test.py
+++ b/tests/integration/test_ttl_move/test.py
@@ -1549,7 +1549,7 @@ def test_double_move_while_select(started_cluster, name, positive):
             ) ENGINE = MergeTree
             ORDER BY tuple()
             PARTITION BY n
-            SETTINGS storage_policy='small_jbod_with_external'
+            SETTINGS storage_policy='small_jbod_with_external',temporary_directories_lifetime=1
         """.format(
                 name=name
             )

--- a/tests/integration/test_zero_copy_fetch/configs/storage_conf.xml
+++ b/tests/integration/test_zero_copy_fetch/configs/storage_conf.xml
@@ -38,4 +38,5 @@
     <merge_tree>
         <allow_remote_fs_zero_copy_replication>true</allow_remote_fs_zero_copy_replication>
     </merge_tree>
+    <allow_remove_stale_moving_parts>true</allow_remove_stale_moving_parts>
 </clickhouse>

--- a/tests/integration/test_zero_copy_fetch/test.py
+++ b/tests/integration/test_zero_copy_fetch/test.py
@@ -45,7 +45,7 @@ CREATE TABLE test1 (EventDate Date, CounterID UInt32)
 ENGINE = ReplicatedMergeTree('/clickhouse-tables/test1', 'r1')
 PARTITION BY toMonday(EventDate)
 ORDER BY (CounterID, EventDate)
-SETTINGS index_granularity = 8192, storage_policy = 's3'"""
+SETTINGS index_granularity = 8192, storage_policy = 's3', temporary_directories_lifetime=1"""
     )
 
     node1.query(


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):

- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
* Clean moving parts that was merged or mutated during move

#### TODO:

- [x] Try to add stress tests. I managed to reproduce locally but not sure if tests would be stable enough and what to check (probably `system.remote_data_paths`)