### PR TITLE
Update clickhouse-test

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -2307,7 +2307,7 @@ def reportLogStats(args):
               'Attempt to read after eof', 'String size is too big ({}), maximum: {}'
         ) AS known_short_messages
         SELECT count() AS c, message_format_string, substr(any(message), 1, 120),
-            min(if(notEmpty(regexpExtract(message, '(.*)\\([A-Z0-9_]+\\)') as prefix), prefix, length(message)) - 26 AS length_without_exception_boilerplate) AS min_length_without_exception_boilerplate
+            min(if(length(regexpExtract(message, '(.*)\\([A-Z0-9_]+\\)')) as prefix_len > 0, prefix_len, length(message)) - 26 AS length_without_exception_boilerplate) AS min_length_without_exception_boilerplate
         FROM system.text_log
         WHERE (now() - toIntervalMinute(240)) < event_time
             AND (length(message_format_string) < 16


### PR DESCRIPTION

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


```
2023-12-20 14:41:44 Failed to get stats about log messages: Code: 500. Code: 386. DB::Exception: There is no supertype for types String, UInt64 because some of them are String/FixedString and some of them are not: While processing if(notEmpty(regexpExtract(message, '(.*)\\([A-Z0-9_]+\\)') AS prefix), prefix, length(message)). (NO_COMMON_TYPE) (version 23.12.1.989)
```
