### PR TITLE
Add 4-letter command for yielding leadership

### DIFF
--- a/docs/en/operations/utilities/clickhouse-keeper-client.md
+++ b/docs/en/operations/utilities/clickhouse-keeper-client.md
@@ -12,6 +12,7 @@ A client application to interact with clickhouse-keeper by its native protocol.
 -   `-q QUERY`, `--query=QUERY` — Query to execute. If this parameter is not passed, `clickhouse-keeper-client` will start in interactive mode.
 -   `-h HOST`, `--host=HOST` — Server host. Default value: `localhost`.
 -   `-p N`, `--port=N` — Server port. Default value: 9181
+-   `-c FILE_PATH`, `--config-file=FILE_PATH` — Set path of config file to get the connection string. Default value: `config.xml`.
 -   `--connection-timeout=TIMEOUT` — Set connection timeout in seconds. Default value: 10s.
 -   `--session-timeout=TIMEOUT` — Set session timeout in seconds. Default value: 10s.
 -   `--operation-timeout=TIMEOUT` — Set operation timeout in seconds. Default value: 10s.

--- a/src/Coordination/CoordinationSettings.cpp
+++ b/src/Coordination/CoordinationSettings.cpp
@@ -36,7 +36,7 @@ void CoordinationSettings::loadFromConfig(const String & config_elem, const Poco
 }
 
 
-const String KeeperConfigurationAndSettings::DEFAULT_FOUR_LETTER_WORD_CMD = "conf,cons,crst,envi,ruok,srst,srvr,stat,wchs,dirs,mntr,isro,rcvr,apiv,csnp,lgif,rqld,rclc,clrs,ftfl";
+const String KeeperConfigurationAndSettings::DEFAULT_FOUR_LETTER_WORD_CMD = "conf,cons,crst,envi,ruok,srst,srvr,stat,wchs,dirs,mntr,isro,rcvr,apiv,csnp,lgif,rqld,rclc,clrs,ftfl,ydld";
 
 KeeperConfigurationAndSettings::KeeperConfigurationAndSettings()
     : server_id(NOT_EXIST)

--- a/src/Coordination/FourLetterCommand.cpp
+++ b/src/Coordination/FourLetterCommand.cpp
@@ -172,6 +172,9 @@ void FourLetterCommandFactory::registerCommands(KeeperDispatcher & keeper_dispat
         FourLetterCommandPtr feature_flags_command = std::make_shared<FeatureFlagsCommand>(keeper_dispatcher);
         factory.registerCommand(feature_flags_command);
 
+        FourLetterCommandPtr yield_leadership_command = std::make_shared<YieldLeadershipCommand>(keeper_dispatcher);
+        factory.registerCommand(yield_leadership_command);
+
         factory.initializeAllowList(keeper_dispatcher);
         factory.setInitialize(true);
     }
@@ -577,6 +580,12 @@ String FeatureFlagsCommand::run()
     }
 
     return ret.str();
+}
+
+String YieldLeadershipCommand::run()
+{
+    keeper_dispatcher.yieldLeadership();
+    return "Sent yield leadership request to leader.";
 }
 
 }

--- a/src/Coordination/FourLetterCommand.h
+++ b/src/Coordination/FourLetterCommand.h
@@ -415,4 +415,17 @@ struct FeatureFlagsCommand : public IFourLetterCommand
     ~FeatureFlagsCommand() override = default;
 };
 
+/// Yield leadership and become follower.
+struct YieldLeadershipCommand : public IFourLetterCommand
+{
+    explicit YieldLeadershipCommand(KeeperDispatcher & keeper_dispatcher_)
+        : IFourLetterCommand(keeper_dispatcher_)
+    {
+    }
+
+    String name() override { return "ydld"; }
+    String run() override;
+    ~YieldLeadershipCommand() override = default;
+};
+
 }

--- a/src/Coordination/KeeperDispatcher.h
+++ b/src/Coordination/KeeperDispatcher.h
@@ -237,6 +237,12 @@ public:
         return server->requestLeader();
     }
 
+    /// Yield leadership and become follower.
+    void yieldLeadership()
+    {
+        return server->yieldLeadership();
+    }
+
     void recalculateStorageStats()
     {
         return server->recalculateStorageStats();

--- a/src/Coordination/KeeperServer.cpp
+++ b/src/Coordination/KeeperServer.cpp
@@ -1101,6 +1101,12 @@ bool KeeperServer::requestLeader()
     return isLeader() || raft_instance->request_leadership();
 }
 
