### PR TITLE
Respect default format when using http_write_exception_in_output_format

### DIFF
--- a/src/Formats/FormatFactory.cpp
+++ b/src/Formats/FormatFactory.cpp
@@ -410,7 +410,7 @@ std::unique_ptr<ReadBuffer> FormatFactory::wrapReadBufferIfNeeded(
 
 static void addExistingProgressToOutputFormat(OutputFormatPtr format, ContextPtr context)
 {
-    auto element_id = context->getProcessListElement();
+    auto element_id = context->getProcessListElementSafe();
     if (element_id)
     {
         /// While preparing the query there might have been progress (for example in subscalar subqueries) so add it here

--- a/src/Interpreters/executeQuery.cpp
+++ b/src/Interpreters/executeQuery.cpp
@@ -1340,7 +1340,7 @@ void executeQuery(
             {
                 String format_name = context->getDefaultFormat();
                 output_format = FormatFactory::instance().getOutputFormat(format_name, ostr, {}, context, output_format_settings);
-                if (output_format)
+                if (output_format && output_format->supportsWritingException())
                 {
                     /// Force an update of the headers before we start writing
                     result_details.content_type = output_format->getContentType();

--- a/tests/queries/0_stateless/02899_use_default_format_on_http_exception.reference
+++ b/tests/queries/0_stateless/02899_use_default_format_on_http_exception.reference
@@ -1,0 +1,25 @@
+INSERT WITH default_format=JSON
+Content-Type:application/json;charset=UTF-8
+"exception":"Code:62.
+
+INSERT WITH default_format=XML
+Content-Type:application/xml;charset=UTF-8
+<exception>Code:62.DB::Ex---tion:
+
+INSERT WITH default_format=BADFORMAT
+Content-Type:text/plain;charset=UTF-8
+X-ClickHouse-Ex---tion-Code:62
+Code:62.DB::Ex---tion:
+
+INSERT WITH X-ClickHouse-Format: JSON
+Content-Type:application/json;charset=UTF-8
+"exception":"Code:62.
+
+INSERT WITH X-ClickHouse-Format: XML
+Content-Type:application/xml;charset=UTF-8
+<exception>Code:62.DB::Ex---tion:
+
+INSERT WITH X-ClickHouse-Format: BADFORMAT
+Content-Type:text/plain;charset=UTF-8
+X-ClickHouse-Ex---tion-Code:62
+Code:62.DB::Ex---tion:

--- a/tests/queries/0_stateless/02899_use_default_format_on_http_exception.sh
+++ b/tests/queries/0_stateless/02899_use_default_format_on_http_exception.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+CH_URL="$CLICKHOUSE_URL&http_write_exception_in_output_format=1"
+
+echo "INSERT WITH default_format=JSON"
+echo "INSERT INTO system.numbers Select * from numbers(10);" \
+  | ${CLICKHOUSE_CURL} -sS "${CH_URL}&default_format=JSON" -i | grep 'xception\|Content-Type' | sed 's/Exception/Ex---tion/' | awk '{ print $1 $2 $3 }'
+echo ""
+echo "INSERT WITH default_format=XML"
+echo "INSERT INTO system.numbers Select * from numbers(10);" \
+  | ${CLICKHOUSE_CURL} -sS "${CH_URL}&default_format=XML" -i | grep 'xception\|Content-Type' | sed 's/Exception/Ex---tion/' | awk '{ print $1 $2 $3 }'
+echo ""
+echo "INSERT WITH default_format=BADFORMAT"
+echo "INSERT INTO system.numbers Select * from numbers(10);" \
+  | ${CLICKHOUSE_CURL} -sS "${CH_URL}&default_format=BADFORMAT" -i | grep 'xception\|Content-Type' | sed 's/Exception/Ex---tion/' | awk '{ print $1 $2 $3 }'
+
+
+echo ""
+echo "INSERT WITH X-ClickHouse-Format: JSON"
+echo "INSERT INTO system.numbers Select * from numbers(10);" \
+  | ${CLICKHOUSE_CURL} -sS "${CH_URL}" -H 'X-ClickHouse-Format: JSON' -i | grep 'xception\|Content-Type' | sed 's/Exception/Ex---tion/' | awk '{ print $1 $2 $3 }'
+echo ""
+echo "INSERT WITH X-ClickHouse-Format: XML"
+echo "INSERT INTO system.numbers Select * from numbers(10);" \
+  | ${CLICKHOUSE_CURL} -sS "${CH_URL}" -H 'X-ClickHouse-Format: XML' -i | grep 'xception\|Content-Type' | sed 's/Exception/Ex---tion/' | awk '{ print $1 $2 $3 }'
+echo ""
+echo "INSERT WITH X-ClickHouse-Format: BADFORMAT"
+echo "INSERT INTO system.numbers Select * from numbers(10);" \
+  | ${CLICKHOUSE_CURL} -sS "${CH_URL}" -H 'X-ClickHouse-Format: BADFORMAT' -i | grep 'xception\|Content-Type' | sed 's/Exception/Ex---tion/' | awk '{ print $1 $2 $3 }'


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Use the default query format if declared when outputting exception with http_write_exception_in_output_format.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)


cc @Avogar 

Closes https://github.com/ClickHouse/ClickHouse/issues/902. If you pass `default_format=JSON` all exceptions in HTTP should have a JSON format.
Closes https://github.com/ClickHouse/ClickHouse/issues/6272: You can now use the `X-ClickHouse-Format: JSON` header.
References https://github.com/ClickHouse/ClickHouse/issues/55422. In some queries the format inside the SQL itself is not processed (the query is rejected before processing the format) but now you can charge the default format to overcome this limitation. Ideally the format of the query should be used