### PR TITLE
Improved protection from dereferencing of nullptr

### DIFF
--- a/src/Common/mysqlxx/Connection.cpp
+++ b/src/Common/mysqlxx/Connection.cpp
@@ -134,6 +134,8 @@ void Connection::disconnect()
     if (!is_initialized)
         return;
 
+    // If driver->free_me, then mysql_close will deallocate memory by calling 'free' function.
+    assert(driver && !driver->free_me);
     mysql_close(driver.get());
     memset(driver.get(), 0, sizeof(*driver));
 

--- a/src/Functions/array/mapPopulateSeries.cpp
+++ b/src/Functions/array/mapPopulateSeries.cpp
@@ -106,7 +106,7 @@ private:
             if (1 < arguments.size())
                 value_type = arguments[1];
 
-            if (arguments.size() < 2 || (value_type && !isArray(value_type)))
+            if (arguments.size() < 2 || !value_type || !isArray(value_type))
                 throw Exception(ErrorCodes::BAD_ARGUMENTS,
                     "Function {} if array argument is passed as key, additional array argument as value must be passed",
                     getName());

--- a/src/Functions/array/mapPopulateSeries.cpp
+++ b/src/Functions/array/mapPopulateSeries.cpp
@@ -102,17 +102,13 @@ private:
 
         if (key_argument_data_type.isArray())
         {
-            DataTypePtr value_type;
-            if (1 < arguments.size())
-                value_type = arguments[1];
-
-            if (arguments.size() < 2 || !value_type || !isArray(value_type))
+            if (arguments.size() < 2 || !arguments[1] || !isArray(arguments[1]))
                 throw Exception(ErrorCodes::BAD_ARGUMENTS,
                     "Function {} if array argument is passed as key, additional array argument as value must be passed",
                     getName());
 
             const auto & key_array_type = assert_cast<const DataTypeArray &>(*arguments[0]);
-            const auto & value_array_type = assert_cast<const DataTypeArray &>(*value_type);
+            const auto & value_array_type = assert_cast<const DataTypeArray &>(*arguments[1]);
 
             key_argument_series_type = key_array_type.getNestedType();
             value_argument_series_type = value_array_type.getNestedType();

--- a/src/Interpreters/ActionsVisitor.cpp
+++ b/src/Interpreters/ActionsVisitor.cpp
@@ -345,7 +345,7 @@ Block createBlockForSet(
 {
     auto get_tuple_type_from_ast = [context](const auto & func) -> DataTypePtr
     {
-        if (func && (func->name == "tuple" || func->name == "array") && !func->arguments->children.empty())
+        if ((func->name == "tuple" || func->name == "array") && !func->arguments->children.empty())
         {
             /// Won't parse all values of outer tuple.
             auto element = func->arguments->children.at(0);
@@ -356,6 +356,7 @@ Block createBlockForSet(
         return evaluateConstantExpression(func, context).second;
     };
 
+    assert(right_arg);
     const DataTypePtr & right_arg_type = get_tuple_type_from_ast(right_arg);
 
     size_t left_tuple_depth = getTypeDepth(left_arg_type);


### PR DESCRIPTION
Improved protection from dereferencing of `nullptr` in 3 places in the code.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)