### PR TITLE
Fix: race condition in kusto implementation

### DIFF
--- a/src/Parsers/Kusto/KustoFunctions/IParserKQLFunction.cpp
+++ b/src/Parsers/Kusto/KustoFunctions/IParserKQLFunction.cpp
@@ -110,7 +110,7 @@ String IParserKQLFunction::generateUniqueIdentifier()
     // This particular random generator hits each number exactly once before looping over.
     // Because of this, it's sufficient for queries consisting of up to 2^16 (= 65536) distinct function calls.
     // Reference: https://www.pcg-random.org/using-pcg-cpp.html#insecure-generators
-    static pcg32_once_insecure random_generator;
+    static thread_local pcg32_once_insecure random_generator;
     return std::to_string(random_generator());
 }
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

following #42510 
fix race condition, found by thread sanitizer:
https://s3.amazonaws.com/clickhouse-test-reports/0/299845b422ebcffaa2af4dd435785abd5c9cebb6/stateless_tests__tsan__[5_5]/run.log
