### PR TITLE
Add note clarifying Prometheus support in ClickHouse Cloud

### DIFF
--- a/docs/en/operations/server-configuration-parameters/settings.md
+++ b/docs/en/operations/server-configuration-parameters/settings.md
@@ -1823,6 +1823,10 @@ The trailing slash is mandatory.
 
 ## Prometheus {#prometheus}
 
+:::note
+ClickHouse Cloud does not currently support connecting to Prometheus. To be notified when this feature is supported, please contact support@clickhouse.com.
+:::
+
 Exposing metrics data for scraping from [Prometheus](https://prometheus.io).
 
 Settings:


### PR DESCRIPTION

### Changelog category (leave one):

- Documentation (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add note clarifying Prometheus support in ClickHouse Cloud