### PR TITLE
Fix 02263_format_insert_settings flakiness

### DIFF
--- a/tests/queries/0_stateless/02263_format_insert_settings.reference
+++ b/tests/queries/0_stateless/02263_format_insert_settings.reference
@@ -1,6 +1,6 @@
-insert into foo settings max_threads=1
+[multi] insert into foo settings max_threads=1
 Syntax error (query): failed at position 40 (end of query):
-insert into foo format tsv settings max_threads=1
+[multi] insert into foo format tsv settings max_threads=1
 Can't format ASTInsertQuery with data, since data will be lost.
 [multi] insert into foo format tsv settings max_threads=1
 INSERT INTO foo
@@ -8,7 +8,7 @@ SETTINGS max_threads = 1
 FORMAT tsv
 [oneline] insert into foo format tsv settings max_threads=1
 INSERT INTO foo SETTINGS max_threads = 1 FORMAT tsv
-insert into foo settings max_threads=1 format tsv settings max_threads=1
+[multi] insert into foo settings max_threads=1 format tsv settings max_threads=1
 You have SETTINGS before and after FORMAT
 Cannot parse input: expected '\n' before: 'settings max_threads=1 1'
 1

--- a/tests/queries/0_stateless/02263_format_insert_settings.sh
+++ b/tests/queries/0_stateless/02263_format_insert_settings.sh
@@ -8,7 +8,7 @@ function run_format()
 {
     local q="$1" && shift
 
-    echo "$q"
+    echo "[multi] $q"
     $CLICKHOUSE_FORMAT "$@" <<<"$q"
 }
 function run_format_both()
@@ -22,20 +22,20 @@ function run_format_both()
 }
 
 # NOTE: that those queries may work slow, due to stack trace obtaining
-run_format 'insert into foo settings max_threads=1' 2> >(grep -m1 -o "Syntax error (query): failed at position .* (end of query):")
+run_format 'insert into foo settings max_threads=1' |& grep --max-count 2 --only-matching -e "Syntax error (query): failed at position .* (end of query):" -e '^\[.*$'
 
 # compatibility
-run_format 'insert into foo format tsv settings max_threads=1' 2> >(grep -m1 -F -o "Can't format ASTInsertQuery with data, since data will be lost.")
+run_format 'insert into foo format tsv settings max_threads=1' |& grep --max-count 2 --only-matching -e "Can't format ASTInsertQuery with data, since data will be lost." -e '^\[.*$'
 run_format_both 'insert into foo format tsv settings max_threads=1' --allow_settings_after_format_in_insert
-run_format 'insert into foo settings max_threads=1 format tsv settings max_threads=1' --allow_settings_after_format_in_insert 2> >(grep -m1 -F -o "You have SETTINGS before and after FORMAT")
+run_format 'insert into foo settings max_threads=1 format tsv settings max_threads=1' --allow_settings_after_format_in_insert |& grep --max-count 2 --only-matching -e "You have SETTINGS before and after FORMAT" -e '^\[.*$'
 
 # and via server (since this is a separate code path)
 $CLICKHOUSE_CLIENT -q 'drop table if exists data_02263'
 $CLICKHOUSE_CLIENT -q 'create table data_02263 (key Int) engine=Memory()'
-$CLICKHOUSE_CLIENT -q 'insert into data_02263 format TSV settings max_threads=1 1' 2> >(grep -m1 -F -o "Cannot parse input: expected '\n' before: 'settings max_threads=1 1'")
+$CLICKHOUSE_CLIENT -q 'insert into data_02263 format TSV settings max_threads=1 1' |& grep --max-count 1 -F --only-matching "Cannot parse input: expected '\n' before: 'settings max_threads=1 1'"
 $CLICKHOUSE_CLIENT --allow_settings_after_format_in_insert=1 -q 'insert into data_02263 format TSV settings max_threads=1 1'
 $CLICKHOUSE_CLIENT -q 'select * from data_02263'
-$CLICKHOUSE_CLIENT --allow_settings_after_format_in_insert=1 -q 'insert into data_02263 settings max_threads=1 format tsv settings max_threads=1' 2> >(grep -m1 -F -o "You have SETTINGS before and after FORMAT")
+$CLICKHOUSE_CLIENT --allow_settings_after_format_in_insert=1 -q 'insert into data_02263 settings max_threads=1 format tsv settings max_threads=1' |& grep --max-count 1 -F --only-matching "You have SETTINGS before and after FORMAT"
 $CLICKHOUSE_CLIENT -q 'drop table data_02263'
 
 run_format_both 'insert into foo values'


### PR DESCRIPTION
I guess the problem was with the async nature of the process substitution ("2> >(cmd)"), let's avoid using this feature of bash.

CI: https://s3.amazonaws.com/clickhouse-test-reports/52683/b98cb7fa145d1a92c2c78421be1eeb8fe8353d53/stateless_tests__aarch64_.html

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Cc: @alexey-milovidov 