### PR TITLE
Fix compilation of BackupsWorker.cpp

### DIFF
--- a/src/Backups/BackupsWorker.cpp
+++ b/src/Backups/BackupsWorker.cpp
@@ -552,7 +552,7 @@ void BackupsWorker::doBackup(
             {
                 BackupEntriesCollector backup_entries_collector(
                     backup_query->elements, backup_settings, backup_coordination,
-                    backup_create_params.read_settings, context, *backups_thread_pool);
+                    backup_create_params.read_settings, context, getThreadPool(ThreadPoolId::BACKUP_MAKE_FILES_LIST));
                 backup_entries = backup_entries_collector.run();
             }
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Two PRs https://github.com/ClickHouse/ClickHouse/pull/56312 and https://github.com/ClickHouse/ClickHouse/pull/55216 were merged nearly at the same time.