### PR TITLE
Fix race in BoundedReadBuffer

### DIFF
--- a/src/IO/BoundedReadBuffer.h
+++ b/src/IO/BoundedReadBuffer.h
@@ -31,7 +31,8 @@ public:
 
 private:
     std::optional<size_t> read_until_position;
-    size_t file_offset_of_buffer_end = 0;
+    /// atomic because can be used in log or exception messages while being updated.
+    std::atomic<size_t> file_offset_of_buffer_end = 0;
 };
 
 }


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Closes https://github.com/ClickHouse/ClickHouse/issues/51336.
The race happened when using local object storage.