### PR TITLE
Support `ORDER BY ALL`

### DIFF
--- a/docs/en/operations/settings/settings.md
+++ b/docs/en/operations/settings/settings.md
@@ -4152,6 +4152,41 @@ Result:
 └─────┴─────┴───────┘
 ```
 
+## enable_order_by_all {#enable-order-by-all}
+
+Enables or disables sorting by `ALL` columns, i.e. [ORDER BY](../../sql-reference/statements/select/order-by.md)
+
+Possible values:
+
+- 0 — Disable ORDER BY ALL.
+- 1 — Enable ORDER BY ALL.
+
+Default value: `1`.
+
+**Example**
+
+Query:
+
+```sql
+CREATE TABLE TAB(C1 Int, C2 Int, ALL Int) ENGINE=Memory();
+
+INSERT INTO TAB VALUES (10, 20, 30), (20, 20, 10), (30, 10, 20);
+
+SELECT * FROM TAB ORDER BY ALL; -- returns an error that ALL is ambiguous
+
+SELECT * FROM TAB ORDER BY ALL SETTINGS enable_order_by_all;
+```
+
+Result:
+
+```text
+┌─C1─┬─C2─┬─ALL─┐
+│ 20 │ 20 │  10 │
+│ 30 │ 10 │  20 │
+│ 10 │ 20 │  30 │
+└────┴────┴─────┘
+```
+
 ## splitby_max_substrings_includes_remaining_string {#splitby_max_substrings_includes_remaining_string}
 
 Controls whether function [splitBy*()](../../sql-reference/functions/splitting-merging-functions.md) with argument `max_substrings` > 0 will include the remaining string in the last element of the result array.

--- a/docs/en/sql-reference/statements/select/order-by.md
+++ b/docs/en/sql-reference/statements/select/order-by.md
@@ -12,10 +12,12 @@ The `ORDER BY` clause contains
 - `ALL` which means all columns of the `SELECT` clause, e.g. `ORDER BY ALL`.
 
 To disable sorting by column numbers, set setting [enable_positional_arguments](../../../operations/settings/settings.md#enable-positional-arguments) = 0.
+To disable sorting by `ALL`, set setting [enable_order_by_all](../../../operations/settings/settings.md#enable-order-by-all) = 0.
 
-Sort expressions or column numbers in `ORDER BY` can be attributed by a `DESC` (descending) or `ASC` (ascending) modifier which determine the sorting direction.
-If no sort order is specified explicitly, `ASC` is used as default.
-The sorting direction applies to a single expression, not to the entire list, e.g. `ORDER BY Visits DESC, SearchPhrase`. Sorting is performed case-sensitively.
+The `ORDER BY` clause can be attributed by a `DESC` (descending) or `ASC` (ascending) modifier which determines the sorting direction.
+Unless an explicit sort order is specified, `ASC` is used by default.
+The sorting direction applies to a single expression, not to the entire list, e.g. `ORDER BY Visits DESC, SearchPhrase`.
+Also, sorting is performed case-sensitively.
 
 Rows with identical values for a sort expressions are returned in an arbitrary and non-deterministic order.
 If the `ORDER BY` clause is omitted in a `SELECT` statement, the row order is also arbitrary and non-deterministic.

--- a/docs/en/sql-reference/statements/select/order-by.md
+++ b/docs/en/sql-reference/statements/select/order-by.md
@@ -5,12 +5,20 @@ sidebar_label: ORDER BY
 
 # ORDER BY Clause
 
-The `ORDER BY` clause contains a list of expressions, which can each be attributed with `DESC` (descending) or `ASC` (ascending) modifier which determine the sorting direction. If the direction is not specified, `ASC` is assumed, so it’s usually omitted. The sorting direction applies to a single expression, not to the entire list. Example: `ORDER BY Visits DESC, SearchPhrase`.  Sorting is case-sensitive.
+The `ORDER BY` clause contains
 
-If you want to sort by column numbers instead of column names, enable the setting [enable_positional_arguments](../../../operations/settings/settings.md#enable-positional-arguments).
+- a list of expressions, e.g. `ORDER BY visits, search_phrase`,
+- a list of numbers referring to columns in the `SELECT` clause, e.g. `ORDER BY 2, 1`, or
+- `ALL` which means all columns of the `SELECT` clause, e.g. `ORDER BY ALL`.
 
-Rows that have identical values for the list of sorting expressions are output in an arbitrary order, which can also be non-deterministic (different each time).
-If the ORDER BY clause is omitted, the order of the rows is also undefined, and may be non-deterministic as well.
+To disable sorting by column numbers, set setting [enable_positional_arguments](../../../operations/settings/settings.md#enable-positional-arguments) = 0.
+
+Sort expressions or column numbers in `ORDER BY` can be attributed by a `DESC` (descending) or `ASC` (ascending) modifier which determine the sorting direction.
+If no sort order is specified explicitly, `ASC` is used as default.
+The sorting direction applies to a single expression, not to the entire list, e.g. `ORDER BY Visits DESC, SearchPhrase`. Sorting is performed case-sensitively.
+
+Rows with identical values for a sort expressions are returned in an arbitrary and non-deterministic order.
+If the `ORDER BY` clause is omitted in a `SELECT` statement, the row order is also arbitrary and non-deterministic.
 
 ## Sorting of Special Values
 
@@ -239,22 +247,6 @@ Result:
 │ 4 │ (2,'z') │
 │ 6 │ (2,'Z') │
 └───┴─────────┘
-```
-
-## ORDER BY ALL
-
-`ORDER BY ALL` is sorts all selected columns in ascending order.
-
-For example:
-
-``` sql
-SELECT a, b, c FROM t ORDER BY ALL
-```
-
-is the same as
-
-``` sql
-SELECT a, b, c FROM t ORDER BY a, b, c
 ```
 
 ## Implementation Details

