### PR TITLE
Runtime-reconfigurable cache sizes

### DIFF
--- a/docs/en/operations/server-configuration-parameters/settings.md
+++ b/docs/en/operations/server-configuration-parameters/settings.md
@@ -221,6 +221,10 @@ Default: 1024
 
 Size of cache for index marks. Zero means disabled.
 
+:::note
+This setting can be modified at runtime and will take effect immediately.
+:::
+
 Type: UInt64
 
 Default: 0
@@ -229,6 +233,10 @@ Default: 0
 ## index_uncompressed_cache_size
 
 Size of cache for uncompressed blocks of MergeTree indices. Zero means disabled.
+
+:::note
+This setting can be modified at runtime and will take effect immediately.
+:::
 
 Type: UInt64
 
@@ -254,6 +262,10 @@ Default: SLRU
 ## mark_cache_size
 
 Size of cache for marks (index of MergeTree family of tables).
+
+:::note
+This setting can be modified at runtime and will take effect immediately.
+:::
 
 Type: UInt64
 
@@ -288,7 +300,7 @@ Default: 1000
 Limit on total number of concurrently executed queries. Zero means Unlimited. Note that limits on insert and select queries, and on the maximum number of queries for users must also be considered.  See also max_concurrent_insert_queries, max_concurrent_select_queries, max_concurrent_queries_for_all_users. Zero means unlimited.
 
 :::note
-These settings can be modified at runtime and will take effect immediately. Queries that are already running will remain unchanged.
+This setting can be modified at runtime and will take effect immediately. Queries that are already running will remain unchanged.
 :::
 
 Type: UInt64
@@ -300,7 +312,7 @@ Default: 0
 Limit on total number of concurrent insert queries. Zero means Unlimited.
 
 :::note
-These settings can be modified at runtime and will take effect immediately. Queries that are already running will remain unchanged.
+This setting can be modified at runtime and will take effect immediately. Queries that are already running will remain unchanged.
 :::
 
 Type: UInt64
@@ -312,7 +324,7 @@ Default: 0
 Limit on total number of concurrently select queries. Zero means Unlimited.
 
 :::note
-These settings can be modified at runtime and will take effect immediately. Queries that are already running will remain unchanged.
+This setting can be modified at runtime and will take effect immediately. Queries that are already running will remain unchanged.
 :::
 
 Type: UInt64
@@ -455,6 +467,10 @@ Default: 10000
 Sets the cache size (in bytes) for mapped files. This setting allows avoiding frequent open/close calls (which are very expensive due to consequent page faults), and to reuse mappings from several threads and queries. The setting value is the number of mapped regions (usually equal to the number of mapped files). The amount of data in mapped files can be monitored in the tables system.metrics and system.metric_log with the `MMappedFiles` and `MMappedFileBytes` metrics.  Also, in system.asynchronous_metrics and system.asynchronous_metrics_log by the `MMapCacheCells` metric, and in system.events, system.processes, system.query_log, system.query_thread_log, system.query_views_log by the `CreatedReadBufferMMap`, `CreatedReadBufferMMapFailed`, `MMappedFileCacheHits`, `MMappedFileCacheMisses` events.
 
 Note that the amount of data in mapped files does not consume memory directly and is not accounted for in query or server memory usage — because this memory can be discarded similar to the OS page cache. The cache is dropped (the files are closed) automatically on the removal of old parts in tables of the MergeTree family, also it can be dropped manually by the `SYSTEM DROP MMAP CACHE` query.
+
+:::note
+This setting can be modified at runtime and will take effect immediately.
+:::
 
 Type: UInt64
 
@@ -604,6 +620,10 @@ Cache size (in bytes) for uncompressed data used by table engines from the Merge
 There is one shared cache for the server. Memory is allocated on demand. The cache is used if the option use_uncompressed_cache is enabled.
 
 The uncompressed cache is advantageous for very short queries in individual cases.
+
+:::note
+This setting can be modified at runtime and will take effect immediately.
+:::
 
 Type: UInt64
 

--- a/docs/en/sql-reference/statements/system.md
+++ b/docs/en/sql-reference/statements/system.md
@@ -66,13 +66,13 @@ RELOAD FUNCTION [ON CLUSTER cluster_name] function_name
 
 ## DROP DNS CACHE
 
-Resets ClickHouse’s internal DNS cache. Sometimes (for old ClickHouse versions) it is necessary to use this command when changing the infrastructure (changing the IP address of another ClickHouse server or the server used by dictionaries).
+Clears ClickHouse’s internal DNS cache. Sometimes (for old ClickHouse versions) it is necessary to use this command when changing the infrastructure (changing the IP address of another ClickHouse server or the server used by dictionaries).
 
 For more convenient (automatic) cache management, see disable_internal_dns_cache, dns_cache_update_period parameters.
 
 ## DROP MARK CACHE
 
-Resets the mark cache.
+Clears the mark cache.
 
 ## DROP REPLICA
 
@@ -106,22 +106,18 @@ Similar to `SYSTEM DROP REPLICA`, but removes the `Replicated` database replica 
 
 ## DROP UNCOMPRESSED CACHE
 
-Reset the uncompressed data cache.
+Clears the uncompressed data cache.
 The uncompressed data cache is enabled/disabled with the query/user/profile-level setting [use_uncompressed_cache](../../operations/settings/settings.md#setting-use_uncompressed_cache).
 Its size can be configured using the server-level setting [uncompressed_cache_size](../../operations/server-configuration-parameters/settings.md#server-settings-uncompressed_cache_size).
 
 ## DROP COMPILED EXPRESSION CACHE
 
-Reset the compiled expression cache.
+Clears the compiled expression cache.
 The compiled expression cache is enabled/disabled with the query/user/profile-level setting [compile_expressions](../../operations/settings/settings.md#compile-expressions).
 
 ## DROP QUERY CACHE
 
-Resets the [query cache](../../operations/query-cache.md).
-
-```sql
-SYSTEM DROP QUERY CACHE [ON CLUSTER cluster_name]
-```
+Clears the [query cache](../../operations/query-cache.md).
 
 ## FLUSH LOGS
 

--- a/programs/local/LocalServer.cpp
+++ b/programs/local/LocalServer.cpp
@@ -668,8 +668,7 @@ void LocalServer::processConfig()
         uncompressed_cache_size = max_cache_size;
         LOG_INFO(log, "Lowered uncompressed cache size to {} because the system has limited RAM", formatReadableSizeWithBinarySuffix(uncompressed_cache_size));
     }
-    if (uncompressed_cache_size)
-        global_context->setUncompressedCache(uncompressed_cache_policy, uncompressed_cache_size);
+    global_context->setUncompressedCache(uncompressed_cache_policy, uncompressed_cache_size);
 
     String mark_cache_policy = config().getString("mark_cache_policy", DEFAULT_MARK_CACHE_POLICY);
     size_t mark_cache_size = config().getUInt64("mark_cache_size", DEFAULT_MARK_CACHE_MAX_SIZE);
@@ -680,8 +679,7 @@ void LocalServer::processConfig()
         mark_cache_size = max_cache_size;
         LOG_INFO(log, "Lowered mark cache size to {} because the system has limited RAM", formatReadableSizeWithBinarySuffix(mark_cache_size));
     }
-    if (mark_cache_size)
-        global_context->setMarkCache(mark_cache_policy, mark_cache_size);
+    global_context->setMarkCache(mark_cache_policy, mark_cache_size);
 
     size_t index_uncompressed_cache_size = config().getUInt64("index_uncompressed_cache_size", DEFAULT_INDEX_UNCOMPRESSED_CACHE_MAX_SIZE);
     if (index_uncompressed_cache_size > max_cache_size)
@@ -689,8 +687,7 @@ void LocalServer::processConfig()
         index_uncompressed_cache_size = max_cache_size;
         LOG_INFO(log, "Lowered index uncompressed cache size to {} because the system has limited RAM", formatReadableSizeWithBinarySuffix(uncompressed_cache_size));
     }
