### PR TITLE
MergeTree Merge use BatchHeap

### DIFF
--- a/src/Interpreters/SortedBlocksWriter.cpp
+++ b/src/Interpreters/SortedBlocksWriter.cpp
@@ -166,7 +166,7 @@ SortedBlocksWriter::TmpFilePtr SortedBlocksWriter::flush(const BlocksList & bloc
             sort_description,
             rows_in_block,
             /*max_block_size_bytes=*/0,
-            SortingQueueStrategy::Default);
+            SortingQueueStrategy::Batch);
 
         pipeline.addTransform(std::move(transform));
     }
@@ -222,7 +222,7 @@ SortedBlocksWriter::PremergedFiles SortedBlocksWriter::premerge()
                             sort_description,
                             rows_in_block,
                             /*max_block_size_bytes=*/0,
-                            SortingQueueStrategy::Default);
+                            SortingQueueStrategy::Batch);
 
                         pipeline.addTransform(std::move(transform));
                     }
@@ -257,7 +257,7 @@ SortedBlocksWriter::SortedFiles SortedBlocksWriter::finishMerge(std::function<vo
             sort_description,
             rows_in_block,
             /*max_block_size_bytes=*/0,
-            SortingQueueStrategy::Default);
+            SortingQueueStrategy::Batch);
 
         pipeline.addTransform(std::move(transform));
     }
@@ -335,7 +335,7 @@ Block SortedBlocksBuffer::mergeBlocks(Blocks && blocks) const
                 sort_description,
                 num_rows,
                 /*max_block_size_bytes=*/0,
-                SortingQueueStrategy::Default);
+                SortingQueueStrategy::Batch);
 
             builder.addTransform(std::move(transform));
         }

--- a/src/Storages/MergeTree/MergeTask.cpp
+++ b/src/Storages/MergeTree/MergeTask.cpp
@@ -958,7 +958,7 @@ void MergeTask::ExecuteAndFinalizeHorizontalPart::createMergedStream()
                 sort_description,
                 merge_block_size_rows,
                 merge_block_size_bytes,
-                SortingQueueStrategy::Default,
+                SortingQueueStrategy::Batch,
                 /* limit_= */0,
                 /* always_read_till_end_= */false,
                 ctx->rows_sources_write_buf.get(),

--- a/src/Storages/MergeTree/MergeTreePartInfo.cpp
+++ b/src/Storages/MergeTree/MergeTreePartInfo.cpp
@@ -131,7 +131,7 @@ std::optional<MergeTreePartInfo> MergeTreePartInfo::tryParsePartName(
         /// "Part 20170601_20170630_0_2_999999999 intersects 201706_0_1_4294967295".
         /// So we replace unexpected max level to make contains(...) method and comparison operators work
         /// correctly with such virtual parts. On part name serialization we will use legacy max level to keep the name unchanged.
-        part_info.use_leagcy_max_level = true;
+        part_info.use_legacy_max_level = true;
         level = MAX_LEVEL;
     }
 
@@ -205,7 +205,7 @@ String MergeTreePartInfo::getPartNameV1() const
     writeChar('_', wb);
     writeIntText(max_block, wb);
     writeChar('_', wb);
-    if (use_leagcy_max_level)
+    if (use_legacy_max_level)
     {
         assert(level == MAX_LEVEL);
         writeIntText(LEGACY_MAX_LEVEL, wb);
@@ -244,7 +244,7 @@ String MergeTreePartInfo::getPartNameV0(DayNum left_date, DayNum right_date) con
     writeChar('_', wb);
     writeIntText(max_block, wb);
     writeChar('_', wb);
-    if (use_leagcy_max_level)
+    if (use_legacy_max_level)
     {
         assert(level == MAX_LEVEL);
         writeIntText(LEGACY_MAX_LEVEL, wb);
@@ -274,7 +274,7 @@ void MergeTreePartInfo::serialize(WriteBuffer & out) const
     writeIntBinary(max_block, out);
     writeIntBinary(level, out);
     writeIntBinary(mutation, out);
-    writeBoolText(use_leagcy_max_level, out);
+    writeBoolText(use_legacy_max_level, out);
 }
 
 
@@ -297,7 +297,7 @@ void MergeTreePartInfo::deserialize(ReadBuffer & in)
     readIntBinary(max_block, in);
     readIntBinary(level, in);
     readIntBinary(mutation, in);
-    readBoolText(use_leagcy_max_level, in);
+    readBoolText(use_legacy_max_level, in);
 }
 
 DetachedPartInfo DetachedPartInfo::parseDetachedPartName(

--- a/src/Storages/MergeTree/MergeTreePartInfo.h
+++ b/src/Storages/MergeTree/MergeTreePartInfo.h
@@ -26,7 +26,8 @@ struct MergeTreePartInfo
     UInt32 level = 0;
     Int64 mutation = 0;   /// If the part has been mutated or contains mutated parts, is equal to mutation version number.
 
-    bool use_leagcy_max_level = false;  /// For compatibility. TODO remove it
+
+    bool use_legacy_max_level = false;  /// For compatibility. TODO remove it
 
     MergeTreePartInfo() = default;
 

--- a/src/Storages/MergeTree/MergeTreeSelectProcessor.h
+++ b/src/Storages/MergeTree/MergeTreeSelectProcessor.h
@@ -34,7 +34,6 @@ struct ParallelReadingExtension
     Names columns_to_read;
 };
 
-/// Base class for MergeTreeThreadSelectAlgorithm and MergeTreeSelectAlgorithm
 class MergeTreeSelectProcessor : private boost::noncopyable
 {
 public:


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Improve performance of Merge operation for MergeTree using BatchHeap data structure.
