### PR TITLE
Make clickhouse-local logging (server_logs_file) prepend timestamps etc

### DIFF
--- a/programs/local/LocalServer.cpp
+++ b/programs/local/LocalServer.cpp
@@ -32,6 +32,8 @@
 #include <Common/randomSeed.h>
 #include <Common/ThreadPool.h>
 #include <Loggers/Loggers.h>
+#include <Loggers/OwnFormattingChannel.h>
+#include <Loggers/OwnPatternFormatter.h>
 #include <IO/ReadBufferFromFile.h>
 #include <IO/ReadBufferFromString.h>
 #include <IO/WriteBufferFromFileDescriptor.h>
@@ -599,7 +601,9 @@ void LocalServer::processConfig()
     {
         auto poco_logs_level = Poco::Logger::parseLevel(level);
         Poco::Logger::root().setLevel(poco_logs_level);
-        Poco::Logger::root().setChannel(Poco::AutoPtr<Poco::SimpleFileChannel>(new Poco::SimpleFileChannel(server_logs_file)));
+        Poco::AutoPtr<OwnPatternFormatter> pf = new OwnPatternFormatter;
+        Poco::AutoPtr<OwnFormattingChannel> log = new OwnFormattingChannel(pf, new Poco::SimpleFileChannel(server_logs_file));
+        Poco::Logger::root().setChannel(log);
         logging_initialized = true;
     }
     else if (logging || is_interactive)


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
`clickhouse-local`'s log file (if enabled with --server_logs_file flag) will now prefix each line with timestamp, thread id, etc, just like `clickhouse-server`.

Enable the same log embellishments in clickhouse-local as in clickhouse-server. Timestamps and thread ids are especially useful for investigating performance.

Before:
```
Created HTTP(S) session with clickhouse-datasets-us-west-2.s3.us-west-2.amazonaws.com:443 (52.92.240.170:443)
```
After:
```
2023.09.19 00:10:18.758337 [ 1483335 ] {e1027e67-c978-46ee-9144-062ff0022845} <Trace> HTTPSessionAdapter: Created HTTP(S) session with clickhouse-datasets-us-west-2.s3.us-west-2.amazonaws.com:443 (52.92.240.170:443)
```

Or is there a reason why this wasn't enabled before?