### PR TITLE
Try to enable gRPC on Mac

### DIFF
--- a/cmake/target.cmake
+++ b/cmake/target.cmake
@@ -35,7 +35,6 @@ endif ()
 if (CMAKE_CROSSCOMPILING)
     if (OS_DARWIN)
         # FIXME: broken dependencies
-        set (ENABLE_GRPC OFF CACHE INTERNAL "") # no protobuf -> no grpc
         set (ENABLE_ICU OFF CACHE INTERNAL "")
         set (ENABLE_FASTOPS OFF CACHE INTERNAL "")
     elseif (OS_LINUX OR OS_ANDROID)


### PR DESCRIPTION
I tried this out quickly:
- cross-compile on Linux for Mac [0] with the GRPC exception removed. That failed with an unrelated error:

```
  CMake Error at /usr/share/cmake-3.22/Modules/FindPackageHandleStandardArgs.cmake:230 (message):
  Could NOT find Threads (missing: Threads_FOUND)
  Call Stack (most recent call first)>
  /usr/share/cmake-3.22/Modules/FindPackageHandleStandardArgs.cmake:594 (_FPHSA_FAILURE_MESSAGE) 
  /usr/share/cmake-3.22/Modules/FindThreads.cmake:238 (FIND_PACKAGE_HANDLE_STANDARD_ARGS)
  cmake/darwin/default_libs.cmake:16 (find_package) CMakeLists.txt:388 (include)
```

 Cross-compilation works in CI, something must be wrong with my system and I did not bother further.

- compile on Mac for Mac [1] with `-DENABLE_PROTOBUF=1` and `-DENABLE_GRPC=1`. (above GRPC exception is only relevant for cross-compilation). Compilation worked, and using [2] I can confirm that gRPC worked too.

[0] https://clickhouse.com/docs/en/development/build-cross-osx
[1] https://clickhouse.com/docs/en/development/build-osx
[2] https://clickhouse.com/docs/en/interfaces/grpc#grpc-interface-configuration

### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Enabled the gRPC interface for Mac builds.