### PR TITLE
Fix `01485_256_bit_multiply`

### DIFF
--- a/tests/queries/0_stateless/01485_256_bit_multiply.sql
+++ b/tests/queries/0_stateless/01485_256_bit_multiply.sql
@@ -1,3 +1,5 @@
+-- Tags: no-random-settings, no-asan, no-msan, no-tsan, no-ubsan, no-debug
+
 select count() from
 (
     select toInt128(number) * number x, toInt256(number) * number y from numbers_mt(100000000) where x != y


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


See https://s3.amazonaws.com/clickhouse-test-reports/53285/3aca2408548bc149f933379506250e49238a24de/stateless_tests__tsan__[4_5].html