### PR TITLE
Optimize roaring bitmaps in inverted index

### DIFF
--- a/src/Storages/MergeTree/GinIndexStore.cpp
+++ b/src/Storages/MergeTree/GinIndexStore.cpp
@@ -71,7 +71,7 @@ void GinIndexPostingsBuilder::add(UInt32 row_id)
     }
 }
 
-UInt64 GinIndexPostingsBuilder::serialize(WriteBuffer & buffer) const
+UInt64 GinIndexPostingsBuilder::serialize(WriteBuffer & buffer)
 {
     UInt64 written_bytes = 0;
     buffer.write(rowid_lst_length);
@@ -79,6 +79,7 @@ UInt64 GinIndexPostingsBuilder::serialize(WriteBuffer & buffer) const
 
     if (useRoaring())
     {
+        rowid_bitmap.runOptimize();
         auto size = rowid_bitmap.getSizeInBytes();
 
         writeVarUInt(size, buffer);

--- a/src/Storages/MergeTree/GinIndexStore.h
+++ b/src/Storages/MergeTree/GinIndexStore.h
@@ -52,7 +52,7 @@ public:
     void add(UInt32 row_id);
 
     /// Serialize the content of builder to given WriteBuffer, returns the bytes of serialized data
-    UInt64 serialize(WriteBuffer & buffer) const;
+    UInt64 serialize(WriteBuffer & buffer);
 
     /// Deserialize the postings list data from given ReadBuffer, return a pointer to the GinIndexPostingsList created by deserialization
     static GinIndexPostingsListPtr deserialize(ReadBuffer & buffer);


### PR DESCRIPTION
This PR is to optimizes the representation (internal container types) of roaring bitmaps used by posting lists of inverted indexes before writing them into disks. This can significantly reduce the size of the index for repetitive data.

The fix was proposed In #38667 by @juppylm.

Before the fix,  our internal test database which contains server logs  has one bin file with the size 264M and generates 472M .gin_post posting list file. After the fix, the same bin file only generates 94M posting list file which is 5 times smaller. Note that for those database which contains less repetitive data, the size reduction is not very significant. For example, the hacker news database only reduces about 2-5% of posting list file sizes.

The performance of index building and queries are not affected by the fix, however some slightly speed-ups can be observed in general.

### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Posting lists in inverted indexes are now optimized to use the smallest possible representation for internal bitmaps. Depending on the repetitiveness of the data, this may significantly reduce the space consumption of inverted indexes.