### PR TITLE
Fix test `02783_parsedatetimebesteffort_syslog`

### DIFF
--- a/tests/queries/0_stateless/02783_parsedatetimebesteffort_syslog.sql
+++ b/tests/queries/0_stateless/02783_parsedatetimebesteffort_syslog.sql
@@ -1,3 +1,5 @@
+SET session_timezone = 'UTC';
+
 SELECT 'The reference time point is 2023-06-30 23:59:30';
 SELECT '───────────────────────────────────────────────';
 SELECT 'The argument is before the reference time point';


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


https://s3.amazonaws.com/clickhouse-test-reports/0/6e73dcf654ec24584093528c1e88b50274f4b665/stateless_tests__ubsan__[1_2].html