### PR TITLE
[do not merge] Try fix encoding in clickhouse-test

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -1070,7 +1070,7 @@ class TestCase:
                     self.reference_file,
                     self.stdout_file,
                 ],
-                encoding="latin-1",
+                encoding="utf-8",
                 stdout=PIPE,
                 universal_newlines=True,
             ).communicate()[0]

--- a/tests/queries/0_stateless/02790_sql_standard_fetch.sql
+++ b/tests/queries/0_stateless/02790_sql_standard_fetch.sql
@@ -4,28 +4,28 @@ CREATE TEMPORARY TABLE employees (id UInt64, name String, department String, sal
 INSERT INTO employees VALUES (23, 'Henry', 'it', 104), (24, 'Irene', 'it', 104), (25, 'Frank', 'it', 120), (31, 'Cindy', 'sales', 96), (33, 'Alice', 'sales', 100), (32, 'Dave', 'sales', 96), (22, 'Grace', 'it', 90), (21, 'Emma', 'it', '84');
 
 select * from employees
-order by salary desc
+order by salary desc, id asc
 limit 5
 format PrettyCompactNoEscapes;
 
 select * from employees
-order by salary desc
+order by salary desc, id asc
 fetch first 5 rows only
 format PrettyCompactNoEscapes;
 
 select * from employees
-order by salary desc
+order by salary desc, id asc
 fetch first 5 rows with ties
 format PrettyCompactNoEscapes;
 
 select * from employees
-order by salary desc
+order by salary desc, id asc
 offset 3 rows
 fetch next 5 rows only
 format PrettyCompactNoEscapes;
 
 select * from employees
-order by salary desc
+order by salary desc, id asc
 offset 3 rows
 fetch first 5 rows only
 format PrettyCompactNoEscapes;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

example of bad output
https://s3.amazonaws.com/clickhouse-test-reports/51293/ddf60a2d3080fab24401bad1090db4531e17c58d/stateless_tests__debug__[5_5].html

if my change here is OK, I will either merge it to the https://github.com/ClickHouse/ClickHouse/pull/51293 or make independent PR 

The motivation of the changes:
- sometimes client produces wrong utf-8, when the data was generated by random for example as a string type
- clickhouse-test should read the diff result with utf-8 encoding as well as we read client output in utf-8
