### PR TITLE
Add get_direct_children_number command to keeper-client

### DIFF
--- a/docs/en/operations/utilities/clickhouse-keeper-client.md
+++ b/docs/en/operations/utilities/clickhouse-keeper-client.md
@@ -55,6 +55,7 @@ keeper foo bar
 -   `rmr <path>` -- Recursively deletes path. Confirmation required
 -   `flwc <command>` -- Executes four-letter-word command
 -   `help` -- Prints this message
+-   `get_direct_children_number [path]` -- Get numbers of direct children nodes under a specific path
 -   `get_all_children_number [path]` -- Get all numbers of children nodes under a specific path
 -   `get_stat [path]` -- Returns the node's stat (default `.`)
 -   `find_super_nodes <threshold> [path]` -- Finds nodes with number of children larger than some threshold for the given path (default `.`)

--- a/programs/keeper-client/Commands.cpp
+++ b/programs/keeper-client/Commands.cpp
@@ -475,6 +475,29 @@ void FourLetterWordCommand::execute(const ASTKeeperQuery * query, KeeperClient *
     std::cout << client->executeFourLetterCommand(query->args[0].safeGet<String>()) << "\n";
 }
 
+bool GetDirectChildrenNumberCommand::parse(IParser::Pos & pos, std::shared_ptr<ASTKeeperQuery> & node, Expected & expected) const
+{
+    String path;
+    if (!parseKeeperPath(pos, expected, path))
+        path = ".";
+
+    node->args.push_back(std::move(path));
+
+    return true;
+}
+
+void GetDirectChildrenNumberCommand::execute(const ASTKeeperQuery * query, KeeperClient * client) const
+{
+    auto path = client->getAbsolutePath(query->args[0].safeGet<String>());
+
+    std::queue<fs::path> queue;
+    queue.push(path);
+    Coordination::Stat stat;
+    client->zookeeper->get(path, &stat);
+
+    std::cout << stat.numChildren << "\n";
+}
+
 bool GetAllChildrenNumberCommand::parse(IParser::Pos & pos, std::shared_ptr<ASTKeeperQuery> & node, Expected & expected) const
 {
     String path;

--- a/programs/keeper-client/Commands.cpp
+++ b/programs/keeper-client/Commands.cpp
@@ -512,9 +512,6 @@ bool GetAllChildrenNumberCommand::parse(IParser::Pos & pos, std::shared_ptr<ASTK
 void GetAllChildrenNumberCommand::execute(const ASTKeeperQuery * query, KeeperClient * client) const
 {
     auto path = client->getAbsolutePath(query->args[0].safeGet<String>());
-
-    std::queue<fs::path> queue;
-    queue.push(path);
     Coordination::Stat stat;
     client->zookeeper->get(path, &stat);
 

--- a/programs/keeper-client/Commands.cpp
+++ b/programs/keeper-client/Commands.cpp
@@ -490,8 +490,6 @@ void GetDirectChildrenNumberCommand::execute(const ASTKeeperQuery * query, Keepe
 {
     auto path = client->getAbsolutePath(query->args[0].safeGet<String>());
 
-    std::queue<fs::path> queue;
-    queue.push(path);
     Coordination::Stat stat;
     client->zookeeper->get(path, &stat);
 
@@ -512,6 +510,9 @@ bool GetAllChildrenNumberCommand::parse(IParser::Pos & pos, std::shared_ptr<ASTK
 void GetAllChildrenNumberCommand::execute(const ASTKeeperQuery * query, KeeperClient * client) const
 {
     auto path = client->getAbsolutePath(query->args[0].safeGet<String>());
+
+    std::queue<fs::path> queue;
+    queue.push(path);
     Coordination::Stat stat;
     client->zookeeper->get(path, &stat);
 

--- a/programs/keeper-client/Commands.h
+++ b/programs/keeper-client/Commands.h
@@ -238,6 +238,20 @@ class FourLetterWordCommand : public IKeeperClientCommand
     String getHelpMessage() const override { return "{} <command> -- Executes four-letter-word command"; }
 };
 
+class GetDirectChildrenNumberCommand : public IKeeperClientCommand
+{
+    String getName() const override { return "get_direct_children_number"; }
+
+    bool parse(IParser::Pos & pos, std::shared_ptr<ASTKeeperQuery> & node, Expected & expected) const override;
+
+    void execute(const ASTKeeperQuery * query, KeeperClient * client) const override;
+
+    String getHelpMessage() const override
+    {
+        return "{} [path] -- Get numbers of direct children nodes under a specific path";
+    }
+};
+
 class GetAllChildrenNumberCommand : public IKeeperClientCommand
 {
     String getName() const override { return "get_all_children_number"; }

--- a/programs/keeper-client/KeeperClient.cpp
+++ b/programs/keeper-client/KeeperClient.cpp
@@ -207,6 +207,7 @@ void KeeperClient::initialize(Poco::Util::Application & /* self */)
         std::make_shared<SyncCommand>(),
         std::make_shared<HelpCommand>(),
         std::make_shared<FourLetterWordCommand>(),
+        std::make_shared<GetDirectChildrenNumberCommand>(),
         std::make_shared<GetAllChildrenNumberCommand>(),
     });
 

--- a/tests/integration/helpers/keeper_utils.py
+++ b/tests/integration/helpers/keeper_utils.py
@@ -143,6 +143,9 @@ class KeeperClient(object):
     def find_super_nodes(self, threshold: int, timeout: float = 60.0) -> str:
         return self.execute_query(f"find_super_nodes {threshold}", timeout)
 
+    def get_direct_children_number(self, path: str, timeout: float = 60.0) -> str:
+        return self.execute_query(f"get_direct_children_number {path}", timeout)
+
     def get_all_children_number(self, path: str, timeout: float = 60.0) -> str:
         return self.execute_query(f"get_all_children_number {path}", timeout)
 

--- a/tests/integration/test_keeper_client/test.py
+++ b/tests/integration/test_keeper_client/test.py
@@ -217,6 +217,7 @@ def test_quoted_argument_parsing(client: KeeperClient):
     client.execute_query(f"set '{node_path}' \"value4 with some whitespace\" 3")
     assert client.get(node_path) == "value4 with some whitespace"
 
+
 def get_direct_children_number(client: KeeperClient):
     client.touch("/get_direct_children_number")
     client.touch("/get_direct_children_number/1")
@@ -227,6 +228,7 @@ def get_direct_children_number(client: KeeperClient):
     client.touch("/get_direct_children_number/2/2")
 
     assert client.get_direct_children_number("/get_direct_children_number") == "2"
+
 
 def test_get_all_children_number(client: KeeperClient):
     client.touch("/test_get_all_children_number")

--- a/tests/integration/test_keeper_client/test.py
+++ b/tests/integration/test_keeper_client/test.py
@@ -217,6 +217,21 @@ def test_quoted_argument_parsing(client: KeeperClient):
     client.execute_query(f"set '{node_path}' \"value4 with some whitespace\" 3")
     assert client.get(node_path) == "value4 with some whitespace"
 
+def get_direct_children_number(client: KeeperClient):
+    client.touch("/get_direct_children_number")
+    client.touch("/get_direct_children_number/a")
+    client.touch("/get_direct_children_number/a/1")
+    client.touch("/get_direct_children_number/a/2")
+    client.touch("/get_direct_children_number/a/3")
+    client.touch("/get_direct_children_number/a/4")
+    client.touch("/get_direct_children_number/a/5")
+    client.touch("/get_direct_children_number/b")
+    client.touch("/get_direct_children_number/b/1")
+    client.touch("/get_direct_children_number/b/2")
+    client.touch("/get_direct_children_number/b/3")
+    client.touch("/get_direct_children_number/b/4")
+
+    assert client.get_direct_children_number("/get_direct_children_number") == "2"
 
 def test_get_all_children_number(client: KeeperClient):
     client.touch("/test_get_all_children_number")

--- a/tests/integration/test_keeper_client/test.py
+++ b/tests/integration/test_keeper_client/test.py
@@ -219,17 +219,12 @@ def test_quoted_argument_parsing(client: KeeperClient):
 
 def get_direct_children_number(client: KeeperClient):
     client.touch("/get_direct_children_number")
-    client.touch("/get_direct_children_number/a")
-    client.touch("/get_direct_children_number/a/1")
-    client.touch("/get_direct_children_number/a/2")
-    client.touch("/get_direct_children_number/a/3")
-    client.touch("/get_direct_children_number/a/4")
-    client.touch("/get_direct_children_number/a/5")
-    client.touch("/get_direct_children_number/b")
-    client.touch("/get_direct_children_number/b/1")
-    client.touch("/get_direct_children_number/b/2")
-    client.touch("/get_direct_children_number/b/3")
-    client.touch("/get_direct_children_number/b/4")
+    client.touch("/get_direct_children_number/1")
+    client.touch("/get_direct_children_number/1/1")
+    client.touch("/get_direct_children_number/1/2")
+    client.touch("/get_direct_children_number/2")
+    client.touch("/get_direct_children_number/2/1")
+    client.touch("/get_direct_children_number/2/2")
 
     assert client.get_direct_children_number("/get_direct_children_number") == "2"
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- New Feature

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Keeper client improvement: add get_direct_children_number command that returns number of direct children nodes under a 
 path

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
