### PR TITLE
Enable parametrized SQL aliases

### DIFF
--- a/docs/en/interfaces/cli.md
+++ b/docs/en/interfaces/cli.md
@@ -155,7 +155,7 @@ Format a query as usual, then place the values that you want to pass from the ap
 
 ``` bash
 $ clickhouse-client --param_tuple_in_tuple="(10, ('dt', 10))" -q "SELECT * FROM table WHERE val = {tuple_in_tuple:Tuple(UInt8, Tuple(String, UInt8))}"
-$ clickhouse-client --param_tbl="numbers" --param_db="system" --param_col="number" --query "SELECT {col:Identifier} FROM {db:Identifier}.{tbl:Identifier} LIMIT 10"
+$ clickhouse-client --param_tbl="numbers" --param_db="system" --param_col="number" --param_alias="top_ten" --query "SELECT {col:Identifier} as {alias:Identifier} FROM {db:Identifier}.{tbl:Identifier} LIMIT 10"
 ```
 
 ## Configuring {#interfaces_cli_configuration}

--- a/src/Interpreters/ReplaceQueryParameterVisitor.cpp
+++ b/src/Interpreters/ReplaceQueryParameterVisitor.cpp
@@ -33,6 +33,7 @@ namespace ErrorCodes
 void ReplaceQueryParameterVisitor::visit(ASTPtr & ast)
 {
     checkStackSize();
+    resolveParametrizedAlias(ast);
 
     if (ast->as<ASTQueryParameter>())
         visitQueryParameter(ast);
@@ -156,4 +157,13 @@ void ReplaceQueryParameterVisitor::visitIdentifier(ASTPtr & ast)
     ast_identifier->children.clear();
 }
 
+void ReplaceQueryParameterVisitor::resolveParametrizedAlias(ASTPtr & ast)
+{
+    auto ast_with_alias = std::dynamic_pointer_cast<ASTWithAlias>(ast);
+    if (!ast_with_alias)
+        return;
+
+    if (ast_with_alias->parametrised_alias)
+        setAlias(ast, getParamValue((*ast_with_alias->parametrised_alias)->name));
+}
 }

--- a/src/Interpreters/ReplaceQueryParameterVisitor.h
+++ b/src/Interpreters/ReplaceQueryParameterVisitor.h
@@ -27,6 +27,7 @@ private:
     size_t num_replaced_parameters = 0;
 
     const String & getParamValue(const String & name);
+    void resolveParametrizedAlias(ASTPtr & ast);
     void visitIdentifier(ASTPtr & ast);
     void visitQueryParameter(ASTPtr & ast);
     void visitChildren(ASTPtr & ast);

