### PR TITLE
Fix wrong reallocation in HashedArrayDictionary

### DIFF
--- a/src/Dictionaries/FlatDictionary.cpp
+++ b/src/Dictionaries/FlatDictionary.cpp
@@ -395,11 +395,15 @@ void FlatDictionary::updateData()
     if (!update_field_loaded_block || update_field_loaded_block->rows() == 0)
     {
         QueryPipeline pipeline(source_ptr->loadUpdatedAll());
-
         PullingPipelineExecutor executor(pipeline);
+        update_field_loaded_block.reset();
         Block block;
+
         while (executor.pull(block))
         {
+            if (!block.rows())
+                continue;
+
             convertToFullIfSparse(block);
 
             /// We are using this to keep saved data if input stream consists of multiple blocks

--- a/src/Dictionaries/HashedArrayDictionary.cpp
+++ b/src/Dictionaries/HashedArrayDictionary.cpp
@@ -409,11 +409,17 @@ void HashedArrayDictionary<dictionary_key_type>::updateData()
     if (!update_field_loaded_block || update_field_loaded_block->rows() == 0)
     {
         QueryPipeline pipeline(source_ptr->loadUpdatedAll());
-
         PullingPipelineExecutor executor(pipeline);
+        update_field_loaded_block.reset();
         Block block;
+
         while (executor.pull(block))
         {
+            if (!block.rows())
+                continue;
+
+            convertToFullIfSparse(block);
+
             /// We are using this to keep saved data if input stream consists of multiple blocks
             if (!update_field_loaded_block)
                 update_field_loaded_block = std::make_shared<DB::Block>(block.cloneEmpty());

--- a/src/Dictionaries/HashedDictionary.cpp
+++ b/src/Dictionaries/HashedDictionary.cpp
@@ -709,11 +709,15 @@ void HashedDictionary<dictionary_key_type, sparse, sharded>::updateData()
     if (!update_field_loaded_block || update_field_loaded_block->rows() == 0)
     {
         QueryPipeline pipeline(source_ptr->loadUpdatedAll());
-
         PullingPipelineExecutor executor(pipeline);
+        update_field_loaded_block.reset();
         Block block;
+
         while (executor.pull(block))
         {
+            if (!block.rows())
+                continue;
+
             convertToFullIfSparse(block);
 
             /// We are using this to keep saved data if input stream consists of multiple blocks


### PR DESCRIPTION
### Changelog category:
- Improvement

### Changelog entry:
Fix wrong reallocation in HashedArrayDictionary:

```
Could not load external dictionary '65eea2c5-4a86-4530-ad16-76f51826726b', next update is scheduled at 2023-08-30 16:02:22: Code: 49. DB::Exception: Too large size (17582052945329454058) passed to allocator. It indicates an error. (LOGICAL_ERROR), Stack trace (when copying this message, always include the lines below):

0. DB::Exception::Exception(DB::Exception::MessageMasked&&, int, bool) @ 0x000000000e9cb6b7 in /usr/bin/clickhouse
1. DB::Exception::Exception<unsigned long&>(int, FormatStringHelperImpl<std::__1::type_identity<unsigned long&>::type>, unsigned long&) @ 0x000000000903fa1c in /usr/bin/clickhouse
2. Allocator<false, false>::realloc(void*, unsigned long, unsigned long, unsigned long) @ 0x000000000891ecdc in /usr/bin/clickhouse
3. void DB::PODArrayBase<1ul, 4096ul, Allocator<false, false>, 63ul, 64ul>::resize<>(unsigned long) @ 0x000000000905fd66 in /usr/bin/clickhouse
4. DB::ColumnString::insertRangeFrom(DB::IColumn const&, unsigned long, unsigned long) @ 0x0000000014700c72 in /usr/bin/clickhouse
5. DB::HashedArrayDictionary<(DB::DictionaryKeyType)1>::updateData() @ 0x00000000119ec6e6 in /usr/bin/clickhouse
6. DB::HashedArrayDictionary<(DB::DictionaryKeyType)1>::loadData() @ 0x00000000119e5d8d in /usr/bin/clickhouse
7. DB::HashedArrayDictionary<(DB::DictionaryKeyType)1>::HashedArrayDictionary(DB::StorageID const&, DB::DictionaryStructure const&, std::shared_ptr<DB::IDictionarySource>, DB::HashedArrayDictionaryStorageConfiguration const&, std::shared_ptr<DB::Block>) @ 0x00000000119e5ace in /usr/bin/clickhouse
8. DB::registerDictionaryArrayHashed(DB::DictionaryFactory&)::$_2::operator()(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, DB::DictionaryStructure const&, Poco::Util::AbstractConfiguration const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::shared_ptr<DB::IDictionarySource>, DB::DictionaryKeyType) const @ 0x0000000011a1c3d8 in /usr/bin/clickhouse
9. std::__1::unique_ptr<DB::IDictionary, std::__1::default_delete<DB::IDictionary>> std::__1::__function::__policy_invoker<std::__1::unique_ptr<DB::IDictionary, std::__1::default_delete<DB::IDictionary>> (std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, DB::DictionaryStructure const&, Poco::Util::AbstractConfiguration const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::shared_ptr<DB::IDictionarySource>, std::__1::shared_ptr<DB::Context const>, bool)>::__call_impl<std::__1::__function::__default_alloc_func<DB::registerDictionaryArrayHashed(DB::DictionaryFactory&)::$_1, std::__1::unique_ptr<DB::IDictionary, std::__1::default_delete<DB::IDictionary>> (std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, DB::DictionaryStructure const&, Poco::Util::AbstractConfiguration const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::shared_ptr<DB::IDictionarySource>, std::__1::shared_ptr<DB::Context const>, bool)>>(std::__1::__function::__policy_storage const*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, DB::DictionaryStructure const&, Poco::Util::AbstractConfiguration const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::shared_ptr<DB::IDictionarySource>&&, std::__1::shared_ptr<DB::Context const>&&, bool) ? @ 0x0000000011a1c665 in /usr/bin/clickhouse
10. DB::DictionaryFactory::create(String const&, Poco::Util::AbstractConfiguration const&, String const&, std::shared_ptr<DB::Context const>, bool) const @ 0x0000000013095d7d in /usr/bin/clickhouse
11. DB::ExternalDictionariesLoader::create(String const&, Poco::Util::AbstractConfiguration const&, String const&, String const&) const @ 0x0000000013dfd83c in /usr/bin/clickhouse
12. DB::ExternalLoader::LoadingDispatcher::doLoading(String const&, unsigned long, bool, unsigned long, bool, std::shared_ptr<DB::ThreadGroup>) @ 0x0000000013e0a9a9 in /usr/bin/clickhouse
13. void std::__function::__policy_invoker<void ()>::__call_impl<std::__function::__default_alloc_func<ThreadFromGlobalPoolImpl<true>::ThreadFromGlobalPoolImpl<void (DB::ExternalLoader::LoadingDispatcher::*)(String const&, unsigned long, bool, unsigned long, bool, std::shared_ptr<DB::ThreadGroup>), DB::ExternalLoader::LoadingDispatcher*, String&, unsigned long&, bool&, unsigned long&, bool, std::shared_ptr<DB::ThreadGroup>>(void (DB::ExternalLoader::LoadingDispatcher::*&&)(String const&, unsigned long, bool, unsigned long, bool, std::shared_ptr<DB::ThreadGroup>), DB::ExternalLoader::LoadingDispatcher*&&, String&, unsigned long&, bool&, unsigned long&, bool&&, std::shared_ptr<DB::ThreadGroup>&&)::'lambda'(), void ()>>(std::__function::__policy_storage const*) @ 0x0000000013e1055f in /usr/bin/clickhouse
14. ThreadPoolImpl<std::thread>::worker(std::__list_iterator<std::thread, void*>) @ 0x000000000eab71af in /usr/bin/clickhouse
```