### PR TITLE
Fix schema cache for fallback JSON->JSONEachRow with changed settings

### DIFF
--- a/src/Processors/Formats/Impl/JSONRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/JSONRowInputFormat.cpp
@@ -1,6 +1,7 @@
 #include <Processors/Formats/Impl/JSONRowInputFormat.h>
 #include <Formats/JSONUtils.h>
 #include <Formats/FormatFactory.h>
+#include <Formats/EscapingRuleUtils.h>
 #include <IO/ReadHelpers.h>
 
 namespace DB
@@ -134,6 +135,11 @@ void registerJSONSchemaReader(FormatFactory & factory)
     {
         factory.registerSchemaReader(
             format, [](ReadBuffer & buf, const FormatSettings & format_settings) { return std::make_unique<JSONRowSchemaReader>(buf, format_settings); });
+
+        factory.registerAdditionalInfoForSchemaCacheGetter(format, [](const FormatSettings & settings)
+        {
+            return getAdditionalFormatInfoByEscapingRule(settings, FormatSettings::EscapingRule::JSON);
+        });
     };
     register_schema_reader("JSON");
     /// JSONCompact has the same suffix with metadata.

--- a/tests/queries/0_stateless/02909_settings_in_json_schema_cache.reference
+++ b/tests/queries/0_stateless/02909_settings_in_json_schema_cache.reference
@@ -1,0 +1,3 @@
+x	Nullable(Int64)					
+x	Int64					
+2

--- a/tests/queries/0_stateless/02909_settings_in_json_schema_cache.sh
+++ b/tests/queries/0_stateless/02909_settings_in_json_schema_cache.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+echo '{"x" : 42}' > $CLICKHOUSE_TEST_UNIQUE_NAME.json
+$CLICKHOUSE_LOCAL -nm -q "
+DESC file('$CLICKHOUSE_TEST_UNIQUE_NAME.json') SETTINGS schema_inference_make_columns_nullable=1;
+DESC file('$CLICKHOUSE_TEST_UNIQUE_NAME.json') SETTINGS schema_inference_make_columns_nullable=0;
+SELECT count() from system.schema_inference_cache where format = 'JSON' and additional_format_info like '%schema_inference_make_columns_nullable%';"
+
+rm $CLICKHOUSE_TEST_UNIQUE_NAME.json
+


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix schema cache for fallback JSON->JSONEachRow with changed settings

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
