### PR TITLE
Read `wait_on_pool_size_limit` for S3 disk from config

### DIFF
--- a/src/Disks/ObjectStorages/S3/diskSettings.cpp
+++ b/src/Disks/ObjectStorages/S3/diskSettings.cpp
@@ -66,7 +66,7 @@ std::unique_ptr<S3::Client> getClient(
     client_configuration.http_keep_alive_timeout_ms
         = config.getUInt(config_prefix + ".http_keep_alive_timeout_ms", DEFAULT_HTTP_KEEP_ALIVE_TIMEOUT * 1000);
     client_configuration.http_connection_pool_size = config.getUInt(config_prefix + ".http_connection_pool_size", 1000);
-    client_configuration.wait_on_pool_size_limit = false;
+    client_configuration.wait_on_pool_size_limit = config.getBool(config_prefix + ".wait_on_pool_size_limit", false);
 
     /*
      * Override proxy configuration for backwards compatibility with old configuration format.


### PR DESCRIPTION
Read `wait_on_pool_size_limit` for S3 disk from config. This allows controlling of `SingleEndpointHTTPSessionPool` behaviour ( see `PoolBase::BehaviourOnLimit`). The default behaviour remains the same.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
