### PR TITLE
Fix cluster discovery initialization + setting up fail points in config

### DIFF
--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -42,6 +42,7 @@
 #include <Common/Config/AbstractConfigurationComparison.h>
 #include <Common/assertProcessUserMatchesDataOwner.h>
 #include <Common/makeSocketAddress.h>
+#include <Common/FailPoint.h>
 #include <Server/waitServersToFinish.h>
 #include <Core/ServerUUID.h>
 #include <IO/ReadHelpers.h>
@@ -883,6 +884,8 @@ try
             }
         }
     }
+
+    FailPointInjection::enableFromGlobalConfig(config());
 
     int default_oom_score = 0;
 

--- a/src/Common/FailPoint.cpp
+++ b/src/Common/FailPoint.cpp
@@ -35,6 +35,7 @@ static struct InitFiu
 #define APPLY_FOR_FAILPOINTS(ONCE, REGULAR, PAUSEABLE_ONCE, PAUSEABLE) \
     ONCE(replicated_merge_tree_commit_zk_fail_after_op) \
     REGULAR(use_delayed_remote_source) \
+    REGULAR(cluster_discovery_faults) \
     REGULAR(dummy_failpoint) \
     PAUSEABLE_ONCE(dummy_pausable_failpoint_once) \
     PAUSEABLE(dummy_pausable_failpoint)

--- a/src/Common/FailPoint.cpp
+++ b/src/Common/FailPoint.cpp
@@ -1,5 +1,6 @@
 #include <Common/Exception.h>
 #include <Common/FailPoint.h>
+#include <Common/Config/ConfigHelper.h>
 
 #include <boost/core/noncopyable.hpp>
 #include <chrono>
@@ -162,6 +163,21 @@ void FailPointInjection::wait(const String & fail_point_name)
         auto ptr = iter->second;
         ptr->wait();
     }
-};
+}
+
+void FailPointInjection::enableFromGlobalConfig(const Poco::Util::AbstractConfiguration & config)
+{
+    String root_key = "fail_points_active";
+
+    Poco::Util::AbstractConfiguration::Keys tables_keys;
+    config.keys(root_key, tables_keys);
+
+    for (const auto & table_key : tables_keys)
+    {
+        if (ConfigHelper::getBool(config, root_key + "." + table_key))
+            FailPointInjection::enableFailPoint(table_key);
+    }
+}
+
 
 }

--- a/src/Common/FailPoint.cpp
+++ b/src/Common/FailPoint.cpp
@@ -170,13 +170,13 @@ void FailPointInjection::enableFromGlobalConfig(const Poco::Util::AbstractConfig
 {
     String root_key = "fail_points_active";
 
-    Poco::Util::AbstractConfiguration::Keys tables_keys;
-    config.keys(root_key, tables_keys);
+    Poco::Util::AbstractConfiguration::Keys fail_point_names;
+    config.keys(root_key, fail_point_names);
 
-    for (const auto & table_key : tables_keys)
+    for (const auto & fail_point_name : fail_point_names)
     {
-        if (ConfigHelper::getBool(config, root_key + "." + table_key))
-            FailPointInjection::enableFailPoint(table_key);
+        if (ConfigHelper::getBool(config, root_key + "." + fail_point_name))
+            FailPointInjection::enableFailPoint(fail_point_name);
     }
 }
 

--- a/src/Common/FailPoint.h
+++ b/src/Common/FailPoint.h
@@ -3,6 +3,7 @@
 
 #include <Common/Exception.h>
 #include <Core/Types.h>
+#include <Poco/Util/AbstractConfiguration.h>
 
 #ifdef __clang__
 #pragma clang diagnostic push
@@ -45,6 +46,8 @@ public:
     static void disableFailPoint(const String & fail_point_name);
 
     static void wait(const String & fail_point_name);
+
+    static void enableFromGlobalConfig(const Poco::Util::AbstractConfiguration & config);
 
 private:
     static std::mutex mu;

--- a/src/Interpreters/ClusterDiscovery.cpp
+++ b/src/Interpreters/ClusterDiscovery.cpp
@@ -363,7 +363,7 @@ void ClusterDiscovery::initialUpdate()
         static size_t fail_count = 0;
         fail_count++;
         /// strict limit on fail count to avoid flaky tests
-        auto is_failed = fail_count < success_chance || std::uniform_int_distribution<>(0, success_chance)(thread_local_rng) != 0;
+        auto is_failed = fail_count < success_chance && std::uniform_int_distribution<>(0, success_chance)(thread_local_rng) != 0;
         if (is_failed)
             throw Exception(ErrorCodes::KEEPER_EXCEPTION, "Failpoint cluster_discovery_faults is triggered");
     });

