### PR TITLE
boost getNestedColumnWithDefaultOnNull by insertManyDefaults

### DIFF
--- a/src/Columns/ColumnNullable.cpp
+++ b/src/Columns/ColumnNullable.cpp
@@ -806,7 +806,7 @@ ColumnPtr ColumnNullable::getNestedColumnWithDefaultOnNull() const
 
         size_t next_none_null_index = next_null_index;
         while (next_none_null_index < end && null_map_data[next_none_null_index])
-            ++ next_none_null_index;
+            ++next_none_null_index;
 
         if (next_null_index != next_none_null_index)
             res->insertManyDefaults(next_none_null_index - next_null_index);

--- a/src/Columns/ColumnNullable.cpp
+++ b/src/Columns/ColumnNullable.cpp
@@ -804,10 +804,14 @@ ColumnPtr ColumnNullable::getNestedColumnWithDefaultOnNull() const
         if (next_null_index != start)
             res->insertRangeFrom(*nested_column, start, next_null_index - start);
 
-        if (next_null_index < end)
-            res->insertDefault();
+        size_t next_none_null_index = next_null_index;
+        while (next_none_null_index < end && null_map_data[next_none_null_index])
+            ++ next_none_null_index;
 
-        start = next_null_index + 1;
+        if (next_null_index != next_none_null_index)
+            res->insertManyDefaults(next_none_null_index - next_null_index);
+
+        start = next_none_null_index;
     }
     return res;
 }


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

