### PR TITLE
Add compatibility in the replication protocol for a removed feature

### DIFF
--- a/src/Storages/MergeTree/ReplicatedMergeTreeLogEntry.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeLogEntry.cpp
@@ -269,6 +269,12 @@ void ReplicatedMergeTreeLogEntryData::readText(ReadBuffer & in, MergeTreeDataFor
 
                     deduplicate_by_columns = std::move(new_deduplicate_by_columns);
                 }
+                else if (checkString("cleanup: ", in))
+                {
+                    /// Obsolete option, does nothing.
+                    bool cleanup = false;
+                    in >> cleanup;
+                }
                 else
                     trailing_newline_found = true;
             }


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Clusters that have used the disastrous feature will not break on the upgrade. See #57932