### PR TITLE
Use pool for proxied S3 disk http sessions

### DIFF
--- a/src/IO/HTTPCommon.cpp
+++ b/src/IO/HTTPCommon.cpp
@@ -324,6 +324,14 @@ namespace
             auto retry_timeout = timeouts.connection_timeout.totalMilliseconds();
             auto session = pool_ptr->second->get(retry_timeout);
 
+            const auto & session_data = session->sessionData();
+            if (session_data.empty() || !Poco::AnyCast<HTTPSessionReuseTag>(&session_data))
+            {
+                /// Reset session if it is not reusable. See comment for HTTPSessionReuseTag.
+                session->reset();
+            }
+            session->attachSessionData({});
+
             setTimeouts(*session, timeouts);
 
             return session;

--- a/src/IO/ReadBufferFromS3.cpp
+++ b/src/IO/ReadBufferFromS3.cpp
@@ -74,8 +74,17 @@ void resetSessionIfNeeded(bool read_all_range_successfully, std::optional<Aws::S
     }
     else if (auto session = getSession(*read_result); !session.isNull())
     {
-        DB::markSessionForReuse(session);
-        ProfileEvents::increment(ProfileEvents::ReadBufferFromS3PreservedSessions);
+        if (!session->getProxyHost().empty())
+        {
+            /// Reset proxified sessions because proxy can change for every request. See ProxyConfigurationResolver.
+            resetSession(*read_result);
+            ProfileEvents::increment(ProfileEvents::ReadBufferFromS3ResetSessions);
+        }
+        else
+        {
+            DB::markSessionForReuse(session);
+            ProfileEvents::increment(ProfileEvents::ReadBufferFromS3PreservedSessions);
+        }
     }
 }
 }

