### PR TITLE
Add GH status for PR formating

### DIFF
--- a/.gitmessage
+++ b/.gitmessage
@@ -1,0 +1,10 @@
+
+
+## To avoid merge commit in CI run (add a leading space to apply):
+#no-merge-commit
+
+## Running specified job (add a leading space to apply):
+#job_<JOB NAME>
+#job_stateless_tests_release
+#job_package_debug
+#job_integration_tests_asan

--- a/tests/ci/build_report_check.py
+++ b/tests/ci/build_report_check.py
@@ -78,7 +78,7 @@ def main():
     pr_info = PRInfo()
     commit = get_commit(gh, pr_info.sha)
 
-    atexit.register(update_mergeable_check, gh, pr_info, build_check_name)
+    atexit.register(update_mergeable_check, commit, pr_info, build_check_name)
 
     rerun_helper = RerunHelper(commit, build_check_name)
     if rerun_helper.is_already_finished_by_status():

--- a/tests/ci/ci_config.py
+++ b/tests/ci/ci_config.py
@@ -847,6 +847,7 @@ CI_CONFIG.validate()
 
 # checks required by Mergeable Check
 REQUIRED_CHECKS = [
+    "PR Check",
     "ClickHouse build check",
     "ClickHouse special build check",
     "Docs Check",

--- a/tests/ci/clickbench.py
+++ b/tests/ci/clickbench.py
@@ -133,7 +133,7 @@ def main():
     pr_info = PRInfo()
 
     commit = get_commit(gh, pr_info.sha)
-    atexit.register(update_mergeable_check, gh, pr_info, check_name)
+    atexit.register(update_mergeable_check, commit, pr_info, check_name)
 
     rerun_helper = RerunHelper(commit, check_name)
     if rerun_helper.is_already_finished_by_status():

--- a/tests/ci/commit_status_helper.py
+++ b/tests/ci/commit_status_helper.py
@@ -18,7 +18,7 @@ from github.IssueComment import IssueComment
 from github.Repository import Repository
 
 from ci_config import CI_CONFIG, REQUIRED_CHECKS, CHECK_DESCRIPTIONS, CheckDescription
-from env_helper import GITHUB_REPOSITORY, GITHUB_RUN_URL, TEMP_PATH
+from env_helper import GITHUB_JOB_URL, GITHUB_REPOSITORY, TEMP_PATH
 from pr_info import PRInfo, SKIP_MERGEABLE_CHECK_LABEL
 from report import (
     ERROR,
@@ -436,7 +436,7 @@ def set_mergeable_check(
         context=MERGEABLE_NAME,
         description=description,
         state=state,
-        target_url=GITHUB_RUN_URL,
+        target_url=GITHUB_JOB_URL(),
     )
 
 
@@ -474,10 +474,16 @@ def update_mergeable_check(commit: Commit, pr_info: PRInfo, check_name: str) -> 
             fail.append(status.context)
 
     state: StatusType = SUCCESS
-    description = ", ".join(success)
+
+    if success:
+        description = ", ".join(success)
+    else:
+        description = "awaiting job statuses"
+
     if fail:
         description = "failed: " + ", ".join(fail)
         state = FAILURE
     description = format_description(description)
+
     if mergeable_status is None or mergeable_status.description != description:
         set_mergeable_check(commit, description, state)

--- a/tests/ci/docs_check.py
+++ b/tests/ci/docs_check.py
@@ -67,7 +67,7 @@ def main():
     if rerun_helper.is_already_finished_by_status():
         logging.info("Check is already finished according to github status, exiting")
         sys.exit(0)
-    atexit.register(update_mergeable_check, gh, pr_info, NAME)
+    atexit.register(update_mergeable_check, commit, pr_info, NAME)
 
     if not pr_info.has_changes_in_documentation() and not args.force:
         logging.info("No changes in documentation")

--- a/tests/ci/fast_test_check.py
+++ b/tests/ci/fast_test_check.py
@@ -124,7 +124,7 @@ def main():
     gh = Github(get_best_robot_token(), per_page=100)
     commit = get_commit(gh, pr_info.sha)
 
-    atexit.register(update_mergeable_check, gh, pr_info, NAME)
+    atexit.register(update_mergeable_check, commit, pr_info, NAME)
 
     rerun_helper = RerunHelper(commit, NAME)
     if rerun_helper.is_already_finished_by_status():

--- a/tests/ci/finish_check.py
+++ b/tests/ci/finish_check.py
@@ -18,9 +18,9 @@ def main():
 
     pr_info = PRInfo(need_orgs=True)
     gh = Github(get_best_robot_token(), per_page=100)
-    # Update the Mergeable Check at the final step
-    update_mergeable_check(gh, pr_info, CI_STATUS_NAME)
     commit = get_commit(gh, pr_info.sha)
+    # Update the Mergeable Check at the final step
+    update_mergeable_check(commit, pr_info, CI_STATUS_NAME)
 
     statuses = [
         status

--- a/tests/ci/functional_test_check.py
+++ b/tests/ci/functional_test_check.py
@@ -254,7 +254,7 @@ def main():
     )
 
     commit = get_commit(gh, pr_info.sha)
-    atexit.register(update_mergeable_check, gh, pr_info, check_name)
+    atexit.register(update_mergeable_check, commit, pr_info, check_name)
 
     if validate_bugfix_check and "pr-bugfix" not in pr_info.labels:
         if args.post_commit_status == "file":

--- a/tests/ci/install_check.py
+++ b/tests/ci/install_check.py
@@ -279,7 +279,7 @@ def main():
     if CI:
         gh = Github(get_best_robot_token(), per_page=100)
         commit = get_commit(gh, pr_info.sha)
-        atexit.register(update_mergeable_check, gh, pr_info, args.check_name)
+        atexit.register(update_mergeable_check, commit, pr_info, args.check_name)
 
         rerun_helper = RerunHelper(commit, args.check_name)
         if rerun_helper.is_already_finished_by_status():

--- a/tests/ci/libfuzzer_test_check.py
+++ b/tests/ci/libfuzzer_test_check.py
@@ -118,7 +118,7 @@ def main():
     gh = Github(get_best_robot_token(), per_page=100)
     pr_info = PRInfo()
     commit = get_commit(gh, pr_info.sha)
-    atexit.register(update_mergeable_check, gh, pr_info, check_name)
+    atexit.register(update_mergeable_check, commit, pr_info, check_name)
 
     temp_path.mkdir(parents=True, exist_ok=True)
 

--- a/tests/ci/run_check.py
+++ b/tests/ci/run_check.py
@@ -161,21 +161,6 @@ def main():
         )
         sys.exit(1)
 
-    set_mergeable_check(commit, "skipped")
-
-    ci_report_url = create_ci_report(pr_info, [])
-    if not can_run:
-        print("::notice ::Cannot run")
-        post_commit_status(
-            commit,
-            labels_state,
-            ci_report_url,
-            description,
-            CI_STATUS_NAME,
-            pr_info,
-        )
-        sys.exit(1)
-
     if FEATURE_LABEL in pr_info.labels and not pr_info.has_changes_in_documentation():
         print(
             f"The '{FEATURE_LABEL}' in the labels, "
@@ -191,6 +176,21 @@ def main():
             pr_info,
         )
         update_mergeable_check(commit, pr_info, PR_CHECK)
+    else:
+        set_mergeable_check(commit, "skipped", state="success")
+
+    ci_report_url = create_ci_report(pr_info, [])
+    if not can_run:
+        print("::notice ::Cannot run")
+        post_commit_status(
+            commit,
+            labels_state,
+            ci_report_url,
+            description,
+            CI_STATUS_NAME,
+            pr_info,
+        )
+        sys.exit(1)
 
     print("::notice ::Can run")
     post_commit_status(

--- a/tests/ci/run_check.py
+++ b/tests/ci/run_check.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import atexit
 import sys
 import logging
 from typing import Tuple
@@ -13,7 +14,6 @@ from commit_status_helper import (
     post_commit_status,
     post_labels,
     remove_labels,
-    set_mergeable_check,
     update_mergeable_check,
 )
 from env_helper import GITHUB_REPOSITORY, GITHUB_SERVER_URL
@@ -35,6 +35,7 @@ CAN_BE_TESTED_LABEL = "can be tested"
 DO_NOT_TEST_LABEL = "do not test"
 FEATURE_LABEL = "pr-feature"
 SUBMODULE_CHANGED_LABEL = "submodule changed"
+PR_CHECK = "PR Check"
 
 
 def pr_is_by_trusted_user(pr_user_login, pr_user_orgs):
@@ -59,24 +60,20 @@ def pr_is_by_trusted_user(pr_user_login, pr_user_orgs):
 
 # Returns whether we should look into individual checks for this PR. If not, it
 # can be skipped entirely.
-# Returns can_run, description, labels_state
-def should_run_ci_for_pr(pr_info: PRInfo) -> Tuple[bool, str, str]:
+# Returns can_run, description
+def should_run_ci_for_pr(pr_info: PRInfo) -> Tuple[bool, str]:
     # Consider the labels and whether the user is trusted.
     print("Got labels", pr_info.labels)
     if FORCE_TESTS_LABEL in pr_info.labels:
         print(f"Label '{FORCE_TESTS_LABEL}' set, forcing remaining checks")
-        return True, f"Labeled '{FORCE_TESTS_LABEL}'", "pending"
+        return True, f"Labeled '{FORCE_TESTS_LABEL}'"
 
     if DO_NOT_TEST_LABEL in pr_info.labels:
         print(f"Label '{DO_NOT_TEST_LABEL}' set, skipping remaining checks")
-        return False, f"Labeled '{DO_NOT_TEST_LABEL}'", "success"
+        return False, f"Labeled '{DO_NOT_TEST_LABEL}'"
 
     if OK_SKIP_LABELS.intersection(pr_info.labels):
-        return (
-            True,
-            "Don't try new checks for release/backports/cherry-picks",
-            "success",
-        )
+        return True, "Don't try new checks for release/backports/cherry-picks"
 
     if CAN_BE_TESTED_LABEL not in pr_info.labels and not pr_is_by_trusted_user(
         pr_info.user_login, pr_info.user_orgs
@@ -84,9 +81,9 @@ def should_run_ci_for_pr(pr_info: PRInfo) -> Tuple[bool, str, str]:
         print(
             f"PRs by untrusted users need the '{CAN_BE_TESTED_LABEL}' label - please contact a member of the core team"
         )
-        return False, "Needs 'can be tested' label", "failure"
+        return False, "Needs 'can be tested' label"
 
-    return True, "No special conditions apply", "pending"
+    return True, "No special conditions apply"
 
 
 def main():
@@ -99,7 +96,7 @@ def main():
         print("::notice ::Cannot run, no PR exists for the commit")
         sys.exit(1)
 
-    can_run, description, labels_state = should_run_ci_for_pr(pr_info)
+    can_run, description = should_run_ci_for_pr(pr_info)
     if can_run and OK_SKIP_LABELS.intersection(pr_info.labels):
         print("::notice :: Early finish the check, running in a special PR")
         sys.exit(0)
@@ -107,6 +104,7 @@ def main():
     description = format_description(description)
     gh = Github(get_best_robot_token(), per_page=100)
     commit = get_commit(gh, pr_info.sha)
+    atexit.register(update_mergeable_check, commit, pr_info, PR_CHECK)
 
     description_error, category = check_pr_description(pr_info.body, GITHUB_REPOSITORY)
     pr_labels_to_add = []
@@ -156,7 +154,7 @@ def main():
             "failure",
             url,
             format_description(description_error),
-            CI_STATUS_NAME,
+            PR_CHECK,
             pr_info,
         )
         sys.exit(1)
@@ -166,7 +164,6 @@ def main():
             f"The '{FEATURE_LABEL}' in the labels, "
             "but there's no changed documentation"
         )
-        PR_CHECK = "PR Check"
         post_commit_status(
             commit,
             FAILURE,
@@ -175,23 +172,13 @@ def main():
             PR_CHECK,
             pr_info,
         )
-        update_mergeable_check(commit, pr_info, PR_CHECK)
-    else:
-        set_mergeable_check(commit, "skipped", state="success")
+        # allow the workflow to continue
 
-    ci_report_url = create_ci_report(pr_info, [])
     if not can_run:
         print("::notice ::Cannot run")
-        post_commit_status(
-            commit,
-            labels_state,
-            ci_report_url,
-            description,
-            CI_STATUS_NAME,
-            pr_info,
-        )
         sys.exit(1)
 
+    ci_report_url = create_ci_report(pr_info, [])
     print("::notice ::Can run")
     post_commit_status(
         commit,

--- a/tests/ci/style_check.py
+++ b/tests/ci/style_check.py
@@ -145,7 +145,7 @@ def main():
     gh = GitHub(get_best_robot_token(), create_cache_dir=False)
     commit = get_commit(gh, pr_info.sha)
 
-    atexit.register(update_mergeable_check, gh, pr_info, NAME)
+    atexit.register(update_mergeable_check, commit, pr_info, NAME)
 
     rerun_helper = RerunHelper(commit, NAME)
     if rerun_helper.is_already_finished_by_status():

--- a/tests/ci/unit_tests_check.py
+++ b/tests/ci/unit_tests_check.py
@@ -187,7 +187,7 @@ def main():
     gh = Github(get_best_robot_token(), per_page=100)
     commit = get_commit(gh, pr_info.sha)
 
-    atexit.register(update_mergeable_check, gh, pr_info, check_name)
+    atexit.register(update_mergeable_check, commit, pr_info, check_name)
 
     rerun_helper = RerunHelper(commit, check_name)
     if rerun_helper.is_already_finished_by_status():


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
separate status created "PR check" to indicate PR readiness (formatting, added docs), managed by run_check.py

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
