### PR TITLE
Implement endianness-independent serialization for UUID

### DIFF
--- a/src/DataTypes/Serializations/SerializationUUID.cpp
+++ b/src/DataTypes/Serializations/SerializationUUID.cpp
@@ -51,7 +51,7 @@ void SerializationUUID::deserializeTextQuoted(IColumn & column, ReadBuffer & ist
     {
         assertChar('\'', istr);
         char * next_pos = find_first_symbols<'\\', '\''>(istr.position(), istr.buffer().end());
-        const auto len = next_pos - istr.position();
+        const size_t len = next_pos - istr.position();
         if ((len == 32 || len == 36) && istr.position()[len] == '\'')
         {
             uuid = parseUUID(std::span(reinterpret_cast<const UInt8 *>(istr.position()), len));

--- a/src/DataTypes/Serializations/SerializationUUID.cpp
+++ b/src/DataTypes/Serializations/SerializationUUID.cpp
@@ -51,19 +51,11 @@ void SerializationUUID::deserializeTextQuoted(IColumn & column, ReadBuffer & ist
     {
         assertChar('\'', istr);
         char * next_pos = find_first_symbols<'\\', '\''>(istr.position(), istr.buffer().end());
-        size_t len = next_pos - istr.position();
-        if ((len == 32) && (istr.position()[32] == '\''))
+        const auto len = next_pos - istr.position();
+        if ((len == 32 || len == 36) && istr.position()[len] == '\'')
         {
-            parseUUIDWithoutSeparator(
-                reinterpret_cast<const UInt8 *>(istr.position()), std::reverse_iterator<UInt8 *>(reinterpret_cast<UInt8 *>(&uuid) + 16));
-            istr.ignore(33);
-            fast = true;
-        }
-        else if ((len == 36) && (istr.position()[36] == '\''))
-        {
-            parseUUID(
-                reinterpret_cast<const UInt8 *>(istr.position()), std::reverse_iterator<UInt8 *>(reinterpret_cast<UInt8 *>(&uuid) + 16));
-            istr.ignore(37);
+            uuid = parseUUID(std::span(reinterpret_cast<const UInt8 *>(istr.position()), len));
+            istr.ignore(len + 1);
             fast = true;
         }
         else

--- a/src/IO/ReadHelpers.cpp
+++ b/src/IO/ReadHelpers.cpp
@@ -46,48 +46,40 @@ inline void parseHex(IteratorSrc src, IteratorDst dst)
         dst[dst_pos] = unhex2(reinterpret_cast<const char *>(&src[src_pos]));
 }
 
-void parseUUID(const UInt8 * src36, UInt8 * dst16)
+UUID parseUUID(std::span<const UInt8> src)
 {
-    /// If string is not like UUID - implementation specific behaviour.
+    UUID uuid;
+    const auto * src_ptr = src.data();
+    auto * dst = reinterpret_cast<UInt8 *>(&uuid);
+    if (const auto size = src.size(); size == 36)
+    {
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+        parseHex<4>(src_ptr, dst);
+        parseHex<2>(src_ptr + 9, dst + 4);
+        parseHex<2>(src_ptr + 14, dst + 6);
+        parseHex<2>(src_ptr + 19, dst + 8);
+        parseHex<6>(src_ptr + 24, dst + 10);
+#else
+        const std::reverse_iterator dst_it(dst + sizeof(UUID));
+        /// FIXME This code looks like trash.
+        parseHex<4>(src_ptr, dst + 8);
+        parseHex<2>(src_ptr + 9, dst + 12);
+        parseHex<2>(src_ptr + 14, dst + 14);
+        parseHex<2>(src_ptr + 19, dst);
+        parseHex<6>(src_ptr + 24, dst + 2);
+#endif
+    }
+    else if (size == 32)
+    {
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+        parseHex<16>(src_ptr, dst);
+#else
+        parseHex<8>(src_ptr, dst + 8);
+        parseHex<8>(src_ptr + 16, dst);
+#endif
+    }
 
-    parseHex<4>(&src36[0], &dst16[0]);
-    parseHex<2>(&src36[9], &dst16[4]);
-    parseHex<2>(&src36[14], &dst16[6]);
-    parseHex<2>(&src36[19], &dst16[8]);
-    parseHex<6>(&src36[24], &dst16[10]);
-}
-
-void parseUUIDWithoutSeparator(const UInt8 * src36, UInt8 * dst16)
-{
-    /// If string is not like UUID - implementation specific behaviour.
-
-    parseHex<16>(&src36[0], &dst16[0]);
-}
-
-/** Function used when byte ordering is important when parsing uuid
- *  ex: When we create an UUID type
- */
-void parseUUID(const UInt8 * src36, std::reverse_iterator<UInt8 *> dst16)
-{
-    /// If string is not like UUID - implementation specific behaviour.
-
-    /// FIXME This code looks like trash.
-    parseHex<4>(&src36[0], dst16 + 8);
-    parseHex<2>(&src36[9], dst16 + 12);
-    parseHex<2>(&src36[14], dst16 + 14);
-    parseHex<2>(&src36[19], dst16);
-    parseHex<6>(&src36[24], dst16 + 2);
-}
-
-/** Function used when byte ordering is important when parsing uuid
- *  ex: When we create an UUID type
- */
-void parseUUIDWithoutSeparator(const UInt8 * src36, std::reverse_iterator<UInt8 *> dst16)
-{
-    /// If string is not like UUID - implementation specific behaviour.
-
-    parseHex<8>(&src36[0], dst16 + 8);
-    parseHex<8>(&src36[16], dst16);
+    return uuid;
 }
 
 void NO_INLINE throwAtAssertionFailed(const char * s, ReadBuffer & buf)

--- a/src/IO/ReadHelpers.cpp
+++ b/src/IO/ReadHelpers.cpp
@@ -53,15 +53,18 @@ UUID parseUUID(std::span<const UInt8> src)
     const auto * src_ptr = src.data();
     auto * dst = reinterpret_cast<UInt8 *>(&uuid);
     const auto size = src.size();
+
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+    const std::reverse_iterator dst_it(dst + sizeof(UUID));
+#endif
     if (size == 36)
     {
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
-        const std::reverse_iterator dst_it(dst + sizeof(UUID));
-        parseHex<4>(src_ptr, dst + 8);
-        parseHex<2>(src_ptr + 9, dst + 12);
-        parseHex<2>(src_ptr + 14, dst + 14);
-        parseHex<2>(src_ptr + 19, dst);
-        parseHex<6>(src_ptr + 24, dst + 2);
+        parseHex<4>(src_ptr, dst_it + 8);
+        parseHex<2>(src_ptr + 9, dst_it + 12);
+        parseHex<2>(src_ptr + 14, dst_it + 14);
+        parseHex<2>(src_ptr + 19, dst_it);
+        parseHex<6>(src_ptr + 24, dst_it + 2);
 #else
         parseHex<4>(src_ptr, dst);
         parseHex<2>(src_ptr + 9, dst + 4);
@@ -73,8 +76,8 @@ UUID parseUUID(std::span<const UInt8> src)
     else if (size == 32)
     {
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
-        parseHex<8>(src_ptr, dst + 8);
-        parseHex<8>(src_ptr + 16, dst);
+        parseHex<8>(src_ptr, dst_it + 8);
+        parseHex<8>(src_ptr + 16, dst_it);
 #else
         parseHex<16>(src_ptr, dst);
 #endif

--- a/src/IO/ReadHelpers.h
+++ b/src/IO/ReadHelpers.h
@@ -8,6 +8,7 @@
 #include <algorithm>
 #include <iterator>
 #include <bit>
+#include <span>
 
 #include <type_traits>
 
@@ -623,12 +624,6 @@ struct NullOutput
     void push_back(char) {} /// NOLINT
 };
 
-void parseUUID(const UInt8 * src36, UInt8 * dst16);
-void parseUUIDWithoutSeparator(const UInt8 * src36, UInt8 * dst16);
-void parseUUID(const UInt8 * src36, std::reverse_iterator<UInt8 *> dst16);
-void parseUUIDWithoutSeparator(const UInt8 * src36, std::reverse_iterator<UInt8 *> dst16);
-
-
 template <typename ReturnType>
 ReturnType readDateTextFallback(LocalDate & date, ReadBuffer & buf);
 
@@ -770,6 +765,9 @@ inline bool tryReadDateText(ExtendedDayNum & date, ReadBuffer & buf)
     return readDateTextImpl<bool>(date, buf);
 }
 
+/// If string is not like UUID - implementation specific behaviour.
+UUID parseUUID(std::span<const UInt8> src);
+
 template <typename ReturnType = void>
 inline ReturnType readUUIDTextImpl(UUID & uuid, ReadBuffer & buf)
 {
@@ -797,12 +795,9 @@ inline ReturnType readUUIDTextImpl(UUID & uuid, ReadBuffer & buf)
                     return ReturnType(false);
                 }
             }
-
-            parseUUID(reinterpret_cast<const UInt8 *>(s), std::reverse_iterator<UInt8 *>(reinterpret_cast<UInt8 *>(&uuid) + 16));
         }
-        else
-            parseUUIDWithoutSeparator(reinterpret_cast<const UInt8 *>(s), std::reverse_iterator<UInt8 *>(reinterpret_cast<UInt8 *>(&uuid) + 16));
 
+        uuid = parseUUID({reinterpret_cast<const UInt8 *>(s), size});
         return ReturnType(true);
     }
     else

--- a/src/IO/ReadHelpers.h
+++ b/src/IO/ReadHelpers.h
@@ -765,7 +765,6 @@ inline bool tryReadDateText(ExtendedDayNum & date, ReadBuffer & buf)
     return readDateTextImpl<bool>(date, buf);
 }
 