--- a/src/IO/S3/PocoHTTPClient.cpp
+++ b/src/IO/S3/PocoHTTPClient.cpp
@@ -276,7 +276,7 @@ void PocoHTTPClient::makeRequestInternal(
 {
     /// Most sessions in pool are already connected and it is not possible to set proxy host/port to a connected session.
     const auto request_configuration = per_request_configuration();
-    if (http_connection_pool_size && request_configuration.host.empty())
+    if (http_connection_pool_size)
         makeRequestInternalImpl<true>(request, request_configuration, response, readLimiter, writeLimiter);
     else
         makeRequestInternalImpl<false>(request, request_configuration, response, readLimiter, writeLimiter);


### PR DESCRIPTION
Get rid of exhaustion of available ports due to large number of hanging sockets in CLOSE_WAIT state in case of using proxy for S3 disk connections. Use pool to limit proxied connections to S3 disk like for not-proxied.

Otherwise, under heavy load on S3 disk, we periodically get 30k CLOSE_WAIT connections and errors in log
```
2023.10.06 15:27:09.433893 [ 1477336 ] {} <Error> AWSClient: Failed to make request to: https://cloud-storage-c9qia44rob2di08ah3bj.s3.yandexcloud.net/cloud_storage/c9qia44rob2di08ah3bj/shard1/hsc/kwxclcsxzmgdwhuogkqjlqswottnw: Poco::Exception. Code: 1000, e.code() = 99, Net Exception: Cannot assign requested address: [2a02:6b8::1d9]:443, Stack trace (when copying this message, always include the lines below):

0. ./build_docker/./base/poco/Net/src/NetException.cpp:26: Poco::Net::SocketImpl::error(int, String const&) @ 0x17a972fc in /usr/lib/debug/usr/bin/clickhouse.debug
1. ./build_docker/./contrib/llvm-project/libcxx/include/string:1499: Poco::Net::SocketImpl::connect(Poco::Net::SocketAddress const&, Poco::Timespan const&) @ 0x17a97abf in /usr/lib/debug/usr/bin/clickhouse.debug
2. ./build_docker/./base/poco/Foundation/include/Poco/AutoPtr.h:205: Poco::Net::SecureSocketImpl::connect(Poco::Net::SocketAddress const&, Poco::Timespan const&, bool) @ 0x17a60227 in /usr/lib/debug/usr/bin/clickhouse.debug
3. ./build_docker/./base/poco/Foundation/include/Poco/AutoPtr.h:205: Poco::Net::SecureStreamSocketImpl::connect(Poco::Net::SocketAddress const&, Poco::Timespan const&) @ 0x17a64c79 in /usr/lib/debug/usr/bin/clickhouse.debug
4. ./build_docker/./base/poco/Net/src/HTTPSession.cpp:197: Poco::Net::HTTPSClientSession::connect(Poco::Net::SocketAddress const&) @ 0x17a50902 in /usr/lib/debug/usr/bin/clickhouse.debug
5. ./build_docker/./base/poco/Net/src/HTTPClientSession.cpp:0: Poco::Net::HTTPClientSession::reconnect() @ 0x17a6e761 in /usr/lib/debug/usr/bin/clickhouse.debug
6. ./build_docker/./base/poco/Net/include/Poco/Net/HTTPSession.h:217: Poco::Net::HTTPClientSession::sendRequest(Poco::Net::HTTPRequest&) @ 0x17a6d903 in /usr/lib/debug/usr/bin/clickhouse.debug
7. ./build_docker/./src/IO/S3/PocoHTTPClient.cpp:0: DB::S3::PocoHTTPClient::makeRequestInternal(Aws::Http::HttpRequest&, std::shared_ptr<DB::S3::PocoHTTPResponse>&, Aws::Utils::RateLimits::RateLimiterInterface*, Aws::Utils::RateLimits::RateLimiterInterface*) const @ 0x128d422d in /usr/lib/debug/usr/bin/clickhouse.debug
8. ./build_docker/./src/IO/S3/PocoHTTPClient.cpp:180: DB::S3::PocoHTTPClient::MakeRequest(std::shared_ptr<Aws::Http::HttpRequest> const&, Aws::Utils::RateLimits::RateLimiterInterface*, Aws::Utils::RateLimits::RateLimiterInterface*) const @ 0x128d20dc in /usr/lib/debug/usr/bin/clickhouse.debug
9. Aws::Client::AWSClient::AttemptOneRequest(std::shared_ptr<Aws::Http::HttpRequest> const&, Aws::AmazonWebServiceRequest const&, char const*, char const*, char const*) const @ 0x17c7cea9 in /usr/lib/debug/usr/bin/clickhouse.debug
10. Aws::Client::AWSClient::AttemptExhaustively(Aws::Http::URI const&, Aws::AmazonWebServiceRequest const&, Aws::Http::HttpMethod, char const*, char const*, char const*) const @ 0x17c7a012 in /usr/lib/debug/usr/bin/clickhouse.debug
11. Aws::Client::AWSClient::MakeRequestWithUnparsedResponse(Aws::Http::URI const&, Aws::AmazonWebServiceRequest const&, Aws::Http::HttpMethod, char const*, char const*, char const*) const @ 0x17c819a5 in /usr/lib/debug/usr/bin/clickhouse.debug
12. Aws::S3::S3Client::GetObject(Aws::S3::Model::GetObjectRequest const&) const @ 0x17d8e359 in /usr/lib/debug/usr/bin/clickhouse.debug
13. ./build_docker/./contrib/aws/aws-cpp-sdk-core/include/aws/core/utils/Outcome.h:160: DB::S3::Client::GetObject(DB::S3::ExtendedRequest<Aws::S3::Model::GetObjectRequest> const&) const @ 0x128b859f in /usr/lib/debug/usr/bin/clickhouse.debug
14. ./build_docker/./src/IO/ResourceGuard.h:122: DB::ReadBufferFromS3::initialize() @ 0x128efa35 in /usr/lib/debug/usr/bin/clickhouse.debug
15. ./build_docker/./src/IO/ReadBufferFromS3.cpp:0: DB::ReadBufferFromS3::nextImpl() @ 0x128ed571 in /usr/lib/debug/usr/bin/clickhouse.debug
16. ./build_docker/./src/IO/ReadBuffer.h:66: DB::ReadBufferFromRemoteFSGather::readImpl() @ 0x12db73b1 in /usr/lib/debug/usr/bin/clickhouse.debug
17. ./build_docker/./src/Disks/IO/ReadBufferFromRemoteFSGather.cpp:151: DB::ReadBufferFromRemoteFSGather::nextImpl() @ 0x12db6ff0 in /usr/lib/debug/usr/bin/clickhouse.debug
18. ./build_docker/./src/Disks/IO/ReadBufferFromRemoteFSGather.cpp:109: DB::ReadBufferFromRemoteFSGather::readInto(char*, unsigned long, unsigned long, unsigned long) @ 0x12db6f77 in /usr/lib/debug/usr/bin/clickhouse.debug
19. ./build_docker/./base/glibc-compatibility/musl/clock_gettime.c:62: std::__packaged_task_func<std::function<std::future<DB::IAsynchronousReader::Result> (DB::ThreadPoolRemoteFSReader::submit(DB::IAsynchronousReader::Request)::$_0&&, long)> DB::threadPoolCallbackRunner<DB::IAsynchronousReader::Result, DB::ThreadPoolRemoteFSReader::submit(DB::IAsynchronousReader::Request)::$_0>(ThreadPoolImpl<ThreadFromGlobalPoolImpl<false>>&, String const&)::'lambda'(DB::ThreadPoolRemoteFSReader::submit(DB::IAsynchronousReader::Request)::$_0&&, long)::operator()(DB::ThreadPoolRemoteFSReader::submit(DB::IAsynchronousReader::Request)::$_0&&, long)::'lambda'(), std::allocator<std::function<std::future<DB::IAsynchronousReader::Result> (DB::ThreadPoolRemoteFSReader::submit(DB::IAsynchronousReader::Request)::$_0&&, long)> DB::threadPoolCallbackRunner<DB::IAsynchronousReader::Result, DB::ThreadPoolRemoteFSReader::submit(DB::IAsynchronousReader::Request)::$_0>(ThreadPoolImpl<ThreadFromGlobalPoolImpl<false>>&, String const&)::'lambda'(DB::ThreadPoolRemoteFSReader::submit(DB::IAsynchronousReader::Request)::$_0&&, long)::operator()(DB::ThreadPoolRemoteFSReader::submit(DB::IAsynchronousReader::Request)::$_0&&, long)::'lambda'()>, DB::IAsynchronousReader::Result ()>::operator()() (.c750d46528d62e6fd5e67fe0d154f6e8) @ 0x12f5bc2e in /usr/lib/debug/usr/bin/clickhouse.debug
20. ./build_docker/./contrib/llvm-project/libcxx/include/future:1380: std::packaged_task<DB::IAsynchronousReader::Result ()>::operator()() @ 0x12f5c3c3 in /usr/lib/debug/usr/bin/clickhouse.debug
21. ./build_docker/./base/base/../base/wide_integer_impl.h:789: ThreadPoolImpl<ThreadFromGlobalPoolImpl<false>>::worker(std::__list_iterator<ThreadFromGlobalPoolImpl<false>, void*>) @ 0xe367da5 in /usr/lib/debug/usr/bin/clickhouse.debug
22. ./build_docker/./src/Common/ThreadPool.cpp:0: void std::__function::__policy_invoker<void ()>::__call_impl<std::__function::__default_alloc_func<ThreadFromGlobalPoolImpl<false>::ThreadFromGlobalPoolImpl<void ThreadPoolImpl<ThreadFromGlobalPoolImpl<false>>::scheduleImpl<void>(std::function<void ()>, long, std::optional<unsigned long>, bool)::'lambda0'()>(void&&)::'lambda'(), void ()>>(std::__function::__policy_storage const*) @ 0xe36a915 in /usr/lib/debug/usr/bin/clickhouse.debug
23. ./build_docker/./base/base/../base/wide_integer_impl.h:789: ThreadPoolImpl<std::thread>::worker(std::__list_iterator<std::thread, void*>) @ 0xe363b73 in /usr/lib/debug/usr/bin/clickhouse.debug
24. ./build_docker/./contrib/llvm-project/libcxx/include/__memory/unique_ptr.h:302: void* std::__thread_proxy[abi:v15000]<std::tuple<std::unique_ptr<std::__thread_struct, std::default_delete<std::__thread_struct>>, void ThreadPoolImpl<std::thread>::scheduleImpl<void>(std::function<void ()>, long, std::optional<unsigned long>, bool)::'lambda0'()>>(void*) @ 0xe3697e1 in /usr/lib/debug/usr/bin/clickhouse.debug
25. start_thread @ 0x76db in /lib/x86_64-linux-gnu/libpthread-2.27.so
26. __clone @ 0x12161f in /lib/x86_64-linux-gnu/libc-2.27.so
 (version 23.3.13.6 (official build))
```


Also restore `HTTPSessionReuseTag` session reusing logic that was changed in https://github.com/ClickHouse/ClickHouse/pull/52116

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