--- a/src/Interpreters/ClusterDiscovery.cpp
+++ b/src/Interpreters/ClusterDiscovery.cpp
@@ -360,7 +360,10 @@ void ClusterDiscovery::initialUpdate()
     fiu_do_on(FailPoints::cluster_discovery_faults,
     {
         constexpr UInt8 success_chance = 4;
-        auto is_failed = std::uniform_int_distribution<>(0, success_chance)(thread_local_rng) != 0;
+        static size_t fail_count = 0;
+        fail_count++;
+        /// strict limit on fail count to avoid flaky tests
+        auto is_failed = fail_count < success_chance || std::uniform_int_distribution<>(0, success_chance)(thread_local_rng) != 0;
         if (is_failed)
             throw Exception(ErrorCodes::KEEPER_EXCEPTION, "Failpoint cluster_discovery_faults is triggered");
     });

--- a/src/Interpreters/ClusterDiscovery.cpp
+++ b/src/Interpreters/ClusterDiscovery.cpp
@@ -347,6 +347,8 @@ void ClusterDiscovery::registerInZk(zkutil::ZooKeeperPtr & zk, ClusterInfo & inf
 
 void ClusterDiscovery::initialUpdate()
 {
+    LOG_DEBUG(log, "Initializing");
+
     auto zk = context->getZooKeeper();
     for (auto & [_, info] : clusters_info)
     {
@@ -357,6 +359,8 @@ void ClusterDiscovery::initialUpdate()
             clusters_to_update->set(info.name);
         }
     }
+    LOG_DEBUG(log, "Initialized");
+    is_initialized = true;
 }
 
 void ClusterDiscovery::start()
@@ -414,6 +418,10 @@ bool ClusterDiscovery::runMainThread(std::function<void()> up_to_date_callback)
     using namespace std::chrono_literals;
 
     constexpr auto force_update_interval = 2min;
+
+    if (!is_initialized)
+        initialUpdate();
+
     bool finished = false;
     while (!finished)
     {

--- a/src/Interpreters/ClusterDiscovery.cpp
+++ b/src/Interpreters/ClusterDiscovery.cpp
@@ -7,13 +7,15 @@
 #include <unordered_set>
 
 #include <base/getFQDNOrHostName.h>
-#include <Common/logger_useful.h>
 
-#include <Common/Exception.h>
-#include <Common/StringUtils/StringUtils.h>
-#include <Common/ZooKeeper/Types.h>
-#include <Common/setThreadName.h>
 #include <Common/Config/ConfigHelper.h>
+#include <Common/Exception.h>
+#include <Common/FailPoint.h>
+#include <Common/logger_useful.h>
+#include <Common/setThreadName.h>
+#include <Common/StringUtils/StringUtils.h>
+#include <Common/thread_local_rng.h>
+#include <Common/ZooKeeper/Types.h>
 
 #include <Core/ServerUUID.h>
 
@@ -31,7 +33,13 @@ namespace DB
 
 namespace ErrorCodes
 {
+    extern const int KEEPER_EXCEPTION;
     extern const int LOGICAL_ERROR;
+}
+
+namespace FailPoints
+{
+    extern const char cluster_discovery_faults[];
 }
 
 namespace
@@ -348,6 +356,14 @@ void ClusterDiscovery::registerInZk(zkutil::ZooKeeperPtr & zk, ClusterInfo & inf
 void ClusterDiscovery::initialUpdate()
 {
     LOG_DEBUG(log, "Initializing");
+
+    fiu_do_on(FailPoints::cluster_discovery_faults,
+    {
+        constexpr UInt8 success_chance = 4;
+        auto is_failed = std::uniform_int_distribution<>(0, success_chance)(thread_local_rng) != 0;
+        if (is_failed)
+            throw Exception(ErrorCodes::KEEPER_EXCEPTION, "Failpoint cluster_discovery_faults is triggered");
+    });
 
     auto zk = context->getZooKeeper();
     for (auto & [_, info] : clusters_info)

--- a/src/Interpreters/ClusterDiscovery.h
+++ b/src/Interpreters/ClusterDiscovery.h
@@ -137,6 +137,7 @@ private:
     mutable std::mutex mutex;
     std::unordered_map<String, ClusterPtr> cluster_impls;
 
+    bool is_initialized = false;
     ThreadFromGlobalPool main_thread;
 
     Poco::Logger * log;

--- a/tests/integration/test_cluster_discovery/config/config.xml
+++ b/tests/integration/test_cluster_discovery/config/config.xml
@@ -20,4 +20,8 @@
             </shard>
         </two_shards>
     </remote_servers>
+
+    <fail_points_active>
+        <cluster_discovery_faults/>
+    </fail_points_active>
 </clickhouse>


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):

- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
* Fix cluster discovery initialization in case of inaccessible keeper

ref https://github.com/ClickHouse/ClickHouse/issues/47176