### PR TITLE
Add exceptions.count column to Kafka system tables

### DIFF
--- a/docs/en/operations/system-tables/kafka_consumers.md
+++ b/docs/en/operations/system-tables/kafka_consumers.md
@@ -16,6 +16,7 @@ Columns:
 - `assignments.current_offset` (Array(Int64)) - current offset.
 - `exceptions.time`, (Array(DateTime)) - timestamp when the 10 most recent exceptions were generated.
 - `exceptions.text`, (Array(String)) - text of 10 most recent exceptions.
+- `exceptions.count`, (UInt64) - total number of exceptions.
 - `last_poll_time`, (DateTime) - timestamp of the most recent poll.
 - `num_messages_read`, (UInt64) - number of messages read by the consumer.
 - `last_commit_time`, (DateTime) - timestamp of the most recent poll.
@@ -45,6 +46,7 @@ assignments.partition_id:   [0]
 assignments.current_offset: [18446744073709550615]
 exceptions.time:            []
 exceptions.text:            []
+exceptions.count:           0
 last_poll_time:             2006-11-09 18:47:47
 num_messages_read:          4
 last_commit_time:           2006-11-10 04:39:40

--- a/src/Storages/Kafka/KafkaConsumer.cpp
+++ b/src/Storages/Kafka/KafkaConsumer.cpp
@@ -592,19 +592,19 @@ KafkaConsumer::Stat KafkaConsumer::getStat() const
         });
     }
 
-    auto exc_buffer = decltype(this->exceptions_buffer){};
-    auto num_exc = decltype(this->num_exceptions){};
+    KafkaConsumer::ExceptionsBuffer exc_buffer;
+    UInt64 num_exc;
     {
         std::lock_guard<std::mutex> lock(exception_mutex);
-        exc_buffer = this->exceptions_buffer;
-        num_exc = this->num_exceptions;
+        exc_buffer = exceptions_buffer;
+        num_exc = num_exceptions;
     }
 
-    auto rdkafka_stat_copy = [&]()
+    String rdkafka_stat_copy;
     {
         std::lock_guard<std::mutex> lock(rdkafka_stat_mutex);
-        return this->rdkafka_stat;
-    }();
+        rdkafka_stat_copy = rdkafka_stat;
+    }
 
     return {
         .consumer_id = getMemberId() /* consumer->get_member_id() */,

--- a/src/Storages/Kafka/KafkaConsumer.h
+++ b/src/Storages/Kafka/KafkaConsumer.h
@@ -56,6 +56,7 @@ public:
         UInt64 num_rebalance_assignments;
         UInt64 num_rebalance_revocations;
         KafkaConsumer::ExceptionsBuffer exceptions_buffer;
+        UInt64 num_exceptions;
         bool in_use;
         std::string rdkafka_stat;
     };
@@ -158,6 +159,7 @@ private:
     mutable std::mutex exception_mutex;
     const size_t EXCEPTIONS_DEPTH = 10;
     ExceptionsBuffer exceptions_buffer;
+    UInt64 num_exceptions;
 
     std::atomic<UInt64> last_exception_timestamp_usec = 0;
     std::atomic<UInt64> last_poll_timestamp_usec = 0;

--- a/src/Storages/System/StorageSystemKafkaConsumers.cpp
+++ b/src/Storages/System/StorageSystemKafkaConsumers.cpp
@@ -33,6 +33,7 @@ NamesAndTypesList StorageSystemKafkaConsumers::getNamesAndTypes()
         {"assignments.current_offset", std::make_shared<DataTypeArray>(std::make_shared<DataTypeInt64>())},
         {"exceptions.time", std::make_shared<DataTypeArray>(std::make_shared<DataTypeDateTime>())},
         {"exceptions.text", std::make_shared<DataTypeArray>(std::make_shared<DataTypeString>())},
+        {"exceptions.count", std::make_shared<DataTypeUInt64>()},
         {"last_poll_time", std::make_shared<DataTypeDateTime>()},
         {"num_messages_read", std::make_shared<DataTypeUInt64>()},
         {"last_commit_time", std::make_shared<DataTypeDateTime>()},
