### PR TITLE
Fix the statless tests image for old commits

### DIFF
--- a/docker/test/stateless/run.sh
+++ b/docker/test/stateless/run.sh
@@ -16,7 +16,7 @@ dpkg -i package_folder/clickhouse-client_*.deb
 ln -s /usr/share/clickhouse-test/clickhouse-test /usr/bin/clickhouse-test
 
 # shellcheck disable=SC1091
-source /usr/share/clickhouse-test/ci/attach_gdb.lib
+source /usr/share/clickhouse-test/ci/attach_gdb.lib || true  # FIXME: to not break old builds, clean on 2023-09-01
 
 # install test configs
 /usr/share/clickhouse-test/config/install.sh
@@ -88,7 +88,7 @@ fi
 
 sleep 5
 
-attach_gdb_to_clickhouse
+attach_gdb_to_clickhouse || true  # FIXME: to not break old builds, clean on 2023-09-01
 
 function run_tests()
 {


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
The tests unfortunately are broken for old commits now because of #50487, it makes it working everywhere