### PR TITLE
ClusterDiscovery supports setting username and password

### DIFF
--- a/docs/en/operations/cluster-discovery.md
+++ b/docs/en/operations/cluster-discovery.md
@@ -65,6 +65,18 @@ With Cluster Discovery, rather than defining each node explicitly, you simply sp
     <cluster_name>
         <discovery>
             <path>/clickhouse/discovery/cluster_name</path>
+
+            <!-- # Optional configuration parameters: -->
+
+            <!-- ## Authentication credentials to access all other nodes in cluster: -->
+            <!-- <user>user1</user> -->
+            <!-- <password>pass123</password> -->
+
+            <!-- ## Shard for current node (see below): -->
+            <!-- <shard>1</shard> -->
+
+            <!-- ## Observer mode (see below): -->
+            <!-- <observer/> -->
         </discovery>
     </cluster_name>
 </remote_servers>

--- a/docs/en/operations/cluster-discovery.md
+++ b/docs/en/operations/cluster-discovery.md
@@ -71,6 +71,8 @@ With Cluster Discovery, rather than defining each node explicitly, you simply sp
             <!-- ## Authentication credentials to access all other nodes in cluster: -->
             <!-- <user>user1</user> -->
             <!-- <password>pass123</password> -->
+            <!-- ### Alternatively to password, interserver secret may be used: -->
+            <!-- <secret>secret123</secret> -->
 
             <!-- ## Shard for current node (see below): -->
             <!-- <shard>1</shard> -->

