### PR TITLE
New analyzer: add duplicate distinct pass

### DIFF
--- a/src/Analyzer/Passes/DuplicateDistinctPass.cpp
+++ b/src/Analyzer/Passes/DuplicateDistinctPass.cpp
@@ -1,0 +1,103 @@
+#include "DuplicateDistinctPass.h"
+
+#include <Analyzer/InDepthQueryTreeVisitor.h>
+#include <Analyzer/ColumnNode.h>
+#include <Analyzer/QueryNode.h>
+
+namespace DB
+{
+
+namespace
+{
+
+/// Check whether query_node and subquery_node projection columns matches.
+bool projectionMatches(const QueryNode * query_node, const QueryNode * subquery_node)
+{
+    auto query_columns = query_node->getProjection().getNodes();
+    auto subquery_columns = subquery_node->getProjectionColumns();
+
+    for (const auto & query_column : query_columns)
+    {
+        auto find = std::find_if(
+            subquery_columns.begin(),
+            subquery_columns.end(),
+            [&](const auto & subquery_column) -> bool
+            {
+                if (auto * column_node = query_column->as<ColumnNode>())
+                {
+                    return subquery_column == column_node->getColumn();
+                }
+                return false;
+            });
+
+        if (find == subquery_columns.end())
+            return false;
+    }
+    return true;
+};
+
+class DuplicateDistinctVisitor : public InDepthQueryTreeVisitorWithContext<DuplicateDistinctVisitor>
+{
+public:
+    using Base = InDepthQueryTreeVisitorWithContext<DuplicateDistinctVisitor>;
+    using Base::Base;
+
+    static bool shouldTraverseTopToBottom()
+    {
+        return false;
+    }
+
+    void visitImpl(QueryTreeNodePtr & node)
+    {
+        if (!getSettings().optimize_duplicate_order_by_and_distinct)
+            return;
+        if (getSettings().distributed_group_by_no_merge)
+            return;
+
+        auto * query_node = node->as<QueryNode>();
+        if (!query_node)
+            return;
+
+        auto * subquery_node = query_node->getJoinTree()->as<QueryNode>();
+        if (!subquery_node)
+        {
+            subquery_is_distinct = query_node->isDistinct();
+            return;
+        }
+
+        if (!subquery_is_distinct)
+        {
+            subquery_is_distinct = query_node->isDistinct();
+            return;
+        }
+
+        /// Check whether query_node and subquery_node projection columns matches.
+        auto match = projectionMatches(query_node, subquery_node);
+
+        if (query_node->isDistinct() && match)
+        {
+            /// we can remove distinct
+            query_node->setIsDistinct(false);
+        }
+
+        subquery_is_distinct = query_node->isDistinct() || match;
+    }
+
+private:
+    /// Identify whether subquery provide distinct result.
+    ///     1. true if subquery has distinct modifier
+    ///     2. true if subquery has no distinct modifier, but its subquery can provide distinct result
+    ///        and column list can match. Example(subquery): SELECT a FROM (SELECT DISTINCT a FROM t)
+    ///     3. false
+    bool subquery_is_distinct;
+};
+
+}
+
+void DuplicateDistinctPass::run(QueryTreeNodePtr query_tree_node, ContextPtr context)
+{
+    DuplicateDistinctVisitor visitor(context);
+    visitor.visit(query_tree_node);
+}
+
+}

--- a/src/Analyzer/Passes/DuplicateDistinctPass.cpp
+++ b/src/Analyzer/Passes/DuplicateDistinctPass.cpp
@@ -84,7 +84,7 @@ private:
     ///     2. true if subquery has no distinct modifier, but its subquery can provide distinct result
     ///        and column list can match. Example(subquery): SELECT a FROM (SELECT DISTINCT a FROM t)
     ///     3. false
-    bool subquery_is_distinct;
+    bool subquery_is_distinct = false;
 };
 
 }

--- a/src/Analyzer/Passes/DuplicateDistinctPass.h
+++ b/src/Analyzer/Passes/DuplicateDistinctPass.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <Analyzer/IQueryTreePass.h>
+
+namespace DB
+{
+
+/** Remove duplicate distinct if it's possible.
+  *
+  * Example: SELECT DISTINCT c1 FROM (SELECT DISTINCT c1 FROM table);
+  * Result: SELECT c1 FROM (SELECT DISTINCT c1 FROM table);
+  */
+class DuplicateDistinctPass final : public IQueryTreePass
+{
+public:
+    String getName() override { return "DuplicateDistinct"; }
+
+    String getDescription() override
+    {
+        return "Remove duplicate distinct if it's possible.";
+    }
+
+    void run(QueryTreeNodePtr query_tree_node, ContextPtr context) override;
+
+};
+
+}

