### PR TITLE
Fix a race condition between RESTART REPLICAS and DROP DATABASE

### DIFF
--- a/src/Interpreters/InterpreterDropQuery.cpp
+++ b/src/Interpreters/InterpreterDropQuery.cpp
@@ -432,8 +432,9 @@ AccessRightsElements InterpreterDropQuery::getRequiredAccessForDDLOnCluster() co
 }
 
 void InterpreterDropQuery::executeDropQuery(ASTDropQuery::Kind kind, ContextPtr global_context, ContextPtr current_context,
-                                            const StorageID & target_table_id, bool sync, bool ignore_sync_setting)
+                                            const StorageID & target_table_id, bool sync, bool ignore_sync_setting, bool need_ddl_guard)
 {
+    auto ddl_guard = (need_ddl_guard ? DatabaseCatalog::instance().getDDLGuard(target_table_id.database_name, target_table_id.table_name) : nullptr);
     if (DatabaseCatalog::instance().tryGetTable(target_table_id, current_context))
     {
         /// We create and execute `drop` query for internal table.

--- a/src/Interpreters/InterpreterDropQuery.h
+++ b/src/Interpreters/InterpreterDropQuery.h
@@ -25,7 +25,7 @@ public:
     BlockIO execute() override;
 
     static void executeDropQuery(ASTDropQuery::Kind kind, ContextPtr global_context, ContextPtr current_context,
-                                 const StorageID & target_table_id, bool sync, bool ignore_sync_setting = false);
+                                 const StorageID & target_table_id, bool sync, bool ignore_sync_setting = false, bool need_ddl_guard = false);
 
     bool supportsTransactions() const override;
 

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -383,19 +383,19 @@ def get_stacktraces_from_clickhouse(args):
     )
     replicated_msg = (
         f"{args.client} {settings_str} --query "
-        '"SELECT materialize((hostName(), tcpPort())) as host, thread_id, '
+        '"SELECT materialize((hostName(), tcpPort())) as host, thread_name, thread_id, query_id, trace, '
         "arrayStringConcat(arrayMap(x, y -> concat(x, ': ', y), "
         "arrayMap(x -> addressToLine(x), trace), "
-        "arrayMap(x -> demangle(addressToSymbol(x)), trace)), '\n') as trace "
+        "arrayMap(x -> demangle(addressToSymbol(x)), trace)), '\n') as trace_str "
         "FROM clusterAllReplicas('test_cluster_database_replicated', 'system.stack_trace') "
         'ORDER BY host, thread_id FORMAT Vertical"'
     )
 
     msg = (
         f"{args.client} {settings_str} --query "
-        "\"SELECT arrayStringConcat(arrayMap(x, y -> concat(x, ': ', y), "
+        "\"SELECT thread_name, thread_id, query_id, trace, arrayStringConcat(arrayMap(x, y -> concat(x, ': ', y), "
         "arrayMap(x -> addressToLine(x), trace), "
-        "arrayMap(x -> demangle(addressToSymbol(x)), trace)), '\n') as trace "
+        "arrayMap(x -> demangle(addressToSymbol(x)), trace)), '\n') as trace_str "
         'FROM system.stack_trace FORMAT Vertical"'
     )
 


### PR DESCRIPTION

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Follow-up to https://github.com/ClickHouse/ClickHouse/pull/47863 

Fixes a deadlock: https://s3.amazonaws.com/clickhouse-test-reports/0/428a05a560dd9561f1729c38b963250b980c2f19/stateless_tests__aarch64_.html

https://s3.amazonaws.com/clickhouse-test-reports/0/67b45619eb30490012c1b9800717f305a531cb90/stateless_tests__release__analyzer_.html

