### PR TITLE
Fix erroneous `sort_description` propagation in `CreatingSets`

### DIFF
--- a/src/Processors/QueryPlan/CreatingSetsStep.cpp
+++ b/src/Processors/QueryPlan/CreatingSetsStep.cpp
@@ -80,7 +80,7 @@ CreatingSetsStep::CreatingSetsStep(DataStreams input_streams_)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "CreatingSetsStep cannot be created with no inputs");
 
     input_streams = std::move(input_streams_);
-    output_stream = input_streams.front();
+    output_stream = DataStream{input_streams.front().header};
 
     for (size_t i = 1; i < input_streams.size(); ++i)
         if (input_streams[i].header)

--- a/tests/queries/0_stateless/02788_fix_logical_error_in_sorting.sql
+++ b/tests/queries/0_stateless/02788_fix_logical_error_in_sorting.sql
@@ -1,0 +1,77 @@
+CREATE TABLE session_events
+(
+    clientId UInt64,
+    sessionId String,
+    pageId UInt64,
+    eventNumber UInt64,
+    timestamp UInt64,
+    type LowCardinality(String),
+    data String
+)
+ENGINE = MergeTree
+PARTITION BY toYYYYMM(toDate(pageId / 1000))
+ORDER BY (clientId, sessionId, pageId, timestamp);
+
+CREATE TABLE event_types
+(
+    type String,
+    active Int16
+)
+ENGINE = MergeTree
+PARTITION BY substring(type, 1, 1)
+ORDER BY (type, active);
+
+SYSTEM STOP MERGES session_events;
+SYSTEM STOP MERGES event_types;
+
+INSERT INTO session_events SELECT
+    141,
+    '693de636-6d9b-47b7-b52a-33bd303b6255',
+    1686053240314,
+    number,
+    number,
+    toString(number % 10),
+    ''
+FROM numbers_mt(100000);
+
+INSERT INTO session_events SELECT
+    141,
+    '693de636-6d9b-47b7-b52a-33bd303b6255',
+    1686053240314,
+    number,
+    number,
+    toString(number % 10),
+    ''
+FROM numbers_mt(100000);
+
+INSERT INTO event_types SELECT
+    toString(number % 10),
+    number % 2
+FROM numbers(20);
+
+SET optimize_sorting_by_input_stream_properties = 1;
+
+-- We check only that no exception was thrown
+EXPLAIN PIPELINE
+SELECT
+    pageId,
+    [prev_active_ts, timestamp] AS inactivity_timestamps,
+    timestamp - prev_active_ts AS inactive_duration,
+    timestamp
+FROM
+(
+    SELECT
+        pageId,
+        timestamp,
+        neighbor(timestamp, -1) AS prev_active_ts
+    FROM session_events
+    WHERE (type IN (
+        SELECT type
+        FROM event_types
+        WHERE active = 1
+    )) AND (sessionId = '693de636-6d9b-47b7-b52a-33bd303b6255') AND (session_events.clientId = 141) AND (pageId = 1686053240314)
+    ORDER BY timestamp ASC
+)
+WHERE runningDifference(timestamp) >= 500
+ORDER BY timestamp ASC
+FORMAT Null;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Sort description was erroneously propagated through `CreatingSets` step. That could cause `If input stream is globally sorted then there should be only 1 input stream at this stage` error.