### PR TITLE
Ignore ON CLUSTER clause in grant/revoke queries for management of replicated access entities. 

### DIFF
--- a/src/Interpreters/Access/InterpreterGrantQuery.cpp
+++ b/src/Interpreters/Access/InterpreterGrantQuery.cpp
@@ -7,6 +7,7 @@
 #include <Access/RolesOrUsersSet.h>
 #include <Access/User.h>
 #include <Interpreters/Context.h>
+#include <Interpreters/removeOnClusterClauseIfNeeded.h>
 #include <Interpreters/QueryLog.h>
 #include <Interpreters/executeDDLQueryOnCluster.h>
 #include <boost/range/algorithm/copy.hpp>
@@ -396,7 +397,8 @@ namespace
 
 BlockIO InterpreterGrantQuery::execute()
 {
-    auto & query = query_ptr->as<ASTGrantQuery &>();
+    const auto updated_query = removeOnClusterClauseIfNeeded(query_ptr, getContext());
+    auto & query = updated_query->as<ASTGrantQuery &>();
 
     query.replaceCurrentUserTag(getContext()->getUserName());
     query.access_rights_elements.eraseNonGrantable();
@@ -430,7 +432,7 @@ BlockIO InterpreterGrantQuery::execute()
         current_user_access->checkGranteesAreAllowed(grantees);
         DDLQueryOnClusterParams params;
         params.access_to_check = std::move(required_access);
-        return executeDDLQueryOnCluster(query_ptr, getContext(), params);
+        return executeDDLQueryOnCluster(updated_query, getContext(), params);
     }
 
     /// Check if the current user has corresponding access rights granted with grant option.

--- a/src/Interpreters/removeOnClusterClauseIfNeeded.cpp
+++ b/src/Interpreters/removeOnClusterClauseIfNeeded.cpp
@@ -14,6 +14,7 @@
 #include <Parsers/Access/ASTCreateSettingsProfileQuery.h>
 #include <Parsers/Access/ASTCreateUserQuery.h>
 #include <Parsers/Access/ASTDropAccessEntityQuery.h>
+#include <Parsers/Access/ASTGrantQuery.h>
 
 
 namespace DB
@@ -33,7 +34,8 @@ static bool isAccessControlQuery(const ASTPtr & query)
         || query->as<ASTCreateRoleQuery>()
         || query->as<ASTCreateRowPolicyQuery>()
         || query->as<ASTCreateSettingsProfileQuery>()
-        || query->as<ASTDropAccessEntityQuery>();
+        || query->as<ASTDropAccessEntityQuery>()
+        || query->as<ASTGrantQuery>();
 }
 
 ASTPtr removeOnClusterClauseIfNeeded(const ASTPtr & query, ContextPtr context, const WithoutOnClusterASTRewriteParams & params)

--- a/tests/integration/test_replicated_users/test.py
+++ b/tests/integration/test_replicated_users/test.py
@@ -114,6 +114,41 @@ def test_create_replicated_on_cluster_ignore(started_cluster, entity):
     node1.query(f"DROP {entity.keyword} {entity.name} {entity.options}")
 
 
+@pytest.mark.parametrize(
+    "use_on_cluster",
+    [
+        pytest.param(False, id="Without_on_cluster"),
+        pytest.param(True, id="With_ignored_on_cluster"),
+    ],
+)
+def test_grant_revoke_replicated(started_cluster, use_on_cluster: bool):
+    node1.replace_config(
+        "/etc/clickhouse-server/users.d/users.xml",
+        inspect.cleandoc(
+            f"""
+            <clickhouse>
+                <profiles>
+                    <default>
+                        <ignore_on_cluster_for_replicated_access_entities_queries>{int(use_on_cluster)}</ignore_on_cluster_for_replicated_access_entities_queries>
+                    </default>
+                </profiles>
+            </clickhouse>
+            """
+        ),
+    )
+    node1.query("SYSTEM RELOAD CONFIG")
+    on_cluster = "ON CLUSTER default" if use_on_cluster else ""
+
+    node1.query(f"CREATE USER theuser {on_cluster}")
+
+    assert node1.query(f"GRANT {on_cluster} SELECT ON *.* to theuser") == ""
+
+    assert node2.query(f"SHOW GRANTS FOR theuser") == "GRANT SELECT ON *.* TO theuser\n"
+
+    assert node1.query(f"REVOKE {on_cluster} SELECT ON *.* from theuser") == ""
+    node1.query(f"DROP USER theuser {on_cluster}")
+
+
 @pytest.mark.parametrize("entity", entities, ids=get_entity_id)
 def test_create_replicated_if_not_exists_on_cluster(started_cluster, entity):
     node1.query(


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
Add grant/revoke in the list for `ignore_on_cluster_for_replicated_access_entities_queries` option. It is necessary for seamless migration of the existing codebase to replicated storage without changing current SQL queries. Also It will be good to have a backport.
### Changelog category (leave one):

- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
conf
```
 <user_directories>
       <replicated>
           <zookeeper_path>/clickhouse/access/</zookeeper_path>
       </replicated>
 </user_directories>
```
sql
```
show SETTINGS like 'ignore_on_cluster_for_replicated_access_entities_queries'
┌─name─────────────────────────────────────────────────────┬─type─┬─value─┐
│ ignore_on_cluster_for_replicated_access_entities_queries │ Bool │ 1     │
└──────────────────────────────────────────────────────────┴──────┴───────┘


grant on cluster '{cluster}' select on *.* to user2  \G


Row 1:
──────
host:                node1
port:                9440
status:              0
error:               
num_hosts_remaining: 1
num_hosts_active:    0

Row 2:
──────
host:                node2
port:                9440
status:              0
error:               
num_hosts_remaining: 0
num_hosts_active:    0

```

Ref: #52975 

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
