### PR TITLE
tests: fix 01111_create_drop_replicated_db_stress flakiness

### DIFF
--- a/tests/queries/0_stateless/01111_create_drop_replicated_db_stress.sh
+++ b/tests/queries/0_stateless/01111_create_drop_replicated_db_stress.sh
@@ -64,7 +64,7 @@ function alter_table()
         if [ -z "$table" ]; then continue; fi
         $CLICKHOUSE_CLIENT --distributed_ddl_task_timeout=0 -q \
         "alter table $table update n = n + (select max(n) from merge(REGEXP('${CLICKHOUSE_DATABASE}.*'), '.*')) where 1 settings allow_nondeterministic_mutations=1" \
-        2>&1| grep -Fa "Exception: " | grep -Fv "Cannot enqueue query" | grep -Fv "ZooKeeper session expired" | grep -Fv UNKNOWN_DATABASE | grep -Fv UNKNOWN_TABLE | grep -Fv TABLE_IS_READ_ONLY | grep -Fv TABLE_IS_DROPPED
+        2>&1| grep -Fa "Exception: " | grep -Fv "Cannot enqueue query" | grep -Fv "ZooKeeper session expired" | grep -Fv -e UNKNOWN_DATABASE -e UNKNOWN_TABLE -e TABLE_IS_READ_ONLY -e TABLE_IS_DROPPED -e "Error while executing table function merge. Either there is no database, which matches regular expression"
         sleep 0.$RANDOM
     done
 }


### PR DESCRIPTION
Ignore one more error in this test, since it is possible to run this merge() function w/o any tables, which will fail with:

    Error while executing table function merge. Either there is no database, which matches regular expression `default.*`, or there are no tables in database matches `default.*`, which fit tables expression:

CI: https://s3.amazonaws.com/clickhouse-test-reports/51359/4b0b4fad7c2f5fc892b5d54c22ff22a3def6d64c/stateless_tests__ubsan__[1_2].html

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)