### PR TITLE
Fix stack symbolizer parsing DW_FORM_ref_addr incorrectly and sometimes crashing

### DIFF
--- a/src/Common/Dwarf.cpp
+++ b/src/Common/Dwarf.cpp
@@ -971,6 +971,50 @@ Dwarf::Die Dwarf::getDieAtOffset(const CompilationUnit & cu, uint64_t offset) co
     return die;
 }
 
+std::optional<std::pair<std::optional<Dwarf::CompilationUnit>, uint64_t>> Dwarf::getReferenceAttribute(
+    const CompilationUnit & cu, const Die & die, uint64_t attr_name) const
+{
+    bool found = false;
+    uint64_t value;
+    uint64_t form;
+    forEachAttribute(cu, die, [&](const Attribute & attr)
+    {
+        if (attr.spec.name == attr_name)
+        {
+            found = true;
+            value = std::get<uint64_t>(attr.attr_value);
+            form = attr.spec.form;
+            return false;
+        }
+        return true;
+    });
+    if (!found)
+        return std::nullopt;
+    switch (form)
+    {
+        case DW_FORM_ref1:
+        case DW_FORM_ref2:
+        case DW_FORM_ref4:
+        case DW_FORM_ref8:
+        case DW_FORM_ref_udata:
+            return std::make_pair(std::nullopt, cu.offset + value);
+
+        case DW_FORM_ref_addr:
+            return std::make_pair(findCompilationUnit(value), value);
+
+        case DW_FORM_ref_sig8:
+            /// Currently we don't use this parser for types, so no need to support this.
+            throw Exception(ErrorCodes::CANNOT_PARSE_DWARF, "Type signatures are not supported (DIE at 0x{:x}, attr 0x{:x}).", die.offset, attr_name);
+
+        case DW_FORM_ref_sup4:
+        case DW_FORM_ref_sup8:
+            throw Exception(ErrorCodes::CANNOT_PARSE_DWARF, "Supplementary object files are not supported (DIE at 0x{:x}, attr 0x{:x}).", die.offset, attr_name);
+
+        default:
+            throw Exception(ErrorCodes::CANNOT_PARSE_DWARF, "Unexpected form of attribute 0x{:x}: 0x{:x} (DIE at 0x{:x}).", attr_name, form, die.offset);
+    }
+}
+
 /**
  * Find the @locationInfo for @address in the compilation unit represented
  * by the @sp .debug_info entry.
@@ -1300,50 +1344,23 @@ void Dwarf::findInlinedSubroutineDieForAddress(
         location.file = line_vm.getFullFileName(*call_file);
         location.line = *call_line;
 
-        /// Something wrong with receiving debug info about inline.
-        /// If set to true we stop parsing DWARF.
-        bool die_for_inline_broken = false;
-
         auto get_function_name = [&](const CompilationUnit & srcu, uint64_t die_offset)
         {
-            Die decl_die = getDieAtOffset(srcu, die_offset);
-            auto & die_to_look_for_name = decl_die;
+            Die die_to_look_for_name = getDieAtOffset(srcu, die_offset);
 
-            Die def_die;
             // Jump to the actual function definition instead of declaration for name
             // and line info.
             // DW_AT_specification: Incomplete, non-defining, or separate declaration
             // corresponding to a declaration
-            auto offset = getAttribute<uint64_t>(srcu, decl_die, DW_AT_specification);
-            if (offset)
+            auto def = getReferenceAttribute(srcu, die_to_look_for_name, DW_AT_specification);
+            if (def.has_value())
             {
-                /// FIXME: actually it's a bug in our DWARF parser.
-                ///
-                /// Most of the times compilation unit offset (srcu.offset) is some big number inside .debug_info (like 434782255).
-                /// Offset of DIE definition is some small relative number to srcu.offset (like 3518).
-                /// However in some unknown cases offset looks like global, non relative number (like 434672579) and in this
-                /// case we obviously doing something wrong parsing DWARF.
-                ///
-                /// What is important -- this bug? reproduces only with -flto=thin in release mode.
-                /// Also llvm-dwarfdump --verify ./clickhouse says that our DWARF is ok, so it's another prove
-                /// that we just doing something wrong.
-                ///
-                /// FIXME: Currently we just give up parsing DWARF for inlines when we got into this situation.
-                if (srcu.offset + offset.value() >= info_.size())
-                {
-                    die_for_inline_broken = true;
-                }
-                else
-                {
-                    def_die = getDieAtOffset(srcu, srcu.offset + offset.value());
-                    die_to_look_for_name = def_die;
-                }
+                auto [def_cu, def_offset] = std::move(def.value());
+                const CompilationUnit & def_cu_ref = def_cu.has_value() ? def_cu.value() : srcu;
+                die_to_look_for_name = getDieAtOffset(def_cu_ref, def_offset);
             }
 
             std::string_view name;
-
-            if (die_for_inline_broken)
-                return name;
 
             // The file and line will be set in the next inline subroutine based on
             // its DW_AT_call_file and DW_AT_call_line.
@@ -1385,10 +1402,6 @@ void Dwarf::findInlinedSubroutineDieForAddress(
         location.name = (*abstract_origin_ref_type != DW_FORM_ref_addr)
             ? get_function_name(cu, cu.offset + *abstract_origin)
             : get_function_name(findCompilationUnit(*abstract_origin), *abstract_origin);
-
-        /// FIXME: see comment above
-        if (die_for_inline_broken)
-            return false;
 
         locations.push_back(location);
 

--- a/src/Common/Dwarf.h
+++ b/src/Common/Dwarf.h
@@ -453,22 +453,11 @@ private:
     // Finds the Compilation Unit starting at offset.
     CompilationUnit findCompilationUnit(uint64_t targetOffset) const;
 
-
-    template <class T>
-    std::optional<T> getAttribute(const CompilationUnit & cu, const Die & die, uint64_t attr_name) const
-    {
-        std::optional<T> result;
-        forEachAttribute(cu, die, [&](const Attribute & attr)
-        {
-            if (attr.spec.name == attr_name)
-            {
-                result = std::get<T>(attr.attr_value);
-                return false;
-            }
-            return true;
-        });
-        return result;
-    }
+    // Parses an attribute of "reference" form class, i.e. a reference to another DIE.
+    // Returns the unit containing the target DIE (nullopt if it's in the same unit as the source DIE)
+    // and the offset of the target DIE (relative to .debug_info, not to unit).
+    std::optional<std::pair<std::optional<CompilationUnit>, uint64_t>> getReferenceAttribute(
+        const CompilationUnit & cu, const Die & die, uint64_t attr_name) const;
 
     // Check if the given address is in the range list at the given offset in .debug_ranges.
     bool isAddrInRangeList(


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
 * Fixed clickhouse sometimes crashing with uncaught CANNOT_PARSE_DWARF exception (e.g. "invalid section offset") when symbolizing stack trace, e.g. when receiving SIGTSTP.

Closes https://github.com/ClickHouse/ClickHouse/issues/49010 , https://github.com/ClickHouse/ClickHouse/issues/55387

(If you're not familiar with DWARF, there's a one-paragraph intro in https://github.com/ClickHouse/ClickHouse/pull/55450/files , search for "Quick background")

The attribute DW_AT_specification is a *reference*, i.e. an offset of another Debug Information Entry. Depending on the attribute's *form*, it's either an offset relative to the current unit or an absolute offset relative to the whole `.debug_info` section. (See the spec https://dwarfstd.org/doc/DWARF5.pdf page 217, "There are four types of reference", and page 210 to confirm that DW_AT_specification is indeed a "reference" in this sense.)

It looks like the author of `Common/Dwarf.cpp` didn't know about absolute offsets. The code doesn't check the form of the attribute and always treats it as relative to the unit. For absolute offsets, this produces garbage entry offset, which sometimes leads to reading garbage data, throwing an exception, and crashing.