### PR TITLE
Fix test_insert_same_partition_and_merge by increasing wait time

### DIFF
--- a/tests/integration/test_merge_tree_azure_blob_storage/test.py
+++ b/tests/integration/test_merge_tree_azure_blob_storage/test.py
@@ -215,7 +215,7 @@ def test_insert_same_partition_and_merge(cluster, merge_vertical):
         if attempt == 59:
             assert parts_count == "(1)"
 
-        time.sleep(1)
+        time.sleep(10)
 
     assert azure_query(node, f"SELECT sum(id) FROM {TABLE_NAME} FORMAT Values") == "(0)"
     assert (


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


https://s3.amazonaws.com/clickhouse-test-reports/47532/60b97b2c2c04be526e81ad1918b6210642e5f053/integration_tests__asan__[6_6].html

Increased wait time as parts are removed after last check for parts 

`2023.07.06 13:15:12.476487 [ 9 ] {daacb176-59b0-4dc3-a314-2aa3cfbb7776} <Debug> executeQuery: (from 172.16.8.1:37756) SELECT COUNT(*) FROM system.parts WHERE table = 'blob_storage_table' FORMAT Values (stage: Complete)`

`2023.07.06 13:15:12.630257 [ 227 ] {} <Test> default.blob_storage_table (76161ee3-f86f-4036-b1da-5c37a2cb5144): removePartsFinally: removing 20200103_1_1_0 (state Deleting) from data_parts_indexes
2023.07.06 13:15:12.630279 [ 227 ] {} <Test> default.blob_storage_table (76161ee3-f86f-4036-b1da-5c37a2cb5144): removePartsFinally: removing 20200103_2_2_0 (state Deleting) from data_parts_indexes
2023.07.06 13:15:12.630287 [ 227 ] {} <Test> default.blob_storage_table (76161ee3-f86f-4036-b1da-5c37a2cb5144): removePartsFinally: removing 20200103_3_3_0 (state Deleting) from data_parts_indexes
2023.07.06 13:15:12.630294 [ 227 ] {} <Test> default.blob_storage_table (76161ee3-f86f-4036-b1da-5c37a2cb5144): removePartsFinally: removing 20200103_4_4_0 (state Deleting) from data_parts_indexes
2023.07.06 13:15:12.630300 [ 227 ] {} <Test> default.blob_storage_table (76161ee3-f86f-4036-b1da-5c37a2cb5144): removePartsFinally: removing 20200103_5_5_0 (state Deleting) from data_parts_indexes
2023.07.06 13:15:12.630306 [ 227 ] {} <Test> default.blob_storage_table (76161ee3-f86f-4036-b1da-5c37a2cb5144): removePartsFinally: removing 20200103_6_6_0 (state Deleting) from data_parts_indexes`