### PR TITLE
Fix incorrect merging of Nested for SELECT FINAL FROM SummingMergeTree

### DIFF
--- a/tests/queries/0_stateless/02892_SummingMergeTree_Nested.reference
+++ b/tests/queries/0_stateless/02892_SummingMergeTree_Nested.reference
@@ -1,0 +1,11 @@
+-- { echo }
+select * from nested_smt order by val;
+2023-10-05	1	[1,2,3]	[10,20,30]
+2023-10-05	2	[1,2,3]	[1,1,1]
+select * from nested_smt final;
+2023-10-05	3	[1,2,3]	[11,21,31]
+system start merges nested_smt;
+optimize table nested_smt final;
+select * from nested_smt;
+2023-10-05	3	[1,2,3]	[11,21,31]
+drop table nested_smt;

--- a/tests/queries/0_stateless/02892_SummingMergeTree_Nested.sql
+++ b/tests/queries/0_stateless/02892_SummingMergeTree_Nested.sql
@@ -1,0 +1,26 @@
+drop table if exists nested_smt;
+create table nested_smt (
+     date date,
+     val UInt64,
+     counters_Map Nested (
+         id UInt8,
+         count Int32
+     )
+)
+ENGINE = SummingMergeTree()
+ORDER BY (date);
+
+system stop merges nested_smt;
+
+insert into nested_smt values ('2023-10-05', 1, [1,2,3], [10,20,30]);
+insert into nested_smt values ('2023-10-05', 2, [1,2,3], [1,1,1]);
+
+-- { echo }
+select * from nested_smt order by val;
+select * from nested_smt final;
+
+system start merges nested_smt;
+optimize table nested_smt final;
+select * from nested_smt;
+
+drop table nested_smt;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix incorrect merging of Nested for SELECT FINAL FROM SummingMergeTree

The problem was the order of the columns, in case of SELECT FINAL it got "counters_Map.count", "counters_Map.id"

But in case of OPTIMIZE FINAL it got "counters_Map.id", "counters_Map.count" correctly.

Note, that this bugs exists there from very old versions, I've checked 19.x and it was there.

P.S. there is a workaround for this problem, if you will use one of the following patterns for key columns:
- *ID
- *Key
- *Type

That way it will be explicitly matched as key and everything will work.
