### PR TITLE
Fix cache related logical error in stress tests

### DIFF
--- a/src/Interpreters/Cache/FileSegment.cpp
+++ b/src/Interpreters/Cache/FileSegment.cpp
@@ -186,9 +186,7 @@ bool FileSegment::isDownloaded() const
 
 String FileSegment::getCallerId()
 {
-    if (!CurrentThread::isInitialized()
-        || !CurrentThread::get().getQueryContext()
-        || CurrentThread::getQueryId().empty())
+    if (!CurrentThread::isInitialized() || CurrentThread::getQueryId().empty())
         return "None:" + toString(getThreadId());
 
     return std::string(CurrentThread::getQueryId()) + ":" + toString(getThreadId());


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Fixes logical error "Operation completePartAndResetDownloader can be done only by downloader".
Closes https://github.com/ClickHouse/ClickHouse/issues/53009.

The error happens because query context expires after query received and error, but `MergeTreeMarkLoader` was still active because it was asynchronously started and was not destroyed before query context expires, but cache was checking for `CurrentThread::getQueryContext() != nullptr`:
```
2023.08.03 15:42:38.458269 [ 2501 ] {85955690-c5dd-4e15-a182-8a8b7ddb4248} <Debug> executeQuery: (from [::1]:45546) (comment: 01018_ddl_dictionaries_concurrent_requrests.sh) SELECT * FROM database_for_dict.dict1 FORMAT Null; (stage: Complete)
2023.08.03 15:42:38.879561 [ 2501 ] {85955690-c5dd-4e15-a182-8a8b7ddb4248} <Error> executeQuery: Code: 36. DB::Exception: external dictionary '9eb3cbff-87f8-44df-b8b1-e4c630182ead' not found. (BAD_ARGUMENTS) (version 23.8.1.1) (from [::1]:45546) (comment: 01018_ddl_dictionaries_concurrent_requrests.sh) (in query: SELECT * FROM database_for_dict.dict1 FORMAT Null;), Stack trace (when copying this message, always include the lines below):
2023.08.03 15:42:38.886933 [ 2501 ] {85955690-c5dd-4e15-a182-8a8b7ddb4248} <Error> TCPHandler: Code: 36. DB::Exception: external dictionary '9eb3cbff-87f8-44df-b8b1-e4c630182ead' not found. (BAD_ARGUMENTS), Stack trace (when copying this message, always include the lines below):
2023.08.03 15:42:38.887530 [ 2501 ] {85955690-c5dd-4e15-a182-8a8b7ddb4248} <Debug> TCPHandler: Processed in 0.438897431 sec.
2023.08.03 15:42:39.226399 [ 2327 ] {85955690-c5dd-4e15-a182-8a8b7ddb4248} <Fatal> : Logical error: 'Operation `completePartAndResetDownloader` can be done only by downloader. (CallerId: None:2327, downloader id: 85955690-c5dd-4e15-a182-8a8b7ddb4248:2327)'.

```