### PR TITLE
Add setting allow_experimental_partial_result

### DIFF
--- a/docs/en/operations/settings/settings.md
+++ b/docs/en/operations/settings/settings.md
@@ -4659,6 +4659,10 @@ SELECT toFloat64('1.7091'), toFloat64('1.5008753E7') SETTINGS precise_float_pars
 
 Interval (in milliseconds) for sending updates with partial data about the result table to the client (in interactive mode) during query execution. Setting to 0 disables partial results. Only supported for single-threaded GROUP BY without key, ORDER BY, LIMIT and OFFSET.
 
+:::note
+It's an experimental feature. Enable `allow_experimental_partial_result` setting first to use it.
+:::
+
 ## max_rows_in_partial_result
 
 Maximum rows to show in the partial result after every real-time update while the query runs (use partial result limit + OFFSET as a value in case of OFFSET in the query).

--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -106,7 +106,6 @@ namespace ErrorCodes
     extern const int CANNOT_OPEN_FILE;
     extern const int FILE_ALREADY_EXISTS;
     extern const int USER_SESSION_LIMIT_EXCEEDED;
-    extern const int FUNCTION_NOT_ALLOWED;
 }
 
 }
@@ -959,11 +958,6 @@ void ClientBase::processOrdinaryQuery(const String & query_to_execute, ASTPtr pa
 
     if (has_partial_result_setting)
     {
-        if (!settings.allow_experimental_partial_result)
-            throw Exception(ErrorCodes::FUNCTION_NOT_ALLOWED,
-                "Partial results are not allowed by default, it's an experimental feature. "
-                "Setting 'allow_experimental_partial_result' must be enabled to use 'partial_result_update_duration_ms'");
-
         partial_result_mode = PartialResultMode::NotInit;
         if (is_interactive)
             std::cout << "Partial result:" << std::endl;

--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -106,6 +106,7 @@ namespace ErrorCodes
     extern const int CANNOT_OPEN_FILE;
     extern const int FILE_ALREADY_EXISTS;
     extern const int USER_SESSION_LIMIT_EXCEEDED;
+    extern const int FUNCTION_NOT_ALLOWED;
 }
 
 }
