### PR TITLE
[WIP] generate object storage key by template

### DIFF
--- a/src/Common/MatchGenerator.cpp
+++ b/src/Common/MatchGenerator.cpp
@@ -1,0 +1,418 @@
+#ifdef __clang__
+#  pragma clang diagnostic push
+#  pragma clang diagnostic ignored "-Wzero-as-null-pointer-constant"
+#  pragma clang diagnostic ignored "-Wgnu-anonymous-struct"
+#  pragma clang diagnostic ignored "-Wnested-anon-types"
+#  pragma clang diagnostic ignored "-Wunused-parameter"
+#  pragma clang diagnostic ignored "-Wshadow-field-in-constructor"
+#  pragma clang diagnostic ignored "-Wdtor-name"
+#endif
+#include <re2/re2.h>
+#include <re2/regexp.h>
+#include <re2/walker-inl.h>
+#ifdef __clang__
+#  pragma clang diagnostic pop
+#endif
+
+#ifdef LOG_INFO
+#undef LOG_INFO
+#undef LOG_WARNING
+#undef LOG_ERROR
+#undef LOG_FATAL
+#endif
+
+#include "MatchGenerator.h"
+
+#include <Common/Exception.h>
+#include <Common/logger_useful.h>
+#include <Common/thread_local_rng.h>
+#include <random>
+#include <map>
+#include <functional>
+#include <magic_enum.hpp>
+
+namespace DB
+{
+namespace ErrorCodes
+{
+extern const int BAD_ARGUMENTS;
+extern const int LOGICAL_ERROR;
+}
+}
+
+
+namespace re2
+{
+
+class RandomStringPrepareWalker : public Regexp::Walker<Regexp *>
+{
+private:
+    static constexpr int ImplicitMax = 100;
+
+    using Children = std::vector<Regexp*>;
+
+    class Generators;
+
+    /// This function objects look much prettier than lambda expression when stack traces are printed
+    class NodeFunction
+    {
+    public:
+        virtual String operator() (const Generators& generators) = 0;
+        virtual ~NodeFunction() = default;
+    };
+
+    using NodeFunctionPtr = std::shared_ptr<NodeFunction>;
+
+    class Generators: public std::map<re2::Regexp *, NodeFunctionPtr> {};
+
+    class RegexpConcatFunction : public NodeFunction
+    {
+    public:
+        RegexpConcatFunction(Children children_)
+            : children(std::move(children_))
+        {}
+
+        String operator () (const Generators& generators_) override
+        {
+            String result;
+            for (auto child: children)
+            {
+                auto res = generators_.at(child)->operator()(generators_);
+                result.append(res);
+            }
+            return result;
+        }
+
+    private:
+        Children children;
+    };
+
+    class RegexpAlternateFunction : public NodeFunction
+    {
+    public:
+        RegexpAlternateFunction(Children children_)
+            : children(std::move(children_))
+        {}
+
+        String operator () (const Generators& generators_) override
+        {
+            std::uniform_int_distribution<int> distribution(0, static_cast<int>(children.size()-1));
+            int chosen = distribution(thread_local_rng);
+            return generators_.at(children[chosen])->operator()(generators_);
+        }
+
+    private:
+        Children children;
+    };
+
+    class RegexpRepeatFunction : public NodeFunction
+    {
+    public:
+        RegexpRepeatFunction(Regexp * re_, int min_repeat_, int max_repeat_)
+            : re(re_)
+            , min_repeat(min_repeat_)
+            , max_repeat(max_repeat_)
+        {}
+
+        String operator () (const Generators& generators_) override
+        {
+            std::uniform_int_distribution<int> distribution(min_repeat, max_repeat);
+            int chosen = distribution(thread_local_rng);
+
+            String result;
+            for (int i = 0; i < chosen; ++i)
+                result.append(generators_.at(re)->operator()(generators_));
+            return result;
+        }
+
+    private:
+        Regexp * re;
+        int min_repeat = 0;
+        int max_repeat = 0;
+    };
+
+    class RegexpCharClassFunction : public NodeFunction
+    {
+    public:
+        RegexpCharClassFunction(Regexp * re_)
+            : re(re_)
+        {}
+
+        String operator () (const Generators&) override
+        {
+            CharClass * cc = re->cc();
+            if (cc->empty())
+                throw DB::Exception(DB::ErrorCodes::BAD_ARGUMENTS, "kRegexpCharClass is empty");
+
+            std::uniform_int_distribution<int> distribution(1, cc->size());
+            int chosen = distribution(thread_local_rng);
+            int count_down = chosen;
+
+            auto it = cc->begin();
+            for (; it != cc->end(); ++it)
+            {
+                auto range_len = it->hi - it->lo + 1;
+                if (count_down <= range_len)
+                    break;
+                count_down -= range_len;
+            }
+
+            if (it == cc->end())
+                throw DB::Exception(DB::ErrorCodes::LOGICAL_ERROR,
+                                    "Unable to choose the rune. Runes {}, chosen {}",
+                                    cc->size(), chosen);
+
+            Rune r = it->lo + count_down - 1;
+            char buffer[UTFmax+1];
+            buffer[re2::runetochar(buffer, &r)] = 0;
+            return String(buffer);
+        }
+
+    private:
+        Regexp * re;
+    };
+
+    class RegexpLiteralStringFunction : public NodeFunction
+    {
+    public:
+        RegexpLiteralStringFunction(Regexp * re_)
+            : re(re_)
+        {}
+
+        String operator () (const Generators&) override
+        {
+            if (re->nrunes() == 0)
+                return String();
+
+            String result;
+            char buffer[UTFmax+1];
+            for (int i = 0; i < re->nrunes(); ++i)
+            {
+                buffer[re2::runetochar(buffer, &re->runes()[i])] = 0;
+                result.append(buffer);
+            }
+            return result;
+        }
+
+    private:
+        Regexp * re;
+    };
+
+    class RegexpLiteralFunction : public NodeFunction
+    {
+    public:
+        RegexpLiteralFunction(Regexp * re_)
+            : re(re_)
+        {}
+
+        String operator () (const Generators&) override
+        {
+            String result;
+            char buffer[UTFmax+1];
+
+            Rune r = re->rune();
+            buffer[re2::runetochar(buffer, &r)] = 0;
+            result.append(buffer);
+
+            return result;
+        }
+
+    private:
+        Regexp * re;
+    };
+
+    class ThrowExceptionFunction : public NodeFunction
+    {
+    public:
+        ThrowExceptionFunction(Regexp * re_)
+            : re(re_)
+        {}
+
+        String operator () (const Generators&) override
+        {
+            throw DB::Exception(
+                DB::ErrorCodes::BAD_ARGUMENTS,
+                "RandomStringPrepareWalker: regexp node '{}' is not supported for generating a random match",
+                magic_enum::enum_name(re->op()));
+        }
+
+    private:
+        Regexp * re;
+    };
+
+
+public:
+    RandomStringPrepareWalker(bool logging)
+        : logger(logging ? &Poco::Logger::get("GeneratorCombiner") : nullptr)
+    {
+        if (logger)
+            LOG_DEBUG(logger, "GeneratorCombiner");
+    }
+
+    std::function<String()> getGenerator()
+    {
+        if (root == nullptr)
+            throw DB::Exception(DB::ErrorCodes::LOGICAL_ERROR, "no root has been set");
+
+        if (generators.size() == 0)
+            throw DB::Exception(DB::ErrorCodes::LOGICAL_ERROR, "no generators");
+
+        auto result = [generators_ = std::move(generators), root_ = std::move(root)] () -> String {
+            return generators_.at(root_)->operator()(generators_);
+        };
+
+        root = nullptr;
+        generators.clear();
+
+        return std::move(result);
+    }
+
+private:
+    Children CopyChildrenArgs(Regexp** children, int nchild)
+    {
+        Children result;
+        result.reserve(nchild);
+        for (int i = 0; i < nchild; ++i)
+            result.push_back(Copy(children[i]));
+        return result;
+    }
+
+    Regexp * ShortVisit(Regexp* /*re*/, Regexp * /*parent_arg*/) override
+    {
+        if (logger)
+            LOG_DEBUG(logger, "ShortVisit");
+        throw DB::Exception(DB::ErrorCodes::LOGICAL_ERROR, "should not be call");
+    }
+
+    Regexp * PreVisit(Regexp * re, Regexp* parent_arg, bool* /*stop*/) override /*noexcept*/
+    {
+        if (logger)
+            LOG_DEBUG(logger, "GeneratorCombiner PreVisit node {}", magic_enum::enum_name(re->op()));
+
+        if (parent_arg == nullptr)
+        {
+            chassert(root == nullptr);
+            chassert(re != nullptr);
+            root = re;
+        }
+
+        return re;
+    }
+
+    Regexp * PostVisit(Regexp * re, Regexp* /*parent_arg*/, Regexp* pre_arg,
+                       Regexp ** child_args, int nchild_args) override /*noexcept*/
+    {
+        if (logger)
+            LOG_DEBUG(logger, "GeneratorCombiner PostVisit node {}",
+                      magic_enum::enum_name(re->op()));
+
+        switch (re->op())
+        {
+            case kRegexpConcat: // Matches concatenation of sub_[0..nsub-1].
+                generators[re] = std::make_shared<RegexpConcatFunction>(CopyChildrenArgs(child_args, nchild_args));
+                break;
+            case kRegexpAlternate: // Matches union of sub_[0..nsub-1].
+                generators[re] = std::make_shared<RegexpAlternateFunction>(CopyChildrenArgs(child_args, nchild_args));
+                break;
+            case kRegexpQuest: // Matches sub_[0] zero or one times.
+                chassert(nchild_args == 1);
+                generators[re] = std::make_shared<RegexpRepeatFunction>(child_args[0], 0, 1);
+                break;
+            case kRegexpStar: // Matches sub_[0] zero or more times.
+                chassert(nchild_args == 1);
+                generators[re] = std::make_shared<RegexpRepeatFunction>(child_args[0], 0, ImplicitMax);
+                break;
+            case kRegexpPlus: // Matches sub_[0] one or more times.
+                chassert(nchild_args == 1);
+                generators[re] = std::make_shared<RegexpRepeatFunction>(child_args[0], 1, ImplicitMax);
+                break;
+            case kRegexpCharClass: // Matches character class given by cc_.
+                chassert(nchild_args == 0);
+                generators[re] = std::make_shared<RegexpCharClassFunction>(re);
+                break;
+            case kRegexpLiteralString: // Matches runes_.
+                chassert(nchild_args == 0);
+                generators[re] = std::make_shared<RegexpLiteralStringFunction>(re);
+                break;
+            case kRegexpLiteral: // Matches rune_.
+                chassert(nchild_args == 0);
+                generators[re] = std::make_shared<RegexpLiteralFunction>(re);
+                break;
+            case kRegexpCapture: // Parenthesized (capturing) subexpression.
+                chassert(nchild_args == 1);
+                generators[re] = generators[child_args[0]];
+                break;
+
+            case kRegexpNoMatch: // Matches no strings.
+            case kRegexpEmptyMatch: // Matches empty string.
+            case kRegexpRepeat: // Matches sub_[0] at least min_ times, at most max_ times.
+            case kRegexpAnyChar: // Matches any character.
+            case kRegexpAnyByte: // Matches any byte [sic].
+            case kRegexpBeginLine: // Matches empty string at beginning of line.
+            case kRegexpEndLine: // Matches empty string at end of line.
+            case kRegexpWordBoundary: // Matches word boundary "\b".
+            case kRegexpNoWordBoundary: // Matches not-a-word boundary "\B".
+            case kRegexpBeginText: // Matches empty string at beginning of text.
+            case kRegexpEndText: // Matches empty string at end of text.
+            case kRegexpHaveMatch: // Forces match of entire expression
+                generators[re] = std::make_shared<ThrowExceptionFunction>(re);
+        }
+
+        return pre_arg;
+    }
+
+private:
+    Poco::Logger * logger = nullptr;
+
+    Regexp * root = nullptr;
+    Generators generators;
+};
+
+}
+
+
+namespace DB
+{
+
+void RandomStringGeneratorByRegexp::RegexpPtrDeleter::operator() (re2::Regexp * re) const noexcept
+{
+    re->Decref();
+}
+
+RandomStringGeneratorByRegexp::RandomStringGeneratorByRegexp(String re_str, bool logging)
+{
+    re2::RE2::Options options;
+    options.set_case_sensitive(true);
+    auto flags = static_cast<re2::Regexp::ParseFlags>(options.ParseFlags());
+
+    re2::RegexpStatus status;
+    regexp.reset(re2::Regexp::Parse(re_str, flags, &status));
+
+    if (!regexp)
+        throw DB::Exception(DB::ErrorCodes::BAD_ARGUMENTS,
+                            "Error parsing regexp '{}': {}",
+                            re_str, status.Text());
+
+    regexp.reset(regexp->Simplify());
+
+    auto walker = re2::RandomStringPrepareWalker(logging);
+    walker.Walk(regexp.get(), {});
+    generatorFunc = walker.getGenerator();
+
+    {
+        auto test_check = generate();
+        auto matched = RE2::FullMatch(test_check, re2::RE2(re_str));
+        if (!matched)
+            throw DB::Exception(DB::ErrorCodes::BAD_ARGUMENTS,
+                                "Generator is unable to produce random string for regexp '{}': {}",
+                                re_str, test_check);
+    }
+}
+
+String RandomStringGeneratorByRegexp::generate() const
+{
+    chassert(generatorFunc);
+    return generatorFunc();
+}
+
+}

