### PR TITLE
Add setting http_make_head_request

### DIFF
--- a/docs/en/operations/settings/settings.md
+++ b/docs/en/operations/settings/settings.md
@@ -460,6 +460,17 @@ Possible values:
 
 Default value: 1048576.
 
+## http_make_head_request {#http-make-head-request}
+
+Enables or disables execution of a HEAD request before the actual GET request
+
+Possible values:
+
+- 0 — Disabled.
+- 1 — Enabled.
+
+Default value: 1.
+
 ## table_function_remote_max_addresses {#table_function_remote_max_addresses}
 
 Sets the maximum number of addresses generated from patterns for the [remote](../../sql-reference/table-functions/remote.md) function.

--- a/docs/en/operations/settings/settings.md
+++ b/docs/en/operations/settings/settings.md
@@ -462,14 +462,9 @@ Default value: 1048576.
 
 ## http_make_head_request {#http-make-head-request}
 
-Enables or disables execution of a HEAD request before the actual GET request
+The `http_make_head_request` setting allows the execution of a `HEAD` request while reading data from HTTP to retrieve information about the file to be read, such as its size. Since it's enabled by default, it may be desirable to disable this setting in cases where the server does not support `HEAD` requests.
 
-Possible values:
-
-- 0 — Disabled.
-- 1 — Enabled.
-
-Default value: 1.
+Default value: `true`.
 
 ## table_function_remote_max_addresses {#table_function_remote_max_addresses}
 

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -333,7 +333,7 @@ class IColumn;
     M(UInt64, http_max_field_value_size, 128 * 1024, "Maximum length of field value in HTTP header", 0) \
     M(UInt64, http_max_chunk_size, 100_GiB, "Maximum value of a chunk size in HTTP chunked transfer encoding", 0) \
     M(Bool, http_skip_not_found_url_for_globs, true, "Skip url's for globs with HTTP_NOT_FOUND error", 0) \
-    M(Bool, http_make_head_request, true, "If it is set to true, execute a HEAD request before the actual GET request", 0) \
+    M(Bool, http_make_head_request, true, "Allows the execution of a `HEAD` request while reading data from HTTP to retrieve information about the file to be read, such as its size", 0) \
     M(Bool, optimize_throw_if_noop, false, "If setting is enabled and OPTIMIZE query didn't actually assign a merge then an explanatory exception is thrown", 0) \
     M(Bool, use_index_for_in_with_subqueries, true, "Try using an index if there is a subquery or a table expression on the right side of the IN operator.", 0) \
     M(UInt64, use_index_for_in_with_subqueries_max_values, 0, "The maximum size of set in the right hand side of the IN operator to use table index for filtering. It allows to avoid performance degradation and higher memory usage due to preparation of additional data structures for large queries. Zero means no limit.", 0) \

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -333,6 +333,7 @@ class IColumn;
     M(UInt64, http_max_field_value_size, 128 * 1024, "Maximum length of field value in HTTP header", 0) \
     M(UInt64, http_max_chunk_size, 100_GiB, "Maximum value of a chunk size in HTTP chunked transfer encoding", 0) \
     M(Bool, http_skip_not_found_url_for_globs, true, "Skip url's for globs with HTTP_NOT_FOUND error", 0) \
+    M(Bool, http_make_head_request, true, "If it is set to true, execute a HEAD request before the actual GET request", 0) \
     M(Bool, optimize_throw_if_noop, false, "If setting is enabled and OPTIMIZE query didn't actually assign a merge then an explanatory exception is thrown", 0) \
     M(Bool, use_index_for_in_with_subqueries, true, "Try using an index if there is a subquery or a table expression on the right side of the IN operator.", 0) \
     M(UInt64, use_index_for_in_with_subqueries_max_values, 0, "The maximum size of set in the right hand side of the IN operator to use table index for filtering. It allows to avoid performance degradation and higher memory usage due to preparation of additional data structures for large queries. Zero means no limit.", 0) \

--- a/src/IO/ReadSettings.h
+++ b/src/IO/ReadSettings.h
@@ -120,6 +120,7 @@ struct ReadSettings
     size_t http_retry_initial_backoff_ms = 100;
     size_t http_retry_max_backoff_ms = 1600;
     bool http_skip_not_found_url_for_globs = true;
+    bool http_make_head_request = true;
 
     /// Monitoring
     bool for_object_storage = false; // to choose which profile events should be incremented

--- a/src/IO/ReadWriteBufferFromHTTP.cpp
+++ b/src/IO/ReadWriteBufferFromHTTP.cpp
@@ -808,10 +808,10 @@ std::optional<time_t> ReadWriteBufferFromHTTPBase<UpdatableSessionPtr>::tryGetLa
 template <typename UpdatableSessionPtr>
 HTTPFileInfo ReadWriteBufferFromHTTPBase<UpdatableSessionPtr>::getFileInfo()
 {
+    /// May be disabled in case the user knows in advance that the server doesn't support HEAD requests.
+    /// Allows to avoid making unnecessary requests in such cases.
     if (!settings.http_make_head_request)
-    {
-            return HTTPFileInfo{};
-    }
+        return HTTPFileInfo{};
 
     Poco::Net::HTTPResponse response;
     try

--- a/src/IO/ReadWriteBufferFromHTTP.cpp
+++ b/src/IO/ReadWriteBufferFromHTTP.cpp
@@ -808,6 +808,11 @@ std::optional<time_t> ReadWriteBufferFromHTTPBase<UpdatableSessionPtr>::tryGetLa
 template <typename UpdatableSessionPtr>
 HTTPFileInfo ReadWriteBufferFromHTTPBase<UpdatableSessionPtr>::getFileInfo()
 {
+    if (!settings.http_make_head_request)
+    {
+            return HTTPFileInfo{};
+    }
+
     Poco::Net::HTTPResponse response;
     try
     {

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -4843,6 +4843,7 @@ ReadSettings Context::getReadSettings() const
     res.http_retry_initial_backoff_ms = settings.http_retry_initial_backoff_ms;
     res.http_retry_max_backoff_ms = settings.http_retry_max_backoff_ms;
     res.http_skip_not_found_url_for_globs = settings.http_skip_not_found_url_for_globs;
+    res.http_make_head_request = settings.http_make_head_request;
 
     res.mmap_cache = getMMappedFileCache().get();
 

--- a/tests/ci/stress.py
+++ b/tests/ci/stress.py
@@ -68,6 +68,9 @@ def get_options(i: int, upgrade_check: bool) -> str:
     if random.random() < 0.1:
         client_options.append("optimize_trivial_approximate_count_query=1")
 
+    if random.random() < 0.3:
+        client_options.append(f"http_make_head_request={random.randint(0, 1)}")
+
     if client_options:
         options.append(" --client-option " + " ".join(client_options))
 

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -631,7 +631,6 @@ class SettingsRandomizer:
                 get_localzone(),
             ]
         ),
-        "http_make_head_request": lambda: random.randint(0, 1),
     }
 
     @staticmethod

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -631,6 +631,7 @@ class SettingsRandomizer:
                 get_localzone(),
             ]
         ),
+        "http_make_head_request": lambda: random.randint(0, 1),
     }
 
     @staticmethod


### PR DESCRIPTION
Clickhouse always does a HEAD request before actually executing the GET request,
this adds a settings to skip that request. Closes #49028


### Changelog category (leave one):
- New Feature

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Allow disabling of HEAD request before GET request
