### PR TITLE
Fix test_max_rows_to_read_leaf_with_view flakiness (due to prefer_localhost_replica)

### DIFF
--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -365,8 +365,8 @@ class IColumn;
     M(UInt64, max_bytes_to_read, 0, "Limit on read bytes (after decompression) from the most 'deep' sources. That is, only in the deepest subquery. When reading from a remote server, it is only checked on a remote server.", 0) \
     M(OverflowMode, read_overflow_mode, OverflowMode::THROW, "What to do when the limit is exceeded.", 0) \
     \
-    M(UInt64, max_rows_to_read_leaf, 0, "Limit on read rows on the leaf nodes for distributed queries. Limit is applied for local reads only excluding the final merge stage on the root node.", 0) \
-    M(UInt64, max_bytes_to_read_leaf, 0, "Limit on read bytes (after decompression) on the leaf nodes for distributed queries. Limit is applied for local reads only excluding the final merge stage on the root node.", 0) \
+    M(UInt64, max_rows_to_read_leaf, 0, "Limit on read rows on the leaf nodes for distributed queries. Limit is applied for local reads only excluding the final merge stage on the root node. Note, the setting is unstable with prefer_localhost_replica=1.", 0) \
+    M(UInt64, max_bytes_to_read_leaf, 0, "Limit on read bytes (after decompression) on the leaf nodes for distributed queries. Limit is applied for local reads only excluding the final merge stage on the root node. Note, the setting is unstable with prefer_localhost_replica=1.", 0) \
     M(OverflowMode, read_overflow_mode_leaf, OverflowMode::THROW, "What to do when the leaf limit is exceeded.", 0) \
     \
     M(UInt64, max_rows_to_group_by, 0, "If aggregation during GROUP BY is generating more than specified number of rows (unique GROUP BY keys), the behavior will be determined by the 'group_by_overflow_mode' which by default is - throw an exception, but can be also switched to an approximate GROUP BY mode.", 0) \

--- a/tests/integration/test_max_rows_to_read_leaf_with_view/test.py
+++ b/tests/integration/test_max_rows_to_read_leaf_with_view/test.py
@@ -55,7 +55,7 @@ def test_max_rows_to_read_leaf_via_view(started_cluster):
     """
     assert (
         node1.query(
-            "SELECT count() from test_view SETTINGS max_rows_to_read_leaf=200"
+            "SELECT count() from test_view SETTINGS max_rows_to_read_leaf=200, prefer_localhost_replica=0"
         ).rstrip()
         == "400"
     )
@@ -66,7 +66,9 @@ def test_max_rows_to_read_leaf_via_view(started_cluster):
         node2.query(
             "INSERT INTO local_table (id) select * from system.numbers limit 10"
         )
-        node2.query("SELECT count() from test_view SETTINGS max_rows_to_read_leaf=200")
+        node2.query(
+            "SELECT count() from test_view SETTINGS max_rows_to_read_leaf=200, prefer_localhost_replica=0"
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`max_rows_to_read_leaf` is unstable without `prefer_localhost_replica` - https://github.com/ClickHouse/ClickHouse/pull/14221#issuecomment-719921673

CI: https://s3.amazonaws.com/clickhouse-test-reports/0/186bd9c85974f641a70581a704a43ebdb6d302a8/integration_tests__asan__analyzer__[4_6]/integration_run_parallel1_0.log

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Cc: @hagen1778