--- a/src/Common/MatchGenerator.h
+++ b/src/Common/MatchGenerator.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <base/types.h>
+#include <memory>
+
+namespace re2
+{
+    class Regexp;
+}
+
+namespace DB
+{
+
+class RandomStringGeneratorByRegexp
+{
+public:
+    RandomStringGeneratorByRegexp(String re_str, bool logging);
+    String generate() const;
+
+private:
+    struct RegexpPtrDeleter
+    {
+        void operator()(re2::Regexp * re) const noexcept;
+    };
+    using RegexpPtr = std::unique_ptr<re2::Regexp, RegexpPtrDeleter>;
+
+    RegexpPtr regexp;
+    std::function<String()> generatorFunc;
+};
+
+}

--- a/src/Common/ObjectStorageKey.cpp
+++ b/src/Common/ObjectStorageKey.cpp
@@ -65,4 +65,5 @@ ObjectStorageKey ObjectStorageKey::createAsAbsolute(String key_)
     object_key.is_relative = false;
     return object_key;
 }
+
 }

--- a/src/Common/ObjectStorageKeyGenerator.cpp
+++ b/src/Common/ObjectStorageKeyGenerator.cpp
@@ -1,0 +1,97 @@
+#include "ObjectStorageKeyGenerator.h"
+
+#include <Common/getRandomASCIIString.h>
+#include <Common/MatchGenerator.h>
+
+#include <base/types.h>
+#include <fmt/format.h>
+
+
+class GeneratorWithTemplate : public DB::IObjectStorageKeysGenerator
+{
+public:
+    GeneratorWithTemplate(String key_template_)
+    : key_template(std::move(key_template_))
+    , re_gen(key_template, /*logging*/ false)
+    {
+    }
+
+    DB::ObjectStorageKey generate(const String &) const override
+    {
+        return DB::ObjectStorageKey::createAsAbsolute(re_gen.generate());
+    }
+
+private:
+    String key_template;
+    DB::RandomStringGeneratorByRegexp re_gen;
+};
+
+
+class GeneratorWithPrefix : public DB::IObjectStorageKeysGenerator
+{
+public:
+    GeneratorWithPrefix(String key_prefix_)
+        : key_prefix(std::move(key_prefix_))
+    {}
+
+    DB::ObjectStorageKey generate(const String &) const override
+    {
+        /// Path to store the new S3 object.
+
+        /// Total length is 32 a-z characters for enough randomness.
+        /// First 3 characters are used as a prefix for
+        /// https://aws.amazon.com/premiumsupport/knowledge-center/s3-object-key-naming-pattern/
+
+        constexpr size_t key_name_total_size = 32;
+        constexpr size_t key_name_prefix_size = 3;
+
+        /// Path to store new S3 object.
+        String key = fmt::format("{}/{}",
+                                 DB::getRandomASCIIString(key_name_prefix_size),
+                                 DB::getRandomASCIIString(key_name_total_size - key_name_prefix_size));
+
+        /// what ever key_prefix value is, consider that key as relative
+        return DB::ObjectStorageKey::createAsRelative(key_prefix, key);
+    }
+
+private:
+    String key_prefix;
+};
+
+
+class GeneratorAsIsWithPrefix : public DB::IObjectStorageKeysGenerator
+{
+public:
+    GeneratorAsIsWithPrefix(String key_prefix_)
+        : key_prefix(std::move(key_prefix_))
+    {}
+
+    DB::ObjectStorageKey generate(const String & path) const override
+    {
+        return DB::ObjectStorageKey::createAsRelative(key_prefix, path);
+    }
+
+private:
+    String key_prefix;
+};
+
+
+namespace DB
+{
+
+ObjectStorageKeysGeneratorPtr createObjectStorageKeysGeneratorAsIsWithPrefix(String key_prefix)
+{
+    return std::make_shared<GeneratorAsIsWithPrefix>(std::move(key_prefix));
+}
+
+ObjectStorageKeysGeneratorPtr createObjectStorageKeysGeneratorByPrefix(String key_prefix)
+{
+    return std::make_shared<GeneratorWithPrefix>(std::move(key_prefix));
+}
+
+ObjectStorageKeysGeneratorPtr createObjectStorageKeysGeneratorByTemplate(String key_template)
+{
+    return std::make_shared<GeneratorWithTemplate>(std::move(key_template));
+}
+
+}

