### PR TITLE
Finalize file descriptor in ~WriteBufferToFileSegment

### DIFF
--- a/src/Interpreters/Cache/WriteBufferToFileSegment.cpp
+++ b/src/Interpreters/Cache/WriteBufferToFileSegment.cpp
@@ -86,4 +86,10 @@ std::shared_ptr<ReadBuffer> WriteBufferToFileSegment::getReadBufferImpl()
     return std::make_shared<ReadBufferFromFile>(file_segment->getPathInLocalCache());
 }
 
+WriteBufferToFileSegment::~WriteBufferToFileSegment()
+{
+    /// To be sure that file exists before destructor of segment_holder is called
+    WriteBufferFromFileDecorator::finalize();
+}
+
 }

--- a/src/Interpreters/Cache/WriteBufferToFileSegment.h
+++ b/src/Interpreters/Cache/WriteBufferToFileSegment.h
@@ -16,6 +16,7 @@ public:
     explicit WriteBufferToFileSegment(FileSegmentsHolderPtr segment_holder);
 
     void nextImpl() override;
+    ~WriteBufferToFileSegment() override;
 
 private:
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

"Shot in the dark" fix, can't yet reproduce