### PR TITLE
Remove unneeded parameter `use_external_buffer` from `AsynchronousReadBuffer*`

### DIFF
--- a/src/Disks/IO/createReadBufferFromFileBase.cpp
+++ b/src/Disks/IO/createReadBufferFromFileBase.cpp
@@ -36,8 +36,7 @@ std::unique_ptr<ReadBufferFromFileBase> createReadBufferFromFileBase(
     std::optional<size_t> file_size,
     int flags,
     char * existing_memory,
-    size_t alignment,
-    bool use_external_buffer)
+    size_t alignment)
 {
     if (file_size.has_value() && !*file_size)
         return std::make_unique<ReadBufferFromEmptyFile>();
@@ -149,8 +148,7 @@ std::unique_ptr<ReadBufferFromFileBase> createReadBufferFromFileBase(
                 existing_memory,
                 buffer_alignment,
                 file_size,
-                settings.local_throttler,
-                use_external_buffer);
+                settings.local_throttler);
         }
         else
             throw Exception(ErrorCodes::LOGICAL_ERROR, "Unknown read method");

--- a/src/Disks/IO/createReadBufferFromFileBase.h
+++ b/src/Disks/IO/createReadBufferFromFileBase.h
@@ -21,6 +21,5 @@ std::unique_ptr<ReadBufferFromFileBase> createReadBufferFromFileBase(
     std::optional<size_t> file_size = {},
     int flags_ = -1,
     char * existing_memory = nullptr,
-    size_t alignment = 0,
-    bool use_external_buffer = false);
+    size_t alignment = 0);
 }

--- a/src/IO/AsynchronousReadBufferFromFile.h
+++ b/src/IO/AsynchronousReadBufferFromFile.h
@@ -67,10 +67,8 @@ public:
         char * existing_memory = nullptr,
         size_t alignment = 0,
         std::optional<size_t> file_size_ = std::nullopt,
-        ThrottlerPtr throttler_ = {},
-        bool use_external_buffer_ = false)
-        : AsynchronousReadBufferFromFileDescriptor(
-            reader_, priority_, -1, buf_size, existing_memory, alignment, file_size_, throttler_, use_external_buffer_)
+        ThrottlerPtr throttler_ = {})
+        : AsynchronousReadBufferFromFileDescriptor(reader_, priority_, -1, buf_size, existing_memory, alignment, file_size_, throttler_)
         , file_name(file_name_)
     {
         file = OpenedFileCache::instance().get(file_name, flags);

--- a/src/IO/AsynchronousReadBufferFromFileDescriptor.h
+++ b/src/IO/AsynchronousReadBufferFromFileDescriptor.h
@@ -29,7 +29,6 @@ protected:
     size_t bytes_to_ignore = 0;           /// How many bytes should we ignore upon a new read request.
     int fd;
     ThrottlerPtr throttler;
-    bool use_external_buffer;
 
     bool nextImpl() override;
 
@@ -47,8 +46,7 @@ public:
         char * existing_memory = nullptr,
         size_t alignment = 0,
         std::optional<size_t> file_size_ = std::nullopt,
-        ThrottlerPtr throttler_ = {},
-        bool use_external_buffer_ = false);
+        ThrottlerPtr throttler_ = {});
 
     ~AsynchronousReadBufferFromFileDescriptor() override;
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)