### PR TITLE
Fix mypy (fixes CI style check)

### DIFF
--- a/docker/test/style/Dockerfile
+++ b/docker/test/style/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update && env DEBIAN_FRONTEND=noninteractive apt-get install --yes \
     shellcheck \
     yamllint \
     locales \
-    && pip3 install black==23.1.0 boto3 codespell==2.2.1 mypy==1.3.0 PyGithub unidiff pylint==2.6.2 \
+    && pip3 install black==23.1.0 boto3 codespell==2.2.1 mypy==1.3.0 PyGithub==1.59.1 unidiff pylint==2.6.2 \
     && apt-get clean \
     && rm -rf /root/.cache/pip 
 

--- a/tests/ci/style_check.py
+++ b/tests/ci/style_check.py
@@ -140,7 +140,7 @@ def main():
     stopwatch = Stopwatch()
 
     repo_path = Path(GITHUB_WORKSPACE)
-    temp_path = Path(TEMP_PATH) / "style_check"
+    temp_path = Path(TEMP_PATH)
     temp_path.mkdir(parents=True, exist_ok=True)
 
     pr_info = PRInfo()


### PR DESCRIPTION
I've inspected the last image that works (from
https://github.com/ClickHouse/ClickHouse/pull/53493) and the one that does not, and downgrading PyGithub helps (though at first I thought that the culprit was typing_extensions)

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix mypy (fixes CI style check)

Follow-up for: https://github.com/ClickHouse/ClickHouse/pull/51769 (cc @Felixoid )