### PR TITLE
Ditch tons of garbage

### DIFF
--- a/base/base/JSON.cpp
+++ b/base/base/JSON.cpp
@@ -7,8 +7,6 @@
 #include <base/find_symbols.h>
 #include <base/preciseExp10.h>
 
-#include <iostream>
-
 #define JSON_MAX_DEPTH 100
 
 

--- a/base/base/wide_integer_impl.h
+++ b/base/base/wide_integer_impl.h
@@ -12,7 +12,6 @@
 #include <tuple>
 #include <limits>
 
-#include <boost/multiprecision/cpp_bin_float.hpp>
 #include <boost/math/special_functions/fpclassify.hpp>
 
 // NOLINTBEGIN(*)

--- a/base/base/wide_integer_impl.h
+++ b/base/base/wide_integer_impl.h
@@ -21,6 +21,7 @@
 #define CONSTEXPR_FROM_DOUBLE constexpr
 using FromDoubleIntermediateType = long double;
 #else
+#include <boost/multiprecision/cpp_bin_float.hpp>
 /// `wide_integer_from_builtin` can't be constexpr with non-literal `cpp_bin_float_double_extended`
 #define CONSTEXPR_FROM_DOUBLE
 using FromDoubleIntermediateType = boost::multiprecision::cpp_bin_float_double_extended;

--- a/base/poco/Data/ODBC/src/Unicode_UNIXODBC.cpp
+++ b/base/poco/Data/ODBC/src/Unicode_UNIXODBC.cpp
@@ -19,7 +19,6 @@
 #include "Poco/UTF16Encoding.h"
 #include "Poco/Buffer.h"
 #include "Poco/Exception.h"
-#include <iostream>
 
 
 using Poco::Buffer;

--- a/base/poco/Foundation/src/Task.cpp
+++ b/base/poco/Foundation/src/Task.cpp
@@ -16,7 +16,6 @@
 #include "Poco/TaskManager.h"
 #include "Poco/Exception.h"
 
-#include <iostream>
 #include <array>
 
 

--- a/base/poco/JSON/src/Object.cpp
+++ b/base/poco/JSON/src/Object.cpp
@@ -14,7 +14,6 @@
 
 #include "Poco/JSON/Object.h"
 #include <iostream>
-#include <sstream>
 
 
 using Poco::Dynamic::Var;

--- a/base/poco/Net/src/HTTPClientSession.cpp
+++ b/base/poco/Net/src/HTTPClientSession.cpp
@@ -26,7 +26,6 @@
 #include "Poco/CountingStream.h"
 #include "Poco/RegularExpression.h"
 #include <sstream>
-#include <iostream>
 
 
 using Poco::NumberFormatter;

--- a/programs/disks/ICommand.cpp
+++ b/programs/disks/ICommand.cpp
@@ -1,4 +1,6 @@
 #include "ICommand.h"
