### PR TITLE
Tune autoscale to scale for single job in the queue

### DIFF
--- a/tests/ci/autoscale_runners_lambda/app.py
+++ b/tests/ci/autoscale_runners_lambda/app.py
@@ -66,11 +66,6 @@ def get_scales(runner_type: str) -> Tuple[int, int]:
     # Let's have it the same as the other ASG
     # UPDATE THE COMMENT ON CHANGES
     scale_up = 3
-    if runner_type.startswith("private-"):
-        scale_up = 1
-    elif runner_type == "limited-tester":
-        # The limited runners should inflate and deflate faster
-        scale_up = 2
     return scale_down, scale_up
 
 
@@ -120,7 +115,7 @@ def set_capacity(
         # Are we already at the capacity limits
         stop = stop or asg["MaxSize"] <= asg["DesiredCapacity"]
         # Let's calculate a new desired capacity
-        desired_capacity = asg["DesiredCapacity"] + (capacity_deficit // scale_up)
+        desired_capacity = asg["DesiredCapacity"] + (capacity_deficit + scale_up - 1) // scale_up
         desired_capacity = max(desired_capacity, asg["MinSize"])
         desired_capacity = min(desired_capacity, asg["MaxSize"])
         # Finally, should the capacity be even changed

--- a/tests/ci/autoscale_runners_lambda/app.py
+++ b/tests/ci/autoscale_runners_lambda/app.py
@@ -115,7 +115,9 @@ def set_capacity(
         # Are we already at the capacity limits
         stop = stop or asg["MaxSize"] <= asg["DesiredCapacity"]
         # Let's calculate a new desired capacity
-        desired_capacity = asg["DesiredCapacity"] + (capacity_deficit + scale_up - 1) // scale_up
+        desired_capacity = (
+            asg["DesiredCapacity"] + (capacity_deficit + scale_up - 1) // scale_up
+        )
         desired_capacity = max(desired_capacity, asg["MinSize"])
         desired_capacity = min(desired_capacity, asg["MaxSize"])
         # Finally, should the capacity be even changed

--- a/tests/ci/autoscale_runners_lambda/test_autoscale.py
+++ b/tests/ci/autoscale_runners_lambda/test_autoscale.py
@@ -69,14 +69,14 @@ class TestSetCapacity(unittest.TestCase):
             # Do not change capacity
             TestCase("noqueue", 1, 13, 20, [Queue("in_progress", 155, "noqueue")], -1),
             TestCase(
-                "w/reserve-1", 1, 13, 20, [Queue("queued", 15, "w/reserve-1")], -1
+                "w/reserve-1", 1, 13, 20, [Queue("queued", 15, "w/reserve-1")], 14
             ),
             # Increase capacity
-            TestCase("increase-1", 1, 13, 20, [Queue("queued", 23, "increase-1")], 16),
+            TestCase("increase-1", 1, 13, 20, [Queue("queued", 23, "increase-1")], 17),
             TestCase(
-                "style-checker", 1, 13, 20, [Queue("queued", 33, "style-checker")], 19
+                "style-checker", 1, 13, 20, [Queue("queued", 33, "style-checker")], 20
             ),
-            TestCase("increase-2", 1, 13, 20, [Queue("queued", 18, "increase-2")], 14),
+            TestCase("increase-2", 1, 13, 20, [Queue("queued", 18, "increase-2")], 15),
             TestCase("increase-3", 1, 13, 20, [Queue("queued", 183, "increase-3")], 20),
             TestCase(
                 "increase-w/o reserve",
@@ -87,21 +87,9 @@ class TestSetCapacity(unittest.TestCase):
                     Queue("in_progress", 11, "increase-w/o reserve"),
                     Queue("queued", 12, "increase-w/o reserve"),
                 ],
-                16,
+                17,
             ),
             TestCase("lower-min", 10, 5, 20, [Queue("queued", 5, "lower-min")], 10),
-            # scale up group with prefix private-
-            TestCase(
-                "private-increase",
-                1,
-                13,
-                20,
-                [
-                    Queue("in_progress", 12, "private-increase"),
-                    Queue("queued", 11, "private-increase"),
-                ],
-                20,
-            ),
             # Decrease capacity
             TestCase("w/reserve", 1, 13, 20, [Queue("queued", 5, "w/reserve")], 5),
             TestCase(


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
autoscale at least plus one node in case of deficit, to avoid 1 job in queue for too long

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
