### PR TITLE
MaterializedMySQL: Fix the infinite loop in ReadBuffer::read

### DIFF
--- a/src/IO/MySQLPacketPayloadReadBuffer.cpp
+++ b/src/IO/MySQLPacketPayloadReadBuffer.cpp
@@ -45,6 +45,9 @@ bool MySQLPacketPayloadReadBuffer::nextImpl()
     }
 
     in.nextIfAtEnd();
+    /// Don't return a buffer when no bytes available
+    if (!in.hasPendingData())
+        return false;
     working_buffer = ReadBuffer::Buffer(in.position(), in.buffer().end());
     size_t count = std::min(in.available(), payload_length - offset);
     working_buffer.resize(count);


### PR DESCRIPTION
This fixes https://github.com/ClickHouse/ClickHouse/issues/33549

The infinite loop caused because sometimes the pos of ReadBuffer overflows the end.

It happens f.e. when `MySQLPacketPayloadReadBuffer::nextImpl` might return empty buffer, since `in.nextIfAtEnd();` could not read more bytes and thus no bytes available (pos == end). 
It might happen when a network error or the connection to MySQL was closed or killed. This leads to empty `working_buffer` but successful returning (`return true;`) from the func. 
And check `if (in.eof())` from `MySQLBinlogEventReadBuffer::nextImpl()` fails and also causes empty its `working_buffer` and successful return.

At the end `payload.ignore(1)` and `payload.read(c)` produces the infinite loop since it is not eof() and ++pos overflows the end of the buffer.
**When pos > end, it is never eof() since avaliable() always > 0**

Should be tested by `test_mysql_kill*` from test_materialized_mysql_database/test.py

Details:
`MySQLClient` calls `MySQLFlavor::readPayload(ReadBufferFromPocoSocket)` where the flow is
`MySQLBinlogEventReadBuffer` -> `MySQLPacketPayloadReadBuffer` -> `ReadBufferFromPocoSocket`

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Fixed the infinite loop in ReadBuffer when the pos overflows the end of the buffer in MaterializedMySQL.


<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
