### PR TITLE
More efficient constructor for SerializationEnum

### DIFF
--- a/src/DataTypes/DataTypeEnum.cpp
+++ b/src/DataTypes/DataTypeEnum.cpp
@@ -170,7 +170,7 @@ bool DataTypeEnum<Type>::contains(const IDataType & rhs) const
 template <typename Type>
 SerializationPtr DataTypeEnum<Type>::doGetDefaultSerialization() const
 {
-    return std::make_shared<SerializationEnum<Type>>(this->getValues());
+    return std::make_shared<SerializationEnum<Type>>(std::static_pointer_cast<const DataTypeEnum<Type>>(shared_from_this()));
 }
 
 

--- a/src/DataTypes/Serializations/SerializationEnum.cpp
+++ b/src/DataTypes/Serializations/SerializationEnum.cpp
@@ -11,13 +11,13 @@ namespace DB
 template <typename Type>
 void SerializationEnum<Type>::serializeText(const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettings &) const
 {
-    writeString(this->getNameForValue(assert_cast<const ColumnType &>(column).getData()[row_num]), ostr);
+    writeString(ref_enum_values->getNameForValue(assert_cast<const ColumnType &>(column).getData()[row_num]), ostr);
 }
 
 template <typename Type>
 void SerializationEnum<Type>::serializeTextEscaped(const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettings &) const
 {
-    writeEscapedString(this->getNameForValue(assert_cast<const ColumnType &>(column).getData()[row_num]).toView(), ostr);
+    writeEscapedString(ref_enum_values->getNameForValue(assert_cast<const ColumnType &>(column).getData()[row_num]).toView(), ostr);
 }
 
 template <typename Type>
@@ -30,14 +30,14 @@ void SerializationEnum<Type>::deserializeTextEscaped(IColumn & column, ReadBuffe
         /// NOTE It would be nice to do without creating a temporary object - at least extract std::string out.
         std::string field_name;
         readEscapedString(field_name, istr);
-        assert_cast<ColumnType &>(column).getData().push_back(this->getValue(StringRef(field_name), true));
+        assert_cast<ColumnType &>(column).getData().push_back(ref_enum_values->getValue(StringRef(field_name), true));
     }
 }
 
 template <typename Type>
 void SerializationEnum<Type>::serializeTextQuoted(const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettings &) const
 {
-    writeQuotedString(this->getNameForValue(assert_cast<const ColumnType &>(column).getData()[row_num]), ostr);
+    writeQuotedString(ref_enum_values->getNameForValue(assert_cast<const ColumnType &>(column).getData()[row_num]), ostr);
 }
 
 template <typename Type>
