### PR TITLE
Try enable `01154_move_partition_long` with s3

### DIFF
--- a/tests/queries/0_stateless/01154_move_partition_long.sh
+++ b/tests/queries/0_stateless/01154_move_partition_long.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
-# Tags: long, no-parallel, no-s3-storage
-# FIXME: s3 storage should work OK, it
-# reproduces bug which exists not only in S3 version.
+# Tags: long, no-parallel
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh


### PR DESCRIPTION

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Probably fixed by https://github.com/ClickHouse/ClickHouse/pull/54193 