### PR TITLE
[WIP] Add hide-secrets flag

### DIFF
--- a/programs/format/Format.cpp
+++ b/programs/format/Format.cpp
@@ -58,7 +58,7 @@ int mainEntryClickHouseFormat(int argc, char ** argv)
             ("backslash", "add a backslash at the end of each line of the formatted query")
             ("allow_settings_after_format_in_insert", "Allow SETTINGS after FORMAT, but note, that this is not always safe")
             ("seed", po::value<std::string>(), "seed (arbitrary string) that determines the result of obfuscation")
-            ("show-secrets" , "show secret parts of the AST. For example in query: CREATE USER user IDENTIFIED WITH PLAINTEXT_PASSWORD BY 'hello', 'hello' is a secret part of AST")
+            ("show-secrets" , "show secret parts of the AST, e.g. passwords or API keys")
         ;
 
         Settings cmd_settings;
@@ -91,13 +91,13 @@ int mainEntryClickHouseFormat(int argc, char ** argv)
 
         if (quiet && (hilite || oneline || show_secrets || obfuscate))
         {
-            std::cerr << "Options 'hilite' or 'oneline' or 'obfuscate' have no sense in 'quiet' mode." << std::endl;
+            std::cerr << "Options 'hilite' or 'oneline' or 'show-secrets' or 'obfuscate' have no sense in 'quiet' mode." << std::endl;
             return 2;
         }
 
         if (obfuscate && (hilite || oneline || show_secrets || quiet))
         {
-            std::cerr << "Options 'hilite' or 'oneline' or 'quiet' have no sense in 'obfuscate' mode." << std::endl;
+            std::cerr << "Options 'hilite' or 'oneline' or 'show-secrets' or 'quiet' have no sense in 'obfuscate' mode." << std::endl;
             return 2;
         }
 

--- a/programs/format/Format.cpp
+++ b/programs/format/Format.cpp
@@ -58,7 +58,7 @@ int mainEntryClickHouseFormat(int argc, char ** argv)
             ("backslash", "add a backslash at the end of each line of the formatted query")
             ("allow_settings_after_format_in_insert", "Allow SETTINGS after FORMAT, but note, that this is not always safe")
             ("seed", po::value<std::string>(), "seed (arbitrary string) that determines the result of obfuscation")
-            ("show-secrets" , "show secret parts of the AST")
+            ("show-secrets" , "show secret parts of the AST. For example in query: CREATE USER user IDENTIFIED WITH PLAINTEXT_PASSWORD BY 'hello', 'hello' is a secret part of AST")
         ;
 
         Settings cmd_settings;
@@ -75,7 +75,7 @@ int mainEntryClickHouseFormat(int argc, char ** argv)
 
         if (options.count("help"))
         {
-            std::cout << "Usage: " << argv[0] << " [options] < query " << std::endl;
+            std::cout << "Usage: " << argv[0] << " [options] < query" << std::endl;
             std::cout << desc << std::endl;
             return 1;
         }
@@ -89,13 +89,13 @@ int mainEntryClickHouseFormat(int argc, char ** argv)
         bool show_secrets = options.count("show-secrets");
         bool allow_settings_after_format_in_insert = options.count("allow_settings_after_format_in_insert");
 
-        if (quiet && (hilite || oneline || obfuscate))
+        if (quiet && (hilite || oneline || show_secrets || obfuscate))
         {
             std::cerr << "Options 'hilite' or 'oneline' or 'obfuscate' have no sense in 'quiet' mode." << std::endl;
             return 2;
         }
 
