### PR TITLE
S3Queue improvements, part 2 (Ordered mode related only)

### DIFF
--- a/src/Storages/S3Queue/S3QueueFilesMetadata.h
+++ b/src/Storages/S3Queue/S3QueueFilesMetadata.h
@@ -126,8 +126,8 @@ private:
         AlreadyProcessed,
         AlreadyFailed,
     };
-    std::pair<SetFileProcessingResult, ProcessingNodeHolderPtr> trySetFileAsProcessingForOrderedMode(const std::string & path);
-    std::pair<SetFileProcessingResult, ProcessingNodeHolderPtr> trySetFileAsProcessingForUnorderedMode(const std::string & path);
+    ProcessingNodeHolderPtr trySetFileAsProcessingForOrderedMode(const std::string & path, FileStatus & file_status);
+    ProcessingNodeHolderPtr trySetFileAsProcessingForUnorderedMode(const std::string & path, FileStatus & file_status);
 
     std::tuple<SetFileProcessingResult, ProcessingNodeHolderPtr, bool> trySetFileAsProcessingForOrderedMode(const std::deque<std::string> & paths);
 

--- a/src/Storages/S3Queue/S3QueueSettings.h
+++ b/src/Storages/S3Queue/S3QueueSettings.h
@@ -26,6 +26,7 @@ class ASTStorage;
     M(UInt32, s3queue_polling_min_timeout_ms, 1000, "Minimal timeout before next polling", 0) \
     M(UInt32, s3queue_polling_max_timeout_ms, 10000, "Maximum timeout before next polling", 0) \
     M(UInt32, s3queue_polling_backoff_ms, 1000, "Polling backoff", 0) \
+    M(UInt32, s3queue_parallel_processing_window, 10, "For Ordered mode. A window within which parallel processing is allowed.", 0) \
     M(UInt32, s3queue_tracked_files_limit, 1000, "For unordered mode. Max set size for tracking processed files in ZooKeeper", 0) \
     M(UInt32, s3queue_cleanup_interval_min_ms, 60000, "For unordered mode. Polling backoff min for cleanup", 0) \
     M(UInt32, s3queue_cleanup_interval_max_ms, 60000, "For unordered mode. Polling backoff max for cleanup", 0) \

--- a/src/Storages/S3Queue/S3QueueSource.h
+++ b/src/Storages/S3Queue/S3QueueSource.h
@@ -40,7 +40,10 @@ public:
     class FileIterator : public IIterator
     {
     public:
-        FileIterator(std::shared_ptr<S3QueueFilesMetadata> metadata_, std::unique_ptr<GlobIterator> glob_iterator_, std::atomic<bool> & shutdown_called_);
+        FileIterator(
+            std::shared_ptr<S3QueueFilesMetadata> metadata_,
+            std::unique_ptr<GlobIterator> glob_iterator_,
+            std::atomic<bool> & shutdown_called_);
 
         /// Note:
         /// List results in s3 are always returned in UTF-8 binary order.
@@ -53,6 +56,30 @@ public:
         const std::shared_ptr<S3QueueFilesMetadata> metadata;
         const std::unique_ptr<GlobIterator> glob_iterator;
         std::atomic<bool> & shutdown_called;
+    };
+
+    class FileIteratorWindowProcessing : public IIterator
+    {
+    public:
+        FileIteratorWindowProcessing(
+            std::shared_ptr<S3QueueFilesMetadata> metadata_,
+            std::unique_ptr<GlobIterator> glob_iterator_,
+            size_t window_size_,
+            std::atomic<bool> & shutdown_called_);
+
+        /// Note:
+        /// List results in s3 are always returned in UTF-8 binary order.
+        /// (https://docs.aws.amazon.com/AmazonS3/latest/userguide/ListingKeysUsingAPIs.html)
+        KeyWithInfoPtr next() override;
+
+        size_t estimatedKeysCount() override;
+
+    private:
+        const std::shared_ptr<S3QueueFilesMetadata> metadata;
+        const std::unique_ptr<GlobIterator> glob_iterator;
+        const size_t window_size;
+        std::atomic<bool> & shutdown_called;
+        std::vector<KeyWithInfoPtr> current_window;
         std::mutex mutex;
     };
 

