### PR TITLE
Set exception for promise in `CreatingSetsTransform` in more cases

### DIFF
--- a/src/Processors/Transforms/CreatingSetsTransform.cpp
+++ b/src/Processors/Transforms/CreatingSetsTransform.cpp
@@ -17,9 +17,25 @@ namespace ErrorCodes
 {
     extern const int LOGICAL_ERROR;
     extern const int SET_SIZE_LIMIT_EXCEEDED;
+    extern const int UNKNOWN_EXCEPTION;
 }
 
-CreatingSetsTransform::~CreatingSetsTransform() = default;
+CreatingSetsTransform::~CreatingSetsTransform()
+{
+    if (promise_to_build)
+    {
+        /// set_exception can also throw
+        try
+        {
+            promise_to_build->set_exception(std::make_exception_ptr(
+                Exception(ErrorCodes::UNKNOWN_EXCEPTION, "Failed to build set, most likely pipeline executor was stopped")));
+        }
+        catch (...)
+        {
+            tryLogCurrentException(log, "Failed to set_exception for promise");
+        }
+    }
+}
 
 CreatingSetsTransform::CreatingSetsTransform(
     Block in_header_,
@@ -86,7 +102,7 @@ void CreatingSetsTransform::startSubquery()
             }
             else
             {
-                LOG_TRACE(log, "Waiting for set to be build by another thread, key: {}", set_and_key->key);
+                LOG_TRACE(log, "Waiting for set to be built by another thread, key: {}", set_and_key->key);
                 SharedSet set_built_by_another_thread = std::move(std::get<1>(from_cache));
                 const SetPtr & ready_set = set_built_by_another_thread.get();
                 if (!ready_set)
@@ -188,7 +204,10 @@ Chunk CreatingSetsTransform::generate()
     {
         set_and_key->set->finishInsert();
         if (promise_to_build)
+        {
             promise_to_build->set_value(set_and_key->set);
+            promise_to_build.reset();
+        }
     }
 
     if (table_out.initialized())


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

https://s3.amazonaws.com/clickhouse-test-reports/0/53158fa789fb49188c825e960e97908f7c8e2140/fuzzer_astfuzzerubsan/report.html

Exception can happen anywhere while pipeline is being executed. In destructor if promise was not set a `logical_error` is thrown.

Prev PR for ref https://github.com/ClickHouse/ClickHouse/pull/54920

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