@@ -70,6 +71,7 @@ void StorageSystemKafkaConsumers::fillData(MutableColumns & res_columns, Context
     auto & exceptions_time_offset = assert_cast<ColumnArray &>(*res_columns[index++]).getOffsets();
     auto & exceptions_text = assert_cast<ColumnString &>(assert_cast<ColumnArray &>(*res_columns[index]).getData());
     auto & exceptions_text_offset = assert_cast<ColumnArray &>(*res_columns[index++]).getOffsets();
+    auto & num_exceptions = assert_cast<ColumnUInt64 &>(*res_columns[index++]);
     auto & last_poll_time = assert_cast<ColumnDateTime &>(*res_columns[index++]);
     auto & num_messages_read = assert_cast<ColumnUInt64 &>(*res_columns[index++]);
     auto & last_commit_time = assert_cast<ColumnDateTime &>(*res_columns[index++]);
@@ -129,10 +131,10 @@ void StorageSystemKafkaConsumers::fillData(MutableColumns & res_columns, Context
                     exceptions_text.insertData(exc.text.data(), exc.text.size());
                     exceptions_time.insert(exc.timestamp_usec);
                 }
-                exceptions_num += consumer_stat.exceptions_buffer.size();
+                exceptions_num += consumer_stat.num_exceptions;
                 exceptions_text_offset.push_back(exceptions_num);
                 exceptions_time_offset.push_back(exceptions_num);
-
+                num_exceptions.insert(exceptions_num);
 
                 last_poll_time.insert(consumer_stat.last_poll_time);
                 num_messages_read.insert(consumer_stat.num_messages_read);

--- a/tests/integration/test_kafka_bad_messages/test.py
+++ b/tests/integration/test_kafka_bad_messages/test.py
@@ -319,13 +319,13 @@ def test_bad_messages_parsing_exception(kafka_cluster, max_retries=20):
             kafka_cluster, f"{format_name}_err", ["qwertyuiop", "asdfghjkl", "zxcvbnm"]
         )
 
