### PR TITLE
Add total_bytes_to_read to Progress packet in TCP protocol for better progress bar

### DIFF
--- a/src/Core/ProtocolDefines.h
+++ b/src/Core/ProtocolDefines.h
@@ -53,7 +53,7 @@
 /// NOTE: DBMS_TCP_PROTOCOL_VERSION has nothing common with VERSION_REVISION,
 /// later is just a number for server version (one number instead of commit SHA)
 /// for simplicity (sometimes it may be more convenient in some use cases).
-#define DBMS_TCP_PROTOCOL_VERSION 54462
+#define DBMS_TCP_PROTOCOL_VERSION 54463
 
 #define DBMS_MIN_PROTOCOL_VERSION_WITH_INITIAL_QUERY_START_TIME 54449
 
@@ -73,3 +73,5 @@
 #define DBMS_MIN_PROTOCOL_VERSION_WITH_PASSWORD_COMPLEXITY_RULES 54461
 
 #define DBMS_MIN_REVISION_WITH_INTERSERVER_SECRET_V2 54462
+
+#define DBMS_MIN_PROTOCOL_VERSION_WITH_TOTAL_BYTES_IN_PROGRESS 54463

--- a/src/IO/Progress.cpp
+++ b/src/IO/Progress.cpp
@@ -9,11 +9,28 @@
 
 namespace DB
 {
+
+namespace
+{
+    UInt64 getApproxTotalRowsToRead(UInt64 read_rows, UInt64 read_bytes, UInt64 total_bytes_to_read)
+    {
+        if (!read_rows || !read_bytes)
+            return 0;
+
+        auto bytes_per_row = std::ceil(static_cast<double>(read_bytes) / read_rows);
+        return static_cast<UInt64>(std::ceil(static_cast<double>(total_bytes_to_read) / bytes_per_row));
+    }
+}
+
 void ProgressValues::read(ReadBuffer & in, UInt64 server_revision)
 {
     readVarUInt(read_rows, in);
     readVarUInt(read_bytes, in);
     readVarUInt(total_rows_to_read, in);
+    if (server_revision >= DBMS_MIN_PROTOCOL_VERSION_WITH_TOTAL_BYTES_IN_PROGRESS)
+    {
+        readVarUInt(total_bytes_to_read, in);
+    }
     if (server_revision >= DBMS_MIN_REVISION_WITH_CLIENT_WRITE_INFO)
     {
         readVarUInt(written_rows, in);
@@ -30,7 +47,17 @@ void ProgressValues::write(WriteBuffer & out, UInt64 client_revision) const
 {
     writeVarUInt(read_rows, out);
     writeVarUInt(read_bytes, out);
-    writeVarUInt(total_rows_to_read, out);
+    /// In new TCP protocol we can send total_bytes_to_read without total_rows_to_read.
+    /// If client doesn't support total_bytes_to_read, send approx total_rows_to_read
+    /// to indicate at least approx progress.
+    if (client_revision < DBMS_MIN_PROTOCOL_VERSION_WITH_TOTAL_BYTES_IN_PROGRESS && total_bytes_to_read && !total_rows_to_read)
+        writeVarUInt(getApproxTotalRowsToRead(read_rows, read_bytes, total_bytes_to_read), out);
+    else
+        writeVarUInt(total_rows_to_read, out);
+    if (client_revision >= DBMS_MIN_PROTOCOL_VERSION_WITH_TOTAL_BYTES_IN_PROGRESS)
+    {
+        writeVarUInt(total_bytes_to_read, out);
+    }
     if (client_revision >= DBMS_MIN_REVISION_WITH_CLIENT_WRITE_INFO)
     {
         writeVarUInt(written_rows, out);
@@ -190,6 +217,7 @@ void Progress::read(ReadBuffer & in, UInt64 server_revision)
     read_rows.store(values.read_rows, std::memory_order_relaxed);
     read_bytes.store(values.read_bytes, std::memory_order_relaxed);
     total_rows_to_read.store(values.total_rows_to_read, std::memory_order_relaxed);
+    total_bytes_to_read.store(values.total_bytes_to_read, std::memory_order_relaxed);
 
     written_rows.store(values.written_rows, std::memory_order_relaxed);
     written_bytes.store(values.written_bytes, std::memory_order_relaxed);


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add total_bytes_to_read to Progress packet in TCP protocol for better Progress bar

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
