### PR TITLE
Add FORMAT_BYTES as an alias for formatReadableSize

### DIFF
--- a/docs/en/sql-reference/functions/other-functions.md
+++ b/docs/en/sql-reference/functions/other-functions.md
@@ -666,6 +666,8 @@ SELECT
     formatReadableSize(filesize_bytes) AS filesize
 ```
 
+Alias: `FORMAT_BYTES`.
+
 ``` text
 ┌─filesize_bytes─┬─filesize───┐
 │              1 │ 1.00 B     │

--- a/src/Functions/formatReadableSize.cpp
+++ b/src/Functions/formatReadableSize.cpp
@@ -21,6 +21,7 @@ namespace
 REGISTER_FUNCTION(FormatReadableSize)
 {
     factory.registerFunction<FunctionFormatReadable<Impl>>();
+    factory.registerAlias("FORMAT_BYTES", Impl::name, FunctionFactory::CaseInsensitive);
 }
 
 }

--- a/tests/queries/0_stateless/00232_format_readable_size.sql
+++ b/tests/queries/0_stateless/00232_format_readable_size.sql
@@ -1,4 +1,4 @@
 WITH round(exp(number), 6) AS x, x > 0xFFFFFFFFFFFFFFFF ? 0xFFFFFFFFFFFFFFFF : toUInt64(x) AS y, x > 0x7FFFFFFF ? 0x7FFFFFFF : toInt32(x) AS z
-SELECT formatReadableSize(x), formatReadableSize(y), formatReadableSize(z)
+SELECT FORMAT_BYTES(x), format_bytes(y), formatReadableSize(z)
 FROM system.numbers
 LIMIT 70;


### PR DESCRIPTION
### Changelog category (leave one):
- New Feature

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add `FORMAT_BYTES` as an alias for `formatReadableSize`.

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

Add `FORMAT_BYTES` as an alias for `formatReadableSize` for MYSQL compatibility.

Related to:  #57589
> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