-/// If string is not like UUID - implementation specific behaviour.
 UUID parseUUID(std::span<const UInt8> src);
 
 template <typename ReturnType = void>

--- a/src/IO/WriteHelpers.cpp
+++ b/src/IO/WriteHelpers.cpp
@@ -23,17 +23,35 @@ void formatHex(IteratorSrc src, IteratorDst dst, size_t num_bytes)
 /** Function used when byte ordering is important when parsing uuid
  *  ex: When we create an UUID type
  */
-void formatUUID(std::reverse_iterator<const UInt8 *> src16, UInt8 * dst36)
+std::array<char, 36> formatUUID(const UUID & uuid)
 {
-    formatHex(src16 + 8, &dst36[0], 4);
-    dst36[8] = '-';
-    formatHex(src16 + 12, &dst36[9], 2);
-    dst36[13] = '-';
-    formatHex(src16 + 14, &dst36[14], 2);
-    dst36[18] = '-';
-    formatHex(src16, &dst36[19], 2);
-    dst36[23] = '-';
-    formatHex(src16 + 2, &dst36[24], 6);
+    std::array<char, 36> dst;
+    const auto * src_ptr = reinterpret_cast<const UInt8 *>(&uuid);
+    auto * dst_ptr = dst.data();
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+    formatHex(src_ptr, dst_ptr, 4);
+    dst[8] = '-';
+    formatHex(src_ptr + 4, dst_ptr + 9, 2);
+    dst[13] = '-';
+    formatHex(src_ptr + 6, dst_ptr + 14, 2);
+    dst[18] = '-';
+    formatHex(src_ptr + 8, dst_ptr + 19, 2);
+    dst[23] = '-';
+    formatHex(src_ptr + 10, dst_ptr + 24, 6);
+#else
+    const std::reverse_iterator src_it(src_ptr + 16);
+    formatHex(src_it + 8, dst_ptr, 4);
+    dst[8] = '-';
+    formatHex(src_it + 12, dst_ptr + 9, 2);
+    dst[13] = '-';
+    formatHex(src_it + 14, dst_ptr + 14, 2);
+    dst[18] = '-';
+    formatHex(src_it, dst_ptr + 19, 2);
+    dst[23] = '-';
+    formatHex(src_it + 2, dst_ptr + 24, 6);
+#endif
+
+    return dst;
 }
 
 void writeIPv4Text(const IPv4 & ip, WriteBuffer & buf)

