### PR TITLE
Fix: sorted distinct with sparse columns

### DIFF
--- a/src/Processors/Transforms/DistinctSortedChunkTransform.cpp
+++ b/src/Processors/Transforms/DistinctSortedChunkTransform.cpp
@@ -205,6 +205,8 @@ void DistinctSortedChunkTransform::transform(Chunk & chunk)
     if (unlikely(0 == chunk_rows))
         return;
 
+    convertToFullIfSparse(chunk);
+
     Columns input_columns = chunk.detachColumns();
     /// split input columns into sorted and other("non-sorted") columns
     initChunkProcessing(input_columns);

--- a/tests/queries/0_stateless/02862_sorted_distinct_sparse_fix.reference
+++ b/tests/queries/0_stateless/02862_sorted_distinct_sparse_fix.reference
@@ -1,0 +1,12 @@
+-- { echoOn }
+SELECT name, column, serialization_kind
+FROM system.parts_columns
+WHERE table = 't_sparse_distinct' AND database = currentDatabase() AND column = 'v'
+ORDER BY name;
+all_1_1_0	v	Default
+all_2_2_0	v	Sparse
+set optimize_distinct_in_order=1;
+set max_threads=1;
+select trimLeft(explain) from (explain pipeline SELECT DISTINCT id, v FROM t_sparse_distinct) where explain ilike '%DistinctSortedChunkTransform%';
+DistinctSortedChunkTransform
+SELECT DISTINCT id, v FROM t_sparse_distinct format Null;

--- a/tests/queries/0_stateless/02862_sorted_distinct_sparse_fix.sql
+++ b/tests/queries/0_stateless/02862_sorted_distinct_sparse_fix.sql
@@ -21,3 +21,5 @@ set max_threads=1;
 
 select trimLeft(explain) from (explain pipeline SELECT DISTINCT id, v FROM t_sparse_distinct) where explain ilike '%DistinctSortedChunkTransform%';
 SELECT DISTINCT id, v FROM t_sparse_distinct format Null;
+
+DROP TABLE t_sparse_distinct;

--- a/tests/queries/0_stateless/02862_sorted_distinct_sparse_fix.sql
+++ b/tests/queries/0_stateless/02862_sorted_distinct_sparse_fix.sql
@@ -1,0 +1,23 @@
+DROP TABLE IF EXISTS t_sparse_distinct;
+
+CREATE TABLE t_sparse_distinct (id UInt32, v String)
+ENGINE = MergeTree
+ORDER BY id
+SETTINGS ratio_of_defaults_for_sparse_serialization = 0.9;
+
+SYSTEM STOP MERGES t_sparse_distinct;
+
+INSERT INTO t_sparse_distinct SELECT number % 10, toString(number % 100 = 0) FROM numbers(100);
+INSERT INTO t_sparse_distinct(id) SELECT number % 10 FROM numbers(100);
+
+-- { echoOn }
+SELECT name, column, serialization_kind
+FROM system.parts_columns
+WHERE table = 't_sparse_distinct' AND database = currentDatabase() AND column = 'v'
+ORDER BY name;
+
+set optimize_distinct_in_order=1;
+set max_threads=1;
+
+select trimLeft(explain) from (explain pipeline SELECT DISTINCT id, v FROM t_sparse_distinct) where explain ilike '%DistinctSortedChunkTransform%';
+SELECT DISTINCT id, v FROM t_sparse_distinct format Null;


### PR DESCRIPTION
Fixes https://github.com/ClickHouse/ClickHouse/issues/52540

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixes possible crashes in `DISTINCT` queries with enabled `optimize_distinct_in_order` and sparse columns
