### PR TITLE
#51292 added default_temporary_table_engine setting

### DIFF
--- a/docs/en/operations/settings/settings.md
+++ b/docs/en/operations/settings/settings.md
@@ -3203,7 +3203,7 @@ ENGINE = Log
 
 ## default_temporary_table_engine {#default_temporary_table_engine}
 
-Same as [default_temporary_table_engine](#default_temporary_table_engine) but for temporary tables.
+Same as [default_table_engine](#default_table_engine) but for temporary tables.
 
 Default value: `Memory`.
 

--- a/docs/en/operations/settings/settings.md
+++ b/docs/en/operations/settings/settings.md
@@ -3201,6 +3201,40 @@ ENGINE = Log
 └──────────────────────────────────────────────────────────────────────────┘
 ```
 
+## default_temporary_table_engine {#default_temporary_table_engine}
+
+Same as [default_temporary_table_engine](#default_temporary_table_engine) but for temporary tables.
+
+Default value: `Memory`.
+
+In this example, any new temporary table that does not specify an `Engine` will use the `Log` table engine:
+
+Query:
+
+```sql
+SET default_temporary_table_engine = 'Log';
+
+CREATE TEMPORARY TABLE my_table (
+    x UInt32,
+    y UInt32
+);
+
+SHOW CREATE TEMPORARY TABLE my_table;
+```
+
+Result:
+
+```response
+┌─statement────────────────────────────────────────────────────────────────┐
+│ CREATE TEMPORARY TABLE default.my_table
+(
+    `x` UInt32,
+    `y` UInt32
+)
+ENGINE = Log
+└──────────────────────────────────────────────────────────────────────────┘
+```
+
 ## data_type_default_nullable {#data_type_default_nullable}
 
 Allows data types without explicit modifiers [NULL or NOT NULL](../../sql-reference/statements/create/table.md/#null-modifiers) in column definition will be [Nullable](../../sql-reference/data-types/nullable.md/#data_type-nullable).

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -517,6 +517,7 @@ class IColumn;
     M(Seconds, wait_for_window_view_fire_signal_timeout, 10, "Timeout for waiting for window view fire signal in event time processing", 0) \
     M(UInt64, min_free_disk_space_for_temporary_data, 0, "The minimum disk space to keep while writing temporary data used in external sorting and aggregation.", 0) \
     \
+    M(DefaultTableEngine, default_temporary_table_engine, DefaultTableEngine::Memory, "Default table engine used when ENGINE is not set in CREATE TEMPORARY statement.",0) \
     M(DefaultTableEngine, default_table_engine, DefaultTableEngine::None, "Default table engine used when ENGINE is not set in CREATE statement.",0) \
     M(Bool, show_table_uuid_in_table_create_query_if_not_nil, false, "For tables in databases with Engine=Atomic show UUID of the table in its CREATE query.", 0) \
     M(Bool, database_atomic_wait_for_drop_and_detach_synchronously, false, "When executing DROP or DETACH TABLE in Atomic database, wait for table data to be finally dropped or detached.", 0) \

--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -881,13 +881,16 @@ void InterpreterCreateQuery::validateTableStructure(const ASTCreateQuery & creat
     }
 }
 
-namespace {
-    void checkTemporaryTableEngineName(const String& name) {
+namespace
+{
+    void checkTemporaryTableEngineName(const String& name)
+    {
         if (name.starts_with("Replicated") || name == "KeeperMap")
             throw Exception(ErrorCodes::INCORRECT_QUERY, "Temporary tables cannot be created with Replicated or KeeperMap table engines");
     }
 
-    void setDefaultTableEngine(ASTStorage &storage, DefaultTableEngine engine) {
+    void setDefaultTableEngine(ASTStorage &storage, DefaultTableEngine engine)
+    {
         if (engine == DefaultTableEngine::None)
             throw Exception(ErrorCodes::ENGINE_REQUIRED, "Table engine is not specified in CREATE query");
 

--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -914,9 +914,7 @@ void InterpreterCreateQuery::setEngine(ASTCreateQuery & create) const
 
     if (create.temporary)
     {
-        /// It's possible if some part of storage definition (such as PARTITION BY) is specified, but ENGINE is not.
-        /// It makes sense when default_table_engine setting is used, but not for temporary tables.
-        /// For temporary tables we ignore this setting to allow CREATE TEMPORARY TABLE query without specifying ENGINE
+        /// Some part of storage definition is specified, but ENGINE is not: just set the one from default_temporary_table_engine setting.
 
         if (!create.cluster.empty())
             throw Exception(ErrorCodes::INCORRECT_QUERY, "Temporary tables cannot be created with ON CLUSTER clause");

--- a/src/Interpreters/InterpreterCreateQuery.h
+++ b/src/Interpreters/InterpreterCreateQuery.h
@@ -90,8 +90,6 @@ private:
     /// Calculate list of columns, constraints, indices, etc... of table. Rewrite query in canonical way.
     TableProperties getTablePropertiesAndNormalizeCreateQuery(ASTCreateQuery & create) const;
     void validateTableStructure(const ASTCreateQuery & create, const TableProperties & properties) const;
-    static String getTableEngineName(DefaultTableEngine default_table_engine);
-    static void setDefaultTableEngine(ASTStorage & storage, DefaultTableEngine engine);
     void setEngine(ASTCreateQuery & create) const;
     AccessRightsElements getRequiredAccess() const;
 

--- a/src/Interpreters/InterpreterCreateQuery.h
+++ b/src/Interpreters/InterpreterCreateQuery.h
@@ -91,7 +91,7 @@ private:
     TableProperties getTablePropertiesAndNormalizeCreateQuery(ASTCreateQuery & create) const;
     void validateTableStructure(const ASTCreateQuery & create, const TableProperties & properties) const;
     static String getTableEngineName(DefaultTableEngine default_table_engine);
-    static void setDefaultTableEngine(ASTStorage & storage, ContextPtr local_context);
+    static void setDefaultTableEngine(ASTStorage & storage, DefaultTableEngine engine);
     void setEngine(ASTCreateQuery & create) const;
     AccessRightsElements getRequiredAccess() const;
 

--- a/tests/queries/0_stateless/02184_default_table_engine.reference
+++ b/tests/queries/0_stateless/02184_default_table_engine.reference
@@ -27,3 +27,4 @@ CREATE TABLE default.val2\n(\n    `n` Int32\n) AS values(\'n int\', 1, 2)
 CREATE TABLE default.log\n(\n    `n` Int32\n)\nENGINE = Log
 CREATE TABLE default.kek\n(\n    `n` Int32\n)\nENGINE = Memory
 CREATE TABLE default.lol\n(\n    `n` Int32\n)\nENGINE = MergeTree\nORDER BY n\nSETTINGS min_bytes_for_wide_part = 123, index_granularity = 8192
+CREATE TEMPORARY TABLE tmp_log\n(\n    `n` Int32\n)\nENGINE = Log

--- a/tests/queries/0_stateless/02184_default_table_engine.sql
+++ b/tests/queries/0_stateless/02184_default_table_engine.sql
@@ -83,8 +83,8 @@ CREATE TEMPORARY TABLE tmp (n int);
 SHOW CREATE TEMPORARY TABLE tmp;
 CREATE TEMPORARY TABLE tmp1 (n int) ENGINE=Memory;
 CREATE TEMPORARY TABLE tmp2 (n int) ENGINE=Log;
-CREATE TEMPORARY TABLE tmp2 (n int) ORDER BY n; -- {serverError 80}
-CREATE TEMPORARY TABLE tmp2 (n int, PRIMARY KEY (n)); -- {serverError 80}
+CREATE TEMPORARY TABLE tmp2 (n int) ORDER BY n; -- {serverError 36}
+CREATE TEMPORARY TABLE tmp2 (n int, PRIMARY KEY (n)); -- {serverError 36}
 
 CREATE TABLE log (n int);
 SHOW CREATE log;

--- a/tests/queries/0_stateless/02184_default_table_engine.sql
+++ b/tests/queries/0_stateless/02184_default_table_engine.sql
@@ -128,3 +128,7 @@ SHOW CREATE TABLE kek;
 SHOW CREATE TABLE lol;
 DROP TABLE kek;
 DROP TABLE lol;
+
+SET default_temporary_table_engine = 'Log';
+CREATE TEMPORARY TABLE tmp_log (n int);
+SHOW CREATE TEMPORARY TABLE tmp_log;


### PR DESCRIPTION
### Changelog category (leave one):
- New Feature


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Added `default_temporary_table_engine` setting. Same as `default_table_engine` but for temporary tables. #51292

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
