### PR TITLE
Fix docs for `fileCluster`

### DIFF
--- a/docs/en/sql-reference/table-functions/fileCluster.md
+++ b/docs/en/sql-reference/table-functions/fileCluster.md
@@ -45,7 +45,7 @@ $ cat /var/lib/clickhouse/user_files/test1.csv
     1,"file1"
     11,"file11"
 
-$ cat /var/lib/clickhouse/user_files/test1.csv
+$ cat /var/lib/clickhouse/user_files/test2.csv
     2,"file2"
     22,"file22"
 ```

--- a/docs/ru/sql-reference/table-functions/fileCluster.md
+++ b/docs/ru/sql-reference/table-functions/fileCluster.md
@@ -44,7 +44,7 @@ $ cat /var/lib/clickhouse/user_files/test1.csv
     1,"file1"
     11,"file11"
 
-$ cat /var/lib/clickhouse/user_files/test1.csv
+$ cat /var/lib/clickhouse/user_files/test2.csv
     2,"file2"
     22,"file22"
 ```


### PR DESCRIPTION
Fix typo in docs of #56868 ([comment](https://github.com/ClickHouse/ClickHouse/pull/56868#discussion_r1418754149))

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
