### PR TITLE
Fix after #51622

### DIFF
--- a/src/Interpreters/Cache/Metadata.cpp
+++ b/src/Interpreters/Cache/Metadata.cpp
@@ -890,6 +890,9 @@ FileSegments LockedKey::sync()
     FileSegments broken;
     for (auto it = key_metadata->begin(); it != key_metadata->end();)
     {
+        if (it->second->evicting() || !it->second->releasable())
+            continue;
+
         auto file_segment = it->second->file_segment;
         if (file_segment->isDetached())
         {

--- a/src/Interpreters/Cache/Metadata.cpp
+++ b/src/Interpreters/Cache/Metadata.cpp
@@ -891,7 +891,10 @@ FileSegments LockedKey::sync()
     for (auto it = key_metadata->begin(); it != key_metadata->end();)
     {
         if (it->second->evicting() || !it->second->releasable())
+        {
+            ++it;
             continue;
+        }
 
         auto file_segment = it->second->file_segment;
         if (file_segment->isDetached())


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Fixes data race found by stress test, was introduced in https://github.com/ClickHouse/ClickHouse/pull/51622.
https://s3.amazonaws.com/clickhouse-test-reports/53829/ef3489762a9da0be8450f21aca04202a1bf0b872/stress_test__tsan_/stderr.log