--- a/src/IO/WriteHelpers.cpp
+++ b/src/IO/WriteHelpers.cpp
@@ -20,25 +20,12 @@ void formatHex(IteratorSrc src, IteratorDst dst, size_t num_bytes)
     }
 }
 
-/** Function used when byte ordering is important when parsing uuid
- *  ex: When we create an UUID type
- */
 std::array<char, 36> formatUUID(const UUID & uuid)
 {
     std::array<char, 36> dst;
     const auto * src_ptr = reinterpret_cast<const UInt8 *>(&uuid);
     auto * dst_ptr = dst.data();
-#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
-    formatHex(src_ptr, dst_ptr, 4);
-    dst[8] = '-';
-    formatHex(src_ptr + 4, dst_ptr + 9, 2);
-    dst[13] = '-';
-    formatHex(src_ptr + 6, dst_ptr + 14, 2);
-    dst[18] = '-';
-    formatHex(src_ptr + 8, dst_ptr + 19, 2);
-    dst[23] = '-';
-    formatHex(src_ptr + 10, dst_ptr + 24, 6);
-#else
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
     const std::reverse_iterator src_it(src_ptr + 16);
     formatHex(src_it + 8, dst_ptr, 4);
     dst[8] = '-';
@@ -49,6 +36,16 @@ std::array<char, 36> formatUUID(const UUID & uuid)
     formatHex(src_it, dst_ptr + 19, 2);
     dst[23] = '-';
     formatHex(src_it + 2, dst_ptr + 24, 6);
+#else
+    formatHex(src_ptr, dst_ptr, 4);
+    dst[8] = '-';
+    formatHex(src_ptr + 4, dst_ptr + 9, 2);
+    dst[13] = '-';
+    formatHex(src_ptr + 6, dst_ptr + 14, 2);
+    dst[18] = '-';
+    formatHex(src_ptr + 8, dst_ptr + 19, 2);
+    dst[23] = '-';
+    formatHex(src_ptr + 10, dst_ptr + 24, 6);
 #endif
 
     return dst;

--- a/src/IO/WriteHelpers.h
+++ b/src/IO/WriteHelpers.h
@@ -625,13 +625,12 @@ inline void writeXMLStringForTextElement(std::string_view s, WriteBuffer & buf)
     writeXMLStringForTextElement(s.data(), s.data() + s.size(), buf);
 }
 
