### PR TITLE
Fix test 01605_adaptive_granularity_block_borders

### DIFF
--- a/tests/queries/0_stateless/01605_adaptive_granularity_block_borders.sql
+++ b/tests/queries/0_stateless/01605_adaptive_granularity_block_borders.sql
@@ -5,9 +5,9 @@ SET allow_prefetched_read_pool_for_remote_filesystem=0;
 
 DROP TABLE IF EXISTS adaptive_table;
 
---- If granularity of consequent blocks differs a lot, then adaptive
---- granularity will adjust amout of marks correctly. Data for test empirically
---- derived, it's quite hard to get good parameters.
+-- If granularity of consequent blocks differs a lot, then adaptive
+-- granularity will adjust the amount of marks correctly.
+-- Data for test was empirically derived, it's quite hard to get good parameters.
 
 CREATE TABLE adaptive_table(
     key UInt64,
@@ -32,6 +32,7 @@ SET enable_filesystem_cache = 0;
 
 -- If we have computed granularity incorrectly than we will exceed this limit.
 SET max_memory_usage='30M';
+SET max_threads = 1;
 
 SELECT max(length(value)) FROM adaptive_table;
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


See https://s3.amazonaws.com/clickhouse-test-reports/51341/cf7ff318219d5711bc8b5f4d2deaa69dee93e9ad/stateless_tests__aarch64_/run.log

Broken after the parallelization after reading from tables was enabled by default.

Closes https://github.com/ClickHouse/ClickHouse/issues/50681