--- a/src/Analyzer/QueryTreePassManager.cpp
+++ b/src/Analyzer/QueryTreePassManager.cpp
@@ -42,6 +42,7 @@
 #include <Analyzer/Passes/CrossToInnerJoinPass.h>
 #include <Analyzer/Passes/ShardNumColumnToFunctionPass.h>
 #include <Analyzer/Passes/ConvertQueryToCNFPass.h>
+#include <Analyzer/Passes/DuplicateDistinctPass.h>
 
 namespace DB
 {
@@ -278,6 +279,8 @@ void addQueryTreePasses(QueryTreePassManager & manager)
     manager.addPass(std::make_unique<AutoFinalOnQueryPass>());
     manager.addPass(std::make_unique<CrossToInnerJoinPass>());
     manager.addPass(std::make_unique<ShardNumColumnToFunctionPass>());
+
+    manager.addPass(std::make_unique<DuplicateDistinctPass>());
 }
 
 }

--- a/tests/queries/0_stateless/02816_analyzer_duplicate_distinct.reference
+++ b/tests/queries/0_stateless/02816_analyzer_duplicate_distinct.reference
@@ -1,0 +1,124 @@
+set optimize_duplicate_order_by_and_distinct = 1
+QUERY id: 0
+  PROJECTION COLUMNS
+    number UInt64
+  PROJECTION
+    LIST id: 1, nodes: 1
+      COLUMN id: 2, column_name: number, result_type: UInt64, source_id: 3
+  JOIN TREE
+    QUERY id: 3, is_subquery: 1, is_distinct: 1
+      PROJECTION COLUMNS
+        number UInt64
+      PROJECTION
+        LIST id: 4, nodes: 1
+          COLUMN id: 5, column_name: number, result_type: UInt64, source_id: 6
+      JOIN TREE
+        TABLE_FUNCTION id: 6, table_function_name: numbers
+          ARGUMENTS
+            LIST id: 7, nodes: 1
+              CONSTANT id: 8, constant_value: UInt64_3, constant_value_type: UInt8
+QUERY id: 0
+  PROJECTION COLUMNS
+    t UInt64
+  PROJECTION
+    LIST id: 1, nodes: 1
+      COLUMN id: 2, column_name: t, result_type: UInt64, source_id: 3
+  JOIN TREE
+    QUERY id: 3, is_subquery: 1, is_distinct: 1
+      PROJECTION COLUMNS
+        t UInt64
+      PROJECTION
+        LIST id: 4, nodes: 1
+          COLUMN id: 5, column_name: number, result_type: UInt64, source_id: 6
+      JOIN TREE
+        TABLE_FUNCTION id: 6, table_function_name: numbers
+          ARGUMENTS
+            LIST id: 7, nodes: 1
+              CONSTANT id: 8, constant_value: UInt64_3, constant_value_type: UInt8
+QUERY id: 0
+  PROJECTION COLUMNS
+    number UInt64
+  PROJECTION
+    LIST id: 1, nodes: 1
+      COLUMN id: 2, column_name: number, result_type: UInt64, source_id: 3
+  JOIN TREE
+    QUERY id: 3, is_subquery: 1
+      PROJECTION COLUMNS
+        number UInt64
+      PROJECTION
+        LIST id: 4, nodes: 1
+          COLUMN id: 5, column_name: number, result_type: UInt64, source_id: 6
+      JOIN TREE
+        QUERY id: 6, is_subquery: 1, is_distinct: 1
+          PROJECTION COLUMNS
+            number UInt64
+          PROJECTION
+            LIST id: 7, nodes: 1
+              COLUMN id: 8, column_name: number, result_type: UInt64, source_id: 9
+          JOIN TREE
+            TABLE_FUNCTION id: 9, table_function_name: numbers
+              ARGUMENTS
+                LIST id: 10, nodes: 1
+                  CONSTANT id: 11, constant_value: UInt64_3, constant_value_type: UInt8
+set optimize_duplicate_order_by_and_distinct = 0
+QUERY id: 0, is_distinct: 1
+  PROJECTION COLUMNS
+    number UInt64
+  PROJECTION
+    LIST id: 1, nodes: 1
+      COLUMN id: 2, column_name: number, result_type: UInt64, source_id: 3
+  JOIN TREE
+    QUERY id: 3, is_subquery: 1, is_distinct: 1
+      PROJECTION COLUMNS
+        number UInt64
+      PROJECTION
+        LIST id: 4, nodes: 1
+          COLUMN id: 5, column_name: number, result_type: UInt64, source_id: 6
+      JOIN TREE
+        TABLE_FUNCTION id: 6, table_function_name: numbers
+          ARGUMENTS
+            LIST id: 7, nodes: 1
+              CONSTANT id: 8, constant_value: UInt64_3, constant_value_type: UInt8
+QUERY id: 0, is_distinct: 1
+  PROJECTION COLUMNS
+    t UInt64
+  PROJECTION
+    LIST id: 1, nodes: 1
+      COLUMN id: 2, column_name: t, result_type: UInt64, source_id: 3
+  JOIN TREE
+    QUERY id: 3, is_subquery: 1, is_distinct: 1
+      PROJECTION COLUMNS
+        t UInt64
+      PROJECTION
+        LIST id: 4, nodes: 1
+          COLUMN id: 5, column_name: number, result_type: UInt64, source_id: 6
+      JOIN TREE
+        TABLE_FUNCTION id: 6, table_function_name: numbers
+          ARGUMENTS
+            LIST id: 7, nodes: 1
+              CONSTANT id: 8, constant_value: UInt64_3, constant_value_type: UInt8
+QUERY id: 0, is_distinct: 1
+  PROJECTION COLUMNS
+    number UInt64
+  PROJECTION
+    LIST id: 1, nodes: 1
+      COLUMN id: 2, column_name: number, result_type: UInt64, source_id: 3
+  JOIN TREE
+    QUERY id: 3, is_subquery: 1
+      PROJECTION COLUMNS
+        number UInt64
+      PROJECTION
+        LIST id: 4, nodes: 1
+          COLUMN id: 5, column_name: number, result_type: UInt64, source_id: 6
+      JOIN TREE
+        QUERY id: 6, is_subquery: 1, is_distinct: 1
+          PROJECTION COLUMNS
+            number UInt64
+          PROJECTION
+            LIST id: 7, nodes: 1
+              COLUMN id: 8, column_name: number, result_type: UInt64, source_id: 9
+          JOIN TREE
+            TABLE_FUNCTION id: 9, table_function_name: numbers
+              ARGUMENTS
+                LIST id: 10, nodes: 1
+                  CONSTANT id: 11, constant_value: UInt64_3, constant_value_type: UInt8

