### PR TITLE
Improve JSON-handling on s390x

### DIFF
--- a/contrib/CMakeLists.txt
+++ b/contrib/CMakeLists.txt
@@ -136,9 +136,7 @@ add_contrib (aws-cmake
 )
 
 add_contrib (base64-cmake base64)
-if (NOT ARCH_S390X)
 add_contrib (simdjson-cmake simdjson)
-endif()
 add_contrib (rapidjson-cmake rapidjson)
 add_contrib (fastops-cmake fastops)
 add_contrib (libuv-cmake libuv)

--- a/src/DataTypes/Serializations/SerializationNumber.cpp
+++ b/src/DataTypes/Serializations/SerializationNumber.cpp
@@ -145,15 +145,8 @@ void SerializationNumber<T>::serializeBinaryBulk(const IColumn & column, WriteBu
 
     if constexpr (std::endian::native == std::endian::big && sizeof(T) >= 2)
     {
-        static constexpr auto to_little_endian = [](auto i)
-        {
-            transformEndianness<std::endian::little>(i);
-            return i;
-        };
-
         std::ranges::for_each(
-            x | std::views::drop(offset) | std::views::take(limit) | std::views::transform(to_little_endian),
-            [&ostr](const auto & i) { ostr.write(reinterpret_cast<const char *>(&i), sizeof(typename ColumnVector<T>::ValueType)); });
+            x | std::views::drop(offset) | std::views::take(limit), [&ostr](const auto & i) { writeBinaryLittleEndian(i, ostr); });
     }
     else
         ostr.write(reinterpret_cast<const char *>(&x[offset]), sizeof(typename ColumnVector<T>::ValueType) * limit);

--- a/src/DataTypes/Serializations/SerializationUUID.cpp
+++ b/src/DataTypes/Serializations/SerializationUUID.cpp
@@ -7,6 +7,7 @@
 #include <IO/WriteHelpers.h>
 #include <Common/assert_cast.h>
 
+#include <ranges>
 
 namespace DB
 {
@@ -136,23 +137,31 @@ void SerializationUUID::deserializeBinary(IColumn & column, ReadBuffer & istr, c
 void SerializationUUID::serializeBinaryBulk(const IColumn & column, WriteBuffer & ostr, size_t offset, size_t limit) const
 {
     const typename ColumnVector<UUID>::Container & x = typeid_cast<const ColumnVector<UUID> &>(column).getData();
-
-    size_t size = x.size();
-
-    if (limit == 0 || offset + limit > size)
+    if (const size_t size = x.size(); limit == 0 || offset + limit > size)
         limit = size - offset;
 
-    if (limit)
+    if (limit == 0)
+        return;
+
+    if constexpr (std::endian::native == std::endian::big)
+    {
+        std::ranges::for_each(
+            x | std::views::drop(offset) | std::views::take(limit), [&ostr](const auto & uuid) { writeBinaryLittleEndian(uuid, ostr); });
+    }
+    else
         ostr.write(reinterpret_cast<const char *>(&x[offset]), sizeof(UUID) * limit);
 }
 
 void SerializationUUID::deserializeBinaryBulk(IColumn & column, ReadBuffer & istr, size_t limit, double /*avg_value_size_hint*/) const
 {
     typename ColumnVector<UUID>::Container & x = typeid_cast<ColumnVector<UUID> &>(column).getData();
-    size_t initial_size = x.size();
+    const size_t initial_size = x.size();
     x.resize(initial_size + limit);
-    size_t size = istr.readBig(reinterpret_cast<char*>(&x[initial_size]), sizeof(UUID) * limit);
+    const size_t size = istr.readBig(reinterpret_cast<char *>(&x[initial_size]), sizeof(UUID) * limit);
     x.resize(initial_size + size / sizeof(UUID));
-}
 
+    if constexpr (std::endian::native == std::endian::big)
+        std::ranges::for_each(
+            x | std::views::drop(initial_size), [](auto & uuid) { transformEndianness<std::endian::big, std::endian::little>(uuid); });
+}
 }


### PR DESCRIPTION
The goal with these changes is to fix `00918_json_functions` for big-endian platforms. I achieved this by implementing endianness-independent serialization for UUIDs and using `simdjson` instead of `RapidJSON` on `s390x`.

I'm aware that #49457 did the exact opposite by switching to `RapidJSON` from `simdjson`, but based on internal records it was meant to fix functional test `01825_type_json_12`, which passes using `s390x` + `simdjson`.

I also refactored existing serialization implementations for decimals and numbers for performance reasons.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)