### PR TITLE
Extend function tuple to return named tuple and add function tupleNames

### DIFF
--- a/docs/en/sql-reference/functions/tuple-functions.md
+++ b/docs/en/sql-reference/functions/tuple-functions.md
@@ -7,7 +7,7 @@ sidebar_label: Tuples
 ## tuple
 
 A function that allows grouping multiple columns.
-For columns with the types T1, T2, ..., it returns a Tuple(T1, T2, ...) type tuple containing these columns. There is no cost to execute the function.
+For columns C1, C2, ... with the types T1, T2, ..., it returns a named Tuple(C1 T1, C2 T2, ...) type tuple containing these columns if their names are unique and can be treated as unquoted identifiers, otherwise a Tuple(T1, T2, ...) is returned. There is no cost to execute the function.
 Tuples are normally used as intermediate values for an argument of IN operators, or for creating a list of formal parameters of lambda functions. Tuples can’t be written to a table.
 
 The function implements the operator `(x, y, ...)`.
@@ -257,6 +257,60 @@ Result:
 ┌─tupleToNameValuePairs(tuple(3, 2, 1))─┐
 │ [('1',3),('2',2),('3',1)]             │
 └───────────────────────────────────────┘
+```
+
+## tupleNames
+
+Converts a tuple into an array of column names. For a tuple in the form `Tuple(a T, b T, ...)`, it returns an array of strings representing the named columns of the tuple. If the tuple elements do not have explicit names, their indices will be used as the column names instead.
+
+**Syntax**
+
+``` sql
+tupleNames(tuple)
+```
+
+**Arguments**
+
+- `tuple` — Named tuple. [Tuple](../../sql-reference/data-types/tuple.md) with any types of values.
+
+**Returned value**
+
+- An array with strings.
+
+Type: [Array](../../sql-reference/data-types/array.md)([Tuple](../../sql-reference/data-types/tuple.md)([String](../../sql-reference/data-types/string.md), ...)).
+
+**Example**
+
+Query:
+
+``` sql
+CREATE TABLE tupletest (col Tuple(user_ID UInt64, session_ID UInt64)) ENGINE = Memory;
+
+INSERT INTO tupletest VALUES (tuple(1, 2));
+
+SELECT tupleNames(col) FROM tupletest;
+```
+
+Result:
+
+``` text
+┌─tupleNames(col)──────────┐
+│ ['user_ID','session_ID'] │
+└──────────────────────────┘
+```
+
+If you pass a simple tuple to the function, ClickHouse uses the indexes of the columns as their names:
+
+``` sql
+SELECT tupleNames(tuple(3, 2, 1));
+```
+
+Result:
+
+``` text
+┌─tupleNames((3, 2, 1))─┐
+│ ['1','2','3']         │
+└───────────────────────┘
 ```
 
 ## tuplePlus

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -755,6 +755,7 @@ class IColumn;
     M(Bool, optimize_group_by_function_keys, true, "Eliminates functions of other keys in GROUP BY section", 0) \
     M(Bool, optimize_group_by_constant_keys, true, "Optimize GROUP BY when all keys in block are constant", 0) \
     M(Bool, legacy_column_name_of_tuple_literal, false, "List all names of element of large tuple literals in their column names instead of hash. This settings exists only for compatibility reasons. It makes sense to set to 'true', while doing rolling update of cluster from version lower than 21.7 to higher.", 0) \
+    M(Bool, enable_named_columns_in_function_tuple, true, "Generate named tuples in function tuple() when all names are unique and can be treated as unquoted identifiers.", 0) \
     \
     M(Bool, query_plan_enable_optimizations, true, "Globally enable/disable query optimization at the query plan level", 0) \
     M(UInt64, query_plan_max_optimizations_to_apply, 10000, "Limit the total number of optimizations applied to query plan. If zero, ignored. If limit reached, throw exception", 0) \

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -59,6 +59,7 @@ static std::initializer_list<std::pair<ClickHouseVersion, SettingsChangesHistory
 {
     {"24.7", {{"output_format_parquet_write_page_index", false, true, "Add a possibility to write page index into parquet files."},
               {"optimize_functions_to_subcolumns", false, true, "Enable optimization by default"},
+              {"enable_named_columns_in_function_tuple", false, true, "Generate named tuples in function tuple() when all names are unique and can be treated as unquoted identifiers."},
               {"input_format_json_ignore_key_case", false, false, "Ignore json key case while read json field from string."},
               {"optimize_trivial_insert_select", true, false, "The optimization does not make sense in many cases."},
               {"lightweight_mutation_projection_mode", "throw", "throw", "When lightweight delete happens on a table with projection(s), the possible operations include throw the exception as projection exists, or drop all projection related to this table then do lightweight delete."},

--- a/src/Functions/tuple.cpp
+++ b/src/Functions/tuple.cpp
@@ -5,7 +5,17 @@ namespace DB
 
 REGISTER_FUNCTION(Tuple)
 {
-    factory.registerFunction<FunctionTuple>();
+    factory.registerFunction<FunctionTuple>(FunctionDocumentation{
+        .description = R"(
+Returns a tuple by grouping input arguments.
+
+For columns C1, C2, ... with the types T1, T2, ..., it returns a named Tuple(C1 T1, C2 T2, ...) type tuple containing these columns if their names are unique and can be treated as unquoted identifiers, otherwise a Tuple(T1, T2, ...) is returned. There is no cost to execute the function.
+Tuples are normally used as intermediate values for an argument of IN operators, or for creating a list of formal parameters of lambda functions. Tuples can’t be written to a table.
+
+The function implements the operator `(x, y, ...)`.
+)",
+        .examples{{"typical", "SELECT tuple(1, 2)", "(1,2)"}},
+        .categories{"Miscellaneous"}});
 }
 
 }

--- a/src/Functions/tupleNames.cpp
+++ b/src/Functions/tupleNames.cpp
@@ -1,0 +1,118 @@
+#include <Columns/ColumnArray.h>
+#include <Columns/ColumnString.h>
+#include <DataTypes/DataTypeArray.h>
+#include <DataTypes/DataTypeString.h>
+#include <DataTypes/DataTypeTuple.h>
+#include <Functions/FunctionFactory.h>
+
+namespace DB
+{
+namespace ErrorCodes
+{
+extern const int ILLEGAL_TYPE_OF_ARGUMENT;
+}
+
+namespace
+{
+
+/** Transform a named tuple into names, which is a constant array of strings.
+  */
+class ExecutableFunctionTupleNames : public IExecutableFunction
+{
+public:
+    static constexpr auto name = "tupleNames";
+
+    explicit ExecutableFunctionTupleNames(Array name_fields_) : name_fields(std::move(name_fields_)) { }
+
+    String getName() const override { return name; }
+
+    ColumnPtr executeImpl(const ColumnsWithTypeAndName &, const DataTypePtr & result_type, size_t input_rows_count) const override
+    {
+        return result_type->createColumnConst(input_rows_count, name_fields);
+    }
+
+private:
+    Array name_fields;
+};
+
+class FunctionBaseTupleNames : public IFunctionBase
+{
+public:
+    static constexpr auto name = "tupleNames";
+
+    explicit FunctionBaseTupleNames(DataTypePtr argument_type, DataTypePtr result_type_, Array name_fields_)
+        : argument_types({std::move(argument_type)}), result_type(std::move(result_type_)), name_fields(std::move(name_fields_))
+    {
+    }
+
+    String getName() const override { return name; }
+
+    bool isSuitableForConstantFolding() const override { return true; }
+
+    bool isSuitableForShortCircuitArgumentsExecution(const DataTypesWithConstInfo & /*arguments*/) const override { return true; }
+
+    const DataTypes & getArgumentTypes() const override { return argument_types; }
+
+    const DataTypePtr & getResultType() const override { return result_type; }
+
+    ExecutableFunctionPtr prepare(const ColumnsWithTypeAndName &) const override
+    {
+        return std::make_unique<ExecutableFunctionTupleNames>(name_fields);
+    }
+
+private:
+    DataTypes argument_types;
+    DataTypePtr result_type;
+    Array name_fields;
+};
+
+class TupleNamesOverloadResolver : public IFunctionOverloadResolver
+{
+public:
+    static constexpr auto name = "tupleNames";
+
+    static FunctionOverloadResolverPtr create(ContextPtr) { return std::make_unique<TupleNamesOverloadResolver>(); }
+
+    String getName() const override { return name; }
+
+    size_t getNumberOfArguments() const override { return 1; }
+
+    DataTypePtr getReturnTypeImpl(const ColumnsWithTypeAndName & arguments) const override
+    {
+        const DataTypeTuple * tuple = checkAndGetDataType<DataTypeTuple>(arguments[0].type.get());
+
+        if (!tuple)
+            throw Exception(ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT, "First argument for function {} must be a tuple", getName());
+
+        return std::make_shared<DataTypeArray>(std::make_shared<DataTypeString>());
+    }
+
+    FunctionBasePtr buildImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type) const override
+    {
+        const DataTypeTuple * tuple = checkAndGetDataType<DataTypeTuple>(arguments[0].type.get());
+
+        if (!tuple)
+            throw Exception(ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT, "First argument for function {} must be a tuple", getName());
+
+        DataTypes types = tuple->getElements();
+        Array name_fields;
+        for (const auto & elem_name : tuple->getElementNames())
+            name_fields.emplace_back(elem_name);
+
+        return std::make_unique<FunctionBaseTupleNames>(arguments[0].type, result_type, std::move(name_fields));
+    }
+};
+
+}
+
+REGISTER_FUNCTION(TupleNames)
+{
+    factory.registerFunction<TupleNamesOverloadResolver>(FunctionDocumentation{
+        .description = R"(
+Converts a tuple into an array of column names. For a tuple in the form `Tuple(a T, b T, ...)`, it returns an array of strings representing the named columns of the tuple. If the tuple elements do not have explicit names, their indices will be used as the column names instead.
+)",
+        .examples{{"typical", "SELECT tupleNames(tuple(1 as a, 2 as b))", "['a','b']"}},
+        .categories{"Miscellaneous"}});
+}
+
+}

--- a/src/Parsers/isUnquotedIdentifier.cpp
+++ b/src/Parsers/isUnquotedIdentifier.cpp
@@ -1,0 +1,20 @@
+#include <Parsers/isUnquotedIdentifier.h>
+
+#include <Parsers/Lexer.h>
+
+namespace DB
+{
+
+bool isUnquotedIdentifier(const String & name)
+{
+    Lexer lexer(name.data(), name.data() + name.size());
+
+    auto maybe_ident = lexer.nextToken();
+
+    if (maybe_ident.type != TokenType::BareWord)
+        return false;
+
+    return lexer.nextToken().isEnd();
+}
+
+}

--- a/src/Parsers/isUnquotedIdentifier.h
+++ b/src/Parsers/isUnquotedIdentifier.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <base/types.h>
+
+namespace DB
+{
+
+bool isUnquotedIdentifier(const String & name);
+
+}

--- a/src/Processors/Formats/Impl/ConstantExpressionTemplate.cpp
+++ b/src/Processors/Formats/Impl/ConstantExpressionTemplate.cpp
@@ -227,7 +227,12 @@ private:
                         return true;
             }
 
-            String column_name = "_dummy_" + std::to_string(replaced_literals.size());
+            /// When generating placeholder names, ensure that we use names
+            /// requiring quotes to be valid identifiers. This prevents the
+            /// tuple() function from generating named tuples. Otherwise,
+            /// inserting named tuples with different names into another named
+            /// tuple will result in only default values being inserted.
+            String column_name = "-dummy-" + std::to_string(replaced_literals.size());
             replaced_literals.emplace_back(literal, column_name, force_nullable);
             setDataType(replaced_literals.back());
             ast = std::make_shared<ASTIdentifier>(column_name);

--- a/src/Processors/Formats/Impl/ValuesBlockInputFormat.h
+++ b/src/Processors/Formats/Impl/ValuesBlockInputFormat.h
@@ -37,18 +37,7 @@ public:
     void resetReadBuffer() override;
 
     /// TODO: remove context somehow.
-    void setContext(const ContextPtr & context_)
-    {
-        auto context_copy = Context::createCopy(context_);
-
-        /// ConstantExpressionTemplate generates placeholder names (_dummy_N)
-        /// for all literals, which are valid names for creating named tuples.
-        /// This behavior needs to be explicitly disabled, because if named
-        /// tuples with different names are inserted into a named tuple, it will
-        /// only insert default values.
-        context_copy->setSetting("enable_named_columns_in_function_tuple", false);
-        context = context_copy;
-    }
+    void setContext(const ContextPtr & context_) { context = Context::createCopy(context_); }
 
     const BlockMissingValues & getMissingValues() const override { return block_missing_values; }
 

--- a/src/Processors/Formats/Impl/ValuesBlockInputFormat.h
+++ b/src/Processors/Formats/Impl/ValuesBlockInputFormat.h
@@ -37,7 +37,18 @@ public:
     void resetReadBuffer() override;
 
     /// TODO: remove context somehow.
-    void setContext(const ContextPtr & context_) { context = Context::createCopy(context_); }
+    void setContext(const ContextPtr & context_)
+    {
+        auto context_copy = Context::createCopy(context_);
+
+        /// ConstantExpressionTemplate generates placeholder names (_dummy_N)
+        /// for all literals, which are valid names for creating named tuples.
+        /// This behavior needs to be explicitly disabled, because if named
+        /// tuples with different names are inserted into a named tuple, it will
+        /// only insert default values.
+        context_copy->setSetting("enable_named_columns_in_function_tuple", false);
+        context = context_copy;
+    }
 
     const BlockMissingValues & getMissingValues() const override { return block_missing_values; }
 

--- a/tests/queries/0_stateless/00307_format_xml.sql
+++ b/tests/queries/0_stateless/00307_format_xml.sql
@@ -1,2 +1,2 @@
 SET output_format_write_statistics = 0;
-SELECT 'Hello & world' AS s, 'Hello\n<World>', toDateTime('2001-02-03 04:05:06') AS time, arrayMap(x -> toString(x), range(10)) AS arr, (s, time) AS tpl SETTINGS extremes = 1 FORMAT XML;
+SELECT 'Hello & world' AS s, 'Hello\n<World>', toDateTime('2001-02-03 04:05:06') AS time, arrayMap(x -> toString(x), range(10)) AS arr, (s, time) AS tpl SETTINGS extremes = 1, enable_named_columns_in_function_tuple = 0 FORMAT XML;

--- a/tests/queries/0_stateless/00309_formats.sql
+++ b/tests/queries/0_stateless/00309_formats.sql
@@ -1,4 +1,6 @@
 SET output_format_write_statistics = 0;
+SET enable_named_columns_in_function_tuple = 0;
+
 SELECT number * 246 + 10 AS n, toDate('2000-01-01') + n AS d, range(n) AS arr, arrayStringConcat(arrayMap(x -> reinterpretAsString(x), arr)) AS s, (n, d) AS tuple FROM system.numbers LIMIT 2 FORMAT RowBinary;
 SELECT number * 246 + 10 AS n, toDate('2000-01-01') + n AS d, range(n) AS arr, arrayStringConcat(arrayMap(x -> reinterpretAsString(x), arr)) AS s, (n, d) AS tuple FROM system.numbers LIMIT 2 FORMAT RowBinaryWithNamesAndTypes;
 SELECT number * 246 + 10 AS n, toDate('2000-01-01') + n AS d, range(n) AS arr, arrayStringConcat(arrayMap(x -> reinterpretAsString(x), arr)) AS s, (n, d) AS tuple FROM system.numbers LIMIT 2 FORMAT TabSeparatedWithNamesAndTypes;

--- a/tests/queries/0_stateless/01144_multiword_data_types.sql
+++ b/tests/queries/0_stateless/01144_multiword_data_types.sql
@@ -23,7 +23,7 @@ CREATE TABLE multiword_types (
 SHOW CREATE TABLE multiword_types;
 
 INSERT INTO multiword_types(a) VALUES (1);
-SELECT toTypeName((*,)) FROM multiword_types;
+SELECT toTypeName((*,)) FROM multiword_types SETTINGS enable_named_columns_in_function_tuple = 0;
 
 CREATE TABLE unsigned_types (
     a TINYINT  SIGNED,
@@ -43,7 +43,7 @@ CREATE TABLE unsigned_types (
 SHOW CREATE TABLE unsigned_types;
 
 INSERT INTO unsigned_types(a) VALUES (1);
-SELECT toTypeName((*,)) FROM unsigned_types;
+SELECT toTypeName((*,)) FROM unsigned_types SETTINGS enable_named_columns_in_function_tuple = 0;
 
 SELECT CAST('42' AS DOUBLE PRECISION), CAST(42, 'NATIONAL CHARACTER VARYING'), CAST(-1 AS tinyint  UnSiGnEd), CAST(65535, ' sMaLlInT  signed ');
 

--- a/tests/queries/0_stateless/01232_untuple.reference
+++ b/tests/queries/0_stateless/01232_untuple.reference
@@ -2,7 +2,7 @@
 hello	1	3	world
 9
 9	(0,1)
-key	tupleElement(argMax((v1, v2, v3, v4, v5), v1), \'1\')	tupleElement(argMax((v1, v2, v3, v4, v5), v1), \'2\')	tupleElement(argMax((v1, v2, v3, v4, v5), v1), \'3\')	tupleElement(argMax((v1, v2, v3, v4, v5), v1), \'4\')	tupleElement(argMax((v1, v2, v3, v4, v5), v1), \'5\')
+key	tupleElement(argMax((v1, v2, v3, v4, v5), v1), \'v1\')	tupleElement(argMax((v1, v2, v3, v4, v5), v1), \'v2\')	tupleElement(argMax((v1, v2, v3, v4, v5), v1), \'v3\')	tupleElement(argMax((v1, v2, v3, v4, v5), v1), \'v4\')	tupleElement(argMax((v1, v2, v3, v4, v5), v1), \'v5\')
 1	20	20	10	20	30
 2	11	20	10	20	30
 3	70	20	10	20	30

--- a/tests/queries/0_stateless/01232_untuple.sql
+++ b/tests/queries/0_stateless/01232_untuple.sql
@@ -1,4 +1,5 @@
 SET allow_experimental_analyzer = 1;
+SET enable_named_columns_in_function_tuple = 1;
 
 select untuple((* except (b),)) from (select 1 a, 2 b, 3 c);
 select 'hello', untuple((* except (b),)), 'world' from (select 1 a, 2 b, 3 c);

--- a/tests/queries/0_stateless/02294_nothing_arguments_in_functions.sql
+++ b/tests/queries/0_stateless/02294_nothing_arguments_in_functions.sql
@@ -1,3 +1,5 @@
+set enable_named_columns_in_function_tuple = 0;
+
 select arrayMap(x -> 2 * x, []);
 select toTypeName(arrayMap(x -> 2 * x, []));
 select arrayMap((x, y) -> x + y, [], []);

--- a/tests/queries/0_stateless/02415_all_new_functions_must_be_documented.reference
+++ b/tests/queries/0_stateless/02415_all_new_functions_must_be_documented.reference
@@ -876,7 +876,6 @@ tryBase58Decode
 tumble
 tumbleEnd
 tumbleStart
-tuple
 tupleConcat
 tupleDivide
 tupleDivideByNumber

--- a/tests/queries/0_stateless/02541_tuple_element_with_null.sql
+++ b/tests/queries/0_stateless/02541_tuple_element_with_null.sql
@@ -9,7 +9,7 @@ SETTINGS index_granularity = 8192;
 
 INSERT INTO test_tuple_element VALUES (tuple(1,2)), (tuple(NULL, 3));
 
-SELECT 
+SELECT
     tupleElement(tuple, 'k1', 0) fine_k1_with_0,
     tupleElement(tuple, 'k1', NULL) k1_with_null,
     tupleElement(tuple, 'k2', 0) k2_with_0,

--- a/tests/queries/0_stateless/02890_named_tuple_functions.reference
+++ b/tests/queries/0_stateless/02890_named_tuple_functions.reference
@@ -1,0 +1,8 @@
+Tuple(\n    i Int32,\n    j Int32)
+['i','j']
+Tuple(UInt8, Int32)
+['1','2']
+Tuple(\n    k UInt8,\n    j Int32)
+['k','j']
+Tuple(Int32, Int32, Int32, Int32)
+['1','2','3','4']

--- a/tests/queries/0_stateless/02890_named_tuple_functions.reference
+++ b/tests/queries/0_stateless/02890_named_tuple_functions.reference
@@ -6,3 +6,4 @@ Tuple(\n    k UInt8,\n    j Int32)
 ['k','j']
 Tuple(Int32, Int32, Int32, Int32)
 ['1','2','3','4']
+(1,2,3)

--- a/tests/queries/0_stateless/02890_named_tuple_functions.sql
+++ b/tests/queries/0_stateless/02890_named_tuple_functions.sql
@@ -20,3 +20,12 @@ select tupleNames(tuple(i, i, j, j)) from x;
 select tupleNames(1); -- { serverError 43 }
 
 drop table x;
+
+drop table if exists tbl;
+
+-- Make sure named tuple won't break Values insert
+create table tbl (x Tuple(a Int32, b Int32, c Int32)) engine MergeTree order by ();
+insert into tbl values (tuple(1, 2, 3)); -- without tuple it's interpreted differently inside values block.
+select * from tbl;
+
+drop table tbl

--- a/tests/queries/0_stateless/02890_named_tuple_functions.sql
+++ b/tests/queries/0_stateless/02890_named_tuple_functions.sql
@@ -1,0 +1,22 @@
+set enable_named_columns_in_function_tuple = 1;
+set allow_experimental_analyzer = 1;
+
+drop table if exists x;
+create table x (i int, j int) engine MergeTree order by i;
+insert into x values (1, 2);
+
+select toTypeName(tuple(i, j)) from x;
+select tupleNames(tuple(i, j)) from x;
+
+select toTypeName(tuple(1, j)) from x;
+select tupleNames(tuple(1, j)) from x;
+
+select toTypeName(tuple(1 as k, j)) from x;
+select tupleNames(tuple(1 as k, j)) from x;
+
+select toTypeName(tuple(i, i, j, j)) from x;
+select tupleNames(tuple(i, i, j, j)) from x;
+
+select tupleNames(1); -- { serverError 43 }
+
+drop table x;

--- a/tests/queries/0_stateless/02890_untuple_column_names.reference
+++ b/tests/queries/0_stateless/02890_untuple_column_names.reference
@@ -57,6 +57,10 @@ t.1: 1
 Row 1:
 ──────
 t.1: 1
+-- tuple() with enable_named_columns_in_function_tuple = 1 and allow_experimental_analyzer = 1 keeps the column names
+Row 1:
+──────
+t.a: 1
 -- thankfully JSONExtract() keeps them
 Row 1:
 ──────

--- a/tests/queries/0_stateless/02890_untuple_column_names.sql
+++ b/tests/queries/0_stateless/02890_untuple_column_names.sql
@@ -37,8 +37,11 @@ SELECT untuple(tuple(1)::Tuple(Int)), untuple(tuple(1)::Tuple(Int)) FORMAT Verti
 SELECT untuple(tuple(1)::Tuple(Int)), untuple(tuple(1)::Tuple(Int)) FORMAT Vertical SETTINGS allow_experimental_analyzer = 1; -- Bug: doesn't throw an exception
 
 SELECT '-- tuple() loses the column names (would be good to fix, see #36773)';
-SELECT untuple(tuple(1 as a)) as t FORMAT Vertical SETTINGS allow_experimental_analyzer = 0;
-SELECT untuple(tuple(1 as a)) as t FORMAT Vertical SETTINGS allow_experimental_analyzer = 1;
+SELECT untuple(tuple(1 as a)) as t FORMAT Vertical SETTINGS allow_experimental_analyzer = 0, enable_named_columns_in_function_tuple = 0;
+SELECT untuple(tuple(1 as a)) as t FORMAT Vertical SETTINGS allow_experimental_analyzer = 1, enable_named_columns_in_function_tuple = 0;
+
+SELECT '-- tuple() with enable_named_columns_in_function_tuple = 1 and allow_experimental_analyzer = 1 keeps the column names';
+SELECT untuple(tuple(1 as a)) as t FORMAT Vertical SETTINGS allow_experimental_analyzer = 1, enable_named_columns_in_function_tuple = 1;
 
 SELECT '-- thankfully JSONExtract() keeps them';
 SELECT untuple(JSONExtract('{"key": "value"}', 'Tuple(key String)')) x FORMAT Vertical SETTINGS allow_experimental_analyzer = 0;

--- a/tests/queries/0_stateless/03038_nested_dynamic_merges.sh
+++ b/tests/queries/0_stateless/03038_nested_dynamic_merges.sh
@@ -7,7 +7,7 @@ CLICKHOUSE_LOG_COMMENT=
 # shellcheck source=../shell_config.sh
 . "$CUR_DIR"/../shell_config.sh
 
-CH_CLIENT="$CLICKHOUSE_CLIENT --allow_experimental_variant_type=1 --use_variant_as_common_type=1 --allow_experimental_dynamic_type=1"
+CH_CLIENT="$CLICKHOUSE_CLIENT --allow_experimental_variant_type=1 --use_variant_as_common_type=1 --allow_experimental_dynamic_type=1 --enable_named_columns_in_function_tuple=0"
 
 
 function test()

--- a/utils/check-style/aspell-ignore/en/aspell-dict.txt
+++ b/utils/check-style/aspell-ignore/en/aspell-dict.txt
@@ -2797,6 +2797,7 @@ tupleModulo
 tupleModuloByNumber
 tupleMultiply
 tupleMultiplyByNumber
+tupleNames
 tupleNegate
 tuplePlus
 tupleToNameValuePairs


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- New Feature

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Extend function `tuple` to construct named tuples in query. Introduce function `tupleNames` to extract names from tuples.

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
