### PR TITLE
tests: fix possible EADDRINUSE v2

### DIFF
--- a/docker/test/integration/runner/compose/docker_compose_hdfs.yml
+++ b/docker/test/integration/runner/compose/docker_compose_hdfs.yml
@@ -12,3 +12,5 @@ services:
             - type: ${HDFS_FS:-tmpfs}
               source: ${HDFS_LOGS:-}
               target: /usr/local/hadoop/logs
+        sysctls:
+            net.ipv4.ip_local_port_range: '55000 65535'

--- a/docker/test/integration/runner/compose/docker_compose_kafka.yml
+++ b/docker/test/integration/runner/compose/docker_compose_kafka.yml
@@ -31,6 +31,8 @@ services:
       - kafka_zookeeper
     security_opt:
       - label:disable
+    sysctls:
+      net.ipv4.ip_local_port_range: '55000 65535'
 
   schema-registry:
     image: confluentinc/cp-schema-registry:5.2.0

--- a/docker/test/integration/runner/compose/docker_compose_kerberized_hdfs.yml
+++ b/docker/test/integration/runner/compose/docker_compose_kerberized_hdfs.yml
@@ -20,6 +20,8 @@ services:
     depends_on:
       - hdfskerberos
     entrypoint: /etc/bootstrap.sh -d
+    sysctls:
+      net.ipv4.ip_local_port_range: '55000 65535'
 
   hdfskerberos:
     image: clickhouse/kerberos-kdc:${DOCKER_KERBEROS_KDC_TAG:-latest}
@@ -29,3 +31,5 @@ services:
       - ${KERBERIZED_HDFS_DIR}/../../kerberos_image_config.sh:/config.sh
       - /dev/urandom:/dev/random
     expose: [88, 749]
+    sysctls:
+      net.ipv4.ip_local_port_range: '55000 65535'

--- a/docker/test/integration/runner/compose/docker_compose_kerberized_kafka.yml
+++ b/docker/test/integration/runner/compose/docker_compose_kerberized_kafka.yml
@@ -48,6 +48,8 @@ services:
       - kafka_kerberos
     security_opt:
       - label:disable
+    sysctls:
+      net.ipv4.ip_local_port_range: '55000 65535'
 
   kafka_kerberos:
     image: clickhouse/kerberos-kdc:${DOCKER_KERBEROS_KDC_TAG:-latest}

--- a/docker/test/integration/runner/compose/docker_compose_minio.yml
+++ b/docker/test/integration/runner/compose/docker_compose_minio.yml
@@ -14,7 +14,7 @@ services:
       MINIO_ACCESS_KEY: minio
       MINIO_SECRET_KEY: minio123
       MINIO_PROMETHEUS_AUTH_TYPE: public
-    command: server --address :9001 --certs-dir /certs /data1-1
+    command: server --console-address 127.0.0.1:19001 --address :9001 --certs-dir /certs /data1-1
     depends_on:
       - proxy1
       - proxy2

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -17,14 +17,9 @@ def tune_local_port_range():
     # Lots of services uses non privileged ports:
     # - hdfs -- 50020/50070/...
     # - minio
-    # - mysql
-    # - psql
-    #
-    # So instead of tuning all these thirdparty services, let's simply
-    # prohibit using such ports for outgoing connections, this should fix
-    # possible "Address already in use" errors.
     #
     # NOTE: 5K is not enough, and sometimes leads to EADDRNOTAVAIL error.
+    # NOTE: it is not inherited, so you may need to specify this in docker_compose_$SERVICE.yml
     run_and_check(["sysctl net.ipv4.ip_local_port_range='55000 65535'"], shell=True)
 
 


### PR DESCRIPTION
As it turns out, docker does not pass through the sysctls, so `net.ipv4.ip_local_port_range` should be adjusted in `docker_compose_SERVICE.yml` as well.

This has been done for HDFS, but for MinIO it is simpler to fix this by not using dynamic port for console address (Due to how it is written in MinIO it has a race between it allocates the free port and bind to it, and even though this is a problem of MinIO I'm not a go developer to fix it).

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Follow-up for: #52148 (cc @alexey-milovidov )