### PR TITLE
test with truncate distributed table

### DIFF
--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -3378,6 +3378,7 @@ class ClickHouseInstance:
     ):
         # logging.debug(f"Executing query {sql} on {self.name}")
         result = None
+        exception = None
         for i in range(retry_count):
             try:
                 result = self.query(
@@ -3396,11 +3397,14 @@ class ClickHouseInstance:
                 time.sleep(sleep_time)
             except Exception as ex:
                 # logging.debug("Retry {} got exception {}".format(i + 1, ex))
+                exception = ex
                 time.sleep(sleep_time)
 
         if result is not None:
             return result
-        raise Exception("Can't execute query {}".format(sql))
+        raise Exception(
+            "Can't execute query {} with exception {}".format(sql, exception)
+        )
 
     # As query() but doesn't wait response and returns response handler
     def get_query_request(self, sql, *args, **kwargs):

--- a/tests/integration/test_distributed_ddl/cluster.py
+++ b/tests/integration/test_distributed_ddl/cluster.py
@@ -154,14 +154,14 @@ class ClickHouseClusterWithDDLHelpers(ClickHouseCluster):
         )
 
     @staticmethod
-    def insert_reliable(instance, query_insert):
+    def insert_reliable(instance, *args, **kwargs):
         """
         Make retries in case of UNKNOWN_STATUS_OF_INSERT or zkutil::KeeperException errors
         """
 
         for i in range(100):
             try:
-                instance.query(query_insert)
+                instance.query(*args, **kwargs)
                 return
             except Exception as e:
                 last_exception = e

