### PR TITLE
Change cursor style for overwrite mode (INS) to blinking in client

### DIFF
--- a/src/Client/ReplxxLineReader.cpp
+++ b/src/Client/ReplxxLineReader.cpp
@@ -447,6 +447,17 @@ ReplxxLineReader::ReplxxLineReader(
         uint32_t reverse_search = Replxx::KEY::control('R');
         return rx.invoke(Replxx::ACTION::HISTORY_INCREMENTAL_SEARCH, reverse_search);
     });
+
+    /// Change cursor style for overwrite mode to blinking (see console_codes(5))
+    rx.bind_key(Replxx::KEY::INSERT, [this](char32_t)
+    {
+        overwrite_mode = !overwrite_mode;
+        if (overwrite_mode)
+            rx.print("%s", "\033[5 q");
+        else
+            rx.print("%s", "\033[0 q");
+        return rx.invoke(Replxx::ACTION::TOGGLE_OVERWRITE_MODE, 0);
+    });
 }
 
 ReplxxLineReader::~ReplxxLineReader()

--- a/src/Client/ReplxxLineReader.h
+++ b/src/Client/ReplxxLineReader.h
@@ -41,6 +41,7 @@ private:
     bool bracketed_paste_enabled = false;
 
     std::string editor;
+    bool overwrite_mode = false;
 };
 
 }


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Change cursor style for overwrite mode (INS) to blinking in client

Fixes: https://github.com/ClickHouse/ClickHouse/issues/50297 (cc @alexey-milovidov )