### PR TITLE
Modify config merging of non-'clickhouse' rooted configs.

### DIFF
--- a/src/Common/Config/ConfigProcessor.h
+++ b/src/Common/Config/ConfigProcessor.h
@@ -144,7 +144,9 @@ private:
 
     void mergeRecursive(XMLDocumentPtr config, Poco::XML::Node * config_root, const Poco::XML::Node * with_root);
 
-    void merge(XMLDocumentPtr config, XMLDocumentPtr with);
+    /// If config root node name is not 'clickhouse' and merging config's root node names doesn't match, bypasses merging and returns false.
+    /// For compatibility root node 'yandex' considered equal to 'clickhouse'.
+    bool merge(XMLDocumentPtr config, XMLDocumentPtr with);
 
     void doIncludesRecursive(
             XMLDocumentPtr config,


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
When merging into non-'clickhouse' rooted configuration, configs with different root node name just bypassed without exception.

Closes #50289
Closes #47485

Rationale:
Sometimes we want to assemble configs which have different than 'clickhouse' root node name - for example UDF configuration. According to logic besides immediate config file, we also traverse directories with '<file_name>.d' and 'conf.d' where merging file resides. Also we want to have the same root node name for merging configs. As a result, if we assemble non-'clickhouse' rooted configuration and 'conf.d' in the same directory contains differently rooted config, next exception will be produced:
```
Processing configuration file 'function.xml'.
Merging configuration file 'conf.d/graphite_rollup.xml'.
2023.07.29 19:25:14.079309 [ 3806116 ] {} <Error> ExternalUserDefinedExecutableFunctionsLoader: Failed to load config file 'function.xml': Poco::Exception. Code: 1000, e.code() = 0, Exception: Failed to merge config with 'conf.d/gr
aphite_rollup.xml': Exception: Root element doesn't have the corresponding root element as the config file. It must be <functions>, Stack trace (when copying this message, always include the lines below):

0. ./build_docker/./src/Common/Config/ConfigProcessor.cpp:0: DB::ConfigProcessor::processConfig(bool*, zkutil::ZooKeeperNodeCache*, std::shared_ptr<Poco::Event> const&) @ 0x00000000157e78d2 in /home/ubuntu/ClickHouse/clickhouse
1. ./build_docker/./contrib/llvm-project/libcxx/include/__memory/shared_ptr.h:701: DB::ConfigProcessor::loadConfig(bool) @ 0x00000000157e7bb4 in /home/ubuntu/ClickHouse/clickhouse
2. ./build_docker/./contrib/llvm-project/libcxx/include/string:1499: DB::ExternalLoaderXMLConfigRepository::load(String const&) @ 0x0000000013be2745 in /home/ubuntu/ClickHouse/clickhouse
3. ./build_docker/./src/Interpreters/ExternalLoader.cpp:284: DB::ExternalLoader::LoadablesConfigReader::readFileInfo(DB::ExternalLoader::LoadablesConfigReader::FileInfo&, DB::IExternalLoaderConfigRepository&, String const&) const @
 0x0000000013bd96b2 in /home/ubuntu/ClickHouse/clickhouse
4. ./build_docker/./src/Interpreters/ExternalLoader.cpp:223: DB::ExternalLoader::LoadablesConfigReader::readRepositories(std::optional<String> const&, std::optional<String> const&) @ 0x0000000013bd58aa in /home/ubuntu/ClickHouse/cl
ickhouse
5. ./build_docker/./contrib/llvm-project/libcxx/include/optional:260: DB::ExternalLoader::LoadablesConfigReader::read(String const&) @ 0x0000000013bcb920 in /home/ubuntu/ClickHouse/clickhouse
6. ./build_docker/./src/Interpreters/ExternalLoader.cpp:1510: DB::ExternalLoader::addConfigRepository(std::unique_ptr<DB::IExternalLoaderConfigRepository, std::default_delete<DB::IExternalLoaderConfigRepository>>) const @ 0x0000000
013bca1a7 in /home/ubuntu/ClickHouse/clickhouse
7. ./build_docker/./src/Interpreters/Context.cpp:2188: DB::Context::loadOrReloadUserDefinedExecutableFunctions(Poco::Util::AbstractConfiguration const&) @ 0x000000001370f353 in /home/ubuntu/ClickHouse/clickhouse
8. ./build_docker/./programs/server/Server.cpp:1812: DB::Server::main(std::vector<String, std::allocator<String>> const&) @ 0x000000000e9487c3 in /home/ubuntu/ClickHouse/clickhouse
9. ./build_docker/./base/poco/Util/src/Application.cpp:0: Poco::Util::Application::run() @ 0x00000000181dea46 in /home/ubuntu/ClickHouse/clickhouse
10. ./build_docker/./programs/server/Server.cpp:396: DB::Server::run() @ 0x000000000e93669e in /home/ubuntu/ClickHouse/clickhouse
11. ./build_docker/./base/poco/Util/src/ServerApplication.cpp:132: Poco::Util::ServerApplication::run(int, char**) @ 0x00000000181f2179 in /home/ubuntu/ClickHouse/clickhouse
12. ./build_docker/./programs/server/Server.cpp:0: mainEntryClickHouseServer(int, char**) @ 0x000000000e93336a in /home/ubuntu/ClickHouse/clickhouse
13. ./build_docker/./programs/main.cpp:0: main @ 0x0000000008f0e50f in /home/ubuntu/ClickHouse/clickhouse
14. ? @ 0x00007f21e4429d90 in ?
15. __libc_start_main @ 0x00007f21e4429e40 in ?
16. _start @ 0x000000000828b3ae in /home/ubuntu/ClickHouse/clickhouse
 (version 23.7.1.2471 (official build))
```
This PR resolves this problem by bypassing all non-'clickhouse' rooted configs for non-'clickhouse' assemblies.
