### PR TITLE
`sleep` function now can be cancelled with KILL QUERY

### DIFF
--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -456,7 +456,8 @@ The server successfully detected this situation and will download merged part fr
     M(ReadBufferSeekCancelConnection, "Number of seeks which lead to new connection (s3, http)") \
     \
     M(SleepFunctionCalls, "Number of times a sleep function (sleep, sleepEachRow) has been called.") \
-    M(SleepFunctionMicroseconds, "Time spent sleeping due to a sleep function call.") \
+    M(SleepFunctionMicroseconds, "Time set to sleep in a sleep function (sleep, sleepEachRow).") \
+    M(SleepFunctionElapsedMicroseconds, "Time spent sleeping in a sleep function (sleep, sleepEachRow).") \
     \
     M(ThreadPoolReaderPageCacheHit, "Number of times the read inside ThreadPoolReader was done from page cache.") \
     M(ThreadPoolReaderPageCacheHitBytes, "Number of bytes read inside ThreadPoolReader when it was done from page cache.") \

--- a/src/Functions/sleep.h
+++ b/src/Functions/sleep.h
@@ -28,7 +28,6 @@ namespace ErrorCodes
     extern const int TOO_SLOW;
     extern const int ILLEGAL_COLUMN;
     extern const int BAD_ARGUMENTS;
-    extern const int QUERY_WAS_CANCELLED;
 }
 
 /** sleep(seconds) - the specified number of seconds sleeps each columns.
@@ -144,8 +143,8 @@ public:
                     sleepForMicroseconds(sleep_ms);
                     microseconds -= sleep_ms;
 
-                    if (query_status && query_status->isKilled())
-                        throw Exception(ErrorCodes::QUERY_WAS_CANCELLED, "Query was cancelled");
+                    if (query_status && !query_status->checkTimeLimit())
+                        break;
                 }
 
                 ProfileEvents::increment(ProfileEvents::SleepFunctionCalls, count);

--- a/src/Functions/sleep.h
+++ b/src/Functions/sleep.h
@@ -140,7 +140,7 @@ public:
                 {
                     UInt64 sleep_time = microseconds - elapsed;
                     if (query_status)
-                        sleep_time = std::min(sleep_time, /* 1 second */ static_cast<size_t>(1000000));
+                        sleep_time = std::min(sleep_time, /* 1 second */ static_cast<UInt64>(1000000));
 
                     sleepForMicroseconds(sleep_time);
                     elapsed += sleep_time;

--- a/tests/queries/0_stateless/02932_kill_query_sleep.reference
+++ b/tests/queries/0_stateless/02932_kill_query_sleep.reference
@@ -1,0 +1,2 @@
+Cancelling query
+QUERY_WAS_CANCELLED

--- a/tests/queries/0_stateless/02932_kill_query_sleep.sh
+++ b/tests/queries/0_stateless/02932_kill_query_sleep.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+
+function wait_query_started()
+{
+    local query_id="$1"
+    while [[ $($CLICKHOUSE_CLIENT --query="SELECT count() FROM system.query_log WHERE query_id='$query_id'") == 0 ]]; do
+        sleep 0.1;
+        $CLICKHOUSE_CLIENT --query "SYSTEM FLUSH LOGS;"
+    done
+}
+
+function kill_query()
+{
+    local query_id="$1"
+    $CLICKHOUSE_CLIENT --query "KILL QUERY WHERE query_id='$query_id'" >/dev/null
+    while [[ $($CLICKHOUSE_CLIENT --query="SELECT count() FROM system.processes WHERE query_id='$query_id'") != 0 ]]; do sleep 0.1; done
+}
+
+
+sleep_query_id="sleep_query_id_02932_kill_query_sleep_${CLICKHOUSE_DATABASE}_$RANDOM"
+
+# This sleep query wants to sleep for 1000 seconds (which is too long).
+# We're going to cancel this query later.
+sleep_query="SELECT sleep(1000)"
+
+$CLICKHOUSE_CLIENT --query_id="$sleep_query_id" --function_sleep_max_microseconds_per_block="1000000000" --query "$sleep_query" >/dev/null 2>&1 &
+wait_query_started "$sleep_query_id"
+
+echo "Cancelling query"
+kill_query "$sleep_query_id"
+
+$CLICKHOUSE_CLIENT --query "SYSTEM FLUSH LOGS;"
+$CLICKHOUSE_CLIENT --query "SELECT exception FROM system.query_log WHERE query_id='$sleep_query_id'" | grep -oF "QUERY_WAS_CANCELLED"

--- a/tests/queries/0_stateless/02932_kill_query_sleep.sh
+++ b/tests/queries/0_stateless/02932_kill_query_sleep.sh
@@ -8,7 +8,7 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 function wait_query_started()
 {
     local query_id="$1"
-    while [[ $($CLICKHOUSE_CLIENT --query="SELECT count() FROM system.query_log WHERE query_id='$query_id'") == 0 ]]; do
+    while [[ $($CLICKHOUSE_CLIENT --query="SELECT count() FROM system.query_log WHERE query_id='$query_id' AND current_database = currentDatabase()") == 0 ]]; do
         sleep 0.1;
         $CLICKHOUSE_CLIENT --query "SYSTEM FLUSH LOGS;"
     done
@@ -35,4 +35,4 @@ echo "Cancelling query"
 kill_query "$sleep_query_id"
 
 $CLICKHOUSE_CLIENT --query "SYSTEM FLUSH LOGS;"
-$CLICKHOUSE_CLIENT --query "SELECT exception FROM system.query_log WHERE query_id='$sleep_query_id'" | grep -oF "QUERY_WAS_CANCELLED"
+$CLICKHOUSE_CLIENT --query "SELECT exception FROM system.query_log WHERE query_id='$sleep_query_id' AND current_database = currentDatabase()" | grep -oF "QUERY_WAS_CANCELLED"


### PR DESCRIPTION
### Changelog category:
- Improvement

### Changelog entry:
`sleep()` function now can be cancelled with `KILL QUERY`
