### PR TITLE
Always use `pread` for reading cache segments

### DIFF
--- a/src/Disks/IO/CachedOnDiskReadBufferFromFile.cpp
+++ b/src/Disks/IO/CachedOnDiskReadBufferFromFile.cpp
@@ -177,22 +177,13 @@ CachedOnDiskReadBufferFromFile::getCacheReadBuffer(const FileSegment & file_segm
     }
 
     ReadSettings local_read_settings{settings};
-    local_read_settings.local_fs_prefetch = false;
-    if (local_read_settings.local_fs_method != LocalFSReadMethod::pread_threadpool)
-        local_read_settings.local_fs_method = LocalFSReadMethod::pread;
+    local_read_settings.local_fs_method = LocalFSReadMethod::pread;
 
     if (use_external_buffer)
         local_read_settings.local_fs_buffer_size = 0;
 
-    cache_file_reader = createReadBufferFromFileBase(
-        path,
-        local_read_settings,
-        std::nullopt,
-        std::nullopt,
-        file_segment.getFlagsForLocalRead(),
-        /*existing_memory=*/nullptr,
-        /*alignment=*/0,
-        /*use_external_buffer=*/true);
+    cache_file_reader
+        = createReadBufferFromFileBase(path, local_read_settings, std::nullopt, std::nullopt, file_segment.getFlagsForLocalRead());
 
     if (getFileSizeFromReadBuffer(*cache_file_reader) == 0)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Attempt to read from an empty cache file: {}", path);


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


This was a wrong change (introduced in #55841): we always read from cache segments synchronously anyway, so `pread_threadpool` cannot do anything good.

Other changes made in `AsynchronousReadBufferFromFile*` to pass `use_external_buffer` will be reverted in a separate PR, that will not be back-ported. 