### PR TITLE
Don't fall-back to in-order pool when `max_streams = 1` for remote fs

### DIFF
--- a/src/Processors/QueryPlan/ReadFromMergeTree.cpp
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.cpp
@@ -612,7 +612,8 @@ Pipe ReadFromMergeTree::read(
     if (read_type == ReadType::ParallelReplicas)
         return readFromPoolParallelReplicas(std::move(parts_with_range), std::move(required_columns), std::move(pool_settings));
 
-    if (read_type == ReadType::Default && max_streams > 1)
+    /// Reading from default thread pool is beneficial for remote storage because of new prefetches.
+    if (read_type == ReadType::Default && (max_streams > 1 || checkAllPartsOnRemoteFS(parts_with_range)))
         return readFromPool(std::move(parts_with_range), std::move(required_columns), std::move(pool_settings));
 
     auto pipe = readInOrder(parts_with_range, required_columns, pool_settings, read_type, /*limit=*/ 0);

--- a/tests/queries/0_stateless/01605_adaptive_granularity_block_borders.sql
+++ b/tests/queries/0_stateless/01605_adaptive_granularity_block_borders.sql
@@ -1,5 +1,6 @@
--- Tags: no-random-merge-tree-settings, no-tsan, no-debug
+-- Tags: no-random-merge-tree-settings, no-tsan, no-debug, no-s3-storage
 -- no-tsan: too slow
+-- no-s3-storage: for remote tables we use thread pool even when reading with one stream, so memory consumption is higher
 
 SET use_uncompressed_cache = 0;
 SET allow_prefetched_read_pool_for_remote_filesystem=0;

--- a/tests/queries/0_stateless/02233_optimize_aggregation_in_order_prefix.sql
+++ b/tests/queries/0_stateless/02233_optimize_aggregation_in_order_prefix.sql
@@ -1,3 +1,5 @@
+-- Tags: no-s3-storage
+
 drop table if exists data_02233;
 create table data_02233 (parent_key Int, child_key Int, value Int) engine=MergeTree() order by parent_key;
 

--- a/tests/queries/0_stateless/02343_aggregation_pipeline.sql
+++ b/tests/queries/0_stateless/02343_aggregation_pipeline.sql
@@ -1,3 +1,5 @@
+-- Tags: no-s3-storage
+
 -- produces different pipeline if enabled
 set enable_memory_bound_merging_of_aggregation_results = 0;
 

--- a/tests/queries/0_stateless/02521_aggregation_by_partitions.sql
+++ b/tests/queries/0_stateless/02521_aggregation_by_partitions.sql
@@ -1,4 +1,4 @@
--- Tags: long
+-- Tags: long, no-s3-storage
 
 set max_threads = 16;
 set allow_aggregate_partitions_independently = 1;

--- a/tests/queries/0_stateless/02554_fix_grouping_sets_predicate_push_down.sql
+++ b/tests/queries/0_stateless/02554_fix_grouping_sets_predicate_push_down.sql
@@ -1,3 +1,5 @@
+-- Tags: no-s3-storage
+
 DROP TABLE IF EXISTS test_grouping_sets_predicate;
 
 CREATE TABLE test_grouping_sets_predicate

--- a/tests/queries/0_stateless/02582_async_reading_with_small_limit.sql
+++ b/tests/queries/0_stateless/02582_async_reading_with_small_limit.sql
@@ -1,3 +1,5 @@
+-- Tags: no-s3-storage
+
 drop table if exists t;
 
 create table t(a UInt64) engine=MergeTree order by tuple();


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Now we use default read pool for reading from external storage when `max_streams = 1`. It is beneficial when read prefetches are enabled.