### PR TITLE
Reuse granule during skip index reading

### DIFF
--- a/src/Interpreters/BloomFilter.cpp
+++ b/src/Interpreters/BloomFilter.cpp
@@ -41,8 +41,15 @@ BloomFilter::BloomFilter(const BloomFilterParameters & params)
 BloomFilter::BloomFilter(size_t size_, size_t hashes_, size_t seed_)
     : size(size_), hashes(hashes_), seed(seed_), words((size + sizeof(UnderType) - 1) / sizeof(UnderType)), filter(words, 0)
 {
-    assert(size != 0);
-    assert(hashes != 0);
+    chassert(size != 0);
+    chassert(hashes != 0);
+}
+
+void BloomFilter::resize(size_t size_)
+{
+    size = size_;
+    words = ((size + sizeof(UnderType) - 1) / sizeof(UnderType));
+    filter.resize(words);
 }
 
 bool BloomFilter::find(const char * data, size_t len)

--- a/src/Interpreters/BloomFilter.h
+++ b/src/Interpreters/BloomFilter.h
@@ -37,6 +37,7 @@ public:
     /// seed -- random seed for hash functions generation.
     BloomFilter(size_t size_, size_t hashes_, size_t seed_);
 
+    void resize(size_t size_);
     bool find(const char * data, size_t len);
     void add(const char * data, size_t len);
     void clear();

--- a/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
@@ -1675,7 +1675,7 @@ MarkRanges MergeTreeDataSelectExecutor::filterMarksUsingIndex(
         for (size_t index_mark = index_range.begin; index_mark < index_range.end; ++index_mark)
         {
             if (index_mark != index_range.begin || !granule || last_index_mark != index_range.begin)
-                granule = reader.read();
+                reader.read(granule);
 
             auto ann_condition = std::dynamic_pointer_cast<IMergeTreeIndexConditionApproximateNearestNeighbor>(condition);
             if (ann_condition != nullptr)
@@ -1793,7 +1793,7 @@ MarkRanges MergeTreeDataSelectExecutor::filterMarksUsingMergedIndex(
             {
                 for (size_t i = 0; i < readers.size(); ++i)
                 {
-                    granules[i] = readers[i]->read();
+                    readers[i]->read(granules[i]);
                     granules_filled = true;
                 }
             }

--- a/src/Storages/MergeTree/MergeTreeIndexFullText.h
+++ b/src/Storages/MergeTree/MergeTreeIndexFullText.h
@@ -25,8 +25,8 @@ struct MergeTreeIndexGranuleFullText final : public IMergeTreeIndexGranule
 
     bool empty() const override { return !has_elems; }
 
-    String index_name;
-    BloomFilterParameters params;
+    const String index_name;
+    const BloomFilterParameters params;
 
     std::vector<BloomFilter> bloom_filters;
     bool has_elems;

--- a/src/Storages/MergeTree/MergeTreeIndexGranuleBloomFilter.h
+++ b/src/Storages/MergeTree/MergeTreeIndexGranuleBloomFilter.h
@@ -22,9 +22,10 @@ public:
     const std::vector<BloomFilterPtr> & getFilters() const { return bloom_filters; }
 
 private:
+    const size_t bits_per_row;
+    const size_t hash_functions;
+
     size_t total_rows = 0;
-    size_t bits_per_row;
-    size_t hash_functions;
     std::vector<BloomFilterPtr> bloom_filters;
 
     void fillingBloomFilter(BloomFilterPtr & bf, const HashSet<UInt64> & hashes) const;

--- a/src/Storages/MergeTree/MergeTreeIndexInverted.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexInverted.cpp
@@ -73,11 +73,11 @@ void MergeTreeIndexGranuleInverted::deserializeBinary(ReadBuffer & istr, MergeTr
     {
         size_serialization->deserializeBinary(field_rows, istr, {});
         size_t filter_size = field_rows.get<size_t>();
+        gin_filter.getFilter().resize(filter_size);
 
         if (filter_size == 0)
             continue;
 
-        gin_filter.getFilter().assign(filter_size, {});
         istr.readStrict(reinterpret_cast<char *>(gin_filter.getFilter().data()), filter_size * sizeof(GinSegmentWithRowIdRangeVector::value_type));
     }
     has_elems = true;

--- a/src/Storages/MergeTree/MergeTreeIndexInverted.h
+++ b/src/Storages/MergeTree/MergeTreeIndexInverted.h
@@ -24,8 +24,8 @@ struct MergeTreeIndexGranuleInverted final : public IMergeTreeIndexGranule
 
     bool empty() const override { return !has_elems; }
 
-    String index_name;
-    GinFilterParameters params;
+    const String index_name;
+    const GinFilterParameters params;
     GinFilters gin_filters;
     bool has_elems;
 };

--- a/src/Storages/MergeTree/MergeTreeIndexMinMax.h
+++ b/src/Storages/MergeTree/MergeTreeIndexMinMax.h
@@ -25,8 +25,9 @@ struct MergeTreeIndexGranuleMinMax final : public IMergeTreeIndexGranule
 
     bool empty() const override { return hyperrectangle.empty(); }
 
-    String index_name;
-    Block index_sample_block;
+    const String index_name;
+    const Block index_sample_block;
+
     std::vector<Range> hyperrectangle;
 };
 

--- a/src/Storages/MergeTree/MergeTreeIndexReader.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexReader.cpp
@@ -69,11 +69,12 @@ void MergeTreeIndexReader::seek(size_t mark)
     stream->seekToMark(mark);
 }
 
-MergeTreeIndexGranulePtr MergeTreeIndexReader::read()
+void MergeTreeIndexReader::read(MergeTreeIndexGranulePtr & granule)
 {
-    auto granule = index->createIndexGranule();
+    if (granule == nullptr)
+        granule = index->createIndexGranule();
+
     granule->deserializeBinary(*stream->getDataBuffer(), version);
-    return granule;
 }
 
 }

