### PR TITLE
Better error message in case when merge selecting task failed.

### DIFF
--- a/src/Storages/MergeTree/MergeTreeDataMergerMutator.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataMergerMutator.cpp
@@ -166,18 +166,20 @@ SelectPartsDecision MergeTreeDataMergerMutator::selectPartsToMerge(
     String best_partition_id_to_optimize = getBestPartitionToOptimizeEntire(info.partitions_info);
     if (!best_partition_id_to_optimize.empty())
     {
-            return selectAllPartsToMergeWithinPartition(
-                future_part,
-                can_merge_callback,
-                best_partition_id_to_optimize,
-                /*final=*/true,
-                metadata_snapshot,
-                txn,
-                out_disable_reason,
-                /*optimize_skip_merged_partitions=*/true);
+        return selectAllPartsToMergeWithinPartition(
+            future_part,
+            can_merge_callback,
+            best_partition_id_to_optimize,
+            /*final=*/true,
+            metadata_snapshot,
+            txn,
+            out_disable_reason,
+            /*optimize_skip_merged_partitions=*/true);
     }
 
-    out_disable_reason = "There is no need to merge parts according to merge selector algorithm";
+    if (!out_disable_reason.empty())
+        out_disable_reason += ". ";
+    out_disable_reason += "There is no need to merge parts according to merge selector algorithm";
     return SelectPartsDecision::CANNOT_SELECT;
 }
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Previously the real reason was overwritten by a message `There is no need to merge parts according to merge selector algorithm`.