### PR TITLE
Fix data race in context

### DIFF
--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -3417,9 +3417,8 @@ void Context::initializeSystemLogs()
     /// triggered from another thread, that is launched while initializing the system logs,
     /// for example, system.filesystem_cache_log will be triggered by parts loading
     /// of any other table if it is stored on a disk with cache.
-    callOnce(shared->system_logs_initializer, [&] {
-        shared->system_logs = std::make_unique<SystemLogs>(getGlobalContext(), getConfigRef());
-    });
+    auto lock = getGlobalLock();
+    shared->system_logs = std::make_unique<SystemLogs>(getGlobalContext(), getConfigRef());
 }
 
 void Context::initializeTraceCollector()

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -3417,8 +3417,11 @@ void Context::initializeSystemLogs()
     /// triggered from another thread, that is launched while initializing the system logs,
     /// for example, system.filesystem_cache_log will be triggered by parts loading
     /// of any other table if it is stored on a disk with cache.
-    auto lock = getGlobalLock();
-    shared->system_logs = std::make_unique<SystemLogs>(getGlobalContext(), getConfigRef());
+    callOnce(shared->system_logs_initializer, [&] {
+        auto system_logs = std::make_unique<SystemLogs>(getGlobalContext(), getConfigRef());
+        auto lock = getGlobalLock();
+        shared->system_logs = std::move(system_logs);
+    });
 }
 
 void Context::initializeTraceCollector()


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Looks broken after https://github.com/ClickHouse/ClickHouse/pull/55121.
See https://s3.amazonaws.com/clickhouse-test-reports/55252/c57a92f5fcdf2b131ebbcc6758260399e8ca976d/stress_test__tsan_/stderr.log.