### PR TITLE
Improve progress bar for file/s3/hdfs/url table functions. Step 1

### DIFF
--- a/src/IO/WithFileSize.h
+++ b/src/IO/WithFileSize.h
@@ -18,4 +18,9 @@ bool isBufferWithFileSize(const ReadBuffer & in);
 
 size_t getFileSizeFromReadBuffer(ReadBuffer & in);
 
+/// Return nullopt if couldn't find out file size;
+std::optional<size_t> tryGetFileSizeFromReadBuffer(ReadBuffer & in);
+
+size_t getDataOffsetMaybeCompressed(const ReadBuffer & in);
+
 }

--- a/src/Processors/Formats/IInputFormat.h
+++ b/src/Processors/Formats/IInputFormat.h
@@ -53,6 +53,8 @@ public:
 
     void setErrorsLogger(const InputFormatErrorsLoggerPtr & errors_logger_) { errors_logger = errors_logger_; }
 
+    virtual size_t getApproxBytesReadForChunk() const { return 0; }
+
 protected:
     ColumnMappingPtr column_mapping{};
 

--- a/src/Processors/Formats/IRowInputFormat.cpp
+++ b/src/Processors/Formats/IRowInputFormat.cpp
@@ -96,6 +96,7 @@ Chunk IRowInputFormat::generate()
     block_missing_values.clear();
 
     size_t num_rows = 0;
+    size_t chunk_start_offset = getDataOffsetMaybeCompressed(getReadBuffer());
 
     try
     {
@@ -242,6 +243,7 @@ Chunk IRowInputFormat::generate()
         column->finalize();
 
     Chunk chunk(std::move(columns), num_rows);
+    approx_bytes_read_for_chunk = getDataOffsetMaybeCompressed(getReadBuffer()) - chunk_start_offset;
     return chunk;
 }
 

--- a/src/Processors/Formats/IRowInputFormat.h
+++ b/src/Processors/Formats/IRowInputFormat.h
@@ -74,6 +74,8 @@ protected:
 
     size_t getTotalRows() const { return total_rows; }
 
+    size_t getApproxBytesReadForChunk() const override { return approx_bytes_read_for_chunk; }
+
     Serializations serializations;
 
 private:
@@ -83,6 +85,7 @@ private:
     size_t num_errors = 0;
 
     BlockMissingValues block_missing_values;
+    size_t approx_bytes_read_for_chunk;
 };
 
 }

--- a/src/Processors/Formats/Impl/ArrowBlockInputFormat.cpp
+++ b/src/Processors/Formats/Impl/ArrowBlockInputFormat.cpp
@@ -33,7 +33,7 @@ Chunk ArrowBlockInputFormat::generate()
     Chunk res;
     block_missing_values.clear();
     arrow::Result<std::shared_ptr<arrow::RecordBatch>> batch_result;
-
+    size_t batch_start = getDataOffsetMaybeCompressed(*in);
     if (stream)
     {
         if (!stream_reader)
@@ -76,6 +76,11 @@ Chunk ArrowBlockInputFormat::generate()
     BlockMissingValues * block_missing_values_ptr = format_settings.defaults_for_omitted_fields ? &block_missing_values : nullptr;
     arrow_column_to_ch_column->arrowTableToCHChunk(res, *table_result, (*table_result)->num_rows(), block_missing_values_ptr);
 
+    /// There is no easy way to get original record batch size from Arrow metadata.
+    /// Let's just use the number of bytes read from read buffer.
+    auto batch_end = getDataOffsetMaybeCompressed(*in);
+    if (batch_end > batch_start)
+        approx_bytes_read_for_chunk = batch_end - batch_start;
     return res;
 }
 

--- a/src/Processors/Formats/Impl/ArrowBlockInputFormat.h
+++ b/src/Processors/Formats/Impl/ArrowBlockInputFormat.h
@@ -27,6 +27,8 @@ public:
 
     const BlockMissingValues & getMissingValues() const override;
 
+    size_t getApproxBytesReadForChunk() const override { return approx_bytes_read_for_chunk; }
+
 private:
     Chunk generate() override;
 
@@ -48,6 +50,7 @@ private:
     int record_batch_current = 0;
 
     BlockMissingValues block_missing_values;
+    size_t approx_bytes_read_for_chunk;
 
     const FormatSettings format_settings;
 

--- a/src/Processors/Formats/Impl/JSONColumnsBlockInputFormatBase.cpp
+++ b/src/Processors/Formats/Impl/JSONColumnsBlockInputFormatBase.cpp
@@ -117,6 +117,7 @@ Chunk JSONColumnsBlockInputFormatBase::generate()
     if (reader->checkChunkEnd())
         return Chunk(std::move(columns), 0);
 
