### PR TITLE
tests: fix 00719_parallel_ddl_table flakiness in debug builds

### DIFF
--- a/tests/queries/0_stateless/00719_parallel_ddl_table.sh
+++ b/tests/queries/0_stateless/00719_parallel_ddl_table.sh
@@ -10,7 +10,7 @@ ${CLICKHOUSE_CLIENT} --query "DROP TABLE IF EXISTS parallel_ddl"
 
 function query()
 {
-    for _ in {1..100}; do
+    for _ in {1..50}; do
         ${CLICKHOUSE_CLIENT} --query "CREATE TABLE IF NOT EXISTS parallel_ddl(a Int) ENGINE = Memory"
         ${CLICKHOUSE_CLIENT} --query "DROP TABLE IF EXISTS parallel_ddl"
     done


### PR DESCRIPTION
In debug bulds each client invocation takes ~1 second, and on CI it can take more if the node is under some load, so let's decrease number of iterations.

Anyway CI runs each test ~1K times daily, and if there will be something even this number of iterations should be enough.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)