### PR TITLE
Do not demangle stack frames from __functional

### DIFF
--- a/src/Common/StackTrace.cpp
+++ b/src/Common/StackTrace.cpp
@@ -291,9 +291,20 @@ void StackTrace::tryCapture()
 constexpr std::pair<std::string_view, std::string_view> replacements[]
     = {{"::__1", ""}, {"std::basic_string<char, std::char_traits<char>, std::allocator<char>>", "String"}};
 
-String collapseNames(String && haystack)
+// Demangle @c symbol_name if it's not from __functional header (as such functions don't provide any useful
+// information but pollute stack traces).
+// Replace parts from @c replacements with shorter aliases
+String demangleAndCollapseNames(std::string_view file, const char * const symbol_name)
 {
-    // TODO: surely there is a written version already for better in place search&replace
+    std::string_view file_copy = file;
+    if (auto trim_pos = file.find_last_of('/'); trim_pos != file.npos)
+        file_copy.remove_suffix(file.size() - trim_pos);
+    if (file_copy.ends_with("functional"))
+        return "?";
+
+    String haystack = demangle(symbol_name);
+
+    // TODO myrrc surely there is a written version already for better in place search&replace
     for (auto [needle, to] : replacements)
     {
         size_t pos = 0;
@@ -354,6 +365,7 @@ toStringEveryLineImpl([[maybe_unused]] bool fatal, const StackTraceRefTriple & s
         DB::WriteBufferFromOwnString out;
         out << i << ". ";
 
+        String file;
         if (std::error_code ec; object && std::filesystem::exists(object->name, ec) && !ec)
         {
             auto dwarf_it = dwarfs.try_emplace(object->name, object->elf).first;
@@ -361,11 +373,14 @@ toStringEveryLineImpl([[maybe_unused]] bool fatal, const StackTraceRefTriple & s
             DB::Dwarf::LocationInfo location;
 
             if (dwarf_it->second.findAddress(uintptr_t(physical_addr), location, mode, inline_frames))
-                out << location.file.toString() << ":" << location.line << ": ";
+            {
+                file = location.file.toString();
+                out << file << ":" << location.line << ": ";
+            }
         }
 
         if (const auto * const symbol = symbol_index.findSymbol(virtual_addr))
-            out << collapseNames(demangle(symbol->name));
+            out << demangleAndCollapseNames(file, symbol->name);
         else
             out << "?";
 
@@ -380,13 +395,14 @@ toStringEveryLineImpl([[maybe_unused]] bool fatal, const StackTraceRefTriple & s
         for (size_t j = 0; j < inline_frames.size(); ++j)
         {
             const auto & frame = inline_frames[j];
+            const String file_for_inline_frame = frame.location.file.toString();
             callback(fmt::format(
                 "{}.{}. inlined from {}:{}: {}",
                 i,
                 j + 1,
-                frame.location.file.toString(),
+                file_for_inline_frame,
                 frame.location.line,
-                collapseNames(demangle(frame.name))));
+                demangleAndCollapseNames(file_for_inline_frame, frame.name)));
         }
 
         callback(out.str());


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Do not demangle and symbolize stack frames from __functional c++ header.