### PR TITLE
Update settings_profile_elements.md

### DIFF
--- a/docs/en/operations/system-tables/settings_profile_elements.md
+++ b/docs/en/operations/system-tables/settings_profile_elements.md
@@ -26,6 +26,6 @@ Columns:
 
 - `max` ([Nullable](../../sql-reference/data-types/nullable.md)([String](../../sql-reference/data-types/string.md))) — The maximum value of the setting. NULL if not set.
 
-- `readonly` ([Nullable](../../sql-reference/data-types/nullable.md)([UInt8](../../sql-reference/data-types/int-uint.md#uint-ranges))) — Profile that allows only read queries.
+- `writability` ([Nullable](../../sql-reference/data-types/nullable.md)([Enum8](../../sql-reference/data-types/enum.md)('WRITABLE' = 0, 'CONST' = 1, 'CHANGEABLE_IN_READONLY' = 2))) — Sets the settings constraint writability kind.
 
 - `inherit_profile` ([Nullable](../../sql-reference/data-types/nullable.md)([String](../../sql-reference/data-types/string.md))) — A parent profile for this setting profile. `NULL` if not set. Setting profile will inherit all the settings' values and constraints (`min`, `max`, `readonly`) from its parent profiles.

--- a/utils/check-style/aspell-ignore/en/aspell-dict.txt
+++ b/utils/check-style/aspell-ignore/en/aspell-dict.txt
@@ -2564,6 +2564,7 @@ wordShingleSimHashCaseInsensitive
 wordShingleSimHashCaseInsensitiveUTF
 wordShingleSimHashUTF
 wordshingleMinHash
+writability
 wrt
 xcode
 xeus


### PR DESCRIPTION
Updating the column name `readonly` for `writability` according to the current state of this table.

Example: https://github.com/ClickHouse/ClickHouse/blob/a0d25fdd543eb61bf8a70d12549565794d334ffd/tests/queries/0_stateless/02117_show_create_table_system.reference#L1021

### Changelog category (leave one):

- Documentation (changelog entry is not required)