### PR TITLE
Enable test_query_is_lock_free[detach table] for the analyzer

### DIFF
--- a/tests/analyzer_integration_broken_tests.txt
+++ b/tests/analyzer_integration_broken_tests.txt
@@ -4,7 +4,6 @@ test_concurrent_backups_s3/test.py::test_concurrent_backups
 test_dictionaries_update_and_reload/test.py::test_reload_after_fail_in_cache_dictionary
 test_distributed_backward_compatability/test.py::test_distributed_in_tuple
 test_distributed_type_object/test.py::test_distributed_type_object
-test_drop_is_lock_free/test.py::test_query_is_lock_free[detach table]
 test_executable_table_function/test.py::test_executable_function_input_python
 test_mask_sensitive_info/test.py::test_encryption_functions
 test_merge_table_over_distributed/test.py::test_global_in

--- a/tests/integration/test_drop_is_lock_free/test.py
+++ b/tests/integration/test_drop_is_lock_free/test.py
@@ -125,7 +125,10 @@ def test_query_is_lock_free(lock_free_query, exclusive_table):
                 SELECT count() FROM {exclusive_table};
             """
         )
-        assert f"Table default.{exclusive_table} does not exist" in result
+        assert (
+            f"Table default.{exclusive_table} does not exist" in result
+            or f"Unknown table expression identifier '{exclusive_table}'" in result
+        )
     else:
         assert 0 == int(
             node.query(


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

Same as other tests (e.g. `test_system_logs`)
