### PR TITLE
Fix: avoid using regex match, possibly containing alternation, as a key condition.

### DIFF
--- a/src/Storages/MergeTree/KeyCondition.cpp
+++ b/src/Storages/MergeTree/KeyCondition.cpp
@@ -421,7 +421,12 @@ const KeyCondition::AtomMap KeyCondition::atom_map
             if (value.getType() != Field::Types::String)
                 return false;
 
-            String prefix = extractFixedPrefixFromRegularExpression(value.get<const String &>());
+            const String & expression = value.get<const String &>();
+            // This optimization can't process alternation - this would reguire a comprehensive parsing of reqular expression.
+            if (expression.contains('|'))
+                return false;
+
+            String prefix = extractFixedPrefixFromRegularExpression(expression);
             if (prefix.empty())
                 return false;
 

--- a/src/Storages/MergeTree/KeyCondition.cpp
+++ b/src/Storages/MergeTree/KeyCondition.cpp
@@ -422,7 +422,7 @@ const KeyCondition::AtomMap KeyCondition::atom_map
                 return false;
 
             const String & expression = value.get<const String &>();
-            // This optimization can't process alternation - this would reguire a comprehensive parsing of reqular expression.
+            // This optimization can't process alternation - this would require a comprehensive parsing of regular expression.
             if (expression.contains('|'))
                 return false;
 

--- a/tests/queries/0_stateless/02462_match_regexp_pk.sql
+++ b/tests/queries/0_stateless/02462_match_regexp_pk.sql
@@ -7,3 +7,4 @@ SELECT count() FROM mt_match_pk WHERE match(v, '^ab');
 SELECT count() FROM mt_match_pk WHERE match(v, '^a.');
 SELECT count() FROM mt_match_pk WHERE match(v, '^ab*');
 SELECT count() FROM mt_match_pk WHERE match(v, '^ac?');
+SELECT count() FROM mt_match_pk WHERE match(v, '^a$|^b'); -- {serverError INDEX_NOT_USED}


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed bug of match() function (regex) with pattern containing alternation produces incorrect key condition.

closes #53222
