### PR TITLE
Parse data in JSON format as JSONEachRow if failed to parse metadata

### DIFF
--- a/src/Formats/JSONUtils.cpp
+++ b/src/Formats/JSONUtils.cpp
@@ -687,10 +687,9 @@ namespace JSONUtils
         return names_and_types;
     }
 
-    NamesAndTypesList readMetadataAndValidateHeader(ReadBuffer & in, const Block & header)
+    void validateMetadataByHeader(const NamesAndTypesList & names_and_types_from_metadata, const Block & header)
     {
-        auto names_and_types = JSONUtils::readMetadata(in);
-        for (const auto & [name, type] : names_and_types)
+        for (const auto & [name, type] : names_and_types_from_metadata)
         {
             if (!header.has(name))
                 continue;
@@ -698,10 +697,16 @@ namespace JSONUtils
             auto header_type = header.getByName(name).type;
             if (!type->equals(*header_type))
                 throw Exception(
-                                ErrorCodes::INCORRECT_DATA,
-                                "Type {} of column '{}' from metadata is not the same as type in header {}",
-                                type->getName(), name, header_type->getName());
+                    ErrorCodes::INCORRECT_DATA,
+                    "Type {} of column '{}' from metadata is not the same as type in header {}",
+                    type->getName(), name, header_type->getName());
         }
+    }
+
+    NamesAndTypesList readMetadataAndValidateHeader(ReadBuffer & in, const Block & header)
+    {
+        auto names_and_types = JSONUtils::readMetadata(in);
+        validateMetadataByHeader(names_and_types, header);
         return names_and_types;
     }
 

--- a/src/Formats/JSONUtils.h
+++ b/src/Formats/JSONUtils.h
@@ -124,6 +124,7 @@ namespace JSONUtils
 
     NamesAndTypesList readMetadata(ReadBuffer & in);
     NamesAndTypesList readMetadataAndValidateHeader(ReadBuffer & in, const Block & header);
+    void validateMetadataByHeader(const NamesAndTypesList & names_and_types_from_metadata, const Block & header);
 
     bool skipUntilFieldInObject(ReadBuffer & in, const String & desired_field_name);
     void skipTheRestOfObject(ReadBuffer & in);

--- a/src/Processors/Formats/Impl/JSONEachRowRowInputFormat.h
+++ b/src/Processors/Formats/Impl/JSONEachRowRowInputFormat.h
@@ -32,10 +32,11 @@ public:
     String getName() const override { return "JSONEachRowRowInputFormat"; }
     void resetParser() override;
 
-private:
+protected:
     void readPrefix() override;
     void readSuffix() override;
 
+private:
     bool readRow(MutableColumns & columns, RowReadExtension & ext) override;
     bool allowSyncAfterError() const override { return true; }
     void syncAfterError() override;

--- a/src/Processors/Formats/Impl/JSONRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/JSONRowInputFormat.cpp
@@ -65,6 +65,17 @@ void JSONRowInputFormat::readSuffix()
     }
 }
 
+void JSONRowInputFormat::setReadBuffer(DB::ReadBuffer & in_)
+{
+    peekable_buf->setSubBuffer(in_);
+}
+
+void JSONRowInputFormat::resetParser()
+{
+    JSONEachRowRowInputFormat::resetParser();
+    peekable_buf->reset();
+}
+
 JSONRowSchemaReader::JSONRowSchemaReader(ReadBuffer & in_, const FormatSettings & format_settings_)
     : JSONRowSchemaReader(std::make_unique<PeekableReadBuffer>(in_), format_settings_)
 {

--- a/src/Processors/Formats/Impl/JSONRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/JSONRowInputFormat.cpp
@@ -12,42 +12,84 @@ namespace ErrorCodes
 }
 
 JSONRowInputFormat::JSONRowInputFormat(ReadBuffer & in_, const Block & header_, Params params_, const FormatSettings & format_settings_)
