### PR TITLE
Fix caching objects in pygithub, and changelogs

### DIFF
--- a/tests/ci/github_helper.py
+++ b/tests/ci/github_helper.py
@@ -127,7 +127,7 @@ class GitHub(github.Github):
             label="release",
         )
 
-    def sleep_on_rate_limit(self):
+    def sleep_on_rate_limit(self) -> None:
         for limit, data in self.get_rate_limit().raw_data.items():
             if data["remaining"] == 0:
                 sleep_time = data["reset"] - int(datetime.now().timestamp()) + 1
@@ -199,13 +199,13 @@ class GitHub(github.Github):
         # We don't want the cache_updated being always old,
         # for example in cases when the user is not updated for ages
         cache_updated = max(
-            datetime.fromtimestamp(cache_file.stat().st_mtime), cached_obj.updated_at
+            cache_file.stat().st_mtime, cached_obj.updated_at.timestamp()
         )
         if obj_updated_at is None:
             # When we don't know about the object is updated or not,
             # we update it once per hour
             obj_updated_at = datetime.now() - timedelta(hours=1)
-        if obj_updated_at <= cache_updated:
+        if obj_updated_at.timestamp() <= cache_updated:
             return True, cached_obj
         return False, cached_obj
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixing issues like this https://github.com/ClickHouse/ClickHouse/actions/runs/6561500747/job/17821324272#step:6:3716