### PR TITLE
clickhouse-client: don't show "0 rows in set" if it is zero and if exception was thrown

### DIFF
--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -1950,9 +1950,10 @@ void ClientBase::processParsedSingleQuery(const String & full_query, const Strin
 
     if (is_interactive)
     {
-        std::cout << std::endl
-            << processed_rows << " row" << (processed_rows == 1 ? "" : "s")
-            << " in set. Elapsed: " << progress_indication.elapsedSeconds() << " sec. ";
+        std::cout << std::endl;
+        if (!server_exception)
+            std::cout << processed_rows << " row" << (processed_rows == 1 ? "" : "s") << " in set. ";
+        std::cout << "Elapsed: " << progress_indication.elapsedSeconds() << " sec. ";
         progress_indication.writeFinalProgress();
         std::cout << std::endl << std::endl;
     }

--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -1951,7 +1951,7 @@ void ClientBase::processParsedSingleQuery(const String & full_query, const Strin
     if (is_interactive)
     {
         std::cout << std::endl;
-        if (!server_exception)
+        if (!server_exception || processed_rows != 0)
             std::cout << processed_rows << " row" << (processed_rows == 1 ? "" : "s") << " in set. ";
         std::cout << "Elapsed: " << progress_indication.elapsedSeconds() << " sec. ";
         progress_indication.writeFinalProgress();


### PR DESCRIPTION
Close #52936

### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
clickhouse-client won't show "0 rows in set" if it is zero and if exception was thrown

