### PR TITLE
Better optimization of consecutive keys in aggregation

### DIFF
--- a/src/Common/ColumnsHashingImpl.h
+++ b/src/Common/ColumnsHashingImpl.h
@@ -42,11 +42,14 @@ struct LastElementCache
     Value value;
     bool empty = true;
     bool found = false;
+    bool value_changed = false;
 
-    bool check(const Value & value_) { return !empty && value == value_; }
+    bool check(const Value & value_) const { return value == value_; }
 
     template <typename Key>
-    bool check(const Key & key) { return !empty && value.first == key; }
+    bool check(const Key & key) const { return value.first == key; }
+
+    bool hasOnlyOneValue() const { return !empty && found && !value_changed; }
 };
 
 template <typename Data>
@@ -166,6 +169,7 @@ public:
                     return EmplaceResult(!has_null_key);
             }
         }
+
         auto key_holder = static_cast<Derived &>(*this).getKeyHolder(row, pool);
         return emplaceImpl(key_holder, data);
     }
@@ -192,6 +196,23 @@ public:
     {
         auto key_holder = static_cast<Derived &>(*this).getKeyHolder(row, pool);
         return data.hash(keyHolderGetKey(key_holder));
+    }
+
+    ALWAYS_INLINE void resetCache()
+    {
+        if constexpr (consecutive_keys_optimization)
+        {
+            cache.empty = true;
+            cache.found = false;
+            cache.value_changed = false;
+        }
+    }
+
+    ALWAYS_INLINE bool hasOnlyOneValueSinceLastReset() const
+    {
+        if constexpr (consecutive_keys_optimization)
+            return cache.hasOnlyOneValue();
+        return false;
     }
 
     ALWAYS_INLINE bool isNullAt(size_t row) const
@@ -225,11 +246,9 @@ protected:
             else
                 cache.value = Value();
         }
-        if constexpr (nullable)
-        {
 
+        if constexpr (nullable)
             null_map = &checkAndGetColumn<ColumnNullable>(column)->getNullMapColumn();
-        }
     }
 
     template <typename Data, typename KeyHolder>
@@ -237,12 +256,19 @@ protected:
     {
         if constexpr (Cache::consecutive_keys_optimization)
         {
-            if (cache.found && cache.check(keyHolderGetKey(key_holder)))
+            if (!cache.empty)
             {
-                if constexpr (has_mapped)
-                    return EmplaceResult(cache.value.second, cache.value.second, false);
+                if (cache.found && cache.check(keyHolderGetKey(key_holder)))
+                {
+                    if constexpr (has_mapped)
+                        return EmplaceResult(cache.value.second, cache.value.second, false);
+                    else
+                        return EmplaceResult(false);
+                }
                 else
-                    return EmplaceResult(false);
+                {
+                    cache.value_changed = true;
+                }
             }
         }
 
@@ -293,12 +319,19 @@ protected:
             /// It's possible to support such combination, but code will became more complex.
             /// Now there's not place where we need this options enabled together
             static_assert(!FindResult::has_offset, "`consecutive_keys_optimization` and `has_offset` are conflicting options");
-            if (cache.check(key))
+            if (!cache.empty)
             {
-                if constexpr (has_mapped)
-                    return FindResult(&cache.value.second, cache.found, 0);
+                if (cache.check(key))
+                {
+                    if constexpr (has_mapped)
+                        return FindResult(&cache.value.second, cache.found, 0);
+                    else
+                        return FindResult(cache.found, 0);
+                }
                 else
-                    return FindResult(cache.found, 0);
+                {
+                    cache.value_changed = true;
+                }
             }
         }
 

--- a/src/Common/ColumnsHashingImpl.h
+++ b/src/Common/ColumnsHashingImpl.h
@@ -31,6 +31,11 @@ public:
 
 using HashMethodContextPtr = std::shared_ptr<HashMethodContext>;
 
