### PR TITLE
Remove temporary debug logging in MultiplexedConnections

### DIFF
--- a/src/Client/MultiplexedConnections.h
+++ b/src/Client/MultiplexedConnections.h
@@ -106,14 +106,7 @@ private:
     std::optional<ReplicaInfo> replica_info;
 
     /// A mutex for the sendCancel function to execute safely in separate thread.
-    mutable std::timed_mutex cancel_mutex;
-
-    /// Temporary instrumentation to debug a weird deadlock on cancel_mutex.
-    /// TODO: Once the investigation is done, get rid of these, and of INSTRUMENTED_LOCK_MUTEX, and
-    ///       change cancel_mutex to std::mutex.
-    mutable std::atomic<UInt64> mutex_last_locked_by{0};
-    mutable std::atomic<Int64> mutex_locked{0};
-    mutable std::array<UInt8, sizeof(std::timed_mutex)> mutex_memory_dump;
+    mutable std::mutex cancel_mutex;
 
     friend struct RemoteQueryExecutorRoutine;
 };


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Undo https://github.com/ClickHouse/ClickHouse/pull/54940 because the bug was fixed (https://github.com/ClickHouse/ClickHouse/pull/55516)