### PR TITLE
Tune network memory for dockerhub proxy hosts

### DIFF
--- a/tests/ci/worker/dockerhub_proxy_template.sh
+++ b/tests/ci/worker/dockerhub_proxy_template.sh
@@ -15,6 +15,19 @@ if [[ "$ETH_DNS" ]] && [[ "${ETH_DNS#*: }" != *"$CLOUDFLARE_NS"* ]]; then
   resolvectl dns "$IFACE" "${new_dns[@]}"
 fi
 
+# tune sysctl for network performance
+cat > /etc/sysctl.d/10-network-memory.conf << EOF
+net.core.netdev_max_backlog=2000
+net.core.rmem_max=1048576
+net.core.wmem_max=1048576
+net.ipv4.tcp_max_syn_backlog=1024
+net.ipv4.tcp_rmem=4096 131072  16777216
+net.ipv4.tcp_wmem=4096 87380   16777216
+net.ipv4.tcp_mem=4096  131072  16777216
+EOF
+
+sysctl -p /etc/sysctl.d/10-network-memory.conf
+
 mkdir /home/ubuntu/registrystorage
 
 sed -i 's/preserve_hostname: false/preserve_hostname: true/g' /etc/cloud/cloud.cfg
@@ -22,4 +35,11 @@ sed -i 's/preserve_hostname: false/preserve_hostname: true/g' /etc/cloud/cloud.c
 REGISTRY_PROXY_USERNAME=robotclickhouse
 REGISTRY_PROXY_PASSWORD=$(aws ssm get-parameter --name dockerhub_robot_password --with-decryption | jq '.Parameter.Value' -r)
 
-docker run -d --network=host -p 5000:5000 -v /home/ubuntu/registrystorage:/var/lib/registry -e REGISTRY_HTTP_ADDR=0.0.0.0:5000 -e REGISTRY_STORAGE_DELETE_ENABLED=true -e REGISTRY_PROXY_REMOTEURL=https://registry-1.docker.io -e REGISTRY_PROXY_PASSWORD="$REGISTRY_PROXY_PASSWORD" -e REGISTRY_PROXY_USERNAME="$REGISTRY_PROXY_USERNAME" --restart=always --name registry registry:2
+docker run -d --network=host -p 5000:5000 -v /home/ubuntu/registrystorage:/var/lib/registry \
+  -e REGISTRY_STORAGE_CACHE='' \
+  -e REGISTRY_HTTP_ADDR=0.0.0.0:5000 \
+  -e REGISTRY_STORAGE_DELETE_ENABLED=true \
+  -e REGISTRY_PROXY_REMOTEURL=https://registry-1.docker.io \
+  -e REGISTRY_PROXY_PASSWORD="$REGISTRY_PROXY_PASSWORD" \
+  -e REGISTRY_PROXY_USERNAME="$REGISTRY_PROXY_USERNAME" \
+  --restart=always --name registry registry:2


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixes #56108, the issue with dockerhub registry is addressed by tuned TCP memory sysctl parameters.