--- a/src/Interpreters/ClusterDiscovery.cpp
+++ b/src/Interpreters/ClusterDiscovery.cpp
@@ -136,7 +136,7 @@ ClusterDiscovery::ClusterDiscovery(
         const auto & password = config.getString(cluster_config_prefix + ".password", "");
         const auto & cluster_secret = config.getString(cluster_config_prefix + ".secret", "");
         if (!password.empty() && !cluster_secret.empty())
-            throw Exception(ErrorCodes::NO_ELEMENTS_IN_CONFIG, "Mutually exclusive options 'password' and 'secret' are specified for cluster '{}'", key);
+            throw Exception(ErrorCodes::NO_ELEMENTS_IN_CONFIG, "Both 'password' and 'secret' are specified for cluster '{}', only one option can be used at the same time", key);
 
         clusters_info.emplace(
             key,

--- a/src/Interpreters/ClusterDiscovery.h
+++ b/src/Interpreters/ClusterDiscovery.h
@@ -82,19 +82,28 @@ private:
         /// they are mutually invisible to each other.
         bool current_cluster_is_invisible = false;
 
-        explicit ClusterInfo(const String & name_,
-                             const String & zk_root_,
-                             const String & host_name,
-                             UInt16 port,
-                             bool secure,
-                             size_t shard_id,
-                             bool observer_mode,
-                             bool invisible)
+        bool is_secure_connection = false;
+        String username;
+        String password;
+
+        ClusterInfo(const String & name_,
+                    const String & zk_root_,
+                    const String & host_name,
+                    const String & username_,
+                    const String & password_,
+                    UInt16 port,
+                    bool secure,
+                    size_t shard_id,
+                    bool observer_mode,
+                    bool invisible)
             : name(name_)
             , zk_root(zk_root_)
             , current_node(host_name + ":" + toString(port), secure, shard_id)
             , current_node_is_observer(observer_mode)
             , current_cluster_is_invisible(invisible)
+            , is_secure_connection(secure)
+            , username(username_)
+            , password(password_)
         {
         }
     };

--- a/src/Interpreters/ClusterDiscovery.h
+++ b/src/Interpreters/ClusterDiscovery.h
@@ -85,12 +85,14 @@ private:
         bool is_secure_connection = false;
         String username;
         String password;
+        String cluster_secret;
 
         ClusterInfo(const String & name_,
                     const String & zk_root_,
                     const String & host_name,
                     const String & username_,
                     const String & password_,
+                    const String & cluster_secret_,
                     UInt16 port,
                     bool secure,
                     size_t shard_id,
@@ -104,6 +106,7 @@ private:
             , is_secure_connection(secure)
             , username(username_)
             , password(password_)
+            , cluster_secret(cluster_secret_)
         {
         }
     };

--- a/tests/integration/test_cluster_discovery/common.py
+++ b/tests/integration/test_cluster_discovery/common.py
@@ -1,0 +1,41 @@
+import time
+
+
+def check_on_cluster(
+    nodes,
+    expected,
+    *,
+    what,
+    cluster_name="test_auto_cluster",
+    msg=None,
+    retries=5,
+    query_params={},
+):
+    """
+    Select data from `system.clusters` on specified nodes and check the result
+    """
+    assert 1 <= retries <= 6
+
+    node_results = {}
+    for retry in range(1, retries + 1):
+        for node in nodes:
+            if node_results.get(node.name) == expected:
+                # do not retry node after success
+                continue
+            query_text = (
+                f"SELECT {what} FROM system.clusters WHERE cluster = '{cluster_name}'"
+            )
+            node_results[node.name] = int(node.query(query_text, **query_params))
+
+        if all(actual == expected for actual in node_results.values()):
+            break
+
+        print(f"Retry {retry}/{retries} unsuccessful, result: {node_results}")
+
+        if retry != retries:
+            time.sleep(2**retry)
+    else:
+        msg = msg or f"Wrong '{what}' result"
+        raise Exception(
+            f"{msg}: {node_results}, expected: {expected} (after {retries} retries)"
+        )

--- a/tests/integration/test_cluster_discovery/config/config_with_pwd.xml
+++ b/tests/integration/test_cluster_discovery/config/config_with_pwd.xml
@@ -9,6 +9,13 @@
                 <password>password123</password>
             </discovery>
         </test_auto_cluster_with_pwd>
+        <test_auto_cluster_with_wrong_pwd>
+            <discovery>
+                <path>/clickhouse/discovery/test_auto_cluster_with_wrong_pwd</path>
+                <user>user1</user>
+                <password>wrongpass1234</password>
+            </discovery>
+        </test_auto_cluster_with_wrong_pwd>
     </remote_servers>
 
 </clickhouse>

--- a/tests/integration/test_cluster_discovery/config/config_with_pwd.xml
+++ b/tests/integration/test_cluster_discovery/config/config_with_pwd.xml
@@ -1,0 +1,14 @@
+<clickhouse>
+    <allow_experimental_cluster_discovery>1</allow_experimental_cluster_discovery>
+
+    <remote_servers>
+        <test_auto_cluster_with_pwd>
+            <discovery>
+                <path>/clickhouse/discovery/test_auto_cluster_with_pwd</path>
+                <user>user1</user>
+                <password>password123</password>
+            </discovery>
+        </test_auto_cluster_with_pwd>
+    </remote_servers>
+
+</clickhouse>

--- a/tests/integration/test_cluster_discovery/config/config_with_secret1.xml
+++ b/tests/integration/test_cluster_discovery/config/config_with_secret1.xml
@@ -1,0 +1,22 @@
+<clickhouse>
+    <allow_experimental_cluster_discovery>1</allow_experimental_cluster_discovery>
+
+    <remote_servers>
+
+        <test_auto_cluster_with_secret>
+            <discovery>
+                <path>/clickhouse/discovery/test_auto_cluster_with_secret</path>
+                <secret>secret123</secret>
+            </discovery>
+        </test_auto_cluster_with_secret>
+
+        <test_auto_cluster_with_wrong_secret>
+            <discovery>
+                <path>/clickhouse/discovery/test_auto_cluster_with_wrong_secret</path>
+                <secret>correctsecret321</secret>
+            </discovery>
+        </test_auto_cluster_with_wrong_secret>
+
+    </remote_servers>
+
+</clickhouse>

--- a/tests/integration/test_cluster_discovery/config/config_with_secret2.xml
+++ b/tests/integration/test_cluster_discovery/config/config_with_secret2.xml
@@ -1,0 +1,22 @@
+<clickhouse>
+    <allow_experimental_cluster_discovery>1</allow_experimental_cluster_discovery>
+
+    <remote_servers>
+
+        <test_auto_cluster_with_secret>
+            <discovery>
+                <path>/clickhouse/discovery/test_auto_cluster_with_secret</path>
+                <secret>secret123</secret>
+            </discovery>
+        </test_auto_cluster_with_secret>
+
+        <test_auto_cluster_with_wrong_secret>
+            <discovery>
+                <path>/clickhouse/discovery/test_auto_cluster_with_wrong_secret</path>
+                <secret>wrongsecret333</secret>
+            </discovery>
+        </test_auto_cluster_with_wrong_secret>
+
+    </remote_servers>
+
+</clickhouse>

--- a/tests/integration/test_cluster_discovery/config/users.d/users_with_pwd.xml
+++ b/tests/integration/test_cluster_discovery/config/users.d/users_with_pwd.xml
@@ -1,0 +1,17 @@
+<clickhouse>
+    <profiles>
+        <default>
+        </default>
+    </profiles>
+
+    <users>
+        <default>
+            <password>passwordAbc</password>
+            <profile>default</profile>
+        </default>
+        <user1>
+            <password>password123</password>
+            <profile>default</profile>
+        </user1>
+    </users>
+</clickhouse>

--- a/tests/integration/test_cluster_discovery/test.py
+++ b/tests/integration/test_cluster_discovery/test.py
@@ -1,7 +1,8 @@
 import pytest
 
 import functools
-import time
+from .common import check_on_cluster
+
 
 from helpers.cluster import ClickHouseCluster
 
@@ -34,39 +35,6 @@ def start_cluster():
         yield cluster
     finally:
         cluster.shutdown()
-
-
-def check_on_cluster(
-    nodes, expected, *, what, cluster_name="test_auto_cluster", msg=None, retries=5
-):
-    """
-    Select data from `system.clusters` on specified nodes and check the result
-    """
-    assert 1 <= retries <= 6
-
-    node_results = {}
-    for retry in range(1, retries + 1):
-        for node in nodes:
-            if node_results.get(node.name) == expected:
-                # do not retry node after success
-                continue
-            query_text = (
-                f"SELECT {what} FROM system.clusters WHERE cluster = '{cluster_name}'"
-            )
-            node_results[node.name] = int(node.query(query_text))
-
-        if all(actual == expected for actual in node_results.values()):
-            break
-
-        print(f"Retry {retry}/{retries} unsuccessful, result: {node_results}")
-
-        if retry != retries:
-            time.sleep(2**retry)
-    else:
-        msg = msg or f"Wrong '{what}' result"
-        raise Exception(
-            f"{msg}: {node_results}, expected: {expected} (after {retries} retries)"
-        )
 
 
 def test_cluster_discovery_startup_and_stop(start_cluster):

--- a/tests/integration/test_cluster_discovery/test_password.py
+++ b/tests/integration/test_cluster_discovery/test_password.py
@@ -65,5 +65,8 @@ def test_connect_with_password(start_cluster):
         "SELECT sum(number) FROM clusterAllReplicas('test_auto_cluster_with_wrong_secret', numbers(3)) GROUP BY hostname()",
         password="passwordAbc",
     )
