### PR TITLE
add missing documentation for system sync database replica.

### DIFF
--- a/docs/en/sql-reference/statements/system.md
+++ b/docs/en/sql-reference/statements/system.md
@@ -340,6 +340,11 @@ After running this statement the `[db.]replicated_merge_tree_family_table_name` 
  - If a `LIGHTWEIGHT` modifier was specified then the query waits only for `GET_PART`, `ATTACH_PART`, `DROP_RANGE`, `REPLACE_RANGE` and `DROP_PART` entries to be processed.
  - If a `PULL` modifier was specified then the query pulls new replication queue entries from ZooKeeper, but does not wait for anything to be processed.
 
+### SYNC DATABASE REPLICA
+
+Sync all tables from all [replicated database](https://clickhouse.com/docs/en/engines/database-engines/replicated). This will make the ClickHouse synchronously fetch all table definition
+from zookeeper and applied locally.
+
 ### RESTART REPLICA
 
 Provides possibility to reinitialize Zookeeper session's state for `ReplicatedMergeTree` table, will compare current state with Zookeeper as source of truth and add tasks to Zookeeper queue if needed.

--- a/docs/en/sql-reference/statements/system.md
+++ b/docs/en/sql-reference/statements/system.md
@@ -342,9 +342,11 @@ After running this statement the `[db.]replicated_merge_tree_family_table_name` 
 
 ### SYNC DATABASE REPLICA
 
-Sync all tables from all [replicated database](https://clickhouse.com/docs/en/engines/database-engines/replicated). This will make the ClickHouse synchronously fetch all table definition
-from zookeeper and applied locally.
+Waits until the specified [replicated database](https://clickhouse.com/docs/en/engines/database-engines/replicated) applies all schema changes from the DDL queue of that database. 
 
+**Syntax**
+```sql
+SYSTEM SYNC DATABASE REPLICA replicated_database_name;
 ### RESTART REPLICA
 
 Provides possibility to reinitialize Zookeeper session's state for `ReplicatedMergeTree` table, will compare current state with Zookeeper as source of truth and add tasks to Zookeeper queue if needed.

--- a/docs/en/sql-reference/statements/system.md
+++ b/docs/en/sql-reference/statements/system.md
@@ -347,6 +347,8 @@ Waits until the specified [replicated database](https://clickhouse.com/docs/en/e
 **Syntax**
 ```sql
 SYSTEM SYNC DATABASE REPLICA replicated_database_name;
+```
+
 ### RESTART REPLICA
 
 Provides possibility to reinitialize Zookeeper session's state for `ReplicatedMergeTree` table, will compare current state with Zookeeper as source of truth and add tasks to Zookeeper queue if needed.


### PR DESCRIPTION
Signed-off-by: Jianfei Hu <hujianfei258@gmail.com>

The implementation is done long time ago, https://github.com/ClickHouse/ClickHouse/pull/35944/files
But we don't have doc entries for this command. Adding it here based on my understanding.

### Changelog category (leave one):
- Documentation

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add doc for command  `SYSTEM SYNC DATABASE REPLICA`