### PR TITLE
Fixed wrong dereference problem in Context::setTemporaryStorageInCache

### DIFF
--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -982,7 +982,7 @@ void Context::setTemporaryStorageInCache(const String & cache_disk_name, size_t 
 
     auto file_cache = FileCacheFactory::instance().getByName(disk_ptr->getCacheName()).cache;
     if (!file_cache)
-        throw Exception(ErrorCodes::NO_ELEMENTS_IN_CONFIG, "Cache '{}' is not found", file_cache->getBasePath());
+        throw Exception(ErrorCodes::NO_ELEMENTS_IN_CONFIG, "Cache '{}' is not found", disk_ptr->getCacheName());
 
     LOG_DEBUG(shared->log, "Using file cache ({}) for temporary files", file_cache->getBasePath());
 


### PR DESCRIPTION
In of Context.cpp we have:

```cpp
auto file_cache = FileCacheFactory::instance().getByName(disk_ptr->getCacheName()).cache;
if (!file_cache)
    throw Exception(ErrorCodes::NO_ELEMENTS_IN_CONFIG, "Cache '{}' is not found", file_cache->getBasePath());
```

There is a bug in the file_cache->getBasePath() because file_cache is NULL at this stage.
Instread of `file_cache->getBasePath()` we should probably use `disk_ptr->getCacheName()`

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
