### PR TITLE
Fix query_log cache usage column name in docs

### DIFF
--- a/docs/en/operations/query-cache.md
+++ b/docs/en/operations/query-cache.md
@@ -69,7 +69,7 @@ may return cached results then.
 The query cache can be cleared using statement `SYSTEM DROP QUERY CACHE`. The content of the query cache is displayed in system table
 `system.query_cache`. The number of query cache hits and misses since database start are shown as events "QueryCacheHits" and
 "QueryCacheMisses" in system table [system.events](system-tables/events.md). Both counters are only updated for `SELECT` queries which run
-with setting `use_query_cache = true`, other queries do not affect "QueryCacheMisses". Field `query_log_usage` in system table
+with setting `use_query_cache = true`, other queries do not affect "QueryCacheMisses". Field `query_cache_usage` in system table
 [system.query_log](system-tables/query_log.md) shows for each executed query whether the query result was written into or read from the
 query cache. Asynchronous metrics "QueryCacheEntries" and "QueryCacheBytes" in system table
 [system.asynchronous_metrics](system-tables/asynchronous_metrics.md) show how many entries / bytes the query cache currently contains.


### PR DESCRIPTION
It is not called `query_log_usage` but `query_cache_usage`

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Documentation (changelog entry is not required)
