### PR TITLE
Support "do not test" label with ci.py

### DIFF
--- a/tests/ci/ci.py
+++ b/tests/ci/ci.py
@@ -397,6 +397,19 @@ def _configure_jobs(
         else:
             jobs_to_skip += (job,)
 
+    if pr_labels:
+        jobs_requested_by_label = []  # type: List[str]
+        ci_controlling_labels = []  # type: List[str]
+        for label in pr_labels:
+            label_config = CI_CONFIG.get_label_config(label)
+            if label_config:
+                jobs_requested_by_label += label_config.run_jobs
+                ci_controlling_labels += [label]
+        if ci_controlling_labels:
+            print(f"NOTE: CI controlling labels are set: [{ci_controlling_labels}]")
+            print(f"    :   following jobs will be executed: [{jobs_requested_by_label}]")
+            jobs_to_do = jobs_requested_by_label
+
     if commit_tokens:
         requested_jobs = [
             token[len("#job_") :]
@@ -416,7 +429,7 @@ def _configure_jobs(
                     if parent in jobs_to_do and parent not in jobs_to_do_requested:
                         jobs_to_do_requested.append(parent)
             print(
-                f"NOTE: Only specific job(s) were requested: [{jobs_to_do_requested}]"
+                f"NOTE: Only specific job(s) were requested by commit message tokens: [{jobs_to_do_requested}]"
             )
             jobs_to_do = jobs_to_do_requested
 

--- a/tests/ci/ci.py
+++ b/tests/ci/ci.py
@@ -407,7 +407,9 @@ def _configure_jobs(
                 ci_controlling_labels += [label]
         if ci_controlling_labels:
             print(f"NOTE: CI controlling labels are set: [{ci_controlling_labels}]")
-            print(f"    :   following jobs will be executed: [{jobs_requested_by_label}]")
+            print(
+                f"    :   following jobs will be executed: [{jobs_requested_by_label}]"
+            )
             jobs_to_do = jobs_requested_by_label
 
     if commit_tokens:

--- a/tests/ci/run_check.py
+++ b/tests/ci/run_check.py
@@ -32,7 +32,6 @@ TRUSTED_ORG_IDS = {
 
 OK_SKIP_LABELS = {"release", "pr-backport", "pr-cherrypick"}
 CAN_BE_TESTED_LABEL = "can be tested"
-DO_NOT_TEST_LABEL = "do not test"
 FEATURE_LABEL = "pr-feature"
 SUBMODULE_CHANGED_LABEL = "submodule changed"
 PR_CHECK = "PR Check"
@@ -67,10 +66,6 @@ def should_run_ci_for_pr(pr_info: PRInfo) -> Tuple[bool, str]:
     if FORCE_TESTS_LABEL in pr_info.labels:
         print(f"Label '{FORCE_TESTS_LABEL}' set, forcing remaining checks")
         return True, f"Labeled '{FORCE_TESTS_LABEL}'"
-
-    if DO_NOT_TEST_LABEL in pr_info.labels:
-        print(f"Label '{DO_NOT_TEST_LABEL}' set, skipping remaining checks")
-        return False, f"Labeled '{DO_NOT_TEST_LABEL}'"
 
     if OK_SKIP_LABELS.intersection(pr_info.labels):
         return True, "Don't try new checks for release/backports/cherry-picks"


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
"do not tes label" is handled in ci.py, not run_check

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
