### PR TITLE
New setting preferred_projection_name

### DIFF
--- a/docs/en/operations/settings/settings.md
+++ b/docs/en/operations/settings/settings.md
@@ -3954,6 +3954,17 @@ Possible values:
 
 Default value: `''`.
 
+## preferred_optimize_projection_name {#preferred_optimize_projection_name}
+
+If it is set to a non-empty string, ClickHouse will try to apply specified projection in query.
+
+
+Possible values:
+
+- string: name of preferred projection
+
+Default value: `''`.
+
 ## alter_sync {#alter-sync}
 
 Allows to set up waiting for actions to be executed on replicas by [ALTER](../../sql-reference/statements/alter/index.md), [OPTIMIZE](../../sql-reference/statements/optimize.md) or [TRUNCATE](../../sql-reference/statements/truncate.md) queries.

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -605,6 +605,7 @@ class IColumn;
     M(Bool, optimize_use_implicit_projections, true, "Automatically choose implicit projections to perform SELECT query", 0) \
     M(Bool, force_optimize_projection, false, "If projection optimization is enabled, SELECT queries need to use projection", 0) \
     M(String, force_optimize_projection_name, "", "If it is set to a non-empty string, check that this projection is used in the query at least once.", 0) \
+    M(String, preferred_optimize_projection_name, "", "If it is set to a non-empty string, ClickHouse tries to apply specified projection", 0) \
     M(Bool, async_socket_for_remote, true, "Asynchronously read from socket executing remote query", 0) \
     M(Bool, async_query_sending_for_remote, true, "Asynchronously create connections and send query to shards in remote query", 0) \
     M(Bool, insert_null_as_default, true, "Insert DEFAULT values instead of NULL in INSERT SELECT (UNION ALL)", 0) \

--- a/src/Processors/QueryPlan/Optimizations/QueryPlanOptimizationSettings.h
+++ b/src/Processors/QueryPlan/Optimizations/QueryPlanOptimizationSettings.h
@@ -42,7 +42,6 @@ struct QueryPlanOptimizationSettings
     bool optimize_projection = false;
     bool force_use_projection = false;
     String force_projection_name;
-    String preferred_projection_name;
     bool optimize_use_implicit_projections = false;
 
     static QueryPlanOptimizationSettings fromSettings(const Settings & from);

--- a/src/Processors/QueryPlan/Optimizations/QueryPlanOptimizationSettings.h
+++ b/src/Processors/QueryPlan/Optimizations/QueryPlanOptimizationSettings.h
@@ -42,6 +42,7 @@ struct QueryPlanOptimizationSettings
     bool optimize_projection = false;
     bool force_use_projection = false;
     String force_projection_name;
+    String preferred_projection_name;
     bool optimize_use_implicit_projections = false;
 
     static QueryPlanOptimizationSettings fromSettings(const Settings & from);

