### PR TITLE
Fewer concurrent requests in 02908_many_requests_to_system_replicas

### DIFF
--- a/tests/queries/0_stateless/02908_many_requests_to_system_replicas.reference
+++ b/tests/queries/0_stateless/02908_many_requests_to_system_replicas.reference
@@ -1,5 +1,5 @@
 Creating 300 tables
-Making making 500 requests to system.replicas
+Making making 200 requests to system.replicas
 Query system.replicas while waiting for other concurrent requests to finish
 0
 900

--- a/tests/queries/0_stateless/02908_many_requests_to_system_replicas.sh
+++ b/tests/queries/0_stateless/02908_many_requests_to_system_replicas.sh
@@ -8,7 +8,7 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 set -e
 
 NUM_TABLES=300
-CONCURRENCY=500
+CONCURRENCY=200
 
 echo "Creating $NUM_TABLES tables"
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Make 200 instead of 500 concurrent requests to make test more stable