### PR TITLE
Increased log waiting timeout in test_profile_max_sessions_for_user

### DIFF
--- a/tests/integration/test_profile_max_sessions_for_user/test.py
+++ b/tests/integration/test_profile_max_sessions_for_user/test.py
@@ -96,7 +96,10 @@ def threaded_run_test(sessions):
         thread.start()
 
     if len(sessions) > MAX_SESSIONS_FOR_USER:
-        assert_logs_contain_with_retry(instance, "overflown session count")
+        # High retry amount to avoid flakiness in ASAN (+Analyzer) tests
+        assert_logs_contain_with_retry(
+            instance, "overflown session count", retry_count=60
+        )
 
     instance.query(f"KILL QUERY WHERE user='{TEST_USER}' SYNC")
 


### PR DESCRIPTION
I see several [fails ](https://play.clickhouse.com/play?user=play#U0VMRUNUIGNoZWNrX3N0YXJ0X3RpbWUsIGNoZWNrX25hbWUsIHRlc3RfbmFtZSwgcmVwb3J0X3VybApGUk9NIGNoZWNrcwpXSEVSRSBjaGVja19zdGFydF90aW1lID4gJzIwMjMtMDgtMTEnCiAgICBBTkQgdGVzdF9zdGF0dXMgIT0gJ1NLSVBQRUQnCiAgICBBTkQgdGVzdF9zdGF0dXMgTElLRSAnRiUnCiAgICBBTkQgY2hlY2tfc3RhdHVzICE9ICdzdWNjZXNzJwogICAgQU5EIHBvc2l0aW9uKHRlc3RfbmFtZSwgJ3Byb2ZpbGVfbWF4X3Nlc3Npb25zX2Zvcl91c2VyJykgPiAwCk9SREVSIEJZIGNoZWNrX3N0YXJ0X3RpbWU=) past in 20 days in these tests:
- test_profile_max_sessions_for_user_grpc
- test_profile_max_sessions_for_user/test.py::test_profile_max_sessions_for_user_tcp_and_others

`assert_logs_contain_with_retry` waits ~10 seconds before `overflown session count` will be printed in logs. All recent fails run for more than 10 seconds. Those fails always include ASAN/TSAN/Analyzer. I assume that this timeout is not enough for these cases. 

Change:
Increased timeout to 30 seconds (60 tries with 0.5 seconds waiting)

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
