### PR TITLE
allow URI to support non-ascii characters

### DIFF
--- a/base/poco/Foundation/src/URI.cpp
+++ b/base/poco/Foundation/src/URI.cpp
@@ -720,7 +720,7 @@ unsigned short URI::getWellKnownPort() const
 void URI::parse(const std::string& uri)
 {
 	std::for_each(uri.begin(), uri.end(), [] (char ch) {
-		if (static_cast<signed char>(ch) <= 32 || ch == '\x7F')
+		if (static_cast<unsigned char>(ch) <= 32 || ch == '\x7F')
 			throw URISyntaxException("URI contains invalid characters");
 	});
 


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


when visiting a S3 with URI containing non-ascii chars (e.g. s3://raptorx-test/bin-package/native-engine/mhb-test1/customer客户表/customer/part-00000-f36cbfed-be1f-4add-8033-cdf6240fb67a-c000.snappy.parquet), an exception is thrown because this check fails:

```c++
	std::for_each(uri.begin(), uri.end(), [] (char ch) {
		if (static_cast<signed char>(ch) <= 32 || ch == '\x7F')
			throw URISyntaxException("URI contains invalid characters");
	});
``` 

For URIs with non-ascii chars, `ch` will prefix with "10", "110", "110",etc, which makes `ch` a negative value and `<=32` to be true.
I believe this piece of code is intended to check if uri contains <control> chars (https://www.utf8-chartable.de/unicode-utf8-table.pl?number=128) ranging from 0 to 32, so casting `ch` to an unsigned char is probably a better choice( so that there's no need to consider negative case).

BTW, as I checked Github history, this piece of code is not appearing in https://github.com/pocoproject/poco/blob/devel/Foundation/src/URI.cpp#L770 (even not found in this file's history). Is this check really necessary?
### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

### Documentation entry for user-facing changes