### PR TITLE
Use pathlib.Path in S3Helper, rewrite build reports, improve small things

### DIFF
--- a/tests/ci/ast_fuzzer_check.py
+++ b/tests/ci/ast_fuzzer_check.py
@@ -160,7 +160,7 @@ def main():
     s3_helper = S3Helper()
     for f in paths:
         try:
-            paths[f] = s3_helper.upload_test_report_to_s3(paths[f], s3_prefix + f)
+            paths[f] = s3_helper.upload_test_report_to_s3(Path(paths[f]), s3_prefix + f)
         except Exception as ex:
             logging.info("Exception uploading file %s text %s", f, ex)
             paths[f] = ""

--- a/tests/ci/build_check.py
+++ b/tests/ci/build_check.py
@@ -345,7 +345,7 @@ def main():
         os.remove(performance_path)
 
     build_urls = (
-        s3_helper.upload_build_folder_to_s3(
+        s3_helper.upload_build_directory_to_s3(
             build_output_path,
             s3_path_prefix,
             keep_dirs_in_s3_path=False,

--- a/tests/ci/build_check.py
+++ b/tests/ci/build_check.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python3
 
 from pathlib import Path
-from typing import List, Tuple
+from typing import Tuple
 import subprocess
 import logging
-import json
 import os
 import sys
 import time
@@ -22,6 +21,7 @@ from env_helper import (
 )
 from git_helper import Git, git_runner
 from pr_info import PRInfo
+from report import BuildResult, FAILURE, StatusType, SUCCESS
 from s3_helper import S3Helper
 from tee_popen import TeePopen
 from version_helper import (
@@ -98,7 +98,7 @@ def get_packager_cmd(
 
 def build_clickhouse(
     packager_cmd: str, logs_path: Path, build_output_path: Path
-) -> Tuple[Path, bool]:
+) -> Tuple[Path, StatusType]:
     build_log_path = logs_path / BUILD_LOG_NAME
     success = False
     with TeePopen(packager_cmd, build_log_path) as process:
@@ -118,15 +118,16 @@ def build_clickhouse(
                 )
         else:
             logging.info("Build failed")
-    return build_log_path, success
+    return build_log_path, SUCCESS if success else FAILURE
 
 
 def check_for_success_run(
     s3_helper: S3Helper,
     s3_prefix: str,
     build_name: str,
-    build_config: BuildConfig,
+    version: ClickHouseVersion,
 ) -> None:
+    # TODO: Remove after S3 artifacts
     # the final empty argument is necessary for distinguish build and build_suffix
     logged_prefix = os.path.join(S3_BUILDS_BUCKET, s3_prefix, "")
     logging.info("Checking for artifacts in %s", logged_prefix)
@@ -155,50 +156,21 @@ def check_for_success_run(
         return
 
     success = len(build_urls) > 0
-    create_json_artifact(
-        TEMP_PATH,
+    build_result = BuildResult(
         build_name,
         log_url,
         build_urls,
-        build_config,
+        version.describe,
+        SUCCESS if success else FAILURE,
         0,
-        success,
+        GITHUB_JOB,
     )
+    build_result.write_json(Path(TEMP_PATH))
     # Fail build job if not successeded
     if not success:
         sys.exit(1)
     else:
         sys.exit(0)
-
-
-def create_json_artifact(
-    temp_path: str,
-    build_name: str,
-    log_url: str,
-    build_urls: List[str],
-    build_config: BuildConfig,
-    elapsed: int,
-    success: bool,
-) -> None:
-    subprocess.check_call(
-        f"echo 'BUILD_URLS=build_urls_{build_name}' >> $GITHUB_ENV", shell=True
-    )
-
-    result = {
-        "log_url": log_url,
-        "build_urls": build_urls,
-        "build_config": build_config.__dict__,
-        "elapsed_seconds": elapsed,
-        "status": success,
-        "job_name": GITHUB_JOB,
-    }
-
-    json_name = "build_urls_" + build_name + ".json"
-
-    print(f"Dump json report {result} to {json_name} with env build_urls_{build_name}")
-
-    with open(os.path.join(temp_path, json_name), "w", encoding="utf-8") as build_links:
-        json.dump(result, build_links)
 
 
 def get_release_or_pr(pr_info: PRInfo, version: ClickHouseVersion) -> Tuple[str, str]:
@@ -269,7 +241,7 @@ def main():
 
     # If this is rerun, then we try to find already created artifacts and just
     # put them as github actions artifact (result)
-    check_for_success_run(s3_helper, s3_path_prefix, build_name, build_config)
+    check_for_success_run(s3_helper, s3_path_prefix, build_name, version)
 
     docker_image = get_image_with_version(IMAGES_PATH, IMAGE_NAME)
     image_version = docker_image.version
@@ -312,16 +284,17 @@ def main():
     os.makedirs(logs_path, exist_ok=True)
 
     start = time.time()
-    log_path, success = build_clickhouse(packager_cmd, logs_path, build_output_path)
+    log_path, build_status = build_clickhouse(
+        packager_cmd, logs_path, build_output_path
+    )
     elapsed = int(time.time() - start)
     subprocess.check_call(
         f"sudo chown -R ubuntu:ubuntu {build_output_path}", shell=True
     )
-    logging.info("Build finished with %s, log path %s", success, log_path)
-    if success:
+    logging.info("Build finished as %s, log path %s", build_status, log_path)
+    if build_status == SUCCESS:
         cargo_cache.upload()
-
-    if not success:
+    else:
         # We check if docker works, because if it's down, it's infrastructure
         try:
             subprocess.check_call("docker info", shell=True)
@@ -367,8 +340,20 @@ def main():
 
     print(f"::notice ::Log URL: {log_url}")
 
-    create_json_artifact(
-        TEMP_PATH, build_name, log_url, build_urls, build_config, elapsed, success
+    build_result = BuildResult(
+        build_name,
+        log_url,
+        build_urls,
+        version.describe,
+        build_status,
+        elapsed,
+        GITHUB_JOB,
+    )
+    result_json_path = build_result.write_json(temp_path)
+    logging.info(
+        "Build result file %s is written, content:\n %s",
+        result_json_path,
+        result_json_path.read_text(encoding="utf-8"),
     )
 
     upload_master_static_binaries(pr_info, build_config, s3_helper, build_output_path)
@@ -449,7 +434,7 @@ FORMAT JSONCompactEachRow"""
     prepared_events = prepare_tests_results_for_clickhouse(
         pr_info,
         [],
-        "success" if success else "failure",
+        build_status,
         stopwatch.duration_seconds,
         stopwatch.start_time_str,
         log_url,
@@ -458,7 +443,7 @@ FORMAT JSONCompactEachRow"""
     ch_helper.insert_events_into(db="default", table="checks", events=prepared_events)
 
     # Fail the build job if it didn't succeed
-    if not success:
+    if build_status != SUCCESS:
         sys.exit(1)
 
 

--- a/tests/ci/build_download_helper.py
+++ b/tests/ci/build_download_helper.py
@@ -6,7 +6,7 @@ import os
 import sys
 import time
 from pathlib import Path
-from typing import Any, Callable, List
+from typing import Any, Callable, List, Union
 
 import requests  # type: ignore
 
@@ -98,7 +98,7 @@ def get_build_name_for_check(check_name: str) -> str:
     return CI_CONFIG.test_configs[check_name].required_build
 
 
-def read_build_urls(build_name: str, reports_path: str) -> List[str]:
+def read_build_urls(build_name: str, reports_path: Union[Path, str]) -> List[str]:
     for root, _, files in os.walk(reports_path):
         for f in files:
             if build_name in f:

--- a/tests/ci/build_report_check.py
+++ b/tests/ci/build_report_check.py
@@ -5,6 +5,7 @@ import logging
 import os
 import sys
 import atexit
+from pathlib import Path
 from typing import Dict, List, Tuple
 
 from github import Github
@@ -118,11 +119,10 @@ def get_build_name_from_file_name(file_name):
 
 def main():
     logging.basicConfig(level=logging.INFO)
-    temp_path = TEMP_PATH
+    temp_path = Path(TEMP_PATH)
     logging.info("Reports path %s", REPORTS_PATH)
 
-    if not os.path.exists(temp_path):
-        os.makedirs(temp_path)
+    temp_path.mkdir(parents=True, exist_ok=True)
 
     build_check_name = sys.argv[1]
     needs_data = {}  # type: NeedsDataType
@@ -242,9 +242,8 @@ def main():
         commit_url,
     )
 
-    report_path = os.path.join(temp_path, "report.html")
-    with open(report_path, "w", encoding="utf-8") as fd:
-        fd.write(report)
+    report_path = temp_path / "report.html"
+    report_path.write_text(report, encoding="utf-8")
 
     logging.info("Going to upload prepared report")
     context_name_for_path = build_check_name.lower().replace(" ", "_")

--- a/tests/ci/build_report_check.py
+++ b/tests/ci/build_report_check.py
@@ -6,19 +6,24 @@ import os
 import sys
 import atexit
 from pathlib import Path
-from typing import Dict, List, Tuple
 
 from github import Github
 
 from env_helper import (
     GITHUB_JOB_URL,
     GITHUB_REPOSITORY,
-    GITHUB_RUN_URL,
     GITHUB_SERVER_URL,
     REPORTS_PATH,
     TEMP_PATH,
 )
-from report import create_build_html_report, BuildResult, BuildResults
+from report import (
+    BuildResult,
+    ERROR,
+    PENDING,
+    SUCCESS,
+    create_build_html_report,
+    get_worst_status,
+)
 from s3_helper import S3Helper
 from get_robot_token import get_best_robot_token
 from pr_info import NeedsDataType, PRInfo
@@ -35,94 +40,17 @@ from ci_config import CI_CONFIG
 NEEDS_DATA_PATH = os.getenv("NEEDS_DATA_PATH", "")
 
 
-def group_by_artifacts(build_urls: List[str]) -> Dict[str, List[str]]:
-    groups = {
-        "apk": [],
-        "deb": [],
-        "binary": [],
-        "tgz": [],
-        "rpm": [],
-        "performance": [],
-    }  # type: Dict[str, List[str]]
-    for url in build_urls:
-        if url.endswith("performance.tar.zst"):
-            groups["performance"].append(url)
-        elif (
-            url.endswith(".deb")
-            or url.endswith(".buildinfo")
-            or url.endswith(".changes")
-            or url.endswith(".tar.gz")
-        ):
-            groups["deb"].append(url)
-        elif url.endswith(".apk"):
-            groups["apk"].append(url)
-        elif url.endswith(".rpm"):
-            groups["rpm"].append(url)
-        elif url.endswith(".tgz") or url.endswith(".tgz.sha512"):
-            groups["tgz"].append(url)
-        else:
-            groups["binary"].append(url)
-    return groups
-
-
-def get_failed_report(
-    job_name: str,
-) -> Tuple[BuildResults, List[List[str]], List[str]]:
-    message = f"{job_name} failed"
-    build_result = BuildResult(
-        compiler="unknown",
-        debug_build=False,
-        sanitizer="unknown",
-        status=message,
-        elapsed_seconds=0,
-        comment="",
-    )
-    return [build_result], [[""]], [GITHUB_RUN_URL]
-
-
-def process_report(
-    build_report: dict,
-) -> Tuple[BuildResults, List[List[str]], List[str]]:
-    build_config = build_report["build_config"]
-    build_result = BuildResult(
-        compiler=build_config["compiler"],
-        debug_build=build_config["debug_build"],
-        sanitizer=build_config["sanitizer"],
-        status="success" if build_report["status"] else "failure",
-        elapsed_seconds=build_report["elapsed_seconds"],
-        comment=build_config["comment"],
-    )
-    build_results = []
-    build_urls = []
-    build_logs_urls = []
-    urls_groups = group_by_artifacts(build_report["build_urls"])
-    found_group = False
-    for _, group_urls in urls_groups.items():
-        if group_urls:
-            build_results.append(build_result)
-            build_urls.append(group_urls)
-            build_logs_urls.append(build_report["log_url"])
-            found_group = True
-
-    # No one group of urls is found, a failed report
-    if not found_group:
-        build_results.append(build_result)
-        build_urls.append([""])
-        build_logs_urls.append(build_report["log_url"])
-
-    return build_results, build_urls, build_logs_urls
-
-
-def get_build_name_from_file_name(file_name):
-    return file_name.replace("build_urls_", "").replace(".json", "")
-
-
 def main():
     logging.basicConfig(level=logging.INFO)
     temp_path = Path(TEMP_PATH)
-    logging.info("Reports path %s", REPORTS_PATH)
-
     temp_path.mkdir(parents=True, exist_ok=True)
+
+    logging.info("Reports path %s", REPORTS_PATH)
+    reports_path = Path(REPORTS_PATH)
+    logging.info(
+        "Reports found:\n %s",
+        "\n ".join(p.as_posix() for p in reports_path.rglob("*.json")),
+    )
 
     build_check_name = sys.argv[1]
     needs_data = {}  # type: NeedsDataType
@@ -132,11 +60,11 @@ def main():
             needs_data = json.load(file_handler)
             required_builds = len(needs_data)
 
-    if needs_data and all(i["result"] == "skipped" for i in needs_data.values()):
-        logging.info("All builds are skipped, exiting")
-        sys.exit(0)
-
-    logging.info("The next builds are required: %s", ", ".join(needs_data))
+    if needs_data:
+        logging.info("The next builds are required: %s", ", ".join(needs_data))
+        if all(i["result"] == "skipped" for i in needs_data.values()):
+            logging.info("All builds are skipped, exiting")
+            sys.exit(0)
 
     gh = Github(get_best_robot_token(), per_page=100)
     pr_info = PRInfo()
@@ -153,73 +81,41 @@ def main():
     required_builds = required_builds or len(builds_for_check)
 
     # Collect reports from json artifacts
-    builds_report_map = {}
-    for root, _, files in os.walk(REPORTS_PATH):
-        for f in files:
-            if f.startswith("build_urls_") and f.endswith(".json"):
-                logging.info("Found build report json %s", f)
-                build_name = get_build_name_from_file_name(f)
-                if build_name in builds_for_check:
-                    with open(os.path.join(root, f), "rb") as file_handler:
-                        builds_report_map[build_name] = json.load(file_handler)
-                else:
-                    logging.info(
-                        "Skipping report %s for build %s, it's not in our reports list",
-                        f,
-                        build_name,
-                    )
+    build_results = []
+    for build_name in builds_for_check:
+        report_name = BuildResult.get_report_name(build_name).stem
+        build_result = BuildResult.read_json(reports_path / report_name, build_name)
+        if build_result.is_missing:
+            logging.warning("Build results for %s are missing", build_name)
+            continue
+        build_results.append(build_result)
 
-    # Sort reports by config order
-    build_reports = [
-        builds_report_map[build_name]
-        for build_name in builds_for_check
-        if build_name in builds_report_map
+    # The code to collect missing reports for failed jobs
+    missing_job_names = [
+        name
+        for name in needs_data
+        if not any(1 for build_result in build_results if build_result.job_name == name)
     ]
-
-    some_builds_are_missing = len(build_reports) < required_builds
-    missing_build_names = []
-    if some_builds_are_missing:
-        logging.warning(
-            "Expected to get %s build results, got only %s",
-            required_builds,
-            len(build_reports),
-        )
-        missing_build_names = [
-            name
-            for name in needs_data
-            if not any(rep for rep in build_reports if rep["job_name"] == name)
-        ]
-    else:
-        logging.info("Got exactly %s builds", len(builds_report_map))
-
-    # Group build artifacts by groups
-    build_results = []  # type: BuildResults
-    build_artifacts = []  # type: List[List[str]]
-    build_logs = []  # type: List[str]
-
-    for build_report in build_reports:
-        _build_results, build_artifacts_url, build_logs_url = process_report(
-            build_report
-        )
+    missing_builds = len(missing_job_names)
+    for job_name in reversed(missing_job_names):
+        build_result = BuildResult.missing_result("missing")
+        build_result.job_name = job_name
+        build_result.status = PENDING
         logging.info(
-            "Got %s artifact groups for build report report", len(_build_results)
+            "There is missing report for %s, created a dummy result %s",
+            job_name,
+            build_result,
         )
-        build_results.extend(_build_results)
-        build_artifacts.extend(build_artifacts_url)
-        build_logs.extend(build_logs_url)
+        build_results.insert(0, build_result)
 
-    for failed_job in missing_build_names:
-        _build_results, build_artifacts_url, build_logs_url = get_failed_report(
-            failed_job
-        )
-        build_results.extend(_build_results)
-        build_artifacts.extend(build_artifacts_url)
-        build_logs.extend(build_logs_url)
-
-    total_groups = len(build_results)
+    # Calculate artifact groups like packages and binaries
+    total_groups = sum(len(br.grouped_urls) for br in build_results)
+    ok_groups = sum(
+        len(br.grouped_urls) for br in build_results if br.status == SUCCESS
+    )
     logging.info("Totally got %s artifact groups", total_groups)
     if total_groups == 0:
-        logging.error("No success builds, failing check")
+        logging.error("No success builds, failing check without creating a status")
         sys.exit(1)
 
     s3_helper = S3Helper()
@@ -234,8 +130,6 @@ def main():
     report = create_build_html_report(
         build_check_name,
         build_results,
-        build_logs,
-        build_artifacts,
         task_url,
         branch_url,
         branch_name,
@@ -258,27 +152,20 @@ def main():
     print(f"::notice ::Report url: {url}")
 
     # Prepare a commit status
-    ok_groups = 0
-    summary_status = "success"
-    for build_result in build_results:
-        if build_result.status == "failure" and summary_status != "error":
-            summary_status = "failure"
-        if build_result.status == "error" or not build_result.status:
-            summary_status = "error"
-
-        if build_result.status == "success":
-            ok_groups += 1
+    summary_status = get_worst_status(br.status for br in build_results)
 
     # Check if there are no builds at all, do not override bad status
-    if summary_status == "success":
-        if some_builds_are_missing:
-            summary_status = "pending"
+    if summary_status == SUCCESS:
+        if missing_builds:
+            summary_status = PENDING
         elif ok_groups == 0:
-            summary_status = "error"
+            summary_status = ERROR
 
     addition = ""
-    if some_builds_are_missing:
-        addition = f" ({len(build_reports)} of {required_builds} builds are OK)"
+    if missing_builds:
+        addition = (
+            f" ({required_builds - missing_builds} of {required_builds} builds are OK)"
+        )
 
     description = format_description(
         f"{ok_groups}/{total_groups} artifact groups are OK{addition}"
@@ -288,7 +175,7 @@ def main():
         commit, summary_status, url, description, build_check_name, pr_info
     )
 
-    if summary_status == "error":
+    if summary_status == ERROR:
         sys.exit(1)
 
 

--- a/tests/ci/docker_pull_helper.py
+++ b/tests/ci/docker_pull_helper.py
@@ -6,7 +6,8 @@ import time
 import subprocess
 import logging
 
-from typing import List, Optional
+from pathlib import Path
+from typing import List, Optional, Union
 
 
 class DockerImage:
@@ -22,7 +23,7 @@ class DockerImage:
 
 
 def get_images_with_versions(
-    reports_path: str,
+    reports_path: Union[Path, str],
     required_images: List[str],
     pull: bool = True,
     version: Optional[str] = None,
@@ -80,7 +81,10 @@ def get_images_with_versions(
 
 
 def get_image_with_version(
-    reports_path: str, image: str, pull: bool = True, version: Optional[str] = None
+    reports_path: Union[Path, str],
+    image: str,
+    pull: bool = True,
+    version: Optional[str] = None,
 ) -> DockerImage:
     logging.info("Looking for images file in %s", reports_path)
     return get_images_with_versions(reports_path, [image], pull, version=version)[0]

--- a/tests/ci/install_check.py
+++ b/tests/ci/install_check.py
@@ -29,7 +29,7 @@ from docker_pull_helper import get_image_with_version, DockerImage
 from env_helper import CI, TEMP_PATH as TEMP, REPORTS_PATH
 from get_robot_token import get_best_robot_token
 from pr_info import PRInfo
-from report import TestResults, TestResult
+from report import TestResults, TestResult, FAILURE, FAIL, OK, SUCCESS
 from s3_helper import S3Helper
 from stopwatch import Stopwatch
 from tee_popen import TeePopen
@@ -40,10 +40,6 @@ RPM_IMAGE = "clickhouse/install-rpm-test"
 DEB_IMAGE = "clickhouse/install-deb-test"
 TEMP_PATH = Path(TEMP)
 LOGS_PATH = TEMP_PATH / "tests_logs"
-SUCCESS = "success"
-FAILURE = "failure"
-OK = "OK"
-FAIL = "FAIL"
 
 
 def prepare_test_scripts():

--- a/tests/ci/performance_comparison_check.py
+++ b/tests/ci/performance_comparison_check.py
@@ -7,6 +7,7 @@ import json
 import subprocess
 import traceback
 import re
+from pathlib import Path
 from typing import Dict
 
 from github import Github
@@ -218,15 +219,17 @@ if __name__ == "__main__":
     uploaded = {}  # type: Dict[str, str]
     for name, path in paths.items():
         try:
-            uploaded[name] = s3_helper.upload_test_report_to_s3(path, s3_prefix + name)
+            uploaded[name] = s3_helper.upload_test_report_to_s3(
+                Path(path), s3_prefix + name
+            )
         except Exception:
             uploaded[name] = ""
             traceback.print_exc()
 
     # Upload all images and flamegraphs to S3
     try:
-        s3_helper.upload_test_folder_to_s3(
-            os.path.join(result_path, "images"), s3_prefix + "images"
+        s3_helper.upload_test_directory_to_s3(
+            Path(result_path) / "images", s3_prefix + "images"
         )
     except Exception:
         traceback.print_exc()

--- a/tests/ci/report.py
+++ b/tests/ci/report.py
@@ -10,9 +10,10 @@ import datetime
 
 ### BEST FRONTEND PRACTICES BELOW
 
-HTML_BASE_TEST_TEMPLATE = """
+HEAD_HTML_TEMPLATE = """
 <!DOCTYPE html>
 <html>
+<head>
   <style>
 
 :root {{
@@ -98,15 +99,9 @@ tr:hover {{ filter: var(--tr-hover-filter); }}
 <div class="main">
 <span class="nowrap themes"><span id="toggle-dark">🌚</span><span id="toggle-light">🌞</span></span>
 <h1><span class="gradient">{header}</span></h1>
-<p class="links">
-<a href="{raw_log_url}">{raw_log_name}</a>
-<a href="{commit_url}">Commit</a>
-{additional_urls}
-<a href="{task_url}">Task (github actions)</a>
-<a href="{job_url}">Job (github actions)</a>
-</p>
-{test_part}
-<img id="fish" src="https://presentations.clickhouse.com/images/fish.png" />
+"""
+
+FOOTER_HTML_TEMPLATE = """<img id="fish" src="https://presentations.clickhouse.com/images/fish.png" />
 <script type="text/javascript">
     /// Straight from https://stackoverflow.com/questions/14267781/sorting-html-table-with-javascript
 
@@ -160,6 +155,21 @@ tr:hover {{ filter: var(--tr-hover-filter); }}
 </body>
 </html>
 """
+
+
+HTML_BASE_TEST_TEMPLATE = (
+    f"{HEAD_HTML_TEMPLATE}"
+    """<p class="links">
+<a href="{raw_log_url}">{raw_log_name}</a>
+<a href="{commit_url}">Commit</a>
+{additional_urls}
+<a href="{task_url}">Task (github actions)</a>
+<a href="{job_url}">Job (github actions)</a>
+</p>
+{test_part}
+"""
+    f"{FOOTER_HTML_TEMPLATE}"
+)
 
 HTML_TEST_PART = """
 <table>
@@ -423,27 +433,12 @@ def create_test_html_report(
     return html
 
 
-HTML_BASE_BUILD_TEMPLATE = """
-<!DOCTYPE html>
-<html>
-<head>
-  <style>
-body {{ font-family: "DejaVu Sans", "Noto Sans", Arial, sans-serif; background: #EEE; }}
-h1 {{ margin-left: 10px; }}
-th, td {{ border: 0; padding: 5px 10px 5px 10px; text-align: left; vertical-align: top; line-height: 1.5; background-color: #FFF;
-border: 0; box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.05), 0 8px 25px -5px rgba(0, 0, 0, 0.1); }}
-a {{ color: #06F; text-decoration: none; }}
-a:hover, a:active {{ color: #F40; text-decoration: underline; }}
-table {{ border: 0; }}
-.main {{ margin: auto; }}
-p.links a {{ padding: 5px; margin: 3px; background: #FFF; line-height: 2; white-space: nowrap; box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.05), 0 8px 25px -5px rgba(0, 0, 0, 0.1); }}
-tr:hover td {{filter: brightness(95%);}}
-  </style>
-<title>{title}</title>
-</head>
-<body>
-<div class="main">
-<h1>{header}</h1>
+HTML_BASE_BUILD_TEMPLATE = (
+    f"{HEAD_HTML_TEMPLATE}"
+    """<p class="links">
+<a href="{commit_url}">Commit</a>
+<a href="{task_url}">Task (github actions)</a>
+</p>
 <table>
 <tr>
 <th>Compiler</th>
@@ -457,13 +452,9 @@ tr:hover td {{filter: brightness(95%);}}
 </tr>
 {rows}
 </table>
-<p class="links">
-<a href="{commit_url}">Commit</a>
-<a href="{task_url}">Task (github actions)</a>
-</p>
-</body>
-</html>
 """
+    f"{FOOTER_HTML_TEMPLATE}"
+)
 
 LINK_TEMPLATE = '<a href="{url}">{text}</a>'
 

--- a/tests/ci/report.py
+++ b/tests/ci/report.py
@@ -343,7 +343,7 @@ def create_test_html_report(
         additional_urls = []
 
     if test_results:
-        rows_part = ""
+        rows_part = []
         num_fails = 0
         has_test_time = False
         has_log_urls = False
@@ -358,11 +358,13 @@ def create_test_html_report(
             if test_result.log_files is not None:
                 has_log_urls = True
 
-            row = "<tr>"
+            row = []
             has_error = test_result.status in ("FAIL", "NOT_FAILED")
             if has_error and test_result.raw_logs is not None:
-                row = '<tr class="failed">'
-            row += "<td>" + test_result.name + "</td>"
+                row.append('<tr class="failed">')
+            else:
+                row.append("<tr>")
+            row.append(f"<td>{test_result.name}</td>")
             colspan += 1
             style = _get_status_style(test_result.status, colortheme=statuscolors)
 
@@ -372,12 +374,12 @@ def create_test_html_report(
                 num_fails = num_fails + 1
                 fail_id = f'id="fail{num_fails}" '
 
-            row += f'<td {fail_id}style="{style}">{test_result.status}</td>'
+            row.append(f'<td {fail_id}style="{style}">{test_result.status}</td>')
             colspan += 1
 
             if test_result.time is not None:
                 has_test_time = True
-                row += f"<td>{test_result.time}</td>"
+                row.append(f"<td>{test_result.time}</td>")
                 colspan += 1
 
             if test_result.log_urls is not None:
@@ -385,19 +387,19 @@ def create_test_html_report(
                 test_logs_html = "<br>".join(
                     [_get_html_url(url) for url in test_result.log_urls]
                 )
-                row += "<td>" + test_logs_html + "</td>"
+                row.append(f"<td>{test_logs_html}</td>")
                 colspan += 1
 
-            row += "</tr>"
-            rows_part += row
+            row.append("</tr>")
+            rows_part.append("".join(row))
             if test_result.raw_logs is not None:
                 raw_logs = escape(test_result.raw_logs)
-                row = (
+                row_raw_logs = (
                     '<tr class="failed-content">'
                     f'<td colspan="{colspan}"><pre>{raw_logs}</pre></td>'
                     "</tr>"
                 )
-                rows_part += row
+                rows_part.append(row_raw_logs)
 
         headers = BASE_HEADERS.copy()
         if has_test_time:
@@ -406,7 +408,7 @@ def create_test_html_report(
             headers.append("Logs")
 
         headers_html = "".join(["<th>" + h + "</th>" for h in headers])
-        test_part = HTML_TEST_PART.format(headers=headers_html, rows=rows_part)
+        test_part = HTML_TEST_PART.format(headers=headers_html, rows="".join(rows_part))
     else:
         test_part = ""
 
@@ -469,36 +471,36 @@ def create_build_html_report(
     branch_name: str,
     commit_url: str,
 ) -> str:
-    rows = ""
+    rows = []
     for build_result, build_log_url, artifact_urls in zip(
         build_results, build_logs_urls, artifact_urls_list
     ):
-        row = "<tr>"
-        row += f"<td>{build_result.compiler}</td>"
+        row = ["<tr>"]
+        row.append(f"<td>{build_result.compiler}</td>")
         if build_result.debug_build:
-            row += "<td>debug</td>"
+            row.append("<td>debug</td>")
         else:
-            row += "<td>relwithdebuginfo</td>"
+            row.append("<td>relwithdebuginfo</td>")
         if build_result.sanitizer:
-            row += f"<td>{build_result.sanitizer}</td>"
+            row.append(f"<td>{build_result.sanitizer}</td>")
         else:
-            row += "<td>none</td>"
+            row.append("<td>none</td>")
 
         if build_result.status:
             style = _get_status_style(build_result.status)
-            row += f'<td style="{style}">{build_result.status}</td>'
+            row.append(f'<td style="{style}">{build_result.status}</td>')
         else:
             style = _get_status_style("error")
-            row += f'<td style="{style}">error</td>'
+            row.append(f'<td style="{style}">error</td>')
 
-        row += f'<td><a href="{build_log_url}">link</a></td>'
+        row.append(f'<td><a href="{build_log_url}">link</a></td>')
 
         if build_result.elapsed_seconds:
             delta = datetime.timedelta(seconds=build_result.elapsed_seconds)
         else:
             delta = "unknown"  # type: ignore
 
-        row += f"<td>{delta}</td>"
+        row.append(f"<td>{delta}</td>")
 
         links = ""
         link_separator = "<br/>"
@@ -510,16 +512,16 @@ def create_build_html_report(
                 links += link_separator
             if links:
                 links = links[: -len(link_separator)]
-            row += f"<td>{links}</td>"
+            row.append(f"<td>{links}</td>")
 
-        row += f"<td>{build_result.comment}</td>"
+        row.append(f"<td>{build_result.comment}</td>")
 
-        row += "</tr>"
-        rows += row
+        row.append("</tr>")
+        rows.append("".join(row))
     return HTML_BASE_BUILD_TEMPLATE.format(
         title=_format_header(header, branch_name),
         header=_format_header(header, branch_name, branch_url),
-        rows=rows,
+        rows="".join(rows),
         task_url=task_url,
         branch_name=branch_name,
         commit_url=commit_url,

--- a/tests/ci/upload_result_helper.py
+++ b/tests/ci/upload_result_helper.py
@@ -34,7 +34,7 @@ def process_logs(
                 test_result.log_urls.append(processed_logs[path])
             elif path:
                 url = s3_client.upload_test_report_to_s3(
-                    path.as_posix(), s3_path_prefix + "/" + path.name
+                    path, s3_path_prefix + "/" + path.name
                 )
                 test_result.log_urls.append(url)
                 processed_logs[path] = url
@@ -44,7 +44,7 @@ def process_logs(
         if log_path:
             additional_urls.append(
                 s3_client.upload_test_report_to_s3(
-                    log_path, s3_path_prefix + "/" + os.path.basename(log_path)
+                    Path(log_path), s3_path_prefix + "/" + os.path.basename(log_path)
                 )
             )
 
@@ -100,9 +100,9 @@ def upload_results(
         additional_urls,
         statuscolors=statuscolors,
     )
-    with open("report.html", "w", encoding="utf-8") as f:
-        f.write(html_report)
+    report_path = Path("report.html")
+    report_path.write_text(html_report, encoding="utf-8")
 
-    url = s3_client.upload_test_report_to_s3("report.html", s3_path_prefix + ".html")
+    url = s3_client.upload_test_report_to_s3(report_path, s3_path_prefix + ".html")
     logging.info("Search result in url %s", url)
     return url

--- a/tests/ci/version_helper.py
+++ b/tests/ci/version_helper.py
@@ -245,8 +245,10 @@ def get_version_from_string(
 
 def get_version_from_tag(tag: str) -> ClickHouseVersion:
     Git.check_tag(tag)
-    tag = tag[1:].split("-")[0]
-    return get_version_from_string(tag)
+    tag, description = tag[1:].split("-", 1)
+    version = get_version_from_string(tag)
+    version.with_description(description)
+    return version
 
 
 def version_arg(version: str) -> ClickHouseVersion:


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Use only `pathlib.Path` in `S3Helper`; rewrite build reports; use the same theme for tests and build reports; add function `get_job_id_url` to get ID and URL for other jobs; improve `get_version_from_tag` function.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
