### PR TITLE
Add query cache metrics to system.asynchronous_metrics

### DIFF
--- a/docs/en/operations/query-cache.md
+++ b/docs/en/operations/query-cache.md
@@ -61,11 +61,12 @@ use_query_cache = true`) but one should keep in mind that all `SELECT` queries i
 may return cached results then.
 
 The query cache can be cleared using statement `SYSTEM DROP QUERY CACHE`. The content of the query cache is displayed in system table
-`system.query_cache`. The number of query cache hits and misses are shown as events "QueryCacheHits" and "QueryCacheMisses" in system table
-[system.events](system-tables/events.md). Both counters are only updated for `SELECT` queries which run with setting "use_query_cache =
-true". Other queries do not affect the cache miss counter. Field `query_log_usage` in system table
-[system.query_log](system-tables/query_log.md) shows for each ran query whether the query result was written into or read from the query
-cache.
+`system.query_cache`. The number of query cache hits and misses since database start are shown as events "QueryCacheHits" and
+"QueryCacheMisses" in system table [system.events](system-tables/events.md). Both counters are only updated for `SELECT` queries which run
+with setting `use_query_cache = true`, other queries do not affect "QueryCacheMisses". Field `query_log_usage` in system table
+[system.query_log](system-tables/query_log.md) shows for each executed query whether the query result was written into or read from the
+query cache. Asynchronous metrics "QueryCacheEntries" and "QueryCacheBytes" in system table
+[system.asynchronous_metrics](system-tables/asynchronous_metrics.md) show how many entries / bytes the query cache currently contains.
 
 The query cache exists once per ClickHouse server process. However, cache results are by default not shared between users. This can be
 changed (see below) but doing so is not recommended for security reasons.

--- a/docs/en/operations/system-tables/asynchronous_metrics.md
+++ b/docs/en/operations/system-tables/asynchronous_metrics.md
@@ -32,6 +32,10 @@ SELECT * FROM system.asynchronous_metrics LIMIT 10
 └─────────────────────────────────────────┴────────────┴────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
 ```
 
+<!--- Unlike with system.events and system.metrics, the asynchronous metrics are not gathered in a simple list in a source code file - they
+      are mixed with logic in src/Interpreters/ServerAsynchronousMetrics.cpp.
+      Listing them here explicitly for reader convenience. --->
+
 ## Metric descriptions
 
 
@@ -482,6 +486,14 @@ The value is similar to `OSUserTime` but divided to the number of CPU cores to b
 ### PostgreSQLThreads
 
 Number of threads in the server of the PostgreSQL compatibility protocol.
+
+### QueryCacheBytes
+
+Total size of the query cache cache in bytes.
+
+### QueryCacheEntries
+
+Total number of entries in the query cache.
 
 ### ReplicasMaxAbsoluteDelay
 

--- a/docs/en/operations/system-tables/events.md
+++ b/docs/en/operations/system-tables/events.md
@@ -11,6 +11,8 @@ Columns:
 - `value` ([UInt64](../../sql-reference/data-types/int-uint.md)) — Number of events occurred.
 - `description` ([String](../../sql-reference/data-types/string.md)) — Event description.
 
