### PR TITLE
add exception handling on PG connection for unavailable connection

### DIFF
--- a/src/Core/PostgreSQL/Connection.cpp
+++ b/src/Core/PostgreSQL/Connection.cpp
@@ -59,8 +59,16 @@ void Connection::updateConnection()
     if (connection)
         connection->close();
 
-    /// Always throws if there is no connection.
-    connection = std::make_unique<pqxx::connection>(connection_info.connection_string);
+    try
+    {
+        /// Always throws if there is no connection.
+        connection = std::make_unique<pqxx::connection>(connection_info.connection_string);
+    }
+    catch (const pqxx::broken_connection & e)
+    {
+        LOG_ERROR(log, "Unable to update connection: {}", e.what());
+        throw;
+    }
 
     if (replication)
         connection->set_variable("default_transaction_isolation", "'repeatable read'");


### PR DESCRIPTION
Related to #51277, but this pr fixes a general bug and is also a partial fix of the issue.
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix potential connection failure of PostgreSQL by throwing exception to the upper level