### PR TITLE
Fix leak in StorageHDFS

### DIFF
--- a/src/Storages/HDFS/StorageHDFS.cpp
+++ b/src/Storages/HDFS/StorageHDFS.cpp
@@ -226,6 +226,13 @@ namespace
         auto res = LSWithRegexpMatching("/", fs, path_from_uri);
         return res;
     }
+
+    struct HDFSFileInfoDeleter
+    {
+        /// Can have only one entry (see hdfsGetPathInfo())
+        void operator()(hdfsFileInfo * info) { hdfsFreeFileInfo(info, 1); }
+    };
+    using HDFSFileInfoPtr = std::unique_ptr<hdfsFileInfo, HDFSFileInfoDeleter>;
 }
 
 StorageHDFS::StorageHDFS(
@@ -459,7 +466,7 @@ public:
     StorageHDFS::PathWithInfo next()
     {
         String uri;
-        hdfsFileInfo * hdfs_info;
+        HDFSFileInfoPtr hdfs_info;
         do
         {
             size_t current_index = index.fetch_add(1);
@@ -468,7 +475,7 @@ public:
 
             uri = uris[current_index];
             auto path_and_uri = getPathFromUriAndUriWithoutPath(uri);
-            hdfs_info = hdfsGetPathInfo(fs.get(), path_and_uri.first.c_str());
+            hdfs_info.reset(hdfsGetPathInfo(fs.get(), path_and_uri.first.c_str()));
         }
         /// Skip non-existed files.
         while (!hdfs_info && String(hdfsGetLastError()).find("FileNotFoundException") != std::string::npos);
@@ -554,7 +561,7 @@ bool HDFSSource::initialize()
         {
             auto builder = createHDFSBuilder(uri_without_path + "/", getContext()->getGlobalContext()->getConfigRef());
             auto fs = createHDFSFS(builder.get());
-            auto * hdfs_info = hdfsGetPathInfo(fs.get(), path_from_uri.c_str());
+            HDFSFileInfoPtr hdfs_info(hdfsGetPathInfo(fs.get(), path_from_uri.c_str()));
             if (hdfs_info)
                 path_with_info.info = StorageHDFS::PathInfo{hdfs_info->mLastMod, static_cast<size_t>(hdfs_info->mSize)};
         }
@@ -1026,7 +1033,7 @@ std::optional<ColumnsDescription> StorageHDFS::tryGetColumnsFromCache(
 
             auto builder = createHDFSBuilder(uri_without_path + "/", ctx->getGlobalContext()->getConfigRef());
             auto fs = createHDFSFS(builder.get());
-            auto * hdfs_info = hdfsGetPathInfo(fs.get(), path_with_info.path.c_str());
+            HDFSFileInfoPtr hdfs_info(hdfsGetPathInfo(fs.get(), path_with_info.path.c_str()));
             if (hdfs_info)
                 return hdfs_info->mLastMod;
 


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix leak in StorageHDFS

LSan report:

    Direct leak of 400 byte(s) in 5 object(s) allocated from:
        0 0x564c44d5308d in operator new[](unsigned long) (/usr/bin/clickhouse+0xbdf908d) (BuildId: 9bd2befe9c5f1d960238405d4a3fc9860273b81a)
        1 0x564c7b1b83f2 in hdfsGetPathInfo build_docker/./contrib/libhdfs3/src/client/Hdfs.cpp:1096:18
        2 0x564c670a8fed in DB::HDFSSource::URISIterator::Impl::next() build_docker/./src/Storages/HDFS/StorageHDFS.cpp:471:25
        3 0x564c670a54e9 in DB::HDFSSource::URISIterator::next() build_docker/./src/Storages/HDFS/StorageHDFS.cpp:510:19

CI: https://s3.amazonaws.com/clickhouse-test-reports/55261/de503f75dcbc5a4d0e7fbb2e6b08c2106d62848a/integration_tests__asan__[3_6].html
