### PR TITLE
Add `max_table_size_to_drop` and `max_partition_size_to_drop` in MergeTree settings

### DIFF
--- a/docs/en/engines/table-engines/mergetree-family/mergetree.md
+++ b/docs/en/engines/table-engines/mergetree-family/mergetree.md
@@ -176,6 +176,14 @@ Additional parameters that control the behavior of the `MergeTree` (optional):
 
 `max_partitions_to_read` — Limits the maximum number of partitions that can be accessed in one query. You can also specify setting [max_partitions_to_read](/docs/en/operations/settings/merge-tree-settings.md/#max-partitions-to-read) in the global setting.
 
+#### max_table_size_to_drop
+
+`max_table_size_to_drop` - Restriction on deleting tables. Also see server setting [max_table_size_to_drop](/docs/en/operations/server-configuration-parameters/settings.md/#max-table-size-to-drop).
+
+#### max_partition_size_to_drop
+
+`max_partition_size_to_drop` - Restriction on dropping partitions. Also see server setting [max_partition_size_to_drop](/docs/en/operations/server-configuration-parameters/settings.md/#max-partition-size-to-drop).
+
 **Example of Sections Setting**
 
 ``` sql

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -3702,6 +3702,12 @@ void Context::checkTableCanBeDropped(const String & database, const String & tab
 }
 
 
+void Context::checkTableCanBeDropped(const String & database, const String & table, const size_t & table_size, const size_t & max_table_size_to_drop) const
+{
+    checkCanBeDropped(database, table, table_size, max_table_size_to_drop);
+}
+
+
 void Context::setMaxPartitionSizeToDrop(size_t max_size)
 {
     // Is initialized at server startup and updated at config reload
@@ -3713,6 +3719,12 @@ void Context::checkPartitionCanBeDropped(const String & database, const String &
 {
     size_t max_partition_size_to_drop = shared->max_partition_size_to_drop.load(std::memory_order_relaxed);
 
+    checkCanBeDropped(database, table, partition_size, max_partition_size_to_drop);
+}
+
+
+void Context::checkPartitionCanBeDropped(const String & database, const String & table, const size_t & partition_size, const size_t & max_partition_size_to_drop) const
+{
     checkCanBeDropped(database, table, partition_size, max_partition_size_to_drop);
 }
 

--- a/src/Interpreters/Context.h
+++ b/src/Interpreters/Context.h
@@ -1043,10 +1043,12 @@ public:
     /// Prevents DROP TABLE if its size is greater than max_size (50GB by default, max_size=0 turn off this check)
     void setMaxTableSizeToDrop(size_t max_size);
     void checkTableCanBeDropped(const String & database, const String & table, const size_t & table_size) const;
+    void checkTableCanBeDropped(const String & database, const String & table, const size_t & table_size, const size_t & max_table_size_to_drop) const;
 
     /// Prevents DROP PARTITION if its size is greater than max_size (50GB by default, max_size=0 turn off this check)
     void setMaxPartitionSizeToDrop(size_t max_size);
     void checkPartitionCanBeDropped(const String & database, const String & table, const size_t & partition_size) const;
+    void checkPartitionCanBeDropped(const String & database, const String & table, const size_t & partition_size, const size_t & max_partition_size_to_drop) const;
 
     /// Lets you select the compression codec according to the conditions described in the configuration file.
     std::shared_ptr<ICompressionCodec> chooseCompressionCodec(size_t part_size, double part_size_ratio) const;

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -4918,6 +4918,12 @@ void MergeTreeData::checkPartitionCanBeDropped(const ASTPtr & partition, Context
         partition_size += part->getBytesOnDisk();
 
     auto table_id = getStorageID();
+    auto max_partition_size_to_drop = getSettings()->max_partition_size_to_drop;
+    if (max_partition_size_to_drop >= 0)
+    {
+        getContext()->checkPartitionCanBeDropped(table_id.database_name, table_id.table_name, partition_size, max_partition_size_to_drop);
+        return;
+    }
     getContext()->checkPartitionCanBeDropped(table_id.database_name, table_id.table_name, partition_size);
 }
 
@@ -4931,6 +4937,12 @@ void MergeTreeData::checkPartCanBeDropped(const String & part_name)
         throw Exception(ErrorCodes::NO_SUCH_DATA_PART, "No part {} in committed state", part_name);
 
     auto table_id = getStorageID();
+    auto max_partition_size_to_drop = getSettings()->max_partition_size_to_drop;
+    if (max_partition_size_to_drop >= 0)
+    {
+        getContext()->checkPartitionCanBeDropped(table_id.database_name, table_id.table_name, part->getBytesOnDisk(), max_partition_size_to_drop);
+        return;
+    }
     getContext()->checkPartitionCanBeDropped(table_id.database_name, table_id.table_name, part->getBytesOnDisk());
 }
 

--- a/src/Storages/MergeTree/MergeTreeSettings.h
+++ b/src/Storages/MergeTree/MergeTreeSettings.h
@@ -88,6 +88,8 @@ struct Settings;
     \
     /* Part removal settings. */ \
     M(UInt64, simultaneous_parts_removal_limit, 0, "Maximum number of parts to remove during one CleanupThread iteration (0 means unlimited).", 0) \
+    M(Int64, max_table_size_to_drop, -1, "If size of a table is greater than this value (in bytes) than table could not be dropped with any DROP query. If -1 use Server settings", 0) \
+    M(Int64, max_partition_size_to_drop, -1, "Same as max_table_size_to_drop, but for the partitions. If -1 use Server settings.", 0) \
     \
     /** Replication settings. */ \
     M(UInt64, replicated_deduplication_window, 100, "How many last blocks of hashes should be kept in ZooKeeper (old blocks will be deleted).", 0) \

--- a/src/Storages/StorageMergeTree.cpp
+++ b/src/Storages/StorageMergeTree.cpp
@@ -297,6 +297,13 @@ void StorageMergeTree::checkTableCanBeDropped([[ maybe_unused ]] ContextPtr quer
         return;
 
     auto table_id = getStorageID();
+    const auto & storage_settings = getSettings();
+    if (storage_settings->max_table_size_to_drop >= 0)
+    {
+        getContext()->checkTableCanBeDropped(table_id.database_name, table_id.table_name, getTotalActiveSizeInBytes(), storage_settings->max_table_size_to_drop);
+        return;
+    }
+    // use max_table_size_to_drop from server settings
     getContext()->checkTableCanBeDropped(table_id.database_name, table_id.table_name, getTotalActiveSizeInBytes());
 }
 

--- a/tests/integration/test_reload_max_table_size_to_drop/test.py
+++ b/tests/integration/test_reload_max_table_size_to_drop/test.py
@@ -1,8 +1,12 @@
 import os
+import shutil
 import time
+import contextlib
 
 import pytest
 from helpers.cluster import ClickHouseCluster
+from helpers.client import QueryRuntimeException
+from functools import partial
 
 cluster = ClickHouseCluster(__file__)
 node = cluster.add_instance("node", main_configs=["configs/max_table_size_to_drop.xml"])
@@ -22,7 +26,21 @@ def start_cluster():
         cluster.shutdown()
 
 
-def test_reload_max_table_size_to_drop(start_cluster):
+@pytest.fixture
+def reset_config():
+    """
+    Reset configuration with max_table/partition_size_to_drop
+    """
+    config_file = "max_table_size_to_drop.xml"
+    shutil.copy(
+        os.path.join(os.path.dirname(__file__), f"configs/{config_file}"),
+        os.path.join(node.config_d_dir, config_file),
+    )
+
+    node.query("SYSTEM RELOAD CONFIG")
+
+
+def test_reload_max_table_size_to_drop(start_cluster, reset_config):
     node.query("INSERT INTO test VALUES (now(), 0)")
     config_path = os.path.join(
         SCRIPT_DIR,
@@ -55,3 +73,62 @@ def test_reload_max_table_size_to_drop(start_cluster):
     out, err = drop.get_answer_and_error()
     assert out == ""
     assert err == ""
+
+
+def test_max_table_size_to_drop_for_engine_settings(start_cluster, reset_config):
+    node.query(
+        "CREATE TABLE data(date Date, id UInt32) ENGINE = MergeTree() ORDER BY tuple()"
+    )
+    node.query("INSERT INTO data VALUES (now(), 0)")
+
+    node.query(
+        "CREATE TABLE data2(date Date, id UInt32) ENGINE = MergeTree() ORDER BY tuple() SETTINGS max_table_size_to_drop = 10000"
+    )
+    node.query("INSERT INTO data2 VALUES (now(), 0)")
+
+    # wait_table_size_changed("data2", lambda x: x > 1)
+    # Table can be dropped since engine max_table_size_to_drop setting overwrite server setting
+    node.query("DROP TABLE data2 SYNC")
+
+    assert "data2" not in node.query("show tables")
+
+    # But can't still delete `data` table since it uses server setting
+    with pytest.raises(QueryRuntimeException) as exc:
+        node.query("DROP TABLE data SYNC")
+
+    assert "TABLE_SIZE_EXCEEDS_MAX_DROP_SIZE_LIMIT" in str(exc)
+
+
+def test_max_table_size_to_drop_for_engine_settings_with_reset(
+    start_cluster, reset_config
+):
+    node.query(
+        "CREATE TABLE data2(date Date, id UInt32) ENGINE = MergeTree() ORDER BY tuple() SETTINGS max_table_size_to_drop = 10000"
+    )
+    node.query("INSERT INTO data2 VALUES (now(), 0)")
+
+    # reset settings to default, so server-wise setting will be used to check the max table size to drop
+    node.query("ALTER TABLE data2 RESET SETTING max_table_size_to_drop")
+
+    with pytest.raises(QueryRuntimeException) as exc:
+        node.query("DROP TABLE data2 SYNC")
+
+    assert "TABLE_SIZE_EXCEEDS_MAX_DROP_SIZE_LIMIT" in str(exc)
+
+
+def test_max_partition_size_to_drop_for_table(start_cluster, reset_config):
+    node.query(
+        "CREATE TABLE data3(date Date, id UInt32) ENGINE = MergeTree() PARTITION BY date ORDER BY tuple()"
+    )
+    node.query("INSERT INTO data3 VALUES ('2022-01-01', 0)")
+
+    with pytest.raises(QueryRuntimeException) as exc:
+        node.query("ALTER TABLE data3 DROP PARTITION '2022-01-01'")
+
+    assert "TABLE_SIZE_EXCEEDS_MAX_DROP_SIZE_LIMIT" in str(exc)
+
+    node.query("ALTER TABLE data3 MODIFY SETTING max_partition_size_to_drop=1000")
+
+    node.query("ALTER TABLE data3 DROP PARTITION '2022-01-01'")
+
+    assert int(node.query("SELECT count(id) FROM data3")) == 0

--- a/tests/integration/test_reload_max_table_size_to_drop/test.py
+++ b/tests/integration/test_reload_max_table_size_to_drop/test.py
@@ -33,10 +33,10 @@ def test_reload_max_table_size_to_drop(start_cluster):
 
     time.sleep(5)  # wait for data part commit
 
-    drop = node.get_query_request("DROP TABLE test")
+    drop = node.get_query_request("DROP TABLE test SYNC")
     out, err = drop.get_answer_and_error()
     assert out == ""
-    assert err != ""
+    assert "Table or Partition in default.test was not dropped." in err
 
     config = open(config_path, "r")
     config_lines = config.readlines()


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- New Feature

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add `max_table_size_to_drop` and `max_partition_size_to_drop` in MergeTree settings

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

Possible to set up `max_table_size_to_drop` and `max_partition_size_to_drop`
for MergeTree engine.

```
create table data
(
  a UInt8
)
engine=MergeTree
order by tuple()
settings max_table_size_to_drop=1000, max_partition_size_to_drop=1000
```

Default value for these settings in MergeTree = -1. If -1 is set - settings from server
section are used.

Fix https://github.com/ClickHouse/ClickHouse/issues/38250
> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
