### PR TITLE
Switch to SSL port for clickhouse-client for hostnames pointing to clickhouse cloud

### DIFF
--- a/programs/client/Client.cpp
+++ b/programs/client/Client.cpp
@@ -425,7 +425,7 @@ void Client::connect()
     if (hosts_and_ports.empty())
     {
         String host = config().getString("host", "localhost");
-        UInt16 port = ConnectionParameters::getPortFromConfig(config());
+        UInt16 port = ConnectionParameters::getPortFromConfig(config(), host);
         hosts_and_ports.emplace_back(HostAndPort{host, port});
     }
 

--- a/programs/local/LocalServer.cpp
+++ b/programs/local/LocalServer.cpp
@@ -424,7 +424,7 @@ void LocalServer::setupUsers()
 
 void LocalServer::connect()
 {
-    connection_parameters = ConnectionParameters(config());
+    connection_parameters = ConnectionParameters(config(), "localhost");
     connection = LocalConnection::createConnection(
         connection_parameters, global_context, need_render_progress, need_render_profile_events, server_display_name);
 }

--- a/src/Client/ConnectionParameters.cpp
+++ b/src/Client/ConnectionParameters.cpp
@@ -27,7 +27,7 @@ ConnectionParameters::ConnectionParameters(const Poco::Util::AbstractConfigurati
                                            std::string connection_host,
                                            std::optional<UInt16> connection_port)
     : host(connection_host)
-    , port(connection_port.value_or(getPortFromConfig(config)))
+    , port(connection_port.value_or(getPortFromConfig(config, connection_host)))
 {
     bool is_secure = config.getBool("secure", false);
     bool is_clickhouse_cloud = connection_host.ends_with(".clickhouse.cloud") || connection_host.ends_with(".clickhouse-staging.com");
@@ -113,16 +113,19 @@ ConnectionParameters::ConnectionParameters(const Poco::Util::AbstractConfigurati
     timeouts.sync_request_timeout = Poco::Timespan(config.getInt("sync_request_timeout", DBMS_DEFAULT_SYNC_REQUEST_TIMEOUT_SEC), 0);
 }
 
-ConnectionParameters::ConnectionParameters(const Poco::Util::AbstractConfiguration & config)
-    : ConnectionParameters(config, config.getString("host", "localhost"), getPortFromConfig(config))
+ConnectionParameters::ConnectionParameters(const Poco::Util::AbstractConfiguration & config,
+                                           std::string connection_host)
+    : ConnectionParameters(config, config.getString("host", "localhost"), getPortFromConfig(config, connection_host))
 {
 }
 
-UInt16 ConnectionParameters::getPortFromConfig(const Poco::Util::AbstractConfiguration & config)
+UInt16 ConnectionParameters::getPortFromConfig(const Poco::Util::AbstractConfiguration & config,
+                                               std::string connection_host)
 {
     bool is_secure = config.getBool("secure", false);
+    bool is_clickhouse_cloud = connection_host.ends_with(".clickhouse.cloud") || connection_host.ends_with(".clickhouse-staging.com");
     return config.getInt("port",
-        config.getInt(is_secure ? "tcp_port_secure" : "tcp_port",
-            is_secure ? DBMS_DEFAULT_SECURE_PORT : DBMS_DEFAULT_PORT));
+        config.getInt(is_secure || is_clickhouse_cloud ? "tcp_port_secure" : "tcp_port",
+            is_secure || is_clickhouse_cloud ? DBMS_DEFAULT_SECURE_PORT : DBMS_DEFAULT_PORT));
 }
 }

--- a/src/Client/ConnectionParameters.h
+++ b/src/Client/ConnectionParameters.h
@@ -26,10 +26,10 @@ struct ConnectionParameters
     ConnectionTimeouts timeouts;
 
     ConnectionParameters() = default;
-    ConnectionParameters(const Poco::Util::AbstractConfiguration & config);
+    ConnectionParameters(const Poco::Util::AbstractConfiguration & config, std::string host);
     ConnectionParameters(const Poco::Util::AbstractConfiguration & config, std::string host, std::optional<UInt16> port);
 
-    static UInt16 getPortFromConfig(const Poco::Util::AbstractConfiguration & config);
+    static UInt16 getPortFromConfig(const Poco::Util::AbstractConfiguration & config, std::string connection_host);
 
     /// Ask to enter the user's password if password option contains this value.
     /// "\n" is used because there is hardly a chance that a user would use '\n' as password.


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Resolves https://github.com/ClickHouse/ClickHouse/issues/50650

Earlier [PR](https://github.com/ClickHouse/ClickHouse/pull/56638) missed the part of changing port.

I tested this branch locally:

```
❯ ./build/programs/clickhouse-client --host <host> --password <password>
ClickHouse client version 23.11.1.1.
Connecting to vqrnur2y11.us-east-2.aws.clickhouse-staging.com:9440 as user default.
Connected to ClickHouse server version 23.9.2 revision 54466.

ClickHouse server version is older than ClickHouse client. It may indicate that the server is out of date and can be upgraded.

clickhouse-cloud :)
```

cc @alexey-milovidov 
