### PR TITLE
improve `move_primary_key_columns_to_end_of_prewhere`

### DIFF
--- a/src/Storages/MergeTree/MergeTreeWhereOptimizer.cpp
+++ b/src/Storages/MergeTree/MergeTreeWhereOptimizer.cpp
@@ -226,7 +226,7 @@ static bool isConditionGood(const RPNBuilderTreeNode & condition, const NameSet 
     return false;
 }
 
-void MergeTreeWhereOptimizer::analyzeImpl(Conditions & res, const RPNBuilderTreeNode & node, const WhereOptimizerContext & where_optimizer_context) const
+void MergeTreeWhereOptimizer::analyzeImpl(Conditions & res, const RPNBuilderTreeNode & node, const WhereOptimizerContext & where_optimizer_context, std::set<Int64> & pk_positions) const
 {
     auto function_node_optional = node.toFunctionNodeOrNull();
 
@@ -237,7 +237,7 @@ void MergeTreeWhereOptimizer::analyzeImpl(Conditions & res, const RPNBuilderTree
         for (size_t i = 0; i < arguments_size; ++i)
         {
             auto argument = function_node_optional->getArgumentAt(i);
-            analyzeImpl(res, argument, where_optimizer_context);
+            analyzeImpl(res, argument, where_optimizer_context, pk_positions);
         }
     }
     else
@@ -270,6 +270,7 @@ void MergeTreeWhereOptimizer::analyzeImpl(Conditions & res, const RPNBuilderTree
             cond.good = cond.viable;
             /// Find min position in PK of any column that is used in this condition.
             cond.min_position_in_primary_key = findMinPosition(cond.table_columns, primary_key_names_positions);
+            pk_positions.emplace(cond.min_position_in_primary_key);
         }
 
         res.emplace_back(std::move(cond));
@@ -281,7 +282,27 @@ MergeTreeWhereOptimizer::Conditions MergeTreeWhereOptimizer::analyze(const RPNBu
     const WhereOptimizerContext & where_optimizer_context) const
 {
     Conditions res;
-    analyzeImpl(res, node, where_optimizer_context);
+    std::set<Int64> pk_positions;
+    analyzeImpl(res, node, where_optimizer_context, pk_positions);
+    /// e.g. if primary kes are (a,b,c) but the condition is a = 1 and c = 1, we should only put (a = 1) to the last,
+    /// and treat (c = 1) as normal column.
+    if (where_optimizer_context.move_primary_key_columns_to_end_of_prewhere)
+    {
+        Int64 min_valid_pk_pos = -1;
+        for (auto pk_pos : pk_positions)
+        {
+            if (pk_pos != min_valid_pk_pos + 1)
+                break;
+            min_valid_pk_pos = pk_pos;
+        }
+        for (auto & cond : res)
+        {
+            if (cond.min_position_in_primary_key > min_valid_pk_pos)
+                cond.min_position_in_primary_key = std::numeric_limits<Int64>::max() - 1;
+        }
+        LOG_TRACE(log, "the min valid primary key position is {}", min_valid_pk_pos);
+    }
+
     return res;
 }
 

--- a/src/Storages/MergeTree/MergeTreeWhereOptimizer.cpp
+++ b/src/Storages/MergeTree/MergeTreeWhereOptimizer.cpp
@@ -284,7 +284,7 @@ MergeTreeWhereOptimizer::Conditions MergeTreeWhereOptimizer::analyze(const RPNBu
     Conditions res;
     std::set<Int64> pk_positions;
     analyzeImpl(res, node, where_optimizer_context, pk_positions);
-    
+
     /// E.g., if the primary key is (a, b, c) but the condition is a = 1 and c = 1,
     /// we should only put (a = 1) to the tail of PREWHERE,
     /// and treat (c = 1) as a normal column.

--- a/src/Storages/MergeTree/MergeTreeWhereOptimizer.cpp
+++ b/src/Storages/MergeTree/MergeTreeWhereOptimizer.cpp
@@ -284,8 +284,10 @@ MergeTreeWhereOptimizer::Conditions MergeTreeWhereOptimizer::analyze(const RPNBu
     Conditions res;
     std::set<Int64> pk_positions;
     analyzeImpl(res, node, where_optimizer_context, pk_positions);
-    /// e.g. if primary kes are (a,b,c) but the condition is a = 1 and c = 1, we should only put (a = 1) to the last,
-    /// and treat (c = 1) as normal column.
+    
+    /// E.g., if the primary key is (a, b, c) but the condition is a = 1 and c = 1,
+    /// we should only put (a = 1) to the tail of PREWHERE,
+    /// and treat (c = 1) as a normal column.
     if (where_optimizer_context.move_primary_key_columns_to_end_of_prewhere)
     {
         Int64 min_valid_pk_pos = -1;
@@ -300,7 +302,7 @@ MergeTreeWhereOptimizer::Conditions MergeTreeWhereOptimizer::analyze(const RPNBu
             if (cond.min_position_in_primary_key > min_valid_pk_pos)
                 cond.min_position_in_primary_key = std::numeric_limits<Int64>::max() - 1;
         }
-        LOG_TRACE(log, "the min valid primary key position is {}", min_valid_pk_pos);
+        LOG_TRACE(log, "The min valid primary key position for moving to the tail of PREWHERE is {}", min_valid_pk_pos);
     }
 
     return res;

--- a/src/Storages/MergeTree/MergeTreeWhereOptimizer.h
+++ b/src/Storages/MergeTree/MergeTreeWhereOptimizer.h
@@ -108,7 +108,7 @@ private:
 
     std::optional<OptimizeResult> optimizeImpl(const RPNBuilderTreeNode & node, const WhereOptimizerContext & where_optimizer_context) const;
 
-    void analyzeImpl(Conditions & res, const RPNBuilderTreeNode & node, const WhereOptimizerContext & where_optimizer_context) const;
+    void analyzeImpl(Conditions & res, const RPNBuilderTreeNode & node, const WhereOptimizerContext & where_optimizer_context, std::set<Int64> & pk_positions) const;
 
     /// Transform conjunctions chain in WHERE expression to Conditions list.
     Conditions analyze(const RPNBuilderTreeNode & node, const WhereOptimizerContext & where_optimizer_context) const;

--- a/tests/queries/0_stateless/02842_move_pk_to_end_of_prewhere.reference
+++ b/tests/queries/0_stateless/02842_move_pk_to_end_of_prewhere.reference
@@ -1,0 +1,20 @@
+SELECT count()
+FROM t_02848_mt1
+PREWHERE notEmpty(v) AND (k = 3)
+1
+SELECT count()
+FROM t_02848_mt2
+PREWHERE (d LIKE \'%es%\') AND (c < 20) AND (b = \'3\') AND (a = 3)
+1
+SELECT count()
+FROM t_02848_mt2
+PREWHERE (d LIKE \'%es%\') AND (c < 20) AND (c > 0) AND (a = 3)
+1
+SELECT count()
+FROM t_02848_mt2
+PREWHERE (d LIKE \'%es%\') AND (b = \'3\') AND (c < 20)
+1
+SELECT count()
+FROM t_02848_mt2
+PREWHERE (d LIKE \'%es%\') AND (b = \'3\') AND (a = 3)
+1

--- a/tests/queries/0_stateless/02842_move_pk_to_end_of_prewhere.sql
+++ b/tests/queries/0_stateless/02842_move_pk_to_end_of_prewhere.sql
@@ -1,0 +1,34 @@
+SET optimize_move_to_prewhere = 1;
+SET enable_multiple_prewhere_read_steps = 1;
+
+DROP TABLE IF EXISTS t_02848_mt1;
+DROP TABLE IF EXISTS t_02848_mt2;
+
+CREATE TABLE t_02848_mt1 (k UInt32, v String) ENGINE = MergeTree ORDER BY k SETTINGS min_bytes_for_wide_part=0;
+
+INSERT INTO t_02848_mt1 SELECT number, toString(number) FROM numbers(100);
+
+EXPLAIN SYNTAX SELECT count() FROM t_02848_mt1 WHERE k = 3 AND notEmpty(v);
+SELECT count() FROM t_02848_mt1 WHERE k = 3 AND notEmpty(v);
+
+CREATE TABLE t_02848_mt2 (a UInt32, b String, c Int32, d String) ENGINE = MergeTree ORDER BY (a,b,c) SETTINGS min_bytes_for_wide_part=0;
+
+INSERT INTO t_02848_mt2 SELECT number, toString(number), number, 'aaaabbbbccccddddtestxxxyyy' FROM numbers(100);
+
+-- the estimated column sizes are: {a: 428, b: 318, c: 428, d: 73}
+-- it's not correct but let's fix it in the future.
+
+EXPLAIN SYNTAX SELECT count() FROM t_02848_mt2 WHERE a = 3 AND b == '3' AND c < 20 AND d like '%es%';
+SELECT count() FROM t_02848_mt2 WHERE a = 3 AND b == '3' AND c < 20 AND d like '%es%';
+
+EXPLAIN SYNTAX SELECT count() FROM t_02848_mt2 WHERE a = 3 AND c < 20 AND c > 0 AND d like '%es%';
+SELECT count() FROM t_02848_mt2 WHERE a = 3 AND c < 20 AND c > 0 AND d like '%es%';
+
+EXPLAIN SYNTAX SELECT count() FROM t_02848_mt2 WHERE  b == '3' AND c < 20 AND d like '%es%';
+SELECT count() FROM t_02848_mt2 WHERE b == '3' AND c < 20 AND d like '%es%';
+
+EXPLAIN SYNTAX SELECT count() FROM t_02848_mt2 WHERE a = 3 AND b == '3' AND d like '%es%';
+SELECT count() FROM t_02848_mt2 WHERE a = 3 AND b == '3' AND d like '%es%';
+
+DROP TABLE t_02848_mt1;
+DROP TABLE t_02848_mt2;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
if primary kes are (a,b,c) but the condition is a = 1 and c = 1, we should only put (a = 1) to the last and treat (c = 1) as normal column.
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
 improve `move_primary_key_columns_to_end_of_prewhere`

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
