### PR TITLE
Fix parsing virtual hosted S3 URI in clickhouse_backupview script

### DIFF
--- a/utils/backupview/clickhouse_backupview.py
+++ b/utils/backupview/clickhouse_backupview.py
@@ -1256,7 +1256,7 @@ class S3URI:
         host = parsed_url.netloc
         if host.find(".s3") == -1:
             return False
-        self.bucket, new_host = path.split(".s3", maxsplit=1)
+        self.bucket, new_host = host.split(".s3", maxsplit=1)
         if len(self.bucket) < 3:
             return False
         new_host = "s3" + new_host


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)