### PR TITLE
Use `source` instead of `bash` for pre-build script

### DIFF
--- a/docker/packager/binary/build.sh
+++ b/docker/packager/binary/build.sh
@@ -63,7 +63,8 @@ then
   # Execute all commands
   for file in /build/packages/pre-build/*.sh ;
   do
-    # The script may want to modify environment variables. Why not to allow it to do so? 
+    # The script may want to modify environment variables. Why not to allow it to do so?
+    # shellcheck disable=SC1090
     source "$file"
   done
 else

--- a/docker/packager/binary/build.sh
+++ b/docker/packager/binary/build.sh
@@ -63,7 +63,8 @@ then
   # Execute all commands
   for file in /build/packages/pre-build/*.sh ;
   do
-    bash "$file"
+    # The script may want to modify environment variables. Why not to allow it to do so? 
+    source "$file"
   done
 else
   echo "There are no subcommands to execute :)"


### PR DESCRIPTION
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
The script may want to modify env variables. 