### PR TITLE
Docs: Update instructions to fetch the repo

### DIFF
--- a/docs/en/development/developer-instruction.md
+++ b/docs/en/development/developer-instruction.md
@@ -23,43 +23,34 @@ Create a fork of ClickHouse repository. To do that please click on the “fork�
 
 The development process consists of first committing the intended changes into your fork of ClickHouse and then creating a “pull request” for these changes to be accepted into the main repository (ClickHouse/ClickHouse).
 
-To work with git repositories, please install `git`.
-
-To do that in Ubuntu you would run in the command line terminal:
+To work with Git repositories, please install `git`. To do that in Ubuntu you would run in the command line terminal:
 
     sudo apt update
     sudo apt install git
 
-A brief manual on using Git can be found here: https://education.github.com/git-cheat-sheet-education.pdf.
-For a detailed manual on Git see https://git-scm.com/book/en/v2.
+A brief manual on using Git can be found [here](https://education.github.com/git-cheat-sheet-education.pdf).
+For a detailed manual on Git see [here](https://git-scm.com/book/en/v2).
 
 ## Cloning a Repository to Your Development Machine {#cloning-a-repository-to-your-development-machine}
 
 Next, you need to download the source files onto your working machine. This is called “to clone a repository” because it creates a local copy of the repository on your working machine.
 
-In the command line terminal run:
+Run in your terminal:
 
-    git clone --shallow-submodules git@github.com:your_github_username/ClickHouse.git
+    git clone git@github.com:your_github_username/ClickHouse.git  # replace placeholder with your GitHub user name
     cd ClickHouse
 
-Or (if you'd like to use sparse checkout for submodules and avoid checking out unneeded files):
+This command will create a directory `ClickHouse/` containing the source code of ClickHouse. If you specify a custom checkout directory (after the URL), it is important that this path does not contain whitespaces as it may lead to problems with the build system.
 
-    git clone git@github.com:your_github_username/ClickHouse.git
-    cd ClickHouse
-    ./contrib/update-submodules.sh
+To make library dependencies available for the build, the ClickHouse repository uses Git submodules, i.e. references to external repositories. These are not checked out by default. To do so, you can either
 
-Note: please, substitute *your_github_username* with what is appropriate!
+- run `git clone` with option `--recurse-submodules`,
 
-This command will create a directory `ClickHouse` containing the working copy of the project.
+- if `git clone` did not check out submodules, run `git submodule update --init --jobs <N>` (e.g. `<N> = 12` to parallelize the checkout) to achieve the same as the previous alternative, or
 
-It is important that the path to the working directory contains no whitespaces as it may lead to problems with running the build system.
+- if `git clone` did not check out submodules and you like to use [sparse](https://github.blog/2020-01-17-bring-your-monorepo-down-to-size-with-sparse-checkout/) and [shallow](https://github.blog/2020-12-21-get-up-to-speed-with-partial-clone-and-shallow-clone/) submodule checkout to omit unneeded files and history in submodules to save space (ca. 5 GB instead of ca. 15 GB), run `./contrib/update-submodules.sh`. Not really recommended as it generally makes working with submodules less convenient and slower.
 
-Please note that ClickHouse repository uses `submodules`. That is what the references to additional repositories are called (i.e. external libraries on which the project depends). It means that when cloning the repository you need to specify the `--recursive` flag as in the example above. If the repository has been cloned without submodules, to download them you need to run the following:
-
-    git submodule init
-    git submodule update
-
-You can check the status with the command: `git submodule status`.
+You can check the Git status with the command: `git submodule status`.
 
 If you get the following error message:
 
@@ -82,36 +73,6 @@ You can also add original ClickHouse repo address to your local repository to pu
     git remote add upstream git@github.com:ClickHouse/ClickHouse.git
 
 After successfully running this command you will be able to pull updates from the main ClickHouse repo by running `git pull upstream master`.
-
-### Working with Submodules {#working-with-submodules}
-
-Working with submodules in git could be painful. Next commands will help to manage it:
-
-    # ! each command accepts
-    # Update remote URLs for submodules. Barely rare case
-    git submodule sync
-    # Add new submodules
-    git submodule init
-    # Update existing submodules to the current state
-    git submodule update
-    # Two last commands could be merged together
-    git submodule update --init
-
-The next commands would help you to reset all submodules to the initial state (!WARNING! - any changes inside will be deleted):
-
-    # Synchronizes submodules' remote URL with .gitmodules
-    git submodule sync
-    # Update the registered submodules with initialize not yet initialized
-    git submodule update --init
-    # Reset all changes done after HEAD
-    git submodule foreach git reset --hard
-    # Clean files from .gitignore
-    git submodule foreach git clean -xfd
-    # Repeat last 4 commands for all submodule
-    git submodule foreach git submodule sync
-    git submodule foreach git submodule update --init
-    git submodule foreach git submodule foreach git reset --hard
-    git submodule foreach git submodule foreach git clean -xfd
 
 ## Build System {#build-system}
 


### PR DESCRIPTION
... also omitted the "Working with submodules" part because it is rarely needed and overlaps with the documented steps to checkout the repo.

### Changelog category (leave one):
- Documentation (changelog entry is not required)