### PR TITLE
Remove strange object storage methods

### DIFF
--- a/src/Disks/ObjectStorages/AzureBlobStorage/AzureObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/AzureBlobStorage/AzureObjectStorage.cpp
@@ -91,7 +91,9 @@ void AzureObjectStorage::listObjects(const std::string & path, RelativePathsWith
                 blob.Name,
                 ObjectMetadata{
                     static_cast<uint64_t>(blob.BlobSize),
-                    blob.Details.LastModified.time_since_epoch().count(),
+                    Poco::Timestamp::fromEpochTime(
+                        std::chrono::duration_cast<std::chrono::seconds>(
+                            blob.Details.LastModified.time_since_epoch()).count()),
                     {}});
         }
 

--- a/src/Disks/ObjectStorages/AzureBlobStorage/AzureObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/AzureBlobStorage/AzureObjectStorage.cpp
@@ -67,6 +67,49 @@ bool AzureObjectStorage::exists(const StoredObject & object) const
     return false;
 }
 
+void AzureObjectStorage::listObjects(const std::string & path, RelativePathsWithMetadata & children, int max_keys) const
+{
+    auto client_ptr = client.get();
+
+    /// What a shame, no Exists method...
+    Azure::Storage::Blobs::ListBlobsOptions options;
+    options.Prefix = path;
+    if (max_keys)
+        options.PageSizeHint = max_keys;
+    else
+        options.PageSizeHint = settings.get()->list_object_keys_size;
+    Azure::Storage::Blobs::ListBlobsPagedResponse blob_list_response;
+
+    while (true)
+    {
+        blob_list_response = client_ptr->ListBlobs(options);
+        auto blobs_list = blob_list_response.Blobs;
+
+        for (const auto & blob : blobs_list)
+        {
+            children.emplace_back(
+                blob.Name,
+                ObjectMetadata{
+                    static_cast<uint64_t>(blob.BlobSize),
+                    blob.Details.LastModified.time_since_epoch().count(),
+                    {}});
+        }
+
+        if (max_keys)
+        {
+            int keys_left = max_keys - static_cast<int>(children.size());
+            if (keys_left <= 0)
+                break;
+            options.PageSizeHint = keys_left;
+        }
+
+        if (blob_list_response.HasPage())
+            options.ContinuationToken = blob_list_response.NextPageToken;
+        else
+            break;
+    }
+}
+
 std::unique_ptr<ReadBufferFromFileBase> AzureObjectStorage::readObject( /// NOLINT
     const StoredObject & object,
     const ReadSettings & read_settings,
@@ -144,33 +187,6 @@ std::unique_ptr<WriteBufferFromFileBase> AzureObjectStorage::writeObject( /// NO
         settings.get()->max_single_part_upload_size,
         buf_size,
         patchSettings(write_settings));
-}
-
-void AzureObjectStorage::findAllFiles(const std::string & path, RelativePathsWithSize & children, int max_keys) const
-{
-    auto client_ptr = client.get();
-
-    Azure::Storage::Blobs::ListBlobsOptions blobs_list_options;
-    blobs_list_options.Prefix = path;
-    if (max_keys)
-        blobs_list_options.PageSizeHint = max_keys;
-    else
-        blobs_list_options.PageSizeHint = settings.get()->list_object_keys_size;
-
-    auto blobs_list_response = client_ptr->ListBlobs(blobs_list_options);
-    for (;;)
-    {
-        auto blobs_list = blobs_list_response.Blobs;
-
-        for (const auto & blob : blobs_list)
-            children.emplace_back(blob.Name, blob.BlobSize);
-
-        if (max_keys && children.size() >= static_cast<size_t>(max_keys))
-            break;
-        if (!blobs_list_response.HasPage())
-            break;
-        blobs_list_response.MoveToNextPage();
-    }
 }
 
 /// Remove file. Throws exception if file doesn't exists or it's a directory.

--- a/src/Disks/ObjectStorages/AzureBlobStorage/AzureObjectStorage.h
+++ b/src/Disks/ObjectStorages/AzureBlobStorage/AzureObjectStorage.h
@@ -58,6 +58,8 @@ public:
         AzureClientPtr && client_,
         SettingsPtr && settings_);
 
