### PR TITLE
Fix race on zk_log initialization

### DIFF
--- a/src/Common/ZooKeeper/ZooKeeperImpl.cpp
+++ b/src/Common/ZooKeeper/ZooKeeperImpl.cpp
@@ -1147,7 +1147,8 @@ void ZooKeeper::pushRequest(RequestInfo && info)
     {
         checkSessionDeadline();
         info.time = clock::now();
-        if (zk_log)
+        auto maybe_zk_log = std::atomic_load(&zk_log);
+        if (maybe_zk_log)
         {
             info.request->thread_id = getThreadId();
             info.request->query_id = String(CurrentThread::getQueryId());


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Race reported by TSAN:
```
WARNING: ThreadSanitizer: data race (pid=12755)
  Read of size 8 at 0x7b6c00004c48 by thread T242:
    #0 std::__1::shared_ptr<DB::ZooKeeperLog>::get[abi:v15000]() const build_docker/./contrib/llvm-project/libcxx/include/__memory/shared_ptr.h:801:16 (clickhouse+0x1cc1e90e) (BuildId: 50dcc99123bdb0c65e2c9474a15c7fbc4103025c)
    #1 std::__1::shared_ptr<DB::ZooKeeperLog>::operator bool[abi:v15000]() const build_docker/./contrib/llvm-project/libcxx/include/__memory/shared_ptr.h:833:16 (clickhouse+0x1cc1e90e)
    #2 Coordination::ZooKeeper::pushRequest(Coordination::ZooKeeper::RequestInfo&&) build_docker/./src/Common/ZooKeeper/ZooKeeperImpl.cpp:1150:13 (clickhouse+0x1cc1e90e)
    #3 Coordination::ZooKeeper::multi(std::__1::vector<std::__1::shared_ptr<Coordination::Request>, std::__1::allocator<std::__1::shared_ptr<Coordination::Request>>> const&, std::__1::function<void (Coordination::MultiResponse const&)>) build_docker/./src/Common/ZooKeeper/ZooKeeperImpl.cpp:1459:5 (clickhouse+0x1cc230c4) (BuildId: 50dcc99123bdb0c65e2c9474a15c7fbc4103025c)
    #4 zkutil::ZooKeeper::asyncTryMultiNoThrow(std::__1::vector<std::__1::shared_ptr<Coordination::Request>, std::__1::allocator<std::__1::shared_ptr<Coordination::Request>>> const&) build_docker/./src/Common/ZooKeeper/ZooKeeper.cpp:1219:11 (clickhouse+0x1cbae758) (BuildId: 50dcc99123bdb0c65e2c9474a15c7fbc4103025c)
    #5 zkutil::ZooKeeper::multiImpl(std::__1::vector<std::__1::shared_ptr<Coordination::Request>, std::__1::allocator<std::__1::shared_ptr<Coordination::Request>>> const&, std::__1::vector<std::__1::shared_ptr<Coordination::Response>, std::__1::allocator<std::__1::shared_ptr<Coordination::Response>>>&) build_docker/./src/Common/ZooKeeper/ZooKeeper.cpp:641:26 (clickhouse+0x1cbaaa00) (BuildId: 50dcc99123bdb0c65e2c9474a15c7fbc4103025c)
    #6 zkutil::ZooKeeper::tryMulti(std::__1::vector<std::__1::shared_ptr<Coordination::Request>, std::__1::allocator<std::__1::shared_ptr<Coordination::Request>>> const&, std::__1::vector<std::__1::shared_ptr<Coordination::Response>, std::__1::allocator<std::__1::shared_ptr<Coordination::Response>>>&) build_docker/./src/Common/ZooKeeper/ZooKeeper.cpp:667:32 (clickhouse+0x1cbaea89) (BuildId: 50dcc99123bdb0c65e2c9474a15c7fbc4103025c)
....


  Previous write of size 8 at 0x7b6c00004c48 by main thread (mutexes: write M0, write M1):
    #0 std::__1::enable_if<is_move_constructible<DB::ZooKeeperLog*>::value && is_move_assignable<DB::ZooKeeperLog*>::value, void>::type std::__1::swap[abi:v15000]<DB::ZooKeeperLog*>(DB::ZooKeeperLog*&, DB::ZooKeeperLog*&) build_docker/./contrib/llvm-project/libcxx/include/__utility/swap.h:36:7 (clickhouse+0x1cc23427) (BuildId: 50dcc99123bdb0c65e2c9474a15c7fbc4103025c)
    #1 std::__1::shared_ptr<DB::ZooKeeperLog>::swap[abi:v15000](std::__1::shared_ptr<DB::ZooKeeperLog>&) build_docker/./contrib/llvm-project/libcxx/include/__memory/shared_ptr.h:761:9 (clickhouse+0x1cc23427)
    #2 void std::__1::atomic_store<DB::ZooKeeperLog>(std::__1::shared_ptr<DB::ZooKeeperLog>*, std::__1::shared_ptr<DB::ZooKeeperLog>) build_docker/./contrib/llvm-project/libcxx/include/__memory/shared_ptr.h:1826:10 (clickhouse+0x1cc23427)
    #3 Coordination::ZooKeeper::setZooKeeperLog(std::__1::shared_ptr<DB::ZooKeeperLog>) build_docker/./src/Common/ZooKeeper/ZooKeeperImpl.cpp:1482:5 (clickhouse+0x1cc23427)
    #4 zkutil::ZooKeeper::setZooKeeperLog(std::__1::shared_ptr<DB::ZooKeeperLog>) build_docker/./src/Common/ZooKeeper/ZooKeeper.cpp:1313:13 (clickhouse+0x1cbbae42) (BuildId: 50dcc99123bdb0c65e2c9474a15c7fbc4103025c)
    #5 DB::Context::setSystemZooKeeperLogAfterInitializationIfNeeded() build_docker/./src/Interpreters/Context.cpp:3048:32 (clickhouse+0x19805174) (BuildId: 50dcc99123bdb0c65e2c9474a15c7fbc4103025c)
    #6 DB::Server::main(std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>> const&) build_docker/./programs/server/Server.cpp:1763:25 (clickhouse+0x10699de3) (BuildId: 50dcc99123bdb0c65e2c9474a15c7fbc4103025c)
    #7 Poco::Util::Application::run() build_docker/./base/poco/Util/src/Application.cpp:315:8 (clickhouse+0x2070d13e) (BuildId: 50dcc99123bdb0c65e2c9474a15c7fbc4103025c)
    #8 DB::Server::run() build_docker/./programs/server/Server.cpp:401:25 (clickhouse+0x10685b3c) (BuildId: 50dcc99123bdb0c65e2c9474a15c7fbc4103025c)
    #9 Poco::Util::ServerApplication::run(int, char**) build_docker/./base/poco/Util/src/ServerApplication.cpp:131:9 (clickhouse+0x2072cdb4) (BuildId: 50dcc99123bdb0c65e2c9474a15c7fbc4103025c)
    #10 mainEntryClickHouseServer(int, char**) build_docker/./programs/server/Server.cpp:207:20 (clickhouse+0x10682ce3) (BuildId: 50dcc99123bdb0c65e2c9474a15c7fbc4103025c)
    #11 main build_docker/./programs/main.cpp:505:12 (clickhouse+0x7f8bb40) (BuildId: 50dcc99123bdb0c65e2c9474a15c7fbc4103025c)

```