### PR TITLE
Fix wrong attribution of untracked memory to a user/query

### DIFF
--- a/src/Common/MemoryTracker.cpp
+++ b/src/Common/MemoryTracker.cpp
@@ -593,7 +593,7 @@ bool MemoryTracker::isSizeOkForSampling(UInt64 size) const
 void MemoryTracker::setParent(MemoryTracker * elem)
 {
     /// Untracked memory shouldn't be accounted to a query or a user if it was allocated before the thread was attached
-    /// to a query thread group or a user group, bacause this memory will be (🤞) freed outside of these scopes.
+    /// to a query thread group or a user group, because this memory will be (🤞) freed outside of these scopes.
     if (level == VariableContext::Thread && DB::current_thread)
         DB::current_thread->flushUntrackedMemory();
 

--- a/src/Common/MemoryTracker.cpp
+++ b/src/Common/MemoryTracker.cpp
@@ -1,18 +1,19 @@
 #include "MemoryTracker.h"
 
 #include <IO/WriteHelpers.h>
-#include <Common/HashTable/Hash.h>
-#include <Common/VariableContext.h>
-#include <Common/TraceSender.h>
 #include <Common/Exception.h>
+#include <Common/HashTable/Hash.h>
 #include <Common/LockMemoryExceptionInThread.h>
 #include <Common/MemoryTrackerBlockerInThread.h>
-#include <Common/formatReadable.h>
-#include <Common/ProfileEvents.h>
-#include <Common/thread_local_rng.h>
 #include <Common/OvercommitTracker.h>
+#include <Common/ProfileEvents.h>
 #include <Common/Stopwatch.h>
+#include <Common/ThreadStatus.h>
+#include <Common/TraceSender.h>
+#include <Common/VariableContext.h>
+#include <Common/formatReadable.h>
 #include <Common/logger_useful.h>
+#include <Common/thread_local_rng.h>
 
 #include "config.h"
 
@@ -587,6 +588,16 @@ bool MemoryTracker::isSizeOkForSampling(UInt64 size) const
 {
     /// We can avoid comparison min_allocation_size_bytes with zero, because we cannot have 0 bytes allocation/deallocation
     return ((max_allocation_size_bytes == 0 || size <= max_allocation_size_bytes) && size >= min_allocation_size_bytes);
+}
+
+void MemoryTracker::setParent(MemoryTracker * elem)
+{
+    /// Untracked memory shouldn't be accounted to a query or a user if it was allocated before the thread was attached
+    /// to a query thread group or a user group, bacause this memory will be (🤞) freed outside of these scopes.
+    if (level == VariableContext::Thread && DB::current_thread)
+        DB::current_thread->flushUntrackedMemory();
+
+    parent.store(elem, std::memory_order_relaxed);
 }
 
 bool canEnqueueBackgroundTask()

--- a/src/Common/MemoryTracker.h
+++ b/src/Common/MemoryTracker.h
@@ -196,10 +196,7 @@ public:
 
     /// next should be changed only once: from nullptr to some value.
     /// NOTE: It is not true in MergeListElement
-    void setParent(MemoryTracker * elem)
-    {
-        parent.store(elem, std::memory_order_relaxed);
-    }
+    void setParent(MemoryTracker * elem);
 
     MemoryTracker * getParent()
     {

--- a/tests/queries/0_stateless/02896_memory_accounting_for_user.sh
+++ b/tests/queries/0_stateless/02896_memory_accounting_for_user.sh
@@ -1,31 +1,46 @@
 #!/usr/bin/env bash
-# Tags: no-parallel
+# Tags: no-parallel, long
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CUR_DIR"/../shell_config.sh
 
 
-total_iterations=1000
-iterations_in_parallel=8
+total_iterations=16
+parallelism=32
 
-$CLICKHOUSE_CLIENT --query='drop table if exists test_inserts'
-$CLICKHOUSE_CLIENT --query='create table test_inserts engine=Null AS system.numbers'
+$CLICKHOUSE_CLIENT --query='DROP TABLE IF EXISTS test_inserts'
+$CLICKHOUSE_CLIENT --query='CREATE TABLE test_inserts ENGINE=Null AS system.numbers'
 
-for ((i = 1; i <= $total_iterations; i++)); do
-    while true; do
-        running_jobs=$(jobs -p | wc -w)
-        if [ $running_jobs -lt $iterations_in_parallel ]; then
-            break
-        fi
-        sleep 0.01
-    done
-    (
-        (
-            $CLICKHOUSE_LOCAL --query='SELECT * FROM numbers(1000000)' | curl 'http://localhost:8123/?query=INSERT%20INTO%20test_inserts%20FORMAT%20TSV' --data-binary @- 2>/dev/null
-            $CLICKHOUSE_CLIENT -q "insert into test_inserts select * from numbers_mt(1e6)"
-            # $CLICKHOUSE_CLIENT --query="WITH (SELECT memory_usage FROM system.user_processes WHERE user='default') as user_mem, (SELECT value FROM system.metrics WHERE metric='MemoryTracking') AS system_mem SELECT throwIf(user_mem > system_mem) FORMAT Null"
-    ) &)
+run_query() {
+  ( $CLICKHOUSE_CLIENT --query='SELECT * FROM numbers_mt(1000000) FORMAT CSV' | $CLICKHOUSE_CLIENT --max_threads 8 --max_memory_usage_for_user 1073741824 -q 'INSERT INTO test_inserts FORMAT CSV' 2>/dev/null )
+}
+
+for ((i = 1; i <= total_iterations; i++)); do
+  for ((j = 1; j <= parallelism; j++)); do
+    run_query & pids+=($!)
+  done
+
+  EXIT_CODE=0
+  new_pids=()
+  for pid in "${pids[@]:0:parallelism}"; do
+    CODE=0
+    wait "${pid}" || CODE=$?
+    run_query & new_pids+=($!)
+    if [[ "${CODE}" != "0" ]]; then
+        EXIT_CODE=1;
+    fi
+  done
+  for pid in "${pids[@]:parallelism}"; do
+    CODE=0
+    wait "${pid}" || CODE=$?
+    if [[ "${CODE}" != "0" ]]; then
+        EXIT_CODE=1;
+    fi
+  done
+  pids=("${new_pids[@]}")
+
+  if [[ $EXIT_CODE -ne 0 ]]; then
+    exit $EXIT_CODE
+  fi
 done
-
-wait

--- a/tests/queries/0_stateless/02896_memory_accounting_for_user.sh
+++ b/tests/queries/0_stateless/02896_memory_accounting_for_user.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Tags: no-parallel
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+
+total_iterations=1000
+iterations_in_parallel=8
+
+$CLICKHOUSE_CLIENT --query='drop table if exists test_inserts'
+$CLICKHOUSE_CLIENT --query='create table test_inserts engine=Null AS system.numbers'
+
+for ((i = 1; i <= $total_iterations; i++)); do
+    while true; do
+        running_jobs=$(jobs -p | wc -w)
+        if [ $running_jobs -lt $iterations_in_parallel ]; then
+            break
+        fi
+        sleep 0.01
+    done
+    (
+        (
+            $CLICKHOUSE_LOCAL --query='SELECT * FROM numbers(1000000)' | curl 'http://localhost:8123/?query=INSERT%20INTO%20test_inserts%20FORMAT%20TSV' --data-binary @- 2>/dev/null
+            $CLICKHOUSE_CLIENT -q "insert into test_inserts select * from numbers_mt(1e6)"
+            # $CLICKHOUSE_CLIENT --query="WITH (SELECT memory_usage FROM system.user_processes WHERE user='default') as user_mem, (SELECT value FROM system.metrics WHERE metric='MemoryTracking') AS system_mem SELECT throwIf(user_mem > system_mem) FORMAT Null"
+    ) &)
+done
+
+wait


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed accounting of memory allocated before attaching thread to a query or a user.

Fixes: #55875