### PR TITLE
bugfix: Flush async insert queue first on shutdown

### DIFF
--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -479,6 +479,9 @@ struct ContextSharedPart : boost::noncopyable
             return;
         shutdown_called = true;
 
+        /// Need to flush the async insert queue before shutting down the database catalog
+        async_insert_queue.reset();
+
         /// Stop periodic reloading of the configuration files.
         /// This must be done first because otherwise the reloading may pass a changed config
         /// to some destroyed parts of ContextSharedPart.

--- a/tests/integration/test_restart_server/test.py
+++ b/tests/integration/test_restart_server/test.py
@@ -24,11 +24,13 @@ def test_drop_memory_database():
 
 def test_flushes_async_insert_queue():
     node.query(
-        "CREATE TABLE flush_test (a String, b UInt64) ENGINE = MergeTree ORDER BY a;"
+        """
+    CREATE TABLE flush_test (a String, b UInt64) ENGINE = MergeTree ORDER BY a;
+    SET async_insert = 1;
+    SET wait_for_async_insert = 0;
+    SET async_insert_busy_timeout_ms = 1000000;
+    INSERT INTO flush_test VALUES ('world', 23456);
+    """
     )
-    node.query("SET async_insert = 1;")
-    node.query("SET wait_for_async_insert = 0;")
-    node.query("SET async_insert_busy_timeout_ms = 1000000;")
-    node.query("INSERT INTO flush_test VALUES ('world', 23456);")
     node.restart_clickhouse()
     assert node.query("SELECT * FROM flush_test") == "world\t23456\n"

--- a/tests/integration/test_restart_server/test.py
+++ b/tests/integration/test_restart_server/test.py
@@ -5,7 +5,7 @@ cluster = ClickHouseCluster(__file__)
 node = cluster.add_instance("node", stay_alive=True)
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="module", autouse=True)
 def start_cluster():
     try:
         cluster.start()
@@ -14,9 +14,21 @@ def start_cluster():
         cluster.shutdown()
 
 
-def test_drop_memory_database(start_cluster):
+def test_drop_memory_database():
     node.query("CREATE DATABASE test ENGINE Memory")
     node.query("CREATE TABLE test.test_table(a String) ENGINE Memory")
     node.query("DROP DATABASE test")
     node.restart_clickhouse(kill=True)
     assert node.query("SHOW DATABASES LIKE 'test'").strip() == ""
+
+
+def test_flushes_async_insert_queue():
+    node.query(
+        "CREATE TABLE flush_test (a String, b UInt64) ENGINE = MergeTree ORDER BY a;"
+    )
+    node.query("SET async_insert = 1;")
+    node.query("SET wait_for_async_insert = 0;")
+    node.query("SET async_insert_busy_timeout_ms = 1000000;")
+    node.query("INSERT INTO flush_test VALUES ('world', 23456);")
+    node.restart_clickhouse()
+    assert node.query("SELECT * FROM flush_test") == "world\t23456\n"


### PR DESCRIPTION
Fixes bug where on graceful shutdown the database catalog is shutdown before queries in the async insert queue run, causing all the queries to fail and data to be lost.

Can easily recreate by running

```
CREATE TABLE test (a String, b UInt64) ENGINE = MergeTree ORDER BY a;
SET async_insert = 1;
SET wait_for_async_insert = 0;
SET async_insert_busy_timeout_ms = 1000000;
INSERT INTO test VALUES ('world', 23456);
```

then shutting down the server.  Expected behaviour: when ClickHouse is restarted, table `test` has 1 row.  Actual behaviour: Clickhouse logs an ERROR and when restarted table `test` has 0 rows.

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Fix bug in flushing of async insert queue on graceful shutdown.