-void formatUUID(std::reverse_iterator<const UInt8 *> src16, UInt8 * dst36);
+std::array<char, 36> formatUUID(const UUID & uuid);
 
 inline void writeUUIDText(const UUID & uuid, WriteBuffer & buf)
 {
-    char s[36];
-    formatUUID(std::reverse_iterator<const UInt8 *>(reinterpret_cast<const UInt8 *>(&uuid) + 16), reinterpret_cast<UInt8 *>(s));
-    buf.write(s, sizeof(s));
+    const auto text = formatUUID(uuid);
+    buf.write(text.data(), text.size());
 }
 
 void writeIPv4Text(const IPv4 & ip, WriteBuffer & buf);

--- a/src/IO/WriteHelpers.h
+++ b/src/IO/WriteHelpers.h
@@ -625,12 +625,15 @@ inline void writeXMLStringForTextElement(std::string_view s, WriteBuffer & buf)
     writeXMLStringForTextElement(s.data(), s.data() + s.size(), buf);
 }
 
+/// @brief Serialize `uuid` into an array of characters in big-endian byte order.
+/// @param uuid UUID to serialize.
+/// @return Array of characters in big-endian byte order.
 std::array<char, 36> formatUUID(const UUID & uuid);
 
 inline void writeUUIDText(const UUID & uuid, WriteBuffer & buf)
 {
-    const auto text = formatUUID(uuid);
-    buf.write(text.data(), text.size());
+    const auto serialized_uuid = formatUUID(uuid);
+    buf.write(serialized_uuid.data(), serialized_uuid.size());
 }
 
 void writeIPv4Text(const IPv4 & ip, WriteBuffer & buf);

