### PR TITLE
[bugfix] possible postgresql logical replication error: wrong type co…

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,2 @@
+#./packager --package-type binary --build-type debug --compiler=clang-16  --cache=ccache --clickhouse-repo-path=/var/clickhouse/ClickHouse --output-dir=/var/clickhouse/ClickHouse/docker/packager/my_house  --ccache-dir=/var/clickhouse/ClickHouse/docker/packager/.ccache
+CMAKE_FLAGS='-DENABLE_THINLTO='  ./docker/packager/packager --package-type binary  --compiler=clang-16  --cache=ccache --clickhouse-repo-path=/var/clickhouse/ClickHouse2 --output-dir=/var/clickhouse/ClickHouse2/my_house  --ccache-dir=/var/clickhouse/ClickHouse2/docker/packager/.ccache

--- a/src/Databases/PostgreSQL/fetchPostgreSQLTableStructure.cpp
+++ b/src/Databases/PostgreSQL/fetchPostgreSQLTableStructure.cpp
@@ -263,7 +263,7 @@ PostgreSQLTableStructure fetchPostgreSQLTableStructure(
            "attnotnull AS not_null, attndims AS dims, atttypid as type_id, atttypmod as type_modifier "
            "FROM pg_attribute "
            "WHERE attrelid = (SELECT oid FROM pg_class WHERE {}) "
-           "AND NOT attisdropped AND attnum > 0", where);
+           "AND NOT attisdropped AND attnum > 0 order by attnum asc", where);
 
     auto postgres_table_with_schema = postgres_schema.empty() ? postgres_table : doubleQuoteString(postgres_schema) + '.' + doubleQuoteString(postgres_table);
     table.physical_columns = readNamesAndTypesList(tx, postgres_table_with_schema, query, use_nulls, false);


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Fix  possible postgresql logical replication  conversion_error when using MaterializedPostgreSQL

### Documentation entry for user-facing changes
```
2023.08.14 20:16:59.971005 [ 4326 ] {} <Error> void DB::DatabaseMaterializedPostgreSQL::startSynchronization(): std::exception. Code: 1001, type: pqxx::conversion_error, e.what() = Could not convert string to numeric value: 'male'., Stack trace (when copying this message, always include the lines below):

0. ./build_docker/../contrib/libpqxx/src/except.cxx:98: pqxx::internal::float_traits<double>::from_string(std::__1::basic_string_view<char, std::__1::char_traits<char> >) @ 0x16b8cf0a in /usr/lib/debug/usr/bin/clickhouse.debug
1. ./build_docker/../src/Common/PODArray.h:436: DB::insertPostgreSQLValue(DB::IColumn&, std::__1::basic_string_view<char, std::__1::char_traits<char> >, DB::ExternalResultDescription::ValueType, std::__1::shared_ptr<DB::IDataType const>, std::__1::unordered_map<unsigned long, DB::PostgreSQLArrayInfo, std::__1::hash<unsigned long>, std::__1::equal_to<unsigned long>, std::__1::allocator<std::__1::pair<unsigned long const, DB::PostgreSQLArrayInfo> > >&, unsigned long) @ 0x11b740d2 in /usr/lib/debug/usr/bin/clickhouse.debug
2. ./build_docker/../src/Processors/Transforms/PostgreSQLSource.cpp:156: DB::PostgreSQLSource<pqxx::transaction<(pqxx::isolation_level)1, (pqxx::write_policy)0> >::generate() @ 0x78b6e39 in /usr/lib/debug/usr/bin/clickhouse.debug
3. ./build_docker/../src/Processors/Chunk.h:90: DB::ISource::tryGenerate() @ 0x12fe9675 in /usr/lib/debug/usr/bin/clickhouse.debug
4. ./build_docker/../contrib/libcxx/include/optional:321: DB::ISource::work() @ 0x12fe9206 in /usr/lib/debug/usr/bin/clickhouse.debug
5. ./build_docker/../src/Processors/Executors/ExecutionThreadContext.cpp:0: DB::ExecutionThreadContext::executeTask() @ 0x13004ce6 in /usr/lib/debug/usr/bin/clickhouse.debug
6. ./build_docker/../src/Processors/Executors/PipelineExecutor.cpp:228: DB::PipelineExecutor::executeStepImpl(unsigned long, std::__1::atomic<bool>*) @ 0x12ff94bc in /usr/lib/debug/usr/bin/clickhouse.debug
7. ./build_docker/../contrib/libcxx/include/__memory/shared_ptr.h:702: DB::PipelineExecutor::executeImpl(unsigned long) @ 0x12ff7ed9 in /usr/lib/debug/usr/bin/clickhouse.debug
```
