### PR TITLE
Add ability to log when max_partitions_per_insert_block is reached

### DIFF
--- a/docs/en/operations/settings/query-complexity.md
+++ b/docs/en/operations/settings/query-complexity.md
@@ -298,7 +298,7 @@ Default value: `THROW`.
 - [JOIN clause](../../sql-reference/statements/select/join.md#select-join)
 - [Join table engine](../../engines/table-engines/special/join.md)
 
-## max_partitions_per_insert_block {#max-partitions-per-insert-block}
+## max_partitions_per_insert_block {#settings-max_partitions_per_insert_block}
 
 Limits the maximum number of partitions in a single inserted block.
 
@@ -309,9 +309,18 @@ Default value: 100.
 
 **Details**
 
-When inserting data, ClickHouse calculates the number of partitions in the inserted block. If the number of partitions is more than `max_partitions_per_insert_block`, ClickHouse throws an exception with the following text:
+When inserting data, ClickHouse calculates the number of partitions in the inserted block. If the number of partitions is more than `max_partitions_per_insert_block`, ClickHouse either logs a warning or throws an exception based on `throw_on_max_partitions_per_insert_block`. Exceptions have the following text:
 
-> “Too many partitions for single INSERT block (more than” + toString(max_parts) + “). The limit is controlled by ‘max_partitions_per_insert_block’ setting. A large number of partitions is a common misconception. It will lead to severe negative performance impact, including slow server startup, slow INSERT queries and slow SELECT queries. Recommended total number of partitions for a table is under 1000..10000. Please note, that partitioning is not intended to speed up SELECT queries (ORDER BY key is sufficient to make range queries fast). Partitions are intended for data manipulation (DROP PARTITION, etc).”
+> “Too many partitions for a single INSERT block (`partitions_count` partitions, limit is ” + toString(max_partitions) + “). The limit is controlled by the ‘max_partitions_per_insert_block’ setting. A large number of partitions is a common misconception. It will lead to severe negative performance impact, including slow server startup, slow INSERT queries and slow SELECT queries. Recommended total number of partitions for a table is under 1000..10000. Please note, that partitioning is not intended to speed up SELECT queries (ORDER BY key is sufficient to make range queries fast). Partitions are intended for data manipulation (DROP PARTITION, etc).”
+
+## throw_on_max_partitions_per_insert_block {#settings-throw_on_max_partition_per_insert_block}
+
+Allows you to control behaviour when `max_partitions_per_insert_block` is reached.
+
+- `true`  - When an insert block reaches `max_partitions_per_insert_block`, an exception is raised.
+- `false` - Logs a warning when `max_partitions_per_insert_block` is reached.
+
+Default value: `true`
 
 ## max_temporary_data_on_disk_size_for_user {#settings_max_temporary_data_on_disk_size_for_user}
 

--- a/docs/ru/operations/settings/query-complexity.md
+++ b/docs/ru/operations/settings/query-complexity.md
@@ -311,7 +311,7 @@ FORMAT Null;
 
 **Подробности**
 
-При вставке данных ClickHouse проверяет количество разделов в вставляемом блоке. Если количество разделов превышает число `max_partitions_per_insert_block`, ClickHouse либо регистрирует, либо выбрасывает исключение на основе `throw_on_max_partitions_per_insert_block`.  Исключения имеют следующий текст:
+При вставке данных ClickHouse проверяет количество партиций во вставляемом блоке. Если количество разделов превышает число `max_partitions_per_insert_block`, ClickHouse либо логирует предупреждение, либо выбрасывает исключение в зависимости от значения `throw_on_max_partitions_per_insert_block`.  Исключения имеют следующий текст:
 
 > “Too many partitions for a single INSERT block (`partitions_count` partitions, limit is ” + toString(max_partitions) + “). The limit is controlled by the ‘max_partitions_per_insert_block’ setting. A large number of partitions is a common misconception. It will lead to severe negative performance impact, including slow server startup, slow INSERT queries and slow SELECT queries. Recommended total number of partitions for a table is under 1000..10000. Please note, that partitioning is not intended to speed up SELECT queries (ORDER BY key is sufficient to make range queries fast). Partitions are intended for data manipulation (DROP PARTITION, etc).”
 

--- a/docs/ru/operations/settings/query-complexity.md
+++ b/docs/ru/operations/settings/query-complexity.md
@@ -317,7 +317,7 @@ FORMAT Null;
 
 ## throw_on_max_partitions_per_insert_block {#settings-throw_on_max_partition_per_insert_block}
 
-Pozvolyayet vam kontrolirovat' povedeniye pri dostizhenii `max_partitions_per_insert_block`
+Позволяет контролировать поведение при достижении `max_partitions_per_insert_block`
 
 - `true`  - Когда вставляемый блок достигает max_partitions_per_insert_block, возникает исключение.
 - `false` - Записывает предупреждение при достижении `max_partitions_per_insert_block`.

--- a/docs/ru/operations/settings/query-complexity.md
+++ b/docs/ru/operations/settings/query-complexity.md
@@ -319,7 +319,7 @@ FORMAT Null;
 
 Позволяет контролировать поведение при достижении `max_partitions_per_insert_block`
 
-- `true`  - Когда вставляемый блок достигает max_partitions_per_insert_block, возникает исключение.
+- `true`  - Когда вставляемый блок достигает `max_partitions_per_insert_block`, возникает исключение.
 - `false` - Записывает предупреждение при достижении `max_partitions_per_insert_block`.
 
 Значение по умолчанию: `true`

--- a/docs/ru/operations/settings/query-complexity.md
+++ b/docs/ru/operations/settings/query-complexity.md
@@ -311,9 +311,18 @@ FORMAT Null;
 
 **Подробности**
 
-При вставке данных, ClickHouse вычисляет количество партиций во вставленном блоке. Если число партиций больше, чем `max_partitions_per_insert_block`, ClickHouse генерирует исключение со следующим текстом:
+При вставке данных ClickHouse проверяет количество разделов в вставляемом блоке. Если количество разделов превышает число `max_partitions_per_insert_block`, ClickHouse либо регистрирует, либо выбрасывает исключение на основе `throw_on_max_partitions_per_insert_block`.  Исключения имеют следующий текст:
 
-> «Too many partitions for single INSERT block (more than» + toString(max_parts) + «). The limit is controlled by ‘max_partitions_per_insert_block’ setting. Large number of partitions is a common misconception. It will lead to severe negative performance impact, including slow server startup, slow INSERT queries and slow SELECT queries. Recommended total number of partitions for a table is under 1000..10000. Please note, that partitioning is not intended to speed up SELECT queries (ORDER BY key is sufficient to make range queries fast). Partitions are intended for data manipulation (DROP PARTITION, etc).»
+> “Too many partitions for a single INSERT block (`partitions_count` partitions, limit is ” + toString(max_partitions) + “). The limit is controlled by the ‘max_partitions_per_insert_block’ setting. A large number of partitions is a common misconception. It will lead to severe negative performance impact, including slow server startup, slow INSERT queries and slow SELECT queries. Recommended total number of partitions for a table is under 1000..10000. Please note, that partitioning is not intended to speed up SELECT queries (ORDER BY key is sufficient to make range queries fast). Partitions are intended for data manipulation (DROP PARTITION, etc).”
+
+## throw_on_max_partitions_per_insert_block {#settings-throw_on_max_partition_per_insert_block}
+
+Pozvolyayet vam kontrolirovat' povedeniye pri dostizhenii `max_partitions_per_insert_block`
+
+- `true`  - Когда вставляемый блок достигает max_partitions_per_insert_block, возникает исключение.
+- `false` - Записывает предупреждение при достижении `max_partitions_per_insert_block`.
+
+Значение по умолчанию: `true`
 
 ## max_sessions_for_user {#max-sessions-per-user}
 

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -500,6 +500,7 @@ class IColumn;
     M(Bool, formatdatetime_parsedatetime_m_is_month_name, true, "Formatter '%M' in functions 'formatDateTime()' and 'parseDateTime()' produces the month name instead of minutes.", 0) \
     \
     M(UInt64, max_partitions_per_insert_block, 100, "Limit maximum number of partitions in single INSERTed block. Zero means unlimited. Throw exception if the block contains too many partitions. This setting is a safety threshold, because using large number of partitions is a common misconception.", 0) \
+    M(Bool, throw_on_max_partitions_per_insert_block, true, "Used with max_partitions_per_insert_block. If true (default), an exception will be thrown when max_partitions_per_insert_block is reached. If false, details of the insert query reaching this limit with the number of partitions will be logged. This can be useful if you're trying to understand the impact on users when changing max_partitions_per_insert_block.", 0) \
     M(Int64, max_partitions_to_read, -1, "Limit the max number of partitions that can be accessed in one query. <= 0 means unlimited.", 0) \
     M(Bool, check_query_single_value_result, true, "Return check query result as single 1/0 value", 0) \
     M(Bool, allow_drop_detached, false, "Allow ALTER TABLE ... DROP DETACHED PART[ITION] ... queries", 0) \

--- a/tests/queries/0_stateless/01593_insert_settings.sql
+++ b/tests/queries/0_stateless/01593_insert_settings.sql
@@ -3,6 +3,8 @@ create table data_01593 (key Int) engine=MergeTree() order by key partition by k
 
 insert into data_01593 select * from numbers_mt(10);
 insert into data_01593 select * from numbers_mt(10) settings max_partitions_per_insert_block=1; -- { serverError TOO_MANY_PARTS }
+-- throw_on_max_partitions_per_insert_block=false means we'll just log that the limit was reached rather than throw
+insert into data_01593 select * from numbers_mt(10) settings max_partitions_per_insert_block=1, throw_on_max_partitions_per_insert_block=false;
 -- settings for INSERT is prefered
 insert into data_01593 settings max_partitions_per_insert_block=100 select * from numbers_mt(10) settings max_partitions_per_insert_block=1;
 


### PR DESCRIPTION
If you wish to reduce the value of  `max_partitions_per_insert_block` down from it's default of 100, 
it can difficult to do without knowing which inserts/clients would be impacted.

This commit adds the ability to log when the above limit is reached rather than throw an exception,
so that you can gauge the impact on users when dropping this value down.
Also incrementing the RejectedInserts ProfileEvent when this is encountered so rejections here are accounted for.


### Changelog category (leave one):
- Improvement



### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add ability to log when max_partitions_per_insert_block is reached
...

