### PR TITLE
Query Cache: Try to fix bad cast from ColumnConst to ColumnVector<char8_t>

### DIFF
--- a/src/Interpreters/Cache/QueryCache.cpp
+++ b/src/Interpreters/Cache/QueryCache.cpp
@@ -263,23 +263,23 @@ void QueryCache::Writer::finalizeWrite()
 
     if (auto entry = cache.getWithKey(key); entry.has_value() && !IsStale()(entry->key))
     {
-        /// same check as in ctor because a parallel Writer could have inserted the current key in the meantime
+        /// Same check as in ctor because a parallel Writer could have inserted the current key in the meantime
         LOG_TRACE(&Poco::Logger::get("QueryCache"), "Skipped insert (non-stale entry found), query: {}", key.queryStringFromAst());
         return;
     }
 
     if (squash_partial_results)
     {
-        // Squash partial result chunks to chunks of size 'max_block_size' each. This costs some performance but provides a more natural
-        // compression of neither too small nor big blocks. Also, it will look like 'max_block_size' is respected when the query result is
-        // served later on from the query cache.
+        /// Squash partial result chunks to chunks of size 'max_block_size' each. This costs some performance but provides a more natural
+        /// compression of neither too small nor big blocks. Also, it will look like 'max_block_size' is respected when the query result is
+        /// served later on from the query cache.
 
         Chunks squashed_chunks;
         size_t rows_remaining_in_squashed = 0; /// how many further rows can the last squashed chunk consume until it reaches max_block_size
 
         for (auto & chunk : query_result->chunks)
         {
-            convertToFullIfSparse(chunk);
+            convertToFullIfNeeded(chunk);
 
             const size_t rows_chunk = chunk.getNumRows();
             if (rows_chunk == 0)

--- a/src/Interpreters/Cache/QueryCache.cpp
+++ b/src/Interpreters/Cache/QueryCache.cpp
@@ -233,6 +233,7 @@ void QueryCache::Writer::buffer(Chunk && chunk, ChunkType chunk_type)
             auto & buffered_chunk = (chunk_type == ChunkType::Totals) ? query_result->totals : query_result->extremes;
 
             convertToFullIfSparse(chunk);
+            convertToFullIfConst(chunk);
 
             if (!buffered_chunk.has_value())
                 buffered_chunk = std::move(chunk);
@@ -279,7 +280,8 @@ void QueryCache::Writer::finalizeWrite()
 
         for (auto & chunk : query_result->chunks)
         {
-            convertToFullIfNeeded(chunk);
+            convertToFullIfSparse(chunk);
+            convertToFullIfConst(chunk);
 
             const size_t rows_chunk = chunk.getNumRows();
             if (rows_chunk == 0)

--- a/src/Processors/Chunk.cpp
+++ b/src/Processors/Chunk.cpp
@@ -212,30 +212,13 @@ void convertToFullIfConst(Chunk & chunk)
     chunk.setColumns(std::move(columns), num_rows);
 }
 
-void convertToFullIfLowCardinality(Chunk & chunk)
-{
-    size_t num_rows = chunk.getNumRows();
-    auto columns = chunk.detachColumns();
-    for (auto & column : columns)
-        column = recursiveRemoveLowCardinality(column);
-    chunk.setColumns(std::move(columns), num_rows);
-}
-
 void convertToFullIfSparse(Chunk & chunk)
 {
     size_t num_rows = chunk.getNumRows();
     auto columns = chunk.detachColumns();
     for (auto & column : columns)
         column = recursiveRemoveSparse(column);
-
     chunk.setColumns(std::move(columns), num_rows);
-}
-
-void convertToFullIfNeeded(Chunk & chunk)
-{
-    convertToFullIfSparse(chunk);
-    convertToFullIfConst(chunk);
-    convertToFullIfLowCardinality(chunk);
 }
 
 }

--- a/src/Processors/Chunk.h
+++ b/src/Processors/Chunk.h
@@ -150,8 +150,6 @@ private:
 /// or when you need to perform operation with two columns
 /// and their structure must be equal (e.g. compareAt).
 void convertToFullIfConst(Chunk & chunk);
-void convertToFullIfLowCardinality(Chunk & chunk);
 void convertToFullIfSparse(Chunk & chunk);
-void convertToFullIfNeeded(Chunk & chunk);
 
 }

--- a/src/Processors/Chunk.h
+++ b/src/Processors/Chunk.h
@@ -149,6 +149,9 @@ private:
 /// It's needed, when you have to access to the internals of the column,
 /// or when you need to perform operation with two columns
 /// and their structure must be equal (e.g. compareAt).
+void convertToFullIfConst(Chunk & chunk);
+void convertToFullIfLowCardinality(Chunk & chunk);
 void convertToFullIfSparse(Chunk & chunk);
+void convertToFullIfNeeded(Chunk & chunk);
 
 }


### PR DESCRIPTION
Hopefully resolves #49445

The query cache buffers query result chunks and eventually squashes them before insertion into the cache. Here, squashing failed because not all chunks were of the same type. Looks like chunks of the same underlying type (e.g. UInt8) in a query result can be of mixed const, sparse or low-cardinality type. Fixed this by always materializing the data regardless of the compression. Strange thing is that the failing query in the stress test (*) isn't able to reproduce the bug, and I haven't managed to trigger the issue otherwise --> no test case added.

(*) `SELECT 1 UNION ALL SELECT 1 INTERSECT SELECT 1`,  [here](https://s3.amazonaws.com/clickhouse-test-reports/0/18817517ed6f8849e3d979e10fbb273e0edf0eaa/stress_test__debug_/fatal_messages.txt)

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix assert in query cache with mixed const/non-const result chunks