### PR TITLE
MaterializedMySQL: Keep parentheses for empty table overrides

### DIFF
--- a/src/Parsers/ASTTableOverrides.cpp
+++ b/src/Parsers/ASTTableOverrides.cpp
@@ -36,8 +36,6 @@ void ASTTableOverride::formatImpl(const FormatSettings & settings_, FormatState 
         settings.ostr << hl_keyword << "TABLE OVERRIDE " << hl_none;
         ASTIdentifier(table_name).formatImpl(settings, state, frame);
     }
-    if (!columns && (!storage || storage->children.empty()))
-        return;
     auto override_frame = frame;
     if (is_standalone)
     {

--- a/src/Parsers/tests/gtest_Parser.cpp
+++ b/src/Parsers/tests/gtest_Parser.cpp
@@ -215,7 +215,7 @@ INSTANTIATE_TEST_SUITE_P(ParserCreateDatabaseQuery, ParserTest,
         },
         {
             "CREATE DATABASE db ENGINE=Foo TABLE OVERRIDE `tbl` (), TABLE OVERRIDE a (COLUMNS (_created DateTime MATERIALIZED now())), TABLE OVERRIDE b (PARTITION BY rand())",
-            "CREATE DATABASE db\nENGINE = Foo\nTABLE OVERRIDE `tbl`,\nTABLE OVERRIDE `a`\n(\n    COLUMNS\n    (\n        `_created` DateTime MATERIALIZED now()\n    )\n),\nTABLE OVERRIDE `b`\n(\n    PARTITION BY rand()\n)"
+            "CREATE DATABASE db\nENGINE = Foo\nTABLE OVERRIDE `tbl`\n(\n\n),\nTABLE OVERRIDE `a`\n(\n    COLUMNS\n    (\n        `_created` DateTime MATERIALIZED now()\n    )\n),\nTABLE OVERRIDE `b`\n(\n    PARTITION BY rand()\n)"
         },
         {
             "CREATE DATABASE db ENGINE=MaterializeMySQL('addr:port', 'db', 'user', 'pw') TABLE OVERRIDE tbl (COLUMNS (id UUID) PARTITION BY toYYYYMM(created))",

--- a/tests/integration/test_materialized_mysql_database/materialize_with_ddl.py
+++ b/tests/integration/test_materialized_mysql_database/materialize_with_ddl.py
@@ -2032,6 +2032,18 @@ def table_overrides(clickhouse_node, mysql_node, service_name):
         )
 
     clickhouse_node.query("DROP DATABASE IF EXISTS table_overrides")
+    # Check empty table overrides
+    clickhouse_node.query(
+        f"""
+        CREATE DATABASE table_overrides ENGINE=MaterializeMySQL('{service_name}:3306', 'table_overrides', 'root', 'clickhouse')
+        TABLE OVERRIDE t1 ()
+    """
+    )
+    check_query(clickhouse_node, "SELECT count() FROM table_overrides.t1", "1001\n")
+    show_db = clickhouse_node.query("SHOW CREATE DATABASE table_overrides")
+    assert "TABLE OVERRIDE `t1`\\n(\\n\\n)" in show_db, show_db
+
+    clickhouse_node.query("DROP DATABASE IF EXISTS table_overrides")
     mysql_node.query("DROP DATABASE IF EXISTS table_overrides")
 
 


### PR DESCRIPTION
Empty table overrides are formatted without parentheses, but they are required by a parser,
and it is not possible to parse empty table overrides without it.

    :) CREATE DATABASE db ... TABLE OVERRIDE t1()
    
    CREATE DATABASE db
    ...
    TABLE OVERRIDE `t1`

This query will be transfered to metadata and ClickHouse will not be able to start up, since table overrides require ().

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- MaterlializedMySQL: Now empty table overrides are formatted always with parentheses.

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
