### PR TITLE
Use hash_of_all_files to check identity of parts during on-cluster backups

### DIFF
--- a/src/Backups/BackupCoordinationReplicatedTables.cpp
+++ b/src/Backups/BackupCoordinationReplicatedTables.cpp
@@ -185,11 +185,10 @@ void BackupCoordinationReplicatedTables::addPartNames(PartNamesForTableReplica &
                 const String & other_replica_name = **other.replica_names.begin();
                 throw Exception(
                     ErrorCodes::CANNOT_BACKUP_TABLE,
-                    "Table {} on replica {} has part {} which is different from the part on replica {}. Must be the same",
-                    table_name_for_logs,
-                    replica_name,
-                    part_name,
-                    other_replica_name);
+                    "Table {} on replica {} has part {} different from the part on replica {} "
+                    "(checksum '{}' on replica {} != checksum '{}' on replica {})",
+                    table_name_for_logs, replica_name, part_name, other_replica_name,
+                    getHexUIntLowercase(checksum), replica_name, getHexUIntLowercase(other.checksum), other_replica_name);
             }
         }
 

--- a/src/Storages/MergeTree/MergeTreeData.h
+++ b/src/Storages/MergeTree/MergeTreeData.h
@@ -1324,8 +1324,16 @@ protected:
     /// Moves part to specified space, used in ALTER ... MOVE ... queries
     MovePartsOutcome movePartsToSpace(const DataPartsVector & parts, SpacePtr space);
 
+    struct PartBackupEntries
+    {
+        String part_name;
+        UInt128 part_checksum; /// same as MinimalisticDataPartChecksums::hash_of_all_files
+        BackupEntries backup_entries;
+    };
+    using PartsBackupEntries = std::vector<PartBackupEntries>;
+
     /// Makes backup entries to backup the parts of this table.
-    BackupEntries backupParts(const DataPartsVector & data_parts, const String & data_path_in_backup, const BackupSettings & backup_settings, const ContextPtr & local_context);
+    PartsBackupEntries backupParts(const DataPartsVector & data_parts, const String & data_path_in_backup, const BackupSettings & backup_settings, const ContextPtr & local_context);
 
     class RestoredPartsHolder;
 

--- a/src/Storages/StorageMergeTree.cpp
+++ b/src/Storages/StorageMergeTree.cpp
@@ -2160,7 +2160,10 @@ void StorageMergeTree::backupData(BackupEntriesCollector & backup_entries_collec
     for (const auto & data_part : data_parts)
         min_data_version = std::min(min_data_version, data_part->info.getDataVersion() + 1);
 
-    backup_entries_collector.addBackupEntries(backupParts(data_parts, data_path_in_backup, backup_settings, local_context));
+    auto parts_backup_entries = backupParts(data_parts, data_path_in_backup, backup_settings, local_context);
+    for (auto & part_backup_entries : parts_backup_entries)
+        backup_entries_collector.addBackupEntries(std::move(part_backup_entries.backup_entries));
+
     backup_entries_collector.addBackupEntries(backupMutations(min_data_version, data_path_in_backup));
 }
 


### PR DESCRIPTION
### Changelog category:
- Improvement

### Changelog entry:
Use `hash_of_all_files` from `system.parts` to check identity of parts during on-cluster backups.

Instead of a quite specific algorithm https://github.com/ClickHouse/ClickHouse/blob/ffde5affeb54e651afd01454a236a0bd6ac04983/src/Storages/StorageReplicatedMergeTree.cpp#L9359-L9369 to calculate the hash of a MergeTree's part the more common `hash_of_all_files` algorithm will be used from now on.