### PR TITLE
Fix `test_keeper_four_word_command/test.py::test_cmd_crst`

### DIFF
--- a/tests/integration/test_keeper_four_word_command/test.py
+++ b/tests/integration/test_keeper_four_word_command/test.py
@@ -460,12 +460,19 @@ def test_cmd_crst(started_cluster):
         print("cons output(after crst) -------------------------------------")
         print(data)
 
-        # 2 connections, 1 for 'cons' command, 1 for zk
+        # 2 or 3 connections, 1 for 'crst', 1 for 'cons' command, 1 for zk
+        # there can be a case when 'crst' connection is not cleaned before the cons call
+        print("cons output(after crst) -------------------------------------")
+        print(data)
         cons = [n for n in data.split("\n") if len(n) > 0]
-        assert len(cons) == 2
+        assert len(cons) == 2 or len(cons) == 3
 
         # connection for zk
-        zk_conn = [n for n in cons if not n.__contains__("sid=0xffffffffffffffff")][0]
+        zk_conns = [n for n in cons if not n.__contains__("sid=0xffffffffffffffff")]
+
+        # there can only be one
+        assert len(zk_conns) == 1
+        zk_conn = zk_conns[0]
 
         conn_stat = re.match(r"(.*?)[:].*[(](.*?)[)].*", zk_conn.strip(), re.S).group(2)
         assert conn_stat is not None


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)



### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