+struct LastElementCacheStats
+{
+    UInt64 hits = 0;
+    UInt64 misses = 0;
+};
 
 namespace columns_hashing_impl
 {
@@ -39,17 +44,19 @@ template <typename Value, bool consecutive_keys_optimization_>
 struct LastElementCache
 {
     static constexpr bool consecutive_keys_optimization = consecutive_keys_optimization_;
+
     Value value;
     bool empty = true;
     bool found = false;
-    bool value_changed = false;
+    LastElementCacheStats stats;
 
     bool check(const Value & value_) const { return value == value_; }
 
     template <typename Key>
     bool check(const Key & key) const { return value.first == key; }
 
-    bool hasOnlyOneValue() const { return !empty && found && !value_changed; }
+    bool hasOnlyOneValue() const { return !empty && found && stats.misses == 0; }
+    LastElementCacheStats getStats() const { return stats; }
 };
 
 template <typename Data>
@@ -187,6 +194,7 @@ public:
                     return FindResult(data.hasNullKeyData(), 0);
             }
         }
+
         auto key_holder = static_cast<Derived &>(*this).getKeyHolder(row, pool);
         return findKeyImpl(keyHolderGetKey(key_holder), data);
     }
@@ -204,7 +212,7 @@ public:
         {
             cache.empty = true;
             cache.found = false;
-            cache.value_changed = false;
+            cache.stats = {};
         }
     }
 
@@ -213,6 +221,13 @@ public:
         if constexpr (consecutive_keys_optimization)
             return cache.hasOnlyOneValue();
         return false;
+    }
+
+    ALWAYS_INLINE LastElementCacheStats getCacheStatsSinceLastReset() const
+    {
+        if constexpr (consecutive_keys_optimization)
+            return cache.getStats();
+        return {0, 0};
     }
 
     ALWAYS_INLINE bool isNullAt(size_t row) const
@@ -254,12 +269,13 @@ protected:
     template <typename Data, typename KeyHolder>
     ALWAYS_INLINE EmplaceResult emplaceImpl(KeyHolder & key_holder, Data & data)
     {
-        if constexpr (Cache::consecutive_keys_optimization)
+        if constexpr (consecutive_keys_optimization)
         {
             if (!cache.empty)
             {
                 if (cache.found && cache.check(keyHolderGetKey(key_holder)))
                 {
+                    ++cache.stats.hits;
                     if constexpr (has_mapped)
                         return EmplaceResult(cache.value.second, cache.value.second, false);
                     else
@@ -267,7 +283,7 @@ protected:
                 }
                 else
                 {
-                    cache.value_changed = true;
+                    ++cache.stats.misses;
                 }
             }
         }
@@ -323,6 +339,7 @@ protected:
             {
                 if (cache.check(key))
                 {
+                    ++cache.stats.hits;
                     if constexpr (has_mapped)
                         return FindResult(&cache.value.second, cache.found, 0);
                     else
@@ -330,7 +347,7 @@ protected:
                 }
                 else
                 {
-                    cache.value_changed = true;
+                    ++cache.stats.misses;
                 }
             }
         }
@@ -358,9 +375,8 @@ protected:
 
         size_t offset = 0;
         if constexpr (FindResult::has_offset)
-        {
             offset = it ? data.offsetInternal(it) : 0;
-        }
+
         if constexpr (has_mapped)
             return FindResult(it ? &it->getMapped() : nullptr, it != nullptr, offset);
         else

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -654,7 +654,7 @@ class IColumn;
     M(Bool, allow_aggregate_partitions_independently, false, "Enable independent aggregation of partitions on separate threads when partition key suits group by key. Beneficial when number of partitions close to number of cores and partitions have roughly the same size", 0) \
     M(Bool, force_aggregate_partitions_independently, false, "Force the use of optimization when it is applicable, but heuristics decided not to use it", 0) \
     M(UInt64, max_number_of_partitions_for_independent_aggregation, 128, "Maximal number of partitions in table to apply optimization", 0) \
