### PR TITLE
Implement asynchronous execute of `ALTER TABLE ... MOVE ... TO DISK|VOLUME`

### DIFF
--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -140,6 +140,7 @@ class IColumn;
     \
     M(UInt64, alter_sync, 1, "Wait for actions to manipulate the partitions. 0 - do not wait, 1 - wait for execution only of itself, 2 - wait for everyone.", 0) ALIAS(replication_alter_partitions_sync) \
     M(Int64, replication_wait_for_inactive_replica_timeout, 120, "Wait for inactive replica to execute ALTER/OPTIMIZE. Time in seconds, 0 - do not wait, negative - wait for unlimited time.", 0) \
+    M(Bool, alter_move_to_space_execute_async, false, "Execute ALTER TABLE MOVE ... TO [DISK|VOLUME] asynchronously", 0) \
     \
     M(LoadBalancing, load_balancing, LoadBalancing::RANDOM, "Which replicas (among healthy replicas) to preferably send a query to (on the first attempt) for distributed processing.", 0) \
     M(UInt64, load_balancing_first_offset, 0, "Which replica to preferably send a query when FIRST_OR_RANDOM load balancing strategy is used.", 0) \

--- a/src/Storages/MergeTree/BackgroundJobsAssignee.cpp
+++ b/src/Storages/MergeTree/BackgroundJobsAssignee.cpp
@@ -67,10 +67,11 @@ void BackgroundJobsAssignee::scheduleFetchTask(ExecutableTaskPtr fetch_task)
 }
 
 
-void BackgroundJobsAssignee::scheduleMoveTask(ExecutableTaskPtr move_task)
+bool BackgroundJobsAssignee::scheduleMoveTask(ExecutableTaskPtr move_task)
 {
     bool res = getContext()->getMovesExecutor()->trySchedule(move_task);
     res ? trigger() : postpone();
+    return res;
 }
 
 

--- a/src/Storages/MergeTree/BackgroundJobsAssignee.h
+++ b/src/Storages/MergeTree/BackgroundJobsAssignee.h
@@ -67,7 +67,7 @@ public:
 
     bool scheduleMergeMutateTask(ExecutableTaskPtr merge_task);
     void scheduleFetchTask(ExecutableTaskPtr fetch_task);
-    void scheduleMoveTask(ExecutableTaskPtr move_task);
+    bool scheduleMoveTask(ExecutableTaskPtr move_task);
     void scheduleCommonTask(ExecutableTaskPtr common_task, bool need_trigger);
 
     /// Just call finish

--- a/src/Storages/MergeTree/MergeTreeData.h
+++ b/src/Storages/MergeTree/MergeTreeData.h
@@ -1359,8 +1359,6 @@ protected:
     /// method has different implementations for replicated and non replicated
     /// MergeTree because they store mutations in different way.
     virtual std::map<int64_t, MutationCommands> getAlterMutationCommandsForPart(const DataPartPtr & part) const = 0;
-    /// Moves part to specified space, used in ALTER ... MOVE ... queries
-    MovePartsOutcome movePartsToSpace(const DataPartsVector & parts, SpacePtr space, const ReadSettings & read_settings, const WriteSettings & write_settings);
 
     struct PartBackupEntries
     {
@@ -1512,6 +1510,9 @@ private:
     };
 
     using CurrentlyMovingPartsTaggerPtr = std::shared_ptr<CurrentlyMovingPartsTagger>;
+
+    /// Moves part to specified space, used in ALTER ... MOVE ... queries
+    std::future<MovePartsOutcome> movePartsToSpace(const CurrentlyMovingPartsTaggerPtr & moving_tagger, const ReadSettings & read_settings, const WriteSettings & write_settings, bool async);
 
     /// Move selected parts to corresponding disks
     MovePartsOutcome moveParts(const CurrentlyMovingPartsTaggerPtr & moving_tagger, const ReadSettings & read_settings, const WriteSettings & write_settings, bool wait_for_move_if_zero_copy);

--- a/src/Storages/MergeTree/MergeTreePartsMover.h
+++ b/src/Storages/MergeTree/MergeTreePartsMover.h
@@ -18,6 +18,7 @@ enum class MovePartsOutcome
     NothingToMove,
     MovesAreCancelled,
     MoveWasPostponedBecauseOfZeroCopy,
+    CannotScheduleMove,
 };
 
 /// Active part from storage and destination reservation where it has to be moved

