### PR TITLE
CacheDictionary request only unique keys from source

### DIFF
--- a/src/Dictionaries/CacheDictionary.cpp
+++ b/src/Dictionaries/CacheDictionary.cpp
@@ -549,12 +549,12 @@ void CacheDictionary<dictionary_key_type>::update(CacheDictionaryUpdateUnitPtr<d
 
     for (size_t i = 0; i < key_index_to_state_from_storage.size(); ++i)
     {
-        if (key_index_to_state_from_storage[i].isExpired()
-            || key_index_to_state_from_storage[i].isNotFound())
+        if (key_index_to_state_from_storage[i].isExpired() || key_index_to_state_from_storage[i].isNotFound())
         {
             auto requested_key = requested_keys[i];
             auto [_, inserted] = not_found_keys.insert(requested_key);
-            if (inserted) {
+            if (inserted)
+            {
                 if constexpr (dictionary_key_type == DictionaryKeyType::Simple)
                     requested_keys_vector.emplace_back(requested_keys[i]);
                 else

--- a/src/Dictionaries/CacheDictionary.cpp
+++ b/src/Dictionaries/CacheDictionary.cpp
@@ -552,13 +552,14 @@ void CacheDictionary<dictionary_key_type>::update(CacheDictionaryUpdateUnitPtr<d
         if (key_index_to_state_from_storage[i].isExpired()
             || key_index_to_state_from_storage[i].isNotFound())
         {
-            if constexpr (dictionary_key_type == DictionaryKeyType::Simple)
-                requested_keys_vector.emplace_back(requested_keys[i]);
-            else
-                requested_complex_key_rows.emplace_back(i);
-
             auto requested_key = requested_keys[i];
-            not_found_keys.insert(requested_key);
+            auto [_, inserted] = not_found_keys.insert(requested_key);
+            if (inserted) {
+                if constexpr (dictionary_key_type == DictionaryKeyType::Simple)
+                    requested_keys_vector.emplace_back(requested_keys[i]);
+                else
+                    requested_complex_key_rows.emplace_back(i);
+            }
         }
     }
 


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
CacheDictionary request only unique keys from source. Closes #51762. 

