### PR TITLE
Bump boost to 1.83

### DIFF
--- a/contrib/boost-cmake/CMakeLists.txt
+++ b/contrib/boost-cmake/CMakeLists.txt
@@ -25,18 +25,16 @@ if (OS_LINUX)
     )
 endif ()
 
-# headers-only
 
+# headers-only
 add_library (_boost_headers_only INTERFACE)
 add_library (boost::headers_only ALIAS _boost_headers_only)
 target_include_directories (_boost_headers_only SYSTEM BEFORE INTERFACE ${LIBRARY_DIR})
 
-# asio
-
 target_compile_definitions (_boost_headers_only INTERFACE
   BOOST_ASIO_STANDALONE=1
-  # Avoid using of deprecated in c++ > 17 std::result_of
-  BOOST_ASIO_HAS_STD_INVOKE_RESULT=1
+  BOOST_ASIO_HAS_STD_INVOKE_RESULT=1 # Avoid using of deprecated in c++ > 17 std::result_of
+  BOOST_TIMER_ENABLE_DEPRECATED=1 # wordnet-blast (enabled via USE_NLP) uses Boost legacy timer classes
 )
 
 # iostreams


### PR DESCRIPTION
See https://github.com/ClickHouse/boost/pull/41.

(related earlier updates: [1.82](https://github.com/ClickHouse/ClickHouse/pull/53812), [1.81](https://github.com/ClickHouse/ClickHouse/pull/53679), [1.80](https://github.com/ClickHouse/ClickHouse/pull/53625), [1.79](https://github.com/ClickHouse/ClickHouse/pull/53490))

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)