### PR TITLE
Fix data-race in CreatingSetsTransform (on errors) due to throwing shared exception

### DIFF
--- a/tests/analyzer_integration_broken_tests.txt
+++ b/tests/analyzer_integration_broken_tests.txt
@@ -91,3 +91,4 @@ test_zookeeper_config/test.py::test_chroot_with_different_root
 test_zookeeper_config/test.py::test_chroot_with_same_root
 test_merge_tree_azure_blob_storage/test.py::test_table_manipulations
 test_parallel_replicas_skip_shards/test.py::test_skip_unavailable_shards
+test_build_sets_from_multiple_threads/test.py::test_set

--- a/tests/integration/test_build_sets_from_multiple_threads/configs/users_overrides.xml
+++ b/tests/integration/test_build_sets_from_multiple_threads/configs/users_overrides.xml
@@ -1,0 +1,7 @@
+<clickhouse>
+    <profiles>
+        <default>
+            <max_execution_time>3</max_execution_time>
+        </default>
+    </profiles>
+</clickhouse>

--- a/tests/integration/test_build_sets_from_multiple_threads/test.py
+++ b/tests/integration/test_build_sets_from_multiple_threads/test.py
@@ -1,0 +1,70 @@
+# pylint: disable=unused-argument
+# pylint: disable=redefined-outer-name
+# pylint: disable=line-too-long
+
+from helpers.cluster import ClickHouseCluster
+from helpers.client import QueryRuntimeException
+import pytest
+
+cluster = ClickHouseCluster(__file__)
+node = cluster.add_instance("node", user_configs=["configs/users_overrides.xml"])
+
+
+@pytest.fixture(scope="module", autouse=True)
+def start_cluster():
+    try:
+        cluster.start()
+        yield
+    finally:
+        cluster.shutdown()
+
+
+# See https://github.com/ClickHouse/ClickHouse/issues/55279
+def test_set():
+    node.query(
+        """
+    CREATE TABLE 02581_trips (id UInt32, description String, id2 UInt32) ENGINE = MergeTree PRIMARY KEY id ORDER BY id;
+    INSERT INTO 02581_trips SELECT number, '', number FROM numbers(1);
+    INSERT INTO 02581_trips SELECT number, '', number FROM numbers(1);
+    INSERT INTO 02581_trips SELECT number, '', number FROM numbers(1);
+    INSERT INTO 02581_trips SELECT number, '', number FROM numbers(1);
+    INSERT INTO 02581_trips SELECT number, '', number FROM numbers(1);
+    INSERT INTO 02581_trips SELECT number, '', number FROM numbers(1);
+    INSERT INTO 02581_trips SELECT number, '', number FROM numbers(1);
+    INSERT INTO 02581_trips SELECT number, '', number FROM numbers(1);
+    INSERT INTO 02581_trips SELECT number, '', number FROM numbers(1);
+    INSERT INTO 02581_trips SELECT number, '', number FROM numbers(1);
+    INSERT INTO 02581_trips SELECT number, '', number FROM numbers(1);
+    INSERT INTO 02581_trips SELECT number, '', number FROM numbers(1);
+    INSERT INTO 02581_trips SELECT number, '', number FROM numbers(1);
+    INSERT INTO 02581_trips SELECT number, '', number FROM numbers(1);
+    INSERT INTO 02581_trips SELECT number, '', number FROM numbers(1);
+    INSERT INTO 02581_trips SELECT number, '', number FROM numbers(1);
+    INSERT INTO 02581_trips SELECT number, '', number FROM numbers(1);
+    INSERT INTO 02581_trips SELECT number, '', number FROM numbers(1);
+    INSERT INTO 02581_trips SELECT number, '', number FROM numbers(1);
+    INSERT INTO 02581_trips SELECT number, '', number FROM numbers(1);
+    INSERT INTO 02581_trips SELECT number, '', number FROM numbers(1);
+    INSERT INTO 02581_trips SELECT number, '', number FROM numbers(1);
+    INSERT INTO 02581_trips SELECT number, '', number FROM numbers(1);
+    INSERT INTO 02581_trips SELECT number, '', number FROM numbers(1);
+    INSERT INTO 02581_trips SELECT number, '', number FROM numbers(1);
+    INSERT INTO 02581_trips SELECT number, '', number FROM numbers(1);
+    INSERT INTO 02581_trips SELECT number, '', number FROM numbers(1);
+    INSERT INTO 02581_trips SELECT number, '', number FROM numbers(1);
+    INSERT INTO 02581_trips SELECT number, '', number FROM numbers(1);
+    INSERT INTO 02581_trips SELECT number, '', number FROM numbers(1);
+    INSERT INTO 02581_trips SELECT number, '', number FROM numbers(1);
+    INSERT INTO 02581_trips SELECT number, '', number FROM numbers(1);
+    INSERT INTO 02581_trips SELECT number, '', number FROM numbers(1);
+    INSERT INTO 02581_trips SELECT number, '', number FROM numbers(1);
+    INSERT INTO 02581_trips SELECT number, '', number FROM numbers(1);
+    """
+    )
+    with pytest.raises(
+        QueryRuntimeException,
+        match="Exception happened during execution of mutation",
+    ):
+        node.query(
+            "ALTER TABLE `02581_trips` UPDATE description = 'a' WHERE id IN (SELECT CAST(number * 10, 'UInt32') FROM numbers(10e9)) SETTINGS mutations_sync = 2"
+        )


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix data-race in CreatingSetsTransform (on errors) due to throwing shared exception

