### PR TITLE
bugfix: addresses_expr ignored for psql named collections

### DIFF
--- a/src/Databases/DatabaseFactory.cpp
+++ b/src/Databases/DatabaseFactory.cpp
@@ -323,7 +323,7 @@ DatabasePtr DatabaseFactory::getImpl(const ASTCreateQuery & create, const String
 
         if (auto named_collection = tryGetNamedCollectionWithOverrides(engine_args, context))
         {
-            configuration = StoragePostgreSQL::processNamedCollectionResult(*named_collection, false);
+            configuration = StoragePostgreSQL::processNamedCollectionResult(*named_collection, context, false);
             use_table_cache = named_collection->getOrDefault<UInt64>("use_table_cache", 0);
         }
         else
@@ -386,7 +386,7 @@ DatabasePtr DatabaseFactory::getImpl(const ASTCreateQuery & create, const String
 
         if (auto named_collection = tryGetNamedCollectionWithOverrides(engine_args, context))
         {
-            configuration = StoragePostgreSQL::processNamedCollectionResult(*named_collection, false);
+            configuration = StoragePostgreSQL::processNamedCollectionResult(*named_collection, context, false);
         }
         else
         {

--- a/src/Storages/StoragePostgreSQL.cpp
+++ b/src/Storages/StoragePostgreSQL.cpp
@@ -456,7 +456,7 @@ SinkToStoragePtr StoragePostgreSQL::write(
     return std::make_shared<PostgreSQLSink>(metadata_snapshot, pool->get(), remote_table_name, remote_table_schema, on_conflict);
 }
 
-StoragePostgreSQL::Configuration StoragePostgreSQL::processNamedCollectionResult(const NamedCollection & named_collection, bool require_table)
+StoragePostgreSQL::Configuration StoragePostgreSQL::processNamedCollectionResult(const NamedCollection & named_collection, ContextPtr context_, bool require_table)
 {
     StoragePostgreSQL::Configuration configuration;
     ValidateKeysMultiset<ExternalDatabaseEqualKeysSet> required_arguments = {"user", "username", "password", "database", "db"};
@@ -472,6 +472,12 @@ StoragePostgreSQL::Configuration StoragePostgreSQL::processNamedCollectionResult
         configuration.host = named_collection.getAny<String>({"host", "hostname"});
         configuration.port = static_cast<UInt16>(named_collection.get<UInt64>("port"));
         configuration.addresses = {std::make_pair(configuration.host, configuration.port)};
+    }
+    else
+    {
+        size_t max_addresses = context_->getSettingsRef().glob_expansion_max_elements;
+        configuration.addresses = parseRemoteDescriptionForExternalDatabase(
+            configuration.addresses_expr, max_addresses, 5432);
     }
 
     configuration.username = named_collection.getAny<String>({"username", "user"});
@@ -490,7 +496,7 @@ StoragePostgreSQL::Configuration StoragePostgreSQL::getConfiguration(ASTs engine
     StoragePostgreSQL::Configuration configuration;
     if (auto named_collection = tryGetNamedCollectionWithOverrides(engine_args, context))
     {
-        configuration = StoragePostgreSQL::processNamedCollectionResult(*named_collection);
+        configuration = StoragePostgreSQL::processNamedCollectionResult(*named_collection, context);
     }
     else
     {

--- a/src/Storages/StoragePostgreSQL.h
+++ b/src/Storages/StoragePostgreSQL.h
@@ -65,7 +65,7 @@ public:
 
     static Configuration getConfiguration(ASTs engine_args, ContextPtr context);
 
-    static Configuration processNamedCollectionResult(const NamedCollection & named_collection, bool require_table = true);
+    static Configuration processNamedCollectionResult(const NamedCollection & named_collection, ContextPtr context_, bool require_table = true);
 
     static ColumnsDescription getTableStructureFromData(
         const postgres::PoolWithFailoverPtr & pool_,

--- a/tests/integration/test_storage_postgresql/configs/named_collections.xml
+++ b/tests/integration/test_storage_postgresql/configs/named_collections.xml
@@ -16,8 +16,7 @@
         <postgres3>
             <user>postgres</user>
             <password>mysecretpassword</password>
-            <host>postgres1</host>
-            <port>1111</port>
+            <addresses_expr>postgres1:1111</addresses_expr>
             <database>postgres</database>
             <table>test_table</table>
         </postgres3>

--- a/tests/integration/test_storage_postgresql/configs/named_collections.xml
+++ b/tests/integration/test_storage_postgresql/configs/named_collections.xml
@@ -16,7 +16,8 @@
         <postgres3>
             <user>postgres</user>
             <password>mysecretpassword</password>
-            <addresses_expr>postgres1:1111</addresses_expr>
+            <host>postgres1</host>
+            <port>1111</port>
             <database>postgres</database>
             <table>test_table</table>
         </postgres3>
@@ -28,5 +29,12 @@
             <database>postgres</database>
             <table>test_replicas</table>
         </postgres4>
+        <postgres5>
+            <user>postgres</user>
+            <password>mysecretpassword</password>
+            <addresses_expr>postgres1:5432</addresses_expr>
+            <database>postgres</database>
+            <table>test_table</table>
+        </postgres5>
     </named_collections>
 </clickhouse>


### PR DESCRIPTION
The `addresses_expr` field in named collections is ignored for psql.  Setting this field raises a Poco error like this:

```
DB::Exception: No address specified. (LOGICAL_ERROR)
```

I just copied what mysql does with this field.

### Changelog category (leave one):

- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

* Properly use `addresses_expr` field on named collections for PostgreSQL storage 
