### PR TITLE
Fix LOGICAL_ERROR if SETTINGS are specified in table function argument

### DIFF
--- a/src/Parsers/ASTSetQuery.h
+++ b/src/Parsers/ASTSetQuery.h
@@ -37,6 +37,8 @@ public:
     void updateTreeHashImpl(SipHash & hash_state) const override;
 
     QueryKind getQueryKind() const override { return QueryKind::Set; }
+
+    void appendColumnName(WriteBuffer &) const override;
 };
 
 }

--- a/tests/queries/0_stateless/02815_settings_in_table_function_arg.sql
+++ b/tests/queries/0_stateless/02815_settings_in_table_function_arg.sql
@@ -1,0 +1,4 @@
+select * from numbers(SETTINGS max_threads = 1); -- { serverError BAD_ARGUMENTS }
+select * from numbers(coalesce(coalesce(1024, coalesce(coalesce(executable('JSON', 'data String', SETTINGS max_command_execution_time = 100), 65535, coalesce(coalesce(coalesce(coalesce(coalesce(coalesce(coalesce(coalesce(2147483647, '0.0000065537'), '65535')), NULL), 10, '1'), '0.0001048577')), NULL))), NULL)), 0) ; -- { serverError BAD_ARGUMENTS }
+
+


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Change exception code in `ASTSetQuery::appendColumnName` in order to avoid LOGICAL_ERROR in case if settings are specified for table function constant argument.

https://s3.amazonaws.com/clickhouse-test-reports/0/84f7a6a6d7de25063a13cb67889e75d47a191fb9/fuzzer_astfuzzermsan/report.html