### PR TITLE
Fixed potential exception due to stale profile UUID

### DIFF
--- a/src/Access/SettingsProfilesCache.cpp
+++ b/src/Access/SettingsProfilesCache.cpp
@@ -140,7 +140,6 @@ void SettingsProfilesCache::mergeSettingsAndConstraintsFor(EnabledSettings & ena
 
     auto info = std::make_shared<SettingsProfilesInfo>(access_control);
 
-    info->profiles = merged_settings.toProfileIDs();
     substituteProfiles(merged_settings, info->profiles, info->profiles_with_implicit, info->names_of_profiles);
 
     info->settings = merged_settings.toSettingsChanges();
@@ -156,6 +155,8 @@ void SettingsProfilesCache::substituteProfiles(
     std::vector<UUID> & substituted_profiles,
     std::unordered_map<UUID, String> & names_of_substituted_profiles) const
 {
+    profiles = elements.toProfileIDs();
+
     /// We should substitute profiles in reversive order because the same profile can occur
     /// in `elements` multiple times (with some other settings in between) and in this case
     /// the last occurrence should override all the previous ones.
@@ -231,12 +232,12 @@ std::shared_ptr<const SettingsProfilesInfo> SettingsProfilesCache::getSettingsPr
     if (auto pos = this->profile_infos_cache.get(profile_id))
         return *pos;
 
-    SettingsProfileElements elements = all_profiles[profile_id]->elements;
+    SettingsProfileElements elements;
+    auto & element = elements.emplace_back();
+    element.parent_profile = profile_id;
 
     auto info = std::make_shared<SettingsProfilesInfo>(access_control);
 
-    info->profiles.push_back(profile_id);
-    info->profiles_with_implicit.push_back(profile_id);
     substituteProfiles(elements, info->profiles, info->profiles_with_implicit, info->names_of_profiles);
     info->settings = elements.toSettingsChanges();
     info->constraints.merge(elements.toSettingsConstraints(access_control));

--- a/src/Access/SettingsProfilesCache.cpp
+++ b/src/Access/SettingsProfilesCache.cpp
@@ -4,8 +4,6 @@
 #include <Access/SettingsProfilesInfo.h>
 #include <Common/quoteString.h>
 
-#include <boost/range/algorithm_ext/erase.hpp>
-
 
 namespace DB
 {
@@ -188,7 +186,7 @@ void SettingsProfilesCache::substituteProfiles(
     }
     std::reverse(substituted_profiles.begin(), substituted_profiles.end());
 
-    boost::range::remove_erase_if(profiles, [&substituted_profiles_set](const UUID & profile_id)
+    std::erase_if(profiles, [&substituted_profiles_set](const UUID & profile_id)
     {
         return !substituted_profiles_set.contains(profile_id);
     });

--- a/src/Access/SettingsProfilesCache.h
+++ b/src/Access/SettingsProfilesCache.h
@@ -37,7 +37,11 @@ private:
     void profileRemoved(const UUID & profile_id);
     void mergeSettingsAndConstraints();
     void mergeSettingsAndConstraintsFor(EnabledSettings & enabled) const;
-    void substituteProfiles(SettingsProfileElements & elements, std::vector<UUID> & substituted_profiles, std::unordered_map<UUID, String> & names_of_substituted_profiles) const;
+
+    void substituteProfiles(SettingsProfileElements & elements,
+        std::vector<UUID> & profiles,
+        std::vector<UUID> & substituted_profiles,
+        std::unordered_map<UUID, String> & names_of_substituted_profiles) const;
 
     const AccessControl & access_control;
     std::unordered_map<UUID, SettingsProfilePtr> all_profiles;

--- a/src/Access/SettingsProfilesInfo.cpp
+++ b/src/Access/SettingsProfilesInfo.cpp
@@ -66,7 +66,7 @@ Strings SettingsProfilesInfo::getProfileNames() const
 {
     Strings result;
     result.reserve(profiles.size());
-    for (const auto & profile_id : profiles_with_implicit)
+    for (const auto & profile_id : profiles)
     {
         const auto p = names_of_profiles.find(profile_id);
         if (p != names_of_profiles.end())

--- a/src/Access/SettingsProfilesInfo.cpp
+++ b/src/Access/SettingsProfilesInfo.cpp
@@ -66,7 +66,7 @@ Strings SettingsProfilesInfo::getProfileNames() const
 {
     Strings result;
     result.reserve(profiles.size());
-    for (const auto & profile_id : profiles)
+    for (const auto & profile_id : profiles_with_implicit)
     {
         const auto p = names_of_profiles.find(profile_id);
         if (p != names_of_profiles.end())


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed (a rare) exception in case when user's assigned profiles are updated right after user logging in, which could cause a missing entry in `session_log` or problems with logging in.



`SettingsProfilesInfo::profiles` is not updated in bg if any of the profiles assigned to the user change, but `SettingsProfilesInfo::profiles_with_implicit` is.

Update of #42641
kudos @tavplubix  https://github.com/ClickHouse/ClickHouse/pull/42641/files/3d0c07ac5b8f18917f2314474030910176ec7940#r1406196201

Closes: #54656
