### PR TITLE
Fix data race in CreatingSetsTransform (v2)

### DIFF
--- a/src/Processors/Transforms/CreatingSetsTransform.cpp
+++ b/src/Processors/Transforms/CreatingSetsTransform.cpp
@@ -7,7 +7,10 @@
 #include <Interpreters/Context.h>
 #include <Storages/IStorage.h>
 
+#include <Common/Exception.h>
 #include <Common/logger_useful.h>
+
+#include <exception>
 
 
 namespace DB
@@ -95,18 +98,18 @@ void CreatingSetsTransform::startSubquery()
         /// Retry if the set from cache fails to be built.
         while (true)
         {
-            auto from_cache = prepared_sets_cache->findOrPromiseToBuild(set_and_key->key);
-            if (from_cache.index() == 0)
+            try
             {
-                LOG_TRACE(log, "Building set, key: {}", set_and_key->key);
-                promise_to_build = std::move(std::get<0>(from_cache));
-            }
-            else
-            {
-                LOG_TRACE(log, "Waiting for set to be built by another thread, key: {}", set_and_key->key);
-                SharedSet set_built_by_another_thread = std::move(std::get<1>(from_cache));
-                try
+                auto from_cache = prepared_sets_cache->findOrPromiseToBuild(set_and_key->key);
+                if (from_cache.index() == 0)
                 {
+                    LOG_TRACE(log, "Building set, key: {}", set_and_key->key);
+                    promise_to_build = std::move(std::get<0>(from_cache));
+                }
+                else
+                {
+                    LOG_TRACE(log, "Waiting for set to be built by another thread, key: {}", set_and_key->key);
+                    SharedSet set_built_by_another_thread = std::move(std::get<1>(from_cache));
                     const SetPtr & ready_set = set_built_by_another_thread.get();
                     if (!ready_set)
                     {
@@ -118,14 +121,20 @@ void CreatingSetsTransform::startSubquery()
                     done_with_set = true;
                     set_from_cache = true;
                 }
-                catch (const Exception & e)
-                {
-                    /// Exception that is thrown by the future::get() is shared across all waiters and cannot be modified from multiple threads.
-                    /// Re-create exception to allow later multiple modify (i.e. addMessage() during pipeline execution)
-                    throw Exception(e);
-                }
+                break;
             }
-            break;
+            /// Exception that is thrown by the shared_future::get() is shared across all waiters and cannot be modified from multiple threads.
+            /// Re-create exception to allow later concurrent modify (i.e. addMessage() during pipeline execution)
+            ///
+            /// Note, that findOrPromiseToBuild() can also call shared_future::get()
+            catch (const Exception & e)
+            {
+                throw Exception(e);
+            }
+            catch (...)
+            {
+                throw Exception::createRuntime(ErrorCodes::UNKNOWN_EXCEPTION, getExceptionMessage(std::current_exception(), /* with_stacktrace= */ false));
+            }
         }
     }
 


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix data race in CreatingSetsTransform

The problem is that findOrPromiseToBuild() can also call shared_future::get():

    (lldb) bt 10
    * thread 194, name = 'MergeMutate', stop reason = step over
      frame 0: 0x0000564126046bd2 clickhouse`std::rethrow_exception(p=(__ptr_ = 0x00007b5000130c80)) at exception_pointer_cxxabi.ipp:68:39
      frame 1: 0x000056411c4c5ddd clickhouse`std::__1::__assoc_state<std::__1::shared_ptr<DB::Set>>::copy(this=<unavailable>) at future:701:9
      frame 2: 0x000056411c4c0e3f clickhouse`DB::PreparedSetsCache::findOrPromiseToBuild(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) [inlined] std::__1::shared_future<std::__1::shared_ptr<DB::Set>>::get[abi:v15000](this=0x00007b0c00154eb8) const at future:2243:46
      frame 3: 0x000056411c4c0e2e clickhouse`DB::PreparedSetsCache::findOrPromiseToBuild(this=0x00007b1c00077018, key="__set_10438532338982543705_15680061365857338647") at PreparedSets.cpp:349:116

Follow-up for: #55338 (cc @alexey-milovidov )
Fixes: #55279