### PR TITLE
use env to find bash

### DIFF
--- a/src/Parsers/fuzzers/codegen_fuzzer/update.sh
+++ b/src/Parsers/fuzzers/codegen_fuzzer/update.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 
 _main() {

--- a/src/Storages/System/StorageSystemLicenses.sh
+++ b/src/Storages/System/StorageSystemLicenses.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ROOT_PATH="$(git rev-parse --show-toplevel)"
 IFS=$'\t'

--- a/utils/list-licenses/list-licenses.sh
+++ b/utils/list-licenses/list-licenses.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
     # use GNU versions, their presence is ensured in cmake/tools.cmake


### PR DESCRIPTION
### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
use `/usr/bin/env` to resolve bash
