### PR TITLE
Fix Query Parameters not working with custom HTTP handlers

### DIFF
--- a/src/Server/HTTPHandler.cpp
+++ b/src/Server/HTTPHandler.cpp
@@ -1193,6 +1193,16 @@ bool PredefinedQueryHandler::customizeQueryParam(ContextMutablePtr context, cons
         return true;
     }
 
+    if (startsWith(key, QUERY_PARAMETER_NAME_PREFIX))
+    {
+        /// Save name and values of substitution in dictionary.
+        const String parameter_name = key.substr(strlen(QUERY_PARAMETER_NAME_PREFIX));
+
+        if (receive_params.contains(parameter_name))
+            context->setQueryParameter(parameter_name, value);
+        return true;
+    }
+
     return false;
 }
 

--- a/src/Server/HTTPHandlerFactory.cpp
+++ b/src/Server/HTTPHandlerFactory.cpp
@@ -182,13 +182,15 @@ void addDefaultHandlersFactory(
     auto query_handler = std::make_shared<HandlingRuleHTTPHandlerFactory<DynamicQueryHandler>>(std::move(dynamic_creator));
     query_handler->addFilter([](const auto & request)
         {
-            return (startsWith(request.getURI(), "/?")
-                    && (request.getMethod() == Poco::Net::HTTPRequest::HTTP_GET
-                        || request.getMethod() == Poco::Net::HTTPRequest::HTTP_HEAD))
-                || ((startsWith(request.getURI(), "/?")
-                    || request.getURI() == "/")
-                    && (request.getMethod() == Poco::Net::HTTPRequest::HTTP_OPTIONS
-                        || request.getMethod() == Poco::Net::HTTPRequest::HTTP_POST));
+            bool pathMatchesGetOrHead = startsWith(request.getURI(), "/?") || startsWith(request.getURI(), "/query?");
+            bool isGetOrHeadRequest = request.getMethod() == Poco::Net::HTTPRequest::HTTP_GET
+                                || request.getMethod() == Poco::Net::HTTPRequest::HTTP_HEAD;
+
+            bool pathMatchesPostOrOptions = pathMatchesGetOrHead || request.getURI() == "/";
+            bool isPostOrOptionsRequest = request.getMethod() == Poco::Net::HTTPRequest::HTTP_POST
+                                    || request.getMethod() == Poco::Net::HTTPRequest::HTTP_OPTIONS;
+
+            return (pathMatchesGetOrHead && isGetOrHeadRequest) || (pathMatchesPostOrOptions && isPostOrOptionsRequest);
         }
     );
     factory.addHandler(query_handler);

--- a/src/Server/HTTPHandlerFactory.cpp
+++ b/src/Server/HTTPHandlerFactory.cpp
@@ -182,15 +182,19 @@ void addDefaultHandlersFactory(
     auto query_handler = std::make_shared<HandlingRuleHTTPHandlerFactory<DynamicQueryHandler>>(std::move(dynamic_creator));
     query_handler->addFilter([](const auto & request)
         {
-            bool pathMatchesGetOrHead = startsWith(request.getURI(), "/?") || startsWith(request.getURI(), "/query?");
-            bool isGetOrHeadRequest = request.getMethod() == Poco::Net::HTTPRequest::HTTP_GET
-                                || request.getMethod() == Poco::Net::HTTPRequest::HTTP_HEAD;
+            bool path_matches_get_or_head = startsWith(request.getURI(), "?")
+                            || startsWith(request.getURI(), "/?")
+                            || startsWith(request.getURI(), "/query?");
+            bool is_get_or_head_request = request.getMethod() == Poco::Net::HTTPRequest::HTTP_GET
+                            || request.getMethod() == Poco::Net::HTTPRequest::HTTP_HEAD;
 
-            bool pathMatchesPostOrOptions = pathMatchesGetOrHead || request.getURI() == "/";
-            bool isPostOrOptionsRequest = request.getMethod() == Poco::Net::HTTPRequest::HTTP_POST
+            bool path_matches_post_or_options = path_matches_get_or_head
+                             || request.getURI() == "/"
+                             || request.getURI().empty();
+            bool is_post_or_options_request = request.getMethod() == Poco::Net::HTTPRequest::HTTP_POST
                                     || request.getMethod() == Poco::Net::HTTPRequest::HTTP_OPTIONS;
 
-            return (pathMatchesGetOrHead && isGetOrHeadRequest) || (pathMatchesPostOrOptions && isPostOrOptionsRequest);
+            return (path_matches_get_or_head && is_get_or_head_request) || (path_matches_post_or_options && is_post_or_options_request);
         }
     );
     factory.addHandler(query_handler);

--- a/src/Server/HTTPHandlerFactory.cpp
+++ b/src/Server/HTTPHandlerFactory.cpp
@@ -181,6 +181,7 @@ void addDefaultHandlersFactory(
     };
     auto query_handler = std::make_shared<HandlingRuleHTTPHandlerFactory<DynamicQueryHandler>>(std::move(dynamic_creator));
     query_handler->allowPostAndGetParamsAndOptionsRequest();
+    query_handler->attachNonStrictPath("/query");
     factory.addHandler(query_handler);
 
     /// We check that prometheus handler will be served on current (default) port.

--- a/src/Server/HTTPHandlerFactory.cpp
+++ b/src/Server/HTTPHandlerFactory.cpp
@@ -44,8 +44,6 @@ static inline auto createHandlersFactoryFromConfig(
     Poco::Util::AbstractConfiguration::Keys keys;
     config.keys(prefix, keys);
 
-    bool enable_default_handlers = false;
-
     for (const auto & key : keys)
     {
         if (key == "defaults")

--- a/src/Server/HTTPHandlerFactory.cpp
+++ b/src/Server/HTTPHandlerFactory.cpp
@@ -48,7 +48,8 @@ static inline auto createHandlersFactoryFromConfig(
 
     for (const auto & key : keys)
     {
-        if (key == "defaults") {
+        if (key == "defaults")
+        {
             addDefaultHandlersFactory(*main_handler_factory, server, config, async_metrics);
         }
         else if (startsWith(key, "rule"))

--- a/src/Server/HTTPHandlerFactory.cpp
+++ b/src/Server/HTTPHandlerFactory.cpp
@@ -180,8 +180,15 @@ void addDefaultHandlersFactory(
         return std::make_unique<DynamicQueryHandler>(server, "query");
     };
     auto query_handler = std::make_shared<HandlingRuleHTTPHandlerFactory<DynamicQueryHandler>>(std::move(dynamic_creator));
-    query_handler->allowPostAndGetParamsAndOptionsRequest();
-    query_handler->attachNonStrictPath("/?");
+    query_handler->addFilter([](const auto & request)
+        {
+            return (startsWith(request.getURI(), "/?")
+                && (request.getMethod() == Poco::Net::HTTPRequest::HTTP_GET
+                || request.getMethod() == Poco::Net::HTTPRequest::HTTP_HEAD))
+                || request.getMethod() == Poco::Net::HTTPRequest::HTTP_OPTIONS
+                || request.getMethod() == Poco::Net::HTTPRequest::HTTP_POST;
+        }
+    );
     factory.addHandler(query_handler);
 
     /// We check that prometheus handler will be served on current (default) port.

--- a/src/Server/HTTPHandlerFactory.cpp
+++ b/src/Server/HTTPHandlerFactory.cpp
@@ -183,10 +183,12 @@ void addDefaultHandlersFactory(
     query_handler->addFilter([](const auto & request)
         {
             return (startsWith(request.getURI(), "/?")
-                && (request.getMethod() == Poco::Net::HTTPRequest::HTTP_GET
-                || request.getMethod() == Poco::Net::HTTPRequest::HTTP_HEAD))
-                || request.getMethod() == Poco::Net::HTTPRequest::HTTP_OPTIONS
-                || request.getMethod() == Poco::Net::HTTPRequest::HTTP_POST;
+                    && (request.getMethod() == Poco::Net::HTTPRequest::HTTP_GET
+                        || request.getMethod() == Poco::Net::HTTPRequest::HTTP_HEAD))
+                || ((startsWith(request.getURI(), "/?")
+                    || request.getURI() == "/")
+                    && (request.getMethod() == Poco::Net::HTTPRequest::HTTP_OPTIONS
+                        || request.getMethod() == Poco::Net::HTTPRequest::HTTP_POST));
         }
     );
     factory.addHandler(query_handler);

--- a/src/Server/HTTPHandlerRequestFilter.h
+++ b/src/Server/HTTPHandlerRequestFilter.h
@@ -98,7 +98,7 @@ static inline auto headersFilter(const Poco::Util::AbstractConfiguration & confi
     {
         for (const auto & [header_name, header_expression] : headers_expression)
         {
-            const auto & header_value = request.get(header_name, "");
+            const auto header_value = request.get(header_name, "");
             if (!checkExpression(std::string_view(header_value.data(), header_value.size()), header_expression))
                 return false;
         }

--- a/tests/integration/test_http_handlers_config/test.py
+++ b/tests/integration/test_http_handlers_config/test.py
@@ -159,6 +159,13 @@ def test_predefined_query_handler():
         assert cluster.instance.query("SELECT * FROM test_table") == "100\tTEST\n"
         cluster.instance.query("DROP TABLE test_table")
 
+        res4 = cluster.instance.http_request(
+            "test_predefined_handler_get?max_threads=1&param_setting_name=max_threads",
+            method="GET",
+            headers={"XXX": "xxx"},
+        )
+        assert b"max_threads\t1\n" == res1.content
+
 
 def test_fixed_static_handler():
     with contextlib.closing(

--- a/tests/integration/test_http_handlers_config/test.py
+++ b/tests/integration/test_http_handlers_config/test.py
@@ -455,6 +455,7 @@ def test_defaults_http_handlers():
             ).status_code
         )
 
+
 def test_defaults_http_handlers_config_order():
     def check_predefined_query_handler():
         assert (
@@ -474,22 +475,28 @@ def test_defaults_http_handlers_config_order():
         )
         assert b"max_threads\t1\n" == response.content
         assert (
-            "text/tab-separated-values; charset=UTF-8" == response.headers["content-type"]
+            "text/tab-separated-values; charset=UTF-8"
+            == response.headers["content-type"]
         )
 
     with contextlib.closing(
         SimpleCluster(
-            ClickHouseCluster(__file__), "defaults_handlers_config_order_first", "test_defaults_handlers_config_order/defaults_first"
+            ClickHouseCluster(__file__),
+            "defaults_handlers_config_order_first",
+            "test_defaults_handlers_config_order/defaults_first",
         )
     ) as cluster:
         check_predefined_query_handler()
 
     with contextlib.closing(
         SimpleCluster(
-            ClickHouseCluster(__file__), "defaults_handlers_config_order_first", "test_defaults_handlers_config_order/defaults_last"
+            ClickHouseCluster(__file__),
+            "defaults_handlers_config_order_first",
+            "test_defaults_handlers_config_order/defaults_last",
         )
     ) as cluster:
         check_predefined_query_handler()
+
 
 def test_prometheus_handler():
     with contextlib.closing(

--- a/tests/integration/test_http_handlers_config/test.py
+++ b/tests/integration/test_http_handlers_config/test.py
@@ -441,6 +441,7 @@ def test_defaults_http_handlers():
             == cluster.instance.http_request("?query=SELECT+1", method="GET").content
         )
 
+        assert 404 == cluster.instance.http_request("/nonexistent?query=SELECT+1", method="GET").status_code
 
 def test_prometheus_handler():
     with contextlib.closing(

--- a/tests/integration/test_http_handlers_config/test.py
+++ b/tests/integration/test_http_handlers_config/test.py
@@ -448,7 +448,13 @@ def test_defaults_http_handlers():
             == cluster.instance.http_request("?query=SELECT+1", method="GET").content
         )
 
-        assert 404 == cluster.instance.http_request("/nonexistent?query=SELECT+1", method="GET").status_code
+        assert (
+            404
+            == cluster.instance.http_request(
+                "/nonexistent?query=SELECT+1", method="GET"
+            ).status_code
+        )
+
 
 def test_prometheus_handler():
     with contextlib.closing(

--- a/tests/integration/test_http_handlers_config/test_defaults_handlers_config_order/defaults_first/config.xml
+++ b/tests/integration/test_http_handlers_config/test_defaults_handlers_config_order/defaults_first/config.xml
@@ -1,0 +1,17 @@
+
+<clickhouse>
+    <http_server_default_response>Default server response</http_server_default_response>
+
+    <http_handlers>
+        <defaults/>
+        <rule>
+            <methods>GET</methods>
+            <headers><XXX>xxx</XXX></headers>
+            <url>/test_predefined_handler_get</url>
+            <handler>
+                <type>predefined_query_handler</type>
+                <query>SELECT name, value FROM system.settings WHERE name = {setting_name:String}</query>
+            </handler>
+        </rule>
+    </http_handlers>
+</clickhouse>

--- a/tests/integration/test_http_handlers_config/test_defaults_handlers_config_order/defaults_last/config.xml
+++ b/tests/integration/test_http_handlers_config/test_defaults_handlers_config_order/defaults_last/config.xml
@@ -1,0 +1,17 @@
+
+<clickhouse>
+    <http_server_default_response>Default server response</http_server_default_response>
+
+    <http_handlers>
+        <rule>
+            <methods>GET</methods>
+            <headers><XXX>xxx</XXX></headers>
+            <url>/test_predefined_handler_get</url>
+            <handler>
+                <type>predefined_query_handler</type>
+                <query>SELECT name, value FROM system.settings WHERE name = {setting_name:String}</query>
+            </handler>
+        </rule>
+        <defaults/>
+    </http_handlers>
+</clickhouse>

--- a/tests/integration/test_system_start_stop_listen/test.py
+++ b/tests/integration/test_system_start_stop_listen/test.py
@@ -30,14 +30,10 @@ def started_cluster():
 
 def http_works(port=8123):
     try:
-        response = requests.post(f"http://{main_node.ip_address}:{port}/ping")
-        if response.status_code == 400:
-            return True
-    except:
-        pass
-
-    return False
-
+        response = requests.get(f"http://{main_node.ip_address}:{port}/ping")
+        return response.status_code == 200
+    except requests.exceptions.ConnectionError:
+        return False
 
 def assert_everything_works():
     custom_client = Client(main_node.ip_address, 9001, command=cluster.client_bin_path)

--- a/tests/integration/test_system_start_stop_listen/test.py
+++ b/tests/integration/test_system_start_stop_listen/test.py
@@ -35,6 +35,7 @@ def http_works(port=8123):
     except requests.exceptions.ConnectionError:
         return False
 
+
 def assert_everything_works():
     custom_client = Client(main_node.ip_address, 9001, command=cluster.client_bin_path)
     main_node.query(QUERY)

--- a/tests/queries/0_stateless/02403_big_http_chunk_size.python
+++ b/tests/queries/0_stateless/02403_big_http_chunk_size.python
@@ -14,7 +14,7 @@ def main():
     sock = socket(AF_INET, SOCK_STREAM)
     sock.connect((host, port))
     sock.settimeout(60)
-    s = "POST /play HTTP/1.1\r\n"
+    s = "POST / HTTP/1.1\r\n"
     s += "Host: %s\r\n" % host
     s += "Content-type: multipart/form-data\r\n"
     s += "Transfer-encoding: chunked\r\n"


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Fix missing URI filter for `query` endpoint. This may led to `query` handler being invoked instead of matching HTTP handlers, depending on the order of configuration entries, see https://github.com/ClickHouse/ClickHouse/issues/55393#issuecomment-1757934962.
- Support `param_`-prefixed parameter names for `PredefinedQueryHandler`s
Fixes https://github.com/ClickHouse/ClickHouse/issues/55393

