### PR TITLE
Don't run test 02919_skip_lots_of_parsing_errors on aarch64

### DIFF
--- a/tests/queries/0_stateless/02919_skip_lots_of_parsing_errors.sh
+++ b/tests/queries/0_stateless/02919_skip_lots_of_parsing_errors.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest
+# Tags: no-fasttest, no-cpu-aarch64
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

There are a lot of catching exceptions in this test (~200k), it's really slow in aarch64 build