### PR TITLE
Read column once while reading more that one subcolumn from it in Compact parts

### DIFF
--- a/src/Storages/MergeTree/MergeTreeReaderCompact.cpp
+++ b/src/Storages/MergeTree/MergeTreeReaderCompact.cpp
@@ -216,6 +216,10 @@ size_t MergeTreeReaderCompact::readRows(
     {
         size_t rows_to_read = data_part_info_for_read->getIndexGranularity().getMarkRows(from_mark);
 
+        /// If we need to read multiple subcolumns from a single column in storage,
+        /// we will read it this column only once and then reuse to extract all subcolumns.
+        std::unordered_map<String, ColumnPtr> columns_cache_for_subcolumns;
+
         for (size_t pos = 0; pos < num_columns; ++pos)
         {
             if (!res_columns[pos])
@@ -226,7 +230,7 @@ size_t MergeTreeReaderCompact::readRows(
                 auto & column = res_columns[pos];
                 size_t column_size_before_reading = column->size();
 
-                readData(columns_to_read[pos], column, from_mark, current_task_last_mark, *column_positions[pos], rows_to_read, columns_for_offsets[pos]);
+                readData(columns_to_read[pos], column, from_mark, current_task_last_mark, *column_positions[pos], rows_to_read, columns_for_offsets[pos], columns_cache_for_subcolumns);
 
                 size_t read_rows_in_column = column->size() - column_size_before_reading;
                 if (read_rows_in_column != rows_to_read)
@@ -265,7 +269,7 @@ size_t MergeTreeReaderCompact::readRows(
 void MergeTreeReaderCompact::readData(
     const NameAndTypePair & name_and_type, ColumnPtr & column,
     size_t from_mark, size_t current_task_last_mark, size_t column_position, size_t rows_to_read,
-    ColumnNameLevel name_level_for_offsets)
+    ColumnNameLevel name_level_for_offsets, std::unordered_map<String, ColumnPtr> & columns_cache_for_subcolumns)
 {
     const auto & [name, type] = name_and_type;
     std::optional<NameAndTypePair> column_for_offsets;
@@ -331,22 +335,32 @@ void MergeTreeReaderCompact::readData(
     if (name_and_type.isSubcolumn())
     {
         NameAndTypePair name_type_in_storage{name_and_type.getNameInStorage(), name_and_type.getTypeInStorage()};
+        ColumnPtr temp_column;
 
-        /// In case of reading onlys offset use the correct serialization for reading of the prefix
-        auto serialization = getSerializationInPart(name_type_in_storage);
-        ColumnPtr temp_column = name_type_in_storage.type->createColumn(*serialization);
-
-        if (column_for_offsets)
+        auto it = columns_cache_for_subcolumns.find(name_type_in_storage.name);
+        if (it != columns_cache_for_subcolumns.end())
         {
-            auto serialization_for_prefix = getSerializationInPart(*column_for_offsets);
-
-            deserialize_settings.getter = buffer_getter_for_prefix;
-            serialization_for_prefix->deserializeBinaryBulkStatePrefix(deserialize_settings, state_for_prefix);
+            temp_column = it->second;
         }
+        else
+        {
+            /// In case of reading onlys offset use the correct serialization for reading of the prefix
+            auto serialization = getSerializationInPart(name_type_in_storage);
+            temp_column = name_type_in_storage.type->createColumn(*serialization);
 
-        deserialize_settings.getter = buffer_getter;
-        serialization->deserializeBinaryBulkStatePrefix(deserialize_settings, state);
-        serialization->deserializeBinaryBulkWithMultipleStreams(temp_column, rows_to_read, deserialize_settings, state, nullptr);
+            if (column_for_offsets)
+            {
+                auto serialization_for_prefix = getSerializationInPart(*column_for_offsets);
+
+                deserialize_settings.getter = buffer_getter_for_prefix;
+                serialization_for_prefix->deserializeBinaryBulkStatePrefix(deserialize_settings, state_for_prefix);
+            }
+
+            deserialize_settings.getter = buffer_getter;
+            serialization->deserializeBinaryBulkStatePrefix(deserialize_settings, state);
+            serialization->deserializeBinaryBulkWithMultipleStreams(temp_column, rows_to_read, deserialize_settings, state, nullptr);
+            columns_cache_for_subcolumns[name_type_in_storage.name] = temp_column;
+        }
 
         auto subcolumn = name_type_in_storage.type->getSubcolumn(name_and_type.getSubcolumnName(), temp_column);
 

--- a/src/Storages/MergeTree/MergeTreeReaderCompact.h
+++ b/src/Storages/MergeTree/MergeTreeReaderCompact.h
@@ -76,7 +76,7 @@ private:
 
     void readData(const NameAndTypePair & name_and_type, ColumnPtr & column, size_t from_mark,
         size_t current_task_last_mark, size_t column_position,
-        size_t rows_to_read, ColumnNameLevel name_level_for_offsets);
+        size_t rows_to_read, ColumnNameLevel name_level_for_offsets, std::unordered_map<String, ColumnPtr> & columns_cache_for_subcolumns);
 
     /// Returns maximal value of granule size in compressed file from @mark_ranges.
     /// This value is used as size of read buffer.


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Read column once while reading more that one subcolumn from it in Compact parts

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
