### PR TITLE
Unforget to pass callback to readBigAt() in ParallelReadBuffer

### DIFF
--- a/src/IO/ParallelReadBuffer.cpp
+++ b/src/IO/ParallelReadBuffer.cpp
@@ -256,7 +256,7 @@ void ParallelReadBuffer::readerThreadFunction(ReadWorkerPtr read_worker)
             return false;
         };
 
-        size_t r = input.readBigAt(read_worker->segment.data(), read_worker->segment.size(), read_worker->start_offset);
+        size_t r = input.readBigAt(read_worker->segment.data(), read_worker->segment.size(), read_worker->start_offset, on_progress);
 
         if (!on_progress(r) && r < read_worker->segment.size())
             throw Exception(


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

A simple bug in a previous PR. Thanks @Avogar for catching it.

(The purpose of that callback was to make ParallelReadBuffer (a) stream bytes as soon as the underlying buffer reports them, typically every 1 MB, instead of waiting for a whole segment, typically 10 MB, (b) respond to cancellation faster, again every 1 MB instead of 10 MB. E.g. if download speed is hundreds of KB/s, that's a difference between seconds and tens of seconds - seems important enough.)