### PR TITLE
[RFC] Set log_comment to the file name while processing files in client

### DIFF
--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -2566,6 +2566,14 @@ bool ClientBase::processMultiQueryFromFile(const String & file_name)
     ReadBufferFromFile in(file_name);
     readStringUntilEOF(queries_from_file, in);
 
+    if (!global_context->getSettings().log_comment.changed)
+    {
+        Settings settings = global_context->getSettings();
+        /// NOTE: cannot use even weakly_canonical() since it fails for /dev/stdin due to resolving of "pipe:[X]"
+        settings.log_comment = fs::absolute(fs::path(file_name));
+        global_context->setSettings(settings);
+    }
+
     return executeMultiQuery(queries_from_file);
 }
 

--- a/tests/queries/0_stateless/02930_client_file_log_comment.reference
+++ b/tests/queries/0_stateless/02930_client_file_log_comment.reference
@@ -1,0 +1,4 @@
+42
+select 42\n	/dev/stdin
+4242
+select 4242\n	foo

--- a/tests/queries/0_stateless/02930_client_file_log_comment.sh
+++ b/tests/queries/0_stateless/02930_client_file_log_comment.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# reset --log_comment
+CLICKHOUSE_LOG_COMMENT=
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+$CLICKHOUSE_CLIENT --queries-file /dev/stdin <<<'select 42'
+$CLICKHOUSE_CLIENT -nm -q "
+    system flush logs;
+    select query, log_comment from system.query_log where current_database = '$CLICKHOUSE_DATABASE' and event_date >= yesterday() and query = 'select 42\n' and type != 'QueryStart';
+"
+
+$CLICKHOUSE_CLIENT --log_comment foo --queries-file /dev/stdin <<<'select 4242'
+$CLICKHOUSE_CLIENT -nm -q "
+    system flush logs;
+    select query, log_comment from system.query_log where current_database = '$CLICKHOUSE_DATABASE' and event_date >= yesterday() and query = 'select 4242\n' and type != 'QueryStart';
+"


### PR DESCRIPTION
This will be useful for fuzzer, to know which file had been processed to trigger the crash, since right now you need to find unique parts of the query that had not been added by fuzzer to reproduce.

But I guess this will be useful not only for fuzzing, but for general introspection as well.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)