### PR TITLE
Fix network manager for integration tests

### DIFF
--- a/tests/integration/helpers/network.py
+++ b/tests/integration/helpers/network.py
@@ -219,10 +219,15 @@ class _NetworkManager:
 
     def __init__(
         self,
-        container_expire_timeout=120,
-        container_exit_timeout=120,
+        container_expire_timeout=600,
+        container_exit_timeout=660,
         docker_api_version=os.environ.get("DOCKER_API_VERSION"),
     ):
+        # container should be alive for at least 15 seconds then the expiration
+        # timeout, this is the protection from the case when the container will
+        # be destroyed just when some test will try to use it.
+        assert container_exit_timeout >= container_expire_timeout + 15
+
         self.container_expire_timeout = container_expire_timeout
         self.container_exit_timeout = container_exit_timeout
 


### PR DESCRIPTION
Sometimes you may get:

    >           raise subprocess.CalledProcessError(exit_code, cmd)
    E           subprocess.CalledProcessError: Command '['iptables', '--wait', '-D', 'DOCKER-USER', '-p', 'tcp', '-s', '172.16.2.3', '-d', '172.16.2.2', '-j', 'DROP']' returned non-zero exit status 137.

And only sometimes you may get the reason:

    OCI runtime exec failed: exec failed: cannot exec in a stopped container: unknown

So this means that container for iptables does not exists anymore, and the reason is the timeout. And the fact that container_exit_timeout was equal to container_expire_timeout and was 120.

From the docker logs:

    time="2023-07-16T15:46:52.513673446Z" level=debug msg="form data: {\"AttachStderr\":false,\"AttachStdin\":false,\"AttachStdout\":false,\"Cmd\":[\"sleep\",\"120\"],\"HostConfig\":{\"AutoRemove\":true,\"NetworkMode\":\"host\"},\"Image\":\"clickhouse/integration-helper:latest\",\"NetworkDisabled\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Tty\":false}"
    time="2023-07-16T15:48:57.611857183Z" level=debug msg="form data: {\"AttachStderr\":false,\"AttachStdin\":false,\"AttachStdout\":false,\"Cmd\":[\"sleep\",\"120\"],\"HostConfig\":{\"AutoRemove\":true,\"NetworkMode\":\"host\"},\"Image\":\"clickhouse/integration-helper:latest\",\"NetworkDisabled\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Tty\":false}"

And then pytest will try to execute the iptables command:

    time="2023-07-16T15:50:57.698705244Z" level=debug msg="starting exec command 860920ab2aa07e8d285050f200ac92423a3cf8ec3fb2f57683541e62cf6bc20e in container 66d6c96671b5e987345290ddd260727d96b99789b512d40f333f6263f42fd2f1"

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Cc: @alexey-milovidov 