### PR TITLE
Create consumers for Kafka tables on fly (but keep them for some period since last used)

### DIFF
--- a/src/Common/setThreadName.cpp
+++ b/src/Common/setThreadName.cpp
@@ -28,25 +28,31 @@ namespace ErrorCodes
 static thread_local char thread_name[THREAD_NAME_SIZE]{};
 
 
-void setThreadName(const char * name)
+void setThreadName(const char * name, bool truncate)
 {
-    if (strlen(name) > THREAD_NAME_SIZE - 1)
+    size_t name_len = strlen(name);
+    if (!truncate && name_len > THREAD_NAME_SIZE - 1)
         throw DB::Exception(DB::ErrorCodes::PTHREAD_ERROR, "Thread name cannot be longer than 15 bytes");
 
+    size_t name_capped_len = std::min<size_t>(1 + name_len, THREAD_NAME_SIZE - 1);
+    char name_capped[THREAD_NAME_SIZE];
+    memcpy(name_capped, name, name_capped_len);
+    name_capped[name_capped_len] = '\0';
+
 #if defined(OS_FREEBSD)
-    pthread_set_name_np(pthread_self(), name);
+    pthread_set_name_np(pthread_self(), name_capped);
     if ((false))
 #elif defined(OS_DARWIN)
-    if (0 != pthread_setname_np(name))
+    if (0 != pthread_setname_np(name_capped))
 #elif defined(OS_SUNOS)
-    if (0 != pthread_setname_np(pthread_self(), name))
+    if (0 != pthread_setname_np(pthread_self(), name_capped))
 #else
-    if (0 != prctl(PR_SET_NAME, name, 0, 0, 0))
+    if (0 != prctl(PR_SET_NAME, name_capped, 0, 0, 0))
 #endif
         if (errno != ENOSYS && errno != EPERM)    /// It's ok if the syscall is unsupported or not allowed in some environments.
             throw DB::ErrnoException(DB::ErrorCodes::PTHREAD_ERROR, "Cannot set thread name with prctl(PR_SET_NAME, ...)");
 
-    memcpy(thread_name, name, std::min<size_t>(1 + strlen(name), THREAD_NAME_SIZE - 1));
+    memcpy(thread_name, name_capped, name_capped_len);
 }
 
 const char * getThreadName()

--- a/src/Common/setThreadName.h
+++ b/src/Common/setThreadName.h
@@ -4,7 +4,9 @@
 /** Sets the thread name (maximum length is 15 bytes),
   *  which will be visible in ps, gdb, /proc,
   *  for convenience of observation and debugging.
+  *
+  * @param truncate - if true, will truncate to 15 automatically, otherwise throw
   */
-void setThreadName(const char * name);
+void setThreadName(const char * name, bool truncate = false);
 
 const char * getThreadName();

--- a/src/Storages/Kafka/KafkaConsumer.cpp
+++ b/src/Storages/Kafka/KafkaConsumer.cpp
@@ -604,6 +604,7 @@ KafkaConsumer::Stat KafkaConsumer::getStat() const
         .exceptions_buffer = [&](){std::lock_guard<std::mutex> lock(exception_mutex);
             return exceptions_buffer;}(),
         .in_use = in_use.load(),
+        .last_used_usec = last_used_usec.load(),
         .rdkafka_stat = [&](){std::lock_guard<std::mutex> lock(rdkafka_stat_mutex);
             return rdkafka_stat;}(),
     };

--- a/src/Storages/Kafka/KafkaConsumer.h
+++ b/src/Storages/Kafka/KafkaConsumer.h
@@ -72,7 +72,7 @@ public:
 
     ~KafkaConsumer();
 
-    void setConsumer(const ConsumerPtr & consumer);
+    void createConsumer(cppkafka::Configuration consumer_config);
     bool hasConsumer() const { return consumer.get() != nullptr; }
     ConsumerPtr && moveConsumer() { return std::move(consumer); }
 

