### PR TITLE
Allow nodes in config with from_env/from_zk and non empty element with replace=1

### DIFF
--- a/src/Common/Config/ConfigProcessor.cpp
+++ b/src/Common/Config/ConfigProcessor.cpp
@@ -519,8 +519,9 @@ void ConfigProcessor::doIncludesRecursive(
 
     if (attr_nodes["from_zk"]) /// we have zookeeper subst
     {
-        if (node->hasChildNodes()) /// only allow substitution for nodes with no value
-            throw Poco::Exception("Element <" + node->nodeName() + "> has value, can't process from_zk substitution");
+        /// only allow substitution for nodes with no value and without "replace"
+        if (node->hasChildNodes() && !replace)
+            throw Poco::Exception("Element <" + node->nodeName() + "> has value and does not have 'replace' attribute, can't process from_zk substitution");
 
         contributing_zk_paths.insert(attr_nodes["from_zk"]->getNodeValue());
 
@@ -544,8 +545,9 @@ void ConfigProcessor::doIncludesRecursive(
 
     if (attr_nodes["from_env"]) /// we have env subst
     {
-        if (node->hasChildNodes()) /// only allow substitution for nodes with no value
-            throw Poco::Exception("Element <" + node->nodeName() + "> has value, can't process from_env substitution");
+        /// only allow substitution for nodes with no value and without "replace"
+        if (node->hasChildNodes() && !replace)
+            throw Poco::Exception("Element <" + node->nodeName() + "> has value and does not have 'replace' attribute, can't process from_env substitution");
 
         XMLDocumentPtr env_document;
         auto get_env_node = [&](const std::string & name) -> const Node *

--- a/tests/integration/test_config_substitutions/configs/000-config_with_env_subst.xml
+++ b/tests/integration/test_config_substitutions/configs/000-config_with_env_subst.xml
@@ -2,6 +2,7 @@
   <profiles>
     <default>
         <max_query_size from_env="MAX_QUERY_SIZE" />
+        <max_threads replace="1" from_env="MAX_THREADS">1</max_threads>
     </default>
   </profiles>
   <users>

--- a/tests/integration/test_config_substitutions/test.py
+++ b/tests/integration/test_config_substitutions/test.py
@@ -1,6 +1,7 @@
 import pytest
 
 from helpers.cluster import ClickHouseCluster
+from helpers.client import QueryRuntimeException
 
 cluster = ClickHouseCluster(__file__)
 node1 = cluster.add_instance(
@@ -36,9 +37,13 @@ node7 = cluster.add_instance(
         "configs/000-config_with_env_subst.xml",
         "configs/010-env_subst_override.xml",
     ],
-    env_variables={"MAX_QUERY_SIZE": "121212"},
+    env_variables={
+        # overridden with 424242
+        "MAX_QUERY_SIZE": "121212",
+        "MAX_THREADS": "2",
+    },
     instance_env_variables=True,
-)  # overridden with 424242
+)
 
 
 @pytest.fixture(scope="module")
@@ -91,6 +96,65 @@ def test_config(start_cluster):
         node7.query("select value from system.settings where name = 'max_query_size'")
         == "424242\n"
     )
+    assert (
+        node7.query("select value from system.settings where name = 'max_threads'")
+        == "2\n"
+    )
+
+
+def test_config_invalid_overrides(start_cluster):
+    node7.replace_config(
+        "/etc/clickhouse-server/users.d/000-config_with_env_subst.xml",
+        """
+<clickhouse>
+  <profiles>
+    <default>
+        <max_query_size from_env="MAX_QUERY_SIZE" />
+        <max_threads from_env="MAX_THREADS">100</max_threads>
+    </default>
+  </profiles>
+  <users>
+      <default>
+          <password></password>
+          <profile>default</profile>
+          <quota>default</quota>
+      </default>
+
+      <include incl="users_1" />
+      <include incl="users_2" />
+  </users>
+</clickhouse>
+""",
+    )
+    with pytest.raises(
+        QueryRuntimeException,
+        match="Failed to preprocess config '/etc/clickhouse-server/users.xml': Exception: Element <max_threads> has value and does not have 'replace' attribute, can't process from_env substitution",
+    ):
+        node7.query("SYSTEM RELOAD CONFIG")
+    node7.replace_config(
+        "/etc/clickhouse-server/users.d/000-config_with_env_subst.xml",
+        """
+<clickhouse>
+  <profiles>
+    <default>
+        <max_query_size from_env="MAX_QUERY_SIZE" />
+        <max_threads replace="1" from_env="MAX_THREADS">1</max_threads>
+    </default>
+  </profiles>
+  <users>
+      <default>
+          <password></password>
+          <profile>default</profile>
+          <quota>default</quota>
+      </default>
+
+      <include incl="users_1" />
+      <include incl="users_2" />
+  </users>
+</clickhouse>
+""",
+    )
+    node7.query("SYSTEM RELOAD CONFIG")
 
 
 def test_include_config(start_cluster):


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Allow nodes in config with from_env/from_zk and non empty element with replace=1

Such nodes in config are useful as a nodes with default values, that can be overwritten from ZooKeeper/env.

So after this patch the following is valid, and is interpreted as default value 86400, and can be overwritten via env:

```xml
<asynchronous_metrics_update_period_s replace="1" from_env="CH_ASYNCHRONOUS_METRICS_UPDATE_PERIOD_S">86400</asynchronous_metrics_update_period_s>
```

While the following is not:

```xml
<asynchronous_metrics_update_period_s             from_env="CH_ASYNCHRONOUS_METRICS_UPDATE_PERIOD_S">86400</asynchronous_metrics_update_period_s>
```

Follow-up for: #56694 (@thevar1able )