### PR TITLE
Support remote query timeout for distributed query.

### DIFF
--- a/src/Client/HedgedConnections.h
+++ b/src/Client/HedgedConnections.h
@@ -68,6 +68,7 @@ public:
     {
         size_t offset;
         size_t index;
+        bool remote_query_timeout_exceeded = false;
     };
 
     HedgedConnections(const ConnectionPoolWithFailoverPtr & pool_,
@@ -166,6 +167,9 @@ private:
 
     /// Map socket file descriptor to replica location (it's offset and index in OffsetState.replicas).
     std::unordered_map<int, ReplicaLocation> fd_to_replica_location;
+
+    /// the remote query timeout.
+    TimerDescriptor remote_query_timeout;
 
     /// Map receive data timeout file descriptor to replica location.
     std::unordered_map<int, ReplicaLocation> timeout_fd_to_replica_location;

--- a/src/Core/Protocol.h
+++ b/src/Core/Protocol.h
@@ -92,7 +92,8 @@ namespace Protocol
             MergeTreeReadTaskRequest = 16,  /// Request from a MergeTree replica to a coordinator
             TimezoneUpdate = 17,            /// Receive server's (session-wide) default timezone
             SSHChallenge = 18,              /// Return challenge for SSH signature signing
-            MAX = SSHChallenge,
+            RemoteQueryTimeout = 19,        /// Packet generated due to remote query timeout.
+            MAX = RemoteQueryTimeout,
 
         };
 

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -67,6 +67,8 @@ class IColumn;
     M(Milliseconds, receive_data_timeout_ms, 2000, "Connection timeout for receiving first packet of data or packet with positive progress from replica", 0) \
     M(Bool, use_hedged_requests, true, "Use hedged requests for distributed queries", 0) \
     M(Bool, allow_changing_replica_until_first_data_packet, false, "Allow HedgedConnections to change replica until receiving first data packet", 0) \
+    M(Seconds, remote_query_timeout, 0, "Overall timeout for one remote query execution. Zero means not set.", 0) \
+    M(Bool, allow_remote_query_timeout, false, "If true, distributed query can still continue with timeout of remote queries, Otherwise, throw exception is case timeout of any remote query execution.", 0) \
     M(Milliseconds, queue_max_wait_ms, 0, "The wait time in the request queue, if the number of concurrent requests exceeds the maximum.", 0) \
     M(Milliseconds, connection_pool_max_wait_ms, 0, "The wait time when the connection pool is full.", 0) \
     M(Milliseconds, replace_running_query_max_wait_ms, 5000, "The wait time for running query with the same query_id to finish when setting 'replace_running_query' is active.", 0) \

--- a/src/Formats/FormatFactory.cpp
+++ b/src/Formats/FormatFactory.cpp
@@ -450,7 +450,7 @@ OutputFormatPtr FormatFactory::getOutputFormatParallelIfPossible(
             return output_getter(output, sample, format_settings);
         };
 
-        ParallelFormattingOutputFormat::Params builder{buf, sample, formatter_creator, settings.max_threads};
+        ParallelFormattingOutputFormat::Params builder{buf, sample, formatter_creator, settings.max_threads, context};
 
         if (context->hasQueryContext() && settings.log_queries)
             context->getQueryContext()->addQueryFactoriesInfo(Context::QueryLogFactories::Format, name);

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -4875,4 +4875,44 @@ const ServerSettings & Context::getServerSettings() const
     return shared->server_settings;
 }
 
+void Context::initRemoteQueryTimeoutCount() const
+{
+    auto lock = getLock();
+    if (remote_query_timeout_count_ptr == nullptr)
+        remote_query_timeout_count_ptr = std::make_shared<UInt32>(0);
+}
+
+UInt32 Context::getRemoteQueryTimeoutCount() const
+{
+    auto lock = getLock();
+    return *remote_query_timeout_count_ptr;
+}
+
+void Context::incrementRemoteQueryTimeoutCount() const
+{
+    auto lock = getLock();
+    if (remote_query_timeout_count_ptr != nullptr)
+        ++(*remote_query_timeout_count_ptr);
+}
+
+void Context::initTotalChildQueryCount() const
+{
+    auto lock = getLock();
+    if (total_child_query_count_ptr == nullptr)
+        total_child_query_count_ptr = std::make_shared<UInt32>(0);
+}
+
+UInt32 Context::getTotalChildQueryCount() const
+{
+    auto lock = getLock();
+    return *total_child_query_count_ptr;
+}
+
+void Context::incrementTotalChildQueryCount(UInt32 cnt) const
+{
+    auto lock = getLock();
+    if (total_child_query_count_ptr != nullptr)
+        *total_child_query_count_ptr += cnt;
+}
+
 }

