### PR TITLE
Allow `chassert` to guide the static analyzer

### DIFF
--- a/base/base/defines.h
+++ b/base/base/defines.h
@@ -119,7 +119,7 @@
         #include <base/types.h>
         namespace DB
         {
-            void abortOnFailedAssertion(const String & description);
+            [[noreturn]] void abortOnFailedAssertion(const String & description);
         }
         #define chassert(x) do { static_cast<bool>(x) ? void(0) : ::DB::abortOnFailedAssertion(#x); } while (0)
         #define UNREACHABLE() abort()

--- a/base/base/defines.h
+++ b/base/base/defines.h
@@ -125,6 +125,9 @@
         #define UNREACHABLE() abort()
         // clang-format off
     #else
+        /// Here sizeof() trick is used to suppress unused warning for result,
+        /// since simple "(void)x" will evaluate the expression, while
+        /// "sizeof(!(x))" will not.
         #define chassert(x) (void)sizeof(!(x))
         #define UNREACHABLE() __builtin_unreachable()
     #endif

--- a/base/base/defines.h
+++ b/base/base/defines.h
@@ -125,11 +125,7 @@
         #define UNREACHABLE() abort()
         // clang-format off
     #else
-        /// Here sizeof() trick is used to suppress unused warning for result,
-        /// since simple "(void)x" will evaluate the expression, while
-        /// "sizeof(!(x))" will not.
-        #define NIL_EXPRESSION(x) (void)sizeof(!(x))
-        #define chassert(x) NIL_EXPRESSION(x)
+        #define chassert(x) (void)sizeof(!(x))
         #define UNREACHABLE() __builtin_unreachable()
     #endif
 #endif

--- a/base/base/defines.h
+++ b/base/base/defines.h
@@ -121,7 +121,7 @@
         {
             void abortOnFailedAssertion(const String & description);
         }
-        #define chassert(x) static_cast<bool>(x) ? void(0) : ::DB::abortOnFailedAssertion(#x)
+        #define chassert(x) do { static_cast<bool>(x) ? void(0) : ::DB::abortOnFailedAssertion(#x); } while (0)
         #define UNREACHABLE() abort()
         // clang-format off
     #else

--- a/src/Common/Exception.cpp
+++ b/src/Common/Exception.cpp
@@ -41,12 +41,6 @@ namespace ErrorCodes
 void abortOnFailedAssertion(const String & description)
 {
     LOG_FATAL(&Poco::Logger::root(), "Logical error: '{}'.", description);
-
-    /// This is to suppress -Wmissing-noreturn
-    volatile bool always_false = false;
-    if (always_false)
-        return;
-
     abort();
 }
 

--- a/src/Common/Exception.h
+++ b/src/Common/Exception.h
@@ -19,7 +19,7 @@ namespace Poco { class Logger; }
 namespace DB
 {
 
-void abortOnFailedAssertion(const String & description);
+[[noreturn]] void abortOnFailedAssertion(const String & description);
 
 /// This flag can be set for testing purposes - to check that no exceptions are thrown.
 extern bool terminate_on_any_exception;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Extract from #56350