### PR TITLE
Delete debug logging in OutputFormatWithUTF8ValidationAdaptor

### DIFF
--- a/src/Processors/Formats/OutputFormatWithUTF8ValidationAdaptor.h
+++ b/src/Processors/Formats/OutputFormatWithUTF8ValidationAdaptor.h
@@ -45,7 +45,6 @@ public:
 
     void resetFormatterImpl() override
     {
-        LOG_DEBUG(&Poco::Logger::get("RowOutputFormatWithExceptionHandlerAdaptor"), "resetFormatterImpl");
         Base::resetFormatterImpl();
         if (validating_ostr)
             validating_ostr = std::make_unique<WriteBufferValidUTF8>(*Base::getWriteBufferPtr());


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

