### PR TITLE
Include query cache usage in SYSTEM.QUERY_LOG

### DIFF
--- a/docs/en/operations/query-cache.md
+++ b/docs/en/operations/query-cache.md
@@ -62,8 +62,10 @@ may return cached results then.
 
 The query cache can be cleared using statement `SYSTEM DROP QUERY CACHE`. The content of the query cache is displayed in system table
 `system.query_cache`. The number of query cache hits and misses are shown as events "QueryCacheHits" and "QueryCacheMisses" in system table
-`system.events`. Both counters are only updated for `SELECT` queries which run with setting "use_query_cache = true". Other queries do not
-affect the cache miss counter.
+[system.events](system-tables/events.md). Both counters are only updated for `SELECT` queries which run with setting "use_query_cache =
+true". Other queries do not affect the cache miss counter. Field `query_log_usage` in system table
+[system.query_log](system-tables/query_log.md) shows for each ran query whether the query result was written into or read from the query
+cache.
 
 The query cache exists once per ClickHouse server process. However, cache results are by default not shared between users. This can be
 changed (see below) but doing so is not recommended for security reasons.

--- a/docs/en/operations/system-tables/query_log.md
+++ b/docs/en/operations/system-tables/query_log.md
@@ -112,10 +112,10 @@ Columns:
 - `used_storages` ([Array(String)](../../sql-reference/data-types/array.md)) — Canonical names of `storages`, which were used during query execution.
 - `used_table_functions` ([Array(String)](../../sql-reference/data-types/array.md)) — Canonical names of `table functions`, which were used during query execution.
 - `query_cache_usage` ([Enum8](../../sql-reference/data-types/enum.md)) — Usage of the [query cache](../query-cache.md) during query execution. Values:
-    - `'Unknown' = 1` = Status unknown.
-    - `'None' = 2` = The query result was neither written into nor read from the query cache.
-    - `'Write' = 3` = The query result was written into the query cache.
-    - `'Read' = 4` = The query result was read from the query cache.
+    - `'Unknown'` = Status unknown.
+    - `'None'` = The query result was neither written into nor read from the query cache.
+    - `'Write'` = The query result was written into the query cache.
+    - `'Read'` = The query result was read from the query cache.
 
 **Example**
 

--- a/docs/en/operations/system-tables/query_log.md
+++ b/docs/en/operations/system-tables/query_log.md
@@ -111,6 +111,11 @@ Columns:
 - `used_functions` ([Array(String)](../../sql-reference/data-types/array.md)) — Canonical names of `functions`, which were used during query execution.
 - `used_storages` ([Array(String)](../../sql-reference/data-types/array.md)) — Canonical names of `storages`, which were used during query execution.
 - `used_table_functions` ([Array(String)](../../sql-reference/data-types/array.md)) — Canonical names of `table functions`, which were used during query execution.
+- `query_cache_usage` ([Enum8](../../sql-reference/data-types/enum.md)) — Usage of the [query cache](../query-cache.md) during query execution. Values:
+    - `'None' = 1` = The query result was neither written into nor read from the query cache.
+    - `'Write' = 1` = The query result was written into the query cache.
+    - `'Read' = 1` = The query result was read from the query cache.
+    - `'Unknown' = 1` = Unknown status.
 
 **Example**
 
@@ -186,6 +191,7 @@ used_formats:                          []
 used_functions:                        []
 used_storages:                         []
 used_table_functions:                  []
