### PR TITLE
Introduce new part metadata file

### DIFF
--- a/docs/en/operations/system-tables/parts.md
+++ b/docs/en/operations/system-tables/parts.md
@@ -49,7 +49,9 @@ Columns:
 
 - `secondary_indices_marks_bytes` ([UInt64](../../sql-reference/data-types/int-uint.md)) – The size of the file with marks for secondary indices.
 
-- `modification_time` ([DateTime](../../sql-reference/data-types/datetime.md)) – The time the directory with the data part was modified. This usually corresponds to the time of data part creation.
+- `creation_time` ([Nullable](../../sql-reference/data-types/nullable.md)([DateTime](../../sql-reference/data-types/datetime.md))) – For old parts (`metadata_format_version` is 0), it is null. For all newer versions, the time at which this part was created.
+
+- `modification_time` ([DateTime](../../sql-reference/data-types/datetime.md)) – The time the directory with the data part was modified.
 
 - `remove_time` ([DateTime](../../sql-reference/data-types/datetime.md)) – The time when the data part became inactive.
 
@@ -100,6 +102,8 @@ Columns:
 - `delete_ttl_info_max` ([DateTime](../../sql-reference/data-types/datetime.md)) — The maximum value of the date and time key for [TTL DELETE rule](../../engines/table-engines/mergetree-family/mergetree.md/#table_engine-mergetree-ttl).
 
 - `move_ttl_info.expression` ([Array](../../sql-reference/data-types/array.md)([String](../../sql-reference/data-types/string.md))) — Array of expressions. Each expression defines a [TTL MOVE rule](../../engines/table-engines/mergetree-family/mergetree.md/#table_engine-mergetree-ttl).
+
+- `metadata_format_version` ([UInt32](../../sql-reference/data-types/int-uint.md)) – Version of the `metadata.json` for this part. Values documented under [setting `desired_part_metadata_format_version`](../../operations/settings/merge-tree-settings.md#desired_part_metadata_format_version-desired_part_metadata_format_version)
 
 :::note
 The `move_ttl_info.expression` array is kept mostly for backward compatibility, now the simplest way to check `TTL MOVE` rule is to use the `move_ttl_info.min` and `move_ttl_info.max` fields.

--- a/docs/en/operations/system-tables/tables.md
+++ b/docs/en/operations/system-tables/tables.md
@@ -61,6 +61,8 @@ Columns:
 
 - `lifetime_bytes` ([Nullable](../../sql-reference/data-types/nullable.md)([UInt64](../../sql-reference/data-types/int-uint.md))) - Total number of bytes INSERTed since server start (only for `Buffer` tables).
 
+- `part_metadata_format_version` ([Nullable](../../sql-reference/data-types/nullable.md)([UInt32](../../sql-reference/data-types/int-uint.md))) - Null for non mergetree family. For mergetree, the part metadata format version for newly written parts. Existing parts can have other versions. Values documented under [setting `desired_part_metadata_format_version`](../../operations/settings/merge-tree-settings.md#desired_part_metadata_format_version-desired_part_metadata_format_version)
+
 - `comment` ([String](../../sql-reference/data-types/string.md)) - The comment for the table.
 
 - `has_own_data` ([UInt8](../../sql-reference/data-types/int-uint.md)) — Flag that indicates whether the table itself stores some data on disk or only accesses some other source.

--- a/src/Storages/MergeTree/DataPartsExchange.cpp
+++ b/src/Storages/MergeTree/DataPartsExchange.cpp
@@ -748,7 +748,11 @@ MergeTreeData::MutableDataPartPtr Fetcher::downloadPartToMemory(
         CompressionCodecFactory::instance().get("NONE", {}), NO_TRANSACTION_PTR);
 
     part_out.write(block);
-    part_out.finalizePart(new_data_part, false);
+
+    // In the case of fetching an in-memory part, it's not clear what the creation time should be
+    // We would like it to be identical to replicas, but we have no way to see the value there.
+    // Changing replication protocol just for this thing seems overkill, so use current time instead :/
+    part_out.finalizePart(new_data_part, false, time(nullptr));
     new_data_part->checksums.checkEqual(checksums, /* have_uncompressed = */ true);
 
     return new_data_part;

--- a/src/Storages/MergeTree/IMergeTreeDataPart.cpp
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.cpp
@@ -644,6 +644,7 @@ void IMergeTreeDataPart::loadColumnsChecksumsIndexes(bool require_columns_checks
 
     try
     {
+        loadMetadataJson();
         loadUUID();
         loadColumns(require_columns_checksums);
         loadChecksums(require_columns_checksums);
@@ -673,10 +674,24 @@ void IMergeTreeDataPart::loadColumnsChecksumsIndexes(bool require_columns_checks
     }
 }
 
+void IMergeTreeDataPart::appendFilesOfMetadataJSON(Strings & files)
+{
+    files.push_back("metadata.json");
+}
+
+void IMergeTreeDataPart::loadMetadataJson()
+{
+    if (metadata_manager->exists("metadata.json"))
+    {
+        metadata.readJSON(*metadata_manager->read("metadata.json"));
+    }
+}
+
 void IMergeTreeDataPart::appendFilesOfColumnsChecksumsIndexes(Strings & files, bool include_projection) const
 {
     if (isStoredOnDisk())
     {
+        appendFilesOfMetadataJSON(files);
         appendFilesOfUUID(files);
         appendFilesOfColumns(files);
         appendFilesOfChecksums(files);

--- a/src/Storages/MergeTree/IMergeTreeDataPart.h
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.h
@@ -19,6 +19,7 @@
 #include <Storages/MergeTree/MergeTreeIOSettings.h>
 #include <Storages/MergeTree/KeyCondition.h>
 #include <Storages/MergeTree/MergeTreeDataPartBuilder.h>
+#include <Storages/MergeTree/PartMetadataJSON.h>
 #include <Storages/ColumnsDescription.h>
 #include <Interpreters/TransactionVersionMetadata.h>
 #include <DataTypes/Serializations/SerializationInfo.h>
@@ -223,6 +224,8 @@ public:
     size_t rows_count = 0;
 
     time_t modification_time = 0;
+    PartMetadataJSON metadata;
+
     /// When the part is removed from the working set. Changes once.
     mutable std::atomic<time_t> remove_time { std::numeric_limits<time_t>::max() };
 
@@ -609,8 +612,13 @@ private:
     /// It is used while reading from wide parts.
     ColumnsDescription columns_description_with_collected_nested;
 
+    // Reads part metadata from metadata.json if it exists.
+    void loadMetadataJson();
+
     /// Reads part unique identifier (if exists) from uuid.txt
     void loadUUID();
+
+    static void appendFilesOfMetadataJSON(Strings & files);
 
     static void appendFilesOfUUID(Strings & files);
 

--- a/src/Storages/MergeTree/MergeTask.cpp
+++ b/src/Storages/MergeTree/MergeTask.cpp
@@ -777,9 +777,9 @@ bool MergeTask::MergeProjectionsStage::finalizeProjectionsAndWholeMerge() const
     }
 
     if (global_ctx->chosen_merge_algorithm != MergeAlgorithm::Vertical)
-        global_ctx->to->finalizePart(global_ctx->new_data_part, ctx->need_sync);
+        global_ctx->to->finalizePart(global_ctx->new_data_part, ctx->need_sync, global_ctx->time_of_merge);
     else
-        global_ctx->to->finalizePart(global_ctx->new_data_part, ctx->need_sync, &global_ctx->storage_columns, &global_ctx->checksums_gathered_columns);
+        global_ctx->to->finalizePart(global_ctx->new_data_part, ctx->need_sync, global_ctx->time_of_merge, &global_ctx->storage_columns, &global_ctx->checksums_gathered_columns);
 
     global_ctx->new_data_part->getDataPartStorage().precommitTransaction();
     global_ctx->promise.set_value(global_ctx->new_data_part);

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -8134,7 +8134,8 @@ std::pair<MergeTreeData::MutableDataPartPtr, scope_guard> MergeTreeData::createE
 
     out.write(block);
     /// Here is no projections as no data inside
-    out.finalizePart(new_data_part, sync_on_insert);
+    /// We set create time to the current time since it's just an empty part.
+    out.finalizePart(new_data_part, sync_on_insert, time(nullptr));
 
     new_data_part_storage->precommitTransaction();
     return std::make_pair(std::move(new_data_part), std::move(tmp_dir_holder));

--- a/src/Storages/MergeTree/MergeTreeData.h
+++ b/src/Storages/MergeTree/MergeTreeData.h
@@ -1060,6 +1060,10 @@ public:
     /// Do nothing for non-replicated tables
     virtual void createAndStoreFreezeMetadata(DiskPtr disk, DataPartPtr part, String backup_part_path) const;
 
+    /// Should report the metadata format version to be used when writing new parts
+    /// Implementation depends on whether it is replicated
+    virtual PartMetadataFormatVersion partMetadataFormatVersion() const = 0;
+
     /// Parts that currently submerging (merging to bigger parts) or emerging
     /// (to be appeared after merging finished). These two variables have to be used
     /// with `currently_submerging_emerging_mutex`.

--- a/src/Storages/MergeTree/MergeTreeDataMergerMutator.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataMergerMutator.cpp
@@ -406,7 +406,7 @@ MergeTreeDataMergerMutator::MergeSelectingInfo MergeTreeDataMergerMutator::getPo
 
         IMergeSelector::Part part_info;
         part_info.size = part->getBytesOnDisk();
-        part_info.age = res.current_time - part->modification_time;
+        part_info.age = res.current_time - part->metadata.creationTime(part->modification_time);
         part_info.level = part->info.level;
         part_info.data = &part;
         part_info.ttl_infos = &part->ttl_infos;

--- a/src/Storages/MergeTree/MergeTreeDataWriter.h
+++ b/src/Storages/MergeTree/MergeTreeDataWriter.h
@@ -94,7 +94,8 @@ public:
         Poco::Logger * log,
         Block block,
         const ProjectionDescription & projection,
-        IMergeTreeDataPart * parent_part);
+        IMergeTreeDataPart * parent_part,
+        time_t creation_time);
 
     /// For mutation: MATERIALIZE PROJECTION.
     static TemporaryPart writeTempProjectionPart(
@@ -128,7 +129,8 @@ private:
         const MergeTreeData & data,
         Poco::Logger * log,
         Block block,
-        const ProjectionDescription & projection);
+        const ProjectionDescription & projection,
+        time_t creation_time);
 
     MergeTreeData & data;
     Poco::Logger * log;

--- a/src/Storages/MergeTree/MergeTreeSettings.cpp
+++ b/src/Storages/MergeTree/MergeTreeSettings.cpp
@@ -211,5 +211,14 @@ void MergeTreeSettings::sanityCheck(size_t background_pool_tasks) const
             "The value of merge_selecting_sleep_slowdown_factor setting ({}) cannot be less than 1.0",
             merge_selecting_sleep_slowdown_factor);
     }
+
+    if (desired_part_metadata_format_version > PART_METADATA_MAX_FORMAT_VERSION)
+    {
+        throw Exception(
+            ErrorCodes::BAD_ARGUMENTS,
+            "desired_part_metadata_format_version is set to an unknown value. The max is {}. Configured value is {}",
+            PART_METADATA_MAX_FORMAT_VERSION,
+            desired_part_metadata_format_version);
+    }
 }
 }

