### PR TITLE
Sync UUIDs of tables on replicas after RESTORE

### DIFF
--- a/src/Backups/BackupUtils.h
+++ b/src/Backups/BackupUtils.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Parsers/ASTBackupQuery.h>
+#include <Interpreters/Context_fwd.h>
 
 
 namespace DB
@@ -12,8 +13,11 @@ class DDLRenamingMap;
 /// Initializes a DDLRenamingMap from a BACKUP or RESTORE query.
 DDLRenamingMap makeRenamingMapFromBackupQuery(const ASTBackupQuery::Elements & elements);
 
-
 /// Returns access required to execute BACKUP query.
 AccessRightsElements getRequiredAccessToBackup(const ASTBackupQuery::Elements & elements);
+
+/// Checks the definition of a restored table - it must correspond to the definition from the backup.
+bool compareRestoredTableDef(const IAST & restored_table_create_query, const IAST & create_query_from_backup, const ContextPtr & global_context);
+bool compareRestoredDatabaseDef(const IAST & restored_database_create_query, const IAST & create_query_from_backup, const ContextPtr & global_context);
 
 }

--- a/src/Backups/DDLAdjustingForBackupVisitor.cpp
+++ b/src/Backups/DDLAdjustingForBackupVisitor.cpp
@@ -81,9 +81,6 @@ namespace
 
     void visitCreateQuery(ASTCreateQuery & create, const DDLAdjustingForBackupVisitor::Data & data)
     {
-        create.uuid = UUIDHelpers::Nil;
-        create.to_inner_uuid = UUIDHelpers::Nil;
-
         if (create.storage)
             visitStorage(*create.storage, data);
     }

--- a/src/Backups/IRestoreCoordination.h
+++ b/src/Backups/IRestoreCoordination.h
@@ -7,6 +7,7 @@ namespace DB
 {
 class Exception;
 enum class UserDefinedSQLObjectType;
+class ASTCreateQuery;
 
 /// Replicas use this class to coordinate what they're reading from a backup while executing RESTORE ON CLUSTER.
 /// There are two implementation of this interface: RestoreCoordinationLocal and RestoreCoordinationRemote.
@@ -40,10 +41,13 @@ public:
     /// The function returns false if user-defined function at a specified zk path are being already restored by another replica.
     virtual bool acquireReplicatedSQLObjects(const String & loader_zk_path, UserDefinedSQLObjectType object_type) = 0;
 
+    /// Generates a new UUID for a table. The same UUID must be used for a replicated table on each replica,
+    /// (because otherwise the macro "{uuid}" in the ZooKeeper path will not work correctly).
+    virtual void generateUUIDForTable(ASTCreateQuery & create_query) = 0;
+
     /// This function is used to check if concurrent restores are running
     /// other than the restore passed to the function
     virtual bool hasConcurrentRestores(const std::atomic<size_t> & num_active_restores) const = 0;
-
 };
 
 }

--- a/src/Backups/RestoreCoordinationLocal.cpp
+++ b/src/Backups/RestoreCoordinationLocal.cpp
@@ -1,4 +1,5 @@
 #include <Backups/RestoreCoordinationLocal.h>
+#include <Parsers/formatAST.h>
 #include <Common/logger_useful.h>
 
 
@@ -49,6 +50,40 @@ bool RestoreCoordinationLocal::acquireReplicatedAccessStorage(const String &)
 bool RestoreCoordinationLocal::acquireReplicatedSQLObjects(const String &, UserDefinedSQLObjectType)
 {
     return true;
+}
+
+void RestoreCoordinationLocal::generateUUIDForTable(ASTCreateQuery & create_query)
+{
+    String query_str = serializeAST(create_query);
+
+    auto find_in_map = [&]
+    {
+        auto it = create_query_uuids.find(query_str);
+        if (it != create_query_uuids.end())
+        {
+            create_query.setUUID(it->second);
+            return true;
+        }
+        return false;
+    };
+
+    {
+        std::lock_guard lock{mutex};
+        if (find_in_map())
+            return;
+    }
+
+    create_query.setUUID({});
+    auto new_uuids = create_query.generateRandomUUID();
+    String new_query_str = serializeAST(create_query);
+
+    {
+        std::lock_guard lock{mutex};
+        if (find_in_map())
+            return;
+        create_query_uuids[query_str] = new_uuids;
+        create_query_uuids[new_query_str] = new_uuids;
+    }
 }
 
 bool RestoreCoordinationLocal::hasConcurrentRestores(const std::atomic<size_t> & num_active_restores) const