```
2023-08-16 07:37:18 Row 340:
2023-08-16 07:37:18 ────────
2023-08-16 07:37:18 trace: /usr/lib/aarch64-linux-gnu/libc.so.6: 
2023-08-16 07:37:18 ./build_docker/./contrib/llvm-project/libcxx/include/atomic:1026: bool std::__1::__libcpp_thread_poll_with_backoff[abi:v15000]<std::__1::__cxx_atomic_wait_test_fn_impl<std::__1::__cxx_atomic_impl<bool, std::__1::__cxx_atomic_base_impl<bool>>, bool>&, std::__1::__libcpp_atomic_wait_backoff_impl<std::__1::__cxx_atomic_impl<bool, std::__1::__cxx_atomic_base_impl<bool>>, std::__1::__cxx_atomic_wait_test_fn_impl<std::__1::__cxx_atomic_impl<bool, std::__1::__cxx_atomic_base_impl<bool>>, bool>>&>(std::__1::__cxx_atomic_wait_test_fn_impl<std::__1::__cxx_atomic_impl<bool, std::__1::__cxx_atomic_base_impl<bool>>, bool>&, std::__1::__libcpp_atomic_wait_backoff_impl<std::__1::__cxx_atomic_impl<bool, std::__1::__cxx_atomic_base_impl<bool>>, std::__1::__cxx_atomic_wait_test_fn_impl<std::__1::__cxx_atomic_impl<bool, std::__1::__cxx_atomic_base_impl<bool>>, bool>>&, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1000000000l>>)
2023-08-16 07:37:18 ./build_docker/./contrib/llvm-project/libcxx/include/atomic:0: DB::StorageReplicatedMergeTree::startup()
2023-08-16 07:37:18 ./build_docker/./src/Common/CurrentThread.cpp:94: DB::InterpreterSystemQuery::tryRestartReplica(DB::StorageID const&, std::__1::shared_ptr<DB::Context>, bool)
2023-08-16 07:37:18 ./build_docker/./contrib/llvm-project/libcxx/include/__memory/shared_ptr.h:701: void std::__1::__function::__policy_invoker<void ()>::__call_impl<std::__1::__function::__default_alloc_func<DB::InterpreterSystemQuery::restartReplicas(std::__1::shared_ptr<DB::Context>)::$_0, void ()>>(std::__1::__function::__policy_storage const*)
2023-08-16 07:37:18 ./build_docker/./base/base/../base/wide_integer_impl.h:809: ThreadPoolImpl<ThreadFromGlobalPoolImpl<false>>::worker(std::__1::__list_iterator<ThreadFromGlobalPoolImpl<false>, void*>)
2023-08-16 07:37:18 ./build_docker/./src/Common/ThreadPool.h:243: void std::__1::__function::__policy_invoker<void ()>::__call_impl<std::__1::__function::__default_alloc_func<ThreadFromGlobalPoolImpl<false>::ThreadFromGlobalPoolImpl<void ThreadPoolImpl<ThreadFromGlobalPoolImpl<false>>::scheduleImpl<void>(std::__1::function<void ()>, Priority, std::__1::optional<unsigned long>, bool)::'lambda0'()>(void&&)::'lambda'(), void ()>>(std::__1::__function::__policy_storage const*)
2023-08-16 07:37:18 ./build_docker/./base/base/../base/wide_integer_impl.h:809: void* std::__1::__thread_proxy[abi:v15000]<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, void ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, Priority, std::__1::optional<unsigned long>, bool)::'lambda0'()>>(void*)
2023-08-16 07:37:18 /usr/lib/aarch64-linux-gnu/libc.so.6: 
2023-08-16 07:37:18 /usr/lib/aarch64-linux-gnu/libc.so.6: 

2023-08-16 07:37:18 Row 2065:
2023-08-16 07:37:18 ─────────
2023-08-16 07:37:18 trace: /usr/lib/aarch64-linux-gnu/libc.so.6: 
2023-08-16 07:37:18 /usr/lib/aarch64-linux-gnu/libc.so.6: 
2023-08-16 07:37:18 ./build_docker/./contrib/llvm-project/libcxx/include/atomic:958: DB::DDLGuard::DDLGuard(std::__1::map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, DB::DDLGuard::Entry, std::__1::less<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const, DB::DDLGuard::Entry>>>&, DB::SharedMutex&, std::__1::unique_lock<std::__1::mutex>, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&)
2023-08-16 07:37:18 ./build_docker/./contrib/llvm-project/libcxx/include/__mutex_base:143: DB::DatabaseCatalog::getDDLGuard(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&)
2023-08-16 07:37:18 ./build_docker/./contrib/llvm-project/libcxx/include/__memory/unique_ptr.h:302: DB::InterpreterSystemQuery::restartReplicas(std::__1::shared_ptr<DB::Context>)
2023-08-16 07:37:18 ./build_docker/./src/Interpreters/InterpreterSystemQuery.cpp:538: DB::InterpreterSystemQuery::execute()
2023-08-16 07:37:18 ./build_docker/./src/Interpreters/executeQuery.cpp:0: DB::executeQueryImpl(char const*, char const*, std::__1::shared_ptr<DB::Context>, bool, DB::QueryProcessingStage::Enum, DB::ReadBuffer*)
2023-08-16 07:37:18 ./build_docker/./contrib/llvm-project/libcxx/include/__memory/shared_ptr.h:612: DB::executeQuery(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::shared_ptr<DB::Context>, bool, DB::QueryProcessingStage::Enum)
2023-08-16 07:37:18 ./build_docker/./src/Server/TCPHandler.cpp:424: DB::TCPHandler::runImpl()
2023-08-16 07:37:18 ./build_docker/./src/Common/CurrentThread.cpp:94: DB::TCPHandler::run()
2023-08-16 07:37:18 ./build_docker/./base/poco/Net/src/TCPServerConnection.cpp:57: Poco::Net::TCPServerConnection::start()
2023-08-16 07:37:18 ./build_docker/./contrib/llvm-project/libcxx/include/__memory/unique_ptr.h:48: Poco::Net::TCPServerDispatcher::run()
2023-08-16 07:37:18 ./build_docker/./base/poco/Foundation/src/ThreadPool.cpp:202: Poco::PooledThread::run()
2023-08-16 07:37:18 ./build_docker/./base/poco/Foundation/include/Poco/SharedPtr.h:231: Poco::ThreadImpl::runnableEntry(void*)
2023-08-16 07:37:18 /usr/lib/aarch64-linux-gnu/libc.so.6: 
2023-08-16 07:37:18 /usr/lib/aarch64-linux-gnu/libc.so.6: 
```