-        if (obfuscate && (hilite || oneline || quiet))
+        if (obfuscate && (hilite || oneline || show_secrets || quiet))
         {
             std::cerr << "Options 'hilite' or 'oneline' or 'quiet' have no sense in 'obfuscate' mode." << std::endl;
             return 2;

--- a/programs/format/Format.cpp
+++ b/programs/format/Format.cpp
@@ -58,7 +58,7 @@ int mainEntryClickHouseFormat(int argc, char ** argv)
             ("backslash", "add a backslash at the end of each line of the formatted query")
             ("allow_settings_after_format_in_insert", "Allow SETTINGS after FORMAT, but note, that this is not always safe")
             ("seed", po::value<std::string>(), "seed (arbitrary string) that determines the result of obfuscation")
-            ("hide-secrets", "nothing interesting")
+            ("show-secrets" , "show secret parts of the AST")
         ;
 
         Settings cmd_settings;
@@ -75,7 +75,7 @@ int mainEntryClickHouseFormat(int argc, char ** argv)
 
         if (options.count("help"))
         {
-            std::cout << "Usage: " << argv[0] << " [options] < query" << std::endl;
+            std::cout << "Usage: " << argv[0] << " [options] < query " << std::endl;
             std::cout << desc << std::endl;
             return 1;
         }
@@ -86,6 +86,7 @@ int mainEntryClickHouseFormat(int argc, char ** argv)
         bool multiple = options.count("multiquery");
         bool obfuscate = options.count("obfuscate");
         bool backslash = options.count("backslash");
+        bool show_secrets = options.count("show-secrets");
         bool allow_settings_after_format_in_insert = options.count("allow_settings_after_format_in_insert");
 
         if (quiet && (hilite || oneline || obfuscate))
@@ -176,7 +177,7 @@ int mainEntryClickHouseFormat(int argc, char ** argv)
                     if (!backslash)
                     {
                         WriteBufferFromOStream res_buf(std::cout, 4096);
-                        formatAST(*res, res_buf, hilite, oneline);
+                        formatAST(*res, res_buf, hilite, oneline, show_secrets);
                         res_buf.finalize();
                         if (multiple)
                             std::cout << "\n;\n";

--- a/programs/format/Format.cpp
+++ b/programs/format/Format.cpp
@@ -58,6 +58,7 @@ int mainEntryClickHouseFormat(int argc, char ** argv)
             ("backslash", "add a backslash at the end of each line of the formatted query")
             ("allow_settings_after_format_in_insert", "Allow SETTINGS after FORMAT, but note, that this is not always safe")
             ("seed", po::value<std::string>(), "seed (arbitrary string) that determines the result of obfuscation")
+            ("hide-secrets", "nothing interesting")
         ;
 
         Settings cmd_settings;

--- a/src/Parsers/ASTFunctionWithKeyValueArguments.cpp
+++ b/src/Parsers/ASTFunctionWithKeyValueArguments.cpp
@@ -29,7 +29,7 @@ void ASTPair::formatImpl(const FormatSettings & settings, FormatState & state, F
     if (second_with_brackets)
         settings.ostr << (settings.hilite ? hilite_keyword : "") << "(";
 
-    if (!settings.show_secrets && (first == "password"))
+    if (!settings.show_secrets && (first == "password" || first == "value"))
     {
         /// Hide password in the definition of a dictionary:
         /// SOURCE(CLICKHOUSE(host 'example01-01-1' port 9000 user 'default' password '[HIDDEN]' db 'default' table 'ids'))

--- a/src/Parsers/Access/ASTAuthenticationData.cpp
+++ b/src/Parsers/Access/ASTAuthenticationData.cpp
@@ -131,7 +131,7 @@ void ASTAuthenticationData::formatImpl(const FormatSettings & settings, FormatSt
 
     if (password && !settings.show_secrets)
     {
-        prefix = "";
+        prefix += " `[HIDDEN]'";
         password = false;
         salt = false;
         if (type)

--- a/src/Parsers/Access/ASTAuthenticationData.cpp
+++ b/src/Parsers/Access/ASTAuthenticationData.cpp
@@ -131,7 +131,6 @@ void ASTAuthenticationData::formatImpl(const FormatSettings & settings, FormatSt
 
     if (password && !settings.show_secrets)
     {
-        prefix += " `[HIDDEN]'";
         password = false;
         salt = false;
         if (type)
@@ -155,6 +154,9 @@ void ASTAuthenticationData::formatImpl(const FormatSettings & settings, FormatSt
     {
         settings.ostr << " ";
         children[0]->format(settings);
+    }
+    else{
+        settings.ostr << " '[HIDDEN]'";
     }
 
     if (salt)

--- a/src/Parsers/IAST.h
+++ b/src/Parsers/IAST.h
@@ -195,7 +195,7 @@ public:
         bool one_line;
         bool always_quote_identifiers = false;
         IdentifierQuotingStyle identifier_quoting_style = IdentifierQuotingStyle::Backticks;
-        bool show_secrets = false; /// Show secret parts of the AST (e.g. passwords, encryption keys).
+        bool show_secrets; /// Show secret parts of the AST (e.g. passwords, encryption keys).
 
         // Newline or whitespace.
         char nl_or_ws;

--- a/src/Parsers/IAST.h
+++ b/src/Parsers/IAST.h
@@ -195,12 +195,12 @@ public:
         bool one_line;
         bool always_quote_identifiers = false;
         IdentifierQuotingStyle identifier_quoting_style = IdentifierQuotingStyle::Backticks;
-        bool show_secrets = true; /// Show secret parts of the AST (e.g. passwords, encryption keys).
+        bool show_secrets = false; /// Show secret parts of the AST (e.g. passwords, encryption keys).
 
         // Newline or whitespace.
         char nl_or_ws;
 
-        FormatSettings(WriteBuffer & ostr_, bool one_line_, bool show_secrets_ = true)
+        FormatSettings(WriteBuffer & ostr_, bool one_line_, bool show_secrets_ = false)
             : ostr(ostr_), one_line(one_line_), show_secrets(show_secrets_)
         {
             nl_or_ws = one_line ? ' ' : '\n';

--- a/src/Parsers/formatAST.cpp
+++ b/src/Parsers/formatAST.cpp
@@ -6,9 +6,8 @@ namespace DB
 
 void formatAST(const IAST & ast, WriteBuffer & buf, bool hilite, bool one_line, bool show_secrets)
 {
-    IAST::FormatSettings settings(buf, one_line);
+    IAST::FormatSettings settings(buf, one_line, show_secrets);
     settings.hilite = hilite;
-    settings.show_secrets = show_secrets;
     ast.format(settings);
 }
 

--- a/src/Parsers/formatAST.cpp
+++ b/src/Parsers/formatAST.cpp
@@ -4,11 +4,11 @@
 namespace DB
 {
 
-void formatAST(const IAST & ast, WriteBuffer & buf, bool hilite, bool one_line)
+void formatAST(const IAST & ast, WriteBuffer & buf, bool hilite, bool one_line, bool show_secrets)
 {
     IAST::FormatSettings settings(buf, one_line);
     settings.hilite = hilite;
-
+    settings.show_secrets = show_secrets;
     ast.format(settings);
 }
 

--- a/src/Parsers/formatAST.h
+++ b/src/Parsers/formatAST.h
@@ -11,7 +11,7 @@ class WriteBuffer;
 /** Takes a syntax tree and turns it back into text.
   * In case of INSERT query, the data will be missing.
   */
-void formatAST(const IAST & ast, WriteBuffer & buf, bool hilite = true, bool one_line = false);
+void formatAST(const IAST & ast, WriteBuffer & buf, bool hilite = true, bool one_line = false, bool show_secrets = false);
 
 String serializeAST(const IAST & ast, bool one_line = true);
 


### PR DESCRIPTION
This pull request implements issue #48290

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- New Feature

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
