### PR TITLE
Improvements to backup restore disallow_concurrency test

### DIFF
--- a/tests/integration/test_backup_restore_on_cluster/test_disallow_concurrency.py
+++ b/tests/integration/test_backup_restore_on_cluster/test_disallow_concurrency.py
@@ -156,7 +156,9 @@ def test_concurrent_backups_on_same_node():
             )
             return
         else:
-            raise Exception("Concurrent backups both passed, when one is expected to fail")
+            raise Exception(
+                "Concurrent backups both passed, when one is expected to fail"
+            )
 
     expected_errors = [
         "Concurrent backups not supported",
@@ -202,7 +204,7 @@ def test_concurrent_backups_on_different_nodes():
     assert status in ["CREATING_BACKUP", "BACKUP_CREATED"]
 
     result, error = nodes[0].query_and_get_answer_with_error(
-            f"BACKUP TABLE tbl ON CLUSTER 'cluster' TO {backup_name}"
+        f"BACKUP TABLE tbl ON CLUSTER 'cluster' TO {backup_name}"
     )
 
     if not error:
@@ -224,7 +226,9 @@ def test_concurrent_backups_on_different_nodes():
             )
             return
         else:
-            raise Exception("Concurrent backups both passed, when one is expected to fail")
+            raise Exception(
+                "Concurrent backups both passed, when one is expected to fail"
+            )
 
     expected_errors = [
         "Concurrent backups not supported",
@@ -291,8 +295,9 @@ def test_concurrent_restores_on_same_node():
             )
             return
         else:
-            raise Exception("Concurrent restores both passed, when one is expected to fail")
-
+            raise Exception(
+                "Concurrent restores both passed, when one is expected to fail"
+            )
 
     expected_errors = [
         "Concurrent restores not supported",
@@ -359,7 +364,9 @@ def test_concurrent_restores_on_different_node():
             )
             return
         else:
-            raise Exception("Concurrent restores both passed, when one is expected to fail")
+            raise Exception(
+                "Concurrent restores both passed, when one is expected to fail"
+            )
 
     expected_errors = [
         "Concurrent restores not supported",

--- a/tests/integration/test_backup_restore_on_cluster/test_disallow_concurrency.py
+++ b/tests/integration/test_backup_restore_on_cluster/test_disallow_concurrency.py
@@ -133,21 +133,31 @@ def test_concurrent_backups_on_same_node():
     )
     assert status in ["CREATING_BACKUP", "BACKUP_CREATED"]
 
-    try:
-        error = nodes[0].query_and_get_error(
-            f"BACKUP TABLE tbl ON CLUSTER 'cluster' TO {backup_name}"
-        )
-    except Exception as e:
+    result, error = nodes[0].query_and_get_answer_with_error(
+        f"BACKUP TABLE tbl ON CLUSTER 'cluster' TO {backup_name}"
+    )
+
+    if not error:
         status = (
             nodes[0]
             .query(f"SELECT status FROM system.backups WHERE id == '{id}'")
             .rstrip("\n")
         )
         # It is possible that the second backup was picked up first, and then the async backup
-        if status == "CREATING_BACKUP" or status == "BACKUP_FAILED":
+        if status == "BACKUP_FAILED":
+            return
+        elif status == "CREATING_BACKUP":
+            assert_eq_with_retry(
+                nodes[0],
+                f"SELECT status FROM system.backups WHERE id = '{id}'",
+                "BACKUP_FAILED",
+                sleep_time=2,
+                retry_count=50,
+            )
             return
         else:
-            raise e
+            raise Exception("Concurrent backups both passed, when one is expected to fail")
+
     expected_errors = [
         "Concurrent backups not supported",
         f"Backup {backup_name} already exists",
@@ -191,20 +201,31 @@ def test_concurrent_backups_on_different_nodes():
     )
     assert status in ["CREATING_BACKUP", "BACKUP_CREATED"]
 
