### PR TITLE
docs: state limitations of `USING` clause.

### DIFF
--- a/docs/en/sql-reference/statements/select/join.md
+++ b/docs/en/sql-reference/statements/select/join.md
@@ -334,6 +334,7 @@ For multiple `JOIN` clauses in a single `SELECT` query:
 
 - Taking all the columns via `*` is available only if tables are joined, not subqueries.
 - The `PREWHERE` clause is not available.
+- The `USING` clause is not available.
 
 For `ON`, `WHERE`, and `GROUP BY` clauses:
 


### PR DESCRIPTION
State that it is (currently) not possible to use `USING` with multiple joins. The exception thrown is `Multiple USING statements are not supported`. The relevant code section is https://github.com/ClickHouse/ClickHouse/blob/d08ce131074209fbeb6e3590ae7f2d5baae7fc6a/src/Interpreters/CrossToInnerJoinVisitor.cpp#L191-L192.

### Changelog category (leave one):
- Documentation (changelog entry is not required)