### PR TITLE
Disable grace_hash join in stress tests

### DIFF
--- a/tests/ci/stress.py
+++ b/tests/ci/stress.py
@@ -37,9 +37,6 @@ def get_options(i, upgrade_check):
             client_options.append("join_algorithm='partial_merge'")
         if join_alg_num % 5 == 2:
             client_options.append("join_algorithm='full_sorting_merge'")
-        if join_alg_num % 5 == 3 and not upgrade_check:
-            # Some crashes are not fixed in 23.2 yet, so ignore the setting in Upgrade check
-            client_options.append("join_algorithm='grace_hash'")
         if join_alg_num % 5 == 4:
             client_options.append("join_algorithm='auto'")
             client_options.append("max_rows_in_join=1000")


### PR DESCRIPTION

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Until https://github.com/ClickHouse/ClickHouse/issues/50220 is fixed
