### PR TITLE
Suppress check for covered parts in ZooKeeper

### DIFF
--- a/docker/test/upgrade/run.sh
+++ b/docker/test/upgrade/run.sh
@@ -119,6 +119,13 @@ mv /var/log/clickhouse-server/clickhouse-server.log /var/log/clickhouse-server/c
 install_packages package_folder
 export ZOOKEEPER_FAULT_INJECTION=1
 configure
+
+# Just in case previous version left some garbage in zk
+sudo cat /etc/clickhouse-server/config.d/lost_forever_check.xml \
+  | sed "s|>1<|>0<|g" \
+  > /etc/clickhouse-server/config.d/lost_forever_check.xml.tmp
+sudo mv /etc/clickhouse-server/config.d/lost_forever_check.xml.tmp /etc/clickhouse-server/config.d/lost_forever_check.xml
+
 start 500
 clickhouse-client --query "SELECT 'Server successfully started', 'OK', NULL, ''" >> /test_output/test_results.tsv \
     || (rg --text "<Error>.*Application" /var/log/clickhouse-server/clickhouse-server.log > /test_output/application_errors.txt \

--- a/tests/config/config.d/lost_forever_check.xml
+++ b/tests/config/config.d/lost_forever_check.xml
@@ -1,0 +1,4 @@
+<clickhouse>
+    <replicated_merge_tree_paranoid_check_on_drop_range>1</replicated_merge_tree_paranoid_check_on_drop_range>
+    <replicated_merge_tree_paranoid_check_on_startup>1</replicated_merge_tree_paranoid_check_on_startup>
+</clickhouse>

--- a/tests/config/config.d/merge_tree.xml
+++ b/tests/config/config.d/merge_tree.xml
@@ -5,6 +5,4 @@
         <max_cleanup_delay_period>60</max_cleanup_delay_period>
         <cleanup_thread_preferred_points_per_iteration>10</cleanup_thread_preferred_points_per_iteration>
     </merge_tree>
-
-    <replicated_merge_tree_paranoid_check_on_drop_range>1</replicated_merge_tree_paranoid_check_on_drop_range>
 </clickhouse>

--- a/tests/config/install.sh
+++ b/tests/config/install.sh
@@ -33,6 +33,7 @@ ln -sf $SRC_PATH/config.d/test_cluster_with_incorrect_pw.xml $DEST_SERVER_PATH/c
 ln -sf $SRC_PATH/config.d/keeper_port.xml $DEST_SERVER_PATH/config.d/
 ln -sf $SRC_PATH/config.d/logging_no_rotate.xml $DEST_SERVER_PATH/config.d/
 ln -sf $SRC_PATH/config.d/merge_tree.xml $DEST_SERVER_PATH/config.d/
+ln -sf $SRC_PATH/config.d/lost_forever_check.xml $DEST_SERVER_PATH/config.d/
 ln -sf $SRC_PATH/config.d/metadata_cache.xml $DEST_SERVER_PATH/config.d/
 ln -sf $SRC_PATH/config.d/tcp_with_proxy.xml $DEST_SERVER_PATH/config.d/
 ln -sf $SRC_PATH/config.d/prometheus.xml $DEST_SERVER_PATH/config.d/


### PR DESCRIPTION

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Suppress https://github.com/ClickHouse/ClickHouse/issues/51182 (maybe we should deprecate the "metadata cache" feature)