### PR TITLE
Correct UniquesHashSet to be endianness-independent.

### DIFF
--- a/src/AggregateFunctions/UniquesHashSet.h
+++ b/src/AggregateFunctions/UniquesHashSet.h
@@ -109,24 +109,12 @@ private:
     inline size_t max_fill() const           { return 1ULL << (size_degree - 1); } /// NOLINT
     inline size_t mask() const               { return buf_size() - 1; }
 
-    inline size_t place(HashValue x) const
-    {
-        if constexpr (std::endian::native == std::endian::little)
-            return (x >> UNIQUES_HASH_BITS_FOR_SKIP) & mask();
-        else
-            return (std::byteswap(x) >> UNIQUES_HASH_BITS_FOR_SKIP) & mask();
-    }
+    inline size_t place(HashValue x) const { return (x >> UNIQUES_HASH_BITS_FOR_SKIP) & mask(); }
 
     /// The value is divided by 2 ^ skip_degree
-    inline bool good(HashValue hash) const
-    {
-        return hash == ((hash >> skip_degree) << skip_degree);
-    }
+    inline bool good(HashValue hash) const { return hash == ((hash >> skip_degree) << skip_degree); }
 
-    HashValue hash(Value key) const
-    {
-        return static_cast<HashValue>(Hash()(key));
-    }
+    HashValue hash(Value key) const { return static_cast<HashValue>(Hash()(key)); }
 
     /// Delete all values whose hashes do not divide by 2 ^ skip_degree
     void rehash()
@@ -338,11 +326,7 @@ public:
 
     void ALWAYS_INLINE insert(Value x)
     {
-        HashValue hash_value;
-        if constexpr (std::endian::native == std::endian::little)
-            hash_value = hash(x);
-        else
-            hash_value = std::byteswap(hash(x));
+        const HashValue hash_value = hash(x);
         if (!good(hash_value))
             return;
 
@@ -403,25 +387,25 @@ public:
         if (m_size > UNIQUES_HASH_MAX_SIZE)
             throw Poco::Exception("Cannot write UniquesHashSet: too large size_degree.");
 
-        DB::writeIntBinary(skip_degree, wb);
+        DB::writeBinaryLittleEndian(skip_degree, wb);
         DB::writeVarUInt(m_size, wb);
 
         if (has_zero)
         {
             HashValue x = 0;
-            DB::writeIntBinary(x, wb);
+            DB::writeBinaryLittleEndian(x, wb);
         }
 
         for (size_t i = 0; i < buf_size(); ++i)
             if (buf[i])
-                DB::writeIntBinary(buf[i], wb);
+                DB::writeBinaryLittleEndian(buf[i], wb);
     }
 
     void read(DB::ReadBuffer & rb)
     {
         has_zero = false;
 
-        DB::readIntBinary(skip_degree, rb);
+        DB::readBinaryLittleEndian(skip_degree, rb);
         DB::readVarUInt(m_size, rb);
 
         if (m_size > UNIQUES_HASH_MAX_SIZE)
@@ -440,7 +424,7 @@ public:
             for (size_t i = 0; i < m_size; ++i)
             {
                 HashValue x = 0;
-                DB::readIntBinary(x, rb);
+                DB::readBinaryLittleEndian(x, rb);
                 if (x == 0)
                     has_zero = true;
                 else
@@ -454,6 +438,7 @@ public:
 
             for (size_t i = 0; i < m_size; ++i)
             {
+                DB::transformEndianness<std::endian::native, std::endian::little>(hs[i]);
                 if (hs[i] == 0)
                     has_zero = true;
                 else
@@ -465,7 +450,7 @@ public:
     void readAndMerge(DB::ReadBuffer & rb)
     {
         UInt8 rhs_skip_degree = 0;
-        DB::readIntBinary(rhs_skip_degree, rb);
+        DB::readBinaryLittleEndian(rhs_skip_degree, rb);
 
         if (rhs_skip_degree > skip_degree)
         {
@@ -490,7 +475,7 @@ public:
             for (size_t i = 0; i < rhs_size; ++i)
             {
                 HashValue x = 0;
-                DB::readIntBinary(x, rb);
+                DB::readBinaryLittleEndian(x, rb);
                 insertHash(x);
             }
         }
@@ -501,6 +486,7 @@ public:
 
             for (size_t i = 0; i < rhs_size; ++i)
             {
+                DB::transformEndianness<std::endian::native, std::endian::little>(hs[i]);
                 insertHash(hs[i]);
             }
         }


### PR DESCRIPTION
Correct the `UniquesHashSet` to utilize native Endianness for hashes in the internal buffer. Fix serialization and deserialization to utilize Little Endian. The following functional tests have the correct output for s390x

* `00973_uniq_non_associativity`
* `01380_nullable_state`
* `02418_aggregate_combinators`
* `02428_combinators_with_over_statement`
* `02429_combinators_in_array_reduce`
* `02430_initialize_aggregation_with_combinators`

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

