### PR TITLE
Used assert_cast instead of dynamic_cast in ExternalDataSourceCache

### DIFF
--- a/src/Storages/Cache/ExternalDataSourceCache.cpp
+++ b/src/Storages/Cache/ExternalDataSourceCache.cpp
@@ -57,7 +57,7 @@ LocalFileHolder::~LocalFileHolder()
 {
     if (original_readbuffer)
     {
-        dynamic_cast<SeekableReadBuffer *>(original_readbuffer.get())->seek(0, SEEK_SET);
+        assert_cast<SeekableReadBuffer *>(original_readbuffer.get())->seek(0, SEEK_SET);
         file_cache_controller->value().startBackgroundDownload(std::move(original_readbuffer), *thread_pool);
     }
 }
@@ -122,7 +122,7 @@ off_t RemoteReadBuffer::seek(off_t offset, int whence)
 {
     if (local_file_holder->original_readbuffer)
     {
-        auto ret = dynamic_cast<SeekableReadBuffer *>(local_file_holder->original_readbuffer.get())->seek(offset, whence);
+        auto ret = assert_cast<SeekableReadBuffer *>(local_file_holder->original_readbuffer.get())->seek(offset, whence);
         BufferBase::set(
             local_file_holder->original_readbuffer->buffer().begin(),
             local_file_holder->original_readbuffer->buffer().size(),
@@ -147,7 +147,7 @@ off_t RemoteReadBuffer::getPosition()
 {
     if (local_file_holder->original_readbuffer)
     {
-        return dynamic_cast<SeekableReadBuffer *>(local_file_holder->original_readbuffer.get())->getPosition();
+        return assert_cast<SeekableReadBuffer *>(local_file_holder->original_readbuffer.get())->getPosition();
     }
     return local_file_holder->file_buffer->getPosition();
 }


### PR DESCRIPTION
Used `assert_cast` instead of `dynamic_cast` in `ExternalDataSourceCache`.
`dynamic_cast` may return `nullptr` and then dereference of nullptr will happen.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
