### PR TITLE
Fix logical assert in `tupleElement()` with default values

### DIFF
--- a/docs/en/sql-reference/functions/tuple-functions.md
+++ b/docs/en/sql-reference/functions/tuple-functions.md
@@ -22,14 +22,15 @@ tuple(x, y, …)
 
 A function that allows getting a column from a tuple.
 
-If the second argument is a number `n`, it is the column index, starting from 1. If the second argument is a string `s`, it represents the name of the element. Besides, we can provide the third optional argument, such that when index out of bounds or element for such name does not exist, the default value returned instead of throw exception. The second and third arguments if provided are always must be constant. There is no cost to execute the function.
+If the second argument is a number `index`, it is the column index, starting from 1. If the second argument is a string `name`, it represents the name of the element. Besides, we can provide the third optional argument, such that when index out of bounds or no element exist for the name, the default value returned instead of throwing an exception. The second and third arguments, if provided, must be constants. There is no cost to execute the function.
 
-The function implements the operator `x.n` and `x.s`.
+The function implements operators `x.index` and `x.name`.
 
 **Syntax**
 
 ``` sql
-tupleElement(tuple, n/s [, default_value])
+tupleElement(tuple, index, [, default_value])
+tupleElement(tuple, name, [, default_value])
 ```
 
 ## untuple

--- a/src/Common/assert_cast.h
+++ b/src/Common/assert_cast.h
@@ -23,7 +23,7 @@ namespace DB
   * The exact match of the type is checked. That is, cast to the ancestor will be unsuccessful.
   */
 template <typename To, typename From>
