### PR TITLE
MySQL compatibility: allow to configure String/FixedString BLOB vs TEXT mapping

### DIFF
--- a/docs/en/operations/settings/settings.md
+++ b/docs/en/operations/settings/settings.md
@@ -3290,7 +3290,7 @@ Possible values:
 
 Default value: `0`.
 
-## mysql_remap_string_as_text_in_show_columns {#mysql_remap_string_as_text_in_show_columns}
+## mysql_map_string_to_text_in_show_columns {#mysql_map_string_to_text_in_show_columns}
 
 When enabled, [String](../../sql-reference/data-types/string.md) ClickHouse data type will be displayed as `TEXT` in [SHOW COLUMNS](../../sql-reference/statements/show.md#show_columns).
 
@@ -3301,7 +3301,7 @@ Has effect only when [use_mysql_types_in_show_columns](#use_mysql_types_in_show_
 
 Default value: `0`.
 
-## mysql_remap_fixed_string_as_text_in_show_columns {#mysql_remap_fixed_string_as_text_in_show_columns}
+## mysql_map_fixed_string_to_text_in_show_columns {#mysql_map_fixed_string_to_text_in_show_columns}
 
 When enabled, [FixedString](../../sql-reference/data-types/fixedstring.md) ClickHouse data type will be displayed as `TEXT` in [SHOW COLUMNS](../../sql-reference/statements/show.md#show_columns).
 

--- a/docs/en/operations/settings/settings.md
+++ b/docs/en/operations/settings/settings.md
@@ -3290,6 +3290,28 @@ Possible values:
 
 Default value: `0`.
 
+## mysql_remap_string_as_text_in_show_columns {#mysql_remap_string_as_text_in_show_columns}
+
+When enabled, [String](../../sql-reference/data-types/string.md) ClickHouse data type will be displayed as `TEXT` in [SHOW COLUMNS](../../sql-reference/statements/show.md#show_columns).
+
+Has effect only when [use_mysql_types_in_show_columns](#use_mysql_types_in_show_columns) is enabled.
+
+- 0 - Use `BLOB`.
+- 1 - Use `TEXT`.
+
+Default value: `0`.
+
+## mysql_remap_fixed_string_as_text_in_show_columns {#mysql_remap_fixed_string_as_text_in_show_columns}
+
+When enabled, [FixedString](../../sql-reference/data-types/fixedstring.md) ClickHouse data type will be displayed as `TEXT` in [SHOW COLUMNS](../../sql-reference/statements/show.md#show_columns).
+
+Has effect only when [use_mysql_types_in_show_columns](#use_mysql_types_in_show_columns) is enabled.
+
+- 0 - Use `BLOB`.
+- 1 - Use `TEXT`.
+
+Default value: `0`.
+
 ## execute_merges_on_single_replica_time_threshold {#execute-merges-on-single-replica-time-threshold}
 
 Enables special logic to perform merges on replicas.

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -205,7 +205,9 @@ class IColumn;
     M(Bool, allow_experimental_inverted_index, false, "If it is set to true, allow to use experimental inverted index.", 0) \
     \
     M(UInt64, mysql_max_rows_to_insert, 65536, "The maximum number of rows in MySQL batch insertion of the MySQL storage engine", 0) \
-    M(Bool, use_mysql_types_in_show_columns, false, "Show MySQL types in SHOW COLUMNS and system.columns", 0) \
+    M(Bool, use_mysql_types_in_show_columns, false, "Show native MySQL types in SHOW [FULL] COLUMNS", 0) \
+    M(Bool, mysql_remap_string_as_text_in_show_columns, false, "If enabled, String type will be mapped to TEXT in SHOW [FULL] COLUMNS, BLOB otherwise. Only works if use_mysql_types_in_show_columns is enabled too", 0) \
+    M(Bool, mysql_remap_fixed_string_as_text_in_show_columns, false, "If enabled, FixedString type will be mapped to TEXT in SHOW [FULL] COLUMNS, BLOB otherwise. Only works if use_mysql_types_in_show_columns is enabled too", 0) \
     \
     M(UInt64, optimize_min_equality_disjunction_chain_length, 3, "The minimum length of the expression `expr = x1 OR ... expr = xN` for optimization ", 0) \
     \

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -206,8 +206,8 @@ class IColumn;
     \
     M(UInt64, mysql_max_rows_to_insert, 65536, "The maximum number of rows in MySQL batch insertion of the MySQL storage engine", 0) \
     M(Bool, use_mysql_types_in_show_columns, false, "Show native MySQL types in SHOW [FULL] COLUMNS", 0) \
-    M(Bool, mysql_remap_string_as_text_in_show_columns, false, "If enabled, String type will be mapped to TEXT in SHOW [FULL] COLUMNS, BLOB otherwise. Only works if use_mysql_types_in_show_columns is enabled too", 0) \
-    M(Bool, mysql_remap_fixed_string_as_text_in_show_columns, false, "If enabled, FixedString type will be mapped to TEXT in SHOW [FULL] COLUMNS, BLOB otherwise. Only works if use_mysql_types_in_show_columns is enabled too", 0) \
+    M(Bool, mysql_map_string_to_text_in_show_columns, false, "If enabled, String type will be mapped to TEXT in SHOW [FULL] COLUMNS, BLOB otherwise. Will only take effect if use_mysql_types_in_show_columns is enabled too", 0) \
+    M(Bool, mysql_map_fixed_string_to_text_in_show_columns, false, "If enabled, FixedString type will be mapped to TEXT in SHOW [FULL] COLUMNS, BLOB otherwise. Will only take effect if use_mysql_types_in_show_columns is enabled too", 0) \
     \
     M(UInt64, optimize_min_equality_disjunction_chain_length, 3, "The minimum length of the expression `expr = x1 OR ... expr = xN` for optimization ", 0) \
     \

--- a/tests/queries/0_stateless/02775_show_columns_mysql_compatibility.reference
+++ b/tests/queries/0_stateless/02775_show_columns_mysql_compatibility.reference
@@ -120,7 +120,7 @@ ui32	INTEGER UNSIGNED	NO		\N
 ui64	BIGINT UNSIGNED	NO		\N	
 ui8	TINYINT UNSIGNED	NO		\N	
 uuid	CHAR	NO		\N	
--- SHOW COLUMNS with mysql_remap_string_as_text_in_show_columns = 1
+-- SHOW COLUMNS with mysql_map_string_to_text_in_show_columns = 1
 a	TEXT	NO		\N	
 agg	TEXT	NO		\N	
 b	TINYINT	NO		\N	
@@ -181,7 +181,7 @@ ui32	INTEGER UNSIGNED	NO		\N
 ui64	BIGINT UNSIGNED	NO		\N	
 ui8	TINYINT UNSIGNED	NO		\N	
 uuid	CHAR	NO		\N	
--- SHOW COLUMNS with mysql_remap_fixed_string_as_text_in_show_columns = 1
+-- SHOW COLUMNS with mysql_map_fixed_string_to_text_in_show_columns = 1
 a	TEXT	NO		\N	
 agg	TEXT	NO		\N	
 b	TINYINT	NO		\N	
@@ -242,64 +242,125 @@ ui32	INTEGER UNSIGNED	NO		\N
 ui64	BIGINT UNSIGNED	NO		\N	
 ui8	TINYINT UNSIGNED	NO		\N	
 uuid	CHAR	NO		\N	
--- SHOW COLUMNS with both mysql_remap_string_as_text_in_show_columns = 1 and mysql_remap_fixed_string_as_text_in_show_columns = 1
-a	TEXT	NO		\N	
-agg	TEXT	NO		\N	
-b	TINYINT	NO		\N	
-d	DATE	NO		\N	
-d32	DATE	NO		\N	
-dec128	DECIMAL(38, 2)	NO		\N	
-dec128_native	DECIMAL(35, 30)	NO		\N	
-dec128_text	TEXT	NO		\N	
-dec256	TEXT	NO		\N	
-dec256_native	DECIMAL(65, 2)	NO		\N	
-dec256_text	TEXT	NO		\N	
-dec32	DECIMAL(9, 2)	NO		\N	
-dec64	DECIMAL(18, 2)	NO		\N	
-dt	DATETIME	NO		\N	
-dt64	DATETIME	NO		\N	
-dt64_3_tz1	DATETIME	NO		\N	
-dt64_3_tz2	DATETIME	NO		\N	
-dt64_6	DATETIME	NO		\N	
-dt64_9	DATETIME	NO		\N	
-dt_tz1	DATETIME	NO		\N	
-dt_tz2	DATETIME	NO		\N	
-enm	TEXT	NO		\N	
-f32	FLOAT	NO		\N	
-f64	DOUBLE	NO		\N	
-fs	TEXT	NO		\N	
-i128	TEXT	NO		\N	
-i16	SMALLINT	NO		\N	
-i256	TEXT	NO		\N	
-i32	INTEGER	NO		\N	
-i64	BIGINT	NO		\N	
-i8	TINYINT	NO		\N	
-ip4	TEXT	NO		\N	
-ip6	TEXT	NO		\N	
-lfs	TEXT	NO		\N	
-lnfs	TEXT	YES		\N	
-lns	TEXT	YES		\N	
-ls	TEXT	NO		\N	
-m	JSON	NO		\N	
-m_complex	JSON	NO		\N	
-mpg	TEXT	NO		\N	
-ndt64	DATETIME	YES		\N	
-ndt64_tz	DATETIME	YES		\N	
-nested.col1	TEXT	NO		\N	
-nested.col2	TEXT	NO		\N	
-nfs	TEXT	YES		\N	
-ns	TEXT	YES		\N	
-o	JSON	NO		\N	
-p	TEXT	NO		\N	
-pg	TEXT	NO		\N	
-r	TEXT	NO		\N	
-s	TEXT	NO		\N	
-sagg	TEXT	NO		\N	
-t	JSON	NO		\N	
-ui128	TEXT	NO		\N	
-ui16	SMALLINT UNSIGNED	NO		\N	
-ui256	TEXT	NO		\N	
-ui32	INTEGER UNSIGNED	NO		\N	
-ui64	BIGINT UNSIGNED	NO		\N	
-ui8	TINYINT UNSIGNED	NO		\N	
-uuid	CHAR	NO		\N	
+-- SHOW COLUMNS with mysql_map_string_to_text_in_show_columns = 1 and without use_mysql_types_in_show_columns
+a	Array(String)	NO		\N	
+agg	AggregateFunction(uniq, UInt64)	NO		\N	
+b	Bool	NO		\N	
+d	Date	NO		\N	
+d32	Date32	NO		\N	
+dec128	Decimal(38, 2)	NO		\N	
+dec128_native	Decimal(35, 30)	NO		\N	
+dec128_text	Decimal(35, 31)	NO		\N	
+dec256	Decimal(76, 2)	NO		\N	
+dec256_native	Decimal(65, 2)	NO		\N	
+dec256_text	Decimal(66, 2)	NO		\N	
+dec32	Decimal(9, 2)	NO		\N	
+dec64	Decimal(18, 2)	NO		\N	
+dt	DateTime	NO		\N	
+dt64	DateTime64(3)	NO		\N	
+dt64_3_tz1	DateTime64(3, \'UTC\')	NO		\N	
+dt64_3_tz2	DateTime64(3, \'Asia/Shanghai\')	NO		\N	
+dt64_6	DateTime64(6, \'UTC\')	NO		\N	
+dt64_9	DateTime64(9, \'UTC\')	NO		\N	
+dt_tz1	DateTime(\'UTC\')	NO		\N	
+dt_tz2	DateTime(\'Europe/Amsterdam\')	NO		\N	
+enm	Enum8(\'hallo\' = 1, \'welt\' = 2)	NO		\N	
+f32	Float32	NO		\N	
+f64	Float64	NO		\N	
+fs	FixedString(3)	NO		\N	
+i128	Int128	NO		\N	
+i16	Int16	NO		\N	
+i256	Int256	NO		\N	
+i32	Int32	NO		\N	
+i64	Int64	NO		\N	
+i8	Int8	NO		\N	
+ip4	IPv4	NO		\N	
+ip6	IPv6	NO		\N	
+lfs	LowCardinality(FixedString(3))	NO		\N	
+lnfs	LowCardinality(Nullable(FixedString(3)))	YES		\N	
+lns	LowCardinality(Nullable(String))	YES		\N	
+ls	LowCardinality(String)	NO		\N	
+m	Map(Int32, String)	NO		\N	
+m_complex	Map(Int32, Map(Int32, LowCardinality(Nullable(String))))	NO		\N	
+mpg	MultiPolygon	NO		\N	
+ndt64	Nullable(DateTime64(3))	YES		\N	
+ndt64_tz	Nullable(DateTime64(3, \'Asia/Shanghai\'))	YES		\N	
+nested.col1	Array(String)	NO		\N	
+nested.col2	Array(UInt32)	NO		\N	
+nfs	Nullable(FixedString(3))	YES		\N	
+ns	Nullable(String)	YES		\N	
+o	Object(\'json\')	NO		\N	
+p	Point	NO		\N	
+pg	Polygon	NO		\N	
+r	Ring	NO		\N	
+s	String	NO		\N	
+sagg	SimpleAggregateFunction(sum, Float64)	NO		\N	
+t	Tuple(Int32, String, Nullable(String), LowCardinality(String), LowCardinality(Nullable(String)), Tuple(Int32, String))	NO		\N	
+ui128	UInt128	NO		\N	
+ui16	UInt16	NO		\N	
+ui256	UInt256	NO		\N	
+ui32	UInt32	NO		\N	
+ui64	UInt64	NO		\N	
+ui8	UInt8	NO		\N	
+uuid	UUID	NO		\N	
+-- SHOW COLUMNS with mysql_map_fixed_string_to_text_in_show_columns = 1 and without use_mysql_types_in_show_columns
+a	Array(String)	NO		\N	
+agg	AggregateFunction(uniq, UInt64)	NO		\N	
+b	Bool	NO		\N	
+d	Date	NO		\N	
+d32	Date32	NO		\N	
+dec128	Decimal(38, 2)	NO		\N	
+dec128_native	Decimal(35, 30)	NO		\N	
+dec128_text	Decimal(35, 31)	NO		\N	
+dec256	Decimal(76, 2)	NO		\N	
+dec256_native	Decimal(65, 2)	NO		\N	
+dec256_text	Decimal(66, 2)	NO		\N	
+dec32	Decimal(9, 2)	NO		\N	
+dec64	Decimal(18, 2)	NO		\N	
+dt	DateTime	NO		\N	
+dt64	DateTime64(3)	NO		\N	
+dt64_3_tz1	DateTime64(3, \'UTC\')	NO		\N	
+dt64_3_tz2	DateTime64(3, \'Asia/Shanghai\')	NO		\N	
+dt64_6	DateTime64(6, \'UTC\')	NO		\N	
+dt64_9	DateTime64(9, \'UTC\')	NO		\N	
+dt_tz1	DateTime(\'UTC\')	NO		\N	
+dt_tz2	DateTime(\'Europe/Amsterdam\')	NO		\N	
+enm	Enum8(\'hallo\' = 1, \'welt\' = 2)	NO		\N	
+f32	Float32	NO		\N	
+f64	Float64	NO		\N	
+fs	FixedString(3)	NO		\N	
+i128	Int128	NO		\N	
+i16	Int16	NO		\N	
+i256	Int256	NO		\N	
+i32	Int32	NO		\N	
+i64	Int64	NO		\N	
+i8	Int8	NO		\N	
+ip4	IPv4	NO		\N	
+ip6	IPv6	NO		\N	
+lfs	LowCardinality(FixedString(3))	NO		\N	
+lnfs	LowCardinality(Nullable(FixedString(3)))	YES		\N	
+lns	LowCardinality(Nullable(String))	YES		\N	
+ls	LowCardinality(String)	NO		\N	
+m	Map(Int32, String)	NO		\N	
+m_complex	Map(Int32, Map(Int32, LowCardinality(Nullable(String))))	NO		\N	
+mpg	MultiPolygon	NO		\N	
+ndt64	Nullable(DateTime64(3))	YES		\N	
+ndt64_tz	Nullable(DateTime64(3, \'Asia/Shanghai\'))	YES		\N	
+nested.col1	Array(String)	NO		\N	
+nested.col2	Array(UInt32)	NO		\N	
+nfs	Nullable(FixedString(3))	YES		\N	
+ns	Nullable(String)	YES		\N	
+o	Object(\'json\')	NO		\N	
+p	Point	NO		\N	
+pg	Polygon	NO		\N	
+r	Ring	NO		\N	
+s	String	NO		\N	
+sagg	SimpleAggregateFunction(sum, Float64)	NO		\N	
+t	Tuple(Int32, String, Nullable(String), LowCardinality(String), LowCardinality(Nullable(String)), Tuple(Int32, String))	NO		\N	
+ui128	UInt128	NO		\N	
+ui16	UInt16	NO		\N	
+ui256	UInt256	NO		\N	
+ui32	UInt32	NO		\N	
+ui64	UInt64	NO		\N	
+ui8	UInt8	NO		\N	
+uuid	UUID	NO		\N	

--- a/tests/queries/0_stateless/02775_show_columns_mysql_compatibility.reference
+++ b/tests/queries/0_stateless/02775_show_columns_mysql_compatibility.reference
@@ -84,6 +84,128 @@ dt_tz2	DATETIME	NO		\N
 enm	TEXT	NO		\N	
 f32	FLOAT	NO		\N	
 f64	DOUBLE	NO		\N	
+fs	BLOB	NO		\N	
+i128	TEXT	NO		\N	
+i16	SMALLINT	NO		\N	
+i256	TEXT	NO		\N	
+i32	INTEGER	NO		\N	
+i64	BIGINT	NO		\N	
+i8	TINYINT	NO		\N	
+ip4	TEXT	NO		\N	
+ip6	TEXT	NO		\N	
+lfs	BLOB	NO		\N	
+lnfs	BLOB	YES		\N	
+lns	BLOB	YES		\N	
+ls	BLOB	NO		\N	
+m	JSON	NO		\N	
+m_complex	JSON	NO		\N	
+mpg	TEXT	NO		\N	
+ndt64	DATETIME	YES		\N	
+ndt64_tz	DATETIME	YES		\N	
+nested.col1	TEXT	NO		\N	
+nested.col2	TEXT	NO		\N	
+nfs	BLOB	YES		\N	
+ns	BLOB	YES		\N	
+o	JSON	NO		\N	
+p	TEXT	NO		\N	
+pg	TEXT	NO		\N	
+r	TEXT	NO		\N	
+s	BLOB	NO		\N	
+sagg	TEXT	NO		\N	
+t	JSON	NO		\N	
+ui128	TEXT	NO		\N	
+ui16	SMALLINT UNSIGNED	NO		\N	
+ui256	TEXT	NO		\N	
+ui32	INTEGER UNSIGNED	NO		\N	
+ui64	BIGINT UNSIGNED	NO		\N	
+ui8	TINYINT UNSIGNED	NO		\N	
+uuid	CHAR	NO		\N	
+-- SHOW COLUMNS with mysql_remap_string_as_text_in_show_columns = 1
+a	TEXT	NO		\N	
+agg	TEXT	NO		\N	
+b	TINYINT	NO		\N	
+d	DATE	NO		\N	
+d32	DATE	NO		\N	
+dec128	DECIMAL(38, 2)	NO		\N	
+dec128_native	DECIMAL(35, 30)	NO		\N	
+dec128_text	TEXT	NO		\N	
+dec256	TEXT	NO		\N	
+dec256_native	DECIMAL(65, 2)	NO		\N	
+dec256_text	TEXT	NO		\N	
+dec32	DECIMAL(9, 2)	NO		\N	
+dec64	DECIMAL(18, 2)	NO		\N	
+dt	DATETIME	NO		\N	
+dt64	DATETIME	NO		\N	
+dt64_3_tz1	DATETIME	NO		\N	
+dt64_3_tz2	DATETIME	NO		\N	
+dt64_6	DATETIME	NO		\N	
+dt64_9	DATETIME	NO		\N	
+dt_tz1	DATETIME	NO		\N	
+dt_tz2	DATETIME	NO		\N	
+enm	TEXT	NO		\N	
+f32	FLOAT	NO		\N	
+f64	DOUBLE	NO		\N	
+fs	BLOB	NO		\N	
+i128	TEXT	NO		\N	
+i16	SMALLINT	NO		\N	
+i256	TEXT	NO		\N	
+i32	INTEGER	NO		\N	
+i64	BIGINT	NO		\N	
+i8	TINYINT	NO		\N	
+ip4	TEXT	NO		\N	
+ip6	TEXT	NO		\N	
+lfs	BLOB	NO		\N	
+lnfs	BLOB	YES		\N	
+lns	TEXT	YES		\N	
+ls	TEXT	NO		\N	
+m	JSON	NO		\N	
+m_complex	JSON	NO		\N	
+mpg	TEXT	NO		\N	
+ndt64	DATETIME	YES		\N	
+ndt64_tz	DATETIME	YES		\N	
+nested.col1	TEXT	NO		\N	
+nested.col2	TEXT	NO		\N	
+nfs	BLOB	YES		\N	
+ns	TEXT	YES		\N	
+o	JSON	NO		\N	
+p	TEXT	NO		\N	
+pg	TEXT	NO		\N	
+r	TEXT	NO		\N	
+s	TEXT	NO		\N	
+sagg	TEXT	NO		\N	
+t	JSON	NO		\N	
+ui128	TEXT	NO		\N	
+ui16	SMALLINT UNSIGNED	NO		\N	
+ui256	TEXT	NO		\N	
+ui32	INTEGER UNSIGNED	NO		\N	
+ui64	BIGINT UNSIGNED	NO		\N	
+ui8	TINYINT UNSIGNED	NO		\N	
+uuid	CHAR	NO		\N	
+-- SHOW COLUMNS with mysql_remap_fixed_string_as_text_in_show_columns = 1
+a	TEXT	NO		\N	
+agg	TEXT	NO		\N	
+b	TINYINT	NO		\N	
+d	DATE	NO		\N	
+d32	DATE	NO		\N	
+dec128	DECIMAL(38, 2)	NO		\N	
+dec128_native	DECIMAL(35, 30)	NO		\N	
+dec128_text	TEXT	NO		\N	
+dec256	TEXT	NO		\N	
+dec256_native	DECIMAL(65, 2)	NO		\N	
+dec256_text	TEXT	NO		\N	
+dec32	DECIMAL(9, 2)	NO		\N	
+dec64	DECIMAL(18, 2)	NO		\N	
+dt	DATETIME	NO		\N	
+dt64	DATETIME	NO		\N	
+dt64_3_tz1	DATETIME	NO		\N	
+dt64_3_tz2	DATETIME	NO		\N	
+dt64_6	DATETIME	NO		\N	
+dt64_9	DATETIME	NO		\N	
+dt_tz1	DATETIME	NO		\N	
+dt_tz2	DATETIME	NO		\N	
+enm	TEXT	NO		\N	
+f32	FLOAT	NO		\N	
+f64	DOUBLE	NO		\N	
 fs	TEXT	NO		\N	
 i128	TEXT	NO		\N	
 i16	SMALLINT	NO		\N	
@@ -111,6 +233,67 @@ p	TEXT	NO		\N
 pg	TEXT	NO		\N	
 r	TEXT	NO		\N	
 s	BLOB	NO		\N	
+sagg	TEXT	NO		\N	
+t	JSON	NO		\N	
+ui128	TEXT	NO		\N	
+ui16	SMALLINT UNSIGNED	NO		\N	
+ui256	TEXT	NO		\N	
+ui32	INTEGER UNSIGNED	NO		\N	
+ui64	BIGINT UNSIGNED	NO		\N	
+ui8	TINYINT UNSIGNED	NO		\N	
+uuid	CHAR	NO		\N	
+-- SHOW COLUMNS with both mysql_remap_string_as_text_in_show_columns = 1 and mysql_remap_fixed_string_as_text_in_show_columns = 1
+a	TEXT	NO		\N	
+agg	TEXT	NO		\N	
+b	TINYINT	NO		\N	
+d	DATE	NO		\N	
+d32	DATE	NO		\N	
+dec128	DECIMAL(38, 2)	NO		\N	
+dec128_native	DECIMAL(35, 30)	NO		\N	
+dec128_text	TEXT	NO		\N	
+dec256	TEXT	NO		\N	
+dec256_native	DECIMAL(65, 2)	NO		\N	
+dec256_text	TEXT	NO		\N	
+dec32	DECIMAL(9, 2)	NO		\N	
+dec64	DECIMAL(18, 2)	NO		\N	
+dt	DATETIME	NO		\N	
+dt64	DATETIME	NO		\N	
+dt64_3_tz1	DATETIME	NO		\N	
+dt64_3_tz2	DATETIME	NO		\N	
+dt64_6	DATETIME	NO		\N	
+dt64_9	DATETIME	NO		\N	
+dt_tz1	DATETIME	NO		\N	
+dt_tz2	DATETIME	NO		\N	
+enm	TEXT	NO		\N	
+f32	FLOAT	NO		\N	
+f64	DOUBLE	NO		\N	
+fs	TEXT	NO		\N	
+i128	TEXT	NO		\N	
+i16	SMALLINT	NO		\N	
+i256	TEXT	NO		\N	
+i32	INTEGER	NO		\N	
+i64	BIGINT	NO		\N	
+i8	TINYINT	NO		\N	
+ip4	TEXT	NO		\N	
+ip6	TEXT	NO		\N	
+lfs	TEXT	NO		\N	
+lnfs	TEXT	YES		\N	
+lns	TEXT	YES		\N	
+ls	TEXT	NO		\N	
+m	JSON	NO		\N	
+m_complex	JSON	NO		\N	
+mpg	TEXT	NO		\N	
+ndt64	DATETIME	YES		\N	
+ndt64_tz	DATETIME	YES		\N	
+nested.col1	TEXT	NO		\N	
+nested.col2	TEXT	NO		\N	
+nfs	TEXT	YES		\N	
+ns	TEXT	YES		\N	
+o	JSON	NO		\N	
+p	TEXT	NO		\N	
+pg	TEXT	NO		\N	
+r	TEXT	NO		\N	
+s	TEXT	NO		\N	
 sagg	TEXT	NO		\N	
 t	JSON	NO		\N	
 ui128	TEXT	NO		\N	

--- a/tests/queries/0_stateless/02775_show_columns_mysql_compatibility.sql
+++ b/tests/queries/0_stateless/02775_show_columns_mysql_compatibility.sql
@@ -78,4 +78,13 @@ SHOW COLUMNS FROM tab SETTINGS use_mysql_types_in_show_columns = 0;
 SELECT '-- SHOW COLUMNS with use_mysql_types_in_show_columns = 1';
 SHOW COLUMNS FROM tab SETTINGS use_mysql_types_in_show_columns = 1;
 
+SELECT '-- SHOW COLUMNS with mysql_remap_string_as_text_in_show_columns = 1';
+SHOW COLUMNS FROM tab SETTINGS mysql_remap_string_as_text_in_show_columns=1;
+
+SELECT '-- SHOW COLUMNS with mysql_remap_fixed_string_as_text_in_show_columns = 1';
+SHOW COLUMNS FROM tab SETTINGS mysql_remap_fixed_string_as_text_in_show_columns=1;
+
+SELECT '-- SHOW COLUMNS with both mysql_remap_string_as_text_in_show_columns = 1 and mysql_remap_fixed_string_as_text_in_show_columns = 1';
+SHOW COLUMNS FROM tab SETTINGS mysql_remap_string_as_text_in_show_columns=1, mysql_remap_fixed_string_as_text_in_show_columns=1;
+
 DROP TABLE tab;

--- a/tests/queries/0_stateless/02775_show_columns_mysql_compatibility.sql
+++ b/tests/queries/0_stateless/02775_show_columns_mysql_compatibility.sql
@@ -78,13 +78,16 @@ SHOW COLUMNS FROM tab SETTINGS use_mysql_types_in_show_columns = 0;
 SELECT '-- SHOW COLUMNS with use_mysql_types_in_show_columns = 1';
 SHOW COLUMNS FROM tab SETTINGS use_mysql_types_in_show_columns = 1;
 
-SELECT '-- SHOW COLUMNS with mysql_remap_string_as_text_in_show_columns = 1';
-SHOW COLUMNS FROM tab SETTINGS mysql_remap_string_as_text_in_show_columns=1;
+SELECT '-- SHOW COLUMNS with mysql_map_string_to_text_in_show_columns = 1';
+SHOW COLUMNS FROM tab SETTINGS use_mysql_types_in_show_columns = 1, mysql_map_string_to_text_in_show_columns=1;
 
-SELECT '-- SHOW COLUMNS with mysql_remap_fixed_string_as_text_in_show_columns = 1';
-SHOW COLUMNS FROM tab SETTINGS mysql_remap_fixed_string_as_text_in_show_columns=1;
+SELECT '-- SHOW COLUMNS with mysql_map_fixed_string_to_text_in_show_columns = 1';
+SHOW COLUMNS FROM tab SETTINGS use_mysql_types_in_show_columns = 1, mysql_map_fixed_string_to_text_in_show_columns=1;
 
-SELECT '-- SHOW COLUMNS with both mysql_remap_string_as_text_in_show_columns = 1 and mysql_remap_fixed_string_as_text_in_show_columns = 1';
-SHOW COLUMNS FROM tab SETTINGS mysql_remap_string_as_text_in_show_columns=1, mysql_remap_fixed_string_as_text_in_show_columns=1;
+SELECT '-- SHOW COLUMNS with mysql_map_string_to_text_in_show_columns = 1 and without use_mysql_types_in_show_columns';
+SHOW COLUMNS FROM tab SETTINGS use_mysql_types_in_show_columns = 0, mysql_map_string_to_text_in_show_columns=1;
+
+SELECT '-- SHOW COLUMNS with mysql_map_fixed_string_to_text_in_show_columns = 1 and without use_mysql_types_in_show_columns';
+SHOW COLUMNS FROM tab SETTINGS use_mysql_types_in_show_columns = 0, mysql_map_fixed_string_to_text_in_show_columns=1;
 
 DROP TABLE tab;


### PR DESCRIPTION
Resolves #53482
Resolves #52777

### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
`SHOW COLUMNS` now correctly reports type `FixedString` as `BLOB` if setting `use_mysql_types_in_show_columns` is on. Also added two new settings, `mysql_map_string_to_text_in_show_columns` and `mysql_map_fixed_string_to_text_in_show_columns` to switch the output for types `String` and `FixedString` as `TEXT` or `BLOB`.