### PR TITLE
Fix configuration merge for nodes with substitution attributes

### DIFF
--- a/src/Common/Config/ConfigProcessor.cpp
+++ b/src/Common/Config/ConfigProcessor.cpp
@@ -334,10 +334,7 @@ void ConfigProcessor::mergeRecursive(XMLDocumentPtr config, Node * config_root, 
                     bool source_has_value = with_element.hasChildNodes();
                     if (source_has_value)
                         for (const auto & attr_name: SUBSTITUTION_ATTRS)
-                        {
-                            if (config_element.hasAttribute(attr_name))
-                                config_element.removeAttribute(attr_name);
-                        }
+                            config_element.removeAttribute(attr_name);
 
                     mergeAttributes(config_element, with_element);
                     mergeRecursive(config, config_node, with_node);

--- a/src/Common/Config/ConfigProcessor.cpp
+++ b/src/Common/Config/ConfigProcessor.cpp
@@ -522,6 +522,9 @@ void ConfigProcessor::doIncludesRecursive(
 
     if (attr_nodes["from_zk"]) /// we have zookeeper subst
     {
+        if (node->hasChildNodes()) /// only allow substitution for nodes with no value
+            throw Poco::Exception("Element <" + node->nodeName() + "> has value, can't process from_zk substitution");
+
         contributing_zk_paths.insert(attr_nodes["from_zk"]->getNodeValue());
 
         if (zk_node_cache)
@@ -544,6 +547,9 @@ void ConfigProcessor::doIncludesRecursive(
 
     if (attr_nodes["from_env"]) /// we have env subst
     {
+        if (node->hasChildNodes()) /// only allow substitution for nodes with no value
+            throw Poco::Exception("Element <" + node->nodeName() + "> has value, can't process from_env substitution");
+
         XMLDocumentPtr env_document;
         auto get_env_node = [&](const std::string & name) -> const Node *
         {

--- a/src/Common/Config/ConfigProcessor.cpp
+++ b/src/Common/Config/ConfigProcessor.cpp
@@ -326,6 +326,11 @@ void ConfigProcessor::mergeRecursive(XMLDocumentPtr config, Node * config_root, 
                     NodePtr new_node = config->importNode(with_node, true);
                     config_root->replaceChild(new_node, config_node);
                 }
+                else if (with_element.hasChildNodes() && with_element.firstChild()->nodeType() == Node::TEXT_NODE)
+                {
+                    NodePtr new_node = config->importNode(with_node, true);
+                    config_root->replaceChild(new_node, config_node);
+                }
                 else
                 {
                     Element & config_element = dynamic_cast<Element &>(*config_node);

--- a/src/Common/Config/ConfigProcessor.cpp
+++ b/src/Common/Config/ConfigProcessor.cpp
@@ -326,14 +326,18 @@ void ConfigProcessor::mergeRecursive(XMLDocumentPtr config, Node * config_root, 
                     NodePtr new_node = config->importNode(with_node, true);
                     config_root->replaceChild(new_node, config_node);
                 }
-                else if (with_element.hasChildNodes() && with_element.firstChild()->nodeType() == Node::TEXT_NODE)
-                {
-                    NodePtr new_node = config->importNode(with_node, true);
-                    config_root->replaceChild(new_node, config_node);
-                }
                 else
                 {
                     Element & config_element = dynamic_cast<Element &>(*config_node);
+
+                    /// Remove substitution attributes from the merge target node if source node already has a value
+                    bool source_has_value = with_element.hasChildNodes();
+                    if (source_has_value)
+                        for (const auto & attr_name: SUBSTITUTION_ATTRS)
+                        {
+                            if (config_element.hasAttribute(attr_name))
+                                config_element.removeAttribute(attr_name);
+                        }
 
                     mergeAttributes(config_element, with_element);
                     mergeRecursive(config, config_node, with_node);

--- a/tests/integration/test_config_substitutions/configs/000-config_with_env_subst.xml
+++ b/tests/integration/test_config_substitutions/configs/000-config_with_env_subst.xml
@@ -1,0 +1,17 @@
+<clickhouse>
+  <profiles>
+    <default>
+        <max_query_size from_env="MAX_QUERY_SIZE" />
+    </default>
+  </profiles>
+  <users>
+      <default>
+          <password></password>
+          <profile>default</profile>
+          <quota>default</quota>
+      </default>
+
+      <include incl="users_1" />
+      <include incl="users_2" />
+  </users>
+</clickhouse>

--- a/tests/integration/test_config_substitutions/configs/010-env_subst_override.xml
+++ b/tests/integration/test_config_substitutions/configs/010-env_subst_override.xml
@@ -1,0 +1,17 @@
+<clickhouse>
+  <profiles>
+    <default>
+        <max_query_size>424242</max_query_size>
+    </default>
+  </profiles>
+  <users>
+      <default>
+          <password></password>
+          <profile>default</profile>
+          <quota>default</quota>
+      </default>
+
+      <include incl="users_1" />
+      <include incl="users_2" />
+  </users>
+</clickhouse>

--- a/tests/integration/test_config_substitutions/test.py
+++ b/tests/integration/test_config_substitutions/test.py
@@ -32,10 +32,13 @@ node6 = cluster.add_instance(
 )
 node7 = cluster.add_instance(
     "node7",
-    user_configs=["configs/000-config_with_env_subst.xml", "configs/010-env_subst_override.xml"],
+    user_configs=[
+        "configs/000-config_with_env_subst.xml",
+        "configs/010-env_subst_override.xml",
+    ],
     env_variables={"MAX_QUERY_SIZE": "121212"},
     instance_env_variables=True,
-) # overridden with 424242
+)  # overridden with 424242
 
 
 @pytest.fixture(scope="module")

--- a/tests/integration/test_config_substitutions/test.py
+++ b/tests/integration/test_config_substitutions/test.py
@@ -30,6 +30,12 @@ node6 = cluster.add_instance(
     },
     main_configs=["configs/include_from_source.xml"],
 )
+node7 = cluster.add_instance(
+    "node7",
+    user_configs=["configs/000-config_with_env_subst.xml", "configs/010-env_subst_override.xml"],
+    env_variables={"MAX_QUERY_SIZE": "121212"},
+    instance_env_variables=True,
+) # overridden with 424242
 
 
 @pytest.fixture(scope="module")
@@ -77,6 +83,10 @@ def test_config(start_cluster):
     assert (
         node6.query("select value from system.settings where name = 'max_query_size'")
         == "99999\n"
+    )
+    assert (
+        node7.query("select value from system.settings where name = 'max_query_size'")
+        == "424242\n"
     )
 
 


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix unexpected configuration value concatenation in case of overriding an entry having a substitution (`from_env`/`from_zk`/`incl`) https://github.com/ClickHouse/ClickHouse/issues/56537