--- a/src/Common/ObjectStorageKeyGenerator.h
+++ b/src/Common/ObjectStorageKeyGenerator.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "ObjectStorageKey.h"
+#include <memory>
+
+namespace DB
+{
+
+class IObjectStorageKeysGenerator
+{
+public:
+    virtual ObjectStorageKey generate(const String & path) const = 0;
+    virtual ~IObjectStorageKeysGenerator() = default;
+};
+
+using ObjectStorageKeysGeneratorPtr = std::shared_ptr<IObjectStorageKeysGenerator>;
+
+ObjectStorageKeysGeneratorPtr createObjectStorageKeysGeneratorAsIsWithPrefix(String key_prefix);
+ObjectStorageKeysGeneratorPtr createObjectStorageKeysGeneratorByPrefix(String key_prefix);
+ObjectStorageKeysGeneratorPtr createObjectStorageKeysGeneratorByTemplate(String key_template);
+
+}

--- a/src/Common/tests/gtest_generate_random_by_regexp.cpp
+++ b/src/Common/tests/gtest_generate_random_by_regexp.cpp
@@ -71,12 +71,12 @@ UInt64 elapsed(DB::ObjectStorageKeysGeneratorPtr generator)
 
     Stopwatch watch;
 
-    for (int i = 0; i < 20000; ++i)
+    for (int i = 0; i < 100000; ++i)
     {
         [[ maybe_unused ]] auto result = generator->generate(path).serialize();
     }
 
