### PR TITLE
Fix data race of shell command

### DIFF
--- a/src/Common/ShellCommand.cpp
+++ b/src/Common/ShellCommand.cpp
@@ -101,6 +101,12 @@ bool ShellCommand::tryWaitProcessWithTimeout(size_t timeout_in_seconds)
     out.close();
     err.close();
 
+    for (auto & [_, fd] : write_fds)
+        fd.close();
+
+    for (auto & [_, fd] : read_fds)
+        fd.close();
+
     return waitForPid(pid, timeout_in_seconds);
 }
 
@@ -286,6 +292,12 @@ int ShellCommand::tryWait()
     in.close();
     out.close();
     err.close();
+
+    for (auto & [_, fd] : write_fds)
+        fd.close();
+
+    for (auto & [_, fd] : read_fds)
+        fd.close();
 
     LOG_TRACE(getLogger(), "Will wait for shell command pid {}", pid);
 

--- a/src/Processors/Sources/ShellCommandSource.cpp
+++ b/src/Processors/Sources/ShellCommandSource.cpp
@@ -462,8 +462,20 @@ namespace
                     if (thread.joinable())
                         thread.join();
 
-                if (check_exit_code && !process_pool)
-                    command->wait();
+                if (check_exit_code)
+                {
+                    if (process_pool)
+                    {
+                        bool valid_command
+                            = configuration.read_fixed_number_of_rows && current_read_rows >= configuration.number_of_rows_to_read;
+
+                        // We can only wait for pooled commands when they are invalid.
+                        if (!valid_command)
+                            command->wait();
+                    }
+                    else
+                        command->wait();
+                }
 
                 rethrowExceptionDuringSendDataIfNeeded();
             }

--- a/src/Processors/Sources/ShellCommandSource.cpp
+++ b/src/Processors/Sources/ShellCommandSource.cpp
@@ -439,11 +439,7 @@ namespace
                 }
 
                 if (!executor->pull(chunk))
-                {
-                    if (check_exit_code)
-                        command->wait();
                     return {};
-                }
 
                 current_read_rows += chunk.getNumRows();
             }
@@ -465,6 +461,9 @@ namespace
                 for (auto & thread : send_data_threads)
                     if (thread.joinable())
                         thread.join();
+
+                if (check_exit_code && !process_pool)
+                    command->wait();
 
                 rethrowExceptionDuringSendDataIfNeeded();
             }


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix data race when closing up shell command buffers. This fixes #53630 . This PR further improves the handling of shell command buffer close in more scenarios.