--- a/src/Interpreters/Context.h
+++ b/src/Interpreters/Context.h
@@ -434,7 +434,7 @@ protected:
     mutable std::shared_ptr<UInt32> remote_query_timeout_count_ptr = nullptr;
 
     /// Total number of child local/remote queries generated for a distributed query (may involve multiple distributed tables), and subquery does not count here. this is only for query context.
-    mutable std::shared_ptr<UInt32> total_child_query_count_ptr = nullptr;    
+    mutable std::shared_ptr<UInt32> total_child_query_count_ptr = nullptr;
 
 public:
     /// Some counters for current query execution.

--- a/src/Interpreters/Context.h
+++ b/src/Interpreters/Context.h
@@ -430,6 +430,12 @@ protected:
     /// mutation tasks of one mutation executed against different parts of the same table.
     PreparedSetsCachePtr prepared_sets_cache;
 
+    /// A counter indicating how many remote query executions failed due to remote query timeout exceeded. this is only for query context.
+    mutable std::shared_ptr<UInt32> remote_query_timeout_count_ptr = nullptr;
+
+    /// Total number of child local/remote queries generated for a distributed query (may involve multiple distributed tables), and subquery does not count here. this is only for query context.
+    mutable std::shared_ptr<UInt32> total_child_query_count_ptr = nullptr;    
+
 public:
     /// Some counters for current query execution.
     /// Most of them are workarounds and should be removed in the future.
@@ -1226,6 +1232,18 @@ public:
     PreparedSetsCachePtr getPreparedSetsCache() const;
 
     const ServerSettings & getServerSettings() const;
+
+    void initRemoteQueryTimeoutCount() const;
+
+    UInt32 getRemoteQueryTimeoutCount() const;
+
+    void incrementRemoteQueryTimeoutCount() const;
+
+    void initTotalChildQueryCount() const;
+
+    UInt32 getTotalChildQueryCount() const;
+
+    void incrementTotalChildQueryCount(UInt32 cnt) const;
 
 private:
     std::shared_ptr<const SettingsConstraintsAndProfileIDs> getSettingsConstraintsAndCurrentProfilesWithLock() const;

--- a/src/Interpreters/Session.cpp
+++ b/src/Interpreters/Session.cpp
@@ -670,6 +670,9 @@ ContextMutablePtr Session::makeQueryContextImpl(const ClientInfo * client_info_t
     /// Interserver does not create session context
     recordLoginSucess(query_context);
 
+    query_context->initRemoteQueryTimeoutCount();
+    query_context->initTotalChildQueryCount();    
+
     return query_context;
 }
 

--- a/src/Interpreters/Session.cpp
+++ b/src/Interpreters/Session.cpp
@@ -671,7 +671,7 @@ ContextMutablePtr Session::makeQueryContextImpl(const ClientInfo * client_info_t
     recordLoginSucess(query_context);
 
     query_context->initRemoteQueryTimeoutCount();
-    query_context->initTotalChildQueryCount();    
+    query_context->initTotalChildQueryCount();
 
     return query_context;
 }

--- a/src/Processors/Formats/Impl/ParallelFormattingOutputFormat.cpp
+++ b/src/Processors/Formats/Impl/ParallelFormattingOutputFormat.cpp
@@ -157,17 +157,15 @@ namespace DB
                 /// Use this copy to after notification to stop the execution.
                 auto copy_of_unit_type = unit.type;
 
-                /// TODO : Make other output formats who does not support parralel formatting return extra parameters for remote query timeout in the header of http response as well.
+                /// TODO : Make other output formats who does not support parallel formatting return extra parameters for remote query timeout in the header of http response as well.
                 if (auto * write_buffer_from_http_response = reinterpret_cast<WriteBufferFromHTTPServerResponse *>(&out))
                 {
                     auto & http_response = write_buffer_from_http_response->getHTTPResponse();
-                    auto remote_timeout_count = context->getRemoteQueryTimeoutCount();
-                    if (remote_timeout_count)
+                    auto remote_query_timeout_count = context->getRemoteQueryTimeoutCount();
+                    if (remote_query_timeout_count && !http_response.has("X-ClickHouse-Remote-Query-Timeout-Count"))
                     {
-                        if(!http_response.has("X-ClickHouse-Remote-Query-Timeout-Count"))
-                            http_response.add("X-ClickHouse-Remote-Query-Timeout-Count", std::to_string(remote_timeout_count));
-                        if (remote_timeout_count && !http_response.has("X-ClickHouse-Total-Child-Query-Count"))
-                            http_response.add("X-ClickHouse-Total-Child-Query-Count", std::to_string(context->getTotalChildQueryCount()));
+                        http_response.add("X-ClickHouse-Remote-Query-Timeout-Count", std::to_string(remote_query_timeout_count));
+                        http_response.add("X-ClickHouse-Total-Child-Query-Count", std::to_string(context->getTotalChildQueryCount()));
                     }
                 }
 

