### PR TITLE
Drop session if we fail to get Keeper API version 

### DIFF
--- a/src/Common/ZooKeeper/ZooKeeperImpl.cpp
+++ b/src/Common/ZooKeeper/ZooKeeperImpl.cpp
@@ -1107,16 +1107,19 @@ void ZooKeeper::initApiVersion()
     get(keeper_api_version_path, std::move(callback), {});
     if (future.wait_for(std::chrono::milliseconds(args.operation_timeout_ms)) != std::future_status::ready)
     {
-        LOG_TRACE(log, "Failed to get API version: timeout");
-        return;
+        throw Exception(Error::ZOPERATIONTIMEOUT, "Failed to get API version: timeout");
     }
 
     auto response = future.get();
 
-    if (response.error != Coordination::Error::ZOK)
+    if (response.error == Coordination::Error::ZNONODE)
     {
-        LOG_TRACE(log, "Failed to get API version");
+        LOG_TRACE(log, "API version not found, assuming {}", keeper_api_version);
         return;
+    }
+    else if (response.error != Coordination::Error::ZOK)
+    {
+        throw Exception(response.error, "Failed to get API version");
     }
 
     uint8_t keeper_version{0};


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Fall back to old API version only if the version node doesn't exist. 