### PR TITLE
Make `HandlingRuleHTTPHandlerFactory` more stupid, but less error prone

### DIFF
--- a/src/Server/HTTPHandler.cpp
+++ b/src/Server/HTTPHandler.cpp
@@ -1263,8 +1263,12 @@ HTTPRequestHandlerFactoryPtr createDynamicHandlerFactory(IServer & server,
     if (config.has(config_prefix + ".handler.content_type"))
         content_type_override = config.getString(config_prefix + ".handler.content_type");
 
-    auto factory = std::make_shared<HandlingRuleHTTPHandlerFactory<DynamicQueryHandler>>(
-        server, std::move(query_param_name), std::move(content_type_override));
+    auto creator = [&server, query_param_name, content_type_override] () -> std::unique_ptr<DynamicQueryHandler>
+    {
+        return std::make_unique<DynamicQueryHandler>(server, query_param_name, content_type_override);
+    };
+
+    auto factory = std::make_shared<HandlingRuleHTTPHandlerFactory<DynamicQueryHandler>>(std::move(creator));
 
     factory->addFiltersFromConfig(config, config_prefix);
 
@@ -1335,25 +1339,40 @@ HTTPRequestHandlerFactoryPtr createPredefinedHandlerFactory(IServer & server,
         auto regex = getCompiledRegex(url_expression);
         if (capturingNamedQueryParam(analyze_receive_params, regex))
         {
-            factory = std::make_shared<HandlingRuleHTTPHandlerFactory<PredefinedQueryHandler>>(
-                server,
-                std::move(analyze_receive_params),
-                std::move(predefined_query),
-                std::move(regex),
-                std::move(headers_name_with_regex),
-                std::move(content_type_override));
+            auto creator = [
+                &server,
+                analyze_receive_params,
+                predefined_query,
+                regex,
+                headers_name_with_regex,
+                content_type_override]
+                -> std::unique_ptr<PredefinedQueryHandler>
+            {
+                return std::make_unique<PredefinedQueryHandler>(
+                    server, analyze_receive_params, predefined_query, regex,
+                    headers_name_with_regex, content_type_override);
+            };
+            factory = std::make_shared<HandlingRuleHTTPHandlerFactory<PredefinedQueryHandler>>(std::move(creator));
             factory->addFiltersFromConfig(config, config_prefix);
             return factory;
         }
     }
 
-    factory = std::make_shared<HandlingRuleHTTPHandlerFactory<PredefinedQueryHandler>>(
-        server,
-        std::move(analyze_receive_params),
-        std::move(predefined_query),
-        CompiledRegexPtr{},
-        std::move(headers_name_with_regex),
-        std::move(content_type_override));
+    auto creator = [
+        &server,
+        analyze_receive_params,
+        predefined_query,
+        headers_name_with_regex,
+        content_type_override]
+        -> std::unique_ptr<PredefinedQueryHandler>
+    {
+        return std::make_unique<PredefinedQueryHandler>(
+            server, analyze_receive_params, predefined_query, CompiledRegexPtr{},
+            headers_name_with_regex, content_type_override);
+    };
+
+    factory = std::make_shared<HandlingRuleHTTPHandlerFactory<PredefinedQueryHandler>>(std::move(creator));
+
     factory->addFiltersFromConfig(config, config_prefix);
 
     return factory;

--- a/src/Server/HTTPHandlerFactory.cpp
+++ b/src/Server/HTTPHandlerFactory.cpp
@@ -119,17 +119,25 @@ HTTPRequestHandlerFactoryPtr createHandlerFactory(IServer & server, const Poco::
     throw Exception(ErrorCodes::LOGICAL_ERROR, "LOGICAL ERROR: Unknown HTTP handler factory name.");
 }
 
-static const auto ping_response_expression = "Ok.\n";
-static const auto root_response_expression = "config://http_server_default_response";
 
 void addCommonDefaultHandlersFactory(HTTPRequestHandlerFactoryMain & factory, IServer & server)
 {
-    auto root_handler = std::make_shared<HandlingRuleHTTPHandlerFactory<StaticRequestHandler>>(server, root_response_expression);
+    auto root_creator = [&server]() -> std::unique_ptr<StaticRequestHandler>
+    {
+        constexpr auto root_response_expression = "config://http_server_default_response";
+        return std::make_unique<StaticRequestHandler>(server, root_response_expression);
+    };
+    auto root_handler = std::make_shared<HandlingRuleHTTPHandlerFactory<StaticRequestHandler>>(std::move(root_creator));
     root_handler->attachStrictPath("/");
     root_handler->allowGetAndHeadRequest();
     factory.addHandler(root_handler);
 
-    auto ping_handler = std::make_shared<HandlingRuleHTTPHandlerFactory<StaticRequestHandler>>(server, ping_response_expression);
+    auto ping_creator = [&server]() -> std::unique_ptr<StaticRequestHandler>
+    {
+        constexpr auto ping_response_expression = "Ok.\n";
+        return std::make_unique<StaticRequestHandler>(server, ping_response_expression);
+    };
+    auto ping_handler = std::make_shared<HandlingRuleHTTPHandlerFactory<StaticRequestHandler>>(std::move(ping_creator));
     ping_handler->attachStrictPath("/ping");
     ping_handler->allowGetAndHeadRequest();
     factory.addPathToHints("/ping");
@@ -167,7 +175,11 @@ void addDefaultHandlersFactory(
 {
     addCommonDefaultHandlersFactory(factory, server);
 
-    auto query_handler = std::make_shared<HandlingRuleHTTPHandlerFactory<DynamicQueryHandler>>(server, "query");
+    auto dynamic_creator = [&server] () -> std::unique_ptr<DynamicQueryHandler>
+    {
+        return std::make_unique<DynamicQueryHandler>(server, "query");
+    };
+    auto query_handler = std::make_shared<HandlingRuleHTTPHandlerFactory<DynamicQueryHandler>>(std::move(dynamic_creator));
     query_handler->allowPostAndGetParamsAndOptionsRequest();
     factory.addHandler(query_handler);
 
@@ -175,8 +187,12 @@ void addDefaultHandlersFactory(
     /// Otherwise it will be created separately, see createHandlerFactory(...).
     if (config.has("prometheus") && config.getInt("prometheus.port", 0) == 0)
     {
-        auto prometheus_handler = std::make_shared<HandlingRuleHTTPHandlerFactory<PrometheusRequestHandler>>(
-            server, PrometheusMetricsWriter(config, "prometheus", async_metrics));
+        PrometheusMetricsWriter writer(config, "prometheus", async_metrics);
+        auto creator = [&server, writer] () -> std::unique_ptr<PrometheusRequestHandler>
+        {
+            return std::make_unique<PrometheusRequestHandler>(server, writer);
+        };
+        auto prometheus_handler = std::make_shared<HandlingRuleHTTPHandlerFactory<PrometheusRequestHandler>>(std::move(creator));
         prometheus_handler->attachStrictPath(config.getString("prometheus.endpoint", "/metrics"));
         prometheus_handler->allowGetAndHeadRequest();
         factory.addHandler(prometheus_handler);

--- a/src/Server/HTTPHandlerFactory.h
+++ b/src/Server/HTTPHandlerFactory.h
@@ -25,17 +25,16 @@ class HandlingRuleHTTPHandlerFactory : public HTTPRequestHandlerFactory
 public:
     using Filter = std::function<bool(const HTTPServerRequest &)>;
 
-    template <typename... TArgs>
-    explicit HandlingRuleHTTPHandlerFactory(TArgs &&... args)
+    using Creator = std::function<std::unique_ptr<TEndpoint>()>;
+    explicit HandlingRuleHTTPHandlerFactory(Creator && creator_)
+        : creator(std::move(creator_))
+    {}
+
+    explicit HandlingRuleHTTPHandlerFactory(IServer & server)
     {
-        creator = [my_args = std::tuple<TArgs...>(std::forward<TArgs>(args) ...)]()
-        {
-            return std::apply([&](auto && ... endpoint_args)
-            {
-                return std::make_unique<TEndpoint>(std::forward<decltype(endpoint_args)>(endpoint_args)...);
-            }, std::move(my_args));
-        };
+        creator = [&server]() -> std::unique_ptr<TEndpoint> { return std::make_unique<TEndpoint>(server); };
     }
+
 
     void addFilter(Filter cur_filter)
     {

--- a/src/Server/PrometheusRequestHandler.cpp
+++ b/src/Server/PrometheusRequestHandler.cpp
@@ -47,25 +47,31 @@ createPrometheusHandlerFactory(IServer & server,
     AsynchronousMetrics & async_metrics,
     const std::string & config_prefix)
 {
-    auto factory = std::make_shared<HandlingRuleHTTPHandlerFactory<PrometheusRequestHandler>>(
-        server, PrometheusMetricsWriter(config, config_prefix + ".handler", async_metrics));
+    PrometheusMetricsWriter writer(config, config_prefix + ".handler", async_metrics);
+    auto creator = [&server, writer]() -> std::unique_ptr<PrometheusRequestHandler>
+    {
+        return std::make_unique<PrometheusRequestHandler>(server, writer);
+    };
+
+    auto factory = std::make_shared<HandlingRuleHTTPHandlerFactory<PrometheusRequestHandler>>(std::move(creator));
     factory->addFiltersFromConfig(config, config_prefix);
     return factory;
 }
 
-HTTPRequestHandlerFactoryPtr
-createPrometheusMainHandlerFactory(IServer & server,
-    const Poco::Util::AbstractConfiguration & config,
-    AsynchronousMetrics & async_metrics,
-    const std::string & name)
+HTTPRequestHandlerFactoryPtr createPrometheusMainHandlerFactory(
+    IServer & server, const Poco::Util::AbstractConfiguration & config, AsynchronousMetrics & async_metrics, const std::string & name)
 {
     auto factory = std::make_shared<HTTPRequestHandlerFactoryMain>(name);
-    auto handler = std::make_shared<HandlingRuleHTTPHandlerFactory<PrometheusRequestHandler>>(
-        server, PrometheusMetricsWriter(config, "prometheus", async_metrics));
+    PrometheusMetricsWriter writer(config, "prometheus", async_metrics);
+    auto creator = [&server, writer]() -> std::unique_ptr<PrometheusRequestHandler>
+    {
+        return std::make_unique<PrometheusRequestHandler>(server, writer);
+    };
+
+    auto handler = std::make_shared<HandlingRuleHTTPHandlerFactory<PrometheusRequestHandler>>(std::move(creator));
     handler->attachStrictPath(config.getString("prometheus.endpoint", "/metrics"));
     handler->allowGetAndHeadRequest();
     factory->addHandler(handler);
     return factory;
 }
-
 }

--- a/src/Server/StaticRequestHandler.cpp
+++ b/src/Server/StaticRequestHandler.cpp
@@ -168,8 +168,13 @@ HTTPRequestHandlerFactoryPtr createStaticHandlerFactory(IServer & server,
     int status = config.getInt(config_prefix + ".handler.status", 200);
     std::string response_content = config.getRawString(config_prefix + ".handler.response_content", "Ok.\n");
     std::string response_content_type = config.getString(config_prefix + ".handler.content_type", "text/plain; charset=UTF-8");
-    auto factory = std::make_shared<HandlingRuleHTTPHandlerFactory<StaticRequestHandler>>(
-        server, std::move(response_content), std::move(status), std::move(response_content_type));
+
+    auto creator = [&server, response_content, status, response_content_type]() -> std::unique_ptr<StaticRequestHandler>
+    {
+        return std::make_unique<StaticRequestHandler>(server, response_content, status, response_content_type);
+    };
+
+    auto factory = std::make_shared<HandlingRuleHTTPHandlerFactory<StaticRequestHandler>>(std::move(creator));
 
     factory->addFiltersFromConfig(config, config_prefix);
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

The source of issue which was discovered by @thevar1able is in this constructor:

```(c++)
    template <typename... TArgs>
    explicit HandlingRuleHTTPHandlerFactory(TArgs &&... args)
    {
        creator = [my_args = std::tuple<TArgs...>(std::forward<TArgs>(args) ...)]()
        {
            return std::apply([&](auto && ... endpoint_args)
            {
                return std::make_unique<TEndpoint>(std::forward<decltype(endpoint_args)>(endpoint_args)...);
            }, std::move(my_args));
        };
    }
```
The code looks really smart, unfortunately it doesn't work properly when you want to pass object in constructor by value. Code like 
```
FactoryPtr createFactory(std::shared_ptr<MyLovelyArg> my_arg)
{
    auto factory = std::make_shared<HandlingRuleHTTPHandlerFactory<SomeRandomHandler>>(my_arg);
    return factory;
}
```
will lead to quite obscure segfault without any compilation errors. In case of value-argument `TArgs &&... args` will be deduced as reference to temporary `shared_ptr` and `creator` lambda will capture reference to temporary object. In contrast, when you use `std::move(my_arg)` object type will be deduced as just `shared_ptr` and segfault will be avoided. That is why there are so many `std::move` arguments for this factory (not for real moves, just for proper capture in lambda). 

The code was more convenient to use, unfortunately error-prone, related example https://github.com/ClickHouse/ClickHouse/pull/37902. 

The minimal repro is here https://pastila.nl/?00c7c5cb/286a703b4d644f43c557c68a7f04593a#vkSRIoLQ2lQdeIslY5ZjTw==.