### PR TITLE
Update sampling-query-profiler.md

### DIFF
--- a/docs/en/operations/optimizing-performance/sampling-query-profiler.md
+++ b/docs/en/operations/optimizing-performance/sampling-query-profiler.md
@@ -11,6 +11,8 @@ ClickHouse runs sampling profiler that allows analyzing query execution. Using p
 
 Query profiler is automatically enabled in ClickHouse Cloud and you can run a sample query as follows
 
+:::note If you are running the following query in ClickHouse Cloud, make sure to change `FROM system.trace_log` to `FROM clusterAllReplicas(default, system.trace_log)` to select from all nodes of the cluster :::
+
 ``` sql
 SELECT
     count(),


### PR DESCRIPTION
### Changelog category (leave one):
- Documentation (changelog entry is not required)

Adding a note to clarify that the sample query provided, in CH Cloud, might return empty information as it cycles through nodes of the cluster. You need to add clusterAllReplicas.

It also recommends to run it in cloud, but it's missing this key change:
```Query profiler is automatically enabled in ClickHouse Cloud and you can run a sample query as follows```

Query I'm referring to:
```sql
SELECT
    count(),
    arrayStringConcat(arrayMap(x -> concat(demangle(addressToSymbol(x)), '\n    ', addressToLine(x)), trace), '\n') AS sym
FROM system.trace_log
WHERE (query_id = 'ebca3574-ad0a-400a-9cbc-dca382f5998c') AND (event_date = today())
GROUP BY trace
ORDER BY count() DESC
LIMIT 10
SETTINGS allow_introspection_functions = 1
```
