### PR TITLE
Allow to use `concat` function with a single argument

### DIFF
--- a/docs/en/sql-reference/functions/string-functions.md
+++ b/docs/en/sql-reference/functions/string-functions.md
@@ -439,7 +439,7 @@ concat(s1, s2, ...)
 
 **Arguments**
 
-At least two values of arbitrary type.
+At least one value of arbitrary type.
 
 Arguments which are not of types [String](../../sql-reference/data-types/string.md) or [FixedString](../../sql-reference/data-types/fixedstring.md) are converted to strings using their default serialization. As this decreases performance, it is not recommended to use non-String/FixedString arguments.
 

--- a/src/Functions/concat.cpp
+++ b/src/Functions/concat.cpp
@@ -207,6 +207,8 @@ public:
 
     FunctionBasePtr buildImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr & return_type) const override
     {
+        if (arguments.size() == 1)
+            return FunctionFactory::instance().getImpl("toString", context)->build(arguments);
         if (std::ranges::all_of(arguments, [](const auto & elem) { return isArray(elem.type); }))
             return FunctionFactory::instance().getImpl("arrayConcat", context)->build(arguments);
         if (std::ranges::all_of(arguments, [](const auto & elem) { return isMap(elem.type); }))
@@ -221,10 +223,10 @@ public:
 
     DataTypePtr getReturnTypeImpl(const DataTypes & arguments) const override
     {
-        if (arguments.size() < 2)
+        if (arguments.empty())
             throw Exception(
                 ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH,
-                "Number of arguments for function {} doesn't match: passed {}, should be at least 2.",
+                "Number of arguments for function {} doesn't match: passed {}, should be at least 1.",
                 getName(),
                 arguments.size());
 

--- a/tests/queries/0_stateless/00727_concat.reference
+++ b/tests/queries/0_stateless/00727_concat.reference
@@ -64,4 +64,6 @@ Three arguments test
 42144255
 42144
 42144255
+42
+foo
 Testing the alias

--- a/tests/queries/0_stateless/00727_concat.reference
+++ b/tests/queries/0_stateless/00727_concat.reference
@@ -66,6 +66,8 @@ Three arguments test
 42144255
 -- Single argument tests
 42
+42
+foo
 foo
 \N
 \N

--- a/tests/queries/0_stateless/00727_concat.reference
+++ b/tests/queries/0_stateless/00727_concat.reference
@@ -64,6 +64,9 @@ Three arguments test
 42144255
 42144
 42144255
+-- Single argument tests
 42
 foo
+\N
+\N
 Testing the alias

--- a/tests/queries/0_stateless/00727_concat.sql
+++ b/tests/queries/0_stateless/00727_concat.sql
@@ -85,7 +85,9 @@ SELECT concat(42, 144, 255);
 
 SELECT '-- Single argument tests';
 SELECT concat(42);
+SELECT concat(materialize(42));
 SELECT concat('foo');
+SELECT concat(materialize('foo'));
 SELECT concat(NULL);
 SELECT concat(materialize(NULL :: Nullable(UInt64)));
 

--- a/tests/queries/0_stateless/00727_concat.sql
+++ b/tests/queries/0_stateless/00727_concat.sql
@@ -82,8 +82,12 @@ SELECT concat(materialize(42 :: Int32), materialize(144 :: UInt64));
 SELECT concat(materialize(42 :: Int32), materialize(144 :: UInt64), materialize(255 :: UInt32));
 SELECT concat(42, 144);
 SELECT concat(42, 144, 255);
+
+SELECT '-- Single argument tests';
 SELECT concat(42);
 SELECT concat('foo');
+SELECT concat(NULL);
+SELECT concat(materialize(NULL :: Nullable(UInt64)));
 
 SELECT CONCAT('Testing the ', 'alias');
 

--- a/tests/queries/0_stateless/00727_concat.sql
+++ b/tests/queries/0_stateless/00727_concat.sql
@@ -82,8 +82,9 @@ SELECT concat(materialize(42 :: Int32), materialize(144 :: UInt64));
 SELECT concat(materialize(42 :: Int32), materialize(144 :: UInt64), materialize(255 :: UInt32));
 SELECT concat(42, 144);
 SELECT concat(42, 144, 255);
+SELECT concat(42);
+SELECT concat('foo');
 
 SELECT CONCAT('Testing the ', 'alias');
 
 SELECT concat();  -- { serverError 42 }
-SELECT concat(1); -- { serverError 42 }


### PR DESCRIPTION
Allows to use the `concat` function with a single argument to be more compatible with MySQL implementation (see [the official docs](https://dev.mysql.com/doc/refman/8.0/en/string-functions.html#function_concat)). If only one argument is specified, it will not fail now and call `toString` instead. 

Resolves #56995 

### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Function `concat()` can now be called with a single argument, e.g., `SELECT concat('abc')`. This makes its behavior more consistent with MySQL's concat implementation.