### PR TITLE
Expose the number of errors occurred on server from the Prometheus endpoint.

### DIFF
--- a/docs/en/operations/server-configuration-parameters/settings.md
+++ b/docs/en/operations/server-configuration-parameters/settings.md
@@ -1837,10 +1837,10 @@ Settings:
 
 - `endpoint` – HTTP endpoint for scraping metrics by prometheus server. Start from ‘/’.
 - `port` – Port for `endpoint`.
-- `metrics` – Flag that sets to expose metrics from the [system.metrics](../../operations/system-tables/metrics.md#system_tables-metrics) table.
-- `events` – Flag that sets to expose metrics from the [system.events](../../operations/system-tables/events.md#system_tables-events) table.
-- `asynchronous_metrics` – Flag that sets to expose current metrics values from the [system.asynchronous_metrics](../../operations/system-tables/asynchronous_metrics.md#system_tables-asynchronous_metrics) table.
-- `errors` - Flag that sets to expose the number of errors by error codes occurred since the last server restart. This information could be obtained from the [system.errors](../../operations/system-tables/asynchronous_metrics.md#system_tables-errors) as well.
+- `metrics` – Expose metrics from the [system.metrics](../../operations/system-tables/metrics.md#system_tables-metrics) table.
+- `events` – Expose metrics from the [system.events](../../operations/system-tables/events.md#system_tables-events) table.
+- `asynchronous_metrics` – Expose current metrics values from the [system.asynchronous_metrics](../../operations/system-tables/asynchronous_metrics.md#system_tables-asynchronous_metrics) table.
+- `errors` - Expose the number of errors by error codes occurred since the last server restart. This information could be obtained from the [system.errors](../../operations/system-tables/asynchronous_metrics.md#system_tables-errors) as well.
 
 **Example**
 

--- a/docs/en/operations/server-configuration-parameters/settings.md
+++ b/docs/en/operations/server-configuration-parameters/settings.md
@@ -1840,6 +1840,7 @@ Settings:
 - `metrics` – Flag that sets to expose metrics from the [system.metrics](../../operations/system-tables/metrics.md#system_tables-metrics) table.
 - `events` – Flag that sets to expose metrics from the [system.events](../../operations/system-tables/events.md#system_tables-events) table.
 - `asynchronous_metrics` – Flag that sets to expose current metrics values from the [system.asynchronous_metrics](../../operations/system-tables/asynchronous_metrics.md#system_tables-asynchronous_metrics) table.
+- `errors` - Flag that sets to expose the number of errors by error codes occurred since the last server restart. This information could be obtained from the [system.errors](../../operations/system-tables/asynchronous_metrics.md#system_tables-errors) as well.
 
 **Example**
 
@@ -1855,6 +1856,7 @@ Settings:
         <metrics>true</metrics>
         <events>true</events>
         <asynchronous_metrics>true</asynchronous_metrics>
+        <errors>true</errors>
     </prometheus>
     <!-- highlight-end -->
 </clickhouse>

--- a/docs/ru/operations/server-configuration-parameters/settings.md
+++ b/docs/ru/operations/server-configuration-parameters/settings.md
@@ -1216,6 +1216,7 @@ ClickHouse использует потоки из глобального пул�
 -   `metrics` – флаг для экспорта текущих значений метрик из таблицы [system.metrics](../system-tables/metrics.md#system_tables-metrics).
 -   `events` – флаг для экспорта текущих значений метрик из таблицы [system.events](../system-tables/events.md#system_tables-events).
 -   `asynchronous_metrics` – флаг для экспорта текущих значений значения метрик из таблицы [system.asynchronous_metrics](../system-tables/asynchronous_metrics.md#system_tables-asynchronous_metrics).
+-   `errors` - флаг для экспорта количества ошибок (по кодам) случившихся с момента последнего рестарта сервера. Эта информация может быть получена из таблицы [system.errors](../system-tables/asynchronous_metrics.md#system_tables-errors)
 
 **Пример**
 
@@ -1226,6 +1227,7 @@ ClickHouse использует потоки из глобального пул�
         <metrics>true</metrics>
         <events>true</events>
         <asynchronous_metrics>true</asynchronous_metrics>
+        <errors>true</errors>
     </prometheus>
 ```
 

--- a/src/Server/PrometheusMetricsWriter.cpp
+++ b/src/Server/PrometheusMetricsWriter.cpp
@@ -50,6 +50,7 @@ PrometheusMetricsWriter::PrometheusMetricsWriter(
     , send_events(config.getBool(config_name + ".events", true))
     , send_metrics(config.getBool(config_name + ".metrics", true))
     , send_asynchronous_metrics(config.getBool(config_name + ".asynchronous_metrics", true))
+    , send_errors(config.getBool(config_name + ".errors", true))
 {
 }
 
@@ -112,12 +113,32 @@ void PrometheusMetricsWriter::write(WriteBuffer & wb) const
             std::string metric_doc{value.documentation};
             convertHelpToSingleLine(metric_doc);
 
-            // TODO: add HELP section? asynchronous_metrics contains only key and value
             writeOutLine(wb, "# HELP", key, metric_doc);
             writeOutLine(wb, "# TYPE", key, "gauge");
             writeOutLine(wb, key, value.value);
         }
     }
+
+    if (send_errors)
+    {
+        for (size_t i = 0, end = ErrorCodes::end(); i < end; ++i)
+        {
+            const auto & error = ErrorCodes::values[i].get();
+            std::string_view name = ErrorCodes::getName(static_cast<ErrorCodes::ErrorCode>(i));
+
+            if (name.empty())
+                continue;
+
+            std::string key{error_metrics_prefix + toString(name)};
+            std::string help = fmt::format("The number of {} errors since last server restart", name);
+
+            writeOutLine(wb, "# HELP", key, help);
+            writeOutLine(wb, "# TYPE", key, "counter");
+            /// We are interested in errors which are happened only on this server.
+            writeOutLine(wb, key, error.local.count);
+        }
+    }
+
 }
 
 }

--- a/src/Server/PrometheusMetricsWriter.h
+++ b/src/Server/PrometheusMetricsWriter.h
@@ -27,10 +27,12 @@ private:
     const bool send_events;
     const bool send_metrics;
     const bool send_asynchronous_metrics;
+    const bool send_errors;
 
     static inline constexpr auto profile_events_prefix = "ClickHouseProfileEvents_";
     static inline constexpr auto current_metrics_prefix = "ClickHouseMetrics_";
     static inline constexpr auto asynchronous_metrics_prefix = "ClickHouseAsyncMetrics_";
+    static inline constexpr auto error_metrics_prefix = "ClickHouseErrorMetric_";
 };
 
 }


### PR DESCRIPTION
### Changelog category (leave one):
- New Feature


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Expose the number of errors occurred on a server since last restart from the Prometheus endpoint. 
