### PR TITLE
Try making Keeper in `DatabaseReplicated` tests more stable

### DIFF
--- a/tests/config/config.d/database_replicated.xml
+++ b/tests/config/config.d/database_replicated.xml
@@ -42,7 +42,7 @@
             <heart_beat_interval_ms>1000</heart_beat_interval_ms>
             <election_timeout_lower_bound_ms>2000</election_timeout_lower_bound_ms>
             <election_timeout_upper_bound_ms>5000</election_timeout_upper_bound_ms>
-            <raft_logs_level>trace</raft_logs_level>
+            <raft_logs_level>debug</raft_logs_level>
             <force_sync>false</force_sync>
             <!-- we want all logs for complex problems investigation -->
             <reserved_log_items>1000000000000000</reserved_log_items>

--- a/tests/config/config.d/database_replicated.xml
+++ b/tests/config/config.d/database_replicated.xml
@@ -40,9 +40,9 @@
             <operation_timeout_ms>10000</operation_timeout_ms>
             <session_timeout_ms>30000</session_timeout_ms>
             <heart_beat_interval_ms>1000</heart_beat_interval_ms>
-            <election_timeout_lower_bound_ms>4000</election_timeout_lower_bound_ms>
+            <election_timeout_lower_bound_ms>2000</election_timeout_lower_bound_ms>
             <election_timeout_upper_bound_ms>5000</election_timeout_upper_bound_ms>
-            <raft_logs_level>information</raft_logs_level>
+            <raft_logs_level>trace</raft_logs_level>
             <force_sync>false</force_sync>
             <!-- we want all logs for complex problems investigation -->
             <reserved_log_items>1000000000000000</reserved_log_items>

--- a/tests/config/config.d/database_replicated.xml
+++ b/tests/config/config.d/database_replicated.xml
@@ -42,7 +42,7 @@
             <heart_beat_interval_ms>1000</heart_beat_interval_ms>
             <election_timeout_lower_bound_ms>2000</election_timeout_lower_bound_ms>
             <election_timeout_upper_bound_ms>5000</election_timeout_upper_bound_ms>
-            <raft_logs_level>debug</raft_logs_level>
+            <raft_logs_level>information</raft_logs_level>
             <force_sync>false</force_sync>
             <!-- we want all logs for complex problems investigation -->
             <reserved_log_items>1000000000000000</reserved_log_items>


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Seems like Keeper can be unstable in some of the stateless tests using 3-node setup (https://s3.amazonaws.com/clickhouse-test-reports/49732/8f3b3271d3fc8d174b7d5d5e912e9b70c886c96a/stateless_tests__release__databasereplicated__%5B4_4%5D.html)

Because of the strange gaps in communication (network related maybe?) we ended up in state where Keeper1 and Keeper2 both became leaders for short period of time and with that committed a config.

After that, Keeper3 initiated vote each time forcing Keeper1 and Keeper2 to reset their election timers. Vote fails because Keeper3 has less logs than both Keeper1 and Keeper2. Repeat this process 3 times.

A possible solution could be increasing the range for the election timeout (right now it’s 4-5s). If we set it to 2-5s maybe there will be a higher chance “correct” Keeper nodes will get a chance for leader election.

Keeper3:
```
113:2023.06.22 23:08:04.703331 [ 1388 ] {} <Information> RaftInstance: [VOTE INIT] my id 3, my role candidate, term 3, log idx 0, log term 0, priority (target 1 / mine 1)
127:2023.06.22 23:08:08.879667 [ 1394 ] {} <Information> RaftInstance: [VOTE INIT] my id 3, my role candidate, term 4, log idx 0, log term 0, priority (target 1 / mine 1)
141:2023.06.22 23:08:13.227426 [ 1402 ] {} <Information> RaftInstance: [VOTE INIT] my id 3, my role candidate, term 5, log idx 0, log term 0, priority (target 1 / mine 1)
156:2023.06.22 23:08:17.759869 [ 1401 ] {} <Information> RaftInstance: [VOTE INIT] my id 3, my role candidate, term 6, log idx 0, log term 0, priority (target 1 / mine 1)
```
Keeper2:
```
85:2023.06.22 23:07:59.581539 [ 1365 ] {} <Information> RaftInstance: [BECOME FOLLOWER] term 1
116:2023.06.22 23:08:04.833995 [ 1365 ] {} <Information> RaftInstance: [BECOME FOLLOWER] term 3
485:2023.06.22 23:08:09.008621 [ 1374 ] {} <Information> RaftInstance: [BECOME FOLLOWER] term 4
916:2023.06.22 23:08:13.315691 [ 1370 ] {} <Information> RaftInstance: [BECOME FOLLOWER] term 5
922:2023.06.22 23:08:13.315819 [ 1377 ] {} <Information> RaftInstance: election timeout while serving append entries, ignore it.
1093:2023.06.22 23:08:17.888896 [ 1367 ] {} <Information> RaftInstance: [BECOME FOLLOWER] term 6
```

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
