### PR TITLE
Update PocoHTTPClient.cpp

### DIFF
--- a/src/IO/S3/PocoHTTPClient.cpp
+++ b/src/IO/S3/PocoHTTPClient.cpp
@@ -536,7 +536,10 @@ void PocoHTTPClient::makeRequestInternalImpl(
     }
     catch (...)
     {
-        tryLogCurrentException(log, fmt::format("Failed to make request to: {}", uri));
+        auto error_message = getCurrentExceptionMessageAndPattern(/* with_stacktrace */ true);
+        error_message.text = fmt::format("Failed to make request to: {}: {}", uri, error_message.text);
+        LOG_INFO(log, error_message);
+
         response->SetClientErrorType(Aws::Client::CoreErrors::NETWORK_CONNECTION);
         response->SetClientErrorMessage(getCurrentExceptionMessage(false));
 


### PR DESCRIPTION

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Change severity from `Error` to `Info` because usually we have retries, and it's not an error. Many different tests fail because of this:
https://s3.amazonaws.com/clickhouse-test-reports/53052/35083d90463f111c5f335050a38ae07b68dc3dbd/stateless_tests__release__s3_storage__[2_2].html
https://s3.amazonaws.com/clickhouse-test-reports/52971/7da85cc0de3e3a2b63ccae5639231ddb31f0fe31/stateless_tests__debug__s3_storage__[5_6].html
https://s3.amazonaws.com/clickhouse-test-reports/52555/d83eabcf772d942c18c8d8b2dccb43aaad1bf235/stateless_tests__release__s3_storage__[2_2].html
https://s3.amazonaws.com/clickhouse-test-reports/52495/6321ae41a069cf65ffbe14e214676f9013ad315e/stateless_tests__release__s3_storage__[2_2].html
https://s3.amazonaws.com/clickhouse-test-reports/51958/83e767920f2e85b50219a4027dd5d2a3283d881d/stateless_tests__debug__s3_storage__[2_6].html