### PR TITLE
Fix bad code in the `system.filesystem_cache`: catching exceptions

### DIFF
--- a/src/Storages/System/StorageSystemFilesystemCache.cpp
+++ b/src/Storages/System/StorageSystemFilesystemCache.cpp
@@ -68,9 +68,10 @@ void StorageSystemFilesystemCache::fillData(MutableColumns & res_columns, Contex
             res_columns[i++]->insert(toString(file_segment->getKind()));
             res_columns[i++]->insert(file_segment->isUnbound());
 
-            std::error_code ignored;
-            if (fs::exists(path, ignored))
-                res_columns[i++]->insert(fs::file_size(path));
+            std::error_code ec;
+            auto size = fs::file_size(path, ec);
+            if (!ec)
+                res_columns[i++]->insert(size);
             else
                 res_columns[i++]->insertDefault();
         }

--- a/src/Storages/System/StorageSystemFilesystemCache.cpp
+++ b/src/Storages/System/StorageSystemFilesystemCache.cpp
@@ -1,7 +1,6 @@
 #include "StorageSystemFilesystemCache.h"
 #include <DataTypes/DataTypeString.h>
 #include <DataTypes/DataTypesNumber.h>
-#include <DataTypes/DataTypeTuple.h>
 #include <DataTypes/DataTypeNullable.h>
 #include <Interpreters/Cache/FileCache.h>
 #include <Interpreters/Cache/FileSegment.h>
@@ -68,17 +67,12 @@ void StorageSystemFilesystemCache::fillData(MutableColumns & res_columns, Contex
             res_columns[i++]->insert(file_segment->getDownloadedSize());
             res_columns[i++]->insert(toString(file_segment->getKind()));
             res_columns[i++]->insert(file_segment->isUnbound());
-            try
-            {
-                if (fs::exists(path))
-                    res_columns[i++]->insert(fs::file_size(path));
-                else
-                    res_columns[i++]->insertDefault();
-            }
-            catch (...)
-            {
+
+            std::error_code ignored;
+            if (fs::exists(path, ignored))
+                res_columns[i++]->insert(fs::file_size(path));
+            else
                 res_columns[i++]->insertDefault();
-            }
         }
     }
 }


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
