### PR TITLE
Regular do clean task for StorageMergeTree

### DIFF
--- a/src/Storages/MergeTree/MergeTreeSettings.h
+++ b/src/Storages/MergeTree/MergeTreeSettings.h
@@ -131,6 +131,7 @@ struct Settings;
     M(UInt64, max_cleanup_delay_period, 300, "Maximum period to clean old queue logs, blocks hashes and parts.", 0) \
     M(UInt64, cleanup_delay_period_random_add, 10, "Add uniformly distributed value from 0 to x seconds to cleanup_delay_period to avoid thundering herd effect and subsequent DoS of ZooKeeper in case of very large number of tables.", 0) \
     M(UInt64, cleanup_thread_preferred_points_per_iteration, 150, "Preferred batch size for background cleanup (points are abstract but 1 point is approximately equivalent to 1 inserted block).", 0) \
+    M(UInt64, max_wait_clean_timeout, 10 * 60, "max wait clean timeout for storage merge tree, default 10 minutes.", 0)   \
     M(UInt64, min_relative_delay_to_close, 300, "Minimal delay from other replicas to close, stop serving requests and not return Ok during status check.", 0) \
     M(UInt64, min_absolute_delay_to_close, 0, "Minimal absolute delay to close, stop serving requests and not return Ok during status check.", 0) \
     M(UInt64, enable_vertical_merge_algorithm, 1, "Enable usage of Vertical merge algorithm.", 0) \

--- a/src/Storages/StorageMergeTree.h
+++ b/src/Storages/StorageMergeTree.h
@@ -132,6 +132,7 @@ private:
     /// For block numbers.
     SimpleIncrement increment;
 
+    time_t last_time_clean {0};
     /// For clearOldParts
     AtomicStopwatch time_after_previous_cleanup_parts;
     /// For clearOldTemporaryDirectories.


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement


### Changelog entry

**When StorageMergeTree has been more than 10 minutes since the last cleaning task, just do the clean job forcely.**

I encountered a strange problem today, that is, **the system table has a lot of inactive parts and cannot be cleaned.**

After reading the code, I found that background tasks need to be executed in the order of **merge, mutate, and clean** for StorageMergeTree, The system table has been Merging all the time and cannot schedule the cleaning tasks.

So I want fix the problem, When StorageMergeTree has been more than 10 minutes since the last cleaning task, just do the clean job forcely.



### Documentation entry for user-facing changes


<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
