### PR TITLE
Added test to check CapnProto cache

### DIFF
--- a/tests/integration/test_format_schema_on_server/test.py
+++ b/tests/integration/test_format_schema_on_server/test.py
@@ -112,3 +112,66 @@ message MessageTmp {
             "SELECT * FROM test.simple FORMAT Protobuf SETTINGS format_schema='message_tmp:MessageTmp'"
         )
     assert "NO_COLUMNS_SERIALIZED_TO_PROTOBUF_FIELDS)" in str(exc.value)
+
+
+def test_drop_capn_proto_format(started_cluster):
+    create_simple_table()
+    instance.query("INSERT INTO test.simple VALUES (1, 'abc'), (2, 'def')")
+    capn_proto_schema = """
+@0x801f030c2b67bf19;
+
+struct MessageTmp {
+    key @0 :UInt64;
+    value @1 :Text;
+}
+"""
+    capn_schema_path_name = "message_tmp.capnp"
+
+    database_path = os.path.abspath(os.path.join(instance.path, "database"))
+    format_schemas_path = os.path.join(database_path, "format_schemas")
+    with open(os.path.join(format_schemas_path, capn_schema_path_name), "w") as file:
+        file.write(capn_proto_schema)
+
+    assert instance.http_query(
+        "SELECT * FROM test.simple FORMAT CapnProto SETTINGS format_schema='message_tmp:MessageTmp'"
+    ) == instance.query(
+        f"SELECT * FROM test.simple Format CapnProto SETTINGS format_schema='{format_schemas_path}/message_tmp:MessageTmp'"
+    )
+
+    new_schema = """
+@0x801f030c2b67bf19;
+
+struct MessageTmp {
+    key2 @0 :UInt64;
+    value2 @1 :Text;
+}
+"""
+    with open(os.path.join(format_schemas_path, capn_schema_path_name), "w") as file:
+        file.write(new_schema)
+
+    instance.query("DROP TABLE IF EXISTS test.new_simple")
+    instance.query(
+        """
+        CREATE TABLE test.new_simple (key2 UInt64, value2 String)
+            ENGINE = MergeTree ORDER BY tuple();
+        """
+    )
+    instance.query("INSERT INTO test.new_simple VALUES (1, 'abc'), (2, 'def')")
+
+    # instance.query("SYSTEM DROP FORMAT SCHEMA CACHE FOR CapnProto")
+
+    # Tets works with new scheme
+    assert instance.http_query(
+        "SELECT * FROM test.new_simple FORMAT CapnProto SETTINGS format_schema='message_tmp:MessageTmp'"
+    ) == instance.query(
+        f"SELECT * FROM test.new_simple Format CapnProto SETTINGS format_schema='{format_schemas_path}/message_tmp:MessageTmp'"
+    )
+    # Tests that stop working with old scheme
+    with pytest.raises(Exception) as exc:
+        instance.http_query(
+            "SELECT * FROM test.simple FORMAT CapnProto SETTINGS format_schema='message_tmp:MessageTmp'"
+        )
+    assert (
+        "Capnproto schema doesn't contain field with name key. (THERE_IS_NO_COLUMN)"
+        in str(exc.value)
+    )


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Since the current schema for CapnProto doesn't use cache, the
integration test was for the future if someone adds a cache.

Also, I was curious how schema cache affects performance and I compared reading binary files
with Protobuf (I guess it works the same for CapnProto).

```
for i in {1..1000}; do clickhouse-client -q \
  "select * from test.simple format Protobuf settings format_schema='/format_schemas/simple:KeyValuePair'" > simple-protobuf${i}.bin; done

clickhouse-client --time -q "select * from file('simple-protobuf{1..999}.bin', 'Protobuf') format Null settings format_schema = 'simple:KeyValuePair'"
```

Protobuf with cache and without works with approximately the same
time.


Follows - https://github.com/ClickHouse/ClickHouse/pull/55064 
cc @Avogar 
