### PR TITLE
Respect max_block_size while generating rows for system.stack_trace (will fix flakiness of the test)

### DIFF
--- a/src/Storages/System/StorageSystemStackTrace.cpp
+++ b/src/Storages/System/StorageSystemStackTrace.cpp
@@ -13,6 +13,7 @@
 #include <Storages/VirtualColumnUtils.h>
 #include <Columns/ColumnString.h>
 #include <Columns/ColumnsNumber.h>
+#include <Columns/ColumnArray.h>
 #include <DataTypes/DataTypeString.h>
 #include <DataTypes/DataTypesNumber.h>
 #include <DataTypes/DataTypeArray.h>
@@ -159,24 +160,6 @@ bool wait(int timeout_ms)
     }
 }
 
-ColumnPtr getFilteredThreadIds(ASTPtr query, ContextPtr context)
-{
-    MutableColumnPtr all_thread_ids = ColumnUInt64::create();
-
-    std::filesystem::directory_iterator end;
-
-    /// There is no better way to enumerate threads in a process other than looking into procfs.
-    for (std::filesystem::directory_iterator it("/proc/self/task"); it != end; ++it)
-    {
-        pid_t tid = parse<pid_t>(it->path().filename());
-        all_thread_ids->insert(tid);
-    }
-
-    Block block { ColumnWithTypeAndName(std::move(all_thread_ids), std::make_shared<DataTypeUInt64>(), "thread_id") };
-    VirtualColumnUtils::filterBlockWithQuery(query, block, context);
-    return block.getByPosition(0).column;
-}
-
 using ThreadIdToName = std::unordered_map<UInt64, String, DefaultHash<UInt64>>;
 ThreadIdToName getFilteredThreadNames(ASTPtr query, ContextPtr context, const PaddedPODArray<UInt64> & thread_ids, Poco::Logger * log)
 {
@@ -230,6 +213,170 @@ ThreadIdToName getFilteredThreadNames(ASTPtr query, ContextPtr context, const Pa
     return tid_to_name;
 }
 
+/// Send a signal to every thread and wait for result.
+/// We must wait for every thread one by one sequentially,
+///  because there is a limit on number of queued signals in OS and otherwise signals may get lost.
+/// Also, non-RT signals are not delivered if previous signal is handled right now (by default; but we use RT signals).
+class StorageSystemStackTraceSource : public ISource
+{
+public:
+    StorageSystemStackTraceSource(const Names & column_names, Block header_, const ASTPtr query_, ContextPtr context_, UInt64 max_block_size_, Poco::Logger * log_)
+        : ISource(header_)
+        , context(context_)
+        , header(std::move(header_))
+        , query(query_)
+        , max_block_size(max_block_size_)
+        , pipe_read_timeout_ms(static_cast<int>(context->getSettingsRef().storage_system_stack_trace_pipe_read_timeout_ms.totalMilliseconds()))
+        , log(log_)
+        , proc_it("/proc/self/task")
+    {
+        /// Create a mask of what columns are needed in the result.
+        NameSet names_set(column_names.begin(), column_names.end());
+        send_signal = names_set.contains("trace") || names_set.contains("query_id");
+        read_thread_names = names_set.contains("thread_name");
+    }
+
+    String getName() const override { return "StackTrace"; }
+
+protected:
+    Chunk generate() override
+    {
+        /// It shouldn't be possible to do concurrent reads from this table.
+        std::lock_guard lock(mutex);
+
+        MutableColumns res_columns = header.cloneEmptyColumns();
+
+        ColumnPtr thread_ids;
+        {
+            Stopwatch watch;
+            thread_ids = getFilteredThreadIds();
+            LOG_TEST(log, "Read {} threads, took {} ms", thread_ids->size(), watch.elapsedMilliseconds());
+        }
+        if (thread_ids->empty())
+            return Chunk();
+
+        const auto & thread_ids_data = assert_cast<const ColumnUInt64 &>(*thread_ids).getData();
+
+        ThreadIdToName thread_names;
+        if (read_thread_names)
+            thread_names = getFilteredThreadNames(query, context, thread_ids_data, log);
+
+        for (UInt64 tid : thread_ids_data)
+        {
+            size_t res_index = 0;
+
+            String thread_name;
+            if (read_thread_names)
+            {
+                if (auto it = thread_names.find(tid); it != thread_names.end())
+                    thread_name = it->second;
+                else
+                    continue; /// was filtered out by "thread_name" condition
+            }
+
+            if (!send_signal)
+            {
+                res_columns[res_index++]->insert(thread_name);
+                res_columns[res_index++]->insert(tid);
+                res_columns[res_index++]->insertDefault();
+                res_columns[res_index++]->insertDefault();
+            }
+            else
+            {
+                ++signals_sent;
+                Stopwatch watch;
+                SCOPE_EXIT({ signals_sent_ms += watch.elapsedMilliseconds(); });
+
+                sigval sig_value{};
+
+                sig_value.sival_int = sequence_num.load(std::memory_order_acquire);
+                if (0 != ::sigqueue(static_cast<int>(tid), sig, sig_value))
+                {
+                    /// The thread may has been already finished.
+                    if (ESRCH == errno)
+                        continue;
+
+                    throwFromErrno("Cannot send signal with sigqueue", ErrorCodes::CANNOT_SIGQUEUE);
+                }
+
+                /// Just in case we will wait for pipe with timeout. In case signal didn't get processed.
+                if (wait(pipe_read_timeout_ms) && sig_value.sival_int == data_ready_num.load(std::memory_order_acquire))
+                {
+                    size_t stack_trace_size = stack_trace.getSize();
+                    size_t stack_trace_offset = stack_trace.getOffset();
+
+                    Array arr;
+                    arr.reserve(stack_trace_size - stack_trace_offset);
+                    for (size_t i = stack_trace_offset; i < stack_trace_size; ++i)
+                        arr.emplace_back(reinterpret_cast<intptr_t>(stack_trace.getFramePointers()[i]));
+
+                    res_columns[res_index++]->insert(thread_name);
+                    res_columns[res_index++]->insert(tid);
+                    res_columns[res_index++]->insertData(query_id_data, query_id_size);
+                    res_columns[res_index++]->insert(arr);
+                }
+                else
+                {
+                    LOG_DEBUG(log, "Cannot obtain a stack trace for thread {}", tid);
+
+                    res_columns[res_index++]->insert(thread_name);
+                    res_columns[res_index++]->insert(tid);
+                    res_columns[res_index++]->insertDefault();
+                    res_columns[res_index++]->insertDefault();
+                }
+
+                /// Signed integer overflow is undefined behavior in both C and C++. However, according to
+                /// C++ standard, Atomic signed integer arithmetic is defined to use two's complement; there
+                /// are no undefined results. See https://en.cppreference.com/w/cpp/atomic/atomic and
+                /// http://eel.is/c++draft/atomics.types.generic#atomics.types.int-8
+                ++sequence_num;
+            }
+        }
+        LOG_TEST(log, "Send signal to {} threads (total), took {} ms", signals_sent, signals_sent_ms);
+
+        UInt64 num_rows = res_columns.at(0)->size();
+        Chunk chunk(std::move(res_columns), num_rows);
+        return chunk;
+    }
+
+private:
+    ContextPtr context;
+    Block header;
+    const ASTPtr query;
+
+    const size_t max_block_size;
+    const int pipe_read_timeout_ms;
+    bool send_signal = false;
+    bool read_thread_names = false;
+
+    Poco::Logger * log;
+
+    std::filesystem::directory_iterator proc_it;
+    std::filesystem::directory_iterator end;
+
+    size_t signals_sent = 0;
+    size_t signals_sent_ms = 0;
+
+    std::mutex mutex;
+
+    ColumnPtr getFilteredThreadIds()
+    {
+        MutableColumnPtr all_thread_ids = ColumnUInt64::create();
+
+        size_t i = 0;
+        /// There is no better way to enumerate threads in a process other than looking into procfs.
+        for (; i < max_block_size && proc_it != end; ++proc_it, ++i)
+        {
+            pid_t tid = parse<pid_t>(proc_it->path().filename());
+            all_thread_ids->insert(tid);
+        }
+
+        Block block { ColumnWithTypeAndName(std::move(all_thread_ids), std::make_shared<DataTypeUInt64>(), "thread_id") };
+        VirtualColumnUtils::filterBlockWithQuery(query, block, context);
+        return block.getByPosition(0).column;
+    }
+};
+
 }
 
 
