### PR TITLE
Fix checking the lock file too often while writing a backup

### DIFF
--- a/src/Backups/BackupImpl.cpp
+++ b/src/Backups/BackupImpl.cpp
@@ -144,6 +144,7 @@ void BackupImpl::open(const ContextPtr & context)
         if (!uuid)
             uuid = UUIDHelpers::generateV4();
         lock_file_name = use_archive ? (archive_params.archive_name + ".lock") : ".lock";
+        lock_file_before_first_file_checked = false;
         writing_finalized = false;
 
         /// Check that we can write a backup there and create the lock file to own this destination.
@@ -833,13 +834,10 @@ void BackupImpl::writeFile(const BackupFileInfo & info, BackupEntryPtr entry)
     if (writing_finalized)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Backup is already finalized");
 
-    bool should_check_lock_file = false;
     {
         std::lock_guard lock{mutex};
         ++num_files;
         total_size += info.size;
-        if (!num_entries)
-            should_check_lock_file = true;
     }
 
     auto src_disk = entry->getDisk();
@@ -859,7 +857,7 @@ void BackupImpl::writeFile(const BackupFileInfo & info, BackupEntryPtr entry)
         return;
     }
 
-    if (!should_check_lock_file)
+    if (!lock_file_before_first_file_checked.exchange(true))
         checkLockFile(true);
 
     /// NOTE: `mutex` must be unlocked during copying otherwise writing will be in one thread maximum and hence slow.

--- a/src/Backups/BackupImpl.h
+++ b/src/Backups/BackupImpl.h
@@ -141,6 +141,7 @@ private:
     std::shared_ptr<IArchiveReader> archive_reader;
     std::shared_ptr<IArchiveWriter> archive_writer;
     String lock_file_name;
+    std::atomic<bool> lock_file_before_first_file_checked = false;
 
     bool writing_finalized = false;
     bool deduplicate_files = true;


### PR DESCRIPTION
### Changelog category:
- Bug Fix

### Changelog entry:
Fix checking the lock file too often while writing a backup