### PR TITLE
Show total_bytes and total_rows in system tables for RocksDB storage

### DIFF
--- a/docs/en/engines/table-engines/integrations/embedded-rocksdb.md
+++ b/docs/en/engines/table-engines/integrations/embedded-rocksdb.md
@@ -85,6 +85,10 @@ You can also change any [rocksdb options](https://github.com/facebook/rocksdb/wi
 </rocksdb>
 ```
 
+By default trivial approximate count optimization is turned off, which might affect the performance `count()` queries. To enable this
+optimization set up `optimize_trivial_approximate_count_query = 1`. Also, this setting affects `system.tables` for EmbeddedRocksDB engine,
+turn on the settings to see approximate values for `total_rows` and `total_bytes`.
+
 ## Supported operations {#supported-operations}
 
 ### Inserts

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -545,7 +545,7 @@ class IColumn;
     M(Bool, database_atomic_wait_for_drop_and_detach_synchronously, false, "When executing DROP or DETACH TABLE in Atomic database, wait for table data to be finally dropped or detached.", 0) \
     M(Bool, enable_scalar_subquery_optimization, true, "If it is set to true, prevent scalar subqueries from (de)serializing large scalar values and possibly avoid running the same subquery more than once.", 0) \
     M(Bool, optimize_trivial_count_query, true, "Process trivial 'SELECT count() FROM table' query from metadata.", 0) \
-    M(Bool, optimize_trivial_approximate_count_query, true, "Use an approximate value for trivial count optimization of storages that support such estimations.", 0) \
+    M(Bool, optimize_trivial_approximate_count_query, false, "Use an approximate value for trivial count optimization of storages that support such estimations.", 0) \
     M(Bool, optimize_count_from_files, true, "Optimize counting rows from files in supported input formats", 0) \
     M(Bool, use_cache_for_count_from_files, true, "Use cache to count the number of rows in files", 0) \
     M(Bool, optimize_respect_aliases, true, "If it is set to true, it will respect aliases in WHERE/GROUP BY/ORDER BY, that will help with partition pruning/secondary indexes/optimize_aggregation_in_order/optimize_read_in_order/optimize_trivial_count", 0) \

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -545,7 +545,7 @@ class IColumn;
     M(Bool, database_atomic_wait_for_drop_and_detach_synchronously, false, "When executing DROP or DETACH TABLE in Atomic database, wait for table data to be finally dropped or detached.", 0) \
     M(Bool, enable_scalar_subquery_optimization, true, "If it is set to true, prevent scalar subqueries from (de)serializing large scalar values and possibly avoid running the same subquery more than once.", 0) \
     M(Bool, optimize_trivial_count_query, true, "Process trivial 'SELECT count() FROM table' query from metadata.", 0) \
-    M(Bool, optimize_trivial_approximate_count_query, false, "Use an approximate value for trivial count optimization of storages that support such estimations.", 0) \
+    M(Bool, optimize_trivial_approximate_count_query, true, "Use an approximate value for trivial count optimization of storages that support such estimations.", 0) \
     M(Bool, optimize_count_from_files, true, "Optimize counting rows from files in supported input formats", 0) \
     M(Bool, use_cache_for_count_from_files, true, "Use cache to count the number of rows in files", 0) \
     M(Bool, optimize_respect_aliases, true, "If it is set to true, it will respect aliases in WHERE/GROUP BY/ORDER BY, that will help with partition pruning/secondary indexes/optimize_aggregation_in_order/optimize_read_in_order/optimize_trivial_count", 0) \

--- a/src/Storages/RocksDB/StorageEmbeddedRocksDB.cpp
+++ b/src/Storages/RocksDB/StorageEmbeddedRocksDB.cpp
@@ -690,17 +690,6 @@ Chunk StorageEmbeddedRocksDB::getBySerializedKeys(
     return Chunk(std::move(columns), num_rows);
 }
 
-void registerStorageEmbeddedRocksDB(StorageFactory & factory)
-{
-    StorageFactory::StorageFeatures features{
-        .supports_sort_order = true,
-        .supports_ttl = true,
-        .supports_parallel_insert = true,
-    };
-
-    factory.registerStorage("EmbeddedRocksDB", create, features);
-}
-
 std::optional<UInt64> StorageEmbeddedRocksDB::totalRows(const Settings & settings) const
 {
     if (!settings.optimize_trivial_approximate_count_query)
@@ -725,4 +714,14 @@ std::optional<UInt64> StorageEmbeddedRocksDB::totalBytes(const Settings & /*sett
     return estimated_bytes;
 }
 
+void registerStorageEmbeddedRocksDB(StorageFactory & factory)
+{
+    StorageFactory::StorageFeatures features{
+        .supports_sort_order = true,
+        .supports_ttl = true,
+        .supports_parallel_insert = true,
+    };
+
+    factory.registerStorage("EmbeddedRocksDB", create, features);
+}
 }

--- a/src/Storages/RocksDB/StorageEmbeddedRocksDB.cpp
+++ b/src/Storages/RocksDB/StorageEmbeddedRocksDB.cpp
@@ -703,17 +703,26 @@ void registerStorageEmbeddedRocksDB(StorageFactory & factory)
 
 std::optional<UInt64> StorageEmbeddedRocksDB::totalRows(const Settings & settings) const
 {
-    if (settings.optimize_trivial_approximate_count_query)
-    {
-        std::shared_lock lock(rocksdb_ptr_mx);
-        if (!rocksdb_ptr)
-            return {};
-        UInt64 estimated_rows;
-        if (!rocksdb_ptr->GetIntProperty("rocksdb.estimate-num-keys", &estimated_rows))
-            return {};
-        return estimated_rows;
-    }
-    return {};
+    if (!settings.optimize_trivial_approximate_count_query)
+        return {};
+    std::shared_lock lock(rocksdb_ptr_mx);
+    if (!rocksdb_ptr)
+        return {};
+    UInt64 estimated_rows;
+    if (!rocksdb_ptr->GetIntProperty("rocksdb.estimate-num-keys", &estimated_rows))
+        return {};
+    return estimated_rows;
+}
+
+std::optional<UInt64> StorageEmbeddedRocksDB::totalBytes(const Settings & /*settings*/) const
+{
+    std::shared_lock lock(rocksdb_ptr_mx);
+    if (!rocksdb_ptr)
+        return {};
+    UInt64 estimated_bytes;
+    if (!rocksdb_ptr->GetIntProperty("rocksdb.estimate-live-data-size", &estimated_bytes))
+        return {};
+    return estimated_bytes;
 }
 
 }

--- a/src/Storages/RocksDB/StorageEmbeddedRocksDB.cpp
+++ b/src/Storages/RocksDB/StorageEmbeddedRocksDB.cpp
@@ -720,7 +720,7 @@ std::optional<UInt64> StorageEmbeddedRocksDB::totalBytes(const Settings & /*sett
     if (!rocksdb_ptr)
         return {};
     UInt64 estimated_bytes;
-    if (!rocksdb_ptr->GetIntProperty("rocksdb.estimate-live-data-size", &estimated_bytes))
+    if (!rocksdb_ptr->GetAggregatedIntProperty("rocksdb.estimate-live-data-size", &estimated_bytes))
         return {};
     return estimated_bytes;
 }

--- a/src/Storages/RocksDB/StorageEmbeddedRocksDB.h
+++ b/src/Storages/RocksDB/StorageEmbeddedRocksDB.h
@@ -5,6 +5,7 @@
 #include <Storages/IStorage.h>
 #include <Interpreters/IKeyValueEntity.h>
 #include <rocksdb/status.h>
+#include <Storages/RocksDB/EmbeddedRocksDBSink.h>
 
 
 namespace rocksdb
@@ -88,6 +89,8 @@ public:
     bool supportsTrivialCountOptimization() const override { return true; }
 
     std::optional<UInt64> totalRows(const Settings & settings) const override;
+
+    std::optional<UInt64> totalBytes(const Settings & settings) const override;
 
 private:
     const String primary_key;

--- a/src/Storages/RocksDB/StorageEmbeddedRocksDB.h
+++ b/src/Storages/RocksDB/StorageEmbeddedRocksDB.h
@@ -86,6 +86,7 @@ public:
 
     bool supportsDelete() const override { return true; }
 
+    /// To turn on the optimization optimize_trivial_approximate_count_query=1 should be set for a query.
     bool supportsTrivialCountOptimization() const override { return true; }
 
     std::optional<UInt64> totalRows(const Settings & settings) const override;

--- a/tests/queries/0_stateless/02892_rocksdb_trivial_count.reference
+++ b/tests/queries/0_stateless/02892_rocksdb_trivial_count.reference
@@ -1,6 +1,10 @@
 -- { echoOn }
 SELECT count() FROM dict SETTINGS optimize_trivial_approximate_count_query = 0, max_rows_to_read = 1; -- { serverError TOO_MANY_ROWS }
-SELECT count() FROM dict SETTINGS max_rows_to_read = 1;
+SELECT count() FROM dict SETTINGS optimize_trivial_approximate_count_query = 1, max_rows_to_read = 1;
 121
-SELECT total_rows FROM system.tables WHERE database = currentDatabase() AND name = 'dict';
-121
+SET optimize_trivial_approximate_count_query = 1;
+-- needs more data to see total_bytes or just detach and attach the table
+DETACH TABLE dict SYNC;
+ATTACH TABLE dict;
+SELECT total_rows, total_bytes > 0 FROM system.tables WHERE database = currentDatabase() AND name = 'dict' FORMAT CSV;
+121,1

--- a/tests/queries/0_stateless/02892_rocksdb_trivial_count.reference
+++ b/tests/queries/0_stateless/02892_rocksdb_trivial_count.reference
@@ -1,1 +1,6 @@
+-- { echoOn }
+SELECT count() FROM dict SETTINGS optimize_trivial_approximate_count_query = 0, max_rows_to_read = 1; -- { serverError TOO_MANY_ROWS }
+SELECT count() FROM dict SETTINGS max_rows_to_read = 1;
+121
+SELECT total_rows FROM system.tables WHERE database = currentDatabase() AND name = 'dict';
 121

--- a/tests/queries/0_stateless/02892_rocksdb_trivial_count.sql
+++ b/tests/queries/0_stateless/02892_rocksdb_trivial_count.sql
@@ -2,5 +2,7 @@
 
 CREATE TABLE dict (key UInt64, value String) ENGINE = EmbeddedRocksDB PRIMARY KEY key;
 INSERT INTO dict SELECT number, toString(number) FROM numbers(121);
+-- { echoOn }
 SELECT count() FROM dict SETTINGS optimize_trivial_approximate_count_query = 0, max_rows_to_read = 1; -- { serverError TOO_MANY_ROWS }
-SELECT count() FROM dict SETTINGS optimize_trivial_approximate_count_query = 1, max_rows_to_read = 1;
+SELECT count() FROM dict SETTINGS max_rows_to_read = 1;
+SELECT total_rows FROM system.tables WHERE database = currentDatabase() AND name = 'dict';

--- a/tests/queries/0_stateless/02892_rocksdb_trivial_count.sql
+++ b/tests/queries/0_stateless/02892_rocksdb_trivial_count.sql
@@ -4,5 +4,9 @@ CREATE TABLE dict (key UInt64, value String) ENGINE = EmbeddedRocksDB PRIMARY KE
 INSERT INTO dict SELECT number, toString(number) FROM numbers(121);
 -- { echoOn }
 SELECT count() FROM dict SETTINGS optimize_trivial_approximate_count_query = 0, max_rows_to_read = 1; -- { serverError TOO_MANY_ROWS }
-SELECT count() FROM dict SETTINGS max_rows_to_read = 1;
-SELECT total_rows FROM system.tables WHERE database = currentDatabase() AND name = 'dict';
+SELECT count() FROM dict SETTINGS optimize_trivial_approximate_count_query = 1, max_rows_to_read = 1;
+SET optimize_trivial_approximate_count_query = 1;
+-- needs more data to see total_bytes or just detach and attach the table
+DETACH TABLE dict SYNC;
+ATTACH TABLE dict;
+SELECT total_rows, total_bytes > 0 FROM system.tables WHERE database = currentDatabase() AND name = 'dict' FORMAT CSV;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Show `total_bytes` and `total_rows` in system tables for RocksDB storage

Follows: https://github.com/ClickHouse/ClickHouse/pull/55806
cc @canhld94 @vdimir @azat 
