### PR TITLE
Bump version of the distributed_ddl_entry_format_version to 5 by default

### DIFF
--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -629,7 +629,7 @@ class IColumn;
     M(Bool, database_replicated_allow_only_replicated_engine, false, "Allow to create only Replicated tables in database with engine Replicated", 0) \
     M(Bool, database_replicated_allow_replicated_engine_arguments, true, "Allow to create only Replicated tables in database with engine Replicated with explicit arguments", 0) \
     M(DistributedDDLOutputMode, distributed_ddl_output_mode, DistributedDDLOutputMode::THROW, "Format of distributed DDL query result", 0) \
-    M(UInt64, distributed_ddl_entry_format_version, 3, "Compatibility version of distributed DDL (ON CLUSTER) queries", 0) \
+    M(UInt64, distributed_ddl_entry_format_version, 5, "Compatibility version of distributed DDL (ON CLUSTER) queries", 0) \
     \
     M(UInt64, external_storage_max_read_rows, 0, "Limit maximum number of rows when table with external engine should flush history data. Now supported only for MySQL table engine, database engine, dictionary and MaterializedMySQL. If equal to 0, this setting is disabled", 0) \
     M(UInt64, external_storage_max_read_bytes, 0, "Limit maximum number of bytes when table with external engine should flush history data. Now supported only for MySQL table engine, database engine, dictionary and MaterializedMySQL. If equal to 0, this setting is disabled", 0)  \

