### PR TITLE
Ignore finished ON CLUSTER tasks if hostname changed

### DIFF
--- a/src/Interpreters/DDLTask.cpp
+++ b/src/Interpreters/DDLTask.cpp
@@ -215,7 +215,7 @@ ContextMutablePtr DDLTaskBase::makeQueryContext(ContextPtr from_context, const Z
 }
 
 
-bool DDLTask::findCurrentHostID(ContextPtr global_context, Poco::Logger * log)
+bool DDLTask::findCurrentHostID(ContextPtr global_context, Poco::Logger * log, const ZooKeeperPtr & zookeeper)
 {
     bool host_in_hostlist = false;
     std::exception_ptr first_exception = nullptr;
@@ -262,6 +262,23 @@ bool DDLTask::findCurrentHostID(ContextPtr global_context, Poco::Logger * log)
 
     if (!host_in_hostlist && first_exception)
     {
+        String reason;
+        if (zookeeper->exists(getFinishedNodePath()))
+        {
+            LOG_WARNING(log, "Failed to find current host ID, but assuming that {} is finished because {} exists. Skipping the task. Error: {}",
+                        entry_name, getFinishedNodePath(), getExceptionMessage(first_exception, /*with_stacktrace*/ true));
+            return false;
+        }
+
+        size_t finished_nodes_count = zookeeper->getChildren(fs::path(entry_path) / "finished").size();
+        if (entry.hosts.size() == finished_nodes_count)
+        {
+            LOG_WARNING(log, "Failed to find current host ID, but assuming that {} is finished because the number of finished nodes ({}) "
+                        "equals to the number of hosts in list. Skipping the task. Error: {}",
+                        entry_name, finished_nodes_count, getExceptionMessage(first_exception, /*with_stacktrace*/ true));
+            return false;
+        }
+
         /// We don't know for sure if we should process task or not
         std::rethrow_exception(first_exception);
     }

--- a/src/Interpreters/DDLTask.h
+++ b/src/Interpreters/DDLTask.h
@@ -143,7 +143,7 @@ struct DDLTask : public DDLTaskBase
 {
     DDLTask(const String & name, const String & path) : DDLTaskBase(name, path) {}
 
-    bool findCurrentHostID(ContextPtr global_context, Poco::Logger * log);
+    bool findCurrentHostID(ContextPtr global_context, Poco::Logger * log, const ZooKeeperPtr & zookeeper);
 
     void setClusterInfo(ContextPtr context, Poco::Logger * log);
 

--- a/src/Interpreters/DDLWorker.cpp
+++ b/src/Interpreters/DDLWorker.cpp
@@ -214,7 +214,7 @@ DDLTaskPtr DDLWorker::initAndCheckTask(const String & entry_name, String & out_r
     /// Stage 2: resolve host_id and check if we should execute query or not
     /// Multiple clusters can use single DDL queue path in ZooKeeper,
     /// So we should skip task if we cannot find current host in cluster hosts list.
-    if (!task->findCurrentHostID(context, log))
+    if (!task->findCurrentHostID(context, log, zookeeper))
     {
         out_reason = "There is no a local address in host list";
         return add_to_skip_set();

--- a/tests/integration/test_ddl_alter_query/configs/remote_servers.xml
+++ b/tests/integration/test_ddl_alter_query/configs/remote_servers.xml
@@ -25,4 +25,6 @@
             </shard>
         </test_cluster>
     </remote_servers>
+
+    <allow_zookeeper_write>1</allow_zookeeper_write>
 </clickhouse>


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
In rare cases, `ON CLUSTER` queries queue could get stuck with `Unexpected error, will try to restart main thread: Not found address of host` error if the hostname of some host has changed. It's fixed. Fixes https://github.com/ClickHouse/ClickHouse/issues/39710
