### PR TITLE
Update `Mergeable Check` at the finishing CI

### DIFF
--- a/tests/ci/finish_check.py
+++ b/tests/ci/finish_check.py
@@ -8,6 +8,7 @@ from commit_status_helper import (
     get_commit,
     get_commit_filtered_statuses,
     post_commit_status,
+    update_mergeable_check,
 )
 from get_robot_token import get_best_robot_token
 from pr_info import PRInfo
@@ -18,6 +19,8 @@ def main():
 
     pr_info = PRInfo(need_orgs=True)
     gh = Github(get_best_robot_token(), per_page=100)
+    # Update the Mergeable Check at the final step
+    update_mergeable_check(gh, pr_info, CI_STATUS_NAME)
     commit = get_commit(gh, pr_info.sha)
 
     statuses = [
@@ -27,7 +30,8 @@ def main():
     ]
     if not statuses:
         return
-    status = statuses[0]
+    # Take the latest status
+    status = statuses[-1]
     if status.state == "pending":
         post_commit_status(
             commit,


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
