### PR TITLE
Fix flaky test `02719_aggregate_with_empty_string_key`

### DIFF
--- a/tests/queries/0_stateless/02719_aggregate_with_empty_string_key.sql
+++ b/tests/queries/0_stateless/02719_aggregate_with_empty_string_key.sql
@@ -2,6 +2,6 @@ drop table if exists test ;
 create table test(str Nullable(String), i Int64) engine=Memory();
 insert into test values(null, 1),('', 2),('s', 1);
 select '-----------String------------';
-select str ,max(i) from test group by str;
+select str, max(i) from test group by str order by str nulls first;
 
 drop table test;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
