### PR TITLE
Correct aggregate function cross tab accessors to be endianness-independent.

### DIFF
--- a/src/AggregateFunctions/AggregateFunctionTheilsU.cpp
+++ b/src/AggregateFunctions/AggregateFunctionTheilsU.cpp
@@ -34,7 +34,7 @@ struct TheilsUData : CrossTabData
         for (const auto & [key, value] : count_ab)
         {
             Float64 value_ab = value;
-            Float64 value_b = count_b.at(key.items[1]);
+            Float64 value_b = count_b.at(key.items[UInt128::_impl::little(1)]);
 
             dep += (value_ab / count) * log(value_ab / value_b);
         }

--- a/src/AggregateFunctions/CrossTab.h
+++ b/src/AggregateFunctions/CrossTab.h
@@ -98,8 +98,8 @@ struct CrossTabData
         Float64 chi_squared = 0;
         for (const auto & [key, value_ab] : count_ab)
         {
-            Float64 value_a = count_a.at(key.items[0]);
-            Float64 value_b = count_b.at(key.items[1]);
+            Float64 value_a = count_a.at(key.items[UInt128::_impl::little(0)]);
+            Float64 value_b = count_b.at(key.items[UInt128::_impl::little(1)]);
 
             Float64 expected_value_ab = (value_a * value_b) / count;
 

--- a/src/Common/HashTable/Hash.h
+++ b/src/Common/HashTable/Hash.h
@@ -358,7 +358,7 @@ struct UInt128Hash
 {
     size_t operator()(UInt128 x) const
     {
-        return CityHash_v1_0_2::Hash128to64({x.items[0], x.items[1]});
+        return CityHash_v1_0_2::Hash128to64({x.items[UInt128::_impl::little(0)], x.items[UInt128::_impl::little(1)]});
     }
 };
 


### PR DESCRIPTION
Fixed an issue where `AggregateFunctionCrossTab` functions would inadvertently use the wrong _half_ of the `UInt128`s underlying `wide_integer`. This ultimately causing a `LOGICAL_ERROR` error to be thrown from `HashTable::at` on Big Endian platforms. The primary functional test that this PR addresses is `02158_contingency` on s390x.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Documentation entry for user-facing changes
- [ ] Documentation is written (mandatory for new features)