### PR TITLE
Allow querying inside a dropped database in clickhouse-local

### DIFF
--- a/src/Client/LocalConnection.cpp
+++ b/src/Client/LocalConnection.cpp
@@ -95,12 +95,18 @@ void LocalConnection::sendQuery(
     else
         query_context = session.makeQueryContext();
     query_context->setCurrentQueryId(query_id);
+
     if (send_progress)
     {
         query_context->setProgressCallback([this] (const Progress & value) { this->updateProgress(value); });
         query_context->setFileProgressCallback([this](const FileProgress & value) { this->updateProgress(Progress(value)); });
     }
-    if (!current_database.empty())
+
+    /// Switch the database to the desired one (set by the USE query)
+    /// but don't attempt to do it if we are already in that database.
+    /// (there is a rare case when it matters - if we deleted the current database,
+    // we can still do some queries, but we cannot switch to the same database)
+    if (!current_database.empty() && current_database != query_context->getCurrentDatabase())
         query_context->setCurrentDatabase(current_database);
 
     query_context->addQueryParameters(query_parameters);

--- a/tests/queries/0_stateless/02900_clickhouse_local_drop_current_database.reference
+++ b/tests/queries/0_stateless/02900_clickhouse_local_drop_current_database.reference
@@ -1,0 +1,10 @@
+CREATE DATABASE foo;
+USE foo;
+SELECT 1;
+1
+DROP DATABASE foo;
+SELECT 2;
+2
+USE _local;
+SELECT 3;
+3

--- a/tests/queries/0_stateless/02900_clickhouse_local_drop_current_database.sh
+++ b/tests/queries/0_stateless/02900_clickhouse_local_drop_current_database.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+${CLICKHOUSE_LOCAL} --echo --multiquery "
+    CREATE DATABASE foo;
+    USE foo;
+    SELECT 1;
+    DROP DATABASE foo;
+    SELECT 2;
+    USE _local;
+    SELECT 3;
+"


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
If you dropped the current database, you will still be able to run some queries in `clickhouse-local` and switch to another database. This makes the behavior consistent with `clickhouse-client`. This closes #55834.