### PR TITLE
Fix possible PARAMETER_OUT_OF_BOUND error during subcolumns reading from wide part in MergeTree

### DIFF
--- a/src/DataTypes/Serializations/SerializationArray.cpp
+++ b/src/DataTypes/Serializations/SerializationArray.cpp
@@ -348,6 +348,8 @@ void SerializationArray::deserializeBinaryBulkWithMultipleStreams(
 {
     auto mutable_column = column->assumeMutable();
     ColumnArray & column_array = typeid_cast<ColumnArray &>(*mutable_column);
+    size_t prev_last_offset = column_array.getOffsets().back();
+
     settings.path.push_back(Substream::ArraySizes);
 
     if (auto cached_column = getFromSubstreamsCache(cache, settings.path))
@@ -371,9 +373,9 @@ void SerializationArray::deserializeBinaryBulkWithMultipleStreams(
 
     /// Number of values corresponding with `offset_values` must be read.
     size_t last_offset = offset_values.back();
-    if (last_offset < nested_column->size())
+    if (last_offset < previous_last_offset)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Nested column is longer than last offset");
-    size_t nested_limit = last_offset - nested_column->size();
+    size_t nested_limit = last_offset - previous_last_offset;
 
     if (unlikely(nested_limit > MAX_ARRAYS_SIZE))
         throw Exception(ErrorCodes::TOO_LARGE_ARRAY_SIZE, "Array sizes are too large: {}", nested_limit);

--- a/src/DataTypes/Serializations/SerializationArray.cpp
+++ b/src/DataTypes/Serializations/SerializationArray.cpp
@@ -373,9 +373,9 @@ void SerializationArray::deserializeBinaryBulkWithMultipleStreams(
 
     /// Number of values corresponding with `offset_values` must be read.
     size_t last_offset = offset_values.back();
-    if (last_offset < previous_last_offset)
+    if (last_offset < prev_last_offset)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Nested column is longer than last offset");
-    size_t nested_limit = last_offset - previous_last_offset;
+    size_t nested_limit = last_offset - prev_last_offset;
 
     if (unlikely(nested_limit > MAX_ARRAYS_SIZE))
         throw Exception(ErrorCodes::TOO_LARGE_ARRAY_SIZE, "Array sizes are too large: {}", nested_limit);

--- a/tests/queries/0_stateless/02950_reading_array_tuple_subcolumns.sql
+++ b/tests/queries/0_stateless/02950_reading_array_tuple_subcolumns.sql
@@ -1,0 +1,15 @@
+DROP TABLE IF EXISTS test;
+CREATE TABLE test
+(
+    `id` UInt64,
+    `t` Tuple(a UInt64, b Array(Tuple(c UInt64, d UInt64)))
+)
+ENGINE = MergeTree
+ORDER BY id
+SETTINGS min_rows_for_wide_part = 1, min_bytes_for_wide_part = 1, index_granularity = 8192;
+INSERT INTO test SELECT number, tuple(number, arrayMap(x -> tuple(number + 1, number + 2), range(number % 10))) FROM numbers(100000);
+INSERT INTO test SELECT number, tuple(number, arrayMap(x -> tuple(number + 1, number + 2), range(number % 10))) FROM numbers(100000);
+INSERT INTO test SELECT number, tuple(number, arrayMap(x -> tuple(number + 1, number + 2), range(number % 10))) FROM numbers(100000);
+SELECT t.b, t.b.c FROM test ORDER BY id FORMAT Null;
+DROP TABLE test;
+


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix possible PARAMETER_OUT_OF_BOUND error during subcolumns reading from wide part in MergeTree. Closes https://github.com/ClickHouse/ClickHouse/issues/58174

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
