### PR TITLE
Add a regression test for broken Vertical merge after ADD+DROP COLUMN

### DIFF
--- a/tests/queries/0_stateless/02842_vertical_merge_after_add_drop_column.sql
+++ b/tests/queries/0_stateless/02842_vertical_merge_after_add_drop_column.sql
@@ -1,0 +1,24 @@
+-- In some version vertical merges after DROP COLUMN had been broken in some cases
+
+drop table if exists data;
+
+create table data (
+    key Int,
+    `legacy_features_Map.id` Array(UInt8),
+    `legacy_features_Map.count` Array(UInt32),
+) engine=MergeTree()
+order by key
+settings
+    min_bytes_for_wide_part=0,
+    min_rows_for_wide_part=0,
+    vertical_merge_algorithm_min_rows_to_activate=0,
+    vertical_merge_algorithm_min_columns_to_activate=0;
+
+insert into data (key) values (1);
+insert into data (key) values (2);
+
+alter table data add column `features_legacy_Map.id` Array(UInt8), add column `features_legacy_Map.count` Array(UInt32);
+
+alter table data drop column legacy_features_Map settings mutations_sync=2;
+
+optimize table data final;

--- a/tests/queries/0_stateless/02842_vertical_merge_after_add_drop_column.sql
+++ b/tests/queries/0_stateless/02842_vertical_merge_after_add_drop_column.sql
@@ -1,4 +1,4 @@
--- In some version vertical merges after DROP COLUMN had been broken in some cases
+-- In some versions vertical merges after DROP COLUMN was broken in some cases
 
 drop table if exists data;
 
@@ -22,3 +22,4 @@ alter table data add column `features_legacy_Map.id` Array(UInt8), add column `f
 alter table data drop column legacy_features_Map settings mutations_sync=2;
 
 optimize table data final;
+DROP TABLE data;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add a regression test for broken Vertical merge after ADD+DROP COLUMN

In #20202 DROP COLUMN had been made no-op, i.e. it simply hardlinked everything and no columns had been removed. In most of the cases this is OK, however Vertical merge may inject another column instead of current if it does not exists
(injectRequiredColumns(LoadedMergeTreeDataPartInfoForReader{}) in MergeTreeSequentialSource ctor), and it may select this already removed column and it will fail with an error:

    DB::Exception: There is no column legacy_features_Map.count in table. (NO_SUCH_COLUMN_IN_TABLE), Stack trace (when copying this message, always include the lines below):
    0. src/Common/Exception.cpp:91: DB::Exception::Exception(DB::Exception::MessageMasked&&, int, bool) @ 0xe0c67d5 in /usr/lib/debug/usr/bin/clickhouse.debug
    2. src/Storages/StorageSnapshot.cpp:111: DB::StorageSnapshot::getColumn(DB::GetColumnsOptions const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) const @ 0x13ff1cb3 in /usr/lib/debug/usr/bin/clickhouse.debug
    3. contrib/llvm-project/libcxx/include/new:246: DB::StorageSnapshot::getColumnsByNames(DB::GetColumnsOptions const&, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>> const&) const @ 0x13ff19f1 in /usr/lib/debug/usr/bin/clickhouse.debug
    4. src/Storages/MergeTree/MergeTreeSequentialSource.cpp:0: DB::MergeTreeSequentialSource::MergeTreeSequentialSource(DB::MergeTreeData const&, std::__1::shared_ptr<DB::StorageSnapshot> const&, std::__1::shared_ptr<DB::IMergeTreeDataPart const>, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>>, std::__1::optional<DB::MarkRanges>, bool, bool, bool, bool) @ 0x143d108c in /usr/lib/debug/usr/bin/clickhouse.debug
    5. contrib/llvm-project/libcxx/include/__memory/construct_at.h:35: DB::createMergeTreeSequentialSource(DB::MergeTreeData const&, std::__1::shared_ptr<DB::StorageSnapshot> const&, std::__1::shared_ptr<DB::IMergeTreeDataPart const>, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>>, bool, bool, bool, std::__1::shared_ptr<std::__1::atomic<unsigned long>>) @ 0x143d25ee in /usr/lib/debug/usr/bin/clickhouse.debug
    6. contrib/llvm-project/libcxx/include/vector:434: DB::MergeTask::VerticalMergeStage::prepareVerticalMergeForOneColumn() const @ 0x1422c525 in /usr/lib/debug/usr/bin/clickhouse.debug

Such merges can be distinguished with the following message in logs:

    Part X doesn't change up to mutation version Y (optimized)
                                                   ^^^^^^^^^^^

Funny that this has been accidentally fixed in the PR with the title "Remove strange code from MutateTask" (#48666)

Cc: @alesapin 
Cc: @amosbird 

_P.S. I've submitted a test only because I spend around a day to figure out what went wrong._