### PR TITLE
Fix #58171

### DIFF
--- a/src/IO/SharedThreadPools.cpp
+++ b/src/IO/SharedThreadPools.cpp
@@ -66,6 +66,8 @@ void StaticThreadPool::reloadConfiguration(size_t max_threads, size_t max_free_t
     if (!instance)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "The {} is not initialized", name);
 
+    std::lock_guard lock(mutex);
+
     instance->setMaxThreads(turbo_mode_enabled > 0 ? max_threads_turbo : max_threads);
     instance->setMaxFreeThreads(max_free_threads);
     instance->setQueueSize(queue_size);


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


This closes #58171.