### PR TITLE
Handle multiple IPs for http/https session creation.

### DIFF
--- a/base/poco/Net/include/Poco/Net/HTTPClientSession.h
+++ b/base/poco/Net/include/Poco/Net/HTTPClientSession.h
@@ -306,7 +306,7 @@ namespace Net
             DEFAULT_KEEP_ALIVE_TIMEOUT = 8
         };
 
-        void reconnect();
+        virtual void reconnect();
         /// Connects the underlying socket to the HTTP server.
 
         int write(const char * buffer, std::streamsize length);

--- a/base/poco/NetSSL_OpenSSL/include/Poco/Net/HTTPSClientSession.h
+++ b/base/poco/NetSSL_OpenSSL/include/Poco/Net/HTTPSClientSession.h
@@ -121,7 +121,7 @@ namespace Net
         /// caching is enabled for the given Context, and the server
         /// agrees to reuse the session).
 
-        virtual ~HTTPSClientSession();
+        ~HTTPSClientSession();
         /// Destroys the HTTPSClientSession and closes
         /// the underlying socket.
 

--- a/base/poco/NetSSL_OpenSSL/include/Poco/Net/HTTPSClientSession.h
+++ b/base/poco/NetSSL_OpenSSL/include/Poco/Net/HTTPSClientSession.h
@@ -121,7 +121,7 @@ namespace Net
         /// caching is enabled for the given Context, and the server
         /// agrees to reuse the session).
 
-        ~HTTPSClientSession();
+        virtual ~HTTPSClientSession();
         /// Destroys the HTTPSClientSession and closes
         /// the underlying socket.
 

