### PR TITLE
Fix docs typo (makeDateTime32 -> makeDateTime64)

### DIFF
--- a/docs/en/sql-reference/functions/date-time-functions.md
+++ b/docs/en/sql-reference/functions/date-time-functions.md
@@ -134,7 +134,7 @@ Like [makeDateTime](#makedatetime) but produces a [DateTime64](../../sql-referen
 **Syntax**
 
 ``` sql
-makeDateTime32(year, month, day, hour, minute, second[, fraction[, precision[, timezone]]])
+makeDateTime64(year, month, day, hour, minute, second[, fraction[, precision[, timezone]]])
 ```
 
 ## timestamp


### PR DESCRIPTION
Appears to have been a simple typo. Fixing to the actual function!

### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
