### PR TITLE
Avoid too many calls to Poco::Logger::get

### DIFF
--- a/src/Interpreters/Cache/Metadata.cpp
+++ b/src/Interpreters/Cache/Metadata.cpp
@@ -53,15 +53,16 @@ KeyMetadata::KeyMetadata(
     const Key & key_,
     const std::string & key_path_,
     CleanupQueue & cleanup_queue_,
+    [[maybe_unused]] Poco::Logger * log_,
     bool created_base_directory_)
     : key(key_)
     , key_path(key_path_)
     , cleanup_queue(cleanup_queue_)
     , created_base_directory(created_base_directory_)
 #ifdef ABORT_ON_LOGICAL_ERROR
-    , log(&Poco::Logger::get("LockedKey(" + key.toString() + ")"))
+    , log(&Poco::Logger::get("Key(" + key.toString() + ")"))
 #else
-    , log(&Poco::Logger::get("LockedKey"))
+    , log(log_)
 #endif
 {
     if (created_base_directory)
@@ -195,7 +196,7 @@ LockedKeyPtr CacheMetadata::lockKeyMetadata(
 
             it = emplace(
                 key, std::make_shared<KeyMetadata>(
-                    key, getPathForKey(key), *cleanup_queue, is_initial_load)).first;
+                    key, getPathForKey(key), *cleanup_queue, log, is_initial_load)).first;
         }
 
         key_metadata = it->second;

--- a/src/Interpreters/Cache/Metadata.cpp
+++ b/src/Interpreters/Cache/Metadata.cpp
@@ -53,17 +53,13 @@ KeyMetadata::KeyMetadata(
     const Key & key_,
     const std::string & key_path_,
     CleanupQueue & cleanup_queue_,
-    [[maybe_unused]] Poco::Logger * log_,
+    Poco::Logger * log_,
     bool created_base_directory_)
     : key(key_)
     , key_path(key_path_)
     , cleanup_queue(cleanup_queue_)
     , created_base_directory(created_base_directory_)
-#ifdef ABORT_ON_LOGICAL_ERROR
-    , log(&Poco::Logger::get("Key(" + key.toString() + ")"))
-#else
     , log(log_)
-#endif
 {
     if (created_base_directory)
         chassert(fs::exists(key_path));

--- a/src/Interpreters/Cache/Metadata.h
+++ b/src/Interpreters/Cache/Metadata.h
@@ -70,6 +70,7 @@ private:
     KeyGuard guard;
     CleanupQueue & cleanup_queue;
     std::atomic<bool> created_base_directory = false;
+    Poco::Logger * log;
 };
 
 using KeyMetadataPtr = std::shared_ptr<KeyMetadata>;
@@ -171,7 +172,6 @@ struct LockedKey : private boost::noncopyable
 private:
     const std::shared_ptr<KeyMetadata> key_metadata;
     KeyGuard::Lock lock; /// `lock` must be destructed before `key_metadata`.
-    Poco::Logger * log;
 };
 
 }

--- a/src/Interpreters/Cache/Metadata.h
+++ b/src/Interpreters/Cache/Metadata.h
@@ -44,6 +44,7 @@ struct KeyMetadata : public std::map<size_t, FileSegmentMetadataPtr>,
         const Key & key_,
         const std::string & key_path_,
         CleanupQueue & cleanup_queue_,
+        Poco::Logger * log_,
         bool created_base_directory_ = false);
 
     enum class KeyState


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


