### PR TITLE
improve vector/list type when push_back with rvalue

### DIFF
--- a/src/Core/Block.cpp
+++ b/src/Core/Block.cpp
@@ -631,7 +631,7 @@ Names Block::getNames() const
     res.reserve(columns());
 
     for (const auto & elem : data)
-        res.push_back(elem.name);
+        res.push_back(std::move(elem.name));
 
     return res;
 }
@@ -643,7 +643,7 @@ DataTypes Block::getDataTypes() const
     res.reserve(columns());
 
     for (const auto & elem : data)
-        res.push_back(elem.type);
+        res.push_back(std::move(elem.type));
 
     return res;
 }
@@ -655,7 +655,7 @@ Names Block::getDataTypeNames() const
     res.reserve(columns());
 
     for (const auto & elem : data)
-        res.push_back(elem.type->getName());
+        res.push_back(std::move(elem.type->getName()));
 
     return res;
 }
@@ -789,7 +789,7 @@ Serializations Block::getSerializations() const
     res.reserve(data.size());
 
     for (const auto & column : data)
-        res.push_back(column.type->getDefaultSerialization());
+        res.push_back(std::move(column.type->getDefaultSerialization()));
 
     return res;
 }

--- a/src/Core/NamesAndTypes.cpp
+++ b/src/Core/NamesAndTypes.cpp
@@ -146,7 +146,7 @@ Names NamesAndTypesList::getNames() const
     Names res;
     res.reserve(size());
     for (const NameAndTypePair & column : *this)
-        res.push_back(column.name);
+        res.push_back(std::move(column.name));
     return res;
 }
 
@@ -155,7 +155,7 @@ DataTypes NamesAndTypesList::getTypes() const
     DataTypes res;
     res.reserve(size());
     for (const NameAndTypePair & column : *this)
-        res.push_back(column.type);
+        res.push_back(std::move(column.type));
     return res;
 }
 
@@ -177,7 +177,7 @@ NamesAndTypesList NamesAndTypesList::filter(const NameSet & names) const
     for (const NameAndTypePair & column : *this)
     {
         if (names.contains(column.name))
-            res.push_back(column);
+            res.push_back(std::move(column));
     }
     return res;
 }

--- a/src/Disks/StoragePolicy.cpp
+++ b/src/Disks/StoragePolicy.cpp
@@ -170,7 +170,7 @@ Disks StoragePolicy::getDisks() const
     Disks res;
     for (const auto & volume : volumes)
         for (const auto & disk : volume->getDisks())
-            res.push_back(disk);
+            res.push_back(std::move(disk));
     return res;
 }
 

--- a/src/IO/tests/gtest_writebuffer_s3.cpp
+++ b/src/IO/tests/gtest_writebuffer_s3.cpp
@@ -111,7 +111,7 @@ public:
 
         auto & parts = multiPartUploads.at(upload_id);
         for (const auto & tag: etags) {
-            completedParts.push_back(parts.at(tag));
+            completedParts.push_back(std::move(parts.at(tag)));
         }
 
         std::stringstream file_data;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- New Feature
- Improvement
- Performance Improvement
- Backward Incompatible Change
- Build/Testing/Packaging Improvement
- Documentation (changelog entry is not required)
- Bug Fix (user-visible misbehavior in an official stable release)
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
