### PR TITLE
Added peak_memory_usage to clickhouse-client final progress message

### DIFF
--- a/src/Common/ProgressIndication.cpp
+++ b/src/Common/ProgressIndication.cpp
@@ -101,6 +101,10 @@ void ProgressIndication::writeFinalProgress()
                     << formatReadableSizeWithDecimalSuffix(progress.read_bytes * 1000000000.0 / elapsed_ns) << "/s.)";
     else
         std::cout << ". ";
+
+    auto peak_memory_usage = getMemoryUsage().peak;
+    if (peak_memory_usage >= 0)
+        std::cout << "\nPeak memory usage: " << formatReadableSizeWithBinarySuffix(peak_memory_usage) << ".";
 }
 
 void ProgressIndication::writeProgress(WriteBufferFromFileDescriptor & message)

--- a/tests/queries/0_stateless/01921_test_progress_bar.py
+++ b/tests/queries/0_stateless/01921_test_progress_bar.py
@@ -17,3 +17,4 @@ with client(name="client1>", log=log) as client1:
     client1.send("SELECT number FROM numbers(1000) FORMAT Null")
     client1.expect("Progress: 1\.00 thousand rows, 8\.00 KB .*" + end_of_block)
     client1.expect("0 rows in set. Elapsed: [\\w]{1}\.[\\w]{3} sec.")
+    client1.expect("Peak memory usage: .*B" + end_of_block)


### PR DESCRIPTION
Original message from clickhouse-client PR #51946 was reverted in #52598, but then it was decided to restore the change with a small message structure change: https://github.com/ClickHouse/ClickHouse/pull/51946#issuecomment-1654150123

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Client final message example:
```
1 row in set. Elapsed: 7.328 sec. Processed 19.00 billion rows, 152.00 GB (2.59 billion rows/s., 20.74 GB/s.)
Peak memory usage: 9.52 KiB.
```