### PR TITLE
Follow up recommendations from #57167

### DIFF
--- a/tests/ci/cherry_pick.py
+++ b/tests/ci/cherry_pick.py
@@ -58,7 +58,7 @@ class ReleaseBranch:
     CHERRYPICK_DESCRIPTION = """Original pull-request #{pr_number}
 
 This pull-request is a first step of an automated backporting.
-It contains changes like after calling a local command `git cherry-pick`.
+It contains changes similar to calling a local command `git cherry-pick`.
 If you intend to continue backporting this changes, then resolve all conflicts if any.
 Otherwise, if you do not want to backport them, then just close this pull-request.
 
@@ -66,19 +66,25 @@ The check results does not matter at this step - you can safely ignore them.
 
 ### Note
 
-This pull-request will be merged automatically as it reaches the mergeable state, \
-**do not merge it manually**. It's 100% safe, but completely meaningless.
+This pull-request will be merged automatically. Please, **do not merge it manually** \
+(but if you accidentally did, nothing bad will happen).
 
-### If the PR was closed and then reopened
+### If the PR was manually reopened after being closed
 
-If it stuck (e.g. for a day), check {pr_url} for `{backport_created_label}` *label* and \
-delete it if necessary. Manually merging will do nothing, since \
-`{backport_created_label}` *label* prevents the original PR {pr_url} from being \
-processed.
+If this PR is stuck (i.e. not automatically merged after one day), check {pr_url} for \
+`{backport_created_label}` *label* and delete it.
 
-If the cherry-pick PR is completely screwed, and you want to recreate it: delete the \
-`{label_cherrypick}` label and delete this branch.
-You may also need to delete the `{backport_created_label}` label from the original PR.
+Manually merging will do nothing. The `{backport_created_label}` *label* prevents the \
+original PR {pr_url} from being processed.
+
+If this cherry-pick PR is completely screwed by a wrong conflicts resolution, and you \
+want to recreate it:
+
+- delete the `{label_cherrypick}` label from the PR
+- delete this branch from the repository
+
+You also need to check the original PR {pr_url} for `{backport_created_label}`, and \
+delete if it's presented there
 """
     BACKPORT_DESCRIPTION = """This pull-request is a last step of an automated \
 backporting.

--- a/tests/ci/cherry_pick.py
+++ b/tests/ci/cherry_pick.py
@@ -58,8 +58,8 @@ class ReleaseBranch:
     CHERRYPICK_DESCRIPTION = """Original pull-request #{pr_number}
 
 This pull-request is a first step of an automated backporting.
-It contains changes similar to calling a local command `git cherry-pick`.
-If you intend to continue backporting this changes, then resolve all conflicts if any.
+It contains changes similar to calling `git cherry-pick` locally.
+If you intend to continue backporting the changes, then resolve all conflicts if any.
 Otherwise, if you do not want to backport them, then just close this pull-request.
 
 The check results does not matter at this step - you can safely ignore them.
@@ -69,7 +69,9 @@ The check results does not matter at this step - you can safely ignore them.
 This pull-request will be merged automatically. Please, **do not merge it manually** \
 (but if you accidentally did, nothing bad will happen).
 
-### If the PR was manually reopened after being closed
+### Troubleshooting
+
+#### If the PR was manually reopened after being closed
 
 If this PR is stuck (i.e. not automatically merged after one day), check {pr_url} for \
 `{backport_created_label}` *label* and delete it.
@@ -77,7 +79,7 @@ If this PR is stuck (i.e. not automatically merged after one day), check {pr_url
 Manually merging will do nothing. The `{backport_created_label}` *label* prevents the \
 original PR {pr_url} from being processed.
 
-### If the conflicts were resolved in a wrong way
+#### If the conflicts were resolved in a wrong way
 
 If this cherry-pick PR is completely screwed by a wrong conflicts resolution, and you \
 want to recreate it:

--- a/tests/ci/cherry_pick.py
+++ b/tests/ci/cherry_pick.py
@@ -77,6 +77,8 @@ If this PR is stuck (i.e. not automatically merged after one day), check {pr_url
 Manually merging will do nothing. The `{backport_created_label}` *label* prevents the \
 original PR {pr_url} from being processed.
 
+### If the conflicts were resolved in a wrong way
+
 If this cherry-pick PR is completely screwed by a wrong conflicts resolution, and you \
 want to recreate it:
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Make the cherry-pick PR's description even more clear