### PR TITLE
Catch all exceptions in `WriteBufferFromEncryptedFile` destructor

### DIFF
--- a/src/IO/WriteBufferFromEncryptedFile.cpp
+++ b/src/IO/WriteBufferFromEncryptedFile.cpp
@@ -21,7 +21,14 @@ WriteBufferFromEncryptedFile::WriteBufferFromEncryptedFile(
 
 WriteBufferFromEncryptedFile::~WriteBufferFromEncryptedFile()
 {
-    finalize();
+    try
+    {
+        finalize();
+    }
+    catch (...)
+    {
+        tryLogCurrentException(__PRETTY_FUNCTION__);
+    }
 }
 
 void WriteBufferFromEncryptedFile::finalizeBefore()


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Catch all exception in destructor of `WriteBufferFromEncryptedFile` to avoid abort of the process.

---

```
Terminate called for uncaught exception:
Code: 499. DB::Exception: Message: The AWS Access Key Id you provided does not exist in our records., bucket 463754717262.us-east-2.aws.clickhouse.cloud-shared, key ch-s3-5106e792-249d-4f6e-b294-e32563589729/mergetree/zgw/oswtntxvremqjlhrrajtfwdybyzes, object size 0. (S3_ERROR), Stack trace (when copying this message, always include the lines below):
...
```