-    : JSONEachRowRowInputFormat(in_, header_, params_, format_settings_, false), validate_types_from_metadata(format_settings_.json.validate_types_from_metadata)
+    : JSONRowInputFormat(std::make_unique<PeekableReadBuffer>(in_), header_, params_, format_settings_)
+{
+}
+
+JSONRowInputFormat::JSONRowInputFormat(std::unique_ptr<PeekableReadBuffer> buf, const DB::Block & header_, DB::IRowInputFormat::Params params_, const DB::FormatSettings & format_settings_)
+    : JSONEachRowRowInputFormat(*buf, header_, params_, format_settings_, false), validate_types_from_metadata(format_settings_.json.validate_types_from_metadata), peekable_buf(std::move(buf))
 {
 }
 
 void JSONRowInputFormat::readPrefix()
 {
-    skipBOMIfExists(*in);
-    JSONUtils::skipObjectStart(*in);
+    skipBOMIfExists(*peekable_buf);
+
+    PeekableReadBufferCheckpoint checkpoint(*peekable_buf);
+    NamesAndTypesList names_and_types_from_metadata;
+
+    /// Try to parse metadata, if failed, try to parse data as JSONEachRow format.
+    try
+    {
+        JSONUtils::skipObjectStart(*peekable_buf);
+        names_and_types_from_metadata = JSONUtils::readMetadata(*peekable_buf);
+        JSONUtils::skipComma(*peekable_buf);
+        if (!JSONUtils::skipUntilFieldInObject(*peekable_buf, "data"))
+            throw Exception(ErrorCodes::INCORRECT_DATA, "Expected field \"data\" with table content");
+
+        JSONUtils::skipArrayStart(*peekable_buf);
+        data_in_square_brackets = true;
+    }
+    catch (...)
+    {
+        peekable_buf->rollbackToCheckpoint();
+        JSONEachRowRowInputFormat::readPrefix();
+        parse_as_json_each_row = true;
+        return;
+    }
+
     if (validate_types_from_metadata)
-        JSONUtils::readMetadataAndValidateHeader(*in, getPort().getHeader());
-    else
-        JSONUtils::readMetadata(*in);
-
-    JSONUtils::skipComma(*in);
-    if (!JSONUtils::skipUntilFieldInObject(*in, "data"))
-        throw Exception(ErrorCodes::INCORRECT_DATA, "Expected field \"data\" with table content");
-
-    JSONUtils::skipArrayStart(*in);
-    data_in_square_brackets = true;
+        JSONUtils::validateMetadataByHeader(names_and_types_from_metadata, getPort().getHeader());
 }
 
 void JSONRowInputFormat::readSuffix()
 {
-    JSONUtils::skipArrayEnd(*in);
-    JSONUtils::skipTheRestOfObject(*in);
+    if (parse_as_json_each_row)
+    {
+        JSONEachRowRowInputFormat::readSuffix();
+    }
+    else
+    {
+        JSONUtils::skipArrayEnd(*peekable_buf);
+        JSONUtils::skipTheRestOfObject(*peekable_buf);
+    }
 }
 
-JSONRowSchemaReader::JSONRowSchemaReader(ReadBuffer & in_) : ISchemaReader(in_)
+JSONRowSchemaReader::JSONRowSchemaReader(ReadBuffer & in_, const FormatSettings & format_settings_)
+    : JSONRowSchemaReader(std::make_unique<PeekableReadBuffer>(in_), format_settings_)
+{
+}
+
+JSONRowSchemaReader::JSONRowSchemaReader(std::unique_ptr<PeekableReadBuffer> buf, const DB::FormatSettings & format_settings_)
+    : JSONEachRowSchemaReader(*buf, format_settings_), peekable_buf(std::move(buf))
 {
 }
 
 NamesAndTypesList JSONRowSchemaReader::readSchema()
 {
-    skipBOMIfExists(in);
-    JSONUtils::skipObjectStart(in);
-    return JSONUtils::readMetadata(in);
+    skipBOMIfExists(*peekable_buf);
+    PeekableReadBufferCheckpoint checkpoint(*peekable_buf);
+    /// Try to parse metadata, if failed, try to parse data as JSONEachRow format
+    try
+    {
+        JSONUtils::skipObjectStart(*peekable_buf);
+        return JSONUtils::readMetadata(*peekable_buf);
+    }
+    catch (...)
+    {
+        peekable_buf->rollbackToCheckpoint(true);
+        return JSONEachRowSchemaReader::readSchema();
+    }
 }
 
 void registerInputFormatJSON(FormatFactory & factory)