+    size_t chunk_start = getDataOffsetMaybeCompressed(*in);
     std::vector<UInt8> seen_columns(columns.size(), 0);
     Int64 rows = -1;
     size_t iteration = 0;
@@ -150,6 +151,8 @@ Chunk JSONColumnsBlockInputFormatBase::generate()
         ++iteration;
     }
     while (!reader->checkChunkEndOrSkipColumnDelimiter());
+
+    approx_bytes_read_for_chunk = getDataOffsetMaybeCompressed(*in) - chunk_start;
 
     if (rows <= 0)
         return Chunk(std::move(columns), 0);

--- a/src/Processors/Formats/Impl/JSONColumnsBlockInputFormatBase.h
+++ b/src/Processors/Formats/Impl/JSONColumnsBlockInputFormatBase.h
@@ -53,6 +53,8 @@ public:
 
     const BlockMissingValues & getMissingValues() const override { return block_missing_values; }
 
+    size_t getApproxBytesReadForChunk() const override { return approx_bytes_read_for_chunk; }
+
 protected:
     Chunk generate() override;
 
@@ -65,6 +67,7 @@ protected:
     Serializations serializations;
     std::unique_ptr<JSONColumnsReaderBase> reader;
     BlockMissingValues block_missing_values;
+    size_t approx_bytes_read_for_chunk;
 };
 
 

--- a/src/Processors/Formats/Impl/NativeFormat.cpp
+++ b/src/Processors/Formats/Impl/NativeFormat.cpp
@@ -38,7 +38,10 @@ public:
     Chunk generate() override
     {
         block_missing_values.clear();
+        size_t block_start = getDataOffsetMaybeCompressed(*in);
         auto block = reader->read();
+        approx_bytes_read_for_chunk = getDataOffsetMaybeCompressed(*in) - block_start;
+
         if (!block)
             return {};
 
@@ -57,10 +60,13 @@ public:
 
     const BlockMissingValues & getMissingValues() const override { return block_missing_values; }
 
+    size_t getApproxBytesReadForChunk() const override { return approx_bytes_read_for_chunk; }
+
 private:
     std::unique_ptr<NativeReader> reader;
     Block header;
     BlockMissingValues block_missing_values;
+    size_t approx_bytes_read_for_chunk;
 };
 
 class NativeOutputFormat final : public IOutputFormat

--- a/src/Processors/Formats/Impl/ORCBlockInputFormat.cpp
+++ b/src/Processors/Formats/Impl/ORCBlockInputFormat.cpp
@@ -71,6 +71,7 @@ Chunk ORCBlockInputFormat::generate()
     /// Otherwise fill the missing columns with zero values of its type.
     BlockMissingValues * block_missing_values_ptr = format_settings.defaults_for_omitted_fields ? &block_missing_values : nullptr;
     arrow_column_to_ch_column->arrowTableToCHChunk(res, table, num_rows, block_missing_values_ptr);
+    approx_bytes_read_for_chunk = file_reader->GetRawORCReader()->getStripe(stripe_current)->getDataLength();
     return res;
 }
 

--- a/src/Processors/Formats/Impl/ORCBlockInputFormat.cpp
+++ b/src/Processors/Formats/Impl/ORCBlockInputFormat.cpp
@@ -64,6 +64,7 @@ Chunk ORCBlockInputFormat::generate()
     if (!table || !num_rows)
         return {};
 
+    approx_bytes_read_for_chunk = file_reader->GetRawORCReader()->getStripe(stripe_current)->getDataLength();
     ++stripe_current;
 
     Chunk res;
@@ -71,7 +72,6 @@ Chunk ORCBlockInputFormat::generate()
     /// Otherwise fill the missing columns with zero values of its type.
     BlockMissingValues * block_missing_values_ptr = format_settings.defaults_for_omitted_fields ? &block_missing_values : nullptr;
     arrow_column_to_ch_column->arrowTableToCHChunk(res, table, num_rows, block_missing_values_ptr);
-    approx_bytes_read_for_chunk = file_reader->GetRawORCReader()->getStripe(stripe_current)->getDataLength();
     return res;
 }
 

--- a/src/Processors/Formats/Impl/ORCBlockInputFormat.h
+++ b/src/Processors/Formats/Impl/ORCBlockInputFormat.h
@@ -29,6 +29,8 @@ public:
 
     const BlockMissingValues & getMissingValues() const override;
 
+    size_t getApproxBytesReadForChunk() const override { return approx_bytes_read_for_chunk; }
+
 protected:
     Chunk generate() override;
 
@@ -50,6 +52,7 @@ private:
     std::vector<int> include_indices;
 
     BlockMissingValues block_missing_values;
