### PR TITLE
Fix "Invalid number of rows in Chunk" in MaterializedPostgreSQL

### DIFF
--- a/src/Storages/PostgreSQL/MaterializedPostgreSQLConsumer.cpp
+++ b/src/Storages/PostgreSQL/MaterializedPostgreSQLConsumer.cpp
@@ -269,6 +269,20 @@ void MaterializedPostgreSQLConsumer::readTupleData(
                 insertDefaultValue(buffer, column_idx);
                 break;
             }
+            case 'b': /// Binary data.
+            {
+                LOG_WARNING(log, "We do not yet process this format of data, will insert default value");
+                insertDefaultValue(buffer, column_idx);
+                break;
+            }
+            default:
+            {
+                LOG_WARNING(log, "Unexpected identifier: {}. This is a bug! Please report an issue on github", identifier);
+                chassert(false);
+
+                insertDefaultValue(buffer, column_idx);
+                break;
+            }
         }
     };
 
@@ -281,6 +295,10 @@ void MaterializedPostgreSQLConsumer::readTupleData(
         }
         catch (...)
         {
+            LOG_ERROR(log,
+                      "Got error while receiving value for column {}, will insert default value. Error: {}",
+                      column_idx, getCurrentExceptionMessage(true));
+
             insertDefaultValue(buffer, column_idx);
             /// Let's collect only the first exception.
             /// This delaying of error throw is needed because


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix "Invalid number of rows in Chunk" in MaterializedPostgreSQL (which could happen with PostgreSQL version >= 13)