### PR TITLE
Fix data race during BackupsWorker::backup_log initialization

### DIFF
--- a/src/Backups/BackupsWorker.h
+++ b/src/Backups/BackupsWorker.h
@@ -32,7 +32,7 @@ class BackupLog;
 class BackupsWorker
 {
 public:
-    BackupsWorker(size_t num_backup_threads, size_t num_restore_threads, bool allow_concurrent_backups_, bool allow_concurrent_restores_);
+    BackupsWorker(ContextPtr global_context, size_t num_backup_threads, size_t num_restore_threads, bool allow_concurrent_backups_, bool allow_concurrent_restores_);
 
     /// Waits until all tasks have been completed.
     void shutdown();

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -2224,7 +2224,7 @@ BackupsWorker & Context::getBackupsWorker() const
     UInt64 restore_threads = config.getUInt64("restore_threads", settings_ref.restore_threads);
 
     if (!shared->backups_worker)
-        shared->backups_worker.emplace(backup_threads, restore_threads, allow_concurrent_backups, allow_concurrent_restores);
+        shared->backups_worker.emplace(getGlobalContext(), backup_threads, restore_threads, allow_concurrent_backups, allow_concurrent_restores);
 
     return *shared->backups_worker;
 }


### PR DESCRIPTION
Follow-up to #53638

### Changelog category (leave one):

- Not for changelog (changelog entry is not required)

The bug was automatically detected [here](https://s3.amazonaws.com/clickhouse-test-reports/35961/c9753d7fd99050f0b6d4c4c5a02ab2c265239879/stateless_tests__tsan__%5B3_5%5D/stderr.log).