### PR TITLE
Fix creation of empty parts

### DIFF
--- a/src/Storages/MergeTree/MergeTreeData.h
+++ b/src/Storages/MergeTree/MergeTreeData.h
@@ -936,7 +936,9 @@ public:
     WriteAheadLogPtr getWriteAheadLog();
 
     constexpr static auto EMPTY_PART_TMP_PREFIX = "tmp_empty_";
-    MergeTreeData::MutableDataPartPtr createEmptyPart(MergeTreePartInfo & new_part_info, const MergeTreePartition & partition, const String & new_part_name, const MergeTreeTransactionPtr & txn);
+    std::pair<MergeTreeData::MutableDataPartPtr, scope_guard> createEmptyPart(
+        MergeTreePartInfo & new_part_info, const MergeTreePartition & partition,
+        const String & new_part_name, const MergeTreeTransactionPtr & txn);
 
     MergeTreeDataFormatVersion format_version;
 

--- a/src/Storages/StorageMergeTree.cpp
+++ b/src/Storages/StorageMergeTree.cpp
@@ -1653,11 +1653,7 @@ struct FutureNewEmptyPart
     MergeTreePartition partition;
     std::string part_name;
 
-    scope_guard tmp_dir_guard;
-
     StorageMergeTree::MutableDataPartPtr data_part;
-
-    std::string getDirName() const { return StorageMergeTree::EMPTY_PART_TMP_PREFIX + part_name; }
 };
 
 using FutureNewEmptyParts = std::vector<FutureNewEmptyPart>;
@@ -1688,19 +1684,19 @@ FutureNewEmptyParts initCoverageWithNewEmptyParts(const DataPartsVector & old_pa
     return future_parts;
 }
 
-StorageMergeTree::MutableDataPartsVector createEmptyDataParts(MergeTreeData & data, FutureNewEmptyParts & future_parts, const MergeTreeTransactionPtr & txn)
+std::pair<StorageMergeTree::MutableDataPartsVector, std::vector<scope_guard>> createEmptyDataParts(
+    MergeTreeData & data, FutureNewEmptyParts & future_parts, const MergeTreeTransactionPtr & txn)
 {
-    StorageMergeTree::MutableDataPartsVector data_parts;
+    std::pair<StorageMergeTree::MutableDataPartsVector, std::vector<scope_guard>> data_parts;
     for (auto & part: future_parts)
-        data_parts.push_back(data.createEmptyPart(part.part_info, part.partition, part.part_name, txn));
+    {
+        auto [new_data_part, tmp_dir_holder] = data.createEmptyPart(part.part_info, part.partition, part.part_name, txn);
+        data_parts.first.emplace_back(std::move(new_data_part));
+        data_parts.second.emplace_back(std::move(tmp_dir_holder));
+    }
     return data_parts;
 }
 
-void captureTmpDirectoryHolders(MergeTreeData & data, FutureNewEmptyParts & future_parts)
-{
-    for (auto & part : future_parts)
-        part.tmp_dir_guard = data.getTemporaryPartDirectoryHolder(part.getDirName());
-}
 
 void StorageMergeTree::renameAndCommitEmptyParts(MutableDataPartsVector & new_parts, Transaction & transaction)
 {
@@ -1767,9 +1763,7 @@ void StorageMergeTree::truncate(const ASTPtr &, const StorageMetadataPtr &, Cont
                      fmt::join(getPartsNames(future_parts), ", "), fmt::join(getPartsNames(parts), ", "),
                      transaction.getTID());
 
-            captureTmpDirectoryHolders(*this, future_parts);
-
-            auto new_data_parts = createEmptyDataParts(*this, future_parts, txn);
+            auto [new_data_parts, tmp_dir_holders] = createEmptyDataParts(*this, future_parts, txn);
             renameAndCommitEmptyParts(new_data_parts, transaction);
 
             PartLog::addNewParts(query_context, PartLog::createPartLogEntries(new_data_parts, watch.elapsed(), profile_events_scope.getSnapshot()));
@@ -1828,9 +1822,7 @@ void StorageMergeTree::dropPart(const String & part_name, bool detach, ContextPt
                          fmt::join(getPartsNames(future_parts), ", "), fmt::join(getPartsNames({part}), ", "),
                          transaction.getTID());
 
-                captureTmpDirectoryHolders(*this, future_parts);
-
-                auto new_data_parts = createEmptyDataParts(*this, future_parts, txn);
+                auto [new_data_parts, tmp_dir_holders] = createEmptyDataParts(*this, future_parts, txn);
                 renameAndCommitEmptyParts(new_data_parts, transaction);
 
                 PartLog::addNewParts(query_context, PartLog::createPartLogEntries(new_data_parts, watch.elapsed(), profile_events_scope.getSnapshot()));
@@ -1914,9 +1906,8 @@ void StorageMergeTree::dropPartition(const ASTPtr & partition, bool detach, Cont
                      fmt::join(getPartsNames(future_parts), ", "), fmt::join(getPartsNames(parts), ", "),
                      transaction.getTID());
 
-            captureTmpDirectoryHolders(*this, future_parts);
 
-            auto new_data_parts = createEmptyDataParts(*this, future_parts, txn);
+            auto [new_data_parts, tmp_dir_holders] = createEmptyDataParts(*this, future_parts, txn);
             renameAndCommitEmptyParts(new_data_parts, transaction);
 
             PartLog::addNewParts(query_context, PartLog::createPartLogEntries(new_data_parts, watch.elapsed(), profile_events_scope.getSnapshot()));

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -9509,7 +9509,7 @@ bool StorageReplicatedMergeTree::createEmptyPartInsteadOfLost(zkutil::ZooKeeperP
         }
     }
 