-    M(Float, min_hit_rate_to_use_consecutive_keys_optimization, 0.5, "Minimal hit rate of a cache which is used for consecutive keys optimization in aggreagtion to keep it enabled", 0) \
+    M(Float, min_hit_rate_to_use_consecutive_keys_optimization, 0.5, "Minimal hit rate of a cache which is used for consecutive keys optimization in aggregation to keep it enabled", 0) \
     /** Experimental feature for moving data between shards. */ \
     \
     M(Bool, allow_experimental_query_deduplication, false, "Experimental data deduplication for SELECT queries based on part UUIDs", 0) \

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -654,8 +654,6 @@ class IColumn;
     M(Bool, allow_aggregate_partitions_independently, false, "Enable independent aggregation of partitions on separate threads when partition key suits group by key. Beneficial when number of partitions close to number of cores and partitions have roughly the same size", 0) \
     M(Bool, force_aggregate_partitions_independently, false, "Force the use of optimization when it is applicable, but heuristics decided not to use it", 0) \
     M(UInt64, max_number_of_partitions_for_independent_aggregation, 128, "Maximal number of partitions in table to apply optimization", 0) \
-    M(UInt64, num_rows_to_collect_statistics_for_consecutive_keys_optimization, DEFAULT_BLOCK_SIZE, "", 0) \
-    M(Float, hit_rate_to_use_consecutive_keys_optimization, 0.5, "", 0) \
     /** Experimental feature for moving data between shards. */ \
     \
     M(Bool, allow_experimental_query_deduplication, false, "Experimental data deduplication for SELECT queries based on part UUIDs", 0) \

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -654,6 +654,7 @@ class IColumn;
     M(Bool, allow_aggregate_partitions_independently, false, "Enable independent aggregation of partitions on separate threads when partition key suits group by key. Beneficial when number of partitions close to number of cores and partitions have roughly the same size", 0) \
     M(Bool, force_aggregate_partitions_independently, false, "Force the use of optimization when it is applicable, but heuristics decided not to use it", 0) \
     M(UInt64, max_number_of_partitions_for_independent_aggregation, 128, "Maximal number of partitions in table to apply optimization", 0) \
+    M(Float, min_hit_rate_to_use_consecutive_keys_optimization, 0.5, "Minimal hit rate of a cache which is used for consecutive keys optimization in aggreagtion to keep it enabled", 0) \
     /** Experimental feature for moving data between shards. */ \
     \
     M(Bool, allow_experimental_query_deduplication, false, "Experimental data deduplication for SELECT queries based on part UUIDs", 0) \

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -654,6 +654,8 @@ class IColumn;
     M(Bool, allow_aggregate_partitions_independently, false, "Enable independent aggregation of partitions on separate threads when partition key suits group by key. Beneficial when number of partitions close to number of cores and partitions have roughly the same size", 0) \
     M(Bool, force_aggregate_partitions_independently, false, "Force the use of optimization when it is applicable, but heuristics decided not to use it", 0) \
     M(UInt64, max_number_of_partitions_for_independent_aggregation, 128, "Maximal number of partitions in table to apply optimization", 0) \
+    M(UInt64, num_rows_to_collect_statistics_for_consecutive_keys_optimization, DEFAULT_BLOCK_SIZE, "", 0) \
+    M(Float, hit_rate_to_use_consecutive_keys_optimization, 0.5, "", 0) \
     /** Experimental feature for moving data between shards. */ \
     \
     M(Bool, allow_experimental_query_deduplication, false, "Experimental data deduplication for SELECT queries based on part UUIDs", 0) \

--- a/src/Interpreters/Aggregator.h
+++ b/src/Interpreters/Aggregator.h
@@ -1467,16 +1467,15 @@ private:
         bool final,
         ThreadPool * thread_pool) const;
 
