### PR TITLE
Fix QPL functional test for s390x

### DIFF
--- a/tests/queries/0_stateless/00804_test_deflate_qpl_codec_compression.sql
+++ b/tests/queries/0_stateless/00804_test_deflate_qpl_codec_compression.sql
@@ -1,6 +1,6 @@
---Tags: no-fasttest, no-cpu-aarch64
+--Tags: no-fasttest, no-cpu-aarch64, no-cpu-s390x
 -- no-fasttest because DEFLATE_QPL isn't available in fasttest
--- no-cpu-aarch64 because DEFLATE_QPL is x86-only
+-- no-cpu-aarch64 and no-cpu-s390x because DEFLATE_QPL is x86-only
 
 -- A bunch of random DDLs to test the DEFLATE_QPL codec.
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
The Intel Query Processing Library (QPL) is only used for x86 only. The fix is to skip functional test `00804_test_deflate_qpl_codec_compression` for s390x.

### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Skipped QPL functional test for s390x.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
