### PR TITLE
Remove experimental from opentelemetry.md

### DIFF
--- a/docs/en/operations/opentelemetry.md
+++ b/docs/en/operations/opentelemetry.md
@@ -2,14 +2,10 @@
 slug: /en/operations/opentelemetry
 sidebar_position: 62
 sidebar_label: Tracing ClickHouse with OpenTelemetry
-title: "[experimental] Tracing ClickHouse with OpenTelemetry"
+title: "Tracing ClickHouse with OpenTelemetry"
 ---
 
 [OpenTelemetry](https://opentelemetry.io/) is an open standard for collecting traces and metrics from the distributed application. ClickHouse has some support for OpenTelemetry.
-
-:::note    
-This is an experimental feature that will change in backwards-incompatible ways in future releases.
-:::
 
 ## Supplying Trace Context to ClickHouse
 


### PR DESCRIPTION
### Changelog category (leave one):
- Documentation (changelog entry is not required)

Let's merge if this feature is no longer experimental....and close if it's still experimental.
