### PR TITLE
MaterializedMySQL: Rename materialize_with_ddl.py -> materialized_with_ddl

### DIFF
--- a/tests/integration/test_materialized_mysql_database/materialized_with_ddl.py
+++ b/tests/integration/test_materialized_mysql_database/materialized_with_ddl.py
@@ -423,7 +423,7 @@ def drop_table_with_materialized_mysql_database(
     mysql_node.query("DROP DATABASE test_database_drop")
 
 
-def create_table_like_with_materialize_mysql_database(
+def create_table_like_with_materialized_mysql_database(
     clickhouse_node, mysql_node, service_name
 ):
     mysql_node.query("DROP DATABASE IF EXISTS create_like")
@@ -1578,49 +1578,49 @@ def system_tables_test(clickhouse_node, mysql_node, service_name):
     mysql_node.query("DROP DATABASE system_tables_test")
 
 
-def materialize_with_column_comments_test(clickhouse_node, mysql_node, service_name):
-    mysql_node.query("DROP DATABASE IF EXISTS materialize_with_column_comments_test")
+def materialized_with_column_comments_test(clickhouse_node, mysql_node, service_name):
+    mysql_node.query("DROP DATABASE IF EXISTS materialized_with_column_comments_test")
     clickhouse_node.query(
-        "DROP DATABASE IF EXISTS materialize_with_column_comments_test"
+        "DROP DATABASE IF EXISTS materialized_with_column_comments_test"
     )
-    mysql_node.query("CREATE DATABASE materialize_with_column_comments_test")
+    mysql_node.query("CREATE DATABASE materialized_with_column_comments_test")
     mysql_node.query(
-        "CREATE TABLE materialize_with_column_comments_test.test (id int NOT NULL PRIMARY KEY, value VARCHAR(255) COMMENT 'test comment') ENGINE=InnoDB"
+        "CREATE TABLE materialized_with_column_comments_test.test (id int NOT NULL PRIMARY KEY, value VARCHAR(255) COMMENT 'test comment') ENGINE=InnoDB"
     )
     clickhouse_node.query(
-        "CREATE DATABASE materialize_with_column_comments_test ENGINE = MaterializedMySQL('{}:3306', 'materialize_with_column_comments_test', 'root', 'clickhouse')".format(
+        "CREATE DATABASE materialized_with_column_comments_test ENGINE = MaterializedMySQL('{}:3306', 'materialized_with_column_comments_test', 'root', 'clickhouse')".format(
             service_name
         )
     )
     check_query(
         clickhouse_node,
-        "DESCRIBE TABLE materialize_with_column_comments_test.test",
+        "DESCRIBE TABLE materialized_with_column_comments_test.test",
         "id\tInt32\t\t\t\t\t\nvalue\tNullable(String)\t\t\ttest comment\t\t\n_sign\tInt8\tMATERIALIZED\t1\t\t\t\n_version\tUInt64\tMATERIALIZED\t1\t\t\t\n",
     )
     mysql_node.query(
-        "ALTER TABLE materialize_with_column_comments_test.test MODIFY value VARCHAR(255) COMMENT 'comment test'"
+        "ALTER TABLE materialized_with_column_comments_test.test MODIFY value VARCHAR(255) COMMENT 'comment test'"
     )
     check_query(
         clickhouse_node,
-        "DESCRIBE TABLE materialize_with_column_comments_test.test",
+        "DESCRIBE TABLE materialized_with_column_comments_test.test",
         "id\tInt32\t\t\t\t\t\nvalue\tNullable(String)\t\t\tcomment test\t\t\n_sign\tInt8\tMATERIALIZED\t1\t\t\t\n_version\tUInt64\tMATERIALIZED\t1\t\t\t\n",
     )
     mysql_node.query(
-        "ALTER TABLE materialize_with_column_comments_test.test ADD value2 int COMMENT 'test comment 2'"
+        "ALTER TABLE materialized_with_column_comments_test.test ADD value2 int COMMENT 'test comment 2'"
     )
     check_query(
         clickhouse_node,
-        "DESCRIBE TABLE materialize_with_column_comments_test.test",
+        "DESCRIBE TABLE materialized_with_column_comments_test.test",
         "id\tInt32\t\t\t\t\t\nvalue\tNullable(String)\t\t\tcomment test\t\t\nvalue2\tNullable(Int32)\t\t\ttest comment 2\t\t\n_sign\tInt8\tMATERIALIZED\t1\t\t\t\n_version\tUInt64\tMATERIALIZED\t1\t\t\t\n",
     )
-    clickhouse_node.query("DROP DATABASE materialize_with_column_comments_test")
-    mysql_node.query("DROP DATABASE materialize_with_column_comments_test")
+    clickhouse_node.query("DROP DATABASE materialized_with_column_comments_test")
+    mysql_node.query("DROP DATABASE materialized_with_column_comments_test")
 
 
-def materialize_with_enum8_test(clickhouse_node, mysql_node, service_name):
-    mysql_node.query("DROP DATABASE IF EXISTS materialize_with_enum8_test")
-    clickhouse_node.query("DROP DATABASE IF EXISTS materialize_with_enum8_test")
-    mysql_node.query("CREATE DATABASE materialize_with_enum8_test")
+def materialized_with_enum8_test(clickhouse_node, mysql_node, service_name):
+    mysql_node.query("DROP DATABASE IF EXISTS materialized_with_enum8_test")
+    clickhouse_node.query("DROP DATABASE IF EXISTS materialized_with_enum8_test")
+    mysql_node.query("CREATE DATABASE materialized_with_enum8_test")
     enum8_values_count = 127
     enum8_values = ""
     enum8_values_with_backslash = ""
@@ -1632,46 +1632,46 @@ def materialize_with_enum8_test(clickhouse_node, mysql_node, service_name):
         "\\'" + str(enum8_values_count) + "\\' = " + str(enum8_values_count)
     )
     mysql_node.query(
-        "CREATE TABLE materialize_with_enum8_test.test (id int NOT NULL PRIMARY KEY, value ENUM("
+        "CREATE TABLE materialized_with_enum8_test.test (id int NOT NULL PRIMARY KEY, value ENUM("
         + enum8_values
         + ")) ENGINE=InnoDB"
     )
     mysql_node.query(
-        "INSERT INTO materialize_with_enum8_test.test (id, value) VALUES (1, '1'),(2, '2')"
+        "INSERT INTO materialized_with_enum8_test.test (id, value) VALUES (1, '1'),(2, '2')"
     )
     clickhouse_node.query(
-        "CREATE DATABASE materialize_with_enum8_test ENGINE = MaterializedMySQL('{}:3306', 'materialize_with_enum8_test', 'root', 'clickhouse')".format(
+        "CREATE DATABASE materialized_with_enum8_test ENGINE = MaterializedMySQL('{}:3306', 'materialized_with_enum8_test', 'root', 'clickhouse')".format(
             service_name
         )
     )
     check_query(
         clickhouse_node,
-        "SELECT value FROM materialize_with_enum8_test.test ORDER BY id",
+        "SELECT value FROM materialized_with_enum8_test.test ORDER BY id",
         "1\n2\n",
     )
     mysql_node.query(
-        "INSERT INTO materialize_with_enum8_test.test (id, value) VALUES (3, '127')"
+        "INSERT INTO materialized_with_enum8_test.test (id, value) VALUES (3, '127')"
     )
     check_query(
         clickhouse_node,
-        "SELECT value FROM materialize_with_enum8_test.test ORDER BY id",
+        "SELECT value FROM materialized_with_enum8_test.test ORDER BY id",
         "1\n2\n127\n",
     )
     check_query(
         clickhouse_node,
-        "DESCRIBE TABLE materialize_with_enum8_test.test",
+        "DESCRIBE TABLE materialized_with_enum8_test.test",
         "id\tInt32\t\t\t\t\t\nvalue\tNullable(Enum8("
         + enum8_values_with_backslash
         + "))\t\t\t\t\t\n_sign\tInt8\tMATERIALIZED\t1\t\t\t\n_version\tUInt64\tMATERIALIZED\t1\t\t\t\n",
     )
-    clickhouse_node.query("DROP DATABASE materialize_with_enum8_test")
-    mysql_node.query("DROP DATABASE materialize_with_enum8_test")
+    clickhouse_node.query("DROP DATABASE materialized_with_enum8_test")
+    mysql_node.query("DROP DATABASE materialized_with_enum8_test")
 
 
-def materialize_with_enum16_test(clickhouse_node, mysql_node, service_name):
-    mysql_node.query("DROP DATABASE IF EXISTS materialize_with_enum16_test")
-    clickhouse_node.query("DROP DATABASE IF EXISTS materialize_with_enum16_test")
-    mysql_node.query("CREATE DATABASE materialize_with_enum16_test")
+def materialized_with_enum16_test(clickhouse_node, mysql_node, service_name):
+    mysql_node.query("DROP DATABASE IF EXISTS materialized_with_enum16_test")
+    clickhouse_node.query("DROP DATABASE IF EXISTS materialized_with_enum16_test")
+    mysql_node.query("CREATE DATABASE materialized_with_enum16_test")
     enum16_values_count = 600
     enum16_values = ""
     enum16_values_with_backslash = ""
@@ -1683,40 +1683,40 @@ def materialize_with_enum16_test(clickhouse_node, mysql_node, service_name):
         "\\'" + str(enum16_values_count) + "\\' = " + str(enum16_values_count)
     )
     mysql_node.query(
-        "CREATE TABLE materialize_with_enum16_test.test (id int NOT NULL PRIMARY KEY, value ENUM("
+        "CREATE TABLE materialized_with_enum16_test.test (id int NOT NULL PRIMARY KEY, value ENUM("
         + enum16_values
         + ")) ENGINE=InnoDB"
     )
     mysql_node.query(
-        "INSERT INTO materialize_with_enum16_test.test (id, value) VALUES (1, '1'),(2, '2')"
+        "INSERT INTO materialized_with_enum16_test.test (id, value) VALUES (1, '1'),(2, '2')"
     )
     clickhouse_node.query(
-        "CREATE DATABASE materialize_with_enum16_test ENGINE = MaterializedMySQL('{}:3306', 'materialize_with_enum16_test', 'root', 'clickhouse')".format(
+        "CREATE DATABASE materialized_with_enum16_test ENGINE = MaterializedMySQL('{}:3306', 'materialized_with_enum16_test', 'root', 'clickhouse')".format(
             service_name
         )
     )
     check_query(
         clickhouse_node,
-        "SELECT value FROM materialize_with_enum16_test.test ORDER BY id",
+        "SELECT value FROM materialized_with_enum16_test.test ORDER BY id",
         "1\n2\n",
     )
     mysql_node.query(
-        "INSERT INTO materialize_with_enum16_test.test (id, value) VALUES (3, '500')"
+        "INSERT INTO materialized_with_enum16_test.test (id, value) VALUES (3, '500')"
     )
     check_query(
         clickhouse_node,
-        "SELECT value FROM materialize_with_enum16_test.test ORDER BY id",
+        "SELECT value FROM materialized_with_enum16_test.test ORDER BY id",
         "1\n2\n500\n",
     )
     check_query(
         clickhouse_node,
-        "DESCRIBE TABLE materialize_with_enum16_test.test",
+        "DESCRIBE TABLE materialized_with_enum16_test.test",
         "id\tInt32\t\t\t\t\t\nvalue\tNullable(Enum16("
         + enum16_values_with_backslash
         + "))\t\t\t\t\t\n_sign\tInt8\tMATERIALIZED\t1\t\t\t\n_version\tUInt64\tMATERIALIZED\t1\t\t\t\n",
     )
-    clickhouse_node.query("DROP DATABASE materialize_with_enum16_test")
-    mysql_node.query("DROP DATABASE materialize_with_enum16_test")
+    clickhouse_node.query("DROP DATABASE materialized_with_enum16_test")
+    mysql_node.query("DROP DATABASE materialized_with_enum16_test")
 
 
 def alter_enum8_to_enum16_test(clickhouse_node, mysql_node, service_name):

--- a/tests/integration/test_materialized_mysql_database/test.py
+++ b/tests/integration/test_materialized_mysql_database/test.py
@@ -14,7 +14,7 @@ from helpers.cluster import (
 import docker
 import logging
 
-from . import materialize_with_ddl
+from . import materialized_with_ddl
 
 DOCKER_COMPOSE_PATH = get_docker_compose_path()
 
@@ -152,16 +152,16 @@ def clickhouse_node():
 def test_materialized_database_dml_with_mysql_5_7(
     started_cluster, started_mysql_5_7, clickhouse_node: ClickHouseInstance
 ):
-    materialize_with_ddl.dml_with_materialized_mysql_database(
+    materialized_with_ddl.dml_with_materialized_mysql_database(
         clickhouse_node, started_mysql_5_7, "mysql57"
     )
-    materialize_with_ddl.materialized_mysql_database_with_views(
+    materialized_with_ddl.materialized_mysql_database_with_views(
         clickhouse_node, started_mysql_5_7, "mysql57"
     )
-    materialize_with_ddl.materialized_mysql_database_with_datetime_and_decimal(
+    materialized_with_ddl.materialized_mysql_database_with_datetime_and_decimal(
         clickhouse_node, started_mysql_5_7, "mysql57"
     )
-    materialize_with_ddl.move_to_prewhere_and_column_filtering(
+    materialized_with_ddl.move_to_prewhere_and_column_filtering(
         clickhouse_node, started_mysql_5_7, "mysql57"
     )
 
@@ -169,16 +169,16 @@ def test_materialized_database_dml_with_mysql_5_7(
 def test_materialized_database_dml_with_mysql_8_0(
     started_cluster, started_mysql_8_0, clickhouse_node
 ):
-    materialize_with_ddl.dml_with_materialized_mysql_database(
+    materialized_with_ddl.dml_with_materialized_mysql_database(
         clickhouse_node, started_mysql_8_0, "mysql80"
     )
-    materialize_with_ddl.materialized_mysql_database_with_views(
+    materialized_with_ddl.materialized_mysql_database_with_views(
         clickhouse_node, started_mysql_8_0, "mysql80"
     )
-    materialize_with_ddl.materialized_mysql_database_with_datetime_and_decimal(
+    materialized_with_ddl.materialized_mysql_database_with_datetime_and_decimal(
         clickhouse_node, started_mysql_8_0, "mysql80"
     )
-    materialize_with_ddl.move_to_prewhere_and_column_filtering(
+    materialized_with_ddl.move_to_prewhere_and_column_filtering(
         clickhouse_node, started_mysql_8_0, "mysql80"
     )
 
@@ -186,30 +186,30 @@ def test_materialized_database_dml_with_mysql_8_0(
 def test_materialized_database_ddl_with_mysql_5_7(
     started_cluster, started_mysql_5_7, clickhouse_node
 ):
-    materialize_with_ddl.drop_table_with_materialized_mysql_database(
+    materialized_with_ddl.drop_table_with_materialized_mysql_database(
         clickhouse_node, started_mysql_5_7, "mysql57"
     )
-    materialize_with_ddl.create_table_with_materialized_mysql_database(
+    materialized_with_ddl.create_table_with_materialized_mysql_database(
         clickhouse_node, started_mysql_5_7, "mysql57"
     )
-    materialize_with_ddl.rename_table_with_materialized_mysql_database(
+    materialized_with_ddl.rename_table_with_materialized_mysql_database(
         clickhouse_node, started_mysql_5_7, "mysql57"
     )
-    materialize_with_ddl.alter_add_column_with_materialized_mysql_database(
+    materialized_with_ddl.alter_add_column_with_materialized_mysql_database(
         clickhouse_node, started_mysql_5_7, "mysql57"
     )
-    materialize_with_ddl.alter_drop_column_with_materialized_mysql_database(
+    materialized_with_ddl.alter_drop_column_with_materialized_mysql_database(
         clickhouse_node, started_mysql_5_7, "mysql57"
     )
     # mysql 5.7 cannot support alter rename column
-    # materialize_with_ddl.alter_rename_column_with_materialized_mysql_database(clickhouse_node, started_mysql_5_7, "mysql57")
-    materialize_with_ddl.alter_rename_table_with_materialized_mysql_database(
+    # materialized_with_ddl.alter_rename_column_with_materialized_mysql_database(clickhouse_node, started_mysql_5_7, "mysql57")
+    materialized_with_ddl.alter_rename_table_with_materialized_mysql_database(
         clickhouse_node, started_mysql_5_7, "mysql57"
     )
-    materialize_with_ddl.alter_modify_column_with_materialized_mysql_database(
+    materialized_with_ddl.alter_modify_column_with_materialized_mysql_database(
         clickhouse_node, started_mysql_5_7, "mysql57"
     )
-    materialize_with_ddl.create_table_like_with_materialize_mysql_database(
+    materialized_with_ddl.create_table_like_with_materialized_mysql_database(
         clickhouse_node, started_mysql_5_7, "mysql57"
     )
 
@@ -217,31 +217,31 @@ def test_materialized_database_ddl_with_mysql_5_7(
 def test_materialized_database_ddl_with_mysql_8_0(
     started_cluster, started_mysql_8_0, clickhouse_node
 ):
-    materialize_with_ddl.drop_table_with_materialized_mysql_database(
+    materialized_with_ddl.drop_table_with_materialized_mysql_database(
         clickhouse_node, started_mysql_8_0, "mysql80"
     )
-    materialize_with_ddl.create_table_with_materialized_mysql_database(
+    materialized_with_ddl.create_table_with_materialized_mysql_database(
         clickhouse_node, started_mysql_8_0, "mysql80"
     )
-    materialize_with_ddl.rename_table_with_materialized_mysql_database(
+    materialized_with_ddl.rename_table_with_materialized_mysql_database(
         clickhouse_node, started_mysql_8_0, "mysql80"
     )
-    materialize_with_ddl.alter_add_column_with_materialized_mysql_database(
+    materialized_with_ddl.alter_add_column_with_materialized_mysql_database(
         clickhouse_node, started_mysql_8_0, "mysql80"
     )
-    materialize_with_ddl.alter_drop_column_with_materialized_mysql_database(
+    materialized_with_ddl.alter_drop_column_with_materialized_mysql_database(
         clickhouse_node, started_mysql_8_0, "mysql80"
     )
-    materialize_with_ddl.alter_rename_table_with_materialized_mysql_database(
+    materialized_with_ddl.alter_rename_table_with_materialized_mysql_database(
         clickhouse_node, started_mysql_8_0, "mysql80"
     )
-    materialize_with_ddl.alter_rename_column_with_materialized_mysql_database(
+    materialized_with_ddl.alter_rename_column_with_materialized_mysql_database(
         clickhouse_node, started_mysql_8_0, "mysql80"
     )
-    materialize_with_ddl.alter_modify_column_with_materialized_mysql_database(
+    materialized_with_ddl.alter_modify_column_with_materialized_mysql_database(
         clickhouse_node, started_mysql_8_0, "mysql80"
     )
-    materialize_with_ddl.create_table_like_with_materialize_mysql_database(
+    materialized_with_ddl.create_table_like_with_materialized_mysql_database(
         clickhouse_node, started_mysql_8_0, "mysql80"
     )
 
@@ -249,7 +249,7 @@ def test_materialized_database_ddl_with_mysql_8_0(
 def test_materialized_database_ddl_with_empty_transaction_5_7(
     started_cluster, started_mysql_5_7, clickhouse_node
 ):
-    materialize_with_ddl.query_event_with_empty_transaction(
+    materialized_with_ddl.query_event_with_empty_transaction(
         clickhouse_node, started_mysql_5_7, "mysql57"
     )
 
@@ -257,7 +257,7 @@ def test_materialized_database_ddl_with_empty_transaction_5_7(
 def test_materialized_database_ddl_with_empty_transaction_8_0(
     started_cluster, started_mysql_8_0, clickhouse_node
 ):
-    materialize_with_ddl.query_event_with_empty_transaction(
+    materialized_with_ddl.query_event_with_empty_transaction(
         clickhouse_node, started_mysql_8_0, "mysql80"
     )
 
@@ -265,7 +265,7 @@ def test_materialized_database_ddl_with_empty_transaction_8_0(
 def test_select_without_columns_5_7(
     started_cluster, started_mysql_5_7, clickhouse_node
 ):
-    materialize_with_ddl.select_without_columns(
+    materialized_with_ddl.select_without_columns(
         clickhouse_node, started_mysql_5_7, "mysql57"
     )
 
@@ -273,7 +273,7 @@ def test_select_without_columns_5_7(
 def test_select_without_columns_8_0(
     started_cluster, started_mysql_8_0, clickhouse_node
 ):
-    materialize_with_ddl.select_without_columns(
+    materialized_with_ddl.select_without_columns(
         clickhouse_node, started_mysql_8_0, "mysql80"
     )
 
@@ -281,7 +281,7 @@ def test_select_without_columns_8_0(
 def test_insert_with_modify_binlog_checksum_5_7(
     started_cluster, started_mysql_5_7, clickhouse_node
 ):
-    materialize_with_ddl.insert_with_modify_binlog_checksum(
+    materialized_with_ddl.insert_with_modify_binlog_checksum(
         clickhouse_node, started_mysql_5_7, "mysql57"
     )
 
@@ -289,7 +289,7 @@ def test_insert_with_modify_binlog_checksum_5_7(
 def test_insert_with_modify_binlog_checksum_8_0(
     started_cluster, started_mysql_8_0, clickhouse_node
 ):
-    materialize_with_ddl.insert_with_modify_binlog_checksum(
+    materialized_with_ddl.insert_with_modify_binlog_checksum(
         clickhouse_node, started_mysql_8_0, "mysql80"
     )
 
@@ -297,7 +297,7 @@ def test_insert_with_modify_binlog_checksum_8_0(
 def test_materialized_database_err_sync_user_privs_5_7(
     started_cluster, started_mysql_5_7, clickhouse_node
 ):
-    materialize_with_ddl.err_sync_user_privs_with_materialized_mysql_database(
+    materialized_with_ddl.err_sync_user_privs_with_materialized_mysql_database(
         clickhouse_node, started_mysql_5_7, "mysql57"
     )
 
@@ -305,19 +305,19 @@ def test_materialized_database_err_sync_user_privs_5_7(
 def test_materialized_database_err_sync_user_privs_8_0(
     started_cluster, started_mysql_8_0, clickhouse_node
 ):
-    materialize_with_ddl.err_sync_user_privs_with_materialized_mysql_database(
+    materialized_with_ddl.err_sync_user_privs_with_materialized_mysql_database(
         clickhouse_node, started_mysql_8_0, "mysql80"
     )
 
 
 def test_network_partition_5_7(started_cluster, started_mysql_5_7, clickhouse_node):
-    materialize_with_ddl.network_partition_test(
+    materialized_with_ddl.network_partition_test(
         clickhouse_node, started_mysql_5_7, "mysql57"
     )
 
 
 def test_network_partition_8_0(started_cluster, started_mysql_8_0, clickhouse_node):
-    materialize_with_ddl.network_partition_test(
+    materialized_with_ddl.network_partition_test(
         clickhouse_node, started_mysql_8_0, "mysql80"
     )
 
@@ -325,7 +325,7 @@ def test_network_partition_8_0(started_cluster, started_mysql_8_0, clickhouse_no
 def test_mysql_kill_sync_thread_restore_5_7(
     started_cluster, started_mysql_5_7, clickhouse_node
 ):
-    materialize_with_ddl.mysql_kill_sync_thread_restore_test(
+    materialized_with_ddl.mysql_kill_sync_thread_restore_test(
         clickhouse_node, started_mysql_5_7, "mysql57"
     )
 
@@ -333,7 +333,7 @@ def test_mysql_kill_sync_thread_restore_5_7(
 def test_mysql_kill_sync_thread_restore_8_0(
     started_cluster, started_mysql_8_0, clickhouse_node
 ):
-    materialize_with_ddl.mysql_kill_sync_thread_restore_test(
+    materialized_with_ddl.mysql_kill_sync_thread_restore_test(
         clickhouse_node, started_mysql_8_0, "mysql80"
     )
 
@@ -341,7 +341,7 @@ def test_mysql_kill_sync_thread_restore_8_0(
 def test_mysql_killed_while_insert_5_7(
     started_cluster, started_mysql_5_7, clickhouse_node
 ):
-    materialize_with_ddl.mysql_killed_while_insert(
+    materialized_with_ddl.mysql_killed_while_insert(
         clickhouse_node, started_mysql_5_7, "mysql57"
     )
 
@@ -349,7 +349,7 @@ def test_mysql_killed_while_insert_5_7(
 def test_mysql_killed_while_insert_8_0(
     started_cluster, started_mysql_8_0, clickhouse_node
 ):
-    materialize_with_ddl.mysql_killed_while_insert(
+    materialized_with_ddl.mysql_killed_while_insert(
         clickhouse_node, started_mysql_8_0, "mysql80"
     )
 
@@ -357,7 +357,7 @@ def test_mysql_killed_while_insert_8_0(
 def test_clickhouse_killed_while_insert_5_7(
     started_cluster, started_mysql_5_7, clickhouse_node
 ):
-    materialize_with_ddl.clickhouse_killed_while_insert(
+    materialized_with_ddl.clickhouse_killed_while_insert(
         clickhouse_node, started_mysql_5_7, "mysql57"
     )
 
@@ -365,7 +365,7 @@ def test_clickhouse_killed_while_insert_5_7(
 def test_clickhouse_killed_while_insert_8_0(
     started_cluster, started_mysql_8_0, clickhouse_node
 ):
-    materialize_with_ddl.clickhouse_killed_while_insert(
+    materialized_with_ddl.clickhouse_killed_while_insert(
         clickhouse_node, started_mysql_8_0, "mysql80"
     )
 
@@ -373,12 +373,12 @@ def test_clickhouse_killed_while_insert_8_0(
 def test_utf8mb4(
     started_cluster, started_mysql_8_0, started_mysql_5_7, clickhouse_node
 ):
-    materialize_with_ddl.utf8mb4_test(clickhouse_node, started_mysql_5_7, "mysql57")
-    materialize_with_ddl.utf8mb4_test(clickhouse_node, started_mysql_8_0, "mysql80")
+    materialized_with_ddl.utf8mb4_test(clickhouse_node, started_mysql_5_7, "mysql57")
+    materialized_with_ddl.utf8mb4_test(clickhouse_node, started_mysql_8_0, "mysql80")
 
 
 def test_system_parts_table(started_cluster, started_mysql_8_0, clickhouse_node):
-    materialize_with_ddl.system_parts_test(
+    materialized_with_ddl.system_parts_test(
         clickhouse_node, started_mysql_8_0, "mysql80"
     )
 
@@ -386,10 +386,10 @@ def test_system_parts_table(started_cluster, started_mysql_8_0, clickhouse_node)
 def test_multi_table_update(
     started_cluster, started_mysql_8_0, started_mysql_5_7, clickhouse_node
 ):
-    materialize_with_ddl.multi_table_update_test(
+    materialized_with_ddl.multi_table_update_test(
         clickhouse_node, started_mysql_5_7, "mysql57"
     )
-    materialize_with_ddl.multi_table_update_test(
+    materialized_with_ddl.multi_table_update_test(
         clickhouse_node, started_mysql_8_0, "mysql80"
     )
 
@@ -397,10 +397,10 @@ def test_multi_table_update(
 def test_system_tables_table(
     started_cluster, started_mysql_8_0, started_mysql_5_7, clickhouse_node
 ):
-    materialize_with_ddl.system_tables_test(
+    materialized_with_ddl.system_tables_test(
         clickhouse_node, started_mysql_5_7, "mysql57"
     )
-    materialize_with_ddl.system_tables_test(
+    materialized_with_ddl.system_tables_test(
         clickhouse_node, started_mysql_8_0, "mysql80"
     )
 
@@ -408,10 +408,10 @@ def test_system_tables_table(
 def test_materialized_with_column_comments(
     started_cluster, started_mysql_8_0, started_mysql_5_7, clickhouse_node
 ):
-    materialize_with_ddl.materialize_with_column_comments_test(
+    materialized_with_ddl.materialized_with_column_comments_test(
         clickhouse_node, started_mysql_5_7, "mysql57"
     )
-    materialize_with_ddl.materialize_with_column_comments_test(
+    materialized_with_ddl.materialized_with_column_comments_test(
         clickhouse_node, started_mysql_8_0, "mysql80"
     )
 
@@ -419,22 +419,22 @@ def test_materialized_with_column_comments(
 def test_materialized_with_enum(
     started_cluster, started_mysql_8_0, started_mysql_5_7, clickhouse_node
 ):
-    materialize_with_ddl.materialize_with_enum8_test(
+    materialized_with_ddl.materialized_with_enum8_test(
         clickhouse_node, started_mysql_5_7, "mysql57"
     )
-    materialize_with_ddl.materialize_with_enum16_test(
+    materialized_with_ddl.materialized_with_enum16_test(
         clickhouse_node, started_mysql_5_7, "mysql57"
     )
-    materialize_with_ddl.alter_enum8_to_enum16_test(
+    materialized_with_ddl.alter_enum8_to_enum16_test(
         clickhouse_node, started_mysql_5_7, "mysql57"
     )
-    materialize_with_ddl.materialize_with_enum8_test(
+    materialized_with_ddl.materialized_with_enum8_test(
         clickhouse_node, started_mysql_8_0, "mysql80"
     )
-    materialize_with_ddl.materialize_with_enum16_test(
+    materialized_with_ddl.materialized_with_enum16_test(
         clickhouse_node, started_mysql_8_0, "mysql80"
     )
-    materialize_with_ddl.alter_enum8_to_enum16_test(
+    materialized_with_ddl.alter_enum8_to_enum16_test(
         clickhouse_node, started_mysql_8_0, "mysql80"
     )
 
@@ -445,10 +445,10 @@ def test_materialized_with_enum(
 def test_mysql_settings(
     started_cluster, started_mysql_8_0, started_mysql_5_7, clickhouse_node
 ):
-    materialize_with_ddl.mysql_settings_test(
+    materialized_with_ddl.mysql_settings_test(
         clickhouse_node, started_mysql_5_7, "mysql57"
     )
-    materialize_with_ddl.mysql_settings_test(
+    materialized_with_ddl.mysql_settings_test(
         clickhouse_node, started_mysql_8_0, "mysql80"
     )
 
@@ -456,10 +456,10 @@ def test_mysql_settings(
 def test_large_transaction(
     started_cluster, started_mysql_8_0, started_mysql_5_7, clickhouse_node
 ):
-    materialize_with_ddl.materialized_mysql_large_transaction(
+    materialized_with_ddl.materialized_mysql_large_transaction(
         clickhouse_node, started_mysql_8_0, "mysql80"
     )
-    materialize_with_ddl.materialized_mysql_large_transaction(
+    materialized_with_ddl.materialized_mysql_large_transaction(
         clickhouse_node, started_mysql_5_7, "mysql57"
     )
 
@@ -467,24 +467,24 @@ def test_large_transaction(
 def test_table_table(
     started_cluster, started_mysql_8_0, started_mysql_5_7, clickhouse_node
 ):
-    materialize_with_ddl.table_table(clickhouse_node, started_mysql_8_0, "mysql80")
-    materialize_with_ddl.table_table(clickhouse_node, started_mysql_5_7, "mysql57")
+    materialized_with_ddl.table_table(clickhouse_node, started_mysql_8_0, "mysql80")
+    materialized_with_ddl.table_table(clickhouse_node, started_mysql_5_7, "mysql57")
 
 
 def test_table_overrides(
     started_cluster, started_mysql_8_0, started_mysql_5_7, clickhouse_node
 ):
-    materialize_with_ddl.table_overrides(clickhouse_node, started_mysql_5_7, "mysql57")
-    materialize_with_ddl.table_overrides(clickhouse_node, started_mysql_8_0, "mysql80")
+    materialized_with_ddl.table_overrides(clickhouse_node, started_mysql_5_7, "mysql57")
+    materialized_with_ddl.table_overrides(clickhouse_node, started_mysql_8_0, "mysql80")
 
 
 def test_materialized_database_support_all_kinds_of_mysql_datatype(
     started_cluster, started_mysql_8_0, started_mysql_5_7, clickhouse_node
 ):
-    materialize_with_ddl.materialized_database_support_all_kinds_of_mysql_datatype(
+    materialized_with_ddl.materialized_database_support_all_kinds_of_mysql_datatype(
         clickhouse_node, started_mysql_8_0, "mysql80"
     )
-    materialize_with_ddl.materialized_database_support_all_kinds_of_mysql_datatype(
+    materialized_with_ddl.materialized_database_support_all_kinds_of_mysql_datatype(
         clickhouse_node, started_mysql_5_7, "mysql57"
     )
 
@@ -492,10 +492,10 @@ def test_materialized_database_support_all_kinds_of_mysql_datatype(
 def test_materialized_database_settings_materialized_mysql_tables_list(
     started_cluster, started_mysql_8_0, started_mysql_5_7, clickhouse_node
 ):
-    materialize_with_ddl.materialized_database_settings_materialized_mysql_tables_list(
+    materialized_with_ddl.materialized_database_settings_materialized_mysql_tables_list(
         clickhouse_node, started_mysql_8_0, "mysql80"
     )
-    materialize_with_ddl.materialized_database_settings_materialized_mysql_tables_list(
+    materialized_with_ddl.materialized_database_settings_materialized_mysql_tables_list(
         clickhouse_node, started_mysql_5_7, "mysql57"
     )
 
@@ -503,10 +503,10 @@ def test_materialized_database_settings_materialized_mysql_tables_list(
 def test_materialized_database_mysql_date_type_to_date32(
     started_cluster, started_mysql_8_0, started_mysql_5_7, clickhouse_node
 ):
-    materialize_with_ddl.materialized_database_mysql_date_type_to_date32(
+    materialized_with_ddl.materialized_database_mysql_date_type_to_date32(
         clickhouse_node, started_mysql_8_0, "mysql80"
     )
-    materialize_with_ddl.materialized_database_mysql_date_type_to_date32(
+    materialized_with_ddl.materialized_database_mysql_date_type_to_date32(
         clickhouse_node, started_mysql_5_7, "mysql57"
     )
 
@@ -514,18 +514,18 @@ def test_materialized_database_mysql_date_type_to_date32(
 def test_savepoint_query(
     started_cluster, started_mysql_8_0, started_mysql_5_7, clickhouse_node
 ):
-    materialize_with_ddl.savepoint(clickhouse_node, started_mysql_8_0, "mysql80")
-    materialize_with_ddl.savepoint(clickhouse_node, started_mysql_5_7, "mysql57")
+    materialized_with_ddl.savepoint(clickhouse_node, started_mysql_8_0, "mysql80")
+    materialized_with_ddl.savepoint(clickhouse_node, started_mysql_5_7, "mysql57")
 
 
 def test_materialized_database_mysql_drop_ddl(
     started_cluster, started_mysql_8_0, started_mysql_5_7, clickhouse_node
 ):
-    materialize_with_ddl.dropddl(clickhouse_node, started_mysql_8_0, "mysql80")
-    materialize_with_ddl.dropddl(clickhouse_node, started_mysql_5_7, "mysql57")
+    materialized_with_ddl.dropddl(clickhouse_node, started_mysql_8_0, "mysql80")
+    materialized_with_ddl.dropddl(clickhouse_node, started_mysql_5_7, "mysql57")
 
 
 def test_named_collections(started_cluster, started_mysql_8_0, clickhouse_node):
-    materialize_with_ddl.named_collections(
+    materialized_with_ddl.named_collections(
         clickhouse_node, started_mysql_8_0, "mysql80"
     )


### PR DESCRIPTION
Make it more consistent to current names.
Keep some tests with `ENGINE = MaterializeMySQL` to test BC.

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
