### PR TITLE
Add get_all_children_number command to keeper-client

### DIFF
--- a/docs/en/operations/utilities/clickhouse-keeper-client.md
+++ b/docs/en/operations/utilities/clickhouse-keeper-client.md
@@ -55,6 +55,7 @@ keeper foo bar
 -   `rmr <path>` -- Recursively deletes path. Confirmation required
 -   `flwc <command>` -- Executes four-letter-word command
 -   `help` -- Prints this message
+-   `get_all_children_number [path]` -- Returns the total number of znode nodes for all children
 -   `get_stat [path]` -- Returns the node's stat (default `.`)
 -   `find_super_nodes <threshold> [path]` -- Finds nodes with number of children larger than some threshold for the given path (default `.`)
 -   `delete_stale_backups` -- Deletes ClickHouse nodes used for backups that are now inactive

--- a/docs/en/operations/utilities/clickhouse-keeper-client.md
+++ b/docs/en/operations/utilities/clickhouse-keeper-client.md
@@ -55,7 +55,7 @@ keeper foo bar
 -   `rmr <path>` -- Recursively deletes path. Confirmation required
 -   `flwc <command>` -- Executes four-letter-word command
 -   `help` -- Prints this message
--   `get_all_children_number [path]` -- Returns the total number of znode nodes for all children
+-   `get_all_children_number [path]` -- Get all numbers of children nodes under a specific path
 -   `get_stat [path]` -- Returns the node's stat (default `.`)
 -   `find_super_nodes <threshold> [path]` -- Finds nodes with number of children larger than some threshold for the given path (default `.`)
 -   `delete_stale_backups` -- Deletes ClickHouse nodes used for backups that are now inactive

--- a/programs/keeper-client/Commands.cpp
+++ b/programs/keeper-client/Commands.cpp
@@ -326,7 +326,6 @@ void FindBigFamily::execute(const ASTKeeperQuery * query, KeeperClient * client)
         auto children = client->zookeeper->getChildren(next_path);
         for (auto & child : children)
             child = next_path / child;
-        
         auto response = client->zookeeper->get(children);
 
         for (size_t i = 0; i < response.size(); ++i)
@@ -505,7 +504,6 @@ void GetAllChildrenNumberCommand::execute(const ASTKeeperQuery * query, KeeperCl
         auto children = client->zookeeper->getChildren(next_path);
         for (auto & child : children)
             child = next_path / child;
-
         auto response = client->zookeeper->get(children);
 
         for (size_t i = 0; i < response.size(); ++i)

--- a/programs/keeper-client/Commands.cpp
+++ b/programs/keeper-client/Commands.cpp
@@ -475,4 +475,45 @@ void FourLetterWordCommand::execute(const ASTKeeperQuery * query, KeeperClient *
     std::cout << client->executeFourLetterCommand(query->args[0].safeGet<String>()) << "\n";
 }
 
+bool GetAllChildrenNumberCommand::parse(IParser::Pos & pos, std::shared_ptr<ASTKeeperQuery> & node, Expected & expected) const
+{
+    String path;
+    if (!parseKeeperPath(pos, expected, path))
+        path = ".";
+
+    node->args.push_back(std::move(path));
+
+    return true;
+}
+
+void GetAllChildrenNumberCommand::execute(const ASTKeeperQuery * query, KeeperClient * client) const
+{
+    auto path = client->getAbsolutePath(query->args[0].safeGet<String>());
+
+    std::queue<fs::path> queue;
+    queue.push(path);
+    Coordination::Stat stat;
+    client->zookeeper->get(path, &stat);
+
+    int totalNumChildren = stat.numChildren;
+    while (!queue.empty())
+    {
+        auto next_path = queue.front();
+        queue.pop();
+
+        auto children = client->zookeeper->getChildren(next_path);
+        std::transform(children.cbegin(), children.cend(), children.begin(), [&](const String & child) { return next_path / child; });
+
+        auto response = client->zookeeper->get(children);
+
+        for (size_t i = 0; i < response.size(); ++i)
+        {
+            totalNumChildren += response[i].stat.numChildren;
+            queue.push(children[i]);
+        }
+    }
+
+    std::cout << totalNumChildren << "\n";
+}
+
 }

