### PR TITLE
Fix typo in cluster name.

### DIFF
--- a/src/Databases/DatabaseReplicated.cpp
+++ b/src/Databases/DatabaseReplicated.cpp
@@ -263,7 +263,7 @@ ClusterPtr DatabaseReplicated::getClusterImpl() const
 std::vector<UInt8> DatabaseReplicated::tryGetAreReplicasActive(const ClusterPtr & cluster_) const
 {
     Strings paths;
-    const auto & addresses_with_failover = cluster->getShardsAddresses();
+    const auto & addresses_with_failover = cluster_->getShardsAddresses();
     const auto & shards_info = cluster_->getShardsInfo();
     for (size_t shard_index = 0; shard_index < shards_info.size(); ++shard_index)
     {


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

https://s3.amazonaws.com/clickhouse-test-reports/53282/506c5667a748283135abb32c5b5bf484c20bbb3c/stress_test__tsan_/stderr.log