### PR TITLE
Bump openldap to LTS version (v2.5.16)

### DIFF
--- a/contrib/openldap-cmake/CMakeLists.txt
+++ b/contrib/openldap-cmake/CMakeLists.txt
@@ -99,6 +99,8 @@ set(_ldap_srcs
     "${OPENLDAP_SOURCE_DIR}/libraries/libldap/bind.c"
     "${OPENLDAP_SOURCE_DIR}/libraries/libldap/open.c"
     "${OPENLDAP_SOURCE_DIR}/libraries/libldap/result.c"
+    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/avl.c"
+    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/tavl.c"
     "${OPENLDAP_SOURCE_DIR}/libraries/libldap/error.c"
     "${OPENLDAP_SOURCE_DIR}/libraries/libldap/compare.c"
     "${OPENLDAP_SOURCE_DIR}/libraries/libldap/search.c"
@@ -161,6 +163,17 @@ set(_ldap_srcs
     "${OPENLDAP_SOURCE_DIR}/libraries/libldap/lbase64.c"
     "${OPENLDAP_SOURCE_DIR}/libraries/libldap/msctrl.c"
     "${OPENLDAP_SOURCE_DIR}/libraries/libldap/psearchctrl.c"
+
+    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/threads.c"
+    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/rdwr.c"
+    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/tpool.c"
+    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/rq.c"
+    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/thr_posix.c"
+    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/thr_thr.c"
+    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/thr_nt.c"
+    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/thr_pth.c"
+    # "${OPENLDAP_SOURCE_DIR}/libraries/libldap/thr_stub.c"
+    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/thr_debug.c"
 )
 
 mkversion(ldap)
@@ -185,43 +198,43 @@ target_compile_definitions(_ldap
     PRIVATE LDAP_LIBRARY
 )
 
-set(_ldap_r_specific_srcs
-    "${OPENLDAP_SOURCE_DIR}/libraries/libldap_r/threads.c"
-    "${OPENLDAP_SOURCE_DIR}/libraries/libldap_r/rdwr.c"
-    "${OPENLDAP_SOURCE_DIR}/libraries/libldap_r/tpool.c"
-    "${OPENLDAP_SOURCE_DIR}/libraries/libldap_r/rq.c"
-    "${OPENLDAP_SOURCE_DIR}/libraries/libldap_r/thr_posix.c"
-    "${OPENLDAP_SOURCE_DIR}/libraries/libldap_r/thr_thr.c"
-    "${OPENLDAP_SOURCE_DIR}/libraries/libldap_r/thr_nt.c"
-    "${OPENLDAP_SOURCE_DIR}/libraries/libldap_r/thr_pth.c"
-    "${OPENLDAP_SOURCE_DIR}/libraries/libldap_r/thr_stub.c"
-    "${OPENLDAP_SOURCE_DIR}/libraries/libldap_r/thr_debug.c"
-)
+# set(_ldap_r_specific_srcs
+#     "${OPENLDAP_SOURCE_DIR}/libraries/libldap/threads.c"
+#     "${OPENLDAP_SOURCE_DIR}/libraries/libldap/rdwr.c"
+#     "${OPENLDAP_SOURCE_DIR}/libraries/libldap/tpool.c"
+#     "${OPENLDAP_SOURCE_DIR}/libraries/libldap/rq.c"
+#     "${OPENLDAP_SOURCE_DIR}/libraries/libldap/thr_posix.c"
+#     "${OPENLDAP_SOURCE_DIR}/libraries/libldap/thr_thr.c"
+#     "${OPENLDAP_SOURCE_DIR}/libraries/libldap/thr_nt.c"
+#     "${OPENLDAP_SOURCE_DIR}/libraries/libldap/thr_pth.c"
+#     # "${OPENLDAP_SOURCE_DIR}/libraries/libldap/thr_stub.c"
+#     "${OPENLDAP_SOURCE_DIR}/libraries/libldap/thr_debug.c"
+# )
 
-mkversion(ldap_r)
+# mkversion(ldap_r)
 
-add_library(_ldap_r
-    ${_ldap_r_specific_srcs}
-    ${_ldap_srcs}
-    "${CMAKE_CURRENT_BINARY_DIR}/ldap_r-version.c"
-)
+# add_library(_ldap_r
+#     ${_ldap_r_specific_srcs}
+#     ${_ldap_srcs}
+#     "${CMAKE_CURRENT_BINARY_DIR}/ldap_r-version.c"
+# )
 
-target_link_libraries(_ldap_r
-    PRIVATE _lber
-    PRIVATE OpenSSL::Crypto OpenSSL::SSL
-)
+# target_link_libraries(_ldap_r
+#     PRIVATE _lber
+#     PRIVATE OpenSSL::Crypto OpenSSL::SSL
+# )
 
-target_include_directories(_ldap_r SYSTEM
-    PUBLIC ${_extra_build_dir}/include
-    PUBLIC "${OPENLDAP_SOURCE_DIR}/include"
-    PRIVATE "${OPENLDAP_SOURCE_DIR}/libraries/libldap_r"
-    PRIVATE "${OPENLDAP_SOURCE_DIR}/libraries/libldap"
-)
+# target_include_directories(_ldap_r SYSTEM
+#     PUBLIC ${_extra_build_dir}/include
+#     PUBLIC "${OPENLDAP_SOURCE_DIR}/include"
+#     PRIVATE "${OPENLDAP_SOURCE_DIR}/libraries/libldap_r"
+#     PRIVATE "${OPENLDAP_SOURCE_DIR}/libraries/libldap"
+# )
 
-target_compile_definitions(_ldap_r
-    PRIVATE LDAP_R_COMPILE
-    PRIVATE LDAP_LIBRARY
-)
+# target_compile_definitions(_ldap_r
+#     PRIVATE LDAP_R_COMPILE
+#     PRIVATE LDAP_LIBRARY
+# )
 
-add_library(ch_contrib::ldap ALIAS _ldap_r)
+add_library(ch_contrib::ldap ALIAS _ldap)
 add_library(ch_contrib::lber ALIAS _lber)

--- a/contrib/openldap-cmake/CMakeLists.txt
+++ b/contrib/openldap-cmake/CMakeLists.txt
@@ -96,84 +96,82 @@ target_compile_definitions(_lber
 )
 
 set(_ldap_srcs
-    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/bind.c"
-    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/open.c"
-    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/result.c"
-    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/avl.c"
-    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/tavl.c"
-    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/error.c"
-    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/compare.c"
-    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/search.c"
-    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/controls.c"
-    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/messages.c"
-    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/references.c"
-    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/extended.c"
-    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/cyrus.c"
-    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/modify.c"
-    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/add.c"
-    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/modrdn.c"
-    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/delete.c"
     "${OPENLDAP_SOURCE_DIR}/libraries/libldap/abandon.c"
-    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/sasl.c"
-    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/sbind.c"
-    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/unbind.c"
+    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/add.c"
+    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/addentry.c"
+    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/assertion.c"
+    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/avl.c"
+    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/bind.c"
     "${OPENLDAP_SOURCE_DIR}/libraries/libldap/cancel.c"
+    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/charray.c"
+    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/compare.c"
+    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/controls.c"
+    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/cyrus.c"
+    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/dds.c"
+    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/delete.c"
+    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/deref.c"
+    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/dnssrv.c"
+    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/error.c"
+    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/extended.c"
+    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/fetch.c"
     "${OPENLDAP_SOURCE_DIR}/libraries/libldap/filter.c"
     "${OPENLDAP_SOURCE_DIR}/libraries/libldap/free.c"
-    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/sort.c"
-    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/passwd.c"
-    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/whoami.c"
-    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/vc.c"
+    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/getattr.c"
     "${OPENLDAP_SOURCE_DIR}/libraries/libldap/getdn.c"
     "${OPENLDAP_SOURCE_DIR}/libraries/libldap/getentry.c"
-    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/getattr.c"
     "${OPENLDAP_SOURCE_DIR}/libraries/libldap/getvalues.c"
-    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/addentry.c"
-    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/request.c"
-    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/os-ip.c"
-    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/url.c"
-    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/pagectrl.c"
-    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/sortctrl.c"
-    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/vlvctrl.c"
     "${OPENLDAP_SOURCE_DIR}/libraries/libldap/init.c"
-    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/options.c"
-    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/print.c"
-    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/string.c"
-    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/util-int.c"
-    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/schema.c"
-    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/charray.c"
-    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/os-local.c"
-    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/dnssrv.c"
-    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/utf-8.c"
-    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/utf-8-conv.c"
-    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/tls2.c"
-    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/tls_o.c"
-    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/tls_g.c"
-    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/turn.c"
-    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/ppolicy.c"
-    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/dds.c"
-    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/txn.c"
-    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/ldap_sync.c"
-    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/stctrl.c"
-    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/assertion.c"
-    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/deref.c"
-    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/ldifutil.c"
-    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/ldif.c"
-    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/fetch.c"
     "${OPENLDAP_SOURCE_DIR}/libraries/libldap/lbase64.c"
+    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/ldap_sync.c"
+    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/ldif.c"
+    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/ldifutil.c"
+    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/messages.c"
+    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/modify.c"
+    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/modrdn.c"
     "${OPENLDAP_SOURCE_DIR}/libraries/libldap/msctrl.c"
+    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/open.c"
+    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/options.c"
+    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/os-ip.c"
+    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/os-local.c"
+    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/pagectrl.c"
+    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/passwd.c"
+    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/ppolicy.c"
+    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/print.c"
     "${OPENLDAP_SOURCE_DIR}/libraries/libldap/psearchctrl.c"
-
-    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/threads.c"
     "${OPENLDAP_SOURCE_DIR}/libraries/libldap/rdwr.c"
-    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/tpool.c"
+    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/references.c"
+    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/request.c"
+    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/result.c"
     "${OPENLDAP_SOURCE_DIR}/libraries/libldap/rq.c"
-    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/thr_posix.c"
-    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/thr_thr.c"
-    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/thr_nt.c"
-    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/thr_pth.c"
-    # "${OPENLDAP_SOURCE_DIR}/libraries/libldap/thr_stub.c"
+    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/sasl.c"
+    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/sbind.c"
+    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/schema.c"
+    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/search.c"
+    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/sort.c"
+    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/sortctrl.c"
+    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/stctrl.c"
+    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/string.c"
+    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/tavl.c"
     "${OPENLDAP_SOURCE_DIR}/libraries/libldap/thr_debug.c"
+    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/thr_nt.c"
+    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/thr_posix.c"
+    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/thr_pth.c"
+    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/thr_thr.c"
+    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/threads.c"
+    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/tls2.c"
+    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/tls_g.c"
+    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/tls_o.c"
+    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/tpool.c"
+    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/turn.c"
+    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/txn.c"
+    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/unbind.c"
+    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/url.c"
+    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/utf-8-conv.c"
+    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/utf-8.c"
+    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/util-int.c"
+    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/vc.c"
+    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/vlvctrl.c"
+    "${OPENLDAP_SOURCE_DIR}/libraries/libldap/whoami.c"
 )
 
 mkversion(ldap)
@@ -197,44 +195,6 @@ target_include_directories(_ldap SYSTEM
 target_compile_definitions(_ldap
     PRIVATE LDAP_LIBRARY
 )
-
-# set(_ldap_r_specific_srcs
-#     "${OPENLDAP_SOURCE_DIR}/libraries/libldap/threads.c"
-#     "${OPENLDAP_SOURCE_DIR}/libraries/libldap/rdwr.c"
-#     "${OPENLDAP_SOURCE_DIR}/libraries/libldap/tpool.c"
-#     "${OPENLDAP_SOURCE_DIR}/libraries/libldap/rq.c"
-#     "${OPENLDAP_SOURCE_DIR}/libraries/libldap/thr_posix.c"
-#     "${OPENLDAP_SOURCE_DIR}/libraries/libldap/thr_thr.c"
-#     "${OPENLDAP_SOURCE_DIR}/libraries/libldap/thr_nt.c"
-#     "${OPENLDAP_SOURCE_DIR}/libraries/libldap/thr_pth.c"
-#     # "${OPENLDAP_SOURCE_DIR}/libraries/libldap/thr_stub.c"
-#     "${OPENLDAP_SOURCE_DIR}/libraries/libldap/thr_debug.c"
-# )
-
-# mkversion(ldap_r)
-
-# add_library(_ldap_r
-#     ${_ldap_r_specific_srcs}
-#     ${_ldap_srcs}
-#     "${CMAKE_CURRENT_BINARY_DIR}/ldap_r-version.c"
-# )
-
-# target_link_libraries(_ldap_r
-#     PRIVATE _lber
-#     PRIVATE OpenSSL::Crypto OpenSSL::SSL
-# )
-
-# target_include_directories(_ldap_r SYSTEM
-#     PUBLIC ${_extra_build_dir}/include
-#     PUBLIC "${OPENLDAP_SOURCE_DIR}/include"
-#     PRIVATE "${OPENLDAP_SOURCE_DIR}/libraries/libldap_r"
-#     PRIVATE "${OPENLDAP_SOURCE_DIR}/libraries/libldap"
-# )
-
-# target_compile_definitions(_ldap_r
-#     PRIVATE LDAP_R_COMPILE
-#     PRIVATE LDAP_LIBRARY
-# )
 
 add_library(ch_contrib::ldap ALIAS _ldap)
 add_library(ch_contrib::lber ALIAS _lber)


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)