### PR TITLE
Added  TSAN option report_atomic_races=0 for test_max_sessions_for_user 

### DIFF
--- a/tests/integration/test_profile_max_sessions_for_user/test.py
+++ b/tests/integration/test_profile_max_sessions_for_user/test.py
@@ -51,7 +51,12 @@ instance = cluster.add_instance(
         "configs/server.key",
     ],
     user_configs=["configs/users.xml"],
-    env_variables={"UBSAN_OPTIONS": "print_stacktrace=1"},
+    env_variables={
+        "UBSAN_OPTIONS": "print_stacktrace=1",
+        # Bug in TSAN reproduces in this test https://github.com/grpc/grpc/issues/29550#issuecomment-1188085387
+        "TSAN_OPTIONS": "report_atomic_races=0 "
+        + os.getenv("TSAN_OPTIONS", default=""),
+    },
 )
 
 


### PR DESCRIPTION
GRPC handler produces TSAN warnings: `WARNING: ThreadSanitizer: data race` like [this](https://s3.amazonaws.com/clickhouse-test-reports/52953/8a9ec35c7fe96c64948ee12b3876df291faecefc/integration_tests__tsan__[1_6].html)

I see setting Environment Variable `"TSAN_OPTIONS": "report_atomic_races=0 " + os.getenv("TSAN_OPTIONS", default="") `in other GRPC related tests:
https://github.com/ClickHouse/ClickHouse/blob/c1ca0f35e7688d1a5e479768cd43d81f930243d3/tests/integration/test_grpc_protocol/test.py#L44-L46

https://github.com/ClickHouse/ClickHouse/blob/c1ca0f35e7688d1a5e479768cd43d81f930243d3/tests/integration/test_grpc_protocol_ssl/test.py#L45-L48

`test_max_sessions_for_user `uses GRPC connections also, so it looks like it also needs this TSAN option.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)