### PR TITLE
Fix flaky test: distinct in order with analyzer

### DIFF
--- a/tests/queries/0_stateless/02676_distinct_reading_in_order_analyzer.sql
+++ b/tests/queries/0_stateless/02676_distinct_reading_in_order_analyzer.sql
@@ -5,4 +5,5 @@ set allow_experimental_analyzer=1;
 create table t (a UInt64, b UInt64) engine=MergeTree() order by (a);
 insert into t select number % 2, number from numbers(10);
 
+set optimize_distinct_in_order=1;
 select trimBoth(explain) from (explain pipeline select distinct a from t) where explain like '%InOrder%';


### PR DESCRIPTION
`optimize_distinct_in_order` is randomized, so need to set the setting explicitly

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)