### PR TITLE
Add retries to rests test_async_query_sending/test_async_connect

### DIFF
--- a/tests/integration/test_hedged_requests/test.py
+++ b/tests/integration/test_hedged_requests/test.py
@@ -133,7 +133,7 @@ def check_if_query_sending_was_suspended():
         "SELECT value FROM system.events WHERE event='SuspendSendingQueryToShard'"
     )
 
-    assert int(result) >= 1
+    return len(result) != 0 and int(result) >= 1
 
 
 def check_if_query_sending_was_not_suspended():
@@ -380,11 +380,19 @@ def test_async_connect(started_cluster):
     # Restart server to reset connection pool state
     NODES["node"].restart_clickhouse()
 
-    NODES["node"].query(
-        "SELECT hostName(), id FROM distributed_connect ORDER BY id LIMIT 1 SETTINGS prefer_localhost_replica = 0, connect_timeout_with_failover_ms=5000, async_query_sending_for_remote=1, max_threads=1, max_distributed_connections=1"
-    )
-    check_changing_replica_events(2)
-    check_if_query_sending_was_suspended()
+    attempt = 0
+    while attempt < 1000:
+        NODES["node"].query(
+            "SELECT hostName(), id FROM distributed_connect ORDER BY id LIMIT 1 SETTINGS prefer_localhost_replica = 0, connect_timeout_with_failover_ms=5000, async_query_sending_for_remote=1, max_threads=1, max_distributed_connections=1"
+        )
+
+        check_changing_replica_events(2)
+        if check_if_query_sending_was_suspended():
+            break
+
+        attempt += 1
+
+    assert attempt < 1000
 
     NODES["node"].query("DROP TABLE distributed_connect")
 
@@ -418,10 +426,17 @@ def test_async_query_sending(started_cluster):
     )
     check_if_query_sending_was_not_suspended()
 
-    NODES["node"].query(
-        "SELECT hostName(), id FROM distributed_query_sending ORDER BY id LIMIT 1 SETTINGS"
-        " prefer_localhost_replica = 0, async_query_sending_for_remote=1, max_threads = 1, max_distributed_connections=1"
-    )
-    check_if_query_sending_was_suspended()
+    attempt = 0
+    while attempt < 1000:
+        NODES["node"].query(
+            "SELECT hostName(), id FROM distributed_query_sending ORDER BY id LIMIT 1 SETTINGS"
+            " prefer_localhost_replica = 0, async_query_sending_for_remote=1, max_threads = 1, max_distributed_connections=1"
+        )
 
+        if check_if_query_sending_was_suspended():
+            break
+
+        attempt += 1
+
+    assert attempt < 1000
     NODES["node"].query("DROP TABLE distributed_query_sending")

--- a/tests/integration/test_hedged_requests/test.py
+++ b/tests/integration/test_hedged_requests/test.py
@@ -381,7 +381,7 @@ def test_async_connect(started_cluster):
     NODES["node"].restart_clickhouse()
 
     attempt = 0
-    while attempt < 1000:
+    while attempt < 100:
         NODES["node"].query(
             "SELECT hostName(), id FROM distributed_connect ORDER BY id LIMIT 1 SETTINGS prefer_localhost_replica = 0, connect_timeout_with_failover_ms=5000, async_query_sending_for_remote=1, max_threads=1, max_distributed_connections=1"
         )
@@ -392,7 +392,7 @@ def test_async_connect(started_cluster):
 
         attempt += 1
 
-    assert attempt < 1000
+    assert attempt < 100
 
     NODES["node"].query("DROP TABLE distributed_connect")
 
@@ -427,7 +427,7 @@ def test_async_query_sending(started_cluster):
     check_if_query_sending_was_not_suspended()
 
     attempt = 0
-    while attempt < 1000:
+    while attempt < 100:
         NODES["node"].query(
             "SELECT hostName(), id FROM distributed_query_sending ORDER BY id LIMIT 1 SETTINGS"
             " prefer_localhost_replica = 0, async_query_sending_for_remote=1, max_threads = 1, max_distributed_connections=1"
@@ -438,5 +438,5 @@ def test_async_query_sending(started_cluster):
 
         attempt += 1
 
-    assert attempt < 1000
+    assert attempt < 100
     NODES["node"].query("DROP TABLE distributed_query_sending")


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
