### PR TITLE
Fix a versions' tweak for tagged commits, improve version_helper

### DIFF
--- a/tests/ci/docker_test.py
+++ b/tests/ci/docker_test.py
@@ -10,9 +10,8 @@ from pr_info import PRInfo
 from report import TestResult
 import docker_images_check as di
 
-with patch("git_helper.Git"):
-    from version_helper import get_version_from_string
-    import docker_server as ds
+from version_helper import get_version_from_string
+import docker_server as ds
 
 # di.logging.basicConfig(level=di.logging.INFO)
 
@@ -312,7 +311,3 @@ class TestDockerServer(unittest.TestCase):
         for case in cases_equal:
             release = ds.auto_release_type(case[0], "auto")
             self.assertEqual(case[1], release)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/ci/git_helper.py
+++ b/tests/ci/git_helper.py
@@ -126,15 +126,16 @@ class Git:
         # Format should match TAG_REGEXP
         if self._ignore_no_tags and is_shallow():
             try:
-                self._update_tags()
+                self._update_tags(True)
             except subprocess.CalledProcessError:
                 pass
 
             return
         self._update_tags()
 
-    def _update_tags(self):
-        self.latest_tag = self.run("git describe --tags --abbrev=0")
+    def _update_tags(self, suppress_stderr: bool = False) -> None:
+        stderr = subprocess.DEVNULL if suppress_stderr else None
+        self.latest_tag = self.run("git describe --tags --abbrev=0", stderr=stderr)
         # Format should be: {latest_tag}-{commits_since_tag}-g{sha_short}
         self.description = self.run("git describe --tags --long")
         self.commits_since_tag = int(

--- a/tests/ci/git_helper.py
+++ b/tests/ci/git_helper.py
@@ -171,7 +171,16 @@ class Git:
         if not self.latest_tag.endswith("-testing"):
             # When we are on the tag, we still need to have tweak=1 to not
             # break cmake with versions like 12.13.14.0
-            return self.commits_since_tag or TWEAK
+            if not self.commits_since_tag:
+                # We are in a tagged commit. The tweak should match the
+                # current version's value
+                version = self.latest_tag.split("-", maxsplit=1)[0]
+                try:
+                    return int(version.split(".")[-1])
+                except ValueError:
+                    # There are no tags, or a wrong tag. Return default
+                    return TWEAK
+            return self.commits_since_tag
 
         version = self.latest_tag.split("-", maxsplit=1)[0]
         return int(version.split(".")[-1]) + self.commits_since_tag

--- a/tests/ci/version_helper.py
+++ b/tests/ci/version_helper.py
@@ -335,6 +335,7 @@ def main():
         "--version-type",
         "-t",
         choices=VersionType.VALID,
+        default=VersionType.TESTING,
         help="optional parameter to generate DESCRIBE",
     )
     parser.add_argument(
@@ -344,10 +345,16 @@ def main():
         help="if the ENV variables should be exported",
     )
     parser.add_argument(
-        "--update",
-        "-u",
+        "--update-part",
         choices=("major", "minor", "patch"),
-        help="the version part to update, tweak is always calculated from commits",
+        help="the version part to update, tweak is always calculated from commits, "
+        "implies `--update-cmake`",
+    )
+    parser.add_argument(
+        "--update-cmake",
+        "-u",
+        action="store_true",
+        help=f"is update for {FILE_WITH_VERSION_PATH} is needed or not",
     )
     parser.add_argument(
         "--update-contributors",
@@ -364,13 +371,12 @@ def main():
 
     version = get_version_from_repo(args.version_path, Git(True))
 
-    if args.update:
-        version = version.update(args.update)
+    if args.update_part:
+        version = version.update(args.update_part)
 
-    if args.version_type:
-        version.with_description(args.version_type)
+    version.with_description(args.version_type)
 
-    if args.update:
+    if args.update_part or args.update_cmake:
         update_cmake_version(version)
 
     for k, v in version.as_dict().items():

--- a/tests/ci/version_test.py
+++ b/tests/ci/version_test.py
@@ -11,11 +11,11 @@ class TestFunctions(unittest.TestCase):
         cases = (
             ("0.0.0.0", vh.get_version_from_string("0.0.0.0")),
             ("1.1.1.2", vh.get_version_from_string("1.1.1.2")),
-            ("v1.1.1.2-lts", vh.get_version_from_string("1.1.1.2")),
-            ("v1.1.1.2-prestable", vh.get_version_from_string("1.1.1.2")),
-            ("v1.1.1.2-stable", vh.get_version_from_string("1.1.1.2")),
-            ("v1.1.1.2-testing", vh.get_version_from_string("1.1.1.2")),
-            ("refs/tags/v1.1.1.2-testing", vh.get_version_from_string("1.1.1.2")),
+            ("v11.1.1.2-lts", vh.get_version_from_string("11.1.1.2")),
+            ("v01.1.1.2-prestable", vh.get_version_from_string("1.1.1.2")),
+            ("v21.1.1.2-stable", vh.get_version_from_string("21.1.1.2")),
+            ("v31.1.1.2-testing", vh.get_version_from_string("31.1.1.2")),
+            ("refs/tags/v31.1.1.2-testing", vh.get_version_from_string("31.1.1.2")),
         )
         for test_case in cases:
             version = vh.version_arg(test_case[0])
@@ -25,6 +25,7 @@ class TestFunctions(unittest.TestCase):
             "1.1.1.a",
             "1.1.1.1.1",
             "1.1.1.2-testing",
+            "v1.1.1.2-testing",
             "v1.1.1.2-testin",
             "refs/tags/v1.1.1.2-testin",
         )


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix the `$(git_root)/tests/ci/version_helper.py --update patch` to update `cmake/autogenerated_versions.txt` without changing the version's parts. Besides that, `Git.tweak` now returns a valid value for tagged commits.