### PR TITLE
Optimise memory consumption when external group by generates ton of temporary files

### DIFF
--- a/src/Disks/tests/gtest_disk.cpp
+++ b/src/Disks/tests/gtest_disk.cpp
@@ -7,16 +7,17 @@
 namespace fs = std::filesystem;
 
 
-DB::DiskPtr createDisk()
+DB::DiskPtr createDisk(const std::string & path)
 {
-    fs::create_directory("tmp/");
-    return std::make_shared<DB::DiskLocal>("local_disk", "tmp/");
+    fs::create_directory(path);
+    return std::make_shared<DB::DiskLocal>("local_disk", path);
 }
 
 void destroyDisk(DB::DiskPtr & disk)
 {
+    const auto path = disk->getPath();
     disk.reset();
-    fs::remove_all("tmp/");
+    fs::remove_all(path);
 }
 
 class DiskTest : public testing::Test

--- a/src/Disks/tests/gtest_disk.h
+++ b/src/Disks/tests/gtest_disk.h
@@ -3,6 +3,6 @@
 #include <Disks/DiskLocal.h>
 #include <Disks/IDisk.h>
 
-DB::DiskPtr createDisk();
+DB::DiskPtr createDisk(const std::string & path = "tmp/");
 
 void destroyDisk(DB::DiskPtr & disk);

