### PR TITLE
Improvement: tune max_bytes_to_merge_at_max_space_in_pool, max_bytes_to_merge_at_min_space_in_pool and materialize_ttl_after_modify default value.

### DIFF
--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -587,7 +587,7 @@ class IColumn;
     M(Bool, transform_null_in, false, "If enabled, NULL values will be matched with 'IN' operator as if they are considered equal.", 0) \
     M(Bool, allow_nondeterministic_mutations, false, "Allow non-deterministic functions in ALTER UPDATE/ALTER DELETE statements", 0) \
     M(Seconds, lock_acquire_timeout, DBMS_DEFAULT_LOCK_ACQUIRE_TIMEOUT_SEC, "How long locking request should wait before failing", 0) \
-    M(Bool, materialize_ttl_after_modify, true, "Apply TTL for old data, after ALTER MODIFY TTL query", 0) \
+    M(Bool, materialize_ttl_after_modify, false, "Apply TTL for old data after ALTER MODIFY TTL query if true", 0) \
     M(String, function_implementation, "", "Choose function implementation for specific target or variant (experimental). If empty enable all of them.", 0) \
     M(Bool, data_type_default_nullable, false, "Data types without NULL or NOT NULL will make Nullable", 0) \
     M(Bool, cast_keep_nullable, false, "CAST operator keep Nullable for result data type", 0) \

--- a/src/Storages/MergeTree/MergeTreeSettings.h
+++ b/src/Storages/MergeTree/MergeTreeSettings.h
@@ -39,8 +39,8 @@ struct Settings;
     /** Merge settings. */ \
     M(UInt64, merge_max_block_size, 8192, "How many rows in blocks should be formed for merge operations. By default has the same value as `index_granularity`.", 0) \
     M(UInt64, merge_max_block_size_bytes, 10 * 1024 * 1024, "How many bytes in blocks should be formed for merge operations. By default has the same value as `index_granularity_bytes`.", 0) \
-    M(UInt64, max_bytes_to_merge_at_max_space_in_pool, 150ULL * 1024 * 1024 * 1024, "Maximum in total size of parts to merge, when there are maximum free threads in background pool (or entries in replication queue).", 0) \
-    M(UInt64, max_bytes_to_merge_at_min_space_in_pool, 1024 * 1024, "Maximum in total size of parts to merge, when there are minimum free threads in background pool (or entries in replication queue).", 0) \
+    M(UInt64, max_bytes_to_merge_at_max_space_in_pool, 100ULL * 1024 * 1024 * 1024, "Maximum in total size of parts to merge, when there are maximum free threads in background pool (or entries in replication queue).", 0) \
+    M(UInt64, max_bytes_to_merge_at_min_space_in_pool, 1024 * 1024 * 1024, "Maximum in total size of parts to merge, when there are minimum free threads in background pool (or entries in replication queue).", 0) \
     M(UInt64, max_replicated_merges_in_queue, 1000, "How many tasks of merging and mutating parts are allowed simultaneously in ReplicatedMergeTree queue.", 0) \
     M(UInt64, max_replicated_mutations_in_queue, 8, "How many tasks of mutating parts are allowed simultaneously in ReplicatedMergeTree queue.", 0) \
     M(UInt64, max_replicated_merges_with_ttl_in_queue, 1, "How many tasks of merging parts with TTL are allowed simultaneously in ReplicatedMergeTree queue.", 0) \


### PR DESCRIPTION
In the case of a large amount of data (100TB a day, 30 days of data retention), these default parameters do not apply, causing some anomalies. Here are some problems encountered in my production environment:
1. Memory Limit error is triggered when merging parts, causing the merge task to be retried continuously.
2. Due to constant attempts to merge parts, the IO usage of some machines has been at 100% for a long time, and disk reading has been maintained at 500MB/s.
3. Too many parts errors caused by the first two problems when data is written.
4. Tasks in system.replication_queue are constantly being retried, and there are a large number of merge tasks that consume performance.

After I modified these three parameters, my problem was solved.
It is hoped that these modifications can reduce the burden on operation and maintenance personnel, especially those who don’t know much about clickhouse can easily get started and reduce the chance of making mistakes.

### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Tune `max_bytes_to_merge_at_max_space_in_pool` default value to 100GB
Tune  `max_bytes_to_merge_at_min_space_in_pool` default value to 1GB 
Tune `materialize_ttl_after_modify` default value to false

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