@@ -45,7 +45,7 @@ void SerializationEnum<Type>::deserializeTextQuoted(IColumn & column, ReadBuffer
 {
     std::string field_name;
     readQuotedStringWithSQLStyle(field_name, istr);
-    assert_cast<ColumnType &>(column).getData().push_back(this->getValue(StringRef(field_name)));
+    assert_cast<ColumnType &>(column).getData().push_back(ref_enum_values->getValue(StringRef(field_name)));
 }
 
 template <typename Type>
@@ -61,20 +61,20 @@ void SerializationEnum<Type>::deserializeWholeText(IColumn & column, ReadBuffer 
     {
         std::string field_name;
         readStringUntilEOF(field_name, istr);
-        assert_cast<ColumnType &>(column).getData().push_back(this->getValue(StringRef(field_name), true));
+        assert_cast<ColumnType &>(column).getData().push_back(ref_enum_values->getValue(StringRef(field_name), true));
     }
 }
 
 template <typename Type>
 void SerializationEnum<Type>::serializeTextJSON(const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettings & settings) const
 {
-    writeJSONString(this->getNameForValue(assert_cast<const ColumnType &>(column).getData()[row_num]).toView(), ostr, settings);
+    writeJSONString(ref_enum_values->getNameForValue(assert_cast<const ColumnType &>(column).getData()[row_num]).toView(), ostr, settings);
 }
 
 template <typename Type>
 void SerializationEnum<Type>::serializeTextXML(const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettings &) const
 {
-    writeXMLStringForTextElement(this->getNameForValue(assert_cast<const ColumnType &>(column).getData()[row_num]).toView(), ostr);
+    writeXMLStringForTextElement(ref_enum_values->getNameForValue(assert_cast<const ColumnType &>(column).getData()[row_num]).toView(), ostr);
 }
 
 template <typename Type>
@@ -86,14 +86,14 @@ void SerializationEnum<Type>::deserializeTextJSON(IColumn & column, ReadBuffer &
     {
         std::string field_name;
         readJSONString(field_name, istr);
-        assert_cast<ColumnType &>(column).getData().push_back(this->getValue(StringRef(field_name)));
+        assert_cast<ColumnType &>(column).getData().push_back(ref_enum_values->getValue(StringRef(field_name)));
     }
 }
 
 template <typename Type>
 void SerializationEnum<Type>::serializeTextCSV(const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettings &) const
 {
-    writeCSVString(this->getNameForValue(assert_cast<const ColumnType &>(column).getData()[row_num]), ostr);
+    writeCSVString(ref_enum_values->getNameForValue(assert_cast<const ColumnType &>(column).getData()[row_num]), ostr);
 }
 
 template <typename Type>
@@ -105,7 +105,7 @@ void SerializationEnum<Type>::deserializeTextCSV(IColumn & column, ReadBuffer & 
     {
         std::string field_name;
         readCSVString(field_name, istr, settings.csv);
-        assert_cast<ColumnType &>(column).getData().push_back(this->getValue(StringRef(field_name), true));
+        assert_cast<ColumnType &>(column).getData().push_back(ref_enum_values->getValue(StringRef(field_name), true));
     }
 }
 
@@ -114,7 +114,7 @@ void SerializationEnum<Type>::serializeTextMarkdown(
     const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettings & settings) const
 {
     if (settings.markdown.escape_special_characters)
-        writeMarkdownEscapedString(this->getNameForValue(assert_cast<const ColumnType &>(column).getData()[row_num]).toView(), ostr);
+        writeMarkdownEscapedString(ref_enum_values->getNameForValue(assert_cast<const ColumnType &>(column).getData()[row_num]).toView(), ostr);
     else
         serializeTextEscaped(column, row_num, ostr, settings);
 }

--- a/src/DataTypes/Serializations/SerializationEnum.cpp
+++ b/src/DataTypes/Serializations/SerializationEnum.cpp
@@ -11,13 +11,13 @@ namespace DB
 template <typename Type>
 void SerializationEnum<Type>::serializeText(const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettings &) const
 {
-    writeString(ref_enum_values->getNameForValue(assert_cast<const ColumnType &>(column).getData()[row_num]), ostr);
+    writeString(ref_enum_values.getNameForValue(assert_cast<const ColumnType &>(column).getData()[row_num]), ostr);
 }
 
 template <typename Type>
 void SerializationEnum<Type>::serializeTextEscaped(const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettings &) const
 {
-    writeEscapedString(ref_enum_values->getNameForValue(assert_cast<const ColumnType &>(column).getData()[row_num]).toView(), ostr);
+    writeEscapedString(ref_enum_values.getNameForValue(assert_cast<const ColumnType &>(column).getData()[row_num]).toView(), ostr);
 }
 
 template <typename Type>
@@ -30,14 +30,14 @@ void SerializationEnum<Type>::deserializeTextEscaped(IColumn & column, ReadBuffe
         /// NOTE It would be nice to do without creating a temporary object - at least extract std::string out.
         std::string field_name;
         readEscapedString(field_name, istr);
-        assert_cast<ColumnType &>(column).getData().push_back(ref_enum_values->getValue(StringRef(field_name), true));
+        assert_cast<ColumnType &>(column).getData().push_back(ref_enum_values.getValue(StringRef(field_name), true));
     }
 }
 
 template <typename Type>
 void SerializationEnum<Type>::serializeTextQuoted(const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettings &) const
 {
-    writeQuotedString(ref_enum_values->getNameForValue(assert_cast<const ColumnType &>(column).getData()[row_num]), ostr);
+    writeQuotedString(ref_enum_values.getNameForValue(assert_cast<const ColumnType &>(column).getData()[row_num]), ostr);
 }
 
 template <typename Type>
