### PR TITLE
CREATE VIEW check if the column list is same as the select query

### DIFF
--- a/tests/queries/0_stateless/02888_create_view_check_columns.sql
+++ b/tests/queries/0_stateless/02888_create_view_check_columns.sql
@@ -1,0 +1,11 @@
+drop view if exists view_columns_check_v1;
+drop view if exists view_columns_check_v2;
+drop view if exists view_columns_check_v3;
+
+create view view_columns_check_v1 (a UInt64) as select number as a from system.numbers limit 1;
+create view view_columns_check_v2 (a String) as select number as a from system.numbers limit 1; -- { serverError 80 }
+create view view_columns_check_v3 (b UInt64) as select number as a from system.numbers limit 1; -- { serverError 80 }
+
+drop view if exists view_columns_check_v1;
+drop view if exists view_columns_check_v2;
+drop view if exists view_columns_check_v3;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
CREATE VIEW check if the column list is same as the select query

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
