### PR TITLE
Remove existing moving/ dir if allow_remove_stale_moving_parts is off

### DIFF
--- a/src/Storages/MergeTree/MergeTreePartsMover.cpp
+++ b/src/Storages/MergeTree/MergeTreePartsMover.cpp
@@ -236,7 +236,7 @@ MergeTreePartsMover::TemporaryClonedPart MergeTreePartsMover::clonePart(const Me
                     part->name, part->getDataPartStorage().getDiskName(), disk->getName(),
                     fullPath(disk, path_to_clone + relative_path));
 
-            LOG_WARNING(log, "Path {} already exists. Will remove it and clone again",
+            LOG_DEBUG(log, "Path {} already exists. Will remove it and clone again",
                 fullPath(disk, path_to_clone + relative_path));
             disk->removeRecursive(fs::path(path_to_clone) / relative_path / "");
         }

--- a/src/Storages/MergeTree/MergeTreePartsMover.cpp
+++ b/src/Storages/MergeTree/MergeTreePartsMover.cpp
@@ -236,7 +236,7 @@ MergeTreePartsMover::TemporaryClonedPart MergeTreePartsMover::clonePart(const Me
                     part->name, part->getDataPartStorage().getDiskName(), disk->getName(),
                     fullPath(disk, path_to_clone + relative_path));
 
-            LOG_DEBUG(log, "Path {} already exists. Will remove it and clone again.",
+            LOG_WARNING(log, "Path {} already exists. Will remove it and clone again",
                 fullPath(disk, path_to_clone + relative_path));
             disk->removeRecursive(fs::path(path_to_clone) / relative_path / "");
         }

--- a/src/Storages/MergeTree/MergeTreePartsMover.cpp
+++ b/src/Storages/MergeTree/MergeTreePartsMover.cpp
@@ -229,10 +229,16 @@ MergeTreePartsMover::TemporaryClonedPart MergeTreePartsMover::clonePart(const Me
         String relative_path = part->getDataPartStorage().getPartDirectory();
         if (disk->exists(path_to_clone + relative_path))
         {
-            throw Exception(ErrorCodes::DIRECTORY_ALREADY_EXISTS,
-                "Cannot clone part {} from '{}' to '{}': path '{}' already exists",
-                part->name, part->getDataPartStorage().getDiskName(), disk->getName(),
+            // If setting is on, we should've already cleaned moving/ dir on startup
+            if (data->allowRemoveStaleMovingParts())
+                throw Exception(ErrorCodes::DIRECTORY_ALREADY_EXISTS,
+                    "Cannot clone part {} from '{}' to '{}': path '{}' already exists",
+                    part->name, part->getDataPartStorage().getDiskName(), disk->getName(),
+                    fullPath(disk, path_to_clone + relative_path));
+
+            LOG_DEBUG(log, "Path {} already exists. Will remove it and clone again.",
                 fullPath(disk, path_to_clone + relative_path));
+            disk->removeRecursive(fs::path(path_to_clone) / relative_path / "");
         }
 
         disk->createDirectories(path_to_clone);


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Bring back 22.8 behavior (remove old dir instead of exception) if allow_remove_stale_moving_parts is off.

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)


As moving/ dir still exists for some parts even with the setting turned on (so garbage isn't cleaned on startup), it's reasonable to get back old behavior.