### PR TITLE
Do not remove part if `Too many open files` is thrown

### DIFF
--- a/src/Storages/MergeTree/checkDataPart.cpp
+++ b/src/Storages/MergeTree/checkDataPart.cpp
@@ -75,6 +75,11 @@ bool isRetryableException(const std::exception_ptr exception_ptr)
         return true;
     }
 #endif
+    catch (const ErrnoException & e)
+    {
+        if (e.getErrno() == EMFILE)
+            return true;
+    }
     catch (const Exception & e)
     {
         if (isNotEnoughMemoryErrorCode(e.code()))


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Do not remove parts if `Too many open files` exception from the filesystem is thrown. Closes https://github.com/ClickHouse/ClickHouse/issues/56210