### PR TITLE
Disable killing the server by systemd 

### DIFF
--- a/packages/clickhouse-server.service
+++ b/packages/clickhouse-server.service
@@ -17,6 +17,10 @@ User=clickhouse
 Group=clickhouse
 Restart=always
 RestartSec=30
+# The following ClickHouse directives should be used instead of forcing SIGKILL by systemd:
+# - shutdown_wait_unfinished_queries
+# - shutdown_wait_unfinished
+TimeoutStopSec=infinity
 # Since ClickHouse is systemd aware default 1m30sec may not be enough
 TimeoutStartSec=0
 # %p is resolved to the systemd unit name

--- a/packages/clickhouse-server.service
+++ b/packages/clickhouse-server.service
@@ -21,6 +21,9 @@ RestartSec=30
 # - shutdown_wait_unfinished_queries
 # - shutdown_wait_unfinished
 TimeoutStopSec=infinity
+# Disable forwarding signals by watchdog, since with default systemd's
+# kill-mode control-group, systemd will send signal to all process in cgroup.
+Environment=CLICKHOUSE_WATCHDOG_NO_FORWARD=1
 # Since ClickHouse is systemd aware default 1m30sec may not be enough
 TimeoutStartSec=0
 # %p is resolved to the systemd unit name

--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -1602,7 +1602,7 @@ try
                 LOG_INFO(log, "Closed all listening sockets.");
 
             if (current_connections > 0)
-                current_connections = waitServersToFinish(servers_to_start_before_tables, servers_lock, config().getInt("shutdown_wait_unfinished", 5));
+                current_connections = waitServersToFinish(servers_to_start_before_tables, servers_lock, server_settings.shutdown_wait_unfinished);
 
             if (current_connections)
                 LOG_INFO(log, "Closed connections to servers for tables. But {} remain. Probably some tables of other users cannot finish their connections after context shutdown.", current_connections);
@@ -1909,7 +1909,7 @@ try
                 global_context->getProcessList().killAllQueries();
 
             if (current_connections)
-                current_connections = waitServersToFinish(servers, servers_lock, config().getInt("shutdown_wait_unfinished", 5));
+                current_connections = waitServersToFinish(servers, servers_lock, server_settings.shutdown_wait_unfinished);
 
             if (current_connections)
                 LOG_WARNING(log, "Closed connections. But {} remain."

--- a/programs/server/config.xml
+++ b/programs/server/config.xml
@@ -1493,4 +1493,10 @@
     <!-- On Linux systems this can control the behavior of OOM killer.
     <oom_score>-1000</oom_score>
     -->
+
+    <!-- Delay (in seconds) to wait for unfinished queries before force exit -->
+    <!-- <shutdown_wait_unfinished>5</shutdown_wait_unfinished> -->
+
+    <!-- If set true ClickHouse will wait for running queries finish before shutdown. -->
+    <!-- <shutdown_wait_unfinished_queries>false</shutdown_wait_unfinished_queries> -->
 </clickhouse>

--- a/src/Core/ServerSettings.h
+++ b/src/Core/ServerSettings.h
@@ -16,6 +16,7 @@ namespace DB
 #define SERVER_SETTINGS(M, ALIAS) \
     M(Bool, show_addresses_in_stack_traces, true, "If it is set true will show addresses in stack traces", 0) \
     M(Bool, shutdown_wait_unfinished_queries, false, "If set true ClickHouse will wait for running queries finish before shutdown.", 0) \
+    M(UInt64, shutdown_wait_unfinished, 5, "Delay in seconds to wait for unfinished queries", 0) \
     M(UInt64, max_thread_pool_size, 10000, "The maximum number of threads that could be allocated from the OS and used for query execution and background operations.", 0) \
     M(UInt64, max_thread_pool_free_size, 1000, "The maximum number of threads that will always stay in a global thread pool once allocated and remain idle in case of insufficient number of tasks.", 0) \
     M(UInt64, thread_pool_queue_size, 10000, "The maximum number of tasks that will be placed in a queue and wait for execution.", 0) \

--- a/src/Daemon/BaseDaemon.cpp
+++ b/src/Daemon/BaseDaemon.cpp
@@ -181,6 +181,15 @@ static void signalHandler(int sig, siginfo_t * info, void * context)
     errno = saved_errno;
 }
 
