### PR TITLE
Resize BufferFromVector underlying vector only pos_offset == vector.size()

### DIFF
--- a/src/IO/WriteBufferFromVector.h
+++ b/src/IO/WriteBufferFromVector.h
@@ -86,7 +86,10 @@ private:
         size_t old_size = vector.size();
         /// pos may not be equal to vector.data() + old_size, because WriteBuffer::next() can be used to flush data
         size_t pos_offset = pos - reinterpret_cast<Position>(vector.data());
-        vector.resize(old_size * size_multiplier);
+        if (pos_offset == vector.size())
+        {
+            vector.resize(old_size * size_multiplier);
+        }
         internal_buffer = Buffer(reinterpret_cast<Position>(vector.data() + pos_offset), reinterpret_cast<Position>(vector.data() + vector.size()));
         working_buffer = internal_buffer;
     }

--- a/src/IO/WriteBufferFromVector.h
+++ b/src/IO/WriteBufferFromVector.h
@@ -86,7 +86,7 @@ private:
         size_t old_size = vector.size();
         /// pos may not be equal to vector.data() + old_size, because WriteBuffer::next() can be used to flush data
         size_t pos_offset = pos - reinterpret_cast<Position>(vector.data());
-        if (pos_offset == vector.size())
+        if (pos_offset == old_size)
         {
             vector.resize(old_size * size_multiplier);
         }


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category:
- Not For Changelog


### Changelog entry:
Resize underlying vector only pos_offset == vector.size()

### Some context

I was using `BufferFromVector` in [chdb](https://github.com/chdb-io/chdb) as the output buffer.
When tracing [bug](https://github.com/chdb-io/chdb/issues/31) I found that with every flush the underlying vector size of `BufferFromVector` will be doubled.

I tried to trace back the code to figure out why it was working that way, but I couldn't find any clues. The code was authored by @alexey-milovidov approximately 12 years ago. I am not very sure the PR is right.

As console output is not necessary for chdb, I did a quick and dirty fix [here](https://github.com/chdb-io/chdb/pull/32). But still, I think that will waste some memory when `BufferFromVector` was flushed.

