### PR TITLE
Optimize query uniqueness check in ProcessList

### DIFF
--- a/src/Interpreters/ProcessList.cpp
+++ b/src/Interpreters/ProcessList.cpp
@@ -183,14 +183,11 @@ ProcessList::insert(const String & query_, const IAST * ast, ContextMutablePtr q
         }
 
         /// Check other users running query with our query_id
-        for (const auto & user_process_list : user_to_queries)
+        if (auto query_user = queries_to_user.find(client_info.current_query_id); query_user != queries_to_user.end() && query_user->second != client_info.current_user)
         {
-            if (user_process_list.first == client_info.current_user)
-                continue;
-            if (auto running_query = user_process_list.second.queries.find(client_info.current_query_id); running_query != user_process_list.second.queries.end())
-                throw Exception(ErrorCodes::QUERY_WITH_SAME_ID_IS_ALREADY_RUNNING,
-                                "Query with id = {} is already running by user {}",
-                                client_info.current_query_id, user_process_list.first);
+            throw Exception(ErrorCodes::QUERY_WITH_SAME_ID_IS_ALREADY_RUNNING,
+                            "Query with id = {} is already running by user {}",
+                            client_info.current_query_id, query_user->second);
         }
 
         auto user_process_list_it = user_to_queries.find(client_info.current_user);
@@ -259,6 +256,7 @@ ProcessList::insert(const String & query_, const IAST * ast, ContextMutablePtr q
         (*process_it)->setUserProcessList(&user_process_list);
 
         user_process_list.queries.emplace(client_info.current_query_id, res->getQueryStatus());
+        queries_to_user.emplace(client_info.current_query_id, client_info.current_user);
 
         /// Track memory usage for all simultaneously running queries from single user.
         user_process_list.user_memory_tracker.setOrRaiseHardLimit(settings.max_memory_usage_for_user);
@@ -312,6 +310,9 @@ ProcessListEntry::~ProcessListEntry()
             found = true;
         }
     }
+
+    if (auto query_user = parent.queries_to_user.find(query_id); query_user != parent.queries_to_user.end())
+        parent.queries_to_user.erase(query_user);
 
     /// Wait for the query if it is in the cancellation right now.
     parent.cancelled_cv.wait(lock.lock, [&]() { return process_list_element_ptr->is_cancelling == false; });

--- a/src/Interpreters/ProcessList.cpp
+++ b/src/Interpreters/ProcessList.cpp
@@ -311,11 +311,11 @@ ProcessListEntry::~ProcessListEntry()
         }
     }
 
-    if (auto query_user = parent.queries_to_user.find(query_id); query_user != parent.queries_to_user.end())
-        parent.queries_to_user.erase(query_user);
-
     /// Wait for the query if it is in the cancellation right now.
     parent.cancelled_cv.wait(lock.lock, [&]() { return process_list_element_ptr->is_cancelling == false; });
+
+    if (auto query_user = parent.queries_to_user.find(query_id); query_user != parent.queries_to_user.end())
+        parent.queries_to_user.erase(query_user);
 
     /// This removes the memory_tracker of one request.
     parent.processes.erase(it);

--- a/src/Interpreters/ProcessList.h
+++ b/src/Interpreters/ProcessList.h
@@ -345,6 +345,8 @@ public:
 
     /// User -> queries
     using UserToQueries = std::unordered_map<String, ProcessListForUser>;
+    /// query_id -> User
+    using QueriesToUser = std::unordered_map<String, String>;
 
     using QueryKindAmounts = std::unordered_map<IAST::QueryKind, QueryAmount>;
 
@@ -365,6 +367,9 @@ protected:
 
     /// Stores per-user info: queries, statistics and limits
     UserToQueries user_to_queries;
+
+    /// Stores query IDs and associated users, used for query ID uniqueness check
+    QueriesToUser queries_to_user;
 
     /// Stores info about queries grouped by their priority
     QueryPriorities priorities;


### PR DESCRIPTION
Hi!
In our ClickHouse use case, we have a lot of users (currently ~couple thousands per CH instance), all of whom are expected to run queries. 
Recently we tried to push this even further (~couple tens of thousands users per CH instance), which resulted in a significant degradation in our QPS throughput. We were able to achieve only between 100 and 200 QPS, with each query taking up to 30s (expected run time for these queries is under 100ms).

With tracing logs enabled, we were able to figure that most queries were spending their time on this lock:
https://github.com/ClickHouse/ClickHouse/blob/c2f4dc0f14f55cf9785da86cb2bf07c556e22d1e/src/Interpreters/ProcessList.cpp#L82C27-L82C27
The reason was that the inserts into the ProcessList were taking too long, specifically in this for loop:
https://github.com/ClickHouse/ClickHouse/blob/c2f4dc0f14f55cf9785da86cb2bf07c556e22d1e/src/Interpreters/ProcessList.cpp#L185-L194
The for loop iterates over every user the server ever saw, which explains why most queries spend so much time on this lock (we saw times up to 10ms spend in the loop, which would explain the ~100 QPS limit we saw).
This PR, replaces the for loop with a single lookup into a `std::unordered_map`.

We tested this patch in our environment and achieved over 2000 QPS on the same workload as before (could definitely go higher).


### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Improve performance of executing queries for use cases with many users

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
