### PR TITLE
Fix flaky test_parallel_replicas_distributed_read_from_all

### DIFF
--- a/tests/integration/test_parallel_replicas_distributed_read_from_all/test.py
+++ b/tests/integration/test_parallel_replicas_distributed_read_from_all/test.py
@@ -143,6 +143,8 @@ def test_read_equally_from_each_replica(start_cluster, prefer_localhost_replica)
     nodes[0].query(f"system start fetches {table_name}")
     nodes[1].query(f"system start fetches {table_name}")
     nodes[2].query(f"system start fetches {table_name}")
+    # ensure that replica in sync before querying it to get stable result
+    nodes[0].query(f"system sync  replica {table_name} strict")
     assert (
         nodes[0].query(
             f"SELECT count(), min(key), max(key), sum(key) FROM {table_name}_d"

--- a/tests/integration/test_parallel_replicas_distributed_read_from_all/test.py
+++ b/tests/integration/test_parallel_replicas_distributed_read_from_all/test.py
@@ -144,10 +144,14 @@ def test_read_equally_from_each_replica(start_cluster, prefer_localhost_replica)
     nodes[1].query(f"system start fetches {table_name}")
     nodes[2].query(f"system start fetches {table_name}")
     # ensure that replica in sync before querying it to get stable result
-    nodes[0].query(f"system sync  replica {table_name} strict")
+    nodes[0].query(f"system start merges {table_name}")
+    nodes[0].query(f"system sync  replica {table_name}")
     assert (
         nodes[0].query(
-            f"SELECT count(), min(key), max(key), sum(key) FROM {table_name}_d"
+            f"SELECT count(), min(key), max(key), sum(key) FROM {table_name}_d",
+            settings={
+                "allow_experimental_parallel_reading_from_replicas": 0,
+            }
         )
         == expected_result
     )

--- a/tests/integration/test_parallel_replicas_distributed_read_from_all/test.py
+++ b/tests/integration/test_parallel_replicas_distributed_read_from_all/test.py
@@ -151,7 +151,7 @@ def test_read_equally_from_each_replica(start_cluster, prefer_localhost_replica)
             f"SELECT count(), min(key), max(key), sum(key) FROM {table_name}_d",
             settings={
                 "allow_experimental_parallel_reading_from_replicas": 0,
-            }
+            },
         )
         == expected_result
     )


### PR DESCRIPTION
Sync replica before querying it to get stable result
Fixes https://github.com/ClickHouse/ClickHouse/issues/55169

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)