### PR TITLE
Speed up buildup of inverted index using absl::flat_hash_map

### DIFF
--- a/src/Common/FST.h
+++ b/src/Common/FST.h
@@ -3,13 +3,13 @@
 #include <map>
 #include <memory>
 #include <string>
-#include <unordered_map>
 #include <unordered_set>
 #include <vector>
 #include <Core/Types.h>
 #include <IO/ReadHelpers.h>
 #include <IO/WriteBuffer.h>
 #include <base/types.h>
+#include <absl/container/flat_hash_map.h>
 
 namespace DB
 {
@@ -107,7 +107,7 @@ public:
     UInt64 state_index = 0;
 
     /// Arcs which are started from state, the 'char' is the label on the arc
-    std::unordered_map<char, Arc> arcs;
+    absl::flat_hash_map<char, Arc> arcs;
 
 private:
     struct FlagValues
@@ -146,7 +146,7 @@ private:
     StatePtr initial_state;
 
     /// map of (state_hash, StatePtr)
-    std::unordered_map<UInt64, StatePtr> minimized_states;
+    absl::flat_hash_map<UInt64, StatePtr> minimized_states;
 
     /// Next available ID of state
     UInt64 next_id = 1;

--- a/src/Storages/MergeTree/GinIndexStore.h
+++ b/src/Storages/MergeTree/GinIndexStore.h
@@ -11,6 +11,7 @@
 #include <mutex>
 #include <unordered_map>
 #include <vector>
+#include <absl/container/flat_hash_map.h>
 
 /// GinIndexStore manages the generalized inverted index ("gin") for a data part, and it is made up of one or more immutable
 /// index segments.
@@ -124,7 +125,7 @@ class GinIndexStore
 {
 public:
     /// Container for all term's Gin Index Postings List Builder
-    using GinIndexPostingsBuilderContainer = std::unordered_map<std::string, GinIndexPostingsBuilderPtr>;
+    using GinIndexPostingsBuilderContainer = absl::flat_hash_map<std::string, GinIndexPostingsBuilderPtr>;
 
     GinIndexStore(const String & name_, DataPartStoragePtr storage_);
     GinIndexStore(const String & name_, DataPartStoragePtr storage_, MutableDataPartStoragePtr data_part_storage_builder_, UInt64 max_digestion_size_);


### PR DESCRIPTION
The original inverted index building uses `std::unordered_map` for the posting list builder and FST builder. The fix uses `absl::flat_hash_map` to replace `std::unordered_map`. It can accelerate the building process by ca. 30%.

Performance test:

```
set allow_experimental_inverted_index=1;
set max_insert_threads=6;

-- Insert all rows from table "hackernews" to a inverted(ngrams=3) indexed table called "hn3_28":

CREATE TABLE hackernews ENGINE = MergeTree ORDER BY id
          AS SELECT * FROM url('https://datasets.clickhouse.com/hackernews.native.zst', Native,
          $$
          id UInt32,
          deleted UInt8,
          type Enum('story' = 1, 'comment' = 2, 'poll' = 3, 'pollopt' = 4, 'job' = 5),
          by LowCardinality(String),
          time DateTime,
          text String,
          dead UInt8,
          parent UInt32,
          poll UInt32,
          kids Array(UInt32),
          url String,
          score Int32,
          title String,
          parts Array(UInt32),
          descendants Int32
          $$);
CREATE TABLE hn3_28
(
id UInt32,
          deleted UInt8,
          type Enum('story' = 1, 'comment' = 2, 'poll' = 3, 'pollopt' = 4, 'job' = 5),
          by LowCardinality(String),
          time DateTime,
          text String,
          dead UInt8,
          parent UInt32,
          poll UInt32,
          kids Array(UInt32),
          url String,
          score Int32,
          title String,
          parts Array(UInt32),
          descendants Int32,
		  INDEX gin_index(text) TYPE inverted(3) GRANULARITY 1
) ENGINE = MergeTree ORDER BY id;

insert into hn3_28 select * from hackernews;
```

Before the fix, the result  of the insert statement is as following:
```
0 rows in set. Elapsed: 388.717 sec. Processed 28.74 million rows, 11.88 GB (73.93 thousand rows/s., 30.57 MB/s.)
Peak memory usage: 5.30 GiB.
```

After the fix, the result of the insert statement is as following:
```
0 rows in set. Elapsed: 269.037 sec. Processed 28.74 million rows, 11.88 GB (106.82 thousand rows/s., 44.17 MB/s.)
Peak memory usage: 5.28 GiB.
```

### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Improved the performance of inverted index creation by 30%. This was achieved by replacing `std::unordered_map` with `absl::flat_hash_map`.