### PR TITLE
Pin rust nightly (to make it stable)

### DIFF
--- a/docker/packager/binary/Dockerfile
+++ b/docker/packager/binary/Dockerfile
@@ -49,8 +49,8 @@ ENV CARGO_HOME=/rust/cargo
 ENV PATH="/rust/cargo/bin:${PATH}"
 RUN curl https://sh.rustup.rs -sSf | bash -s -- -y && \
     chmod 777 -R /rust && \
-    rustup toolchain install nightly && \
-    rustup default nightly && \
+    rustup toolchain install nightly-2023-07-04 && \
+    rustup default nightly-2023-07-04 && \
     rustup component add rust-src && \
     rustup target add aarch64-unknown-linux-gnu && \
     rustup target add x86_64-apple-darwin && \


### PR DESCRIPTION
Because of using Rust nightly, and without #49601 the Rust toolchain is very unstable, and can be frequently failed.

So let's ping particular version.

Also I've looked and it seems that Rust archives stores this archive without any TTL, since there is even a version for 2015 year.

Follow-up for: #50541 (cc @alexey-milovidov @Felixoid @Algunenano )

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)