### PR TITLE
:lipstick: [S3::URI] Fix comment typos around versionId

### DIFF
--- a/src/IO/S3/URI.cpp
+++ b/src/IO/S3/URI.cpp
@@ -52,9 +52,9 @@ URI::URI(const std::string & uri_)
             has_version_id = true;
         }
 
-    /// Poco::URI will ignore '?' when parsing the path, but if there is a vestionId in the http parameter,
+    /// Poco::URI will ignore '?' when parsing the path, but if there is a versionId in the http parameter,
     /// '?' can not be used as a wildcard, otherwise it will be ambiguous.
-    /// If no "vertionId" in the http parameter, '?' can be used as a wildcard.
+    /// If no "versionId" in the http parameter, '?' can be used as a wildcard.
     /// It is necessary to encode '?' to avoid deletion during parsing path.
     if (!has_version_id && uri_.find('?') != String::npos)
     {


### PR DESCRIPTION
### Changelog category:
- Not for changelog (changelog entry is not required)

Fixes a comment typo referencing the `versionId` in the `S3::URI` class