### PR TITLE
fix node setting in the test

### DIFF
--- a/tests/integration/test_checking_s3_blobs_paranoid/configs/s3_retries.xml
+++ b/tests/integration/test_checking_s3_blobs_paranoid/configs/s3_retries.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<clickhouse>
+    <profiles>
+        <default>
+            <s3_retry_attempts>5</s3_retry_attempts>
+        </default>
+    </profiles>
+</clickhouse>

--- a/tests/integration/test_checking_s3_blobs_paranoid/configs/setting.xml
+++ b/tests/integration/test_checking_s3_blobs_paranoid/configs/setting.xml
@@ -5,10 +5,8 @@
         <default>
             <s3_check_objects_after_upload>1</s3_check_objects_after_upload>
             <enable_s3_requests_logging>1</enable_s3_requests_logging>
-            <s3_retry_attempts>5</s3_retry_attempts>
         </default>
     </profiles>
-
     <users>
         <default>
             <password></password>

--- a/tests/integration/test_checking_s3_blobs_paranoid/test.py
+++ b/tests/integration/test_checking_s3_blobs_paranoid/test.py
@@ -19,6 +19,7 @@ def cluster():
             ],
             user_configs=[
                 "configs/setting.xml",
+                "configs/s3_retries.xml",
             ],
             with_minio=True,
         )


### PR DESCRIPTION
Fix test_checking_s3_blobs_paranoid/test.py::test_query_is_canceled_with_inf_retries

rewriting the setting in the next file works unstable.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
