### PR TITLE
Fix unrelated messages from LSan in clickhouse-client

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -57,6 +57,8 @@ MESSAGES_TO_RETRY = [
     "ConnectionPoolWithFailover: Connection failed at try",
     "DB::Exception: New table appeared in database being dropped or detached. Try again",
     "is already started to be removing by another replica right now",
+    # This is from LSan, and it indicates its own internal problem:
+    "Unable to get registers from thread",
 ]
 
 MAX_RETRIES = 3


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


See https://s3.amazonaws.com/clickhouse-test-reports/0/087dd6dbfa9ba662a95fc52ba9f383cd3dad9594/stateless_tests__asan__[2_4].html and https://github.com/google/sanitizers/issues/1641
