### PR TITLE
Add a setting to specify s3 disk is read only.

### DIFF
--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -108,6 +108,7 @@ class IColumn;
     M(UInt64, s3_retry_attempts, 100, "Setting for Aws::Client::RetryStrategy, Aws::Client does retries itself, 0 means no retries", 0) \
     M(UInt64, s3_request_timeout_ms, 30000, "Idleness timeout for sending and receiving data to/from S3. Fail if a single TCP read or write call blocks for this long.", 0) \
     M(UInt64, s3_http_connection_pool_size, 1000, "How many reusable open connections to keep per S3 endpoint. This only applies to the S3 table engine and table function, not to S3 disks (for disks, use disk config instead). Global setting, can only be set in config, overriding it per session or per query has no effect.", 0) \
+    M(Bool, s3_read_only, false, "Whether the s3 disk is read only or not. This is useful when creating a read only table with s3_plain type s3 disk", 0) \
     M(Bool, enable_s3_requests_logging, false, "Enable very explicit logging of S3 requests. Makes sense for debug only.", 0) \
     M(String, s3queue_default_zookeeper_path, "/clickhouse/s3queue/", "Default zookeeper path prefix for S3Queue engine", 0) \
     M(Bool, s3queue_enable_logging_to_s3queue_log, false, "Enable writing to system.s3queue_log. The value can be overwritten per table with table settings", 0) \

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -108,7 +108,6 @@ class IColumn;
     M(UInt64, s3_retry_attempts, 100, "Setting for Aws::Client::RetryStrategy, Aws::Client does retries itself, 0 means no retries", 0) \
     M(UInt64, s3_request_timeout_ms, 30000, "Idleness timeout for sending and receiving data to/from S3. Fail if a single TCP read or write call blocks for this long.", 0) \
     M(UInt64, s3_http_connection_pool_size, 1000, "How many reusable open connections to keep per S3 endpoint. This only applies to the S3 table engine and table function, not to S3 disks (for disks, use disk config instead). Global setting, can only be set in config, overriding it per session or per query has no effect.", 0) \
-    M(Bool, s3_read_only, false, "Whether the s3 disk is read only or not. This is useful when creating a read only table with s3_plain type s3 disk", 0) \
     M(Bool, enable_s3_requests_logging, false, "Enable very explicit logging of S3 requests. Makes sense for debug only.", 0) \
     M(String, s3queue_default_zookeeper_path, "/clickhouse/s3queue/", "Default zookeeper path prefix for S3Queue engine", 0) \
     M(Bool, s3queue_enable_logging_to_s3queue_log, false, "Enable writing to system.s3queue_log. The value can be overwritten per table with table settings", 0) \

--- a/src/Disks/ObjectStorages/S3/S3ObjectStorage.h
+++ b/src/Disks/ObjectStorages/S3/S3ObjectStorage.h
@@ -22,11 +22,13 @@ struct S3ObjectStorageSettings
         const S3Settings::RequestSettings & request_settings_,
         uint64_t min_bytes_for_seek_,
         int32_t list_object_keys_size_,
-        int32_t objects_chunk_size_to_delete_)
+        int32_t objects_chunk_size_to_delete_,
+        bool read_only_)
         : request_settings(request_settings_)
         , min_bytes_for_seek(min_bytes_for_seek_)
         , list_object_keys_size(list_object_keys_size_)
         , objects_chunk_size_to_delete(objects_chunk_size_to_delete_)
+        , read_only(read_only_)
     {}
 
     S3Settings::RequestSettings request_settings;
@@ -34,6 +36,7 @@ struct S3ObjectStorageSettings
     uint64_t min_bytes_for_seek;
     int32_t list_object_keys_size;
     int32_t objects_chunk_size_to_delete;
+    bool read_only;
 };
 
 
@@ -165,6 +168,8 @@ public:
     bool supportParallelWrite() const override { return true; }
 
     ObjectStorageKey generateObjectKeyForPath(const std::string & path) const override;
