### PR TITLE
Revert "Merge pull request #51800 from Avogar/assert-current-thread"

### DIFF
--- a/src/Common/ThreadStatus.cpp
+++ b/src/Common/ThreadStatus.cpp
@@ -67,8 +67,8 @@ ThreadGroup::ThreadGroup()
     : master_thread_id(CurrentThread::get().thread_id)
 {}
 
-ThreadStatus::ThreadStatus(bool check_current_thread_on_destruction_)
-    : thread_id{getThreadId()}, check_current_thread_on_destruction(check_current_thread_on_destruction_)
+ThreadStatus::ThreadStatus()
+    : thread_id{getThreadId()}
 {
     last_rusage = std::make_unique<RUsageCounters>();
 
@@ -199,14 +199,10 @@ ThreadStatus::~ThreadStatus()
     if (deleter)
         deleter();
 
-    chassert(!check_current_thread_on_destruction || current_thread == this);
-
     /// Only change current_thread if it's currently being used by this ThreadStatus
     /// For example, PushingToViews chain creates and deletes ThreadStatus instances while running in the main query thread
     if (current_thread == this)
         current_thread = nullptr;
-    else if (check_current_thread_on_destruction)
-        LOG_ERROR(log, "current_thread contains invalid address");
 }
 
 void ThreadStatus::updatePerformanceCounters()

--- a/src/Common/ThreadStatus.h
+++ b/src/Common/ThreadStatus.h
@@ -224,10 +224,8 @@ private:
 
     Poco::Logger * log = nullptr;
 
-    bool check_current_thread_on_destruction;
-
 public:
-    explicit ThreadStatus(bool check_current_thread_on_destruction_ = true);
+    ThreadStatus();
     ~ThreadStatus();
 
     ThreadGroupPtr getThreadGroup() const;

