### PR TITLE
Keeper fix for changelog and snapshots

### DIFF
--- a/programs/keeper/keeper_config.xml
+++ b/programs/keeper/keeper_config.xml
@@ -41,6 +41,7 @@
                 <min_session_timeout_ms>10000</min_session_timeout_ms>
                 <session_timeout_ms>100000</session_timeout_ms>
                 <raft_logs_level>information</raft_logs_level>
+                <compress_logs>false</compress_logs>
                 <!-- All settings listed in https://github.com/ClickHouse/ClickHouse/blob/master/src/Coordination/CoordinationSettings.h -->
             </coordination_settings>
 

--- a/src/Coordination/Changelog.cpp
+++ b/src/Coordination/Changelog.cpp
@@ -516,7 +516,7 @@ public:
 
                 if (record.header.version > CURRENT_CHANGELOG_VERSION)
                     throw Exception(
-                        ErrorCodes::UNKNOWN_FORMAT_VERSION, "Unsupported changelog version {} on path {}", record.header.version, filepath);
+                        ErrorCodes::UNKNOWN_FORMAT_VERSION, "Unsupported changelog version {} on path {}", static_cast<uint8_t>(record.header.version), filepath);
 
                 /// Read data
                 if (record.header.blob_size != 0)
@@ -1478,6 +1478,11 @@ void Changelog::setRaftServer(const nuraft::ptr<nuraft::raft_server> & raft_serv
 {
     assert(raft_server_);
     raft_server = raft_server_;
+}
+
+bool Changelog::isInitialized() const
+{
+    return initialized;
 }
 
 }

--- a/src/Coordination/Changelog.h
+++ b/src/Coordination/Changelog.h
@@ -153,6 +153,8 @@ public:
 
     void setRaftServer(const nuraft::ptr<nuraft::raft_server> & raft_server_);
 
+    bool isInitialized() const;
+
     /// Fsync log to disk
     ~Changelog();
 

--- a/src/Coordination/KeeperLogStore.cpp
+++ b/src/Coordination/KeeperLogStore.cpp
@@ -127,7 +127,8 @@ void KeeperLogStore::shutdownChangelog()
 bool KeeperLogStore::flushChangelogAndShutdown()
 {
     std::lock_guard lock(changelog_lock);
-    changelog.flush();
+    if (changelog.isInitialized())
+        changelog.flush();
     changelog.shutdown();
     return true;
 }

--- a/tests/config/config.d/keeper_port.xml
+++ b/tests/config/config.d/keeper_port.xml
@@ -20,6 +20,8 @@
             <election_timeout_lower_bound_ms>0</election_timeout_lower_bound_ms>
             <election_timeout_upper_bound_ms>0</election_timeout_upper_bound_ms>
 
+            <compress_logs>0</compress_logs>
+
             <async_replication>1</async_replication>
         </coordination_settings>
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Keeper fix: if Keeper fails to delete older snapshots but a new snapshot is successfully created it will not retry to create a new snapshot. Additionally, the invalid changelog version is correctly printed.

Fix https://github.com/ClickHouse/ClickHouse/issues/57242

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