--- a/src/Backups/RestoreCoordinationLocal.cpp
+++ b/src/Backups/RestoreCoordinationLocal.cpp
@@ -73,8 +73,8 @@ void RestoreCoordinationLocal::generateUUIDForTable(ASTCreateQuery & create_quer
             return;
     }
 
-    create_query.setUUID({});
-    auto new_uuids = create_query.generateRandomUUID();
+    auto new_uuids = create_query.generateRandomUUID(/* always_generate_new_uuid= */ true);
+
     String new_query_str = serializeAST(create_query);
 
     {
@@ -82,7 +82,6 @@ void RestoreCoordinationLocal::generateUUIDForTable(ASTCreateQuery & create_quer
         if (find_in_map())
             return;
         create_query_uuids[query_str] = new_uuids;
-        create_query_uuids[new_query_str] = new_uuids;
     }
 }
 

--- a/src/Backups/RestoreCoordinationLocal.h
+++ b/src/Backups/RestoreCoordinationLocal.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Backups/IRestoreCoordination.h>
+#include <Parsers/ASTCreateQuery.h>
 #include <mutex>
 #include <set>
 #include <unordered_set>
@@ -39,6 +40,10 @@ public:
     /// The function returns false if user-defined function at a specified zk path are being already restored by another replica.
     bool acquireReplicatedSQLObjects(const String & loader_zk_path, UserDefinedSQLObjectType object_type) override;
 
+    /// Generates a new UUID for a table. The same UUID must be used for a replicated table on each replica,
+    /// (because otherwise the macro "{uuid}" in the ZooKeeper path will not work correctly).
+    void generateUUIDForTable(ASTCreateQuery & create_query) override;
+
     bool hasConcurrentRestores(const std::atomic<size_t> & num_active_restores) const override;
 
 private:
@@ -46,6 +51,8 @@ private:
 
     std::set<std::pair<String /* database_zk_path */, String /* table_name */>> acquired_tables_in_replicated_databases;
     std::unordered_set<String /* table_zk_path */> acquired_data_in_replicated_tables;
+    std::unordered_map<String, ASTCreateQuery::UUIDs> create_query_uuids;
+
     mutable std::mutex mutex;
 };
 

