### PR TITLE
Refactors index page for Введение section.

### DIFF
--- a/docs/ru/introduction/_category_.yml
+++ b/docs/ru/introduction/_category_.yml
@@ -2,6 +2,3 @@ position: 1
 label: 'Введение'
 collapsible: true
 collapsed: true
-link:
-  type: generated-index
-  title: Введение

--- a/docs/ru/introduction/index.md
+++ b/docs/ru/introduction/index.md
@@ -1,0 +1,13 @@
+---
+slug: /ru/introduction/
+sidebar_label: "Введение"
+sidebar_position: 8
+---
+
+# Введение
+
+В этом разделе содержится информация о том, как начать работу с ClickHouse.
+
+- [Отличительные возможности ClickHouse](./distinctive-features.md)
+- [Производительность](./performance.md)
+- [История ClickHouse](./history.md)


### PR DESCRIPTION
### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Documentation entry for user-facing changes
- [x] Documentation is written (mandatory for new features)

---

Removes weird meta tags from index page in the Russian `/introduction` section. Looks like this now:

<img width="1552" alt="Screenshot 2023-11-15 at 22 16 35" src="https://github.com/ClickHouse/ClickHouse/assets/9611008/47d84272-e4f2-41e5-b6f2-d525748ab774">

Closes https://github.com/ClickHouse/clickhouse-docs/issues/1679