--- a/tests/integration/test_move_partition_to_volume_async/__init__.py
+++ b/tests/integration/test_move_partition_to_volume_async/__init__.py
@@ -1,0 +1,1 @@
+#!/usr/bin/env python3

--- a/tests/integration/test_move_partition_to_volume_async/configs/storage_policy.xml
+++ b/tests/integration/test_move_partition_to_volume_async/configs/storage_policy.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<clickhouse>
+  <storage_configuration>
+    <disks>
+        <default/>
+
+        <s3>
+            <type>s3</type>
+            <endpoint>http://minio1:9001/root/data/</endpoint>
+            <access_key_id>minio</access_key_id>
+            <secret_access_key>minio123</secret_access_key>
+        </s3>
+
+        <broken_s3>
+            <type>s3</type>
+            <endpoint>http://resolver:8083/root/data/</endpoint>
+            <access_key_id>minio</access_key_id>
+            <secret_access_key>minio123</secret_access_key>
+        </broken_s3>
+    </disks>
+
+    <policies>
+        <slow_s3>
+            <volumes>
+                <main>
+                    <disk>default</disk>
+                </main>
+                <broken>
+                    <disk>broken_s3</disk>
+                </broken>
+            </volumes>
+
+            <move_factor>0.0</move_factor>
+        </slow_s3>
+    </policies>
+  </storage_configuration>
+
+</clickhouse>

--- a/tests/integration/test_move_partition_to_volume_async/test.py
+++ b/tests/integration/test_move_partition_to_volume_async/test.py
@@ -14,6 +14,7 @@ from helpers.wait_for_helpers import wait_for_merges
 
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 
+
 @pytest.fixture(scope="module")
 def init_broken_s3(cluster):
     yield start_s3_mock(cluster, "broken_s3", "8083")
@@ -23,6 +24,7 @@ def init_broken_s3(cluster):
 def broken_s3(init_broken_s3):
     init_broken_s3.reset()
     yield init_broken_s3
+
 
 @pytest.fixture(scope="module")
 def cluster():
@@ -47,7 +49,8 @@ def cluster():
 def test_async_alter_move(cluster, broken_s3):
     node = cluster.instances["node"]
 
