### PR TITLE
Fix test `00061_storage_buffer`

### DIFF
--- a/tests/queries/1_stateful/00061_storage_buffer.sql
+++ b/tests/queries/1_stateful/00061_storage_buffer.sql
@@ -2,7 +2,7 @@ DROP TABLE IF EXISTS test.hits_dst;
 DROP TABLE IF EXISTS test.hits_buffer;
 
 CREATE TABLE test.hits_dst AS test.hits;
-CREATE TABLE test.hits_buffer AS test.hits_dst ENGINE = Buffer(test, hits_dst, 8, 1, 10, 10000, 100000, 10000000, 100000000);
+CREATE TABLE test.hits_buffer AS test.hits_dst ENGINE = Buffer(test, hits_dst, 8, 600, 600, 1000000, 1000000, 100000000, 1000000000);
 
 INSERT INTO test.hits_buffer SELECT * FROM test.hits WHERE CounterID = 800784;
 SELECT count() FROM test.hits_buffer;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


See https://s3.amazonaws.com/clickhouse-test-reports/52954/bde87997155abcb3014b67d78bfde0a29905a5ce/stateful_tests__tsan__parallelreplicas_.html

The test was racy due to only a one to ten seconds delay in buffer's flush.