### PR TITLE
Print more information about one logical error in MergeTreeDataWriter

### DIFF
--- a/src/Processors/Merges/Algorithms/AggregatingSortedAlgorithm.h
+++ b/src/Processors/Merges/Algorithms/AggregatingSortedAlgorithm.h
@@ -24,6 +24,7 @@ public:
         size_t max_block_size_rows_,
         size_t max_block_size_bytes_);
 
+    const char * getName() const override { return "AggregatingSortedAlgorithm"; }
     void initialize(Inputs inputs) override;
     void consume(Input & input, size_t source_num) override;
     Status merge() override;

--- a/src/Processors/Merges/Algorithms/CollapsingSortedAlgorithm.h
+++ b/src/Processors/Merges/Algorithms/CollapsingSortedAlgorithm.h
@@ -38,6 +38,7 @@ public:
         WriteBuffer * out_row_sources_buf_ = nullptr,
         bool use_average_block_sizes = false);
 
+    const char * getName() const override { return "CollapsingSortedAlgorithm"; }
     Status merge() override;
 
 private:

--- a/src/Processors/Merges/Algorithms/FinishAggregatingInOrderAlgorithm.h
+++ b/src/Processors/Merges/Algorithms/FinishAggregatingInOrderAlgorithm.h
@@ -45,6 +45,7 @@ public:
         size_t max_block_size_rows_,
         size_t max_block_size_bytes_);
 
+    const char * getName() const override { return "FinishAggregatingInOrderAlgorithm"; }
     void initialize(Inputs inputs) override;
     void consume(Input & input, size_t source_num) override;
     Status merge() override;

--- a/src/Processors/Merges/Algorithms/GraphiteRollupSortedAlgorithm.h
+++ b/src/Processors/Merges/Algorithms/GraphiteRollupSortedAlgorithm.h
@@ -30,6 +30,7 @@ public:
         Graphite::Params params_,
         time_t time_of_merge_);
 
+    const char * getName() const override { return "GraphiteRollupSortedAlgorithm"; }
     Status merge() override;
 
     struct ColumnsDefinition

--- a/src/Processors/Merges/Algorithms/IMergingAlgorithm.h
+++ b/src/Processors/Merges/Algorithms/IMergingAlgorithm.h
@@ -47,6 +47,7 @@ public:
 
     using Inputs = std::vector<Input>;
 
+    virtual const char * getName() const = 0;
     virtual void initialize(Inputs inputs) = 0;
     virtual void consume(Input & input, size_t source_num) = 0;
     virtual Status merge() = 0;

--- a/src/Processors/Merges/Algorithms/MergingSortedAlgorithm.h
+++ b/src/Processors/Merges/Algorithms/MergingSortedAlgorithm.h
@@ -26,6 +26,7 @@ public:
 
     void addInput();
 
+    const char * getName() const override { return "MergingSortedAlgorithm"; }
     void initialize(Inputs inputs) override;
     void consume(Input & input, size_t source_num) override;
     Status merge() override;

--- a/src/Processors/Merges/Algorithms/ReplacingSortedAlgorithm.h
+++ b/src/Processors/Merges/Algorithms/ReplacingSortedAlgorithm.h
@@ -30,6 +30,7 @@ public:
         bool cleanup = false,
         size_t * cleanedup_rows_count = nullptr);
 
+    const char * getName() const override { return "ReplacingSortedAlgorithm"; }
     Status merge() override;
 
 private:

--- a/src/Processors/Merges/Algorithms/SummingSortedAlgorithm.h
+++ b/src/Processors/Merges/Algorithms/SummingSortedAlgorithm.h
@@ -25,6 +25,7 @@ public:
         size_t max_block_size_rows,
         size_t max_block_size_bytes);
 
+    const char * getName() const override { return "SummingSortedAlgorithm"; }
     void initialize(Inputs inputs) override;
     void consume(Input & input, size_t source_num) override;
     Status merge() override;

--- a/src/Processors/Merges/Algorithms/VersionedCollapsingAlgorithm.h
+++ b/src/Processors/Merges/Algorithms/VersionedCollapsingAlgorithm.h
@@ -25,6 +25,7 @@ public:
         WriteBuffer * out_row_sources_buf_ = nullptr,
         bool use_average_block_sizes = false);
 
+    const char * getName() const override { return "VersionedCollapsingAlgorithm"; }
     Status merge() override;
 
 private:

--- a/src/Processors/Transforms/ColumnGathererTransform.h
+++ b/src/Processors/Transforms/ColumnGathererTransform.h
@@ -59,6 +59,7 @@ class ColumnGathererStream final : public IMergingAlgorithm
 public:
     ColumnGathererStream(size_t num_inputs, ReadBuffer & row_sources_buf_, size_t block_preferred_size_ = DEFAULT_BLOCK_SIZE);
 
+    const char * getName() const override { return "ColumnGathererStream"; }
     void initialize(Inputs inputs) override;
     void consume(Input & input, size_t source_num) override;
     Status merge() override;

--- a/src/Processors/Transforms/MergeJoinTransform.h
+++ b/src/Processors/Transforms/MergeJoinTransform.h
@@ -229,6 +229,7 @@ class MergeJoinAlgorithm final : public IMergingAlgorithm
 public:
     explicit MergeJoinAlgorithm(JoinPtr table_join, const Blocks & input_headers, size_t max_block_size_);
 
+    const char * getName() const override { return "MergeJoinAlgorithm"; }
     virtual void initialize(Inputs inputs) override;
     virtual void consume(Input & input, size_t source_num) override;
     virtual Status merge() override;

--- a/src/Storages/MergeTree/MergeTreeDataWriter.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataWriter.cpp
@@ -365,7 +365,7 @@ Block MergeTreeDataWriter::mergeBlock(
 
     /// Check that after first merge merging_algorithm is waiting for data from input 0.
     if (status.required_source != 0)
-        throw Exception(ErrorCodes::LOGICAL_ERROR, "Logical error: required source after the first merge is not 0.");
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Logical error: required source after the first merge is not 0. Chunk rows: {}, is_finished: {}, required_source: {}, algorithm: {}", status.chunk.getNumRows(), status.is_finished, status.required_source, merging_algorithm->getName());
 
     status = merging_algorithm->merge();
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

We saw this error a few times:
```
Message: Code: 49. DB::Exception: Logical error: required source after the first merge is not 0.: While executing WaitForAsyncInsert. (LOGICAL_ERROR), Stack trace (when copying this message, always include the lines below):

0. DB::Exception::Exception(DB::Exception::MessageMasked&&, int, bool) @ 0x000000000eaddc37 in /usr/bin/clickhouse
1. ? @ 0x000000000a415c00 in /usr/bin/clickhouse
2. DB::MergeTreeDataWriter::mergeBlock(DB::Block const&, DB::SortDescription, std::vector<String, std::allocator<String>
```

This PR just adds more information to the exception message to make it easier to investigate next time it happens.