### PR TITLE
Fix RWLock inconsistency after write lock timeout

### DIFF
--- a/src/Common/RWLock.cpp
+++ b/src/Common/RWLock.cpp
@@ -3,6 +3,8 @@
 #include <Common/Exception.h>
 #include <Common/CurrentMetrics.h>
 #include <Common/ProfileEvents.h>
+#include <IO/Operators.h>
+#include <IO/WriteBufferFromString.h>
 
 
 namespace ProfileEvents
@@ -155,12 +157,19 @@ RWLockImpl::getLock(RWLockImpl::Type type, const String & query_id, const std::c
 
     if (type == Type::Write)
     {
+        /// Always add a group for a writer (writes are never performed simultaneously).
         writers_queue.emplace_back(type);  /// SM1: may throw (nothing to roll back)
     }
-    else if (readers_queue.empty() ||
-            (rdlock_owner == readers_queue.begin() && readers_queue.size() == 1 && !writers_queue.empty()))
+    else
     {
-        readers_queue.emplace_back(type);  /// SM1: may throw (nothing to roll back)
+        /// We don't always add a group to readers_queue here because multiple readers can use the same group.
+        /// We can reuse the last group if we're in write phase now, or if the last group didn't get ownership yet,
+        /// or even if it got ownership but there are no writers waiting in writers_queue.
+        bool can_use_last_group = !readers_queue.empty() &&
+            ((rdlock_owner == readers_queue.end()) || !rdlock_owner->ownership || writers_queue.empty());
+
+        if (!can_use_last_group)
+            readers_queue.emplace_back(type);  /// SM1: may throw (nothing to roll back)
     }
     GroupsContainer::iterator it_group =
             (type == Type::Write) ? std::prev(writers_queue.end()) : std::prev(readers_queue.end());
@@ -169,11 +178,12 @@ RWLockImpl::getLock(RWLockImpl::Type type, const String & query_id, const std::c
     if (rdlock_owner == readers_queue.end() && wrlock_owner == writers_queue.end())
     {
         (type == Read ? rdlock_owner : wrlock_owner) = it_group;  /// SM2: nothrow
+        grantOwnership(it_group);
     }
     else
     {
         /// Wait until our group becomes the lock owner
-        const auto predicate = [&] () { return it_group == (type == Read ? rdlock_owner : wrlock_owner); };
+        const auto predicate = [&] () { return it_group->ownership; };
 
         if (lock_deadline_tp == std::chrono::time_point<std::chrono::steady_clock>::max())
         {
@@ -193,10 +203,12 @@ RWLockImpl::getLock(RWLockImpl::Type type, const String & query_id, const std::c
                 /// Rollback(SM1): nothrow
                 if (it_group->requests == 0)
                 {
-                    /// When WRITE lock fails, we need to notify next read that is waiting,
-                    /// to avoid handing request, hence next=true.
-                    dropOwnerGroupAndPassOwnership(it_group, /* next= */ true);
+                    ((type == Read) ? readers_queue : writers_queue).erase(it_group);
                 }
+                /// While we were waiting for this write lock (which has just failed) more readers could start waiting,
+                /// we need to wake up them now.
+                if ((rdlock_owner != readers_queue.end()) && writers_queue.empty())
+                    grantOwnershipToAllReaders();
                 return nullptr;
             }
         }
@@ -216,7 +228,7 @@ RWLockImpl::getLock(RWLockImpl::Type type, const String & query_id, const std::c
             /// Methods std::list<>::emplace_back() and std::unordered_map<>::emplace() provide strong exception safety
             /// We only need to roll back the changes to these objects: owner_queries and the readers/writers queue
             if (it_group->requests == 0)
-                dropOwnerGroupAndPassOwnership(it_group, /* next= */ false);  /// Rollback(SM1): nothrow
+                dropOwnerGroupAndPassOwnership(it_group);  /// Rollback(SM1): nothrow
 
             throw;
         }
@@ -246,8 +258,6 @@ void RWLockImpl::unlock(GroupsContainer::iterator group_it, const String & query
     /// All of these are Undefined behavior and nothing we can do!
     if (rdlock_owner == readers_queue.end() && wrlock_owner == writers_queue.end())
         return;
-    if (rdlock_owner != readers_queue.end() && group_it != rdlock_owner)
-        return;
     if (wrlock_owner != writers_queue.end() && group_it != wrlock_owner)
         return;
 
@@ -264,12 +274,26 @@ void RWLockImpl::unlock(GroupsContainer::iterator group_it, const String & query
 
     /// If we are the last remaining referrer, remove this QNode and notify the next one
     if (--group_it->requests == 0)               /// SM: nothrow
-        dropOwnerGroupAndPassOwnership(group_it, /* next= */ false);
+        dropOwnerGroupAndPassOwnership(group_it);
 }
 
 
-void RWLockImpl::dropOwnerGroupAndPassOwnership(GroupsContainer::iterator group_it, bool next) noexcept
+void RWLockImpl::dropOwnerGroupAndPassOwnership(GroupsContainer::iterator group_it) noexcept
 {
+    /// All readers with ownership must finish before switching to write phase.
+    /// Such readers has iterators from `readers_queue.begin()` to `rdlock_owner`, so if `rdlock_owner` is equal to `readers_queue.begin()`
+    /// that means there is only one reader with ownership left in the readers_queue and we can proceed to generic procedure.
+    if ((group_it->type == Read) && (rdlock_owner != readers_queue.begin()) && (rdlock_owner != readers_queue.end()))
+    {
+        if (rdlock_owner == group_it)
+            --rdlock_owner;
+        readers_queue.erase(group_it);
+        /// If there are no writers waiting in writers_queue then we can wake up other readers.
+        if (writers_queue.empty())
+            grantOwnershipToAllReaders();
+        return;
+    }
+
     rdlock_owner = readers_queue.end();
     wrlock_owner = writers_queue.end();
 
@@ -278,42 +302,78 @@ void RWLockImpl::dropOwnerGroupAndPassOwnership(GroupsContainer::iterator group_
         readers_queue.erase(group_it);
         /// Prepare next phase
         if (!writers_queue.empty())
-        {
             wrlock_owner = writers_queue.begin();
-        }
         else
-        {
             rdlock_owner = readers_queue.begin();
-        }
     }
     else
     {
         writers_queue.erase(group_it);
         /// Prepare next phase
         if (!readers_queue.empty())
-        {
-            if (next && readers_queue.size() > 1)
-            {
-                rdlock_owner = std::next(readers_queue.begin());
-            }
-            else
-            {
-                rdlock_owner = readers_queue.begin();
-            }
-        }
+            rdlock_owner = readers_queue.begin();
         else
-        {
             wrlock_owner = writers_queue.begin();
-        }
     }
 
     if (rdlock_owner != readers_queue.end())
     {
-        rdlock_owner->cv.notify_all();
+        grantOwnershipToAllReaders();
     }
     else if (wrlock_owner != writers_queue.end())
     {
-        wrlock_owner->cv.notify_one();
+        grantOwnership(wrlock_owner);
     }
 }
+
+
+void RWLockImpl::grantOwnership(GroupsContainer::iterator group_it) noexcept
+{
+    if (!group_it->ownership)
+    {
+        group_it->ownership = true;
+        group_it->cv.notify_all();
+    }
+}
+
+
+void RWLockImpl::grantOwnershipToAllReaders() noexcept
+{
+    if (rdlock_owner != readers_queue.end())
+    {
+        for (;;)
+        {
+            grantOwnership(rdlock_owner);
+            if (std::next(rdlock_owner) == readers_queue.end())
+                break;
+            ++rdlock_owner;
+        }
+    }
+}
+
+
+std::unordered_map<String, size_t> RWLockImpl::getOwnerQueryIds() const
+{
+    std::lock_guard lock{internal_state_mtx};
+    return owner_queries;
+}
+
+
+String RWLockImpl::getOwnerQueryIdsDescription() const
+{
+    auto map = getOwnerQueryIds();
+    WriteBufferFromOwnString out;
+    bool need_comma = false;
+    for (const auto & [query_id, num_owners] : map)
+    {
+        if (need_comma)
+            out << ", ";
+        out << query_id;
+        if (num_owners != 1)
+            out << " (" << num_owners << ")";
+        need_comma = true;
+    }
+    return out.str();
+}
+
 }

--- a/src/Common/tests/gtest_rw_lock.cpp
+++ b/src/Common/tests/gtest_rw_lock.cpp
@@ -24,6 +24,39 @@ namespace DB
 }
 
 
+namespace
+{
+    class Events
+    {
+    public:
+        Events() : start_time(std::chrono::steady_clock::now()) {}
+
+        void add(String && event)
+        {
+            String timepoint = std::to_string(std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_time).count());
+            if (timepoint.length() < 5)
+                timepoint.insert(0, 5 - timepoint.length(), ' ');
+            std::lock_guard lock{mutex};
+            std::cout << timepoint << " : " << event << std::endl;
+            events.emplace_back(std::move(event));
+        }
+
+        void check(const Strings & expected_events)
+        {
+            std::lock_guard lock{mutex};
+            EXPECT_EQ(events.size(), expected_events.size());
+            for (size_t i = 0; i != events.size(); ++i)
+                EXPECT_EQ(events[i], (i < expected_events.size() ? expected_events[i] : ""));
+        }
+
+    private:
+        const std::chrono::time_point<std::chrono::steady_clock> start_time;
+        Strings events TSA_GUARDED_BY(mutex);
+        mutable std::mutex mutex;
+    };
+}
+
+
 TEST(Common, RWLock1)
 {
     /// Tests with threads require this, because otherwise
@@ -286,4 +319,201 @@ TEST(Common, RWLockNotUpgradeableWithNoQuery)
     }
 
     read_thread.join();
+}
+
+
+TEST(Common, RWLockWriteLockTimeoutDuringRead)
+{
+    static auto rw_lock = RWLockImpl::create();
+    Events events;
+
+    std::thread ra_thread([&] ()
+    {
+        events.add("Locking ra");
+        auto ra = rw_lock->getLock(RWLockImpl::Read, "ra");
+        events.add(ra ? "Locked ra" : "Failed to lock ra");
+        EXPECT_NE(ra, nullptr);
+
+        std::this_thread::sleep_for(std::chrono::duration<int, std::milli>(400));
+
+        events.add("Unlocking ra");
+        ra.reset();
+        events.add("Unlocked ra");
+    });
+
+    std::thread wc_thread([&] ()
+    {
+        std::this_thread::sleep_for(std::chrono::duration<int, std::milli>(100));
+        events.add("Locking wc");
+        auto wc = rw_lock->getLock(RWLockImpl::Write, "wc", std::chrono::milliseconds(200));
+        events.add(wc ? "Locked wc" : "Failed to lock wc");
+        EXPECT_EQ(wc, nullptr);
+    });
+
+    ra_thread.join();
+    wc_thread.join();
+
+    {
+        events.add("Locking wd");
+        auto wd = rw_lock->getLock(RWLockImpl::Write, "wd", std::chrono::milliseconds(1000));
+        events.add(wd ? "Locked wd" : "Failed to lock wd");
+        EXPECT_NE(wd, nullptr);
+        events.add("Unlocking wd");
+        wd.reset();
+        events.add("Unlocked wd");
+    }
+
+    events.check(
+        {"Locking ra",
+         "Locked ra",
+         "Locking wc",
+         "Failed to lock wc",
+         "Unlocking ra",
+         "Unlocked ra",
+         "Locking wd",
+         "Locked wd",
+         "Unlocking wd",
+         "Unlocked wd"});
+}
+
+
+TEST(Common, RWLockWriteLockTimeoutDuringTwoReads)
+{
+    static auto rw_lock = RWLockImpl::create();
+    Events events;
+
+    std::thread ra_thread([&] ()
+    {
+        events.add("Locking ra");
+        auto ra = rw_lock->getLock(RWLockImpl::Read, "ra");
+        events.add(ra ? "Locked ra" : "Failed to lock ra");
+        EXPECT_NE(ra, nullptr);
+
+        std::this_thread::sleep_for(std::chrono::duration<int, std::milli>(400));
+
+        events.add("Unlocking ra");
+        ra.reset();
+        events.add("Unlocked ra");
+    });
+
+    std::thread rb_thread([&] ()
+    {
+        std::this_thread::sleep_for(std::chrono::duration<int, std::milli>(200));
+        events.add("Locking rb");
+
+        auto rb = rw_lock->getLock(RWLockImpl::Read, "rb");
+        events.add(rb ? "Locked rb" : "Failed to lock rb");
+        EXPECT_NE(rb, nullptr);
+
+        std::this_thread::sleep_for(std::chrono::duration<int, std::milli>(200));
+        events.add("Unlocking rb");
+        rb.reset();
+        events.add("Unlocked rb");
+    });
+
+    std::thread wc_thread([&] ()
+    {
+        std::this_thread::sleep_for(std::chrono::duration<int, std::milli>(100));
+        events.add("Locking wc");
+        auto wc = rw_lock->getLock(RWLockImpl::Write, "wc", std::chrono::milliseconds(200));
+        events.add(wc ? "Locked wc" : "Failed to lock wc");
+        EXPECT_EQ(wc, nullptr);
+    });
+
+    ra_thread.join();
+    rb_thread.join();
+    wc_thread.join();
+
+    {
+        events.add("Locking wd");
+        auto wd = rw_lock->getLock(RWLockImpl::Write, "wd", std::chrono::milliseconds(1000));
+        events.add(wd ? "Locked wd" : "Failed to lock wd");
+        EXPECT_NE(wd, nullptr);
+        events.add("Unlocking wd");
+        wd.reset();
+        events.add("Unlocked wd");
+    }
+
+    events.check(
+        {"Locking ra",
+         "Locked ra",
+         "Locking wc",
+         "Locking rb",
+         "Failed to lock wc",
+         "Locked rb",
+         "Unlocking ra",
+         "Unlocked ra",
+         "Unlocking rb",
+         "Unlocked rb",
+         "Locking wd",
+         "Locked wd",
+         "Unlocking wd",
+         "Unlocked wd"});
+}
+
+
+TEST(Common, RWLockWriteLockTimeoutDuringWriteWithWaitingRead)
+{
+    static auto rw_lock = RWLockImpl::create();
+    Events events;
+
+    std::thread wa_thread([&] ()
+    {
+        events.add("Locking wa");
+        auto wa = rw_lock->getLock(RWLockImpl::Write, "wa");
+        events.add(wa ? "Locked wa" : "Failed to lock wa");
+        EXPECT_NE(wa, nullptr);
+
+        std::this_thread::sleep_for(std::chrono::duration<int, std::milli>(500));
+
+        events.add("Unlocking wa");
+        wa.reset();
+        events.add("Unlocked wa");
+    });
+
+    std::thread wb_thread([&] ()
+    {
+        std::this_thread::sleep_for(std::chrono::duration<int, std::milli>(100));
+        events.add("Locking wb");
+        auto wc = rw_lock->getLock(RWLockImpl::Write, "wc", std::chrono::milliseconds(200));
+        events.add(wc ? "Locked wb" : "Failed to lock wb");
+        EXPECT_EQ(wc, nullptr);
+    });
+    
+    std::thread rc_thread([&] ()
+    {
+        std::this_thread::sleep_for(std::chrono::duration<int, std::milli>(200));
+        events.add("Locking rc");
+        auto rc = rw_lock->getLock(RWLockImpl::Read, "rc", std::chrono::milliseconds(200));
+        events.add(rc ? "Locked rc" : "Failed to lock rc");
+        EXPECT_EQ(rc, nullptr);
+    });
+
+    wa_thread.join();
+    wb_thread.join();
+    rc_thread.join();
+
+    {
+        events.add("Locking wd");
+        auto wd = rw_lock->getLock(RWLockImpl::Write, "wd", std::chrono::milliseconds(1000));
+        events.add(wd ? "Locked wd" : "Failed to lock wd");
+        EXPECT_NE(wd, nullptr);
+        events.add("Unlocking wd");
+        wd.reset();
+        events.add("Unlocked wd");
+    }
+
+    events.check(
+        {"Locking wa",
+         "Locked wa",
+         "Locking wb",
+         "Locking rc",
+         "Failed to lock wb",
+         "Failed to lock rc",
+         "Unlocking wa",
+         "Unlocked wa",
+         "Locking wd",
+         "Locked wd",
+         "Unlocking wd",
+         "Unlocked wd"});
 }

