### PR TITLE
Support multiple lines on dashboard charts

### DIFF
--- a/programs/server/dashboard.html
+++ b/programs/server/dashboard.html
@@ -108,7 +108,7 @@
             filter: blur(1px);
         }
 
-        .chart div { position: absolute; }
+        .chart > div { position: absolute; }
 
         .inputs {
             height: auto;
@@ -214,8 +214,6 @@
             background-color: var(--input-background);
             color: var(--text-color);
         }
-
-        .u-legend th { display: none; }
 
         .themes {
             float: right;
@@ -519,9 +517,53 @@ let queries = [];
 /// Query parameters with predefined default values.
 /// All other parameters will be automatically found in the queries.
 let params = {
-    "rounding": "60",
-    "seconds": "86400"
+    'rounding': '60',
+    'seconds': '86400'
 };
+
+/// Palette generation for charts
+function generatePalette(baseColor, numColors) {
+    const baseHSL = hexToHsl(baseColor);
+    const hueStep = 360 / numColors;
+    const palette = [];
+    for (let i = 0; i < numColors; i++) {
+        const hue = Math.round((baseHSL.h + i * hueStep) % 360);
+        const color = `hsl(${hue}, ${baseHSL.s}%, ${baseHSL.l}%)`;
+        palette.push(color);
+    }
+    return palette;
+}
+
+/// Helper function to convert hex color to HSL
+function hexToHsl(hex) {
+    hex = hex.replace(/^#/, '');
+    const bigint = parseInt(hex, 16);
+    const r = (bigint >> 16) & 255;
+    const g = (bigint >> 8) & 255;
+    const b = bigint & 255;
+    const r_norm = r / 255;
+    const g_norm = g / 255;
+    const b_norm = b / 255;
+    const max = Math.max(r_norm, g_norm, b_norm);
+    const min = Math.min(r_norm, g_norm, b_norm);
+    const l = (max + min) / 2;
+    let s = 0;
+    if (max !== min) {
+        s = l > 0.5 ? (max - min) / (2 - max - min) : (max - min) / (max + min);
+    }
+    let h = 0;
+    if (max !== min) {
+        if (max === r_norm) {
+            h = (g_norm - b_norm) / (max - min) + (g_norm < b_norm ? 6 : 0);
+        } else if (max === g_norm) {
+            h = (b_norm - r_norm) / (max - min) + 2;
+        } else {
+            h = (r_norm - g_norm) / (max - min) + 4;
+        }
+    }
+    h = Math.round(h * 60);
+    return { h, s: Math.round(s * 100), l: Math.round(l * 100) };
+}
 
 let theme = 'light';
 
@@ -912,6 +954,8 @@ document.getElementById('mass-editor-textarea').addEventListener('input', e => {
 
 function legendAsTooltipPlugin({ className, style = { background: "var(--legend-background)" } } = {}) {
     let legendEl;
+    let showTop = false;
+    const showLimit = 5;
 
     function init(u, opts) {
         legendEl = u.root.querySelector(".u-legend");
@@ -931,13 +975,22 @@ function legendAsTooltipPlugin({ className, style = { background: "var(--legend-
             ...style
         });
 
-        // hide series color markers
-        const idents = legendEl.querySelectorAll(".u-marker");
+        if (opts.series.length == 2) {
+            const nodes = legendEl.querySelectorAll("th");
+            for (let i = 0; i < nodes.length; i++)
+                nodes[i].style.display = "none";
+        } else {
+            legendEl.querySelector("th").remove();
+            legendEl.querySelector("td").setAttribute('colspan', '2');
+            legendEl.querySelector("td").style.textAlign = 'center';
+        }
 
-        for (let i = 0; i < idents.length; i++)
-            idents[i].style.display = "none";
+        if (opts.series.length - 1 > showLimit) {
+            showTop = true;
+        }
 
         const overEl = u.over;
+        overEl.style.overflow = "visible";
 
         overEl.appendChild(legendEl);
 
@@ -945,11 +998,26 @@ function legendAsTooltipPlugin({ className, style = { background: "var(--legend-
         overEl.addEventListener("mouseleave", () => {legendEl.style.display = "none";});
     }
 
+    function nodeListToArray(nodeList) {
+        return Array.prototype.slice.call(nodeList);
+    }
+
     function update(u) {
         let { left, top } = u.cursor;
         left -= legendEl.clientWidth / 2;
         top -= legendEl.clientHeight / 2;
         legendEl.style.transform = "translate(" + left + "px, " + top + "px)";
+        if (showTop) {
+            let nodes = nodeListToArray(legendEl.querySelectorAll("tr"));
+            let header = nodes.shift();
+            nodes.forEach(function (node) { node._sort_key = +node.querySelector("td").textContent; });
+            nodes.sort((a, b) => +b._sort_key - +a._sort_key);
+            nodes.forEach(function (node) { node.parentNode.appendChild(node); });
+            for (let i = 0; i < nodes.length; i++) {
+                nodes[i].style.display = i < showLimit ? null : "none";
+                delete nodes[i]._sort_key;
+            }
+        }
     }
 
     return {
@@ -959,6 +1027,7 @@ function legendAsTooltipPlugin({ className, style = { background: "var(--legend-
         }
     };
 }
+
 
 async function doFetch(query, url_params = '') {
     host = document.getElementById('url').value || host;
@@ -985,6 +1054,9 @@ async function doFetch(query, url_params = '') {
         reply = await response.text();
         if (response.ok) {
             reply = JSON.parse(reply);
+            if (reply.exception) {
+                error = reply.exception;
+            }
         } else {
             error = reply;
         }
@@ -1032,6 +1104,61 @@ async function draw(idx, chart, url_params, query) {
         }
     }
 
+    // Transform string-labeled data to multi-column data
+    function transformToColumns() {
+        const x = reply.meta[0].name; // time; must be ordered
+        const l = reply.meta[1].name; // string label column to distinguish series; must be ordered
+        const y = reply.meta[2].name; // values; must have single value for (x, l) pair
+        const labels = [...new Set(reply.data[l])].sort((a, b) => a - b);
+        if (labels.includes('__time__')) {
+            error = "The second column is not allowed to contain '__time__' values.";
+            return;
+        }
+        const times = [...new Set(reply.data[x])].sort((a, b) => a - b);
+        let new_meta = [{ name: '__time__', type: reply.meta[0].type }];
+        let new_data = { __time__: [] };
+        for (let label of labels) {
+            new_meta.push({ name: label, type: reply.meta[2].type });
+            new_data[label] = [];
+        }
+        let new_rows = 0;
+        function row_done(row_time) {
+            new_rows++;
+            new_data.__time__.push(row_time);
+            for (let label of labels) {
+                if (new_data[label].length < new_rows) {
+                    new_data[label].push(null);
+                }
+            }
+        }
+        let prev_time = reply.data[x][0];
+        const old_rows = reply.data[x].length;
+        for (let i = 0; i < old_rows; i++) {
+            const time = reply.data[x][i];
+            const label = reply.data[l][i];
+            const value = reply.data[y][i];
+            if (prev_time != time) {
+                row_done(prev_time);
+                prev_time = time;
+            }
+            new_data[label].push(value);
+        }
+        row_done(prev_time);
+        reply.meta = new_meta;
+        reply.data = new_data;
+        reply.rows = new_rows;
+    }
+
+    function isStringColumn(type) {
+        return type === 'String' || type === 'LowCardinality(String)';
+    }
+
+    if (!error) {
+        if (reply.meta.length == 3 && isStringColumn(reply.meta[1].type)) {
+            transformToColumns();
+        }
+    }
+
     let error_div = chart.querySelector('.query-error');
     let title_div = chart.querySelector('.title');
     if (error) {
@@ -1046,30 +1173,31 @@ async function draw(idx, chart, url_params, query) {
     }
 
     const [line_color, fill_color, grid_color, axes_color] = theme != 'dark'
-        ? ["#F88", "#FEE", "#EED", "#2c3235"]
-        : ["#864", "#045", "#2c3235", "#c7d0d9"];
+        ? ["#ff8888", "#ffeeee", "#eeeedd", "#2c3235"]
+        : ["#886644", "#004455", "#2c3235", "#c7d0d9"];
 
     let sync = uPlot.sync("sync");
 
-    let axes = [];
-    let series = [];
-    let data = [];
-    series.push({ label: "x" });
-    data.push(reply.data[reply.meta[0].name]);
+    let axis = {
+        stroke: axes_color,
+        grid: { width: 1 / devicePixelRatio, stroke: grid_color },
+        ticks: { width: 1 / devicePixelRatio, stroke: grid_color }
+    };
+
+    let axes = [axis, axis];
+    let series = [{ label: "x" }];
+    let data = [reply.data[reply.meta[0].name]];
+
+    // Treat every column as series
+    const series_count = reply.meta.length;
+    const fill = series_count == 2 ? fill_color : undefined;
+    const palette = generatePalette(line_color, series_count);
     let max_value = Number.NEGATIVE_INFINITY;
-    for (let i = 1; i < reply.meta.length; i++) {
+    for (let i = 1; i < series_count; i++) {
         let label = reply.meta[i].name;
-        axes.push({
-            stroke: axes_color,
-            grid: { width: 1 / devicePixelRatio, stroke: grid_color },
-            ticks: { width: 1 / devicePixelRatio, stroke: grid_color }
-        });
-        series.push({ label, stroke: line_color, fill: fill_color });
+        series.push({ label, stroke: palette[i - 1], fill });
         data.push(reply.data[label]);
         max_value = Math.max(max_value, ...reply.data[label]);
-    }
-    if (reply.meta.length == 2) {
-        series[1].label = "y";
     }
 
     const opts = {

--- a/programs/server/dashboard.html
+++ b/programs/server/dashboard.html
@@ -1003,7 +1003,6 @@ function legendAsTooltipPlugin({ className, style = { background: "var(--legend-
             footer.classList.add('u-value');
             footer.parentNode.classList.add('u-series','footer');
             footer.textContent = ". . .";
-            console.log(legendEl);
         }
 
         const overEl = u.over;

--- a/programs/server/dashboard.html
+++ b/programs/server/dashboard.html
@@ -431,6 +431,16 @@
             display: none;
         }
 
+        .u-series {
+            line-height: 0.8;
+        }
+
+        .u-series.footer {
+            font-size: 8px;
+            padding-top: 0;
+            margin-top: 0;
+        }
+
         /* Source: https://cdn.jsdelivr.net/npm/uplot@1.6.21/dist/uPlot.min.css
          * It is copy-pasted to lower the number of requests.
          */
@@ -987,6 +997,13 @@ function legendAsTooltipPlugin({ className, style = { background: "var(--legend-
 
         if (opts.series.length - 1 > showLimit) {
             showTop = true;
+            let footer = legendEl.insertRow().insertCell();
+            footer.setAttribute('colspan', '2');
+            footer.style.textAlign = 'center';
+            footer.classList.add('u-value');
+            footer.parentNode.classList.add('u-series','footer');
+            footer.textContent = ". . .";
+            console.log(legendEl);
         }
 
         const overEl = u.over;
@@ -1010,6 +1027,7 @@ function legendAsTooltipPlugin({ className, style = { background: "var(--legend-
         if (showTop) {
             let nodes = nodeListToArray(legendEl.querySelectorAll("tr"));
             let header = nodes.shift();
+            let footer = nodes.pop();
             nodes.forEach(function (node) { node._sort_key = +node.querySelector("td").textContent; });
             nodes.sort((a, b) => +b._sort_key - +a._sort_key);
             nodes.forEach(function (node) { node.parentNode.appendChild(node); });
@@ -1017,6 +1035,7 @@ function legendAsTooltipPlugin({ className, style = { background: "var(--legend-
                 nodes[i].style.display = i < showLimit ? null : "none";
                 delete nodes[i]._sort_key;
             }
+            footer.parentNode.appendChild(footer);
         }
     }
 

--- a/programs/server/dashboard.html
+++ b/programs/server/dashboard.html
@@ -478,7 +478,6 @@
   * - compress the state for URL's #hash;
   * - footer with "about" or a link to source code;
   * - allow to configure a table on a server to save the dashboards;
-  * - multiple lines on chart;
   * - if a query returned one value, display this value instead of a diagram;
   * - if a query returned something unusual, display the table;
   */
@@ -966,7 +965,7 @@ async function doFetch(query, url_params = '') {
     user = document.getElementById('user').value;
     password = document.getElementById('password').value;
 
-    let url = `${host}?default_format=JSONCompactColumns&enable_http_compression=1`
+    let url = `${host}?default_format=JSONColumnsWithMetadata&enable_http_compression=1`
 
     if (add_http_cors_header) {
         // For debug purposes, you may set add_http_cors_header from a browser console
@@ -980,14 +979,14 @@ async function doFetch(query, url_params = '') {
         url += `&password=${encodeURIComponent(password)}`;
     }
 
-    let response, data, error;
+    let response, reply, error;
     try {
         response = await fetch(url + url_params, { method: "POST", body: query });
-        data = await response.text();
+        reply = await response.text();
         if (response.ok) {
-            data = JSON.parse(data);
+            reply = JSON.parse(reply);
         } else {
-            error = data;
+            error = reply;
         }
     } catch (e) {
         console.log(e);
@@ -1006,7 +1005,7 @@ async function doFetch(query, url_params = '') {
         }
     }
 
-    return {data, error};
+    return {reply, error};
 }
 
 async function draw(idx, chart, url_params, query) {
@@ -1015,17 +1014,21 @@ async function draw(idx, chart, url_params, query) {
         plots[idx] = null;
     }
 
-    let {data, error} = await doFetch(query, url_params);
-
+    let {reply, error} = await doFetch(query, url_params);
     if (!error) {
-        if (!Array.isArray(data)) {
-            error = "Query should return an array.";
-        } else if (data.length == 0) {
+        if (reply.rows.length == 0) {
             error = "Query returned empty result.";
-        } else if (data.length != 2) {
-            error = "Query should return exactly two columns: unix timestamp and value.";
-        } else if (!Array.isArray(data[0]) || !Array.isArray(data[1]) || data[0].length != data[1].length) {
-            error = "Wrong data format of the query.";
+        } else if (reply.meta.length < 2) {
+            error = "Query should return at least two columns: unix timestamp and value.";
+        } else {
+            for (let i = 0; i < reply.meta.length; i++) {
+                let label = reply.meta[i].name;
+                let column = reply.data[label];
+                if (!Array.isArray(column) || column.length != reply.data[reply.meta[0].name].length) {
+                    error = "Wrong data format of the query.";
+                    break;
+                }
+            }
         }
     }
 
@@ -1048,19 +1051,32 @@ async function draw(idx, chart, url_params, query) {
 
     let sync = uPlot.sync("sync");
 
-    const max_value = Math.max(...data[1]);
+    let axes = [];
+    let series = [];
+    let data = [];
+    series.push({ label: "x" });
+    data.push(reply.data[reply.meta[0].name]);
+    let max_value = Number.NEGATIVE_INFINITY;
+    for (let i = 1; i < reply.meta.length; i++) {
+        let label = reply.meta[i].name;
+        axes.push({
+            stroke: axes_color,
+            grid: { width: 1 / devicePixelRatio, stroke: grid_color },
+            ticks: { width: 1 / devicePixelRatio, stroke: grid_color }
+        });
+        series.push({ label, stroke: line_color, fill: fill_color });
+        data.push(reply.data[label]);
+        max_value = Math.max(max_value, ...reply.data[label]);
+    }
+    if (reply.meta.length == 2) {
+        series[1].label = "y";
+    }
 
     const opts = {
         width: chart.clientWidth,
         height: chart.clientHeight,
-        axes: [ { stroke: axes_color,
-                  grid: { width: 1 / devicePixelRatio, stroke: grid_color },
-                  ticks: { width: 1 / devicePixelRatio, stroke: grid_color } },
-                { stroke: axes_color,
-                  grid: { width: 1 / devicePixelRatio, stroke: grid_color },
-                  ticks: { width: 1 / devicePixelRatio, stroke: grid_color } } ],
-        series: [ { label: "x" },
-                  { label: "y", stroke: line_color, fill: fill_color } ],
+        axes,
+        series,
         padding: [ null, null, null, (Math.round(max_value * 100) / 100).toString().length * 6 - 10 ],
         plugins: [ legendAsTooltipPlugin() ],
         cursor: {
@@ -1216,22 +1232,21 @@ function saveState() {
 }
 
 async function searchQueries() {
-    let {data, error} = await doFetch(search_query);
+    let {reply, error} = await doFetch(search_query);
     if (error) {
         throw new Error(error);
     }
-    if (!Array.isArray(data)) {
-        throw new Error("Search query should return an array.");
-    } else if (data.length == 0) {
+    let data = reply.data;
+    if (reply.rows == 0) {
         throw new Error("Search query returned empty result.");
-    } else if (data.length != 2) {
+    } else if (reply.meta.length != 2 || reply.meta[0].name != "title" || reply.meta[1].name != "query") {
         throw new Error("Search query should return exactly two columns: title and query.");
-    } else if (!Array.isArray(data[0]) || !Array.isArray(data[1]) || data[0].length != data[1].length) {
+    } else if (!Array.isArray(data.title) || !Array.isArray(data.query) || data.title.length != data.query.length) {
         throw new Error("Wrong data format of the search query.");
     }
 
-    for (let i = 0; i < data[0].length; i++) {
-        queries.push({title: data[0][i], query: data[1][i]});
+    for (let i = 0; i < data.title.length; i++) {
+        queries.push({title: data.title[i], query: data.query[i]});
     }
 
     regenerate();


### PR DESCRIPTION
Now three data formats are supported:
1. Two columns: time and values. Old format.
2. Multiple columns: time and many number-typed columns. The first column is time and every other is considered a separate series. Example:
```sql
SELECT toStartOfInterval(event_time, INTERVAL {rounding:UInt32} SECOND)::INT AS t, max(CurrentMetric_Query) as Queries, max(CurrentMetric_Merge) as Merges
FROM system.metric_log
WHERE event_date >= toDate(now() - {seconds:UInt32}) AND event_time >= now() - {seconds:UInt32}
GROUP BY t
ORDER BY t WITH FILL STEP {rounding:UInt32}
```
<img width="844" alt="Screenshot 2023-11-28 at 02 30 02" src="https://github.com/ClickHouse/ClickHouse/assets/1014716/a1c81526-d926-40c0-b765-03f419724619">



3. Three columns: time, string-typed label, and value. Values are grouped into series based on the label column. Example:
```sql
WITH '2008-01-01'::Date AS start_date
SELECT
    toStartOfInterval(created_at, INTERVAL 7 DAYS)::INT AS t,
    actor_login,
    count()::Int32 AS c
FROM default.github_events
WHERE created_at >= start_date
  AND repo_name = 'ClickHouse/ClickHouse'
  AND event_type IN ('PullRequestEvent', 'PullRequestReviewEvent')
  AND ((event_type = 'PullRequestEvent' AND actor_login = assignee AND action = 'closed')
    OR (event_type = 'PullRequestReviewEvent' AND review_state = 'approved'))
GROUP BY t, actor_login
ORDER BY t, actor_login
```
<img width="947" alt="Screenshot 2023-11-28 at 01 14 14" src="https://github.com/ClickHouse/ClickHouse/assets/1014716/2e31f114-3d29-4933-852d-ffb645e5ad20">

Another example:
```sql
SELECT toStartOfInterval(event_time, INTERVAL {rounding:UInt32} SECOND)::INT AS t, metric, avg(value)
FROM system.asynchronous_metric_log
WHERE event_date >= toDate(now() - {seconds:UInt32}) AND event_time >= now() - {seconds:UInt32} AND metric like '%TimeNormalized'
GROUP BY t, metric
ORDER BY t, metric
```
<img width="948" alt="Screenshot 2023-11-28 at 01 21 30" src="https://github.com/ClickHouse/ClickHouse/assets/1014716/925dafa4-9925-4af4-a3f3-87598f57fbd2">


Note that in case of too many series (>5) legend tooltip resorts series and shows only top 5.

### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
HTTP server page `/dashboard` now supports charts with multiple lines
