### PR TITLE
Fix bug in `uniqExact` parallel merging

### DIFF
--- a/tests/queries/0_stateless/02782_uniq_exact_parallel_merging_bug.sh
+++ b/tests/queries/0_stateless/02782_uniq_exact_parallel_merging_bug.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Tags: long
+
+# shellcheck disable=SC2154
+
+unset CLICKHOUSE_LOG_COMMENT
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+
+clickhouse-client -q "
+    CREATE TABLE ${CLICKHOUSE_DATABASE}.t(s String)
+    ENGINE = MergeTree
+    ORDER BY tuple();
+"
+
+clickhouse-client -q "insert into ${CLICKHOUSE_DATABASE}.t select number%10==0 ? toString(number) : '' from numbers_mt(1e7)"
+
+clickhouse-benchmark -q "select count(distinct s) from ${CLICKHOUSE_DATABASE}.t settings max_memory_usage = '50Mi'" --ignore-error -c 16 -i 1000 2>/dev/null

--- a/tests/queries/0_stateless/02782_uniq_exact_parallel_merging_bug.sh
+++ b/tests/queries/0_stateless/02782_uniq_exact_parallel_merging_bug.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: long
+# Tags: long, no-random-settings, no-tsan, no-asan, no-ubsan, no-msan
 
 # shellcheck disable=SC2154
 


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
We didn't call `wait` on the thread pool if task scheduling failed with an exception.

