### PR TITLE
Fix SIGSEGV in MergeSortingPartialResultTransform (due to zero chunks after remerge())

### DIFF
--- a/src/Processors/Transforms/MergeSortingPartialResultTransform.cpp
+++ b/src/Processors/Transforms/MergeSortingPartialResultTransform.cpp
@@ -21,13 +21,14 @@ PartialResultTransform::ShaphotResult MergeSortingPartialResultTransform::getRea
 
     /// Sort all input data
     merge_sorting_transform->remerge();
-    /// Add a copy of the first `partial_result_limit` rows to a generated_chunk
-    /// to send it later as a partial result in the next prepare stage of the current processor
-    auto generated_columns = merge_sorting_transform->chunks[0].cloneEmptyColumns();
 
     /// It's possible that we had only empty chunks before remerge
     if (merge_sorting_transform->chunks.empty())
         return {{}, SnaphotStatus::NotReady};
+
+    /// Add a copy of the first `partial_result_limit` rows to a generated_chunk
+    /// to send it later as a partial result in the next prepare stage of the current processor
+    auto generated_columns = merge_sorting_transform->chunks[0].cloneEmptyColumns();
 
     size_t total_rows = 0;
     for (const auto & merged_chunk : merge_sorting_transform->chunks)

--- a/tests/queries/0_stateless/02894_MergeSortingPartialResultTransform_empty_block.sql
+++ b/tests/queries/0_stateless/02894_MergeSortingPartialResultTransform_empty_block.sql
@@ -1,0 +1,11 @@
+drop table if exists data;
+create table data (key Int) engine=MergeTree() order by key;
+insert into data select * from numbers(1);
+insert into data select * from numbers(1);
+system stop merges data;
+-- need sleep to trigger partial results to uncover the bug with empty chunk after remerge due to empty array join, i.e.:
+--
+--   MergeSortingTransform: Re-merging intermediate ORDER BY data (1 blocks with 0 rows) to save memory consumption
+--   MergeSortingTransform: Memory usage is lowered from 4.26 KiB to 0.00 B
+--
+select key, sleepEachRow(1) from data array join [] as x order by key settings optimize_read_in_order=0, allow_experimental_partial_result=1, partial_result_update_duration_ms=1, max_threads=1, max_execution_time=0, max_block_size=1;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix SIGSEGV in MergeSortingPartialResultTransform (due to zero chunks after remerge())

It is possible to have non zero input chunks before remerge() and zero after:

    2023.10.08 10:21:20.944928 [ 4321 ] {427df456-1400-4fbe-8bd7-c4de139f00ca} <Debug> MergeSortingTransform: Re-merging intermediate ORDER BY data (1 blocks with 0 rows) to save memory consumption
    2023.10.08 10:36:16.447001 [ 14466 ] {} <Fatal> BaseDaemon: (version 23.10.1.1, build id: 3E53B6B3A53FD562F44C88703BD88EB713881A44, git hash: 5ddfb170a1096cf88664b1a4b9b7bd2e7ef36c29) (from thread 4321) (query_id: 427df456-1400-4fbe-8bd7-c4de139f00ca) (query: SELECT CounterID FROM test.visits ARRAY JOIN Goals.ID WHERE CounterID = 942285 ORDER BY CounterID

CI: https://s3.amazonaws.com/clickhouse-test-reports/55276/099665478df3e77d1df0332dd705ca7209e903af/stress_test__debug_.html
Fixes: https://github.com/ClickHouse/ClickHouse/pull/48607