### PR TITLE
Fix "logs and exception messages formatting", part 2

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -2241,7 +2241,7 @@ def reportLogStats(args):
         GROUP BY message_format_string ORDER BY count() DESC LIMIT 20 FORMAT TSVWithNamesAndTypes
     """
     value = clickhouse_execute(args, query).decode(errors="replace")
-    print("\nTop messages that don't match its format string:\n")
+    print("\nTop messages not matching their format strings:\n")
     print(value)
     print("\n")
 

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -2269,11 +2269,11 @@ def reportLogStats(args):
               'Attempt to read after eof', 'String size is too big ({}), maximum: {}'
         ) AS known_short_messages
         SELECT count() AS c, message_format_string, substr(any(message), 1, 120),
-            min(if(length(regexpExtract(message, '(.*)\\([A-Z0-9_]+\\)')) as pref > 0, pref, length(message)) - 26 AS length_without_exception_boilerplate) AS min_length_without_exception_boilerplate
+            min(if(notEmpty(regexpExtract(message, '(.*)\\([A-Z0-9_]+\\)') as prefix), prefix, length(message)) - 26 AS length_without_exception_boilerplate) AS min_length_without_exception_boilerplate
         FROM system.text_log
         WHERE (now() - toIntervalMinute(240)) < event_time
             AND (length(message_format_string) < 16
-                OR (message ilike '%DB::Exception%' AND length_without_exception_boilerplate < 30))
+                OR (message ILIKE '%DB::Exception%' AND length_without_exception_boilerplate < 30))
             AND message_format_string NOT IN known_short_messages
         GROUP BY message_format_string ORDER BY c DESC LIMIT 50 FORMAT TSVWithNamesAndTypes
     """

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -2241,7 +2241,7 @@ def reportLogStats(args):
         GROUP BY message_format_string ORDER BY count() DESC LIMIT 20 FORMAT TSVWithNamesAndTypes
     """
     value = clickhouse_execute(args, query).decode(errors="replace")
-    print("\nTop messages that does not match its format string:\n")
+    print("\nTop messages that don't match its format string:\n")
     print(value)
     print("\n")
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


https://s3.amazonaws.com/clickhouse-test-reports/0/05bc8ef1e02b9c7332f08091775b255d191341bf/stateless_tests__tsan__[5_5]/run.log