### PR TITLE
Remove garbage from libssh

### DIFF
--- a/contrib/libssh-cmake/CMakeLists.txt
+++ b/contrib/libssh-cmake/CMakeLists.txt
@@ -7,12 +7,6 @@ endif()
 
 set(LIB_SOURCE_DIR "${ClickHouse_SOURCE_DIR}/contrib/libssh")
 set(LIB_BINARY_DIR "${ClickHouse_BINARY_DIR}/contrib/libssh")
-# Specify search path for CMake modules to be loaded by include()
-# and find_package()
-list(APPEND CMAKE_MODULE_PATH "${LIB_SOURCE_DIR}/cmake/Modules")
-
-include(DefineCMakeDefaults)
-include(DefineCompilerFlags)
 
 project(libssh VERSION 0.9.7 LANGUAGES C)
 
@@ -28,12 +22,6 @@ set(APPLICATION_NAME ${PROJECT_NAME})
 #     Increment REVISION.
 set(LIBRARY_VERSION "4.8.7")
 set(LIBRARY_SOVERSION "4")
-
-# where to look first for cmake modules, before ${CMAKE_ROOT}/Modules/ is checked
-
-# add definitions
-
-include(DefinePlatformDefaults)
 
 # Copy library files to a lib sub-directory
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${LIB_BINARY_DIR}/lib")

--- a/contrib/libssh-cmake/IncludeSources.cmake
+++ b/contrib/libssh-cmake/IncludeSources.cmake
@@ -1,19 +1,7 @@
 set(LIBSSH_LINK_LIBRARIES
-  ${LIBSSH_REQUIRED_LIBRARIES}
-)
-
-
-set(LIBSSH_LINK_LIBRARIES
   ${LIBSSH_LINK_LIBRARIES}
   OpenSSL::Crypto
 )
-
-if (MINGW AND Threads_FOUND)
-  set(LIBSSH_LINK_LIBRARIES
-    ${LIBSSH_LINK_LIBRARIES}
-    Threads::Threads
-  )
-endif()
 
 set(libssh_SRCS
   ${LIB_SOURCE_DIR}/src/agent.c
@@ -66,30 +54,11 @@ set(libssh_SRCS
   ${LIB_SOURCE_DIR}/src/pki_ed25519_common.c
 )
 
-if (DEFAULT_C_NO_DEPRECATION_FLAGS)
-    set_source_files_properties(known_hosts.c
-                                PROPERTIES
-                                    COMPILE_FLAGS ${DEFAULT_C_NO_DEPRECATION_FLAGS})
-endif()
-
-if (CMAKE_USE_PTHREADS_INIT)
-    set(libssh_SRCS
-        ${libssh_SRCS}
-        ${LIB_SOURCE_DIR}/src/threads/noop.c
-        ${LIB_SOURCE_DIR}/src/threads/pthread.c
-    )
-elseif (CMAKE_USE_WIN32_THREADS_INIT)
-        set(libssh_SRCS
-            ${libssh_SRCS}
-            ${LIB_SOURCE_DIR}/src/threads/noop.c
-            ${LIB_SOURCE_DIR}/src/threads/winlocks.c
-        )
-else()
-    set(libssh_SRCS
-        ${libssh_SRCS}
-        ${LIB_SOURCE_DIR}/src/threads/noop.c
-    )
-endif()
+set(libssh_SRCS
+    ${libssh_SRCS}
+    ${LIB_SOURCE_DIR}/src/threads/noop.c
+    ${LIB_SOURCE_DIR}/src/threads/pthread.c
+)
 
 # LIBCRYPT specific
 set(libssh_SRCS
@@ -127,14 +96,3 @@ target_compile_options(_ssh
                      PRIVATE
                         ${DEFAULT_C_COMPILE_FLAGS}
                         -D_GNU_SOURCE)
-
-
-set_target_properties(_ssh
-    PROPERTIES
-      VERSION
-        ${LIBRARY_VERSION}
-      SOVERSION
-        ${LIBRARY_SOVERSION}
-      DEFINE_SYMBOL
-        LIBSSH_EXPORTS
-)


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


We don't allow "try compile" in CMake (dynamic compiler checks).

See also: https://pastila.nl/?0006b8e8/8560133f5f51f49e42d32959064c664b#NHfzvOscc6e48RHYlIrmhw== - what happens when there is 100% build-cache hit rate.