### PR TITLE
A test `01019_alter_materialized_view_consistent` is unstable with Analyzer

### DIFF
--- a/tests/analyzer_tech_debt.txt
+++ b/tests/analyzer_tech_debt.txt
@@ -85,3 +85,4 @@
 01940_custom_tld_sharding_key
 02815_range_dict_no_direct_join
 02861_join_on_nullsafe_compare
+01019_alter_materialized_view_consistent


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
