### PR TITLE
Fix build in Backups/BackupIO_S3.cpp

### DIFF
--- a/src/Backups/BackupIO_S3.cpp
+++ b/src/Backups/BackupIO_S3.cpp
@@ -254,7 +254,6 @@ void BackupWriterS3::copyFile(const String & destination, const String & source,
     LOG_TRACE(log, "Copying file inside backup from {} to {} ", source, destination);
     copyS3File(
         client,
-        client,
         /* src_bucket */ s3_uri.bucket,
         /* src_key= */ fs::path(s3_uri.key) / source,
         0,


### PR DESCRIPTION
PR #56460 broke the build:

```
/home/ubuntu/repo/ClickHouse/src/Backups/BackupIO_S3.cpp:255:5: error: no matching function for call to 'copyS3File'
  255 |     copyS3File(
      |     ^~~~~~~~~~
/home/ubuntu/repo/ClickHouse/src/IO/S3/copyS3File.h:31:6: note: candidate function not viable: no known conversion from 'std::shared_ptr<S3::Client>' to 'const String' (aka 'const basic_string<char, char_traits<char>, allocator<char>>') for 2nd argument
   33 | void copyS3File(
      |      ^
   34 |     const std::shared_ptr<const S3::Client> & s3_client,
   35 |     const String & src_bucket,
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
[10301/12493] Building CXX object src/CMakeFiles/dbms.dir/Functions/CastOverloadResolver.cpp.o
ninja: build stopped: subcommand failed.
```

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
