### PR TITLE
Small improvement for SystemLogBase

### DIFF
--- a/src/Common/SystemLogBase.cpp
+++ b/src/Common/SystemLogBase.cpp
@@ -188,6 +188,9 @@ typename SystemLogQueue<LogElement>::Index SystemLogQueue<LogElement>::pop(std::
                                                                            bool & should_prepare_tables_anyway,
                                                                            bool & exit_this_thread)
 {
+    /// Call dtors and deallocate strings without holding the global lock
+    output.resize(0);
+
     std::unique_lock lock(mutex);
     flush_event.wait_for(lock,
         std::chrono::milliseconds(settings.flush_interval_milliseconds),
@@ -200,7 +203,6 @@ typename SystemLogQueue<LogElement>::Index SystemLogQueue<LogElement>::pop(std::
     queue_front_index += queue.size();
     // Swap with existing array from previous flush, to save memory
     // allocations.
-    output.resize(0);
     queue.swap(output);
 
     should_prepare_tables_anyway = is_force_prepare_tables;


### PR DESCRIPTION

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Some interesting stacktraces: https://pastila.nl/?000210e9/890337be9277a5ab8d24698b32ba94f1#+olK8V9KMUs3eUtPwBrH9Q==

There are a lot of threads waiting in
```
| | | | | | | | | | | 251  0x000000000c8b58b5 in DB::SystemLogQueue<DB::TextLogElement>::push(DB::TextLogElement&&) ()
| | | | | | | | | | | | 251  0x00007f4c17c42002 in pthread_mutex_lock () from /lib/x86_64-linux-gnu/libc.so.6
```
And one thread holding the lock and deallocating some strings:
```
| | | | 2    0x0000000012456acb in DB::SystemLog<DB::TextLogElement>::savingThreadFunction() ()
| | | | | 2    0x000000000c8c6c5f in DB::SystemLogQueue<DB::TextLogElement>::pop(std::__1::vector<DB::TextLogElement, std::__1::allocator<DB::TextLogElement> >&, bool&, bool&) ()
| | | | | | 1    0x000000000c8d1343 in void std::__1::__destroy_at[abi:v15000]<DB::TextLogElement, 0>(DB::TextLogElement*) ()
| | | | | | | 1    0x0000000015f2dee4 in sdallocx_default ()
| | | | | | | | 1    0x0000000015fc17fc in tcache_bin_flush_small ()
| | | | | | | | | 1    0x0000000015f3c6b4 in arena_decay ()
| | | | | | | | | | 1    0x0000000015f4433c in arena_decay_impl.llvm ()
| | | | | | | | | | | 1    0x0000000015f870e2 in pac_maybe_decay_purge ()
| | | | | | | | | | | | 1    0x0000000015f86e5c in pac_decay_to_limit.llvm ()
| | | | | | | | | | | | | 1    0x0000000015f4da39 in extent_purge_lazy_impl.llvm ()
| | | | | | | | | | | | | | 1    0x00007f4c17cc898b in madvise () from /lib/x86_64-linux-gnu/libc.so.6
```

(looks like it was amplified by another issue with `madvise` performance)