### PR TITLE
Fix flaky inverted index functional test

### DIFF
--- a/src/Storages/MergeTree/DataPartStorageOnDiskBase.cpp
+++ b/src/Storages/MergeTree/DataPartStorageOnDiskBase.cpp
@@ -749,8 +749,13 @@ void DataPartStorageOnDiskBase::clearDirectory(
         /// Remove each expected file in directory, then remove directory itself.
         RemoveBatchRequest request;
         for (const auto & file : names_to_remove)
-            request.emplace_back(fs::path(dir) / file);
+        {
+            if ((file.ends_with(".gin_dict") || file.ends_with(".gin_post") || file.ends_with(".gin_seg") || file.ends_with(".gin_sid"))
+             && (!disk->isFile(fs::path(dir) / file)))
+                continue;
 
+            request.emplace_back(fs::path(dir) / file);
+        }
         request.emplace_back(fs::path(dir) / "default_compression_codec.txt", true);
         request.emplace_back(fs::path(dir) / "delete-on-destroy.txt", true);
         request.emplace_back(fs::path(dir) / "txn_version.txt", true);

--- a/src/Storages/MergeTree/DataPartStorageOnDiskBase.cpp
+++ b/src/Storages/MergeTree/DataPartStorageOnDiskBase.cpp
@@ -750,8 +750,7 @@ void DataPartStorageOnDiskBase::clearDirectory(
         RemoveBatchRequest request;
         for (const auto & file : names_to_remove)
         {
-            if ((file.ends_with(".gin_dict") || file.ends_with(".gin_post") || file.ends_with(".gin_seg") || file.ends_with(".gin_sid"))
-             && (!disk->isFile(fs::path(dir) / file)))
+            if (isGinFile(file) && (!disk->isFile(fs::path(dir) / file)))
                 continue;
 
             request.emplace_back(fs::path(dir) / file);

--- a/src/Storages/MergeTree/GinIndexStore.h
+++ b/src/Storages/MergeTree/GinIndexStore.h
@@ -300,4 +300,9 @@ private:
     std::mutex mutex;
 };
 
+inline bool isGinFile(const String &file_name)
+{
+    return (file_name.ends_with(".gin_dict") || file_name.ends_with(".gin_post") || file_name.ends_with(".gin_seg") || file_name.ends_with(".gin_sid"));
+}
+
 }

--- a/src/Storages/MergeTree/MergeTreeDataPartChecksum.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataPartChecksum.cpp
@@ -8,6 +8,7 @@
 #include <Compression/CompressedReadBuffer.h>
 #include <Compression/CompressedWriteBuffer.h>
 #include <Storages/MergeTree/IDataPartStorage.h>
+#include <Storages/MergeTree/GinIndexStore.h>
 #include <optional>
 
 
@@ -48,7 +49,7 @@ void MergeTreeDataPartChecksum::checkEqual(const MergeTreeDataPartChecksum & rhs
 void MergeTreeDataPartChecksum::checkSize(const IDataPartStorage & storage, const String & name) const
 {
     /// Skip inverted index files, these have a default MergeTreeDataPartChecksum with file_size == 0
-    if (name.ends_with(".gin_dict") || name.ends_with(".gin_post") || name.ends_with(".gin_seg") || name.ends_with(".gin_sid"))
+    if (isGinFile(name))
         return;
 
     if (!storage.exists(name))

--- a/src/Storages/MergeTree/checkDataPart.cpp
+++ b/src/Storages/MergeTree/checkDataPart.cpp
@@ -248,7 +248,7 @@ static IMergeTreeDataPart::Checksums checkDataPart(
         }
 
         /// Exclude files written by inverted index from check. No correct checksums are available for them currently.
-        if (file_name.ends_with(".gin_dict") || file_name.ends_with(".gin_post") || file_name.ends_with(".gin_seg") || file_name.ends_with(".gin_sid"))
+        if (isGinFile(file_name))
             continue;
 
         auto checksum_it = checksums_data.files.find(file_name);

--- a/tests/queries/0_stateless/02346_full_text_search.sql
+++ b/tests/queries/0_stateless/02346_full_text_search.sql
@@ -243,40 +243,6 @@ CREATE TABLE tab (row_id UInt32, str String, INDEX idx str TYPE inverted) ENGINE
 INSERT INTO tab VALUES (0, 'a');
 SELECT * FROM tab WHERE str == 'b' AND 1.0;
 
-
--- Tests with parameter max_digestion_size_per_segment are flaky in CI, not clear why --> comment out for the time being:
-
--- ----------------------------------------------------
--- SELECT 'Test max_digestion_size_per_segment';
---
--- DROP TABLE IF EXISTS tab;
---
--- CREATE TABLE tab(k UInt64, s String, INDEX af(s) TYPE inverted(0))
---                     Engine=MergeTree
---                     ORDER BY (k)
---                     SETTINGS max_digestion_size_per_segment = 1024, index_granularity = 256
---                     AS
---                         SELECT
---                         number,
---                         format('{},{},{},{}', hex(12345678), hex(87654321), hex(number/17 + 5), hex(13579012)) as s
---                         FROM numbers(10240);
---
--- -- check inverted index was created
--- SELECT name, type FROM system.data_skipping_indices WHERE table == 'tab' AND database = currentDatabase() LIMIT 1;
---
--- -- search inverted index
--- SELECT s FROM tab WHERE hasToken(s, '6969696969898240');
---
--- -- check the query only read 1 granule (1 row total; each granule has 256 rows)
--- SYSTEM FLUSH LOGS;
--- SELECT read_rows==256 from system.query_log 
---         WHERE query_kind ='Select'
---             AND current_database = currentDatabase()
---             AND endsWith(trimRight(query), 'SELECT s FROM tab WHERE hasToken(s, \'6969696969898240\');') 
---             AND type='QueryFinish' 
---             AND result_rows==1
---         LIMIT 1;
---
 SELECT 'Test max_rows_per_postings_list';
 DROP TABLE IF EXISTS tab;
 -- create table 'tab' with inverted index parameter (ngrams, max_rows_per_most_list) which is (0, 10240)


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
This PR is to address issue [02346_full_text_search is flaky](https://github.com/ClickHouse/ClickHouse/issues/47696). 

There are 2 issues which are related to DB Exception "Cannot quickly remove directory". One was due to "directory is not empty" which cannot be reproduced anymore which I believe it was fixed by putting inverted index files into checksum checks. This PR fixed the DB exception due to "cannot unlink file" which can be reproduced as described in [issue 56998](https://github.com/ClickHouse/ClickHouse/issues/56998).

There were also 3 mismatching results. The last two were generated by testing "density" settings which are no longer valid since the settings has been replaced by "max_rows_per_postings_list". The first mismatch was from testing settings "max_digestion_size_per_segment". Since this test doesn't really test anything (with/without the setting the results are not affected) and there is no good way to test it, let's remove this test officially.

### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed flaky inverted index functional test.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
