### PR TITLE
[WIP]Reorder short circuit functions' arguments adaptively

### DIFF
--- a/src/Columns/ColumnFunction.cpp
+++ b/src/Columns/ColumnFunction.cpp
@@ -376,6 +376,11 @@ ColumnWithTypeAndName ColumnFunction::reduceImpl(FunctionExecuteProfile * profil
         ProfileEvents::increment(ProfileEvents::CompiledFunctionExecute);
 
     res.column = function->execute(columns, res.type, elements_size, /* dry_run = */ false, profile);
+    if constexpr (with_profile)
+    {
+        for (const auto & arg_profile : profile->arguments_profiles)
+            profile->elapsed_ns += arg_profile.second.elapsed_ns;
+    }
     if (res.column->getDataType() != res.type->getColumnType())
         throw Exception(
             ErrorCodes::LOGICAL_ERROR,

--- a/src/Columns/ColumnFunction.cpp
+++ b/src/Columns/ColumnFunction.cpp
@@ -305,7 +305,15 @@ DataTypePtr ColumnFunction::getResultType() const
     return function->getResultType();
 }
 
-ColumnWithTypeAndName ColumnFunction::reduce() const
+ColumnWithTypeAndName ColumnFunction::reduce(FunctionExecuteProfile * profile) const
+{
+    if (profile)
+        return reduceImpl<true>(profile);
+    return reduceImpl<false>(nullptr);
+}
+
+template <bool with_profile>
+ColumnWithTypeAndName ColumnFunction::reduceImpl(FunctionExecuteProfile * profile) const
 {
     auto args = function->getArgumentTypes().size();
     auto captured = captured_columns.size();
@@ -328,15 +336,35 @@ ColumnWithTypeAndName ColumnFunction::reduce() const
             for (size_t i : settings.arguments_with_disabled_lazy_execution)
             {
                 if (const ColumnFunction * arg = checkAndGetShortCircuitArgument(columns[i].column))
-                    columns[i] = arg->reduce();
+                {
+                    if constexpr (with_profile)
+                    {
+                        profile->arguments_profiles.emplace_back(std::make_pair(i, FunctionExecuteProfile()));
+                        auto & arg_profile = profile->arguments_profiles.back().second;
+                        columns[i] = arg->reduceImpl<with_profile>(&arg_profile);
+                    }
+                    else
+                        columns[i] = arg->reduce();
+                }
             }
         }
         else
         {
+            size_t i = 0;
             for (auto & col : columns)
             {
                 if (const ColumnFunction * arg = checkAndGetShortCircuitArgument(col.column))
-                    col = arg->reduce();
+                {
+                    if constexpr (with_profile)
+                    {
+                        profile->arguments_profiles.emplace_back(std::make_pair(i, FunctionExecuteProfile()));
+                        auto & arg_profile = profile->arguments_profiles.back().second;
+                        columns[i] = arg->reduceImpl<with_profile>(&arg_profile);
+                    }
+                    else
+                        col = arg->reduce();
+                }
+                i += 1;
             }
         }
     }
@@ -347,7 +375,7 @@ ColumnWithTypeAndName ColumnFunction::reduce() const
     if (is_function_compiled)
         ProfileEvents::increment(ProfileEvents::CompiledFunctionExecute);
 
-    res.column = function->execute(columns, res.type, elements_size, /* dry_run = */ false);
+    res.column = function->execute(columns, res.type, elements_size, /* dry_run = */ false, profile);
     if (res.column->getDataType() != res.type->getColumnType())
         throw Exception(
             ErrorCodes::LOGICAL_ERROR,

--- a/src/Columns/ColumnFunction.cpp
+++ b/src/Columns/ColumnFunction.cpp
@@ -344,7 +344,7 @@ ColumnWithTypeAndName ColumnFunction::reduceImpl(FunctionExecuteProfile * profil
                         columns[i] = arg->reduceImpl<with_profile>(&arg_profile);
                     }
                     else
-                        columns[i] = arg->reduce();
+                        columns[i] = arg->reduceImpl<false>(nullptr);
                 }
             }
         }
@@ -362,7 +362,7 @@ ColumnWithTypeAndName ColumnFunction::reduceImpl(FunctionExecuteProfile * profil
                         columns[i] = arg->reduceImpl<with_profile>(&arg_profile);
                     }
                     else
-                        col = arg->reduce();
+                        col = arg->reduceImpl<false>(nullptr);
                 }
                 i += 1;
             }

--- a/src/Columns/ColumnFunction.h
+++ b/src/Columns/ColumnFunction.h
@@ -16,6 +16,7 @@ namespace ErrorCodes
 
 class IFunctionBase;
 using FunctionBasePtr = std::shared_ptr<const IFunctionBase>;
+struct FunctionExecuteProfile;
 
 /** A column containing a lambda expression.
   * Contains an expression and captured columns, but not input arguments.
@@ -58,7 +59,10 @@ public:
     size_t allocatedBytes() const override;
 
     void appendArguments(const ColumnsWithTypeAndName & columns);
-    ColumnWithTypeAndName reduce() const;
+    ColumnWithTypeAndName reduce(FunctionExecuteProfile * profile = nullptr) const;
+    template<bool with_profile>
+    ColumnWithTypeAndName reduceImpl(FunctionExecuteProfile * profile) const;
+
 
     Field operator[](size_t n) const override;
 

--- a/src/Columns/MaskOperations.cpp
+++ b/src/Columns/MaskOperations.cpp
@@ -5,6 +5,7 @@
 #include <Columns/ColumnsCommon.h>
 #include <Columns/ColumnConst.h>
 #include <Columns/ColumnLowCardinality.h>
+#include <Functions/IFunction.h>
 #include <algorithm>
 
 namespace DB
@@ -256,7 +257,14 @@ void maskedExecute(ColumnWithTypeAndName & column, const PaddedPODArray<UInt8> &
 {
     const auto * column_function = checkAndGetShortCircuitArgument(column.column);
     if (!column_function)
+    {
+        if (profile)
+        {
+            profile->elapsed_ns = 0;
+            profile->input_rows = column.column->size();
+        }
         return;
+    }
 
     size_t original_size = column.column->size();
 

--- a/src/Columns/MaskOperations.h
+++ b/src/Columns/MaskOperations.h
@@ -19,7 +19,10 @@ struct MaskInfo
 {
     bool has_ones;
     bool has_zeros;
+    size_t ones_count = 0;
 };
+
+struct FunctionExecuteProfile;
 
 /// The next functions are used to extract UInt8 mask from a column,
 /// filtered by some condition (mask). We will use value from a column
@@ -63,7 +66,8 @@ void inverseMask(PaddedPODArray<UInt8> & mask, MaskInfo & mask_info);
 void maskedExecute(
     ColumnWithTypeAndName & column,
     const PaddedPODArray<UInt8> & mask,
-    const MaskInfo & mask_info = {true, true});
+    const MaskInfo & mask_info = {true, true},
+    FunctionExecuteProfile * profile = nullptr);
 
 /// If given column is lazy executed argument, reduce it. If empty is true,
 /// create an empty column with the execution result type.

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -5643,6 +5643,10 @@ For testing purposes. Replaces all external table functions to Null to not initi
     DECLARE(Bool, restore_replace_external_dictionary_source_to_null, false, R"(
 Replace external dictionary sources to Null on restore. Useful for testing purposes
 )", 0) \
+    DECLARE(Bool, enable_adaptive_short_circuit, true, R"(
+Enable adatpive short circuite execution. It will reorder the arguments of specific short circuit functions based on execution cost. e.g. `and` and `or`.
+It helps to minimize the total cost of the function execution.
+    )", 0) \
         /* Parallel replicas */ \
     DECLARE(UInt64, allow_experimental_parallel_reading_from_replicas, 0, R"(
 Use up to `max_parallel_replicas` the number of replicas from each shard for SELECT query execution. Reading is parallelized and coordinated dynamically. 0 - disabled, 1 - enabled, silently disable them in case of failure, 2 - enabled, throw an exception in case of failure

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -633,7 +633,7 @@ static std::initializer_list<std::pair<ClickHouseVersion, SettingsChangesHistory
 {
     {"25.1",
         {
-
+            {"enable_adaptive_short_circuit", true, true,  "New setting. It will reorder the arguments of specific short circuit functions adaptively."},
         }
     },
     {"24.12",

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -83,6 +83,8 @@ static std::initializer_list<std::pair<ClickHouseVersion, SettingsChangesHistory
             {"skip_redundant_aliases_in_udf", false, false, "New setting."},
             {"parallel_replicas_index_analysis_only_on_coordinator", true, true, "Index analysis done only on replica-coordinator and skipped on other replicas. Effective only with enabled parallel_replicas_local_plan"}, // enabling it was moved to 24.10
             {"least_greatest_legacy_null_behavior", true, false, "New setting"},
+            {"least_greatest_legacy_null_behavior", false, false, "New setting"},
+            {"enable_adaptive_short_circuit", true, true, "New setting. It will reorder the arguments of specific short circuit functions adaptively."},
             /// Release closed. Please use 25.1
         }
     },

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -635,7 +635,6 @@ static std::initializer_list<std::pair<ClickHouseVersion, SettingsChangesHistory
 {
     {"25.1",
         {
-            {"enable_adaptive_short_circuit", true, true,  "New setting. It will reorder the arguments of specific short circuit functions adaptively."},
         }
     },
     {"24.12",

--- a/src/Functions/FunctionBinaryArithmetic.h
+++ b/src/Functions/FunctionBinaryArithmetic.h
@@ -1500,7 +1500,7 @@ public:
                 && (isDecimalOrNullableDecimal(arguments[0].type) || isDecimalOrNullableDecimal(arguments[1].type)));
     }
 
-    bool isNonExcept() const override
+    bool isNoExcept() const override
     {
         const bool has_except =  IsOperation<Op>::int_div ||
             IsOperation<Op>::modulo ||

--- a/src/Functions/FunctionBinaryArithmetic.h
+++ b/src/Functions/FunctionBinaryArithmetic.h
@@ -1500,6 +1500,15 @@ public:
                 && (isDecimalOrNullableDecimal(arguments[0].type) || isDecimalOrNullableDecimal(arguments[1].type)));
     }
 
+    bool isNonExcept() const override
+    {
+        const bool has_except =  IsOperation<Op>::int_div ||
+            IsOperation<Op>::modulo ||
+            IsOperation<Op>::positive_modulo ||
+            (IsOperation<Op>::div_floating);
+        return !has_except;
+    }
+
     DataTypePtr getReturnTypeImpl(const DataTypes & arguments) const override
     {
         return getReturnTypeImplStatic(arguments, context);

--- a/src/Functions/FunctionSQLJSON.h
+++ b/src/Functions/FunctionSQLJSON.h
@@ -229,6 +229,7 @@ public:
     static constexpr auto name = Name::name;
     String getName() const override { return Name::name; }
     bool isVariadic() const override { return true; }
+    bool isNonExcept() const override { return true; }
     size_t getNumberOfArguments() const override { return 0; }
     bool useDefaultImplementationForConstants() const override { return true; }
     ColumnNumbers getArgumentsThatAreAlwaysConstant() const override { return {1}; }

--- a/src/Functions/FunctionSQLJSON.h
+++ b/src/Functions/FunctionSQLJSON.h
@@ -229,7 +229,7 @@ public:
     static constexpr auto name = Name::name;
     String getName() const override { return Name::name; }
     bool isVariadic() const override { return true; }
-    bool isNonExcept() const override { return true; }
+    bool isNoExcept() const override { return true; }
     size_t getNumberOfArguments() const override { return 0; }
     bool useDefaultImplementationForConstants() const override { return true; }
     ColumnNumbers getArgumentsThatAreAlwaysConstant() const override { return {1}; }

--- a/src/Functions/FunctionStringOrArrayToT.h
+++ b/src/Functions/FunctionStringOrArrayToT.h
@@ -22,7 +22,7 @@ namespace ErrorCodes
 }
 
 
-template <typename Impl, typename Name, typename ResultType, bool is_suitable_for_short_circuit_arguments_execution = true>
+template <typename Impl, typename Name, typename ResultType, bool is_suitable_for_short_circuit_arguments_execution = true, bool is_no_except = false>
 class FunctionStringOrArrayToT : public IFunction
 {
 public:
@@ -67,6 +67,8 @@ public:
     }
 
     bool useDefaultImplementationForConstants() const override { return true; }