+    size_t approx_bytes_read_for_chunk;
 
     const FormatSettings format_settings;
     const std::unordered_set<int> & skip_stripes;

--- a/src/Processors/Formats/Impl/ParallelParsingInputFormat.cpp
+++ b/src/Processors/Formats/Impl/ParallelParsingInputFormat.cpp
@@ -39,8 +39,10 @@ void ParallelParsingInputFormat::segmentatorThreadFunction(ThreadGroupPtr thread
             // Segmentating the original input.
             unit.segment.resize(0);
 
+            size_t segment_start = getDataOffsetMaybeCompressed(*in);
             auto [have_more_data, currently_read_rows] = file_segmentation_engine(*in, unit.segment, min_chunk_bytes, max_block_size);
 
+            unit.original_segment_size = getDataOffsetMaybeCompressed(*in) - segment_start;
             unit.offset = successfully_read_rows_count;
             successfully_read_rows_count += currently_read_rows;
 
@@ -108,6 +110,11 @@ void ParallelParsingInputFormat::parserThreadFunction(ThreadGroupPtr thread_grou
             /// NOLINTNEXTLINE(bugprone-use-after-move, hicpp-invalid-access-moved)
             unit.chunk_ext.chunk.emplace_back(std::move(chunk));
             unit.chunk_ext.block_missing_values.emplace_back(parser.getMissingValues());
+            size_t approx_chunk_size = input_format->getApproxBytesReadForChunk();
+            /// We could decompress data during file segmentation.
+            /// Correct chunk size using original segment size.
+            approx_chunk_size = static_cast<size_t>(std::ceil(static_cast<double>(approx_chunk_size) / unit.segment.size() * unit.original_segment_size));
+            unit.chunk_ext.approx_chunk_sizes.push_back(approx_chunk_size);
         }
 
         /// Extract column_mapping from first parser to propagate it to others
@@ -237,6 +244,7 @@ Chunk ParallelParsingInputFormat::generate()
 
     Chunk res = std::move(unit.chunk_ext.chunk.at(*next_block_in_current_unit));
     last_block_missing_values = std::move(unit.chunk_ext.block_missing_values[*next_block_in_current_unit]);
+    last_approx_bytes_read_for_chunk = unit.chunk_ext.approx_chunk_sizes.at(*next_block_in_current_unit);
 
     next_block_in_current_unit.value() += 1;
 

--- a/src/Processors/Formats/Impl/ParallelParsingInputFormat.h
+++ b/src/Processors/Formats/Impl/ParallelParsingInputFormat.h
@@ -126,6 +126,8 @@ public:
         return last_block_missing_values;
     }
 
+    size_t getApproxBytesReadForChunk() const override { return last_approx_bytes_read_for_chunk; }
+
     String getName() const override final { return "ParallelParsingBlockInputFormat"; }
 
 private:
@@ -200,6 +202,7 @@ private:
     const size_t max_block_size;
 
     BlockMissingValues last_block_missing_values;
+    size_t last_approx_bytes_read_for_chunk;
 
     /// Non-atomic because it is used in one thread.
     std::optional<size_t> next_block_in_current_unit;
@@ -245,6 +248,7 @@ private:
     {
         std::vector<Chunk> chunk;
         std::vector<BlockMissingValues> block_missing_values;
+        std::vector<size_t> approx_chunk_sizes;
     };
 
     struct ProcessingUnit
@@ -256,6 +260,7 @@ private:
 
         ChunkExt chunk_ext;
         Memory<> segment;
+        size_t original_segment_size;
         std::atomic<ProcessingUnitStatus> status;
         /// Needed for better exception message.
         size_t offset = 0;

--- a/src/Processors/Formats/Impl/ParquetBlockInputFormat.cpp
+++ b/src/Processors/Formats/Impl/ParquetBlockInputFormat.cpp
@@ -147,6 +147,9 @@ void ParquetBlockInputFormat::initializeRowGroupReader(size_t row_group_idx)
         format_settings.parquet.allow_missing_columns,
         format_settings.null_as_default,
         format_settings.parquet.case_insensitive_column_matching);
+
+    row_group.row_group_bytes_uncompressed = metadata->RowGroup(static_cast<int>(row_group_idx))->total_compressed_size();
+    row_group.row_group_rows = metadata->RowGroup(static_cast<int>(row_group_idx))->num_rows();
 }
 
 void ParquetBlockInputFormat::scheduleRowGroup(size_t row_group_idx)
