### PR TITLE
support trigger materialized view when replace partition

### DIFF
--- a/src/Interpreters/InterpreterAlterQuery.h
+++ b/src/Interpreters/InterpreterAlterQuery.h
@@ -10,7 +10,7 @@ namespace DB
 class AccessRightsElements;
 class ASTAlterCommand;
 class ASTAlterQuery;
-
+struct PartitionCommand;
 
 /** Allows you add or remove a column in the table.
   * It also allows you to manipulate the partitions of the MergeTree family tables.
@@ -36,6 +36,8 @@ private:
     BlockIO executeToDatabase(const ASTAlterQuery & alter);
 
     ASTPtr query_ptr;
+
+    void triggerViewInsert(const PartitionCommand & command, const StorageID & table_id);
 };
 
 }

--- a/src/Parsers/ASTAlterQuery.h
+++ b/src/Parsers/ASTAlterQuery.h
@@ -194,6 +194,10 @@ public:
     String from_table;
     /// To distinguish REPLACE and ATTACH PARTITION partition FROM db.table
     bool replace = true;
+
+    /// to distinguish REPLACE PARTITION AND trigger materialized view of alter table
+    bool trigger_view = false;
+
     /// MOVE PARTITION partition TO TABLE db.table
     String to_database;
     String to_table;
@@ -226,6 +230,8 @@ public:
     };
 
     AlterObjectType alter_object = AlterObjectType::UNKNOWN;
+
+    bool need_trigger_view{false}; /// true for ALTER TABLE REPLACE PARTITION AND TRIGGER MATERIALIZED VIEW
 
     ASTExpressionList * command_list = nullptr;
 

--- a/src/Parsers/ParserAlterQuery.cpp
+++ b/src/Parsers/ParserAlterQuery.cpp
@@ -839,6 +839,7 @@ bool ParserAlterQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
     ParserKeyword s_alter_table("ALTER TABLE");
     ParserKeyword s_alter_live_view("ALTER LIVE VIEW");
     ParserKeyword s_alter_database("ALTER DATABASE");
+    ParserKeyword s_trigger_view("AND TRIGGER VIEW");
 
     ASTAlterQuery::AlterObjectType alter_object_type;
 
@@ -889,6 +890,11 @@ bool ParserAlterQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
 
     if (query->table)
         query->children.push_back(query->table);
+
+    if (s_trigger_view.ignore(pos, expected)) {
+        query->need_trigger_view = true;
+        return true;
+    }
 
     return true;
 }

--- a/src/Storages/PartitionCommands.cpp
+++ b/src/Storages/PartitionCommands.cpp
@@ -81,6 +81,7 @@ std::optional<PartitionCommand> PartitionCommand::parse(const ASTAlterCommand * 
         res.replace = command_ast->replace;
         res.from_database = command_ast->from_database;
         res.from_table = command_ast->from_table;
+        res.trigger_view = command_ast->trigger_view;
         return res;
     }
     else if (command_ast->type == ASTAlterCommand::FETCH_PARTITION)

--- a/src/Storages/PartitionCommands.h
+++ b/src/Storages/PartitionCommands.h
@@ -49,6 +49,9 @@ struct PartitionCommand
     String from_table;
     bool replace = true;
 
+    /// to distinguish REPLACE PARTITION AND trigger materialized view of alter table
+    bool trigger_view = false;
+
     /// For MOVE PARTITION
     String to_database;
     String to_table;


### PR DESCRIPTION

### Changelog category (leave one):
- New Feature
- Improvement
- Performance Improvement

#52508 

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Adding ‘an and trigger’ view to the end of the alter statement automatically writes the partitioned data to the associated materialized view

```
ALTER TABLE db.tb REPLACE PARTITION 20230301 FROM db.tb_tmp AND TRIGGER VIEW
```


