### PR TITLE
Prepared set cache in mutation pipeline stuck

### DIFF
--- a/src/Processors/IAccumulatingTransform.cpp
+++ b/src/Processors/IAccumulatingTransform.cpp
@@ -13,14 +13,6 @@ IAccumulatingTransform::IAccumulatingTransform(Block input_header, Block output_
 {
 }
 
-InputPort * IAccumulatingTransform::addTotalsPort()
-{
-    if (inputs.size() > 1)
-        throw Exception(ErrorCodes::LOGICAL_ERROR, "Totals port was already added to IAccumulatingTransform");
-
-    return &inputs.emplace_back(getInputPort().getHeader(), this);
-}
-
 IAccumulatingTransform::Status IAccumulatingTransform::prepare()
 {
     /// Check can output.

--- a/src/Processors/IAccumulatingTransform.h
+++ b/src/Processors/IAccumulatingTransform.h
@@ -36,10 +36,6 @@ public:
     Status prepare() override;
     void work() override;
 
-    /// Adds additional port for totals.
-    /// If added, totals will have been ready by the first generate() call (in totals chunk).
-    InputPort * addTotalsPort();
-
     InputPort & getInputPort() { return input; }
     OutputPort & getOutputPort() { return output; }
 };

--- a/src/QueryPipeline/QueryPipelineBuilder.cpp
+++ b/src/QueryPipeline/QueryPipelineBuilder.cpp
@@ -579,6 +579,7 @@ void QueryPipelineBuilder::addCreatingSetsTransform(
     const SizeLimits & limits,
     PreparedSetsCachePtr prepared_sets_cache)
 {
+    dropTotalsAndExtremes();
     resize(1);
 
     auto transform = std::make_shared<CreatingSetsTransform>(
@@ -589,12 +590,7 @@ void QueryPipelineBuilder::addCreatingSetsTransform(
             limits,
             std::move(prepared_sets_cache));
 
-    InputPort * totals_port = nullptr;
-
-    if (pipe.getTotalsPort())
-        totals_port = transform->addTotalsPort();
-
-    pipe.addTransform(std::move(transform), totals_port, nullptr);
+    pipe.addTransform(std::move(transform));
 }
 
 void QueryPipelineBuilder::addPipelineBefore(QueryPipelineBuilder pipeline)

--- a/tests/queries/0_stateless/02863_mutation_where_in_set_result_cache_pipeline_stuck_bug.sql
+++ b/tests/queries/0_stateless/02863_mutation_where_in_set_result_cache_pipeline_stuck_bug.sql
@@ -1,0 +1,10 @@
+drop table if exists tab;
+create table tab (x UInt32, y UInt32) engine = MergeTree order by x;
+
+insert into tab select number, number from numbers(10);
+insert into tab select number, number from numbers(20);
+
+set mutations_sync=2;
+
+alter table tab delete where x > 1000 and y in (select sum(number + 1) from numbers_mt(1e7) group by number % 2 with totals);
+drop table if exists tab;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix `Pipeline stuck` error in mutation with `IN (subquery WITH TOTALS)` where ready set was taken from cache.

https://s3.amazonaws.com/clickhouse-test-reports/52797/38adb70931a6bad155e1568f92e4aaf1865ee7bc/fuzzer_astfuzzerubsan/report.html