### PR TITLE
Fix race between `executeMetadataAlter` and `initializeReplication`

### DIFF
--- a/src/Databases/DatabaseReplicated.h
+++ b/src/Databases/DatabaseReplicated.h
@@ -48,6 +48,8 @@ public:
     /// then it will be executed on all replicas.
     BlockIO tryEnqueueReplicatedDDL(const ASTPtr & query, ContextPtr query_context, bool internal) override;
 
+    bool canExecuteReplicatedMetadataAlter() const override;
+
     bool hasReplicationThread() const override { return true; }
 
     void stopReplication() override;

--- a/src/Databases/IDatabase.h
+++ b/src/Databases/IDatabase.h
@@ -254,6 +254,9 @@ public:
         throw Exception(ErrorCodes::NOT_IMPLEMENTED, "{}: alterTable() is not supported", getEngineName());
     }
 
+    /// Special method for ReplicatedMergeTree and DatabaseReplicated
+    virtual bool canExecuteReplicatedMetadataAlter() const { return true; }
+
     /// Returns time of table's metadata change, 0 if there is no corresponding metadata file.
     virtual time_t getObjectMetadataModificationTime(const String & /*name*/) const
     {

--- a/src/Storages/MergeTree/ReplicatedMergeTreeQueue.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeQueue.cpp
@@ -1448,6 +1448,15 @@ bool ReplicatedMergeTreeQueue::shouldExecuteLogEntry(
             LOG_TRACE(LogToStr(out_postpone_reason, log), fmt_string, entry.znode_name, entry.alter_version, head_alter);
             return false;
         }
+
+        auto database_name = storage.getStorageID().database_name;
+        auto database = DatabaseCatalog::instance().getDatabase(database_name);
+        if (!database->canExecuteReplicatedMetadataAlter())
+        {
+            LOG_TRACE(LogToStr(out_postpone_reason, log), "Cannot execute alter metadata {} with version {} "
+                      "because database {} cannot process metadata alters now", entry.znode_name, entry.alter_version, database_name);
+            return false;
+        }
     }
 
     /// If this MUTATE_PART is part of alter modify/drop query, than we have to execute them one by one


### PR DESCRIPTION

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Fixes `test_replicated_database/test.py::test_replicated_table_structure_alter`: https://s3.amazonaws.com/clickhouse-test-reports/0/97f76d712c6a040ebec65767d778c44f1292156f/integration_tests__release__[3_4].html 