### PR TITLE
Revert changes in `ZstdDeflatingAppendableWriteBuffer`

### DIFF
--- a/src/IO/ZstdDeflatingAppendableWriteBuffer.h
+++ b/src/IO/ZstdDeflatingAppendableWriteBuffer.h
@@ -52,8 +52,6 @@ private:
     /// NOTE: will fill compressed data to the out.working_buffer, but will not call out.next method until the buffer is full
     void nextImpl() override;
 
-    void flush(ZSTD_EndDirective mode);
-
     /// Write terminating ZSTD_e_end: empty block + frame epilogue. BTW it
     /// should be almost noop, because frame epilogue contains only checksums,
     /// and they are disabled for this buffer.


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Revert changes in https://github.com/ClickHouse/ClickHouse/pull/53064
Breaks Keeper compressed logs https://github.com/ClickHouse/ClickHouse/pull/53090#issuecomment-1667527071

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