-    if (index_uncompressed_cache_size)
-        global_context->setIndexUncompressedCache(index_uncompressed_cache_size);
+    global_context->setIndexUncompressedCache(index_uncompressed_cache_size);
 
     size_t index_mark_cache_size = config().getUInt64("index_mark_cache_size", DEFAULT_INDEX_MARK_CACHE_MAX_SIZE);
     if (index_mark_cache_size > max_cache_size)
@@ -698,8 +695,7 @@ void LocalServer::processConfig()
         index_mark_cache_size = max_cache_size;
         LOG_INFO(log, "Lowered index mark cache size to {} because the system has limited RAM", formatReadableSizeWithBinarySuffix(uncompressed_cache_size));
     }
-    if (index_mark_cache_size)
-        global_context->setIndexMarkCache(index_mark_cache_size);
+    global_context->setIndexMarkCache(index_mark_cache_size);
 
     size_t mmap_cache_size = config().getUInt64("mmap_cache_size", DEFAULT_MMAP_CACHE_MAX_SIZE);
     if (mmap_cache_size > max_cache_size)
@@ -707,11 +703,10 @@ void LocalServer::processConfig()
         mmap_cache_size = max_cache_size;
         LOG_INFO(log, "Lowered mmap file cache size to {} because the system has limited RAM", formatReadableSizeWithBinarySuffix(uncompressed_cache_size));
     }
-    if (mmap_cache_size)
-        global_context->setMMappedFileCache(mmap_cache_size);
+    global_context->setMMappedFileCache(mmap_cache_size);
 
-    /// In Server.cpp (./clickhouse-server), we would initialize the query cache here.
-    /// Intentionally not doing this in clickhouse-local as it doesn't make sense.
+    /// Initialize a dummy query cache.
+    global_context->setQueryCache(0, 0, 0, 0);
 
 #if USE_EMBEDDED_COMPILER
     size_t compiled_expression_cache_max_size_in_bytes = config().getUInt64("compiled_expression_cache_size", DEFAULT_COMPILED_EXPRESSION_CACHE_MAX_SIZE);

--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -1105,6 +1105,69 @@ try
     if (config().has("macros"))
         global_context->setMacros(std::make_unique<Macros>(config(), "macros", log));
 
+    /// Set up caches.
+
+    const size_t max_cache_size = static_cast<size_t>(physical_server_memory * server_settings.cache_size_to_ram_max_ratio);
+
+    String uncompressed_cache_policy = server_settings.uncompressed_cache_policy;
+    size_t uncompressed_cache_size = server_settings.uncompressed_cache_size;
+    if (uncompressed_cache_size > max_cache_size)
+    {
+        uncompressed_cache_size = max_cache_size;
+        LOG_INFO(log, "Lowered uncompressed cache size to {} because the system has limited RAM", formatReadableSizeWithBinarySuffix(uncompressed_cache_size));
+    }
+    global_context->setUncompressedCache(uncompressed_cache_policy, uncompressed_cache_size);
+
+    String mark_cache_policy = server_settings.mark_cache_policy;
+    size_t mark_cache_size = server_settings.mark_cache_size;
+    if (mark_cache_size > max_cache_size)
+    {
+        mark_cache_size = max_cache_size;
+        LOG_INFO(log, "Lowered mark cache size to {} because the system has limited RAM", formatReadableSizeWithBinarySuffix(mark_cache_size));
+    }
+    global_context->setMarkCache(mark_cache_policy, mark_cache_size);
+
+    size_t index_uncompressed_cache_size = server_settings.index_uncompressed_cache_size;
+    if (index_uncompressed_cache_size > max_cache_size)
+    {
+        index_uncompressed_cache_size = max_cache_size;
+        LOG_INFO(log, "Lowered index uncompressed cache size to {} because the system has limited RAM", formatReadableSizeWithBinarySuffix(uncompressed_cache_size));
+    }
+    global_context->setIndexUncompressedCache(index_uncompressed_cache_size);
+
+    size_t index_mark_cache_size = server_settings.index_mark_cache_size;
+    if (index_mark_cache_size > max_cache_size)
+    {
+        index_mark_cache_size = max_cache_size;
+        LOG_INFO(log, "Lowered index mark cache size to {} because the system has limited RAM", formatReadableSizeWithBinarySuffix(uncompressed_cache_size));
+    }
+    global_context->setIndexMarkCache(index_mark_cache_size);
+
+    size_t mmap_cache_size = server_settings.mmap_cache_size;
+    if (mmap_cache_size > max_cache_size)
+    {
+        mmap_cache_size = max_cache_size;
+        LOG_INFO(log, "Lowered mmap file cache size to {} because the system has limited RAM", formatReadableSizeWithBinarySuffix(uncompressed_cache_size));
+    }
+    global_context->setMMappedFileCache(mmap_cache_size);
+
+    size_t query_cache_max_size_in_bytes = config().getUInt64("query_cache.max_size_in_bytes", DEFAULT_QUERY_CACHE_MAX_SIZE);
+    size_t query_cache_max_entries = config().getUInt64("query_cache.max_entries", DEFAULT_QUERY_CACHE_MAX_ENTRIES);
+    size_t query_cache_query_cache_max_entry_size_in_bytes = config().getUInt64("query_cache.max_entry_size_in_bytes", DEFAULT_QUERY_CACHE_MAX_ENTRY_SIZE_IN_BYTES);
+    size_t query_cache_max_entry_size_in_rows = config().getUInt64("query_cache.max_entry_rows_in_rows", DEFAULT_QUERY_CACHE_MAX_ENTRY_SIZE_IN_ROWS);
+    if (query_cache_max_size_in_bytes > max_cache_size)
+    {
+        query_cache_max_size_in_bytes = max_cache_size;
+        LOG_INFO(log, "Lowered query cache size to {} because the system has limited RAM", formatReadableSizeWithBinarySuffix(uncompressed_cache_size));
+    }
+    global_context->setQueryCache(query_cache_max_size_in_bytes, query_cache_max_entries, query_cache_query_cache_max_entry_size_in_bytes, query_cache_max_entry_size_in_rows);
+
+#if USE_EMBEDDED_COMPILER
+    size_t compiled_expression_cache_max_size_in_bytes = config().getUInt64("compiled_expression_cache_size", DEFAULT_COMPILED_EXPRESSION_CACHE_MAX_SIZE);
+    size_t compiled_expression_cache_max_elements = config().getUInt64("compiled_expression_cache_elements_size", DEFAULT_COMPILED_EXPRESSION_CACHE_MAX_ENTRIES);
+    CompiledExpressionCacheFactory::instance().init(compiled_expression_cache_max_size_in_bytes, compiled_expression_cache_max_elements);
+#endif
+
     /// Initialize main config reloader.
     std::string include_from_path = config().getString("include_from", "/etc/metrika.xml");
 
