### PR TITLE
Stress tests: Try to wait until server is responsive after gdb detach

### DIFF
--- a/docker/test/fuzzer/run-fuzzer.sh
+++ b/docker/test/fuzzer/run-fuzzer.sh
@@ -210,7 +210,7 @@ detach
 quit
 " > script.gdb
 
-    gdb -batch -command script.gdb -p "$(cat /var/run/clickhouse-server/clickhouse-server.pid)" &
+    gdb -batch -command script.gdb -p $server_pid &
     sleep 5
     # gdb will send SIGSTOP, spend some time loading debug info and then send SIGCONT, wait for it (up to send_timeout, 300s)
     time clickhouse-client --query "SELECT 'Connected to clickhouse-server after attaching gdb'" ||:
@@ -219,13 +219,12 @@ quit
     # to freeze and the fuzzer will fail. In debug build it can take a lot of time.
     for _ in {1..180}
     do
-        sleep 1
         if clickhouse-client --query "select 1"
         then
             break
         fi
+        sleep 1
     done
-    clickhouse-client --query "select 1" # This checks that the server is responding
     kill -0 $server_pid # This checks that it is our server that is started and not some other one
     echo 'Server started and responded'
 

--- a/tests/ci/stress.py
+++ b/tests/ci/stress.py
@@ -131,20 +131,17 @@ def prepare_for_hung_check(drop_databases: bool) -> bool:
 
     # We attach gdb to clickhouse-server before running tests
     # to print stacktraces of all crashes even if clickhouse cannot print it for some reason.
-    # However, it obstruct checking for hung queries.
+    # However, it obstructs checking for hung queries.
     logging.info("Will terminate gdb (if any)")
     call_with_retry("kill -TERM $(pidof gdb)")
     call_with_retry("tail --pid=$(pidof gdb) -f /dev/null")
     # Sometimes there is a message `Child process was stopped by signal 19` in logs after stopping gdb
     call_with_retry(
-        "kill -CONT $(cat /var/run/clickhouse-server/clickhouse-server.pid)"
+        "kill -CONT $(cat /var/run/clickhouse-server/clickhouse-server.pid) && clickhouse client -q 'SELECT 1 FORMAT Null'"
     )
 
     # ThreadFuzzer significantly slows down server and causes false-positive hung check failures
-    call_with_retry("clickhouse client -q 'SYSTEM STOP THREAD FUZZER'")
-
-    call_with_retry(make_query_command("SELECT 1 FORMAT Null"))
-
+    call_with_retry(make_query_command("SYSTEM STOP THREAD FUZZER"))
     # Some tests execute SYSTEM STOP MERGES or similar queries.
     # It may cause some ALTERs to hang.
     # Possibly we should fix tests and forbid to use such queries without specifying table.


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...


Looking at https://s3.amazonaws.com/clickhouse-test-reports/55962/38a2ba5769ebc780bad146d44732b358a2df4ccb/stress_test__ubsan_.html


Server logs:
```
2023.10.24 16:10:36.093465 [ 2408 ] {c9873ae5-7f96-4856-b05b-044e7546bb64} <Test> FileCache(s3_cache): Overflow: true, size: 238, ready to remove: 0 (0 in number), current cache size: 134217712/134217728, elements: 209/10000000, while reserving for 048b98f44be0a51dc31fed21bf59692b:0
2023.10.24 16:10:36.176773 [ 2019 ] {} <Warning> Application: Child process was stopped by signal 19.
2023.10.24 16:23:29.482799 [ 2019 ] {} <Fatal> Application: Child process was terminated by signal 9 (KILL). If it is not done by 'forcestop' command or manually, the possible cause is OOM Killer (see 'dmesg' and look at the '/var/log/kern.log' for the details).
```

The server received a signal 19 (`SIGSTOP`), then we don't see any logs for 13.5 minutes and finally a `SIGKILL` is received. There isn't any messages in the attached dmesg.log so it doesn't look as a OOM.


In the stress run.log:
```
2023-10-24 16:10:30,962 Finished 15 from 16 processes
2023-10-24 16:10:35,967 All processes finished
2023-10-24 16:10:35,967 Compressing stress logs
2023-10-24 16:10:35,978 Logs compressed
2023-10-24 16:10:35,979 Will terminate gdb (if any)
Quit
2023-10-24 16:11:06,147 Failed to prepare for hung check: Command 'clickhouse client -q 'SYSTEM STOP THREAD FUZZER'' timed out after 30 seconds
2023-10-24 16:11:06,148 Checking if some queries hung
Using queries from '/usr/share/clickhouse-test/queries' directory
Connecting to ClickHouse server...
Connection timeout, will not retry
```


So after terminating GDB, the process received a SIGSTOP, it seems it wasn't CONT'inuated (so the stress checks failed as they couldn't query the server) and ~15 minutes later it was finally killed. Most likely culprit of the kill is the final call to `clickhouse stop --force` under stress_tests.lib (stop()).

Let's try resending CONT signals until the server is responsive.
