### PR TITLE
Fix flaky `shutdown_wait_unfinished_queries` integration test

### DIFF
--- a/tests/integration/helpers/client.py
+++ b/tests/integration/helpers/client.py
@@ -144,6 +144,7 @@ class Client:
         user=None,
         password=None,
         database=None,
+        query_id=None,
     ):
         return self.get_query_request(
             sql,
@@ -153,6 +154,7 @@ class Client:
             user=user,
             password=password,
             database=database,
+            query_id=query_id,
         ).get_answer_and_error()
 
 

--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -3476,6 +3476,7 @@ class ClickHouseInstance:
         user=None,
         password=None,
         database=None,
+        query_id=None,
     ):
         logging.debug(f"Executing query {sql} on {self.name}")
         return self.client.query_and_get_answer_with_error(
@@ -3486,6 +3487,7 @@ class ClickHouseInstance:
             user=user,
             password=password,
             database=database,
+            query_id=query_id,
         )
 
     # Connects to the instance via HTTP interface, sends a query and returns the answer

--- a/tests/integration/test_shutdown_wait_unfinished_queries/test.py
+++ b/tests/integration/test_shutdown_wait_unfinished_queries/test.py
@@ -2,7 +2,9 @@ import pytest
 
 import threading
 import time
+import uuid
 from helpers.cluster import ClickHouseCluster
+from helpers.test_tools import assert_eq_with_retry
 
 cluster = ClickHouseCluster(__file__)
 node_wait_queries = cluster.add_instance(
@@ -30,32 +32,35 @@ def start_cluster():
         cluster.shutdown()
 
 
-def do_long_query(node):
+def do_long_query(node, query_id):
     global result
 
     result = node.query_and_get_answer_with_error(
         "SELECT sleepEachRow(1) FROM system.numbers LIMIT 10",
         settings={"send_logs_level": "trace"},
+        query_id=query_id,
     )
 
 
 def test_shutdown_wait_unfinished_queries(start_cluster):
     global result
 
-    long_query = threading.Thread(target=do_long_query, args=(node_wait_queries,))
+    query_id = uuid.uuid4().hex
+    long_query = threading.Thread(target=do_long_query, args=(node_wait_queries, query_id,))
     long_query.start()
 
-    time.sleep(1)
+    assert_eq_with_retry(node_wait_queries, f"SELECT query_id FROM system.processes WHERE query_id = '{query_id}'", query_id)
     node_wait_queries.stop_clickhouse(kill=False)
 
     long_query.join()
 
     assert result[0].count("0") == 10
 
-    long_query = threading.Thread(target=do_long_query, args=(node_kill_queries,))
+    query_id = uuid.uuid4().hex
+    long_query = threading.Thread(target=do_long_query, args=(node_kill_queries, query_id,))
     long_query.start()
 
-    time.sleep(1)
+    assert_eq_with_retry(node_kill_queries, f"SELECT query_id FROM system.processes WHERE query_id = '{query_id}'", query_id)
     node_kill_queries.stop_clickhouse(kill=False)
 
     long_query.join()

--- a/tests/integration/test_shutdown_wait_unfinished_queries/test.py
+++ b/tests/integration/test_shutdown_wait_unfinished_queries/test.py
@@ -46,10 +46,20 @@ def test_shutdown_wait_unfinished_queries(start_cluster):
     global result
 
     query_id = uuid.uuid4().hex
-    long_query = threading.Thread(target=do_long_query, args=(node_wait_queries, query_id,))
+    long_query = threading.Thread(
+        target=do_long_query,
+        args=(
+            node_wait_queries,
+            query_id,
+        ),
+    )
     long_query.start()
 
-    assert_eq_with_retry(node_wait_queries, f"SELECT query_id FROM system.processes WHERE query_id = '{query_id}'", query_id)
+    assert_eq_with_retry(
+        node_wait_queries,
+        f"SELECT query_id FROM system.processes WHERE query_id = '{query_id}'",
+        query_id,
+    )
     node_wait_queries.stop_clickhouse(kill=False)
 
     long_query.join()
@@ -57,10 +67,20 @@ def test_shutdown_wait_unfinished_queries(start_cluster):
     assert result[0].count("0") == 10
 
     query_id = uuid.uuid4().hex
-    long_query = threading.Thread(target=do_long_query, args=(node_kill_queries, query_id,))
+    long_query = threading.Thread(
+        target=do_long_query,
+        args=(
+            node_kill_queries,
+            query_id,
+        ),
+    )
     long_query.start()
 
-    assert_eq_with_retry(node_kill_queries, f"SELECT query_id FROM system.processes WHERE query_id = '{query_id}'", query_id)
+    assert_eq_with_retry(
+        node_kill_queries,
+        f"SELECT query_id FROM system.processes WHERE query_id = '{query_id}'",
+        query_id,
+    )
     node_kill_queries.stop_clickhouse(kill=False)
 
     long_query.join()


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Addresses https://github.com/ClickHouse/ClickHouse/pull/49469#issuecomment-1686112290