### PR TITLE
Hardening checks for sorted distinct due to crashes

### DIFF
--- a/src/Processors/Transforms/DistinctSortedChunkTransform.h
+++ b/src/Processors/Transforms/DistinctSortedChunkTransform.h
@@ -72,6 +72,9 @@ private:
 
     MutableColumns prev_chunk_latest_key;
     const bool sorted_stream = false;
+
+    /// Temporary hardening due to crashes
+    bool non_sorted_string_column_only = false;
 };
 
 }


### PR DESCRIPTION
Addresses the case when only have one non-sorted String column in sorted distinct. Check if the string column contains invalid strings before inserting it into the clearable hash table; otherwise, it can lead to a crash like [this](https://github.com/ClickHouse/ClickHouse/issues/52540#issue-1819301578). Related to #52540

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
