### PR TITLE
Make sending logs to the cloud less fragile (and fix an unrelated flaky test)

### DIFF
--- a/docker/test/base/setup_export_logs.sh
+++ b/docker/test/base/setup_export_logs.sh
@@ -17,6 +17,9 @@ CONNECTION_PARAMETERS=${CONNECTION_PARAMETERS:=""}
 # Create all configured system logs:
 clickhouse-client --query "SYSTEM FLUSH LOGS"
 
+# It's doesn't make sense to try creating tables if SYNC fails
+echo "SYSTEM SYNC DATABASE REPLICA default" clickhouse-client --receive_timeout 180 $CONNECTION_PARAMETERS || exit 0
+
 # For each system log table:
 clickhouse-client --query "SHOW TABLES FROM system LIKE '%\\_log'" | while read -r table
 do
@@ -38,7 +41,7 @@ do
 
     echo "Creating destination table ${table}_${hash}" >&2
 
-    echo "$statement" | clickhouse-client $CONNECTION_PARAMETERS
+    echo "$statement" | clickhouse-client --distributed_ddl_task_timeout=10 $CONNECTION_PARAMETERS || continue
 
     echo "Creating table system.${table}_sender" >&2
 
@@ -46,6 +49,7 @@ do
     clickhouse-client --query "
         CREATE TABLE system.${table}_sender
         ENGINE = Distributed(${CLUSTER}, default, ${table}_${hash})
+        SETTINGS flush_on_detach=0
         EMPTY AS
         SELECT ${EXTRA_COLUMNS_EXPRESSION}, *
         FROM system.${table}

--- a/tests/queries/0_stateless/02443_detach_attach_partition.sh
+++ b/tests/queries/0_stateless/02443_detach_attach_partition.sh
@@ -30,17 +30,24 @@ function thread_attach()
 }
 
 insert_type=$(($RANDOM % 3))
+if [[ "$engine" == "ReplicatedMergeTree" ]]; then
+    insert_type=$(($RANDOM % 2))
+fi
 $CLICKHOUSE_CLIENT -q "SELECT '$CLICKHOUSE_DATABASE', 'insert_type $insert_type' FORMAT Null"
 
 function insert()
 {
     # Fault injection may lead to duplicates
     if [[ "$insert_type" -eq 0 ]]; then
-        $CLICKHOUSE_CLIENT --insert_deduplication_token=$1 -q "INSERT INTO alter_table$(($RANDOM % 2)) SELECT $RANDOM, $1" 2>/dev/null
+        $CLICKHOUSE_CLIENT --insert_keeper_fault_injection_probability=0 -q "INSERT INTO alter_table$(($RANDOM % 2)) SELECT $RANDOM, $1" 2>/dev/null
     elif [[ "$insert_type" -eq 1 ]]; then
         $CLICKHOUSE_CLIENT -q "INSERT INTO alter_table$(($RANDOM % 2)) SELECT $1, $1" 2>/dev/null
     else
-        $CLICKHOUSE_CLIENT --insert_keeper_fault_injection_probability=0 -q "INSERT INTO alter_table$(($RANDOM % 2)) SELECT $RANDOM, $1" 2>/dev/null
+        # It may reproduce something interesting: if the insert status is unknown (due to fault injection in retries)
+        # and the part was committed locally but not in zk, then it will be active and DETACH may detach it.
+        # And we will ATTACH it later. But the next INSERT attempt will not be deduplicated because the first one failed.
+        # So we will get duplicates.
+        $CLICKHOUSE_CLIENT --insert_deduplication_token=$1 -q "INSERT INTO alter_table$(($RANDOM % 2)) SELECT $RANDOM, $1" 2>/dev/null
     fi
 }
 


### PR DESCRIPTION

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


See https://github.com/ClickHouse/ClickHouse/issues/53408 (`SETTINGS flush_on_detach=0` is supposed to fix that)