-To assert_cast(From && from)
+inline To assert_cast(From && from)
 {
 #ifndef NDEBUG
     try

--- a/src/Functions/tupleElement.cpp
+++ b/src/Functions/tupleElement.cpp
@@ -203,13 +203,15 @@ private:
         {
             const size_t index = index_column->getUInt(0);
 
-            if (index == 0)
-                throw Exception(ErrorCodes::ILLEGAL_INDEX, "Indices in tuples are 1-based.");
+            if (index > 0 && index <= tuple.getElements().size())
+                return {index - 1};
+            else
+            {
+                if (argument_size == 2)
+                    throw Exception(ErrorCodes::NOT_FOUND_COLUMN_IN_BLOCK, "Tuple doesn't have element with index '{}'", index);
+                return std::nullopt;
+            }
 
-            if (index > tuple.getElements().size())
-                throw Exception(ErrorCodes::ILLEGAL_INDEX, "Index for tuple element is out of range.");
-
-            return {index - 1};
         }
         else if (const auto * name_col = checkAndGetColumnConst<ColumnString>(index_column.get()))
         {

--- a/src/Functions/tupleElement.cpp
+++ b/src/Functions/tupleElement.cpp
@@ -34,32 +34,14 @@ class FunctionTupleElement : public IFunction
 {
 public:
     static constexpr auto name = "tupleElement";
-    static FunctionPtr create(ContextPtr)
-    {
-        return std::make_shared<FunctionTupleElement>();
-    }
 
-    String getName() const override
-    {
-        return name;
-    }
-
+    static FunctionPtr create(ContextPtr) { return std::make_shared<FunctionTupleElement>(); }
+    String getName() const override { return name; }
     bool isVariadic() const override { return true; }
-
-    size_t getNumberOfArguments() const override
-    {
-        return 0;
-    }
-
-    bool useDefaultImplementationForConstants() const override
-    {
-        return true;
-    }
-
+    size_t getNumberOfArguments() const override { return 0; }
+    bool useDefaultImplementationForConstants() const override { return true; }
     ColumnNumbers getArgumentsThatAreAlwaysConstant() const override { return {1}; }
-
     bool useDefaultImplementationForNulls() const override { return false; }
-
     bool isSuitableForShortCircuitArgumentsExecution(const DataTypesWithConstInfo & /*arguments*/) const override { return false; }
 
     DataTypePtr getReturnTypeImpl(const ColumnsWithTypeAndName & arguments) const override
@@ -72,107 +54,98 @@ public:
                             getName(), number_of_arguments);
 
         size_t count_arrays = 0;
-        const IDataType * tuple_col = arguments[0].type.get();
-        while (const DataTypeArray * array = checkAndGetDataType<DataTypeArray>(tuple_col))
+        const IDataType * input_type = arguments[0].type.get();
+        while (const DataTypeArray * array = checkAndGetDataType<DataTypeArray>(input_type))
         {
-            tuple_col = array->getNestedType().get();
+            input_type = array->getNestedType().get();
             ++count_arrays;
         }
 
-        const DataTypeTuple * tuple = checkAndGetDataType<DataTypeTuple>(tuple_col);
+        const DataTypeTuple * tuple = checkAndGetDataType<DataTypeTuple>(input_type);
         if (!tuple)
             throw Exception(ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT,
                 "First argument for function {} must be tuple or array of tuple. Actual {}",
                 getName(),
                 arguments[0].type->getName());
 
-        auto index = getElementNum(arguments[1].column, *tuple, number_of_arguments);
+        std::optional<size_t> index = getElementIndex(arguments[1].column, *tuple, number_of_arguments);
         if (index.has_value())
         {
-            DataTypePtr out_return_type = tuple->getElements()[index.value()];
+            DataTypePtr return_type = tuple->getElements()[index.value()];
 
             for (; count_arrays; --count_arrays)
-                out_return_type = std::make_shared<DataTypeArray>(out_return_type);
+                return_type = std::make_shared<DataTypeArray>(return_type);
 
-            return out_return_type;
+            return return_type;
         }
         else
         {
-            const IDataType * default_col = arguments[2].type.get();
-            size_t default_argument_count_arrays = 0;
-            if (const DataTypeArray * array = checkAndGetDataType<DataTypeArray>(default_col))
-            {
-                default_argument_count_arrays = array->getNumberOfDimensions();
-            }
+            const IDataType * default_type = arguments[2].type.get();
+            size_t default_count_arrays = 0;
 
-            if (count_arrays != default_argument_count_arrays)
-            {
+            if (const DataTypeArray * default_type_as_array = checkAndGetDataType<DataTypeArray>(default_type))
+                default_count_arrays = default_type_as_array->getNumberOfDimensions();
+
+            if (count_arrays != default_count_arrays)
                 throw Exception(ErrorCodes::NUMBER_OF_DIMENSIONS_MISMATCHED,
                                 "Dimension of types mismatched between first argument and third argument. "
                                 "Dimension of 1st argument: {}. "
-                                "Dimension of 3rd argument: {}.",count_arrays, default_argument_count_arrays);
-            }
+                                "Dimension of 3rd argument: {}", count_arrays, default_count_arrays);
+
             return arguments[2].type;
         }
     }
 
     ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr &, size_t input_rows_count) const override
     {
-        Columns array_offsets;
+        const auto & input_arg = arguments[0];
+        const IDataType * input_type = input_arg.type.get();
+        const IColumn * input_col = input_arg.column.get();
 
-        const auto & first_arg = arguments[0];
-
-        const IDataType * tuple_type = first_arg.type.get();
-        const IColumn * tuple_col = first_arg.column.get();
-        bool first_arg_is_const = false;
-        if (typeid_cast<const ColumnConst *>(tuple_col))
+        bool input_arg_is_const = false;
+        if (typeid_cast<const ColumnConst *>(input_col))
         {
-            tuple_col = assert_cast<const ColumnConst *>(tuple_col)->getDataColumnPtr().get();
-            first_arg_is_const = true;
+            input_col = assert_cast<const ColumnConst *>(input_col)->getDataColumnPtr().get();
+            input_arg_is_const = true;
         }
-        while (const DataTypeArray * array_type = checkAndGetDataType<DataTypeArray>(tuple_type))
-        {
-            const ColumnArray * array_col = assert_cast<const ColumnArray *>(tuple_col);
 
-            tuple_type = array_type->getNestedType().get();
-            tuple_col = &array_col->getData();
+        Columns array_offsets;
+        while (const DataTypeArray * array_type = checkAndGetDataType<DataTypeArray>(input_type))
+        {
+            const ColumnArray * array_col = assert_cast<const ColumnArray *>(input_col);
+
+            input_type = array_type->getNestedType().get();
+            input_col = &array_col->getData();
             array_offsets.push_back(array_col->getOffsetsPtr());
         }
 
-        const DataTypeTuple * tuple_type_concrete = checkAndGetDataType<DataTypeTuple>(tuple_type);
-        const ColumnTuple * tuple_col_concrete = checkAndGetColumn<ColumnTuple>(tuple_col);
-        if (!tuple_type_concrete || !tuple_col_concrete)
+        const DataTypeTuple * input_type_as_tuple = checkAndGetDataType<DataTypeTuple>(input_type);
+        const ColumnTuple * input_col_as_tuple = checkAndGetColumn<ColumnTuple>(input_col);
+        if (!input_type_as_tuple || !input_col_as_tuple)
             throw Exception(ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT,
-                "First argument for function {} must be tuple or array of tuple. Actual {}",
-                getName(),
-                first_arg.type->getName());
+                "First argument for function {} must be tuple or array of tuple. Actual {}", getName(), input_arg.type->getName());
 
-        auto index = getElementNum(arguments[1].column, *tuple_type_concrete, arguments.size());
+        std::optional<size_t> index = getElementIndex(arguments[1].column, *input_type_as_tuple, arguments.size());
 
         if (!index.has_value())
         {
             if (!array_offsets.empty())
-            {
                 recursiveCheckArrayOffsets(arguments[0].column, arguments[2].column, array_offsets.size());
-            }
             return arguments[2].column;
         }
 
-        ColumnPtr res = tuple_col_concrete->getColumns()[index.value()];
+        ColumnPtr res = input_col_as_tuple->getColumns()[index.value()];
 
         /// Wrap into Arrays
         for (auto it = array_offsets.rbegin(); it != array_offsets.rend(); ++it)
             res = ColumnArray::create(res, *it);
 
-        if (first_arg_is_const)
-        {
+        if (input_arg_is_const)
             res = ColumnConst::create(res, input_rows_count);
-        }
         return res;
     }
 
 private:
