### PR TITLE
Caching skip-able entries in DDLWorker

### DIFF
--- a/src/Interpreters/DDLWorker.cpp
+++ b/src/Interpreters/DDLWorker.cpp
@@ -167,6 +167,9 @@ ZooKeeperPtr DDLWorker::getAndSetZooKeeper()
 
 DDLTaskPtr DDLWorker::initAndCheckTask(const String & entry_name, String & out_reason, const ZooKeeperPtr & zookeeper)
 {
+    if (entries_to_skip.contains(entry_name))
+        return {};
+
     String node_data;
     String entry_path = fs::path(queue_dir) / entry_name;
 
@@ -186,6 +189,12 @@ DDLTaskPtr DDLWorker::initAndCheckTask(const String & entry_name, String & out_r
         zookeeper->tryCreate(fs::path(entry_path) / "finished" / host_id, status.serializeText(), zkutil::CreateMode::Persistent);
     };
 
+    auto add_to_skip_set = [&]()
+    {
+        entries_to_skip.insert(entry_name);
+        return nullptr;
+    };
+
     try
     {
         /// Stage 1: parse entry
@@ -198,7 +207,7 @@ DDLTaskPtr DDLWorker::initAndCheckTask(const String & entry_name, String & out_r
         /// Otherwise, that node will be ignored by DDLQueryStatusSource.
         out_reason = "Incorrect task format";
         write_error_status(host_fqdn_id, ExecutionStatus::fromCurrentException(), out_reason);
-        return {};
+        return add_to_skip_set();
     }
 
     /// Stage 2: resolve host_id and check if we should execute query or not
@@ -207,7 +216,7 @@ DDLTaskPtr DDLWorker::initAndCheckTask(const String & entry_name, String & out_r
     if (!task->findCurrentHostID(context, log))
     {
         out_reason = "There is no a local address in host list";
-        return {};
+        return add_to_skip_set();
     }
 
     try
@@ -223,13 +232,13 @@ DDLTaskPtr DDLWorker::initAndCheckTask(const String & entry_name, String & out_r
     {
         out_reason = "Cannot parse query or obtain cluster info";
         write_error_status(task->host_id_str, ExecutionStatus::fromCurrentException(), out_reason);
-        return {};
+        return add_to_skip_set();
     }
 
     if (zookeeper->exists(task->getFinishedNodePath()))
     {
         out_reason = TASK_PROCESSED_OUT_REASON;
-        return {};
+        return add_to_skip_set();
     }
 
     /// Now task is ready for execution
@@ -955,6 +964,7 @@ void DDLWorker::cleanupQueue(Int64, const ZooKeeperPtr & zookeeper)
                 continue;
             }
             zkutil::KeeperMultiException::check(rm_entry_res, ops, res);
+            entries_to_skip.remove(node_name);
         }
         catch (...)
         {

--- a/src/Interpreters/DDLWorker.h
+++ b/src/Interpreters/DDLWorker.h
@@ -13,7 +13,9 @@
 #include <chrono>
 #include <condition_variable>
 #include <mutex>
+#include <shared_mutex>
 #include <thread>
+#include <unordered_set>
 
 namespace zkutil
 {
@@ -79,6 +81,33 @@ public:
     ZooKeeperPtr getAndSetZooKeeper();
 
 protected:
+
+    class ConcurrentSet
+    {
+    public:
+        bool contains(const String & key) const
+        {
+            std::shared_lock lock(mtx);
+            return set.contains(key);
+        }
+
+        bool insert(const String & key)
+        {
+            std::unique_lock lock(mtx);
+            return set.emplace(key).second;
+        }
+
+        bool remove(const String & key)
+        {
+            std::unique_lock lock(mtx);
+            return set.erase(key);
+        }
+
+    private:
+        std::unordered_set<String> set;
+        mutable std::shared_mutex mtx;
+    };
+
     /// Iterates through queue tasks in ZooKeeper, runs execution of new tasks
     void scheduleTasks(bool reinitialized);
 
@@ -160,6 +189,9 @@ protected:
     size_t max_tasks_in_queue = 1000;
 
     std::atomic<UInt32> max_id = 0;
+
+    ConcurrentSet entries_to_skip;
+
     const CurrentMetrics::Metric * max_entry_metric;
     const CurrentMetrics::Metric * max_pushed_entry_metric;
 };


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Caching skip-able entries while executing DDL from Zookeeper distributed DDL queue

So we can quickly skip entries without doing some heavy jobs in `DDLWorker::initAndCheckTask`

This PR complements #54819, together improve the DDLWorker speed, especially when machine under high load.

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
