### PR TITLE
Fix 'Invalid cursor state' in odbc interacting with MS SQL Server

### DIFF
--- a/programs/odbc-bridge/ColumnInfoHandler.cpp
+++ b/programs/odbc-bridge/ColumnInfoHandler.cpp
@@ -145,11 +145,11 @@ void ODBCColumnsInfoHandler::handleRequest(HTTPServerRequest & request, HTTPServ
             if (tables.next())
             {
                 catalog_name = tables.table_catalog();
+                /// `tables.next()` call is mandatory to drain the iterator before next operation and avoid "Invalid cursor state"
+                if (tables.next())
+                    throw Exception(ErrorCodes::UNKNOWN_TABLE, "Driver returned more than one table for '{}': '{}' and '{}'",
+                                    table_name, catalog_name, tables.table_schema());
                 LOG_TRACE(log, "Will fetch info for table '{}.{}'", catalog_name, table_name);
-                while (tables.next())
-                {
-                    /// drain the iterator before next operation to avoid "Invalid cursor state"
-                }
                 return catalog.find_columns(/* column = */ "", table_name, /* schema = */ "", catalog_name);
             }
 
@@ -157,11 +157,11 @@ void ODBCColumnsInfoHandler::handleRequest(HTTPServerRequest & request, HTTPServ
             if (tables.next())
             {
                 catalog_name = tables.table_catalog();
+                /// `tables.next()` call is mandatory to drain the iterator before next operation and avoid "Invalid cursor state"
+                if (tables.next())
+                    throw Exception(ErrorCodes::UNKNOWN_TABLE, "Driver returned more than one table for '{}': '{}' and '{}'",
+                                    table_name, catalog_name, tables.table_schema());
                 LOG_TRACE(log, "Will fetch info for table '{}.{}.{}'", catalog_name, schema_name, table_name);
-                while (tables.next())
-                {
-                    /// drain the iterator before next operation to avoid "Invalid cursor state"
-                }
                 return catalog.find_columns(/* column = */ "", table_name, schema_name, catalog_name);
             }
 

--- a/programs/odbc-bridge/ColumnInfoHandler.cpp
+++ b/programs/odbc-bridge/ColumnInfoHandler.cpp
@@ -146,6 +146,10 @@ void ODBCColumnsInfoHandler::handleRequest(HTTPServerRequest & request, HTTPServ
             {
                 catalog_name = tables.table_catalog();
                 LOG_TRACE(log, "Will fetch info for table '{}.{}'", catalog_name, table_name);
+                while (tables.next())
+                {
+                    /// drain the iterator before next operation to avoid "Invalid cursor state"
+                }
                 return catalog.find_columns(/* column = */ "", table_name, /* schema = */ "", catalog_name);
             }
 
@@ -154,6 +158,10 @@ void ODBCColumnsInfoHandler::handleRequest(HTTPServerRequest & request, HTTPServ
             {
                 catalog_name = tables.table_catalog();
                 LOG_TRACE(log, "Will fetch info for table '{}.{}.{}'", catalog_name, schema_name, table_name);
+                while (tables.next())
+                {
+                    /// drain the iterator before next operation to avoid "Invalid cursor state"
+                }
                 return catalog.find_columns(/* column = */ "", table_name, schema_name, catalog_name);
             }
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):

- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Fix 'Invalid cursor state' in odbc-bridge interacting with MS SQL Server via FreeTDS driver
