### PR TITLE
add ecto_ch to client-libraries.md

### DIFF
--- a/docs/en/interfaces/third-party/client-libraries.md
+++ b/docs/en/interfaces/third-party/client-libraries.md
@@ -74,6 +74,7 @@ ClickHouse Inc does **not** maintain the libraries listed below and hasn’t don
 ### Elixir
  - [clickhousex](https://github.com/appodeal/clickhousex/)
  - [pillar](https://github.com/sofakingworld/pillar)
+ - [ecto_ch](https://github.com/plausible/ecto_ch)
 ### Nim
  - [nim-clickhouse](https://github.com/leonardoce/nim-clickhouse)
 ### Haskell


### PR DESCRIPTION
### Changelog category (leave one):
- Documentation

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

This PR adds https://github.com/plausible/ecto_ch to the list of client libraries.
