### PR TITLE
init and destroy ares channel on demand..

### DIFF
--- a/src/Common/tests/gtest_dns_reverse_resolve.cpp
+++ b/src/Common/tests/gtest_dns_reverse_resolve.cpp
@@ -9,34 +9,35 @@ namespace DB
 {
 TEST(Common, ReverseDNS)
 {
-    auto addresses = std::vector<std::string>({
-        "8.8.8.8", "2001:4860:4860::8888", // dns.google
-        "142.250.219.35", // google.com
-        "157.240.12.35", // facebook
-        "208.84.244.116", "2600:1419:c400::214:c410", //www.terra.com.br,
-        "127.0.0.1", "::1"
-    });
-
     auto func = [&]()
     {
         // Good random seed, good engine
         auto rnd1 = std::mt19937(std::random_device{}());
 
-        for (int i = 0; i < 50; ++i)
+        for (int i = 0; i < 10; ++i)
         {
             auto & dns_resolver_instance = DNSResolver::instance();
-//            unfortunately, DNS cache can't be disabled because we might end up causing a DDoS attack
-//            dns_resolver_instance.setDisableCacheFlag();
+            dns_resolver_instance.setDisableCacheFlag();
 
-            auto addr_index = rnd1() % addresses.size();
+            auto val1 = rnd1() % static_cast<uint32_t>((pow(2, 31) - 1));
+            auto val2 = rnd1() % static_cast<uint32_t>((pow(2, 31) - 1));
+            auto val3 = rnd1() % static_cast<uint32_t>((pow(2, 31) - 1));
+            auto val4 = rnd1() % static_cast<uint32_t>((pow(2, 31) - 1));
 
-            [[maybe_unused]] auto result = dns_resolver_instance.reverseResolve(Poco::Net::IPAddress{ addresses[addr_index] });
+            uint32_t ipv4_buffer[1] = {
+                static_cast<uint32_t>(val1)
+            };
 
-//            will not assert either because some of the IP addresses might change in the future and
-//            this test will become flaky
-//            ASSERT_TRUE(!result.empty());
+            uint32_t ipv6_buffer[4] = {
+                static_cast<uint32_t>(val1),
+                static_cast<uint32_t>(val2),
+                static_cast<uint32_t>(val3),
+                static_cast<uint32_t>(val4)
+            };
+
+            dns_resolver_instance.reverseResolve(Poco::Net::IPAddress{ ipv4_buffer, sizeof(ipv4_buffer)});
+            dns_resolver_instance.reverseResolve(Poco::Net::IPAddress{ ipv6_buffer, sizeof(ipv6_buffer)});
         }
-
     };
 
     auto number_of_threads = 200u;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Remove mutex from CaresPTRResolver and create `ares_channel` on demand. Trying to fix: https://github.com/ClickHouse/ClickHouse/pull/52327#issuecomment-1643021543

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
