### PR TITLE
Fix: Log engine Mark file to read and write in little Endian for s390x

### DIFF
--- a/src/Storages/StorageLog.cpp
+++ b/src/Storages/StorageLog.cpp
@@ -503,15 +503,15 @@ void LogSink::writeData(const NameAndTypePair & name_and_type, const IColumn & c
 
 void StorageLog::Mark::write(WriteBuffer & out) const
 {
-    writeIntBinary(rows, out);
-    writeIntBinary(offset, out);
+    writeBinaryLittleEndian(rows, out);
+    writeBinaryLittleEndian(offset, out);
 }
 
 
 void StorageLog::Mark::read(ReadBuffer & in)
 {
-    readIntBinary(rows, in);
-    readIntBinary(offset, in);
+    readBinaryLittleEndian(rows, in);
+    readBinaryLittleEndian(offset, in);
 }
 
 


### PR DESCRIPTION
Issue: https://github.ibm.com/ClickHouse/issue-repo/issues/2966

Fix for s390x.

RCA: In 390x the contents for __marks.mrk file( in Log engine) were being written in big-endian format to the disk resulting in failure of a couple of test cases.

Testcases:
02047_log_family_complex_structs_data_file_dumps:
02047_log_family_data_file_dumps:

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

