### PR TITLE
Reintroduce OPTIMIZE CLEANUP as no-op

### DIFF
--- a/src/Parsers/ParserOptimizeQuery.cpp
+++ b/src/Parsers/ParserOptimizeQuery.cpp
@@ -28,6 +28,7 @@ bool ParserOptimizeQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expecte
     ParserKeyword s_partition("PARTITION");
     ParserKeyword s_final("FINAL");
     ParserKeyword s_deduplicate("DEDUPLICATE");
+    ParserKeyword s_cleanup("CLEANUP");
     ParserKeyword s_by("BY");
     ParserToken s_dot(TokenType::Dot);
     ParserIdentifier name_p(true);
@@ -75,6 +76,9 @@ bool ParserOptimizeQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expecte
                 .parse(pos, deduplicate_by_columns, expected))
             return false;
     }
+
+    /// Obsolete feature, ignored for backward compatibility.
+    s_cleanup.ignore(pos, expected);
 
     auto query = std::make_shared<ASTOptimizeQuery>();
     node = query;

--- a/tests/queries/0_stateless/02948_optimize_cleanup_as_noop.sql
+++ b/tests/queries/0_stateless/02948_optimize_cleanup_as_noop.sql
@@ -1,0 +1,7 @@
+# There was a wrong, harmful feature, leading to bugs and data corruption.
+# This feature is removed, but we take care to maintain compatibility on the syntax level, so now it works as a no-op.
+
+DROP TABLE IF EXISTS t;
+CREATE TABLE t (x UInt8, PRIMARY KEY x) ENGINE = ReplacingMergeTree;
+OPTIMIZE TABLE t CLEANUP;
+DROP TABLE t;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Compatibility with a bad feature, `OPTIMIZE CLEANUP` on a syntax level. See https://github.com/ClickHouse/ClickHouse/pull/57932.