### PR TITLE
Improve error message in MergePredicate

### DIFF
--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -8280,14 +8280,27 @@ MovePartsOutcome MergeTreeData::moveParts(const CurrentlyMovingPartsTaggerPtr & 
     return result;
 }
 
-bool MergeTreeData::partsContainSameProjections(const DataPartPtr & left, const DataPartPtr & right)
+bool MergeTreeData::partsContainSameProjections(const DataPartPtr & left, const DataPartPtr & right, String & out_reason)
 {
     if (left->getProjectionParts().size() != right->getProjectionParts().size())
+    {
+        out_reason = fmt::format(
+            "Parts have different number of projections: {} in one part and {} in another",
+            left->getProjectionParts().size(),
+            right->getProjectionParts().size()
+        );
         return false;
+    }
+
     for (const auto & [name, _] : left->getProjectionParts())
     {
         if (!right->hasProjection(name))
+        {
+            out_reason = fmt::format(
+                "Some part doesn't have projection '{}' while another does", name
+            )
             return false;
+        }
     }
     return true;
 }

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -8285,9 +8285,11 @@ bool MergeTreeData::partsContainSameProjections(const DataPartPtr & left, const 
     if (left->getProjectionParts().size() != right->getProjectionParts().size())
     {
         out_reason = fmt::format(
-            "Parts have different number of projections: {} in one part and {} in another",
+            "Parts have different number of projections: {} in part '{}' and {} in part '{}'",
             left->getProjectionParts().size(),
-            right->getProjectionParts().size()
+            left->name,
+            right->getProjectionParts().size(),
+            right->name
         );
         return false;
     }
@@ -8297,8 +8299,8 @@ bool MergeTreeData::partsContainSameProjections(const DataPartPtr & left, const 
         if (!right->hasProjection(name))
         {
             out_reason = fmt::format(
-                "Some part doesn't have projection '{}' while another does", name
-            )
+                "The part '{}' doesn't have projection '{}' while part '{}' does", right->name, name, left->name
+            );
             return false;
         }
     }

--- a/src/Storages/MergeTree/MergeTreeData.h
+++ b/src/Storages/MergeTree/MergeTreeData.h
@@ -425,7 +425,7 @@ public:
     static ReservationPtr tryReserveSpace(UInt64 expected_size, const IDataPartStorage & data_part_storage);
     static ReservationPtr reserveSpace(UInt64 expected_size, const IDataPartStorage & data_part_storage);
 
-    static bool partsContainSameProjections(const DataPartPtr & left, const DataPartPtr & right);
+    static bool partsContainSameProjections(const DataPartPtr & left, const DataPartPtr & right, String & out_reason);
 
     StoragePolicyPtr getStoragePolicy() const override;
 

--- a/src/Storages/MergeTree/ReplicatedMergeTreeQueue.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeQueue.cpp
@@ -2403,7 +2403,7 @@ bool BaseMergePredicate<VirtualPartsT, MutationsStateT>::canMergeTwoParts(
         }
     }
 
-    return MergeTreeData::partsContainSameProjections(left, right);
+    return MergeTreeData::partsContainSameProjections(left, right, out_reason);
 }
 
 template<typename VirtualPartsT, typename MutationsStateT>

--- a/src/Storages/StorageMergeTree.cpp
+++ b/src/Storages/StorageMergeTree.cpp
@@ -932,11 +932,8 @@ MergeMutateSelectedEntryPtr StorageMergeTree::selectPartsToMerge(
             return false;
         }
 
-        if (!partsContainSameProjections(left, right))
-        {
-            disable_reason = "Some parts contains differ projections";
+        if (!partsContainSameProjections(left, right, disable_reason))
             return false;
-        }
 
         auto max_possible_level = getMaxLevelInBetween(left, right);
         if (max_possible_level > std::max(left->info.level, right->info.level))


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Sometimes `OPTIMIZE` with `optimize_throw_if_noop=1` may fail with an error `unknown reason` while the real cause of it - different projections in different parts. This behavior is fixed. 