### PR TITLE
add doc note for MongoDB Atlas

### DIFF
--- a/docs/en/engines/table-engines/integrations/mongodb.md
+++ b/docs/en/engines/table-engines/integrations/mongodb.md
@@ -33,6 +33,15 @@ CREATE TABLE [IF NOT EXISTS] [db.]table_name
 
 - `options` — MongoDB connection string options (optional parameter).
 
+:::tip
+If you are using the MongoDB Atlas cloud offering please add these options:
+
+```
+'connectTimeoutMS=10000&ssl=true&authSource=admin'
+```
+
+:::
+
 ## Usage Example {#usage-example}
 
 Create a table in ClickHouse which allows to read data from MongoDB collection:

--- a/docs/en/sql-reference/table-functions/mongodb.md
+++ b/docs/en/sql-reference/table-functions/mongodb.md
@@ -30,6 +30,14 @@ mongodb(host:port, database, collection, user, password, structure [, options])
 
 - `options` - MongoDB connection string options (optional parameter).
 
+:::tip
+If you are using the MongoDB Atlas cloud offering please add these options:
+
+```
+'connectTimeoutMS=10000&ssl=true&authSource=admin'
+```
+
+:::
 
 **Returned Value**
 


### PR DESCRIPTION
When integrating with the MongoDB Atlas service the table function and table engine need options set.

### Changelog category (leave one):
- Documentation (changelog entry is not required)