-
     void recursiveCheckArrayOffsets(ColumnPtr col_x, ColumnPtr col_y, size_t depth) const
     {
         for (size_t i = 1; i < depth; ++i)
@@ -187,22 +160,16 @@ private:
     void checkArrayOffsets(ColumnPtr col_x, ColumnPtr col_y) const
     {
         if (isColumnConst(*col_x))
-        {
             checkArrayOffsetsWithFirstArgConst(col_x, col_y);
-        }
         else if (isColumnConst(*col_y))
-        {
             checkArrayOffsetsWithFirstArgConst(col_y, col_x);
-        }
         else
         {
             const auto & array_x = *assert_cast<const ColumnArray *>(col_x.get());
             const auto & array_y = *assert_cast<const ColumnArray *>(col_y.get());
             if (!array_x.hasEqualOffsets(array_y))
-            {
                 throw Exception(ErrorCodes::SIZES_OF_ARRAYS_DONT_MATCH,
                                 "The argument 1 and argument 3 of function {} have different array sizes", getName());
-            }
         }
     }
 
@@ -220,23 +187,21 @@ private:
         size_t row_size = offsets_y.size();
         for (size_t row = 0; row < row_size; ++row)
         {
-            if (unlikely(offsets_x[0] != offsets_y[row] - prev_offset))
-            {
+            if (offsets_x[0] != offsets_y[row] - prev_offset)
                 throw Exception(ErrorCodes::SIZES_OF_ARRAYS_DONT_MATCH,
                                 "The argument 1 and argument 3 of function {} have different array sizes", getName());
-            }
             prev_offset = offsets_y[row];
         }
     }
 
