### PR TITLE
New analyzer: add duplicate order by pass

### DIFF
--- a/src/Analyzer/Passes/DuplicateOrderByPass.cpp
+++ b/src/Analyzer/Passes/DuplicateOrderByPass.cpp
@@ -91,10 +91,10 @@ bool containsStatefulFunc(const QueryTreeNodes & nodes)
     return false;
 }
 
-class DuplicateOrderByVisitor : public InDepthQueryTreeVisitorWithContext<DuplicateOrderByVisitor>
+class DuplicateOrderByVisitor : public InDepthQueryTreeVisitor<DuplicateOrderByVisitor>
 {
 public:
-    using Base = InDepthQueryTreeVisitorWithContext<DuplicateOrderByVisitor>;
+    using Base = InDepthQueryTreeVisitor<DuplicateOrderByVisitor>;
     using Base::Base;
 
     static bool shouldTraverseTopToBottom()
@@ -104,9 +104,6 @@ public:
 
     void visitImpl(QueryTreeNodePtr & node)
     {
-        if (!getSettings().optimize_duplicate_order_by_and_distinct)
-            return;
-
         auto * query_node = node->as<QueryNode>();
 
         if (!query_node)
@@ -133,7 +130,10 @@ public:
 
 void DuplicateOrderByPass::run(QueryTreeNodePtr query_tree_node, ContextPtr context)
 {
-    DuplicateOrderByVisitor visitor(context);
+    if (!context->getSettings().optimize_duplicate_order_by_and_distinct)
+        return;
+
+    DuplicateOrderByVisitor visitor;
     visitor.visit(query_tree_node);
 }
 

--- a/src/Analyzer/Passes/DuplicateOrderByPass.cpp
+++ b/src/Analyzer/Passes/DuplicateOrderByPass.cpp
@@ -1,0 +1,140 @@
+#include "DuplicateOrderByPass.h"
+
+#include <AggregateFunctions/AggregateFunctionFactory.h>
+#include <Analyzer/FunctionNode.h>
+#include <Analyzer/InDepthQueryTreeVisitor.h>
+#include <Analyzer/QueryNode.h>
+#include <Analyzer/SortNode.h>
+#include <Analyzer/JoinNode.h>
+
+namespace DB
+{
+
+namespace
+{
+
+/// Remove order by clause from subquery node
+void removeOrderby(QueryNode * subquery_node)
+{
+    if (!subquery_node->hasOrderBy())
+        return;
+
+    /// If we have limits then the ORDER BY is non-removable.
+    if (subquery_node->hasLimit() || subquery_node->hasLimitBy()
+        || subquery_node->hasLimitByLimit() || subquery_node->hasLimitByOffset())
+        return;
+
+    /// If ORDER BY contains filling (in addition to sorting) it is non-removable.
+    for (const auto & child : subquery_node->getOrderBy().getNodes())
+    {
+        if (auto * sort_node = child->as<SortNode>())
+        {
+            if (sort_node->hasFillStep() || sort_node->hasFillTo() || sort_node->hasFillFrom())
+                return;
+        }
+    }
+
+    /// remove order by
+    subquery_node->getOrderBy().getNodes().clear();
+}
+
+/// remove order by from join tree
+void removeFromJoinTree(QueryTreeNodePtr& join_tree)
+{
+    if (auto * subquery_node = join_tree->as<QueryNode>())
+    {
+        removeOrderby(subquery_node);
+    }
+    else if (auto * join_node = join_tree->as<JoinNode>())
+    {
+        removeFromJoinTree(join_node->getLeftTableExpression());
+        removeFromJoinTree(join_node->getRightTableExpression());
+    }
+};
+
+/// Whether nodes contain stateful functions
+class StatefulFunctionsVisitor : public ConstInDepthQueryTreeVisitor<StatefulFunctionsVisitor>
+{
+public:
+    using Base = ConstInDepthQueryTreeVisitor<StatefulFunctionsVisitor>;
+    using Base::Base;
+
+    bool contains_stateful_function = false;
+
+    void visitImpl(const QueryTreeNodePtr & node)
+    {
+        if (auto * to_check_func = node->as<FunctionNode>())
+        {
+            if (to_check_func->getAggregateFunction())
+            {
+                auto agg_func_properties = AggregateFunctionFactory::instance().tryGetProperties(to_check_func->getFunctionName());
+                if (agg_func_properties && agg_func_properties->is_order_dependent)
+                    contains_stateful_function = true;
+            }
+            else if (to_check_func->getFunction()->isStateful())
+            {
+                contains_stateful_function = true;
+            }
+        }
+    }
+};
+
+bool containsStatefulFunc(const QueryTreeNodes & nodes)
+{
+    for (const auto & node : nodes)
+    {
+        StatefulFunctionsVisitor visitor;
+        visitor.visit(node);
+        if (visitor.contains_stateful_function)
+            return true;
+    }
+    return false;
+}
+
+class DuplicateOrderByVisitor : public InDepthQueryTreeVisitorWithContext<DuplicateOrderByVisitor>
+{
+public:
+    using Base = InDepthQueryTreeVisitorWithContext<DuplicateOrderByVisitor>;
+    using Base::Base;
+
+    static bool shouldTraverseTopToBottom() const
+    {
+        return false;
+    }
+
+    void visitImpl(QueryTreeNodePtr & node)
+    {
+        if (!getSettings().optimize_duplicate_order_by_and_distinct)
+            return;
+
+        auto * query_node = node->as<QueryNode>();
+
+        if (!query_node)
+            return;
+
+        if (!query_node->hasOrderBy() && !query_node->hasGroupBy())
+            return;
+
+        if (containsStatefulFunc(query_node->getProjection().getNodes()))
+            return;
+
+        if (query_node->hasGroupBy())
+        {
+            if (containsStatefulFunc(query_node->getGroupBy().getNodes()))
+                return;
+        }
+
+        /// checking done, remove order by
+        removeFromJoinTree(query_node->getJoinTree());
+    }
+};
+
+}
+
+void DuplicateOrderByPass::run(QueryTreeNodePtr query_tree_node, ContextPtr context)
+{
+    DuplicateOrderByVisitor visitor(context);
+    visitor.visit(query_tree_node);
+}
+
+}

--- a/src/Analyzer/Passes/DuplicateOrderByPass.cpp
+++ b/src/Analyzer/Passes/DuplicateOrderByPass.cpp
@@ -97,7 +97,7 @@ public:
     using Base = InDepthQueryTreeVisitorWithContext<DuplicateOrderByVisitor>;
     using Base::Base;
 
-    static bool shouldTraverseTopToBottom() const
+    static bool shouldTraverseTopToBottom()
     {
         return false;
     }

--- a/src/Analyzer/Passes/DuplicateOrderByPass.h
+++ b/src/Analyzer/Passes/DuplicateOrderByPass.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <Analyzer/IQueryTreePass.h>
+
+namespace DB
+{
+
+/** Remove duplicate ORDER BY if it's possible.
+  *
+  * Example: SELECT c1 FROM (SELECT c1 FROM table ORDER BY c1) ORDER BY c1;
+  * Result: SELECT c1 FROM (SELECT c1 FROM table) ORDER BY c1;
+  *
+  * Example: SELECT c1 FROM (SELECT c1 FROM table ORDER BY c1) GROUP BY c1;
+  * Result: SELECT c1 FROM (SELECT c1 FROM table) ORDER BY c1;
+  */
+class DuplicateOrderByPass final : public IQueryTreePass
+{
+public:
+    String getName() override { return "DuplicateOrderBy"; }
+
+    String getDescription() override
+    {
+        return "Remove duplicate ORDER BY if it's possible.";
+    }
+
+    void run(QueryTreeNodePtr query_tree_node, ContextPtr context) override;
+
+};
+
+}

--- a/src/Analyzer/QueryTreePassManager.cpp
+++ b/src/Analyzer/QueryTreePassManager.cpp
@@ -42,6 +42,7 @@
 #include <Analyzer/Passes/CrossToInnerJoinPass.h>
 #include <Analyzer/Passes/ShardNumColumnToFunctionPass.h>
 #include <Analyzer/Passes/ConvertQueryToCNFPass.h>
+#include <Analyzer/Passes/DuplicateOrderByPass.h>
 
 namespace DB
 {
@@ -278,6 +279,8 @@ void addQueryTreePasses(QueryTreePassManager & manager)
     manager.addPass(std::make_unique<AutoFinalOnQueryPass>());
     manager.addPass(std::make_unique<CrossToInnerJoinPass>());
     manager.addPass(std::make_unique<ShardNumColumnToFunctionPass>());
+
+    manager.addPass(std::make_unique<DuplicateOrderByPass>());
 }
 
 }

--- a/tests/queries/0_stateless/02816_analyzer_duplicate_order_by.reference
+++ b/tests/queries/0_stateless/02816_analyzer_duplicate_order_by.reference
@@ -1,0 +1,152 @@
+QUERY id: 0
+  PROJECTION COLUMNS
+    number UInt64
+  PROJECTION
+    LIST id: 1, nodes: 1
+      COLUMN id: 2, column_name: number, result_type: UInt64, source_id: 3
+  JOIN TREE
+    QUERY id: 3, is_subquery: 1
+      PROJECTION COLUMNS
+        number UInt64
+      PROJECTION
+        LIST id: 4, nodes: 1
+          COLUMN id: 5, column_name: number, result_type: UInt64, source_id: 6
+      JOIN TREE
+        QUERY id: 6, is_subquery: 1
+          PROJECTION COLUMNS
+            number UInt64
+          PROJECTION
+            LIST id: 7, nodes: 1
+              COLUMN id: 8, column_name: number, result_type: UInt64, source_id: 9
+          JOIN TREE
+            TABLE_FUNCTION id: 9, table_function_name: numbers
+              ARGUMENTS
+                LIST id: 10, nodes: 1
+                  CONSTANT id: 11, constant_value: UInt64_3, constant_value_type: UInt8
+  ORDER BY
+    LIST id: 12, nodes: 1
+      SORT id: 13, sort_direction: ASCENDING, with_fill: 0
+        EXPRESSION
+          COLUMN id: 14, column_name: number, result_type: UInt64, source_id: 3
+QUERY id: 0
+  PROJECTION COLUMNS
+    number UInt64
+  PROJECTION
+    LIST id: 1, nodes: 1
+      COLUMN id: 2, column_name: number, result_type: UInt64, source_id: 3
+  JOIN TREE
+    QUERY id: 3, is_subquery: 1
+      PROJECTION COLUMNS
+        number UInt64
+      PROJECTION
+        LIST id: 4, nodes: 1
+          COLUMN id: 5, column_name: number, result_type: UInt64, source_id: 6
+      JOIN TREE
+        QUERY id: 6, is_subquery: 1
+          PROJECTION COLUMNS
+            number UInt64
+          PROJECTION
+            LIST id: 7, nodes: 1
+              COLUMN id: 8, column_name: number, result_type: UInt64, source_id: 9
+          JOIN TREE
+            TABLE_FUNCTION id: 9, table_function_name: numbers
+              ARGUMENTS
+                LIST id: 10, nodes: 1
+                  CONSTANT id: 11, constant_value: UInt64_3, constant_value_type: UInt8
+          ORDER BY
+            LIST id: 12, nodes: 1
+              SORT id: 13, sort_direction: ASCENDING, with_fill: 0
+                EXPRESSION
+                  COLUMN id: 14, column_name: number, result_type: UInt64, source_id: 9
+      ORDER BY
+        LIST id: 15, nodes: 1
+          SORT id: 16, sort_direction: ASCENDING, with_fill: 0
+            EXPRESSION
+              COLUMN id: 17, column_name: number, result_type: UInt64, source_id: 6
+  ORDER BY
+    LIST id: 18, nodes: 1
+      SORT id: 19, sort_direction: ASCENDING, with_fill: 0
+        EXPRESSION
+          COLUMN id: 20, column_name: number, result_type: UInt64, source_id: 3
+QUERY id: 0
+  PROJECTION COLUMNS
+    number UInt8
+  PROJECTION
+    LIST id: 1, nodes: 1
+      COLUMN id: 2, column_name: number, result_type: UInt8, source_id: 3
+  JOIN TREE
+    QUERY id: 3, is_subquery: 1
+      PROJECTION COLUMNS
+        number UInt8
+      PROJECTION
+        LIST id: 4, nodes: 1
+          COLUMN id: 5, column_name: number, result_type: UInt8, source_id: 6
+      JOIN TREE
+        QUERY id: 6, is_subquery: 1
+          PROJECTION COLUMNS
+            number UInt8
+          PROJECTION
+            LIST id: 7, nodes: 1
+              FUNCTION id: 8, function_name: modulo, function_type: ordinary, result_type: UInt8
+                ARGUMENTS
+                  LIST id: 9, nodes: 2
+                    COLUMN id: 10, column_name: number, result_type: UInt64, source_id: 11
+                    CONSTANT id: 12, constant_value: UInt64_2, constant_value_type: UInt8
+          JOIN TREE
+            TABLE_FUNCTION id: 11, table_function_name: numbers
+              ARGUMENTS
+                LIST id: 13, nodes: 1
+                  CONSTANT id: 14, constant_value: UInt64_3, constant_value_type: UInt8
+  ORDER BY
+    LIST id: 15, nodes: 1
+      SORT id: 16, sort_direction: ASCENDING, with_fill: 0
+        EXPRESSION
+          COLUMN id: 17, column_name: number, result_type: UInt8, source_id: 3
+QUERY id: 0
+  PROJECTION COLUMNS
+    number UInt8
+  PROJECTION
+    LIST id: 1, nodes: 1
+      COLUMN id: 2, column_name: number, result_type: UInt8, source_id: 3
+  JOIN TREE
+    QUERY id: 3, is_subquery: 1
+      PROJECTION COLUMNS
+        number UInt8
+      PROJECTION
+        LIST id: 4, nodes: 1
+          COLUMN id: 5, column_name: number, result_type: UInt8, source_id: 6
+      JOIN TREE
+        QUERY id: 6, is_subquery: 1
+          PROJECTION COLUMNS
+            number UInt8
+          PROJECTION
+            LIST id: 7, nodes: 1
+              FUNCTION id: 8, function_name: modulo, function_type: ordinary, result_type: UInt8
+                ARGUMENTS
+                  LIST id: 9, nodes: 2
+                    COLUMN id: 10, column_name: number, result_type: UInt64, source_id: 11
+                    CONSTANT id: 12, constant_value: UInt64_2, constant_value_type: UInt8
+          JOIN TREE
+            TABLE_FUNCTION id: 11, table_function_name: numbers
+              ARGUMENTS
+                LIST id: 13, nodes: 1
+                  CONSTANT id: 14, constant_value: UInt64_3, constant_value_type: UInt8
+          ORDER BY
+            LIST id: 15, nodes: 1
+              SORT id: 16, sort_direction: ASCENDING, with_fill: 0
+                EXPRESSION
+                  FUNCTION id: 8, function_name: modulo, function_type: ordinary, result_type: UInt8
+                    ARGUMENTS
+                      LIST id: 9, nodes: 2
+                        COLUMN id: 10, column_name: number, result_type: UInt64, source_id: 11
+                        CONSTANT id: 12, constant_value: UInt64_2, constant_value_type: UInt8
+      ORDER BY
+        LIST id: 17, nodes: 1
+          SORT id: 18, sort_direction: ASCENDING, with_fill: 0
+            EXPRESSION
+              COLUMN id: 19, column_name: number, result_type: UInt8, source_id: 6
+  ORDER BY
+    LIST id: 20, nodes: 1
+      SORT id: 21, sort_direction: ASCENDING, with_fill: 0
+        EXPRESSION
+          COLUMN id: 22, column_name: number, result_type: UInt8, source_id: 3

--- a/tests/queries/0_stateless/02816_analyzer_duplicate_order_by.reference
+++ b/tests/queries/0_stateless/02816_analyzer_duplicate_order_by.reference
@@ -70,83 +70,48 @@ QUERY id: 0
           COLUMN id: 20, column_name: number, result_type: UInt64, source_id: 3
 QUERY id: 0
   PROJECTION COLUMNS
-    number UInt8
+    number UInt64
   PROJECTION
     LIST id: 1, nodes: 1
-      COLUMN id: 2, column_name: number, result_type: UInt8, source_id: 3
+      COLUMN id: 2, column_name: number, result_type: UInt64, source_id: 3
   JOIN TREE
     QUERY id: 3, is_subquery: 1
       PROJECTION COLUMNS
-        number UInt8
+        number UInt64
       PROJECTION
         LIST id: 4, nodes: 1
-          COLUMN id: 5, column_name: number, result_type: UInt8, source_id: 6
+          COLUMN id: 5, column_name: number, result_type: UInt64, source_id: 6
       JOIN TREE
-        QUERY id: 6, is_subquery: 1
-          PROJECTION COLUMNS
-            number UInt8
-          PROJECTION
+        TABLE_FUNCTION id: 6, table_function_name: numbers
+          ARGUMENTS
             LIST id: 7, nodes: 1
-              FUNCTION id: 8, function_name: modulo, function_type: ordinary, result_type: UInt8
-                ARGUMENTS
-                  LIST id: 9, nodes: 2
-                    COLUMN id: 10, column_name: number, result_type: UInt64, source_id: 11
-                    CONSTANT id: 12, constant_value: UInt64_2, constant_value_type: UInt8
-          JOIN TREE
-            TABLE_FUNCTION id: 11, table_function_name: numbers
-              ARGUMENTS
-                LIST id: 13, nodes: 1
-                  CONSTANT id: 14, constant_value: UInt64_3, constant_value_type: UInt8
-  ORDER BY
-    LIST id: 15, nodes: 1
-      SORT id: 16, sort_direction: ASCENDING, with_fill: 0
-        EXPRESSION
-          COLUMN id: 17, column_name: number, result_type: UInt8, source_id: 3
+              CONSTANT id: 8, constant_value: UInt64_3, constant_value_type: UInt8
+  GROUP BY
+    LIST id: 9, nodes: 1
+      COLUMN id: 10, column_name: number, result_type: UInt64, source_id: 3
 QUERY id: 0
   PROJECTION COLUMNS
-    number UInt8
+    number UInt64
   PROJECTION
     LIST id: 1, nodes: 1
-      COLUMN id: 2, column_name: number, result_type: UInt8, source_id: 3
+      COLUMN id: 2, column_name: number, result_type: UInt64, source_id: 3
   JOIN TREE
     QUERY id: 3, is_subquery: 1
       PROJECTION COLUMNS
-        number UInt8
+        number UInt64
       PROJECTION
         LIST id: 4, nodes: 1
-          COLUMN id: 5, column_name: number, result_type: UInt8, source_id: 6
+          COLUMN id: 5, column_name: number, result_type: UInt64, source_id: 6
       JOIN TREE
-        QUERY id: 6, is_subquery: 1
-          PROJECTION COLUMNS
-            number UInt8
-          PROJECTION
+        TABLE_FUNCTION id: 6, table_function_name: numbers
+          ARGUMENTS
             LIST id: 7, nodes: 1
-              FUNCTION id: 8, function_name: modulo, function_type: ordinary, result_type: UInt8
-                ARGUMENTS
-                  LIST id: 9, nodes: 2
-                    COLUMN id: 10, column_name: number, result_type: UInt64, source_id: 11
-                    CONSTANT id: 12, constant_value: UInt64_2, constant_value_type: UInt8
-          JOIN TREE
-            TABLE_FUNCTION id: 11, table_function_name: numbers
-              ARGUMENTS
-                LIST id: 13, nodes: 1
-                  CONSTANT id: 14, constant_value: UInt64_3, constant_value_type: UInt8
-          ORDER BY
-            LIST id: 15, nodes: 1
-              SORT id: 16, sort_direction: ASCENDING, with_fill: 0
-                EXPRESSION
-                  FUNCTION id: 8, function_name: modulo, function_type: ordinary, result_type: UInt8
-                    ARGUMENTS
-                      LIST id: 9, nodes: 2
-                        COLUMN id: 10, column_name: number, result_type: UInt64, source_id: 11
-                        CONSTANT id: 12, constant_value: UInt64_2, constant_value_type: UInt8
+              CONSTANT id: 8, constant_value: UInt64_3, constant_value_type: UInt8
       ORDER BY
-        LIST id: 17, nodes: 1
-          SORT id: 18, sort_direction: ASCENDING, with_fill: 0
+        LIST id: 9, nodes: 1
+          SORT id: 10, sort_direction: ASCENDING, with_fill: 0
             EXPRESSION
-              COLUMN id: 19, column_name: number, result_type: UInt8, source_id: 6
-  ORDER BY
-    LIST id: 20, nodes: 1
-      SORT id: 21, sort_direction: ASCENDING, with_fill: 0
-        EXPRESSION
-          COLUMN id: 22, column_name: number, result_type: UInt8, source_id: 3
+              COLUMN id: 11, column_name: number, result_type: UInt64, source_id: 6
+  GROUP BY
+    LIST id: 12, nodes: 1
+      COLUMN id: 13, column_name: number, result_type: UInt64, source_id: 3

--- a/tests/queries/0_stateless/02816_analyzer_duplicate_order_by.sql
+++ b/tests/queries/0_stateless/02816_analyzer_duplicate_order_by.sql
@@ -1,0 +1,67 @@
+set allow_experimental_analyzer = 1;
+
+set optimize_duplicate_order_by_and_distinct = 1;
+
+EXPLAIN QUERY TREE SELECT *
+FROM
+(
+    SELECT *
+    FROM
+    (
+        SELECT *
+        FROM numbers(3)
+        ORDER BY number
+    )
+    ORDER BY number
+)
+ORDER BY number;
+
+set optimize_duplicate_order_by_and_distinct = 0;
+
+EXPLAIN QUERY TREE SELECT *
+FROM
+(
+   SELECT *
+   FROM
+   (
+       SELECT *
+       FROM numbers(3)
+       ORDER BY number
+   )
+   ORDER BY number
+)
+ORDER BY number;
+
+set optimize_duplicate_order_by_and_distinct = 1;
+
+EXPLAIN QUERY TREE SELECT *
+FROM
+(
+    SELECT *
+    FROM
+    (
+        SELECT number % 2
+        AS number
+        FROM numbers(3)
+        ORDER BY number
+    )
+    ORDER BY number
+)
+ORDER BY number;
+
+set optimize_duplicate_order_by_and_distinct = 0;
+
+EXPLAIN QUERY TREE SELECT *
+FROM
+(
+    SELECT *
+    FROM
+    (
+        SELECT number % 2
+        AS number
+        FROM numbers(3)
+        ORDER BY number
+    )
+    ORDER BY number
+)
+ORDER BY number;

--- a/tests/queries/0_stateless/02816_analyzer_duplicate_order_by.sql
+++ b/tests/queries/0_stateless/02816_analyzer_duplicate_order_by.sql
@@ -37,31 +37,19 @@ set optimize_duplicate_order_by_and_distinct = 1;
 EXPLAIN QUERY TREE SELECT *
 FROM
 (
-    SELECT *
-    FROM
-    (
-        SELECT number % 2
-        AS number
-        FROM numbers(3)
-        ORDER BY number
-    )
-    ORDER BY number
+   SELECT *
+   FROM numbers(3)
+   ORDER BY number
 )
-ORDER BY number;
+GROUP BY number;
 
 set optimize_duplicate_order_by_and_distinct = 0;
 
 EXPLAIN QUERY TREE SELECT *
 FROM
 (
-    SELECT *
-    FROM
-    (
-        SELECT number % 2
-        AS number
-        FROM numbers(3)
-        ORDER BY number
-    )
-    ORDER BY number
+   SELECT *
+   FROM numbers(3)
+   ORDER BY number
 )
-ORDER BY number;
+GROUP BY number;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Remove duplicate ORDER BY if it's possible.

Example: SELECT c1 FROM (SELECT c1 FROM table ORDER BY c1) ORDER BY c1;
Result: SELECT c1 FROM (SELECT c1 FROM table) ORDER BY c1;

Example: SELECT c1 FROM (SELECT c1 FROM table ORDER BY c1) GROUP BY c1;
Result: SELECT c1 FROM (SELECT c1 FROM table) ORDER BY c1;


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
