### PR TITLE
Support SHARDS for HashedArrayDictionary

### DIFF
--- a/docs/en/sql-reference/dictionaries/index.md
+++ b/docs/en/sql-reference/dictionaries/index.md
@@ -394,7 +394,7 @@ Configuration example:
 or
 
 ``` sql
-LAYOUT(HASHED_ARRAY())
+LAYOUT(HASHED_ARRAY([SHARDS 1]))
 ```
 
 ### complex_key_hashed_array
@@ -412,7 +412,7 @@ Configuration example:
 or
 
 ``` sql
-LAYOUT(COMPLEX_KEY_HASHED_ARRAY())
+LAYOUT(COMPLEX_KEY_HASHED_ARRAY([SHARDS 1]))
 ```
 
 ### range_hashed {#range_hashed}
@@ -2415,8 +2415,8 @@ clickhouse client \
     --secure \
     --password MY_PASSWORD \
     --query "
-    INSERT INTO regexp_dictionary_source_table 
-    SELECT * FROM input ('id UInt64, parent_id UInt64, regexp String, keys Array(String), values Array(String)') 
+    INSERT INTO regexp_dictionary_source_table
+    SELECT * FROM input ('id UInt64, parent_id UInt64, regexp String, keys Array(String), values Array(String)')
     FORMAT CSV" < regexp_dict.csv
 ```
 

--- a/src/Dictionaries/HashedArrayDictionary.cpp
+++ b/src/Dictionaries/HashedArrayDictionary.cpp
@@ -20,17 +20,19 @@ namespace ErrorCodes
 {
     extern const int BAD_ARGUMENTS;
     extern const int DICTIONARY_IS_EMPTY;
+    extern const int LOGICAL_ERROR;
     extern const int UNSUPPORTED_METHOD;
 }
 
-template <DictionaryKeyType dictionary_key_type>
-HashedArrayDictionary<dictionary_key_type>::HashedArrayDictionary(
+template <DictionaryKeyType dictionary_key_type, bool sharded>
+HashedArrayDictionary<dictionary_key_type, sharded>::HashedArrayDictionary(
     const StorageID & dict_id_,
     const DictionaryStructure & dict_struct_,
     DictionarySourcePtr source_ptr_,
     const HashedArrayDictionaryStorageConfiguration & configuration_,
     BlockPtr update_field_loaded_block_)
     : IDictionary(dict_id_)
+    , log(&Poco::Logger::get("HashedArrayDictionary"))
     , dict_struct(dict_struct_)
     , source_ptr(std::move(source_ptr_))
     , configuration(configuration_)
@@ -42,8 +44,8 @@ HashedArrayDictionary<dictionary_key_type>::HashedArrayDictionary(
     calculateBytesAllocated();
 }
 
-template <DictionaryKeyType dictionary_key_type>
-ColumnPtr HashedArrayDictionary<dictionary_key_type>::getColumn(
+template <DictionaryKeyType dictionary_key_type, bool sharded>
+ColumnPtr HashedArrayDictionary<dictionary_key_type, sharded>::getColumn(
     const std::string & attribute_name,
     const DataTypePtr & result_type,
     const Columns & key_columns,
@@ -67,8 +69,8 @@ ColumnPtr HashedArrayDictionary<dictionary_key_type>::getColumn(
     return getAttributeColumn(attribute, dictionary_attribute, keys_size, default_values_column, extractor);
 }
 
-template <DictionaryKeyType dictionary_key_type>
-Columns HashedArrayDictionary<dictionary_key_type>::getColumns(
+template <DictionaryKeyType dictionary_key_type, bool sharded>
+Columns HashedArrayDictionary<dictionary_key_type, sharded>::getColumns(
     const Strings & attribute_names,
     const DataTypes & result_types,
     const Columns & key_columns,
@@ -83,7 +85,7 @@ Columns HashedArrayDictionary<dictionary_key_type>::getColumns(
 
     const size_t keys_size = extractor.getKeysSize();
 
-    PaddedPODArray<ssize_t> key_index_to_element_index;
+    KeyIndexToElementIndex key_index_to_element_index;
 
     /** Optimization for multiple attributes.
       * For each key save element index in key_index_to_element_index array.
@@ -92,7 +94,6 @@ Columns HashedArrayDictionary<dictionary_key_type>::getColumns(
       */
     if (attribute_names.size() > 1)
     {
-        const auto & key_attribute_container = key_attribute.container;
         size_t keys_found = 0;
 
         key_index_to_element_index.resize(keys_size);
@@ -100,15 +101,23 @@ Columns HashedArrayDictionary<dictionary_key_type>::getColumns(
         for (size_t key_index = 0; key_index < keys_size; ++key_index)
         {
             auto key = extractor.extractCurrentKey();
+            auto shard = getShard(key);
+            const auto & key_attribute_container = key_attribute.containers[shard];
 
             auto it = key_attribute_container.find(key);
             if (it == key_attribute_container.end())
             {
-                key_index_to_element_index[key_index] = -1;
+                if constexpr (sharded)
+                    key_index_to_element_index[key_index] = std::make_pair(-1, shard);
+                else
+                    key_index_to_element_index[key_index] = -1;
             }
             else
             {
-                key_index_to_element_index[key_index] = it->getMapped();
+                if constexpr (sharded)
+                    key_index_to_element_index[key_index] = std::make_pair(it->getMapped(), shard);
+                else
+                    key_index_to_element_index[key_index] = it->getMapped();
                 ++keys_found;
             }
 
@@ -147,8 +156,8 @@ Columns HashedArrayDictionary<dictionary_key_type>::getColumns(
     return result_columns;
 }
 
-template <DictionaryKeyType dictionary_key_type>
-ColumnUInt8::Ptr HashedArrayDictionary<dictionary_key_type>::hasKeys(const Columns & key_columns, const DataTypes & key_types) const
+template <DictionaryKeyType dictionary_key_type, bool sharded>
+ColumnUInt8::Ptr HashedArrayDictionary<dictionary_key_type, sharded>::hasKeys(const Columns & key_columns, const DataTypes & key_types) const
 {
     if (dictionary_key_type == DictionaryKeyType::Complex)
         dict_struct.validateKeyTypes(key_types);
@@ -166,8 +175,10 @@ ColumnUInt8::Ptr HashedArrayDictionary<dictionary_key_type>::hasKeys(const Colum
     for (size_t requested_key_index = 0; requested_key_index < keys_size; ++requested_key_index)
     {
         auto requested_key = extractor.extractCurrentKey();
+        auto shard = getShard(requested_key);
+        const auto & key_attribute_container = key_attribute.containers[shard];
 
-        out[requested_key_index] = key_attribute.container.find(requested_key) != key_attribute.container.end();
+        out[requested_key_index] = key_attribute_container.find(requested_key) != key_attribute_container.end();
 
         keys_found += out[requested_key_index];
         extractor.rollbackCurrentKey();
@@ -179,8 +190,8 @@ ColumnUInt8::Ptr HashedArrayDictionary<dictionary_key_type>::hasKeys(const Colum
     return result;
 }
 
-template <DictionaryKeyType dictionary_key_type>
-ColumnPtr HashedArrayDictionary<dictionary_key_type>::getHierarchy(ColumnPtr key_column [[maybe_unused]], const DataTypePtr &) const
+template <DictionaryKeyType dictionary_key_type, bool sharded>
+ColumnPtr HashedArrayDictionary<dictionary_key_type, sharded>::getHierarchy(ColumnPtr key_column [[maybe_unused]], const DataTypePtr &) const
 {
     if constexpr (dictionary_key_type == DictionaryKeyType::Simple)
     {
@@ -197,16 +208,20 @@ ColumnPtr HashedArrayDictionary<dictionary_key_type>::getHierarchy(ColumnPtr key
         if (!dictionary_attribute.null_value.isNull())
             null_value = dictionary_attribute.null_value.get<UInt64>();
 
-        const auto & key_attribute_container = key_attribute.container;
-        const AttributeContainerType<UInt64> & parent_keys_container = std::get<AttributeContainerType<UInt64>>(hierarchical_attribute.container);
 
-        auto is_key_valid_func = [&](auto & key) { return key_attribute_container.find(key) != key_attribute_container.end(); };
+        auto is_key_valid_func = [&, this](auto & key)
+        {
+            const auto & key_attribute_container = key_attribute.containers[getShard(key)];
+            return key_attribute_container.find(key) != key_attribute_container.end();
+        };
 
         size_t keys_found = 0;
 
-        auto get_parent_func = [&](auto & hierarchy_key)
+        auto get_parent_func = [&, this](auto & hierarchy_key)
         {
             std::optional<UInt64> result;
+            auto shard = getShard(hierarchy_key);
+            const auto & key_attribute_container = key_attribute.containers[shard];
 
             auto it = key_attribute_container.find(hierarchy_key);
 
@@ -215,8 +230,9 @@ ColumnPtr HashedArrayDictionary<dictionary_key_type>::getHierarchy(ColumnPtr key
 
             size_t key_index = it->getMapped();
 
-            if (unlikely(hierarchical_attribute.is_index_null) && (*hierarchical_attribute.is_index_null)[key_index])
+            if (unlikely(hierarchical_attribute.is_index_null) && (*hierarchical_attribute.is_index_null)[shard][key_index])
                 return result;
+            const auto & parent_keys_container = std::get<AttributeContainerShardsType<UInt64>>(hierarchical_attribute.containers)[shard];
 
             UInt64 parent_key = parent_keys_container[key_index];
             if (null_value && *null_value == parent_key)
@@ -241,8 +257,8 @@ ColumnPtr HashedArrayDictionary<dictionary_key_type>::getHierarchy(ColumnPtr key
     }
 }
 
-template <DictionaryKeyType dictionary_key_type>
-ColumnUInt8::Ptr HashedArrayDictionary<dictionary_key_type>::isInHierarchy(
+template <DictionaryKeyType dictionary_key_type, bool sharded>
+ColumnUInt8::Ptr HashedArrayDictionary<dictionary_key_type, sharded>::isInHierarchy(
     ColumnPtr key_column [[maybe_unused]],
     ColumnPtr in_key_column [[maybe_unused]],
     const DataTypePtr &) const
@@ -265,16 +281,20 @@ ColumnUInt8::Ptr HashedArrayDictionary<dictionary_key_type>::isInHierarchy(
         if (!dictionary_attribute.null_value.isNull())
             null_value = dictionary_attribute.null_value.get<UInt64>();
 
-        const auto & key_attribute_container = key_attribute.container;
-        const AttributeContainerType<UInt64> & parent_keys_container = std::get<AttributeContainerType<UInt64>>(hierarchical_attribute.container);
 
-        auto is_key_valid_func = [&](auto & key) { return key_attribute_container.find(key) != key_attribute_container.end(); };
+        auto is_key_valid_func = [&](auto & key)
+        {
+            const auto & key_attribute_container = key_attribute.containers[getShard(key)];
+            return key_attribute_container.find(key) != key_attribute_container.end();
+        };
 
         size_t keys_found = 0;
 
         auto get_parent_func = [&](auto & hierarchy_key)
         {
             std::optional<UInt64> result;
+            auto shard = getShard(hierarchy_key);
+            const auto & key_attribute_container = key_attribute.containers[shard];
 
             auto it = key_attribute_container.find(hierarchy_key);
 
@@ -283,9 +303,10 @@ ColumnUInt8::Ptr HashedArrayDictionary<dictionary_key_type>::isInHierarchy(
 
             size_t key_index = it->getMapped();
 
-            if (unlikely(hierarchical_attribute.is_index_null) && (*hierarchical_attribute.is_index_null)[key_index])
+            if (unlikely(hierarchical_attribute.is_index_null) && (*hierarchical_attribute.is_index_null)[shard][key_index])
                 return result;
 
+            const auto & parent_keys_container = std::get<AttributeContainerShardsType<UInt64>>(hierarchical_attribute.containers)[shard];
             UInt64 parent_key = parent_keys_container[key_index];
             if (null_value && *null_value == parent_key)
                 return result;
@@ -309,8 +330,8 @@ ColumnUInt8::Ptr HashedArrayDictionary<dictionary_key_type>::isInHierarchy(
     }
 }
 
-template <DictionaryKeyType dictionary_key_type>
-DictionaryHierarchicalParentToChildIndexPtr HashedArrayDictionary<dictionary_key_type>::getHierarchicalIndex() const
+template <DictionaryKeyType dictionary_key_type, bool sharded>
+DictionaryHierarchicalParentToChildIndexPtr HashedArrayDictionary<dictionary_key_type, sharded>::getHierarchicalIndex() const
 {
     if constexpr (dictionary_key_type == DictionaryKeyType::Simple)
     {
@@ -318,33 +339,35 @@ DictionaryHierarchicalParentToChildIndexPtr HashedArrayDictionary<dictionary_key
             return hierarchical_index;
 
         size_t hierarchical_attribute_index = *dict_struct.hierarchical_attribute_index;
-        const auto & hierarchical_attribute = attributes[hierarchical_attribute_index];
-        const AttributeContainerType<UInt64> & parent_keys_container = std::get<AttributeContainerType<UInt64>>(hierarchical_attribute.container);
-
-        const auto & key_attribute_container = key_attribute.container;
-
-        HashMap<size_t, UInt64> index_to_key;
-        index_to_key.reserve(key_attribute.container.size());
-
-        for (auto & [key, value] : key_attribute_container)
-            index_to_key[value] = key;
 
         DictionaryHierarchicalParentToChildIndex::ParentToChildIndex parent_to_child;
-        parent_to_child.reserve(index_to_key.size());
-
-        size_t parent_keys_container_size = parent_keys_container.size();
-        for (size_t i = 0; i < parent_keys_container_size; ++i)
+        for (size_t shard = 0; shard < configuration.shards; ++shard)
         {
-            if (unlikely(hierarchical_attribute.is_index_null) && (*hierarchical_attribute.is_index_null)[i])
-                continue;
+            HashMap<size_t, UInt64> index_to_key;
+            index_to_key.reserve(element_counts[shard]);
 
-            const auto * it = index_to_key.find(i);
-            if (it == index_to_key.end())
-                continue;
+            for (auto & [key, value] : key_attribute.containers[shard])
+                index_to_key[value] = key;
 
-            auto child_key = it->getMapped();
-            auto parent_key = parent_keys_container[i];
-            parent_to_child[parent_key].emplace_back(child_key);
+            parent_to_child.reserve(parent_to_child.size() + index_to_key.size());
+
+            const auto & hierarchical_attribute = attributes[hierarchical_attribute_index];
+            const auto & parent_keys_container = std::get<AttributeContainerShardsType<UInt64>>(hierarchical_attribute.containers)[shard];
+
+            size_t parent_keys_container_size = parent_keys_container.size();
+            for (size_t i = 0; i < parent_keys_container_size; ++i)
+            {
+                if (unlikely(hierarchical_attribute.is_index_null) && (*hierarchical_attribute.is_index_null)[shard][i])
+                    continue;
+
+                const auto * it = index_to_key.find(i);
+                if (it == index_to_key.end())
+                    continue;
+
+                auto child_key = it->getMapped();
+                auto parent_key = parent_keys_container[i];
+                parent_to_child[parent_key].emplace_back(child_key);
+            }
         }
 
         return std::make_shared<DictionaryHierarchicalParentToChildIndex>(parent_to_child);
@@ -355,8 +378,8 @@ DictionaryHierarchicalParentToChildIndexPtr HashedArrayDictionary<dictionary_key
     }
 }
 
-template <DictionaryKeyType dictionary_key_type>
-ColumnPtr HashedArrayDictionary<dictionary_key_type>::getDescendants(
+template <DictionaryKeyType dictionary_key_type, bool sharded>
+ColumnPtr HashedArrayDictionary<dictionary_key_type, sharded>::getDescendants(
     ColumnPtr key_column [[maybe_unused]],
     const DataTypePtr &,
     size_t level [[maybe_unused]],
@@ -381,8 +404,8 @@ ColumnPtr HashedArrayDictionary<dictionary_key_type>::getDescendants(
     }
 }
 
-template <DictionaryKeyType dictionary_key_type>
-void HashedArrayDictionary<dictionary_key_type>::createAttributes()
+template <DictionaryKeyType dictionary_key_type, bool sharded>
+void HashedArrayDictionary<dictionary_key_type, sharded>::createAttributes()
 {
     const auto size = dict_struct.attributes.size();
     attributes.reserve(size);
@@ -395,17 +418,24 @@ void HashedArrayDictionary<dictionary_key_type>::createAttributes()
             using AttributeType = typename Type::AttributeType;
             using ValueType = DictionaryValueType<AttributeType>;
 
-            auto is_index_null = dictionary_attribute.is_nullable ? std::make_optional<std::vector<bool>>() : std::optional<std::vector<bool>>{};
-            Attribute attribute{dictionary_attribute.underlying_type, AttributeContainerType<ValueType>(), std::move(is_index_null)};
+            auto is_index_null = dictionary_attribute.is_nullable ? std::make_optional<std::vector<typename Attribute::RowsMask>>(configuration.shards) : std::nullopt;
+            Attribute attribute{dictionary_attribute.underlying_type, AttributeContainerShardsType<ValueType>(configuration.shards), std::move(is_index_null)};
             attributes.emplace_back(std::move(attribute));
         };
 
         callOnDictionaryAttributeType(dictionary_attribute.underlying_type, type_call);
     }
+
+    key_attribute.containers.resize(configuration.shards);
+    element_counts.resize(configuration.shards);
+
+    string_arenas.resize(configuration.shards);
+    for (auto & arena : string_arenas)
+        arena = std::make_unique<Arena>();
 }
 
-template <DictionaryKeyType dictionary_key_type>
-void HashedArrayDictionary<dictionary_key_type>::updateData()
+template <DictionaryKeyType dictionary_key_type, bool sharded>
+void HashedArrayDictionary<dictionary_key_type, sharded>::updateData()
 {
     if (!update_field_loaded_block || update_field_loaded_block->rows() == 0)
     {
@@ -445,13 +475,17 @@ void HashedArrayDictionary<dictionary_key_type>::updateData()
     if (update_field_loaded_block)
     {
         resize(update_field_loaded_block->rows());
-        blockToAttributes(*update_field_loaded_block.get());
+        DictionaryKeysArenaHolder<dictionary_key_type> arena_holder;
+        blockToAttributes(*update_field_loaded_block.get(), arena_holder, /* shard = */ 0);
     }
 }
 
-template <DictionaryKeyType dictionary_key_type>
-void HashedArrayDictionary<dictionary_key_type>::blockToAttributes(const Block & block [[maybe_unused]])
+template <DictionaryKeyType dictionary_key_type, bool sharded>
+void HashedArrayDictionary<dictionary_key_type, sharded>::blockToAttributes(const Block & block, DictionaryKeysArenaHolder<dictionary_key_type> & arena_holder, size_t shard)
 {
+    if (unlikely(shard >= configuration.shards))
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Shard number {} is out of range: 0..{}", shard, configuration.shards - 1);
+
     size_t skip_keys_size_offset = dict_struct.getKeysSize();
 
     Columns key_columns;
@@ -461,7 +495,6 @@ void HashedArrayDictionary<dictionary_key_type>::blockToAttributes(const Block &
     for (size_t i = 0; i < skip_keys_size_offset; ++i)
         key_columns.emplace_back(block.safeGetByPosition(i).column);
 
-    DictionaryKeysArenaHolder<dictionary_key_type> arena_holder;
     DictionaryKeysExtractor<dictionary_key_type> keys_extractor(key_columns, arena_holder.getComplexKeyArena());
     const size_t keys_size = keys_extractor.getKeysSize();
 
@@ -471,18 +504,18 @@ void HashedArrayDictionary<dictionary_key_type>::blockToAttributes(const Block &
     {
         auto key = keys_extractor.extractCurrentKey();
 
-        auto it = key_attribute.container.find(key);
+        auto it = key_attribute.containers[shard].find(key);
 
-        if (it != key_attribute.container.end())
+        if (it != key_attribute.containers[shard].end())
         {
             keys_extractor.rollbackCurrentKey();
             continue;
         }
 
         if constexpr (std::is_same_v<KeyType, StringRef>)
-            key = copyStringInArena(string_arena, key);
+            key = copyStringInArena(*string_arenas[shard], key);
 
-        key_attribute.container.insert({key, element_count});
+        key_attribute.containers[shard].insert({key, element_counts[shard]});
 
         for (size_t attribute_index = 0; attribute_index < attributes.size(); ++attribute_index)
         {
@@ -498,16 +531,16 @@ void HashedArrayDictionary<dictionary_key_type>::blockToAttributes(const Block &
                 using AttributeType = typename Type::AttributeType;
                 using AttributeValueType = DictionaryValueType<AttributeType>;
 
-                auto & attribute_container = std::get<AttributeContainerType<AttributeValueType>>(attribute.container);
+                auto & attribute_container = std::get<AttributeContainerShardsType<AttributeValueType>>(attribute.containers)[shard];
                 attribute_container.emplace_back();
 
                 if (attribute_is_nullable)
                 {
-                    attribute.is_index_null->emplace_back();
+                    (*attribute.is_index_null)[shard].emplace_back();
 
                     if (column_value_to_insert.isNull())
                     {
-                        (*attribute.is_index_null).back() = true;
+                        (*attribute.is_index_null)[shard].back() = true;
                         return;
                     }
                 }
@@ -515,7 +548,7 @@ void HashedArrayDictionary<dictionary_key_type>::blockToAttributes(const Block &
                 if constexpr (std::is_same_v<AttributeValueType, StringRef>)
                 {
                     String & value_to_insert = column_value_to_insert.get<String>();
-                    StringRef string_in_arena_reference = copyStringInArena(string_arena, value_to_insert);
+                    StringRef string_in_arena_reference = copyStringInArena(*string_arenas[shard], value_to_insert);
                     attribute_container.back() = string_in_arena_reference;
                 }
                 else
@@ -528,23 +561,29 @@ void HashedArrayDictionary<dictionary_key_type>::blockToAttributes(const Block &
             callOnDictionaryAttributeType(attribute.type, type_call);
         }
 
-        ++element_count;
+        ++element_counts[shard];
+        ++total_element_count;
         keys_extractor.rollbackCurrentKey();
     }
 }
 
-template <DictionaryKeyType dictionary_key_type>
-void HashedArrayDictionary<dictionary_key_type>::resize(size_t total_rows)
+template <DictionaryKeyType dictionary_key_type, bool sharded>
+void HashedArrayDictionary<dictionary_key_type, sharded>::resize(size_t total_rows)
 {
     if (unlikely(!total_rows))
         return;
 
-    key_attribute.container.reserve(total_rows);
+    /// In multi shards configuration it is pointless.
+    if constexpr (sharded)
+        return;
+
+    for (auto & container : key_attribute.containers)
+        container.reserve(total_rows);
 }
 
-template <DictionaryKeyType dictionary_key_type>
+template <DictionaryKeyType dictionary_key_type, bool sharded>
 template <typename KeysProvider>
-ColumnPtr HashedArrayDictionary<dictionary_key_type>::getAttributeColumn(
+ColumnPtr HashedArrayDictionary<dictionary_key_type, sharded>::getAttributeColumn(
     const Attribute & attribute,
     const DictionaryAttribute & dictionary_attribute,
     size_t keys_size,
@@ -638,16 +677,14 @@ ColumnPtr HashedArrayDictionary<dictionary_key_type>::getAttributeColumn(
     return result;
 }
 
-template <DictionaryKeyType dictionary_key_type>
+template <DictionaryKeyType dictionary_key_type, bool sharded>
 template <typename AttributeType, bool is_nullable, typename ValueSetter, typename DefaultValueExtractor>
-void HashedArrayDictionary<dictionary_key_type>::getItemsImpl(
+void HashedArrayDictionary<dictionary_key_type, sharded>::getItemsImpl(
     const Attribute & attribute,
     DictionaryKeysExtractor<dictionary_key_type> & keys_extractor,
     ValueSetter && set_value [[maybe_unused]],
     DefaultValueExtractor & default_value_extractor) const
 {
-    const auto & key_attribute_container = key_attribute.container;
-    const auto & attribute_container = std::get<AttributeContainerType<AttributeType>>(attribute.container);
     const size_t keys_size = keys_extractor.getKeysSize();
 
     size_t keys_found = 0;
@@ -655,6 +692,9 @@ void HashedArrayDictionary<dictionary_key_type>::getItemsImpl(
     for (size_t key_index = 0; key_index < keys_size; ++key_index)
     {
         auto key = keys_extractor.extractCurrentKey();
+        auto shard = getShard(key);
+        const auto & key_attribute_container = key_attribute.containers[shard];
+        const auto & attribute_container = std::get<AttributeContainerShardsType<AttributeType>>(attribute.containers)[shard];
 
         const auto it = key_attribute_container.find(key);
 
@@ -665,7 +705,7 @@ void HashedArrayDictionary<dictionary_key_type>::getItemsImpl(
             const auto & element = attribute_container[element_index];
 
             if constexpr (is_nullable)
-                set_value(key_index, element, (*attribute.is_index_null)[element_index]);
+                set_value(key_index, element, (*attribute.is_index_null)[shard][element_index]);
             else
                 set_value(key_index, element, false);
 
@@ -686,28 +726,39 @@ void HashedArrayDictionary<dictionary_key_type>::getItemsImpl(
     found_count.fetch_add(keys_found, std::memory_order_relaxed);
 }
 
-template <DictionaryKeyType dictionary_key_type>
+template <DictionaryKeyType dictionary_key_type, bool sharded>
 template <typename AttributeType, bool is_nullable, typename ValueSetter, typename DefaultValueExtractor>
-void HashedArrayDictionary<dictionary_key_type>::getItemsImpl(
+void HashedArrayDictionary<dictionary_key_type, sharded>::getItemsImpl(
     const Attribute & attribute,
-    const PaddedPODArray<ssize_t> & key_index_to_element_index,
+    const KeyIndexToElementIndex & key_index_to_element_index,
     ValueSetter && set_value,
     DefaultValueExtractor & default_value_extractor) const
 {
-    const auto & attribute_container = std::get<AttributeContainerType<AttributeType>>(attribute.container);
     const size_t keys_size = key_index_to_element_index.size();
+    size_t shard = 0;
 
     for (size_t key_index = 0; key_index < keys_size; ++key_index)
     {
-        bool key_exists = key_index_to_element_index[key_index] != -1;
-
-        if (key_exists)
+        ssize_t element_index;
+        if constexpr (sharded)
         {
-            size_t element_index = static_cast<size_t>(key_index_to_element_index[key_index]);
-            const auto & element = attribute_container[element_index];
+            element_index = key_index_to_element_index[key_index].first;
+            shard = key_index_to_element_index[key_index].second;
+        }
+        else
+        {
+            element_index = key_index_to_element_index[key_index];
+        }
+
+        if (element_index != -1)
+        {
+            const auto & attribute_container = std::get<AttributeContainerShardsType<AttributeType>>(attribute.containers)[shard];
+
+            size_t found_element_index = static_cast<size_t>(element_index);
+            const auto & element = attribute_container[found_element_index];
 
             if constexpr (is_nullable)
-                set_value(key_index, element, (*attribute.is_index_null)[element_index]);
+                set_value(key_index, element, (*attribute.is_index_null)[shard][found_element_index]);
             else
                 set_value(key_index, element, false);
         }
@@ -721,13 +772,17 @@ void HashedArrayDictionary<dictionary_key_type>::getItemsImpl(
     }
 }
 
-template <DictionaryKeyType dictionary_key_type>
-void HashedArrayDictionary<dictionary_key_type>::loadData()
+template <DictionaryKeyType dictionary_key_type, bool sharded>
+void HashedArrayDictionary<dictionary_key_type, sharded>::loadData()
 {
     if (!source_ptr->hasUpdateField())
     {
-        QueryPipeline pipeline;
-        pipeline = QueryPipeline(source_ptr->loadAll());
+
+        std::optional<DictionaryParallelLoaderType> parallel_loader;
+        if constexpr (sharded)
+            parallel_loader.emplace(*this);
+
+        QueryPipeline pipeline(source_ptr->loadAll());
         DictionaryPipelineExecutor executor(pipeline, configuration.use_async_executor);
 
         UInt64 pull_time_microseconds = 0;
@@ -751,9 +806,21 @@ void HashedArrayDictionary<dictionary_key_type>::loadData()
 
             Stopwatch watch_process;
             resize(total_rows);
-            blockToAttributes(block);
+
+            if (parallel_loader)
+            {
+                parallel_loader->addBlock(block);
+            }
+            else
+            {
+                DictionaryKeysArenaHolder<dictionary_key_type> arena_holder;
+                blockToAttributes(block, arena_holder, /* shard = */ 0);
+            }
             process_time_microseconds += watch_process.elapsedMicroseconds();
         }
+
+        if (parallel_loader)
+            parallel_loader->finish();
 
         LOG_DEBUG(&Poco::Logger::get("HashedArrayDictionary"),
             "Finished {}reading {} blocks with {} rows from pipeline in {:.2f} sec and inserted into hashtable in {:.2f} sec",
@@ -765,14 +832,14 @@ void HashedArrayDictionary<dictionary_key_type>::loadData()
         updateData();
     }
 
-    if (configuration.require_nonempty && 0 == element_count)
+    if (configuration.require_nonempty && 0 == total_element_count)
         throw Exception(ErrorCodes::DICTIONARY_IS_EMPTY,
             "{}: dictionary source is empty and 'require_nonempty' property is set.",
             getFullName());
 }
 
-template <DictionaryKeyType dictionary_key_type>
-void HashedArrayDictionary<dictionary_key_type>::buildHierarchyParentToChildIndexIfNeeded()
+template <DictionaryKeyType dictionary_key_type, bool sharded>
+void HashedArrayDictionary<dictionary_key_type, sharded>::buildHierarchyParentToChildIndexIfNeeded()
 {
     if (!dict_struct.hierarchical_attribute_index)
         return;
@@ -781,12 +848,13 @@ void HashedArrayDictionary<dictionary_key_type>::buildHierarchyParentToChildInde
         hierarchical_index = getHierarchicalIndex();
 }
 
-template <DictionaryKeyType dictionary_key_type>
-void HashedArrayDictionary<dictionary_key_type>::calculateBytesAllocated()
+template <DictionaryKeyType dictionary_key_type, bool sharded>
+void HashedArrayDictionary<dictionary_key_type, sharded>::calculateBytesAllocated()
 {
     bytes_allocated += attributes.size() * sizeof(attributes.front());
 
-    bytes_allocated += key_attribute.container.size();
+    for (const auto & container : key_attribute.containers)
+        bytes_allocated += container.size();
 
     for (auto & attribute : attributes)
     {
@@ -796,26 +864,29 @@ void HashedArrayDictionary<dictionary_key_type>::calculateBytesAllocated()
             using AttributeType = typename Type::AttributeType;
             using ValueType = DictionaryValueType<AttributeType>;
 
-            const auto & container = std::get<AttributeContainerType<ValueType>>(attribute.container);
-            bytes_allocated += sizeof(AttributeContainerType<ValueType>);
-
-            if constexpr (std::is_same_v<ValueType, Array>)
+            for (const auto & container : std::get<AttributeContainerShardsType<ValueType>>(attribute.containers))
             {
-                /// It is not accurate calculations
-                bytes_allocated += sizeof(Array) * container.size();
-            }
-            else
-            {
-                bytes_allocated += container.allocated_bytes();
-            }
+                bytes_allocated += sizeof(AttributeContainerType<ValueType>);
 
-            bucket_count = container.capacity();
+                if constexpr (std::is_same_v<ValueType, Array>)
+                {
+                    /// It is not accurate calculations
+                    bytes_allocated += sizeof(Array) * container.size();
+                }
+                else
+                {
+                    bytes_allocated += container.allocated_bytes();
+                }
+
+                bucket_count = container.capacity();
+            }
         };
 
         callOnDictionaryAttributeType(attribute.type, type_call);
 
         if (attribute.is_index_null.has_value())
-            bytes_allocated += (*attribute.is_index_null).size();
+            for (const auto & container : attribute.is_index_null.value())
+                bytes_allocated += container.size();
     }
 
     if (update_field_loaded_block)
@@ -826,18 +897,19 @@ void HashedArrayDictionary<dictionary_key_type>::calculateBytesAllocated()
         hierarchical_index_bytes_allocated = hierarchical_index->getSizeInBytes();
         bytes_allocated += hierarchical_index_bytes_allocated;
     }
-
-    bytes_allocated += string_arena.allocatedBytes();
+    for (const auto & string_arena : string_arenas)
+        bytes_allocated += string_arena->allocatedBytes();
 }
 
-template <DictionaryKeyType dictionary_key_type>
-Pipe HashedArrayDictionary<dictionary_key_type>::read(const Names & column_names, size_t max_block_size, size_t num_streams) const
+template <DictionaryKeyType dictionary_key_type, bool sharded>
+Pipe HashedArrayDictionary<dictionary_key_type, sharded>::read(const Names & column_names, size_t max_block_size, size_t num_streams) const
 {
     PaddedPODArray<HashedArrayDictionary::KeyType> keys;
-    keys.reserve(key_attribute.container.size());
+    keys.reserve(total_element_count);
 
-    for (auto & [key, _] : key_attribute.container)
-        keys.emplace_back(key);
+    for (const auto & container : key_attribute.containers)
+        for (auto & [key, _] : container)
+            keys.emplace_back(key);
 
     ColumnsWithTypeAndName key_columns;
 
@@ -858,8 +930,10 @@ Pipe HashedArrayDictionary<dictionary_key_type>::read(const Names & column_names
     return result;
 }
 
-template class HashedArrayDictionary<DictionaryKeyType::Simple>;
-template class HashedArrayDictionary<DictionaryKeyType::Complex>;
+template class HashedArrayDictionary<DictionaryKeyType::Simple, /* sharded */ false>;
+template class HashedArrayDictionary<DictionaryKeyType::Simple, /* sharded */ true>;
+template class HashedArrayDictionary<DictionaryKeyType::Complex, /* sharded */ false>;
+template class HashedArrayDictionary<DictionaryKeyType::Complex, /* sharded */ true>;
 
 void registerDictionaryArrayHashed(DictionaryFactory & factory)
 {
@@ -886,7 +960,14 @@ void registerDictionaryArrayHashed(DictionaryFactory & factory)
         const DictionaryLifetime dict_lifetime{config, config_prefix + ".lifetime"};
         const bool require_nonempty = config.getBool(config_prefix + ".require_nonempty", false);
 
-        HashedArrayDictionaryStorageConfiguration configuration{require_nonempty, dict_lifetime};
+        std::string dictionary_layout_name = dictionary_key_type == DictionaryKeyType::Simple ? "hashed_array" : "complex_key_hashed_array";
+        std::string dictionary_layout_prefix = ".layout." + dictionary_layout_name;
+
+        Int64 shards = config.getInt(config_prefix + dictionary_layout_prefix + ".shards", 1);
+        if (shards <= 0 || 128 < shards)
+            throw Exception(ErrorCodes::BAD_ARGUMENTS,"{}: SHARDS parameter should be within [1, 128]", full_name);
+
+        HashedArrayDictionaryStorageConfiguration configuration{require_nonempty, dict_lifetime, static_cast<size_t>(shards)};
 
         ContextMutablePtr context = copyContextAndApplySettingsFromDictionaryConfig(global_context, config, config_prefix);
         const auto & settings = context->getSettingsRef();
@@ -895,9 +976,17 @@ void registerDictionaryArrayHashed(DictionaryFactory & factory)
         configuration.use_async_executor = clickhouse_source && clickhouse_source->isLocal() && settings.dictionary_use_async_executor;
 
         if (dictionary_key_type == DictionaryKeyType::Simple)
-            return std::make_unique<HashedArrayDictionary<DictionaryKeyType::Simple>>(dict_id, dict_struct, std::move(source_ptr), configuration);
+        {
+            if (shards > 1)
+                return std::make_unique<HashedArrayDictionary<DictionaryKeyType::Simple, true>>(dict_id, dict_struct, std::move(source_ptr), configuration);
+            return std::make_unique<HashedArrayDictionary<DictionaryKeyType::Simple, false>>(dict_id, dict_struct, std::move(source_ptr), configuration);
+        }
         else
-            return std::make_unique<HashedArrayDictionary<DictionaryKeyType::Complex>>(dict_id, dict_struct, std::move(source_ptr), configuration);
+        {
+            if (shards > 1)
+                return std::make_unique<HashedArrayDictionary<DictionaryKeyType::Complex, true>>(dict_id, dict_struct, std::move(source_ptr), configuration);
+            return std::make_unique<HashedArrayDictionary<DictionaryKeyType::Complex, false>>(dict_id, dict_struct, std::move(source_ptr), configuration);
+        }
     };
 
     factory.registerLayout("hashed_array",

--- a/src/Dictionaries/HashedArrayDictionary.h
+++ b/src/Dictionaries/HashedArrayDictionary.h
@@ -13,6 +13,7 @@
 #include <Dictionaries/IDictionary.h>
 #include <Dictionaries/IDictionarySource.h>
 #include <Dictionaries/DictionaryHelpers.h>
+#include <Dictionaries/HashedDictionaryParallelLoader.h>
 
 /** This dictionary stores all attributes in arrays.
   * Key is stored in hash table and value is index into attribute array.
@@ -25,12 +26,17 @@ struct HashedArrayDictionaryStorageConfiguration
 {
     const bool require_nonempty;
     const DictionaryLifetime lifetime;
+    size_t shards = 1;
+    size_t shard_load_queue_backlog = 10000;
     bool use_async_executor = false;
 };
 
-template <DictionaryKeyType dictionary_key_type>
+template <DictionaryKeyType dictionary_key_type, bool sharded>
 class HashedArrayDictionary final : public IDictionary
 {
+    using DictionaryParallelLoaderType = HashedDictionaryImpl::HashedDictionaryParallelLoader<dictionary_key_type, HashedArrayDictionary<dictionary_key_type, sharded>>;
+    friend class HashedDictionaryImpl::HashedDictionaryParallelLoader<dictionary_key_type, HashedArrayDictionary<dictionary_key_type, sharded>>;
+
 public:
     using KeyType = std::conditional_t<dictionary_key_type == DictionaryKeyType::Simple, UInt64, StringRef>;
 
@@ -63,13 +69,13 @@ public:
 
     double getHitRate() const override { return 1.0; }
 
-    size_t getElementCount() const override { return element_count; }
+    size_t getElementCount() const override { return total_element_count; }
 
-    double getLoadFactor() const override { return static_cast<double>(element_count) / bucket_count; }
+    double getLoadFactor() const override { return static_cast<double>(total_element_count) / bucket_count; }
 
     std::shared_ptr<const IExternalLoadable> clone() const override
     {
-        return std::make_shared<HashedArrayDictionary<dictionary_key_type>>(getDictionaryID(), dict_struct, source_ptr->clone(), configuration, update_field_loaded_block);
+        return std::make_shared<HashedArrayDictionary<dictionary_key_type, sharded>>(getDictionaryID(), dict_struct, source_ptr->clone(), configuration, update_field_loaded_block);
     }
 
     DictionarySourcePtr getSource() const override { return source_ptr; }
@@ -132,50 +138,54 @@ private:
     template <typename Value>
     using AttributeContainerType = std::conditional_t<std::is_same_v<Value, Array>, std::vector<Value>, PaddedPODArray<Value>>;
 
+    template <typename Value>
+    using AttributeContainerShardsType = std::vector<AttributeContainerType<Value>>;
+
     struct Attribute final
     {
         AttributeUnderlyingType type;
 
         std::variant<
-            AttributeContainerType<UInt8>,
-            AttributeContainerType<UInt16>,
-            AttributeContainerType<UInt32>,
-            AttributeContainerType<UInt64>,
-            AttributeContainerType<UInt128>,
-            AttributeContainerType<UInt256>,
-            AttributeContainerType<Int8>,
-            AttributeContainerType<Int16>,
-            AttributeContainerType<Int32>,
-            AttributeContainerType<Int64>,
-            AttributeContainerType<Int128>,
-            AttributeContainerType<Int256>,
-            AttributeContainerType<Decimal32>,
-            AttributeContainerType<Decimal64>,
-            AttributeContainerType<Decimal128>,
-            AttributeContainerType<Decimal256>,
-            AttributeContainerType<DateTime64>,
-            AttributeContainerType<Float32>,
-            AttributeContainerType<Float64>,
-            AttributeContainerType<UUID>,
-            AttributeContainerType<IPv4>,
-            AttributeContainerType<IPv6>,
-            AttributeContainerType<StringRef>,
-            AttributeContainerType<Array>>
-            container;
+            AttributeContainerShardsType<UInt8>,
+            AttributeContainerShardsType<UInt16>,
+            AttributeContainerShardsType<UInt32>,
+            AttributeContainerShardsType<UInt64>,
+            AttributeContainerShardsType<UInt128>,
+            AttributeContainerShardsType<UInt256>,
+            AttributeContainerShardsType<Int8>,
+            AttributeContainerShardsType<Int16>,
+            AttributeContainerShardsType<Int32>,
+            AttributeContainerShardsType<Int64>,
+            AttributeContainerShardsType<Int128>,
+            AttributeContainerShardsType<Int256>,
+            AttributeContainerShardsType<Decimal32>,
+            AttributeContainerShardsType<Decimal64>,
+            AttributeContainerShardsType<Decimal128>,
+            AttributeContainerShardsType<Decimal256>,
+            AttributeContainerShardsType<DateTime64>,
+            AttributeContainerShardsType<Float32>,
+            AttributeContainerShardsType<Float64>,
+            AttributeContainerShardsType<UUID>,
+            AttributeContainerShardsType<IPv4>,
+            AttributeContainerShardsType<IPv6>,
+            AttributeContainerShardsType<StringRef>,
+            AttributeContainerShardsType<Array>>
+            containers;
 
-        std::optional<std::vector<bool>> is_index_null;
+        /// One container per shard
+        using RowsMask = std::vector<bool>;
+        std::optional<std::vector<RowsMask>> is_index_null;
     };
 
     struct KeyAttribute final
     {
-
-        KeyContainerType container;
-
+        /// One container per shard
+        std::vector<KeyContainerType> containers;
     };
 
     void createAttributes();
 
-    void blockToAttributes(const Block & block);
+    void blockToAttributes(const Block & block, DictionaryKeysArenaHolder<dictionary_key_type> & arena_holder, size_t shard);
 
     void updateData();
 
@@ -184,6 +194,22 @@ private:
     void buildHierarchyParentToChildIndexIfNeeded();
 
     void calculateBytesAllocated();
+
+    UInt64 getShard(UInt64 key) const
+    {
+        if constexpr (!sharded)
+            return 0;
+        /// NOTE: function here should not match with the DefaultHash<> since
+        /// it used for the HashMap/sparse_hash_map.
+        return intHashCRC32(key) % configuration.shards;
+    }
+
+    UInt64 getShard(StringRef key) const
+    {
+        if constexpr (!sharded)
+            return 0;
+        return StringRefHash()(key) % configuration.shards;
+    }
 
     template <typename KeysProvider>
     ColumnPtr getAttributeColumn(
@@ -200,10 +226,13 @@ private:
         ValueSetter && set_value,
         DefaultValueExtractor & default_value_extractor) const;
 
+
+    using KeyIndexToElementIndex = std::conditional_t<sharded, PaddedPODArray<std::pair<ssize_t, UInt8>>, PaddedPODArray<ssize_t>>;
+
     template <typename AttributeType, bool is_nullable, typename ValueSetter, typename DefaultValueExtractor>
     void getItemsImpl(
         const Attribute & attribute,
-        const PaddedPODArray<ssize_t> & key_index_to_element_index,
+        const KeyIndexToElementIndex & key_index_to_element_index,
         ValueSetter && set_value,
         DefaultValueExtractor & default_value_extractor) const;
 
@@ -215,6 +244,8 @@ private:
 
     void resize(size_t total_rows);
 
+    Poco::Logger * log;
+
     const DictionaryStructure dict_struct;
     const DictionarySourcePtr source_ptr;
     const HashedArrayDictionaryStorageConfiguration configuration;
@@ -225,17 +256,20 @@ private:
 
     size_t bytes_allocated = 0;
     size_t hierarchical_index_bytes_allocated = 0;
-    size_t element_count = 0;
+    std::atomic<size_t> total_element_count = 0;
+    std::vector<size_t> element_counts;
     size_t bucket_count = 0;
     mutable std::atomic<size_t> query_count{0};
     mutable std::atomic<size_t> found_count{0};
 
     BlockPtr update_field_loaded_block;
-    Arena string_arena;
+    std::vector<std::unique_ptr<Arena>> string_arenas;
     DictionaryHierarchicalParentToChildIndexPtr hierarchical_index;
 };
 
-extern template class HashedArrayDictionary<DictionaryKeyType::Simple>;
-extern template class HashedArrayDictionary<DictionaryKeyType::Complex>;
+extern template class HashedArrayDictionary<DictionaryKeyType::Simple, false>;
+extern template class HashedArrayDictionary<DictionaryKeyType::Simple, true>;
+extern template class HashedArrayDictionary<DictionaryKeyType::Complex, false>;
+extern template class HashedArrayDictionary<DictionaryKeyType::Complex, true>;
 
 }

--- a/src/Dictionaries/HashedDictionary.h
+++ b/src/Dictionaries/HashedDictionary.h
@@ -71,7 +71,8 @@ struct HashedDictionaryConfiguration
 template <DictionaryKeyType dictionary_key_type, bool sparse, bool sharded>
 class HashedDictionary final : public IDictionary
 {
-    friend class HashedDictionaryParallelLoader<dictionary_key_type, sparse, sharded>;
+    using DictionaryParallelLoaderType = HashedDictionaryParallelLoader<dictionary_key_type, HashedDictionary<dictionary_key_type, sparse, sharded>>;
+    friend class HashedDictionaryParallelLoader<dictionary_key_type, HashedDictionary<dictionary_key_type, sparse, sharded>>;
 
 public:
     using KeyType = std::conditional_t<dictionary_key_type == DictionaryKeyType::Simple, UInt64, StringRef>;
@@ -987,7 +988,7 @@ void HashedDictionary<dictionary_key_type, sparse, sharded>::getItemsImpl(
         auto key = keys_extractor.extractCurrentKey();
         auto shard = getShard(key);
 
-        const auto & container = attribute_containers[getShard(key)];
+        const auto & container = attribute_containers[shard];
         const auto it = container.find(key);
 
         if (it != container.end())
@@ -1020,11 +1021,11 @@ void HashedDictionary<dictionary_key_type, sparse, sharded>::loadData()
 {
     if (!source_ptr->hasUpdateField())
     {
-        std::optional<HashedDictionaryParallelLoader<dictionary_key_type, sparse, sharded>> parallel_loader;
+        std::optional<DictionaryParallelLoaderType> parallel_loader;
         if constexpr (sharded)
             parallel_loader.emplace(*this);
 
-        QueryPipeline pipeline = QueryPipeline(source_ptr->loadAll());
+        QueryPipeline pipeline(source_ptr->loadAll());
 
         DictionaryPipelineExecutor executor(pipeline, configuration.use_async_executor);
         Block block;

--- a/src/Dictionaries/HashedDictionaryParallelLoader.h
+++ b/src/Dictionaries/HashedDictionaryParallelLoader.h
@@ -38,13 +38,12 @@ namespace DB::HashedDictionaryImpl
 {
 
 /// Implementation parallel dictionary load for SHARDS
-template <DictionaryKeyType dictionary_key_type, bool sparse, bool sharded>
+template <DictionaryKeyType dictionary_key_type, typename DictionaryType>
 class HashedDictionaryParallelLoader : public boost::noncopyable
 {
-    using HashedDictionary = HashedDictionary<dictionary_key_type, sparse, sharded>;
 
 public:
-    explicit HashedDictionaryParallelLoader(HashedDictionary & dictionary_)
+    explicit HashedDictionaryParallelLoader(DictionaryType & dictionary_)
         : dictionary(dictionary_)
         , shards(dictionary.configuration.shards)
         , pool(CurrentMetrics::HashedDictionaryThreads, CurrentMetrics::HashedDictionaryThreadsActive, CurrentMetrics::HashedDictionaryThreadsScheduled, shards)
@@ -118,7 +117,7 @@ public:
     }
 
 private:
-    HashedDictionary & dictionary;
+    DictionaryType & dictionary;
     const size_t shards;
     ThreadPool pool;
     std::vector<std::optional<ConcurrentBoundedQueue<Block>>> shards_queues;

--- a/tests/queries/0_stateless/02098_hashed_array_dictionary_simple_key.reference
+++ b/tests/queries/0_stateless/02098_hashed_array_dictionary_simple_key.reference
@@ -26,6 +26,34 @@ select all values as input stream
 0	value_0	value_second_0
 1	value_1	value_second_1
 2	value_2	value_second_2
+Dictionary hashed_array_dictionary_simple_key_simple_attributes
+dictGet existing value
+value_0	value_second_0
+value_1	value_second_1
+value_2	value_second_2
+dictGet with non existing value
+value_0	value_second_0
+value_1	value_second_1
+value_2	value_second_2
+value_first_default	value_second_default
+dictGetOrDefault existing value
+value_0	value_second_0
+value_1	value_second_1
+value_2	value_second_2
+dictGetOrDefault non existing value
+value_0	value_second_0
+value_1	value_second_1
+value_2	value_second_2
+default	default
+dictHas
+1
+1
+1
+0
+select all values as input stream
+0	value_0	value_second_0
+1	value_1	value_second_1
+2	value_2	value_second_2
 Dictionary hashed_array_dictionary_simple_key_complex_attributes
 dictGet existing value
 value_0	value_second_0
@@ -54,6 +82,44 @@ select all values as input stream
 0	value_0	value_second_0
 1	value_1	\N
 2	value_2	value_second_2
+Dictionary hashed_array_dictionary_simple_key_complex_attributes
+dictGet existing value
+value_0	value_second_0
+value_1	\N
+value_2	value_second_2
+dictGet with non existing value
+value_0	value_second_0
+value_1	\N
+value_2	value_second_2
+value_first_default	value_second_default
+dictGetOrDefault existing value
+value_0	value_second_0
+value_1	\N
+value_2	value_second_2
+dictGetOrDefault non existing value
+value_0	value_second_0
+value_1	\N
+value_2	value_second_2
+default	default
+dictHas
+1
+1
+1
+0
+select all values as input stream
+0	value_0	value_second_0
+1	value_1	\N
+2	value_2	value_second_2
+Dictionary hashed_array_dictionary_simple_key_hierarchy
+dictGet
+0
+0
+1
+1
+2
+dictGetHierarchy
+[1]
+[4,2,1]
 Dictionary hashed_array_dictionary_simple_key_hierarchy
 dictGet
 0

--- a/tests/queries/0_stateless/02098_hashed_array_dictionary_simple_key.sql.j2
+++ b/tests/queries/0_stateless/02098_hashed_array_dictionary_simple_key.sql.j2
@@ -11,6 +11,8 @@ INSERT INTO simple_key_simple_attributes_source_table VALUES(0, 'value_0', 'valu
 INSERT INTO simple_key_simple_attributes_source_table VALUES(1, 'value_1', 'value_second_1');
 INSERT INTO simple_key_simple_attributes_source_table VALUES(2, 'value_2', 'value_second_2');
 
+{% for dictionary_config in ['', 'SHARDS 16'] -%}
+
 DROP DICTIONARY IF EXISTS hashed_array_dictionary_simple_key_simple_attributes;
 CREATE DICTIONARY hashed_array_dictionary_simple_key_simple_attributes
 (
@@ -20,7 +22,7 @@ CREATE DICTIONARY hashed_array_dictionary_simple_key_simple_attributes
 )
 PRIMARY KEY id
 SOURCE(CLICKHOUSE(TABLE 'simple_key_simple_attributes_source_table'))
-LAYOUT(HASHED_ARRAY())
+LAYOUT(HASHED_ARRAY({{ dictionary_config }}))
 LIFETIME(MIN 1 MAX 1000)
 SETTINGS(dictionary_use_async_executor=1, max_threads=8);
 
@@ -43,6 +45,7 @@ SELECT 'select all values as input stream';
 SELECT * FROM hashed_array_dictionary_simple_key_simple_attributes ORDER BY id;
 
 DROP DICTIONARY hashed_array_dictionary_simple_key_simple_attributes;
+{% endfor %}
 
 DROP TABLE simple_key_simple_attributes_source_table;
 
@@ -59,6 +62,8 @@ INSERT INTO simple_key_complex_attributes_source_table VALUES(0, 'value_0', 'val
 INSERT INTO simple_key_complex_attributes_source_table VALUES(1, 'value_1', NULL);
 INSERT INTO simple_key_complex_attributes_source_table VALUES(2, 'value_2', 'value_second_2');
 
+{% for dictionary_config in ['', 'SHARDS 16'] -%}
+
 DROP DICTIONARY IF EXISTS hashed_array_dictionary_simple_key_complex_attributes;
 CREATE DICTIONARY hashed_array_dictionary_simple_key_complex_attributes
 (
@@ -68,7 +73,7 @@ CREATE DICTIONARY hashed_array_dictionary_simple_key_complex_attributes
 )
 PRIMARY KEY id
 SOURCE(CLICKHOUSE(TABLE 'simple_key_complex_attributes_source_table'))
-LAYOUT(HASHED_ARRAY())
+LAYOUT(HASHED_ARRAY({{ dictionary_config }}))
 LIFETIME(MIN 1 MAX 1000);
 
 SELECT 'Dictionary hashed_array_dictionary_simple_key_complex_attributes';
@@ -90,6 +95,9 @@ SELECT 'select all values as input stream';
 SELECT * FROM hashed_array_dictionary_simple_key_complex_attributes ORDER BY id;
 
 DROP DICTIONARY hashed_array_dictionary_simple_key_complex_attributes;
+
+{% endfor %}
+
 DROP TABLE simple_key_complex_attributes_source_table;
 
 DROP TABLE IF EXISTS simple_key_hierarchy_table;
@@ -104,6 +112,8 @@ INSERT INTO simple_key_hierarchy_table VALUES (2, 1);
 INSERT INTO simple_key_hierarchy_table VALUES (3, 1);
 INSERT INTO simple_key_hierarchy_table VALUES (4, 2);
 
+{% for dictionary_config in ['', 'SHARDS 16'] -%}
+
 DROP DICTIONARY IF EXISTS hashed_array_dictionary_simple_key_hierarchy;
 CREATE DICTIONARY hashed_array_dictionary_simple_key_hierarchy
 (
@@ -112,7 +122,7 @@ CREATE DICTIONARY hashed_array_dictionary_simple_key_hierarchy
 )
 PRIMARY KEY id
 SOURCE(CLICKHOUSE(HOST 'localhost' PORT tcpPort() USER 'default' TABLE 'simple_key_hierarchy_table'))
-LAYOUT(HASHED_ARRAY())
+LAYOUT(HASHED_ARRAY({{ dictionary_config }}))
 LIFETIME(MIN 1 MAX 1000);
 
 SELECT 'Dictionary hashed_array_dictionary_simple_key_hierarchy';
@@ -122,5 +132,8 @@ SELECT 'dictGetHierarchy';
 SELECT dictGetHierarchy('hashed_array_dictionary_simple_key_hierarchy', toUInt64(1));
 SELECT dictGetHierarchy('hashed_array_dictionary_simple_key_hierarchy', toUInt64(4));
 
+{% endfor %}
+
 DROP DICTIONARY hashed_array_dictionary_simple_key_hierarchy;
+
 DROP TABLE simple_key_hierarchy_table;

--- a/tests/queries/0_stateless/02099_hashed_array_dictionary_complex_key.reference
+++ b/tests/queries/0_stateless/02099_hashed_array_dictionary_complex_key.reference
@@ -26,6 +26,62 @@ select all values as input stream
 0	id_key_0	value_0	value_second_0
 1	id_key_1	value_1	value_second_1
 2	id_key_2	value_2	value_second_2
+Dictionary hashed_array_dictionary_complex_key_simple_attributes
+dictGet existing value
+value_0	value_second_0
+value_1	value_second_1
+value_2	value_second_2
+dictGet with non existing value
+value_0	value_second_0
+value_1	value_second_1
+value_2	value_second_2
+value_first_default	value_second_default
+dictGetOrDefault existing value
+value_0	value_second_0
+value_1	value_second_1
+value_2	value_second_2
+dictGetOrDefault non existing value
+value_0	value_second_0
+value_1	value_second_1
+value_2	value_second_2
+default	default
+dictHas
+1
+1
+1
+0
+select all values as input stream
+0	id_key_0	value_0	value_second_0
+1	id_key_1	value_1	value_second_1
+2	id_key_2	value_2	value_second_2
+Dictionary hashed_array_dictionary_complex_key_complex_attributes
+dictGet existing value
+value_0	value_second_0
+value_1	\N
+value_2	value_second_2
+dictGet with non existing value
+value_0	value_second_0
+value_1	\N
+value_2	value_second_2
+value_first_default	value_second_default
+dictGetOrDefault existing value
+value_0	value_second_0
+value_1	\N
+value_2	value_second_2
+dictGetOrDefault non existing value
+value_0	value_second_0
+value_1	\N
+value_2	value_second_2
+default	default
+dictHas
+1
+1
+1
+0
+select all values as input stream
+0	id_key_0	value_0	value_second_0
+1	id_key_1	value_1	\N
+2	id_key_2	value_2	value_second_2
 Dictionary hashed_array_dictionary_complex_key_complex_attributes
 dictGet existing value
 value_0	value_second_0

--- a/tests/queries/0_stateless/02099_hashed_array_dictionary_complex_key.sql.j2
+++ b/tests/queries/0_stateless/02099_hashed_array_dictionary_complex_key.sql.j2
@@ -12,6 +12,8 @@ INSERT INTO complex_key_simple_attributes_source_table VALUES(0, 'id_key_0', 'va
 INSERT INTO complex_key_simple_attributes_source_table VALUES(1, 'id_key_1', 'value_1', 'value_second_1');
 INSERT INTO complex_key_simple_attributes_source_table VALUES(2, 'id_key_2', 'value_2', 'value_second_2');
 
+{% for dictionary_config in ['', 'SHARDS 16'] -%}
+
 DROP DICTIONARY IF EXISTS hashed_array_dictionary_complex_key_simple_attributes;
 CREATE DICTIONARY hashed_array_dictionary_complex_key_simple_attributes
 (
@@ -23,7 +25,7 @@ CREATE DICTIONARY hashed_array_dictionary_complex_key_simple_attributes
 PRIMARY KEY id, id_key
 SOURCE(CLICKHOUSE(TABLE 'complex_key_simple_attributes_source_table'))
 LIFETIME(MIN 1 MAX 1000)
-LAYOUT(COMPLEX_KEY_HASHED_ARRAY());
+LAYOUT(COMPLEX_KEY_HASHED_ARRAY({{ dictionary_config }}));
 
 SELECT 'Dictionary hashed_array_dictionary_complex_key_simple_attributes';
 SELECT 'dictGet existing value';
@@ -45,6 +47,8 @@ SELECT * FROM hashed_array_dictionary_complex_key_simple_attributes ORDER BY (id
 
 DROP DICTIONARY hashed_array_dictionary_complex_key_simple_attributes;
 
+{% endfor %}
+
 DROP TABLE complex_key_simple_attributes_source_table;
 
 DROP TABLE IF EXISTS complex_key_complex_attributes_source_table;
@@ -61,6 +65,8 @@ INSERT INTO complex_key_complex_attributes_source_table VALUES(0, 'id_key_0', 'v
 INSERT INTO complex_key_complex_attributes_source_table VALUES(1, 'id_key_1', 'value_1', NULL);
 INSERT INTO complex_key_complex_attributes_source_table VALUES(2, 'id_key_2', 'value_2', 'value_second_2');
 
+{% for dictionary_config in ['', 'SHARDS 16'] -%}
+
 DROP DICTIONARY IF EXISTS hashed_array_dictionary_complex_key_complex_attributes;
 CREATE DICTIONARY hashed_array_dictionary_complex_key_complex_attributes
 (
@@ -73,7 +79,7 @@ CREATE DICTIONARY hashed_array_dictionary_complex_key_complex_attributes
 PRIMARY KEY id, id_key
 SOURCE(CLICKHOUSE(TABLE 'complex_key_complex_attributes_source_table'))
 LIFETIME(MIN 1 MAX 1000)
-LAYOUT(COMPLEX_KEY_HASHED_ARRAY());
+LAYOUT(COMPLEX_KEY_HASHED_ARRAY({{ dictionary_config }}));
 
 SELECT 'Dictionary hashed_array_dictionary_complex_key_complex_attributes';
 SELECT 'dictGet existing value';
@@ -92,6 +98,8 @@ SELECT 'dictHas';
 SELECT dictHas('hashed_array_dictionary_complex_key_complex_attributes', (number, concat('id_key_', toString(number)))) FROM system.numbers LIMIT 4;
 SELECT 'select all values as input stream';
 SELECT * FROM hashed_array_dictionary_complex_key_complex_attributes ORDER BY (id, id_key);
+
+{% endfor %}
 
 DROP DICTIONARY hashed_array_dictionary_complex_key_complex_attributes;
 DROP TABLE complex_key_complex_attributes_source_table;

--- a/tests/queries/0_stateless/02311_hashed_array_dictionary_hierarchical_functions.reference
+++ b/tests/queries/0_stateless/02311_hashed_array_dictionary_hierarchical_functions.reference
@@ -33,3 +33,38 @@ Get descendants at first level
 []
 []
 []
+Get hierarchy
+[]
+[1]
+[2,1]
+[3,1]
+[4,2,1]
+[]
+Get is in hierarchy
+0
+1
+1
+1
+1
+0
+Get children
+[1]
+[2,3]
+[4]
+[]
+[]
+[]
+Get all descendants
+[1,2,3,4]
+[2,3,4]
+[4]
+[]
+[]
+[]
+Get descendants at first level
+[1]
+[2,3]
+[4]
+[]
+[]
+[]

--- a/tests/queries/0_stateless/02311_hashed_array_dictionary_hierarchical_functions.sql.j2
+++ b/tests/queries/0_stateless/02311_hashed_array_dictionary_hierarchical_functions.sql.j2
@@ -7,6 +7,8 @@ CREATE TABLE hierarchy_source_table
 
 INSERT INTO hierarchy_source_table VALUES (1, 0), (2, 1), (3, 1), (4, 2);
 
+{% for dictionary_config in ['', 'SHARDS 16'] -%}
+
 DROP DICTIONARY IF EXISTS hierarchy_hashed_array_dictionary;
 CREATE DICTIONARY hierarchy_hashed_array_dictionary
 (
@@ -15,7 +17,7 @@ CREATE DICTIONARY hierarchy_hashed_array_dictionary
 )
 PRIMARY KEY id
 SOURCE(CLICKHOUSE(TABLE 'hierarchy_source_table'))
-LAYOUT(HASHED_ARRAY())
+LAYOUT(HASHED_ARRAY({{ dictionary_config }}))
 LIFETIME(MIN 1 MAX 1000);
 
 SELECT 'Get hierarchy';
@@ -28,6 +30,8 @@ SELECT 'Get all descendants';
 SELECT dictGetDescendants('hierarchy_hashed_array_dictionary', number) FROM system.numbers LIMIT 6;
 SELECT 'Get descendants at first level';
 SELECT dictGetDescendants('hierarchy_hashed_array_dictionary', number, 1) FROM system.numbers LIMIT 6;
+
+{% endfor %}
 
 DROP DICTIONARY hierarchy_hashed_array_dictionary;
 

--- a/tests/queries/0_stateless/02316_hierarchical_dictionaries_nullable_parent_key.reference
+++ b/tests/queries/0_stateless/02316_hierarchical_dictionaries_nullable_parent_key.reference
@@ -106,6 +106,42 @@ Get descendants at first level
 []
 []
 []
+HashedArray dictionary
+Get hierarchy
+[0]
+[1,0]
+[2,1,0]
+[3]
+[4,2,1,0]
+[]
+Get is in hierarchy
+1
+1
+1
+1
+1
+0
+Get children
+[1]
+[2]
+[4]
+[]
+[]
+[]
+Get all descendants
+[1,2,4]
+[2,4]
+[4]
+[]
+[]
+[]
+Get descendants at first level
+[1]
+[2]
+[4]
+[]
+[]
+[]
 Cache dictionary
 Get hierarchy
 [0]

--- a/tests/queries/0_stateless/02316_hierarchical_dictionaries_nullable_parent_key.sql.j2
+++ b/tests/queries/0_stateless/02316_hierarchical_dictionaries_nullable_parent_key.sql.j2
@@ -56,7 +56,7 @@ SELECT 'Get descendants at first level';
 SELECT dictGetDescendants('hierachical_hashed_dictionary', number, 1) FROM system.numbers LIMIT 6;
 
 DROP DICTIONARY hierachical_hashed_dictionary;
-
+{% for dictionary_config in ['', 'SHARDS 16'] -%}
 DROP DICTIONARY IF EXISTS hierachical_hashed_array_dictionary;
 CREATE DICTIONARY hierachical_hashed_array_dictionary
 (
@@ -64,7 +64,7 @@ CREATE DICTIONARY hierachical_hashed_array_dictionary
     parent_id Nullable(UInt64) HIERARCHICAL
 ) PRIMARY KEY id
 SOURCE(CLICKHOUSE(TABLE 'test_hierarhical_table'))
-LAYOUT(HASHED_ARRAY())
+LAYOUT(HASHED_ARRAY({{ dictionary_config }}))
 LIFETIME(0);
 
 SELECT 'HashedArray dictionary';
@@ -81,6 +81,8 @@ SELECT 'Get descendants at first level';
 SELECT dictGetDescendants('hierachical_hashed_array_dictionary', number, 1) FROM system.numbers LIMIT 6;
 
 DROP DICTIONARY hierachical_hashed_array_dictionary;
+
+{% endfor %}
 
 DROP DICTIONARY IF EXISTS hierachical_cache_dictionary;
 CREATE DICTIONARY hierachical_cache_dictionary

--- a/tests/queries/0_stateless/02760_dictionaries_memory.sql.j2
+++ b/tests/queries/0_stateless/02760_dictionaries_memory.sql.j2
@@ -14,6 +14,7 @@ SET max_memory_usage='4Mi';
     'FLAT(INITIAL_ARRAY_SIZE 3_000_000 MAX_ARRAY_SIZE 3_000_000)',
     'HASHED()',
     'HASHED_ARRAY()',
+    'HASHED_ARRAY(SHARDS 2)',
     'SPARSE_HASHED()',
     'SPARSE_HASHED(SHARDS 2 /* shards are special, they use threads */)',
 ] %}


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- New Feature



### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
* Dictionary with `HASHED_ARRAY` (and `COMPLEX_KEY_HASHED_ARRAY`) layout supports `SHARDS` similarly to `HASHED`.


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)