-    return watch.elapsedMilliseconds();
+    return watch.elapsedMicroseconds();
 }
 
 TEST(ObjectStorageKey, Performance)
@@ -95,7 +95,7 @@ TEST(ObjectStorageKey, Performance)
             std::cerr << "slow ratio: +" << float(elapsed_new) / elapsed_old << std::endl;
         else
             std::cerr << "fast ratio: " << float(elapsed_old) / elapsed_new << std::endl;
-        ASSERT_LT(elapsed_new, 2 * elapsed_old);
+        ASSERT_LT(elapsed_new, 1.2 * elapsed_old);
     }
 
 }

--- a/src/Common/tests/gtest_generate_random_by_regexp.cpp
+++ b/src/Common/tests/gtest_generate_random_by_regexp.cpp
@@ -71,7 +71,7 @@ UInt64 elapsed(DB::ObjectStorageKeysGeneratorPtr generator)
 
     Stopwatch watch;
 
-    for (int i = 0; i < 10000; ++i)
+    for (int i = 0; i < 20000; ++i)
     {
         [[ maybe_unused ]] auto result = generator->generate(path).serialize();
     }
@@ -81,17 +81,21 @@ UInt64 elapsed(DB::ObjectStorageKeysGeneratorPtr generator)
 
 TEST(ObjectStorageKey, Performance)
 {
-    auto elapsed_old = elapsed(DB::createObjectStorageKeysGeneratorByPrefix("mergetree/"));
+    auto elapsed_old = elapsed(DB::createObjectStorageKeysGeneratorByPrefix(
+            "xx-xx-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/mergetree/"));
     std::cerr << "old: " << elapsed_old << std::endl;
 
-    auto elapsed_new = elapsed(DB::createObjectStorageKeysGeneratorByTemplate("mergetree/[a-z]{3}/[a-z]{29}"));
+    auto elapsed_new = elapsed(DB::createObjectStorageKeysGeneratorByTemplate(
+            "xx-xx-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/mergetree/[a-z]{3}/[a-z]{29}"));
     std::cerr << "new: " << elapsed_new << std::endl;
 
     if (elapsed_new > elapsed_old)
     {
-        auto diff = elapsed_new - elapsed_old;
-        std::cerr << "slow ratio: " << float(diff) / elapsed_old << std::endl;
-        ASSERT_GT(1.1 * elapsed_old, elapsed_new);
+        if (elapsed_new > elapsed_old)
+            std::cerr << "slow ratio: +" << float(elapsed_new) / elapsed_old << std::endl;
+        else
+            std::cerr << "fast ratio: " << float(elapsed_old) / elapsed_new << std::endl;
+        ASSERT_LT(elapsed_new, 2 * elapsed_old);
     }
 
 }