--- a/src/Processors/QueryPlan/Optimizations/optimizeUseAggregateProjection.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeUseAggregateProjection.cpp
@@ -453,21 +453,16 @@ AggregateProjectionCandidates getAggregateProjectionCandidates(
     {
         for (const auto & projection : projections)
         {
-            if (projection.type == ProjectionDescription::Type::Aggregate)
+            if ((projection.type == ProjectionDescription::Type::Aggregate) && (proj_name_from_settings == projection.name))
             {
-                size_t last_dot_pos = projection.name.find_last_of('.');
-                std::string projection_name = (last_dot_pos != std::string::npos) ? projection.name.substr(last_dot_pos + 1) : projection.name;
-                if (proj_name_from_settings == projection_name)
-                {
-                    agg_projections.push_back(&projection);
-                    is_projection_found = true;
-                    break;
-                }
+                agg_projections.push_back(&projection);
+                is_projection_found = true;
+                break;
             }
         }
         if (!is_projection_found)
-            throw Exception(ErrorCodes::INCORRECT_DATA, "Projection {} is specified in setting force_optimize_projection_name but not used",
-                            proj_name_from_settings);
+            for (const auto & projection : projections)
+                agg_projections.push_back(&projection);
     }
     else
         for (const auto & projection : projections)

--- a/src/Processors/QueryPlan/Optimizations/optimizeUseAggregateProjection.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeUseAggregateProjection.cpp
@@ -444,7 +444,7 @@ AggregateProjectionCandidates getAggregateProjectionCandidates(
 
     const auto & projections = metadata->projections;
     std::vector<const ProjectionDescription *> agg_projections;
-    
+
     for (const auto & projection : projections)
         if (projection.type == ProjectionDescription::Type::Aggregate)
             agg_projections.push_back(&projection);

--- a/src/Processors/QueryPlan/Optimizations/optimizeUseNormalProjection.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeUseNormalProjection.cpp
@@ -15,11 +15,6 @@
 namespace DB::QueryPlanOptimizations
 {
 
-namespace ErrorCodes
-{
-    extern const int INCORRECT_DATA;
-}
-
 /// Normal projection analysis result in case it can be applied.
 /// For now, it is empty.
 /// Normal projection can be used only if it contains all required source columns.

--- a/src/Processors/QueryPlan/Optimizations/optimizeUseNormalProjection.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeUseNormalProjection.cpp
@@ -140,17 +140,12 @@ bool optimizeUseNormalProjections(Stack & stack, QueryPlan::Nodes & nodes)
     {
         for (const auto * projection : normal_projections)
         {
-            size_t last_dot_pos = projection->name.find_last_of('.');
-            std::string projection_name = (last_dot_pos != std::string::npos) ? projection->name.substr(last_dot_pos + 1) : projection->name;
-            if (projection_name == proj_name_from_settings)
+            if (projection->name == proj_name_from_settings)
             {
                 is_projection_found = true;
                 break;
             }
         }
-        if (!is_projection_found)
-            throw Exception(ErrorCodes::INCORRECT_DATA, "Projection {} is specified in setting force_optimize_projection_name but not used",
-                            proj_name_from_settings);
     }
 
     for (const auto * projection : normal_projections)
@@ -175,12 +170,9 @@ bool optimizeUseNormalProjections(Stack & stack, QueryPlan::Nodes & nodes)
         if (candidate.sum_marks >= ordinary_reading_marks)
             continue;
 
-        size_t last_dot_pos = projection->name.find_last_of('.');
-        std::string projection_name = (last_dot_pos != std::string::npos) ? projection->name.substr(last_dot_pos + 1) : projection->name;
-
         if (!is_projection_found && (best_candidate == nullptr || candidate.sum_marks < best_candidate->sum_marks))
             best_candidate = &candidate;
-        else if (is_projection_found && projection_name == proj_name_from_settings)
+        else if (is_projection_found && projection->name == proj_name_from_settings)
             best_candidate = &candidate;
     }
 

--- a/src/Processors/QueryPlan/Optimizations/optimizeUseNormalProjection.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeUseNormalProjection.cpp
@@ -15,6 +15,11 @@
 namespace DB::QueryPlanOptimizations
 {
 
+namespace ErrorCodes
+{
+    extern const int INCORRECT_DATA;
+}
+
 /// Normal projection analysis result in case it can be applied.
 /// For now, it is empty.
 /// Normal projection can be used only if it contains all required source columns.

--- a/tests/queries/0_stateless/02907_preferred_optimize_projection_name.reference
+++ b/tests/queries/0_stateless/02907_preferred_optimize_projection_name.reference
@@ -3,5 +3,6 @@ projection_test_by_string
 Executing query with setting
 test
 projection_test_by_more
+Executing query with wrong projection
 test
 projection_test_by_string

--- a/tests/queries/0_stateless/02907_preferred_optimize_projection_name.reference
+++ b/tests/queries/0_stateless/02907_preferred_optimize_projection_name.reference
@@ -3,4 +3,5 @@ projection_test_by_string
 Executing query with setting
 test
 projection_test_by_more
-0
+test
+projection_test_by_string

--- a/tests/queries/0_stateless/02907_preferred_optimize_projection_name.reference
+++ b/tests/queries/0_stateless/02907_preferred_optimize_projection_name.reference
@@ -1,0 +1,6 @@
+test
+projection_test_by_string
+Executing query with setting
+test
+projection_test_by_more
+0

--- a/tests/queries/0_stateless/02907_preferred_optimize_projection_name.sh
+++ b/tests/queries/0_stateless/02907_preferred_optimize_projection_name.sh
@@ -77,9 +77,15 @@ FROM system.query_log
 WHERE query_id = '02907_test_1' AND arrayElement(projections, 1) LIKE '%projection_test_by_string'
 LIMIT 1" | grep -o "projection_test_by_string" || true
 
-$CLICKHOUSE_CLIENT --query_id '02907_test_1' --preferred_optimize_projection_name 'non_existing_projection' -q "
+$CLICKHOUSE_CLIENT --query_id '02907_test_2' --preferred_optimize_projection_name 'non_existing_projection' -q "
 SELECT test_string
 FROM test
 WHERE (test_id > 50)
     AND (test_id < 150)
-GROUP BY test_string;" 2>&1 | grep -c "BAD_ARGUMENTS" || true
+GROUP BY test_string;"
+
+$CLICKHOUSE_CLIENT -q "
+SELECT projections
+FROM system.query_log
+WHERE query_id = '02907_test_2' AND arrayElement(projections, 1) LIKE '%projection_test_by_string'
+LIMIT 1"  | grep -o "projection_test_by_string" || true

--- a/tests/queries/0_stateless/02907_preferred_optimize_projection_name.sh
+++ b/tests/queries/0_stateless/02907_preferred_optimize_projection_name.sh
@@ -5,8 +5,10 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CURDIR"/../shell_config.sh
 
+$CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS test_opt_proj;"
+
 $CLICKHOUSE_CLIENT -q "
-CREATE TABLE test (
+CREATE TABLE test_opt_proj (
     test_id UInt64,
     test_name String,
     test_count Nullable(Float64),
@@ -30,7 +32,7 @@ CREATE TABLE test (
 ORDER BY test_string;"
 
 $CLICKHOUSE_CLIENT -q "
-INSERT INTO test
+INSERT INTO test_opt_proj
 SELECT number,
     'test',
     1.* (number / 2),
@@ -39,53 +41,67 @@ FROM numbers(100, 500);"
 
 $CLICKHOUSE_CLIENT --query_id '02907_test' -q "
 SELECT test_string
-FROM test
+FROM test_opt_proj
 WHERE (test_id > 50)
     AND (test_id < 150)
 GROUP BY test_string;"
 
+$CLICKHOUSE_CLIENT -q "SYSTEM FLUSH LOGS;"
+
 $CLICKHOUSE_CLIENT -q "
 SELECT projections
 FROM system.query_log
-WHERE query_id = '02907_test' AND arrayElement(projections, 1) LIKE '%projection_test_by_string'
+WHERE query_id = '02907_test' AND current_database=currentDatabase()
 LIMIT 1;" | grep -o "projection_test_by_string" || true
 
 $CLICKHOUSE_CLIENT -q "
 SELECT projections
 FROM system.query_log 
-WHERE query_id = '02907_test' AND arrayElement(projections, 1) LIKE '%projection_test_by_more' 
+WHERE query_id = '02907_test' AND current_database=currentDatabase()
 LIMIT 1;" | grep -o "projection_test_by_more" || true
 
 echo "Executing query with setting"
 
 $CLICKHOUSE_CLIENT --query_id '02907_test_1' --preferred_optimize_projection_name 'projection_test_by_more' -q "
 SELECT test_string
-FROM test
+FROM test_opt_proj
 WHERE (test_id > 50)
     AND (test_id < 150)
 GROUP BY test_string;"
 
+$CLICKHOUSE_CLIENT -q "SYSTEM FLUSH LOGS;"
+
 $CLICKHOUSE_CLIENT -q "
 SELECT projections
 FROM system.query_log
-WHERE query_id = '02907_test_1' AND arrayElement(projections, 1) LIKE '%projection_test_by_more'
+WHERE query_id = '02907_test_1' AND current_database=currentDatabase()
 LIMIT 1;" | grep -o "projection_test_by_more" || true
 
 $CLICKHOUSE_CLIENT -q "
 SELECT projections
 FROM system.query_log
-WHERE query_id = '02907_test_1' AND arrayElement(projections, 1) LIKE '%projection_test_by_string'
+WHERE query_id = '02907_test_1' AND current_database=currentDatabase()
 LIMIT 1" | grep -o "projection_test_by_string" || true
+
+echo "Executing query with wrong projection"
 
 $CLICKHOUSE_CLIENT --query_id '02907_test_2' --preferred_optimize_projection_name 'non_existing_projection' -q "
 SELECT test_string
-FROM test
+FROM test_opt_proj
 WHERE (test_id > 50)
     AND (test_id < 150)
 GROUP BY test_string;"
 
+$CLICKHOUSE_CLIENT -q "SYSTEM FLUSH LOGS;"
+
 $CLICKHOUSE_CLIENT -q "
 SELECT projections
 FROM system.query_log
-WHERE query_id = '02907_test_2' AND arrayElement(projections, 1) LIKE '%projection_test_by_string'
-LIMIT 1"  | grep -o "projection_test_by_string" || true
+WHERE query_id = '02907_test_2' AND current_database=currentDatabase()
+LIMIT 1;" | grep -o "projection_test_by_string" || true
+
+$CLICKHOUSE_CLIENT -q "
+SELECT projections
+FROM system.query_log 
+WHERE query_id = '02907_test_2' AND current_database=currentDatabase()
+LIMIT 1;" | grep -o "projection_test_by_more" || true

--- a/tests/queries/0_stateless/02907_preferred_optimize_projection_name.sh
+++ b/tests/queries/0_stateless/02907_preferred_optimize_projection_name.sh
@@ -39,7 +39,7 @@ SELECT number,
     'test'
 FROM numbers(100, 500);"
 
-$CLICKHOUSE_CLIENT --query_id '02907_test' -q "
+$CLICKHOUSE_CLIENT --query_id 02907_test_$CLICKHOUSE_DATABASE -q "
 SELECT test_string
 FROM test_opt_proj
 WHERE (test_id > 50)
@@ -51,18 +51,18 @@ $CLICKHOUSE_CLIENT -q "SYSTEM FLUSH LOGS;"
 $CLICKHOUSE_CLIENT -q "
 SELECT projections
 FROM system.query_log
-WHERE query_id = '02907_test' AND current_database=currentDatabase()
+WHERE query_id = '02907_test_$CLICKHOUSE_DATABASE' AND current_database=currentDatabase()
 LIMIT 1;" | grep -o "projection_test_by_string" || true
 
 $CLICKHOUSE_CLIENT -q "
 SELECT projections
 FROM system.query_log 
-WHERE query_id = '02907_test' AND current_database=currentDatabase()
+WHERE query_id = '02907_test_$CLICKHOUSE_DATABASE' AND current_database=currentDatabase()
 LIMIT 1;" | grep -o "projection_test_by_more" || true
 
 echo "Executing query with setting"
 
-$CLICKHOUSE_CLIENT --query_id '02907_test_1' --preferred_optimize_projection_name 'projection_test_by_more' -q "
+$CLICKHOUSE_CLIENT --query_id 02907_test_1_$CLICKHOUSE_DATABASE --preferred_optimize_projection_name 'projection_test_by_more' -q "
 SELECT test_string
 FROM test_opt_proj
 WHERE (test_id > 50)
@@ -74,18 +74,18 @@ $CLICKHOUSE_CLIENT -q "SYSTEM FLUSH LOGS;"
 $CLICKHOUSE_CLIENT -q "
 SELECT projections
 FROM system.query_log
-WHERE query_id = '02907_test_1' AND current_database=currentDatabase()
+WHERE query_id = '02907_test_1_$CLICKHOUSE_DATABASE' AND current_database=currentDatabase()
 LIMIT 1;" | grep -o "projection_test_by_more" || true
 
 $CLICKHOUSE_CLIENT -q "
 SELECT projections
 FROM system.query_log
-WHERE query_id = '02907_test_1' AND current_database=currentDatabase()
+WHERE query_id = '02907_test_1_$CLICKHOUSE_DATABASE' AND current_database=currentDatabase()
 LIMIT 1" | grep -o "projection_test_by_string" || true
 
 echo "Executing query with wrong projection"
 
-$CLICKHOUSE_CLIENT --query_id '02907_test_2' --preferred_optimize_projection_name 'non_existing_projection' -q "
+$CLICKHOUSE_CLIENT --query_id 02907_test_2_$CLICKHOUSE_DATABASE --preferred_optimize_projection_name 'non_existing_projection' -q "
 SELECT test_string
 FROM test_opt_proj
 WHERE (test_id > 50)
@@ -97,11 +97,11 @@ $CLICKHOUSE_CLIENT -q "SYSTEM FLUSH LOGS;"
 $CLICKHOUSE_CLIENT -q "
 SELECT projections
 FROM system.query_log
-WHERE query_id = '02907_test_2' AND current_database=currentDatabase()
+WHERE query_id = '02907_test_2_$CLICKHOUSE_DATABASE' AND current_database=currentDatabase()
 LIMIT 1;" | grep -o "projection_test_by_string" || true
 
 $CLICKHOUSE_CLIENT -q "
 SELECT projections
 FROM system.query_log 
-WHERE query_id = '02907_test_2' AND current_database=currentDatabase()
+WHERE query_id = '02907_test_2_$CLICKHOUSE_DATABASE' AND current_database=currentDatabase()
 LIMIT 1;" | grep -o "projection_test_by_more" || true

--- a/tests/queries/0_stateless/02907_preferred_optimize_projection_name.sh
+++ b/tests/queries/0_stateless/02907_preferred_optimize_projection_name.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+$CLICKHOUSE_CLIENT -q "
+CREATE TABLE test (
+    test_id UInt64,
+    test_name String,
+    test_count Nullable(Float64),
+    test_string String,
+    PROJECTION projection_test_by_string (
+        SELECT test_string,
+            sum(test_count)
+        GROUP BY test_id,
+            test_string,
+            test_name
+    ),
+    PROJECTION projection_test_by_more (
+        SELECT test_string,
+            test_name,
+            sum(test_count)
+        GROUP BY test_id,
+            test_string,
+            test_name
+    )
+) ENGINE = MergeTree
+ORDER BY test_string;"
+
+$CLICKHOUSE_CLIENT -q "
+INSERT INTO test
+SELECT number,
+    'test',
+    1.* (number / 2),
+    'test'
+FROM numbers(100, 500);"
+
+$CLICKHOUSE_CLIENT --query_id '02907_test' -q "
+SELECT test_string
+FROM test
+WHERE (test_id > 50)
+    AND (test_id < 150)
+GROUP BY test_string;"
+
+$CLICKHOUSE_CLIENT -q "
+SELECT projections
+FROM system.query_log
+WHERE query_id = '02907_test' AND arrayElement(projections, 1) LIKE '%projection_test_by_string'
+LIMIT 1;" | grep -o "projection_test_by_string" || true
+
+$CLICKHOUSE_CLIENT -q "
+SELECT projections
+FROM system.query_log 
+WHERE query_id = '02907_test' AND arrayElement(projections, 1) LIKE '%projection_test_by_more' 
+LIMIT 1;" | grep -o "projection_test_by_more" || true
+
+echo "Executing query with setting"
+
+$CLICKHOUSE_CLIENT --query_id '02907_test_1' --preferred_optimize_projection_name 'projection_test_by_more' -q "
+SELECT test_string
+FROM test
+WHERE (test_id > 50)
+    AND (test_id < 150)
+GROUP BY test_string;"
+
+$CLICKHOUSE_CLIENT -q "
+SELECT projections
+FROM system.query_log
+WHERE query_id = '02907_test_1' AND arrayElement(projections, 1) LIKE '%projection_test_by_more'
+LIMIT 1;" | grep -o "projection_test_by_more" || true
+
+$CLICKHOUSE_CLIENT -q "
+SELECT projections
+FROM system.query_log
+WHERE query_id = '02907_test_1' AND arrayElement(projections, 1) LIKE '%projection_test_by_string'
+LIMIT 1" | grep -o "projection_test_by_string" || true
+
+$CLICKHOUSE_CLIENT --query_id '02907_test_1' --preferred_optimize_projection_name 'non_existing_projection' -q "
+SELECT test_string
+FROM test
+WHERE (test_id > 50)
+    AND (test_id < 150)
+GROUP BY test_string;" 2>&1 | grep -c "BAD_ARGUMENTS" || true


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- New Feature

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
This pull request implements new setting called `preferred_projection_name`. If it is set to a non-empty string, the specified projection would be used if possible.

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
