### PR TITLE
Add a warning if delayed accounting is not enabled (breaks OSIOWaitMicroseconds)

### DIFF
--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -536,6 +536,16 @@ static void sanityChecks(Server & server)
     {
     }
 
+    try
+    {
+        const char * filename = "/proc/sys/kernel/task_delayacct";
+        if (readNumber(filename) == 0)
+            server.context()->addWarningMessage("Delay accounting is not enabled, OSIOWaitMicroseconds will not be gathered. Check " + String(filename));
+    }
+    catch (...) // NOLINT(bugprone-empty-catch)
+    {
+    }
+
     std::string dev_id = getBlockDeviceId(data_path);
     if (getBlockDeviceType(dev_id) == BlockDeviceType::ROT && getBlockDeviceReadAheadBytes(dev_id) == 0)
         server.context()->addWarningMessage("Rotational disk with disabled readahead is in use. Performance can be degraded. Used for data: " + String(data_path));


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add a warning if delayed accounting is not enabled (breaks OSIOWaitMicroseconds)

Since [5.14+](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=e4042ad492357) `kernel.task_delayacct` had been disabled by default

Fixes: #55998 (cc @den-crane )