### PR TITLE
Fix system.data_skipping_indices for recreated indices

### DIFF
--- a/tests/queries/0_stateless/02028_system_data_skipping_indices_size.reference
+++ b/tests/queries/0_stateless/02028_system_data_skipping_indices_size.reference
@@ -1,1 +1,2 @@
 default	test_table	value_index	minmax	minmax	value	1	38	12	24
+default	test_table	value_index	minmax	minmax	value	1	38	12	24

--- a/tests/queries/0_stateless/02028_system_data_skipping_indices_size.sql
+++ b/tests/queries/0_stateless/02028_system_data_skipping_indices_size.sql
@@ -12,4 +12,10 @@ ORDER BY key SETTINGS compress_marks=false;
 INSERT INTO test_table VALUES (0, 'Value');
 SELECT * FROM system.data_skipping_indices WHERE database = currentDatabase();
 
+ALTER TABLE test_table DROP INDEX value_index;
+ALTER TABLE test_table ADD INDEX value_index value TYPE minmax GRANULARITY 1;
+ALTER TABLE test_table MATERIALIZE INDEX value_index SETTINGS mutations_sync=1;
+
+SELECT * FROM system.data_skipping_indices WHERE database = currentDatabase();
+
 DROP TABLE test_table;


### PR DESCRIPTION
Fix secondary index size in system.data_skipping_indices table in the case of dropped and added again index.

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed secondary index size displayed in system.data_skipping_indices table in the case of dropped and added again index.
