### PR TITLE
Re-fix data race in CachedOnDiskReadBufferFromFile in a better way

### DIFF
--- a/src/Disks/IO/ReadBufferFromWebServer.h
+++ b/src/Disks/IO/ReadBufferFromWebServer.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <atomic>
 #include <IO/ReadBufferFromFileBase.h>
 #include <IO/BufferWithOwnMemory.h>
 #include <IO/ReadSettings.h>
@@ -34,7 +33,7 @@ public:
 
     void setReadUntilPosition(size_t position) override;
 
-    size_t getFileOffsetOfBufferEnd() const override { return offset.load(std::memory_order_relaxed); }
+    size_t getFileOffsetOfBufferEnd() const override { return offset; }
 
     bool supportsRightBoundedReads() const override { return true; }
 
@@ -55,10 +54,7 @@ private:
 
     bool use_external_buffer;
 
-    /// atomic is required for CachedOnDiskReadBufferFromFile, which can access
-    /// to this variable via getFileOffsetOfBufferEnd()/seek() from multiple
-    /// threads.
-    std::atomic<off_t> offset = 0;
+    off_t offset = 0;
     off_t read_until_position = 0;
 };
 

--- a/src/IO/SeekableReadBuffer.h
+++ b/src/IO/SeekableReadBuffer.h
@@ -44,10 +44,6 @@ public:
 
     virtual String getInfoForLog() { return ""; }
 
-    /// NOTE: This method should be thread-safe against seek(), since it can be
-    /// used in CachedOnDiskReadBufferFromFile from multiple threads (because
-    /// it first releases the buffer, and then do logging, and so other thread
-    /// can already call seek() which will lead to data-race).
     virtual size_t getFileOffsetOfBufferEnd() const { throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Method getFileOffsetOfBufferEnd() not implemented"); }
 
     /// If true, setReadUntilPosition() guarantees that eof will be reported at the given position.


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

The fix in https://github.com/ClickHouse/ClickHouse/pull/55372 looks really hacky: it allows getting read buffer's position in parallel with changing that position (i.e.seeking), which sounds like a sus combination generally, only ok here because it's used for logging and it's ok to log garbage sometimes.

Here's a hopefully better fix: reset `implementation_buffer` whenever `file_segment.completePartAndResetDownloader()`/`resetDownloader()` happens.

Also fixes what looks like another similar race condition where `swap(*implementation_buffer)` happened after releasing the "ownership" of implementation_buffer.

Undid the original fix just in case the new fix turns out to be wrong - then the same tests should catch the same race again.