### PR TITLE
Enable ipv4 for keeper unit tests in default

### DIFF
--- a/src/Coordination/tests/gtest_coordination.cpp
+++ b/src/Coordination/tests/gtest_coordination.cpp
@@ -197,7 +197,8 @@ struct SimpliestRaftServer
             port,
             nuraft::asio_service::options{},
             params,
-            opts);
+            opts,
+            false);
 
         if (!raft_instance)
         {


### PR DESCRIPTION
### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Support ipv4 as the default is a better choice because ipv6 is likely not open in some develop environments .
BTW: this PR will be updated according to another [PR 64 in NuRaft](https://github.com/ClickHouse/NuRaft/pull/64).
