### PR TITLE
Fix data race in SYSTEM STOP LISTEN

### DIFF
--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -1516,11 +1516,13 @@ try
 
     global_context->setStopServersCallback([&](const ServerType & server_type)
     {
+        std::lock_guard lock(servers_lock);
         stopServers(servers, server_type);
     });
 
     global_context->setStartServersCallback([&](const ServerType & server_type)
     {
+        std::lock_guard lock(servers_lock);
         createServers(
             config(),
             listen_hosts,


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Found in a test: [link](https://s3.amazonaws.com/clickhouse-test-reports/0/be1e92a2acc430742a60e8836023bd66b4f74708/integration_tests__tsan__[5_6]/integration_run_parallel4_0.log)