### PR TITLE
Disable pure parallel replicas if trivial count optimization is possible

### DIFF
--- a/src/Interpreters/InterpreterSelectQuery.cpp
+++ b/src/Interpreters/InterpreterSelectQuery.cpp
@@ -833,6 +833,19 @@ InterpreterSelectQuery::InterpreterSelectQuery(
         need_analyze_again = true;
     }
 
+    if (can_analyze_again
+        && settings.max_parallel_replicas > 1
+        && settings.allow_experimental_parallel_reading_from_replicas > 0
+        && settings.parallel_replicas_custom_key.value.empty()
+        && getTrivialCount(0).has_value())
+    {
+        /// The query could use trivial count if it didn't use parallel replicas, so let's disable it and reanalyze
+        context->setSetting("allow_experimental_parallel_reading_from_replicas", Field(0));
+        context->setSetting("max_parallel_replicas", UInt64{0});
+        need_analyze_again = true;
+        LOG_TRACE(log, "Disabling parallel replicas to be able to use a trivial count optimization");
+    }
+
     if (need_analyze_again)
     {
         size_t current_query_analyze_count = context->getQueryContext()->kitchen_sink.analyze_counter.load();
@@ -2254,45 +2267,54 @@ void InterpreterSelectQuery::addPrewhereAliasActions()
     }
 }
 
