### PR TITLE
Disable table structure check for secondary queries from Replicated db

### DIFF
--- a/src/Databases/DatabaseReplicated.cpp
+++ b/src/Databases/DatabaseReplicated.cpp
@@ -985,7 +985,7 @@ void DatabaseReplicated::recoverLostReplica(const ZooKeeperPtr & current_zookeep
         const auto & create_query_string = metadata_it->second;
         if (isTableExist(table_name, getContext()))
         {
-            assert(create_query_string == readMetadataFile(table_name));
+            assert(create_query_string == readMetadataFile(table_name) || getTableUUIDIfReplicated(create_query_string, getContext()) != UUIDHelpers::Nil);
             continue;
         }
 
@@ -1274,7 +1274,7 @@ void DatabaseReplicated::commitAlterTable(const StorageID & table_id,
                                           const String & statement, ContextPtr query_context)
 {
     auto txn = query_context->getZooKeeperMetadataTransaction();
-    assert(!ddl_worker->isCurrentlyActive() || txn);
+    assert(!ddl_worker || !ddl_worker->isCurrentlyActive() || txn);
     if (txn && txn->isInitialQuery())
     {
         String metadata_zk_path = zookeeper_path + "/metadata/" + escapeForFileName(table_id.table_name);

--- a/src/Databases/DatabaseReplicatedWorker.cpp
+++ b/src/Databases/DatabaseReplicatedWorker.cpp
@@ -91,6 +91,7 @@ void DatabaseReplicatedDDLWorker::initializeReplication()
     if (zookeeper->tryGet(database->replica_path + "/digest", digest_str))
     {
         digest = parse<UInt64>(digest_str);
+        LOG_TRACE(log, "Metadata digest in ZooKeeper: {}", digest);
         std::lock_guard lock{database->metadata_mutex};
         local_digest = database->tables_metadata_digest;
     }

--- a/src/Storages/MergeTree/registerStorageMergeTree.cpp
+++ b/src/Storages/MergeTree/registerStorageMergeTree.cpp
@@ -23,6 +23,7 @@
 #include <Interpreters/Context.h>
 #include <Interpreters/FunctionNameNormalizer.h>
 #include <Interpreters/evaluateConstantExpression.h>
+#include <Interpreters/DDLTask.h>
 
 
 namespace DB
@@ -684,6 +685,10 @@ static StoragePtr create(const StorageFactory::Arguments & args)
 
     if (replicated)
     {
+        bool need_check_table_structure = true;
+        if (auto txn = args.getLocalContext()->getZooKeeperMetadataTransaction())
+            need_check_table_structure = txn->isInitialQuery();
+
         return std::make_shared<StorageReplicatedMergeTree>(
             zookeeper_path,
             replica_name,
@@ -696,7 +701,8 @@ static StoragePtr create(const StorageFactory::Arguments & args)
             merging_params,
             std::move(storage_settings),
             args.has_force_restore_data_flag,
-            renaming_restrictions);
+            renaming_restrictions,
+            need_check_table_structure);
     }
     else
         return std::make_shared<StorageMergeTree>(

--- a/src/Storages/StorageReplicatedMergeTree.h
+++ b/src/Storages/StorageReplicatedMergeTree.h
@@ -108,7 +108,8 @@ public:
         const MergingParams & merging_params_,
         std::unique_ptr<MergeTreeSettings> settings_,
         bool has_force_restore_data_flag,
-        RenamingRestrictions renaming_restrictions_);
+        RenamingRestrictions renaming_restrictions_,
+        bool need_check_structure);
 
     void startup() override;
     void shutdown() override;
@@ -529,7 +530,7 @@ private:
       */
     void createNewZooKeeperNodes();
 
-    void checkTableStructure(const String & zookeeper_prefix, const StorageMetadataPtr & metadata_snapshot);
+    bool checkTableStructure(const String & zookeeper_prefix, const StorageMetadataPtr & metadata_snapshot, bool strict_check = true);
 
     /// A part of ALTER: apply metadata changes only (data parts are altered separately).
     /// Must be called under IStorage::lockForAlter() lock.

--- a/tests/integration/test_replicated_database/test.py
+++ b/tests/integration/test_replicated_database/test.py
@@ -1274,6 +1274,7 @@ def test_recover_digest_mismatch(started_cluster):
 
     print("Everything Okay")
 
+
 def test_replicated_table_structure_alter(started_cluster):
     main_node.query("DROP DATABASE IF EXISTS table_structure")
     dummy_node.query("DROP DATABASE IF EXISTS table_structure")
@@ -1292,13 +1293,20 @@ def test_replicated_table_structure_alter(started_cluster):
     dummy_node.query("DETACH DATABASE table_structure")
 
     settings = {"distributed_ddl_task_timeout": 0}
-    main_node.query("CREATE TABLE table_structure.rmt (n int, v UInt64) ENGINE=ReplicatedReplacingMergeTree(v) ORDER BY n", settings=settings)
+    main_node.query(
+        "CREATE TABLE table_structure.rmt (n int, v UInt64) ENGINE=ReplicatedReplacingMergeTree(v) ORDER BY n",
+        settings=settings,
+    )
 
     competing_node.query("SYSTEM SYNC DATABASE REPLICA table_structure")
     competing_node.query("DETACH DATABASE table_structure")
 
-    main_node.query("ALTER TABLE table_structure.rmt ADD COLUMN m int", settings=settings)
-    main_node.query("ALTER TABLE table_structure.rmt COMMENT COLUMN v 'version'", settings=settings)
+    main_node.query(
+        "ALTER TABLE table_structure.rmt ADD COLUMN m int", settings=settings
+    )
+    main_node.query(
+        "ALTER TABLE table_structure.rmt COMMENT COLUMN v 'version'", settings=settings
+    )
     main_node.query("INSERT INTO table_structure.rmt VALUES (1, 2, 3)")
 
     command = "rm -f /var/lib/clickhouse/metadata/table_structure/mem.sql"
@@ -1312,7 +1320,7 @@ def test_replicated_table_structure_alter(started_cluster):
 
     competing_node.query("SYSTEM SYNC DATABASE REPLICA table_structure")
     competing_node.query("SYSTEM SYNC REPLICA table_structure.rmt")
-    #time.sleep(600)
+    # time.sleep(600)
     assert "mem" in competing_node.query("SHOW TABLES FROM table_structure")
     assert "1\t2\t3\n" == competing_node.query("SELECT * FROM table_structure.rmt")
 
@@ -1320,4 +1328,6 @@ def test_replicated_table_structure_alter(started_cluster):
     main_node.query("INSERT INTO table_structure.rmt VALUES (1, 2, 3, 4)")
     dummy_node.query("SYSTEM SYNC DATABASE REPLICA table_structure")
     dummy_node.query("SYSTEM SYNC REPLICA table_structure.rmt")
-    assert "1\t2\t3\t0\n1\t2\t3\t4\n" == dummy_node.query("SELECT * FROM table_structure.rmt ORDER BY k")
+    assert "1\t2\t3\t0\n1\t2\t3\t4\n" == dummy_node.query(
+        "SELECT * FROM table_structure.rmt ORDER BY k"
+    )

--- a/tests/integration/test_replicated_database/test.py
+++ b/tests/integration/test_replicated_database/test.py
@@ -34,6 +34,7 @@ competing_node = cluster.add_instance(
     main_configs=["configs/config.xml"],
     user_configs=["configs/settings.xml"],
     with_zookeeper=True,
+    stay_alive=True,
     macros={"shard": 1, "replica": 3},
 )
 snapshotting_node = cluster.add_instance(
@@ -1272,3 +1273,51 @@ def test_recover_digest_mismatch(started_cluster):
     dummy_node.query("DROP DATABASE IF EXISTS recover_digest_mismatch")
 
     print("Everything Okay")
+
+def test_replicated_table_structure_alter(started_cluster):
+    main_node.query("DROP DATABASE IF EXISTS table_structure")
+    dummy_node.query("DROP DATABASE IF EXISTS table_structure")
+
+    main_node.query(
+        "CREATE DATABASE table_structure ENGINE = Replicated('/clickhouse/databases/table_structure', 'shard1', 'replica1');"
+    )
+    dummy_node.query(
+        "CREATE DATABASE table_structure ENGINE = Replicated('/clickhouse/databases/table_structure', 'shard1', 'replica2');"
+    )
+    competing_node.query(
+        "CREATE DATABASE table_structure ENGINE = Replicated('/clickhouse/databases/table_structure', 'shard1', 'replica3');"
+    )
+
+    competing_node.query("CREATE TABLE table_structure.mem (n int) ENGINE=Memory")
+    dummy_node.query("DETACH DATABASE table_structure")
+
+    settings = {"distributed_ddl_task_timeout": 0}
+    main_node.query("CREATE TABLE table_structure.rmt (n int, v UInt64) ENGINE=ReplicatedReplacingMergeTree(v) ORDER BY n", settings=settings)
+
+    competing_node.query("SYSTEM SYNC DATABASE REPLICA table_structure")
+    competing_node.query("DETACH DATABASE table_structure")
+
+    main_node.query("ALTER TABLE table_structure.rmt ADD COLUMN m int", settings=settings)
+    main_node.query("ALTER TABLE table_structure.rmt COMMENT COLUMN v 'version'", settings=settings)
+    main_node.query("INSERT INTO table_structure.rmt VALUES (1, 2, 3)")
+
+    command = "rm -f /var/lib/clickhouse/metadata/table_structure/mem.sql"
+    competing_node.exec_in_container(["bash", "-c", command])
+    competing_node.restart_clickhouse(kill=True)
+
+    dummy_node.query("ATTACH DATABASE table_structure")
+    dummy_node.query("SYSTEM SYNC DATABASE REPLICA table_structure")
+    dummy_node.query("SYSTEM SYNC REPLICA table_structure.rmt")
+    assert "1\t2\t3\n" == dummy_node.query("SELECT * FROM table_structure.rmt")
+
+    competing_node.query("SYSTEM SYNC DATABASE REPLICA table_structure")
+    competing_node.query("SYSTEM SYNC REPLICA table_structure.rmt")
+    #time.sleep(600)
+    assert "mem" in competing_node.query("SHOW TABLES FROM table_structure")
+    assert "1\t2\t3\n" == competing_node.query("SELECT * FROM table_structure.rmt")
+
+    main_node.query("ALTER TABLE table_structure.rmt ADD COLUMN k int")
+    main_node.query("INSERT INTO table_structure.rmt VALUES (1, 2, 3, 4)")
+    dummy_node.query("SYSTEM SYNC DATABASE REPLICA table_structure")
+    dummy_node.query("SYSTEM SYNC REPLICA table_structure.rmt")
+    assert "1\t2\t3\t0\n1\t2\t3\t4\n" == dummy_node.query("SELECT * FROM table_structure.rmt ORDER BY k")


### PR DESCRIPTION

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)



