### PR TITLE
Fix MySQL interface boolean representation

### DIFF
--- a/src/Core/MySQL/PacketsProtocolBinary.cpp
+++ b/src/Core/MySQL/PacketsProtocolBinary.cpp
@@ -50,10 +50,7 @@ ResultSetRow::ResultSetRow(const Serializations & serializations_, const DataTyp
                 payload_size += 1;
                 break;
             case TypeIndex::UInt8:
-                if (data_type->getName() == "Bool")
-                    payload_size += 2; // BIT MySQL type is string<lenenc> in binary
-                else
-                    payload_size += 1;
+                payload_size += 1;
                 break;
             case TypeIndex::Int16:
             case TypeIndex::UInt16:
@@ -168,8 +165,6 @@ void ResultSetRow::writePayloadImpl(WriteBuffer & buffer) const
             }
             case TypeIndex::UInt8: {
                 UInt8 value = assert_cast<const ColumnVector<UInt8> &>(*col).getData()[row_num];
-                if (data_type->getName() == "Bool")
-                    buffer.write(static_cast<char>(1));
                 buffer.write(reinterpret_cast<char *>(&value), 1);
                 break;
             }

--- a/src/Core/MySQL/PacketsProtocolText.cpp
+++ b/src/Core/MySQL/PacketsProtocolText.cpp
@@ -146,15 +146,8 @@ ColumnDefinition getColumnDefinition(const String & column_name, const DataTypeP
     switch (type_index)
     {
         case TypeIndex::UInt8:
-            if (normalized_data_type->getName() == "Bool")
-            {
-                column_type = ColumnType::MYSQL_TYPE_BIT;
-            }
-            else
-            {
-                column_type = ColumnType::MYSQL_TYPE_TINY;
-                flags = ColumnDefinitionFlags::BINARY_FLAG | ColumnDefinitionFlags::UNSIGNED_FLAG;
-            }
+            column_type = ColumnType::MYSQL_TYPE_TINY;
+            flags = ColumnDefinitionFlags::BINARY_FLAG | ColumnDefinitionFlags::UNSIGNED_FLAG;
             break;
         case TypeIndex::UInt16:
             column_type = ColumnType::MYSQL_TYPE_SHORT;

--- a/tests/integration/test_mysql_protocol/prepared_statements.reference
+++ b/tests/integration/test_mysql_protocol/prepared_statements.reference
@@ -14,7 +14,7 @@ ui128 type is CHAR, value: 15324355
 ui256 type is CHAR, value: 41345135123432
 f32 type is FLOAT, value: -0.796896
 f64 type is DOUBLE, value: -0.113259
-b type is BIT, value: true
+b type is TINYINT, value: true
 Row #2
 i8 type is TINYINT, value: 127
 i16 type is SMALLINT, value: 32767
@@ -30,7 +30,7 @@ ui128 type is CHAR, value: 340282366920938463463374607431768211455
 ui256 type is CHAR, value: 115792089237316195423570985008687907853269984665640564039457584007913129639935
 f32 type is FLOAT, value: 1.234000
 f64 type is DOUBLE, value: 3.352451
-b type is BIT, value: false
+b type is TINYINT, value: false
 
 ### testStringTypes
 Row #1


### PR DESCRIPTION
Resolves https://github.com/ClickHouse/ClickHouse/issues/37999


This PR fixes incorrect `Boolean` type serialization in MySQL interface with text protocol (`COM_QUERY`). Now it should correctly provide the expected `0` or `1` instead of strings `true` and `false`. 

Additionally, as it introduced [some problems](https://github.com/ClickHouse/ClickHouse/issues/55310), the reported type for Booleans was reverted from `BIT` to `TINYINT` for both text and binary protocols (`COM_QUERY` / `COM_STMT_EXECUTE`).


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed incorrect `Boolean` type serialization in MySQL interface with text protocol (`COM_QUERY`). Now it should correctly provide the expected `0` or `1` instead of strings `true` and `false`. Additionally, the reported type for a `Boolean` column was reverted from `BIT` to `TINYINT` for both text and binary protocols (`COM_QUERY` / `COM_STMT_EXECUTE`).