### PR TITLE
Avoid excessive calls to getifaddrs in isLocalAddress

### DIFF
--- a/src/Common/isLocalAddress.cpp
+++ b/src/Common/isLocalAddress.cpp
@@ -91,16 +91,19 @@ struct NetworkInterfaces : public boost::noncopyable
     {
         static constexpr int NET_INTERFACE_VALID_PERIOD_MS = 30000;
         static NetworkInterfaces nf;
-        static auto last_updated_time = std::chrono::steady_clock::now();
+        static std::atomic<std::chrono::steady_clock::time_point> last_updated_time = std::chrono::steady_clock::now();
         static std::shared_mutex nf_mtx;
 
         auto now = std::chrono::steady_clock::now();
+        auto last_updated_time_snapshot = last_updated_time.load();
 
-        if (std::chrono::duration_cast<std::chrono::milliseconds>(now - last_updated_time).count() > NET_INTERFACE_VALID_PERIOD_MS)
+        if (std::chrono::duration_cast<std::chrono::milliseconds>(now - last_updated_time_snapshot).count() > NET_INTERFACE_VALID_PERIOD_MS)
         {
             std::unique_lock lock(nf_mtx);
+            if (last_updated_time.load() != last_updated_time_snapshot) /// it's possible that last_updated_time after we get the snapshot
+                return nf;
             nf.swap(NetworkInterfaces());
-            last_updated_time = now;
+            last_updated_time.store(now);
             return nf;
         }
         else

--- a/src/Common/isLocalAddress.cpp
+++ b/src/Common/isLocalAddress.cpp
@@ -38,8 +38,9 @@ struct NetworkInterfaces : public boost::noncopyable
 
     void swap(NetworkInterfaces && other)
     {
+        auto * tmp = ifaddr;
         ifaddr = other.ifaddr;
-        other.ifaddr = nullptr;
+        other.ifaddr = tmp;
     }
 
     bool hasAddress(const Poco::Net::IPAddress & address) const

--- a/src/Common/isLocalAddress.cpp
+++ b/src/Common/isLocalAddress.cpp
@@ -78,7 +78,7 @@ struct NetworkInterfaces
         freeifaddrs(ifaddr);
     }
 
-    static NetworkInterfaces & instance()
+    static const NetworkInterfaces & instance()
     {
         static constexpr int NET_INTERFACE_VALID_PERIOD_SECONDS = 30;
         static std::unique_ptr<NetworkInterfaces> nf = std::make_unique<NetworkInterfaces>();


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Avoid excessive calls to getifaddrs in isLocalAddress

We observe that the DDLWorker run extremely slow on some host. When tracing the DDLWorker thread during an `ON CLUSTER` query, most of sample is this stack:

```
#0  __libc_recvmsg (flags=0, msg=0x7f81387f5ef0, fd=689) at ../sysdeps/unix/sysv/linux/recvmsg.c:28
#1  __libc_recvmsg (fd=689, msg=msg@entry=0x7f81387f5ef0, flags=flags@entry=0) at ../sysdeps/unix/sysv/linux/recvmsg.c:25
#2  0x00007f8408d4d85d in __netlink_request (h=h@entry=0x7f81387f5ff0, type=type@entry=18) at ../sysdeps/unix/sysv/linux/ifaddrs.c:173
#3  0x00007f8408d4db91 in getifaddrs_internal (ifap=0x7f81387f6088) at ../sysdeps/unix/sysv/linux/ifaddrs.c:336
#4  0x00007f8408d4e800 in __GI___getifaddrs (ifap=0x7f81387f6088) at ../sysdeps/unix/sysv/linux/ifaddrs.c:838
#5  0x000000000f3c9105 in DB::(anonymous namespace)::NetworkInterfaces::NetworkInterfaces (this=0x7f81387f6088) at ./src/Common/isLocalAddress.cpp:28
#6  DB::isLocalAddress (address=...) at ./src/Common/isLocalAddress.cpp:114
#7  0x00000000141916b0 in DB::isLocalAddress (address=..., clickhouse_port=9001) at ./src/Common/isLocalAddress.cpp:121
#8  DB::HostID::isLocalAddress (this=0x7f3a0909e920, clickhouse_port=9001) at ./src/Interpreters/DDLTask.cpp:45
#9  0x0000000014194a09 in DB::DDLTask::findCurrentHostID (this=0x7f825faf9300, global_context=..., log=0x7f8131ee3b00) at ./src/Interpreters/DDLTask.cpp:222
#10 0x00000000141a1469 in DB::DDLWorker::initAndCheckTask (this=0x7f7f3624ff40, entry_name=..., out_reason=..., zookeeper=...) at ./src/Interpreters/DDLWorker.cpp:207
#11 0x00000000141a497c in DB::DDLWorker::scheduleTasks (this=0x7f7f3624ff40, reinitialized=<optimized out>) at ./src/Interpreters/DDLWorker.cpp:401
#12 0x000000001419ec5f in DB::DDLWorker::runMainThread (this=0x7f7f3624ff40) at ./src/Interpreters/DDLWorker.cpp:1126
```

Running profiling for DDLWorker on the same host:

```
% time     seconds  usecs/call     calls    errors syscall
------ ----------- ----------- --------- --------- ----------------
 65.79  496.403282        1891    262504           recvmsg
 11.60   87.560212        1834     47729           sendto
  5.07   38.267529        5709      6702      1305 futex
  4.36   32.898326        1378     23865           socket
  4.19   31.595030        1323     23864           close
  3.91   29.510535        1236     23865           getsockname
  3.89   29.344959        1229     23865           bind
  1.19    8.979492        5425      1655           madvise
------ ----------- ----------- --------- --------- ----------------
100.00  754.559365        1822    414049      1305 total
```

It isn't neccessary to create new `NetworkInterfaces` object for every isLocalAddress calls.

cc @alesapin 

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
