### PR TITLE
Remove unused parallel replicas coordinator in query info

### DIFF
--- a/src/Interpreters/ClusterProxy/executeQuery.cpp
+++ b/src/Interpreters/ClusterProxy/executeQuery.cpp
@@ -318,20 +318,11 @@ void executeQueryWithParallelReplicas(
     }
 
     auto coordinator = std::make_shared<ParallelReplicasReadingCoordinator>(all_replicas_count);
-
-    /// This is a little bit weird, but we construct an "empty" coordinator without
-    /// any specified reading/coordination method (like Default, InOrder, InReverseOrder)
-    /// Because we will understand it later during QueryPlan optimization
-    /// So we place a reference to the coordinator to some common plane like QueryInfo
-    /// to then tell it about the reading method we chose.
-    query_info.coordinator = coordinator;
-
     auto external_tables = new_context->getExternalTables();
-
     auto read_from_remote = std::make_unique<ReadFromParallelRemoteReplicasStep>(
         query_ast,
         new_cluster,
-        coordinator,
+        std::move(coordinator),
         stream_factory.header,
         stream_factory.processed_stage,
         main_table,

--- a/src/Storages/SelectQueryInfo.h
+++ b/src/Storages/SelectQueryInfo.h
@@ -10,7 +10,6 @@
 #include <Planner/PlannerContext.h>
 #include <QueryPipeline/StreamLocalLimits.h>
 #include <Storages/ProjectionsDescription.h>
-#include <Storages/MergeTree/ParallelReplicasReadingCoordinator.h>
 
 #include <memory>
 
@@ -210,8 +209,6 @@ struct SelectQueryInfo
     ClusterPtr optimized_cluster;
     /// should we use custom key with the cluster
     bool use_custom_key = false;
-
-    mutable ParallelReplicasReadingCoordinatorPtr coordinator;
 
     TreeRewriterResultPtr syntax_analyzer_result;
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
