### PR TITLE
fix typo in the test 02479

### DIFF
--- a/tests/queries/0_stateless/02479_race_condition_between_insert_and_droppin_mv.sh
+++ b/tests/queries/0_stateless/02479_race_condition_between_insert_and_droppin_mv.sh
@@ -42,7 +42,7 @@ TIMEOUT=55
 
 for i in {1..4}
 do
-    timeout $TIMEOUT bash -c drop_mv $i &
+    timeout $TIMEOUT bash -c "drop_mv $i" &
 done
 
 for i in {1..4}


### PR DESCRIPTION
Otherwise it does
`2023-12-19 14:12:50 query:                DROP TABLE IF EXISTS test_race_condition_mv_`

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
