### PR TITLE
Ignore comments when comparing column descriptions

### DIFF
--- a/src/Storages/ColumnsDescription.cpp
+++ b/src/Storages/ColumnsDescription.cpp
@@ -60,7 +60,6 @@ bool ColumnDescription::identical(const ColumnDescription & other) const
     return name == other.name
         && type->identical(*other.type)
         && default_desc == other.default_desc
-        && comment == other.comment
         && ast_to_str(codec) == ast_to_str(other.codec)
         && ast_to_str(ttl) == ast_to_str(other.ttl);
 }
@@ -72,7 +71,6 @@ bool ColumnDescription::operator==(const ColumnDescription & other) const
     return name == other.name
         && type->equals(*other.type)
         && default_desc == other.default_desc
-        && comment == other.comment
         && ast_to_str(codec) == ast_to_str(other.codec)
         && ast_to_str(ttl) == ast_to_str(other.ttl);
 }

--- a/tests/integration/test_replicated_database/test.py
+++ b/tests/integration/test_replicated_database/test.py
@@ -1351,3 +1351,48 @@ def test_replicated_table_structure_alter(started_cluster):
     assert "1\t2\t3\t0\n1\t2\t3\t4\n" == dummy_node.query(
         "SELECT * FROM table_structure.rmt ORDER BY k"
     )
+
+
+def test_modify_comment(started_cluster):
+    main_node.query(
+        "CREATE DATABASE modify_comment_db ENGINE = Replicated('/test/modify_comment', 'shard1', 'replica' || '1');"
+    )
+
+    dummy_node.query(
+        "CREATE DATABASE modify_comment_db ENGINE = Replicated('/test/modify_comment', 'shard1', 'replica' || '2');"
+    )
+
+    main_node.query(
+        "CREATE TABLE modify_comment_db.modify_comment_table (d Date, k UInt64, i32 Int32) ENGINE=ReplicatedMergeTree ORDER BY k PARTITION BY toYYYYMM(d);"
+    )
+
+    def restart_verify_not_readonly():
+        main_node.restart_clickhouse()
+        assert (
+            main_node.query(
+                "SELECT is_readonly FROM system.replicas WHERE table = 'modify_comment_table'"
+            )
+            == "0\n"
+        )
+        dummy_node.restart_clickhouse()
+        assert (
+            dummy_node.query(
+                "SELECT is_readonly FROM system.replicas WHERE table = 'modify_comment_table'"
+            )
+            == "0\n"
+        )
+
+    main_node.query(
+        "ALTER TABLE modify_comment_db.modify_comment_table COMMENT COLUMN d 'Some comment'"
+    )
+
+    restart_verify_not_readonly()
+
+    main_node.query(
+        "ALTER TABLE modify_comment_db.modify_comment_table MODIFY COMMENT 'Some error comment'"
+    )
+
+    restart_verify_not_readonly()
+
+    main_node.query("DROP DATABASE modify_comment_db SYNC")
+    dummy_node.query("DROP DATABASE modify_comment_db SYNC")


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Ignore comments when comparing column descriptions. Comments don't affect the behavior of the table so if they get out of sync between replicas, they shouldn't prevent the table from starting. 

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