--- a/src/Processors/Formats/Impl/AvroRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/AvroRowInputFormat.cpp
@@ -256,7 +256,7 @@ AvroDeserializer::DeserializeFn AvroDeserializer::createDeserializeFn(const avro
                     if (tmp.length() != 36)
                         throw ParsingException(ErrorCodes::CANNOT_PARSE_UUID, "Cannot parse uuid {}", tmp);
 
-                    const auto uuid = parseUUID({reinterpret_cast<const UInt8 *>(tmp.data()), tmp.length()});
+                    const UUID uuid = parseUUID({reinterpret_cast<const UInt8 *>(tmp.data()), tmp.length()});
                     assert_cast<DataTypeUUID::ColumnType &>(column).insertValue(uuid);
                     return true;
                 };

--- a/src/Processors/Formats/Impl/AvroRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/AvroRowInputFormat.cpp
@@ -256,8 +256,7 @@ AvroDeserializer::DeserializeFn AvroDeserializer::createDeserializeFn(const avro
                     if (tmp.length() != 36)
                         throw ParsingException(ErrorCodes::CANNOT_PARSE_UUID, "Cannot parse uuid {}", tmp);
 
-                    UUID uuid;
-                    parseUUID(reinterpret_cast<const UInt8 *>(tmp.data()), std::reverse_iterator<UInt8 *>(reinterpret_cast<UInt8 *>(&uuid) + 16));
+                    const auto uuid = parseUUID({reinterpret_cast<const UInt8 *>(tmp.data()), tmp.length()});
                     assert_cast<DataTypeUUID::ColumnType &>(column).insertValue(uuid);
                     return true;
                 };

--- a/src/Processors/Formats/Impl/AvroRowOutputFormat.cpp
+++ b/src/Processors/Formats/Impl/AvroRowOutputFormat.cpp
@@ -329,8 +329,8 @@ AvroSerializer::SchemaWithSerializeFn AvroSerializer::createSchemaWithSerializeF
             return {schema, [](const IColumn & column, size_t row_num, avro::Encoder & encoder)
             {
                 const auto & uuid = assert_cast<const DataTypeUUID::ColumnType &>(column).getElement(row_num);
-                const auto text = formatUUID(uuid);
-                encoder.encodeBytes(reinterpret_cast<const uint8_t *>(text.data()), text.size());
+                const auto serialized_uuid = formatUUID(uuid);
+                encoder.encodeBytes(reinterpret_cast<const uint8_t *>(serialized_uuid.data()), serialized_uuid.size());
             }};
         }
         case TypeIndex::Array:

--- a/src/Processors/Formats/Impl/AvroRowOutputFormat.cpp
+++ b/src/Processors/Formats/Impl/AvroRowOutputFormat.cpp
@@ -329,9 +329,8 @@ AvroSerializer::SchemaWithSerializeFn AvroSerializer::createSchemaWithSerializeF
             return {schema, [](const IColumn & column, size_t row_num, avro::Encoder & encoder)
             {
                 const auto & uuid = assert_cast<const DataTypeUUID::ColumnType &>(column).getElement(row_num);
-                std::array<UInt8, 36> s;
-                formatUUID(std::reverse_iterator<const UInt8 *>(reinterpret_cast<const UInt8 *>(&uuid) + 16), s.data());
-                encoder.encodeBytes(reinterpret_cast<const uint8_t *>(s.data()), s.size());
+                const auto text = formatUUID(uuid);
+                encoder.encodeBytes(reinterpret_cast<const uint8_t *>(text.data()), text.size());
             }};
         }
         case TypeIndex::Array:


### PR DESCRIPTION
The changes aim to fix functional test `02128_hex_bin_on_uuid` for big-endian platforms. I also did a bit of cleaning up in order to make memory-handling clearer.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)