### PR TITLE
More precise Integer type inference, and fix #50582

### DIFF
--- a/src/DataTypes/DataTypesNumber.h
+++ b/src/DataTypes/DataTypesNumber.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <type_traits>
+#include <utility>
 #include <Core/Field.h>
 #include <DataTypes/DataTypeNumberBase.h>
 #include <DataTypes/Serializations/SerializationNumber.h>
@@ -9,10 +10,20 @@
 namespace DB
 {
 
+using DataTypes = std::vector<DataTypePtr>;
+
 template <typename T>
 class DataTypeNumber final : public DataTypeNumberBase<T>
 {
 public:
+    DataTypeNumber() = default;
+
+    explicit DataTypeNumber(DataTypes data_types)
+        : DataTypeNumberBase<T>()
+        , possible_data_types(std::move(data_types))
+    {
+    }
+
     bool equals(const IDataType & rhs) const override { return typeid(rhs) == typeid(*this); }
 
     bool canBeUsedAsVersion() const override { return true; }
@@ -32,6 +43,11 @@ public:
     {
         return std::make_shared<SerializationNumber<T>>();
     }
+
+    DataTypes getPossiblePtr() const override { return possible_data_types; }
+
+private:
+    DataTypes possible_data_types;
 };
 
 using DataTypeUInt8 = DataTypeNumber<UInt8>;

--- a/src/DataTypes/FieldToDataType.cpp
+++ b/src/DataTypes/FieldToDataType.cpp
@@ -33,18 +33,34 @@ DataTypePtr FieldToDataType<on_error>::operator() (const Null &) const
 template <LeastSupertypeOnError on_error>
 DataTypePtr FieldToDataType<on_error>::operator() (const UInt64 & x) const
 {
+    if (x <= std::numeric_limits<Int8>::max()) return std::make_shared<DataTypeUInt8>(DataTypes{ std::make_shared<DataTypeInt8>() });
     if (x <= std::numeric_limits<UInt8>::max()) return std::make_shared<DataTypeUInt8>();
+    if (x <= std::numeric_limits<Int16>::max()) return std::make_shared<DataTypeUInt16>(DataTypes{ std::make_shared<DataTypeInt16>() });
     if (x <= std::numeric_limits<UInt16>::max()) return std::make_shared<DataTypeUInt16>();
+    if (x <= std::numeric_limits<Int32>::max()) return std::make_shared<DataTypeUInt32>(DataTypes{ std::make_shared<DataTypeInt32>() });
     if (x <= std::numeric_limits<UInt32>::max()) return std::make_shared<DataTypeUInt32>();
+    if (x <= std::numeric_limits<Int64>::max()) return std::make_shared<DataTypeUInt64>(DataTypes{ std::make_shared<DataTypeInt64>() });
     return std::make_shared<DataTypeUInt64>();
 }
 
 template <LeastSupertypeOnError on_error>
 DataTypePtr FieldToDataType<on_error>::operator() (const Int64 & x) const
 {
-    if (x <= std::numeric_limits<Int8>::max() && x >= std::numeric_limits<Int8>::min()) return std::make_shared<DataTypeInt8>();
-    if (x <= std::numeric_limits<Int16>::max() && x >= std::numeric_limits<Int16>::min()) return std::make_shared<DataTypeInt16>();
-    if (x <= std::numeric_limits<Int32>::max() && x >= std::numeric_limits<Int32>::min()) return std::make_shared<DataTypeInt32>();
+    if (x >= 0)
+    {
+        if (x <= std::numeric_limits<Int8>::max()) return std::make_shared<DataTypeInt8>();
+        if (x <= std::numeric_limits<UInt8>::max()) return std::make_shared<DataTypeInt16>(DataTypes{ std::make_shared<DataTypeUInt8>() });
+        if (x <= std::numeric_limits<Int16>::max()) return std::make_shared<DataTypeInt16>();
+        if (x <= std::numeric_limits<UInt16>::max()) return std::make_shared<DataTypeInt32>(DataTypes{ std::make_shared<DataTypeUInt16>() });
+        if (x <= std::numeric_limits<Int32>::max()) return std::make_shared<DataTypeInt32>();
+        if (x <= std::numeric_limits<UInt32>::max()) return std::make_shared<DataTypeInt64>(DataTypes{ std::make_shared<DataTypeUInt32>() });
+    }
+    else
+    {
+        if (x >= std::numeric_limits<Int8>::min()) return std::make_shared<DataTypeInt8>();
+        if (x >= std::numeric_limits<Int16>::min()) return std::make_shared<DataTypeInt16>();
+        if (x >= std::numeric_limits<Int32>::min()) return std::make_shared<DataTypeInt32>();
+    }
     return std::make_shared<DataTypeInt64>();
 }
 

--- a/src/DataTypes/IDataType.h
+++ b/src/DataTypes/IDataType.h
@@ -73,6 +73,8 @@ public:
 
     DataTypePtr getPtr() const { return shared_from_this(); }
 
+    virtual DataTypes getPossiblePtr() const { return { shared_from_this() }; }
+
     /// Name of data type family (example: FixedString, Array).
     virtual const char * getFamilyName() const = 0;
     /// Name of corresponding data type in MySQL (exampe: Bigint, Blob, etc)

--- a/src/DataTypes/getLeastSupertype.h
+++ b/src/DataTypes/getLeastSupertype.h
@@ -29,6 +29,8 @@ DataTypePtr tryGetLeastSupertype(const DataTypes & types);
 
 using TypeIndexSet = std::unordered_set<TypeIndex>;
 
+void optimizeTypeIds(const DataTypes & types, TypeIndexSet & type_ids);
+
 template <LeastSupertypeOnError on_error = LeastSupertypeOnError::Throw>
 DataTypePtr getLeastSupertype(const TypeIndexSet & types);
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
More precise Integer type inference, fix #50582


### Documentation entry for user-facing changes

ClickHouse will be able to recognize whether an Int is unsigned, signed, or both, which means that an Int will have multiple possible types. This will make the getLeastSupertype function more accurate.
Example :
select  [-4741124612489978151, -3236599669630092879, 5607475129431807682]
'-4741124612489978151' is Int64, '-3236599669630092879' is Int64, '5607475129431807682' is UInt64 or Int64.
So, their least supertype is Int64

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
