### PR TITLE
Expose more settings from caches

### DIFF
--- a/docs/en/operations/server-configuration-parameters/settings.md
+++ b/docs/en/operations/server-configuration-parameters/settings.md
@@ -217,6 +217,14 @@ Type: UInt32
 Default: 1024
 
 
+## index_mark_cache_policy
+
+Index mark cache policy name.
+
+Type: String
+
+Default: SLRU
+
 ## index_mark_cache_size
 
 Size of cache for index marks. Zero means disabled.
@@ -229,6 +237,21 @@ Type: UInt64
 
 Default: 0
 
+## index_mark_cache_size_ratio
+
+The size of the protected queue in the index mark cache relative to the cache's total size.
+
+Type: Double
+
+Default: 0.5
+
+## index_uncompressed_cache_policy
+
+Index uncompressed cache policy name.
+
+Type: String
+
+Default: SLRU
 
 ## index_uncompressed_cache_size
 
@@ -242,6 +265,13 @@ Type: UInt64
 
 Default: 0
 
+## index_uncompressed_cache_size_ratio
+
+The size of the protected queue in the index uncompressed cache relative to the cache's total size.
+
+Type: Double
+
+Default: 0.5
 
 ## io_thread_pool_queue_size
 
@@ -270,6 +300,14 @@ This setting can be modified at runtime and will take effect immediately.
 Type: UInt64
 
 Default: 5368709120
+
+## mark_cache_size_ratio
+
+The size of the protected queue in the mark cache relative to the cache's total size.
+
+Type: Double
+
+Default: 0.5
 
 ## max_backup_bandwidth_for_server
 
@@ -628,6 +666,14 @@ This setting can be modified at runtime and will take effect immediately.
 Type: UInt64
 
 Default: 0
+
+## uncompressed_cache_size_ratio
+
+The size of the protected queue in the uncompressed cache relative to the cache's total size.
+
+Type: Double
+
+Default: 0.5
 
 ## builtin_dictionaries_reload_interval {#builtin-dictionaries-reload-interval}
 

--- a/programs/local/LocalServer.cpp
+++ b/programs/local/LocalServer.cpp
@@ -657,9 +657,9 @@ void LocalServer::processConfig()
     /// There is no need for concurrent queries, override max_concurrent_queries.
     global_context->getProcessList().setMaxSize(0);
 
-    const size_t memory_amount = getMemoryAmount();
+    const size_t physical_server_memory = getMemoryAmount();
     const double cache_size_to_ram_max_ratio = config().getDouble("cache_size_to_ram_max_ratio", 0.5);
-    const size_t max_cache_size = static_cast<size_t>(memory_amount * cache_size_to_ram_max_ratio);
+    const size_t max_cache_size = static_cast<size_t>(physical_server_memory * cache_size_to_ram_max_ratio);
 
     String uncompressed_cache_policy = config().getString("uncompressed_cache_policy", DEFAULT_UNCOMPRESSED_CACHE_POLICY);
     size_t uncompressed_cache_size = config().getUInt64("uncompressed_cache_size", DEFAULT_UNCOMPRESSED_CACHE_MAX_SIZE);

--- a/programs/local/LocalServer.cpp
+++ b/programs/local/LocalServer.cpp
@@ -663,15 +663,17 @@ void LocalServer::processConfig()
 
     String uncompressed_cache_policy = config().getString("uncompressed_cache_policy", DEFAULT_UNCOMPRESSED_CACHE_POLICY);
     size_t uncompressed_cache_size = config().getUInt64("uncompressed_cache_size", DEFAULT_UNCOMPRESSED_CACHE_MAX_SIZE);
+    double uncompressed_cache_size_ratio = config().getDouble("uncompressed_cache_size_ratio", DEFAULT_UNCOMPRESSED_CACHE_SIZE_RATIO);
     if (uncompressed_cache_size > max_cache_size)
     {
         uncompressed_cache_size = max_cache_size;
         LOG_INFO(log, "Lowered uncompressed cache size to {} because the system has limited RAM", formatReadableSizeWithBinarySuffix(uncompressed_cache_size));
     }
-    global_context->setUncompressedCache(uncompressed_cache_policy, uncompressed_cache_size);
+    global_context->setUncompressedCache(uncompressed_cache_policy, uncompressed_cache_size, uncompressed_cache_size_ratio);
 
     String mark_cache_policy = config().getString("mark_cache_policy", DEFAULT_MARK_CACHE_POLICY);
     size_t mark_cache_size = config().getUInt64("mark_cache_size", DEFAULT_MARK_CACHE_MAX_SIZE);
+    double mark_cache_size_ratio = config().getDouble("mark_cache_size_ratio", DEFAULT_MARK_CACHE_SIZE_RATIO);
     if (!mark_cache_size)
         LOG_ERROR(log, "Too low mark cache size will lead to severe performance degradation.");
     if (mark_cache_size > max_cache_size)
@@ -679,23 +681,27 @@ void LocalServer::processConfig()
         mark_cache_size = max_cache_size;
         LOG_INFO(log, "Lowered mark cache size to {} because the system has limited RAM", formatReadableSizeWithBinarySuffix(mark_cache_size));
     }
-    global_context->setMarkCache(mark_cache_policy, mark_cache_size);
+    global_context->setMarkCache(mark_cache_policy, mark_cache_size, mark_cache_size_ratio);
 
+    String index_uncompressed_cache_policy = config().getString("index_uncompressed_cache_policy", DEFAULT_INDEX_UNCOMPRESSED_CACHE_POLICY);
     size_t index_uncompressed_cache_size = config().getUInt64("index_uncompressed_cache_size", DEFAULT_INDEX_UNCOMPRESSED_CACHE_MAX_SIZE);
+    double index_uncompressed_cache_size_ratio = config().getDouble("index_uncompressed_cache_size_ratio", DEFAULT_INDEX_UNCOMPRESSED_CACHE_SIZE_RATIO);
     if (index_uncompressed_cache_size > max_cache_size)
     {
         index_uncompressed_cache_size = max_cache_size;
         LOG_INFO(log, "Lowered index uncompressed cache size to {} because the system has limited RAM", formatReadableSizeWithBinarySuffix(uncompressed_cache_size));
     }
-    global_context->setIndexUncompressedCache(index_uncompressed_cache_size);
+    global_context->setIndexUncompressedCache(index_uncompressed_cache_policy, index_uncompressed_cache_size, index_uncompressed_cache_size_ratio);
 
+    String index_mark_cache_policy = config().getString("index_mark_cache_policy", DEFAULT_INDEX_MARK_CACHE_POLICY);
     size_t index_mark_cache_size = config().getUInt64("index_mark_cache_size", DEFAULT_INDEX_MARK_CACHE_MAX_SIZE);
+    double index_mark_cache_size_ratio = config().getDouble("index_mark_cache_size_ratio", DEFAULT_INDEX_MARK_CACHE_SIZE_RATIO);
     if (index_mark_cache_size > max_cache_size)
     {
         index_mark_cache_size = max_cache_size;
         LOG_INFO(log, "Lowered index mark cache size to {} because the system has limited RAM", formatReadableSizeWithBinarySuffix(uncompressed_cache_size));
     }
-    global_context->setIndexMarkCache(index_mark_cache_size);
+    global_context->setIndexMarkCache(index_mark_cache_policy, index_mark_cache_size, index_mark_cache_size_ratio);
 
     size_t mmap_cache_size = config().getUInt64("mmap_cache_size", DEFAULT_MMAP_CACHE_MAX_SIZE);
     if (mmap_cache_size > max_cache_size)

--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -1111,37 +1111,43 @@ try
 
     String uncompressed_cache_policy = server_settings.uncompressed_cache_policy;
     size_t uncompressed_cache_size = server_settings.uncompressed_cache_size;
+    double uncompressed_cache_size_ratio = server_settings.uncompressed_cache_size_ratio;
     if (uncompressed_cache_size > max_cache_size)
     {
         uncompressed_cache_size = max_cache_size;
         LOG_INFO(log, "Lowered uncompressed cache size to {} because the system has limited RAM", formatReadableSizeWithBinarySuffix(uncompressed_cache_size));
     }
-    global_context->setUncompressedCache(uncompressed_cache_policy, uncompressed_cache_size);
+    global_context->setUncompressedCache(uncompressed_cache_policy, uncompressed_cache_size, uncompressed_cache_size_ratio);
 
     String mark_cache_policy = server_settings.mark_cache_policy;
     size_t mark_cache_size = server_settings.mark_cache_size;