--- a/src/Common/tests/gtest_rw_lock.cpp
+++ b/src/Common/tests/gtest_rw_lock.cpp
@@ -37,7 +37,7 @@ namespace
             if (timepoint.length() < 5)
                 timepoint.insert(0, 5 - timepoint.length(), ' ');
             std::lock_guard lock{mutex};
-            std::cout << timepoint << " : " << event << std::endl;
+            //std::cout << timepoint << " : " << event << std::endl;
             events.emplace_back(std::move(event));
         }
 

--- a/src/Storages/IStorage.cpp
+++ b/src/Storages/IStorage.cpp
@@ -41,8 +41,8 @@ RWLockImpl::LockHolder IStorage::tryLockTimed(
     {
         const String type_str = type == RWLockImpl::Type::Read ? "READ" : "WRITE";
         throw Exception(ErrorCodes::DEADLOCK_AVOIDED,
-            "{} locking attempt on \"{}\" has timed out! ({}ms) Possible deadlock avoided. Client should retry",
-            type_str, getStorageID(), acquire_timeout.count());
+            "{} locking attempt on \"{}\" has timed out! ({}ms) Possible deadlock avoided. Client should retry. Owner query ids: {}",
+            type_str, getStorageID(), acquire_timeout.count(), rwlock->getOwnerQueryIdsDescription());
     }
     return lock_holder;
 }

