### PR TITLE
Fix the PR body check for `Reverts #number`

### DIFF
--- a/tests/ci/cancel_and_rerun_workflow_lambda/app.py
+++ b/tests/ci/cancel_and_rerun_workflow_lambda/app.py
@@ -323,7 +323,9 @@ def main(event):
 
     if action == "edited":
         print("PR is edited, check if the body is correct")
-        error, category = check_pr_description(pull_request["body"])
+        error, _ = check_pr_description(
+            pull_request["body"], pull_request["base"]["repo"]["full_name"]
+        )
         if error:
             print(
                 f"The PR's body is wrong, is going to comment it. The error is: {error}"

--- a/tests/ci/lambda_shared_package/lambda_shared/pr.py
+++ b/tests/ci/lambda_shared_package/lambda_shared/pr.py
@@ -101,7 +101,7 @@ LABELS = {
 CATEGORY_TO_LABEL = {c: lb for lb, categories in LABELS.items() for c in categories}
 
 
-def check_pr_description(pr_body: str) -> Tuple[str, str]:
+def check_pr_description(pr_body: str, repo_name: str) -> Tuple[str, str]:
     """The function checks the body to being properly formatted according to
     .github/PULL_REQUEST_TEMPLATE.md, if the first returned string is not empty,
     then there is an error."""
@@ -109,11 +109,7 @@ def check_pr_description(pr_body: str) -> Tuple[str, str]:
     lines = [re.sub(r"\s+", " ", line) for line in lines]
 
     # Check if body contains "Reverts ClickHouse/ClickHouse#36337"
-    if [
-        True
-        for line in lines
-        if re.match(r"\AReverts {GITHUB_REPOSITORY}#[\d]+\Z", line)
-    ]:
+    if [True for line in lines if re.match(rf"\AReverts {repo_name}#[\d]+\Z", line)]:
         return "", LABELS["pr-not-for-changelog"][0]
 
     category = ""

--- a/tests/ci/run_check.py
+++ b/tests/ci/run_check.py
@@ -108,7 +108,7 @@ def main():
     gh = Github(get_best_robot_token(), per_page=100)
     commit = get_commit(gh, pr_info.sha)
 
-    description_error, category = check_pr_description(pr_info.body)
+    description_error, category = check_pr_description(pr_info.body, GITHUB_REPOSITORY)
     pr_labels_to_add = []
     pr_labels_to_remove = []
     if (


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix a long-time broken adjustment for revert PRs, see https://github.com/ClickHouse/ClickHouse/pull/52872