+You can find all supported events in source file [src/Common/ProfileEvents.cpp](https://github.com/ClickHouse/ClickHouse/blob/master/src/Common/ProfileEvents.cpp).
+
 **Example**
 
 ``` sql

--- a/docs/en/operations/system-tables/metrics.md
+++ b/docs/en/operations/system-tables/metrics.md
@@ -11,7 +11,7 @@ Columns:
 - `value` ([Int64](../../sql-reference/data-types/int-uint.md)) — Metric value.
 - `description` ([String](../../sql-reference/data-types/string.md)) — Metric description.
 
-The list of supported metrics you can find in the [src/Common/CurrentMetrics.cpp](https://github.com/ClickHouse/ClickHouse/blob/master/src/Common/CurrentMetrics.cpp) source file of ClickHouse.
+You can find all supported metrics in source file [src/Common/CurrentMetrics.cpp](https://github.com/ClickHouse/ClickHouse/blob/master/src/Common/CurrentMetrics.cpp).
 
 **Example**
 

--- a/src/Interpreters/Cache/QueryCache.cpp
+++ b/src/Interpreters/Cache/QueryCache.cpp
@@ -496,6 +496,16 @@ void QueryCache::reset()
     cache_size_in_bytes = 0;
 }
 
+size_t QueryCache::weight() const
+{
+    return cache.weight();
+}
+
+size_t QueryCache::count() const
+{
+    return cache.count();
+}
+
 size_t QueryCache::recordQueryRun(const Key & key)
 {
     std::lock_guard lock(mutex);

--- a/src/Interpreters/Cache/QueryCache.h
+++ b/src/Interpreters/Cache/QueryCache.h
@@ -186,6 +186,9 @@ public:
 
     void reset();
 
+    size_t weight() const;
+    size_t count() const;
+
     /// Record new execution of query represented by key. Returns number of executions so far.
     size_t recordQueryRun(const Key & key);
 
@@ -193,7 +196,7 @@ public:
     std::vector<QueryCache::Cache::KeyMapped> dump() const;
 
 private:
-    Cache cache;
+    Cache cache; /// has its own locking --> not protected by mutex
 
     mutable std::mutex mutex;
     TimesExecuted times_executed TSA_GUARDED_BY(mutex);

--- a/src/Interpreters/ServerAsynchronousMetrics.cpp
+++ b/src/Interpreters/ServerAsynchronousMetrics.cpp
@@ -92,6 +92,12 @@ void ServerAsynchronousMetrics::updateImpl(AsynchronousMetricValues & new_values
             " The files opened with `mmap` are kept in the cache to avoid costly TLB flushes."};
     }
 
+    if (auto query_cache = getContext()->getQueryCache())
+    {
+        new_values["QueryCacheBytes"] = { query_cache->weight(), "Total size of the query cache in bytes." };
+        new_values["QueryCacheEntries"] = { query_cache->count(), "Total number of entries in the query cache." };
+    }
+
     {
         auto caches = FileCacheFactory::instance().getAll();
         size_t total_bytes = 0;

--- a/utils/check-style/aspell-ignore/en/aspell-dict.txt
+++ b/utils/check-style/aspell-ignore/en/aspell-dict.txt
@@ -211,7 +211,6 @@ Decrypted
 Deduplicate
 Deduplication
 DelayedInserts
-delim
 DeliveryTag
 DeltaLake
 Denormalize
@@ -699,6 +698,8 @@ PyCharm
 QEMU
 QTCreator
 Quantile
+QueryCacheBytes
+QueryCacheEntries
 QueryCacheHits
 QueryCacheMisses
 QueryPreempted
@@ -761,9 +762,9 @@ RoaringBitmap
 RocksDB
 Rollup
 RowBinary
+RowBinaryWithDefaults
 RowBinaryWithNames
 RowBinaryWithNamesAndTypes
-RowBinaryWithDefaults
 Runtime
 SATA
 SELECTs
@@ -776,7 +777,6 @@ SMALLINT
 SPNEGO
 SQEs
 SQLAlchemy
-SquaredDistance
 SQLConsoleDetail
 SQLInsert
 SQLSTATE
@@ -811,6 +811,7 @@ Smirnov'test
 Soundex
 SpanKind
 Spearman's
+SquaredDistance
 StartTLS
 StartTime
 StartupSystemTables
@@ -838,8 +839,6 @@ Subexpression
 Submodules
 Subqueries
 Substrings
-substringIndex
-substringIndexUTF
 SummingMergeTree
 SuperSet
 Superset
@@ -1272,6 +1271,7 @@ cryptographic
 csv
 csvwithnames
 csvwithnamesandtypes
+curdate
 currentDatabase
 currentProfiles
 currentRoles
@@ -1331,6 +1331,7 @@ defaultProfiles
 defaultRoles
 defaultValueOfArgumentType
 defaultValueOfTypeName
+delim
 deltaLake
 deltaSum
 deltaSumTimestamp
@@ -1542,13 +1543,13 @@ hadoop
 halfMD
 halfday
 hardlinks
+hasAll
+hasAny
+hasColumnInTable
 hasSubsequence
 hasSubsequenceCaseInsensitive
 hasSubsequenceCaseInsensitiveUTF
 hasSubsequenceUTF
-hasAll
-hasAny
-hasColumnInTable
 hasSubstr
 hasToken
 hasTokenCaseInsensitive
@@ -1590,10 +1591,10 @@ incrementing
 indexHint
 indexOf
 infi
-initialQueryID
-initializeAggregation
 initcap
 initcapUTF
+initialQueryID
+initializeAggregation
 injective
 innogames
 inodes
@@ -2131,9 +2132,9 @@ routineley
 rowNumberInAllBlocks
 rowNumberInBlock
 rowbinary
+rowbinarywithdefaults
 rowbinarywithnames
 rowbinarywithnamesandtypes
-rowbinarywithdefaults
 rsync
 rsyslog
 runnable
@@ -2185,8 +2186,8 @@ sleepEachRow
 snowflakeToDateTime
 socketcache
 soundex
-sparkbar
 sparkBar
+sparkbar
 sparsehash
 speedscope
 splitByChar
@@ -2256,6 +2257,8 @@ subreddits
 subseconds
 subsequence
 substring
+substringIndex
+substringIndexUTF
 substringUTF
 substrings
 subtitiles
@@ -2556,4 +2559,3 @@ znode
 znodes
 zookeeperSessionUptime
 zstd
-curdate


### PR DESCRIPTION
Cf. https://github.com/ClickHouse/ClickHouse/pull/52384#issuecomment-1653241216 

### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
system.asynchronous_metrics now includes metrics "QueryCacheEntries" and "QueryCacheBytes" to inspect the query cache