### PR TITLE
Set exceptions bit when using std::[io]stringstream

### DIFF
--- a/programs/copier/Internals.cpp
+++ b/programs/copier/Internals.cpp
@@ -19,6 +19,7 @@ using ConfigurationPtr = Poco::AutoPtr<Poco::Util::AbstractConfiguration>;
 ConfigurationPtr getConfigurationFromXMLString(const std::string & xml_data)
 {
     std::stringstream ss(xml_data);         // STYLE_CHECK_ALLOW_STD_STRING_STREAM
+    // Can't set exceptions because Poco::XML parser generates errors on valid input
     Poco::XML::InputSource input_source{ss};
     return {new Poco::Util::XMLConfiguration{&input_source}};
 }

--- a/programs/local/LocalServer.cpp
+++ b/programs/local/LocalServer.cpp
@@ -360,6 +360,7 @@ std::string LocalServer::getInitialCreateTableQuery()
 static ConfigurationPtr getConfigurationFromXMLString(const char * xml_data)
 {
     std::stringstream ss{std::string{xml_data}};    // STYLE_CHECK_ALLOW_STD_STRING_STREAM
+    // Can't set exceptions because Poco::XML parser generates errors on valid input
     Poco::XML::InputSource input_source{ss};
     return {new Poco::Util::XMLConfiguration{&input_source}};
 }

--- a/src/Daemon/BaseDaemon.cpp
+++ b/src/Daemon/BaseDaemon.cpp
@@ -772,6 +772,7 @@ void BaseDaemon::initialize(Application & self)
     {
         std::string umask_str = config().getString("umask");
         std::stringstream stream; // STYLE_CHECK_ALLOW_STD_STRING_STREAM
+        stream.exceptions(std::ios::failbit);
         stream << umask_str;
         stream >> std::oct >> umask_num;
     }

--- a/src/Daemon/BaseDaemon.cpp
+++ b/src/Daemon/BaseDaemon.cpp
@@ -772,7 +772,6 @@ void BaseDaemon::initialize(Application & self)
     {
         std::string umask_str = config().getString("umask");
         std::stringstream stream; // STYLE_CHECK_ALLOW_STD_STRING_STREAM
-        stream.exceptions(std::ios::failbit);
         stream << umask_str;
         stream >> std::oct >> umask_num;
     }

