### PR TITLE
Add base backup name to system.backups and system.backup_log tables

### DIFF
--- a/src/Backups/BackupOperationInfo.h
+++ b/src/Backups/BackupOperationInfo.h
@@ -17,6 +17,9 @@ struct BackupOperationInfo
     /// Operation name, a string like "Disk('backups', 'my_backup')"
     String name;
 
+    /// Base Backup Operation name, a string like "Disk('backups', 'my_base_backup')"
+    String base_backup_name;
+
     /// This operation is internal and should not be shown in system.backups
     bool internal = false;
 

--- a/src/Backups/BackupsWorker.cpp
+++ b/src/Backups/BackupsWorker.cpp
@@ -394,9 +394,13 @@ OperationID BackupsWorker::startMakingBackup(const ASTPtr & query, const Context
 
     auto backup_info = BackupInfo::fromAST(*backup_query->backup_name);
     String backup_name_for_logging = backup_info.toStringForLogging();
+    String base_backup_name;
+    if (backup_settings.base_backup_info)
+        base_backup_name = backup_settings.base_backup_info->toString();
+
     try
     {
-        addInfo(backup_id, backup_name_for_logging, backup_settings.internal, BackupStatus::CREATING_BACKUP);
+        addInfo(backup_id, backup_name_for_logging, base_backup_name, backup_settings.internal, BackupStatus::CREATING_BACKUP);
 
         /// Prepare context to use.
         ContextPtr context_in_use = context;
@@ -745,8 +749,11 @@ OperationID BackupsWorker::startRestoring(const ASTPtr & query, ContextMutablePt
     {
         auto backup_info = BackupInfo::fromAST(*restore_query->backup_name);
         String backup_name_for_logging = backup_info.toStringForLogging();
+        String base_backup_name;
+        if (restore_settings.base_backup_info)
+            base_backup_name = restore_settings.base_backup_info->toString();
 
-        addInfo(restore_id, backup_name_for_logging, restore_settings.internal, BackupStatus::RESTORING);
+        addInfo(restore_id, backup_name_for_logging, base_backup_name, restore_settings.internal, BackupStatus::RESTORING);
 
         /// Prepare context to use.
         ContextMutablePtr context_in_use = context;
@@ -1005,11 +1012,12 @@ void BackupsWorker::restoreTablesData(const OperationID & restore_id, BackupPtr 
 }
 
 
-void BackupsWorker::addInfo(const OperationID & id, const String & name, bool internal, BackupStatus status)
+void BackupsWorker::addInfo(const OperationID & id, const String & name, const String & base_backup_name, bool internal, BackupStatus status)
 {
     BackupOperationInfo info;
     info.id = id;
     info.name = name;
+    info.base_backup_name = base_backup_name;
     info.internal = internal;
     info.status = status;
     info.start_time = std::chrono::system_clock::now();

--- a/src/Backups/BackupsWorker.h
+++ b/src/Backups/BackupsWorker.h
@@ -83,7 +83,7 @@ private:
     /// Run data restoring tasks which insert data to tables.
     void restoreTablesData(const BackupOperationID & restore_id, BackupPtr backup, DataRestoreTasks && tasks, ThreadPool & thread_pool);
 
-    void addInfo(const BackupOperationID & id, const String & name, bool internal, BackupStatus status);
+    void addInfo(const BackupOperationID & id, const String & name, const String & base_backup_name, bool internal, BackupStatus status);
     void setStatus(const BackupOperationID & id, BackupStatus status, bool throw_if_error = true);
     void setStatusSafe(const String & id, BackupStatus status) { setStatus(id, status, false); }
     void setNumFilesAndSize(const BackupOperationID & id, size_t num_files, UInt64 total_size, size_t num_entries,

--- a/src/Interpreters/BackupLog.cpp
+++ b/src/Interpreters/BackupLog.cpp
@@ -27,6 +27,7 @@ NamesAndTypesList BackupLogElement::getNamesAndTypes()
         {"event_time_microseconds", std::make_shared<DataTypeDateTime64>(6)},
         {"id", std::make_shared<DataTypeString>()},
         {"name", std::make_shared<DataTypeString>()},
+        {"base_backup_name", std::make_shared<DataTypeString>()},
         {"status", std::make_shared<DataTypeEnum8>(getBackupStatusEnumValues())},
         {"error", std::make_shared<DataTypeString>()},
         {"start_time", std::make_shared<DataTypeDateTime>()},
@@ -49,6 +50,7 @@ void BackupLogElement::appendToBlock(MutableColumns & columns) const
     columns[i++]->insert(event_time_usec);
     columns[i++]->insert(info.id);
     columns[i++]->insert(info.name);
+    columns[i++]->insert(info.base_backup_name);
     columns[i++]->insert(static_cast<Int8>(info.status));
     columns[i++]->insert(info.error_message);
     columns[i++]->insert(static_cast<UInt32>(std::chrono::system_clock::to_time_t(info.start_time)));

--- a/src/Storages/System/StorageSystemBackups.cpp
+++ b/src/Storages/System/StorageSystemBackups.cpp
@@ -20,6 +20,7 @@ NamesAndTypesList StorageSystemBackups::getNamesAndTypes()
     NamesAndTypesList names_and_types{
         {"id", std::make_shared<DataTypeString>()},
         {"name", std::make_shared<DataTypeString>()},
+        {"base_backup_name", std::make_shared<DataTypeString>()},
         {"status", std::make_shared<DataTypeEnum8>(getBackupStatusEnumValues())},
         {"error", std::make_shared<DataTypeString>()},
         {"start_time", std::make_shared<DataTypeDateTime>()},
@@ -42,6 +43,7 @@ void StorageSystemBackups::fillData(MutableColumns & res_columns, ContextPtr con
     size_t column_index = 0;
     auto & column_id = assert_cast<ColumnString &>(*res_columns[column_index++]);
     auto & column_name = assert_cast<ColumnString &>(*res_columns[column_index++]);
+    auto & column_base_backup_name = assert_cast<ColumnString &>(*res_columns[column_index++]);
     auto & column_status = assert_cast<ColumnInt8 &>(*res_columns[column_index++]);
     auto & column_error = assert_cast<ColumnString &>(*res_columns[column_index++]);
     auto & column_start_time = assert_cast<ColumnUInt32 &>(*res_columns[column_index++]);
@@ -59,6 +61,7 @@ void StorageSystemBackups::fillData(MutableColumns & res_columns, ContextPtr con
     {
         column_id.insertData(info.id.data(), info.id.size());
         column_name.insertData(info.name.data(), info.name.size());
+        column_base_backup_name.insertData(info.base_backup_name.data(), info.base_backup_name.size());
         column_status.insertValue(static_cast<Int8>(info.status));
         column_error.insertData(info.error_message.data(), info.error_message.size());
         column_start_time.insertValue(static_cast<UInt32>(std::chrono::system_clock::to_time_t(info.start_time)));


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Why

Currently we don't capture any base backup information for an incremental backup in system tables. Thus the only way to find out which base backup an incremental backup is build upon is by using system.query_log. I think we can have base backup information in system tables which will be useful.

Test locally via:

```
:) BACKUP TABLE test.table TO Disk('backups', '1.zip')

┌─id───────────────────────────────────┬─status─────────┐
│ 180c3e2e-56f1-4755-9422-798f53b40918 │ BACKUP_CREATED │
└──────────────────────────────────────┴────────────────┘

:) BACKUP TABLE test.table TO Disk('backups', 'inc-1.zip') SETTINGS base_backup = Disk('backups', '1.zip')

┌─id───────────────────────────────────┬─status─────────┐
│ ef14e271-1df2-42df-86c2-a0d490a73e0d │ BACKUP_CREATED │
└──────────────────────────────────────┴────────────────┘
```

```
:) select * from system.backups order by end_time \G

SELECT *
FROM system.backups
ORDER BY end_time ASC

Query id: ddfd06f4-5916-4e32-9098-e6ee980fa5a3

Row 1:
──────
id:                180c3e2e-56f1-4755-9422-798f53b40918
name:              Disk('backups', '1.zip')
base_backup_name:
status:            BACKUP_CREATED
...

Row 2:
──────
id:                ef14e271-1df2-42df-86c2-a0d490a73e0d
name:              Disk('backups', 'inc-1.zip')
base_backup_name:  Disk('backups', '1.zip')
status:            BACKUP_CREATED
...
```

```
:) select * from system.backup_log order by start_time \G

SELECT *
FROM system.backup_log
ORDER BY start_time ASC

Query id: 4bab215f-c13a-4228-9bdd-54b76c403ecc

Row 1:
──────
hostname:                Pradeeps-Laptop.local
event_date:              2023-12-23
event_time_microseconds: 2023-12-23 10:45:24.046735
id:                      180c3e2e-56f1-4755-9422-798f53b40918
name:                    Disk('backups', '1.zip')
base_backup_name:
status:                  CREATING_BACKUP
...

Row 2:
──────
hostname:                Pradeeps-Laptop.local
event_date:              2023-12-23
event_time_microseconds: 2023-12-23 10:45:24.048666
id:                      180c3e2e-56f1-4755-9422-798f53b40918
name:                    Disk('backups', '1.zip')
base_backup_name:
status:                  BACKUP_CREATED
...

Row 3:
──────
hostname:                Pradeeps-Laptop.local
event_date:              2023-12-23
event_time_microseconds: 2023-12-23 10:47:01.893280
id:                      ef14e271-1df2-42df-86c2-a0d490a73e0d
name:                    Disk('backups', 'inc-1.zip')
base_backup_name:        Disk('backups', '1.zip')
status:                  CREATING_BACKUP
...

Row 4:
──────
hostname:                Pradeeps-Laptop.local
event_date:              2023-12-23
event_time_microseconds: 2023-12-23 10:47:01.895341
id:                      ef14e271-1df2-42df-86c2-a0d490a73e0d
name:                    Disk('backups', 'inc-1.zip')
base_backup_name:        Disk('backups', '1.zip')
status:                  BACKUP_CREATED
...
```
