### PR TITLE
docs: fix arrayFold/arrayReduce anchors in see also section

### DIFF
--- a/docs/en/sql-reference/functions/array-functions.md
+++ b/docs/en/sql-reference/functions/array-functions.md
@@ -1175,7 +1175,7 @@ FROM numbers(1,10);
 
 **See also**
 
-- [arrayReduce](#arrayReduce)
+- [arrayReduce](#arrayreduce)
 
 ## arrayReverse(arr)
 

--- a/docs/en/sql-reference/functions/array-functions.md
+++ b/docs/en/sql-reference/functions/array-functions.md
@@ -1083,7 +1083,7 @@ Result:
 
 **See also**
 
-- [arrayFold](#arrayFold)
+- [arrayFold](#arrayfold)
 
 ## arrayReduceInRanges
 


### PR DESCRIPTION
The anchor tag for `arrayFold` in the `See also` section of [arrayReduce](https://clickhouse.com/docs/en/sql-reference/functions/array-functions#arrayreduce) does not work as the casing is incorrect.

### Changelog category (leave one):
- Documentation (changelog entry is not required)