--- a/src/Storages/MergeTree/MergeTreeSettings.h
+++ b/src/Storages/MergeTree/MergeTreeSettings.h
@@ -6,6 +6,7 @@
 #include <Core/SettingsEnums.h>
 #include <Interpreters/Context_fwd.h>
 #include <Storages/MergeTree/MergeTreeDataFormatVersion.h>
+#include <Storages/MergeTree/PartMetadataJSON.h>
 
 
 namespace Poco::Util
@@ -173,8 +174,9 @@ struct Settings;
     M(UInt64, part_moves_between_shards_delay_seconds, 30, "Time to wait before/after moving parts between shards.", 0) \
     M(Bool, allow_remote_fs_zero_copy_replication, false, "Don't use this setting in production, because it is not ready.", 0) \
     M(String, remote_fs_zero_copy_zookeeper_path, "/clickhouse/zero_copy", "ZooKeeper path for zero-copy table-independent info.", 0) \
-    M(Bool, remote_fs_zero_copy_path_compatible_mode, false, "Run zero-copy in compatible mode during conversion process.", 0)                                                                                                                                       \
+    M(Bool, remote_fs_zero_copy_path_compatible_mode, false, "Run zero-copy in compatible mode during conversion process.", 0) \
     M(Bool, allow_experimental_block_number_column, false, "Enable persisting column _block_number for each row.", 0) \
