### PR TITLE
Fix libssh+openssl3 & s390x

### DIFF
--- a/contrib/libssh-cmake/CMakeLists.txt
+++ b/contrib/libssh-cmake/CMakeLists.txt
@@ -55,9 +55,6 @@ if (OS_LINUX)
     elseif (ARCH_PPC64LE)
         target_include_directories(_ssh PRIVATE "${ClickHouse_SOURCE_DIR}/contrib/libssh-cmake/linux/ppc64le")
     elseif (ARCH_S390X)
-        # Like ppc64le but with HAVE_OPENSSL_FIPS_MODE undefined. This is because the OpenSSL used by s390x doesn't support
-        # FIPS_mode(). Besides that, the custom s390x/config.h only exists to make things compile without additional ifdefs.
-        # With high probability, libssl with OpenSSL on s390x is broken.
         target_include_directories(_ssh PRIVATE "${ClickHouse_SOURCE_DIR}/contrib/libssh-cmake/linux/s390x")
     elseif (ARCH_RISCV64)
         target_include_directories(_ssh PRIVATE "${ClickHouse_SOURCE_DIR}/contrib/libssh-cmake/linux/riscv64")

--- a/contrib/libssh-cmake/darwin/config.h
+++ b/contrib/libssh-cmake/darwin/config.h
@@ -127,7 +127,9 @@
 /* #undef HAVE_OPENSSL_EVP_KDF_CTX_NEW_ID */
 
 /* Define to 1 if you have the `FIPS_mode' function. */
+#if USE_BORINGSSL
 #define HAVE_OPENSSL_FIPS_MODE 1
+#endif
 
 /* Define to 1 if you have the `EVP_DigestSign' function. */
 #define HAVE_OPENSSL_EVP_DIGESTSIGN 1

--- a/contrib/libssh-cmake/freebsd/config.h
+++ b/contrib/libssh-cmake/freebsd/config.h
@@ -127,7 +127,9 @@
 /* #undef HAVE_OPENSSL_EVP_KDF_CTX_NEW_ID */
 
 /* Define to 1 if you have the `FIPS_mode' function. */
+#if USE_BORINGSSL
 #define HAVE_OPENSSL_FIPS_MODE 1
+#endif
 
 /* Define to 1 if you have the `EVP_DigestSign' function. */
 #define HAVE_OPENSSL_EVP_DIGESTSIGN 1

--- a/contrib/libssh-cmake/linux/aarch64-musl/config.h
+++ b/contrib/libssh-cmake/linux/aarch64-musl/config.h
@@ -127,7 +127,9 @@
 /* #undef HAVE_OPENSSL_EVP_KDF_CTX_NEW_ID */
 
 /* Define to 1 if you have the `FIPS_mode' function. */
+#if USE_BORINGSSL
 #define HAVE_OPENSSL_FIPS_MODE 1
+#endif
 
 /* Define to 1 if you have the `EVP_DigestSign' function. */
 #define HAVE_OPENSSL_EVP_DIGESTSIGN 1

--- a/contrib/libssh-cmake/linux/aarch64/config.h
+++ b/contrib/libssh-cmake/linux/aarch64/config.h
@@ -127,7 +127,9 @@
 /* #undef HAVE_OPENSSL_EVP_KDF_CTX_NEW_ID */
 
 /* Define to 1 if you have the `FIPS_mode' function. */
+#if USE_BORINGSSL
 #define HAVE_OPENSSL_FIPS_MODE 1
+#endif
 
 /* Define to 1 if you have the `EVP_DigestSign' function. */
 #define HAVE_OPENSSL_EVP_DIGESTSIGN 1

--- a/contrib/libssh-cmake/linux/ppc64le/config.h
+++ b/contrib/libssh-cmake/linux/ppc64le/config.h
@@ -127,7 +127,9 @@
 /* #undef HAVE_OPENSSL_EVP_KDF_CTX_NEW_ID */
 
 /* Define to 1 if you have the `FIPS_mode' function. */
