### PR TITLE
Fix instances of sparse column in mask extraction [WIP]

### DIFF
--- a/src/Columns/MaskOperations.cpp
+++ b/src/Columns/MaskOperations.cpp
@@ -203,7 +203,7 @@ MaskInfo extractMaskImpl(
     const PaddedPODArray<UInt8> * null_bytemap,
     PaddedPODArray<UInt8> * nulls = nullptr)
 {
-    auto column = col->convertToFullColumnIfLowCardinality();
+    auto column = col->convertToFullColumnIfLowCardinality()->convertToFullColumnIfSparse();
 
     /// Special implementation for Null and Const columns.
     if (column->onlyNull() || checkAndGetColumn<ColumnConst>(*column))


### PR DESCRIPTION
Under difficult to replicate scenarios we've observed Sparse columns periodically causing an error code 44 to be thrown in `src/Columns/MaskOperations.cpp`.

An example of the exception being thrown [here](https://github.com/ClickHouse/ClickHouse/blob/23.3/src/Columns/MaskOperations.cpp#L230):
``` log
Code: 44. DB::Exception: Cannot convert column Sparse(UInt8) to mask.: while executing 'FUNCTION and(equals(client_id, 'saas_test') :: 12, greaterOrEquals(timestamp, 1698122346000) :: 6, less(timestamp, 1698122405000) :: 7, equals(lowerUTF8(http_call_origin), 'https://www.google.com') :: 10, equals(type, 'httpRequest') :: 8) -> and(equals(client_id, 'saas_instana_test'), greaterOrEquals(timestamp, 1698122346000), less(timestamp, 1698122405000), equals(lowerUTF8(http_call_origin), 'https://www.google.com'), equals(type, 'httpRequest')) UInt8 : 9'. (ILLEGAL_COLUMN) (version 23.3.13.6 (official build))
stack_trace:                           0. DB::Exception::Exception(DB::Exception::MessageMasked&&, int, bool) @ 0xe2949b5 in /opt/clickhouse/bin/clickhouse
1. ? @ 0x8a9a044 in /opt/clickhouse/bin/clickhouse
2. ? @ 0x1404a37a in /opt/clickhouse/bin/clickhouse
3. ? @ 0x12e6a6b5 in /opt/clickhouse/bin/clickhouse
4. ? @ 0x8a9a48e in /opt/clickhouse/bin/clickhouse
5. DB::IExecutableFunction::executeWithoutLowCardinalityColumns(std::vector<DB::ColumnWithTypeAndName, std::allocator<DB::ColumnWithTypeAndName>> const&, std::shared_ptr<DB::IDataType const> const&, unsigned long, bool) const @ 0x126712eb in /opt/clickhouse/bin/clickhouse
6. DB::IExecutableFunction::executeWithoutSparseColumns(std::vector<DB::ColumnWithTypeAndName, std::allocator<DB::ColumnWithTypeAndName>> const&, std::shared_ptr<DB::IDataType const> const&, unsigned long, bool) const @ 0x12671d6c in /opt/clickhouse/bin/clickhouse
7. DB::IExecutableFunction::execute(std::vector<DB::ColumnWithTypeAndName, std::allocator<DB::ColumnWithTypeAndName>> const&, std::shared_ptr<DB::IDataType const> const&, unsigned long, bool) const @ 0x12672fdb in /opt/clickhouse/bin/clickhouse
8. DB::ExpressionActions::execute(DB::Block&, unsigned long&, bool) const @ 0x12fe637b in /opt/clickhouse/bin/clickhouse
9. DB::FilterTransform::doTransform(DB::Chunk&) @ 0x14d90458 in /opt/clickhouse/bin/clickhouse
10. DB::FilterTransform::transform(DB::Chunk&) @ 0x14d90374 in /opt/clickhouse/bin/clickhouse
11. ? @ 0x10c21030 in /opt/clickhouse/bin/clickhouse
12. DB::ISimpleTransform::work() @ 0x14b88abf in /opt/clickhouse/bin/clickhouse
13. DB::ExecutionThreadContext::executeTask() @ 0x14ba4dea in /opt/clickhouse/bin/clickhouse
14. DB::PipelineExecutor::executeStepImpl(unsigned long, std::atomic<bool>*) @ 0x14b99e5b in /opt/clickhouse/bin/clickhouse
15. ? @ 0x14b9c19c in /opt/clickhouse/bin/clickhouse
16. ThreadPoolImpl<std::thread>::worker(std::__list_iterator<std::thread, void*>) @ 0xe363b73 in /opt/clickhouse/bin/clickhouse
17. ? @ 0xe3697e1 in /opt/clickhouse/bin/clickhouse
18. ? @ 0x7f40bdf87609 in ?
19. __clone @ 0x7f40bdeac133 in ?
```

There appears to be a strange interaction between short-circuit evaluating functions, `lowerUTF8` in the above dump, and Sparse columns with respect to mask operations. We also observed this same behavior with `lengthUTF8` which IS suitable for short-circuiting, but not observed with `length` which IS NOT.

Disabling `short_circuit_function_evaluation` resolves the issue, as well as setting `ratio_of_defaults_for_sparse_serialization = 1.0` for the MergeTree.

I found a similar PR for `MaskOperations` extraction that fixed this same code 44 error but for columns that have `LowCardinality` (https://github.com/ClickHouse/ClickHouse/pull/28887).

Alternatively, this issue may be resolved by recent PRs (possibly one of https://github.com/ClickHouse/ClickHouse/pull/49716 https://github.com/ClickHouse/ClickHouse/pull/52827 https://github.com/ClickHouse/ClickHouse/pull/53548 https://github.com/ClickHouse/ClickHouse/pull/55275), and an upgrade would resolve the problem.

Please let me know if you have any suggestions, as this might not be the most appropriate place to turn the sparse column into a full.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed bug with Sparse columns in short-circuit evaluation.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

