### PR TITLE
Remove useless slow on client performance check

### DIFF
--- a/docker/test/performance-comparison/compare.sh
+++ b/docker/test/performance-comparison/compare.sh
@@ -644,7 +644,7 @@ function report
 rm -r report ||:
 mkdir report report/tmp ||:
 
-rm ./*.{rep,svg} test-times.tsv test-dump.tsv unstable.tsv unstable-query-ids.tsv unstable-query-metrics.tsv changed-perf.tsv unstable-tests.tsv unstable-queries.tsv bad-tests.tsv slow-on-client.tsv all-queries.tsv run-errors.tsv ||:
+rm ./*.{rep,svg} test-times.tsv test-dump.tsv unstable.tsv unstable-query-ids.tsv unstable-query-metrics.tsv changed-perf.tsv unstable-tests.tsv unstable-queries.tsv bad-tests.tsv all-queries.tsv run-errors.tsv ||:
 
 cat analyze/errors.log >> report/errors.log ||:
 cat profile-errors.log >> report/errors.log ||:
@@ -809,12 +809,6 @@ create table test_perf_changes_report engine File(TSV, 'report/test-perf-changes
 create view total_client_time_per_query as select *
     from file('analyze/client-times.tsv', TSV,
         'test text, query_index int, client float, server float');
-
-create table slow_on_client_report engine File(TSV, 'report/slow-on-client.tsv')
-    as select client, server, round(client/server, 3) p,
-        test, query_display_name
-    from total_client_time_per_query left join query_display_names using (test, query_index)
-    where p > round(1.02, 3) order by p desc;
 
 create table wall_clock_time_per_test engine Memory as select *
     from file('wall-clock-times.tsv', TSV, 'test text, real float, user float, system float');

--- a/docker/test/performance-comparison/report.py
+++ b/docker/test/performance-comparison/report.py
@@ -364,20 +364,6 @@ if args.report == "main":
             ]
         )
 
-    slow_on_client_rows = tsvRows("report/slow-on-client.tsv")
-    error_tests += len(slow_on_client_rows)
-    addSimpleTable(
-        "Slow on Client",
-        ["Client time,&nbsp;s", "Server time,&nbsp;s", "Ratio", "Test", "Query"],
-        slow_on_client_rows,
-    )
-    if slow_on_client_rows:
-        errors_explained.append(
-            [
-                f'<a href="#{currentTableAnchor()}">Some queries are taking noticeable time client-side (missing `FORMAT Null`?)</a>'
-            ]
-        )
-
     def add_backward_incompatible():
         rows = tsvRows("report/partial-queries-report.tsv")
         if not rows:


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Remove useless slow on client performance check


Remove the `Slow on Client` check in performance tests. This test isn't doing what it says it's doing, as the only difference between the "client time" and "server time" is whether the measurement happens inside or outside of the loop making the requests, that is, the client time is the server time plus the time spent passing parameters to the execute function and the time printing the timings (io).

ClickHouse driver measuring time (aka "server time"): https://github.com/mymarilyn/clickhouse-driver/blob/ce712b5bc7a7900e844c7c8f99a1e3426aa326f7/clickhouse_driver/client.py#L359-L379

ClickHouse measuring "client time": https://github.com/ClickHouse/ClickHouse/blob/698ceee1a9373722d5a7caea8c9cb197ffaed3cd/docker/test/performance-comparison/perf.py#L415-L468

Note: Tagged as performance to force a performance run to make sure reports are ok.
Closes https://github.com/ClickHouse/ClickHouse/issues/53551

