### PR TITLE
Fix syntax highlight in client for spaceship operator

### DIFF
--- a/src/Client/ClientBaseHelpers.cpp
+++ b/src/Client/ClientBaseHelpers.cpp
@@ -130,6 +130,7 @@ void highlight(const String & query, std::vector<replxx::Replxx::Color> & colors
             {TokenType::Greater, replxx::color::bold(Replxx::Color::DEFAULT)},
             {TokenType::LessOrEquals, replxx::color::bold(Replxx::Color::DEFAULT)},
             {TokenType::GreaterOrEquals, replxx::color::bold(Replxx::Color::DEFAULT)},
+            {TokenType::Spaceship, replxx::color::bold(Replxx::Color::DEFAULT)},
             {TokenType::Concatenation, replxx::color::bold(Replxx::Color::DEFAULT)},
             {TokenType::At, replxx::color::bold(Replxx::Color::DEFAULT)},
             {TokenType::DoubleAt, Replxx::Color::MAGENTA},


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix syntax highlight in client for spaceship operator

Follow-up for: #54067 (cc @vdimir )