-    expected_result = """avro::Exception: Invalid data file. Magic does not match: : while parsing Kafka message (topic: Avro_err, partition: 0, offset: 0)\\'|1|1|1|default|kafka_Avro
-Cannot parse input: expected \\'{\\' before: \\'qwertyuiop\\': while parsing Kafka message (topic: JSONEachRow_err, partition: 0, offset: 0|1|1|1|default|kafka_JSONEachRow
+    expected_result = """avro::Exception: Invalid data file. Magic does not match: : while parsing Kafka message (topic: Avro_err, partition: 0, offset: 0)\\'|1|1|1|3|default|kafka_Avro
+Cannot parse input: expected \\'{\\' before: \\'qwertyuiop\\': while parsing Kafka message (topic: JSONEachRow_err, partition: 0, offset: 0|1|1|1|3|default|kafka_JSONEachRow
 """
     # filter out stacktrace in exceptions.text[1] because it is hardly stable enough
     result_system_kafka_consumers = instance.query_with_retry(
         """
-        SELECT substr(exceptions.text[1], 1, 131), length(exceptions.text) > 1 AND length(exceptions.text) < 15, length(exceptions.time) > 1 AND length(exceptions.time) < 15, abs(dateDiff('second', exceptions.time[1], now())) < 40, database, table FROM system.kafka_consumers WHERE table in('kafka_Avro', 'kafka_JSONEachRow') ORDER BY table, assignments.partition_id[1]
+        SELECT substr(exceptions.text[1], 1, 131), length(exceptions.text) > 1 AND length(exceptions.text) < 15, length(exceptions.time) > 1 AND length(exceptions.time) < 15, abs(dateDiff('second', exceptions.time[1], now())) < 40, exceptions.count, database, table FROM system.kafka_consumers WHERE table in('kafka_Avro', 'kafka_JSONEachRow') ORDER BY table, assignments.partition_id[1]
         """,
         retry_count=max_retries,
         sleep_time=1,
@@ -373,11 +373,11 @@ def test_bad_messages_to_mv(kafka_cluster, max_retries=20):
 
     kafka_produce(kafka_cluster, "tomv", ['{"key":10, "value":"aaa"}'])
 
-    expected_result = """Code: 6. DB::Exception: Cannot parse string \\'aaa\\' as UInt64: syntax error at begin of string. Note: there are toUInt64OrZero and to|1|1|1|default|kafka1
+    expected_result = """Code: 6. DB::Exception: Cannot parse string \\'aaa\\' as UInt64: syntax error at begin of string. Note: there are toUInt64OrZero and to|1|1|1|1|default|kafka1
 """
     result_system_kafka_consumers = instance.query_with_retry(
         """
-        SELECT substr(exceptions.text[1], 1, 131), length(exceptions.text) > 1 AND length(exceptions.text) < 15, length(exceptions.time) > 1 AND length(exceptions.time) < 15, abs(dateDiff('second', exceptions.time[1], now())) < 40, database, table FROM system.kafka_consumers  WHERE table='kafka1' ORDER BY table, assignments.partition_id[1]
+        SELECT substr(exceptions.text[1], 1, 131), length(exceptions.text) > 1 AND length(exceptions.text) < 15, length(exceptions.time) > 1 AND length(exceptions.time) < 15, abs(dateDiff('second', exceptions.time[1], now())) < 40, exceptions.count, database, table FROM system.kafka_consumers  WHERE table='kafka1' ORDER BY table, assignments.partition_id[1]
         """,
         retry_count=max_retries,
         sleep_time=1,

--- a/tests/integration/test_storage_kafka/test.py
+++ b/tests/integration/test_storage_kafka/test.py
@@ -4588,6 +4588,7 @@ def test_system_kafka_consumers(kafka_cluster):
           assignments.current_offset,
           if(length(exceptions.time)>0, exceptions.time[1]::String, 'never') as last_exception_time_,
           if(length(exceptions.text)>0, exceptions.text[1], 'no exception') as last_exception_,
+          exceptions.count as exception_count_,
           stable_timestamp(last_poll_time) as last_poll_time_, num_messages_read, stable_timestamp(last_commit_time) as last_commit_time_,
           num_commits, stable_timestamp(last_rebalance_time) as last_rebalance_time_,
           num_rebalance_revocations, num_rebalance_assignments, is_currently_used
@@ -4607,6 +4608,7 @@ assignments.partition_id:   [0]
 assignments.current_offset: [4]
 last_exception_time_:       never
 last_exception_:            no exception
+exception_count_:           0
 last_poll_time_:            now
 num_messages_read:          4
 last_commit_time_:          now
@@ -4688,6 +4690,7 @@ def test_system_kafka_consumers_rebalance(kafka_cluster, max_retries=15):
           assignments.current_offset,
           if(length(exceptions.time)>0, exceptions.time[1]::String, 'never') as last_exception_time_,
           if(length(exceptions.text)>0, exceptions.text[1], 'no exception') as last_exception_,
+          exceptions.count as exception_count_,
           stable_timestamp(last_poll_time) as last_poll_time_, num_messages_read, stable_timestamp(last_commit_time) as last_commit_time_,
           num_commits, stable_timestamp(last_rebalance_time) as last_rebalance_time_,
           num_rebalance_revocations, num_rebalance_assignments, is_currently_used
@@ -4707,6 +4710,7 @@ assignments.partition_id:   [0]
 assignments.current_offset: [2]
 last_exception_time_:       never
 last_exception_:            no exception
+exception_count_:           0
 last_poll_time_:            now
 num_messages_read:          4
 last_commit_time_:          now
@@ -4726,6 +4730,7 @@ assignments.partition_id:   [1]
 assignments.current_offset: [2]
 last_exception_time_:       never
 last_exception_:            no exception
+exception_count_:           0
 last_poll_time_:            now
 num_messages_read:          1
 last_commit_time_:          now


### PR DESCRIPTION
This maintains a *total* count of exceptions, which is useful for things like monitoring via Prometheus.

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add `exceptions.count` column to Kafka system tables.

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