--- a/src/Disks/ObjectStorages/S3/ProxyResolverConfiguration.cpp
+++ b/src/Disks/ObjectStorages/S3/ProxyResolverConfiguration.cpp
@@ -60,7 +60,7 @@ ClientConfigurationPerRequest ProxyResolverConfiguration::getConfiguration(const
         {
             auto resolved_endpoint = endpoint;
             resolved_endpoint.setHost(resolved_hosts[i].toString());
-            session = makeHTTPSession(resolved_endpoint, timeouts, false);
+            session = makeHTTPSession(resolved_endpoint, timeouts);
 
             try
             {

--- a/src/IO/HTTPCommon.cpp
+++ b/src/IO/HTTPCommon.cpp
@@ -51,6 +51,39 @@ namespace
         session.setKeepAliveTimeout(timeouts.http_keep_alive_timeout);
     }
 
+    template <typename Session>
+    class HTTPSessionAdapter : public Session
+    {
+    public:
+        HTTPSessionAdapter(const std::string & host, UInt16 port) :
+            Session(host,port)
+        {
+
+        }
+        ~HTTPSessionAdapter() override = default;
+
+    protected:
+       void reconnect() override {
+            const auto& endpoinds = DNSResolver::instance().resolveHostAll(Session::getHost());
+
+            for (auto it = endpoinds.begin(); ;) {
+                try {
+                    Session::setResolvedHost(it->toString());
+                    Session::reconnect();
+                    LOG_TRACE((&Poco::Logger::get("HTTPSessionAdapter")), "Created HTTP(S) session with {}:{} ({}:{})", Session::getHost(), Session::getPort(),
+                                                                           it->toString(), Session::getPort());
+                    break;
+                } catch (...) {
+                    Session::close();
+                    if (++it == endpoinds.end())
+                    {
+                        throw Poco::TimeoutException("Can't connect to the host. All resolved endpoints are unreachable.", Session::getHost(), Session::getPort());
+                    }
+                }
+            }
+        }
+    };
+
     bool isHTTPS(const Poco::URI & uri)
     {
         if (uri.getScheme() == "https")
@@ -61,28 +94,21 @@ namespace
             throw Exception(ErrorCodes::UNSUPPORTED_URI_SCHEME, "Unsupported scheme in URI '{}'", uri.toString());
     }
 
-    HTTPSessionPtr makeHTTPSessionImpl(const std::string & host, UInt16 port, bool https, bool keep_alive, bool resolve_host = true)
+    HTTPSessionPtr makeHTTPSessionImpl(const std::string & host, UInt16 port, bool https, bool keep_alive)
     {
         HTTPSessionPtr session;
 
         if (https)
         {
 #if USE_SSL
-            /// Cannot resolve host in advance, otherwise SNI won't work in Poco.
-            /// For more information about SNI, see the https://en.wikipedia.org/wiki/Server_Name_Indication
-            auto https_session = std::make_shared<Poco::Net::HTTPSClientSession>(host, port);
-            if (resolve_host)
-                https_session->setResolvedHost(DNSResolver::instance().resolveHost(host).toString());
-
-            session = std::move(https_session);
+            session = std::make_shared<HTTPSessionAdapter<Poco::Net::HTTPSClientSession>>(host, port);
 #else
             throw Exception(ErrorCodes::FEATURE_IS_NOT_ENABLED_AT_BUILD_TIME, "ClickHouse was built without HTTPS support");
 #endif
         }
         else
         {
-            String resolved_host = resolve_host ? DNSResolver::instance().resolveHost(host).toString() : host;
-            session = std::make_shared<Poco::Net::HTTPClientSession>(resolved_host, port);
+            session = std::make_shared<HTTPSessionAdapter<Poco::Net::HTTPClientSession>>(host, port);
         }
 
         ProfileEvents::increment(ProfileEvents::CreatedHTTPConnections);
@@ -101,13 +127,12 @@ namespace
         const String proxy_host;
         const UInt16 proxy_port;
         const bool proxy_https;
-        const bool resolve_host;
 
         using Base = PoolBase<Poco::Net::HTTPClientSession>;
 
         ObjectPtr allocObject() override
         {
-            auto session = makeHTTPSessionImpl(host, port, https, true, resolve_host);
+            auto session = makeHTTPSessionImpl(host, port, https, true);
             if (!proxy_host.empty())
             {
                 const String proxy_scheme = proxy_https ? "https" : "http";
@@ -130,8 +155,7 @@ namespace
             const std::string & proxy_host_,
             UInt16 proxy_port_,
             bool proxy_https_,
-            size_t max_pool_size_,
-            bool resolve_host_ = true)
+            size_t max_pool_size_)
             : Base(static_cast<unsigned>(max_pool_size_), &Poco::Logger::get("HTTPSessionPool"))
             , host(host_)
             , port(port_)
@@ -139,7 +163,6 @@ namespace
             , proxy_host(proxy_host_)
             , proxy_port(proxy_port_)
             , proxy_https(proxy_https_)
-            , resolve_host(resolve_host_)
         {
         }
     };
@@ -185,23 +208,6 @@ namespace
         std::mutex mutex;
         std::unordered_map<Key, PoolPtr, Hasher> endpoints_pool;
 
-        void updateHostIfIpChanged(Entry & session, const String & new_ip)
-        {
-            const auto old_ip = session->getResolvedHost().empty() ? session->getHost() : session->getResolvedHost();
-
-            if (new_ip != old_ip)
-            {
-                session->reset();
-                if (session->getResolvedHost().empty())
-                {
-                    session->setHost(new_ip);
-                }
-                else
-                {
-                    session->setResolvedHost(new_ip);
-                }
-            }
-        }
 
     protected:
         HTTPSessionPool() = default;
@@ -217,8 +223,7 @@ namespace
             const Poco::URI & uri,
             const Poco::URI & proxy_uri,
             const ConnectionTimeouts & timeouts,
-            size_t max_connections_per_endpoint,
-            bool resolve_host = true)
+            size_t max_connections_per_endpoint)
         {
             std::lock_guard lock(mutex);
             const std::string & host = uri.getHost();
@@ -240,31 +245,11 @@ namespace
             auto pool_ptr = endpoints_pool.find(key);
             if (pool_ptr == endpoints_pool.end())
                 std::tie(pool_ptr, std::ignore) = endpoints_pool.emplace(
-                    key, std::make_shared<SingleEndpointHTTPSessionPool>(host, port, https, proxy_host, proxy_port, proxy_https, max_connections_per_endpoint, resolve_host));
+                    key, std::make_shared<SingleEndpointHTTPSessionPool>(host, port, https, proxy_host, proxy_port, proxy_https, max_connections_per_endpoint));
 
             auto retry_timeout = timeouts.connection_timeout.totalMicroseconds();
             auto session = pool_ptr->second->get(retry_timeout);
 
-            /// We store exception messages in session data.
-            /// Poco HTTPSession also stores exception, but it can be removed at any time.
-            const auto & session_data = session->sessionData();
-            if (!session_data.empty())
-            {
-                auto msg = Poco::AnyCast<std::string>(session_data);
-                if (!msg.empty())
-                {
-                    LOG_TRACE((&Poco::Logger::get("HTTPCommon")), "Failed communicating with {} with error '{}' will try to reconnect session", host, msg);
-
-                    if (resolve_host)
-                    {
-                        updateHostIfIpChanged(session, DNSResolver::instance().resolveHost(host).toString());
-                    }
-                }
-                /// Reset the message, once it has been printed,
-                /// otherwise you will get report for failed parts on and on,
-                /// even for different tables (since they uses the same session).
-                session->attachSessionData({});
-            }
 
             setTimeouts(*session, timeouts);
 
