### PR TITLE
Backport moving/ part checking code from master

### DIFF
--- a/src/Storages/MergeTree/IMergeTreeDataPart.cpp
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.cpp
@@ -497,8 +497,11 @@ void IMergeTreeDataPart::removeIfNeeded()
                 throw Exception(ErrorCodes::LOGICAL_ERROR, "relative_path {} of part {} is invalid or not set",
                                 getDataPartStorage().getPartDirectory(), name);
 
-            const auto part_parent_directory = directoryPath(part_directory);
-            bool is_moving_part = part_parent_directory.ends_with("moving/");
+            fs::path part_directory_path = getDataPartStorage().getRelativePath();
+            if (part_directory_path.filename().empty())
+                part_directory_path = part_directory_path.parent_path();
+            const bool is_moving_part = part_directory_path.parent_path().filename() == "moving";
+
             if (!startsWith(file_name, "tmp") && !endsWith(file_name, ".tmp_proj") && !is_moving_part)
             {
                 LOG_ERROR(


### PR DESCRIPTION

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

In 23.3 there is an incorrect check for parts in `moving` directory which leads to errors:

```
~DataPart() should remove part store/04b/04b1ef98-6f93-4638-8157-431b66bd0f51/moving/20230716_4842_4842_0/ but its name doesn't start with "tmp" or end with ".tmp_proj". Too suspicious, keeping the part.
```

This patch backports the correct behaviour