### PR TITLE
fix Logical Error in AsynchronousBoundedReadBuffer

### DIFF
--- a/src/Disks/IO/AsynchronousBoundedReadBuffer.h
+++ b/src/Disks/IO/AsynchronousBoundedReadBuffer.h
@@ -46,6 +46,8 @@ public:
 
     void setReadUntilEnd() override { return setReadUntilPosition(getFileSize()); }
 
+    size_t getFileOffsetOfBufferEnd() const override  { return file_offset_of_buffer_end; }
+
     off_t getPosition() override { return file_offset_of_buffer_end - available() + bytes_to_ignore; }
 
 private:

--- a/src/IO/ReadBufferFromS3.h
+++ b/src/IO/ReadBufferFromS3.h
@@ -16,11 +16,6 @@
 
 #include <aws/s3/model/GetObjectResult.h>
 
-namespace Aws::S3
-{
-class Client;
-}
-
 namespace DB
 {
 /**

--- a/src/IO/tests/gtest_writebuffer_s3.cpp
+++ b/src/IO/tests/gtest_writebuffer_s3.cpp
@@ -277,7 +277,7 @@ struct Client : DB::S3::Client
         const String prefix = "bytes=";
         if (range.starts_with(prefix))
         {
-            int ret = sscanf(range.c_str(), "bytes=%zu-%zu", &begin, &end);
+            int ret = sscanf(range.c_str(), "bytes=%zu-%zu", &begin, &end); /// NOLINT
             chassert(ret == 2);
         }
 

--- a/src/IO/tests/gtest_writebuffer_s3.cpp
+++ b/src/IO/tests/gtest_writebuffer_s3.cpp
@@ -273,14 +273,12 @@ struct Client : DB::S3::Client
         size_t begin = 0;
         size_t end = data.size() - 1;
 
-        String range = request.GetRange();
+        const String & range = request.GetRange();
         const String prefix = "bytes=";
         if (range.starts_with(prefix))
         {
-            auto dash_pos = range.find('-');
-            range[dash_pos] = '\0';
-            begin = atol(range.c_str() + prefix.size());
-            end = atol(range.c_str() + dash_pos + 1);
+            int ret = sscanf(range.c_str(), "bytes=%zu-%zu", &begin, &end);
+            chassert(ret == 2);
         }
 
         auto factory = request.GetResponseStreamFactory();
@@ -1273,6 +1271,7 @@ TEST_F(WBS3Test, ReadBeyondLastOffset) {
     String res;
     readStringUntilEOF(res, *encrypted_read_buffer);
     ASSERT_EQ(res, data.substr(0, 50));
+    ASSERT_TRUE(encrypted_read_buffer->eof());
 }
 
 #endif

--- a/src/IO/tests/gtest_writebuffer_s3.cpp
+++ b/src/IO/tests/gtest_writebuffer_s3.cpp
@@ -23,10 +23,20 @@
 
 #include <IO/WriteBufferFromS3.h>
 #include <IO/S3Common.h>
+#include <IO/FileEncryptionCommon.h>
+#include <IO/WriteBufferFromEncryptedFile.h>
+#include <IO/ReadBufferFromEncryptedFile.h>
+#include <IO/AsyncReadCounters.h>
+#include <IO/ReadBufferFromS3.h>
+#include <IO/S3/Client.h>
+
+#include <Disks/IO/ThreadPoolReader.h>
+#include <Disks/IO/ReadBufferFromRemoteFSGather.h>
+#include <Disks/IO/AsynchronousBoundedReadBuffer.h>
 
 #include <Common/filesystemHelpers.h>
-#include <IO/S3/Client.h>
 #include <Core/Settings.h>
+
 
 namespace DB
 {
@@ -258,10 +268,24 @@ struct Client : DB::S3::Client
         ++counters.getObject;
 
         auto & bStore = store->GetBucketStore(request.GetBucket());
+        const String data = bStore.objects[request.GetKey()];
+
+        size_t begin = 0;
+        size_t end = data.size() - 1;
+
+        String range = request.GetRange();
+        const String prefix = "bytes=";
+        if (range.starts_with(prefix))
+        {
+            auto dash_pos = range.find('-');
+            range[dash_pos] = '\0';
+            begin = atol(range.c_str() + prefix.size());
+            end = atol(range.c_str() + dash_pos + 1);
+        }
 
         auto factory = request.GetResponseStreamFactory();
         Aws::Utils::Stream::ResponseStream responseStream(factory);
-        responseStream.GetUnderlyingStream() << std::stringstream(bStore.objects[request.GetKey()]).rdbuf();
+        responseStream.GetUnderlyingStream() << std::stringstream(data.substr(begin, end - begin + 1)).rdbuf();
 
         Aws::AmazonWebServiceResult<Aws::Utils::Stream::ResponseStream> awsStream(std::move(responseStream), Aws::Http::HeaderValueCollection());
         Aws::S3::Model::GetObjectResult getObjectResult(std::move(awsStream));
@@ -1146,6 +1170,109 @@ TEST_P(SyncAsync, StrictUploadPartSize) {
             ASSERT_THAT(actual_parts_sizes, testing::ElementsAre(11, 11, 11, 11, 11, 11, 1));
         }
     }
+}
+
+String fillStringWithPattern(String pattern, int n)
+{
+    String data;
+    for (int i = 0; i < n; ++i)
+    {
+        data += pattern;
+    }
+    return data;
+}
+
+TEST_F(WBS3Test, ReadBeyondLastOffset) {
+    const String remote_file = "ReadBeyondLastOffset";
+
+    const String key = "1234567812345678";
+    const String data = fillStringWithPattern("0123456789", 10);
+
+    ReadSettings disk_read_settings;
+    disk_read_settings.enable_filesystem_cache = false;
+    disk_read_settings.local_fs_buffer_size = 70;
+    disk_read_settings.remote_fs_buffer_size = FileEncryption::Header::kSize + 60;
+
+    {
+        /// write encrypted file
+
+        FileEncryption::Header header;
+        header.algorithm = FileEncryption::Algorithm::AES_128_CTR;
+        header.key_fingerprint = FileEncryption::calculateKeyFingerprint(key);
+        header.init_vector = FileEncryption::InitVector::random();
+
+        auto wbs3 = getWriteBuffer(remote_file);
+        getAsyncPolicy().setAutoExecute(true);
+
+        WriteBufferFromEncryptedFile wb(10, std::move(wbs3), key, header);
+        wb.write(data.data(), data.size());
+        wb.finalize();
+    }
+
+    std::unique_ptr<ReadBufferFromEncryptedFile> encrypted_read_buffer;
+
+    {
+        /// create encrypted file reader
+
+        auto cache_log = std::shared_ptr<FilesystemCacheLog>();
+        const StoredObjects objects = { StoredObject(remote_file, data.size() + FileEncryption::Header::kSize) };
+        auto reader = std::make_unique<ThreadPoolReader>(1, 1);
+        auto async_read_counters = std::make_shared<AsyncReadCounters>();
+        auto prefetch_log = std::shared_ptr<FilesystemReadPrefetchesLog>();
+
+        auto rb_creator = [this, disk_read_settings] (const std::string & path, size_t read_until_position) -> std::unique_ptr<ReadBufferFromFileBase>
+        {
+            S3Settings::RequestSettings request_settings;
+            return std::make_unique<ReadBufferFromS3>(
+                client,
+                bucket,
+                path,
+                "Latest",
+                request_settings,
+                disk_read_settings,
+                /* use_external_buffer */true,
+                /* offset */0,
+                read_until_position,
+                /* restricted_seek */true);
+        };
+
+        auto rb_remote_fs = std::make_unique<ReadBufferFromRemoteFSGather>(
+            std::move(rb_creator),
+            objects,
+            disk_read_settings,
+            cache_log,
+            true);
+
+        auto rb_async = std::make_unique<AsynchronousBoundedReadBuffer>(
+            std::move(rb_remote_fs), *reader, disk_read_settings, async_read_counters, prefetch_log);
+
+        /// read the header from the buffer
+        /// as a result AsynchronousBoundedReadBuffer consists some data from the file inside working buffer
+        FileEncryption::Header header;
+        header.read(*rb_async);
+
+        ASSERT_EQ(rb_async->available(), disk_read_settings.remote_fs_buffer_size - FileEncryption::Header::kSize);
+        ASSERT_EQ(rb_async->getPosition(), FileEncryption::Header::kSize);
+        ASSERT_EQ(rb_async->getFileOffsetOfBufferEnd(), disk_read_settings.remote_fs_buffer_size);
+
+        /// ReadBufferFromEncryptedFile is constructed over an ReadBuffer which was already in use.
+        /// The 'FileEncryption::Header' has been read from `rb_async`.
+        /// 'rb_async' will read the data from `rb_async` working buffer
+        encrypted_read_buffer = std::make_unique<ReadBufferFromEncryptedFile>(
+            disk_read_settings.local_fs_buffer_size, std::move(rb_async), key, header);
+    }
+
+    /// When header is read, file is read into working buffer till some position. Tn the test the file is read until remote_fs_buffer_size (124) position.
+    /// Set the right border before that position and make sure that encrypted_read_buffer does not have access to it
+    ASSERT_GT(disk_read_settings.remote_fs_buffer_size, 50);
+    encrypted_read_buffer->setReadUntilPosition(50);
+
+    /// encrypted_read_buffer reads the data with buffer size `local_fs_buffer_size`
+    /// If the impl file has read the data beyond the ReadUntilPosition, encrypted_read_buffer does not read it
+    /// getFileOffsetOfBufferEnd should read data till `ReadUntilPosition`
+    String res;
+    readStringUntilEOF(res, *encrypted_read_buffer);
+    ASSERT_EQ(res, data.substr(0, 50));
 }
 
 #endif


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

In combination with `ReadBufferFromEncryptedFile` buffer `AsynchronousBoundedReadBuffer` could throw `LOGICAL ERROR Read beyond last offset`.

That happens because `ReadBufferFromEncryptedFile` is created over a buffer which already has some data inside working buffer. `DiskEncrypted::readFile` reads the encryption header from an instance of `AsynchronousBoundedReadBuffer`, which is passed to an instance of `ReadBufferFromEncryptedFile`.

As a result there was a possibility that `ReadBufferFromEncryptedFile` reads from the working buffer of underlay buffer beyond `read until position`.

That situation is uncatchable because this moderately new change.
https://github.com/ClickHouse/ClickHouse/blob/145c99ee94a46cd5b28dbcb998fb7d9b64a540e5/src/Storages/MergeTree/MergeTreeReaderCompact.cpp#L60-L63
getReadBufferSize makes remote/local buffer equal to the granule size.

Without that change the case is easy to catch if you
- make granula size less than remote_fs_buffer_size vaule;
- set local_fs_buffer_size to the value bigger that remote_fs_buffer_size. 
Without tuning local_fs_buffer_size there is a special data is needed, but that is happened on real data.

In the PR the gtest which emulates reading (stack of buffers) like it happens in real instance. That test triggers the error.


