### PR TITLE
State of State and avg aggregation function fix for big endian 

### DIFF
--- a/src/AggregateFunctions/AggregateFunctionAvg.h
+++ b/src/AggregateFunctions/AggregateFunctionAvg.h
@@ -109,7 +109,7 @@ public:
 
     void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::optional<size_t> /* version */) const override
     {
-        writeBinary(this->data(place).numerator, buf);
+        writeBinaryLittleEndian(this->data(place).numerator, buf);
 
         if constexpr (std::is_unsigned_v<Denominator>)
             writeVarUInt(this->data(place).denominator, buf);
@@ -119,7 +119,7 @@ public:
 
     void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::optional<size_t> /* version */, Arena *) const override
     {
-        readBinary(this->data(place).numerator, buf);
+        readBinaryLittleEndian(this->data(place).numerator, buf);
 
         if constexpr (std::is_unsigned_v<Denominator>)
             readVarUInt(this->data(place).denominator, buf);

--- a/src/Common/HashTable/HashTable.h
+++ b/src/Common/HashTable/HashTable.h
@@ -201,11 +201,11 @@ struct HashTableCell
     void setMapped(const value_type & /*value*/) {}
 
     /// Serialization, in binary and text form.
-    void write(DB::WriteBuffer & wb) const         { DB::writeBinary(key, wb); }
+    void write(DB::WriteBuffer & wb) const         { DB::writeBinaryLittleEndian(key, wb); }
     void writeText(DB::WriteBuffer & wb) const     { DB::writeDoubleQuoted(key, wb); }
 
     /// Deserialization, in binary and text form.
-    void read(DB::ReadBuffer & rb)        { DB::readBinary(key, rb); }
+    void read(DB::ReadBuffer & rb)        { DB::readBinaryLittleEndian(key, rb); }
     void readText(DB::ReadBuffer & rb)    { DB::readDoubleQuoted(key, rb); }
 
     /// When cell pointer is moved during erase, reinsert or resize operations

--- a/src/Processors/Formats/Impl/ODBCDriver2BlockOutputFormat.cpp
+++ b/src/Processors/Formats/Impl/ODBCDriver2BlockOutputFormat.cpp
@@ -19,7 +19,7 @@ ODBCDriver2BlockOutputFormat::ODBCDriver2BlockOutputFormat(
 
 static void writeODBCString(WriteBuffer & out, const std::string & str)
 {
-    writePODBinaryLittleEndian(Int32(str.size()), out);
+    writeBinaryLittleEndian(Int32(str.size()), out);
     out.write(str.data(), str.size());
 }
 
@@ -33,7 +33,7 @@ void ODBCDriver2BlockOutputFormat::writeRow(const Columns & columns, size_t row_
 
         if (column->isNullAt(row_idx))
         {
-            writePODBinaryLittleEndian(Int32(-1), out);
+            writeBinaryLittleEndian(Int32(-1), out);
         }
         else
         {
@@ -72,11 +72,11 @@ void ODBCDriver2BlockOutputFormat::writePrefix()
     const size_t columns = header.columns();
 
     /// Number of header rows.
-    writePODBinaryLittleEndian(Int32(2), out);
+    writeBinaryLittleEndian(Int32(2), out);
 
     /// Names of columns.
     /// Number of columns + 1 for first name column.
-    writePODBinaryLittleEndian(Int32(columns + 1), out);
+    writeBinaryLittleEndian(Int32(columns + 1), out);
     writeODBCString(out, "name");
     for (size_t i = 0; i < columns; ++i)
     {
@@ -85,7 +85,7 @@ void ODBCDriver2BlockOutputFormat::writePrefix()
     }
 
     /// Types of columns.
-    writePODBinaryLittleEndian(Int32(columns + 1), out);
+    writeBinaryLittleEndian(Int32(columns + 1), out);
     writeODBCString(out, "type");
     for (size_t i = 0; i < columns; ++i)
     {

--- a/src/Processors/Formats/Impl/ODBCDriver2BlockOutputFormat.cpp
+++ b/src/Processors/Formats/Impl/ODBCDriver2BlockOutputFormat.cpp
@@ -19,7 +19,7 @@ ODBCDriver2BlockOutputFormat::ODBCDriver2BlockOutputFormat(
 
 static void writeODBCString(WriteBuffer & out, const std::string & str)
 {
-    writeIntBinary(Int32(str.size()), out);
+    writePODBinaryLittleEndian(Int32(str.size()), out);
     out.write(str.data(), str.size());
 }
 
@@ -33,7 +33,7 @@ void ODBCDriver2BlockOutputFormat::writeRow(const Columns & columns, size_t row_
 
         if (column->isNullAt(row_idx))
         {
-            writeIntBinary(Int32(-1), out);
+            writePODBinaryLittleEndian(Int32(-1), out);
         }
         else
         {
@@ -72,11 +72,11 @@ void ODBCDriver2BlockOutputFormat::writePrefix()
     const size_t columns = header.columns();
 
     /// Number of header rows.
-    writeIntBinary(Int32(2), out);
+    writePODBinaryLittleEndian(Int32(2), out);
 
     /// Names of columns.
     /// Number of columns + 1 for first name column.
-    writeIntBinary(Int32(columns + 1), out);
+    writePODBinaryLittleEndian(Int32(columns + 1), out);
     writeODBCString(out, "name");
     for (size_t i = 0; i < columns; ++i)
     {
@@ -85,7 +85,7 @@ void ODBCDriver2BlockOutputFormat::writePrefix()
     }
 
     /// Types of columns.
-    writeIntBinary(Int32(columns + 1), out);
+    writePODBinaryLittleEndian(Int32(columns + 1), out);
     writeODBCString(out, "type");
     for (size_t i = 0; i < columns; ++i)
     {


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
fix avg aggregation and state of state aggregation function on big endian

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
