### PR TITLE
Remove flaky test

### DIFF
--- a/tests/integration/test_merge_tree_s3/test.py
+++ b/tests/integration/test_merge_tree_s3/test.py
@@ -740,31 +740,6 @@ def test_cache_with_full_disk_space(cluster, node_name):
 
 
 @pytest.mark.parametrize("node_name", ["node"])
-def test_store_cleanup_disk_s3(cluster, node_name):
-    node = cluster.instances[node_name]
-    node.query("DROP TABLE IF EXISTS s3_test SYNC")
-    node.query(
-        "CREATE TABLE s3_test UUID '00000000-1000-4000-8000-000000000001' (n UInt64) Engine=MergeTree() ORDER BY n SETTINGS storage_policy='s3';"
-    )
-    node.query("INSERT INTO s3_test SELECT 1")
-
-    node.stop_clickhouse(kill=True)
-    path_to_data = "/var/lib/clickhouse/"
-    node.exec_in_container(["rm", f"{path_to_data}/metadata/default/s3_test.sql"])
-    node.start_clickhouse()
-
-    node.wait_for_log_line(
-        "Removing unused directory", timeout=90, look_behind_lines=1000
-    )
-    node.wait_for_log_line("directories from store")
-    node.query(
-        "CREATE TABLE s3_test UUID '00000000-1000-4000-8000-000000000001' (n UInt64) Engine=MergeTree() ORDER BY n SETTINGS storage_policy='s3';"
-    )
-    node.query("INSERT INTO s3_test SELECT 1")
-    check_no_objects_after_drop(cluster)
-
-
-@pytest.mark.parametrize("node_name", ["node"])
 def test_cache_setting_compatibility(cluster, node_name):
     node = cluster.instances[node_name]
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
This closes #48691.

Details:

> Alexey Milovidov
@Alexander Tokmakov, you should know about this: [https://s3.amazonaws.com/clickhouse-test-reports/50533/009fe3d25e8a755e86d45084f2af57[…]ease__[2_4]/integration_run_test_merge_tree_s3_test_py_0.log](https://s3.amazonaws.com/clickhouse-test-reports/50533/009fe3d25e8a755e86d45084f2af5784f4463523/integration_tests__release__[2_4]/integration_run_test_merge_tree_s3_test_py_0.log)
(this test fails very frequently)
PS. I checked the code DatabaseCatalog::cleanupStoreDirectoryTask and it looks dangerous - we are removing data when it is unexpected. Maybe better do nothing (when we found some garbage, we should not touch it, or move to a safe place, instead of removing).

> Alexey Milovidov
@Igor Nikonov, if you attempted to fix this test, you might want to know that it didn't help.

> Alexey Milovidov
@Alexander Tokmakov, what is the whole motivation of this test_store_cleanup_disk_s3 ?
It does manual intervention to filesystem - not a scenario to expect in production. Maybe remove it?

> Alexey Milovidov
If you know the motivation for this test - provide it directly in comments.

> Alexander Tokmakov
The motivation is: check that background cleanup of leftovers works as expected (it's not easy to create some leftovers in a natural way). I thought that @Igor Nikonov is working on fixing the test (https://github.com/ClickHouse/ClickHouse/issues/48691 is assigned to him), but I will take a look by myself if he cannot do it
PS. I checked the code DatabaseCatalog::cleanupStoreDirectoryTask and it looks dangerous - we are removing data when it is unexpected. Maybe better do nothing (when we found some garbage, we should not touch it, or move to a safe place, instead of removing).

> At first we set permissions to 000 and only then remove after one month. And in tests we remove it after 1 second, no issues found. So it's not that dangerous. Initially we used to do nothing, but Yandex had some complaints about garbage in store/ dir that was hard to remove manually
[#48691 test_store_cleanup_disk_s3 is flaky](https://github.com/ClickHouse/ClickHouse/issues/48691)
[https://s3.amazonaws.com/clickhouse-test-reports/0/c3482a104f73f237450f7d7781871859472687d9/integration_tests__asan__[6/6].html](https://s3.amazonaws.com/clickhouse-test-reports/0/c3482a104f73f237450f7d7781871859472687d9/integration_tests__asan__%5B6/6%5D.html)
https://play.clickhouse.com/play?user=play#U0VMRUNUIHB1bGxfcmVxdWVzdF9udW1iZXIsIGNoZWNrX3N0YXJ0X3RpbWUsIGNoZWNrX25hbWUsIHRlc3RfbmFtZSwgdGVzdF9zdGF0dXMsIGNoZWNrX3N0YXR1cywgcmVwb3J0X3VybApGUk9NIGNoZWNrcwpXSEVSRSAxCiAgICAtLUFORCBwdWxsX3JlcXVlc3RfbnVtYmVyID0gMAogICAgQU5EIHRlc3Rfc3RhdHVzICE9ICdTS0lQUEVEJwogICAgQU5EIHRlc3Rfc3RhdHVzICE9ICdPSycKICAgIEFORCBjaGVja19zdGF0dXMgIT0gJ3N1Y2Nlc3MnCiAgICBBTkQgdGVzdF9uYW1lIGxpa2UgJyV0ZXN0X3N0b3JlX2NsZWFudXBfZGlza19zMyUnCk9SREVSIEJZIGNoZWNrX3N0YXJ0X3RpbWUgZGVzYywgY2hlY2tfbmFtZSwgdGVzdF9uYW1l

> Alexey Milovidov
I see we failed to fix it in two months, do you mind if I'll remove this test?


TLDR: the feature should not have existed in the first place.