### PR TITLE
Shrink blocks in HashJoin on consuming half of maximum memory

### DIFF
--- a/src/Columns/ColumnVector.cpp
+++ b/src/Columns/ColumnVector.cpp
@@ -433,7 +433,7 @@ void ColumnVector<T>::updatePermutation(IColumn::PermutationSortDirection direct
 template <typename T>
 MutableColumnPtr ColumnVector<T>::cloneResized(size_t size) const
 {
-    auto res = this->create();
+    auto res = this->create(size);
 
     if (size > 0)
     {

--- a/src/Columns/IColumn.h
+++ b/src/Columns/IColumn.h
@@ -397,6 +397,16 @@ public:
     /// It affects performance only (not correctness).
     virtual void reserve(size_t /*n*/) {}
 
+    /// Requests the removal of unused capacity.
+    /// It is a non-binding request to reduce the capacity of the underlying container to its size.
+    virtual void shrinkToFit()
+    {
+      /// Create a new column with the same values and move it into the initial column
+      auto temporary_copy = cloneEmpty();
+      temporary_copy->insertRangeFrom(*this, 0, size());
+      getPtr() = std::move(temporary_copy);
+    }
+
     /// If we have another column as a source (owner of data), copy all data to ourself and reset source.
     virtual void ensureOwnership() {}
 

--- a/src/Columns/IColumn.h
+++ b/src/Columns/IColumn.h
@@ -399,12 +399,9 @@ public:
 
     /// Requests the removal of unused capacity.
     /// It is a non-binding request to reduce the capacity of the underlying container to its size.
-    virtual void shrinkToFit()
+    virtual MutablePtr shrinkToFit() const
     {
-      /// Create a new column with the same values and move it into the initial column
-      auto temporary_copy = cloneEmpty();
-      temporary_copy->insertRangeFrom(*this, 0, size());
-      getPtr() = std::move(temporary_copy);
+      return cloneResized(size());
     }
 
     /// If we have another column as a source (owner of data), copy all data to ourself and reset source.

--- a/src/Columns/IColumn.h
+++ b/src/Columns/IColumn.h
@@ -401,7 +401,7 @@ public:
     /// It is a non-binding request to reduce the capacity of the underlying container to its size.
     virtual MutablePtr shrinkToFit() const
     {
-      return cloneResized(size());
+        return cloneResized(size());
     }
 
     /// If we have another column as a source (owner of data), copy all data to ourself and reset source.

--- a/src/Core/Block.cpp
+++ b/src/Core/Block.cpp
@@ -597,6 +597,14 @@ Block Block::sortColumns() const
     return sorted_block;
 }
 
+Block Block::shrinkToFit() const
+{
+    Columns new_columns(data.size(), nullptr);
+    for (size_t i = 0; i < data.size(); ++i)
+        new_columns[i] = data[i].column->shrinkToFit();
+    return cloneWithColumns(new_columns);
+}
+
 
 const ColumnsWithTypeAndName & Block::getColumnsWithTypeAndName() const
 {

--- a/src/Core/Block.h
+++ b/src/Core/Block.h
@@ -150,15 +150,7 @@ public:
     Block sortColumns() const;
 
     /** See IColumn::shrinkToFit() */
-    void shrinkToFit()
-    {
-        for (auto & elem : data)
-        {
-            auto mutate_column = IColumn::mutate(std::move(elem.column));
-            mutate_column->shrinkToFit();
-            elem.column = std::move(mutate_column);
-        }
-    }
+    Block shrinkToFit() const;
 
     void clear();
     void swap(Block & other) noexcept;

--- a/src/Core/Block.h
+++ b/src/Core/Block.h
@@ -149,6 +149,17 @@ public:
     /** Get a block with columns that have been rearranged in the order of their names. */
     Block sortColumns() const;
 
+    /** See IColumn::shrinkToFit() */
+    void shrinkToFit()
+    {
+        for (auto & elem : data)
+        {
+            auto mutate_column = IColumn::mutate(std::move(elem.column));
+            mutate_column->shrinkToFit();
+            elem.column = std::move(mutate_column);
+        }
+    }
+
     void clear();
     void swap(Block & other) noexcept;
 

--- a/src/Interpreters/HashJoin.cpp
+++ b/src/Interpreters/HashJoin.cpp
@@ -1765,25 +1765,21 @@ void HashJoin::joinBlock(Block & block, ExtraBlockPtr & not_processed)
     }
 
     if (kind == JoinKind::Right || kind == JoinKind::Full)
-    {
         materializeBlockInplace(block);
-    }
 
     {
         std::vector<const std::decay_t<decltype(data->maps[0])> * > maps_vector;
         for (size_t i = 0; i < table_join->getClauses().size(); ++i)
             maps_vector.push_back(&data->maps[i]);
 
-        if (joinDispatch(kind, strictness, maps_vector, [&](auto kind_, auto strictness_, auto & maps_vector_)
+        if (!joinDispatch(kind, strictness, maps_vector, [&](auto kind_, auto strictness_, auto & maps_vector_)
         {
             joinBlockImpl<kind_, strictness_>(block, sample_block_with_columns_to_add, maps_vector_);
         }))
-        {
-            /// Joined
-        }
-        else
             throw Exception(ErrorCodes::LOGICAL_ERROR, "Wrong JOIN combination: {} {}", strictness, kind);
     }
+
+    block.shrinkToFit();
 }
 
 HashJoin::~HashJoin()

--- a/src/Interpreters/HashJoin.cpp
+++ b/src/Interpreters/HashJoin.cpp
@@ -1779,7 +1779,7 @@ void HashJoin::joinBlock(Block & block, ExtraBlockPtr & not_processed)
             throw Exception(ErrorCodes::LOGICAL_ERROR, "Wrong JOIN combination: {} {}", strictness, kind);
     }
 
-    block.shrinkToFit();
+    block = block.shrinkToFit();
 }
 
 HashJoin::~HashJoin()

--- a/src/Interpreters/HashJoin.h
+++ b/src/Interpreters/HashJoin.h
@@ -430,6 +430,9 @@ private:
     /// Left table column names that are sources for required_right_keys columns
     std::vector<String> required_right_keys_sources;
 
+    /// When trackaed memory consumption is more than a threshold, we will shrink to fit stored blocks.
+    bool shrink_blocks = false;
+
     Poco::Logger * log;
 
     /// Should be set via setLock to protect hash table from modification from StorageJoin

--- a/src/Interpreters/HashJoin.h
+++ b/src/Interpreters/HashJoin.h
@@ -430,7 +430,7 @@ private:
     /// Left table column names that are sources for required_right_keys columns
     std::vector<String> required_right_keys_sources;
 
-    /// When trackaed memory consumption is more than a threshold, we will shrink to fit stored blocks.
+    /// When tracked memory consumption is more than a threshold, we will shrink to fit stored blocks.
     bool shrink_blocks = false;
 
     Poco::Logger * log;

--- a/src/Interpreters/HashJoin.h
+++ b/src/Interpreters/HashJoin.h
@@ -393,6 +393,8 @@ public:
 
     void debugKeys() const;
 
+    void shrinkStoredBlocksToFit(size_t & total_bytes_in_join);
+
 private:
     template<bool> friend class NotJoinedHash;
 
@@ -432,6 +434,7 @@ private:
 
     /// When tracked memory consumption is more than a threshold, we will shrink to fit stored blocks.
     bool shrink_blocks = false;
+    Int64 memory_usage_before_adding_blocks = 0;
 
     Poco::Logger * log;
 

--- a/src/Interpreters/TableJoin.cpp
+++ b/src/Interpreters/TableJoin.cpp
@@ -112,6 +112,7 @@ TableJoin::TableJoin(const Settings & settings, VolumePtr tmp_volume_)
     , partial_merge_join_left_table_buffer_bytes(settings.partial_merge_join_left_table_buffer_bytes)
     , max_files_to_merge(settings.join_on_disk_max_files_to_merge)
     , temporary_files_codec(settings.temporary_files_codec)
+    , max_memory_usage(settings.max_memory_usage)
     , tmp_volume(tmp_volume_)
 {
 }
@@ -952,5 +953,11 @@ ActionsDAGPtr TableJoin::createJoinedBlockActions(ContextPtr context) const
     auto syntax_result = TreeRewriter(context).analyze(expression_list, columnsFromJoinedTable());
     return ExpressionAnalyzer(expression_list, syntax_result, context).getActionsDAG(true, false);
 }
