### PR TITLE
Make typeid_cast for pointers noexcept

### DIFF
--- a/src/Common/typeid_cast.h
+++ b/src/Common/typeid_cast.h
@@ -25,14 +25,14 @@ namespace DB
   */
 template <typename To, typename From>
 requires std::is_reference_v<To>
-To typeid_cast(From & from)
+To typeid_cast(From & from) noexcept(false)
 {
     try
     {
         if ((typeid(From) == typeid(To)) || (typeid(from) == typeid(To)))
             return static_cast<To>(from);
     }
-    catch (const std::exception & e)
+    catch (const std::bad_typeid & e)
     {
         throw DB::Exception::createDeprecated(e.what(), DB::ErrorCodes::LOGICAL_ERROR);
     }
@@ -44,19 +44,12 @@ To typeid_cast(From & from)
 
 template <typename To, typename From>
 requires std::is_pointer_v<To>
-To typeid_cast(From * from)
+To typeid_cast(From * from) noexcept
 {
-    try
-    {
-        if ((typeid(From) == typeid(std::remove_pointer_t<To>)) || (from && typeid(*from) == typeid(std::remove_pointer_t<To>)))
-            return static_cast<To>(from);
-        else
-            return nullptr;
-    }
-    catch (const std::exception & e)
-    {
-        throw DB::Exception::createDeprecated(e.what(), DB::ErrorCodes::LOGICAL_ERROR);
-    }
+    if ((typeid(From) == typeid(std::remove_pointer_t<To>)) || (from && typeid(*from) == typeid(std::remove_pointer_t<To>)))
+        return static_cast<To>(from);
+    else
+        return nullptr;
 }
 
 namespace detail
@@ -79,17 +72,10 @@ inline constexpr bool is_shared_ptr_v = is_shared_ptr<T>::value;
 
 template <typename To, typename From>
 requires detail::is_shared_ptr_v<To>
-To typeid_cast(const std::shared_ptr<From> & from)
+To typeid_cast(const std::shared_ptr<From> & from) noexcept
 {
-    try
-    {
-        if ((typeid(From) == typeid(typename To::element_type)) || (from && typeid(*from) == typeid(typename To::element_type)))
-            return std::static_pointer_cast<typename To::element_type>(from);
-        else
-            return nullptr;
-    }
-    catch (const std::exception & e)
-    {
-        throw DB::Exception::createDeprecated(e.what(), DB::ErrorCodes::LOGICAL_ERROR);
-    }
+    if ((typeid(From) == typeid(typename To::element_type)) || (from && typeid(*from) == typeid(typename To::element_type)))
+        return std::static_pointer_cast<typename To::element_type>(from);
+    else
+        return nullptr;
 }

--- a/src/Common/typeid_cast.h
+++ b/src/Common/typeid_cast.h
@@ -27,15 +27,8 @@ template <typename To, typename From>
 requires std::is_reference_v<To>
 To typeid_cast(From & from) noexcept(false)
 {
-    try
-    {
-        if ((typeid(From) == typeid(To)) || (typeid(from) == typeid(To)))
-            return static_cast<To>(from);
-    }
-    catch (const std::bad_typeid & e)
-    {
-        throw DB::Exception::createDeprecated(e.what(), DB::ErrorCodes::LOGICAL_ERROR);
-    }
+    if ((typeid(From) == typeid(To)) || (typeid(from) == typeid(To)))
+        return static_cast<To>(from);
 
     throw DB::Exception(DB::ErrorCodes::LOGICAL_ERROR, "Bad cast from type {} to {}",
                         demangle(typeid(from).name()), demangle(typeid(To).name()));


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Motivation:

While performing static analysis of the ClickHouse code using [the Svace analyzer](https://www.ispras.ru/en/technologies/svace/), I encountered the frequently used function `typeid_cast`. During the analysis, I noticed that the implementation of this function has an exception handler for pointers. However, based on the standard [[expr.typeid]](https://eel.is/c++draft/expr.typeid#3), an exception can only be thrown in this context if the `typeid` operator is applied to `nullptr`. Since the function body already includes a check and dereference of the pointer, an exception will not actually occur. Hence, it is safe to make the cast `noexcept`.

**UPD:** Exceptions also cannot be thrown from the impl of cast for references as specified by [expr.typeid].

By making this change, we can align the implementation with the intended behavior. Please consider accepting this pull request to enhance the typeid_cast function in ClickHouse.

Thank you.