+#if USE_BORINGSSL
 #define HAVE_OPENSSL_FIPS_MODE 1
+#endif
 
 /* Define to 1 if you have the `EVP_DigestSign' function. */
 #define HAVE_OPENSSL_EVP_DIGESTSIGN 1

--- a/contrib/libssh-cmake/linux/riscv64/config.h
+++ b/contrib/libssh-cmake/linux/riscv64/config.h
@@ -127,7 +127,9 @@
 /* #undef HAVE_OPENSSL_EVP_KDF_CTX_NEW_ID */
 
 /* Define to 1 if you have the `FIPS_mode' function. */
-/* #undef HAVE_OPENSSL_FIPS_MODE */
+#if USE_BORINGSSL
+#define HAVE_OPENSSL_FIPS_MODE 1
+#endif
 
 /* Define to 1 if you have the `EVP_DigestSign' function. */
 #define HAVE_OPENSSL_EVP_DIGESTSIGN 1

--- a/contrib/libssh-cmake/linux/s390x/config.h
+++ b/contrib/libssh-cmake/linux/s390x/config.h
@@ -5,7 +5,7 @@
 #define VERSION "0.9.7"
 
 #define SYSCONFDIR "etc"
-#define BINARYDIR "/home/ubuntu/workdir/ClickHouse/build/ppc64le"
+#define BINARYDIR "/home/ubuntu/workdir/ClickHouse/build/s390x"
 #define SOURCEDIR "/home/ubuntu/workdir/ClickHouse"
 
 /* Global bind configuration file path */
@@ -127,7 +127,9 @@
 /* #undef HAVE_OPENSSL_EVP_KDF_CTX_NEW_ID */
 
 /* Define to 1 if you have the `FIPS_mode' function. */
-/* #undef HAVE_OPENSSL_FIPS_MODE */
+#if USE_BORINGSSL
+#define HAVE_OPENSSL_FIPS_MODE 1
+#endif
 
 /* Define to 1 if you have the `EVP_DigestSign' function. */
 #define HAVE_OPENSSL_EVP_DIGESTSIGN 1
@@ -282,4 +284,4 @@
 
 /* Define WORDS_BIGENDIAN to 1 if your processor stores words with the most
    significant byte first (like Motorola and SPARC, unlike Intel). */
-/* #undef WORDS_BIGENDIAN */
+#define WORDS_BIGENDIAN 1

--- a/contrib/libssh-cmake/linux/x86-64-musl/config.h
+++ b/contrib/libssh-cmake/linux/x86-64-musl/config.h
@@ -127,7 +127,9 @@
 /* #undef HAVE_OPENSSL_EVP_KDF_CTX_NEW_ID */
 
 /* Define to 1 if you have the `FIPS_mode' function. */
+#if USE_BORINGSSL
 #define HAVE_OPENSSL_FIPS_MODE 1
+#endif
 
 /* Define to 1 if you have the `EVP_DigestSign' function. */
 #define HAVE_OPENSSL_EVP_DIGESTSIGN 1

--- a/contrib/libssh-cmake/linux/x86-64/config.h
+++ b/contrib/libssh-cmake/linux/x86-64/config.h
@@ -127,7 +127,9 @@
 /* #undef HAVE_OPENSSL_EVP_KDF_CTX_NEW_ID */
 
 /* Define to 1 if you have the `FIPS_mode' function. */
+#if USE_BORINGSSL
 #define HAVE_OPENSSL_FIPS_MODE 1
+#endif
 
 /* Define to 1 if you have the `EVP_DigestSign' function. */
 #define HAVE_OPENSSL_EVP_DIGESTSIGN 1


### PR DESCRIPTION
Requires https://github.com/ClickHouse/libssh/pull/3 to merge in order to work with OpenSSL3.x 

For **ALL** platforms FIPS_mode function does not exist for openSSL3x (the version in the contrib dir) but does exist for the current version of Boring.

N.B. ClickHouse does not support openssl

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)