### PR TITLE
Fix flaky test_parallel_replicas_over_distributed

### DIFF
--- a/tests/integration/test_parallel_replicas_over_distributed/test.py
+++ b/tests/integration/test_parallel_replicas_over_distributed/test.py
@@ -129,6 +129,9 @@ def test_parallel_replicas_over_distributed(
     node = nodes[0]
     expected_result = f"6003\t-1999\t1999\t3\n"
 
+    # sync all replicas to get consistent result
+    node.query(f"SYSTEM SYNC REPLICA ON CLUSTER {cluster} {table_name}")
+
     # parallel replicas
     assert (
         node.query(
@@ -143,11 +146,12 @@ def test_parallel_replicas_over_distributed(
         == expected_result
     )
 
-    # sync all replicas to get consistent result by next distributed query
-    node.query(f"SYSTEM SYNC REPLICA ON CLUSTER {cluster} {table_name}")
-
     # w/o parallel replicas
     assert (
-        node.query(f"SELECT count(), min(key), max(key), sum(key) FROM {table_name}_d")
+        node.query(f"SELECT count(), min(key), max(key), sum(key) FROM {table_name}_d",
+            settings={
+                "allow_experimental_parallel_reading_from_replicas": 0,
+           }
+        )
         == expected_result
     )

--- a/tests/integration/test_parallel_replicas_over_distributed/test.py
+++ b/tests/integration/test_parallel_replicas_over_distributed/test.py
@@ -148,10 +148,11 @@ def test_parallel_replicas_over_distributed(
 
     # w/o parallel replicas
     assert (
-        node.query(f"SELECT count(), min(key), max(key), sum(key) FROM {table_name}_d",
+        node.query(
+            f"SELECT count(), min(key), max(key), sum(key) FROM {table_name}_d",
             settings={
                 "allow_experimental_parallel_reading_from_replicas": 0,
-           }
+            },
         )
         == expected_result
     )


### PR DESCRIPTION
Without replicas sync, the query result can vary
Fixes https://github.com/ClickHouse/ClickHouse/issues/55972

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)