### PR TITLE
Update `query_masking_rules` when reloading the config, attempt 2

### DIFF
--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -1467,6 +1467,8 @@ try
 
                 global_context->reloadAuxiliaryZooKeepersConfigIfChanged(config);
 
+                global_context->reloadQueryMaskingRulesIfChanged(config);
+
                 std::lock_guard lock(servers_lock);
                 updateServers(*config, server_pool, async_metrics, servers, servers_to_start_before_tables);
             }

--- a/src/Common/Exception.cpp
+++ b/src/Common/Exception.cpp
@@ -69,14 +69,14 @@ void handle_error_code([[maybe_unused]] const std::string & msg, int code, bool 
 Exception::MessageMasked::MessageMasked(const std::string & msg_)
     : msg(msg_)
 {
-    if (auto * masker = SensitiveDataMasker::getInstance())
+    if (auto masker = SensitiveDataMasker::getInstance())
         masker->wipeSensitiveData(msg);
 }
 
 Exception::MessageMasked::MessageMasked(std::string && msg_)
     : msg(std::move(msg_))
 {
-    if (auto * masker = SensitiveDataMasker::getInstance())
+    if (auto masker = SensitiveDataMasker::getInstance())
         masker->wipeSensitiveData(msg);
 }
 

--- a/src/Common/SensitiveDataMasker.cpp
+++ b/src/Common/SensitiveDataMasker.cpp
@@ -85,9 +85,9 @@ public:
 
 SensitiveDataMasker::~SensitiveDataMasker() = default;
 
-std::shared_ptr<SensitiveDataMasker> SensitiveDataMasker::sensitive_data_masker = nullptr;
+SensitiveDataMasker::MaskerMultiVersion SensitiveDataMasker::sensitive_data_masker{};
 
-void SensitiveDataMasker::setInstance(std::shared_ptr<SensitiveDataMasker> sensitive_data_masker_)
+void SensitiveDataMasker::setInstance(std::unique_ptr<SensitiveDataMasker>&& sensitive_data_masker_)
 {
 
     if (!sensitive_data_masker_)
@@ -95,18 +95,17 @@ void SensitiveDataMasker::setInstance(std::shared_ptr<SensitiveDataMasker> sensi
 
     if (sensitive_data_masker_->rulesCount() > 0)
     {
-        std::atomic_store(&sensitive_data_masker, std::move(sensitive_data_masker_));
+        sensitive_data_masker.set(std::move(sensitive_data_masker_));
     }
     else
     {
-        std::atomic_store(&sensitive_data_masker, std::shared_ptr<SensitiveDataMasker>(nullptr));
+        sensitive_data_masker.set(nullptr);
     }
 }
 
-std::shared_ptr<SensitiveDataMasker> SensitiveDataMasker::getInstance()
+SensitiveDataMasker::MaskerMultiVersion::Version SensitiveDataMasker::getInstance()
 {
-    // TODO: use std::atomic<std::shared_ptr> when compiler supports it
-    return std::atomic_load(&sensitive_data_masker);
+    return sensitive_data_masker.get();
 }
 
 SensitiveDataMasker::SensitiveDataMasker(const Poco::Util::AbstractConfiguration & config, const std::string & config_prefix)

--- a/src/Common/SensitiveDataMasker.cpp
+++ b/src/Common/SensitiveDataMasker.cpp
@@ -1,5 +1,6 @@
 #include "SensitiveDataMasker.h"
 
+#include <mutex>
 #include <set>
 #include <string>
 #include <atomic>
@@ -86,20 +87,28 @@ public:
 SensitiveDataMasker::~SensitiveDataMasker() = default;
 
 std::unique_ptr<SensitiveDataMasker> SensitiveDataMasker::sensitive_data_masker = nullptr;
+std::mutex SensitiveDataMasker::instance_mutex;
 
 void SensitiveDataMasker::setInstance(std::unique_ptr<SensitiveDataMasker> sensitive_data_masker_)
 {
+
     if (!sensitive_data_masker_)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Logical error: the 'sensitive_data_masker' is not set");
 
+    std::lock_guard lock(instance_mutex);
     if (sensitive_data_masker_->rulesCount() > 0)
     {
         sensitive_data_masker = std::move(sensitive_data_masker_);
+    }
+    else
+    {
+        sensitive_data_masker.reset();
     }
 }
 
 SensitiveDataMasker * SensitiveDataMasker::getInstance()
 {
+    std::lock_guard lock(instance_mutex);
     return sensitive_data_masker.get();
 }
 

--- a/src/Common/SensitiveDataMasker.cpp
+++ b/src/Common/SensitiveDataMasker.cpp
@@ -86,10 +86,10 @@ public:
 
 SensitiveDataMasker::~SensitiveDataMasker() = default;
 
-std::unique_ptr<SensitiveDataMasker> SensitiveDataMasker::sensitive_data_masker = nullptr;
+std::shared_ptr<SensitiveDataMasker> SensitiveDataMasker::sensitive_data_masker = nullptr;
 std::mutex SensitiveDataMasker::instance_mutex;
 
-void SensitiveDataMasker::setInstance(std::unique_ptr<SensitiveDataMasker> sensitive_data_masker_)
+void SensitiveDataMasker::setInstance(std::shared_ptr<SensitiveDataMasker> sensitive_data_masker_)
 {
 
     if (!sensitive_data_masker_)
@@ -106,10 +106,10 @@ void SensitiveDataMasker::setInstance(std::unique_ptr<SensitiveDataMasker> sensi
     }
 }
 
-SensitiveDataMasker * SensitiveDataMasker::getInstance()
+std::shared_ptr<SensitiveDataMasker> SensitiveDataMasker::getInstance()
 {
     std::lock_guard lock(instance_mutex);
-    return sensitive_data_masker.get();
+    return sensitive_data_masker;
 }
 
 SensitiveDataMasker::SensitiveDataMasker(const Poco::Util::AbstractConfiguration & config, const std::string & config_prefix)
@@ -206,7 +206,7 @@ std::string wipeSensitiveDataAndCutToLength(const std::string & str, size_t max_
 {
     std::string res = str;
 
-    if (auto * masker = SensitiveDataMasker::getInstance())
+    if (auto masker = SensitiveDataMasker::getInstance())
         masker->wipeSensitiveData(res);
 
     size_t length = res.length();

--- a/src/Common/SensitiveDataMasker.h
+++ b/src/Common/SensitiveDataMasker.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <mutex>
 #include <vector>
 #include <cstdint>
 
@@ -45,6 +46,7 @@ class SensitiveDataMasker
 private:
     class MaskingRule;
     std::vector<std::unique_ptr<MaskingRule>> all_masking_rules;
+    static std::mutex instance_mutex;
     static std::unique_ptr<SensitiveDataMasker> sensitive_data_masker;
 
 public:

--- a/src/Common/SensitiveDataMasker.h
+++ b/src/Common/SensitiveDataMasker.h
@@ -47,7 +47,7 @@ private:
     class MaskingRule;
     std::vector<std::unique_ptr<MaskingRule>> all_masking_rules;
     static std::mutex instance_mutex;
-    static std::unique_ptr<SensitiveDataMasker> sensitive_data_masker;
+    static std::shared_ptr<SensitiveDataMasker> sensitive_data_masker;
 
 public:
     SensitiveDataMasker(const Poco::Util::AbstractConfiguration & config, const std::string & config_prefix);
@@ -58,8 +58,8 @@ public:
 
     /// setInstance is not thread-safe and should be called once in single-thread mode.
     /// https://github.com/ClickHouse/ClickHouse/pull/6810#discussion_r321183367
-    static void setInstance(std::unique_ptr<SensitiveDataMasker> sensitive_data_masker_);
-    static SensitiveDataMasker * getInstance();
+    static void setInstance(std::shared_ptr<SensitiveDataMasker> sensitive_data_masker_);
+    static std::shared_ptr<SensitiveDataMasker> getInstance();
 
     /// Used in tests.
     void addMaskingRule(const std::string & name, const std::string & regexp_string, const std::string & replacement_string);

--- a/src/Common/SensitiveDataMasker.h
+++ b/src/Common/SensitiveDataMasker.h
@@ -2,6 +2,7 @@
 
 #include <memory>
 #include <vector>
+#include "Common/MultiVersion.h"
 
 namespace Poco
 {
@@ -44,7 +45,8 @@ class SensitiveDataMasker
 private:
     class MaskingRule;
     std::vector<std::unique_ptr<MaskingRule>> all_masking_rules;
-    static std::shared_ptr<SensitiveDataMasker> sensitive_data_masker;
+    using MaskerMultiVersion = MultiVersion<SensitiveDataMasker>;
+    static MaskerMultiVersion sensitive_data_masker;
 
 public:
     SensitiveDataMasker(const Poco::Util::AbstractConfiguration & config, const std::string & config_prefix);
@@ -55,8 +57,8 @@ public:
 
     /// setInstance is not thread-safe and should be called once in single-thread mode.
     /// https://github.com/ClickHouse/ClickHouse/pull/6810#discussion_r321183367
-    static void setInstance(std::shared_ptr<SensitiveDataMasker> sensitive_data_masker_);
-    static std::shared_ptr<SensitiveDataMasker> getInstance();
+    static void setInstance(std::unique_ptr<SensitiveDataMasker>&& sensitive_data_masker_);
+    static MaskerMultiVersion::Version getInstance();
 
     /// Used in tests.
     void addMaskingRule(const std::string & name, const std::string & regexp_string, const std::string & replacement_string);

--- a/src/Common/SensitiveDataMasker.h
+++ b/src/Common/SensitiveDataMasker.h
@@ -1,9 +1,7 @@
 #pragma once
 
 #include <memory>
-#include <mutex>
 #include <vector>
-#include <cstdint>
 
 namespace Poco
 {
@@ -46,7 +44,6 @@ class SensitiveDataMasker
 private:
     class MaskingRule;
     std::vector<std::unique_ptr<MaskingRule>> all_masking_rules;
-    static std::mutex instance_mutex;
     static std::shared_ptr<SensitiveDataMasker> sensitive_data_masker;
 
 public:

--- a/src/Interpreters/Context.h
+++ b/src/Interpreters/Context.h
@@ -964,6 +964,8 @@ public:
     // Reload Zookeeper
     void reloadZooKeeperIfChanged(const ConfigurationPtr & config) const;
 
+    void reloadQueryMaskingRulesIfChanged(const ConfigurationPtr & config) const;
+
     void setSystemZooKeeperLogAfterInitializationIfNeeded();
 
     /// --- Caches ------------------------------------------------------------------------------------------

--- a/src/Interpreters/ThreadStatusExt.cpp
+++ b/src/Interpreters/ThreadStatusExt.cpp
@@ -546,7 +546,7 @@ void ThreadStatus::logToQueryThreadLog(QueryThreadLog & thread_log, const String
 static String getCleanQueryAst(const ASTPtr q, ContextPtr context)
 {
     String res = serializeAST(*q);
-    if (auto * masker = SensitiveDataMasker::getInstance())
+    if (auto masker = SensitiveDataMasker::getInstance())
         masker->wipeSensitiveData(res);
 
     res = res.substr(0, context->getSettingsRef().log_queries_cut_to_length);

--- a/src/Loggers/OwnSplitChannel.cpp
+++ b/src/Loggers/OwnSplitChannel.cpp
@@ -27,7 +27,7 @@ void OwnSplitChannel::log(const Poco::Message & msg)
         return;
 #endif
 
-    if (auto * masker = SensitiveDataMasker::getInstance())
+    if (auto masker = SensitiveDataMasker::getInstance())
     {
         auto message_text = msg.getText();
         auto matches = masker->wipeSensitiveData(message_text);

--- a/tests/integration/test_reload_query_masking_rules/configs/changed_settings.xml
+++ b/tests/integration/test_reload_query_masking_rules/configs/changed_settings.xml
@@ -1,0 +1,19 @@
+<clickhouse>
+    <query_log>
+        <database>system</database>
+        <table>query_log</table>
+        <partition_by>toYYYYMM(event_date)</partition_by>
+        <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+        <max_size_rows>1048576</max_size_rows>
+        <reserved_size_rows>8192</reserved_size_rows>
+        <buffer_size_rows_flush_threshold>524288</buffer_size_rows_flush_threshold>
+        <flush_on_crash>false</flush_on_crash>
+    </query_log>
+
+    <query_masking_rules>
+        <rule>
+            <regexp>TOPSECRET.TOPSECRET</regexp>
+            <replace>[hidden]</replace>
+        </rule>
+    </query_masking_rules>
+</clickhouse>

--- a/tests/integration/test_reload_query_masking_rules/configs/empty_settings.xml
+++ b/tests/integration/test_reload_query_masking_rules/configs/empty_settings.xml
@@ -1,0 +1,12 @@
+<clickhouse>
+    <query_log>
+        <database>system</database>
+        <table>query_log</table>
+        <partition_by>toYYYYMM(event_date)</partition_by>
+        <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+        <max_size_rows>1048576</max_size_rows>
+        <reserved_size_rows>8192</reserved_size_rows>
+        <buffer_size_rows_flush_threshold>524288</buffer_size_rows_flush_threshold>
+        <flush_on_crash>false</flush_on_crash>
+    </query_log>
+</clickhouse>

--- a/tests/integration/test_reload_query_masking_rules/test.py
+++ b/tests/integration/test_reload_query_masking_rules/test.py
@@ -1,0 +1,57 @@
+import pytest
+import os
+from helpers.cluster import ClickHouseCluster
+from helpers.test_tools import assert_eq_with_retry, assert_logs_contain_with_retry
+
+SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
+cluster = ClickHouseCluster(__file__)
+node = cluster.add_instance("node", user_configs=["configs/empty_settings.xml"])
+
+
+@pytest.fixture(scope="module", autouse=True)
+def started_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+@pytest.fixture(autouse=True)
+def reset_to_normal_settings_after_test():
+    try:
+        node.copy_file_to_container(
+            os.path.join(SCRIPT_DIR, "configs/empty_settings.xml"),
+            "/etc/clickhouse-server/config.d/z.xml",
+        )
+        node.query("SYSTEM RELOAD CONFIG")
+        yield
+    finally:
+        pass
+
+
+# @pytest.mark.parametrize("reload_strategy", ["force", "timeout"])
+def test_reload_query_masking_rules():
+    # At first, empty configuration is fed to ClickHouse. The query
+    # "SELECT 'TOPSECRET.TOPSECRET'" will not be redacted, and the new masking
+    # event will not be registered
+    node.query("SELECT 'TOPSECRET.TOPSECRET'")
+    assert_logs_contain_with_retry(node, "SELECT 'TOPSECRET.TOPSECRET'")
+    assert not node.contains_in_log(r"SELECT '\[hidden\]'")
+    node.rotate_logs()
+
+    node.copy_file_to_container(
+        os.path.join(SCRIPT_DIR, "configs/changed_settings.xml"),
+        "/etc/clickhouse-server/config.d/z.xml",
+    )
+
+    node.query("SYSTEM RELOAD CONFIG")
+
+    # Now the same query will be redacted in the logs and the counter of events
+    # will be incremented
+    node.query("SELECT 'TOPSECRET.TOPSECRET'")
+
+    assert_logs_contain_with_retry(node, r"SELECT '\[hidden\]'")
+    assert not node.contains_in_log("SELECT 'TOPSECRET.TOPSECRET'")
+
+    node.rotate_logs()


### PR DESCRIPTION
This PR reintroduces changes from #56573 (first commit) and fixes the data race that was introduced with that PR.

That PR added scope lock for `getInstance` and `setInstance`, but `getInstance` returned a pointer that could be invalidated between call for `getInstance` and actual usage of the pointer.

This time  I changed `SensitiveDataMasker` singleton from `unique_ptr` to `shared_ptr`, so even if `setInstance` is called right after `getInstance`, the pointer returned from `getInstance` will live long enough to call `wipeSensitiveData` on it.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)



<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
