### PR TITLE
MergeTree FINAL to not compare rows from same non-L0 part

### DIFF
--- a/src/Processors/Chunk.cpp
+++ b/src/Processors/Chunk.cpp
@@ -19,8 +19,11 @@ Chunk::Chunk(DB::Columns columns_, UInt64 num_rows_) : columns(std::move(columns
     checkNumRowsIsConsistent();
 }
 
-Chunk::Chunk(Columns columns_, UInt64 num_rows_, ChunkInfoPtr chunk_info_, int part_level_)
-    : columns(std::move(columns_)), num_rows(num_rows_), chunk_info(std::move(chunk_info_)), origin_merge_tree_part_level(part_level_)
+Chunk::Chunk(Columns columns_, UInt64 num_rows_, ChunkInfoPtr chunk_info_, std::optional<UInt32> part_level_)
+    : columns(std::move(columns_))
+    , num_rows(num_rows_)
+    , chunk_info(std::move(chunk_info_))
+    , origin_merge_tree_part_level(std::move(part_level_))
 {
     checkNumRowsIsConsistent();
 }
@@ -41,8 +44,11 @@ Chunk::Chunk(MutableColumns columns_, UInt64 num_rows_)
     checkNumRowsIsConsistent();
 }
 
-Chunk::Chunk(MutableColumns columns_, UInt64 num_rows_, ChunkInfoPtr chunk_info_, int part_level_)
-    : columns(unmuteColumns(std::move(columns_))), num_rows(num_rows_), chunk_info(std::move(chunk_info_)), origin_merge_tree_part_level(part_level_)
+Chunk::Chunk(MutableColumns columns_, UInt64 num_rows_, ChunkInfoPtr chunk_info_, std::optional<UInt32> part_level_)
+    : columns(unmuteColumns(std::move(columns_)))
+    , num_rows(num_rows_)
+    , chunk_info(std::move(chunk_info_))
+    , origin_merge_tree_part_level(std::move(part_level_))
 {
     checkNumRowsIsConsistent();
 }
@@ -236,7 +242,7 @@ Chunk cloneConstWithDefault(const Chunk & chunk, size_t num_rows)
 
 bool Chunk::mayContainRowsWithSamePrimaryKeys() const
 {
-    return origin_merge_tree_part_level < 1;
+    return unlikely(!origin_merge_tree_part_level) || !(*origin_merge_tree_part_level);
 }
 
 }

--- a/src/Processors/Chunk.cpp
+++ b/src/Processors/Chunk.cpp
@@ -238,9 +238,4 @@ Chunk cloneConstWithDefault(const Chunk & chunk, size_t num_rows)
     return Chunk(std::move(columns), num_rows);
 }
 
-bool Chunk::doNotContainRowsWithSamePrimaryKeys() const
-{
-    return likely(chunk_info) && chunk_info->getMergeTreePartLevel() > 0;
-}
-
 }

--- a/src/Processors/Chunk.cpp
+++ b/src/Processors/Chunk.cpp
@@ -19,11 +19,10 @@ Chunk::Chunk(DB::Columns columns_, UInt64 num_rows_) : columns(std::move(columns
     checkNumRowsIsConsistent();
 }
 
-Chunk::Chunk(Columns columns_, UInt64 num_rows_, ChunkInfoPtr chunk_info_, std::optional<UInt32> part_level_)
+Chunk::Chunk(Columns columns_, UInt64 num_rows_, ChunkInfoPtr chunk_info_)
     : columns(std::move(columns_))
     , num_rows(num_rows_)
     , chunk_info(std::move(chunk_info_))
-    , origin_merge_tree_part_level(std::move(part_level_))
 {
     checkNumRowsIsConsistent();
 }
@@ -44,18 +43,17 @@ Chunk::Chunk(MutableColumns columns_, UInt64 num_rows_)
     checkNumRowsIsConsistent();
 }
 
