### PR TITLE
S3Queue: fix metadata reference increment 

### DIFF
--- a/src/Storages/S3Queue/S3QueueMetadataFactory.cpp
+++ b/src/Storages/S3Queue/S3QueueMetadataFactory.cpp
@@ -43,6 +43,7 @@ void S3QueueMetadataFactory::remove(const std::string & zookeeper_path)
     if (it == metadata_by_path.end())
         throw Exception(ErrorCodes::BAD_ARGUMENTS, "Metadata with zookeeper path {} does not exist", zookeeper_path);
 
+    chassert(it->second.ref_count > 0);
     if (--it->second.ref_count == 0)
     {
         try

--- a/src/Storages/S3Queue/S3QueueMetadataFactory.h
+++ b/src/Storages/S3Queue/S3QueueMetadataFactory.h
@@ -25,6 +25,7 @@ private:
         explicit Metadata(std::shared_ptr<S3QueueFilesMetadata> metadata_) : metadata(metadata_), ref_count(1) {}
 
         std::shared_ptr<S3QueueFilesMetadata> metadata;
+        /// TODO: the ref count should be kept in keeper, because of the case with distributed processing.
         size_t ref_count = 0;
     };
     using MetadataByPath = std::unordered_map<std::string, Metadata>;

--- a/src/Storages/S3Queue/S3QueueTableMetadata.cpp
+++ b/src/Storages/S3Queue/S3QueueTableMetadata.cpp
@@ -83,8 +83,8 @@ void S3QueueTableMetadata::checkImmutableFieldsEquals(const S3QueueTableMetadata
             ErrorCodes::METADATA_MISMATCH,
             "Existing table metadata in ZooKeeper differs in engine mode. "
             "Stored in ZooKeeper: {}, local: {}",
-            DB::toString(from_zk.after_processing),
-            DB::toString(after_processing));
+            DB::toString(from_zk.mode),
+            DB::toString(mode));
 
     if (s3queue_tracked_files_limit != from_zk.s3queue_tracked_files_limit)
         throw Exception(


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix incorrect metadata ref count in case exception from storage constructor.