### PR TITLE
Add max/peak RSS into system.asynchronous_metrics

### DIFF
--- a/docs/en/operations/system-tables/asynchronous_metrics.md
+++ b/docs/en/operations/system-tables/asynchronous_metrics.md
@@ -239,6 +239,10 @@ The amount of virtual memory mapped for the pages of machine code of the server 
 
 The amount of virtual memory mapped for the use of stack and for the allocated memory, in bytes. It is unspecified whether it includes the per-thread stacks and most of the allocated memory, that is allocated with the 'mmap' system call. This metric exists only for completeness reasons. I recommend to use the `MemoryResident` metric for monitoring.
 
+### MemoryResidentMax
+
+Maximum amount of physical memory used by the server process, in bytes.
+
 ### MemoryResident
 
 The amount of physical memory used by the server process, in bytes.

--- a/utils/check-style/aspell-ignore/en/aspell-dict.txt
+++ b/utils/check-style/aspell-ignore/en/aspell-dict.txt
@@ -502,6 +502,7 @@ Memcheck
 MemoryCode
 MemoryDataAndStack
 MemoryResident
+MemoryResidentMax
 MemorySanitizer
 MemoryShared
 MemoryTracking


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add max/peak RSS (`MemoryResidentMax`) into system.asynchronous_metrics

Will be useful for perf tests (at least), since if some queries became memory greedy this will not be reflected (because memory will be freed by the time of compare).