### PR TITLE
Fix bad test `01605_dictinct_two_level`

### DIFF
--- a/tests/queries/0_stateless/01605_dictinct_two_level.reference
+++ b/tests/queries/0_stateless/01605_dictinct_two_level.reference
@@ -8,13 +8,13 @@
 ['7']
 ['8']
 ['9']
-test.com	['foo3223','foo6455','foo382','foo5566','foo1037']
-test.com0	['foo0']
-test.com0.0001	['foo1']
-test.com0.0002	['foo2']
-test.com0.0003	['foo3']
-test.com0.0004	['foo4']
-test.com0.0005	['foo5']
-test.com0.0006	['foo6']
-test.com0.0007	['foo7']
-test.com0.0008	['foo8']
+test.com	5
+test.com0	1
+test.com0.0001	1
+test.com0.0002	1
+test.com0.0003	1
+test.com0.0004	1
+test.com0.0005	1
+test.com0.0006	1
+test.com0.0007	1
+test.com0.0008	1

--- a/tests/queries/0_stateless/01605_dictinct_two_level.sql
+++ b/tests/queries/0_stateless/01605_dictinct_two_level.sql
@@ -5,21 +5,21 @@ SELECT groupArray(DISTINCT toString(number % 10)) FROM numbers_mt(50000)
     GROUP BY number ORDER BY number LIMIT 10
     SETTINGS max_threads = 2, max_block_size = 2000;
 
-DROP TABLE IF EXISTS dictinct_two_level;
+DROP TABLE IF EXISTS distinct_two_level;
 
-CREATE TABLE dictinct_two_level (
+CREATE TABLE distinct_two_level (
     time DateTime64(3),
     domain String,
     subdomain String
 ) ENGINE = MergeTree ORDER BY time;
 
-INSERT INTO dictinct_two_level SELECT 1546300800000, 'test.com', concat('foo', toString(number % 10000)) from numbers(10000);
-INSERT INTO dictinct_two_level SELECT 1546300800000, concat('test.com', toString(number / 10000)) , concat('foo', toString(number % 10000)) from numbers(10000);
+INSERT INTO distinct_two_level SELECT 1546300800000, 'test.com', concat('foo', toString(number % 10000)) from numbers(10000);
+INSERT INTO distinct_two_level SELECT 1546300800000, concat('test.com', toString(number / 10000)) , concat('foo', toString(number % 10000)) from numbers(10000);
 
 SELECT
-    domain, groupArraySample(5, 11111)(DISTINCT subdomain) AS example_subdomains
-FROM dictinct_two_level
+    domain, arrayUniq(groupArraySample(5, 11111)(DISTINCT subdomain)) AS example_subdomains
+FROM distinct_two_level
 GROUP BY domain ORDER BY domain, example_subdomains
 LIMIT 10;
 
-DROP TABLE IF EXISTS dictinct_two_level;
+DROP TABLE IF EXISTS distinct_two_level;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


https://s3.amazonaws.com/clickhouse-test-reports/0/9ac7cfc026cb8d7cf1ab48c0f4b12c656f52fe15/stateless_tests__release__s3_storage__[2_2].html