-    node.query("""
+    node.query(
+        """
     CREATE TABLE moving_table_async
     (
         key UInt64,
@@ -56,32 +59,43 @@ def test_async_alter_move(cluster, broken_s3):
     ENGINE MergeTree()
     ORDER BY tuple()
     SETTINGS storage_policy = 'slow_s3'
-    """)
+    """
+    )
 
-    node.query("INSERT INTO moving_table_async SELECT number, randomPrintableASCII(1000) FROM numbers(10000)")
+    node.query(
+        "INSERT INTO moving_table_async SELECT number, randomPrintableASCII(1000) FROM numbers(10000)"
+    )
 
     broken_s3.setup_slow_answers(
         timeout=5,
         count=1000000,
     )
 
-    node.query("ALTER TABLE moving_table_async MOVE PARTITION tuple() TO DISK 'broken_s3'", settings={'alter_move_to_space_execute_async': True}, timeout=10)
+    node.query(
+        "ALTER TABLE moving_table_async MOVE PARTITION tuple() TO DISK 'broken_s3'",
+        settings={"alter_move_to_space_execute_async": True},
+        timeout=10,
+    )
 
     # not flaky, just introduce some wait
     time.sleep(3)
 
     for i in range(100):
-        count = node.query("SELECT count() FROM system.moves where table = 'moving_table_async'")
+        count = node.query(
+            "SELECT count() FROM system.moves where table = 'moving_table_async'"
+        )
         if count == "1\n":
             break
         time.sleep(0.1)
     else:
         assert False, "Cannot find any moving background operation"
 
+
 def test_sync_alter_move(cluster, broken_s3):
     node = cluster.instances["node"]
 
-    node.query("""
+    node.query(
+        """
     CREATE TABLE moving_table_sync
     (
         key UInt64,
@@ -90,16 +104,30 @@ def test_sync_alter_move(cluster, broken_s3):
     ENGINE MergeTree()
     ORDER BY tuple()
     SETTINGS storage_policy = 'slow_s3'
-    """)
+    """
+    )
 
-    node.query("INSERT INTO moving_table_sync SELECT number, randomPrintableASCII(1000) FROM numbers(10000)")
+    node.query(
+        "INSERT INTO moving_table_sync SELECT number, randomPrintableASCII(1000) FROM numbers(10000)"
+    )
 
     broken_s3.reset()
 
-    node.query("ALTER TABLE moving_table_sync MOVE PARTITION tuple() TO DISK 'broken_s3'", timeout=30)
+    node.query(
+        "ALTER TABLE moving_table_sync MOVE PARTITION tuple() TO DISK 'broken_s3'",
+        timeout=30,
+    )
     # not flaky, just introduce some wait
     time.sleep(3)
 
-    assert node.query("SELECT count() FROM system.moves where table = 'moving_table_sync'") == "0\n"
+    assert (
+        node.query("SELECT count() FROM system.moves where table = 'moving_table_sync'")
+        == "0\n"
+    )
 
-    assert node.query("SELECT disk_name FROM system.parts WHERE table = 'moving_table_sync'") == "broken_s3\n"
+    assert (
+        node.query(
+            "SELECT disk_name FROM system.parts WHERE table = 'moving_table_sync'"
+        )
+        == "broken_s3\n"
+    )

--- a/tests/integration/test_move_partition_to_volume_async/test.py
+++ b/tests/integration/test_move_partition_to_volume_async/test.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+import logging
+import time
+import os
+
+import pytest
+from helpers.cluster import ClickHouseCluster
+from helpers.mock_servers import start_s3_mock, start_mock_servers
+from helpers.utility import generate_values, replace_config, SafeThread
+from helpers.wait_for_helpers import wait_for_delete_inactive_parts
+from helpers.wait_for_helpers import wait_for_delete_empty_parts
+from helpers.wait_for_helpers import wait_for_merges
+
+
+SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
+
+@pytest.fixture(scope="module")
+def init_broken_s3(cluster):
+    yield start_s3_mock(cluster, "broken_s3", "8083")
+
+
+@pytest.fixture(scope="function")
+def broken_s3(init_broken_s3):
+    init_broken_s3.reset()
+    yield init_broken_s3
+
+@pytest.fixture(scope="module")
+def cluster():
+    try:
+        cluster = ClickHouseCluster(__file__)
+        cluster.add_instance(
+            "node",
+            main_configs=[
+                "configs/storage_policy.xml",
+            ],
+            with_minio=True,
+        )
+
+        cluster.start()
+        logging.info("Cluster started")
+
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def test_async_alter_move(cluster, broken_s3):
+    node = cluster.instances["node"]
+
+    node.query("""
+    CREATE TABLE moving_table_async
+    (
+        key UInt64,
+        data String
+    )
+    ENGINE MergeTree()
+    ORDER BY tuple()
+    SETTINGS storage_policy = 'slow_s3'
+    """)
+
+    node.query("INSERT INTO moving_table_async SELECT number, randomPrintableASCII(1000) FROM numbers(10000)")
+
+    broken_s3.setup_slow_answers(
+        timeout=5,
+        count=1000000,
+    )
+
+    node.query("ALTER TABLE moving_table_async MOVE PARTITION tuple() TO DISK 'broken_s3'", settings={'alter_move_to_space_execute_async': True}, timeout=10)
+
+    # not flaky, just introduce some wait
+    time.sleep(3)
+
+    for i in range(100):
+        count = node.query("SELECT count() FROM system.moves where table = 'moving_table_async'")
+        if count == "1\n":
+            break
+        time.sleep(0.1)
+    else:
+        assert False, "Cannot find any moving background operation"
+
+def test_sync_alter_move(cluster, broken_s3):
+    node = cluster.instances["node"]
+
+    node.query("""
+    CREATE TABLE moving_table_sync
+    (
+        key UInt64,
+        data String
+    )
+    ENGINE MergeTree()
+    ORDER BY tuple()
+    SETTINGS storage_policy = 'slow_s3'
+    """)
+
+    node.query("INSERT INTO moving_table_sync SELECT number, randomPrintableASCII(1000) FROM numbers(10000)")
+
+    broken_s3.reset()
+
+    node.query("ALTER TABLE moving_table_sync MOVE PARTITION tuple() TO DISK 'broken_s3'", timeout=30)
+    # not flaky, just introduce some wait
+    time.sleep(3)
+
+    assert node.query("SELECT count() FROM system.moves where table = 'moving_table_sync'") == "0\n"
+
+    assert node.query("SELECT disk_name FROM system.parts WHERE table = 'moving_table_sync'") == "broken_s3\n"


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Implement user-level setting `alter_move_to_space_execute_async` which allow to execute queries `ALTER TABLE ... MOVE PARTITION|PART TO DISK|VOLUME` asynchronously. The size of pool for background executions is controlled by `background_move_pool_size`. Default behavior is synchronous execution. Fixes #47643.