### PR TITLE
Catch issues with dockerd during the build

### DIFF
--- a/tests/ci/build_check.py
+++ b/tests/ci/build_check.py
@@ -343,6 +343,15 @@ def main():
         f"sudo chown -R ubuntu:ubuntu {build_output_path}", shell=True
     )
     logging.info("Build finished with %s, log path %s", success, log_path)
+    if not success:
+        # We check if docker works, because if it's down, it's infrastructure
+        try:
+            subprocess.check_call("docker info", shell=True)
+        except subprocess.CalledProcessError:
+            logging.error(
+                "The dockerd looks down, won't upload anything and generate report"
+            )
+            sys.exit(1)
 
     # FIXME performance
     performance_urls = []


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
When the instance is going down, often the build is quick enough to upload a wrong log and prevent the following restart. The fix tries to address it.