### PR TITLE
update 02003_memory_limit_in_client.sh

### DIFF
--- a/tests/queries/0_stateless/02003_memory_limit_in_client.sh
+++ b/tests/queries/0_stateless/02003_memory_limit_in_client.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash -f
+#!/usr/bin/env bash
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

I don't think `-f` in `#!/usr/bin/bash -f` is a valid option. Also update the script to just use `#!/usr/bin/env bash` (rely on env for finding bash) like it's used eveywhere else.
> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
