### PR TITLE
Fix "logs and exception messages formatting", part 3

### DIFF
--- a/src/Functions/FunctionsAES.cpp
+++ b/src/Functions/FunctionsAES.cpp
@@ -15,14 +15,13 @@ namespace ErrorCodes
 {
     extern const int OPENSSL_ERROR;
 }
-}
+
 
 namespace OpenSSLDetails
 {
 void onError(std::string error_message)
 {
-    error_message += ". OpenSSL error code: " + std::to_string(ERR_get_error());
-    throw DB::Exception::createDeprecated(error_message, DB::ErrorCodes::OPENSSL_ERROR);
+    throw Exception(ErrorCodes::OPENSSL_ERROR, "{}. OpenSSL error code: {}", error_message, ERR_get_error());
 }
 
 StringRef foldEncryptionKeyInMySQLCompatitableMode(size_t cipher_key_size, StringRef key, std::array<char, EVP_MAX_KEY_LENGTH> & folded_key)
@@ -44,6 +43,8 @@ const EVP_CIPHER * getCipherByName(StringRef cipher_name)
     // with EVP_CIPHER_CTX_reset() or EVP_EncryptInit_ex(), but using EVP_CIPHER_fetch()
     // causes data race, so we stick to the slower but safer alternative here.
     return EVP_get_cipherbyname(cipher_name.data);
+}
+
 }
 
 }

--- a/src/Functions/FunctionsAES.h
+++ b/src/Functions/FunctionsAES.h
@@ -25,13 +25,14 @@
 
 #include <string.h>
 
+
 namespace DB
 {
 namespace ErrorCodes
 {
     extern const int BAD_ARGUMENTS;
 }
-}
+
 
 namespace OpenSSLDetails
 {
@@ -60,7 +61,7 @@ struct KeyHolder
     inline StringRef setKey(size_t cipher_key_size, StringRef key) const
     {
         if (key.size != cipher_key_size)
-            throw DB::Exception(DB::ErrorCodes::BAD_ARGUMENTS, "Invalid key size: {} expected {}", key.size, cipher_key_size);
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Invalid key size: {} expected {}", key.size, cipher_key_size);
 
         return key;
     }
@@ -72,7 +73,7 @@ struct KeyHolder<CipherMode::MySQLCompatibility>
     inline StringRef setKey(size_t cipher_key_size, StringRef key)
     {
         if (key.size < cipher_key_size)
-            throw DB::Exception(DB::ErrorCodes::BAD_ARGUMENTS, "Invalid key size: {} expected {}", key.size, cipher_key_size);
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Invalid key size: {} expected {}", key.size, cipher_key_size);
 
         // MySQL does something fancy with the keys that are too long,
         // ruining compatibility with OpenSSL and not improving security.
@@ -118,7 +119,7 @@ inline void validateCipherMode(const EVP_CIPHER * evp_cipher)
         }
     }
 
-    throw DB::Exception(DB::ErrorCodes::BAD_ARGUMENTS, "Unsupported cipher mode");
+    throw Exception(ErrorCodes::BAD_ARGUMENTS, "Unsupported cipher mode");
 }
 
 template <CipherMode mode>
@@ -127,13 +128,11 @@ inline void validateIV(StringRef iv_value, const size_t cipher_iv_size)
     // In MySQL mode we don't care if IV is longer than expected, only if shorter.
     if ((mode == CipherMode::MySQLCompatibility && iv_value.size != 0 && iv_value.size < cipher_iv_size)
             || (mode == CipherMode::OpenSSLCompatibility && iv_value.size != 0 && iv_value.size != cipher_iv_size))
-        throw DB::Exception(DB::ErrorCodes::BAD_ARGUMENTS, "Invalid IV size: {} expected {}", iv_value.size, cipher_iv_size);
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Invalid IV size: {} expected {}", iv_value.size, cipher_iv_size);
 }
 
 }
 