--- a/src/Storages/S3Queue/StorageS3Queue.h
+++ b/src/Storages/S3Queue/StorageS3Queue.h
@@ -55,7 +55,7 @@ public:
     zkutil::ZooKeeperPtr getZooKeeper() const;
 
 private:
-    using FileIterator = StorageS3QueueSource::FileIterator;
+    using FileIterator = StorageS3QueueSource::IIterator;
 
     const std::unique_ptr<S3QueueSettings> s3queue_settings;
     const fs::path zk_path;

--- a/src/Storages/StorageS3.cpp
+++ b/src/Storages/StorageS3.cpp
@@ -188,6 +188,20 @@ public:
         return nextAssumeLocked();
     }
 
+    std::vector<KeyWithInfoPtr> nextBatch(size_t n)
+    {
+        std::lock_guard lock(mutex);
+        std::vector<KeyWithInfoPtr> result;
+        while (n--)
+        {
+            auto key_with_info = nextAssumeLocked();
+            if (!key_with_info || key_with_info->key.empty())
+                break;
+            result.push_back(key_with_info);
+        }
+        return result;
+    }
+
     size_t objectsCount()
     {
         return buffer.size();
@@ -384,6 +398,11 @@ StorageS3Source::DisclosedGlobIterator::DisclosedGlobIterator(
 StorageS3Source::KeyWithInfoPtr StorageS3Source::DisclosedGlobIterator::next()
 {
     return pimpl->next();
+}
+
+std::vector<StorageS3Source::KeyWithInfoPtr> StorageS3Source::DisclosedGlobIterator::nextBatch(size_t n)
+{
+    return pimpl->nextBatch(n);
 }
 
 size_t StorageS3Source::DisclosedGlobIterator::estimatedKeysCount()

--- a/src/Storages/StorageS3.h
+++ b/src/Storages/StorageS3.h
@@ -85,6 +85,7 @@ public:
             std::function<void(FileProgress)> progress_callback_ = {});
 
         KeyWithInfoPtr next() override;
+        std::vector<KeyWithInfoPtr> nextBatch(size_t n);
         size_t estimatedKeysCount() override;
 
     private:

--- a/tests/integration/test_storage_s3_queue/test.py
+++ b/tests/integration/test_storage_s3_queue/test.py
@@ -653,13 +653,13 @@ def test_multiple_tables_streaming_sync(started_cluster, mode):
         return int(run_query(node, f"SELECT count() FROM {table_name}"))
 
     for _ in range(100):
-        if (
-            get_count(f"{dst_table_name}_1")
-            + get_count(f"{dst_table_name}_2")
-            + get_count(f"{dst_table_name}_3")
-        ) == files_to_generate:
+        count = get_count(f"{dst_table_name}_1") + get_count(f"{dst_table_name}_2") + get_count(f"{dst_table_name}_3")
+        if count == files_to_generate:
             break
+        print(f"{count}/{files_to_generate}")
         time.sleep(1)
+
+    assert get_count(f"{dst_table_name}_1") + get_count(f"{dst_table_name}_2") + get_count(f"{dst_table_name}_3") == files_to_generate
 
     res1 = [
         list(map(int, l.split()))


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Make `Ordered` processing mode safely parallelizable. Continuation of https://github.com/ClickHouse/ClickHouse/pull/54422.
Before this PR setting `s3queue_processing_threads_num` was disabled (forcefully set to 1) for `Ordered` mode, because it was unsafe, and for the same reason, distributed processing was unsafe. (See https://github.com/ClickHouse/ClickHouse/pull/54422#discussion_r1360738148)