### PR TITLE
Increase timeout of Fast Test

### DIFF
--- a/tests/ci/fast_test_check.py
+++ b/tests/ci/fast_test_check.py
@@ -150,7 +150,7 @@ def main():
         os.makedirs(logs_path)
 
     run_log_path = os.path.join(logs_path, "run.log")
-    with TeePopen(run_cmd, run_log_path, timeout = 90 * 60) as process:
+    with TeePopen(run_cmd, run_log_path, timeout=90 * 60) as process:
         retcode = process.wait()
         if retcode == 0:
             logging.info("Run successfully")


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


See https://s3.amazonaws.com/clickhouse-test-reports/51368/d84a4626b03ce9aa6d0a3c562ed30dc65670e5cb/fast_test/run.log