### PR TITLE
Suppress error statistics update for internal exceptions

### DIFF
--- a/src/Common/Exception.cpp
+++ b/src/Common/Exception.cpp
@@ -52,6 +52,8 @@ void abortOnFailedAssertion(const String & description)
 
 bool terminate_on_any_exception = false;
 
+thread_local bool update_error_statistics = true;
+
 /// - Aborts the process if error code is LOGICAL_ERROR.
 /// - Increments error codes statistics.
 void handle_error_code([[maybe_unused]] const std::string & msg, int code, bool remote, const Exception::FramePointers & trace)
@@ -64,6 +66,9 @@ void handle_error_code([[maybe_unused]] const std::string & msg, int code, bool 
         abortOnFailedAssertion(msg);
     }
 #endif
+
+    if (!update_error_statistics) [[unlikely]]
+        return;
 
     ErrorCodes::increment(code, remote, msg, trace);
 }

--- a/src/Common/Exception.h
+++ b/src/Common/Exception.h
@@ -7,6 +7,7 @@
 #include <Poco/Exception.h>
 
 #include <base/defines.h>
+#include <base/scope_guard.h>
 #include <Common/StackTrace.h>
 #include <Common/LoggingFormatStringHelpers.h>
 
@@ -22,6 +23,17 @@ void abortOnFailedAssertion(const String & description);
 
 /// This flag can be set for testing purposes - to check that no exceptions are thrown.
 extern bool terminate_on_any_exception;
+
+/// This flag controls if error statistics should be updated when an exception is thrown. These
+/// statistics are shown for example in system.errors. Defaults to true. If the error is internal,
+/// non-critical, and handled otherwise it is useful to disable the statistics update and not
+/// alarm the user needlessly.
+extern thread_local bool update_error_statistics;
+
+/// Disable the update of error statistics
+#define DO_NOT_UPDATE_ERROR_STATISTICS() \
+    update_error_statistics = false; \
+    SCOPE_EXIT({ update_error_statistics = true; })
 
 
 class Exception : public Poco::Exception

--- a/src/Storages/System/StorageSystemFunctions.cpp
+++ b/src/Storages/System/StorageSystemFunctions.cpp
@@ -141,6 +141,7 @@ void StorageSystemFunctions::fillData(MutableColumns & res_columns, ContextPtr c
         std::optional<UInt64> is_deterministic;
         try
         {
+            DO_NOT_UPDATE_ERROR_STATISTICS();
             is_deterministic = functions_factory.tryGet(function_name, context)->isDeterministic();
         }
         catch (const Exception & e)


### PR DESCRIPTION
PR #55035 led to unnecessary entries in `system.errors`, see https://github.com/ClickHouse/ClickHouse/pull/55035#issuecomment-1738732058. This PR adds a mechanism to suppress the update of error statistics and thereby omits these entries.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
System view `system.functions` contained in some cases unexpected entries with error codes `DICTIONARIES_WAS_NOT_LOADED`, `FUNCTION_NOT_ALLOWED`, `NOT_IMPLEMENTED` and `SUPPORT_IS_DISABLED`. These entries were generated either when querying system view `system.functions` or when connecting to ClickHouse with a client that uses keyword auto-completion, e.g. clickhouse-client. These entries are now suppressed. Existing entries of this kind can be ignored.