@@ -271,126 +418,17 @@ Pipe StorageSystemStackTrace::read(
     SelectQueryInfo & query_info,
     ContextPtr context,
     QueryProcessingStage::Enum /*processed_stage*/,
-    const size_t /*max_block_size*/,
+    const size_t max_block_size,
     const size_t /*num_streams*/)
 {
     storage_snapshot->check(column_names);
-
-    int pipe_read_timeout_ms = static_cast<int>(
-        context->getSettingsRef().storage_system_stack_trace_pipe_read_timeout_ms.totalMilliseconds());
-
-    /// It shouldn't be possible to do concurrent reads from this table.
-    std::lock_guard lock(mutex);
-
-    /// Create a mask of what columns are needed in the result.
-
-    NameSet names_set(column_names.begin(), column_names.end());
-
-    Block sample_block = storage_snapshot->metadata->getSampleBlock();
-
-    bool send_signal = names_set.contains("trace") || names_set.contains("query_id");
-    bool read_thread_names = names_set.contains("thread_name");
-
-    MutableColumns res_columns = sample_block.cloneEmptyColumns();
-
-    /// Send a signal to every thread and wait for result.
-    /// We must wait for every thread one by one sequentially,
-    ///  because there is a limit on number of queued signals in OS and otherwise signals may get lost.
-    /// Also, non-RT signals are not delivered if previous signal is handled right now (by default; but we use RT signals).
-
-    /// Obviously, results for different threads may be out of sync.
-
-    ColumnPtr thread_ids;
-    {
-        Stopwatch watch;
-        thread_ids = getFilteredThreadIds(query_info.query, context);
-        LOG_TEST(log, "Read {} threads, took {} ms", thread_ids->size(), watch.elapsedMilliseconds());
-    }
-    const auto & thread_ids_data = assert_cast<const ColumnUInt64 &>(*thread_ids).getData();
-
-    ThreadIdToName thread_names;
-    if (read_thread_names)
-        thread_names = getFilteredThreadNames(query_info.query, context, thread_ids_data, log);
-
-    size_t signals_sent = 0;
-    size_t signals_sent_ms = 0;
-    for (UInt64 tid : thread_ids_data)
-    {
-        size_t res_index = 0;
-
-        String thread_name;
-        if (read_thread_names)
-        {
-            if (auto it = thread_names.find(tid); it != thread_names.end())
-                thread_name = it->second;
-            else
-                continue; /// was filtered out by "thread_name" condition
-        }
-
-        if (!send_signal)
-        {
-            res_columns[res_index++]->insert(thread_name);
-            res_columns[res_index++]->insert(tid);
-            res_columns[res_index++]->insertDefault();
-            res_columns[res_index++]->insertDefault();
-        }
-        else
-        {
-            ++signals_sent;
-            Stopwatch watch;
-            SCOPE_EXIT({ signals_sent_ms += watch.elapsedMilliseconds(); });
-
-            sigval sig_value{};
-
-            sig_value.sival_int = sequence_num.load(std::memory_order_acquire);
-            if (0 != ::sigqueue(static_cast<int>(tid), sig, sig_value))
-            {
-                /// The thread may has been already finished.
-                if (ESRCH == errno)
-                    continue;
-
-                throwFromErrno("Cannot send signal with sigqueue", ErrorCodes::CANNOT_SIGQUEUE);
-            }
-
-            /// Just in case we will wait for pipe with timeout. In case signal didn't get processed.
-            if (wait(pipe_read_timeout_ms) && sig_value.sival_int == data_ready_num.load(std::memory_order_acquire))
-            {
-                size_t stack_trace_size = stack_trace.getSize();
-                size_t stack_trace_offset = stack_trace.getOffset();
-
-                Array arr;
-                arr.reserve(stack_trace_size - stack_trace_offset);
-                for (size_t i = stack_trace_offset; i < stack_trace_size; ++i)
-                    arr.emplace_back(reinterpret_cast<intptr_t>(stack_trace.getFramePointers()[i]));
-
-                res_columns[res_index++]->insert(thread_name);
-                res_columns[res_index++]->insert(tid);
-                res_columns[res_index++]->insertData(query_id_data, query_id_size);
-                res_columns[res_index++]->insert(arr);
-            }
-            else
-            {
-                LOG_DEBUG(log, "Cannot obtain a stack trace for thread {}", tid);
-
-                res_columns[res_index++]->insert(thread_name);
-                res_columns[res_index++]->insert(tid);
-                res_columns[res_index++]->insertDefault();
-                res_columns[res_index++]->insertDefault();
-            }
-
-            /// Signed integer overflow is undefined behavior in both C and C++. However, according to
-            /// C++ standard, Atomic signed integer arithmetic is defined to use two's complement; there
-            /// are no undefined results. See https://en.cppreference.com/w/cpp/atomic/atomic and
-            /// http://eel.is/c++draft/atomics.types.generic#atomics.types.int-8
-            ++sequence_num;
-        }
-    }
-    LOG_TEST(log, "Send signal to {} threads, took {} ms", signals_sent, signals_sent_ms);
-
-    UInt64 num_rows = res_columns.at(0)->size();
-    Chunk chunk(std::move(res_columns), num_rows);
-
-    return Pipe(std::make_shared<SourceFromSingleChunk>(sample_block, std::move(chunk)));
+    return Pipe(std::make_shared<StorageSystemStackTraceSource>(
+        column_names,
+        storage_snapshot->metadata->getSampleBlock(),
+        query_info.query->clone(),
+        context,
+        max_block_size,
+        log));
 }
 
 }

