### PR TITLE
Check what will happen if we build ClickHouse with Musl (part 3)

### DIFF
--- a/PreLoad.cmake
+++ b/PreLoad.cmake
@@ -78,7 +78,7 @@ if (OS MATCHES "Linux"
     AND ("$ENV{CC}" MATCHES ".*clang.*" OR CMAKE_C_COMPILER MATCHES ".*clang.*"))
 
     if (ARCH MATCHES "amd64|x86_64")
-        set (CMAKE_TOOLCHAIN_FILE "cmake/linux/toolchain-x86_64.cmake" CACHE INTERNAL "")
+        set (CMAKE_TOOLCHAIN_FILE "cmake/linux/toolchain-x86_64-musl.cmake" CACHE INTERNAL "")
     elseif (ARCH MATCHES "^(aarch64.*|AARCH64.*|arm64.*|ARM64.*)")
         set (CMAKE_TOOLCHAIN_FILE "cmake/linux/toolchain-aarch64.cmake" CACHE INTERNAL "")
     elseif (ARCH MATCHES "^(ppc64le.*|PPC64LE.*)")

--- a/contrib/corrosion-cmake/CMakeLists.txt
+++ b/contrib/corrosion-cmake/CMakeLists.txt
@@ -17,20 +17,20 @@ endif()
 
 message(STATUS "Checking Rust toolchain for current target")
 
-if(CMAKE_TOOLCHAIN_FILE MATCHES "linux/toolchain-x86_64")
+if((CMAKE_TOOLCHAIN_FILE MATCHES "linux/toolchain-x86_64") AND (CMAKE_TOOLCHAIN_FILE MATCHES "musl"))
+    set(Rust_CARGO_TARGET "x86_64-unknown-linux-musl")
+elseif(CMAKE_TOOLCHAIN_FILE MATCHES "linux/toolchain-x86_64")
     set(Rust_CARGO_TARGET "x86_64-unknown-linux-gnu")
-endif()
-
-if(CMAKE_TOOLCHAIN_FILE MATCHES "linux/toolchain-aarch64")
+elseif((CMAKE_TOOLCHAIN_FILE MATCHES "linux/toolchain-aarch64") AND (CMAKE_TOOLCHAIN_FILE MATCHES "musl"))
+    set(Rust_CARGO_TARGET "aarch64-unknown-linux-musl")
+elseif(CMAKE_TOOLCHAIN_FILE MATCHES "linux/toolchain-aarch64")
     set(Rust_CARGO_TARGET "aarch64-unknown-linux-gnu")
-endif()
-
-if((CMAKE_TOOLCHAIN_FILE MATCHES "darwin") AND (CMAKE_TOOLCHAIN_FILE MATCHES "x86_64"))
+elseif((CMAKE_TOOLCHAIN_FILE MATCHES "darwin") AND (CMAKE_TOOLCHAIN_FILE MATCHES "x86_64"))
     set(Rust_CARGO_TARGET "x86_64-apple-darwin")
-endif()
-
-if((CMAKE_TOOLCHAIN_FILE MATCHES "freebsd") AND (CMAKE_TOOLCHAIN_FILE MATCHES "x86_64"))
+elseif((CMAKE_TOOLCHAIN_FILE MATCHES "freebsd") AND (CMAKE_TOOLCHAIN_FILE MATCHES "x86_64"))
     set(Rust_CARGO_TARGET "x86_64-unknown-freebsd")
+elseif(CMAKE_TOOLCHAIN_FILE MATCHES "linux/toolchain-riscv64")
+    set(Rust_CARGO_TARGET "riscv64gc-unknown-linux-gnu")
 endif()
 
 if(CMAKE_TOOLCHAIN_FILE MATCHES "ppc64le")

--- a/contrib/corrosion-cmake/CMakeLists.txt
+++ b/contrib/corrosion-cmake/CMakeLists.txt
@@ -18,6 +18,7 @@ endif()
 message(STATUS "Checking Rust toolchain for current target")
 
 # See https://doc.rust-lang.org/nightly/rustc/platform-support.html
+
 if((CMAKE_TOOLCHAIN_FILE MATCHES "linux/toolchain-x86_64") AND (CMAKE_TOOLCHAIN_FILE MATCHES "musl"))
     set(Rust_CARGO_TARGET "x86_64-unknown-linux-musl")
 elseif(CMAKE_TOOLCHAIN_FILE MATCHES "linux/toolchain-x86_64")

--- a/contrib/corrosion-cmake/CMakeLists.txt
+++ b/contrib/corrosion-cmake/CMakeLists.txt
@@ -17,6 +17,8 @@ endif()
 
 message(STATUS "Checking Rust toolchain for current target")
 
+# See https://doc.rust-lang.org/nightly/rustc/platform-support.html
+
 if((CMAKE_TOOLCHAIN_FILE MATCHES "linux/toolchain-x86_64") AND (CMAKE_TOOLCHAIN_FILE MATCHES "musl"))
     set(Rust_CARGO_TARGET "x86_64-unknown-linux-musl")
 elseif(CMAKE_TOOLCHAIN_FILE MATCHES "linux/toolchain-x86_64")

--- a/contrib/corrosion-cmake/CMakeLists.txt
+++ b/contrib/corrosion-cmake/CMakeLists.txt
@@ -18,7 +18,6 @@ endif()
 message(STATUS "Checking Rust toolchain for current target")
 
 # See https://doc.rust-lang.org/nightly/rustc/platform-support.html
-
 if((CMAKE_TOOLCHAIN_FILE MATCHES "linux/toolchain-x86_64") AND (CMAKE_TOOLCHAIN_FILE MATCHES "musl"))
     set(Rust_CARGO_TARGET "x86_64-unknown-linux-musl")
 elseif(CMAKE_TOOLCHAIN_FILE MATCHES "linux/toolchain-x86_64")

--- a/docker/packager/binary/Dockerfile
+++ b/docker/packager/binary/Dockerfile
@@ -52,11 +52,15 @@ RUN curl https://sh.rustup.rs -sSf | bash -s -- -y && \
     rustup toolchain install nightly-2023-07-04 && \
     rustup default nightly-2023-07-04 && \
     rustup component add rust-src && \
+    rustup target add x86_64-unknown-linux-gnu && \
     rustup target add aarch64-unknown-linux-gnu && \
     rustup target add x86_64-apple-darwin && \
     rustup target add x86_64-unknown-freebsd && \
     rustup target add aarch64-apple-darwin && \
-    rustup target add powerpc64le-unknown-linux-gnu
+    rustup target add powerpc64le-unknown-linux-gnu && \
+    rustup target add x86_64-unknown-linux-musl && \
+    rustup target add aarch64-unknown-linux-musl && \
+    rustup target add riscv64gc-unknown-linux-gnu
 
 # Create vendor cache for cargo.
 #


### PR DESCRIPTION
### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
ClickHouse is built with Musl instead of GLibc by default.