### PR TITLE
Try to fix a rare fail in 00612_http_max_query_size

### DIFF
--- a/tests/queries/0_stateless/00612_http_max_query_size.sh
+++ b/tests/queries/0_stateless/00612_http_max_query_size.sh
@@ -36,7 +36,7 @@ def gen_data(q):
 
     pattern = ''' or toString(number) = '{}'\n'''
 
-    for i in range(1, 4 * 1024):
+    for i in range(0, 1024 * 2):
         yield pattern.format(str(i).zfill(1024 - len(pattern) + 2)).encode()
 
 s = requests.Session()


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

It was possible that connection was closed by server (after exception) before all the data was send.
Just tune some limits so that exception should happen in the last 1024 bytes.

https://play.clickhouse.com/play?user=play#ClNFTEVDVCB0ZXN0X2R1cmF0aW9uX21zLCBwdWxsX3JlcXVlc3RfbnVtYmVyLCBjaGVja19zdGFydF90aW1lLCBjaGVja19uYW1lLCB0ZXN0X25hbWUsIHRlc3Rfc3RhdHVzLCBjaGVja19zdGF0dXMsIHJlcG9ydF91cmwKRlJPTSBjaGVja3MKV0hFUkUgMQogICAgQU5EIHB1bGxfcmVxdWVzdF9udW1iZXIgPSAwCiAgICBBTkQgdGVzdF9zdGF0dXMgIT0gJ1NLSVBQRUQnCiAgICBBTkQgdGVzdF9zdGF0dXMgIT0gJ09LJwogICAgQU5EIGNoZWNrX3N0YXR1cyAhPSAnc3VjY2VzcycKICAgIEFORCAodGVzdF9uYW1lIGxpa2UgJyUwMDYxMl9odHRwX21heF9xdWVyeV9zaXplJScpCiAgICAtLUFORCB0ZXN0X2R1cmF0aW9uX21zID4gNjAwMDAwCk9SREVSIEJZIGNoZWNrX3N0YXJ0X3RpbWUgZGVzYywgY2hlY2tfbmFtZSwgdGVzdF9uYW1l