+
+    bool isReadOnly() const override { return s3_settings.get()->read_only; }
 
 private:
     void setNewSettings(std::unique_ptr<S3ObjectStorageSettings> && s3_settings_);

--- a/src/Disks/ObjectStorages/S3/diskSettings.cpp
+++ b/src/Disks/ObjectStorages/S3/diskSettings.cpp
@@ -35,7 +35,7 @@ std::unique_ptr<S3ObjectStorageSettings> getSettings(const Poco::Util::AbstractC
         config.getUInt64(config_prefix + ".min_bytes_for_seek", 1024 * 1024),
         config.getInt(config_prefix + ".list_object_keys_size", 1000),
         config.getInt(config_prefix + ".objects_chunk_size_to_delete", 1000),
-        config.getBool(config_prefix + ".s3_read_only", false));
+        config.getBool(config_prefix + ".readonly", false));
 }
 
 std::unique_ptr<S3::Client> getClient(

--- a/src/Disks/ObjectStorages/S3/diskSettings.cpp
+++ b/src/Disks/ObjectStorages/S3/diskSettings.cpp
@@ -34,7 +34,8 @@ std::unique_ptr<S3ObjectStorageSettings> getSettings(const Poco::Util::AbstractC
         request_settings,
         config.getUInt64(config_prefix + ".min_bytes_for_seek", 1024 * 1024),
         config.getInt(config_prefix + ".list_object_keys_size", 1000),
-        config.getInt(config_prefix + ".objects_chunk_size_to_delete", 1000));
+        config.getInt(config_prefix + ".objects_chunk_size_to_delete", 1000),
+        config.getBool(config_prefix + ".s3_read_only", false));
 }
 
 std::unique_ptr<S3::Client> getClient(

--- a/tests/integration/test_attach_table_from_s3_plain_readonly/configs/config.xml
+++ b/tests/integration/test_attach_table_from_s3_plain_readonly/configs/config.xml
@@ -1,0 +1,13 @@
+<clickhouse>
+    <storage_configuration>
+        <disks>
+            <disk_s3_plain_readonly>
+                <type>s3_plain</type>
+                <endpoint>http://minio1:9001/root/data/disks/disk_s3_plain/</endpoint>
+                <access_key_id>minio</access_key_id>
+                <secret_access_key>minio123</secret_access_key>
+                <readonly>true</readonly>
+            </disk_s3_plain_readonly>
+        </disks>
+    </storage_configuration>
+</clickhouse>

--- a/tests/integration/test_attach_table_from_s3_plain_readonly/configs/config.xml
+++ b/tests/integration/test_attach_table_from_s3_plain_readonly/configs/config.xml
@@ -9,5 +9,14 @@
                 <readonly>true</readonly>
             </disk_s3_plain_readonly>
         </disks>
+        <policies>
+            <s3_plain_readonly>
+                <volumes>
+                    <main>
+                        <disk>disk_s3_plain_readonly</disk>
+                    </main>
+                </volumes>
+            </s3_plain_readonly>
+        </policies>
     </storage_configuration>
 </clickhouse>

--- a/tests/integration/test_attach_table_from_s3_plain_readonly/configs/settings.xml
+++ b/tests/integration/test_attach_table_from_s3_plain_readonly/configs/settings.xml
@@ -1,0 +1,12 @@
+<clickhouse>
+    <profiles>
+        <default>
+            <allow_experimental_database_replicated>1</allow_experimental_database_replicated>
+        </default>
+    </profiles>
+    <users>
+        <default>
+            <profile>default</profile>
+        </default>
+    </users>
+</clickhouse>

--- a/tests/integration/test_attach_table_from_s3_plain_readonly/test.py
+++ b/tests/integration/test_attach_table_from_s3_plain_readonly/test.py
@@ -2,6 +2,7 @@ import re
 import os
 import logging
 import pytest
+import json
 
 from helpers.cluster import ClickHouseCluster
 from helpers.test_tools import assert_eq_with_retry
@@ -10,14 +11,24 @@ from pathlib import Path
 
 cluster = ClickHouseCluster(__file__)
 
-node = cluster.add_instance(
-    "node",
+node1 = cluster.add_instance(
+    "node1",
     main_configs=["configs/config.xml"],
     user_configs=["configs/settings.xml"],
     with_zookeeper=True,
     with_minio=True,
     stay_alive=True,
     macros={"shard": 1, "replica": 1},
+)
+
+node2 = cluster.add_instance(
+    "node2",
+    main_configs=["configs/config.xml"],
+    user_configs=["configs/settings.xml"],
+    with_zookeeper=True,
+    with_minio=True,
+    stay_alive=True,
+    macros={"shard": 1, "replica": 2},
 )
 
 uuid_regex = re.compile("[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}")
@@ -35,7 +46,7 @@ def upload_to_minio(minio_client, bucket_name, local_path, minio_path=''):
                     minio_client.put_object(bucket_name, minio_object_name, data, file_stat.st_size)
                 logging.info(f'Uploaded {local_file_path} to {minio_object_name}')
             except S3Error as e:
-                logging.info(f'Error uploading {local_file_path}: {e}')
+                logging.error(f'Error uploading {local_file_path}: {e}')
 
 
 @pytest.fixture(scope="module")
@@ -49,7 +60,8 @@ def started_cluster():
 
 
 def test_attach_table_from_s3_plain_readonly(started_cluster):
-    node.query(
+    # Create an atomic DB with mergetree sample data
+    node1.query(
     """
     create database local_db;
 
@@ -59,35 +71,31 @@ def test_attach_table_from_s3_plain_readonly(started_cluster):
     """
     )
 
-    assert int(node.query("select num from local_db.test_table limit 1")) == 5
+    assert int(node1.query("select num from local_db.test_table limit 1")) == 5
     
-    # Copy local file into minio bucket
-    table_data_path = os.path.join(node.path, f"database/store")
+    # Copy local MergeTree data into minio bucket
+    table_data_path = os.path.join(node1.path, f"database/store")
     minio = cluster.minio_client
-    upload_to_minio(minio, cluster.minio_bucket, table_data_path, "data/disks/disk_s3_plain/")
+    upload_to_minio(minio, cluster.minio_bucket, table_data_path, "data/disks/disk_s3_plain/store/")
 
-    ### remove
-    s3_objects = list(minio.list_objects(cluster.minio_bucket, "data/", recursive=True))
-    for s3_object in s3_objects:
-        logging.info("bianpengyuan Existing S3 object: %s", s3_object.object_name)
-    ### remove
+    # Drop the non-replicated table, we don't need it anymore
+    table_uuid = node1.query("SELECT uuid FROM system.tables WHERE database='local_db' AND table='test_table'").strip()
+    node1.query("drop table local_db.test_table SYNC;")
 
-    # Create a replicated database, and attach the merge tree data disk
-    table_uuid = node.query("SELECT uuid FROM system.tables WHERE database='local_db' AND table='test_table'").strip()
-    node.query(
+    # Create a replicated database
+    node1.query("create database s3_plain_test_db ENGINE = Replicated('/test/s3_plain_test_db', 'shard1', 'replica1');")
+    node2.query("create database s3_plain_test_db ENGINE = Replicated('/test/s3_plain_test_db', 'shard1', 'replica2');")
+
+    # Create a MergeTree table at one node, by attaching the merge tree data
+    node1.query(
     f"""
-    drop table local_db.test_table SYNC;
-
-    create database s3_plain_test_db ENGINE = Replicated('/test/s3_plain_test_db', 'shard1', 'replica1');
     attach table s3_plain_test_db.test_table UUID '{table_uuid}' (num UInt32)
     engine=MergeTree()
     order by num
-    settings
-        disk=disk(type=s3_plain,
-            endpoint='http://minio1:9001/root/data/disks/disk_s3_plain/',
-            access_key_id='minio',
-            secret_access_key='minio123');
+    settings storage_policy = 's3_plain_readonly'
     """
     )
 
-    assert int(node.query("select num from s3_plain_test_db.test_table limit 1")) == 5
+    # Check that both nodes can query and get result.
+    assert int(node1.query("select num from s3_plain_test_db.test_table limit 1")) == 5
+    assert int(node2.query("select num from s3_plain_test_db.test_table limit 1")) == 5

--- a/tests/integration/test_attach_table_from_s3_plain_readonly/test.py
+++ b/tests/integration/test_attach_table_from_s3_plain_readonly/test.py
@@ -1,0 +1,93 @@
+import re
+import os
+import logging
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+from helpers.test_tools import assert_eq_with_retry
+from minio.error import S3Error
+from pathlib import Path
+
+cluster = ClickHouseCluster(__file__)
+
+node = cluster.add_instance(
+    "node",
+    main_configs=["configs/config.xml"],
+    user_configs=["configs/settings.xml"],
+    with_zookeeper=True,
+    with_minio=True,
+    stay_alive=True,
+    macros={"shard": 1, "replica": 1},
+)
+
+uuid_regex = re.compile("[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}")
+
+def upload_to_minio(minio_client, bucket_name, local_path, minio_path=''):
+    local_path = Path(local_path)
+    for root, _, files in os.walk(local_path):
+        for file in files:
+            local_file_path = Path(root) / file
+            minio_object_name = minio_path + str(local_file_path.relative_to(local_path))
+
+            try:
+                with open(local_file_path, 'rb') as data:
+                    file_stat = os.stat(local_file_path)
+                    minio_client.put_object(bucket_name, minio_object_name, data, file_stat.st_size)
+                logging.info(f'Uploaded {local_file_path} to {minio_object_name}')
+            except S3Error as e:
+                logging.info(f'Error uploading {local_file_path}: {e}')
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+        yield cluster
+
+    finally:
+        cluster.shutdown()
+
+
+def test_attach_table_from_s3_plain_readonly(started_cluster):
+    node.query(
+    """
+    create database local_db;
+
+    create table local_db.test_table (num UInt32) engine=MergeTree() order by num;
+
+    insert into local_db.test_table (*) Values (5)
+    """
+    )
+
+    assert int(node.query("select num from local_db.test_table limit 1")) == 5
+    
+    # Copy local file into minio bucket
+    table_data_path = os.path.join(node.path, f"database/store")
+    minio = cluster.minio_client
+    upload_to_minio(minio, cluster.minio_bucket, table_data_path, "data/disks/disk_s3_plain/")
+
+    ### remove
+    s3_objects = list(minio.list_objects(cluster.minio_bucket, "data/", recursive=True))
+    for s3_object in s3_objects:
+        logging.info("bianpengyuan Existing S3 object: %s", s3_object.object_name)
+    ### remove
+
+    # Create a replicated database, and attach the merge tree data disk
+    table_uuid = node.query("SELECT uuid FROM system.tables WHERE database='local_db' AND table='test_table'").strip()
+    node.query(
+    f"""
+    drop table local_db.test_table SYNC;
+
+    create database s3_plain_test_db ENGINE = Replicated('/test/s3_plain_test_db', 'shard1', 'replica1');
+    attach table s3_plain_test_db.test_table UUID '{table_uuid}' (num UInt32)
+    engine=MergeTree()
+    order by num
+    settings
+        disk=disk(type=s3_plain,
+            endpoint='http://minio1:9001/root/data/disks/disk_s3_plain/',
+            access_key_id='minio',
+            secret_access_key='minio123');
+    """
+    )
+
+    assert int(node.query("select num from s3_plain_test_db.test_table limit 1")) == 5


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Added a new setting `readonly` which can be used to specify a s3 disk is read only. It can be useful to create a table with read only `s3_plain` type disk.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
