### PR TITLE
Removes duplicated slugs in docs.

### DIFF
--- a/docs/en/getting-started/example-datasets/wikistat.md
+++ b/docs/en/getting-started/example-datasets/wikistat.md
@@ -1,5 +1,4 @@
 ---
-slug: /en/getting-started/example-datasets/wikistat
 sidebar_label: WikiStat
 ---
 

--- a/docs/en/operations/optimizing-performance/profile-guided-optimization.md
+++ b/docs/en/operations/optimizing-performance/profile-guided-optimization.md
@@ -1,5 +1,4 @@
 ---
-slug: /en/operations/optimizing-performance/profile-guided-optimization
 sidebar_position: 54
 sidebar_label: Profile Guided Optimization (PGO)
 ---


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

---

Closes https://github.com/ClickHouse/clickhouse-docs/issues/1654

We're getting some warning when building the docs site:

```plaintext
10:50:07 AM: - Attempting to create page at /docs/en/getting-started/example-datasets/wikistat, but a page already exists at this route.
10:50:07 AM: - Attempting to create page at /docs/en/getting-started/example-datasets/wikistat, but a page already exists at this route.
10:50:07 AM: - Attempting to create page at /docs/en/operations/optimizing-performance/profile-guided-optimization, but a page already exists at this route.
10:50:07 AM: - Attempting to create page at /docs/en/operations/optimizing-performance/profile-guided-optimization, but a page already exists at this route.
10:50:07 AM: This could lead to non-deterministic routing behavior.
```

This is because the two files changed in this PR (`/docs/en/operations/optimizing-performance/profile-guided-optimization.md` and `/docs/en/getting-started/example-datasets/wikistat.md` had slugs identical to the addresses given to them by Docusaurs at build-time.

Removing these two slugs from the front-matter removed the above error. The pages are still available are their normal addresses -- there are no redirects needed.