<details>

<summary>TSan report</summary>

```
WARNING: ThreadSanitizer: data race (pid=3436)
  Read of size 1 at 0x7b50001b07a7 by thread T187:
    0 std::__1::basic_string<>::__is_long[abi:v15000] const build_docker/./contrib/llvm-project/libcxx/include/string:1499:33 (clickhouse-tsan+0x1faa29ff) (BuildId: f978f51991d62a36512b8fc6952335a82292896f)
    1 std::__1::basic_string<>::size[abi:v15000]() const build_docker/./contrib/llvm-project/libcxx/include/string:968:17 (clickhouse-tsan+0x1faa29ff)
    2 std::__1::basic_string<>::empty[abi:v15000]() const build_docker/./contrib/llvm-project/libcxx/include/string:996:42 (clickhouse-tsan+0x1faa29ff)
    3 Poco::Exception::extendedMessage() build_docker/./base/poco/Foundation/src/Exception.cpp:114:13 (clickhouse-tsan+0x1faa29ff)
    4 DB::Exception::addMessage() <null> (clickhouse-tsan+0x7e0d5f1) (BuildId: f978f51991d62a36512b8fc6952335a82292896f)
    5 DB::executeJob(DB::ExecutingGraph::Node*, DB::ReadProgressCallback*) build_docker/./src/Processors/Executors/ExecutionThreadContext.cpp:70:23 (clickhouse-tsan+0x1b3f2fed) (BuildId: f978f51991d62a36512b8fc6952335a82292896f)
    6 DB::ExecutionThreadContext::executeTask() build_docker/./src/Processors/Executors/ExecutionThreadContext.cpp:95:9 (clickhouse-tsan+0x1b3f2fed)
    7 DB::PipelineExecutor::executeStepImpl(unsigned long, std::__1::atomic<bool>*) build_docker/./src/Processors/Executors/PipelineExecutor.cpp:273:26 (clickhouse-tsan+0x1b3e5a10) (BuildId: f978f51991d62a36512b8fc6952335a82292896f)
    8 DB::PipelineExecutor::executeSingleThread(unsigned long) build_docker/./src/Processors/Executors/PipelineExecutor.cpp:239:5 (clickhouse-tsan+0x1b3e4bb8) (BuildId: f978f51991d62a36512b8fc6952335a82292896f)
    9 DB::PipelineExecutor::executeImpl(unsigned long, bool) build_docker/./src/Processors/Executors/PipelineExecutor.cpp:399:9 (clickhouse-tsan+0x1b3e4bb8)
    10 DB::PipelineExecutor::execute(unsigned long, bool) build_docker/./src/Processors/Executors/PipelineExecutor.cpp:111:9 (clickhouse-tsan+0x1b3e48be) (BuildId: f978f51991d62a36512b8fc6952335a82292896f)
    11 DB::CompletedPipelineExecutor::execute() build_docker/./src/Processors/Executors/CompletedPipelineExecutor.cpp:110:18 (clickhouse-tsan+0x1b3e31c8) (BuildId: f978f51991d62a36512b8fc6952335a82292896f)
    12 DB::FutureSetFromSubquery::buildOrderedSetInplace(std::__1::shared_ptr<DB::Context const> const&) build_docker/./src/Interpreters/PreparedSets.cpp:202:14 (clickhouse-tsan+0x19a58396) (BuildId: f978f51991d62a36512b8fc6952335a82292896f)

  Previous write of size 8 at 0x7b50001b07a0 by thread T192:
    0 std::__1::basic_string<>::__set_long_cap[abi:v15000](unsigned long) build_docker/./contrib/llvm-project/libcxx/include/string:1592:37 (clickhouse-tsan+0x238809e2) (BuildId: f978f51991d62a36512b8fc6952335a82292896f)
    1 std::__1::basic_string<>::__grow_by_and_replace(unsigned long, unsigned long, unsigned long, unsigned long, unsigned long, unsigned long, char const*) build_docker/./contrib/llvm-project/libcxx/include/string:2367:5 (clickhouse-tsan+0x238809e2)
    2 std::__1::basic_string<>::append(char const*, unsigned long) build_docker/./contrib/llvm-project/libcxx/include/string:2692:9 (clickhouse-tsan+0x238809e2)
    3 std::__1::basic_string<>::append(char const*) build_docker/./contrib/llvm-project/libcxx/include/string:2849:12 (clickhouse-tsan+0x1faa2a58) (BuildId: f978f51991d62a36512b8fc6952335a82292896f)
    4 Poco::Exception::extendedMessage() build_docker/./base/poco/Foundation/src/Exception.cpp:114:27 (clickhouse-tsan+0x1faa2a58)
    5 DB::Exception::addMessage() <null> (clickhouse-tsan+0x7e0d5f1) (BuildId: f978f51991d62a36512b8fc6952335a82292896f)
    6 DB::executeJob(DB::ExecutingGraph::Node*, DB::ReadProgressCallback*) build_docker/./src/Processors/Executors/ExecutionThreadContext.cpp:70:23 (clickhouse-tsan+0x1b3f2fed) (BuildId: f978f51991d62a36512b8fc6952335a82292896f)
    7 DB::ExecutionThreadContext::executeTask() build_docker/./src/Processors/Executors/ExecutionThreadContext.cpp:95:9 (clickhouse-tsan+0x1b3f2fed)
    8 DB::PipelineExecutor::executeStepImpl(unsigned long, std::__1::atomic<bool>*) build_docker/./src/Processors/Executors/PipelineExecutor.cpp:273:26 (clickhouse-tsan+0x1b3e5a10) (BuildId: f978f51991d62a36512b8fc6952335a82292896f)
    9 DB::PipelineExecutor::executeSingleThread(unsigned long) build_docker/./src/Processors/Executors/PipelineExecutor.cpp:239:5 (clickhouse-tsan+0x1b3e4bb8) (BuildId: f978f51991d62a36512b8fc6952335a82292896f)
    10 DB::PipelineExecutor::executeImpl(unsigned long, bool) build_docker/./src/Processors/Executors/PipelineExecutor.cpp:399:9 (clickhouse-tsan+0x1b3e4bb8)
    11 DB::PipelineExecutor::execute(unsigned long, bool) build_docker/./src/Processors/Executors/PipelineExecutor.cpp:111:9 (clickhouse-tsan+0x1b3e48be) (BuildId: f978f51991d62a36512b8fc6952335a82292896f)
    12 DB::CompletedPipelineExecutor::execute() build_docker/./src/Processors/Executors/CompletedPipelineExecutor.cpp:110:18 (clickhouse-tsan+0x1b3e31c8) (BuildId: f978f51991d62a36512b8fc6952335a82292896f)
    13 DB::FutureSetFromSubquery::buildOrderedSetInplace(std::__1::shared_ptr<DB::Context const> const&) build_docker/./src/Interpreters/PreparedSets.cpp:202:14 (clickhouse-tsan+0x19a58396) (BuildId: f978f51991d62a36512b8fc6952335a82292896f)

  Location is heap block of size 480 at 0x7b50001b0600 allocated by thread T193:
    0 posix_memalign <null> (clickhouse-tsan+0x7d6ac85) (BuildId: f978f51991d62a36512b8fc6952335a82292896f)
    1 std::__1::__libcpp_aligned_alloc[abi:v15000](unsigned long, unsigned long) build_docker/./contrib/llvm-project/libcxxabi/../libcxx/include/new:328:9 (clickhouse-tsan+0x238b5a05) (BuildId: f978f51991d62a36512b8fc6952335a82292896f)
    2 __cxxabiv1::__aligned_malloc_with_fallback(unsigned long) build_docker/./contrib/llvm-project/libcxxabi/src/fallback_malloc.cpp:215:20 (clickhouse-tsan+0x238b5a05)
    3 __cxa_allocate_exception build_docker/./contrib/llvm-project/libcxxabi/src/cxa_exception.cpp:190:17 (clickhouse-tsan+0x238b31e5) (BuildId: f978f51991d62a36512b8fc6952335a82292896f)
    4 std::exception_ptr std::make_exception_ptr[abi:v15000]<DB::Exception>(DB::Exception) build_docker/./contrib/llvm-project/libcxx/include/exception:206:9 (clickhouse-tsan+0x144bfa8a) (BuildId: f978f51991d62a36512b8fc6952335a82292896f)
    5 DB::CreatingSetsTransform::~CreatingSetsTransform() build_docker/./src/Processors/Transforms/CreatingSetsTransform.cpp:30:45 (clickhouse-tsan+0x1b7603c3) (BuildId: f978f51991d62a36512b8fc6952335a82292896f)
    ...
    35 DB::FutureSetFromSubquery::buildOrderedSetInplace(std::__1::shared_ptr<DB::Context const> const&) build_docker/./src/Interpreters/PreparedSets.cpp:211:1 (clickhouse-tsan+0x19a58608) (BuildId: f978f51991d62a36512b8fc6952335a82292896f)
```

</details>

Introduced-in: https://github.com/ClickHouse/ClickHouse/pull/46835 (cc @davenger )
Fixes: https://github.com/ClickHouse/ClickHouse/issues/55279