### PR TITLE
Update ceilRowsToCompleteGranules to use binary search.

### DIFF
--- a/src/Storages/MergeTree/MergeTreeRangeReader.cpp
+++ b/src/Storages/MergeTree/MergeTreeRangeReader.cpp
@@ -907,13 +907,21 @@ UInt64 MergeTreeRangeReader::Stream::lastPartOffset() const
 
 size_t MergeTreeRangeReader::Stream::ceilRowsToCompleteGranules(size_t rows_num) const
 {
-    /// FIXME suboptimal
-    size_t result = 0;
-    size_t from_mark = current_mark;
-    while (result < rows_num && from_mark < last_mark)
-        result += index_granularity->getMarkRows(from_mark++);
-
-    return result;
+    /// Find the first occurrence of mark that satisfies getRowsCountInRange(left, mark + 1) >= rows_num
+    /// in [current_mark, last_mark).
+    assert(current_mark + 1 <= last_mark);
+    size_t left_mark = current_mark;
+    size_t right_mark = last_mark;
+    while (left_mark < right_mark)
+    {
+        size_t mid_mark = left_mark + (right_mark - left_mark) / 2;
+        if (index_granularity->getRowsCountInRange(current_mark, mid_mark + 1) >= rows_num)
+            right_mark = mid_mark;
+        else
+            left_mark = mid_mark + 1;
+    }
+    size_t end_mark = (left_mark == last_mark) ? left_mark : left_mark + 1;
+    return index_granularity->getRowsCountInRange(current_mark, end_mark);
 }
 
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category:
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Replace the linear method in `MergeTreeRangeReader::Stream::ceilRowsToCompleteGranules` with a binary search.


<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