--- a/src/Functions/FunctionSQLJSON.h
+++ b/src/Functions/FunctionSQLJSON.h
@@ -41,7 +41,7 @@ template <typename Element>
 class DefaultJSONStringSerializer
 {
 public:
-    explicit DefaultJSONStringSerializer(ColumnString & col_str_) : col_str(col_str_) { }
+    explicit DefaultJSONStringSerializer(ColumnString & col_str_) : col_str(col_str_) { out.exceptions(std::ios::failbit); }
 
     inline void addRawData(const char * ptr, size_t len)
     {

--- a/src/Functions/svg.cpp
+++ b/src/Functions/svg.cpp
@@ -80,6 +80,7 @@ public:
             for (size_t i = 0; i < input_rows_count; ++i)
             {
                 std::stringstream str; // STYLE_CHECK_ALLOW_STD_STRING_STREAM
+                str.exceptions(std::ios::failbit);
                 boost::geometry::correct(figures[i]);
                 str << boost::geometry::svg(figures[i], has_style ? style->getDataAt(i).toString() : "");
                 std::string serialized = str.str();

--- a/src/Loggers/Loggers.cpp
+++ b/src/Loggers/Loggers.cpp
@@ -46,6 +46,7 @@ static std::string renderFileNameTemplate(time_t now, const std::string & file_p
     std::tm buf;
     localtime_r(&now, &buf);
     std::ostringstream ss; // STYLE_CHECK_ALLOW_STD_STRING_STREAM
+    ss.exceptions(std::ios::failbit);
     ss << std::put_time(&buf, path.filename().c_str());
     return path.replace_filename(ss.str());
 }

--- a/src/Server/HTTP/HTMLForm.cpp
+++ b/src/Server/HTTP/HTMLForm.cpp
@@ -75,7 +75,7 @@ HTMLForm::HTMLForm(const Settings & settings, const Poco::Net::HTTPRequest & req
 
 HTMLForm::HTMLForm(const Settings & settings, const Poco::URI & uri) : HTMLForm(settings)
 {
-    ReadBufferFromString istr(uri.getRawQuery());  // STYLE_CHECK_ALLOW_STD_STRING_STREAM
+    ReadBufferFromString istr(uri.getRawQuery());
     readQuery(istr);
 }
 

--- a/src/Storages/Cache/RemoteCacheController.cpp
+++ b/src/Storages/Cache/RemoteCacheController.cpp
@@ -189,6 +189,7 @@ void RemoteCacheController::flush(bool need_flush_status)
         jobj.set("file_status", static_cast<Int32>(file_status));
         jobj.set("metadata_class", metadata_class);
         std::stringstream buf; // STYLE_CHECK_ALLOW_STD_STRING_STREAM
+        buf.exceptions(std::ios::failbit);
         jobj.stringify(buf);
         file_writer->write(buf.str().c_str(), buf.str().size());
         file_writer->close();

--- a/src/Storages/Hive/StorageHiveMetadata.cpp
+++ b/src/Storages/Hive/StorageHiveMetadata.cpp
@@ -19,6 +19,7 @@ String StorageHiveMetadata::toString() const
     jobj.set("last_modification_timestamp", last_modification_timestamp);
     jobj.set("file_size", file_size);
     std::stringstream buf; // STYLE_CHECK_ALLOW_STD_STRING_STREAM
+    buf.exceptions(std::ios::failbit);
     jobj.stringify(buf);
     return buf.str();
 
@@ -27,6 +28,7 @@ String StorageHiveMetadata::toString() const
 bool StorageHiveMetadata::fromString(const String &buf)
 {
     std::stringstream istream; // STYLE_CHECK_ALLOW_STD_STRING_STREAM
+    istream.exceptions(std::ios::failbit);
     istream << buf;
     Poco::JSON::Parser parser;
     auto jobj = parser.parse(istream).extract<Poco::JSON::Object::Ptr>();
@@ -34,7 +36,7 @@ bool StorageHiveMetadata::fromString(const String &buf)
     schema = jobj->get("schema").convert<String>();
     cluster = jobj->get("cluster").convert<String>();
     last_modification_timestamp = jobj->get("last_modification_timestamp").convert<UInt64>();
-    file_size =jobj->get("file_size").convert<UInt64>();
+    file_size = jobj->get("file_size").convert<UInt64>();
     return true;
 }
 

--- a/utils/self-extracting-executable/decompressor.cpp
+++ b/utils/self-extracting-executable/decompressor.cpp
@@ -390,6 +390,7 @@ uint64_t getInode(const char * self)
     for (std::string line; std::getline(maps, line);)
     {
         std::stringstream ss(line); // STYLE_CHECK_ALLOW_STD_STRING_STREAM
+        ss.exceptions(std::ios::failbit);
         std::string addr, mode, offset, id, path;
         uint64_t inode = 0;
         if (ss >> addr >> mode >> offset >> id >> inode >> path && path == self)
@@ -441,6 +442,7 @@ int main(int/* argc*/, char* argv[])
     }
 
     std::stringstream lock_path; // STYLE_CHECK_ALLOW_STD_STRING_STREAM
+    lock_path.exceptions(std::ios::failbit);
     lock_path << "/tmp/" << name << ".decompression." << inode << ".lock";
     int lock = open(lock_path.str().c_str(), O_CREAT | O_RDWR, 0666);
     if (lock < 0)

--- a/utils/zookeeper-cli/zookeeper-cli.cpp
+++ b/utils/zookeeper-cli/zookeeper-cli.cpp
@@ -81,6 +81,7 @@ int main(int argc, char ** argv)
             try
             {
                 std::stringstream ss(line);     // STYLE_CHECK_ALLOW_STD_STRING_STREAM
+                ss.exceptions(std::ios::failbit);
 
                 std::string cmd;
                 ss >> cmd;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

By default std streams don't throw exceptions, which is not what we expect. There were quite a few places missing setting the bit to change the behaviour

Context: https://github.com/ClickHouse/ClickHouse/pull/56112#discussion_r1375601828