--- a/src/Backups/RestoreCoordinationRemote.cpp
+++ b/src/Backups/RestoreCoordinationRemote.cpp
@@ -246,11 +246,6 @@ void RestoreCoordinationRemote::generateUUIDForTable(ASTCreateQuery & create_que
             with_retries.renewZooKeeper(zk);
 
             String path = zookeeper_path + "/table_uuids/" + escapeForFileName(query_str);
-
-            Coordination::Requests ops;
-            ops.emplace_back(zkutil::makeCreateRequest(path, new_uuids_str, zkutil::CreateMode::Persistent));
-
-            Coordination::Responses responses;
             Coordination::Error res = zk->tryCreate(path, new_uuids_str, zkutil::CreateMode::Persistent);
 
             if (res == Coordination::Error::ZOK)

--- a/src/Backups/RestoreCoordinationRemote.h
+++ b/src/Backups/RestoreCoordinationRemote.h
@@ -46,6 +46,10 @@ public:
     /// The function returns false if user-defined function at a specified zk path are being already restored by another replica.
     bool acquireReplicatedSQLObjects(const String & loader_zk_path, UserDefinedSQLObjectType object_type) override;
 
+    /// Generates a new UUID for a table. The same UUID must be used for a replicated table on each replica,
+    /// (because otherwise the macro "{uuid}" in the ZooKeeper path will not work correctly).
+    void generateUUIDForTable(ASTCreateQuery & create_query) override;
+
     bool hasConcurrentRestores(const std::atomic<size_t> & num_active_restores) const override;
 
 private:

--- a/src/Backups/RestorerFromBackup.cpp
+++ b/src/Backups/RestorerFromBackup.cpp
@@ -571,12 +571,14 @@ void RestorerFromBackup::createDatabase(const String & database_name) const
     if (database_info.is_predefined_database)
         return;
 
-    auto create_database_query = database_info.create_database_query;
-    if (restore_settings.create_table == RestoreTableCreationMode::kCreateIfNotExists)
-    {
-        create_database_query = create_database_query->clone();
-        create_database_query->as<ASTCreateQuery &>().if_not_exists = true;
-    }
+    auto create_database_query = typeid_cast<std::shared_ptr<ASTCreateQuery>>(database_info.create_database_query->clone());
+
+    /// Generate a new UUID for a database.
+    /// The generated UUID will be ignored if the database does not support UUIDs.
+    restore_coordination->generateUUIDForTable(*create_database_query);
+
+    /// Add the clause `IF NOT EXISTS` if that is specified in the restore settings.
+    create_database_query->if_not_exists = (restore_settings.create_table == RestoreTableCreationMode::kCreateIfNotExists);
 
     LOG_TRACE(log, "Creating database {}: {}", backQuoteIfNeed(database_name), serializeAST(*create_database_query));
 
@@ -605,17 +607,17 @@ void RestorerFromBackup::checkDatabase(const String & database_name)
         if (!restore_settings.allow_different_database_def && !database_info.is_predefined_database)
         {
             /// Check that the database's definition is the same as expected.
-            ASTPtr create_database_query = database->getCreateDatabaseQuery();
-            adjustCreateQueryForBackup(create_database_query, context->getGlobalContext(), nullptr);
-            ASTPtr expected_create_query = database_info.create_database_query;
-            if (serializeAST(*create_database_query) != serializeAST(*expected_create_query))
+
+            ASTPtr existing_database_def = database->getCreateDatabaseQuery();
+            ASTPtr database_def_from_backup = database_info.create_database_query;
+            if (!compareRestoredDatabaseDef(*existing_database_def, *database_def_from_backup, context->getGlobalContext()))
             {
                 throw Exception(
                     ErrorCodes::CANNOT_RESTORE_DATABASE,
                     "The database has a different definition: {} "
                     "comparing to its definition in the backup: {}",
-                    serializeAST(*create_database_query),
-                    serializeAST(*expected_create_query));
+                    serializeAST(*existing_database_def),
+                    serializeAST(*database_def_from_backup));
             }
         }
     }
@@ -714,20 +716,23 @@ void RestorerFromBackup::createTable(const QualifiedTableName & table_name)
     if (table_info.is_predefined_table)
         return;
 
