### PR TITLE
Fix incorrect normal projection AST format

### DIFF
--- a/src/Parsers/ASTProjectionSelectQuery.cpp
+++ b/src/Parsers/ASTProjectionSelectQuery.cpp
@@ -73,11 +73,11 @@ void ASTProjectionSelectQuery::formatImpl(const FormatSettings & s, FormatState 
 
     if (orderBy())
     {
-        /// Let's convert the ASTFunction into ASTExpressionList, which generates consistent format
+        /// Let's convert tuple ASTFunction into ASTExpressionList, which generates consistent format
         /// between GROUP BY and ORDER BY projection definition.
         s.ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << indent_str << "ORDER BY " << (s.hilite ? hilite_none : "");
         ASTPtr order_by;
-        if (auto * func = orderBy()->as<ASTFunction>())
+        if (auto * func = orderBy()->as<ASTFunction>(); func && func->name == "tuple")
             order_by = func->arguments;
         else
         {

--- a/tests/queries/0_stateless/01710_normal_projection_format.reference
+++ b/tests/queries/0_stateless/01710_normal_projection_format.reference
@@ -1,0 +1,1 @@
+CREATE TABLE default.test\n(\n    `uuid` FixedString(16),\n    `id` Int32,\n    `ns` FixedString(16),\n    `dt` DateTime64(6),\n    PROJECTION mtlog_proj_source_reference\n    (\n        SELECT *\n        ORDER BY substring(ns, 1, 5)\n    )\n)\nENGINE = MergeTree\nORDER BY (id, dt, uuid)\nSETTINGS index_granularity = 8192

--- a/tests/queries/0_stateless/01710_normal_projection_format.sql
+++ b/tests/queries/0_stateless/01710_normal_projection_format.sql
@@ -1,0 +1,17 @@
+DROP TABLE if exists test;
+
+CREATE TABLE test
+(
+    uuid FixedString(16),
+    id int,
+    ns FixedString(16),
+    dt DateTime64(6),
+)
+ENGINE = MergeTree
+ORDER BY (id, dt, uuid);
+
+ALTER TABLE test ADD PROJECTION mtlog_proj_source_reference (SELECT * ORDER BY substring(ns, 1, 5));
+
+SHOW CREATE test;
+
+drop table test;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix incorrect normal projection AST format when single function is used in ORDER BY. This fixes https://github.com/ClickHouse/ClickHouse/issues/52607

