### PR TITLE
Increase default timeout in tests for keeper-client

### DIFF
--- a/tests/integration/helpers/keeper_utils.py
+++ b/tests/integration/helpers/keeper_utils.py
@@ -71,7 +71,7 @@ class KeeperClient(object):
 
         self.stopped = False
 
-    def execute_query(self, query: str, timeout: float = 10.0) -> str:
+    def execute_query(self, query: str, timeout: float = 60.0) -> str:
         output = io.BytesIO()
 
         self.proc.stdin.write(query.encode() + b"\n")
@@ -103,19 +103,19 @@ class KeeperClient(object):
         data = output.getvalue().strip().decode()
         return data
 
-    def cd(self, path: str, timeout: float = 10.0):
+    def cd(self, path: str, timeout: float = 60.0):
         self.execute_query(f"cd {path}", timeout)
 
-    def ls(self, path: str, timeout: float = 10.0) -> list[str]:
+    def ls(self, path: str, timeout: float = 60.0) -> list[str]:
         return self.execute_query(f"ls {path}", timeout).split(" ")
 
-    def create(self, path: str, value: str, timeout: float = 10.0):
+    def create(self, path: str, value: str, timeout: float = 60.0):
         self.execute_query(f"create {path} {value}", timeout)
 
-    def get(self, path: str, timeout: float = 10.0) -> str:
+    def get(self, path: str, timeout: float = 60.0) -> str:
         return self.execute_query(f"get {path}", timeout)
 
-    def exists(self, path: str, timeout: float = 10.0) -> bool:
+    def exists(self, path: str, timeout: float = 60.0) -> bool:
         return bool(int(self.execute_query(f"exists {path}", timeout)))
 
     def stop(self):
@@ -123,19 +123,19 @@ class KeeperClient(object):
             self.stopped = True
             self.proc.communicate(b"exit\n", timeout=10.0)
 
-    def sync(self, path: str, timeout: float = 10.0):
+    def sync(self, path: str, timeout: float = 60.0):
         self.execute_query(f"sync {path}", timeout)
 
-    def touch(self, path: str, timeout: float = 10.0):
+    def touch(self, path: str, timeout: float = 60.0):
         self.execute_query(f"touch {path}", timeout)
 
-    def find_big_family(self, path: str, n: int = 10, timeout: float = 10.0) -> str:
+    def find_big_family(self, path: str, n: int = 10, timeout: float = 60.0) -> str:
         return self.execute_query(f"find_big_family {path} {n}", timeout)
 
-    def find_super_nodes(self, threshold: int, timeout: float = 10.0) -> str:
+    def find_super_nodes(self, threshold: int, timeout: float = 60.0) -> str:
         return self.execute_query(f"find_super_nodes {threshold}", timeout)
 
-    def delete_stale_backups(self, timeout: float = 10.0) -> str:
+    def delete_stale_backups(self, timeout: float = 60.0) -> str:
         return self.execute_query("delete_stale_backups", timeout)
 
     def reconfig(
@@ -143,7 +143,7 @@ class KeeperClient(object):
         joining: tp.Optional[str],
         leaving: tp.Optional[str],
         new_members: tp.Optional[str],
-        timeout: float = 10.0,
+        timeout: float = 60.0,
     ) -> str:
         if bool(joining) + bool(leaving) + bool(new_members) != 1:
             raise ValueError(


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

