### PR TITLE
increase s3_retry_attempts

### DIFF
--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -103,7 +103,7 @@ class IColumn;
     M(Bool, s3_check_objects_after_upload, false, "Check each uploaded object to s3 with head request to be sure that upload was successful", 0) \
     M(Bool, s3_allow_parallel_part_upload, true, "Use multiple threads for s3 multipart upload. It may lead to slightly higher memory usage", 0) \
     M(Bool, s3_throw_on_zero_files_match, false, "Throw an error, when ListObjects request cannot match any files", 0) \
-    M(UInt64, s3_retry_attempts, 10, "Setting for Aws::Client::RetryStrategy, Aws::Client does retries itself, 0 means no retries", 0) \
+    M(UInt64, s3_retry_attempts, 100, "Setting for Aws::Client::RetryStrategy, Aws::Client does retries itself, 0 means no retries", 0) \
     M(UInt64, s3_request_timeout_ms, 3000, "Idleness timeout for sending and receiving data to/from S3. Fail if a single TCP read or write call blocks for this long.", 0) \
     M(UInt64, s3_http_connection_pool_size, 1000, "How many reusable open connections to keep per S3 endpoint. Only applies to the S3 table engine and table function, not to S3 disks (for disks, use disk config instead). Global setting, can only be set in config, overriding it per session or per query has no effect.", 0) \
     M(Bool, enable_s3_requests_logging, false, "Enable very explicit logging of S3 requests. Makes sense for debug only.", 0) \

--- a/tests/integration/test_checking_s3_blobs_paranoid/configs/inf_s3_retries.xml
+++ b/tests/integration/test_checking_s3_blobs_paranoid/configs/inf_s3_retries.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<clickhouse>
+    <profiles>
+        <default>
+            <s3_retry_attempts>1000000</s3_retry_attempts>
+        </default>
+    </profiles>
+</clickhouse>

--- a/tests/integration/test_checking_s3_blobs_paranoid/configs/setting.xml
+++ b/tests/integration/test_checking_s3_blobs_paranoid/configs/setting.xml
@@ -5,6 +5,7 @@
         <default>
             <s3_check_objects_after_upload>1</s3_check_objects_after_upload>
             <enable_s3_requests_logging>1</enable_s3_requests_logging>
+            <s3_retry_attempts>5</s3_retry_attempts>
         </default>
     </profiles>
 

--- a/tests/integration/test_checking_s3_blobs_paranoid/test.py
+++ b/tests/integration/test_checking_s3_blobs_paranoid/test.py
@@ -22,6 +22,17 @@ def cluster():
             ],
             with_minio=True,
         )
+        cluster.add_instance(
+            "node_with_inf_s3_retries",
+            main_configs=[
+                "configs/storage_conf.xml",
+            ],
+            user_configs=[
+                "configs/setting.xml",
+                "configs/inf_s3_retries.xml",
+            ],
+            with_minio=True,
+        )
         logging.info("Starting cluster...")
         cluster.start()
         logging.info("Cluster started")
@@ -468,7 +479,7 @@ def test_when_s3_broken_pipe_at_upload_is_retried(cluster, broken_s3):
 
 
 def test_query_is_canceled_with_inf_retries(cluster, broken_s3):
-    node = cluster.instances["node"]
+    node = cluster.instances["node_with_inf_s3_retries"]
 
     broken_s3.setup_at_part_upload(
         count=10000000,
@@ -490,7 +501,6 @@ def test_query_is_canceled_with_inf_retries(cluster, broken_s3):
         FROM system.numbers
         LIMIT 1000000
         SETTINGS
-            s3_retry_attempts=1000000,
             s3_max_single_part_upload_size=100,
             s3_min_upload_part_size=10000,
             s3_check_objects_after_upload=0

--- a/tests/integration/test_mask_sensitive_info/configs/users.xml
+++ b/tests/integration/test_mask_sensitive_info/configs/users.xml
@@ -1,4 +1,9 @@
 <clickhouse>
+    <profiles>
+        <default>
+            <s3_retry_attempts>5</s3_retry_attempts>
+        </default>
+    </profiles>
     <users>
         <default>
             <password></password>

--- a/tests/integration/test_s3_table_functions/configs/users.d/users.xml
+++ b/tests/integration/test_s3_table_functions/configs/users.d/users.xml
@@ -1,4 +1,9 @@
 <clickhouse>
+    <profiles>
+        <default>
+            <s3_retry_attempts>5</s3_retry_attempts>
+        </default>
+    </profiles>
     <users>
         <default>
             <password></password>

--- a/tests/integration/test_storage_s3/configs/defaultS3.xml
+++ b/tests/integration/test_storage_s3/configs/defaultS3.xml
@@ -1,4 +1,9 @@
 <clickhouse>
+    <profiles>
+        <default>
+            <s3_retry_attempts>5</s3_retry_attempts>
+        </default>
+    </profiles>
     <s3>
         <s3_mock>
             <endpoint>http://resolver:8080</endpoint>

--- a/tests/integration/test_storage_s3/configs/s3_retry.xml
+++ b/tests/integration/test_storage_s3/configs/s3_retry.xml
@@ -1,0 +1,7 @@
+<clickhouse>
+    <profiles>
+        <default>
+            <s3_retry_attempts>5</s3_retry_attempts>
+        </default>
+    </profiles>
+</clickhouse>

--- a/tests/integration/test_storage_s3/test.py
+++ b/tests/integration/test_storage_s3/test.py
@@ -55,7 +55,7 @@ def started_cluster():
                 "configs/named_collections.xml",
                 "configs/schema_cache.xml",
             ],
-            user_configs=["configs/access.xml", "configs/users.xml"],
+            user_configs=["configs/access.xml", "configs/users.xml", "configs/s3_retry.xml"],
         )
         cluster.add_instance(
             "dummy_without_named_collections",
@@ -71,7 +71,7 @@ def started_cluster():
             "s3_max_redirects",
             with_minio=True,
             main_configs=["configs/defaultS3.xml"],
-            user_configs=["configs/s3_max_redirects.xml"],
+            user_configs=["configs/s3_max_redirects.xml", "configs/s3_retry.xml"],
         )
         cluster.add_instance(
             "s3_non_default",

--- a/tests/integration/test_storage_s3/test.py
+++ b/tests/integration/test_storage_s3/test.py
@@ -55,7 +55,11 @@ def started_cluster():
                 "configs/named_collections.xml",
                 "configs/schema_cache.xml",
             ],
-            user_configs=["configs/access.xml", "configs/users.xml", "configs/s3_retry.xml"],
+            user_configs=[
+                "configs/access.xml",
+                "configs/users.xml",
+                "configs/s3_retry.xml",
+            ],
         )
         cluster.add_instance(
             "dummy_without_named_collections",


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
It is better to retry retriable s3 errors than totally fail the query. Set bigger value to the s3_retry_attempts by default.

It is safe to increase s3_retry_attempts after this fixes:
https://github.com/ClickHouse/ClickHouse/pull/54651
https://github.com/ClickHouse/ClickHouse/pull/54697