-    template <bool no_more_keys, typename Method, typename Table>
+    template <bool no_more_keys, typename State, typename Table>
     void mergeStreamsImplCase(
         Arena * aggregates_pool,
-        Method & method,
+        State & state,
         Table & data,
         AggregateDataPtr overflow_row,
         size_t row_begin,
         size_t row_end,
         const AggregateColumnsConstData & aggregate_columns_data,
-        const ColumnRawPtrs & key_columns,
         Arena * arena_for_keys) const;
 
     /// `arena_for_keys` used to store serialized aggregation keys (in methods like `serialized`) to save some space.
@@ -1488,6 +1487,7 @@ private:
         Method & method,
         Table & data,
         AggregateDataPtr overflow_row,
+        LastElementCacheStats & consecutive_keys_cache_stats,
         bool no_more_keys,
         Arena * arena_for_keys = nullptr) const;
 
@@ -1497,6 +1497,7 @@ private:
         Method & method,
         Table & data,
         AggregateDataPtr overflow_row,
+        LastElementCacheStats & consecutive_keys_cache_stats,
         bool no_more_keys,
         size_t row_begin,
         size_t row_end,
@@ -1507,6 +1508,7 @@ private:
     void mergeBlockWithoutKeyStreamsImpl(
         Block block,
         AggregatedDataVariants & result) const;
+
     void mergeWithoutKeyStreamsImpl(
         AggregatedDataVariants & result,
         size_t row_begin,

--- a/src/Interpreters/Aggregator.h
+++ b/src/Interpreters/Aggregator.h
@@ -1507,6 +1507,18 @@ private:
         MutableColumns & final_key_columns) const;
 
     static bool hasSparseArguments(AggregateFunctionInstruction * aggregate_instructions);
+
+    static void addBatch(
+        size_t row_begin, size_t row_end,
+        AggregateFunctionInstruction * inst,
+        AggregateDataPtr * places,
+        Arena * arena);
+
+    static void addBatchSinglePlace(
+        size_t row_begin, size_t row_end,
+        AggregateFunctionInstruction * inst,
+        AggregateDataPtr place,
+        Arena * arena);
 };
 
 

--- a/src/Interpreters/Aggregator.h
+++ b/src/Interpreters/Aggregator.h
@@ -205,8 +205,17 @@ struct AggregationMethodOneNumber
     }
 
     /// To use one `Method` in different threads, use different `State`.
-    using State = ColumnsHashing::HashMethodOneNumber<typename Data::value_type,
-        Mapped, FieldType, consecutive_keys_optimization, false, nullable>;
+    template <bool use_cache>
+    using StateImpl = ColumnsHashing::HashMethodOneNumber<
+        typename Data::value_type,
+        Mapped,
+        FieldType,
+        use_cache && consecutive_keys_optimization,
+        /*need_offset=*/ false,
+        nullable>;
+
+    using State = StateImpl<true>;
+    using StateNoCache = StateImpl<false>;
 
     /// Use optimization for low cardinality.
     static const bool low_cardinality_optimization = false;
@@ -259,7 +268,11 @@ struct AggregationMethodString
 
     explicit AggregationMethodString(size_t size_hint) : data(size_hint) { }
 
-    using State = ColumnsHashing::HashMethodString<typename Data::value_type, Mapped>;
+    template <bool use_cache>
+    using StateImpl = ColumnsHashing::HashMethodString<typename Data::value_type, Mapped, /*place_string_to_arena=*/ true, use_cache>;
+
+    using State = StateImpl<true>;
+    using StateNoCache = StateImpl<false>;
 
     static const bool low_cardinality_optimization = false;
     static const bool one_key_nullable_optimization = false;
@@ -292,7 +305,11 @@ struct AggregationMethodStringNoCache
     {
     }
 
-    using State = ColumnsHashing::HashMethodString<typename Data::value_type, Mapped, true, false, false, nullable>;
+    template <bool use_cache>
+    using StateImpl = ColumnsHashing::HashMethodString<typename Data::value_type, Mapped, true, false, false, nullable>;
+
+    using State = StateImpl<true>;
+    using StateNoCache = StateImpl<false>;
 
     static const bool low_cardinality_optimization = false;
     static const bool one_key_nullable_optimization = nullable;
