### PR TITLE
Do not spam sqlancer build log

### DIFF
--- a/docker/test/sqlancer/Dockerfile
+++ b/docker/test/sqlancer/Dockerfile
@@ -15,7 +15,7 @@ RUN mkdir /sqlancer && \
 	wget -q -O- https://github.com/sqlancer/sqlancer/archive/main.tar.gz | \
 		tar zx -C /sqlancer && \
 	cd /sqlancer/sqlancer-main && \
-	mvn package -DskipTests && \
+	mvn --no-transfer-progress package -DskipTests && \
 	rm -r /root/.m2
 
 COPY run.sh /


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Reduce the docker build log by disabling maven downloading log.