### PR TITLE
Update DDLTask.cpp

### DIFF
--- a/src/Interpreters/DDLTask.cpp
+++ b/src/Interpreters/DDLTask.cpp
@@ -262,7 +262,6 @@ bool DDLTask::findCurrentHostID(ContextPtr global_context, Poco::Logger * log, c
 
     if (!host_in_hostlist && first_exception)
     {
-        String reason;
         if (zookeeper->exists(getFinishedNodePath()))
         {
             LOG_WARNING(log, "Failed to find current host ID, but assuming that {} is finished because {} exists. Skipping the task. Error: {}",


### PR DESCRIPTION

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


See https://github.com/ClickHouse/ClickHouse/pull/57339#discussion_r1409715987
It's strange that clang-tidy didn't catch that