@@ -334,7 +351,11 @@ struct AggregationMethodFixedString
     {
     }
 
-    using State = ColumnsHashing::HashMethodFixedString<typename Data::value_type, Mapped>;
+    template <bool use_cache>
+    using StateImpl = ColumnsHashing::HashMethodFixedString<typename Data::value_type, Mapped, /*place_string_to_arena=*/ true, use_cache>;
+
+    using State = StateImpl<true>;
+    using StateNoCache = StateImpl<false>;
 
     static const bool low_cardinality_optimization = false;
     static const bool one_key_nullable_optimization = false;
@@ -366,7 +387,11 @@ struct AggregationMethodFixedStringNoCache
     {
     }
 
-    using State = ColumnsHashing::HashMethodFixedString<typename Data::value_type, Mapped, true, false, false, nullable>;
+    template <bool use_cache>
+    using StateImpl = ColumnsHashing::HashMethodFixedString<typename Data::value_type, Mapped, true, false, false, nullable>;
+
+    using State = StateImpl<true>;
+    using StateNoCache = StateImpl<false>;
 
     static const bool low_cardinality_optimization = false;
     static const bool one_key_nullable_optimization = nullable;
@@ -392,20 +417,24 @@ template <typename SingleColumnMethod>
 struct AggregationMethodSingleLowCardinalityColumn : public SingleColumnMethod
 {
     using Base = SingleColumnMethod;
-    using BaseState = typename Base::State;
-
     using Data = typename Base::Data;
     using Key = typename Base::Key;
     using Mapped = typename Base::Mapped;
-
     using Base::data;
+
+    template <bool use_cache>
+    using BaseStateImpl = typename Base::template StateImpl<use_cache>;
 
     AggregationMethodSingleLowCardinalityColumn() = default;
 
     template <typename Other>
     explicit AggregationMethodSingleLowCardinalityColumn(const Other & other) : Base(other) {}
 
-    using State = ColumnsHashing::HashMethodSingleLowCardinalityColumn<BaseState, Mapped, true>;
+    template <bool use_cache>
+    using StateImpl = ColumnsHashing::HashMethodSingleLowCardinalityColumn<BaseStateImpl<use_cache>, Mapped, use_cache>;
+
+    using State = StateImpl<true>;
+    using StateNoCache = StateImpl<false>;
 
     static const bool low_cardinality_optimization = true;
 
@@ -429,7 +458,7 @@ struct AggregationMethodSingleLowCardinalityColumn : public SingleColumnMethod
 
 
 /// For the case where all keys are of fixed length, and they fit in N (for example, 128) bits.
-template <typename TData, bool has_nullable_keys_ = false, bool has_low_cardinality_ = false, bool use_cache = true>
+template <typename TData, bool has_nullable_keys_ = false, bool has_low_cardinality_ = false, bool consecutive_keys_optimization = false>
 struct AggregationMethodKeysFixed
 {
     using Data = TData;
@@ -449,13 +478,17 @@ struct AggregationMethodKeysFixed
     {
     }
 
-    using State = ColumnsHashing::HashMethodKeysFixed<
+    template <bool use_cache>
+    using StateImpl = ColumnsHashing::HashMethodKeysFixed<
         typename Data::value_type,
         Key,
         Mapped,
         has_nullable_keys,
         has_low_cardinality,
-        use_cache>;
+        use_cache && consecutive_keys_optimization>;
+
+    using State = StateImpl<true>;
+    using StateNoCache = StateImpl<false>;
 
     static const bool low_cardinality_optimization = false;
     static const bool one_key_nullable_optimization = false;
@@ -546,7 +579,11 @@ struct AggregationMethodSerialized
     {
     }
 
-    using State = ColumnsHashing::HashMethodSerialized<typename Data::value_type, Mapped>;
+    template <bool use_cache>
+    using StateImpl = ColumnsHashing::HashMethodSerialized<typename Data::value_type, Mapped>;
+
+    using State = StateImpl<true>;
+    using StateNoCache = StateImpl<false>;
 
     static const bool low_cardinality_optimization = false;
     static const bool one_key_nullable_optimization = false;
@@ -566,6 +603,7 @@ class Aggregator;
 
 using ColumnsHashing::HashMethodContext;
 using ColumnsHashing::HashMethodContextPtr;
+using ColumnsHashing::LastElementCacheStats;
 
 struct AggregatedDataVariants : private boost::noncopyable
 {
@@ -598,6 +636,9 @@ struct AggregatedDataVariants : private boost::noncopyable
     /** Specialization for the case when there are no keys, and for keys not fitted into max_rows_to_group_by.
       */
     AggregatedDataWithoutKey without_key = nullptr;
+
+    /// TODO:
+    LastElementCacheStats consecutive_keys_cache_stats;
 
     // Disable consecutive key optimization for Uint8/16, because they use a FixedHashMap
     // and the lookup there is almost free, so we don't need to cache the last lookup result
@@ -1295,15 +1336,28 @@ private:
         size_t row_end,
         ColumnRawPtrs & key_columns,
         AggregateFunctionInstruction * aggregate_instructions,
+        LastElementCacheStats & consecutive_keys_cache_stats,
+        bool no_more_keys,
+        bool all_keys_are_const,
+        AggregateDataPtr overflow_row) const;
+
+    template <typename Method, typename State>
+    void executeImpl(
+        Method & method,
+        State & state,
+        Arena * aggregates_pool,
+        size_t row_begin,
+        size_t row_end,
+        AggregateFunctionInstruction * aggregate_instructions,
         bool no_more_keys,
         bool all_keys_are_const,
         AggregateDataPtr overflow_row) const;
 
     /// Specialization for a particular value no_more_keys.
-    template <bool no_more_keys, bool use_compiled_functions, bool prefetch, typename Method>
+    template <bool no_more_keys, bool use_compiled_functions, bool prefetch, typename Method, typename State>
     void executeImplBatch(
         Method & method,
-        typename Method::State & state,
+        State & state,
         Arena * aggregates_pool,
         size_t row_begin,
         size_t row_end,

--- a/src/Interpreters/InterpreterSelectQuery.cpp
+++ b/src/Interpreters/InterpreterSelectQuery.cpp
@@ -2006,7 +2006,7 @@ static void executeMergeAggregatedImpl(
       *  but it can work more slowly.
       */
 
-    Aggregator::Params params(keys, aggregates, overflow_row, settings.max_threads, settings.max_block_size);
+    Aggregator::Params params(keys, aggregates, overflow_row, settings.max_threads, settings.max_block_size, settings.min_hit_rate_to_use_consecutive_keys_optimization);
 
     auto merging_aggregated = std::make_unique<MergingAggregatedStep>(
         query_plan.getCurrentDataStream(),
@@ -2672,6 +2672,7 @@ static Aggregator::Params getAggregatorParams(
         settings.enable_software_prefetch_in_aggregation,
         /* only_merge */ false,
         settings.optimize_group_by_constant_keys,
+        settings.min_hit_rate_to_use_consecutive_keys_optimization,
         stats_collecting_params
     };
 }

--- a/src/Planner/Planner.cpp
+++ b/src/Planner/Planner.cpp
@@ -374,6 +374,7 @@ Aggregator::Params getAggregatorParams(const PlannerContextPtr & planner_context
         settings.enable_software_prefetch_in_aggregation,
         /* only_merge */ false,
         settings.optimize_group_by_constant_keys,
+        settings.min_hit_rate_to_use_consecutive_keys_optimization,
         stats_collecting_params);
 
     return aggregator_params;
@@ -476,7 +477,8 @@ void addMergingAggregatedStep(QueryPlan & query_plan,
         aggregation_analysis_result.aggregate_descriptions,
         query_analysis_result.aggregate_overflow_row,
         settings.max_threads,
-        settings.max_block_size);
+        settings.max_block_size,
+        settings.min_hit_rate_to_use_consecutive_keys_optimization);
 
     bool is_remote_storage = false;
     bool parallel_replicas_from_merge_tree = false;

--- a/src/Processors/QueryPlan/AggregatingStep.cpp
+++ b/src/Processors/QueryPlan/AggregatingStep.cpp
@@ -231,7 +231,10 @@ void AggregatingStep::transformPipeline(QueryPipelineBuilder & pipeline, const B
                     transform_params->params.enable_prefetch,
                     /* only_merge */ false,
                     transform_params->params.optimize_group_by_constant_keys,
-                    transform_params->params.stats_collecting_params};
+                    transform_params->params.min_hit_rate_to_use_consecutive_keys_optimization,
+                    transform_params->params.stats_collecting_params,
+                };
+
                 auto transform_params_for_set = std::make_shared<AggregatingTransformParams>(src_header, std::move(params_for_set), final);
 
                 if (streams > 1)

--- a/src/Processors/TTL/TTLAggregationAlgorithm.cpp
+++ b/src/Processors/TTL/TTLAggregationAlgorithm.cpp
@@ -41,8 +41,10 @@ TTLAggregationAlgorithm::TTLAggregationAlgorithm(
         settings.min_count_to_compile_aggregate_expression,
         settings.max_block_size,
         settings.enable_software_prefetch_in_aggregation,
-        false /* only_merge */,
-        settings.optimize_group_by_constant_keys);
+        /*only_merge=*/ false,
+        settings.optimize_group_by_constant_keys,
+        settings.min_chunk_bytes_for_parallel_parsing,
+        /*stats_collecting_params=*/ {});
 
     aggregator = std::make_unique<Aggregator>(header, params);
 

--- a/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
@@ -325,7 +325,9 @@ QueryPlanPtr MergeTreeDataSelectExecutor::read(
                 settings.max_block_size,
                 settings.enable_software_prefetch_in_aggregation,
                 only_merge,
-                settings.optimize_group_by_constant_keys);
+                settings.optimize_group_by_constant_keys,
+                settings.min_hit_rate_to_use_consecutive_keys_optimization,
+                /*stats_collecting_params=*/ {});
 
             return std::make_pair(params, only_merge);
         };