-Chunk::Chunk(MutableColumns columns_, UInt64 num_rows_, ChunkInfoPtr chunk_info_, std::optional<UInt32> part_level_)
+Chunk::Chunk(MutableColumns columns_, UInt64 num_rows_, ChunkInfoPtr chunk_info_)
     : columns(unmuteColumns(std::move(columns_)))
     , num_rows(num_rows_)
     , chunk_info(std::move(chunk_info_))
-    , origin_merge_tree_part_level(std::move(part_level_))
 {
     checkNumRowsIsConsistent();
 }
 
 Chunk Chunk::clone() const
 {
-    return Chunk(getColumns(), getNumRows(), chunk_info, origin_merge_tree_part_level);
+    return Chunk(getColumns(), getNumRows(), chunk_info);
 }
 
 void Chunk::setColumns(Columns columns_, UInt64 num_rows_)
@@ -240,9 +238,9 @@ Chunk cloneConstWithDefault(const Chunk & chunk, size_t num_rows)
     return Chunk(std::move(columns), num_rows);
 }
 
-bool Chunk::mayContainRowsWithSamePrimaryKeys() const
+bool Chunk::doNotContainRowsWithSamePrimaryKeys() const
 {
-    return unlikely(!origin_merge_tree_part_level) || !(*origin_merge_tree_part_level);
+    return likely(chunk_info) && chunk_info->getMergeTreePartLevel() > 0;
 }
 
 }

--- a/src/Processors/Chunk.cpp
+++ b/src/Processors/Chunk.cpp
@@ -19,8 +19,8 @@ Chunk::Chunk(DB::Columns columns_, UInt64 num_rows_) : columns(std::move(columns
     checkNumRowsIsConsistent();
 }
 
-Chunk::Chunk(Columns columns_, UInt64 num_rows_, ChunkInfoPtr chunk_info_)
-    : columns(std::move(columns_)), num_rows(num_rows_), chunk_info(std::move(chunk_info_))
+Chunk::Chunk(Columns columns_, UInt64 num_rows_, ChunkInfoPtr chunk_info_, int part_level_)
+    : columns(std::move(columns_)), num_rows(num_rows_), chunk_info(std::move(chunk_info_)), origin_merge_tree_part_level(part_level_)
 {
     checkNumRowsIsConsistent();
 }
@@ -41,15 +41,15 @@ Chunk::Chunk(MutableColumns columns_, UInt64 num_rows_)
     checkNumRowsIsConsistent();
 }
 
-Chunk::Chunk(MutableColumns columns_, UInt64 num_rows_, ChunkInfoPtr chunk_info_)
-    : columns(unmuteColumns(std::move(columns_))), num_rows(num_rows_), chunk_info(std::move(chunk_info_))
+Chunk::Chunk(MutableColumns columns_, UInt64 num_rows_, ChunkInfoPtr chunk_info_, int part_level_)
+    : columns(unmuteColumns(std::move(columns_))), num_rows(num_rows_), chunk_info(std::move(chunk_info_)), origin_merge_tree_part_level(part_level_)
 {
     checkNumRowsIsConsistent();
 }
 
 Chunk Chunk::clone() const
 {
-    return Chunk(getColumns(), getNumRows(), chunk_info);
+    return Chunk(getColumns(), getNumRows(), chunk_info, origin_merge_tree_part_level);
 }
 
 void Chunk::setColumns(Columns columns_, UInt64 num_rows_)
@@ -232,6 +232,11 @@ Chunk cloneConstWithDefault(const Chunk & chunk, size_t num_rows)
     }
 
     return Chunk(std::move(columns), num_rows);
+}
+
+bool Chunk::mayContainRowsWithSamePrimaryKeys() const
+{
+    return origin_merge_tree_part_level < 1;
 }
 
 }

--- a/src/Processors/Chunk.h
+++ b/src/Processors/Chunk.h
@@ -11,9 +11,6 @@ class ChunkInfo
 public:
     virtual ~ChunkInfo() = default;
     ChunkInfo() = default;
