### PR TITLE
support settings in alter statement

### DIFF
--- a/src/Interpreters/InterpreterAlterQuery.cpp
+++ b/src/Interpreters/InterpreterAlterQuery.cpp
@@ -47,8 +47,17 @@ namespace ErrorCodes
 
 InterpreterAlterQuery::InterpreterAlterQuery(const ASTPtr & query_ptr_, ContextPtr context_) : WithContext(context_), query_ptr(query_ptr_)
 {
+    /// init settings from alter sql
+    initSettings();
 }
 
+void InterpreterAlterQuery::initSettings()
+{
+    auto & alter_query = query_ptr->as<ASTAlterQuery &>();
+    if (alter_query.settings_ast) {
+        InterpreterSetQuery(alter_query.settings_ast, *context).executeForCurrentContext();
+    }
+}
 
 BlockIO InterpreterAlterQuery::execute()
 {


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (#52505 )
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

```
ALTER TABLE db.tb REPLACE PARTITION 20230301 FROM db.tb_tmp 
SETTINGS lock_acquire_timeout = 86400000
```


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