--- a/programs/keeper-client/Commands.cpp
+++ b/programs/keeper-client/Commands.cpp
@@ -324,8 +324,9 @@ void FindBigFamily::execute(const ASTKeeperQuery * query, KeeperClient * client)
         queue.pop();
 
         auto children = client->zookeeper->getChildren(next_path);
-        std::transform(children.cbegin(), children.cend(), children.begin(), [&](const String & child) { return next_path / child; });
-
+        for (auto & child : children)
+            child = next_path / child;
+        
         auto response = client->zookeeper->get(children);
 
         for (size_t i = 0; i < response.size(); ++i)
@@ -502,7 +503,8 @@ void GetAllChildrenNumberCommand::execute(const ASTKeeperQuery * query, KeeperCl
         queue.pop();
 
         auto children = client->zookeeper->getChildren(next_path);
-        std::transform(children.cbegin(), children.cend(), children.begin(), [&](const String & child) { return next_path / child; });
+        for (auto & child : children)
+            child = next_path / child;
 
         auto response = client->zookeeper->get(children);
 

--- a/programs/keeper-client/Commands.h
+++ b/programs/keeper-client/Commands.h
@@ -238,4 +238,18 @@ class FourLetterWordCommand : public IKeeperClientCommand
     String getHelpMessage() const override { return "{} <command> -- Executes four-letter-word command"; }
 };
 
+class GetAllChildrenNumberCommand : public IKeeperClientCommand
+{
+    String getName() const override { return "get_all_children_number"; }
+
+    bool parse(IParser::Pos & pos, std::shared_ptr<ASTKeeperQuery> & node, Expected & expected) const override;
+
+    void execute(const ASTKeeperQuery * query, KeeperClient * client) const override;
+
+    String getHelpMessage() const override
+    {
+        return "{} [path] -- Returns the total number of znode nodes for all children";
+    }
+};
+
 }

--- a/programs/keeper-client/Commands.h
+++ b/programs/keeper-client/Commands.h
@@ -248,7 +248,7 @@ class GetAllChildrenNumberCommand : public IKeeperClientCommand
 
     String getHelpMessage() const override
     {
-        return "{} [path] -- Returns the total number of znode nodes for all children";
+        return "{} [path] -- Get all numbers of children nodes under a specific path";
     }
 };
 

--- a/programs/keeper-client/KeeperClient.cpp
+++ b/programs/keeper-client/KeeperClient.cpp
@@ -2,6 +2,7 @@
 #include "Commands.h"
 #include <Client/ReplxxLineReader.h>
 #include <Client/ClientBase.h>
+#include "Common/VersionNumber.h"
 #include <Common/Config/ConfigProcessor.h>
 #include <Common/EventNotifier.h>
 #include <Common/filesystemHelpers.h>
@@ -206,6 +207,7 @@ void KeeperClient::initialize(Poco::Util::Application & /* self */)
         std::make_shared<SyncCommand>(),
         std::make_shared<HelpCommand>(),
         std::make_shared<FourLetterWordCommand>(),
+        std::make_shared<GetAllChildrenNumberCommand>(),
     });
 
     String home_path;

--- a/tests/integration/helpers/keeper_utils.py
+++ b/tests/integration/helpers/keeper_utils.py
@@ -148,7 +148,7 @@ class KeeperClient(object):
     
     def get_all_children_number(self, path: str, timeout: float = 60.0) -> str:
         return self.execute_query(f"get_all_children_number {path}", timeout)