@@ -958,6 +959,11 @@ void ClientBase::processOrdinaryQuery(const String & query_to_execute, ASTPtr pa
 
     if (has_partial_result_setting)
     {
+        if (!settings.allow_experimental_partial_result)
+            throw Exception(ErrorCodes::FUNCTION_NOT_ALLOWED,
+                "Partial results are not allowed by default, it's an experimental feature. "
+                "Setting 'allow_experimental_partial_result' must be enabled to use 'partial_result_update_duration_ms'");
+
         partial_result_mode = PartialResultMode::NotInit;
         if (is_interactive)
             std::cout << "Partial result:" << std::endl;

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -311,6 +311,7 @@ class IColumn;
     \
     M(Bool, partial_result_on_first_cancel, false, "Allows query to return a partial result after cancel.", 0) \
     \
+    M(Bool, allow_experimental_partial_result, 0, "Enable experimental feature: partial results for running queries.", 0) \
     M(Milliseconds, partial_result_update_duration_ms, 0, "Interval (in milliseconds) for sending updates with partial data about the result table to the client (in interactive mode) during query execution. Setting to 0 disables partial results. Only supported for single-threaded GROUP BY without key, ORDER BY, LIMIT and OFFSET.", 0) \
     M(UInt64, max_rows_in_partial_result, 10, "Maximum rows to show in the partial result after every real-time update while the query runs (use partial result limit + OFFSET as a value in case of OFFSET in the query).", 0) \
     \

--- a/src/Processors/QueryPlan/BuildQueryPipelineSettings.cpp
+++ b/src/Processors/QueryPlan/BuildQueryPipelineSettings.cpp
@@ -6,6 +6,11 @@
 namespace DB
 {
 
+namespace ErrorCodes
+{
+    extern const int FUNCTION_NOT_ALLOWED;
+}
+
 BuildQueryPipelineSettings BuildQueryPipelineSettings::fromContext(ContextPtr from)
 {
     BuildQueryPipelineSettings settings;
@@ -13,6 +18,10 @@ BuildQueryPipelineSettings BuildQueryPipelineSettings::fromContext(ContextPtr fr
     const auto & context_settings = from->getSettingsRef();
     settings.partial_result_limit = context_settings.max_rows_in_partial_result;
     settings.partial_result_duration_ms = context_settings.partial_result_update_duration_ms.totalMilliseconds();
+    if (settings.partial_result_duration_ms && !context_settings.allow_experimental_partial_result)
+        throw Exception(ErrorCodes::FUNCTION_NOT_ALLOWED,
+            "Partial results are not allowed by default, it's an experimental feature. "
+            "Setting 'allow_experimental_partial_result' must be enabled to use 'partial_result_update_duration_ms'");
 
     settings.actions_settings = ExpressionActionsSettings::fromSettings(context_settings, CompileExpressions::yes);
     settings.process_list_element = from->getProcessListElement();

--- a/src/Processors/Transforms/ExpressionTransform.cpp
+++ b/src/Processors/Transforms/ExpressionTransform.cpp
@@ -28,7 +28,9 @@ void ExpressionTransform::transform(Chunk & chunk)
 ProcessorPtr ExpressionTransform::getPartialResultProcessor(const ProcessorPtr & /*current_processor*/, UInt64 /*partial_result_limit*/, UInt64 /*partial_result_duration_ms*/)
 {
     const auto & header = getInputPort().getHeader();
-    return std::make_shared<ExpressionTransform>(header, expression);
+    auto result = std::make_shared<ExpressionTransform>(header, expression);
+    result->setDescription("(Partial result)");
+    return result;
 }
 
 ConvertingTransform::ConvertingTransform(const Block & header_, ExpressionActionsPtr expression_)

--- a/src/Processors/Transforms/MergeSortingPartialResultTransform.cpp
+++ b/src/Processors/Transforms/MergeSortingPartialResultTransform.cpp
@@ -24,6 +24,11 @@ PartialResultTransform::ShaphotResult MergeSortingPartialResultTransform::getRea
     /// Add a copy of the first `partial_result_limit` rows to a generated_chunk
     /// to send it later as a partial result in the next prepare stage of the current processor
     auto generated_columns = merge_sorting_transform->chunks[0].cloneEmptyColumns();
+
+    /// It's possible that we had only empty chunks before remerge
+    if (merge_sorting_transform->chunks.empty())
+        return {{}, SnaphotStatus::NotReady};
+
     size_t total_rows = 0;
     for (const auto & merged_chunk : merge_sorting_transform->chunks)
     {

--- a/src/QueryPipeline/Pipe.h
+++ b/src/QueryPipeline/Pipe.h
@@ -48,7 +48,7 @@ public:
     OutputPort * getOutputPort(size_t pos) const { return output_ports[pos]; }
     OutputPort * getTotalsPort() const { return totals_port; }
     OutputPort * getExtremesPort() const { return extremes_port; }
-    OutputPort * getPartialResultPort(size_t pos) const { return partial_result_ports.empty() ? nullptr : partial_result_ports[pos]; }
+    OutputPort * getPartialResultPort(size_t pos) const;
 
     bool isPartialResultActive() { return is_partial_result_active; }
 

--- a/src/QueryPipeline/QueryPipeline.cpp
+++ b/src/QueryPipeline/QueryPipeline.cpp
@@ -9,6 +9,7 @@
 #include <Interpreters/ExpressionActions.h>
 #include <QueryPipeline/ReadProgressCallback.h>
 #include <QueryPipeline/Pipe.h>
+#include <QueryPipeline/printPipeline.h>
 #include <Processors/Sinks/EmptySink.h>
 #include <Processors/Sinks/NullSink.h>
 #include <Processors/Sinks/SinkToStorage.h>
@@ -53,13 +54,19 @@ static void checkInput(const InputPort & input, const ProcessorPtr & processor)
             processor->getName());
 }
 
-static void checkOutput(const OutputPort & output, const ProcessorPtr & processor)
+static void checkOutput(const OutputPort & output, const ProcessorPtr & processor, const Processors & processors = {})
 {
     if (!output.isConnected())
+    {
+        WriteBufferFromOwnString out;
+        if (!processors.empty())
+            printPipeline(processors, out);
+
         throw Exception(
             ErrorCodes::LOGICAL_ERROR,
-            "Cannot create QueryPipeline because {} has disconnected output",
-            processor->getName());
+            "Cannot create QueryPipeline because {} {} has disconnected output: {}",
+            processor->getName(), processor->getDescription(), out.str());
+    }
 }
 
 static void checkPulling(
@@ -109,7 +116,7 @@ static void checkPulling(
             else if (partial_result && &out == partial_result)
                 found_partial_result = true;
             else
-                checkOutput(out, processor);
+                checkOutput(out, processor, processors);
         }
     }
 

--- a/src/QueryPipeline/QueryPipelineBuilder.cpp
+++ b/src/QueryPipeline/QueryPipelineBuilder.cpp
@@ -116,8 +116,7 @@ void QueryPipelineBuilder::init(QueryPipeline & pipeline)
         pipe.activatePartialResult(pipeline.partial_result_limit, pipeline.partial_result_duration_ms);
         pipe.partial_result_ports = {pipeline.partial_result};
     }
-
-    if (!pipeline.partial_result)
+    else
         pipe.dropPartialResult();
 
     pipe.totals_port = pipeline.totals;

--- a/src/QueryPipeline/QueryPipelineBuilder.h
+++ b/src/QueryPipeline/QueryPipelineBuilder.h
@@ -86,7 +86,10 @@ public:
     void setSinks(const Pipe::ProcessorGetterWithStreamKind & getter);
 
     /// Activate building separate pipeline for sending partial result.
-    void activatePartialResult(UInt64 partial_result_limit, UInt64 partial_result_duration_ms) { pipe.activatePartialResult(partial_result_limit, partial_result_duration_ms); }
+    void activatePartialResult(UInt64 partial_result_limit, UInt64 partial_result_duration_ms)
+    {
+        pipe.activatePartialResult(partial_result_limit, partial_result_duration_ms);
+    }
 
     /// Check if building of a pipeline for sending partial result active.
     bool isPartialResultActive() { return pipe.isPartialResultActive(); }

--- a/src/Server/TCPHandler.cpp
+++ b/src/Server/TCPHandler.cpp
@@ -101,6 +101,7 @@ namespace DB::ErrorCodes
     extern const int CLIENT_INFO_DOES_NOT_MATCH;
     extern const int SUPPORT_IS_DISABLED;
     extern const int UNSUPPORTED_METHOD;
+    extern const int FUNCTION_NOT_ALLOWED;
 }
 
 namespace
@@ -888,7 +889,13 @@ void TCPHandler::processOrdinaryQueryWithProcessors()
     std::unique_lock progress_lock(task_callback_mutex, std::defer_lock);
 
     {
-        bool has_partial_result_setting = query_context->getSettingsRef().partial_result_update_duration_ms.totalMilliseconds() > 0;
+        const auto & settings = query_context->getSettingsRef();
+        bool has_partial_result_setting = settings.partial_result_update_duration_ms.totalMilliseconds() > 0;
+        if (has_partial_result_setting && !settings.allow_experimental_partial_result)
+            throw Exception(ErrorCodes::FUNCTION_NOT_ALLOWED,
+                "Partial results are not allowed by default, it's an experimental feature. "
+                "Setting 'allow_experimental_partial_result' must be enabled to use 'partial_result_update_duration_ms'");
+
         PullingAsyncPipelineExecutor executor(pipeline, has_partial_result_setting);
         CurrentMetrics::Increment query_thread_metric_increment{CurrentMetrics::QueryThread};
 

--- a/tests/ci/stress.py
+++ b/tests/ci/stress.py
@@ -59,6 +59,12 @@ def get_options(i: int, upgrade_check: bool) -> str:
         client_options.append("implicit_transaction=1")
         client_options.append("throw_on_unsupported_query_inside_transaction=0")
 
+    if random.random() < 0.1:
+        client_options.append("allow_experimental_partial_result=1")
+        client_options.append(
+            f"partial_result_update_duration_ms={random.randint(10, 1000)}"
+        )
+
     if client_options:
         options.append(" --client-option " + " ".join(client_options))
 

--- a/tests/queries/0_stateless/02833_partial_sorting_result_during_query_execution.python
+++ b/tests/queries/0_stateless/02833_partial_sorting_result_during_query_execution.python
@@ -13,7 +13,7 @@ from tcp_client import TCPClient
 
 def run_query_without_errors(query, support_partial_result):
     with TCPClient() as client:
-        client.sendQuery(query)
+        client.sendQuery(query, settings={"allow_experimental_partial_result": True})
 
         # external tables
         client.sendEmptyBlock()

--- a/tests/queries/0_stateless/02834_partial_aggregating_result_during_query_execution.python
+++ b/tests/queries/0_stateless/02834_partial_aggregating_result_during_query_execution.python
@@ -42,7 +42,7 @@ def run_query_without_errors(
         invariants = {}
 
     with TCPClient() as client:
-        client.sendQuery(query)
+        client.sendQuery(query, settings={"allow_experimental_partial_result": True})
 
         # external tables
         client.sendEmptyBlock()

--- a/tests/queries/0_stateless/02876_experimental_partial_result.sql
+++ b/tests/queries/0_stateless/02876_experimental_partial_result.sql
@@ -1,0 +1,4 @@
+
+SET partial_result_update_duration_ms = 10;
+
+SELECT sum(number) FROM numbers_mt(100_000) SETTINGS max_threads = 1; -- { clientError FUNCTION_NOT_ALLOWED }

--- a/tests/queries/0_stateless/02876_experimental_partial_result.sql
+++ b/tests/queries/0_stateless/02876_experimental_partial_result.sql
@@ -1,4 +1,4 @@
 
 SET partial_result_update_duration_ms = 10;
 
-SELECT sum(number) FROM numbers_mt(100_000) SETTINGS max_threads = 1; -- { clientError FUNCTION_NOT_ALLOWED }
+SELECT sum(number) FROM numbers_mt(100_000) SETTINGS max_threads = 1; -- { serverError FUNCTION_NOT_ALLOWED }


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)

Follow up for https://github.com/ClickHouse/ClickHouse/pull/54476