### PR TITLE
Fixed spelling of "Continous" to "Continuous"

### DIFF
--- a/src/Functions/minSampleSize.cpp
+++ b/src/Functions/minSampleSize.cpp
@@ -79,9 +79,9 @@ static bool isBetweenZeroAndOne(Float64 v)
     return v >= 0.0 && v <= 1.0 && fabs(v - 0.0) >= DBL_EPSILON && fabs(v - 1.0) >= DBL_EPSILON;
 }
 
-struct ContinousImpl
+struct ContinuousImpl
 {
-    static constexpr auto name = "minSampleSizeContinous";
+    static constexpr auto name = "minSampleSizeContinuous";
     static constexpr size_t num_args = 5;
     static constexpr size_t const_args[] = {2, 3, 4};
 
@@ -284,7 +284,9 @@ struct ConversionImpl
 
 REGISTER_FUNCTION(MinSampleSize)
 {
-    factory.registerFunction<FunctionMinSampleSize<ContinousImpl>>();
+    factory.registerFunction<FunctionMinSampleSize<ContinuousImpl>>();
+    /// Needed for backward compatibility
+    factory.registerAlias("minSampleSizeContinuous", FunctionMinSampleSize<ContinuousImpl>::name);
     factory.registerFunction<FunctionMinSampleSize<ConversionImpl>>();
 }
 

--- a/src/Functions/minSampleSize.cpp
+++ b/src/Functions/minSampleSize.cpp
@@ -286,7 +286,7 @@ REGISTER_FUNCTION(MinSampleSize)
 {
     factory.registerFunction<FunctionMinSampleSize<ContinuousImpl>>();
     /// Needed for backward compatibility
-    factory.registerAlias("minSampleSizeContinuous", FunctionMinSampleSize<ContinuousImpl>::name);
+    factory.registerAlias("minSampleSizeContinous", FunctionMinSampleSize<ContinuousImpl>::name);
     factory.registerFunction<FunctionMinSampleSize<ConversionImpl>>();
 }
 

--- a/tests/queries/0_stateless/02415_all_new_functions_must_be_documented.reference
+++ b/tests/queries/0_stateless/02415_all_new_functions_must_be_documented.reference
@@ -433,7 +433,7 @@ materialize
 max2
 metroHash64
 min2
-minSampleSizeContinous
+minSampleSizeContinuous
 minSampleSizeConversion
 minus
 modulo


### PR DESCRIPTION
### Changelog category (leave one):

- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed typo in SQL function `minSampleSizeContinous` (renamed `minSampleSizeContinuous`). Old name is preserved for backward compatibility. This closes: https://github.com/ClickHouse/ClickHouse/issues/56139
