### PR TITLE
Fix filtering by virtual columns with OR filter in query (resubmit)

### DIFF
--- a/tests/integration/test_system_merges/test.py
+++ b/tests/integration/test_system_merges/test.py
@@ -188,7 +188,7 @@ def test_mutation_simple(started_cluster, replicated):
         # ALTER will sleep for 9s
         def alter():
             node1.query(
-                f"ALTER TABLE {name} UPDATE a = 42 WHERE sleep(9) OR 1",
+                f"ALTER TABLE {name} UPDATE a = 42 WHERE sleep(9) = 0",
                 settings=settings,
             )
 

--- a/tests/queries/0_stateless/02840_merge__table_or_filter.sql.j2
+++ b/tests/queries/0_stateless/02840_merge__table_or_filter.sql.j2
@@ -18,6 +18,11 @@ create view v2 as select * from d2;
 
 create table m as v1 engine=Merge(currentDatabase(), '^(v1|v2)$');
 
+{# -- FIXME:
+select _table, key from m where (value = 10 and _table = 'v1') or (value = 20 and _table = 'v1') or 0 or 0 settings {{ settings }};
+select _table, key from m where (value = 10 and _table = 'v3') or (value = 20 and _table = 'v3') or 0 or 0 settings {{ settings }};
+#}
+
 -- avoid reorder
 set max_threads=1;
 -- { echoOn }

--- a/tests/queries/0_stateless/02896_multiple_OR.reference
+++ b/tests/queries/0_stateless/02896_multiple_OR.reference
@@ -1,0 +1,14 @@
+-- { echoOn }
+SELECT * FROM or_bug WHERE (key = 1) OR false OR false;
+1
+SELECT * FROM or_bug WHERE (key = 1) OR false;
+1
+SELECT * FROM or_bug WHERE (key = 1);
+1
+-- { echoOn }
+select * from forms where text_field like '%this%' or 0 = 1 or 0 = 1;
+5840ead423829c1eab29fa97	this is a test
+select * from forms where text_field like '%this%' or 0 = 1;
+5840ead423829c1eab29fa97	this is a test
+select * from forms where text_field like '%this%';
+5840ead423829c1eab29fa97	this is a test

--- a/tests/queries/0_stateless/02896_multiple_OR.sql
+++ b/tests/queries/0_stateless/02896_multiple_OR.sql
@@ -1,0 +1,28 @@
+-- https://github.com/ClickHouse/ClickHouse/pull/52653
+DROP TABLE IF EXISTS or_bug;
+CREATE TABLE or_bug (key UInt8) ENGINE=MergeTree ORDER BY key;
+INSERT INTO TABLE or_bug VALUES (0), (1);
+
+-- { echoOn }
+SELECT * FROM or_bug WHERE (key = 1) OR false OR false;
+SELECT * FROM or_bug WHERE (key = 1) OR false;
+SELECT * FROM or_bug WHERE (key = 1);
+-- { echoOff }
+
+-- https://github.com/ClickHouse/ClickHouse/issues/55288
+DROP TABLE IF EXISTS forms;
+CREATE TABLE forms
+(
+   `form_id` FixedString(24),
+   `text_field` String
+)
+ENGINE = MergeTree
+PRIMARY KEY form_id
+ORDER BY form_id;
+insert into forms values ('5840ead423829c1eab29fa97','this is a test');
+
+-- { echoOn }
+select * from forms where text_field like '%this%' or 0 = 1 or 0 = 1;
+select * from forms where text_field like '%this%' or 0 = 1;
+select * from forms where text_field like '%this%';
+-- { echoOff }


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix filtering by virtual columns with OR filter in query (_part* filtering for MergeTree, _path/_file for various File/HDFS/... engines, _table for Merge)

The problem with the initial implementation #52653 was:
- OR can have multiple arguments
- It simply not correct to assume that if there are two arguments this is OK.
  Consider the following example:

    "WHERE (column_not_from_partition_by = 1) OR false OR false"

  Will be converted to:

    "WHERE false OR false"

And it will simply read nothing.

Yes, we could apply some optimization for bool, but this will not always
work, since to optimize things like "0 = 1" we need to execute it.

And the only way to make handle this correctly (with ability to ignore
some commands during filtering) is to make is_constant() function return
has it use something from the input block, so that we can be sure, that
we have some sensible, and not just "false".

Plus we cannot simply ignore the difference of the input and output
arguments of handling OR, we need to add always-true (1/true) if the
size is different, since otherwise it could break invariants (see
comment in the code).

P.S. analyzer does not have this bug, since it execute expression as
whole, and this is what filterBlockWithQuery() should do actually
instead, but this will be a more complex patch.

Resubmits: #55418 (due to the test failure it got reverted, this had been addressed in this PR, see last patch) (cc @alexey-milovidov )
Reverts: #55657 (cc @antonio2368 )
Fixes: https://github.com/ClickHouse/ClickHouse/issues/54779 (cc @slanderous-mambo )
Fixes: https://github.com/ClickHouse/ClickHouse/issues/55288 (cc @allen12921)