### PR TITLE
Avoid possible memory leaks in compressors in case of missing buffer finalization

### DIFF
--- a/src/IO/LZMADeflatingWriteBuffer.cpp
+++ b/src/IO/LZMADeflatingWriteBuffer.cpp
@@ -44,7 +44,11 @@ LZMADeflatingWriteBuffer::LZMADeflatingWriteBuffer(
             LZMA_VERSION_STRING);
 }
 
-LZMADeflatingWriteBuffer::~LZMADeflatingWriteBuffer() = default;
+LZMADeflatingWriteBuffer::~LZMADeflatingWriteBuffer()
+{
+    /// It is OK to call deflateEnd() twice (one from the finalizeAfter())
+    lzma_end(&lstr);
+}
 
 void LZMADeflatingWriteBuffer::nextImpl()
 {

--- a/src/IO/Lz4DeflatingWriteBuffer.cpp
+++ b/src/IO/Lz4DeflatingWriteBuffer.cpp
@@ -40,7 +40,11 @@ Lz4DeflatingWriteBuffer::Lz4DeflatingWriteBuffer(
             LZ4F_VERSION);
 }
 
-Lz4DeflatingWriteBuffer::~Lz4DeflatingWriteBuffer() = default;
+Lz4DeflatingWriteBuffer::~Lz4DeflatingWriteBuffer()
+{
+    if (ctx)
+        LZ4F_freeCompressionContext(ctx);
+}
 
 void Lz4DeflatingWriteBuffer::nextImpl()
 {
@@ -156,6 +160,7 @@ void Lz4DeflatingWriteBuffer::finalizeBefore()
 void Lz4DeflatingWriteBuffer::finalizeAfter()
 {
     LZ4F_freeCompressionContext(ctx);
+    ctx = nullptr;
 }
 
 }

--- a/src/IO/ZlibDeflatingWriteBuffer.cpp
+++ b/src/IO/ZlibDeflatingWriteBuffer.cpp
@@ -72,7 +72,11 @@ void ZlibDeflatingWriteBuffer::nextImpl()
     }
 }
 
-ZlibDeflatingWriteBuffer::~ZlibDeflatingWriteBuffer() = default;
+ZlibDeflatingWriteBuffer::~ZlibDeflatingWriteBuffer()
+{
+    /// It is OK to call deflateEnd() twice (one from the finalizeAfter() that does the proper error checking)
+    deflateEnd(&zstr);
+}
 
 void ZlibDeflatingWriteBuffer::finalizeBefore()
 {

--- a/src/IO/ZstdDeflatingWriteBuffer.cpp
+++ b/src/IO/ZstdDeflatingWriteBuffer.cpp
@@ -30,7 +30,11 @@ ZstdDeflatingWriteBuffer::ZstdDeflatingWriteBuffer(
     output = {nullptr, 0, 0};
 }
 
-ZstdDeflatingWriteBuffer::~ZstdDeflatingWriteBuffer() = default;
+ZstdDeflatingWriteBuffer::~ZstdDeflatingWriteBuffer()
+{
+    if (cctx)
+        ZSTD_freeCCtx(cctx);
+}
 
 void ZstdDeflatingWriteBuffer::flush(ZSTD_EndDirective mode)
 {
@@ -88,6 +92,7 @@ void ZstdDeflatingWriteBuffer::finalizeAfter()
     try
     {
         size_t err = ZSTD_freeCCtx(cctx);
+        cctx = nullptr;
         /// This is just in case, since it is impossible to get an error by using this wrapper.
         if (unlikely(err))
             throw Exception(ErrorCodes::ZSTD_ENCODER_FAILED, "ZSTD_freeCCtx failed: error: '{}'; zstd version: {}",


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Avoid possible memory leaks in compressors in case of missing buffer finalization

Sometimes it is still possible, the pattern could looks like this:

    try
    {
        writer->finalize();
        writer->flush();
        write_buf->finalize();
    }
    catch (...)
    {
        /// Stop ParallelFormattingOutputFormat correctly.
        release();
        throw;
    }

Here, `write_buf` will not be finalized, in case of exception during `writer` `finalize`/`flush`.

Fixes: #50395 (cc @CheSema )