### PR TITLE
Make StorageSet::getSet() thread safe

### DIFF
--- a/src/Storages/StorageSet.cpp
+++ b/src/Storages/StorageSet.cpp
@@ -176,7 +176,7 @@ void StorageSet::truncate(const ASTPtr &, const StorageMetadataPtr & metadata_sn
     Block header = metadata_snapshot->getSampleBlock();
 
     increment = 0;
-    set = std::make_shared<Set>(SizeLimits(), 0, true);
+    std::atomic_store(&set, std::make_shared<Set>(SizeLimits(), 0, true));
     set->setHeader(header.getColumnsWithTypeAndName());
 }
 

--- a/src/Storages/StorageSet.h
+++ b/src/Storages/StorageSet.h
@@ -79,7 +79,7 @@ public:
     String getName() const override { return "Set"; }
 
     /// Access the insides.
-    SetPtr & getSet() { return set; }
+    SetPtr getSet() const { return std::atomic_load(&set); }
 
     void truncate(const ASTPtr &, const StorageMetadataPtr & metadata_snapshot, ContextPtr, TableExclusiveLockHolder &) override;
 

--- a/tests/queries/0_stateless/02867_storage_set_tsan.sh
+++ b/tests/queries/0_stateless/02867_storage_set_tsan.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Tags: race, no-debug
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+$CLICKHOUSE_CLIENT -mn -q """
+DROP TABLE IF EXISTS t1_02867;
+CREATE TABLE t1_02867 (x UInt64) ENGINE=Set();
+"""
+
+function repeat_select() {
+    n=0
+    while [ "$n" -lt 20 ];
+    do
+        n=$(( n + 1 ))
+        $CLICKHOUSE_CLIENT -q "SELECT count() as a FROM numbers(10) WHERE number IN t1_02867" > /dev/null 2> /dev/null || exit
+    done
+}
+
+function repeat_truncate_insert() {
+    n=0
+    while [ "$n" -lt 20 ];
+    do
+        n=$(( n + 1 ))
+        $CLICKHOUSE_CLIENT -q "TRUNCATE t1_02867;" > /dev/null 2> /dev/null || exit
+    done
+}
+
+repeat_select &
+repeat_truncate_insert &
+repeat_select &
+repeat_truncate_insert &
+repeat_select &
+repeat_truncate_insert &
+repeat_select &
+repeat_truncate_insert &
+
+sleep 10
+
+$CLICKHOUSE_CLIENT -mn -q "DROP TABLE IF EXISTS t1_02867;"


### PR DESCRIPTION
Found by TSan.
Happened when CREATE TABLE ... ENGINE = Set()
and TRUNCATE TABLE is called

    DB::StorageSet::truncate
    DB::InterpreterDropQuery::executeToTableImpl
    ...
    DB::InterpreterDropQuery::execute

and mutations are happening

    DB::ExpressionAnalyzer::isPlainStorageSetInSubquery calls `return storage_set->getSet();`    
    DB::ExpressionAnalyzer::tryMakeSetForIndexFromSubquery 
    ...
    DB::MergeTreeDataMergerMutator::mutatePartToTemporaryPart DB::StorageMergeTree::mutateSelectedPart
    DB::StorageMergeTree::scheduleDataProcessingJob

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)



<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
