### PR TITLE
Fix an exception message in Pipe::addTransform

### DIFF
--- a/src/QueryPipeline/Pipe.cpp
+++ b/src/QueryPipeline/Pipe.cpp
@@ -556,7 +556,7 @@ void Pipe::addTransform(ProcessorPtr transform, InputPort * totals, InputPort * 
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Cannot add transform consuming totals to Pipe because Pipe does not have totals");
 
     if (extremes && !extremes_port)
-        throw Exception(ErrorCodes::LOGICAL_ERROR, "Cannot add transform consuming extremes to Pipe because it already has extremes");
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Cannot add transform consuming extremes to Pipe because Pipe does not have extremes");
 
     if (totals)
     {


### PR DESCRIPTION
Fix an exception message in `void Pipe::addTransform(ProcessorPtr transform, InputPort * totals, InputPort * extremes)`.

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
