### PR TITLE
Add ability to turn off flush of Distributed on DETACH/DROP/server shutdown

### DIFF
--- a/src/Storages/Distributed/DistributedSettings.h
+++ b/src/Storages/Distributed/DistributedSettings.h
@@ -26,6 +26,7 @@ class ASTStorage;
     M(UInt64, monitor_split_batch_on_failure, 0, "Default - distributed_directory_monitor_split_batch_on_failure", 0) \
     M(Milliseconds, monitor_sleep_time_ms, 0, "Default - distributed_directory_monitor_sleep_time_ms", 0) \
     M(Milliseconds, monitor_max_sleep_time_ms, 0, "Default - distributed_directory_monitor_max_sleep_time_ms", 0) \
+    M(Bool, flush_on_detach, true, "Flush data to remote nodes on DETACH/DROP/server shutdown", 0) \
 
 DECLARE_SETTINGS_TRAITS(DistributedSettingsTraits, LIST_OF_DISTRIBUTED_SETTINGS)
 

--- a/src/Storages/StorageDistributed.cpp
+++ b/src/Storages/StorageDistributed.cpp
@@ -1438,6 +1438,12 @@ ActionLock StorageDistributed::getActionLock(StorageActionBlockType type)
 
 void StorageDistributed::flushAndPrepareForShutdown()
 {
+    if (!getDistributedSettingsRef().flush_on_detach)
+    {
+        LOG_INFO(log, "Skip flushing data (due to flush_on_detach=0)");
+        return;
+    }
+
     try
     {
         flushClusterNodesAllData(getContext());

--- a/tests/queries/0_stateless/02860_distributed_flush_on_detach.reference
+++ b/tests/queries/0_stateless/02860_distributed_flush_on_detach.reference
@@ -1,0 +1,27 @@
+-- { echoOn }
+
+create table data (key Int) engine=Memory();
+create table dist (key Int) engine=Distributed(default, currentDatabase(), data);
+system stop distributed sends dist;
+-- check that FLUSH DISTRIBUTED does flushing anyway
+insert into dist values (1);
+select * from data;
+system flush distributed dist;
+select * from data;
+1
+truncate table data;
+-- check that flush_on_detach=1 by default
+insert into dist values (1);
+detach table dist;
+select * from data;
+1
+attach table dist;
+truncate table data;
+-- check flush_on_detach=0
+drop table dist;
+create table dist (key Int) engine=Distributed(default, currentDatabase(), data) settings flush_on_detach=0;
+system stop distributed sends dist;
+insert into dist values (1);
+detach table dist;
+select * from data;
+attach table dist;

--- a/tests/queries/0_stateless/02860_distributed_flush_on_detach.sql
+++ b/tests/queries/0_stateless/02860_distributed_flush_on_detach.sql
@@ -1,0 +1,33 @@
+set prefer_localhost_replica=0;
+
+drop table if exists data;
+drop table if exists dist;
+
+-- { echoOn }
+
+create table data (key Int) engine=Memory();
+create table dist (key Int) engine=Distributed(default, currentDatabase(), data);
+system stop distributed sends dist;
+
+-- check that FLUSH DISTRIBUTED does flushing anyway
+insert into dist values (1);
+select * from data;
+system flush distributed dist;
+select * from data;
+truncate table data;
+
+-- check that flush_on_detach=1 by default
+insert into dist values (1);
+detach table dist;
+select * from data;
+attach table dist;
+truncate table data;
+
+-- check flush_on_detach=0
+drop table dist;
+create table dist (key Int) engine=Distributed(default, currentDatabase(), data) settings flush_on_detach=0;
+system stop distributed sends dist;
+insert into dist values (1);
+detach table dist;
+select * from data;
+attach table dist;


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add ability to turn off flush of Distributed tables on `DETACH`/`DROP`/server shutdown (`flush_on_detach` setting for `Distributed`)

Sometimes you can have tons of data there, i.e. few TiBs, and sending them on server shutdown does not looks sane (maybe there is a bug and you need to update/restart to fix flushing).

Refs: #53408 (cc @tavplubix )