### PR TITLE
Fix "logs and exception messages formatting", part 1

### DIFF
--- a/src/Common/mysqlxx/Pool.cpp
+++ b/src/Common/mysqlxx/Pool.cpp
@@ -52,8 +52,7 @@ void Pool::Entry::decrementRefCount()
 Pool::Pool(const Poco::Util::AbstractConfiguration & cfg, const std::string & config_name,
      unsigned default_connections_, unsigned max_connections_,
      const char * parent_config_name_)
-    : logger(Poco::Logger::get("mysqlxx::Pool"))
-    , default_connections(default_connections_)
+    : default_connections(default_connections_)
     , max_connections(max_connections_)
 {
     server = cfg.getString(config_name + ".host");
@@ -127,6 +126,38 @@ Pool::Pool(const Poco::Util::AbstractConfiguration & cfg, const std::string & co
 }
 
 
+Pool::Pool(
+    const std::string & db_,
+     const std::string & server_,
+     const std::string & user_,
+     const std::string & password_,
+     unsigned port_,
+     const std::string & socket_,
+     unsigned connect_timeout_,
+     unsigned rw_timeout_,
+     unsigned default_connections_,
+     unsigned max_connections_,
+     unsigned enable_local_infile_,
+     bool opt_reconnect_)
+    : default_connections(default_connections_)
+    , max_connections(max_connections_)
+    , db(db_)
+    , server(server_)
+    , user(user_)
+    , password(password_)
+    , port(port_)
+    , socket(socket_)
+    , connect_timeout(connect_timeout_)
+    , rw_timeout(rw_timeout_)
+    , enable_local_infile(enable_local_infile_)
+    , opt_reconnect(opt_reconnect_)
+{
+    LOG_DEBUG(log,
+        "Created MySQL Pool with settings: connect_timeout={}, read_write_timeout={}, default_connections_number={}, max_connections_number={}",
+        connect_timeout, rw_timeout, default_connections, max_connections);
+}
+
+
 Pool::~Pool()
 {
     std::lock_guard lock(mutex);
@@ -148,29 +179,29 @@ Pool::Entry Pool::get(uint64_t wait_timeout)
     initialize();
     for (;;)
     {
-        logger.trace("(%s): Iterating through existing MySQL connections", getDescription());
+        LOG_TRACE(log, "{}: Iterating through existing MySQL connections", getDescription());
 
         for (auto & connection : connections)
         {
             if (connection->ref_count == 0)
             {
-                logger.test("Found free connection in pool, returning it to the caller");
+                LOG_TEST(log, "Found free connection in pool, returning it to the caller");
                 return Entry(connection, this);
             }
         }
 
-        logger.trace("(%s): Trying to allocate a new connection.", getDescription());
+        LOG_TRACE(log, "{}: Trying to allocate a new connection.", getDescription());
         if (connections.size() < static_cast<size_t>(max_connections))
         {
             Connection * conn = allocConnection();
             if (conn)
                 return Entry(conn, this);
 
-            logger.trace("(%s): Unable to create a new connection: Allocation failed.", getDescription());
+            LOG_TRACE(log, "{}: Unable to create a new connection: Allocation failed.", getDescription());
         }
         else
         {
-            logger.trace("(%s): Unable to create a new connection: Max number of connections has been reached.", getDescription());
+            LOG_TRACE(log, "{}: Unable to create a new connection: Max number of connections has been reached.", getDescription());
         }
 
         if (!wait_timeout)
@@ -180,7 +211,7 @@ Pool::Entry Pool::get(uint64_t wait_timeout)
             throw Poco::Exception("mysqlxx::Pool is full (connection_wait_timeout is exceeded)");
 
         lock.unlock();
-        logger.trace("(%s): Sleeping for %d seconds.", getDescription(), MYSQLXX_POOL_SLEEP_ON_CONNECT_FAIL);
+        LOG_TRACE(log, "{}: Sleeping for {} seconds.", getDescription(), MYSQLXX_POOL_SLEEP_ON_CONNECT_FAIL);
         sleepForSeconds(MYSQLXX_POOL_SLEEP_ON_CONNECT_FAIL);
         lock.lock();
     }
@@ -206,7 +237,7 @@ Pool::Entry Pool::tryGet()
                     return res;
             }
 
-            logger.debug("(%s): Idle connection to MySQL server cannot be recovered, dropping it.", getDescription());
+            LOG_DEBUG(log, "{}: Idle connection to MySQL server cannot be recovered, dropping it.", getDescription());
 
             /// This one is disconnected, cannot be reestablished and so needs to be disposed of.
             connection_it = connections.erase(connection_it);
@@ -229,7 +260,7 @@ Pool::Entry Pool::tryGet()
 
 void Pool::removeConnection(Connection* connection)
 {
-    logger.trace("(%s): Removing connection.", getDescription());
+    LOG_TRACE(log, "{}: Removing connection.", getDescription());
 
     std::lock_guard lock(mutex);
     if (connection)
@@ -260,8 +291,8 @@ void Pool::Entry::forceConnected() const
         else
             sleepForSeconds(MYSQLXX_POOL_SLEEP_ON_CONNECT_FAIL);
 
-        pool->logger.debug(
-            "Creating a new MySQL connection to %s with settings: connect_timeout=%u, read_write_timeout=%u",
+        LOG_DEBUG(pool->log,
+            "Creating a new MySQL connection to {} with settings: connect_timeout={}, read_write_timeout={}",
             pool->description, pool->connect_timeout, pool->rw_timeout);
 
         data->conn.connect(
@@ -287,21 +318,21 @@ bool Pool::Entry::tryForceConnected() const
     auto * const mysql_driver = data->conn.getDriver();
     const auto prev_connection_id = mysql_thread_id(mysql_driver);
 
-    pool->logger.trace("Entry(connection %lu): sending PING to check if it is alive.", prev_connection_id);
+    LOG_TRACE(pool->log, "Entry(connection {}): sending PING to check if it is alive.", prev_connection_id);
     if (data->conn.ping())  /// Attempts to reestablish lost connection
     {
         const auto current_connection_id = mysql_thread_id(mysql_driver);
         if (prev_connection_id != current_connection_id)
         {
-            pool->logger.debug("Entry(connection %lu): Reconnected to MySQL server. Connection id changed: %lu -> %lu",
-                                current_connection_id, prev_connection_id, current_connection_id);
+            LOG_DEBUG(pool->log, "Entry(connection {}): Reconnected to MySQL server. Connection id changed: {} -> {}",
+                current_connection_id, prev_connection_id, current_connection_id);
         }
 
-        pool->logger.trace("Entry(connection %lu): PING ok.", current_connection_id);
+        LOG_TRACE(pool->log, "Entry(connection {}): PING ok.", current_connection_id);
         return true;
     }
 
-    pool->logger.trace("Entry(connection %lu): PING failed.", prev_connection_id);
+    LOG_TRACE(pool->log, "Entry(connection {}): PING failed.", prev_connection_id);
     return false;
 }
 
@@ -326,10 +357,10 @@ Pool::Connection * Pool::allocConnection(bool dont_throw_if_failed_first_time)
 
     try
     {
-        logger.debug("Connecting to %s", description);
+        LOG_DEBUG(log, "Connecting to {}", description);
 
-        logger.debug(
-            "Creating a new MySQL connection to %s with settings: connect_timeout=%u, read_write_timeout=%u",
+        LOG_DEBUG(log,
+            "Creating a new MySQL connection to {} with settings: connect_timeout={}, read_write_timeout={}",
             description, connect_timeout, rw_timeout);
 
         conn_ptr->conn.connect(
@@ -349,7 +380,7 @@ Pool::Connection * Pool::allocConnection(bool dont_throw_if_failed_first_time)
     }
     catch (mysqlxx::ConnectionFailed & e)
     {
-        logger.error(e.what());
+        LOG_ERROR(log, "Failed to connect to MySQL ({}): {}", description, e.what());
 
         if ((!was_successful && !dont_throw_if_failed_first_time)
             || e.errnum() == ER_ACCESS_DENIED_ERROR

--- a/src/Common/mysqlxx/mysqlxx/Pool.h
+++ b/src/Common/mysqlxx/mysqlxx/Pool.h
@@ -169,28 +169,10 @@ public:
          unsigned default_connections_ = MYSQLXX_POOL_DEFAULT_START_CONNECTIONS,
          unsigned max_connections_ = MYSQLXX_POOL_DEFAULT_MAX_CONNECTIONS,
          unsigned enable_local_infile_ = MYSQLXX_DEFAULT_ENABLE_LOCAL_INFILE,
-         bool opt_reconnect_ = MYSQLXX_DEFAULT_MYSQL_OPT_RECONNECT)
-    : logger(Poco::Logger::get("mysqlxx::Pool"))
-    , default_connections(default_connections_)
-    , max_connections(max_connections_)
-    , db(db_)
-    , server(server_)
-    , user(user_)
-    , password(password_)
-    , port(port_)
-    , socket(socket_)
-    , connect_timeout(connect_timeout_)
-    , rw_timeout(rw_timeout_)
-    , enable_local_infile(enable_local_infile_)
-    , opt_reconnect(opt_reconnect_)
-    {
-        logger.debug(
-            "Created MySQL Pool with settings: connect_timeout=%u, read_write_timeout=%u, default_connections_number=%u, max_connections_number=%u",
-            connect_timeout, rw_timeout, default_connections, max_connections);
-    }
+         bool opt_reconnect_ = MYSQLXX_DEFAULT_MYSQL_OPT_RECONNECT);
 
     Pool(const Pool & other)
-        : logger(other.logger), default_connections{other.default_connections},
+        : default_connections{other.default_connections},
           max_connections{other.max_connections},
           db{other.db}, server{other.server},
           user{other.user}, password{other.password},
@@ -220,7 +202,7 @@ public:
     void removeConnection(Connection * connection);
 
 protected:
-    Poco::Logger & logger;
+    Poco::Logger * log = &Poco::Logger::get("mysqlxx::Pool");
 
     /// Number of MySQL connections which are created at launch.
     unsigned default_connections;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


https://s3.amazonaws.com/clickhouse-test-reports/0/05bc8ef1e02b9c7332f08091775b255d191341bf/stateless_tests__tsan__[5_5]/run.log