### PR TITLE
[WIP] Fix checking size of a removed projection

### DIFF
--- a/src/Storages/MergeTree/MergeTreeDataPartChecksum.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataPartChecksum.cpp
@@ -50,12 +50,15 @@ void MergeTreeDataPartChecksum::checkSize(const IDataPartStorage & storage, cons
     if (name.ends_with(".gin_dict") || name.ends_with(".gin_post") || name.ends_with(".gin_seg") || name.ends_with(".gin_sid"))
         return;
 
+    // This is a projection, no need to check its size.
+    if (name.ends_with(".proj"))
+        return;
+
     if (!storage.exists(name))
         throw Exception(ErrorCodes::FILE_DOESNT_EXIST, "{} doesn't exist", fs::path(storage.getRelativePath()) / name);
 
-    // This is a projection, no need to check its size.
     if (storage.isDirectory(name))
-        return;
+        throw Exception(ErrorCodes::UNEXPECTED_FILE_IN_DATA_PART, "Directory {} in data part is not a projection", fs::path(storage.getRelativePath()) / name);
 
     UInt64 size = storage.getFileSize(name);
     if (size != file_size)


### PR DESCRIPTION
### Changelog category:
- Bug Fix

### Changelog entry:
Sometimes when a projection is dropped the file `checksums.txt` is not updated and still contains information about the dropped projection's checksum. As a result a data part cannot be loaded:

```
error: Code: 107. DB::Exception: .../all_1_1_0/prjname.proj doesn't exist. Stack trace:

0. DB::Exception::Exception(DB::Exception::MessageMasked&&, int, bool) @ 0x000000000eaaa2f7 in /usr/bin/clickhouse
1. ? @ 0x0000000015182ec0 in /usr/bin/clickhouse
2. DB::MergeTreeDataPartChecksum::checkSize(DB::IDataPartStorage const&, String const&) const @ 0x00000000151961e4 in /usr/bin/clickhouse
3. DB::IMergeTreeDataPart::checkConsistencyBase() const @ 0x00000000150441f8 in /usr/bin/clickhouse
4. DB::MergeTreeDataPartCompact::checkConsistency(bool) const @ 0x000000001519ec5b in /usr/bin/clickhouse
5. DB::IMergeTreeDataPart::loadColumnsChecksumsIndexes(bool, bool) @ 0x00000000150310c3 in /usr/bin/clickhouse
```