--- a/src/Storages/System/StorageSystemStackTrace.h
+++ b/src/Storages/System/StorageSystemStackTrace.h
@@ -2,7 +2,6 @@
 
 #ifdef OS_LINUX /// Because of 'sigqueue' functions and RT signals.
 
-#include <mutex>
 #include <Storages/IStorage.h>
 
 namespace Poco
@@ -38,7 +37,6 @@ public:
     bool isSystemStorage() const override { return true; }
 
 protected:
-    mutable std::mutex mutex;
     Poco::Logger * log;
 };
 

--- a/tests/queries/0_stateless/01051_system_stack_trace.reference
+++ b/tests/queries/0_stateless/01051_system_stack_trace.reference
@@ -1,0 +1,18 @@
+-- { echo }
+SELECT count() > 0 FROM system.stack_trace WHERE query_id != '' AND thread_name = 'TCPHandler';
+1
+-- opimization for not reading /proc/self/task/{}/comm and avoid sending signal
+SELECT countIf(thread_id > 0) > 0 FROM system.stack_trace;
+1
+-- optimization for trace
+SELECT length(trace) > 0 FROM system.stack_trace WHERE length(trace) > 0 LIMIT 1;
+1
+-- optimization for query_id
+SELECT length(query_id) > 0 FROM system.stack_trace WHERE query_id != '' AND thread_name = 'TCPHandler' LIMIT 1;
+1
+-- optimization for thread_name
+SELECT length(thread_name) > 0 FROM system.stack_trace WHERE thread_name != '' LIMIT 1;
+1
+-- enough rows (optimizations works "correctly")
+SELECT count() > 100 FROM system.stack_trace;
+1

