### PR TITLE
Fix incorrect formatting of CREATE query with PRIMARY KEY

### DIFF
--- a/src/Parsers/ASTColumnDeclaration.cpp
+++ b/src/Parsers/ASTColumnDeclaration.cpp
@@ -77,10 +77,6 @@ void ASTColumnDeclaration::formatImpl(const FormatSettings & settings, FormatSta
                       << (*null_modifier ? "" : "NOT ") << "NULL" << (settings.hilite ? hilite_none : "");
     }
 
-    if (primary_key_specifier)
-        settings.ostr << ' ' << (settings.hilite ? hilite_keyword : "")
-                      << "PRIMARY KEY" << (settings.hilite ? hilite_none : "");
-
     if (default_expression)
     {
         settings.ostr << ' ' << (settings.hilite ? hilite_keyword : "") << default_specifier << (settings.hilite ? hilite_none : "");


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix incorrect formatting of CREATE query with PRIMARY KEY. Closes https://github.com/ClickHouse/ClickHouse/issues/54402

cc: @qoega 