### PR TITLE
Update stress.py

### DIFF
--- a/tests/ci/stress.py
+++ b/tests/ci/stress.py
@@ -133,7 +133,9 @@ def prepare_for_hung_check(drop_databases: bool) -> bool:
     logging.info("Will terminate gdb (if any)")
     call_with_retry("kill -TERM $(pidof gdb)")
     # Sometimes there is a message `Child process was stopped by signal 19` in logs after stopping gdb
-    call_with_retry("kill -CONT $(cat /var/run/clickhouse-server/clickhouse-server.pid)")
+    call_with_retry(
+        "kill -CONT $(cat /var/run/clickhouse-server/clickhouse-server.pid)"
+    )
 
     # ThreadFuzzer significantly slows down server and causes false-positive hung check failures
     call_with_retry("clickhouse client -q 'SYSTEM STOP THREAD FUZZER'")

--- a/tests/ci/stress.py
+++ b/tests/ci/stress.py
@@ -133,7 +133,7 @@ def prepare_for_hung_check(drop_databases: bool) -> bool:
     logging.info("Will terminate gdb (if any)")
     call_with_retry("kill -TERM $(pidof gdb)")
     # Sometimes there is a message `Child process was stopped by signal 19` in logs after stopping gdb
-    call_with_retry("kill -CONT $(lsof -ti:9000)")
+    call_with_retry("kill -CONT $(cat /var/run/clickhouse-server/clickhouse-server.pid)")
 
     # ThreadFuzzer significantly slows down server and causes false-positive hung check failures
     call_with_retry("clickhouse client -q 'SYSTEM STOP THREAD FUZZER'")


### PR DESCRIPTION

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Because lsof may find a clickhouse-client.

https://s3.amazonaws.com/clickhouse-test-reports/55430/0baee0c612a5c0d692240be377b64bd3d29287fc/stress_test__tsan_.html

```
2023-10-11 20:25:21,674 All processes finished
2023-10-11 20:25:21,674 Compressing stress logs
2023-10-11 20:25:21,691 Logs compressed
2023-10-11 20:25:21,691 Will terminate gdb (if any)
Quit
2023-10-11 20:25:52,010 Failed to prepare for hung check: Command 'clickhouse client -q 'SYSTEM STOP THREAD FUZZER'' timed out after 30 seconds
2023-10-11 20:25:52,010 Checking if some queries hung
Using queries from '/usr/share/clickhouse-test/queries' directory
Connecting to ClickHouse server...
Connection timeout, will not retry

All connection tries failed
Server is not responding. Cannot execute 'SELECT 1' query.
Got server pid 1992
```

```
1954441:2023.10.11 20:25:22.029525 [ 1990 ] {} <Warning> Application: Child process was stopped by signal 19.
```