### PR TITLE
arrayFold: Switch accumulator and array arguments

### DIFF
--- a/docs/en/sql-reference/functions/array-functions.md
+++ b/docs/en/sql-reference/functions/array-functions.md
@@ -1081,6 +1081,10 @@ Result:
 └─────────────────────────────────────────────────────────────┘
 ```
 
+**See also**
+
+- [arrayFold](#arrayFold)
+
 ## arrayReduceInRanges
 
 Applies an aggregate function to array elements in given ranges and returns an array containing the result corresponding to each range. The function will return the same result as multiple `arrayReduce(agg_func, arraySlice(arr1, index, length), ...)`.
@@ -1138,7 +1142,7 @@ arrayFold(lambda_function, arr1, arr2, ..., accumulator)
 Query:
 
 ``` sql
-SELECT arrayFold( x,acc -> acc + x*2,  [1, 2, 3, 4], toInt64(3)) AS res;
+SELECT arrayFold( acc,x -> acc + x*2,  [1, 2, 3, 4], toInt64(3)) AS res;
 ```
 
 Result:
@@ -1152,7 +1156,7 @@ Result:
 **Example with the Fibonacci sequence**
 
 ```sql
-SELECT arrayFold( x, acc -> (acc.2, acc.2 + acc.1), range(number), (1::Int64, 0::Int64)).1 AS fibonacci
+SELECT arrayFold( acc,x -> (acc.2, acc.2 + acc.1), range(number), (1::Int64, 0::Int64)).1 AS fibonacci
 FROM numbers(1,10);
 
 ┌─fibonacci─┐
