### PR TITLE
Add more details to "Data after merge is not byte-identical to data on another replicas"

### DIFF
--- a/src/Storages/MergeTree/IMergeTreeDataPart.h
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.h
@@ -364,6 +364,7 @@ public:
     void setBytesOnDisk(UInt64 bytes_on_disk_) { bytes_on_disk = bytes_on_disk_; }
 
     size_t getFileSizeOrZero(const String & file_name) const;
+    auto getFilesChecksums() const { return checksums.files; }
 
     /// Moves a part to detached/ directory and adds prefix to its name
     void renameToDetached(const String & prefix);

--- a/src/Storages/MergeTree/MergeFromLogEntryTask.cpp
+++ b/src/Storages/MergeTree/MergeFromLogEntryTask.cpp
@@ -357,6 +357,13 @@ bool MergeFromLogEntryTask::finalize(ReplicatedMergeMutateTaskBase::PartLogWrite
 
             ProfileEvents::increment(ProfileEvents::DataAfterMergeDiffersFromReplica);
 
+            Strings files_with_size;
+            for (const auto & file : part->getFilesChecksums())
+            {
+                files_with_size.push_back(fmt::format("{}: {} ({})",
+                    file.first, file.second.file_size, getHexUIntLowercase(file.second.file_hash)));
+            }
+
             LOG_ERROR(log,
                 "{}. Data after merge is not byte-identical to data on another replicas. There could be several reasons:"
                 " 1. Using newer version of compression library after server update."
@@ -368,8 +375,10 @@ bool MergeFromLogEntryTask::finalize(ReplicatedMergeMutateTaskBase::PartLogWrite
                 " 7. Manual modification of source data after server startup."
                 " 8. Manual modification of checksums stored in ZooKeeper."
                 " 9. Part format related settings like 'enable_mixed_granularity_parts' are different on different replicas."
-                " We will download merged part from replica to force byte-identical result.",
-                getCurrentExceptionMessage(false));
+                " We will download merged part from replica to force byte-identical result."
+                " List of files in local parts:\n{}",
+                getCurrentExceptionMessage(false),
+                fmt::join(files_with_size, "\n"));
 
             write_part_log(ExecutionStatus::fromCurrentException("", true));
 

--- a/src/Storages/MergeTree/MergeTreeDataPartChecksum.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataPartChecksum.cpp
@@ -34,15 +34,27 @@ void MergeTreeDataPartChecksum::checkEqual(const MergeTreeDataPartChecksum & rhs
         if (!rhs.is_compressed)
             throw Exception(ErrorCodes::CHECKSUM_DOESNT_MATCH, "No uncompressed checksum for file {}", name);
         if (rhs.uncompressed_size != uncompressed_size)
-            throw Exception(ErrorCodes::BAD_SIZE_OF_FILE_IN_DATA_PART, "Unexpected uncompressed size of file {} in data part", name);
+        {
+            throw Exception(ErrorCodes::BAD_SIZE_OF_FILE_IN_DATA_PART, "Unexpected uncompressed size of file {} in data part ({} vs {})",
+                name, uncompressed_size, rhs.uncompressed_size);
+        }
         if (rhs.uncompressed_hash != uncompressed_hash)
-            throw Exception(ErrorCodes::CHECKSUM_DOESNT_MATCH, "Checksum mismatch for uncompressed file {} in data part", name);
+        {
+            throw Exception(ErrorCodes::CHECKSUM_DOESNT_MATCH, "Checksum mismatch for uncompressed file {} in data part ({} vs {})",
+                name, getHexUIntLowercase(uncompressed_hash), getHexUIntLowercase(rhs.uncompressed_hash));
+        }
         return;
     }
     if (rhs.file_size != file_size)
-        throw Exception(ErrorCodes::BAD_SIZE_OF_FILE_IN_DATA_PART, "Unexpected size of file {} in data part", name);
+    {
+        throw Exception(ErrorCodes::BAD_SIZE_OF_FILE_IN_DATA_PART, "Unexpected size of file {} in data part ({} vs {})",
+            name, file_size, rhs.file_size);
+    }
     if (rhs.file_hash != file_hash)
-        throw Exception(ErrorCodes::CHECKSUM_DOESNT_MATCH, "Checksum mismatch for file {} in data part", name);
+    {
+        throw Exception(ErrorCodes::CHECKSUM_DOESNT_MATCH, "Checksum mismatch for file {} in data part ({} vs {})",
+            name, getHexUIntLowercase(file_hash), getHexUIntLowercase(rhs.file_hash));
+    }
 }
 
 void MergeTreeDataPartChecksum::checkSize(const IDataPartStorage & storage, const String & name) const
@@ -446,17 +458,29 @@ void MinimalisticDataPartChecksums::checkEqualImpl(const MinimalisticDataPartChe
     Strings errors;
 
     if (hash_of_uncompressed_files != rhs.hash_of_uncompressed_files)
-        errors.emplace_back("hash of uncompressed files doesn't match");
+    {
+        errors.emplace_back(fmt::format("hash of uncompressed files doesn't match ({} vs {})",
+            getHexUIntLowercase(hash_of_uncompressed_files),
+            getHexUIntLowercase(rhs.hash_of_uncompressed_files)));
+    }
 
     if (check_uncompressed_hash_in_compressed_files)
     {
         if (uncompressed_hash_of_compressed_files != rhs.uncompressed_hash_of_compressed_files)
-            errors.emplace_back("uncompressed hash of compressed files doesn't match");
+        {
+            errors.emplace_back(fmt::format("uncompressed hash of compressed files doesn't match ({} vs {})",
+                getHexUIntLowercase(uncompressed_hash_of_compressed_files),
+                getHexUIntLowercase(rhs.uncompressed_hash_of_compressed_files)));
+        }
     }
     else
     {
         if (hash_of_all_files != rhs.hash_of_all_files)
-            errors.emplace_back("total hash of all files doesn't match");
+        {
+            errors.emplace_back(fmt::format("total hash of all files doesn't match ({} vs {})",
+                getHexUIntLowercase(hash_of_all_files),
+                getHexUIntLowercase(rhs.hash_of_all_files)));
+        }
     }
 
     if (!errors.empty())


### PR DESCRIPTION
It should be a very rare error, but in case of error you need as much details as there are:
- print mismatched info (hash, size)
- print all files with size and checksum (this may help for instance when new file is added, or when extesion changed -- compression marks)

P.S. maybe detach_not_byte_identical_parts should be enabled by default? Thoughts?

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Cc: @tavplubix 