--- a/src/Storages/MergeTree/MergeTreeIndexReader.h
+++ b/src/Storages/MergeTree/MergeTreeIndexReader.h
@@ -23,7 +23,7 @@ public:
 
     void seek(size_t mark);
 
-    MergeTreeIndexGranulePtr read();
+    void read(MergeTreeIndexGranulePtr & granule);
 
 private:
     MergeTreeIndexPtr index;

--- a/src/Storages/MergeTree/MergeTreeIndexSet.h
+++ b/src/Storages/MergeTree/MergeTreeIndexSet.h
@@ -35,9 +35,10 @@ struct MergeTreeIndexGranuleSet final : public IMergeTreeIndexGranule
 
     ~MergeTreeIndexGranuleSet() override = default;
 
-    String index_name;
-    size_t max_rows;
-    Block index_sample_block;
+    const String index_name;
+    const size_t max_rows;
+    const Block index_sample_block;
+
     Block block;
 };
 

--- a/tests/performance/min_max_index.xml
+++ b/tests/performance/min_max_index.xml
@@ -1,0 +1,11 @@
+<test>
+    <create_query>CREATE TABLE index_test (z UInt32, INDEX i_x (mortonDecode(2, z).1) TYPE minmax, INDEX i_y (mortonDecode(2, z).2) TYPE minmax) ENGINE = MergeTree ORDER BY z</create_query>
+
+    <fill_query>INSERT INTO index_test SELECT number FROM numbers(0x100000000) WHERE rand() % 3 = 1</fill_query>
+
+    <query><![CDATA[
+    SELECT count() FROM index_test WHERE mortonDecode(2, z).1 >= 20000 AND mortonDecode(2, z).1 <= 20100 AND mortonDecode(2, z).2 >= 10000 AND mortonDecode(2, z).2 <= 10100
+    ]]></query>
+
+    <drop_query>DROP TABLE IF EXISTS index_test</drop_query>
+</test>


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Avoid unnecessary reconstruction of index granules when reading skip indexes. This addresses https://github.com/ClickHouse/ClickHouse/issues/55653#issuecomment-1763766009 .
