### PR TITLE
Use the same default paths for clickhouse_keeper (symlink) as for clickhouse_keeper (executable)

### DIFF
--- a/programs/keeper/Keeper.cpp
+++ b/programs/keeper/Keeper.cpp
@@ -294,7 +294,7 @@ try
     else if (config().has("keeper_server.snapshot_storage_path"))
         path = std::filesystem::path(config().getString("keeper_server.snapshot_storage_path")).parent_path();
     else
-        path = config().getString("path", KEEPER_DEFAULT_PATH);
+        path = KEEPER_DEFAULT_PATH;
 
     std::filesystem::create_directories(path);
 

--- a/programs/keeper/Keeper.cpp
+++ b/programs/keeper/Keeper.cpp
@@ -294,7 +294,7 @@ try
     else if (config().has("keeper_server.snapshot_storage_path"))
         path = std::filesystem::path(config().getString("keeper_server.snapshot_storage_path")).parent_path();
     else
-        path = std::filesystem::path{KEEPER_DEFAULT_PATH};
+        path = config().getString("path", KEEPER_DEFAULT_PATH);
 
     std::filesystem::create_directories(path);
 
@@ -330,6 +330,7 @@ try
     auto global_context = Context::createGlobal(shared_context.get());
 
     global_context->makeGlobalContext();
+    global_context->setApplicationType(Context::ApplicationType::KEEPER);
     global_context->setPath(path);
     global_context->setRemoteHostFilter(config());
 
@@ -365,7 +366,7 @@ try
     }
 
     /// Initialize keeper RAFT. Do nothing if no keeper_server in config.
-    global_context->initializeKeeperDispatcher(/* start_async = */ true);
+    global_context->initializeKeeperDispatcher(/* start_async = */ false);
     FourLetterCommandFactory::registerCommands(*global_context->getKeeperDispatcher());
 
     auto config_getter = [&] () -> const Poco::Util::AbstractConfiguration &

--- a/programs/keeper/Keeper.cpp
+++ b/programs/keeper/Keeper.cpp
@@ -288,13 +288,27 @@ try
     std::string path;
 
     if (config().has("keeper_server.storage_path"))
+    {
         path = config().getString("keeper_server.storage_path");
+    }
+    else if (std::filesystem::is_directory(std::filesystem::path{config().getString("path", DBMS_DEFAULT_PATH)} / "coordination"))
+    {
+        throw Exception(ErrorCodes::NO_ELEMENTS_IN_CONFIG,
+                        "By default 'keeper.storage_path' could be assigned to {}, but the directory {} already exists. Please specify 'keeper.storage_path' in the keeper configuration explicitly",
+                        KEEPER_DEFAULT_PATH, String{std::filesystem::path{config().getString("path", DBMS_DEFAULT_PATH)} / "coordination"});
+    }
     else if (config().has("keeper_server.log_storage_path"))
+    {
         path = std::filesystem::path(config().getString("keeper_server.log_storage_path")).parent_path();
+    }
     else if (config().has("keeper_server.snapshot_storage_path"))
+    {
         path = std::filesystem::path(config().getString("keeper_server.snapshot_storage_path")).parent_path();
+    }
     else
+    {
         path = KEEPER_DEFAULT_PATH;
+    }
 
     std::filesystem::create_directories(path);
 

--- a/src/Coordination/Standalone/Context.h
+++ b/src/Coordination/Standalone/Context.h
@@ -98,6 +98,14 @@ public:
     std::shared_ptr<FilesystemCacheLog> getFilesystemCacheLog() const;
     std::shared_ptr<FilesystemReadPrefetchesLog> getFilesystemReadPrefetchesLog() const;
 
+    enum class ApplicationType
+    {
+        KEEPER
+    };
+
+    void setApplicationType(ApplicationType) {}
+    ApplicationType getApplicationType() const { return ApplicationType::KEEPER; }
+
     IAsynchronousReader & getThreadPoolReader(FilesystemReaderType type) const;
     std::shared_ptr<AsyncReadCounters> getAsyncReadCounters() const;
     ThreadPool & getThreadPoolWriter() const;


### PR DESCRIPTION
### Changelog category:
- Improvement

### Changelog entry:
Use the same default paths for `clickhouse_keeper` (symlink) as for `clickhouse_keeper` (executable).

Before this PR the default paths were different:
| | clickhouse_keeper (executable) | clickhouse_keeper (symlink) | clickhouse-server |
|---|---|---|---|
| storage_path (default) | /var/lib/clickhouse-keeper | /var/lib/clickhouse-keeper | - |
| state_storage_disk (default) | /var/lib/clickhouse-keeper | /var/lib/clickhouse/coordination | /var/lib/clickhouse/coordination |
| log_storage_path (default) | /var/lib/clickhouse-keeper/logs | /var/lib/clickhouse/coordination/logs | /var/lib/clickhouse/coordination/logs |
| snapshot_storage_path (default) | /var/lib/clickhouse-keeper/snapshots | /var/lib/clickhouse/coordination/snapshots | /var/lib/clickhouse/coordination/snapshots |

After this PR the default paths for `clickhouse_keeper` (executable) and `clickhouse_keeper` (symlink) will be the same:
| | clickhouse_keeper (executable) | clickhouse_keeper (symlink) | clickhouse-server |
|---|---|---|---|
| storage_path (default) | /var/lib/clickhouse-keeper | /var/lib/clickhouse-keeper | - |
| state_storage_disk (default) | /var/lib/clickhouse-keeper | /var/lib/clickhouse-keeper | /var/lib/clickhouse/coordination |
| log_storage_path (default) | /var/lib/clickhouse-keeper/logs | /var/lib/clickhouse-keeper/logs | /var/lib/clickhouse/coordination/logs |
| snapshot_storage_path (default) | /var/lib/clickhouse-keeper/snapshots | /var/lib/clickhouse-keeper/snapshots | /var/lib/clickhouse/coordination/snapshots |

This PR allows to run integration tests with keeper built even without `-DBUILD_STANDALONE_KEEPER=1` 