### PR TITLE
Improve integrations tests

### DIFF
--- a/tests/integration/ci-runner.py
+++ b/tests/integration/ci-runner.py
@@ -436,13 +436,15 @@ class ClickhouseIntegrationTestsRunner:
         cmd = (
             f"cd {repo_path}/tests/integration && "
             f"timeout --signal=KILL 1h ./runner {runner_opts} {image_cmd} -- --setup-plan "
-            f"| tee '{out_file_full}'"
         )
 
-        logging.info("Getting all tests with cmd '%s'", cmd)
-        subprocess.check_call(  # STYLE_CHECK_ALLOW_SUBPROCESS_CHECK_CALL
-            cmd, shell=True
+        logging.info(
+            "Getting all tests to the file %s with cmd: \n%s", out_file_full, cmd
         )
+        with open(out_file_full, "wb") as ofd:
+            subprocess.check_call(  # STYLE_CHECK_ALLOW_SUBPROCESS_CHECK_CALL
+                cmd, shell=True, stdout=ofd, stderr=ofd
+            )
 
         all_tests = set()
         with open(out_file_full, "r", encoding="utf-8") as all_tests_fd:


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
In #54043 the setup plan started to appear in the logs. It should be only in the `runner_get_all_tests.log` only. As well, send the failed infrastructure event to CI db.
