### PR TITLE
Run CI for PRs with missing documentation

### DIFF
--- a/tests/ci/run_check.py
+++ b/tests/ci/run_check.py
@@ -150,7 +150,7 @@ def main():
             DOCS_NAME,
             pr_info,
         )
-        sys.exit(1)
+        sys.exit(0)
 
     if description_error:
         print(


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Seems weird to not run tests until documentation is written. Writing documentation is often the last step, after (or in parallel with) making sure that the PR doesn't break tests.