### PR TITLE
Improve legibility of window functions list

### DIFF
--- a/docs/en/sql-reference/window-functions/index.md
+++ b/docs/en/sql-reference/window-functions/index.md
@@ -86,14 +86,14 @@ WINDOW window_name as ([[PARTITION BY grouping_column] [ORDER BY sorting_column]
 
 These functions can be used only as a window function.
 
-`row_number()` -	Number the current row within its partition starting from 1.
-`first_value(x)` -	Return the first non-NULL value evaluated within its ordered frame.
-`last_value(x)` -	Return the last non-NULL value evaluated within its ordered frame.
-`nth_value(x, offset)` - Return the first non-NULL value evaluated against the nth row (offset) in its ordered frame.
-`rank()` -	Rank the current row within its partition with gaps.
-`dense_rank()`	- Rank the current row within its partition without gaps.
-`lagInFrame(x)` - Return a value evaluated at the row that is at a specified physical offset row before the current row within the ordered frame.
-`leadInFrame(x)` - Return a value evaluated at the row that is offset rows after the current row within the ordered frame.
+- `row_number()` -	Number the current row within its partition starting from 1.
+- `first_value(x)` -	Return the first non-NULL value evaluated within its ordered frame.
+- `last_value(x)` -	Return the last non-NULL value evaluated within its ordered frame.
+- `nth_value(x, offset)` - Return the first non-NULL value evaluated against the nth row (offset) in its ordered frame.
+- `rank()` -	Rank the current row within its partition with gaps.
+- `dense_rank()`	- Rank the current row within its partition without gaps.
+- `lagInFrame(x)` - Return a value evaluated at the row that is at a specified physical offset row before the current row within the ordered frame.
+- `leadInFrame(x)` - Return a value evaluated at the row that is offset rows after the current row within the ordered frame.
 
 ```text
       PARTITION

--- a/docs/en/sql-reference/window-functions/index.md
+++ b/docs/en/sql-reference/window-functions/index.md
@@ -86,12 +86,12 @@ WINDOW window_name as ([[PARTITION BY grouping_column] [ORDER BY sorting_column]
 
 These functions can be used only as a window function.
 
-- `row_number()` -	Number the current row within its partition starting from 1.
-- `first_value(x)` -	Return the first non-NULL value evaluated within its ordered frame.
+- `row_number()` - Number the current row within its partition starting from 1.
+- `first_value(x)` - Return the first non-NULL value evaluated within its ordered frame.
 - `last_value(x)` -	Return the last non-NULL value evaluated within its ordered frame.
 - `nth_value(x, offset)` - Return the first non-NULL value evaluated against the nth row (offset) in its ordered frame.
-- `rank()` -	Rank the current row within its partition with gaps.
-- `dense_rank()`	- Rank the current row within its partition without gaps.
+- `rank()` - Rank the current row within its partition with gaps.
+- `dense_rank()` - Rank the current row within its partition without gaps.
 - `lagInFrame(x)` - Return a value evaluated at the row that is at a specified physical offset row before the current row within the ordered frame.
 - `leadInFrame(x)` - Return a value evaluated at the row that is offset rows after the current row within the ordered frame.
 


### PR DESCRIPTION
Before, markdown was rendering these as one big paragraph.

See: https://clickhouse.com/docs/en/sql-reference/window-functions#functions

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
