### PR TITLE
Fix working with read buffers in StreamingFormatExecutor

### DIFF
--- a/src/IO/PeekableReadBuffer.cpp
+++ b/src/IO/PeekableReadBuffer.cpp
@@ -20,33 +20,6 @@ PeekableReadBuffer::PeekableReadBuffer(ReadBuffer & sub_buf_, size_t start_size_
     checkStateCorrect();
 }
 
-void PeekableReadBuffer::reset()
-{
-    checkStateCorrect();
-}
-
-void PeekableReadBuffer::setSubBuffer(ReadBuffer & sub_buf_)
-{
-    sub_buf = &sub_buf_;
-    resetImpl();
-}
-
-void PeekableReadBuffer::resetImpl()
-{
-    peeked_size = 0;
-    checkpoint = std::nullopt;
-    checkpoint_in_own_memory = false;
-    use_stack_memory = true;
-
-    if (!currentlyReadFromOwnMemory())
-        sub_buf->position() = pos;
-
-    Buffer & sub_working = sub_buf->buffer();
-    BufferBase::set(sub_working.begin(), sub_working.size(), sub_buf->offset());
-
-    checkStateCorrect();
-}
-
 bool PeekableReadBuffer::peekNext()
 {
     checkStateCorrect();

--- a/src/IO/PeekableReadBuffer.h
+++ b/src/IO/PeekableReadBuffer.h
@@ -74,12 +74,6 @@ public:
     /// This data will be lost after destruction of peekable buffer.
     bool hasUnreadData() const;
 
-    // for streaming reading (like in Kafka) we need to restore initial state of the buffer
-    // without recreating the buffer.
-    void reset();
-
-    void setSubBuffer(ReadBuffer & sub_buf_);
-
     const ReadBuffer & getSubBuffer() const { return *sub_buf; }
 
 private:

--- a/src/Interpreters/AsynchronousInsertQueue.cpp
+++ b/src/Interpreters/AsynchronousInsertQueue.cpp
@@ -767,7 +767,6 @@ Chunk AsynchronousInsertQueue::processEntriesWithParsing(
     };
 
     StreamingFormatExecutor executor(header, format, std::move(on_error), std::move(adding_defaults_transform));
-    std::unique_ptr<ReadBuffer> last_buffer;
     auto chunk_info = std::make_shared<AsyncInsertInfo>();
     auto query_for_logging = serializeQuery(*key.query, insert_context->getSettingsRef().log_queries_cut_to_length);
 
@@ -783,11 +782,6 @@ Chunk AsynchronousInsertQueue::processEntriesWithParsing(
         auto buffer = std::make_unique<ReadBufferFromString>(*bytes);
         size_t num_bytes = bytes->size();
         size_t num_rows = executor.execute(*buffer);
-
-        /// Keep buffer, because it still can be used
-        /// in destructor, while resetting buffer at next iteration.
-        last_buffer = std::move(buffer);
-
         total_rows += num_rows;
         chunk_info->offsets.push_back(total_rows);
         chunk_info->tokens.push_back(entry->async_dedup_token);
@@ -795,8 +789,6 @@ Chunk AsynchronousInsertQueue::processEntriesWithParsing(
         add_to_async_insert_log(entry, query_for_logging, current_exception, num_rows, num_bytes);
         current_exception.clear();
     }
-
-    format->addBuffer(std::move(last_buffer));
 
     Chunk chunk(executor.getResultColumns(), total_rows);
     chunk.setChunkInfo(std::move(chunk_info));

--- a/src/Processors/Executors/StreamingFormatExecutor.cpp
+++ b/src/Processors/Executors/StreamingFormatExecutor.cpp
@@ -34,15 +34,13 @@ MutableColumns StreamingFormatExecutor::getResultColumns()
 
 size_t StreamingFormatExecutor::execute(ReadBuffer & buffer)
 {
-    auto & initial_buf = format->getReadBuffer();
     format->setReadBuffer(buffer);
-    size_t rows = execute();
+
     /// Format destructor can touch read buffer (for example when we use PeekableReadBuffer),
     /// but we cannot control lifetime of provided read buffer. To avoid heap use after free
-    /// we can set initial read buffer back, because initial read buffer was created before
-    /// format, so it will be destructed after it.
-    format->setReadBuffer(initial_buf);
-    return rows;
+    /// we call format->resetReadBuffer() method that resets all buffers inside format.
+    SCOPE_EXIT(format->resetReadBuffer());
+    return execute();
 }
 
 size_t StreamingFormatExecutor::execute()

--- a/src/Processors/Formats/IInputFormat.cpp
+++ b/src/Processors/Formats/IInputFormat.cpp
@@ -24,7 +24,6 @@ void IInputFormat::resetParser()
 
 void IInputFormat::setReadBuffer(ReadBuffer & in_)
 {
-    chassert(in); // not supported by random-access formats
     in = &in_;
 }
 

--- a/src/Processors/Formats/IInputFormat.h
+++ b/src/Processors/Formats/IInputFormat.h
@@ -36,7 +36,7 @@ public:
     virtual void resetParser();
 
     virtual void setReadBuffer(ReadBuffer & in_);
-    ReadBuffer & getReadBuffer() const { chassert(in); return *in; }
+    virtual void resetReadBuffer() { in = nullptr; }
 
     virtual const BlockMissingValues & getMissingValues() const
     {
@@ -61,6 +61,8 @@ public:
     void needOnlyCount() { need_only_count = true; }
 
 protected:
+    ReadBuffer & getReadBuffer() const { chassert(in); return *in; }
+
     virtual Chunk getChunkForCount(size_t rows);
 
     ColumnMappingPtr column_mapping{};

--- a/src/Processors/Formats/Impl/ArrowBufferedStreams.cpp
+++ b/src/Processors/Formats/Impl/ArrowBufferedStreams.cpp
@@ -7,7 +7,6 @@
 #include <IO/ReadBufferFromFileDescriptor.h>
 #include <IO/WriteBufferFromString.h>
 #include <IO/copyData.h>
-#include <IO/PeekableReadBuffer.h>
 #include <arrow/buffer.h>
 #include <arrow/util/future.h>
 #include <arrow/io/memory.h>

--- a/src/Processors/Formats/Impl/CSVRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/CSVRowInputFormat.cpp
@@ -106,13 +106,14 @@ void CSVRowInputFormat::syncAfterError()
 
 void CSVRowInputFormat::setReadBuffer(ReadBuffer & in_)
 {
-    buf->setSubBuffer(in_);
+    buf = std::make_unique<PeekableReadBuffer>(in_);
+    RowInputFormatWithNamesAndTypes::setReadBuffer(*buf);
 }
 
-void CSVRowInputFormat::resetParser()
+void CSVRowInputFormat::resetReadBuffer()
 {
-    RowInputFormatWithNamesAndTypes::resetParser();
-    buf->reset();
+    buf.reset();
+    RowInputFormatWithNamesAndTypes::resetReadBuffer();
 }
 
 void CSVFormatReader::skipRow()

--- a/src/Processors/Formats/Impl/CSVRowInputFormat.h
+++ b/src/Processors/Formats/Impl/CSVRowInputFormat.h
@@ -27,7 +27,7 @@ public:
     String getName() const override { return "CSVRowInputFormat"; }
 
     void setReadBuffer(ReadBuffer & in_) override;
-    void resetParser() override;
+    void resetReadBuffer() override;
 
 protected:
     CSVRowInputFormat(const Block & header_, std::shared_ptr<PeekableReadBuffer> in_, const Params & params_,

--- a/src/Processors/Formats/Impl/CustomSeparatedRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/CustomSeparatedRowInputFormat.cpp
@@ -91,19 +91,20 @@ void CustomSeparatedRowInputFormat::syncAfterError()
 
 void CustomSeparatedRowInputFormat::setReadBuffer(ReadBuffer & in_)
 {
-    buf->setSubBuffer(in_);
+    buf = std::make_unique<PeekableReadBuffer>(in_);
+    RowInputFormatWithNamesAndTypes::setReadBuffer(*buf);
+}
+
+void CustomSeparatedRowInputFormat::resetReadBuffer()
+{
+    buf.reset();
+    RowInputFormatWithNamesAndTypes::resetReadBuffer();
 }
 
 CustomSeparatedFormatReader::CustomSeparatedFormatReader(
     PeekableReadBuffer & buf_, bool ignore_spaces_, const FormatSettings & format_settings_)
     : FormatWithNamesAndTypesReader(buf_, format_settings_), buf(&buf_), ignore_spaces(ignore_spaces_)
 {
-}
-
-void CustomSeparatedRowInputFormat::resetParser()
-{
-    RowInputFormatWithNamesAndTypes::resetParser();
-    buf->reset();
 }
 
 void CustomSeparatedFormatReader::skipPrefixBeforeHeader()

--- a/src/Processors/Formats/Impl/CustomSeparatedRowInputFormat.h
+++ b/src/Processors/Formats/Impl/CustomSeparatedRowInputFormat.h
@@ -18,9 +18,9 @@ public:
         const Params & params_,
         bool with_names_, bool with_types_, bool ignore_spaces_, const FormatSettings & format_settings_);
 
-    void resetParser() override;
     String getName() const override { return "CustomSeparatedRowInputFormat"; }
     void setReadBuffer(ReadBuffer & in_) override;
+    void resetReadBuffer() override;
 
 private:
     CustomSeparatedRowInputFormat(

--- a/src/Processors/Formats/Impl/JSONAsStringRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/JSONAsStringRowInputFormat.cpp
@@ -27,12 +27,18 @@ JSONAsRowInputFormat::JSONAsRowInputFormat(const Block & header_, std::unique_pt
             header_.columns());
 }
 
-void JSONAsRowInputFormat::resetParser()
+
+void JSONAsRowInputFormat::setReadBuffer(ReadBuffer & in_)
 {
-    JSONEachRowRowInputFormat::resetParser();
-    buf->reset();
+    buf = std::make_unique<PeekableReadBuffer>(in_);
+    JSONEachRowRowInputFormat::setReadBuffer(*buf);
 }
 
+void JSONAsRowInputFormat::resetReadBuffer()
+{
+    buf.reset();
+    JSONEachRowRowInputFormat::resetReadBuffer();
+}
 
 bool JSONAsRowInputFormat::readRow(MutableColumns & columns, RowReadExtension &)
 {
@@ -67,12 +73,6 @@ bool JSONAsRowInputFormat::readRow(MutableColumns & columns, RowReadExtension &)
 
     return !buf->eof();
 }
-
-void JSONAsRowInputFormat::setReadBuffer(ReadBuffer & in_)
-{
-    buf->setSubBuffer(in_);
-}
-
 
 JSONAsStringRowInputFormat::JSONAsStringRowInputFormat(
     const Block & header_, ReadBuffer & in_, Params params_, const FormatSettings & format_settings_)

--- a/src/Processors/Formats/Impl/JSONAsStringRowInputFormat.h
+++ b/src/Processors/Formats/Impl/JSONAsStringRowInputFormat.h
@@ -18,8 +18,8 @@ class JSONAsRowInputFormat : public JSONEachRowRowInputFormat
 public:
     JSONAsRowInputFormat(const Block & header_, ReadBuffer & in_, Params params_, const FormatSettings & format_settings);
 
-    void resetParser() override;
     void setReadBuffer(ReadBuffer & in_) override;
+    void resetReadBuffer() override;
 
 private:
     JSONAsRowInputFormat(const Block & header_, std::unique_ptr<PeekableReadBuffer> buf_, Params params_, const FormatSettings & format_settings);

--- a/src/Processors/Formats/Impl/JSONRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/JSONRowInputFormat.cpp
@@ -60,13 +60,14 @@ void JSONRowInputFormat::readSuffix()
 
 void JSONRowInputFormat::setReadBuffer(DB::ReadBuffer & in_)
 {
-    peekable_buf->setSubBuffer(in_);
+    peekable_buf = std::make_unique<PeekableReadBuffer>(in_);
+    JSONEachRowRowInputFormat::setReadBuffer(*peekable_buf);
 }
 
-void JSONRowInputFormat::resetParser()
+void JSONRowInputFormat::resetReadBuffer()
 {
-    JSONEachRowRowInputFormat::resetParser();
-    peekable_buf->reset();
+    peekable_buf.reset();
+    JSONEachRowRowInputFormat::resetReadBuffer();
 }
 
 JSONRowSchemaReader::JSONRowSchemaReader(ReadBuffer & in_, const FormatSettings & format_settings_)

--- a/src/Processors/Formats/Impl/JSONRowInputFormat.h
+++ b/src/Processors/Formats/Impl/JSONRowInputFormat.h
@@ -24,7 +24,7 @@ public:
     String getName() const override { return "JSONRowInputFormat"; }
 
     void setReadBuffer(ReadBuffer & in_) override;
-    void resetParser() override;
+    void resetReadBuffer() override;
 
 private:
     JSONRowInputFormat(

--- a/src/Processors/Formats/Impl/MsgPackRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/MsgPackRowInputFormat.cpp
@@ -56,8 +56,19 @@ MsgPackRowInputFormat::MsgPackRowInputFormat(const Block & header_, std::unique_
 void MsgPackRowInputFormat::resetParser()
 {
     IRowInputFormat::resetParser();
-    buf->reset();
     visitor.reset();
+}
+
+void MsgPackRowInputFormat::setReadBuffer(ReadBuffer & in_)
+{
+    buf = std::make_unique<PeekableReadBuffer>(in_);
+    IRowInputFormat::setReadBuffer(*buf);
+}
+
+void MsgPackRowInputFormat::resetReadBuffer()
+{
+    buf.reset();
+    IRowInputFormat::resetReadBuffer();
 }
 
 void MsgPackVisitor::set_info(IColumn & column, DataTypePtr type, UInt8 & read) // NOLINT
@@ -541,11 +552,6 @@ bool MsgPackRowInputFormat::readRow(MutableColumns & columns, RowReadExtension &
         return false;
     }
     return true;
-}
-
-void MsgPackRowInputFormat::setReadBuffer(ReadBuffer & in_)
-{
-    buf->setSubBuffer(in_);
 }
 
 MsgPackSchemaReader::MsgPackSchemaReader(ReadBuffer & in_, const FormatSettings & format_settings_)

--- a/src/Processors/Formats/Impl/MsgPackRowInputFormat.h
+++ b/src/Processors/Formats/Impl/MsgPackRowInputFormat.h
@@ -69,6 +69,7 @@ public:
     String getName() const override { return "MagPackRowInputFormat"; }
     void resetParser() override;
     void setReadBuffer(ReadBuffer & in_) override;
+    void resetReadBuffer() override;
 
 private:
     MsgPackRowInputFormat(const Block & header_, std::unique_ptr<PeekableReadBuffer> buf_, Params params_, const FormatSettings & settings);

--- a/src/Processors/Formats/Impl/RegexpRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/RegexpRowInputFormat.cpp
@@ -84,10 +84,16 @@ RegexpRowInputFormat::RegexpRowInputFormat(
 {
 }
 
-void RegexpRowInputFormat::resetParser()
+void RegexpRowInputFormat::setReadBuffer(ReadBuffer & in_)
 {
-    IRowInputFormat::resetParser();
-    buf->reset();
+    buf = std::make_unique<PeekableReadBuffer>(in_);
+    IRowInputFormat::setReadBuffer(*buf);
+}
+
+void RegexpRowInputFormat::resetReadBuffer()
+{
+    buf.reset();
+    IRowInputFormat::resetReadBuffer();
 }
 
 bool RegexpRowInputFormat::readField(size_t index, MutableColumns & columns)
@@ -126,11 +132,6 @@ bool RegexpRowInputFormat::readRow(MutableColumns & columns, RowReadExtension & 
     if (field_extractor.parseRow(*buf))
         readFieldsFromMatch(columns, ext);
     return true;
-}
-
-void RegexpRowInputFormat::setReadBuffer(ReadBuffer & in_)
-{
-    buf->setSubBuffer(in_);
 }
 
 RegexpSchemaReader::RegexpSchemaReader(ReadBuffer & in_, const FormatSettings & format_settings_)

--- a/src/Processors/Formats/Impl/RegexpRowInputFormat.h
+++ b/src/Processors/Formats/Impl/RegexpRowInputFormat.h
@@ -61,8 +61,8 @@ public:
     RegexpRowInputFormat(ReadBuffer & in_, const Block & header_, Params params_, const FormatSettings & format_settings_);
 
     String getName() const override { return "RegexpRowInputFormat"; }
-    void resetParser() override;
     void setReadBuffer(ReadBuffer & in_) override;
+    void resetReadBuffer() override;
 
 private:
     RegexpRowInputFormat(std::unique_ptr<PeekableReadBuffer> buf_, const Block & header_, Params params_, const FormatSettings & format_settings_);

--- a/src/Processors/Formats/Impl/TabSeparatedRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/TabSeparatedRowInputFormat.cpp
@@ -67,13 +67,14 @@ TabSeparatedRowInputFormat::TabSeparatedRowInputFormat(
 
 void TabSeparatedRowInputFormat::setReadBuffer(ReadBuffer & in_)
 {
-    buf->setSubBuffer(in_);
+    buf = std::make_unique<PeekableReadBuffer>(in_);
+    RowInputFormatWithNamesAndTypes::setReadBuffer(*buf);
 }
 
-void TabSeparatedRowInputFormat::resetParser()
+void TabSeparatedRowInputFormat::resetReadBuffer()
 {
-    RowInputFormatWithNamesAndTypes::resetParser();
-    buf->reset();
+    buf.reset();
+    RowInputFormatWithNamesAndTypes::resetReadBuffer();
 }
 
 TabSeparatedFormatReader::TabSeparatedFormatReader(PeekableReadBuffer & in_, const FormatSettings & format_settings_, bool is_raw_)

--- a/src/Processors/Formats/Impl/TabSeparatedRowInputFormat.h
+++ b/src/Processors/Formats/Impl/TabSeparatedRowInputFormat.h
@@ -23,7 +23,7 @@ public:
     String getName() const override { return "TabSeparatedRowInputFormat"; }
 
     void setReadBuffer(ReadBuffer & in_) override;
-    void resetParser() override;
+    void resetReadBuffer() override;
 
 private:
     TabSeparatedRowInputFormat(const Block & header_, std::unique_ptr<PeekableReadBuffer> in_, const Params & params_,

--- a/src/Processors/Formats/Impl/TemplateRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/TemplateRowInputFormat.cpp
@@ -288,12 +288,19 @@ void TemplateRowInputFormat::resetParser()
 {
     RowInputFormatWithDiagnosticInfo::resetParser();
     end_of_stream = false;
-    buf->reset();
 }
 
 void TemplateRowInputFormat::setReadBuffer(ReadBuffer & in_)
 {
-    buf->setSubBuffer(in_);
+    buf = std::make_unique<PeekableReadBuffer>(in_);
+    RowInputFormatWithDiagnosticInfo::setReadBuffer(*buf);
+    format_reader->setReadBuffer(*buf);
+}
+
+void TemplateRowInputFormat::resetReadBuffer()
+{
+    buf.reset();
+    RowInputFormatWithDiagnosticInfo::resetReadBuffer();
 }
 
 TemplateFormatReader::TemplateFormatReader(

--- a/src/Processors/Formats/Impl/TemplateRowInputFormat.h
+++ b/src/Processors/Formats/Impl/TemplateRowInputFormat.h
@@ -28,6 +28,8 @@ public:
     String getName() const override { return "TemplateRowInputFormat"; }
 
     void resetParser() override;
+    void setReadBuffer(ReadBuffer & in_) override;
+    void resetReadBuffer() override;
 
 private:
     TemplateRowInputFormat(const Block & header_, std::unique_ptr<PeekableReadBuffer> buf_, const Params & params_,
@@ -49,8 +51,6 @@ private:
     void tryDeserializeField(const DataTypePtr & type, IColumn & column, size_t file_column) override;
 
     bool isGarbageAfterField(size_t after_col_idx, ReadBuffer::Position pos) override;
-
-    void setReadBuffer(ReadBuffer & in_) override;
 
     std::unique_ptr<PeekableReadBuffer> buf;
     const DataTypes data_types;

--- a/src/Processors/Formats/Impl/ValuesBlockInputFormat.cpp
+++ b/src/Processors/Formats/Impl/ValuesBlockInputFormat.cpp
@@ -642,13 +642,19 @@ void ValuesBlockInputFormat::resetParser()
     IInputFormat::resetParser();
     // I'm not resetting parser modes here.
     // There is a good chance that all messages have the same format.
-    buf->reset();
     total_rows = 0;
 }
 
 void ValuesBlockInputFormat::setReadBuffer(ReadBuffer & in_)
 {
-    buf->setSubBuffer(in_);
+    buf = std::make_unique<PeekableReadBuffer>(in_);
+    IInputFormat::setReadBuffer(*buf);
+}
+
+void ValuesBlockInputFormat::resetReadBuffer()
+{
+    buf.reset();
+    IInputFormat::resetReadBuffer();
 }
 
 ValuesSchemaReader::ValuesSchemaReader(ReadBuffer & in_, const FormatSettings & format_settings_)

--- a/src/Processors/Formats/Impl/ValuesBlockInputFormat.h
+++ b/src/Processors/Formats/Impl/ValuesBlockInputFormat.h
@@ -34,6 +34,7 @@ public:
 
     void resetParser() override;
     void setReadBuffer(ReadBuffer & in_) override;
+    void resetReadBuffer() override;
 
     /// TODO: remove context somehow.
     void setContext(ContextPtr & context_) { context = Context::createCopy(context_); }

--- a/tests/integration/test_storage_kafka/clickhouse_path/format_schemas/key_value_message.capnp
+++ b/tests/integration/test_storage_kafka/clickhouse_path/format_schemas/key_value_message.capnp
@@ -1,0 +1,7 @@
+@0x99f75f775fe63dae;
+
+struct Message
+{
+    key @0 : UInt64;
+    value @1 : UInt64;
+}

--- a/tests/integration/test_storage_kafka/clickhouse_path/format_schemas/key_value_message.proto
+++ b/tests/integration/test_storage_kafka/clickhouse_path/format_schemas/key_value_message.proto
@@ -1,0 +1,6 @@
+syntax = "proto3";
+
+message Message {
+    uint64 key = 1;
+    uint64 value = 1;
+}

--- a/tests/integration/test_storage_kafka/test.py
+++ b/tests/integration/test_storage_kafka/test.py
@@ -4865,7 +4865,7 @@ def test_formats_errors(kafka_cluster):
         "JSONColumns",
         "JSONCompactColumns",
         "JSONColumnsWithMetadata",
-        "BSONEachRow"
+        "BSONEachRow",
         "Native",
         "Arrow",
         "Parquet",
@@ -4905,12 +4905,20 @@ def test_formats_errors(kafka_cluster):
         """
         )
 
-        kafka_produce(kafka_cluster, format_name, ["Broken message\nBroken message\nBroken message\n"])
+        kafka_produce(
+            kafka_cluster,
+            format_name,
+            ["Broken message\nBroken message\nBroken message\n"]
+        )
 
         attempt = 0
         num_errors = 0
         while attempt < 200:
-            num_errors = int(instance.query(f"SELECT length(exceptions.text) from system.kafka_consumers where database = 'test' and table = '{table_name}'"))
+            num_errors = int(
+                instance.query(
+                    f"SELECT length(exceptions.text) from system.kafka_consumers where database = 'test' and table = '{table_name}'"
+                )
+            )
             if num_errors > 0:
                 break
             attempt += 1

--- a/tests/integration/test_storage_kafka/test.py
+++ b/tests/integration/test_storage_kafka/test.py
@@ -4834,6 +4834,94 @@ JSONExtractString(rdkafka_stat, 'type'): consumer
     kafka_delete_topic(admin_client, topic)
 
 
+def test_formats_errors(kafka_cluster):
+    admin_client = KafkaAdminClient(
+        bootstrap_servers="localhost:{}".format(kafka_cluster.kafka_port)
+    )
+
+    for format_name in [
+        "Template",
+        "Regexp",
+        "TSV",
+        "TSVWithNamesAndTypes",
+        "TSKV",
+        "CSV",
+        "CSVWithNames",
+        "CSVWithNamesAndTypes",
+        "CustomSeparated",
+        "CustomSeparatedWithNames",
+        "CustomSeparatedWithNamesAndTypes",
+        "Values",
+        "JSON",
+        "JSONEachRow",
+        "JSONStringsEachRow",
+        "JSONCompactEachRow",
+        "JSONCompactEachRowWithNamesAndTypes",
+        "JSONObjectEachRow",
+        "Avro",
+        "RowBinary",
+        "RowBinaryWithNamesAndTypes",
+        "MsgPack",
+        "JSONColumns",
+        "JSONCompactColumns",
+        "JSONColumnsWithMetadata",
+        "BSONEachRow"
+        "Native",
+        "Arrow",
+        "Parquet",
+        "ORC",
+        "JSONCompactColumns",
+        "Npy",
+        "ParquetMetadata",
+        "CapnProto",
+        "Protobuf",
+        "ProtobufSingle",
+        "ProtobufList",
+        "DWARF",
+        "HiveText",
+        "MySQLDump",
+    ]:
+        kafka_create_topic(admin_client, format_name)
+        table_name = f"kafka_{format_name}"
+
+        instance.query(
+            f"""
+            DROP TABLE IF EXISTS test.view;
+            DROP TABLE IF EXISTS test.{table_name};
+
+            CREATE TABLE test.{table_name} (key UInt64, value UInt64)
+                ENGINE = Kafka
+                SETTINGS kafka_broker_list = 'kafka1:19092',
+                         kafka_topic_list = '{format_name}',
+                         kafka_group_name = '{format_name}',
+                         kafka_format = '{format_name}',
+                         kafka_max_rows_per_message = 5,
+                         format_template_row='template_row.format',
+                         format_regexp='id: (.+?)',
+                         input_format_with_names_use_header=0;
+
+            CREATE MATERIALIZED VIEW test.view Engine=Log AS
+                SELECT key, value FROM test.{table_name};
+        """
+        )
+
+        kafka_produce(kafka_cluster, format_name, ["Broken message\nBroken message\nBroken message\n"])
+
+        attempt = 0
+        num_errors = 0
+        while attempt < 200:
+            num_errors = int(instance.query(f"SELECT length(exceptions.text) from system.kafka_consumers where database = 'test' and table = '{table_name}'"))
+            if num_errors > 0:
+                break
+            attempt += 1
+
+        assert num_errors > 0
+
+        kafka_delete_topic(admin_client, format_name)
+        instance.query(f"DROP TABLE test.{table_name}")
+        instance.query("DROP TABLE test.view")
+
+
 if __name__ == "__main__":
     cluster.start()
     input("Cluster created, press any key to destroy...")

--- a/tests/integration/test_storage_kafka/test.py
+++ b/tests/integration/test_storage_kafka/test.py
@@ -4908,7 +4908,7 @@ def test_formats_errors(kafka_cluster):
         kafka_produce(
             kafka_cluster,
             format_name,
-            ["Broken message\nBroken message\nBroken message\n"]
+            ["Broken message\nBroken message\nBroken message\n"],
         )
 
         attempt = 0

--- a/tests/integration/test_storage_kafka/test.py
+++ b/tests/integration/test_storage_kafka/test.py
@@ -4898,7 +4898,8 @@ def test_formats_errors(kafka_cluster):
                          kafka_max_rows_per_message = 5,
                          format_template_row='template_row.format',
                          format_regexp='id: (.+?)',
-                         input_format_with_names_use_header=0;
+                         input_format_with_names_use_header=0,
+                         format_schema='key_value_message:Message';
 
             CREATE MATERIALIZED VIEW test.view Engine=Log AS
                 SELECT key, value FROM test.{table_name};


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix working with read buffers in StreamingFormatExecutor, previously it could lead to segfaults in Kafka and other streaming engines.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
