### PR TITLE
Use the tuple element names as column names in `untuple()`

### DIFF
--- a/docs/en/sql-reference/data-types/tuple.md
+++ b/docs/en/sql-reference/data-types/tuple.md
@@ -62,7 +62,7 @@ SELECT (1, 'a') AS x, (today(), rand(), 'someString') AS y, ('a') AS not_a_tuple
 
 ## Data Type Detection
 
-When creating tuples on the fly, ClickHouse interfers the type of the tuple's arguments as the smallest types which can hold the provided argument value. If the value is [NULL](../../sql-reference/syntax.md#null-literal), the interfered type is [Nullable](../../sql-reference/data-types/nullable.md).
+When creating tuples on the fly, ClickHouse interferes the type of the tuples arguments as the smallest types which can hold the provided argument value. If the value is [NULL](../../sql-reference/syntax.md#null-literal), the interfered type is [Nullable](../../sql-reference/data-types/nullable.md).
 
 Example of automatic data type detection:
 
@@ -104,7 +104,7 @@ Result:
 
 ## Comparison operations with Tuple
 
-Two tuples are compared by sequentially comparing their elements from the left to the right. If first tuple's element is greater (smaller) than the second tuple's corresponding element, then the first tuple is greater (smaller) than the second, otherwise (both elements are equal), the next element is compared.
+Two tuples are compared by sequentially comparing their elements from the left to the right. If first tuples element is greater (smaller) than the second tuples corresponding element, then the first tuple is greater (smaller) than the second, otherwise (both elements are equal), the next element is compared.
 
 Example:
 

--- a/docs/en/sql-reference/data-types/tuple.md
+++ b/docs/en/sql-reference/data-types/tuple.md
@@ -12,7 +12,7 @@ Tuples are used for temporary column grouping. Columns can be grouped when an IN
 
 Tuples can be the result of a query. In this case, for text formats other than JSON, values are comma-separated in brackets. In JSON formats, tuples are output as arrays (in square brackets).
 
-## Creating a Tuple
+## Creating Tuples
 
 You can use a function to create a tuple:
 
@@ -23,7 +23,7 @@ tuple(T1, T2, ...)
 Example of creating a tuple:
 
 ``` sql
-SELECT tuple(1,'a') AS x, toTypeName(x)
+SELECT tuple(1, 'a') AS x, toTypeName(x)
 ```
 
 ``` text
@@ -32,7 +32,7 @@ SELECT tuple(1,'a') AS x, toTypeName(x)
 └─────────┴───────────────────────────┘
 ```
 
-Tuple can contain a single element
+A Tuple can contain a single element
 
 Example:
 
@@ -46,12 +46,12 @@ SELECT tuple('a') AS x;
 └───────┘
 ```
 
-There is a syntax sugar using parentheses `( tuple_element1, tuple_element2 )` to create a tuple of several elements without tuple function.
+Syntax `(tuple_element1, tuple_element2)` may be used to create a tuple of several elements without calling the `tuple()` function.
 
 Example:
 
 ``` sql
-SELECT (1, 'a') AS x, (today(), rand(), 'someString') y, ('a') not_a_tuple;
+SELECT (1, 'a') AS x, (today(), rand(), 'someString') AS y, ('a') AS not_a_tuple;
 ```
 
 ``` text
@@ -60,9 +60,9 @@ SELECT (1, 'a') AS x, (today(), rand(), 'someString') y, ('a') not_a_tuple;
 └─────────┴────────────────────────────────────────┴─────────────┘
 ```
 
-## Working with Data Types
+## Data Type Detection
 
-When creating a tuple on the fly, ClickHouse automatically detects the type of each argument as the minimum of the types which can store the argument value. If the argument is [NULL](../../sql-reference/syntax.md#null-literal), the type of the tuple element is [Nullable](../../sql-reference/data-types/nullable.md).
+When creating tuples on the fly, ClickHouse interfers the type of the tuple's arguments as the smallest types which can hold the provided argument value. If the value is [NULL](../../sql-reference/syntax.md#null-literal), the interfered type is [Nullable](../../sql-reference/data-types/nullable.md).
 
 Example of automatic data type detection:
 
@@ -71,23 +71,21 @@ SELECT tuple(1, NULL) AS x, toTypeName(x)
 ```
 
 ``` text
-┌─x────────┬─toTypeName(tuple(1, NULL))──────┐
-│ (1,NULL) │ Tuple(UInt8, Nullable(Nothing)) │
-└──────────┴─────────────────────────────────┘
+┌─x─────────┬─toTypeName(tuple(1, NULL))──────┐
+│ (1, NULL) │ Tuple(UInt8, Nullable(Nothing)) │
+└───────────┴─────────────────────────────────┘
 ```
 
-## Addressing Tuple Elements
+## Referring to Tuple Elements
 
-It is possible to read elements of named tuples using indexes and names:
+Tuple elements can be referred to by name or by index:
 
 ``` sql
 CREATE TABLE named_tuples (`a` Tuple(s String, i Int64)) ENGINE = Memory;
-
 INSERT INTO named_tuples VALUES (('y', 10)), (('x',-10));
 
-SELECT a.s FROM named_tuples;
-
-SELECT a.2 FROM named_tuples;
+SELECT a.s FROM named_tuples; -- by name
+SELECT a.2 FROM named_tuples; -- by index
 ```
 
 Result:
@@ -106,7 +104,7 @@ Result:
 
 ## Comparison operations with Tuple
 
-The operation of comparing two tuples is performed sequentially element by element from left to right. If the element of the first tuple is greater than the corresponding element of the second tuple, then the first tuple is greater than the second, if the elements are equal, the next element is compared.
+Two tuples are compared by sequentially comparing their elements from the left to the right. If first tuple's element is greater (smaller) than the second tuple's corresponding element, then the first tuple is greater (smaller) than the second, otherwise (both elements are equal), the next element is compared.
 
 Example:
 

--- a/docs/en/sql-reference/functions/tuple-functions.md
+++ b/docs/en/sql-reference/functions/tuple-functions.md
@@ -37,6 +37,8 @@ tupleElement(tuple, name, [, default_value])
 
 Performs syntactic substitution of [tuple](../../sql-reference/data-types/tuple.md#tuplet1-t2) elements in the call location.
 
+The names of the result columns are implementation-specific and subject to change. Do not assume specific column names after `untuple`.
+
 **Syntax**
 
 ``` sql
@@ -86,8 +88,6 @@ Result:
 │    77 │ kl    │
 └───────┴───────┘
 ```
-
-Note: the names are implementation specific and are subject to change. You should not assume specific names of the columns after application of the `untuple`.
 
 Example of using an `EXCEPT` expression:
 

--- a/src/Interpreters/ActionsVisitor.cpp
+++ b/src/Interpreters/ActionsVisitor.cpp
@@ -758,8 +758,8 @@ ASTs ActionsMatcher::doUntuple(const ASTFunction * function, ActionsMatcher::Dat
 
     ASTs columns;
     size_t tid = 0;
-	auto untuple_alias = function->tryGetAlias();
-	for (const auto & element_name [[maybe_unused]] : tuple_type->getElementNames())
+    auto untuple_alias = function->tryGetAlias();
+    for (const auto & element_name [[maybe_unused]] : tuple_type->getElementNames())
     {
         auto tuple_ast = function->arguments->children[0];
 

--- a/src/Interpreters/ActionsVisitor.cpp
+++ b/src/Interpreters/ActionsVisitor.cpp
@@ -759,7 +759,7 @@ ASTs ActionsMatcher::doUntuple(const ASTFunction * function, ActionsMatcher::Dat
     ASTs columns;
     size_t tid = 0;
     auto untuple_alias = function->tryGetAlias();
-    for (const auto & element_name [[maybe_unused]] : tuple_type->getElementNames())
+    for (const auto & element_name : tuple_type->getElementNames())
     {
         auto tuple_ast = function->arguments->children[0];
 

--- a/src/Interpreters/ActionsVisitor.cpp
+++ b/src/Interpreters/ActionsVisitor.cpp
@@ -758,8 +758,8 @@ ASTs ActionsMatcher::doUntuple(const ASTFunction * function, ActionsMatcher::Dat
 
     ASTs columns;
     size_t tid = 0;
-    auto func_alias = function->tryGetAlias();
-    for (const auto & name [[maybe_unused]] : tuple_type->getElementNames())
+	auto untuple_alias = function->tryGetAlias();
+	for (const auto & element_name [[maybe_unused]] : tuple_type->getElementNames())
     {
         auto tuple_ast = function->arguments->children[0];
 
@@ -773,8 +773,14 @@ ASTs ActionsMatcher::doUntuple(const ASTFunction * function, ActionsMatcher::Dat
         visit(*literal, literal, data);
 
         auto func = makeASTFunction("tupleElement", tuple_ast, literal);
-        if (!func_alias.empty())
-            func->setAlias(func_alias + "." + toString(tid));
+		if (!untuple_alias.empty())
+		{
+			func->setAlias(untuple_alias + "." + toString(tid));
+		} else if (tuple_type->haveExplicitNames())
+		{
+			func->setAlias(element_name);
+		}
+
         auto function_builder = FunctionFactory::instance().get(func->name, data.getContext());
         data.addFunction(function_builder, {tuple_name_type->name, literal->getColumnName()}, func->getColumnName());
 

--- a/src/Interpreters/ActionsVisitor.cpp
+++ b/src/Interpreters/ActionsVisitor.cpp
@@ -774,12 +774,10 @@ ASTs ActionsMatcher::doUntuple(const ASTFunction * function, ActionsMatcher::Dat
 
         auto func = makeASTFunction("tupleElement", tuple_ast, literal);
 		if (!untuple_alias.empty())
-		{
-			func->setAlias(untuple_alias + "." + toString(tid));
-		} else if (tuple_type->haveExplicitNames())
-		{
-			func->setAlias(element_name);
-		}
+        {
+            auto element_alias = tuple_type->haveExplicitNames() ? element_name : toString(tid);
+            func->setAlias(untuple_alias + "." + element_alias);
+        }
 
         auto function_builder = FunctionFactory::instance().get(func->name, data.getContext());
         data.addFunction(function_builder, {tuple_name_type->name, literal->getColumnName()}, func->getColumnName());

--- a/src/Interpreters/ActionsVisitor.cpp
+++ b/src/Interpreters/ActionsVisitor.cpp
@@ -773,7 +773,7 @@ ASTs ActionsMatcher::doUntuple(const ASTFunction * function, ActionsMatcher::Dat
         visit(*literal, literal, data);
 
         auto func = makeASTFunction("tupleElement", tuple_ast, literal);
-		if (!untuple_alias.empty())
+        if (!untuple_alias.empty())
         {
             auto element_alias = tuple_type->haveExplicitNames() ? element_name : toString(tid);
             func->setAlias(untuple_alias + "." + element_alias);

--- a/tests/queries/0_stateless/02890_untuple_column_names.reference
+++ b/tests/queries/0_stateless/02890_untuple_column_names.reference
@@ -1,27 +1,30 @@
--- { echoOn }
-
--- If the untuple() function has an alias, and the tuple element has an explicit name,
--- we want to use it to generate the resulting column name. Check all permutations of
--- aliases. Also use different tuple types to check that we don't generate different
--- columns with the same name (see #26179).
-
-select untuple(tuple(1)::Tuple(a Int)), untuple(tuple('s')::Tuple(a String)) format TSVWithNames;
+-- tuple element alias
 tupleElement(CAST(tuple(1), \'Tuple(a Int)\'), 1)	tupleElement(CAST(tuple(\'s\'), \'Tuple(a String)\'), 1)
 1	s
-select untuple(tuple(1)::Tuple(a Int)) x, untuple(tuple('s')::Tuple(a String)) y format TSVWithNames;
+tupleElement(CAST(tuple(1), \'Tuple(a Int)\'), \'a\')	tupleElement(CAST(tuple(\'s\'), \'Tuple(a String)\'), \'a\')
+1	s
+-- tuple element alias, untuple() alias
 x.a	y.a
 1	s
-select untuple(tuple(1)::Tuple(Int)) x, untuple(tuple('s')::Tuple(String)) y format TSVWithNames;
+x.a	y.a
+1	s
+-- untuple() alias
 x.1	y.1
 1	s
-select untuple(tuple(1)::Tuple(Int)), untuple(tuple('s')::Tuple(String)) format TSVWithNames;
+x.1	y.1
+1	s
+-- no aliases
 tupleElement(CAST(tuple(1), \'Tuple(Int)\'), 1)	tupleElement(CAST(tuple(\'s\'), \'Tuple(String)\'), 1)
 1	s
+tupleElement(CAST(tuple(1), \'Tuple(Int)\'), \'1\')	tupleElement(CAST(tuple(\'s\'), \'Tuple(String)\'), \'1\')
+1	s
 -- tuple() loses the column names (would be good to fix, see #36773)
-select untuple(tuple(1 as a)) as t format TSVWithNames;
+t.1
+1
 t.1
 1
 -- thankfully JSONExtract() keeps them
-select untuple(JSONExtract('{"key": "value"}', 'Tuple(key String)')) x format TSVWithNames;
+x.key
+value
 x.key
 value

--- a/tests/queries/0_stateless/02890_untuple_column_names.reference
+++ b/tests/queries/0_stateless/02890_untuple_column_names.reference
@@ -1,18 +1,27 @@
 -- { echoOn }
 
+-- If the untuple() function has an alias, and the tuple element has an explicit name,
+-- we want to use it to generate the resulting column name. Check all permutations of
+-- aliases. Also use different tuple types to check that we don't generate different
+-- columns with the same name (see #26179).
+
+select untuple(tuple(1)::Tuple(a Int)), untuple(tuple('s')::Tuple(a String)) format TSVWithNames;
+tupleElement(CAST(tuple(1), \'Tuple(a Int)\'), 1)	tupleElement(CAST(tuple(\'s\'), \'Tuple(a String)\'), 1)
+1	s
+select untuple(tuple(1)::Tuple(a Int)) x, untuple(tuple('s')::Tuple(a String)) y format TSVWithNames;
+x.a	y.a
+1	s
+select untuple(tuple(1)::Tuple(Int)) x, untuple(tuple('s')::Tuple(String)) y format TSVWithNames;
+x.1	y.1
+1	s
+select untuple(tuple(1)::Tuple(Int)), untuple(tuple('s')::Tuple(String)) format TSVWithNames;
+tupleElement(CAST(tuple(1), \'Tuple(Int)\'), 1)	tupleElement(CAST(tuple(\'s\'), \'Tuple(String)\'), 1)
+1	s
 -- tuple() loses the column names (would be good to fix, see #36773)
-select untuple(tuple(1 as a, 2 as b)) format TSVWithNames;
-tupleElement((1, 2), 1)	tupleElement((1, 2), 2)
-1	2
--- explicitly specified tuple element names are used as column names
-select untuple(tuple(1, 2)::Tuple(a Int, b Int)) format TSVWithNames;
-a	b
-1	2
--- indexes are used when untuple() has an alias (backward compatibility)
-select untuple(tuple(1, 2)::Tuple(a Int, b Int)) u format TSVWithNames;
-u.1	u.2
-1	2
--- default names are used when there are no tuple element names and no untuple alias
-select untuple(tuple(1, 2)::Tuple(Int, Int)) format TSVWithNames;
-tupleElement(CAST((1, 2), \'Tuple(Int, Int)\'), 1)	tupleElement(CAST((1, 2), \'Tuple(Int, Int)\'), 2)
-1	2
+select untuple(tuple(1 as a)) as t format TSVWithNames;
+t.1
+1
+-- thankfully JSONExtract() keeps them
+select untuple(JSONExtract('{"key": "value"}', 'Tuple(key String)')) x format TSVWithNames;
+x.key
+value

--- a/tests/queries/0_stateless/02890_untuple_column_names.reference
+++ b/tests/queries/0_stateless/02890_untuple_column_names.reference
@@ -1,0 +1,18 @@
+-- { echoOn }
+
+-- tuple() loses the column names (would be good to fix, see #36773)
+select untuple(tuple(1 as a, 2 as b)) format TSVWithNames;
+tupleElement((1, 2), 1)	tupleElement((1, 2), 2)
+1	2
+-- explicitly specified tuple element names are used as column names
+select untuple(tuple(1, 2)::Tuple(a Int, b Int)) format TSVWithNames;
+a	b
+1	2
+-- indexes are used when untuple() has an alias (backward compatibility)
+select untuple(tuple(1, 2)::Tuple(a Int, b Int)) u format TSVWithNames;
+u.1	u.2
+1	2
+-- default names are used when there are no tuple element names and no untuple alias
+select untuple(tuple(1, 2)::Tuple(Int, Int)) format TSVWithNames;
+tupleElement(CAST((1, 2), \'Tuple(Int, Int)\'), 1)	tupleElement(CAST((1, 2), \'Tuple(Int, Int)\'), 2)
+1	2

--- a/tests/queries/0_stateless/02890_untuple_column_names.sql
+++ b/tests/queries/0_stateless/02890_untuple_column_names.sql
@@ -1,20 +1,28 @@
--- { echoOn }
-
 -- If the untuple() function has an alias, and the tuple element has an explicit name,
 -- we want to use it to generate the resulting column name. Check all permutations of
 -- aliases. Also use different tuple types to check that we don't generate different
 -- columns with the same name (see #26179).
 
-select untuple(tuple(1)::Tuple(a Int)), untuple(tuple('s')::Tuple(a String)) format TSVWithNames;
+SELECT '-- tuple element alias';
+SELECT untuple(tuple(1)::Tuple(a Int)), untuple(tuple('s')::Tuple(a String)) FORMAT TSVWithNames SETTINGS allow_experimental_analyzer = 0;
+SELECT untuple(tuple(1)::Tuple(a Int)), untuple(tuple('s')::Tuple(a String)) FORMAT TSVWithNames SETTINGS allow_experimental_analyzer = 1;
 
-select untuple(tuple(1)::Tuple(a Int)) x, untuple(tuple('s')::Tuple(a String)) y format TSVWithNames;
+SELECT '-- tuple element alias, untuple() alias';
+SELECT untuple(tuple(1)::Tuple(a Int)) x, untuple(tuple('s')::Tuple(a String)) y FORMAT TSVWithNames SETTINGS allow_experimental_analyzer = 0;
+SELECT untuple(tuple(1)::Tuple(a Int)) x, untuple(tuple('s')::Tuple(a String)) y FORMAT TSVWithNames SETTINGS allow_experimental_analyzer = 1;
 
-select untuple(tuple(1)::Tuple(Int)) x, untuple(tuple('s')::Tuple(String)) y format TSVWithNames;
+SELECT '-- untuple() alias';
+SELECT untuple(tuple(1)::Tuple(Int)) x, untuple(tuple('s')::Tuple(String)) y FORMAT TSVWithNames SETTINGS allow_experimental_analyzer = 0;
+SELECT untuple(tuple(1)::Tuple(Int)) x, untuple(tuple('s')::Tuple(String)) y FORMAT TSVWithNames SETTINGS allow_experimental_analyzer = 1;
 
-select untuple(tuple(1)::Tuple(Int)), untuple(tuple('s')::Tuple(String)) format TSVWithNames;
+SELECT '-- no aliases';
+SELECT untuple(tuple(1)::Tuple(Int)), untuple(tuple('s')::Tuple(String)) FORMAT TSVWithNames SETTINGS allow_experimental_analyzer = 0;
+SELECT untuple(tuple(1)::Tuple(Int)), untuple(tuple('s')::Tuple(String)) FORMAT TSVWithNames SETTINGS allow_experimental_analyzer = 1;
 
--- tuple() loses the column names (would be good to fix, see #36773)
-select untuple(tuple(1 as a)) as t format TSVWithNames;
+SELECT '-- tuple() loses the column names (would be good to fix, see #36773)';
+SELECT untuple(tuple(1 as a)) as t FORMAT TSVWithNames SETTINGS allow_experimental_analyzer = 0;
+SELECT untuple(tuple(1 as a)) as t FORMAT TSVWithNames SETTINGS allow_experimental_analyzer = 1;
 
--- thankfully JSONExtract() keeps them
-select untuple(JSONExtract('{"key": "value"}', 'Tuple(key String)')) x format TSVWithNames;
+SELECT '-- thankfully JSONExtract() keeps them';
+SELECT untuple(JSONExtract('{"key": "value"}', 'Tuple(key String)')) x FORMAT TSVWithNames SETTINGS allow_experimental_analyzer = 0;
+SELECT untuple(JSONExtract('{"key": "value"}', 'Tuple(key String)')) x FORMAT TSVWithNames SETTINGS allow_experimental_analyzer = 1;

--- a/tests/queries/0_stateless/02890_untuple_column_names.sql
+++ b/tests/queries/0_stateless/02890_untuple_column_names.sql
@@ -1,13 +1,20 @@
 -- { echoOn }
 
+-- If the untuple() function has an alias, and the tuple element has an explicit name,
+-- we want to use it to generate the resulting column name. Check all permutations of
+-- aliases. Also use different tuple types to check that we don't generate different
+-- columns with the same name (see #26179).
+
+select untuple(tuple(1)::Tuple(a Int)), untuple(tuple('s')::Tuple(a String)) format TSVWithNames;
+
+select untuple(tuple(1)::Tuple(a Int)) x, untuple(tuple('s')::Tuple(a String)) y format TSVWithNames;
+
+select untuple(tuple(1)::Tuple(Int)) x, untuple(tuple('s')::Tuple(String)) y format TSVWithNames;
+
+select untuple(tuple(1)::Tuple(Int)), untuple(tuple('s')::Tuple(String)) format TSVWithNames;
+
 -- tuple() loses the column names (would be good to fix, see #36773)
-select untuple(tuple(1 as a, 2 as b)) format TSVWithNames;
+select untuple(tuple(1 as a)) as t format TSVWithNames;
 
--- explicitly specified tuple element names are used as column names
-select untuple(tuple(1, 2)::Tuple(a Int, b Int)) format TSVWithNames;
-
--- indexes are used when untuple() has an alias (backward compatibility)
-select untuple(tuple(1, 2)::Tuple(a Int, b Int)) u format TSVWithNames;
-
--- default names are used when there are no tuple element names and no untuple alias
-select untuple(tuple(1, 2)::Tuple(Int, Int)) format TSVWithNames;
+-- thankfully JSONExtract() keeps them
+select untuple(JSONExtract('{"key": "value"}', 'Tuple(key String)')) x format TSVWithNames;

--- a/tests/queries/0_stateless/02890_untuple_column_names.sql
+++ b/tests/queries/0_stateless/02890_untuple_column_names.sql
@@ -1,0 +1,13 @@
+-- { echoOn }
+
+-- tuple() loses the column names (would be good to fix, see #36773)
+select untuple(tuple(1 as a, 2 as b)) format TSVWithNames;
+
+-- explicitly specified tuple element names are used as column names
+select untuple(tuple(1, 2)::Tuple(a Int, b Int)) format TSVWithNames;
+
+-- indexes are used when untuple() has an alias (backward compatibility)
+select untuple(tuple(1, 2)::Tuple(a Int, b Int)) u format TSVWithNames;
+
+-- default names are used when there are no tuple element names and no untuple alias
+select untuple(tuple(1, 2)::Tuple(Int, Int)) format TSVWithNames;


### PR DESCRIPTION
Function `untuple()` currently ignores the element names of named tuples and generates ugly result column names:

```sql
:) SELECT untuple(JSONExtract('{"key": "value"}', 'Tuple(key String)'));

┌─tupleElement(JSONExtract('{"key": "value"}', 'Tuple(key String)'), 1)─┐
│ value                                                                 │
└───────────────────────────────────────────────────────────────────────┘
```

Why would anyone want column names like this? And there's effectively no way to change these names when using `untuple()`. Let's respect the user intention and use the explicitly specified tuple element names (new behavior):

```sql
:) SELECT untuple(JSONExtract('{"key": "value"}', 'Tuple(key String)'));

┌─key───┐
│ value │
└───────┘
```

Interestingly, when the `untuple()` function itself has an alias, the result column names are already usable as of now but with an index as the column name instead of the element alias. This behavior is retained by this PR for backward compatibility:

```sql
:) SELECT untuple(JSONExtract('{"key": "value"}', 'Tuple(key String)')) a;

┌─a.1───┐
│ value │
└───────┘
```

When the element names are not specified, also keep the old behavior (ugly name):

```sql
:) SELECT untuple(JSONExtract('{"key": "value"}', 'Tuple(String)'));

┌─tupleElement(JSONExtract('{"key": "value"}', 'Tuple(String)'), 1)─┐
│ value                                                             │
└───────────────────────────────────────────────────────────────────┘
```

### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
When function "untuple()" is now called on a tuple with named elements and itself has an alias (e.g. "select untuple(tuple(1)::Tuple(element_alias Int)) AS untuple_alias"), then the result column name is now generated from the untuple alias and the tuple element alias (in the example: "untuple_alias.element_alias").