### PR TITLE
Hashtable order fix on big endian platform

### DIFF
--- a/src/Common/HashTable/Hash.h
+++ b/src/Common/HashTable/Hash.h
@@ -393,6 +393,18 @@ struct UInt128HashCRC32
     }
 };
 
+#elif defined(__s390x__) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+
+struct UInt128HashCRC32
+{
+    size_t operator()(UInt128 x) const
+    {
+        UInt64 crc = -1ULL;
+        crc = s390x_crc32(crc, x.items[UInt128::_impl::little(0)]);
+        crc = s390x_crc32(crc, x.items[UInt128::_impl::little(1)]);
+        return crc;
+    }
+};
 #else
 
 /// On other platforms we do not use CRC32. NOTE This can be confusing.
@@ -451,6 +463,19 @@ struct UInt256HashCRC32
     }
 };
 
+#elif defined(__s390x__) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+struct UInt256HashCRC32
+{
+    size_t operator()(UInt256 x) const
+    {
+        UInt64 crc = -1ULL;
+        crc = s390x_crc32(crc, x.items[UInt256::_impl::little(0)]);
+        crc = s390x_crc32(crc, x.items[UInt256::_impl::little(1)]);
+        crc = s390x_crc32(crc, x.items[UInt256::_impl::little(2)]);
+        crc = s390x_crc32(crc, x.items[UInt256::_impl::little(3)]);
+        return crc;
+    }
+};
 #else
 
 /// We do not need to use CRC32 on other platforms. NOTE This can be confusing.

--- a/src/Common/HashTable/StringHashTable.h
+++ b/src/Common/HashTable/StringHashTable.h
@@ -71,6 +71,28 @@ struct StringHashTableHash
         res = _mm_crc32_u64(res, key.c);
         return res;
     }
+#elif defined(__s390x__) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+    size_t ALWAYS_INLINE operator()(StringKey8 key) const
+    {
+        size_t res = -1ULL;
+        res = s390x_crc32(res, key);
+        return res;
+    }
+    size_t ALWAYS_INLINE operator()(StringKey16 key) const
+    {
+        size_t res = -1ULL;
+        res = s390x_crc32(res, key.items[UInt128::_impl::little(0)]);
+        res = s390x_crc32(res, key.items[UInt128::_impl::little(1)]);
+        return res;
+    }
+    size_t ALWAYS_INLINE operator()(StringKey24 key) const
+    {
+        size_t res = -1ULL;
+        res = s390x_crc32(res, key.a);
+        res = s390x_crc32(res, key.b);
+        res = s390x_crc32(res, key.c);
+        return res;
+    }
 #else
     size_t ALWAYS_INLINE operator()(StringKey8 key) const
     {

--- a/src/Common/benchmarks/integer_hash_tables_and_hashes.cpp
+++ b/src/Common/benchmarks/integer_hash_tables_and_hashes.cpp
@@ -188,12 +188,17 @@ namespace Hashes
     #include <nmmintrin.h>
     #endif
 
+    #if defined(__s390x__) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+    #include <crc32-s390x.h>
+    #endif
     struct CRC32Hash
     {
         size_t operator()(Key x) const
         {
     #ifdef __SSE4_2__
             return _mm_crc32_u64(-1ULL, x);
+    #elif defined(__s390x__) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+           return s390x_crc32(-1ULL, x);
     #else
             /// On other platforms we do not have CRC32. NOTE This can be confusing.
             return intHash64(x);

--- a/src/Interpreters/AggregationCommon.h
+++ b/src/Interpreters/AggregationCommon.h
@@ -90,7 +90,10 @@ void fillFixedBatch(size_t keys_size, const ColumnRawPtrs & key_columns, const S
             /// Note: here we violate strict aliasing.
             /// It should be ok as log as we do not reffer to any value from `out` before filling.
             const char * source = static_cast<const ColumnVectorHelper *>(column)->getRawDataBegin<sizeof(T)>();
-            T * dest = reinterpret_cast<T *>(reinterpret_cast<char *>(out.data()) + offset);
+            size_t offset_to = offset;
+            if constexpr (std::endian::native == std::endian::big)
+                offset_to = sizeof(Key) - sizeof(T) - offset;
+            T * dest = reinterpret_cast<T *>(reinterpret_cast<char *>(out.data()) + offset_to);
             fillFixedBatch<T, sizeof(Key) / sizeof(T)>(num_rows, reinterpret_cast<const T *>(source), dest);
             offset += sizeof(T);
         }

--- a/src/Interpreters/Aggregator.h
+++ b/src/Interpreters/Aggregator.h
@@ -512,7 +512,10 @@ struct AggregationMethodKeysFixed
             else
             {
                 size_t size = key_sizes[i];
-                observed_column->insertData(reinterpret_cast<const char *>(&key) + pos, size);
+                size_t offset_to = pos;
+                if constexpr (std::endian::native == std::endian::big)
+                   offset_to = sizeof(Key) - size - pos;
+                observed_column->insertData(reinterpret_cast<const char *>(&key) + offset_to, size);
                 pos += size;
             }
         }


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- fix packFixedBatch() on z/big-endian platform
- Include s390x_crc32() for hash option

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
