### PR TITLE
Forbid create inverted index if setting not enabled

### DIFF
--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -2893,11 +2893,11 @@ void MergeTreeData::checkAlterIsPossible(const AlterCommands & commands, Context
                             queryToString(mutation_commands.ast()));
     }
 
+    commands.apply(new_metadata, getContext());
+
     if (commands.hasInvertedIndex(new_metadata) && !settings.allow_experimental_inverted_index)
         throw Exception(ErrorCodes::SUPPORT_IS_DISABLED,
                 "Experimental Inverted Index feature is not enabled (turn on setting 'allow_experimental_inverted_index')");
-
-    commands.apply(new_metadata, getContext());
 
     /// Set of columns that shouldn't be altered.
     NameSet columns_alter_type_forbidden;

--- a/tests/queries/0_stateless/02895_forbid_create_inverted_index.sql
+++ b/tests/queries/0_stateless/02895_forbid_create_inverted_index.sql
@@ -1,5 +1,6 @@
 SET allow_experimental_inverted_index = 0;
-CREATE OR REPLACE TABLE tab
+DROP TABLE IF EXISTS tab;
+CREATE TABLE tab
 (
     `key` UInt64,
     `str` String
@@ -8,3 +9,5 @@ ENGINE = MergeTree
 ORDER BY key;
 
 ALTER TABLE tab ADD INDEX inv_idx(str) TYPE inverted(0); -- { serverError SUPPORT_IS_DISABLED }
+
+DROP TABLE tab;

--- a/tests/queries/0_stateless/02895_forbid_create_inverted_index.sql
+++ b/tests/queries/0_stateless/02895_forbid_create_inverted_index.sql
@@ -1,0 +1,10 @@
+SET allow_experimental_inverted_index = 0;
+CREATE OR REPLACE TABLE tab
+(
+    `key` UInt64,
+    `str` String
+)
+ENGINE = MergeTree
+ORDER BY key;
+
+ALTER TABLE tab ADD INDEX inv_idx(str) TYPE inverted(0); -- { serverError SUPPORT_IS_DISABLED }


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)


Closes #55501.