### PR TITLE
Update delete.md

### DIFF
--- a/docs/en/sql-reference/statements/delete.md
+++ b/docs/en/sql-reference/statements/delete.md
@@ -56,7 +56,7 @@ With the described implementation now we can see what can negatively affect 'DEL
 - Having a lot of data in Compact parts—in a Compact part, all columns are stored in one file.
 
 :::note
-Lightweight delete does not work for tables with projection as rows in projection may be affected and require the projection to be rebuilt. Rebuilding projection makes the deletion not lightweight, so this is not supported. 
+Currently, Lightweight delete does not work for tables with projection as rows in projection may be affected and require the projection to be rebuilt. Rebuilding projection makes the deletion not lightweight, so this is not supported. 
 :::
 
 ## Related content

--- a/docs/en/sql-reference/statements/delete.md
+++ b/docs/en/sql-reference/statements/delete.md
@@ -55,6 +55,9 @@ With the described implementation now we can see what can negatively affect 'DEL
 - Table having a very large number of data parts
 - Having a lot of data in Compact parts—in a Compact part, all columns are stored in one file.
 
+:::note
+Lightweight delete does not work for tables with projection as rows in projection may be affected and require the projection to be rebuilt. Rebuilding projection makes the deletion not lightweight, so this is not supported. 
+:::
 
 ## Related content
 


### PR DESCRIPTION
LWD is not supported in table with projection

```
-- setting up
drop table if exists tbl;
create table tbl (a UInt32, b UInt32) engine=MergeTree order by a;
insert into tbl select number, number from numbers(100);

-- LWD works
delete from tbl where a = 0;

-- add projection
alter table tbl add projection p_tbl (select * order by b);
alter table tbl materialize projection p_tbl;

-- LWD does not work
delete from tbl where a = 1;

6431ca279626 :) delete from tbl where a = 1;

DELETE FROM tbl WHERE a = 1

Query id: 5825deed-22fe-454b-9ae0-fc20632b69ca


0 rows in set. Elapsed: 0.004 sec.

Received exception from server (version 23.3.3):
Code: 36. DB::Exception: Received from localhost:9000. DB::Exception: DELETE query is not supported for table default.tbl. (BAD_ARGUMENTS)
```

### Changelog category (leave one):
- Documentation (changelog entry is not required)