### PR TITLE
Don't report LOGICAL_ERROR if a file got truncated during read

### DIFF
--- a/src/IO/ParallelReadBuffer.cpp
+++ b/src/IO/ParallelReadBuffer.cpp
@@ -8,7 +8,7 @@ namespace DB
 
 namespace ErrorCodes
 {
-    extern const int LOGICAL_ERROR;
+    extern const int UNEXPECTED_END_OF_FILE;
     extern const int CANNOT_SEEK_THROUGH_FILE;
     extern const int SEEK_POSITION_OUT_OF_BOUND;
 
@@ -260,7 +260,7 @@ void ParallelReadBuffer::readerThreadFunction(ReadWorkerPtr read_worker)
 
         if (!on_progress(r) && r < read_worker->segment.size())
             throw Exception(
-                ErrorCodes::LOGICAL_ERROR,
+                ErrorCodes::UNEXPECTED_END_OF_FILE,
                 "Failed to read all the data from the reader at offset {}, got {}/{} bytes",
                 read_worker->start_offset, r, read_worker->segment.size());
     }


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Report UNEXPECTED_END_OF_FILE instead. This may happen e.g. if you start a `SELECT ... FROM s3(...)`, then, while it's running, update the S3 blob to have smaller size.