### PR TITLE
Fix rare logical error in Replicated database

### DIFF
--- a/src/Interpreters/InterpreterSystemQuery.cpp
+++ b/src/Interpreters/InterpreterSystemQuery.cpp
@@ -728,6 +728,11 @@ StoragePtr InterpreterSystemQuery::tryRestartReplica(const StorageID & replica, 
     if (!table || !dynamic_cast<const StorageReplicatedMergeTree *>(table.get()))
         return nullptr;
 
+    SCOPE_EXIT({
+        if (table)
+            table->is_being_restarted = false;
+    });
+    table->is_being_restarted = true;
     table->flushAndShutdown();
     {
         /// If table was already dropped by anyone, an exception will be thrown

--- a/src/Processors/Chunk.cpp
+++ b/src/Processors/Chunk.cpp
@@ -73,7 +73,7 @@ void Chunk::checkNumRowsIsConsistent()
         auto & column = columns[i];
         if (column->size() != num_rows)
             throw Exception(ErrorCodes::LOGICAL_ERROR, "Invalid number of rows in Chunk column {}: expected {}, got {}",
-                            column->getName()+ " position " + toString(i), toString(num_rows), toString(column->size()));
+                            column->getName() + " position " + toString(i), toString(num_rows), toString(column->size()));
     }
 }
 

--- a/src/Storages/IStorage.h
+++ b/src/Storages/IStorage.h
@@ -593,6 +593,7 @@ public:
 
     std::atomic<bool> is_dropped{false};
     std::atomic<bool> is_detached{false};
+    std::atomic<bool> is_being_restarted{false};
 
     /// Does table support index for IN sections
     virtual bool supportsIndexForIn() const { return false; }


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


https://s3.amazonaws.com/clickhouse-test-reports/56215/977380b17176e51a59e65a611545bba5526cbe67/upgrade_check__msan_.html

```
493842:2023.11.02 01:38:55.621498 [ 5721 ] {fcae29bf-5eb5-4f2f-9e50-84b219bd2f11} <Debug> DDLWorker(rdb_test_15): Executing query: ALTER TABLE rdb_test_15.rmt DROP PARTITION ID 'all', ADD COLUMN `m` int
494253:2023.11.02 01:38:55.757426 [ 5721 ] {fcae29bf-5eb5-4f2f-9e50-84b219bd2f11} <Error> TCPHandler: Code: 49. DB::Exception: There was an error on s1|r1: Cannot execute replicated DDL query, table is dropped or detached permanently (probably it's a bug): While executing DDLQueryStatus. (LOGICAL_ERROR), Stack trace (when copying this message, always include the lines below):
494254-
494255-0. ./build_docker/./src/Common/Exception.cpp:98: DB::Exception::Exception(DB::Exception::MessageMasked&&, int, bool) @ 0x000000000c73d977 in /usr/lib/debug/usr/bin/clickhouse.debug
494256-1. ./build_docker/./contrib/llvm-project/libcxx/include/string:1499: DB::Exception::Exception<String const&, String&>(int, FormatStringHelperImpl<std::type_identity<String const&>::type, std::type_identity<String&>::type>, String const&, String&) @ 0x000000000c7f0a47 in /usr/lib/debug/usr/bin/clickhouse.debug
494257-2. ./build_docker/./src/Interpreters/executeDDLQueryOnCluster.cpp:500: DB::DDLQueryStatusSource::generate() @ 0x00000000124831f3 in /usr/lib/debug/usr/bin/clickhouse.debug
494258-3. ./build_docker/./src/Processors/Chunk.h:90: DB::ISource::tryGenerate() @ 0x00000000133658f8 in /usr/lib/debug/usr/bin/clickhouse.debug
494259-4. ./build_docker/./contrib/llvm-project/libcxx/include/optional:344: DB::ISource::work() @ 0x000000001336542a in /usr/lib/debug/usr/bin/clickhouse.debug
494260-5. ./build_docker/./src/Processors/Executors/ExecutionThreadContext.cpp:0: DB::ExecutionThreadContext::executeTask() @ 0x000000001337d2fa in /usr/lib/debug/usr/bin/clickhouse.debug
494261-6. ./build_docker/./src/Processors/Executors/PipelineExecutor.cpp:273: DB::PipelineExecutor::executeStepImpl(unsigned long, std::atomic<bool>*) @ 0x0000000013373db0 in /usr/lib/debug/usr/bin/clickhouse.debug
494262-7. ./build_docker/./contrib/llvm-project/libcxx/include/__memory/shared_ptr.h:701: DB::PipelineExecutor::execute(unsigned long, bool) @ 0x0000000013373040 in /usr/lib/debug/usr/bin/clickhouse.debug
494263-8. ./build_docker/./src/Processors/Executors/PullingAsyncPipelineExecutor.cpp:0: void std::__function::__policy_invoker<void ()>::__call_impl<std::__function::__default_alloc_func<ThreadFromGlobalPoolImpl<true>::ThreadFromGlobalPoolImpl<DB::PullingAsyncPipelineExecutor::pull(DB::Chunk&, unsigned long)::$_0>(DB::PullingAsyncPipelineExecutor::pull(DB::Chunk&, unsigned long)::$_0&&)::'lambda'(), void ()>>(std::__function::__policy_storage const*) @ 0x0000000013380d0f in /usr/lib/debug/usr/bin/clickhouse.debug
494264-9. ./build_docker/./base/base/../base/wide_integer_impl.h:809: void* std::__thread_proxy[abi:v15000]<std::tuple<std::unique_ptr<std::__thread_struct, std::default_delete<std::__thread_struct>>, void ThreadPoolImpl<std::thread>::scheduleImpl<void>(std::function<void ()>, Priority, std::optional<unsigned long>, bool)::'lambda0'()>>(void*) @ 0x000000000c826da7 in /usr/lib/debug/usr/bin/clickhouse.debug
494265-10. ? @ 0x00007fca9ab43ac3 in ?
494266-11. ? @ 0x00007fca9abd5a40 in ?
```
```
2023.11.02 01:38:55.617600 [ 14268 ] {} <Trace> InterpreterSystemQuery: Restarting replica rdb_test_15.rmt
```

See also https://github.com/ClickHouse/ClickHouse/pull/19684