### PR TITLE
Use diff object again, since JSON API limits the files

### DIFF
--- a/tests/ci/pr_info.py
+++ b/tests/ci/pr_info.py
@@ -4,6 +4,8 @@ import logging
 import os
 from typing import Dict, List, Set, Union, Literal
 
+from unidiff import PatchSet  # type: ignore
+
 from build_download_helper import get_gh_api
 from env_helper import (
     GITHUB_REPOSITORY,
@@ -263,11 +265,14 @@ class PRInfo:
             raise TypeError("The event does not have diff URLs")
 
         for diff_url in self.diff_urls:
-            response = get_gh_api(diff_url, sleep=RETRY_SLEEP)
+            response = get_gh_api(
+                diff_url,
+                sleep=RETRY_SLEEP,
+                headers={"Accept": "application/vnd.github.v3.diff"},
+            )
             response.raise_for_status()
-            diff = response.json()
-            if "files" in diff:
-                self.changed_files = {f["filename"] for f in diff["files"]}
+            diff_object = PatchSet(response.text)
+            self.changed_files.update({f.path for f in diff_object})
         print(f"Fetched info about {len(self.changed_files)} changed files")
 
     def get_dict(self):

--- a/tests/ci/worker/prepare-ci-ami.sh
+++ b/tests/ci/worker/prepare-ci-ami.sh
@@ -90,7 +90,6 @@ systemctl restart docker
 sudo -u ubuntu docker buildx version
 sudo -u ubuntu docker buildx create --use --name default-builder
 
-# FIXME: remove unidiff as soon as no old PRs could use it, here and in Dockerfile
 pip install boto3 pygithub requests urllib3 unidiff dohq-artifactory
 
 mkdir -p $RUNNER_HOME && cd $RUNNER_HOME


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