@@ -1169,6 +1173,9 @@ FROM numbers(1,10);
 └───────────┘
 ```
 
+**See also**
+
+- [arrayReduce](#arrayReduce)
 
 ## arrayReverse(arr)
 

--- a/tests/performance/array_fold.xml
+++ b/tests/performance/array_fold.xml
@@ -1,5 +1,5 @@
 <test>
-    <query>SELECT arrayFold((x, acc) -> acc + x, range(number % 100), toUInt64(0)) from numbers(100000) Format Null</query>
-    <query>SELECT arrayFold((x, acc) -> acc + 1, range(number % 100), toUInt64(0)) from numbers(100000) Format Null</query>
-    <query>SELECT arrayFold((x, acc) -> acc + x, range(number), toUInt64(0)) from numbers(10000) Format Null</query>
+    <query>SELECT arrayFold((acc, x) -> acc + x, range(number % 100), toUInt64(0)) from numbers(100000) Format Null</query>
+    <query>SELECT arrayFold((acc, x) -> acc + 1, range(number % 100), toUInt64(0)) from numbers(100000) Format Null</query>
+    <query>SELECT arrayFold((acc, x) -> acc + x, range(number), toUInt64(0)) from numbers(10000) Format Null</query>
 </test>

--- a/tests/queries/0_stateless/02718_array_fold.sql
+++ b/tests/queries/0_stateless/02718_array_fold.sql
@@ -1,23 +1,24 @@
 SELECT 'Negative tests';
 SELECT arrayFold(); -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }
 SELECT arrayFold(1); -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }
-SELECT arrayFold(1, toUInt64(0)); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
-SELECT arrayFold( x,acc -> x,  emptyArrayString(), toInt8(0)); -- { serverError TYPE_MISMATCH }
-SELECT arrayFold( x,acc -> x,  'not an array', toUInt8(0)); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
-SELECT arrayFold( x,y,acc -> x,  [0, 1], 'not an array', toUInt8(0)); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
-SELECT arrayFold( x,acc -> x,  [0, 1], [2, 3], toUInt8(0)); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
-SELECT arrayFold( x,y,acc -> x,  [0, 1], [2, 3, 4], toUInt8(0)); -- { serverError SIZES_OF_ARRAYS_DONT_MATCH }
+SELECT arrayFold(1, toUInt64(0)); -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }
+SELECT arrayFold(1, emptyArrayUInt64(), toUInt64(0)); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+SELECT arrayFold( acc,x -> x,  emptyArrayString(), toInt8(0)); -- { serverError TYPE_MISMATCH }
+SELECT arrayFold( acc,x -> x,  'not an array', toUInt8(0)); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+SELECT arrayFold( acc,x,y -> x,  [0, 1], 'not an array', toUInt8(0)); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+SELECT arrayFold( acc,x -> x,  [0, 1], [2, 3], toUInt8(0)); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+SELECT arrayFold( acc,x,y -> x,  [0, 1], [2, 3, 4], toUInt8(0)); -- { serverError SIZES_OF_ARRAYS_DONT_MATCH }
 
 SELECT 'Const arrays';
-SELECT arrayFold( x,acc -> acc+x*2,  [1, 2, 3, 4], toInt64(3));
-SELECT arrayFold( x,acc -> acc+x*2,  emptyArrayInt64(), toInt64(3));
-SELECT arrayFold( x,y,acc -> acc+x*2+y*3,  [1, 2, 3, 4], [5, 6, 7, 8], toInt64(3));
-SELECT arrayFold( x,acc -> arrayPushBack(acc, x),  [1, 2, 3, 4], emptyArrayInt64());
-SELECT arrayFold( x,acc -> arrayPushFront(acc, x),  [1, 2, 3, 4], emptyArrayInt64());
-SELECT arrayFold( x,acc -> (arrayPushFront(acc.1, x),arrayPushBack(acc.2, x)),  [1, 2, 3, 4], (emptyArrayInt64(), emptyArrayInt64()));
-SELECT arrayFold( x,acc -> x%2 ? (arrayPushBack(acc.1, x), acc.2): (acc.1, arrayPushBack(acc.2, x)),  [1, 2, 3, 4, 5, 6], (emptyArrayInt64(), emptyArrayInt64()));
+SELECT arrayFold( acc,x -> acc+x*2,  [1, 2, 3, 4], toInt64(3));
+SELECT arrayFold( acc,x -> acc+x*2,  emptyArrayInt64(), toInt64(3));
+SELECT arrayFold( acc,x,y -> acc+x*2+y*3,  [1, 2, 3, 4], [5, 6, 7, 8], toInt64(3));
+SELECT arrayFold( acc,x -> arrayPushBack(acc, x),  [1, 2, 3, 4], emptyArrayInt64());
+SELECT arrayFold( acc,x -> arrayPushFront(acc, x),  [1, 2, 3, 4], emptyArrayInt64());
+SELECT arrayFold( acc,x -> (arrayPushFront(acc.1, x),arrayPushBack(acc.2, x)),  [1, 2, 3, 4], (emptyArrayInt64(), emptyArrayInt64()));
+SELECT arrayFold( acc,x -> x%2 ? (arrayPushBack(acc.1, x), acc.2): (acc.1, arrayPushBack(acc.2, x)),  [1, 2, 3, 4, 5, 6], (emptyArrayInt64(), emptyArrayInt64()));
 
 SELECT 'Non-const arrays';
-SELECT arrayFold( x,acc -> acc+x,  range(number), number) FROM system.numbers LIMIT 5;
-SELECT arrayFold( x,acc -> arrayPushFront(acc,x),  range(number), emptyArrayUInt64()) FROM system.numbers LIMIT 5;
-SELECT arrayFold( x,acc -> x%2 ? arrayPushFront(acc,x) : arrayPushBack(acc,x),  range(number), emptyArrayUInt64()) FROM system.numbers LIMIT 5;
+SELECT arrayFold( acc,x -> acc+x,  range(number), number) FROM system.numbers LIMIT 5;
+SELECT arrayFold( acc,x -> arrayPushFront(acc,x),  range(number), emptyArrayUInt64()) FROM system.numbers LIMIT 5;
+SELECT arrayFold( acc,x -> x%2 ? arrayPushFront(acc,x) : arrayPushBack(acc,x),  range(number), emptyArrayUInt64()) FROM system.numbers LIMIT 5;


### PR DESCRIPTION
The lambda argument of function [arrayFold](https://clickhouse.com/docs/en/sql-reference/functions/array-functions#arrayfold) now requires the accumulator as the first argument. This makes the semantics more similar to other languages, e.g.
- Python: https://docs.python.org/3/library/functools.html#functools.reduce
- JS: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/reduce 
- C++: https://en.cppreference.com/w/cpp/algorithm/accumulate

"Not for changelog" because `arrayFold` is [new](https://github.com/ClickHouse/ClickHouse/pull/49794) and not in any released version yet.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)