### PR TITLE
Fix generating deep nested columns in CapnProto/Protobuf schemas

### DIFF
--- a/src/Formats/StructureToFormatSchemaUtils.cpp
+++ b/src/Formats/StructureToFormatSchemaUtils.cpp
@@ -96,6 +96,10 @@ NamesAndTypesList collectNested(const NamesAndTypesList & names_and_types, bool 
             nested[field_name].emplace_back(nested_name, type);
     }
 
+    /// Collect nested recursively.
+    for (auto & [field_name, elements] : nested)
+        elements = collectNested(elements, allow_split_by_underscore, format_name);
+
     for (const auto & [field_name, elements]: nested)
         result.emplace_back(field_name, std::make_shared<DataTypeTuple>(elements.getTypes(), elements.getNames()));
 

--- a/tests/queries/0_stateless/02920_capnp_protobuf_auto_schema_nested.reference
+++ b/tests/queries/0_stateless/02920_capnp_protobuf_auto_schema_nested.reference
@@ -1,0 +1,52 @@
+
+message Message
+{
+    message H
+    {
+        uint32 k = 1;
+    }
+    H h = 1;
+    message A
+    {
+        uint32 g = 1;
+        message B
+        {
+            uint32 c = 1;
+            uint32 f = 2;
+            message D
+            {
+                uint32 e = 1;
+            }
+            D d = 3;
+        }
+        B b = 2;
+    }
+    A a = 2;
+}
+46	(45,(42,44,43))
+
+struct Message
+{
+    struct H
+    {
+        k @0 : UInt8;
+    }
+    h @0 : H;
+    struct A
+    {
+        g @0 : UInt8;
+        struct B
+        {
+            c @0 : UInt8;
+            f @1 : UInt8;
+            struct D
+            {
+                e @0 : UInt8;
+            }
+            d @2 : D;
+        }
+        b @1 : B;
+    }
+    a @1 : A;
+}
+(46)	(45,(42,44,(43)))

--- a/tests/queries/0_stateless/02920_capnp_protobuf_auto_schema_nested.sh
+++ b/tests/queries/0_stateless/02920_capnp_protobuf_auto_schema_nested.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+SCHEMA_FILE=$CLICKHOUSE_TEST_UNIQUE_NAME-schema
+FILE=$CLICKHOUSE_TEST_UNIQUE_NAME
+
+$CLICKHOUSE_LOCAL -q "select 42 as \`a.b.c\`, 43 as \`a.b.d.e\`, 44 as \`a.b.f\`, 45 as \`a.g\`, 46 as \`h.k\` format Protobuf settings output_format_schema='$SCHEMA_FILE.proto'" > $FILE.pb
+tail -n +2 $SCHEMA_FILE.proto
+$CLICKHOUSE_LOCAL -q "select * from file('$FILE.pb') settings format_schema='$SCHEMA_FILE:Message'"
+
+$CLICKHOUSE_LOCAL -q "select 42 as a_b_c, 43 as a_b_d_e, 44 as a_b_f, 45 as a_g, 46 as h_k format CapnProto settings output_format_schema='$SCHEMA_FILE.capnp'" > $FILE.capnp
+tail -n +2 $SCHEMA_FILE.capnp
+$CLICKHOUSE_LOCAL -q "select * from file('$FILE.capnp') settings format_schema='$SCHEMA_FILE:Message'"
+
+rm $SCHEMA_FILE*
+rm $FILE.*
+


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix generating deep nested columns in CapnProto/Protobuf autogenerated schemas. Closes https://github.com/ClickHouse/ClickHouse/issues/56692

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