@@ -1324,7 +1387,14 @@ try
 
             global_context->updateStorageConfiguration(*config);
             global_context->updateInterserverCredentials(*config);
+
+            global_context->updateUncompressedCacheConfiguration(*config);
+            global_context->updateMarkCacheConfiguration(*config);
+            global_context->updateIndexUncompressedCacheConfiguration(*config);
+            global_context->updateIndexMarkCacheConfiguration(*config);
+            global_context->updateMMappedFileCacheConfiguration(*config);
             global_context->updateQueryCacheConfiguration(*config);
+
             CompressionCodecEncrypted::Configuration::instance().tryLoad(*config, "encryption_codecs");
 #if USE_SSL
             CertificateReloader::instance().tryLoad(*config);
@@ -1484,19 +1554,6 @@ try
     /// Limit on total number of concurrently executed queries.
     global_context->getProcessList().setMaxSize(server_settings.max_concurrent_queries);
 
-    /// Set up caches.
-
-    const size_t max_cache_size = static_cast<size_t>(physical_server_memory * server_settings.cache_size_to_ram_max_ratio);
-
-    String uncompressed_cache_policy = server_settings.uncompressed_cache_policy;
-    size_t uncompressed_cache_size = server_settings.uncompressed_cache_size;
-    if (uncompressed_cache_size > max_cache_size)
-    {
-        uncompressed_cache_size = max_cache_size;
-        LOG_INFO(log, "Lowered uncompressed cache size to {} because the system has limited RAM", formatReadableSizeWithBinarySuffix(uncompressed_cache_size));
-    }
-    global_context->setUncompressedCache(uncompressed_cache_policy, uncompressed_cache_size);
-
     /// Load global settings from default_profile and system_profile.
     global_context->setDefaultProfiles(config());
 
@@ -1511,61 +1568,6 @@ try
             server_settings.async_insert_threads,
             server_settings.async_insert_queue_flush_on_shutdown));
     }
-
-    String mark_cache_policy = server_settings.mark_cache_policy;
-    size_t mark_cache_size = server_settings.mark_cache_size;
-    if (!mark_cache_size)
-        LOG_ERROR(log, "Too low mark cache size will lead to severe performance degradation.");
-    if (mark_cache_size > max_cache_size)
-    {
-        mark_cache_size = max_cache_size;
-        LOG_INFO(log, "Lowered mark cache size to {} because the system has limited RAM", formatReadableSizeWithBinarySuffix(mark_cache_size));
-    }
-    global_context->setMarkCache(mark_cache_policy, mark_cache_size);
-
-    size_t index_uncompressed_cache_size = server_settings.index_uncompressed_cache_size;
-    if (index_uncompressed_cache_size > max_cache_size)
-    {
-        index_uncompressed_cache_size = max_cache_size;
-        LOG_INFO(log, "Lowered index uncompressed cache size to {} because the system has limited RAM", formatReadableSizeWithBinarySuffix(uncompressed_cache_size));
-    }
-    if (index_uncompressed_cache_size)
-        global_context->setIndexUncompressedCache(server_settings.index_uncompressed_cache_size);
-
-    size_t index_mark_cache_size = server_settings.index_mark_cache_size;
-    if (index_mark_cache_size > max_cache_size)
-    {
-        index_mark_cache_size = max_cache_size;
-        LOG_INFO(log, "Lowered index mark cache size to {} because the system has limited RAM", formatReadableSizeWithBinarySuffix(uncompressed_cache_size));
-    }
-    if (index_mark_cache_size)
-        global_context->setIndexMarkCache(server_settings.index_mark_cache_size);
-
-    size_t mmap_cache_size = server_settings.mmap_cache_size;
-    if (mmap_cache_size > max_cache_size)
-    {
-        mmap_cache_size = max_cache_size;
-        LOG_INFO(log, "Lowered mmap file cache size to {} because the system has limited RAM", formatReadableSizeWithBinarySuffix(uncompressed_cache_size));
-    }
-    if (mmap_cache_size)
-        global_context->setMMappedFileCache(server_settings.mmap_cache_size);
-
-    size_t query_cache_max_size_in_bytes = config().getUInt64("query_cache.max_size_in_bytes", DEFAULT_QUERY_CACHE_MAX_SIZE);
-    size_t query_cache_max_entries = config().getUInt64("query_cache.max_entries", DEFAULT_QUERY_CACHE_MAX_ENTRIES);
-    size_t query_cache_query_cache_max_entry_size_in_bytes = config().getUInt64("query_cache.max_entry_size_in_bytes", DEFAULT_QUERY_CACHE_MAX_ENTRY_SIZE_IN_BYTES);
-    size_t query_cache_max_entry_size_in_rows = config().getUInt64("query_cache.max_entry_rows_in_rows", DEFAULT_QUERY_CACHE_MAX_ENTRY_SIZE_IN_ROWS);
-    if (query_cache_max_size_in_bytes > max_cache_size)
-    {
-        query_cache_max_size_in_bytes = max_cache_size;
-        LOG_INFO(log, "Lowered query cache size to {} because the system has limited RAM", formatReadableSizeWithBinarySuffix(uncompressed_cache_size));
-    }
-    global_context->setQueryCache(query_cache_max_size_in_bytes, query_cache_max_entries, query_cache_query_cache_max_entry_size_in_bytes, query_cache_max_entry_size_in_rows);
-
-#if USE_EMBEDDED_COMPILER
-    size_t compiled_expression_cache_max_size_in_bytes = config().getUInt64("compiled_expression_cache_size", DEFAULT_COMPILED_EXPRESSION_CACHE_MAX_SIZE);
-    size_t compiled_expression_cache_max_elements = config().getUInt64("compiled_expression_cache_elements_size", DEFAULT_COMPILED_EXPRESSION_CACHE_MAX_ENTRIES);
-    CompiledExpressionCacheFactory::instance().init(compiled_expression_cache_max_size_in_bytes, compiled_expression_cache_max_elements);
-#endif
 
     /// Set path for format schema files
     fs::path format_schema_path(config().getString("format_schema_path", path / "format_schemas/"));

--- a/src/Access/MultipleAccessStorage.cpp
+++ b/src/Access/MultipleAccessStorage.cpp
@@ -46,7 +46,7 @@ void MultipleAccessStorage::setStorages(const std::vector<StoragePtr> & storages
 {
     std::lock_guard lock{mutex};
     nested_storages = std::make_shared<const Storages>(storages);
-    ids_cache.reset();
+    ids_cache.clear();
 }
 
 void MultipleAccessStorage::addStorage(const StoragePtr & new_storage)
@@ -69,7 +69,7 @@ void MultipleAccessStorage::removeStorage(const StoragePtr & storage_to_remove)
     auto new_storages = std::make_shared<Storages>(*nested_storages);
     new_storages->erase(new_storages->begin() + index);
     nested_storages = new_storages;
-    ids_cache.reset();
+    ids_cache.clear();
 }
 
 std::vector<StoragePtr> MultipleAccessStorage::getStorages()

--- a/src/Common/CacheBase.h
+++ b/src/Common/CacheBase.h
@@ -151,7 +151,7 @@ public:
         std::lock_guard cache_lock(mutex);
 
         /// Insert the new value only if the token is still in present in insert_tokens.