--- a/src/Parsers/ASTWithAlias.h
+++ b/src/Parsers/ASTWithAlias.h
@@ -6,6 +6,7 @@
 namespace DB
 {
 
+class ASTQueryParameter;
 
 /** Base class for AST, which can contain an alias (identifiers, literals, functions).
   */
@@ -17,6 +18,9 @@ public:
     /// If is true, getColumnName returns alias. Uses for aliases in former WITH section of SELECT query.
     /// Example: 'WITH pow(2, 2) as a SELECT pow(a, 2)' returns 'pow(a, 2)' instead of 'pow(pow(2, 2), 2)'
     bool prefer_alias_to_column_name = false;
+    // An alias can be defined as a query parameter,
+    // in which case we can only resolve it during query execution.
+    std::optional<std::shared_ptr<ASTQueryParameter>> parametrised_alias;
 
     using IAST::IAST;
 

--- a/src/Parsers/ExpressionElementParsers.cpp
+++ b/src/Parsers/ExpressionElementParsers.cpp
@@ -1518,7 +1518,7 @@ const char * ParserAlias::restricted_keywords[] =
 bool ParserAlias::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
 {
     ParserKeyword s_as(Keyword::AS);
-    ParserIdentifier id_p(false, Highlight::alias);
+    ParserIdentifier id_p{true, Highlight::alias};
 
     bool has_as_word = s_as.ignore(pos, expected);
     if (!allow_alias_without_as_keyword && !has_as_word)
@@ -2065,6 +2065,10 @@ bool ParserWithOptionalAlias::parseImpl(Pos & pos, ASTPtr & node, Expected & exp
         if (auto * ast_with_alias = dynamic_cast<ASTWithAlias *>(node.get()))
         {
             tryGetIdentifierNameInto(alias_node, ast_with_alias->alias);
+
+            // the alias is parametrised and will be resolved later when the query context is known
+            if (!alias_node->children.empty() && alias_node->children.front()->as<ASTQueryParameter>())
+                ast_with_alias->parametrised_alias = std::dynamic_pointer_cast<ASTQueryParameter>(alias_node->children.front());
         }
         else
         {

--- a/tests/queries/0_stateless/01550_query_identifier_parameters.reference
+++ b/tests/queries/0_stateless/01550_query_identifier_parameters.reference
@@ -3,3 +3,10 @@
 0
 0
 45
+"numnum"
+0
+"numnum"
+0
+"numnum","count()"
+1,5
+0,5

--- a/tests/queries/0_stateless/01550_query_identifier_parameters.sh
+++ b/tests/queries/0_stateless/01550_query_identifier_parameters.sh
@@ -11,5 +11,6 @@ $CLICKHOUSE_CLIENT --param_col 'number' --query 'select a.{col:Identifier} from 
 $CLICKHOUSE_CLIENT --param_tbl 'numbers' --param_col 'number' --query 'select sum({tbl:Identifier}.{col:Identifier}) FROM (select * from system.{tbl:Identifier} limit 10) numbers'
 $CLICKHOUSE_CLIENT --param_alias 'numnum' --query 'select number as {alias:Identifier} from system.numbers limit 1 format CSVWithNames'
 $CLICKHOUSE_CLIENT --param_alias 'numnum' --param_tbl 'numbers' --query 'select number as {alias:Identifier} from system.{tbl:Identifier} limit 1 format CSVWithNames'
+
 # functions and grouping / ordering support
 $CLICKHOUSE_CLIENT --param_alias 'numnum' --query 'select number % 2 as {alias:Identifier}, count() from (select number from system.numbers limit 10) group by {alias:Identifier} order by {alias:Identifier} desc format CSVWithNames'

--- a/tests/queries/0_stateless/01550_query_identifier_parameters.sh
+++ b/tests/queries/0_stateless/01550_query_identifier_parameters.sh
@@ -9,3 +9,7 @@ $CLICKHOUSE_CLIENT --param_db 'system' --param_tbl 'numbers' --query 'select * f
 $CLICKHOUSE_CLIENT --param_col 'number' --query 'select {col:Identifier} from system.numbers limit 1'
 $CLICKHOUSE_CLIENT --param_col 'number' --query 'select a.{col:Identifier} from system.numbers a limit 1'
 $CLICKHOUSE_CLIENT --param_tbl 'numbers' --param_col 'number' --query 'select sum({tbl:Identifier}.{col:Identifier}) FROM (select * from system.{tbl:Identifier} limit 10) numbers'
+$CLICKHOUSE_CLIENT --param_alias 'numnum' --query 'select number as {alias:Identifier} from system.numbers limit 1 format CSVWithNames'
+$CLICKHOUSE_CLIENT --param_alias 'numnum' --param_tbl 'numbers' --query 'select number as {alias:Identifier} from system.{tbl:Identifier} limit 1 format CSVWithNames'
+# functions and grouping / ordering support
+$CLICKHOUSE_CLIENT --param_alias 'numnum' --query 'select number % 2 as {alias:Identifier}, count() from (select number from system.numbers limit 10) group by {alias:Identifier} order by {alias:Identifier} desc format CSVWithNames'


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Allow parametrised SQL aliases.


### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

- Motivation: With this change, not only table names can be passed as query parameters, but also identifier aliases. This is useful when exposing Clickhouse via a proxy that allows dynamic column names while shadowing underlying table structure.

- Example use:
`curl "localhost:8123/?param_lim=3&param_foo=custom_column_name" -X POST -d "select number as {foo:Identifier} from system.numbers limit {lim:UInt64} format CSVWithNames"`


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
