### PR TITLE
Print stack trace addresses in clickhouse-diagnostics 

### DIFF
--- a/utils/clickhouse-diagnostics/README.md
+++ b/utils/clickhouse-diagnostics/README.md
@@ -2574,16 +2574,43 @@ Settings:                            {}
 SELECT
     '\n' || arrayStringConcat(
        arrayMap(
-           x,
-           y -> concat(x, ': ', y),
+           x, y, z -> concat(x, ': ', y, ' @ ', z),
            arrayMap(x -> addressToLine(x), trace),
-           arrayMap(x -> demangle(addressToSymbol(x)), trace)),
+           arrayMap(x -> demangle(addressToSymbol(x)), trace),
+           arrayMap(x -> '0x' || hex(x), trace)),
        '\n') AS trace
 FROM system.stack_trace
 ```
 **result**
 ```
-ClickhouseError("Code: 446. DB::Exception: default: Introspection functions are disabled, because setting 'allow_introspection_functions' is set to 0: While processing concat('\\n', arrayStringConcat(arrayMap((x, y) -> concat(x, ': ', y), arrayMap(x -> addressToLine(x), trace), arrayMap(x -> demangle(addressToSymbol(x)), trace)), '\\n')) AS trace. (FUNCTION_NOT_ALLOWED) (version 21.11.8.4 (official build))",)
+Row 1:
+──────
+trace: 
+:  @ 0x7F6694A91117
+:  @ 0x7F6694A93A41
+./build/./contrib/llvm-project/libcxx/src/condition_variable.cpp:47: std::__1::condition_variable::wait(std::__1::unique_lock<std::__1::mutex>&) @ 0x16F4A56F
+./build/./contrib/llvm-project/libcxx/include/atomic:958: BaseDaemon::waitForTerminationRequest() @ 0x0B85564B
+./build/./contrib/llvm-project/libcxx/include/vector:434: DB::Server::main(std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>> const&) @ 0x0B6644CE
+./build/./base/poco/Util/src/Application.cpp:0: Poco::Util::Application::run() @ 0x1489B8A6
+./build/./programs/server/Server.cpp:402: DB::Server::run() @ 0x0B651E91
+./build/./base/poco/Util/src/ServerApplication.cpp:132: Poco::Util::ServerApplication::run(int, char**) @ 0x148AF4F1
+./build/./programs/server/Server.cpp:0: mainEntryClickHouseServer(int, char**) @ 0x0B64FA96
+./build/./programs/main.cpp:0: main @ 0x06AB8C92
+:  @ 0x7F6694A29D90
+:  @ 0x7F6694A29E40
+./build/./programs/clickhouse: _start @ 0x06AB802E
+
+Row 2:
+──────
+trace: 
+:  @ 0x7F6694B14A0C
+./build/./src/IO/ReadBufferFromFileDescriptor.cpp:0: DB::ReadBufferFromFileDescriptor::readImpl(char*, unsigned long, unsigned long, unsigned long) @ 0x0B622EAB
+./build/./src/IO/ReadBufferFromFileDescriptor.cpp:126: DB::ReadBufferFromFileDescriptor::nextImpl() @ 0x0B6231A0
+./build/./src/IO/ReadBuffer.h:70: SignalListener::run() @ 0x0B85631D
+./build/./base/poco/Foundation/include/Poco/SharedPtr.h:139: Poco::ThreadImpl::runnableEntry(void*) @ 0x149CA102
+:  @ 0x7F6694A94AC3
+:  @ 0x7F6694B26A40
+
 ```
 #### uname
 **command**

--- a/utils/clickhouse-diagnostics/clickhouse-diagnostics
+++ b/utils/clickhouse-diagnostics/clickhouse-diagnostics
@@ -453,10 +453,10 @@ LIMIT 10
 SELECT_STACK_TRACES = r"""SELECT
     '\n' || arrayStringConcat(
        arrayMap(
-           x,
-           y -> concat(x, ': ', y),
+           x, y, z -> concat(x, ': ', y, ' @ ', z),
            arrayMap(x -> addressToLine(x), trace),
-           arrayMap(x -> demangle(addressToSymbol(x)), trace)),
+           arrayMap(x -> demangle(addressToSymbol(x)), trace),
+           arrayMap(x -> '0x' || hex(x), trace)),
        '\n') AS trace
 FROM system.stack_trace
 """


### PR DESCRIPTION
### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Some of the stack frames might not be resolved when collecting stacks. In such cases the raw address might be helpful.

Before:
```
trace: 
: 
: 
./build/./contrib/llvm-project/libcxx/src/condition_variable.cpp:47: std::__1::condition_variable::wait(std::__1::unique_lock<std::__1::mutex>&)
./build/./contrib/boost/boost/circular_buffer/base.hpp:808: DB::MergeTreeBackgroundExecutor<DB::RoundRobinRuntimeQueue>::threadFunction()
./build/./base/base/../base/wide_integer_impl.h:809: ThreadPoolImpl<ThreadFromGlobalPoolImpl<false>>::worker(std::__1::__list_iterator<ThreadFromGlobalPoolImpl<false>, void*>)
./build/./src/Common/ThreadPool.cpp:0: ThreadFromGlobalPoolImpl<false>::ThreadFromGlobalPoolImpl<void ThreadPoolImpl<ThreadFromGlobalPoolImpl<false>>::scheduleImpl<void>(std::__1::function<void ()>, Priority, std::__1::optional<unsigned long>, bool)::'lambda0'()>(void&&)::'lambda'()::operator()()
./build/./base/base/../base/wide_integer_impl.h:809: ThreadPoolImpl<std::__1::thread>::worker(std::__1::__list_iterator<std::__1::thread, void*>)
./build/./contrib/llvm-project/libcxx/include/__memory/unique_ptr.h:302: void* std::__1::__thread_proxy[abi:v15000]<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, void ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, Priority, std::__1::optional<unsigned long>, bool)::'lambda0'()>>(void*)
: 
: 
```

After:
```
trace: 
:  @ 0x7F6694A91117
:  @ 0x7F6694A93A41
./build/./contrib/llvm-project/libcxx/src/condition_variable.cpp:47: std::__1::condition_variable::wait(std::__1::unique_lock<std::__1::mutex>&) @ 0x16F4A56F
./build/./contrib/boost/boost/circular_buffer/base.hpp:808: DB::MergeTreeBackgroundExecutor<DB::RoundRobinRuntimeQueue>::threadFunction() @ 0x11BFCDCD
./build/./base/base/../base/wide_integer_impl.h:809: ThreadPoolImpl<ThreadFromGlobalPoolImpl<false>>::worker(std::__1::__list_iterator<ThreadFromGlobalPoolImpl<false>, void*>) @ 0x0B69FED8
./build/./src/Common/ThreadPool.cpp:0: ThreadFromGlobalPoolImpl<false>::ThreadFromGlobalPoolImpl<void ThreadPoolImpl<ThreadFromGlobalPoolImpl<false>>::scheduleImpl<void>(std::__1::function<void ()>, Priority, std::__1::optional<unsigned long>, bool)::'lambda0'()>(void&&)::'lambda'()::operator()() @ 0x0B6A2F5F
./build/./base/base/../base/wide_integer_impl.h:809: ThreadPoolImpl<std::__1::thread>::worker(std::__1::__list_iterator<std::__1::thread, void*>) @ 0x0B69D5C2
./build/./contrib/llvm-project/libcxx/include/__memory/unique_ptr.h:302: void* std::__1::__thread_proxy[abi:v15000]<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, void ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, Priority, std::__1::optional<unsigned long>, bool)::'lambda0'()>>(void*) @ 0x0B6A142E
:  @ 0x7F6694A94AC3
:  @ 0x7F6694B26A40
```