### PR TITLE
test_s3_engine_heavy_write_check_mem: turn test off

### DIFF
--- a/tests/integration/test_merge_tree_s3/test.py
+++ b/tests/integration/test_merge_tree_s3/test.py
@@ -851,7 +851,9 @@ def test_merge_canceled_by_s3_errors_when_move(cluster, broken_s3, node_name):
 def test_s3_engine_heavy_write_check_mem(
     cluster, broken_s3, node_name, in_flight_memory
 ):
-    pytest.skip("Disabled, will be fixed after https://github.com/ClickHouse/ClickHouse/issues/51152")
+    pytest.skip(
+        "Disabled, will be fixed after https://github.com/ClickHouse/ClickHouse/issues/51152"
+    )
 
     in_flight = in_flight_memory[0]
     memory = in_flight_memory[1]
@@ -874,7 +876,9 @@ def test_s3_engine_heavy_write_check_mem(
     broken_s3.setup_fake_multpartuploads()
     slow_responces = 10
     slow_timeout = 15
-    broken_s3.setup_slow_answers(10 * 1024 * 1024, timeout=slow_timeout, count=slow_responces)
+    broken_s3.setup_slow_answers(
+        10 * 1024 * 1024, timeout=slow_timeout, count=slow_responces
+    )
 
     query_id = f"INSERT_INTO_S3_ENGINE_QUERY_ID_{in_flight}"
     node.query(

--- a/tests/integration/test_merge_tree_s3/test.py
+++ b/tests/integration/test_merge_tree_s3/test.py
@@ -851,6 +851,8 @@ def test_merge_canceled_by_s3_errors_when_move(cluster, broken_s3, node_name):
 def test_s3_engine_heavy_write_check_mem(
     cluster, broken_s3, node_name, in_flight_memory
 ):
+    pytest.skip("Disabled, will be fixed after https://github.com/ClickHouse/ClickHouse/issues/51152")
+
     in_flight = in_flight_memory[0]
     memory = in_flight_memory[1]
 
@@ -870,12 +872,16 @@ def test_s3_engine_heavy_write_check_mem(
     )
 
     broken_s3.setup_fake_multpartuploads()
-    broken_s3.setup_slow_answers(10 * 1024 * 1024, timeout=15, count=10)
+    slow_responces = 10
+    slow_timeout = 15
+    broken_s3.setup_slow_answers(10 * 1024 * 1024, timeout=slow_timeout, count=slow_responces)
 
     query_id = f"INSERT_INTO_S3_ENGINE_QUERY_ID_{in_flight}"
     node.query(
         "INSERT INTO s3_test SELECT number, toString(number) FROM numbers(50000000)"
-        f" SETTINGS max_memory_usage={2*memory}"
+        f" SETTINGS "
+        f" max_memory_usage={2*memory}"
+        # f", max_threads=1" # ParallelFormattingOutputFormat consumption depends on it
         f", s3_max_inflight_parts_for_one_file={in_flight}",
         query_id=query_id,
     )
@@ -892,7 +898,8 @@ def test_s3_engine_heavy_write_check_mem(
     assert int(memory_usage) < 1.2 * memory
     assert int(memory_usage) > 0.8 * memory
 
-    assert int(wait_inflight) > in_flight * 1000 * 1000
+    # The more in_flight value is the less time CH waits.
+    assert int(wait_inflight) / 1000 / 1000 > slow_responces * slow_timeout / in_flight
 
     check_no_objects_after_drop(cluster, node_name=node_name)
 

--- a/tests/integration/test_merge_tree_s3/test.py
+++ b/tests/integration/test_merge_tree_s3/test.py
@@ -885,7 +885,7 @@ def test_s3_engine_heavy_write_check_mem(
         "INSERT INTO s3_test SELECT number, toString(number) FROM numbers(50000000)"
         f" SETTINGS "
         f" max_memory_usage={2*memory}"
-        # f", max_threads=1" # ParallelFormattingOutputFormat consumption depends on it
+        f", max_threads=1" # ParallelFormattingOutputFormat consumption depends on it
         f", s3_max_inflight_parts_for_one_file={in_flight}",
         query_id=query_id,
     )

--- a/tests/integration/test_merge_tree_s3/test.py
+++ b/tests/integration/test_merge_tree_s3/test.py
@@ -885,7 +885,7 @@ def test_s3_engine_heavy_write_check_mem(
         "INSERT INTO s3_test SELECT number, toString(number) FROM numbers(50000000)"
         f" SETTINGS "
         f" max_memory_usage={2*memory}"
-        f", max_threads=1" # ParallelFormattingOutputFormat consumption depends on it
+        f", max_threads=1"  # ParallelFormattingOutputFormat consumption depends on it
         f", s3_max_inflight_parts_for_one_file={in_flight}",
         query_id=query_id,
     )


### PR DESCRIPTION
It is pointless to fix that test now.
There is a significant impact from ParallelFormattingOutputFormat and its settings.
Firstly that task has to be done https://github.com/ClickHouse/ClickHouse/issues/51152

In contrast the similar test for s3 disk test_s3_disk_heavy_write_check_mem is pretty stable. S3 disk does not use ParallelFormattingOutputFormat. 

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Turn off flaky test test_s3_engine_heavy_write_check_mem until the memory consumption is stable.
