### PR TITLE
fix build issue on clang 15

### DIFF
--- a/src/Formats/CapnProtoSerializer.cpp
+++ b/src/Formats/CapnProtoSerializer.cpp
@@ -751,7 +751,7 @@ namespace
     private:
         using Reader = typename CapnpType::Reader;
 
-        CapnpType::Reader getData(const ColumnPtr & column, size_t row_num)
+        typename CapnpType::Reader getData(const ColumnPtr & column, size_t row_num)
         {
             auto data = column->getDataAt(row_num);
             if constexpr (std::is_same_v<CapnpType, capnp::Data>)
@@ -801,7 +801,7 @@ namespace
     private:
         using Reader = typename CapnpType::Reader;
 
-        CapnpType::Reader getData(const ColumnPtr & column, size_t row_num)
+        typename CapnpType::Reader getData(const ColumnPtr & column, size_t row_num)
         {
             auto data = column->getDataAt(row_num);
             if constexpr (std::is_same_v<CapnpType, capnp::Data>)

--- a/src/Formats/CapnProtoSerializer.cpp
+++ b/src/Formats/CapnProtoSerializer.cpp
@@ -751,7 +751,7 @@ namespace
     private:
         using Reader = typename CapnpType::Reader;
 
-        typename CapnpType::Reader getData(const ColumnPtr & column, size_t row_num)
+        Reader getData(const ColumnPtr & column, size_t row_num)
         {
             auto data = column->getDataAt(row_num);
             if constexpr (std::is_same_v<CapnpType, capnp::Data>)
@@ -801,7 +801,7 @@ namespace
     private:
         using Reader = typename CapnpType::Reader;
 
-        typename CapnpType::Reader getData(const ColumnPtr & column, size_t row_num)
+        Reader getData(const ColumnPtr & column, size_t row_num)
         {
             auto data = column->getDataAt(row_num);
             if constexpr (std::is_same_v<CapnpType, capnp::Data>)


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes
Closes \#50963

It's a minor change and keeps support for clang-15 to ease the transition period

