### PR TITLE
Make the code less bloated

### DIFF
--- a/src/Common/ErrorCodes.cpp
+++ b/src/Common/ErrorCodes.cpp
@@ -606,7 +606,7 @@ namespace ErrorCodes
     APPLY_FOR_ERROR_CODES(M)
 #undef M
 
-    constexpr ErrorCode END = 3000;
+    constexpr ErrorCode END = 1002;
     ErrorPairHolder values[END + 1]{};
 
     struct ErrorCodesNames


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


This variable took over 500 KB in the binary.