### PR TITLE
Expose the total number of errors to Prometheus endpoint

### DIFF
--- a/src/Server/PrometheusMetricsWriter.cpp
+++ b/src/Server/PrometheusMetricsWriter.cpp
@@ -121,6 +121,8 @@ void PrometheusMetricsWriter::write(WriteBuffer & wb) const
 
     if (send_errors)
     {
+        size_t total_count = 0;
+
         for (size_t i = 0, end = ErrorCodes::end(); i < end; ++i)
         {
             const auto & error = ErrorCodes::values[i].get();
@@ -136,7 +138,15 @@ void PrometheusMetricsWriter::write(WriteBuffer & wb) const
             writeOutLine(wb, "# TYPE", key, "counter");
             /// We are interested in errors which are happened only on this server.
             writeOutLine(wb, key, error.local.count);
+
+            total_count += error.local.count;
         }
+
+        /// Write the total number of errors as a separate metric
+        std::string key{error_metrics_prefix + toString("ALL")};
+        writeOutLine(wb, "# HELP", key, "The total number of errors since last server restart");
+        writeOutLine(wb, "# TYPE", key, "counter");
+        writeOutLine(wb, key, total_count);
     }
 
 }

--- a/tests/integration/test_prometheus_endpoint/test.py
+++ b/tests/integration/test_prometheus_endpoint/test.py
@@ -77,3 +77,10 @@ def test_prometheus_endpoint(start_cluster):
 
     metrics_dict = get_and_check_metrics(10)
     assert metrics_dict["ClickHouseProfileEvents_Query"] >= prev_query_count + 3
+
+    node.query_and_get_error("SELECT throwIf(1, 'test', toInt16(42)) SETTINGS allow_custom_error_code_in_throwif=1")
+    metrics_dict = get_and_check_metrics(10)
+
+    assert metrics_dict["ClickHouseErrorMetric_NUMBER_OF_ARGUMENTS_DOESNT_MATCH"] >= 1
+    assert metrics_dict["ClickHouseErrorMetric_ALL"] >= 1
+

--- a/tests/integration/test_prometheus_endpoint/test.py
+++ b/tests/integration/test_prometheus_endpoint/test.py
@@ -78,9 +78,10 @@ def test_prometheus_endpoint(start_cluster):
     metrics_dict = get_and_check_metrics(10)
     assert metrics_dict["ClickHouseProfileEvents_Query"] >= prev_query_count + 3
 
-    node.query_and_get_error("SELECT throwIf(1, 'test', toInt16(42)) SETTINGS allow_custom_error_code_in_throwif=1")
+    node.query_and_get_error(
+        "SELECT throwIf(1, 'test', toInt16(42)) SETTINGS allow_custom_error_code_in_throwif=1"
+    )
     metrics_dict = get_and_check_metrics(10)
 
     assert metrics_dict["ClickHouseErrorMetric_NUMBER_OF_ARGUMENTS_DOESNT_MATCH"] >= 1
     assert metrics_dict["ClickHouseErrorMetric_ALL"] >= 1
-


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Expose the total number of errors occurred since last server as a `ClickHouseErrorMetric_ALL` metric.