### PR TITLE
Ask linker to remove garbage from external libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,7 +164,7 @@ if (OS_LINUX)
     #   and whatever is poisoning it by LD_PRELOAD should not link to our symbols.
     # - The clickhouse-odbc-bridge and clickhouse-library-bridge binaries
     #   should not expose their symbols to ODBC drivers and libraries.
-    set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--no-export-dynamic")
+    set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--no-export-dynamic -Wl,--gc-sections")
 endif ()
 
 if (OS_DARWIN)

--- a/contrib/CMakeLists.txt
+++ b/contrib/CMakeLists.txt
@@ -1,7 +1,7 @@
 #"${folder}/CMakeLists.txt" Third-party libraries may have substandard code.
 
-set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -w")
-set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -w")
+set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -w -ffunction-sections -fdata-sections")
+set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -w -ffunction-sections -fdata-sections")
 
 if (WITH_COVERAGE)
   set (WITHOUT_COVERAGE_LIST ${WITHOUT_COVERAGE})


### PR DESCRIPTION
### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Optimized build size further by removing unused code from external libraries.


```
milovidov@milovidov-desktop:~/work/ClickHouse/programs/server$ ls -l ../../build/programs/clickhouse ../../build/programs/clickhouse-stripped 
-rwxrwxr-x 1 milovidov milovidov 3262167040 nov 15 07:32 ../../build/programs/clickhouse
-rwxrwxr-x 1 milovidov milovidov  516006576 nov 15 06:59 ../../build/programs/clickhouse-stripped
milovidov@milovidov-desktop:~/work/ClickHouse/programs/server$ ls -l ../../build/programs/clickhouse ../../build/programs/clickhouse-stripped 
-rwxrwxr-x 1 milovidov milovidov 3237493152 nov 15 12:24 ../../build/programs/clickhouse
-rwxrwxr-x 1 milovidov milovidov  484915416 nov 15 12:24 ../../build/programs/clickhouse-stripped
```