### PR TITLE
Fix test 02497_trace_events_stress_long

### DIFF
--- a/tests/queries/0_stateless/02497_trace_events_stress_long.sh
+++ b/tests/queries/0_stateless/02497_trace_events_stress_long.sh
@@ -43,19 +43,21 @@ timeout $TIMEOUT bash -c thread2 >/dev/null &
 
 wait
 
-$CLICKHOUSE_CLIENT -q "KILL QUERY WHERE query_id LIKE '02497_$CLICKHOUSE_DATABASE%' SYNC" >/dev/null
-
-# After this moment, the server can still run another query.
-# For example, the 'timeout' command killed all threads of thread1,
-# and the 'timeout' itself has finished, and we have successfully 'wait'-ed for it,
-# but just before that, one of the threads successfully sent a query to the server,
-# but the server didn't start to run this query yet,
-# and even when the KILL QUERY was run, the query from the thread didn't start,
-# but only started after the KILL QUERY has been already processed.
-
-# That's why we have to run the next command in a loop.
-
 for _ in {1..10}
 do
+    $CLICKHOUSE_CLIENT -q "KILL QUERY WHERE query_id LIKE '02497_$CLICKHOUSE_DATABASE%' SYNC" >/dev/null
+
+    # After this moment, the server can still run another query.
+    # For example, the 'timeout' command killed all threads of thread1,
+    # and the 'timeout' itself has finished, and we have successfully 'wait'-ed for it,
+    # but just before that, one of the threads successfully sent a query to the server,
+    # but the server didn't start to run this query yet,
+    # and even when the KILL QUERY was run, the query from the thread didn't start,
+    # but only started after the KILL QUERY has been already processed.
+
+    # That's why we have to run this in a loop.
+
     $CLICKHOUSE_CLIENT -q "SELECT count() FROM system.processes WHERE query_id LIKE '02497_$CLICKHOUSE_DATABASE%'" | rg '^0$' && break
+
+    sleep 1
 done


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


See https://s3.amazonaws.com/clickhouse-test-reports/51374/8017ea79c173d2e14f76111fff97e0b1f84d934e/stateless_tests__release_.html