### PR TITLE
Fix `AddressSanitizer failed to allocate 0x0 (0) bytes of SetAlternateSignalStack` in integration tests

### DIFF
--- a/tests/integration/helpers/client.py
+++ b/tests/integration/helpers/client.py
@@ -182,7 +182,8 @@ class CommandRequest:
         # we suppress stderror on client becase sometimes thread sanitizer
         # can print some debug information there
         env = {}
-        env["TSAN_OPTIONS"] = "verbosity=0"
+        env["ASAN_OPTIONS"] = "use_sigaltstack=0"
+        env["TSAN_OPTIONS"] = "use_sigaltstack=0 verbosity=0"
         self.process = sp.Popen(
             command,
             stdin=stdin_file,


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

We pass the same flags [here](https://github.com/ClickHouse/ClickHouse/blob/master/tests/integration/helpers/cluster.py#L386-L387) through the env-file to docker compose. 

https://s3.amazonaws.com/clickhouse-test-reports/51163/662152dddc1280023ba04956f6f0d0c2d2b96785/integration_tests__asan__[4_6].html