### PR TITLE
Fix flaky test `test_host_regexp_multiple_ptr_records`

### DIFF
--- a/tests/integration/test_host_regexp_multiple_ptr_records/coredns_config/Corefile
+++ b/tests/integration/test_host_regexp_multiple_ptr_records/coredns_config/Corefile
@@ -1,6 +1,6 @@
 . {
     hosts /example.com {
-        reload "200ms"
+        reload "20ms"
         fallthrough
     }
     forward . 127.0.0.11

--- a/tests/integration/test_host_regexp_multiple_ptr_records_concurrent/coredns_config/Corefile
+++ b/tests/integration/test_host_regexp_multiple_ptr_records_concurrent/coredns_config/Corefile
@@ -1,6 +1,6 @@
 . {
     hosts /example.com {
-        reload "200ms"
+        reload "20ms"
         fallthrough
     }
     forward . 127.0.0.11


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Closes https://github.com/ClickHouse/ClickHouse/issues/51471
