### PR TITLE
Fix link to failed check report in status commit

### DIFF
--- a/tests/ci/commit_status_helper.py
+++ b/tests/ci/commit_status_helper.py
@@ -242,12 +242,12 @@ def generate_status_comment(pr_info: PRInfo, statuses: CommitStatuses) -> str:
     for desc, gs in grouped_statuses.items():
         state = get_worst_state(gs)
         state_text = f"{STATUS_ICON_MAP[state]} {state}"
-        # take the first target_url
-        target_url = next(
-            (status.target_url for status in gs if status.target_url), None
-        )
-        if target_url:
-            state_text = f'<a href="{target_url}">{state_text}</a>'
+        # take the first target_url with the worst state
+        for status in gs:
+            if status.target_url and status.state == state:
+                state_text = f'<a href="{status.target_url}">{state_text}</a>'
+                break
+
         table_row = (
             f"<tr><td>{desc.name}</td><td>{desc.description}</td>"
             f"<td>{state_text}</td></tr>\n"


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)


Since we have grouped checks in status commit, we should choose link to _any **failed**_ report.
It used to be just _any_ link even successful e.g. https://github.com/ClickHouse/ClickHouse/pull/55373#issuecomment-1752777029