### PR TITLE
Fix memory usage functional test for s390x

### DIFF
--- a/tests/queries/0_stateless/02354_distributed_with_external_aggregation_memory_usage.sql
+++ b/tests/queries/0_stateless/02354_distributed_with_external_aggregation_memory_usage.sql
@@ -16,13 +16,13 @@ set max_bytes_before_external_group_by = '2G',
     max_block_size = 65505;
 
 -- whole aggregation state of local aggregation uncompressed is 5.8G
--- it is hard to provide an accurate estimation for memory usage, so 4G is just the actual value taken from the logs + delta
+-- it is hard to provide an accurate estimation for memory usage, so 5G is just the actual value taken from the logs + delta
 -- also avoid using localhost, so the queries will go over separate connections
 -- (otherwise the memory usage for merge will be counted together with the localhost query)
 select a, b, c, sum(a) as s
 from remote('127.0.0.{2,3}', currentDatabase(), t_2354_dist_with_external_aggr)
 group by a, b, c
 format Null
-settings max_memory_usage = '4Gi';
+settings max_memory_usage = '5Gi';
 
 DROP TABLE t_2354_dist_with_external_aggr;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
Fix shaky functional test 02354_distributed_with_external_aggregation_memory_usage in s390x.


### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed functional test in 02354_distributed_with_external_aggregation_memory_usage in s390x.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
