### PR TITLE
Fix flaky and slow tests.

### DIFF
--- a/tests/queries/0_stateless/01710_projection_aggregation_in_order.sql
+++ b/tests/queries/0_stateless/01710_projection_aggregation_in_order.sql
@@ -1,5 +1,3 @@
--- Tags: disabled
--- FIXME https://github.com/ClickHouse/ClickHouse/issues/49552
 -- Test that check the correctness of the result for optimize_aggregation_in_order and projections,
 -- not that this optimization will take place.
 
@@ -20,7 +18,7 @@ CREATE TABLE normal
     )
 )
 ENGINE = MergeTree
-ORDER BY (key, ts);
+ORDER BY tuple();
 
 INSERT INTO normal SELECT
     number,
@@ -52,7 +50,7 @@ CREATE TABLE agg
     )
 )
 ENGINE = MergeTree
-ORDER BY (key, ts);
+ORDER BY tuple();
 
 INSERT INTO agg SELECT
     1,

--- a/tests/queries/0_stateless/02516_projections_with_rollup.sql
+++ b/tests/queries/0_stateless/02516_projections_with_rollup.sql
@@ -1,6 +1,3 @@
--- Tags: disabled
--- FIXME https://github.com/ClickHouse/ClickHouse/issues/49552
-
 DROP TABLE IF EXISTS video_log;
 DROP TABLE IF EXISTS video_log_result__fuzz_0;
 DROP TABLE IF EXISTS rng;
@@ -16,7 +13,8 @@ CREATE TABLE video_log
 )
 ENGINE = MergeTree
 PARTITION BY toDate(datetime)
-ORDER BY (user_id, device_id);
+ORDER BY (user_id, device_id)
+SETTINGS index_granularity_bytes=10485760, index_granularity=8192;
 
 CREATE TABLE video_log_result__fuzz_0
 (
@@ -62,7 +60,7 @@ LIMIT 10;
 ALTER TABLE video_log
     ADD PROJECTION p_norm
     (
-        SELECT 
+        SELECT
             datetime,
             device_id,
             bytes,
@@ -77,12 +75,12 @@ SETTINGS mutations_sync = 1;
 ALTER TABLE video_log
     ADD PROJECTION p_agg
     (
-        SELECT 
+        SELECT
             toStartOfHour(datetime) AS hour,
             domain,
             sum(bytes),
             avg(duration)
-        GROUP BY 
+        GROUP BY
             hour,
             domain
     );


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix some flaky and slow tests. This fixes #49552.

01710_projection_aggregation_in_order.sql

Make sure projection uses less marks than the original table. If the number of marks are equal, the behavior is subject to change.

02516_projections_with_rollup.sql 

If `index_granularity` is too small, the test will be extremely slow to run, because MergeTreeSequentialSource always returns one granule per block. It might be worth optimizing with some `max_block_size` setting.