### PR TITLE
Fix clang-tidy

### DIFF
--- a/src/Functions/FunctionsStringHashFixedString.cpp
+++ b/src/Functions/FunctionsStringHashFixedString.cpp
@@ -172,7 +172,7 @@ struct SHA512Impl256
         /// SSL library that we use, for S390X architecture only OpenSSL is supported. But the SHA512-256, SHA512_256_Init,
         /// SHA512_256_Update, SHA512_256_Final methods to calculate hash (similar to the other SHA functions) aren't available
         /// in the current version of OpenSSL that we use which necessitates the use of the EVP interface.
-        auto md_ctx = EVP_MD_CTX_create();
+        auto * md_ctx = EVP_MD_CTX_create();
         EVP_DigestInit_ex(md_ctx, EVP_sha512_256(), nullptr /*engine*/);
         EVP_DigestUpdate(md_ctx, begin, size);
         EVP_DigestFinal_ex(md_ctx, out_char_data, nullptr /*size*/);


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

https://github.com/ClickHouse/ClickHouse/actions/runs/7290020260/job/19867060594?pr=58130#step:8:14204