### PR TITLE
Fix parts lifetime in `MergeTreeTransaction`

### DIFF
--- a/src/Interpreters/MergeTreeTransaction.cpp
+++ b/src/Interpreters/MergeTreeTransaction.cpp
@@ -326,6 +326,8 @@ void MergeTreeTransaction::afterFinalize()
     is_read_only = storages.empty();
 
     /// Release shared pointers just in case
+    creating_parts.clear();
+    removing_parts.clear();
     storages.clear();
     mutations.clear();
     finalized = true;


### PR DESCRIPTION

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Fixes https://github.com/ClickHouse/ClickHouse/issues/51338 
