### PR TITLE
Add option `--show-whitespaces-in-diff` to clickhouse-test

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -1161,9 +1161,9 @@ class TestCase:
                 universal_newlines=True,
             )
             if self.show_whitespaces_in_diff:
-                cat_proc = Popen(["cat", "-te"], stdin=diff_proc.stdout, stdout=PIPE)
+                sed_proc = Popen(["sed", "-e", "s/[ \t]\\+$/&$/g"], stdin=diff_proc.stdout, stdout=PIPE)
                 diff_proc.stdout.close()  # Allow diff to receive a SIGPIPE if cat exits.
-                diff = cat_proc.communicate()[0].decode("utf-8", errors="ignore")
+                diff = sed_proc.communicate()[0].decode("utf-8", errors="ignore")
             else:
                 diff = diff_proc.communicate()[0]
 
@@ -2767,7 +2767,7 @@ def parse_args():
     parser.add_argument(
         "--show-whitespaces-in-diff",
         action="store_true",
-        help="Display TAB characters as ^I and trailing spaces as $ in diff",
+        help="Display $ characters after line with trailing whitespaces in diff output",
     )
 
     group = parser.add_mutually_exclusive_group(required=False)

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -1161,7 +1161,11 @@ class TestCase:
                 universal_newlines=True,
             )
             if self.show_whitespaces_in_diff:
-                sed_proc = Popen(["sed", "-e", "s/[ \t]\\+$/&$/g"], stdin=diff_proc.stdout, stdout=PIPE)
+                sed_proc = Popen(
+                    ["sed", "-e", "s/[ \t]\\+$/&$/g"],
+                    stdin=diff_proc.stdout,
+                    stdout=PIPE,
+                )
                 diff_proc.stdout.close()  # Allow diff to receive a SIGPIPE if cat exits.
                 diff = sed_proc.communicate()[0].decode("utf-8", errors="ignore")
             else:

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -947,6 +947,8 @@ class TestCase:
             else ""
         )
 
+        self.show_whitespaces_in_diff = args.show_whitespaces_in_diff
+
     # should skip test, should increment skipped_total, skip reason
     def should_skip_test(self, suite) -> Optional[FailureReason]:
         tags = self.tags
@@ -1146,7 +1148,7 @@ class TestCase:
         )
 
         if result_is_different:
-            diff = Popen(
+            diff_proc = Popen(
                 [
                     "diff",
                     "-U",
@@ -1157,7 +1159,14 @@ class TestCase:
                 encoding="latin-1",
                 stdout=PIPE,
                 universal_newlines=True,
-            ).communicate()[0]
+            )
+            if self.show_whitespaces_in_diff:
+                cat_proc = Popen(["cat", "-te"], stdin=diff_proc.stdout, stdout=PIPE)
+                diff_proc.stdout.close()  # Allow diff to receive a SIGPIPE if cat exits.
+                diff = cat_proc.communicate()[0].decode("utf-8", errors="ignore")
+            else:
+                diff = diff_proc.communicate()[0]
+
             if diff.startswith("Binary files "):
                 diff += "Content of stdout:\n===================\n"
                 file = open(self.stdout_file, "rb")
@@ -2753,6 +2762,12 @@ def parse_args():
         "--run-by-hash-total",
         type=int,
         help="Total test groups for crc32(test_name) % run_by_hash_total == run_by_hash_num",
+    )
+
+    parser.add_argument(
+        "--show-whitespaces-in-diff",
+        action="store_true",
+        help="Display TAB characters as ^I and trailing spaces as $ in diff",
     )
 
     group = parser.add_mutually_exclusive_group(required=False)


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)

Some times reference differs from output only because of white spaces (e.g. string column with empty value as a last column

```bash
rg -l '\t$' ./tests/queries/0_stateless/*.reference | wc -l
264
```

which is difficult to see)

Perhaps it's worth only adding `$` in the end of the line, but in this PR all tabs replaced as well. So not sure should we use `cat -te` or `cat -e`