### PR TITLE
Fix build errors on clang15 in CapnProtoSerializer

### DIFF
--- a/src/Formats/CapnProtoSerializer.cpp
+++ b/src/Formats/CapnProtoSerializer.cpp
@@ -751,7 +751,7 @@ namespace
     private:
         using Reader = typename CapnpType::Reader;
 
-        CapnpType::Reader getData(const ColumnPtr & column, size_t row_num)
+        typename CapnpType::Reader getData(const ColumnPtr & column, size_t row_num)
         {
             auto data = column->getDataAt(row_num);
             if constexpr (std::is_same_v<CapnpType, capnp::Data>)
@@ -801,7 +801,7 @@ namespace
     private:
         using Reader = typename CapnpType::Reader;
 
-        CapnpType::Reader getData(const ColumnPtr & column, size_t row_num)
+        typename CapnpType::Reader getData(const ColumnPtr & column, size_t row_num)
         {
             auto data = column->getDataAt(row_num);
             if constexpr (std::is_same_v<CapnpType, capnp::Data>)


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

I'm getting these errors: https://pastila.nl/?005ea3d4/2ee24fb084b8be392a98efdd4d418000

(Not sure what's the difference between my machine and everybody else's + CI, where builds apparently succeed. Maybe I'm the only one still on clang 15?)

Closes https://github.com/ClickHouse/ClickHouse/issues/50963