### PR TITLE
Fix crash in case of adding a column with type Object(JSON)

### DIFF
--- a/src/Storages/AlterCommands.cpp
+++ b/src/Storages/AlterCommands.cpp
@@ -1070,7 +1070,7 @@ void AlterCommands::validate(const StoragePtr & table, ContextPtr context) const
         const auto & column_name = command.column_name;
         if (command.type == AlterCommand::ADD_COLUMN)
         {
-            /// Adding a new column of type Object(JSON) is broken, so we don't allow to do it for now. 
+            /// Adding a new column of type Object(JSON) is broken, so we don't allow to do it for now.
             if (const auto * type_object = typeid_cast<const DataTypeObject *>(command.data_type.get()))
                 throw Exception(ErrorCodes::SUPPORT_IS_DISABLED, "Adding a new column of type Object to existing table is not allowed");
 

--- a/src/Storages/AlterCommands.cpp
+++ b/src/Storages/AlterCommands.cpp
@@ -1070,6 +1070,7 @@ void AlterCommands::validate(const StoragePtr & table, ContextPtr context) const
         const auto & column_name = command.column_name;
         if (command.type == AlterCommand::ADD_COLUMN)
         {
+            /// Adding a new column of type Object(JSON) is broken, so we don't allow to do it for now. 
             if (const auto * type_object = typeid_cast<const DataTypeObject *>(command.data_type.get()))
                 throw Exception(ErrorCodes::SUPPORT_IS_DISABLED, "Adding a new column of type Object to existing table is not allowed");
 

--- a/src/Storages/AlterCommands.cpp
+++ b/src/Storages/AlterCommands.cpp
@@ -44,6 +44,7 @@ namespace ErrorCodes
     extern const int LOGICAL_ERROR;
     extern const int DUPLICATE_COLUMN;
     extern const int NOT_IMPLEMENTED;
+    extern const int SUPPORT_IS_DISABLED;
 }
 
 namespace
@@ -1069,6 +1070,9 @@ void AlterCommands::validate(const StoragePtr & table, ContextPtr context) const
         const auto & column_name = command.column_name;
         if (command.type == AlterCommand::ADD_COLUMN)
         {
+            if (const auto * type_object = typeid_cast<const DataTypeObject *>(command.data_type.get()))
+                throw Exception(ErrorCodes::SUPPORT_IS_DISABLED, "Adding a new column of type Object to existing table is not allowed");
+
             if (all_columns.has(column_name) || all_columns.hasNested(column_name))
             {
                 if (!command.if_not_exists)
@@ -1098,6 +1102,9 @@ void AlterCommands::validate(const StoragePtr & table, ContextPtr context) const
         }
         else if (command.type == AlterCommand::MODIFY_COLUMN)
         {
+            if (const auto * type_object = typeid_cast<const DataTypeObject *>(command.data_type.get()))
+                throw Exception(ErrorCodes::SUPPORT_IS_DISABLED, "Modifying a column type to Object in existing table is not allowed");
+
             if (!all_columns.has(column_name))
             {
                 if (!command.if_exists)

--- a/src/Storages/AlterCommands.cpp
+++ b/src/Storages/AlterCommands.cpp
@@ -1074,7 +1074,7 @@ void AlterCommands::validate(const StoragePtr & table, ContextPtr context) const
             /// Looks like there is something around default expression for this column (method `getDefault` is not implemented for the data type Object).
             /// But after ALTER TABLE ADD COLUMN we need to fill existing rows with something (exactly the default value).
             /// So we don't allow to do it for now.
-            if (command.data_type->hasDynamicSubcolumns())
+            if (command.data_type && command.data_type->hasDynamicSubcolumns())
                 throw Exception(ErrorCodes::SUPPORT_IS_DISABLED, "Adding a new column of a type which has dynamic subcolumns to an existing table is not allowed. It has known bugs");
 
             if (all_columns.has(column_name) || all_columns.hasNested(column_name))

--- a/src/Storages/AlterCommands.cpp
+++ b/src/Storages/AlterCommands.cpp
@@ -1071,7 +1071,7 @@ void AlterCommands::validate(const StoragePtr & table, ContextPtr context) const
         if (command.type == AlterCommand::ADD_COLUMN)
         {
             /// FIXME: Adding a new column of type Object(JSON) is broken.
-            /// Looks like there is something around default expession for this column (method `getDefault` is not implemented for the data type Object).
+            /// Looks like there is something around default expression for this column (method `getDefault` is not implemented for the data type Object).
             /// But after ALTER TABLE ADD COLUMN we need to fill existing rows with something (exactly the default value).
             /// So we don't allow to do it for now.
             if (command.data_type->hasDynamicSubcolumns())
@@ -1154,7 +1154,7 @@ void AlterCommands::validate(const StoragePtr & table, ContextPtr context) const
             }
 
             /// FIXME: Modifying the column to/from Object(JSON) is broken.
-            /// Looks like there is something around default expession for this column (method `getDefault` is not implemented for the data type Object).
+            /// Looks like there is something around default expression for this column (method `getDefault` is not implemented for the data type Object).
             /// But after ALTER TABLE MODIFY COLUMN we need to fill existing rows with something (exactly the default value) or calculate the common type for it.
             /// So we don't allow to do it for now.
             if (command.data_type)

--- a/tests/queries/0_stateless/01825_type_json_add_column.sql.j2
+++ b/tests/queries/0_stateless/01825_type_json_add_column.sql.j2
@@ -1,4 +1,5 @@
--- Tags: no-fasttest
+-- Tags: no-fasttest, disabled
+-- Disabled, because ClickHouse server may crash. https://github.com/ClickHouse/ClickHouse/pull/56307
 
 {% for storage in ["MergeTree", "ReplicatedMergeTree('/clickhouse/tables/{database}/test_01825_add_column/', 'r1')"] -%}
 

--- a/tests/queries/0_stateless/02910_object-json-crash-add-column.sql
+++ b/tests/queries/0_stateless/02910_object-json-crash-add-column.sql
@@ -1,0 +1,36 @@
+DROP TABLE IF EXISTS test02910;
+
+CREATE TABLE test02910
+(
+	i Int8,
+	jString String
+) ENGINE = MergeTree
+ORDER BY i;
+
+INSERT INTO test02910 (i, jString) SELECT 1, '{"a":"123"}';
+ALTER TABLE test02910 ADD COLUMN j2 JSON default jString;  -- { serverError SUPPORT_IS_DISABLED }
+
+DROP TABLE IF EXISTS test02910_second;
+
+CREATE TABLE test02910_second
+(
+    `Id1` String,
+    `Id2` String,
+    `timestamp` DateTime64(6),
+    `tags` Array(String),
+)
+ENGINE = MergeTree
+PRIMARY KEY (Id1, Id2)
+ORDER BY (Id1, Id2, timestamp)
+SETTINGS index_granularity = 8192, index_granularity_bytes = 0;
+
+INSERT INTO test02910_second SELECT number, number, '2023-10-28 11:11:11.11111', [] FROM numbers(10);
+INSERT INTO test02910_second SELECT number, number, '2023-10-28 11:11:11.11111', ['a'] FROM numbers(10);
+INSERT INTO test02910_second SELECT number, number, '2023-10-28 11:11:11.11111', ['b'] FROM numbers(10);
+INSERT INTO test02910_second SELECT number, number, '2023-10-28 11:11:11.11111', ['c', 'd'] FROM numbers(10);
+INSERT INTO test02910_second SELECT number, number, '2023-10-28 11:11:11.11111', [] FROM numbers(10);
+
+ALTER TABLE test02910_second ADD COLUMN `tags_json` JSON; -- { serverError SUPPORT_IS_DISABLED }
+
+DROP TABLE IF EXISTS test02910;
+DROP TABLE IF EXISTS test02910_second;

--- a/tests/queries/0_stateless/02910_object-json-crash-add-column.sql
+++ b/tests/queries/0_stateless/02910_object-json-crash-add-column.sql
@@ -8,7 +8,14 @@ CREATE TABLE test02910
 ORDER BY i;
 
 INSERT INTO test02910 (i, jString) SELECT 1, '{"a":"123"}';
+
+ALTER TABLE test02910 ADD COLUMN j2 Tuple(JSON) DEFAULT jString;  -- { serverError SUPPORT_IS_DISABLED }
+ALTER TABLE test02910 ADD COLUMN j2 Tuple(Float64, JSON);  -- { serverError SUPPORT_IS_DISABLED }
+ALTER TABLE test02910 ADD COLUMN j2 Tuple(Array(Tuple(JSON))) DEFAULT jString;  -- { serverError SUPPORT_IS_DISABLED }
 ALTER TABLE test02910 ADD COLUMN j2 JSON default jString;  -- { serverError SUPPORT_IS_DISABLED }
+
+-- If we would allow adding a column with dynamic subcolumns the subsequent select would crash the server.
+-- SELECT * FROM test02910;
 
 DROP TABLE IF EXISTS test02910_second;
 
@@ -30,7 +37,13 @@ INSERT INTO test02910_second SELECT number, number, '2023-10-28 11:11:11.11111',
 INSERT INTO test02910_second SELECT number, number, '2023-10-28 11:11:11.11111', ['c', 'd'] FROM numbers(10);
 INSERT INTO test02910_second SELECT number, number, '2023-10-28 11:11:11.11111', [] FROM numbers(10);
 
+ALTER TABLE test02910_second ADD COLUMN `tags_json` Tuple(JSON) DEFAULT jString;  -- { serverError SUPPORT_IS_DISABLED }
+ALTER TABLE test02910_second ADD COLUMN `tags_json` Tuple(Float64, JSON);  -- { serverError SUPPORT_IS_DISABLED }
+ALTER TABLE test02910_second ADD COLUMN `tags_json` Tuple(Array(Tuple(JSON))) DEFAULT jString;  -- { serverError SUPPORT_IS_DISABLED }
 ALTER TABLE test02910_second ADD COLUMN `tags_json` JSON; -- { serverError SUPPORT_IS_DISABLED }
+
+-- If we would allow adding a column with dynamic subcolumns the subsequent select would crash the server.
+-- SELECT * FROM test02910;
 
 DROP TABLE IF EXISTS test02910;
 DROP TABLE IF EXISTS test02910_second;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Prohibit adding a column with type `Object(JSON)` to an existing table. This closes: https://github.com/ClickHouse/ClickHouse/issues/56095 This closes: https://github.com/ClickHouse/ClickHouse/issues/49944