### PR TITLE
Quick fail undocumented features

### DIFF
--- a/tests/ci/pr_info.py
+++ b/tests/ci/pr_info.py
@@ -279,7 +279,7 @@ class PRInfo:
             "user_orgs": self.user_orgs,
         }
 
-    def has_changes_in_documentation(self):
+    def has_changes_in_documentation(self) -> bool:
         # If the list wasn't built yet the best we can do is to
         # assume that there were changes.
         if self.changed_files is None or not self.changed_files:
@@ -287,10 +287,9 @@ class PRInfo:
 
         for f in self.changed_files:
             _, ext = os.path.splitext(f)
-            path_in_docs = "docs" in f
-            path_in_website = "website" in f
+            path_in_docs = f.startswith("docs/")
             if (
-                ext in DIFF_IN_DOCUMENTATION_EXT and (path_in_docs or path_in_website)
+                ext in DIFF_IN_DOCUMENTATION_EXT and path_in_docs
             ) or "docker/docs" in f:
                 return True
         return False

--- a/tests/ci/run_check.py
+++ b/tests/ci/run_check.py
@@ -147,7 +147,8 @@ def main():
             "failure",
             NotSet,
             f"expect adding docs for {FEATURE_LABEL}",
-            CI_STATUS_NAME,
+            DOCS_NAME,
+            pr_info,
         )
         sys.exit(1)
 

--- a/tests/ci/run_check.py
+++ b/tests/ci/run_check.py
@@ -137,17 +137,19 @@ def main():
     if pr_labels_to_remove:
         remove_labels(gh, pr_info, pr_labels_to_remove)
 
-    if FEATURE_LABEL in pr_info.labels:
-        print(f"The '{FEATURE_LABEL}' in the labels, expect the 'Docs Check' status")
+    if FEATURE_LABEL in pr_info.labels and not pr_info.has_changes_in_documentation():
+        print(
+            f"The '{FEATURE_LABEL}' in the labels, "
+            "but there's no changed documentation"
+        )
         post_commit_status(  # do not pass pr_info here intentionally
             commit,
-            "pending",
+            "failure",
             NotSet,
             f"expect adding docs for {FEATURE_LABEL}",
-            DOCS_NAME,
+            CI_STATUS_NAME,
         )
-    elif not description_error:
-        set_mergeable_check(commit, "skipped")
+        sys.exit(1)
 
     if description_error:
         print(
@@ -173,6 +175,7 @@ def main():
         )
         sys.exit(1)
 
+    set_mergeable_check(commit, "skipped")
     ci_report_url = create_ci_report(pr_info, [])
     if not can_run:
         print("::notice ::Cannot run")


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
If no documentation is added to a `pr-feature`, the workflow will fail quickly.

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)