### PR TITLE
Relax flaky test `test_s3_engine_heavy_write_check_mem`

### DIFF
--- a/tests/integration/test_merge_tree_s3/test.py
+++ b/tests/integration/test_merge_tree_s3/test.py
@@ -892,7 +892,7 @@ def test_s3_engine_heavy_write_check_mem(
     assert int(memory_usage) < 1.2 * memory
     assert int(memory_usage) > 0.8 * memory
 
-    assert int(wait_inflight) > 10 * 1000 * 1000
+    assert int(wait_inflight) > in_flight * 1000 * 1000
 
     check_no_objects_after_drop(cluster, node_name=node_name)
 

--- a/tests/integration/test_merge_tree_s3/test.py
+++ b/tests/integration/test_merge_tree_s3/test.py
@@ -855,6 +855,11 @@ def test_s3_engine_heavy_write_check_mem(
     memory = in_flight_memory[1]
 
     node = cluster.instances[node_name]
+
+    # it's bad idea to test something related to memory with sanitizers
+    if node.is_built_with_sanitizer():
+        pytest.skip("Disabled for sanitizers")
+
     node.query("DROP TABLE IF EXISTS s3_test SYNC")
     node.query(
         "CREATE TABLE s3_test"


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

