### PR TITLE
Disable `01600_parts_types_metrics_long` for asan

### DIFF
--- a/tests/queries/0_stateless/01600_parts_types_metrics_long.sh
+++ b/tests/queries/0_stateless/01600_parts_types_metrics_long.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: no-s3-storage
+# Tags: no-s3-storage, no-asan
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


The test is verifying that the counts in `system.parts` and number in `system.metrics` are the same but it checks for all tables because we cannot filter `system.metrics` for specific table. 
So this test just verifies that **sometimes** those counts match.
We rely heavily on luck while basically not proving anything, especially when running in parallel where a lot of parts are created and removed. 

cc @azat as the author of the test, you can correct me if I'm wrong

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
