### PR TITLE
Fix ON CLUSTER queries without database on initial node

### DIFF
--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -1225,9 +1225,9 @@ BlockIO InterpreterCreateQuery::createTable(ASTCreateQuery & create)
     DatabasePtr database;
     bool need_add_to_database = !create.temporary;
     if (need_add_to_database)
-        database = DatabaseCatalog::instance().getDatabase(database_name);
+        database = DatabaseCatalog::instance().tryGetDatabase(database_name);
 
-    if (need_add_to_database && database->shouldReplicateQuery(getContext(), query_ptr))
+    if (need_add_to_database && database && database->shouldReplicateQuery(getContext(), query_ptr))
     {
         chassert(!ddl_guard);
         auto guard = DatabaseCatalog::instance().getDDLGuard(create.getDatabase(), create.getTable());
@@ -1241,6 +1241,9 @@ BlockIO InterpreterCreateQuery::createTable(ASTCreateQuery & create)
         chassert(!ddl_guard);
         return executeQueryOnCluster(create);
     }
+
+    if (need_add_to_database && !database)
+        throw Exception(ErrorCodes::UNKNOWN_DATABASE, "Database {} does not exist", backQuoteIfNeed(database_name));
 
     if (create.replace_table)
     {

--- a/tests/integration/test_external_cluster/configs/clusters.xml
+++ b/tests/integration/test_external_cluster/configs/clusters.xml
@@ -1,0 +1,12 @@
+<clickhouse>
+<remote_servers>
+    <external>
+        <shard>
+            <replica>
+                <host>data_node</host>
+                <port>9000</port>
+            </replica>
+        </shard>
+    </external>
+</remote_servers>
+</clickhouse>

--- a/tests/integration/test_external_cluster/test.py
+++ b/tests/integration/test_external_cluster/test.py
@@ -1,0 +1,69 @@
+import re
+import pytest
+from helpers.cluster import ClickHouseCluster
+from helpers.test_tools import assert_eq_with_retry
+
+cluster = ClickHouseCluster(__file__)
+
+control_node = cluster.add_instance(
+    "control_node",
+    main_configs=["configs/clusters.xml"],
+    with_zookeeper=True,
+)
+
+data_node = cluster.add_instance(
+    "data_node",
+    main_configs=["configs/clusters.xml"],
+    with_zookeeper=True,
+    macros={"shard": 1, "replica": 1},
+)
+
+uuid_regex = re.compile("[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}")
+
+
+def assert_create_query(node, database_name, table_name, expected):
+    replace_uuid = lambda x: re.sub(uuid_regex, "uuid", x)
+    query = "SELECT create_table_query FROM system.tables WHERE database='{}' AND table='{}'".format(
+        database_name, table_name
+    )
+    assert_eq_with_retry(node, query, expected, get_result=replace_uuid)
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def test_ddl(started_cluster):
+    control_node.query("CREATE DATABASE test_db ON CLUSTER 'external' ENGINE=Atomic")
+    control_node.query(
+        "CREATE TABLE test_db.test_table ON CLUSTER 'external' (id Int64) Engine=MergeTree ORDER BY id"
+    )
+    control_node.query(
+        "ALTER TABLE test_db.test_table ON CLUSTER 'external' add column data String"
+    )
+
+    expected = "CREATE TABLE test_db.test_table (`id` Int64, `data` String) ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 8192"
+    assert_create_query(data_node, "test_db", "test_table", expected)
+
+    control_node.query("DROP TABLE test_db.test_table ON CLUSTER 'external'")
+    control_node.query("DROP DATABASE test_db ON CLUSTER 'external'")
+
+    expected = ""
+    assert_create_query(data_node, "test_db", "test_table", expected)
+
+
+def test_ddl_replicated(started_cluster):
+    control_node.query(
+        "CREATE DATABASE test_db ON CLUSTER 'external' ENGINE=Replicated('/replicated')",
+        settings={"allow_experimental_database_replicated": 1},
+    )
+    # Exception is expected
+    assert "It's not initial query" in control_node.query_and_get_error(
+        "CREATE TABLE test_db.test_table ON CLUSTER 'external' (id Int64) Engine=MergeTree ORDER BY id"
+    )
+    control_node.query("DROP DATABASE test_db ON CLUSTER 'external'")


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix ON CLUSTER queries without the database being present on an initial node. Closes https://github.com/ClickHouse/ClickHouse/issues/55009