### PR TITLE
Fix ColumnConst::forEachSubcolumn missing from previous PR

### DIFF
--- a/src/Columns/ColumnConst.h
+++ b/src/Columns/ColumnConst.h
@@ -230,12 +230,12 @@ public:
         data->getExtremes(min, max);
     }
 
-    void forEachSubcolumn(ColumnCallback callback) const override
+    void forEachSubcolumn(MutableColumnCallback callback) override
     {
         callback(data);
     }
 
-    void forEachSubcolumnRecursively(RecursiveColumnCallback callback) const override
+    void forEachSubcolumnRecursively(RecursiveMutableColumnCallback callback) override
     {
         callback(*data);
         data->forEachSubcolumnRecursively(callback);


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Ouch, I missed this file in https://github.com/ClickHouse/ClickHouse/pull/51072 (didn't save the file in the editor). Sorry for the PR spam.