### PR TITLE
Fix test_distributed_storage_configuration flakiness

### DIFF
--- a/tests/integration/test_distributed_storage_configuration/configs/config.d/overrides.xml
+++ b/tests/integration/test_distributed_storage_configuration/configs/config.d/overrides.xml
@@ -27,14 +27,14 @@
         </disks>
 
         <policies>
-            <default>
+            <jbod_policy>
                 <volumes>
                     <main>
                         <disk>disk1</disk>
                         <disk>disk2</disk>
                     </main>
                 </volumes>
-            </default>
+            </jbod_policy>
         </policies>
     </storage_configuration>
 </clickhouse>

--- a/tests/integration/test_distributed_storage_configuration/test.py
+++ b/tests/integration/test_distributed_storage_configuration/test.py
@@ -53,7 +53,7 @@ def test_insert(start_cluster):
         test,
         foo,
         key%2,
-        'default'
+        'jbod_policy'
     )
     """
     )


### PR DESCRIPTION
It fails [1] due to extra reservation on disk2 for some system.*_log tables, sure we can turn them off, but better to fix it explicitly with a separate policy.

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/0/98cddf5312722e403dcea429639ac13dc6cada33/integration_tests__tsan__[2_6].html

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Cc: @alexey-milovidov 