### PR TITLE
Make UInt128TrivialHash endianness-independent

### DIFF
--- a/src/Common/HashTable/Hash.h
+++ b/src/Common/HashTable/Hash.h
@@ -402,7 +402,7 @@ struct UInt128HashCRC32 : public UInt128Hash {};
 
 struct UInt128TrivialHash
 {
-    size_t operator()(UInt128 x) const { return x.items[0]; }
+    size_t operator()(UInt128 x) const { return x.items[UInt128::_impl::little(0)]; }
 };
 
 struct UUIDTrivialHash


### PR DESCRIPTION
These changes are meant to make `02482_json_nested_arrays_with_same_keys` pass on big-endian platforms by making the trivial hash implementation take the same component (i.e. least significant one) regardless of endianness.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)