### PR TITLE
Don't validate result type in CAST during attach

### DIFF
--- a/src/Databases/DatabaseOnDisk.cpp
+++ b/src/Databases/DatabaseOnDisk.cpp
@@ -61,6 +61,8 @@ std::pair<String, StoragePtr> createTableFromAST(
     bool force_restore)
 {
     ast_create_query.attach = true;
+    context->setAttachQuery(true);
+    SCOPE_EXIT(context->setAttachQuery(false));
     ast_create_query.setDatabase(database_name);
 
     if (ast_create_query.select && ast_create_query.isView())

--- a/src/Interpreters/Context.h
+++ b/src/Interpreters/Context.h
@@ -268,6 +268,7 @@ private:
     bool has_process_list_elem = false;     /// It's impossible to check if weak_ptr was initialized or not
     StorageID insertion_table = StorageID::createEmpty();  /// Saved insertion table in query context
     bool is_distributed = false;  /// Whether the current context it used for distributed query
+    bool is_attach_query = false;  /// Whether the current context is used for attach query
 
     String default_format;  /// Format, used when server formats data by itself and if query does not have FORMAT specification.
                             /// Thus, used in HTTP interface. If not specified - then some globally default format is used.
@@ -713,6 +714,9 @@ public:
 
     void setDistributed(bool is_distributed_) { is_distributed = is_distributed_; }
     bool isDistributed() const { return is_distributed; }
+
+    void setAttachQuery(bool is_attach_query_) { is_attach_query = is_attach_query_; }
+    bool isAttachQuery() const { return is_attach_query; }
 
     String getDefaultFormat() const;    /// If default_format is not specified, some global default format is returned.
     void setDefaultFormat(const String & name);

--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -742,7 +742,6 @@ InterpreterCreateQuery::TableProperties InterpreterCreateQuery::getTableProperti
     }
     else if (create.select)
     {
-
         Block as_select_sample;
 
         if (getContext()->getSettingsRef().allow_experimental_analyzer)
@@ -1652,6 +1651,8 @@ BlockIO InterpreterCreateQuery::execute()
 {
     FunctionNameNormalizer().visit(query_ptr.get());
     auto & create = query_ptr->as<ASTCreateQuery &>();
+    getContext()->setAttachQuery(create.attach);
+    SCOPE_EXIT(getContext()->setAttachQuery(false));
 
     bool is_create_database = create.database && !create.table;
     if (!create.cluster.empty() && !maybeRemoveOnCluster(query_ptr, getContext()))

--- a/tests/queries/0_stateless/02843_dont_validate_types_in_cast_on_attach.sql
+++ b/tests/queries/0_stateless/02843_dont_validate_types_in_cast_on_attach.sql
@@ -1,0 +1,8 @@
+set allow_experimental_object_type=1;
+drop table if exists test_json;
+create table test_json (x UInt64, json JSON default CAST('{}', 'JSON')) engine=MergeTree order by x;
+detach table test_json;
+set allow_experimental_object_type=1;
+attach table test_json;
+drop table test_json;
+

--- a/tests/queries/0_stateless/02843_dont_validate_types_in_cast_on_attach.sql
+++ b/tests/queries/0_stateless/02843_dont_validate_types_in_cast_on_attach.sql
@@ -2,7 +2,7 @@ set allow_experimental_object_type=1;
 drop table if exists test_json;
 create table test_json (x UInt64, json JSON default CAST('{}', 'JSON')) engine=MergeTree order by x;
 detach table test_json;
-set allow_experimental_object_type=1;
+set allow_experimental_object_type=0;
 attach table test_json;
 drop table test_json;
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Don't validate result type in CAST during attach table so server can startup successfully.
