### PR TITLE
Fix test `02434_cancel_insert_when_client_dies`

### DIFF
--- a/tests/queries/0_stateless/02434_cancel_insert_when_client_dies.sh
+++ b/tests/queries/0_stateless/02434_cancel_insert_when_client_dies.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: no-random-settings
+# Tags: no-random-settings, no-asan, no-msan, no-tsan, no-debug
 # shellcheck disable=SC2009
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


| check_start_time | check_name | test_name | report_url |
|-:|:-|:-|:-|
| 2023-06-02 08:32:14 | Stateless tests (msan) [6/6] | 02434_cancel_insert_when_client_dies | https://s3.amazonaws.com/clickhouse-test-reports/0/54144d15ab06b916b1948edcdbe0963b72a2fa23/stateless_tests__msan__[6_6].html |
| 2023-06-17 14:54:24 | Stateless tests (tsan) [3/5] | 02434_cancel_insert_when_client_dies | https://s3.amazonaws.com/clickhouse-test-reports/0/b11e148fa89667ff62f5e0df6882c5cd2c221cf7/stateless_tests__tsan__[3_5].html |
| 2023-06-17 17:20:11 | Stateless tests (tsan) [3/5] | 02434_cancel_insert_when_client_dies | https://s3.amazonaws.com/clickhouse-test-reports/0/e8ca174d68b517d5c30ba92bcbbbea3deb6b6760/stateless_tests__tsan__[3_5].html |
| 2023-06-19 13:07:22 | Stateless tests (tsan) [3/5] | 02434_cancel_insert_when_client_dies | https://s3.amazonaws.com/clickhouse-test-reports/0/86ca7eb4c2f27da3400680379a60c8214e113bbf/stateless_tests__tsan__[3_5].html |
| 2023-07-20 09:30:36 | Stateless tests (msan) [6/6] | 02434_cancel_insert_when_client_dies | https://s3.amazonaws.com/clickhouse-test-reports/0/f115e0fbe52177947fe5d081c65e9189c9b14782/stateless_tests__msan__[6_6].html |