+    void listObjects(const std::string & path, RelativePathsWithMetadata & children, int max_keys) const override;
+
     DataSourceDescription getDataSourceDescription() const override { return data_source_description; }
 
     std::string getName() const override { return "AzureObjectStorage"; }
@@ -83,8 +85,6 @@ public:
         std::optional<ObjectAttributes> attributes = {},
         size_t buf_size = DBMS_DEFAULT_BUFFER_SIZE,
         const WriteSettings & write_settings = {}) override;
-
-    void findAllFiles(const std::string & path, RelativePathsWithSize & children, int max_keys) const override;
 
     /// Remove file. Throws exception if file doesn't exists or it's a directory.
     void removeObject(const StoredObject & object) override;

--- a/src/Disks/ObjectStorages/Cached/CachedObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/Cached/CachedObjectStorage.cpp
@@ -201,9 +201,9 @@ std::unique_ptr<IObjectStorage> CachedObjectStorage::cloneObjectStorage(
     return object_storage->cloneObjectStorage(new_namespace, config, config_prefix, context);
 }
 
-void CachedObjectStorage::findAllFiles(const std::string & path, RelativePathsWithSize & children, int max_keys) const
+void CachedObjectStorage::listObjects(const std::string & path, RelativePathsWithMetadata & children, int max_keys) const
 {
-    object_storage->findAllFiles(path, children, max_keys);
+    object_storage->listObjects(path, children, max_keys);
 }
 
 ObjectMetadata CachedObjectStorage::getObjectMetadata(const std::string & path) const

--- a/src/Disks/ObjectStorages/Cached/CachedObjectStorage.h
+++ b/src/Disks/ObjectStorages/Cached/CachedObjectStorage.h
@@ -71,7 +71,7 @@ public:
         const std::string & config_prefix,
         ContextPtr context) override;
 
-    void findAllFiles(const std::string & path, RelativePathsWithSize & children, int max_keys) const override;
+    void listObjects(const std::string & path, RelativePathsWithMetadata & children, int max_keys) const override;
 
     ObjectMetadata getObjectMetadata(const std::string & path) const override;
 

--- a/src/Disks/ObjectStorages/DiskObjectStorageMetadata.cpp
+++ b/src/Disks/ObjectStorages/DiskObjectStorageMetadata.cpp
@@ -54,7 +54,7 @@ void DiskObjectStorageMetadata::deserialize(ReadBuffer & buf)
         assertChar('\n', buf);
 
         storage_objects[i].relative_path = object_relative_path;
-        storage_objects[i].bytes_size = object_size;
+        storage_objects[i].metadata.size_bytes = object_size;
     }
 
     readIntText(ref_count, buf);
@@ -93,9 +93,9 @@ void DiskObjectStorageMetadata::serialize(WriteBuffer & buf, bool sync) const
     writeIntText(total_size, buf);
     writeChar('\n', buf);
 
