### PR TITLE
Disable upgrade check for 02808_custom_disk_with_user_defined_name

### DIFF
--- a/tests/queries/0_stateless/02808_custom_disk_with_user_defined_name.sh
+++ b/tests/queries/0_stateless/02808_custom_disk_with_user_defined_name.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest
+# Tags: no-fasttest, no-upgrade-check
 
 # set -x
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Compatibility is broken in #52820
See https://s3.amazonaws.com/clickhouse-test-reports/52859/9caef8b4a56e94d684f18318af0928c437ae2b83/upgrade_check__tsan_/run.log