-    std::optional<size_t> getElementNum(const ColumnPtr & index_column, const DataTypeTuple & tuple, const size_t argument_size) const
+    std::optional<size_t> getElementIndex(const ColumnPtr & index_column, const DataTypeTuple & tuple, size_t argument_size) const
     {
         if (checkAndGetColumnConst<ColumnUInt8>(index_column.get())
             || checkAndGetColumnConst<ColumnUInt16>(index_column.get())
             || checkAndGetColumnConst<ColumnUInt32>(index_column.get())
             || checkAndGetColumnConst<ColumnUInt64>(index_column.get()))
         {
-            size_t index = index_column->getUInt(0);
+            const size_t index = index_column->getUInt(0);
 
             if (index == 0)
                 throw Exception(ErrorCodes::ILLEGAL_INDEX, "Indices in tuples are 1-based.");
@@ -244,21 +209,20 @@ private:
             if (index > tuple.getElements().size())
                 throw Exception(ErrorCodes::ILLEGAL_INDEX, "Index for tuple element is out of range.");
 
-            return std::optional<size_t>(index - 1);
+            return {index - 1};
         }
         else if (const auto * name_col = checkAndGetColumnConst<ColumnString>(index_column.get()))
         {
-            auto index = tuple.tryGetPositionByName(name_col->getValue<String>());
-            if (index.has_value())
-            {
-                return index;
-            }
+            std::optional<size_t> index = tuple.tryGetPositionByName(name_col->getValue<String>());
 
-            if (argument_size == 2)
+            if (index.has_value())
+                return index;
+            else
             {
-                throw Exception(ErrorCodes::NOT_FOUND_COLUMN_IN_BLOCK, "Tuple doesn't have element with name '{}'", name_col->getValue<String>());
+                if (argument_size == 2)
+                    throw Exception(ErrorCodes::NOT_FOUND_COLUMN_IN_BLOCK, "Tuple doesn't have element with name '{}'", name_col->getValue<String>());
+                return std::nullopt;
             }
-            return std::nullopt;
         }
         else
             throw Exception(ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT,

--- a/tests/queries/0_stateless/02116_tuple_element.sql
+++ b/tests/queries/0_stateless/02116_tuple_element.sql
@@ -14,12 +14,12 @@ EXPLAIN SYNTAX SELECT tupleElement(t1, 2) FROM t_tuple_element;
 SELECT tupleElement(t1, 'a') FROM t_tuple_element;
 EXPLAIN SYNTAX SELECT tupleElement(t1, 'a') FROM t_tuple_element;
 
-SELECT tupleElement(number, 1) FROM numbers(1); -- { serverError 43 }
-SELECT tupleElement(t1) FROM t_tuple_element; -- { serverError 42 }
-SELECT tupleElement(t1, 'b') FROM t_tuple_element; -- { serverError 10, 47 }
-SELECT tupleElement(t1, 0) FROM t_tuple_element; -- { serverError 127 }
-SELECT tupleElement(t1, 3) FROM t_tuple_element; -- { serverError 127 }
-SELECT tupleElement(t1, materialize('a')) FROM t_tuple_element; -- { serverError 43 }
+SELECT tupleElement(number, 1) FROM numbers(1); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+SELECT tupleElement(t1) FROM t_tuple_element; -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }
+SELECT tupleElement(t1, 'b') FROM t_tuple_element; -- { serverError NOT_FOUND_COLUMN_IN_BLOCK, UNKNOWN_IDENTIFIER }
+SELECT tupleElement(t1, 0) FROM t_tuple_element; -- { serverError ILLEGAL_INDEX }
+SELECT tupleElement(t1, 3) FROM t_tuple_element; -- { serverError ILLEGAL_INDEX }
+SELECT tupleElement(t1, materialize('a')) FROM t_tuple_element; -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
 
 SELECT t2.1 FROM t_tuple_element;
 EXPLAIN SYNTAX SELECT t2.1 FROM t_tuple_element;
@@ -27,11 +27,11 @@ EXPLAIN SYNTAX SELECT t2.1 FROM t_tuple_element;
 SELECT tupleElement(t2, 1) FROM t_tuple_element;
 EXPLAIN SYNTAX SELECT tupleElement(t2, 1) FROM t_tuple_element;
 
-SELECT tupleElement(t2) FROM t_tuple_element; -- { serverError 42 }
-SELECT tupleElement(t2, 'a') FROM t_tuple_element; -- { serverError 10, 47 }
-SELECT tupleElement(t2, 0) FROM t_tuple_element; -- { serverError 127 }
-SELECT tupleElement(t2, 3) FROM t_tuple_element; -- { serverError 127 }
-SELECT tupleElement(t2, materialize(1)) FROM t_tuple_element; -- { serverError 43 }
+SELECT tupleElement(t2) FROM t_tuple_element; -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }
+SELECT tupleElement(t2, 'a') FROM t_tuple_element; -- { serverError NOT_FOUND_COLUMN_IN_BLOCK, UNKNOWN_IDENTIFIER }
+SELECT tupleElement(t2, 0) FROM t_tuple_element; -- { serverError ILLEGAL_INDEX }
+SELECT tupleElement(t2, 3) FROM t_tuple_element; -- { serverError ILLEGAL_INDEX }
+SELECT tupleElement(t2, materialize(1)) FROM t_tuple_element; -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
 
 DROP TABLE t_tuple_element;
 

