### PR TITLE
Fix digest check in replicated ddl worker

### DIFF
--- a/src/Databases/DatabaseReplicatedWorker.cpp
+++ b/src/Databases/DatabaseReplicatedWorker.cpp
@@ -128,7 +128,7 @@ void DatabaseReplicatedDDLWorker::initializeReplication()
     }
 
     std::lock_guard lock{database->metadata_mutex};
-    if (!database->checkDigestValid(context))
+    if (!database->checkDigestValid(context, false))
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Inconsistent database metadata after reconnection to ZooKeeper");
 }
 


### PR DESCRIPTION
Look like this check is not really a debug check and should not be skipped.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
