### PR TITLE
Correct default value for parts_to_delay_insert

### DIFF
--- a/docs/en/operations/settings/merge-tree-settings.md
+++ b/docs/en/operations/settings/merge-tree-settings.md
@@ -71,7 +71,7 @@ Possible values:
 
 - Any positive integer.
 
-Default value: 150.
+Default value: 1000.
 
 ClickHouse artificially executes `INSERT` longer (adds ‘sleep’) so that the background merge process can merge parts faster than they are added.
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Documentation (changelog entry is not required)

One of my colleagues pointed out the documentation here is out of date. The default for `parts_to_delay_insert` has changed to 1000 (see https://github.com/ClickHouse/ClickHouse/blob/9fc5b9c2c5d008f0f71630bd688d52d9e77609d6/src/Storages/MergeTree/MergeTreeSettings.h#L76) but the docs do not reflect this.