--- a/tests/queries/0_stateless/01175_distributed_ddl_output_mode_long.reference
+++ b/tests/queries/0_stateless/01175_distributed_ddl_output_mode_long.reference
@@ -27,19 +27,19 @@ localhost	9000	57	Code: 57. Error: Table default.never_throw already exists. (TA
 localhost	9000	0		1	0
 localhost	1	\N	\N	1	0
 distributed_ddl_queue
-2	localhost	9000	test_shard_localhost	CREATE TABLE default.none ON CLUSTER test_shard_localhost (`n` Int32) ENGINE = Memory	1	localhost	9000	Finished	0		1	1
-2	localhost	9000	test_shard_localhost	CREATE TABLE default.none ON CLUSTER test_shard_localhost (`n` Int32) ENGINE = Memory	1	localhost	9000	Finished	57	Code: 57. DB::Error: Table default.none already exists. (TABLE_ALREADY_EXISTS)	1	1
-2	localhost	9000	test_unavailable_shard	DROP TABLE IF EXISTS default.none ON CLUSTER test_unavailable_shard	1	localhost	1	Inactive	\N	\N	\N	\N
-2	localhost	9000	test_unavailable_shard	DROP TABLE IF EXISTS default.none ON CLUSTER test_unavailable_shard	1	localhost	9000	Finished	0		1	1
-2	localhost	9000	test_shard_localhost	CREATE TABLE default.throw ON CLUSTER test_shard_localhost (`n` Int32) ENGINE = Memory	1	localhost	9000	Finished	0		1	1
-2	localhost	9000	test_shard_localhost	CREATE TABLE default.throw ON CLUSTER test_shard_localhost (`n` Int32) ENGINE = Memory	1	localhost	9000	Finished	57	Code: 57. DB::Error: Table default.throw already exists. (TABLE_ALREADY_EXISTS)	1	1
-2	localhost	9000	test_unavailable_shard	DROP TABLE IF EXISTS default.throw ON CLUSTER test_unavailable_shard	1	localhost	1	Inactive	\N	\N	\N	\N
-2	localhost	9000	test_unavailable_shard	DROP TABLE IF EXISTS default.throw ON CLUSTER test_unavailable_shard	1	localhost	9000	Finished	0		1	1
-2	localhost	9000	test_shard_localhost	CREATE TABLE default.null_status ON CLUSTER test_shard_localhost (`n` Int32) ENGINE = Memory	1	localhost	9000	Finished	0		1	1
-2	localhost	9000	test_shard_localhost	CREATE TABLE default.null_status ON CLUSTER test_shard_localhost (`n` Int32) ENGINE = Memory	1	localhost	9000	Finished	57	Code: 57. DB::Error: Table default.null_status already exists. (TABLE_ALREADY_EXISTS)	1	1
-2	localhost	9000	test_unavailable_shard	DROP TABLE IF EXISTS default.null_status ON CLUSTER test_unavailable_shard	1	localhost	1	Inactive	\N	\N	\N	\N
-2	localhost	9000	test_unavailable_shard	DROP TABLE IF EXISTS default.null_status ON CLUSTER test_unavailable_shard	1	localhost	9000	Finished	0		1	1
-2	localhost	9000	test_shard_localhost	CREATE TABLE default.never_throw ON CLUSTER test_shard_localhost (`n` Int32) ENGINE = Memory	1	localhost	9000	Finished	0		1	1
-2	localhost	9000	test_shard_localhost	CREATE TABLE default.never_throw ON CLUSTER test_shard_localhost (`n` Int32) ENGINE = Memory	1	localhost	9000	Finished	57	Code: 57. DB::Error: Table default.never_throw already exists. (TABLE_ALREADY_EXISTS)	1	1
-2	localhost	9000	test_unavailable_shard	DROP TABLE IF EXISTS default.never_throw ON CLUSTER test_unavailable_shard	1	localhost	1	Inactive	\N	\N	\N	\N
-2	localhost	9000	test_unavailable_shard	DROP TABLE IF EXISTS default.never_throw ON CLUSTER test_unavailable_shard	1	localhost	9000	Finished	0		1	1
+5	localhost	9000	test_shard_localhost	CREATE TABLE default.none ON CLUSTER test_shard_localhost (`n` Int32) ENGINE = Memory	1	localhost	9000	Finished	0		1	1
+5	localhost	9000	test_shard_localhost	CREATE TABLE default.none ON CLUSTER test_shard_localhost (`n` Int32) ENGINE = Memory	1	localhost	9000	Finished	57	Code: 57. DB::Error: Table default.none already exists. (TABLE_ALREADY_EXISTS)	1	1
+5	localhost	9000	test_unavailable_shard	DROP TABLE IF EXISTS default.none ON CLUSTER test_unavailable_shard	1	localhost	1	Inactive	\N	\N	\N	\N
+5	localhost	9000	test_unavailable_shard	DROP TABLE IF EXISTS default.none ON CLUSTER test_unavailable_shard	1	localhost	9000	Finished	0		1	1
+5	localhost	9000	test_shard_localhost	CREATE TABLE default.throw ON CLUSTER test_shard_localhost (`n` Int32) ENGINE = Memory	1	localhost	9000	Finished	0		1	1
+5	localhost	9000	test_shard_localhost	CREATE TABLE default.throw ON CLUSTER test_shard_localhost (`n` Int32) ENGINE = Memory	1	localhost	9000	Finished	57	Code: 57. DB::Error: Table default.throw already exists. (TABLE_ALREADY_EXISTS)	1	1
+5	localhost	9000	test_unavailable_shard	DROP TABLE IF EXISTS default.throw ON CLUSTER test_unavailable_shard	1	localhost	1	Inactive	\N	\N	\N	\N
+5	localhost	9000	test_unavailable_shard	DROP TABLE IF EXISTS default.throw ON CLUSTER test_unavailable_shard	1	localhost	9000	Finished	0		1	1
+5	localhost	9000	test_shard_localhost	CREATE TABLE default.null_status ON CLUSTER test_shard_localhost (`n` Int32) ENGINE = Memory	1	localhost	9000	Finished	0		1	1
+5	localhost	9000	test_shard_localhost	CREATE TABLE default.null_status ON CLUSTER test_shard_localhost (`n` Int32) ENGINE = Memory	1	localhost	9000	Finished	57	Code: 57. DB::Error: Table default.null_status already exists. (TABLE_ALREADY_EXISTS)	1	1
+5	localhost	9000	test_unavailable_shard	DROP TABLE IF EXISTS default.null_status ON CLUSTER test_unavailable_shard	1	localhost	1	Inactive	\N	\N	\N	\N
+5	localhost	9000	test_unavailable_shard	DROP TABLE IF EXISTS default.null_status ON CLUSTER test_unavailable_shard	1	localhost	9000	Finished	0		1	1
+5	localhost	9000	test_shard_localhost	CREATE TABLE default.never_throw ON CLUSTER test_shard_localhost (`n` Int32) ENGINE = Memory	1	localhost	9000	Finished	0		1	1
+5	localhost	9000	test_shard_localhost	CREATE TABLE default.never_throw ON CLUSTER test_shard_localhost (`n` Int32) ENGINE = Memory	1	localhost	9000	Finished	57	Code: 57. DB::Error: Table default.never_throw already exists. (TABLE_ALREADY_EXISTS)	1	1
+5	localhost	9000	test_unavailable_shard	DROP TABLE IF EXISTS default.never_throw ON CLUSTER test_unavailable_shard	1	localhost	1	Inactive	\N	\N	\N	\N
+5	localhost	9000	test_unavailable_shard	DROP TABLE IF EXISTS default.never_throw ON CLUSTER test_unavailable_shard	1	localhost	9000	Finished	0		1	1

--- a/tests/queries/0_stateless/02761_ddl_initial_query_id.reference
+++ b/tests/queries/0_stateless/02761_ddl_initial_query_id.reference
@@ -1,4 +1,4 @@
-default distributed_ddl_entry_format_version
+distributed_ddl_entry_format_version=OPENTELEMETRY_ENABLED_VERSION (older then PRESERVE_INITIAL_QUERY_ID_VERSION)
 DROP TABLE IF EXISTS foo ON CLUSTER test_shard_localhost
 distributed_ddl_entry_format_version=PRESERVE_INITIAL_QUERY_ID_VERSION
 DROP TABLE IF EXISTS default.foo

--- a/tests/queries/0_stateless/02761_ddl_initial_query_id.sh
+++ b/tests/queries/0_stateless/02761_ddl_initial_query_id.sh
@@ -4,9 +4,10 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CUR_DIR"/../shell_config.sh
 
-echo "default distributed_ddl_entry_format_version"
+echo "distributed_ddl_entry_format_version=OPENTELEMETRY_ENABLED_VERSION (older then PRESERVE_INITIAL_QUERY_ID_VERSION)"
+OPENTELEMETRY_ENABLED_VERSION=4
 query_id="$(random_str 10)"
-$CLICKHOUSE_CLIENT --query_id "$query_id" --distributed_ddl_output_mode=none -q "DROP TABLE IF EXISTS foo ON CLUSTER test_shard_localhost"
+$CLICKHOUSE_CLIENT --distributed_ddl_entry_format_version=$OPENTELEMETRY_ENABLED_VERSION --query_id "$query_id" --distributed_ddl_output_mode=none -q "DROP TABLE IF EXISTS foo ON CLUSTER test_shard_localhost"
 $CLICKHOUSE_CLIENT -q "SYSTEM FLUSH LOGS"
 $CLICKHOUSE_CLIENT -q "SELECT query FROM system.query_log WHERE initial_query_id = '$query_id' AND type != 'QueryStart'"
 


### PR DESCRIPTION
### Changelog category (leave one):
- Backward Incompatible Change

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Bump version of the distributed_ddl_entry_format_version to 5 by default (enables opentelemetry and initial_query_idd pass through). This will not allow to process existing entries for distributed DDL after **downgrade** (but note, that usually there should be no such unprocessed entries)

This will enable the following features for distributed DDL queries:
- opentelemetry support (#41484, #50045)
- initial_query_id pass through (#50015)