+    M(UInt32, desired_part_metadata_format_version, PART_METADATA_DEFAULT_FORMAT_VERSION, "The part metadata format version to write new parts with. In replicated tables, the minimum such value from all replicas is used. The feature is experimental, so default value is `0`, which disables.", 0) \
     \
     /** Compress marks and primary key. */ \
     M(Bool, compress_marks, true, "Marks support compression, reduce mark file size and speed up network transmission.", 0) \

--- a/src/Storages/MergeTree/MergedBlockOutputStream.h
+++ b/src/Storages/MergeTree/MergedBlockOutputStream.h
@@ -56,12 +56,14 @@ public:
     Finalizer finalizePartAsync(
         const MergeTreeMutableDataPartPtr & new_part,
         bool sync,
+        time_t create_time,
         const NamesAndTypesList * total_columns_list = nullptr,
         MergeTreeData::DataPart::Checksums * additional_column_checksums = nullptr);
 
     void finalizePart(
         const MergeTreeMutableDataPartPtr & new_part,
         bool sync,
+        time_t create_time,
         const NamesAndTypesList * total_columns_list = nullptr,
         MergeTreeData::DataPart::Checksums * additional_column_checksums = nullptr);
 

--- a/src/Storages/MergeTree/PartMetadataJSON.cpp
+++ b/src/Storages/MergeTree/PartMetadataJSON.cpp
@@ -1,0 +1,70 @@
+#include "PartMetadataJSON.h"
+
+#include <Poco/JSON/JSON.h>
+#include <Poco/JSON/Object.h>
+#include <Poco/JSON/Parser.h>
+
+#include <Common/Exception.h>
+#include <IO/ReadHelpers.h>
+#include <IO/WriteHelpers.h>
+
+namespace DB
+{
+
+namespace ErrorCodes
+{
+    extern const int UNKNOWN_FORMAT_VERSION;
+    extern const int FORMAT_VERSION_TOO_OLD;
+}
+
+PartMetadataJSON::PartMetadataJSON(Poco::JSON::Object::Ptr json_): json(json_) {}
+
+void PartMetadataJSON::readJSON(ReadBuffer & in)
+{
+    String json_str;
+    readString(json_str, in);
+
+    Poco::JSON::Parser parser;
+    json = parser.parse(json_str).extract<Poco::JSON::Object::Ptr>();
+}
+
+void PartMetadataJSON::writeJSON(WriteBuffer & out) const
+{
+    if (!json)
+        throw Exception(ErrorCodes::FORMAT_VERSION_TOO_OLD, "Tried to write metadata.json but it is not set in memory, logic bug");
+    std::ostringstream oss; // STYLE_CHECK_ALLOW_STD_STRING_STREAM
+    oss.exceptions(std::ios::failbit);
+    Poco::JSON::Stringifier::stringify(json, oss);
+    writeString(oss.str(), out);
+}
+
+PartMetadataFormatVersion PartMetadataJSON::metadataFormatVersion() const
+{
+    if (!json)
+        return PART_METADATA_FORMAT_VERSION_OLD;
+    auto version = json->getValue<UInt32>("version");
+    if (version > PART_METADATA_MAX_FORMAT_VERSION)
+        // The part was actually read with an unknown value for metadata version
+        // I don't think we can just assume a lower value, since future version of clickhouse might fundamentally shake things up
+        // So instead, we must throw exception, presumably this part will get detached :(
+        throw Exception(ErrorCodes::UNKNOWN_FORMAT_VERSION, "Unknown part metadata format version {}. Maximum supported version is {}", version, PART_METADATA_MAX_FORMAT_VERSION);
+    return PartMetadataFormatVersion{version};
+}
+
+time_t PartMetadataJSON::creationTime() const
+{
+    if (metadataFormatVersion() < PART_METADATA_FORMAT_VERSION_INITIAL)
+        throw Exception(ErrorCodes::FORMAT_VERSION_TOO_OLD, "Part was written with format version {} which does not have creation time. Requires at least format version {}", metadataFormatVersion(), PART_METADATA_FORMAT_VERSION_INITIAL);
+    auto timestamp = json->getValue<UInt64>("creation_time");
+    return time_t(timestamp);
+}
+
+time_t PartMetadataJSON::creationTime(time_t fallback) const
+{
+    if (metadataFormatVersion() < PART_METADATA_FORMAT_VERSION_INITIAL)
+        return fallback;
+    auto timestamp = json->getValue<UInt64>("creation_time");
+    return time_t(timestamp);
+}
+
+}

