### PR TITLE
Define Thrift version for parquet and use correct arrow version

### DIFF
--- a/contrib/arrow-cmake/CMakeLists.txt
+++ b/contrib/arrow-cmake/CMakeLists.txt
@@ -31,12 +31,12 @@ endif()
 
 set (CMAKE_CXX_STANDARD 17)
 
-set(ARROW_VERSION "6.0.1")
+set(ARROW_VERSION "11.0.0")
 string(REGEX MATCH "^[0-9]+\\.[0-9]+\\.[0-9]+" ARROW_BASE_VERSION "${ARROW_VERSION}")
 
-set(ARROW_VERSION_MAJOR "6")
+set(ARROW_VERSION_MAJOR "11")
 set(ARROW_VERSION_MINOR "0")
-set(ARROW_VERSION_PATCH "1")
+set(ARROW_VERSION_PATCH "0")
 
 if(ARROW_VERSION_MAJOR STREQUAL "0")
     # Arrow 0.x.y => SO version is "x", full SO version is "x.y.0"

--- a/contrib/arrow-cmake/CMakeLists.txt
+++ b/contrib/arrow-cmake/CMakeLists.txt
@@ -514,6 +514,10 @@ if (SANITIZE STREQUAL "undefined")
     target_compile_options(_arrow PRIVATE -fno-sanitize=undefined)
 endif ()
 
+# Define Thrift version for parquet (we use 0.16.0)
+add_definitions(-DPARQUET_THRIFT_VERSION_MAJOR=0)
+add_definitions(-DPARQUET_THRIFT_VERSION_MINOR=16)
+
 # === tools
 
 set(TOOLS_DIR "${ClickHouse_SOURCE_DIR}/contrib/arrow/cpp/tools/parquet")


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

It can fix possible errors like `MaxMessageSize`. See https://github.com/ClickHouse/arrow/blob/1f1b3d35fb6eb73e6492d3afd8a85cde848d174f/cpp/src/parquet/thrift_internal.h#L403-L415