### PR TITLE
Randomize block_number column setting in ci

### DIFF
--- a/docker/test/stateless/stress_tests.lib
+++ b/docker/test/stateless/stress_tests.lib
@@ -70,6 +70,13 @@ function configure()
     sudo chown clickhouse /etc/clickhouse-server/config.d/keeper_port.xml
     sudo chgrp clickhouse /etc/clickhouse-server/config.d/keeper_port.xml
 
+    #Randomize merge tree setting allow_experimental_block_number_column
+    value=$(($RANDOM % 2))
+    sudo cat /etc/clickhouse-server/config.d/merge_tree_settings.xml \
+    | sed "s|<allow_experimental_block_number_column>[01]</allow_experimental_block_number_column>|<allow_experimental_block_number_column>$value</allow_experimental_block_number_column>|" \
+    > /etc/clickhouse-server/config.d/merge_tree_settings.xml.tmp
+    sudo mv /etc/clickhouse-server/config.d/merge_tree_settings.xml.tmp /etc/clickhouse-server/config.d/merge_tree_settings.xml
+
     # for clickhouse-server (via service)
     echo "ASAN_OPTIONS='malloc_context_size=10 verbosity=1 allocator_release_to_os_interval_ms=10000'" >> /etc/environment
     # for clickhouse-client

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -673,7 +673,6 @@ class MergeTreeSettingsRandomizer:
         "primary_key_compress_block_size": lambda: random.randint(8000, 100000),
         "replace_long_file_name_to_hash": lambda: random.randint(0, 1),
         "max_file_name_length": threshold_generator(0.3, 0.3, 0, 128),
-        "allow_experimental_block_number_column": lambda: random.randint(0, 1),
     }
 
     @staticmethod

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -673,6 +673,7 @@ class MergeTreeSettingsRandomizer:
         "primary_key_compress_block_size": lambda: random.randint(8000, 100000),
         "replace_long_file_name_to_hash": lambda: random.randint(0, 1),
         "max_file_name_length": threshold_generator(0.3, 0.3, 0, 128),
+        "allow_experimental_block_number_column": lambda: random.randint(0, 1),
     }
 
     @staticmethod

--- a/tests/config/config.d/merge_tree_settings.xml
+++ b/tests/config/config.d/merge_tree_settings.xml
@@ -2,6 +2,7 @@
     <merge_tree>
         <!-- 10 seconds (default is 1 minute) -->
         <zookeeper_session_expiration_check_period>10</zookeeper_session_expiration_check_period>
+        <!-- Setting randomized for stress test, it is disabled here and this line is used to randomize it in the script -->
         <allow_experimental_block_number_column>0</allow_experimental_block_number_column>
     </merge_tree>
 </clickhouse>

--- a/tests/config/config.d/merge_tree_settings.xml
+++ b/tests/config/config.d/merge_tree_settings.xml
@@ -2,5 +2,6 @@
     <merge_tree>
         <!-- 10 seconds (default is 1 minute) -->
         <zookeeper_session_expiration_check_period>10</zookeeper_session_expiration_check_period>
+        <allow_experimental_block_number_column>o</allow_experimental_block_number_column>
     </merge_tree>
 </clickhouse>

--- a/tests/config/config.d/merge_tree_settings.xml
+++ b/tests/config/config.d/merge_tree_settings.xml
@@ -2,6 +2,6 @@
     <merge_tree>
         <!-- 10 seconds (default is 1 minute) -->
         <zookeeper_session_expiration_check_period>10</zookeeper_session_expiration_check_period>
-        <allow_experimental_block_number_column>o</allow_experimental_block_number_column>
+        <allow_experimental_block_number_column>0</allow_experimental_block_number_column>
     </merge_tree>
 </clickhouse>


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

