### PR TITLE
Fix recalculation of skip indexes in ALTER UPDATE queries when table has adaptive granularity

### DIFF
--- a/src/Interpreters/MutationsInterpreter.cpp
+++ b/src/Interpreters/MutationsInterpreter.cpp
@@ -590,6 +590,7 @@ void MutationsInterpreter::prepare(bool dry_run)
                 predicate = makeASTFunction("isZeroOrNull", predicate);
 
             stages.back().filters.push_back(predicate);
+            /// ALTER DELETE can changes number of rows in the part, so we need to rebuild indexes and projection
             need_rebuild_indexes = true;
             need_rebuild_projections = true;
         }
@@ -696,6 +697,8 @@ void MutationsInterpreter::prepare(bool dry_run)
                 }
             }
 
+            /// If the part is compact and adaptive index granularity is enabled, modify data in one column via ALTER UPDATE can change
+            /// the part granularity, so we need to rebuild indexes
             if (source.isCompactPart() && source.getMergeTreeData() && source.getMergeTreeData()->getSettings()->index_granularity_bytes > 0)
                 need_rebuild_indexes = true;
         }

--- a/src/Interpreters/MutationsInterpreter.h
+++ b/src/Interpreters/MutationsInterpreter.h
@@ -122,6 +122,7 @@ public:
         bool materializeTTLRecalculateOnly() const;
         bool hasSecondaryIndex(const String & name) const;
         bool hasProjection(const String & name) const;
+        bool isCompactPart() const;
 
         void read(
             Stage & first_stage,

--- a/src/Storages/MergeTree/MergeTreeMarksLoader.cpp
+++ b/src/Storages/MergeTree/MergeTreeMarksLoader.cpp
@@ -107,13 +107,14 @@ MarkCache::MappedPtr MergeTreeMarksLoader::loadMarksImpl()
     // We first read the marks into a temporary simple array, then compress them into a more compact
     // representation.
     PODArray<MarkInCompressedFile> plain_marks(marks_count * columns_in_mark); // temporary
+    auto full_mark_path = std::string(fs::path(data_part_storage->getFullPath()) / mrk_path);
 
     if (file_size == 0 && marks_count != 0)
     {
         throw Exception(
             ErrorCodes::CORRUPTED_DATA,
             "Empty marks file '{}': {}, must be: {}",
-            std::string(fs::path(data_part_storage->getFullPath()) / mrk_path),
+            full_mark_path,
             file_size, expected_uncompressed_size);
     }
 
@@ -121,7 +122,7 @@ MarkCache::MappedPtr MergeTreeMarksLoader::loadMarksImpl()
         throw Exception(
             ErrorCodes::CORRUPTED_DATA,
             "Bad size of marks file '{}': {}, must be: {}",
-            std::string(fs::path(data_part_storage->getFullPath()) / mrk_path),
+            full_mark_path,
             file_size,
             expected_uncompressed_size);
 
@@ -142,7 +143,7 @@ MarkCache::MappedPtr MergeTreeMarksLoader::loadMarksImpl()
             throw Exception(
                 ErrorCodes::CANNOT_READ_ALL_DATA,
                 "Cannot read all marks from file {}, is eof: {}, buffer size: {}, file size: {}",
-                mrk_path,
+                full_mark_path,
                 reader->eof(),
                 reader->buffer().size(),
                 file_size);
@@ -155,7 +156,7 @@ MarkCache::MappedPtr MergeTreeMarksLoader::loadMarksImpl()
                 throw Exception(
                     ErrorCodes::CANNOT_READ_ALL_DATA,
                     "Cannot read all marks from file {}, marks expected {} (bytes size {}), marks read {} (bytes size {})",
-                    mrk_path, marks_count, expected_uncompressed_size, i, reader->count());
+                    full_mark_path, marks_count, expected_uncompressed_size, i, reader->count());
 
             size_t granularity;
             reader->readStrict(
@@ -167,7 +168,7 @@ MarkCache::MappedPtr MergeTreeMarksLoader::loadMarksImpl()
             throw Exception(
                 ErrorCodes::CANNOT_READ_ALL_DATA,
                 "Too many marks in file {}, marks expected {} (bytes size {})",
-                mrk_path, marks_count, expected_uncompressed_size);
+                full_mark_path, marks_count, expected_uncompressed_size);
     }
 
 #if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__

--- a/tests/queries/0_stateless/02891_alter_update_adaptive_granularity.reference
+++ b/tests/queries/0_stateless/02891_alter_update_adaptive_granularity.reference
@@ -1,0 +1,1 @@
+342	442	The Containers library is a generic collection of class templates and algorithms that allow programmers to easily implement common data structures like queues, lists and stacks

--- a/tests/queries/0_stateless/02891_alter_update_adaptive_granularity.sql
+++ b/tests/queries/0_stateless/02891_alter_update_adaptive_granularity.sql
@@ -1,0 +1,24 @@
+CREATE TABLE kv
+(
+    `key` UInt64,
+    `value` UInt64,
+    `s` String,
+    INDEX value_idx value TYPE minmax GRANULARITY 1
+)
+ENGINE = ReplacingMergeTree
+ORDER BY key
+SETTINGS index_granularity = 32, index_granularity_bytes = 1024;
+
+INSERT INTO kv SELECT
+    number,
+    number + 100,
+    toString(number)
+FROM numbers(2048);
+
+ALTER TABLE kv
+    UPDATE s = 'The Containers library is a generic collection of class templates and algorithms that allow programmers to easily implement common data structures like queues, lists and stacks' WHERE 1
+SETTINGS mutations_sync = 2;
+
+SELECT *
+FROM kv
+WHERE value = 442;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Fix recalculation of skip indexes in ALTER UPDATE queries when table has adaptive granularity

When table has adaptive granularity, `ALTER UPDATE` may change number of marks in compact parts.

Reproduce: https://fiddle.clickhouse.com/9f2b67f0-07ab-4d90-82fa-5f2c1abf7ee7

```sql
CREATE TABLE kv
(
    `key` UInt64,
    `value` UInt64,
    `s` String,
    INDEX value_idx value TYPE SET(0) GRANULARITY 1
)
ENGINE = ReplacingMergeTree
ORDER BY key
SETTINGS index_granularity = 32, index_granularity_bytes = 1024;

INSERT INTO kv SELECT
    number,
    number + 100,
    toString(number)
FROM numbers(2048);

ALTER TABLE kv
    UPDATE s = 'barzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzdgfasdghasldfasdfaghfweaufghdasgjasd;lfkaksvnasdljfhjd;alkfgjsdaghasdhgfaosdfhdasjh' WHERE 1
SETTINGS mutations_sync = 2;

SELECT *
FROM kv
WHERE value = 42;
```

Certainly close #53858, close #52652 

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
