### PR TITLE
Lower the number of iterations in test_host_regexp_multiple_ptr_records_concurrent

### DIFF
--- a/tests/integration/test_host_regexp_multiple_ptr_records_concurrent/scripts/stress_test.py
+++ b/tests/integration/test_host_regexp_multiple_ptr_records_concurrent/scripts/stress_test.py
@@ -9,7 +9,7 @@ server_ip = sys.argv[2]
 mutex = threading.Lock()
 success_counter = 0
 number_of_threads = 100
-number_of_iterations = 80
+number_of_iterations = 50
 
 
 def perform_request():

--- a/tests/integration/test_host_regexp_multiple_ptr_records_concurrent/scripts/stress_test.py
+++ b/tests/integration/test_host_regexp_multiple_ptr_records_concurrent/scripts/stress_test.py
@@ -9,7 +9,7 @@ server_ip = sys.argv[2]
 mutex = threading.Lock()
 success_counter = 0
 number_of_threads = 100
-number_of_iterations = 100
+number_of_iterations = 80
 
 
 def perform_request():


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Suddenly, `test_host_regexp_multiple_ptr_records_concurrent` became flaky.

I have looked through two reports, both of them manage to complete > 9k requests. This change lowers the iteration so the total amount of requests is 5k.

https://github.com/ClickHouse/ClickHouse/issues/54305

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