--- a/tests/queries/0_stateless/02286_tuple_numeric_identifier.sql
+++ b/tests/queries/0_stateless/02286_tuple_numeric_identifier.sql
@@ -12,8 +12,8 @@ SELECT * FROM t_tuple_numeric FORMAT JSONEachRow;
 SELECT `t`.`1`.`2`, `t`.`1`.`3`, `t`.`4` FROM t_tuple_numeric;
 SELECT t.1.1, t.1.2, t.2 FROM t_tuple_numeric;
 
-SELECT t.1.3 FROM t_tuple_numeric; -- {serverError ILLEGAL_INDEX}
-SELECT t.4 FROM t_tuple_numeric; -- {serverError ILLEGAL_INDEX}
+SELECT t.1.3 FROM t_tuple_numeric; -- {serverError NOT_FOUND_COLUMN_IN_BLOCK}
+SELECT t.4 FROM t_tuple_numeric; -- {serverError NOT_FOUND_COLUMN_IN_BLOCK}
 SELECT `t`.`1`.`1`, `t`.`1`.`2`, `t`.`2` FROM t_tuple_numeric; -- {serverError UNKNOWN_IDENTIFIER}
 
 DROP TABLE t_tuple_numeric;

--- a/tests/queries/0_stateless/02354_tuple_element_with_default.reference
+++ b/tests/queries/0_stateless/02354_tuple_element_with_default.reference
@@ -1,28 +1,15 @@
-z
-SELECT tupleElement(t1, \'z\', \'z\')
-FROM t_tuple_element_default
-0
-SELECT tupleElement(t1, \'z\', 0)
-FROM t_tuple_element_default
-z
-SELECT tupleElement(t2, \'z\', \'z\')
-FROM t_tuple_element_default
-z
-z
---------------------
-[(3,4)]
-SELECT tupleElement([(1, 2)], \'a\', [(3, 4)])
---------------------
-SELECT tupleElement(t1, \'a\', [tuple(1)])
-FROM t_tuple_element_default
---------------------
-[(0)]
-SELECT tupleElement(t1, \'a\', [tuple(0)])
-FROM t_tuple_element_default
-[0]
-SELECT tupleElement(t1, \'a\', [0])
-FROM t_tuple_element_default
-[0]
-[0]
-SELECT tupleElement(t1, \'a\', [0])
-FROM t_tuple_element_default
+hello
+world
+default
+default
+[(['a'],1)]
+[1,3]
+[2,4]
+default
+--------
+hello
+world
+default
+default
+[(['a'],1)]
+[[1,2,3]]

--- a/tests/queries/0_stateless/02354_tuple_element_with_default.reference
+++ b/tests/queries/0_stateless/02354_tuple_element_with_default.reference
@@ -7,6 +7,8 @@ FROM t_tuple_element_default
 z
 SELECT tupleElement(t2, \'z\', \'z\')
 FROM t_tuple_element_default
+z
+z
 --------------------
 [(3,4)]
 SELECT tupleElement([(1, 2)], \'a\', [(3, 4)])

--- a/tests/queries/0_stateless/02354_tuple_element_with_default.sql
+++ b/tests/queries/0_stateless/02354_tuple_element_with_default.sql
@@ -1,50 +1,23 @@
-DROP TABLE IF EXISTS t_tuple_element_default;
+-- const tuple argument
 
-CREATE TABLE t_tuple_element_default(t1 Tuple(a UInt32, s String), t2 Tuple(UInt32, String)) ENGINE = Memory;
-INSERT INTO t_tuple_element_default VALUES ((1, 'a'), (2, 'b'));
+SELECT tupleElement(('hello', 'world'), 1, 'default');
+SELECT tupleElement(('hello', 'world'), 2, 'default');
+SELECT tupleElement(('hello', 'world'), 3, 'default');
+SELECT tupleElement(('hello', 'world'), 'xyz', 'default');
+SELECT tupleElement(('hello', 'world'), 3, [([('a')], 1)]); -- arbitrary default value
 
-SELECT tupleElement(t1, 'z', 'z') FROM t_tuple_element_default;
-EXPLAIN SYNTAX SELECT tupleElement(t1, 'z', 'z') FROM t_tuple_element_default;
-SELECT tupleElement(t1, 'z', 0) FROM t_tuple_element_default;
-EXPLAIN SYNTAX SELECT tupleElement(t1, 'z', 0) FROM t_tuple_element_default;
-SELECT tupleElement(t2, 'z', 'z') FROM t_tuple_element_default;
-EXPLAIN SYNTAX SELECT tupleElement(t2, 'z', 'z') FROM t_tuple_element_default;
+SELECT tupleElement([(1, 2), (3, 4)], 1, 'default');
+SELECT tupleElement([(1, 2), (3, 4)], 2, 'default');
+SELECT tupleElement([(1, 2), (3, 4)], 3, 'default');
 
-SELECT tupleElement(t1, 3, 'z') FROM t_tuple_element_default;
-SELECT tupleElement(t1, 0, 'z') FROM t_tuple_element_default;
+SELECT '--------';
 
-DROP TABLE t_tuple_element_default;
+-- non-const tuple argument
 
-SELECT '--------------------';
+SELECT tupleElement(materialize(('hello', 'world')), 1, 'default');
+SELECT tupleElement(materialize(('hello', 'world')), 2, 'default');
+SELECT tupleElement(materialize(('hello', 'world')), 3, 'default');
+SELECT tupleElement(materialize(('hello', 'world')), 'xzy', 'default');
+SELECT tupleElement(materialize(('hello', 'world')), 'xzy', [([('a')], 1)]); -- arbitrary default value
 
-SELECT tupleElement(array(tuple(1, 2)), 'a', 0); -- { serverError NUMBER_OF_DIMENSIONS_MISMATCHED }
-SELECT tupleElement(array(tuple(1, 2)), 'a', array(tuple(1, 2), tuple(3, 4))); -- { serverError SIZES_OF_ARRAYS_DONT_MATCH }
-SELECT tupleElement(array(array(tuple(1))), 'a', array(array(1, 2, 3))); -- { serverError SIZES_OF_ARRAYS_DONT_MATCH }
-
-SELECT tupleElement(array(tuple(1, 2)), 'a', array(tuple(3, 4)));
-EXPLAIN SYNTAX SELECT tupleElement(array(tuple(1, 2)), 'a', array(tuple(3, 4)));
-
-SELECT '--------------------';
-
-CREATE TABLE t_tuple_element_default(t1 Array(Tuple(UInt32)), t2 UInt32) ENGINE = Memory;
-
-SELECT tupleElement(t1, 'a', array(tuple(1))) FROM t_tuple_element_default;
-EXPLAIN SYNTAX SELECT tupleElement(t1, 'a', array(tuple(1))) FROM t_tuple_element_default;
-
-SELECT '--------------------';
-
-INSERT INTO t_tuple_element_default VALUES ([(1)], 100);
-
-SELECT tupleElement(t1, 'a', array(tuple(0))) FROM t_tuple_element_default;
-EXPLAIN SYNTAX SELECT tupleElement(t1, 'a', array(tuple(0))) FROM t_tuple_element_default;
-
-SELECT tupleElement(t1, 'a', array(0)) FROM t_tuple_element_default;
-EXPLAIN SYNTAX SELECT tupleElement(t1, 'a', array(0)) FROM t_tuple_element_default;
-
-INSERT INTO t_tuple_element_default VALUES ([(2)], 200);
-
-SELECT tupleElement(t1, 'a', array(0)) FROM t_tuple_element_default;
-EXPLAIN SYNTAX SELECT tupleElement(t1, 'a', array(0)) FROM t_tuple_element_default;
-
-DROP TABLE t_tuple_element_default;
-
+SELECT tupleElement([[(count('2147483646'), 1)]], 'aaaa', [[1, 2, 3]]) -- bug #51525

--- a/tests/queries/0_stateless/02354_tuple_element_with_default.sql
+++ b/tests/queries/0_stateless/02354_tuple_element_with_default.sql
@@ -10,16 +10,16 @@ EXPLAIN SYNTAX SELECT tupleElement(t1, 'z', 0) FROM t_tuple_element_default;
 SELECT tupleElement(t2, 'z', 'z') FROM t_tuple_element_default;
 EXPLAIN SYNTAX SELECT tupleElement(t2, 'z', 'z') FROM t_tuple_element_default;
 
-SELECT tupleElement(t1, 3, 'z') FROM t_tuple_element_default; -- { serverError 127 }
-SELECT tupleElement(t1, 0, 'z') FROM t_tuple_element_default; -- { serverError 127 }
+SELECT tupleElement(t1, 3, 'z') FROM t_tuple_element_default; -- { serverError ILLEGAL_INDEX }
+SELECT tupleElement(t1, 0, 'z') FROM t_tuple_element_default; -- { serverError ILLEGAL_INDEX }
 
 DROP TABLE t_tuple_element_default;
 
 SELECT '--------------------';
 
-SELECT tupleElement(array(tuple(1, 2)), 'a', 0); -- { serverError 645 }
-SELECT tupleElement(array(tuple(1, 2)), 'a', array(tuple(1, 2), tuple(3, 4))); -- { serverError 190 }
-SELECT tupleElement(array(array(tuple(1))), 'a', array(array(1, 2, 3))); -- { serverError 190 }
+SELECT tupleElement(array(tuple(1, 2)), 'a', 0); -- { serverError NUMBER_OF_DIMENSIONS_MISMATCHED }
+SELECT tupleElement(array(tuple(1, 2)), 'a', array(tuple(1, 2), tuple(3, 4))); -- { serverError SIZES_OF_ARRAYS_DONT_MATCH }
+SELECT tupleElement(array(array(tuple(1))), 'a', array(array(1, 2, 3))); -- { serverError SIZES_OF_ARRAYS_DONT_MATCH }
 
 SELECT tupleElement(array(tuple(1, 2)), 'a', array(tuple(3, 4)));
 EXPLAIN SYNTAX SELECT tupleElement(array(tuple(1, 2)), 'a', array(tuple(3, 4)));

--- a/tests/queries/0_stateless/02354_tuple_element_with_default.sql
+++ b/tests/queries/0_stateless/02354_tuple_element_with_default.sql
@@ -10,8 +10,8 @@ EXPLAIN SYNTAX SELECT tupleElement(t1, 'z', 0) FROM t_tuple_element_default;
 SELECT tupleElement(t2, 'z', 'z') FROM t_tuple_element_default;
 EXPLAIN SYNTAX SELECT tupleElement(t2, 'z', 'z') FROM t_tuple_element_default;
 
-SELECT tupleElement(t1, 3, 'z') FROM t_tuple_element_default; -- { serverError ILLEGAL_INDEX }
-SELECT tupleElement(t1, 0, 'z') FROM t_tuple_element_default; -- { serverError ILLEGAL_INDEX }
+SELECT tupleElement(t1, 3, 'z') FROM t_tuple_element_default;
+SELECT tupleElement(t1, 0, 'z') FROM t_tuple_element_default;
 
 DROP TABLE t_tuple_element_default;
 


### PR DESCRIPTION
Closes #51525

(same as #51535 but against many-fixes-2)

This PR does two things (besides an extra commit with cosmetics):
1. `tupleElement()` now returns the default value if the index argument is out-of-bounds and a default value is given (it previously threw an exception). This aligns the documented and expected behavior with the actual behavior. Note that we continue to throw an exception if the index argument is out-of-bounds and *no* default value is given.
2. `tupleElement()` now allows default values of arbitrary type, fixing #51525 as a side effect. This logical error happened in a sanity check which made sure that an input value of `Array` type has the same size (element count) as the (`Array`) default value. There was some discussion about this in the [original PR](https://github.com/ClickHouse/ClickHouse/pull/38989) but I don't really understand why this restriction is necessary. On the one hand, lifting it simplifies the code \+ will allow useful statements like `SELECT tupleElement([(1, 2), (3, 4)], 'no column name', 'invalid column')`, on the other hand, operators `tuple.index`, `tuple.name`, `array.index` and `array.name` are not affected anyways as they don't use default values.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix a logical assert in "tupleElement()" with default values