### PR TITLE
Introduce short names for `clickhouse-client` and `clickhouse-local`

### DIFF
--- a/docker/test/stateless/run.sh
+++ b/docker/test/stateless/run.sh
@@ -19,6 +19,11 @@ dpkg -i package_folder/clickhouse-common-static-dbg_*.deb
 dpkg -i package_folder/clickhouse-server_*.deb
 dpkg -i package_folder/clickhouse-client_*.deb
 
+# Check that the tools are available under short names
+ch --query "SELECT 1" || exit 1
+chl --query "SELECT 1" || exit 1
+chc --version || exit 1
+
 ln -s /usr/share/clickhouse-test/clickhouse-test /usr/bin/clickhouse-test
 
 # shellcheck disable=SC1091

--- a/docker/test/stateless/run.sh
+++ b/docker/test/stateless/run.sh
@@ -67,7 +67,7 @@ if [ "$NUM_TRIES" -gt "1" ]; then
     export THREAD_FUZZER_pthread_mutex_unlock_AFTER_SLEEP_TIME_US=10000
 
     mkdir -p /var/run/clickhouse-server
-    # simpliest way to forward env variables to server
+    # simplest way to forward env variables to server
     sudo -E -u clickhouse /usr/bin/clickhouse-server --config /etc/clickhouse-server/config.xml --daemon --pid-file /var/run/clickhouse-server/clickhouse-server.pid
 else
     sudo clickhouse start


### PR DESCRIPTION
### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Make `clickhouse-local` and `clickhouse-client` available under short names (`ch`, `chl`, `chc`) for usability.