### PR TITLE
Log list of parts that we are going to read from

### DIFF
--- a/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
@@ -1315,7 +1315,7 @@ QueryPlanStepPtr MergeTreeDataSelectExecutor::readFromParts(
 
     selectColumnNames(column_names_to_return, data, real_column_names, virt_column_names, sample_factor_column_queried);
 
-    LOG_TRACE(log, "Reading from parts: [{}]", partsNamesToString(parts, 100));
+    LOG_TEST(log, "Reading from parts: [{}]", partsNamesToString(parts, 100));
 
     return std::make_unique<ReadFromMergeTree>(
         std::move(parts),


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Just to facilitate debugging queries with some optimizations that do not log info about parts (I was looking at `select count() ...` query that was optimized to `ReadFromPreparedSource (_minmax_count_projection)`)