### PR TITLE
Do not use inline cache in server images

### DIFF
--- a/tests/ci/docker_server.py
+++ b/tests/ci/docker_server.py
@@ -238,7 +238,7 @@ def build_and_push_image(
     result = []  # type: TestResults
     if os != "ubuntu":
         tag += f"-{os}"
-    init_args = ["docker", "buildx", "build", "--build-arg BUILDKIT_INLINE_CACHE=1"]
+    init_args = ["docker", "buildx", "build"]
     if push:
         init_args.append("--push")
         init_args.append("--output=type=image,push-by-digest=true")


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Packing inline cache into docker images sometimes causes strange special effects. Since we don't use it at all, it's good to go.