### PR TITLE
Reduce parallelism on the query planner if data is small

### DIFF
--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -192,6 +192,7 @@ class IColumn;
     M(Bool, output_format_parallel_formatting, true, "Enable parallel formatting for some data formats.", 0) \
     \
     M(UInt64, merge_tree_min_rows_for_concurrent_read, (20 * 8192), "If at least as many lines are read from one file, the reading can be parallelized.", 0) \
+    M(UInt64, optimize_dynamic_max_threads, 0, "wip", 0) \
     M(UInt64, merge_tree_min_bytes_for_concurrent_read, (24 * 10 * 1024 * 1024), "If at least as many bytes are read from one file, the reading can be parallelized.", 0) \
     M(UInt64, merge_tree_min_rows_for_seek, 0, "You can skip reading more than that number of rows at the price of one seek per file.", 0) \
     M(UInt64, merge_tree_min_bytes_for_seek, 0, "You can skip reading more than that number of bytes at the price of one seek per file.", 0) \

--- a/src/Processors/QueryPlan/Optimizations/QueryPlanOptimizationSettings.cpp
+++ b/src/Processors/QueryPlan/Optimizations/QueryPlanOptimizationSettings.cpp
@@ -20,6 +20,8 @@ QueryPlanOptimizationSettings QueryPlanOptimizationSettings::fromSettings(const 
     settings.optimize_projection = from.optimize_use_projections && from.query_plan_optimize_projection;
     settings.force_use_projection = settings.optimize_projection && from.force_optimize_projection;
     settings.optimize_use_implicit_projections = settings.optimize_projection && from.optimize_use_implicit_projections;
+    settings.optimize_dynamic_max_threads = from.optimize_dynamic_max_threads;
+
     return settings;
 }
 

--- a/src/Processors/QueryPlan/Optimizations/QueryPlanOptimizationSettings.h
+++ b/src/Processors/QueryPlan/Optimizations/QueryPlanOptimizationSettings.h
@@ -43,6 +43,8 @@ struct QueryPlanOptimizationSettings
     bool force_use_projection = false;
     bool optimize_use_implicit_projections = false;
 
+    bool optimize_dynamic_max_threads = false;
+
     static QueryPlanOptimizationSettings fromSettings(const Settings & from);
     static QueryPlanOptimizationSettings fromContext(ContextPtr from);
 };


### PR DESCRIPTION

### Changelog category (leave one):
- New Feature

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Add `optimize_dynamic_max_threads`  setting to limit number of threads used by the query based on number of marks to read

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

max_threads setting allows to limit parallelism of a query. But clickhouse will always try to use as much parallelism as possible, regardless of the data size. Sometimes it does not make sense, and will spawn many threads to process 20 marks, which adds system overheads for no performance gain. The goal is to assess the number of marks from merge tree to process, and select the right amount of threads to process the query from 1 to max_threads. 