### PR TITLE
Enable producing endianness-independent output in lz4

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = https://github.com/facebook/zstd
 [submodule "contrib/lz4"]
 	path = contrib/lz4
-	url = https://github.com/lz4/lz4
+	url = https://github.com/ClickHouse/lz4
 [submodule "contrib/librdkafka"]
 	path = contrib/librdkafka
 	url = https://github.com/ClickHouse/librdkafka

--- a/contrib/lz4-cmake/CMakeLists.txt
+++ b/contrib/lz4-cmake/CMakeLists.txt
@@ -13,6 +13,11 @@ add_library (ch_contrib::lz4 ALIAS _lz4)
 
 target_compile_definitions (_lz4 PUBLIC LZ4_DISABLE_DEPRECATE_WARNINGS=1)
 target_compile_definitions (_lz4 PUBLIC LZ4_FAST_DEC_LOOP=1)
+
+if(ARCH_S390X)
+    target_compile_definitions(_lz4 PRIVATE LZ4_STATIC_LINKING_ONLY_ENDIANNESS_INDEPENDENT_OUTPUT)
+endif()
+
 if (SANITIZE STREQUAL "undefined")
     target_compile_options (_lz4 PRIVATE -fno-sanitize=undefined)
 endif ()


### PR DESCRIPTION
This set of changes is meant to fix functional test `02381_compress_marks_and_primary_key` for big-endian platforms. I achieved this by enabling a feature flag in the `lz4` compression library (`LZ4_STATIC_LINKING_ONLY_ENDIANNESS_INDEPENDENT_OUTPUT `) so that it produces the same output on big-endian platforms as it does on little-endian.

I discussed this with @rschu1ze who graciously forked the latest version of `lz4` under the ClickHouse organization so that my changes that implement this feature in `lz4` (https://github.com/lz4/lz4/pull/1253) could be incorporated in an expedited manner in order to meet deadlines - details regarding this are in https://github.com/ClickHouse/lz4/pull/1.

I also opened an issue (#53815) so as not to forget about resetting the submodule to the original project once my changes are merged into their repository.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)