### PR TITLE
Fix startup failure due to TTL dependency

### DIFF
--- a/src/Databases/DDLLoadingDependencyVisitor.cpp
+++ b/src/Databases/DDLLoadingDependencyVisitor.cpp
@@ -1,4 +1,5 @@
 #include <Databases/DDLLoadingDependencyVisitor.h>
+#include <Databases/DDLDependencyVisitor.h>
 #include <Dictionaries/getDictionaryConfigurationFromAST.h>
 #include <Interpreters/Context.h>
 #include <Interpreters/misc.h>
@@ -7,6 +8,7 @@
 #include <Parsers/ASTIdentifier.h>
 #include <Parsers/ASTLiteral.h>
 #include <Parsers/ASTSelectWithUnionQuery.h>
+#include <Parsers/ASTTTLElement.h>
 #include <Poco/String.h>
 
 
@@ -22,6 +24,7 @@ TableNamesSet getLoadingDependenciesFromCreateQuery(ContextPtr global_context, c
     data.default_database = global_context->getCurrentDatabase();
     data.create_query = ast;
     data.global_context = global_context;
+    data.table_name = table;
     TableLoadingDependenciesVisitor visitor{data};
     visitor.visit(ast);
     data.dependencies.erase(table);
@@ -113,6 +116,12 @@ void DDLLoadingDependencyVisitor::visit(const ASTFunctionWithKeyValueArguments &
 
 void DDLLoadingDependencyVisitor::visit(const ASTStorage & storage, Data & data)
 {
+    if (storage.ttl_table)
+    {
+        auto ttl_dependensies = getDependenciesFromCreateQuery(data.global_context, data.table_name, storage.ttl_table->ptr());
+        data.dependencies.merge(ttl_dependensies);
+    }
+
     if (!storage.engine)
         return;
 

--- a/src/Databases/DDLLoadingDependencyVisitor.h
+++ b/src/Databases/DDLLoadingDependencyVisitor.h
@@ -38,6 +38,7 @@ public:
         TableNamesSet dependencies;
         ContextPtr global_context;
         ASTPtr create_query;
+        QualifiedTableName table_name;
     };
 
     using Visitor = ConstInDepthNodeVisitor<DDLLoadingDependencyVisitor, true>;

--- a/tests/queries/0_stateless/02908_table_ttl_dependency.sh
+++ b/tests/queries/0_stateless/02908_table_ttl_dependency.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Tags: no-ordinary-database
+# Tag no-ordinary-database: requires UUID
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+$CLICKHOUSE_CLIENT -nm -q "
+    DROP TABLE IF EXISTS 02908_dependent;
+    DROP TABLE IF EXISTS 02908_main;
+
+    CREATE TABLE 02908_main (a UInt32) ENGINE = MergeTree ORDER BY a;
+    CREATE TABLE 02908_dependent (a UInt32, ts DateTime) ENGINE = MergeTree ORDER BY a TTL ts + 1 WHERE a IN (SELECT a FROM ${CLICKHOUSE_DATABASE}.02908_main);
+"
+
+$CLICKHOUSE_CLIENT -nm -q "
+    DROP TABLE 02908_main;
+" 2>&1 | grep -F -q "HAVE_DEPENDENT_OBJECTS"
+
+$CLICKHOUSE_CLIENT -nm -q "
+    DROP TABLE 02908_dependent;
+    DROP TABLE 02908_main;
+"


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix startup failure and DROP query due to dependency on the other table in the subquery of TTL expression. Closes https://github.com/ClickHouse/ClickHouse/issues/56310
