### PR TITLE
Beautify `show merges`

### DIFF
--- a/docs/en/sql-reference/statements/show.md
+++ b/docs/en/sql-reference/statements/show.md
@@ -656,6 +656,15 @@ If either `LIKE` or `ILIKE` clause is specified, the query returns a list of sys
 
 Returns a list of merges. All merges are listed in the [system.merges](../../operations/system-tables/merges.md) table.
 
+- `table` -- Table name.
+- `database` -- The name of the database the table is in.
+- `estimate_complete` -- The estimated time to complete (in seconds).
+- `elapsed` -- The time elapsed (in seconds) since the merge started.
+- `progress` -- The percentage of completed work (0-100 percent).
+- `is_mutation` -- 1 if this process is a part mutation.
+- `size_compressed` -- The total size of the compressed data of the merged parts.
+- `memory_usage` -- Memory consumption of the merge process.
+
 
 **Syntax**
 
@@ -674,10 +683,9 @@ SHOW MERGES;
 Result:
 
 ```text
-┌─table──────┬─database─┬─estimate_complete─┬─────elapsed─┬─progress─┬─is_mutation─┬─size─────┬─mem───────┐
-│ your_table │ default  │              0.14 │ 0.365592338 │     0.73 │           0 │ 5.40 MiB │ 10.25 MiB │
-└────────────┴──────────┴───────────────────┴─────────────┴──────────┴─────────────┴────────────┴─────────┘
-
+┌─table──────┬─database─┬─estimate_complete─┬─elapsed─┬─progress─┬─is_mutation─┬─size_compressed─┬─memory_usage─┐
+│ your_table │ default  │              0.14 │    0.36 │    73.01 │           0 │        5.40 MiB │    10.25 MiB │
+└────────────┴──────────┴───────────────────┴─────────┴──────────┴─────────────┴─────────────────┴──────────────┘
 ```
 
 Query:
@@ -689,9 +697,8 @@ SHOW MERGES LIKE 'your_t%' LIMIT 1;
 Result:
 
 ```text
-┌─table──────┬─database─┬─estimate_complete─┬─────elapsed─┬─progress─┬─is_mutation─┬─size─────┬─mem───────┐
-│ your_table │ default  │              0.05 │ 1.727629065 │     0.97 │           0 │ 5.40 MiB │ 10.25 MiB │
-└────────────┴──────────┴───────────────────┴─────────────┴──────────┴─────────────┴────────────┴─────────┘
-
+┌─table──────┬─database─┬─estimate_complete─┬─elapsed─┬─progress─┬─is_mutation─┬─size_compressed─┬─memory_usage─┐
+│ your_table │ default  │              0.14 │    0.36 │    73.01 │           0 │        5.40 MiB │    10.25 MiB │
+└────────────┴──────────┴───────────────────┴─────────┴──────────┴─────────────┴─────────────────┴──────────────┘
 ```
 

--- a/src/Interpreters/InterpreterShowTablesQuery.cpp
+++ b/src/Interpreters/InterpreterShowTablesQuery.cpp
@@ -120,9 +120,9 @@ String InterpreterShowTablesQuery::getRewrittenQuery()
     if (query.merges)
     {
         WriteBufferFromOwnString rewritten_query;
-        rewritten_query << "SELECT table, database, round((elapsed * (1 / progress)) - elapsed, 2) AS estimate_complete, elapsed, "
-                           "round(progress, 2) AS progress, is_mutation, formatReadableSize(total_size_bytes_compressed) AS size, "
-                           "formatReadableSize(memory_usage) AS mem FROM system.merges";
+        rewritten_query << "SELECT table, database, round((elapsed * (1 / merges.progress)) - merges.elapsed, 2) AS estimate_complete, round(elapsed,2) elapsed, "
+                           "round(progress*100, 2) AS progress, is_mutation, formatReadableSize(total_size_bytes_compressed) AS size_compressed, "
+                           "formatReadableSize(memory_usage) AS memory_usage FROM system.merges";
 
         if (!query.like.empty())
         {


### PR DESCRIPTION
Reduced precision of elapsed
Progress in % 0-100
Renamed size column to size_compressed
Renamed mem column to memory_usage

```
was
┌─table─────┬─database─┬─estimate_complete─┬─────elapsed─┬─progress─┬─is_mutation─┬─size─────┬─mem───────┐
│ two_disks │ default  │              5.54 │ 10.76121776 │     0.66 │           0 │ 2.56 GiB │ 97.46 MiB │
└───────────┴──────────┴───────────────────┴─────────────┴──────────┴─────────────┴──────────┴───────────┘

now
┌─table─────┬─database─┬─estimate_complete─┬─elapsed─┬─progress─┬─is_mutation─┬─size_compressed─┬─memory_usage─┐
│ two_disks │ default  │              12.9 │    5.12 │    28.41 │           0 │ 3.19 GiB        │ 32.55 MiB    │
└───────────┴──────────┴───────────────────┴─────────┴──────────┴─────────────┴─────────────────┴──────────────┘
```

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

