### PR TITLE
Fix flaky test_replicated_merge_tree_encryption_codec.

### DIFF
--- a/tests/integration/test_replicated_merge_tree_encryption_codec/test.py
+++ b/tests/integration/test_replicated_merge_tree_encryption_codec/test.py
@@ -92,6 +92,8 @@ def test_different_keys():
     create_table()
 
     insert_data()
+    node1.query("SYSTEM SYNC REPLICA ON CLUSTER 'cluster' tbl")
+
     assert "BAD_DECRYPT" in node1.query_and_get_error("SELECT * FROM tbl")
     assert "BAD_DECRYPT" in node2.query_and_get_error("SELECT * FROM tbl")
 


### PR DESCRIPTION
### Changelog category:
- Not for changelog

Fix flaky test `test_replicated_merge_tree_encryption_codec/test.py::test_different_keys` ([example of failure](https://s3.amazonaws.com/clickhouse-test-reports/0/6c975c4a87ea5c0fbeabec4e9d6b58a7a708bb8c/integration_tests__release__[2_4]/integration_run_parallel3_0.log))