--- a/src/Processors/Transforms/buildPushingToViewsChain.cpp
+++ b/src/Processors/Transforms/buildPushingToViewsChain.cpp
@@ -282,7 +282,7 @@ Chain buildPushingToViewsChain(
         auto * original_thread = current_thread;
         SCOPE_EXIT({ current_thread = original_thread; });
 
-        std::unique_ptr<ThreadStatus> view_thread_status_ptr = std::make_unique<ThreadStatus>(/*check_current_thread_on_destruction=*/ false);
+        std::unique_ptr<ThreadStatus> view_thread_status_ptr = std::make_unique<ThreadStatus>();
         /// Copy of a ThreadStatus should be internal.
         view_thread_status_ptr->setInternalThread();
         view_thread_status_ptr->attachToGroup(running_group);


### PR DESCRIPTION
This reverts commit 0fb6dd8f89800f3dcd2ca32bd20a5afc954d6978, reversing changes made to c2a5318df4a91678850cf8f493e75728264cf139.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


The PR has broken RabbitMQ integration: https://github.com/ClickHouse/ClickHouse/pull/51800

See

https://play.clickhouse.com/play?user=play#U0VMRUNUIGNoZWNrX3N0YXJ0X3RpbWU6OkRhdGUsIGNoZWNrX3N0YXJ0X3RpbWUsIHB1bGxfcmVxdWVzdF9udW1iZXIsIGNvbW1pdF9zaGEsIGNvdW50KCksIGdyb3VwVW5pcUFycmF5KGNoZWNrX25hbWUpCkZST00gY2hlY2tzCldIRVJFIDEKICAgIEFORCBjaGVja19zdGFydF90aW1lID49IG5vdygpIC0gSU5URVJWQUwgMSBXRUVLCiAgICBBTkQgdGVzdF9zdGF0dXMgIT0gJ1NLSVBQRUQnCiAgICBBTkQgdGVzdF9zdGF0dXMgTElLRSAnRiUnCiAgICBBTkQgY2hlY2tfc3RhdHVzICE9ICdzdWNjZXNzJwogICAgQU5EIHRlc3RfbmFtZSBMSUtFICcldGVzdF9zdG9yYWdlX3JhYmJpdG1xJScKR1JPVVAgQlkgQUxMCk9SREVSIEJZIDEgV0lUSCBGSUxMLCBjaGVja19zdGFydF90aW1l

https://play.clickhouse.com/play?user=play#U0VMRUNUIGNoZWNrX3N0YXJ0X3RpbWU6OkRhdGUsIGNoZWNrX3N0YXJ0X3RpbWUsIHB1bGxfcmVxdWVzdF9udW1iZXIsIGNvbW1pdF9zaGEsIGNvdW50KCksIGdyb3VwVW5pcUFycmF5KGNoZWNrX25hbWUpCkZST00gY2hlY2tzCldIRVJFIDEKICAgIEFORCBjaGVja19zdGFydF90aW1lID49IG5vdygpIC0gSU5URVJWQUwgMSBXRUVLCiAgICBBTkQgdGVzdF9zdGF0dXMgIT0gJ1NLSVBQRUQnCiAgICBBTkQgdGVzdF9zdGF0dXMgTElLRSAnRiUnCiAgICBBTkQgY2hlY2tfc3RhdHVzICE9ICdzdWNjZXNzJwogICAgQU5EIHRlc3RfbmFtZSBMSUtFICcldGVzdF9zdG9yYWdlX3JhYmJpdG1xJScKR1JPVVAgQlkgQUxMCk9SREVSIEJZIDEgV0lUSCBGSUxMLCBjaGVja19zdGFydF90aW1l

```
llvm-addr2line -afiCe ./clickhouse 0x000000000e181453 0x0000000014cecd1d 0x0000000014cecffd 0x0000000014ced154 0x0000000012c419a1 0x0000000012c444da 0x0000000012c49e3b 0x0000000012c35ff7 0x000000001431d978 0x000000001431b555 0x00000000129fb5c2 0x00000000129feaea 0x00000000129ff931 0x000000000e28974f 0x000000000e28f741 0x00007f0904785b43 0x00007f0904817a00
0xe181453
CurrentMemoryTracker::free(long)
./build_docker/./src/Common/CurrentMemoryTracker.cpp:106
void Memory::untrackMemory<>(void*, unsigned long)
./build_docker/./src/Common/memory.h:202
operator delete(void*, unsigned long)
./build_docker/./src/Common/new_delete.cpp:157
0x14cecd1d
std::__1::__list_imp<std::__1::unique_ptr<DB::ThreadStatus, std::__1::default_delete<DB::ThreadStatus>>, std::__1::allocator<std::__1::unique_ptr<DB::ThreadStatus, std::__1::default_delete<DB::ThreadStatus>>>>::empty[abi:v15000]() const
./build_docker/./contrib/llvm-project/libcxx/include/list:616
std::__1::list<std::__1::unique_ptr<DB::ThreadStatus, std::__1::default_delete<DB::ThreadStatus>>, std::__1::allocator<std::__1::unique_ptr<DB::ThreadStatus, std::__1::default_delete<DB::ThreadStatus>>>>::empty[abi:v15000]() const
./build_docker/./contrib/llvm-project/libcxx/include/list:918
DB::ThreadStatusesHolder::~ThreadStatusesHolder()
./build_docker/./src/Processors/Transforms/buildPushingToViewsChain.cpp:49
void std::__1::__destroy_at[abi:v15000]<DB::ThreadStatusesHolder, 0>(DB::ThreadStatusesHolder*)
./build_docker/./contrib/llvm-project/libcxx/include/__memory/construct_at.h:63
void std::__1::destroy_at[abi:v15000]<DB::ThreadStatusesHolder, 0>(DB::ThreadStatusesHolder*)
./build_docker/./contrib/llvm-project/libcxx/include/__memory/construct_at.h:88
void std::__1::allocator_traits<std::__1::allocator<DB::ThreadStatusesHolder>>::destroy[abi:v15000]<DB::ThreadStatusesHolder, void, void>(std::__1::allocator<DB::ThreadStatusesHolder>&, DB::ThreadStatusesHolder*)
./build_docker/./contrib/llvm-project/libcxx/include/__memory/allocator_traits.h:317
std::__1::__shared_ptr_emplace<DB::ThreadStatusesHolder, std::__1::allocator<DB::ThreadStatusesHolder>>::__on_zero_shared()
./build_docker/./contrib/llvm-project/libcxx/include/__memory/shared_ptr.h:309
0x14cecffd
long std::__1::(anonymous namespace)::__libcpp_atomic_load[abi:v15000]<long>(long const*, int)
./build_docker/./contrib/llvm-project/libcxx/src/include/atomic_support.h:74
std::__1::__shared_weak_count::__release_weak()
./build_docker/./contrib/llvm-project/libcxx/src/memory.cpp:108
std::__1::__shared_weak_count::__release_shared[abi:v15000]()
./build_docker/./contrib/llvm-project/libcxx/include/__memory/shared_ptr.h:216
std::__1::shared_ptr<DB::ThreadStatusesHolder>::~shared_ptr[abi:v15000]()
./build_docker/./contrib/llvm-project/libcxx/include/__memory/shared_ptr.h:702
DB::ViewsData::~ViewsData()
./build_docker/./src/Processors/Transforms/buildPushingToViewsChain.cpp:56
void std::__1::__destroy_at[abi:v15000]<DB::ViewsData, 0>(DB::ViewsData*)
./build_docker/./contrib/llvm-project/libcxx/include/__memory/construct_at.h:63
void std::__1::destroy_at[abi:v15000]<DB::ViewsData, 0>(DB::ViewsData*)
./build_docker/./contrib/llvm-project/libcxx/include/__memory/construct_at.h:88
void std::__1::allocator_traits<std::__1::allocator<DB::ViewsData>>::destroy[abi:v15000]<DB::ViewsData, void, void>(std::__1::allocator<DB::ViewsData>&, DB::ViewsData*)
./build_docker/./contrib/llvm-project/libcxx/include/__memory/allocator_traits.h:317
std::__1::__shared_ptr_emplace<DB::ViewsData, std::__1::allocator<DB::ViewsData>>::__on_zero_shared()
./build_docker/./contrib/llvm-project/libcxx/include/__memory/shared_ptr.h:309
0x14ced154
long std::__1::(anonymous namespace)::__libcpp_atomic_load[abi:v15000]<long>(long const*, int)
./build_docker/./contrib/llvm-project/libcxx/src/include/atomic_support.h:74
std::__1::__shared_weak_count::__release_weak()
./build_docker/./contrib/llvm-project/libcxx/src/memory.cpp:108
std::__1::__shared_weak_count::__release_shared[abi:v15000]()
./build_docker/./contrib/llvm-project/libcxx/include/__memory/shared_ptr.h:216
std::__1::shared_ptr<DB::ViewsData>::~shared_ptr[abi:v15000]()
./build_docker/./contrib/llvm-project/libcxx/include/__memory/shared_ptr.h:702
DB::CopyingDataToViewsTransform::~CopyingDataToViewsTransform()
./build_docker/./src/Processors/Transforms/buildPushingToViewsChain.cpp:88
void std::__1::__destroy_at[abi:v15000]<DB::CopyingDataToViewsTransform, 0>(DB::CopyingDataToViewsTransform*)
./build_docker/./contrib/llvm-project/libcxx/include/__memory/construct_at.h:63
void std::__1::destroy_at[abi:v15000]<DB::CopyingDataToViewsTransform, 0>(DB::CopyingDataToViewsTransform*)
./build_docker/./contrib/llvm-project/libcxx/include/__memory/construct_at.h:88
void std::__1::allocator_traits<std::__1::allocator<DB::CopyingDataToViewsTransform>>::destroy[abi:v15000]<DB::CopyingDataToViewsTransform, void, void>(std::__1::allocator<DB::CopyingDataToViewsTransform>&, DB::CopyingDataToViewsTransform*)
./build_docker/./contrib/llvm-project/libcxx/include/__memory/allocator_traits.h:317
std::__1::__shared_ptr_emplace<DB::CopyingDataToViewsTransform, std::__1::allocator<DB::CopyingDataToViewsTransform>>::__on_zero_shared()
./build_docker/./contrib/llvm-project/libcxx/include/__memory/shared_ptr.h:309
0x12c419a1
long std::__1::(anonymous namespace)::__libcpp_atomic_load[abi:v15000]<long>(long const*, int)
./build_docker/./contrib/llvm-project/libcxx/src/include/atomic_support.h:74
std::__1::__shared_weak_count::__release_weak()
./build_docker/./contrib/llvm-project/libcxx/src/memory.cpp:108
std::__1::__shared_weak_count::__release_shared[abi:v15000]()
./build_docker/./contrib/llvm-project/libcxx/include/__memory/shared_ptr.h:216
std::__1::shared_ptr<DB::IProcessor>::~shared_ptr[abi:v15000]()
./build_docker/./contrib/llvm-project/libcxx/include/__memory/shared_ptr.h:702
void std::__1::__destroy_at[abi:v15000]<std::__1::shared_ptr<DB::IProcessor>, 0>(std::__1::shared_ptr<DB::IProcessor>*)
./build_docker/./contrib/llvm-project/libcxx/include/__memory/construct_at.h:63
void std::__1::destroy_at[abi:v15000]<std::__1::shared_ptr<DB::IProcessor>, 0>(std::__1::shared_ptr<DB::IProcessor>*)
./build_docker/./contrib/llvm-project/libcxx/include/__memory/construct_at.h:88
void std::__1::allocator_traits<std::__1::allocator<std::__1::shared_ptr<DB::IProcessor>>>::destroy[abi:v15000]<std::__1::shared_ptr<DB::IProcessor>, void, void>(std::__1::allocator<std::__1::shared_ptr<DB::IProcessor>>&, std::__1::shared_ptr<DB::IProcessor>*)
./build_docker/./contrib/llvm-project/libcxx/include/__memory/allocator_traits.h:317
std::__1::vector<std::__1::shared_ptr<DB::IProcessor>, std::__1::allocator<std::__1::shared_ptr<DB::IProcessor>>>::__base_destruct_at_end[abi:v15000](std::__1::shared_ptr<DB::IProcessor>*)
./build_docker/./contrib/llvm-project/libcxx/include/vector:833
std::__1::vector<std::__1::shared_ptr<DB::IProcessor>, std::__1::allocator<std::__1::shared_ptr<DB::IProcessor>>>::__clear[abi:v15000]()
./build_docker/./contrib/llvm-project/libcxx/include/vector:827
std::__1::vector<std::__1::shared_ptr<DB::IProcessor>, std::__1::allocator<std::__1::shared_ptr<DB::IProcessor>>>::~vector[abi:v15000]()
./build_docker/./contrib/llvm-project/libcxx/include/vector:436
void std::__1::__destroy_at[abi:v15000]<std::__1::vector<std::__1::shared_ptr<DB::IProcessor>, std::__1::allocator<std::__1::shared_ptr<DB::IProcessor>>>, 0>(std::__1::vector<std::__1::shared_ptr<DB::IProcessor>, std::__1::allocator<std::__1::shared_ptr<DB::IProcessor>>>*)
./build_docker/./contrib/llvm-project/libcxx/include/__memory/construct_at.h:63
void std::__1::destroy_at[abi:v15000]<std::__1::vector<std::__1::shared_ptr<DB::IProcessor>, std::__1::allocator<std::__1::shared_ptr<DB::IProcessor>>>, 0>(std::__1::vector<std::__1::shared_ptr<DB::IProcessor>, std::__1::allocator<std::__1::shared_ptr<DB::IProcessor>>>*)
./build_docker/./contrib/llvm-project/libcxx/include/__memory/construct_at.h:88
void std::__1::allocator_traits<std::__1::allocator<std::__1::vector<std::__1::shared_ptr<DB::IProcessor>, std::__1::allocator<std::__1::shared_ptr<DB::IProcessor>>>>>::destroy[abi:v15000]<std::__1::vector<std::__1::shared_ptr<DB::IProcessor>, std::__1::allocator<std::__1::shared_ptr<DB::IProcessor>>>, void, void>(std::__1::allocator<std::__1::vector<std::__1::shared_ptr<DB::IProcessor>, std::__1::allocator<std::__1::shared_ptr<DB::IProcessor>>>>&, std::__1::vector<std::__1::shared_ptr<DB::IProcessor>, std::__1::allocator<std::__1::shared_ptr<DB::IProcessor>>>*)
./build_docker/./contrib/llvm-project/libcxx/include/__memory/allocator_traits.h:317
std::__1::__shared_ptr_emplace<std::__1::vector<std::__1::shared_ptr<DB::IProcessor>, std::__1::allocator<std::__1::shared_ptr<DB::IProcessor>>>, std::__1::allocator<std::__1::vector<std::__1::shared_ptr<DB::IProcessor>, std::__1::allocator<std::__1::shared_ptr<DB::IProcessor>>>>>::__on_zero_shared()
./build_docker/./contrib/llvm-project/libcxx/include/__memory/shared_ptr.h:309
0x12c444da
long std::__1::(anonymous namespace)::__libcpp_atomic_load[abi:v15000]<long>(long const*, int)
./build_docker/./contrib/llvm-project/libcxx/src/include/atomic_support.h:74
std::__1::__shared_weak_count::__release_weak()
./build_docker/./contrib/llvm-project/libcxx/src/memory.cpp:108
std::__1::__shared_weak_count::__release_shared[abi:v15000]()
./build_docker/./contrib/llvm-project/libcxx/include/__memory/shared_ptr.h:216
std::__1::shared_ptr<std::__1::vector<std::__1::shared_ptr<DB::IProcessor>, std::__1::allocator<std::__1::shared_ptr<DB::IProcessor>>>>::~shared_ptr[abi:v15000]()
./build_docker/./contrib/llvm-project/libcxx/include/__memory/shared_ptr.h:702
DB::QueryPipeline::~QueryPipeline()
./build_docker/./src/QueryPipeline/QueryPipeline.cpp:44
0x12c49e3b
DB::QueryPipeline::reset()
./build_docker/./src/QueryPipeline/QueryPipeline.cpp:659
0x12c35ff7
std::__1::enable_if<is_move_constructible<DB::ProcessListEntry*>::value && is_move_assignable<DB::ProcessListEntry*>::value, void>::type std::__1::swap[abi:v15000]<DB::ProcessListEntry*>(DB::ProcessListEntry*&, DB::ProcessListEntry*&)
./build_docker/./contrib/llvm-project/libcxx/include/__utility/swap.h:37
std::__1::shared_ptr<DB::ProcessListEntry>::swap[abi:v15000](std::__1::shared_ptr<DB::ProcessListEntry>&)
./build_docker/./contrib/llvm-project/libcxx/include/__memory/shared_ptr.h:761
std::__1::shared_ptr<DB::ProcessListEntry>::reset[abi:v15000]()
./build_docker/./contrib/llvm-project/libcxx/include/__memory/shared_ptr.h:768
DB::BlockIO::reset()
./build_docker/./src/QueryPipeline/BlockIO.cpp:25
DB::BlockIO::~BlockIO()
./build_docker/./src/QueryPipeline/BlockIO.cpp:51
0x1431d978
DB::InterpreterInsertQuery::~InterpreterInsertQuery()
./build_docker/./src/Interpreters/InterpreterInsertQuery.h:20
DB::StorageRabbitMQ::tryStreamToViews()
./build_docker/./src/Storages/RabbitMQ/StorageRabbitMQ.cpp:1156
0x1431b555
DB::StorageRabbitMQ::streamingToViewsFunc()
./build_docker/./src/Storages/RabbitMQ/StorageRabbitMQ.cpp:988
0x129fb5c2
clock_gettime
./build_docker/./base/glibc-compatibility/musl/clock_gettime.c:62
clock_gettime_ns(int)
./build_docker/./src/Common/Stopwatch.h:25
clock_gettime_ns_adjusted(unsigned long, int)
./build_docker/./src/Common/Stopwatch.h:36
Stopwatch::nanoseconds() const
./build_docker/./src/Common/Stopwatch.h:82
Stopwatch::elapsedNanoseconds() const
./build_docker/./src/Common/Stopwatch.h:68
Stopwatch::elapsedMilliseconds() const
./build_docker/./src/Common/Stopwatch.h:70
DB::BackgroundSchedulePoolTaskInfo::execute()
./build_docker/./src/Core/BackgroundSchedulePool.cpp:111
0x129feaea
std::__1::shared_ptr<DB::BackgroundSchedulePoolTaskInfo>::~shared_ptr[abi:v15000]()
./build_docker/./contrib/llvm-project/libcxx/include/__memory/shared_ptr.h:701
DB::BackgroundSchedulePool::threadFunction()
./build_docker/./src/Core/BackgroundSchedulePool.cpp:303
0x129ff931
ThreadFromGlobalPoolImpl<false>::ThreadFromGlobalPoolImpl<DB::BackgroundSchedulePool::BackgroundSchedulePool(unsigned long, StrongTypedef<unsigned long, CurrentMetrics::MetricTag>, StrongTypedef<unsigned long, CurrentMetrics::MetricTag>, char const*)::$_0>(DB::BackgroundSchedulePool::BackgroundSchedulePool(unsigned long, StrongTypedef<unsigned long, CurrentMetrics::MetricTag>, StrongTypedef<unsigned long, CurrentMetrics::MetricTag>, char const*)::$_0&&)::'lambda'()::operator()()
./build_docker/./src/Core/BackgroundSchedulePool.cpp:0
decltype(std::declval<DB::BackgroundSchedulePool::BackgroundSchedulePool(unsigned long, StrongTypedef<unsigned long, CurrentMetrics::MetricTag>, StrongTypedef<unsigned long, CurrentMetrics::MetricTag>, char const*)::$_0>()()) std::__1::__invoke[abi:v15000]<ThreadFromGlobalPoolImpl<false>::ThreadFromGlobalPoolImpl<DB::BackgroundSchedulePool::BackgroundSchedulePool(unsigned long, StrongTypedef<unsigned long, CurrentMetrics::MetricTag>, StrongTypedef<unsigned long, CurrentMetrics::MetricTag>, char const*)::$_0>(DB::BackgroundSchedulePool::BackgroundSchedulePool(unsigned long, StrongTypedef<unsigned long, CurrentMetrics::MetricTag>, StrongTypedef<unsigned long, CurrentMetrics::MetricTag>, char const*)::$_0&&)::'lambda'()&>(DB::BackgroundSchedulePool::BackgroundSchedulePool(unsigned long, StrongTypedef<unsigned long, CurrentMetrics::MetricTag>, StrongTypedef<unsigned long, CurrentMetrics::MetricTag>, char const*)::$_0&&)
./build_docker/./contrib/llvm-project/libcxx/include/__functional/invoke.h:394
void std::__1::__invoke_void_return_wrapper<void, true>::__call<ThreadFromGlobalPoolImpl<false>::ThreadFromGlobalPoolImpl<DB::BackgroundSchedulePool::BackgroundSchedulePool(unsigned long, StrongTypedef<unsigned long, CurrentMetrics::MetricTag>, StrongTypedef<unsigned long, CurrentMetrics::MetricTag>, char const*)::$_0>(DB::BackgroundSchedulePool::BackgroundSchedulePool(unsigned long, StrongTypedef<unsigned long, CurrentMetrics::MetricTag>, StrongTypedef<unsigned long, CurrentMetrics::MetricTag>, char const*)::$_0&&)::'lambda'()&>(ThreadFromGlobalPoolImpl<false>::ThreadFromGlobalPoolImpl<DB::BackgroundSchedulePool::BackgroundSchedulePool(unsigned long, StrongTypedef<unsigned long, CurrentMetrics::MetricTag>, StrongTypedef<unsigned long, CurrentMetrics::MetricTag>, char const*)::$_0>(DB::BackgroundSchedulePool::BackgroundSchedulePool(unsigned long, StrongTypedef<unsigned long, CurrentMetrics::MetricTag>, StrongTypedef<unsigned long, CurrentMetrics::MetricTag>, char const*)::$_0&&)::'lambda'()&)
./build_docker/./contrib/llvm-project/libcxx/include/__functional/invoke.h:479
std::__1::__function::__default_alloc_func<ThreadFromGlobalPoolImpl<false>::ThreadFromGlobalPoolImpl<DB::BackgroundSchedulePool::BackgroundSchedulePool(unsigned long, StrongTypedef<unsigned long, CurrentMetrics::MetricTag>, StrongTypedef<unsigned long, CurrentMetrics::MetricTag>, char const*)::$_0>(DB::BackgroundSchedulePool::BackgroundSchedulePool(unsigned long, StrongTypedef<unsigned long, CurrentMetrics::MetricTag>, StrongTypedef<unsigned long, CurrentMetrics::MetricTag>, char const*)::$_0&&)::'lambda'(), void ()>::operator()[abi:v15000]()
./build_docker/./contrib/llvm-project/libcxx/include/__functional/function.h:235
void std::__1::__function::__policy_invoker<void ()>::__call_impl<std::__1::__function::__default_alloc_func<ThreadFromGlobalPoolImpl<false>::ThreadFromGlobalPoolImpl<DB::BackgroundSchedulePool::BackgroundSchedulePool(unsigned long, StrongTypedef<unsigned long, CurrentMetrics::MetricTag>, StrongTypedef<unsigned long, CurrentMetrics::MetricTag>, char const*)::$_0>(DB::BackgroundSchedulePool::BackgroundSchedulePool(unsigned long, StrongTypedef<unsigned long, CurrentMetrics::MetricTag>, StrongTypedef<unsigned long, CurrentMetrics::MetricTag>, char const*)::$_0&&)::'lambda'(), void ()>>(std::__1::__function::__policy_storage const*)
./build_docker/./contrib/llvm-project/libcxx/include/__functional/function.h:716
0xe28974f
bool wide::integer<128ul, unsigned int>::_impl::operator_eq<wide::integer<128ul, unsigned int>>(wide::integer<128ul, unsigned int> const&, wide::integer<128ul, unsigned int> const&)
./build_docker/./base/base/../base/wide_integer_impl.h:809
bool wide::operator==<128ul, unsigned int, 128ul, unsigned int>(wide::integer<128ul, unsigned int> const&, wide::integer<128ul, unsigned int> const&)
./build_docker/./base/base/../base/wide_integer_impl.h:1482
StrongTypedef<wide::integer<128ul, unsigned int>, DB::UUIDTag>::operator==(StrongTypedef<wide::integer<128ul, unsigned int>, DB::UUIDTag> const&) const
./build_docker/./base/base/../base/strong_typedef.h:42
DB::OpenTelemetry::Span::isTraceEnabled() const
./build_docker/./src/Common/OpenTelemetryTraceContext.h:65
ThreadPoolImpl<std::__1::thread>::worker(std::__1::__list_iterator<std::__1::thread, void*>)
./build_docker/./src/Common/ThreadPool.cpp:429
0xe28f741
std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>::reset[abi:v15000](std::__1::__thread_struct*)
./build_docker/./contrib/llvm-project/libcxx/include/__memory/unique_ptr.h:302
std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>::~unique_ptr[abi:v15000]()
./build_docker/./contrib/llvm-project/libcxx/include/__memory/unique_ptr.h:259
std::__1::__tuple_leaf<0ul, std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, false>::~__tuple_leaf()
./build_docker/./contrib/llvm-project/libcxx/include/tuple:265
std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, void ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, Priority, std::__1::optional<unsigned long>, bool)::'lambda0'()>::~tuple()
./build_docker/./contrib/llvm-project/libcxx/include/tuple:538
std::__1::default_delete<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, void ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, Priority, std::__1::optional<unsigned long>, bool)::'lambda0'()>>::operator()[abi:v15000](std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, void ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, Priority, std::__1::optional<unsigned long>, bool)::'lambda0'()>*) const
./build_docker/./contrib/llvm-project/libcxx/include/__memory/unique_ptr.h:48
std::__1::unique_ptr<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, void ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, Priority, std::__1::optional<unsigned long>, bool)::'lambda0'()>, std::__1::default_delete<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, void ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, Priority, std::__1::optional<unsigned long>, bool)::'lambda0'()>>>::reset[abi:v15000](std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, void ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, Priority, std::__1::optional<unsigned long>, bool)::'lambda0'()>*)
./build_docker/./contrib/llvm-project/libcxx/include/__memory/unique_ptr.h:305
std::__1::unique_ptr<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, void ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, Priority, std::__1::optional<unsigned long>, bool)::'lambda0'()>, std::__1::default_delete<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, void ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, Priority, std::__1::optional<unsigned long>, bool)::'lambda0'()>>>::~unique_ptr[abi:v15000]()
./build_docker/./contrib/llvm-project/libcxx/include/__memory/unique_ptr.h:259
void* std::__1::__thread_proxy[abi:v15000]<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, void ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, Priority, std::__1::optional<unsigned long>, bool)::'lambda0'()>>(void*)
./build_docker/./contrib/llvm-project/libcxx/include/thread:297
0x7f0904785b43
??
??:0
0x7f0904817a00
??
??:0
```