### PR TITLE
I don't understand why backup log is not enabled by default

### DIFF
--- a/programs/server/config.xml
+++ b/programs/server/config.xml
@@ -1217,14 +1217,13 @@
     </asynchronous_insert_log>
 
     <!-- Backup/restore log.
-         Uncomment to write backup/restore log records into a system table.
+    -->
     <backup_log>
         <database>system</database>
         <table>backup_log</table>
         <partition_by>toYYYYMM(event_date)</partition_by>
-        <flush_interval_milliseconds>0</flush_interval_milliseconds>
+        <flush_interval_milliseconds>7500</flush_interval_milliseconds>
     </backup_log>
-    -->
 
     <!-- <top_level_domains_path>/var/lib/clickhouse/top_level_domains/</top_level_domains_path> -->
     <!-- Custom TLD lists.


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Also, zero flush interval will lead to a busy loop - this looks wrong.