### PR TITLE
Update system_warnings test

### DIFF
--- a/tests/queries/0_stateless/01945_system_warnings.sh
+++ b/tests/queries/0_stateless/01945_system_warnings.sh
@@ -21,5 +21,4 @@ ${CLICKHOUSE_CLIENT} --multiple_joins_rewriter_version=42 -q "SELECT message FRO
 ${CLICKHOUSE_CLIENT} -q "SELECT count() = countDistinct(message) FROM system.warnings"
 
 # Avoid too many warnings, especially in CI
-${CLICKHOUSE_CLIENT} -q "SELECT count() < 5 FROM system.warnings"
-
+${CLICKHOUSE_CLIENT} -q "SELECT count() < 10 FROM system.warnings"


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


See https://s3.amazonaws.com/clickhouse-test-reports/0/b10bcbc7f41d361fa4b7948b389dbbd4642c51e6/stateless_tests__debug__[4_5]/clickhouse-server.err.log

There are 5 warnings:

```
2023.06.26 21:34:09.823991 [ 663 ] {} <Warning> Context: Server was built in debug mode. It will work slowly.
2023.06.26 21:34:09.824371 [ 663 ] {} <Warning> Context: Server logging level is set to 'test' and performance is degraded. This cannot be used in production.
2023.06.26 21:34:09.824597 [ 663 ] {} <Warning> Context: Linux is not using a fast clock source. Performance can be degraded. Check /sys/devices/system/clocksource/clocksource0/current_clocksource
2023.06.26 21:34:09.827485 [ 663 ] {} <Warning> Context: The setting 'allow_remote_fs_zero_copy_replication' is enabled for MergeTree tables. But the feature of 'zero-copy replication' is under development and is not ready for production. The usage of this feature can lead to data corruption and loss. The setting should be disabled in production.
2023.06.26 21:34:41.149154 [ 663 ] {} <Warning> Context: Table system.session_log is enabled. It's unreliable and may contain garbage. Do not use it for any kind of security monitoring.
```

The only suspicious is about the clock source.