### PR TITLE
Update stress.py

### DIFF
--- a/tests/ci/stress.py
+++ b/tests/ci/stress.py
@@ -137,7 +137,10 @@ def prepare_for_hung_check(drop_databases: bool) -> bool:
     # However, it obstructs checking for hung queries.
     logging.info("Will terminate gdb (if any)")
     call_with_retry("kill -TERM $(pidof gdb)")
-    call_with_retry("timeout 50s tail --pid=$(pidof gdb) -f /dev/null || kill -9 $(pidof gdb) ||:", timeout=60)
+    call_with_retry(
+        "timeout 50s tail --pid=$(pidof gdb) -f /dev/null || kill -9 $(pidof gdb) ||:",
+        timeout=60,
+    )
     # Sometimes there is a message `Child process was stopped by signal 19` in logs after stopping gdb
     call_with_retry(
         "kill -CONT $(cat /var/run/clickhouse-server/clickhouse-server.pid) && clickhouse client -q 'SELECT 1 FORMAT Null'"

--- a/tests/ci/stress.py
+++ b/tests/ci/stress.py
@@ -137,7 +137,7 @@ def prepare_for_hung_check(drop_databases: bool) -> bool:
     # However, it obstructs checking for hung queries.
     logging.info("Will terminate gdb (if any)")
     call_with_retry("kill -TERM $(pidof gdb)")
-    call_with_retry("tail --pid=$(pidof gdb) -f /dev/null")
+    call_with_retry("timeout 50s tail --pid=$(pidof gdb) -f /dev/null || kill -9 $(pidof gdb) ||:", timeout=60)
     # Sometimes there is a message `Child process was stopped by signal 19` in logs after stopping gdb
     call_with_retry(
         "kill -CONT $(cat /var/run/clickhouse-server/clickhouse-server.pid) && clickhouse client -q 'SELECT 1 FORMAT Null'"

--- a/tests/ci/stress.py
+++ b/tests/ci/stress.py
@@ -362,7 +362,7 @@ def main():
         )
         hung_check_log = args.output_folder / "hung_check.log"  # type: Path
         tee = Popen(["/usr/bin/tee", hung_check_log], stdin=PIPE)
-        res = call(cmd, shell=True, stdout=tee.stdin, stderr=STDOUT)
+        res = call(cmd, shell=True, stdout=tee.stdin, stderr=STDOUT, timeout=600)
         if tee.stdin is not None:
             tee.stdin.close()
         if res != 0 and have_long_running_queries and not suppress_hung_check:


### PR DESCRIPTION

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Looks like gdb gets stuck sometimes:
https://s3.amazonaws.com/clickhouse-test-reports/56316/0b0b1b21c689a0f4290d3faefed0eee2596541d7/stress_test__tsan_.html
```gdb.log:
...
2023-11-04 16:46:22 [Thread 0x7f4379a95640 (LWP 38488) exited]
2023-11-04 16:46:22 [Thread 0x7f43e52ff640 (LWP 38352) exited]
2023-11-04 16:46:22 [Thread 0x7f415b809640 (LWP 35974) exited]
```
(no more lines since then)

```
...
2023-11-04 17:08:58,505 Finished 15 from 16 processes
2023-11-04 17:09:03,509 All processes finished
2023-11-04 17:09:03,510 Compressing stress logs
2023-11-04 17:09:04,118 Logs compressed
2023-11-04 17:09:04,119 Will terminate gdb (if any)
2023-11-04 17:09:04,120 Running command: kill -TERM $(pidof gdb)
2023-11-04 17:09:04,302 Running command: tail --pid=$(pidof gdb) -f /dev/null
2023-11-04 17:09:34,408 Failed to prepare for hung check: Command 'tail --pid=$(pidof gdb) -f /dev/null' timed out after 30 seconds
2023-11-04 17:09:34,416 Checking if some queries hung
...
```