### PR TITLE
Fix missing thread accounting for insert_distributed_sync=1

### DIFF
--- a/src/Storages/Distributed/DistributedSink.cpp
+++ b/src/Storages/Distributed/DistributedSink.cpp
@@ -553,8 +553,15 @@ void DistributedSink::onFinish()
                 {
                     if (job.executor)
                     {
-                        pool->scheduleOrThrowOnError([&job]()
+                        pool->scheduleOrThrowOnError([&job, thread_group = CurrentThread::getGroup()]()
                         {
+                            SCOPE_EXIT_SAFE(
+                                if (thread_group)
+                                    CurrentThread::detachFromGroupIfNotDetached();
+                            );
+                            if (thread_group)
+                                CurrentThread::attachToGroupIfDetached(thread_group);
+
                             job.executor->finish();
                         });
                     }

--- a/tests/queries/0_stateless/02895_peak_memory_usage_http_headers_regression.sh
+++ b/tests/queries/0_stateless/02895_peak_memory_usage_http_headers_regression.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+$CLICKHOUSE_CLIENT -nm -q "
+DROP TABLE IF EXISTS data;
+DROP TABLE IF EXISTS data2;
+DROP VIEW IF EXISTS mv1;
+
+CREATE TABLE data (key Int32) ENGINE = Null;
+CREATE TABLE data2 (key Int32) ENGINE = Null;
+CREATE MATERIALIZED VIEW mv1 TO data2 AS SELECT * FROM data;
+"
+
+${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}" -d @- <<< "INSERT INTO FUNCTION remote('127.{1,2}', $CLICKHOUSE_DATABASE, data, rand()) SELECT * FROM numbers(1e5)"


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix missing thread accounting for insert_distributed_sync=1

I found this when I was looking at the same problem to (https://github.com/ClickHouse/ClickHouse/issues/55280), and there is also a test that without (https://github.com/ClickHouse/ClickHouse/pull/55336) leads to SIGSEGV.