--- a/src/Storages/Kafka/KafkaConsumer.h
+++ b/src/Storages/Kafka/KafkaConsumer.h
@@ -57,6 +57,7 @@ public:
         UInt64 num_rebalance_revocations;
         KafkaConsumer::ExceptionsBuffer exceptions_buffer;
         bool in_use;
+        UInt64 last_used_usec;
         std::string rdkafka_stat;
     };
 
@@ -113,10 +114,19 @@ public:
         rdkafka_stat = stat_json_string;
     }
     void inUse() { in_use = true; }
-    void notInUse() { in_use = false; }
+    void notInUse()
+    {
+        in_use = false;
+        last_used_usec = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+    }
 
     // For system.kafka_consumers
     Stat getStat() const;
+
+    bool isInUse() const { return in_use; }
+    UInt64 getLastUsedUsec() const { return last_used_usec; }
+
+    std::string getMemberId() const;
 
 private:
     using Messages = std::vector<cppkafka::Message>;
@@ -168,6 +178,8 @@ private:
     std::atomic<UInt64> num_rebalance_assignments = 0;
     std::atomic<UInt64> num_rebalance_revocations = 0;
     std::atomic<bool> in_use = 0;
+    /// Last used time (for TTL)
+    std::atomic<UInt64> last_used_usec = 0;
 
     mutable std::mutex rdkafka_stat_mutex;
     std::string rdkafka_stat;
@@ -178,8 +190,6 @@ private:
     /// Return number of messages with an error.
     size_t filterMessageErrors();
     ReadBufferPtr getNextMessage();
-
-    std::string getMemberId() const;
 };
 
 }

--- a/src/Storages/Kafka/KafkaConsumer.h
+++ b/src/Storages/Kafka/KafkaConsumer.h
@@ -61,9 +61,7 @@ public:
         std::string rdkafka_stat;
     };
 
-public:
     KafkaConsumer(
-        ConsumerPtr consumer_,
         Poco::Logger * log_,
         size_t max_batch_size,
         size_t poll_timeout_,
@@ -73,6 +71,11 @@ public:
     );
 
     ~KafkaConsumer();
+
+    void setConsumer(const ConsumerPtr & consumer);
+    bool hasConsumer() const { return consumer.get() != nullptr; }
+    ConsumerPtr && moveConsumer() { return std::move(consumer); }
+
     void commit(); // Commit all processed messages.
     void subscribe(); // Subscribe internal consumer to topics.
     void unsubscribe(); // Unsubscribe internal consumer in case of failure.

--- a/src/Storages/Kafka/KafkaSettings.cpp
+++ b/src/Storages/Kafka/KafkaSettings.cpp
@@ -11,6 +11,7 @@ namespace DB
 namespace ErrorCodes
 {
     extern const int UNKNOWN_SETTING;
+    extern const int BAD_ARGUMENTS;
 }
 
 IMPLEMENT_SETTINGS_TRAITS(KafkaSettingsTraits, LIST_OF_KAFKA_SETTINGS)
@@ -36,6 +37,17 @@ void KafkaSettings::loadFromQuery(ASTStorage & storage_def)
         settings_ast->is_standalone = false;
         storage_def.set(storage_def.settings, settings_ast);
     }
+}
+
+void KafkaSettings::sanityCheck() const
+{
+    if (kafka_consumers_pool_ttl_ms < KAFKA_RESCHEDULE_MS)
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "The value of 'kafka_consumers_pool_ttl_ms' ({}) cannot be less then rescheduled interval ({})",
+            kafka_consumers_pool_ttl_ms, KAFKA_RESCHEDULE_MS);
+
+    if (kafka_consumers_pool_ttl_ms > KAFKA_CONSUMERS_POOL_TTL_MS_MAX)
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "The value of 'kafka_consumers_pool_ttl_ms' ({}) cannot be too big (greater then {}), since this may cause live memory leaks",
+            kafka_consumers_pool_ttl_ms, KAFKA_CONSUMERS_POOL_TTL_MS_MAX);
 }
 
 }

