### PR TITLE
Bump croaring to 2.0.2

### DIFF
--- a/contrib/croaring-cmake/CMakeLists.txt
+++ b/contrib/croaring-cmake/CMakeLists.txt
@@ -2,23 +2,25 @@ set(LIBRARY_DIR "${ClickHouse_SOURCE_DIR}/contrib/croaring")
 
 set(SRCS
     "${LIBRARY_DIR}/src/array_util.c"
+    "${LIBRARY_DIR}/src/bitset.c"
     "${LIBRARY_DIR}/src/bitset_util.c"
+    "${LIBRARY_DIR}/src/isadetection.c"
+    "${LIBRARY_DIR}/src/memory.c"
+    "${LIBRARY_DIR}/src/roaring.c"
+    "${LIBRARY_DIR}/src/roaring_array.c"
+    "${LIBRARY_DIR}/src/roaring_priority_queue.c"
     "${LIBRARY_DIR}/src/containers/array.c"
     "${LIBRARY_DIR}/src/containers/bitset.c"
     "${LIBRARY_DIR}/src/containers/containers.c"
     "${LIBRARY_DIR}/src/containers/convert.c"
-    "${LIBRARY_DIR}/src/containers/mixed_intersection.c"
-    "${LIBRARY_DIR}/src/containers/mixed_union.c"
-    "${LIBRARY_DIR}/src/containers/mixed_equal.c"
-    "${LIBRARY_DIR}/src/containers/mixed_subset.c"
-    "${LIBRARY_DIR}/src/containers/mixed_negation.c"
-    "${LIBRARY_DIR}/src/containers/mixed_xor.c"
     "${LIBRARY_DIR}/src/containers/mixed_andnot.c"
-    "${LIBRARY_DIR}/src/containers/run.c"
-    "${LIBRARY_DIR}/src/roaring.c"
-    "${LIBRARY_DIR}/src/roaring_priority_queue.c"
-    "${LIBRARY_DIR}/src/roaring_array.c"
-    "${LIBRARY_DIR}/src/memory.c")
+    "${LIBRARY_DIR}/src/containers/mixed_equal.c"
+    "${LIBRARY_DIR}/src/containers/mixed_intersection.c"
+    "${LIBRARY_DIR}/src/containers/mixed_negation.c"
+    "${LIBRARY_DIR}/src/containers/mixed_subset.c"
+    "${LIBRARY_DIR}/src/containers/mixed_union.c"
+    "${LIBRARY_DIR}/src/containers/mixed_xor.c"
+    "${LIBRARY_DIR}/src/containers/run.c")
 
 add_library(_roaring ${SRCS})
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Bump croaring library to v2.0.2