--- a/src/Common/tests/gtest_generate_random_by_regexp.cpp
+++ b/src/Common/tests/gtest_generate_random_by_regexp.cpp
@@ -1,0 +1,97 @@
+#include <Common/MatchGenerator.h>
+#include <Common/ObjectStorageKeyGenerator.h>
+#include <Common/Stopwatch.h>
+#include <Common/Exception.h>
+
+#include <gtest/gtest.h>
+
+void routine(String s)
+{
+    std::cerr << "case '"<< s << "'";
+    auto gen = DB::RandomStringGeneratorByRegexp(s, /*logging*/ true);
+    [[maybe_unused]] auto res = gen.generate();
+    std::cerr << " result '"<< res << "'" << std::endl;
+}
+
+TEST(GenerateRandomString, Positive)
+{
+    routine(".");
+    routine("[[:xdigit:]]");
+    routine("[0-9a-f]");
+    routine("[a-z]");
+    routine("prefix-[0-9a-f]-suffix");
+    routine("prefix-[a-z]-suffix");
+    routine("[0-9a-f]{3}");
+    routine("prefix-[0-9a-f]{3}-suffix");
+    routine("prefix-[a-z]{3}-suffix/[0-9a-f]{20}");
+    routine("left|right");
+    routine("[a-z]{0,3}");
+    routine("just constant string");
+    routine("[a-z]?");
+    routine("[a-z]*");
+    routine("[a-z]+");
+    routine("[^a-z]");
+    routine("[[:lower:]]{3}/suffix");
+    routine("prefix-(A|B|[0-9a-f]){3}");
+    routine("mergetree/[a-z]{3}/[a-z]{29}");
+}
+
+TEST(GenerateRandomString, Negative)
+{
+    EXPECT_THROW(routine("[[:do_not_exists:]]"), DB::Exception);
+    EXPECT_THROW(routine("[:do_not_exis..."), DB::Exception);
+    EXPECT_THROW(routine("^abc"), DB::Exception);
+}
+
+TEST(GenerateRandomString, DifferentResult)
+{
+    std::cerr << "100 different keys" << std::endl;
+    auto gen = DB::RandomStringGeneratorByRegexp("prefix-[a-z]{3}-suffix/[0-9a-f]{20}", /*logging*/ true);
+    std::set<String> deduplicate;
+    for (int i = 0; i < 100; ++i)
+        ASSERT_TRUE(deduplicate.insert(gen.generate()).second);
+    std::cerr << "100 different keys: ok" << std::endl;
+}
+
+TEST(GenerateRandomString, FullRange)
+{
+    std::cerr << "all possible letters" << std::endl;
+    auto gen = DB::RandomStringGeneratorByRegexp("[a-z]", /*logging*/ false);
+    std::set<String> deduplicate;
+    int count = 'z' - 'a' + 1;
+    while (deduplicate.size() < count)
+        if (deduplicate.insert(gen.generate()).second)
+            std::cerr << " +1 ";
+    std::cerr << "all possible letters, ok" << std::endl;
+}
+
+UInt64 elapsed(DB::ObjectStorageKeysGeneratorPtr generator)
+{
+    String path = "some_path";
+
+    Stopwatch watch;
+
+    for (int i = 0; i < 10000; ++i)
+    {
+        [[ maybe_unused ]] auto result = generator->generate(path).serialize();
+    }
+
+    return watch.elapsedMilliseconds();
+}
+
+TEST(ObjectStorageKey, Performance)
+{
+    auto elapsed_old = elapsed(DB::createObjectStorageKeysGeneratorByPrefix("mergetree/"));
+    std::cerr << "old: " << elapsed_old << std::endl;
+
+    auto elapsed_new = elapsed(DB::createObjectStorageKeysGeneratorByTemplate("mergetree/[a-z]{3}/[a-z]{29}"));
+    std::cerr << "new: " << elapsed_new << std::endl;
+
+    if (elapsed_new > elapsed_old)
+    {
+        auto diff = elapsed_new - elapsed_old;
+        std::cerr << "slow ratio: " << float(diff) / elapsed_old << std::endl;
+        ASSERT_GT(1.1 * elapsed_old, elapsed_new);
+    }
+
+}

