### PR TITLE
Enable --secure flag for clickhouse-client for hostnames pointing to clickhouse cloud

### DIFF
--- a/src/Client/ConnectionParameters.cpp
+++ b/src/Client/ConnectionParameters.cpp
@@ -30,7 +30,7 @@ ConnectionParameters::ConnectionParameters(const Poco::Util::AbstractConfigurati
     , port(connection_port.value_or(getPortFromConfig(config)))
 {
     bool is_secure = config.getBool("secure", false);
-    bool is_clickhouse_cloud = connection_host.ends_with(".clickhouse.cloud");
+    bool is_clickhouse_cloud = connection_host.ends_with(".clickhouse.cloud") || connection_host.ends_with(".clickhouse-staging.com");
     security = (is_secure || is_clickhouse_cloud) ? Protocol::Secure::Enable : Protocol::Secure::Disable;
 
     default_database = config.getString("database", "");

--- a/src/Client/ConnectionParameters.cpp
+++ b/src/Client/ConnectionParameters.cpp
@@ -30,7 +30,8 @@ ConnectionParameters::ConnectionParameters(const Poco::Util::AbstractConfigurati
     , port(connection_port.value_or(getPortFromConfig(config)))
 {
     bool is_secure = config.getBool("secure", false);
-    security = is_secure ? Protocol::Secure::Enable : Protocol::Secure::Disable;
+    bool is_clickhouse_cloud = connection_host.ends_with(".clickhouse.cloud");
+    security = (is_secure || is_clickhouse_cloud) ? Protocol::Secure::Enable : Protocol::Secure::Disable;
 
     default_database = config.getString("database", "");
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Resolves https://github.com/ClickHouse/ClickHouse/issues/50650