### PR TITLE
Fix global context for tests with --gtest_filter

### DIFF
--- a/contrib/googletest-cmake/CMakeLists.txt
+++ b/contrib/googletest-cmake/CMakeLists.txt
@@ -6,13 +6,7 @@ target_compile_definitions (_gtest PUBLIC GTEST_HAS_POSIX_RE=0)
 target_include_directories(_gtest SYSTEM PUBLIC "${SRC_DIR}/googletest/include")
 target_include_directories(_gtest PRIVATE "${SRC_DIR}/googletest")
 
-add_library(_gtest_main "${SRC_DIR}/googletest/src/gtest_main.cc")
-set_target_properties(_gtest_main PROPERTIES VERSION "1.0.0")
-target_link_libraries(_gtest_main PUBLIC _gtest)
-
-add_library(_gtest_all INTERFACE)
-target_link_libraries(_gtest_all INTERFACE _gtest _gtest_main)
-add_library(ch_contrib::gtest_all ALIAS _gtest_all)
+add_library(ch_contrib::gtest ALIAS _gtest)
 
 add_library(_gmock "${SRC_DIR}/googlemock/src/gmock-all.cc")
 set_target_properties(_gmock PROPERTIES VERSION "1.0.0")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -592,7 +592,7 @@ if (ENABLE_TESTS)
 
     target_link_libraries(unit_tests_dbms PRIVATE
         ch_contrib::gmock_all
-        ch_contrib::gtest_all
+        ch_contrib::gtest
         clickhouse_functions
         clickhouse_aggregate_functions
         clickhouse_parsers

--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -15,7 +15,6 @@
 #include <Common/scope_guard_safe.h>
 #include <Common/Exception.h>
 #include <Common/getNumberOfPhysicalCPUCores.h>
-#include <Common/tests/gtest_global_context.h>
 #include <Common/typeid_cast.h>
 #include <Common/UTF8Helpers.h>
 #include <Common/TerminalSize.h>

--- a/src/Common/tests/gtest_event_notifier.cpp
+++ b/src/Common/tests/gtest_event_notifier.cpp
@@ -9,7 +9,6 @@ TEST(EventNotifier, SimpleTest)
     using namespace DB;
 
     size_t result = 1;
-    EventNotifier::init();
 
     auto handler3 = EventNotifier::instance().subscribe(Coordination::Error::ZSESSIONEXPIRED, [&result](){ result *= 3; });
 

--- a/src/Common/tests/gtest_main.cpp
+++ b/src/Common/tests/gtest_main.cpp
@@ -1,0 +1,18 @@
+#include <gtest/gtest.h>
+
+#include <Common/tests/gtest_global_context.h>
+
+class ContextEnvironment : public testing::Environment
+{
+public:
+    void SetUp() override { getContext(); }
+};
+
+int main(int argc, char ** argv)
+{
+    testing::InitGoogleTest(&argc, argv);
+
+    testing::AddGlobalTestEnvironment(new ContextEnvironment);
+
+    return RUN_ALL_TESTS();
+}

--- a/src/Coordination/tests/gtest_coordination.cpp
+++ b/src/Coordination/tests/gtest_coordination.cpp
@@ -71,6 +71,13 @@ protected:
     DB::KeeperContextPtr keeper_context = std::make_shared<DB::KeeperContext>(true);
     Poco::Logger * log{&Poco::Logger::get("CoordinationTest")};
 
+    void SetUp() override
+    {
+        Poco::AutoPtr<Poco::ConsoleChannel> channel(new Poco::ConsoleChannel(std::cerr));
+        Poco::Logger::root().setChannel(channel);
+        Poco::Logger::root().setLevel("trace");
+    }
+
     void setLogDirectory(const std::string & path) { keeper_context->setLogDisk(std::make_shared<DB::DiskLocal>("LogDisk", path)); }
 
     void setSnapshotDirectory(const std::string & path)
@@ -2910,14 +2917,5 @@ TEST_P(CoordinationTest, TestReapplyingDeltas)
 INSTANTIATE_TEST_SUITE_P(CoordinationTestSuite,
     CoordinationTest,
     ::testing::ValuesIn(std::initializer_list<CompressionParam>{CompressionParam{true, ".zstd"}, CompressionParam{false, ""}}));
-
-int main(int argc, char ** argv)
-{
-    Poco::AutoPtr<Poco::ConsoleChannel> channel(new Poco::ConsoleChannel(std::cerr));
-    Poco::Logger::root().setChannel(channel);
-    Poco::Logger::root().setLevel("trace");
-    testing::InitGoogleTest(&argc, argv);
-    return RUN_ALL_TESTS();
-}
 
 #endif


### PR DESCRIPTION
If you run tests that requires context, but do not initialize it, then
it will SIGSEGV, because Context is not initialized.

Fix this by using google test envrionment, and instead of gtest_main
implement own main function that will initialize it.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)