### PR TITLE
'from' is supported as a Expression and fix #53543

### DIFF
--- a/src/Parsers/ExpressionListParsers.cpp
+++ b/src/Parsers/ExpressionListParsers.cpp
@@ -865,6 +865,10 @@ public:
                 if (!ParserKeyword("FROM").ignore(test_pos, test_expected))
                     return true;
 
+                // If there is a comma after 'from' then the first one was a name of a column
+                if (test_pos->type == TokenType::Comma)
+                    return true;
+
                 /// If we parse a second FROM then the first one was a name of a column
                 if (ParserKeyword("FROM").ignore(test_pos, test_expected))
                     return true;

--- a/tests/queries/0_stateless/02868_select_support_from_keywords.reference
+++ b/tests/queries/0_stateless/02868_select_support_from_keywords.reference
@@ -1,0 +1,1 @@
+CREATE VIEW default.test_view\n(\n    `date` Date,\n    `__sign` Int8,\n    `from` Float64,\n    `to` Float64\n) AS\nWITH cte AS\n    (\n        SELECT\n            date,\n            __sign,\n            from,\n            to\n        FROM default.test_table\n        FINAL\n    )\nSELECT\n    date,\n    __sign,\n    from,\n    to\nFROM cte

--- a/tests/queries/0_stateless/02868_select_support_from_keywords.sql
+++ b/tests/queries/0_stateless/02868_select_support_from_keywords.sql
@@ -1,0 +1,5 @@
+create table test_table ( `date` Date, `__sign` Int8, `from` Float64, `to` Float64 ) ENGINE = CollapsingMergeTree(__sign) PARTITION BY toYYYYMM(date) ORDER BY (date) SETTINGS index_granularity = 8192;
+create VIEW test_view AS WITH cte AS (SELECT date, __sign, "from", "to" FROM test_table FINAL) SELECT date, __sign, "from", "to" FROM cte;
+show create table test_view;
+drop table test_view;
+drop table test_table;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
'from' is supported as a Expression

fix #53543
If there is a comma after `from`, then the `from` was a name of a column.
example:
```
SELECT
    date,
    from,
    to
FROM test_table
```
After the fix, the `FROM` in this SQL will be properly parsed as a column name