### PR TITLE
AggregateFunctionNullVariadic without serialize flag

### DIFF
--- a/src/AggregateFunctions/Combinators/AggregateFunctionNull.cpp
+++ b/src/AggregateFunctions/Combinators/AggregateFunctionNull.cpp
@@ -21,6 +21,14 @@ namespace
 
 class AggregateFunctionCombinatorNull final : public IAggregateFunctionCombinator
 {
+    using AggregateFunctionNullUnaryNullable = AggregateFunctionNullUnary<true, true>;
+    using AggregateFunctionNullUnaryWithSerialize = AggregateFunctionNullUnary<false, true>;
+    using AggregateFunctionNullUnaryNoSerialize = AggregateFunctionNullUnary<false, false>;
+
+    using AggregateFunctionNullVariadicNullable = AggregateFunctionNullVariadic<true, true>;
+    using AggregateFunctionNullVariadicWithSerialize = AggregateFunctionNullVariadic<false, true>;
+    using AggregateFunctionNullVariadicNoSerialize = AggregateFunctionNullVariadic<false, false>;
+
 public:
     String getName() const override { return "Null"; }
 
@@ -119,35 +127,35 @@ public:
             return new_function;
         }
 
-        bool return_type_is_nullable = !properties.returns_default_when_only_null && nested_function->getResultType()->canBeInsideNullable();
-        bool serialize_flag = return_type_is_nullable || properties.returns_default_when_only_null;
+        const bool return_type_is_nullable = !properties.returns_default_when_only_null && nested_function->getResultType()->canBeInsideNullable();
+        const bool serialize_flag = return_type_is_nullable || properties.returns_default_when_only_null;
 
         if (arguments.size() == 1)
         {
             if (return_type_is_nullable)
             {
-                return std::make_shared<AggregateFunctionNullUnary<true, true>>(nested_function, arguments, params);
+                return std::make_shared<AggregateFunctionNullUnaryNullable>(nested_function, arguments, params);
             }
             else
             {
                 if (serialize_flag)
-                    return std::make_shared<AggregateFunctionNullUnary<false, true>>(nested_function, arguments, params);
+                    return std::make_shared<AggregateFunctionNullUnaryWithSerialize>(nested_function, arguments, params);
                 else
-                    return std::make_shared<AggregateFunctionNullUnary<false, false>>(nested_function, arguments, params);
+                    return std::make_shared<AggregateFunctionNullUnaryNoSerialize>(nested_function, arguments, params);
             }
         }
         else
         {
             if (return_type_is_nullable)
             {
-                return std::make_shared<AggregateFunctionNullVariadic<true, true>>(nested_function, arguments, params);
+                return std::make_shared<AggregateFunctionNullVariadicNullable>(nested_function, arguments, params);
             }
             else
             {
                 if (serialize_flag)
-                    return std::make_shared<AggregateFunctionNullVariadic<false, true>>(nested_function, arguments, params);
+                    return std::make_shared<AggregateFunctionNullVariadicWithSerialize>(nested_function, arguments, params);
                 else
-                    return std::make_shared<AggregateFunctionNullVariadic<false, true>>(nested_function, arguments, params);
+                    return std::make_shared<AggregateFunctionNullVariadicNoSerialize>(nested_function, arguments, params);
             }
         }
     }


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

There are 2 equal expression in then and else for creating AggregateFunctionNullVariadic. Althought quick fix  (I mean change <false, true>) solves problem, it seems to me that problem can reappear again. Good idea use alias for types which diffrent only one type of template argument.

I'm not sure I've chosen the right specialization.

Please, let me know if need to improve something.


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