-void InterpreterSelectQuery::executeFetchColumns(QueryProcessingStage::Enum processing_stage, QueryPlan & query_plan)
+/// Based on the query analysis, check if optimizing the count trivial count to use totalRows is possible
+std::optional<UInt64> InterpreterSelectQuery::getTrivialCount(UInt64 max_parallel_replicas)
 {
-    auto & query = getSelectQuery();
     const Settings & settings = context->getSettingsRef();
-
-    /// Optimization for trivial query like SELECT count() FROM table.
     bool optimize_trivial_count =
         syntax_analyzer_result->optimize_trivial_count
-        && (settings.max_parallel_replicas <= 1)
+        && (max_parallel_replicas <= 1)
         && !settings.allow_experimental_query_deduplication
         && !settings.empty_result_for_aggregation_by_empty_set
         && storage
         && storage->getName() != "MaterializedMySQL"
         && !storage->hasLightweightDeletedMask()
         && query_info.filter_asts.empty()
-        && processing_stage == QueryProcessingStage::FetchColumns
         && query_analyzer->hasAggregation()
         && (query_analyzer->aggregates().size() == 1)
         && typeid_cast<const AggregateFunctionCount *>(query_analyzer->aggregates()[0].function.get());
 
-    if (optimize_trivial_count)
+    if (!optimize_trivial_count)
+        return {};
+
+    auto & query = getSelectQuery();
+    if (!query.prewhere() && !query.where() && !context->getCurrentTransaction())
+    {
+        return storage->totalRows(settings);
+    }
+    else
+    {
+        // It's possible to optimize count() given only partition predicates
+        SelectQueryInfo temp_query_info;
+        temp_query_info.query = query_ptr;
+        temp_query_info.syntax_analyzer_result = syntax_analyzer_result;
+        temp_query_info.prepared_sets = query_analyzer->getPreparedSets();
+
+        return storage->totalRowsByPartitionPredicate(temp_query_info, context);
+    }
+}
+
+void InterpreterSelectQuery::executeFetchColumns(QueryProcessingStage::Enum processing_stage, QueryPlan & query_plan)
+{
+    auto & query = getSelectQuery();
+    const Settings & settings = context->getSettingsRef();
+
+    /// Optimization for trivial query like SELECT count() FROM table.
+    if (processing_stage == QueryProcessingStage::FetchColumns)
     {
         const auto & desc = query_analyzer->aggregates()[0];
         const auto & func = desc.function;
-        std::optional<UInt64> num_rows{};
-
-        if (!query.prewhere() && !query.where() && !context->getCurrentTransaction())
-        {
-            num_rows = storage->totalRows(settings);
-        }
-        else // It's possible to optimize count() given only partition predicates
-        {
-            SelectQueryInfo temp_query_info;
-            temp_query_info.query = query_ptr;
-            temp_query_info.syntax_analyzer_result = syntax_analyzer_result;
-            temp_query_info.prepared_sets = query_analyzer->getPreparedSets();
-
-            num_rows = storage->totalRowsByPartitionPredicate(temp_query_info, context);
-        }
+        std::optional<UInt64> num_rows = getTrivialCount(settings.max_parallel_replicas);
 
         if (num_rows)
         {

--- a/src/Interpreters/InterpreterSelectQuery.h
+++ b/src/Interpreters/InterpreterSelectQuery.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <optional>
 
 #include <Access/EnabledRowPolicies.h>
 #include <Core/QueryProcessingStage.h>
@@ -187,6 +188,7 @@ private:
     void executeExtremes(QueryPlan & query_plan);
     void executeSubqueriesInSetsAndJoins(QueryPlan & query_plan);
     bool autoFinalOnQuery(ASTSelectQuery & select_query);
+    std::optional<UInt64> getTrivialCount(UInt64 max_parallel_replicas);
 
     enum class Modificator
     {

--- a/src/Planner/PlannerJoinTree.cpp
+++ b/src/Planner/PlannerJoinTree.cpp
@@ -170,7 +170,7 @@ bool applyTrivialCountIfPossible(
     QueryPlan & query_plan,
     const TableNode & table_node,
     const QueryTreeNodePtr & query_tree,
-    const ContextPtr & query_context,
+    ContextMutablePtr & query_context,
     const Names & columns_names)
 {
     const auto & settings = query_context->getSettingsRef();
@@ -208,8 +208,7 @@ bool applyTrivialCountIfPossible(
     if (storage->hasLightweightDeletedMask())
         return false;
 
-    if (settings.max_parallel_replicas > 1 ||
-        settings.allow_experimental_query_deduplication
+    if (settings.allow_experimental_query_deduplication
         || settings.empty_result_for_aggregation_by_empty_set)
         return false;
 
@@ -227,6 +226,18 @@ bool applyTrivialCountIfPossible(
     std::optional<UInt64> num_rows = storage->totalRows(settings);
     if (!num_rows)
         return false;
+
+    if (settings.max_parallel_replicas > 1)
+    {
+        if (!settings.parallel_replicas_custom_key.value.empty() || settings.allow_experimental_parallel_reading_from_replicas == 0)
+            return false;
+
+        /// The query could use trivial count if it didn't use parallel replicas, so let's disable it
+        query_context->setSetting("allow_experimental_parallel_reading_from_replicas", Field(0));
+        query_context->setSetting("max_parallel_replicas", UInt64{0});
+        LOG_TRACE(&Poco::Logger::get("Planner"), "Disabling parallel replicas to be able to use a trivial count optimization");
+
+    }
 
     /// Set aggregation state
     const AggregateFunctionCount & agg_count = *count_func;
@@ -619,7 +630,7 @@ JoinTreeQueryPlan buildQueryPlanForTableExpression(QueryTreeNodePtr table_expres
             is_single_table_expression &&
             table_node &&
             select_query_info.has_aggregates &&
-            applyTrivialCountIfPossible(query_plan, *table_node, select_query_info.query_tree, planner_context->getQueryContext(), table_expression_data.getColumnNames());
+            applyTrivialCountIfPossible(query_plan, *table_node, select_query_info.query_tree, planner_context->getMutableQueryContext(), table_expression_data.getColumnNames());
 
         if (is_trivial_count_applied)
         {

--- a/tests/queries/0_stateless/02783_parallel_replicas_trivial_count_optimization.reference
+++ b/tests/queries/0_stateless/02783_parallel_replicas_trivial_count_optimization.reference
@@ -1,0 +1,12 @@
+100000
+100000
+100000
+100000
+100000
+100000
+02783_count-default_0_disabled	Not parallel	1	16
+02783_count-default_0_pure	Not parallel	1	16
+02783_count-default_0_pure_analyzer	Not parallel	1	16
+02783_count-default_1_disabled	Not parallel	1	16
+02783_count-default_1_pure	Not parallel	1	16
+02783_count-default_1_pure_analyzer	Not parallel	1	16

--- a/tests/queries/0_stateless/02783_parallel_replicas_trivial_count_optimization.sh
+++ b/tests/queries/0_stateless/02783_parallel_replicas_trivial_count_optimization.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+function has_used_parallel_replicas () {
+    $CLICKHOUSE_CLIENT --query "
+        SELECT
+            initial_query_id,
+            if(count() != 2, 'Used parallel', 'Not parallel'),
+            sumIf(read_rows, is_initial_query) as read_rows,
+            sumIf(read_bytes, is_initial_query) as read_bytes
+        FROM system.query_log
+    WHERE event_date >= yesterday() and initial_query_id LIKE '$1%'
+    GROUP BY initial_query_id
+    ORDER BY min(event_time_microseconds) ASC
+    FORMAT TSV"
+}
+
+function run_query_with_pure_parallel_replicas () {
+    $CLICKHOUSE_CLIENT \
+        --query "$2" \
+        --query_id "${1}_disabled" \
+        --max_parallel_replicas 0
+
+    $CLICKHOUSE_CLIENT \
+        --query "$2" \
+        --query_id "${1}_pure" \
+        --max_parallel_replicas 3 \
+        --prefer_localhost_replica 1 \
+        --use_hedged_requests 0 \
+        --cluster_for_parallel_replicas 'test_cluster_one_shard_three_replicas_localhost' \
+        --allow_experimental_parallel_reading_from_replicas 1 \
+        --allow_experimental_analyzer 0
+
+    # Not implemented yet
+    $CLICKHOUSE_CLIENT \
+        --query "$2" \
+        --query_id "${1}_pure_analyzer" \
+        --max_parallel_replicas 3 \
+        --prefer_localhost_replica 1 \
+        --use_hedged_requests 0 \
+        --cluster_for_parallel_replicas 'test_cluster_one_shard_three_replicas_localhost' \
+        --allow_experimental_parallel_reading_from_replicas 1 \
+        --allow_experimental_analyzer 1
+}
+
+function run_query_with_custom_key_parallel_replicas () {
+    $CLICKHOUSE_CLIENT \
+        --query "$2" \
+        --query_id "${1}_disabled" \
+        --max_parallel_replicas 0
+
+    $CLICKHOUSE_CLIENT \
+        --query "$2" \
+        --query_id "${1}_custom_key" \
+        --max_parallel_replicas 3 \
+        --use_hedged_requests 0 \
+        --parallel_replicas_custom_key_filter_type 'default' \
+        --parallel_replicas_custom_key "$2" \
+        --allow_experimental_analyzer 0
+
+    $CLICKHOUSE_CLIENT \
+        --query "$2" \
+        --query_id "${1}_custom_key_analyzer" \
+        --max_parallel_replicas 3 \
+        --use_hedged_requests 0 \
+        --parallel_replicas_custom_key_filter_type 'default' \
+        --parallel_replicas_custom_key "$2" \
+        --allow_experimental_analyzer 1
+}
+
+$CLICKHOUSE_CLIENT --query "
+    CREATE TABLE replicated_numbers
+    (
+        number Int64,
+    )
+    ENGINE=ReplicatedMergeTree('/clickhouse/tables/{database}/replicated_numbers', 'r1')
+    ORDER BY (number)
+    AS SELECT number FROM numbers(100000);
+"
+
+query_id_base="02783_count-$CLICKHOUSE_DATABASE"
+
+run_query_with_pure_parallel_replicas "${query_id_base}_0" "SELECT count() FROM replicated_numbers"
+run_query_with_pure_parallel_replicas "${query_id_base}_1" "SELECT * FROM (SELECT count() FROM replicated_numbers) LIMIT 20"
+
+# Not implemented yet as the query fails to execute correctly to begin with
+#run_query_with_custom_key_parallel_replicas "${query_id_base}_2" "SELECT count() FROM cluster(test_cluster_one_shard_three_replicas_localhost, currentDatabase(), replicated_numbers)" "sipHash64(number)"
+#run_query_with_custom_key_parallel_replicas "${query_id_base}_3" "SELECT * FROM (SELECT count() FROM cluster(test_cluster_one_shard_three_replicas_localhost, currentDatabase(), replicated_numbers)) LIMIT 20" "sipHash64(number)"
+
+
+$CLICKHOUSE_CLIENT --query "SYSTEM FLUSH LOGS"
+has_used_parallel_replicas "${query_id_base}"


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Disable pure parallel replicas if trivial count optimization is possible

### Documentation entry for user-facing changes
XXX


Using parallel replicas to do count() operations when trivial count is possible is extremely disadvantageous (in all cases I'd say) as it means both initializing parallel replicas, organizing the work and then reading the smallest column (vs checking just the part metadata). So in those cases we disable parallel replicas and do all the work in the initiator.


I've only attempted to implement this for pure parallel replicas (both in the old interpreter and the new analyzer) as custom key replicas isn't working right now and dealing with cluster() vs normal storage was more complex (but mainly the first reason).