### PR TITLE
Fix transform query for external database

### DIFF
--- a/src/Storages/tests/gtest_transform_query_for_external_database.cpp
+++ b/src/Storages/tests/gtest_transform_query_for_external_database.cpp
@@ -320,6 +320,18 @@ TEST(TransformQueryForExternalDatabase, ForeignColumnInWhere)
           R"(SELECT "column", "apply_id" FROM "test"."table" WHERE ("column" > 2) AND ("apply_id" = 1))");
 }
 
+TEST(TransformQueryForExternalDatabase, TupleSurroundPredicates)
+{
+    const State & state = State::instance();
+
+    check(
+        state,
+        1,
+        {"column", "field", "a"},
+        "SELECT column, field, a FROM table WHERE ((column > 10) AND (length(field) > 0)) AND a > 0",
+        R"(SELECT "column", "field", "a" FROM "test"."table" WHERE ("a" > 0) AND ("column" > 10))");
+}
+
 TEST(TransformQueryForExternalDatabase, NoStrict)
 {
     const State & state = State::instance();

--- a/src/Storages/transformQueryForExternalDatabase.cpp
+++ b/src/Storages/transformQueryForExternalDatabase.cpp
@@ -329,14 +329,26 @@ String transformQueryForExternalDatabaseImpl(
         }
         else if (auto * function = original_where->as<ASTFunction>())
         {
-            if (function->name == "and")
+            if (function->name == "and" || function->name == "tuple")
             {
                 auto new_function_and = makeASTFunction("and");
-                for (auto & elem : function->arguments->children)
+                std::queue<const ASTFunction *> predicates;
+                predicates.push(function);
+
+                while (!predicates.empty())
                 {
-                    if (isCompatible(elem))
-                        new_function_and->arguments->children.push_back(elem);
+                    const auto * func = predicates.front();
+                    predicates.pop();
+
+                    for (auto & elem : func->arguments->children)
+                    {
+                        if (isCompatible(elem))
+                            new_function_and->arguments->children.push_back(elem);
+                        else if (const auto * child = elem->as<ASTFunction>(); child && (child->name == "and" || child->name == "tuple"))
+                            predicates.push(child);
+                    }
                 }
+
                 if (new_function_and->arguments->children.size() == 1)
                     select->setExpression(ASTSelectQuery::Expression::WHERE, std::move(new_function_and->arguments->children[0]));
                 else if (new_function_and->arguments->children.size() > 1)


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):

- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix and improve transform query for external database, we should recursively obtain all compatible predicates.

Found in case with predicate push down. for example, we have query like:

```sql
SELECT *
FROM
(
    SELECT *
    FROM t
    WHERE (a > 10) AND (toUInt64OrZero(timestamp_) > 12345)
)
WHERE c < 10
```
After predicate push down, the subquery become:
```sql
SELECT *
FROM t
WHERE ((a > 10) AND (toUInt64OrZero(timestamp_) > 12345)) and ((c < 10))
```
Before, the predicates `((a > 10) AND (toUInt64OrZero(timestamp_) > 12345))` will be dropped totally, only `c < 10` left, now, we will get predicates `(a > 10) and (c < 10)`.