### PR TITLE
Fix logic in `AsynchronousBoundedReadBuffer::seek`

### DIFF
--- a/src/Disks/IO/AsynchronousBoundedReadBuffer.cpp
+++ b/src/Disks/IO/AsynchronousBoundedReadBuffer.cpp
@@ -301,9 +301,8 @@ off_t AsynchronousBoundedReadBuffer::seek(off_t offset, int whence)
     * Lazy ignore. Save number of bytes to ignore and ignore it either for prefetch buffer or current buffer.
     * Note: we read in range [file_offset_of_buffer_end, read_until_position).
     */
-    if (file_offset_of_buffer_end && read_until_position && new_pos < *read_until_position
-        && new_pos > file_offset_of_buffer_end
-        && new_pos < file_offset_of_buffer_end + read_settings.remote_read_min_bytes_for_seek)
+    if (!impl->seekIsCheap() && file_offset_of_buffer_end && read_until_position && new_pos < *read_until_position
+        && new_pos > file_offset_of_buffer_end && new_pos < file_offset_of_buffer_end + read_settings.remote_read_min_bytes_for_seek)
     {
         ProfileEvents::increment(ProfileEvents::RemoteFSLazySeeks);
         bytes_to_ignore = new_pos - file_offset_of_buffer_end;

--- a/src/Disks/IO/ReadBufferFromRemoteFSGather.h
+++ b/src/Disks/IO/ReadBufferFromRemoteFSGather.h
@@ -50,6 +50,8 @@ public:
 
     off_t getPosition() override { return file_offset_of_buffer_end - available() + bytes_to_ignore; }
 
+    bool seekIsCheap() override { return !current_buf; }
+
 private:
     SeekableReadBufferPtr createImplementationBuffer(const StoredObject & object);
 

--- a/src/IO/SeekableReadBuffer.h
+++ b/src/IO/SeekableReadBuffer.h
@@ -83,6 +83,10 @@ public:
 
     /// Checks if readBigAt() is allowed. May be slow, may throw (e.g. it may do an HTTP request or an fstat).
     virtual bool supportsReadAt() { return false; }
+
+    /// We do some tricks to avoid seek cost. E.g we read more data and than ignore it (see remote_read_min_bytes_for_seek).
+    /// Sometimes however seek is basically free because underlying read buffer wasn't yet initialised (or re-initialised after reset).
+    virtual bool seekIsCheap() { return false; }
 };
 
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required) 

---

Previously (before #50109) we checked that `impl->initialized()` and only then choose the branch that reads with ignore. As turned out that we may over-read really significant amounts, specifically I saw x7 more `RemoteFSLazySeeks` on hits Q23.
`ReadBufferFromRemoteFSGather` no longer has `initialized` method, so I created dedicated method in `SeekableReadBuffer` with more or less clear purpose. But I'm open to suggestions.