--- a/src/Storages/MergeTree/PartMetadataJSON.h
+++ b/src/Storages/MergeTree/PartMetadataJSON.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <base/strong_typedef.h>
+#include <base/types.h>
+#include <Poco/JSON/JSON.h>
+#include <Poco/JSON/Object.h>
+
+namespace DB
+{
+
+STRONG_TYPEDEF(UInt32, PartMetadataFormatVersion)
+
+const PartMetadataFormatVersion PART_METADATA_FORMAT_VERSION_OLD {0};
+const PartMetadataFormatVersion PART_METADATA_FORMAT_VERSION_INITIAL {1};
+
+// For now the default version is held back, while the feature is still considered experimental
+const PartMetadataFormatVersion PART_METADATA_DEFAULT_FORMAT_VERSION = PART_METADATA_FORMAT_VERSION_OLD;
+// Increment any time a new format version is added
+const PartMetadataFormatVersion PART_METADATA_MAX_FORMAT_VERSION = PART_METADATA_FORMAT_VERSION_INITIAL;
+
+class ReadBuffer;
+class WriteBuffer;
+
+class PartMetadataJSON
+{
+public:
+    PartMetadataJSON() = default;
+    PartMetadataJSON(Poco::JSON::Object::Ptr json_);
+
+    void readJSON(ReadBuffer & in);
+    void writeJSON(WriteBuffer & out) const;
+
+    PartMetadataFormatVersion metadataFormatVersion() const;
+
+    // Get the creationTime for this metadata
+    // Requires metadata version >= PART_METADATA_FORMAT_VERSION_INITIAL, otherwise an exception is thrown
+    //
+    // creationTime represents the time at which merging logic was last applied for the data in this part
+    // merging logic occurs when a part is inserted, or merged with other parts.
+    // merging logic is not necessarily run when a mutation or delete occurs, nor when it is fetched from another replica or attached.
+    time_t creationTime() const;
+    // Get the creationTime for this metadata, or a default if metadata version is too low
+    time_t creationTime(time_t fallback) const;
+
+private:
+    Poco::JSON::Object::Ptr json;
+};
+
+}

--- a/src/Storages/MergeTree/ReplicatedMergeTreeAddress.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeAddress.cpp
@@ -16,6 +16,8 @@ void ReplicatedMergeTreeAddress::writeText(WriteBuffer & out) const
         << "database: " << escape << database << '\n'
         << "table: " << escape << table << '\n'
         << "scheme: " << escape << scheme << '\n';
+    if (desired_part_metadata_format_version > PART_METADATA_FORMAT_VERSION_OLD)
+        out << "desired_part_metadata_format_version: " << desired_part_metadata_format_version.toUnderType() << '\n';
 
 }
 
@@ -32,6 +34,10 @@ void ReplicatedMergeTreeAddress::readText(ReadBuffer & in)
         in >> "scheme: " >> escape >> scheme >> "\n";
     else
         scheme = "http";
+    if (!in.eof())
+        in >> "desired_part_metadata_format_version: " >> desired_part_metadata_format_version.toUnderType() >> "\n";
+    else
+        desired_part_metadata_format_version = PART_METADATA_FORMAT_VERSION_OLD;
 }
 
 String ReplicatedMergeTreeAddress::toString() const

--- a/src/Storages/MergeTree/ReplicatedMergeTreeAddress.h
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeAddress.h
@@ -2,6 +2,7 @@
 #include <base/types.h>
 #include <IO/ReadBuffer.h>
 #include <IO/WriteBuffer.h>
+#include <Storages/MergeTree/PartMetadataJSON.h>
 
 
 namespace DB
@@ -17,6 +18,8 @@ struct ReplicatedMergeTreeAddress
     String database;
     String table;
     String scheme;
+    // If the version wasn't explicitly set, it's probably coming from an old version of CH
+    PartMetadataFormatVersion desired_part_metadata_format_version = PART_METADATA_FORMAT_VERSION_OLD;
 
     ReplicatedMergeTreeAddress() = default;
     explicit ReplicatedMergeTreeAddress(const String & str)

--- a/src/Storages/MergeTree/ReplicatedMergeTreePartCheckThread.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreePartCheckThread.cpp
@@ -394,7 +394,7 @@ ReplicatedCheckResult ReplicatedMergeTreePartCheckThread::checkPartImpl(const St
 
         }
     }
