### PR TITLE
Add more doc examples for the EXISTS operator

### DIFF
--- a/docs/en/sql-reference/operators/exists.md
+++ b/docs/en/sql-reference/operators/exists.md
@@ -5,7 +5,7 @@ slug: /en/sql-reference/operators/exists
 
 The `EXISTS` operator checks how many records are in the result of a subquery. If it is empty, then the operator returns `0`. Otherwise, it returns `1`.
 
-`EXISTS` can be used in a [WHERE](../../sql-reference/statements/select/where.md) clause.
+`EXISTS` can also be used in a [WHERE](../../sql-reference/statements/select/where.md) clause.
 
 :::tip    
 References to main query tables and columns are not supported in a subquery.
@@ -13,11 +13,25 @@ References to main query tables and columns are not supported in a subquery.
 
 **Syntax**
 
-```sql
-WHERE EXISTS(subquery)
+``` sql
+EXISTS(subquery)
 ```
 
 **Example**
+
+Query checking existence of values in a subquery:
+
+``` sql
+SELECT EXISTS(SELECT * FROM numbers(10) WHERE number > 8), EXISTS(SELECT * FROM numbers(10) WHERE number > 11)
+```
+
+Result:
+
+``` text
+┌─in(1, _subquery1)─┬─in(1, _subquery2)─┐
+│                 1 │                 0 │
+└───────────────────┴───────────────────┘
+```
 
 Query with a subquery returning several rows:
 


### PR DESCRIPTION
The existing documentation for EXISTS makes it look like it only works as part of a WHERE clause, when in fact, it can be used in many places. Changing the docs to note that a bit differently with another example should provide more clarity on the use of this term.

### Changelog category (leave one):
- Documentation (changelog entry is not required)
