### PR TITLE
SELECT clause in CREATE SQL statement is always quoted when formatting.

### DIFF
--- a/src/Parsers/ASTCreateQuery.cpp
+++ b/src/Parsers/ASTCreateQuery.cpp
@@ -442,7 +442,9 @@ void ASTCreateQuery::formatQueryImpl(const FormatSettings & settings, FormatStat
         settings.ostr << (settings.hilite ? hilite_keyword : "") << " AS"
                       << settings.nl_or_ws
                       << (comment ? "(" : "") << (settings.hilite ? hilite_none : "");
-        select->formatImpl(settings, state, frame);
+        FormatSettings settings_ = settings;
+        settings_.always_quote_identifiers = true;
+        select->formatImpl(settings_, state, frame);
         settings.ostr << (settings.hilite ? hilite_keyword : "") << (comment ? ")" : "") << (settings.hilite ? hilite_none : "");
     }
 

--- a/tests/queries/0_stateless/02864_create_select_keywords.reference
+++ b/tests/queries/0_stateless/02864_create_select_keywords.reference
@@ -1,0 +1,1 @@
+CREATE VIEW default.test_view\n(\n    `date` Date,\n    `__sign` Int8,\n    `from` Float64,\n    `to` Float64\n) AS\nWITH `cte` AS\n    (\n        SELECT\n            `date`,\n            `__sign`,\n            `from`,\n            `to`\n        FROM `default`.`test_table`\n        FINAL\n    )\nSELECT\n    `date`,\n    `__sign`,\n    `from`,\n    `to`\nFROM `cte`

--- a/tests/queries/0_stateless/02864_create_select_keywords.sql
+++ b/tests/queries/0_stateless/02864_create_select_keywords.sql
@@ -1,0 +1,5 @@
+create table test_table ( `date` Date, `__sign` Int8, `from` Float64, `to` Float64 ) ENGINE = CollapsingMergeTree(__sign) PARTITION BY toYYYYMM(date) ORDER BY (date) SETTINGS index_granularity = 8192;
+create VIEW test_view AS WITH cte AS (SELECT date, __sign, "from", "to" FROM test_table FINAL) SELECT date, __sign, "from", "to" FROM cte;
+show create table test_view;
+drop table test_view;
+drop table test_table;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Select SQL always quote identifiers in create SQL

### Documentation entry for user-facing changes
fix #53543
When formatting the CREATE SQL statement, the SELECT clause is always formatted with quoted identifiers to avoid issues caused by keywords being present.