### PR TITLE
Fix endian issue in jemalloc_bins for s390x

### DIFF
--- a/src/Storages/System/StorageSystemJemalloc.cpp
+++ b/src/Storages/System/StorageSystemJemalloc.cpp
@@ -25,6 +25,12 @@ UInt64 getJeMallocValue(const char * name)
     UInt64 value{};
     size_t size = sizeof(value);
     mallctl(name, &value, &size, nullptr, 0);
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+    if (size == 4)
+    {
+        value >>= 32;
+    }
+#endif
     return value;
 }
 

--- a/src/Storages/System/StorageSystemJemalloc.cpp
+++ b/src/Storages/System/StorageSystemJemalloc.cpp
@@ -25,6 +25,9 @@ UInt64 getJeMallocValue(const char * name)
     UInt64 value{};
     size_t size = sizeof(value);
     mallctl(name, &value, &size, nullptr, 0);
+    /// mallctl() fills the value with 32 bit integer for some queries("arenas.nbins" for example).
+    /// In this case variable 'size' will be changed from 8 to 4 and the 64 bit variable 'value' will hold the 32 bit actual value times 2^32 on big-endian machines.
+    /// We should right shift the value by 32 on big-endian machines(which is unnecessary on little-endian machines).
 #if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
     if (size == 4)
     {


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
On s390x, getJeMallocValue() at  StorageSystemJemalloc.cpp:28 returns wrong value when querying value of "arenas.nbins" because of endian issue. This causes the failure of functional test `01161_all_system_tables`.

For example, the function is supposed to return `0x24` but it returns `0x2400000000` instead.

The reason is that mallctl() returns an UInt32 value for "arenas.nbins" (the value of `size` is set to 4 after the call), but the UInt64 `value` interprets it as `0x2400000000` (taking `0x24` for an example) on s390x.

The fix is to right shift 32 bit of the UInt64 value for s390x when the returned size is 4 in order to get correct result for s390x.

### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed endian issue in jemalloc_bins system table for s390x.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
