### PR TITLE
Fix broken labeling for `manual approve`

### DIFF
--- a/tests/ci/workflow_approve_rerun_lambda/app.py
+++ b/tests/ci/workflow_approve_rerun_lambda/app.py
@@ -224,8 +224,8 @@ def approve_run(workflow_description: WorkflowDescription, token: str) -> None:
 
 
 def label_manual_approve(pull_request, token):
-    url = f"{pull_request['url']}/labels"
-    data = {"labels": "manual approve"}
+    url = f"{pull_request['issue_url']}/labels"
+    data = {"labels": ["manual approve"]}
 
     _exec_post_with_retry(url, token, data)
 

--- a/tests/ci/workflow_approve_rerun_lambda/app.py
+++ b/tests/ci/workflow_approve_rerun_lambda/app.py
@@ -376,11 +376,10 @@ def main(event):
     changed_files = get_changed_files_for_pull_request(pull_request, token)
     print(f"Totally have {len(changed_files)} changed files in PR:", changed_files)
     if check_suspicious_changed_files(changed_files):
-        print(
-            f"Pull Request {pull_request['number']} has suspicious changes, "
-            "label it for manuall approve"
-        )
-        label_manual_approve(pull_request, token)
+        print(f"Pull Request {pull_request['number']} has suspicious changes")
+        if "manual approve" not in labels:
+            print("Label the PR as needed for manuall approve")
+            label_manual_approve(pull_request, token)
     else:
         print(f"Pull Request {pull_request['number']} has no suspicious changes")
         approve_run(workflow_description, token)


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
The method for labeling PR has had a wrong url. Now it uses https://api.github.com/repos/ClickHouse/ClickHouse/issues/51382/labels instead of https://api.github.com/repos/ClickHouse/ClickHouse/pulls/51382/labels