### PR TITLE
Always renew ZK client in `WithRetries`

### DIFF
--- a/src/Backups/WithRetries.cpp
+++ b/src/Backups/WithRetries.cpp
@@ -55,6 +55,10 @@ void WithRetries::renewZooKeeper(FaultyKeeper my_faulty_zookeeper) const
 
         callback(my_faulty_zookeeper);
     }
+    else
+    {
+        my_faulty_zookeeper->setKeeper(zookeeper);
+    }
 }
 
 const WithRetries::KeeperSettings & WithRetries::getKeeperSettings() const


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

`WithRetries` will renew ZooKeeper only if `(!zookeeper || zookeeper->expired())`.
When `ZooKeeperWithFaultInjection` produced fault injection it only reset internal ZK pointer and without finalizing the client will not be expired which meant that the operation would continue to fail for all retries because it wouldn't be renewed.

We cannot finalize inside `ZooKeeperWithFaultInjection` because we can do iteration cleanup so we need to always set the internal Keeper client inside `renewZooKeeper`

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