@@ -69,7 +111,7 @@ void registerJSONSchemaReader(FormatFactory & factory)
     auto register_schema_reader = [&](const String & format)
     {
         factory.registerSchemaReader(
-            format, [](ReadBuffer & buf, const FormatSettings &) { return std::make_unique<JSONRowSchemaReader>(buf); });
+            format, [](ReadBuffer & buf, const FormatSettings & format_settings) { return std::make_unique<JSONRowSchemaReader>(buf, format_settings); });
     };
     register_schema_reader("JSON");
     /// JSONCompact has the same suffix with metadata.

--- a/src/Processors/Formats/Impl/JSONRowInputFormat.h
+++ b/src/Processors/Formats/Impl/JSONRowInputFormat.h
@@ -23,6 +23,9 @@ public:
 
     String getName() const override { return "JSONRowInputFormat"; }
 
+    void setReadBuffer(ReadBuffer & in_) override;
+    void resetParser() override;
+
 private:
     JSONRowInputFormat(
         std::unique_ptr<PeekableReadBuffer> buf,

--- a/src/Processors/Formats/Impl/JSONRowInputFormat.h
+++ b/src/Processors/Formats/Impl/JSONRowInputFormat.h
@@ -24,20 +24,34 @@ public:
     String getName() const override { return "JSONRowInputFormat"; }
 
 private:
+    JSONRowInputFormat(
+        std::unique_ptr<PeekableReadBuffer> buf,
+        const Block & header_,
+        Params params_,
+        const FormatSettings & format_settings_);
+
     void readPrefix() override;
     void readSuffix() override;
 
     const bool validate_types_from_metadata;
+    bool parse_as_json_each_row = false;
+    std::unique_ptr<PeekableReadBuffer> peekable_buf;
+    std::exception_ptr reading_metadata_exception;
 };
 
-class JSONRowSchemaReader : public ISchemaReader
+class JSONRowSchemaReader : public JSONEachRowSchemaReader
 {
 public:
-    JSONRowSchemaReader(ReadBuffer & in_);
+    JSONRowSchemaReader(ReadBuffer & in_, const FormatSettings & format_settings_);
 
     NamesAndTypesList readSchema() override;
 
     bool hasStrictOrderOfColumns() const override { return false; }
+
+private:
+    JSONRowSchemaReader(std::unique_ptr<PeekableReadBuffer> buf, const FormatSettings & format_settings_);
+
+    std::unique_ptr<PeekableReadBuffer> peekable_buf;
 };
 
 }

--- a/tests/queries/0_stateless/02874_parse_json_as_json_each_row_on_no_metadata.reference
+++ b/tests/queries/0_stateless/02874_parse_json_as_json_each_row_on_no_metadata.reference
@@ -1,0 +1,3 @@
+a	Nullable(Int64)					
+b	Nullable(String)					
+10	Hello

--- a/tests/queries/0_stateless/02874_parse_json_as_json_each_row_on_no_metadata.sql
+++ b/tests/queries/0_stateless/02874_parse_json_as_json_each_row_on_no_metadata.sql
@@ -1,0 +1,3 @@
+desc format(JSON, '{"a" : 10, "b" : "Hello"}');
+select * from format(JSON, '{"a" : 10, "b" : "Hello"}');
+


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Parse data in JSON format as JSONEachRow if failed to parse metadata. It will allow to read files with `.json` extension even if real format is JSONEachRow. Closes https://github.com/ClickHouse/ClickHouse/issues/45740

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
