### PR TITLE
Fix 'Fuzzer failed (134)'

### DIFF
--- a/programs/client/Client.cpp
+++ b/programs/client/Client.cpp
@@ -812,6 +812,11 @@ bool Client::processWithFuzzing(const String & full_query)
         }
         catch (...)
         {
+            if (!ast_to_process)
+                fmt::print(stderr,
+                    "Error while forming new query: {}\n",
+                    getCurrentExceptionMessage(true));
+
             // Some functions (e.g. protocol parsers) don't throw, but
             // set last_exception instead, so we'll also do it here for
             // uniformity.

--- a/src/Client/QueryFuzzer.cpp
+++ b/src/Client/QueryFuzzer.cpp
@@ -221,6 +221,10 @@ Field QueryFuzzer::fuzzField(Field field)
         }
     }
 
+    /// If we made the field too deep, throw exception here, before calling the noexcept move
+    /// constructor that would terminate the whole process if field is invalid.
+    field.validate();
+
     return field;
 }
 

--- a/src/Core/Field.cpp
+++ b/src/Core/Field.cpp
@@ -304,6 +304,11 @@ void writeFieldText(const Field & x, WriteBuffer & buf)
 }
 
 
+void Field::validate()
+{
+    dispatch([this] (auto & value) { calculateAndCheckFieldDepth<NearestFieldType<std::decay_t<decltype(value)>>>(value); }, *this);
+}
+
 String Field::dump() const
 {
     return applyVisitor(FieldVisitorDump(), *this);

--- a/src/Core/Field.h
+++ b/src/Core/Field.h
@@ -659,6 +659,9 @@ public:
         UNREACHABLE();
     }
 
+    // Throws if anything's wrong, e.g. the field is too deep.
+    void validate();
+
     String dump() const;
     static Field restoreFromDump(std::string_view dump_);
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Fixes https://github.com/ClickHouse/ClickHouse/issues/52214

When fuzzed produces a Field with too much nesting, it would either crash from exception thrown from noexcept move constructor or crash from trying to cast a null pointer. This PR fixes both.