### PR TITLE
Updating query cache doc with security consideration

### DIFF
--- a/docs/en/operations/query-cache.md
+++ b/docs/en/operations/query-cache.md
@@ -33,7 +33,6 @@ This reduces maintenance effort and avoids redundancy.
 The cached query result is tied to the user executing it. Authorization checks are performed when the query is executed, meaning that if there are any alterations to the user's role or permissions between one cached query and the next query, the query result will not reflect these changes. We recommend using different users to distingush between different level of access, instead of actively toggling roles for a single user between queries, as this practice may lead to unexpected query results.
 :::
 
-
 ## Configuration Settings and Usage
 
 Setting [use_query_cache](settings/settings.md#use-query-cache) can be used to control whether a specific query or all queries of the

--- a/docs/en/operations/query-cache.md
+++ b/docs/en/operations/query-cache.md
@@ -30,7 +30,7 @@ the same caching logic and configuration is often duplicated. With ClickHouse's 
 This reduces maintenance effort and avoids redundancy.
 
 :::security consideration
-The cached query result is tied to the user executing it. Authorization checks are performed when the query is executed, meaning that if there are any alterations to the user's role or permissions between one cached query and the next query, the query result will not reflect these changes. We recommend using different users to distingush between different level of access, instead of actively toggling roles for a single user between queries, as this practice may lead to unexpected query results.
+The cached query result is tied to the user executing it. Authorization checks are performed when the query is executed. This means that if there are any alterations to the user's role or permissions between the time the query is cached and when the cache is accessed, the result will not reflect these changes. We recommend using different users to distinguish between different levels of access, instead of actively toggling roles for a single user between queries, as this practice may lead to unexpected query results.
 :::
 
 ## Configuration Settings and Usage

--- a/docs/en/operations/query-cache.md
+++ b/docs/en/operations/query-cache.md
@@ -29,6 +29,11 @@ Transactionally inconsistent caching is traditionally provided by client tools o
 the same caching logic and configuration is often duplicated. With ClickHouse's query cache, the caching logic moves to the server side.
 This reduces maintenance effort and avoids redundancy.
 
+:::security consideration
+The cached query result is tied to the user executing it. Authorization checks are performed when the query is executed, meaning that if there are any alterations to the user's role or permissions between one cached query and the next query, the query result will not reflect these changes. We recommend using different users to distingush between different level of access, instead of actively toggling roles for a single user between queries, as this practice may lead to unexpected query results.
+:::
+
+
 ## Configuration Settings and Usage
 
 Setting [use_query_cache](settings/settings.md#use-query-cache) can be used to control whether a specific query or all queries of the


### PR DESCRIPTION
Updating the query cache documentation to include a security consideration about the behaviour of query cache. At the moment, we do not flush the cache or discard cache result when user switch roles or when their permission is updated on the fly, as such, the previous cached result (before permission being updated) will be shown until it expires.

### Changelog category (leave one):
- Documentation (changelog entry is not required)

