### PR TITLE
Make SQLancer check not "always green"

### DIFF
--- a/tests/ci/sqlancer_check.py
+++ b/tests/ci/sqlancer_check.py
@@ -153,10 +153,10 @@ def main():
     test_results = []  # type: TestResults
     # Try to get status message saved by the SQLancer
     try:
-        # with open(
-        #     os.path.join(workspace_path, "status.txt"), "r", encoding="utf-8"
-        # ) as status_f:
-        #     status = status_f.readline().rstrip("\n")
+        with open(
+            os.path.join(workspace_path, "status.txt"), "r", encoding="utf-8"
+        ) as status_f:
+            status = status_f.readline().rstrip("\n")
         if os.path.exists(os.path.join(workspace_path, "server_crashed.log")):
             test_results.append(TestResult("Server crashed", "FAIL"))
         with open(
@@ -171,7 +171,7 @@ def main():
         ) as desc_f:
             description = desc_f.readline().rstrip("\n")
     except:
-        # status = "failure"
+        status = "failure"
         description = "Task failed: $?=" + str(retcode)
 
     description = format_description(description)


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

[SQLancer](https://github.com/sqlancer/sqlancer) check is considered stable as bugs that were triggered by it are fixed. Now failures of SQLancer check will be reported as failed check status.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
