### PR TITLE
Try to fix asan wanring in HashJoin

### DIFF
--- a/tests/queries/0_stateless/02831_ast_fuzz_asan_join.sql
+++ b/tests/queries/0_stateless/02831_ast_fuzz_asan_join.sql
@@ -1,0 +1,22 @@
+SELECT
+    '0',
+    toTypeName(materialize(js2.s))
+FROM
+(
+    SELECT number AS k
+    FROM numbers(100)
+) AS js1
+FULL OUTER JOIN
+(
+    SELECT
+        toLowCardinality(2147483647 + 256) AS k,
+        '-0.0000000001',
+        1024,
+        toString(number + 10) AS s
+    FROM numbers(1024)
+) AS js2 ON js1.k = js2.k
+ORDER BY
+    inf DESC NULLS FIRST,
+    js1.k ASC NULLS LAST,
+    js2.k ASC
+FORMAT `Null`


### PR DESCRIPTION
Related to #49792. Try to fix heap-buffer-overflow in HashJoin. Currently, can't reproduce it, so just added test with query which lead to the warning previously

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