RESTART REPLICAS waits for the table to be started, but it will never be, because it was dropped:
```
2023.08.12 06:46:09.079106 [ 35181 ] {} <Trace> InterpreterSystemQuery: Restarting replica db_test_xtl0mbyo.`.inner_id.53dc3af6-2043-45e7-b46b-b6d193a35b7d`
...
548741:2023.08.12 06:46:09.128865 [ 35181 ] {} <Debug> db_test_xtl0mbyo.`.inner_id.53dc3af6-2043-45e7-b46b-b6d193a35b7d` (6f4f2b9e-5797-4d71-b997-ac4e378ce172): Loaded data parts (6 items)
548742:2023.08.12 06:46:09.128882 [ 35181 ] {} <Information> db_test_xtl0mbyo.`.inner_id.53dc3af6-2043-45e7-b46b-b6d193a35b7d` (6f4f2b9e-5797-4d71-b997-ac4e378ce172): Table will be in readonly mode until initialization is finished
548743:2023.08.12 06:46:09.128919 [ 35181 ] {} <Trace> db_test_xtl0mbyo.`.inner_id.53dc3af6-2043-45e7-b46b-b6d193a35b7d` (6f4f2b9e-5797-4d71-b997-ac4e378ce172): Starting up table
548753:2023.08.12 06:46:09.133544 [ 33677 ] {bd489dad-77e4-454a-8d2d-07f463036be8} <Trace> db_test_xtl0mbyo.`.inner_id.53dc3af6-2043-45e7-b46b-b6d193a35b7d` (6f4f2b9e-5797-4d71-b997-ac4e378ce172): stopBeingLeader called but we are not a leader already
548754:2023.08.12 06:46:09.133843 [ 33677 ] {bd489dad-77e4-454a-8d2d-07f463036be8} <Information> db_test_xtl0mbyo.`.inner_id.53dc3af6-2043-45e7-b46b-b6d193a35b7d` (ReplicatedMergeTreeAttachThread): Attach thread finished
548755:2023.08.12 06:46:09.133850 [ 33677 ] {bd489dad-77e4-454a-8d2d-07f463036be8} <Trace> db_test_xtl0mbyo.`.inner_id.53dc3af6-2043-45e7-b46b-b6d193a35b7d` (ReplicatedMergeTreeRestartingThread): Restarting thread finished
```