### PR TITLE
KeeperClient auto-detection of keeper node from clickhouse configs

### DIFF
--- a/programs/keeper-client/KeeperClient.cpp
+++ b/programs/keeper-client/KeeperClient.cpp
@@ -217,7 +217,14 @@ void KeeperClient::initialize(Poco::Util::Application & /* self */)
         }
     }
 
-    Poco::Logger::root().setLevel(config().getString("log-level", "information"));
+    String default_log_level;
+    if (config().has("query"))
+        /// We don't want to see any information log in query mode, unless it was set explicitly
+        default_log_level = "error";
+    else
+        default_log_level = "information";
+
+    Poco::Logger::root().setLevel( config().getString("log-level", default_log_level));
 
     EventNotifier::init();
 }

--- a/tests/integration/test_keeper_client/test.py
+++ b/tests/integration/test_keeper_client/test.py
@@ -33,6 +33,8 @@ def keeper_query(query: str):
             str(cluster.get_instance_ip("zoo1")),
             "--port",
             str(cluster.zookeeper_port),
+            "--log-level",
+            "error",
             "-q",
             query,
         ],

--- a/tests/integration/test_keeper_client/test.py
+++ b/tests/integration/test_keeper_client/test.py
@@ -33,8 +33,6 @@ def keeper_query(query: str):
             str(cluster.get_instance_ip("zoo1")),
             "--port",
             str(cluster.zookeeper_port),
-            "--log-level",
-            "error",
             "-q",
             query,
         ],


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
If no hostname or port were specified, keeper client will try to search for a connection string in the ClickHouse's config.xml


https://github.com/ClickHouse/ClickHouse/issues/53591

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
