### PR TITLE
Temporarily disable annoy index tests (flaky for analyzer)

### DIFF
--- a/tests/queries/0_stateless/02354_annoy_index.sql
+++ b/tests/queries/0_stateless/02354_annoy_index.sql
@@ -1,4 +1,4 @@
--- Tags: no-fasttest, no-ubsan, no-cpu-aarch64, no-upgrade-check
+-- Tags: disabled, no-fasttest, no-ubsan, no-cpu-aarch64, no-upgrade-check
 
 SET allow_experimental_annoy_index = 1;
 


### PR DESCRIPTION
Introduced with https://github.com/ClickHouse/ClickHouse/pull/50312, https://github.com/ClickHouse/ClickHouse/pull/50661 will re-enable the test and make a real fix.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)