-    auto create_table_query = table_info.create_table_query;
-    if (restore_settings.create_table == RestoreTableCreationMode::kCreateIfNotExists)
-    {
-        create_table_query = create_table_query->clone();
-        create_table_query->as<ASTCreateQuery &>().if_not_exists = true;
-    }
+    auto create_table_query = typeid_cast<std::shared_ptr<ASTCreateQuery>>(table_info.create_table_query->clone());
+
+    /// Generate a new UUID for a table (the same table on different hosts must use the same UUID, `restore_coordination` will make it so).
+    /// The generated UUID will be ignored if the database does not support UUIDs.
+    restore_coordination->generateUUIDForTable(*create_table_query);
+
+    /// Add the clause `IF NOT EXISTS` if that is specified in the restore settings.
+    create_table_query->if_not_exists = (restore_settings.create_table == RestoreTableCreationMode::kCreateIfNotExists);
 
     LOG_TRACE(
         log, "Creating {}: {}", tableNameWithTypeToString(table_name.database, table_name.table, false), serializeAST(*create_table_query));
 
     try
     {
-        DatabasePtr database = DatabaseCatalog::instance().getDatabase(table_name.database);
-        table_info.database = database;
+        if (!table_info.database)
+            table_info.database = DatabaseCatalog::instance().getDatabase(table_name.database);
+        DatabasePtr database = table_info.database;
 
         /// Execute CREATE TABLE query (we call IDatabase::createTableRestoredFromBackup() to allow the database to do some
         /// database-specific things).
@@ -747,19 +752,16 @@ void RestorerFromBackup::createTable(const QualifiedTableName & table_name)
 void RestorerFromBackup::checkTable(const QualifiedTableName & table_name)
 {
     auto & table_info = table_infos.at(table_name);
-    auto database = table_info.database;
 
     try
     {
-        if (!database)
-        {
-            database = DatabaseCatalog::instance().getDatabase(table_name.database);
-            table_info.database = database;
-        }
-
         auto resolved_id = (table_name.database == DatabaseCatalog::TEMPORARY_DATABASE)
             ? context->resolveStorageID(StorageID{"", table_name.table}, Context::ResolveExternal)
             : context->resolveStorageID(StorageID{table_name.database, table_name.table}, Context::ResolveGlobal);
+
+        if (!table_info.database)
+            table_info.database = DatabaseCatalog::instance().getDatabase(table_name.database);
+        DatabasePtr database = table_info.database;
 
         StoragePtr storage = database->getTable(resolved_id.table_name, context);
         table_info.storage = storage;
@@ -767,17 +769,16 @@ void RestorerFromBackup::checkTable(const QualifiedTableName & table_name)
 
         if (!restore_settings.allow_different_table_def && !table_info.is_predefined_table)
         {
-            ASTPtr create_table_query = database->getCreateTableQuery(resolved_id.table_name, context);
-            adjustCreateQueryForBackup(create_table_query, context->getGlobalContext(), nullptr);
-            ASTPtr expected_create_query = table_info.create_table_query;
-            if (serializeAST(*create_table_query) != serializeAST(*expected_create_query))
+            ASTPtr existing_table_def = database->getCreateTableQuery(resolved_id.table_name, context);
+            ASTPtr table_def_from_backup = table_info.create_table_query;
+            if (!compareRestoredTableDef(*existing_table_def, *table_def_from_backup, context->getGlobalContext()))
             {
                 throw Exception(
                     ErrorCodes::CANNOT_RESTORE_TABLE,
                     "The table has a different definition: {} "
                     "comparing to its definition in the backup: {}",
-                    serializeAST(*create_table_query),
-                    serializeAST(*expected_create_query));
+                    serializeAST(*existing_table_def),
+                    serializeAST(*table_def_from_backup));
             }
         }
     }

--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -219,10 +219,12 @@ BlockIO InterpreterCreateQuery::createDatabase(ASTCreateQuery & create)
     else
     {
         bool is_on_cluster = getContext()->getClientInfo().query_kind == ClientInfo::QueryKind::SECONDARY_QUERY;
-        if (create.uuid != UUIDHelpers::Nil && !is_on_cluster)
+        if (create.uuid != UUIDHelpers::Nil && !is_on_cluster && !internal)
             throw Exception(ErrorCodes::INCORRECT_QUERY, "Ordinary database engine does not support UUID");
 
-        /// Ignore UUID if it's ON CLUSTER query
+        /// The database doesn't support UUID so we'll ignore it. The UUID could be set here because of either
+        /// a) the initiator of `ON CLUSTER` query generated it to ensure the same UUIDs are used on different hosts; or
+        /// b) `RESTORE from backup` query generated it to ensure the same UUIDs are used on different hosts.
         create.uuid = UUIDHelpers::Nil;
         metadata_path = metadata_path / "metadata" / database_name_escaped;
     }
@@ -983,19 +985,6 @@ void InterpreterCreateQuery::setEngine(ASTCreateQuery & create) const
     setDefaultTableEngine(*create.storage, getContext()->getSettingsRef().default_table_engine.value);
 }
 
-static void generateUUIDForTable(ASTCreateQuery & create)
-{
-    if (create.uuid == UUIDHelpers::Nil)
-        create.uuid = UUIDHelpers::generateV4();
-
-    /// If destination table (to_table_id) is not specified for materialized view,
-    /// then MV will create inner table. We should generate UUID of inner table here,
-    /// so it will be the same on all hosts if query in ON CLUSTER or database engine is Replicated.
-    bool need_uuid_for_inner_table = !create.attach && create.is_materialized_view && !create.to_table_id;
-    if (need_uuid_for_inner_table && create.to_inner_uuid == UUIDHelpers::Nil)
-        create.to_inner_uuid = UUIDHelpers::generateV4();
-}
-
 void InterpreterCreateQuery::assertOrSetUUID(ASTCreateQuery & create, const DatabasePtr & database) const
 {
     const auto * kind = create.is_dictionary ? "Dictionary" : "Table";
@@ -1028,17 +1017,19 @@ void InterpreterCreateQuery::assertOrSetUUID(ASTCreateQuery & create, const Data
                             kind_upper, create.table);
         }
 