@@ -253,7 +256,8 @@ void ParquetBlockInputFormat::decodeOneChunk(size_t row_group_idx, std::unique_l
 
     auto tmp_table = arrow::Table::FromRecordBatches({*batch});
 
-    PendingChunk res = {.chunk_idx = row_group.next_chunk_idx, .row_group_idx = row_group_idx};
+    size_t approx_chunk_original_size = static_cast<size_t>(std::ceil(static_cast<double>(row_group.row_group_bytes_uncompressed) / row_group.row_group_rows * (*tmp_table)->num_rows()));
+    PendingChunk res = {.chunk_idx = row_group.next_chunk_idx, .row_group_idx = row_group_idx, .approx_original_chunk_size = approx_chunk_original_size};
 
     /// If defaults_for_omitted_fields is true, calculate the default values from default expression for omitted fields.
     /// Otherwise fill the missing columns with zero values of its type.
@@ -327,6 +331,7 @@ Chunk ParquetBlockInputFormat::generate()
             scheduleMoreWorkIfNeeded(chunk.row_group_idx);
 
             previous_block_missing_values = std::move(chunk.block_missing_values);
+            previous_approx_bytes_read_for_chunk = chunk.approx_original_chunk_size;
             return std::move(chunk.chunk);
         }
 

--- a/src/Processors/Formats/Impl/ParquetBlockInputFormat.h
+++ b/src/Processors/Formats/Impl/ParquetBlockInputFormat.h
@@ -60,6 +60,8 @@ public:
 
     const BlockMissingValues & getMissingValues() const override;
 
+    size_t getApproxBytesReadForChunk() const override { return previous_approx_bytes_read_for_chunk; }
+
 private:
     Chunk generate() override;
 
@@ -200,6 +202,9 @@ private:
         size_t next_chunk_idx = 0;
         size_t num_pending_chunks = 0;
 
+        size_t row_group_bytes_uncompressed = 0;
+        size_t row_group_rows = 0;
+
         // These are only used by the decoding thread, so don't require locking the mutex.
         std::unique_ptr<parquet::arrow::FileReader> file_reader;
         std::shared_ptr<arrow::RecordBatchReader> record_batch_reader;
@@ -213,6 +218,7 @@ private:
         BlockMissingValues block_missing_values;
         size_t chunk_idx; // within row group
         size_t row_group_idx;
+        size_t approx_original_chunk_size;
 
         // For priority_queue.
         // In ordered mode we deliver strictly in order of increasing row group idx,
@@ -267,6 +273,7 @@ private:
     std::unique_ptr<ThreadPool> pool;
 
     BlockMissingValues previous_block_missing_values;
+    size_t previous_approx_bytes_read_for_chunk;
 
     std::exception_ptr background_exception = nullptr;
     std::atomic<int> is_stopped{0};

--- a/src/Processors/Formats/Impl/ValuesBlockInputFormat.cpp
+++ b/src/Processors/Formats/Impl/ValuesBlockInputFormat.cpp
@@ -61,6 +61,7 @@ Chunk ValuesBlockInputFormat::generate()
     const Block & header = getPort().getHeader();
     MutableColumns columns = header.cloneEmptyColumns();
     block_missing_values.clear();
+    size_t chunk_start = getDataOffsetMaybeCompressed(*buf);
 
     for (size_t rows_in_block = 0; rows_in_block < params.max_block_size; ++rows_in_block)
     {
@@ -78,6 +79,8 @@ Chunk ValuesBlockInputFormat::generate()
             throw;
         }
     }
+
+    approx_bytes_read_for_chunk = getDataOffsetMaybeCompressed(*buf) - chunk_start;
 
     /// Evaluate expressions, which were parsed using templates, if any
     for (size_t i = 0; i < columns.size(); ++i)

--- a/src/Processors/Formats/Impl/ValuesBlockInputFormat.h
+++ b/src/Processors/Formats/Impl/ValuesBlockInputFormat.h
@@ -40,6 +40,7 @@ public:
 
     const BlockMissingValues & getMissingValues() const override { return block_missing_values; }
 
+    size_t getApproxBytesReadForChunk() const override { return approx_bytes_read_for_chunk; }
 private:
     ValuesBlockInputFormat(std::unique_ptr<PeekableReadBuffer> buf_, const Block & header_, const RowInputFormatParams & params_,
                            const FormatSettings & format_settings_);
@@ -95,6 +96,7 @@ private:
     Serializations serializations;
 
     BlockMissingValues block_missing_values;
+    size_t approx_bytes_read_for_chunk;
 };
 
 class ValuesSchemaReader : public IRowSchemaReader

--- a/src/Storages/HDFS/StorageHDFS.cpp
+++ b/src/Storages/HDFS/StorageHDFS.cpp
@@ -30,6 +30,7 @@
 #include <Storages/PartitionedSink.h>
 #include <Storages/getVirtualsForStorage.h>
 #include <Storages/checkAndGetLiteralArgument.h>