-    else if (part->modification_time + MAX_AGE_OF_LOCAL_PART_THAT_WASNT_ADDED_TO_ZOOKEEPER < current_time)
+    else if (part->metadata.creationTime(part->modification_time) + MAX_AGE_OF_LOCAL_PART_THAT_WASNT_ADDED_TO_ZOOKEEPER < current_time)
     {
         /// If the part is not in ZooKeeper, delete it locally.
         /// Probably, someone just wrote down the part, and has not yet added to ZK.
@@ -409,9 +409,9 @@ ReplicatedCheckResult ReplicatedMergeTreePartCheckThread::checkPartImpl(const St
     else
     {
         auto message = PreformattedMessage::create("Young part {} with age {} seconds hasn't been added to ZooKeeper yet. It's ok.",
-                                                   part_name, (current_time - part->modification_time));
+                                                   part_name, (current_time - part->metadata.creationTime(part->modification_time)));
         LOG_INFO(log, message);
-        result.recheck_after = part->modification_time + MAX_AGE_OF_LOCAL_PART_THAT_WASNT_ADDED_TO_ZOOKEEPER - current_time;
+        result.recheck_after = part->metadata.creationTime(part->modification_time) + MAX_AGE_OF_LOCAL_PART_THAT_WASNT_ADDED_TO_ZOOKEEPER - current_time;
         result.status = {part_name, true, message};
         result.action = ReplicatedCheckResult::RecheckLater;
         return result;

--- a/src/Storages/StorageMergeTree.h
+++ b/src/Storages/StorageMergeTree.h
@@ -114,6 +114,9 @@ public:
 
     std::map<std::string, MutationCommands> getUnfinishedMutationCommands() const override;
 
+    // In non-replicated implementation, we just grab the value of the setting desired_part_metadata_format_version, or else default to most recent version
+    PartMetadataFormatVersion partMetadataFormatVersion() const override;
+
     MergeTreeDeduplicationLog * getDeduplicationLog() { return deduplication_log.get(); }
 
 private:

--- a/src/Storages/StorageReplicatedMergeTree.h
+++ b/src/Storages/StorageReplicatedMergeTree.h
@@ -374,6 +374,9 @@ public:
     using ShutdownDeadline = std::chrono::time_point<std::chrono::system_clock>;
     void waitForUniquePartsToBeFetchedByOtherReplicas(ShutdownDeadline shutdown_deadline);
 
+    // In replicated implementation, we use the lowest value of setting desired_part_metadata_format_version from all replicas
+    PartMetadataFormatVersion partMetadataFormatVersion() const override;
+
 private:
     std::atomic_bool are_restoring_replica {false};
 

--- a/src/Storages/System/StorageSystemTables.cpp
+++ b/src/Storages/System/StorageSystemTables.cpp
@@ -57,6 +57,7 @@ StorageSystemTables::StorageSystemTables(const StorageID & table_id_)
         {"total_marks", std::make_shared<DataTypeNullable>(std::make_shared<DataTypeUInt64>())},
         {"lifetime_rows", std::make_shared<DataTypeNullable>(std::make_shared<DataTypeUInt64>())},
         {"lifetime_bytes", std::make_shared<DataTypeNullable>(std::make_shared<DataTypeUInt64>())},
+        {"part_metadata_format_version", std::make_shared<DataTypeNullable>(std::make_shared<DataTypeUInt32>())},
         {"comment", std::make_shared<DataTypeString>()},
         {"has_own_data", std::make_shared<DataTypeUInt8>()},
         {"loading_dependencies_database", std::make_shared<DataTypeArray>(std::make_shared<DataTypeString>())},
@@ -527,6 +528,14 @@ protected:
                     auto lifetime_bytes = table ? table->lifetimeBytes() : std::nullopt;
                     if (lifetime_bytes)
                         res_columns[res_index++]->insert(*lifetime_bytes);
+                    else
+                        res_columns[res_index++]->insertDefault();
+                }
+
+                if (columns_mask[src_index++])
+                {
+                    if (table_merge_tree)
+                        res_columns[res_index++]->insert(table_merge_tree->partMetadataFormatVersion().toUnderType());
                     else
                         res_columns[res_index++]->insertDefault();
                 }

--- a/tests/integration/test_replicated_part_metadata/configs/metadata_version.xml
+++ b/tests/integration/test_replicated_part_metadata/configs/metadata_version.xml
@@ -1,0 +1,5 @@
+<clickhouse>
+    <merge_tree>
+        <desired_part_metadata_format_version>1</desired_part_metadata_format_version>
+    </merge_tree>
+</clickhouse>

--- a/tests/integration/test_replicated_part_metadata/test.py
+++ b/tests/integration/test_replicated_part_metadata/test.py
@@ -1,0 +1,354 @@
+import pytest
+from helpers.client import QueryRuntimeException
+from helpers.cluster import ClickHouseCluster
+from ast import literal_eval
+import logging
+from contextlib import contextmanager
+import time
+
+cluster = ClickHouseCluster(__file__)
+
+node1 = cluster.add_instance(
+    "node1",
+    with_zookeeper=True,
+    use_keeper=False,
+    main_configs=["configs/metadata_version.xml"],
+    stay_alive=True,
+)
+
+node2 = cluster.add_instance(
+    "node2", with_zookeeper=True, use_keeper=False, stay_alive=True
+)
+
+all_nodes = [node1, node2]
+
+CONFIG = """
+<clickhouse>
+    <merge_tree>
+        <desired_part_metadata_format_version>{}</desired_part_metadata_format_version>
+    </merge_tree>
+</clickhouse>
+"""
+
+
+@pytest.fixture(scope="module", autouse=True)
+def start_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def test_desired_metadata_format_version():
+    # Basic verification that our new setting is being loaded as expected
+    # On node1 we explicitly enabled the feature by setting the value to 1.
+    setting = node1.query(
+        "SELECT value,changed FROM system.merge_tree_settings WHERE name='desired_part_metadata_format_version'"
+    )
+    assert setting.strip() == "1\t1"
+
+    # Node2 has the default value for the setting which should be zero, since it's still experimental
+    setting = node2.query(
+        "SELECT value,changed FROM system.merge_tree_settings WHERE name='desired_part_metadata_format_version'"
+    )
+    assert setting.strip() == "0\t0"
+
+
+def test_plain_merge_tree():
+    # Verify that for a non-replicated mergetree table, the parts have creation time recorded correctly according to the setting.
+    for node in all_nodes:
+        node.query(
+            """
+            CREATE TABLE test_plain_merge_tree(ts DateTime, id UInt32)
+            ENGINE=MergeTree
+            PARTITION BY toYYYYMMDD(ts)
+            ORDER BY ts
+            """
+        )
+        node.query("INSERT INTO test_plain_merge_tree VALUES (now(), 0)")
+
+    # node1 enables our new metadata, so we expect parts to have creation time populated
+    res = node1.query(
+        "SELECT creation_time BETWEEN now()-1 AND now(), metadata_format_version FROM system.parts WHERE active and table='test_plain_merge_tree'"
+    )
+    assert res == "1\t1\n"
+
+    # node2 disables the new metadata, so we should see no creation time
+    res = node2.query(
+        "SELECT creation_time, metadata_format_version FROM system.parts WHERE active and table='test_plain_merge_tree'"
+    )
+    assert res == "\\N\t0\n"
+
+    # On node1
+    # If we run some no-op mutation, the modification time will change but the creation time will stay the same
+    # Start by getting original creation time:
+    original_create_time = node1.query(
+        "SELECT creation_time FROM system.parts WHERE active and table='test_plain_merge_tree'"
+    )
+    time.sleep(3)
+    node1.query(
+        "ALTER TABLE test_plain_merge_tree UPDATE id=id+1 WHERE false SETTINGS mutations_sync=2"
+    )
+    res = node1.query(
+        "SELECT modification_time-2 > creation_time FROM system.parts WHERE active and table='test_plain_merge_tree'"
+    )
+    assert res == "1\n"
+    # Also verify that the create time is identical, since the part hasn't been changed other than the name
+    altered_create_time = node1.query(
+        "SELECT creation_time FROM system.parts WHERE active and table='test_plain_merge_tree'"
+    )
+    assert original_create_time == altered_create_time
+
+
+def test_replicated_part_metadata():
+    # Now we will test that replicated merge trees create the new metadata as designed
+    for i, node in enumerate(all_nodes):
+        node.query(
+            f"""
+            CREATE TABLE test_replicated_part_metadata(ts DateTime, id UInt32, dummy UInt32)
+            ENGINE = ReplicatedMergeTree('/clickhouse/tables/test_replicated_part_metadata', '{i+1}')
+            PARTITION BY toYYYYMMDD(ts) ORDER BY ts
+            """
+        )
+        # to avoid any extra merging happening until we want it:
+        node.query("SYSTEM STOP MERGES")
+
+    zk = cluster.get_kazoo_client("zoo1")
+
+    # verify that the setting only is written to zookeeper if it has a value greater than zero
+    # i.e. the new feature is enabled
+    res, _ = zk.get("/clickhouse/tables/test_replicated_part_metadata/replicas/1/host")
+    assert b"\ndesired_part_metadata_format_version: 1\n" in res
+    # node2 has the setting at zero, so it's address info shouldn't include this line:
+    res, _ = zk.get("/clickhouse/tables/test_replicated_part_metadata/replicas/2/host")
+    assert b"\ndesired_part_metadata_format_version:" not in res
+
+    # We can assert that both nodes observe the same desired version for the table:
+    for node in all_nodes:
+        assert "0\n" == node.query(
+            "SELECT part_metadata_format_version FROM system.tables where name='test_replicated_part_metadata'"
+        )
+
+    # Insert some data so we can see part is created without new metadata
+    node1.query(
+        "INSERT INTO test_replicated_part_metadata SETTINGS insert_quorum='auto' VALUES (now()-2, 0, 123) (now()-1, 1, 234)"
+    )
+    for node in all_nodes:
+        assert "1\t0\n" == node.query(
+            "SELECT isNull(creation_time), metadata_format_version FROM system.parts WHERE active and table='test_replicated_part_metadata'"
+        )
+
+    # Let's bump node2 to desire the newer node format version
+    node2.replace_config(
+        "/etc/clickhouse-server/config.d/metadata_version.xml", CONFIG.format(1)
+    )
+    node2.restart_clickhouse()
+
+    # Now both nodes agree to use the new metadata format version, newly written part should use it:
+    node1.query(
+        "INSERT INTO test_replicated_part_metadata VALUES (now()-2, 0, 345) (now()-1, 1, 456)"
+    )
+
+    # We now expect both nodes to agree about the setting, and about desired version for new parts
+    # We can assert that both nodes observe the same desired version for the table:
+    for i, node in enumerate(all_nodes):
+        assert "1\t1\n" == node.query(
+            "SELECT value,changed FROM system.merge_tree_settings WHERE name='desired_part_metadata_format_version'"
+        )
+        assert "1\n" == node.query(
+            "SELECT part_metadata_format_version FROM system.tables where name='test_replicated_part_metadata'"
+        )
+        res, _ = zk.get(
+            f"/clickhouse/tables/test_replicated_part_metadata/replicas/{i+1}/host"
+        )
+        assert b"\ndesired_part_metadata_format_version: 1\n" in res
+        # Old part should still not have creation time, new part should have creation time
+        assert "1\t0\n0\t1\n" == node.query(
+            "SELECT isNull(creation_time), metadata_format_version FROM system.parts WHERE active and table='test_replicated_part_metadata' ORDER BY modification_time"
+        )
+        node.query("SYSTEM START MERGES")
+
+    # Verify that if we optimize, both parts combine into a single part with the new metadata
+    node1.query("OPTIMIZE TABLE test_replicated_part_metadata FINAL")
+    for i, node in enumerate(all_nodes):
+        assert "0\t1\n" == node.query(
+            "SELECT isNull(creation_time), metadata_format_version FROM system.parts WHERE active and table='test_replicated_part_metadata'"
+        )
+
+    # If we run some no-op mutation, the modification time will change but the creation time will stay the same
+    original_create_time = node1.query(
+        "SELECT creation_time FROM system.parts WHERE active and table='test_replicated_part_metadata'"
+    )
+    time.sleep(2)
+    node1.query(
+        "ALTER TABLE test_replicated_part_metadata UPDATE id=id+1 WHERE false SETTINGS mutations_sync=2"
+    )
+    for i, node in enumerate(all_nodes):
+        assert original_create_time == node.query(
+            "SELECT creation_time FROM system.parts WHERE active and table='test_replicated_part_metadata'"
+        )
+        node.query("SYSTEM STOP MERGES")
+
+    # Let's bump node2 to an invalid version and verify it fails to start
+    node2.replace_config(
+        "/etc/clickhouse-server/config.d/metadata_version.xml", CONFIG.format(10)
+    )
+    node2.stop_clickhouse()
+    with pytest.raises(Exception):
+        node2.start_clickhouse(retry_start=False)
+    assert node2.contains_in_log(
+        "DB::Exception: desired_part_metadata_format_version is set to an unknown value"
+    )
+
+    # We will reset node2 to disable the feature again
+    # So we can assert the parts are all still readable even though they have a newer format version than the configured setting
+    node2.replace_config(
+        "/etc/clickhouse-server/config.d/metadata_version.xml", CONFIG.format(0)
+    )
+    node2.start_clickhouse()
+
+    # verify that the setting is updated:
+    setting = node2.query(
+        "SELECT value,changed FROM system.merge_tree_settings WHERE name='desired_part_metadata_format_version'"
+    )
+    assert setting.strip() == "0\t1"
+    res, _ = zk.get("/clickhouse/tables/test_replicated_part_metadata/replicas/2/host")
+    assert b"\ndesired_part_metadata_format_version:" not in res
+
+    # Verify we still see creation time and metadata format version from existing part, even though we disabled the setting
+    assert "0\t1\n" == node2.query(
+        "SELECT isNull(creation_time), metadata_format_version FROM system.parts WHERE active and table='test_replicated_part_metadata'"
+    )
+
+    # If we optimize the table in this state, we should end up with a part having old metadata version, since this is the lowest common denom
+    node1.query("SYSTEM START MERGES")
+    node2.query("SYSTEM START MERGES")
+    node1.query("OPTIMIZE TABLE test_replicated_part_metadata FINAL")
+    assert "1\t0\n" == node1.query(
+        "SELECT isNull(creation_time), metadata_format_version FROM system.parts WHERE active and table='test_replicated_part_metadata' ORDER BY modification_time"
+    )
+    assert "1\t0\n" == node2.query(
+        "SELECT isNull(creation_time), metadata_format_version FROM system.parts WHERE active and table='test_replicated_part_metadata' ORDER BY modification_time"
+    )
+
+    # return node2 to original config before other tests could run
+    node2.exec_in_container(
+        ["rm", "/etc/clickhouse-server/config.d/metadata_version.xml"]
+    )
+    node2.restart_clickhouse()
+    setting = node2.query(
+        "SELECT value,changed FROM system.merge_tree_settings WHERE name='desired_part_metadata_format_version'"
+    )
+    assert setting.strip() == "0\t0"
+
+
+# I want to verify that a lightweight delete will never result in creation time changing
+# So if a part exists with lightweight deletes, it's guaranteed the creation time matches that of original part
+def test_delete_inplace():
+    node1.query(
+        f"""
+            CREATE TABLE test_delete_inplace(id UInt32, dummy UInt32)
+            ENGINE = ReplicatedMergeTree('/clickhouse/tables/test_delete_inplace', '1')
+            ORDER BY id
+            """
+    )
+    node1.query(
+        "INSERT INTO test_delete_inplace SELECT number, number FROM numbers(20)"
+    )
+
+    assert "Compact\t0\t0\n" == node1.query(
+        "SELECT part_type, level, data_version FROM system.parts where active and table='test_delete_inplace'"
+    )
+    ctime = node1.query(
+        "SELECT creation_time FROM system.parts where active and table='test_delete_inplace'"
+    )
+
+    # Trigger a mutation via lightweight delete
+    time.sleep(1)
+    node1.query(
+        "DELETE FROM test_delete_inplace WHERE dummy%2 == 0 SETTINGS mutations_sync=2"
+    )
+
+    # We expect that both the data version increments while level stays the same, indicating that creation time hasn't changed
+    assert "Compact\t0\t1\t1\n" == node1.query(
+        "SELECT part_type, level, data_version, has_lightweight_delete FROM system.parts where active and table='test_delete_inplace'"
+    )
+    assert ctime == node1.query(
+        "SELECT creation_time FROM system.parts where active and table='test_delete_inplace'"
+    )
+
+    # Verify with another "normal" mutation too
+    time.sleep(1)
+    node1.query(
+        "ALTER TABLE test_delete_inplace UPDATE dummy = dummy + 1 WHERE dummy%3 == 0 SETTINGS mutations_sync=2"
+    )
+
+    # Same expectation as before, data version increase, level & ctime don't change
+    # Also verify the has_lightweight_delete didn't change
+    assert "Compact\t0\t2\t1\n" == node1.query(
+        "SELECT part_type, level, data_version, has_lightweight_delete FROM system.parts where active and table='test_delete_inplace'"
+    )
+    assert ctime == node1.query(
+        "SELECT creation_time FROM system.parts where active and table='test_delete_inplace'"
+    )
+
+
+# I also want to verify that the setting `min_age_to_force_merge_seconds` will respect my creation time
+# It should automatically schedule merging of parts regardless of other criteria, based on the age.
+# I want to ensure that this continues to occur even if the modification time is increasing in the meantime
+def test_merge_old_parts():
+    # Now we will test that replicated merge trees create the new metadata as designed
+    for i, node in enumerate(all_nodes):
+        node.replace_config(
+            "/etc/clickhouse-server/config.d/metadata_version.xml", CONFIG.format(1)
+        )
+        node.restart_clickhouse()
+        node.query(
+            f"""
+            CREATE TABLE test_merge_old_parts(ts DateTime, id UInt32, dummy UInt32)
+            ENGINE = ReplicatedMergeTree('/clickhouse/tables/test_merge_old_parts', '{i+1}')
+            PARTITION BY toYYYYMMDD(ts) ORDER BY ts SETTINGS min_age_to_force_merge_seconds=4, merge_selecting_sleep_ms=250, min_age_to_force_merge_on_partition_only=true;
+            """
+        )
+        assert "1\n" == node.query(
+            "SELECT part_metadata_format_version FROM system.tables where name='test_merge_old_parts'"
+        )
+        node.query("SYSTEM STOP MERGES")
+
+    node1.query(
+        "INSERT INTO test_merge_old_parts VALUES (now()-2, 0, 345) (now()-1, 1, 456)"
+    )
+    assert "1\t0\t1\n" == node1.query(
+        "SELECT not isNull(creation_time), level, metadata_format_version FROM system.parts WHERE active and table='test_merge_old_parts'"
+    )
+
+    for node in all_nodes:
+        node.query("SYSTEM START MERGES")
+
+    ctime = node1.query(
+        "SELECT creation_time FROM system.parts WHERE active and table='test_merge_old_parts'"
+    ).strip()
+
+    # Continuously "update" the part with no-op mutations
+    # The part isn't changed, meaning no merging logic will run, so creation time stays the same
+    # But from the perspective of clickhouse, the data version increments, meaning it is still a "new" part in that sense
+    for i in range(5):
+        node1.query(
+            "ALTER TABLE test_merge_old_parts UPDATE id=id+1 WHERE false SETTINGS mutations_sync=2"
+        )
+        time.sleep(1)
+
+    assert "1\t1\t5\t1\n" == node1.query(
+        f"SELECT creation_time >= addSeconds(toDateTime('{ctime}'), 4), level, data_version, metadata_format_version FROM system.parts WHERE active and table='test_merge_old_parts'"
+    )
+
+    # return node2 to original config before other tests could run
+    node2.exec_in_container(
+        ["rm", "/etc/clickhouse-server/config.d/metadata_version.xml"]
+    )
+    node2.restart_clickhouse()
+    setting = node2.query(
+        "SELECT value,changed FROM system.merge_tree_settings WHERE name='desired_part_metadata_format_version'"
+    )
+    assert setting.strip() == "0\t0"

--- a/tests/queries/0_stateless/02117_show_create_table_system.reference
+++ b/tests/queries/0_stateless/02117_show_create_table_system.reference
@@ -466,6 +466,7 @@ CREATE TABLE system.parts
     `secondary_indices_compressed_bytes` UInt64,
     `secondary_indices_uncompressed_bytes` UInt64,
     `secondary_indices_marks_bytes` UInt64,
+    `creation_time` Nullable(DateTime),
     `modification_time` DateTime,
     `remove_time` DateTime,
     `refcount` UInt32,
@@ -514,6 +515,7 @@ CREATE TABLE system.parts
     `has_lightweight_delete` UInt8,
     `last_removal_attempt_time` DateTime,
     `removal_state` String,
+    `metadata_format_version` UInt32,
     `bytes` UInt64 ALIAS bytes_on_disk,
     `marks_size` UInt64 ALIAS marks_bytes,
     `part_name` String ALIAS name
@@ -1091,6 +1093,7 @@ CREATE TABLE system.tables
     `total_marks` Nullable(UInt64),
     `lifetime_rows` Nullable(UInt64),
     `lifetime_bytes` Nullable(UInt64),
+    `part_metadata_format_version` Nullable(UInt32),
     `comment` String,
     `has_own_data` UInt8,
     `loading_dependencies_database` Array(String),


### PR DESCRIPTION
~~Note that this PR is WIP. I've opened it already to get some feedback on things I'm not yet sure of in my implementation.~~ I think this can be reviewed now

- [X] ~~I need to improve the setting reloading. I want it to be that changing the setting is immediately seen by the clickhouse process (and sibling replicas) without restarting the process.~~ I decided process restart is fine to pick up the change actually
- [X] ~~I'm not sure if the setting should be a "server setting". In my head I was thinking of making it a mergetree setting, as it seems kind of specific to that, but I see no reload path for it~~ I just made it a regular setting, again, process restart will pick it up
- [X] ~~I'm aware that many tests will fail currently, as there will be changes due to the new part format~~ I think that tests should be passing now
- [X] ~~I still need to document the change~~ I've written docs which I think cover the change well
- [X] ~~Consider if projection parts need special treatment at all (I think no?)~~ Pretty sure projection parts ought to have this file too. Not necessary in this iteration but in future, things like row counts, part structure might be included, and those can be different for projection part from parent part. So they need the file.
- [X] ~~The change needs more tests to cover:~~
  - [X] ~~Config reloading behaves how we want~~ it does seem to
  - [X] ~~creation time is recorded correctly, and respected by settings like `min_age_to_force_merge_seconds`. Test mutations don't affect the creation time~~ verified
  - [X] ~~Verify that when downgrading the new setting, parts which already were written with metadata can be read~~ Our tests roll forward and back several times, checking the part metadata.

---

This should begin the process of potentially unifying the part metadata files [1]. This change itself does not unify any of the metadata, but rather it just creates a foundation on which that could be done.

I use the new file to track a new metadata item -- the creation time of the part. Creation time effectively records the time at which the merging process created this part, that is to say, mutating a part should not affect it's creation time (unless the mutation resulted in a complete rewrite of the part, such that merging logic was also applied).

The new metadata contains a setting which can be used to enable graceful upgrade. The new metadata would not get written until all replicas are using the same version. This should avoid the "checksum mismatch" errors which often crop up when part formats can change in newer versions. It also means that if for some reason, the operator wants to opt-out of the new metadata, they can easily configure clickhouse to not use it.

We also record the metadata format version, in `system.tables` and `system.parts`. In `system.parts` we record also the creation time, leaving it as `null` in the case of parts written without the new metadata.

I envision that in future, essentially all the metadata files could be ported to exist within this JSON. I've done a cursory glance over things like the columns files, counts etc, and see no reason why this approach should not work. With the versioning in place, those changes should also be quite graceful.

Finally, there has been some discussion upstream that the metadata ought to be held in shared storage rather than on disk. This use-case does not interest me particularly, however my approach should be compatible with a change to that effect in future -- I believe that a new implementation of `IPartMetadataManager` could be written which reads `metadata.json` from Keeper, or whichever shared storage is preferred.

### Changelog category (leave one):
- New Feature

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

A new part meta data file called `metadata.json` is added to newly written parts.
This behaviour can be controlled using the setting `desired_part_metadata_format_version`.

### Documentation entry for user-facing changes

- [X] Documentation is written (mandatory for new features)

### Related issues
 - https://github.com/ClickHouse/ClickHouse/issues/46813
 - https://github.com/ClickHouse/ClickHouse/issues/53448

