### PR TITLE
A bit safer UserDefinedSQLFunctionVisitor

### DIFF
--- a/src/Functions/UserDefined/UserDefinedSQLFunctionVisitor.cpp
+++ b/src/Functions/UserDefined/UserDefinedSQLFunctionVisitor.cpp
@@ -26,7 +26,10 @@ namespace ErrorCodes
 void UserDefinedSQLFunctionVisitor::visit(ASTPtr & ast)
 {
     if (!ast)
+    {
+        chassert(false);
         return;
+    }
 
     const auto visit_child_with_shared_ptr = [&](ASTPtr & child)
     {

--- a/src/Functions/UserDefined/UserDefinedSQLFunctionVisitor.cpp
+++ b/src/Functions/UserDefined/UserDefinedSQLFunctionVisitor.cpp
@@ -25,6 +25,9 @@ namespace ErrorCodes
 
 void UserDefinedSQLFunctionVisitor::visit(ASTPtr & ast)
 {
+    if (!ast)
+        return;
+
     const auto visit_child_with_shared_ptr = [&](ASTPtr & child)
     {
         if (!child)


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Saves from the crash https://pastila.nl/?00214769/c29d92391704905dd2bf12092751178e.
Though it is still a question why some child in `ast->children` is `nullptr`, but this crash is not reproducible stably.