### PR TITLE
verbose exception messages for StorageFuzzJSON

### DIFF
--- a/src/Storages/StorageFuzzJSON.cpp
+++ b/src/Storages/StorageFuzzJSON.cpp
@@ -11,6 +11,7 @@
 #include <Common/JSONParsers/RapidJSONParser.h>
 #include <Common/JSONParsers/SimdJSONParser.h>
 #include <Common/checkStackSize.h>
+#include <Common/escapeString.h>
 
 namespace DB
 {
@@ -138,7 +139,7 @@ void traverse(const ParserImpl::Element & e, std::shared_ptr<JSONNode> node)
     {
         auto field = getFixedValue(e);
         if (!field)
-            throw Exception(ErrorCodes::INCORRECT_DATA, "Failed to parse a fixed JSON value.");
+            throw Exception(ErrorCodes::INCORRECT_DATA, "Failed to parse a fixed JSON value '{}'.", escapeString(e.getString()));
 
         val.fixed = std::move(field);
     }
@@ -151,7 +152,14 @@ std::shared_ptr<JSONNode> parseJSON(const String & json)
     ParserImpl p;
 
     if (!p.parse(json, document))
-        throw Exception(ErrorCodes::INCORRECT_DATA, "Failed to parse JSON string.");
+    {
+        constexpr size_t max_length = 128LU;
+        throw Exception(
+            ErrorCodes::INCORRECT_DATA,
+            "Failed to parse JSON from the string '{}'{}.",
+            escapeString(json.substr(0, max_length)),
+            json.size() >= max_length ? "... (truncated)" : "");
+    }
 
     auto root = std::make_shared<JSONNode>();
     traverse(document, root);


### PR DESCRIPTION
Follow-up to https://github.com/ClickHouse/ClickHouse/pull/56490#discussion_r1409556111

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
