### PR TITLE
Add back flaky tests to analyzer_tech_debt.txt

### DIFF
--- a/tests/analyzer_tech_debt.txt
+++ b/tests/analyzer_tech_debt.txt
@@ -40,3 +40,6 @@
 02784_parallel_replicas_automatic_decision_join
 02818_parameterized_view_with_cte_multiple_usage
 02815_range_dict_no_direct_join
+# Flaky. Please don't delete them without fixing them:
+01600_parts_states_metrics_long
+01287_max_execution_speed


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

Just because they pass it doesn't mean they are fixed:
`01600_parts_states_metrics_long` -> 13 failures in 3 days. Only with the analyzer
`01287_max_execution_speed` -> 12 failures in 2 days. Only with the analyzer

Not sure if the comment breaks anything: it should be taken as a test name and be ok, but let's wait until the CI reports back 