### PR TITLE
Add bytes_uncompressed to system.part_log

### DIFF
--- a/src/Interpreters/PartLog.cpp
+++ b/src/Interpreters/PartLog.cpp
@@ -245,6 +245,7 @@ bool PartLog::addNewParts(
             elem.part_type = part->getType();
 
             elem.bytes_compressed_on_disk = part->getBytesOnDisk();
+            elem.bytes_uncompressed = part->getBytesUncompressedOnDisk();
             elem.rows = part->rows_count;
 
             elem.error = static_cast<UInt16>(execution_status.code);

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -2325,6 +2325,7 @@ void MergeTreeData::removePartsFinally(const MergeTreeData::DataPartsVector & pa
             part_log_elem.partition_id = part->info.partition_id;
             part_log_elem.part_name = part->name;
             part_log_elem.bytes_compressed_on_disk = part->getBytesOnDisk();
+            part_log_elem.bytes_uncompressed = part->getBytesUncompressedOnDisk();
             part_log_elem.rows = part->rows_count;
             part_log_elem.part_type = part->getType();
 
@@ -7509,6 +7510,7 @@ try
         part_log_elem.disk_name = result_part->getDataPartStorage().getDiskName();
         part_log_elem.path_on_disk = result_part->getDataPartStorage().getFullPath();
         part_log_elem.bytes_compressed_on_disk = result_part->getBytesOnDisk();
+        part_log_elem.bytes_uncompressed = result_part->getBytesUncompressedOnDisk();
         part_log_elem.rows = result_part->rows_count;
         part_log_elem.part_type = result_part->getType();
     }
@@ -7523,7 +7525,6 @@ try
         part_log_elem.bytes_read_uncompressed = (*merge_entry)->bytes_read_uncompressed;
 
         part_log_elem.rows = (*merge_entry)->rows_written;
-        part_log_elem.bytes_uncompressed = (*merge_entry)->bytes_written_uncompressed;
         part_log_elem.peak_memory_usage = (*merge_entry)->getMemoryTracker().getPeak();
     }
 

