### PR TITLE
Destroy fiber in case of exception in cancelBefore in AsyncTaskExecutor

### DIFF
--- a/src/Common/AsyncTaskExecutor.cpp
+++ b/src/Common/AsyncTaskExecutor.cpp
@@ -46,7 +46,15 @@ void AsyncTaskExecutor::cancel()
 {
     std::lock_guard guard(fiber_lock);
     is_cancelled = true;
-    cancelBefore();
+    try
+    {
+        cancelBefore();
+    }
+    catch (...)
+    {
+        destroyFiber();
+        throw;
+    }
     destroyFiber();
     cancelAfter();
 }

--- a/src/Common/AsyncTaskExecutor.cpp
+++ b/src/Common/AsyncTaskExecutor.cpp
@@ -1,4 +1,6 @@
 #include <Common/AsyncTaskExecutor.h>
+#include <base/scope_guard.h>
+
 
 namespace DB
 {
@@ -46,16 +48,10 @@ void AsyncTaskExecutor::cancel()
 {
     std::lock_guard guard(fiber_lock);
     is_cancelled = true;
-    try
     {
+        SCOPE_EXIT({ destroyFiber(); });
         cancelBefore();
     }
-    catch (...)
-    {
-        destroyFiber();
-        throw;
-    }
-    destroyFiber();
     cancelAfter();
 }
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix possible deadlock caused by not destroyed fiber in case of exception in async task cancellation. Closes https://github.com/ClickHouse/ClickHouse/issues/55185

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
