### PR TITLE
Address 02668_ulid_decoding flakiness

### DIFF
--- a/tests/queries/0_stateless/02668_ulid_decoding.sql
+++ b/tests/queries/0_stateless/02668_ulid_decoding.sql
@@ -1,3 +1,5 @@
+-- Tags: no-fasttest
+
 SELECT dateDiff('minute', ULIDStringToDateTime(generateULID()), now()) <= 1;
 SELECT toTimezone(ULIDStringToDateTime('01GWJWKW30MFPQJRYEAF4XFZ9E'), 'America/Costa_Rica');
 SELECT ULIDStringToDateTime('01GWJWKW30MFPQJRYEAF4XFZ9E', 'America/Costa_Rica');

--- a/tests/queries/0_stateless/02668_ulid_decoding.sql
+++ b/tests/queries/0_stateless/02668_ulid_decoding.sql
@@ -1,6 +1,4 @@
--- Tags: no-fasttest
-
-SELECT dateDiff('minute', ULIDStringToDateTime(generateULID()), now()) = 0;
+SELECT dateDiff('minute', ULIDStringToDateTime(generateULID()), now()) <= 1;
 SELECT toTimezone(ULIDStringToDateTime('01GWJWKW30MFPQJRYEAF4XFZ9E'), 'America/Costa_Rica');
 SELECT ULIDStringToDateTime('01GWJWKW30MFPQJRYEAF4XFZ9E', 'America/Costa_Rica');
 SELECT ULIDStringToDateTime('01GWJWKW30MFPQJRYEAF4XFZ9', 'America/Costa_Rica'); -- { serverError ILLEGAL_COLUMN }


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

Test is flaky: https://s3.amazonaws.com/clickhouse-test-reports/57189/4e6ff36abf2fefb3a6b1a979af2bc3102eba15aa/stateless_tests__debug__[5_5].html

If you are unlucky you might get a minute of difference between (generateULID() and now()):

```
SELECT dateDiff('minute', toDateTime64('2023-11-28 16:13:59.999', 3), toDateTime64('2023-11-28 16:14:00.000', 3))

Query id: 9478add7-c26b-42ae-bcf8-0294fb5596b5

┌─dateDiff('minute', toDateTime64('2023-11-28 16:13:59.999', 3), toDateTime64('2023-11-28 16:14:00.000', 3))─┐
│                                                                                                          1 │
└────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
```