### PR TITLE
Ignore foreign keys in tables definition

### DIFF
--- a/src/Parsers/ASTForeignKeyDeclaration.h
+++ b/src/Parsers/ASTForeignKeyDeclaration.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <Parsers/IAST.h>
+
+namespace DB
+{
+
+/*
+ * Currently ignore the foreign key node, flesh it out when needed
+ */
+class ASTForeignKeyDeclaration : public IAST
+{
+public:
+    String name;
+
+    String getID(char) const override { return "Foreign Key"; }
+
+    ASTPtr clone() const override 
+    {
+        auto res = std::make_shared<ASTForeignKeyDeclaration>();
+        res->name = name;
+        return res;
+    }
+};
+
+}

--- a/src/Parsers/ASTForeignKeyDeclaration.h
+++ b/src/Parsers/ASTForeignKeyDeclaration.h
@@ -15,7 +15,7 @@ public:
 
     String getID(char) const override { return "Foreign Key"; }
 
-    ASTPtr clone() const override 
+    ASTPtr clone() const override
     {
         auto res = std::make_shared<ASTForeignKeyDeclaration>();
         res->name = name;

--- a/src/Parsers/ParserCreateQuery.cpp
+++ b/src/Parsers/ParserCreateQuery.cpp
@@ -2,6 +2,7 @@
 #include <Parsers/ASTConstraintDeclaration.h>
 #include <Parsers/ASTCreateQuery.h>
 #include <Parsers/ASTExpressionList.h>
+#include <Parsers/ASTForeignKeyDeclaration.h>
 #include <Parsers/ASTFunction.h>
 #include <Parsers/ASTIdentifier.h>
 #include <Parsers/ASTIndexDeclaration.h>
@@ -222,17 +223,69 @@ bool ParserProjectionDeclaration::parseImpl(Pos & pos, ASTPtr & node, Expected &
     return true;
 }
 
+bool ParserForeignKeyDeclaration::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
+{
+    ParserKeyword s_references("REFERENCES");
+    ParserCompoundIdentifier table_name_p(true, true);
+    ParserExpression expression_p;
+
+    ASTPtr name;
+    ASTPtr expr;
+
+    if (!expression_p.parse(pos, expr, expected))
+        return false;
+
+    if (!s_references.ignore(pos, expected))
+        return false;
+
+    if (!table_name_p.parse(pos, name, expected))
+        return false;
+
+    if (!expression_p.parse(pos, expr, expected))
+        return false;
+
+    ParserKeyword s_on("ON");
+    while (s_on.ignore(pos, expected))
+    {
+        ParserKeyword s_delete("DELETE");
+        ParserKeyword s_update("UPDATE");
+
+        if (!s_delete.ignore(pos, expected) && !s_update.ignore(pos, expected))
+            return false;
+
+        ParserKeyword s_restrict("RESTRICT");
+        ParserKeyword s_cascade("CASCADE");
+        ParserKeyword s_set_null("SET NULL");
+        ParserKeyword s_no_action("NO ACTION");
+        ParserKeyword s_set_default("SET DEFAULT");
+
+        if (!s_restrict.ignore(pos, expected) && !s_cascade.ignore(pos, expected) &&
+            !s_set_null.ignore(pos, expected) && !s_no_action.ignore(pos, expected) &&
+            !s_set_default.ignore(pos, expected))
+        {
+            return false;
+        }
+    }
+
+    auto foreign_key = std::make_shared<ASTForeignKeyDeclaration>();
+    foreign_key->name = "Foreign Key";
+    node = foreign_key;
+
+    return true;
+}
 
 bool ParserTablePropertyDeclaration::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
 {
     ParserKeyword s_index("INDEX");
     ParserKeyword s_constraint("CONSTRAINT");
     ParserKeyword s_projection("PROJECTION");
+    ParserKeyword s_foreign_key("FOREIGN KEY");
     ParserKeyword s_primary_key("PRIMARY KEY");
 
     ParserIndexDeclaration index_p;
     ParserConstraintDeclaration constraint_p;
     ParserProjectionDeclaration projection_p;
+    ParserForeignKeyDeclaration foreign_key_p;
     ParserColumnDeclaration column_p{true, true};
     ParserExpression primary_key_p;
 
@@ -256,6 +309,11 @@ bool ParserTablePropertyDeclaration::parseImpl(Pos & pos, ASTPtr & node, Expecte
     else if (s_primary_key.ignore(pos, expected))
     {
         if (!primary_key_p.parse(pos, new_node, expected))
+            return false;
+    }
+    else if (s_foreign_key.ignore(pos, expected))
+    {
+        if (!foreign_key_p.parse(pos, new_node, expected))
             return false;
     }
     else
@@ -321,6 +379,11 @@ bool ParserTablePropertiesDeclarationList::parseImpl(Pos & pos, ASTPtr & node, E
             constraints->children.push_back(elem);
         else if (elem->as<ASTProjectionDeclaration>())
             projections->children.push_back(elem);
+        else if (elem->as<ASTForeignKeyDeclaration>()) 
+        {
+            /// Ignore the foreign key node
+            continue;
+        }
         else if (elem->as<ASTIdentifier>() || elem->as<ASTFunction>())
         {
             if (primary_key)

--- a/src/Parsers/ParserCreateQuery.cpp
+++ b/src/Parsers/ParserCreateQuery.cpp
@@ -379,7 +379,7 @@ bool ParserTablePropertiesDeclarationList::parseImpl(Pos & pos, ASTPtr & node, E
             constraints->children.push_back(elem);
         else if (elem->as<ASTProjectionDeclaration>())
             projections->children.push_back(elem);
-        else if (elem->as<ASTForeignKeyDeclaration>()) 
+        else if (elem->as<ASTForeignKeyDeclaration>())
         {
             /// Ignore the foreign key node
             continue;

--- a/src/Parsers/ParserCreateQuery.h
+++ b/src/Parsers/ParserCreateQuery.h
@@ -403,6 +403,13 @@ protected:
     bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
 };
 
+class ParserForeignKeyDeclaration : public IParserBase
+{
+protected:
+    const char * getName() const override { return "foreign key declaration"; }
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+};
+
 class ParserTablePropertyDeclaration : public IParserBase
 {
 protected:

--- a/tests/queries/0_stateless/02863_ignore_foreign_keys_in_tables_definition.reference
+++ b/tests/queries/0_stateless/02863_ignore_foreign_keys_in_tables_definition.reference
@@ -1,0 +1,3 @@
+CREATE TABLE default.child\n(\n    `id` Int32,\n    `pid` Int32\n)\nENGINE = MergeTree\nPRIMARY KEY id\nORDER BY id\nSETTINGS index_granularity = 8192
+CREATE TABLE default.child2\n(\n    `id` Int32,\n    `pid` Int32\n)\nENGINE = MergeTree\nPRIMARY KEY id\nORDER BY id\nSETTINGS index_granularity = 8192
+CREATE TABLE default.child3\n(\n    `id` Int32,\n    `pid` Int32\n)\nENGINE = MergeTree\nPRIMARY KEY id\nORDER BY id\nSETTINGS index_granularity = 8192

--- a/tests/queries/0_stateless/02863_ignore_foreign_keys_in_tables_definition.sql
+++ b/tests/queries/0_stateless/02863_ignore_foreign_keys_in_tables_definition.sql
@@ -1,0 +1,29 @@
+-- https://github.com/ClickHouse/ClickHouse/issues/53380
+
+
+drop table if exists parent;
+drop table if exists child;
+
+create table parent (id int, primary key(id)) engine MergeTree;
+create table child  (id int, pid int, primary key(id), foreign key(pid)) engine MergeTree; -- { clientError SYNTAX_ERROR }
+create table child  (id int, pid int, primary key(id), foreign key(pid) references) engine MergeTree; -- { clientError SYNTAX_ERROR }
+create table child  (id int, pid int, primary key(id), foreign key(pid) references parent(pid)) engine MergeTree;
+
+show create table child;
+
+create table child2 (id int, pid int, primary key(id), 
+                     foreign key(pid) references parent(pid) on delete) engine MergeTree; -- { clientError SYNTAX_ERROR }
+create table child2 (id int, pid int, primary key(id), 
+                     foreign key(pid) references parent(pid) on delete cascade) engine MergeTree;
+
+show create table child2;
+
+create table child3 (id int, pid int, primary key(id), 
+                     foreign key(pid) references parent(pid) on delete cascade on update restrict) engine MergeTree;
+
+show create table child3;
+
+drop table child3;
+drop table child2;
+drop table child;
+drop table parent;


### PR DESCRIPTION
<!---
only modify in the client side, parse the foreign key in client side, ignore its ast node, so no foreign key would be sent to the server side
-->
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...Ignore foreign keys in tables definition to improve compatibility with MySQL, so a user wouldn't need to rewrite his SQL of the foreign key part, ref https://github.com/ClickHouse/ClickHouse/issues/53380

### Documentation entry for user-facing changes
- Motivation:  previously, MySQL users have to remove their foreign key declaration in their SQL script to submit to ClickHouse, because ClickHouse would treat foreign key declaration as illegal. With this feature, foreign keys would be recognized and ignored, so no necessary to modify MySQL script of the foreign key part. 

- Example use: following queries can be executed now with foreign key omit:
-- CREATE TABLE child  (id INT, pid INT, PRIMARY KEY(id), FOREIGN KEY(pid) REFERENCES parent(pid)) ENGINE MergeTree;
-- CREATE TABLE child (id INT, pid INT, PRIMARY KEY(id), FOREIGN KEY(pid) REFERENCES parent(pid) ON DELETE CASCADE ON UPDATE RESTRICT) ENGINE MergeTree;
