### PR TITLE
Remove output_format_markdown_escape_special_characters from settings changes history

### DIFF
--- a/src/Core/SettingsChangesHistory.h
+++ b/src/Core/SettingsChangesHistory.h
@@ -80,7 +80,6 @@ namespace SettingsChangesHistory
 /// It's used to implement `compatibility` setting (see https://github.com/ClickHouse/ClickHouse/issues/35972)
 static std::map<ClickHouseVersion, SettingsChangesHistory::SettingsChanges> settings_changes_history =
 {
-    {"23.8", {{"output_format_markdown_escape_special_characters", false, true, "Escape special characters in Markdown"}}},
     {"23.8", {{"rewrite_count_distinct_if_with_count_distinct_implementation", false, true, "Rewrite countDistinctIf with count_distinct_implementation configuration"}}},
     {"23.7", {{"function_sleep_max_microseconds_per_block", 0, 3000000, "In previous versions, the maximum sleep time of 3 seconds was applied only for `sleep`, but not for `sleepEachRow` function. In the new version, we introduce this setting. If you set compatibility with the previous versions, we will disable the limit altogether."}}},
     {"23.6", {{"http_send_timeout", 180, 30, "3 minutes seems crazy long. Note that this is timeout for a single network write call, not for the whole upload operation."},

--- a/src/DataTypes/Serializations/SerializationCustomSimpleText.cpp
+++ b/src/DataTypes/Serializations/SerializationCustomSimpleText.cpp
@@ -97,7 +97,7 @@ void SerializationCustomSimpleText::serializeTextXML(const IColumn & column, siz
 void SerializationCustomSimpleText::serializeTextMarkdown(
     const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettings & settings) const
 {
-    if (settings.output_format_markdown_escape_special_characters)
+    if (settings.markdown.escape_special_characters)
         writeMarkdownEscapedString(serializeToString(*this, column, row_num, settings), ostr);
     else
         writeEscapedString(serializeToString(*this, column, row_num, settings), ostr);

--- a/src/DataTypes/Serializations/SerializationEnum.cpp
+++ b/src/DataTypes/Serializations/SerializationEnum.cpp
@@ -115,7 +115,7 @@ template <typename Type>
 void SerializationEnum<Type>::serializeTextMarkdown(
     const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettings & settings) const
 {
-    if (settings.output_format_markdown_escape_special_characters)
+    if (settings.markdown.escape_special_characters)
         writeMarkdownEscapedString(this->getNameForValue(assert_cast<const ColumnType &>(column).getData()[row_num]).toView(), ostr);
     else
         serializeTextEscaped(column, row_num, ostr, settings);

--- a/src/DataTypes/Serializations/SerializationFixedString.cpp
+++ b/src/DataTypes/Serializations/SerializationFixedString.cpp
@@ -213,7 +213,7 @@ void SerializationFixedString::deserializeTextCSV(IColumn & column, ReadBuffer &
 void SerializationFixedString::serializeTextMarkdown(
     const DB::IColumn & column, size_t row_num, DB::WriteBuffer & ostr, const DB::FormatSettings & settings) const
 {
-    if (settings.output_format_markdown_escape_special_characters)
+    if (settings.markdown.escape_special_characters)
     {
         writeMarkdownEscapedString(
             reinterpret_cast<const char *>(&(assert_cast<const ColumnFixedString &>(column).getChars()[n * row_num])), n, ostr);

--- a/src/DataTypes/Serializations/SerializationObject.cpp
+++ b/src/DataTypes/Serializations/SerializationObject.cpp
@@ -517,7 +517,7 @@ template <typename Parser>
 void SerializationObject<Parser>::serializeTextMarkdown(
     const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettings & settings) const
 {
-    if (settings.output_format_markdown_escape_special_characters)
+    if (settings.markdown.escape_special_characters)
     {
         WriteBufferFromOwnString ostr_str;
         serializeTextImpl(column, row_num, ostr_str, settings);

--- a/src/DataTypes/Serializations/SerializationString.cpp
+++ b/src/DataTypes/Serializations/SerializationString.cpp
@@ -364,7 +364,7 @@ void SerializationString::deserializeTextCSV(IColumn & column, ReadBuffer & istr
 void SerializationString::serializeTextMarkdown(
     const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettings & settings) const
 {
-    if (settings.output_format_markdown_escape_special_characters)
+    if (settings.markdown.escape_special_characters)
         writeMarkdownEscapedString(assert_cast<const ColumnString &>(column).getDataAt(row_num).toView(), ostr);
     else
         serializeTextEscaped(column, row_num, ostr, settings);

--- a/src/Formats/FormatFactory.cpp
+++ b/src/Formats/FormatFactory.cpp
@@ -213,7 +213,7 @@ FormatSettings getFormatSettings(ContextPtr context, const Settings & settings)
     format_settings.try_infer_integers = settings.input_format_try_infer_integers;
     format_settings.try_infer_dates = settings.input_format_try_infer_dates;
     format_settings.try_infer_datetimes = settings.input_format_try_infer_datetimes;
-    format_settings.output_format_markdown_escape_special_characters = settings.output_format_markdown_escape_special_characters;
+    format_settings.markdown.escape_special_characters = settings.output_format_markdown_escape_special_characters;
     format_settings.bson.output_string_as_string = settings.output_format_bson_string_as_string;
     format_settings.bson.skip_fields_with_unsupported_types_in_schema_inference = settings.input_format_bson_skip_fields_with_unsupported_types_in_schema_inference;
     format_settings.max_binary_string_size = settings.format_binary_max_string_size;

--- a/src/Formats/FormatSettings.h
+++ b/src/Formats/FormatSettings.h
@@ -46,8 +46,6 @@ struct FormatSettings
     bool try_infer_dates = false;
     bool try_infer_datetimes = false;
 
-    bool output_format_markdown_escape_special_characters = false;
-
     enum class DateTimeInputFormat
     {
         Basic,        /// Default format for fast parsing: YYYY-MM-DD hh:mm:ss (ISO-8601 without fractional part and timezone) or NNNNNNNNNN unix timestamp.
@@ -407,6 +405,11 @@ struct FormatSettings
     {
         bool allow_types_conversion = true;
     } native;
+
+    struct
+    {
+        bool escape_special_characters = false;
+    } markdown;
 };
 
 }


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

It was added by mistake in https://github.com/ClickHouse/ClickHouse/pull/53860/files#diff-695994316524543454e2b6085cbd7d36e053afac2551a53d4297b4050c50088b