-        generateUUIDForTable(create);
+        create.generateRandomUUID();
     }
     else
     {
         bool is_on_cluster = getContext()->getClientInfo().query_kind == ClientInfo::QueryKind::SECONDARY_QUERY;
         bool has_uuid = create.uuid != UUIDHelpers::Nil || create.to_inner_uuid != UUIDHelpers::Nil;
-        if (has_uuid && !is_on_cluster)
+        if (has_uuid && !is_on_cluster && !internal)
             throw Exception(ErrorCodes::INCORRECT_QUERY,
                             "{} UUID specified, but engine of database {} is not Atomic", kind, create.getDatabase());
 
-        /// Ignore UUID if it's ON CLUSTER query
+        /// The database doesn't support UUID so we'll ignore it. The UUID could be set here because of either
+        /// a) the initiator of `ON CLUSTER` query generated it to ensure the same UUIDs are used on different hosts; or
+        /// b) `RESTORE from backup` query generated it to ensure the same UUIDs are used on different hosts.
         create.uuid = UUIDHelpers::Nil;
         create.to_inner_uuid = UUIDHelpers::Nil;
     }
@@ -1619,7 +1610,7 @@ void InterpreterCreateQuery::prepareOnClusterQuery(ASTCreateQuery & create, Cont
 
     /// For CREATE query generate UUID on initiator, so it will be the same on all hosts.
     /// It will be ignored if database does not support UUIDs.
-    generateUUIDForTable(create);
+    create.generateRandomUUID();
 
     /// For cross-replication cluster we cannot use UUID in replica path.
     String cluster_name_expanded = local_context->getMacros()->expand(cluster_name);

--- a/src/Parsers/ASTCreateQuery.cpp
+++ b/src/Parsers/ASTCreateQuery.cpp
@@ -6,6 +6,8 @@
 #include <Common/quoteString.h>
 #include <Interpreters/StorageID.h>
 #include <IO/Operators.h>
+#include <IO/ReadBufferFromString.h>
+#include <IO/WriteBufferFromString.h>
 
 
 namespace DB
@@ -458,6 +460,48 @@ bool ASTCreateQuery::isParameterizedView() const
     if (is_ordinary_view && select && select->hasQueryParameters())
         return true;
     return false;
+}
+
+
+ASTCreateQuery::UUIDs::UUIDs(const ASTCreateQuery & query)
+    : uuid(query.uuid)
+    , to_inner_uuid(query.to_inner_uuid)
+{
+}
+
+String ASTCreateQuery::UUIDs::toString() const
+{
+    WriteBufferFromOwnString out;
+    out << "{" << uuid << "," << to_inner_uuid << "}";
+    return out.str();
+}
+
+ASTCreateQuery::UUIDs ASTCreateQuery::UUIDs::fromString(const String & str)
+{
+    ReadBufferFromString in{str};
+    ASTCreateQuery::UUIDs res;
+    in >> "{" >> res.uuid >> "," >> res.to_inner_uuid >> "}";
+    return res;
+}
+
+ASTCreateQuery::UUIDs ASTCreateQuery::generateRandomUUID()
+{
+    if (uuid == UUIDHelpers::Nil)
+        uuid = UUIDHelpers::generateV4();
+
+    /// If destination table (to_table_id) is not specified for materialized view,
+    /// then MV will create inner table. We should generate UUID of inner table here.
+    bool need_uuid_for_inner_table = !attach && is_materialized_view && !to_table_id;
+    if (need_uuid_for_inner_table && (to_inner_uuid == UUIDHelpers::Nil))
+        to_inner_uuid = UUIDHelpers::generateV4();
+
+    return UUIDs{*this};
+}
+
+void ASTCreateQuery::setUUID(const UUIDs & uuids)
+{
+    uuid = uuids.uuid;
+    to_inner_uuid = uuids.to_inner_uuid;
 }
 
 }

