### PR TITLE
Fix SipHash128 reference for big-endian platforms

### DIFF
--- a/src/Common/SipHash.h
+++ b/src/Common/SipHash.h
@@ -200,11 +200,7 @@ public:
     ALWAYS_INLINE UInt128 get128()
     {
         UInt128 res;
-#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
-        get128(res.items[1], res.items[0]);
-#else
-        get128(res.items[0], res.items[1]);
-#endif
+        get128(res.items[UInt128::_impl::little(0)], res.items[UInt128::_impl::little(1)]);
         return res;
     }
 
@@ -214,20 +210,13 @@ public:
             throw DB::Exception(
                 DB::ErrorCodes::LOGICAL_ERROR, "Logical error: can't call get128Reference when is_reference_128 is not set");
         finalize();
-        auto lo = v0 ^ v1 ^ v2 ^ v3;
+        const auto lo = v0 ^ v1 ^ v2 ^ v3;
         v1 ^= 0xdd;
         SIPROUND;
         SIPROUND;
         SIPROUND;
         SIPROUND;
-        auto hi = v0 ^ v1 ^ v2 ^ v3;
-
-        if constexpr (std::endian::native == std::endian::big)
-        {
-            lo = std::byteswap(lo);
-            hi = std::byteswap(hi);
-            std::swap(lo, hi);
-        }
+        const auto hi = v0 ^ v1 ^ v2 ^ v3;
 
         UInt128 res = hi;
         res <<= 64;


### PR DESCRIPTION
These changes aim to resolve failures in functional tests `02534_keyed_siphash` and `02552_siphash128_reference` by making sure that the 128-bit number storing the result of `get128Reference` ends up matching the endianness convention of the platform its being run on.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)