### PR TITLE
Generate safe IVs

### DIFF
--- a/src/IO/FileEncryptionCommon.cpp
+++ b/src/IO/FileEncryptionCommon.cpp
@@ -8,10 +8,11 @@
 #include <Common/SipHash.h>
 #include <Common/safe_cast.h>
 
-#include <boost/algorithm/string/predicate.hpp>
-#include <cassert>
-#include <random>
+#    include <cassert>
+#    include <boost/algorithm/string/predicate.hpp>
 
+#    include <openssl/err.h>
+#    include <openssl/rand.h>
 
 namespace DB
 {
@@ -20,6 +21,7 @@ namespace ErrorCodes
 {
     extern const int BAD_ARGUMENTS;
     extern const int DATA_ENCRYPTION_ERROR;
+    extern const int OPENSSL_ERROR;
 }
 
 namespace FileEncryption
@@ -260,12 +262,11 @@ void InitVector::write(WriteBuffer & out) const
 
 InitVector InitVector::random()
 {
-    std::random_device rd;
-    std::mt19937 gen{rd()};
-    std::uniform_int_distribution<UInt128::base_type> dis;
     UInt128 counter;
-    for (auto & i : counter.items)
-        i = dis(gen);
+    auto * buf = reinterpret_cast<unsigned char *>(counter.items);
+    auto ret = RAND_bytes(buf, sizeof(counter.items));
+    if (ret != 1)
+        throw Exception(DB::ErrorCodes::OPENSSL_ERROR, "OpenSSL error code: {}", ERR_get_error());
     return InitVector{counter};
 }
 


### PR DESCRIPTION
IVs should never be re-used when using CTR.
The previous implementation had a 50% probability to generate an IV that was already used after 65536 generations. This happens because std::mt19937 is seeded using a 32bit integer and returns a 32 bits integer.
Because of the birthday problem, collisions have a 50% chance after only 2^16 IV's generations.
CH uses one IV per file and, for most use cases, 65k files are not as many as they seem.
Also, the initial entropy is gathered using std::random_device which is "best-effort" and it's allowed by the standard to return a fixed sequence of numbers.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed not-so-random IV generation for CTR disk encryption.

@alexey-milovidov 