### PR TITLE
Fixes `Join data was released` in `grace_hash` join algorithm

### DIFF
--- a/tests/ci/stress.py
+++ b/tests/ci/stress.py
@@ -38,6 +38,9 @@ def get_options(i, upgrade_check):
             client_options.append("join_algorithm='partial_merge'")
         if join_alg_num % 5 == 2:
             client_options.append("join_algorithm='full_sorting_merge'")
+        if join_alg_num % 5 == 3 and not upgrade_check:
+            # Some crashes are not fixed in 23.2 yet, so ignore the setting in Upgrade check
+            client_options.append("join_algorithm='grace_hash'")
         if join_alg_num % 5 == 4:
             client_options.append("join_algorithm='auto'")
             client_options.append("max_rows_in_join=1000")

--- a/tests/queries/0_stateless/02275_full_sort_join_long.sql.j2
+++ b/tests/queries/0_stateless/02275_full_sort_join_long.sql.j2
@@ -30,7 +30,7 @@ SELECT 'skipped';
 
 {% for join_algorithm in ['full_sorting_merge', 'grace_hash'] -%}
 
-SET max_bytes_in_join = '{% if join_algorithm == 'grace_hash' %}1M{% else %}0{% endif %}';
+SET max_bytes_in_join = '{% if join_algorithm == 'grace_hash' %}16M{% else %}0{% endif %}';
 
 SELECT '-- {{ join_algorithm }} --';
 SET join_algorithm = '{{ join_algorithm }}';


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement



### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Issue #50220 reports a core in `grace_hash` join. We finally reproduce the exception on local, and found that the issue is related to the failure of creating temporary file. Somehow this is triggered in https://github.com/ClickHouse/ClickHouse/pull/49816 https://github.com/ClickHouse/ClickHouse/pull/49483. 

