### PR TITLE
Update 00002_log_and_exception_messages_formatting.sql

### DIFF
--- a/tests/queries/0_stateless/00002_log_and_exception_messages_formatting.sql
+++ b/tests/queries/0_stateless/00002_log_and_exception_messages_formatting.sql
@@ -10,7 +10,7 @@ create view logs as select * from system.text_log where now() - toIntervalMinute
 -- Check that we don't have too many messages formatted with fmt::runtime or strings concatenation.
 -- 0.001 threshold should be always enough, the value was about 0.00025
 select 'runtime messages', greatest(coalesce(sum(length(message_format_string) = 0) / countOrNull(), 0), 0.001) from logs
-    where message not like '% Received from %clickhouse-staging.com:9440%';
+    where message not like '% Received from %clickhouse-staging.com:9440%' and source_file not like '%/AWSLogger.cpp%';
 
 -- Check the same for exceptions. The value was 0.03
 select 'runtime exceptions', greatest(coalesce(sum(length(message_format_string) = 0) / countOrNull(), 0), 0.05) from logs


### PR DESCRIPTION

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

https://s3.amazonaws.com/clickhouse-test-reports/57682/f876bea0500e3d150609b2cd79878dd04d36b2dd/stateless_tests__tsan__s3_storage__[5_5].html

```
2023-12-08 19:00:08 -runtime messages	0.001
2023-12-08 19:00:08 +runtime messages	0.0011781789961961984
```

```
2023-12-08 19:00:32 Top messages without format string (fmt::runtime):
2023-12-08 19:00:32 
2023-12-08 19:00:32 count	pattern	runtime_message	line
2023-12-08 19:00:32 UInt64	String	String	Tuple(String, UInt64)
2023-12-08 19:00:32 224	IfthesignaturecheckfailedThiscou	If the signature check failed. This could be because of a time skew. Attempting to adjust the signer.	('/AWSLogger.cpp',71)
2023-12-08 19:00:32 221	Failedtomakerequesttohttplocalho	Failed to make request to: http://localhost:11111/test/test/qgg/tyhbplkrxyhdpqtinrlansfkwyqce: Poco::Exception. Code: 1000, e.code() = 0, Timeout, Stack trace (when copying this message, always include the lines below):\n\n0. ./contrib/llvm-project/libcxx/in	('/PocoHTTPClient.cpp',610)
2023-12-08 19:00:32 221	Requestfailednowwaitingmsbeforea	Request failed, now waiting 0 ms before attempting again.	('/AWSLogger.cpp',71)
2023-12-08 19:00:32 40	EntryconnectionPINGok	Entry(connection 0): PING ok.	('',0)
2023-12-08 19:00:32 40	EntryconnectionsendingPINGtochec	Entry(connection 0): sending PING to check if it is alive.	('',0)
```