-
-    /// To be overriden by MergeTreePartLevelInfo
-    virtual UInt64 getMergeTreePartLevel() const { return 0; }
 };
 
 using ChunkInfoPtr = std::shared_ptr<const ChunkInfo>;
@@ -107,9 +104,6 @@ public:
     void append(const Chunk & chunk);
     void append(const Chunk & chunk, size_t from, size_t length); // append rows [from, from+length) of chunk
 
-    /// Only use in FINAL
-    bool doNotContainRowsWithSamePrimaryKeys() const;
-
 private:
     Columns columns;
     UInt64 num_rows = 0;
@@ -119,17 +113,6 @@ private:
 };
 
 using Chunks = std::vector<Chunk>;
-
-/// To carry part level if chunk is produced by a merge tree source
-class MergeTreePartLevelInfo : public ChunkInfo
-{
-public:
-    MergeTreePartLevelInfo() = default;
-    explicit MergeTreePartLevelInfo(UInt64 part_level) : origin_merge_tree_part_level(part_level) { }
-    UInt64 getMergeTreePartLevel() const override { return origin_merge_tree_part_level; }
-private:
-    UInt64 origin_merge_tree_part_level = 0;
-};
 
 /// AsyncInsert needs two kinds of information:
 /// - offsets of different sub-chunks

--- a/src/Processors/Chunk.h
+++ b/src/Processors/Chunk.h
@@ -38,16 +38,15 @@ public:
         : columns(std::move(other.columns))
         , num_rows(other.num_rows)
         , chunk_info(std::move(other.chunk_info))
-        , origin_merge_tree_part_level(other.origin_merge_tree_part_level)
+        , origin_merge_tree_part_level(std::move(other.origin_merge_tree_part_level))
     {
         other.num_rows = 0;
-        other.origin_merge_tree_part_level = -1;
     }
 
     Chunk(Columns columns_, UInt64 num_rows_);
-    Chunk(Columns columns_, UInt64 num_rows_, ChunkInfoPtr chunk_info_, int part_level_ = -1);
+    Chunk(Columns columns_, UInt64 num_rows_, ChunkInfoPtr chunk_info_, std::optional<UInt32> part_level_ = {});
     Chunk(MutableColumns columns_, UInt64 num_rows_);
-    Chunk(MutableColumns columns_, UInt64 num_rows_, ChunkInfoPtr chunk_info_, int part_level_ = -1);
+    Chunk(MutableColumns columns_, UInt64 num_rows_, ChunkInfoPtr chunk_info_, std::optional<UInt32> part_level_ = {});
 
     Chunk & operator=(const Chunk & other) = delete;
     Chunk & operator=(Chunk && other) noexcept
@@ -55,9 +54,8 @@ public:
         columns = std::move(other.columns);
         chunk_info = std::move(other.chunk_info);
         num_rows = other.num_rows;
-        origin_merge_tree_part_level = other.origin_merge_tree_part_level;
+        origin_merge_tree_part_level = std::move(other.origin_merge_tree_part_level);
         other.num_rows = 0;
-        other.origin_merge_tree_part_level = -1;
         return *this;
     }
 
@@ -76,7 +74,7 @@ public:
         num_rows = 0;
         columns.clear();
         chunk_info.reset();
-        origin_merge_tree_part_level = -1;
+        origin_merge_tree_part_level.reset();
     }
 
     const Columns & getColumns() const { return columns; }
@@ -118,8 +116,8 @@ private:
     UInt64 num_rows = 0;
     ChunkInfoPtr chunk_info;
 
-    /// It can be non-negative when Chunk produced by a merge tree source
-    Int32 origin_merge_tree_part_level = -1;
+    /// It can be non-nullopt when Chunk produced by a merge tree source
+    std::optional<UInt64> origin_merge_tree_part_level;
 
     void checkNumRowsIsConsistent();
 };