--- a/src/Processors/Formats/Impl/ParallelFormattingOutputFormat.h
+++ b/src/Processors/Formats/Impl/ParallelFormattingOutputFormat.h
@@ -13,6 +13,7 @@
 #include <IO/BufferWithOwnMemory.h>
 #include <IO/WriteBuffer.h>
 #include <IO/NullWriteBuffer.h>
+#include <Interpreters/Context.h>
 
 #include <deque>
 #include <atomic>
@@ -73,6 +74,7 @@ public:
         const Block & header;
         InternalFormatterCreator internal_formatter_creator;
         const size_t max_threads_for_parallel_formatting;
+        ContextPtr context = nullptr;
     };
 
     ParallelFormattingOutputFormat() = delete;
@@ -81,7 +83,7 @@ public:
         : IOutputFormat(params.header, params.out)
         , internal_formatter_creator(params.internal_formatter_creator)
         , pool(CurrentMetrics::ParallelFormattingOutputFormatThreads, CurrentMetrics::ParallelFormattingOutputFormatThreadsActive, params.max_threads_for_parallel_formatting)
-
+        , context(params.context)
     {
         LOG_TEST(&Poco::Logger::get("ParallelFormattingOutputFormat"), "Parallel formatting is being used");
 
@@ -233,6 +235,9 @@ private:
 
     // There are multiple "formatters", that's why we use thread pool.
     ThreadPool pool;
+
+    ContextPtr context;
+
     // Collecting all memory to original ReadBuffer
     ThreadFromGlobalPool collector_thread;
     std::mutex collector_thread_mutex;

--- a/src/Processors/QueryPlan/ReadFromRemote.cpp
+++ b/src/Processors/QueryPlan/ReadFromRemote.cpp
@@ -119,6 +119,7 @@ ReadFromRemote::ReadFromRemote(
     , shard_count(shard_count_)
     , cluster_name(cluster_name_)
 {
+    context->incrementTotalChildQueryCount(shard_count);
 }
 
 void ReadFromRemote::enforceSorting(SortDescription output_sort_description)

--- a/src/QueryPipeline/RemoteQueryExecutor.cpp
+++ b/src/QueryPipeline/RemoteQueryExecutor.cpp
@@ -520,6 +520,11 @@ RemoteQueryExecutor::ReadResult RemoteQueryExecutor::processPacket(Packet packet
         case Protocol::Server::TimezoneUpdate:
             break;
 
+        case Protocol::Server::RemoteQueryTimeout:
+            /// return an empty block indicating the end of the remote query execution in case of remote query timeout.
+            context->incrementRemoteQueryTimeoutCount();
+            return Block();
+
         default:
             got_unknown_packet_from_replica = true;
             throw Exception(

--- a/src/Server/HTTP/WriteBufferFromHTTPServerResponse.h
+++ b/src/Server/HTTP/WriteBufferFromHTTPServerResponse.h
@@ -77,6 +77,11 @@ public:
 
     void setExceptionCode(int exception_code_) { exception_code = exception_code_; }
 
+    HTTPServerResponse & getHTTPResponse()
+    {
+        return response;
+    }
+
 private:
     /// Send at least HTTP headers if no data has been sent yet.
     /// Use after the data has possibly been sent and no error happened (and thus you do not plan


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- New Feature


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Support skipping slow/hang shards for distributed query by the mechanism below :

1. Make HedgedConnections supports remote query timeout, which is controlled by settings `remote_query_timeout` and `allow_remote_query_timeout`, and HedgedConnections returns a packet of special type `Protocol::Server::RemoteQueryTimeout` in case of remote query timeout.
2. Make Remote query executor return an empty block indicating the end of the remote query execution in case it get a packet of type `Protocol::Server::RemoteQueryTimeout`.
3. Added parameter `X-ClickHouse-Remote-Query-Timeout-Count` and `X-ClickHouse-Total-Child-Query-Count` in the header of http response for user to check if remote query timeout occur.

### Documentation entry for user-facing changes
In some scenarios, like log search scenario, users expect to receive incomplete query results in case some shard gets stuck or runs super slow. 

We propose to add a remote query timeout for distributed query. Two settings `remote_query_timeout` and `allow_remote_query_timeout` can be used to configure the remote query timeout. 

With the `remote_query_timeout` and `allow_remote_query_timeout` set, the distributed query can skip the shards who doesn't finish query execution in `remote_query_timeout` and return without the result from those skipped shards, and some parameters are added in http response header for users to check if any remote query timed out.

- [x] Documentation is written (mandatory for new features)



> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
