### PR TITLE
Add server setting `mysql_port_require_secure_transport` to enforce TLS on the MySQL port

### DIFF
--- a/docs/en/operations/server-configuration-parameters/settings.md
+++ b/docs/en/operations/server-configuration-parameters/settings.md
@@ -2315,6 +2315,16 @@ Example
 <mysql_port>9004</mysql_port>
 ```
 
+## mysql_port_require_secure_transport {#mysql_port_require_secure_transport}
+
+Only allow connections to the [MySQL port](#mysql_port) that use TLS/SSL, connections that do not upgrade to TLS/SSL return an error `ER_SECURE_TRANSPORT_REQUIRED` to the client.  Similar to the MySQL server setting `require_secure_transport`.
+
+Example:
+
+``` xml
+<mysql_port_require_secure_transport>true</mysql_port_require_secure_transport>
+```
+
 ## postgresql_port {#postgresql_port}
 
 Port for communicating with clients over PostgreSQL protocol.

--- a/src/Core/ServerSettings.h
+++ b/src/Core/ServerSettings.h
@@ -98,7 +98,8 @@ namespace DB
     M(Double, total_memory_tracker_sample_probability, 0, "Collect random allocations and deallocations and write them into system.trace_log with 'MemorySample' trace_type. The probability is for every alloc/free regardless to the size of the allocation (can be changed with `memory_profiler_sample_min_allocation_size` and `memory_profiler_sample_max_allocation_size`). Note that sampling happens only when the amount of untracked memory exceeds 'max_untracked_memory'. You may want to set 'max_untracked_memory' to 0 for extra fine grained sampling.", 0) \
     M(UInt64, total_memory_profiler_sample_min_allocation_size, 0, "Collect random allocations of size greater or equal than specified value with probability equal to `total_memory_profiler_sample_probability`. 0 means disabled. You may want to set 'max_untracked_memory' to 0 to make this threshold to work as expected.", 0) \
     M(UInt64, total_memory_profiler_sample_max_allocation_size, 0, "Collect random allocations of size less or equal than specified value with probability equal to `total_memory_profiler_sample_probability`. 0 means disabled. You may want to set 'max_untracked_memory' to 0 to make this threshold to work as expected.", 0) \
-    M(Bool, validate_tcp_client_information, false, "Validate client_information in the query packet over the native TCP protocol.", 0)
+    M(Bool, validate_tcp_client_information, false, "Validate client_information in the query packet over the native TCP protocol.", 0) \
+    M(Bool, mysql_port_require_secure_transport, false, "Require secure transport for MySQL protocol.", 0)
 
 DECLARE_SETTINGS_TRAITS(ServerSettingsTraits, SERVER_SETTINGS)
 

--- a/src/Server/MySQLHandler.h
+++ b/src/Server/MySQLHandler.h
@@ -42,7 +42,8 @@ public:
         TCPServer & tcp_server_,
         const Poco::Net::StreamSocket & socket_,
         bool ssl_enabled,
-        uint32_t connection_id_);
+        uint32_t connection_id_,
+        bool require_secure_transport_);
 
     void run() final;
 
@@ -102,6 +103,7 @@ protected:
     std::shared_ptr<ReadBufferFromPocoSocket> in;
     std::shared_ptr<WriteBuffer> out;
     bool secure_connection = false;
+    bool require_secure_transport;
 };
 
 #if USE_SSL
@@ -115,7 +117,8 @@ public:
         bool ssl_enabled,
         uint32_t connection_id_,
         RSA & public_key_,
-        RSA & private_key_);
+        RSA & private_key_,
+        bool require_secure_transport_);
 
 private:
     void authPluginSSL() override;

--- a/src/Server/MySQLHandlerFactory.cpp
+++ b/src/Server/MySQLHandlerFactory.cpp
@@ -21,9 +21,10 @@ namespace ErrorCodes
     extern const int OPENSSL_ERROR;
 }
 
-MySQLHandlerFactory::MySQLHandlerFactory(IServer & server_)
+MySQLHandlerFactory::MySQLHandlerFactory(IServer & server_, bool require_secure_transport_)
     : server(server_)
     , log(&Poco::Logger::get("MySQLHandlerFactory"))
+    , require_secure_transport(require_secure_transport_)
 {
 #if USE_SSL
     try
@@ -130,7 +131,7 @@ Poco::Net::TCPServerConnection * MySQLHandlerFactory::createConnection(const Poc
     uint32_t connection_id = last_connection_id++;
     LOG_TRACE(log, "MySQL connection. Id: {}. Address: {}", connection_id, socket.peerAddress().toString());
 #if USE_SSL
-    return new MySQLHandlerSSL(server, tcp_server, socket, ssl_enabled, connection_id, *public_key, *private_key);
+    return new MySQLHandlerSSL(server, tcp_server, socket, ssl_enabled, connection_id, *public_key, *private_key, require_secure_transport);
 #else
     return new MySQLHandler(server, tcp_server, socket, ssl_enabled, connection_id);
 #endif

--- a/src/Server/MySQLHandlerFactory.h
+++ b/src/Server/MySQLHandlerFactory.h
@@ -20,6 +20,7 @@ class MySQLHandlerFactory : public TCPServerConnectionFactory
 private:
     IServer & server;
     Poco::Logger * log;
+    bool require_secure_transport;
 
 #if USE_SSL
     struct RSADeleter
@@ -38,7 +39,7 @@ private:
 
     std::atomic<unsigned> last_connection_id = 0;
 public:
-    explicit MySQLHandlerFactory(IServer & server_);
+    explicit MySQLHandlerFactory(IServer & server_, bool require_secure_transport_);
 
     void readRSAKeys();
 

--- a/tests/integration/test_mysql_protocol/configs/mysql_secure.xml
+++ b/tests/integration/test_mysql_protocol/configs/mysql_secure.xml
@@ -1,0 +1,4 @@
+<clickhouse>
+    <mysql_port>9001</mysql_port>
+    <mysql_port_require_secure_transport>true</mysql_port_require_secure_transport>
+</clickhouse>

--- a/tests/integration/test_mysql_protocol/test_secure.py
+++ b/tests/integration/test_mysql_protocol/test_secure.py
@@ -1,0 +1,62 @@
+import pymysql
+import pytest
+from helpers.cluster import ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__)
+node = cluster.add_instance(
+    "node",
+    main_configs=[
+        "configs/ssl_conf.xml",
+        "configs/mysql_secure.xml",
+        "configs/dhparam.pem",
+        "configs/server.crt",
+        "configs/server.key",
+    ],
+    user_configs=["configs/users.xml"],
+    env_variables={"UBSAN_OPTIONS": "print_stacktrace=1"},
+)
+
+server_port = 9001
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    cluster.start()
+    try:
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def test_secure(started_cluster):
+    connection = pymysql.connect(
+        user="default",
+        password="123",
+        database="default",
+        host=started_cluster.get_instance_ip("node"),
+        port=server_port,
+        ssl_disabled=False,
+        ssl_verify_identity=True,
+    )
+    try:
+        cur = connection.cursor()
+        cur.execute("SELECT 1")
+        assert cur.fetchone() == (1,)
+    finally:
+        connection.close()
+
+
+def test_cannot_connect_insecure(started_cluster):
+    with pytest.raises(pymysql.err.OperationalError) as e:
+        pymysql.connect(
+            user="default",
+            password="abacab",
+            database="default",
+            host=started_cluster.get_instance_ip("node"),
+            port=server_port,
+            ssl_disabled=True,
+        )
+    assert e.value.args == (
+        3159,
+        "Connections using insecure transport are prohibited.",
+    )


### PR DESCRIPTION
We only want TLS connections to our CH, including the MySQL interface.  Copies the MySQL setting `require_secure_transport` including the same error code and similar error message.  See https://dev.mysql.com/doc/mysql-security-excerpt/8.0/en/using-encrypted-connections.html#mandatory-encrypted-connections

### Changelog category (leave one):

- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Add server setting `mysql_port_require_secure_transport` to enforce TLS on the MySQL port.

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)
