### PR TITLE
Fix config update in HTTP Header Filtering

### DIFF
--- a/src/Common/HTTPHeaderFilter.cpp
+++ b/src/Common/HTTPHeaderFilter.cpp
@@ -35,7 +35,7 @@ void HTTPHeaderFilter::setValuesFromConfig(const Poco::Util::AbstractConfigurati
 
     forbidden_headers.clear();
     forbidden_headers_regexp.clear();
-    
+
     if (config.has("http_forbid_headers"))
     {
         std::vector<std::string> keys;

--- a/src/Common/HTTPHeaderFilter.cpp
+++ b/src/Common/HTTPHeaderFilter.cpp
@@ -33,6 +33,9 @@ void HTTPHeaderFilter::setValuesFromConfig(const Poco::Util::AbstractConfigurati
 {
     std::lock_guard guard(mutex);
 
+    forbidden_headers.clear();
+    forbidden_headers_regexp.clear();
+    
     if (config.has("http_forbid_headers"))
     {
         std::vector<std::string> keys;
@@ -45,11 +48,6 @@ void HTTPHeaderFilter::setValuesFromConfig(const Poco::Util::AbstractConfigurati
             else if (startsWith(key, "header"))
                 forbidden_headers.insert(config.getString("http_forbid_headers." + key));
         }
-    }
-    else
-    {
-        forbidden_headers.clear();
-        forbidden_headers_regexp.clear();
     }
 }
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
`forbidden_headers` and `forbidden_headers_regexp` vectors were not cleared if `http_forbid_headers` config section was modified.