### PR TITLE
avoid running pull request CI workflow for fixes touching .md files only

### DIFF
--- a/.github/workflows/docs_check.yml
+++ b/.github/workflows/docs_check.yml
@@ -13,9 +13,7 @@ on:  # yamllint disable-line rule:truthy
     branches:
       - master
     paths:
-      - 'CHANGELOG.md'
-      - 'README.md'
-      - 'SECURITY.md'
+      - '**.md'
       - 'docker/docs/**'
       - 'docs/**'
       - 'utils/check-style/aspell-ignore/**'

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -13,9 +13,7 @@ on:  # yamllint disable-line rule:truthy
     branches:
       - master
     paths-ignore:
-      - 'CHANGELOG.md'
-      - 'README.md'
-      - 'SECURITY.md'
+      - '**.md'
       - 'docker/docs/**'
       - 'docs/**'
       - 'utils/check-style/aspell-ignore/**'

--- a/tests/config/README.md
+++ b/tests/config/README.md
@@ -1,8 +1,8 @@
 # ClickHouse configs for test environment
 
 ## How to use
-CI use these configs in all checks installing them with `install.sh` script. If you want to run all tests from `tests/queries/0_stateless` and `test/queries/1_stateful` on your local machine you have to set up configs from this directory for your `clickhouse-server`. The most simple way is to install them using `install.sh` script. Other option is just copy files into your clickhouse config directory.
+CI use these configs in all checks installing them with `install.sh` script. If you want to run all tests from `tests/queries/0_stateless` and `test/queries/1_stateful` on your local machine you have to set up configs from this directory for your `clickhouse-server`. The easiest way is to install them using `install.sh` script. Another option is to copy files into your clickhouse config directory.
 
 ## How to add new config
 
-Just place file `.xml` with new config into appropriate directory and add `ln` command into `install.sh` script. After that CI will use this config in all tests runs.
+Place file `.xml` with new config in the appropriate directory and add `ln` command into `install.sh` script. CI will use then this config in all test runs.


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
avoid running CI pull request pipeline for 

### Changelog category (leave one):
Build/Testing/Packaging Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
avoid running pull request CI workflow for fixes touching .md files only
