### PR TITLE
Added a setting to allow reading rows marked as deleted

### DIFF
--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -551,7 +551,7 @@ class IColumn;
     M(Bool, optimize_respect_aliases, true, "If it is set to true, it will respect aliases in WHERE/GROUP BY/ORDER BY, that will help with partition pruning/secondary indexes/optimize_aggregation_in_order/optimize_read_in_order/optimize_trivial_count", 0) \
     M(UInt64, mutations_sync, 0, "Wait for synchronous execution of ALTER TABLE UPDATE/DELETE queries (mutations). 0 - execute asynchronously. 1 - wait current server. 2 - wait all replicas if they exist.", 0) \
     M(Bool, enable_lightweight_delete, true, "Enable lightweight DELETE mutations for mergetree tables.", 0) ALIAS(allow_experimental_lightweight_delete) \
-    M(Bool, apply_deleted_mask, true, "Enables filtering out rows deleted with lightweight DELETE. If disabled, a query will be able to read those rows. This is useful for debugging and \"undelete\" scenarious", 0) \
+    M(Bool, apply_deleted_mask, true, "Enables filtering out rows deleted with lightweight DELETE. If disabled, a query will be able to read those rows. This is useful for debugging and \"undelete\" scenarios", 0) \
     M(Bool, optimize_move_functions_out_of_any, false, "Move functions out of aggregate functions 'any', 'anyLast'.", 0) \
     M(Bool, optimize_normalize_count_variants, true, "Rewrite aggregate functions that semantically equals to count() as count().", 0) \
     M(Bool, optimize_injective_functions_inside_uniq, true, "Delete injective functions of one argument inside uniq*() functions.", 0) \

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -551,6 +551,7 @@ class IColumn;
     M(Bool, optimize_respect_aliases, true, "If it is set to true, it will respect aliases in WHERE/GROUP BY/ORDER BY, that will help with partition pruning/secondary indexes/optimize_aggregation_in_order/optimize_read_in_order/optimize_trivial_count", 0) \
     M(UInt64, mutations_sync, 0, "Wait for synchronous execution of ALTER TABLE UPDATE/DELETE queries (mutations). 0 - execute asynchronously. 1 - wait current server. 2 - wait all replicas if they exist.", 0) \
     M(Bool, enable_lightweight_delete, true, "Enable lightweight DELETE mutations for mergetree tables.", 0) ALIAS(allow_experimental_lightweight_delete) \
+    M(Bool, apply_deleted_mask, true, "Enables filtering out rows deleted with lightweight DELETE. If disabled, a query will be able to read those rows. This is useful for debugging and \"undelete\" scenarious", 0) \
     M(Bool, optimize_move_functions_out_of_any, false, "Move functions out of aggregate functions 'any', 'anyLast'.", 0) \
     M(Bool, optimize_normalize_count_variants, true, "Rewrite aggregate functions that semantically equals to count() as count().", 0) \
     M(Bool, optimize_injective_functions_inside_uniq, true, "Delete injective functions of one argument inside uniq*() functions.", 0) \

