### PR TITLE
Set default value for std::atomic to solve 'Negative temporary data size' when using grace hash join

### DIFF
--- a/src/Interpreters/TemporaryDataOnDisk.h
+++ b/src/Interpreters/TemporaryDataOnDisk.h
@@ -38,8 +38,8 @@ class TemporaryDataOnDiskScope : boost::noncopyable
 public:
     struct StatAtomic
     {
-        std::atomic<size_t> compressed_size;
-        std::atomic<size_t> uncompressed_size;
+        std::atomic<size_t> compressed_size{0};
+        std::atomic<size_t> uncompressed_size{0};
     };
 
     explicit TemporaryDataOnDiskScope(VolumePtr volume_, size_t limit_)


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Set default value for std::atomic, or it's a ub.