### PR TITLE
Prevent parquet schema inference reading the first 1 MB of the file unnecessarily

### DIFF
--- a/src/Formats/ReadSchemaUtils.cpp
+++ b/src/Formats/ReadSchemaUtils.cpp
@@ -5,6 +5,7 @@
 #include <Storages/IStorage.h>
 #include <Common/assert_cast.h>
 #include <IO/WithFileName.h>
+#include <IO/WithFileSize.h>
 
 
 namespace DB
@@ -86,7 +87,16 @@ try
                 buf = read_buffer_iterator.next();
                 if (!buf)
                     break;
-                is_eof = buf->eof();
+
+                /// We just want to check for eof, but eof() can be pretty expensive.
+                /// So we use getFileSize() when available, which has better worst case.
+                /// (For remote files, typically eof() would read 1 MB from S3, which may be much
+                ///  more than what the schema reader and even data reader will read).
+                auto size = tryGetFileSizeFromReadBuffer(*buf);
+                if (size.has_value())
+                    is_eof = *size == 0;
+                else
+                    is_eof = buf->eof();
             }
             catch (Exception & e)
             {


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Parquet schema inference needs to read just the last ~64 KiB of the file. But there was also an `eof()` call before that, just to check if the file is empty, which by default reads 1 MiB of the file, which takes a noticeable time in S3. This PR makes it do getFileSize() instead, which is an S3 request as well, but the result is cached and used later, so the total number of requests doesn't increase.