### PR TITLE
clang-format: Disable namespace indentation and omit {} in if/for/while

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -79,7 +79,7 @@ IndentWidth: 4
 IndentWrappedFunctionNames: false
 MacroBlockBegin: ''
 MacroBlockEnd: ''
-NamespaceIndentation: Inner
+NamespaceIndentation: None
 ObjCBlockIndentWidth: 4
 ObjCSpaceAfterProperty: true
 ObjCSpaceBeforeProtocolList: true
@@ -89,6 +89,7 @@ PenaltyBreakFirstLessLess: 120
 PenaltyBreakString: 1000
 PenaltyExcessCharacter: 1000000
 PenaltyReturnTypeOnItsOwnLine: 60
+RemoveBracesLLVM: true
 SpaceAfterCStyleCast: false
 SpaceBeforeAssignmentOperators: true
 SpaceBeforeParens: ControlStatements


### PR DESCRIPTION
1. Disables namespace indentation in accordance with 16. of (*) and the majority of the codebase.
2. Disables {} for single-statement if/for/while in accordance with 17. of (*) and the majority of the codebase.

Note: Use of clang-format is manual, voluntary, and usually only for new files. No code is or should later be reformatted by this PR, this is only about how *new* files look.

Motivated by https://github.com/ClickHouse/ClickHouse/pull/54115#discussion_r1322741846.

(*) https://clickhouse.com/docs/en/development/style#formatting

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)