--- a/tests/queries/0_stateless/01051_system_stack_trace.sql
+++ b/tests/queries/0_stateless/01051_system_stack_trace.sql
@@ -1,0 +1,24 @@
+-- Tags: no-parallel
+-- Tag no-parallel: to decrease failure probability of collecting stack traces
+
+-- Process one thread at a time
+SET max_block_size = 1;
+
+-- It is OK to have bigger timeout here since:
+-- a) this test is marked as no-parallel
+-- b) there is a filter by thread_name, so it will send signals only to the threads with the name TCPHandler
+-- c) max_block_size is 1
+SET storage_system_stack_trace_pipe_read_timeout_ms = 5000;
+
+-- { echo }
+SELECT count() > 0 FROM system.stack_trace WHERE query_id != '' AND thread_name = 'TCPHandler';
+-- opimization for not reading /proc/self/task/{}/comm and avoid sending signal
+SELECT countIf(thread_id > 0) > 0 FROM system.stack_trace;
+-- optimization for trace
+SELECT length(trace) > 0 FROM system.stack_trace WHERE length(trace) > 0 LIMIT 1;
+-- optimization for query_id
+SELECT length(query_id) > 0 FROM system.stack_trace WHERE query_id != '' AND thread_name = 'TCPHandler' LIMIT 1;
+-- optimization for thread_name
+SELECT length(thread_name) > 0 FROM system.stack_trace WHERE thread_name != '' LIMIT 1;
+-- enough rows (optimizations works "correctly")
+SELECT count() > 100 FROM system.stack_trace;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Respect max_block_size while generating rows for system.stack_trace (will fix flakiness of the test)

CI: https://s3.amazonaws.com/clickhouse-test-reports/54873/fbadf604096edfe435da2ac6944b896d745b2412/fast_test.html
Fixes: `01051_system_stack_trace`