### PR TITLE
Fix something in ReplicatedMergeTree

### DIFF
--- a/src/Storages/MergeTree/IMergeTreeDataPart.h
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.h
@@ -246,6 +246,8 @@ public:
         REMOVE_BLOBS,
         /// is set when Clickhouse is sure that the blobs belong to other replica and current replica has not locked them on s3 yet
         PRESERVE_BLOBS,
+        /// remove blobs even if the part is not temporary
+        REMOVE_BLOBS_OF_NOT_TEMPORARY,
     };
     BlobsRemovalPolicyForTemporaryParts remove_tmp_policy = BlobsRemovalPolicyForTemporaryParts::ASK_KEEPER;
 

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -3911,7 +3911,7 @@ MergeTreeData::PartsToRemoveFromZooKeeper MergeTreeData::removePartsInRangeFromW
         new_data_part->remove_time.store(0, std::memory_order_relaxed);
         /// Such parts are always local, they don't participate in replication, they don't have shared blobs.
         /// So we don't have locks for shared data in zk for them, and can just remove blobs (this avoids leaving garbage in S3)
-        new_data_part->remove_tmp_policy = IMergeTreeDataPart::BlobsRemovalPolicyForTemporaryParts::REMOVE_BLOBS;
+        new_data_part->remove_tmp_policy = IMergeTreeDataPart::BlobsRemovalPolicyForTemporaryParts::REMOVE_BLOBS_OF_NOT_TEMPORARY;
     }
 
     /// Since we can return parts in Deleting state, we have to use a wrapper that restricts access to such parts.

--- a/src/Storages/MergeTree/MergeTreeData.h
+++ b/src/Storages/MergeTree/MergeTreeData.h
@@ -1464,7 +1464,7 @@ protected:
 
     /// This has to be "true" by default, because in case of empty table or absence of Outdated parts
     /// it is automatically finished.
-    bool outdated_data_parts_loading_finished TSA_GUARDED_BY(outdated_data_parts_mutex) = true;
+    std::atomic_bool outdated_data_parts_loading_finished = true;
 
     void loadOutdatedDataParts(bool is_async);
     void startOutdatedDataPartsLoadingTask();

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -9240,7 +9240,7 @@ StorageReplicatedMergeTree::unlockSharedData(const IMergeTreeDataPart & part, co
         }
     }
 