--- a/src/Processors/QueryPlan/ReadFromMergeTree.cpp
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.cpp
@@ -115,6 +115,7 @@ static MergeTreeReaderSettings getMergeTreeReaderSettings(
         .save_marks_in_cache = true,
         .checksum_on_read = settings.checksum_on_read,
         .read_in_order = query_info.input_order_info != nullptr,
+        .apply_deleted_mask = settings.apply_deleted_mask,
         .use_asynchronous_read_from_pool = settings.allow_asynchronous_read_from_io_pool_for_merge_tree
             && (settings.max_streams_to_max_threads_ratio > 1 || settings.max_streams_for_merge_tree_reading > 1),
         .enable_multiple_prewhere_read_steps = settings.enable_multiple_prewhere_read_steps,

--- a/tests/queries/0_stateless/02902_diable_apply_deleted_mask.reference
+++ b/tests/queries/0_stateless/02902_diable_apply_deleted_mask.reference
@@ -1,0 +1,16 @@
+Normal SELECT does not see deleted rows
+1	1	1
+3	3	1
+With the setting enabled the deleted rows are visible
+0	0	0
+1	1	1
+2	2	0
+3	3	1
+4	4	0
+With the setting enabled the deleted rows are visible but still can be filterd out
+1	1
+3	3
+Read the data after OPTIMIZE, all deleted rwos should be physically removed now
+1	1	1
+3	3	1
+5	5	1

--- a/tests/queries/0_stateless/02902_diable_apply_deleted_mask.reference
+++ b/tests/queries/0_stateless/02902_diable_apply_deleted_mask.reference
@@ -1,13 +1,13 @@
 Normal SELECT does not see deleted rows
 1	1	1
 3	3	1
-With the setting enabled the deleted rows are visible
+With the setting disabled the deleted rows are visible
 0	0	0
 1	1	1
 2	2	0
 3	3	1
 4	4	0
-With the setting enabled the deleted rows are visible but still can be filterd out
+With the setting disabled the deleted rows are visible but still can be filterd out
 1	1
 3	3
 Read the data after OPTIMIZE, all deleted rwos should be physically removed now

--- a/tests/queries/0_stateless/02902_diable_apply_deleted_mask.sql
+++ b/tests/queries/0_stateless/02902_diable_apply_deleted_mask.sql
@@ -1,0 +1,25 @@
+DROP TABLE IF EXISTS test_apply_deleted_mask;
+
+CREATE TABLE test_apply_deleted_mask(id Int64, value String) ENGINE = MergeTree ORDER BY id;
+
+INSERT INTO test_apply_deleted_mask SELECT number, number::String FROM numbers(5);
+
+DELETE FROM test_apply_deleted_mask WHERE id % 2 = 0;
+
+SELECT 'Normal SELECT does not see deleted rows';
+SELECT *, _row_exists FROM test_apply_deleted_mask;
+
+SELECT 'With the setting enabled the deleted rows are visible';
+SELECT *, _row_exists FROM test_apply_deleted_mask SETTINGS apply_deleted_mask = 0;
+
+SELECT 'With the setting enabled the deleted rows are visible but still can be filterd out';
+SELECT * FROM test_apply_deleted_mask WHERE _row_exists SETTINGS apply_deleted_mask = 0;
+
+INSERT INTO test_apply_deleted_mask SELECT number, number::String FROM numbers(5, 1);
+
+OPTIMIZE TABLE test_apply_deleted_mask FINAL SETTINGS mutations_sync=2;
+
+SELECT 'Read the data after OPTIMIZE, all deleted rwos should be physically removed now';
+SELECT *, _row_exists FROM test_apply_deleted_mask SETTINGS apply_deleted_mask = 0;
+
+DROP TABLE test_apply_deleted_mask;

--- a/tests/queries/0_stateless/02902_diable_apply_deleted_mask.sql
+++ b/tests/queries/0_stateless/02902_diable_apply_deleted_mask.sql
@@ -9,7 +9,7 @@ DELETE FROM test_apply_deleted_mask WHERE id % 2 = 0;
 SELECT 'Normal SELECT does not see deleted rows';
 SELECT *, _row_exists FROM test_apply_deleted_mask;
 
-SELECT 'With the setting enabled the deleted rows are visible';
+SELECT 'With the setting disabled the deleted rows are visible';
 SELECT *, _row_exists FROM test_apply_deleted_mask SETTINGS apply_deleted_mask = 0;
 
 SELECT 'With the setting enabled the deleted rows are visible but still can be filterd out';

--- a/tests/queries/0_stateless/02902_diable_apply_deleted_mask.sql
+++ b/tests/queries/0_stateless/02902_diable_apply_deleted_mask.sql
@@ -12,7 +12,7 @@ SELECT *, _row_exists FROM test_apply_deleted_mask;
 SELECT 'With the setting disabled the deleted rows are visible';
 SELECT *, _row_exists FROM test_apply_deleted_mask SETTINGS apply_deleted_mask = 0;
 
-SELECT 'With the setting enabled the deleted rows are visible but still can be filterd out';
+SELECT 'With the setting disabled the deleted rows are visible but still can be filterd out';
 SELECT * FROM test_apply_deleted_mask WHERE _row_exists SETTINGS apply_deleted_mask = 0;
 
 INSERT INTO test_apply_deleted_mask SELECT number, number::String FROM numbers(5, 1);


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
The setting `apply_deleted_mask` when disabled allows to read rows that where marked as deleted by lightweight DELETE queries. This is useful for debugging.