--- a/src/Parsers/ASTCreateQuery.cpp
+++ b/src/Parsers/ASTCreateQuery.cpp
@@ -484,8 +484,11 @@ ASTCreateQuery::UUIDs ASTCreateQuery::UUIDs::fromString(const String & str)
     return res;
 }
 
-ASTCreateQuery::UUIDs ASTCreateQuery::generateRandomUUID()
+ASTCreateQuery::UUIDs ASTCreateQuery::generateRandomUUID(bool always_generate_new_uuid)
 {
+    if (always_generate_new_uuid)
+        setUUID({});
+
     if (uuid == UUIDHelpers::Nil)
         uuid = UUIDHelpers::generateV4();
 

--- a/src/Parsers/ASTCreateQuery.h
+++ b/src/Parsers/ASTCreateQuery.h
@@ -146,6 +146,18 @@ public:
 
     QueryKind getQueryKind() const override { return QueryKind::Create; }
 
+    struct UUIDs
+    {
+        UUID uuid = UUIDHelpers::Nil;
+        UUID to_inner_uuid = UUIDHelpers::Nil;
+        UUIDs() = default;
+        explicit UUIDs(const ASTCreateQuery & query);
+        String toString() const;
+        static UUIDs fromString(const String & str);
+    };
+    UUIDs generateRandomUUID();
+    void setUUID(const UUIDs & uuids);
+
 protected:
     void formatQueryImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
 

--- a/src/Parsers/ASTCreateQuery.h
+++ b/src/Parsers/ASTCreateQuery.h
@@ -155,7 +155,7 @@ public:
         String toString() const;
         static UUIDs fromString(const String & str);
     };
-    UUIDs generateRandomUUID();
+    UUIDs generateRandomUUID(bool always_generate_new_uuid = false);
     void setUUID(const UUIDs & uuids);
 
 protected:

--- a/tests/integration/test_backup_restore_on_cluster/test.py
+++ b/tests/integration/test_backup_restore_on_cluster/test.py
@@ -276,6 +276,37 @@ def test_table_with_parts_in_queue_considered_non_empty():
     )
 
 
+def test_replicated_table_with_uuid_in_zkpath():
+    node1.query(
+        "CREATE TABLE tbl ON CLUSTER 'cluster' ("
+        "x UInt8, y String"
+        ") ENGINE=ReplicatedMergeTree('/clickhouse/tables/{uuid}','{replica}')"
+        "ORDER BY x"
+    )
+
+    node1.query("INSERT INTO tbl VALUES (1, 'AA')")
+    node2.query("INSERT INTO tbl VALUES (2, 'BB')")
+
+    backup_name = new_backup_name()
+    node1.query(f"BACKUP TABLE tbl ON CLUSTER 'cluster' TO {backup_name}")
+
+    # The table `tbl2` is expected to have a different UUID so it's ok to have both `tbl` and `tbl2` at the same time.
+    node2.query(f"RESTORE TABLE tbl AS tbl2 ON CLUSTER 'cluster' FROM {backup_name}")
+
+    node1.query("INSERT INTO tbl2 VALUES (3, 'CC')")
+
+    node1.query("SYSTEM SYNC REPLICA ON CLUSTER 'cluster' tbl")
+    node1.query("SYSTEM SYNC REPLICA ON CLUSTER 'cluster' tbl2")
+
+    for instance in [node1, node2]:
+        assert instance.query("SELECT * FROM tbl ORDER BY x") == TSV(
+            [[1, "AA"], [2, "BB"]]
+        )
+        assert instance.query("SELECT * FROM tbl2 ORDER BY x") == TSV(
+            [[1, "AA"], [2, "BB"], [3, "CC"]]
+        )
+
+
 def test_replicated_table_with_not_synced_insert():
     node1.query(
         "CREATE TABLE tbl ON CLUSTER 'cluster' ("


### PR DESCRIPTION
### Changelog category:
- Improvement

### Changelog entry:
`RESTORE TABLE ON CLUSTER` must create replicated tables with a matching UUID on hosts. Otherwise the macro `{uuid}` in ZooKeeper path can't work correctly after RESTORE. This PR implements that.

This PR fixes https://github.com/ClickHouse/ClickHouse/issues/42709.