### PR TITLE
Check if partition ID is `nullptr`

### DIFF
--- a/src/Parsers/ASTPartition.cpp
+++ b/src/Parsers/ASTPartition.cpp
@@ -36,8 +36,9 @@ String ASTPartition::getID(char delim) const
 {
     if (value)
         return "Partition";
-    else
-        return "Partition_ID" + (delim + id->getID());
+
+    std::string id_string = id ? id->getID() : "";
+    return "Partition_ID" + (delim + id_string);
 }
 
 ASTPtr ASTPartition::clone() const


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


UBSAN caught in fuzzer tests
```
/build/src/Parsers/ASTPartition.cpp:40:46: runtime error: member call on null pointer of type 'DB::IAST'
    #0 0x55d79f5ab36b in DB::ASTPartition::getID(char) const build_docker/./src/Parsers/ASTPartition.cpp:40:46
    #1 0x55d79f67d42f in DB::IAST::dumpTree(DB::WriteBuffer&, unsigned long) const build_docker/./src/Parsers/IAST.cpp:253:27
    #2 0x55d79f67d6bc in DB::IAST::dumpTree(DB::WriteBuffer&, unsigned long) const build_docker/./src/Parsers/IAST.cpp:259:16
    #3 0x55d79f67d6bc in DB::IAST::dumpTree(DB::WriteBuffer&, unsigned long) const build_docker/./src/Parsers/IAST.cpp:259:16
    #4 0x55d79f67d6bc in DB::IAST::dumpTree(DB::WriteBuffer&, unsigned long) const build_docker/./src/Parsers/IAST.cpp:259:16
    #5 0x55d78e2ed62a in DB::Client::processWithFuzzing(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) build_docker/./programs/client/Client.cpp:769:24
    #6 0x55d79e424194 in DB::ClientBase::executeMultiQuery(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) build_docker/./src/Client/ClientBase.cpp:2138:26
    #7 0x55d79e426c7b in DB::ClientBase::processMultiQueryFromFile(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) build_docker/./src/Client/ClientBase.cpp:2566:12
    #8 0x55d79e42c8ba in DB::ClientBase::runNonInteractive() build_docker/./src/Client/ClientBase.cpp:2583:18
    #9 0x55d78e2e42d1 in DB::Client::main(std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>> const&) build_docker/./programs/client/Client.cpp:373:9
    #10 0x55d7a065cbb2 in Poco::Util::Application::run() build_docker/./base/poco/Util/src/Application.cpp:315:8
    #11 0x55d78e3005a6 in mainEntryClickHouseClient(int, char**) build_docker/./programs/client/Client.cpp:1458:23
    #12 0x55d78225ed8b in main build_docker/./programs/main.cpp:491:12
    #13 0x7faf4f20ed8f in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
    #14 0x7faf4f20ee3f in __libc_start_main csu/../csu/libc-start.c:392:3
    #15 0x55d7822347ed in _start (/workspace/clickhouse+0x187207ed) (BuildId: d7272a2356a3027f49f931bffdf9fbbb9f09a91b)

SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /build/src/Parsers/ASTPartition.cpp:40:46 in
```

https://s3.amazonaws.com/clickhouse-test-reports/0/1d2ac48261ddd4999b8f73b69de76ea04d3025b8/fuzzer_astfuzzerubsan/report.html

Introduced probably in https://github.com/ClickHouse/ClickHouse/pull/55604

cc @alesapin I reverted to the old behaviour where if no id is set we just append empty id string.
But I'm not sure when it happens, I assume when `all` is set, maybe we should return `Partition ALL` in `getID` in that case?

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
