### PR TITLE
Add load_metadata_threads to describe filesystem cache

### DIFF
--- a/src/Interpreters/InterpreterDescribeCacheQuery.cpp
+++ b/src/Interpreters/InterpreterDescribeCacheQuery.cpp
@@ -27,6 +27,7 @@ static Block getSampleBlock()
         ColumnWithTypeAndName{std::make_shared<DataTypeString>(), "path"},
         ColumnWithTypeAndName{std::make_shared<DataTypeNumber<UInt64>>(), "background_download_threads"},
         ColumnWithTypeAndName{std::make_shared<DataTypeNumber<UInt64>>(), "enable_bypass_cache_with_threshold"},
+        ColumnWithTypeAndName{std::make_shared<DataTypeNumber<UInt64>>(), "load_metadata_threads"},
     };
     return Block(columns);
 }
@@ -55,6 +56,7 @@ BlockIO InterpreterDescribeCacheQuery::execute()
     res_columns[i++]->insert(cache->getBasePath());
     res_columns[i++]->insert(settings.background_download_threads);
     res_columns[i++]->insert(settings.enable_bypass_cache_with_threshold);
+    res_columns[i++]->insert(settings.load_metadata_threads);
 
     BlockIO res;
     size_t num_rows = res_columns[0]->size();

--- a/tests/queries/0_stateless/02344_describe_cache.reference
+++ b/tests/queries/0_stateless/02344_describe_cache.reference
@@ -1,2 +1,2 @@
 1
-102400	10000000	33554432	4194304	0	0	0	0	/var/lib/clickhouse/filesystem_caches/02344_describe_cache_test	2	0
+102400	10000000	33554432	4194304	0	0	0	0	/var/lib/clickhouse/filesystem_caches/02344_describe_cache_test	2	0	1


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Add `load_metadata_threads` setting to `DESCRIBE FILESYSTEM CACHE` statement