### PR TITLE
Switch from DWARF 4 to 5 and see what happens

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -320,7 +320,7 @@ endif ()
 set (COMPILER_FLAGS "${COMPILER_FLAGS}")
 
 # Our built-in unwinder only supports DWARF version up to 4.
-set (DEBUG_INFO_FLAGS "-g -gdwarf-4")
+set (DEBUG_INFO_FLAGS "-g")
 
 # Disable omit frame pointer compiler optimization using -fno-omit-frame-pointer
 option(DISABLE_OMIT_FRAME_POINTER "Disable omit frame pointer compiler optimization" OFF)

--- a/src/Common/Dwarf.h
+++ b/src/Common/Dwarf.h
@@ -46,8 +46,8 @@ class Elf;
  * can parse Debug Information Entries (DIEs), abbreviations, attributes (of
  * all forms), and we can interpret bytecode for the line number VM.
  *
- * We can interpret DWARF records of version 2, 3, or 4, although we don't
- * actually support many of the version 4 features (such as VLIW, multiple
+ * We can interpret DWARF records of version 2, 3, 4, or 5, although we don't
+ * actually support many of the features of versions 4 and 5 (such as VLIW, multiple
  * operations per instruction)
  *
  * Note that the DWARF record parser does not allocate heap memory at all.


### PR DESCRIPTION
### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Use DWARF 5 debug symbols for the clickhouse binary (was DWARF 4 previously).

According  to https://github.com/ClickHouse/ClickHouse/issues/41191 , this didn't work a year ago because GDB didn't support DWARF 5 well enough. Let's run CI again and see if it's magically fixed (we've updated the Linux version in CI recently, right?).

If not, we should probably switch all testing scripts (~12 of them) to use lldb instead of gdb. The lldb is also much faster, but less convenient to use and more likely to have compatibility problems (e.g. I ran into https://bugs.launchpad.net/ubuntu/+source/llvm-defaults/+bug/1972855 locally).