### PR TITLE
Reduce the number of syscalls in FileCache::loadMetadata

### DIFF
--- a/src/Interpreters/Cache/FileCache.cpp
+++ b/src/Interpreters/Cache/FileCache.cpp
@@ -870,13 +870,12 @@ void FileCache::loadMetadata()
     }
 
     size_t total_size = 0;
-    for (auto key_prefix_it = fs::directory_iterator{metadata.getBaseDirectory()};
-         key_prefix_it != fs::directory_iterator();)
+    for (auto key_prefix_it = fs::directory_iterator{metadata.getBaseDirectory()}; key_prefix_it != fs::directory_iterator();
+         key_prefix_it++)
     {
         const fs::path key_prefix_directory = key_prefix_it->path();
-        key_prefix_it++;
 
-        if (!fs::is_directory(key_prefix_directory))
+        if (!key_prefix_it->is_directory())
         {
             if (key_prefix_directory.filename() != "status")
             {
@@ -887,19 +886,19 @@ void FileCache::loadMetadata()
             continue;
         }
 
-        if (fs::is_empty(key_prefix_directory))
+        fs::directory_iterator key_it{key_prefix_directory};
+        if (key_it == fs::directory_iterator{})
         {
             LOG_DEBUG(log, "Removing empty key prefix directory: {}", key_prefix_directory.string());
             fs::remove(key_prefix_directory);
             continue;
         }
 
-        for (fs::directory_iterator key_it{key_prefix_directory}; key_it != fs::directory_iterator();)
+        for (/* key_it already initialized to verify emptiness */; key_it != fs::directory_iterator(); key_it++)
         {
             const fs::path key_directory = key_it->path();
-            ++key_it;
 
-            if (!fs::is_directory(key_directory))
+            if (!key_it->is_directory())
             {
                 LOG_DEBUG(
                     log,
@@ -908,7 +907,7 @@ void FileCache::loadMetadata()
                 continue;
             }
 
-            if (fs::is_empty(key_directory))
+            if (fs::directory_iterator{key_directory} == fs::directory_iterator{})
             {
                 LOG_DEBUG(log, "Removing empty key directory: {}", key_directory.string());
                 fs::remove(key_directory);


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Reduce the number of syscalls in FileCache::loadMetadata

### Documentation entry for user-facing changes
--

References https://github.com/ClickHouse/ClickHouse/issues/52037

A couple changes focused only on the iteration over the folders to check what's empty:
* Using `path = it->path(); fs::is_directory(path)` requires a call to `newfstatat`/`stat`. We avoid this syscall by using the information already present in the iterator.
* `fs::is_empty(path)` adds another syscall in order to check the type of path. As we know per the previous condition that it is a directory we can also avoid that syscall to get the type. To do that, we simply build a directory iterator with the path and see if it's empty. 

cc @kssenii


The impact is hard to measure since it depends on what's in cache and what isn't and the rest of the operations that I haven't measured.

In a synthetic benchmark, with 1000 folders and each one of them 1000 subfolders with 1 file in each, and everything in kernel/disk cache, the iteration time and checks for emptiness go from 4039 ms to 3150 ms in my machine.

```bash
for i in {0..1000}; do for j in {0..1000}; do echo "$i $j"; mkdir -p $i/$j; touch $i/$j/a.txt; done; done
```

Before (4039 ms):
```c++
size_t empties_fs(const std::string &path)
{
    size_t empties = 0;

    for (auto level_1_it = directory_iterator{path};
        level_1_it != directory_iterator();
        level_1_it++)
    {
        const auto level_1_path = level_1_it->path();

        if (!is_directory(level_1_path))
            continue;
        if (is_empty(level_1_path))
            empties++;
        else
        {
            for (auto level_2_it = directory_iterator{level_1_path};
                level_2_it != directory_iterator();
                level_2_it++)
            {
                const auto level_2_path = level_2_it->path();
                if (!is_directory(level_2_path))
                    continue;
                if (is_empty(level_2_path))
                    empties++;
            }
        }
    }

    return empties;
}
```

After (3150 ms):
```c++
size_t empties_fs(const std::string &path)
{
    size_t empties = 0;
    for (auto level_1_it = directory_iterator{path};
        level_1_it != directory_iterator();
        level_1_it++)
    {
        if (!level_1_it->is_directory())
            continue;
        const auto level_1_path = level_1_it->path();

        auto level_2_it = directory_iterator{level_1_path};
        if (level_2_it == directory_iterator{})
            empties++;
        else
        {
            for (;
                level_2_it != directory_iterator();
                level_2_it++)
            {
                if (!level_2_it->is_directory())
                    continue;

                const auto level_2_path = level_2_it->path();
                if (directory_iterator{level_2_path} == directory_iterator{})
                    empties++;
            }
        }
    }


    return empties;
}
```

cc @kssenii