### PR TITLE
Fix flakiness of test_system_merges (by increasing sleep interval properly)

### DIFF
--- a/tests/integration/test_system_merges/configs/user_overrides.xml
+++ b/tests/integration/test_system_merges/configs/user_overrides.xml
@@ -1,0 +1,7 @@
+<clickhouse>
+    <profiles>
+        <default>
+            <function_sleep_max_microseconds_per_block>10G</function_sleep_max_microseconds_per_block>
+        </default>
+    </profiles>
+</clickhouse>

--- a/tests/integration/test_system_merges/test.py
+++ b/tests/integration/test_system_merges/test.py
@@ -10,6 +10,7 @@ cluster = ClickHouseCluster(__file__)
 node1 = cluster.add_instance(
     "node1",
     main_configs=["configs/logs_config.xml"],
+    user_configs=["configs/user_overrides.xml"],
     with_zookeeper=True,
     macros={"shard": 0, "replica": 1},
 )
@@ -17,6 +18,7 @@ node1 = cluster.add_instance(
 node2 = cluster.add_instance(
     "node2",
     main_configs=["configs/logs_config.xml"],
+    user_configs=["configs/user_overrides.xml"],
     with_zookeeper=True,
     macros={"shard": 0, "replica": 2},
 )
@@ -183,10 +185,10 @@ def test_mutation_simple(started_cluster, replicated):
             starting_block, starting_block, starting_block + 1
         )
 
-        # ALTER will sleep for 3s * 3 (rows) = 9s
+        # ALTER will sleep for 9s
         def alter():
             node1.query(
-                f"ALTER TABLE {name} UPDATE a = 42 WHERE sleep(3) OR 1",
+                f"ALTER TABLE {name} UPDATE a = 42 WHERE sleep(9) OR 1",
                 settings=settings,
             )
 


### PR DESCRIPTION
CI: https://s3.amazonaws.com/clickhouse-test-reports/55418/769ed2e19d46fcb9cb6a678a0da6d6f2fc5d239e/integration_tests__tsan__[4_6].html

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)