### PR TITLE
Fix possible EADDRINUSE ("Address already in use") in integration tests

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -13,6 +13,22 @@ logging.raiseExceptions = False
 
 
 @pytest.fixture(autouse=True, scope="session")
+def tune_local_port_range():
+    # Lots of services uses non privileged ports:
+    # - hdfs -- 50020/50070/...
+    # - minio
+    # - mysql
+    # - psql
+    #
+    # So instead of tuning all these thirdparty services, let's simply
+    # prohibit using such ports for outgoing connections, this should fix
+    # possible "Address already in use" errors.
+    #
+    # NOTE: 5K is not enough, and sometimes leads to EADDRNOTAVAIL error.
+    run_and_check(["sysctl net.ipv4.ip_local_port_range='55000 65535'"], shell=True)
+
+
+@pytest.fixture(autouse=True, scope="session")
 def cleanup_environment():
     try:
         if int(os.environ.get("PYTEST_CLEANUP_CONTAINERS", 0)) == 1:


### PR DESCRIPTION
Here is one example [1]:

    minio1_1    | WARNING: Console endpoint is listening on a dynamic port (32911), please use --console-address ":PORT" to choose a static port.
    minio1_1    | ERROR Unable to initialize console server: Specified port is already in use
    minio1_1    |       > Please ensure no other program uses the same address/port

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/52103/7d510eac7c5f0dfb3361e269be30972e6022fada/integration_tests__tsan__[1_6].html

And here is second [2]:

    java.net.BindException: Problem binding to [0.0.0.0:50020] java.net.BindException: Address already in use; For more details see:  http://wiki.apache.org/hadoop/BindException

  [2]: https://s3.amazonaws.com/clickhouse-test-reports/51493/63e88b725d3d255a6534adce4d434ce5f95d2874/integration_tests__asan__[1_6].html

P.S. I think 5K ports should be enough.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)