### PR TITLE
Fix empty NAMED COLLECTIONs

### DIFF
--- a/src/Common/NamedCollections/NamedCollectionUtils.cpp
+++ b/src/Common/NamedCollections/NamedCollectionUtils.cpp
@@ -217,6 +217,12 @@ public:
         for (const auto & [name, value] : result_changes_map)
             create_query.changes.emplace_back(name, value);
 
+        if (create_query.changes.empty())
+            throw Exception(
+                ErrorCodes::BAD_ARGUMENTS,
+                "Named collection cannot be empty (collection name: {})",
+                query.collection_name);
+
         writeCreateQueryToMetadata(
             create_query,
             getMetadataPath(query.collection_name),

--- a/src/Parsers/ASTAlterNamedCollectionQuery.cpp
+++ b/src/Parsers/ASTAlterNamedCollectionQuery.cpp
@@ -14,7 +14,7 @@ ASTPtr ASTAlterNamedCollectionQuery::clone() const
 
 void ASTAlterNamedCollectionQuery::formatImpl(const IAST::FormatSettings & settings, IAST::FormatState &, IAST::FormatStateStacked) const
 {
-    settings.ostr << (settings.hilite ? hilite_keyword : "") << "Alter NAMED COLLECTION ";
+    settings.ostr << (settings.hilite ? hilite_keyword : "") << "ALTER NAMED COLLECTION ";
     if (if_exists)
         settings.ostr << "IF EXISTS ";
     settings.ostr << (settings.hilite ? hilite_identifier : "") << backQuoteIfNeed(collection_name) << (settings.hilite ? hilite_none : "");

--- a/tests/queries/0_stateless/02908_empty_named_collection.sql
+++ b/tests/queries/0_stateless/02908_empty_named_collection.sql
@@ -1,0 +1,5 @@
+-- Tags: no-parallel
+
+CREATE NAMED COLLECTION foobar03 AS a = 1;
+ALTER NAMED COLLECTION foobar03 DELETE b; -- { serverError BAD_ARGUMENTS }
+DROP NAMED COLLECTION foobar03;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix empty NAMED COLLECTIONs which broke `system.named_collections`. Closes https://github.com/ClickHouse/ClickHouse/issues/52696