### PR TITLE
Partially fixed test 01747_system_session_log_long

### DIFF
--- a/tests/config/users.d/session_log_test.xml
+++ b/tests/config/users.d/session_log_test.xml
@@ -17,7 +17,7 @@
 
     <users>
         <session_log_test_xml_user>
-            <password></password>
+            <no_password></no_password>
             <networks incl="networks" replace="replace">
                 <ip>::1</ip>
                 <ip>127.0.0.1</ip>

--- a/tests/queries/0_stateless/01747_system_session_log_long.reference
+++ b/tests/queries/0_stateless/01747_system_session_log_long.reference
@@ -4,215 +4,291 @@ TCP endpoint
 TCP 'wrong password' case is skipped for no_password.
 HTTP endpoint
 HTTP 'wrong password' case is skipped for no_password.
-MySQL endpoint
+HTTP endpoint with named session
+HTTP 'wrong password' case is skipped for no_password.
+MySQL endpoint no_password
+Wrong username
+Wrong password
 MySQL 'wrong password' case is skipped for no_password.
+PostrgreSQL endpoint
+PostgreSQL 'wrong password' case is skipped for no_password.
 
 #  no_password - No profiles no roles 
 TCP endpoint
 TCP 'wrong password' case is skipped for no_password.
 HTTP endpoint
 HTTP 'wrong password' case is skipped for no_password.
-MySQL endpoint
+HTTP endpoint with named session
+HTTP 'wrong password' case is skipped for no_password.
+MySQL endpoint no_password
+Wrong username
+Wrong password
 MySQL 'wrong password' case is skipped for no_password.
+PostrgreSQL endpoint
+PostgreSQL 'wrong password' case is skipped for no_password.
 
 #  no_password - Two profiles, no roles 
 TCP endpoint
 TCP 'wrong password' case is skipped for no_password.
 HTTP endpoint
 HTTP 'wrong password' case is skipped for no_password.
-MySQL endpoint
+HTTP endpoint with named session
+HTTP 'wrong password' case is skipped for no_password.
+MySQL endpoint no_password
+Wrong username
+Wrong password
 MySQL 'wrong password' case is skipped for no_password.
+PostrgreSQL endpoint
+PostgreSQL 'wrong password' case is skipped for no_password.
 
 #  no_password - Two profiles and two simple roles 
 TCP endpoint
 TCP 'wrong password' case is skipped for no_password.
 HTTP endpoint
 HTTP 'wrong password' case is skipped for no_password.
-MySQL endpoint
+HTTP endpoint with named session
+HTTP 'wrong password' case is skipped for no_password.
+MySQL endpoint no_password
+Wrong username
+Wrong password
 MySQL 'wrong password' case is skipped for no_password.
+PostrgreSQL endpoint
+PostgreSQL 'wrong password' case is skipped for no_password.
 
 #  plaintext_password - No profiles no roles 
 TCP endpoint
 HTTP endpoint
-MySQL endpoint
+HTTP endpoint with named session
+MySQL endpoint plaintext_password
+Wrong username
+Wrong password
+PostrgreSQL endpoint
 
 #  plaintext_password - Two profiles, no roles 
 TCP endpoint
 HTTP endpoint
-MySQL endpoint
+HTTP endpoint with named session
+MySQL endpoint plaintext_password
+Wrong username
+Wrong password
+PostrgreSQL endpoint
 
 #  plaintext_password - Two profiles and two simple roles 
 TCP endpoint
 HTTP endpoint
-MySQL endpoint
+HTTP endpoint with named session
+MySQL endpoint plaintext_password
+Wrong username
+Wrong password
+PostrgreSQL endpoint
 
 #  sha256_password - No profiles no roles 
 TCP endpoint
 HTTP endpoint
-MySQL endpoint
+HTTP endpoint with named session
+MySQL endpoint sha256_password
 MySQL 'successful login' case is skipped for sha256_password.
+Wrong username
+Wrong password
+PostrgreSQL endpoint
+PostgreSQL tests are skipped for sha256_password
 
 #  sha256_password - Two profiles, no roles 
 TCP endpoint
 HTTP endpoint
