### PR TITLE
Small fix in `MergeTreePrefetchedReadPool`

### DIFF
--- a/src/Storages/MergeTree/MergeTreePrefetchedReadPool.cpp
+++ b/src/Storages/MergeTree/MergeTreePrefetchedReadPool.cpp
@@ -494,7 +494,7 @@ MergeTreePrefetchedReadPool::ThreadsTasks MergeTreePrefetchedReadPool::createThr
     ThreadsTasks result_threads_tasks;
     for (size_t i = 0, part_idx = 0; i < threads && part_idx < parts_infos.size(); ++i)
     {
-        auto need_marks = min_marks_per_thread;
+        ssize_t need_marks = min_marks_per_thread;
 
         /// Priority is given according to the prefetch number for each thread,
         /// e.g. the first task of each thread has the same priority and is greater
@@ -515,7 +515,7 @@ MergeTreePrefetchedReadPool::ThreadsTasks MergeTreePrefetchedReadPool::createThr
             }
 
             MarkRanges ranges_to_get_from_part;
-            size_t marks_to_get_from_part = std::min(need_marks, marks_in_part);
+            size_t marks_to_get_from_part = std::min<size_t>(need_marks, marks_in_part);
 
             /// Split by prefetch step even if !allow_prefetch below. Because it will allow
             /// to make a better distribution of tasks which did not fill into memory limit

--- a/src/Storages/MergeTree/MergeTreePrefetchedReadPool.cpp
+++ b/src/Storages/MergeTree/MergeTreePrefetchedReadPool.cpp
@@ -494,7 +494,7 @@ MergeTreePrefetchedReadPool::ThreadsTasks MergeTreePrefetchedReadPool::createThr
     ThreadsTasks result_threads_tasks;
     for (size_t i = 0, part_idx = 0; i < threads && part_idx < parts_infos.size(); ++i)
     {
-        ssize_t need_marks = min_marks_per_thread;
+        int64_t need_marks = min_marks_per_thread;
 
         /// Priority is given according to the prefetch number for each thread,
         /// e.g. the first task of each thread has the same priority and is greater


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Problematic scenario:
1. `need_marks = min_marks_per_thread`
2. `marks_to_get_from_part = need_marks`
3. condition on l.557 is true
4. on l.568 `need_marks` became smth around 2^63 because of signed overflow
5. all the rest tasks will be assigned to the current thread

However almost no impact because of tasks stealing.