### PR TITLE
More stable `02703_keeper_map_concurrent_create_drop`

### DIFF
--- a/tests/queries/0_stateless/02703_keeper_map_concurrent_create_drop.sh
+++ b/tests/queries/0_stateless/02703_keeper_map_concurrent_create_drop.sh
@@ -15,7 +15,8 @@ function create_drop_loop()
     done
 
     i=0
-    while true;
+    local TIMELIMIT=$((SECONDS+$2))
+    while [ $SECONDS -lt "$TIMELIMIT" ];
     do
         $CLICKHOUSE_CLIENT --query="CREATE TABLE IF NOT EXISTS $table_name (key UInt64, value UInt64) ENGINE = KeeperMap('/02703_keeper_map/$CLICKHOUSE_DATABASE') PRIMARY KEY(key)"
         $CLICKHOUSE_CLIENT --query="INSERT INTO $table_name VALUES ($1, $i)"
@@ -40,7 +41,7 @@ TIMEOUT=30
 
 for i in `seq $THREADS`
 do
-    timeout $TIMEOUT bash -c "create_drop_loop $i" 2> /dev/null &
+    create_drop_loop $i $TIMEOUT 2> /dev/null &
 done
 
 wait


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Fix cases like
https://s3.amazonaws.com/clickhouse-test-reports/0/428a6891961d6accae86c3981da63c7ae5597e62/stateless_tests__release__databasereplicated__[2_4].html

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