+    double mark_cache_size_ratio = server_settings.mark_cache_size_ratio;
     if (mark_cache_size > max_cache_size)
     {
         mark_cache_size = max_cache_size;
         LOG_INFO(log, "Lowered mark cache size to {} because the system has limited RAM", formatReadableSizeWithBinarySuffix(mark_cache_size));
     }
-    global_context->setMarkCache(mark_cache_policy, mark_cache_size);
+    global_context->setMarkCache(mark_cache_policy, mark_cache_size, mark_cache_size_ratio);
 
+    String index_uncompressed_cache_policy = server_settings.index_uncompressed_cache_policy;
     size_t index_uncompressed_cache_size = server_settings.index_uncompressed_cache_size;
+    double index_uncompressed_cache_size_ratio = server_settings.index_uncompressed_cache_size_ratio;
     if (index_uncompressed_cache_size > max_cache_size)
     {
         index_uncompressed_cache_size = max_cache_size;
         LOG_INFO(log, "Lowered index uncompressed cache size to {} because the system has limited RAM", formatReadableSizeWithBinarySuffix(uncompressed_cache_size));
     }
-    global_context->setIndexUncompressedCache(index_uncompressed_cache_size);
+    global_context->setIndexUncompressedCache(index_uncompressed_cache_policy, index_uncompressed_cache_size, index_uncompressed_cache_size_ratio);
 
+    String index_mark_cache_policy = server_settings.index_mark_cache_policy;
     size_t index_mark_cache_size = server_settings.index_mark_cache_size;
+    double index_mark_cache_size_ratio = server_settings.index_mark_cache_size_ratio;
     if (index_mark_cache_size > max_cache_size)
     {
         index_mark_cache_size = max_cache_size;
         LOG_INFO(log, "Lowered index mark cache size to {} because the system has limited RAM", formatReadableSizeWithBinarySuffix(uncompressed_cache_size));
     }
-    global_context->setIndexMarkCache(index_mark_cache_size);
+    global_context->setIndexMarkCache(index_mark_cache_policy, index_mark_cache_size, index_mark_cache_size_ratio);
 
     size_t mmap_cache_size = server_settings.mmap_cache_size;
     if (mmap_cache_size > max_cache_size)

--- a/src/Common/CacheBase.h
+++ b/src/Common/CacheBase.h
@@ -79,7 +79,7 @@ public:
     MappedPtr get(const Key & key)
     {
         std::lock_guard lock(mutex);
-        auto res = cache_policy->get(key, lock);
+        auto res = cache_policy->get(key);
         if (res)
             ++hits;
         else
@@ -90,7 +90,7 @@ public:
     std::optional<KeyMapped> getWithKey(const Key & key)
     {
         std::lock_guard lock(mutex);
-        auto res = cache_policy->getWithKey(key, lock);
+        auto res = cache_policy->getWithKey(key);
         if (res.has_value())
             ++hits;
         else
@@ -101,7 +101,7 @@ public:
     void set(const Key & key, const MappedPtr & mapped)
     {
         std::lock_guard lock(mutex);
-        cache_policy->set(key, mapped, lock);
+        cache_policy->set(key, mapped);
     }
 
     /// If the value for the key is in the cache, returns it. If it is not, calls load_func() to
@@ -118,7 +118,7 @@ public:
         InsertTokenHolder token_holder;
         {
             std::lock_guard cache_lock(mutex);
-            auto val = cache_policy->get(key, cache_lock);
+            auto val = cache_policy->get(key);
             if (val)
             {
                 ++hits;
@@ -156,7 +156,7 @@ public:
         auto token_it = insert_tokens.find(key);
         if (token_it != insert_tokens.end() && token_it->second.get() == token)
         {
-            cache_policy->set(key, token->value, cache_lock);
+            cache_policy->set(key, token->value);
             result = true;
         }
 
@@ -185,49 +185,49 @@ public:
         insert_tokens.clear();
         hits = 0;
         misses = 0;
-        cache_policy->clear(lock);
+        cache_policy->clear();
     }
 
     void remove(const Key & key)
     {
         std::lock_guard lock(mutex);
-        cache_policy->remove(key, lock);
+        cache_policy->remove(key);
     }
 
     size_t weight() const
     {
         std::lock_guard lock(mutex);
-        return cache_policy->weight(lock);
+        return cache_policy->weight();
     }
 
     size_t count() const
     {
         std::lock_guard lock(mutex);
-        return cache_policy->count(lock);
+        return cache_policy->count();
     }
 
     size_t maxSize() const
     {
         std::lock_guard lock(mutex);
-        return cache_policy->maxSize(lock);
+        return cache_policy->maxSize();
     }
 
     void setMaxCount(size_t max_count)
     {
         std::lock_guard lock(mutex);
-        cache_policy->setMaxCount(max_count, lock);
+        cache_policy->setMaxCount(max_count);
     }
 
     void setMaxSize(size_t max_size_in_bytes)
     {
         std::lock_guard lock(mutex);
-        cache_policy->setMaxSize(max_size_in_bytes, lock);
+        cache_policy->setMaxSize(max_size_in_bytes);
     }
 
     void setQuotaForUser(const String & user_name, size_t max_size_in_bytes, size_t max_entries)
     {
         std::lock_guard lock(mutex);
-        cache_policy->setQuotaForUser(user_name, max_size_in_bytes, max_entries, lock);
+        cache_policy->setQuotaForUser(user_name, max_size_in_bytes, max_entries);
     }
 
     virtual ~CacheBase() = default;

--- a/src/Common/CacheBase.h
+++ b/src/Common/CacheBase.h
@@ -194,10 +194,10 @@ public:
         cache_policy->remove(key);
     }
 
-    size_t weight() const
+    size_t sizeInBytes() const
     {
         std::lock_guard lock(mutex);
-        return cache_policy->weight();
+        return cache_policy->sizeInBytes();
     }
 
     size_t count() const
@@ -206,10 +206,10 @@ public:
         return cache_policy->count();
     }
 
-    size_t maxSize() const
+    size_t maxSizeInBytes() const
     {
         std::lock_guard lock(mutex);
-        return cache_policy->maxSize();
+        return cache_policy->maxSizeInBytes();
     }
 
     void setMaxCount(size_t max_count)
@@ -218,10 +218,10 @@ public:
         cache_policy->setMaxCount(max_count);
     }
 
-    void setMaxSize(size_t max_size_in_bytes)
+    void setMaxSizeInBytes(size_t max_size_in_bytes)
     {
         std::lock_guard lock(mutex);
-        cache_policy->setMaxSize(max_size_in_bytes);
+        cache_policy->setMaxSizeInBytes(max_size_in_bytes);
     }
 
     void setQuotaForUser(const String & user_name, size_t max_size_in_bytes, size_t max_entries)

--- a/src/Common/CacheBase.h
+++ b/src/Common/CacheBase.h
@@ -40,14 +40,17 @@ public:
     using MappedPtr = typename CachePolicy::MappedPtr;
     using KeyMapped = typename CachePolicy::KeyMapped;
 
-    /// Use this ctor if you don't care about the internal cache policy.
-    explicit CacheBase(size_t max_size_in_bytes, size_t max_count = 0, double size_ratio = 0.5)
+    static constexpr auto NO_MAX_COUNT = 0uz;
+    static constexpr auto DEFAULT_SIZE_RATIO = 0.5l;
+
+    /// Use this ctor if you only care about the cache size but not internals like the cache policy.
+    explicit CacheBase(size_t max_size_in_bytes, size_t max_count = NO_MAX_COUNT, double size_ratio = DEFAULT_SIZE_RATIO)
         : CacheBase("SLRU", max_size_in_bytes, max_count, size_ratio)
     {
     }
 
