### PR TITLE
Fix 02882_clickhouse_keeper_client_no_confirmation test

### DIFF
--- a/tests/queries/0_stateless/02882_clickhouse_keeper_client_no_confirmation.sh
+++ b/tests/queries/0_stateless/02882_clickhouse_keeper_client_no_confirmation.sh
@@ -8,6 +8,6 @@ path="/test-keeper-client-$CLICKHOUSE_DATABASE"
 
 $CLICKHOUSE_KEEPER_CLIENT -q "rm $path" >& /dev/null
 
-$CLICKHOUSE_KEEPER_CLIENT -q "create $path '' 0"
+$CLICKHOUSE_KEEPER_CLIENT -q "create $path 'foobar'"
 $CLICKHOUSE_KEEPER_CLIENT -q "rmr $path"
 $CLICKHOUSE_KEEPER_CLIENT -q "get $path" 2>&1


### PR DESCRIPTION
The syntax of the command had been changed, let's update the test.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Closes: https://github.com/ClickHouse/ClickHouse/pull/54759
Follow-up for: https://github.com/ClickHouse/ClickHouse/pull/54632
Cc: @tavplubix 