### PR TITLE
Fix "Illegal column timezone [...]" error in stress tests

### DIFF
--- a/tests/queries/0_stateless/00515_enhanced_time_zones.sql
+++ b/tests/queries/0_stateless/00515_enhanced_time_zones.sql
@@ -68,4 +68,4 @@ DETACH TABLE tab;
 ATTACH TABLE tab SETTINGS allow_nonconst_timezone_arguments = 0; -- { serverError ILLEGAL_COLUMN }
 ATTACH TABLE tab SETTINGS allow_nonconst_timezone_arguments = 1;
 
-DROP TABLE tab;
+DROP TABLE tab SYNC;


### PR DESCRIPTION
https://s3.amazonaws.com/clickhouse-test-reports/0/2643fd2c25bd189c1617892cf96dd372f81403c7/stress_test__asan_.html

https://s3.amazonaws.com/clickhouse-test-reports/0/2643fd2c25bd189c1617892cf96dd372f81403c7/stress_test__asan_/application_errors.txt

Follow-up to #50834

The test creates a table with a special compatibility setting enabled, and eventually DROPs it. The DROP is asynchronous, delayed to after the next restart (performed by the stress test). At this time the setting no longer applies and the table cannot be loaded. The fix is to drop the table synchronously.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)