--- a/tests/queries/0_stateless/02816_analyzer_duplicate_distinct.sql
+++ b/tests/queries/0_stateless/02816_analyzer_duplicate_distinct.sql
@@ -1,0 +1,60 @@
+set allow_experimental_analyzer = 1;
+
+SELECT  'set optimize_duplicate_order_by_and_distinct = 1';
+set optimize_duplicate_order_by_and_distinct = 1;
+
+EXPLAIN QUERY TREE SELECT DISTINCT number
+FROM
+(
+   SELECT DISTINCT number
+   FROM numbers(3)
+);
+
+EXPLAIN QUERY TREE SELECT DISTINCT t
+FROM
+(
+   SELECT DISTINCT number as t
+   FROM numbers(3)
+);
+
+
+EXPLAIN QUERY TREE SELECT DISTINCT number
+FROM
+(
+   SELECT number
+   FROM
+   (
+       SELECT DISTINCT number
+       FROM numbers(3)
+   )
+);
+
+
+SELECT  'set optimize_duplicate_order_by_and_distinct = 0';
+set optimize_duplicate_order_by_and_distinct = 0;
+
+EXPLAIN QUERY TREE SELECT DISTINCT number
+FROM
+(
+   SELECT DISTINCT number
+   FROM numbers(3)
+);
+
+EXPLAIN QUERY TREE SELECT DISTINCT t
+FROM
+(
+   SELECT DISTINCT number as t
+   FROM numbers(3)
+);
+
+
+EXPLAIN QUERY TREE SELECT DISTINCT number
+FROM
+(
+   SELECT number
+   FROM
+   (
+       SELECT DISTINCT number
+       FROM numbers(3)
+   )
+);


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Remove duplicate distinct if it's possible.

Example: SELECT DISTINCT c1 FROM (SELECT DISTINCT c1 FROM table);
Result: SELECT c1 FROM (SELECT DISTINCT c1 FROM table);



> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
