### PR TITLE
Fix test_dictionaries_update_and_reload/test.py::test_reload_while_loading flakiness

### DIFF
--- a/tests/integration/test_dictionaries_update_and_reload/test.py
+++ b/tests/integration/test_dictionaries_update_and_reload/test.py
@@ -92,16 +92,16 @@ def test_reload_while_loading(started_cluster):
     assert get_status("slow") == "NOT_LOADED"
     assert get_loading_duration("slow") == 0
 
-    # It's not possible to get a value from the dictionary within 0.5 second, so the following query fails by timeout.
+    # It's not possible to get a value from the dictionary within 1 second, so the following query fails by timeout.
     with pytest.raises(QueryTimeoutExceedException):
-        query("SELECT dictGetInt32('slow', 'a', toUInt64(5))", timeout=0.5)
+        query("SELECT dictGetInt32('slow', 'a', toUInt64(5))", timeout=1)
 
     # The dictionary is now loading.
     assert get_status("slow") == "LOADING"
     start_time, duration = get_loading_start_time("slow"), get_loading_duration("slow")
     assert duration > 0
 
-    time.sleep(0.5)  # Still loading.
+    time.sleep(1)  # Still loading.
     assert get_status("slow") == "LOADING"
     prev_start_time, prev_duration = start_time, duration
     start_time, duration = get_loading_start_time("slow"), get_loading_duration("slow")
@@ -110,14 +110,14 @@ def test_reload_while_loading(started_cluster):
 
     # SYSTEM RELOAD DICTIONARY should restart loading.
     with pytest.raises(QueryTimeoutExceedException):
-        query("SYSTEM RELOAD DICTIONARY 'slow'", timeout=0.5)
+        query("SYSTEM RELOAD DICTIONARY 'slow'", timeout=1)
     assert get_status("slow") == "LOADING"
     prev_start_time, prev_duration = start_time, duration
     start_time, duration = get_loading_start_time("slow"), get_loading_duration("slow")
     assert start_time > prev_start_time
     assert duration < prev_duration
 
-    time.sleep(0.5)  # Still loading.
+    time.sleep(1)  # Still loading.
     assert get_status("slow") == "LOADING"
     prev_start_time, prev_duration = start_time, duration
     start_time, duration = get_loading_start_time("slow"), get_loading_duration("slow")
@@ -128,7 +128,7 @@ def test_reload_while_loading(started_cluster):
     replace_in_file_in_container(
         "/etc/clickhouse-server/dictionaries/slow.xml", "sleep 100", "sleep 0"
     )
-    time.sleep(5)  # Configuration files are reloaded once in 5 seconds.
+    query("SYSTEM RELOAD CONFIG")
 
     # This time loading should finish quickly.
     assert get_status("slow") == "LOADED"


### PR DESCRIPTION
On CI this test fails due to start_time == prev_start_time:

            start_time, duration = get_loading_start_time("slow"), get_loading_duration("slow")
    >       assert start_time > prev_start_time
    E       assert time.struct_time(tm_year=2023, tm_mon=12, tm_mday=9, tm_hour=23, tm_min=42, tm_sec=2, tm_wday=5, tm_yday=343, tm_isdst=-1) > time.struct_time(tm_year=2023, tm_mon=12, tm_mday=9, tm_hour=23, tm_min=42, tm_sec=2, tm_wday=5, tm_yday=343, tm_isdst=-1)

The reason I guess is that there is sleep(0.5), while the loading_start_time is DateTime not DateTime64, so you cannot distinguish values if the difference is less then one second

CI: https://s3.amazonaws.com/clickhouse-test-reports/57710/7af1c0885daaf1e41470c5fdd92abfc7b6b2befc/integration_tests__asan__[3_4].html

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)