### PR TITLE
Update `system.disks` after deleting disk from conf without restart

### DIFF
--- a/src/Disks/DiskSelector.h
+++ b/src/Disks/DiskSelector.h
@@ -41,6 +41,8 @@ public:
 
     void addToDiskMap(const String & name, DiskPtr disk);
 
+    void deleteFromDiskMap(const String & name);
+
     void shutdown();
 
 private:

--- a/tests/integration/test_reloading_storage_configuration/test.py
+++ b/tests/integration/test_reloading_storage_configuration/test.py
@@ -536,10 +536,9 @@ def test_remove_disk(started_cluster):
         start_over()
         node1.query("SYSTEM RELOAD CONFIG")
 
-        assert "remove_disk_jbod3" in set(
+        assert "remove_disk_jbod3" not in set(
             node1.query("SELECT name FROM system.disks").splitlines()
         )
-        assert re.search("Warning.*remove_disk_jbod3", get_log(node1))
     finally:
         try:
             node1.query("DROP TABLE IF EXISTS {}".format(name))


### PR DESCRIPTION
It is possible to change disk or add a new one without ClickHouse restart, since this commit, disk will be deleted on the fly as well.

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Update `system.disks` after deleting disk from conf without ClickHouse restart.
