### PR TITLE
Update test_storage_s3_queue

### DIFF
--- a/tests/integration/test_storage_s3_queue/test.py
+++ b/tests/integration/test_storage_s3_queue/test.py
@@ -626,7 +626,8 @@ def test_multiple_tables_meta_mismatch(started_cluster):
     )
 
 
-@pytest.mark.parametrize("mode", AVAILABLE_MODES)
+# TODO: Update the modes for this test to include "ordered" once PR #55795 is finished.
+@pytest.mark.parametrize("mode", ["unordered"])
 def test_multiple_tables_streaming_sync(started_cluster, mode):
     node = started_cluster.instances["instance"]
     table_name = f"multiple_tables_streaming_sync_{mode}"


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Made test `test_multiple_tables_streaming_sync` to be only run for "unordered" mode, because for "ordered" mode it cannot be not flaky until https://github.com/ClickHouse/ClickHouse/pull/55795 is finished (see PR description for more details).
Closes https://github.com/ClickHouse/ClickHouse/issues/55090.