### PR TITLE
Add `information_schema.statistics` system view

### DIFF
--- a/docs/en/operations/system-tables/information_schema.md
+++ b/docs/en/operations/system-tables/information_schema.md
@@ -18,12 +18,14 @@ SHOW TABLES FROM information_schema;
 │ KEY_COLUMN_USAGE        │
 │ REFERENTIAL_CONSTRAINTS │
 │ SCHEMATA                │
+| STATISTICS              |
 │ TABLES                  │
 │ VIEWS                   │
 │ columns                 │
 │ key_column_usage        │
 │ referential_constraints │
 │ schemata                │
+| statistics              |
 │ tables                  │
 │ views                   │
 └─────────────────────────┘
@@ -32,11 +34,12 @@ SHOW TABLES FROM information_schema;
 `INFORMATION_SCHEMA` contains the following views:
 
 - [COLUMNS](#columns)
-- [SCHEMATA](#schemata)
-- [TABLES](#tables)
-- [VIEWS](#views)
 - [KEY_COLUMN_USAGE](#key_column_usage)
 - [REFERENTIAL_CONSTRAINTS](#referential_constraints)
+- [SCHEMATA](#schemata)
+- [STATISTICS](#statistics)
+- [TABLES](#tables)
+- [VIEWS](#views)
 
 Case-insensitive equivalent views, e.g. `INFORMATION_SCHEMA.columns` are provided for reasons of compatibility with other databases. The same applies to all the columns in these views - both lowercase (for example, `table_name`) and uppercase (`TABLE_NAME`) variants are provided.
 
@@ -372,3 +375,28 @@ Columns:
 - `delete_rule` ([String](../../sql-reference/data-types/string.md)) — Currently unused.
 - `table_name` ([String](../../sql-reference/data-types/string.md)) — Currently unused.
 - `referenced_table_name` ([String](../../sql-reference/data-types/string.md)) — Currently unused.
+
+## STATISTICS {#statistics}
+
+Provides information about table indexes. Currently returns an empty result (no rows) which is just enough to provide compatibility with 3rd party tools like Tableau Online.
+
+Columns:
+
+- `table_catalog` ([String](../../sql-reference/data-types/string.md)) — Currently unused.
+- `table_schema` ([String](../../sql-reference/data-types/string.md)) — Currently unused.
+- `table_name` ([String](../../sql-reference/data-types/string.md)) — Currently unused.
+- `non_unique` [Int32](../../sql-reference/data-types/int-uint.md) — Currently unused.
+- `index_schema` ([String](../../sql-reference/data-types/string.md)) — Currently unused.
+- `index_name` ([Nullable](../../sql-reference/data-types/nullable.md)([String](../../sql-reference/data-types/string.md))) — Currently unused.
+- `seq_in_index` [UInt32](../../sql-reference/data-types/int-uint.md) — Currently unused.
+- `column_name` ([Nullable](../../sql-reference/data-types/nullable.md)([String](../../sql-reference/data-types/string.md))) — Currently unused.
+- `collation` ([Nullable](../../sql-reference/data-types/nullable.md)([String](../../sql-reference/data-types/string.md))) — Currently unused.
+- `cardinality` ([Nullable](../../sql-reference/data-types/nullable.md)([Int64](../../sql-reference/data-types/int-uint.md))) — Currently unused.
+- `sub_part` ([Nullable](../../sql-reference/data-types/nullable.md)([Int64](../../sql-reference/data-types/int-uint.md))) — Currently unused.
+- `packed` ([Nullable](../../sql-reference/data-types/nullable.md)([String](../../sql-reference/data-types/string.md))) — Currently unused.
+- `nullable` ([String](../../sql-reference/data-types/string.md)) — Currently unused.
+- `index_type` ([String](../../sql-reference/data-types/string.md)) — Currently unused.
+- `comment` ([String](../../sql-reference/data-types/string.md)) — Currently unused.
+- `index_comment` ([String](../../sql-reference/data-types/string.md)) — Currently unused.
+- `is_visible` ([String](../../sql-reference/data-types/string.md)) — Currently unused.
+- `expression` ([Nullable](../../sql-reference/data-types/nullable.md)([String](../../sql-reference/data-types/string.md))) — Currently unused.

--- a/docs/en/operations/system-tables/information_schema.md
+++ b/docs/en/operations/system-tables/information_schema.md
@@ -385,10 +385,10 @@ Columns:
 - `table_catalog` ([String](../../sql-reference/data-types/string.md)) — Currently unused.
 - `table_schema` ([String](../../sql-reference/data-types/string.md)) — Currently unused.
 - `table_name` ([String](../../sql-reference/data-types/string.md)) — Currently unused.
-- `non_unique` [Int32](../../sql-reference/data-types/int-uint.md) — Currently unused.
+- `non_unique` ([Int32](../../sql-reference/data-types/int-uint.md)) — Currently unused.
 - `index_schema` ([String](../../sql-reference/data-types/string.md)) — Currently unused.
 - `index_name` ([Nullable](../../sql-reference/data-types/nullable.md)([String](../../sql-reference/data-types/string.md))) — Currently unused.
-- `seq_in_index` [UInt32](../../sql-reference/data-types/int-uint.md) — Currently unused.
+- `seq_in_index` ([UInt32](../../sql-reference/data-types/int-uint.md)) — Currently unused.
 - `column_name` ([Nullable](../../sql-reference/data-types/nullable.md)([String](../../sql-reference/data-types/string.md))) — Currently unused.
 - `collation` ([Nullable](../../sql-reference/data-types/nullable.md)([String](../../sql-reference/data-types/string.md))) — Currently unused.
 - `cardinality` ([Nullable](../../sql-reference/data-types/nullable.md)([Int64](../../sql-reference/data-types/int-uint.md))) — Currently unused.

--- a/src/Storages/System/attachInformationSchemaTables.cpp
+++ b/src/Storages/System/attachInformationSchemaTables.cpp
@@ -373,6 +373,86 @@ static constexpr std::string_view referential_constraints = R"(
     WHERE false; -- make sure this view is always empty
 )";
 
+static constexpr std::string_view statistics = R"(
+    ATTACH VIEW statistics
+        (
+        `table_catalog` String,
+        `table_schema` String,
+        `table_name` String,
+        `non_unique` Int32,
+        `index_schema` String,
+        `index_name` Nullable(String),
+        `seq_in_index` UInt32,
+        `column_name` Nullable(String),
+        `collation` Nullable(String),
+        `cardinality` Nullable(Int64),
+        `sub_part` Nullable(Int64),
+        `packed` Nullable(String),
+        `nullable` String,
+        `index_type` String,
+        `comment` String,
+        `index_comment` String,
+        `is_visible` String,
+        `expression` Nullable(String),
+        `TABLE_CATALOG` String,
+        `TABLE_SCHEMA` String,
+        `TABLE_NAME` String,
+        `NON_UNIQUE` Int32,
+        `INDEX_SCHEMA` String,
+        `INDEX_NAME` Nullable(String),
+        `SEQ_IN_INDEX` UInt32,
+        `COLUMN_NAME` Nullable(String),
+        `COLLATION` Nullable(String),
+        `CARDINALITY` Nullable(Int64),
+        `SUB_PART` Nullable(Int64),
+        `PACKED` Nullable(String),
+        `NULLABLE` String,
+        `INDEX_TYPE` String,
+        `COMMENT` String,
+        `INDEX_COMMENT` String,
+        `IS_VISIBLE` String,
+        `EXPRESSION` Nullable(String)
+    ) AS
+    SELECT
+        ''            AS table_catalog,
+        ''            AS table_schema,
+        ''            AS table_name,
+        0             AS non_unique,
+        ''            AS index_schema,
+        NULL          AS index_name,
+        0             AS seq_in_index,
+        NULL          AS column_name,
+        NULL          AS collation,
+        NULL          AS cardinality,
+        NULL          AS sub_part,
+        NULL          AS packed,
+        ''            AS nullable,
+        ''            AS index_type,
+        ''            AS comment,
+        ''            AS index_comment,
+        ''            AS is_visible,
+        NULL          AS expression,
+        table_catalog AS TABLE_CATALOG,
+        table_schema  AS TABLE_SCHEMA,
+        table_name    AS TABLE_NAME,
+        non_unique    AS NON_UNIQUE,
+        index_schema  AS INDEX_SCHEMA,
+        index_name    AS INDEX_NAME,
+        seq_in_index  AS SEQ_IN_INDEX,
+        column_name   AS COLUMN_NAME,
+        collation     AS COLLATION,
+        cardinality   AS CARDINALITY,
+        sub_part      AS SUB_PART,
+        packed        AS PACKED,
+        nullable      AS NULLABLE,
+        index_type    AS INDEX_TYPE,
+        comment       AS COMMENT,
+        index_comment AS INDEX_COMMENT,
+        is_visible    AS IS_VISIBLE,
+        expression    AS EXPRESSION
+    WHERE false; -- make sure this view is always empty
+)";
+
 /// View structures are taken from http://www.contrib.andrew.cmu.edu/~shadow/sql/sql1992.txt
 
 static void createInformationSchemaView(ContextMutablePtr context, IDatabase & database, const String & view_name, std::string_view query)
@@ -424,6 +504,7 @@ void attachInformationSchema(ContextMutablePtr context, IDatabase & information_
     createInformationSchemaView(context, information_schema_database, "columns", columns);
     createInformationSchemaView(context, information_schema_database, "key_column_usage", key_column_usage);
     createInformationSchemaView(context, information_schema_database, "referential_constraints", referential_constraints);
+    createInformationSchemaView(context, information_schema_database, "statistics", statistics);
 }
 
 }

--- a/tests/queries/0_stateless/01161_information_schema.reference
+++ b/tests/queries/0_stateless/01161_information_schema.reference
@@ -2,24 +2,28 @@ COLUMNS
 KEY_COLUMN_USAGE
 REFERENTIAL_CONSTRAINTS
 SCHEMATA
+STATISTICS
 TABLES
 VIEWS
 columns
 key_column_usage
 referential_constraints
 schemata
+statistics
 tables
 views
 COLUMNS
 KEY_COLUMN_USAGE
 REFERENTIAL_CONSTRAINTS
 SCHEMATA
+STATISTICS
 TABLES
 VIEWS
 columns
 key_column_usage
 referential_constraints
 schemata
+statistics
 tables
 views
 -- information_schema.schemata
@@ -53,5 +57,6 @@ def	default	PRIMARY	def	default	kcu1	i	1	\N	\N	\N	\N	def	default	PRIMARY	def	def
 def	default	PRIMARY	def	default	kcu2	d	1	\N	\N	\N	\N	def	default	PRIMARY	def	default	kcu2	d	1	\N	\N	\N	\N
 def	default	PRIMARY	def	default	kcu2	u	1	\N	\N	\N	\N	def	default	PRIMARY	def	default	kcu2	u	1	\N	\N	\N	\N
 -- information_schema.referential_constraints
+-- information_schema.statistics
 1
 1

--- a/tests/queries/0_stateless/01161_information_schema.sql
+++ b/tests/queries/0_stateless/01161_information_schema.sql
@@ -39,6 +39,9 @@ SELECT * FROM information_schema.key_column_usage WHERE table_schema = currentDa
 
 SELECT '-- information_schema.referential_constraints';
 SELECT * FROM information_schema.referential_constraints;
+
+SELECT '-- information_schema.statistics';
+SELECT * FROM information_schema.statistics;
 --
 -- mixed upper/lowercase schema and table name:
 SELECT count() FROM information_schema.TABLES WHERE table_schema = currentDatabase() AND table_name = 't';


### PR DESCRIPTION
Adds `information_schema.statistics`, which is not very useful in the context of ClickHouse, but required for Tableau Online via MySQL compatibility.

Resolves https://github.com/ClickHouse/ClickHouse/issues/56432

### Changelog category (leave one):
- New Feature

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Added system view `information_schema.statistics` for better compatibility with Tableau Online.