### PR TITLE
Fix query hang after updating LDAP roles

### DIFF
--- a/src/Access/LDAPAccessStorage.cpp
+++ b/src/Access/LDAPAccessStorage.cpp
@@ -312,7 +312,7 @@ void LDAPAccessStorage::updateAssignedRolesNoLock(const UUID & id, const String 
         return entity_;
     };
 
-    memory_storage.update(id, update_func);
+    memory_storage.updateNoLock(id, update_func, true);
 }
 
 

--- a/src/Access/LDAPAccessStorage.h
+++ b/src/Access/LDAPAccessStorage.h
@@ -58,7 +58,7 @@ private: // IAccessStorage implementations.
     void assignRolesNoLock(User & user, const LDAPClient::SearchResultsList & external_roles, const std::size_t external_roles_hash) const;
     void updateAssignedRolesNoLock(const UUID & id, const String & user_name, const LDAPClient::SearchResultsList & external_roles) const;
     std::set<String> mapExternalRolesNoLock(const LDAPClient::SearchResultsList & external_roles) const;
-    bool areLDAPCredentialsValidNoLock(const User & user, const Credentials & credentials,
+    virtual bool areLDAPCredentialsValidNoLock(const User & user, const Credentials & credentials,
         const ExternalAuthenticators & external_authenticators, LDAPClient::SearchResultsList & role_search_results) const;
 
     mutable std::recursive_mutex mutex;

--- a/src/Access/MemoryAccessStorage.h
+++ b/src/Access/MemoryAccessStorage.h
@@ -46,7 +46,9 @@ private:
 
     bool insertNoLock(const UUID & id, const AccessEntityPtr & entity, bool replace_if_exists, bool throw_if_exists) TSA_REQUIRES(mutex);
     bool removeNoLock(const UUID & id, bool throw_if_not_exists) TSA_REQUIRES(mutex);
-    bool updateNoLock(const UUID & id, const UpdateFunc & update_func, bool throw_if_not_exists) TSA_REQUIRES(mutex);
+
+    friend class LDAPAccessStorage;
+    bool updateNoLock(const UUID & id, const UpdateFunc & update_func, bool throw_if_not_exists) TSA_NO_THREAD_SAFETY_ANALYSIS;
 
     void removeAllExceptNoLock(const std::vector<UUID> & ids_to_keep) TSA_REQUIRES(mutex);
     void removeAllExceptNoLock(const boost::container::flat_set<UUID> & ids_to_keep) TSA_REQUIRES(mutex);

--- a/src/Access/tests/gtest_ldap_access_storage.cpp
+++ b/src/Access/tests/gtest_ldap_access_storage.cpp
@@ -1,0 +1,139 @@
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+#include <Access/AccessControl.h>
+#include <Access/ExternalAuthenticators.h>
+#include <Access/LDAPAccessStorage.h>
+#include <Access/Role.h>
+#include <Poco/Net/IPAddress.h>
+
+using namespace DB;
+using namespace testing;
+using namespace std::chrono_literals;
+
+using ConfigurationPtr = Poco::AutoPtr<Poco::Util::AbstractConfiguration>;
+
+std::mutex exit_mutex;
+
+class TerminateOnDeadlock final
+{
+public:
+    using Clock = std::chrono::system_clock;
+    explicit TerminateOnDeadlock(Clock::duration timeout_)
+        : timeout{timeout_}
+    {
+        thread = std::thread(&TerminateOnDeadlock::waitForCompletion, this);
+        std::unique_lock lock{ mutex };
+        started_var.wait(lock);
+    }
+
+    ~TerminateOnDeadlock()
+    {
+        completed_var.notify_one();
+        thread.join();
+    }
+
+private:
+    void waitForCompletion()
+    {
+        std::unique_lock lock{mutex};
+        started_var.notify_one();
+        if (completed_var.wait_for(lock, timeout) == std::cv_status::timeout) {
+            std::unique_lock exit_lock{exit_mutex};
+            std::exit(1);
+        }
+    }
+
+    const Clock::duration timeout;
+    std::mutex mutex;
+    std::condition_variable completed_var;
+    std::condition_variable started_var;
+    std::thread thread;
+};
+
+class LDAPAccessStorageMock : public LDAPAccessStorage
+{
+public:
+    explicit LDAPAccessStorageMock(const String & storage_name_, AccessControl & access_control_, const Poco::Util::AbstractConfiguration & config, const String & prefix)
+        : LDAPAccessStorage(storage_name_, access_control_, config, prefix)
+    {
+    }
+
+    MOCK_CONST_METHOD4(areLDAPCredentialsValidNoLock,
+        bool(const User&, const Credentials&, const ExternalAuthenticators&, LDAPClient::SearchResultsList&));
+};
+
+void UpdateAuthenticatedUserTestImpl()
+{
+    TerminateOnDeadlock guardDeadLock{5s};
+
+    auto address = Poco::Net::IPAddress{"127.0.0.1"};
+    auto credentials = BasicCredentials{"user1", "pwd"};
+
+    // most ldap server parameters in this config have no sense
+    // we just should have correct structure to parse
+    std::stringstream xml_conf(std::string(R"CONFIG(<clickhouse>
+        <ldap_servers>
+            <ldap_server1>
+                <host>localhost</host>
+                <port>389</port>
+                <enable_tls>no</enable_tls>
+                <tls_require_cert>never</tls_require_cert>
+                <bind_dn>localhost\\user1</bind_dn>
+                <user_dn_detection>
+                    <base_dn>OU=CHILD,DC=somename,DC=dcch,DC=local</base_dn>
+                    <search_filter>(&amp;(objectClass=user)(sAMAccountName=user1))</search_filter>
+                </user_dn_detection>
+            </ldap_server1>
+        </ldap_servers>
+        <role_mapping>
+                <base_dn>OU=CHILD,DC=somename,DC=dcch,DC=local</base_dn>
+                <attribute>CN</attribute>
+                <scope>subtree</scope>
+                <search_filter>(&amp;(objectClass=group)(member={user_dn}))</search_filter>
+        </role_mapping>
+    </clickhouse>)CONFIG"));
+
+    Poco::XML::InputSource input_source{xml_conf};
+    auto config = Poco::AutoPtr(new Poco::Util::XMLConfiguration(&input_source));
+    config->setString("server", "ldap_server1");
+    config->setString("roles", "role1");
+
+    AccessControl access_control;
+    access_control.setExternalAuthenticatorsConfig(*config);
+
+    auto ldap_storage = std::make_shared<LDAPAccessStorageMock>("ldap", access_control, *config, "");
+    Mock::AllowLeak(&*ldap_storage);    // in some cases when this death test fails (due to deadlock) mock leakage is a normal behavior
+                                        // so we suppress warning message here
+    access_control.addStorage(ldap_storage);
+
+    access_control.addMemoryStorage("memory", false); // we use this storage just to avoid 'Unable to grant role' warning
+    auto mem_storage = access_control.getStorageByName("memory");
+    auto role = std::make_shared<Role>();
+    role->setName("role1");
+    mem_storage->insert(role);
+
+    LDAPClient::SearchResultsList role_search_results{LDAPClient::SearchResults{"role1"}};
+
+    EXPECT_CALL(*ldap_storage, areLDAPCredentialsValidNoLock(_,_,_,_)).WillOnce(DoAll(
+        SetArgReferee<3>(role_search_results),
+        Return(true)));
+    auto res = ldap_storage->authenticate(credentials, address, access_control.getExternalAuthenticators(), true, true);
+    ASSERT_NE(res, UUID{});
+
+    LDAPClient::SearchResultsList role_search_results2{LDAPClient::SearchResults{"role2"}};
+
+    EXPECT_CALL(*ldap_storage, areLDAPCredentialsValidNoLock(_,_,_,_)).WillOnce(DoAll(
+        SetArgReferee<3>(role_search_results2),
+        Return(true)));
+    res = ldap_storage->authenticate(credentials, address, access_control.getExternalAuthenticators(), true, true); // deadlock occurs here before #53708 fix
+    ASSERT_NE(res, UUID{});
+
+    std::unique_lock lock{exit_mutex};
+    std::exit(Test::HasFailure() ? 2 : 0);
+}
+
+// this test verifies fix for #53708 issue
+TEST(LDAPAccessStorage, UpdateAuthenticatedUser)
+{
+    EXPECT_EXIT(UpdateAuthenticatedUserTestImpl(), ExitedWithCode(0), "");
+}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -582,6 +582,8 @@ if (ENABLE_TESTS)
         file(GLOB_RECURSE "${DST_VAR}" CONFIGURE_DEPENDS RELATIVE "${BASE_DIR}" "gtest*.cpp")
     endmacro()
 
+    add_definitions("-DLDAP_DEPRECATED=0")
+
     # attach all dbms gtest sources
     grep_gtest_sources("${ClickHouse_SOURCE_DIR}/src" dbms_gtest_sources)
     clickhouse_add_executable(unit_tests_dbms ${dbms_gtest_sources})
@@ -589,6 +591,7 @@ if (ENABLE_TESTS)
     # gtest framework has substandard code
     target_compile_options(unit_tests_dbms PRIVATE
         -Wno-sign-compare
+        -Wno-reserved-macro-identifier
     )
 
     target_link_libraries(unit_tests_dbms PRIVATE
@@ -603,6 +606,14 @@ if (ENABLE_TESTS)
         clickhouse_common_zookeeper
         string_utils
         hilite_comparator)
+
+    if (TARGET ch_contrib::ldap)
+        target_link_libraries(unit_tests_dbms PRIVATE ch_contrib::ldap)
+    endif()
+
+    if (TARGET ch_contrib::krb5)
+        target_link_libraries(unit_tests_dbms PRIVATE ch_contrib::krb5)
+    endif()
 
     if (TARGET ch_contrib::simdjson)
         target_link_libraries(unit_tests_dbms PRIVATE ch_contrib::simdjson)


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed issue when updating of mapped LDAP roles can lead to query hangs and denial of service.
Fixes #53708
