### PR TITLE
Mark test 02125_many_mutations_2 as no-parallel to avoid flakiness

### DIFF
--- a/tests/queries/0_stateless/02125_many_mutations_2.sh
+++ b/tests/queries/0_stateless/02125_many_mutations_2.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: long, no-tsan, no-debug, no-asan, no-msan, no-ubsan
+# Tags: long, no-tsan, no-debug, no-asan, no-msan, no-ubsan, no-parallel
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Sometimes `02125_many_mutations_2` can fail because of `Not enough idle threads to apply mutations at the moment`: https://s3.amazonaws.com/clickhouse-test-reports/51934/8057be547c6d8dc5fb35b82f10d8ce01bf1f6033/stateless_tests__release__s3_storage__%5B1_2%5D.html Let's try to mark it `no-parallel` to fix it.