### PR TITLE
Fix flakiness of 02263_lazy_mark_load

### DIFF
--- a/tests/queries/0_stateless/02263_lazy_mark_load.sh
+++ b/tests/queries/0_stateless/02263_lazy_mark_load.sh
@@ -30,7 +30,11 @@ EOF
 ${CLICKHOUSE_CLIENT} -q "SYSTEM STOP MERGES lazy_mark_test"
 ${CLICKHOUSE_CLIENT} -q "INSERT INTO lazy_mark_test select number, number % 3, number % 5, number % 10, number % 13, number % 15, number % 17, number % 18, number % 22, number % 25 from numbers(1000000)"
 ${CLICKHOUSE_CLIENT} -q "SYSTEM DROP MARK CACHE"
-${CLICKHOUSE_CLIENT} --log_queries=1 --query_id "${QUERY_ID}" -q "SELECT * FROM lazy_mark_test WHERE n3==11 SETTINGS load_marks_asynchronously=0"
+# max_threads=1 is needed because otherwise OpenedFileCache makes ProfileEvents['FileOpen'] nondeterministic
+# (usually all threads access the file at overlapping times, and the file is opened just once;
+#  but sometimes a thread is much slower than others and ends opening the same file a second time)
+${CLICKHOUSE_CLIENT} --log_queries=1 --query_id "${QUERY_ID}" -q "SELECT * FROM lazy_mark_test WHERE n3==11 SETTINGS load_marks_asynchronously=0, max_threads=1"
 ${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH LOGS"
 
+# Expect 2 open files: n3 marks and n3 data.
 ${CLICKHOUSE_CLIENT} -q "select ProfileEvents['FileOpen'] from system.query_log where query_id = '${QUERY_ID}' and type = 'QueryFinish' and current_database = currentDatabase()"


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

The tests reads one column and expects this query to open 2 files (profile event FileOpen): the marks file and the data file. But sometimes the data file would be opened twice, by different threads, because of a (reasonable) race in how file descriptor cache works. This PR just sets max_threads=1 to avoid this.

(The race is: OpenedFileCache caches file descriptors as weak_ptr, i.e. only while anyone is using the file; here, all threads use the file "at the same time", so usually they all hit the cache and open the file only once in total; but if some thread is much faster/slower than others, the file gets opened twice.)