### PR TITLE
tests: mark 02152_http_external_tables_memory_tracking as no-parallel

### DIFF
--- a/tests/queries/0_stateless/02152_http_external_tables_memory_tracking.sh
+++ b/tests/queries/0_stateless/02152_http_external_tables_memory_tracking.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: no-tsan, no-cpu-aarch64
+# Tags: no-tsan, no-cpu-aarch64, no-parallel
 # TSan does not supports tracing.
 # trace_log doesn't work on aarch64
 


### PR DESCRIPTION
This should help with flakiness of this test, since this test is pretty heavy.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Fixes: #53215 (cc @evillique, @kssenii )