--- a/src/Processors/Merges/Algorithms/AggregatingSortedAlgorithm.cpp
+++ b/src/Processors/Merges/Algorithms/AggregatingSortedAlgorithm.cpp
@@ -305,7 +305,7 @@ IMergingAlgorithm::Status AggregatingSortedAlgorithm::merge()
 
         {
             detail::RowRef current_key;
-            current_key.set(current);
+            setRowRef(current_key, current);
 
             key_differs = last_key.empty() || !last_key.hasEqualSortColumnsWith(current_key);
 

--- a/src/Processors/Merges/Algorithms/AggregatingSortedAlgorithm.cpp
+++ b/src/Processors/Merges/Algorithms/AggregatingSortedAlgorithm.cpp
@@ -307,7 +307,7 @@ IMergingAlgorithm::Status AggregatingSortedAlgorithm::merge()
             detail::RowRef current_key;
             setRowRef(current_key, current);
 
-            key_differs = last_key.empty() || !last_key.hasEqualSortColumnsWith(current_key);
+            key_differs = last_key.empty() || rowsHaveDifferentSortColumns(last_key, current_key);
 
             last_key = current_key;
             last_chunk_sort_columns.clear();

--- a/src/Processors/Merges/Algorithms/CollapsingSortedAlgorithm.cpp
+++ b/src/Processors/Merges/Algorithms/CollapsingSortedAlgorithm.cpp
@@ -144,7 +144,7 @@ IMergingAlgorithm::Status CollapsingSortedAlgorithm::merge()
         if (last_row.empty())
             setRowRef(last_row, current);
 
-        bool key_differs = !last_row.hasEqualSortColumnsWith(current_row);
+        bool key_differs = rowsHaveDifferentSortColumns(last_row, current_row);
         if (key_differs)
         {
             /// if there are enough rows and the last one is calculated completely

--- a/src/Processors/Merges/Algorithms/IMergingAlgorithmWithDelayedChunk.h
+++ b/src/Processors/Merges/Algorithms/IMergingAlgorithmWithDelayedChunk.h
@@ -24,6 +24,7 @@ protected:
     void initializeQueue(Inputs inputs);
     void updateCursor(Input & input, size_t source_num);
     bool skipLastRowFor(size_t input_number) const { return current_inputs[input_number].skip_last_row; }
+    void setRowRef(detail::RowRef & row, SortCursor & cursor) { row.set(cursor, current_inputs[cursor.impl->order].chunk.mayContainRowsWithSamePrimaryKeys()); }
 
 private:
     Block header;

--- a/src/Processors/Merges/Algorithms/IMergingAlgorithmWithDelayedChunk.h
+++ b/src/Processors/Merges/Algorithms/IMergingAlgorithmWithDelayedChunk.h
@@ -24,7 +24,7 @@ protected:
     void initializeQueue(Inputs inputs);
     void updateCursor(Input & input, size_t source_num);
     bool skipLastRowFor(size_t input_number) const { return current_inputs[input_number].skip_last_row; }
-    void setRowRef(detail::RowRef & row, SortCursor & cursor) { row.set(cursor, current_inputs[cursor.impl->order].chunk.mayContainRowsWithSamePrimaryKeys()); }
+    void setRowRef(detail::RowRef & row, SortCursor & cursor) { row.set(cursor, current_inputs[cursor.impl->order].chunk.doNotContainRowsWithSamePrimaryKeys()); }
 
 private:
     Block header;

--- a/src/Processors/Merges/Algorithms/IMergingAlgorithmWithDelayedChunk.h
+++ b/src/Processors/Merges/Algorithms/IMergingAlgorithmWithDelayedChunk.h
@@ -24,7 +24,15 @@ protected:
     void initializeQueue(Inputs inputs);
     void updateCursor(Input & input, size_t source_num);
     bool skipLastRowFor(size_t input_number) const { return current_inputs[input_number].skip_last_row; }
-    void setRowRef(detail::RowRef & row, SortCursor & cursor) { row.set(cursor, current_inputs[cursor.impl->order].chunk.doNotContainRowsWithSamePrimaryKeys()); }
+    void setRowRef(detail::RowRef & row, SortCursor & cursor) { row.set(cursor); }
+    bool rowsHaveDifferentSortColumns(const detail::RowRef & lhs, const detail::RowRef & rhs)
+    {
+        /// By the time this method is called, `inputs_origin_merge_tree_part_level[lhs.source_stream_index]` must have been
+        /// initialized in either `initializeQueue` or `updateCursor`
+        if (lhs.source_stream_index == rhs.source_stream_index && inputs_origin_merge_tree_part_level[lhs.source_stream_index] > 0)
+            return true;
+        return !lhs.hasEqualSortColumnsWith(rhs);
+    }
 
 private:
     Block header;
@@ -32,6 +40,8 @@ private:
     /// Inputs currently being merged.
     Inputs current_inputs;
     SortCursorImpls cursors;
+
+    std::vector<size_t> inputs_origin_merge_tree_part_level;
 
     /// In merging algorithm, we need to compare current sort key with the last one.
     /// So, sorting columns for last row needed to be stored.

--- a/src/Processors/Merges/Algorithms/IMergingAlgorithmWithSharedChunks.cpp
+++ b/src/Processors/Merges/Algorithms/IMergingAlgorithmWithSharedChunks.cpp
@@ -1,4 +1,5 @@
 #include <Processors/Merges/Algorithms/IMergingAlgorithmWithSharedChunks.h>
+#include <Processors/Merges/Algorithms/MergeTreePartLevelInfo.h>
 
 namespace DB
 {
@@ -10,6 +11,7 @@ IMergingAlgorithmWithSharedChunks::IMergingAlgorithmWithSharedChunks(
     , chunk_allocator(num_inputs + max_row_refs)
     , cursors(num_inputs)
     , sources(num_inputs)
+    , sources_origin_merge_tree_part_level(num_inputs)
     , out_row_sources_buf(out_row_sources_buf_)
 {
 }
@@ -41,6 +43,8 @@ void IMergingAlgorithmWithSharedChunks::initialize(Inputs inputs)
 
         source.chunk->all_columns = cursors[source_num].all_columns;
         source.chunk->sort_columns = cursors[source_num].sort_columns;
+
+        sources_origin_merge_tree_part_level[source_num] = getPartLevelFromChunk(*source.chunk);
     }
 
     queue = SortingQueue<SortCursor>(cursors);
@@ -57,6 +61,8 @@ void IMergingAlgorithmWithSharedChunks::consume(Input & input, size_t source_num
 
     source.chunk->all_columns = cursors[source_num].all_columns;
     source.chunk->sort_columns = cursors[source_num].sort_columns;
+
+    sources_origin_merge_tree_part_level[source_num] = getPartLevelFromChunk(*source.chunk);
 
     queue.push(cursors[source_num]);
 }

--- a/src/Processors/Merges/Algorithms/IMergingAlgorithmWithSharedChunks.h
+++ b/src/Processors/Merges/Algorithms/IMergingAlgorithmWithSharedChunks.h
@@ -35,6 +35,7 @@ protected:
     /// Sources currently being merged.
     using Sources = std::vector<Source>;
     Sources sources;
+    std::vector<size_t> sources_origin_merge_tree_part_level;
 
     SortingQueue<SortCursor> queue;
 
@@ -45,6 +46,14 @@ protected:
     using RowRef = detail::RowRefWithOwnedChunk;
     void setRowRef(RowRef & row, SortCursor & cursor) { row.set(cursor, sources[cursor.impl->order].chunk); }
     bool skipLastRowFor(size_t input_number) const { return sources[input_number].skip_last_row; }
+    bool rowsHaveDifferentSortColumns(const RowRef & lhs, const RowRef & rhs)
+    {
+        /// By the time this method is called, `sources_origin_merge_tree_part_level[lhs.source_stream_index]` must have been
+        /// initialized in either `initialize` or `consume`
+        if (lhs.source_stream_index == rhs.source_stream_index && sources_origin_merge_tree_part_level[lhs.source_stream_index] > 0)
+            return true;
+        return !lhs.hasEqualSortColumnsWith(rhs);
+    }
 };
 
 }

--- a/src/Processors/Merges/Algorithms/MergeTreePartLevelInfo.h
+++ b/src/Processors/Merges/Algorithms/MergeTreePartLevelInfo.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <Processors/Chunk.h>
+
+namespace DB
+{
+
+/// To carry part level if chunk is produced by a merge tree source
+class MergeTreePartLevelInfo : public ChunkInfo
+{
+public:
+    MergeTreePartLevelInfo() = delete;
+    explicit MergeTreePartLevelInfo(ssize_t part_level) : origin_merge_tree_part_level(part_level) { }
+    size_t origin_merge_tree_part_level = 0;
+};
+
+inline size_t getPartLevelFromChunk(const Chunk & chunk)
+{
+    const auto & info = chunk.getChunkInfo();
+    if (const auto * part_level_info = typeid_cast<const MergeTreePartLevelInfo *>(info.get()))
+        return part_level_info->origin_merge_tree_part_level;
+    return 0;
+}
+
+}

--- a/src/Processors/Merges/Algorithms/ReplacingSortedAlgorithm.cpp
+++ b/src/Processors/Merges/Algorithms/ReplacingSortedAlgorithm.cpp
@@ -56,7 +56,7 @@ IMergingAlgorithm::Status ReplacingSortedAlgorithm::merge()
         RowRef current_row;
         setRowRef(current_row, current);
 
-        bool key_differs = selected_row.empty() || !current_row.hasEqualSortColumnsWith(selected_row);
+        bool key_differs = selected_row.empty() || rowsHaveDifferentSortColumns(selected_row, current_row);
         if (key_differs)
         {
             /// if there are enough rows and the last one is calculated completely

--- a/src/Processors/Merges/Algorithms/RowRef.h
+++ b/src/Processors/Merges/Algorithms/RowRef.h
@@ -160,8 +160,8 @@ struct RowRef
 
     bool hasEqualSortColumnsWith(const RowRef & other) const
     {
-        /// If both chunks are from a same source stream, and stream doesn't contains row with same primary keys
-        /// (e.g. stream read from a non-L0 part), then we don't need to compare them.
+        /// If both chunks are from the same source stream, and the stream doesn't contain a row with the same primary key
+        /// (e.g., stream reads from a part with level > 0), then we don't need to compare them.
         if (source_stream_index >= 0 && source_stream_index == other.source_stream_index && !source_may_contain_rows_with_same_primary_keys)
             return false;
 

--- a/src/Processors/Merges/Algorithms/SummingSortedAlgorithm.cpp
+++ b/src/Processors/Merges/Algorithms/SummingSortedAlgorithm.cpp
@@ -739,7 +739,7 @@ IMergingAlgorithm::Status SummingSortedAlgorithm::merge()
             detail::RowRef current_key;
             setRowRef(current_key, current);
 
-            key_differs = last_key.empty() || !last_key.hasEqualSortColumnsWith(current_key);
+            key_differs = last_key.empty() || rowsHaveDifferentSortColumns(last_key, current_key);
 
             last_key = current_key;
             last_chunk_sort_columns.clear();

--- a/src/Processors/Merges/Algorithms/SummingSortedAlgorithm.cpp
+++ b/src/Processors/Merges/Algorithms/SummingSortedAlgorithm.cpp
@@ -737,7 +737,7 @@ IMergingAlgorithm::Status SummingSortedAlgorithm::merge()
 
         {
             detail::RowRef current_key;
-            current_key.set(current);
+            setRowRef(current_key, current);
 
             key_differs = last_key.empty() || !last_key.hasEqualSortColumnsWith(current_key);
 

--- a/src/Processors/QueryPlan/ReadFromMergeTree.cpp
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.cpp
@@ -568,6 +568,8 @@ Pipe ReadFromMergeTree::readInOrder(
             pool, std::move(algorithm), data, prewhere_info,
             actions_settings, block_size, reader_settings, virt_column_names);
 
+        processor->addPartLevelToChunk(isQueryWithFinal());
+
         auto source = std::make_shared<MergeTreeSource>(std::move(processor));
         if (set_rows_approx)
             source->addTotalRowsApprox(total_rows);

--- a/src/Storages/MergeTree/MergeTreeSelectProcessor.cpp
+++ b/src/Storages/MergeTree/MergeTreeSelectProcessor.cpp
@@ -8,6 +8,7 @@
 #include <Common/typeid_cast.h>
 #include <DataTypes/DataTypeUUID.h>
 #include <DataTypes/DataTypeArray.h>
+#include <Processors/Chunk.h>
 #include <Processors/Transforms/AggregatingTransform.h>
 #include <Storages/BlockNumberColumn.h>
 #include <city.h>
@@ -171,10 +172,9 @@ ChunkAndProgress MergeTreeSelectProcessor::read()
                 auto name = result_header.getByPosition(i).name;
                 ordered_columns.push_back(res.block.getByName(name).column);
             }
-            auto level = task->getInfo().data_part->info.level;
 
             return ChunkAndProgress{
-                .chunk = Chunk(ordered_columns, res.row_count, nullptr, level),
+                .chunk = Chunk(ordered_columns, res.row_count, std::make_shared<MergeTreePartLevelInfo>(task->getInfo().data_part->info.level)),
                 .num_read_rows = res.num_read_rows,
                 .num_read_bytes = res.num_read_bytes,
                 .is_finished = false};

--- a/src/Storages/MergeTree/MergeTreeSelectProcessor.cpp
+++ b/src/Storages/MergeTree/MergeTreeSelectProcessor.cpp
@@ -6,6 +6,7 @@
 #include <Common/ElapsedTimeProfileEventIncrement.h>
 #include <Common/logger_useful.h>
 #include <Common/typeid_cast.h>
+#include <Processors/Merges/Algorithms/MergeTreePartLevelInfo.h>
 #include <DataTypes/DataTypeUUID.h>
 #include <DataTypes/DataTypeArray.h>
 #include <Processors/Chunk.h>
@@ -174,7 +175,7 @@ ChunkAndProgress MergeTreeSelectProcessor::read()
             }
 
             return ChunkAndProgress{
-                .chunk = Chunk(ordered_columns, res.row_count, std::make_shared<MergeTreePartLevelInfo>(task->getInfo().data_part->info.level)),
+                .chunk = Chunk(ordered_columns, res.row_count, add_part_level ? std::make_shared<MergeTreePartLevelInfo>(task->getInfo().data_part->info.level) : nullptr),
                 .num_read_rows = res.num_read_rows,
                 .num_read_bytes = res.num_read_bytes,
                 .is_finished = false};

--- a/src/Storages/MergeTree/MergeTreeSelectProcessor.cpp
+++ b/src/Storages/MergeTree/MergeTreeSelectProcessor.cpp
@@ -171,9 +171,10 @@ ChunkAndProgress MergeTreeSelectProcessor::read()
                 auto name = result_header.getByPosition(i).name;
                 ordered_columns.push_back(res.block.getByName(name).column);
             }
+            auto level = task->getInfo().data_part->info.level;
 
             return ChunkAndProgress{
-                .chunk = Chunk(ordered_columns, res.row_count),
+                .chunk = Chunk(ordered_columns, res.row_count, nullptr, level),
                 .num_read_rows = res.num_read_rows,
                 .num_read_bytes = res.num_read_bytes,
                 .is_finished = false};

--- a/src/Storages/MergeTree/MergeTreeSelectProcessor.h
+++ b/src/Storages/MergeTree/MergeTreeSelectProcessor.h
@@ -69,6 +69,8 @@ public:
         const ExpressionActionsSettings & actions_settings,
         bool enable_multiple_prewhere_read_steps);
 
