### PR TITLE
Consider whole check failure in bugfix validate check as an error

### DIFF
--- a/tests/ci/bugfix_validate_check.py
+++ b/tests/ci/bugfix_validate_check.py
@@ -36,6 +36,18 @@ def process_result(file_path: Path) -> Tuple[bool, TestResults]:
     test_results = []  # type: TestResults
     state, report_url, description = post_commit_status_from_file(file_path)
     prefix = file_path.parent.name
+    if description.strip() in [
+        "Invalid check_status.tsv",
+        "Not found test_results.tsv",
+        "Empty test_results.tsv",
+    ]:
+        status = (
+            f'Check failed (<a href="{report_url}">Report</a>)'
+            if report_url != "null"
+            else "Check failed"
+        )
+        return False, [TestResult(f"{prefix}: {description}", status)]
+
     is_ok = state == "success"
     if is_ok and report_url == "null":
         return is_ok, test_results


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)


In case check is fully broken it would be easier to notice it. Not it's green bu default and we miss cases when it's failed because of broken underlying check.