### PR TITLE
MaterializedMySQL: Add missing DROP DATABASE for tests

### DIFF
--- a/tests/integration/test_materialized_mysql_database/materialize_with_ddl.py
+++ b/tests/integration/test_materialized_mysql_database/materialize_with_ddl.py
@@ -1476,6 +1476,9 @@ def utf8mb4_test(clickhouse_node, mysql_node, service_name):
         "1\t\U0001F984\n2\t\u2601\n",
     )
 
+    clickhouse_node.query("DROP DATABASE utf8mb4_test")
+    mysql_node.query("DROP DATABASE utf8mb4_test")
+
 
 def system_parts_test(clickhouse_node, mysql_node, service_name):
     mysql_node.query("DROP DATABASE IF EXISTS system_parts_test")
@@ -1504,6 +1507,9 @@ def system_parts_test(clickhouse_node, mysql_node, service_name):
     clickhouse_node.query("OPTIMIZE TABLE system_parts_test.test")
     check_active_parts(1)
 
+    clickhouse_node.query("DROP DATABASE system_parts_test")
+    mysql_node.query("DROP DATABASE system_parts_test")
+
 
 def multi_table_update_test(clickhouse_node, mysql_node, service_name):
     mysql_node.query("DROP DATABASE IF EXISTS multi_table_update")
@@ -1529,6 +1535,8 @@ def multi_table_update_test(clickhouse_node, mysql_node, service_name):
 
     check_query(clickhouse_node, "SELECT * FROM multi_table_update.a", "1\tbaz\n")
     check_query(clickhouse_node, "SELECT * FROM multi_table_update.b", "1\tquux\n")
+    clickhouse_node.query("DROP DATABASE multi_table_update")
+    mysql_node.query("DROP DATABASE multi_table_update")
 
 
 def system_tables_test(clickhouse_node, mysql_node, service_name):
@@ -1548,6 +1556,9 @@ def system_tables_test(clickhouse_node, mysql_node, service_name):
         "SELECT partition_key, sorting_key, primary_key FROM system.tables WHERE database = 'system_tables_test' AND name = 'test'",
         "intDiv(id, 4294967)\tid\tid\n",
     )
+
+    clickhouse_node.query("DROP DATABASE system_tables_test")
+    mysql_node.query("DROP DATABASE system_tables_test")
 
 
 def materialize_with_column_comments_test(clickhouse_node, mysql_node, service_name):


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
