### PR TITLE
Push down to right side of a join in more cases

### DIFF
--- a/src/Processors/QueryPlan/JoinStep.cpp
+++ b/src/Processors/QueryPlan/JoinStep.cpp
@@ -54,7 +54,7 @@ QueryPipelineBuilderPtr JoinStep::updatePipeline(QueryPipelineBuilders pipelines
 
 bool JoinStep::allowPushDownToRight() const
 {
-    return join->pipelineType() == JoinPipelineType::YShaped;
+    return join->pipelineType() == JoinPipelineType::YShaped || join->pipelineType() == JoinPipelineType::FillRightFirst;
 }
 
 void JoinStep::describePipeline(FormatSettings & settings) const

--- a/src/Processors/QueryPlan/Optimizations/filterPushDown.cpp
+++ b/src/Processors/QueryPlan/Optimizations/filterPushDown.cpp
@@ -341,6 +341,10 @@ size_t tryPushDownFilter(QueryPlan::Node * parent_node, QueryPlan::Nodes & nodes
             if (table_join.kind() != JoinKind::Inner && table_join.kind() != JoinKind::Cross && table_join.kind() != kind)
                 return 0;
 
+            /// There is no ASOF Right join, so we're talking about pushing to the right side
+            if (kind == JoinKind::Right && table_join.strictness() == JoinStrictness::Asof)
+                return 0;
+
             bool is_left = kind == JoinKind::Left;
             const auto & input_header = is_left ? child->getInputStreams().front().header : child->getInputStreams().back().header;
             const auto & res_header = child->getOutputStream().header;

--- a/tests/performance/join_filter_pushdown.xml
+++ b/tests/performance/join_filter_pushdown.xml
@@ -1,0 +1,9 @@
+<test>
+    <create_query>create table t(a UInt64) engine=MergeTree order by tuple()</create_query>
+    <fill_query>insert into t select * from numbers_mt(5e6)</fill_query>
+
+    <query>select * from t as t0 inner join t as t1 using(a) where t1.a = 100</query>
+
+    <drop_query>drop table t</drop_query>
+</test>
+

--- a/tests/queries/0_stateless/01763_filter_push_down_bugs.sql
+++ b/tests/queries/0_stateless/01763_filter_push_down_bugs.sql
@@ -66,3 +66,17 @@ EXPLAIN indexes=1 SELECT id, delete_time FROM t1
 
 DROP TABLE IF EXISTS t1;
 DROP TABLE IF EXISTS t2;
+
+-- expected to get row (1, 3, 1, 4) from JOIN and empty result from the query
+SELECT *
+FROM
+(
+    SELECT *
+    FROM Values('id UInt64, t UInt64', (1, 3))
+) AS t1
+ASOF INNER JOIN
+(
+    SELECT *
+    FROM Values('id UInt64, t UInt64', (1, 1), (1, 2), (1, 3), (1, 4), (1, 5))
+) AS t2 ON (t1.id = t2.id) AND (t1.t < t2.t)
+WHERE t2.t != 4;

--- a/tests/queries/0_stateless/02514_analyzer_drop_join_on.reference
+++ b/tests/queries/0_stateless/02514_analyzer_drop_join_on.reference
@@ -107,7 +107,7 @@ Header: bx String
               bx_0 String
               c2_5 String
               c1_3 UInt64
-        Filter (( + (JOIN actions + DROP unused columns after JOIN)))
+        Expression
         Header: a2_6 String
                 bx_0 String
                 c2_5 String
@@ -139,7 +139,7 @@ Header: bx String
                   ReadFromMemoryStorage
                   Header: b1 UInt64
                           b2 String
-            Expression ((JOIN actions + Change column names to column identifiers))
+            Filter (( + (JOIN actions + Change column names to column identifiers)))
             Header: c1_3 UInt64
                     c2_5 String
               ReadFromMemoryStorage


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
More pushdown to the right side of join.

---



0.761 | 0.028 | -27.185x | -0.964 | 0.963 | join_filter_pushdown | 0 | select * from t as t0 inner join t as t1 using(a) where t1.a = 100
-- | -- | -- | -- | -- | -- | -- | --
