### PR TITLE
docs: Fixed invalid MySQL named collection examples

### DIFF
--- a/docs/en/operations/named-collections.md
+++ b/docs/en/operations/named-collections.md
@@ -169,7 +169,6 @@ host = '127.0.0.1',
 port = 3306,
 database = 'test',
 connection_pool_size = 8,
-on_duplicate_clause = 1,
 replace_query = 1
 ```
 
@@ -185,7 +184,6 @@ replace_query = 1
             <port>3306</port>
             <database>test</database>
             <connection_pool_size>8</connection_pool_size>
-            <on_duplicate_clause>1</on_duplicate_clause>
             <replace_query>1</replace_query>
         </mymysql>
     </named_collections>

--- a/docs/ru/operations/named-collections.md
+++ b/docs/ru/operations/named-collections.md
@@ -88,7 +88,6 @@ SELECT * FROM s3_engine_table LIMIT 3;
             <port>3306</port>
             <database>test</database>
             <connection_pool_size>8</connection_pool_size>
-            <on_duplicate_clause>1</on_duplicate_clause>
             <replace_query>1</replace_query>
         </mymysql>
     </named_collections>


### PR DESCRIPTION
It's not valid to specify both on_duplicate_clause and replace_query, plus on_duplicate_clause was supposed to be an SQL clause and not a boolean/integer anyway.

If examples were followed exactly then recent (at least newer than 22.8) ClickHouse versions will refuse to start with:

`2023.08.09 12:52:33.860773 [ 1103 ] {} <Error> Application: DB::Exception: Only one of 'replace_query' and 'on_duplicate_clause' can be specified, or none of them: Cannot attach table ...`

### Changelog category (leave one):
- Documentation (changelog entry is not required)