### PR TITLE
Rename COLUMNS expression to dynamic column selection

### DIFF
--- a/docs/en/sql-reference/statements/select/index.md
+++ b/docs/en/sql-reference/statements/select/index.md
@@ -60,9 +60,9 @@ Specifics of each optional clause are covered in separate sections, which are li
 If you want to include all columns in the result, use the asterisk (`*`) symbol. For example, `SELECT * FROM ...`.
 
 
-### COLUMNS expression
+### Dynamic column selection
 
-To match some columns in the result with a [re2](https://en.wikipedia.org/wiki/RE2_(software)) regular expression, you can use the `COLUMNS` expression.
+Dynamic column selection (also known as a COLUMNS expression) allows you to match some columns in a result with a [re2](https://en.wikipedia.org/wiki/RE2_(software)) regular expression.
 
 ``` sql
 COLUMNS('regexp')


### PR DESCRIPTION
### Changelog category (leave one):
- Documentation (changelog entry is not required)

Based on support requests, users find the term `dynamic column selection` more intuitive than `COLUMNS expression`.