### PR TITLE
Rephrase ALL supported note

### DIFF
--- a/docs/en/operations/backup.md
+++ b/docs/en/operations/backup.md
@@ -30,7 +30,7 @@ description: In order to effectively mitigate possible human errors, you should 
 ```
 
 :::note ALL
-`ALL` is only applicable to the `RESTORE` command prior to version 23.4 of Clickhouse.
+Prior to version 23.4 of Clickhouse, `ALL` was only applicable to the `RESTORE` command.
 :::
 
 ## Background

--- a/docs/en/operations/backup.md
+++ b/docs/en/operations/backup.md
@@ -30,7 +30,7 @@ description: In order to effectively mitigate possible human errors, you should 
 ```
 
 :::note ALL
-Prior to version 23.4 of Clickhouse, `ALL` was only applicable to the `RESTORE` command.
+Prior to version 23.4 of ClickHouse, `ALL` was only applicable to the `RESTORE` command.
 :::
 
 ## Background


### PR DESCRIPTION
I interpreted the note as 'ALL' is only supported before 23.4  I think this reordering makes it clearer

### Changelog category (leave one):

- Documentation (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Rephrase note for `ALL` modifier for `BACKUP` command.