### PR TITLE
Avoid problem with configuration queued.min.messages

### DIFF
--- a/src/Storages/Kafka/StorageKafka.cpp
+++ b/src/Storages/Kafka/StorageKafka.cpp
@@ -513,8 +513,9 @@ KafkaConsumerPtr StorageKafka::createConsumer(size_t consumer_number)
     // that allows to prevent fast draining of the librdkafka queue
     // during building of single insert block. Improves performance
     // significantly, but may lead to bigger memory consumption.
-    size_t default_queued_min_messages = 100000; // we don't want to decrease the default
-    conf.set("queued.min.messages", std::max(getMaxBlockSize(),default_queued_min_messages));
+    size_t default_queued_min_messages = 100000; // must be greater than or equal to default
+    size_t max_allowed_queued_min_messages = 10000000; // must be less than or equal to max allowed value
+    conf.set("queued.min.messages", std::min(std::max(getMaxBlockSize(), default_queued_min_messages), max_allowed_queued_min_messages));
 
     /// a reference to the consumer is needed in statistic callback
     /// although the consumer does not exist when callback is being registered


### PR DESCRIPTION
Parameter "queued.min.messages" defines automatically using kafka_max_block_size or max_insert_block_size, but we should limit max value because server can't run consumers to fetch data from Kafka if this parameter is greater then allowed.


### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Set limit of the maximum configuration value for queued.min.messages to avoid problem with start fetching data with Kafka