--- a/src/Interpreters/TemporaryDataOnDisk.cpp
+++ b/src/Interpreters/TemporaryDataOnDisk.cpp
@@ -205,16 +205,16 @@ struct TemporaryFileStream::OutputWriter
 
 struct TemporaryFileStream::InputReader
 {
-    InputReader(const String & path, const Block & header_, size_t size)
-        : in_file_buf(path, std::min<size_t>(DBMS_DEFAULT_BUFFER_SIZE, size))
+    InputReader(const String & path, const Block & header_, size_t size = 0)
+        : in_file_buf(path, size ? std::min<size_t>(DBMS_DEFAULT_BUFFER_SIZE, size) : DBMS_DEFAULT_BUFFER_SIZE)
         , in_compressed_buf(in_file_buf)
         , in_reader(in_compressed_buf, header_, DBMS_TCP_PROTOCOL_VERSION)
     {
         LOG_TEST(&Poco::Logger::get("TemporaryFileStream"), "Reading {} from {}", header_.dumpStructure(), path);
     }
 
-    InputReader(const String & path, size_t size)
-        : in_file_buf(path, std::min<size_t>(DBMS_DEFAULT_BUFFER_SIZE, size))
+    explicit InputReader(const String & path, size_t size = 0)
+        : in_file_buf(path, size ? std::min<size_t>(DBMS_DEFAULT_BUFFER_SIZE, size) : DBMS_DEFAULT_BUFFER_SIZE)
         , in_compressed_buf(in_file_buf)
         , in_reader(in_compressed_buf, DBMS_TCP_PROTOCOL_VERSION)
     {

--- a/src/Interpreters/TemporaryDataOnDisk.cpp
+++ b/src/Interpreters/TemporaryDataOnDisk.cpp
@@ -11,7 +11,7 @@
 #include <Disks/DiskLocal.h>
 #include <Disks/IO/WriteBufferFromTemporaryFile.h>
 
-#include <Common/logger_useful.h>
+#include <Core/Defines.h>
 #include <Interpreters/Cache/WriteBufferToFileSegment.h>
 
 namespace DB
@@ -205,16 +205,16 @@ struct TemporaryFileStream::OutputWriter
 
 struct TemporaryFileStream::InputReader
 {
-    InputReader(const String & path, const Block & header_)
-        : in_file_buf(path)
+    InputReader(const String & path, const Block & header_, size_t size)
+        : in_file_buf(path, std::min<size_t>(DBMS_DEFAULT_BUFFER_SIZE, size))
         , in_compressed_buf(in_file_buf)
         , in_reader(in_compressed_buf, header_, DBMS_TCP_PROTOCOL_VERSION)
     {
         LOG_TEST(&Poco::Logger::get("TemporaryFileStream"), "Reading {} from {}", header_.dumpStructure(), path);
     }
 
-    explicit InputReader(const String & path)
-        : in_file_buf(path)
+    InputReader(const String & path, size_t size)
+        : in_file_buf(path, std::min<size_t>(DBMS_DEFAULT_BUFFER_SIZE, size))
         , in_compressed_buf(in_file_buf)
         , in_reader(in_compressed_buf, DBMS_TCP_PROTOCOL_VERSION)
     {
@@ -305,7 +305,7 @@ Block TemporaryFileStream::read()
 
     if (!in_reader)
     {
-        in_reader = std::make_unique<InputReader>(getPath(), header);
+        in_reader = std::make_unique<InputReader>(getPath(), header, getSize());
     }
 
     Block block = in_reader->read();
@@ -368,6 +368,16 @@ String TemporaryFileStream::getPath() const
         return file->getAbsolutePath();
     if (segment_holder && !segment_holder->empty())
         return segment_holder->front().getPathInLocalCache();
+
+    throw Exception(ErrorCodes::LOGICAL_ERROR, "TemporaryFileStream has no file");
+}
+
+size_t TemporaryFileStream::getSize() const
+{
+    if (file)
+        return file->getDisk()->getFileSize(file->getRelativePath());
+    if (segment_holder && !segment_holder->empty())
+        return segment_holder->front().getReservedSize();
 
     throw Exception(ErrorCodes::LOGICAL_ERROR, "TemporaryFileStream has no file");
 }

--- a/src/Interpreters/TemporaryDataOnDisk.h
+++ b/src/Interpreters/TemporaryDataOnDisk.h
@@ -141,6 +141,7 @@ public:
     Block read();
 
     String getPath() const;
+    size_t getSize() const;
 
     Block getHeader() const { return header; }
 

--- a/src/Interpreters/tests/gtest_lru_file_cache.cpp
+++ b/src/Interpreters/tests/gtest_lru_file_cache.cpp
@@ -985,7 +985,7 @@ TEST_F(FileCacheTest, TemporaryDataReadBufferSize)
         DiskPtr disk;
         SCOPE_EXIT_SAFE(destroyDisk(disk));
 
-        disk = createDisk();
+        disk = createDisk("temporary_data_read_buffer_size_test_dir");
         VolumePtr volume = std::make_shared<SingleDiskVolume>("volume", disk);
 
         auto tmp_data_scope = std::make_shared<TemporaryDataOnDiskScope>(/*volume=*/volume, /*cache=*/nullptr, /*limit=*/0);

--- a/src/Interpreters/tests/gtest_lru_file_cache.cpp
+++ b/src/Interpreters/tests/gtest_lru_file_cache.cpp
@@ -1,30 +1,37 @@
+#include <filesystem>
 #include <iomanip>
 #include <iostream>
-#include <gtest/gtest.h>
-#include <Interpreters/Cache/FileCache.h>
-#include <Interpreters/Cache/FileSegment.h>
-#include <Common/CurrentThread.h>
-#include <Common/filesystemHelpers.h>
-#include <Interpreters/Cache/FileCacheSettings.h>
-#include <Interpreters/TemporaryDataOnDisk.h>
-#include <Common/tests/gtest_global_context.h>
-#include <Common/SipHash.h>
-#include <base/hex.h>
-#include <Interpreters/Context.h>
-#include <IO/ReadHelpers.h>
-#include <IO/WriteHelpers.h>
-#include <filesystem>
+#include <memory>
 #include <thread>
 #include <DataTypes/DataTypesNumber.h>
-#include <Poco/Util/XMLConfiguration.h>
-#include <Poco/DOM/DOMParser.h>
+#include <IO/ReadHelpers.h>
+#include <IO/WriteHelpers.h>
+#include <Interpreters/Cache/FileCache.h>
+#include <Interpreters/Cache/FileCacheSettings.h>
+#include <Interpreters/Cache/FileSegment.h>
+#include <Interpreters/Context.h>
+#include <Interpreters/TemporaryDataOnDisk.h>
+#include <base/hex.h>
 #include <base/sleep.h>
+#include <gtest/gtest.h>
+#include <Poco/DOM/DOMParser.h>
+#include <Poco/Util/XMLConfiguration.h>
+#include <Common/CurrentThread.h>
+#include <Common/SipHash.h>
+#include <Common/filesystemHelpers.h>
+#include <Common/scope_guard_safe.h>
+#include <Common/tests/gtest_global_context.h>
 
 #include <Poco/ConsoleChannel.h>
 #include <Disks/IO/CachedOnDiskWriteBufferFromFile.h>
 #include <Disks/IO/CachedOnDiskReadBufferFromFile.h>
 #include <Disks/IO/createReadBufferFromFileBase.h>
 #include <Interpreters/Cache/WriteBufferToFileSegment.h>
+
+#include <Disks/SingleDiskVolume.h>
+#include <Disks/tests/gtest_disk.h>
+#include <Interpreters/DatabaseCatalog.h>
+#include <base/scope_guard.h>
 
 namespace fs = std::filesystem;
 using namespace DB;
@@ -944,5 +951,52 @@ TEST_F(FileCacheTest, CachedReadBuffer)
         cached_buffer->position() = cached_buffer->buffer().end();
         cached_buffer->next();
         assertEqual(cache->dumpQueue(), {Range(10, 14), Range(15, 19), Range(20, 24), Range(25, 29), Range(0, 4), Range(5, 9) });
+    }
+}
+
+TEST_F(FileCacheTest, TemporaryDataReadBufferSize)
+{
+    /// Temporary data stored in cache
+    {
+        DB::FileCacheSettings settings;
+        settings.max_size = 10_KiB;
+        settings.max_file_segment_size = 1_KiB;
+        settings.base_path = cache_base_path;
+
+        DB::FileCache file_cache("cache", settings);
+        file_cache.initialize();
+
+        auto tmp_data_scope = std::make_shared<TemporaryDataOnDiskScope>(/*volume=*/nullptr, &file_cache, /*limit=*/0);
+
+        auto tmp_data = std::make_unique<TemporaryDataOnDisk>(tmp_data_scope);
+
+        auto block = generateBlock(/*size=*/3);
+        auto & stream = tmp_data->createStream(block);
+        stream.write(block);
+        stream.finishWriting();
+
+        /// We allocate buffer of size min(getSize(), DBMS_DEFAULT_BUFFER_SIZE)
+        /// We do care about buffer size because realistic external group by could generate 10^5 temporary files
+        ASSERT_EQ(stream.getSize(), 62);
+    }
+
+    /// Temporary data stored on disk
+    {
+        DiskPtr disk;
+        SCOPE_EXIT_SAFE(destroyDisk(disk));
+
+        disk = createDisk();
+        VolumePtr volume = std::make_shared<SingleDiskVolume>("volume", disk);
+
+        auto tmp_data_scope = std::make_shared<TemporaryDataOnDiskScope>(/*volume=*/volume, /*cache=*/nullptr, /*limit=*/0);
+
+        auto tmp_data = std::make_unique<TemporaryDataOnDisk>(tmp_data_scope);
+
+        auto block = generateBlock(/*size=*/3);
+        auto & stream = tmp_data->createStream(block);
+        stream.write(block);
+        stream.finishWriting();
+
+        ASSERT_EQ(stream.getSize(), 62);
     }
 }


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Optimised external aggregation memory consumption in case many temporary files were generated. 

---

The problem:

``` sql
<Debug> AggregatingTransform: Will merge 168207 temporary files of size 7.01 GiB compressed, 117.39 GiB uncompressed.
```