### PR TITLE
Fix `test_zookeeper_config`

### DIFF
--- a/tests/integration/test_zookeeper_config/test.py
+++ b/tests/integration/test_zookeeper_config/test.py
@@ -58,12 +58,7 @@ def test_chroot_with_same_root(started_cluster):
 
     # Replication might take time
 
-    for i in range(100):
-        if node1.query("select count() from simple").strip() == "2":
-            break
-        time.sleep(1)
-    else:
-        assert node1.query("select count() from simple").strip() == "2"
+    assert_eq_with_retry(node1, "select count() from simple", "2\n")
 
     for i in range(100):
         if node2.query("select count() from simple").strip() == "2":

--- a/tests/integration/test_zookeeper_config/test.py
+++ b/tests/integration/test_zookeeper_config/test.py
@@ -56,10 +56,21 @@ def test_chroot_with_same_root(started_cluster):
         for j in range(2):  # Second insert to test deduplication
             node.query("INSERT INTO simple VALUES ({0}, {0})".format(i))
 
-    time.sleep(1)
+    # Replication might take time
 
-    assert node1.query("select count() from simple").strip() == "2"
-    assert node2.query("select count() from simple").strip() == "2"
+    for i in range(100):
+        if node1.query("select count() from simple").strip() == "2":
+            break
+        time.sleep(1)
+    else:
+        assert node1.query("select count() from simple").strip() == "2"
+
+    for i in range(100):
+        if node2.query("select count() from simple").strip() == "2":
+            break
+        time.sleep(1)
+    else:
+        assert node1.query("select count() from simple").strip() == "2"
 
 
 def test_chroot_with_different_root(started_cluster):

--- a/tests/integration/test_zookeeper_config/test.py
+++ b/tests/integration/test_zookeeper_config/test.py
@@ -60,12 +60,7 @@ def test_chroot_with_same_root(started_cluster):
 
     assert_eq_with_retry(node1, "select count() from simple", "2\n")
 
-    for i in range(100):
-        if node2.query("select count() from simple").strip() == "2":
-            break
-        time.sleep(1)
-    else:
-        assert node1.query("select count() from simple").strip() == "2"
+    assert_eq_with_retry(node2, "select count() from simple", "2\n")
 
 
 def test_chroot_with_different_root(started_cluster):

--- a/tests/integration/test_zookeeper_config/test.py
+++ b/tests/integration/test_zookeeper_config/test.py
@@ -2,6 +2,7 @@ import time
 import pytest
 import logging
 from helpers.cluster import ClickHouseCluster
+from helpers.test_tools import assert_eq_with_retry
 
 cluster = ClickHouseCluster(
     __file__, zookeeper_config_path="configs/zookeeper_config_root_a.xml"


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


It was dependent on sleep.