### PR TITLE
Update materialized_with_ddl.py

### DIFF
--- a/tests/integration/test_materialized_mysql_database/materialized_with_ddl.py
+++ b/tests/integration/test_materialized_mysql_database/materialized_with_ddl.py
@@ -1249,7 +1249,7 @@ def err_sync_user_privs_with_materialized_mysql_database(
     )
     assert "priv_err_db" in clickhouse_node.query("SHOW DATABASES")
     assert "test_table_1" not in clickhouse_node.query("SHOW TABLES FROM priv_err_db")
-    clickhouse_node.query_with_retry("DETACH DATABASE priv_err_db")
+    clickhouse_node.query_with_retry("DETACH DATABASE priv_err_db SYNC")
 
     mysql_node.query("REVOKE SELECT ON priv_err_db.* FROM 'test'@'%'")
     time.sleep(3)
@@ -1442,7 +1442,7 @@ def mysql_kill_sync_thread_restore_test(clickhouse_node, mysql_node, service_nam
             time.sleep(sleep_time)
             clickhouse_node.query("SELECT * FROM test_database.test_table")
 
-    clickhouse_node.query_with_retry("DETACH DATABASE test_database")
+    clickhouse_node.query_with_retry("DETACH DATABASE test_database SYNC")
     clickhouse_node.query("ATTACH DATABASE test_database")
     check_query(
         clickhouse_node,
@@ -1506,7 +1506,7 @@ def mysql_killed_while_insert(clickhouse_node, mysql_node, service_name):
 
         mysql_node.alloc_connection()
 
-        clickhouse_node.query_with_retry("DETACH DATABASE kill_mysql_while_insert")
+        clickhouse_node.query_with_retry("DETACH DATABASE kill_mysql_while_insert SYNC")
         clickhouse_node.query("ATTACH DATABASE kill_mysql_while_insert")
 
         result = mysql_node.query_and_get_data(
@@ -2593,7 +2593,7 @@ def named_collections(clickhouse_node, mysql_node, service_name):
         "1\ta\t1\n2\tb\t2\n",
     )
     clickhouse_node.query(f"ALTER NAMED COLLECTION {db} SET port=9999")
-    clickhouse_node.query(f"DETACH DATABASE {db}")
+    clickhouse_node.query_with_retry(f"DETACH DATABASE {db} SYNC")
     mysql_node.query(f"INSERT INTO {db}.t1 VALUES (3, 'c', 3)")
     assert "ConnectionFailed:" in clickhouse_node.query_and_get_error(
         f"ATTACH DATABASE {db}"


### PR DESCRIPTION

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Fixes flaky `test_materialized_mysql_database/test.py::test_named_collections`:
```
E           helpers.client.QueryRuntimeException: Client failed! Return code: 219, stderr: Received exception from server (version 23.8.1):
E           Code: 219. DB::Exception: Received from 172.16.14.4:9000. DB::Exception: Database named_collections cannot be detached, because some tables are still in use. Retry later.. Stack trace:
E           
E           0. DB::Exception::Exception(DB::Exception::MessageMasked&&, int, bool) @ 0x000000000c5f2a37 in /usr/bin/clickhouse
E           1. DB::Exception::Exception<String>(int, FormatStringHelperImpl<std::type_identity<String>::type>, String&&) @ 0x0000000007099e6d in /usr/bin/clickhouse
E           2. DB::DatabaseAtomic::assertCanBeDetached(bool) @ 0x00000000112bb513 in /usr/bin/clickhouse
E           3. DB::InterpreterDropQuery::execute() @ 0x0000000011bf5615 in /usr/bin/clickhouse
E           4. DB::executeQueryImpl(char const*, char const*, std::shared_ptr<DB::Context>, bool, DB::QueryProcessingStage::Enum, DB::ReadBuffer*) @ 0x000000001210de0e in /usr/bin/clickhouse
E           5. DB::executeQuery(String const&, std::shared_ptr<DB::Context>, bool, DB::QueryProcessingStage::Enum) @ 0x000000001210966e in /usr/bin/clickhouse
E           6. DB::TCPHandler::runImpl() @ 0x0000000012fba5f9 in /usr/bin/clickhouse
E           7. DB::TCPHandler::run() @ 0x0000000012fcc3b9 in /usr/bin/clickhouse
E           8. Poco::Net::TCPServerConnection::start() @ 0x00000000159a1a34 in /usr/bin/clickhouse
E           9. Poco::Net::TCPServerDispatcher::run() @ 0x00000000159a2c31 in /usr/bin/clickhouse
E           10. Poco::PooledThread::run() @ 0x0000000015ad8d67 in /usr/bin/clickhouse
E           11. Poco::ThreadImpl::runnableEntry(void*) @ 0x0000000015ad703c in /usr/bin/clickhouse
E           12. ? @ 0x00007fbf27413b43 in ?
E           13. ? @ 0x00007fbf274a5a00 in ?
E           . (DATABASE_NOT_EMPTY)
E           (query: DETACH DATABASE named_collections)
```

Related to https://github.com/ClickHouse/ClickHouse/pull/53032