### PR TITLE
Another fix for #54059

### DIFF
--- a/src/Disks/IO/CachedOnDiskReadBufferFromFile.cpp
+++ b/src/Disks/IO/CachedOnDiskReadBufferFromFile.cpp
@@ -133,6 +133,8 @@ void CachedOnDiskReadBufferFromFile::initialize(size_t offset, size_t size)
         file_segments = cache->getOrSet(cache_key, offset, size, file_size.value(), create_settings);
     }
 
+    file_segments->setCacheUser(cache_user_id);
+
     /**
      * Segments in returned list are ordered in ascending order and represent a full contiguous
      * interval (no holes). Each segment in returned list has state: DOWNLOADED, DOWNLOADING or EMPTY.

--- a/src/Disks/IO/CachedOnDiskReadBufferFromFile.cpp
+++ b/src/Disks/IO/CachedOnDiskReadBufferFromFile.cpp
@@ -40,6 +40,7 @@ namespace ErrorCodes
     extern const int ARGUMENT_OUT_OF_BOUND;
 }
 
+
 CachedOnDiskReadBufferFromFile::CachedOnDiskReadBufferFromFile(
     const String & source_file_path_,
     const FileCache::Key & cache_key_,
@@ -65,6 +66,7 @@ CachedOnDiskReadBufferFromFile::CachedOnDiskReadBufferFromFile(
     , read_until_position(read_until_position_ ? *read_until_position_ : file_size_)
     , implementation_buffer_creator(implementation_buffer_creator_)
     , query_id(query_id_)
+    , cache_user_id(FileCache::getCallerId())
     , current_buffer_id(getRandomASCIIString(8))
     , allow_seeks_after_first_read(allow_seeks_after_first_read_)
     , use_external_buffer(use_external_buffer_)
@@ -769,6 +771,9 @@ bool CachedOnDiskReadBufferFromFile::writeCache(char * data, size_t size, size_t
 
 bool CachedOnDiskReadBufferFromFile::nextImpl()
 {
+    FileSegment::setCallerId(cache_user_id);
+    SCOPE_EXIT({ FileSegment::resetCallerId(); });
+
     try
     {
         return nextImplStep();

--- a/src/Disks/IO/CachedOnDiskReadBufferFromFile.h
+++ b/src/Disks/IO/CachedOnDiskReadBufferFromFile.h
@@ -138,8 +138,9 @@ private:
     String nextimpl_step_log_info;
     String last_caller_id;
 
-    String query_id;
-    String current_buffer_id;
+    const String query_id;
+    const String cache_user_id;
+    const String current_buffer_id;
 
     bool allow_seeks_after_first_read;
     [[maybe_unused]]bool use_external_buffer;

--- a/src/Disks/IO/CachedOnDiskWriteBufferFromFile.cpp
+++ b/src/Disks/IO/CachedOnDiskWriteBufferFromFile.cpp
@@ -152,6 +152,7 @@ FileSegment & FileSegmentRangeWriter::allocateFileSegment(size_t offset, FileSeg
     /// We set max_file_segment_size to be downloaded,
     /// if we have less size to write, file segment will be resized in complete() method.
     file_segments = cache->set(key, offset, cache->getMaxFileSegmentSize(), create_settings);
+    file_segments->setCacheUser(cache_user_id);
     chassert(file_segments->size() == 1);
     return file_segments->front();
 }

--- a/src/Disks/IO/CachedOnDiskWriteBufferFromFile.h
+++ b/src/Disks/IO/CachedOnDiskWriteBufferFromFile.h
@@ -25,8 +25,11 @@ class FileSegmentRangeWriter
 {
 public:
     FileSegmentRangeWriter(
-        FileCache * cache_, const FileSegment::Key & key_,
-        std::shared_ptr<FilesystemCacheLog> cache_log_, const String & query_id_, const String & source_path_);
+        FileCache * cache_,
+        const FileSegment::Key & key_,
+        std::shared_ptr<FilesystemCacheLog> cache_log_,
+        const String & query_id_,
+        const String & source_path_);
 
     /**
     * Write a range of file segments. Allocate file segment of `max_file_segment_size` and write to
@@ -49,9 +52,10 @@ private:
     FileSegment::Key key;
 
     Poco::Logger * log;
-    std::shared_ptr<FilesystemCacheLog> cache_log;
-    String query_id;
-    String source_path;
+    const std::shared_ptr<FilesystemCacheLog> cache_log;
+    const String query_id;
+    const String source_path;
+    const String cache_user_id;
 
     FileSegmentsHolderPtr file_segments;
 
@@ -81,6 +85,7 @@ public:
 
 private:
     void cacheData(char * data, size_t size, bool throw_on_error);
+    void finalizeCacheData();
 
     Poco::Logger * log;
 

--- a/src/Interpreters/Cache/FileCache.cpp
+++ b/src/Interpreters/Cache/FileCache.cpp
@@ -1,5 +1,6 @@
 #include "FileCache.h"
 
+#include <base/getThreadId.h>
 #include <IO/Operators.h>
 #include <IO/ReadHelpers.h>
 #include <IO/ReadSettings.h>
@@ -8,7 +9,6 @@
 #include <Interpreters/Cache/FileCacheSettings.h>
 #include <Interpreters/Cache/LRUFileCachePriority.h>
 #include <Interpreters/Context.h>
-#include <base/hex.h>
 #include <Common/ThreadPool.h>
 #include <Common/ElapsedTimeProfileEventIncrement.h>
 
@@ -1151,6 +1151,14 @@ void FileCache::assertCacheCorrectness()
         chassert(file_segment.assertCorrectness());
         return PriorityIterationResult::CONTINUE;
     }, lock);
+}
+
+std::string FileCache::getCallerId()
+{
+    if (!CurrentThread::isInitialized() || CurrentThread::getQueryId().empty())
+        return "None:" + toString(getThreadId());
+    else
+        return std::string(CurrentThread::getQueryId()) + ":" + toString(getThreadId());
 }
 
 FileCache::QueryContextHolder::QueryContextHolder(

--- a/src/Interpreters/Cache/FileCache.h
+++ b/src/Interpreters/Cache/FileCache.h
@@ -124,6 +124,8 @@ public:
 
     bool tryReserve(FileSegment & file_segment, size_t size, FileCacheReserveStat & stat);
 
+    static std::string getCallerId();
+
     FileSegments getSnapshot();
 
     FileSegments getSnapshot(const Key & key);

--- a/src/Interpreters/Cache/FileSegment.cpp
+++ b/src/Interpreters/Cache/FileSegment.cpp
@@ -928,6 +928,9 @@ FileSegmentsHolder::~FileSegmentsHolder()
 {
     ProfileEventTimeIncrement<Microseconds> watch(ProfileEvents::FileSegmentHolderCompleteMicroseconds);
 
+    FileSegment::setCallerId(cache_user_id);
+    SCOPE_EXIT({ FileSegment::resetCallerId(); });
+
     if (!complete_on_dtor)
         return;
 

--- a/src/Interpreters/Cache/FileSegment.h
+++ b/src/Interpreters/Cache/FileSegment.h
@@ -327,6 +327,8 @@ struct FileSegmentsHolder : private boost::noncopyable
 
     ~FileSegmentsHolder();
 
+    void setCacheUser(const std::string & cache_user_id_) { cache_user_id = cache_user_id_; }
+
     bool empty() const { return file_segments.empty(); }
 
     size_t size() const { return file_segments.size(); }
@@ -354,6 +356,7 @@ struct FileSegmentsHolder : private boost::noncopyable
 private:
     FileSegments file_segments{};
     const bool complete_on_dtor = true;
+    std::string cache_user_id;
 
     FileSegments::iterator completeAndPopFrontImpl();
 };

--- a/src/Interpreters/Cache/FileSegment.h
+++ b/src/Interpreters/Cache/FileSegment.h
@@ -138,6 +138,8 @@ public:
     };
 
     static String getCallerId();
+    static void setCallerId(const std::string & caller_id_);
+    static void resetCallerId();
 
     String getInfoForLog() const;
 

--- a/src/Interpreters/Cache/Metadata.cpp
+++ b/src/Interpreters/Cache/Metadata.cpp
@@ -563,6 +563,9 @@ void CacheMetadata::downloadThreadFunc()
 
 void CacheMetadata::downloadImpl(FileSegment & file_segment, std::optional<Memory<>> & memory)
 {
+    FileSegment::setCallerId(cache_user_id);
+    SCOPE_EXIT({ FileSegment::resetCallerId(); });
+
     chassert(file_segment.assertCorrectness());
 
     if (file_segment.getOrSetDownloader() != FileSegment::getCallerId())

--- a/src/Interpreters/Cache/WriteBufferToFileSegment.cpp
+++ b/src/Interpreters/Cache/WriteBufferToFileSegment.cpp
@@ -33,6 +33,7 @@ WriteBufferToFileSegment::WriteBufferToFileSegment(FileSegmentsHolderPtr segment
     , segment_holder(std::move(segment_holder_))
     , cache_user_id(FileCache::getCallerId())
 {
+    segment_holder->setCacheUser(cache_user_id);
 }
 
 /// If it throws an exception, the file segment will be incomplete, so you should not use it in the future.

--- a/src/Interpreters/Cache/WriteBufferToFileSegment.h
+++ b/src/Interpreters/Cache/WriteBufferToFileSegment.h
@@ -28,6 +28,8 @@ private:
 
     /// Empty if file_segment is not owned by this WriteBufferToFileSegment
     FileSegmentsHolderPtr segment_holder;
+
+    const std::string cache_user_id;
 };
 
 

--- a/src/Interpreters/tests/gtest_lru_file_cache.cpp
+++ b/src/Interpreters/tests/gtest_lru_file_cache.cpp
@@ -68,7 +68,6 @@ using HolderPtr = FileSegmentsHolderPtr;
 fs::path caches_dir = fs::current_path() / "lru_cache_test";
 std::string cache_base_path = caches_dir / "cache1" / "";
 
-FileSegment::setCallerId("unit_test");
 
 void assertEqual(FileSegments::const_iterator segments_begin, FileSegments::const_iterator segments_end, size_t segments_size, const Ranges & expected_ranges, const States & expected_states = {})
 {
@@ -196,6 +195,8 @@ public:
 
 TEST_F(FileCacheTest, get)
 {
+    FileSegment::setCallerId("unit_test");
+
     DB::ThreadStatus thread_status;
 
     /// To work with cache need query_id and query context.
@@ -664,6 +665,8 @@ TEST_F(FileCacheTest, get)
 
 TEST_F(FileCacheTest, writeBuffer)
 {
+    FileSegment::setCallerId("unit_test");
+
     FileCacheSettings settings;
     settings.max_size = 100;
     settings.max_elements = 5;
@@ -770,6 +773,8 @@ static size_t readAllTemporaryData(TemporaryFileStream & stream)
 
 TEST_F(FileCacheTest, temporaryData)
 {
+    FileSegment::setCallerId("unit_test");
+
     DB::FileCacheSettings settings;
     settings.max_size = 10_KiB;
     settings.max_file_segment_size = 1_KiB;
@@ -875,6 +880,8 @@ TEST_F(FileCacheTest, temporaryData)
 
 TEST_F(FileCacheTest, CachedReadBuffer)
 {
+    FileSegment::setCallerId("unit_test");
+
     DB::ThreadStatus thread_status;
 
     /// To work with cache need query_id and query context.

--- a/src/Interpreters/tests/gtest_lru_file_cache.cpp
+++ b/src/Interpreters/tests/gtest_lru_file_cache.cpp
@@ -68,6 +68,7 @@ using HolderPtr = FileSegmentsHolderPtr;
 fs::path caches_dir = fs::current_path() / "lru_cache_test";
 std::string cache_base_path = caches_dir / "cache1" / "";
 
+FileSegment::setCallerId("unit_test");
 
 void assertEqual(FileSegments::const_iterator segments_begin, FileSegments::const_iterator segments_end, size_t segments_size, const Ranges & expected_ranges, const States & expected_states = {})
 {


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix error from cache `"Operation <op> can be done only by downloader"`, which happens because of enabled `enable_prefetched_read_pool_for_remote_filesystem`. Closes https://github.com/ClickHouse/ClickHouse/issues/54059.


See comment https://github.com/ClickHouse/ClickHouse/issues/54059#issuecomment-1698827672 for the explanation of the changes.