### PR TITLE
Prevent excesive memory usage when deserializing AggregateFunctionTopKGenericData

### DIFF
--- a/src/AggregateFunctions/AggregateFunctionTopK.cpp
+++ b/src/AggregateFunctions/AggregateFunctionTopK.cpp
@@ -8,9 +8,6 @@
 #include <DataTypes/DataTypeIPv4andIPv6.h>
 
 
-static inline constexpr UInt64 TOP_K_MAX_SIZE = 0xFFFFFF;
-
-
 namespace DB
 {
 
@@ -134,9 +131,12 @@ AggregateFunctionPtr createAggregateFunctionTopK(const std::string & name, const
 
         threshold = applyVisitor(FieldVisitorConvertToNumber<UInt64>(), params[0]);
 
-        if (threshold > TOP_K_MAX_SIZE || load_factor > TOP_K_MAX_SIZE || threshold * load_factor > TOP_K_MAX_SIZE)
-            throw Exception(ErrorCodes::ARGUMENT_OUT_OF_BOUND,
-                            "Too large parameter(s) for aggregate function '{}' (maximum is {})", name, toString(TOP_K_MAX_SIZE));
+        if (threshold > DB::TOP_K_MAX_SIZE || load_factor > DB::TOP_K_MAX_SIZE || threshold * load_factor > DB::TOP_K_MAX_SIZE)
+            throw Exception(
+                ErrorCodes::ARGUMENT_OUT_OF_BOUND,
+                "Too large parameter(s) for aggregate function '{}' (maximum is {})",
+                name,
+                toString(DB::TOP_K_MAX_SIZE));
 
         if (threshold == 0)
             throw Exception(ErrorCodes::ARGUMENT_OUT_OF_BOUND, "Parameter 0 is illegal for aggregate function '{}'", name);

--- a/tests/queries/0_stateless/02902_topKGeneric_deserialization_memory.sql
+++ b/tests/queries/0_stateless/02902_topKGeneric_deserialization_memory.sql
@@ -1,0 +1,7 @@
+-- https://github.com/ClickHouse/ClickHouse/issues/49706
+-- Using format Parquet for convenience so it errors out without output (but still deserializes the output)
+-- Without the fix this would OOM the client when deserializing the state
+SELECT
+    topKResampleState(1048576, 257, 65536, 10)(toString(number), number)
+FROM numbers(3)
+FORMAT Parquet; -- { clientError UNKNOWN_TYPE }

--- a/tests/queries/0_stateless/02902_topKGeneric_deserialization_memory.sql
+++ b/tests/queries/0_stateless/02902_topKGeneric_deserialization_memory.sql
@@ -1,3 +1,5 @@
+-- Tags: no-fasttest
+
 -- https://github.com/ClickHouse/ClickHouse/issues/49706
 -- Using format Parquet for convenience so it errors out without output (but still deserializes the output)
 -- Without the fix this would OOM the client when deserializing the state


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Prevent excesive memory usage when deserializing AggregateFunctionTopKGenericData

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)


Closes https://github.com/ClickHouse/ClickHouse/issues/49706
