### PR TITLE
Sparse checkout: Use `--remote` for `git submodule update`

### DIFF
--- a/contrib/update-submodules.sh
+++ b/contrib/update-submodules.sh
@@ -9,4 +9,8 @@ cd $GIT_DIR
 contrib/sparse-checkout/setup-sparse-checkout.sh
 git submodule init
 git submodule sync
-git config --file .gitmodules --get-regexp .*path | sed 's/[^ ]* //' | xargs -I _ --max-procs 64 git submodule update --depth=1 --single-branch _
+# NOTE: do not use --remote for `git submodule update`[1] command, since the submodule references to the specific commit SHA1 in the subproject.
+#       It may cause unexpected behavior. Instead you need to commit a new SHA1 for a submodule.
+#
+#       [1] - https://git-scm.com/book/en/v2/Git-Tools-Submodules
+git config --file .gitmodules --get-regexp '.*path' | sed 's/[^ ]* //' | xargs -I _ --max-procs 64 git submodule update --depth=1 --single-branch _


### PR DESCRIPTION
cc @rschu1ze 

Prevents errors like

```
fatal: Fetched in submodule path 'contrib/google-protobuf', but it did not contain 089b89c8d4140f0d49fe4222b047a8ea814bc752. Direct fetching of that commit failed.
````

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)