-        /// (The token may be absent because of a concurrent reset() call).
+        /// (The token may be absent because of a concurrent clear() call).
         bool result = false;
         auto token_it = insert_tokens.find(key);
         if (token_it != insert_tokens.end() && token_it->second.get() == token)
@@ -179,13 +179,13 @@ public:
         return cache_policy->dump();
     }
 
-    void reset()
+    void clear()
     {
         std::lock_guard lock(mutex);
         insert_tokens.clear();
         hits = 0;
         misses = 0;
-        cache_policy->reset(lock);
+        cache_policy->clear(lock);
     }
 
     void remove(const Key & key)

--- a/src/Common/DNSResolver.cpp
+++ b/src/Common/DNSResolver.cpp
@@ -270,8 +270,8 @@ std::unordered_set<String> DNSResolver::reverseResolve(const Poco::Net::IPAddres
 
 void DNSResolver::dropCache()
 {
-    impl->cache_host.reset();
-    impl->cache_address.reset();
+    impl->cache_host.clear();
+    impl->cache_address.clear();
 
     std::scoped_lock lock(impl->update_mutex, impl->drop_mutex);
 

--- a/src/Common/ICachePolicy.h
+++ b/src/Common/ICachePolicy.h
@@ -55,7 +55,7 @@ public:
 
     virtual void remove(const Key & key, std::lock_guard<std::mutex> & /*cache_lock*/) = 0;
 
-    virtual void reset(std::lock_guard<std::mutex> & /*cache_lock*/) = 0;
+    virtual void clear(std::lock_guard<std::mutex> & /*cache_lock*/) = 0;
     virtual std::vector<KeyMapped> dump() const = 0;
 
 protected:

--- a/src/Common/ICachePolicy.h
+++ b/src/Common/ICachePolicy.h
@@ -10,11 +10,6 @@
 namespace DB
 {
 
-namespace ErrorCodes
-{
-    extern const int NOT_IMPLEMENTED;
-}
-
 template <typename T>
 struct EqualWeightFunction
 {
@@ -46,8 +41,8 @@ public:
     virtual size_t count(std::lock_guard<std::mutex> & /*cache_lock*/) const = 0;
     virtual size_t maxSize(std::lock_guard<std::mutex>& /*cache_lock*/) const = 0;
 
-    virtual void setMaxCount(size_t /*max_count*/, std::lock_guard<std::mutex> & /* cache_lock */) { throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Not implemented for cache policy"); }
-    virtual void setMaxSize(size_t /*max_size_in_bytes*/, std::lock_guard<std::mutex> & /* cache_lock */) { throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Not implemented for cache policy"); }
+    virtual void setMaxCount(size_t /*max_count*/, std::lock_guard<std::mutex> & /* cache_lock */) = 0;
+    virtual void setMaxSize(size_t /*max_size_in_bytes*/, std::lock_guard<std::mutex> & /* cache_lock */) = 0;
     virtual void setQuotaForUser(const String & user_name, size_t max_size_in_bytes, size_t max_entries, std::lock_guard<std::mutex> & /*cache_lock*/) { user_quotas->setQuotaForUser(user_name, max_size_in_bytes, max_entries); }
 
     /// HashFunction usually hashes the entire key and the found key will be equal the provided key. In such cases, use get(). It is also

--- a/src/Common/LRUCachePolicy.h
+++ b/src/Common/LRUCachePolicy.h
@@ -61,7 +61,7 @@ public:
         removeOverflow();
     }
 
-    void reset(std::lock_guard<std::mutex> & /* cache_lock */) override
+    void clear(std::lock_guard<std::mutex> & /* cache_lock */) override
     {
         queue.clear();
         cells.clear();

--- a/src/Common/SLRUCachePolicy.h
+++ b/src/Common/SLRUCachePolicy.h
@@ -69,7 +69,7 @@ public:
         removeOverflow(probationary_queue, max_size_in_bytes, current_size_in_bytes, /*is_protected=*/false);
     }
 
-    void reset(std::lock_guard<std::mutex> & /* cache_lock */) override
+    void clear(std::lock_guard<std::mutex> & /* cache_lock */) override
     {
         cells.clear();
         probationary_queue.clear();

--- a/src/Common/SLRUCachePolicy.h
+++ b/src/Common/SLRUCachePolicy.h
@@ -9,9 +9,8 @@ namespace DB
 {
 
 /// Cache policy SLRU evicts entries which were used only once and are not used for a long time,
-/// this policy protects entries which were used more then once from a sequential scan.
-/// WeightFunction is a functor that takes Mapped as a parameter and returns "weight" (approximate size)
-/// of that value.
+/// this policy protects entries which were used more then once from a sequential scan. Also see cache policy LRU for reference.
+/// WeightFunction is a functor that takes Mapped as a parameter and returns "weight" (approximate size) of that value.
 /// Cache starts to evict entries when their total weight exceeds max_size_in_bytes.
 /// Value weight should not change after insertion.
 /// To work with the thread-safe implementation of this class use a class "CacheBase" with first parameter "SLRU"
@@ -30,8 +29,9 @@ public:
       * max_protected_size == 0 means that the default protected size is equal to half of the total max size.
       */
     /// TODO: construct from special struct with cache policy parameters (also with max_protected_size).
-    SLRUCachePolicy(size_t max_size_in_bytes_, size_t max_count_, double size_ratio, OnWeightLossFunction on_weight_loss_function_)
+    SLRUCachePolicy(size_t max_size_in_bytes_, size_t max_count_, double size_ratio_, OnWeightLossFunction on_weight_loss_function_)
         : Base(std::make_unique<NoCachePolicyUserQuota>())
+        , size_ratio(size_ratio_)
         , max_protected_size(static_cast<size_t>(max_size_in_bytes_ * std::min(1.0, size_ratio)))
         , max_size_in_bytes(max_size_in_bytes_)
         , max_count(max_count_)
@@ -54,6 +54,21 @@ public:
         return max_size_in_bytes;
     }
 
+    void setMaxCount(size_t max_count_, std::lock_guard<std::mutex> & /* cache_lock */) override
+    {
+        max_count = max_count_;
+        removeOverflow(protected_queue, max_protected_size, current_protected_size, /*is_protected=*/true);
+        removeOverflow(probationary_queue, max_size_in_bytes, current_size_in_bytes, /*is_protected=*/false);
+    }
+
+    void setMaxSize(size_t max_size_in_bytes_, std::lock_guard<std::mutex> & /* cache_lock */) override
+    {
+        max_protected_size = static_cast<size_t>(max_size_in_bytes_ * std::min(1.0, size_ratio));
+        max_size_in_bytes = max_size_in_bytes_;
+        removeOverflow(protected_queue, max_protected_size, current_protected_size, /*is_protected=*/true);
+        removeOverflow(probationary_queue, max_size_in_bytes, current_size_in_bytes, /*is_protected=*/false);
+    }
+
     void reset(std::lock_guard<std::mutex> & /* cache_lock */) override
     {
         cells.clear();
@@ -68,12 +83,13 @@ public:
         auto it = cells.find(key);
         if (it == cells.end())
             return;
+
         auto & cell = it->second;
+
         current_size_in_bytes -= cell.size;
         if (cell.is_protected)
-        {
             current_protected_size -= cell.size;
-        }
+
         auto & queue = cell.is_protected ? protected_queue : probationary_queue;
         queue.erase(cell.queue_iterator);
         cells.erase(it);
@@ -192,16 +208,17 @@ private:
 
     Cells cells;
 
+    const double size_ratio;
     size_t current_protected_size = 0;
     size_t current_size_in_bytes = 0;
-    const size_t max_protected_size;
-    const size_t max_size_in_bytes;
-    const size_t max_count;
+    size_t max_protected_size;
+    size_t max_size_in_bytes;
+    size_t max_count;
 
     WeightFunction weight_function;
     OnWeightLossFunction on_weight_loss_function;
 
-    void removeOverflow(SLRUQueue & queue, const size_t max_weight_size, size_t & current_weight_size, bool is_protected)
+    void removeOverflow(SLRUQueue & queue, size_t max_weight_size, size_t & current_weight_size, bool is_protected)
     {
         size_t current_weight_lost = 0;
         size_t queue_size = queue.size();
@@ -223,8 +240,7 @@ private:
         {
             need_remove = [&]()
             {
-                return ((max_count != 0 && cells.size() > max_count)
-                || (current_weight_size > max_weight_size)) && (queue_size > 0);
+                return ((max_count != 0 && cells.size() > max_count) || (current_weight_size > max_weight_size)) && (queue_size > 0);
             };
         }
 
@@ -234,10 +250,7 @@ private:
 
             auto it = cells.find(key);
             if (it == cells.end())
-            {
-                // Queue became inconsistent
-                abort();
-            }
+                std::terminate(); // Queue became inconsistent
 
             auto & cell = it->second;
 
@@ -262,10 +275,7 @@ private:
             on_weight_loss_function(current_weight_lost);
 
         if (current_size_in_bytes > (1ull << 63))
-        {
-            // Queue became inconsistent
-            abort();
-        }
+            std::terminate(); // Queue became inconsistent
     }
 };
 

--- a/src/Common/TTLCachePolicy.h
+++ b/src/Common/TTLCachePolicy.h
@@ -121,7 +121,7 @@ public:
         max_size_in_bytes = max_size_in_bytes_;
     }
 
-    void reset(std::lock_guard<std::mutex> & /* cache_lock */) override
+    void clear(std::lock_guard<std::mutex> & /* cache_lock */) override
     {
         cache.clear();
     }

--- a/src/Common/tests/gtest_slru_cache.cpp
+++ b/src/Common/tests/gtest_slru_cache.cpp
@@ -92,7 +92,7 @@ TEST(SLRUCache, removeFromProtected)
     ASSERT_TRUE(value == nullptr);
 }
 
-TEST(SLRUCache, reset)
+TEST(SLRUCache, clear)
 {
     using SimpleCacheBase = DB::CacheBase<int, int>;
     auto slru_cache = SimpleCacheBase("SLRU", /*max_size_in_bytes=*/10, /*max_count=*/0, /*size_ratio*/0.5);
@@ -101,7 +101,7 @@ TEST(SLRUCache, reset)
 
     slru_cache.set(2, std::make_shared<int>(4)); /// add to protected_queue
 
-    slru_cache.reset();
+    slru_cache.clear();
 
     auto value = slru_cache.get(1);
     ASSERT_TRUE(value == nullptr);

--- a/src/Core/ServerSettings.h
+++ b/src/Core/ServerSettings.h
@@ -39,7 +39,7 @@ namespace DB
     M(UInt64, restore_threads, 16, "The maximum number of threads to execute RESTORE requests.", 0) \
     M(Int32, max_connections, 1024, "Max server connections.", 0) \
     M(UInt32, asynchronous_metrics_update_period_s, 1, "Period in seconds for updating asynchronous metrics.", 0) \
-    M(UInt32, asynchronous_heavy_metrics_update_period_s, 120, "Period in seconds for updating asynchronous metrics.", 0) \
+    M(UInt32, asynchronous_heavy_metrics_update_period_s, 120, "Period in seconds for updating heavy asynchronous metrics.", 0) \
     M(String, default_database, "default", "Default database name.", 0) \
     M(String, tmp_policy, "", "Policy for storage with temporary data.", 0) \
     M(UInt64, max_temporary_data_on_disk_size, 0, "The maximum amount of storage that could be used for external aggregation, joins or sorting., ", 0) \

--- a/src/Interpreters/Cache/QueryCache.h
+++ b/src/Interpreters/Cache/QueryCache.h
@@ -180,7 +180,7 @@ public:
     Reader createReader(const Key & key);
     Writer createWriter(const Key & key, std::chrono::milliseconds min_query_runtime, bool squash_partial_results, size_t max_block_size, size_t max_query_cache_size_in_bytes_quota, size_t max_query_cache_entries_quota);
 
-    void reset();
+    void clear();
 
     size_t weight() const;
     size_t count() const;

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -2261,6 +2261,16 @@ void Context::setUncompressedCache(const String & uncompressed_cache_policy, siz
     shared->uncompressed_cache = std::make_shared<UncompressedCache>(uncompressed_cache_policy, max_size_in_bytes);
 }
 
+void Context::updateUncompressedCacheConfiguration(const Poco::Util::AbstractConfiguration & config)
+{
+    auto lock = getLock();
+
+    if (!shared->uncompressed_cache)
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Uncompressed cache was not created yet.");
+
+    size_t max_size_in_bytes = config.getUInt64("uncompressed_cache_size", DEFAULT_UNCOMPRESSED_CACHE_MAX_SIZE);
+    shared->uncompressed_cache->setMaxSize(max_size_in_bytes);
+}
 
 UncompressedCachePtr Context::getUncompressedCache() const
 {
@@ -2268,14 +2278,13 @@ UncompressedCachePtr Context::getUncompressedCache() const
     return shared->uncompressed_cache;
 }
 
-
 void Context::clearUncompressedCache() const
 {
     auto lock = getLock();
+
     if (shared->uncompressed_cache)
         shared->uncompressed_cache->reset();
 }
-
 
 void Context::setMarkCache(const String & mark_cache_policy, size_t cache_size_in_bytes)
 {
@@ -2287,6 +2296,17 @@ void Context::setMarkCache(const String & mark_cache_policy, size_t cache_size_i
     shared->mark_cache = std::make_shared<MarkCache>(mark_cache_policy, cache_size_in_bytes);
 }
 
+void Context::updateMarkCacheConfiguration(const Poco::Util::AbstractConfiguration & config)
+{
+    auto lock = getLock();
+
+    if (!shared->mark_cache)
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Mark cache was not created yet.");
+
+    size_t max_size_in_bytes = config.getUInt64("mark_cache_size", DEFAULT_MARK_CACHE_MAX_SIZE);
+    shared->mark_cache->setMaxSize(max_size_in_bytes);
+}
+
 MarkCachePtr Context::getMarkCache() const
 {
     auto lock = getLock();
@@ -2296,6 +2316,7 @@ MarkCachePtr Context::getMarkCache() const
 void Context::clearMarkCache() const
 {
     auto lock = getLock();
+
     if (shared->mark_cache)
         shared->mark_cache->reset();
 }
@@ -2325,20 +2346,30 @@ void Context::setIndexUncompressedCache(size_t max_size_in_bytes)
     shared->index_uncompressed_cache = std::make_shared<UncompressedCache>(max_size_in_bytes);
 }
 
+void Context::updateIndexUncompressedCacheConfiguration(const Poco::Util::AbstractConfiguration & config)
+{
+    auto lock = getLock();
+
+    if (!shared->index_uncompressed_cache)
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Index uncompressed cache was not created yet.");
+
+    size_t max_size_in_bytes = config.getUInt64("index_uncompressed_cache_size", DEFAULT_INDEX_UNCOMPRESSED_CACHE_MAX_SIZE);
+    shared->index_uncompressed_cache->setMaxSize(max_size_in_bytes);
+}
+
 UncompressedCachePtr Context::getIndexUncompressedCache() const
 {
     auto lock = getLock();
     return shared->index_uncompressed_cache;
 }
 
-
 void Context::clearIndexUncompressedCache() const
 {
     auto lock = getLock();
+
     if (shared->index_uncompressed_cache)
         shared->index_uncompressed_cache->reset();
 }
-
 
 void Context::setIndexMarkCache(size_t cache_size_in_bytes)
 {
@@ -2350,6 +2381,17 @@ void Context::setIndexMarkCache(size_t cache_size_in_bytes)
     shared->index_mark_cache = std::make_shared<MarkCache>(cache_size_in_bytes);
 }
 
+void Context::updateIndexMarkCacheConfiguration(const Poco::Util::AbstractConfiguration & config)
+{
+    auto lock = getLock();
+
+    if (!shared->index_mark_cache)
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Index mark cache was not created yet.");
+
+    size_t max_size_in_bytes = config.getUInt64("index_mark_cache_size", DEFAULT_INDEX_MARK_CACHE_MAX_SIZE);
+    shared->index_mark_cache->setMaxSize(max_size_in_bytes);
+}
+
 MarkCachePtr Context::getIndexMarkCache() const
 {
     auto lock = getLock();
@@ -2359,6 +2401,7 @@ MarkCachePtr Context::getIndexMarkCache() const
 void Context::clearIndexMarkCache() const
 {
     auto lock = getLock();
+
     if (shared->index_mark_cache)
         shared->index_mark_cache->reset();
 }
@@ -2373,6 +2416,17 @@ void Context::setMMappedFileCache(size_t cache_size_in_num_entries)
     shared->mmap_cache = std::make_shared<MMappedFileCache>(cache_size_in_num_entries);
 }
 
+void Context::updateMMappedFileCacheConfiguration(const Poco::Util::AbstractConfiguration & config)
+{
+    auto lock = getLock();
+
+    if (!shared->mmap_cache)
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Mapped file cache was not created yet.");
+
+    size_t max_size_in_bytes = config.getUInt64("mmap_cache_size", DEFAULT_MMAP_CACHE_MAX_SIZE);
+    shared->mmap_cache->setMaxSize(max_size_in_bytes);
+}
+
 MMappedFileCachePtr Context::getMMappedFileCache() const
 {
     auto lock = getLock();
@@ -2382,6 +2436,7 @@ MMappedFileCachePtr Context::getMMappedFileCache() const
 void Context::clearMMappedFileCache() const
 {
     auto lock = getLock();
+
     if (shared->mmap_cache)
         shared->mmap_cache->reset();
 }
@@ -2399,14 +2454,15 @@ void Context::setQueryCache(size_t max_size_in_bytes, size_t max_entries, size_t
 void Context::updateQueryCacheConfiguration(const Poco::Util::AbstractConfiguration & config)
 {
     auto lock = getLock();
-    if (shared->query_cache)
-    {
-        size_t max_size_in_bytes = config.getUInt64("query_cache.max_size_in_bytes", DEFAULT_QUERY_CACHE_MAX_SIZE);
-        size_t max_entries = config.getUInt64("query_cache.max_entries", DEFAULT_QUERY_CACHE_MAX_ENTRIES);
-        size_t max_entry_size_in_bytes = config.getUInt64("query_cache.max_entry_size_in_bytes", DEFAULT_QUERY_CACHE_MAX_ENTRY_SIZE_IN_BYTES);
-        size_t max_entry_size_in_rows = config.getUInt64("query_cache.max_entry_rows_in_rows", DEFAULT_QUERY_CACHE_MAX_ENTRY_SIZE_IN_ROWS);
-        shared->query_cache->updateConfiguration(max_size_in_bytes, max_entries, max_entry_size_in_bytes, max_entry_size_in_rows);
-    }
+
+    if (!shared->query_cache)
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Query cache was not created yet.");
+
+    size_t max_size_in_bytes = config.getUInt64("query_cache.max_size_in_bytes", DEFAULT_QUERY_CACHE_MAX_SIZE);
+    size_t max_entries = config.getUInt64("query_cache.max_entries", DEFAULT_QUERY_CACHE_MAX_ENTRIES);
+    size_t max_entry_size_in_bytes = config.getUInt64("query_cache.max_entry_size_in_bytes", DEFAULT_QUERY_CACHE_MAX_ENTRY_SIZE_IN_BYTES);
+    size_t max_entry_size_in_rows = config.getUInt64("query_cache.max_entry_rows_in_rows", DEFAULT_QUERY_CACHE_MAX_ENTRY_SIZE_IN_ROWS);
+    shared->query_cache->updateConfiguration(max_size_in_bytes, max_entries, max_entry_size_in_bytes, max_entry_size_in_rows);
 }
 
 QueryCachePtr Context::getQueryCache() const
@@ -2418,6 +2474,7 @@ QueryCachePtr Context::getQueryCache() const
 void Context::clearQueryCache() const
 {
     auto lock = getLock();
+
     if (shared->query_cache)
         shared->query_cache->reset();
 }
@@ -2426,22 +2483,27 @@ void Context::clearCaches() const
 {
     auto lock = getLock();
 
-    if (shared->uncompressed_cache)
-        shared->uncompressed_cache->reset();
+    if (!shared->uncompressed_cache)
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Uncompressed cache was not created yet.");
+    shared->uncompressed_cache->reset();
 
-    if (shared->mark_cache)
-        shared->mark_cache->reset();
+    if (!shared->mark_cache)
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Mark cache was not created yet.");
+    shared->mark_cache->reset();
 
-    if (shared->index_uncompressed_cache)
-        shared->index_uncompressed_cache->reset();
+    if (!shared->index_uncompressed_cache)
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Index uncompressed cache was not created yet.");
+    shared->index_uncompressed_cache->reset();
 
-    if (shared->index_mark_cache)
-        shared->index_mark_cache->reset();
+    if (!shared->index_mark_cache)
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Index mark cache was not created yet.");
+    shared->index_mark_cache->reset();
 
-    if (shared->mmap_cache)
-        shared->mmap_cache->reset();
+    if (!shared->mmap_cache)
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Mmapped file cache was not created yet.");
+    shared->mmap_cache->reset();
 
-    /// Intentionally not dropping the query cache which is transactionally inconsistent by design.
+    /// Intentionally not clearing the query cache which is transactionally inconsistent by design.
 }
 
 ThreadPool & Context::getPrefetchThreadpool() const

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -547,7 +547,7 @@ struct ContextSharedPart : boost::noncopyable
               */
 #if USE_EMBEDDED_COMPILER
             if (auto * cache = CompiledExpressionCacheFactory::instance().tryGetCache())
-                cache->reset();
+                cache->clear();
 #endif
 
             /// Preemptive destruction is important, because these objects may have a refcount to ContextShared (cyclic reference).
@@ -2283,7 +2283,7 @@ void Context::clearUncompressedCache() const
     auto lock = getLock();
 
     if (shared->uncompressed_cache)
-        shared->uncompressed_cache->reset();
+        shared->uncompressed_cache->clear();
 }
 
 void Context::setMarkCache(const String & mark_cache_policy, size_t cache_size_in_bytes)
@@ -2318,7 +2318,7 @@ void Context::clearMarkCache() const
     auto lock = getLock();
 
     if (shared->mark_cache)
-        shared->mark_cache->reset();
+        shared->mark_cache->clear();
 }
 
 ThreadPool & Context::getLoadMarksThreadpool() const
@@ -2368,7 +2368,7 @@ void Context::clearIndexUncompressedCache() const
     auto lock = getLock();
 
     if (shared->index_uncompressed_cache)
-        shared->index_uncompressed_cache->reset();
+        shared->index_uncompressed_cache->clear();
 }
 
 void Context::setIndexMarkCache(size_t cache_size_in_bytes)
@@ -2403,7 +2403,7 @@ void Context::clearIndexMarkCache() const
     auto lock = getLock();
 
     if (shared->index_mark_cache)
-        shared->index_mark_cache->reset();
+        shared->index_mark_cache->clear();
 }
 
 void Context::setMMappedFileCache(size_t cache_size_in_num_entries)
@@ -2438,7 +2438,7 @@ void Context::clearMMappedFileCache() const
     auto lock = getLock();
 
     if (shared->mmap_cache)
-        shared->mmap_cache->reset();
+        shared->mmap_cache->clear();
 }
 
 void Context::setQueryCache(size_t max_size_in_bytes, size_t max_entries, size_t max_entry_size_in_bytes, size_t max_entry_size_in_rows)
@@ -2476,7 +2476,7 @@ void Context::clearQueryCache() const
     auto lock = getLock();
 
     if (shared->query_cache)
-        shared->query_cache->reset();
+        shared->query_cache->clear();
 }
 
 void Context::clearCaches() const
@@ -2485,23 +2485,23 @@ void Context::clearCaches() const
 
     if (!shared->uncompressed_cache)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Uncompressed cache was not created yet.");
-    shared->uncompressed_cache->reset();
+    shared->uncompressed_cache->clear();
 
     if (!shared->mark_cache)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Mark cache was not created yet.");
-    shared->mark_cache->reset();
+    shared->mark_cache->clear();
 
     if (!shared->index_uncompressed_cache)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Index uncompressed cache was not created yet.");
-    shared->index_uncompressed_cache->reset();
+    shared->index_uncompressed_cache->clear();
 
     if (!shared->index_mark_cache)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Index mark cache was not created yet.");
-    shared->index_mark_cache->reset();
+    shared->index_mark_cache->clear();
 
     if (!shared->mmap_cache)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Mmapped file cache was not created yet.");
-    shared->mmap_cache->reset();
+    shared->mmap_cache->clear();
 
     /// Intentionally not clearing the query cache which is transactionally inconsistent by design.
 }

--- a/src/Interpreters/Context.h
+++ b/src/Interpreters/Context.h
@@ -917,33 +917,32 @@ public:
 
     /// --- Caches ------------------------------------------------------------------------------------------
 
-    /// Create a cache of uncompressed blocks of specified size. This can be done only once.
     void setUncompressedCache(const String & uncompressed_cache_policy, size_t max_size_in_bytes);
+    void updateUncompressedCacheConfiguration(const Poco::Util::AbstractConfiguration & config);
     std::shared_ptr<UncompressedCache> getUncompressedCache() const;
     void clearUncompressedCache() const;
 
-    /// Create a cache of marks of specified size. This can be done only once.
     void setMarkCache(const String & mark_cache_policy, size_t cache_size_in_bytes);
+    void updateMarkCacheConfiguration(const Poco::Util::AbstractConfiguration & config);
     std::shared_ptr<MarkCache> getMarkCache() const;
     void clearMarkCache() const;
     ThreadPool & getLoadMarksThreadpool() const;
 
-    /// Create a cache of index uncompressed blocks of specified size. This can be done only once.
     void setIndexUncompressedCache(size_t max_size_in_bytes);
+    void updateIndexUncompressedCacheConfiguration(const Poco::Util::AbstractConfiguration & config);
     std::shared_ptr<UncompressedCache> getIndexUncompressedCache() const;
     void clearIndexUncompressedCache() const;
 
-    /// Create a cache of index marks of specified size. This can be done only once.
     void setIndexMarkCache(size_t cache_size_in_bytes);
+    void updateIndexMarkCacheConfiguration(const Poco::Util::AbstractConfiguration & config);
     std::shared_ptr<MarkCache> getIndexMarkCache() const;
     void clearIndexMarkCache() const;
 
-    /// Create a cache of mapped files to avoid frequent open/map/unmap/close and to reuse from several threads.
     void setMMappedFileCache(size_t cache_size_in_num_entries);
+    void updateMMappedFileCacheConfiguration(const Poco::Util::AbstractConfiguration & config);
     std::shared_ptr<MMappedFileCache> getMMappedFileCache() const;
     void clearMMappedFileCache() const;
 
-    /// Create a cache of query results for statements which run repeatedly.
     void setQueryCache(size_t max_size_in_bytes, size_t max_entries, size_t max_entry_size_in_bytes, size_t max_entry_size_in_rows);
     void updateQueryCacheConfiguration(const Poco::Util::AbstractConfiguration & config);
     std::shared_ptr<QueryCache> getQueryCache() const;

--- a/src/Interpreters/InterpreterSystemQuery.cpp
+++ b/src/Interpreters/InterpreterSystemQuery.cpp
@@ -345,7 +345,7 @@ BlockIO InterpreterSystemQuery::execute()
         case Type::DROP_COMPILED_EXPRESSION_CACHE:
             getContext()->checkAccess(AccessType::SYSTEM_DROP_COMPILED_EXPRESSION_CACHE);
             if (auto * cache = CompiledExpressionCacheFactory::instance().tryGetCache())
-                cache->reset();
+                cache->clear();
             break;
 #endif
 #if USE_AWS_S3

--- a/src/Interpreters/ServerAsynchronousMetrics.cpp
+++ b/src/Interpreters/ServerAsynchronousMetrics.cpp
@@ -6,6 +6,7 @@
 #include <Interpreters/Cache/FileCache.h>
 #include <Interpreters/Cache/FileCacheFactory.h>
 #include <Interpreters/Context.h>
+#include <Interpreters/Cache/QueryCache.h>
 #include <Interpreters/JIT/CompiledExpressionCache.h>
 
 #include <Databases/IDatabase.h>

--- a/tests/integration/test_runtime_configurable_cache_size/configs/default.xml
+++ b/tests/integration/test_runtime_configurable_cache_size/configs/default.xml
@@ -1,0 +1,9 @@
+<clickhouse>
+
+    <query_cache>
+        <max_entries>2</max_entries>
+    </query_cache>
+
+    <mark_cache_size>496</mark_cache_size>
+
+</clickhouse>

--- a/tests/integration/test_runtime_configurable_cache_size/configs/smaller_mark_cache.xml
+++ b/tests/integration/test_runtime_configurable_cache_size/configs/smaller_mark_cache.xml
@@ -1,0 +1,5 @@
+<clickhouse>
+
+    <mark_cache_size>248</mark_cache_size>
+
+</clickhouse>

--- a/tests/integration/test_runtime_configurable_cache_size/configs/smaller_query_cache.xml
+++ b/tests/integration/test_runtime_configurable_cache_size/configs/smaller_query_cache.xml
@@ -1,0 +1,7 @@
+<clickhouse>
+
+    <query_cache>
+        <max_entries>1</max_entries>
+    </query_cache>
+
+</clickhouse>

--- a/tests/integration/test_runtime_configurable_cache_size/test.py
+++ b/tests/integration/test_runtime_configurable_cache_size/test.py
@@ -1,0 +1,143 @@
+import os
+import pytest
+import shutil
+import time
+from helpers.cluster import ClickHouseCluster
+
+# Tests that sizes of in-memory caches (mark / uncompressed / index mark / index uncompressed / mmapped file / query cache) can be changed
+# at runtime (issue #51085). This file tests only the mark cache (which uses the SLRU cache policy) and the query cache (which uses the TTL
+# cache policy). As such, both tests are representative for the other caches.
+
+cluster = ClickHouseCluster(__file__)
+node = cluster.add_instance(
+    "node",
+    main_configs=["configs/default.xml"],
+    stay_alive=True,
+)
+
+
+@pytest.fixture(scope="module")
+def start_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
+CONFIG_DIR = os.path.join(SCRIPT_DIR, "configs")
+
+
+def test_mark_cache_size_is_runtime_configurable(start_cluster):
+    # the initial config specifies the mark cache size as 496 bytes, just enough to hold two marks
+    node.query("SYSTEM DROP MARK CACHE")
+
+    node.query("CREATE TABLE test1 (val String) ENGINE=MergeTree ORDER BY val")
+    node.query("INSERT INTO test1 VALUES ('abc') ('def') ('ghi')")
+    node.query("SELECT * FROM test1 WHERE val = 'def'")  # cache 1st mark
+
+    node.query("CREATE TABLE test2 (val String) ENGINE=MergeTree ORDER BY val")
+    node.query("INSERT INTO test2 VALUES ('abc') ('def') ('ghi')")
+    node.query("SELECT * FROM test2 WHERE val = 'def'")  # cache 2nd mark
+
+    # Result checking is based on asynchronous metrics. These are calculated by default every 1.0 sec, and this is also the
+    # smallest possible value. Found no statement to force-recalculate them, therefore waaaaait...
+    time.sleep(2.0)
+    res = node.query(
+        "SELECT value FROM system.asynchronous_metrics WHERE metric LIKE 'MarkCacheFiles'"
+    )
+    assert res == "2\n"
+    res = node.query(
+        "SELECT value FROM system.asynchronous_metrics WHERE metric LIKE 'MarkCacheBytes'"
+    )
+    assert res == "496\n"
+
+    # switch to a config with a mark cache size of 248 bytes
+    node.copy_file_to_container(
+        os.path.join(CONFIG_DIR, "smaller_mark_cache.xml"),
+        "/etc/clickhouse-server/config.d/default.xml",
+    )
+
+    node.query("SYSTEM RELOAD CONFIG")
+
+    # check that eviction worked as expected
+    time.sleep(2.0)
+    res = node.query(
+        "SELECT value FROM system.asynchronous_metrics WHERE metric LIKE 'MarkCacheFiles'"
+    )
+    assert res == "1\n"
+    res = node.query(
+        "SELECT value FROM system.asynchronous_metrics WHERE metric LIKE 'MarkCacheBytes'"
+    )
+    assert res == "248\n"
+
+    # check that the new mark cache maximum size is respected when more marks are cached
+    node.query("CREATE TABLE test3 (val String) ENGINE=MergeTree ORDER BY val")
+    node.query("INSERT INTO test3 VALUES ('abc') ('def') ('ghi')")
+    node.query("SELECT * FROM test3 WHERE val = 'def'")
+    time.sleep(2.0)
+    res = node.query(
+        "SELECT value FROM system.asynchronous_metrics WHERE metric LIKE 'MarkCacheFiles'"
+    )
+    assert res == "1\n"
+    res = node.query(
+        "SELECT value FROM system.asynchronous_metrics WHERE metric LIKE 'MarkCacheBytes'"
+    )
+    assert res == "248\n"
+
+    # restore the original config
+    node.copy_file_to_container(
+        os.path.join(CONFIG_DIR, "default.xml"),
+        "/etc/clickhouse-server/config.d/default.xml",
+    )
+
+
+def test_query_cache_size_is_runtime_configurable(start_cluster):
+    # the inital config specifies the maximum query cache size as 2, run 3 queries, expect 2 cache entries
+    node.query("SYSTEM DROP QUERY CACHE")
+    node.query("SELECT 1 SETTINGS use_query_cache = 1, query_cache_ttl = 1")
+    node.query("SELECT 2 SETTINGS use_query_cache = 1, query_cache_ttl = 1")
+    node.query("SELECT 3 SETTINGS use_query_cache = 1, query_cache_ttl = 1")
+
+    time.sleep(2.0)
+    res = node.query(
+        "SELECT value FROM system.asynchronous_metrics WHERE metric = 'QueryCacheEntries'"
+    )
+    assert res == "2\n"
+
+    # switch to a config with a maximum query cache size of 1
+    node.copy_file_to_container(
+        os.path.join(CONFIG_DIR, "smaller_query_cache.xml"),
+        "/etc/clickhouse-server/config.d/default.xml",
+    )
+
+    node.query("SYSTEM RELOAD CONFIG")
+
+    # check that eviction worked as expected
+    time.sleep(2.0)
+    res = node.query(
+        "SELECT value FROM system.asynchronous_metrics WHERE metric = 'QueryCacheEntries'"
+    )
+    assert (
+        res == "2\n"
+    )  # "Why not 1?", you think. Reason is that QC uses the TTLCachePolicy that evicts lazily only upon insert.
+    # Not a real issue, can be changed later, at least there's a test now.
+
+    # Also, you may also wonder "why query_cache_ttl = 1"? Reason is that TTLCachePolicy only removes *stale* entries. With the default TTL
+    # (60 sec), no entries would be removed at all. Again: not a real issue, can be changed later and there's at least a test now.
+
+    # check that the new query cache maximum size is respected when more queries run
+    node.query("SELECT 4 SETTINGS use_query_cache = 1, query_cache_ttl = 1")
+    node.query("SELECT 5 SETTINGS use_query_cache = 1, query_cache_ttl = 1")
+    time.sleep(2.0)
+    res = node.query(
+        "SELECT value FROM system.asynchronous_metrics WHERE metric = 'QueryCacheEntries'"
+    )
+    assert res == "1\n"
+
+    # restore the original config
+    node.copy_file_to_container(
+        os.path.join(CONFIG_DIR, "default.xml"),
+        "/etc/clickhouse-server/config.d/default.xml",
+    )


### PR DESCRIPTION
Fixes #51085 

Note: Only https://github.com/ClickHouse/ClickHouse/pull/51446/commits/96c8b250ce39770df0cc296a880d327d4d1b8136 contains relevant changes, the other commit has sort-of-unrelated some cleanups.

Only
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
The sizes of the (index) uncompressed/mark, mmap and query caches can now be configured dynamically at runtime.