-    /// Use this ctor if you want the user to configure the cache policy via some setting. Supports only general-purpose policies LRU and SLRU.
-    explicit CacheBase(std::string_view cache_policy_name, size_t max_size_in_bytes, size_t max_count = 0, double size_ratio = 0.5)
+    /// Use this ctor if the user should be able to configure the cache policy and cache sizes via settings. Supports only general-purpose policies LRU and SLRU.
+    explicit CacheBase(std::string_view cache_policy_name, size_t max_size_in_bytes, size_t max_count, double size_ratio)
     {
         auto on_weight_loss_function = [&](size_t weight_loss) { onRemoveOverflowWeightLoss(weight_loss); };
 

--- a/src/Common/ICachePolicy.h
+++ b/src/Common/ICachePolicy.h
@@ -37,12 +37,12 @@ public:
     explicit ICachePolicy(CachePolicyUserQuotaPtr user_quotas_) : user_quotas(std::move(user_quotas_)) {}
     virtual ~ICachePolicy() = default;
 
-    virtual size_t weight() const = 0;
+    virtual size_t sizeInBytes() const = 0;
     virtual size_t count() const = 0;
-    virtual size_t maxSize() const = 0;
+    virtual size_t maxSizeInBytes() const = 0;
 
     virtual void setMaxCount(size_t /*max_count*/) = 0;
-    virtual void setMaxSize(size_t /*max_size_in_bytes*/) = 0;
+    virtual void setMaxSizeInBytes(size_t /*max_size_in_bytes*/) = 0;
     virtual void setQuotaForUser(const String & user_name, size_t max_size_in_bytes, size_t max_entries) { user_quotas->setQuotaForUser(user_name, max_size_in_bytes, max_entries); }
 
     /// HashFunction usually hashes the entire key and the found key will be equal the provided key. In such cases, use get(). It is also

--- a/src/Common/ICachePolicy.h
+++ b/src/Common/ICachePolicy.h
@@ -37,25 +37,25 @@ public:
     explicit ICachePolicy(CachePolicyUserQuotaPtr user_quotas_) : user_quotas(std::move(user_quotas_)) {}
     virtual ~ICachePolicy() = default;
 
-    virtual size_t weight(std::lock_guard<std::mutex> & /*cache_lock*/) const = 0;
-    virtual size_t count(std::lock_guard<std::mutex> & /*cache_lock*/) const = 0;
-    virtual size_t maxSize(std::lock_guard<std::mutex>& /*cache_lock*/) const = 0;
+    virtual size_t weight() const = 0;
+    virtual size_t count() const = 0;
+    virtual size_t maxSize() const = 0;
 
-    virtual void setMaxCount(size_t /*max_count*/, std::lock_guard<std::mutex> & /* cache_lock */) = 0;
-    virtual void setMaxSize(size_t /*max_size_in_bytes*/, std::lock_guard<std::mutex> & /* cache_lock */) = 0;
-    virtual void setQuotaForUser(const String & user_name, size_t max_size_in_bytes, size_t max_entries, std::lock_guard<std::mutex> & /*cache_lock*/) { user_quotas->setQuotaForUser(user_name, max_size_in_bytes, max_entries); }
+    virtual void setMaxCount(size_t /*max_count*/) = 0;
+    virtual void setMaxSize(size_t /*max_size_in_bytes*/) = 0;
+    virtual void setQuotaForUser(const String & user_name, size_t max_size_in_bytes, size_t max_entries) { user_quotas->setQuotaForUser(user_name, max_size_in_bytes, max_entries); }
 
     /// HashFunction usually hashes the entire key and the found key will be equal the provided key. In such cases, use get(). It is also
     /// possible to store other, non-hashed data in the key. In that case, the found key is potentially different from the provided key.
     /// Then use getWithKey() to also return the found key including it's non-hashed data.
-    virtual MappedPtr get(const Key & key, std::lock_guard<std::mutex> & /* cache_lock */) = 0;
-    virtual std::optional<KeyMapped> getWithKey(const Key &, std::lock_guard<std::mutex> & /*cache_lock*/) = 0;
+    virtual MappedPtr get(const Key & key) = 0;
+    virtual std::optional<KeyMapped> getWithKey(const Key &) = 0;
 
-    virtual void set(const Key & key, const MappedPtr & mapped, std::lock_guard<std::mutex> & /*cache_lock*/) = 0;
+    virtual void set(const Key & key, const MappedPtr & mapped) = 0;
 
-    virtual void remove(const Key & key, std::lock_guard<std::mutex> & /*cache_lock*/) = 0;
+    virtual void remove(const Key & key) = 0;
 
-    virtual void clear(std::lock_guard<std::mutex> & /*cache_lock*/) = 0;
+    virtual void clear() = 0;
     virtual std::vector<KeyMapped> dump() const = 0;
 
 protected:

--- a/src/Common/LRUCachePolicy.h
+++ b/src/Common/LRUCachePolicy.h
@@ -34,7 +34,7 @@ public:
     {
     }
 
-    size_t weight() const override
+    size_t sizeInBytes() const override
     {
         return current_size_in_bytes;
     }
@@ -44,7 +44,7 @@ public:
         return cells.size();
     }
 
-    size_t maxSize() const override
+    size_t maxSizeInBytes() const override
     {
         return max_size_in_bytes;
     }
@@ -55,7 +55,7 @@ public:
         removeOverflow();
     }
 
