### PR TITLE
Fix libssh+openssl3 & s390x (Part 2.1)

### DIFF
--- a/contrib/libssh-cmake/IncludeSources.cmake
+++ b/contrib/libssh-cmake/IncludeSources.cmake
@@ -101,9 +101,8 @@ set(libssh_SRCS
     ${LIB_SOURCE_DIR}/src/dh_crypto.c
 )
 
-# see the comment on s390x in libssh-cmake/CMakeLists.txt
-if(OPENSSL_VERSION VERSION_LESS "1.1.0" AND NOT ARCH_S390X)
-    set(libssh_SRCS ${libssh_SRCS} ${LIB_SOURCE_DIR}/src/libcrypto-compat.c)
+if (NOT (ENABLE_OPENSSL OR ENABLE_OPENSSL_DYNAMIC))
+    add_compile_definitions(USE_BORINGSSL=1)
 endif()
 
 set(libssh_SRCS


### PR DESCRIPTION
Fix of reverted https://github.com/ClickHouse/ClickHouse/pull/55187

Never include compat file, even for boring.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

