### PR TITLE
Fix performance tests due to warnings from jemalloc about Per-CPU arena disabled

### DIFF
--- a/docker/test/performance-comparison/compare.sh
+++ b/docker/test/performance-comparison/compare.sh
@@ -14,6 +14,13 @@ LEFT_SERVER_PORT=9001
 # patched version
 RIGHT_SERVER_PORT=9002
 
+# abort_conf   -- abort if some options is not recognized
+# abort        -- abort if something is not right in the env (i.e. per-cpu arenas does not work)
+# narenas      -- set them explicitly to avoid disabling per-cpu arena in env
+#                 that returns different number of CPUs for some of the following
+#                 _SC_NPROCESSORS_ONLN/_SC_NPROCESSORS_CONF/sched_getaffinity
+export MALLOC_CONF="abort_conf:true,abort:true,narenas:$(nproc --all)"
+
 function wait_for_server # port, pid
 {
     for _ in {1..60}
@@ -109,10 +116,6 @@ function restart
     while pkill -f clickhouse-serv ; do echo . ; sleep 1 ; done
     echo all killed
 
-    # Change the jemalloc settings here.
-    # https://github.com/jemalloc/jemalloc/wiki/Getting-Started
-    export MALLOC_CONF="confirm_conf:true"
-
     set -m # Spawn servers in their own process groups
 
     local left_server_opts=(
@@ -146,8 +149,6 @@ function restart
     disown $right_pid
 
     set +m
-
-    unset MALLOC_CONF
 
     wait_for_server $LEFT_SERVER_PORT $left_pid
     echo left ok


### PR DESCRIPTION
jemalloc can show the following warning:

    Number of CPUs detected is not deterministic. Per-CPU arena disabled

It will be shown if one of the following returns different number of CPUs:
- _SC_NPROCESSORS_ONLN
- _SC_NPROCESSORS_CONF
- sched_getaffinity()

And actually for my CPU linux returns different numbers, because there are more possible CPUs then online, from dmesg:

    smpboot: Allowing 128 CPUs, 64 hotplug CPUs

And from sysfs:

    # grep . /sys/devices/system/cpu/{possible,online,offline}
    /sys/devices/system/cpu/possible:0-127
    /sys/devices/system/cpu/online:0-63
    /sys/devices/system/cpu/offline:64-127

From ACPI:

    # acpidump -o acpi
    # acpixtract -a acpi
    # iasl -d *.dat
    # grep -e 'Processor Enabled' apic.dsl | sort | uniq -c
        64                            Processor Enabled : 0
        64                            Processor Enabled : 1

So I guess this is the same as what happened in this perf run [1].

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/51360/5d43a64112711b339b82b1c0e8df7882546a1a3c/performance_comparison_[4_4]/report.html

P.S. personally I, just use cmdline=possible_cpus=64 to fix this for my setup.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)