### PR TITLE
Try to remove more leftovers.

### DIFF
--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -3199,7 +3199,6 @@ class ClickHouseInstance:
     ):
         self.name = name
         self.base_cmd = cluster.base_cmd
-        self.base_dir = base_path
         self.docker_id = cluster.get_instance_docker_id(self.name)
         self.cluster = cluster
         self.hostname = hostname if hostname is not None else self.name
@@ -4193,14 +4192,6 @@ class ClickHouseInstance:
         self.exec_in_container(
             ["bash", "-c", f"sed -i 's/{replace}/{replacement}/g' {path_to_config}"]
         )
-
-    def put_users_config(self, config_path):
-        """Put new config (useful if you cannot put it at the start)"""
-
-        instance_config_dir = p.abspath(p.join(self.path, "configs"))
-        users_d_dir = p.abspath(p.join(instance_config_dir, "users.d"))
-        config_path = p.join(self.base_dir, config_path)
-        shutil.copy(config_path, users_d_dir)
 
     def create_dir(self):
         """Create the instance directory and all the needed files there."""

--- a/tests/integration/test_version_update_after_mutation/configs/force_remove_data_recursively_on_drop.xml
+++ b/tests/integration/test_version_update_after_mutation/configs/force_remove_data_recursively_on_drop.xml
@@ -1,7 +1,0 @@
-<clickhouse>
-    <profiles>
-        <default>
-            <force_remove_data_recursively_on_drop>1</force_remove_data_recursively_on_drop>
-        </default>
-    </profiles>
-</clickhouse>

--- a/tests/integration/test_version_update_after_mutation/test.py
+++ b/tests/integration/test_version_update_after_mutation/test.py
@@ -51,12 +51,6 @@ def start_cluster():
         cluster.shutdown()
 
 
-def restart_node(node):
-    # set force_remove_data_recursively_on_drop (cannot be done before, because the version is too old)
-    node.put_users_config("configs/force_remove_data_recursively_on_drop.xml")
-    node.restart_with_latest_version(signal=9, fix_metadata=True)
-
-
 def test_mutate_and_upgrade(start_cluster):
     for node in [node1, node2]:
         node.query("DROP TABLE IF EXISTS mt")
@@ -73,9 +67,8 @@ def test_mutate_and_upgrade(start_cluster):
 
     node2.query("DETACH TABLE mt")  # stop being leader
     node1.query("DETACH TABLE mt")  # stop being leader
-
-    restart_node(node1)
-    restart_node(node2)
+    node1.restart_with_latest_version(signal=9, fix_metadata=True)
+    node2.restart_with_latest_version(signal=9, fix_metadata=True)
 
     # After hard restart table can be in readonly mode
     exec_query_with_retry(
@@ -131,7 +124,7 @@ def test_upgrade_while_mutation(start_cluster):
     # (We could be in process of creating some system table, which will leave empty directory on restart,
     # so when we start moving system tables from ordinary to atomic db, it will complain about some undeleted files)
     node3.query("SYSTEM FLUSH LOGS")
-    restart_node(node3)
+    node3.restart_with_latest_version(signal=9, fix_metadata=True)
 
     # checks for readonly
     exec_query_with_retry(node3, "OPTIMIZE TABLE mt1", sleep_time=5, retry_count=60)

--- a/tests/integration/test_version_update_after_mutation/test.py
+++ b/tests/integration/test_version_update_after_mutation/test.py
@@ -67,6 +67,8 @@ def test_mutate_and_upgrade(start_cluster):
 
     node2.query("DETACH TABLE mt")  # stop being leader
     node1.query("DETACH TABLE mt")  # stop being leader
+    node1.query("SYSTEM FLUSH LOGS")
+    node2.query("SYSTEM FLUSH LOGS")
     node1.restart_with_latest_version(signal=9, fix_metadata=True)
     node2.restart_with_latest_version(signal=9, fix_metadata=True)
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Attempt to fix #44929 
From https://s3.amazonaws.com/clickhouse-test-reports/0/88cd1851f0e9f6f85795371090c30d44c3762391/integration_tests__release__[4_4].html

```
2023.07.22 23:49:28.660209 [ 142 ] {} <Information> loadMetadata: Moved all tables from system to `.tmp_convert.system.13709156833167399561`
2023.07.22 23:49:28.660253 [ 142 ] {} <Debug> executeQuery: (internal) DROP DATABASE system (stage: Complete)
2023.07.22 23:49:28.660865 [ 142 ] {} <Error> Application: Caught exception while loading metadata: Code: 219. DB::Exception: Cannot drop: filesystem error: in remove: Directory not empty ["/var/lib/clickhouse/data/system/"]. Probably database contain some detached tables or metadata leftovers from Ordinary engine. If you want to remove all data anyway, try to attach database back and drop it again with enabled force_remove_data_recursively_on_drop setting: Exception while trying to convert database system from Ordinary to Atomic. It may be in some intermediate state. You can finish conversion manually by moving the rest tables from system to .tmp_convert.system.13709156833167399561 (using RENAME TABLE) and executing DROP DATABASE system and RENAME DATABASE .tmp_convert.system.13709156833167399561 TO system. (DATABASE_NOT_EMPTY), Stack trace (when copying this message, always include the lines below):
```

![image](https://github.com/ClickHouse/ClickHouse/assets/4092911/991f59e7-8048-4a9b-b704-1f9a95f4beab)

Note:
* reverted #52514 because setting did not apply https://github.com/ClickHouse/ClickHouse/blob/f38a7aeabe83cff19fba7d727081da75c06912c7/src/Interpreters/loadMetadata.cpp#L333
* added `system flush logs` as it was done in #48783

Thanks to @tavplubix 