### PR TITLE
Allow HashedDictionary/FunctionsConversion as large TU

### DIFF
--- a/utils/check-style/check-large-objects.sh
+++ b/utils/check-style/check-large-objects.sh
@@ -2,8 +2,21 @@
 
 # Check that there are no new translation units compiled to an object file larger than a certain size.
 
+TU_EXCLUDES=(
+    CastOverloadResolver
+    AggregateFunctionMax
+    AggregateFunctionMin
+    AggregateFunctionUniq
+    FunctionsConversion
+
+    RangeHashedDictionary
+    HashedDictionary
+
+    Aggregator
+)
+
 if find $1 -name '*.o' | xargs wc -c | grep -v total | sort -rn | awk '{ if ($1 > 50000000) print }' \
-    | grep -v -P 'CastOverloadResolver|AggregateFunctionMax|AggregateFunctionMin|RangeHashedDictionary|Aggregator|AggregateFunctionUniq'
+    | grep -v -f <(printf "%s\n" "${TU_EXCLUDES[@]}")
 then
     echo "^ It's not allowed to have so large translation units."
     exit 1


### PR DESCRIPTION
In case of -DOMIT_HEAVY_DEBUG_SYMBOLS=OFF they are large.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Follow-up for: #56559 (cc @alexey-milovidov )