--- a/src/Disks/ObjectStorages/DiskObjectStorageMetadata.cpp
+++ b/src/Disks/ObjectStorages/DiskObjectStorageMetadata.cpp
@@ -20,14 +20,13 @@ namespace ErrorCodes
 void DiskObjectStorageMetadata::deserialize(ReadBuffer & buf)
 {
     readIntText(version, buf);
+    assertChar('\n', buf);
 
     if (version < VERSION_ABSOLUTE_PATHS || version > VERSION_FULL_OBJECT_KEY)
         throw Exception(
             ErrorCodes::UNKNOWN_FORMAT,
             "Unknown metadata file version. Path: {}. Version: {}. Maximum expected version: {}",
             metadata_file_path, toString(version), toString(VERSION_FULL_OBJECT_KEY));
-
-    assertChar('\n', buf);
 
     UInt32 keys_count;
     readIntText(keys_count, buf);
@@ -122,6 +121,7 @@ void DiskObjectStorageMetadata::serialize(WriteBuffer & buf, bool sync) const
 
     chassert(write_version >= VERSION_ABSOLUTE_PATHS && write_version <= VERSION_FULL_OBJECT_KEY);
     writeIntText(write_version, buf);
+
     writeChar('\n', buf);
 
     writeIntText(keys_with_meta.size(), buf);

--- a/src/Disks/ObjectStorages/S3/S3ObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/S3/S3ObjectStorage.cpp
@@ -17,7 +17,6 @@
 #include <Interpreters/threadPoolCallbackRunner.h>
 #include <Disks/ObjectStorages/S3/diskSettings.h>
 
-#include <Common/getRandomASCIIString.h>
 #include <Common/ProfileEvents.h>
 #include <Common/StringUtils/StringUtils.h>
 #include <Common/logger_useful.h>
@@ -520,27 +519,12 @@ std::unique_ptr<IObjectStorage> S3ObjectStorage::cloneObjectStorage(
     return std::make_unique<S3ObjectStorage>(
         std::move(new_client), std::move(new_s3_settings),
         version_id, s3_capabilities, new_namespace,
-        endpoint, object_key_prefix);
+        endpoint, key_generator);
 }
 
-ObjectStorageKey S3ObjectStorage::generateObjectKeyForPath(const std::string &) const
+ObjectStorageKey S3ObjectStorage::generateObjectKeyForPath(const std::string & path) const
 {
-    /// Path to store the new S3 object.
-
-    /// Total length is 32 a-z characters for enough randomness.
-    /// First 3 characters are used as a prefix for
-    /// https://aws.amazon.com/premiumsupport/knowledge-center/s3-object-key-naming-pattern/
-
-    constexpr size_t key_name_total_size = 32;
-    constexpr size_t key_name_prefix_size = 3;
-
-    /// Path to store new S3 object.
-    String key = fmt::format("{}/{}",
-                             getRandomASCIIString(key_name_prefix_size),
-                             getRandomASCIIString(key_name_total_size - key_name_prefix_size));
-
-    /// what ever key_prefix value is, consider that key as relative
-    return ObjectStorageKey::createAsRelative(object_key_prefix, key);
+    return key_generator->generate(path);
 }
 
 

