### PR TITLE
Cleanup: unnecessary SelectQueryInfo usage around distributed

### DIFF
--- a/src/Interpreters/ClusterProxy/executeQuery.cpp
+++ b/src/Interpreters/ClusterProxy/executeQuery.cpp
@@ -38,7 +38,7 @@ ContextMutablePtr updateSettingsForCluster(bool interserver_mode,
     ContextPtr context,
     const Settings & settings,
     const StorageID & main_table,
-    const SelectQueryInfo * query_info,
+    const ASTPtr & additional_filter_ast,
     Poco::Logger * log)
 {
     Settings new_settings = settings;
@@ -115,11 +115,11 @@ ContextMutablePtr updateSettingsForCluster(bool interserver_mode,
     ///
     /// Here we don't try to analyze setting again. In case if query_info->additional_filter_ast is not empty, some filter was applied.
     /// It's just easier to add this filter for a source table.
-    if (query_info && query_info->additional_filter_ast)
+    if (additional_filter_ast)
     {
         Tuple tuple;
         tuple.push_back(main_table.getShortName());
-        tuple.push_back(queryToString(query_info->additional_filter_ast));
+        tuple.push_back(queryToString(additional_filter_ast));
         new_settings.additional_table_filters.value.push_back(std::move(tuple));
     }
 
@@ -174,7 +174,8 @@ void executeQuery(
     std::vector<QueryPlanPtr> plans;
     SelectStreamFactory::Shards remote_shards;
 
-    auto new_context = updateSettingsForCluster(!query_info.getCluster()->getSecret().empty(), context, settings, main_table, &query_info, log);
+    auto new_context = updateSettingsForCluster(!not_optimized_cluster->getSecret().empty(), context, settings,
+                                                main_table, query_info.additional_filter_ast, log);
     new_context->increaseDistributedDepth();
 
     size_t shards = query_info.getCluster()->getShardCount();
@@ -269,7 +270,7 @@ void executeQueryWithParallelReplicas(
     SelectStreamFactory & stream_factory,
     const ASTPtr & query_ast,
     ContextPtr context,
-    const SelectQueryInfo & query_info,
+    std::shared_ptr<const StorageLimitsList> storage_limits,
     const ClusterPtr & not_optimized_cluster)
 {
     const auto & settings = context->getSettingsRef();
@@ -333,7 +334,7 @@ void executeQueryWithParallelReplicas(
         std::move(scalars),
         std::move(external_tables),
         &Poco::Logger::get("ReadFromParallelRemoteReplicasStep"),
-        query_info.storage_limits);
+        std::move(storage_limits));
 
     query_plan.addStep(std::move(read_from_remote));
 }

--- a/src/Interpreters/ClusterProxy/executeQuery.cpp
+++ b/src/Interpreters/ClusterProxy/executeQuery.cpp
@@ -38,7 +38,7 @@ ContextMutablePtr updateSettingsForCluster(bool interserver_mode,
     ContextPtr context,
     const Settings & settings,
     const StorageID & main_table,
-    const ASTPtr & additional_filter_ast,
+    ASTPtr additional_filter_ast,
     Poco::Logger * log)
 {
     Settings new_settings = settings;

--- a/src/Interpreters/ClusterProxy/executeQuery.h
+++ b/src/Interpreters/ClusterProxy/executeQuery.h
@@ -20,6 +20,9 @@ using ExpressionActionsPtr = std::shared_ptr<ExpressionActions>;
 
 struct StorageID;
 
+struct StorageLimits;
+using StorageLimitsList = std::list<StorageLimits>;
+
 namespace ClusterProxy
 {
 
@@ -66,7 +69,7 @@ void executeQueryWithParallelReplicas(
     SelectStreamFactory & stream_factory,
     const ASTPtr & query_ast,
     ContextPtr context,
-    const SelectQueryInfo & query_info,
+    std::shared_ptr<const StorageLimitsList> storage_limits,
     const ClusterPtr & not_optimized_cluster);
 }
 

--- a/src/Interpreters/ClusterProxy/executeQuery.h
+++ b/src/Interpreters/ClusterProxy/executeQuery.h
@@ -41,7 +41,7 @@ ContextMutablePtr updateSettingsForCluster(bool interserver_mode,
     ContextPtr context,
     const Settings & settings,
     const StorageID & main_table,
-    const SelectQueryInfo * query_info = nullptr,
+    ASTPtr additional_filter_ast = nullptr,
     Poco::Logger * log = nullptr);
 
 using AdditionalShardFilterGenerator = std::function<ASTPtr(uint64_t)>;

--- a/src/Storages/StorageDistributed.cpp
+++ b/src/Storages/StorageDistributed.cpp
@@ -75,7 +75,6 @@
 #include <Interpreters/RequiredSourceColumnsVisitor.h>
 #include <Interpreters/getCustomKeyFilterForParallelReplicas.h>
 #include <Interpreters/getHeaderForProcessingStage.h>
-#include <Interpreters/TreeRewriter.h>
 
 #include <Functions/IFunction.h>
 #include <Functions/FunctionFactory.h>

--- a/src/Storages/StorageDistributed.cpp
+++ b/src/Storages/StorageDistributed.cpp
@@ -1316,7 +1316,7 @@ ClusterPtr StorageDistributed::getOptimizedCluster(ContextPtr local_context, con
 
     if (has_sharding_key && sharding_key_is_usable)
     {
-        ClusterPtr optimized = skipUnusedShards(cluster, select, syntax_analyzer_result,  storage_snapshot, local_context);
+        ClusterPtr optimized = skipUnusedShards(cluster, select, syntax_analyzer_result, storage_snapshot, local_context);
         if (optimized)
             return optimized;
     }

--- a/src/Storages/StorageDistributed.cpp
+++ b/src/Storages/StorageDistributed.cpp
@@ -75,6 +75,7 @@
 #include <Interpreters/RequiredSourceColumnsVisitor.h>
 #include <Interpreters/getCustomKeyFilterForParallelReplicas.h>
 #include <Interpreters/getHeaderForProcessingStage.h>
+#include <Interpreters/TreeRewriter.h>
 
 #include <Functions/IFunction.h>
 #include <Functions/FunctionFactory.h>
@@ -437,7 +438,9 @@ QueryProcessingStage::Enum StorageDistributed::getQueryProcessingStage(
         {
             /// Always calculate optimized cluster here, to avoid conditions during read()
             /// (Anyway it will be calculated in the read())
-            ClusterPtr optimized_cluster = getOptimizedCluster(local_context, storage_snapshot, query_info);
+            const auto & select = query_info.query->as<const ASTSelectQuery &>();
+            auto syntax_analyzer_result = query_info.syntax_analyzer_result;
+            ClusterPtr optimized_cluster = getOptimizedCluster(local_context, storage_snapshot, select, syntax_analyzer_result);
             if (optimized_cluster)
             {
                 LOG_DEBUG(log, "Skipping irrelevant shards - the query will be sent to the following shards of the cluster (shard numbers): {}",
@@ -1303,8 +1306,8 @@ ClusterPtr StorageDistributed::getCluster() const
     return owned_cluster ? owned_cluster : getContext()->getCluster(cluster_name);
 }
 
-ClusterPtr StorageDistributed::getOptimizedCluster(
-    ContextPtr local_context, const StorageSnapshotPtr & storage_snapshot, const SelectQueryInfo & query_info) const
+ClusterPtr StorageDistributed::getOptimizedCluster(ContextPtr local_context, const StorageSnapshotPtr & storage_snapshot,
+                                                   const ASTSelectQuery & select, const TreeRewriterResultPtr & syntax_analyzer_result) const
 {
     ClusterPtr cluster = getCluster();
     const Settings & settings = local_context->getSettingsRef();
@@ -1313,7 +1316,7 @@ ClusterPtr StorageDistributed::getOptimizedCluster(
 
     if (has_sharding_key && sharding_key_is_usable)
     {
-        ClusterPtr optimized = skipUnusedShards(cluster, query_info, storage_snapshot, local_context);
+        ClusterPtr optimized = skipUnusedShards(cluster, select, syntax_analyzer_result,  storage_snapshot, local_context);
         if (optimized)
             return optimized;
     }
@@ -1362,16 +1365,16 @@ IColumn::Selector StorageDistributed::createSelector(const ClusterPtr cluster, c
 /// using constraints from "PREWHERE" and "WHERE" conditions, otherwise returns `nullptr`
 ClusterPtr StorageDistributed::skipUnusedShards(
     ClusterPtr cluster,
-    const SelectQueryInfo & query_info,
+    const ASTSelectQuery & select,
+    const TreeRewriterResultPtr & syntax_analyzer_result,
     const StorageSnapshotPtr & storage_snapshot,
     ContextPtr local_context) const
 {
-    const auto & select = query_info.query->as<ASTSelectQuery &>();
     if (!select.prewhere() && !select.where())
         return nullptr;
 
     /// FIXME: support analyzer
-    if (!query_info.syntax_analyzer_result)
+    if (!syntax_analyzer_result)
         return nullptr;
 
     ASTPtr condition_ast;
@@ -1380,7 +1383,7 @@ ClusterPtr StorageDistributed::skipUnusedShards(
     {
         ASTPtr select_without_join_ptr = select.clone();
         ASTSelectQuery select_without_join = select_without_join_ptr->as<ASTSelectQuery &>();
-        TreeRewriterResult analyzer_result_without_join = *query_info.syntax_analyzer_result;
+        TreeRewriterResult analyzer_result_without_join = *syntax_analyzer_result;
 
         removeJoin(select_without_join, analyzer_result_without_join, local_context);
         if (!select_without_join.prewhere() && !select_without_join.where())

--- a/src/Storages/StorageDistributed.h
+++ b/src/Storages/StorageDistributed.h
@@ -28,6 +28,9 @@ using DiskPtr = std::shared_ptr<IDisk>;
 class ExpressionActions;
 using ExpressionActionsPtr = std::shared_ptr<ExpressionActions>;
 
+struct TreeRewriterResult;
+using TreeRewriterResultPtr = std::shared_ptr<const TreeRewriterResult>;
+
 /** A distributed table that resides on multiple servers.
   * Uses data from the specified database and tables on each server.
   *
@@ -182,10 +185,12 @@ private:
     /// Apply the following settings:
     /// - optimize_skip_unused_shards
     /// - force_optimize_skip_unused_shards
-    ClusterPtr getOptimizedCluster(ContextPtr, const StorageSnapshotPtr & storage_snapshot, const SelectQueryInfo & query_info) const;
+    ClusterPtr getOptimizedCluster(ContextPtr local_context, const StorageSnapshotPtr & storage_snapshot,
+                                   const ASTSelectQuery & select, const TreeRewriterResultPtr & syntax_analyzer_result) const;
 
-    ClusterPtr skipUnusedShards(
-        ClusterPtr cluster, const SelectQueryInfo & query_info, const StorageSnapshotPtr & storage_snapshot, ContextPtr context) const;
+   ClusterPtr skipUnusedShards(
+        ClusterPtr cluster, const ASTSelectQuery & select, const TreeRewriterResultPtr & syntax_analyzer_result,
+        const StorageSnapshotPtr & storage_snapshot, ContextPtr context) const;
 
     /// This method returns optimal query processing stage.
     ///

--- a/src/Storages/StorageDistributed.h
+++ b/src/Storages/StorageDistributed.h
@@ -188,9 +188,8 @@ private:
     ClusterPtr getOptimizedCluster(ContextPtr local_context, const StorageSnapshotPtr & storage_snapshot,
                                    const ASTSelectQuery & select, const TreeRewriterResultPtr & syntax_analyzer_result) const;
 
-   ClusterPtr skipUnusedShards(
-        ClusterPtr cluster, const ASTSelectQuery & select, const TreeRewriterResultPtr & syntax_analyzer_result,
-        const StorageSnapshotPtr & storage_snapshot, ContextPtr context) const;
+   ClusterPtr skipUnusedShards(ClusterPtr cluster, const ASTSelectQuery & select, const TreeRewriterResultPtr & syntax_analyzer_result,
+                               const StorageSnapshotPtr & storage_snapshot, ContextPtr context) const;
 
     /// This method returns optimal query processing stage.
     ///

--- a/src/Storages/StorageDistributed.h
+++ b/src/Storages/StorageDistributed.h
@@ -185,11 +185,18 @@ private:
     /// Apply the following settings:
     /// - optimize_skip_unused_shards
     /// - force_optimize_skip_unused_shards
-    ClusterPtr getOptimizedCluster(ContextPtr local_context, const StorageSnapshotPtr & storage_snapshot,
-                                   const ASTSelectQuery & select, const TreeRewriterResultPtr & syntax_analyzer_result) const;
+    ClusterPtr getOptimizedCluster(
+        ContextPtr local_context,
+        const StorageSnapshotPtr & storage_snapshot,
+        const ASTSelectQuery & select,
+        const TreeRewriterResultPtr & syntax_analyzer_result) const;
 
-   ClusterPtr skipUnusedShards(ClusterPtr cluster, const ASTSelectQuery & select, const TreeRewriterResultPtr & syntax_analyzer_result,
-                               const StorageSnapshotPtr & storage_snapshot, ContextPtr context) const;
+    ClusterPtr skipUnusedShards(
+        ClusterPtr cluster,
+        const ASTSelectQuery & select,
+        const TreeRewriterResultPtr & syntax_analyzer_result,
+        const StorageSnapshotPtr & storage_snapshot,
+        ContextPtr context) const;
 
     /// This method returns optimal query processing stage.
     ///

--- a/src/Storages/StorageMergeTree.cpp
+++ b/src/Storages/StorageMergeTree.cpp
@@ -239,7 +239,7 @@ void StorageMergeTree::read(
         ClusterProxy::executeQueryWithParallelReplicas(
             query_plan, getStorageID(), /*remove_table_function_ptr*/ nullptr,
             select_stream_factory, modified_query_ast,
-            local_context, query_info, cluster);
+            local_context, query_info.storage_limits, cluster);
     }
     else
     {

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -5190,7 +5190,7 @@ void StorageReplicatedMergeTree::readParallelReplicasImpl(
         query_plan, getStorageID(),
         /* table_func_ptr= */ nullptr,
         select_stream_factory, modified_query_ast,
-        local_context, query_info, parallel_replicas_cluster);
+        local_context, query_info.storage_limits, parallel_replicas_cluster);
 }
 
 void StorageReplicatedMergeTree::readLocalImpl(


### PR DESCRIPTION
Remove unnecessary `SelectQueryInfo` usage which fogs functions dependencies

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