-MySQL endpoint
+HTTP endpoint with named session
+MySQL endpoint sha256_password
 MySQL 'successful login' case is skipped for sha256_password.
+Wrong username
+Wrong password
+PostrgreSQL endpoint
+PostgreSQL tests are skipped for sha256_password
 
 #  sha256_password - Two profiles and two simple roles 
 TCP endpoint
 HTTP endpoint
-MySQL endpoint
+HTTP endpoint with named session
+MySQL endpoint sha256_password
 MySQL 'successful login' case is skipped for sha256_password.
+Wrong username
+Wrong password
+PostrgreSQL endpoint
+PostgreSQL tests are skipped for sha256_password
 
 #  double_sha1_password - No profiles no roles 
 TCP endpoint
 HTTP endpoint
-MySQL endpoint
+HTTP endpoint with named session
+MySQL endpoint double_sha1_password
+Wrong username
+Wrong password
+PostrgreSQL endpoint
+PostgreSQL tests are skipped for double_sha1_password
 
 #  double_sha1_password - Two profiles, no roles 
 TCP endpoint
 HTTP endpoint
-MySQL endpoint
+HTTP endpoint with named session
+MySQL endpoint double_sha1_password
+Wrong username
+Wrong password
+PostrgreSQL endpoint
+PostgreSQL tests are skipped for double_sha1_password
 
 #  double_sha1_password - Two profiles and two simple roles 
 TCP endpoint
 HTTP endpoint
-MySQL endpoint
+HTTP endpoint with named session
+MySQL endpoint double_sha1_password
+Wrong username
+Wrong password
+PostrgreSQL endpoint
+PostgreSQL tests are skipped for double_sha1_password
 ${BASE_USERNAME}_double_sha1_password_no_profiles_no_roles	TCP	LoginFailure	1
 ${BASE_USERNAME}_double_sha1_password_no_profiles_no_roles	TCP	LoginSuccess	1
 ${BASE_USERNAME}_double_sha1_password_no_profiles_no_roles	TCP	Logout	1
-${BASE_USERNAME}_double_sha1_password_no_profiles_no_roles	HTTP	LoginFailure	1
-${BASE_USERNAME}_double_sha1_password_no_profiles_no_roles	HTTP	LoginSuccess	1
-${BASE_USERNAME}_double_sha1_password_no_profiles_no_roles	HTTP	Logout	1
+${BASE_USERNAME}_double_sha1_password_no_profiles_no_roles	HTTP	LoginFailure	many
+${BASE_USERNAME}_double_sha1_password_no_profiles_no_roles	HTTP	LoginSuccess	many
+${BASE_USERNAME}_double_sha1_password_no_profiles_no_roles	HTTP	Logout	many
 ${BASE_USERNAME}_double_sha1_password_no_profiles_no_roles	MySQL	LoginFailure	many
 ${BASE_USERNAME}_double_sha1_password_no_profiles_no_roles	MySQL	LoginSuccess	1
 ${BASE_USERNAME}_double_sha1_password_no_profiles_no_roles	MySQL	Logout	1
 ${BASE_USERNAME}_double_sha1_password_two_profiles_no_roles	TCP	LoginFailure	1
 ${BASE_USERNAME}_double_sha1_password_two_profiles_no_roles	TCP	LoginSuccess	1
 ${BASE_USERNAME}_double_sha1_password_two_profiles_no_roles	TCP	Logout	1
