### PR TITLE
Pass through exceptions for reading from S3

### DIFF
--- a/src/IO/ReadBufferFromIStream.cpp
+++ b/src/IO/ReadBufferFromIStream.cpp
@@ -34,6 +34,11 @@ bool ReadBufferFromIStream::nextImpl()
 ReadBufferFromIStream::ReadBufferFromIStream(std::istream & istr_, size_t size)
     : BufferWithOwnMemory<ReadBuffer>(size), istr(istr_)
 {
+    /// - badbit will be set if some exception will be throw from ios implementation
+    /// - failbit can be set when for instance read() reads less data, so we
+    ///   cannot set it, since we are requesting to read more data, then the
+    ///   buffer has now.
+    istr.exceptions(std::ios::badbit);
 }
 
 }

--- a/src/IO/ReadBufferFromS3.cpp
+++ b/src/IO/ReadBufferFromS3.cpp
@@ -196,7 +196,7 @@ bool ReadBufferFromS3::nextImpl()
             next_result = impl->next();
             break;
         }
-        catch (Exception & e)
+        catch (Poco::Exception & e)
         {
             if (!processException(e, getPosition(), attempt) || last_attempt)
                 throw;


### PR DESCRIPTION
Reading from S3 has retries on almost any exception, except for CANNOT_ALLOCATE_MEMORY, but the problem is that this exception may not be even delivered to ReadBufferFromS3::processException(), due to std::istream will hide it (see [1]).

  [1]: https://github.com/ClickHouse/llvm-project/blob/1834e42289c58402c804a87be4d489892b88f3ec/libcxx/include/istream#L1059

So let's pass throught them to see at least some information instead of just:

    Message: Cannot read from istream at offset 0

And here as an example of exception:

<details>

    (lldb) bt
    * thread 244, name = 'MergeMutate', stop reason = breakpoint 6.1
      * frame 0: 0x000000001aa9c791 clickhouse`::__cxa_throw(thrown_object=0x00007fc3b68fdb00, tinfo=0x000000000548af50, dest=(clickhouse`Poco::Net::NetException::~NetException() at NetException.cpp:26))(void *)) at cxa_exception.cpp:258:33 frame 1: 0x0000000017c55b2b clickhouse`Poco::Net::SocketImpl::error(code=-1232086272, arg=0x00007fc3be4f4d30) at SocketImpl.cpp:985:3 frame 2: 0x0000000017c1f7ff clickhouse`Poco::Net::SecureSocketImpl::handleError(int) [inlined] Poco::Net::SocketImpl::error(code=<unavailable>) at SocketImpl.cpp:923:2 frame 3: 0x0000000017c1f7e4 clickhouse`Poco::Net::SecureSocketImpl::handleError(this=0x00007fc35ae42b30, rc=-1) at SecureSocketImpl.cpp:531 frame 4: 0x0000000017c208f9 clickhouse`Poco::Net::SecureSocketImpl::receiveBytes(this=0x00007fc35ae42b30, buffer=0x00007fc346e402c4, length=131068, flags=<unavailable>) at SecureSocketImpl.cpp:353:10 frame 5: 0x0000000017c3b388 clickhouse`Poco::Net::HTTPSession::read(char*, long) [inlined] Poco::Net::StreamSocket::receiveBytes(buffer=<unavailable>, length=<unavailable>, flags=0) at StreamSocket.cpp:130:17 frame 6: 0x0000000017c3b379 clickhouse`Poco::Net::HTTPSession::read(char*, long) [inlined] Poco::Net::HTTPSession::receive(this=<unavailable>, buffer=<unavailable>, length=<unavailable>) at HTTPSession.cpp:166 frame 7: 0x0000000017c3b379 clickhouse`Poco::Net::HTTPSession::read(this=0x00007fc3973e9098, buffer=<unavailable>, length=<unavailable>) at HTTPSession.cpp:144 frame 8: 0x0000000017c0f706 clickhouse`Poco::Net::HTTPSClientSession::read(this=<unavailable>, buffer=<unavailable>, length=<unavailable>) at HTTPSClientSession.cpp:195:23 frame 9: 0x0000000017c32eb4 clickhouse`Poco::Net::HTTPFixedLengthStreamBuf::readFromDevice(this=0x00007fc361bd6708, buffer=<unavailable>, length=<unavailable>) at HTTPFixedLengthStream.cpp:53:16 frame 10: 0x0000000017c2a368 clickhouse`Poco::BasicBufferedStreamBuf<char, std::__1::char_traits<char>, Poco::Net::HTTPBufferAllocator>::underflow(this=0x00007fc361bd6708) at BufferedStreamBuf.h:97:17 frame 11: 0x0000000008b2abca clickhouse`std::__1::basic_streambuf<char, std::__1::char_traits<char> >::uflow(this=0x00007fc361bd6708) at streambuf:445:9 frame 12: 0x0000000008b2ab5a clickhouse`std::__1::basic_streambuf<char, std::__1::char_traits<char> >::xsgetn(this=0x00007fc361bd6708, __s="P, __n=1048576) at streambuf:422:25 frame 13: 0x0000000008b2ca0e clickhouse`std::__1::basic_istream<char, std::__1::char_traits<char> >::read(char*, long) [inlined] std::__1::basic_streambuf<char, std::__1::char_traits<char> >::sgetn[abi:v15000](this=<unavailable>, __s="!P, __n=1048576) at streambuf:204:14 frame 14: 0x0000000008b2ca02 clickhouse`std::__1::basic_istream<char, std::__1::char_traits<char> >::read(this=0x00007fc35ae42d40, __s="!P, __n=1048576) at istream:1052 frame 15: 0x0000000010de0b9f clickhouse`DB::ReadBufferFromIStream::nextImpl(this=0x00007fc3663d2380) at ReadBufferFromIStream.cpp:15:10

</details>

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Pass throught exceptions for reading from S3

_P.S. also one interesting thing is that I found one place which will eat exceptions anyway - https://github.com/ClickHouse/llvm-project/blob/1834e42289c58402c804a87be4d489892b88f3ec/libcxx/include/istream#L873 (https://github.com/llvm/llvm-project/commit/396145d0da19e495#diff-06491c2f2d40e37fdc399c9eb6000cb023d60b75bfe318ac72b776471fbba95cR879)_