### PR TITLE
Fix possible performance test error

### DIFF
--- a/docker/test/performance-comparison/compare.sh
+++ b/docker/test/performance-comparison/compare.sh
@@ -285,7 +285,7 @@ function run_tests
         # Use awk because bash doesn't support floating point arithmetic.
         profile_seconds=$(awk "BEGIN { print ($profile_seconds_left > 0 ? 10 : 0) }")
 
-        if [ "$(rg -c $(basename $test) changed-test-definitions.txt)" -gt 0 ]
+        if rg --quiet "$(basename $test)" changed-test-definitions.txt
         then
           # Run all queries from changed test files to ensure that all new queries will be tested.
           max_queries=0


### PR DESCRIPTION
CI [1]:

    2023-10-24 12:18:27	 ++ rg -c array_fill.xml changed-test-definitions.txt
    2023-10-24 12:18:27	 + '[' '' -gt 0 ']'
    2023-10-24 12:18:27	 right/scripts/compare.sh: line 288: [: : integer expression expected

The problem is that by default ripgrep does not print anything if there are zero matches, unlike grep. But there is --include-zero.

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/55944/da408df4a7296835897d7cef80d63f252df79b75/performance_comparison_[2_4]/compare.log

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Follow-up for: #44819 (cc @alexey-milovidov )