### PR TITLE
Optimizations for system.replicas with many tables

### DIFF
--- a/src/Storages/System/StorageSystemReplicas.h
+++ b/src/Storages/System/StorageSystemReplicas.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 #include <Storages/IStorage.h>
 
 
@@ -7,7 +8,7 @@ namespace DB
 {
 
 class Context;
-
+class StorageSystemReplicasImpl;
 
 /** Implements `replicas` system table, which provides information about the status of the replicated tables.
   */
@@ -15,6 +16,7 @@ class StorageSystemReplicas final : public IStorage
 {
 public:
     explicit StorageSystemReplicas(const StorageID & table_id_);
+    ~StorageSystemReplicas() override;
 
     std::string getName() const override { return "SystemReplicas"; }
 
@@ -28,6 +30,9 @@ public:
         size_t num_streams) override;
 
     bool isSystemStorage() const override { return true; }
+
+private:
+    std::unique_ptr<StorageSystemReplicasImpl> impl;
 };
 
 }

--- a/tests/queries/0_stateless/02908_many_requests_to_system_replicas.reference
+++ b/tests/queries/0_stateless/02908_many_requests_to_system_replicas.reference
@@ -1,0 +1,5 @@
+Creating 300 tables
+Making making 500 requests to system.replicas
+Query system.replicas while waiting for other concurrent requests to finish
+0
+900

--- a/tests/queries/0_stateless/02908_many_requests_to_system_replicas.sh
+++ b/tests/queries/0_stateless/02908_many_requests_to_system_replicas.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Tags: long, zookeeper, no-parallel, no-fasttest
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+set -e
+
+NUM_TABLES=300
+CONCURRENCY=500
+
+echo "Creating $NUM_TABLES tables"
+
+function init_table()
+{
+    i=$1
+    curl $CLICKHOUSE_URL --silent --fail --data "CREATE TABLE test_02908_r1_$i (a UInt64) ENGINE=ReplicatedMergeTree('/02908/{database}/test_$i', 'r1') ORDER BY tuple()"
+    curl $CLICKHOUSE_URL --silent --fail --data "CREATE TABLE test_02908_r2_$i (a UInt64) ENGINE=ReplicatedMergeTree('/02908/{database}/test_$i', 'r2') ORDER BY tuple()"
+    curl $CLICKHOUSE_URL --silent --fail --data "CREATE TABLE test_02908_r3_$i (a UInt64) ENGINE=ReplicatedMergeTree('/02908/{database}/test_$i', 'r3') ORDER BY tuple()"
+
+    curl $CLICKHOUSE_URL --silent --fail --data "INSERT INTO test_02908_r1_$i  SELECT rand64() FROM numbers(5);"
+}
+
+export init_table;
+
+for i in `seq 1 $NUM_TABLES`;
+do
+    init_table $i &
+done
+
+wait;
+
+
+echo "Making making $CONCURRENCY requests to system.replicas"
+
+for i in `seq 1 $CONCURRENCY`;
+do
+    curl $CLICKHOUSE_URL --silent --fail --data "SELECT * FROM system.replicas WHERE database=currentDatabase() FORMAT Null;" &
+done
+
+echo "Query system.replicas while waiting for other concurrent requests to finish"
+# lost_part_count column is read from ZooKeeper
+curl $CLICKHOUSE_URL --silent --fail --data "SELECT sum(lost_part_count) FROM system.replicas WHERE database=currentDatabase();";
+# is_leader column is filled without ZooKeeper
+curl $CLICKHOUSE_URL --silent --fail --data "SELECT sum(is_leader) FROM system.replicas WHERE database=currentDatabase();";
+
+wait;


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Queries to `system.replicas` initiate requests to ZooKeeper when certain columns are queried. When there are thousands of tables these requests might produce a considerable load on ZooKeeper. If there are multiple simultaneous queries to `system.replicas` they do same requests multiple times. The change is to "deduplicate" requests from concurrent queries.