### PR TITLE
Flaky 02922_analyzer_aggregate_nothing_type

### DIFF
--- a/tests/queries/0_stateless/02901_parallel_replicas_rollup.sh
+++ b/tests/queries/0_stateless/02901_parallel_replicas_rollup.sh
@@ -29,7 +29,7 @@ $CLICKHOUSE_CLIENT \
   --query_id "${query_id}" \
   --max_parallel_replicas 3 \
   --prefer_localhost_replica 1 \
-  --cluster_for_parallel_replicas "parallel_replicas" \
+  --cluster_for_parallel_replicas "test_cluster_one_shard_three_replicas_localhost" \
   --allow_experimental_parallel_reading_from_replicas 1 \
   --parallel_replicas_for_non_replicated_merge_tree 1 \
   --parallel_replicas_min_number_of_rows_per_replica 0 \
@@ -62,7 +62,7 @@ $CLICKHOUSE_CLIENT \
   --query_id "${query_id}" \
   --max_parallel_replicas 3 \
   --prefer_localhost_replica 1 \
-  --cluster_for_parallel_replicas "parallel_replicas" \
+  --cluster_for_parallel_replicas "test_cluster_one_shard_three_replicas_localhost" \
   --allow_experimental_parallel_reading_from_replicas 1 \
   --parallel_replicas_for_non_replicated_merge_tree 1 \
   --parallel_replicas_min_number_of_rows_per_replica 0 \

--- a/tests/queries/0_stateless/02922_analyzer_aggregate_nothing_type.sql
+++ b/tests/queries/0_stateless/02922_analyzer_aggregate_nothing_type.sql
@@ -11,7 +11,7 @@ SET
     allow_experimental_parallel_reading_from_replicas=1,
     max_parallel_replicas=2,
     use_hedged_requests=0,
-    cluster_for_parallel_replicas='parallel_replicas',
+    cluster_for_parallel_replicas='test_cluster_one_shard_three_replicas_localhost',
     parallel_replicas_for_non_replicated_merge_tree=1
 ;
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes


The cluster `parallel_replicas` includes an unavailable replica in its config and when used, with skip shards, it adds extra warnings to the output -> https://s3.amazonaws.com/clickhouse-test-reports/0/cc23ddd94aa479171d5f14f5fea6650ed2a868fa/stateless_tests__tsan__[1_5].html