### PR TITLE
Fix libssh+openssl3 & s390x (part 2)

### DIFF
--- a/contrib/libssh-cmake/IncludeSources.cmake
+++ b/contrib/libssh-cmake/IncludeSources.cmake
@@ -101,8 +101,8 @@ set(libssh_SRCS
     ${LIB_SOURCE_DIR}/src/dh_crypto.c
 )
 
-# see the comment on s390x in libssh-cmake/CMakeLists.txt
-if(OPENSSL_VERSION VERSION_LESS "1.1.0" AND NOT ARCH_S390X)
+if (NOT (ENABLE_OPENSSL OR ENABLE_OPENSSL_DYNAMIC))
+    add_compile_definitions(USE_BORINGSSL=1)
     set(libssh_SRCS ${libssh_SRCS} ${LIB_SOURCE_DIR}/src/libcrypto-compat.c)
 endif()
 


### PR DESCRIPTION
Continuation of https://github.com/ClickHouse/ClickHouse/pull/55154
- missing change
- submodule update

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)