### PR TITLE
Align qpl_deflate codec with master

### DIFF
--- a/contrib/idxd-config-cmake/CMakeLists.txt
+++ b/contrib/idxd-config-cmake/CMakeLists.txt
@@ -8,16 +8,16 @@ set (SRCS
     "${LIBACCEL_SOURCE_DIR}/util/sysfs.c"
 )
 
-add_library(accel-config ${SRCS})
+add_library(_accel-config ${SRCS})
 
-target_compile_options(accel-config PRIVATE "-D_GNU_SOURCE")
+target_compile_options(_accel-config PRIVATE "-D_GNU_SOURCE")
 
-target_include_directories(accel-config BEFORE
+target_include_directories(_accel-config BEFORE
     PRIVATE ${UUID_DIR}
     PRIVATE ${LIBACCEL_HEADER_DIR}
     PRIVATE ${LIBACCEL_SOURCE_DIR})
 
-target_include_directories(accel-config SYSTEM BEFORE
+target_include_directories(_accel-config SYSTEM BEFORE
     PUBLIC ${LIBACCEL_SOURCE_DIR}/accfg)
 
-#add_library(ch_contrib::accel-config ALIAS accel-config)
+add_library(accel-config ALIAS _accel-config)

--- a/contrib/qpl-cmake/CMakeLists.txt
+++ b/contrib/qpl-cmake/CMakeLists.txt
@@ -25,6 +25,9 @@ message(STATUS "Intel QPL version: ${QPL_VERSION}")
 # Generate 8 library targets: middle_layer_lib, isal, isal_asm, qplcore_px, qplcore_avx512, qplcore_sw_dispatcher, core_iaa, middle_layer_lib.
 # Output ch_contrib::qpl by linking with 8 library targets.
 
+# The qpl submodule comes with its own version of isal. It contains code which does not exist in upstream isal. It would be nice to link
+# only upstream isal (ch_contrib::isal) but at this point we can't.
+
 include("${QPL_PROJECT_DIR}/cmake/CompileOptions.cmake")
 
 # check nasm compiler
@@ -300,7 +303,7 @@ set_target_properties(middle_layer_lib PROPERTIES CXX_STANDARD 17)
 target_include_directories(middle_layer_lib
         PRIVATE ${UUID_DIR}
         PUBLIC $<BUILD_INTERFACE:${QPL_SRC_DIR}/middle-layer>
-        PUBLIC $<TARGET_PROPERTY:qpl,INTERFACE_INCLUDE_DIRECTORIES>
+        PUBLIC $<TARGET_PROPERTY:_qpl,INTERFACE_INCLUDE_DIRECTORIES>
         PUBLIC $<TARGET_PROPERTY:qplcore_sw_dispatcher,INTERFACE_INCLUDE_DIRECTORIES>
         PUBLIC $<TARGET_PROPERTY:isal,INTERFACE_INCLUDE_DIRECTORIES>
         PUBLIC $<TARGET_PROPERTY:core_iaa,INTERFACE_INCLUDE_DIRECTORIES>)
@@ -308,40 +311,40 @@ target_include_directories(middle_layer_lib
 target_compile_definitions(middle_layer_lib PUBLIC -DQPL_LIB)
 
 # [SUBDIR]c_api
-file(GLOB_RECURSE QPL_C_API_SRC 
+file(GLOB_RECURSE QPL_C_API_SRC
         ${QPL_SRC_DIR}/c_api/*.c
         ${QPL_SRC_DIR}/c_api/*.cpp)
 
 get_property(LIB_DEPS GLOBAL PROPERTY QPL_LIB_DEPS)
 
-add_library(qpl STATIC ${QPL_C_API_SRC} ${LIB_DEPS})
+add_library(_qpl STATIC ${QPL_C_API_SRC} ${LIB_DEPS})
 
-target_include_directories(qpl
+target_include_directories(_qpl
         PUBLIC $<BUILD_INTERFACE:${QPL_PROJECT_DIR}/include/> $<INSTALL_INTERFACE:include>
         PRIVATE $<TARGET_PROPERTY:middle_layer_lib,INTERFACE_INCLUDE_DIRECTORIES>
         PRIVATE $<BUILD_INTERFACE:${QPL_SRC_DIR}/c_api>)
 
-set_target_properties(qpl PROPERTIES
+set_target_properties(_qpl PROPERTIES
         $<$<C_COMPILER_ID:GNU>:C_STANDARD 17>
         CXX_STANDARD 17)
 
-target_compile_options(qpl
+target_compile_options(_qpl
         PRIVATE $<$<C_COMPILER_ID:GNU>:${QPL_LINUX_TOOLCHAIN_REQUIRED_FLAGS};
                                        ${QPL_LINUX_TOOLCHAIN_DYNAMIC_LIBRARY_FLAGS};
                                        $<$<CONFIG:Release>:-O3;-D_FORTIFY_SOURCE=2>>
         PRIVATE $<$<COMPILE_LANG_AND_ID:CXX,GNU>:${QPL_LINUX_TOOLCHAIN_CPP_EMBEDDED_FLAGS}>)
 
-target_compile_definitions(qpl
+target_compile_definitions(_qpl
         PRIVATE -DQPL_LIB
         PRIVATE -DQPL_BADARG_CHECK
         PRIVATE $<$<BOOL:${DYNAMIC_LOADING_LIBACCEL_CONFIG}>:DYNAMIC_LOADING_LIBACCEL_CONFIG>
         PUBLIC -DENABLE_QPL_COMPRESSION)
 
-target_link_libraries(qpl
+target_link_libraries(_qpl
         PRIVATE accel-config)
 
-target_include_directories(qpl SYSTEM BEFORE
+target_include_directories(_qpl SYSTEM BEFORE
         PUBLIC "${QPL_PROJECT_DIR}/include"
         PUBLIC ${UUID_DIR})
 
-#add_library (ch_contrib::qpl ALIAS qpl)
+add_library (qpl ALIAS _qpl)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -398,6 +398,7 @@ endif()
 
 if (ENABLE_QPL)
     dbms_target_link_libraries(PRIVATE qpl)
+    dbms_target_link_libraries(PRIVATE accel-config)
 endif ()
 
 if (XZ_LIBRARY)

--- a/src/Compression/CompressionCodecDeflateQpl.h
+++ b/src/Compression/CompressionCodecDeflateQpl.h
@@ -3,6 +3,7 @@
 #include <Compression/ICompressionCodec.h>
 #include <map>
 #include <random>
+#include <pcg_random.hpp>
 #include <qpl/qpl.h>
 
 namespace Poco
@@ -24,23 +25,24 @@ public:
     static DeflateQplJobHWPool & instance();
 
     qpl_job * acquireJob(UInt32 & job_id);
-    static void releaseJob(UInt32 job_id);
-    static const bool & isJobPoolReady() { return job_pool_ready; }
+    void releaseJob(UInt32 job_id);
+    const bool & isJobPoolReady() { return job_pool_ready; }
 
 private:
-    static bool tryLockJob(UInt32 index);
-    static void unLockJob(UInt32 index);
+    bool tryLockJob(UInt32 index);
+    void unLockJob(UInt32 index);
 
+    /// size of each job objects
+    UInt32 per_job_size;
     /// Maximum jobs running in parallel supported by IAA hardware
-    static constexpr auto MAX_HW_JOB_NUMBER = 1024;
+    UInt32 max_hw_jobs;
     /// Entire buffer for storing all job objects
-    static char* hw_jobs_buffer;
-    /// Job pool for storing all job object pointers
-    static std::array<qpl_job *, MAX_HW_JOB_NUMBER> hw_job_ptr_pool;
+    std::unique_ptr<uint8_t[]> hw_jobs_buffer;
     /// Locks for accessing each job object pointers
-    static std::array<std::atomic_bool, MAX_HW_JOB_NUMBER> hw_job_ptr_locks;
-    static bool job_pool_ready;
-    std::mt19937 random_engine;
+    std::unique_ptr<std::atomic_bool[]> hw_job_ptr_locks;
+
+    bool job_pool_ready;
+    pcg64_fast random_engine;
     std::uniform_int_distribution<int> distribution;
 };
 
@@ -63,8 +65,10 @@ class HardwareCodecDeflateQpl
 public:
     /// RET_ERROR stands for hardware codec fail, needs fallback to software codec.
     static constexpr Int32 RET_ERROR = -1;
+    /// Maximum times to check if hardware job complete, otherwise fallback to software codec.
+    static constexpr UInt32 MAX_CHECKS = UINT16_MAX;
 
-    HardwareCodecDeflateQpl();
+    HardwareCodecDeflateQpl(SoftwareCodecDeflateQpl & codec);
     ~HardwareCodecDeflateQpl();
 
     Int32 doCompressData(const char * source, UInt32 source_size, char * dest, UInt32 dest_size) const;
@@ -85,9 +89,11 @@ private:
     /// For flush, pop out job ID && job object from this map. Use job ID to release job lock and use job object to check job status till complete.
     std::map<UInt32, qpl_job *> decomp_async_job_map;
     Poco::Logger * log;
+    /// Provides a fallback in case of errors.
+    SoftwareCodecDeflateQpl & sw_codec;
 };
 
-class CompressionCodecDeflateQpl : public ICompressionCodec
+class CompressionCodecDeflateQpl final : public ICompressionCodec
 {
 public:
     CompressionCodecDeflateQpl();
@@ -108,8 +114,8 @@ protected:
 private:
     UInt32 getMaxCompressedDataSize(UInt32 uncompressed_size) const override;
 
-    std::unique_ptr<HardwareCodecDeflateQpl> hw_codec;
     std::unique_ptr<SoftwareCodecDeflateQpl> sw_codec;
+    std::unique_ptr<HardwareCodecDeflateQpl> hw_codec;
 };
 
 }


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Aligned qpl_deflate codec with changes in master [57291](https://github.com/ClickHouse/ClickHouse/pull/57291)
- Bumped Intel QPL (used by codec `DEFLATE_QPL`) from v1.2.0 to v1.3.1 .
- Fixed a bug in case of BOF (Block On Fault) = 0, changed to handle page faults by falling back to SW path.