### PR TITLE
Proper destruction of task in ShellCommandSource

### DIFF
--- a/src/Processors/Sources/ShellCommandSource.cpp
+++ b/src/Processors/Sources/ShellCommandSource.cpp
@@ -266,7 +266,7 @@ namespace
         {
             for (auto && send_data_task : send_data_tasks)
             {
-                send_data_threads.emplace_back([task = std::move(send_data_task), this]()
+                send_data_threads.emplace_back([task = std::move(send_data_task), this]() mutable
                 {
                     try
                     {
@@ -276,6 +276,10 @@ namespace
                     {
                         std::lock_guard lock(send_data_lock);
                         exception_during_send_data = std::current_exception();
+
+                        /// task should be reset inside catch block or else it breaks d'tor
+                        /// invariants such as in ~WriteBuffer.
+                        task = {};
                     }
                 });
             }


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Proper destruction of task in ShellCommandSource. This fixes #53454 .