### PR TITLE
Disable test_memory_profiler_min_max_borders for sanitizers

### DIFF
--- a/tests/integration/test_memory_profiler_min_max_borders/test.py
+++ b/tests/integration/test_memory_profiler_min_max_borders/test.py
@@ -20,6 +20,9 @@ def started_cluster():
 
 
 def test_trace_boundaries_work(started_cluster):
+    if node.is_built_with_sanitizer():
+        pytest.skip("Disabled for sanitizers")
+
     node.query("select randomPrintableASCII(number) from numbers(1000) FORMAT Null")
     node.query("SYSTEM FLUSH LOGS")
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Cc: @alesapin 
Follow-up for: https://github.com/ClickHouse/ClickHouse/pull/52419