### PR TITLE
Inline SipHash::get128(char *)

### DIFF
--- a/src/Common/SipHash.h
+++ b/src/Common/SipHash.h
@@ -188,7 +188,7 @@ public:
 
     /// Get the result in some form. This can only be done once!
 
-    void get128(char * out)
+    ALWAYS_INLINE void get128(char * out)
     {
         finalize();
 #if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__


### PR DESCRIPTION
The SipHash-128 values of the strings are calculated and stored in a set when the UniqExact aggregate function is applied to a ColumnString, as the following snippet shows:

```
StringRef value = column.getDataAt(row_num);
UInt128 key;
SipHash hash;
hash.update(value.data, value.size);
hash.get128(key);
```

The implementation of SipHash requires an internal 8-byte buffer, current_word (or current_bytes), for holding the input data in the cross function calls of SipHash::update and SipHash::get128. But, in the above situation, where the update and get128 only take place once, the copy of input data to the buffer is unnecessary.

With get128 inlined, the compiler could optimize the code as a whole and reduce the unexpected memory operations, and as a result, the query performance is improved.

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
The performance experiments of **OnTime** on the ICX device (Intel Xeon Platinum 8380 CPU, 80 cores, 160 threads) show that this change could bring an improvement of **11.6%** to the QPS of the query **Q8** while having no impact on others.

And in the performance analysis, we found this change could effectively reduce the counts of memory stores and loads by **65,7%** and **18.3%** respectively when a fixed amount of Q8 is executed, and the CPU cycles are reduced by **12.5%**.