-${BASE_USERNAME}_double_sha1_password_two_profiles_no_roles	HTTP	LoginFailure	1
-${BASE_USERNAME}_double_sha1_password_two_profiles_no_roles	HTTP	LoginSuccess	1
-${BASE_USERNAME}_double_sha1_password_two_profiles_no_roles	HTTP	Logout	1
+${BASE_USERNAME}_double_sha1_password_two_profiles_no_roles	HTTP	LoginFailure	many
+${BASE_USERNAME}_double_sha1_password_two_profiles_no_roles	HTTP	LoginSuccess	many
+${BASE_USERNAME}_double_sha1_password_two_profiles_no_roles	HTTP	Logout	many
 ${BASE_USERNAME}_double_sha1_password_two_profiles_no_roles	MySQL	LoginFailure	many
 ${BASE_USERNAME}_double_sha1_password_two_profiles_no_roles	MySQL	LoginSuccess	1
 ${BASE_USERNAME}_double_sha1_password_two_profiles_no_roles	MySQL	Logout	1
 ${BASE_USERNAME}_double_sha1_password_two_profiles_two_roles	TCP	LoginFailure	1
 ${BASE_USERNAME}_double_sha1_password_two_profiles_two_roles	TCP	LoginSuccess	1
 ${BASE_USERNAME}_double_sha1_password_two_profiles_two_roles	TCP	Logout	1
-${BASE_USERNAME}_double_sha1_password_two_profiles_two_roles	HTTP	LoginFailure	1
-${BASE_USERNAME}_double_sha1_password_two_profiles_two_roles	HTTP	LoginSuccess	1
-${BASE_USERNAME}_double_sha1_password_two_profiles_two_roles	HTTP	Logout	1
+${BASE_USERNAME}_double_sha1_password_two_profiles_two_roles	HTTP	LoginFailure	many
+${BASE_USERNAME}_double_sha1_password_two_profiles_two_roles	HTTP	LoginSuccess	many
+${BASE_USERNAME}_double_sha1_password_two_profiles_two_roles	HTTP	Logout	many
 ${BASE_USERNAME}_double_sha1_password_two_profiles_two_roles	MySQL	LoginFailure	many
 ${BASE_USERNAME}_double_sha1_password_two_profiles_two_roles	MySQL	LoginSuccess	1
 ${BASE_USERNAME}_double_sha1_password_two_profiles_two_roles	MySQL	Logout	1
 ${BASE_USERNAME}_no_password_no_profiles_no_roles	TCP	LoginSuccess	1
 ${BASE_USERNAME}_no_password_no_profiles_no_roles	TCP	Logout	1
-${BASE_USERNAME}_no_password_no_profiles_no_roles	HTTP	LoginSuccess	1
-${BASE_USERNAME}_no_password_no_profiles_no_roles	HTTP	Logout	1
+${BASE_USERNAME}_no_password_no_profiles_no_roles	HTTP	LoginSuccess	many
+${BASE_USERNAME}_no_password_no_profiles_no_roles	HTTP	Logout	many
 ${BASE_USERNAME}_no_password_no_profiles_no_roles	MySQL	LoginSuccess	1
 ${BASE_USERNAME}_no_password_no_profiles_no_roles	MySQL	Logout	1
 ${BASE_USERNAME}_no_password_two_profiles_no_roles	TCP	LoginSuccess	1
 ${BASE_USERNAME}_no_password_two_profiles_no_roles	TCP	Logout	1
-${BASE_USERNAME}_no_password_two_profiles_no_roles	HTTP	LoginSuccess	1
-${BASE_USERNAME}_no_password_two_profiles_no_roles	HTTP	Logout	1
+${BASE_USERNAME}_no_password_two_profiles_no_roles	HTTP	LoginSuccess	many
+${BASE_USERNAME}_no_password_two_profiles_no_roles	HTTP	Logout	many
 ${BASE_USERNAME}_no_password_two_profiles_no_roles	MySQL	LoginSuccess	1
 ${BASE_USERNAME}_no_password_two_profiles_no_roles	MySQL	Logout	1
 ${BASE_USERNAME}_no_password_two_profiles_two_roles	TCP	LoginSuccess	1
 ${BASE_USERNAME}_no_password_two_profiles_two_roles	TCP	Logout	1