+    void addPartLevelToChunk(bool add_part_level_) { add_part_level = add_part_level_; }
+
 private:
     /// This struct allow to return block with no columns but with non-zero number of rows similar to Chunk
     struct BlockAndProgress
@@ -108,6 +110,9 @@ private:
     Block header_without_const_virtual_columns;
     /// A result of getHeader(). A chunk which this header is returned from read().
     Block result_header;
+
+    /// Should we add part level to produced chunk. Part level is useful for next steps if query has FINAL
+    bool add_part_level = false;
 
     Poco::Logger * log = &Poco::Logger::get("MergeTreeSelectProcessor");
     std::atomic<bool> is_cancelled{false};

--- a/src/Storages/MergeTree/MergeTreeSequentialSource.cpp
+++ b/src/Storages/MergeTree/MergeTreeSequentialSource.cpp
@@ -206,7 +206,7 @@ try
                 ++it;
             }
 
-            return Chunk(std::move(res_columns), rows_read);
+            return Chunk(std::move(res_columns), rows_read, nullptr, data_part->info.level);
         }
     }
     else

--- a/src/Storages/MergeTree/MergeTreeSequentialSource.cpp
+++ b/src/Storages/MergeTree/MergeTreeSequentialSource.cpp
@@ -12,6 +12,7 @@
 #include <Processors/QueryPlan/QueryPlan.h>
 #include <Processors/QueryPlan/FilterStep.h>
 #include <Common/logger_useful.h>