+#include <iostream>
+
 
 namespace DB
 {

--- a/src/Access/MemoryAccessStorage.h
+++ b/src/Access/MemoryAccessStorage.h
@@ -6,6 +6,7 @@
 #include <memory>
 #include <mutex>
 #include <unordered_map>
+#include <boost/container/flat_set.hpp>
 
 
 namespace DB

--- a/src/AggregateFunctions/tests/gtest_ranks.cpp
+++ b/src/AggregateFunctions/tests/gtest_ranks.cpp
@@ -2,7 +2,6 @@
 #include <IO/ReadBufferFromString.h>
 #include <Common/PODArray.h>
 #include <AggregateFunctions/StatCommon.h>
-#include <iostream>
 
 #include <gtest/gtest.h>
 

--- a/src/Analyzer/Passes/FuseFunctionsPass.cpp
+++ b/src/Analyzer/Passes/FuseFunctionsPass.cpp
@@ -14,6 +14,9 @@
 #include <Analyzer/FunctionNode.h>
 #include <Analyzer/HashUtils.h>
 
+#include <numeric>
+
+
 namespace DB
 {
 

--- a/src/Analyzer/examples/query_analyzer.cpp
+++ b/src/Analyzer/examples/query_analyzer.cpp
@@ -1,4 +1,3 @@
-#include <iostream>
 
 int main(int argc, char ** argv)
 {

--- a/src/Client/ConnectionParameters.cpp
+++ b/src/Client/ConnectionParameters.cpp
@@ -1,6 +1,5 @@
 #include "ConnectionParameters.h"
 #include <fstream>
-#include <iostream>
 #include <Core/Defines.h>
 #include <Core/Protocol.h>
 #include <Core/Types.h>

--- a/src/Client/ConnectionString.cpp
+++ b/src/Client/ConnectionString.cpp
@@ -6,7 +6,6 @@
 #include <Poco/URI.h>
 
 #include <array>
-#include <iostream>
 #include <string>
 #include <unordered_map>
 

--- a/src/Columns/ColumnObject.cpp
+++ b/src/Columns/ColumnObject.cpp
@@ -2,17 +2,17 @@
 #include <Columns/ColumnObject.h>
 #include <Columns/ColumnsNumber.h>
 #include <Columns/ColumnArray.h>
-#include <Columns/ColumnSparse.h>
 #include <DataTypes/ObjectUtils.h>
 #include <DataTypes/getLeastSupertype.h>
 #include <DataTypes/DataTypeNothing.h>
 #include <DataTypes/DataTypeNullable.h>
 #include <DataTypes/DataTypeFactory.h>
-#include <DataTypes/NestedUtils.h>
 #include <Interpreters/castColumn.h>
 #include <Interpreters/convertFieldToType.h>
 #include <Common/HashTable/HashSet.h>
 #include <Processors/Transforms/ColumnGathererTransform.h>
+#include <numeric>
+
 
 namespace DB
 {

--- a/src/Columns/tests/gtest_column_sparse.cpp
+++ b/src/Columns/tests/gtest_column_sparse.cpp
@@ -10,6 +10,7 @@
 
 #include <Common/FieldVisitors.h>
 
+
 using namespace DB;
 static pcg64 rng(randomSeed());
 

--- a/src/Common/Config/configReadClient.cpp
+++ b/src/Common/Config/configReadClient.cpp
@@ -3,7 +3,6 @@
 #include <Poco/Util/LayeredConfiguration.h>
 #include "ConfigProcessor.h"
 #include <filesystem>
-#include <iostream>
 #include <base/types.h>
 
 namespace fs = std::filesystem;

--- a/src/Common/CounterInFile.h
+++ b/src/Common/CounterInFile.h
@@ -4,7 +4,6 @@
 #include <sys/file.h>
 
 #include <string>
-#include <iostream>
 #include <mutex>
 #include <filesystem>
 

--- a/src/Common/DateLUTImpl.cpp
+++ b/src/Common/DateLUTImpl.cpp
@@ -10,7 +10,6 @@
 #include <chrono>
 #include <cstring>
 #include <memory>
-#include <iostream>
 
 
 /// Embedded timezones.

--- a/src/Common/EventNotifier.h
+++ b/src/Common/EventNotifier.h
@@ -7,10 +7,10 @@
 #include <map>
 #include <memory>
 #include <utility>
-#include <iostream>
 
 #include <base/types.h>
 #include <Common/HashTable/Hash.h>
+
 
 namespace DB
 {

--- a/src/Common/FST.cpp
+++ b/src/Common/FST.cpp
@@ -1,7 +1,6 @@
 #include "FST.h"
 #include <algorithm>
 #include <cassert>
-#include <iostream>
 #include <memory>
 #include <vector>
 #include <Common/Exception.h>

--- a/src/Common/SpaceSaving.h
+++ b/src/Common/SpaceSaving.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <iostream>
 #include <vector>
 
 #include <boost/range/adaptor/reversed.hpp>
@@ -18,6 +17,7 @@
 #include <IO/ReadBuffer.h>
 #include <IO/ReadHelpers.h>
 #include <IO/VarInt.h>
+
 
 /*
  * Implementation of the Filtered Space-Saving for TopK streaming analysis.

--- a/src/Common/StudentTTest.cpp
+++ b/src/Common/StudentTTest.cpp
@@ -1,7 +1,6 @@
 #include "StudentTTest.h"
 
 #include <cmath>
-#include <iostream>
 #include <iomanip>
 #include <sstream>
 #include <stdexcept>

--- a/src/Common/ThreadPool.cpp
+++ b/src/Common/ThreadPool.cpp
@@ -6,7 +6,6 @@
 #include <Common/noexcept_scope.h>
 
 #include <cassert>
-#include <iostream>
 #include <type_traits>
 
 #include <Poco/Util/Application.h>

--- a/src/Common/UnicodeBar.cpp
+++ b/src/Common/UnicodeBar.cpp
@@ -7,7 +7,6 @@
 #include <Common/UnicodeBar.h>
 #include <Common/NaNUtils.h>
 
-#include <iostream>
 
 namespace DB
 {

--- a/src/Common/VersionNumber.h
+++ b/src/Common/VersionNumber.h
@@ -2,8 +2,8 @@
 
 #include <string>
 #include <vector>
-#include <iostream>
 #include <base/types.h>
+
 
 namespace DB
 {
@@ -26,11 +26,6 @@ struct VersionNumber
     auto operator<=>(const VersionNumber & rhs) const { return compare(rhs); }
 
     std::string toString() const;
-
-    friend std::ostream & operator<<(std::ostream & os, const VersionNumber & v)
-    {
-        return os << v.toString();
-    }
 
 private:
     using Components = std::vector<Int64>;

--- a/src/Common/benchmarks/integer_hash_tables_and_hashes.cpp
+++ b/src/Common/benchmarks/integer_hash_tables_and_hashes.cpp
@@ -1,7 +1,6 @@
 #include <benchmark/benchmark.h>
 
 #include <iomanip>
-#include <iostream>
 #include <random>
 #include <vector>
 

--- a/src/Common/examples/average.cpp
+++ b/src/Common/examples/average.cpp
@@ -1,4 +1,3 @@
-#include <iostream>
 #include <string>
 #include <bit>
 

--- a/src/Common/examples/chaos_sanitizer.cpp
+++ b/src/Common/examples/chaos_sanitizer.cpp
@@ -6,7 +6,6 @@
 
 #include <IO/ReadHelpers.h>
 
-#include <Common/Exception.h>
 #include <Common/ThreadFuzzer.h>
 
 

--- a/src/Common/examples/compact_array.cpp
+++ b/src/Common/examples/compact_array.cpp
@@ -4,10 +4,10 @@
 #include <filesystem>
 #include <string>
 #include <iostream>
-#include <fstream>
 #include <stdexcept>
 #include <cstdlib>
 #include <unistd.h>
+
 
 namespace fs = std::filesystem;
 

--- a/src/Common/tests/gtest_hash_table.cpp
+++ b/src/Common/tests/gtest_hash_table.cpp
@@ -1,5 +1,5 @@
 #include <iomanip>
-#include <iostream>
+#include <numeric>
 
 #include <Interpreters/AggregationCommon.h>
 

--- a/src/Common/tests/gtest_lru_cache.cpp
+++ b/src/Common/tests/gtest_lru_cache.cpp
@@ -1,5 +1,4 @@
 #include <iomanip>
-#include <iostream>
 #include <gtest/gtest.h>
 #include <Common/CacheBase.h>
 

--- a/src/Common/tests/gtest_lru_hash_map.cpp
+++ b/src/Common/tests/gtest_lru_hash_map.cpp
@@ -1,5 +1,4 @@
 #include <iomanip>
-#include <iostream>
 
 #include <Common/HashTable/LRUHashMap.h>
 

--- a/src/Common/tests/gtest_lru_resource_cache.cpp
+++ b/src/Common/tests/gtest_lru_resource_cache.cpp
@@ -1,5 +1,4 @@
 #include <iomanip>
-#include <iostream>
 #include <gtest/gtest.h>
 #include <Common/LRUResourceCache.h>
 

--- a/src/Common/tests/gtest_slru_cache.cpp
+++ b/src/Common/tests/gtest_slru_cache.cpp
@@ -1,5 +1,4 @@
 #include <iomanip>
-#include <iostream>
 #include <gtest/gtest.h>
 #include <Common/CacheBase.h>
 

--- a/src/Common/tests/gtest_thread_pool_limit.cpp
+++ b/src/Common/tests/gtest_thread_pool_limit.cpp
@@ -1,5 +1,4 @@
 #include <atomic>
-#include <iostream>
 #include <Common/ThreadPool.h>
 #include <Common/CurrentMetrics.h>
 

--- a/src/Common/tests/gtest_thread_pool_loop.cpp
+++ b/src/Common/tests/gtest_thread_pool_loop.cpp
@@ -1,5 +1,4 @@
 #include <atomic>
-#include <iostream>
 #include <Common/ThreadPool.h>
 #include <Common/CurrentMetrics.h>
 

--- a/src/Common/tests/gtest_thread_pool_schedule_exception.cpp
+++ b/src/Common/tests/gtest_thread_pool_schedule_exception.cpp
@@ -1,4 +1,3 @@
-#include <iostream>
 #include <stdexcept>
 #include <Common/ThreadPool.h>
 #include <Common/CurrentMetrics.h>

--- a/src/Compression/CompressionCodecDeflateQpl.cpp
+++ b/src/Compression/CompressionCodecDeflateQpl.cpp
@@ -1,15 +1,17 @@
 #ifdef ENABLE_QPL_COMPRESSION
+
 #include <cstdio>
 #include <thread>
 #include <Compression/CompressionCodecDeflateQpl.h>
 #include <Compression/CompressionFactory.h>
 #include <Compression/CompressionInfo.h>
-#include <Parsers/ASTIdentifier.h>
 #include <Poco/Logger.h>
 #include <Common/logger_useful.h>
 #include "libaccel_config.h"
 #include <Common/MemorySanitizer.h>
 #include <base/scope_guard.h>
+#include <immintrin.h>
+
 
 namespace DB
 {

--- a/src/Compression/fuzzers/compressed_buffer_fuzzer.cpp
+++ b/src/Compression/fuzzers/compressed_buffer_fuzzer.cpp
@@ -1,4 +1,3 @@
-#include <iostream>
 #include <IO/ReadBufferFromMemory.h>
 #include <Compression/CompressedReadBuffer.h>
 #include <Common/Exception.h>

--- a/src/Compression/fuzzers/delta_decompress_fuzzer.cpp
+++ b/src/Compression/fuzzers/delta_decompress_fuzzer.cpp
@@ -1,4 +1,3 @@
-#include <iostream>
 #include <string>
 
 #include <Compression/ICompressionCodec.h>

--- a/src/Compression/fuzzers/double_delta_decompress_fuzzer.cpp
+++ b/src/Compression/fuzzers/double_delta_decompress_fuzzer.cpp
@@ -1,4 +1,3 @@
-#include <iostream>
 #include <string>
 
 #include <Compression/ICompressionCodec.h>

--- a/src/Compression/fuzzers/encrypted_decompress_fuzzer.cpp
+++ b/src/Compression/fuzzers/encrypted_decompress_fuzzer.cpp
@@ -1,6 +1,5 @@
 #include <cstddef>
 #include <cstdint>
-#include <iostream>
 #include <memory>
 #include <string>
 

--- a/src/Compression/fuzzers/lz4_decompress_fuzzer.cpp
+++ b/src/Compression/fuzzers/lz4_decompress_fuzzer.cpp
@@ -1,4 +1,3 @@
-#include <iostream>
 #include <string>
 
 #include <Compression/ICompressionCodec.h>

--- a/src/Coordination/SnapshotableHashTable.h
+++ b/src/Coordination/SnapshotableHashTable.h
@@ -6,7 +6,7 @@
 #include <unordered_map>
 #include <list>
 #include <atomic>
-#include <iostream>
+
 
 namespace DB
 {

--- a/src/Coordination/SummingStateMachine.cpp
+++ b/src/Coordination/SummingStateMachine.cpp
@@ -1,5 +1,4 @@
 #include <Coordination/SummingStateMachine.h>
-#include <iostream>
 #include <cstring>
 
 namespace DB

--- a/src/Coordination/pathUtils.cpp
+++ b/src/Coordination/pathUtils.cpp
@@ -1,5 +1,4 @@
 #include <Coordination/pathUtils.h>
-#include <iostream>
 
 namespace DB
 {

--- a/src/Core/MySQL/MySQLCharset.cpp
+++ b/src/Core/MySQL/MySQLCharset.cpp
@@ -1,6 +1,5 @@
 #include "MySQLCharset.h"
 #include "config.h"
-#include <iostream>
 #include <Common/Exception.h>
 
 #if USE_ICU

--- a/src/Core/fuzzers/names_and_types_fuzzer.cpp
+++ b/src/Core/fuzzers/names_and_types_fuzzer.cpp
@@ -1,4 +1,3 @@
-#include <iostream>
 #include <Core/NamesAndTypes.h>
 #include <IO/ReadBufferFromMemory.h>
 

--- a/src/Daemon/BaseDaemon.h
+++ b/src/Daemon/BaseDaemon.h
@@ -2,7 +2,6 @@
 
 #include <sys/types.h>
 #include <unistd.h>
-#include <iostream>
 #include <memory>
 #include <functional>
 #include <optional>

--- a/src/Daemon/SentryWriter.cpp
+++ b/src/Daemon/SentryWriter.cpp
@@ -3,7 +3,6 @@
 #include <Poco/Util/Application.h>
 #include <Poco/Util/LayeredConfiguration.h>
 
-#include <base/defines.h>
 #include <base/getFQDNOrHostName.h>
 #include <base/getMemoryAmount.h>
 #include <Common/logger_useful.h>
@@ -13,7 +12,6 @@
 #include <Common/StackTrace.h>
 #include <Common/getNumberOfPhysicalCPUCores.h>
 #include <Core/ServerUUID.h>
-#include <base/hex.h>
 
 #include "config.h"
 #include "config_version.h"

--- a/src/Dictionaries/HashedDictionary.cpp
+++ b/src/Dictionaries/HashedDictionary.cpp
@@ -25,6 +25,7 @@
 #include <Dictionaries/HierarchyDictionariesUtils.h>
 #include <Dictionaries/HashedDictionaryCollectionTraits.h>
 
+
 namespace CurrentMetrics
 {
     extern const Metric HashedDictionaryThreads;

--- a/src/Dictionaries/PolygonDictionaryUtils.h
+++ b/src/Dictionaries/PolygonDictionaryUtils.h
@@ -13,6 +13,7 @@
 
 #include <numeric>
 
+
 namespace DB
 {
 

--- a/src/Disks/IO/ReadBufferFromRemoteFSGather.cpp
+++ b/src/Disks/IO/ReadBufferFromRemoteFSGather.cpp
@@ -2,7 +2,6 @@
 
 #include <IO/SeekableReadBuffer.h>
 
-#include <iostream>
 #include <Disks/IO/CachedOnDiskReadBufferFromFile.h>
 #include <Disks/ObjectStorages/Cached/CachedObjectStorage.h>
 #include <IO/ReadSettings.h>

--- a/src/Functions/array/arrayShuffle.cpp
+++ b/src/Functions/array/arrayShuffle.cpp
@@ -16,6 +16,7 @@
 #include <algorithm>
 #include <numeric>
 
+
 namespace DB
 {
 

--- a/src/Functions/evalMLMethod.cpp
+++ b/src/Functions/evalMLMethod.cpp
@@ -5,7 +5,6 @@
 #include <Columns/ColumnAggregateFunction.h>
 #include <Common/typeid_cast.h>
 
-#include <iostream>
 
 #include <Common/PODArray.h>
 

--- a/src/Functions/keyvaluepair/impl/StateHandler.h
+++ b/src/Functions/keyvaluepair/impl/StateHandler.h
@@ -2,7 +2,6 @@
 
 #include <string_view>
 
-#include <iostream>
 
 namespace DB
 {

--- a/src/Functions/translate.cpp
+++ b/src/Functions/translate.cpp
@@ -6,6 +6,8 @@
 #include <Common/StringUtils/StringUtils.h>
 #include <Common/UTF8Helpers.h>
 #include <Common/HashTable/HashMap.h>
+#include <numeric>
+
 
 namespace DB
 {

--- a/src/IO/Archives/LibArchiveReader.h
+++ b/src/IO/Archives/LibArchiveReader.h
@@ -4,7 +4,6 @@
 
 #include <IO/Archives/IArchiveReader.h>
 
-#include <iostream>
 
 namespace DB
 {

--- a/src/IO/HTTPCommon.h
+++ b/src/IO/HTTPCommon.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <iostream>
 #include <memory>
 #include <mutex>
 

--- a/src/IO/ReadBufferFromIStream.h
+++ b/src/IO/ReadBufferFromIStream.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <iostream>
-
 #include <IO/ReadBuffer.h>
 #include <IO/BufferWithOwnMemory.h>
 

--- a/src/IO/S3/SessionAwareIOStream.h
+++ b/src/IO/S3/SessionAwareIOStream.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <iostream>
+#include <iosfwd>
 
 
 namespace DB::S3

--- a/src/IO/StdStreamFromReadBuffer.h
+++ b/src/IO/StdStreamFromReadBuffer.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <IO/StdStreamBufFromReadBuffer.h>
-#include <iostream>
 #include <memory>
 
 

--- a/src/IO/VarInt.h
+++ b/src/IO/VarInt.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <iostream>
 #include <base/types.h>
 #include <base/defines.h>
 #include <IO/ReadBuffer.h>

--- a/src/IO/WriteBuffer.h
+++ b/src/IO/WriteBuffer.h
@@ -2,7 +2,6 @@
 
 #include <algorithm>
 #include <memory>
-#include <iostream>
 #include <cassert>
 #include <cstring>
 

--- a/src/IO/WriteBufferFromOStream.h
+++ b/src/IO/WriteBufferFromOStream.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <iostream>
+#include <iosfwd>
 
 #include <IO/WriteBuffer.h>
 #include <IO/BufferWithOwnMemory.h>

--- a/src/IO/examples/read_buffer_from_hdfs.cpp
+++ b/src/IO/examples/read_buffer_from_hdfs.cpp
@@ -1,4 +1,3 @@
-#include <iostream>
 #include <memory>
 #include <string>
 #include <IO/WriteBufferFromFile.h>

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -2,14 +2,10 @@
 #include <set>
 #include <optional>
 #include <memory>
-#include <Poco/Mutex.h>
 #include <Poco/UUID.h>
-#include <Poco/Net/IPAddress.h>
 #include <Poco/Util/Application.h>
 #include <Common/Macros.h>
-#include <Common/escapeForFileName.h>
 #include <Common/EventNotifier.h>
-#include <Common/setThreadName.h>
 #include <Common/Stopwatch.h>
 #include <Common/formatReadable.h>
 #include <Common/Throttler.h>
@@ -17,12 +13,10 @@
 #include <Common/FieldVisitorToString.h>
 #include <Common/getMultipleKeysFromConfig.h>
 #include <Coordination/KeeperDispatcher.h>
-#include <Compression/ICompressionCodec.h>
 #include <Core/BackgroundSchedulePool.h>
 #include <Formats/FormatFactory.h>
 #include <Databases/IDatabase.h>
 #include <Server/ServerType.h>
-#include <Storages/IStorage.h>
 #include <Storages/MarkCache.h>
 #include <Storages/MergeTree/MergeList.h>
 #include <Storages/MergeTree/MovesList.h>
@@ -34,8 +28,6 @@
 #include <Disks/DiskLocal.h>
 #include <Disks/ObjectStorages/DiskObjectStorage.h>
 #include <Disks/ObjectStorages/IObjectStorage.h>
-#include <Disks/IO/ThreadPoolRemoteFSReader.h>
-#include <Disks/IO/ThreadPoolReader.h>
 #include <Disks/StoragePolicy.h>
 #include <IO/SynchronousReader.h>
 #include <TableFunctions/TableFunctionFactory.h>
@@ -44,7 +36,6 @@
 #include <Interpreters/TemporaryDataOnDisk.h>
 #include <Interpreters/Cache/QueryCache.h>
 #include <Interpreters/Cache/FileCacheFactory.h>
-#include <Interpreters/Cache/FileCache.h>
 #include <Interpreters/SessionTracker.h>
 #include <Core/ServerSettings.h>
 #include <Interpreters/PreparedSets.h>
@@ -56,7 +47,6 @@
 #include <Access/EnabledRowPolicies.h>
 #include <Access/QuotaUsage.h>
 #include <Access/User.h>
-#include <Access/Credentials.h>
 #include <Access/SettingsProfile.h>
 #include <Access/SettingsProfilesInfo.h>
 #include <Access/SettingsConstraintsAndProfileIDs.h>
@@ -70,7 +60,6 @@
 #include <Functions/UserDefined/ExternalUserDefinedExecutableFunctionsLoader.h>
 #include <Functions/UserDefined/IUserDefinedSQLObjectsLoader.h>
 #include <Functions/UserDefined/createUserDefinedSQLObjectsLoader.h>
-#include <Interpreters/ExpressionActions.h>
 #include <Interpreters/ProcessList.h>
 #include <Interpreters/InterserverCredentials.h>
 #include <Interpreters/Cluster.h>
@@ -87,8 +76,6 @@
 #include <IO/MMappedFileCache.h>
 #include <IO/WriteSettings.h>
 #include <Parsers/ASTCreateQuery.h>
-#include <Parsers/ParserCreateQuery.h>
-#include <Parsers/parseQuery.h>
 #include <Parsers/ASTAsterisk.h>
 #include <Parsers/ASTIdentifier.h>
 #include <Common/StackTrace.h>
@@ -98,14 +85,12 @@
 #include <Common/ZooKeeper/ZooKeeper.h>
 #include <Common/ShellCommand.h>
 #include <Common/logger_useful.h>
-#include <base/EnumReflection.h>
 #include <Common/RemoteHostFilter.h>
 #include <Common/HTTPHeaderFilter.h>
 #include <Interpreters/AsynchronousInsertQueue.h>
 #include <Interpreters/DatabaseCatalog.h>
 #include <Interpreters/JIT/CompiledExpressionCache.h>
 #include <Storages/MergeTree/BackgroundJobsAssignee.h>
-#include <Storages/MergeTree/MergeTreeBackgroundExecutor.h>
 #include <Storages/MergeTree/MergeTreeDataPartUUID.h>
 #include <Storages/MergeTree/MergeTreeMetadataCache.h>
 #include <Interpreters/SynonymsExtensions.h>
@@ -118,12 +103,8 @@
 #include <Parsers/ASTFunction.h>
 #include <Parsers/FunctionParameterValuesVisitor.h>
 #include <Parsers/ASTSelectWithUnionQuery.h>
-#include <base/find_symbols.h>
 #include <Interpreters/InterpreterSelectWithUnionQuery.h>
 
-#if USE_ROCKSDB
-#include <rocksdb/table.h>
-#endif
 
 namespace fs = std::filesystem;
 

--- a/src/Interpreters/GraceHashJoin.cpp
+++ b/src/Interpreters/GraceHashJoin.cpp
@@ -1,15 +1,11 @@
 #include <Interpreters/GraceHashJoin.h>
 #include <Interpreters/HashJoin.h>
 #include <Interpreters/TableJoin.h>
-#include <Interpreters/Context.h>
 
 #include <Formats/NativeWriter.h>
 #include <Interpreters/TemporaryDataOnDisk.h>
 
 #include <Compression/CompressedWriteBuffer.h>
-#include <Core/ProtocolDefines.h>
-#include <Disks/IVolume.h>
-#include <Disks/TemporaryFileOnDisk.h>
 #include <Common/logger_useful.h>
 #include <Common/thread_local_rng.h>
 
@@ -17,6 +13,9 @@
 #include <fmt/format.h>
 
 #include <Formats/formatBlock.h>
+
+#include <numeric>
+
 
 namespace CurrentMetrics
 {

--- a/src/Interpreters/InterpreterKillQueryQuery.cpp
+++ b/src/Interpreters/InterpreterKillQueryQuery.cpp
@@ -24,7 +24,6 @@
 #include <Storages/IStorage.h>
 #include <Common/quoteString.h>
 #include <thread>
-#include <iostream>
 #include <cstddef>
 
 

--- a/src/Loggers/OwnSplitChannel.cpp
+++ b/src/Loggers/OwnSplitChannel.cpp
@@ -1,7 +1,6 @@
 #include "OwnSplitChannel.h"
 #include "OwnFormattingChannel.h"
 
-#include <iostream>
 #include <Core/Block.h>
 #include <Interpreters/InternalTextLogsQueue.h>
 #include <Interpreters/TextLog.h>

--- a/src/Parsers/ASTSelectWithUnionQuery.cpp
+++ b/src/Parsers/ASTSelectWithUnionQuery.cpp
@@ -5,7 +5,6 @@
 #include <IO/Operators.h>
 #include <Parsers/ASTSelectQuery.h>
 
-#include <iostream>
 
 namespace DB
 {

--- a/src/Processors/Executors/StreamingFormatExecutor.cpp
+++ b/src/Processors/Executors/StreamingFormatExecutor.cpp
@@ -1,6 +1,5 @@
 #include <Processors/Executors/StreamingFormatExecutor.h>
 #include <Processors/Transforms/AddingDefaultsTransform.h>
-#include <iostream>
 
 namespace DB
 {

--- a/src/Processors/IAccumulatingTransform.cpp
+++ b/src/Processors/IAccumulatingTransform.cpp
@@ -1,5 +1,4 @@
 #include <Processors/IAccumulatingTransform.h>
-#include <iostream>
 
 namespace DB
 {

--- a/src/Processors/ResizeProcessor.cpp
+++ b/src/Processors/ResizeProcessor.cpp
@@ -1,5 +1,4 @@
 #include <Processors/ResizeProcessor.h>
-#include <iostream>
 
 namespace DB
 {

--- a/src/Processors/Transforms/CountingTransform.cpp
+++ b/src/Processors/Transforms/CountingTransform.cpp
@@ -1,4 +1,3 @@
-#include <iostream>
 
 #include <Interpreters/ProcessList.h>
 #include <Processors/Transforms/CountingTransform.h>

--- a/src/Processors/Transforms/ExceptionKeepingTransform.cpp
+++ b/src/Processors/Transforms/ExceptionKeepingTransform.cpp
@@ -2,7 +2,6 @@
 #include <Common/ThreadStatus.h>
 #include <Common/Stopwatch.h>
 #include <base/scope_guard.h>
-#include <iostream>
 
 namespace DB
 {

--- a/src/Processors/Transforms/SquashingChunksTransform.cpp
+++ b/src/Processors/Transforms/SquashingChunksTransform.cpp
@@ -1,5 +1,4 @@
 #include <Processors/Transforms/SquashingChunksTransform.h>
-#include <iostream>
 
 namespace DB
 {

--- a/src/Server/HTTP/HTTPServerResponse.h
+++ b/src/Server/HTTP/HTTPServerResponse.h
@@ -5,8 +5,8 @@
 #include <Poco/Net/HTTPServerSession.h>
 #include <Poco/Net/HTTPResponse.h>
 
-#include <iostream>
 #include <memory>
+
 
 namespace DB
 {

--- a/src/Storages/MergeTree/GinIndexStore.cpp
+++ b/src/Storages/MergeTree/GinIndexStore.cpp
@@ -11,7 +11,6 @@
 #include <IO/WriteHelpers.h>
 #include <vector>
 #include <unordered_map>
-#include <iostream>
 #include <numeric>
 #include <algorithm>
 

--- a/src/Storages/fuzzers/mergetree_checksum_fuzzer.cpp
+++ b/src/Storages/fuzzers/mergetree_checksum_fuzzer.cpp
@@ -1,4 +1,3 @@
-#include <iostream>
 
 #include <IO/ReadBufferFromMemory.h>
 #include <IO/WriteBufferFromFileDescriptor.h>


### PR DESCRIPTION
### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Speed up the build by removing tons and tonnes of garbage. One of the frequently included headers was poisoned by boost.

```
find . -name '*.h' -or -name '*.cpp' | xargs rg -l -F '#include <iostream>' | xargs rg --files-without-match 'std::(\w+stream|cin|cout|cerr)' | xargs sed -i -r -e '/#include <iostream>/d'
```