-${BASE_USERNAME}_no_password_two_profiles_two_roles	HTTP	LoginSuccess	1
-${BASE_USERNAME}_no_password_two_profiles_two_roles	HTTP	Logout	1
+${BASE_USERNAME}_no_password_two_profiles_two_roles	HTTP	LoginSuccess	many
+${BASE_USERNAME}_no_password_two_profiles_two_roles	HTTP	Logout	many
 ${BASE_USERNAME}_no_password_two_profiles_two_roles	MySQL	LoginSuccess	1
 ${BASE_USERNAME}_no_password_two_profiles_two_roles	MySQL	Logout	1
 ${BASE_USERNAME}_plaintext_password_no_profiles_no_roles	TCP	LoginFailure	1
 ${BASE_USERNAME}_plaintext_password_no_profiles_no_roles	TCP	LoginSuccess	1
 ${BASE_USERNAME}_plaintext_password_no_profiles_no_roles	TCP	Logout	1
-${BASE_USERNAME}_plaintext_password_no_profiles_no_roles	HTTP	LoginFailure	1
-${BASE_USERNAME}_plaintext_password_no_profiles_no_roles	HTTP	LoginSuccess	1
-${BASE_USERNAME}_plaintext_password_no_profiles_no_roles	HTTP	Logout	1
+${BASE_USERNAME}_plaintext_password_no_profiles_no_roles	HTTP	LoginFailure	many
+${BASE_USERNAME}_plaintext_password_no_profiles_no_roles	HTTP	LoginSuccess	many
+${BASE_USERNAME}_plaintext_password_no_profiles_no_roles	HTTP	Logout	many
 ${BASE_USERNAME}_plaintext_password_no_profiles_no_roles	MySQL	LoginFailure	many
 ${BASE_USERNAME}_plaintext_password_no_profiles_no_roles	MySQL	LoginSuccess	1
 ${BASE_USERNAME}_plaintext_password_no_profiles_no_roles	MySQL	Logout	1
+${BASE_USERNAME}_plaintext_password_no_profiles_no_roles	PostgreSQL	LoginFailure	many
 ${BASE_USERNAME}_plaintext_password_two_profiles_no_roles	TCP	LoginFailure	1
 ${BASE_USERNAME}_plaintext_password_two_profiles_no_roles	TCP	LoginSuccess	1
 ${BASE_USERNAME}_plaintext_password_two_profiles_no_roles	TCP	Logout	1
-${BASE_USERNAME}_plaintext_password_two_profiles_no_roles	HTTP	LoginFailure	1
-${BASE_USERNAME}_plaintext_password_two_profiles_no_roles	HTTP	LoginSuccess	1
-${BASE_USERNAME}_plaintext_password_two_profiles_no_roles	HTTP	Logout	1
+${BASE_USERNAME}_plaintext_password_two_profiles_no_roles	HTTP	LoginFailure	many
+${BASE_USERNAME}_plaintext_password_two_profiles_no_roles	HTTP	LoginSuccess	many
+${BASE_USERNAME}_plaintext_password_two_profiles_no_roles	HTTP	Logout	many
 ${BASE_USERNAME}_plaintext_password_two_profiles_no_roles	MySQL	LoginFailure	many
 ${BASE_USERNAME}_plaintext_password_two_profiles_no_roles	MySQL	LoginSuccess	1
 ${BASE_USERNAME}_plaintext_password_two_profiles_no_roles	MySQL	Logout	1
+${BASE_USERNAME}_plaintext_password_two_profiles_no_roles	PostgreSQL	LoginFailure	many
 ${BASE_USERNAME}_plaintext_password_two_profiles_two_roles	TCP	LoginFailure	1
 ${BASE_USERNAME}_plaintext_password_two_profiles_two_roles	TCP	LoginSuccess	1
 ${BASE_USERNAME}_plaintext_password_two_profiles_two_roles	TCP	Logout	1
