### PR TITLE
HashJoin respects max_joined_block_size_rows

### DIFF
--- a/src/Interpreters/ConcurrentHashJoin.cpp
+++ b/src/Interpreters/ConcurrentHashJoin.cpp
@@ -44,7 +44,8 @@ ConcurrentHashJoin::ConcurrentHashJoin(ContextPtr context_, std::shared_ptr<Tabl
     for (size_t i = 0; i < slots; ++i)
     {
         auto inner_hash_join = std::make_shared<InternalHashJoin>();
-        inner_hash_join->data = std::make_unique<HashJoin>(table_join_, right_sample_block, any_take_last_row_);
+
+        inner_hash_join->data = std::make_unique<HashJoin>(table_join_, right_sample_block, any_take_last_row_, 0, fmt::format("concurrent{}", i));
         hash_joins.emplace_back(std::move(inner_hash_join));
     }
 }

--- a/src/Interpreters/GraceHashJoin.h
+++ b/src/Interpreters/GraceHashJoin.h
@@ -44,9 +44,8 @@ class GraceHashJoin final : public IJoin
 {
     class FileBucket;
     class DelayedBlocks;
-    using InMemoryJoin = HashJoin;
 
-    using InMemoryJoinPtr = std::shared_ptr<InMemoryJoin>;
+    using InMemoryJoinPtr = std::shared_ptr<HashJoin>;
 
 public:
     using BucketPtr = std::shared_ptr<FileBucket>;
@@ -91,7 +90,7 @@ public:
 private:
     void initBuckets();
     /// Create empty join for in-memory processing.
-    InMemoryJoinPtr makeInMemoryJoin(size_t reserve_num = 0);
+    InMemoryJoinPtr makeInMemoryJoin(const String & bucket_id, size_t reserve_num = 0);
 
     /// Add right table block to the @join. Calls @rehash on overflow.
     void addBlockToJoinImpl(Block block);

--- a/src/Interpreters/HashJoin.h
+++ b/src/Interpreters/HashJoin.h
@@ -147,7 +147,8 @@ class HashJoin : public IJoin
 {
 public:
     HashJoin(
-        std::shared_ptr<TableJoin> table_join_, const Block & right_sample_block, bool any_take_last_row_ = false, size_t reserve_num = 0);
+        std::shared_ptr<TableJoin> table_join_, const Block & right_sample_block,
+        bool any_take_last_row_ = false, size_t reserve_num = 0, const String & instance_id_ = "");
 
     ~HashJoin() override;
 
@@ -435,6 +436,10 @@ private:
     /// When tracked memory consumption is more than a threshold, we will shrink to fit stored blocks.
     bool shrink_blocks = false;
     Int64 memory_usage_before_adding_blocks = 0;
+
+    /// Identifier to distinguish different HashJoin instances in logs
+    /// Several instances can be created, for example, in GraceHashJoin to handle different buckets
+    String instance_log_id;
 
     Poco::Logger * log;
 

--- a/src/Interpreters/HashJoin.h
+++ b/src/Interpreters/HashJoin.h
@@ -447,7 +447,7 @@ private:
     void initRightBlockStructure(Block & saved_block_sample);
 
     template <JoinKind KIND, JoinStrictness STRICTNESS, typename Maps>
-    void joinBlockImpl(
+    Block joinBlockImpl(
         Block & block,
         const Block & block_with_columns_to_add,
         const std::vector<const Maps *> & maps_,

--- a/tests/performance/hashjoin_with_large_output.xml
+++ b/tests/performance/hashjoin_with_large_output.xml
@@ -1,0 +1,64 @@
+<test>
+    <settings>
+        <max_threads>16</max_threads>
+        <max_memory_usage>10G</max_memory_usage>
+    </settings>
+
+    <substitutions>
+        <substitution>
+            <name>settings</name>
+            <values>
+                <value>join_algorithm='hash'</value>
+                <value>join_algorithm='grace_hash'</value>
+            </values>
+        </substitution>
+    </substitutions>
+
+    <create_query>
+        create table test_left
+        (
+        k1 String,
+        v1 String
+        )
+        engine = Memory();
+    </create_query>
+    <create_query>
+        create table test_right
+        (
+        k1 String,
+        v1 String,
+        v2 String,
+        v3 String,
+        v4 String,
+        v5 String,
+        v6 String,
+        v7 String,
+        v8 String,
+        v9 String
+        )
+        engine = Memory();
+    </create_query>
+    <fill_query>insert into test_left SELECT toString(number % 20), toString(number) from system.numbers limit 10000;</fill_query>
+    <fill_query>
+        insert into test_right
+        SELECT
+        toString(number % 20),
+        toString(number * 10000),
+        toString(number * 10000 + 1),
+        toString(number * 10000 + 2),
+        toString(number * 10000 + 3),
+        toString(number * 10000 + 4),
+        toString(number * 10000 + 5),
+        toString(number * 10000 + 6),
+        toString(number * 10000 + 7),
+        toString(number * 10000 + 8)
+        from system.numbers limit 10000;
+    </fill_query>
+
+    <query>
+        select * from test_left all inner join test_right on test_left.k1 = test_right.k1  SETTINGS {settings} format Null
+    </query>
+
+    <drop_query>DROP TABLE IF EXISTS test_left</drop_query>
+    <drop_query>DROP TABLE IF EXISTS test_right</drop_query>
+</test>


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):

- Performance Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
* HashJoin respects setting `max_joined_block_size_rows` and do not produce large blocks for `ALL JOIN`

Ref https://github.com/ClickHouse/ClickHouse/pull/54662