### PR TITLE
Added a note about the unavailability of MySQL table engine on MacOS builds

### DIFF
--- a/docs/en/engines/table-engines/integrations/mysql.md
+++ b/docs/en/engines/table-engines/integrations/mysql.md
@@ -35,6 +35,10 @@ The table structure can differ from the original MySQL table structure:
 - Column types may differ from those in the original MySQL table. ClickHouse tries to [cast](../../../engines/database-engines/mysql.md#data_types-support) values to the ClickHouse data types.
 - The [external_table_functions_use_nulls](../../../operations/settings/settings.md#external-table-functions-use-nulls) setting defines how to handle Nullable columns. Default value: 1. If 0, the table function does not make Nullable columns and inserts default values instead of nulls. This is also applicable for NULL values inside arrays.
 
+:::note
+The MySQL Table Engine is currently not available on the ClickHouse builds for MacOS ([issue](https://github.com/ClickHouse/ClickHouse/issues/21191))
+:::
+
 **Engine Parameters**
 
 - `host:port` — MySQL server address.


### PR DESCRIPTION
Added a note about unavailability on MacOS builds

### Changelog category (leave one):
- Documentation (changelog entry is not required)



