### PR TITLE
Revert "Revert "Support use alias column in indices""

### DIFF
--- a/src/Storages/IndicesDescription.cpp
+++ b/src/Storages/IndicesDescription.cpp
@@ -10,6 +10,8 @@
 #include <Parsers/parseQuery.h>
 #include <Storages/extractKeyExpressionList.h>
 
+#include <Storages/ReplaceAliasByExpressionVisitor.h>
+
 #include <Core/Defines.h>
 #include "Common/Exception.h"
 
@@ -20,6 +22,11 @@ namespace ErrorCodes
 {
     extern const int INCORRECT_QUERY;
     extern const int LOGICAL_ERROR;
+}
+
+namespace
+{
+using ReplaceAliasToExprVisitor = InDepthNodeVisitor<ReplaceAliasByExpressionMatcher, true>;
 }
 
 IndexDescription::IndexDescription(const IndexDescription & other)
@@ -94,6 +101,10 @@ IndexDescription IndexDescription::getIndexFromAST(const ASTPtr & definition_ast
     if (index_definition->expr)
     {
         expr_list = extractKeyExpressionList(index_definition->expr->clone());
+
+        ReplaceAliasToExprVisitor::Data data{columns};
+        ReplaceAliasToExprVisitor{data}.visit(expr_list);
+
         result.expression_list_ast = expr_list->clone();
     }
     else

--- a/src/Storages/ReplaceAliasByExpressionVisitor.cpp
+++ b/src/Storages/ReplaceAliasByExpressionVisitor.cpp
@@ -1,0 +1,32 @@
+#include <Storages/ReplaceAliasByExpressionVisitor.h>
+
+#include <Parsers/ASTIdentifier.h>
+#include <Parsers/ASTLiteral.h>
+#include <Storages/ColumnsDescription.h>
+#include <Common/typeid_cast.h>
+
+namespace DB
+{
+
+void ReplaceAliasByExpressionMatcher::visit(ASTPtr & ast, Data & data)
+{
+    if (auto * identifier = ast->as<ASTIdentifier>())
+    {
+        visit(*identifier, ast, data);
+    }
+}
+
+void ReplaceAliasByExpressionMatcher::visit(const ASTIdentifier & column, ASTPtr & ast, Data & data)
+{
+    const auto & column_name = column.name();
+    if (data.columns.hasAlias(column_name))
+    {
+        /// Alias expr is saved in default expr.
+        if (auto col_default = data.columns.getDefault(column_name))
+        {
+            ast = col_default->expression->clone();
+        }
+    }
+}
+
+}

--- a/src/Storages/ReplaceAliasByExpressionVisitor.h
+++ b/src/Storages/ReplaceAliasByExpressionVisitor.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <Parsers/IAST.h>
+#include <Interpreters/InDepthNodeVisitor.h>
+
+namespace DB
+{
+
+class ASTFunction;
+class ColumnsDescription;
+class ASTIdentifier;
+
+
+/* The Visitor is used to replace ALIAS by EXPRESSION when we refer to ALIAS
+ * column in index definition.
+ *
+ * For example, if we have following create statement:
+ * CREATE TABLE t
+ * (
+ *     col UInt8,
+ *     col_alias ALIAS  col + 1
+ *     INDEX idx (col_alias) TYPE minmax
+ * ) ENGINE = MergeTree ORDER BY col;
+ * we need call the visitor to replace `col_alias` by `col` + 1 when get index
+ * description from index definition AST.
+*/
+class ReplaceAliasByExpressionMatcher
+{
+public:
+    struct Data
+    {
+        const ColumnsDescription & columns;
+    };
+
+    static void visit(ASTPtr & ast, Data &);
+    static void visit(const ASTIdentifier &, ASTPtr & ast, Data &);
+    static bool needChildVisit(const ASTPtr &, const ASTPtr &) { return true; }
+};
+
+}

--- a/tests/queries/0_stateless/02911_support_alias_column_in_indices.reference
+++ b/tests/queries/0_stateless/02911_support_alias_column_in_indices.reference
@@ -1,0 +1,55 @@
+Expression ((Projection + Before ORDER BY))
+  Filter (WHERE)
+    ReadFromMergeTree (02911_support_alias_column_in_indices.test1)
+    Indexes:
+      PrimaryKey
+        Keys: 
+          c
+        Condition: (plus(c, 1) in [11, +Inf))
+        Parts: 1/2
+        Granules: 1/2
+      Skip
+        Name: i
+        Description: minmax GRANULARITY 1
+        Parts: 1/1
+        Granules: 1/1
+Expression ((Project names + Projection))
+  Filter ((WHERE + Change column names to column identifiers))
+    ReadFromMergeTree (02911_support_alias_column_in_indices.test1)
+    Indexes:
+      PrimaryKey
+        Keys: 
+          c
+        Condition: (_CAST(plus(c, \'UInt64\'), 1) in [11, +Inf))
+        Parts: 1/2
+        Granules: 1/2
+      Skip
+        Name: i
+        Description: minmax GRANULARITY 1
+        Parts: 1/1
+        Granules: 1/1
+Expression ((Projection + Before ORDER BY))
+  Filter (WHERE)
+    ReadFromMergeTree (02911_support_alias_column_in_indices.test2)
+    Indexes:
+      PrimaryKey
+        Keys: 
+          c
+        Condition: (plus(plus(c, 1), 1) in [16, +Inf))
+        Parts: 1/2
+        Granules: 1/2
+      Skip
+        Name: i
+        Description: minmax GRANULARITY 1
+        Parts: 1/1
+        Granules: 1/1
+Expression ((Project names + Projection))
+  Filter ((WHERE + Change column names to column identifiers))
+    ReadFromMergeTree (02911_support_alias_column_in_indices.test2)
+    Indexes:
+      PrimaryKey
+        Keys: 
+          c
+        Condition: (_CAST(plus(_CAST(plus(c, \'UInt64\'), 1), \'UInt64\'), 1) in [16, +Inf))
+        Parts: 1/2
+        Granules: 1/2

--- a/tests/queries/0_stateless/02911_support_alias_column_in_indices.sql
+++ b/tests/queries/0_stateless/02911_support_alias_column_in_indices.sql
@@ -9,7 +9,10 @@ create table test1
     c UInt32,
     a alias c + 1,
     index i (a) type minmax
-) engine = MergeTree order by c;
+)
+engine = MergeTree
+order by c
+settings index_granularity = 8192, min_index_granularity_bytes = 1024, index_granularity_bytes = 10485760; -- default settings, prevent randomization in tests
 
 insert into test1 select * from numbers(10);
 insert into test1 select * from numbers(11, 20);
@@ -23,7 +26,10 @@ create table test2
     a1 alias c + 1,
     a2 alias a1 + 1,
     index i (a2) type minmax
-) engine = MergeTree order by c;
+)
+engine = MergeTree
+order by c
+settings index_granularity = 8192, min_index_granularity_bytes = 1024, index_granularity_bytes = 10485760; -- default settings, prevent randomization in tests
 
 insert into test2 select * from numbers(10);
 insert into test2 select * from numbers(11, 20);

--- a/tests/queries/0_stateless/02911_support_alias_column_in_indices.sql
+++ b/tests/queries/0_stateless/02911_support_alias_column_in_indices.sql
@@ -1,0 +1,34 @@
+-- Tags: no-parallel
+
+drop database if exists 02911_support_alias_column_in_indices;
+create database 02911_support_alias_column_in_indices;
+use 02911_support_alias_column_in_indices;
+
+create table test1
+(
+    c UInt32,
+    a alias c + 1,
+    index i (a) type minmax
+) engine = MergeTree order by c;
+
+insert into test1 select * from numbers(10);
+insert into test1 select * from numbers(11, 20);
+
+explain indexes = 1 select * from test1 where a > 10 settings allow_experimental_analyzer = 0;
+explain indexes = 1 select * from test1 where a > 10 settings allow_experimental_analyzer = 1;
+
+create table test2
+(
+    c UInt32,
+    a1 alias c + 1,
+    a2 alias a1 + 1,
+    index i (a2) type minmax
+) engine = MergeTree order by c;
+
+insert into test2 select * from numbers(10);
+insert into test2 select * from numbers(11, 20);
+
+explain indexes = 1 select * from test2 where a2 > 15 settings allow_experimental_analyzer = 0;
+explain indexes = 1 select * from test2 where a2 > 15 settings allow_experimental_analyzer = 1; -- buggy, analyzer does not pick up index i
+
+drop database 02911_support_alias_column_in_indices;


### PR DESCRIPTION
Fixes #15449 
Fixes #55650

This PR re-introduces #57220 which was reverted by #57537 (4 out of 4032 runs of `02911_support_alias_column_in_indices.sql` in CI failed). The only [change](https://github.com/ClickHouse/ClickHouse/pull/57546/commits/697e967b40e1a15784aeaf5ab0f820a2352d27d3) over the original PR is that the test was stabilized.

### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
It is now possible to refer to ALIAS column in index (non-primary-key) definitions (issue #55650). Example: `CREATE TABLE tab(col UInt32, col_alias ALIAS col + 1, INDEX idx (col_alias) TYPE minmax) ENGINE = MergeTree ORDER BY col;`