### PR TITLE
Fix named_collection_admin alias

### DIFF
--- a/src/Access/UsersConfigAccessStorage.cpp
+++ b/src/Access/UsersConfigAccessStorage.cpp
@@ -289,7 +289,7 @@ namespace
         }
 
         bool access_management = config.getBool(user_config + ".access_management", false);
-        bool named_collection_control = config.getBool(user_config + ".named_collection_control", false);
+        bool named_collection_control = config.getBool(user_config + ".named_collection_control", false) || config.getBool(user_config + ".named_collection_admin", false);
         bool show_named_collections_secrets = config.getBool(user_config + ".show_named_collections_secrets", false);
 
         if (grant_queries)

--- a/tests/integration/test_storage_s3/configs/users.xml
+++ b/tests/integration/test_storage_s3/configs/users.xml
@@ -3,7 +3,7 @@
         <default>
             <password></password>
             <profile>default</profile>
-            <named_collection_control>1</named_collection_control>
+            <named_collection_admin>1</named_collection_admin>
         </default>
     </users>
 </clickhouse>


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix `named_collection_admin` alias to `named_collection_control` not working from config.