```
2023.06.25 09:36:04.935602 [ 9318 ] {8df8fbde-0a53-46b8-85bf-2810c4c30935} <Error> TCPHandler: Code: 241. DB::Exception: Memory tracker (for query): fault injected. Would use 108.38 MiB (attempt to allocate chunk of 1048927 bytes), maximum: 9.31 GiB: While executing DelayedJoinedBlocksTransform. (MEMORY_LIMIT_EXCEEDED), Stack trace (when copying this message, always include the lines below):

0. std::exception::capture() @ 0x000000002af43e55 in /usr/bin/clickhouse
1. ./build_docker/./base/poco/Foundation/src/Exception.cpp:28: Poco::Exception::Exception(String const&, int) @ 0x0000000048a8d485 in /usr/bin/clickhouse
2. ./build_docker/./src/Common/Exception.cpp:92: DB::Exception::Exception(DB::Exception::MessageMasked&&, int, bool) @ 0x00000000375cea0b in /usr/bin/clickhouse
3. ./build_docker/./contrib/llvm-project/libcxx/include/string:1499: DB::Exception::Exception<char const*, char const*, String, long&, String>(int, FormatStringHelperImpl<std::type_identity<char const*>::type, std::type_identity<char const*>::type, std::type_identity<String>::type, std::type_identity<long&>::type, std::type_identity<String>::type>, char const*&&, char const*&&, String&&, long&, String&&) @ 0x00000000375e159a in /usr/bin/clickhouse
4. ./build_docker/./src/Common/MemoryTracker.cpp:0: MemoryTracker::allocImpl(long, bool, MemoryTracker*) @ 0x00000000375e04b3 in /usr/bin/clickhouse
5. ./build_docker/./src/Common/MemoryTracker.cpp:369: MemoryTracker::allocImpl(long, bool, MemoryTracker*) @ 0x00000000375e0016 in /usr/bin/clickhouse
6. ./build_docker/./src/Common/CurrentMemoryTracker.cpp:59: CurrentMemoryTracker::allocImpl(long, bool) @ 0x00000000375818d4 in /usr/bin/clickhouse
7. ./build_docker/./src/Common/Allocator.h:103: DB::Memory<Allocator<false, false>>::alloc(unsigned long) @ 0x000000003763ca3c in /usr/bin/clickhouse
8. ./build_docker/./src/IO/BufferWithOwnMemory.h:159: DB::BufferWithOwnMemory<DB::WriteBuffer>::BufferWithOwnMemory(unsigned long, char*, unsigned long) @ 0x000000003763c814 in /usr/bin/clickhouse
9. ./build_docker/./src/Compression/CompressedWriteBuffer.cpp:67: DB::CompressedWriteBuffer::CompressedWriteBuffer(DB::WriteBuffer&, std::shared_ptr<DB::ICompressionCodec>, unsigned long) @ 0x0000000043b6b3f7 in /usr/bin/clickhouse
10. ./build_docker/./src/Interpreters/TemporaryDataOnDisk.cpp:150: DB::TemporaryFileStream::OutputWriter::OutputWriter(std::unique_ptr<DB::WriteBuffer, std::default_delete<DB::WriteBuffer>>, DB::Block const&) @ 0x0000000045875cdb in /usr/bin/clickhouse
11. ./build_docker/./contrib/llvm-project/libcxx/include/__memory/unique_ptr.h:0: DB::TemporaryFileStream::TemporaryFileStream(std::unique_ptr<DB::TemporaryFileOnDisk, std::default_delete<DB::TemporaryFileOnDisk>>, DB::Block const&, DB::TemporaryDataOnDisk*) @ 0x00000000458714f7 in /usr/bin/clickhouse
12. ./build_docker/./src/Interpreters/TemporaryDataOnDisk.cpp:89: DB::TemporaryDataOnDisk::createStream(DB::Block const&, unsigned long) @ 0x0000000045870fe3 in /usr/bin/clickhouse
13. ./build_docker/./src/Interpreters/GraceHashJoin.cpp:395: DB::GraceHashJoin::addBucket(std::vector<std::shared_ptr<DB::GraceHashJoin::FileBucket>, std::allocator<std::shared_ptr<DB::GraceHashJoin::FileBucket>>>&) @ 0x0000000044977a7a in /usr/bin/clickhouse
14. ./build_docker/./src/Interpreters/GraceHashJoin.cpp:384: DB::GraceHashJoin::rehashBuckets(unsigned long) @ 0x000000004497df12 in /usr/bin/clickhouse
15. ./build_docker/./contrib/llvm-project/libcxx/include/vector:951: DB::GraceHashJoin::addJoinedBlockImpl(DB::Block) @ 0x000000004497a038 in /usr/bin/clickhouse
16. ./build_docker/./src/Interpreters/GraceHashJoin.cpp:0: DB::GraceHashJoin::getDelayedBlocks() @ 0x0000000044981d7a in /usr/bin/clickhouse
17. ./build_docker/./src/Processors/Transforms/JoiningTransform.cpp:468: DB::DelayedJoinedBlocksTransform::work() @ 0x0000000047718fe0 in /usr/bin/clickhouse
18. ./build_docker/./src/Processors/Executors/ExecutionThreadContext.cpp:50: DB::ExecutionThreadContext::executeTask() @ 0x00000000471f67b0 in /usr/bin/clickhouse
19. ./build_docker/./src/Processors/Executors/PipelineExecutor.cpp:255: DB::PipelineExecutor::executeStepImpl(unsigned long, std::atomic<bool>*) @ 0x00000000471e5a1b in /usr/bin/clickhouse
20. ./build_docker/./contrib/llvm-project/libcxx/include/__memory/shared_ptr.h:833: void std::__function::__policy_invoker<void ()>::__call_impl<std::__function::__default_alloc_func<DB::PipelineExecutor::spawnThreads()::$_0, void ()>>(std::__function::__policy_storage const*) @ 0x00000000471e76e5 in /usr/bin/clickhouse
21. ./build_docker/./base/base/../base/wide_integer_impl.h:796: ThreadPoolImpl<ThreadFromGlobalPoolImpl<false>>::worker(std::__list_iterator<ThreadFromGlobalPoolImpl<false>, void*>) @ 0x000000003771db60 in /usr/bin/clickhouse
22. ./build_docker/./src/Common/ThreadPool.cpp:0: ThreadFromGlobalPoolImpl<false>::ThreadFromGlobalPoolImpl<void ThreadPoolImpl<ThreadFromGlobalPoolImpl<false>>::scheduleImpl<void>(std::function<void ()>, Priority, std::optional<unsigned long>, bool)::'lambda0'()>(void&&)::'lambda'()::operator()() @ 0x0000000037722faf in /usr/bin/clickhouse
23. ./build_docker/./base/base/../base/wide_integer_impl.h:796: ThreadPoolImpl<std::thread>::worker(std::__list_iterator<std::thread, void*>) @ 0x000000003771aa20 in /usr/bin/clickhouse
24. ./build_docker/./contrib/llvm-project/libcxx/include/__memory/unique_ptr.h:302: void* std::__thread_proxy[abi:v15000]<std::tuple<std::unique_ptr<std::__thread_struct, std::default_delete<std::__thread_struct>>, void ThreadPoolImpl<std::thread>::scheduleImpl<void>(std::function<void ()>, Priority, std::optional<unsigned long>, bool)::'lambda0'()>>(void*) @ 0x000000003771ffea in /usr/bin/clickhouse
25. ? @ 0x00007f6939eb7609 in ?
26. __clone @ 0x00007f6939ddc133 in ?
```

When the exception happen, all the threads of the query process are not stopped immediately at the same time, there is still a thread trying to use the `hash_join` which has been released in the the thread with exceptions. So the core happens.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
