### PR TITLE
Fix keeper-client help message

### DIFF
--- a/programs/keeper-client/KeeperClient.cpp
+++ b/programs/keeper-client/KeeperClient.cpp
@@ -127,42 +127,42 @@ void KeeperClient::defineOptions(Poco::Util::OptionSet & options)
 
     options.addOption(
         Poco::Util::Option("host", "h", "server hostname. default `localhost`")
-            .argument("host")
+            .argument("<host>")
             .binding("host"));
 
     options.addOption(
         Poco::Util::Option("port", "p", "server port. default `2181`")
-            .argument("port")
+            .argument("<port>")
             .binding("port"));
 
     options.addOption(
         Poco::Util::Option("query", "q", "will execute given query, then exit.")
-            .argument("query")
+            .argument("<query>")
             .binding("query"));
 
     options.addOption(
         Poco::Util::Option("connection-timeout", "", "set connection timeout in seconds. default 10s.")
-            .argument("connection-timeout")
+            .argument("<seconds>")
             .binding("connection-timeout"));
 
     options.addOption(
         Poco::Util::Option("session-timeout", "", "set session timeout in seconds. default 10s.")
-            .argument("session-timeout")
+            .argument("<seconds>")
             .binding("session-timeout"));
 
     options.addOption(
         Poco::Util::Option("operation-timeout", "", "set operation timeout in seconds. default 10s.")
-            .argument("operation-timeout")
+            .argument("<seconds>")
             .binding("operation-timeout"));
 
     options.addOption(
         Poco::Util::Option("history-file", "", "set path of history file. default `~/.keeper-client-history`")
-            .argument("history-file")
+            .argument("<file>")
             .binding("history-file"));
 
     options.addOption(
         Poco::Util::Option("log-level", "", "set log level")
-            .argument("log-level")
+            .argument("<level>")
             .binding("log-level"));
 }
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...
