### PR TITLE
Add auto-vectorization for BinaryOperation

### DIFF
--- a/src/Functions/FunctionBinaryArithmetic.h
+++ b/src/Functions/FunctionBinaryArithmetic.h
@@ -40,6 +40,7 @@
 #include <base/map.h>
 #include <Common/FieldVisitorsAccurateComparison.h>
 #include <Common/assert_cast.h>
+#include <Common/TargetSpecific.h>
 #include <Common/typeid_cast.h>
 #include <Common/Arena.h>
 #include <Core/ColumnWithTypeAndName.h>
@@ -225,8 +226,11 @@ struct BinaryOperation
     static const constexpr bool allow_fixed_string = false;
     static const constexpr bool allow_string_integer = false;
 
+    MULTITARGET_FUNCTION_AVX512BW_AVX512F_AVX2_SSE42(
+    MULTITARGET_FUNCTION_HEADER(
     template <OpCase op_case>
-    static void NO_INLINE process(const A * __restrict a, const B * __restrict b, ResultType * __restrict c, size_t size, const NullMap * right_nullmap = nullptr)
+    static void NO_INLINE
+    ), processImpl, MULTITARGET_FUNCTION_BODY((const A * __restrict a, const B * __restrict b, ResultType * __restrict c, size_t size, const NullMap * right_nullmap = nullptr) /// NOLINT
     {
         if constexpr (op_case == OpCase::RightConstant)
         {
@@ -250,6 +254,39 @@ struct BinaryOperation
                 for (size_t i = 0; i < size; ++i)
                     apply<op_case>(a, b, c, i);
         }
+    })
+    )
+
+    template <OpCase op_case>
+    static void NO_INLINE process(const A * __restrict a, const B * __restrict b, ResultType * __restrict c, size_t size, const NullMap * right_nullmap = nullptr)
+    {
+#if USE_MULTITARGET_CODE
+        if (isArchSupported(TargetArch::AVX512BW))
+        {
+            processImplAVX512BW <op_case> (a, b, c, size, right_nullmap);
+            return;
+        }
+
+        if (isArchSupported(TargetArch::AVX512F))
+        {
+            processImplAVX512F <op_case> (a, b, c, size, right_nullmap);
+            return;
+        }
+
+        if (isArchSupported(TargetArch::AVX2))
+        {
+            processImplAVX2 <op_case> (a, b, c, size, right_nullmap);
+            return;
+        }
+
+        if (isArchSupported(TargetArch::SSE42))
+        {
+            processImplSSE42 <op_case> (a, b, c, size, right_nullmap);
+            return;
+        }
+#endif
+
+        processImpl <op_case> (a, b, c, size, right_nullmap);
     }
 
     static ResultType process(A a, B b) { return Op::template apply<ResultType>(a, b); }


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Enable auto-vectorization for binary operations such as `+` and `*`. On a 2 x 80 vCPUs system with ClickBench, Q29 becomes 5% faster, and the total runtime of 43 queries improved by 1.6%.