### PR TITLE
Fix possible distributed sends stuck due to "No such file or directory" (during recovering batch from disk)

### DIFF
--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -238,6 +238,7 @@
     M(DictCacheLockReadNs, "Number of nanoseconds spend in waiting for read lock to lookup the data for the dictionaries of 'cache' types.") \
     \
     M(DistributedSyncInsertionTimeoutExceeded, "A timeout has exceeded while waiting for shards during synchronous insertion into a Distributed table (with 'distributed_foreground_insert' = 1)") \
+    M(DistributedAsyncInsertionFailures, "Number of failures for asynchronous insertion into a Distributed table (with 'distributed_foreground_insert' = 0)") \
     M(DataAfterMergeDiffersFromReplica, R"(
 Number of times data after merge is not byte-identical to the data on another replicas. There could be several reasons:
 1. Using newer version of compression library after server update.

--- a/src/Storages/Distributed/DistributedAsyncInsertBatch.cpp
+++ b/src/Storages/Distributed/DistributedAsyncInsertBatch.cpp
@@ -5,6 +5,7 @@
 #include <Storages/StorageDistributed.h>
 #include <QueryPipeline/RemoteInserter.h>
 #include <Common/CurrentMetrics.h>
+#include <base/defines.h>
 #include <IO/Operators.h>
 #include <IO/WriteBufferFromFile.h>
 
@@ -163,6 +164,22 @@ void DistributedAsyncInsertBatch::deserialize()
     readText(in);
 }
 
+bool DistributedAsyncInsertBatch::valid()
+{
+    chassert(!files.empty());
+
+    bool res = true;
+    for (const auto & file : files)
+    {
+        if (!fs::exists(file))
+        {
+            LOG_WARNING(parent.log, "File {} does not exists, likely due abnormal shutdown", file);
+            res = false;
+        }
+    }
+    return res;
+}
+
 void DistributedAsyncInsertBatch::writeText(WriteBuffer & out)
 {
     for (const auto & file : files)
@@ -201,14 +218,6 @@ void DistributedAsyncInsertBatch::sendBatch()
     {
         for (const auto & file : files)
         {
-            /// In case of recovery it is possible that some of files will be
-            /// missing, if server had been restarted abnormally
-            if (recovered && !fs::exists(file))
-            {
-                LOG_WARNING(parent.log, "File {} does not exists, likely due abnormal shutdown", file);
-                continue;
-            }
-
             ReadBufferFromFile in(file);
             const auto & distributed_header = DistributedAsyncInsertHeader::read(in, parent.log);
 

--- a/src/Storages/Distributed/DistributedAsyncInsertBatch.h
+++ b/src/Storages/Distributed/DistributedAsyncInsertBatch.h
@@ -18,8 +18,15 @@ public:
     bool isEnoughSize() const;
     void send();
 
+    /// Write batch to current_batch.txt
     void serialize();
+
+    /// Read batch from current_batch.txt
     void deserialize();
+
+    /// Does all required files exists?
+    /// (The only way variant when it is valid is during restoring batch from disk).
+    bool valid();
 
     size_t total_rows = 0;
     size_t total_bytes = 0;


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix possible distributed sends stuck due to "No such file or directory" (during recovering batch from disk). Fix possible issues with `error_count` from `system.distribution_queue` (in case of `distributed_directory_monitor_max_sleep_time_ms` >5min). Introduce profile event to track async INSERT failures - `DistributedAsyncInsertionFailures`.

Follow-up for: #49884
Fixes: #45491 (cc @hanfei1991 )