### PR TITLE
Fix test test_replicated_merge_tree_encryption_codec/test.py::test_different_keys

### DIFF
--- a/tests/integration/test_replicated_merge_tree_encryption_codec/test.py
+++ b/tests/integration/test_replicated_merge_tree_encryption_codec/test.py
@@ -96,6 +96,9 @@ def test_different_keys():
     node2.query("INSERT INTO tbl VALUES (2, 'str2')")
     node1.query("SYSTEM SYNC REPLICA ON CLUSTER 'cluster' tbl")
 
+    # After "SYSTEM SYNC REPLICA" we expect node1 and node2 here both having a part for (1, 'str1') encrypted with "key_a",
+    # and a part for (2, 'str2') encrypted with "key_b".
+    # So the command "SELECT * from tbl" must fail on both nodes because each node has only one encryption key.
     assert "BAD_DECRYPT" in node1.query_and_get_error("SELECT * FROM tbl")
     assert "BAD_DECRYPT" in node2.query_and_get_error("SELECT * FROM tbl")
 

--- a/tests/integration/test_replicated_merge_tree_encryption_codec/test.py
+++ b/tests/integration/test_replicated_merge_tree_encryption_codec/test.py
@@ -91,7 +91,9 @@ def test_different_keys():
     copy_keys(node2, "key_b")
     create_table()
 
-    insert_data()
+    # Insert two blocks without duplicated blocks to force each replica to actually fetch parts from another replica.
+    node1.query("INSERT INTO tbl VALUES (1, 'str1')")
+    node2.query("INSERT INTO tbl VALUES (2, 'str2')")
     node1.query("SYSTEM SYNC REPLICA ON CLUSTER 'cluster' tbl")
 
     assert "BAD_DECRYPT" in node1.query_and_get_error("SELECT * FROM tbl")


### PR DESCRIPTION
### Changelog category:
- Not for changelog

Fix test `test_replicated_merge_tree_encryption_codec/test.py::test_different_keys` (see [failure](https://s3.amazonaws.com/clickhouse-test-reports/57074/2ba2f480513a5b4561468c3d95bcd0c634936b44/integration_tests__release__[2_4].html))