-${BASE_USERNAME}_plaintext_password_two_profiles_two_roles	HTTP	LoginFailure	1
-${BASE_USERNAME}_plaintext_password_two_profiles_two_roles	HTTP	LoginSuccess	1
-${BASE_USERNAME}_plaintext_password_two_profiles_two_roles	HTTP	Logout	1
+${BASE_USERNAME}_plaintext_password_two_profiles_two_roles	HTTP	LoginFailure	many
+${BASE_USERNAME}_plaintext_password_two_profiles_two_roles	HTTP	LoginSuccess	many
+${BASE_USERNAME}_plaintext_password_two_profiles_two_roles	HTTP	Logout	many
 ${BASE_USERNAME}_plaintext_password_two_profiles_two_roles	MySQL	LoginFailure	many
 ${BASE_USERNAME}_plaintext_password_two_profiles_two_roles	MySQL	LoginSuccess	1
 ${BASE_USERNAME}_plaintext_password_two_profiles_two_roles	MySQL	Logout	1
+${BASE_USERNAME}_plaintext_password_two_profiles_two_roles	PostgreSQL	LoginFailure	many
 ${BASE_USERNAME}_sha256_password_no_profiles_no_roles	TCP	LoginFailure	1
 ${BASE_USERNAME}_sha256_password_no_profiles_no_roles	TCP	LoginSuccess	1
 ${BASE_USERNAME}_sha256_password_no_profiles_no_roles	TCP	Logout	1
-${BASE_USERNAME}_sha256_password_no_profiles_no_roles	HTTP	LoginFailure	1
-${BASE_USERNAME}_sha256_password_no_profiles_no_roles	HTTP	LoginSuccess	1
-${BASE_USERNAME}_sha256_password_no_profiles_no_roles	HTTP	Logout	1
+${BASE_USERNAME}_sha256_password_no_profiles_no_roles	HTTP	LoginFailure	many
+${BASE_USERNAME}_sha256_password_no_profiles_no_roles	HTTP	LoginSuccess	many
+${BASE_USERNAME}_sha256_password_no_profiles_no_roles	HTTP	Logout	many
 ${BASE_USERNAME}_sha256_password_no_profiles_no_roles	MySQL	LoginFailure	many
 ${BASE_USERNAME}_sha256_password_two_profiles_no_roles	TCP	LoginFailure	1
 ${BASE_USERNAME}_sha256_password_two_profiles_no_roles	TCP	LoginSuccess	1
 ${BASE_USERNAME}_sha256_password_two_profiles_no_roles	TCP	Logout	1
-${BASE_USERNAME}_sha256_password_two_profiles_no_roles	HTTP	LoginFailure	1
-${BASE_USERNAME}_sha256_password_two_profiles_no_roles	HTTP	LoginSuccess	1
-${BASE_USERNAME}_sha256_password_two_profiles_no_roles	HTTP	Logout	1
+${BASE_USERNAME}_sha256_password_two_profiles_no_roles	HTTP	LoginFailure	many
+${BASE_USERNAME}_sha256_password_two_profiles_no_roles	HTTP	LoginSuccess	many
+${BASE_USERNAME}_sha256_password_two_profiles_no_roles	HTTP	Logout	many
 ${BASE_USERNAME}_sha256_password_two_profiles_no_roles	MySQL	LoginFailure	many
 ${BASE_USERNAME}_sha256_password_two_profiles_two_roles	TCP	LoginFailure	1
 ${BASE_USERNAME}_sha256_password_two_profiles_two_roles	TCP	LoginSuccess	1
 ${BASE_USERNAME}_sha256_password_two_profiles_two_roles	TCP	Logout	1
-${BASE_USERNAME}_sha256_password_two_profiles_two_roles	HTTP	LoginFailure	1
-${BASE_USERNAME}_sha256_password_two_profiles_two_roles	HTTP	LoginSuccess	1
-${BASE_USERNAME}_sha256_password_two_profiles_two_roles	HTTP	Logout	1
+${BASE_USERNAME}_sha256_password_two_profiles_two_roles	HTTP	LoginFailure	many
+${BASE_USERNAME}_sha256_password_two_profiles_two_roles	HTTP	LoginSuccess	many
+${BASE_USERNAME}_sha256_password_two_profiles_two_roles	HTTP	Logout	many
 ${BASE_USERNAME}_sha256_password_two_profiles_two_roles	MySQL	LoginFailure	many
 invalid_${BASE_USERNAME}_double_sha1_password_no_profiles_no_roles	TCP	LoginFailure	1
