### PR TITLE
Update `query_masking_rules` when reloading the config

### DIFF
--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -1372,6 +1372,8 @@ try
 
                 global_context->reloadAuxiliaryZooKeepersConfigIfChanged(config);
 
+                global_context->reloadQueryMaskingRulesIfChanged(config);
+
                 std::lock_guard lock(servers_lock);
                 updateServers(*config, server_pool, async_metrics, servers, servers_to_start_before_tables);
             }

--- a/src/Common/SensitiveDataMasker.cpp
+++ b/src/Common/SensitiveDataMasker.cpp
@@ -104,6 +104,10 @@ void SensitiveDataMasker::setInstance(std::unique_ptr<SensitiveDataMasker> sensi
     {
         sensitive_data_masker = std::move(sensitive_data_masker_);
     }
+    else
+    {
+        sensitive_data_masker.reset();
+    }
 }
 
 SensitiveDataMasker * SensitiveDataMasker::getInstance()

--- a/src/Common/SensitiveDataMasker.cpp
+++ b/src/Common/SensitiveDataMasker.cpp
@@ -1,5 +1,6 @@
 #include "SensitiveDataMasker.h"
 
+#include <mutex>
 #include <set>
 #include <string>
 #include <atomic>
@@ -94,9 +95,12 @@ public:
 SensitiveDataMasker::~SensitiveDataMasker() = default;
 
 std::unique_ptr<SensitiveDataMasker> SensitiveDataMasker::sensitive_data_masker = nullptr;
