### PR TITLE
Fix rare race condition with empty key prefix directory deletion in fs cache

### DIFF
--- a/src/Interpreters/Cache/Metadata.cpp
+++ b/src/Interpreters/Cache/Metadata.cpp
@@ -62,11 +62,13 @@ KeyMetadata::KeyMetadata(
     CleanupQueue & cleanup_queue_,
     DownloadQueue & download_queue_,
     Poco::Logger * log_,
+    std::shared_mutex & key_prefix_directory_mutex_,
     bool created_base_directory_)
     : key(key_)
     , key_path(key_path_)
     , cleanup_queue(cleanup_queue_)
     , download_queue(download_queue_)
+    , key_prefix_directory_mutex(key_prefix_directory_mutex_)
     , created_base_directory(created_base_directory_)
     , log(log_)
 {
@@ -102,16 +104,21 @@ bool KeyMetadata::createBaseDirectory()
     {
         try
         {
+            std::shared_lock lock(key_prefix_directory_mutex);
             fs::create_directories(key_path);
         }
-        catch (...)
+        catch (const fs::filesystem_error & e)
         {
-            /// Avoid errors like
-            /// std::__1::__fs::filesystem::filesystem_error: filesystem error: in create_directories: No space left on device
-            /// and mark file segment with SKIP_CACHE state
-            tryLogCurrentException(__PRETTY_FUNCTION__);
             created_base_directory = false;
-            return false;
+
+            if (e.code() == std::errc::no_space_on_device)
+            {
+                LOG_TRACE(log, "Failed to create base directory for key {}, "
+                          "because no space left on device", key);
+
+                return false;
+            }
+            throw;
         }
     }
     return true;
@@ -200,7 +207,7 @@ LockedKeyPtr CacheMetadata::lockKeyMetadata(
 
             it = emplace(
                 key, std::make_shared<KeyMetadata>(
-                    key, getPathForKey(key), *cleanup_queue, *download_queue, log, is_initial_load)).first;
+                    key, getPathForKey(key), *cleanup_queue, *download_queue, log, key_prefix_directory_mutex, is_initial_load)).first;
         }
 
         key_metadata = it->second;
@@ -315,16 +322,9 @@ void CacheMetadata::doCleanup()
 
         try
         {
+            std::unique_lock mutex(key_prefix_directory_mutex);
             if (fs::exists(key_prefix_directory) && fs::is_empty(key_prefix_directory))
                 fs::remove(key_prefix_directory);
-        }
-        catch (const fs::filesystem_error & e)
-        {
-            /// Key prefix directory can become non-empty just now, it is expected.
-            if (e.code() == std::errc::directory_not_empty)
-                continue;
-            LOG_ERROR(log, "Error while removing key {}: {}", cleanup_key, getCurrentExceptionMessage(true));
-            chassert(false);
         }
         catch (...)
         {

--- a/src/Interpreters/Cache/Metadata.h
+++ b/src/Interpreters/Cache/Metadata.h
@@ -5,6 +5,7 @@
 #include <Interpreters/Cache/FileCacheKey.h>
 #include <Interpreters/Cache/FileSegment.h>
 #include <Interpreters/Cache/FileCache_fwd_internal.h>
+#include <shared_mutex>
 
 namespace DB
 {
@@ -50,6 +51,7 @@ struct KeyMetadata : public std::map<size_t, FileSegmentMetadataPtr>,
         CleanupQueue & cleanup_queue_,
         DownloadQueue & download_queue_,
         Poco::Logger * log_,
+        std::shared_mutex & key_prefix_directory_mutex_,
         bool created_base_directory_ = false);
 
     enum class KeyState
@@ -76,6 +78,7 @@ private:
     KeyGuard guard;
     CleanupQueue & cleanup_queue;
     DownloadQueue & download_queue;
+    std::shared_mutex & key_prefix_directory_mutex;
     std::atomic<bool> created_base_directory = false;
     Poco::Logger * log;
 };
@@ -128,6 +131,7 @@ private:
     mutable CacheMetadataGuard guard;
     const CleanupQueuePtr cleanup_queue;
     const DownloadQueuePtr download_queue;
+    std::shared_mutex key_prefix_directory_mutex;
     Poco::Logger * log;
 
     void downloadImpl(FileSegment & file_segment, std::optional<Memory<>> & memory);


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix very rare race condition with empty key prefix directory deletion in fs cache

Could result in
```
2023.08.03 21:59:26.770943 [ 1956 ] {7219cd11-02fc-4e20-aee6-7c818d86f3d8} <Error> bool DB::KeyMetadata::createBaseDirectory(): std::exception. Code: 1001, type: std::__1::__fs::filesystem::filesystem_error, e.what() = filesystem error: in create_directories: No such file or directory ["/var/lib/clickhouse/caches/s3_cache/ec2/ec2a23be34c7c10f0483fb4e853cd3fb"], Stack trace (when copying this message, always include the lines below):

```