+query_cache_usage:                     None
 ```
 
 **See Also**

--- a/docs/en/operations/system-tables/query_log.md
+++ b/docs/en/operations/system-tables/query_log.md
@@ -112,10 +112,10 @@ Columns:
 - `used_storages` ([Array(String)](../../sql-reference/data-types/array.md)) — Canonical names of `storages`, which were used during query execution.
 - `used_table_functions` ([Array(String)](../../sql-reference/data-types/array.md)) — Canonical names of `table functions`, which were used during query execution.
 - `query_cache_usage` ([Enum8](../../sql-reference/data-types/enum.md)) — Usage of the [query cache](../query-cache.md) during query execution. Values:
-    - `'None' = 1` = The query result was neither written into nor read from the query cache.
-    - `'Write' = 1` = The query result was written into the query cache.
-    - `'Read' = 1` = The query result was read from the query cache.
-    - `'Unknown' = 1` = Unknown status.
+    - `'Unknown' = 1` = Status unknown.
+    - `'None' = 2` = The query result was neither written into nor read from the query cache.
+    - `'Write' = 3` = The query result was written into the query cache.
+    - `'Read' = 4` = The query result was read from the query cache.
 
 **Example**
 

--- a/src/Interpreters/AsynchronousInsertQueue.cpp
+++ b/src/Interpreters/AsynchronousInsertQueue.cpp
@@ -605,7 +605,7 @@ try
             total_rows, total_bytes, key.query_str);
 
         bool pulling_pipeline = false;
-        logQueryFinish(query_log_elem, insert_context, key.query, pipeline, pulling_pipeline, query_span, internal);
+        logQueryFinish(query_log_elem, insert_context, key.query, pipeline, pulling_pipeline, query_span, QueryCache::Usage::None, internal);
     }
     catch (...)
     {

--- a/src/Interpreters/Cache/QueryCache.h
+++ b/src/Interpreters/Cache/QueryCache.h
@@ -26,11 +26,10 @@ class QueryCache
 public:
     enum class Usage
     {
-        /// starts at 1 for compatibitity with DataTypeEnum8
-        Unknown = 1,  /// we don't know what what happened
-        None,         /// query result neither written nor read into/from query cache
-        Write,        /// query result written into query cache
-        Read,         /// query result read from query cache
+        Unknown,  /// we don't know what what happened
+        None,     /// query result neither written nor read into/from query cache
+        Write,    /// query result written into query cache
+        Read,     /// query result read from query cache
     };
 
     /// Represents a query result in the cache.

--- a/src/Interpreters/Cache/QueryCache.h
+++ b/src/Interpreters/Cache/QueryCache.h
@@ -27,10 +27,10 @@ public:
     enum class Usage
     {
         /// starts at 1 for compatibitity with DataTypeEnum8
-        None = 1,   /// query result neither written nor read into/from query cache
-        Write,      /// query result wrote into query cache
-        Read,       /// query result read from query cache
-        Unknown,    /// we don't know what what happened
+        Unknown = 1,  /// we don't know what what happened
+        None,         /// query result neither written nor read into/from query cache
+        Write,        /// query result written into query cache
+        Read,         /// query result read from query cache
     };
 
     /// Represents a query result in the cache.

--- a/src/Interpreters/Cache/QueryCache.h
+++ b/src/Interpreters/Cache/QueryCache.h
@@ -24,6 +24,15 @@ bool astContainsNonDeterministicFunctions(ASTPtr ast, ContextPtr context);
 class QueryCache
 {
 public:
+    enum class Usage
+    {
+        /// starts at 1 for compatibitity with DataTypeEnum8
+        None = 1,   /// query result neither written nor read into/from query cache
+        Write,      /// query result wrote into query cache
+        Read,       /// query result read from query cache
+        Unknown,    /// we don't know what what happened
+    };
+
     /// Represents a query result in the cache.
     struct Key
     {

--- a/src/Interpreters/QueryLog.cpp
+++ b/src/Interpreters/QueryLog.cpp
@@ -41,6 +41,15 @@ NamesAndTypesList QueryLogElement::getNamesAndTypes()
             {"ExceptionWhileProcessing",    static_cast<Int8>(EXCEPTION_WHILE_PROCESSING)}
         });
 
+    auto query_cache_usage_datatype = std::make_shared<DataTypeEnum8>(
+        DataTypeEnum8::Values
+        {
+            {"None",        static_cast<Int8>(QueryCache::Usage::None)},
+            {"Write",       static_cast<Int8>(QueryCache::Usage::Write)},
+            {"Read",        static_cast<Int8>(QueryCache::Usage::Read)},
+            {"Unknown",     static_cast<Int8>(QueryCache::Usage::Unknown)}
+        });
+
     auto low_cardinality_string = std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeString>());
     auto array_low_cardinality_string = std::make_shared<DataTypeArray>(low_cardinality_string);
 
@@ -125,6 +134,8 @@ NamesAndTypesList QueryLogElement::getNamesAndTypes()
         {"used_row_policies", array_low_cardinality_string},
 
         {"transaction_id", getTransactionIDDataType()},
+
+        {"query_cache_usage", std::move(query_cache_usage_datatype)},
 
         {"asynchronous_read_counters", std::make_shared<DataTypeMap>(low_cardinality_string, std::make_shared<DataTypeUInt64>())},
     };
@@ -276,6 +287,8 @@ void QueryLogElement::appendToBlock(MutableColumns & columns) const
     }
 
     columns[i++]->insert(Tuple{tid.start_csn, tid.local_tid, tid.host_id});
+
+    columns[i++]->insert(query_cache_usage);
 
     if (async_read_counters)
         async_read_counters->dumpToMapColumn(columns[i++].get());

--- a/src/Interpreters/QueryLog.cpp
+++ b/src/Interpreters/QueryLog.cpp
@@ -44,10 +44,10 @@ NamesAndTypesList QueryLogElement::getNamesAndTypes()
     auto query_cache_usage_datatype = std::make_shared<DataTypeEnum8>(
         DataTypeEnum8::Values
         {
+            {"Unknown",     static_cast<Int8>(QueryCache::Usage::Unknown)},
             {"None",        static_cast<Int8>(QueryCache::Usage::None)},
             {"Write",       static_cast<Int8>(QueryCache::Usage::Write)},
-            {"Read",        static_cast<Int8>(QueryCache::Usage::Read)},
-            {"Unknown",     static_cast<Int8>(QueryCache::Usage::Unknown)}
+            {"Read",        static_cast<Int8>(QueryCache::Usage::Read)}
         });
 
     auto low_cardinality_string = std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeString>());

--- a/src/Interpreters/QueryLog.h
+++ b/src/Interpreters/QueryLog.h
@@ -4,8 +4,9 @@
 #include <Core/NamesAndTypes.h>
 #include <Core/NamesAndAliases.h>
 #include <Core/Settings.h>
-#include <Interpreters/SystemLog.h>
+#include <Interpreters/Cache/QueryCache.h>
 #include <Interpreters/ClientInfo.h>
+#include <Interpreters/SystemLog.h>
 #include <Interpreters/TransactionVersionMetadata.h>
 #include <IO/AsyncReadCounters.h>
 #include <Parsers/IAST.h>
@@ -95,6 +96,8 @@ struct QueryLogElement
     std::shared_ptr<Settings> query_settings;
 
     TransactionID tid;
+
+    QueryCache::Usage query_cache_usage = QueryCache::Usage::Unknown;
 
     static std::string name() { return "QueryLog"; }
 

--- a/src/Interpreters/executeQuery.cpp
+++ b/src/Interpreters/executeQuery.cpp
@@ -209,7 +209,7 @@ static void logException(ContextPtr context, QueryLogElement & elem, bool log_er
 }
 
 static void
-addStatusInfoToQueryElement(QueryLogElement & element, const QueryStatusInfo & info, const ASTPtr query_ast, const ContextPtr context_ptr)
+addStatusInfoToQueryLogElement(QueryLogElement & element, const QueryStatusInfo & info, const ASTPtr query_ast, const ContextPtr context_ptr)
 {
     const auto time_now = std::chrono::system_clock::now();
     UInt64 elapsed_microseconds = info.elapsed_microseconds;
@@ -347,6 +347,7 @@ void logQueryFinish(
     const QueryPipeline & query_pipeline,
     bool pulling_pipeline,
     std::shared_ptr<OpenTelemetry::SpanHolder> query_span,
+    QueryCache::Usage query_cache_usage,
     bool internal)
 {
     const Settings & settings = context->getSettingsRef();
@@ -364,7 +365,7 @@ void logQueryFinish(
         QueryStatusInfo info = process_list_elem->getInfo(true, context->getSettingsRef().log_profile_events);
         elem.type = QueryLogElementType::QUERY_FINISH;
 
-        addStatusInfoToQueryElement(elem, info, query_ast, context);
+        addStatusInfoToQueryLogElement(elem, info, query_ast, context);
 
         if (pulling_pipeline)
         {
@@ -398,6 +399,8 @@ void logQueryFinish(
                 rows_per_second,
                 ReadableSize(elem.read_bytes / elapsed_seconds));
         }
+
+        elem.query_cache_usage = query_cache_usage;
 
         if (log_queries && elem.type >= log_queries_min_type
             && static_cast<Int64>(elem.query_duration_ms) >= log_queries_min_query_duration_ms)
@@ -499,12 +502,14 @@ void logQueryException(
     if (process_list_elem)
     {
         QueryStatusInfo info = process_list_elem->getInfo(true, settings.log_profile_events, false);
-        addStatusInfoToQueryElement(elem, info, query_ast, context);
+        addStatusInfoToQueryLogElement(elem, info, query_ast, context);
     }
     else
     {
         elem.query_duration_ms = start_watch.elapsedMilliseconds();
     }
+
+    elem.query_cache_usage = QueryCache::Usage::None;
 
     if (settings.calculate_text_stack_trace && log_error)
         setExceptionStackTrace(elem);
@@ -975,7 +980,7 @@ static std::tuple<ASTPtr, BlockIO> executeQueryImpl(
 
         QueryCachePtr query_cache = context->getQueryCache();
         const bool can_use_query_cache = query_cache != nullptr && settings.use_query_cache && !internal && (ast->as<ASTSelectQuery>() || ast->as<ASTSelectWithUnionQuery>());
-        bool write_into_query_cache = false;
+        QueryCache::Usage query_cache_usage = QueryCache::Usage::None;
 
         if (!async_insert)
         {
@@ -992,6 +997,7 @@ static std::tuple<ASTPtr, BlockIO> executeQueryImpl(
                         QueryPipeline pipeline;
                         pipeline.readFromQueryCache(reader.getSource(), reader.getSourceTotals(), reader.getSourceExtremes());
                         res.pipeline = std::move(pipeline);
+                        query_cache_usage = QueryCache::Usage::Read;
                         return true;
                     }
                 }
@@ -1095,7 +1101,7 @@ static std::tuple<ASTPtr, BlockIO> executeQueryImpl(
                                              settings.query_cache_max_size_in_bytes,
                                              settings.query_cache_max_entries));
                             res.pipeline.writeResultIntoQueryCache(query_cache_writer);
-                            write_into_query_cache = true;
+                            query_cache_usage = QueryCache::Usage::Write;
                         }
                     }
 
@@ -1147,19 +1153,19 @@ static std::tuple<ASTPtr, BlockIO> executeQueryImpl(
             auto finish_callback = [elem,
                                     context,
                                     ast,
-                                    write_into_query_cache,
+                                    query_cache_usage,
                                     internal,
                                     implicit_txn_control,
                                     execute_implicit_tcl_query,
                                     pulling_pipeline = pipeline.pulling(),
                                     query_span](QueryPipeline & query_pipeline) mutable
             {
-                if (write_into_query_cache)
+                if (query_cache_usage == QueryCache::Usage::Write)
                     /// Trigger the actual write of the buffered query result into the query cache. This is done explicitly to prevent
                     /// partial/garbage results in case of exceptions during query execution.
                     query_pipeline.finalizeWriteInQueryCache();
 
-                logQueryFinish(elem, context, ast, query_pipeline, pulling_pipeline, query_span, internal);
+                logQueryFinish(elem, context, ast, query_pipeline, pulling_pipeline, query_span, query_cache_usage, internal);
 
                 if (*implicit_txn_control)
                     execute_implicit_tcl_query(context, ASTTransactionControl::COMMIT);

--- a/src/Interpreters/executeQuery.h
+++ b/src/Interpreters/executeQuery.h
@@ -92,6 +92,7 @@ void logQueryFinish(
     const QueryPipeline & query_pipeline,
     bool pulling_pipeline,
     std::shared_ptr<OpenTelemetry::SpanHolder> query_span,
+    QueryCache::Usage query_cache_usage,
     bool internal);
 
 void logQueryException(

--- a/tests/queries/0_stateless/02494_query_cache_query_log.reference
+++ b/tests/queries/0_stateless/02494_query_cache_query_log.reference
@@ -1,16 +1,12 @@
 -- Run a query with query cache not enabled
 124437993
-QueryStart	SELECT 124437993;	Unknown
 QueryFinish	SELECT 124437993;	None
 -- Run a query with query cache enabled
 124437994
-QueryStart	SELECT 124437994 SETTINGS use_query_cache = 1;	Unknown
 QueryFinish	SELECT 124437994 SETTINGS use_query_cache = 1;	Write
 -- Run the same query with query cache enabled
 124437994
-QueryStart	SELECT 124437994 SETTINGS use_query_cache = 1;	Unknown
-QueryStart	SELECT 124437994 SETTINGS use_query_cache = 1;	Unknown
-QueryFinish	SELECT 124437994 SETTINGS use_query_cache = 1;	Read
 QueryFinish	SELECT 124437994 SETTINGS use_query_cache = 1;	Write
+QueryFinish	SELECT 124437994 SETTINGS use_query_cache = 1;	Read
 -- Throw exception with query cache enabled
 SELECT 124437995, throwIf(1) SETTINGS use_query_cache = 1;	None

--- a/tests/queries/0_stateless/02494_query_cache_query_log.reference
+++ b/tests/queries/0_stateless/02494_query_cache_query_log.reference
@@ -1,0 +1,16 @@
+-- Run a query with query cache not enabled
+124437993
+QueryStart	SELECT 124437993;	Unknown
+QueryFinish	SELECT 124437993;	None
+-- Run a query with query cache enabled
+124437994
+QueryStart	SELECT 124437994 SETTINGS use_query_cache = 1;	Unknown
+QueryFinish	SELECT 124437994 SETTINGS use_query_cache = 1;	Write
+-- Run the same query with query cache enabled
+124437994
+QueryStart	SELECT 124437994 SETTINGS use_query_cache = 1;	Unknown
+QueryStart	SELECT 124437994 SETTINGS use_query_cache = 1;	Unknown
+QueryFinish	SELECT 124437994 SETTINGS use_query_cache = 1;	Read
+QueryFinish	SELECT 124437994 SETTINGS use_query_cache = 1;	Write
+-- Throw exception with query cache enabled
+SELECT 124437995, throwIf(1) SETTINGS use_query_cache = 1;	None

--- a/tests/queries/0_stateless/02494_query_cache_query_log.sql
+++ b/tests/queries/0_stateless/02494_query_cache_query_log.sql
@@ -17,7 +17,8 @@ SELECT type, query, query_cache_usage
 FROM system.query_log
 WHERE current_database = currentDatabase()
     AND query = 'SELECT 124437993;'
-ORDER BY type;
+    AND type = 'QueryFinish'
+ORDER BY type, query_cache_usage;
 
 
 
@@ -31,7 +32,8 @@ SELECT type, query, query_cache_usage
 FROM system.query_log
 WHERE current_database = currentDatabase()
     AND query = 'SELECT 124437994 SETTINGS use_query_cache = 1;'
-ORDER BY type;
+    AND type = 'QueryFinish'
+ORDER BY type, query_cache_usage;
 
 
 
@@ -45,7 +47,8 @@ SELECT type, query, query_cache_usage
 FROM system.query_log
 WHERE current_database = currentDatabase()
     AND query = 'SELECT 124437994 SETTINGS use_query_cache = 1;'
-ORDER BY type;
+    AND type = 'QueryFinish'
+ORDER BY type, query_cache_usage;
 
 
 

--- a/tests/queries/0_stateless/02494_query_cache_query_log.sql
+++ b/tests/queries/0_stateless/02494_query_cache_query_log.sql
@@ -1,0 +1,64 @@
+-- Tags: no-parallel
+-- Tag no-parallel: Messes with internal cache
+
+SYSTEM DROP QUERY CACHE;
+
+-- DROP TABLE system.query_log; -- debugging
+
+
+
+SELECT '-- Run a query with query cache not enabled';
+SELECT 124437993;
+
+SYSTEM FLUSH LOGS;
+
+-- Field 'query_cache_usage' should be 'None'
+SELECT type, query, query_cache_usage
+FROM system.query_log
+WHERE current_database = currentDatabase()
+    AND query = 'SELECT 124437993;'
+ORDER BY type;
+
+
+
+SELECT '-- Run a query with query cache enabled';
+SELECT 124437994 SETTINGS use_query_cache = 1;
+
+SYSTEM FLUSH LOGS;
+
+-- Field 'query_cache_usage' should be 'Write'
+SELECT type, query, query_cache_usage
+FROM system.query_log
+WHERE current_database = currentDatabase()
+    AND query = 'SELECT 124437994 SETTINGS use_query_cache = 1;'
+ORDER BY type;
+
+
+
+SELECT '-- Run the same query with query cache enabled';
+SELECT 124437994 SETTINGS use_query_cache = 1;
+
+SYSTEM FLUSH LOGS;
+
+-- Field 'query_cache_usage' should be 'Read'
+SELECT type, query, query_cache_usage
+FROM system.query_log
+WHERE current_database = currentDatabase()
+    AND query = 'SELECT 124437994 SETTINGS use_query_cache = 1;'
+ORDER BY type;
+
+
+
+SELECT '-- Throw exception with query cache enabled';
+SELECT 124437995, throwIf(1) SETTINGS use_query_cache = 1; -- { serverError FUNCTION_THROW_IF_VALUE_IS_NON_ZERO }
+
+SYSTEM FLUSH LOGS;
+
+-- Field 'query_cache_usage' should be 'None'
+SELECT query, query_cache_usage
+FROM system.query_log
+WHERE current_database = currentDatabase()
+    AND query = 'SELECT 124437995, throwIf(1) SETTINGS use_query_cache = 1;'
+    AND type = 'ExceptionWhileProcessing';
+
+SYSTEM DROP QUERY CACHE;


### PR DESCRIPTION
`system.query_log` now records if and how a query used the query cache. A new field `query_cache_usage` was added with possible values:
- `None` (no usage, usually because `SETTINGS use_query_cache` was not specified)
- `Write` (the query result was stored in the query cache)
- `Read` (the query result was read from the query cache)
- `Unknown` (all other situations - should not happen in practice)

@CamiloSierraH FYI

### Changelog category (leave one):
- New Feature

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
A new field "query_cache_usage" in SYSTEM.QUERY_LOG now shows if and how the query cache was used