--- a/tests/integration/test_backup_restore_on_cluster/test_concurrency.py
+++ b/tests/integration/test_backup_restore_on_cluster/test_concurrency.py
@@ -216,7 +216,7 @@ def test_create_or_drop_tables_during_backup(db_engine, table_engine):
             node = nodes[randint(0, num_nodes - 1)]
             # "DROP TABLE IF EXISTS" still can throw some errors (e.g. "WRITE locking attempt on node0 has timed out!")
             # So we use query_and_get_answer_with_error() to ignore any errors.
-            # `lock_acquire_timeout` is also reduced because we don't wait our test to wait too long.
+            # `lock_acquire_timeout` is reduced because we don't wait our test to wait too long.
             node.query_and_get_answer_with_error(
                 f"DROP TABLE IF EXISTS {table_name} SYNC",
                 settings={"lock_acquire_timeout": 10},
@@ -227,15 +227,23 @@ def test_create_or_drop_tables_during_backup(db_engine, table_engine):
             table_name1 = f"mydb.tbl{randint(1, num_nodes)}"
             table_name2 = f"mydb.tbl{randint(1, num_nodes)}"
             node = nodes[randint(0, num_nodes - 1)]
+            # `lock_acquire_timeout` is reduced because we don't wait our test to wait too long.
             node.query_and_get_answer_with_error(
-                f"RENAME TABLE {table_name1} TO {table_name2}"
+                f"RENAME TABLE {table_name1} TO {table_name2}",
+                settings={"lock_acquire_timeout": 10},
             )
 
     def truncate_tables():
         while time.time() < end_time:
             table_name = f"mydb.tbl{randint(1, num_nodes)}"
             node = nodes[randint(0, num_nodes - 1)]
-            node.query(f"TRUNCATE TABLE IF EXISTS {table_name} SYNC")
+            # "TRUNCATE TABLE IF EXISTS" still can throw some errors (e.g. "WRITE locking attempt on node0 has timed out!")
+            # So we use query_and_get_answer_with_error() to ignore any errors.
+            # `lock_acquire_timeout` is reduced because we don't wait our test to wait too long.
+            node.query_and_get_answer_with_error(
+                f"TRUNCATE TABLE IF EXISTS {table_name} SYNC",
+                settings={"lock_acquire_timeout": 10},
+            )
 
     def make_backups():
         ids = []

--- a/tests/integration/test_backup_restore_on_cluster/test_concurrency.py
+++ b/tests/integration/test_backup_restore_on_cluster/test_concurrency.py
@@ -237,7 +237,8 @@ def test_create_or_drop_tables_during_backup(db_engine, table_engine):
         while time.time() < end_time:
             table_name = f"mydb.tbl{randint(1, num_nodes)}"
             node = nodes[randint(0, num_nodes - 1)]
-            # "TRUNCATE TABLE IF EXISTS" still can throw some errors (e.g. "WRITE locking attempt on node0 has timed out!")
+            # "TRUNCATE TABLE IF EXISTS" still can throw some errors
+            # (e.g. "WRITE locking attempt on node0 has timed out!" if the table engine is "Log").
             # So we use query_and_get_answer_with_error() to ignore any errors.
             # `lock_acquire_timeout` is reduced because we don't wait our test to wait too long.
             node.query_and_get_answer_with_error(


### PR DESCRIPTION
### Changelog category:
- Bug Fix

### Changelog entry:
Fix RWLock inconsistency after write lock timeout.

This PR is to provide a correct fix for the issue described in the description of https://github.com/ClickHouse/ClickHouse/pull/38864. The fix provided in https://github.com/ClickHouse/ClickHouse/pull/38864 was not complete and after that fix after exclusive lock failure `RWLock` could become inconsistent and not be actually unlocked after releasing all locks. See https://github.com/ClickHouse/ClickHouse/issues/42719#issuecomment-1836237499
