### PR TITLE
Doc. note how to enable OSIOWaitMicroseconds in new Linux kernels

### DIFF
--- a/docs/en/operations/system-tables/index.md
+++ b/docs/en/operations/system-tables/index.md
@@ -78,6 +78,11 @@ If procfs is supported and enabled on the system, ClickHouse server collects the
 - `OSReadBytes`
 - `OSWriteBytes`
 
+:::note
+OSIOWaitMicroseconds is disabled by default in Linux Kernels starting from 5.14.x.
+You can enable it using `sudo sysctl kernel.task_delayacct=1` or by creating a .conf file in /etc/sysctl.d/ with `kernel.task_delayacct = 1`
+:::
+
 ## Related content
 
 - Blog: [System Tables and a window into the internals of ClickHouse](https://clickhouse.com/blog/clickhouse-debugging-issues-with-system-tables)

--- a/docs/en/operations/system-tables/index.md
+++ b/docs/en/operations/system-tables/index.md
@@ -79,8 +79,8 @@ If procfs is supported and enabled on the system, ClickHouse server collects the
 - `OSWriteBytes`
 
 :::note
-OSIOWaitMicroseconds is disabled by default in Linux Kernels starting from 5.14.x.
-You can enable it using `sudo sysctl kernel.task_delayacct=1` or by creating a .conf file in /etc/sysctl.d/ with `kernel.task_delayacct = 1`
+`OSIOWaitMicroseconds` is disabled by default in Linux kernels starting from 5.14.x.
+You can enable it using `sudo sysctl kernel.task_delayacct=1` or by creating a `.conf` file in `/etc/sysctl.d/` with `kernel.task_delayacct = 1`
 :::
 
 ## Related content

--- a/utils/check-style/aspell-ignore/en/aspell-dict.txt
+++ b/utils/check-style/aspell-ignore/en/aspell-dict.txt
@@ -590,6 +590,7 @@ OSGuestTimeNormalized
 OSIOWaitTime
 OSIOWaitTimeCPU
 OSIOWaitTimeNormalized
+OSIOWaitMicroseconds
 OSIdleTime
 OSIdleTimeCPU
 OSIdleTimeNormalized
@@ -2360,6 +2361,7 @@ symlinks
 syntaxes
 syscall
 syscalls
+sysctl
 syslog
 syslogd
 systemd


### PR DESCRIPTION
related https://github.com/ClickHouse/ClickHouse/issues/55998

### Changelog category (leave one):
- Documentation (changelog entry is not required)
