### PR TITLE
use mold in fasttest builds

### DIFF
--- a/docker/test/fasttest/Dockerfile
+++ b/docker/test/fasttest/Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get update \
         unixodbc \
         pv \
         zstd \
+        mold \
     --yes --no-install-recommends
 
 RUN pip3 install numpy scipy pandas Jinja2

--- a/docker/test/fasttest/run.sh
+++ b/docker/test/fasttest/run.sh
@@ -171,6 +171,7 @@ function run_cmake
         "-DENABLE_SIMDJSON=1"
         "-DENABLE_JEMALLOC=1"
         "-DENABLE_LIBURING=1"
+        "-DLINKER_NAME=mold"
     )
 
     export CCACHE_DIR="$FASTTEST_WORKSPACE/ccache"


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry

Use mold for fasttest builds to reduce linking time.