--- a/src/Disks/ObjectStorages/S3/S3ObjectStorage.h
+++ b/src/Disks/ObjectStorages/S3/S3ObjectStorage.h
@@ -9,6 +9,7 @@
 #include <memory>
 #include <Storages/StorageS3Settings.h>
 #include <Common/MultiVersion.h>
+#include <Common/ObjectStorageKeyGenerator.h>
 
 
 namespace DB
@@ -36,7 +37,6 @@ struct S3ObjectStorageSettings
     int32_t objects_chunk_size_to_delete;
 };
 
-
 class S3ObjectStorage : public IObjectStorage
 {
 private:
@@ -50,9 +50,9 @@ private:
         const S3Capabilities & s3_capabilities_,
         String bucket_,
         String connection_string,
-        String object_key_prefix_)
+        ObjectStorageKeysGeneratorPtr key_generator_)
         : bucket(std::move(bucket_))
-        , object_key_prefix(std::move(object_key_prefix_))
+        , key_generator(std::move(key_generator_))
         , client(std::move(client_))
         , s3_settings(std::move(s3_settings_))
         , s3_capabilities(s3_capabilities_)
@@ -172,7 +172,7 @@ private:
 
 private:
     std::string bucket;
-    String object_key_prefix;
+    ObjectStorageKeysGeneratorPtr key_generator;
 
 
     MultiVersion<S3::Client> client;
@@ -192,11 +192,6 @@ private:
 class S3PlainObjectStorage : public S3ObjectStorage
 {
 public:
-    ObjectStorageKey generateObjectKeyForPath(const std::string & path) const override
-    {
-        return ObjectStorageKey::createAsRelative(object_key_prefix, path);
-    }
-
     std::string getName() const override { return "S3PlainObjectStorage"; }
 
     template <class ...Args>

--- a/src/Disks/ObjectStorages/S3/registerDiskS3.cpp
+++ b/src/Disks/ObjectStorages/S3/registerDiskS3.cpp
@@ -91,6 +91,60 @@ private:
     }
 };
 
+std::pair<String, ObjectStorageKeysGeneratorPtr> getPrefixAndKeyGenerator(
+    String type, const S3::URI & uri, const Poco::Util::AbstractConfiguration & config, const String & config_prefix)
+{
+    if (type == "s3_plain")
+        return {uri.key, createObjectStorageKeysGeneratorAsIsWithPrefix(uri.key)};
+
+    chassert(type == "s3");
+
+    bool storage_metadata_write_full_object_key = DiskObjectStorageMetadata::getWriteFullObjectKeySetting();
+    bool send_metadata = config.getBool(config_prefix + ".send_metadata", false);
+
+    if (send_metadata && storage_metadata_write_full_object_key)
+        throw Exception(ErrorCodes::BAD_ARGUMENTS,
+                        "Wrong configuration in {}. "
+                        "s3 does not supports feature 'send_metadata' with feature 'storage_metadata_write_full_object_key'.",
+                        config_prefix);
+
+    String object_key_compatibility_prefix = config.getString(config_prefix + ".key_compatibility_prefix", String());
+    String object_key_template = config.getString(config_prefix + ".key_template", String());
+
+    if (object_key_template.empty())
+    {
+        if (!object_key_compatibility_prefix.empty())
+            throw Exception(ErrorCodes::BAD_ARGUMENTS,
+                            "Wrong configuration in {}. "
+                            "Setting 'key_compatibility_prefix' can be defined only with setting 'key_template'.",
+                            config_prefix);
+
+        return {uri.key, createObjectStorageKeysGeneratorByPrefix(uri.key)};
+    }
+
+    if (send_metadata)
+        throw Exception(ErrorCodes::BAD_ARGUMENTS,
+                        "Wrong configuration in {}. "
+                        "s3 does not supports send_metadata with setting 'key_template'.",
+                        config_prefix);
+
+    if (!storage_metadata_write_full_object_key)
+        throw Exception(ErrorCodes::BAD_ARGUMENTS,
+                        "Wrong configuration in {}. "
+                        "Feature 'storage_metadata_write_full_object_key' has to be enabled in order to use setting 'key_template'.",
+                        config_prefix);
+
+    if (!uri.key.empty())
+        throw Exception(ErrorCodes::BAD_ARGUMENTS,
+                        "Wrong configuration in {}. "
+                        "URI.key is forbidden with settings 'key_template', use setting 'key_compatibility_prefix' instead'. "
+                        "URI.key: '{}', bucket: '{}'. ",
+                        config_prefix,
+                        uri.key, uri.bucket);
+
+    return {object_key_compatibility_prefix, createObjectStorageKeysGeneratorByTemplate(object_key_template)};
+}
+
 }
 
 void registerDiskS3(DiskFactory & factory, bool global_skip_access_check)