--- a/src/Storages/Kafka/KafkaSettings.h
+++ b/src/Storages/Kafka/KafkaSettings.h
@@ -8,6 +8,12 @@ namespace DB
 {
 class ASTStorage;
 
+const auto KAFKA_RESCHEDULE_MS = 500;
+const auto KAFKA_CLEANUP_TIMEOUT_MS = 3000;
+// once per minute leave do reschedule (we can't lock threads in pool forever)
+const auto KAFKA_MAX_THREAD_WORK_DURATION_MS = 60000;
+// 10min
+const auto KAFKA_CONSUMERS_POOL_TTL_MS_MAX = 600'000;
 
 #define KAFKA_RELATED_SETTINGS(M, ALIAS) \
     M(String, kafka_broker_list, "", "A comma-separated list of brokers for Kafka engine.", 0) \
@@ -25,6 +31,7 @@ class ASTStorage;
     /* default is stream_poll_timeout_ms */ \
     M(Milliseconds, kafka_poll_timeout_ms, 0, "Timeout for single poll from Kafka.", 0) \
     M(UInt64, kafka_poll_max_batch_size, 0, "Maximum amount of messages to be polled in a single Kafka poll.", 0) \
+    M(UInt64, kafka_consumers_pool_ttl_ms, 60'000, "TTL for Kafka consumers (in milliseconds)", 0) \
     /* default is stream_flush_interval_ms */ \
     M(Milliseconds, kafka_flush_interval_ms, 0, "Timeout for flushing data from Kafka.", 0) \
     M(Bool, kafka_thread_per_consumer, false, "Provide independent thread for each consumer", 0) \
@@ -53,6 +60,8 @@ DECLARE_SETTINGS_TRAITS(KafkaSettingsTraits, LIST_OF_KAFKA_SETTINGS)
 struct KafkaSettings : public BaseSettings<KafkaSettingsTraits>
 {
     void loadFromQuery(ASTStorage & storage_def);
+
+    void sanityCheck() const;
 };
 
 }

--- a/src/Storages/Kafka/StorageKafka.cpp
+++ b/src/Storages/Kafka/StorageKafka.cpp
@@ -746,12 +746,10 @@ void StorageKafka::updateConfiguration(cppkafka::Configuration & kafka_config,
         /// materialized view attached.
         ///
         /// So for now it is disabled by default, until properly fixed.
-#if 0
         if (!config.has(config_prefix + "." + "statistics_interval_ms"))
         {
             kafka_config.set("statistics.interval.ms", "3000"); // every 3 seconds by default. set to 0 to disable.
         }
-#endif
 
         if (kafka_config.get("statistics.interval.ms") != "0")
         {

--- a/src/Storages/Kafka/StorageKafka.cpp
+++ b/src/Storages/Kafka/StorageKafka.cpp
@@ -798,14 +798,10 @@ void StorageKafka::updateConfiguration(cppkafka::Configuration & kafka_config)
 
     /// NOTE: statistics should be consumed, otherwise it creates too much
     /// entries in the queue, that leads to memory leak and slow shutdown.
-    ///
-    /// This is the case when you have kafka table but no SELECT from it or
-    /// materialized view attached.
-    ///
-    /// So for now it is disabled by default, until properly fixed.
     if (!config.has(config_prefix + "." + "statistics_interval_ms"))
     {
-        kafka_config.set("statistics.interval.ms", "3000"); // every 3 seconds by default. set to 0 to disable.
+        // every 3 seconds by default. set to 0 to disable.
+        kafka_config.set("statistics.interval.ms", "3000");
     }
 
     // Configure interceptor to change thread name

--- a/src/Storages/Kafka/StorageKafka.cpp
+++ b/src/Storages/Kafka/StorageKafka.cpp
@@ -436,6 +436,8 @@ void StorageKafka::startup()
 
 void StorageKafka::shutdown(bool)
 {
+    shutdown_called = true;
+
     for (auto & task : tasks)
     {
         // Interrupt streaming thread

--- a/src/Storages/Kafka/StorageKafka.cpp
+++ b/src/Storages/Kafka/StorageKafka.cpp
@@ -286,6 +286,10 @@ StorageKafka::StorageKafka(
         tasks.emplace_back(std::make_shared<TaskContext>(std::move(task)));
     }
 
+    consumers.resize(num_consumers);
+    for (size_t i = 0; i < num_consumers; ++i)
+        consumers[i] = createKafkaConsumer(i);
+
     cleanup_thread = std::make_unique<ThreadFromGlobalPool>([this]()
     {
         const auto & table = getStorageID().getTableName();
@@ -422,10 +426,6 @@ SinkToStoragePtr StorageKafka::write(const ASTPtr &, const StorageMetadataPtr & 
 
 void StorageKafka::startup()
 {
-    consumers.resize(num_consumers);
-    for (size_t i = 0; i < num_consumers; ++i)
-        consumers[i] = createKafkaConsumer(i);
-
     // Start the reader thread
     for (auto & task : tasks)
     {

--- a/src/Storages/Kafka/StorageKafka.h
+++ b/src/Storages/Kafka/StorageKafka.h
@@ -130,8 +130,6 @@ private:
     SettingsChanges createSettingsAdjustments();
     /// Creates KafkaConsumer object without real consumer (cppkafka::Consumer)
     KafkaConsumerPtr createKafkaConsumer(size_t consumer_number);
-    /// Creates real cppkafka::Consumer object
-    ConsumerPtr createConsumer(KafkaConsumer & kafka_consumer, size_t consumer_number);
     /// Returns consumer configuration with all changes that had been overwritten in config
     cppkafka::Configuration getConsumerConfiguration(size_t consumer_number);
 

--- a/src/Storages/Kafka/StorageKafka.h
+++ b/src/Storages/Kafka/StorageKafka.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <Common/ThreadPool_fwd.h>
 #include <Common/Macros.h>
 #include <Core/BackgroundSchedulePool.h>
 #include <Storages/IStorage.h>
@@ -106,6 +107,7 @@ private:
 
     std::mutex mutex;
     std::condition_variable cv;
+    std::condition_variable cleanup_cv;
 
     // Stream thread
     struct TaskContext
@@ -118,6 +120,8 @@ private:
     };
     std::vector<std::shared_ptr<TaskContext>> tasks;
     bool thread_per_consumer = false;
+
+    std::unique_ptr<ThreadFromGlobalPool> cleanup_thread;
 
     /// For memory accounting in the librdkafka threads.
     std::mutex thread_statuses_mutex;

--- a/src/Storages/Kafka/StorageKafka.h
+++ b/src/Storages/Kafka/StorageKafka.h
@@ -9,6 +9,7 @@
 
 #include <Poco/Semaphore.h>
 
+#include <condition_variable>
 #include <mutex>
 #include <list>
 #include <atomic>
@@ -102,7 +103,6 @@ private:
     const String schema_name;
     const size_t num_consumers; /// total number of consumers
     Poco::Logger * log;
-    Poco::Semaphore semaphore;
     const bool intermediate_commit;
     const SettingsChanges settings_adjustments;
 
@@ -112,6 +112,7 @@ private:
     std::vector<KafkaConsumerWeakPtr> all_consumers; /// busy (belong to a KafkaSource) and vacant consumers
 
     std::mutex mutex;
+    std::condition_variable cv;
 
     // Stream thread
     struct TaskContext
@@ -157,6 +158,7 @@ private:
     bool streamToViews();
     bool checkDependencies(const StorageID & table_id);
 
+    void cleanConsumers();
 };
 
 }

--- a/src/Storages/Kafka/StorageKafka.h
+++ b/src/Storages/Kafka/StorageKafka.h
@@ -108,10 +108,6 @@ private:
 
     std::atomic<bool> mv_attached = false;
 
-    /// Can differ from num_consumers in case of exception in startup() (or if startup() hasn't been called).
-    /// In this case we still need to be able to shutdown() properly.
-    size_t num_created_consumers = 0; /// number of actually created consumers.
-
     std::vector<KafkaConsumerPtr> consumers; /// available consumers
     std::vector<KafkaConsumerWeakPtr> all_consumers; /// busy (belong to a KafkaSource) and vacant consumers
 

--- a/src/Storages/System/StorageSystemKafkaConsumers.cpp
+++ b/src/Storages/System/StorageSystemKafkaConsumers.cpp
@@ -41,6 +41,7 @@ NamesAndTypesList StorageSystemKafkaConsumers::getNamesAndTypes()
         {"num_rebalance_revocations", std::make_shared<DataTypeUInt64>()},
         {"num_rebalance_assignments", std::make_shared<DataTypeUInt64>()},
         {"is_currently_used", std::make_shared<DataTypeUInt8>()},
+        {"last_used", std::make_shared<DataTypeDateTime64>(6)},
         {"rdkafka_stat", std::make_shared<DataTypeString>()},
     };
     return names_and_types;
@@ -78,6 +79,7 @@ void StorageSystemKafkaConsumers::fillData(MutableColumns & res_columns, Context
     auto & num_rebalance_revocations = assert_cast<ColumnUInt64 &>(*res_columns[index++]);
     auto & num_rebalance_assigments = assert_cast<ColumnUInt64 &>(*res_columns[index++]);
     auto & is_currently_used = assert_cast<ColumnUInt8 &>(*res_columns[index++]);
+    auto & last_used = assert_cast<ColumnDateTime64 &>(*res_columns[index++]);
     auto & rdkafka_stat = assert_cast<ColumnString &>(*res_columns[index++]);
 
     const auto access = context->getAccess();
@@ -144,6 +146,7 @@ void StorageSystemKafkaConsumers::fillData(MutableColumns & res_columns, Context
                 num_rebalance_assigments.insert(consumer_stat.num_rebalance_assignments);
 
                 is_currently_used.insert(consumer_stat.in_use);
+                last_used.insert(consumer_stat.last_used_usec);
 
                 rdkafka_stat.insertData(consumer_stat.rdkafka_stat.data(), consumer_stat.rdkafka_stat.size());
             }

--- a/src/Storages/System/StorageSystemKafkaConsumers.cpp
+++ b/src/Storages/System/StorageSystemKafkaConsumers.cpp
@@ -98,58 +98,55 @@ void StorageSystemKafkaConsumers::fillData(MutableColumns & res_columns, Context
 
         auto safe_consumers = storage_kafka_ptr->getSafeConsumers();
 
-        for (const auto & weak_consumer : safe_consumers.consumers)
+        for (const auto & consumer : safe_consumers.consumers)
         {
-            if (auto consumer = weak_consumer.lock())
+            auto consumer_stat = consumer->getStat();
+
+            database.insertData(database_str.data(), database_str.size());
+            table.insertData(table_str.data(), table_str.size());
+
+            consumer_id.insertData(consumer_stat.consumer_id.data(), consumer_stat.consumer_id.size());
+
+            const auto num_assignnemts = consumer_stat.assignments.size();
+
+            for (size_t num = 0; num < num_assignnemts; ++num)
             {
-                auto consumer_stat = consumer->getStat();
+                const auto & assign = consumer_stat.assignments[num];
 
-                database.insertData(database_str.data(), database_str.size());
-                table.insertData(table_str.data(), table_str.size());
+                assigments_topics.insertData(assign.topic_str.data(), assign.topic_str.size());
 
-                consumer_id.insertData(consumer_stat.consumer_id.data(), consumer_stat.consumer_id.size());
-
-                const auto num_assignnemts = consumer_stat.assignments.size();
-
-                for (size_t num = 0; num < num_assignnemts; ++num)
-                {
-                    const auto & assign = consumer_stat.assignments[num];
-
-                    assigments_topics.insertData(assign.topic_str.data(), assign.topic_str.size());
-
-                    assigments_partition_id.insert(assign.partition_id);
-                    assigments_current_offset.insert(assign.current_offset);
-                }
-                last_assignment_num += num_assignnemts;
-
-                assigments_topics_offsets.push_back(last_assignment_num);
-                assigments_partition_id_offsets.push_back(last_assignment_num);
-                assigments_current_offset_offsets.push_back(last_assignment_num);
-
-                for (const auto & exc : consumer_stat.exceptions_buffer)
-                {
-                    exceptions_text.insertData(exc.text.data(), exc.text.size());
-                    exceptions_time.insert(exc.timestamp_usec);
-                }
-                exceptions_num += consumer_stat.exceptions_buffer.size();
-                exceptions_text_offset.push_back(exceptions_num);
-                exceptions_time_offset.push_back(exceptions_num);
-
-
-                last_poll_time.insert(consumer_stat.last_poll_time);
-                num_messages_read.insert(consumer_stat.num_messages_read);
-                last_commit_time.insert(consumer_stat.last_commit_timestamp_usec);
-                num_commits.insert(consumer_stat.num_commits);
-                last_rebalance_time.insert(consumer_stat.last_rebalance_timestamp_usec);
-
-                num_rebalance_revocations.insert(consumer_stat.num_rebalance_revocations);
-                num_rebalance_assigments.insert(consumer_stat.num_rebalance_assignments);
-
-                is_currently_used.insert(consumer_stat.in_use);
-                last_used.insert(consumer_stat.last_used_usec);
-
-                rdkafka_stat.insertData(consumer_stat.rdkafka_stat.data(), consumer_stat.rdkafka_stat.size());
+                assigments_partition_id.insert(assign.partition_id);
+                assigments_current_offset.insert(assign.current_offset);
             }
+            last_assignment_num += num_assignnemts;
+
+            assigments_topics_offsets.push_back(last_assignment_num);
+            assigments_partition_id_offsets.push_back(last_assignment_num);
+            assigments_current_offset_offsets.push_back(last_assignment_num);
+
+            for (const auto & exc : consumer_stat.exceptions_buffer)
+            {
+                exceptions_text.insertData(exc.text.data(), exc.text.size());
+                exceptions_time.insert(exc.timestamp_usec);
+            }
+            exceptions_num += consumer_stat.exceptions_buffer.size();
+            exceptions_text_offset.push_back(exceptions_num);
+            exceptions_time_offset.push_back(exceptions_num);
+
+
+            last_poll_time.insert(consumer_stat.last_poll_time);
+            num_messages_read.insert(consumer_stat.num_messages_read);
+            last_commit_time.insert(consumer_stat.last_commit_timestamp_usec);
+            num_commits.insert(consumer_stat.num_commits);
+            last_rebalance_time.insert(consumer_stat.last_rebalance_timestamp_usec);
+
+            num_rebalance_revocations.insert(consumer_stat.num_rebalance_revocations);
+            num_rebalance_assigments.insert(consumer_stat.num_rebalance_assignments);
+
+            is_currently_used.insert(consumer_stat.in_use);
+            last_used.insert(consumer_stat.last_used_usec);
+
+            rdkafka_stat.insertData(consumer_stat.rdkafka_stat.data(), consumer_stat.rdkafka_stat.size());
         }
     };
 


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Create consumers for Kafka tables on fly (but keep them for some period - `kafka_consumers_pool_ttl_ms`, since last used), this should fix problem with statistics for `system.kafka_consumers` (that does not consumed when nobody reads from Kafka table, which leads to live memory leak and slow table detach) and also this PR enables stats for `system.kafka_consumers` by default again.

Pool of consumers created a problem for librdkafka internal statistics,
you need to read from the queue always, while in ClickHouse consumers
created regardless are there any readers or not (attached materialized
views or direct SELECTs).

Otherwise, this statistics messages got queued and never released,
which:
- creates live memory leak
- and also makes destroy very slow, due to librdkafka internals (it
  moves entries from this queue into another linked list, but in a
  with sorting, which is incredibly slow for linked lists)

So the idea is simple, let's create a pool of consumers only when they
are required, and destroy them after some timeout (right now it is 60
seconds) if nobody uses them, that way this problem should gone.

This should also reduce number of internal librdkafka threads, when
nobody reads from Kafka tables.

~~Requires: https://github.com/ClickHouse/ClickHouse/pull/57822 (not requires, but just better to merge it after it, since in that case I will enable statistics by default here again, or maybe it should be done separately...)~~
Fixes: https://github.com/ClickHouse/ClickHouse/pull/50999 (cc @ilejn)

_Note: this should not be backported_