### PR TITLE
Reset PG's conn timeout and try times to avoid endless wait for unavailable URLs

### DIFF
--- a/src/Core/PostgreSQL/PoolWithFailover.h
+++ b/src/Core/PostgreSQL/PoolWithFailover.h
@@ -14,7 +14,7 @@
 
 static constexpr inline auto POSTGRESQL_POOL_DEFAULT_SIZE = 16;
 static constexpr inline auto POSTGRESQL_POOL_WAIT_TIMEOUT = 5000;
-static constexpr inline auto POSTGRESQL_POOL_WITH_FAILOVER_DEFAULT_MAX_TRIES = 5;
+static constexpr inline auto POSTGRESQL_POOL_WITH_FAILOVER_DEFAULT_MAX_TRIES = 2;
 
 namespace postgres
 {

--- a/src/Core/PostgreSQL/Utils.cpp
+++ b/src/Core/PostgreSQL/Utils.cpp
@@ -16,7 +16,7 @@ ConnectionInfo formatConnectionString(String dbname, String host, UInt16 port, S
         << " port=" << port
         << " user=" << DB::quote << user
         << " password=" << DB::quote << password
-        << " connect_timeout=10";
+        << " connect_timeout=2";
     return {out.str(), host + ':' + DB::toString(port)};
 }
 


### PR DESCRIPTION
Related to issue #51277, reset PG's conn timeout and try times to avoid endless wait for unavailable URLs

### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Currenting setting takes too much time to connnect to PG when URL is not right, so the relevant query stucks there and get cancelled 