### PR TITLE
Fix race in `ColumnUnique`

### DIFF
--- a/src/Columns/ColumnUnique.h
+++ b/src/Columns/ColumnUnique.h
@@ -670,9 +670,8 @@ UInt128 ColumnUnique<ColumnType>::IncrementalHash::getHash(const ColumnType & co
         for (size_t i = 0; i < column_size; ++i)
             column.updateHashWithValue(i, sip_hash);
 
-        hash = sip_hash.get128();
-
         std::lock_guard lock(mutex);
+        hash = sip_hash.get128();
         cur_hash = hash;
         num_added_rows.store(column_size);
     }


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix unsynchronised write to a shared variable in `ColumnUnique`.

Fixes: #54445