### PR TITLE
ngramDistance* queries fix for big endian platform

### DIFF
--- a/src/Functions/FunctionsStringSimilarity.cpp
+++ b/src/Functions/FunctionsStringSimilarity.cpp
@@ -140,18 +140,30 @@ struct NgramDistanceImpl
             {
                 case 1:
                     res = 0;
-                    memcpy(&res, pos, 1);
+                    if constexpr (std::endian::native == std::endian::little)
+                        memcpy(&res, pos, 1);
+                    else
+                        reverseMemcpy(reinterpret_cast<char*>(&res) + sizeof(CodePoint) - 1, pos, 1);
                     break;
                 case 2:
                     res = 0;
-                    memcpy(&res, pos, 2);
+                    if constexpr (std::endian::native == std::endian::little)
+                        memcpy(&res, pos, 2);
+                    else
+                        reverseMemcpy(reinterpret_cast<char*>(&res) + sizeof(CodePoint) - 2, pos, 2);
                     break;
                 case 3:
                     res = 0;
-                    memcpy(&res, pos, 3);
+                    if constexpr (std::endian::native == std::endian::little)
+                        memcpy(&res, pos, 3);
+                    else
+                        reverseMemcpy(reinterpret_cast<char*>(&res) + sizeof(CodePoint) - 3, pos, 3);
                     break;
                 default:
-                    memcpy(&res, pos, 4);
+                    if constexpr (std::endian::native == std::endian::little)
+                        memcpy(&res, pos, 4);
+                    else
+                        reverseMemcpy(reinterpret_cast<char*>(&res) + sizeof(CodePoint) - 4, pos, 4);
             }
 
             /// This is not a really true case insensitive utf8. We zero the 5-th bit of every byte.


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix ngramDistance* queries on big endian platform

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
