### PR TITLE
Add `max_bytes_before_external_sort` setting to query complexity doc

### DIFF
--- a/docs/en/operations/settings/query-complexity.md
+++ b/docs/en/operations/settings/query-complexity.md
@@ -106,6 +106,15 @@ Possible values:
 
 Default value: 0.
 
+## max_bytes_before_external_sort {#settings-max_bytes_before_external_sort}
+
+Enables or disables execution of `ORDER BY` clauses in external memory. See [ORDER BY Implementation Details](../../sql-reference/statements/select/order-by.md#implementation-details)
+
+- Maximum volume of RAM (in bytes) that can be used by the single [ORDER BY](../../sql-reference/statements/select/order-by.md) operation. Recommended value is half of available system memory
+- 0 — `ORDER BY` in external memory disabled.
+
+Default value: 0.
+
 ## max_rows_to_sort {#max-rows-to-sort}
 
 A maximum number of rows before sorting. This allows you to limit memory consumption when sorting.

--- a/docs/ru/operations/settings/query-complexity.md
+++ b/docs/ru/operations/settings/query-complexity.md
@@ -108,6 +108,15 @@ sidebar_label: "Ограничения на сложность запроса"
 
 Значение по умолчанию — 0.
 
+## max_bytes_before_external_sort {#settings-max_bytes_before_external_sort}
+
+Включает или отключает выполнение предложений `ORDER BY` во внешней памяти. См. [ORDER BY Подробности реализации](../../sql-reference/statements/select/order-by.md#implementation-details)
+
+- Максимальный объем оперативной памяти (в байтах), который может использоваться одной операцией [ORDER BY](../../sql-reference/statements/select/order-by.md). Рекомендуемое значение — половина доступной системной памяти.
+- 0 — `ORDER BY` во внешней памяти отключен.
+
+Значение по умолчанию: 0.
+
 ## max_rows_to_sort {#max-rows-to-sort}
 
 Максимальное количество строк до сортировки. Позволяет ограничить потребление оперативки при сортировке.

--- a/docs/ru/operations/settings/query-complexity.md
+++ b/docs/ru/operations/settings/query-complexity.md
@@ -110,7 +110,7 @@ sidebar_label: "Ограничения на сложность запроса"
 
 ## max_bytes_before_external_sort {#settings-max_bytes_before_external_sort}
 
-Включает или отключает выполнение предложений `ORDER BY` во внешней памяти. См. [ORDER BY Подробности реализации](../../sql-reference/statements/select/order-by.md#implementation-details)
+Включает или отключает выполнение `ORDER BY` во внешней памяти. См. [Детали реализации ORDER BY](../../sql-reference/statements/select/order-by.md#implementation-details)
 
 - Максимальный объем оперативной памяти (в байтах), который может использоваться одной операцией [ORDER BY](../../sql-reference/statements/select/order-by.md). Рекомендуемое значение — половина доступной системной памяти.
 - 0 — `ORDER BY` во внешней памяти отключен.


### PR DESCRIPTION
The setting should be mentioned here along with
`max_bytes_before_group_by` setting.

Note: The russian translation is courtesy of Google Translate.

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
