### PR TITLE
Use more thread pools in BACKUP/RESTORE to avoid its hanging in tests

### DIFF
--- a/src/Backups/BackupFileInfo.cpp
+++ b/src/Backups/BackupFileInfo.cpp
@@ -215,14 +215,13 @@ BackupFileInfos buildFileInfosForBackupEntries(const BackupEntries & backup_entr
             ++num_active_jobs;
         }
 
-        auto job = [&mutex, &num_active_jobs, &event, &exception, &infos, &backup_entries, &read_settings, &base_backup, &thread_group, i, log](bool async)
+        auto job = [&mutex, &num_active_jobs, &event, &exception, &infos, &backup_entries, &read_settings, &base_backup, &thread_group, i, log]()
         {
             SCOPE_EXIT_SAFE({
                 std::lock_guard lock{mutex};
                 if (!--num_active_jobs)
                     event.notify_all();
-                if (async)
-                    CurrentThread::detachFromGroupIfNotDetached();
+                CurrentThread::detachFromGroupIfNotDetached();
             });
 
             try
@@ -230,11 +229,10 @@ BackupFileInfos buildFileInfosForBackupEntries(const BackupEntries & backup_entr
                 const auto & name = backup_entries[i].first;
                 const auto & entry = backup_entries[i].second;
 
-                if (async && thread_group)
+                if (thread_group)
                     CurrentThread::attachToGroup(thread_group);
 
-                if (async)
-                    setThreadName("BackupWorker");
+                setThreadName("BackupWorker");
 
                 {
                     std::lock_guard lock{mutex};
@@ -252,8 +250,7 @@ BackupFileInfos buildFileInfosForBackupEntries(const BackupEntries & backup_entr
             }
         };
 
-        if (!thread_pool.trySchedule([job] { job(true); }))
-            job(false);
+        thread_pool.scheduleOrThrowOnError(job);
     }
 
     {

--- a/src/Backups/BackupsWorker.cpp
+++ b/src/Backups/BackupsWorker.cpp
@@ -218,42 +218,145 @@ namespace
 }
 
 
-BackupsWorker::BackupsWorker(
-    ContextPtr global_context,
-    size_t num_backup_threads,
-    size_t num_restore_threads,
-    bool allow_concurrent_backups_,
-    bool allow_concurrent_restores_)
-    : backups_thread_pool(std::make_unique<ThreadPool>(
-        CurrentMetrics::BackupsThreads,
-        CurrentMetrics::BackupsThreadsActive,
-        num_backup_threads,
-        /* max_free_threads = */ 0,
-        num_backup_threads))
-    , restores_thread_pool(std::make_unique<ThreadPool>(
-          CurrentMetrics::RestoreThreads,
-          CurrentMetrics::RestoreThreadsActive,
-          num_restore_threads,
-          /* max_free_threads = */ 0,
-          num_restore_threads))
-    , backup_async_executor_pool(std::make_unique<ThreadPool>(
-          CurrentMetrics::BackupsThreads,
-          CurrentMetrics::BackupsThreadsActive,
-          num_backup_threads,
-          num_backup_threads,
-          num_backup_threads))
-    , restore_async_executor_pool(std::make_unique<ThreadPool>(
-          CurrentMetrics::RestoreThreads,
-          CurrentMetrics::RestoreThreadsActive,
-          num_restore_threads,
-          num_restore_threads,
-          num_restore_threads))
-    , log(&Poco::Logger::get("BackupsWorker"))
+/// We have to use multiple thread pools because
+/// 1) there should be separate thread pools for BACKUP and RESTORE;
+/// 2) a task from a thread pool can't wait another task from the same thread pool. (Because if it schedules and waits
+/// while the thread pool is still occupied with the waiting task then a scheduled task can be never executed).
+enum class BackupsWorker::ThreadPoolId
+{
+    /// "BACKUP ON CLUSTER ASYNC" waits in background while "BACKUP ASYNC" is finished on the nodes of the cluster, then finalizes the backup.
+    BACKUP_ASYNC_ON_CLUSTER,
+
+    /// "BACKUP ASYNC" waits in background while all file infos are built and then it copies the backup's files.
+    BACKUP_ASYNC,
+
+    /// Making a list of files to copy and copying of those files is always sequential, so those operations can share one thread pool.
+    BACKUP_MAKE_LIST_FILES_TO_COPY,
+    BACKUP_COPY_FILES = BACKUP_MAKE_LIST_FILES_TO_COPY,
+
+    /// "RESTORE ON CLUSTER ASYNC" waits in background while "BACKUP ASYNC" is finished on the nodes of the cluster, then finalizes the backup.
+    RESTORE_ASYNC_ON_CLUSTER,
+
+    /// "RESTORE ASYNC" waits in background while the data of all tables are restored.
+    RESTORE_ASYNC,
+
+    /// Restores the data of tables.
+    RESTORE_TABLES_DATA,
+
+    MAX,
+};
+
+
+/// Keeps thread pools for BackupsWorker.
+class BackupsWorker::ThreadPools
+{
+public:
+    ThreadPools(size_t num_backup_threads_, size_t num_restore_threads_)
+        : num_backup_threads(num_backup_threads_), num_restore_threads(num_restore_threads_)
+    {
+    }
+
+    /// Returns a thread pool, creates it if it's not created yet.
+    ThreadPool & getThreadPool(ThreadPoolId thread_pool_id)
+    {
+        std::lock_guard lock{mutex};
+        auto & thread_pool = thread_pools[static_cast<size_t>(thread_pool_id)];
+        if (!thread_pool)
+        {
+            CurrentMetrics::Metric metric_threads;
+            CurrentMetrics::Metric metric_active_threads;
+            size_t max_threads = 0;
+
+            /// What to do with a new job if a corresponding thread pool is already running `max_threads` jobs:
+            /// `use_queue == true` - put into the thread pool's queue,
+            /// `use_queue == false` - schedule() should wait until some of the jobs finish.
+            bool use_queue = false;
+
+            switch (thread_pool_id)
+            {
+                case ThreadPoolId::BACKUP_ASYNC:
+                case ThreadPoolId::BACKUP_ASYNC_ON_CLUSTER:
+                case ThreadPoolId::BACKUP_COPY_FILES:
+                {
+                    metric_threads = CurrentMetrics::BackupsThreads;
+                    metric_active_threads = CurrentMetrics::BackupsThreadsActive;
+                    max_threads = num_backup_threads;
+                    /// We don't use the thread pool's queue for copying files because otherwise that queue could be memory-wasting.
+                    use_queue = (thread_pool_id != ThreadPoolId::BACKUP_COPY_FILES);
+                    break;
+                }
+
+                case ThreadPoolId::RESTORE_ASYNC:
+                case ThreadPoolId::RESTORE_ASYNC_ON_CLUSTER:
+                case ThreadPoolId::RESTORE_TABLES_DATA:
+                {
+                    metric_threads = CurrentMetrics::RestoreThreads;
+                    metric_active_threads = CurrentMetrics::RestoreThreadsActive;
+                    max_threads = num_restore_threads;
+                    use_queue = (thread_pool_id != ThreadPoolId::RESTORE_TABLES_DATA);
+                    break;
+                }
+
+                default:
+                    UNREACHABLE();
+            }
+
+            /// We set max_free_threads = 0 because we don't want to keep any threads if there is no RESTORE query running right now.
+            size_t max_free_threads = 0;
+            size_t queue_size = use_queue ? 0 : max_threads;
+            thread_pool = std::make_unique<ThreadPool>(metric_threads, metric_active_threads, max_threads, max_free_threads, queue_size);
+        }
+        return *thread_pool;
+    }
+
+    /// Waits for all threads to finish.
+    void wait()
+    {
+        auto wait_sequence = {
+            ThreadPoolId::RESTORE_ASYNC_ON_CLUSTER,
+            ThreadPoolId::RESTORE_ASYNC,
+            ThreadPoolId::RESTORE_TABLES_DATA,
+            ThreadPoolId::BACKUP_ASYNC_ON_CLUSTER,
+            ThreadPoolId::BACKUP_ASYNC,
+            ThreadPoolId::BACKUP_COPY_FILES,
+        };
+
+        for (auto thread_pool_id : wait_sequence)
+        {
+            ThreadPool * thread_pool;
+            {
+                std::lock_guard lock{mutex};
+                thread_pool = thread_pools[static_cast<size_t>(thread_pool_id)].get();
+            }
+            if (thread_pool)
+                thread_pool->wait();
+        }
+    }
+
+private:
+    const size_t num_backup_threads;
+    const size_t num_restore_threads;
+    std::unique_ptr<ThreadPool> thread_pools[static_cast<size_t>(ThreadPoolId::MAX)] TSA_GUARDED_BY(mutex);
+    std::mutex mutex;
+};
+
+
+BackupsWorker::BackupsWorker(ContextPtr global_context, size_t num_backup_threads, size_t num_restore_threads, bool allow_concurrent_backups_, bool allow_concurrent_restores_)
+    : thread_pools(std::make_unique<ThreadPools>(num_backup_threads, num_restore_threads))
     , allow_concurrent_backups(allow_concurrent_backups_)
     , allow_concurrent_restores(allow_concurrent_restores_)
+    , log(&Poco::Logger::get("BackupsWorker"))
 {
     backup_log = global_context->getBackupLog();
-    /// We set max_free_threads = 0 because we don't want to keep any threads if there is no BACKUP or RESTORE query running right now.
+}
+
+
+BackupsWorker::~BackupsWorker() = default;
+
+
+ThreadPool & BackupsWorker::getThreadPool(ThreadPoolId thread_pool_id)
+{
+    return thread_pools->getThreadPool(thread_pool_id);
 }
 
 
@@ -313,16 +416,9 @@ OperationID BackupsWorker::startMakingBackup(const ASTPtr & query, const Context
 
         if (backup_settings.async)
         {
-            backup_async_executor_pool->scheduleOrThrowOnError(
-                [this,
-                 backup_query,
-                 backup_id,
-                 backup_name_for_logging,
-                 backup_info,
-                 backup_settings,
-                 backup_coordination,
-                 context_in_use,
-                 mutable_context]
+            auto & thread_pool = getThreadPool(on_cluster ? ThreadPoolId::BACKUP_ASYNC_ON_CLUSTER : ThreadPoolId::BACKUP_ASYNC);
+            thread_pool.scheduleOrThrowOnError(
+                [this, backup_query, backup_id, backup_name_for_logging, backup_info, backup_settings, backup_coordination, context_in_use, mutable_context]
                 {
                     doBackup(
                         backup_query,
@@ -515,7 +611,7 @@ void BackupsWorker::buildFileInfosForBackupEntries(const BackupPtr & backup, con
     LOG_TRACE(log, "{}", Stage::BUILDING_FILE_INFOS);
     backup_coordination->setStage(Stage::BUILDING_FILE_INFOS, "");
     backup_coordination->waitForStage(Stage::BUILDING_FILE_INFOS);
-    backup_coordination->addFileInfos(::DB::buildFileInfosForBackupEntries(backup_entries, backup->getBaseBackup(), read_settings, *backups_thread_pool));
+    backup_coordination->addFileInfos(::DB::buildFileInfosForBackupEntries(backup_entries, backup->getBaseBackup(), read_settings, getThreadPool(ThreadPoolId::BACKUP_MAKE_LIST_FILES_TO_COPY)));
 }
 
 
@@ -541,6 +637,7 @@ void BackupsWorker::writeBackupEntries(BackupMutablePtr backup, BackupEntries &&
     std::exception_ptr exception;
 
     bool always_single_threaded = !backup->supportsWritingInMultipleThreads();
+    auto & thread_pool = getThreadPool(ThreadPoolId::BACKUP_COPY_FILES);
     auto thread_group = CurrentThread::getGroup();
 
     for (size_t i = 0; i != backup_entries.size(); ++i)
@@ -608,7 +705,7 @@ void BackupsWorker::writeBackupEntries(BackupMutablePtr backup, BackupEntries &&
             continue;
         }
 
-        backups_thread_pool->scheduleOrThrowOnError([job] { job(true); });
+        thread_pool.scheduleOrThrowOnError([job] { job(true); });
     }
 
     {
@@ -666,25 +763,19 @@ OperationID BackupsWorker::startRestoring(const ASTPtr & query, ContextMutablePt
 
         if (restore_settings.async)
         {
-            restore_async_executor_pool->scheduleOrThrowOnError(
-                [this,
-                 restore_query,
-                 restore_id,
-                 backup_name_for_logging,
-                 backup_info,
-                 restore_settings,
-                 restore_coordination,
-                 context_in_use]
-            {
-                doRestore(
-                    restore_query,
-                    restore_id,
-                    backup_name_for_logging,
-                    backup_info,
-                    restore_settings,
-                    restore_coordination,
-                    context_in_use,
-                    /* called_async= */ true);
+            auto & thread_pool = getThreadPool(on_cluster ? ThreadPoolId::RESTORE_ASYNC_ON_CLUSTER : ThreadPoolId::RESTORE_ASYNC);
+            thread_pool.scheduleOrThrowOnError(
+                [this, restore_query, restore_id, backup_name_for_logging, backup_info, restore_settings, restore_coordination, context_in_use]
+                {
+                    doRestore(
+                        restore_query,
+                        restore_id,
+                        backup_name_for_logging,
+                        backup_info,
+                        restore_settings,
+                        restore_coordination,
+                        context_in_use,
+                        /* called_async= */ true);
                 });
         }
         else
@@ -818,7 +909,7 @@ void BackupsWorker::doRestore(
             }
 
             /// Execute the data restoring tasks.
-            restoreTablesData(restore_id, backup, std::move(data_restore_tasks), *restores_thread_pool);
+            restoreTablesData(restore_id, backup, std::move(data_restore_tasks), getThreadPool(ThreadPoolId::RESTORE_TABLES_DATA));
 
             /// We have restored everything, we need to tell other hosts (they could be waiting for it).
             restore_coordination->setStage(Stage::COMPLETED, "");
@@ -1049,10 +1140,7 @@ void BackupsWorker::shutdown()
     if (has_active_backups_and_restores)
         LOG_INFO(log, "Waiting for {} backups and {} restores to be finished", num_active_backups, num_active_restores);
 
-    backups_thread_pool->wait();
-    restores_thread_pool->wait();
-    backup_async_executor_pool->wait();
-    restore_async_executor_pool->wait();
+    thread_pools->wait();
 
     if (has_active_backups_and_restores)
         LOG_INFO(log, "All backup and restore tasks have finished");

--- a/src/Backups/BackupsWorker.h
+++ b/src/Backups/BackupsWorker.h
@@ -33,6 +33,7 @@ class BackupsWorker
 {
 public:
     BackupsWorker(ContextPtr global_context, size_t num_backup_threads, size_t num_restore_threads, bool allow_concurrent_backups_, bool allow_concurrent_restores_);
+    ~BackupsWorker();
 
     /// Waits until all tasks have been completed.
     void shutdown();
@@ -88,11 +89,15 @@ private:
     void setNumFilesAndSize(const BackupOperationID & id, size_t num_files, UInt64 total_size, size_t num_entries,
                             UInt64 uncompressed_size, UInt64 compressed_size, size_t num_read_files, UInt64 num_read_bytes);
 
-    std::unique_ptr<ThreadPool> backups_thread_pool;
-    std::unique_ptr<ThreadPool> restores_thread_pool;
+    enum class ThreadPoolId;
+    ThreadPool & getThreadPool(ThreadPoolId thread_pool_id);
 
-    std::unique_ptr<ThreadPool> backup_async_executor_pool;
-    std::unique_ptr<ThreadPool> restore_async_executor_pool;
+    class ThreadPools;
+    std::unique_ptr<ThreadPools> thread_pools;
+
+    const bool allow_concurrent_backups;
+    const bool allow_concurrent_restores;
+    Poco::Logger * log;
 
     std::unordered_map<BackupOperationID, BackupOperationInfo> infos;
     std::shared_ptr<BackupLog> backup_log;
@@ -100,9 +105,6 @@ private:
     std::atomic<size_t> num_active_backups = 0;
     std::atomic<size_t> num_active_restores = 0;
     mutable std::mutex infos_mutex;
-    Poco::Logger * log;
-    const bool allow_concurrent_backups;
-    const bool allow_concurrent_restores;
 };
 
 }


### PR DESCRIPTION
### Changelog category:
- Not for changelog

This PR is a follow-up to https://github.com/ClickHouse/ClickHouse/pull/55132, it adds two more thread pools to handle `BACKUP ON CLUSTER ASYNC` and `RESTORE ON CLUSTER ASYNC` without possible hanging. The PR also introduces lazily creation of such thread pools.