### PR TITLE
Issue a warning instead of throwing when s3 zerocopy part metadata directory already exists

### DIFF
--- a/src/Storages/MergeTree/MergeTreePartsMover.cpp
+++ b/src/Storages/MergeTree/MergeTreePartsMover.cpp
@@ -11,7 +11,6 @@ namespace DB
 namespace ErrorCodes
 {
     extern const int ABORTED;
-    extern const int DIRECTORY_ALREADY_EXISTS;
     extern const int LOGICAL_ERROR;
 }
 


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Revert old behavior on zerocopy s3 metadata creation: if a directory exists (and checksums match), re-fetch it instead of throwing.



In 23.7 https://github.com/ClickHouse/ClickHouse/pull/50489 (backported to 23.3.10) an exception is thrown if part metadata already exists. One of our clients encountered this issue, so a fix is proposed: back to 23.3.4 solution where a warning is issued in a log. Throwing an exception makes zerocopy replication unusable.