### PR TITLE
Uniform SSL configuration for Keeper and CH server

### DIFF
--- a/src/Coordination/KeeperServer.cpp
+++ b/src/Coordination/KeeperServer.cpp
@@ -66,7 +66,7 @@ namespace
         auto & ssl_manager = Poco::Net::SSLManager::instance();
         const auto & ssl_ctx = contextType == SSLContext::Server ? ssl_manager.defaultServerContext() : ssl_manager.defaultClientContext();
 
-        auto raw_ssl_ctx = ssl_ctx->sslContext();
+        auto * raw_ssl_ctx = ssl_ctx->sslContext();
         assert(raw_ssl_ctx);
 
         // asio will SSL_CTX_free context in destructor,

--- a/src/Coordination/KeeperServer.cpp
+++ b/src/Coordination/KeeperServer.cpp
@@ -39,7 +39,6 @@ namespace DB
 namespace ErrorCodes
 {
     extern const int RAFT_ERROR;
-    extern const int NO_ELEMENTS_IN_CONFIG;
     extern const int SUPPORT_IS_DISABLED;
     extern const int LOGICAL_ERROR;
     extern const int INVALID_CONFIG_PARAMETER;
@@ -70,7 +69,7 @@ namespace
         auto raw_ssl_ctx = ssl_ctx->sslContext();
         assert(raw_ssl_ctx);
 
-        // asio will SSL_CTX_free context in desctructor,
+        // asio will SSL_CTX_free context in destructor,
         // so we need to make sure that that wouldn't actually destroy a context.
         SSL_CTX_up_ref(raw_ssl_ctx);
 
@@ -80,11 +79,11 @@ namespace
     void setSSLParams(nuraft::asio_service::options & asio_opts)
     {
         // In order to maintain uniformity with CH on how SSL is used by Keeper,
-        // we need to use same SSL_CTX configuration as rest of ClickHouse does.
-        // Since copying configuration from one SSL_CTX to another is hard, we are using same
-        // SSL_CTX as rest of CH does (via Poco).
+        // we need to use the same SSL_CTX configuration as the rest of ClickHouse does.
+        // Since copying the configuration from one SSL_CTX to another is hard,
+        // we are using the same SSL_CTX instance as the rest of CH does (via Poco).
         //
-        // OpenSSL explicitly prohibts sharing SSL_CTX by multiple threads, but BoringSSL allows it
+        // OpenSSL explicitly prohibits sharing SSL_CTX by multiple threads, but BoringSSL allows it
         // and states that SSL_CTX is thread-safe.
         asio_opts.enable_ssl_ = true;
         asio_opts.ssl_context_provider_server_ = getSslContext<SSLContext::Server>;

--- a/tests/integration/test_keeper_internal_secure/configs/ssl_conf.xml
+++ b/tests/integration/test_keeper_internal_secure/configs/ssl_conf.xml
@@ -7,6 +7,9 @@
             <caConfig>/etc/clickhouse-server/config.d/rootCA.pem</caConfig>
             <loadDefaultCAFile>true</loadDefaultCAFile>
             <verificationMode>none</verificationMode>
+            <invalidCertificateHandler>
+                <name>AcceptCertificateHandler</name>
+            </invalidCertificateHandler>
             <cacheSessions>true</cacheSessions>
             <disableProtocols>sslv2,sslv3</disableProtocols>
             <preferServerCiphers>true</preferServerCiphers>
@@ -14,6 +17,9 @@
         <client>
             <!-- certificate is outdated and outgoing connection would fail otherwise -->
             <verificationMode>none</verificationMode>
+            <invalidCertificateHandler>
+                <name>AcceptCertificateHandler</name>
+            </invalidCertificateHandler>
         </client>
     </openSSL>
 </clickhouse>

--- a/tests/integration/test_keeper_internal_secure/configs/ssl_conf.xml
+++ b/tests/integration/test_keeper_internal_secure/configs/ssl_conf.xml
@@ -11,5 +11,9 @@
             <disableProtocols>sslv2,sslv3</disableProtocols>
             <preferServerCiphers>true</preferServerCiphers>
         </server>
+        <client>
+            <!-- certificate is outdated and outgoing connection would fail otherwise -->
+            <verificationMode>none</verificationMode>
+        </client>
     </openSSL>
 </clickhouse>


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Allowing the SSL configuration of Keeper to be more fine-grained and uniform with the ClickHouse server, by re-using Poco's `SSL_CTX`. That adds support for all of the configuration features that were not set by the initial implementation: `openSSL.server.dhParamsFile`, `openSSL.server.cipherList`, `openSSL.server.disableProtocols`, and others.

Depends on https://github.com/eBay/NuRaft/pull/412

`SSL_CTX` instances are already shared by 'server' threads of ClickHouse when handling multiple incoming SSL requests and by 'client' threads when establishing outgoing SSL connections and that seems to be working just fine.

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

Keeper's NuRaft SSL connections can now be configured in exactly the same way as ClickHouse server SSL connections, supporting the full range of [Poco's SSL configuration options](https://docs.pocoproject.org/current/Poco.Net.SSLManager.html).

This change could potentially lead to issues with existing secure Keeper-to-Keeper configurations due to differences in defaults and behavior.
| what | old behaviour  | new behaviour | how to restore to old behaviour |
| -------- | -------------- | ----------- | --------- |
| ⚠️ client (outgoing SSL connections) configuration | Used the same configuration as the server from `openssl.server` | Uses client-specific configuration from `openssl.client` | Copy contents of `openssl.server` configuration into `openssl.client` |
| ⚠️ `verificationMode` default mode (when not explicitly set) |  ⚠️ default mode is `none`<sup>*</sup> and certificate checks errors are ignored | ⚠️ default mode is `relaxed`, certificate check errors not ignored, aborting connection process  | to maintain previous NON-SECURE behavior set `verificationMode` to `none` and set `<invalidCertificateHandler></name>AcceptCertificateHandler</name></invalidCertificateHandler>` for both client and server SSL configurations |
| ⚠️ `loadDefaultCAFile` | **doesn't load** default CA files if `loadDefaultCAFile` is not explicitly set | ⚠️ **loads** default CA files if `loadDefaultCAFile` is not explicitly set | set `loadDefaultCAFile` to `false` | 
| `privateKeyFile` | MUST be present | may be skipped | |
| `certificateFile` | MUST be present | may be skipped | | 
| `caConfig` | only supports file. Requiring to amalgamate trust chain into a single certificate file for complex configurations | supports both file and directory configuration | |

- ⚠️ means behavior changed in a way that may cause problems with establishing connections.
- <sup>*</sup> Only `none` and `relaxed` are supported, any value other than `none` effectively means `relaxed`.

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
