### PR TITLE
Fix randomization of Keeper configs in stress tests

### DIFF
--- a/docker/test/stateless/stress_tests.lib
+++ b/docker/test/stateless/stress_tests.lib
@@ -53,7 +53,7 @@ function configure()
       > /etc/clickhouse-server/config.d/keeper_port.xml.tmp
     sudo mv /etc/clickhouse-server/config.d/keeper_port.xml.tmp /etc/clickhouse-server/config.d/keeper_port.xml
 
-    function randomize_keeper_config_boolean_value {
+    function randomize_config_boolean_value {
         value=$(($RANDOM % 2))
         sudo cat /etc/clickhouse-server/config.d/$2.xml \
         | sed "s|<$1>[01]</$1>|<$1>$value</$1>|" \
@@ -63,16 +63,20 @@ function configure()
 
     if [[ -n "$RANDOMIZE_KEEPER_FEATURE_FLAGS" ]] && [[ "$RANDOMIZE_KEEPER_FEATURE_FLAGS" -eq 1 ]]; then
         # Randomize all Keeper feature flags
-        randomize_keeper_config_boolean_value filtered_list keeper_port
-        randomize_keeper_config_boolean_value multi_read keeper_port
-        randomize_keeper_config_boolean_value check_not_exists keeper_port
-        randomize_keeper_config_boolean_value create_if_not_exists keeper_port
+        randomize_config_boolean_value filtered_list keeper_port
+        randomize_config_boolean_value multi_read keeper_port
+        randomize_config_boolean_value check_not_exists keeper_port
+        randomize_config_boolean_value create_if_not_exists keeper_port
     fi
 
     sudo chown clickhouse /etc/clickhouse-server/config.d/keeper_port.xml
     sudo chgrp clickhouse /etc/clickhouse-server/config.d/keeper_port.xml
 
-    randomize_keeper_config_boolean_value use_compression zookeeper
+    if [[ -n "$ZOOKEEPER_FAULT_INJECTION" ]] && [[ "$ZOOKEEPER_FAULT_INJECTION" -eq 1 ]]; then
+        randomize_config_boolean_value use_compression zookeeper_fault_injection
+    else
+        randomize_config_boolean_value use_compression zookeeper
+    fi
 
     # for clickhouse-server (via service)
     echo "ASAN_OPTIONS='malloc_context_size=10 verbosity=1 allocator_release_to_os_interval_ms=10000'" >> /etc/environment

--- a/docker/test/stateless/stress_tests.lib
+++ b/docker/test/stateless/stress_tests.lib
@@ -63,16 +63,16 @@ function configure()
 
     if [[ -n "$RANDOMIZE_KEEPER_FEATURE_FLAGS" ]] && [[ "$RANDOMIZE_KEEPER_FEATURE_FLAGS" -eq 1 ]]; then
         # Randomize all Keeper feature flags
-        randomize_config_boolean_value filtered_list keeper_port
-        randomize_config_boolean_value multi_read keeper_port
-        randomize_config_boolean_value check_not_exists keeper_port
-        randomize_config_boolean_value create_if_not_exists keeper_port
+        randomize_keeper_config_boolean_value filtered_list keeper_port
+        randomize_keeper_config_boolean_value multi_read keeper_port
+        randomize_keeper_config_boolean_value check_not_exists keeper_port
+        randomize_keeper_config_boolean_value create_if_not_exists keeper_port
     fi
 
     sudo chown clickhouse /etc/clickhouse-server/config.d/keeper_port.xml
     sudo chgrp clickhouse /etc/clickhouse-server/config.d/keeper_port.xml
 
-    randomize_config_boolean_value use_compression zookeeper
+    randomize_keeper_config_boolean_value use_compression zookeeper
 
     # for clickhouse-server (via service)
     echo "ASAN_OPTIONS='malloc_context_size=10 verbosity=1 allocator_release_to_os_interval_ms=10000'" >> /etc/environment

--- a/tests/config/config.d/zookeeper.xml
+++ b/tests/config/config.d/zookeeper.xml
@@ -2,7 +2,7 @@
     <zookeeper>
         <!--<zookeeper_load_balancing>random / in_order / nearest_hostname / hostname_levenshtein_distance / first_or_random / round_robin</zookeeper_load_balancing>-->
         <zookeeper_load_balancing>random</zookeeper_load_balancing>
-        <use_compression>true</use_compression>
+        <use_compression>1</use_compression>
         <node index="1">
             <host>127.0.0.1</host>
             <port>9181</port>

--- a/tests/config/config.d/zookeeper_fault_injection.xml
+++ b/tests/config/config.d/zookeeper_fault_injection.xml
@@ -1,5 +1,6 @@
 <clickhouse>
     <zookeeper>
+        <use_compression>1</use_compression>
         <node index="1">
             <host>localhost</host>
             <port>9181</port>


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
