### PR TITLE
Allow full range for var-int encoded integers

### DIFF
--- a/src/IO/VarInt.cpp
+++ b/src/IO/VarInt.cpp
@@ -6,20 +6,11 @@ namespace DB
 namespace ErrorCodes
 {
     extern const int ATTEMPT_TO_READ_AFTER_EOF;
-    extern const int BAD_ARGUMENTS;
 }
 
 void throwReadAfterEOF()
 {
     throw Exception(ErrorCodes::ATTEMPT_TO_READ_AFTER_EOF, "Attempt to read after eof");
-}
-
-void throwValueTooLargeForVarIntEncoding(UInt64 x)
-{
-    /// Under practical circumstances, we should virtually never end up here but AST Fuzzer manages to create superlarge input integers
-    /// which trigger this exception. Intentionally not throwing LOGICAL_ERROR or calling abort() or [ch]assert(false), so AST Fuzzer
-    /// can swallow the exception and continue to run.
-    throw Exception(ErrorCodes::BAD_ARGUMENTS, "Value {} is too large for VarInt encoding", x);
 }
 
 }

--- a/src/IO/VarInt.h
+++ b/src/IO/VarInt.h
@@ -97,13 +97,13 @@ inline char * writeVarInt(Int64 x, char * ostr)
 namespace impl
 {
 
-template <bool fast>
+template <bool check_eof>
 inline void readVarUInt(UInt64 & x, ReadBuffer & istr)
 {
     x = 0;
     for (size_t i = 0; i < 9; ++i)
     {
-        if constexpr (!fast)
+        if constexpr (check_eof)
             if (istr.eof()) [[unlikely]]
                 throwReadAfterEOF();
 
@@ -121,8 +121,8 @@ inline void readVarUInt(UInt64 & x, ReadBuffer & istr)
 inline void readVarUInt(UInt64 & x, ReadBuffer & istr)
 {
     if (istr.buffer().end() - istr.position() >= 9)
-        return impl::readVarUInt<true>(x, istr);
-    return impl::readVarUInt<false>(x, istr);
+        return impl::readVarUInt<false>(x, istr);
+    return impl::readVarUInt<true>(x, istr);
 }
 
 inline void readVarUInt(UInt64 & x, std::istream & istr)

--- a/src/IO/VarInt.h
+++ b/src/IO/VarInt.h
@@ -12,24 +12,77 @@ namespace DB
 
 /// Variable-Length Quantity (VLQ) Base-128 compression, also known as Variable Byte (VB) or Varint encoding.
 
-/// Write UInt64 in variable length format (base128)
-void writeVarUInt(UInt64 x, std::ostream & ostr);
-void writeVarUInt(UInt64 x, WriteBuffer & ostr);
-char * writeVarUInt(UInt64 x, char * ostr);
-
-/// Read UInt64, written in variable length format (base128)
-void readVarUInt(UInt64 & x, std::istream & istr);
-void readVarUInt(UInt64 & x, ReadBuffer & istr);
-const char * readVarUInt(UInt64 & x, const char * istr, size_t size);
-
-/// Get the length of an variable-length-encoded integer
-size_t getLengthOfVarUInt(UInt64 x);
-size_t getLengthOfVarInt(Int64 x);
-
 [[noreturn]] void throwReadAfterEOF();
 [[noreturn]] void throwValueTooLargeForVarIntEncoding(UInt64 x);
 
-/// Write Int64 in variable length format (base128)
+
+/// NOTE: Due to historical reasons, only values up to 1<<63-1 can be safely encoded/decoded (bigger values are not idempotent under
+/// encoding/decoding). This cannot be changed without breaking backward compatibility (some drivers, e.g. clickhouse-rs (Rust), have the
+/// same limitation, others support the full 1<<64 range, e.g. clickhouse-driver (Python))
+constexpr UInt64 VAR_UINT_MAX = (1ULL<<63) - 1;
+
+inline void writeVarUInt(UInt64 x, WriteBuffer & ostr)
+{
+    if (x > VAR_UINT_MAX) [[unlikely]]
+        throwValueTooLargeForVarIntEncoding(x);
+
+    for (size_t i = 0; i < 9; ++i)
+    {
+        uint8_t byte = x & 0x7F;
+        if (x > 0x7F)
+            byte |= 0x80;
+
+        ostr.nextIfAtEnd();
+        *ostr.position() = byte;
+        ++ostr.position();
+
+        x >>= 7;
+        if (!x)
+            return;
+    }
+}
+
+inline void writeVarUInt(UInt64 x, std::ostream & ostr)
+{
+    if (x > VAR_UINT_MAX) [[unlikely]]
+        throwValueTooLargeForVarIntEncoding(x);
+
+    for (size_t i = 0; i < 9; ++i)
+    {
+        uint8_t byte = x & 0x7F;
+        if (x > 0x7F)
+            byte |= 0x80;
+
+        ostr.put(byte);
+
+        x >>= 7;
+        if (!x)
+            return;
+    }
+}
+
+inline char * writeVarUInt(UInt64 x, char * ostr)
+{
+    if (x > VAR_UINT_MAX) [[unlikely]]
+        throwValueTooLargeForVarIntEncoding(x);
+
+    for (size_t i = 0; i < 9; ++i)
+    {
+        uint8_t byte = x & 0x7F;
+        if (x > 0x7F)
+            byte |= 0x80;
+
+        *ostr = byte;
+        ++ostr;
+
+        x >>= 7;
+        if (!x)
+            return ostr;
+    }
+
+    return ostr;
+}
+
 template <typename Out>
 inline void writeVarInt(Int64 x, Out & ostr)
 {
@@ -41,8 +94,71 @@ inline char * writeVarInt(Int64 x, char * ostr)
     return writeVarUInt(static_cast<UInt64>((x << 1) ^ (x >> 63)), ostr);
 }
 
+namespace impl
+{
 
-/// Read Int64, written in variable length format (base128)
+template <bool fast>
+inline void readVarUInt(UInt64 & x, ReadBuffer & istr)
+{
+    x = 0;
+    for (size_t i = 0; i < 9; ++i)
+    {
+        if constexpr (!fast)
+            if (istr.eof()) [[unlikely]]
+                throwReadAfterEOF();
+
+        UInt64 byte = *istr.position();
+        ++istr.position();
+        x |= (byte & 0x7F) << (7 * i);
+
+        if (!(byte & 0x80))
+            return;
+    }
+}
+
+}
+
+inline void readVarUInt(UInt64 & x, ReadBuffer & istr)
+{
+    if (istr.buffer().end() - istr.position() >= 9)
+        return impl::readVarUInt<true>(x, istr);
+    return impl::readVarUInt<false>(x, istr);
+}
+
+inline void readVarUInt(UInt64 & x, std::istream & istr)
+{
+    x = 0;
+    for (size_t i = 0; i < 9; ++i)
+    {
+        UInt64 byte = istr.get();
+        x |= (byte & 0x7F) << (7 * i);
+
+        if (!(byte & 0x80))
+            return;
+    }
+}
+
+inline const char * readVarUInt(UInt64 & x, const char * istr, size_t size)
+{
+    const char * end = istr + size;
+
+    x = 0;
+    for (size_t i = 0; i < 9; ++i)
+    {
+        if (istr == end) [[unlikely]]
+            throwReadAfterEOF();
+
+        UInt64 byte = *istr;
+        ++istr;
+        x |= (byte & 0x7F) << (7 * i);
+
+        if (!(byte & 0x80))
+            return istr;
+    }
+
+    return istr;
+}
+
 template <typename In>
 inline void readVarInt(Int64 & x, In & istr)
 {
@@ -56,9 +172,6 @@ inline const char * readVarInt(Int64 & x, const char * istr, size_t size)
     x = (static_cast<UInt64>(x) >> 1) ^ -(x & 1);
     return res;
 }
-
-
-/// For [U]Int32, [U]Int16, size_t.
 
 inline void readVarUInt(UInt32 & x, ReadBuffer & istr)
 {
@@ -96,137 +209,6 @@ inline void readVarUInt(T & x, ReadBuffer & istr)
     readVarUInt(tmp, istr);
     x = tmp;
 }
-
-template <bool fast>
-inline void readVarUIntImpl(UInt64 & x, ReadBuffer & istr)
-{
-    x = 0;
-    for (size_t i = 0; i < 9; ++i)
-    {
-        if constexpr (!fast)
-            if (istr.eof()) [[unlikely]]
-                throwReadAfterEOF();
-
-        UInt64 byte = *istr.position();
-        ++istr.position();
-        x |= (byte & 0x7F) << (7 * i);
-
-        if (!(byte & 0x80))
-            return;
-    }
-}
-
-inline void readVarUInt(UInt64 & x, ReadBuffer & istr)
-{
-    if (istr.buffer().end() - istr.position() >= 9)
-        return readVarUIntImpl<true>(x, istr);
-    return readVarUIntImpl<false>(x, istr);
-}
-
-
-inline void readVarUInt(UInt64 & x, std::istream & istr)
-{
-    x = 0;
-    for (size_t i = 0; i < 9; ++i)
-    {
-        UInt64 byte = istr.get();
-        x |= (byte & 0x7F) << (7 * i);
-
-        if (!(byte & 0x80))
-            return;
-    }
-}
-
-inline const char * readVarUInt(UInt64 & x, const char * istr, size_t size)
-{
-    const char * end = istr + size;
-
-    x = 0;
-    for (size_t i = 0; i < 9; ++i)
-    {
-        if (istr == end) [[unlikely]]
-            throwReadAfterEOF();
-
-        UInt64 byte = *istr;
-        ++istr;
-        x |= (byte & 0x7F) << (7 * i);
-
-        if (!(byte & 0x80))
-            return istr;
-    }
-
-    return istr;
-}
-
-/// NOTE: Due to historical reasons, only values up to 1<<63-1 can be safely encoded/decoded (bigger values are not idempotent under
-/// encoding/decoding). This cannot be changed without breaking backward compatibility (some drivers, e.g. clickhouse-rs (Rust), have the
-/// same limitation, others support the full 1<<64 range, e.g. clickhouse-driver (Python))
-constexpr UInt64 VAR_UINT_MAX = (1ULL<<63) - 1;
-
-inline void writeVarUInt(UInt64 x, WriteBuffer & ostr)
-{
-    if (x > VAR_UINT_MAX) [[unlikely]]
-        throwValueTooLargeForVarIntEncoding(x);
-
-    for (size_t i = 0; i < 9; ++i)
-    {
-        uint8_t byte = x & 0x7F;
-        if (x > 0x7F)
-            byte |= 0x80;
-
-        ostr.nextIfAtEnd();
-        *ostr.position() = byte;
-        ++ostr.position();
-
-        x >>= 7;
-        if (!x)
-            return;
-    }
-}
-
-
-inline void writeVarUInt(UInt64 x, std::ostream & ostr)
-{
-    if (x > VAR_UINT_MAX) [[unlikely]]
-        throwValueTooLargeForVarIntEncoding(x);
-
-    for (size_t i = 0; i < 9; ++i)
-    {
-        uint8_t byte = x & 0x7F;
-        if (x > 0x7F)
-            byte |= 0x80;
-
-        ostr.put(byte);
-
-        x >>= 7;
-        if (!x)
-            return;
-    }
-}
-
-
-inline char * writeVarUInt(UInt64 x, char * ostr)
-{
-    if (x > VAR_UINT_MAX) [[unlikely]]
-        throwValueTooLargeForVarIntEncoding(x);
-
-    for (size_t i = 0; i < 9; ++i)
-    {
-        uint8_t byte = x & 0x7F;
-        if (x > 0x7F)
-            byte |= 0x80;
-
-        *ostr = byte;
-        ++ostr;
-
-        x >>= 7;
-        if (!x)
-            return ostr;
-    }
-
-    return ostr;
-}
-
 
 inline size_t getLengthOfVarUInt(UInt64 x)
 {

--- a/src/Server/TCPHandler.cpp
+++ b/src/Server/TCPHandler.cpp
@@ -1905,17 +1905,18 @@ void TCPHandler::sendData(const Block & block)
 {
     initBlockOutput(block);
 
-    auto prev_bytes_written_out = out->count();
-    auto prev_bytes_written_compressed_out = state.maybe_compressed_out->count();
+    size_t prev_bytes_written_out = out->count();
+    size_t prev_bytes_written_compressed_out = state.maybe_compressed_out->count();
 
     try
     {
         /// For testing hedged requests
         if (unknown_packet_in_send_data)
         {
+            constexpr UInt64 marker = (1ULL<<63) - 1;
             --unknown_packet_in_send_data;
             if (unknown_packet_in_send_data == 0)
-                writeVarUInt(VAR_UINT_MAX, *out);
+                writeVarUInt(marker, *out);
         }
 
         writeVarUInt(Protocol::Server::Data, *out);

--- a/tests/queries/0_stateless/02812_large_varints.sql
+++ b/tests/queries/0_stateless/02812_large_varints.sql
@@ -1,0 +1,4 @@
+-- 64-bit integers with MSB set (i.e. values > (1ULL<<63) - 1) could for historical/compat reasons not be serialized as var-ints (issue #51486).
+-- These two queries internally produce such big values, run them to be sure no bad things happen.
+SELECT topKWeightedState(65535)(now(), -2) FORMAT Null;
+SELECT number FROM numbers(toUInt64(-1)) limit 10 Format Null;


### PR DESCRIPTION
Resolves: #51486

Until now, it was illegal to encode 64-bit (unsigned) integers with
MSB=1, i.e. values > (1ULL<<63) - 1, as [var-int](https://en.wikipedia.org/wiki/Variable-length_quantity). In more detail, the
var-int code used by ClickHouse server and client spent at most 9 bytes
per value such that 9 * 7 = 63 bits could be encoded. Some 3rd party
clients (e.g. Rust clickhouse-rs) have the same limitation, whereas other
clients understand the full range (Python clickhouse-driver).

PRs #47608 and #48628 added sanity checks as asserts or exceptions
during var-int encoding on the server side. This was considered okay as
such huge integers so far occurred only during testing (usually fuzzing)
but not in practice.

Issue #51486 is a new fuzzing issue where the exception thrown from the
sanity check led to a half-baked progress packet and as a result, a
logical error / server crash.

The only fix which is not another bandaid is to allow the full range in
var-int coding. Clients will have to allow the full range too, a note
will be added to the changelog. (the alternative was to create another
protocol version but as var-int is used all over the place this was
considered infeasible.)

Review note: only this [commit](https://github.com/ClickHouse/ClickHouse/pull/51905/commits/271297823ae6abe82908220d1a540fbf0113f4d8) is relevant.

### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Var-int encoded integers (e.g. used by the native protocol) can now use the full 64-bit range. 3rd party clients are advised to update their var-int code accordingly.