### PR TITLE
Fix AST fuzzer crash in MergeTreeIndex{FullText|Inverted}

### DIFF
--- a/src/Storages/MergeTree/MergeTreeIndexFullText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexFullText.cpp
@@ -346,13 +346,13 @@ bool MergeTreeConditionFullText::extractAtomFromTree(const RPNBuilderTreeNode & 
 
             if (const_value.getType() == Field::Types::Int64)
             {
-                out.function = const_value.get<UInt64>() ? RPNElement::ALWAYS_TRUE : RPNElement::ALWAYS_FALSE;
+                out.function = const_value.get<Int64>() ? RPNElement::ALWAYS_TRUE : RPNElement::ALWAYS_FALSE;
                 return true;
             }
 
             if (const_value.getType() == Field::Types::Float64)
             {
-                out.function = const_value.get<UInt64>() ? RPNElement::ALWAYS_TRUE : RPNElement::ALWAYS_FALSE;
+                out.function = const_value.get<Float64>() != 0.0 ? RPNElement::ALWAYS_TRUE : RPNElement::ALWAYS_FALSE;
                 return true;
             }
         }

--- a/src/Storages/MergeTree/MergeTreeIndexFullText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexFullText.cpp
@@ -337,15 +337,22 @@ bool MergeTreeConditionFullText::extractAtomFromTree(const RPNBuilderTreeNode & 
         if (node.tryGetConstant(const_value, const_type))
         {
             /// Check constant like in KeyCondition
-            if (const_value.getType() == Field::Types::UInt64
-                || const_value.getType() == Field::Types::Int64
-                || const_value.getType() == Field::Types::Float64)
-            {
-                /// Zero in all types is represented in memory the same way as in UInt64.
-                out.function = const_value.get<UInt64>()
-                            ? RPNElement::ALWAYS_TRUE
-                            : RPNElement::ALWAYS_FALSE;
 
+            if (const_value.getType() == Field::Types::UInt64)
+            {
+                out.function = const_value.get<UInt64>() ? RPNElement::ALWAYS_TRUE : RPNElement::ALWAYS_FALSE;
+                return true;
+            }
+
+            if (const_value.getType() == Field::Types::Int64)
+            {
+                out.function = const_value.get<UInt64>() ? RPNElement::ALWAYS_TRUE : RPNElement::ALWAYS_FALSE;
+                return true;
+            }
+
+            if (const_value.getType() == Field::Types::Float64)
+            {
+                out.function = const_value.get<UInt64>() ? RPNElement::ALWAYS_TRUE : RPNElement::ALWAYS_FALSE;
                 return true;
             }
         }

--- a/src/Storages/MergeTree/MergeTreeIndexInverted.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexInverted.cpp
@@ -385,13 +385,13 @@ bool MergeTreeConditionInverted::traverseAtomAST(const RPNBuilderTreeNode & node
 
             if (const_value.getType() == Field::Types::Int64)
             {
-                out.function = const_value.get<UInt64>() ? RPNElement::ALWAYS_TRUE : RPNElement::ALWAYS_FALSE;
+                out.function = const_value.get<Int64>() ? RPNElement::ALWAYS_TRUE : RPNElement::ALWAYS_FALSE;
                 return true;
             }
 
             if (const_value.getType() == Field::Types::Float64)
             {
-                out.function = const_value.get<UInt64>() ? RPNElement::ALWAYS_TRUE : RPNElement::ALWAYS_FALSE;
+                out.function = const_value.get<Float64>() != 0.00 ? RPNElement::ALWAYS_TRUE : RPNElement::ALWAYS_FALSE;
                 return true;
             }
         }

--- a/src/Storages/MergeTree/MergeTreeIndexInverted.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexInverted.cpp
@@ -377,15 +377,21 @@ bool MergeTreeConditionInverted::traverseAtomAST(const RPNBuilderTreeNode & node
         if (node.tryGetConstant(const_value, const_type))
         {
             /// Check constant like in KeyCondition
-            if (const_value.getType() == Field::Types::UInt64
-                || const_value.getType() == Field::Types::Int64
-                || const_value.getType() == Field::Types::Float64)
+            if (const_value.getType() == Field::Types::UInt64)
             {
-                /// Zero in all types is represented in memory the same way as in UInt64.
-                out.function = const_value.get<UInt64>()
-                            ? RPNElement::ALWAYS_TRUE
-                            : RPNElement::ALWAYS_FALSE;
+                out.function = const_value.get<UInt64>() ? RPNElement::ALWAYS_TRUE : RPNElement::ALWAYS_FALSE;
+                return true;
+            }
 
+            if (const_value.getType() == Field::Types::Int64)
+            {
+                out.function = const_value.get<UInt64>() ? RPNElement::ALWAYS_TRUE : RPNElement::ALWAYS_FALSE;
+                return true;
+            }
+
+            if (const_value.getType() == Field::Types::Float64)
+            {
+                out.function = const_value.get<UInt64>() ? RPNElement::ALWAYS_TRUE : RPNElement::ALWAYS_FALSE;
                 return true;
             }
         }

--- a/tests/queries/0_stateless/00990_hasToken_and_tokenbf.sql
+++ b/tests/queries/0_stateless/00990_hasToken_and_tokenbf.sql
@@ -60,7 +60,7 @@ SELECT max(id) FROM bloom_filter WHERE hasToken(s, 'zzz') == 1; -- { serverError
 
 DROP TABLE bloom_filter;
 
--- Test AST fuzzer crash (Bug #54541)
+-- AST fuzzer crash, issue #54541
 CREATE TABLE tab (row_id UInt32, str String, INDEX idx str TYPE tokenbf_v1(256, 2, 0)) ENGINE = MergeTree ORDER BY row_id;
 INSERT INTO tab VALUES (0, 'a');
 SELECT * FROM tab WHERE str == 'else' AND 1.0;

--- a/tests/queries/0_stateless/00990_hasToken_and_tokenbf.sql
+++ b/tests/queries/0_stateless/00990_hasToken_and_tokenbf.sql
@@ -59,3 +59,9 @@ SELECT max(id) FROM bloom_filter WHERE hasToken(s, 'yyy'); -- { serverError 158 
 SELECT max(id) FROM bloom_filter WHERE hasToken(s, 'zzz') == 1; -- { serverError 158 }
 
 DROP TABLE bloom_filter;
+
+-- Test AST fuzzer crash (Bug #54541)
+CREATE TABLE tab (row_id UInt32, str String, INDEX idx str TYPE tokenbf_v1(256, 2, 0)) ENGINE = MergeTree ORDER BY row_id;
+INSERT INTO tab VALUES (0, 'a');
+SELECT * FROM tab WHERE str == 'else' AND 1.0;
+DROP TABLE tab;

--- a/tests/queries/0_stateless/02346_full_text_search.reference
+++ b/tests/queries/0_stateless/02346_full_text_search.reference
@@ -46,3 +46,4 @@ Test inverted(2) on UTF-8 data
 af	inverted
 102	clickhouse你好
 1
+AST Fuzzer crash, issue #54541

--- a/tests/queries/0_stateless/02346_full_text_search.sql
+++ b/tests/queries/0_stateless/02346_full_text_search.sql
@@ -235,6 +235,15 @@ SELECT read_rows==2 from system.query_log
     LIMIT 1;
 
 
+----------------------------------------------------
+SELECT 'AST Fuzzer crash, issue #54541';
+
+DROP TABLE IF EXISTS tab;
+CREATE TABLE tab (row_id UInt32, str String, INDEX idx str TYPE inverted) ENGINE = MergeTree ORDER BY row_id;
+INSERT INTO tab VALUES (0, 'a');
+SELECT * FROM tab WHERE str == 'b' AND 1.0;
+
+
 -- Tests with parameter max_digestion_size_per_segment are flaky in CI, not clear why --> comment out for the time being:
 
 -- ----------------------------------------------------


### PR DESCRIPTION
Fixes #54541

The check / `LOGICAL_ERROR` only exists in debug builds, official builds are not affected --> "Not for changelog".

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)