--- a/src/Storages/MergeTree/MutateTask.cpp
+++ b/src/Storages/MergeTree/MutateTask.cpp
@@ -879,6 +879,7 @@ void finalizeMutatedPart(
     /// All information about sizes is stored in checksums.
     /// It doesn't make sense to touch filesystem for sizes.
     new_data_part->setBytesOnDisk(new_data_part->checksums.getTotalSizeOnDisk());
+    new_data_part->setBytesUncompressedOnDisk(new_data_part->checksums.getTotalSizeUncompressedOnDisk());
     /// Also use information from checksums
     new_data_part->calculateColumnsAndSecondaryIndicesSizesOnDisk();
 

--- a/tests/queries/0_stateless/02950_part_log_bytes_uncompressed.reference
+++ b/tests/queries/0_stateless/02950_part_log_bytes_uncompressed.reference
@@ -1,7 +1,7 @@
 NewPart	part_log_bytes_uncompressed	all_1_1_0	1	1
-NewPart	part_log_bytes_uncompressed	all_2_2_0	1	1
 MergeParts	part_log_bytes_uncompressed	all_1_2_1	1	1
 MutatePart	part_log_bytes_uncompressed	all_1_2_1_3	1	1
+NewPart	part_log_bytes_uncompressed	all_2_2_0	1	1
 NewPart	part_log_bytes_uncompressed	all_4_4_0	1	1
-NewPart	part_log_bytes_uncompressed	all_4_4_1	0	0
 RemovePart	part_log_bytes_uncompressed	all_4_4_0	1	1
+NewPart	part_log_bytes_uncompressed	all_4_4_1	0	0

--- a/tests/queries/0_stateless/02950_part_log_bytes_uncompressed.reference
+++ b/tests/queries/0_stateless/02950_part_log_bytes_uncompressed.reference
@@ -2,3 +2,6 @@ NewPart	part_log_bytes_uncompressed	all_1_1_0	2
 NewPart	part_log_bytes_uncompressed	all_2_2_0	2
 MergeParts	part_log_bytes_uncompressed	all_1_2_1	4
 MutatePart	part_log_bytes_uncompressed	all_1_2_1_3	4
+NewPart	part_log_bytes_uncompressed	all_4_4_0	2
+NewPart	part_log_bytes_uncompressed	all_4_4_1	0
+RemovePart	part_log_bytes_uncompressed	all_4_4_0	2

--- a/tests/queries/0_stateless/02950_part_log_bytes_uncompressed.reference
+++ b/tests/queries/0_stateless/02950_part_log_bytes_uncompressed.reference
@@ -1,0 +1,4 @@
+NewPart	part_log_bytes_uncompressed	all_1_1_0	2
+NewPart	part_log_bytes_uncompressed	all_2_2_0	2
+MergeParts	part_log_bytes_uncompressed	all_1_2_1	4
+MutatePart	part_log_bytes_uncompressed	all_1_2_1_3	4

--- a/tests/queries/0_stateless/02950_part_log_bytes_uncompressed.reference
+++ b/tests/queries/0_stateless/02950_part_log_bytes_uncompressed.reference
@@ -1,7 +1,7 @@
-NewPart	part_log_bytes_uncompressed	all_1_1_0	2
-NewPart	part_log_bytes_uncompressed	all_2_2_0	2
-MergeParts	part_log_bytes_uncompressed	all_1_2_1	4
-MutatePart	part_log_bytes_uncompressed	all_1_2_1_3	4
-NewPart	part_log_bytes_uncompressed	all_4_4_0	2
-NewPart	part_log_bytes_uncompressed	all_4_4_1	0
-RemovePart	part_log_bytes_uncompressed	all_4_4_0	2
+NewPart	part_log_bytes_uncompressed	all_1_1_0	1	1
+NewPart	part_log_bytes_uncompressed	all_2_2_0	1	1
+MergeParts	part_log_bytes_uncompressed	all_1_2_1	1	1
+MutatePart	part_log_bytes_uncompressed	all_1_2_1_3	1	1
+NewPart	part_log_bytes_uncompressed	all_4_4_0	1	1
+NewPart	part_log_bytes_uncompressed	all_4_4_1	0	0
+RemovePart	part_log_bytes_uncompressed	all_4_4_0	1	1

--- a/tests/queries/0_stateless/02950_part_log_bytes_uncompressed.sql
+++ b/tests/queries/0_stateless/02950_part_log_bytes_uncompressed.sql
@@ -5,19 +5,19 @@ CREATE TABLE part_log_bytes_uncompressed (
 Engine=MergeTree()
 ORDER BY key;
 
-INSERT INTO part_log_bytes_uncompressed VALUES (1, 1);
-INSERT INTO part_log_bytes_uncompressed VALUES (2, 1);
+INSERT INTO part_log_bytes_uncompressed SELECT 1, 1 FROM numbers(1000);
+INSERT INTO part_log_bytes_uncompressed SELECT 2, 1 FROM numbers(1000);
 
 OPTIMIZE TABLE part_log_bytes_uncompressed FINAL;
 
 ALTER TABLE part_log_bytes_uncompressed UPDATE value = 3 WHERE 1 = 1 SETTINGS mutations_sync=2;
 
-INSERT INTO part_log_bytes_uncompressed VALUES (3, 1);
+INSERT INTO part_log_bytes_uncompressed SELECT 3, 1 FROM numbers(1000);
 ALTER TABLE part_log_bytes_uncompressed DROP PART 'all_4_4_0' SETTINGS mutations_sync=2;
 
 SYSTEM FLUSH LOGS;
 
-SELECT event_type, table, part_name, bytes_uncompressed FROM system.part_log
+SELECT event_type, table, part_name, bytes_uncompressed > 0, size_in_bytes < bytes_uncompressed FROM system.part_log
 WHERE event_date >= yesterday() AND database = currentDatabase() AND table = 'part_log_bytes_uncompressed'
 ORDER BY event_time_microseconds;
 

--- a/tests/queries/0_stateless/02950_part_log_bytes_uncompressed.sql
+++ b/tests/queries/0_stateless/02950_part_log_bytes_uncompressed.sql
@@ -12,6 +12,9 @@ OPTIMIZE TABLE part_log_bytes_uncompressed FINAL;
 
 ALTER TABLE part_log_bytes_uncompressed UPDATE value = 3 WHERE 1 = 1 SETTINGS mutations_sync=2;
 
+INSERT INTO part_log_bytes_uncompressed VALUES (3, 1);
+ALTER TABLE part_log_bytes_uncompressed DROP PART 'all_4_4_0' SETTINGS mutations_sync=2;
+
 SYSTEM FLUSH LOGS;
 
 SELECT event_type, table, part_name, bytes_uncompressed FROM system.part_log

--- a/tests/queries/0_stateless/02950_part_log_bytes_uncompressed.sql
+++ b/tests/queries/0_stateless/02950_part_log_bytes_uncompressed.sql
@@ -1,0 +1,21 @@
+CREATE TABLE part_log_bytes_uncompressed (
+    key UInt8,
+    value UInt8
+)
+Engine=MergeTree()
+ORDER BY key;
+
+INSERT INTO part_log_bytes_uncompressed VALUES (1, 1);
+INSERT INTO part_log_bytes_uncompressed VALUES (2, 1);
+
+OPTIMIZE TABLE part_log_bytes_uncompressed FINAL;
+
+ALTER TABLE part_log_bytes_uncompressed UPDATE value = 3 WHERE 1 = 1 SETTINGS mutations_sync=2;
+
+SYSTEM FLUSH LOGS;
+
+SELECT event_type, table, part_name, bytes_uncompressed FROM system.part_log
+WHERE event_date >= yesterday() AND database = currentDatabase() AND table = 'part_log_bytes_uncompressed'
+ORDER BY event_time_microseconds;
+
+DROP TABLE part_log_bytes_uncompressed;

--- a/tests/queries/0_stateless/02950_part_log_bytes_uncompressed.sql
+++ b/tests/queries/0_stateless/02950_part_log_bytes_uncompressed.sql
@@ -19,6 +19,6 @@ SYSTEM FLUSH LOGS;
 
 SELECT event_type, table, part_name, bytes_uncompressed > 0, size_in_bytes < bytes_uncompressed FROM system.part_log
 WHERE event_date >= yesterday() AND database = currentDatabase() AND table = 'part_log_bytes_uncompressed'
-ORDER BY event_time_microseconds;
+ORDER BY part_name;
 
 DROP TABLE part_log_bytes_uncompressed;

--- a/tests/queries/0_stateless/02950_part_log_bytes_uncompressed.sql
+++ b/tests/queries/0_stateless/02950_part_log_bytes_uncompressed.sql
@@ -19,6 +19,6 @@ SYSTEM FLUSH LOGS;
 
 SELECT event_type, table, part_name, bytes_uncompressed > 0, size_in_bytes < bytes_uncompressed FROM system.part_log
 WHERE event_date >= yesterday() AND database = currentDatabase() AND table = 'part_log_bytes_uncompressed'
-ORDER BY part_name;
+ORDER BY part_name, event_type;
 
 DROP TABLE part_log_bytes_uncompressed;


### PR DESCRIPTION
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Add `bytes_uncompressed` for all `system.part_log` entries. Also fixes values for merges since `(*merge_entry)->bytes_written_uncompressed` doesn't seem to report the right value.