### PR TITLE
MaterializedMySQL: Add test_named_collections

### DIFF
--- a/tests/integration/test_materialized_mysql_database/configs/users.xml
+++ b/tests/integration/test_materialized_mysql_database/configs/users.xml
@@ -14,6 +14,7 @@
                 <ip>::/0</ip>
             </networks>
             <profile>default</profile>
+            <named_collection_control>1</named_collection_control>
         </default>
     </users>
 </clickhouse>

--- a/tests/integration/test_materialized_mysql_database/test.py
+++ b/tests/integration/test_materialized_mysql_database/test.py
@@ -523,3 +523,9 @@ def test_materialized_database_mysql_drop_ddl(
 ):
     materialize_with_ddl.dropddl(clickhouse_node, started_mysql_8_0, "mysql80")
     materialize_with_ddl.dropddl(clickhouse_node, started_mysql_5_7, "mysql57")
+
+
+def test_named_collections(started_cluster, started_mysql_8_0, clickhouse_node):
+    materialize_with_ddl.named_collections(
+        clickhouse_node, started_mysql_8_0, "mysql80"
+    )


### PR DESCRIPTION
Adding missed test for named collections

There is a test for MySQL, but not for MaterializedMySQL.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