-invalid_${BASE_USERNAME}_double_sha1_password_no_profiles_no_roles	HTTP	LoginFailure	1
+invalid_${BASE_USERNAME}_double_sha1_password_no_profiles_no_roles	HTTP	LoginFailure	many
 invalid_${BASE_USERNAME}_double_sha1_password_no_profiles_no_roles	MySQL	LoginFailure	many
 invalid_${BASE_USERNAME}_double_sha1_password_two_profiles_no_roles	TCP	LoginFailure	1
-invalid_${BASE_USERNAME}_double_sha1_password_two_profiles_no_roles	HTTP	LoginFailure	1
+invalid_${BASE_USERNAME}_double_sha1_password_two_profiles_no_roles	HTTP	LoginFailure	many
 invalid_${BASE_USERNAME}_double_sha1_password_two_profiles_no_roles	MySQL	LoginFailure	many
 invalid_${BASE_USERNAME}_double_sha1_password_two_profiles_two_roles	TCP	LoginFailure	1
-invalid_${BASE_USERNAME}_double_sha1_password_two_profiles_two_roles	HTTP	LoginFailure	1
+invalid_${BASE_USERNAME}_double_sha1_password_two_profiles_two_roles	HTTP	LoginFailure	many
 invalid_${BASE_USERNAME}_double_sha1_password_two_profiles_two_roles	MySQL	LoginFailure	many
 invalid_${BASE_USERNAME}_no_password_no_profiles_no_roles	TCP	LoginFailure	1
-invalid_${BASE_USERNAME}_no_password_no_profiles_no_roles	HTTP	LoginFailure	1
+invalid_${BASE_USERNAME}_no_password_no_profiles_no_roles	HTTP	LoginFailure	many
 invalid_${BASE_USERNAME}_no_password_no_profiles_no_roles	MySQL	LoginFailure	many
+invalid_${BASE_USERNAME}_no_password_no_profiles_no_roles	PostgreSQL	LoginFailure	many
 invalid_${BASE_USERNAME}_no_password_two_profiles_no_roles	TCP	LoginFailure	1
-invalid_${BASE_USERNAME}_no_password_two_profiles_no_roles	HTTP	LoginFailure	1
+invalid_${BASE_USERNAME}_no_password_two_profiles_no_roles	HTTP	LoginFailure	many
 invalid_${BASE_USERNAME}_no_password_two_profiles_no_roles	MySQL	LoginFailure	many
+invalid_${BASE_USERNAME}_no_password_two_profiles_no_roles	PostgreSQL	LoginFailure	many
 invalid_${BASE_USERNAME}_no_password_two_profiles_two_roles	TCP	LoginFailure	1
-invalid_${BASE_USERNAME}_no_password_two_profiles_two_roles	HTTP	LoginFailure	1
+invalid_${BASE_USERNAME}_no_password_two_profiles_two_roles	HTTP	LoginFailure	many
 invalid_${BASE_USERNAME}_no_password_two_profiles_two_roles	MySQL	LoginFailure	many
+invalid_${BASE_USERNAME}_no_password_two_profiles_two_roles	PostgreSQL	LoginFailure	many
 invalid_${BASE_USERNAME}_plaintext_password_no_profiles_no_roles	TCP	LoginFailure	1
-invalid_${BASE_USERNAME}_plaintext_password_no_profiles_no_roles	HTTP	LoginFailure	1
+invalid_${BASE_USERNAME}_plaintext_password_no_profiles_no_roles	HTTP	LoginFailure	many
 invalid_${BASE_USERNAME}_plaintext_password_no_profiles_no_roles	MySQL	LoginFailure	many
+invalid_${BASE_USERNAME}_plaintext_password_no_profiles_no_roles	PostgreSQL	LoginFailure	many
 invalid_${BASE_USERNAME}_plaintext_password_two_profiles_no_roles	TCP	LoginFailure	1
