### PR TITLE
Remove old trash from unit tests

### DIFF
--- a/docker/test/unit/run.sh
+++ b/docker/test/unit/run.sh
@@ -2,5 +2,4 @@
 
 set -x
 
-service zookeeper start && sleep 7 && /usr/share/zookeeper/bin/zkCli.sh -server localhost:2181 -create create /clickhouse_test '';
 timeout 40m gdb -q  -ex 'set print inferior-events off' -ex 'set confirm off' -ex 'set print thread-events off' -ex run -ex bt -ex quit --args ./unit_tests_dbms --gtest_output='json:test_output/test_result.json' | tee test_output/test_result.txt


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


See https://s3.amazonaws.com/clickhouse-test-reports/56105/e6644c17736a07ad32dcf0a848dec05a94a3505a/unit_tests__asan_/run.log