### PR TITLE
Fix: incorrect brace style in clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -53,7 +53,6 @@ ReflowComments: false
 AlignEscapedNewlinesLeft: false
 AlignEscapedNewlines: DontAlign
 AlignTrailingComments: false
-InsertBraces: WrapLikely
 
 # Not changed:
 AccessModifierOffset: -4


### PR DESCRIPTION
`.clang-format` was updated incorrectly in #54947

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)