### PR TITLE
Fix `test_keeper_disks`

### DIFF
--- a/tests/integration/test_keeper_disks/configs/enable_keeper_snapshot.xml
+++ b/tests/integration/test_keeper_disks/configs/enable_keeper_snapshot.xml
@@ -1,0 +1,57 @@
+<clickhouse>
+    <storage_configuration>
+        <disks>
+            <disk_hdfs>
+                <type>hdfs</type>
+                <endpoint>hdfs://hdfs1:9000/</endpoint>
+            </disk_hdfs>
+            <log_local>
+                <type>local</type>
+                <path>/var/lib/clickhouse/coordination/logs/</path>
+            </log_local>
+            <log_s3_plain>
+                <type>s3_plain</type>
+                <endpoint>http://minio1:9001/root/logs/</endpoint>
+                <access_key_id>minio</access_key_id>
+                <secret_access_key>minio123</secret_access_key>
+            </log_s3_plain>
+            <snapshot_local>
+                <type>local</type>
+                <path>/var/lib/clickhouse/coordination/snapshots/</path>
+            </snapshot_local>
+            <snapshot_s3_plain>
+                <type>s3_plain</type>
+                <endpoint>http://minio1:9001/root/snapshots/</endpoint>
+                <access_key_id>minio</access_key_id>
+                <secret_access_key>minio123</secret_access_key>
+            </snapshot_s3_plain>
+        </disks>
+    </storage_configuration>
+
+    <keeper_server>
+        <use_cluster>false</use_cluster>
+        <tcp_port>9181</tcp_port>
+        <server_id>1</server_id>
+        <create_snapshot_on_exit>false</create_snapshot_on_exit>
+
+        <coordination_settings>
+            <operation_timeout_ms>5000</operation_timeout_ms>
+            <session_timeout_ms>10000</session_timeout_ms>
+            <raft_logs_level>trace</raft_logs_level>
+            <snapshot_distance>10000</snapshot_distance>
+            <stale_log_gap>10</stale_log_gap>
+            <reserved_log_items>1</reserved_log_items>
+            <rotate_log_storage_interval>3</rotate_log_storage_interval>
+        </coordination_settings>
+
+        <!-- DISK DEFINITION PLACEHOLDER -->
+
+        <raft_configuration>
+            <server>
+                <id>1</id>
+                <hostname>node</hostname>
+                <port>9234</port>
+            </server>
+        </raft_configuration>
+    </keeper_server>
+</clickhouse>

--- a/tests/integration/test_keeper_disks/test.py
+++ b/tests/integration/test_keeper_disks/test.py
@@ -8,9 +8,17 @@ import os
 
 CURRENT_TEST_DIR = os.path.dirname(os.path.abspath(__file__))
 cluster = ClickHouseCluster(__file__)
