### PR TITLE
fix: StorageNull supports subcolumns

### DIFF
--- a/src/Storages/StorageNull.h
+++ b/src/Storages/StorageNull.h
@@ -46,6 +46,8 @@ public:
 
     bool supportsParallelInsert() const override { return true; }
 
+    bool supportsSubcolumns() const override { return true; }
+
     SinkToStoragePtr write(const ASTPtr &, const StorageMetadataPtr & metadata_snapshot, ContextPtr, bool) override
     {
         return std::make_shared<NullSinkToStorage>(metadata_snapshot->getSampleBlock());

--- a/tests/queries/0_stateless/02902_select_subcolumns_from_engine_null.sql
+++ b/tests/queries/0_stateless/02902_select_subcolumns_from_engine_null.sql
@@ -1,0 +1,6 @@
+CREATE TABLE null_02902 (t Tuple(num Int64, str String)) ENGINE = Null;
+SELECT t FROM null_02902;
+SELECT tupleElement(t, 'num') FROM null_02902;
+SELECT t.num, t.str FROM null_02902;
+
+DROP TABLE null_02902;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix reading subcolumns from StorageNull. Previously it was possible to create a table with engine Null with subcolumns, but it was not possible to select these columns.
Closes #55785 