### PR TITLE
Fix subtly broken copy-on-write of ColumnLowCardinality dictionary

### DIFF
--- a/src/Columns/ColumnLowCardinality.h
+++ b/src/Columns/ColumnLowCardinality.h
@@ -340,7 +340,7 @@ private:
         explicit Dictionary(MutableColumnPtr && column_unique, bool is_shared);
         explicit Dictionary(ColumnPtr column_unique, bool is_shared);
 
-        const ColumnPtr & getColumnUniquePtr() const { return column_unique; }
+        const WrappedPtr & getColumnUniquePtr() const { return column_unique; }
         WrappedPtr & getColumnUniquePtr() { return column_unique; }
 
         const IColumnUnique & getColumnUnique() const { return static_cast<const IColumnUnique &>(*column_unique); }


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed occasional LOGICAL_ERROR when using `LowCardinality(String)`: "String offsets has data inconsistent with chars array".

Fixes https://github.com/ClickHouse/ClickHouse/issues/50715 (In addition to LOGICAL_ERRORs there were TSAN errors when it's enabled.)

This line in `ColumnLowCardinality::forEachSubcolumn()`:
```
    callback(dictionary.getColumnUniquePtr());
```
was trying to pass a const reference to `dictionary.column_unique` to `callback`. But that's not what actually happened. `getColumnUniquePtr()` had slightly different return type than `callback`'s argument type (ColumnPtr vs WrappedPtr), so this actually created a temporary local WrappedPtr and used a const reference to *that*.

That would be fine, if not for the fact that `callback` then const_casts the reference and assigns it. So it ended up assigning a temporary local variable instead of the field `dictionary.column_unique`. Oops.

This PR is a minimal fix that's easy to backport. Then https://github.com/ClickHouse/ClickHouse/pull/51072 does a little refactoring to prevent this specific error in future.