### PR TITLE
Add default timeout value for ClickHouseHelper

### DIFF
--- a/tests/ci/clickhouse_helper.py
+++ b/tests/ci/clickhouse_helper.py
@@ -67,6 +67,7 @@ class ClickHouseHelper:
         if args:
             url = args[0]
         url = kwargs.get("url", url)
+        kwargs["timeout"] = kwargs.get("timeout", 100)
 
         for i in range(5):
             try:


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
By default `requests.post` does not have any timeout. We provide the default value `timeout=100` now.