### PR TITLE
Update timeouts in tests for transactions

### DIFF
--- a/tests/queries/0_stateless/01169_alter_partition_isolation_stress.sh
+++ b/tests/queries/0_stateless/01169_alter_partition_isolation_stress.sh
@@ -240,7 +240,7 @@ kill -TERM $PID_1
 kill -TERM $PID_2
 wait ||:
 
-wait_for_queries_to_finish
+wait_for_queries_to_finish 40
 
 $CLICKHOUSE_CLIENT -q "SELECT type, count(n) = countDistinct(n) FROM merge(currentDatabase(), '') GROUP BY type ORDER BY type"
 $CLICKHOUSE_CLIENT -q "SELECT DISTINCT arraySort(groupArrayIf(n, type=1)) = arraySort(groupArrayIf(n, type=2)) FROM merge(currentDatabase(), '') GROUP BY _table ORDER BY _table"

--- a/tests/queries/0_stateless/01171_mv_select_insert_isolation_long.sh
+++ b/tests/queries/0_stateless/01171_mv_select_insert_isolation_long.sh
@@ -131,7 +131,7 @@ kill -TERM $PID_6
 kill -TERM $PID_7
 kill -TERM $PID_8
 wait
-wait_for_queries_to_finish
+wait_for_queries_to_finish 40
 
 $CLICKHOUSE_CLIENT --multiquery --query "
 BEGIN TRANSACTION;

--- a/tests/queries/0_stateless/01174_select_insert_isolation.sh
+++ b/tests/queries/0_stateless/01174_select_insert_isolation.sh
@@ -56,7 +56,7 @@ thread_select & PID_4=$!
 wait $PID_1 && wait $PID_2 && wait $PID_3
 kill -TERM $PID_4
 wait
-wait_for_queries_to_finish
+wait_for_queries_to_finish 40
 
 $CLICKHOUSE_CLIENT --multiquery --query "
 BEGIN TRANSACTION;


### PR DESCRIPTION

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


https://s3.amazonaws.com/clickhouse-test-reports/0/7028f9e3972374d4e81cf38236a21cf14bcddfcf/stateless_tests__aarch64_.html

Sometimes the query gets stuck for 20 seconds on ARM, it's not clear why because stacktraces on ARM are broken: https://pastila.nl/?008f2568/b3d013bd4eeca18f3d341d07b1bb0f2a