### PR TITLE
Fix bash completion for mawk (and update format list and add one more delimiter)

### DIFF
--- a/programs/bash-completion/completions/clickhouse-bootstrap
+++ b/programs/bash-completion/completions/clickhouse-bootstrap
@@ -46,6 +46,7 @@ CLICKHOUSE_Format=(
     ArrowStream
     Avro
     AvroConfluent
+    BSONEachRow
     CSV
     CSVWithNames
     CSVWithNamesAndTypes
@@ -56,6 +57,7 @@ CLICKHOUSE_Format=(
     CustomSeparatedIgnoreSpacesWithNamesAndTypes
     CustomSeparatedWithNames
     CustomSeparatedWithNamesAndTypes
+    DWARF
     HiveText
     JSON
     JSONAsObject
@@ -74,7 +76,7 @@ CLICKHOUSE_Format=(
     JSONEachRow
     JSONEachRowWithProgress
     JSONLines
-    JSONStringEachRow
+    JSONObjectEachRow
     JSONStrings
     JSONStringsEachRow
     JSONStringsEachRowWithProgress
@@ -90,14 +92,19 @@ CLICKHOUSE_Format=(
     Null
     ODBCDriver2
     ORC
+    One
     Parquet
+    ParquetMetadata
     PostgreSQLWire
     Pretty
     PrettyCompact
     PrettyCompactMonoBlock
     PrettyCompactNoEscapes
     PrettyCompactNoEscapesMonoBlock
+    PrettyJSONEachRow
+    PrettyJSONLines
     PrettyMonoBlock
+    PrettyNDJSON
     PrettyNoEscapes
     PrettyNoEscapesMonoBlock
     PrettySpace
@@ -111,6 +118,7 @@ CLICKHOUSE_Format=(
     RawBLOB
     Regexp
     RowBinary
+    RowBinaryWithDefaults
     RowBinaryWithNames
     RowBinaryWithNamesAndTypes
     SQLInsert

--- a/programs/bash-completion/completions/clickhouse-bootstrap
+++ b/programs/bash-completion/completions/clickhouse-bootstrap
@@ -146,7 +146,7 @@ function _clickhouse_quote()
 # Extract every option (everything that starts with "-") from the --help dialog.
 function _clickhouse_get_options()
 {
-    "$@" --help 2>&1 | awk -F '[ ,=<>]' '{ for (i=1; i <= NF; ++i) { if (substr($i, 1, 1) == "-" && length($i) > 1) print $i; } }' | sort -u
+    "$@" --help 2>&1 | awk -F '[ ,=<>.]' '{ for (i=1; i <= NF; ++i) { if (substr($i, 1, 1) == "-" && length($i) > 1) print $i; } }' | sort -u
 }
 
 function _complete_for_clickhouse_generic_bin_impl()

--- a/programs/bash-completion/completions/clickhouse-bootstrap
+++ b/programs/bash-completion/completions/clickhouse-bootstrap
@@ -146,7 +146,7 @@ function _clickhouse_quote()
 # Extract every option (everything that starts with "-") from the --help dialog.
 function _clickhouse_get_options()
 {
-    "$@" --help 2>&1 | awk -F '[ ,=<>]' '{ for (i=1; i <= NF; ++i) { if (substr($i, 0, 1) == "-" && length($i) > 1) print $i; } }' | sort -u
+    "$@" --help 2>&1 | awk -F '[ ,=<>]' '{ for (i=1; i <= NF; ++i) { if (substr($i, 1, 1) == "-" && length($i) > 1) print $i; } }' | sort -u
 }
 
 function _complete_for_clickhouse_generic_bin_impl()


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix bash completion for mawk (and update format list and add one more delimiter)

```sh
$ strings < /usr/bin/awk | grep awk
mawk 1.3%s%s %s, Copyright (C) Michael D. Brennan

$ awk '{print substr($0, 0, 1)}' <<<foo # returns empty string

$ awk '{print substr($0, 1, 1)}' <<<foo # returns empty string
f
```

```sh
$ awk -V | head -1
GNU Awk 5.2.2, API 3.2, PMA Avon 8-g1, (GNU MPFR 4.2.1, GNU MP 6.3.0)

$ awk '{print substr($0, 0, 1)}' <<<foo
f
$ awk '{print substr($0, 1, 1)}' <<<foo
f
```