### PR TITLE
Increase timeout for system.stack_trace in 01051_system_stack_trace

### DIFF
--- a/tests/queries/0_stateless/01051_system_stack_trace.reference
+++ b/tests/queries/0_stateless/01051_system_stack_trace.reference
@@ -1,5 +1,5 @@
 -- { echo }
-SELECT count() > 0 FROM system.stack_trace WHERE query_id != '';
+SELECT count() > 0 FROM system.stack_trace WHERE query_id != '' AND thread_name = 'TCPHandler';
 1
 -- opimization for not reading /proc/self/task/{}/comm and avoid sending signal
 SELECT countIf(thread_id > 0) > 0 FROM system.stack_trace;
@@ -8,7 +8,7 @@ SELECT countIf(thread_id > 0) > 0 FROM system.stack_trace;
 SELECT count(trace) > 0 FROM system.stack_trace WHERE length(trace) > 0 LIMIT 1;
 1
 -- optimization for query_id
-SELECT length(query_id) > 0 FROM system.stack_trace WHERE query_id != '' LIMIT 1;
+SELECT length(query_id) > 0 FROM system.stack_trace WHERE query_id != '' AND thread_name = 'TCPHandler' LIMIT 1;
 1
 -- optimization for thread_name
 SELECT length(thread_name) > 0 FROM system.stack_trace WHERE thread_name != '' LIMIT 1;

--- a/tests/queries/0_stateless/01051_system_stack_trace.sql
+++ b/tests/queries/0_stateless/01051_system_stack_trace.sql
@@ -1,13 +1,19 @@
-SET storage_system_stack_trace_pipe_read_timeout_ms = 1000;
+-- Tags: no-parallel
+-- Tag no-parallel: to decrease failure probability of collecting stack traces
+
+-- NOTE: It is OK to have bigger timeout here since:
+-- a) this test is marked as no-parallel
+-- b) there is a filter by thread_name, so it will send signals only to the threads with the name TCPHandler
+SET storage_system_stack_trace_pipe_read_timeout_ms = 5000;
 
 -- { echo }
-SELECT count() > 0 FROM system.stack_trace WHERE query_id != '';
+SELECT count() > 0 FROM system.stack_trace WHERE query_id != '' AND thread_name = 'TCPHandler';
 -- opimization for not reading /proc/self/task/{}/comm and avoid sending signal
 SELECT countIf(thread_id > 0) > 0 FROM system.stack_trace;
 -- optimization for trace
 SELECT count(trace) > 0 FROM system.stack_trace WHERE length(trace) > 0 LIMIT 1;
 -- optimization for query_id
-SELECT length(query_id) > 0 FROM system.stack_trace WHERE query_id != '' LIMIT 1;
+SELECT length(query_id) > 0 FROM system.stack_trace WHERE query_id != '' AND thread_name = 'TCPHandler' LIMIT 1;
 -- optimization for thread_name
 SELECT length(thread_name) > 0 FROM system.stack_trace WHERE thread_name != '' LIMIT 1;
 -- enough rows (optimizations works "correctly")


### PR DESCRIPTION
This should fix possible flakiness [1] due to "Cannot obtain a stack trace for thread":

<details>

    $ zstd -cdq clickhouse-server.log.zst | grep -a 2a66d71f-1340-44c8-9d0f-0779b0218ae4
    2023.09.05 12:04:55.906701 [ 617 ] {2a66d71f-1340-44c8-9d0f-0779b0218ae4} <Debug> executeQuery: (from [::1]:52620) (comment: 01051_system_stack_trace.sql) -- { echo }
    2023.09.05 12:04:55.907041 [ 617 ] {2a66d71f-1340-44c8-9d0f-0779b0218ae4} <Trace> ContextAccess (default): Access granted: SELECT(query_id) ON system.stack_trace
    2023.09.05 12:04:58.858695 [ 617 ] {2a66d71f-1340-44c8-9d0f-0779b0218ae4} <Debug> StorageSystemStackTrace: Cannot obtain a stack trace for thread 617
    2023.09.05 12:05:01.858508 [ 617 ] {2a66d71f-1340-44c8-9d0f-0779b0218ae4} <Debug> StorageSystemStackTrace: Cannot obtain a stack trace for thread 812
    2023.09.05 12:05:04.858698 [ 617 ] {2a66d71f-1340-44c8-9d0f-0779b0218ae4} <Debug> StorageSystemStackTrace: Cannot obtain a stack trace for thread 1707
    2023.09.05 12:05:05.194543 [ 617 ] {2a66d71f-1340-44c8-9d0f-0779b0218ae4} <Trace> InterpreterSelectQuery: FetchColumns -> Complete
    2023.09.05 12:05:05.195960 [ 2835 ] {2a66d71f-1340-44c8-9d0f-0779b0218ae4} <Trace> Aggregator: Aggregation method: without_key
    2023.09.05 12:05:05.195997 [ 2835 ] {2a66d71f-1340-44c8-9d0f-0779b0218ae4} <Trace> AggregatingTransform: Aggregated. 0 to 1 rows (from 0.00 B) in 0.001220809 sec. (0.000 rows/sec., 0.00 B/sec.)
    2023.09.05 12:05:05.196008 [ 2835 ] {2a66d71f-1340-44c8-9d0f-0779b0218ae4} <Trace> Aggregator: Merging aggregated data
    2023.09.05 12:05:05.196020 [ 2835 ] {2a66d71f-1340-44c8-9d0f-0779b0218ae4} <Trace> Aggregator: Statistics updated for key=5518594236514924310: new sum_of_sizes=1, median_size=1
    2023.09.05 12:05:05.197646 [ 617 ] {2a66d71f-1340-44c8-9d0f-0779b0218ae4} <Debug> executeQuery: Read 1937 rows, 158.08 KiB in 9.291003 sec., 208.48125869725797 rows/sec., 17.01 KiB/sec.
    2023.09.05 12:05:05.197748 [ 617 ] {2a66d71f-1340-44c8-9d0f-0779b0218ae4} <Debug> TCPHandler: Processed in 9.291633143 sec.

</details>

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/0/5da7133c9421873c86bf7d5d71e699267fcefbff/stateless_tests__aarch64_.html

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)