### PR TITLE
test on cluster positional_arguments

### DIFF
--- a/tests/queries/0_stateless/02006_test_positional_arguments_on_cluster.reference
+++ b/tests/queries/0_stateless/02006_test_positional_arguments_on_cluster.reference
@@ -1,0 +1,2 @@
+d	Date					
+f	UInt64					

--- a/tests/queries/0_stateless/02006_test_positional_arguments_on_cluster.sql
+++ b/tests/queries/0_stateless/02006_test_positional_arguments_on_cluster.sql
@@ -14,3 +14,6 @@ format Null;
 ALTER TABLE t02006 on cluster test_shard_localhost ADD COLUMN IF NOT EXISTS f UInt64 format Null;
 
 DESC t02006;
+
+DROP TABLE IF EXISTS t02006 on cluster test_shard_localhost format Null;
+DROP TABLE IF EXISTS m02006 on cluster test_shard_localhost format Null;

--- a/tests/queries/0_stateless/02006_test_positional_arguments_on_cluster.sql
+++ b/tests/queries/0_stateless/02006_test_positional_arguments_on_cluster.sql
@@ -1,0 +1,16 @@
+-- Tags: no-ordinary-database, no-replicated-database, distributed, zookeeper
+
+DROP TABLE IF EXISTS t02006 on cluster test_shard_localhost format Null;
+DROP TABLE IF EXISTS m02006 on cluster test_shard_localhost format Null;
+
+CREATE TABLE t02006 on cluster test_shard_localhost (d Date) 
+ENGINE = MergeTree ORDER BY d
+format Null;
+
+CREATE MATERIALIZED VIEW m02006 on cluster test_shard_localhost
+Engine = MergeTree ORDER BY tuple() AS SELECT d, 0 AS i FROM t02006 GROUP BY d, i
+format Null;
+
+ALTER TABLE t02006 on cluster test_shard_localhost ADD COLUMN IF NOT EXISTS f UInt64 format Null;
+
+DESC t02006;


### PR DESCRIPTION
Before 23.3 `ALTER TABLE t02006 on cluster...  ADD COLUMN  f UInt64` fails with:

```
DB::Exception: Positional argument out of bounds: 0 
(expected in range [1, 2]. (ILLEGAL_TYPE_OF_ARGUMENT) 
(version 23.2.1.2537 (official build)). (ILLEGAL_TYPE_OF_ARGUMENT)
```


### Changelog category (leave one):
- Documentation (changelog entry is not required)
