### PR TITLE
Respect block size limits for `arrayJoin`

### DIFF
--- a/src/Interpreters/ExpressionActionsSettings.cpp
+++ b/src/Interpreters/ExpressionActionsSettings.cpp
@@ -13,6 +13,7 @@ ExpressionActionsSettings ExpressionActionsSettings::fromSettings(const Settings
     settings.min_count_to_compile_expression = from.min_count_to_compile_expression;
     settings.max_temporary_columns = from.max_temporary_columns;
     settings.max_temporary_non_const_columns = from.max_temporary_non_const_columns;
+    settings.max_block_size =  from.max_block_size;
     settings.compile_expressions = compile_expressions;
     settings.short_circuit_function_evaluation = from.short_circuit_function_evaluation;
 

--- a/src/Interpreters/ExpressionActionsSettings.h
+++ b/src/Interpreters/ExpressionActionsSettings.h
@@ -23,6 +23,7 @@ struct ExpressionActionsSettings
 
     size_t max_temporary_columns = 0;
     size_t max_temporary_non_const_columns = 0;
+    size_t max_block_size = 0;
 
     CompileExpressions compile_expressions = CompileExpressions::no;
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Try to respect limits for `arrayJoin` (bad version)


The query from [this](https://s3.amazonaws.com/clickhouse-test-reports/0/f1bf3f1fc39f520871ec878d815e515e12fd3e7b/fuzzer_astfuzzertsan/report.html) fuzzer failure report 
```
SELECT
    initializeAggregation('topKWeightedState(1)', 100.0001, arrayJoin(range(65535))),
    arrayJoin(range(1025))
FROM time_table__fuzz_9
```
makes `clickhouse-client` to be killed by OOM. The reason for this - a gigantic block with 67173375 rows which it tries to deserialize. This block was produces by two arrayJoins (65535 * 1025 = 67173375 exactly). This is not an ideal solution. In order to make it better we need to either to work with many blocks at the same time during execution of actions or to introduce something like `SplittingTransform` which will split a gigantic block into a few smaller ones. 