### PR TITLE
Disable more tests for debug.

### DIFF
--- a/tests/queries/0_stateless/00900_long_parquet_load.sh
+++ b/tests/queries/0_stateless/00900_long_parquet_load.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: long, no-fasttest
+# Tags: long, no-fasttest, no-debug
 
 #
 # Load all possible .parquet files found in submodules.

--- a/tests/queries/0_stateless/02352_rwlock.sh
+++ b/tests/queries/0_stateless/02352_rwlock.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: no-parallel, no-fasttest
+# Tags: no-parallel, no-fasttest, no-debug
 # Tag no-parallel -- to avoid running it in parallel, this will avoid possible issues due to high pressure
 
 # Test that ensures that WRITE lock failure notifies READ.


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


![image](https://github.com/ClickHouse/ClickHouse/assets/4092911/f6814469-60ea-4de0-9967-b81b8843c1d7)

`00900_long_parquet_load` is just too slow for debug and timeouts periodically

`02352_rwlock` is based on timeouts. It expects that `DROP` with a timeout of 11 sec should fail before `SELECT` with a timeout of 20 sec. However, in debug build `DROP` can just start 10 sec later than `SELECT`

```
$ zstdless clickhouse-server.log.zst.18 | grep -a 'drop-fjqtftmzgt\|insert-bxvufddkyx' | grep -v "'insert-bxvufddkyx'" | grep -v "PipelineExecutor"
2023.08.01 10:52:11.674491 [ 34975 ] {insert-bxvufddkyx} <Debug> executeQuery: (from [::1]:52222) (comment: 02352_rwlock.sh) INSERT INTO test_5dis02bz_ordinary.data_02352 SELECT sleepEachRow(1) FROM numbers(20) GROUP BY number (stage: Complete)
2023.08.01 10:52:11.675037 [ 34975 ] {insert-bxvufddkyx} <Trace> ContextAccess (default): Access granted: INSERT(key) ON test_5dis02bz_ordinary.data_02352
2023.08.01 10:52:11.679957 [ 34975 ] {insert-bxvufddkyx} <Trace> InterpreterSelectQuery: FetchColumns -> Complete
2023.08.01 10:52:11.715591 [ 33905 ] {insert-bxvufddkyx} <Trace> AggregatingTransform: Aggregating
2023.08.01 10:52:11.715759 [ 33905 ] {insert-bxvufddkyx} <Trace> Aggregator: An entry for key=10848386827378190146 found in cache: sum_of_sizes=20, median_size=20
2023.08.01 10:52:11.715952 [ 33905 ] {insert-bxvufddkyx} <Trace> Aggregator: Aggregation method: key64
2023.08.01 10:52:11.716445 [ 33905 ] {insert-bxvufddkyx} <Trace> AggregatingTransform: Aggregated. 20 to 20 rows (from 160.00 B) in 0.033485978 sec. (597.265 rows/sec., 4.67 KiB/sec.)
2023.08.01 10:52:11.716571 [ 33905 ] {insert-bxvufddkyx} <Trace> Aggregator: Merging aggregated data
2023.08.01 10:52:24.736070 [ 32467 ] {d3d68d7f-5978-465e-9703-4025866ec3e4} <Debug> executeQuery: (from [::1]:33210) (comment: 02352_rwlock.sh) select count() from system.processes where query_id = 'drop-fjqtftmzgt' (stage: Complete)
2023.08.01 10:52:24.743643 [ 34963 ] {drop-fjqtftmzgt} <Debug> executeQuery: (from [::1]:33222) (comment: 02352_rwlock.sh) DROP TABLE test_5dis02bz_ordinary.data_02352 SYNC (stage: Complete)
2023.08.01 10:52:24.744077 [ 34963 ] {drop-fjqtftmzgt} <Trace> ContextAccess (default): Access granted: DROP TABLE ON test_5dis02bz_ordinary.data_02352
2023.08.01 10:52:31.726645 [ 34975 ] {insert-bxvufddkyx} <Debug> executeQuery: Read 20 rows, 160.00 B in 20.053929 sec., 0.9973108012898619 rows/sec., 7.98 B/sec.
2023.08.01 10:52:31.735196 [ 34975 ] {insert-bxvufddkyx} <Debug> MemoryTracker: Peak memory usage (for query): 2.13 MiB.
2023.08.01 10:52:31.735334 [ 34975 ] {insert-bxvufddkyx} <Debug> TCPHandler: Processed in 20.066066563 sec.
2023.08.01 10:52:31.735515 [ 34963 ] {drop-fjqtftmzgt} <Debug> MemoryTracker: Peak memory usage (for query): 2.03 MiB.
2023.08.01 10:52:31.735695 [ 34963 ] {drop-fjqtftmzgt} <Debug> TCPHandler: Processed in 6.99592611 sec.
```