### PR TITLE
Revert "add runOptimize call in bitmap write method"

### DIFF
--- a/src/AggregateFunctions/AggregateFunctionGroupBitmapData.h
+++ b/src/AggregateFunctions/AggregateFunctionGroupBitmapData.h
@@ -151,7 +151,6 @@ public:
         }
         else if (BitmapKind::Bitmap == kind)
         {
-            roaring_bitmap->runOptimize();
             auto size = roaring_bitmap->getSizeInBytes();
             writeVarUInt(size, out);
             std::unique_ptr<char[]> buf(new char[size]);


### PR DESCRIPTION
Reverts ClickHouse/ClickHouse#52842

See https://s3.amazonaws.com/clickhouse-test-reports/51449/df71dcd94d893f124040105ad35755b750abbe9f/stateless_tests__tsan__[5_5]/stderr.log