### PR TITLE
Add `X-ClickHouse-Exception-Retryable` header to the HTTP response

### DIFF
--- a/src/Common/ErrorCodes.cpp
+++ b/src/Common/ErrorCodes.cpp
@@ -1,6 +1,7 @@
 #include <Common/ErrorCodes.h>
 #include <Common/Exception.h>
 #include <chrono>
+#include <set>
 
 /** Previously, these constants were located in one enum.
   * But in this case there is a problem: when you add a new constant, you need to recompile
@@ -610,6 +611,23 @@ namespace ErrorCodes
     constexpr ErrorCode END = 1002;
     ErrorPairHolder values[END + 1]{};
 
+    std::set retryable_errors = {
+        3,   // UNEXPECTED_END_OF_FILE
+        159, // TIMEOUT_EXCEEDED
+        164, // READONLY
+        202, // TOO_MANY_SIMULTANEOUS_QUERIES
+        203, // NO_FREE_CONNECTION
+        209, // SOCKET_TIMEOUT
+        210, // NETWORK_ERROR
+        242, // TABLE_IS_READ_ONLY
+        252, // TOO_MANY_PARTS
+        285, // TOO_FEW_LIVE_REPLICAS
+        319, // UNKNOWN_STATUS_OF_INSERT
+        425, // SYSTEM_ERROR
+        999, // KEEPER_EXCEPTION
+        1002 // UNKNOWN_EXCEPTION
+    };
+
     struct ErrorCodesNames
     {
         std::string_view names[END + 1];
@@ -641,6 +659,11 @@ namespace ErrorCodes
                 return i;
         }
         throw Exception(NO_SUCH_ERROR_CODE, "No error code with name: '{}'", error_name);
+    }
+
+    bool is_retryable(int code)
+    {
+        return retryable_errors.contains(code);
     }
 
     ErrorCode end() { return END + 1; }

--- a/src/Common/ErrorCodes.h
+++ b/src/Common/ErrorCodes.h
@@ -32,6 +32,7 @@ namespace ErrorCodes
     /// for test hints, and it does not worth to keep another structure for
     /// this.
     ErrorCode getErrorCodeByName(std::string_view error_name);
+    bool is_retryable(int code);
 
     struct Error
     {

--- a/src/Server/HTTP/WriteBufferFromHTTPServerResponse.cpp
+++ b/src/Server/HTTP/WriteBufferFromHTTPServerResponse.cpp
@@ -58,7 +58,12 @@ void WriteBufferFromHTTPServerResponse::writeExceptionCode()
     if (headers_finished_sending || !exception_code)
         return;
     if (response_header_ostr)
-        *response_header_ostr << "X-ClickHouse-Exception-Code: " << exception_code << "\r\n" << std::flush;
+    {
+        *response_header_ostr << "X-ClickHouse-Exception-Code: " << exception_code << "\r\n";
+        if (ErrorCodes::is_retryable(exception_code))
+            *response_header_ostr << "X-ClickHouse-Exception-Retryable: 1" << "\r\n";
+        *response_header_ostr << std::flush;
+    }
 }
 
 void WriteBufferFromHTTPServerResponse::finishSendHeaders()

--- a/src/Server/HTTPHandler.cpp
+++ b/src/Server/HTTPHandler.cpp
@@ -909,7 +909,11 @@ try
     if (response.sent() && used_output.out)
         used_output.out->setExceptionCode(exception_code);
     else
+    {
         response.set("X-ClickHouse-Exception-Code", toString<int>(exception_code));
+        if (ErrorCodes::is_retryable(exception_code))
+            response.set("X-ClickHouse-Exception-Retryable", "1");
+    }
 
     /// FIXME: make sure that no one else is reading from the same stream at the moment.
 

--- a/src/Server/StaticRequestHandler.cpp
+++ b/src/Server/StaticRequestHandler.cpp
@@ -59,6 +59,8 @@ static inline void trySendExceptionToClient(
     try
     {
         response.set("X-ClickHouse-Exception-Code", toString<int>(exception_code));
+        if (ErrorCodes::is_retryable(exception_code))
+            response.set("X-ClickHouse-Exception-Retryable", "1");
 
         /// If HTTP method is POST and Keep-Alive is turned on, we should read the whole request body
         /// to avoid reading part of the current request body in the next request.

--- a/tests/queries/0_stateless/01399_http_request_exception_headers.reference
+++ b/tests/queries/0_stateless/01399_http_request_exception_headers.reference
@@ -1,0 +1,48 @@
+-- Non-retryable exceptions
+1
+0
+1
+0
+-- Retryable exceptions
+-- Code: 3
+1
+1
+-- Code: 159
+1
+1
+-- Code: 164
+1
+1
+-- Code: 202
+1
+1
+-- Code: 203
+1
+1
+-- Code: 209
+1
+1
+-- Code: 210
+1
+1
+-- Code: 242
+1
+1
+-- Code: 252
+1
+1
+-- Code: 285
+1
+1
+-- Code: 319
+1
+1
+-- Code: 425
+1
+1
+-- Code: 999
+1
+1
+-- Code: 1002
+1
+1

--- a/tests/queries/0_stateless/01399_http_request_exception_headers.sh
+++ b/tests/queries/0_stateless/01399_http_request_exception_headers.sh
@@ -18,6 +18,6 @@ for code in "${RETRYABLE_EXCEPTION_CODES[@]}"
 do
   echo "-- Code: $code"
   RES=$(${CLICKHOUSE_CURL} -vs "${CLICKHOUSE_URL}" -d "select throwIf(1, 'test', toInt16($code)) settings allow_custom_error_code_in_throwif=1" 2>&1)
-  echo $RES | grep -c "X-ClickHouse-Exception-Code: $code"
+  echo $RES | grep -c "< X-ClickHouse-Exception-Code: $code"
   echo $RES | grep -c '< X-ClickHouse-Exception-Retryable: 1'
 done

--- a/tests/queries/0_stateless/01399_http_request_exception_headers.sh
+++ b/tests/queries/0_stateless/01399_http_request_exception_headers.sh
@@ -5,10 +5,10 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../shell_config.sh
 
 echo "-- Non-retryable exceptions"
-RES=$(curl -vs http://localhost:8123 -d 'SELECT x' 2>&1)
+RES=$(${CLICKHOUSE_CURL} -vs "${CLICKHOUSE_URL}" -d 'SELECT x' 2>&1)
 echo $RES | grep -c '< X-ClickHouse-Exception-Code: 47'
 echo $RES | grep -c '< X-ClickHouse-Exception-Retryable' || true
-RES=$(curl -vs http://localhost:8123 -d 'SELECT someUnknownFunction(42)' 2>&1)
+RES=$(${CLICKHOUSE_CURL} -vs "${CLICKHOUSE_URL}" -d 'SELECT someUnknownFunction(42)' 2>&1)
 echo $RES | grep -c '< X-ClickHouse-Exception-Code: 46'
 echo $RES | grep -c '< X-ClickHouse-Exception-Retryable' || true
 
@@ -17,7 +17,7 @@ declare -a RETRYABLE_EXCEPTION_CODES=(3 159 164 202 203 209 210 242 252 285 319 
 for code in "${RETRYABLE_EXCEPTION_CODES[@]}"
 do
   echo "-- Code: $code"
-  RES=$(curl -vs http://localhost:8123 -d "select throwIf(1, 'test', toInt16($code)) settings allow_custom_error_code_in_throwif=1" 2>&1)
+  RES=$(${CLICKHOUSE_CURL} -vs "${CLICKHOUSE_URL}" -d "select throwIf(1, 'test', toInt16($code)) settings allow_custom_error_code_in_throwif=1" 2>&1)
   echo $RES | grep -c "X-ClickHouse-Exception-Code: $code"
   echo $RES | grep -c '< X-ClickHouse-Exception-Retryable: 1'
 done

--- a/tests/queries/0_stateless/01399_http_request_exception_headers.sh
+++ b/tests/queries/0_stateless/01399_http_request_exception_headers.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+echo "-- Non-retryable exceptions"
+RES=$(curl -vs http://localhost:8123 -d 'SELECT x' 2>&1)
+echo $RES | grep -c '< X-ClickHouse-Exception-Code: 47'
+echo $RES | grep -c '< X-ClickHouse-Exception-Retryable' || true
+RES=$(curl -vs http://localhost:8123 -d 'SELECT someUnknownFunction(42)' 2>&1)
+echo $RES | grep -c '< X-ClickHouse-Exception-Code: 46'
+echo $RES | grep -c '< X-ClickHouse-Exception-Retryable' || true
+
+echo "-- Retryable exceptions"
+declare -a RETRYABLE_EXCEPTION_CODES=(3 159 164 202 203 209 210 242 252 285 319 425 999 1002)
+for code in "${RETRYABLE_EXCEPTION_CODES[@]}"
+do
+  echo "-- Code: $code"
+  RES=$(curl -vs http://localhost:8123 -d "select throwIf(1, 'test', toInt16($code)) settings allow_custom_error_code_in_throwif=1" 2>&1)
+  echo $RES | grep -c "X-ClickHouse-Exception-Code: $code"
+  echo $RES | grep -c '< X-ClickHouse-Exception-Retryable: 1'
+done


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/issues/50695
HTTP only for now.
When an error occurs, and this particular error is known to be retryable, we set `X-ClickHouse-Exception-Retryable: 1` to the response headers. If an error can not be retried, this header _is not set_. 


### Changelog category (leave one):
- New Feature


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

