### PR TITLE
Add array_agg as alias of groupArray for PostgreSQL compatibility

### DIFF
--- a/docs/en/sql-reference/aggregate-functions/reference/grouparray.md
+++ b/docs/en/sql-reference/aggregate-functions/reference/grouparray.md
@@ -44,3 +44,5 @@ Result:
 ```
 
 The groupArray function will remove ᴺᵁᴸᴸ value based on the above results.
+
+- Alias: `array_agg`.

--- a/src/AggregateFunctions/AggregateFunctionGroupArray.cpp
+++ b/src/AggregateFunctions/AggregateFunctionGroupArray.cpp
@@ -125,6 +125,7 @@ void registerAggregateFunctionGroupArray(AggregateFunctionFactory & factory)
     AggregateFunctionProperties properties = { .returns_default_when_only_null = false, .is_order_dependent = true };
 
     factory.registerFunction("groupArray", { createAggregateFunctionGroupArray<false>, properties });
+    factory.registerAlias("array_agg", "groupArray", AggregateFunctionFactory::CaseInsensitive);
     factory.registerFunction("groupArraySample", { createAggregateFunctionGroupArraySample, properties });
     factory.registerFunction("groupArrayLast", { createAggregateFunctionGroupArray<true>, properties });
 }

--- a/tests/queries/0_stateless/02813_array_agg.reference
+++ b/tests/queries/0_stateless/02813_array_agg.reference
@@ -1,0 +1,6 @@
+['hello, world!','hello, world!','hello, world!','hello, world!','hello, world!']
+['hello, world!']
+['hello, world!']
+['hello, world!']
+['hello, world!']
+['hello, world!']

--- a/tests/queries/0_stateless/02813_array_agg.sql
+++ b/tests/queries/0_stateless/02813_array_agg.sql
@@ -1,0 +1,10 @@
+drop table if exists t;
+create table t (n Int32, s String) engine=MergeTree order by n;
+
+insert into t select number, 'hello, world!' from numbers (5);
+
+select array_agg(s) from t;
+
+select aRray_Agg(s) from t group by n;
+
+drop table t;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- New Feature


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add `array_agg` as alias of `groupArray` for PostgreSQL compatibility. Closes #52100.
### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
