### PR TITLE
Allow non standalone keeper run in integration tests

### DIFF
--- a/docker/test/integration/runner/compose/docker_compose_keeper.yml
+++ b/docker/test/integration/runner/compose/docker_compose_keeper.yml
@@ -20,6 +20,9 @@ services:
             - type: ${keeper_fs:-tmpfs}
               source: ${keeper_db_dir1:-}
               target: /var/lib/clickhouse-keeper
+            - type: ${keeper_fs:-tmpfs}
+              source: ${keeper_db_dir1:-}
+              target: /var/lib/clickhouse
         entrypoint: "${keeper_cmd_prefix:-clickhouse keeper} --config=/etc/clickhouse-keeper/keeper_config1.xml --log-file=/var/log/clickhouse-keeper/clickhouse-keeper.log --errorlog-file=/var/log/clickhouse-keeper/clickhouse-keeper.err.log"
         cap_add:
             - SYS_PTRACE
@@ -53,6 +56,9 @@ services:
             - type: ${keeper_fs:-tmpfs}
               source: ${keeper_db_dir2:-}
               target: /var/lib/clickhouse-keeper
+            - type: ${keeper_fs:-tmpfs}
+              source: ${keeper_db_dir1:-}
+              target: /var/lib/clickhouse
         entrypoint: "${keeper_cmd_prefix:-clickhouse keeper} --config=/etc/clickhouse-keeper/keeper_config2.xml --log-file=/var/log/clickhouse-keeper/clickhouse-keeper.log --errorlog-file=/var/log/clickhouse-keeper/clickhouse-keeper.err.log"
         cap_add:
             - SYS_PTRACE
@@ -86,6 +92,9 @@ services:
             - type: ${keeper_fs:-tmpfs}
               source: ${keeper_db_dir3:-}
               target: /var/lib/clickhouse-keeper
+            - type: ${keeper_fs:-tmpfs}
+              source: ${keeper_db_dir1:-}
+              target: /var/lib/clickhouse
         entrypoint: "${keeper_cmd_prefix:-clickhouse keeper} --config=/etc/clickhouse-keeper/keeper_config3.xml --log-file=/var/log/clickhouse-keeper/clickhouse-keeper.log --errorlog-file=/var/log/clickhouse-keeper/clickhouse-keeper.err.log"
         cap_add:
             - SYS_PTRACE


### PR DESCRIPTION
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)

Non-standalone keeper needs `/var/lib/clickhouse` to run


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