-    try:
-        error = nodes[0].query_and_get_error(
+    result, error = nodes[0].query_and_get_answer_with_error(
             f"BACKUP TABLE tbl ON CLUSTER 'cluster' TO {backup_name}"
-        )
-    except Exception as e:
+    )
+
+    if not error:
         status = (
             nodes[1]
             .query(f"SELECT status FROM system.backups WHERE id == '{id}'")
             .rstrip("\n")
         )
-        if status == "CREATING_BACKUP" or status == "BACKUP_FAILED":
+        # It is possible that the second backup was picked up first, and then the async backup
+        if status == "BACKUP_FAILED":
+            return
+        elif status == "CREATING_BACKUP":
+            assert_eq_with_retry(
+                nodes[1],
+                f"SELECT status FROM system.backups WHERE id = '{id}'",
+                "BACKUP_FAILED",
+                sleep_time=2,
+                retry_count=50,
+            )
             return
         else:
-            raise e
+            raise Exception("Concurrent backups both passed, when one is expected to fail")
+
     expected_errors = [
         "Concurrent backups not supported",
         f"Backup {backup_name} already exists",
@@ -247,20 +268,32 @@ def test_concurrent_restores_on_same_node():
     )
     assert status in ["RESTORING", "RESTORED"]
 
-    try:
-        error = nodes[0].query_and_get_error(
-            f"RESTORE TABLE tbl ON CLUSTER 'cluster' FROM {backup_name}"
-        )
-    except Exception as e:
+    result, error = nodes[0].query_and_get_answer_with_error(
+        f"RESTORE TABLE tbl ON CLUSTER 'cluster' FROM {backup_name}"
+    )
+
+    if not error:
         status = (
             nodes[0]
-            .query(f"SELECT status FROM system.backups WHERE id == '{id}'")
+            .query(f"SELECT status FROM system.backups WHERE id == '{restore_id}'")
             .rstrip("\n")
         )
-        if status == "RESTORING" or status == "RESTORE_FAILED":
+        # It is possible that the second backup was picked up first, and then the async backup
+        if status == "RESTORE_FAILED":
+            return
+        elif status == "RESTORING":
+            assert_eq_with_retry(
+                nodes[0],
+                f"SELECT status FROM system.backups WHERE id == '{restore_id}'",
+                "RESTORE_FAILED",
+                sleep_time=2,
+                retry_count=50,
+            )
             return
         else:
-            raise e
+            raise Exception("Concurrent restores both passed, when one is expected to fail")
+
+
     expected_errors = [
         "Concurrent restores not supported",
         "Cannot restore the table default.tbl because it already contains some data",
@@ -303,20 +336,31 @@ def test_concurrent_restores_on_different_node():
     )
     assert status in ["RESTORING", "RESTORED"]
 
-    try:
-        error = nodes[1].query_and_get_error(
-            f"RESTORE TABLE tbl ON CLUSTER 'cluster' FROM {backup_name}"
-        )
-    except Exception as e:
+    result, error = nodes[1].query_and_get_answer_with_error(
+        f"RESTORE TABLE tbl ON CLUSTER 'cluster' FROM {backup_name}"
+    )
+
+    if not error:
         status = (
             nodes[0]
-            .query(f"SELECT status FROM system.backups WHERE id == '{id}'")
+            .query(f"SELECT status FROM system.backups WHERE id == '{restore_id}'")
             .rstrip("\n")
         )
-        if status == "RESTORING" or status == "RESTORE_FAILED":
+        # It is possible that the second backup was picked up first, and then the async backup
+        if status == "RESTORE_FAILED":
+            return
+        elif status == "RESTORING":
+            assert_eq_with_retry(
+                nodes[0],
+                f"SELECT status FROM system.backups WHERE id == '{restore_id}'",
+                "RESTORE_FAILED",
+                sleep_time=2,
+                retry_count=50,
+            )
             return
         else:
-            raise e
+            raise Exception("Concurrent restores both passed, when one is expected to fail")
+
     expected_errors = [
         "Concurrent restores not supported",
         "Cannot restore the table default.tbl because it already contains some data",


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Follow up to PR #52536. Added more checks when first backup/restore starts after second one and used `query_and_get_answer_with_error`
 

cc @vitlibar 