### PR TITLE
limit merge tree projections

### DIFF
--- a/src/Storages/MergeTree/MergeTreeSettings.h
+++ b/src/Storages/MergeTree/MergeTreeSettings.h
@@ -186,6 +186,9 @@ struct Settings;
     M(String, primary_key_compression_codec, "ZSTD(3)", "Compression encoding used by primary, primary key is small enough and cached, so the default compression is ZSTD(3).", 0) \
     M(UInt64, marks_compress_block_size, 65536, "Mark compress block size, the actual size of the block to compress.", 0) \
     M(UInt64, primary_key_compress_block_size, 65536, "Primary compress block size, the actual size of the block to compress.", 0) \
+    \
+    /** Projection settings. */ \
+    M(UInt64, max_projections, 25, "The maximum number of merge tree projections.", 0) \
 
 #define MAKE_OBSOLETE_MERGE_TREE_SETTING(M, TYPE, NAME, DEFAULT) \
     M(TYPE, NAME, DEFAULT, "Obsolete setting, does nothing.", BaseSettingsHelpers::Flags::OBSOLETE)

--- a/tests/queries/0_stateless/02934_merge_tree_max_projections.sql
+++ b/tests/queries/0_stateless/02934_merge_tree_max_projections.sql
@@ -1,0 +1,39 @@
+DROP TABLE IF EXISTS test_max_mt_projections_alter;
+CREATE TABLE test_max_mt_projections_alter (c1 UInt32, c2 UInt32, c3 UInt32)
+        ENGINE = MergeTree ORDER BY c1
+        SETTINGS max_projections = 3;
+
+ALTER TABLE test_max_mt_projections_alter ADD PROJECTION p1 (SELECT c2 ORDER BY c2);
+ALTER TABLE test_max_mt_projections_alter ADD PROJECTION p2 (SELECT c3 ORDER BY c3);
+ALTER TABLE test_max_mt_projections_alter ADD PROJECTION p3 (SELECT c1, c2 ORDER BY c1, c2);
+
+ALTER TABLE test_max_mt_projections_alter
+        ADD PROJECTION p4 (SELECT c2, c3 ORDER BY c2, c3); -- { serverError LIMIT_EXCEEDED }
+
+ALTER TABLE test_max_mt_projections_alter DROP PROJECTION p3;
+
+ALTER TABLE test_max_mt_projections_alter ADD PROJECTION p4 (SELECT c2, c3 ORDER BY c2, c3);
+
+DROP TABLE IF EXISTS test_max_mt_projections_alter;
+
+DROP TABLE IF EXISTS test_max_mt_projections_create;
+CREATE TABLE test_max_mt_projections_create (c1 UInt32, c2 UInt32,
+        PROJECTION p1 (SELECT c1, c2 ORDER BY c2),
+        PROJECTION p2 (SELECT c2 ORDER BY c2))
+        ENGINE = MergeTree ORDER BY c1
+        SETTINGS max_projections = 1; -- { serverError LIMIT_EXCEEDED }
+
+CREATE TABLE test_max_mt_projections_create (c1 UInt32, c2 UInt32,
+        PROJECTION p (SELECT c1, c2 ORDER BY c2))
+        ENGINE = MergeTree ORDER BY c1
+        SETTINGS max_projections = 0; -- { serverError LIMIT_EXCEEDED }
+
+CREATE TABLE test_max_mt_projections_create (c1 UInt32, c2 UInt32,
+        PROJECTION p (SELECT c1, c2 ORDER BY c2))
+        ENGINE = MergeTree ORDER BY c1
+        SETTINGS max_projections = 1;
+
+ALTER TABLE test_max_mt_projections_create
+        ADD PROJECTION p2 (SELECT c2 ORDER BY c2); -- { serverError LIMIT_EXCEEDED }
+
+DROP TABLE IF EXISTS test_max_mt_projections_create;


### PR DESCRIPTION
Add `max_projections` to the MergeTree settings. Defaults to 25.

Fixes: https://github.com/ClickHouse/ClickHouse/issues/56427

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Introduce the limit for the maximum number of table projections (default 25).

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
