### PR TITLE
Fix test `02354_distributed_with_external_aggregation_memory_usage`

### DIFF
--- a/tests/queries/0_stateless/02354_distributed_with_external_aggregation_memory_usage.sql
+++ b/tests/queries/0_stateless/02354_distributed_with_external_aggregation_memory_usage.sql
@@ -1,5 +1,7 @@
 -- Tags: long, no-tsan, no-msan, no-asan, no-ubsan, no-debug, no-s3-storage
 
+DROP TABLE IF EXISTS t_2354_dist_with_external_aggr;
+
 create table t_2354_dist_with_external_aggr(a UInt64, b String, c FixedString(100)) engine = MergeTree order by tuple();
 
 insert into t_2354_dist_with_external_aggr select number, toString(number) as s, toFixedString(s, 100) from numbers_mt(5e7);
@@ -15,8 +17,12 @@ set max_bytes_before_external_group_by = '2G',
 
 -- whole aggregation state of local aggregation uncompressed is 5.8G
 -- it is hard to provide an accurate estimation for memory usage, so 4G is just the actual value taken from the logs + delta
+-- also avoid using localhost, so the queries will go over separate connections
+-- (otherwise the memory usage for merge will be counted together with the localhost query)
 select a, b, c, sum(a) as s
-from remote('127.0.0.{1,2}', currentDatabase(), t_2354_dist_with_external_aggr)
+from remote('127.0.0.{2,3}', currentDatabase(), t_2354_dist_with_external_aggr)
 group by a, b, c
 format Null
 settings max_memory_usage = '4Gi';
+
+DROP TABLE t_2354_dist_with_external_aggr;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


See https://s3.amazonaws.com/clickhouse-test-reports/51492/b006e9e316bc5463619bd47e8c21970ce5506eda/stateless_tests__release__wide_parts_enabled_.html