### PR TITLE
add internal_replication to system clusters table

### DIFF
--- a/src/Storages/System/StorageSystemClusters.cpp
+++ b/src/Storages/System/StorageSystemClusters.cpp
@@ -16,6 +16,7 @@ NamesAndTypesList StorageSystemClusters::getNamesAndTypes()
         {"cluster", std::make_shared<DataTypeString>()},
         {"shard_num", std::make_shared<DataTypeUInt32>()},
         {"shard_weight", std::make_shared<DataTypeUInt32>()},
+        {"internal_replication.", std::make_shared<DataTypeUInt8>()},
         {"replica_num", std::make_shared<DataTypeUInt32>()},
         {"host_name", std::make_shared<DataTypeString>()},
         {"host_address", std::make_shared<DataTypeString>()},
@@ -80,6 +81,7 @@ void StorageSystemClusters::writeCluster(MutableColumns & res_columns, const Nam
             res_columns[i++]->insert(cluster_name);
             res_columns[i++]->insert(shard_info.shard_num);
             res_columns[i++]->insert(shard_info.weight);
+            res_columns[i++]->insert(shard_info.has_internal_replication);
             res_columns[i++]->insert(replica_index + 1);
             res_columns[i++]->insert(address.host_name);
             auto resolved = address.getResolvedAddress();

--- a/src/Storages/System/StorageSystemClusters.cpp
+++ b/src/Storages/System/StorageSystemClusters.cpp
@@ -16,7 +16,7 @@ NamesAndTypesList StorageSystemClusters::getNamesAndTypes()
         {"cluster", std::make_shared<DataTypeString>()},
         {"shard_num", std::make_shared<DataTypeUInt32>()},
         {"shard_weight", std::make_shared<DataTypeUInt32>()},
-        {"internal_replication.", std::make_shared<DataTypeUInt8>()},
+        {"internal_replication", std::make_shared<DataTypeUInt8>()},
         {"replica_num", std::make_shared<DataTypeUInt32>()},
         {"host_name", std::make_shared<DataTypeString>()},
         {"host_address", std::make_shared<DataTypeString>()},


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Now /etc/clickhouse-server/cluster.xml contains internal_replication:
```
<remote-servers>
        <*****>
            <shard>
                <weight>100</weight>
                <internal_replication>true</internal_replication>
                <replica>
```
Unfortunately, internal_replication has not been added to the system clusters table.

```
:) select * from system.clusters \G;

SELECT *
FROM system.clusters

Query id: 3f64378e-2a8f-4843-8a00-be2f79b0c65e

Row 1:
──────
cluster:                 *****
shard_num:               1
shard_weight:            100
replica_num:             1
host_name:               *****
host_address:            *****
port:                    9440
is_local:                1
user:                    default
default_database:        
errors_count:            0
slowdowns_count:         0
estimated_recovery_time: 0
database_shard_name:     
database_replica_name:   
is_active:               ᴺᵁᴸᴸ

1 row in set. Elapsed: 0.002 sec. 
```

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