-    MergeTreeData::MutableDataPartPtr new_data_part = createEmptyPart(new_part_info, partition, lost_part_name, NO_TRANSACTION_PTR);
+    auto [new_data_part, tmp_dir_holder] = createEmptyPart(new_part_info, partition, lost_part_name, NO_TRANSACTION_PTR);
     new_data_part->setName(lost_part_name);
 
     try


### PR DESCRIPTION

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

https://s3.amazonaws.com/clickhouse-test-reports/53142/b6b20514d57822de498d68beeb80c5b3c1d054e6/stateless_tests__release__wide_parts_enabled_.html

```
2023.08.10 04:47:11.640907 [ 25701 ] {4a1c581f-e2f1-4775-8445-d342db59d30d} <Debug> executeQuery: (from [::1]:53110) (comment: 02253_empty_part_checksums.sh) select path from system.parts where database='test_evbfnx77' and table='rmt' and name='0_0_0_0' (stage: Complete)
2023.08.10 04:47:11.984252 [ 744 ] {} <Information> test_evbfnx77.rmt (6467ea4a-9ee0-45ed-adb7-401fb707b760): Going to replace lost part 0_0_0_0 with empty part
2023.08.10 04:47:12.008713 [ 739 ] {} <Warning> test_evbfnx77.rmt (6467ea4a-9ee0-45ed-adb7-401fb707b760): Removing temporary directory /var/lib/clickhouse/store/646/6467ea4a-9ee0-45ed-adb7-401fb707b760/tmp_empty_0_0_0_0/
2023.08.10 04:47:12.009361 [ 744 ] {} <Trace> test_evbfnx77.rmt (6467ea4a-9ee0-45ed-adb7-401fb707b760): Renaming temporary part tmp_empty_0_0_0_0 to 0_0_0_0 with tid (1, 1, 00000000-0000-0000-0000-000000000000).
2023.08.10 04:47:12.010669 [ 744 ] {} <Information> test_evbfnx77.rmt (6467ea4a-9ee0-45ed-adb7-401fb707b760): Created empty part 0_0_0_0 instead of lost part
```

