### PR TITLE
Avoid hangs of system.stack_trace by correctly prohibit parallel read from it

### DIFF
--- a/src/Storages/System/StorageSystemStackTrace.cpp
+++ b/src/Storages/System/StorageSystemStackTrace.cpp
@@ -190,7 +190,7 @@ ThreadIdToName getFilteredThreadNames(ASTPtr query, ContextPtr context, const Pa
         tid_to_name[tid] = thread_name;
         all_thread_names->insert(thread_name);
     }
-    LOG_TEST(log, "Read {} thread names for {} threads, took {} ms", tid_to_name.size(), thread_ids.size(), watch.elapsedMilliseconds());
+    LOG_TRACE(log, "Read {} thread names for {} threads, took {} ms", tid_to_name.size(), thread_ids.size(), watch.elapsedMilliseconds());
 
     Block block { ColumnWithTypeAndName(std::move(all_thread_names), std::make_shared<DataTypeString>(), "thread_name") };
     VirtualColumnUtils::filterBlockWithQuery(query, block, context);
@@ -250,7 +250,7 @@ protected:
         {
             Stopwatch watch;
             thread_ids = getFilteredThreadIds();
-            LOG_TEST(log, "Read {} threads, took {} ms", thread_ids->size(), watch.elapsedMilliseconds());
+            LOG_TRACE(log, "Read {} threads, took {} ms", thread_ids->size(), watch.elapsedMilliseconds());
         }
         if (thread_ids->empty())
             return Chunk();
@@ -332,7 +332,7 @@ protected:
                 ++sequence_num;
             }
         }
-        LOG_TEST(log, "Send signal to {} threads (total), took {} ms", signals_sent, signals_sent_ms);
+        LOG_TRACE(log, "Send signal to {} threads (total), took {} ms", signals_sent, signals_sent_ms);
 
         UInt64 num_rows = res_columns.at(0)->size();
         Chunk chunk(std::move(res_columns), num_rows);


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Prohibit parallel read from system.stack_trace (otherwise this will lead to hang of system.stack_trace table up to `storage_system_stack_trace_pipe_read_timeout_ms`)

Before rewriting system.stack_trace to handle max_block_size (in #54946)
parallel reading from system.stack_trace was prohibited, because this
could lead to hang of system.stack_trace table.

But that rewrite broke this guarantee, so let's fix it to avoid possible
hung.

Fixes: https://github.com/ClickHouse/ClickHouse/pull/54946 (cc @alexey-milovidov )