-invalid_${BASE_USERNAME}_plaintext_password_two_profiles_no_roles	HTTP	LoginFailure	1
+invalid_${BASE_USERNAME}_plaintext_password_two_profiles_no_roles	HTTP	LoginFailure	many
 invalid_${BASE_USERNAME}_plaintext_password_two_profiles_no_roles	MySQL	LoginFailure	many
+invalid_${BASE_USERNAME}_plaintext_password_two_profiles_no_roles	PostgreSQL	LoginFailure	many
 invalid_${BASE_USERNAME}_plaintext_password_two_profiles_two_roles	TCP	LoginFailure	1
-invalid_${BASE_USERNAME}_plaintext_password_two_profiles_two_roles	HTTP	LoginFailure	1
+invalid_${BASE_USERNAME}_plaintext_password_two_profiles_two_roles	HTTP	LoginFailure	many
 invalid_${BASE_USERNAME}_plaintext_password_two_profiles_two_roles	MySQL	LoginFailure	many
+invalid_${BASE_USERNAME}_plaintext_password_two_profiles_two_roles	PostgreSQL	LoginFailure	many
 invalid_${BASE_USERNAME}_sha256_password_no_profiles_no_roles	TCP	LoginFailure	1
-invalid_${BASE_USERNAME}_sha256_password_no_profiles_no_roles	HTTP	LoginFailure	1
+invalid_${BASE_USERNAME}_sha256_password_no_profiles_no_roles	HTTP	LoginFailure	many
 invalid_${BASE_USERNAME}_sha256_password_no_profiles_no_roles	MySQL	LoginFailure	many
 invalid_${BASE_USERNAME}_sha256_password_two_profiles_no_roles	TCP	LoginFailure	1
-invalid_${BASE_USERNAME}_sha256_password_two_profiles_no_roles	HTTP	LoginFailure	1
+invalid_${BASE_USERNAME}_sha256_password_two_profiles_no_roles	HTTP	LoginFailure	many
 invalid_${BASE_USERNAME}_sha256_password_two_profiles_no_roles	MySQL	LoginFailure	many
 invalid_${BASE_USERNAME}_sha256_password_two_profiles_two_roles	TCP	LoginFailure	1
-invalid_${BASE_USERNAME}_sha256_password_two_profiles_two_roles	HTTP	LoginFailure	1
+invalid_${BASE_USERNAME}_sha256_password_two_profiles_two_roles	HTTP	LoginFailure	many
 invalid_${BASE_USERNAME}_sha256_password_two_profiles_two_roles	MySQL	LoginFailure	many
 invalid_session_log_test_xml_user	TCP	LoginFailure	1
-invalid_session_log_test_xml_user	HTTP	LoginFailure	1
+invalid_session_log_test_xml_user	HTTP	LoginFailure	many
 invalid_session_log_test_xml_user	MySQL	LoginFailure	many
+invalid_session_log_test_xml_user	PostgreSQL	LoginFailure	many
 session_log_test_xml_user	TCP	LoginSuccess	1
 session_log_test_xml_user	TCP	Logout	1
-session_log_test_xml_user	HTTP	LoginSuccess	1
-session_log_test_xml_user	HTTP	Logout	1
+session_log_test_xml_user	HTTP	LoginSuccess	many
+session_log_test_xml_user	HTTP	Logout	many
 session_log_test_xml_user	MySQL	LoginSuccess	1
 session_log_test_xml_user	MySQL	Logout	1


### PR DESCRIPTION
This pull request partially fixes 01747_system_session_log_long test and improves error messages during authentication in postgres.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

**Notes:**

- using system.numbers replaced by `system.one` because of #52638 
- ClickHouse server can't connect to itself using postgreSQL protocol because of  #52639
- I did not found an easy way how to test GRPC handler in *.sh test (I can add integrational test for testing GRPC sessions)
- Changes src/Core/PostgreSQLProtocol.h is not mandatory but desireable. Old exception message were like `{user} not found in {storage}` from `getAuthenticationTypeOrLogInFailure` exception. This change makes error message sent to client with less details: `Invalid user or password` for security.
