### PR TITLE
Remove tests

### DIFF
--- a/tests/integration/test_ssl_cert_authentication/test.py
+++ b/tests/integration/test_ssl_cert_authentication/test.py
@@ -206,20 +206,8 @@ def test_https_wrong_cert():
         execute_query_https("SELECT currentUser()", user="john", cert_name="client2")
     assert "403" in str(err.value)
 
-    count = 0
-    # Wrong certificate: self-signed certificate.
-    while count <= MAX_RETRY:
-        with pytest.raises(Exception) as err:
-            execute_query_https("SELECT currentUser()", user="john", cert_name="wrong")
-        err_str = str(err.value)
-        if count < MAX_RETRY and (
-            ("Broken pipe" in err_str) or ("EOF occurred" in err_str)
-        ):
-            count = count + 1
-            logging.warning(f"Failed attempt with wrong cert, err: {err_str}")
-            continue
-        assert "unknown ca" in err_str
-        break
+    # TODO: Add non-flaky tests for:
+    # - Wrong certificate: self-signed certificate.
 
     # No certificate.
     with pytest.raises(Exception) as err:
@@ -309,49 +297,8 @@ def test_https_non_ssl_auth():
         == "jane\n"
     )
 
-    count = 0
-    # However if we send a certificate it must not be wrong.
-    while count <= MAX_RETRY:
-        with pytest.raises(Exception) as err:
-            execute_query_https(
-                "SELECT currentUser()",
-                user="peter",
-                enable_ssl_auth=False,
-                cert_name="wrong",
-            )
-        err_str = str(err.value)
-        if count < MAX_RETRY and (
-            ("Broken pipe" in err_str) or ("EOF occurred" in err_str)
-        ):
-            count = count + 1
-            logging.warning(
-                f"Failed attempt with wrong cert, user: peter, err: {err_str}"
-            )
-            continue
-        assert "unknown ca" in err_str
-        break
-
-    count = 0
-    while count <= MAX_RETRY:
-        with pytest.raises(Exception) as err:
-            execute_query_https(
-                "SELECT currentUser()",
-                user="jane",
-                enable_ssl_auth=False,
-                password="qwe123",
-                cert_name="wrong",
-            )
-        err_str = str(err.value)
-        if count < MAX_RETRY and (
-            ("Broken pipe" in err_str) or ("EOF occurred" in err_str)
-        ):
-            count = count + 1
-            logging.warning(
-                f"Failed attempt with wrong cert, user: jane, err: {err_str}"
-            )
-            continue
-        assert "unknown ca" in err_str
-        break
+    # TODO: Add non-flaky tests for:
+    # - sending wrong cert
 
 
 def test_create_user():

--- a/tests/integration/test_tlsv1_3/test.py
+++ b/tests/integration/test_tlsv1_3/test.py
@@ -90,20 +90,8 @@ def test_https_wrong_cert():
         execute_query_https("SELECT currentUser()", user="john", cert_name="client2")
     assert "HTTP Error 403" in str(err.value)
 
-    count = 0
-    # Wrong certificate: self-signed certificate.
-    while count <= MAX_RETRY:
-        with pytest.raises(Exception) as err:
-            execute_query_https("SELECT currentUser()", user="john", cert_name="wrong")
-        err_str = str(err.value)
-        if count < MAX_RETRY and (
-            ("Broken pipe" in err_str) or ("EOF occurred" in err_str)
-        ):
-            count = count + 1
-            logging.warning(f"Failed attempt with wrong cert, err: {err_str}")
-            continue
-        assert "unknown ca" in err_str
-        break
+    # TODO: Add non-flaky tests for:
+    # - Wrong certificate: self-signed certificate.
 
     # No certificate.
     with pytest.raises(Exception) as err:
@@ -193,49 +181,8 @@ def test_https_non_ssl_auth():
         == "jane\n"
     )
 
-    count = 0
-    # However if we send a certificate it must not be wrong.
-    while count <= MAX_RETRY:
-        with pytest.raises(Exception) as err:
-            execute_query_https(
-                "SELECT currentUser()",
-                user="peter",
-                enable_ssl_auth=False,
-                cert_name="wrong",
-            )
-        err_str = str(err.value)
-        if count < MAX_RETRY and (
-            ("Broken pipe" in err_str) or ("EOF occurred" in err_str)
-        ):
-            count = count + 1
-            logging.warning(
-                f"Failed attempt with wrong cert, user: peter, err: {err_str}"
-            )
-            continue
-        assert "unknown ca" in err_str
-        break
-
-    count = 0
-    while count <= MAX_RETRY:
-        with pytest.raises(Exception) as err:
-            execute_query_https(
-                "SELECT currentUser()",
-                user="jane",
-                enable_ssl_auth=False,
-                password="qwe123",
-                cert_name="wrong",
-            )
-        err_str = str(err.value)
-        if count < MAX_RETRY and (
-            ("Broken pipe" in err_str) or ("EOF occurred" in err_str)
-        ):
-            count = count + 1
-            logging.warning(
-                f"Failed attempt with wrong cert, user: jane, err: {err_str}"
-            )
-            continue
-        assert "unknown ca" in err_str
-        break
+    # TODO: Add non-flaky tests for:
+    # - sending wrong cert
 
 
 def test_create_user():


### PR DESCRIPTION

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

These tests are flaky in our CI system. We had multiple attempts (#39775, #51384, #51434) to make the tests less flaky, but all of them have failed. I tried to reproduce the issue locally, in an actual CI container, but it just didn't fail.

At this point we have no other idea to figure out what is causing the issue. Maybe using `tcpdump` can be the way, but it is not straightforward to make that happen during CI tests.

Considering all the above, we decided that it is better to remove these tests for now.