### PR TITLE
Add RISC-V 64 to the docs

### DIFF
--- a/docs/en/development/build.md
+++ b/docs/en/development/build.md
@@ -11,7 +11,8 @@ Supported platforms:
 
 - x86_64
 - AArch64
-- Power9 (experimental)
+- PowerPC 64 LE (experimental)
+- RISC-V 64 (experimental)
 
 ## Building on Ubuntu
 


### PR DESCRIPTION
### Changelog category (leave one):
- Documentation (changelog entry is not required)
