### PR TITLE
Fix 00899_long_attach_memory_limit

### DIFF
--- a/tests/queries/0_stateless/00899_long_attach_memory_limit.sql
+++ b/tests/queries/0_stateless/00899_long_attach_memory_limit.sql
@@ -1,4 +1,5 @@
--- Tags: long, no-debug, no-parallel, no-fasttest
+-- Tags: long, no-debug, no-parallel, no-fasttest, no-msan, no-tsan
+-- This test is slow under MSan or TSan.
 
 DROP TABLE IF EXISTS index_memory;
 CREATE TABLE index_memory (x UInt64) ENGINE = MergeTree ORDER BY x SETTINGS index_granularity = 1;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


It was always long, see https://play.clickhouse.com/play?user=play#U0VMRUNUIGNoZWNrX3N0YXJ0X3RpbWUsIHRlc3RfZHVyYXRpb25fbXMsIGNoZWNrX25hbWUsIHRlc3RfbmFtZSwgcmVwb3J0X3VybApGUk9NIGNoZWNrcwpXSEVSRSBjaGVja19zdGFydF90aW1lID49IG5vdygpIC0gSU5URVJWQUwgMSBNT05USAogICAgQU5EIHB1bGxfcmVxdWVzdF9udW1iZXIgPSAwCiAgICBBTkQgdGVzdF9zdGF0dXMgIT0gJ1NLSVBQRUQnCiAgICBBTkQgcG9zaXRpb24odGVzdF9uYW1lLCAnMDA4OTlfbG9uZ19hdHRhY2hfbWVtb3J5X2xpbWl0JykgPiAwCiAgICBBTkQgdGVzdF9kdXJhdGlvbl9tcyA+IDEwMDAwMApPUkRFUiBCWSBjaGVja19zdGFydF90aW1l