### PR TITLE
Convert third party library titles to headings

### DIFF
--- a/docs/en/interfaces/third-party/client-libraries.md
+++ b/docs/en/interfaces/third-party/client-libraries.md
@@ -2,6 +2,7 @@
 slug: /en/interfaces/third-party/client-libraries
 sidebar_position: 26
 sidebar_label: Client Libraries
+description: Third-party client libraries
 ---
 
 # Client Libraries from Third-party Developers
@@ -10,68 +11,68 @@ sidebar_label: Client Libraries
 ClickHouse Inc does **not** maintain the libraries listed below and hasn’t done any extensive testing to ensure their quality.
 :::
 
-- Python
-    - [infi.clickhouse_orm](https://github.com/Infinidat/infi.clickhouse_orm)
-    - [clickhouse-driver](https://github.com/mymarilyn/clickhouse-driver)
-    - [clickhouse-client](https://github.com/yurial/clickhouse-client)
-    - [aiochclient](https://github.com/maximdanilchenko/aiochclient)
-    - [asynch](https://github.com/long2ice/asynch)
-- PHP
-    - [smi2/phpclickhouse](https://packagist.org/packages/smi2/phpClickHouse)
-    - [8bitov/clickhouse-php-client](https://packagist.org/packages/8bitov/clickhouse-php-client)
-    - [bozerkins/clickhouse-client](https://packagist.org/packages/bozerkins/clickhouse-client)
-    - [simpod/clickhouse-client](https://packagist.org/packages/simpod/clickhouse-client)
-    - [seva-code/php-click-house-client](https://packagist.org/packages/seva-code/php-click-house-client)
-    - [SeasClick C++ client](https://github.com/SeasX/SeasClick)
-    - [one-ck](https://github.com/lizhichao/one-ck)
-    - [glushkovds/phpclickhouse-laravel](https://packagist.org/packages/glushkovds/phpclickhouse-laravel)
-    - [kolya7k ClickHouse PHP extension](https://github.com//kolya7k/clickhouse-php)
-    - [hyvor/clickhouse-php](https://github.com/hyvor/clickhouse-php)
-- Go
-    - [clickhouse](https://github.com/kshvakov/clickhouse/)
-    - [go-clickhouse](https://github.com/roistat/go-clickhouse)
-    - [chconn](https://github.com/vahid-sohrabloo/chconn)
-    - [mailrugo-clickhouse](https://github.com/mailru/go-clickhouse)
-    - [golang-clickhouse](https://github.com/leprosus/golang-clickhouse)
-    - [uptrace/go-clickhouse](https://clickhouse.uptrace.dev/)
-- Swift
-    - [ClickHouseNIO](https://github.com/patrick-zippenfenig/ClickHouseNIO)
-    - [ClickHouseVapor ORM](https://github.com/patrick-zippenfenig/ClickHouseVapor)
-- NodeJs
-    - [clickhouse (NodeJs)](https://github.com/TimonKK/clickhouse)
-    - [node-clickhouse](https://github.com/apla/node-clickhouse)
-    - [nestjs-clickhouse](https://github.com/depyronick/nestjs-clickhouse)
-    - [clickhouse-client](https://github.com/depyronick/clickhouse-client)
-    - [node-clickhouse-orm](https://github.com/zimv/node-clickhouse-orm)
-- Perl
-    - [perl-DBD-ClickHouse](https://github.com/elcamlost/perl-DBD-ClickHouse)
-    - [HTTP-ClickHouse](https://metacpan.org/release/HTTP-ClickHouse)
-    - [AnyEvent-ClickHouse](https://metacpan.org/release/AnyEvent-ClickHouse)
-- Ruby
-    - [ClickHouse (Ruby)](https://github.com/shlima/click_house)
-    - [clickhouse-activerecord](https://github.com/PNixx/clickhouse-activerecord)
-- Rust
-    - [clickhouse.rs](https://github.com/loyd/clickhouse.rs)
-    - [clickhouse-rs](https://github.com/suharev7/clickhouse-rs)
-    - [Klickhouse](https://github.com/Protryon/klickhouse)
-- R
-    - [RClickHouse](https://github.com/IMSMWU/RClickHouse)
-- Java
-    - [clickhouse-client-java](https://github.com/VirtusAI/clickhouse-client-java)
-    - [clickhouse-client](https://github.com/Ecwid/clickhouse-client)
-- Scala
-    - [clickhouse-scala-client](https://github.com/crobox/clickhouse-scala-client)
-- Kotlin
-    - [AORM](https://github.com/TanVD/AORM)
-- C#
-    - [Octonica.ClickHouseClient](https://github.com/Octonica/ClickHouseClient)
-    - [ClickHouse.Ado](https://github.com/killwort/ClickHouse-Net)
-    - [ClickHouse.Client](https://github.com/DarkWanderer/ClickHouse.Client)
-    - [ClickHouse.Net](https://github.com/ilyabreev/ClickHouse.Net)
-- Elixir
-    - [clickhousex](https://github.com/appodeal/clickhousex/)
-    - [pillar](https://github.com/sofakingworld/pillar)
-- Nim
-    - [nim-clickhouse](https://github.com/leonardoce/nim-clickhouse)
-- Haskell
-    - [hdbc-clickhouse](https://github.com/zaneli/hdbc-clickhouse)
+### Python
+ - [infi.clickhouse_orm](https://github.com/Infinidat/infi.clickhouse_orm)
+ - [clickhouse-driver](https://github.com/mymarilyn/clickhouse-driver)
+ - [clickhouse-client](https://github.com/yurial/clickhouse-client)
+ - [aiochclient](https://github.com/maximdanilchenko/aiochclient)
+ - [asynch](https://github.com/long2ice/asynch)
+### PHP
+ - [smi2/phpclickhouse](https://packagist.org/packages/smi2/phpClickHouse)
+ - [8bitov/clickhouse-php-client](https://packagist.org/packages/8bitov/clickhouse-php-client)
+ - [bozerkins/clickhouse-client](https://packagist.org/packages/bozerkins/clickhouse-client)
+ - [simpod/clickhouse-client](https://packagist.org/packages/simpod/clickhouse-client)
+ - [seva-code/php-click-house-client](https://packagist.org/packages/seva-code/php-click-house-client)
+ - [SeasClick C++ client](https://github.com/SeasX/SeasClick)
+ - [one-ck](https://github.com/lizhichao/one-ck)
+ - [glushkovds/phpclickhouse-laravel](https://packagist.org/packages/glushkovds/phpclickhouse-laravel)
+ - [kolya7k ClickHouse PHP extension](https://github.com//kolya7k/clickhouse-php)
+ - [hyvor/clickhouse-php](https://github.com/hyvor/clickhouse-php)
+### Go
+ - [clickhouse](https://github.com/kshvakov/clickhouse/)
+ - [go-clickhouse](https://github.com/roistat/go-clickhouse)
+ - [chconn](https://github.com/vahid-sohrabloo/chconn)
+ - [mailrugo-clickhouse](https://github.com/mailru/go-clickhouse)
+ - [golang-clickhouse](https://github.com/leprosus/golang-clickhouse)
+ - [uptrace/go-clickhouse](https://clickhouse.uptrace.dev/)
+### Swift
+ - [ClickHouseNIO](https://github.com/patrick-zippenfenig/ClickHouseNIO)
+ - [ClickHouseVapor ORM](https://github.com/patrick-zippenfenig/ClickHouseVapor)
+### NodeJs
+ - [clickhouse (NodeJs)](https://github.com/TimonKK/clickhouse)
+ - [node-clickhouse](https://github.com/apla/node-clickhouse)
+ - [nestjs-clickhouse](https://github.com/depyronick/nestjs-clickhouse)
+ - [clickhouse-client](https://github.com/depyronick/clickhouse-client)
+ - [node-clickhouse-orm](https://github.com/zimv/node-clickhouse-orm)
+### Perl
+ - [perl-DBD-ClickHouse](https://github.com/elcamlost/perl-DBD-ClickHouse)
+ - [HTTP-ClickHouse](https://metacpan.org/release/HTTP-ClickHouse)
+ - [AnyEvent-ClickHouse](https://metacpan.org/release/AnyEvent-ClickHouse)
+### Ruby
+ - [ClickHouse (Ruby)](https://github.com/shlima/click_house)
+ - [clickhouse-activerecord](https://github.com/PNixx/clickhouse-activerecord)
+### Rust
+ - [clickhouse.rs](https://github.com/loyd/clickhouse.rs)
+ - [clickhouse-rs](https://github.com/suharev7/clickhouse-rs)
+ - [Klickhouse](https://github.com/Protryon/klickhouse)
+### R
+ - [RClickHouse](https://github.com/IMSMWU/RClickHouse)
+### Java
+ - [clickhouse-client-java](https://github.com/VirtusAI/clickhouse-client-java)
+ - [clickhouse-client](https://github.com/Ecwid/clickhouse-client)
+### Scala
+ - [clickhouse-scala-client](https://github.com/crobox/clickhouse-scala-client)
+### Kotlin
+ - [AORM](https://github.com/TanVD/AORM)
+### C#
+ - [Octonica.ClickHouseClient](https://github.com/Octonica/ClickHouseClient)
+ - [ClickHouse.Ado](https://github.com/killwort/ClickHouse-Net)
+ - [ClickHouse.Client](https://github.com/DarkWanderer/ClickHouse.Client)
+ - [ClickHouse.Net](https://github.com/ilyabreev/ClickHouse.Net)
+### Elixir
+ - [clickhousex](https://github.com/appodeal/clickhousex/)
+ - [pillar](https://github.com/sofakingworld/pillar)
+### Nim
+ - [nim-clickhouse](https://github.com/leonardoce/nim-clickhouse)
+### Haskell
+ - [hdbc-clickhouse](https://github.com/zaneli/hdbc-clickhouse)


### PR DESCRIPTION
This should improve searching for third-party client libraries

### Changelog category (leave one):
- Documentation (changelog entry is not required)