### PR TITLE
Small fine-tune for using ColumnNullable pointer

### DIFF
--- a/src/Processors/Transforms/MergeJoinTransform.cpp
+++ b/src/Processors/Transforms/MergeJoinTransform.cpp
@@ -52,12 +52,12 @@ int nullableCompareAt(const IColumn & left_column, const IColumn & right_column,
 
         if (left_nullable && right_nullable)
         {
-            int res = left_column.compareAt(lhs_pos, rhs_pos, right_column, null_direction_hint);
+            int res = left_nullable->compareAt(lhs_pos, rhs_pos, right_column, null_direction_hint);
             if (res)
                 return res;
 
             /// NULL != NULL case
-            if (left_column.isNullAt(lhs_pos))
+            if (left_nullable->isNullAt(lhs_pos))
                 return null_direction_hint;
 
             return 0;
@@ -68,7 +68,7 @@ int nullableCompareAt(const IColumn & left_column, const IColumn & right_column,
     {
         if (const auto * left_nullable = checkAndGetColumn<ColumnNullable>(left_column))
         {
-            if (left_column.isNullAt(lhs_pos))
+            if (left_nullable->isNullAt(lhs_pos))
                 return null_direction_hint;
             return left_nullable->getNestedColumn().compareAt(lhs_pos, rhs_pos, right_column, null_direction_hint);
         }
@@ -78,7 +78,7 @@ int nullableCompareAt(const IColumn & left_column, const IColumn & right_column,
     {
         if (const auto * right_nullable = checkAndGetColumn<ColumnNullable>(right_column))
         {
-            if (right_column.isNullAt(rhs_pos))
+            if (right_nullable->isNullAt(rhs_pos))
                 return -null_direction_hint;
             return left_column.compareAt(lhs_pos, rhs_pos, right_nullable->getNestedColumn(), null_direction_hint);
         }


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
As ColumnNullable is final class, then prefer using the ColumnNullable pointer than IColumn refereence.

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