+#include <Storages/ReadFromStorageProgress.h>
 
 #include <Formats/ReadSchemaUtils.h>
 #include <Formats/FormatFactory.h>
@@ -362,9 +363,10 @@ HDFSSource::HDFSSource(
 bool HDFSSource::initialize()
 {
     bool skip_empty_files = getContext()->getSettingsRef().hdfs_skip_empty_files;
+    StorageHDFS::PathWithInfo path_with_info;
     while (true)
     {
-        auto path_with_info = (*file_iterator)();
+        path_with_info = (*file_iterator)();
         if (path_with_info.path.empty())
             return false;
 
@@ -385,7 +387,17 @@ bool HDFSSource::initialize()
         }
     }
 
-    auto input_format = getContext()->getInputFormat(storage->format_name, *read_buf, block_for_format, max_block_size);
+    current_path = path_with_info.path;
+
+    if (path_with_info.info && path_with_info.info->size)
+    {
+        /// Adjust total_rows_approx_accumulated with new total size.
+        if (total_files_size)
+            total_rows_approx_accumulated = static_cast<size_t>(std::ceil(static_cast<double>(total_files_size + path_with_info.info->size) / total_files_size * total_rows_approx_accumulated));
+        total_files_size += path_with_info.info->size;
+    }
+
+    input_format = getContext()->getInputFormat(storage->format_name, *read_buf, block_for_format, max_block_size);
 
     QueryPipelineBuilder builder;
     builder.init(Pipe(input_format));
@@ -422,6 +434,14 @@ Chunk HDFSSource::generate()
         {
             Columns columns = chunk.getColumns();
             UInt64 num_rows = chunk.getNumRows();
+
+            if (num_rows && total_files_size)
+            {
+                size_t chunk_size = input_format->getApproxBytesReadForChunk();
+                if (!chunk_size)
+                    chunk_size = chunk.bytes();
+                updateRowsProgressApprox(*this, num_rows, chunk_size, total_files_size, total_rows_approx_accumulated, total_rows_count_times, total_rows_approx_max);
+            }
 
             for (const auto & virtual_column : requested_virtual_columns)
             {

--- a/src/Storages/HDFS/StorageHDFS.cpp
+++ b/src/Storages/HDFS/StorageHDFS.cpp
@@ -465,6 +465,7 @@ Chunk HDFSSource::generate()
 
         reader.reset();
         pipeline.reset();
+        input_format.reset();
         read_buf.reset();
 
         if (!initialize())

--- a/src/Storages/HDFS/StorageHDFS.h
+++ b/src/Storages/HDFS/StorageHDFS.h
@@ -11,6 +11,9 @@
 
 namespace DB
 {
+
+class IInputFormat;
+
 /**
  * This class represents table engine for external hdfs files.
  * Read method is supported for now.
@@ -161,9 +164,15 @@ private:
     ColumnsDescription columns_description;
 
     std::unique_ptr<ReadBuffer> read_buf;
+    std::shared_ptr<IInputFormat> input_format;
     std::unique_ptr<QueryPipeline> pipeline;
     std::unique_ptr<PullingPipelineExecutor> reader;
     String current_path;
+
+    UInt64 total_rows_approx_max = 0;
+    size_t total_rows_count_times = 0;
+    UInt64 total_rows_approx_accumulated = 0;
+    size_t total_files_size = 0;
 
     /// Recreate ReadBuffer and PullingPipelineExecutor for each file.
     bool initialize();

--- a/src/Storages/ReadFromStorageProgress.cpp
+++ b/src/Storages/ReadFromStorageProgress.cpp
@@ -7,7 +7,8 @@ namespace DB
 
 void updateRowsProgressApprox(
     ISource & source,
-    const Chunk & chunk,
+    size_t num_rows,
+    UInt64 chunk_bytes_size,
     UInt64 total_result_size,
     UInt64 & total_rows_approx_accumulated,
     size_t & total_rows_count_times,
@@ -15,8 +16,6 @@ void updateRowsProgressApprox(
 {
     if (!total_result_size)
         return;
-
-    const size_t num_rows = chunk.getNumRows();
 
     if (!num_rows)
         return;
@@ -32,7 +31,7 @@ void updateRowsProgressApprox(
         }
     }
 
-    const auto bytes_per_row = std::ceil(static_cast<double>(chunk.bytes()) / num_rows);
+    const auto bytes_per_row = std::ceil(static_cast<double>(chunk_bytes_size) / num_rows);
     size_t total_rows_approx = static_cast<size_t>(std::ceil(static_cast<double>(total_result_size) / bytes_per_row));
     total_rows_approx_accumulated += total_rows_approx;
     ++total_rows_count_times;

--- a/src/Storages/ReadFromStorageProgress.h
+++ b/src/Storages/ReadFromStorageProgress.h
@@ -5,12 +5,11 @@ namespace DB
 {
 
 class ISource;
-class Chunk;
 
 void updateRowsProgressApprox(
     ISource & source,
     size_t num_rows,
-    size_t chunk_bytes_size,
+    UInt64 chunk_bytes_size,
     UInt64 total_result_size,
     UInt64 & total_rows_approx_accumulated,
     size_t & total_rows_count_times,

--- a/src/Storages/ReadFromStorageProgress.h
+++ b/src/Storages/ReadFromStorageProgress.h
@@ -9,7 +9,8 @@ class Chunk;
 
 void updateRowsProgressApprox(
     ISource & source,
-    const Chunk & chunk,
+    size_t num_rows,
+    size_t chunk_bytes_size,
     UInt64 total_result_size,
     UInt64 & total_rows_approx_accumulated,
     size_t & total_rows_count_times,

--- a/src/Storages/StorageAzureBlob.cpp
+++ b/src/Storages/StorageAzureBlob.cpp
@@ -1013,11 +1013,13 @@ Chunk StorageAzureBlobSource::generate()
             UInt64 num_rows = chunk.getNumRows();
 
             const auto & file_path = reader.getPath();
-            size_t total_size = file_iterator->getTotalSize();
-            if (num_rows && total_size)
+            if (num_rows && total_objects_size)
             {
+                size_t chunk_size = reader.getFormat()->getApproxBytesReadForChunk();
+                if (!chunk_size)
+                    chunk_size = chunk.bytes();
                 updateRowsProgressApprox(
-                    *this, chunk, total_size, total_rows_approx_accumulated, total_rows_count_times, total_rows_approx_max);
+                    *this, num_rows, chunk_size, total_objects_size, total_rows_approx_accumulated, total_rows_count_times, total_rows_approx_max);
             }
 
             for (const auto & virtual_column : requested_virtual_columns)
@@ -1043,6 +1045,13 @@ Chunk StorageAzureBlobSource::generate()
 
         if (!reader)
             break;
+
+        size_t object_size = tryGetFileSizeFromReadBuffer(*reader.getReadBuffer()).value_or(0);
+        /// Adjust total_rows_approx_accumulated with new total size.
+        if (total_objects_size)
+            total_rows_approx_accumulated = static_cast<size_t>(
+                std::ceil(static_cast<double>(total_objects_size + object_size) / total_objects_size * total_rows_approx_accumulated));
+        total_objects_size += object_size;
 
         /// Even if task is finished the thread may be not freed in pool.
         /// So wait until it will be freed before scheduling a new task.
@@ -1092,7 +1101,13 @@ StorageAzureBlobSource::StorageAzureBlobSource(
 {
     reader = createReader();
     if (reader)
+    {
+        const auto & read_buf = reader.getReadBuffer();
+        if (read_buf)
+            total_objects_size = tryGetFileSizeFromReadBuffer(*reader.getReadBuffer()).value_or(0);
+
         reader_future = createReaderAsync();
+    }
 }
 
 
@@ -1134,7 +1149,7 @@ StorageAzureBlobSource::ReaderHolder StorageAzureBlobSource::createReader()
     auto pipeline = std::make_unique<QueryPipeline>(QueryPipelineBuilder::getPipeline(std::move(builder)));
     auto current_reader = std::make_unique<PullingPipelineExecutor>(*pipeline);
 
-    return ReaderHolder{fs::path(container) / current_key, std::move(read_buf), std::move(pipeline), std::move(current_reader)};
+    return ReaderHolder{fs::path(container) / current_key, std::move(read_buf), input_format, std::move(pipeline), std::move(current_reader)};
 }
 
 std::future<StorageAzureBlobSource::ReaderHolder> StorageAzureBlobSource::createReaderAsync()

--- a/src/Storages/StorageAzureBlob.h
+++ b/src/Storages/StorageAzureBlob.h
@@ -225,10 +225,12 @@ private:
         ReaderHolder(
             String path_,
             std::unique_ptr<ReadBuffer> read_buf_,
+            std::shared_ptr<IInputFormat> input_format_,
             std::unique_ptr<QueryPipeline> pipeline_,
             std::unique_ptr<PullingPipelineExecutor> reader_)
             : path(std::move(path_))
             , read_buf(std::move(read_buf_))
+            , input_format(input_format_)
             , pipeline(std::move(pipeline_))
             , reader(std::move(reader_))
         {
@@ -249,6 +251,7 @@ private:
             /// reader uses pipeline, pipeline uses read_buf.
             reader = std::move(other.reader);
             pipeline = std::move(other.pipeline);
+            input_format = std::move(other.input_format);
             read_buf = std::move(other.read_buf);
             path = std::move(other.path);
             return *this;
@@ -259,9 +262,14 @@ private:
         const PullingPipelineExecutor * operator->() const { return reader.get(); }
         const String & getPath() const { return path; }
 
+        const std::unique_ptr<ReadBuffer> & getReadBuffer() const { return read_buf; }
+
+        const std::shared_ptr<IInputFormat> & getFormat() const { return input_format; }
+
     private:
         String path;
         std::unique_ptr<ReadBuffer> read_buf;
+        std::shared_ptr<IInputFormat> input_format;
         std::unique_ptr<QueryPipeline> pipeline;
         std::unique_ptr<PullingPipelineExecutor> reader;
     };
@@ -277,6 +285,7 @@ private:
     UInt64 total_rows_approx_max = 0;
     size_t total_rows_count_times = 0;
     UInt64 total_rows_approx_accumulated = 0;
+    size_t total_objects_size = 0;
 
     /// Recreate ReadBuffer and Pipeline for each file.
     ReaderHolder createReader();

--- a/src/Storages/StorageFile.cpp
+++ b/src/Storages/StorageFile.cpp
@@ -873,10 +873,7 @@ Pipe StorageFile::read(
     auto progress_callback = context->getFileProgressCallback();
 
     if (progress_callback)
-    {
-        LOG_DEBUG(&Poco::Logger::get("StorageFile"), "Set total_bytes_to_read {}", total_bytes_to_read);
         progress_callback(FileProgress(0, total_bytes_to_read));
-    }
 
     for (size_t i = 0; i < num_streams; ++i)
     {

--- a/src/Storages/StorageFile.cpp
+++ b/src/Storages/StorageFile.cpp
@@ -788,6 +788,7 @@ public:
             /// Close file prematurely if stream was ended.
             reader.reset();
             pipeline.reset();
+            input_format.reset();
             read_buf.reset();
         }
 

--- a/src/Storages/StorageS3.cpp
+++ b/src/Storages/StorageS3.cpp
@@ -573,7 +573,10 @@ StorageS3Source::StorageS3Source(
 {
     reader = createReader();
     if (reader)
+    {
+        total_objects_size = tryGetFileSizeFromReadBuffer(*reader.getReadBuffer()).value_or(0);
         reader_future = createReaderAsync();
+    }
 }
 
 StorageS3Source::ReaderHolder StorageS3Source::createReader()
@@ -611,7 +614,7 @@ StorageS3Source::ReaderHolder StorageS3Source::createReader()
     auto pipeline = std::make_unique<QueryPipeline>(QueryPipelineBuilder::getPipeline(std::move(builder)));
     auto current_reader = std::make_unique<PullingPipelineExecutor>(*pipeline);
 
-    return ReaderHolder{fs::path(bucket) / key_with_info.key, std::move(read_buf), std::move(pipeline), std::move(current_reader)};
+    return ReaderHolder{fs::path(bucket) / key_with_info.key, std::move(read_buf), input_format, std::move(pipeline), std::move(current_reader)};
 }
 
 std::future<StorageS3Source::ReaderHolder> StorageS3Source::createReaderAsync()
@@ -712,11 +715,13 @@ Chunk StorageS3Source::generate()
             UInt64 num_rows = chunk.getNumRows();
 
             const auto & file_path = reader.getPath();
-            size_t total_size = file_iterator->getTotalSize();
-            if (num_rows && total_size)
+
+            if (num_rows && total_objects_size)
             {
-                updateRowsProgressApprox(
-                    *this, chunk, total_size, total_rows_approx_accumulated, total_rows_count_times, total_rows_approx_max);
+                size_t chunk_size = reader.getFormat()->getApproxBytesReadForChunk();
+                if (!chunk_size)
+                    chunk_size = chunk.bytes();
+                updateRowsProgressApprox(*this, num_rows, chunk_size, total_objects_size, total_rows_approx_accumulated, total_rows_count_times, total_rows_approx_max);
             }
 
             for (const auto & virtual_column : requested_virtual_columns)
@@ -742,6 +747,13 @@ Chunk StorageS3Source::generate()
 
         if (!reader)
             break;
+
+        size_t object_size = tryGetFileSizeFromReadBuffer(*reader.getReadBuffer()).value_or(0);
+        /// Adjust total_rows_approx_accumulated with new total size.
+        if (total_objects_size)
+            total_rows_approx_accumulated = static_cast<size_t>(
+                std::ceil(static_cast<double>(total_objects_size + object_size) / total_objects_size * total_rows_approx_accumulated));
+        total_objects_size += object_size;
 
         /// Even if task is finished the thread may be not freed in pool.
         /// So wait until it will be freed before scheduling a new task.

--- a/src/Storages/StorageS3.h
+++ b/src/Storages/StorageS3.h
@@ -163,10 +163,12 @@ private:
         ReaderHolder(
             String path_,
             std::unique_ptr<ReadBuffer> read_buf_,
+            std::shared_ptr<IInputFormat> input_format_,
             std::unique_ptr<QueryPipeline> pipeline_,
             std::unique_ptr<PullingPipelineExecutor> reader_)
             : path(std::move(path_))
             , read_buf(std::move(read_buf_))
+            , input_format(input_format_)
             , pipeline(std::move(pipeline_))
             , reader(std::move(reader_))
         {
@@ -187,10 +189,15 @@ private:
             /// reader uses pipeline, pipeline uses read_buf.
             reader = std::move(other.reader);
             pipeline = std::move(other.pipeline);
+            input_format = std::move(other.input_format);
             read_buf = std::move(other.read_buf);
             path = std::move(other.path);
             return *this;
         }
+
+        const std::unique_ptr<ReadBuffer> & getReadBuffer() const { return read_buf; }
+
+        const std::shared_ptr<IInputFormat> & getFormat() const { return input_format; }
 
         explicit operator bool() const { return reader != nullptr; }
         PullingPipelineExecutor * operator->() { return reader.get(); }
@@ -200,6 +207,7 @@ private:
     private:
         String path;
         std::unique_ptr<ReadBuffer> read_buf;
+        std::shared_ptr<IInputFormat> input_format;
         std::unique_ptr<QueryPipeline> pipeline;
         std::unique_ptr<PullingPipelineExecutor> reader;
     };
@@ -219,6 +227,7 @@ private:
     UInt64 total_rows_approx_max = 0;
     size_t total_rows_count_times = 0;
     UInt64 total_rows_approx_accumulated = 0;
+    size_t total_objects_size = 0;
 
     /// Recreate ReadBuffer and Pipeline for each file.
     ReaderHolder createReader();

--- a/src/Storages/StorageURL.cpp
+++ b/src/Storages/StorageURL.cpp
@@ -270,17 +270,26 @@ StorageURLSource::StorageURLSource(
         curr_uri = uri_and_buf.first;
         read_buf = std::move(uri_and_buf.second);
 
+        size_t file_size = 0;
         try
         {
-            total_size += getFileSizeFromReadBuffer(*read_buf);
+            file_size = getFileSizeFromReadBuffer(*read_buf);
         }
         catch (...)
         {
-            // we simply continue without total_size
+            // we simply continue without updating total_size
+        }
+
+        if (file_size)
+        {
+            /// Adjust total_rows_approx_accumulated with new total size.
+            if (total_size)
+                total_rows_approx_accumulated = static_cast<size_t>(std::ceil(static_cast<double>(total_size + file_size) / total_size * total_rows_approx_accumulated));
+            total_size += file_size;
         }
 
         // TODO: Pass max_parsing_threads and max_download_threads adjusted for num_streams.
-        auto input_format = FormatFactory::instance().getInput(
+        input_format = FormatFactory::instance().getInput(
             format,
             *read_buf,
             sample_block,
@@ -323,8 +332,13 @@ Chunk StorageURLSource::generate()
         {
             UInt64 num_rows = chunk.getNumRows();
             if (num_rows && total_size)
+            {
+                size_t chunk_size = input_format->getApproxBytesReadForChunk();
+                if (!chunk_size)
+                    chunk_size = chunk.bytes();
                 updateRowsProgressApprox(
-                    *this, chunk, total_size, total_rows_approx_accumulated, total_rows_count_times, total_rows_approx_max);
+                    *this, num_rows, chunk_size, total_size, total_rows_approx_accumulated, total_rows_count_times, total_rows_approx_max);
+            }
 
             const String & path{curr_uri.getPath()};
 

--- a/src/Storages/StorageURL.h
+++ b/src/Storages/StorageURL.h
@@ -19,6 +19,7 @@ namespace DB
 class IOutputFormat;
 using OutputFormatPtr = std::shared_ptr<IOutputFormat>;
 
+class IInputFormat;
 struct ConnectionTimeouts;
 class NamedCollection;
 class PullingPipelineExecutor;
@@ -206,6 +207,7 @@ private:
     Poco::URI curr_uri;
 
     std::unique_ptr<ReadBuffer> read_buf;
+    std::shared_ptr<IInputFormat> input_format;
     std::unique_ptr<QueryPipeline> pipeline;
     std::unique_ptr<PullingPipelineExecutor> reader;
 


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Improve the progress bar for file/s3/hdfs/url table functions by using chunk size from source data and using incremental total size counting in each thread. Fix the progress bar for *Cluster functions. This closes #47250.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
