### PR TITLE
Make check for the limited cmake dependencies the part of sparse checkout

### DIFF
--- a/contrib/update-submodules.sh
+++ b/contrib/update-submodules.sh
@@ -14,3 +14,11 @@ git submodule sync
 #
 #       [1] - https://git-scm.com/book/en/v2/Git-Tools-Submodules
 git config --file .gitmodules --get-regexp '.*path' | sed 's/[^ ]* //' | xargs -I _ --max-procs 64 git submodule update --depth=1 --single-branch _
+
+# We don't want to depend on any third-party CMake files.
+# To check it, find and delete them.
+grep -o -P '"contrib/[^"]+"' .gitmodules |
+  grep -v -P 'contrib/(llvm-project|google-protobuf|grpc|abseil-cpp|corrosion)' |
+  xargs -I@ find @ \
+    -'(' -name 'CMakeLists.txt' -or -name '*.cmake' -')' -and -not -name '*.h.cmake' \
+    -delete

--- a/docker/packager/binary/build.sh
+++ b/docker/packager/binary/build.sh
@@ -34,15 +34,6 @@ cd /build/build_docker
 rm -f CMakeCache.txt
 
 
-# We don't want to depend on any third-party CMake files.
-# To check it, find and delete them.
-
-grep -o -P '"contrib/[^"]+"' ../.gitmodules |
-  grep -v -P 'llvm-project|google-protobuf|grpc|abseil-cpp|corrosion' |
-  xargs -I@ find ../@ -'(' -name 'CMakeLists.txt' -or -name '*.cmake' -')' -and -not -name '*.h.cmake' |
-  xargs rm
-
-
 if [ -n "$MAKE_DEB" ]; then
   rm -rf /build/packages/root
   # NOTE: this is for backward compatibility with previous releases,


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
A tiny followup for #56898 