### PR TITLE
Fix a compilation error with CAPNP

### DIFF
--- a/src/Formats/CapnProtoSerializer.cpp
+++ b/src/Formats/CapnProtoSerializer.cpp
@@ -751,7 +751,7 @@ namespace
     private:
         using Reader = typename CapnpType::Reader;
 
-        CapnpType::Reader getData(const ColumnPtr & column, size_t row_num)
+        Reader getData(const ColumnPtr & column, size_t row_num)
         {
             auto data = column->getDataAt(row_num);
             if constexpr (std::is_same_v<CapnpType, capnp::Data>)
@@ -801,7 +801,7 @@ namespace
     private:
         using Reader = typename CapnpType::Reader;
 
-        CapnpType::Reader getData(const ColumnPtr & column, size_t row_num)
+        Reader getData(const ColumnPtr & column, size_t row_num)
         {
             auto data = column->getDataAt(row_num);
             if constexpr (std::is_same_v<CapnpType, capnp::Data>)


### PR DESCRIPTION
The compiler complains "missing 'typename' prior to dependent type name 'CapnpType::Reader'". This commit fixes the issue by replacing the original typename with its type alias prefixed by 'typename'.

### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
This issue occurs on my machine with the Clang compiler (Red Hat 15.0.7-1.module_el8.8.0+1258+af79b238). And the build steps list:
`export CC=clang CXX=clang++`
`cmake ../`
`ninja -j $CORE_COUNT`
