### PR TITLE
Enable ISA-L on x86-64 only by default

### DIFF
--- a/contrib/isa-l-cmake/CMakeLists.txt
+++ b/contrib/isa-l-cmake/CMakeLists.txt
@@ -1,6 +1,7 @@
 option(ENABLE_ISAL_LIBRARY "Enable ISA-L library" ${ENABLE_LIBRARIES})
-if (ARCH_AARCH64)
-    # Disable ISA-L libray on aarch64.
+
+# ISA-L is only available for x86-64, so it shall be disabled for other platforms
+if (NOT ARCH_AMD64)
     set (ENABLE_ISAL_LIBRARY OFF)
 endif ()
 


### PR DESCRIPTION
It seems that [ISA-L](https://github.com/intel/isa-l) is geared towards x86-64, so it'd be best if it was disabled on other platforms by default.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)