@@ -104,7 +158,8 @@ void registerDiskS3(DiskFactory & factory, bool global_skip_access_check)
     {
         String endpoint = context->getMacros()->expand(config.getString(config_prefix + ".endpoint"));
         S3::URI uri(endpoint);
-        if (!uri.key.ends_with('/'))
+        // an empty key remains empty
+        if (!uri.key.empty() && !uri.key.ends_with('/'))
             uri.key.push_back('/');
 
         S3Capabilities s3_capabilities = getCapabilitiesFromConfig(config, config_prefix);
@@ -112,6 +167,8 @@ void registerDiskS3(DiskFactory & factory, bool global_skip_access_check)
 
         String type = config.getString(config_prefix + ".type");
         chassert(type == "s3" || type == "s3_plain");
+
+        auto [object_key_compatibility_prefix, object_key_generator] = getPrefixAndKeyGenerator(type, uri, config, config_prefix);
 
         MetadataStoragePtr metadata_storage;
         auto settings = getSettings(config, config_prefix, context);
@@ -127,16 +184,18 @@ void registerDiskS3(DiskFactory & factory, bool global_skip_access_check)
                 throw Exception(ErrorCodes::BAD_ARGUMENTS, "s3_plain does not supports send_metadata");
 
             s3_storage = std::make_shared<S3PlainObjectStorage>(
-                std::move(client), std::move(settings), uri.version_id, s3_capabilities, uri.bucket, uri.endpoint, uri.key);
+                std::move(client), std::move(settings), uri.version_id, s3_capabilities, uri.bucket, uri.endpoint, object_key_generator);
 
-            metadata_storage = std::make_shared<MetadataStorageFromPlainObjectStorage>(s3_storage, uri.key);
+            metadata_storage = std::make_shared<MetadataStorageFromPlainObjectStorage>(s3_storage, object_key_compatibility_prefix);
         }
         else
         {
             s3_storage = std::make_shared<S3ObjectStorage>(
-                std::move(client), std::move(settings), uri.version_id, s3_capabilities, uri.bucket, uri.endpoint, uri.key);
+                std::move(client), std::move(settings), uri.version_id, s3_capabilities, uri.bucket, uri.endpoint, object_key_generator);
+
             auto [metadata_path, metadata_disk] = prepareForLocalMetadata(name, config, config_prefix, context);
-            metadata_storage = std::make_shared<MetadataStorageFromDisk>(metadata_disk, uri.key);
+
+            metadata_storage = std::make_shared<MetadataStorageFromDisk>(metadata_disk, object_key_compatibility_prefix);
         }
 
         /// NOTE: should we still perform this check for clickhouse-disks?
@@ -159,7 +218,7 @@ void registerDiskS3(DiskFactory & factory, bool global_skip_access_check)
 
         DiskObjectStoragePtr s3disk = std::make_shared<DiskObjectStorage>(
             name,
-            uri.key,
+            uri.key, /// might be empty
             type == "s3" ? "DiskS3" : "DiskS3Plain",
             std::move(metadata_storage),
             std::move(s3_storage),

--- a/tests/integration/test_remote_blobs_naming/configs/setting.xml
+++ b/tests/integration/test_remote_blobs_naming/configs/setting.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<clickhouse>
+    <profiles>
+        <default>
+            <s3_check_objects_after_upload>1</s3_check_objects_after_upload>
+            <enable_s3_requests_logging>1</enable_s3_requests_logging>
+        </default>
+    </profiles>
+
+</clickhouse>

--- a/tests/integration/test_remote_blobs_naming/configs/storage_conf_new.xml
+++ b/tests/integration/test_remote_blobs_naming/configs/storage_conf_new.xml
@@ -20,6 +20,14 @@
                <secret_access_key>minio123</secret_access_key>
                <s3_allow_native_copy>true</s3_allow_native_copy>
            </s3_plain>
+            <s3_template_key>
+                <type>s3</type>
+                <endpoint>http://minio1:9001/root/</endpoint>
+                <access_key_id>minio</access_key_id>
+                <secret_access_key>minio123</secret_access_key>
+                <key_compatibility_prefix>old-style-prefix/with-several-section</key_compatibility_prefix>
+                <key_template>[a-z]{3}-first-random-part/constant-part/[a-z]{3}/[a-z]{29}</key_template>
+            </s3_template_key>
         </disks>
 
         <policies>
@@ -37,6 +45,13 @@
                     </main>
                 </volumes>
             </s3_plain>
+            <s3_template_key>
+                <volumes>
+                    <main>
+                        <disk>s3_template_key</disk>
+                    </main>
+                </volumes>
+            </s3_template_key>
         </policies>
     </storage_configuration>
 


### PR DESCRIPTION
This is built on the basis of https://github.com/ClickHouse/ClickHouse/pull/55566 as continuation of feature development https://github.com/ClickHouse/ClickHouse/issues/55217

Generation path by template is 10% slower (`new/old=1.094`) then custom function. See the results of `gtest::ObjectStorageKey::Performance`. Actually I did a good optimization here. It was almost 3 times slower at the begging (`new/old=2.8`).

### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Will fill later

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)