### PR TITLE
Improve logging format in integration tests

### DIFF
--- a/tests/integration/ci-runner.py
+++ b/tests/integration/ci-runner.py
@@ -195,7 +195,7 @@ def clear_ip_tables_and_restart_daemons():
             shell=True,
         )
     except subprocess.CalledProcessError as err:
-        logging.info("docker kill excepted: " + str(err))
+        logging.info("docker kill excepted: %s", str(err))
 
     try:
         logging.info("Removing all docker containers")
@@ -204,7 +204,7 @@ def clear_ip_tables_and_restart_daemons():
             shell=True,
         )
     except subprocess.CalledProcessError as err:
-        logging.info("docker rm excepted: " + str(err))
+        logging.info("docker rm excepted: %s", str(err))
 
     # don't restart docker if it's disabled
     if os.environ.get("CLICKHOUSE_TESTS_RUNNER_RESTART_DOCKER", "1") == "1":
@@ -212,7 +212,7 @@ def clear_ip_tables_and_restart_daemons():
             logging.info("Stopping docker daemon")
             subprocess.check_output("service docker stop", shell=True)
         except subprocess.CalledProcessError as err:
-            logging.info("docker stop excepted: " + str(err))
+            logging.info("docker stop excepted: %s", str(err))
 
         try:
             for i in range(200):
@@ -227,7 +227,7 @@ def clear_ip_tables_and_restart_daemons():
             else:
                 raise Exception("Docker daemon doesn't responding")
         except subprocess.CalledProcessError as err:
-            logging.info("Can't reload docker: " + str(err))
+            logging.info("Can't reload docker: %s", str(err))
 
     iptables_iter = 0
     try:
@@ -340,7 +340,7 @@ class ClickhouseIntegrationTestsRunner:
                 )
                 return
             except subprocess.CalledProcessError as err:
-                logging.info("docker-compose pull failed: " + str(err))
+                logging.info("docker-compose pull failed: %s", str(err))
                 continue
         logging.error("Pulling images failed for 5 attempts. Will fail the worker.")
         # We pass specific retcode to to ci/integration_test_check.py to skip status reporting and restart job
@@ -376,7 +376,7 @@ class ClickhouseIntegrationTestsRunner:
                         if retcode == 0:
                             logging.info("Installation of %s successfull", full_path)
                         else:
-                            raise Exception("Installation of %s failed", full_path)
+                            raise Exception(f"Installation of {full_path} failed")
                     break
             else:
                 raise Exception("Package with {} not found".format(package))
@@ -587,7 +587,7 @@ class ClickhouseIntegrationTestsRunner:
                 broken_tests,
             )
         except Exception as e:
-            logging.info("Failed to run {}:\n{}".format(str(test_group), str(e)))
+            logging.info("Failed to run %s:\n%s", str(test_group), str(e))
             counters = {
                 "ERROR": [],
                 "PASSED": [],
@@ -931,7 +931,7 @@ class ClickhouseIntegrationTestsRunner:
         if self.use_analyzer:
             with open(f"{repo_path}/tests/analyzer_integration_broken_tests.txt") as f:
                 broken_tests = f.read().splitlines()
-            logging.info(f"Broken tests in the list: {len(broken_tests)}")
+            logging.info("Broken tests in the list: %s", len(broken_tests))
 
         for group, tests in items_to_run:
             logging.info("Running test group %s containing %s tests", group, len(tests))

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -32,14 +32,15 @@ def tune_local_port_range():
 def cleanup_environment():
     try:
         if int(os.environ.get("PYTEST_CLEANUP_CONTAINERS", 0)) == 1:
-            logging.debug(f"Cleaning all iptables rules")
+            logging.debug("Cleaning all iptables rules")
             _NetworkManager.clean_all_user_iptables_rules()
         result = run_and_check(["docker ps | wc -l"], shell=True)
         if int(result) > 1:
             if int(os.environ.get("PYTEST_CLEANUP_CONTAINERS", 0)) != 1:
                 logging.warning(
-                    f"Docker containters({int(result)}) are running before tests run. They can be left from previous pytest run and cause test failures.\n"
-                    "You can set env PYTEST_CLEANUP_CONTAINERS=1 or use runner with --cleanup-containers argument to enable automatic containers cleanup."
+                    "Docker containters(%d) are running before tests run. They can be left from previous pytest run and cause test failures.\n"
+                    "You can set env PYTEST_CLEANUP_CONTAINERS=1 or use runner with --cleanup-containers argument to enable automatic containers cleanup.",
+                    int(result),
                 )
             else:
                 logging.debug("Trying to kill unstopped containers...")
@@ -54,10 +55,10 @@ def cleanup_environment():
                     nothrow=True,
                 )
                 logging.debug("Unstopped containers killed")
-                r = run_and_check(["docker-compose", "ps", "--services", "--all"])
-                logging.debug(f"Docker ps before start:{r.stdout}")
+                out = run_and_check(["docker-compose", "ps", "--services", "--all"])
+                logging.debug("Docker ps before start: %s", out)
         else:
-            logging.debug(f"No running containers")
+            logging.debug("No running containers")
 
         logging.debug("Pruning Docker networks")
         run_and_check(
@@ -66,7 +67,7 @@ def cleanup_environment():
             nothrow=True,
         )
     except Exception as e:
-        logging.exception(f"cleanup_environment:{str(e)}")
+        logging.exception("cleanup_environment: %s", str(e))
         pass
 
     yield

--- a/tests/integration/helpers/client.py
+++ b/tests/integration/helpers/client.py
@@ -230,7 +230,7 @@ class CommandRequest:
             and not self.process_finished_before_timeout
             and not self.ignore_error
         ):
