### PR TITLE
Added waiting for PostgreSQL compatibility port open in integrational tests.

### DIFF
--- a/tests/integration/test_postgresql_protocol/test.py
+++ b/tests/integration/test_postgresql_protocol/test.py
@@ -40,7 +40,10 @@ server_port = 5433
 def started_cluster():
     try:
         cluster.start()
-
+        # Wait for the PostgreSQL handler to start.
+        # Cluster.start waits until port 9000 becomes accessible.
+        # Server opens the PostgreSQL compatibility port a bit later.
+        cluster.instances["node"].wait_for_log_line("PostgreSQL compatibility protocol")
         yield cluster
     except Exception as ex:
         logging.exception(ex)

--- a/tests/integration/test_profile_max_sessions_for_user/test.py
+++ b/tests/integration/test_profile_max_sessions_for_user/test.py
@@ -108,6 +108,10 @@ def threaded_run_test(sessions):
 def started_cluster():
     try:
         cluster.start()
+        # Wait for the PostgreSQL handler to start.
+        # Cluster.start waits until port 9000 becomes accessible.
+        # Server opens the PostgreSQL compatibility port a bit later.
+        instance.wait_for_log_line("PostgreSQL compatibility protocol")
         yield cluster
     finally:
         cluster.shutdown()

--- a/tests/integration/test_session_log/test.py
+++ b/tests/integration/test_session_log/test.py
@@ -1,5 +1,4 @@
 import os
-
 import grpc
 import pymysql.connections
 import pytest
@@ -130,6 +129,10 @@ def mysql_query(query, user_, pass_, raise_exception):
 def started_cluster():
     try:
         cluster.start()
+        # Wait for the PostgreSQL handler to start.
+        # Cluster.start waits until port 9000 becomes accessible.
+        # Server opens the PostgreSQL compatibility port a bit later.
+        instance.wait_for_log_line("PostgreSQL compatibility protocol")
         yield cluster
     finally:
         cluster.shutdown()

--- a/tests/integration/test_storage_postgresql/test.py
+++ b/tests/integration/test_storage_postgresql/test.py
@@ -26,6 +26,10 @@ def started_cluster():
         cluster.start()
         node1.query("CREATE DATABASE test")
         node2.query("CREATE DATABASE test")
+        # Wait for the PostgreSQL handler to start.
+        # cluster.start waits until port 9000 becomes accessible.
+        # Server opens the PostgreSQL compatibility port a bit later.
+        node1.wait_for_log_line("PostgreSQL compatibility protocol")
         yield cluster
 
     finally:


### PR DESCRIPTION
ClickHouseCluster.start waits until port 9000 becomes accessible. PostgreSQL compatibility port may not have been opened yet.
The connection to the ClickHouse server may fail if ClickHouse doesn't have enough time to start.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