-namespace DB
-{
 template <typename Impl>
 class FunctionEncrypt : public IFunction
 {
@@ -313,12 +312,12 @@ private:
                 // in GCM mode IV can be of arbitrary size (>0), IV is optional for other modes.
                 if (mode == CipherMode::RFC5116_AEAD_AES_GCM && iv_value.size == 0)
                 {
-                    throw Exception(DB::ErrorCodes::BAD_ARGUMENTS, "Invalid IV size {} != expected size {}", iv_value.size, iv_size);
+                    throw Exception(ErrorCodes::BAD_ARGUMENTS, "Invalid IV size {} != expected size {}", iv_value.size, iv_size);
                 }
 
                 if (mode != CipherMode::RFC5116_AEAD_AES_GCM && key_value.size != key_size)
                 {
-                    throw Exception(DB::ErrorCodes::BAD_ARGUMENTS, "Invalid key size {} != expected size {}", key_value.size, key_size);
+                    throw Exception(ErrorCodes::BAD_ARGUMENTS, "Invalid key size {} != expected size {}", key_value.size, key_size);
                 }
             }
 
@@ -608,12 +607,12 @@ private:
                 // in GCM mode IV can be of arbitrary size (>0), for other modes IV is optional.
                 if (mode == CipherMode::RFC5116_AEAD_AES_GCM && iv_value.size == 0)
                 {
-                    throw Exception(DB::ErrorCodes::BAD_ARGUMENTS, "Invalid IV size {} != expected size {}", iv_value.size, iv_size);
+                    throw Exception(ErrorCodes::BAD_ARGUMENTS, "Invalid IV size {} != expected size {}", iv_value.size, iv_size);
                 }
 
                 if (key_value.size != key_size)
                 {
-                    throw Exception(DB::ErrorCodes::BAD_ARGUMENTS, "Invalid key size {} != expected size {}", key_value.size, key_size);
+                    throw Exception(ErrorCodes::BAD_ARGUMENTS, "Invalid key size {} != expected size {}", key_value.size, key_size);
                 }
             }
 

--- a/src/Functions/aes_decrypt_mysql.cpp
+++ b/src/Functions/aes_decrypt_mysql.cpp
@@ -5,6 +5,10 @@
 #include <Functions/FunctionFactory.h>
 #include <Functions/FunctionsAES.h>
 
+
+namespace DB
+{
+
 namespace
 {
 
@@ -16,9 +20,6 @@ struct DecryptMySQLModeImpl
 };
 
 }