Also, Fuzzers fail like this:
https://s3.amazonaws.com/clickhouse-test-reports/53424/9e69120bee9e0b256b1e4124eec2d31c3bd232fd/fuzzer_astfuzzerasan/run.log
```
/bin/bash: line 1:     7 Killed                  timeout -s 9 1h /run-fuzzer.sh 2>&1
         8 Done                    | ts "$(printf '%%Y-%%m-%%d %%H:%%M:%%S\t')"
         9 Done                    | tee main.log
```
because of 
```
023-08-17 13:59:44	 (query: CREATE TABLE IF NOT EXISTS asynchronous_insert_log_12366379321827847140
2023-08-17 13:59:44	 (pull_request_number UInt32, commit_sha String, check_start_time DateTime, check_name LowCardinality(String), instance_type LowCardinality(String), 
2023-08-17 13:59:44	     `event_date` Date,
2023-08-17 13:59:44	     `event_time` DateTime,
2023-08-17 13:59:44	     `event_time_microseconds` DateTime64(6),
2023-08-17 13:59:44	     `query` String,
2023-08-17 13:59:44	     `database` LowCardinality(String),
2023-08-17 13:59:44	     `table` LowCardinality(String),
2023-08-17 13:59:44	     `format` LowCardinality(String),
2023-08-17 13:59:44	     `query_id` String,
2023-08-17 13:59:44	     `bytes` UInt64,
2023-08-17 13:59:44	     `rows` UInt64,
2023-08-17 13:59:44	     `exception` String,
2023-08-17 13:59:44	     `status` Enum8('Ok' = 0, 'ParsingError' = 1, 'FlushError' = 2),
2023-08-17 13:59:44	     `flush_time` DateTime,
2023-08-17 13:59:44	     `flush_time_microseconds` DateTime64(6),
2023-08-17 13:59:44	     `flush_query_id` String
2023-08-17 13:59:44	 )
2023-08-17 13:59:44	 ENGINE = MergeTree
2023-08-17 13:59:44	 PARTITION BY event_date
2023-08-17 13:59:44	 ORDER BY (check_name, database, table, event_date, event_time)
2023-08-17 13:59:44	 SETTINGS index_granularity = 8192
2023-08-17 13:59:44	 )
2023-08-17 13:59:44	 Creating table system.asynchronous_insert_log_sender
2023-08-17 13:59:44	 Creating materialized view system.asynchronous_insert_log_watcher
2023-08-17 13:59:45	 Creating destination table asynchronous_metric_log_554766996599054438
2023-08-17 14:02:46	 Received exception from server (version 23.8.1):
2023-08-17 14:02:46	 Code: 159. DB::Exception: Received from CLICKHOUSE_CI_LOGS_HOST:9440. DB::Exception: Watching task /clickhouse/databases/default/log/query-0000109227 is executing longer than distributed_ddl_task_timeout (=180) seconds. There are 3 unfinished hosts (0 of them are currently active), they are going to execute the query in background. (TIMEOUT_EXCEEDED)
2023-08-17 14:02:46	 (query: CREATE TABLE IF NOT EXISTS asynchronous_metric_log_554766996599054438
2023-08-17 14:02:46	 (pull_request_number UInt32, commit_sha String, check_start_time DateTime, check_name LowCardinality(String), instance_type LowCardinality(String), 
2023-08-17 14:02:46	     `event_date` Date CODEC(Delta(2), ZSTD(1)),
2023-08-17 14:02:46	     `event_time` DateTime CODEC(Delta(4), ZSTD(1)),
2023-08-17 14:02:46	     `metric` LowCardinality(String) CODEC(ZSTD(1)),
2023-08-17 14:02:46	     `value` Float64 CODEC(ZSTD(3))
2023-08-17 14:02:46	 )
2023-08-17 14:02:46	 ENGINE = MergeTree
2023-08-17 14:02:46	 PARTITION BY toYYYYMM(event_date)
2023-08-17 14:02:46	 ORDER BY (check_name, metric, event_date, event_time)
2023-08-17 14:02:46	 SETTINGS index_granularity = 8192
2023-08-17 14:02:46	 )
2023-08-17 14:02:46	 Creating table system.asynchronous_metric_log_sender
2023-08-17 14:02:46	 Creating materialized view system.asynchronous_metric_log_watcher
2023-08-17 14:02:47	 Creating destination table crash_log_18405985218782237968
2023-08-17 14:05:48	 Received exception from server (version 23.8.1):
2023-08-17 14:05:48	 Code: 159. DB::Exception: Received from CLICKHOUSE_CI_LOGS_HOST:9440. DB::Exception: Watching task /clickhouse/databases/default/log/query-0000109327 is executing longer than distributed_ddl_task_timeout (=180) seconds. There are 3 unfinished hosts (0 of them are currently active), they are going to execute the query in background. (TIMEOUT_EXCEEDED)
...
```