### PR TITLE
Fix window functions in case of sparse columns.

### DIFF
--- a/src/Processors/Transforms/WindowTransform.cpp
+++ b/src/Processors/Transforms/WindowTransform.cpp
@@ -1066,7 +1066,7 @@ void WindowTransform::appendChunk(Chunk & chunk)
         auto columns = chunk.detachColumns();
         block.original_input_columns = columns;
         for (auto & column : columns)
-            column = recursiveRemoveLowCardinality(std::move(column)->convertToFullColumnIfConst());
+            column = recursiveRemoveLowCardinality(std::move(column)->convertToFullColumnIfConst()->convertToFullColumnIfSparse());
         block.input_columns = std::move(columns);
 
         // Initialize output columns.

--- a/tests/queries/0_stateless/02900_window_function_with_sparse_column.reference
+++ b/tests/queries/0_stateless/02900_window_function_with_sparse_column.reference
@@ -1,0 +1,5 @@
+false
+false
+false
+
+

--- a/tests/queries/0_stateless/02900_window_function_with_sparse_column.sql
+++ b/tests/queries/0_stateless/02900_window_function_with_sparse_column.sql
@@ -1,0 +1,45 @@
+-- https://github.com/ClickHouse/ClickHouse/issues/55843
+-- These tests pass without the fix when either of
+--   - optimize_read_in_window_order = 0 and optimize_read_in_order = 0
+--   - ratio_of_defaults_for_sparse_serialization = 1
+-- However it is better to leave the settings as randomized because we run
+-- stateless tests quite a few times during a PR, so if a bug is introduced
+-- then there is a big chance of catching it. Furthermore, randomized settings
+-- might identify new bugs.
+
+CREATE TABLE test1
+(
+    id String,
+    time DateTime64(9),
+    key Int64,
+    value Bool,
+)
+ENGINE = MergeTree
+PARTITION BY toYYYYMM(time)
+ORDER BY (key, id, time);
+
+INSERT INTO test1 VALUES ('id0', now(), 3, false)
+
+SELECT last_value(value) OVER (PARTITION BY id ORDER BY time ASC) as last_value
+FROM test1
+WHERE (key = 3);
+
+SELECT last_value(value) OVER (ORDER BY time ASC) as last_value
+FROM test1
+WHERE (key = 3);
+
+SELECT last_value(value) OVER (PARTITION BY id ORDER BY time ASC) as last_value
+FROM test1;
+
+
+
+CREATE TABLE test2
+(
+    time DateTime,
+    value String
+)
+ENGINE = MergeTree
+ORDER BY (time) AS SELECT 0, '';
+
+SELECT any(value) OVER (ORDER BY time ASC) FROM test2;
+SELECT last_value(value) OVER (ORDER BY time ASC) FROM test2;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix window functions in case of sparse columns. Previously some queries with window functions returned invalid results or made ClickHouse crash when the columns were sparse.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

Fixes #55843.