+#include <Processors/Merges/Algorithms/MergeTreePartLevelInfo.h>
 
 namespace DB
 {
@@ -168,6 +169,8 @@ Chunk MergeTreeSequentialSource::generate()
 try
 {
     const auto & header = getPort().getHeader();
+    /// Part level is useful for next step for merging non-merge tree table
+    bool add_part_level = storage.merging_params.mode != MergeTreeData::MergingParams::Ordinary;
 
     if (!isCancelled() && current_row < data_part->rows_count)
     {
@@ -207,7 +210,7 @@ try
                 ++it;
             }
 
-            return Chunk(std::move(res_columns), rows_read, std::make_shared<MergeTreePartLevelInfo>(data_part->info.level));
+            return Chunk(std::move(res_columns), rows_read, add_part_level ? std::make_shared<MergeTreePartLevelInfo>(data_part->info.level) : nullptr);
         }
     }
     else

--- a/src/Storages/MergeTree/MergeTreeSequentialSource.cpp
+++ b/src/Storages/MergeTree/MergeTreeSequentialSource.cpp
@@ -7,6 +7,7 @@
 #include <QueryPipeline/QueryPipelineBuilder.h>
 #include <QueryPipeline/Pipe.h>
 #include <Interpreters/Context.h>
+#include <Processors/Chunk.h>
 #include <Processors/Sources/NullSource.h>
 #include <Processors/QueryPlan/QueryPlan.h>
 #include <Processors/QueryPlan/FilterStep.h>
@@ -206,7 +207,7 @@ try
                 ++it;
             }
 
-            return Chunk(std::move(res_columns), rows_read, nullptr, data_part->info.level);
+            return Chunk(std::move(res_columns), rows_read, std::make_shared<MergeTreePartLevelInfo>(data_part->info.level));
         }
     }
     else


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- MergeTree FINAL to not compare rows from same non-L0 part

Currently, merging FINAL comparing current row to next row in sorting queue to check if the key has changed. It means total number of comparisons == number of read rows.
However, if two rows are from same non-L0 part, their keys must be distinct, and we can skip comparing them. This optimisation can significantly reduce number of comparisons in some case, e.g. we read from one big part and and some other small parts.

It means to complement #54366 but I create a new PR because this optimisation will apply to any non-ordinary merge tree.
It can also complement #58120 in case where parts have intersect ranges but almost no intersect rows.

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
