### PR TITLE
Fix data-race in web disk

### DIFF
--- a/src/IO/SeekableReadBuffer.h
+++ b/src/IO/SeekableReadBuffer.h
@@ -44,6 +44,10 @@ public:
 
     virtual String getInfoForLog() { return ""; }
 
+    /// NOTE: This method should be thread-safe against seek(), since it can be
+    /// used in CachedOnDiskReadBufferFromFile from multiple threads (because
+    /// it first releases the buffer, and then do logging, and so other thread
+    /// can already call seek() which will lead to data-race).
     virtual size_t getFileOffsetOfBufferEnd() const { throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Method getFileOffsetOfBufferEnd() not implemented"); }
 
     /// If true, setReadUntilPosition() guarantees that eof will be reported at the given position.


### PR DESCRIPTION
TSan report:

    WARNING: ThreadSanitizer: data race (pid=8)
     Write of size 8 at 0x7b54002b0400 by thread T310:
       0 DB::ReadBufferFromWebServer::seek(long, int) build_docker/./src/Disks/IO/ReadBufferFromWebServer.cpp:159:12 (clickhouse+0x18a6a45b) (BuildId: cb41845e0edd51bbbf1abf7c1716e74d12491aae)
       1 DB::CachedOnDiskReadBufferFromFile::getImplementationBuffer(DB::FileSegment&) build_docker/./src/Disks/IO/CachedOnDiskReadBufferFromFile.cpp:471:47 (clickhouse+0x17f1aace) (BuildId: cb41845e0edd51bbbf1abf7c1716e74d12491aae)
       2 DB::CachedOnDiskReadBufferFromFile::nextImplStep() build_docker/./src/Disks/IO/CachedOnDiskReadBufferFromFile.cpp:844:33 (clickhouse+0x17f1f5af) (BuildId: cb41845e0edd51bbbf1abf7c1716e74d12491aae)
       3 DB::CachedOnDiskReadBufferFromFile::nextImpl() build_docker/./src/Disks/IO/CachedOnDiskReadBufferFromFile.cpp:774:16 (clickhouse+0x17f1f33a) (BuildId: cb41845e0edd51bbbf1abf7c1716e74d12491aae)
       4 DB::ReadBuffer::next() build_docker/./src/IO/ReadBuffer.h:70:20 (clickhouse+0x17f1307f) (BuildId: cb41845e0edd51bbbf1abf7c1716e74d12491aae)
       5 DB::ReadBufferFromRemoteFSGather::readImpl() build_docker/./src/Disks/IO/ReadBufferFromRemoteFSGather.cpp:188:32 (clickhouse+0x17f1307f)
       6 DB::ReadBufferFromRemoteFSGather::nextImpl() build_docker/./src/Disks/IO/ReadBufferFromRemoteFSGather.cpp:160:9 (clickhouse+0x17f12f89) (BuildId: cb41845e0edd51bbbf1abf7c1716e74d12491aae)
       7 DB::ReadBuffer::next() build_docker/./src/IO/ReadBuffer.h:70:20 (clickhouse+0x17d695ca) (BuildId: cb41845e0edd51bbbf1abf7c1716e74d12491aae)
       8 DB::ThreadPoolRemoteFSReader::execute(DB::IAsynchronousReader::Request) build_docker/./src/Disks/IO/ThreadPoolRemoteFSReader.cpp:95:25 (clickhouse+0x17d695ca)
       9 DB::ThreadPoolRemoteFSReader::submit(DB::IAsynchronousReader::Request)::$_0::operator()() const build_docker/./src/Disks/IO/ThreadPoolRemoteFSReader.cpp:70:80 (clickhouse+0x17d6ab48) (BuildId: cb41845e0edd51bbbf1abf7c1716e74d12491aae)

     Previous read of size 8 at 0x7b54002b0400 by thread T297:
       0 DB::ReadBufferFromWebServer::getFileOffsetOfBufferEnd() const build_docker/./src/Disks/IO/ReadBufferFromWebServer.h:36:63 (clickhouse+0x18a6ac9d) (BuildId: cb41845e0edd51bbbf1abf7c1716e74d12491aae)
       1 DB::CachedOnDiskReadBufferFromFile::getInfoForLog() build_docker/./src/Disks/IO/CachedOnDiskReadBufferFromFile.cpp:1223:71 (clickhouse+0x17f24835) (BuildId: cb41845e0edd51bbbf1abf7c1716e74d12491aae)
       2 DB::CachedOnDiskReadBufferFromFile::nextImplStep()::$_0::operator()() const build_docker/./src/Disks/IO/CachedOnDiskReadBufferFromFile.cpp:799:5 (clickhouse+0x17f2347c) (BuildId: cb41845e0edd51bbbf1abf7c1716e74d12491aae)
       3 BasicScopeGuard<DB::CachedOnDiskReadBufferFromFile::nextImplStep()::$_0>::invoke() build_docker/./base/base/../base/scope_guard.h:99:9 (clickhouse+0x17f2347c)
       4 BasicScopeGuard<DB::CachedOnDiskReadBufferFromFile::nextImplStep()::$_0>::~BasicScopeGuard() build_docker/./base/base/../base/scope_guard.h:48:26 (clickhouse+0x17f2347c)
       5 DB::CachedOnDiskReadBufferFromFile::nextImplStep() build_docker/./src/Disks/IO/CachedOnDiskReadBufferFromFile.cpp:1071:1 (clickhouse+0x17f22480) (BuildId: cb41845e0edd51bbbf1abf7c1716e74d12491aae)
       6 DB::CachedOnDiskReadBufferFromFile::nextImpl() build_docker/./src/Disks/IO/CachedOnDiskReadBufferFromFile.cpp:774:16 (clickhouse+0x17f1f33a) (BuildId: cb41845e0edd51bbbf1abf7c1716e74d12491aae)
       7 DB::ReadBuffer::next() build_docker/./src/IO/ReadBuffer.h:70:20 (clickhouse+0x17f1307f) (BuildId: cb41845e0edd51bbbf1abf7c1716e74d12491aae)
       8 DB::ReadBufferFromRemoteFSGather::readImpl() build_docker/./src/Disks/IO/ReadBufferFromRemoteFSGather.cpp:188:32 (clickhouse+0x17f1307f)
       9 DB::ReadBufferFromRemoteFSGather::nextImpl() build_docker/./src/Disks/IO/ReadBufferFromRemoteFSGather.cpp:160:9 (clickhouse+0x17f12f89) (BuildId: cb41845e0edd51bbbf1abf7c1716e74d12491aae)
       10 DB::ReadBuffer::next() build_docker/./src/IO/ReadBuffer.h:70:20 (clickhouse+0x17d695ca) (BuildId: cb41845e0edd51bbbf1abf7c1716e74d12491aae)
       11 DB::ThreadPoolRemoteFSReader::execute(DB::IAsynchronousReader::Request) build_docker/./src/Disks/IO/ThreadPoolRemoteFSReader.cpp:95:25 (clickhouse+0x17d695ca)
       12 DB::ThreadPoolRemoteFSReader::submit(DB::IAsynchronousReader::Request)::$_0::operator()() const build_docker/./src/Disks/IO/ThreadPoolRemoteFSReader.cpp:70:80 (clickhouse+0x17d6ab48) (BuildId: cb41845e0edd51bbbf1abf7c1716e74d12491aae)

CI: https://s3.amazonaws.com/clickhouse-test-reports/55261/de503f75dcbc5a4d0e7fbb2e6b08c2106d62848a/integration_tests__tsan__[5_6].html

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix data-race in web disk

Cc: @kssenii 