--- a/tests/integration/test_distributed_ddl/test_truncate.py
+++ b/tests/integration/test_distributed_ddl/test_truncate.py
@@ -1,0 +1,159 @@
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from helpers.test_tools import TSV
+from .cluster import ClickHouseClusterWithDDLHelpers
+
+
+@pytest.fixture(scope="module")
+def test_cluster():
+    cluster = ClickHouseClusterWithDDLHelpers(__file__, "configs", "truncate")
+
+    try:
+        # TODO: Fix ON CLUSTER alters when nodes have different configs. Need to canonicalize node identity.
+        cluster.prepare(replace_hostnames_with_ips=False)
+
+        firewall_drops_rules = cluster.pm_random_drops.pop_rules()
+
+        yield cluster
+
+        # Enable random ZK packet drops
+        cluster.pm_random_drops.push_rules(firewall_drops_rules)
+
+        instance = cluster.instances["ch1"]
+
+        cluster.ddl_check_query(
+            instance, "DROP TABLE IF EXISTS replicated_table ON CLUSTER cluster SYNC"
+        )
+
+        cluster.ddl_check_query(
+            instance, "DROP TABLE IF EXISTS dist_table ON CLUSTER cluster SYNC"
+        )
+
+        cluster.pm_random_drops.heal_all()
+
+    finally:
+        cluster.shutdown()
+
+
+def test_truncate_over_replicated(test_cluster):
+    instance = test_cluster.instances["ch2"]
+
+    test_cluster.ddl_check_query(
+        instance, "DROP TABLE IF EXISTS replicated_table ON CLUSTER cluster SYNC"
+    )
+
+    test_cluster.ddl_check_query(
+        instance, "DROP TABLE IF EXISTS dist_table ON CLUSTER cluster SYNC"
+    )
+
+    # Temporarily disable random ZK packet drops, they might broke creation if ReplicatedMergeTree replicas
+    firewall_drops_rules = test_cluster.pm_random_drops.pop_rules()
+
+    test_cluster.ddl_check_query(
+        instance,
+        """
+        CREATE TABLE IF NOT EXISTS replicated_table ON CLUSTER cluster (shard Int32, step Int32, src_node Int32)
+        ENGINE = ReplicatedMergeTree('/clickhouse/tables/{layer}-{shard}/replicated_table', '{replica}')
+        ORDER BY (shard, step, src_node)
+        """,
+    )
+
+    test_cluster.ddl_check_query(
+        instance,
+        """
+        CREATE TABLE IF NOT EXISTS dist_table ON CLUSTER cluster (shard Int32, step Int32, src_node Int32)
+        ENGINE = Distributed(cluster, default, replicated_table, shard%2)
+        """,
+    )
+
+    select_query = """
+        SELECT shard, step, src_node FROM dist_table
+        ORDER BY shard, step, src_node
+        """
+
+    expected_data = []
+
+    # async insert and sync replicated table
+    for i in range(4):
+        node_shard = i // 2 * 2
+        dst_shard = (node_shard + 1) % 2
+        test_cluster.instances["ch{}".format(i + 1)].query(
+            f"INSERT INTO dist_table VALUES ({dst_shard}, 1, {i})",
+            settings={"async_insert": "1", "wait_for_async_insert": "0"},
+        )
+        expected_data += [[dst_shard, 1, i]]
+
+    instance.query("SYSTEM FLUSH DISTRIBUTED dist_table ON CLUSTER cluster")
+
+    test_cluster.sync_replicas("replicated_table")
+
+    assert TSV(instance.query(select_query)) == TSV(expected_data)
+
+    # async insert with quorum 2, no need to sync replica, but still need to flush distributed
+    for i in range(4):
+        node_shard = i // 2 * 2
+        dst_shard = (node_shard + 1) % 2
+        test_cluster.instances["ch{}".format(i + 1)].query(
+            f"INSERT INTO dist_table VALUES ({dst_shard}, 2, {i})",
+            settings={
+                "insert_quorum": "2",
+                "async_insert": "1",
+                "wait_for_async_insert": "0",
+            },
+        )
+        expected_data += [[dst_shard, 2, i]]
+
+    instance.query("SYSTEM FLUSH DISTRIBUTED dist_table ON CLUSTER cluster")
+
+    assert TSV(instance.query(select_query)) == TSV(expected_data)
+
+    # insert with quorum 3, queries would be stuck
+    for i in range(4):
+        node_shard = i // 2 * 2
+        dst_shard = (node_shard + 1) % 2
+        test_cluster.instances["ch{}".format(i + 1)].query(
+            f"INSERT INTO dist_table VALUES ({dst_shard}, 3, {i})",
+            settings={
+                "insert_quorum": "3",
+                "async_insert": "1",
+                "wait_for_async_insert": "0",
+            },
+        )
+        # write is failed
+        # expected_data += [[dst_shard, 3, i]]
+
+    error = instance.query_and_get_error(
+        "SYSTEM FLUSH DISTRIBUTED dist_table ON CLUSTER cluster"
+    )
+
+    assert "Number of alive replicas (2) is less than requested quorum (3/2)" in error
+    assert "TOO_FEW_LIVE_REPLICAS" in error
+
+    assert TSV(instance.query(select_query)) == TSV(expected_data)
+
+    instance.query("TRUNCATE TABLE dist_table ON CLUSTER cluster")
+
+    instance.query("SYSTEM FLUSH DISTRIBUTED dist_table ON CLUSTER cluster")
+
+    # insert after recover
+    for i in range(4):
+        node_shard = i // 2 * 2
+        dst_shard = (node_shard + 1) % 2
+        test_cluster.instances["ch{}".format(i + 1)].query(
+            f"INSERT INTO dist_table VALUES ({dst_shard}, 4, {i})",
+            settings={
+                "insert_quorum": "2",
+                "async_insert": "1",
+                "wait_for_async_insert": "0",
+            },
+        )
+        expected_data += [[dst_shard, 4, i]]
+
+    instance.query("SYSTEM FLUSH DISTRIBUTED dist_table ON CLUSTER cluster")
+
+    assert TSV(instance.query(select_query)) == TSV(expected_data)


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
The test claims that it is all right with truncate call for distributed table that it does not trigger any actions with the table below.