### PR TITLE
Disable skim (Rust library) under memory sanitizer

### DIFF
--- a/rust/skim/CMakeLists.txt
+++ b/rust/skim/CMakeLists.txt
@@ -14,6 +14,11 @@ if (OS_FREEBSD)
     return()
 endif()
 
+if (SANITIZE STREQUAL "memory")
+    message(STATUS "skim is disabled under memory sanitizer, because the interop is not instrumented properly")
+    return()
+endif()
+
 clickhouse_import_crate(MANIFEST_PATH Cargo.toml)
 
 # -Wno-dollar-in-identifier-extension: cxx bridge complies names with '$'


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
This closes #50525.