### PR TITLE
Optimization for getting value from  map, `arrayElement`(1/2)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,7 +146,7 @@ if (COMPILER_CLANG)
 
     no_warning(enum-constexpr-conversion) # breaks Protobuf in clang-16
 endif ()
-
+set(COMPILER_FLAGS "${COMPILER_FLAGS} -fvisibility=hidden -fvisibility-inlines-hidden -fno-omit-frame-pointer")
 option(ENABLE_TESTS "Provide unit_test_dbms target with Google.Test unit tests" ON)
 option(ENABLE_EXAMPLES "Build all example programs in 'examples' subdirectories" OFF)
 option(ENABLE_BENCHMARKS "Build all benchmark programs in 'benchmarks' subdirectories" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,7 +146,7 @@ if (COMPILER_CLANG)
 
     no_warning(enum-constexpr-conversion) # breaks Protobuf in clang-16
 endif ()
-set(COMPILER_FLAGS "${COMPILER_FLAGS} -fvisibility=hidden -fvisibility-inlines-hidden -fno-omit-frame-pointer")
+
 option(ENABLE_TESTS "Provide unit_test_dbms target with Google.Test unit tests" ON)
 option(ENABLE_EXAMPLES "Build all example programs in 'examples' subdirectories" OFF)
 option(ENABLE_BENCHMARKS "Build all benchmark programs in 'benchmarks' subdirectories" OFF)

--- a/src/Functions/array/arrayElement.cpp
+++ b/src/Functions/array/arrayElement.cpp
@@ -833,7 +833,10 @@ void FunctionArrayElement::executeMatchKeyToIndex(
             }
         }
         if (!matched)
+        {
+            expected_match_pos = offsets[0];
             matched_idxs.push_back(0);
+        }
     }
 
     /// In practice, map keys are usually in the same order, it is worth a try to

--- a/src/Functions/array/arrayElement.cpp
+++ b/src/Functions/array/arrayElement.cpp
@@ -18,8 +18,6 @@
 #include <Columns/ColumnMap.h>
 #include <Common/typeid_cast.h>
 #include <Common/assert_cast.h>
-#include <Poco/Logger.h>
-#include <Common/logger_useful.h>
 
 
 namespace DB

--- a/src/Functions/array/arrayElement.cpp
+++ b/src/Functions/array/arrayElement.cpp
@@ -837,7 +837,7 @@ void FunctionArrayElement::executeMatchKeyToIndex(
     }
 
     /// In practice, map keys are usually in the same order, it is worth a try to
-    /// predicate the next key position as previous. So it can save a lot of comparisons.
+    /// predicate the next key position. So it can save a lot of comparisons.
     size_t i = 1;
     for (; i < rows; ++i)
     {

--- a/src/Functions/array/arrayElement.cpp
+++ b/src/Functions/array/arrayElement.cpp
@@ -18,6 +18,8 @@
 #include <Columns/ColumnMap.h>
 #include <Common/typeid_cast.h>
 #include <Common/assert_cast.h>
+#include <Poco/Logger.h>
+#include <Common/logger_useful.h>
 
 
 namespace DB
@@ -829,6 +831,7 @@ void FunctionArrayElement::executeMatchKeyToIndex(
                 matched_idxs.push_back(j -  offsets[-1] + 1);
                 matched = true;
                 expected_match_pos = end + j - offsets[-1];
+                // expected_match_pos = j - offsets[-1];
                 break;
             }
         }
