### PR TITLE
Fix data lakes slowness because of synchronous head requests

### DIFF
--- a/src/Storages/StorageS3.cpp
+++ b/src/Storages/StorageS3.cpp
@@ -460,7 +460,7 @@ public:
         for (auto && key : all_keys)
         {
             std::optional<S3::ObjectInfo> info;
-            if (need_total_size)
+            if (need_total_size && all_keys.size() == 1)
             {
                 info = S3::getObjectInfo(client_, bucket, key, version_id_, request_settings_);
                 total_size += info->size;

--- a/src/Storages/StorageS3.cpp
+++ b/src/Storages/StorageS3.cpp
@@ -460,6 +460,9 @@ public:
         for (auto && key : all_keys)
         {
             std::optional<S3::ObjectInfo> info;
+            /// In case all_keys.size() > 1, avoid getting object info now
+            /// (it will be done anyway eventually, but with delay and in parallel).
+            /// But progress bar will not work in this case.
             if (need_total_size && all_keys.size() == 1)
             {
                 info = S3::getObjectInfo(client_, bucket, key, version_id_, request_settings_);


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix data lakes slowness because of synchronous head requests. (Related to Iceberg/Deltalake/Hudi being slow with a lot of files). 