### PR TITLE
Fix transfer query to MySQL compatible query

### DIFF
--- a/src/Storages/tests/gtest_transform_query_for_external_database.cpp
+++ b/src/Storages/tests/gtest_transform_query_for_external_database.cpp
@@ -279,9 +279,13 @@ TEST(TransformQueryForExternalDatabase, MultipleAndSubqueries)
 {
     const State & state = State::instance();
 
-    check(state, 1, {"column"},
-          "SELECT column FROM test.table WHERE 1 = 1 AND toString(column) = '42' AND column = 42 AND left(toString(column), 10) = RIGHT(toString(column), 10) AND column IN (1, 42) AND SUBSTRING(toString(column) FROM 1 FOR 2) = 'Hello' AND column != 4",
-          R"(SELECT "column" FROM "test"."table" WHERE 1 AND ("column" = 42) AND ("column" IN (1, 42)) AND ("column" != 4))");
+    check(
+        state,
+        1,
+        {"column"},
+        "SELECT column FROM test.table WHERE 1 = 1 AND toString(column) = '42' AND column = 42 AND left(toString(column), 10) = "
+        "RIGHT(toString(column), 10) AND column IN (1, 42) AND SUBSTRING(toString(column) FROM 1 FOR 2) = 'Hello' AND column != 4",
+        R"(SELECT "column" FROM "test"."table" WHERE 1 = 1 AND ("column" = 42) AND ("column" IN (1, 42)) AND ("column" != 4))");
     check(state, 1, {"column"},
           "SELECT column FROM test.table WHERE toString(column) = '42' AND left(toString(column), 10) = RIGHT(toString(column), 10) AND column = 42",
           R"(SELECT "column" FROM "test"."table" WHERE "column" = 42)");

--- a/src/Storages/tests/gtest_transform_query_for_external_database.cpp
+++ b/src/Storages/tests/gtest_transform_query_for_external_database.cpp
@@ -285,7 +285,7 @@ TEST(TransformQueryForExternalDatabase, MultipleAndSubqueries)
         {"column"},
         "SELECT column FROM test.table WHERE 1 = 1 AND toString(column) = '42' AND column = 42 AND left(toString(column), 10) = "
         "RIGHT(toString(column), 10) AND column IN (1, 42) AND SUBSTRING(toString(column) FROM 1 FOR 2) = 'Hello' AND column != 4",
-        R"(SELECT "column" FROM "test"."table" WHERE 1 = 1 AND ("column" = 42) AND ("column" IN (1, 42)) AND ("column" != 4))");
+        R"(SELECT "column" FROM "test"."table" WHERE (1 = 1) AND ("column" = 42) AND ("column" IN (1, 42)) AND ("column" != 4))");
     check(state, 1, {"column"},
           "SELECT column FROM test.table WHERE toString(column) = '42' AND left(toString(column), 10) = RIGHT(toString(column), 10) AND column = 42",
           R"(SELECT "column" FROM "test"."table" WHERE "column" = 42)");

--- a/src/Storages/transformQueryForExternalDatabase.cpp
+++ b/src/Storages/transformQueryForExternalDatabase.cpp
@@ -75,6 +75,33 @@ public:
     }
 };
 
+struct ReplaceLiteralToExprVisitorData
+{
+    using TypeToVisit = ASTFunction;
+
+    void visit(ASTFunction & func, ASTPtr &) const
+    {
+        if (func.name == "and" || func.name == "or")
+        {
+            for (auto & argument : func.arguments->children)
+            {
+                auto * literal_expr = typeid_cast<ASTLiteral *>(argument.get());
+                UInt64 value;
+                if (literal_expr && literal_expr->value.tryGet<UInt64>(value) && (value == 0 || value == 1))
+                {
+                    /// 1 -> 1=1, 0 -> 1=0.
+                    if (value)
+                        argument = makeASTFunction("equals", std::make_shared<ASTLiteral>(1), std::make_shared<ASTLiteral>(1));
+                    else
+                        argument = makeASTFunction("equals", std::make_shared<ASTLiteral>(1), std::make_shared<ASTLiteral>(0));
+                }
+            }
+        }
+    }
+};
+
+using ReplaceLiteralToExprVisitor = InDepthNodeVisitor<OneTypeMatcher<ReplaceLiteralToExprVisitorData>, true>;
+
 class DropAliasesMatcher
 {
 public:
@@ -287,6 +314,10 @@ String transformQueryForExternalDatabaseImpl(
     if (original_where && where_has_known_columns)
     {
         replaceConstantExpressions(original_where, context, available_columns);
+
+        /// Replace like WHERE 1 AND 1 to WHRE 1 = 1 AND 1 = 1
+        ReplaceLiteralToExprVisitor::Data replace_literal_to_expr_data;
+        ReplaceLiteralToExprVisitor(replace_literal_to_expr_data).visit(original_where);
 
         if (isCompatible(original_where))
         {

--- a/src/Storages/transformQueryForExternalDatabase.cpp
+++ b/src/Storages/transformQueryForExternalDatabase.cpp
@@ -315,7 +315,7 @@ String transformQueryForExternalDatabaseImpl(
     {
         replaceConstantExpressions(original_where, context, available_columns);
 
-        /// Replace like WHERE 1 AND 1 to WHRE 1 = 1 AND 1 = 1
+        /// Replace like WHERE 1 AND 1 to WHERE 1 = 1 AND 1 = 1
         ReplaceLiteralToExprVisitor::Data replace_literal_to_expr_data;
         ReplaceLiteralToExprVisitor(replace_literal_to_expr_data).visit(original_where);
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):

- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix transfer query to MySQL compatible query. Fixes #57253. Fixes #52654. Fixes #56729.



For example, we have query 
```sql
SELECT
toDate(toDateTime('2023-11-0) AS day_,
toDateTime('2023-11-08 10:00) AS hour_,
k1  t
where  (day_ = toDate(toDateTime('2023-11-08 10:00:00'))) AND 
 (hour_ = toDateTime('2023-11-08 10:00:00'))  and k1 > 1;
```
After replace constant, it become:
```sql
SELECT
toDate(toDateTime('2023-11-0) AS day_,
toDateTime('2023-11-08 10:00) AS hour_,
k1  t
where  1 and 1 and k1 > 1;
```