### PR TITLE
Fix missing argument for style_check.py in master workflow

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -96,7 +96,7 @@ jobs:
       runner_type: style-checker
       run_command: |
           cd "$REPO_COPY/tests/ci"
-          python3 style_check.py
+          python3 style_check.py --no-push
   CompatibilityCheckX86:
     needs: [BuilderDebRelease]
     uses: ./.github/workflows/reusable_test.yml


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Follow-up for #56501, restore missing CLI argument.