### PR TITLE
Fix data-race in kusto parser (in random generator)

### DIFF
--- a/src/Parsers/Kusto/KustoFunctions/IParserKQLFunction.cpp
+++ b/src/Parsers/Kusto/KustoFunctions/IParserKQLFunction.cpp
@@ -110,7 +110,7 @@ String IParserKQLFunction::generateUniqueIdentifier()
     // This particular random generator hits each number exactly once before looping over.
     // Because of this, it's sufficient for queries consisting of up to 2^16 (= 65536) distinct function calls.
     // Reference: https://www.pcg-random.org/using-pcg-cpp.html#insecure-generators
-    static pcg32_once_insecure random_generator;
+    static thread_local pcg32_once_insecure random_generator;
     return std::to_string(random_generator());
 }
 


### PR DESCRIPTION
<details>

<summary>TSan report</summary>

    WARNING: ThreadSanitizer: data race (pid=739)
      Write of size 4 at 0x55e9cbcddc44 by thread T1577:
        0 pcg_detail::engine<unsigned int, unsigned int, pcg_detail::rxs_m_xs_mixin<unsigned int, unsigned int>, true, pcg_detail::specific_stream<unsigned int>, pcg_detail::default_multiplier<unsigned int>>::base_generate0() build_docker/./base/pcg-random/./pcg_random.hpp:420:16 (clickhouse+0x1bf6a0d5) (BuildId: 3de51f55ea4d1bb3b0d1f74325989a86b90a2956)
        1 pcg_detail::engine<unsigned int, unsigned int, pcg_detail::rxs_m_xs_mixin<unsigned int, unsigned int>, true, pcg_detail::specific_stream<unsigned int>, pcg_detail::default_multiplier<unsigned int>>::operator()() build_docker/./base/pcg-random/./pcg_random.hpp:428:33 (clickhouse+0x1bf6a0d5)
        2 DB::IParserKQLFunction::generateUniqueIdentifier() build_docker/./src/Parsers/Kusto/KustoFunctions/IParserKQLFunction.cpp:114:27 (clickhouse+0x1bf6a0d5)
        3 DB::Base64EncodeFromGuid::convertImpl(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>&, DB::IParser::Pos&) build_docker/./src/Parsers/Kusto/KustoFunctions/KQLStringFunctions.cpp:41:9 (clickhouse+0x1bfb2175) (BuildId: 3de51f55ea4d1bb3b0d1f74325989a86b90a2956)
        4 DB::IParserKQLFunction::convert(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>&, DB::IParser::Pos&)::$_0::operator()() const build_docker/./src/Parsers/Kusto/KustoFunctions/IParserKQLFunction.cpp:57:24 (clickhouse+0x1bf68900) (BuildId: 3de51f55ea4d1bb3b0d1f74325989a86b90a2956)
        5 bool DB::IParserKQLFunction::wrapConvertImpl<DB::IParserKQLFunction::convert(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>&, DB::IParser::Pos&)::$_0>(DB::IParser::Pos&, DB::IParserKQLFunction::IncreaseDepthTag, DB::IParserKQLFunction::convert(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>&, DB::IParser::Pos&)::$_0 const&) build_docker/./src/Parsers/Kusto/KustoFunctions/IParserKQLFunction.h:56:20 (clickhouse+0x1bf68900)
        6 DB::IParserKQLFunction::convert(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>&, DB::IParser::Pos&) build_docker/./src/Parsers/Kusto/KustoFunctions/IParserKQLFunction.cpp:52:12 (clickhouse+0x1bf68900)
        7 DB::IParserKQLFunction::getExpression(DB::IParser::Pos&) build_docker/./src/Parsers/Kusto/KustoFunctions/IParserKQLFunction.cpp:331:41 (clickhouse+0x1bf6c17b) (BuildId: 3de51f55ea4d1bb3b0d1f74325989a86b90a2956)
        8 DB::ParserKQLBase::getExprFromToken(DB::IParser::Pos&)::$_0::operator()(DB::IParser::Pos&, DB::IParser::Pos&) const build_docker/./src/Parsers/Kusto/ParserKQLQuery.cpp:218:29 (clickhouse+0x1bf1d065) (BuildId: 3de51f55ea4d1bb3b0d1f74325989a86b90a2956)

      Previous write of size 4 at 0x55e9cbcddc44 by thread T1580:
        0 pcg_detail::engine<unsigned int, unsigned int, pcg_detail::rxs_m_xs_mixin<unsigned int, unsigned int>, true, pcg_detail::specific_stream<unsigned int>, pcg_detail::default_multiplier<unsigned int>>::base_generate0() build_docker/./base/pcg-random/./pcg_random.hpp:420:16 (clickhouse+0x1bf6a0d5) (BuildId: 3de51f55ea4d1bb3b0d1f74325989a86b90a2956)
        1 pcg_detail::engine<unsigned int, unsigned int, pcg_detail::rxs_m_xs_mixin<unsigned int, unsigned int>, true, pcg_detail::specific_stream<unsigned int>, pcg_detail::default_multiplier<unsigned int>>::operator()() build_docker/./base/pcg-random/./pcg_random.hpp:428:33 (clickhouse+0x1bf6a0d5)
        2 DB::IParserKQLFunction::generateUniqueIdentifier() build_docker/./src/Parsers/Kusto/KustoFunctions/IParserKQLFunction.cpp:114:27 (clickhouse+0x1bf6a0d5)
        3 DB::ToBool::convertImpl(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>&, DB::IParser::Pos&) build_docker/./src/Parsers/Kusto/KustoFunctions/KQLCastingFunctions.cpp:24:9 (clickhouse+0x1bf854d5) (BuildId: 3de51f55ea4d1bb3b0d1f74325989a86b90a2956)
        4 DB::IParserKQLFunction::convert(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>&, DB::IParser::Pos&)::$_0::operator()() const build_docker/./src/Parsers/Kusto/KustoFunctions/IParserKQLFunction.cpp:57:24 (clickhouse+0x1bf68900) (BuildId: 3de51f55ea4d1bb3b0d1f74325989a86b90a2956)
        5 bool DB::IParserKQLFunction::wrapConvertImpl<DB::IParserKQLFunction::convert(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>&, DB::IParser::Pos&)::$_0>(DB::IParser::Pos&, DB::IParserKQLFunction::IncreaseDepthTag, DB::IParserKQLFunction::convert(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>&, DB::IParser::Pos&)::$_0 const&) build_docker/./src/Parsers/Kusto/KustoFunctions/IParserKQLFunction.h:56:20 (clickhouse+0x1bf68900)
        6 DB::IParserKQLFunction::convert(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>&, DB::IParser::Pos&) build_docker/./src/Parsers/Kusto/KustoFunctions/IParserKQLFunction.cpp:52:12 (clickhouse+0x1bf68900)
        7 DB::IParserKQLFunction::getExpression(DB::IParser::Pos&) build_docker/./src/Parsers/Kusto/KustoFunctions/IParserKQLFunction.cpp:331:41 (clickhouse+0x1bf6c17b) (BuildId: 3de51f55ea4d1bb3b0d1f74325989a86b90a2956)
        8 DB::ParserKQLBase::getExprFromToken(DB::IParser::Pos&)::$_0::operator()(DB::IParser::Pos&, DB::IParser::Pos&) const build_docker/./src/Parsers/Kusto/ParserKQLQuery.cpp:218:29 (clickhouse+0x1bf1d065) (BuildId: 3de51f55ea4d1bb3b0d1f74325989a86b90a2956)

</details>

CI: https://s3.amazonaws.com/clickhouse-test-reports/55418/769ed2e19d46fcb9cb6a678a0da6d6f2fc5d239e/stateless_tests__tsan__[5_5].html

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Follow-up for: #42510