### PR TITLE
Run build report check job on build failures, fix

### DIFF
--- a/.github/workflows/backport_branches.yml
+++ b/.github/workflows/backport_branches.yml
@@ -157,7 +157,8 @@ jobs:
 ##################################### BUILD REPORTER #######################################
 ############################################################################################
   BuilderReport:
-    if: ${{ !failure() && !cancelled() }}
+    # run report check for failed builds to indicate the CI error
+    if: ${{ !cancelled() }}
     needs:
       - RunConfig
       - BuilderDebAarch64
@@ -177,7 +178,8 @@ jobs:
       run_command: |
         python3 build_report_check.py "$CHECK_NAME"
   BuilderSpecialReport:
-    if: ${{ !failure() && !cancelled() }}
+    # run report check for failed builds to indicate the CI error
+    if: ${{ !cancelled() }}
     needs:
       - RunConfig
       - BuilderBinDarwin

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -262,6 +262,8 @@ jobs:
 ##################################### BUILD REPORTER #######################################
 ############################################################################################
   BuilderReport:
+    # run report check for failed builds to indicate the CI error
+    if: ${{ !cancelled() }}
     needs:
       - RunConfig
       - BuilderBinRelease
@@ -272,7 +274,6 @@ jobs:
       - BuilderDebRelease
       - BuilderDebTsan
       - BuilderDebUBsan
-    if: ${{ !failure() && !cancelled() }}
     uses: ./.github/workflows/reusable_test.yml
     with:
       test_name: ClickHouse build check
@@ -285,7 +286,8 @@ jobs:
       run_command: |
         python3 build_report_check.py "$CHECK_NAME"
   BuilderSpecialReport:
-    if: ${{ !failure() && !cancelled() }}
+    # run report check for failed builds to indicate the CI error
+    if: ${{ !cancelled() }}
     needs:
       - RunConfig
       - BuilderBinAarch64

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -291,6 +291,8 @@ jobs:
 ##################################### BUILD REPORTER #######################################
 ############################################################################################
   BuilderReport:
+    # run report check for failed builds to indicate the CI error
+    if: ${{ !cancelled() }}
     needs:
       - RunConfig
       - BuilderBinRelease
@@ -301,7 +303,6 @@ jobs:
       - BuilderDebRelease
       - BuilderDebTsan
       - BuilderDebUBsan
-    if: ${{ !failure() && !cancelled() }}
     uses: ./.github/workflows/reusable_test.yml
     with:
       test_name: ClickHouse build check
@@ -314,7 +315,8 @@ jobs:
       run_command: |
         python3 build_report_check.py "$CHECK_NAME"
   BuilderSpecialReport:
-    if: ${{ !failure() && !cancelled() }}
+    # run report check for failed builds to indicate the CI error
+    if: ${{ !cancelled() }}
     needs:
       - RunConfig
       - BuilderBinAarch64

--- a/.github/workflows/release_branches.yml
+++ b/.github/workflows/release_branches.yml
@@ -172,6 +172,8 @@ jobs:
 ##################################### BUILD REPORTER #######################################
 ############################################################################################
   BuilderReport:
+    # run report check for failed builds to indicate the CI error
+    if: ${{ !cancelled() }}
     needs:
       - RunConfig
       - BuilderDebRelease
@@ -181,7 +183,6 @@ jobs:
       - BuilderDebUBsan
       - BuilderDebMsan
       - BuilderDebDebug
-    if: ${{ !failure() && !cancelled() }}
     uses: ./.github/workflows/reusable_test.yml
     with:
       test_name: ClickHouse build check
@@ -194,7 +195,8 @@ jobs:
       run_command: |
         python3 build_report_check.py "$CHECK_NAME"
   BuilderSpecialReport:
-    if: ${{ !failure() && !cancelled() }}
+    # run report check for failed builds to indicate the CI error
+    if: ${{ !cancelled() }}
     needs:
       - RunConfig
       - BuilderDebRelease

--- a/.github/workflows/reusable_build.yml
+++ b/.github/workflows/reusable_build.yml
@@ -76,6 +76,8 @@ jobs:
         run: |
           python3 "$GITHUB_WORKSPACE/tests/ci/build_check.py" "$BUILD_NAME"
       - name: Post
+        # it still be build report to upload for failed build job
+        if: always()
         run: |
           python3 "$GITHUB_WORKSPACE/tests/ci/ci.py" --infile ${{ toJson(inputs.data) }} --post --job-name '${{inputs.build_name}}'
       - name: Mark as done


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
 - Build report job runs on failure: remove `if: ! failure()` in yml
 - add `if: always()` in reusable_build's "Post" step to upload the report for failed builds
 

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