+static bool getenvBool(const char * name)
+{
+    bool res = false;
+    const char * env_var = getenv(name); // NOLINT(concurrency-mt-unsafe)
+    if (env_var && 0 == strcmp(env_var, "1"))
+        res = true;
+    return res;
+}
+
 
 /// Avoid link time dependency on DB/Interpreters - will use this function only when linked.
 __attribute__((__weak__)) void collectCrashLog(
@@ -1110,10 +1119,8 @@ void BaseDaemon::setupWatchdog()
     if (argv0)
         original_process_name = argv0;
 
-    bool restart = false;
-    const char * env_watchdog_restart = getenv("CLICKHOUSE_WATCHDOG_RESTART"); // NOLINT(concurrency-mt-unsafe)
-    if (env_watchdog_restart && 0 == strcmp(env_watchdog_restart, "1"))
-        restart = true;
+    bool restart = getenvBool("CLICKHOUSE_WATCHDOG_RESTART");
+    bool forward_signals = !getenvBool("CLICKHOUSE_WATCHDOG_NO_FORWARD");
 
     while (true)
     {
@@ -1194,23 +1201,37 @@ void BaseDaemon::setupWatchdog()
         logger().information(fmt::format("Will watch for the process with pid {}", pid));
 
         /// Forward signals to the child process.
-        addSignalHandler(
-            {SIGHUP, SIGINT, SIGQUIT, SIGTERM},
-            [](int sig, siginfo_t *, void *)
-            {
-                /// Forward all signals except INT as it can be send by terminal to the process group when user press Ctrl+C,
-                /// and we process double delivery of this signal as immediate termination.
-                if (sig == SIGINT)
-                    return;
-
-                const char * error_message = "Cannot forward signal to the child process.\n";
-                if (0 != ::kill(pid, sig))
+        if (forward_signals)
+        {
+            addSignalHandler(
+                {SIGHUP, SIGINT, SIGQUIT, SIGTERM},
+                [](int sig, siginfo_t *, void *)
                 {
-                    auto res = write(STDERR_FILENO, error_message, strlen(error_message));
-                    (void)res;
+                    /// Forward all signals except INT as it can be send by terminal to the process group when user press Ctrl+C,
+                    /// and we process double delivery of this signal as immediate termination.
+                    if (sig == SIGINT)
+                        return;
+
+                    const char * error_message = "Cannot forward signal to the child process.\n";
+                    if (0 != ::kill(pid, sig))
+                    {
+                        auto res = write(STDERR_FILENO, error_message, strlen(error_message));
+                        (void)res;
+                    }
+                },
+                nullptr);
+        }
+        else
+        {
+            for (const auto & sig : {SIGHUP, SIGINT, SIGQUIT, SIGTERM})
+            {
+                if (SIG_ERR == signal(sig, SIG_IGN))
+                {
+                    char * signal_description = strsignal(sig); // NOLINT(concurrency-mt-unsafe)
+                    throwFromErrno(fmt::format("Cannot ignore {}", signal_description), ErrorCodes::SYSTEM_ERROR);
                 }
-            },
-            nullptr);
+            }
+        }
 
         int status = 0;
         do


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Disable killing the server by systemd (that may lead to data loss when using Buffer tables)

### Documentation entry for user-facing changes
Default systemd's timeout for sending SIGKILL after SIGTERM is 1m30s
(TimeoutStopSec), which is can be not enough to wait for queries or
shutdown the storages.

And besides in this case shutdown_wait_unfinished server settings are
ignored.

So let's just disable this systemd logic and rely on
shutdown_wait_unfinished instead.

But note shutting down the storages can take a while, but it is better
to give it time instead of killing the process, since killing may lead
to data loss.