### PR TITLE
Add replica groups to Replicated database engine

### DIFF
--- a/docs/en/operations/server-configuration-parameters/settings.md
+++ b/docs/en/operations/server-configuration-parameters/settings.md
@@ -1330,6 +1330,23 @@ For more information, see the section [Creating replicated tables](../../engines
 <macros incl="macros" optional="true" />
 ```
 
+## replica_group_name {#replica_group_name}
+
+Replica group name for database Replicated.
+
+The cluster created by Replicated database will consist of replicas in the same group.
+DDL queries will only wail for the replicas in the same group.
+
+Empty by default.
+
+**Example**
+
+``` xml
+<replica_group_name>backups</replica_group_name>
+```
+
+Default value: ``.
+
 ## max_open_files {#max-open-files}
 
 The maximum number of open files.

--- a/docs/en/sql-reference/statements/system.md
+++ b/docs/en/sql-reference/statements/system.md
@@ -97,12 +97,12 @@ The fourth one is useful to remove metadata of dead replica when all other repli
 Dead replicas of `Replicated` databases can be dropped using following syntax:
 
 ``` sql
-SYSTEM DROP DATABASE REPLICA 'replica_name' [FROM SHARD 'shard_name'] FROM DATABASE database;
-SYSTEM DROP DATABASE REPLICA 'replica_name' [FROM SHARD 'shard_name'];
-SYSTEM DROP DATABASE REPLICA 'replica_name' [FROM SHARD 'shard_name'] FROM ZKPATH '/path/to/table/in/zk';
+SYSTEM DROP DATABASE REPLICA 'replica_name' [FROM SHARD 'shard_name'] [FROM GROUP 'group_name'] FROM DATABASE database;
+SYSTEM DROP DATABASE REPLICA 'replica_name' [FROM SHARD 'shard_name'] [FROM GROUP 'group_name'];
+SYSTEM DROP DATABASE REPLICA 'replica_name' [FROM SHARD 'shard_name'] [FROM GROUP 'group_name'] FROM ZKPATH '/path/to/table/in/zk';
 ```
 
-Similar to `SYSTEM DROP REPLICA`, but removes the `Replicated` database replica path from ZooKeeper when there's no database to run `DROP DATABASE`. Please note that it does not remove `ReplicatedMergeTree` replicas (so you may need `SYSTEM DROP REPLICA` as well). Shard and replica names are the names that were specified in `Replicated` engine arguments when creating the database. Also, these names can be obtained from `database_shard_name` and `database_replica_name` columns in `system.clusters`. If the `FROM SHARD` clause is missing, then `replica_name` must be a full replica name in `shard_name|replica_name` format.
+Similar to `SYSTEM DROP REPLICA`, but removes the `Replicated` database replica path from ZooKeeper when there's no database to run `DROP DATABASE`. Please note that it does not remove `ReplicatedMergeTree` replicas (so you may need `SYSTEM DROP REPLICA` as well). Shard and replica names are the names that were specified in `Replicated` engine arguments when creating the database. Also, these names can be obtained from `database_shard_name` and `database_replica_name` columns in `system.clusters`. Replica group name is the name defined by `replica_group_name` [setting](../../operations/server-configuration-parameters/settings.md#replica_group_name) in the server configuration. If the `FROM SHARD` clause is missing, then `replica_name` must be a full replica name in `shard_name|replica_name` format if replica groups are not used and in `shard_name|replica_name|group_name` otherwise. 
 
 ## DROP UNCOMPRESSED CACHE
 

--- a/programs/server/config.xml
+++ b/programs/server/config.xml
@@ -914,6 +914,15 @@
     </macros>
     -->
 
+    <!-- Replica group name for database Replicated.
+          The cluster created by Replicated database will consist of replicas in the same group.
+          DDL queries will only wail for the replicas in the same group.
+          Empty by default.
+    -->
+    <!--
+    <replica_group_name><replica_group_name>
+    -->
+
 
     <!-- Reloading interval for embedded dictionaries, in seconds. Default: 3600. -->
     <builtin_dictionaries_reload_interval>3600</builtin_dictionaries_reload_interval>

--- a/src/Databases/DatabaseReplicated.h
+++ b/src/Databases/DatabaseReplicated.h
@@ -54,11 +54,19 @@ public:
 
     void stopReplication() override;
 
+    struct NameParts
+    {
+        String shard;
+        String replica;
+        String replica_group;
+    };
+
     String getShardName() const { return shard_name; }
     String getReplicaName() const { return replica_name; }
+    String getReplicaGroupName() const { return replica_group_name; }
     String getFullReplicaName() const;
-    static String getFullReplicaName(const String & shard, const String & replica);
-    static std::pair<String, String> parseFullReplicaName(const String & name);
+    static String getFullReplicaName(const String & shard, const String & replica, const String & replica_group);
+    static NameParts parseFullReplicaName(const String & name);
 
     const String & getZooKeeperPath() const { return zookeeper_path; }
 
@@ -80,7 +88,7 @@ public:
 
     bool shouldReplicateQuery(const ContextPtr & query_context, const ASTPtr & query_ptr) const override;
 
-    static void dropReplica(DatabaseReplicated * database, const String & database_zookeeper_path, const String & shard, const String & replica);
+    static void dropReplica(DatabaseReplicated * database, const String & database_zookeeper_path, const String & shard, const String & replica, const String & replica_group);
 
     std::vector<UInt8> tryGetAreReplicasActive(const ClusterPtr & cluster_) const;
 
@@ -101,7 +109,6 @@ private:
     } cluster_auth_info;
 
     void fillClusterAuthInfo(String collection_name, const Poco::Util::AbstractConfiguration & config);
-    String getClusterGroup(const Poco::Util::AbstractConfiguration & config);
 
     void checkQueryValid(const ASTPtr & query, ContextPtr query_context) const;
 
@@ -127,8 +134,8 @@ private:
     String zookeeper_path;
     String shard_name;
     String replica_name;
+    String replica_group_name;
     String replica_path;
-    String cluster_path;
     DatabaseReplicatedSettings db_settings;
 
     zkutil::ZooKeeperPtr getZooKeeper() const;

--- a/src/Databases/DatabaseReplicated.h
+++ b/src/Databases/DatabaseReplicated.h
@@ -101,6 +101,7 @@ private:
     } cluster_auth_info;
 
     void fillClusterAuthInfo(String collection_name, const Poco::Util::AbstractConfiguration & config);
+    String getClusterGroup(const Poco::Util::AbstractConfiguration & config);
 
     void checkQueryValid(const ASTPtr & query, ContextPtr query_context) const;
 
@@ -127,6 +128,7 @@ private:
     String shard_name;
     String replica_name;
     String replica_path;
+    String cluster_path;
     DatabaseReplicatedSettings db_settings;
 
     zkutil::ZooKeeperPtr getZooKeeper() const;

--- a/src/Interpreters/Cluster.cpp
+++ b/src/Interpreters/Cluster.cpp
@@ -159,6 +159,7 @@ Cluster::Address::Address(
     host_name = parsed_host_port.first;
     database_shard_name = info.shard_name;
     database_replica_name = info.replica_name;
+    database_replica_group_name = info.replica_group_name;
     port = parsed_host_port.second;
     secure = params.secure ? Protocol::Secure::Enable : Protocol::Secure::Disable;
     priority = params.priority;
@@ -518,7 +519,7 @@ Cluster::Cluster(
         Addresses current;
         for (const auto & replica : shard)
             current.emplace_back(
-                DatabaseReplicaInfo{replica, "", ""},
+                DatabaseReplicaInfo{replica, "", "", ""},
                 params,
                 current_shard_num,
                 current.size() + 1);

--- a/src/Interpreters/Cluster.h
+++ b/src/Interpreters/Cluster.h
@@ -35,6 +35,7 @@ struct DatabaseReplicaInfo
     String hostname;
     String shard_name;
     String replica_name;
+    String replica_group_name;
 };
 
 struct ClusterConnectionParameters
@@ -111,6 +112,7 @@ public:
         String host_name;
         String database_shard_name;
         String database_replica_name;
+        String database_replica_group_name;
         UInt16 port{0};
         String user;
         String password;

--- a/src/Interpreters/InterpreterSystemQuery.cpp
+++ b/src/Interpreters/InterpreterSystemQuery.cpp
@@ -844,7 +844,7 @@ void InterpreterSystemQuery::dropDatabaseReplica(ASTSystemQuery & query)
         if (!query_.replica_zk_path.empty() && fs::path(replicated->getZooKeeperPath()) != fs::path(query_.replica_zk_path))
             return;
         String full_replica_name = query_.shard.empty() ? query_.replica
-                                                        : DatabaseReplicated::getFullReplicaName(query_.shard, query_.replica);
+                                                        : DatabaseReplicated::getFullReplicaName(query_.shard, query_.replica, query_.replica_group);
         if (replicated->getFullReplicaName() != full_replica_name)
             return;
 
@@ -860,7 +860,7 @@ void InterpreterSystemQuery::dropDatabaseReplica(ASTSystemQuery & query)
         if (auto * replicated = dynamic_cast<DatabaseReplicated *>(database.get()))
         {
             check_not_local_replica(replicated, query);
-            DatabaseReplicated::dropReplica(replicated, replicated->getZooKeeperPath(), query.shard, query.replica);
+            DatabaseReplicated::dropReplica(replicated, replicated->getZooKeeperPath(), query.shard, query.replica, query.replica_group);
         }
         else
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "Database {} is not Replicated, cannot drop replica", query.getDatabase());
@@ -885,7 +885,7 @@ void InterpreterSystemQuery::dropDatabaseReplica(ASTSystemQuery & query)
             }
 
             check_not_local_replica(replicated, query);
-            DatabaseReplicated::dropReplica(replicated, replicated->getZooKeeperPath(), query.shard, query.replica);
+            DatabaseReplicated::dropReplica(replicated, replicated->getZooKeeperPath(), query.shard, query.replica, query.replica_group);
             LOG_TRACE(log, "Dropped replica {} of Replicated database {}", query.replica, backQuoteIfNeed(database->getDatabaseName()));
         }
     }
@@ -898,7 +898,7 @@ void InterpreterSystemQuery::dropDatabaseReplica(ASTSystemQuery & query)
             if (auto * replicated = dynamic_cast<DatabaseReplicated *>(elem.second.get()))
                 check_not_local_replica(replicated, query);
 
-        DatabaseReplicated::dropReplica(nullptr, query.replica_zk_path, query.shard, query.replica);
+        DatabaseReplicated::dropReplica(nullptr, query.replica_zk_path, query.shard, query.replica, query.replica_group);
         LOG_INFO(log, "Dropped replica {} of Replicated database with path {}", query.replica, query.replica_zk_path);
     }
     else

--- a/src/Interpreters/executeDDLQueryOnCluster.cpp
+++ b/src/Interpreters/executeDDLQueryOnCluster.cpp
@@ -357,9 +357,9 @@ Chunk DDLQueryStatusSource::generateChunkWithUnfinishedHosts() const
         size_t num = 0;
         if (is_replicated_database)
         {
-            auto [shard, replica] = DatabaseReplicated::parseFullReplicaName(host_id);
-            columns[num++]->insert(shard);
-            columns[num++]->insert(replica);
+            auto parts = DatabaseReplicated::parseFullReplicaName(host_id);
+            columns[num++]->insert(parts.shard);
+            columns[num++]->insert(parts.replica);
             if (active_hosts_set.contains(host_id))
                 columns[num++]->insert(IN_PROGRESS);
             else
@@ -511,9 +511,9 @@ Chunk DDLQueryStatusSource::generate()
             {
                 if (status.code != 0)
                     throw Exception(ErrorCodes::LOGICAL_ERROR, "There was an error on {}: {} (probably it's a bug)", host_id, status.message);
-                auto [shard, replica] = DatabaseReplicated::parseFullReplicaName(host_id);
-                columns[num++]->insert(shard);
-                columns[num++]->insert(replica);
+                auto parts = DatabaseReplicated::parseFullReplicaName(host_id);
+                columns[num++]->insert(parts.shard);
+                columns[num++]->insert(parts.replica);
                 columns[num++]->insert(OK);
             }
             else

--- a/src/Parsers/ASTSystemQuery.h
+++ b/src/Parsers/ASTSystemQuery.h
@@ -101,6 +101,7 @@ public:
     String replica;
     String shard;
     String replica_zk_path;
+    String replica_group;
     bool is_drop_whole_replica{};
     String storage_policy;
     String volume;

--- a/src/Parsers/ParserSystemQuery.cpp
+++ b/src/Parsers/ParserSystemQuery.cpp
@@ -165,6 +165,14 @@ enum class SystemQueryTargetType
         if (!ParserStringLiteral{}.parse(pos, ast, expected))
             return false;
         res->shard = ast->as<ASTLiteral &>().value.safeGet<String>();
+
+        if (database && ParserKeyword{"FROM GROUP"}.ignore(pos, expected))
+        {
+            ASTPtr group_ast;
+            if (!ParserStringLiteral{}.parse(pos, group_ast, expected))
+                return false;
+            res->replica_group = group_ast->as<ASTLiteral &>().value.safeGet<String>();
+        }
     }
 
     if (ParserKeyword{"FROM"}.ignore(pos, expected))

--- a/tests/integration/test_replicated_database_cluster_groups/configs/backup_group.xml
+++ b/tests/integration/test_replicated_database_cluster_groups/configs/backup_group.xml
@@ -1,3 +1,3 @@
 <clickhouse>
-    <database_replicated_cluster_group>backups</database_replicated_cluster_group>
+    <replica_group_name>backups</replica_group_name>
 </clickhouse>

--- a/tests/integration/test_replicated_database_cluster_groups/configs/backup_group.xml
+++ b/tests/integration/test_replicated_database_cluster_groups/configs/backup_group.xml
@@ -1,0 +1,3 @@
+<clickhouse>
+    <database_replicated_cluster_group>backups</database_replicated_cluster_group>
+</clickhouse>

--- a/tests/integration/test_replicated_database_cluster_groups/configs/settings.xml
+++ b/tests/integration/test_replicated_database_cluster_groups/configs/settings.xml
@@ -1,0 +1,14 @@
+<clickhouse>
+    <profiles>
+        <default>
+            <allow_drop_detached>1</allow_drop_detached>
+            <allow_experimental_database_replicated>1</allow_experimental_database_replicated>
+            <allow_experimental_alter_materialized_view_structure>1</allow_experimental_alter_materialized_view_structure>
+        </default>
+    </profiles>
+    <users>
+        <default>
+            <profile>default</profile>
+        </default>
+    </users>
+</clickhouse>

--- a/tests/integration/test_replicated_database_cluster_groups/test.py
+++ b/tests/integration/test_replicated_database_cluster_groups/test.py
@@ -1,0 +1,116 @@
+import re
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+from helpers.test_tools import assert_eq_with_retry
+
+cluster = ClickHouseCluster(__file__)
+
+main_node_1 = cluster.add_instance(
+    "main_node_1",
+    user_configs=["configs/settings.xml"],
+    with_zookeeper=True,
+    stay_alive=True,
+    macros={"shard": 1, "replica": 1},
+)
+main_node_2 = cluster.add_instance(
+    "main_node_2",
+    user_configs=["configs/settings.xml"],
+    with_zookeeper=True,
+    stay_alive=True,
+    macros={"shard": 1, "replica": 2},
+)
+backup_node_1 = cluster.add_instance(
+    "backup_node_1",
+    main_configs=["configs/backup_group.xml"],
+    user_configs=["configs/settings.xml"],
+    with_zookeeper=True,
+    stay_alive=True,
+    macros={"shard": 1, "replica": 3},
+)
+backup_node_2 = cluster.add_instance(
+    "backup_node_2",
+    main_configs=["configs/backup_group.xml"],
+    user_configs=["configs/settings.xml"],
+    with_zookeeper=True,
+    stay_alive=True,
+    macros={"shard": 1, "replica": 4},
+)
+
+all_nodes = [
+    main_node_1,
+    main_node_2,
+    backup_node_1,
+    backup_node_2,
+]
+
+uuid_regex = re.compile("[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}")
+
+
+def assert_create_query(nodes, table_name, expected):
+    replace_uuid = lambda x: re.sub(uuid_regex, "uuid", x)
+    query = "show create table {}".format(table_name)
+    for node in nodes:
+        assert_eq_with_retry(node, query, expected, get_result=replace_uuid)
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+        yield cluster
+
+    finally:
+        cluster.shutdown()
+
+
+def test_cluster_groups(started_cluster):
+    for node in all_nodes:
+        node.query(
+            f"CREATE DATABASE cluster_groups ENGINE = Replicated('/test/cluster_groups', '{node.macros['shard']}', '{node.macros['replica']}');"
+        )
+
+    # 1. system.clusters
+
+    query = "SELECT host_name from system.clusters WHERE cluster = 'cluster_groups' ORDER BY host_name"
+    expected_main = "main_node_1\nmain_node_2\n"
+    expected_backup = "backup_node_1\nbackup_node_2\n"
+
+    for node in [main_node_1, main_node_2]:
+        assert_eq_with_retry(node, query, expected_main)
+
+    for node in [backup_node_1, backup_node_2]:
+        assert_eq_with_retry(node, query, expected_backup)
+
+    # 2. Query execution depends only on your cluster group
+
+    backup_node_1.stop_clickhouse()
+    backup_node_2.stop_clickhouse()
+
+    # OK
+    main_node_1.query(
+        "CREATE TABLE cluster_groups.table_1 (d Date, k UInt64) ENGINE=ReplicatedMergeTree ORDER BY k PARTITION BY toYYYYMM(d);"
+    )
+
+    # Exception
+    main_node_2.stop_clickhouse()
+    settings = {"distributed_ddl_task_timeout": 5}
+    assert (
+        "There are 1 unfinished hosts (0 of them are currently active)"
+        in main_node_1.query_and_get_error(
+            "CREATE TABLE cluster_groups.table_2 (d Date, k UInt64) ENGINE=ReplicatedMergeTree ORDER BY k PARTITION BY toYYYYMM(d);",
+            settings=settings,
+        )
+    )
+
+    # 3. After start both groups are synced
+
+    backup_node_1.start_clickhouse()
+    backup_node_2.start_clickhouse()
+    main_node_2.start_clickhouse()
+
+    expected_1 = "CREATE TABLE cluster_groups.table_1\\n(\\n    `d` Date,\\n    `k` UInt64\\n)\\nENGINE = ReplicatedMergeTree(\\'/clickhouse/tables/{uuid}/{shard}\\', \\'{replica}\\')\\nPARTITION BY toYYYYMM(d)\\nORDER BY k\\nSETTINGS index_granularity = 8192"
+    expected_2 = "CREATE TABLE cluster_groups.table_2\\n(\\n    `d` Date,\\n    `k` UInt64\\n)\\nENGINE = ReplicatedMergeTree(\\'/clickhouse/tables/{uuid}/{shard}\\', \\'{replica}\\')\\nPARTITION BY toYYYYMM(d)\\nORDER BY k\\nSETTINGS index_granularity = 8192"
+
+    assert_create_query(all_nodes, "cluster_groups.table_1", expected_1)
+    assert_create_query(all_nodes, "cluster_groups.table_2", expected_2)


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add replica groups to the Replicated database engine. Closes https://github.com/ClickHouse/ClickHouse/issues/53620

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)