### PR TITLE
Fix sometimes incorrect current_elements count in fs cache

### DIFF
--- a/src/Interpreters/Cache/IFileCachePriority.h
+++ b/src/Interpreters/Cache/IFileCachePriority.h
@@ -50,7 +50,7 @@ public:
 
         virtual Entry & getEntry() = 0;
 
-        virtual void annul() = 0;
+        virtual void invalidate() = 0;
 
         virtual void updateSize(int64_t size) = 0;
     };

--- a/src/Interpreters/Cache/LRUFileCachePriority.cpp
+++ b/src/Interpreters/Cache/LRUFileCachePriority.cpp
@@ -80,7 +80,7 @@ void LRUFileCachePriority::pop(const CacheGuard::Lock &)
 
 LRUFileCachePriority::LRUQueueIterator LRUFileCachePriority::remove(LRUQueueIterator it)
 {
-    /// If size is 0, entry is annuled, current_elements_num was already updated.
+    /// If size is 0, entry is annulled, current_elements_num was already updated.
     if (it->size)
     {
         current_size -= it->size;

--- a/src/Interpreters/Cache/LRUFileCachePriority.cpp
+++ b/src/Interpreters/Cache/LRUFileCachePriority.cpp
@@ -30,7 +30,7 @@ IFileCachePriority::Iterator LRUFileCachePriority::add(
         throw Exception(
             ErrorCodes::LOGICAL_ERROR,
             "Adding zero size entries to LRU queue is not allowed "
-            "(Key: {}, offset: {}", key, offset);
+            "(Key: {}, offset: {})", key, offset);
     }
 
 #ifndef NDEBUG

--- a/src/Interpreters/Cache/LRUFileCachePriority.h
+++ b/src/Interpreters/Cache/LRUFileCachePriority.h
@@ -22,7 +22,7 @@ public:
 
     size_t getSize(const CacheGuard::Lock &) const override { return current_size; }
 
-    size_t getElementsCount(const CacheGuard::Lock &) const override { return queue.size(); }
+    size_t getElementsCount(const CacheGuard::Lock &) const override { return current_elements_num; }
 
     Iterator add(KeyMetadataPtr key_metadata, size_t offset, size_t size, const CacheGuard::Lock &) override;
 
@@ -37,6 +37,7 @@ private:
     Poco::Logger * log = &Poco::Logger::get("LRUFileCachePriority");
 
     std::atomic<size_t> current_size = 0;
+    std::atomic<size_t> current_elements_num = 0;
 
     LRUQueueIterator remove(LRUQueueIterator it);
 };

--- a/src/Interpreters/Cache/LRUFileCachePriority.h
+++ b/src/Interpreters/Cache/LRUFileCachePriority.h
@@ -33,6 +33,9 @@ public:
     void iterate(IterateFunc && func, const CacheGuard::Lock &) override;
 
 private:
+    void updateElementsCount(int64_t num);
+    void updateSize(int64_t size);
+
     LRUQueue queue;
     Poco::Logger * log = &Poco::Logger::get("LRUFileCachePriority");
 

--- a/src/Interpreters/Cache/LRUFileCachePriority.h
+++ b/src/Interpreters/Cache/LRUFileCachePriority.h
@@ -37,6 +37,8 @@ private:
     Poco::Logger * log = &Poco::Logger::get("LRUFileCachePriority");
 
     std::atomic<size_t> current_size = 0;
+    /// current_elements_num is not always equal to queue.size()
+    /// because of invalidated entries.
     std::atomic<size_t> current_elements_num = 0;
 
     LRUQueueIterator remove(LRUQueueIterator it);
@@ -57,7 +59,7 @@ public:
 
     Iterator remove(const CacheGuard::Lock &) override;
 
-    void annul() override;
+    void invalidate() override;
 
     void updateSize(int64_t size) override;
 

--- a/src/Interpreters/Cache/Metadata.cpp
+++ b/src/Interpreters/Cache/Metadata.cpp
@@ -402,7 +402,7 @@ KeyMetadata::iterator LockedKey::removeFileSegment(size_t offset, const FileSegm
     chassert(file_segment->assertCorrectnessUnlocked(segment_lock));
 
     if (file_segment->queue_iterator)
-        file_segment->queue_iterator->annul();
+        file_segment->queue_iterator->invalidate();
 
     const auto path = key_metadata->getFileSegmentPath(*file_segment);
     bool exists = fs::exists(path);


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix sometimes not correct current_elements_num in fs cache.