### PR TITLE
Fix StripeLog storage endian issue for s390x

### DIFF
--- a/src/Formats/IndexForNativeFormat.cpp
+++ b/src/Formats/IndexForNativeFormat.cpp
@@ -20,8 +20,8 @@ void IndexOfBlockForNativeFormat::read(ReadBuffer & istr)
         auto & column = columns.emplace_back();
         readBinary(column.name, istr);
         readBinary(column.type, istr);
-        readBinary(column.location.offset_in_compressed_file, istr);
-        readBinary(column.location.offset_in_decompressed_block, istr);
+        readBinaryLittleEndian(column.location.offset_in_compressed_file, istr);
+        readBinaryLittleEndian(column.location.offset_in_decompressed_block, istr);
     }
 }
 
@@ -34,8 +34,8 @@ void IndexOfBlockForNativeFormat::write(WriteBuffer & ostr) const
         const auto & column = columns[i];
         writeBinary(column.name, ostr);
         writeBinary(column.type, ostr);
-        writeBinary(column.location.offset_in_compressed_file, ostr);
-        writeBinary(column.location.offset_in_decompressed_block, ostr);
+        writeBinaryLittleEndian(column.location.offset_in_compressed_file, ostr);
+        writeBinaryLittleEndian(column.location.offset_in_decompressed_block, ostr);
     }
 }
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
StripeLog storage has endian issue when serializing indices which fails the functional test `00753_system_columns_and_system_tables_long` on s390x.

The fix uses LittleEndian for index serialization for StripeLog on s390x.

### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed StripeLog storage endian issue on the s390x platform.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
