### PR TITLE
optimize ColumnVector::insertMany and ColumnVector::insertManyFrom

### DIFF
--- a/src/Columns/ColumnVector.h
+++ b/src/Columns/ColumnVector.h
@@ -154,6 +154,17 @@ public:
         data.push_back(assert_cast<const Self &>(src).getData()[n]);
     }
 
+    void insertManyFrom(const IColumn & src, size_t position, size_t length) override
+    {
+        ValueType v = assert_cast<const Self &>(src).getData()[position];
+        data.resize_fill(data.size() + length, v);
+    }
+
+    void insertMany(const Field & field, size_t length) override
+    {
+        data.resize_fill(data.size() + length, static_cast<T>(field.get<T>()));
+    }
+
     void insertData(const char * pos, size_t) override
     {
         data.emplace_back(unalignedLoad<T>(pos));


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Performance improvement for `ColumnVector::insertMany` and `ColumnVector::insertManyFrom`
