### PR TITLE
Show correct sharing state in system.query_cache

### DIFF
--- a/src/Storages/System/StorageSystemQueryCache.cpp
+++ b/src/Storages/System/StorageSystemQueryCache.cpp
@@ -47,7 +47,7 @@ void StorageSystemQueryCache::fillData(MutableColumns & res_columns, ContextPtr 
         res_columns[0]->insert(key.queryStringFromAst()); /// approximates the original query string
         res_columns[1]->insert(QueryCache::QueryCacheEntryWeight()(*query_result));
         res_columns[2]->insert(key.expires_at < std::chrono::system_clock::now());
-        res_columns[3]->insert(!key.is_shared);
+        res_columns[3]->insert(key.is_shared);
         res_columns[4]->insert(key.is_compressed);
         res_columns[5]->insert(std::chrono::system_clock::to_time_t(key.expires_at));
         res_columns[6]->insert(key.ast->getTreeHash().first);


### PR DESCRIPTION
undocumented dev view --> not for changelog

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)