### PR TITLE
Fix `test_attach_without_fetching`

### DIFF
--- a/tests/integration/test_attach_without_fetching/test.py
+++ b/tests/integration/test_attach_without_fetching/test.py
@@ -13,7 +13,7 @@ def fill_node(node):
         """
         CREATE TABLE IF NOT EXISTS test(n UInt32)
         ENGINE = ReplicatedMergeTree('/clickhouse/tables/test', '{replica}')
-        ORDER BY n PARTITION BY n % 10 SETTINGS cleanup_delay_period=1, max_cleanup_delay_period=3;
+        ORDER BY n PARTITION BY n % 10 SETTINGS cleanup_delay_period=1, cleanup_delay_period_random_add=1, max_cleanup_delay_period=1;
     """.format(
             replica=node.name
         )


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


It became flaky after https://github.com/ClickHouse/ClickHouse/pull/56282
https://s3.amazonaws.com/clickhouse-test-reports/0/8846cc6770de0af061ea5fdb1da7a019ac23419f/integration_tests__release__[1_4].html
