### PR TITLE
Update 02136_scalar_subquery_metrics.sql

### DIFF
--- a/tests/queries/0_stateless/02136_scalar_subquery_metrics.sql
+++ b/tests/queries/0_stateless/02136_scalar_subquery_metrics.sql
@@ -6,7 +6,7 @@ SELECT '#02136_scalar_subquery_4', (SELECT max(number) FROM numbers(1000)) as n 
 SYSTEM FLUSH LOGS;
 SELECT read_rows, query FROM system.query_log
 WHERE
-      event_date > yesterday()
+      event_date >= yesterday()
   AND type = 'QueryFinish'
   AND current_database == currentDatabase()
   AND query LIKE 'SELECT ''#02136_scalar_subquery_%'


### PR DESCRIPTION

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

https://s3.amazonaws.com/clickhouse-test-reports/52355/d16d4449432999cdee3393b1f47b4a7d7c5314a6/stateless_tests__tsan__[2_5].html

That's funny (take a look at the timestamps):
```
2023-07-21 00:00:00 02136_scalar_subquery_metrics:                                          [ FAIL ] 1.93 sec. - result differs with reference: 
2023-07-21 00:00:00 --- /usr/share/clickhouse-test/queries/0_stateless/02136_scalar_subquery_metrics.reference	2023-07-20 23:55:20.896606340 +0800
2023-07-21 00:00:00 +++ /tmp/clickhouse-test/0_stateless/02136_scalar_subquery_metrics.stdout	2023-07-21 00:00:00.470002186 +0800
2023-07-21 00:00:00 @@ -3,7 +3,3 @@
2023-07-21 00:00:00  #02136_scalar_subquery_3	999	999
2023-07-21 00:00:00  #02136_scalar_subquery_4	999
2023-07-21 00:00:00  #02136_scalar_subquery_4	999
2023-07-21 00:00:00 -1001	SELECT \'#02136_scalar_subquery_1\', (SELECT max(number) FROM numbers(1000)) as n;
2023-07-21 00:00:00 -2001	SELECT \'#02136_scalar_subquery_2\', (SELECT max(number) FROM numbers(1000)) as n, (SELECT min(number) FROM numbers(1000)) as n2;
2023-07-21 00:00:00 -1001	SELECT \'#02136_scalar_subquery_3\', (SELECT max(number) FROM numbers(1000)) as n, (SELECT max(number) FROM numbers(1000)) as n2;
2023-07-21 00:00:00 -1002	SELECT \'#02136_scalar_subquery_4\', (SELECT max(number) FROM numbers(1000)) as n FROM system.numbers LIMIT 2;
2023-07-21 00:00:00 
2023-07-21 00:00:00 
```