@@ -45,7 +45,7 @@ void SerializationEnum<Type>::deserializeTextQuoted(IColumn & column, ReadBuffer
 {
     std::string field_name;
     readQuotedStringWithSQLStyle(field_name, istr);
-    assert_cast<ColumnType &>(column).getData().push_back(ref_enum_values->getValue(StringRef(field_name)));
+    assert_cast<ColumnType &>(column).getData().push_back(ref_enum_values.getValue(StringRef(field_name)));
 }
 
 template <typename Type>
@@ -61,20 +61,20 @@ void SerializationEnum<Type>::deserializeWholeText(IColumn & column, ReadBuffer 
     {
         std::string field_name;
         readStringUntilEOF(field_name, istr);
-        assert_cast<ColumnType &>(column).getData().push_back(ref_enum_values->getValue(StringRef(field_name), true));
+        assert_cast<ColumnType &>(column).getData().push_back(ref_enum_values.getValue(StringRef(field_name), true));
     }
 }
 
 template <typename Type>
 void SerializationEnum<Type>::serializeTextJSON(const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettings & settings) const
 {
-    writeJSONString(ref_enum_values->getNameForValue(assert_cast<const ColumnType &>(column).getData()[row_num]).toView(), ostr, settings);
+    writeJSONString(ref_enum_values.getNameForValue(assert_cast<const ColumnType &>(column).getData()[row_num]).toView(), ostr, settings);
 }
 
 template <typename Type>
 void SerializationEnum<Type>::serializeTextXML(const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettings &) const
 {
-    writeXMLStringForTextElement(ref_enum_values->getNameForValue(assert_cast<const ColumnType &>(column).getData()[row_num]).toView(), ostr);
+    writeXMLStringForTextElement(ref_enum_values.getNameForValue(assert_cast<const ColumnType &>(column).getData()[row_num]).toView(), ostr);
 }
 
 template <typename Type>
@@ -86,14 +86,14 @@ void SerializationEnum<Type>::deserializeTextJSON(IColumn & column, ReadBuffer &
     {
         std::string field_name;
         readJSONString(field_name, istr);
-        assert_cast<ColumnType &>(column).getData().push_back(ref_enum_values->getValue(StringRef(field_name)));
+        assert_cast<ColumnType &>(column).getData().push_back(ref_enum_values.getValue(StringRef(field_name)));
     }
 }
 
 template <typename Type>
 void SerializationEnum<Type>::serializeTextCSV(const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettings &) const
 {
-    writeCSVString(ref_enum_values->getNameForValue(assert_cast<const ColumnType &>(column).getData()[row_num]), ostr);
+    writeCSVString(ref_enum_values.getNameForValue(assert_cast<const ColumnType &>(column).getData()[row_num]), ostr);
 }
 
 template <typename Type>
@@ -105,7 +105,7 @@ void SerializationEnum<Type>::deserializeTextCSV(IColumn & column, ReadBuffer & 
     {
         std::string field_name;
         readCSVString(field_name, istr, settings.csv);
-        assert_cast<ColumnType &>(column).getData().push_back(ref_enum_values->getValue(StringRef(field_name), true));
+        assert_cast<ColumnType &>(column).getData().push_back(ref_enum_values.getValue(StringRef(field_name), true));
     }
 }
 
@@ -114,7 +114,7 @@ void SerializationEnum<Type>::serializeTextMarkdown(
     const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettings & settings) const
 {
     if (settings.markdown.escape_special_characters)
-        writeMarkdownEscapedString(ref_enum_values->getNameForValue(assert_cast<const ColumnType &>(column).getData()[row_num]).toView(), ostr);
+        writeMarkdownEscapedString(ref_enum_values.getNameForValue(assert_cast<const ColumnType &>(column).getData()[row_num]).toView(), ostr);
     else
         serializeTextEscaped(column, row_num, ostr, settings);
 }

--- a/src/DataTypes/Serializations/SerializationEnum.h
+++ b/src/DataTypes/Serializations/SerializationEnum.h
@@ -1,20 +1,32 @@
 #pragma once
 
+#include <memory>
 #include <DataTypes/Serializations/SerializationNumber.h>
 #include <DataTypes/EnumValues.h>
+#include <DataTypes/DataTypeEnum.h>
 
 namespace DB
 {
 
 template <typename Type>
-class SerializationEnum : public SerializationNumber<Type>, public EnumValues<Type>
+class SerializationEnum : public SerializationNumber<Type>
 {
 public:
     using typename SerializationNumber<Type>::FieldType;
     using typename SerializationNumber<Type>::ColumnType;
-    using typename EnumValues<Type>::Values;
+    using Values = EnumValues<Type>::Values;
 
-    explicit SerializationEnum(const Values & values_) : EnumValues<Type>(values_) {}
+    SerializationEnum() = delete;
+    /// To explicitly create a SerializationEnum from Values
+    explicit SerializationEnum(const Values & values_) : own_enum_values(values_), ref_enum_values(&own_enum_values.value()) { }
+    /// To create a SerializationEnum from an IDataType instance, will reuse EnumValues from the type
+    /// Motivation: some Enum type has many elements, and building EnumValues is not trivial
+    /// This constructor allow to create many SerializationEnum from same IDataType without rebuilding
+    /// EnumValues for every call, so it's useful to get default serialization.
+    explicit SerializationEnum(const std::shared_ptr<const DataTypeEnum<Type>> & enum_type)
+        : own_enum_type(enum_type), ref_enum_values(static_cast<const EnumValues<Type> *>(enum_type.get()))
+    {
+    }
 
     void serializeText(const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettings &) const override;
     void serializeTextEscaped(const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettings &) const override;
@@ -35,8 +47,12 @@ public:
     {
         FieldType x;
         readText(x, istr);
-        return this->findByValue(x)->first;
+        return ref_enum_values->findByValue(x)->first;
     }
+
+    std::optional<EnumValues<Type>> own_enum_values;
+    std::shared_ptr<const DataTypeEnum<Type>> own_enum_type;
+    const EnumValues<Type> * ref_enum_values;
 };
 
 }

--- a/src/DataTypes/Serializations/SerializationEnum.h
+++ b/src/DataTypes/Serializations/SerializationEnum.h
@@ -16,15 +16,18 @@ public:
     using typename SerializationNumber<Type>::ColumnType;
     using Values = EnumValues<Type>::Values;
 
-    SerializationEnum() = delete;
-    /// To explicitly create a SerializationEnum from Values
-    explicit SerializationEnum(const Values & values_) : own_enum_values(values_), ref_enum_values(&own_enum_values.value()) { }
-    /// To create a SerializationEnum from an IDataType instance, will reuse EnumValues from the type
-    /// Motivation: some Enum type has many elements, and building EnumValues is not trivial
-    /// This constructor allow to create many SerializationEnum from same IDataType without rebuilding
-    /// EnumValues for every call, so it's useful to get default serialization.
+    // SerializationEnum can be constructed in two ways:
+    /// - Make a copy of the Enum name-to-type mapping.
+    /// - Only store a reference to an existing mapping. This is faster if the Enum has a lot of different values or if SerializationEnum is
+    ///   constructed very frequently. Make sure that the pointed-to mapping has a longer lifespan than SerializationEnum!
+
+    explicit SerializationEnum(const Values & values_)
+        : own_enum_values(values_), ref_enum_values(own_enum_values.value())
+    {
+    }
+
     explicit SerializationEnum(const std::shared_ptr<const DataTypeEnum<Type>> & enum_type)
-        : own_enum_type(enum_type), ref_enum_values(static_cast<const EnumValues<Type> *>(enum_type.get()))
+        : own_enum_type(enum_type), ref_enum_values(*enum_type)
     {
     }
 
@@ -47,12 +50,12 @@ public:
     {
         FieldType x;
         readText(x, istr);
-        return ref_enum_values->findByValue(x)->first;
+        return ref_enum_values.findByValue(x)->first;
     }
 
     std::optional<EnumValues<Type>> own_enum_values;
     std::shared_ptr<const DataTypeEnum<Type>> own_enum_type;
-    const EnumValues<Type> * ref_enum_values;
+    const EnumValues<Type> & ref_enum_values;
 };
 
 }


### PR DESCRIPTION
Motivation: we use some long enum types with > 200 elements, and constructing serialisation for them is not trivial. But `getDefaultSerialization()` is used in many places, and it often appear in CPU profiling:

<img width="2390" alt="image" src="https://github.com/ClickHouse/ClickHouse/assets/22796953/acd0283e-97eb-40d8-9c75-4066c6742a19">

The issue is: each calls to `getDefaultSerialization` create a copy of `EnumValues` (that is one vector and two maps) while it can reuse the `EnumValues` from `DataTypeEnum`. So here this PR tries to do that.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
