### PR TITLE
Add exclude for tryBase64Decode to backward compat test (follow-up to #56913)

### DIFF
--- a/tests/integration/test_backward_compatibility/test_functions.py
+++ b/tests/integration/test_backward_compatibility/test_functions.py
@@ -153,6 +153,9 @@ def test_string_functions(start_cluster):
         # mandatory or optional). The former lib produces a value based on implicit padding, the latter lib throws an error.
         "FROM_BASE64",
         "base64Decode",
+        # PR #56913 (in v23.11) corrected the way tryBase64Decode() behaved with invalid inputs. Old versions return garbage, new versions
+        # return an empty string (as it was always documented).
+        "tryBase64Decode",
         # Removed in 23.9
         "meiliMatch",
     ]


### PR DESCRIPTION
Unflakes `test_backward_compatibility/test_functions.py::test_string_functions`

Fixes #56969

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)