### PR TITLE
Fix 'Illegal column timezone' in stress tests

### DIFF
--- a/docker/test/upgrade/run.sh
+++ b/docker/test/upgrade/run.sh
@@ -59,8 +59,7 @@ install_packages previous_release_package_folder
 # available for dump via clickhouse-local
 configure
 
-# it contains some new settings, but we can safely remove it
-rm /etc/clickhouse-server/config.d/merge_tree.xml
+rm /etc/clickhouse-server/users.d/nonconst_timezone.xml
 
 start
 stop
@@ -86,8 +85,7 @@ export USE_S3_STORAGE_FOR_MERGE_TREE=1
 export ZOOKEEPER_FAULT_INJECTION=0
 configure
 
-# it contains some new settings, but we can safely remove it
-rm /etc/clickhouse-server/config.d/merge_tree.xml
+rm /etc/clickhouse-server/users.d/nonconst_timezone.xml
 
 start
 

--- a/tests/config/install.sh
+++ b/tests/config/install.sh
@@ -78,6 +78,7 @@ ln -sf $SRC_PATH/users.d/enable_blobs_check.xml $DEST_SERVER_PATH/users.d/
 ln -sf $SRC_PATH/users.d/marks.xml $DEST_SERVER_PATH/users.d/
 ln -sf $SRC_PATH/users.d/insert_keeper_retries.xml $DEST_SERVER_PATH/users.d/
 ln -sf $SRC_PATH/users.d/prefetch_settings.xml $DEST_SERVER_PATH/users.d/
+ln -sf $SRC_PATH/users.d/nonconst_timezone.xml $DEST_SERVER_PATH/users.d/
 
 if [[ -n "$USE_NEW_ANALYZER" ]] && [[ "$USE_NEW_ANALYZER" -eq 1 ]]; then
     ln -sf $SRC_PATH/users.d/analyzer.xml $DEST_SERVER_PATH/users.d/

--- a/tests/config/users.d/nonconst_timezone.xml
+++ b/tests/config/users.d/nonconst_timezone.xml
@@ -1,0 +1,7 @@
+<clickhouse>
+    <profiles>
+        <default>
+            <allow_nonconst_timezone_arguments>1</allow_nonconst_timezone_arguments>
+        </default>
+    </profiles>
+</clickhouse>


### PR DESCRIPTION

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Related to https://github.com/ClickHouse/ClickHouse/pull/50834
Fixes https://s3.amazonaws.com/clickhouse-test-reports/50487/42393b51ee1747e838c71196a29eb305fca6257c/stress_test__tsan_.html 