### PR TITLE
Update build macOS documentation

### DIFF
--- a/docs/en/development/build-osx.md
+++ b/docs/en/development/build-osx.md
@@ -57,7 +57,7 @@ mkdir build
 export PATH=$(brew --prefix llvm)/bin:$PATH
 export CC=$(brew --prefix llvm)/bin/clang
 export CXX=$(brew --prefix llvm)/bin/clang++
-cmake -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -S . -B build
+cmake -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DLINKER_NAME=/usr/bin/ld -S . -B build
 cmake --build build
 # The resulting binary will be created at: build/programs/clickhouse
 ```


### PR DESCRIPTION
### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Add extra options to build steps after https://github.com/ClickHouse/ClickHouse/pull/55036