-    void setMaxSize(size_t max_size_in_bytes_) override
+    void setMaxSizeInBytes(size_t max_size_in_bytes_) override
     {
         max_size_in_bytes = max_size_in_bytes_;
         removeOverflow();

--- a/src/Common/LRUCachePolicy.h
+++ b/src/Common/LRUCachePolicy.h
@@ -34,41 +34,41 @@ public:
     {
     }
 
-    size_t weight(std::lock_guard<std::mutex> & /* cache_lock */) const override
+    size_t weight() const override
     {
         return current_size_in_bytes;
     }
 
-    size_t count(std::lock_guard<std::mutex> & /* cache_lock */) const override
+    size_t count() const override
     {
         return cells.size();
     }
 
-    size_t maxSize(std::lock_guard<std::mutex> & /* cache_lock */) const override
+    size_t maxSize() const override
     {
         return max_size_in_bytes;
     }
 
-    void setMaxCount(size_t max_count_, std::lock_guard<std::mutex> & /* cache_lock */) override
+    void setMaxCount(size_t max_count_) override
     {
         max_count = max_count_;
         removeOverflow();
     }
 
-    void setMaxSize(size_t max_size_in_bytes_, std::lock_guard<std::mutex> & /* cache_lock */) override
+    void setMaxSize(size_t max_size_in_bytes_) override
     {
         max_size_in_bytes = max_size_in_bytes_;
         removeOverflow();
     }
 
-    void clear(std::lock_guard<std::mutex> & /* cache_lock */) override
+    void clear() override
     {
         queue.clear();
         cells.clear();
         current_size_in_bytes = 0;
     }
 
-    void remove(const Key & key, std::lock_guard<std::mutex> & /* cache_lock */) override
+    void remove(const Key & key) override
     {
         auto it = cells.find(key);
         if (it == cells.end())
@@ -79,7 +79,7 @@ public:
         cells.erase(it);
     }
 
-    MappedPtr get(const Key & key, std::lock_guard<std::mutex> & /* cache_lock */) override
+    MappedPtr get(const Key & key) override
     {
         auto it = cells.find(key);
         if (it == cells.end())
@@ -93,7 +93,7 @@ public:
         return cell.value;
     }
 
-    std::optional<KeyMapped> getWithKey(const Key & key, std::lock_guard<std::mutex> & /*cache_lock*/) override
+    std::optional<KeyMapped> getWithKey(const Key & key) override
     {
         auto it = cells.find(key);
         if (it == cells.end())
@@ -107,7 +107,7 @@ public:
         return std::make_optional<KeyMapped>({it->first, cell.value});
     }
 
-    void set(const Key & key, const MappedPtr & mapped, std::lock_guard<std::mutex> & /* cache_lock */) override
+    void set(const Key & key, const MappedPtr & mapped) override
     {
         auto [it, inserted] = cells.emplace(std::piecewise_construct,
             std::forward_as_tuple(key),

--- a/src/Common/SLRUCachePolicy.h
+++ b/src/Common/SLRUCachePolicy.h
@@ -39,7 +39,7 @@ public:
     {
     }
 
-    size_t weight() const override
+    size_t sizeInBytes() const override
     {
         return current_size_in_bytes;
     }
@@ -49,7 +49,7 @@ public:
         return cells.size();
     }
 
-    size_t maxSize() const override
+    size_t maxSizeInBytes() const override
     {
         return max_size_in_bytes;
     }
@@ -61,7 +61,7 @@ public:
         removeOverflow(probationary_queue, max_size_in_bytes, current_size_in_bytes, /*is_protected=*/false);
     }
 
-    void setMaxSize(size_t max_size_in_bytes_) override
+    void setMaxSizeInBytes(size_t max_size_in_bytes_) override
     {
         max_protected_size = calculateMaxProtectedSize(max_size_in_bytes_, size_ratio);
         max_size_in_bytes = max_size_in_bytes_;

--- a/src/Common/SLRUCachePolicy.h
+++ b/src/Common/SLRUCachePolicy.h
@@ -31,10 +31,10 @@ public:
     /// TODO: construct from special struct with cache policy parameters (also with max_protected_size).
     SLRUCachePolicy(size_t max_size_in_bytes_, size_t max_count_, double size_ratio_, OnWeightLossFunction on_weight_loss_function_)
         : Base(std::make_unique<NoCachePolicyUserQuota>())
-        , size_ratio(size_ratio_)
-        , max_protected_size(static_cast<size_t>(max_size_in_bytes_ * std::min(1.0, size_ratio)))
         , max_size_in_bytes(max_size_in_bytes_)
+        , max_protected_size(static_cast<size_t>(max_size_in_bytes_ * std::min(1.0, size_ratio)))
         , max_count(max_count_)
+        , size_ratio(size_ratio_)
         , on_weight_loss_function(on_weight_loss_function_)
     {
     }
@@ -208,12 +208,12 @@ private:
 
     Cells cells;
 
+    size_t max_size_in_bytes;
+    size_t max_protected_size;
+    size_t max_count;
     const double size_ratio;
     size_t current_protected_size = 0;
     size_t current_size_in_bytes = 0;
-    size_t max_protected_size;
-    size_t max_size_in_bytes;
-    size_t max_count;
 
     WeightFunction weight_function;
     OnWeightLossFunction on_weight_loss_function;

--- a/src/Common/SLRUCachePolicy.h
+++ b/src/Common/SLRUCachePolicy.h
@@ -39,29 +39,29 @@ public:
     {
     }
 
-    size_t weight(std::lock_guard<std::mutex> & /* cache_lock */) const override
+    size_t weight() const override
     {
         return current_size_in_bytes;
     }
 
-    size_t count(std::lock_guard<std::mutex> & /* cache_lock */) const override
+    size_t count() const override
     {
         return cells.size();
     }
 
-    size_t maxSize(std::lock_guard<std::mutex> & /* cache_lock */) const override
+    size_t maxSize() const override
     {
         return max_size_in_bytes;
     }
 
-    void setMaxCount(size_t max_count_, std::lock_guard<std::mutex> & /* cache_lock */) override
+    void setMaxCount(size_t max_count_) override
     {
         max_count = max_count_;
         removeOverflow(protected_queue, max_protected_size, current_protected_size, /*is_protected=*/true);
         removeOverflow(probationary_queue, max_size_in_bytes, current_size_in_bytes, /*is_protected=*/false);
     }
 
-    void setMaxSize(size_t max_size_in_bytes_, std::lock_guard<std::mutex> & /* cache_lock */) override
+    void setMaxSize(size_t max_size_in_bytes_) override
     {
         max_protected_size = calculateMaxProtectedSize(max_size_in_bytes_, size_ratio);
         max_size_in_bytes = max_size_in_bytes_;
@@ -69,7 +69,7 @@ public:
         removeOverflow(probationary_queue, max_size_in_bytes, current_size_in_bytes, /*is_protected=*/false);
     }
 
-    void clear(std::lock_guard<std::mutex> & /* cache_lock */) override
+    void clear() override
     {
         cells.clear();
         probationary_queue.clear();
@@ -78,7 +78,7 @@ public:
         current_protected_size = 0;
     }
 
-    void remove(const Key & key, std::lock_guard<std::mutex> & /* cache_lock */) override
+    void remove(const Key & key) override
     {
         auto it = cells.find(key);
         if (it == cells.end())
@@ -95,7 +95,7 @@ public:
         cells.erase(it);
     }
 
-    MappedPtr get(const Key & key, std::lock_guard<std::mutex> & /* cache_lock */) override
+    MappedPtr get(const Key & key) override
     {
         auto it = cells.find(key);
         if (it == cells.end())
@@ -116,7 +116,7 @@ public:
         return cell.value;
     }
 
-    std::optional<KeyMapped> getWithKey(const Key & key, std::lock_guard<std::mutex> & /*cache_lock*/) override
+    std::optional<KeyMapped> getWithKey(const Key & key) override
     {
         auto it = cells.find(key);
         if (it == cells.end())
@@ -137,7 +137,7 @@ public:
         return std::make_optional<KeyMapped>({it->first, cell.value});
     }
 
-    void set(const Key & key, const MappedPtr & mapped, std::lock_guard<std::mutex> & /* cache_lock */) override
+    void set(const Key & key, const MappedPtr & mapped) override
     {
         auto [it, inserted] = cells.emplace(std::piecewise_construct,
             std::forward_as_tuple(key),

--- a/src/Common/TTLCachePolicy.h
+++ b/src/Common/TTLCachePolicy.h
@@ -94,7 +94,7 @@ public:
     {
     }
 
-    size_t weight() const override
+    size_t sizeInBytes() const override
     {
         return size_in_bytes;
     }
@@ -104,7 +104,7 @@ public:
         return cache.size();
     }
 
-    size_t maxSize() const override
+    size_t maxSizeInBytes() const override
     {
         return max_size_in_bytes;
     }
@@ -115,7 +115,7 @@ public:
         max_count = max_count_;
     }
 
-    void setMaxSize(size_t max_size_in_bytes_) override
+    void setMaxSizeInBytes(size_t max_size_in_bytes_) override
     {
         /// lazy behavior: the cache only shrinks upon the next insert
         max_size_in_bytes = max_size_in_bytes_;

--- a/src/Common/TTLCachePolicy.h
+++ b/src/Common/TTLCachePolicy.h
@@ -94,39 +94,39 @@ public:
     {
     }
 
-    size_t weight(std::lock_guard<std::mutex> & /* cache_lock */) const override
+    size_t weight() const override
     {
         return size_in_bytes;
     }
 
-    size_t count(std::lock_guard<std::mutex> & /* cache_lock */) const override
+    size_t count() const override
     {
         return cache.size();
     }
 
-    size_t maxSize(std::lock_guard<std::mutex> & /* cache_lock */) const override
+    size_t maxSize() const override
     {
         return max_size_in_bytes;
     }
 
-    void setMaxCount(size_t max_count_, std::lock_guard<std::mutex> & /* cache_lock */) override
+    void setMaxCount(size_t max_count_) override
     {
         /// lazy behavior: the cache only shrinks upon the next insert
         max_count = max_count_;
     }
 
-    void setMaxSize(size_t max_size_in_bytes_, std::lock_guard<std::mutex> & /* cache_lock */) override
+    void setMaxSize(size_t max_size_in_bytes_) override
     {
         /// lazy behavior: the cache only shrinks upon the next insert
         max_size_in_bytes = max_size_in_bytes_;
     }
 
-    void clear(std::lock_guard<std::mutex> & /* cache_lock */) override
+    void clear() override
     {
         cache.clear();
     }
 
-    void remove(const Key & key, std::lock_guard<std::mutex> & /* cache_lock */) override
+    void remove(const Key & key) override
     {
         auto it = cache.find(key);
         if (it == cache.end())
@@ -137,7 +137,7 @@ public:
         size_in_bytes -= sz;
     }
 
-    MappedPtr get(const Key & key, std::lock_guard<std::mutex> & /* cache_lock */) override
+    MappedPtr get(const Key & key) override
     {
         auto it = cache.find(key);
         if (it == cache.end())
@@ -145,7 +145,7 @@ public:
         return it->second;
     }
 
-    std::optional<KeyMapped> getWithKey(const Key & key, std::lock_guard<std::mutex> & /* cache_lock */) override
+    std::optional<KeyMapped> getWithKey(const Key & key) override
     {
         auto it = cache.find(key);
         if (it == cache.end())
@@ -154,7 +154,7 @@ public:
     }
 
     /// Evicts on a best-effort basis. If there are too many non-stale entries, the new entry may not be cached at all!
-    void set(const Key & key, const MappedPtr & mapped, std::lock_guard<std::mutex> & /* cache_lock */) override
+    void set(const Key & key, const MappedPtr & mapped) override
     {
         chassert(mapped.get());
 

--- a/src/Common/tests/gtest_lru_cache.cpp
+++ b/src/Common/tests/gtest_lru_cache.cpp
@@ -5,7 +5,7 @@
 TEST(LRUCache, set)
 {
     using SimpleCacheBase = DB::CacheBase<int, int>;
-    auto lru_cache = SimpleCacheBase("LRU", /*max_size_in_bytes*/ 10, /*max_count*/ 10);
+    auto lru_cache = SimpleCacheBase("LRU", /*max_size_in_bytes*/ 10, /*max_count*/ 10, /*size_ratio*/ 0.5);
     lru_cache.set(1, std::make_shared<int>(2));
     lru_cache.set(2, std::make_shared<int>(3));
 
@@ -18,7 +18,7 @@ TEST(LRUCache, set)
 TEST(LRUCache, update)
 {
     using SimpleCacheBase = DB::CacheBase<int, int>;
-    auto lru_cache = SimpleCacheBase("LRU", /*max_size_in_bytes*/ 10, /*max_count*/ 10);
+    auto lru_cache = SimpleCacheBase("LRU", /*max_size_in_bytes*/ 10, /*max_count*/ 10, /*size_ratio*/ 0.5);
     lru_cache.set(1, std::make_shared<int>(2));
     lru_cache.set(1, std::make_shared<int>(3));
     auto val = lru_cache.get(1);
@@ -29,7 +29,7 @@ TEST(LRUCache, update)
 TEST(LRUCache, get)
 {
     using SimpleCacheBase = DB::CacheBase<int, int>;
-    auto lru_cache = SimpleCacheBase("LRU", /*max_size_in_bytes*/ 10, /*max_count*/ 10);
+    auto lru_cache = SimpleCacheBase("LRU", /*max_size_in_bytes*/ 10, /*max_count*/ 10, /*size_ratio*/ 0.5);
     lru_cache.set(1, std::make_shared<int>(2));
     lru_cache.set(2, std::make_shared<int>(3));
     SimpleCacheBase::MappedPtr value = lru_cache.get(1);
@@ -49,7 +49,7 @@ struct ValueWeight
 TEST(LRUCache, evictOnSize)
 {
     using SimpleCacheBase = DB::CacheBase<int, size_t>;
-    auto lru_cache = SimpleCacheBase("LRU", /*max_size_in_bytes*/ 20, /*max_count*/ 3);
+    auto lru_cache = SimpleCacheBase("LRU", /*max_size_in_bytes*/ 20, /*max_count*/ 3, /*size_ratio*/ 0.5);
     lru_cache.set(1, std::make_shared<size_t>(2));
     lru_cache.set(2, std::make_shared<size_t>(3));
     lru_cache.set(3, std::make_shared<size_t>(4));
@@ -65,7 +65,7 @@ TEST(LRUCache, evictOnSize)
 TEST(LRUCache, evictOnWeight)
 {
     using SimpleCacheBase = DB::CacheBase<int, size_t, std::hash<int>, ValueWeight>;
-    auto lru_cache = SimpleCacheBase("LRU", /*max_size_in_bytes*/ 10, /*max_count*/ 10);
+    auto lru_cache = SimpleCacheBase("LRU", /*max_size_in_bytes*/ 10, /*max_count*/ 10, /*size_ratio*/ 0.5);
     lru_cache.set(1, std::make_shared<size_t>(2));
     lru_cache.set(2, std::make_shared<size_t>(3));
     lru_cache.set(3, std::make_shared<size_t>(4));
@@ -86,7 +86,7 @@ TEST(LRUCache, evictOnWeight)
 TEST(LRUCache, getOrSet)
 {
     using SimpleCacheBase = DB::CacheBase<int, size_t, std::hash<int>, ValueWeight>;
-    auto lru_cache = SimpleCacheBase("LRU", /*max_size_in_bytes*/ 10, /*max_count*/ 10);
+    auto lru_cache = SimpleCacheBase("LRU", /*max_size_in_bytes*/ 10, /*max_count*/ 10, /*size_ratio*/ 0.5);
     size_t x = 10;
     auto load_func = [&] { return std::make_shared<size_t>(x); };
     auto [value, loaded] = lru_cache.getOrSet(1, load_func);

--- a/src/Common/tests/gtest_lru_cache.cpp
+++ b/src/Common/tests/gtest_lru_cache.cpp
@@ -9,7 +9,7 @@ TEST(LRUCache, set)
     lru_cache.set(1, std::make_shared<int>(2));
     lru_cache.set(2, std::make_shared<int>(3));
 
-    auto w = lru_cache.weight();
+    auto w = lru_cache.sizeInBytes();
     auto n = lru_cache.count();
     ASSERT_EQ(w, 2);
     ASSERT_EQ(n, 2);
@@ -74,7 +74,7 @@ TEST(LRUCache, evictOnWeight)
     auto n = lru_cache.count();
     ASSERT_EQ(n, 2);
 
-    auto w = lru_cache.weight();
+    auto w = lru_cache.sizeInBytes();
     ASSERT_EQ(w, 9);
 
     auto value = lru_cache.get(1);

--- a/src/Common/tests/gtest_slru_cache.cpp
+++ b/src/Common/tests/gtest_slru_cache.cpp
@@ -9,7 +9,7 @@ TEST(SLRUCache, set)
     slru_cache.set(1, std::make_shared<int>(2));
     slru_cache.set(2, std::make_shared<int>(3));
 
-    auto w = slru_cache.weight();
+    auto w = slru_cache.sizeInBytes();
     auto n = slru_cache.count();
     ASSERT_EQ(w, 2);
     ASSERT_EQ(n, 2);
@@ -125,7 +125,7 @@ TEST(SLRUCache, evictOnElements)
     auto n = slru_cache.count();
     ASSERT_EQ(n, 1);
 
-    auto w = slru_cache.weight();
+    auto w = slru_cache.sizeInBytes();
     ASSERT_EQ(w, 3);
 
     auto value = slru_cache.get(1);
@@ -148,7 +148,7 @@ TEST(SLRUCache, evictOnWeight)
     auto n = slru_cache.count();
     ASSERT_EQ(n, 2);
 
-    auto w = slru_cache.weight();
+    auto w = slru_cache.sizeInBytes();
     ASSERT_EQ(w, 9);
 
     auto value = slru_cache.get(1);

--- a/src/Compression/examples/cached_compressed_read_buffer.cpp
+++ b/src/Compression/examples/cached_compressed_read_buffer.cpp
@@ -23,7 +23,7 @@ int main(int argc, char ** argv)
 
     try
     {
-        UncompressedCache cache(1024);
+        UncompressedCache cache("SLRU", 1024, 0.5);
         std::string path = argv[1];
 
         std::cerr << std::fixed << std::setprecision(3);

--- a/src/Core/Defines.h
+++ b/src/Core/Defines.h
@@ -66,12 +66,18 @@
 #define DBMS_HIERARCHICAL_DICTIONARY_MAX_DEPTH 1000
 
 /// Default maximum (total and entry) sizes and policies of various caches
-static constexpr auto DEFAULT_UNCOMPRESSED_CACHE_MAX_SIZE = 0_MiB;
 static constexpr auto DEFAULT_UNCOMPRESSED_CACHE_POLICY = "SLRU";
-static constexpr auto DEFAULT_MARK_CACHE_MAX_SIZE = 5368_MiB;
+static constexpr auto DEFAULT_UNCOMPRESSED_CACHE_MAX_SIZE = 0_MiB;
+static constexpr auto DEFAULT_UNCOMPRESSED_CACHE_SIZE_RATIO = 0.5l;
 static constexpr auto DEFAULT_MARK_CACHE_POLICY = "SLRU";
+static constexpr auto DEFAULT_MARK_CACHE_MAX_SIZE = 5368_MiB;
+static constexpr auto DEFAULT_MARK_CACHE_SIZE_RATIO = 0.5l;
+static constexpr auto DEFAULT_INDEX_UNCOMPRESSED_CACHE_POLICY = "SLRU";
 static constexpr auto DEFAULT_INDEX_UNCOMPRESSED_CACHE_MAX_SIZE = 0_MiB;
+static constexpr auto DEFAULT_INDEX_UNCOMPRESSED_CACHE_SIZE_RATIO = 0.5l;
+static constexpr auto DEFAULT_INDEX_MARK_CACHE_POLICY = "SLRU";
 static constexpr auto DEFAULT_INDEX_MARK_CACHE_MAX_SIZE = 0_MiB;
+static constexpr auto DEFAULT_INDEX_MARK_CACHE_SIZE_RATIO = 0.5l;
 static constexpr auto DEFAULT_MMAP_CACHE_MAX_SIZE = 1_KiB; /// chosen by rolling dice
 static constexpr auto DEFAULT_COMPILED_EXPRESSION_CACHE_MAX_SIZE = 128_MiB;
 static constexpr auto DEFAULT_COMPILED_EXPRESSION_CACHE_MAX_ENTRIES = 10'000;

--- a/src/Core/ServerSettings.h
+++ b/src/Core/ServerSettings.h
@@ -60,10 +60,16 @@ namespace DB
     M(Double, cache_size_to_ram_max_ratio, 0.5, "Set cache size ro RAM max ratio. Allows to lower cache size on low-memory systems.", 0) \
     M(String, uncompressed_cache_policy, DEFAULT_UNCOMPRESSED_CACHE_POLICY, "Uncompressed cache policy name.", 0) \
     M(UInt64, uncompressed_cache_size, DEFAULT_UNCOMPRESSED_CACHE_MAX_SIZE, "Size of cache for uncompressed blocks. Zero means disabled.", 0) \
-    M(UInt64, mark_cache_size, DEFAULT_MARK_CACHE_MAX_SIZE, "Size of cache for marks (index of MergeTree family of tables).", 0) \
+    M(Double, uncompressed_cache_size_ratio, DEFAULT_UNCOMPRESSED_CACHE_SIZE_RATIO, "The size of the protected queue in the uncompressed cache relative to the cache's total size.", 0) \
     M(String, mark_cache_policy, DEFAULT_MARK_CACHE_POLICY, "Mark cache policy name.", 0) \
+    M(UInt64, mark_cache_size, DEFAULT_MARK_CACHE_MAX_SIZE, "Size of cache for marks (index of MergeTree family of tables).", 0) \
+    M(Double, mark_cache_size_ratio, DEFAULT_MARK_CACHE_SIZE_RATIO, "The size of the protected queue in the mark cache relative to the cache's total size.", 0) \
+    M(String, index_uncompressed_cache_policy, DEFAULT_INDEX_UNCOMPRESSED_CACHE_POLICY, "Index uncompressed cache policy name.", 0) \
     M(UInt64, index_uncompressed_cache_size, DEFAULT_INDEX_UNCOMPRESSED_CACHE_MAX_SIZE, "Size of cache for uncompressed blocks of MergeTree indices. Zero means disabled.", 0) \
+    M(Double, index_uncompressed_cache_size_ratio, DEFAULT_INDEX_UNCOMPRESSED_CACHE_SIZE_RATIO, "The size of the protected queue in the index uncompressed cache relative to the cache's total size.", 0) \
+    M(String, index_mark_cache_policy, DEFAULT_INDEX_MARK_CACHE_POLICY, "Index mark cache policy name.", 0) \
     M(UInt64, index_mark_cache_size, DEFAULT_INDEX_MARK_CACHE_MAX_SIZE, "Size of cache for index marks. Zero means disabled.", 0) \
+    M(Double, index_mark_cache_size_ratio, DEFAULT_INDEX_MARK_CACHE_SIZE_RATIO, "The size of the protected queue in the index mark cache relative to the cache's total size.", 0) \
     M(UInt64, mmap_cache_size, DEFAULT_MMAP_CACHE_MAX_SIZE, "A cache for mmapped files.", 0) \
     \
     M(Bool, disable_internal_dns_cache, false, "Disable internal DNS caching at all.", 0) \

--- a/src/IO/UncompressedCache.h
+++ b/src/IO/UncompressedCache.h
@@ -42,8 +42,8 @@ private:
     using Base = CacheBase<UInt128, UncompressedCacheCell, UInt128TrivialHash, UncompressedSizeWeightFunction>;
 
 public:
-    UncompressedCache(const String & uncompressed_cache_policy, size_t max_size_in_bytes, double size_ratio)
-        : Base(uncompressed_cache_policy, max_size_in_bytes, 0, size_ratio) {}
+    UncompressedCache(const String & cache_policy, size_t max_size_in_bytes, double size_ratio)
+        : Base(cache_policy, max_size_in_bytes, 0, size_ratio) {}
 
     /// Calculate key from path to file and offset.
     static UInt128 hash(const String & path_to_file, size_t offset)

--- a/src/IO/UncompressedCache.h
+++ b/src/IO/UncompressedCache.h
@@ -42,11 +42,8 @@ private:
     using Base = CacheBase<UInt128, UncompressedCacheCell, UInt128TrivialHash, UncompressedSizeWeightFunction>;
 
 public:
-    explicit UncompressedCache(size_t max_size_in_bytes)
-        : Base(max_size_in_bytes) {}
-
-    UncompressedCache(const String & uncompressed_cache_policy, size_t max_size_in_bytes)
-        : Base(uncompressed_cache_policy, max_size_in_bytes) {}
+    UncompressedCache(const String & uncompressed_cache_policy, size_t max_size_in_bytes, double size_ratio)
+        : Base(uncompressed_cache_policy, max_size_in_bytes, 0, size_ratio) {}
 
     /// Calculate key from path to file and offset.
     static UInt128 hash(const String & path_to_file, size_t offset)

--- a/src/Interpreters/Aggregator.cpp
+++ b/src/Interpreters/Aggregator.cpp
@@ -175,7 +175,7 @@ public:
 private:
     CachePtr getHashTableStatsCache(const Params & params, const std::lock_guard<std::mutex> &)
     {
-        if (!hash_table_stats || hash_table_stats->maxSize() != params.max_entries_for_hash_table_stats)
+        if (!hash_table_stats || hash_table_stats->maxSizeInBytes() != params.max_entries_for_hash_table_stats)
             hash_table_stats = std::make_shared<Cache>(params.max_entries_for_hash_table_stats);
         return hash_table_stats;
     }

--- a/src/Interpreters/Cache/QueryCache.cpp
+++ b/src/Interpreters/Cache/QueryCache.cpp
@@ -480,7 +480,7 @@ QueryCache::QueryCache(size_t max_size_in_bytes, size_t max_entries, size_t max_
 void QueryCache::updateConfiguration(size_t max_size_in_bytes, size_t max_entries, size_t max_entry_size_in_bytes_, size_t max_entry_size_in_rows_)
 {
     std::lock_guard lock(mutex);
-    cache.setMaxSize(max_size_in_bytes);
+    cache.setMaxSizeInBytes(max_size_in_bytes);
     cache.setMaxCount(max_entries);
     max_entry_size_in_bytes = max_entry_size_in_bytes_;
     max_entry_size_in_rows = max_entry_size_in_rows_;
@@ -510,9 +510,9 @@ void QueryCache::clear()
     times_executed.clear();
 }
 
-size_t QueryCache::weight() const
+size_t QueryCache::sizeInBytes() const
 {
-    return cache.weight();
+    return cache.sizeInBytes();
 }
 
 size_t QueryCache::count() const

--- a/src/Interpreters/Cache/QueryCache.h
+++ b/src/Interpreters/Cache/QueryCache.h
@@ -182,7 +182,7 @@ public:
 
     void clear();
 
-    size_t weight() const;
+    size_t sizeInBytes() const;
     size_t count() const;
 
     /// Record new execution of query represented by key. Returns number of executions so far.

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -2286,7 +2286,7 @@ void Context::updateUncompressedCacheConfiguration(const Poco::Util::AbstractCon
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Uncompressed cache was not created yet.");
 
     size_t max_size_in_bytes = config.getUInt64("uncompressed_cache_size", DEFAULT_UNCOMPRESSED_CACHE_MAX_SIZE);
-    shared->uncompressed_cache->setMaxSize(max_size_in_bytes);
+    shared->uncompressed_cache->setMaxSizeInBytes(max_size_in_bytes);
 }
 
 UncompressedCachePtr Context::getUncompressedCache() const
@@ -2321,7 +2321,7 @@ void Context::updateMarkCacheConfiguration(const Poco::Util::AbstractConfigurati
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Mark cache was not created yet.");
 
     size_t max_size_in_bytes = config.getUInt64("mark_cache_size", DEFAULT_MARK_CACHE_MAX_SIZE);
-    shared->mark_cache->setMaxSize(max_size_in_bytes);
+    shared->mark_cache->setMaxSizeInBytes(max_size_in_bytes);
 }
 
 MarkCachePtr Context::getMarkCache() const
@@ -2371,7 +2371,7 @@ void Context::updateIndexUncompressedCacheConfiguration(const Poco::Util::Abstra
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Index uncompressed cache was not created yet.");
 
     size_t max_size_in_bytes = config.getUInt64("index_uncompressed_cache_size", DEFAULT_INDEX_UNCOMPRESSED_CACHE_MAX_SIZE);
-    shared->index_uncompressed_cache->setMaxSize(max_size_in_bytes);
+    shared->index_uncompressed_cache->setMaxSizeInBytes(max_size_in_bytes);
 }
 
 UncompressedCachePtr Context::getIndexUncompressedCache() const
@@ -2406,7 +2406,7 @@ void Context::updateIndexMarkCacheConfiguration(const Poco::Util::AbstractConfig
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Index mark cache was not created yet.");
 
     size_t max_size_in_bytes = config.getUInt64("index_mark_cache_size", DEFAULT_INDEX_MARK_CACHE_MAX_SIZE);
-    shared->index_mark_cache->setMaxSize(max_size_in_bytes);
+    shared->index_mark_cache->setMaxSizeInBytes(max_size_in_bytes);
 }
 
 MarkCachePtr Context::getIndexMarkCache() const
@@ -2441,7 +2441,7 @@ void Context::updateMMappedFileCacheConfiguration(const Poco::Util::AbstractConf
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Mapped file cache was not created yet.");
 
     size_t max_size_in_bytes = config.getUInt64("mmap_cache_size", DEFAULT_MMAP_CACHE_MAX_SIZE);
-    shared->mmap_cache->setMaxSize(max_size_in_bytes);
+    shared->mmap_cache->setMaxSizeInBytes(max_size_in_bytes);
 }
 
 MMappedFileCachePtr Context::getMMappedFileCache() const

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -2268,14 +2268,14 @@ QueryStatusPtr Context::getProcessListElement() const
 }
 
 
-void Context::setUncompressedCache(const String & uncompressed_cache_policy, size_t max_size_in_bytes)
+void Context::setUncompressedCache(const String & cache_policy, size_t max_size_in_bytes, double size_ratio)
 {
     auto lock = getLock();
 
     if (shared->uncompressed_cache)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Uncompressed cache has been already created.");
 
-    shared->uncompressed_cache = std::make_shared<UncompressedCache>(uncompressed_cache_policy, max_size_in_bytes);
+    shared->uncompressed_cache = std::make_shared<UncompressedCache>(cache_policy, max_size_in_bytes, size_ratio);
 }
 
 void Context::updateUncompressedCacheConfiguration(const Poco::Util::AbstractConfiguration & config)
@@ -2303,14 +2303,14 @@ void Context::clearUncompressedCache() const
         shared->uncompressed_cache->clear();
 }
 
-void Context::setMarkCache(const String & mark_cache_policy, size_t cache_size_in_bytes)
+void Context::setMarkCache(const String & cache_policy, size_t cache_size_in_bytes, double size_ratio)
 {
     auto lock = getLock();
 
     if (shared->mark_cache)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Mark cache has been already created.");
 
-    shared->mark_cache = std::make_shared<MarkCache>(mark_cache_policy, cache_size_in_bytes);
+    shared->mark_cache = std::make_shared<MarkCache>(cache_policy, cache_size_in_bytes, size_ratio);
 }
 
 void Context::updateMarkCacheConfiguration(const Poco::Util::AbstractConfiguration & config)
@@ -2353,14 +2353,14 @@ ThreadPool & Context::getLoadMarksThreadpool() const
     return *shared->load_marks_threadpool;
 }
 
-void Context::setIndexUncompressedCache(size_t max_size_in_bytes)
+void Context::setIndexUncompressedCache(const String & cache_policy, size_t max_size_in_bytes, double size_ratio)
 {
     auto lock = getLock();
 
     if (shared->index_uncompressed_cache)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Index uncompressed cache has been already created.");
 
-    shared->index_uncompressed_cache = std::make_shared<UncompressedCache>(max_size_in_bytes);
+    shared->index_uncompressed_cache = std::make_shared<UncompressedCache>(cache_policy, max_size_in_bytes, size_ratio);
 }
 
 void Context::updateIndexUncompressedCacheConfiguration(const Poco::Util::AbstractConfiguration & config)
@@ -2388,14 +2388,14 @@ void Context::clearIndexUncompressedCache() const
         shared->index_uncompressed_cache->clear();
 }
 
-void Context::setIndexMarkCache(size_t cache_size_in_bytes)
+void Context::setIndexMarkCache(const String & cache_policy, size_t cache_size_in_bytes, double size_ratio)
 {
     auto lock = getLock();
 
     if (shared->index_mark_cache)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Index mark cache has been already created.");
 
-    shared->index_mark_cache = std::make_shared<MarkCache>(cache_size_in_bytes);
+    shared->index_mark_cache = std::make_shared<MarkCache>(cache_policy, cache_size_in_bytes, size_ratio);
 }
 
 void Context::updateIndexMarkCacheConfiguration(const Poco::Util::AbstractConfiguration & config)

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -2303,14 +2303,14 @@ void Context::clearUncompressedCache() const
         shared->uncompressed_cache->clear();
 }
 
-void Context::setMarkCache(const String & cache_policy, size_t cache_size_in_bytes, double size_ratio)
+void Context::setMarkCache(const String & cache_policy, size_t max_cache_size_in_bytes, double size_ratio)
 {
     auto lock = getLock();
 
     if (shared->mark_cache)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Mark cache has been already created.");
 
-    shared->mark_cache = std::make_shared<MarkCache>(cache_policy, cache_size_in_bytes, size_ratio);
+    shared->mark_cache = std::make_shared<MarkCache>(cache_policy, max_cache_size_in_bytes, size_ratio);
 }
 
 void Context::updateMarkCacheConfiguration(const Poco::Util::AbstractConfiguration & config)
@@ -2388,14 +2388,14 @@ void Context::clearIndexUncompressedCache() const
         shared->index_uncompressed_cache->clear();
 }
 
-void Context::setIndexMarkCache(const String & cache_policy, size_t cache_size_in_bytes, double size_ratio)
+void Context::setIndexMarkCache(const String & cache_policy, size_t max_cache_size_in_bytes, double size_ratio)
 {
     auto lock = getLock();
 
     if (shared->index_mark_cache)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Index mark cache has been already created.");
 
-    shared->index_mark_cache = std::make_shared<MarkCache>(cache_policy, cache_size_in_bytes, size_ratio);
+    shared->index_mark_cache = std::make_shared<MarkCache>(cache_policy, max_cache_size_in_bytes, size_ratio);
 }
 
 void Context::updateIndexMarkCacheConfiguration(const Poco::Util::AbstractConfiguration & config)
@@ -2423,14 +2423,14 @@ void Context::clearIndexMarkCache() const
         shared->index_mark_cache->clear();
 }
 
-void Context::setMMappedFileCache(size_t cache_size_in_num_entries)
+void Context::setMMappedFileCache(size_t max_cache_size_in_num_entries)
 {
     auto lock = getLock();
 
     if (shared->mmap_cache)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Mapped file cache has been already created.");
 
-    shared->mmap_cache = std::make_shared<MMappedFileCache>(cache_size_in_num_entries);
+    shared->mmap_cache = std::make_shared<MMappedFileCache>(max_cache_size_in_num_entries);
 }
 
 void Context::updateMMappedFileCacheConfiguration(const Poco::Util::AbstractConfiguration & config)

--- a/src/Interpreters/Context.h
+++ b/src/Interpreters/Context.h
@@ -943,7 +943,7 @@ public:
     std::shared_ptr<MarkCache> getIndexMarkCache() const;
     void clearIndexMarkCache() const;
 
-    void setMMappedFileCache(size_t cache_size_in_num_entries);
+    void setMMappedFileCache(size_t max_cache_size_in_num_entries);
     void updateMMappedFileCacheConfiguration(const Poco::Util::AbstractConfiguration & config);
     std::shared_ptr<MMappedFileCache> getMMappedFileCache() const;
     void clearMMappedFileCache() const;

--- a/src/Interpreters/Context.h
+++ b/src/Interpreters/Context.h
@@ -922,23 +922,23 @@ public:
 
     /// --- Caches ------------------------------------------------------------------------------------------
 
-    void setUncompressedCache(const String & uncompressed_cache_policy, size_t max_size_in_bytes);
+    void setUncompressedCache(const String & cache_policy, size_t max_size_in_bytes, double size_ratio);
     void updateUncompressedCacheConfiguration(const Poco::Util::AbstractConfiguration & config);
     std::shared_ptr<UncompressedCache> getUncompressedCache() const;
     void clearUncompressedCache() const;
 
-    void setMarkCache(const String & mark_cache_policy, size_t cache_size_in_bytes);
+    void setMarkCache(const String & cache_policy, size_t cache_size_in_bytes, double size_ratio);
     void updateMarkCacheConfiguration(const Poco::Util::AbstractConfiguration & config);
     std::shared_ptr<MarkCache> getMarkCache() const;
     void clearMarkCache() const;
     ThreadPool & getLoadMarksThreadpool() const;
 
-    void setIndexUncompressedCache(size_t max_size_in_bytes);
+    void setIndexUncompressedCache(const String & cache_policy, size_t max_size_in_bytes, double size_ratio);
     void updateIndexUncompressedCacheConfiguration(const Poco::Util::AbstractConfiguration & config);
     std::shared_ptr<UncompressedCache> getIndexUncompressedCache() const;
     void clearIndexUncompressedCache() const;
 
-    void setIndexMarkCache(size_t cache_size_in_bytes);
+    void setIndexMarkCache(const String & cache_policy, size_t cache_size_in_bytes, double size_ratio);
     void updateIndexMarkCacheConfiguration(const Poco::Util::AbstractConfiguration & config);
     std::shared_ptr<MarkCache> getIndexMarkCache() const;
     void clearIndexMarkCache() const;

--- a/src/Interpreters/Context.h
+++ b/src/Interpreters/Context.h
@@ -927,7 +927,7 @@ public:
     std::shared_ptr<UncompressedCache> getUncompressedCache() const;
     void clearUncompressedCache() const;
 
-    void setMarkCache(const String & cache_policy, size_t cache_size_in_bytes, double size_ratio);
+    void setMarkCache(const String & cache_policy, size_t max_cache_size_in_bytes, double size_ratio);
     void updateMarkCacheConfiguration(const Poco::Util::AbstractConfiguration & config);
     std::shared_ptr<MarkCache> getMarkCache() const;
     void clearMarkCache() const;
@@ -938,7 +938,7 @@ public:
     std::shared_ptr<UncompressedCache> getIndexUncompressedCache() const;
     void clearIndexUncompressedCache() const;
 
-    void setIndexMarkCache(const String & cache_policy, size_t cache_size_in_bytes, double size_ratio);
+    void setIndexMarkCache(const String & cache_policy, size_t max_cache_size_in_bytes, double size_ratio);
     void updateIndexMarkCacheConfiguration(const Poco::Util::AbstractConfiguration & config);
     std::shared_ptr<MarkCache> getIndexMarkCache() const;
     void clearIndexMarkCache() const;

--- a/src/Interpreters/ServerAsynchronousMetrics.cpp
+++ b/src/Interpreters/ServerAsynchronousMetrics.cpp
@@ -68,13 +68,13 @@ void ServerAsynchronousMetrics::updateImpl(AsynchronousMetricValues & new_values
 {
     if (auto mark_cache = getContext()->getMarkCache())
     {
-        new_values["MarkCacheBytes"] = { mark_cache->weight(), "Total size of mark cache in bytes" };
+        new_values["MarkCacheBytes"] = { mark_cache->sizeInBytes(), "Total size of mark cache in bytes" };
         new_values["MarkCacheFiles"] = { mark_cache->count(), "Total number of mark files cached in the mark cache" };
     }
 
     if (auto uncompressed_cache = getContext()->getUncompressedCache())
     {
-        new_values["UncompressedCacheBytes"] = { uncompressed_cache->weight(),
+        new_values["UncompressedCacheBytes"] = { uncompressed_cache->sizeInBytes(),
             "Total size of uncompressed cache in bytes. Uncompressed cache does not usually improve the performance and should be mostly avoided." };
         new_values["UncompressedCacheCells"] = { uncompressed_cache->count(),
             "Total number of entries in the uncompressed cache. Each entry represents a decompressed block of data. Uncompressed cache does not usually improve performance and should be mostly avoided." };
@@ -82,13 +82,13 @@ void ServerAsynchronousMetrics::updateImpl(AsynchronousMetricValues & new_values
 
     if (auto index_mark_cache = getContext()->getIndexMarkCache())
     {
-        new_values["IndexMarkCacheBytes"] = { index_mark_cache->weight(), "Total size of mark cache for secondary indices in bytes." };
+        new_values["IndexMarkCacheBytes"] = { index_mark_cache->sizeInBytes(), "Total size of mark cache for secondary indices in bytes." };
         new_values["IndexMarkCacheFiles"] = { index_mark_cache->count(), "Total number of mark files cached in the mark cache for secondary indices." };
     }
 
     if (auto index_uncompressed_cache = getContext()->getIndexUncompressedCache())
     {
-        new_values["IndexUncompressedCacheBytes"] = { index_uncompressed_cache->weight(),
+        new_values["IndexUncompressedCacheBytes"] = { index_uncompressed_cache->sizeInBytes(),
             "Total size of uncompressed cache in bytes for secondary indices. Uncompressed cache does not usually improve the performance and should be mostly avoided." };
         new_values["IndexUncompressedCacheCells"] = { index_uncompressed_cache->count(),
             "Total number of entries in the uncompressed cache for secondary indices. Each entry represents a decompressed block of data. Uncompressed cache does not usually improve performance and should be mostly avoided." };
@@ -104,7 +104,7 @@ void ServerAsynchronousMetrics::updateImpl(AsynchronousMetricValues & new_values
 
     if (auto query_cache = getContext()->getQueryCache())
     {
-        new_values["QueryCacheBytes"] = { query_cache->weight(), "Total size of the query cache in bytes." };
+        new_values["QueryCacheBytes"] = { query_cache->sizeInBytes(), "Total size of the query cache in bytes." };
         new_values["QueryCacheEntries"] = { query_cache->count(), "Total number of entries in the query cache." };
     }
 
@@ -136,7 +136,7 @@ void ServerAsynchronousMetrics::updateImpl(AsynchronousMetricValues & new_values
 #if USE_EMBEDDED_COMPILER
     if (auto * compiled_expression_cache = CompiledExpressionCacheFactory::instance().tryGetCache())
     {
-        new_values["CompiledExpressionCacheBytes"] = { compiled_expression_cache->weight(),
+        new_values["CompiledExpressionCacheBytes"] = { compiled_expression_cache->sizeInBytes(),
             "Total bytes used for the cache of JIT-compiled code." };
         new_values["CompiledExpressionCacheCount"] = { compiled_expression_cache->count(),
             "Total entries in the cache of JIT-compiled code." };

--- a/src/Storages/MarkCache.h
+++ b/src/Storages/MarkCache.h
@@ -41,8 +41,8 @@ private:
     using Base = CacheBase<UInt128, MarksInCompressedFile, UInt128TrivialHash, MarksWeightFunction>;
 
 public:
-    MarkCache(const String & mark_cache_policy, size_t max_size_in_bytes, double size_ratio)
-        : Base(mark_cache_policy, max_size_in_bytes, 0, size_ratio) {}
+    MarkCache(const String & cache_policy, size_t max_size_in_bytes, double size_ratio)
+        : Base(cache_policy, max_size_in_bytes, 0, size_ratio) {}
 
     /// Calculate key from path to file and offset.
     static UInt128 hash(const String & path_to_file)

--- a/src/Storages/MarkCache.h
+++ b/src/Storages/MarkCache.h
@@ -41,11 +41,8 @@ private:
     using Base = CacheBase<UInt128, MarksInCompressedFile, UInt128TrivialHash, MarksWeightFunction>;
 
 public:
-    explicit MarkCache(size_t max_size_in_bytes)
-        : Base(max_size_in_bytes) {}
-
-    MarkCache(const String & mark_cache_policy, size_t max_size_in_bytes)
-        : Base(mark_cache_policy, max_size_in_bytes) {}
+    MarkCache(const String & mark_cache_policy, size_t max_size_in_bytes, double size_ratio)
+        : Base(mark_cache_policy, max_size_in_bytes, 0, size_ratio) {}
 
     /// Calculate key from path to file and offset.
     static UInt128 hash(const String & path_to_file)


### PR DESCRIPTION
Follow-up to #51446, see the individual commits for what changed.

### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
As expert-level settings, it is now possible to 1. configure the size_ratio (i.e. the relative size of the protected queue) of the [index] mark/uncompressed caches, 2. configure the cache policy of the index mark and index uncompressed caches.