### PR TITLE
Add stateless test for clickhouse keeper-client --no-confirmation

### DIFF
--- a/tests/queries/0_stateless/02882_clickhouse_keeper_client_no_confirmation.reference
+++ b/tests/queries/0_stateless/02882_clickhouse_keeper_client_no_confirmation.reference
@@ -1,0 +1,1 @@
+Can't get data for node '/test-keeper-client-default': node doesn't exist

--- a/tests/queries/0_stateless/02882_clickhouse_keeper_client_no_confirmation.sh
+++ b/tests/queries/0_stateless/02882_clickhouse_keeper_client_no_confirmation.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+path="/test-keeper-client-$CLICKHOUSE_DATABASE"
+
+$CLICKHOUSE_KEEPER_CLIENT -q "rm $path" >& /dev/null
+
+$CLICKHOUSE_KEEPER_CLIENT -q "create $path '' 0"
+$CLICKHOUSE_KEEPER_CLIENT -q "rmr $path"
+$CLICKHOUSE_KEEPER_CLIENT -q "get $path" 2>&1

--- a/tests/queries/shell_config.sh
+++ b/tests/queries/shell_config.sh
@@ -79,6 +79,11 @@ export CLICKHOUSE_PORT_POSTGRESQL=${CLICKHOUSE_PORT_POSTGRESQL:="9005"}
 export CLICKHOUSE_PORT_KEEPER=${CLICKHOUSE_PORT_KEEPER:=$(${CLICKHOUSE_EXTRACT_CONFIG} --try --key=keeper_server.tcp_port 2>/dev/null)} 2>/dev/null
 export CLICKHOUSE_PORT_KEEPER=${CLICKHOUSE_PORT_KEEPER:="9181"}
 
+# keeper-client
+[ -x "${CLICKHOUSE_BINARY}-keeper-client" ] && CLICKHOUSE_KEEPER_CLIENT=${CLICKHOUSE_KEEPER_CLIENT:="${CLICKHOUSE_BINARY}-keeper-client"}
+[ -x "${CLICKHOUSE_BINARY}" ] && CLICKHOUSE_KEEPER_CLIENT=${CLICKHOUSE_KEEPER_CLIENT:="${CLICKHOUSE_BINARY} keeper-client"}
+export CLICKHOUSE_KEEPER_CLIENT=${CLICKHOUSE_KEEPER_CLIENT:="${CLICKHOUSE_BINARY}-keeper-client --port $CLICKHOUSE_PORT_KEEPER"}
+
 export CLICKHOUSE_CLIENT_SECURE=${CLICKHOUSE_CLIENT_SECURE:=$(echo "${CLICKHOUSE_CLIENT}" | sed 's/--secure //' | sed 's/'"--port=${CLICKHOUSE_PORT_TCP}"'//g; s/$/'"--secure --accept-invalid-certificate --port=${CLICKHOUSE_PORT_TCP_SECURE}"'/g')}
 
 # Add database and log comment to url params


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add stateless test for clickhouse keeper-client --no-confirmation

Cc: @pufit 