-    # With incorrect secret, we receive "Connection reset by peer" error instead of "Authentication failed"
-    assert "Connection reset by peer" in result, result
+
+    # With an incorrect secret, we don't get "Authentication failed", but the connection is simply dropped.
+    # So, we get messages like "Connection reset by peer" or "Attempt to read after eof".
+    # We only check that an error occurred and the message is not empty.
+    assert result

--- a/tests/integration/test_cluster_discovery/test_password.py
+++ b/tests/integration/test_cluster_discovery/test_password.py
@@ -42,3 +42,15 @@ def test_connect_with_password(start_cluster):
         msg="Wrong nodes count in cluster",
         query_params={"password": "passwordAbc"},
     )
+
+    result = nodes["node0"].query(
+        "SELECT sum(number) FROM clusterAllReplicas('test_auto_cluster_with_pwd', numbers(3)) GROUP BY hostname()",
+        password="passwordAbc",
+    )
+    assert result == "3\n3\n", result
+
+    result = nodes["node0"].query_and_get_error(
+        "SELECT sum(number) FROM clusterAllReplicas('test_auto_cluster_with_wrong_pwd', numbers(3)) GROUP BY hostname()",
+        password="passwordAbc",
+    )
+    assert "Authentication failed" in result, result


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):

- Improvement



### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

* ClusterDiscovery supports setting username and password, close https://github.com/ClickHouse/ClickHouse/issues/58063

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)
