### PR TITLE
fix trap usage in 01443_merge_truncate_long.sh

### DIFF
--- a/tests/queries/0_stateless/01443_merge_truncate_long.sh
+++ b/tests/queries/0_stateless/01443_merge_truncate_long.sh
@@ -23,7 +23,8 @@ function thread()
     done
 }
 
-thread &
+export -f thread
+bash -c thread &
 pid=$!
 
 for i in {1..100}; do


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

it is better to have a separate process to set up a tap. Otherwise there are a tricky rules who handles the signal.

stats:
https://play.clickhouse.com/play?user=play#c2VsZWN0IAp0b1N0YXJ0T2ZIb3VyKGNoZWNrX3N0YXJ0X3RpbWUpIGFzIGQsCmNvdW50KCksICBncm91cFVuaXFBcnJheShwdWxsX3JlcXVlc3RfbnVtYmVyKSwgIGFueShyZXBvcnRfdXJsKQpmcm9tIGNoZWNrcyB3aGVyZSAnMjAyMi0wNi0wMScgPD0gY2hlY2tfc3RhcnRfdGltZSBhbmQgdGVzdF9uYW1lIGxpa2UgJyUwMTQ0M19tZXJnZV90cnVuY2F0ZV9sb25nJScgYW5kIHRlc3Rfc3RhdHVzIGluICgnRkFJTCcsICdGTEFLWScpIGdyb3VwIGJ5IGQgb3JkZXIgYnkgZCBkZXNj

for now test is hung:
https://s3.amazonaws.com/clickhouse-test-reports/0/b5128bfaa620931a75db3cad11d50564938a733c/stateless_tests__debug__[3_5].html