### PR TITLE
Update default output_format_arrow_compression.md

### DIFF
--- a/docs/en/operations/settings/settings-formats.md
+++ b/docs/en/operations/settings/settings-formats.md
@@ -1164,7 +1164,7 @@ Enabled by default.
 
 Compression method used in output Arrow format. Supported codecs: `lz4_frame`, `zstd`, `none` (uncompressed)
 
-Default value: `none`.
+Default value: `lz4_frame`.
 
 ## ORC format settings {#orc-format-settings}
 


### PR DESCRIPTION

### Changelog category (leave one):
- Documentation (changelog entry is not required)

Updates the default parameter of output_format_arrow_compression_method from "none" to "lz4_frame".

