### PR TITLE
Strip debuginfo symbols from prql-compiler

### DIFF
--- a/rust/prql/Cargo.toml
+++ b/rust/prql/Cargo.toml
@@ -13,7 +13,7 @@ serde_json = "1.0"
 crate-type = ["staticlib"]
 
 [profile.release]
-debug = true
+strip = "debuginfo"
 
 [profile.release-thinlto]
 inherits = "release"

--- a/rust/prql/Cargo.toml
+++ b/rust/prql/Cargo.toml
@@ -13,6 +13,7 @@ serde_json = "1.0"
 crate-type = ["staticlib"]
 
 [profile.release]
+debug = true
 strip = "debuginfo"
 
 [profile.release-thinlto]

--- a/rust/prql/Cargo.toml
+++ b/rust/prql/Cargo.toml
@@ -13,8 +13,7 @@ serde_json = "1.0"
 crate-type = ["staticlib"]
 
 [profile.release]
-debug = true
-strip = "debuginfo"
+debug = false
 
 [profile.release-thinlto]
 inherits = "release"


### PR DESCRIPTION
Fix for https://github.com/PRQL/prql/issues/3768

### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Reduce the size of prql-compiler library