+void KeeperServer::yieldLeadership()
+{
+    if (isLeader())
+        raft_instance->yield_leadership();
+}
+
 void KeeperServer::recalculateStorageStats()
 {
     state_machine->recalculateStorageStats();

--- a/src/Coordination/KeeperServer.h
+++ b/src/Coordination/KeeperServer.h
@@ -144,6 +144,8 @@ public:
 
     bool requestLeader();
 
+    void yieldLeadership();
+
     void recalculateStorageStats();
 };
 

--- a/tests/integration/helpers/keeper_utils.py
+++ b/tests/integration/helpers/keeper_utils.py
@@ -248,6 +248,11 @@ def is_leader(cluster, node, port=9181):
     return "Mode: leader" in stat
 
 
+def is_follower(cluster, node, port=9181):
+    stat = send_4lw_cmd(cluster, node, "stat", port)
+    return "Mode: follower" in stat
+
+
 def get_leader(cluster, nodes):
     for node in nodes:
         if is_leader(cluster, node):

--- a/tests/integration/test_keeper_four_word_command/test.py
+++ b/tests/integration/test_keeper_four_word_command/test.py
@@ -725,3 +725,26 @@ def test_cmd_clrs(started_cluster):
 
     finally:
         destroy_zk_client(zk)
+
+
+def test_cmd_ydld(started_cluster):
+    wait_nodes()
+    for node in [node1, node3]:
+        data = keeper_utils.send_4lw_cmd(cluster, node, cmd="ydld")
+        assert data == "Sent yield leadership request to leader."
+
+        print("ydld output -------------------------------------")
+        print(data)
+
+        if keeper_utils.is_leader(cluster, node):
+            # wait for it to yield leadership
+            retry = 0
+            while keeper_utils.is_leader(cluster, node) and retry < 30:
+                time.sleep(1)
+                retry += 1
+            if retry == 30:
+                print(
+                    node.name
+                    + " did not yield leadership after 30s, maybe there is something wrong."
+                )
+        assert keeper_utils.is_follower(cluster, node)

--- a/tests/integration/test_keeper_four_word_command/test.py
+++ b/tests/integration/test_keeper_four_word_command/test.py
@@ -736,15 +736,19 @@ def test_cmd_ydld(started_cluster):
         print("ydld output -------------------------------------")
         print(data)
 
-        if keeper_utils.is_leader(cluster, node):
+        # Whenever there is a leader switch, there is a brief amount of time when any
+        # of the 4 letter commands will return empty result. Thus, we need to test for
+        # negative condition. So we can't use keeper_utils.is_leader() here and likewise
+        # in the while loop below.
+        if not keeper_utils.is_follower(cluster, node):
             # wait for it to yield leadership
             retry = 0
-            while keeper_utils.is_leader(cluster, node) and retry < 30:
+            while not keeper_utils.is_follower(cluster, node) and retry < 30:
                 time.sleep(1)
                 retry += 1
             if retry == 30:
                 print(
                     node.name
-                    + " did not yield leadership after 30s, maybe there is something wrong."
+                    + " did not become follower after 30s of yielding leadership, maybe there is something wrong."
                 )
         assert keeper_utils.is_follower(cluster, node)


### PR DESCRIPTION
### Changelog category (leave one):
- New Feature


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Add 4-letter command for yielding/resigning leadership

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

### Description

Resolves https://github.com/ClickHouse/ClickHouse/issues/56352

The earlier PR was reverted https://github.com/ClickHouse/ClickHouse/pull/56611 due to failing test. I overlooked few things in previous test.

Whenever there is a leader switch, there is a brief amount of time when any of the 4 letter commands will return empty result. I ran a test where in one terminal i ran the following script
```
while true; do echo -n $(date +%s); echo mntr | nc localhost 9181 | grep zk_server_state | awk -F"zk_server_state" '{print $2}'; done
```
In another terminal i triggered the leader election.
Result:
```
1699693165      leader
1699693165      leader
1699693165      leader
1699693165
1699693165
1699693165
1699693165
1699693165
1699693165
1699693165
1699693165
1699693165
1699693165
1699693165
1699693165
1699693165
1699693165      follower
1699693165      follower
1699693165      follower
1699693165      follower
1699693165      follower
```
This was causing the test to fail. Modified the test to take care of the above scenario.