### PR TITLE
Make autoscaling more responsive

### DIFF
--- a/tests/ci/autoscale_runners_lambda/app.py
+++ b/tests/ci/autoscale_runners_lambda/app.py
@@ -57,7 +57,7 @@ def get_scales(runner_type: str) -> Tuple[int, int]:
     # Scaling down is quicker on the lack of running jobs than scaling up on
     # queue
     scale_down = 2
-    scale_up = 5
+    scale_up = 3
     if runner_type == "style-checker":
         # The ASG should deflate almost instantly
         scale_down = 1
@@ -65,8 +65,9 @@ def get_scales(runner_type: str) -> Tuple[int, int]:
         # The 5 was too quick, there are complainings regarding too slow with
         # 10. I am trying 7 now.
         # 7 still looks a bit slow, so I try 6
+        # Let's have it the same as the other ASG
         # UPDATE THE COMMENT ON CHANGES
-        scale_up = 6
+        ## scale_down = 3
     elif runner_type == "limited-tester":
         # The limited runners should inflate and deflate faster
         scale_down = 1

--- a/tests/ci/autoscale_runners_lambda/test_autoscale.py
+++ b/tests/ci/autoscale_runners_lambda/test_autoscale.py
@@ -68,14 +68,16 @@ class TestSetCapacity(unittest.TestCase):
         test_cases = (
             # Do not change capacity
             TestCase("noqueue", 1, 13, 20, [Queue("in_progress", 155, "noqueue")], -1),
-            TestCase("w/reserve", 1, 13, 20, [Queue("queued", 17, "w/reserve")], -1),
-            # Increase capacity
-            TestCase("increase", 1, 13, 20, [Queue("queued", 23, "increase")], 15),
             TestCase(
-                "style-checker", 1, 13, 20, [Queue("queued", 33, "style-checker")], 16
+                "w/reserve-1", 1, 13, 20, [Queue("queued", 15, "w/reserve-1")], -1
             ),
-            TestCase("increase", 1, 13, 20, [Queue("queued", 18, "increase")], 14),
-            TestCase("increase", 1, 13, 20, [Queue("queued", 183, "increase")], 20),
+            # Increase capacity
+            TestCase("increase-1", 1, 13, 20, [Queue("queued", 23, "increase-1")], 16),
+            TestCase(
+                "style-checker", 1, 13, 20, [Queue("queued", 33, "style-checker")], 19
+            ),
+            TestCase("increase-2", 1, 13, 20, [Queue("queued", 18, "increase-2")], 14),
+            TestCase("increase-3", 1, 13, 20, [Queue("queued", 183, "increase-3")], 20),
             TestCase(
                 "increase-w/o reserve",
                 1,
@@ -85,7 +87,7 @@ class TestSetCapacity(unittest.TestCase):
                     Queue("in_progress", 11, "increase-w/o reserve"),
                     Queue("queued", 12, "increase-w/o reserve"),
                 ],
-                15,
+                16,
             ),
             TestCase("lower-min", 10, 5, 20, [Queue("queued", 5, "lower-min")], 10),
             # Decrease capacity


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Decrease the scale to add new runners