### PR TITLE
Do not allow tests with state ERROR be overwritten by PASSED

### DIFF
--- a/tests/integration/ci-runner.py
+++ b/tests/integration/ci-runner.py
@@ -492,8 +492,6 @@ class ClickhouseIntegrationTestsRunner:
             if test not in main_counters["PASSED"]:
                 if test in main_counters["FAILED"]:
                     main_counters["FAILED"].remove(test)
-                if test in main_counters["ERROR"]:
-                    main_counters["ERROR"].remove(test)
                 if test in main_counters["BROKEN"]:
                     main_counters["BROKEN"].remove(test)
 
@@ -506,7 +504,6 @@ class ClickhouseIntegrationTestsRunner:
             for test in current_counters[state]:
                 if test in main_counters["PASSED"]:
                     main_counters["PASSED"].remove(test)
-                    continue
                 if test not in broken_tests:
                     if test not in main_counters[state]:
                         main_counters[state].append(test)

--- a/tests/tsan_suppressions.txt
+++ b/tests/tsan_suppressions.txt
@@ -1,1 +1,2 @@
-# We have no suppressions!
+# https://github.com/ClickHouse/ClickHouse/issues/55629
+race:rd_kafka_broker_set_nodename


### PR DESCRIPTION
In the ERROR case there can be sanitizers issues, that should not be hidden, like right now it is doing for
`test_s3_table_functions/test.py::test_s3_table_functions_timeouts` test [1], but I was lucky enough to trigger this in [2].

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/55247/e99b0f46961733fa8ba10e490279dbcb0cdd67ad/integration_tests__asan__[5_6].html
  [2]: https://s3.amazonaws.com/clickhouse-test-reports/55245/918d65d6707c69ab541cdb56a076cdb83845d3ed/integration_tests__asan__[5_6].html

Though there could be also other issues, like with dependent services, but still, let's try.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)