### PR TITLE
Improve tests for untuple()

### DIFF
--- a/tests/queries/0_stateless/02890_untuple_column_names.reference
+++ b/tests/queries/0_stateless/02890_untuple_column_names.reference
@@ -1,30 +1,66 @@
 -- tuple element alias
-tupleElement(CAST(tuple(1), \'Tuple(a Int)\'), 1)	tupleElement(CAST(tuple(\'s\'), \'Tuple(a String)\'), 1)
-1	s
-tupleElement(CAST(tuple(1), \'Tuple(a Int)\'), \'a\')	tupleElement(CAST(tuple(\'s\'), \'Tuple(a String)\'), \'a\')
-1	s
--- tuple element alias, untuple() alias
-x.a	y.a
-1	s
-x.a	y.a
-1	s
+Row 1:
+──────
+tupleElement(CAST(tuple(1), 'Tuple(a Int)'), 1):      1
+tupleElement(CAST(tuple('s'), 'Tuple(a String)'), 1): s
+Row 1:
+──────
+tupleElement(CAST(tuple(1), 'Tuple(a Int)'), 'a'):      1
+tupleElement(CAST(tuple('s'), 'Tuple(a String)'), 'a'): s
+Row 1:
+──────
+tupleElement(CAST(tuple(1), 'Tuple(a Int)'), 'a'): 1
+tupleElement(CAST(tuple(1), 'Tuple(a Int)'), 'a'): 1
+-- tuple element alias + untuple() alias
+Row 1:
+──────
+x.a: 1
+y.a: s
+Row 1:
+──────
+x.a: 1
+y.a: s
+Row 1:
+──────
+x.a: 1
+x.a: 1
 -- untuple() alias
-x.1	y.1
-1	s
-x.1	y.1
-1	s
+Row 1:
+──────
+x.1: 1
+y.1: s
+Row 1:
+──────
+x.1: 1
+y.1: s
+Row 1:
+──────
+x.1: 1
+x.1: 1
 -- no aliases
-tupleElement(CAST(tuple(1), \'Tuple(Int)\'), 1)	tupleElement(CAST(tuple(\'s\'), \'Tuple(String)\'), 1)
-1	s
-tupleElement(CAST(tuple(1), \'Tuple(Int)\'), \'1\')	tupleElement(CAST(tuple(\'s\'), \'Tuple(String)\'), \'1\')
-1	s
+Row 1:
+──────
+tupleElement(CAST(tuple(1), 'Tuple(Int)'), 1):      1
+tupleElement(CAST(tuple('s'), 'Tuple(String)'), 1): s
+Row 1:
+──────
+tupleElement(CAST(tuple(1), 'Tuple(Int)'), '1'):      1
+tupleElement(CAST(tuple('s'), 'Tuple(String)'), '1'): s
+Row 1:
+──────
+tupleElement(CAST(tuple(1), 'Tuple(Int)'), '1'): 1
+tupleElement(CAST(tuple(1), 'Tuple(Int)'), '1'): 1
 -- tuple() loses the column names (would be good to fix, see #36773)
-t.1
-1
-t.1
-1
+Row 1:
+──────
+t.1: 1
+Row 1:
+──────
+t.1: 1
 -- thankfully JSONExtract() keeps them
-x.key
-value
-x.key
-value
+Row 1:
+──────
+x.key: value
+Row 1:
+──────
+x.key: value

--- a/tests/queries/0_stateless/02890_untuple_column_names.sql
+++ b/tests/queries/0_stateless/02890_untuple_column_names.sql
@@ -1,28 +1,45 @@
--- If the untuple() function has an alias, and the tuple element has an explicit name,
--- we want to use it to generate the resulting column name. Check all permutations of
--- aliases. Also use different tuple types to check that we don't generate different
--- columns with the same name (see #26179).
+-- If the untuple() function has an alias, and if the tuple element has an explicit name, we want to use it to
+-- generate the resulting column name.
+-- Check all combinations of tuple element alias and untuple() alias. Also to avoid that we generate the same
+-- result column names and confuse query analysis (see #26179), test also two untuple() calls in one SElECT
+-- with the same types and aliases.
 
 SELECT '-- tuple element alias';
-SELECT untuple(tuple(1)::Tuple(a Int)), untuple(tuple('s')::Tuple(a String)) FORMAT TSVWithNames SETTINGS allow_experimental_analyzer = 0;
-SELECT untuple(tuple(1)::Tuple(a Int)), untuple(tuple('s')::Tuple(a String)) FORMAT TSVWithNames SETTINGS allow_experimental_analyzer = 1;
 
-SELECT '-- tuple element alias, untuple() alias';
-SELECT untuple(tuple(1)::Tuple(a Int)) x, untuple(tuple('s')::Tuple(a String)) y FORMAT TSVWithNames SETTINGS allow_experimental_analyzer = 0;
-SELECT untuple(tuple(1)::Tuple(a Int)) x, untuple(tuple('s')::Tuple(a String)) y FORMAT TSVWithNames SETTINGS allow_experimental_analyzer = 1;
+SELECT untuple(tuple(1)::Tuple(a Int)), untuple(tuple('s')::Tuple(a String)) FORMAT Vertical SETTINGS allow_experimental_analyzer = 0;
+SELECT untuple(tuple(1)::Tuple(a Int)), untuple(tuple('s')::Tuple(a String)) FORMAT Vertical SETTINGS allow_experimental_analyzer = 1;
+
+SELECT untuple(tuple(1)::Tuple(a Int)), untuple(tuple(1)::Tuple(a Int)) FORMAT Vertical SETTINGS allow_experimental_analyzer = 0; -- { serverError DUPLICATE_COLUMN }
+SELECT untuple(tuple(1)::Tuple(a Int)), untuple(tuple(1)::Tuple(a Int)) FORMAT Vertical SETTINGS allow_experimental_analyzer = 1; -- Bug: doesn't throw an exception
+
+SELECT '-- tuple element alias + untuple() alias';
+
+SELECT untuple(tuple(1)::Tuple(a Int)) x, untuple(tuple('s')::Tuple(a String)) y FORMAT Vertical SETTINGS allow_experimental_analyzer = 0;
+SELECT untuple(tuple(1)::Tuple(a Int)) x, untuple(tuple('s')::Tuple(a String)) y FORMAT Vertical SETTINGS allow_experimental_analyzer = 1;
+
+SELECT untuple(tuple(1)::Tuple(a Int)) x, untuple(tuple(1)::Tuple(a Int)) x FORMAT Vertical SETTINGS allow_experimental_analyzer = 0; -- { serverError DUPLICATE_COLUMN }
+SELECT untuple(tuple(1)::Tuple(a Int)) x, untuple(tuple(1)::Tuple(a Int)) x FORMAT Vertical SETTINGS allow_experimental_analyzer = 1; -- Bug: doesn't throw an exception
 
 SELECT '-- untuple() alias';
-SELECT untuple(tuple(1)::Tuple(Int)) x, untuple(tuple('s')::Tuple(String)) y FORMAT TSVWithNames SETTINGS allow_experimental_analyzer = 0;
-SELECT untuple(tuple(1)::Tuple(Int)) x, untuple(tuple('s')::Tuple(String)) y FORMAT TSVWithNames SETTINGS allow_experimental_analyzer = 1;
+
+SELECT untuple(tuple(1)::Tuple(Int)) x, untuple(tuple('s')::Tuple(String)) y FORMAT Vertical SETTINGS allow_experimental_analyzer = 0;
+SELECT untuple(tuple(1)::Tuple(Int)) x, untuple(tuple('s')::Tuple(String)) y FORMAT Vertical SETTINGS allow_experimental_analyzer = 1;
+
+SELECT untuple(tuple(1)::Tuple(Int)) x, untuple(tuple(1)::Tuple(Int)) x FORMAT Vertical SETTINGS allow_experimental_analyzer = 0; -- { serverError DUPLICATE_COLUMN }
+SELECT untuple(tuple(1)::Tuple(Int)) x, untuple(tuple(1)::Tuple(Int)) x FORMAT Vertical SETTINGS allow_experimental_analyzer = 1; -- Bug: doesn't throw an exception
 
 SELECT '-- no aliases';
-SELECT untuple(tuple(1)::Tuple(Int)), untuple(tuple('s')::Tuple(String)) FORMAT TSVWithNames SETTINGS allow_experimental_analyzer = 0;
-SELECT untuple(tuple(1)::Tuple(Int)), untuple(tuple('s')::Tuple(String)) FORMAT TSVWithNames SETTINGS allow_experimental_analyzer = 1;
+
+SELECT untuple(tuple(1)::Tuple(Int)), untuple(tuple('s')::Tuple(String)) FORMAT Vertical SETTINGS allow_experimental_analyzer = 0;
+SELECT untuple(tuple(1)::Tuple(Int)), untuple(tuple('s')::Tuple(String)) FORMAT Vertical SETTINGS allow_experimental_analyzer = 1;
+
+SELECT untuple(tuple(1)::Tuple(Int)), untuple(tuple(1)::Tuple(Int)) FORMAT Vertical SETTINGS allow_experimental_analyzer = 0; -- { serverError DUPLICATE_COLUMN }
+SELECT untuple(tuple(1)::Tuple(Int)), untuple(tuple(1)::Tuple(Int)) FORMAT Vertical SETTINGS allow_experimental_analyzer = 1; -- Bug: doesn't throw an exception
 
 SELECT '-- tuple() loses the column names (would be good to fix, see #36773)';
-SELECT untuple(tuple(1 as a)) as t FORMAT TSVWithNames SETTINGS allow_experimental_analyzer = 0;
-SELECT untuple(tuple(1 as a)) as t FORMAT TSVWithNames SETTINGS allow_experimental_analyzer = 1;
+SELECT untuple(tuple(1 as a)) as t FORMAT Vertical SETTINGS allow_experimental_analyzer = 0;
+SELECT untuple(tuple(1 as a)) as t FORMAT Vertical SETTINGS allow_experimental_analyzer = 1;
 
 SELECT '-- thankfully JSONExtract() keeps them';
-SELECT untuple(JSONExtract('{"key": "value"}', 'Tuple(key String)')) x FORMAT TSVWithNames SETTINGS allow_experimental_analyzer = 0;
-SELECT untuple(JSONExtract('{"key": "value"}', 'Tuple(key String)')) x FORMAT TSVWithNames SETTINGS allow_experimental_analyzer = 1;
+SELECT untuple(JSONExtract('{"key": "value"}', 'Tuple(key String)')) x FORMAT Vertical SETTINGS allow_experimental_analyzer = 0;
+SELECT untuple(JSONExtract('{"key": "value"}', 'Tuple(key String)')) x FORMAT Vertical SETTINGS allow_experimental_analyzer = 1;


### PR DESCRIPTION
This is follow-up for #55123

We now check more carefully that no bad things can happen like in #24404 when `untuple()` generates the same column names. This also identified a bug with analyzer = 1 which existed already before #55123 (I'll open an issue separately).

EDIT: #55426

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