--- a/docs/en/sql-reference/statements/select/order-by.md
+++ b/docs/en/sql-reference/statements/select/order-by.md
@@ -241,6 +241,22 @@ Result:
 └───┴─────────┘
 ```
 
+## ORDER BY ALL
+
+`ORDER BY ALL` is sorts all selected columns in ascending order.
+
+For example:
+
+``` sql
+SELECT a, b, c FROM t ORDER BY ALL
+```
+
+is the same as
+
+``` sql
+SELECT a, b, c FROM t ORDER BY a, b, c
+```
+
 ## Implementation Details
 
 Less RAM is used if a small enough [LIMIT](../../../sql-reference/statements/select/limit.md) is specified in addition to `ORDER BY`. Otherwise, the amount of memory spent is proportional to the volume of data for sorting. For distributed query processing, if [GROUP BY](../../../sql-reference/statements/select/group-by.md) is omitted, sorting is partially done on remote servers, and the results are merged on the requestor server. This means that for distributed sorting, the volume of data to sort can be greater than the amount of memory on a single server.

--- a/docs/zh/sql-reference/statements/select/order-by.md
+++ b/docs/zh/sql-reference/statements/select/order-by.md
@@ -61,6 +61,22 @@ sidebar_label: ORDER BY
 
 我们只建议使用 `COLLATE` 对于少量行的最终排序，因为排序与 `COLLATE` 比正常的按字节排序效率低。
 
+## ORDER BY ALL
+
+`ORDER BY ALL` 对所有选定的列进行升序排序。
+
+示例:
+
+``` sql
+SELECT a, b, c FROM t ORDER BY ALL
+```
+
+等同于：
+
+``` sql
+SELECT a, b, c FROM t ORDER BY a, b, c
+```
+
 ## 实现细节 {#implementation-details}
 
 更少的RAM使用，如果一个足够小 [LIMIT](../../../sql-reference/statements/select/limit.md) 除了指定 `ORDER BY`. 否则，所花费的内存量与用于排序的数据量成正比。 对于分布式查询处理，如果 [GROUP BY](../../../sql-reference/statements/select/group-by.md) 省略排序，在远程服务器上部分完成排序，并将结果合并到请求者服务器上。 这意味着对于分布式排序，要排序的数据量可以大于单个服务器上的内存量。

--- a/src/Analyzer/Passes/QueryAnalysisPass.cpp
+++ b/src/Analyzer/Passes/QueryAnalysisPass.cpp
@@ -119,6 +119,7 @@ namespace ErrorCodes
     extern const int NUMBER_OF_COLUMNS_DOESNT_MATCH;
     extern const int FUNCTION_CANNOT_HAVE_PARAMETERS;
     extern const int SYNTAX_ERROR;
+    extern const int UNEXPECTED_EXPRESSION;
 }
 
 /** Query analyzer implementation overview. Please check documentation in QueryAnalysisPass.h first.
@@ -1208,6 +1209,8 @@ private:
     static std::pair<bool, UInt64> recursivelyCollectMaxOrdinaryExpressions(QueryTreeNodePtr & node, QueryTreeNodes & into);
 
     static void expandGroupByAll(QueryNode & query_tree_node_typed);
+
+    static void expandOrderByAll(QueryNode & query_tree_node_typed);
 
     static std::string
     rewriteAggregateFunctionNameIfNeeded(const std::string & aggregate_function_name, NullsAction action, const ContextPtr & context);
@@ -2310,6 +2313,35 @@ void QueryAnalyzer::expandGroupByAll(QueryNode & query_tree_node_typed)
 
     for (auto & node : projection_list.getNodes())
         recursivelyCollectMaxOrdinaryExpressions(node, group_by_nodes);
+}
+
+void QueryAnalyzer::expandOrderByAll(QueryNode & query_tree_node_typed)
+{
+    auto * all_node = query_tree_node_typed.getOrderBy().getNodes()[0]->as<SortNode>();
+    if (!all_node)
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Select analyze for not sort node.");
+
+    auto & projection_nodes = query_tree_node_typed.getProjection().getNodes();
+    auto list_node = std::make_shared<ListNode>();
+    list_node->getNodes().reserve(projection_nodes.size());
+
+    for (auto & node : projection_nodes)
+    {
+        if (auto * identifier_node = node->as<IdentifierNode>(); identifier_node != nullptr)
+            if (Poco::toUpper(identifier_node->getIdentifier().getFullName()) == "ALL" || Poco::toUpper(identifier_node->getAlias()) == "ALL")
+                throw Exception(ErrorCodes::UNEXPECTED_EXPRESSION,
+				"Cannot use ORDER BY ALL to sort a column with name 'all', please disable setting `enable_order_by_all` and try again");
+
+        if (auto * function_node = node->as<FunctionNode>(); function_node != nullptr)
+            if (Poco::toUpper(function_node->getAlias()) == "ALL")
+                throw Exception(ErrorCodes::UNEXPECTED_EXPRESSION,
+                                "Cannot use ORDER BY ALL to sort a column with name 'all', please disable setting `enable_order_by_all` and try again");
+
+        auto sort_node = std::make_shared<SortNode>(node, all_node->getSortDirection(), all_node->getNullsSortDirection());
+        list_node->getNodes().push_back(sort_node);
+    }
+
+    query_tree_node_typed.getOrderByNode() = list_node;
 }
 
 std::string QueryAnalyzer::rewriteAggregateFunctionNameIfNeeded(
@@ -6974,6 +7006,9 @@ void QueryAnalyzer::resolveQuery(const QueryTreeNodePtr & query_node, Identifier
 
     if (query_node_typed.hasHaving() && query_node_typed.isGroupByWithTotals() && is_rollup_or_cube)
         throw Exception(ErrorCodes::NOT_IMPLEMENTED, "WITH TOTALS and WITH ROLLUP or CUBE are not supported together in presence of HAVING");
+
+    if (settings.enable_order_by_all && query_node_typed.isOrderByAll())
+	expandOrderByAll(query_node_typed);
 
     /// Initialize aliases in query node scope
     QueryExpressionsAliasVisitor visitor(scope);

--- a/src/Analyzer/Passes/QueryAnalysisPass.cpp
+++ b/src/Analyzer/Passes/QueryAnalysisPass.cpp
@@ -2330,7 +2330,7 @@ void QueryAnalyzer::expandOrderByAll(QueryNode & query_tree_node_typed)
         if (auto * identifier_node = node->as<IdentifierNode>(); identifier_node != nullptr)
             if (Poco::toUpper(identifier_node->getIdentifier().getFullName()) == "ALL" || Poco::toUpper(identifier_node->getAlias()) == "ALL")
                 throw Exception(ErrorCodes::UNEXPECTED_EXPRESSION,
-				"Cannot use ORDER BY ALL to sort a column with name 'all', please disable setting `enable_order_by_all` and try again");
+                    "Cannot use ORDER BY ALL to sort a column with name 'all', please disable setting `enable_order_by_all` and try again");
 
         if (auto * function_node = node->as<FunctionNode>(); function_node != nullptr)
             if (Poco::toUpper(function_node->getAlias()) == "ALL")
@@ -7008,7 +7008,7 @@ void QueryAnalyzer::resolveQuery(const QueryTreeNodePtr & query_node, Identifier
         throw Exception(ErrorCodes::NOT_IMPLEMENTED, "WITH TOTALS and WITH ROLLUP or CUBE are not supported together in presence of HAVING");
 
     if (settings.enable_order_by_all && query_node_typed.isOrderByAll())
-	expandOrderByAll(query_node_typed);
+        expandOrderByAll(query_node_typed);
 
     /// Initialize aliases in query node scope
     QueryExpressionsAliasVisitor visitor(scope);

--- a/src/Analyzer/QueryNode.h
+++ b/src/Analyzer/QueryNode.h
@@ -219,6 +219,18 @@ public:
         is_group_by_all = is_group_by_all_value;
     }
 
+    /// Returns true, if query node has ORDER BY ALL modifier, false otherwise
+    bool isOrderByAll() const
+    {
+        return is_order_by_all;
+    }
+
+    /// Set query node ORDER BY ALL modifier value
+    void setIsOrderByAll(bool is_order_by_all_value)
+    {
+        is_order_by_all = is_order_by_all_value;
+    }
+
     /// Returns true if query node WITH section is not empty, false otherwise
     bool hasWith() const
     {
@@ -590,6 +602,7 @@ private:
     bool is_group_by_with_cube = false;
     bool is_group_by_with_grouping_sets = false;
     bool is_group_by_all = false;
+    bool is_order_by_all = false;
 
     std::string cte_name;
     NamesAndTypes projection_columns;

--- a/src/Analyzer/QueryTreeBuilder.cpp
+++ b/src/Analyzer/QueryTreeBuilder.cpp
@@ -284,6 +284,7 @@ QueryTreeNodePtr QueryTreeBuilder::buildSelectExpression(const ASTPtr & select_q
     current_query_tree->setIsGroupByWithRollup(select_query_typed.group_by_with_rollup);
     current_query_tree->setIsGroupByWithGroupingSets(select_query_typed.group_by_with_grouping_sets);
     current_query_tree->setIsGroupByAll(select_query_typed.group_by_all);
+    current_query_tree->setIsOrderByAll(select_query_typed.order_by_all);
     current_query_tree->setOriginalAST(select_query);
 
     auto current_context = current_query_tree->getContext();

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -845,7 +845,7 @@ class IColumn;
     M(UInt64, cache_warmer_threads, 4, "Only available in ClickHouse Cloud", 0) \
     M(Int64, ignore_cold_parts_seconds, 0, "Only available in ClickHouse Cloud", 0) \
     M(Int64, prefer_warmed_unmerged_parts_seconds, 0, "Only available in ClickHouse Cloud", 0) \
-    M(Bool, enable_order_by_all, true, "Clause ORDER BY supports specifying ALL, sorts by all columns in the SELECT clause.", 0)\
+    M(Bool, enable_order_by_all, true, "Enable sorting expression ORDER BY ALL.", 0)\
 
 // End of COMMON_SETTINGS
 // Please add settings related to formats into the FORMAT_FACTORY_SETTINGS, move obsolete settings to OBSOLETE_SETTINGS and obsolete format settings to OBSOLETE_FORMAT_SETTINGS.

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -845,6 +845,7 @@ class IColumn;
     M(UInt64, cache_warmer_threads, 4, "Only available in ClickHouse Cloud", 0) \
     M(Int64, ignore_cold_parts_seconds, 0, "Only available in ClickHouse Cloud", 0) \
     M(Int64, prefer_warmed_unmerged_parts_seconds, 0, "Only available in ClickHouse Cloud", 0) \
+    M(Bool, enable_order_by_all, true, "Clause ORDER BY supports specifying ALL, sorts by all columns in the SELECT clause.", 0)\
 
 // End of COMMON_SETTINGS
 // Please add settings related to formats into the FORMAT_FACTORY_SETTINGS, move obsolete settings to OBSOLETE_SETTINGS and obsolete format settings to OBSOLETE_FORMAT_SETTINGS.

--- a/src/Interpreters/TreeRewriter.cpp
+++ b/src/Interpreters/TreeRewriter.cpp
@@ -787,15 +787,15 @@ void expandOrderByAll(ASTSelectQuery * select_query)
 
     for (const auto & expr : select_query->select()->children)
     {
-        if (auto * identifier = expr->as<ASTIdentifier>(); identifier)
+        if (auto * identifier = expr->as<ASTIdentifier>(); identifier != nullptr)
             if (Poco::toUpper(identifier->name()) == "ALL" || Poco::toUpper(identifier->alias) == "ALL")
                 throw Exception(ErrorCodes::UNEXPECTED_EXPRESSION,
-                                "The column name (all/ALL) conflicts with `ORDER BY ALL`, try to disable setting `enable_order_by_all`.");
+                                "Cannot use ORDER BY ALL to sort a column with name 'all', please disable setting `enable_order_by_all` and try again");
 
-        if (auto * function = expr->as<ASTFunction>(); function)
+        if (auto * function = expr->as<ASTFunction>(); function != nullptr)
             if (Poco::toUpper(function->alias) == "ALL")
                 throw Exception(ErrorCodes::UNEXPECTED_EXPRESSION,
-                                "The column name (all/ALL) conflicts with `ORDER BY ALL`, try to disable setting `enable_order_by_all`.");
+                                "Cannot use ORDER BY ALL to sort a column with name 'all', please disable setting `enable_order_by_all` and try again");
 
         auto elem = std::make_shared<ASTOrderByElement>();
         elem->direction = all_elem->direction;

--- a/src/Parsers/ASTSelectQuery.cpp
+++ b/src/Parsers/ASTSelectQuery.cpp
@@ -144,7 +144,10 @@ void ASTSelectQuery::formatImpl(const FormatSettings & s, FormatState & state, F
         window()->as<ASTExpressionList &>().formatImplMultiline(s, state, frame);
     }
 
-    if (orderBy())
+    if (order_by_all)
+        s.ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << indent_str << "ORDER BY ALL" << (s.hilite ? hilite_none : "");
+
+    if (!order_by_all && orderBy())
     {
         s.ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << indent_str << "ORDER BY" << (s.hilite ? hilite_none : "");
         s.one_line

--- a/src/Parsers/ASTSelectQuery.cpp
+++ b/src/Parsers/ASTSelectQuery.cpp
@@ -144,9 +144,6 @@ void ASTSelectQuery::formatImpl(const FormatSettings & s, FormatState & state, F
         window()->as<ASTExpressionList &>().formatImplMultiline(s, state, frame);
     }
 
-    if (order_by_all)
-        s.ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << indent_str << "ORDER BY ALL" << (s.hilite ? hilite_none : "");
-
     if (!order_by_all && orderBy())
     {
         s.ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << indent_str << "ORDER BY" << (s.hilite ? hilite_none : "");
@@ -163,6 +160,24 @@ void ASTSelectQuery::formatImpl(const FormatSettings & s, FormatState & state, F
                 interpolate()->formatImpl(s, state, frame);
                 s.ostr << " )";
             }
+        }
+    }
+
+    if (order_by_all)
+    {
+        s.ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << indent_str << "ORDER BY ALL" << (s.hilite ? hilite_none : "");
+
+        auto * elem = orderBy()->children[0]->as<ASTOrderByElement>();
+        s.ostr << (s.hilite ? hilite_keyword : "")
+               << (elem->direction == -1 ? " DESC" : " ASC")
+               << (s.hilite ? hilite_none : "");
+
+        if (elem->nulls_direction_was_explicitly_specified)
+        {
+            s.ostr << (s.hilite ? hilite_keyword : "")
+                   << " NULLS "
+                   << (elem->nulls_direction == elem->direction ? "LAST" : "FIRST")
+                   << (s.hilite ? hilite_none : "");
         }
     }
 

--- a/src/Parsers/ASTSelectQuery.h
+++ b/src/Parsers/ASTSelectQuery.h
@@ -87,6 +87,7 @@ public:
     bool group_by_with_cube = false;
     bool group_by_with_constant_keys = false;
     bool group_by_with_grouping_sets = false;
+    bool order_by_all = false;
     bool limit_with_ties = false;
 
     ASTPtr & refSelect()    { return getExpression(Expression::SELECT); }

--- a/src/Parsers/ParserSelectQuery.cpp
+++ b/src/Parsers/ParserSelectQuery.cpp
@@ -50,13 +50,6 @@ bool ParserSelectQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
     ParserKeyword s_having("HAVING");
     ParserKeyword s_window("WINDOW");
     ParserKeyword s_order_by("ORDER BY");
-    ParserKeyword ascending("ASCENDING");
-    ParserKeyword descending("DESCENDING");
-    ParserKeyword asc("ASC");
-    ParserKeyword desc("DESC");
-    ParserKeyword nulls("NULLS");
-    ParserKeyword first("FIRST");
-    ParserKeyword last("LAST");
     ParserKeyword s_limit("LIMIT");
     ParserKeyword s_settings("SETTINGS");
     ParserKeyword s_by("BY");
@@ -281,7 +274,7 @@ bool ParserSelectQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
 
         /// if any WITH FILL parse possible INTERPOLATE list
         if (std::any_of(order_expression_list->children.begin(), order_expression_list->children.end(),
-                        [](auto & child) { return child->template as<ASTOrderByElement>()->with_fill; }))
+                [](auto & child) { return child->template as<ASTOrderByElement>()->with_fill; }))
         {
             if (s_interpolate.ignore(pos, expected))
             {

--- a/src/Parsers/ParserSelectQuery.cpp
+++ b/src/Parsers/ParserSelectQuery.cpp
@@ -290,9 +290,9 @@ bool ParserSelectQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
         }
         else if (order_expression_list->children.size() == 1)
         {
-            /// ORDER BY ALL [ASC|DESC] [NULLS [FIRST|LAST]]
+            /// ORDER BY ALL
             auto * identifier = order_expression_list->children[0]->as<ASTOrderByElement>()->children[0]->as<ASTIdentifier>();
-            if (Poco::toUpper(identifier->name()) == "ALL")
+            if (identifier != nullptr && Poco::toUpper(identifier->name()) == "ALL")
                 select_query->order_by_all = true;
         }
     }

--- a/tests/queries/0_stateless/02943_order_by_all.reference
+++ b/tests/queries/0_stateless/02943_order_by_all.reference
@@ -1,9 +1,11 @@
 abc1	3	2
+abc2	1	1
 abc2	3	2
 abc3	2	3
-abc4	1	4
-abc1	1	1
-abc2	1	1
-abc3	1	1
-abc4	1	1
-abc	4
+1	abc1	1
+1	abc3	1
+2	abc2	2
+abc	1	1
+abc	2	3
+abc	3	2
+abc	3	2

--- a/tests/queries/0_stateless/02943_order_by_all.reference
+++ b/tests/queries/0_stateless/02943_order_by_all.reference
@@ -7,43 +7,6 @@ D	1
 2	A
 3	B
 \N	C
--- with ASC/DESC modifiers
-A	2
-B	3
-C	\N
-D	1
-D	1
-C	\N
-B	3
-A	2
--- with NULLS FIRST/LAST modifiers
-\N	C
-1	D
-2	A
-3	B
-1	D
-2	A
-3	B
-\N	C
--- what happens if some column "all" already exists?
-B	3	10
-D	1	20
-A	2	30
-C	\N	40
-D	1
-A	2
-B	3
-C	\N
-A 2
-B 3
-D 1
-\N
-B	3	10
-D	1	20
-A	2	30
-C	\N	40
--- enable new analyzer
--- no modifiers
 A	2
 B	3
 C	\N
@@ -61,7 +24,23 @@ D	1
 C	\N
 B	3
 A	2
+A	2
+B	3
+C	\N
+D	1
+D	1
+C	\N
+B	3
+A	2
 -- with NULLS FIRST/LAST modifiers
+\N	C
+1	D
+2	A
+3	B
+1	D
+2	A
+3	B
+\N	C
 \N	C
 1	D
 2	A
@@ -75,6 +54,14 @@ B	3	10
 D	1	20
 A	2	30
 C	\N	40
+B	3	10
+D	1	20
+A	2	30
+C	\N	40
+D	1
+A	2
+B	3
+C	\N
 D	1
 A	2
 B	3
@@ -83,6 +70,14 @@ A 2
 B 3
 D 1
 \N
+A 2
+B 3
+D 1
+\N
+B	3	10
+D	1	20
+A	2	30
+C	\N	40
 B	3	10
 D	1	20
 A	2	30

--- a/tests/queries/0_stateless/02943_order_by_all.reference
+++ b/tests/queries/0_stateless/02943_order_by_all.reference
@@ -1,0 +1,9 @@
+abc1	3	2
+abc2	3	2
+abc3	2	3
+abc4	1	4
+abc1	1	1
+abc2	1	1
+abc3	1	1
+abc4	1	1
+abc	4

--- a/tests/queries/0_stateless/02943_order_by_all.reference
+++ b/tests/queries/0_stateless/02943_order_by_all.reference
@@ -1,20 +1,28 @@
-A	3
-B	1
+A	2
 B	3
 C	\N
-B	1	1
-A	3	2
-B	3	2
-C	\N	3
-B	1	1
-B	3	2
-A	3	2
-C	\N	3
-C	\N
-B	3
-B	1
-A	3
+D	1
+1	D
+2	A
+3	B
 \N	C
-1	B
-3	A
+B	3	10
+D	1	20
+A	2	30
+C	\N	40
+D	1
+A	2
+B	3
+C	\N
+B	3	10
+D	1	20
+A	2	30
+C	\N	40
+D	1
+C	\N
+B	3
+A	2
+\N	C
+1	D
+2	A
 3	B

--- a/tests/queries/0_stateless/02943_order_by_all.reference
+++ b/tests/queries/0_stateless/02943_order_by_all.reference
@@ -1,11 +1,20 @@
-abc1	3	2
-abc2	1	1
-abc2	3	2
-abc3	2	3
-1	abc1	1
-1	abc3	1
-2	abc2	2
-abc	1	1
-abc	2	3
-abc	3	2
-abc	3	2
+A	3
+B	1
+B	3
+C	\N
+B	1	1
+A	3	2
+B	3	2
+C	\N	3
+B	1	1
+B	3	2
+A	3	2
+C	\N	3
+C	\N
+B	3
+B	1
+A	3
+\N	C
+1	B
+3	A
+3	B

--- a/tests/queries/0_stateless/02943_order_by_all.reference
+++ b/tests/queries/0_stateless/02943_order_by_all.reference
@@ -42,3 +42,48 @@ B	3	10
 D	1	20
 A	2	30
 C	\N	40
+-- enable new analyzer
+-- no modifiers
+A	2
+B	3
+C	\N
+D	1
+1	D
+2	A
+3	B
+\N	C
+-- with ASC/DESC modifiers
+A	2
+B	3
+C	\N
+D	1
+D	1
+C	\N
+B	3
+A	2
+-- with NULLS FIRST/LAST modifiers
+\N	C
+1	D
+2	A
+3	B
+1	D
+2	A
+3	B
+\N	C
+-- what happens if some column "all" already exists?
+B	3	10
+D	1	20
+A	2	30
+C	\N	40
+D	1
+A	2
+B	3
+C	\N
+A 2
+B 3
+D 1
+\N
+B	3	10
+D	1	20
+A	2	30
+C	\N	40

--- a/tests/queries/0_stateless/02943_order_by_all.reference
+++ b/tests/queries/0_stateless/02943_order_by_all.reference
@@ -1,3 +1,4 @@
+-- no modifiers
 A	2
 B	3
 C	\N
@@ -6,23 +7,38 @@ D	1
 2	A
 3	B
 \N	C
-B	3	10
-D	1	20
-A	2	30
-C	\N	40
-D	1
+-- with ASC/DESC modifiers
 A	2
 B	3
 C	\N
-B	3	10
-D	1	20
-A	2	30
-C	\N	40
+D	1
 D	1
 C	\N
 B	3
 A	2
+-- with NULLS FIRST/LAST modifiers
 \N	C
 1	D
 2	A
 3	B
+1	D
+2	A
+3	B
+\N	C
+-- what happens if some column "all" already exists?
+B	3	10
+D	1	20
+A	2	30
+C	\N	40
+D	1
+A	2
+B	3
+C	\N
+A 2
+B 3
+D 1
+\N
+B	3	10
+D	1	20
+A	2	30
+C	\N	40

--- a/tests/queries/0_stateless/02943_order_by_all.sql
+++ b/tests/queries/0_stateless/02943_order_by_all.sql
@@ -13,69 +13,77 @@ ENGINE = Memory;
 INSERT INTO order_by_all VALUES ('B', 3, 10), ('C', NULL, 40), ('D', 1, 20), ('A', 2, 30);
 
 SELECT '-- no modifiers';
+
+SET allow_experimental_analyzer = 0;
+SELECT a, b FROM order_by_all ORDER BY ALL;
+SELECT b, a FROM order_by_all ORDER BY ALL;
+
+SET allow_experimental_analyzer = 1;
 SELECT a, b FROM order_by_all ORDER BY ALL;
 SELECT b, a FROM order_by_all ORDER BY ALL;
 
 SELECT '-- with ASC/DESC modifiers';
+
+SET allow_experimental_analyzer = 0;
+SELECT a, b FROM order_by_all ORDER BY ALL ASC;
+SELECT a, b FROM order_by_all ORDER BY ALL DESC;
+
+SET allow_experimental_analyzer = 1;
 SELECT a, b FROM order_by_all ORDER BY ALL ASC;
 SELECT a, b FROM order_by_all ORDER BY ALL DESC;
 
 SELECT '-- with NULLS FIRST/LAST modifiers';
+
+SET allow_experimental_analyzer = 0;
+SELECT b, a FROM order_by_all ORDER BY ALL NULLS FIRST;
+SELECT b, a FROM order_by_all ORDER BY ALL NULLS LAST;
+
+SET allow_experimental_analyzer = 1;
 SELECT b, a FROM order_by_all ORDER BY ALL NULLS FIRST;
 SELECT b, a FROM order_by_all ORDER BY ALL NULLS LAST;
 
 SELECT '-- what happens if some column "all" already exists?';
 
 -- columns
+
+SET allow_experimental_analyzer = 0;
+SELECT a, b, all FROM order_by_all ORDER BY all;  -- { serverError UNEXPECTED_EXPRESSION }
+SELECT a, b, all FROM order_by_all ORDER BY ALL;  -- { serverError UNEXPECTED_EXPRESSION }
+SELECT a, b, all FROM order_by_all ORDER BY all SETTINGS enable_order_by_all = false;
+
+SET allow_experimental_analyzer = 1;
 SELECT a, b, all FROM order_by_all ORDER BY all;  -- { serverError UNEXPECTED_EXPRESSION }
 SELECT a, b, all FROM order_by_all ORDER BY ALL;  -- { serverError UNEXPECTED_EXPRESSION }
 SELECT a, b, all FROM order_by_all ORDER BY all SETTINGS enable_order_by_all = false;
 
 -- column aliases
+
+SET allow_experimental_analyzer = 0;
+SELECT a, b AS all FROM order_by_all ORDER BY all;  -- { serverError UNEXPECTED_EXPRESSION }
+SELECT a, b AS all FROM order_by_all ORDER BY ALL;  -- { serverError UNEXPECTED_EXPRESSION }
+SELECT a, b AS all FROM order_by_all ORDER BY all SETTINGS enable_order_by_all = false;
+
+SET allow_experimental_analyzer = 1;
 SELECT a, b AS all FROM order_by_all ORDER BY all;  -- { serverError UNEXPECTED_EXPRESSION }
 SELECT a, b AS all FROM order_by_all ORDER BY ALL;  -- { serverError UNEXPECTED_EXPRESSION }
 SELECT a, b AS all FROM order_by_all ORDER BY all SETTINGS enable_order_by_all = false;
 
 -- expressions
+
+SET allow_experimental_analyzer = 0;
 SELECT format('{} {}', a, b) AS all FROM order_by_all ORDER BY all;  -- { serverError UNEXPECTED_EXPRESSION }
 SELECT format('{} {}', a, b) AS all FROM order_by_all ORDER BY ALL;  -- { serverError UNEXPECTED_EXPRESSION }
 SELECT format('{} {}', a, b) AS all FROM order_by_all ORDER BY all SETTINGS enable_order_by_all = false;
 
+SET allow_experimental_analyzer = 1;
+SELECT format('{} {}', a, b) AS all FROM order_by_all ORDER BY all;  -- { serverError UNEXPECTED_EXPRESSION }
+SELECT format('{} {}', a, b) AS all FROM order_by_all ORDER BY ALL;  -- { serverError UNEXPECTED_EXPRESSION }
+SELECT format('{} {}', a, b) AS all FROM order_by_all ORDER BY all SETTINGS enable_order_by_all = false;
+
+SET allow_experimental_analyzer = 0;
 SELECT a, b, all FROM order_by_all ORDER BY all, a;
 
-SELECT '-- enable new analyzer';
-set allow_experimental_analyzer = 1;
-
-SELECT '-- no modifiers';
-SELECT a, b FROM order_by_all ORDER BY ALL;
-SELECT b, a FROM order_by_all ORDER BY ALL;
-
-SELECT '-- with ASC/DESC modifiers';
-SELECT a, b FROM order_by_all ORDER BY ALL ASC;
-SELECT a, b FROM order_by_all ORDER BY ALL DESC;
-
-SELECT '-- with NULLS FIRST/LAST modifiers';
-SELECT b, a FROM order_by_all ORDER BY ALL NULLS FIRST;
-SELECT b, a FROM order_by_all ORDER BY ALL NULLS LAST;
-
-SELECT '-- what happens if some column "all" already exists?';
-
--- columns
-SELECT a, b, all FROM order_by_all ORDER BY all;  -- { serverError UNEXPECTED_EXPRESSION }
-SELECT a, b, all FROM order_by_all ORDER BY ALL;  -- { serverError UNEXPECTED_EXPRESSION }
-SELECT a, b, all FROM order_by_all ORDER BY all SETTINGS enable_order_by_all = false;
-
--- column aliases
-SELECT a, b AS all FROM order_by_all ORDER BY all;  -- { serverError UNEXPECTED_EXPRESSION }
-SELECT a, b AS all FROM order_by_all ORDER BY ALL;  -- { serverError UNEXPECTED_EXPRESSION }
-SELECT a, b AS all FROM order_by_all ORDER BY all SETTINGS enable_order_by_all = false;
-
--- expressions
-SELECT format('{} {}', a, b) AS all FROM order_by_all ORDER BY all;  -- { serverError UNEXPECTED_EXPRESSION }
-SELECT format('{} {}', a, b) AS all FROM order_by_all ORDER BY ALL;  -- { serverError UNEXPECTED_EXPRESSION }
-SELECT format('{} {}', a, b) AS all FROM order_by_all ORDER BY all SETTINGS enable_order_by_all = false;
-
+SET allow_experimental_analyzer = 1;
 SELECT a, b, all FROM order_by_all ORDER BY all, a;
 
 DROP TABLE order_by_all;
-

--- a/tests/queries/0_stateless/02943_order_by_all.sql
+++ b/tests/queries/0_stateless/02943_order_by_all.sql
@@ -1,24 +1,46 @@
+-- Tests that sort expression ORDER BY ALL
+
 DROP TABLE IF EXISTS order_by_all;
 
 CREATE TABLE order_by_all
 (
     a String,
     b Nullable(Int32),
-    all int,
+    all UInt64,
 )
-engine = Memory;
+ENGINE = Memory;
 
 INSERT INTO order_by_all VALUES ('B', 3, 10), ('C', NULL, 40), ('D', 1, 20), ('A', 2, 30);
 
+SELECT '-- no modifiers';
 SELECT a, b FROM order_by_all ORDER BY ALL;
 SELECT b, a FROM order_by_all ORDER BY ALL;
-SELECT a, b, all FROM order_by_all ORDER BY all;  -- { serverError UNEXPECTED_EXPRESSION }
-SELECT a, b as all FROM order_by_all ORDER BY all;  -- { serverError UNEXPECTED_EXPRESSION }
-SELECT a, b, all FROM order_by_all ORDER BY all settings enable_order_by_all = false;
-SELECT a, b as all FROM order_by_all ORDER BY all settings enable_order_by_all = false;
-SELECT a, b, all FROM order_by_all ORDER BY all, a;
+
+SELECT '-- with ASC/DESC modifiers';
+SELECT a, b FROM order_by_all ORDER BY ALL ASC;
 SELECT a, b FROM order_by_all ORDER BY ALL DESC;
+
+SELECT '-- with NULLS FIRST/LAST modifiers';
 SELECT b, a FROM order_by_all ORDER BY ALL NULLS FIRST;
+SELECT b, a FROM order_by_all ORDER BY ALL NULLS LAST;
 
-DROP TABLE IF EXISTS order_by_all;
+SELECT '-- what happens if some column "all" already exists?';
 
+-- columns
+SELECT a, b, all FROM order_by_all ORDER BY all;  -- { serverError UNEXPECTED_EXPRESSION }
+SELECT a, b, all FROM order_by_all ORDER BY ALL;  -- { serverError UNEXPECTED_EXPRESSION }
+SELECT a, b, all FROM order_by_all ORDER BY all SETTINGS enable_order_by_all = false;
+
+-- column aliases
+SELECT a, b AS all FROM order_by_all ORDER BY all;  -- { serverError UNEXPECTED_EXPRESSION }
+SELECT a, b AS all FROM order_by_all ORDER BY ALL;  -- { serverError UNEXPECTED_EXPRESSION }
+SELECT a, b AS all FROM order_by_all ORDER BY all SETTINGS enable_order_by_all = false;
+
+-- expressions
+SELECT format('{} {}', a, b) AS all FROM order_by_all ORDER BY all;  -- { serverError UNEXPECTED_EXPRESSION }
+SELECT format('{} {}', a, b) AS all FROM order_by_all ORDER BY ALL;  -- { serverError UNEXPECTED_EXPRESSION }
+SELECT format('{} {}', a, b) AS all FROM order_by_all ORDER BY all SETTINGS enable_order_by_all = false;
+
+SELECT a, b, all FROM order_by_all ORDER BY all, a;
+
+DROP TABLE order_by_all;

--- a/tests/queries/0_stateless/02943_order_by_all.sql
+++ b/tests/queries/0_stateless/02943_order_by_all.sql
@@ -1,0 +1,15 @@
+DROP TABLE IF EXISTS order_by_all;
+
+CREATE TABLE order_by_all
+(
+    a String,
+    b int,
+    c int
+)
+engine = Memory;
+
+insert into order_by_all values ('abc2', 3, 2), ('abc3', 2, 3), ('abc4', 1, 4), ('abc1', 3, 2);
+
+select a, b, c from order_by_all order by all;
+select a, count(b), count(c) from order_by_all group by all order by all;
+select substring(a, 1, 3), count(b) from order_by_all group by all order by all;

--- a/tests/queries/0_stateless/02943_order_by_all.sql
+++ b/tests/queries/0_stateless/02943_order_by_all.sql
@@ -3,14 +3,19 @@ DROP TABLE IF EXISTS order_by_all;
 CREATE TABLE order_by_all
 (
     a String,
-    b int,
-    c int
+    b Nullable(Int32),
+    all int,
 )
-engine = Memory;
+    engine = Memory;
 
-insert into order_by_all values ('abc2', 3, 2), ('abc3', 2, 3), ('abc2', 1, 1), ('abc1', 3, 2);
+INSERT INTO order_by_all VALUES ('B', 3, 2), ('C', NULL, 3), ('B', 1, 1), ('A', 3, 2);
 
-select a, b, c from order_by_all order by all;
-select count(b), a, count(c) from order_by_all group by all order by all;
-select substring(a, 1, 3), b, c from order_by_all order by all;
+SELECT a, b FROM order_by_all ORDER BY ALL;
+SELECT a, b, all FROM order_by_all ORDER BY all;  -- { serverError UNEXPECTED_EXPRESSION }
+SELECT a, b, all FROM order_by_all ORDER BY all, a;
+SELECT a, b, all FROM order_by_all ORDER BY all settings enable_order_by_all = false;
+SELECT a, b FROM order_by_all ORDER BY ALL DESC;
+SELECT b, a FROM order_by_all ORDER BY ALL NULLS FIRST;
+
+DROP TABLE IF EXISTS order_by_all;
 

--- a/tests/queries/0_stateless/02943_order_by_all.sql
+++ b/tests/queries/0_stateless/02943_order_by_all.sql
@@ -6,14 +6,17 @@ CREATE TABLE order_by_all
     b Nullable(Int32),
     all int,
 )
-    engine = Memory;
+engine = Memory;
 
-INSERT INTO order_by_all VALUES ('B', 3, 2), ('C', NULL, 3), ('B', 1, 1), ('A', 3, 2);
+INSERT INTO order_by_all VALUES ('B', 3, 10), ('C', NULL, 40), ('D', 1, 20), ('A', 2, 30);
 
 SELECT a, b FROM order_by_all ORDER BY ALL;
+SELECT b, a FROM order_by_all ORDER BY ALL;
 SELECT a, b, all FROM order_by_all ORDER BY all;  -- { serverError UNEXPECTED_EXPRESSION }
-SELECT a, b, all FROM order_by_all ORDER BY all, a;
+SELECT a, b as all FROM order_by_all ORDER BY all;  -- { serverError UNEXPECTED_EXPRESSION }
 SELECT a, b, all FROM order_by_all ORDER BY all settings enable_order_by_all = false;
+SELECT a, b as all FROM order_by_all ORDER BY all settings enable_order_by_all = false;
+SELECT a, b, all FROM order_by_all ORDER BY all, a;
 SELECT a, b FROM order_by_all ORDER BY ALL DESC;
 SELECT b, a FROM order_by_all ORDER BY ALL NULLS FIRST;
 

--- a/tests/queries/0_stateless/02943_order_by_all.sql
+++ b/tests/queries/0_stateless/02943_order_by_all.sql
@@ -43,4 +43,39 @@ SELECT format('{} {}', a, b) AS all FROM order_by_all ORDER BY all SETTINGS enab
 
 SELECT a, b, all FROM order_by_all ORDER BY all, a;
 
+SELECT '-- enable new analyzer';
+set allow_experimental_analyzer = 1;
+
+SELECT '-- no modifiers';
+SELECT a, b FROM order_by_all ORDER BY ALL;
+SELECT b, a FROM order_by_all ORDER BY ALL;
+
+SELECT '-- with ASC/DESC modifiers';
+SELECT a, b FROM order_by_all ORDER BY ALL ASC;
+SELECT a, b FROM order_by_all ORDER BY ALL DESC;
+
+SELECT '-- with NULLS FIRST/LAST modifiers';
+SELECT b, a FROM order_by_all ORDER BY ALL NULLS FIRST;
+SELECT b, a FROM order_by_all ORDER BY ALL NULLS LAST;
+
+SELECT '-- what happens if some column "all" already exists?';
+
+-- columns
+SELECT a, b, all FROM order_by_all ORDER BY all;  -- { serverError UNEXPECTED_EXPRESSION }
+SELECT a, b, all FROM order_by_all ORDER BY ALL;  -- { serverError UNEXPECTED_EXPRESSION }
+SELECT a, b, all FROM order_by_all ORDER BY all SETTINGS enable_order_by_all = false;
+
+-- column aliases
+SELECT a, b AS all FROM order_by_all ORDER BY all;  -- { serverError UNEXPECTED_EXPRESSION }
+SELECT a, b AS all FROM order_by_all ORDER BY ALL;  -- { serverError UNEXPECTED_EXPRESSION }
+SELECT a, b AS all FROM order_by_all ORDER BY all SETTINGS enable_order_by_all = false;
+
+-- expressions
+SELECT format('{} {}', a, b) AS all FROM order_by_all ORDER BY all;  -- { serverError UNEXPECTED_EXPRESSION }
+SELECT format('{} {}', a, b) AS all FROM order_by_all ORDER BY ALL;  -- { serverError UNEXPECTED_EXPRESSION }
+SELECT format('{} {}', a, b) AS all FROM order_by_all ORDER BY all SETTINGS enable_order_by_all = false;
+
+SELECT a, b, all FROM order_by_all ORDER BY all, a;
+
 DROP TABLE order_by_all;
+

--- a/tests/queries/0_stateless/02943_order_by_all.sql
+++ b/tests/queries/0_stateless/02943_order_by_all.sql
@@ -8,8 +8,9 @@ CREATE TABLE order_by_all
 )
 engine = Memory;
 
-insert into order_by_all values ('abc2', 3, 2), ('abc3', 2, 3), ('abc4', 1, 4), ('abc1', 3, 2);
+insert into order_by_all values ('abc2', 3, 2), ('abc3', 2, 3), ('abc2', 1, 1), ('abc1', 3, 2);
 
 select a, b, c from order_by_all order by all;
-select a, count(b), count(c) from order_by_all group by all order by all;
-select substring(a, 1, 3), count(b) from order_by_all group by all order by all;
+select count(b), a, count(c) from order_by_all group by all order by all;
+select substring(a, 1, 3), b, c from order_by_all order by all;
+


### PR DESCRIPTION
Closes #57765

### Changelog category (leave one):
- New Feature

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Clause `ORDER BY` now supports specifying `ALL`, meaning that ClickHouse sorts by all columns in the `SELECT` clause. Example: `SELECT col1, col2 FROM tab WHERE [...] ORDER BY ALL`.