@@ -283,26 +268,26 @@ void setResponseDefaultHeaders(HTTPServerResponse & response, size_t keep_alive_
         response.set("Keep-Alive", "timeout=" + std::to_string(timeout.totalSeconds()));
 }
 
-HTTPSessionPtr makeHTTPSession(const Poco::URI & uri, const ConnectionTimeouts & timeouts, bool resolve_host)
+HTTPSessionPtr makeHTTPSession(const Poco::URI & uri, const ConnectionTimeouts & timeouts)
 {
     const std::string & host = uri.getHost();
     UInt16 port = uri.getPort();
     bool https = isHTTPS(uri);
 
-    auto session = makeHTTPSessionImpl(host, port, https, false, resolve_host);
+    auto session = makeHTTPSessionImpl(host, port, https, false);
     setTimeouts(*session, timeouts);
     return session;
 }
 
 
-PooledHTTPSessionPtr makePooledHTTPSession(const Poco::URI & uri, const ConnectionTimeouts & timeouts, size_t per_endpoint_pool_size, bool resolve_host)
+PooledHTTPSessionPtr makePooledHTTPSession(const Poco::URI & uri, const ConnectionTimeouts & timeouts, size_t per_endpoint_pool_size)
 {
-    return makePooledHTTPSession(uri, {}, timeouts, per_endpoint_pool_size, resolve_host);
+    return makePooledHTTPSession(uri, {}, timeouts, per_endpoint_pool_size);
 }
 
-PooledHTTPSessionPtr makePooledHTTPSession(const Poco::URI & uri, const Poco::URI & proxy_uri, const ConnectionTimeouts & timeouts, size_t per_endpoint_pool_size, bool resolve_host)
+PooledHTTPSessionPtr makePooledHTTPSession(const Poco::URI & uri, const Poco::URI & proxy_uri, const ConnectionTimeouts & timeouts, size_t per_endpoint_pool_size)
 {
-    return HTTPSessionPool::instance().getSession(uri, proxy_uri, timeouts, per_endpoint_pool_size, resolve_host);
+    return HTTPSessionPool::instance().getSession(uri, proxy_uri, timeouts, per_endpoint_pool_size);
 }
 
 bool isRedirect(const Poco::Net::HTTPResponse::HTTPStatus status) { return status == Poco::Net::HTTPResponse::HTTP_MOVED_PERMANENTLY  || status == Poco::Net::HTTPResponse::HTTP_FOUND || status == Poco::Net::HTTPResponse::HTTP_SEE_OTHER  || status == Poco::Net::HTTPResponse::HTTP_TEMPORARY_REDIRECT; }

--- a/src/IO/HTTPCommon.cpp
+++ b/src/IO/HTTPCommon.cpp
@@ -57,7 +57,7 @@ namespace
     public:
         HTTPSessionAdapter(const std::string & host, UInt16 port)
             : Session(host,port)
-            , log{&Poco::Logger::get("UserDefinedSQLObjectsLoaderFromDisk")}
+            , log{&Poco::Logger::get("HTTPSessionAdapter")}
         {
             static_assert(std::has_virtual_destructor_v<Session>, "The base class must have a virtual destructor");
         }
@@ -95,12 +95,13 @@ namespace
                 catch (...)
                 {
                     Session::close();
-                    Session::setResolvedHost("");
-                    LOG_WARNING(log, "Failed to create connection with {}:{}. {}", Session::getResolvedHost(), Session::getPort(), getCurrentExceptionMessage(false));
                     if (++it == endpoinds.end())
                     {
+                        Session::setResolvedHost("");
                         throw;
                     }
+                    LOG_WARNING(log, "Failed to create connection with {}:{}. {}", Session::getResolvedHost(), Session::getPort(), getCurrentExceptionMessage(false));
+                    Session::setResolvedHost("");
                 }
             }
         }

--- a/src/IO/HTTPCommon.cpp
+++ b/src/IO/HTTPCommon.cpp
@@ -63,7 +63,8 @@ namespace
         ~HTTPSessionAdapter() override = default;
 
     protected:
