### PR TITLE
Fix incorrect free space accounting for least_used JBOD policy

### DIFF
--- a/docs/en/engines/table-engines/mergetree-family/mergetree.md
+++ b/docs/en/engines/table-engines/mergetree-family/mergetree.md
@@ -866,6 +866,7 @@ Tags:
 - `prefer_not_to_merge` — Disables merging of data parts on this volume. When this setting is enabled, merging data on this volume is not allowed. This allows controlling how ClickHouse works with slow disks.
 - `perform_ttl_move_on_insert` — Disables TTL move on data part INSERT. By default (if enabled) if we insert a data part that already expired by the TTL move rule it immediately goes to a volume/disk declared in move rule. This can significantly slowdown insert in case if destination volume/disk is slow (e.g. S3). If disabled then already expired data part is written into a default volume and then right after moved to TTL volume.
 - `load_balancing` - Policy for disk balancing, `round_robin` or `least_used`.
+- `least_used_ttl_ms` - Configure timeout (in milliseconds) for the updating available space on all disks (`0` - update always, `-1` - never update, default is `60000`). Note, if the disk can be used by ClickHouse only and is not subject to a online filesystem resize/shrink you can use `-1`, in all other cases it is not recommended, since eventually it will lead to incorrect space distribution.
 
 Configuration examples:
 

--- a/src/Disks/StoragePolicy.cpp
+++ b/src/Disks/StoragePolicy.cpp
@@ -71,7 +71,8 @@ StoragePolicy::StoragePolicy(
             /* max_data_part_size_= */ 0,
             /* are_merges_avoided_= */ false,
             /* perform_ttl_move_on_insert_= */ true,
-            VolumeLoadBalancing::ROUND_ROBIN);
+            VolumeLoadBalancing::ROUND_ROBIN,
+            /* least_used_ttl_ms_= */ 60'000);
         volumes.emplace_back(std::move(default_volume));
     }
 

--- a/tests/integration/test_jbod_load_balancing/configs/config.d/storage_configuration.xml
+++ b/tests/integration/test_jbod_load_balancing/configs/config.d/storage_configuration.xml
@@ -31,6 +31,7 @@
                         <disk>jbod3</disk>
 
                         <load_balancing>least_used</load_balancing>
+                        <least_used_ttl_ms>0</least_used_ttl_ms>
                     </disks>
                 </volumes>
             </jbod_least_used>

--- a/tests/integration/test_jbod_load_balancing/test.py
+++ b/tests/integration/test_jbod_load_balancing/test.py
@@ -134,3 +134,66 @@ def test_jbod_load_balancing_least_used_next_disk(start_cluster):
         ]
     finally:
         node.query("DROP TABLE IF EXISTS data_least_used_next_disk SYNC")
+
+
+def test_jbod_load_balancing_least_used_detect_background_changes(start_cluster):
+    def get_parts_on_disks():
+        parts = node.query(
+            """
+        SELECT count(), disk_name
+        FROM system.parts
+        WHERE table = 'data_least_used_detect_background_changes'
+        GROUP BY disk_name
+        ORDER BY disk_name
+        """
+        )
+        parts = [l.split("\t") for l in parts.strip().split("\n")]
+        return parts
+
+    try:
+        node.query(
+            """
+            CREATE TABLE data_least_used_detect_background_changes (p UInt8)
+            ENGINE = MergeTree
+            ORDER BY tuple()
+            SETTINGS storage_policy = 'jbod_least_used';
+
+            SYSTEM STOP MERGES data_least_used_detect_background_changes;
+            """
+        )
+
+        node.exec_in_container(["fallocate", "-l200M", "/jbod3/.test"])
+        node.query(
+            """
+            INSERT INTO data_least_used_detect_background_changes SELECT * FROM numbers(10);
+            INSERT INTO data_least_used_detect_background_changes SELECT * FROM numbers(10);
+            INSERT INTO data_least_used_detect_background_changes SELECT * FROM numbers(10);
+            INSERT INTO data_least_used_detect_background_changes SELECT * FROM numbers(10);
+        """
+        )
+        parts = get_parts_on_disks()
+        assert parts == [
+            ["4", "jbod2"],
+        ]
+
+        node.exec_in_container(["rm", "/jbod3/.test"])
+        node.query(
+            """
+            INSERT INTO data_least_used_detect_background_changes SELECT * FROM numbers(10);
+            INSERT INTO data_least_used_detect_background_changes SELECT * FROM numbers(10);
+            INSERT INTO data_least_used_detect_background_changes SELECT * FROM numbers(10);
+            INSERT INTO data_least_used_detect_background_changes SELECT * FROM numbers(10);
+        """
+        )
+        parts = get_parts_on_disks()
+        assert parts == [
+            # previous INSERT
+            ["4", "jbod2"],
+            # this INSERT
+            ["4", "jbod3"],
+        ]
+    finally:
+        node.exec_in_container(["rm", "-f", "/jbod3/.test"])
+        node.query(
+            "DROP TABLE IF EXISTS data_least_used_detect_background_changes SYNC"
+        )


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix incorrect free space accounting for `least_used` JBOD policy

Before least_used fails to detect when the disk started to have more
space, it works only when the disk starts to have less space.

The reason for this is that it uses priority_queue, and once the disk
goes at the bottom of the queue, free space will not be updated for it
until it will be selected again.

Follow-up for: #36686 (cc @serxa )
Fixes: #47415 