### PR TITLE
Fixed flaky test `02841_parallel_replicas_summary`

### DIFF
--- a/tests/queries/0_stateless/02841_parallel_replicas_summary.reference
+++ b/tests/queries/0_stateless/02841_parallel_replicas_summary.reference
@@ -1,2 +1,4 @@
 1
 1
+02841_summary_default_interactive_0	1
+02841_summary_default_interactive_high	1

--- a/tests/queries/0_stateless/02841_parallel_replicas_summary.reference
+++ b/tests/queries/0_stateless/02841_parallel_replicas_summary.reference
@@ -1,4 +1,2 @@
 1
 1
-02841_summary_default_interactive_0	2
-02841_summary_default_interactive_high	2


### PR DESCRIPTION
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
[A link to an example of failure.](https://s3.amazonaws.com/clickhouse-test-reports/0/f52c187f027352597a7397a6f1abc744ecf85a58/stateless_tests__aarch64_.html)

This tests checks that number of replicas participated in the query execution is 2 always. However, in this case 
<pre>
2023.09.06 02:37:28.775668 [ 1553 ] {} <Trace> DynamicQueryHandler: Request URI: /?max_insert_threads=0&group_by_two_level_threshold=1&group_by_two_level_threshold_bytes=34344847&distributed_aggregation_memory_efficient=1&fsync_metadata=0&output_format_parallel_formatting=0&input_format_parallel_parsing=1&min_chunk_bytes_for_parallel_parsing=1024&max_read_buffer_size=994413&prefer_localhost_replica=0&max_block_size=93047&max_threads=13&optimize_or_like_chain=0&optimize_read_in_order=1&enable_multiple_prewhere_read_steps=0&read_in_order_two_level_merge_threshold=4&optimize_aggregation_in_order=1&aggregation_in_order_max_block_bytes=40211095&min_compress_block_size=378009&max_compress_block_size=2652712&use_uncompressed_cache=1&min_bytes_to_use_direct_io=528165846&min_bytes_to_use_mmap_io=10737418240&local_filesystem_read_method=io_uring&remote_filesystem_read_method=threadpool&local_filesystem_read_prefetch=0&remote_filesystem_read_prefetch=0&allow_prefetched_read_pool_for_remote_filesystem=0&filesystem_prefetch_max_memory_usage=64Mi&filesystem_prefetches_limit=10&filesystem_prefetch_min_bytes_for_single_read_task=1Mi&filesystem_prefetch_step_marks=0&filesystem_prefetch_step_bytes=100Mi&compile_aggregate_expressions=0&compile_sort_description=0&merge_tree_coarse_index_granularity=28&optimize_distinct_in_order=0&optimize_sorting_by_input_stream_properties=0&http_response_buffer_size=1767003&http_wait_end_of_query=True&enable_memory_bound_merging_of_aggregation_results=0&min_count_to_compile_expression=0&min_count_to_compile_aggregate_expression=3&min_count_to_compile_sort_description=3&session_timezone=Africa%2FJuba&database=test_vnhhrm1c&log_comment=02841_parallel_replicas_summary.sh&wait_end_of_query=1&query_id=02841_summary_test_vnhhrm1c_interactive_0
2023.09.06 02:37:28.787793 [ 1553 ] {02841_summary_test_vnhhrm1c_interactive_0} <Debug> executeQuery: (from [::ffff:127.0.0.1]:51976) (comment: 02841_parallel_replicas_summary.sh)  SELECT * FROM replicas_summary LIMIT 100 SETTINGS max_parallel_replicas = 2, cluster_for_parallel_replicas = 'test_cluster_one_shard_three_replicas_localhost', allow_experimental_parallel_reading_from_replicas = 1, parallel_replicas_for_non_replicated_merge_tree = 1, use_hedged_requests = 0, interactive_delay=0  (stage: Complete)
2023.09.06 02:37:28.787967 [ 1553 ] {02841_summary_test_vnhhrm1c_interactive_0} <Trace> ContextAccess (default): Settings: readonly = 0, allow_ddl = true, allow_introspection_functions = false
2023.09.06 02:37:28.787994 [ 1553 ] {02841_summary_test_vnhhrm1c_interactive_0} <Trace> ContextAccess (default): List of all grants: GRANT ALL ON *.* WITH GRANT OPTION
2023.09.06 02:37:28.788010 [ 1553 ] {02841_summary_test_vnhhrm1c_interactive_0} <Trace> ContextAccess (default): List of all grants including implicit: GRANT ALL ON *.* WITH GRANT OPTION
2023.09.06 02:37:28.788168 [ 1553 ] {02841_summary_test_vnhhrm1c_interactive_0} <Debug> test_vnhhrm1c.replicas_summary (6af667dd-5eb4-46ea-89a1-3ab197869169) (SelectExecutor): Key condition: unknown
2023.09.06 02:37:28.788210 [ 1553 ] {02841_summary_test_vnhhrm1c_interactive_0} <Trace> test_vnhhrm1c.replicas_summary (6af667dd-5eb4-46ea-89a1-3ab197869169): Estimated number of granules to read is 6
2023.09.06 02:37:28.788245 [ 1553 ] {02841_summary_test_vnhhrm1c_interactive_0} <Trace> ContextAccess (default): Access granted: SELECT(n) ON test_vnhhrm1c.replicas_summary
2023.09.06 02:37:28.788432 [ 1553 ] {02841_summary_test_vnhhrm1c_interactive_0} <Trace> ContextAccess (default): Access granted: SELECT(n) ON test_vnhhrm1c.replicas_summary
2023.09.06 02:37:28.788509 [ 1553 ] {02841_summary_test_vnhhrm1c_interactive_0} <Trace> InterpreterSelectQuery: WithMergeableState -> Complete
2023.09.06 02:37:28.789446 [ 1464 ] {e8e8a0e6-9edf-4fe8-be79-8fc6a843bc3d} <Debug> executeQuery: (from [::ffff:127.0.0.1]:45880, initial_query_id: 02841_summary_test_vnhhrm1c_interactive_0) (comment: 02841_parallel_replicas_summary.sh) SELECT `replicas_summary`.`n` FROM `test_vnhhrm1c`.`replicas_summary` LIMIT 100 (stage: WithMergeableState)
2023.09.06 02:37:28.790129 [ 1553 ] {02841_summary_test_vnhhrm1c_interactive_0} <Debug> DefaultCoordinator: Sent initial requests: 1 Replicas count: 2
2023.09.06 02:37:28.790186 [ 1553 ] {02841_summary_test_vnhhrm1c_interactive_0} <Trace> DefaultCoordinator: Handling request from replica 0, minimal marks size is 30
2023.09.06 02:37:28.790201 [ 1553 ] {02841_summary_test_vnhhrm1c_interactive_0} <Trace> DefaultCoordinator: Going to respond to replica 0 with 1 parts: [part all_1_1_0 with ranges [(0, 6)]]. Finish: false
<b>2023.09.06 02:37:28.792051 [ 1553 ] {02841_summary_test_vnhhrm1c_interactive_0} <Trace> ReadFromParallelRemoteReplicasStep: (127.0.0.1:9000) Cancelling query because enough data has been read</b>
2023.09.06 02:37:28.792254 [ 1553 ] {02841_summary_test_vnhhrm1c_interactive_0} <Debug> executeQuery: Read 17196 rows, 268.69 KiB in 0.004561 sec., 3770225.827669371 rows/sec., 57.53 MiB/sec.
<b>2023.09.06 02:37:28.792299 [ 1553 ] {02841_summary_test_vnhhrm1c_interactive_0} <Debug> DefaultCoordinator: Coordination done: Statistics: replica 0 - {requests: 2 marks: 6}; replica 1 - {requests: 0 marks: 0}</b>
2023.09.06 02:37:28.792650 [ 1553 ] {02841_summary_test_vnhhrm1c_interactive_0} <Debug> DynamicQueryHandler: Done processing query
2023.09.06 02:37:28.792681 [ 1553 ] {02841_summary_test_vnhhrm1c_interactive_0} <Debug> MemoryTracker: Peak memory usage (for query): 8.08 MiB.
</pre>

Everything was processed by a single replica and the query to another one wasn't even set.

I've also changed the value of `allow_experimental_parallel_reading_from_replicas` from 1 to 2 to ensure parallel replicas will be also effective. 

CC @Algunenano 
