### PR TITLE
Decrease a num of tries for a couple of too slow tests for debug.

### DIFF
--- a/tests/queries/0_stateless/00719_parallel_ddl_db.sh
+++ b/tests/queries/0_stateless/00719_parallel_ddl_db.sh
@@ -11,7 +11,7 @@ ${CLICKHOUSE_CLIENT} --query "DROP DATABASE IF EXISTS parallel_ddl"
 
 function query()
 {
-    for _ in {1..100}; do
+    for _ in {1..50}; do
         ${CLICKHOUSE_CLIENT} --query "CREATE DATABASE IF NOT EXISTS parallel_ddl"
         ${CLICKHOUSE_CLIENT} --query "DROP DATABASE IF EXISTS parallel_ddl"
     done

--- a/tests/queries/0_stateless/02450_kill_distributed_query_deadlock.sh
+++ b/tests/queries/0_stateless/02450_kill_distributed_query_deadlock.sh
@@ -7,7 +7,7 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 # Test that running distributed query and cancel it ASAP,
 # this can trigger a hung/deadlock in ProcessorList.
-for i in {1..100}; do
+for i in {1..50}; do
     query_id="$CLICKHOUSE_TEST_UNIQUE_NAME-$i"
     $CLICKHOUSE_CLIENT --format Null --query_id "$query_id" -q "select * from remote('127.{1|2|3|4|5|6}', numbers(1e12))" 2>/dev/null &
     while :; do


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

02450_kill_distributed_query_deadlock, 00719_parallel_ddl_db

not very often, but periodically timeout
![image](https://github.com/ClickHouse/ClickHouse/assets/4092911/8e34acfe-9d4e-4be8-9bb8-6fbac7885ebb)

from https://s3.amazonaws.com/clickhouse-test-reports/52953/8a9ec35c7fe96c64948ee12b3876df291faecefc/stateless_tests__debug__[2_5].html

in both tests was managed to make 90+ iterations for 10 min