```
2023-08-10 04:47:12 [29bcb0933092] 2023.08.09 17:47:12.480984 [ 25722 ] {4ab24abd-1e85-47b0-987d-8a67d926d8bc} <Error> test_evbfnx77.rmt (ReplicatedMergeTreePartCheckThread): ReplicatedCheckResult DB::ReplicatedMergeTreePartCheckThread::checkPartImpl(const String &): Code: 107. DB::ErrnoException: Cannot open file /var/lib/clickhouse/store/646/6467ea4a-9ee0-45ed-adb7-401fb707b760/0_0_0_0/a.bin, errno: 2, strerror: No such file or directory. (FILE_DOESNT_EXIST), Stack trace (when copying this message, always include the lines below):
2023-08-10 04:47:12 
2023-08-10 04:47:12 0. ./build_docker/./src/Common/Exception.cpp:98: DB::Exception::Exception(DB::Exception::MessageMasked&&, int, bool) @ 0x000000000c7460f7 in /usr/lib/debug/usr/bin/clickhouse.debug
2023-08-10 04:47:12 1. ./build_docker/./contrib/llvm-project/libcxx/include/string:1499: DB::ErrnoException::ErrnoException(String const&, int, int, std::optional<String> const&) @ 0x000000000c747654 in /usr/lib/debug/usr/bin/clickhouse.debug
2023-08-10 04:47:12 2. ./build_docker/./src/Common/Exception.cpp:0: DB::throwFromErrnoWithPath(String const&, String const&, int, int) @ 0x000000000c7479e0 in /usr/lib/debug/usr/bin/clickhouse.debug
2023-08-10 04:47:12 3. ./build_docker/./src/IO/OpenedFile.cpp:0: DB::OpenedFile::open() const @ 0x0000000010bfb68f in /usr/lib/debug/usr/bin/clickhouse.debug
2023-08-10 04:47:12 4. ./build_docker/./src/IO/OpenedFile.cpp:42: DB::OpenedFile::getFD() const @ 0x0000000010bfb735 in /usr/lib/debug/usr/bin/clickhouse.debug
2023-08-10 04:47:12 5. ./build_docker/./src/IO/ReadBufferFromFile.h:99: DB::createReadBufferFromFileBase(String const&, DB::ReadSettings const&, std::optional<unsigned long>, std::optional<unsigned long>, int, char*, unsigned long)::$_0::operator()(unsigned long, unsigned long, int) const @ 0x0000000010bf8260 in /usr/lib/debug/usr/bin/clickhouse.debug
2023-08-10 04:47:12 6. ./build_docker/./src/Disks/IO/createReadBufferFromFileBase.cpp:216: DB::createReadBufferFromFileBase(String const&, DB::ReadSettings const&, std::optional<unsigned long>, std::optional<unsigned long>, int, char*, unsigned long) @ 0x0000000010bf7d1a in /usr/lib/debug/usr/bin/clickhouse.debug
2023-08-10 04:47:12 7. ./build_docker/./src/Disks/DiskLocal.cpp:335: DB::DiskLocal::readFile(String const&, DB::ReadSettings const&, std::optional<unsigned long>, std::optional<unsigned long>) const @ 0x00000000114357fd in /usr/lib/debug/usr/bin/clickhouse.debug
2023-08-10 04:47:12 8. ./build_docker/./src/Storages/MergeTree/DataPartStorageOnDiskFull.cpp:122: DB::DataPartStorageOnDiskFull::readFile(String const&, DB::ReadSettings const&, std::optional<unsigned long>, std::optional<unsigned long>) const @ 0x0000000012ab12b3 in /usr/lib/debug/usr/bin/clickhouse.debug
2023-08-10 04:47:12 9. ./build_docker/./src/Storages/MergeTree/checkDataPart.cpp:109: DB::checkDataPart(std::shared_ptr<DB::IMergeTreeDataPart const>, DB::IDataPartStorage const&, DB::NamesAndTypesList const&, DB::MergeTreeDataPartType const&, std::unordered_set<String, std::hash<String>, std::equal_to<String>, std::allocator<String>> const&, DB::ReadSettings const&, bool, std::function<bool ()>)::$_2::operator()(DB::IDataPartStorage const&, String const&) const @ 0x0000000012e9d86d in /usr/lib/debug/usr/bin/clickhouse.debug
2023-08-10 04:47:12 10. ./build_docker/./src/Storages/MergeTree/checkDataPart.cpp:167: void std::__function::__policy_invoker<void (DB::ISerialization::SubstreamPath const&)>::__call_impl<std::__function::__default_alloc_func<DB::checkDataPart(std::shared_ptr<DB::IMergeTreeDataPart const>, DB::IDataPartStorage const&, DB::NamesAndTypesList const&, DB::MergeTreeDataPartType const&, std::unordered_set<String, std::hash<String>, std::equal_to<String>, std::allocator<String>> const&, DB::ReadSettings const&, bool, std::function<bool ()>)::$_1, void (DB::ISerialization::SubstreamPath const&)>>(std::__function::__policy_storage const*, DB::ISerialization::SubstreamPath const&) @ 0x0000000012e9e6dd in /usr/lib/debug/usr/bin/clickhouse.debug
2023-08-10 04:47:12 11. ./build_docker/./contrib/llvm-projec
```
