### PR TITLE
Improve merge selecting algorithm for big partitions

### DIFF
--- a/src/Storages/MergeTree/SimpleMergeSelector.cpp
+++ b/src/Storages/MergeTree/SimpleMergeSelector.cpp
@@ -170,7 +170,7 @@ void selectWithinPartition(
     if (parts_count >= parts_threshold)
         begin = parts_count - parts_threshold;
 
-    for (size_t begin = ; begin < parts_count; ++begin)
+    for (; begin < parts_count; ++begin)
     {
         /// If too many parts, select only from first, to avoid complexity.
         if (begin > parts_threshold)

--- a/src/Storages/MergeTree/SimpleMergeSelector.cpp
+++ b/src/Storages/MergeTree/SimpleMergeSelector.cpp
@@ -172,10 +172,6 @@ void selectWithinPartition(
 
     for (; begin < parts_count; ++begin)
     {
-        /// If too many parts, select only from first, to avoid complexity.
-        if (begin > parts_threshold)
-            break;
-
         if (!parts[begin].shall_participate_in_merges)
             continue;
 

--- a/src/Storages/MergeTree/SimpleMergeSelector.cpp
+++ b/src/Storages/MergeTree/SimpleMergeSelector.cpp
@@ -157,10 +157,23 @@ void selectWithinPartition(
     if (parts_count <= 1)
         return;
 
-    for (size_t begin = 0; begin < parts_count; ++begin)
+    /// If the parts in the parts vector are sorted by block number,
+    /// it may not be ideal to only select parts for merging from the first N ones.
+    /// This is because if there are more than N parts in the partition,
+    /// we will not be able to assign a merge for newly created parts.
+    /// As a result, the total number of parts within the partition could
+    /// grow uncontrollably, similar to a snowball effect.
+    /// To address this we will try to assign a merge taking into consideration
+    /// only last N parts.
+    static constexpr parts_threshold = 1000;
+    size_t begin = 0;
+    if (parts_count >= parts_threshold)
+        begin = parts_count - parts_threshold;
+
+    for (size_t begin = ; begin < parts_count; ++begin)
     {
         /// If too many parts, select only from first, to avoid complexity.
-        if (begin > 1000)
+        if (begin > parts_threshold)
             break;
 
         if (!parts[begin].shall_participate_in_merges)

--- a/src/Storages/MergeTree/SimpleMergeSelector.cpp
+++ b/src/Storages/MergeTree/SimpleMergeSelector.cpp
@@ -165,7 +165,7 @@ void selectWithinPartition(
     /// grow uncontrollably, similar to a snowball effect.
     /// To address this we will try to assign a merge taking into consideration
     /// only last N parts.
-    static constexpr parts_threshold = 1000;
+    static constexpr size_t parts_threshold = 1000;
     size_t begin = 0;
     if (parts_count >= parts_threshold)
         begin = parts_count - parts_threshold;


### PR DESCRIPTION
### Changelog category (leave one):

- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Improved overall resilience for ClickHouse in case of many parts within partition (more than 1000). It might reduce the number of `TOO_MANY_PARTS` errors. 
