### PR TITLE
Fix 02438_sync_replica_lightweight

### DIFF
--- a/tests/queries/0_stateless/02438_sync_replica_lightweight.reference
+++ b/tests/queries/0_stateless/02438_sync_replica_lightweight.reference
@@ -5,8 +5,9 @@ GET_PART	all_1_1_0
 MERGE_PARTS	all_0_1_1
 3	1	all_0_1_1
 3	2	all_0_1_1
-4	1	all_0_1_1
-4	2	all_0_1_1
+4	1
+4	2
+MERGE_PARTS	all_0_1_1
 5	1	all_0_2_2
 5	2	all_0_2_2
 5	3	all_0_2_2

--- a/tests/queries/0_stateless/02438_sync_replica_lightweight.sql
+++ b/tests/queries/0_stateless/02438_sync_replica_lightweight.sql
@@ -24,7 +24,8 @@ system start replicated sends rmt1;
 system sync replica rmt2 lightweight;   -- waits for fetches, not merges
 select type, new_part_name from system.replication_queue where database=currentDatabase() and table='rmt2' order by new_part_name;
 select 3, n, _part from rmt1 order by n;
-select 4, n, _part from rmt2 order by n;
+select 4, n from rmt2 order by n;
+select type, new_part_name from system.replication_queue where database=currentDatabase() and table='rmt2' order by new_part_name;
 
 system start merges rmt2;
 system sync replica rmt2;


### PR DESCRIPTION

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


https://s3.amazonaws.com/clickhouse-test-reports/55944/66c4a3bdbce488ae2d43230d5a26ba1e7e8e49a7/stateless_tests__aarch64_.html

It may or may not fetch the covering part via "actual part name"