### PR TITLE
gRPC: remove build dependency on systemd

### DIFF
--- a/contrib/sparse-checkout/update-grpc.sh
+++ b/contrib/sparse-checkout/update-grpc.sh
@@ -7,6 +7,7 @@ echo '/*' > $FILES_TO_CHECKOUT
 echo '!/test/*' >> $FILES_TO_CHECKOUT
 echo '/test/build/*' >> $FILES_TO_CHECKOUT
 echo '/test/core/tsi/alts/fake_handshaker/*' >> $FILES_TO_CHECKOUT
+echo '/test/core/event_engine/fuzzing_event_engine/*' >> $FILES_TO_CHECKOUT
 echo '!/tools/*' >> $FILES_TO_CHECKOUT
 echo '/tools/codegen/*' >> $FILES_TO_CHECKOUT
 echo '!/examples/*' >> $FILES_TO_CHECKOUT

--- a/contrib/sparse-checkout/update-grpc.sh
+++ b/contrib/sparse-checkout/update-grpc.sh
@@ -7,7 +7,6 @@ echo '/*' > $FILES_TO_CHECKOUT
 echo '!/test/*' >> $FILES_TO_CHECKOUT
 echo '/test/build/*' >> $FILES_TO_CHECKOUT
 echo '/test/core/tsi/alts/fake_handshaker/*' >> $FILES_TO_CHECKOUT
-echo '/test/core/event_engine/fuzzing_event_engine/*' >> $FILES_TO_CHECKOUT
 echo '!/tools/*' >> $FILES_TO_CHECKOUT
 echo '/tools/codegen/*' >> $FILES_TO_CHECKOUT
 echo '!/examples/*' >> $FILES_TO_CHECKOUT


### PR DESCRIPTION
~This reverts commit 213c7cffb5eae1951f67b8531ec69262696c7e3d, reversing changes made to 9ed47749dee12e900875ff4c6214a177fa07a94c.~

This fixes a glitch that gRPC, starting from v1.52 ([here](https://github.com/grpc/grpc/pull/30485/files#diff-83b81b8aa307569f7bcf5807488afb417670f9269aa16ddc6df9a55d70baf036)), builds against systemd.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Breaks the build if the system has systemd headers installed. The system headers should not affect the build at all to begin with.

https://github.com/ClickHouse/ClickHouse/pull/56543#issuecomment-1808099108