### PR TITLE
Set limit for memory usage for client in Stress tests and ASTFuzzers

### DIFF
--- a/docker/test/fuzzer/run-fuzzer.sh
+++ b/docker/test/fuzzer/run-fuzzer.sh
@@ -234,6 +234,7 @@ quit
     # SC2046: Quote this to prevent word splitting. Actually I need word splitting.
     # shellcheck disable=SC2012,SC2046
     timeout -s TERM --preserve-status 30m clickhouse-client \
+        --max-memory-usage-for-client=1000000000 \
         --receive_timeout=10 \
         --receive_data_timeout_ms=10000 \
         --stacktrace \

--- a/docker/test/fuzzer/run-fuzzer.sh
+++ b/docker/test/fuzzer/run-fuzzer.sh
@@ -212,11 +212,11 @@ quit
 
     gdb -batch -command script.gdb -p $server_pid &
     sleep 5
-    # gdb will send SIGSTOP, spend some time loading debug info and then send SIGCONT, wait for it (up to send_timeout, 300s)
+    # gdb will send SIGSTOP, spend some time loading debug info, and then send SIGCONT, wait for it (up to send_timeout, 300s)
     time clickhouse-client --query "SELECT 'Connected to clickhouse-server after attaching gdb'" ||:
 
     # Check connectivity after we attach gdb, because it might cause the server
-    # to freeze and the fuzzer will fail. In debug build it can take a lot of time.
+    # to freeze, and the fuzzer will fail. In debug build, it can take a lot of time.
     for _ in {1..180}
     do
         if clickhouse-client --query "select 1"
@@ -226,15 +226,15 @@ quit
         sleep 1
     done
     kill -0 $server_pid # This checks that it is our server that is started and not some other one
-    echo 'Server started and responded'
+    echo 'Server started and responded.'
 
     setup_logs_replication
 
     # SC2012: Use find instead of ls to better handle non-alphanumeric filenames. They are all alphanumeric.
-    # SC2046: Quote this to prevent word splitting. Actually I need word splitting.
+    # SC2046: Quote this to prevent word splitting. Actually, I need word splitting.
     # shellcheck disable=SC2012,SC2046
     timeout -s TERM --preserve-status 30m clickhouse-client \
-        --max-memory-usage-for-client=1000000000 \
+        --max_memory_usage_in_client=1000000000 \
         --receive_timeout=10 \
         --receive_data_timeout_ms=10000 \
         --stacktrace \
@@ -254,10 +254,10 @@ quit
     wait "$fuzzer_pid" || fuzzer_exit_code=$?
     echo "Fuzzer exit code is $fuzzer_exit_code"
 
-    # If the server dies, most often the fuzzer returns code 210: connetion
+    # If the server dies, most often the fuzzer returns Code 210: Connetion
     # refused, and sometimes also code 32: attempt to read after eof. For
-    # simplicity, check again whether the server is accepting connections, using
-    # clickhouse-client. We don't check for existence of server process, because
+    # simplicity, check again whether the server is accepting connections using
+    # clickhouse-client. We don't check for the existence of the server process, because
     # the process is still present while the server is terminating and not
     # accepting the connections anymore.
 

--- a/tests/ci/stress.py
+++ b/tests/ci/stress.py
@@ -125,7 +125,7 @@ def call_with_retry(query: str, timeout: int = 30, retry_count: int = 5) -> None
 def make_query_command(query: str) -> str:
     return (
         f'clickhouse client -q "{query}" --max_untracked_memory=1Gi '
-        "--memory_profiler_step=1Gi --max_memory_usage_for_user=0"
+        "--memory_profiler_step=1Gi --max_memory_usage_for_user=0 --max-memory-usage-for-client=1000000000"
     )
 
 

--- a/tests/ci/stress.py
+++ b/tests/ci/stress.py
@@ -125,7 +125,7 @@ def call_with_retry(query: str, timeout: int = 30, retry_count: int = 5) -> None
 def make_query_command(query: str) -> str:
     return (
         f'clickhouse client -q "{query}" --max_untracked_memory=1Gi '
-        "--memory_profiler_step=1Gi --max_memory_usage_for_user=0 --max-memory-usage-for-client=1000000000"
+        "--memory_profiler_step=1Gi --max_memory_usage_for_user=0 --max_memory_usage_in_client=1000000000"
     )
 
 


### PR DESCRIPTION
### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Set memory usage for client (`1G`) to address problems like this: https://s3.amazonaws.com/clickhouse-test-reports/0/f1bf3f1fc39f520871ec878d815e515e12fd3e7b/fuzzer_astfuzzertsan/report.html


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
