### PR TITLE
catch ru changelog up to 2023

### DIFF
--- a/docs/ru/whats-new/changelog/2017.mdx
+++ b/docs/ru/whats-new/changelog/2017.mdx
@@ -1,6 +1,6 @@
 ---
 slug: /ru/whats-new/changelog/2017
-sidebar_position: 6
+sidebar_position: 60
 sidebar_label: 2017
 title: 2017 Changelog
 ---

--- a/docs/ru/whats-new/changelog/2018.mdx
+++ b/docs/ru/whats-new/changelog/2018.mdx
@@ -1,6 +1,6 @@
 ---
 slug: /ru/whats-new/changelog/2018
-sidebar_position: 5
+sidebar_position: 50
 sidebar_label: 2018
 title: 2018 Changelog
 ---

--- a/docs/ru/whats-new/changelog/2019.mdx
+++ b/docs/ru/whats-new/changelog/2019.mdx
@@ -1,6 +1,6 @@
 ---
 slug: /ru/whats-new/changelog/2019
-sidebar_position: 4
+sidebar_position: 40
 sidebar_label: 2019
 title: 2019 Changelog
 ---

--- a/docs/ru/whats-new/changelog/2020.mdx
+++ b/docs/ru/whats-new/changelog/2020.mdx
@@ -1,6 +1,6 @@
 ---
 slug: /ru/whats-new/changelog/2020
-sidebar_position: 3
+sidebar_position: 30
 sidebar_label: 2020
 title: 2020 Changelog
 ---

--- a/docs/ru/whats-new/changelog/2021.mdx
+++ b/docs/ru/whats-new/changelog/2021.mdx
@@ -1,6 +1,6 @@
 ---
 slug: /ru/whats-new/changelog/2021
-sidebar_position: 2
+sidebar_position: 20
 sidebar_label: 2021
 title: 2021 Changelog
 ---

--- a/docs/ru/whats-new/changelog/2022.mdx
+++ b/docs/ru/whats-new/changelog/2022.mdx
@@ -1,0 +1,10 @@
+---
+slug: /ru/whats-new/changelog/2022
+sidebar_position: 10
+sidebar_label: 2022
+title: 2022 Changelog
+---
+
+import Changelog from '@site/docs/en/whats-new/changelog/2022.md';
+
+<Changelog />

--- a/docs/ru/whats-new/changelog/_category_.yml
+++ b/docs/ru/whats-new/changelog/_category_.yml
@@ -2,5 +2,5 @@ label: 'Changelog'
 collapsible: true
 collapsed: true
 link:
-  type: doc
-  id: ru/whats-new/changelog/index
+  type: generated-index
+  title: Changelog

--- a/docs/ru/whats-new/changelog/index.mdx
+++ b/docs/ru/whats-new/changelog/index.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 1
-sidebar_label: 2022
-title: 2022 Changelog
+sidebar_label: 2023
+title: 2023 Changelog
 slug: /ru/whats-new/changelog/index
 ---
 

--- a/docs/zh/whats-new/changelog/index.md
+++ b/docs/zh/whats-new/changelog/index.md
@@ -6,4 +6,4 @@ sidebar_label:  Changelog
 
 # Changelog
 
-You can view the latest Changelog at [https://clickhouse.com/docs/en/whats-new/changelog/](https://clickhouse.com/docs/en/whats-new/changelog/)
+You can view the latest Changelog at [https://clickhouse.com/docs/en/whats-new/changelog/](/docs/en/whats-new/changelog/index.md)


### PR DESCRIPTION
index was pointing to 2022

### Changelog category (leave one):
- Documentation (changelog entry is not required)

