### PR TITLE
Backups use more thread pools to avoid hanging

### DIFF
--- a/src/Backups/BackupFileInfo.cpp
+++ b/src/Backups/BackupFileInfo.cpp
@@ -215,14 +215,13 @@ BackupFileInfos buildFileInfosForBackupEntries(const BackupEntries & backup_entr
             ++num_active_jobs;
         }
 
-        auto job = [&mutex, &num_active_jobs, &event, &exception, &infos, &backup_entries, &read_settings, &base_backup, &thread_group, i, log](bool async)
+        auto job = [&mutex, &num_active_jobs, &event, &exception, &infos, &backup_entries, &read_settings, &base_backup, &thread_group, i, log]()
         {
             SCOPE_EXIT_SAFE({
                 std::lock_guard lock{mutex};
                 if (!--num_active_jobs)
                     event.notify_all();
-                if (async)
-                    CurrentThread::detachFromGroupIfNotDetached();
+                CurrentThread::detachFromGroupIfNotDetached();
             });
 
             try
@@ -230,11 +229,10 @@ BackupFileInfos buildFileInfosForBackupEntries(const BackupEntries & backup_entr
                 const auto & name = backup_entries[i].first;
                 const auto & entry = backup_entries[i].second;
 
-                if (async && thread_group)
+                if (thread_group)
                     CurrentThread::attachToGroup(thread_group);
 
-                if (async)
-                    setThreadName("BackupWorker");
+                setThreadName("BackupWorker");
 
                 {
                     std::lock_guard lock{mutex};
@@ -252,8 +250,7 @@ BackupFileInfos buildFileInfosForBackupEntries(const BackupEntries & backup_entr
             }
         };
 
-        if (!thread_pool.trySchedule([job] { job(true); }))
-            job(false);
+        thread_pool.scheduleOrThrowOnError(job);
     }
 
     {

--- a/src/Backups/BackupsWorker.cpp
+++ b/src/Backups/BackupsWorker.cpp
@@ -917,23 +917,21 @@ void BackupsWorker::restoreTablesData(const OperationID & restore_id, BackupPtr 
             ++num_active_jobs;
         }
 
-        auto job = [&](bool async)
+        auto job = [&]()
         {
             SCOPE_EXIT_SAFE(
                 std::lock_guard lock{mutex};
                 if (!--num_active_jobs)
                     event.notify_all();
-                if (async)
-                    CurrentThread::detachFromGroupIfNotDetached();
+                CurrentThread::detachFromGroupIfNotDetached();
             );
 
             try
             {
-                if (async && thread_group)
+                if (thread_group)
                     CurrentThread::attachToGroup(thread_group);
 
-                if (async)
-                    setThreadName("RestoreWorker");
+                setThreadName("RestoreWorker");
 
                 {
                     std::lock_guard lock{mutex};
@@ -960,7 +958,7 @@ void BackupsWorker::restoreTablesData(const OperationID & restore_id, BackupPtr 
             }
         };
 
-        thread_pool.scheduleOrThrowOnError([job] { job(true); });
+        thread_pool.scheduleOrThrowOnError(job);
     }
 
     {

--- a/src/Backups/BackupsWorker.h
+++ b/src/Backups/BackupsWorker.h
@@ -33,6 +33,7 @@ class BackupsWorker
 {
 public:
     BackupsWorker(ContextPtr global_context, size_t num_backup_threads, size_t num_restore_threads, bool allow_concurrent_backups_, bool allow_concurrent_restores_);
+    ~BackupsWorker();
 
     /// Waits until all tasks have been completed.
     void shutdown();
@@ -88,8 +89,15 @@ private:
     void setNumFilesAndSize(const BackupOperationID & id, size_t num_files, UInt64 total_size, size_t num_entries,
                             UInt64 uncompressed_size, UInt64 compressed_size, size_t num_read_files, UInt64 num_read_bytes);
 
-    std::unique_ptr<ThreadPool> backups_thread_pool;
-    std::unique_ptr<ThreadPool> restores_thread_pool;
+    enum class ThreadPoolId;
+    ThreadPool & getThreadPool(ThreadPoolId thread_pool_id);
+
+    class ThreadPools;
+    std::unique_ptr<ThreadPools> thread_pools;
+
+    const bool allow_concurrent_backups;
+    const bool allow_concurrent_restores;
+    Poco::Logger * log;
 
     std::unordered_map<BackupOperationID, BackupOperationInfo> infos;
     std::shared_ptr<BackupLog> backup_log;
@@ -97,9 +105,6 @@ private:
     std::atomic<size_t> num_active_backups = 0;
     std::atomic<size_t> num_active_restores = 0;
     mutable std::mutex infos_mutex;
-    Poco::Logger * log;
-    const bool allow_concurrent_backups;
-    const bool allow_concurrent_restores;
 };
 
 }


### PR DESCRIPTION
### Changelog category:
- Not for changelog

Use more thread pools in BACKUP/RESTORE to avoid hanging. More thread pools are required because a task from a thread pool can't wait another task from the same thread pool. (Because if it schedules and waits while the thread pool is still occupied with the waiting task then a scheduled task can be never executed)

This PR fixes flakyness of [test_backup_restore_on_cluster/test_concurrency.py](https://s3.amazonaws.com/clickhouse-test-reports/55060/08a9112f38b226b9cc0515272bc935b74c7d25f3/integration_tests__release__%5B2_4%5D.html). Though it doesn't seem that hanging can happen often during a real BACKUP/RESTORE because normally backups and restores are not proceed simultaneously.