### PR TITLE
Release more num_streams if data is small

### DIFF
--- a/src/Processors/QueryPlan/ReadFromMergeTree.cpp
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.cpp
@@ -658,7 +658,29 @@ Pipe ReadFromMergeTree::spreadMarkRangesAmongStreams(RangesInDataParts && parts_
     {
         /// Reduce the number of num_streams if the data is small.
         if (info.sum_marks < num_streams * info.min_marks_for_concurrent_read && parts_with_ranges.size() < num_streams)
-            num_streams = std::max((info.sum_marks + info.min_marks_for_concurrent_read - 1) / info.min_marks_for_concurrent_read, parts_with_ranges.size());
+        {
+            /*
+            If the data is fragmented, then allocate the size of parts to num_streams. If the data is not fragmented, besides the sum_marks and
+            min_marks_for_concurrent_read, involve the system cores to get the num_streams. Increase the num_streams and decrease the min_marks_for_concurrent_read
+            if the data is small but system has plentiful cores. It helps to improve the parallel performance of `MergeTreeRead` significantly.
+            Make sure the new num_streams `num_streams * increase_num_streams_ratio` will not exceed the previous calculated prev_num_streams.
+            The new info.min_marks_for_concurrent_read `info.min_marks_for_concurrent_read / increase_num_streams_ratio` should be larger than 4.
+            https://github.com/ClickHouse/ClickHouse/pull/53867
+            */
+            if ((info.sum_marks + info.min_marks_for_concurrent_read - 1) / info.min_marks_for_concurrent_read > parts_with_ranges.size())
+            {
+                const size_t prev_num_streams = num_streams;
+                num_streams = (info.sum_marks + info.min_marks_for_concurrent_read - 1) / info.min_marks_for_concurrent_read;
+                const size_t increase_num_streams_ratio = std::min(prev_num_streams / num_streams, info.min_marks_for_concurrent_read / 4);
+                if (increase_num_streams_ratio > 1)
+                {
+                    num_streams = num_streams * increase_num_streams_ratio;
+                    info.min_marks_for_concurrent_read = (info.sum_marks + num_streams - 1) / num_streams;
+                }
+            }
+            else
+                num_streams = parts_with_ranges.size();
+        }
     }
 
     auto read_type = is_parallel_reading_from_replicas ? ReadType::ParallelReplicas : ReadType::Default;

--- a/src/Processors/QueryPlan/ReadFromMergeTree.cpp
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.cpp
@@ -664,14 +664,14 @@ Pipe ReadFromMergeTree::spreadMarkRangesAmongStreams(RangesInDataParts && parts_
             min_marks_for_concurrent_read, involve the system cores to get the num_streams. Increase the num_streams and decrease the min_marks_for_concurrent_read
             if the data is small but system has plentiful cores. It helps to improve the parallel performance of `MergeTreeRead` significantly.
             Make sure the new num_streams `num_streams * increase_num_streams_ratio` will not exceed the previous calculated prev_num_streams.
-            The new info.min_marks_for_concurrent_read `info.min_marks_for_concurrent_read / increase_num_streams_ratio` should be larger than 4.
+            The new info.min_marks_for_concurrent_read `info.min_marks_for_concurrent_read / increase_num_streams_ratio` should be larger than 8.
             https://github.com/ClickHouse/ClickHouse/pull/53867
             */
             if ((info.sum_marks + info.min_marks_for_concurrent_read - 1) / info.min_marks_for_concurrent_read > parts_with_ranges.size())
             {
                 const size_t prev_num_streams = num_streams;
                 num_streams = (info.sum_marks + info.min_marks_for_concurrent_read - 1) / info.min_marks_for_concurrent_read;
-                const size_t increase_num_streams_ratio = std::min(prev_num_streams / num_streams, info.min_marks_for_concurrent_read / 4);
+                const size_t increase_num_streams_ratio = std::min(prev_num_streams / num_streams, info.min_marks_for_concurrent_read / 8);
                 if (increase_num_streams_ratio > 1)
                 {
                     num_streams = num_streams * increase_num_streams_ratio;


### PR DESCRIPTION
Besides the sum_marks and min_marks_for_concurrent_read, we could also involve the system cores to get the num_streams if the data is small. Increasing the num_streams and decreasing the min_marks_for_concurrent_read would improve the parallel performance if the system has plentiful cores.

The min_marks_for_concurrent_read could not be too small as it will increase the read count. I have tuned the Q37 of ClickBench with different min_marks_for_concurrent_read on the 80 physical cores system. The sum_marks is 92 and default min_marks_for_concurrent_read is 24. Then the default num_streams are 4.
From the tuning result, we could find that if min_marks_for_concurrent_read is less than 4, it might import the regression.

<html xmlns:v="urn:schemas-microsoft-com:vml"
xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=Excel.Sheet>
<meta name=Generator content="Microsoft Excel 15">
<link id=Main-File rel=Main-File
href="file:///C:/Users/jiebinsu/AppData/Local/Temp/msohtmlclip1/01/clip.htm">
<link rel=File-List
href="file:///C:/Users/jiebinsu/AppData/Local/Temp/msohtmlclip1/01/clip_filelist.xml">
<style>
<!--table
	{mso-displayed-decimal-separator:"\.";
	mso-displayed-thousand-separator:"\,";}
@page
	{margin:.75in .7in .75in .7in;
	mso-header-margin:.3in;
	mso-footer-margin:.3in;}
tr
	{mso-height-source:auto;}
col
	{mso-width-source:auto;}
br
	{mso-data-placement:same-cell;}
td
	{padding-top:1px;
	padding-right:1px;
	padding-left:1px;
	mso-ignore:padding;
	color:black;
	font-size:11.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:Calibri, sans-serif;
	mso-font-charset:0;
	mso-number-format:General;
	text-align:general;
	vertical-align:bottom;
	border:none;
	mso-background-source:auto;
	mso-pattern:auto;
	mso-protection:locked visible;
	white-space:nowrap;
	mso-rotate:0;}
.xl63
	{border:.5pt solid windowtext;}
.xl64
	{mso-number-format:"0\.0%";
	border:.5pt solid windowtext;}
.xl65
	{color:red;
	border:.5pt solid windowtext;
	background:white;
	mso-pattern:black none;}
.xl66
	{border:.5pt solid windowtext;
	background:#A6A6A6;
	mso-pattern:black none;}
.xl67
	{mso-number-format:"0\.0%";
	border:.5pt solid windowtext;
	background:white;
	mso-pattern:black none;}
.xl68
	{border:.5pt solid windowtext;
	background:white;
	mso-pattern:black none;}
-->
</style>
</head>

<body link="#0563C1" vlink="#954F72">



num_streams | min_marks_for_concurrent_read | Normalized QPS
-- | -- | --
4 | 24 | 1
80 | 1 | 128.8%
46 | 2 | 148.0%
31 | 3 | 150.6%
23 | 4 | 153.5%
19 | 5 | 152.7%
16 | 6 | 150.2%
14 | 7 | 149.8%
12 | 8 | 146.7%
6 | 16 | 120.6%



</body>

</html>


Test the patch on 2x80 vCPUs system. Q39 of clickbench has got 3.3x performance improvement. Q36 has got 2.6x performance improvement. The overall geomean has got 9% gain.
<html xmlns:v="urn:schemas-microsoft-com:vml"
xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=Excel.Sheet>
<meta name=Generator content="Microsoft Excel 15">
<link id=Main-File rel=Main-File
href="file:///C:/Users/jiebinsu/AppData/Local/Temp/msohtmlclip1/01/clip.htm">
<link rel=File-List
href="file:///C:/Users/jiebinsu/AppData/Local/Temp/msohtmlclip1/01/clip_filelist.xml">
<style>
<!--table
	{mso-displayed-decimal-separator:"\.";
	mso-displayed-thousand-separator:"\,";}
@page
	{margin:.75in .7in .75in .7in;
	mso-header-margin:.3in;
	mso-footer-margin:.3in;}
tr
	{mso-height-source:auto;}
col
	{mso-width-source:auto;}
br
	{mso-data-placement:same-cell;}
td
	{padding-top:1px;
	padding-right:1px;
	padding-left:1px;
	mso-ignore:padding;
	color:black;
	font-size:11.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:Calibri, sans-serif;
	mso-font-charset:0;
	mso-number-format:General;
	text-align:general;
	vertical-align:bottom;
	border:none;
	mso-background-source:auto;
	mso-pattern:auto;
	mso-protection:locked visible;
	white-space:nowrap;
	mso-rotate:0;}
.xl63
	{border:.5pt solid windowtext;}
.xl64
	{mso-number-format:"0\.0%";
	border:.5pt solid windowtext;}
.xl65
	{border-top:.5pt solid windowtext;
	border-right:none;
	border-bottom:.5pt solid windowtext;
	border-left:.5pt solid windowtext;}
-->
</style>
</head>

<body link="#0563C1" vlink="#954F72">



Q | opt/base
-- | --
0 | 101.3%
1 | 99.1%
2 | 99.4%
3 | 99.4%
4 | 101.3%
5 | 100.4%
6 | 99.9%
7 | 98.4%
8 | 99.0%
9 | 99.6%
10 | 98.6%
11 | 98.3%
12 | 98.9%
13 | 99.1%
14 | 101.2%
15 | 105.9%
16 | 101.9%
17 | 100.4%
18 | 99.4%
19 | 99.9%
20 | 100.0%
21 | 101.2%
22 | 101.1%
23 | 101.4%
24 | 98.9%
25 | 98.2%
26 | 99.5%
27 | 101.6%
28 | 100.7%
29 | 110.4%
30 | 100.6%
31 | 100.8%
32 | 99.6%
33 | 99.4%
34 | 98.0%
35 | 101.9%
36 | 260.4%
37 | 147.9%
38 | 177.8%
39 | 330.7%
40 | 118.4%
41 | 114.3%
42 | 114.5%
Geomean | 109.0%



</body>

</html>

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Release more num_streams if data is small
