### PR TITLE
Disable skim under TSan (Rust does not supports ThreadSanitizer)

### DIFF
--- a/rust/skim/CMakeLists.txt
+++ b/rust/skim/CMakeLists.txt
@@ -13,6 +13,13 @@ if (OS_FREEBSD)
     message(STATUS "skim is disabled for FreeBSD")
     return()
 endif()
+if (SANITIZE STREQUAL "thread")
+    # Rust does not supports Thread Sanitizer [1]
+    #
+    #   [1]: https://doc.rust-lang.org/beta/unstable-book/compiler-flags/sanitizer.html#threadsanitizer
+    message(STATUS "skim is disabled under Thread Sanitizer")
+    return()
+endif()
 
 clickhouse_import_crate(MANIFEST_PATH Cargo.toml)
 


### PR DESCRIPTION
Refs: https://doc.rust-lang.org/beta/unstable-book/compiler-flags/sanitizer.html#threadsanitizer

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)