### PR TITLE
Materialized postgres: fix uncaught exception in getCreateTableQueryImpl

### DIFF
--- a/src/Databases/PostgreSQL/DatabaseMaterializedPostgreSQL.cpp
+++ b/src/Databases/PostgreSQL/DatabaseMaterializedPostgreSQL.cpp
@@ -35,6 +35,7 @@ namespace ErrorCodes
     extern const int UNKNOWN_TABLE;
     extern const int BAD_ARGUMENTS;
     extern const int NOT_IMPLEMENTED;
+    extern const int CANNOT_GET_CREATE_TABLE_QUERY;
 }
 
 DatabaseMaterializedPostgreSQL::DatabaseMaterializedPostgreSQL(
@@ -221,10 +222,25 @@ ASTPtr DatabaseMaterializedPostgreSQL::getCreateTableQueryImpl(const String & ta
 
     std::lock_guard lock(handler_mutex);
 
-    /// FIXME TSA
-    auto storage = std::make_shared<StorageMaterializedPostgreSQL>(StorageID(TSA_SUPPRESS_WARNING_FOR_READ(database_name), table_name), getContext(), remote_database_name, table_name);
-    auto ast_storage = replication_handler->getCreateNestedTableQuery(storage.get(), table_name);
-    assert_cast<ASTCreateQuery *>(ast_storage.get())->uuid = UUIDHelpers::generateV4();
+    ASTPtr ast_storage;
+    try
+    {
+        auto storage = std::make_shared<StorageMaterializedPostgreSQL>(StorageID(TSA_SUPPRESS_WARNING_FOR_READ(database_name), table_name), getContext(), remote_database_name, table_name);
+        ast_storage = replication_handler->getCreateNestedTableQuery(storage.get(), table_name);
+        assert_cast<ASTCreateQuery *>(ast_storage.get())->uuid = UUIDHelpers::generateV4();
+    }
+    catch (...)
+    {
+        if (throw_on_error)
+        {
+            throw Exception(ErrorCodes::CANNOT_GET_CREATE_TABLE_QUERY,
+                            "Received error while fetching table structure for table {} from PostgreSQL: {}",
+                            backQuote(table_name), getCurrentExceptionMessage(true));
+        }
+
+        tryLogCurrentException(__PRETTY_FUNCTION__);
+    }
+
     return ast_storage;
 }
 


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix uncaught exception in `getCreateTableQueryImpl`. 


Should fix "Terminate called for uncaught exception": https://pastila.nl/?0002156d/69fb994fa71b1cd150ad3dc9b4267dab#Yp/6Pw4Ap3vBbQJD/PUd9A==.