-node = cluster.add_instance(
-    "node",
+node_logs = cluster.add_instance(
+    "node_logs",
     main_configs=["configs/enable_keeper.xml"],
+    stay_alive=True,
+    with_minio=True,
+    with_hdfs=True,
+)
+
+node_snapshot = cluster.add_instance(
+    "node_snapshot",
+    main_configs=["configs/enable_keeper_snapshot.xml"],
     stay_alive=True,
     with_minio=True,
     with_hdfs=True,
@@ -46,7 +54,7 @@ def stop_zk(zk):
         pass
 
 
-def stop_clickhouse(cluster, cleanup_disks):
+def stop_clickhouse(cluster, node, cleanup_disks):
     node.stop_clickhouse()
 
     if not cleanup_disks:
@@ -72,8 +80,8 @@ def stop_clickhouse(cluster, cleanup_disks):
     )
 
 
-def setup_storage(cluster, storage_config, cleanup_disks):
-    stop_clickhouse(cluster, cleanup_disks)
+def setup_storage(cluster, node, storage_config, cleanup_disks):
+    stop_clickhouse(cluster, node, cleanup_disks)
     node.copy_file_to_container(
         os.path.join(CURRENT_TEST_DIR, "configs/enable_keeper.xml"),
         "/etc/clickhouse-server/config.d/enable_keeper.xml",
@@ -87,9 +95,10 @@ def setup_storage(cluster, storage_config, cleanup_disks):
     keeper_utils.wait_until_connected(cluster, node)
 
 
-def setup_local_storage(cluster):
+def setup_local_storage(cluster, node):
     setup_storage(
         cluster,
+        node,
         "<log_storage_disk>log_local<\\/log_storage_disk>"
         "<snapshot_storage_disk>snapshot_local<\\/snapshot_storage_disk>",
         cleanup_disks=True,
@@ -107,30 +116,30 @@ def list_s3_objects(cluster, prefix=""):
     ]
 
 
-def get_local_files(path):
+def get_local_files(path, node):
     files = node.exec_in_container(["ls", path]).strip().split("\n")
     files.sort()
     return files
 
 
-def get_local_logs():
-    return get_local_files("/var/lib/clickhouse/coordination/logs")
+def get_local_logs(node):
+    return get_local_files("/var/lib/clickhouse/coordination/logs", node)
 
 
-def get_local_snapshots():
-    return get_local_files("/var/lib/clickhouse/coordination/snapshots")
+def get_local_snapshots(node):
+    return get_local_files("/var/lib/clickhouse/coordination/snapshots", node)
 
 
 def test_supported_disk_types(started_cluster):
-    node.stop_clickhouse()
-    node.start_clickhouse()
-    node.contains_in_log("Disk type 'hdfs' is not supported for Keeper")
+    node_logs.stop_clickhouse()
+    node_logs.start_clickhouse()
+    node_logs.contains_in_log("Disk type 'hdfs' is not supported for Keeper")
 
 
 def test_logs_with_disks(started_cluster):
-    setup_local_storage(started_cluster)
+    setup_local_storage(started_cluster, node_logs)
 
-    node_zk = get_fake_zk("node")
+    node_zk = get_fake_zk("node_logs")
     try:
         node_zk.create("/test")
         for _ in range(30):
@@ -138,10 +147,11 @@ def test_logs_with_disks(started_cluster):
 
         stop_zk(node_zk)
 
-        previous_log_files = get_local_logs()
+        previous_log_files = get_local_logs(node_logs)
 
         setup_storage(
             started_cluster,
+            node_logs,
             "<log_storage_disk>log_s3_plain<\\/log_storage_disk>"
             "<latest_log_storage_disk>log_local<\\/latest_log_storage_disk>"
             "<snapshot_storage_disk>snapshot_local<\\/snapshot_storage_disk>",
@@ -151,13 +161,13 @@ def test_logs_with_disks(started_cluster):
         # all but the latest log should be on S3
         s3_log_files = list_s3_objects(started_cluster, "logs/")
         assert set(s3_log_files) == set(previous_log_files[:-1])
-        local_log_files = get_local_logs()
+        local_log_files = get_local_logs(node_logs)
         assert len(local_log_files) == 1
         assert local_log_files[0] == previous_log_files[-1]
 
         previous_log_files = s3_log_files + local_log_files
 
-        node_zk = get_fake_zk("node")
+        node_zk = get_fake_zk("node_logs")
 
         for _ in range(30):
             node_zk.create("/test/somenode", b"somedata", sequence=True)
@@ -165,7 +175,7 @@ def test_logs_with_disks(started_cluster):
         stop_zk(node_zk)
 
         log_files = list_s3_objects(started_cluster, "logs/")
-        local_log_files = get_local_logs()
+        local_log_files = get_local_logs(node_logs)
         assert len(local_log_files) == 1
 
         log_files.extend(local_log_files)
@@ -175,16 +185,17 @@ def test_logs_with_disks(started_cluster):
 
         setup_storage(
             started_cluster,
+            node_logs,
             "<old_log_storage_disk>log_s3_plain<\\/old_log_storage_disk>"
             "<log_storage_disk>log_local<\\/log_storage_disk>"
             "<snapshot_storage_disk>snapshot_local<\\/snapshot_storage_disk>",
             cleanup_disks=False,
         )
 
-        local_log_files = get_local_logs()
+        local_log_files = get_local_logs(node_logs)
         assert set(local_log_files) == set(previous_log_files)
 
-        node_zk = get_fake_zk("node")
+        node_zk = get_fake_zk("node_logs")
 
         for child in node_zk.get_children("/test"):
             assert node_zk.get(f"/test/{child}")[0] == b"somedata"
@@ -194,9 +205,9 @@ def test_logs_with_disks(started_cluster):
 
 
 def test_snapshots_with_disks(started_cluster):
-    setup_local_storage(started_cluster)
+    setup_local_storage(started_cluster, node_snapshot)
 
-    node_zk = get_fake_zk("node")
+    node_zk = get_fake_zk("node_snapshot")
     try:
         node_zk.create("/test2")
         for _ in range(30):
@@ -204,15 +215,16 @@ def test_snapshots_with_disks(started_cluster):
 
         stop_zk(node_zk)
 
-        snapshot_idx = keeper_utils.send_4lw_cmd(cluster, node, "csnp")
-        node.wait_for_log_line(
+        snapshot_idx = keeper_utils.send_4lw_cmd(cluster, node_snapshot, "csnp")
+        node_snapshot.wait_for_log_line(
             f"Created persistent snapshot {snapshot_idx}", look_behind_lines=1000
         )
 
-        previous_snapshot_files = get_local_snapshots()
+        previous_snapshot_files = get_local_snapshots(node_snapshot)
 
         setup_storage(
             started_cluster,
+            node_snapshot,
             "<snapshot_storage_disk>snapshot_s3_plain<\\/snapshot_storage_disk>"
             "<latest_snapshot_storage_disk>snapshot_local<\\/latest_snapshot_storage_disk>"
             "<log_storage_disk>log_local<\\/log_storage_disk>",
@@ -222,26 +234,26 @@ def test_snapshots_with_disks(started_cluster):
         ## all but the latest log should be on S3
         s3_snapshot_files = list_s3_objects(started_cluster, "snapshots/")
         assert set(s3_snapshot_files) == set(previous_snapshot_files[:-1])
-        local_snapshot_files = get_local_snapshots()
+        local_snapshot_files = get_local_snapshots(node_snapshot)
         assert len(local_snapshot_files) == 1
         assert local_snapshot_files[0] == previous_snapshot_files[-1]
 
         previous_snapshot_files = s3_snapshot_files + local_snapshot_files
 
-        node_zk = get_fake_zk("node")
+        node_zk = get_fake_zk("node_snapshot")
 
         for _ in range(30):
             node_zk.create("/test2/somenode", b"somedata", sequence=True)
 
         stop_zk(node_zk)
 
-        snapshot_idx = keeper_utils.send_4lw_cmd(cluster, node, "csnp")
-        node.wait_for_log_line(
+        snapshot_idx = keeper_utils.send_4lw_cmd(cluster, node_snapshot, "csnp")
+        node_snapshot.wait_for_log_line(
             f"Created persistent snapshot {snapshot_idx}", look_behind_lines=1000
         )
 
         snapshot_files = list_s3_objects(started_cluster, "snapshots/")
-        local_snapshot_files = get_local_snapshots()
+        local_snapshot_files = get_local_snapshots(node_snapshot)
         assert len(local_snapshot_files) == 1
 
         snapshot_files.extend(local_snapshot_files)
@@ -250,16 +262,17 @@ def test_snapshots_with_disks(started_cluster):
 
         setup_storage(
             started_cluster,
+            node_snapshot,
             "<old_snapshot_storage_disk>snapshot_s3_plain<\\/old_snapshot_storage_disk>"
             "<snapshot_storage_disk>snapshot_local<\\/snapshot_storage_disk>"
             "<log_storage_disk>log_local<\\/log_storage_disk>",
             cleanup_disks=False,
         )
 
-        local_snapshot_files = get_local_snapshots()
+        local_snapshot_files = get_local_snapshots(node_snapshot)
         assert set(local_snapshot_files) == set(previous_snapshot_files)
 
-        node_zk = get_fake_zk("node")
+        node_zk = get_fake_zk("node_snapshot")
 
         for child in node_zk.get_children("/test2"):
             assert node_zk.get(f"/test2/{child}")[0] == b"somedata"


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

`csnp` 4LW can fail if a snapshot is already being created in background so we use larger snapshot distance for those tests.


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
