### PR TITLE
Change submodule capnproto to it's fork in ClickHouse

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,7 +19,7 @@
 	url = https://github.com/google/googletest
 [submodule "contrib/capnproto"]
 	path = contrib/capnproto
-	url = https://github.com/capnproto/capnproto
+	url = https://github.com/ClickHouse/capnproto
 [submodule "contrib/double-conversion"]
 	path = contrib/double-conversion
 	url = https://github.com/google/double-conversion


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Should've be done in https://github.com/ClickHouse/ClickHouse/pull/49752