-    for (const auto & [object_relative_path, object_size] : storage_objects)
+    for (const auto & [object_relative_path, object_metadata] : storage_objects)
     {
-        writeIntText(object_size, buf);
+        writeIntText(object_metadata.size_bytes, buf);
         writeChar('\t', buf);
         writeEscapedString(object_relative_path, buf);
         writeChar('\n', buf);
@@ -139,7 +139,7 @@ DiskObjectStorageMetadata::DiskObjectStorageMetadata(
 void DiskObjectStorageMetadata::addObject(const String & path, size_t size)
 {
     total_size += size;
-    storage_objects.emplace_back(path, size);
+    storage_objects.emplace_back(path, ObjectMetadata{size, {}, {}});
 }
 
 

--- a/src/Disks/ObjectStorages/DiskObjectStorageMetadata.h
+++ b/src/Disks/ObjectStorages/DiskObjectStorageMetadata.h
@@ -21,7 +21,7 @@ private:
     const std::string & common_metadata_path;
 
     /// Relative paths of blobs.
-    RelativePathsWithSize storage_objects;
+    RelativePathsWithMetadata storage_objects;
 
     const std::string object_storage_root_path;
 
@@ -63,7 +63,7 @@ public:
         return object_storage_root_path;
     }
 
-    RelativePathsWithSize getBlobsRelativePaths() const
+    RelativePathsWithMetadata getBlobsRelativePaths() const
     {
         return storage_objects;
     }

--- a/src/Disks/ObjectStorages/DiskObjectStorageRemoteMetadataRestoreHelper.cpp
+++ b/src/Disks/ObjectStorages/DiskObjectStorageRemoteMetadataRestoreHelper.cpp
@@ -356,7 +356,7 @@ void DiskObjectStorageRemoteMetadataRestoreHelper::restoreFiles(IObjectStorage *
     LOG_INFO(disk->log, "Starting restore files for disk {}", disk->name);
 
     std::vector<std::future<void>> results;
-    auto restore_files = [this, &source_object_storage, &restore_information, &results](const RelativePathsWithSize & objects)
+    auto restore_files = [this, &source_object_storage, &restore_information, &results](const RelativePathsWithMetadata & objects)
     {
         std::vector<String> keys_names;
         for (const auto & object : objects)
@@ -389,8 +389,8 @@ void DiskObjectStorageRemoteMetadataRestoreHelper::restoreFiles(IObjectStorage *
         return true;
     };
 
-    RelativePathsWithSize children;
-    source_object_storage->findAllFiles(restore_information.source_path, children, /* max_keys= */ 0);
+    RelativePathsWithMetadata children;
+    source_object_storage->listObjects(restore_information.source_path, children, /* max_keys= */ 0);
 
     restore_files(children);
 
@@ -472,7 +472,7 @@ void DiskObjectStorageRemoteMetadataRestoreHelper::restoreFileOperations(IObject
         || disk->object_storage_root_path != restore_information.source_path;
 
     std::set<String> renames;
-    auto restore_file_operations = [this, &source_object_storage, &restore_information, &renames, &send_metadata](const RelativePathsWithSize & objects)
+    auto restore_file_operations = [this, &source_object_storage, &restore_information, &renames, &send_metadata](const RelativePathsWithMetadata & objects)
     {
         const String rename = "rename";
         const String hardlink = "hardlink";
@@ -539,8 +539,8 @@ void DiskObjectStorageRemoteMetadataRestoreHelper::restoreFileOperations(IObject
         return true;
     };
 
-    RelativePathsWithSize children;
-    source_object_storage->findAllFiles(restore_information.source_path + "operations/", children, /* max_keys= */ 0);
+    RelativePathsWithMetadata children;
+    source_object_storage->listObjects(restore_information.source_path + "operations/", children, /* max_keys= */ 0);
     restore_file_operations(children);
 
     if (restore_information.detached)

--- a/src/Disks/ObjectStorages/IObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/IObjectStorage.cpp
@@ -16,15 +16,29 @@ namespace ErrorCodes
     extern const int LOGICAL_ERROR;
 }
 
-void IObjectStorage::findAllFiles(const std::string &, RelativePathsWithSize &, int) const
+bool IObjectStorage::existsOrHasAnyChild(const std::string & path) const
 {
-    throw Exception(ErrorCodes::NOT_IMPLEMENTED, "findAllFiles() is not supported");
+    RelativePathsWithMetadata files;
+    listObjects(path, files, 1);
+    return !files.empty();
 }
-void IObjectStorage::getDirectoryContents(const std::string &,
-    RelativePathsWithSize &,
-    std::vector<std::string> &) const
+
+void IObjectStorage::listObjects(const std::string &, RelativePathsWithMetadata &, int) const
 {
-    throw Exception(ErrorCodes::NOT_IMPLEMENTED, "getDirectoryContents() is not supported");
+    throw Exception(ErrorCodes::NOT_IMPLEMENTED, "listObjects() is not supported");
+}
+
+
+std::optional<ObjectMetadata> IObjectStorage::tryGetObjectMetadata(const std::string & path) const
+{
+    try
+    {
+        return getObjectMetadata(path);
+    }
+    catch (...)
+    {
+        return {};
+    }
 }
 
 ThreadPool & IObjectStorage::getThreadPoolWriter()

--- a/src/Disks/ObjectStorages/IObjectStorage.h
+++ b/src/Disks/ObjectStorages/IObjectStorage.h
@@ -30,25 +30,28 @@ class WriteBufferFromFileBase;
 
 using ObjectAttributes = std::map<std::string, std::string>;
 
-struct RelativePathWithSize
-{
-    String relative_path;
-    size_t bytes_size;
-
-    RelativePathWithSize() = default;
-
-    RelativePathWithSize(const String & relative_path_, size_t bytes_size_)
-        : relative_path(relative_path_), bytes_size(bytes_size_) {}
-};
-using RelativePathsWithSize = std::vector<RelativePathWithSize>;
-
-
 struct ObjectMetadata
 {
     uint64_t size_bytes;
     std::optional<Poco::Timestamp> last_modified;
     std::optional<ObjectAttributes> attributes;
 };
+
+struct RelativePathWithMetadata
+{
+    String relative_path;
+    ObjectMetadata metadata{};
+
+    RelativePathWithMetadata() = default;
+
+    RelativePathWithMetadata(const String & relative_path_, const ObjectMetadata & metadata_)
+        : relative_path(relative_path_), metadata(metadata_)
+    {}
+};
+
+using RelativePathsWithMetadata = std::vector<RelativePathWithMetadata>;
+
+
 
 /// Base class for all object storages which implement some subset of ordinary filesystem operations.
 ///
@@ -65,36 +68,17 @@ public:
     /// Object exists or not
     virtual bool exists(const StoredObject & object) const = 0;
 
-    /// List all objects with specific prefix.
-    ///
-    /// For example if you do this over filesystem, you should skip folders and
-    /// return files only, so something like on local filesystem:
-    ///
-    ///     find . -type f
-    ///
-    /// @param children - out files (relative paths) with their sizes.
-    /// @param max_keys - return not more then max_keys children
-    /// NOTE: max_keys is not the same as list_object_keys_size (disk property)
-    /// - if max_keys is set not more then max_keys keys should be returned
-    /// - however list_object_keys_size determine the size of the batch and should return all keys
-    ///
-    /// NOTE: It makes sense only for real object storages (S3, Azure), since
-    /// it is used only for one of the following:
-    /// - send_metadata (to restore metadata)
-    ///   - see DiskObjectStorage::restoreMetadataIfNeeded()
-    /// - MetadataStorageFromPlainObjectStorage - only for s3_plain disk
-    virtual void findAllFiles(const std::string & path, RelativePathsWithSize & children, int max_keys) const;
+    /// Object exists or any child on the specified path exists.
+    /// We have this method because object storages are flat for example
+    /// /a/b/c/d may exist but /a/b/c may not. So this method will return true for
+    /// /, /a, /a/b, /a/b/c, /a/b/c/d while exists will return true only for /a/b/c/d
+    virtual bool existsOrHasAnyChild(const std::string & path) const;
 
-    /// Analog of directory content for object storage (object storage does not
-    /// have "directory" definition, but it can be emulated with usage of
-    /// "delimiter"), so this is analog of:
-    ///
-    ///     find . -maxdepth 1 $path
-    ///
-    /// Return files in @files and directories in @directories
-    virtual void getDirectoryContents(const std::string & path,
-        RelativePathsWithSize & files,
-        std::vector<std::string> & directories) const;
+    virtual void listObjects(const std::string & path, RelativePathsWithMetadata & children, int max_keys) const;
+
+    /// Get object metadata if supported. It should be possible to receive
+    /// at least size of object
+    virtual std::optional<ObjectMetadata> tryGetObjectMetadata(const std::string & path) const;
 
     /// Get object metadata if supported. It should be possible to receive
     /// at least size of object

--- a/src/Disks/ObjectStorages/IObjectStorage.h
+++ b/src/Disks/ObjectStorages/IObjectStorage.h
@@ -52,7 +52,6 @@ struct RelativePathWithMetadata
 using RelativePathsWithMetadata = std::vector<RelativePathWithMetadata>;
 
 
-
 /// Base class for all object storages which implement some subset of ordinary filesystem operations.
 ///
 /// Examples of object storages are S3, Azure Blob Storage, HDFS.

--- a/src/Disks/ObjectStorages/MetadataStorageFromDisk.cpp
+++ b/src/Disks/ObjectStorages/MetadataStorageFromDisk.cpp
@@ -142,10 +142,10 @@ StoredObjects MetadataStorageFromDisk::getStorageObjects(const std::string & pat
     object_storage_paths.reserve(object_storage_relative_paths.size());
 
     /// Relative paths -> absolute.
-    for (auto & [object_relative_path, size] : object_storage_relative_paths)
+    for (auto & [object_relative_path, object_meta] : object_storage_relative_paths)
     {
         auto object_path = fs::path(metadata->getBlobsCommonPrefix()) / object_relative_path;
-        StoredObject object{ object_path, size, path };
+        StoredObject object{ object_path, object_meta.size_bytes, path };
         object_storage_paths.push_back(object);
     }
 

--- a/src/Disks/ObjectStorages/MetadataStorageFromPlainObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/MetadataStorageFromPlainObjectStorage.cpp
@@ -39,11 +39,10 @@ std::filesystem::path MetadataStorageFromPlainObjectStorage::getAbsolutePath(con
 
 bool MetadataStorageFromPlainObjectStorage::exists(const std::string & path) const
 {
-    RelativePathsWithSize children;
     /// NOTE: exists() cannot be used here since it works only for existing
     /// key, and does not work for some intermediate path.
-    object_storage->findAllFiles(getAbsolutePath(path), children, 1);
-    return !children.empty();
+    std::string abs_path = getAbsolutePath(path);
+    return object_storage->existsOrHasAnyChild(abs_path);
 }
 
 bool MetadataStorageFromPlainObjectStorage::isFile(const std::string & path) const
@@ -55,44 +54,47 @@ bool MetadataStorageFromPlainObjectStorage::isFile(const std::string & path) con
 bool MetadataStorageFromPlainObjectStorage::isDirectory(const std::string & path) const
 {
     std::string directory = getAbsolutePath(path);
-    trimRight(directory);
-    directory += "/";
+    if (!directory.ends_with('/'))
+        directory += '/';
 
-    /// NOTE: This check is far from ideal, since it work only if the directory
-    /// really has files, and has excessive API calls
-    RelativePathsWithSize files;
-    std::vector<std::string> directories;
-    object_storage->getDirectoryContents(directory, files, directories);
-    return !files.empty() || !directories.empty();
+    RelativePathsWithMetadata files;
+    object_storage->listObjects(directory, files, 1);
+    return !files.empty();
 }
 
 uint64_t MetadataStorageFromPlainObjectStorage::getFileSize(const String & path) const
 {
-    RelativePathsWithSize children;
-    object_storage->findAllFiles(getAbsolutePath(path), children, 1);
-    if (children.empty())
-        return 0;
-    if (children.size() != 1)
-        throw Exception(ErrorCodes::LOGICAL_ERROR, "findAllFiles() return multiple paths ({}) for {}", children.size(), path);
-    return children.front().bytes_size;
+    RelativePathsWithMetadata children;
+    auto metadata = object_storage->tryGetObjectMetadata(getAbsolutePath(path));
+    if (metadata)
+        return metadata->size_bytes;
+    return 0;
 }
 
 std::vector<std::string> MetadataStorageFromPlainObjectStorage::listDirectory(const std::string & path) const
 {
-    RelativePathsWithSize files;
-    std::vector<std::string> directories;
-    object_storage->getDirectoryContents(getAbsolutePath(path), files, directories);
+    RelativePathsWithMetadata files;
+    std::string abs_path = getAbsolutePath(path);
+    if (!abs_path.ends_with('/'))
+        abs_path += '/';
+
+    object_storage->listObjects(abs_path, files, 0);
 
     std::vector<std::string> result;
     for (const auto & path_size : files)
+    {
         result.push_back(path_size.relative_path);
-    for (const auto & directory : directories)
-        result.push_back(directory);
+    }
+
     for (auto & row : result)
     {
-        chassert(row.starts_with(object_storage_root_path));
-        row.erase(0, object_storage_root_path.size());
+        chassert(row.starts_with(abs_path));
+        row.erase(0, abs_path.size());
+        auto slash_pos = row.find_first_of('/');
+        if (slash_pos != std::string::npos)
+            row.erase(slash_pos, row.size() - slash_pos);
     }
+
     return result;
 }
 

--- a/src/Disks/ObjectStorages/MetadataStorageFromPlainObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/MetadataStorageFromPlainObjectStorage.cpp
@@ -10,11 +10,6 @@
 namespace DB
 {
 
-namespace ErrorCodes
-{
-    extern const int LOGICAL_ERROR;
-}
-
 MetadataStorageFromPlainObjectStorage::MetadataStorageFromPlainObjectStorage(
     ObjectStoragePtr object_storage_,
     const std::string & object_storage_root_path_)

--- a/src/Disks/ObjectStorages/MetadataStorageFromPlainObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/MetadataStorageFromPlainObjectStorage.cpp
@@ -86,6 +86,7 @@ std::vector<std::string> MetadataStorageFromPlainObjectStorage::listDirectory(co
         result.push_back(path_size.relative_path);
     }
 
+    std::unordered_set<std::string> duplicates_filter;
     for (auto & row : result)
     {
         chassert(row.starts_with(abs_path));
@@ -93,9 +94,10 @@ std::vector<std::string> MetadataStorageFromPlainObjectStorage::listDirectory(co
         auto slash_pos = row.find_first_of('/');
         if (slash_pos != std::string::npos)
             row.erase(slash_pos, row.size() - slash_pos);
+        duplicates_filter.insert(row);
     }
 
-    return result;
+    return std::vector<std::string>(duplicates_filter.begin(), duplicates_filter.end());
 }
 
 DirectoryIteratorPtr MetadataStorageFromPlainObjectStorage::iterateDirectory(const std::string & path) const

--- a/src/Disks/ObjectStorages/S3/S3ObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/S3/S3ObjectStorage.cpp
@@ -183,7 +183,7 @@ std::unique_ptr<WriteBufferFromFileBase> S3ObjectStorage::writeObject( /// NOLIN
         disk_write_settings);
 }
 
-void S3ObjectStorage::findAllFiles(const std::string & path, RelativePathsWithSize & children, int max_keys) const
+void S3ObjectStorage::listObjects(const std::string & path, RelativePathsWithMetadata & children, int max_keys) const
 {
     auto settings_ptr = s3_settings.get();
     auto client_ptr = client.get();
@@ -211,7 +211,7 @@ void S3ObjectStorage::findAllFiles(const std::string & path, RelativePathsWithSi
             break;
 
         for (const auto & object : objects)
-            children.emplace_back(object.GetKey(), object.GetSize());
+            children.emplace_back(object.GetKey(), ObjectMetadata{static_cast<uint64_t>(object.GetSize()), object.GetLastModified().Millis() / 1000, {}});
 
         if (max_keys)
         {
@@ -219,54 +219,6 @@ void S3ObjectStorage::findAllFiles(const std::string & path, RelativePathsWithSi
             if (keys_left <= 0)
                 break;
             request.SetMaxKeys(keys_left);
-        }
-
-        request.SetContinuationToken(outcome.GetResult().GetNextContinuationToken());
-    } while (outcome.GetResult().GetIsTruncated());
-}
-
-void S3ObjectStorage::getDirectoryContents(const std::string & path,
-    RelativePathsWithSize & files,
-    std::vector<std::string> & directories) const
-{
-    auto settings_ptr = s3_settings.get();
-    auto client_ptr = client.get();
-
-    S3::ListObjectsV2Request request;
-    request.SetBucket(bucket);
-    /// NOTE: if you do "ls /foo" instead of "ls /foo/" over S3 with this API
-    /// it will return only "/foo" itself without any underlying nodes.
-    if (path.ends_with("/"))
-        request.SetPrefix(path);
-    else
-        request.SetPrefix(path + "/");
-    request.SetMaxKeys(settings_ptr->list_object_keys_size);
-    request.SetDelimiter("/");
-
-    Aws::S3::Model::ListObjectsV2Outcome outcome;
-    do
-    {
-        ProfileEvents::increment(ProfileEvents::S3ListObjects);
-        ProfileEvents::increment(ProfileEvents::DiskS3ListObjects);
-        outcome = client_ptr->ListObjectsV2(request);
-        throwIfError(outcome);
-
-        auto result = outcome.GetResult();
-        auto result_objects = result.GetContents();
-        auto result_common_prefixes = result.GetCommonPrefixes();
-
-        if (result_objects.empty() && result_common_prefixes.empty())
-            break;
-
-        for (const auto & object : result_objects)
-            files.emplace_back(object.GetKey(), object.GetSize());
-
-        for (const auto & common_prefix : result_common_prefixes)
-        {
-            std::string directory = common_prefix.GetPrefix();
-            /// Make it compatible with std::filesystem::path::filename()
-            trimRight(directory, '/');
-            directories.emplace_back(directory);
         }
 
         request.SetContinuationToken(outcome.GetResult().GetNextContinuationToken());
@@ -357,6 +309,22 @@ void S3ObjectStorage::removeObjects(const StoredObjects & objects)
 void S3ObjectStorage::removeObjectsIfExist(const StoredObjects & objects)
 {
     removeObjectsImpl(objects, true);
+}
+
+std::optional<ObjectMetadata> S3ObjectStorage::tryGetObjectMetadata(const std::string & path) const
+{
+    auto settings_ptr = s3_settings.get();
+    auto object_info = S3::getObjectInfo(*client.get(), bucket, path, {}, settings_ptr->request_settings, /* with_metadata= */ true, /* for_disk_s3= */ true, /* throw_on_error= */ false);
+
+    if (object_info.size == 0 && object_info.last_modification_time == 0 && object_info.metadata.empty())
+        return {};
+
+    ObjectMetadata result;
+    result.size_bytes = object_info.size;
+    result.last_modified = object_info.last_modification_time;
+    result.attributes = object_info.metadata;
+
+    return result;
 }
 
 ObjectMetadata S3ObjectStorage::getObjectMetadata(const std::string & path) const

--- a/src/Disks/ObjectStorages/S3/S3ObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/S3/S3ObjectStorage.cpp
@@ -211,7 +211,7 @@ void S3ObjectStorage::listObjects(const std::string & path, RelativePathsWithMet
             break;
 
         for (const auto & object : objects)
-            children.emplace_back(object.GetKey(), ObjectMetadata{static_cast<uint64_t>(object.GetSize()), object.GetLastModified().Millis() / 1000, {}});
+            children.emplace_back(object.GetKey(), ObjectMetadata{static_cast<uint64_t>(object.GetSize()), Poco::Timestamp::fromEpochTime(object.GetLastModified().Seconds()), {}});
 
         if (max_keys)
         {

--- a/src/Disks/ObjectStorages/S3/S3ObjectStorage.h
+++ b/src/Disks/ObjectStorages/S3/S3ObjectStorage.h
@@ -100,10 +100,7 @@ public:
         size_t buf_size = DBMS_DEFAULT_BUFFER_SIZE,
         const WriteSettings & write_settings = {}) override;
 
-    void findAllFiles(const std::string & path, RelativePathsWithSize & children, int max_keys) const override;
-    void getDirectoryContents(const std::string & path,
-        RelativePathsWithSize & files,
-        std::vector<std::string> & directories) const override;
+    void listObjects(const std::string & path, RelativePathsWithMetadata & children, int max_keys) const override;
 
     /// Uses `DeleteObjectRequest`.
     void removeObject(const StoredObject & object) override;
@@ -120,6 +117,8 @@ public:
     void removeObjectsIfExist(const StoredObjects & objects) override;
 
     ObjectMetadata getObjectMetadata(const std::string & path) const override;
+
+    std::optional<ObjectMetadata> tryGetObjectMetadata(const std::string & path) const override;
 
     void copyObject( /// NOLINT
         const StoredObject & object_from,


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):