### PR TITLE
Fix segfault during Kerberos initialization

### DIFF
--- a/src/Access/KerberosInit.cpp
+++ b/src/Access/KerberosInit.cpp
@@ -44,7 +44,7 @@ private:
     krb5_ccache defcache = nullptr;
     krb5_get_init_creds_opt * options = nullptr;
     // Credentials structure including ticket, session key, and lifetime info.
-    krb5_creds my_creds;
+    krb5_creds my_creds {};
     krb5_keytab keytab = nullptr;
     krb5_principal defcache_princ = nullptr;
     String fmtError(krb5_error_code code) const;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix a segfault caused by a thrown exception in Kerberos initialization during the creation of the Kafka table. Closes https://github.com/ClickHouse/ClickHouse/issues/56073.