### PR TITLE
Fix docker image for integration tests (fixes CI)

### DIFF
--- a/docker/test/integration/runner/Dockerfile
+++ b/docker/test/integration/runner/Dockerfile
@@ -74,7 +74,7 @@ RUN python3 -m pip install --no-cache-dir \
     delta-spark==2.3.0 \
     dict2xml \
     dicttoxml \
-    docker \
+    docker==6.1.3 \
     docker-compose==1.29.2 \
     grpcio \
     grpcio-tools \


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

CI: https://s3.amazonaws.com/clickhouse-test-reports/57951/5e5bdfe4e8071a5e1f867d186adf9b5675e3c597/integration_tests__asan__analyzer__[3_6].html

Actually it is any integration tests jobs on CI

```
2023-12-16 19:01:22 [ 574 ] DEBUG : Command:['docker-compose', '--env-file', '/ClickHouse/tests/integration/test_atomic_drop_table/_instances_0/.env', '--project-name', 'roottestatomicdroptable', '--file', '/ClickHouse/tests/integration/test_atomic_drop_table/_instances_0/node1/docker-compose.yml', '--file', '/compose/docker_compose_keeper.yml', 'pull'] (cluster.py:103, run_and_check)
2023-12-16 19:01:22 [ 574 ] DEBUG : Stderr:Traceback (most recent call last): (cluster.py:113, run_and_check)
2023-12-16 19:01:22 [ 574 ] DEBUG : Stderr:  File "/usr/local/bin/docker-compose", line 8, in <module> (cluster.py:113, run_and_check)
2023-12-16 19:01:22 [ 574 ] DEBUG : Stderr:    sys.exit(main()) (cluster.py:113, run_and_check)
2023-12-16 19:01:22 [ 574 ] DEBUG : Stderr:  File "/usr/local/lib/python3.10/dist-packages/compose/cli/main.py", line 81, in main (cluster.py:113, run_and_check)
2023-12-16 19:01:22 [ 574 ] DEBUG : Stderr:    command_func() (cluster.py:113, run_and_check)
2023-12-16 19:01:22 [ 574 ] DEBUG : Stderr:  File "/usr/local/lib/python3.10/dist-packages/compose/cli/main.py", line 200, in perform_command (cluster.py:113, run_and_check)
2023-12-16 19:01:22 [ 574 ] DEBUG : Stderr:    project = project_from_options('.', options) (cluster.py:113, run_and_check)
2023-12-16 19:01:22 [ 574 ] DEBUG : Stderr:  File "/usr/local/lib/python3.10/dist-packages/compose/cli/command.py", line 60, in project_from_options (cluster.py:113, run_and_check)
2023-12-16 19:01:22 [ 574 ] DEBUG : Stderr:    return get_project( (cluster.py:113, run_and_check)
2023-12-16 19:01:22 [ 574 ] DEBUG : Stderr:  File "/usr/local/lib/python3.10/dist-packages/compose/cli/command.py", line 152, in get_project (cluster.py:113, run_and_check)
2023-12-16 19:01:22 [ 574 ] DEBUG : Stderr:    client = get_client( (cluster.py:113, run_and_check)
2023-12-16 19:01:22 [ 574 ] DEBUG : Stderr:  File "/usr/local/lib/python3.10/dist-packages/compose/cli/docker_client.py", line 41, in get_client (cluster.py:113, run_and_check)
2023-12-16 19:01:22 [ 574 ] DEBUG : Stderr:    client = docker_client( (cluster.py:113, run_and_check)
2023-12-16 19:01:22 [ 574 ] DEBUG : Stderr:  File "/usr/local/lib/python3.10/dist-packages/compose/cli/docker_client.py", line 124, in docker_client (cluster.py:113, run_and_check)
2023-12-16 19:01:22 [ 574 ] DEBUG : Stderr:    kwargs = kwargs_from_env(environment=environment, ssl_version=tls_version) (cluster.py:113, run_and_check)
2023-12-16 19:01:22 [ 574 ] DEBUG : Stderr:TypeError: kwargs_from_env() got an unexpected keyword argument 'ssl_version' (cluster.py:113, run_and_check)
2023-12-16 19:01:22 [ 574 ] DEBUG : Exitcode:1 (cluster.py:115, run_and_check)
2023-12-16 19:01:22 [ 574 ] INFO : Got exception pulling images: Command ['docker-compose', '--env-file', '/ClickHouse/tests/integration/test_atomic_drop_table/_instances_0/.env', '--project-name', 'roottestatomicdroptable', '--file', '/ClickHouse/tests/integration/test_atomic_drop_table/_instances_0/node1/docker-compose.yml', '--file', '/compose/docker_compose_keeper.yml', 'pull'] return non-zero code 1: Traceback (most recent call last):
  File "/usr/local/bin/docker-compose", line 8, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.10/dist-packages/compose/cli/main.py", line 81, in main
    command_func()
  File "/usr/local/lib/python3.10/dist-packages/compose/cli/main.py", line 200, in perform_command
    project = project_from_options('.', options)
  File "/usr/local/lib/python3.10/dist-packages/compose/cli/command.py", line 60, in project_from_options
    return get_project(
  File "/usr/local/lib/python3.10/dist-packages/compose/cli/command.py", line 152, in get_project
    client = get_client(
  File "/usr/local/lib/python3.10/dist-packages/compose/cli/docker_client.py", line 41, in get_client
    client = docker_client(
  File "/usr/local/lib/python3.10/dist-packages/compose/cli/docker_client.py", line 124, in docker_client
    kwargs = kwargs_from_env(environment=environment, ssl_version=tls_version)
TypeError: kwargs_from_env() got an unexpected keyword argument 'ssl_version'
```

Let's just pin the docker library to the latest worked version (though the problem is likely due to docker-compose pip package is pinned, while docker wasn't)