### PR TITLE
Fix running integration tests with spaces in it's names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,6 +161,7 @@ tests/queries/0_stateless/test_*
 tests/queries/0_stateless/*.binary
 tests/queries/0_stateless/*.generated-expect
 tests/queries/0_stateless/*.expect.history
+tests/integration/**/_gen
 
 # rust
 /rust/**/target

--- a/docker/test/integration/runner/Dockerfile
+++ b/docker/test/integration/runner/Dockerfile
@@ -135,4 +135,5 @@ ENV MSAN_OPTIONS='abort_on_error=1 poison_in_dtor=1'
 
 EXPOSE 2375
 ENTRYPOINT ["dockerd-entrypoint.sh"]
-CMD ["sh", "-c", "pytest $PYTEST_OPTS"]
+# To pass additional arguments (i.e. list of tests) use PYTEST_ADDOPTS
+CMD ["sh", "-c", "pytest"]

--- a/tests/analyzer_integration_broken_tests.txt
+++ b/tests/analyzer_integration_broken_tests.txt
@@ -196,3 +196,8 @@ test_quota/test.py::test_tracking_quota
 test_quota/test.py::test_users_xml_is_readonly
 test_replicating_constants/test.py::test_different_versions
 test_merge_tree_s3/test.py::test_heavy_insert_select_check_memory[node]
+test_drop_is_lock_free/test.py::test_query_is_lock_free[detach table]
+test_backward_compatibility/test_data_skipping_indices.py::test_index
+test_backward_compatibility/test_convert_ordinary.py::test_convert_ordinary_to_atomic
+test_backward_compatibility/test_memory_bound_aggregation.py::test_backward_compatability
+test_odbc_interaction/test.py::test_postgres_insert

--- a/tests/integration/ci-runner.py
+++ b/tests/integration/ci-runner.py
@@ -412,7 +412,7 @@ class ClickhouseIntegrationTestsRunner:
         out_file_full = os.path.join(self.result_path, "runner_get_all_tests.log")
         cmd = (
             "cd {repo_path}/tests/integration && "
-            "timeout -s 9 1h ./runner {runner_opts} {image_cmd} ' --setup-plan' "
+            "timeout -s 9 1h ./runner {runner_opts} {image_cmd} -- --setup-plan "
             "| tee {out_file_full} | grep '::' | sed 's/ (fixtures used:.*//g' | sed 's/^ *//g' | sed 's/ *$//g' "
             "| grep -v 'SKIPPED' | sort -u  > {out_file}".format(
                 repo_path=repo_path,
@@ -656,7 +656,7 @@ class ClickhouseIntegrationTestsRunner:
             # -E -- (E)rror
             # -p -- (p)assed
             # -s -- (s)kipped
-            cmd = "cd {}/tests/integration && timeout -s 9 1h ./runner {} {} -t {} {} '-rfEps --run-id={} --color=no --durations=0 {}' | tee {}".format(
+            cmd = "cd {}/tests/integration && timeout -s 9 1h ./runner {} {} -t {} {} -- -rfEps --run-id={} --color=no --durations=0 {} | tee {}".format(
                 repo_path,
                 self._get_runner_opts(),
                 image_cmd,

--- a/tests/integration/ci-runner.py
+++ b/tests/integration/ci-runner.py
@@ -788,6 +788,7 @@ class ClickhouseIntegrationTestsRunner:
                     and test not in counters["ERROR"]
                     and test not in counters["SKIPPED"]
                     and test not in counters["FAILED"]
+                    and test not in counters["BROKEN"]
                     and "::" in test
                 ):
                     counters["ERROR"].append(test)

--- a/tests/integration/ci-runner.py
+++ b/tests/integration/ci-runner.py
@@ -10,6 +10,7 @@ import random
 import shutil
 import subprocess
 import time
+import shlex
 import zlib  # for crc32
 
 
@@ -646,7 +647,7 @@ class ClickhouseIntegrationTestsRunner:
             info_basename = test_group_str + "_" + str(i) + ".nfo"
             info_path = os.path.join(repo_path, "tests/integration", info_basename)
 
-            test_cmd = " ".join([test for test in sorted(test_names)])
+            test_cmd = " ".join([shlex.quote(test) for test in sorted(test_names)])
             parallel_cmd = (
                 " --parallel {} ".format(num_workers) if num_workers > 0 else ""
             )

--- a/tests/integration/runner
+++ b/tests/integration/runner
@@ -11,6 +11,7 @@ import subprocess
 import sys
 import string
 import random
+import shlex
 
 
 def random_str(length=6):
@@ -407,8 +408,14 @@ if __name__ == "__main__":
     if args.analyzer:
         use_analyzer = "-e CLICKHOUSE_USE_NEW_ANALYZER=1"
 
-    pytest_opts = " ".join(args.pytest_args).replace("'", "\\'")
-    tests_list = " ".join(args.tests_list)
+    # NOTE: since pytest options is in the argument value already we need to additionally escape '"'
+    pytest_opts = " ".join(
+        map(lambda x: shlex.quote(x).replace('"', '\\"'), args.pytest_args)
+    )
+    tests_list = " ".join(
+        map(lambda x: shlex.quote(x).replace('"', '\\"'), args.tests_list)
+    )
+
     cmd_base = (
         f"docker run {net} {tty} --rm --name {CONTAINER_NAME} "
         "--privileged --dns-search='.' "  # since recent dns search leaks from host
@@ -420,7 +427,7 @@ if __name__ == "__main__":
         f"--volume={args.src_dir}/Server/grpc_protos:/ClickHouse/src/Server/grpc_protos "
         f"--volume=/run:/run/host:ro {dockerd_internal_volume} {env_tags} {env_cleanup} "
         f"-e DOCKER_CLIENT_TIMEOUT=300 -e COMPOSE_HTTP_TIMEOUT=600 {use_analyzer} -e PYTHONUNBUFFERED=1 "
-        f"-e PYTEST_OPTS='{parallel_args} {pytest_opts} {tests_list} {rand_args} -vvv'"
+        f'-e PYTEST_ADDOPTS="{parallel_args} {pytest_opts} {tests_list} {rand_args} -vvv"'
         f" {DIND_INTEGRATION_TESTS_IMAGE_NAME}:{args.docker_image_version}"
     )
 

--- a/tests/integration/runner
+++ b/tests/integration/runner
@@ -136,9 +136,7 @@ def check_args_and_update_paths(args):
 
 def docker_kill_handler_handler(signum, frame):
     subprocess.check_call(
-        'docker ps --all --quiet --filter name={name} --format="{{{{.ID}}}}"'.format(
-            name=CONTAINER_NAME
-        ),
+        "docker ps --all --quiet --filter name={name}".format(name=CONTAINER_NAME),
         shell=True,
     )
     raise KeyboardInterrupt("Killed by Ctrl+C")
@@ -438,7 +436,7 @@ if __name__ == "__main__":
     )
 
     containers = subprocess.check_output(
-        f"docker ps --all --quiet --filter name={CONTAINER_NAME} --format={{{{.ID}}}}",
+        f"docker ps --all --quiet --filter name={CONTAINER_NAME}",
         shell=True,
         universal_newlines=True,
     ).splitlines()


### PR DESCRIPTION
Previously they were simply ignored, and not only them, but all the
tests in that group, here is an example [1]

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/51448/4ed462ac7834a8180f92ca7d7d3c076e687bfca9/integration_tests__asan__[4_6].html

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)