### PR TITLE
Fix system.stack_trace for threads with blocked SIGRTMIN (resubmit)

### DIFF
--- a/src/Storages/System/StorageSystemStackTrace.cpp
+++ b/src/Storages/System/StorageSystemStackTrace.cpp
@@ -1,4 +1,4 @@
-#ifdef OS_LINUX /// Because of 'sigqueue' functions and RT signals.
+#ifdef OS_LINUX /// Because of 'rt_tgsigqueueinfo' functions and RT signals.
 
 #include <csignal>
 #include <poll.h>
@@ -28,6 +28,12 @@
 #include <Processors/Sources/SourceFromSingleChunk.h>
 #include <QueryPipeline/Pipe.h>
 #include <base/getThreadId.h>
+#include <sys/syscall.h>
+
+int rt_tgsigqueueinfo(pid_t tgid, pid_t tid, int sig, siginfo_t *info)
+{
+    return static_cast<int>(syscall(__NR_rt_tgsigqueueinfo, tgid, tid, sig, info));
+}
 
 
 namespace DB
@@ -48,7 +54,7 @@ namespace
 {
 
 // Initialized in StorageSystemStackTrace's ctor and used in signalHandler.
-std::atomic<pid_t> expected_pid;
+std::atomic<pid_t> server_pid;
 const int sig = SIGRTMIN;
 
 std::atomic<int> sequence_num = 0;    /// For messages sent via pipe.
@@ -80,7 +86,7 @@ void signalHandler(int, siginfo_t * info, void * context)
 
     /// In case malicious user is sending signals manually (for unknown reason).
     /// If we don't check - it may break our synchronization.
-    if (info->si_pid != expected_pid)
+    if (info->si_pid != server_pid)
         return;
 
     /// Signal received too late.
@@ -287,20 +293,22 @@ protected:
                 Stopwatch watch;
                 SCOPE_EXIT({ signals_sent_ms += watch.elapsedMilliseconds(); });
 
-                sigval sig_value{};
+                siginfo_t sig_info{};
+                sig_info.si_code = SI_QUEUE; /// sigqueue()
+                sig_info.si_pid = server_pid;
+                sig_info.si_value.sival_int = sequence_num.load(std::memory_order_acquire);
 
-                sig_value.sival_int = sequence_num.load(std::memory_order_acquire);
-                if (0 != ::sigqueue(static_cast<int>(tid), sig, sig_value))
+                if (0 != ::rt_tgsigqueueinfo(server_pid, static_cast<pid_t>(tid), sig, &sig_info))
                 {
                     /// The thread may has been already finished.
                     if (ESRCH == errno)
                         continue;
 
-                    throw ErrnoException(ErrorCodes::CANNOT_SIGQUEUE, "Cannot send signal with sigqueue");
+                    throw ErrnoException(ErrorCodes::CANNOT_SIGQUEUE, "Cannot queue a signal");
                 }
 
                 /// Just in case we will wait for pipe with timeout. In case signal didn't get processed.
-                if (wait(pipe_read_timeout_ms) && sig_value.sival_int == data_ready_num.load(std::memory_order_acquire))
+                if (wait(pipe_read_timeout_ms) && sig_info.si_value.sival_int == data_ready_num.load(std::memory_order_acquire))
                 {
                     size_t stack_trace_size = stack_trace.getSize();
                     size_t stack_trace_offset = stack_trace.getOffset();
@@ -317,7 +325,7 @@ protected:
                 }
                 else
                 {
-                    LOG_DEBUG(log, "Cannot obtain a stack trace for thread {}", tid);
+                    LOG_DEBUG(log, "Cannot obtain a stack trace for thread {} ({})", tid, thread_name);
 
                     res_columns[res_index++]->insert(thread_name);
                     res_columns[res_index++]->insert(tid);
@@ -396,7 +404,7 @@ StorageSystemStackTrace::StorageSystemStackTrace(const StorageID & table_id_)
     notification_pipe.open();
 
     /// Setup signal handler.
-    expected_pid = getpid();
+    server_pid = getpid();
     struct sigaction sa{};
     sa.sa_sigaction = signalHandler;
     sa.sa_flags = SA_SIGINFO;

--- a/src/Storages/System/StorageSystemStackTrace.cpp
+++ b/src/Storages/System/StorageSystemStackTrace.cpp
@@ -30,12 +30,6 @@
 #include <base/getThreadId.h>
 #include <sys/syscall.h>
 
-int rt_tgsigqueueinfo(pid_t tgid, pid_t tid, int sig, siginfo_t *info)
-{
-    return static_cast<int>(syscall(__NR_rt_tgsigqueueinfo, tgid, tid, sig, info));
-}
-
-
 namespace DB
 {
 
@@ -55,7 +49,7 @@ namespace
 
 // Initialized in StorageSystemStackTrace's ctor and used in signalHandler.
 std::atomic<pid_t> server_pid;
-const int sig = SIGRTMIN;
+const int STACK_TRACE_SERVICE_SIGNAL = SIGRTMIN;
 
 std::atomic<int> sequence_num = 0;    /// For messages sent via pipe.
 std::atomic<int> data_ready_num = 0;
@@ -78,6 +72,11 @@ char query_id_data[max_query_id_size];
 size_t query_id_size = 0;
 
 LazyPipeFDs notification_pipe;
+
+int rt_tgsigqueueinfo(pid_t tgid, pid_t tid, int sig, siginfo_t *info)
+{
+    return static_cast<int>(syscall(__NR_rt_tgsigqueueinfo, tgid, tid, sig, info));
+}
 
 void signalHandler(int, siginfo_t * info, void * context)
 {
@@ -220,6 +219,39 @@ ThreadIdToName getFilteredThreadNames(ASTPtr query, ContextPtr context, const Pa
     return tid_to_name;
 }
 
+bool parseHexNumber(std::string_view sv, UInt64 & res)
+{
+    errno = 0; /// Functions strto* don't clear errno.
+    char * pos_integer = const_cast<char *>(sv.begin());
+    res = std::strtoull(sv.begin(), &pos_integer, 16);
+    return (pos_integer == sv.begin() + sv.size() && errno != ERANGE);
+}
+bool isSignalBlocked(UInt64 tid, int signal)
+{
+    String buffer;
+
+    ReadBufferFromFile status(fmt::format("/proc/{}/status", tid));
+    while (!status.eof())
+    {
+        readEscapedStringUntilEOL(buffer, status);
+        if (!status.eof())
+            ++status.position();
+        if (buffer.starts_with("SigBlk:"))
+            break;
+    }
+    status.close();
+
+    std::string_view line(buffer);
+    line = line.substr(strlen("SigBlk:"));
+    line = line.substr(0, line.rend() - std::find_if_not(line.rbegin(), line.rend(), ::isspace));
+
+    UInt64 sig_blk;
+    if (parseHexNumber(line, sig_blk))
+        return sig_blk & signal;
+    else
+        return false;
+}
+
 /// Send a signal to every thread and wait for result.
 /// We must wait for every thread one by one sequentially,
 ///  because there is a limit on number of queued signals in OS and otherwise signals may get lost.
@@ -238,6 +270,7 @@ public:
         , proc_it("/proc/self/task")
         /// It shouldn't be possible to do concurrent reads from this table.
         , lock(mutex)
+        , signal_str(strsignal(STACK_TRACE_SERVICE_SIGNAL)) /// NOLINT(concurrency-mt-unsafe) // not thread-safe but ok in this context
     {
         /// Create a mask of what columns are needed in the result.
         NameSet names_set(column_names.begin(), column_names.end());
@@ -289,55 +322,64 @@ protected:
             }
             else
             {
-                ++signals_sent;
-                Stopwatch watch;
-                SCOPE_EXIT({ signals_sent_ms += watch.elapsedMilliseconds(); });
-
-                siginfo_t sig_info{};
-                sig_info.si_code = SI_QUEUE; /// sigqueue()
-                sig_info.si_pid = server_pid;
-                sig_info.si_value.sival_int = sequence_num.load(std::memory_order_acquire);
-
-                if (0 != ::rt_tgsigqueueinfo(server_pid, static_cast<pid_t>(tid), sig, &sig_info))
+                bool signal_blocked = isSignalBlocked(tid, STACK_TRACE_SERVICE_SIGNAL);
+                if (!signal_blocked)
                 {
-                    /// The thread may has been already finished.
-                    if (ESRCH == errno)
+                    ++signals_sent;
+                    Stopwatch watch;
+                    SCOPE_EXIT({
+                        signals_sent_ms += watch.elapsedMilliseconds();
+
+                        /// Signed integer overflow is undefined behavior in both C and C++. However, according to
+                        /// C++ standard, Atomic signed integer arithmetic is defined to use two's complement; there
+                        /// are no undefined results. See https://en.cppreference.com/w/cpp/atomic/atomic and
+                        /// http://eel.is/c++draft/atomics.types.generic#atomics.types.int-8
+                        ++sequence_num;
+                    });
+
+                    siginfo_t sig_info{};
+                    sig_info.si_code = SI_QUEUE; /// sigqueue()
+                    sig_info.si_pid = server_pid;
+                    sig_info.si_value.sival_int = sequence_num.load(std::memory_order_acquire);
+
+                    if (0 != rt_tgsigqueueinfo(server_pid, static_cast<pid_t>(tid), STACK_TRACE_SERVICE_SIGNAL, &sig_info))
+                    {
+                        /// The thread may has been already finished.
+                        if (ESRCH == errno)
+                            continue;
+
+                        throw ErrnoException(ErrorCodes::CANNOT_SIGQUEUE, "Cannot queue a signal");
+                    }
+
+                    /// Just in case we will wait for pipe with timeout. In case signal didn't get processed.
+                    if (wait(pipe_read_timeout_ms) && sig_info.si_value.sival_int == data_ready_num.load(std::memory_order_acquire))
+                    {
+                        size_t stack_trace_size = stack_trace.getSize();
+                        size_t stack_trace_offset = stack_trace.getOffset();
+
+                        Array arr;
+                        arr.reserve(stack_trace_size - stack_trace_offset);
+                        for (size_t i = stack_trace_offset; i < stack_trace_size; ++i)
+                            arr.emplace_back(reinterpret_cast<intptr_t>(stack_trace.getFramePointers()[i]));
+
+                        res_columns[res_index++]->insert(thread_name);
+                        res_columns[res_index++]->insert(tid);
+                        res_columns[res_index++]->insertData(query_id_data, query_id_size);
+                        res_columns[res_index++]->insert(arr);
+
                         continue;
-
-                    throw ErrnoException(ErrorCodes::CANNOT_SIGQUEUE, "Cannot queue a signal");
+                    }
                 }
 
-                /// Just in case we will wait for pipe with timeout. In case signal didn't get processed.
-                if (wait(pipe_read_timeout_ms) && sig_info.si_value.sival_int == data_ready_num.load(std::memory_order_acquire))
-                {
-                    size_t stack_trace_size = stack_trace.getSize();
-                    size_t stack_trace_offset = stack_trace.getOffset();
-
-                    Array arr;
-                    arr.reserve(stack_trace_size - stack_trace_offset);
-                    for (size_t i = stack_trace_offset; i < stack_trace_size; ++i)
-                        arr.emplace_back(reinterpret_cast<intptr_t>(stack_trace.getFramePointers()[i]));
-
-                    res_columns[res_index++]->insert(thread_name);
-                    res_columns[res_index++]->insert(tid);
-                    res_columns[res_index++]->insertData(query_id_data, query_id_size);
-                    res_columns[res_index++]->insert(arr);
-                }
+                if (signal_blocked)
+                    LOG_DEBUG(log, "Thread {} ({}) blocks SIG{} signal", tid, thread_name, signal_str);
                 else
-                {
                     LOG_DEBUG(log, "Cannot obtain a stack trace for thread {} ({})", tid, thread_name);
 
-                    res_columns[res_index++]->insert(thread_name);
-                    res_columns[res_index++]->insert(tid);
-                    res_columns[res_index++]->insertDefault();
-                    res_columns[res_index++]->insertDefault();
-                }
-
-                /// Signed integer overflow is undefined behavior in both C and C++. However, according to
-                /// C++ standard, Atomic signed integer arithmetic is defined to use two's complement; there
-                /// are no undefined results. See https://en.cppreference.com/w/cpp/atomic/atomic and
-                /// http://eel.is/c++draft/atomics.types.generic#atomics.types.int-8
-                ++sequence_num;
+                res_columns[res_index++]->insert(thread_name);
+                res_columns[res_index++]->insert(tid);
+                res_columns[res_index++]->insertDefault();
+                res_columns[res_index++]->insertDefault();
             }
         }
         LOG_TRACE(log, "Send signal to {} threads (total), took {} ms", signals_sent, signals_sent_ms);
@@ -366,6 +408,7 @@ private:
     size_t signals_sent_ms = 0;
 
     std::unique_lock<std::mutex> lock;
+    const char * signal_str;
 
     ColumnPtr getFilteredThreadIds()
     {
@@ -412,10 +455,10 @@ StorageSystemStackTrace::StorageSystemStackTrace(const StorageID & table_id_)
     if (sigemptyset(&sa.sa_mask))
         throw ErrnoException(ErrorCodes::CANNOT_MANIPULATE_SIGSET, "Cannot set signal handler");
 
-    if (sigaddset(&sa.sa_mask, sig))
+    if (sigaddset(&sa.sa_mask, STACK_TRACE_SERVICE_SIGNAL))
         throw ErrnoException(ErrorCodes::CANNOT_MANIPULATE_SIGSET, "Cannot set signal handler");
 
-    if (sigaction(sig, &sa, nullptr))
+    if (sigaction(STACK_TRACE_SERVICE_SIGNAL, &sa, nullptr))
         throw ErrnoException(ErrorCodes::CANNOT_SET_SIGNAL_HANDLER, "Cannot set signal handler");
 }
 


### PR DESCRIPTION
Some third-party libraries (i.e. librdkafka) could block it, and in this case system.stack_trace will return stacktrace for the main process (usually, basically it could be any thread with non blocked signal).

By replacing sigqueue() with more precise rt_tgsigqueueinfo(), other threads will not respond to the signal.

(cherry picked from commit 106042cf4162d261364d39cfa1ec85e940c93b5b, https://github.com/ClickHouse/ClickHouse/pull/57907)

Note, initial PR got reverted due to clickhouse-test hangs - https://github.com/ClickHouse/ClickHouse/pull/57974#issuecomment-1860944343, that was because of threads for io_uring.

There are two known cases of threads with blocked signals (almost all of signals):
- librdkafka - https://github.com/confluentinc/librdkafka/issues/78/#issuecomment-1858177682
- io_uring (which didn't always work like that - [LKML](https://lore.kernel.org/all/5ee8ad82-e145-3ed6-1421-eede1ada0d7e@kernel.dk/))

Now `system.stack_trace` will send the signal only if thread do not block it, so this problem for `clickhouse-test` should be fixed (another fix will be is to decrease the `storage_system_stack_trace_pipe_read_timeout_ms`)

### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix system.stack_trace for threads with blocked SIGRTMIN (and also send signal to the threads only if it is not blocked to avoid waiting `storage_system_stack_trace_pipe_read_timeout_ms` when it does not make any sense)

Resubmit of: #57907