### PR TITLE
Remove unneeded columns from logs

### DIFF
--- a/src/Interpreters/MetricLog.cpp
+++ b/src/Interpreters/MetricLog.cpp
@@ -16,7 +16,6 @@ NamesAndTypesList MetricLogElement::getNamesAndTypes()
     columns_with_type_and_name.emplace_back("event_date", std::make_shared<DataTypeDate>());
     columns_with_type_and_name.emplace_back("event_time", std::make_shared<DataTypeDateTime>());
     columns_with_type_and_name.emplace_back("event_time_microseconds", std::make_shared<DataTypeDateTime64>(6));
-    columns_with_type_and_name.emplace_back("milliseconds", std::make_shared<DataTypeUInt64>());
 
     for (size_t i = 0, end = ProfileEvents::end(); i < end; ++i)
     {
@@ -45,7 +44,6 @@ void MetricLogElement::appendToBlock(MutableColumns & columns) const
     columns[column_idx++]->insert(DateLUT::instance().toDayNum(event_time).toUnderType());
     columns[column_idx++]->insert(event_time);
     columns[column_idx++]->insert(event_time_microseconds);
-    columns[column_idx++]->insert(milliseconds);
 
     for (size_t i = 0, end = ProfileEvents::end(); i < end; ++i)
         columns[column_idx++]->insert(profile_events[i]);
@@ -96,7 +94,6 @@ void MetricLog::metricThreadFunction()
             MetricLogElement elem;
             elem.event_time = std::chrono::system_clock::to_time_t(current_time);
             elem.event_time_microseconds = timeInMicroseconds(current_time);
-            elem.milliseconds = timeInMilliseconds(current_time) - timeInSeconds(current_time) * 1000;
 
             elem.profile_events.resize(ProfileEvents::end());
             for (ProfileEvents::Event i = ProfileEvents::Event(0), end = ProfileEvents::end(); i < end; ++i)

--- a/src/Interpreters/MetricLog.h
+++ b/src/Interpreters/MetricLog.h
@@ -22,7 +22,6 @@ struct MetricLogElement
 {
     time_t event_time{};
     Decimal64 event_time_microseconds{};
-    UInt64 milliseconds{};
 
     std::vector<ProfileEvents::Count> profile_events;
     std::vector<CurrentMetrics::Metric> current_metrics;

--- a/src/Interpreters/TextLog.cpp
+++ b/src/Interpreters/TextLog.cpp
@@ -36,7 +36,6 @@ NamesAndTypesList TextLogElement::getNamesAndTypes()
         {"event_date", std::make_shared<DataTypeDate>()},
         {"event_time", std::make_shared<DataTypeDateTime>()},
         {"event_time_microseconds", std::make_shared<DataTypeDateTime64>(6)},
-        {"microseconds", std::make_shared<DataTypeUInt32>()},
 
         {"thread_name", std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeString>())},
         {"thread_id", std::make_shared<DataTypeUInt64>()},
@@ -62,7 +61,6 @@ void TextLogElement::appendToBlock(MutableColumns & columns) const
     columns[i++]->insert(DateLUT::instance().toDayNum(event_time).toUnderType());
     columns[i++]->insert(event_time);
     columns[i++]->insert(event_time_microseconds);
-    columns[i++]->insert(microseconds);
 
     columns[i++]->insertData(thread_name.data(), thread_name.size());
     columns[i++]->insert(thread_id);

--- a/src/Interpreters/TextLog.h
+++ b/src/Interpreters/TextLog.h
@@ -14,7 +14,6 @@ struct TextLogElement
 {
     time_t event_time{};
     Decimal64 event_time_microseconds{};
-    UInt32 microseconds{};
 
     String thread_name;
     UInt64 thread_id{};

--- a/src/Loggers/OwnSplitChannel.cpp
+++ b/src/Loggers/OwnSplitChannel.cpp
@@ -117,7 +117,6 @@ void OwnSplitChannel::logSplit(const Poco::Message & msg)
 
         elem.event_time = msg_ext.time_seconds;
         elem.event_time_microseconds = msg_ext.time_in_microseconds;
-        elem.microseconds = msg_ext.time_microseconds;
 
         elem.thread_name = getThreadName();
         elem.thread_id = msg_ext.thread_id;


### PR DESCRIPTION
### Changelog category (leave one):
- Backward Incompatible Change


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
The `microseconds` column is removed from the `system.text_log`, and the `milliseconds` column is removed from the `system.metric_log`, because they are redundant in the presence of the `event_time_microseconds` column.

Back story: I've initially added `milliseconds` as a separate column to `event_time`, because it is the proper ClickHouse way (better compression, you don't pay for what you don't request). But eventually, other contributors added yet another `event_time_microseconds` column, defeating my principles.