### PR TITLE
Fix segfault in AST optimization of `arrayExists` function

### DIFF
--- a/src/Interpreters/RewriteArrayExistsFunctionVisitor.cpp
+++ b/src/Interpreters/RewriteArrayExistsFunctionVisitor.cpp
@@ -19,7 +19,7 @@ void RewriteArrayExistsFunctionMatcher::visit(ASTPtr & ast, Data & data)
     {
         if (join->using_expression_list)
         {
-            auto it = std::find(join->children.begin(), join->children.end(), join->using_expression_list);
+            auto * it = std::find(join->children.begin(), join->children.end(), join->using_expression_list);
 
             visit(join->using_expression_list, data);
 
@@ -29,7 +29,7 @@ void RewriteArrayExistsFunctionMatcher::visit(ASTPtr & ast, Data & data)
 
         if (join->on_expression)
         {
-            auto it = std::find(join->children.begin(), join->children.end(), join->on_expression);
+            auto * it = std::find(join->children.begin(), join->children.end(), join->on_expression);
 
             visit(join->on_expression, data);
 

--- a/src/Interpreters/RewriteArrayExistsFunctionVisitor.h
+++ b/src/Interpreters/RewriteArrayExistsFunctionVisitor.h
@@ -18,7 +18,7 @@ public:
 
     static void visit(ASTPtr & ast, Data &);
     static void visit(const ASTFunction &, ASTPtr & ast, Data &);
-    static bool needChildVisit(const ASTPtr &, const ASTPtr &) { return true; }
+    static bool needChildVisit(const ASTPtr & ast, const ASTPtr & child);
 };
 
 using RewriteArrayExistsFunctionVisitor = InDepthNodeVisitor<RewriteArrayExistsFunctionMatcher, false>;

--- a/src/Interpreters/RewriteArrayExistsFunctionVisitor.h
+++ b/src/Interpreters/RewriteArrayExistsFunctionVisitor.h
@@ -18,7 +18,7 @@ public:
 
     static void visit(ASTPtr & ast, Data &);
     static void visit(const ASTFunction &, ASTPtr & ast, Data &);
-    static bool needChildVisit(const ASTPtr & ast, const ASTPtr & child);
+    static bool needChildVisit(const ASTPtr & ast, const ASTPtr &);
 };
 
 using RewriteArrayExistsFunctionVisitor = InDepthNodeVisitor<RewriteArrayExistsFunctionMatcher, false>;

--- a/tests/queries/0_stateless/02834_array_exists_segfault.sql
+++ b/tests/queries/0_stateless/02834_array_exists_segfault.sql
@@ -1,0 +1,2 @@
+CREATE TABLE 02834_t (id UInt64, arr Array(UInt64)) ENGINE = MergeTree ORDER BY id;
+WITH subquery AS (SELECT []) SELECT t.* FROM 02834_t AS t JOIN subquery ON arrayExists(x -> x = 1, t.arr); -- { serverError INVALID_JOIN_ON_EXPRESSION }

--- a/tests/queries/0_stateless/02834_array_exists_segfault.sql
+++ b/tests/queries/0_stateless/02834_array_exists_segfault.sql
@@ -1,2 +1,4 @@
+DROP TABLE IF EXISTS 02834_t;
 CREATE TABLE 02834_t (id UInt64, arr Array(UInt64)) ENGINE = MergeTree ORDER BY id;
 WITH subquery AS (SELECT []) SELECT t.* FROM 02834_t AS t JOIN subquery ON arrayExists(x -> x = 1, t.arr); -- { serverError INVALID_JOIN_ON_EXPRESSION }
+DROP TABLE 02834_t;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix segmentation fault caused by AST optimization of `arrayExists` function applied in the JOIN ON part of the query.

cc: @taiyang-li 