-       void reconnect() override {
+       void reconnect() override
+       {
             // First of all will try to establish connection with previous addr.
             if (!Session::getResolvedHost().empty())
             {
@@ -71,7 +72,9 @@ namespace
                 {
                     Session::reconnect();
                     return;
-                } catch(...) {
+                }
+                catch (...)
+                {
                     LOG_TRACE((&Poco::Logger::get("HTTPSessionAdapter")), "Last ip ({})  is unreachable for {}:{}. Will try another resolved address.",
                                                                            Session::getResolvedHost(), Session::getHost(), Session::getPort());
                 }
@@ -79,14 +82,17 @@ namespace
 
             const auto& endpoinds = DNSResolver::instance().resolveHostAll(Session::getHost());
 
-            for (auto it = endpoinds.begin(); ;) {
+            for (auto it = endpoinds.begin();;)
+            {
                 try {
                     Session::setResolvedHost(it->toString());
                     Session::reconnect();
                     LOG_TRACE((&Poco::Logger::get("HTTPSessionAdapter")), "Created HTTP(S) session with {}:{} ({}:{})", Session::getHost(), Session::getPort(),
                                                                            it->toString(), Session::getPort());
                     break;
-                } catch (...) {
+                }
+                catch (...)
+                {
                     Session::close();
                     if (++it == endpoinds.end())
                     {

--- a/src/IO/HTTPCommon.h
+++ b/src/IO/HTTPCommon.h
@@ -58,11 +58,11 @@ using HTTPSessionPtr = std::shared_ptr<Poco::Net::HTTPClientSession>;
 void setResponseDefaultHeaders(HTTPServerResponse & response, size_t keep_alive_timeout);
 
 /// Create session object to perform requests and set required parameters.
-HTTPSessionPtr makeHTTPSession(const Poco::URI & uri, const ConnectionTimeouts & timeouts, bool resolve_host = true);
+HTTPSessionPtr makeHTTPSession(const Poco::URI & uri, const ConnectionTimeouts & timeouts);
 
 /// As previous method creates session, but tooks it from pool, without and with proxy uri.
-PooledHTTPSessionPtr makePooledHTTPSession(const Poco::URI & uri, const ConnectionTimeouts & timeouts, size_t per_endpoint_pool_size, bool resolve_host = true);
-PooledHTTPSessionPtr makePooledHTTPSession(const Poco::URI & uri, const Poco::URI & proxy_uri, const ConnectionTimeouts & timeouts, size_t per_endpoint_pool_size, bool resolve_host = true);
+PooledHTTPSessionPtr makePooledHTTPSession(const Poco::URI & uri, const ConnectionTimeouts & timeouts, size_t per_endpoint_pool_size);
+PooledHTTPSessionPtr makePooledHTTPSession(const Poco::URI & uri, const Poco::URI & proxy_uri, const ConnectionTimeouts & timeouts, size_t per_endpoint_pool_size);
 
 bool isRedirect(Poco::Net::HTTPResponse::HTTPStatus status);
 

--- a/src/IO/S3/PocoHTTPClient.cpp
+++ b/src/IO/S3/PocoHTTPClient.cpp
@@ -313,7 +313,7 @@ void PocoHTTPClient::makeRequestInternal(
 
                 /// Reverse proxy can replace host header with resolved ip address instead of host name.
                 /// This can lead to request signature difference on S3 side.
-                session = makeHTTPSession(target_uri, timeouts, /* resolve_host = */ false);
+                session = makeHTTPSession(target_uri, timeouts);
                 bool use_tunnel = request_configuration.proxy_scheme == Aws::Http::Scheme::HTTP && target_uri.getScheme() == "https";
 
                 session->setProxy(
@@ -325,7 +325,7 @@ void PocoHTTPClient::makeRequestInternal(
             }
             else
             {
-                session = makeHTTPSession(target_uri, timeouts, /* resolve_host = */ true);
+                session = makeHTTPSession(target_uri, timeouts);
             }
 
             /// In case of error this address will be written to logs

--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -3508,6 +3508,11 @@ class ClickHouseInstance:
 
         return error
 
+    def add_local_dns_entry(self, name, ip):
+        self.exec_in_container(
+            (["bash", "-c", "echo '{}' {} >> /etc/hosts".format(ip, name)])
+        )
+
     # Connects to the instance via HTTP interface, sends a query and returns both the answer and the error message
     # as a tuple (output, error).
     def http_query_and_get_answer_with_error(

--- a/tests/integration/parallel_skip.json
+++ b/tests/integration/parallel_skip.json
@@ -66,5 +66,11 @@
   "test_server_reload/test.py::test_remove_http_port",
   "test_server_reload/test.py::test_remove_mysql_port",
   "test_server_reload/test.py::test_remove_postgresql_port",
-  "test_server_reload/test.py::test_remove_tcp_port"
+  "test_server_reload/test.py::test_remove_tcp_port",
+
+  "test_http_failover/test.py::test_ip_url_with_multiple_ips",
+  "test_http_failover/test.py::test_url_invalid_hostname",
+  "test_http_failover/test.py::test_url_ip_change",
+  "test_http_failover/test.py::test_url_inaccessible_hostname",
+  "test_http_failover/test.py::test_url_already_resolved"
 ]

--- a/tests/integration/test_http_failover/test.py
+++ b/tests/integration/test_http_failover/test.py
@@ -26,12 +26,8 @@ node2 = cluster.add_instance(
 
 # Testing different scenarios, when the http endpoint have several ips.
 def _prepare(node):
-    node.exec_in_container(
-        (["bash", "-c", "echo '{}' node1 >> /etc/hosts".format(valid_ipv4)])
-    )
-    node.exec_in_container(
-        (["bash", "-c", "echo '{}' node1 >> /etc/hosts".format(wrong_ipv6)])
-    )
+    node.add_local_dns_entry("node1", valid_ipv4)
+    node.add_local_dns_entry("node1", valid_ipv4)
 
 
 @pytest.fixture(scope="module")
@@ -101,9 +97,7 @@ def test_url_ip_change(started_cluster):
 
     started_cluster.restart_instance_with_ip_change(node1, new_ip_host)
 
-    node2.exec_in_container(
-        (["bash", "-c", "echo '{}' node1 >> /etc/hosts".format(new_ip_host)])
-    )
+    node2.add_local_dns_entry("node1", new_ip_host)
 
     node2.query("SYSTEM DROP DNS CACHE")
 

--- a/tests/integration/test_http_failover/test.py
+++ b/tests/integration/test_http_failover/test.py
@@ -1,0 +1,157 @@
+import pytest
+from helpers.cluster import ClickHouseCluster
+from helpers.client import QueryRuntimeException
+from helpers.test_tools import exec_query_with_retry
+from helpers.test_tools import assert_eq_with_retry
+
+
+cluster = ClickHouseCluster(__file__)
+
+valid_ipv4 = "10.5.172.11"
+wrong_ipv6 = "2001:3984:3989::1:1118"
+
+# Destination node
+node1 = cluster.add_instance(
+    "node1",
+    with_zookeeper=True,
+    ipv4_address=valid_ipv4,
+)
+# Source node
+node2 = cluster.add_instance(
+    "node2",
+    with_zookeeper=True,
+    ipv6_address="2001:3984:3989::1:1219",
+)
+
+
+# Testing different scenarios, when the http endpoint have several ips.
+def _prepare(node):
+    node.exec_in_container(
+        (["bash", "-c", "echo '{}' node1 >> /etc/hosts".format(valid_ipv4)])
+    )
+    node.exec_in_container(
+        (["bash", "-c", "echo '{}' node1 >> /etc/hosts".format(wrong_ipv6)])
+    )
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+        _prepare(node2)
+        yield cluster
+
+    except Exception as ex:
+        print(ex)
+
+    finally:
+        cluster.shutdown()
+        pass
+
+
+def test_ip_url_with_multiple_ips(started_cluster):
+    node1.query(
+        "CREATE TABLE test_table (column1 String, column2 UInt32) ENGINE = MergeTree ORDER BY column2;"
+    )
+
+    node2.query(
+        "INSERT INTO FUNCTION url('http://node1:8123/?query=INSERT+INTO+test_table+FORMAT+CSV', 'CSV', 'column1 String, column2 UInt32') VALUES ('http interface', 42);"
+    )
+    assert node1.query("SELECT count(*) FROM test_table;") == "1\n"
+    assert (
+        node2.query(
+            "SELECT count(*) FROM url('http://node1:8123/?query=SELECT+1', CSV, 'column2 UInt32', headers('Accept'='text/csv; charset=utf-8'));"
+        )
+        == "1\n"
+    )
+
+
+def test_url_invalid_hostname(started_cluster):
+    node1.query("DROP TABLE IF EXISTS test_table")
+
+    node1.query(
+        "CREATE TABLE test_table (column1 String, column2 UInt32) ENGINE = MergeTree ORDER BY column2;"
+    )
+    with pytest.raises(QueryRuntimeException):
+        node2.query(
+            "INSERT INTO FUNCTION url('http://notvalidhost:8123/?query=INSERT+INTO+test_table+FORMAT+CSV', 'CSV', 'column1 String, column2 UInt32') VALUES ('http interface', 42);"
+        )
+
+    assert node1.query("SELECT count(*) FROM test_table;") == "0\n"
+
+    with pytest.raises(QueryRuntimeException):
+        node2.query(
+            "SELECT count(*) FROM url('http://notvalidhost:8123/?query=SELECT+1', CSV, 'column2 UInt32', headers('Accept'='text/csv; charset=utf-8'));"
+        )
+
+
+def test_url_ip_change(started_cluster):
+    node1.query("DROP TABLE IF EXISTS test_table")
+
+    node1.query(
+        "CREATE TABLE test_table (column1 String, column2 UInt32) ENGINE = MergeTree ORDER BY column2;"
+    )
+
+    node2.query(
+        "INSERT INTO FUNCTION url('http://node1:8123/?query=INSERT+INTO+test_table+FORMAT+CSV', 'CSV', 'column1 String, column2 UInt32') VALUES ('first', 1);"
+    )
+    assert node1.query("SELECT count(*) FROM test_table;") == "1\n"
+
+    new_ip_host = "10.5.172.14"
+
+    started_cluster.restart_instance_with_ip_change(node1, new_ip_host)
+
+    node2.exec_in_container(
+        (["bash", "-c", "echo '{}' node1 >> /etc/hosts".format(new_ip_host)])
+    )
+
+    node2.query("SYSTEM DROP DNS CACHE")
+
+    exec_query_with_retry(
+        node2,
+        "INSERT INTO FUNCTION url('http://node1:8123/?query=INSERT+INTO+test_table+FORMAT+CSV', 'CSV', 'column1 String, column2 UInt32') VALUES ('second', 2);",
+    )
+
+    node1.query("SELECT count(*) FROM test_table") == "2\n"
+    node2.query(
+        "SELECT count(*) FROM url('http://node1:8123/?query=SELECT+*+FROM+test_table+FORMAT+CSV', CSV, 'column1 String, column2 UInt32', headers('Accept'='text/csv; charset=utf-8'));"
+    ) == "2\n"
+
+
+def test_url_inaccessible_hostname(started_cluster):
+    node1.query("DROP TABLE IF EXISTS test_table")
+    node1.query(
+        "CREATE TABLE test_table (column1 String, column2 UInt32) ENGINE = MergeTree ORDER BY column2;"
+    )
+
+    new_ip_host = "10.5.172.15"
+    started_cluster.restart_instance_with_ip_change(node1, new_ip_host)
+
+    with pytest.raises(QueryRuntimeException):
+        node2.query(
+            "INSERT INTO FUNCTION url('http://node1:8123/?query=INSERT+INTO+test_table+FORMAT+CSV', 'CSV', 'column1 String, column2 UInt32') VALUES ('http interface', 42);"
+        )
+
+    assert node1.query("SELECT count(*) FROM test_table;") == "0\n"
+
+    with pytest.raises(QueryRuntimeException):
+        node2.query(
+            "SELECT count(*) FROM url('http://node1:8123/?query=SELECT+1', CSV, 'column2 UInt32', headers('Accept'='text/csv; charset=utf-8'));"
+        )
+
+
+def test_url_already_resolved(started_cluster):
+    node1.query("DROP TABLE IF EXISTS test_table")
+    node1.query(
+        "CREATE TABLE test_table (column1 String, column2 UInt32) ENGINE = MergeTree ORDER BY column2;"
+    )
+
+    node2.query(
+        f"INSERT INTO FUNCTION url('http://{node1.ip_address}:8123/?query=INSERT+INTO+test_table+FORMAT+CSV', 'CSV', 'column1 String, column2 UInt32') VALUES ('http interface', 42);"
+    )
+
+    assert node1.query("SELECT count(*) FROM test_table;") == "1\n"
+
+    node2.query(
+        f"SELECT count(*) FROM url('http://{node1.ip_address}:8123/?query=SELECT+*+FROM+test_table+FORMAT+CSV', CSV, 'column1 String, column2 UInt32', headers('Accept'='text/csv; charset=utf-8'));"
+    ) == "2\n"


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
In cases where the http endpoint has multiple IP addresses and first of them is unreacheble, a timeout exception will be thrown. Made session creation with handling all resolved endpoints.


Test example: 
```
def test_ip_url_with_multiple_ips(started_cluster):
    node2.exec_in_container(
        (["bash", "-c", "echo '{}' node1 >> /etc/hosts".format(valid_ipv4)])
    )
    node2.exec_in_container(
        (["bash", "-c", "echo '{}' node1 >> /etc/hosts".format(wrong_ipv6)])
    )
    node1.query(
        "CREATE TABLE test_table (column1 String, column2 UInt32) ENGINE = MergeTree ORDER BY column2;"
    )

    node2.query(
        "INSERT INTO FUNCTION url('http://node1:8123/?query=INSERT+INTO+test_table+FORMAT+CSV', 'CSV', 'column1 String, column2 UInt32') VALUES ('http interface', 42);"
    )
    assert node1.query("SELECT count(*) FROM test_table;") == "1\n"
    assert (
        node2.query(
            "SELECT count(*) FROM url('http://node1:8123/?query=SELECT+1', CSV, 'column2 UInt32', headers('Accept'='text/csv; charset=utf-8'));"
        )
        == "1\n"
    )
```
Result
```
2023.06.16 16:10:41.939471 [ 8 ] {b88e1223-b2b1-4854-b17b-6b3d6809a7c0} <Debug> executeQuery: (from 10.5.1.1:32898) INSERT INTO FUNCTION url('http://node1:8123/?query=INSERT+INTO+test_table+FORMAT+CSV', 'CSV', 'column1 String, column2 UInt32') VALUES  (stage: Complete)
2023.06.16 16:10:41.939639 [ 8 ] {b88e1223-b2b1-4854-b17b-6b3d6809a7c0} <Trace> NamedCollectionsUtils: Loaded 0 collections from SQL
2023.06.16 16:10:41.939677 [ 8 ] {b88e1223-b2b1-4854-b17b-6b3d6809a7c0} <Trace> ContextAccess (default): Access granted: CREATE TEMPORARY TABLE, URL ON *.*
2023.06.16 16:10:41.940017 [ 8 ] {b88e1223-b2b1-4854-b17b-6b3d6809a7c0} <Trace> WriteBufferToHTTP: Sending request to http://node1:8123/?query=INSERT+INTO+test_table+FORMAT+CSV
2023.06.16 16:10:42.001036 [ 283 ] {} <Trace> AsynchronousMetrics: MemoryTracking: was 587.12 MiB, peak 589.11 MiB, free memory in arenas 10.97 MiB, will set to 589.90 MiB (RSS), difference: 2.78 MiB
2023.06.16 16:10:42.956534 [ 8 ] {b88e1223-b2b1-4854-b17b-6b3d6809a7c0} <Error> executeQuery: Poco::Exception. Code: 1000, e.code() = 0, Timeout: connect timed out: [2001:3984:3989::1:1118]:8123 (version 23.5.1.1) (from 10.5.1.1:32898) (in query: INSERT INTO FUNCTION url('http://node1:8123/?query=INSERT+INTO+test_table+FORMAT+CSV', 'CSV', 'column1 String, column2 UInt32') VALUES ), Stack trace (when copying this message, always include the lines below):

0. /home/mburdukov/workspace/clickhouse_build_r/./contrib/llvm-project/libcxx/include/exception:134: Poco::Exception::Exception(String const&, String const&, int) @ 0x000000001ad4ea19 in /usr/bin/clickhouse
1. /home/mburdukov/workspace/clickhouse_build_r/./base/poco/Foundation/src/Exception.cpp:148: Poco::TimeoutException::TimeoutException(String const&, String const&, int) @ 0x000000001ad51c49 in /usr/bin/clickhouse
2. /home/mburdukov/workspace/clickhouse_build_r/./base/poco/Net/src/SocketImpl.cpp:0: Poco::Net::SocketImpl::connect(Poco::Net::SocketAddress const&, Poco::Timespan const&) @ 0x000000001ac35b59 in /usr/bin/clickhouse
3. /home/mburdukov/workspace/clickhouse_build_r/./base/poco/Net/src/HTTPSession.cpp:197: Poco::Net::HTTPSession::connect(Poco::Net::SocketAddress const&) @ 0x000000001ac1ce11 in /usr/bin/clickhouse
4. /home/mburdukov/workspace/clickhouse_build_r/./base/poco/Net/src/HTTPClientSession.cpp:0: Poco::Net::HTTPClientSession::reconnect() @ 0x000000001ac12316 in /usr/bin/clickhouse
5. /home/mburdukov/workspace/clickhouse_build_r/./base/poco/Net/include/Poco/Net/HTTPSession.h:217: Poco::Net::HTTPClientSession::sendRequest(Poco::Net::HTTPRequest&) @ 0x000000001ac118ac in /usr/bin/clickhouse
6. /home/mburdukov/workspace/clickhouse_build_r/./src/IO/WriteBufferFromHTTP.cpp:0: DB::WriteBufferFromHTTP::WriteBufferFromHTTP(Poco::URI const&, String const&, String const&, String const&, std::vector<DB::HTTPHeaderEntry, std::allocator<DB::HTTPHeaderEntry>> const&, DB::ConnectionTimeouts const&, unsigned long) @ 0x00000000121aeb48 in /usr/bin/clickhouse
7. /home/mburdukov/workspace/clickhouse_build_r/./contrib/llvm-project/libcxx/include/__memory/unique_ptr.h:714: DB::StorageURLSink::StorageURLSink(String const&, String const&, std::optional<DB::FormatSettings> const&, DB::Block const&, std::shared_ptr<DB::Context const>, DB::ConnectionTimeouts const&, DB::CompressionMethod, std::vector<DB::HTTPHeaderEntry, std::allocator<DB::HTTPHeaderEntry>> const&, String const&) @ 0x0000000017fbdc3c in /usr/bin/clickhouse
8. /home/mburdukov/workspace/clickhouse_build_r/./contrib/llvm-project/libcxx/include/__memory/construct_at.h:0: DB::IStorageURLBase::write(std::shared_ptr<DB::IAST> const&, std::shared_ptr<DB::StorageInMemoryMetadata const> const&, std::shared_ptr<DB::Context const>, bool) @ 0x0000000017fc1631 in /usr/bin/clickhouse
9. /home/mburdukov/workspace/clickhouse_build_r/./src/Processors/Transforms/buildPushingToViewsChain.cpp:448: DB::buildPushingToViewsChain(std::shared_ptr<DB::IStorage> const&, std::shared_ptr<DB::StorageInMemoryMetadata const> const&, std::shared_ptr<DB::Context const>, std::shared_ptr<DB::IAST> const&, bool, std::shared_ptr<DB::ThreadStatusesHolder>, std::shared_ptr<DB::ThreadGroup>, std::atomic<unsigned long>*, bool, DB::Block const&) @ 0x0000000018910868 in /usr/bin/clickhouse
10. /home/mburdukov/workspace/clickhouse_build_r/./src/Interpreters/InterpreterInsertQuery.cpp:0: DB::InterpreterInsertQuery::buildSink(std::shared_ptr<DB::IStorage> const&, std::shared_ptr<DB::StorageInMemoryMetadata const> const&, std::shared_ptr<DB::ThreadStatusesHolder>, std::shared_ptr<DB::ThreadGroup>, std::atomic<unsigned long>*) @ 0x00000000176563b8 in /usr/bin/clickhouse
11. /home/mburdukov/workspace/clickhouse_build_r/./contrib/llvm-project/libcxx/include/vector:1595: DB::InterpreterInsertQuery::execute() @ 0x0000000017658d97 in /usr/bin/clickhouse
12. /home/mburdukov/workspace/clickhouse_build_r/./src/Interpreters/executeQuery.cpp:0: DB::executeQueryImpl(char const*, char const*, std::shared_ptr<DB::Context>, bool, DB::QueryProcessingStage::Enum, DB::ReadBuffer*) @ 0x00000000179c3ce4 in /usr/bin/clickhouse
13. /home/mburdukov/workspace/clickhouse_build_r/./src/Interpreters/executeQuery.cpp:1182: DB::executeQuery(String const&, std::shared_ptr<DB::Context>, bool, DB::QueryProcessingStage::Enum) @ 0x00000000179c0e76 in /usr/bin/clickhouse
14. /home/mburdukov/workspace/clickhouse_build_r/./src/Server/TCPHandler.cpp:0: DB::TCPHandler::runImpl() @ 0x000000001865fe0b in /usr/bin/clickhouse
15. /home/mburdukov/workspace/clickhouse_build_r/./src/Server/TCPHandler.cpp:2045: DB::TCPHandler::run() @ 0x0000000018670299 in /usr/bin/clickhouse
16. /home/mburdukov/workspace/clickhouse_build_r/./base/poco/Net/src/TCPServerConnection.cpp:57: Poco::Net::TCPServerConnection::start() @ 0x000000001ac3bd47 in /usr/bin/clickhouse
17. /home/mburdukov/workspace/clickhouse_build_r/./contrib/llvm-project/libcxx/include/__memory/unique_ptr.h:48: Poco::Net::TCPServerDispatcher::run() @ 0x000000001ac3c22d in /usr/bin/clickhouse
18. /home/mburdukov/workspace/clickhouse_build_r/./base/poco/Foundation/src/ThreadPool.cpp:202: Poco::PooledThread::run() @ 0x000000001ada2ba7 in /usr/bin/clickhouse
19. /home/mburdukov/workspace/clickhouse_build_r/./base/poco/Foundation/include/Poco/SharedPtr.h:139: Poco::ThreadImpl::runnableEntry(void*) @ 0x000000001ada0763 in /usr/bin/clickhouse
20. ? @ 0x00007f75b4f91609 in ?
21. __clone @ 0x00007f75b4eb6133
```

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