-    if (part.rows_count == 0 && part.remove_tmp_policy == IMergeTreeDataPart::BlobsRemovalPolicyForTemporaryParts::REMOVE_BLOBS)
+    if (part.rows_count == 0 && part.remove_tmp_policy == IMergeTreeDataPart::BlobsRemovalPolicyForTemporaryParts::REMOVE_BLOBS_OF_NOT_TEMPORARY)
     {
         /// It's a non-replicated empty part that was created to avoid unexpected parts after DROP_RANGE
         LOG_INFO(log, "Looks like {} is a non-replicated empty part that was created to avoid unexpected parts after DROP_RANGE, "

--- a/tests/queries/0_stateless/02486_truncate_and_unexpected_parts.reference
+++ b/tests/queries/0_stateless/02486_truncate_and_unexpected_parts.reference
@@ -1,4 +1,15 @@
 1	rmt
-1	rmt1
 2	rmt
+1	rmt1
 2	rmt1
+0
+1	rmt
+2	rmt
+1	rmt1
+2	rmt1
+1	rmt2
+1	rmt2
+3	rmt2
+5	rmt2
+7	rmt2
+9	rmt2

--- a/tests/queries/0_stateless/02486_truncate_and_unexpected_parts.sql
+++ b/tests/queries/0_stateless/02486_truncate_and_unexpected_parts.sql
@@ -24,4 +24,36 @@ insert into rmt1 values (2);
 system sync replica rmt;
 system sync replica rmt1;
 
-select *, _table from merge(currentDatabase(), '') order by (*,), _table;
+select *, _table from merge(currentDatabase(), '') order by  _table, (*,);
+select 0;
+
+drop table rmt sync;
+drop table rmt1 sync;
+create table rmt (n int) engine=ReplicatedMergeTree('/test/02468/{database}', '1') order by tuple() partition by n % 2 settings replicated_max_ratio_of_wrong_parts=0, max_suspicious_broken_parts=0, max_suspicious_broken_parts_bytes=0;
+create table rmt1 (n int) engine=ReplicatedMergeTree('/test/02468/{database}', '2') order by tuple() partition by n % 2 settings replicated_max_ratio_of_wrong_parts=0, max_suspicious_broken_parts=0, max_suspicious_broken_parts_bytes=0;
+insert into rmt values (1);
+insert into rmt1 values (2);
+
+create table rmt2 (n int) engine=ReplicatedMergeTree('/test/02468/{database}2', '1') order by tuple() partition by n % 2 settings replicated_max_ratio_of_wrong_parts=0, max_suspicious_broken_parts=0, max_suspicious_broken_parts_bytes=0;
+
+system stop cleanup rmt;
+system stop merges rmt1;
+insert into rmt select * from numbers(10) settings max_block_size=1;
+system sync replica rmt1 lightweight;
+
+alter table rmt replace partition id '0' from rmt2;
+alter table rmt1 move partition id '1' to table rmt2;
+
+detach table rmt sync;
+detach table rmt1 sync;
+
+attach table rmt;
+attach table rmt1;
+
+insert into rmt values (1);
+insert into rmt1 values (2);
+system sync replica rmt;
+system sync replica rmt1;
+system sync replica rmt2;
+
+select *, _table from merge(currentDatabase(), '') order by _table, (*,);

--- a/tests/queries/0_stateless/02486_truncate_and_unexpected_parts.sql
+++ b/tests/queries/0_stateless/02486_truncate_and_unexpected_parts.sql
@@ -27,13 +27,6 @@ system sync replica rmt1;
 select *, _table from merge(currentDatabase(), '') order by  _table, (*,);
 select 0;
 
-drop table rmt sync;
-drop table rmt1 sync;
-create table rmt (n int) engine=ReplicatedMergeTree('/test/02468/{database}', '1') order by tuple() partition by n % 2 settings replicated_max_ratio_of_wrong_parts=0, max_suspicious_broken_parts=0, max_suspicious_broken_parts_bytes=0;
-create table rmt1 (n int) engine=ReplicatedMergeTree('/test/02468/{database}', '2') order by tuple() partition by n % 2 settings replicated_max_ratio_of_wrong_parts=0, max_suspicious_broken_parts=0, max_suspicious_broken_parts_bytes=0;
-insert into rmt values (1);
-insert into rmt1 values (2);
-
 create table rmt2 (n int) engine=ReplicatedMergeTree('/test/02468/{database}2', '1') order by tuple() partition by n % 2 settings replicated_max_ratio_of_wrong_parts=0, max_suspicious_broken_parts=0, max_suspicious_broken_parts_bytes=0;
 
 system stop cleanup rmt;


### PR DESCRIPTION

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

 - Fixed some trash around REPLACE/MOVE PARTITION (fix wrong block numbers; create empty covering part on initiator too to avoid unexpected parts on restart). Follow-up to https://github.com/ClickHouse/ClickHouse/pull/56282
 - More correct (but less optimal) handling of unexpected Outdated parts, follow-up to https://github.com/ClickHouse/ClickHouse/pull/56693 
 - Fixed "The specified key doesn't exist" for empty parts. Was broken in https://github.com/ClickHouse/ClickHouse/pull/56282. Caught by `00993_system_parts_race_condition_drop_zookeeper` ([example](https://s3.amazonaws.com/clickhouse-test-reports/56552/ff11d69be4ffcba3970b0c3711aceb7e40baba09/stateless_tests__release__s3_storage__[2_2].html))