### PR TITLE
Fix wrong query in log messages check

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -2152,7 +2152,7 @@ def reportLogStats(args):
     print("\n")
 
     query = """
-        SELECT message_format_string, count(), substr(any(message), 1, 120) AS any_message
+        SELECT message_format_string, count(), any(message) AS any_message
         FROM system.text_log
         WHERE (now() - toIntervalMinute(240)) < event_time
         AND (message NOT LIKE (replaceRegexpAll(message_format_string, '{[:.0-9dfx]*}', '%') AS s))


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


```
2023-08-13 17:01:37 Top messages that does not match its format string:
2023-08-13 17:01:37 
2023-08-13 17:01:44 message_format_string	count()	any_message
2023-08-13 17:01:44 LowCardinality(String)	UInt64	String
2023-08-13 17:01:44 {} is in use (by merge/mutation/INSERT) (consider increasing temporary_directories_lifetime setting)	54	/var/lib/clickhouse/disks/s3/store/342/34299426-8676-4e8e-9231-429c380a4a67/tmp_mut_all_1_1_0_5/ is in use (by merge/mut
2023-08-13 17:01:44 	49	Forked a child process to watch
2023-08-13 17:01:44 (from {}{}{}){}{} {} (stage: {})	2	(from [::1]:51758) (comment: 02683_native_too_large_size.sql) SELECT * FROM format(\'Native\', \'WatchID Int64, JavaEnable
```