### PR TITLE
Fix ALTER COLUMN with ALIAS

### DIFF
--- a/src/Storages/AlterCommands.cpp
+++ b/src/Storages/AlterCommands.cpp
@@ -1148,7 +1148,7 @@ void AlterCommands::validate(const StoragePtr & table, ContextPtr context) const
             /// The change of data type to/from Object is broken, so disable it for now
             if (command.data_type)
             {
-                const GetColumnsOptions options(GetColumnsOptions::AllPhysical);
+                const GetColumnsOptions options(GetColumnsOptions::All);
                 const auto old_data_type = all_columns.getColumn(options, column_name).type;
 
                 if (command.data_type->getName().contains("Object")

--- a/tests/queries/0_stateless/02908_alter_column_alias.reference
+++ b/tests/queries/0_stateless/02908_alter_column_alias.reference
@@ -1,0 +1,1 @@
+CREATE TABLE default.t\n(\n    `c0` DateTime,\n    `c1` DateTime,\n    `a` DateTime ALIAS c1\n)\nENGINE = MergeTree\nORDER BY tuple()\nSETTINGS index_granularity = 8192

--- a/tests/queries/0_stateless/02908_alter_column_alias.sql
+++ b/tests/queries/0_stateless/02908_alter_column_alias.sql
@@ -1,0 +1,8 @@
+CREATE TABLE t (
+    c0 DateTime,
+    c1 DateTime,
+    a DateTime alias toStartOfFifteenMinutes(c0)
+) ENGINE = MergeTree() ORDER BY tuple();
+
+ALTER TABLE t MODIFY COLUMN a DateTime ALIAS c1;
+SHOW CREATE t;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix ALTER COLUMN with ALIAS that previously threw the `NO_SUCH_COLUMN_IN_TABLE` exception. Closes https://github.com/ClickHouse/ClickHouse/issues/50927.
