### PR TITLE
Add logging about all found workflows for merge_pr.py

### DIFF
--- a/tests/ci/merge_pr.py
+++ b/tests/ci/merge_pr.py
@@ -246,6 +246,12 @@ def main():
 
     if args.check_running_workflows:
         workflows = get_workflows_for_head(repo, pr.head.sha)
+        logging.info(
+            "The PR #%s has following workflows:\n%s",
+            pr.number,
+            "\n".join(f"{wf.html_url}: status is {wf.status}" for wf in workflows),
+        )
+
         workflows_in_progress = [wf for wf in workflows if wf.status != "completed"]
         # At most one workflow in progress is fine. We check that there no
         # cases like, e.g. PullRequestCI and DocksCheck in progress at once


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
It looks like sometimes GH API lies to us about running workflows, compare [correct](https://github.com/ClickHouse/ClickHouse/actions/runs/5599148724/jobs/10239822674#step:4:18) logs to [wrong](https://github.com/ClickHouse/ClickHouse/actions/runs/5599171297/jobs/10239822969#step:4:18). It won't prevent such issues, but at least will leave pieces of evidence.