@@ -848,8 +851,9 @@ void FunctionArrayElement::executeMatchKeyToIndex(
         const auto & end = offsets[i];
         if (expected_match_pos < end && matcher.match(expected_match_pos, i))
         {
-            matched_idxs.push_back(expected_match_pos - begin + 1);
-            expected_match_pos = end + expected_match_pos - begin;
+            auto map_key_index = expected_match_pos - begin;
+            matched_idxs.push_back(map_key_index + 1);
+            expected_match_pos = end + map_key_index;
         }
         else
             break;

--- a/src/Functions/array/arrayElement.cpp
+++ b/src/Functions/array/arrayElement.cpp
@@ -822,28 +822,26 @@ void FunctionArrayElement::executeMatchKeyToIndex(
     size_t rows = offsets.size();
     size_t expected_match_pos = 0;
     bool matched = false;
-    if (rows)
-    {
-        for (size_t j = offsets[-1], end = offsets[0]; j < end; ++j)
-        {
-            if (matcher.match(j, 0))
-            {
-                matched_idxs.push_back(j -  offsets[-1] + 1);
-                matched = true;
-                expected_match_pos = end + j - offsets[-1];
-                // expected_match_pos = j - offsets[-1];
-                break;
-            }
-        }
-        if (!matched)
-        {
-            expected_match_pos = offsets[0];
-            matched_idxs.push_back(0);
-        }
-    }
+    if (!rows)
+        return;
 
     /// In practice, map keys are usually in the same order, it is worth a try to
-    /// predicate the next key position. So it can save a lot of comparisons.
+    /// predict the next key position. So it can avoid a lot of unnecessary comparisons.
+    for (size_t j = offsets[-1], end = offsets[0]; j < end; ++j)
+    {
+        if (matcher.match(j, 0))
+        {
+            matched_idxs.push_back(j - offsets[-1] + 1);
+            matched = true;
+            expected_match_pos = end + j - offsets[-1];
+            break;
+        }
+    }
+    if (!matched)
+    {
+        expected_match_pos = offsets[0];
+        matched_idxs.push_back(0);
+    }
     size_t i = 1;
     for (; i < rows; ++i)
     {
@@ -858,6 +856,8 @@ void FunctionArrayElement::executeMatchKeyToIndex(
         else
             break;
     }
+
+    // fallback to linear search
     for (; i < rows; ++i)
     {
         matched = false;

--- a/tests/performance/get_map_value.xml
+++ b/tests/performance/get_map_value.xml
@@ -1,0 +1,22 @@
+<test>
+    <create_query>
+        CREATE TABLE test_table_map (a Map(String, String)) ENGINE=Memory
+    </create_query>
+
+    <fill_query>insert into test_table_map select CAST((['xyz', 'abc', '123'], [cast(number % 10 as String), 'dsdfsd', '123']), 'Map(String, String)') from numbers(10000000)</fill_query>
+    
+    <query>select a['xyz'] from test_table_map Format Null settings max_threads=1</query>
+    <query>select a['123'] from test_table_map Format Null settings max_threads=1</query>
+
+    <drop_query>drop table test_table_map</drop_query>
+    
+    <create_query>
+        CREATE TABLE test_table_map (a Map(String, String)) ENGINE=Memory
+    </create_query>
+
+    <fill_query>insert into test_table_map select if (number % 2 = 0, CAST((['xyz', 'abc', '123'], [cast(number % 10 as String), 'dsdfsd', '123']), 'Map(String, String)'), CAST((['123', 'abc', 'xyz'], ['123', 'dsdfsd', cast(number % 10 as String)]), 'Map(String, String)')) from numbers(10000000)</fill_query>
+    
+    <query>select a['xyz'] from test_table_map Format Null settings max_threads=1</query>
+
+    <drop_query>drop table test_table_map</drop_query>
+</test>

--- a/tests/performance/get_map_value.xml
+++ b/tests/performance/get_map_value.xml
@@ -1,22 +1,22 @@
 <test>
     <create_query>
-        CREATE TABLE test_table_map (a Map(String, String)) ENGINE=Memory
+        CREATE TABLE test_table_map_1 (a Map(String, String)) ENGINE=Memory
     </create_query>
 
-    <fill_query>insert into test_table_map select CAST((['xyz', 'abc', '123'], [cast(number % 10 as String), 'dsdfsd', '123']), 'Map(String, String)') from numbers(10000000)</fill_query>
+    <fill_query>insert into test_table_map_1 select CAST((['xyz', 'abc', '123'], [cast(number % 10 as String), 'dsdfsd', '123']), 'Map(String, String)') from numbers(10000000)</fill_query>
     
-    <query>select a['xyz'] from test_table_map Format Null settings max_threads=1</query>
-    <query>select a['123'] from test_table_map Format Null settings max_threads=1</query>
+    <query>select a['xyz'] from test_table_map_1 Format Null settings max_threads=1</query>
+    <query>select a['123'] from test_table_map_1 Format Null settings max_threads=1</query>
 
-    <drop_query>drop table test_table_map</drop_query>
+    <drop_query>drop table test_table_map_1</drop_query>
     
     <create_query>
-        CREATE TABLE test_table_map (a Map(String, String)) ENGINE=Memory
+        CREATE TABLE test_table_map_2 (a Map(String, String)) ENGINE=Memory
     </create_query>
 
-    <fill_query>insert into test_table_map select if (number % 2 = 0, CAST((['xyz', 'abc', '123'], [cast(number % 10 as String), 'dsdfsd', '123']), 'Map(String, String)'), CAST((['123', 'abc', 'xyz'], ['123', 'dsdfsd', cast(number % 10 as String)]), 'Map(String, String)')) from numbers(10000000)</fill_query>
+    <fill_query>insert into test_table_map_2 select if (number % 2 = 0, CAST((['xyz', 'abc', '123'], [cast(number % 10 as String), 'dsdfsd', '123']), 'Map(String, String)'), CAST((['123', 'abc', 'xyz'], ['123', 'dsdfsd', cast(number % 10 as String)]), 'Map(String, String)')) from numbers(10000000)</fill_query>
     
-    <query>select a['xyz'] from test_table_map Format Null settings max_threads=1</query>
+    <query>select a['xyz'] from test_table_map_2 Format Null settings max_threads=1</query>
 
-    <drop_query>drop table test_table_map</drop_query>
+    <drop_query>drop table test_table_map_2</drop_query>
 </test>


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Performance Improvement



### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...
Getting values from a map is widely used. In practice, the key structrues are usally the same in the same map column, we could try to predict the next row's key position and reduce the comparisons.

Some results are given as following
```sql
insert into test_table_map select CAST((['xyz', 'abc', '123'], [cast(number % 10 as String), 'dsdfsd', '123']), 'Map(String, String)') from numbers(20000000);

select a['xyz'] from test_table_map Format Null settings max_threads=1;
--- before
0 rows in set. Elapsed: 0.321 sec. Processed 20.00 million rows, 1.62 GB (62.25 million rows/s., 5.04 GB/s.)
0 rows in set. Elapsed: 0.322 sec. Processed 20.00 million rows, 1.62 GB (62.09 million rows/s., 5.03 GB/s.)
0 rows in set. Elapsed: 0.323 sec. Processed 20.00 million rows, 1.62 GB (61.98 million rows/s., 5.02 GB/s.)
--- after
0 rows in set. Elapsed: 0.316 sec. Processed 20.00 million rows, 1.62 GB (63.23 million rows/s., 5.12 GB/s.)
0 rows in set. Elapsed: 0.319 sec. Processed 20.00 million rows, 1.62 GB (62.70 million rows/s., 5.08 GB/s.)
0 rows in set. Elapsed: 0.316 sec. Processed 20.00 million rows, 1.62 GB (63.35 million rows/s., 5.13 GB/s.)


select a['123'] from test_table_map Format Null settings max_threads=1;
--- before
0 rows in set. Elapsed: 0.459 sec. Processed 20.00 million rows, 1.62 GB (43.56 million rows/s., 3.53 GB/s.)
0 rows in set. Elapsed: 0.460 sec. Processed 20.00 million rows, 1.62 GB (43.45 million rows/s., 3.52 GB/s.)
0 rows in set. Elapsed: 0.460 sec. Processed 20.00 million rows, 1.62 GB (43.44 million rows/s., 3.52 GB/s.)
--- after
0 rows in set. Elapsed: 0.318 sec. Processed 20.00 million rows, 1.62 GB (62.88 million rows/s., 5.09 GB/s.)
0 rows in set. Elapsed: 0.317 sec. Processed 20.00 million rows, 1.62 GB (63.12 million rows/s., 5.11 GB/s.)
0 rows in set. Elapsed: 0.317 sec. Processed 20.00 million rows, 1.62 GB (63.19 million rows/s., 5.12 GB/s.)
```

```sql
insert into test_table_map select if (number % 2 = 0, CAST((['xyz', 'abc', '123'], [cast(number % 10 as String), 'dsdfsd', '123']), 'Map(String, String)'), CAST((['123', 'abc', 'xyz'], ['123', 'dsdfsd', cast(number % 10 as String)]), 'Map(String, String)')) from numbers(20000000);

select a['xyz'] from test_table_map Format Null settings max_threads=1;
--- before
0 rows in set. Elapsed: 0.411 sec. Processed 20.00 million rows, 1.62 GB (48.66 million rows/s., 3.94 GB/s.)
0 rows in set. Elapsed: 0.422 sec. Processed 20.00 million rows, 1.62 GB (47.37 million rows/s., 3.84 GB/s.)
0 rows in set. Elapsed: 0.431 sec. Processed 20.00 million rows, 1.62 GB (46.46 million rows/s., 3.76 GB/s.)
--- after
0 rows in set. Elapsed: 0.408 sec. Processed 20.00 million rows, 1.62 GB (48.97 million rows/s., 3.97 GB/s.)
0 rows in set. Elapsed: 0.410 sec. Processed 20.00 million rows, 1.62 GB (48.79 million rows/s., 3.95 GB/s.)
0 rows in set. Elapsed: 0.414 sec. Processed 20.00 million rows, 1.62 GB (48.33 million rows/s., 3.91 GB/s.)
```

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
