### PR TITLE
Add linux s390x to universal installer

### DIFF
--- a/docs/_includes/install/universal.sh
+++ b/docs/_includes/install/universal.sh
@@ -36,6 +36,9 @@ then
     elif [ "${ARCH}" = "riscv64" ]
     then
         DIR="riscv64"
+    elif [ "${ARCH}" = "s390x" ]
+    then
+        DIR="s390x"
     fi
 elif [ "${OS}" = "FreeBSD" ]
 then


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Add linux s390x to universal installer

