### PR TITLE
Add missing replica syncs in test_backup_restore_on_cluster

### DIFF
--- a/tests/integration/test_backup_restore_on_cluster/test.py
+++ b/tests/integration/test_backup_restore_on_cluster/test.py
@@ -580,6 +580,7 @@ def test_required_privileges():
     node1.query(
         f"RESTORE TABLE tbl AS tbl2 ON CLUSTER 'cluster' FROM {backup_name}", user="u1"
     )
+    node2.query("SYSTEM SYNC REPLICA ON CLUSTER 'cluster' tbl2")
 
     assert node2.query("SELECT * FROM tbl2") == "100\n"
 
@@ -593,6 +594,7 @@ def test_required_privileges():
 
     node1.query("GRANT INSERT, CREATE TABLE ON tbl TO u1")
     node1.query(f"RESTORE ALL ON CLUSTER 'cluster' FROM {backup_name}", user="u1")
+    node2.query("SYSTEM SYNC REPLICA ON CLUSTER 'cluster' tbl")
 
     assert node2.query("SELECT * FROM tbl") == "100\n"
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Got this test failure:
https://s3.amazonaws.com/clickhouse-test-reports/49367/dc23d5cb08a5540a167dca46488c7b30d0ca7a6c/integration_tests__asan__analyzer__[5_6]/integration_run_parallel0_0.log (on https://github.com/ClickHouse/ClickHouse/pull/49367 , which seems unrelated).

Maybe the data just wasn't propagated to the replica, so this PR adds a `SYSTEM SYNC REPLICA`s in there (and I checked that no other tests in that file do a RESTORE followed by a SELECT on different replica). I don't actually know what I'm doing, so plz check if this makes sense at all, @vitlibar :) (I didn't repro the failure, so didn't directly check that this fixes it.)