### PR TITLE
Attemp to fix test_dictionaries_redis flakiness

### DIFF
--- a/tests/integration/test_dictionaries_redis/test_long.py
+++ b/tests/integration/test_dictionaries_redis/test_long.py
@@ -6,6 +6,8 @@ cluster = ClickHouseCluster(__file__)
 
 node = cluster.add_instance("node", with_redis=True)
 
+POOL_SIZE = 16
+
 
 @pytest.fixture(scope="module")
 def start_cluster():
@@ -29,10 +31,10 @@ def start_cluster():
                 value UInt64
             )
             PRIMARY KEY date, id
-            SOURCE(REDIS(HOST '{}' PORT 6379 STORAGE_TYPE 'hash_map' DB_INDEX 0 PASSWORD 'clickhouse'))
+            SOURCE(REDIS(HOST '{}' PORT 6379 STORAGE_TYPE 'hash_map' DB_INDEX 0 PASSWORD 'clickhouse' POOL_SIZE '{}'))
             LAYOUT(COMPLEX_KEY_DIRECT())
             """.format(
-                cluster.redis_host
+                cluster.redis_host, POOL_SIZE
             )
         )
 
@@ -58,12 +60,14 @@ def start_cluster():
 
 def test_redis_dict_long(start_cluster):
     assert (
-        node.query("SELECT count(), uniqExact(date), uniqExact(id) FROM redis_dict")
+        node.query(
+            f"SELECT count(), uniqExact(date), uniqExact(id) FROM redis_dict SETTINGS max_threads={POOL_SIZE}"
+        )
         == "1000\t1\t1000\n"
     )
     assert (
         node.query(
-            "SELECT count(DISTINCT dictGet('redis_dict', 'value', tuple(date, id % 1000))) FROM redis_dictionary_test"
+            f"SELECT count(DISTINCT dictGet('redis_dict', 'value', tuple(date, id % 1000))) FROM redis_dictionary_test SETTINGS max_threads={POOL_SIZE}"
         )
         == "1000\n"
     )


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

References https://github.com/ClickHouse/ClickHouse/issues/55715


AFAICS the problem with the test is that some threads time out when getting a redis connection. This happens because the pipeline mergetree readers (thus threads) are larger than the redis pool. I haven't seen a straightforward way to modify the pipeline based on the dictionary used by dictGet, so for now let's try limiting the max_threads manually in the queries to avoid it failing. 
