### PR TITLE
Fix OOM in grace hash join by control the max rows of left table block to join

### DIFF
--- a/src/Core/Block.h
+++ b/src/Core/Block.h
@@ -183,7 +183,7 @@ using BlocksPtrs = std::shared_ptr<std::vector<BlocksPtr>>;
 struct ExtraBlock
 {
     Block block;
-
+    bool slice_flag = false;
     bool empty() const { return !block; }
 };
 

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -806,6 +806,7 @@ class IColumn;
     M(Bool, implicit_transaction, false, "If enabled and not already inside a transaction, wraps the query inside a full transaction (begin + commit or rollback)", 0) \
     M(UInt64, grace_hash_join_initial_buckets, 1, "Initial number of grace hash join buckets", 0) \
     M(UInt64, grace_hash_join_max_buckets, 1024, "Limit on the number of grace hash join buckets", 0) \
+    M(UInt64, grace_hash_join_block_max_rows, 0, "Limit on the number of grace hash join of rows in block join step", 0) \
     M(Bool, optimize_distinct_in_order, true, "Enable DISTINCT optimization if some columns in DISTINCT form a prefix of sorting. For example, prefix of sorting key in merge tree or ORDER BY statement", 0) \
     M(Bool, allow_experimental_undrop_table_query, true, "Allow to use undrop query to restore dropped table in a limited time", 0) \
     M(Bool, keeper_map_strict_mode, false, "Enforce additional checks during operations on KeeperMap. E.g. throw an exception on an insert for already existing key", 0) \

--- a/src/Interpreters/GraceHashJoin.cpp
+++ b/src/Interpreters/GraceHashJoin.cpp
@@ -452,7 +452,7 @@ void GraceHashJoin::joinBlock(Block & block, std::shared_ptr<ExtraBlock> & not_p
         }
         hash_join->joinBlock(slice, extra_data);
         data = std::move(slice);
-        if(extra_slice.rows() > 0)
+        if (extra_slice.rows() > 0)
         {
             ExtraBlock extra;
             extra.block = std::move(extra_slice);

--- a/src/Interpreters/GraceHashJoin.h
+++ b/src/Interpreters/GraceHashJoin.h
@@ -130,6 +130,7 @@ private:
     bool any_take_last_row;
     const size_t max_num_buckets;
     size_t max_block_size;
+    size_t max_block_rows_to_join;
 
     Names left_key_names;
     Names right_key_names;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
In grace hash join, the left table block is scattered as many buckets, and then load the buckets into the memory, and use inner `HashJoin` to join right table bucket one by one.

Sometimes, the scattered bucket may have data skew,  some bucket data size looks very big,  when join the right table data by  `joinBlock`, the result size is expand to a larger size than the block itself, which the memory can not hold it, and it cause the OutOfMemory problem. And this is happend in our `gluten` (use clickhouse as its backend) test case.

So we introduce a config `grace_hash_join_block_max_rows` here to control the max rows of left bucket to join, if the bucket 0 has data size greater than this config value, then we cut it into many small blocks,  then use these small blocks to join right table buckets one by one, and push to result out to next operator one by one,  which can decrease the result size in per join,  not to have big result in the memory, and not to cause the OOM problem.


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
