### PR TITLE
Don't use default move assignment in TimerDescriptor

### DIFF
--- a/src/Common/TimerDescriptor.cpp
+++ b/src/Common/TimerDescriptor.cpp
@@ -32,6 +32,12 @@ TimerDescriptor::TimerDescriptor(TimerDescriptor && other) noexcept : timer_fd(o
     other.timer_fd = -1;
 }
 
+TimerDescriptor & TimerDescriptor::operator=(DB::TimerDescriptor && other) noexcept
+{
+    std::swap(timer_fd, other.timer_fd);
+    return *this;
+}
+
 TimerDescriptor::~TimerDescriptor()
 {
     /// Do not check for result cause cannot throw exception.

--- a/src/Common/TimerDescriptor.h
+++ b/src/Common/TimerDescriptor.h
@@ -18,7 +18,7 @@ public:
     TimerDescriptor(const TimerDescriptor &) = delete;
     TimerDescriptor & operator=(const TimerDescriptor &) = delete;
     TimerDescriptor(TimerDescriptor && other) noexcept;
-    TimerDescriptor & operator=(TimerDescriptor &&) = default;
+    TimerDescriptor & operator=(TimerDescriptor &&) noexcept;
 
     int getDescriptor() const { return timer_fd; }
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
