### PR TITLE
Fix `test_keeper_session`

### DIFF
--- a/tests/integration/test_keeper_session/test.py
+++ b/tests/integration/test_keeper_session/test.py
@@ -6,6 +6,7 @@ import socket
 import struct
 
 from kazoo.client import KazooClient
+from kazoo.exceptions import NoNodeError
 
 # from kazoo.protocol.serialization import Connect, read_buffer, write_buffer
 
@@ -162,17 +163,38 @@ def test_session_timeout(started_cluster):
 def test_session_close_shutdown(started_cluster):
     wait_nodes()
 
-    node1_zk = get_fake_zk(node1.name)
-    node2_zk = get_fake_zk(node2.name)
+    node1_zk = None
+    node2_zk = None
+    for i in range(20):
+        node1_zk = get_fake_zk(node1.name)
+        node2_zk = get_fake_zk(node2.name)
 
-    eph_node = "/test_node"
-    node2_zk.create(eph_node, ephemeral=True)
-    node1_zk.sync(eph_node)
-    assert node1_zk.exists(eph_node) != None
+        eph_node = "/test_node"
+        node2_zk.create(eph_node, ephemeral=True)
+        node1_zk.sync(eph_node)
 
-    # shutdown while session is active
-    node2.stop_clickhouse()
+        node1_zk.exists(eph_node) != None
 
-    assert node1_zk.exists(eph_node) == None
+        # restart while session is active so it's closed during shutdown
+        node2.restart_clickhouse()
 
-    node2.start_clickhouse()
+        if node1_zk.exists(eph_node) == None:
+            break
+
+        assert node2.contains_in_log("Sessions cannot be closed during shutdown because there is no active leader")
+
+        try:
+            node1_zk.delete(eph_node)
+        except NoNodeError:
+            pass
+
+        assert node1_zk.exists(eph_node) == None
+
+        destroy_zk_client(node1_zk)
+        node1_zk = None
+        destroy_zk_client(node2_zk)
+        node2_zk = None
+
+        time.sleep(1)
+    else:
+        assert False, "Session wasn't properly cleaned up on shutdown"

--- a/tests/integration/test_keeper_session/test.py
+++ b/tests/integration/test_keeper_session/test.py
@@ -181,7 +181,9 @@ def test_session_close_shutdown(started_cluster):
         if node1_zk.exists(eph_node) == None:
             break
 
-        assert node2.contains_in_log("Sessions cannot be closed during shutdown because there is no active leader")
+        assert node2.contains_in_log(
+            "Sessions cannot be closed during shutdown because there is no active leader"
+        )
 
         try:
             node1_zk.delete(eph_node)


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Closing sessions could fail because leader is missing.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
