### PR TITLE
skip extracting darwin toolchain in builder when unncessary

### DIFF
--- a/cmake/toolchain/darwin-x86_64/README.txt
+++ b/cmake/toolchain/darwin-x86_64/README.txt
@@ -1,2 +1,2 @@
-wget https://github.com/phracker/MacOSX-SDKs/releases/download/10.15/MacOSX10.15.sdk.tar.xz
-tar xJf MacOSX10.15.sdk.tar.xz --strip-components=1
+wget https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/MacOSX11.0.sdk.tar.xz
+tar xJf MacOSX11.0.sdk.tar.xz --strip-components=1

--- a/docker/packager/binary/build.sh
+++ b/docker/packager/binary/build.sh
@@ -11,7 +11,7 @@ ccache_status () {
 
 [ -O /build ] || git config --global --add safe.directory /build
 
-if [ "$EXTRACT_TOOLCHAIN_DARWIN" = "1" ];then
+if [ "$EXTRACT_TOOLCHAIN_DARWIN" = "1" ]; then
   mkdir -p /build/cmake/toolchain/darwin-x86_64
   tar xJf /MacOSX11.0.sdk.tar.xz -C /build/cmake/toolchain/darwin-x86_64 --strip-components=1
   ln -sf darwin-x86_64 /build/cmake/toolchain/darwin-aarch64

--- a/docker/packager/binary/build.sh
+++ b/docker/packager/binary/build.sh
@@ -11,9 +11,11 @@ ccache_status () {
 
 [ -O /build ] || git config --global --add safe.directory /build
 
-mkdir -p /build/cmake/toolchain/darwin-x86_64
-tar xJf /MacOSX11.0.sdk.tar.xz -C /build/cmake/toolchain/darwin-x86_64 --strip-components=1
-ln -sf darwin-x86_64 /build/cmake/toolchain/darwin-aarch64
+if [ "$EXTRACT_TOOLCHAIN_DARWIN" = "1" ];then
+  mkdir -p /build/cmake/toolchain/darwin-x86_64
+  tar xJf /MacOSX11.0.sdk.tar.xz -C /build/cmake/toolchain/darwin-x86_64 --strip-components=1
+  ln -sf darwin-x86_64 /build/cmake/toolchain/darwin-aarch64
+fi
 
 # Uncomment to debug ccache. Don't put ccache log in /output right away, or it
 # will be confusingly packed into the "performance" package.

--- a/docker/packager/packager
+++ b/docker/packager/packager
@@ -167,6 +167,7 @@ def parse_env_variables(
         cmake_flags.append(
             "-DCMAKE_TOOLCHAIN_FILE=/build/cmake/darwin/toolchain-x86_64.cmake"
         )
+        result.append("EXTRACT_TOOLCHAIN_DARWIN=1")
     elif is_cross_darwin_arm:
         cc = compiler[: -len(DARWIN_ARM_SUFFIX)]
         cmake_flags.append("-DCMAKE_AR:FILEPATH=/cctools/bin/aarch64-apple-darwin-ar")
@@ -181,6 +182,7 @@ def parse_env_variables(
         cmake_flags.append(
             "-DCMAKE_TOOLCHAIN_FILE=/build/cmake/darwin/toolchain-aarch64.cmake"
         )
+        result.append("EXTRACT_TOOLCHAIN_DARWIN=1")
     elif is_cross_arm:
         cc = compiler[: -len(ARM_SUFFIX)]
         cmake_flags.append(


### PR DESCRIPTION
1. It's unnecessary to extract darwin toolchain when it's not used, as it contains 40k files and about 588 MiB storage, which is a little heavy to be the last straw for some low performance file systems (such as nfs....)

2. And just modify the README.txt in toolchain directory to match the version used in binary builder Dockerfile.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

