### PR TITLE
Better JSON -> JSONEachRow fallback without catching exceptions

### DIFF
--- a/src/Formats/JSONUtils.h
+++ b/src/Formats/JSONUtils.h
@@ -112,6 +112,7 @@ namespace JSONUtils
 
     void skipColon(ReadBuffer & in);
     void skipComma(ReadBuffer & in);
+    bool checkAndSkipComma(ReadBuffer & in);
 
     String readFieldName(ReadBuffer & in);
 
@@ -122,9 +123,11 @@ namespace JSONUtils
 
     void skipObjectStart(ReadBuffer & in);
     void skipObjectEnd(ReadBuffer & in);
+    bool checkAndSkipObjectStart(ReadBuffer & in);
     bool checkAndSkipObjectEnd(ReadBuffer & in);
 
     NamesAndTypesList readMetadata(ReadBuffer & in);
+    bool tryReadMetadata(ReadBuffer & in, NamesAndTypesList & names_and_types);
     NamesAndTypesList readMetadataAndValidateHeader(ReadBuffer & in, const Block & header);
     void validateMetadataByHeader(const NamesAndTypesList & names_and_types_from_metadata, const Block & header);
 

--- a/src/Processors/Formats/Impl/JSONRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/JSONRowInputFormat.cpp
@@ -7,11 +7,6 @@
 namespace DB
 {
 
-namespace ErrorCodes
-{
-    extern const int INCORRECT_DATA;
-}
-
 JSONRowInputFormat::JSONRowInputFormat(ReadBuffer & in_, const Block & header_, Params params_, const FormatSettings & format_settings_)
     : JSONRowInputFormat(std::make_unique<PeekableReadBuffer>(in_), header_, params_, format_settings_)
 {


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Should solve https://github.com/ClickHouse/ClickHouse/issues/57363