### PR TITLE
[RFC] Adjust all std::ios implementations in poco to set failbit/badbit by default

### DIFF
--- a/base/poco/Foundation/include/Poco/StreamUtil.h
+++ b/base/poco/Foundation/include/Poco/StreamUtil.h
@@ -69,6 +69,9 @@
 // init() is called in the MyIOS constructor.
 // Therefore we replace each call to init() with
 // the poco_ios_init macro defined below.
+//
+// Also this macro will adjust exceptions() flags, since by default std::ios
+// will hide exceptions, while in ClickHouse it is better to pass them through.
 
 
 #if !defined(POCO_IOS_INIT_HACK)
@@ -79,7 +82,10 @@
 #if defined(POCO_IOS_INIT_HACK)
 #    define poco_ios_init(buf)
 #else
-#    define poco_ios_init(buf) init(buf)
+#    define poco_ios_init(buf) do {                         \
+    init(buf);                                              \
+    this->exceptions(std::ios::failbit | std::ios::badbit); \
+} while (0)
 #endif
 
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Adjust all std::ios implementations in poco to set failbit/badbit by default