### PR TITLE
Fix stress test: check if storage shutdown before we operate MergeTreeDeduplicationLog

### DIFF
--- a/src/Storages/MergeTree/MergeTreeDeduplicationLog.cpp
+++ b/src/Storages/MergeTree/MergeTreeDeduplicationLog.cpp
@@ -11,7 +11,6 @@
 #include <Disks/IDisk.h>
 
 #include <Common/Exception.h>
-#include <Common/logger_useful.h>
 
 namespace DB
 {

--- a/src/Storages/MergeTree/MergeTreeDeduplicationLog.cpp
+++ b/src/Storages/MergeTree/MergeTreeDeduplicationLog.cpp
@@ -241,8 +241,7 @@ std::pair<MergeTreePartInfo, bool> MergeTreeDeduplicationLog::addPart(const std:
 
     if (stopped)
     {
-        LOG_ERROR(&Poco::Logger::get("MergeTreeDeduplicationLog"), "Storage has been shutdown when we add this part.");
-        return {};
+        throw Exception(ErrorCodes::ABORTED, "Storage has been shutdown when we drop this part.");
     }
 
     chassert(current_writer != nullptr);

--- a/src/Storages/MergeTree/MergeTreeDeduplicationLog.cpp
+++ b/src/Storages/MergeTree/MergeTreeDeduplicationLog.cpp
@@ -10,7 +10,7 @@
 #include <Disks/WriteMode.h>
 #include <Disks/IDisk.h>
 
-#include "Common/Exception.h"
+#include <Common/Exception.h>
 #include <Common/logger_useful.h>
 
 namespace DB

--- a/src/Storages/MergeTree/MergeTreeDeduplicationLog.cpp
+++ b/src/Storages/MergeTree/MergeTreeDeduplicationLog.cpp
@@ -10,10 +10,16 @@
 #include <Disks/WriteMode.h>
 #include <Disks/IDisk.h>
 
+#include "Common/Exception.h"
 #include <Common/logger_useful.h>
 
 namespace DB
 {
+
+namespace ErrorCodes
+{
+    extern const int ABORTED;
+}
 
 namespace
 {
@@ -271,8 +277,7 @@ void MergeTreeDeduplicationLog::dropPart(const MergeTreePartInfo & drop_part_inf
 
     if (stopped)
     {
-        LOG_ERROR(&Poco::Logger::get("MergeTreeDeduplicationLog"), "Storage has been shutdown when we drop this part.");
-        return;
+        throw Exception(ErrorCodes::ABORTED, "Storage has been shutdown when we drop this part.");
     }
 
     chassert(current_writer != nullptr);

--- a/src/Storages/MergeTree/MergeTreeDeduplicationLog.cpp
+++ b/src/Storages/MergeTree/MergeTreeDeduplicationLog.cpp
@@ -240,7 +240,7 @@ std::pair<MergeTreePartInfo, bool> MergeTreeDeduplicationLog::addPart(const std:
 
     if (stopped)
     {
-        throw Exception(ErrorCodes::ABORTED, "Storage has been shutdown when we drop this part.");
+        throw Exception(ErrorCodes::ABORTED, "Storage has been shutdown when we add this part.");
     }
 
     chassert(current_writer != nullptr);

--- a/src/Storages/MergeTree/MergeTreeDeduplicationLog.cpp
+++ b/src/Storages/MergeTree/MergeTreeDeduplicationLog.cpp
@@ -10,6 +10,8 @@
 #include <Disks/WriteMode.h>
 #include <Disks/IDisk.h>
 
+#include <Common/logger_useful.h>
+
 namespace DB
 {
 
@@ -231,6 +233,12 @@ std::pair<MergeTreePartInfo, bool> MergeTreeDeduplicationLog::addPart(const std:
         return std::make_pair(info, false);
     }
 
+    if (stopped)
+    {
+        LOG_ERROR(&Poco::Logger::get("MergeTreeDeduplicationLog"), "Storage has been shutdown when we add this part.");
+        return {};
+    }
+
     chassert(current_writer != nullptr);
 
     /// Create new record
@@ -260,6 +268,12 @@ void MergeTreeDeduplicationLog::dropPart(const MergeTreePartInfo & drop_part_inf
     /// threads and so on.
     if (deduplication_window == 0)
         return;
+
+    if (stopped)
+    {
+        LOG_ERROR(&Poco::Logger::get("MergeTreeDeduplicationLog"), "Storage has been shutdown when we drop this part.");
+        return;
+    }
 
     chassert(current_writer != nullptr);
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
fix ci #47641
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
