### PR TITLE
Less aggressive reschedule with unavailable conn of PG

### DIFF
--- a/src/Databases/PostgreSQL/DatabasePostgreSQL.cpp
+++ b/src/Databases/PostgreSQL/DatabasePostgreSQL.cpp
@@ -334,10 +334,10 @@ void DatabasePostgreSQL::removeOutdatedTables()
     {
         tryLogCurrentException(__PRETTY_FUNCTION__);
 
-        /** Avoid repeated interrupting other normal routines (they acquire locks!) 
-          * for the case of unavailable connection, since it is possible to be 
-          * unsuccessful again, and the unsuccessful conn is very time-consuming: 
-          * connection period is exclusive and timeout is at least 2 seconds for 
+        /** Avoid repeated interrupting other normal routines (they acquire locks!)
+          * for the case of unavailable connection, since it is possible to be
+          * unsuccessful again, and the unsuccessful conn is very time-consuming:
+          * connection period is exclusive and timeout is at least 2 seconds for
           * PostgreSQL.
           */
         cleaner_task->scheduleAfter(reschedule_error_multiplier * cleaner_reschedule_ms);

--- a/src/Databases/PostgreSQL/DatabasePostgreSQL.cpp
+++ b/src/Databases/PostgreSQL/DatabasePostgreSQL.cpp
@@ -36,6 +36,7 @@ namespace ErrorCodes
 
 static const auto suffix = ".removed";
 static const auto cleaner_reschedule_ms = 60000;
+static const auto reschedule_error_multiplier = 10;
 
 DatabasePostgreSQL::DatabasePostgreSQL(
         ContextPtr context_,
@@ -332,7 +333,13 @@ void DatabasePostgreSQL::removeOutdatedTables()
     catch (...)
     {
         tryLogCurrentException(__PRETTY_FUNCTION__);
-        cleaner_task->scheduleAfter(cleaner_reschedule_ms);
+
+        /// Avoid repeated interrupting other normal routines (they acquire locks!) 
+        /// for the case of unavailable connection, since it is possible to be 
+        /// unsuccessful again, and the unsuccessful conn is very time-consuming: 
+        /// connection period is exclusive and timeout is at least 2 seconds for 
+        /// PostgreSQL.
+        cleaner_task->scheduleAfter(reschedule_error_multiplier * cleaner_reschedule_ms);
         return;
     }
 

--- a/src/Databases/PostgreSQL/DatabasePostgreSQL.cpp
+++ b/src/Databases/PostgreSQL/DatabasePostgreSQL.cpp
@@ -334,11 +334,12 @@ void DatabasePostgreSQL::removeOutdatedTables()
     {
         tryLogCurrentException(__PRETTY_FUNCTION__);
 
-        /// Avoid repeated interrupting other normal routines (they acquire locks!) 
-        /// for the case of unavailable connection, since it is possible to be 
-        /// unsuccessful again, and the unsuccessful conn is very time-consuming: 
-        /// connection period is exclusive and timeout is at least 2 seconds for 
-        /// PostgreSQL.
+        /** Avoid repeated interrupting other normal routines (they acquire locks!) 
+          * for the case of unavailable connection, since it is possible to be 
+          * unsuccessful again, and the unsuccessful conn is very time-consuming: 
+          * connection period is exclusive and timeout is at least 2 seconds for 
+          * PostgreSQL.
+          */
         cleaner_task->scheduleAfter(reschedule_error_multiplier * cleaner_reschedule_ms);
         return;
     }


### PR DESCRIPTION
Related to #51277, when unavailable conn pops up for Postgres, aggressive schedule of removeOutdatedTables() delays normal threads reading within time constraint , as these threads compete with each other for locks. Because it is an unsuccessful conn, it might be unsuccessful again, why not reduce the frequence of removeOutdatedTables()?
 
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
make removeOutdatedTables() less aggressive with unsuccessful Postgres connection 