### PR TITLE
important information in cmake is highlighted in blue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ include (cmake/ccache.cmake)
 include (cmake/clang_tidy.cmake)
 include (cmake/git.cmake)
 include (cmake/utils.cmake)
+include (cmake/message.cmake)
 
 # Ignore export() since we don't use it,
 # but it gets broken with a global targets via link_libraries()
@@ -70,7 +71,7 @@ if (NOT CMAKE_BUILD_TYPE OR CMAKE_BUILD_TYPE STREQUAL "None")
     set (CMAKE_BUILD_TYPE "RelWithDebInfo")
     message (STATUS "CMAKE_BUILD_TYPE is not set, set to default = ${CMAKE_BUILD_TYPE}")
 endif ()
-message (STATUS "CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}")
+message (STATUS "${BLUE} CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE} ${END}")
 
 string (TOUPPER ${CMAKE_BUILD_TYPE} CMAKE_BUILD_TYPE_UC)
 

--- a/cmake/message.cmake
+++ b/cmake/message.cmake
@@ -1,0 +1,5 @@
+# Message print settings
+
+string(ASCII 27 Esc)
+set(BLUE "${Esc}[0;36m") 
+set(END "${Esc}[m" ) 


### PR DESCRIPTION
1、Add message.cmake settings, If anyone has similar needs, you can define it here.
2、Different CMAKE_BUILD_TYPE types have different clickhouse sizes for binary files. However, we often make unreasonable settings on the compilation machine, resulting in unreasonable binary files. This is a very important cmake configuration parameter. I hope to highlight this focus in the compilation log. information. Of course, if other developers think there is some important information, they can refer to this implementation.

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
important information in cmake is highlighted in blue

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
