### PR TITLE
Use abiv2 when generating OpenSSL .s files for powerpc64le

### DIFF
--- a/cmake/linux/toolchain-ppc64le.cmake
+++ b/cmake/linux/toolchain-ppc64le.cmake
@@ -5,9 +5,9 @@ set (CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
 
 set (CMAKE_SYSTEM_NAME "Linux")
 set (CMAKE_SYSTEM_PROCESSOR "ppc64le")
-set (CMAKE_C_COMPILER_TARGET "ppc64le-linux-gnu")
-set (CMAKE_CXX_COMPILER_TARGET "ppc64le-linux-gnu")
-set (CMAKE_ASM_COMPILER_TARGET "ppc64le-linux-gnu")
+set (CMAKE_C_COMPILER_TARGET "powerpc64le-linux-gnu")
+set (CMAKE_CXX_COMPILER_TARGET "powerpc64le-linux-gnu")
+set (CMAKE_ASM_COMPILER_TARGET "powerpc64le-linux-gnu")
 
 # Will be changed later, but somehow needed to be set here.
 set (CMAKE_AR "ar")

--- a/contrib/openssl-cmake/CMakeLists.txt
+++ b/contrib/openssl-cmake/CMakeLists.txt
@@ -126,7 +126,7 @@ if(ENABLE_OPENSSL_DYNAMIC OR ENABLE_OPENSSL)
     elseif(ARCH_PPC64LE)
         macro(perl_generate_asm FILE_IN FILE_OUT)
             add_custom_command(OUTPUT ${FILE_OUT}
-                COMMAND /usr/bin/env perl ${FILE_IN} "linux64" ${FILE_OUT})
+                COMMAND /usr/bin/env perl ${FILE_IN} "linux64v2" ${FILE_OUT})
         endmacro()
 
         perl_generate_asm(${OPENSSL_SOURCE_DIR}/crypto/aes/asm/aes-ppc.pl ${OPENSSL_BINARY_DIR}/crypto/aes/aes-ppc.s)


### PR DESCRIPTION
The generated .s files are using abiv1 (big-endian ppc), need to generate abiv2

### Changelog category (leave one):
- Not for changelog

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
N/A
