### PR TITLE
Fix adjusting log_comment in case of multiple files passed

### DIFF
--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -2566,7 +2566,7 @@ bool ClientBase::processMultiQueryFromFile(const String & file_name)
     ReadBufferFromFile in(file_name);
     readStringUntilEOF(queries_from_file, in);
 
-    if (!global_context->getSettings().log_comment.changed)
+    if (!has_log_comment)
     {
         Settings settings = global_context->getSettings();
         /// NOTE: cannot use even weakly_canonical() since it fails for /dev/stdin due to resolving of "pipe:[X]"
@@ -3005,6 +3005,8 @@ void ClientBase::init(int argc, char ** argv)
         total_memory_tracker.setDescription("(total)");
         total_memory_tracker.setMetric(CurrentMetrics::MemoryTracking);
     }
+
+    has_log_comment = config().has("log_comment");
 }
 
 }

--- a/src/Client/ClientBase.h
+++ b/src/Client/ClientBase.h
@@ -321,6 +321,9 @@ protected:
     bool allow_merge_tree_settings = false;
 
     bool cancelled = false;
+
+    /// Does log_comment has specified by user?
+    bool has_log_comment = false;
 };
 
 }

--- a/tests/queries/0_stateless/02930_client_file_log_comment.reference
+++ b/tests/queries/0_stateless/02930_client_file_log_comment.reference
@@ -1,4 +1,6 @@
 42
-select 42\n	/dev/stdin
 4242
-select 4242\n	foo
+424242
+select 42	clickhouse.default-1.sql
+select 4242	clickhouse.default-2.sql
+select 424242\n	foo

--- a/tests/queries/0_stateless/02930_client_file_log_comment.sh
+++ b/tests/queries/0_stateless/02930_client_file_log_comment.sh
@@ -6,14 +6,19 @@ CLICKHOUSE_LOG_COMMENT=
 # shellcheck source=../shell_config.sh
 . "$CUR_DIR"/../shell_config.sh
 
-$CLICKHOUSE_CLIENT --queries-file /dev/stdin <<<'select 42'
-$CLICKHOUSE_CLIENT -nm -q "
-    system flush logs;
-    select query, log_comment from system.query_log where current_database = '$CLICKHOUSE_DATABASE' and event_date >= yesterday() and query = 'select 42\n' and type != 'QueryStart';
-"
+file1="$CUR_DIR/clickhouse.${CLICKHOUSE_DATABASE}-1.sql"
+echo -n 'select 42' >> "$file1"
+file2="$CUR_DIR/clickhouse.${CLICKHOUSE_DATABASE}-2.sql"
+echo -n 'select 4242' >> "$file2"
 
-$CLICKHOUSE_CLIENT --log_comment foo --queries-file /dev/stdin <<<'select 4242'
+$CLICKHOUSE_CLIENT --queries-file "$file1" "$file2" <<<'select 42'
+$CLICKHOUSE_CLIENT --log_comment foo --queries-file /dev/stdin <<<'select 424242'
+
 $CLICKHOUSE_CLIENT -nm -q "
     system flush logs;
-    select query, log_comment from system.query_log where current_database = '$CLICKHOUSE_DATABASE' and event_date >= yesterday() and query = 'select 4242\n' and type != 'QueryStart';
-"
+    select query, log_comment from system.query_log where current_database = '$CLICKHOUSE_DATABASE' and event_date >= yesterday() and query = 'select 42' and type != 'QueryStart';
+    select query, log_comment from system.query_log where current_database = '$CLICKHOUSE_DATABASE' and event_date >= yesterday() and query = 'select 4242' and type != 'QueryStart';
+    select query, log_comment from system.query_log where current_database = '$CLICKHOUSE_DATABASE' and event_date >= yesterday() and query = 'select 424242\n' and type != 'QueryStart';
+" | sed "s#$CUR_DIR/##"
+
+rm "$file1" "$file2"


### PR DESCRIPTION
Previously, due to adjusting global_context and checking it as well, in case of multiple files the log_comment will be adjusted only the first time. Fix this by caching does user passed the log_comment explicitly or not.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Follow-up for: #57191 (cc @alexey-milovidov )
Reported-by: @amosbird 