### PR TITLE
Change type of s3_cache in test_encrypted_disk

### DIFF
--- a/tests/integration/test_encrypted_disk/configs/storage.xml
+++ b/tests/integration/test_encrypted_disk/configs/storage.xml
@@ -23,6 +23,7 @@
                 <key>1234567812345678</key>
             </disk_s3_encrypted_default_path>
             <s3_cache>
+                <type>cache</type>
                 <disk>disk_s3</disk>
                 <path>s3_cache/</path>
                 <max_size>1Gi</max_size>
@@ -95,7 +96,7 @@
                         <disk>disk_s3_encrypted_default_path</disk>
                     </main>
                 </volumes>
-            </s3_encrypted_default_path>_
+            </s3_encrypted_default_path>
             <s3_encrypted_cache_policy>
                 <volumes>
                     <main>

--- a/tests/integration/test_encrypted_disk/configs/storage.xml
+++ b/tests/integration/test_encrypted_disk/configs/storage.xml
@@ -106,5 +106,7 @@
             </s3_encrypted_cache_policy>
          </policies>
     </storage_configuration>
+
+    <temporary_data_in_cache>s3_cache</temporary_data_in_cache>
     <allow_remove_stale_moving_parts>true</allow_remove_stale_moving_parts>
 </clickhouse>


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...