--- a/tests/performance/group_by_consecutive_keys.xml
+++ b/tests/performance/group_by_consecutive_keys.xml
@@ -1,0 +1,8 @@
+<test>
+    <query>SELECT toUInt64(intDiv(number, 1000000)) AS n, count(), sum(number) FROM numbers(10000000) GROUP BY n FORMAT Null</query>
+    <query>SELECT toString(intDiv(number, 1000000)) AS n, count(), sum(number) FROM numbers(10000000) GROUP BY n FORMAT Null</query>
+    <query>SELECT toUInt64(intDiv(number, 1000000)) AS n, count(), uniq(number) FROM numbers(10000000) GROUP BY n FORMAT Null</query>
+    <query>SELECT toUInt64(intDiv(number, 100000)) AS n, count(), sum(number) FROM numbers(10000000) GROUP BY n FORMAT Null</query>
+    <query>SELECT toUInt64(intDiv(number, 100)) AS n, count(), sum(number) FROM numbers(10000000) GROUP BY n FORMAT Null</query>
+    <query>SELECT toUInt64(intDiv(number, 10)) AS n, count(), sum(number) FROM numbers(10000000) GROUP BY n FORMAT Null</query>
+</test>


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Optimized aggregation in some cases.


### Detailed description:
There are two optimizations in this PR:

1. Execute `addBatchSinglePlace` instead of `addBatch` in case when we have only one unique key in block.
2. Disable consecutive keys cache in case when miss rate is high.