-            logging.debug(f"Timed out. Last stdout:{stdout}, stderr:{stderr}")
+            logging.debug("Timed out. Last stdout: %s, stderr: %s", stdout, stderr)
             raise QueryTimeoutExceedException("Client timed out!")
 
         if (

--- a/tests/integration/helpers/external_sources.py
+++ b/tests/integration/helpers/external_sources.py
@@ -77,7 +77,11 @@ class SourceMySQL(ExternalSource):
 
     def create_mysql_conn(self):
         logging.debug(
-            f"pymysql connect {self.user}, {self.password}, {self.internal_hostname}, {self.internal_port}"
+            "pymysql connect %s, %s, %s, %s",
+            self.user,
+            self.password,
+            self.internal_hostname,
+            self.internal_port,
         )
         self.connection = pymysql.connect(
             user=self.user,

--- a/tests/integration/helpers/hdfs_api.py
+++ b/tests/integration/helpers/hdfs_api.py
@@ -87,7 +87,7 @@ class HDFSApi(object):
             raise Exception("kerberos principal and keytab are required")
 
         with mk_krb_conf(self.krb_conf, self.kdc_ip) as instantiated_krb_conf:
-            logging.debug("instantiated_krb_conf {}".format(instantiated_krb_conf))
+            logging.debug("instantiated_krb_conf %s", instantiated_krb_conf)
 
             os.environ["KRB5_CONFIG"] = instantiated_krb_conf
 
@@ -105,12 +105,12 @@ class HDFSApi(object):
                     if res.returncode != 0:
                         # check_call(...) from subprocess does not print stderr, so we do it manually
                         logging.debug(
-                            "Stderr:\n{}\n".format(res.stderr.decode("utf-8"))
+                            "Stderr:\n%s\n", res.stderr.decode("utf-8")
                         )
                         logging.debug(
-                            "Stdout:\n{}\n".format(res.stdout.decode("utf-8"))
+                            "Stdout:\n%s\n", res.stdout.decode("utf-8")
                         )
-                        logging.debug("Env:\n{}\n".format(env))
+                        logging.debug("Env:\n%s\n", env)
                         raise Exception(
                             "Command {} return non-zero code {}: {}".format(
                                 args, res.returncode, res.stderr.decode("utf-8")
@@ -120,7 +120,7 @@ class HDFSApi(object):
                     logging.debug("KDC started, kinit successfully run")
                     return
                 except Exception as ex:
-                    logging.debug("Can't run kinit ... waiting {}".format(str(ex)))
+                    logging.debug("Can't run kinit ... waiting %s", str(ex))
                     time.sleep(1)
 
         raise Exception("Kinit running failure")
@@ -128,30 +128,29 @@ class HDFSApi(object):
     @staticmethod
     def req_wrapper(func, expected_code, cnt=2, **kwargs):
         for i in range(0, cnt):
-            logging.debug(f"CALL: {str(kwargs)}")
+            logging.debug("CALL: %s", str(kwargs))
             response_data = func(**kwargs)
             logging.debug(
-                f"response_data:{response_data.content} headers:{response_data.headers}"
+                "response_data:%s headers:%s", response_data.content, response_data.headers
             )
             if response_data.status_code == expected_code:
                 return response_data
             else:
                 logging.error(
-                    f"unexpected response_data.status_code {response_data.status_code} != {expected_code}"
+                    "unexpected response_data.status_code %s != %s", response_data.status_code, expected_code
                 )
                 time.sleep(1)
         response_data.raise_for_status()
 
     def read_data(self, path, universal_newlines=True):
         logging.debug(
-            "read_data protocol:{} host:{} ip:{} proxy port:{} data port:{} path: {}".format(
-                self.protocol,
-                self.host,
-                self.hdfs_ip,
-                self.proxy_port,
-                self.data_port,
-                path,
-            )
+            "read_data protocol:%s host:%s ip:%s proxy port:%s data port:%s path: %s",
+            self.protocol,
+            self.host,
+            self.hdfs_ip,
+            self.proxy_port,
+            self.data_port,
+            path,
         )
         response = self.req_wrapper(
             requests.get,
@@ -174,7 +173,7 @@ class HDFSApi(object):
             location = response.headers["Location"].replace(
                 "hdfs1:50075", "{}:{}".format(self.hdfs_ip, self.data_port)
             )
-        logging.debug("redirected to {}".format(location))
+        logging.debug("redirected to %s", location)
 
         response_data = self.req_wrapper(
             requests.get,
@@ -192,14 +191,13 @@ class HDFSApi(object):
 
     def write_data(self, path, content):
         logging.debug(
-            "write_data protocol:{} host:{} port:{} path: {} user:{}, principal:{}".format(
-                self.protocol,
-                self.host,
-                self.proxy_port,
-                path,
-                self.user,
-                self.principal,
-            )
+            "write_data protocol:%s host:%s port:%s path: %s user:%s, principal:%s",
+            self.protocol,
+            self.host,
+            self.proxy_port,
+            path,
+            self.user,
+            self.principal,
         )
         named_file = NamedTemporaryFile(mode="wb+")
         fpath = named_file.name
@@ -225,7 +223,7 @@ class HDFSApi(object):
             auth=self.kerberos_auth,
         )
 
-        logging.debug("HDFS api response:{}".format(response.headers))
+        logging.debug("HDFS api response:%s", response.headers)
 
         # additional_params = '&'.join(
         #     response.headers['Location'].split('&')[1:2] + ["user.name={}".format(self.user), "overwrite=true"])
@@ -252,7 +250,7 @@ class HDFSApi(object):
                 verify=False,
                 auth=self.kerberos_auth,
             )
-            logging.debug(f"{response.content} {response.headers}")
+            logging.debug("%s %s", response.content, response.headers)
 
     def write_gzip_data(self, path, content):
         if isinstance(content, str):

--- a/tests/integration/helpers/mock_servers.py
+++ b/tests/integration/helpers/mock_servers.py
@@ -15,7 +15,7 @@ def start_mock_servers(cluster, script_dir, mocks, timeout=100):
     server_names_with_desc = (
         f"{'server' if len(server_names) == 1 else 'servers'} {','.join(server_names)}"
     )
-    logging.info(f"Starting mock {server_names_with_desc}")
+    logging.info("Starting mock %s", server_names_with_desc)
 
     start_time = time.time()
     mocks_to_check = {}
@@ -51,7 +51,10 @@ def start_mock_servers(cluster, script_dir, mocks, timeout=100):
 
             if ping_response == "OK":
                 logging.debug(
-                    f"{server_name} answered {ping_response} on attempt {attempt}"
+                    "%s answered %s on attempt %s",
+                    server_name,
+                    ping_response,
+                    attempt
                 )
                 del mocks_to_check[server_name]
             elif time.time() - start_time > timeout:
@@ -65,7 +68,7 @@ def start_mock_servers(cluster, script_dir, mocks, timeout=100):
             time.sleep(1)
             attempt += 1
 
-    logging.info(f"Mock {server_names_with_desc} started")
+    logging.info("Mock %s started", server_names_with_desc)
 
 
 # The same as start_mock_servers, but

--- a/tests/integration/helpers/network.py
+++ b/tests/integration/helpers/network.py
@@ -173,10 +173,9 @@ class _NetworkManager:
 
             if res.returncode != 0:
                 logging.info(
-                    "All iptables rules cleared, "
-                    + str(iptables_iter)
-                    + " iterations, last error: "
-                    + str(res.stderr)
+                    "All iptables rules cleared, %s iterations, last error: %s",
+                    str(iptables_iter),
+                    str(res.stderr)
                 )
                 return
 
@@ -296,7 +295,7 @@ class _NetworkManager:
             try:
                 self._exec_run(cmd, **kwargs)
             except subprocess.CalledProcessError as e:
-                logging.error(f"_exec_run failed for {cmd}, {e}")
+                logging.error("_exec_run failed for %s, %s", cmd, e)
 
     def _exec_run(self, cmd, **kwargs):
         container = self._ensure_container()

--- a/tests/integration/helpers/test_tools.py
+++ b/tests/integration/helpers/test_tools.py
@@ -95,7 +95,7 @@ def assert_eq_with_retry(
                 break
             time.sleep(sleep_time)
         except Exception as ex:
-            logging.exception(f"assert_eq_with_retry retry {i+1} exception {ex}")
+            logging.exception("assert_eq_with_retry retry %s exception %s", i + 1, ex)
             time.sleep(sleep_time)
     else:
         val = TSV(
@@ -132,7 +132,7 @@ def assert_logs_contain_with_retry(instance, substring, retry_count=20, sleep_ti
                 break
             time.sleep(sleep_time)
         except Exception as ex:
-            logging.exception(f"contains_in_log_with_retry retry {i+1} exception {ex}")
+            logging.exception("contains_in_log_with_retry retry %s exception %s", i + 1, ex)
             time.sleep(sleep_time)
     else:
         raise AssertionError("'{}' not found in logs".format(substring))
@@ -146,13 +146,16 @@ def exec_query_with_retry(
         try:
             res = instance.query(query, timeout=30, settings=settings)
             if not silent:
-                logging.debug(f"Result of {query} on {cnt} try is {res}")
+                logging.debug("Result of %s on %s try is %s", query, cnt, res)
             break
         except Exception as ex:
             exception = ex
             if not silent:
                 logging.exception(
-                    f"Failed to execute query '{query}' on  {cnt} try on instance '{instance.name}' will retry"
+                    "Failed to execute query '%s' on  %s try on instance '%s' will retry",
+                    query,
+                    cnt,
+                    instance.name
                 )
             time.sleep(sleep_time)
     else:

--- a/tests/integration/test_allowed_client_hosts/test.py
+++ b/tests/integration/test_allowed_client_hosts/test.py
@@ -26,7 +26,7 @@ def query_from_one_node_to_another(client_node, server_node, query):
     res3 = client_node.exec_in_container(["host", "clientA2.com"])
     res4 = client_node.exec_in_container(["host", "clientA3.com"])
 
-    logging.debug(f"IP: {res1}, A1 {res2}, A2 {res3}, A3 {res4}")
+    logging.debug("IP: %s, A1 %s, A2 %s, A3 %s", res1, res2, res3, res4)
 
     return client_node.exec_in_container(
         [
@@ -59,7 +59,7 @@ def setup_nodes():
         a2 = query(clientA2, "SELECT fqdn(), hostName()")
         a3 = query(clientA3, "SELECT fqdn(), hostName()")
 
-        logging.debug(f"s:{s}, a1:{a1}, a2:{a2}, a3:{a3}")
+        logging.debug("s:%s, a1:%s, a2:%s, a3:%s", s, a1, a2, a3)
 
         yield cluster
 

--- a/tests/integration/test_attach_without_fetching/test.py
+++ b/tests/integration/test_attach_without_fetching/test.py
@@ -76,7 +76,7 @@ def check_data(nodes, detached_parts):
         for other in nodes:
             if other != node:
                 logging.debug(
-                    f"> Checking data consistency, {other.name} vs {node.name}"
+                    "> Checking data consistency, %s vs %s", other.name, node.name
                 )
                 assert_eq_with_retry(other, "SELECT * FROM test ORDER BY n", res)
 
@@ -124,7 +124,7 @@ def test_attach_without_fetching(start_cluster):
         ],
         privileged=True,
     )
-    logging.debug(f"Before deleting: {to_delete}")
+    logging.debug("Before deleting: %s", to_delete)
 
     node_2.exec_in_container(
         [

--- a/tests/integration/test_backup_restore/test.py
+++ b/tests/integration/test_backup_restore/test.py
@@ -54,7 +54,7 @@ def get_last_backup_path(instance, database, table):
 def copy_backup_to_detached(instance, database, src_table, dst_table):
     fp_backup = os.path.join(path_to_data, "shadow", "*", "data", database, src_table)
     fp_detached = os.path.join(path_to_data, "data", database, dst_table, "detached")
-    logging.debug(f"copy from {fp_backup} to {fp_detached}")
+    logging.debug("copy from %s to %s", fp_backup, fp_detached)
     instance.exec_in_container(["bash", "-c", f"cp -r {fp_backup} -T {fp_detached}"])
 
 

--- a/tests/integration/test_cluster_copier/test_three_nodes.py
+++ b/tests/integration/test_cluster_copier/test_three_nodes.py
@@ -240,7 +240,7 @@ def execute_task(started_cluster, task, cmd_options):
     ]
     cmd += cmd_options
 
-    logging.debug(f"execute_task cmd: {cmd}")
+    logging.debug("execute_task cmd: %s", cmd)
 
     for instance_name in started_cluster.instances.keys():
         instance = started_cluster.instances[instance_name]
@@ -249,13 +249,13 @@ def execute_task(started_cluster, task, cmd_options):
             os.path.join(CURRENT_TEST_DIR, "configs_three_nodes/config-copier.xml"),
             "/etc/clickhouse-server/config-copier.xml",
         )
-        logging.info("Copied copier config to {}".format(instance.name))
+        logging.info("Copied copier config to %s", instance.name)
         exec_id = docker_api.exec_create(container.id, cmd, stderr=True)
         output = docker_api.exec_start(exec_id).decode("utf8")
         logging.info(output)
         copiers_exec_ids.append(exec_id)
         logging.info(
-            "Copier for {} ({}) has started".format(instance.name, instance.ip_address)
+            "Copier for %s (%s) has started", instance.name, instance.ip_address
         )
 
     # time.sleep(1000)

--- a/tests/integration/test_cluster_copier/test_two_nodes.py
+++ b/tests/integration/test_cluster_copier/test_two_nodes.py
@@ -566,13 +566,13 @@ def execute_task(started_cluster, task, cmd_options):
             os.path.join(CURRENT_TEST_DIR, "configs_two_nodes/config-copier.xml"),
             "/etc/clickhouse-server/config-copier.xml",
         )
-        logging.info("Copied copier config to {}".format(instance.name))
+        logging.info("Copied copier config to %s", instance.name)
         exec_id = docker_api.exec_create(container.id, cmd, stderr=True)
         output = docker_api.exec_start(exec_id).decode("utf8")
         logging.info(output)
         copiers_exec_ids.append(exec_id)
         logging.info(
-            "Copier for {} ({}) has started".format(instance.name, instance.ip_address)
+            "Copier for %s (%s) has started", instance.name, instance.ip_address
         )
 
     # time.sleep(1000)

--- a/tests/integration/test_concurrent_ttl_merges/test.py
+++ b/tests/integration/test_concurrent_ttl_merges/test.py
@@ -48,7 +48,8 @@ def count_ttl_merges_in_background_pool(node, table, level):
     count = len(result)
     if count >= level:
         logging.debug(
-            f"count_ttl_merges_in_background_pool: merges more than warn level:\n{result}"
+            "count_ttl_merges_in_background_pool: merges more than warn level:\n%s",
+            result
         )
     return count
 
@@ -89,7 +90,7 @@ def test_no_ttl_merges_in_busy_pool(started_cluster):
     node1.query("ALTER TABLE test_ttl UPDATE data = data + 1 WHERE sleepEachRow(1) = 0")
 
     while count_running_mutations(node1, "test_ttl") < 6:
-        logging.debug(f"Mutations count {count_running_mutations(node1, 'test_ttl')}")
+        logging.debug("Mutations count %s", count_running_mutations(node1, 'test_ttl'))
         assert count_ttl_merges_in_background_pool(node1, "test_ttl", 1) == 0
         time.sleep(0.5)
 
@@ -98,7 +99,7 @@ def test_no_ttl_merges_in_busy_pool(started_cluster):
     rows_count = []
     while count_running_mutations(node1, "test_ttl") == 6:
         logging.debug(
-            f"Mutations count after start TTL{count_running_mutations(node1, 'test_ttl')}"
+            "Mutations count after start TTL%s", count_running_mutations(node1, 'test_ttl')
         )
         rows_count.append(int(node1.query("SELECT count() FROM test_ttl").strip()))
         time.sleep(0.5)

--- a/tests/integration/test_create_user_and_login/test.py
+++ b/tests/integration/test_create_user_and_login/test.py
@@ -93,10 +93,10 @@ EOF""",
                 if (expected_error in err)
             ]
             if found_error:
-                logging.debug(f"Got error '{found_error}' just as expected")
+                logging.debug("Got error '%s' just as expected", found_error)
                 break
             if out == "1\n":
-                logging.debug(f"Got output '1', retrying...")
+                logging.debug("Got output '1', retrying...")
                 time.sleep(0.5)
                 continue
             raise Exception(

--- a/tests/integration/test_default_compression_codec/test.py
+++ b/tests/integration/test_default_compression_codec/test.py
@@ -436,7 +436,7 @@ def test_default_codec_version_update(start_cluster):
     old_version = node3.query("SELECT version()")
     node3.restart_with_latest_version(fix_metadata=True)
     new_version = node3.query("SELECT version()")
-    logging.debug(f"Updated from {old_version} to {new_version}")
+    logging.debug("Updated from %s to %s", old_version, new_version)
     assert (
         node3.query(
             "SELECT default_compression_codec FROM system.parts WHERE table = 'compression_table' and name = '1_1_1_0'"
@@ -492,7 +492,7 @@ def test_default_codec_version_update(start_cluster):
     node3.restart_with_original_version(callback_onstop=callback)
 
     cur_version = node3.query("SELECT version()")
-    logging.debug(f"End with {cur_version}")
+    logging.debug("End with %s", cur_version)
 
 
 def test_default_codec_for_compact_parts(start_cluster):

--- a/tests/integration/test_dictionaries_ddl/test.py
+++ b/tests/integration/test_dictionaries_ddl/test.py
@@ -50,15 +50,14 @@ node4 = cluster.add_instance(
 
 def create_mysql_conn(user, password, hostname, port):
     logging.debug(
-        "Created MySQL connection user:{}, password:{}, host:{}, port{}".format(
-            user, password, hostname, port
-        )
+        "Created MySQL connection user:%s, password:%s, host:%s, port:%s",
+        user, password, hostname, port
     )
     return pymysql.connect(user=user, password=password, host=hostname, port=port)
 
 
 def execute_mysql_query(connection, query):
-    logging.debug("Execute MySQL query:{}".format(query))
+    logging.debug("Execute MySQL query:%s", query)
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
         with connection.cursor() as cursor:

--- a/tests/integration/test_dictionaries_mysql/test.py
+++ b/tests/integration/test_dictionaries_mysql/test.py
@@ -378,7 +378,9 @@ def get_mysql_conn(started_cluster):
             else:
                 conn.ping(reconnect=True)
             logging.debug(
-                f"MySQL Connection establised: {started_cluster.mysql_ip}:{started_cluster.mysql_port}"
+                "MySQL Connection establised: %s:%s",
+                started_cluster.mysql_ip,
+                started_cluster.mysql_port
             )
             return conn
         except Exception as e:
@@ -389,7 +391,7 @@ def get_mysql_conn(started_cluster):
 
 
 def execute_mysql_query(connection, query):
-    logging.debug("Execute MySQL query:{}".format(query))
+    logging.debug("Execute MySQL query:%s", query)
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
         with connection.cursor() as cursor:

--- a/tests/integration/test_dictionaries_redis/test.py
+++ b/tests/integration/test_dictionaries_redis/test.py
@@ -121,7 +121,7 @@ def generate_dict_configs():
             for layout in LAYOUTS:
                 if not source.compatible_with_layout(layout):
                     logging.debug(
-                        f"Source {source.name} incompatible with layout {layout.name}"
+                        "Source %s incompatible with layout %s", source.name, layout.name
                     )
                     continue
 
@@ -132,7 +132,7 @@ def generate_dict_configs():
     dictionaries = []
     for fname in os.listdir(dict_configs_path):
         path = os.path.join(dict_configs_path, fname)
-        logging.debug(f"Found dictionary {path}")
+        logging.debug("Found dictionary %s", path)
         dictionaries.append(path)
 
     node = cluster.add_instance(
@@ -149,9 +149,9 @@ def started_cluster():
         assert len(FIELDS) == len(VALUES)
         for dicts in DICTIONARIES:
             for dictionary in dicts:
-                logging.debug(f"Preparing {dictionary.name}")
+                logging.debug("Preparing %s", dictionary.name)
                 dictionary.prepare_source(cluster)
-                logging.debug(f"Prepared {dictionary.name}")
+                logging.debug(f"Prepared %s", dictionary.name)
 
         yield cluster
 
@@ -165,7 +165,7 @@ def get_entity_id(entity):
 
 @pytest.mark.parametrize("id", list(range(len(FIELDS))), ids=get_entity_id)
 def test_redis_dictionaries(started_cluster, id):
-    logging.debug(f"Run test with id: {id}")
+    logging.debug("Run test with id: %s", id)
 
     dicts = DICTIONARIES[id]
     values = VALUES[id]

--- a/tests/integration/test_external_http_authenticator/test.py
+++ b/tests/integration/test_external_http_authenticator/test.py
@@ -39,7 +39,7 @@ def run_echo_server():
             ["curl", "-s", f"http://localhost:8000/health"],
             nothrow=True,
         )
-        logging.debug(f"Reply1: {ping_response}")
+        logging.debug("Reply1: %s", ping_response)
         if ping_response == "OK":
             return
 

--- a/tests/integration/test_format_avro_confluent/test.py
+++ b/tests/integration/test_format_avro_confluent/test.py
@@ -29,7 +29,7 @@ def started_cluster():
 def run_query(instance, query, data=None, settings=None):
     # type: (ClickHouseInstance, str, object, dict) -> str
 
-    logging.info("Running query '{}'...".format(query))
+    logging.info("Running query '%s'...", query)
     # use http to force parsing on server
     if not data:
         data = " "  # make POST request

--- a/tests/integration/test_jdbc_bridge/test.py
+++ b/tests/integration/test_jdbc_bridge/test.py
@@ -34,12 +34,12 @@ def started_cluster():
             datasources = instance.query("select * from jdbc('', 'show datasources')")
             if "self" in datasources:
                 logging.debug(
-                    f"JDBC Driver self datasource initialized.\n{datasources}"
+                    "JDBC Driver self datasource initialized.\n%s", datasources
                 )
                 break
             else:
                 logging.debug(
-                    f"Waiting JDBC Driver to initialize 'self' datasource.\n{datasources}"
+                    "Waiting JDBC Driver to initialize 'self' datasource.\n%s", datasources
                 )
         yield cluster
     finally:
@@ -88,7 +88,7 @@ def test_jdbc_insert(started_cluster):
         """
         CREATE TABLE test.test_insert ENGINE = Memory AS
         SELECT * FROM test.ClickHouseTable;
-        SELECT * 
+        SELECT *
         FROM jdbc('{0}?mutation', 'INSERT INTO test.test_insert VALUES({1}, ''{1}'', ''{1}'')');
     """.format(
             datasource, records
@@ -112,7 +112,7 @@ def test_jdbc_update(started_cluster):
         """
         CREATE TABLE test.test_update ENGINE = Memory AS
         SELECT * FROM test.ClickHouseTable;
-        SELECT * 
+        SELECT *
         FROM jdbc(
             '{}?mutation',
             'SET mutations_sync = 1; ALTER TABLE test.test_update UPDATE Str=''{}'' WHERE Num = {} - 1;'
@@ -142,7 +142,7 @@ def test_jdbc_delete(started_cluster):
         """
         CREATE TABLE test.test_delete ENGINE = Memory AS
         SELECT * FROM test.ClickHouseTable;
-        SELECT * 
+        SELECT *
         FROM jdbc(
             '{}?mutation',
             'SET mutations_sync = 1; ALTER TABLE test.test_delete DELETE WHERE Num < {} - 1;'

--- a/tests/integration/test_kafka_bad_messages/test.py
+++ b/tests/integration/test_kafka_bad_messages/test.py
@@ -43,7 +43,7 @@ def kafka_create_topic(
             retries += 1
             time.sleep(0.5)
             if retries < max_retries:
-                logging.warning(f"Failed to create topic {e}")
+                logging.warning("Failed to create topic %s", e)
             else:
                 raise
 
@@ -52,14 +52,14 @@ def kafka_delete_topic(admin_client, topic, max_retries=50):
     result = admin_client.delete_topics([topic])
     for topic, e in result.topic_error_codes:
         if e == 0:
-            logging.debug(f"Topic {topic} deleted")
+            logging.debug("Topic %s deleted", topic)
         else:
-            logging.error(f"Failed to delete topic {topic}: {e}")
+            logging.error("Failed to delete topic %s: %s", topic, e)
 
     retries = 0
     while True:
         topics_listed = admin_client.list_topics()
-        logging.debug(f"TOPICS LISTED: {topics_listed}")
+        logging.debug("TOPICS LISTED: %s", topics_listed)
         if topic not in topics_listed:
             return
         else:
@@ -77,7 +77,7 @@ def get_kafka_producer(port, serializer, retries):
                 bootstrap_servers="localhost:{}".format(port),
                 value_serializer=serializer,
             )
-            logging.debug("Kafka Connection establised: localhost:{}".format(port))
+            logging.debug("Kafka Connection establised: localhost:%s", port)
             return producer
         except Exception as e:
             errors += [str(e)]
@@ -94,9 +94,7 @@ def kafka_produce(
     kafka_cluster, topic, messages, timestamp=None, retries=15, partition=None
 ):
     logging.debug(
-        "kafka_produce server:{}:{} topic:{}".format(
-            "localhost", kafka_cluster.kafka_port, topic
-        )
+        "kafka_produce server:localhost:%s topic:%s", kafka_cluster.kafka_port, topic
     )
     producer = get_kafka_producer(
         kafka_cluster.kafka_port, producer_serializer, retries

--- a/tests/integration/test_ldap_external_user_directory/test.py
+++ b/tests/integration/test_ldap_external_user_directory/test.py
@@ -43,7 +43,7 @@ ldapadd -H ldap://{host}:{port} -D "{admin_bind_dn}" -x -w {admin_password}
         demux=True,
     )
     logging.debug(
-        f"test_ldap_external_user_directory code:{code} stdout:{stdout}, stderr:{stderr}"
+        "test_ldap_external_user_directory code:%s stdout:%s, stderr:%s", code, stdout, stderr
     )
     assert code == 0
 

--- a/tests/integration/test_library_bridge/test_exiled.py
+++ b/tests/integration/test_library_bridge/test_exiled.py
@@ -88,7 +88,7 @@ def test_bridge_dies_with_parent(ch_cluster):
             privileged=True,
             user="root",
         )
-        logging.debug(f"Bridge is running, gdb output:\n{out}")
+        logging.debug("Bridge is running, gdb output:\n%s", out)
 
     try:
         assert clickhouse_pid is None

--- a/tests/integration/test_manipulate_statistic/test.py
+++ b/tests/integration/test_manipulate_statistic/test.py
@@ -41,7 +41,7 @@ def check_stat_file_on_disk(node, table, part_name, column_name, exist):
         privileged=True,
     )
     logging.debug(
-        f"Checking stat file in {part_path} for column {column_name}, got {output}"
+        "Checking stat file in %s for column %s, got %s", part_path, column_name, output
     )
     if exist:
         assert len(output) != 0

--- a/tests/integration/test_materialized_mysql_database/materialized_with_ddl.py
+++ b/tests/integration/test_materialized_mysql_database/materialized_with_ddl.py
@@ -31,10 +31,10 @@ def check_query(
             if result_set == latest_result:
                 return
 
-            logging.debug(f"latest_result {latest_result}")
+            logging.debug("latest_result %s", latest_result)
             time.sleep(interval_seconds)
         except Exception as e:
-            logging.debug(f"check_query retry {i+1} exception {e}")
+            logging.debug("check_query retry %s exception %s", i + 1, e)
             time.sleep(interval_seconds)
     else:
         latest_result = clickhouse_node.query(query)

--- a/tests/integration/test_materialized_mysql_database/test.py
+++ b/tests/integration/test_materialized_mysql_database/test.py
@@ -79,9 +79,7 @@ class MySQLConnection:
                 else:
                     self.mysql_connection.ping(reconnect=True)
                 logging.debug(
-                    "MySQL Connection established: {}:{}".format(
-                        self.ip_address, self.port
-                    )
+                    "MySQL Connection established: %s:%s", self.ip_address, self.port
                 )
                 return self.mysql_connection
             except Exception as e:

--- a/tests/integration/test_merge_tree_s3/test.py
+++ b/tests/integration/test_merge_tree_s3/test.py
@@ -122,7 +122,7 @@ def run_s3_mocks(cluster):
 def list_objects(cluster, path="data/", hint="list_objects"):
     minio = cluster.minio_client
     objects = list(minio.list_objects(cluster.minio_bucket, path, recursive=True))
-    logging.info(f"{hint} ({len(objects)}): {[x.object_name for x in objects]}")
+    logging.info("%s (%s): %s", hint, len(objects), [x.object_name for x in objects])
     return objects
 
 

--- a/tests/integration/test_mysql_protocol/test.py
+++ b/tests/integration/test_mysql_protocol/test.py
@@ -160,7 +160,7 @@ def test_mysql_client(started_cluster):
         ),
         demux=True,
     )
-    logging.debug(f"test_mysql_client code:{code} stdout:{stdout}, stderr:{stderr}")
+    logging.debug("test_mysql_client code:%s stdout:%s, stderr:%s", code, stdout, stderr)
     assert stdout.decode() == "\n".join(["1", "1", ""])
 
     code, (stdout, stderr) = started_cluster.mysql_client_container.exec_run(
@@ -605,7 +605,7 @@ def test_mysql_boolean_format(started_cluster):
         demux=True,
     )
     logging.debug(
-        f"test_mysql_boolean_format code:{code} stdout:{stdout}, stderr:{stderr}"
+        "test_mysql_boolean_format code:%s stdout:%s, stderr:%s", code, stdout, stderr
     )
     assert stdout.decode() == "a\tb\tc\n" + "0\t1\t0\n" + "1\t0\t1\n"
 

--- a/tests/integration/test_odbc_interaction/test.py
+++ b/tests/integration/test_odbc_interaction/test.py
@@ -61,7 +61,7 @@ def get_mysql_conn():
             else:
                 conn.ping(reconnect=True)
             logging.debug(
-                f"MySQL Connection establised: {cluster.mysql_ip}:{cluster.mysql_port}"
+                "MySQL Connection establised: %s:%s", cluster.mysql_ip, cluster.mysql_port
             )
             return conn
         except Exception as e:
@@ -95,7 +95,7 @@ def get_postgres_conn(started_cluster):
     for _ in range(15):
         try:
             conn = psycopg2.connect(conn_string)
-            logging.debug("Postgre Connection establised: {}".format(conn_string))
+            logging.debug("Postgre Connection establised: %s", conn_string)
             conn.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
             conn.autocommit = True
             return conn
@@ -119,7 +119,7 @@ def started_cluster():
         cluster.start()
         sqlite_db = node1.odbc_drivers["SQLite3"]["Database"]
 
-        logging.debug(f"sqlite data received: {sqlite_db}")
+        logging.debug("sqlite data received: %s", sqlite_db)
         node1.exec_in_container(
             [
                 "sqlite3",
@@ -461,7 +461,7 @@ def test_sqlite_odbc_hashed_dictionary(started_cluster):
     first_update_time = node1.query(
         "SELECT last_successful_update_time FROM system.dictionaries WHERE name = 'sqlite3_odbc_hashed'"
     )
-    logging.debug(f"First update time {first_update_time}")
+    logging.debug("First update time %s", first_update_time)
 
     assert_eq_with_retry(
         node1, "select dictGetUInt8('sqlite3_odbc_hashed', 'Z', toUInt64(1))", "3"
@@ -474,7 +474,7 @@ def test_sqlite_odbc_hashed_dictionary(started_cluster):
         "SELECT last_successful_update_time FROM system.dictionaries WHERE name = 'sqlite3_odbc_hashed'"
     )
     # Reloaded with new data
-    logging.debug(f"Second update time {second_update_time}")
+    logging.debug("Second update time %s", second_update_time)
     while first_update_time == second_update_time:
         second_update_time = node1.query(
             "SELECT last_successful_update_time FROM system.dictionaries WHERE name = 'sqlite3_odbc_hashed'"
@@ -492,7 +492,7 @@ def test_sqlite_odbc_hashed_dictionary(started_cluster):
     third_update_time = node1.query(
         "SELECT last_successful_update_time FROM system.dictionaries WHERE name = 'sqlite3_odbc_hashed'"
     )
-    logging.debug(f"Third update time {second_update_time}")
+    logging.debug("Third update time %s", third_update_time)
     counter = 0
     while third_update_time == second_update_time:
         third_update_time = node1.query(

--- a/tests/integration/test_odbc_interaction/test_exiled.py
+++ b/tests/integration/test_odbc_interaction/test_exiled.py
@@ -27,7 +27,7 @@ def started_cluster():
         cluster.start()
 
         sqlite_db = node1.odbc_drivers["SQLite3"]["Database"]
-        logging.debug(f"sqlite data received: {sqlite_db}")
+        logging.debug("sqlite data received: %s", sqlite_db)
         node1.exec_in_container(
             [
                 "sqlite3",
@@ -102,7 +102,7 @@ def test_bridge_dies_with_parent(started_cluster):
             privileged=True,
             user="root",
         )
-        logging.debug(f"Bridge is running, gdb output:\n{out}")
+        logging.debug("Bridge is running, gdb output:\n%s", out)
 
     try:
         assert clickhouse_pid is None

--- a/tests/integration/test_render_log_file_name_templates/test.py
+++ b/tests/integration/test_render_log_file_name_templates/test.py
@@ -32,14 +32,14 @@ def test_check_file_names(started_cluster):
     now = datetime.now()
     log_file = log_dir + f"clickhouse-server-{now.strftime('%Y-%m')}.log"
     err_log_file = log_dir + f"clickhouse-server-{now.strftime('%Y-%m')}.err.log"
-    logging.debug(f"log_file {log_file} err_log_file {err_log_file}")
+    logging.debug("log_file %s err_log_file %s", log_file, err_log_file)
 
     for name, instance in started_cluster.instances.items():
         files = instance.exec_in_container(
             ["bash", "-c", f"ls -lh {log_dir}"], nothrow=True
         )
 
-        logging.debug(f"check instance '{name}': {log_dir} contains: {files}")
+        logging.debug("check instance '%s': %s contains: %s", name, log_dir, files)
 
         assert (
             instance.exec_in_container(["bash", "-c", f"ls {log_file}"], nothrow=True)

--- a/tests/integration/test_replicated_mutations/test.py
+++ b/tests/integration/test_replicated_mutations/test.py
@@ -120,7 +120,7 @@ class Runner:
                 i += 1
 
             try:
-                logging.debug(f"thread {thread_num}: insert for {date_str}: {xs}")
+                logging.debug("thread %s: insert for %s: %s", thread_num, date_str, xs)
                 random.choice(self.nodes).query(
                     "INSERT INTO test_mutations FORMAT TSV", payload
                 )
@@ -132,7 +132,7 @@ class Runner:
                     self.total_inserted_rows += len(xs)
 
             except Exception as e:
-                logging.debug(f"Exception while inserting: {e}")
+                logging.debug("Exception while inserting: %s", e)
                 self.exceptions.append(e)
             finally:
                 with self.mtx:
@@ -163,7 +163,7 @@ class Runner:
                 continue
 
             try:
-                logging.debug(f"thread {thread_num}: delete {to_delete_count} * {x}")
+                logging.debug("thread %s: delete %s * %s", thread_num, to_delete_count, x)
                 random.choice(self.nodes).query(
                     "ALTER TABLE test_mutations DELETE WHERE x = {}".format(x)
                 )
@@ -175,7 +175,7 @@ class Runner:
                     self.total_deleted_rows += to_delete_count
 
             except Exception as e:
-                logging.debug(f"Exception while deleting: {e}")
+                logging.debug("Exception while deleting: %s", e)
             finally:
                 with self.mtx:
                     self.currently_deleting_xs.remove(x)
@@ -228,7 +228,7 @@ def test_mutations(started_cluster):
     assert runner.total_mutations > 0
 
     all_done = wait_for_mutations(nodes, runner.total_mutations)
-    logging.debug(f"Total mutations: {runner.total_mutations}")
+    logging.debug("Total mutations: %s", runner.total_mutations)
     for node in nodes:
         logging.debug(
             node.query(

--- a/tests/integration/test_replicated_zero_copy_projection_mutation/test.py
+++ b/tests/integration/test_replicated_zero_copy_projection_mutation/test.py
@@ -72,7 +72,7 @@ def list_objects(cluster, path="data/", hint="list_objects"):
     objects = list(minio.list_objects(cluster.minio_bucket, path, recursive=True))
     names = [x.object_name for x in objects]
     names.sort()
-    logging.info(f"{hint} ({len(objects)}): {names}")
+    logging.info("%s (%s): %s", hint, len(objects), names)
     return names
 
 

--- a/tests/integration/test_storage_hudi/test.py
+++ b/tests/integration/test_storage_hudi/test.py
@@ -72,7 +72,7 @@ def started_cluster():
 def run_query(instance, query, stdin=None, settings=None):
     # type: (ClickHouseInstance, str, object, dict) -> str
 
-    logging.info("Running query '{}'...".format(query))
+    logging.info("Running query '%s'...", query)
     result = instance.query(query, stdin=stdin, settings=settings)
     logging.info("Query finished")
 

--- a/tests/integration/test_storage_iceberg/test.py
+++ b/tests/integration/test_storage_iceberg/test.py
@@ -80,7 +80,7 @@ def started_cluster():
 def run_query(instance, query, stdin=None, settings=None):
     # type: (ClickHouseInstance, str, object, dict) -> str
 
-    logging.info("Running query '{}'...".format(query))
+    logging.info("Running query '%s'...", query)
     result = instance.query(query, stdin=stdin, settings=settings)
     logging.info("Query finished")
 

--- a/tests/integration/test_storage_kerberized_kafka/test.py
+++ b/tests/integration/test_storage_kerberized_kafka/test.py
@@ -40,7 +40,7 @@ def get_kafka_producer(port, serializer):
                 bootstrap_servers="localhost:{}".format(port),
                 value_serializer=serializer,
             )
-            logging.debug("Kafka Connection establised: localhost:{}".format(port))
+            logging.debug("Kafka Connection establised: localhost:%s", port)
             return producer
         except Exception as e:
             errors += [str(e)]
@@ -51,9 +51,9 @@ def get_kafka_producer(port, serializer):
 
 def kafka_produce(kafka_cluster, topic, messages, timestamp=None):
     logging.debug(
-        "kafka_produce server:{}:{} topic:{}".format(
-            "localhost", kafka_cluster.kerberized_kafka_port, topic
-        )
+        "kafka_produce server:localhost:%s topic:%s",
+        kafka_cluster.kerberized_kafka_port,
+        topic
     )
     producer = get_kafka_producer(
         kafka_cluster.kerberized_kafka_port, producer_serializer

--- a/tests/integration/test_storage_postgresql/test.py
+++ b/tests/integration/test_storage_postgresql/test.py
@@ -518,7 +518,7 @@ def test_datetime_with_timezone(started_cluster):
     )
     cursor.execute("select * from test_timezone")
     result = cursor.fetchall()[0]
-    logging.debug(f"{result[0]}, {str(result[1])[:-6]}")
+    logging.debug("%s, %s", result[0], str(result[1])[:-6])
     node1.query(
         "create table test.test_timezone ( ts DateTime, ts_z DateTime('America/New_York')) ENGINE PostgreSQL('postgres1:5432', 'postgres', 'test_timezone', 'postgres', 'mysecretpassword');"
     )

--- a/tests/integration/test_storage_rabbitmq/test.py
+++ b/tests/integration/test_storage_rabbitmq/test.py
@@ -59,7 +59,7 @@ def wait_rabbitmq_to_start(rabbitmq_docker_id, cookie, timeout=180):
                 return
             time.sleep(0.5)
         except Exception as ex:
-            logging.debug("Can't connect to RabbitMQ " + str(ex))
+            logging.debug("Can't connect to RabbitMQ %s", str(ex))
             time.sleep(0.5)
 
 
@@ -82,7 +82,7 @@ def revive_rabbitmq(rabbitmq_id, cookie):
 def rabbitmq_cluster():
     try:
         cluster.start()
-        logging.debug("rabbitmq_id is {}".format(instance.cluster.rabbitmq_docker_id))
+        logging.debug("rabbitmq_id is %s", instance.cluster.rabbitmq_docker_id)
         instance.query("CREATE DATABASE test")
 
         yield cluster
@@ -415,7 +415,7 @@ def test_rabbitmq_materialized_view(rabbitmq_cluster):
 
     while time.monotonic() < deadline:
         result = instance.query("SELECT * FROM test.view2 ORDER BY key")
-        logging.debug(f"Result: {result}")
+        logging.debug("Result: %s", result)
         if rabbitmq_check_result(result):
             break
         time.sleep(1)
@@ -647,7 +647,7 @@ def test_rabbitmq_sharding_between_queues_publish(rabbitmq_cluster):
         expected = messages_num * threads_num
         if int(result1) == expected:
             break
-        logging.debug(f"Result {result1} / {expected}")
+        logging.debug("Result %s / %s", result1, expected)
 
     result2 = instance.query("SELECT count(DISTINCT channel_id) FROM test.view")
 
@@ -741,7 +741,7 @@ def test_rabbitmq_mv_combo(rabbitmq_cluster):
         expected = messages_num * threads_num * NUM_MV
         if int(result) == expected:
             break
-        logging.debug(f"Result: {result} / {expected}")
+        logging.debug("Result: %s / %s", result, expected)
         time.sleep(1)
 
     for thread in threads:
@@ -1046,7 +1046,7 @@ def test_rabbitmq_overloaded_insert(rabbitmq_cluster):
         expected = messages_num * threads_num
         if int(result) == expected:
             break
-        logging.debug(f"Result: {result} / {expected}")
+        logging.debug("Result: %s / %s", result, expected)
         time.sleep(1)
 
     instance.query(
@@ -1077,7 +1077,7 @@ def test_rabbitmq_direct_exchange(rabbitmq_cluster):
 
     num_tables = 5
     for consumer_id in range(num_tables):
-        logging.debug(("Setting up table {}".format(consumer_id)))
+        logging.debug("Setting up table %s", consumer_id)
         instance.query(
             """
             DROP TABLE IF EXISTS test.direct_exchange_{0};
@@ -1170,7 +1170,7 @@ def test_rabbitmq_fanout_exchange(rabbitmq_cluster):
 
     num_tables = 5
     for consumer_id in range(num_tables):
-        logging.debug(("Setting up table {}".format(consumer_id)))
+        logging.debug("Setting up table %s", consumer_id)
         instance.query(
             """
             DROP TABLE IF EXISTS test.fanout_exchange_{0};
@@ -1258,7 +1258,7 @@ def test_rabbitmq_topic_exchange(rabbitmq_cluster):
 
     num_tables = 5
     for consumer_id in range(num_tables):
-        logging.debug(("Setting up table {}".format(consumer_id)))
+        logging.debug("Setting up table %s", consumer_id)
         instance.query(
             """
             DROP TABLE IF EXISTS test.topic_exchange_{0};
@@ -1283,7 +1283,7 @@ def test_rabbitmq_topic_exchange(rabbitmq_cluster):
         )
 
     for consumer_id in range(num_tables):
-        logging.debug(("Setting up table {}".format(num_tables + consumer_id)))
+        logging.debug("Setting up table %s", num_tables + consumer_id)
         instance.query(
             """
             DROP TABLE IF EXISTS test.topic_exchange_{0};
@@ -1383,7 +1383,7 @@ def test_rabbitmq_hash_exchange(rabbitmq_cluster):
     num_tables = 4
     for consumer_id in range(num_tables):
         table_name = "rabbitmq_consumer{}".format(consumer_id)
-        logging.debug(("Setting up {}".format(table_name)))
+        logging.debug("Setting up %s", table_name)
         instance.query(
             """
             DROP TABLE IF EXISTS test.{0};
@@ -1574,7 +1574,7 @@ def test_rabbitmq_headers_exchange(rabbitmq_cluster):
 
     num_tables_to_receive = 2
     for consumer_id in range(num_tables_to_receive):
-        logging.debug(("Setting up table {}".format(consumer_id)))
+        logging.debug("Setting up table %s", consumer_id)
         instance.query(
             """
             DROP TABLE IF EXISTS test.headers_exchange_{0};
@@ -1599,9 +1599,7 @@ def test_rabbitmq_headers_exchange(rabbitmq_cluster):
 
     num_tables_to_ignore = 2
     for consumer_id in range(num_tables_to_ignore):
-        logging.debug(
-            ("Setting up table {}".format(consumer_id + num_tables_to_receive))
-        )
+        logging.debug("Setting up table %s", consumer_id + num_tables_to_receive)
         instance.query(
             """
             DROP TABLE IF EXISTS test.headers_exchange_{0};
@@ -1833,7 +1831,7 @@ def test_rabbitmq_many_consumers_to_each_queue(rabbitmq_cluster):
 
     num_tables = 4
     for table_id in range(num_tables):
-        logging.debug(("Setting up table {}".format(table_id)))
+        logging.debug("Setting up table %s", table_id)
         instance.query(
             """
             DROP TABLE IF EXISTS test.many_consumers_{0};
@@ -2077,7 +2075,7 @@ def test_rabbitmq_restore_failed_connection_without_losses_2(rabbitmq_cluster):
         result = instance.query("SELECT count(DISTINCT key) FROM test.view").strip()
         if int(result) == messages_num:
             break
-        logging.debug(f"Result: {result} / {messages_num}")
+        logging.debug("Result: %s / %s", result, messages_num)
         time.sleep(1)
 
     instance.query(
@@ -2672,11 +2670,11 @@ def test_rabbitmq_drop_mv(rabbitmq_cluster):
 
     while True:
         res = instance.query("SELECT COUNT(*) FROM test.view")
-        logging.debug(f"Current count (1): {res}")
+        logging.debug("Current count (1): %s", res)
         if int(res) == 20:
             break
         else:
-            logging.debug(f"Number of rows in test.view: {res}")
+            logging.debug("Number of rows in test.view: %s", res)
 
     instance.query("DROP VIEW test.consumer SYNC")
     for i in range(20, 40):
@@ -2697,7 +2695,7 @@ def test_rabbitmq_drop_mv(rabbitmq_cluster):
 
     while True:
         result = instance.query("SELECT count() FROM test.view")
-        logging.debug(f"Current count (2): {result}")
+        logging.debug("Current count (2): %s", result)
         if int(result) == 50:
             break
         time.sleep(1)
@@ -2944,7 +2942,7 @@ def test_format_with_prefix_and_suffix(rabbitmq_cluster):
     def onReceived(channel, method, properties, body):
         message = body.decode()
         insert_messages.append(message)
-        logging.debug(f"Received {len(insert_messages)} message: {message}")
+        logging.debug("Received %s message: %s", len(insert_messages), message)
         if len(insert_messages) == 2:
             channel.stop_consuming()
 
@@ -3414,13 +3412,13 @@ def test_rabbitmq_flush_by_time(rabbitmq_cluster):
         count = instance.query(
             "SELECT count() FROM system.parts WHERE database = 'test' AND table = 'view'"
         )
-        logging.debug(f"kssenii total count: {count}")
+        logging.debug("kssenii total count: %s", count)
         count = int(
             instance.query(
                 "SELECT count() FROM system.parts WHERE database = 'test' AND table = 'view' AND name = 'all_1_1_0'"
             )
         )
-        logging.debug(f"kssenii count: {count}")
+        logging.debug("kssenii count: %s", count)
         if count > 0:
             break
 

--- a/tests/integration/test_storage_rabbitmq/test.py
+++ b/tests/integration/test_storage_rabbitmq/test.py
@@ -3318,8 +3318,8 @@ def test_rabbitmq_flush_by_block_size(rabbitmq_cluster):
                     routing_key="",
                     body=json.dumps({"key": 0, "value": 0}),
                 )
-            except e:
-                logging.debug(f"Got error: {str(e)}")
+            except Exception as e:
+                logging.debug("Got error: %s", e)
 
     produce_thread = threading.Thread(target=produce)
     produce_thread.start()
@@ -3396,8 +3396,8 @@ def test_rabbitmq_flush_by_time(rabbitmq_cluster):
                 )
                 logging.debug("Produced a message")
                 time.sleep(0.8)
-            except e:
-                logging.debug(f"Got error: {str(e)}")
+            except Exception as e:
+                logging.debug("Got error: %s", e)
 
     produce_thread = threading.Thread(target=produce)
     produce_thread.start()

--- a/tests/integration/test_storage_s3/test.py
+++ b/tests/integration/test_storage_s3/test.py
@@ -106,7 +106,7 @@ def started_cluster():
 
 
 def run_query(instance, query, *args, **kwargs):
-    logging.info("Running query '{}'...".format(query))
+    logging.info("Running query '%s'...", query)
     result = instance.query(query, *args, **kwargs)
     logging.info("Query finished")
 

--- a/tests/integration/test_storage_s3_queue/test.py
+++ b/tests/integration/test_storage_s3_queue/test.py
@@ -138,7 +138,7 @@ def started_cluster():
 def run_query(instance, query, stdin=None, settings=None):
     # type: (ClickHouseInstance, str, object, dict) -> str
 
-    logging.info("Running query '{}'...".format(query))
+    logging.info("Running query '%s'...", query)
     result = instance.query(query, stdin=stdin, settings=settings)
     logging.info("Query finished")
 

--- a/tests/integration/test_storage_url_with_proxy/test.py
+++ b/tests/integration/test_storage_url_with_proxy/test.py
@@ -38,7 +38,7 @@ def check_proxy_logs(cluster, proxy_instance, http_methods):
             method_with_domain = http_method + " http://minio1"
             method_with_ip = http_method + f" http://{minio_ip}"
 
-            logging.info(f"Method with ip: {method_with_ip}")
+            logging.info("Method with ip: %s", method_with_ip)
 
             has_get_minio_logs = (
                 logs.find(method_with_domain) >= 0 or logs.find(method_with_ip) >= 0

--- a/tests/integration/test_undrop_query/test.py
+++ b/tests/integration/test_undrop_query/test.py
@@ -26,9 +26,7 @@ def test_undrop_drop_and_undrop_loop(started_cluster):
     while count < 10:
         random_sec = random.randint(0, 10)
         table_uuid = uuid.uuid1().__str__()
-        logging.info(
-            "random_sec: " + random_sec.__str__() + ", table_uuid: " + table_uuid
-        )
+        logging.info("random_sec: %s, table_uuid: %s", str(random_sec), table_uuid)
         node.query(
             "create table test_undrop_loop"
             + count.__str__()

--- a/tests/integration/test_zookeeper_config/test.py
+++ b/tests/integration/test_zookeeper_config/test.py
@@ -28,7 +28,7 @@ node3 = cluster.add_instance(
 def create_zk_roots(zk):
     zk.ensure_path("/root_a")
     zk.ensure_path("/root_b")
-    logging.debug(f"Create ZK roots:{zk.get_children('/')}")
+    logging.debug("Create ZK roots:%s", zk.get_children('/'))
 
 
 @pytest.fixture(scope="module", autouse=True)


### PR DESCRIPTION
Using f-strings in `logging` is discouraged because it doesn't enable the lazy
evaluation of the string. That is, when internal logging format is used, the
format string and all the arguments are passed as function arguments. Hence, if
log level is too low to show the message, the string won't be evaluated at all.

Moreover, f-strings in `logging` might be discouraged due to security
considerations: https://bugs.python.org/issue46200
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
