### PR TITLE
Added healthcheck for LDAP

### DIFF
--- a/docker/test/integration/runner/compose/docker_compose_ldap.yml
+++ b/docker/test/integration/runner/compose/docker_compose_ldap.yml
@@ -14,3 +14,8 @@ services:
             LDAP_PORT_NUMBER: ${LDAP_INTERNAL_PORT:-1389}
         ports:
             - ${LDAP_EXTERNAL_PORT:-1389}:${LDAP_INTERNAL_PORT:-1389}
+        healthcheck:
+            test: "ldapsearch -x -b dc=example,dc=org cn > /dev/null"
+            interval: 10s
+            retries: 10
+            timeout: 2s


### PR DESCRIPTION
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

https://s3.amazonaws.com/clickhouse-test-reports/0/5a830834fe564ed91c2dceb7b28973d5a70c0858/integration_tests__release__[4_4]/integration_run_parallel2_0.log

Test failed with error:
```
E           helpers.client.QueryRuntimeException: Client failed! Return code: 4, stderr: Code: 516. DB::Exception: Received from 172.16.12.3:9000. DB::Exception: janedoe: Authentication failed: password is incorrect, or there is no user with such name.. Stack trace:
E           
E           0. DB::Exception::Exception(DB::Exception::MessageMasked&&, int, bool) @ 0x000000000c78d997 in /usr/bin/clickhouse
E           1. DB::Exception::Exception(PreformattedMessage&&, int) @ 0x0000000007287711 in /usr/bin/clickhouse
E           2. DB::AccessControl::authenticate(DB::Credentials const&, Poco::Net::IPAddress const&) const @ 0x0000000010ffb43f in /usr/bin/clickhouse
E           3. DB::Session::authenticate(DB::Credentials const&, Poco::Net::SocketAddress const&) @ 0x00000000122a5502 in /usr/bin/clickhouse
E           4. DB::TCPHandler::runImpl() @ 0x0000000013367dab in /usr/bin/clickhouse
E           5. DB::TCPHandler::run() @ 0x000000001337c499 in /usr/bin/clickhouse
E           6. Poco::Net::TCPServerConnection::start() @ 0x0000000015dd1714 in /usr/bin/clickhouse
E           7. Poco::Net::TCPServerDispatcher::run() @ 0x0000000015dd2911 in /usr/bin/clickhouse
E           8. Poco::PooledThread::run() @ 0x0000000015eddf67 in /usr/bin/clickhouse
E           9. Poco::ThreadImpl::runnableEntry(void*) @ 0x0000000015edc1fc in /usr/bin/clickhouse
E           10. ? @ 0x00007f870706fac3 in ?
E           11. ? @ 0x00007f8707101a40 in ?
E           . (AUTHENTICATION_FAILED)
```
because LDAP server was unavailable. Possibly we don't wait for it to start.
```
2023.10.12 01:14:14.303764 [ 8 ] {} <Error> Access(user directories): from: 172.16.12.1, user: janedoe: Authentication failed: Code: 532. DB::Exception: Can't contact LDAP server. (LDAP_ERROR), Stack trace (when copying this message, always include the lines below):

0. DB::Exception::Exception(DB::Exception::MessageMasked&&, int, bool) @ 0x000000000c78d997 in /usr/bin/clickhouse
1. DB::Exception::createDeprecated(String const&, int, bool) @ 0x00000000075f756d in /usr/bin/clickhouse
2. DB::LDAPClient::handleError(int, String) @ 0x00000000110ae1a6 in /usr/bin/clickhouse
3. DB::LDAPSimpleAuthClient::authenticate(std::vector<DB::LDAPClient::RoleSearchParams, std::allocator<DB::LDAPClient::RoleSearchParams>> const*, std::vector<std::set<String, std::less<String>, std::allocator<String>>, std::allocator<std::set<String, std::less<String>, std::allocator<String>>>>*) @ 0x0
0000000110b2776 in /usr/bin/clickhouse
4. DB::ExternalAuthenticators::checkLDAPCredentials(String const&, DB::BasicCredentials const&, std::vector<DB::LDAPClient::RoleSearchParams, std::allocator<DB::LDAPClient::RoleSearchParams>> const*, std::vector<std::set<String, std::less<String>, std::allocator<String>>, std::allocator<std::set<String
, std::less<String>, std::allocator<String>>>>*) const @ 0x0000000011071696 in /usr/bin/clickhouse
5. DB::LDAPAccessStorage::authenticateImpl(DB::Credentials const&, Poco::Net::IPAddress const&, DB::ExternalAuthenticators const&, bool, bool, bool) const @ 0x00000000110aa77d in /usr/bin/clickhouse
6. DB::MultipleAccessStorage::authenticateImpl(DB::Credentials const&, Poco::Net::IPAddress const&, DB::ExternalAuthenticators const&, bool, bool, bool) const @ 0x00000000110bc9e9 in /usr/bin/clickhouse
7. DB::AccessControl::authenticate(DB::Credentials const&, Poco::Net::IPAddress const&) const @ 0x0000000010ffb19e in /usr/bin/clickhouse
8. DB::Session::authenticate(DB::Credentials const&, Poco::Net::SocketAddress const&) @ 0x00000000122a5502 in /usr/bin/clickhouse
9. DB::TCPHandler::runImpl() @ 0x0000000013367dab in /usr/bin/clickhouse
10. DB::TCPHandler::run() @ 0x000000001337c499 in /usr/bin/clickhouse
11. Poco::Net::TCPServerConnection::start() @ 0x0000000015dd1714 in /usr/bin/clickhouse
12. Poco::Net::TCPServerDispatcher::run() @ 0x0000000015dd2911 in /usr/bin/clickhouse
13. Poco::PooledThread::run() @ 0x0000000015eddf67 in /usr/bin/clickhouse
14. Poco::ThreadImpl::runnableEntry(void*) @ 0x0000000015edc1fc in /usr/bin/clickhouse
15. ? @ 0x00007f870706fac3 in ?
16. ? @ 0x00007f8707101a40 in ?
 (version 23.10.1.721 (official build))
```

So let's do it. 