### PR TITLE
add internal_replication to system.clusters

### DIFF
--- a/src/Storages/System/StorageSystemClusters.cpp
+++ b/src/Storages/System/StorageSystemClusters.cpp
@@ -16,6 +16,7 @@ NamesAndTypesList StorageSystemClusters::getNamesAndTypes()
         {"cluster", std::make_shared<DataTypeString>()},
         {"shard_num", std::make_shared<DataTypeUInt32>()},
         {"shard_weight", std::make_shared<DataTypeUInt32>()},
+        {"internal_replication", std::make_shared<DataTypeUInt8>()},
         {"replica_num", std::make_shared<DataTypeUInt32>()},
         {"host_name", std::make_shared<DataTypeString>()},
         {"host_address", std::make_shared<DataTypeString>()},
@@ -80,6 +81,7 @@ void StorageSystemClusters::writeCluster(MutableColumns & res_columns, const Nam
             res_columns[i++]->insert(cluster_name);
             res_columns[i++]->insert(shard_info.shard_num);
             res_columns[i++]->insert(shard_info.weight);
+            res_columns[i++]->insert(shard_info.has_internal_replication);
             res_columns[i++]->insert(replica_index + 1);
             res_columns[i++]->insert(address.host_name);
             auto resolved = address.getResolvedAddress();

--- a/tests/queries/0_stateless/01293_show_clusters.reference
+++ b/tests/queries/0_stateless/01293_show_clusters.reference
@@ -1,3 +1,3 @@
 test_shard_localhost
-test_cluster_one_shard_two_replicas	1	1	1	127.0.0.1	127.0.0.1	9000	1	default	
-test_cluster_one_shard_two_replicas	1	1	2	127.0.0.2	127.0.0.2	9000	0	default	
+test_cluster_one_shard_two_replicas	1	1	0	1	127.0.0.1	127.0.0.1	9000	1	default
+test_cluster_one_shard_two_replicas	1	1	0	2	127.0.0.2	127.0.0.2	9000	0	default

--- a/tests/queries/0_stateless/01293_show_clusters.sh
+++ b/tests/queries/0_stateless/01293_show_clusters.sh
@@ -5,6 +5,6 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CUR_DIR"/../shell_config.sh
 
 $CLICKHOUSE_CLIENT -q "show clusters like 'test_shard%' limit 1"
-# cluster,shard_num,shard_weight,replica_num,host_name,host_address,port,is_local,user,default_database[,errors_count,slowdowns_count,estimated_recovery_time]
+# cluster,shard_num,shard_weight,internal_replication,replica_num,host_name,host_address,port,is_local,user,default_database[,errors_count,slowdowns_count,estimated_recovery_time]
 # use a cluster with static IPv4
 $CLICKHOUSE_CLIENT -q "show cluster 'test_cluster_one_shard_two_replicas'" | cut -f-10

--- a/tests/queries/0_stateless/02117_show_create_table_system.reference
+++ b/tests/queries/0_stateless/02117_show_create_table_system.reference
@@ -38,6 +38,7 @@ CREATE TABLE system.clusters
     `cluster` String,
     `shard_num` UInt32,
     `shard_weight` UInt32,
+    `internal_replication` UInt8,
     `replica_num` UInt32,
     `host_name` String,
     `host_address` String,


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
add internal_replication to system.clusters


### Documentation entry for user-facing changes

Now /etc/clickhouse-server/cluster.xml contains internal_replication:
```
<remote-servers>
        <*****>
            <shard>
                <weight>100</weight>
                <internal_replication>true</internal_replication>
                <replica>
```

Unfortunately, internal_replication has not been added to the system clusters table.

```
:) select * from system.clusters \G;

SELECT *
FROM system.clusters

Query id: 3f64378e-2a8f-4843-8a00-be2f79b0c65e

Row 1:
──────
cluster:                 *****
shard_num:               1
shard_weight:            100
replica_num:             1
host_name:               *****
host_address:            *****
port:                    9440
is_local:                1
user:                    default
default_database:        
errors_count:            0
slowdowns_count:         0
estimated_recovery_time: 0
database_shard_name:     
database_replica_name:   
is_active:               ᴺᵁᴸᴸ

1 row in set. Elapsed: 0.002 sec. 
```


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