-
+    
     def reconfig(
         self,
         joining: tp.Optional[str],

--- a/tests/integration/helpers/keeper_utils.py
+++ b/tests/integration/helpers/keeper_utils.py
@@ -145,6 +145,9 @@ class KeeperClient(object):
 
     def delete_stale_backups(self, timeout: float = 60.0) -> str:
         return self.execute_query("delete_stale_backups", timeout)
+    
+    def get_all_children_number(self, path: str, timeout: float = 60.0) -> str:
+        return self.execute_query(f"get_all_children_number {path}", timeout)
 
     def reconfig(
         self,

--- a/tests/integration/helpers/keeper_utils.py
+++ b/tests/integration/helpers/keeper_utils.py
@@ -142,13 +142,13 @@ class KeeperClient(object):
 
     def find_super_nodes(self, threshold: int, timeout: float = 60.0) -> str:
         return self.execute_query(f"find_super_nodes {threshold}", timeout)
-        
+
     def get_all_children_number(self, path: str, timeout: float = 60.0) -> str:
         return self.execute_query(f"get_all_children_number {path}", timeout)
 
     def delete_stale_backups(self, timeout: float = 60.0) -> str:
         return self.execute_query("delete_stale_backups", timeout)
-    
+
     def reconfig(
         self,
         joining: tp.Optional[str],

--- a/tests/integration/helpers/keeper_utils.py
+++ b/tests/integration/helpers/keeper_utils.py
@@ -142,12 +142,12 @@ class KeeperClient(object):
 
     def find_super_nodes(self, threshold: int, timeout: float = 60.0) -> str:
         return self.execute_query(f"find_super_nodes {threshold}", timeout)
+        
+    def get_all_children_number(self, path: str, timeout: float = 60.0) -> str:
+        return self.execute_query(f"get_all_children_number {path}", timeout)
 
     def delete_stale_backups(self, timeout: float = 60.0) -> str:
         return self.execute_query("delete_stale_backups", timeout)
-    
-    def get_all_children_number(self, path: str, timeout: float = 60.0) -> str:
-        return self.execute_query(f"get_all_children_number {path}", timeout)
     
     def reconfig(
         self,

--- a/tests/integration/test_keeper_client/test.py
+++ b/tests/integration/test_keeper_client/test.py
@@ -216,3 +216,24 @@ def test_quoted_argument_parsing(client: KeeperClient):
 
     client.execute_query(f"set '{node_path}' \"value4 with some whitespace\" 3")
     assert client.get(node_path) == "value4 with some whitespace"
+
+def test_get_all_children_number(client: KeeperClient):
+    client.touch("/test_get_all_children_number")
+    client.touch("/test_get_all_children_number/1")
+    client.touch("/test_get_all_children_number/1/1")
+    client.touch("/test_get_all_children_number/1/2")
+    client.touch("/test_get_all_children_number/1/3")
+    client.touch("/test_get_all_children_number/1/4")
+    client.touch("/test_get_all_children_number/1/5")
+    client.touch("/test_get_all_children_number/2")
+    client.touch("/test_get_all_children_number/2/1")
+    client.touch("/test_get_all_children_number/2/2")
+    client.touch("/test_get_all_children_number/2/3")
+    client.touch("/test_get_all_children_number/2/4")
+
+    response = client.get_all_children_number("/test_get_all_children_number")
+    assert response == TSV(
+        [
+            ["11"]
+        ]
+    )

--- a/tests/integration/test_keeper_client/test.py
+++ b/tests/integration/test_keeper_client/test.py
@@ -217,6 +217,7 @@ def test_quoted_argument_parsing(client: KeeperClient):
     client.execute_query(f"set '{node_path}' \"value4 with some whitespace\" 3")
     assert client.get(node_path) == "value4 with some whitespace"
 
+
 def test_get_all_children_number(client: KeeperClient):
     client.touch("/test_get_all_children_number")
     client.touch("/test_get_all_children_number/1")
@@ -232,6 +233,7 @@ def test_get_all_children_number(client: KeeperClient):
     client.touch("/test_get_all_children_number/2/4")
 
     response = client.get_all_children_number("/test_get_all_children_number")
+
     assert response == TSV(
         [
             ["11"]

--- a/tests/integration/test_keeper_client/test.py
+++ b/tests/integration/test_keeper_client/test.py
@@ -232,10 +232,4 @@ def test_get_all_children_number(client: KeeperClient):
     client.touch("/test_get_all_children_number/2/3")
     client.touch("/test_get_all_children_number/2/4")
 
-    response = client.get_all_children_number("/test_get_all_children_number")
-
-    assert response == TSV(
-        [
-            ["11"]
-        ]
-    )
+    assert client.get_all_children_number("/test_get_all_children_number") == ["11"]

--- a/tests/integration/test_keeper_client/test.py
+++ b/tests/integration/test_keeper_client/test.py
@@ -232,4 +232,4 @@ def test_get_all_children_number(client: KeeperClient):
     client.touch("/test_get_all_children_number/2/3")
     client.touch("/test_get_all_children_number/2/4")
 
-    assert client.get_all_children_number("/test_get_all_children_number") == ["11"]
+    assert client.get_all_children_number("/test_get_all_children_number") == "11"


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- New Feature

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Keeper client improvement: add get_all_children_number command that returns number of all children nodes under a specific path

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
