### PR TITLE
Support renameTable for DatabaseMemory

### DIFF
--- a/src/Databases/DatabaseMemory.h
+++ b/src/Databases/DatabaseMemory.h
@@ -34,6 +34,14 @@ public:
         const String & table_name,
         bool sync) override;
 
+    void renameTable(
+        ContextPtr local_context,
+        const String & table_name,
+        IDatabase & to_database,
+        const String & to_table_name,
+        bool exchange,
+        bool dictionary) override;
+
     ASTPtr getCreateTableQueryImpl(const String & name, ContextPtr context, bool throw_on_error) const override;
     ASTPtr getCreateDatabaseQuery() const override;
 

--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -1491,9 +1491,9 @@ BlockIO InterpreterCreateQuery::doCreateOrReplaceTable(ASTCreateQuery & create,
 
     {
         auto database = DatabaseCatalog::instance().getDatabase(create.getDatabase());
-        if (database->getUUID() == UUIDHelpers::Nil)
+        if (database->getUUID() == UUIDHelpers::Nil && database->getEngineName() != "Memory")
             throw Exception(ErrorCodes::INCORRECT_QUERY,
-                            "{} query is supported only for Atomic databases",
+                            "{} query is supported only for Atomic and Memory databases",
                             create.create_or_replace ? "CREATE OR REPLACE TABLE" : "REPLACE TABLE");
 
 

--- a/tests/queries/0_stateless/02900_create_or_replace_in_memory_database.reference
+++ b/tests/queries/0_stateless/02900_create_or_replace_in_memory_database.reference
@@ -1,0 +1,10 @@
+CREATE VIEW test_2900_db.t\n(\n    `number` UInt64\n) AS\nSELECT number\nFROM system.numbers
+CREATE VIEW test_2900_db.t\n(\n    `next_number` UInt64\n) AS\nSELECT number + 1 AS next_number\nFROM system.numbers
+t1
+CREATE TABLE test_2900_db.t1\n(\n    `n` UInt64,\n    `s` String\n)\nENGINE = MergeTree\nORDER BY n\nSETTINGS index_granularity = 8192
+t1
+CREATE TABLE test_2900_db.t1\n(\n    `n` UInt64,\n    `s` Nullable(String)\n)\nENGINE = MergeTree\nORDER BY n\nSETTINGS index_granularity = 8192
+2	\N
+t1
+CREATE TABLE test_2900_db.t1\n(\n    `n` UInt64\n)\nENGINE = MergeTree\nORDER BY n\nSETTINGS index_granularity = 8192
+3

--- a/tests/queries/0_stateless/02900_create_or_replace_in_memory_database.sql
+++ b/tests/queries/0_stateless/02900_create_or_replace_in_memory_database.sql
@@ -1,0 +1,37 @@
+-- Tags: no-parallel
+
+DROP DATABASE IF EXISTS test_2900_db;
+CREATE DATABASE test_2900_db ENGINE=Memory;
+
+DROP TABLE IF EXISTS test_2900_db.t;
+
+CREATE OR REPLACE VIEW test_2900_db.t (number UInt64) AS SELECT number FROM system.numbers;
+SHOW CREATE TABLE test_2900_db.t;
+
+CREATE OR REPLACE VIEW test_2900_db.t AS SELECT number+1 AS next_number FROM system.numbers;
+SHOW CREATE TABLE test_2900_db.t;
+
+DROP TABLE test_2900_db.t;
+
+drop table if exists test_2900_db.t1;
+
+create or replace table test_2900_db.t1 (n UInt64, s String) engine=MergeTree order by n;
+show tables from test_2900_db;
+show create table test_2900_db.t1;
+
+insert into test_2900_db.t1 values (1, 'test');
+create or replace table test_2900_db.t1 (n UInt64, s Nullable(String)) engine=MergeTree order by n;
+insert into test_2900_db.t1 values (2, null);
+show tables from test_2900_db;
+show create table test_2900_db.t1;
+select * from test_2900_db.t1;
+
+replace table test_2900_db.t1 (n UInt64) engine=MergeTree order by n;
+insert into test_2900_db.t1 values (3);
+show tables from test_2900_db;
+show create table test_2900_db.t1;
+select * from test_2900_db.t1;
+
+drop table test_2900_db.t1;
+
+drop database test_2900_db;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Allow to RENAME/REPLACE/EXCHANGE tables between DatabaseMemory. 

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
