### PR TITLE
Make test scripts backwards compatible

### DIFF
--- a/tests/ci/utils.lib
+++ b/tests/ci/utils.lib
@@ -23,3 +23,7 @@ function run_with_retry()
     echo "Command '$*' failed after $total_retries retries, exiting"
     exit 1
 }
+
+function fn_exists() {
+    declare -F "$1" > /dev/null;
+}


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


https://github.com/ClickHouse/ClickHouse/pull/51688 broke builds for older commits.

cc @Felixoid 

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
