### PR TITLE
Try to fix 02352_rwlock

### DIFF
--- a/tests/queries/0_stateless/02352_rwlock.sh
+++ b/tests/queries/0_stateless/02352_rwlock.sh
@@ -12,6 +12,11 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 function wait_query_by_id_started()
 {
+    # As the query we are waiting for is running simultaneously, let's give it a little time to actually start. The
+    # queries are supposed to run for multiple seconds, so sleeping 0.5 seconds is not a big deal, especially when
+    # flushing the logs can take up to 3 to 5 seconds. Basically waiting a bit here we can increase the chance that we
+    # don't have spend precious time on flushing logs.
+    sleep 0.5
     local query_id=$1 && shift
     # wait for query to be started
     while [ "$($CLICKHOUSE_CLIENT "$@" -q "select count() from system.processes where query_id = '$query_id'")" -ne 1 ]; do


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

https://play.clickhouse.com/play?user=play#U0VMRUNUIGNoZWNrX3N0YXJ0X3RpbWUsIHB1bGxfcmVxdWVzdF9udW1iZXIsIGNoZWNrX25hbWUsIHRlc3RfbmFtZSwgdGVzdF9zdGF0dXMsIGNoZWNrX3N0YXR1cywgcmVwb3J0X3VybApGUk9NIGNoZWNrcwpXSEVSRSAxCiAgICBBTkQgdGVzdF9zdGF0dXMgIT0gJ1NLSVBQRUQnCiAgICBBTkQgdGVzdF9zdGF0dXMgIT0gJ09LJwogICAgQU5EIGNoZWNrX3N0YXR1cyAhPSAnc3VjY2VzcycKICAgIEFORCB0ZXN0X25hbWUgPSAnMDIzNTJfcndsb2NrJwpPUkRFUiBCWSBjaGVja19zdGFydF90aW1lIGRlc2MsIGNoZWNrX25hbWUsIHRlc3RfbmFtZQ==


The exception about the table not existing happens in the following way:
1. we issue a long insert query
2. the check for the running insert query takes a lot of time sometimes (couldn't spot any reason though why), e.g. 14 seconds (3-4 secs between queries, 3-5 sec for flushing the metrics log)
3. we issue the `DROP TALBE ...` query
4. checking for the running the `DROP TABLE ...` and insert queries take another 5 seconds, but they succeed as we haven't reached the end of the insert query, only 19 sesconds
5. there is 2-3 seconds between the checks and running the select query, which means the insert query finished, thus the `DROP TABLE ...` query also finished => the table doesn't exist anymore

This PR tries to avoid flushing logs, so checking the running queries hopefully will take much less time.
