### PR TITLE
Minor fixes for 02882_replicated_fetch_checksums_doesnt_match.sql

### DIFF
--- a/tests/queries/0_stateless/02882_replicated_fetch_checksums_doesnt_match.sql
+++ b/tests/queries/0_stateless/02882_replicated_fetch_checksums_doesnt_match.sql
@@ -1,6 +1,6 @@
-DROP TABLE IF EXISTS r1;
-DROP TABLE IF EXISTS r2;
-DROP TABLE IF EXISTS r3;
+DROP TABLE IF EXISTS checksums_r3;
+DROP TABLE IF EXISTS checksums_r2;
+DROP TABLE IF EXISTS checksums_r1;
 
 CREATE TABLE checksums_r1 (column1 UInt32, column2 String) Engine = ReplicatedMergeTree('/tables/{database}/checksums_table', 'r1') ORDER BY tuple();
 
@@ -34,7 +34,7 @@ SELECT count() FROM checksums_r3;
 
 SYSTEM FLUSH LOGS;
 
-SELECT * FROM system.text_log WHERE event_time >= now() - 30 and level == 'Error' and message like '%CHECKSUM_DOESNT_MATCH%'and message like '%checksums_r%';
+SELECT * FROM system.text_log WHERE event_time >= now() - INTERVAL 120 SECOND and level == 'Error' and message like '%CHECKSUM_DOESNT_MATCH%' and logger_name like ('%' || currentDatabase() || '%checksums_r%');
 
 DROP TABLE IF EXISTS checksums_r3;
 DROP TABLE IF EXISTS checksums_r2;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
