### PR TITLE
Moves `COMMENT` argument inside `CREATE TABLE` command.

### DIFF
--- a/docs/en/sql-reference/statements/create/table.md
+++ b/docs/en/sql-reference/statements/create/table.md
@@ -14,14 +14,14 @@ By default, tables are created only on the current server. Distributed DDL queri
 
 ### With Explicit Schema
 
-``` sql
+```sql
 CREATE TABLE [IF NOT EXISTS] [db.]table_name [ON CLUSTER cluster]
 (
     name1 [type1] [NULL|NOT NULL] [DEFAULT|MATERIALIZED|EPHEMERAL|ALIAS expr1] [compression_codec] [TTL expr1] [COMMENT 'comment for column'],
     name2 [type2] [NULL|NOT NULL] [DEFAULT|MATERIALIZED|EPHEMERAL|ALIAS expr2] [compression_codec] [TTL expr2] [COMMENT 'comment for column'],
     ...
+    COMMENT 'comment for table'
 ) ENGINE = engine
-  COMMENT 'comment for table'
 ```
 
 Creates a table named `table_name` in the `db` database or the current database if `db` is not set, with the structure specified in brackets and the `engine` engine.


### PR DESCRIPTION
### Changelog category (leave one):

- Documentation (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

- Fixes `CREATE TABLE` example by moving the `COMMENT` argument into the `CREATE TABLE` command.

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

---

Closes https://github.com/ClickHouse/clickhouse-docs/issues/1644.