-
-namespace DB
-{
 
 REGISTER_FUNCTION(AESDecryptMysql)
 {

--- a/src/Functions/aes_encrypt_mysql.cpp
+++ b/src/Functions/aes_encrypt_mysql.cpp
@@ -5,6 +5,9 @@
 #include <Functions/FunctionFactory.h>
 #include <Functions/FunctionsAES.h>
 
+namespace DB
+{
+
 namespace
 {
 
@@ -15,9 +18,6 @@ struct EncryptMySQLModeImpl
 };
 
 }
-
-namespace DB
-{
 
 REGISTER_FUNCTION(AESEncryptMysql)
 {

--- a/src/Functions/decrypt.cpp
+++ b/src/Functions/decrypt.cpp
@@ -5,6 +5,9 @@
 #include <Functions/FunctionFactory.h>
 #include <Functions/FunctionsAES.h>
 
+namespace DB
+{
+
 namespace
 {
 
@@ -16,9 +19,6 @@ struct DecryptImpl
 };
 
 }
-
-namespace DB
-{
 
 REGISTER_FUNCTION(Decrypt)
 {

--- a/src/Functions/encrypt.cpp
+++ b/src/Functions/encrypt.cpp
@@ -5,6 +5,9 @@
 #include <Functions/FunctionFactory.h>
 #include <Functions/FunctionsAES.h>
 
+namespace DB
+{
+
 namespace
 {
 
@@ -15,9 +18,6 @@ struct EncryptImpl
 };
 
 }
-
-namespace DB
-{
 
 REGISTER_FUNCTION(Encrypt)
 {

--- a/src/Functions/tryDecrypt.cpp
+++ b/src/Functions/tryDecrypt.cpp
@@ -3,8 +3,12 @@
 
 #if USE_SSL
 
-#    include <Functions/FunctionFactory.h>
-#    include <Functions/FunctionsAES.h>
+#include <Functions/FunctionFactory.h>
+#include <Functions/FunctionsAES.h>
+
+
+namespace DB
+{
 
 namespace
 {
@@ -17,9 +21,6 @@ struct TryDecryptImpl
 };
 
 }
-
-namespace DB
-{
 
 REGISTER_FUNCTION(TryDecrypt)
 {

--- a/src/IO/FileEncryptionCommon.cpp
+++ b/src/IO/FileEncryptionCommon.cpp
@@ -97,7 +97,7 @@ namespace
             uint8_t * ciphertext = reinterpret_cast<uint8_t *>(out.position());
             int ciphertext_size = 0;
             if (!EVP_EncryptUpdate(evp_ctx, ciphertext, &ciphertext_size, &in[in_size], static_cast<int>(part_size)))
-                throw Exception(ErrorCodes::DATA_ENCRYPTION_ERROR, "Failed to encrypt");
+                throw Exception(ErrorCodes::DATA_ENCRYPTION_ERROR, "Failed to encrypt: {}", ERR_get_error());
 
             in_size += part_size;
             if (ciphertext_size)
@@ -120,7 +120,7 @@ namespace
         uint8_t ciphertext[kBlockSize];
         int ciphertext_size = 0;
         if (!EVP_EncryptUpdate(evp_ctx, ciphertext, &ciphertext_size, padded_data, safe_cast<int>(padded_data_size)))
-            throw Exception(ErrorCodes::DATA_ENCRYPTION_ERROR, "Failed to encrypt");
+            throw Exception(ErrorCodes::DATA_ENCRYPTION_ERROR, "Failed to encrypt: {}", ERR_get_error());
 
         if (!ciphertext_size)
             return 0;
@@ -140,7 +140,7 @@ namespace
         int ciphertext_size = 0;
         if (!EVP_EncryptFinal_ex(evp_ctx,
                                  ciphertext, &ciphertext_size))
-            throw Exception(ErrorCodes::DATA_ENCRYPTION_ERROR, "Failed to finalize encrypting");
+            throw Exception(ErrorCodes::DATA_ENCRYPTION_ERROR, "Failed to finalize encrypting: {}", ERR_get_error());
         if (ciphertext_size)
             out.write(reinterpret_cast<const char *>(ciphertext), ciphertext_size);
         return ciphertext_size;
@@ -152,7 +152,7 @@ namespace
         uint8_t * plaintext = reinterpret_cast<uint8_t *>(out);
         int plaintext_size = 0;
         if (!EVP_DecryptUpdate(evp_ctx, plaintext, &plaintext_size, in, safe_cast<int>(size)))
-            throw Exception(ErrorCodes::DATA_ENCRYPTION_ERROR, "Failed to decrypt");
+            throw Exception(ErrorCodes::DATA_ENCRYPTION_ERROR, "Failed to decrypt: {}", ERR_get_error());
         return plaintext_size;
     }
 
@@ -165,7 +165,7 @@ namespace
         uint8_t plaintext[kBlockSize];
         int plaintext_size = 0;
         if (!EVP_DecryptUpdate(evp_ctx, plaintext, &plaintext_size, padded_data, safe_cast<int>(padded_data_size)))
-            throw Exception(ErrorCodes::DATA_ENCRYPTION_ERROR, "Failed to decrypt");
+            throw Exception(ErrorCodes::DATA_ENCRYPTION_ERROR, "Failed to decrypt: {}", ERR_get_error());
 
         if (!plaintext_size)
             return 0;
@@ -184,7 +184,7 @@ namespace
         uint8_t plaintext[kBlockSize];
         int plaintext_size = 0;
         if (!EVP_DecryptFinal_ex(evp_ctx, plaintext, &plaintext_size))
-            throw Exception(ErrorCodes::DATA_ENCRYPTION_ERROR, "Failed to finalize decrypting");
+            throw Exception(ErrorCodes::DATA_ENCRYPTION_ERROR, "Failed to finalize decrypting: {}", ERR_get_error());
         if (plaintext_size)
             memcpy(out, plaintext, plaintext_size);
         return plaintext_size;
@@ -291,11 +291,11 @@ void Encryptor::encrypt(const char * data, size_t size, WriteBuffer & out)
     auto * evp_ctx = evp_ctx_ptr.get();
 
     if (!EVP_EncryptInit_ex(evp_ctx, evp_cipher, nullptr, nullptr, nullptr))
-        throw Exception(ErrorCodes::DATA_ENCRYPTION_ERROR, "Failed to initialize encryption context with cipher");
+        throw Exception(ErrorCodes::DATA_ENCRYPTION_ERROR, "Failed to initialize encryption context with cipher: {}", ERR_get_error());
 
     if (!EVP_EncryptInit_ex(evp_ctx, nullptr, nullptr,
                             reinterpret_cast<const uint8_t*>(key.c_str()), reinterpret_cast<const uint8_t*>(current_iv.c_str())))
-        throw Exception(ErrorCodes::DATA_ENCRYPTION_ERROR, "Failed to set key and IV for encryption");
+        throw Exception(ErrorCodes::DATA_ENCRYPTION_ERROR, "Failed to set key and IV for encryption: {}", ERR_get_error());
 
     size_t in_size = 0;
     size_t out_size = 0;
@@ -320,7 +320,7 @@ void Encryptor::encrypt(const char * data, size_t size, WriteBuffer & out)
     out_size += encryptFinal(evp_ctx, out);
 
     if (out_size != in_size)
-        throw Exception(ErrorCodes::DATA_ENCRYPTION_ERROR, "Only part of the data was encrypted");
+        throw Exception(ErrorCodes::DATA_ENCRYPTION_ERROR, "Only part of the data was encrypted: {} out of {} bytes", out_size, in_size);
     offset += in_size;
 }
 
@@ -335,11 +335,11 @@ void Encryptor::decrypt(const char * data, size_t size, char * out)
     auto * evp_ctx = evp_ctx_ptr.get();
 
     if (!EVP_DecryptInit_ex(evp_ctx, evp_cipher, nullptr, nullptr, nullptr))
-        throw Exception(ErrorCodes::DATA_ENCRYPTION_ERROR, "Failed to initialize decryption context with cipher");
+        throw Exception(ErrorCodes::DATA_ENCRYPTION_ERROR, "Failed to initialize decryption context with cipher: {}", ERR_get_error());
 
     if (!EVP_DecryptInit_ex(evp_ctx, nullptr, nullptr,
                             reinterpret_cast<const uint8_t*>(key.c_str()), reinterpret_cast<const uint8_t*>(current_iv.c_str())))
-        throw Exception(ErrorCodes::DATA_ENCRYPTION_ERROR, "Failed to set key and IV for decryption");
+        throw Exception(ErrorCodes::DATA_ENCRYPTION_ERROR, "Failed to set key and IV for decryption: {}", ERR_get_error());
 
     size_t in_size = 0;
     size_t out_size = 0;
@@ -364,7 +364,7 @@ void Encryptor::decrypt(const char * data, size_t size, char * out)
     out_size += decryptFinal(evp_ctx, &out[out_size]);
 
     if (out_size != in_size)
-        throw Exception(ErrorCodes::DATA_ENCRYPTION_ERROR, "Only part of the data was decrypted");
+        throw Exception(ErrorCodes::DATA_ENCRYPTION_ERROR, "Only part of the data was decrypted: {} out of {} bytes", out_size, in_size);
     offset += in_size;
 }
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


https://s3.amazonaws.com/clickhouse-test-reports/0/05bc8ef1e02b9c7332f08091775b255d191341bf/stateless_tests__tsan__[5_5]/run.log