### PR TITLE
Fix JSON_QUERY Function parse error while path is all number

### DIFF
--- a/src/Functions/JSONPath/Parsers/ParserJSONPathMemberAccess.cpp
+++ b/src/Functions/JSONPath/Parsers/ParserJSONPathMemberAccess.cpp
@@ -51,7 +51,7 @@ bool ParserJSONPathMemberAccess::parseImpl(Pos & pos, ASTPtr & node, Expected & 
         }
         const auto * last_begin = *pos->begin == '.' ? pos->begin + 1 : pos->begin;
         const auto * last_end = pos->end;
-        const String numberic_member_name = String(last_begin, last_end);
+        const String numberic_member_name(last_begin, last_end);
         ++pos;
 
         if (pos.isValid() && pos->type == TokenType::BareWord && pos->begin == last_end)

--- a/src/Functions/JSONPath/Parsers/ParserJSONPathMemberAccess.cpp
+++ b/src/Functions/JSONPath/Parsers/ParserJSONPathMemberAccess.cpp
@@ -51,12 +51,17 @@ bool ParserJSONPathMemberAccess::parseImpl(Pos & pos, ASTPtr & node, Expected & 
         }
         const auto * last_begin = *pos->begin == '.' ? pos->begin + 1 : pos->begin;
         const auto * last_end = pos->end;
+        const String numberic_member_name = String(last_begin, last_end);
         ++pos;
 
         if (pos.isValid() && pos->type == TokenType::BareWord && pos->begin == last_end)
         {
             member_name = std::make_shared<ASTIdentifier>(String(last_begin, pos->end));
             ++pos;
+        }
+        else if (!pos.isValid() && pos->type == TokenType::EndOfStream)
+        {
+            member_name = std::make_shared<ASTIdentifier>(numberic_member_name);
         }
         else
         {

--- a/src/Functions/JSONPath/Parsers/ParserJSONPathMemberAccess.cpp
+++ b/src/Functions/JSONPath/Parsers/ParserJSONPathMemberAccess.cpp
@@ -51,7 +51,6 @@ bool ParserJSONPathMemberAccess::parseImpl(Pos & pos, ASTPtr & node, Expected & 
         }
         const auto * last_begin = *pos->begin == '.' ? pos->begin + 1 : pos->begin;
         const auto * last_end = pos->end;
-        const String numberic_member_name(last_begin, last_end);
         ++pos;
 
         if (pos.isValid() && pos->type == TokenType::BareWord && pos->begin == last_end)
@@ -61,7 +60,7 @@ bool ParserJSONPathMemberAccess::parseImpl(Pos & pos, ASTPtr & node, Expected & 
         }
         else if (!pos.isValid() && pos->type == TokenType::EndOfStream)
         {
-            member_name = std::make_shared<ASTIdentifier>(numberic_member_name);
+            member_name = std::make_shared<ASTIdentifier>(String(last_begin, last_end));
         }
         else
         {

--- a/tests/queries/0_stateless/01889_sql_json_functions.reference
+++ b/tests/queries/0_stateless/01889_sql_json_functions.reference
@@ -79,6 +79,8 @@ SELECT JSON_QUERY('{"1key":1}', '$.1key');
 [1]
 SELECT JSON_QUERY('{"123":1}', '$.123');
 [1]
+SELECT JSON_QUERY('{"123":1}', '$[123]');
+
 SELECT JSON_QUERY('{"hello":1}', '$[hello]');
 [1]
 SELECT JSON_QUERY('{"hello":1}', '$["hello"]');

--- a/tests/queries/0_stateless/01889_sql_json_functions.reference
+++ b/tests/queries/0_stateless/01889_sql_json_functions.reference
@@ -77,6 +77,8 @@ SELECT JSON_QUERY('{"array":[[0, 1, 2, 3, 4, 5], [0, -1, -2, -3, -4, -5]]}', '$.
 [0, 1, 4, 0, -1, -4]
 SELECT JSON_QUERY('{"1key":1}', '$.1key');
 [1]
+SELECT JSON_QUERY('{"123":1}', '$.123');
+[1]
 SELECT JSON_QUERY('{"hello":1}', '$[hello]');
 [1]
 SELECT JSON_QUERY('{"hello":1}', '$["hello"]');

--- a/tests/queries/0_stateless/01889_sql_json_functions.sql
+++ b/tests/queries/0_stateless/01889_sql_json_functions.sql
@@ -43,6 +43,7 @@ SELECT JSON_QUERY( '{hello:{"world":"!"}}}', '$.hello'); -- invalid json => defa
 SELECT JSON_QUERY('', '$.hello');
 SELECT JSON_QUERY('{"array":[[0, 1, 2, 3, 4, 5], [0, -1, -2, -3, -4, -5]]}', '$.array[*][0 to 2, 4]');
 SELECT JSON_QUERY('{"1key":1}', '$.1key');
+SELECT JSON_QUERY('{"123":1}', '$.123');
 SELECT JSON_QUERY('{"hello":1}', '$[hello]');
 SELECT JSON_QUERY('{"hello":1}', '$["hello"]');
 SELECT JSON_QUERY('{"hello":1}', '$[\'hello\']');

--- a/tests/queries/0_stateless/01889_sql_json_functions.sql
+++ b/tests/queries/0_stateless/01889_sql_json_functions.sql
@@ -44,6 +44,7 @@ SELECT JSON_QUERY('', '$.hello');
 SELECT JSON_QUERY('{"array":[[0, 1, 2, 3, 4, 5], [0, -1, -2, -3, -4, -5]]}', '$.array[*][0 to 2, 4]');
 SELECT JSON_QUERY('{"1key":1}', '$.1key');
 SELECT JSON_QUERY('{"123":1}', '$.123');
+SELECT JSON_QUERY('{"123":1}', '$[123]');
 SELECT JSON_QUERY('{"hello":1}', '$[hello]');
 SELECT JSON_QUERY('{"hello":1}', '$["hello"]');
 SELECT JSON_QUERY('{"hello":1}', '$[\'hello\']');


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix 

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix the JSON_QUERY function can not parse the json string while path is numberic. like in the query SELECT JSON_QUERY('{"123":"abcd"}', '$.123'), we would encounter the exceptions
```
DB::Exception: Unable to parse JSONPath: While processing JSON_QUERY('{"123":"acd"}', '$.123'). (BAD_ARGUMENTS)
```

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
