### PR TITLE
Fix segfault in `TableNameHints` (with `Lazy` database)

### DIFF
--- a/src/Interpreters/DatabaseCatalog.h
+++ b/src/Interpreters/DatabaseCatalog.h
@@ -44,10 +44,7 @@ public:
         if (database)
         {
             for (auto table_it = database->getTablesIterator(context); table_it->isValid(); table_it->next())
-            {
-                const auto & storage_id = table_it->table()->getStorageID();
-                result.emplace_back(storage_id.getTableName());
-            }
+                result.emplace_back(table_it->name());
         }
         return result;
     }


### PR DESCRIPTION

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Fixes https://github.com/ClickHouse/ClickHouse/issues/53823

https://github.com/ClickHouse/ClickHouse/blob/a6f89c05465753379f481cfe91130a9cd87c66b0/src/Databases/IDatabase.h#L52-L55

But we don't need `StoragePtr`, we need only table name
