### PR TITLE
Test parallel replicas with rollup

### DIFF
--- a/tests/queries/0_stateless/02901_parallel_replicas_rollup.reference
+++ b/tests/queries/0_stateless/02901_parallel_replicas_rollup.reference
@@ -1,0 +1,15 @@
+1
+02901_parallel_replicas_rollup-default	Used parallel replicas: true
+0	0	0	6
+2019	0	0	2
+2019	1	0	2
+2019	1	5	1
+2019	1	15	1
+2020	0	0	4
+2020	1	0	2
+2020	1	5	1
+2020	1	15	1
+2020	10	0	2
+2020	10	5	1
+2020	10	15	1
+02901_parallel_replicas_rollup2-default	Used parallel replicas: true

--- a/tests/queries/0_stateless/02901_parallel_replicas_rollup.sh
+++ b/tests/queries/0_stateless/02901_parallel_replicas_rollup.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+function were_parallel_replicas_used ()
+{
+    $CLICKHOUSE_CLIENT --query "SYSTEM FLUSH LOGS"
+
+    # Not using current_database = '$CLICKHOUSE_DATABASE' as nested parallel queries aren't run with it
+    $CLICKHOUSE_CLIENT --query "
+        SELECT
+            initial_query_id,
+            concat('Used parallel replicas: ', (countIf(initial_query_id != query_id) != 0)::bool::String) as used
+        FROM system.query_log
+    WHERE event_date >= yesterday()
+      AND initial_query_id = '$1'
+    GROUP BY initial_query_id
+    ORDER BY min(event_time_microseconds) ASC
+    FORMAT TSV"
+}
+
+$CLICKHOUSE_CLIENT --query "DROP TABLE IF EXISTS nested"
+$CLICKHOUSE_CLIENT --query "CREATE TABLE nested (x UInt8) ENGINE = MergeTree ORDER BY () AS Select 1";
+
+query_id="02901_parallel_replicas_rollup-$CLICKHOUSE_DATABASE"
+$CLICKHOUSE_CLIENT \
+  --query_id "${query_id}" \
+  --max_parallel_replicas 3 \
+  --prefer_localhost_replica 1 \
+  --use_hedged_requests 0 \
+  --cluster_for_parallel_replicas "parallel_replicas" \
+  --allow_experimental_parallel_reading_from_replicas 1 \
+  --parallel_replicas_for_non_replicated_merge_tree 1 \
+  --parallel_replicas_min_number_of_rows_per_replica 0 \
+  --query "
+  SELECT 1 FROM nested
+  GROUP BY 1 WITH ROLLUP
+  ORDER BY max((SELECT 1 WHERE 0));
+";
+were_parallel_replicas_used $query_id
+$CLICKHOUSE_CLIENT --query "DROP TABLE IF EXISTS nested"
+
+
+$CLICKHOUSE_CLIENT --query "DROP TABLE IF EXISTS days"
+$CLICKHOUSE_CLIENT --query "
+    CREATE TABLE days
+    (
+        year Int64,
+        month Int64,
+        day Int64
+    )
+    ENGINE = MergeTree()
+    ORDER BY year";
+$CLICKHOUSE_CLIENT --query "
+  INSERT INTO days VALUES (2019, 1, 5), (2019, 1, 15), (2020, 1, 5), (2020, 1, 15), (2020, 10, 5), (2020, 10, 15);
+";
+
+# Note that we enforce ordering of the final output because it's not guaranteed by GROUP BY ROLLUP, only the values of count() are
+query_id="02901_parallel_replicas_rollup2-$CLICKHOUSE_DATABASE"
+$CLICKHOUSE_CLIENT \
+  --query_id "${query_id}" \
+  --max_parallel_replicas 3 \
+  --prefer_localhost_replica 1 \
+  --use_hedged_requests 0 \
+  --cluster_for_parallel_replicas "parallel_replicas" \
+  --allow_experimental_parallel_reading_from_replicas 1 \
+  --parallel_replicas_for_non_replicated_merge_tree 1 \
+  --parallel_replicas_min_number_of_rows_per_replica 0 \
+  --query "SELECT * FROM (SELECT year, month, day, count(*) FROM days GROUP BY year, month, day WITH ROLLUP) ORDER BY 1, 2, 3";
+
+were_parallel_replicas_used $query_id
+$CLICKHOUSE_CLIENT --query "DROP TABLE IF EXISTS days"


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

Adds a test to confirm #51960 is fixed. Closes #51960

Note that a second test added shows that the output of the query might change with and without parallel replicas when using `ROLLUP` which is ok as long as the values of the rows don't.