+
+    bool isNoExcept() const override { return is_no_except; }
 
     ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type, size_t input_rows_count) const override
     {

--- a/src/Functions/FunctionsComparison.h
+++ b/src/Functions/FunctionsComparison.h
@@ -648,6 +648,8 @@ public:
     explicit FunctionComparison(bool check_decimal_overflow_)
         : check_decimal_overflow(check_decimal_overflow_) {}
 
+    bool isNonExcept() const override { return true; }
+
 private:
     bool check_decimal_overflow = true;
 

--- a/src/Functions/FunctionsComparison.h
+++ b/src/Functions/FunctionsComparison.h
@@ -648,7 +648,7 @@ public:
     explicit FunctionComparison(bool check_decimal_overflow_)
         : check_decimal_overflow(check_decimal_overflow_) {}
 
-    bool isNonExcept() const override { return true; }
+    bool isNoExcept() const override { return true; }
 
 private:
     bool check_decimal_overflow = true;

--- a/src/Functions/FunctionsConversion.h
+++ b/src/Functions/FunctionsConversion.h
@@ -2152,6 +2152,7 @@ public:
     bool isVariadic() const override { return true; }
     size_t getNumberOfArguments() const override { return 0; }
     bool isInjective(const ColumnsWithTypeAndName &) const override { return std::is_same_v<Name, NameToString>; }
+    bool isNoExcept() const override { return std::is_same_v<Name, NameToString>; }
     bool isSuitableForShortCircuitArgumentsExecution(const DataTypesWithConstInfo & arguments) const override
     {
         return !(IsDataTypeDateOrDateTime<ToDataType> && isNumber(*arguments[0].type));

--- a/src/Functions/FunctionsLogical.cpp
+++ b/src/Functions/FunctionsLogical.cpp
@@ -640,7 +640,7 @@ ColumnPtr FunctionAnyArityLogical<Impl, Name>::executeShortCircuit(
         if constexpr (with_profile)
         {
             auto & arg_profile = profile->arguments_profiles.back().second;
-            arg_profile.valid_output_rows = mask_info.ones_count;
+            arg_profile.short_circuit_selected_rows = mask_info.ones_count;
         }
     }
     /// For OR function we need to inverse mask to get the resulting column.
@@ -657,7 +657,7 @@ ColumnPtr FunctionAnyArityLogical<Impl, Name>::executeShortCircuit(
     {
         profile->elapsed_ns = watch.elapsed();
         profile->input_rows = rows;
-        profile->valid_output_rows = res->size();
+        profile->short_circuit_selected_rows = res->size();
     }
 
     if (!nulls)
@@ -706,7 +706,7 @@ ColumnPtr FunctionAnyArityLogical<Impl, Name>::executeImpl(
     {
         profile->elapsed_ns = watch.elapsed();
         profile->input_rows = input_rows_count;
-        profile->valid_output_rows = res->size();
+        profile->short_circuit_selected_rows = res->size();
     }
     return res;
 }

--- a/src/Functions/FunctionsLogical.cpp
+++ b/src/Functions/FunctionsLogical.cpp
@@ -17,6 +17,7 @@
 #include <Functions/FunctionHelpers.h>
 #include <Functions/FunctionUnaryArithmetic.h>
 #include <Common/FieldVisitors.h>
+#include <Common/Stopwatch.h>
 
 #include <cstring>
 #include <algorithm>
@@ -572,7 +573,11 @@ static void applyTernaryLogic(const IColumn::Filter & mask, IColumn::Filter & nu
 }
 
 template <typename Impl, typename Name>
-ColumnPtr FunctionAnyArityLogical<Impl, Name>::executeShortCircuit(ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type) const
+template <bool with_profile>
+ColumnPtr FunctionAnyArityLogical<Impl, Name>::executeShortCircuit(
+    ColumnsWithTypeAndName & arguments,
+    const DataTypePtr & result_type,
+    FunctionExecuteProfile * profile [[maybe_unused]]) const
 {
     if (Name::name != NameAnd::name && Name::name != NameOr::name)
         throw Exception(ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT, "Function {} doesn't support short circuit execution", getName());
@@ -600,6 +605,7 @@ ColumnPtr FunctionAnyArityLogical<Impl, Name>::executeShortCircuit(ColumnsWithTy
     /// to support ternary logic.
     /// The result is !mask_n.
 
+    Stopwatch watch;
     bool inverted = Name::name != NameAnd::name;
     UInt8 null_value = static_cast<UInt8>(Name::name == NameAnd::name);
     IColumn::Filter mask(arguments[0].column->size(), 1);
@@ -610,20 +616,34 @@ ColumnPtr FunctionAnyArityLogical<Impl, Name>::executeShortCircuit(ColumnsWithTy
     if (result_type->isNullable())
         nulls = std::make_unique<IColumn::Filter>(arguments[0].column->size(), 0);
 
-    MaskInfo mask_info;
-    for (size_t i = 1; i <= arguments.size(); ++i)
+    MaskInfo mask_info{.has_ones = true, .has_zeros = false, .ones_count = arguments[0].column->size()};
+    for (size_t i = 0; i <= arguments.size(); ++i)
     {
-        if (inverted)
-            mask_info = extractInvertedMask(mask, arguments[i - 1].column, nulls.get(), null_value);
-        else
-            mask_info = extractMask(mask, arguments[i - 1].column, nulls.get(), null_value);
 
         /// If mask doesn't have ones, we don't need to execute the rest arguments,
         /// because the result won't change.
         if (!mask_info.has_ones || i == arguments.size())
             break;
+        if constexpr (with_profile)
+        {
+            profile->arguments_profiles.emplace_back(std::make_pair(i, FunctionExecuteProfile()));
+            auto & arg_profile = profile->arguments_profiles.back().second;
+            maskedExecute(arguments[i], mask, mask_info, &arg_profile);
 
-        maskedExecute(arguments[i], mask, mask_info);
+        }
+        else
+            maskedExecute(arguments[i], mask, mask_info);
+
+        if (inverted)
+            mask_info = extractInvertedMask(mask, arguments[i].column, nulls.get(), null_value);
+        else
+            mask_info = extractMask(mask, arguments[i].column, nulls.get(), null_value);
+
+        if constexpr (with_profile)
+        {
+            auto & arg_profile = profile->arguments_profiles.back().second;
+            arg_profile.valid_output_rows = mask_info.ones_count;
+        }
     }
     /// For OR function we need to inverse mask to get the resulting column.
     if (inverted)
@@ -640,26 +660,56 @@ ColumnPtr FunctionAnyArityLogical<Impl, Name>::executeShortCircuit(ColumnsWithTy
 
     auto bytemap = ColumnUInt8::create();
     bytemap->getData() = std::move(*nulls);
+    if constexpr (with_profile)
+    {
+        profile->elapsed_ns = watch.elapsed();
+        profile->input_rows = arguments[0].column->size();
+        profile->input_rows = res->size();
+    }
     return ColumnNullable::create(std::move(res), std::move(bytemap));
+}
+template <typename Impl, typename Name>
+ColumnPtr FunctionAnyArityLogical<Impl, Name>::executeImpl(
+    const ColumnsWithTypeAndName & args, const DataTypePtr & result_type, size_t input_rows_count) const
+{
+    return this->executeImpl(args, result_type, input_rows_count, nullptr);
 }
 
 template <typename Impl, typename Name>
 ColumnPtr FunctionAnyArityLogical<Impl, Name>::executeImpl(
-    const ColumnsWithTypeAndName & args, const DataTypePtr & result_type, size_t input_rows_count) const
+    const ColumnsWithTypeAndName & args,
+    const DataTypePtr & result_type,
+    size_t input_rows_count,
+    FunctionExecuteProfile * profile) const
 {
     ColumnsWithTypeAndName arguments = args;
 
     /// Special implementation for short-circuit arguments.
     if (checkShortCircuitArguments(arguments) != -1)
-        return executeShortCircuit(arguments, result_type);
+    {
+        if (profile)
+            return executeShortCircuit<true>(arguments, result_type, profile);
+        return executeShortCircuit<false>(arguments, result_type, profile);
+    }
 
+    Stopwatch watch;
     ColumnRawPtrs args_in;
     for (const auto & arg_index : arguments)
         args_in.push_back(arg_index.column.get());
-
+    
+    ColumnPtr res = nullptr;
     if (result_type->isNullable())
-        return executeForTernaryLogicImpl<Impl>(std::move(args_in), result_type, input_rows_count);
-    return basicExecuteImpl<Impl>(std::move(args_in), input_rows_count);
+        res = executeForTernaryLogicImpl<Impl>(std::move(args_in), result_type, input_rows_count);
+    else
+        res =basicExecuteImpl<Impl>(std::move(args_in), input_rows_count);
+
+    if (profile)
+    {
+        profile->elapsed_ns = watch.elapsed();
+        profile->input_rows = input_rows_count;
+        profile->valid_output_rows = res->size();
+    }
+    return res;
 }
 
 template <typename Impl, typename Name>

--- a/src/Functions/FunctionsLogical.cpp
+++ b/src/Functions/FunctionsLogical.cpp
@@ -695,7 +695,7 @@ ColumnPtr FunctionAnyArityLogical<Impl, Name>::executeImpl(
     ColumnRawPtrs args_in;
     for (const auto & arg_index : arguments)
         args_in.push_back(arg_index.column.get());
-    
+
     ColumnPtr res = nullptr;
     if (result_type->isNullable())
         res = executeForTernaryLogicImpl<Impl>(std::move(args_in), result_type, input_rows_count);

--- a/src/Functions/FunctionsLogical.cpp
+++ b/src/Functions/FunctionsLogical.cpp
@@ -21,8 +21,6 @@
 
 #include <cstring>
 #include <algorithm>
-#include <Poco/Logger.h>
-#include <Common/logger_useful.h>
 
 
 namespace DB

--- a/src/Functions/FunctionsLogical.cpp
+++ b/src/Functions/FunctionsLogical.cpp
@@ -21,6 +21,8 @@
 
 #include <cstring>
 #include <algorithm>
+#include <Poco/Logger.h>
+#include <Common/logger_useful.h>
 
 
 namespace DB

--- a/src/Functions/FunctionsLogical.h
+++ b/src/Functions/FunctionsLogical.h
@@ -175,7 +175,7 @@ public:
     template <bool with_profile>
     ColumnPtr executeShortCircuit(ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type, FunctionExecuteProfile * profile) const;
     bool isSuitableForShortCircuitArgumentsExecution(const DataTypesWithConstInfo & /*arguments*/) const override { return false; }
-    bool isNonExcept() const override { return true; }
+    bool isNoExcept() const override { return true; }
     size_t getNumberOfArguments() const override { return 0; }
     bool canBeExecutedOnLowCardinalityDictionary() const override { return false; }
 

--- a/src/Functions/FunctionsLogical.h
+++ b/src/Functions/FunctionsLogical.h
@@ -164,12 +164,15 @@ public:
     bool isVariadic() const override { return true; }
     bool isShortCircuit(ShortCircuitSettings & settings, size_t /*number_of_arguments*/) const override
     {
-        settings.arguments_with_disabled_lazy_execution.insert(0);
+        bool is_and_or = name == NameAnd::name || name == NameOr::name;
+        if (!is_and_or)
+            settings.arguments_with_disabled_lazy_execution.insert(0);
         settings.enable_lazy_execution_for_common_descendants_of_arguments = true;
         settings.force_enable_lazy_execution = false;
-        return name == NameAnd::name || name == NameOr::name;
+        return is_and_or;
     }
-    ColumnPtr executeShortCircuit(ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type) const;
+    template <bool with_profile>
+    ColumnPtr executeShortCircuit(ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type, FunctionExecuteProfile * profile) const;
     bool isSuitableForShortCircuitArgumentsExecution(const DataTypesWithConstInfo & /*arguments*/) const override { return false; }
     size_t getNumberOfArguments() const override { return 0; }
     bool canBeExecutedOnLowCardinalityDictionary() const override { return false; }
@@ -180,6 +183,7 @@ public:
     DataTypePtr getReturnTypeImpl(const DataTypes & arguments) const override;
 
     ColumnPtr executeImpl(const ColumnsWithTypeAndName & args, const DataTypePtr & result_type, size_t input_rows_count) const override;
+    ColumnPtr executeImpl(const ColumnsWithTypeAndName & args, const DataTypePtr & result_type, size_t input_rows_count, FunctionExecuteProfile * profile) const override;
 
     ColumnPtr getConstantResultForNonConstArguments(const ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type) const override;
 

--- a/src/Functions/FunctionsLogical.h
+++ b/src/Functions/FunctionsLogical.h
@@ -169,11 +169,13 @@ public:
             settings.arguments_with_disabled_lazy_execution.insert(0);
         settings.enable_lazy_execution_for_common_descendants_of_arguments = true;
         settings.force_enable_lazy_execution = false;
+        settings.could_reorder_arguments = is_and_or;
         return is_and_or;
     }
     template <bool with_profile>
     ColumnPtr executeShortCircuit(ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type, FunctionExecuteProfile * profile) const;
     bool isSuitableForShortCircuitArgumentsExecution(const DataTypesWithConstInfo & /*arguments*/) const override { return false; }
+    bool isNonExcept() const override { return true; }
     size_t getNumberOfArguments() const override { return 0; }
     bool canBeExecutedOnLowCardinalityDictionary() const override { return false; }
 

--- a/src/Functions/FunctionsLogical.h
+++ b/src/Functions/FunctionsLogical.h
@@ -248,6 +248,8 @@ public:
         return name;
     }
 
+    bool isNoExcept() const override { return true; }
+
     size_t getNumberOfArguments() const override { return 1; }
 
     DataTypePtr getReturnTypeImpl(const DataTypes & arguments) const override;

--- a/src/Functions/IFunction.cpp
+++ b/src/Functions/IFunction.cpp
@@ -331,7 +331,6 @@ ColumnPtr IExecutableFunction::executeImplWithProfile(const ColumnsWithTypeAndNa
         Stopwatch watch;
         auto res = executeImpl(arguments, result_type, input_rows_count);
         profile->input_rows = arguments.empty() ? 0 : arguments.front().column->size();
-        profile->short_circuit_selected_rows = res ? res->size() : 0;
         profile->elapsed_ns = watch.elapsed();
         return res;
     }

--- a/src/Functions/IFunction.cpp
+++ b/src/Functions/IFunction.cpp
@@ -331,7 +331,7 @@ ColumnPtr IExecutableFunction::executeImplWithProfile(const ColumnsWithTypeAndNa
         Stopwatch watch;
         auto res = executeImpl(arguments, result_type, input_rows_count);
         profile->input_rows = arguments.empty() ? 0 : arguments.front().column->size();
-        profile->valid_output_rows = res ? res->size() : 0;
+        profile->short_circuit_selected_rows = res ? res->size() : 0;
         profile->elapsed_ns = watch.elapsed();
         return res;
     }
@@ -567,7 +567,7 @@ ColumnPtr IFunction::executeImpl(
         Stopwatch watch;
         auto res = executeImpl(arguments, result_type, input_rows_count);
         profile->input_rows = arguments.empty() ? 0 : arguments.front().column->size();
-        profile->valid_output_rows = res ? res->size() : 0;
+        profile->short_circuit_selected_rows = res ? res->size() : 0;
         profile->elapsed_ns = watch.elapsed();
         return res;
     }

--- a/src/Functions/IFunction.cpp
+++ b/src/Functions/IFunction.cpp
@@ -397,6 +397,17 @@ ColumnPtr IFunctionBase::execute(const DB::ColumnsWithTypeAndName& arguments, co
     return prepare(arguments)->execute(arguments, result_type, input_rows_count, dry_run);
 }
 
+ColumnPtr IFunctionBase::executeOnShortCircuite(
+    const DB::ColumnsWithTypeAndName& arguments,
+    const DB::DataTypePtr& result_type,
+    size_t input_rows_count,
+    bool dry_run,
+    ShortCircuiteArgumentExecuteCosts & arg_costs) const
+{
+    checkFunctionArgumentSizes(arguments, input_rows_count);
+    return prepare(arguments)->executeOnShortCircuite(arguments, result_type, input_rows_count, dry_run, arg_costs);
+}
+
 void IFunctionOverloadResolver::checkNumberOfArguments(size_t number_of_arguments) const
 {
     if (isVariadic())

--- a/src/Functions/IFunction.cpp
+++ b/src/Functions/IFunction.cpp
@@ -331,7 +331,7 @@ ColumnPtr IExecutableFunction::executeImplWithProfile(const ColumnsWithTypeAndNa
         Stopwatch watch;
         auto res = executeImpl(arguments, result_type, input_rows_count);
         profile->input_rows = arguments.empty() ? 0 : arguments.front().column->size();
-        profile->output_rows = res ? res->size() : 0;
+        profile->valid_output_rows = res ? res->size() : 0;
         profile->elapsed_ns = watch.elapsed();
         return res;
     }
@@ -567,7 +567,7 @@ ColumnPtr IFunction::executeImpl(
         Stopwatch watch;
         auto res = executeImpl(arguments, result_type, input_rows_count);
         profile->input_rows = arguments.empty() ? 0 : arguments.front().column->size();
-        profile->output_rows = res ? res->size() : 0;
+        profile->valid_output_rows = res ? res->size() : 0;
         profile->elapsed_ns = watch.elapsed();
         return res;
     }

--- a/src/Functions/IFunction.cpp
+++ b/src/Functions/IFunction.cpp
@@ -566,7 +566,7 @@ ColumnPtr IFunction::executeImpl(
         Stopwatch watch;
         auto res = executeImpl(arguments, result_type, input_rows_count);
         profile->input_rows = arguments.empty() ? 0 : arguments.front().column->size();
-        profile->short_circuit_selected_rows = res ? res->size() : 0;
+        profile->short_circuit_selected_rows = profile->input_rows;
         profile->elapsed_ns = watch.elapsed();
         return res;
     }

--- a/src/Functions/IFunction.h
+++ b/src/Functions/IFunction.h
@@ -210,6 +210,8 @@ public:
 
     virtual bool isStateful() const { return false; }
 
+    virtual bool isNonExcept() const { return false; }
+
     /** Should we evaluate this function while constant folding, if arguments are constants?
       * Usually this is true. Notable counterexample is function 'sleep'.
       * If we will call it during query analysis, we will sleep extra amount of time.
@@ -306,6 +308,7 @@ public:
         /// Example: toTypeName(expr), even if expr contains functions that are not suitable for
         /// lazy execution (because of their simplicity), we shouldn't execute them at all.
         bool force_enable_lazy_execution;
+        bool could_reorder_arguments = false;
     };
 
     /** Function is called "short-circuit" if it's arguments can be evaluated lazily
@@ -560,6 +563,7 @@ public:
     virtual bool isDeterministicInScopeOfQuery() const { return true; }
     virtual bool isServerConstant() const { return false; }
     virtual bool isStateful() const { return false; }
+    virtual bool isNonExcept() const { return false; }
 
     using ShortCircuitSettings = IFunctionBase::ShortCircuitSettings;
     virtual bool isShortCircuit(ShortCircuitSettings & /*settings*/, size_t /*number_of_arguments*/) const { return false; }

--- a/src/Functions/IFunction.h
+++ b/src/Functions/IFunction.h
@@ -210,7 +210,7 @@ public:
 
     virtual bool isStateful() const { return false; }
 
-    virtual bool isNonExcept() const { return false; }
+    virtual bool isNoExcept() const { return false; }
 
     /** Should we evaluate this function while constant folding, if arguments are constants?
       * Usually this is true. Notable counterexample is function 'sleep'.
@@ -563,7 +563,7 @@ public:
     virtual bool isDeterministicInScopeOfQuery() const { return true; }
     virtual bool isServerConstant() const { return false; }
     virtual bool isStateful() const { return false; }
-    virtual bool isNonExcept() const { return false; }
+    virtual bool isNoExcept() const { return false; }
 
     using ShortCircuitSettings = IFunctionBase::ShortCircuitSettings;
     virtual bool isShortCircuit(ShortCircuitSettings & /*settings*/, size_t /*number_of_arguments*/) const { return false; }

--- a/src/Functions/IFunction.h
+++ b/src/Functions/IFunction.h
@@ -40,7 +40,7 @@ using OptionalFieldInterval = std::optional<FieldInterval>;
 struct FunctionExecuteProfile
 {
     size_t input_rows = 0;
-    size_t output_rows = 0;
+    size_t valid_output_rows = 0;
     size_t elapsed_ns = 0;
     // If a argument is function column, its profile is stored here.
     std::vector<std::pair<size_t, FunctionExecuteProfile>> arguments_profiles;

--- a/src/Functions/IFunction.h
+++ b/src/Functions/IFunction.h
@@ -40,7 +40,7 @@ using OptionalFieldInterval = std::optional<FieldInterval>;
 struct FunctionExecuteProfile
 {
     size_t input_rows = 0;
-    size_t valid_output_rows = 0;
+    size_t short_circuit_selected_rows = 0;
     size_t elapsed_ns = 0;
     // If a argument is function column, its profile is stored here.
     std::vector<std::pair<size_t, FunctionExecuteProfile>> arguments_profiles;

--- a/src/Functions/IFunction.h
+++ b/src/Functions/IFunction.h
@@ -175,7 +175,6 @@ public:
         size_t input_rows_count,
         bool dry_run,
         FunctionExecuteProfile * profile) const;
-    
 
     /// Get the main function name.
     virtual String getName() const = 0;

--- a/src/Functions/IFunction.h
+++ b/src/Functions/IFunction.h
@@ -209,6 +209,7 @@ public:
 
     virtual bool isStateful() const { return false; }
 
+    // Whether `execute` throws exception on invalid input. For example, a/b throws exception when b is zero.
     virtual bool isNoExcept() const { return false; }
 
     /** Should we evaluate this function while constant folding, if arguments are constants?

--- a/src/Functions/IFunction.h
+++ b/src/Functions/IFunction.h
@@ -210,6 +210,7 @@ public:
     virtual bool isStateful() const { return false; }
 
     // Whether `execute` throws exception on invalid input. For example, a/b throws exception when b is zero.
+    // But this doesn't include invalid argument types.
     virtual bool isNoExcept() const { return false; }
 
     /** Should we evaluate this function while constant folding, if arguments are constants?

--- a/src/Functions/IFunctionAdaptors.cpp
+++ b/src/Functions/IFunctionAdaptors.cpp
@@ -10,6 +10,16 @@ ColumnPtr FunctionToExecutableFunctionAdaptor::executeImpl(const ColumnsWithType
     return function->executeImpl(arguments, result_type, input_rows_count);
 }
 
+ColumnPtr FunctionToExecutableFunctionAdaptor::executeImplWithProfile(
+    const ColumnsWithTypeAndName& arguments,
+    const DataTypePtr& result_type,
+    size_t input_rows_count,
+    FunctionExecuteProfile * profile) const
+{
+    checkFunctionArgumentSizes(arguments, input_rows_count);
+    return function->executeImpl(arguments, result_type, input_rows_count, profile);
+}
+
 ColumnPtr FunctionToExecutableFunctionAdaptor::executeDryRunImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type, size_t input_rows_count) const
 {
     checkFunctionArgumentSizes(arguments, input_rows_count);

--- a/src/Functions/IFunctionAdaptors.h
+++ b/src/Functions/IFunctionAdaptors.h
@@ -17,6 +17,11 @@ public:
 protected:
 
     ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type, size_t input_rows_count) const final;
+    ColumnPtr executeImplWithProfile(
+        const ColumnsWithTypeAndName & arguments,
+        const DataTypePtr & result_type,
+        size_t input_rows_count,
+        FunctionExecuteProfile * profile) const final;
     ColumnPtr executeDryRunImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type, size_t input_rows_count) const final;
 
     bool useDefaultImplementationForNulls() const final { return function->useDefaultImplementationForNulls(); }

--- a/src/Functions/IFunctionAdaptors.h
+++ b/src/Functions/IFunctionAdaptors.h
@@ -76,6 +76,8 @@ public:
 
     bool isStateful() const override { return function->isStateful(); }
 
+    bool isNonExcept() const override { return function->isNonExcept(); }
+
     bool isInjective(const ColumnsWithTypeAndName & sample_columns) const override { return function->isInjective(sample_columns); }
 
     bool isDeterministic() const override { return function->isDeterministic(); }

--- a/src/Functions/IFunctionAdaptors.h
+++ b/src/Functions/IFunctionAdaptors.h
@@ -76,7 +76,7 @@ public:
 
     bool isStateful() const override { return function->isStateful(); }
 
-    bool isNonExcept() const override { return function->isNonExcept(); }
+    bool isNoExcept() const override { return function->isNoExcept(); }
 
     bool isInjective(const ColumnsWithTypeAndName & sample_columns) const override { return function->isInjective(sample_columns); }
 

--- a/src/Functions/isValidUTF8.cpp
+++ b/src/Functions/isValidUTF8.cpp
@@ -266,7 +266,7 @@ struct NameIsValidUTF8
 {
     static constexpr auto name = "isValidUTF8";
 };
-using FunctionValidUTF8 = FunctionStringOrArrayToT<ValidUTF8Impl, NameIsValidUTF8, UInt8>;
+using FunctionValidUTF8 = FunctionStringOrArrayToT<ValidUTF8Impl, NameIsValidUTF8, UInt8, true, true>;
 
 REGISTER_FUNCTION(IsValidUTF8)
 {

--- a/src/Functions/repeat.cpp
+++ b/src/Functions/repeat.cpp
@@ -211,6 +211,8 @@ public:
         return std::make_shared<DataTypeString>();
     }
 
+    bool isNoExcept() const override { return true; }
+
     bool useDefaultImplementationForConstants() const override { return true; }
 
     ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr & /*result_type*/, size_t /*input_rows_count*/) const override

--- a/src/Interpreters/ExpressionActions.cpp
+++ b/src/Interpreters/ExpressionActions.cpp
@@ -348,13 +348,13 @@ static std::unordered_set<const ActionsDAG::Node *> processShortCircuitFunctions
     return lazy_executed_nodes;
 }
 
-static bool isNonExceptNode(const ActionsDAG::Node * node)
+static bool isNoExceptNode(const ActionsDAG::Node * node)
 {
-    if (node->type == ActionsDAG::ActionType::FUNCTION && !node->function_base->isNonExcept())
+    if (node->type == ActionsDAG::ActionType::FUNCTION && !node->function_base->isNoExcept())
         return false;
     for (const auto * child : node->children)
     {
-        if (!isNonExceptNode(child))
+        if (!isNoExceptNode(child))
             return false;
     }
     return true;
@@ -364,7 +364,7 @@ static bool areAllChildrenNonExceptNode(const ActionsDAG::Node * node)
 {
     for (const auto * child : node->children)
     {
-        if (!isNonExceptNode(child))
+        if (!isNoExceptNode(child))
             return false;
     }
     return true;

--- a/src/Interpreters/ExpressionActions.cpp
+++ b/src/Interpreters/ExpressionActions.cpp
@@ -893,7 +893,7 @@ void ExpressionActions::updateActionsProfile(ExpressionActions::Action & action,
 {
     action.elapsed_ns += profile.elapsed_ns;
     action.input_rows += profile.input_rows;
-    action.valid_output_rows += profile.valid_output_rows;
+    action.short_circuit_selected_rows += profile.short_circuit_selected_rows;
     for (const auto & arg_profile : profile.arguments_profiles)
     {
         auto & arg_action = actions[action.arguments[arg_profile.first].actions_pos];
@@ -919,7 +919,7 @@ void ExpressionActions::tryReorderShortCircuitArguments(size_t current_bach_rows
             const auto & arg = action.arguments[i];
             const auto & arg_action = actions[arg.actions_pos];
             double rank_value = arg_action.input_rows ?
-                (arg_action.elapsed_ns * 1.0 / arg_action.input_rows/(1.000001 - arg_action.valid_output_rows/arg_action.input_rows))
+                (arg_action.elapsed_ns * 1.0 / arg_action.input_rows/(1.000001 - arg_action.short_circuit_selected_rows/arg_action.input_rows))
                 : 0.0;
             rank_values.push_back(std::make_pair(i, rank_value));
         }

--- a/src/Interpreters/ExpressionActions.cpp
+++ b/src/Interpreters/ExpressionActions.cpp
@@ -49,9 +49,14 @@ namespace ErrorCodes
 
 static std::unordered_set<const ActionsDAG::Node *> processShortCircuitFunctions(const ActionsDAG & actions_dag, ShortCircuitFunctionEvaluation short_circuit_function_evaluation);
 
-ExpressionActions::ExpressionActions(ActionsDAG actions_dag_, const ExpressionActionsSettings & settings_, bool project_inputs_)
+ExpressionActions::ExpressionActions(
+    ActionsDAG actions_dag_,
+    const ExpressionActionsSettings & settings_,
+    bool project_inputs_,
+    bool enable_adaptive_short_circuiting_)
     : actions_dag(std::move(actions_dag_))
     , project_inputs(project_inputs_)
+    , enable_adaptive_short_circuiting(enable_adaptive_short_circuiting_)
     , settings(settings_)
 {
     /// It's important to determine lazy executed nodes before compiling expressions.
@@ -91,6 +96,7 @@ ExpressionActionsPtr ExpressionActions::clone() const
 
     copy->project_inputs = project_inputs;
     copy->settings = settings;
+    copy->enable_adaptive_short_circuiting = enable_adaptive_short_circuiting;
 
     return copy;
 }

--- a/src/Interpreters/ExpressionActions.h
+++ b/src/Interpreters/ExpressionActions.h
@@ -108,7 +108,7 @@ private:
 
     ExpressionActionsSettings settings;
 
-    size_t reorder_short_circuit_arguments_every_rows = 10000;
+    static const size_t reorder_short_circuit_arguments_every_rows = 100000;
     size_t current_profile_rows = 0;
 
 public:

--- a/src/Interpreters/ExpressionActions.h
+++ b/src/Interpreters/ExpressionActions.h
@@ -76,11 +76,11 @@ public:
         {}
 
         /// Followings are used for reordering arguments of short-circuit nodes
-        /// Rank value is caculated as elapsed_ns/input_rows/(1-valid_output_rows/input_rows)
+        /// Rank value is caculated as elapsed_ns/input_rows/(1-short_circuit_selected_rows/input_rows)
         /// Smaller rank value is better
         size_t elapsed_ns = 0;
         size_t input_rows = 0;
-        size_t valid_output_rows = 0;
+        size_t short_circuit_selected_rows = 0;
 
         std::string toString() const;
         JSONBuilder::ItemPtr toTree() const;

--- a/src/Interpreters/ExpressionActions.h
+++ b/src/Interpreters/ExpressionActions.h
@@ -104,7 +104,7 @@ private:
     Block sample_block;
 
     bool project_inputs = false;
-    bool enable_adaptive_short_circuiting = false;
+    bool enable_adaptive_short_circuit = false;
 
     ExpressionActionsSettings settings;
 
@@ -116,7 +116,7 @@ public:
         ActionsDAG actions_dag_,
         const ExpressionActionsSettings & settings_ = {},
         bool project_inputs_ = false,
-        bool enable_adaptive_short_circuiting_ = false);
+        bool enable_adaptive_short_circuit_ = false);
     ExpressionActions(ExpressionActions &&) = default;
     ExpressionActions & operator=(ExpressionActions &&) = default;
 

--- a/src/Interpreters/ExpressionActions.h
+++ b/src/Interpreters/ExpressionActions.h
@@ -78,11 +78,16 @@ private:
     Block sample_block;
 
     bool project_inputs = false;
+    bool enable_adaptive_short_circuiting = false;
 
     ExpressionActionsSettings settings;
 
 public:
-    explicit ExpressionActions(ActionsDAG actions_dag_, const ExpressionActionsSettings & settings_ = {}, bool project_inputs_ = false);
+    explicit ExpressionActions(
+        ActionsDAG actions_dag_,
+        const ExpressionActionsSettings & settings_ = {},
+        bool project_inputs_ = false,
+        bool enable_adaptive_short_circuiting_ = false);
     ExpressionActions(ExpressionActions &&) = default;
     ExpressionActions & operator=(ExpressionActions &&) = default;
 

--- a/src/Interpreters/ExpressionActions.h
+++ b/src/Interpreters/ExpressionActions.h
@@ -94,8 +94,10 @@ public:
             input_rows = b.input_rows;
             short_circuit_selected_rows = b.short_circuit_selected_rows;
         }
-        Action & operator=(const Action &b)
+        Action & operator=(const Action & b)
         {
+            if (this == &b)
+                return *this;
             std::unique_lock this_lock(mutex);
             node = b.node;
             {

--- a/src/Interpreters/ExpressionActions.h
+++ b/src/Interpreters/ExpressionActions.h
@@ -47,6 +47,7 @@ public:
         bool needed_later = false;
         // Position in ExpressionActions::actions
         size_t actions_pos = 0;
+        size_t reordered_arg_pos = 0;
     };
 
     using Arguments = std::vector<Argument>;
@@ -66,6 +67,7 @@ public:
         bool is_lazy_executed;
         bool is_short_circuit_node;
         bool could_reorder_arguments;
+        std::vector<size_t> reordered_arguments_original_pos;
         Action(const Node * node_,
             const Arguments & arguments_,
             size_t result_position_,
@@ -78,13 +80,17 @@ public:
             is_lazy_executed(is_lazy_executed_),
             is_short_circuit_node(is_short_circuit_node_),
             could_reorder_arguments(could_reorder_arguments_)
-        {}
+        {
+            for (size_t i = 0; i < arguments.size(); ++i)
+                reordered_arguments_original_pos.emplace_back(i);
+        }
         Action(const Action & b)
         {
             node = b.node;
             {
                 std::shared_lock lock(b.mutex);
                 arguments = b.arguments;
+                reordered_arguments_original_pos = b.reordered_arguments_original_pos;
             }
             result_position = b.result_position;
             is_lazy_executed = b.is_lazy_executed;
@@ -103,6 +109,7 @@ public:
             {
                 std::shared_lock lock(b.mutex);
                 arguments = b.arguments;
+                reordered_arguments_original_pos = b.reordered_arguments_original_pos;
             }
             result_position = b.result_position;
             is_lazy_executed = b.is_lazy_executed;
@@ -147,7 +154,7 @@ private:
 
     ExpressionActionsSettings settings;
 
-    static const size_t reorder_short_circuit_arguments_every_rows = 10000;
+    static const size_t reorder_short_circuit_arguments_every_rows;
     size_t current_profile_rows = 0;
 
 public:

--- a/src/Interpreters/ExpressionActions.h
+++ b/src/Interpreters/ExpressionActions.h
@@ -99,6 +99,7 @@ public:
         bool has_high_selectivity = false;
         // Before next `tryScheduleLazyExecution` call, how many rows are executed in this action.
         size_t current_round_calcuated_rows = 0;
+        size_t current_round_elapsed_ns = 0;
 
         std::string toString() const;
         JSONBuilder::ItemPtr toTree() const;
@@ -199,6 +200,8 @@ private:
 
     void updateActionsProfile(ExpressionActions::Action & action, const FunctionExecuteProfile & profile);
     void tryScheduleLazyExecution(size_t current_batch_rows);
+    void propagateCSELazyNodesElapsed();
+    void propagateCSELazyNodeElapsed(const Action & action, size_t extra_elapsed);
     void reorderShortCircuitArguments();
     void updateLazyNodesSelecivity();
     void updateNodeSelectivity(Action & action);

--- a/src/Interpreters/ExpressionActions.h
+++ b/src/Interpreters/ExpressionActions.h
@@ -112,8 +112,8 @@ public:
             return *this;
         }
 
-        /// Followings are used for reordering arguments of short-circuit nodes
-        /// Rank value is caculated as elapsed_ns/input_rows/(1-short_circuit_selected_rows/input_rows)
+        /// Following is used for reordering arguments of short-circuit nodes
+        /// Rank value is calculated as elapsed_ns/input_rows/(1-short_circuit_selected_rows/input_rows)
         /// Smaller rank value is better
         size_t elapsed_ns = 0;
         size_t input_rows = 0;

--- a/src/Planner/PlannerJoinTree.cpp
+++ b/src/Planner/PlannerJoinTree.cpp
@@ -1550,7 +1550,7 @@ std::tuple<QueryPlan, JoinPtr> buildJoinQueryPlan(
         auto drop_unused_columns_after_join_actions_dag = createStepToDropColumns(header_after_join, outer_scope_columns, planner_context);
         if (drop_unused_columns_after_join_actions_dag)
         {
-            auto drop_unused_columns_after_join_transform_step = std::make_unique<ExpressionStep>(result_plan.getCurrentHeader(), std::move(*drop_unused_columns_after_join_actions_dag), enable_adaptive_short_circuit);
+            auto drop_unused_columns_after_join_transform_step = std::make_unique<ExpressionStep>(result_plan.getCurrentHeader(), std::move(*drop_unused_columns_after_join_actions_dag), settings[Setting::enable_adaptive_short_circuit]);
             drop_unused_columns_after_join_transform_step->setStepDescription("Drop unused columns after JOIN");
             result_plan.addStep(std::move(drop_unused_columns_after_join_transform_step));
         }

--- a/src/Planner/PlannerJoinTree.cpp
+++ b/src/Planner/PlannerJoinTree.cpp
@@ -110,6 +110,7 @@ namespace Setting
     extern const SettingsBool use_concurrency_control;
     extern const SettingsBoolAuto query_plan_join_swap_table;
     extern const SettingsUInt64 min_joined_block_size_bytes;
+    extern const SettingsBool enable_adaptive_short_circuit;
 }
 
 namespace ErrorCodes
@@ -643,7 +644,9 @@ UInt64 mainQueryNodeBlockSizeByLimit(const SelectQueryInfo & select_query_info)
 }
 
 std::unique_ptr<ExpressionStep> createComputeAliasColumnsStep(
-    std::unordered_map<std::string, ActionsDAG> & alias_column_expressions, const Header & current_header)
+    PlannerContextPtr & planner_context,
+    std::unordered_map<std::string, ActionsDAG> & alias_column_expressions,
+    const Header & current_header)
 {
     ActionsDAG merged_alias_columns_actions_dag(current_header.getColumnsWithTypeAndName());
     ActionsDAG::NodeRawConstPtrs action_dag_outputs = merged_alias_columns_actions_dag.getInputs();
@@ -659,7 +662,9 @@ std::unique_ptr<ExpressionStep> createComputeAliasColumnsStep(
         merged_alias_columns_actions_dag.addOrReplaceInOutputs(*output_node);
     merged_alias_columns_actions_dag.removeUnusedActions(false);
 
-    auto alias_column_step = std::make_unique<ExpressionStep>(current_header, std::move(merged_alias_columns_actions_dag));
+    auto query_context = planner_context->getQueryContext();
+    bool enable_adaptive_short_circuit = query_context->getSettingsRef()[Setting::enable_adaptive_short_circuit];
+    auto alias_column_step = std::make_unique<ExpressionStep>(current_header, std::move(merged_alias_columns_actions_dag), enable_adaptive_short_circuit);
     alias_column_step->setStepDescription("Compute alias columns");
     return alias_column_step;
 }
@@ -674,6 +679,7 @@ JoinTreeQueryPlan buildQueryPlanForTableExpression(QueryTreeNodePtr table_expres
 {
     const auto & query_context = planner_context->getQueryContext();
     const auto & settings = query_context->getSettingsRef();
+    bool enable_adaptive_short_circuit = settings[Setting::enable_adaptive_short_circuit];
 
     auto & table_expression_data = planner_context->getTableExpressionDataOrThrow(table_expression);
 
@@ -1104,7 +1110,7 @@ JoinTreeQueryPlan buildQueryPlanForTableExpression(QueryTreeNodePtr table_expres
                 auto & alias_column_expressions = table_expression_data.getAliasColumnExpressions();
                 if (!alias_column_expressions.empty() && query_plan.isInitialized() && from_stage == QueryProcessingStage::FetchColumns)
                 {
-                    auto alias_column_step = createComputeAliasColumnsStep(alias_column_expressions, query_plan.getCurrentHeader());
+                    auto alias_column_step = createComputeAliasColumnsStep(planner_context, alias_column_expressions, query_plan.getCurrentHeader());
                     query_plan.addStep(std::move(alias_column_step));
                 }
 
@@ -1193,7 +1199,7 @@ JoinTreeQueryPlan buildQueryPlanForTableExpression(QueryTreeNodePtr table_expres
         auto & alias_column_expressions = table_expression_data.getAliasColumnExpressions();
         if (!alias_column_expressions.empty() && query_plan.isInitialized() && from_stage == QueryProcessingStage::FetchColumns)
         {
-            auto alias_column_step = createComputeAliasColumnsStep(alias_column_expressions, query_plan.getCurrentHeader());
+            auto alias_column_step = createComputeAliasColumnsStep(planner_context, alias_column_expressions, query_plan.getCurrentHeader());
             query_plan.addStep(std::move(alias_column_step));
         }
     }
@@ -1219,7 +1225,7 @@ JoinTreeQueryPlan buildQueryPlanForTableExpression(QueryTreeNodePtr table_expres
 
         rename_actions_dag.getOutputs() = std::move(updated_actions_dag_outputs);
 
-        auto rename_step = std::make_unique<ExpressionStep>(query_plan.getCurrentHeader(), std::move(rename_actions_dag));
+        auto rename_step = std::make_unique<ExpressionStep>(query_plan.getCurrentHeader(), std::move(rename_actions_dag), enable_adaptive_short_circuit);
         rename_step->setStepDescription("Change column names to column identifiers");
         query_plan.addStep(std::move(rename_step));
     }
@@ -1242,7 +1248,7 @@ JoinTreeQueryPlan buildQueryPlanForTableExpression(QueryTreeNodePtr table_expres
                 expected_header.getColumnsWithTypeAndName(),
                 ActionsDAG::MatchColumnsMode::Position,
                 true /*ignore_constant_values*/);
-            auto rename_step = std::make_unique<ExpressionStep>(query_plan.getCurrentHeader(), std::move(rename_actions_dag));
+            auto rename_step = std::make_unique<ExpressionStep>(query_plan.getCurrentHeader(), std::move(rename_actions_dag), enable_adaptive_short_circuit);
             std::string step_description = table_expression_data.isRemote() ? "Change remote column names to local column names" : "Change column names";
             rename_step->setStepDescription(std::move(step_description));
             query_plan.addStep(std::move(rename_step));
@@ -1275,7 +1281,9 @@ void joinCastPlanColumnsToNullable(QueryPlan & plan_to_add_cast, PlannerContextP
     }
 
     cast_actions_dag.appendInputsForUnusedColumns(plan_to_add_cast.getCurrentHeader());
-    auto cast_join_columns_step = std::make_unique<ExpressionStep>(plan_to_add_cast.getCurrentHeader(), std::move(cast_actions_dag));
+    const auto & settings = planner_context->getQueryContext()->getSettingsRef();
+    auto enable_adaptive_short_circuit = settings[Setting::enable_adaptive_short_circuit];
+    auto cast_join_columns_step = std::make_unique<ExpressionStep>(plan_to_add_cast.getCurrentHeader(), std::move(cast_actions_dag), enable_adaptive_short_circuit);
     cast_join_columns_step->setStepDescription("Cast JOIN columns to Nullable");
     plan_to_add_cast.addStep(std::move(cast_join_columns_step));
 }
@@ -1542,7 +1550,7 @@ std::tuple<QueryPlan, JoinPtr> buildJoinQueryPlan(
         auto drop_unused_columns_after_join_actions_dag = createStepToDropColumns(header_after_join, outer_scope_columns, planner_context);
         if (drop_unused_columns_after_join_actions_dag)
         {
-            auto drop_unused_columns_after_join_transform_step = std::make_unique<ExpressionStep>(result_plan.getCurrentHeader(), std::move(*drop_unused_columns_after_join_actions_dag));
+            auto drop_unused_columns_after_join_transform_step = std::make_unique<ExpressionStep>(result_plan.getCurrentHeader(), std::move(*drop_unused_columns_after_join_actions_dag), enable_adaptive_short_circuit);
             drop_unused_columns_after_join_transform_step->setStepDescription("Drop unused columns after JOIN");
             result_plan.addStep(std::move(drop_unused_columns_after_join_transform_step));
         }
@@ -1658,6 +1666,8 @@ JoinTreeQueryPlan buildQueryPlanForJoinNode(
 
 
     bool can_move_out_residuals = false;
+    const auto & query_context = planner_context->getQueryContext();
+    bool enable_adaptive_short_circuit = query_context->getSettingsRef()[Setting::enable_adaptive_short_circuit];
 
     if (!join_constant && join_node.isOnJoinExpression())
     {
@@ -1683,7 +1693,7 @@ JoinTreeQueryPlan buildQueryPlanForJoinNode(
             && (right_pre_filters.empty() || FilterStep::canUseType(right_pre_filters[0]->result_type))
             && (left_pre_filters.empty() || FilterStep::canUseType(left_pre_filters[0]->result_type));
 
-        auto add_pre_filter = [can_move_out_residuals](ActionsDAG & join_expressions_actions, QueryPlan & plan, UsefulSets & useful_sets, const auto & pre_filters)
+        auto add_pre_filter = [can_move_out_residuals, enable_adaptive_short_circuit](ActionsDAG & join_expressions_actions, QueryPlan & plan, UsefulSets & useful_sets, const auto & pre_filters)
         {
             join_expressions_actions.appendInputsForUnusedColumns(plan.getCurrentHeader());
             appendSetsFromActionsDAG(join_expressions_actions, useful_sets);
@@ -1692,7 +1702,7 @@ JoinTreeQueryPlan buildQueryPlanForJoinNode(
             if (can_move_out_residuals && !pre_filters.empty())
                 join_expressions_actions_step = std::make_unique<FilterStep>(plan.getCurrentHeader(), std::move(join_expressions_actions), pre_filters[0]->result_name, false);
             else
-                join_expressions_actions_step = std::make_unique<ExpressionStep>(plan.getCurrentHeader(), std::move(join_expressions_actions));
+                join_expressions_actions_step = std::make_unique<ExpressionStep>(plan.getCurrentHeader(), std::move(join_expressions_actions), enable_adaptive_short_circuit);
 
             join_expressions_actions_step->setStepDescription("JOIN actions");
             plan.addStep(std::move(join_expressions_actions_step));
@@ -1749,7 +1759,7 @@ JoinTreeQueryPlan buildQueryPlanForJoinNode(
 
         cast_actions_dag.appendInputsForUnusedColumns(plan_to_add_cast.getCurrentHeader());
         auto cast_join_columns_step
-            = std::make_unique<ExpressionStep>(plan_to_add_cast.getCurrentHeader(), std::move(cast_actions_dag));
+            = std::make_unique<ExpressionStep>(plan_to_add_cast.getCurrentHeader(), std::move(cast_actions_dag), enable_adaptive_short_circuit);
         cast_join_columns_step->setStepDescription("Cast JOIN USING columns");
         plan_to_add_cast.addStep(std::move(cast_join_columns_step));
     };
@@ -1760,7 +1770,6 @@ JoinTreeQueryPlan buildQueryPlanForJoinNode(
     if (!right_plan_column_name_to_cast_type.empty())
         join_cast_plan_output_nodes(right_plan, right_plan_column_name_to_cast_type);
 
-    const auto & query_context = planner_context->getQueryContext();
     const auto & settings = query_context->getSettingsRef();
 
     if (settings[Setting::join_use_nulls])
@@ -2009,7 +2018,9 @@ JoinTreeQueryPlan buildQueryPlanForArrayJoinNode(const QueryTreeNodePtr & array_
 
     array_join_action_dag.appendInputsForUnusedColumns(plan.getCurrentHeader());
 
-    auto array_join_actions = std::make_unique<ExpressionStep>(plan.getCurrentHeader(), std::move(array_join_action_dag));
+    const auto & settings = planner_context->getQueryContext()->getSettingsRef();
+    auto enable_adaptive_short_circuit = settings[Setting::enable_adaptive_short_circuit];
+    auto array_join_actions = std::make_unique<ExpressionStep>(plan.getCurrentHeader(), std::move(array_join_action_dag), enable_adaptive_short_circuit);
     array_join_actions->setStepDescription("ARRAY JOIN actions");
     appendSetsFromActionsDAG(array_join_actions->getExpression(), join_tree_query_plan.useful_sets);
     plan.addStep(std::move(array_join_actions));
@@ -2039,11 +2050,11 @@ JoinTreeQueryPlan buildQueryPlanForArrayJoinNode(const QueryTreeNodePtr & array_
     drop_unused_columns_before_array_join_actions_dag_outputs = std::move(drop_unused_columns_before_array_join_actions_dag_updated_outputs);
 
     auto drop_unused_columns_before_array_join_transform_step = std::make_unique<ExpressionStep>(plan.getCurrentHeader(),
-        std::move(drop_unused_columns_before_array_join_actions_dag));
+        std::move(drop_unused_columns_before_array_join_actions_dag),
+        enable_adaptive_short_circuit);
     drop_unused_columns_before_array_join_transform_step->setStepDescription("DROP unused columns before ARRAY JOIN");
     plan.addStep(std::move(drop_unused_columns_before_array_join_transform_step));
 
-    const auto & settings = planner_context->getQueryContext()->getSettingsRef();
     auto array_join_step = std::make_unique<ArrayJoinStep>(
         plan.getCurrentHeader(),
         ArrayJoin{std::move(array_join_column_names), array_join_node.isLeft()},

--- a/src/Processors/QueryPlan/ExpressionStep.cpp
+++ b/src/Processors/QueryPlan/ExpressionStep.cpp
@@ -43,7 +43,7 @@ ExpressionStep::ExpressionStep(const Header & input_header_, ActionsDAG actions_
 
 void ExpressionStep::transformPipeline(QueryPipelineBuilder & pipeline, const BuildQueryPipelineSettings & settings)
 {
-    auto expression = std::make_shared<ExpressionActions>(std::move(actions_dag), settings.getActionsSettings());
+    auto expression = std::make_shared<ExpressionActions>(std::move(actions_dag), settings.getActionsSettings(), false, true);
 
     pipeline.addSimpleTransform([&](const Block & header)
     {

--- a/src/Processors/QueryPlan/ExpressionStep.h
+++ b/src/Processors/QueryPlan/ExpressionStep.h
@@ -13,7 +13,7 @@ class ExpressionStep : public ITransformingStep
 {
 public:
 
-    explicit ExpressionStep(const Header & input_header_, ActionsDAG actions_dag_);
+    explicit ExpressionStep(const Header & input_header_, ActionsDAG actions_dag_, bool enable_adaptive_short_circuit_ = false);
     String getName() const override { return "Expression"; }
 
     void transformPipeline(QueryPipelineBuilder & pipeline, const BuildQueryPipelineSettings & settings) override;
@@ -27,11 +27,12 @@ public:
 
     void serialize(Serialization & ctx) const override;
     static std::unique_ptr<IQueryPlanStep> deserialize(Deserialization & ctx);
+    bool enableAdaptiveShortCircuit() const { return enable_adaptive_short_circuit; }
 
 private:
     void updateOutputHeader() override;
-
     ActionsDAG actions_dag;
+    bool enable_adaptive_short_circuit;
 };
 
 }

--- a/src/Processors/QueryPlan/FilterStep.h
+++ b/src/Processors/QueryPlan/FilterStep.h
@@ -13,7 +13,8 @@ public:
         const Header & input_header_,
         ActionsDAG actions_dag_,
         String filter_column_name_,
-        bool remove_filter_column_);
+        bool remove_filter_column_,
+        bool enable_adaptive_short_circuit_ = false);
 
     String getName() const override { return "Filter"; }
     void transformPipeline(QueryPipelineBuilder & pipeline, const BuildQueryPipelineSettings & settings) override;
@@ -25,6 +26,7 @@ public:
     ActionsDAG & getExpression() { return actions_dag; }
     const String & getFilterColumnName() const { return filter_column_name; }
     bool removesFilterColumn() const { return remove_filter_column; }
+    bool enableAdaptiveShortCircuit() const { return enable_adaptive_short_circuit; }
 
     static bool canUseType(const DataTypePtr & type);
 
@@ -38,6 +40,7 @@ private:
     ActionsDAG actions_dag;
     String filter_column_name;
     bool remove_filter_column;
+    bool enable_adaptive_short_circuit;
 };
 
 }

--- a/src/Processors/QueryPlan/Optimizations/splitFilter.cpp
+++ b/src/Processors/QueryPlan/Optimizations/splitFilter.cpp
@@ -63,13 +63,16 @@ size_t trySplitFilter(QueryPlan::Node * node, QueryPlan::Nodes & nodes)
         }
     }
 
+    bool enable_adaptive_short_circuit = filter_step->enableAdaptiveShortCircuit();
+
     filter_node.step = std::make_unique<FilterStep>(
             filter_node.children.at(0)->step->getOutputHeader(),
             std::move(split.first),
             std::move(split_filter_name),
-            remove_filter);
+            remove_filter,
+            enable_adaptive_short_circuit);
 
-    node->step = std::make_unique<ExpressionStep>(filter_node.step->getOutputHeader(), std::move(split.second));
+    node->step = std::make_unique<ExpressionStep>(filter_node.step->getOutputHeader(), std::move(split.second), enable_adaptive_short_circuit);
 
     filter_node.step->setStepDescription("(" + description + ")[split]");
     node->step->setStepDescription(description);

--- a/src/Processors/Transforms/ExpressionTransform.cpp
+++ b/src/Processors/Transforms/ExpressionTransform.cpp
@@ -10,10 +10,9 @@ Block ExpressionTransform::transformHeader(const Block & header, const ActionsDA
     return expression.updateHeader(header);
 }
 
-
 ExpressionTransform::ExpressionTransform(const Block & header_, ExpressionActionsPtr expression_)
     : ISimpleTransform(header_, transformHeader(header_, expression_->getActionsDAG()), false)
-    , expression(expression_->clone())
+    , expression(expression_->clone()) // We make a copy of expression_ here, eliminate lock contention between threads.
 {
 }
 

--- a/src/Processors/Transforms/ExpressionTransform.cpp
+++ b/src/Processors/Transforms/ExpressionTransform.cpp
@@ -13,7 +13,7 @@ Block ExpressionTransform::transformHeader(const Block & header, const ActionsDA
 
 ExpressionTransform::ExpressionTransform(const Block & header_, ExpressionActionsPtr expression_)
     : ISimpleTransform(header_, transformHeader(header_, expression_->getActionsDAG()), false)
-    , expression(std::move(expression_))
+    , expression(expression_->clone())
 {
 }
 
@@ -29,7 +29,7 @@ void ExpressionTransform::transform(Chunk & chunk)
 
 ConvertingTransform::ConvertingTransform(const Block & header_, ExpressionActionsPtr expression_)
     : ExceptionKeepingTransform(header_, ExpressionTransform::transformHeader(header_, expression_->getActionsDAG()))
-    , expression(std::move(expression_))
+    , expression(expression_->clone())
 {
 }
 

--- a/src/Processors/Transforms/ExpressionTransform.cpp
+++ b/src/Processors/Transforms/ExpressionTransform.cpp
@@ -12,7 +12,7 @@ Block ExpressionTransform::transformHeader(const Block & header, const ActionsDA
 
 ExpressionTransform::ExpressionTransform(const Block & header_, ExpressionActionsPtr expression_)
     : ISimpleTransform(header_, transformHeader(header_, expression_->getActionsDAG()), false)
-    , expression(expression_->clone()) // We make a copy of expression_ here, eliminate lock contention between threads.
+    , expression(expression_ ? expression_->clone() : nullptr) // We make a copy of expression_ here, eliminate lock contention between threads.
 {
 }
 

--- a/src/Processors/Transforms/FilterTransform.cpp
+++ b/src/Processors/Transforms/FilterTransform.cpp
@@ -48,7 +48,7 @@ FilterTransform::FilterTransform(
             header_,
             transformHeader(header_, expression_ ? &expression_->getActionsDAG() : nullptr, filter_column_name_, remove_filter_column_),
             true)
-    , expression(expression_->clone())
+    , expression(expression_->clone()) // We make a copy of expression_ here, eliminate lock contention between threads.
     , filter_column_name(std::move(filter_column_name_))
     , remove_filter_column(remove_filter_column_)
     , on_totals(on_totals_)

--- a/src/Processors/Transforms/FilterTransform.cpp
+++ b/src/Processors/Transforms/FilterTransform.cpp
@@ -48,7 +48,7 @@ FilterTransform::FilterTransform(
             header_,
             transformHeader(header_, expression_ ? &expression_->getActionsDAG() : nullptr, filter_column_name_, remove_filter_column_),
             true)
-    , expression(std::move(expression_))
+    , expression(expression_->clone())
     , filter_column_name(std::move(filter_column_name_))
     , remove_filter_column(remove_filter_column_)
     , on_totals(on_totals_)

--- a/src/Processors/Transforms/FilterTransform.cpp
+++ b/src/Processors/Transforms/FilterTransform.cpp
@@ -48,7 +48,7 @@ FilterTransform::FilterTransform(
             header_,
             transformHeader(header_, expression_ ? &expression_->getActionsDAG() : nullptr, filter_column_name_, remove_filter_column_),
             true)
-    , expression(expression_->clone()) // We make a copy of expression_ here, eliminate lock contention between threads.
+    , expression(expression_ ? expression_->clone() : nullptr) // We make a copy of expression_ here, eliminate lock contention between threads.
     , filter_column_name(std::move(filter_column_name_))
     , remove_filter_column(remove_filter_column_)
     , on_totals(on_totals_)

--- a/tests/performance/adaptive_short_circuit.xml
+++ b/tests/performance/adaptive_short_circuit.xml
@@ -1,0 +1,71 @@
+<test>
+    <create_query>
+        create table test_adaptive_short_circuit_1 (a String, b UInt64) Engine=Memory
+    </create_query>
+    <create_query>
+        create table test_adaptive_short_circuit_2 (a String, b UInt64) Engine=Memory
+    </create_query>
+    <fill_query>
+        insert into test_adaptive_short_circuit_1 select a, b from( select concat('{"b":123,"c":', toString(number), ',"a":', toString(number % 1000), '}') as a, rand() % 10000 as b, rand() as c  from numbers(1000)) order by c
+    </fill_query>
+    <fill_query>
+        <!-- for small block -->
+        insert into test_adaptive_short_circuit_2 select a, b from( select concat('{"b":123,"c":', toString(number), ',"a":', toString(number % 1000), '}') as a, rand() % 10000 as b, rand() as c  from numbers(1000)) order by c settings max_block_size=512
+    </fill_query>
+
+
+    <query>
+        <!-- query_plan_merge_filters=false, disable spilit and condition into and atoms -->
+        select * from test_adaptive_short_circuit_1 where less(b, 10) and JSON_VALUE(a, '$.a') = '1' Format null short_circuit_function_evaluation='force_enable',query_plan_merge_filters=false;
+    </query>
+    <query>
+        <!-- query_plan_merge_filters=false, disable spilit and condition into and atoms -->
+        select * from test_adaptive_short_circuit_1 where JSON_VALUE(a, '$.a') = '1' and less(b,10) Format null short_circuit_function_evaluation='force_enable',query_plan_merge_filters=false;
+    </query>
+    <query>
+        select (JSON_VALUE(a, '$.a') = '1' and less(b, 10)) as x  from test_adaptive_short_circuit_1 where Format null short_circuit_function_evaluation='force_enable';
+    </query>
+    <query>
+        select (less(b, 10) and JSON_VALUE(a, '$.a') = '1') as x  from test_adaptive_short_circuit_1 where Format null short_circuit_function_evaluation='force_enable';
+    </query>
+    <query>
+        select * from test_adaptive_short_circuit_1 where greater(b, 10) or JSON_VALUE(a, '$.a') != '1' Format null short_circuit_function_evaluation='force_enable';
+    </query>
+    <query>
+        select * from test_adaptive_short_circuit_1 where JSON_VALUE(a, '$.a') != '1' or greater(b, 10) Format null short_circuit_function_evaluation='force_enable';
+    </query>
+    <query>
+        select (JSON_VALUE(a, '$.a') != '1' or greater(b, 10)) as x  from test_adaptive_short_circuit_1  where Format null short_circuit_function_evaluation='force_enable';
+    </query>
+    <query>
+        select (greater(b,10) or JSON_VALUE(a, '$.a') != '1') as x  from test_adaptive_short_circuit_1 where Format null short_circuit_function_evaluation='force_enable';
+    </query>
+
+    <query>
+        <!-- query_plan_merge_filters=false, disable spilit and condition into and atoms -->
+        select * from test_adaptive_short_circuit_2 where less(b, 10) and JSON_VALUE(a, '$.a') = '1' Format null short_circuit_function_evaluation='force_enable',query_plan_merge_filters=false;
+    </query>
+    <query>
+        <!-- query_plan_merge_filters=false, disable spilit and condition into and atoms -->
+        select * from test_adaptive_short_circuit_2 where JSON_VALUE(a, '$.a') = '1' and less(b,10) Format null short_circuit_function_evaluation='force_enable',query_plan_merge_filters=false;
+    </query>
+    <query>
+        select (JSON_VALUE(a, '$.a') = '1' and less(b, 10)) as x  from test_adaptive_short_circuit_2 where Format null short_circuit_function_evaluation='force_enable';
+    </query>
+    <query>
+        select (less(b, 10) and JSON_VALUE(a, '$.a') = '1') as x  from test_adaptive_short_circuit_2 where Format null short_circuit_function_evaluation='force_enable';
+    </query>
+    <query>
+        select * from test_adaptive_short_circuit_2 where greater(b, 10) or JSON_VALUE(a, '$.a') != '1' Format null short_circuit_function_evaluation='force_enable';
+    </query>
+    <query>
+        select * from test_adaptive_short_circuit_2 where JSON_VALUE(a, '$.a') != '1' or greater(b, 10) Format null short_circuit_function_evaluation='force_enable';
+    </query>
+    <query>
+        select (JSON_VALUE(a, '$.a') != '1' or greater(b, 10)) as x from test_adaptive_short_circuit_2  where Format null short_circuit_function_evaluation='force_enable';
+    </query>
+    <query>
+        select (greater(b,10) or JSON_VALUE(a, '$.a') != '1') as x from test_adaptive_short_circuit_2 where Format null short_circuit_function_evaluation='force_enable';
+    </query>
+</test>
+

--- a/tests/performance/adaptive_short_circuit.xml
+++ b/tests/performance/adaptive_short_circuit.xml
@@ -16,56 +16,56 @@
 
     <query>
         <!-- query_plan_merge_filters=false, disable spilit and condition into and atoms -->
-        select * from test_adaptive_short_circuit_1 where less(b, 10) and JSON_VALUE(a, '$.a') = '1' Format null short_circuit_function_evaluation='force_enable',query_plan_merge_filters=false;
+        select * from test_adaptive_short_circuit_1 where less(b, 10) and JSON_VALUE(a, '$.a') = '1' Format null settings short_circuit_function_evaluation='force_enable',query_plan_merge_filters=false;
     </query>
     <query>
         <!-- query_plan_merge_filters=false, disable spilit and condition into and atoms -->
-        select * from test_adaptive_short_circuit_1 where JSON_VALUE(a, '$.a') = '1' and less(b,10) Format null short_circuit_function_evaluation='force_enable',query_plan_merge_filters=false;
+        select * from test_adaptive_short_circuit_1 where JSON_VALUE(a, '$.a') = '1' and less(b,10) Format null settings short_circuit_function_evaluation='force_enable',query_plan_merge_filters=false;
     </query>
     <query>
-        select (JSON_VALUE(a, '$.a') = '1' and less(b, 10)) as x  from test_adaptive_short_circuit_1 where Format null short_circuit_function_evaluation='force_enable';
+        select (JSON_VALUE(a, '$.a') = '1' and less(b, 10)) as x  from test_adaptive_short_circuit_1 where Format null settings short_circuit_function_evaluation='force_enable';
     </query>
     <query>
-        select (less(b, 10) and JSON_VALUE(a, '$.a') = '1') as x  from test_adaptive_short_circuit_1 where Format null short_circuit_function_evaluation='force_enable';
+        select (less(b, 10) and JSON_VALUE(a, '$.a') = '1') as x  from test_adaptive_short_circuit_1 where Format null settings short_circuit_function_evaluation='force_enable';
     </query>
     <query>
-        select * from test_adaptive_short_circuit_1 where greater(b, 10) or JSON_VALUE(a, '$.a') != '1' Format null short_circuit_function_evaluation='force_enable';
+        select * from test_adaptive_short_circuit_1 where greater(b, 10) or JSON_VALUE(a, '$.a') != '1' Format null settings short_circuit_function_evaluation='force_enable';
     </query>
     <query>
-        select * from test_adaptive_short_circuit_1 where JSON_VALUE(a, '$.a') != '1' or greater(b, 10) Format null short_circuit_function_evaluation='force_enable';
+        select * from test_adaptive_short_circuit_1 where JSON_VALUE(a, '$.a') != '1' or greater(b, 10) Format null settings short_circuit_function_evaluation='force_enable';
     </query>
     <query>
-        select (JSON_VALUE(a, '$.a') != '1' or greater(b, 10)) as x  from test_adaptive_short_circuit_1  where Format null short_circuit_function_evaluation='force_enable';
+        select (JSON_VALUE(a, '$.a') != '1' or greater(b, 10)) as x  from test_adaptive_short_circuit_1  where Format null settings short_circuit_function_evaluation='force_enable';
     </query>
     <query>
-        select (greater(b,10) or JSON_VALUE(a, '$.a') != '1') as x  from test_adaptive_short_circuit_1 where Format null short_circuit_function_evaluation='force_enable';
+        select (greater(b,10) or JSON_VALUE(a, '$.a') != '1') as x  from test_adaptive_short_circuit_1 where Format null settings short_circuit_function_evaluation='force_enable';
     </query>
 
     <query>
         <!-- query_plan_merge_filters=false, disable spilit and condition into and atoms -->
-        select * from test_adaptive_short_circuit_2 where less(b, 10) and JSON_VALUE(a, '$.a') = '1' Format null short_circuit_function_evaluation='force_enable',query_plan_merge_filters=false;
+        select * from test_adaptive_short_circuit_2 where less(b, 10) and JSON_VALUE(a, '$.a') = '1' Format null settings short_circuit_function_evaluation='force_enable',query_plan_merge_filters=false;
     </query>
     <query>
         <!-- query_plan_merge_filters=false, disable spilit and condition into and atoms -->
-        select * from test_adaptive_short_circuit_2 where JSON_VALUE(a, '$.a') = '1' and less(b,10) Format null short_circuit_function_evaluation='force_enable',query_plan_merge_filters=false;
+        select * from test_adaptive_short_circuit_2 where JSON_VALUE(a, '$.a') = '1' and less(b,10) Format null settings short_circuit_function_evaluation='force_enable',query_plan_merge_filters=false;
     </query>
     <query>
-        select (JSON_VALUE(a, '$.a') = '1' and less(b, 10)) as x  from test_adaptive_short_circuit_2 where Format null short_circuit_function_evaluation='force_enable';
+        select (JSON_VALUE(a, '$.a') = '1' and less(b, 10)) as x  from test_adaptive_short_circuit_2 where Format null settings short_circuit_function_evaluation='force_enable';
     </query>
     <query>
-        select (less(b, 10) and JSON_VALUE(a, '$.a') = '1') as x  from test_adaptive_short_circuit_2 where Format null short_circuit_function_evaluation='force_enable';
+        select (less(b, 10) and JSON_VALUE(a, '$.a') = '1') as x  from test_adaptive_short_circuit_2 where Format null settings short_circuit_function_evaluation='force_enable';
     </query>
     <query>
-        select * from test_adaptive_short_circuit_2 where greater(b, 10) or JSON_VALUE(a, '$.a') != '1' Format null short_circuit_function_evaluation='force_enable';
+        select * from test_adaptive_short_circuit_2 where greater(b, 10) or JSON_VALUE(a, '$.a') != '1' Format null settings short_circuit_function_evaluation='force_enable';
     </query>
     <query>
-        select * from test_adaptive_short_circuit_2 where JSON_VALUE(a, '$.a') != '1' or greater(b, 10) Format null short_circuit_function_evaluation='force_enable';
+        select * from test_adaptive_short_circuit_2 where JSON_VALUE(a, '$.a') != '1' or greater(b, 10) Format null settings short_circuit_function_evaluation='force_enable';
     </query>
     <query>
-        select (JSON_VALUE(a, '$.a') != '1' or greater(b, 10)) as x from test_adaptive_short_circuit_2  where Format null short_circuit_function_evaluation='force_enable';
+        select (JSON_VALUE(a, '$.a') != '1' or greater(b, 10)) as x from test_adaptive_short_circuit_2  where Format null settings short_circuit_function_evaluation='force_enable';
     </query>
     <query>
-        select (greater(b,10) or JSON_VALUE(a, '$.a') != '1') as x from test_adaptive_short_circuit_2 where Format null short_circuit_function_evaluation='force_enable';
+        select (greater(b,10) or JSON_VALUE(a, '$.a') != '1') as x from test_adaptive_short_circuit_2 where Format null settings short_circuit_function_evaluation='force_enable';
     </query>
 </test>
 

--- a/tests/performance/adaptive_short_circuit.xml
+++ b/tests/performance/adaptive_short_circuit.xml
@@ -1,4 +1,18 @@
 <test>
+    <substitutions>
+        <substitution>
+        <name>json_begin</name>
+        <values>
+            <value>'{"b":123'</value>
+        </values>
+        </substitution>
+        <substitution>
+        <name>json_end</name>
+        <values>
+            <value>'}'</value>
+        </values>
+        </substitution>
+    </substitutions>
     <create_query>
         create table test_adaptive_short_circuit_1 (a String, b UInt64) Engine=Memory
     </create_query>
@@ -6,66 +20,66 @@
         create table test_adaptive_short_circuit_2 (a String, b UInt64) Engine=Memory
     </create_query>
     <fill_query>
-        insert into test_adaptive_short_circuit_1 select a, b from( select concat('{"b":123,"c":', toString(number), ',"a":', toString(number % 1000), '}') as a, rand() % 10000 as b, rand() as c  from numbers(1000)) order by c
+        insert into test_adaptive_short_circuit_1 select a, b from( select concat({json_begin},',"c":', toString(number), ',"a":', toString(number % 1000), {json_end}) as a, rand() % 10000 as b, rand() as c  from numbers(1000)) order by c
     </fill_query>
     <fill_query>
         <!-- for small block -->
-        insert into test_adaptive_short_circuit_2 select a, b from( select concat('{"b":123,"c":', toString(number), ',"a":', toString(number % 1000), '}') as a, rand() % 10000 as b, rand() as c  from numbers(1000)) order by c settings max_block_size=512
+        insert into test_adaptive_short_circuit_2 select a, b from( select concat({json_begin},',"c":', toString(number), ',"a":', toString(number % 1000), {json_end}) as a, rand() % 10000 as b, rand() as c  from numbers(1000)) order by c settings max_block_size=512
     </fill_query>
 
 
     <query>
         <!-- query_plan_merge_filters=false, disable spilit and condition into and atoms -->
-        select * from test_adaptive_short_circuit_1 where less(b, 10) and JSON_VALUE(a, '$.a') = '1' Format null settings short_circuit_function_evaluation='force_enable',query_plan_merge_filters=false;
+        select * from test_adaptive_short_circuit_1 where less(b, 10) and JSON_VALUE(a, '$.a') = '1' Format null settings short_circuit_function_evaluation='force_enable',query_plan_merge_filters=false
     </query>
     <query>
         <!-- query_plan_merge_filters=false, disable spilit and condition into and atoms -->
-        select * from test_adaptive_short_circuit_1 where JSON_VALUE(a, '$.a') = '1' and less(b,10) Format null settings short_circuit_function_evaluation='force_enable',query_plan_merge_filters=false;
+        select * from test_adaptive_short_circuit_1 where JSON_VALUE(a, '$.a') = '1' and less(b,10) Format null settings short_circuit_function_evaluation='force_enable',query_plan_merge_filters=false
     </query>
     <query>
-        select (JSON_VALUE(a, '$.a') = '1' and less(b, 10)) as x  from test_adaptive_short_circuit_1 where Format null settings short_circuit_function_evaluation='force_enable';
+        select (JSON_VALUE(a, '$.a') = '1' and less(b, 10)) as x  from test_adaptive_short_circuit_1 Format null settings short_circuit_function_evaluation='force_enable'
     </query>
     <query>
-        select (less(b, 10) and JSON_VALUE(a, '$.a') = '1') as x  from test_adaptive_short_circuit_1 where Format null settings short_circuit_function_evaluation='force_enable';
+        select (less(b, 10) and JSON_VALUE(a, '$.a') = '1') as x  from test_adaptive_short_circuit_1 Format null settings short_circuit_function_evaluation='force_enable'
     </query>
     <query>
-        select * from test_adaptive_short_circuit_1 where greater(b, 10) or JSON_VALUE(a, '$.a') != '1' Format null settings short_circuit_function_evaluation='force_enable';
+        select * from test_adaptive_short_circuit_1 where greater(b, 10) or JSON_VALUE(a, '$.a') != '1' Format null settings short_circuit_function_evaluation='force_enable'
     </query>
     <query>
-        select * from test_adaptive_short_circuit_1 where JSON_VALUE(a, '$.a') != '1' or greater(b, 10) Format null settings short_circuit_function_evaluation='force_enable';
+        select * from test_adaptive_short_circuit_1 where JSON_VALUE(a, '$.a') != '1' or greater(b, 10) Format null settings short_circuit_function_evaluation='force_enable'
     </query>
     <query>
-        select (JSON_VALUE(a, '$.a') != '1' or greater(b, 10)) as x  from test_adaptive_short_circuit_1  where Format null settings short_circuit_function_evaluation='force_enable';
+        select (JSON_VALUE(a, '$.a') != '1' or greater(b, 10)) as x  from test_adaptive_short_circuit_1 Format null settings short_circuit_function_evaluation='force_enable'
     </query>
     <query>
-        select (greater(b,10) or JSON_VALUE(a, '$.a') != '1') as x  from test_adaptive_short_circuit_1 where Format null settings short_circuit_function_evaluation='force_enable';
+        select (greater(b,10) or JSON_VALUE(a, '$.a') != '1') as x  from test_adaptive_short_circuit_1 Format null settings short_circuit_function_evaluation='force_enable'
     </query>
 
     <query>
         <!-- query_plan_merge_filters=false, disable spilit and condition into and atoms -->
-        select * from test_adaptive_short_circuit_2 where less(b, 10) and JSON_VALUE(a, '$.a') = '1' Format null settings short_circuit_function_evaluation='force_enable',query_plan_merge_filters=false;
+        select * from test_adaptive_short_circuit_2 where less(b, 10) and JSON_VALUE(a, '$.a') = '1' Format null settings short_circuit_function_evaluation='force_enable',query_plan_merge_filters=false
     </query>
     <query>
         <!-- query_plan_merge_filters=false, disable spilit and condition into and atoms -->
-        select * from test_adaptive_short_circuit_2 where JSON_VALUE(a, '$.a') = '1' and less(b,10) Format null settings short_circuit_function_evaluation='force_enable',query_plan_merge_filters=false;
+        select * from test_adaptive_short_circuit_2 where JSON_VALUE(a, '$.a') = '1' and less(b,10) Format null settings short_circuit_function_evaluation='force_enable',query_plan_merge_filters=false
     </query>
     <query>
-        select (JSON_VALUE(a, '$.a') = '1' and less(b, 10)) as x  from test_adaptive_short_circuit_2 where Format null settings short_circuit_function_evaluation='force_enable';
+        select (JSON_VALUE(a, '$.a') = '1' and less(b, 10)) as x  from test_adaptive_short_circuit_2 Format null settings short_circuit_function_evaluation='force_enable'
     </query>
     <query>
-        select (less(b, 10) and JSON_VALUE(a, '$.a') = '1') as x  from test_adaptive_short_circuit_2 where Format null settings short_circuit_function_evaluation='force_enable';
+        select (less(b, 10) and JSON_VALUE(a, '$.a') = '1') as x  from test_adaptive_short_circuit_2 Format null settings short_circuit_function_evaluation='force_enable'
     </query>
     <query>
-        select * from test_adaptive_short_circuit_2 where greater(b, 10) or JSON_VALUE(a, '$.a') != '1' Format null settings short_circuit_function_evaluation='force_enable';
+        select * from test_adaptive_short_circuit_2 where greater(b, 10) or JSON_VALUE(a, '$.a') != '1' Format null settings short_circuit_function_evaluation='force_enable'
     </query>
     <query>
-        select * from test_adaptive_short_circuit_2 where JSON_VALUE(a, '$.a') != '1' or greater(b, 10) Format null settings short_circuit_function_evaluation='force_enable';
+        select * from test_adaptive_short_circuit_2 where JSON_VALUE(a, '$.a') != '1' or greater(b, 10) Format null settings short_circuit_function_evaluation='force_enable'
     </query>
     <query>
-        select (JSON_VALUE(a, '$.a') != '1' or greater(b, 10)) as x from test_adaptive_short_circuit_2  where Format null settings short_circuit_function_evaluation='force_enable';
+        select (JSON_VALUE(a, '$.a') != '1' or greater(b, 10)) as x from test_adaptive_short_circuit_2 Format null settings short_circuit_function_evaluation='force_enable'
     </query>
     <query>
-        select (greater(b,10) or JSON_VALUE(a, '$.a') != '1') as x from test_adaptive_short_circuit_2 where Format null settings short_circuit_function_evaluation='force_enable';
+        select (greater(b,10) or JSON_VALUE(a, '$.a') != '1') as x from test_adaptive_short_circuit_2 Format null settings short_circuit_function_evaluation='force_enable'
     </query>
 </test>
 

--- a/tests/performance/adaptive_short_circuit.xml
+++ b/tests/performance/adaptive_short_circuit.xml
@@ -20,66 +20,66 @@
         create table test_adaptive_short_circuit_2 (a String, b UInt64) Engine=Memory
     </create_query>
     <fill_query>
-        insert into test_adaptive_short_circuit_1 select a, b from( select concat({json_begin},',"c":', toString(number), ',"a":', toString(number % 1000), {json_end}) as a, rand() % 10000 as b, rand() as c  from numbers(1000)) order by c
+        insert into test_adaptive_short_circuit_1 select a, b from( select concat({json_begin},',"c":', toString(number), ',"a":', toString(number % 1000), {json_end}) as a, rand() % 10000 as b, rand() as c  from numbers(1000000)) order by c
     </fill_query>
     <fill_query>
         <!-- for small block -->
-        insert into test_adaptive_short_circuit_2 select a, b from( select concat({json_begin},',"c":', toString(number), ',"a":', toString(number % 1000), {json_end}) as a, rand() % 10000 as b, rand() as c  from numbers(1000)) order by c settings max_block_size=512
+        insert into test_adaptive_short_circuit_2 select a, b from( select concat({json_begin},',"c":', toString(number), ',"a":', toString(number % 1000), {json_end}) as a, rand() % 10000 as b, rand() as c  from numbers(1000000)) order by c settings max_block_size=512
     </fill_query>
 
 
     <query>
         <!-- query_plan_merge_filters=false, disable spilit and condition into and atoms -->
-        select * from test_adaptive_short_circuit_1 where less(b, 10) and JSON_VALUE(a, '$.a') = '1' Format null settings short_circuit_function_evaluation='force_enable',query_plan_merge_filters=false
+        select * from test_adaptive_short_circuit_1 where less(b, 10) and JSON_VALUE(a, '$.a') = '1' Format null settings short_circuit_function_evaluation='force_enable',query_plan_merge_filters=false,max_threads=4
     </query>
     <query>
         <!-- query_plan_merge_filters=false, disable spilit and condition into and atoms -->
-        select * from test_adaptive_short_circuit_1 where JSON_VALUE(a, '$.a') = '1' and less(b,10) Format null settings short_circuit_function_evaluation='force_enable',query_plan_merge_filters=false
+        select * from test_adaptive_short_circuit_1 where JSON_VALUE(a, '$.a') = '1' and less(b,10) Format null settings short_circuit_function_evaluation='force_enable',query_plan_merge_filters=false,max_threads=4
     </query>
     <query>
-        select (JSON_VALUE(a, '$.a') = '1' and less(b, 10)) as x  from test_adaptive_short_circuit_1 Format null settings short_circuit_function_evaluation='force_enable'
+        select (JSON_VALUE(a, '$.a') = '1' and less(b, 10)) as x  from test_adaptive_short_circuit_1 Format null settings short_circuit_function_evaluation='force_enable',max_threads=4
     </query>
     <query>
-        select (less(b, 10) and JSON_VALUE(a, '$.a') = '1') as x  from test_adaptive_short_circuit_1 Format null settings short_circuit_function_evaluation='force_enable'
+        select (less(b, 10) and JSON_VALUE(a, '$.a') = '1') as x  from test_adaptive_short_circuit_1 Format null settings short_circuit_function_evaluation='force_enable',max_threads=4
     </query>
     <query>
-        select * from test_adaptive_short_circuit_1 where greater(b, 10) or JSON_VALUE(a, '$.a') != '1' Format null settings short_circuit_function_evaluation='force_enable'
+        select * from test_adaptive_short_circuit_1 where greater(b, 10) or JSON_VALUE(a, '$.a') != '1' Format null settings short_circuit_function_evaluation='force_enable',max_threads=4
     </query>
     <query>
-        select * from test_adaptive_short_circuit_1 where JSON_VALUE(a, '$.a') != '1' or greater(b, 10) Format null settings short_circuit_function_evaluation='force_enable'
+        select * from test_adaptive_short_circuit_1 where JSON_VALUE(a, '$.a') != '1' or greater(b, 10) Format null settings short_circuit_function_evaluation='force_enable',max_threads=4
     </query>
     <query>
-        select (JSON_VALUE(a, '$.a') != '1' or greater(b, 10)) as x  from test_adaptive_short_circuit_1 Format null settings short_circuit_function_evaluation='force_enable'
+        select (JSON_VALUE(a, '$.a') != '1' or greater(b, 10)) as x  from test_adaptive_short_circuit_1 Format null settings short_circuit_function_evaluation='force_enable',max_threads=4
     </query>
     <query>
-        select (greater(b,10) or JSON_VALUE(a, '$.a') != '1') as x  from test_adaptive_short_circuit_1 Format null settings short_circuit_function_evaluation='force_enable'
+        select (greater(b,10) or JSON_VALUE(a, '$.a') != '1') as x  from test_adaptive_short_circuit_1 Format null settings short_circuit_function_evaluation='force_enable',max_threads=4
     </query>
 
     <query>
         <!-- query_plan_merge_filters=false, disable spilit and condition into and atoms -->
-        select * from test_adaptive_short_circuit_2 where less(b, 10) and JSON_VALUE(a, '$.a') = '1' Format null settings short_circuit_function_evaluation='force_enable',query_plan_merge_filters=false
+        select * from test_adaptive_short_circuit_2 where less(b, 10) and JSON_VALUE(a, '$.a') = '1' Format null settings short_circuit_function_evaluation='force_enable',query_plan_merge_filters=false,max_threads=4
     </query>
     <query>
         <!-- query_plan_merge_filters=false, disable spilit and condition into and atoms -->
-        select * from test_adaptive_short_circuit_2 where JSON_VALUE(a, '$.a') = '1' and less(b,10) Format null settings short_circuit_function_evaluation='force_enable',query_plan_merge_filters=false
+        select * from test_adaptive_short_circuit_2 where JSON_VALUE(a, '$.a') = '1' and less(b,10) Format null settings short_circuit_function_evaluation='force_enable',query_plan_merge_filters=false,max_threads=4
     </query>
     <query>
-        select (JSON_VALUE(a, '$.a') = '1' and less(b, 10)) as x  from test_adaptive_short_circuit_2 Format null settings short_circuit_function_evaluation='force_enable'
+        select (JSON_VALUE(a, '$.a') = '1' and less(b, 10)) as x  from test_adaptive_short_circuit_2 Format null settings short_circuit_function_evaluation='force_enable',max_threads=4
     </query>
     <query>
-        select (less(b, 10) and JSON_VALUE(a, '$.a') = '1') as x  from test_adaptive_short_circuit_2 Format null settings short_circuit_function_evaluation='force_enable'
+        select (less(b, 10) and JSON_VALUE(a, '$.a') = '1') as x  from test_adaptive_short_circuit_2 Format null settings short_circuit_function_evaluation='force_enable',max_threads=4
     </query>
     <query>
-        select * from test_adaptive_short_circuit_2 where greater(b, 10) or JSON_VALUE(a, '$.a') != '1' Format null settings short_circuit_function_evaluation='force_enable'
+        select * from test_adaptive_short_circuit_2 where greater(b, 10) or JSON_VALUE(a, '$.a') != '1' Format null settings short_circuit_function_evaluation='force_enable',max_threads=4
     </query>
     <query>
-        select * from test_adaptive_short_circuit_2 where JSON_VALUE(a, '$.a') != '1' or greater(b, 10) Format null settings short_circuit_function_evaluation='force_enable'
+        select * from test_adaptive_short_circuit_2 where JSON_VALUE(a, '$.a') != '1' or greater(b, 10) Format null settings short_circuit_function_evaluation='force_enable',max_threads=4
     </query>
     <query>
-        select (JSON_VALUE(a, '$.a') != '1' or greater(b, 10)) as x from test_adaptive_short_circuit_2 Format null settings short_circuit_function_evaluation='force_enable'
+        select (JSON_VALUE(a, '$.a') != '1' or greater(b, 10)) as x from test_adaptive_short_circuit_2 Format null settings short_circuit_function_evaluation='force_enable',max_threads=4
     </query>
     <query>
-        select (greater(b,10) or JSON_VALUE(a, '$.a') != '1') as x from test_adaptive_short_circuit_2 Format null settings short_circuit_function_evaluation='force_enable'
+        select (greater(b,10) or JSON_VALUE(a, '$.a') != '1') as x from test_adaptive_short_circuit_2 Format null settings short_circuit_function_evaluation='force_enable',max_threads=4
     </query>
 </test>
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...
For function `and`/`or`, the short-circuit arguments execution order has an important impact on performance. For example
```sql
-- q1
select * from mt_left where JSON_VALUE(s, '$.a') = '1' and key < 100 Format Null

0 rows in set. Elapsed: 0.067 sec. Processed 10.02 million rows, 475.95 MB (149.84 million rows/s., 7.12 GB/s.)
```
```sql
-- q2
select * from mt_left where key < 100 and JSON_VALUE(s, '$.a') = '1'  Format Null

0 rows in set. Elapsed: 0.018 sec. Processed 10.02 million rows, 475.95 MB (566.96 million rows/s., 26.93 GB/s.)
```

To determine the execution order of arguments, this PR first sample some rows, get the selectivity and execution cost, and then reorder the arguments position. For the `q1` as above, the resutl is
```sql
-- q1
select * from mt_left where JSON_VALUE(s, '$.a') = '1' and key < 100  Format Null
0 rows in set. Elapsed: 0.018 sec. Processed 10.02 million rows, 475.95 MB (550.27 million rows/s., 26.14 GB/s.)
```

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