+
+size_t TableJoin::getMaxMemoryUsage() const
+{
+    return max_memory_usage;
+}
+
 
 }

--- a/src/Interpreters/TableJoin.h
+++ b/src/Interpreters/TableJoin.h
@@ -146,6 +146,9 @@ private:
     const size_t max_files_to_merge = 0;
     const String temporary_files_codec = "LZ4";
 
+    /// Value if setting max_memory_usage for query, can be used when max_bytes_in_join is not specified.
+    size_t max_memory_usage = 0;
+
     ASTs key_asts_left;
     ASTs key_asts_right;
 
@@ -244,6 +247,8 @@ public:
     JoinStrictness strictness() const { return table_join.strictness; }
     bool sameStrictnessAndKind(JoinStrictness, JoinKind) const;
     const SizeLimits & sizeLimits() const { return size_limits; }
+    size_t getMaxMemoryUsage() const;
+
     VolumePtr getGlobalTemporaryVolume() { return tmp_volume; }
 
     ActionsDAGPtr createJoinedBlockActions(ContextPtr context) const;


### PR DESCRIPTION
### Changelog category (leave one):

- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
* HashJoin tries to shrink internal buffers consuming half of maximal available memory (set by `max_bytes_in_join`)

Followup https://github.com/ClickHouse/ClickHouse/pull/50112#issuecomment-1712604733

---

```sql
SET max_bytes_in_join = '2G';

SELECT UserID, h1.Referer, h1.URL, h2.URL
FROM datasets.hits_v1 AS h1
INNER JOIN datasets.hits_v1 AS h2 ON h1.UserID = h2.UserID AND h1.URL = h2.Referer
WHERE h1.URL != '' AND h2.URL != '' AND h1.Referer != '' AND h2.Referer != ''
ORDER BY UserID ASC
LIMIT 1
```

```
<Debug> HashJoin: Shrinking stored blocks table after 954.20 MiB of 1.86 GiB consumed
<Debug> HashJoin: Shrinked stored blocks 193.78 MiB freed, new memory consumption is 760.42 MiB
...
<Debug> MemoryTracker: Peak memory usage (for query): 1.03 GiB.
```

While with  `SET max_bytes_in_join = '20G'`:

```
<Debug> MemoryTracker: Peak memory usage (for query): 1.24 GiB.
```
