### PR TITLE
Remove partial results from build matrix for stress tests

### DIFF
--- a/tests/ci/stress.py
+++ b/tests/ci/stress.py
@@ -60,12 +60,6 @@ def get_options(i: int, upgrade_check: bool) -> str:
         client_options.append("throw_on_unsupported_query_inside_transaction=0")
 
     if random.random() < 0.1:
-        client_options.append("allow_experimental_partial_result=1")
-        client_options.append(
-            f"partial_result_update_duration_ms={random.randint(10, 1000)}"
-        )
-
-    if random.random() < 0.1:
         client_options.append("optimize_trivial_approximate_count_query=1")
 
     if client_options:


### PR DESCRIPTION
The feature had been reverted in #55893 (cc @alexey-milovidov )

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)