### PR TITLE
Upgrade MinIO to support accepting non signed requests

### DIFF
--- a/docker/test/integration/runner/compose/docker_compose_minio.yml
+++ b/docker/test/integration/runner/compose/docker_compose_minio.yml
@@ -2,9 +2,7 @@ version: '2.3'
 
 services:
   minio1:
-    # Newer version of minio results in such errors:
-    # "AWSErrorMarshaller: Encountered AWSError 'InternalError': We encountered an internal error, please try again"
-    image: minio/minio:RELEASE.2021-09-23T04-46-24Z
+    image: minio/minio:RELEASE.2023-09-30T07-02-29Z
     volumes:
       - data1-1:/data1
       - ${MINIO_CERTS_DIR:-}:/certs

--- a/tests/integration/test_storage_delta/test.py
+++ b/tests/integration/test_storage_delta/test.py
@@ -274,7 +274,7 @@ def test_multiple_log_files(started_cluster):
     assert len(files) == 2  # 1 metadata files + 1 data file
 
     s3_objects = list(
-        minio_client.list_objects(bucket, f"/{TABLE_NAME}/_delta_log/", recursive=True)
+        minio_client.list_objects(bucket, f"{TABLE_NAME}/_delta_log/", recursive=True)
     )
     assert len(s3_objects) == 1
 
@@ -288,7 +288,7 @@ def test_multiple_log_files(started_cluster):
     assert len(files) == 4  # 2 metadata files + 2 data files
 
     s3_objects = list(
-        minio_client.list_objects(bucket, f"/{TABLE_NAME}/_delta_log/", recursive=True)
+        minio_client.list_objects(bucket, f"{TABLE_NAME}/_delta_log/", recursive=True)
     )
     assert len(s3_objects) == 2
 


### PR DESCRIPTION
During fixing one issue with multiple reads of input files while sending them to S3 this had been pops up.

The problem is in this place [1].

  [1]: https://github.com/minio/minio/blob/200caab82b622a0ec6c9776ee9b555aedbc9b320/cmd/object-handlers.go#L1573-L1591

And this had been added only in [2].

  [2]: https://github.com/minio/minio/pull/16484

But even this implementation is not complete, since it does not correctly support STREAMING-UNSIGNED-PAYLOAD-TRAILER, but this will be the first step, to see if there are still problems with newer MinIO.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)