+std::mutex SensitiveDataMasker::instance_mutex;
 
 void SensitiveDataMasker::setInstance(std::unique_ptr<SensitiveDataMasker> sensitive_data_masker_)
 {
+    std::lock_guard lock(instance_mutex);
+
     if (!sensitive_data_masker_)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Logical error: the 'sensitive_data_masker' is not set");
 
@@ -112,6 +116,7 @@ void SensitiveDataMasker::setInstance(std::unique_ptr<SensitiveDataMasker> sensi
 
 SensitiveDataMasker * SensitiveDataMasker::getInstance()
 {
+    std::lock_guard lock(instance_mutex);
     return sensitive_data_masker.get();
 }
 

--- a/src/Common/SensitiveDataMasker.cpp
+++ b/src/Common/SensitiveDataMasker.cpp
@@ -99,11 +99,11 @@ std::mutex SensitiveDataMasker::instance_mutex;
 
 void SensitiveDataMasker::setInstance(std::unique_ptr<SensitiveDataMasker> sensitive_data_masker_)
 {
-    std::lock_guard lock(instance_mutex);
 
     if (!sensitive_data_masker_)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Logical error: the 'sensitive_data_masker' is not set");
 
+    std::lock_guard lock(instance_mutex);
     if (sensitive_data_masker_->rulesCount() > 0)
     {
         sensitive_data_masker = std::move(sensitive_data_masker_);

--- a/src/Common/SensitiveDataMasker.h
+++ b/src/Common/SensitiveDataMasker.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <mutex>
 #include <vector>
 #include <cstdint>
 
@@ -45,6 +46,7 @@ class SensitiveDataMasker
 private:
     class MaskingRule;
     std::vector<std::unique_ptr<MaskingRule>> all_masking_rules;
+    static std::mutex instance_mutex;
     static std::unique_ptr<SensitiveDataMasker> sensitive_data_masker;
 
 public:

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -197,7 +197,6 @@ struct ContextSharedPart : boost::noncopyable
     mutable zkutil::ZooKeeperPtr zookeeper TSA_GUARDED_BY(zookeeper_mutex);                 /// Client for ZooKeeper.
     ConfigurationPtr zookeeper_config TSA_GUARDED_BY(zookeeper_mutex);                      /// Stores zookeeper configs
 
-    mutable std::mutex sensitive_data_masker_mutex;
     ConfigurationPtr sensitive_data_masker_config;
 
 #if USE_NURAFT
@@ -3204,8 +3203,6 @@ bool Context::hasAuxiliaryZooKeeper(const String & name) const
 
 void Context::reloadQueryMaskingRulesIfChanged(const ConfigurationPtr & config) const
 {
-    std::lock_guard lock(shared->sensitive_data_masker_mutex);
-
     const auto old_config = shared->sensitive_data_masker_config;
     if (old_config && isSameConfiguration(*config, *old_config, "query_masking_rules"))
         return;

--- a/src/Interpreters/Context.h
+++ b/src/Interpreters/Context.h
@@ -946,6 +946,8 @@ public:
     // Reload Zookeeper
     void reloadZooKeeperIfChanged(const ConfigurationPtr & config) const;
 
+    void reloadQueryMaskingRulesIfChanged(const ConfigurationPtr & config) const;
+
     void setSystemZooKeeperLogAfterInitializationIfNeeded();
 
     /// --- Caches ------------------------------------------------------------------------------------------

--- a/tests/integration/test_reload_query_masking_rules/configs/changed_settings.xml
+++ b/tests/integration/test_reload_query_masking_rules/configs/changed_settings.xml
@@ -1,0 +1,19 @@
+<clickhouse>
+    <query_log>
+        <database>system</database>
+        <table>query_log</table>
+        <partition_by>toYYYYMM(event_date)</partition_by>
+        <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+        <max_size_rows>1048576</max_size_rows>
+        <reserved_size_rows>8192</reserved_size_rows>
+        <buffer_size_rows_flush_threshold>524288</buffer_size_rows_flush_threshold>
+        <flush_on_crash>false</flush_on_crash>
+    </query_log>
+
+    <query_masking_rules>
+        <rule>
+            <regexp>TOPSECRET.TOPSECRET</regexp>
+            <replace>[hidden]</replace>
+        </rule>
+    </query_masking_rules>
+</clickhouse>

--- a/tests/integration/test_reload_query_masking_rules/configs/empty_settings.xml
+++ b/tests/integration/test_reload_query_masking_rules/configs/empty_settings.xml
@@ -1,0 +1,12 @@
+<clickhouse>
+    <query_log>
+        <database>system</database>
+        <table>query_log</table>
+        <partition_by>toYYYYMM(event_date)</partition_by>
+        <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+        <max_size_rows>1048576</max_size_rows>
+        <reserved_size_rows>8192</reserved_size_rows>
+        <buffer_size_rows_flush_threshold>524288</buffer_size_rows_flush_threshold>
+        <flush_on_crash>false</flush_on_crash>
+    </query_log>
+</clickhouse>

--- a/tests/integration/test_reload_query_masking_rules/test.py
+++ b/tests/integration/test_reload_query_masking_rules/test.py
@@ -1,0 +1,74 @@
+import pytest
+import os
+from helpers.cluster import ClickHouseCluster
+from helpers.test_tools import assert_eq_with_retry, assert_logs_contain_with_retry
+
+SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
+cluster = ClickHouseCluster(__file__)
+node = cluster.add_instance("node", user_configs=["configs/empty_settings.xml"])
+
+
+@pytest.fixture(scope="module", autouse=True)
+def started_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+@pytest.fixture(autouse=True)
+def reset_to_normal_settings_after_test():
+    try:
+        node.copy_file_to_container(
+            os.path.join(SCRIPT_DIR, "configs/empty_settings.xml"),
+            "/etc/clickhouse-server/config.d/z.xml",
+        )
+        node.query("SYSTEM RELOAD CONFIG")
+        yield
+    finally:
+        pass
+
+
+# @pytest.mark.parametrize("reload_strategy", ["force", "timeout"])
+def test_reload_query_masking_rules():
+    # At first, empty configuration is fed to ClickHouse. The query
+    # "SELECT 'TOPSECRET.TOPSECRET'" will not be redacted, and the new masking
+    # event will not be registered
+    node.query("SELECT 'TOPSECRET.TOPSECRET'")
+    assert_logs_contain_with_retry(node, "SELECT 'TOPSECRET.TOPSECRET'")
+
+    # If there were no 'QueryMaskingRulesMatch' events, the query below returns
+    # 0 rows
+    assert (
+        node.query(
+            "SELECT count(value) FROM system.events WHERE name = 'QueryMaskingRulesMatch'"
+        )
+        == "0\n"
+    )
+
+    node.copy_file_to_container(
+        os.path.join(SCRIPT_DIR, "configs/changed_settings.xml"),
+        "/etc/clickhouse-server/config.d/z.xml",
+    )
+
+    node.query("SYSTEM RELOAD CONFIG")
+
+    # Now the same query will be redacted in the logs and the counter of events
+    # will be incremented
+    node.query("SELECT 'TOPSECRET.TOPSECRET'")
+
+    assert_eq_with_retry(
+        node,
+        "SELECT count(value) FROM system.events WHERE name = 'QueryMaskingRulesMatch'",
+        "1",
+    )
+    assert_logs_contain_with_retry(node, r"SELECT '\[hidden\]'")
+    assert (
+        node.query(
+            "SELECT value FROM system.events WHERE name = 'QueryMaskingRulesMatch'"
+        )
+        == "1\n"
+    )
+
+    node.rotate_logs()


### PR DESCRIPTION
Fixes #56449.

`query_masking_rules` are taken into account upon server start and redact the log entries. However, its changes are currently not being taken into account on config reload. In order to change this setting, you have to restart the server. This commit fixes that by adding checking this setting for changes as well.

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Update `query_masking_rules` when reloading the config (#56449)

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
