### PR TITLE
Specify that user/password is required for dicts in SQL Console

### DIFF
--- a/docs/en/sql-reference/statements/create/dictionary.md
+++ b/docs/en/sql-reference/statements/create/dictionary.md
@@ -87,6 +87,8 @@ When using the SQL console in [ClickHouse Cloud](https://clickhouse.com), you mu
 :::note
 
 ```sql
+CREATE DATABASE foo_db;
+
 CREATE TABLE foo_db.source_table (
     id UInt64,
     value String

--- a/docs/en/sql-reference/statements/create/dictionary.md
+++ b/docs/en/sql-reference/statements/create/dictionary.md
@@ -106,7 +106,7 @@ CREATE DICTIONARY foo_db.id_value_dictionary
     value String
 )
 PRIMARY KEY id
-SOURCE(CLICKHOUSE(TABLE 'source_table' USER 'foo_user' PASSWORD 'foo_user_complex_password' DB 'foo_db' ))
+SOURCE(CLICKHOUSE(TABLE 'source_table' USER 'clickhouse_admin' PASSWORD 'passworD43$x' DB 'foo_db' ))
 LAYOUT(FLAT())
 LIFETIME(MIN 0 MAX 1000);
 ```

--- a/docs/en/sql-reference/statements/create/dictionary.md
+++ b/docs/en/sql-reference/statements/create/dictionary.md
@@ -82,6 +82,28 @@ LIFETIME(MIN 0 MAX 1000)
 LAYOUT(FLAT())
 ```
 
+:::note
+When using the SQL console in [ClickHouse Cloud](https://clickhouse.com), you must specify a user (`default` or any other user) and password when creating a dictionary.
+:::note
+
+```sql
+CREATE TABLE foo_db.source_table (
+    id UInt64,
+    value String
+) ENGINE = MergeTree
+PRIMARY KEY id;
+
+CREATE DICTIONARY foo_db.id_value_dictionary
+(
+    id UInt64,
+    value String
+)
+PRIMARY KEY id
+SOURCE(CLICKHOUSE(TABLE 'source_table' USER 'foo_user' PASSWORD 'foo_user_complex_password' DB 'foo_db' ))
+LAYOUT(FLAT())
+LIFETIME(MIN 0 MAX 1000);
+```
+
 ### Create a dictionary from a table in a remote ClickHouse service
 
 Input table (in the remote ClickHouse service) `source_table`:

--- a/docs/en/sql-reference/statements/create/dictionary.md
+++ b/docs/en/sql-reference/statements/create/dictionary.md
@@ -83,7 +83,7 @@ LAYOUT(FLAT())
 ```
 
 :::note
-When using the SQL console in [ClickHouse Cloud](https://clickhouse.com), you must specify a user (`default` or any other user) and password when creating a dictionary.
+When using the SQL console in [ClickHouse Cloud](https://clickhouse.com), you must specify a user (`default` or any other user with the role `default_role`) and password when creating a dictionary.
 :::note
 
 ```sql

--- a/docs/en/sql-reference/statements/create/dictionary.md
+++ b/docs/en/sql-reference/statements/create/dictionary.md
@@ -87,6 +87,11 @@ When using the SQL console in [ClickHouse Cloud](https://clickhouse.com), you mu
 :::note
 
 ```sql
+CREATE USER IF NOT EXISTS clickhouse_admin
+IDENTIFIED WITH sha256_password BY 'passworD43$x';
+
+GRANT default_role TO clickhouse_admin;
+
 CREATE DATABASE foo_db;
 
 CREATE TABLE foo_db.source_table (


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Documentation (changelog entry is not required)

@DanRoscigno @rfraposa for review