### PR TITLE
PullingAsyncPipelineExecutor::pull do not return empty blocks

### DIFF
--- a/src/Processors/Executors/PullingAsyncPipelineExecutor.cpp
+++ b/src/Processors/Executors/PullingAsyncPipelineExecutor.cpp
@@ -134,7 +134,7 @@ bool PullingAsyncPipelineExecutor::pull(Chunk & chunk, uint64_t milliseconds)
     {
         chunk = lazy_format->getChunk(milliseconds);
         data->rethrowExceptionIfHas();
-        bool is_finished = lazy_format->isFinished() && !chunk;
+        bool is_finished = lazy_format->isFinished();
         return !is_finished;
     }
 

--- a/src/Processors/Executors/PullingAsyncPipelineExecutor.cpp
+++ b/src/Processors/Executors/PullingAsyncPipelineExecutor.cpp
@@ -134,7 +134,8 @@ bool PullingAsyncPipelineExecutor::pull(Chunk & chunk, uint64_t milliseconds)
     {
         chunk = lazy_format->getChunk(milliseconds);
         data->rethrowExceptionIfHas();
-        return true;
+        bool is_finished = lazy_format->isFinished() && !chunk;
+        return !is_finished;
     }
 
     chunk.clear();


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)

