### PR TITLE
Explicit finalize in ZipArchiveWriter

### DIFF
--- a/src/Backups/BackupImpl.h
+++ b/src/Backups/BackupImpl.h
@@ -89,7 +89,7 @@ private:
     void close();
 
     void openArchive();
-    void closeArchive();
+    void closeArchive(bool finalize);
 
     /// Writes the file ".backup" containing backup's metadata.
     void writeBackupMetadata() TSA_REQUIRES(mutex);

--- a/src/IO/Archives/IArchiveWriter.h
+++ b/src/IO/Archives/IArchiveWriter.h
@@ -13,7 +13,7 @@ class WriteBufferFromFileBase;
 class IArchiveWriter : public std::enable_shared_from_this<IArchiveWriter>, boost::noncopyable
 {
 public:
-    /// Destructors finalizes writing the archive.
+    /// Call finalize() before destructing IArchiveWriter.
     virtual ~IArchiveWriter() = default;
 
     /// Starts writing a file to the archive. The function returns a write buffer,
@@ -25,6 +25,10 @@ public:
     /// Returns true if there is an active instance of WriteBuffer returned by writeFile().
     /// This function should be used mostly for debugging purposes.
     virtual bool isWritingFile() const = 0;
+
+    /// Finalizes writing of the archive. This function must be always called at the end of writing.
+    /// (Unless an error appeared and the archive is in fact no longer needed.)
+    virtual void finalize() = 0;
 
     static constexpr const int kDefaultCompressionLevel = -1;
 

--- a/src/IO/Archives/ZipArchiveWriter.cpp
+++ b/src/IO/Archives/ZipArchiveWriter.cpp
@@ -15,86 +15,56 @@ namespace ErrorCodes
     extern const int CANNOT_PACK_ARCHIVE;
     extern const int SUPPORT_IS_DISABLED;
     extern const int LOGICAL_ERROR;
+    extern const int NOT_IMPLEMENTED;
 }
 
-using RawHandle = zipFile;
 
-
-/// Holds a raw handle, calls acquireRawHandle() in the constructor and releaseRawHandle() in the destructor.
-class ZipArchiveWriter::HandleHolder
+namespace
 {
-public:
-    HandleHolder() = default;
-
-    explicit HandleHolder(const std::shared_ptr<ZipArchiveWriter> & writer_) : writer(writer_), raw_handle(writer->acquireRawHandle()) { }
-
-    ~HandleHolder()
+    void checkResultCodeImpl(int code, const String & file_name)
     {
-        if (raw_handle)
+        if (code >= ZIP_OK)
+            return;
+
+        String message = "Code = ";
+        switch (code)
         {
-            try
-            {
-                int err = zipCloseFileInZip(raw_handle);
-                /// If err == ZIP_PARAMERROR the file is already closed.
-                if (err != ZIP_PARAMERROR)
-                    checkResult(err);
-            }
-            catch (...)
-            {
-                tryLogCurrentException("ZipArchiveWriter");
-            }
-            writer->releaseRawHandle(raw_handle);
+            case ZIP_ERRNO: message += "ERRNO, errno = " + errnoToString(); break;
+            case ZIP_PARAMERROR: message += "PARAMERROR"; break;
+            case ZIP_BADZIPFILE: message += "BADZIPFILE"; break;
+            case ZIP_INTERNALERROR: message += "INTERNALERROR"; break;
+            default: message += std::to_string(code); break;
         }
+        throw Exception(ErrorCodes::CANNOT_PACK_ARCHIVE, "Couldn't pack zip archive: {}, filename={}", message, quoteString(file_name));
     }
-
-    HandleHolder(HandleHolder && src) noexcept
-    {
-        *this = std::move(src);
-    }
-
-    HandleHolder & operator=(HandleHolder && src) noexcept
-    {
-        writer = std::exchange(src.writer, nullptr);
-        raw_handle = std::exchange(src.raw_handle, nullptr);
-        return *this;
-    }
-
-    RawHandle getRawHandle() const { return raw_handle; }
-    std::shared_ptr<ZipArchiveWriter> getWriter() const { return writer; }
-
-    void checkResult(int code) const { writer->checkResult(code); }
-
-private:
-    std::shared_ptr<ZipArchiveWriter> writer;
-    RawHandle raw_handle = nullptr;
-};
+}
 
 
 /// This class represents a WriteBuffer actually returned by writeFile().
 class ZipArchiveWriter::WriteBufferFromZipArchive : public WriteBufferFromFileBase
 {
 public:
-    WriteBufferFromZipArchive(HandleHolder && handle_, const String & filename_)
+    WriteBufferFromZipArchive(std::shared_ptr<ZipArchiveWriter> archive_writer_, const String & filename_)
         : WriteBufferFromFileBase(DBMS_DEFAULT_BUFFER_SIZE, nullptr, 0)
-        , handle(std::move(handle_))
         , filename(filename_)
     {
-        auto compress_method = handle.getWriter()->compression_method;
-        auto compress_level = handle.getWriter()->compression_level;
+        zip_handle = archive_writer_->startWritingFile();
+        archive_writer = archive_writer_;
+
+        auto compress_method = archive_writer_->getCompressionMethod();
+        auto compress_level = archive_writer_->getCompressionLevel();
         checkCompressionMethodIsEnabled(compress_method);
 
         const char * password_cstr = nullptr;
-        const String & password_str = handle.getWriter()->password;
-        if (!password_str.empty())
+        String current_password = archive_writer_->getPassword();
+        if (!current_password.empty())
         {
             checkEncryptionIsEnabled();
-            password_cstr = password_str.c_str();
+            password_cstr = current_password.c_str();
         }
 
-        RawHandle raw_handle = handle.getRawHandle();
-
-        checkResult(zipOpenNewFileInZip3_64(
-            raw_handle,
+        int code = zipOpenNewFileInZip3_64(
+            zip_handle,
             filename_.c_str(),
             /* zipfi= */ nullptr,
             /* extrafield_local= */ nullptr,
@@ -110,19 +80,28 @@ public:
             /* strategy= */ 0,
             password_cstr,
             /* crc_for_crypting= */ 0,
-            /* zip64= */ true));
+            /* zip64= */ true);
+        checkResultCode(code);
     }
 
     ~WriteBufferFromZipArchive() override
     {
         try
         {
-            finalize();
+            closeFile(/* throw_if_error= */ false);
+            endWritingFile();
         }
         catch (...)
         {
-            tryLogCurrentException("ZipArchiveWriter");
+            tryLogCurrentException("WriteBufferFromZipArchive");
         }
+    }
+
+    void finalizeImpl() override
+    {
+        next();
+        closeFile(/* throw_if_error= */ true);
+        endWritingFile();
     }
 
     void sync() override { next(); }
@@ -133,110 +112,106 @@ private:
     {
         if (!offset())
             return;
-        RawHandle raw_handle = handle.getRawHandle();
-        int code = zipWriteInFileInZip(raw_handle, working_buffer.begin(), static_cast<uint32_t>(offset()));
-        checkResult(code);
+        chassert(zip_handle);
+        int code = zipWriteInFileInZip(zip_handle, working_buffer.begin(), static_cast<uint32_t>(offset()));
+        checkResultCode(code);
     }
 
-    void checkResult(int code) const { handle.checkResult(code); }
+    void closeFile(bool throw_if_error)
+    {
+        if (zip_handle)
+        {
+            int code = zipCloseFileInZip(zip_handle);
+            zip_handle = nullptr;
+            if (throw_if_error)
+                checkResultCode(code);
+        }
+    }
 
-    HandleHolder handle;
-    String filename;
+    void endWritingFile()
+    {
+        if (auto archive_writer_ptr = archive_writer.lock())
+        {
+            archive_writer_ptr->endWritingFile();
+            archive_writer.reset();
+        }
+    }
+
+    void checkResultCode(int code) const { checkResultCodeImpl(code, filename); }
+
+    std::weak_ptr<ZipArchiveWriter> archive_writer;
+    const String filename;
+    ZipHandle zip_handle;
 };
 
 
-namespace
+/// Provides a set of functions allowing the minizip library to write its output
+/// to a WriteBuffer instead of an ordinary file in the local filesystem.
+class ZipArchiveWriter::StreamInfo
 {
-    /// Provides a set of functions allowing the minizip library to write its output
-    /// to a WriteBuffer instead of an ordinary file in the local filesystem.
-    class StreamFromWriteBuffer
+public:
+    explicit StreamInfo(std::unique_ptr<WriteBuffer> write_buffer_)
+        : write_buffer(std::move(write_buffer_)), start_offset(write_buffer->count())
     {
-    public:
-        static RawHandle open(std::unique_ptr<WriteBuffer> archive_write_buffer)
-        {
-            Opaque opaque{std::move(archive_write_buffer)};
+    }
 
-            zlib_filefunc64_def func_def;
-            func_def.zopen64_file = &StreamFromWriteBuffer::openFileFunc;
-            func_def.zclose_file = &StreamFromWriteBuffer::closeFileFunc;
-            func_def.zread_file = &StreamFromWriteBuffer::readFileFunc;
-            func_def.zwrite_file = &StreamFromWriteBuffer::writeFileFunc;
-            func_def.zseek64_file = &StreamFromWriteBuffer::seekFunc;
-            func_def.ztell64_file = &StreamFromWriteBuffer::tellFunc;
-            func_def.zerror_file = &StreamFromWriteBuffer::testErrorFunc;
-            func_def.opaque = &opaque;
+    ~StreamInfo() = default;
 
-            return zipOpen2_64(
-                /* path= */ nullptr,
-                /* append= */ false,
-                /* globalcomment= */ nullptr,
-                &func_def);
-        }
+    ZipHandle makeZipHandle()
+    {
+        zlib_filefunc64_def func_def;
+        func_def.zopen64_file = &StreamInfo::openFileFunc;
+        func_def.zclose_file = &StreamInfo::closeFileFunc;
+        func_def.zread_file = &StreamInfo::readFileFunc;
+        func_def.zwrite_file = &StreamInfo::writeFileFunc;
+        func_def.zseek64_file = &StreamInfo::seekFunc;
+        func_def.ztell64_file = &StreamInfo::tellFunc;
+        func_def.zerror_file = &StreamInfo::testErrorFunc;
+        func_def.opaque = this;
 
-    private:
-        std::unique_ptr<WriteBuffer> write_buffer;
-        UInt64 start_offset = 0;
+        return zipOpen2_64(
+            /* path= */ nullptr,
+            /* append= */ false,
+            /* globalcomment= */ nullptr,
+            &func_def);
+    }
 
-        struct Opaque
-        {
-            std::unique_ptr<WriteBuffer> write_buffer;
-        };
+    WriteBuffer & getWriteBuffer() { return *write_buffer; }
 
-        static void * openFileFunc(void * opaque, const void *, int)
-        {
-            Opaque & opq = *reinterpret_cast<Opaque *>(opaque);
-            return new StreamFromWriteBuffer(std::move(opq.write_buffer));
-        }
+private:
+    /// We do nothing in openFileFunc() and in closeFileFunc() because we already have `write_buffer` (file is already opened).
+    static void * openFileFunc(void * opaque, const void *, int) { return opaque; }
+    static int closeFileFunc(void *, void *) { return ZIP_OK; }
 
-        explicit StreamFromWriteBuffer(std::unique_ptr<WriteBuffer> write_buffer_)
-            : write_buffer(std::move(write_buffer_)), start_offset(write_buffer->count()) {}
+    static unsigned long writeFileFunc(void * opaque, void *, const void * buf, unsigned long size) // NOLINT(google-runtime-int)
+    {
+        auto * stream_info = reinterpret_cast<StreamInfo *>(opaque);
+        stream_info->write_buffer->write(reinterpret_cast<const char *>(buf), size);
+        return size;
+    }
 
-        ~StreamFromWriteBuffer()
-        {
-            write_buffer->finalize();
-        }
+    static int testErrorFunc(void *, void *) { return ZIP_OK; }
 
-        static int closeFileFunc(void *, void * stream)
-        {
-            delete reinterpret_cast<StreamFromWriteBuffer *>(stream);
-            return ZIP_OK;
-        }
+    static ZPOS64_T tellFunc(void * opaque, void *)
+    {
+        auto * stream_info = reinterpret_cast<StreamInfo *>(opaque);
+        auto pos = stream_info->write_buffer->count() - stream_info->start_offset;
+        return pos;
+    }
 
-        static StreamFromWriteBuffer & get(void * ptr)
-        {
-            return *reinterpret_cast<StreamFromWriteBuffer *>(ptr);
-        }
+    static long seekFunc(void *, void *, ZPOS64_T, int) // NOLINT(google-runtime-int)
+    {
+        throw Exception(ErrorCodes::NOT_IMPLEMENTED, "StreamInfo::seek() is not implemented");
+    }
 
-        static unsigned long writeFileFunc(void *, void * stream, const void * buf, unsigned long size) // NOLINT(google-runtime-int)
-        {
-            auto & strm = get(stream);
-            strm.write_buffer->write(reinterpret_cast<const char *>(buf), size);
-            return size;
-        }
+    static unsigned long readFileFunc(void *, void *, void *, unsigned long) // NOLINT(google-runtime-int)
+    {
+        throw Exception(ErrorCodes::NOT_IMPLEMENTED, "StreamInfo::readFile() is not implemented");
+    }
 
-        static int testErrorFunc(void *, void *)
-        {
-            return ZIP_OK;
-        }
-
-        static ZPOS64_T tellFunc(void *, void * stream)
-        {
-            auto & strm = get(stream);
-            auto pos = strm.write_buffer->count() - strm.start_offset;
-            return pos;
-        }
-
-        static long seekFunc(void *, void *, ZPOS64_T, int) // NOLINT(google-runtime-int)
-        {
-            throw Exception(ErrorCodes::LOGICAL_ERROR, "StreamFromWriteBuffer::seek must not be called");
-        }
-
-        static unsigned long readFileFunc(void *, void *, void *, unsigned long) // NOLINT(google-runtime-int)
-        {
-            throw Exception(ErrorCodes::LOGICAL_ERROR, "StreamFromWriteBuffer::readFile must not be called");
-        }
-    };
-}
+    std::unique_ptr<WriteBuffer> write_buffer;
+    UInt64 start_offset;
+};
 
 
 ZipArchiveWriter::ZipArchiveWriter(const String & path_to_archive_)
@@ -248,21 +223,42 @@ ZipArchiveWriter::ZipArchiveWriter(const String & path_to_archive_, std::unique_
     : path_to_archive(path_to_archive_), compression_method(MZ_COMPRESS_METHOD_DEFLATE)
 {
     if (archive_write_buffer_)
-        handle = StreamFromWriteBuffer::open(std::move(archive_write_buffer_));
+    {
+        stream_info = std::make_unique<StreamInfo>(std::move(archive_write_buffer_));
+        zip_handle = stream_info->makeZipHandle();
+    }
     else
-        handle = zipOpen64(path_to_archive.c_str(), /* append= */ false);
-    if (!handle)
-        throw Exception(ErrorCodes::CANNOT_PACK_ARCHIVE, "Couldn't create zip archive {}", quoteString(path_to_archive));
+    {
+        zip_handle = zipOpen64(path_to_archive.c_str(), /* append= */ false);
+    }
 
+    if (!zip_handle)
+        throw Exception(ErrorCodes::CANNOT_PACK_ARCHIVE, "Couldn't create zip archive {}", quoteString(path_to_archive));
 }
 
 ZipArchiveWriter::~ZipArchiveWriter()
 {
-    if (handle)
+    if (!finalized)
+    {
+        /// It is totally OK to destroy instance without finalization when an exception occurs.
+        /// However it is suspicious to destroy instance without finalization at the green path.
+        if (!std::uncaught_exceptions() && std::current_exception() == nullptr)
+        {
+            Poco::Logger * log = &Poco::Logger::get("ZipArchiveWriter");
+            LOG_ERROR(log,
+                       "ZipArchiveWriter is not finalized when destructor is called. "
+                       "The zip archive might not be written at all or might be truncated. "
+                       "Stack trace: {}", StackTrace().toString());
+            chassert(false && "ZipArchiveWriter is not finalized in destructor.");
+        }
+    }
+
+    if (zip_handle)
     {
         try
         {
-            checkResult(zipClose(handle, /* global_comment= */ nullptr));
+            zipCloseFileInZip(zip_handle);
+            zipClose(zip_handle, /* global_comment= */ nullptr);
         }
         catch (...)
         {
@@ -273,13 +269,38 @@ ZipArchiveWriter::~ZipArchiveWriter()
 
 std::unique_ptr<WriteBufferFromFileBase> ZipArchiveWriter::writeFile(const String & filename)
 {
-    return std::make_unique<WriteBufferFromZipArchive>(acquireHandle(), filename);
+    return std::make_unique<WriteBufferFromZipArchive>(std::static_pointer_cast<ZipArchiveWriter>(shared_from_this()), filename);
 }
 
 bool ZipArchiveWriter::isWritingFile() const
 {
     std::lock_guard lock{mutex};
-    return !handle;
+    return is_writing_file;
+}
+
+void ZipArchiveWriter::finalize()
+{
+    std::lock_guard lock{mutex};
+    if (finalized)
+        return;
+
+    if (is_writing_file)
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "ZipArchiveWriter::finalize() is called in the middle of writing a file into the zip archive. That's not allowed");
+
+    if (zip_handle)
+    {
+        int code = zipClose(zip_handle, /* global_comment= */ nullptr);
+        zip_handle = nullptr;
+        checkResultCode(code);
+    }
+
+    if (stream_info)
+    {
+        stream_info->getWriteBuffer().finalize();
+        stream_info.reset();
+    }
+
+    finalized = true;
 }
 
 void ZipArchiveWriter::setCompression(const String & compression_method_, int compression_level_)
@@ -289,10 +310,28 @@ void ZipArchiveWriter::setCompression(const String & compression_method_, int co
     compression_level = compression_level_;
 }
 
+int ZipArchiveWriter::getCompressionMethod() const
+{
+    std::lock_guard lock{mutex};
+    return compression_method;
+}
+
+int ZipArchiveWriter::getCompressionLevel() const
+{
+    std::lock_guard lock{mutex};
+    return compression_level;
+}
+
 void ZipArchiveWriter::setPassword(const String & password_)
 {
     std::lock_guard lock{mutex};
     password = password_;
+}
+
+String ZipArchiveWriter::getPassword() const
+{
+    std::lock_guard lock{mutex};
+    return password;
 }
 
 int ZipArchiveWriter::compressionMethodToInt(const String & compression_method_)
@@ -361,45 +400,24 @@ void ZipArchiveWriter::checkEncryptionIsEnabled()
 #endif
 }
 
-ZipArchiveWriter::HandleHolder ZipArchiveWriter::acquireHandle()
-{
-    return HandleHolder{std::static_pointer_cast<ZipArchiveWriter>(shared_from_this())};
-}
-
-RawHandle ZipArchiveWriter::acquireRawHandle()
+ZipArchiveWriter::ZipHandle ZipArchiveWriter::startWritingFile()
 {
     std::lock_guard lock{mutex};
-    if (!handle)
-        throw Exception(ErrorCodes::LOGICAL_ERROR, "Cannot have more than one write buffer while writing a zip archive");
-    return std::exchange(handle, nullptr);
+    if (is_writing_file)
+        throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Cannot write two files to a zip archive in parallel");
+    is_writing_file = true;
+    return zip_handle;
 }
 
-void ZipArchiveWriter::releaseRawHandle(RawHandle raw_handle_)
+void ZipArchiveWriter::endWritingFile()
 {
     std::lock_guard lock{mutex};
-    handle = raw_handle_;
+    is_writing_file = false;
 }
 
-void ZipArchiveWriter::checkResult(int code) const
+void ZipArchiveWriter::checkResultCode(int code) const
 {
-    if (code >= ZIP_OK)
-        return;
-
-    String message = "Code = ";
-    switch (code)
-    {
-        case ZIP_ERRNO: message += "ERRNO, errno = " + errnoToString(); break;
-        case ZIP_PARAMERROR: message += "PARAMERROR"; break;
-        case ZIP_BADZIPFILE: message += "BADZIPFILE"; break;
-        case ZIP_INTERNALERROR: message += "INTERNALERROR"; break;
-        default: message += std::to_string(code); break;
-    }
-    showError(message);
-}
-
-void ZipArchiveWriter::showError(const String & message) const
-{
-    throw Exception(ErrorCodes::CANNOT_PACK_ARCHIVE, "Couldn't pack zip archive {}: {}", quoteString(path_to_archive), message);
+    checkResultCodeImpl(code, path_to_archive);
 }
 
 }

--- a/src/IO/Archives/ZipArchiveWriter.h
+++ b/src/IO/Archives/ZipArchiveWriter.h
@@ -4,6 +4,7 @@
 
 #if USE_MINIZIP
 #include <IO/Archives/IArchiveWriter.h>
+#include <base/defines.h>
 #include <mutex>
 
 
@@ -22,7 +23,7 @@ public:
     /// Constructs an archive that will be written by using a specified `archive_write_buffer_`.
     ZipArchiveWriter(const String & path_to_archive_, std::unique_ptr<WriteBuffer> archive_write_buffer_);
 
-    /// Destructors finalizes writing the archive.
+    /// Call finalize() before destructing IArchiveWriter.
     ~ZipArchiveWriter() override;
 
     /// Starts writing a file to the archive. The function returns a write buffer,
@@ -34,6 +35,10 @@ public:
     /// Returns true if there is an active instance of WriteBuffer returned by writeFile().
     /// This function should be used mostly for debugging purposes.
     bool isWritingFile() const override;
+
+    /// Finalizes writing of the archive. This function must be always called at the end of writing.
+    /// (Unless an error appeared and the archive is in fact no longer needed.)
+    void finalize() override;
 
     /// Supported compression methods.
     static constexpr const char kStore[] = "store";
@@ -68,22 +73,27 @@ public:
     static void checkEncryptionIsEnabled();
 
 private:
+    class StreamInfo;
+    using ZipHandle = void *;
     class WriteBufferFromZipArchive;
-    class HandleHolder;
-    using RawHandle = void *;
 
-    HandleHolder acquireHandle();
-    RawHandle acquireRawHandle();
-    void releaseRawHandle(RawHandle raw_handle_);
+    int getCompressionMethod() const;
+    int getCompressionLevel() const;
+    String getPassword() const;
 
-    void checkResult(int code) const;
-    [[noreturn]] void showError(const String & message) const;
+    ZipHandle startWritingFile();
+    void endWritingFile();
+
+    void checkResultCode(int code) const;
 
     const String path_to_archive;
-    int compression_method; /// By default the compression method is "deflate".
-    int compression_level = kDefaultCompressionLevel;
-    String password;
-    RawHandle handle = nullptr;
+    std::unique_ptr<StreamInfo> TSA_GUARDED_BY(mutex) stream_info;
+    int compression_method TSA_GUARDED_BY(mutex); /// By default the compression method is "deflate".
+    int compression_level TSA_GUARDED_BY(mutex) = kDefaultCompressionLevel;
+    String password TSA_GUARDED_BY(mutex);
+    ZipHandle zip_handle TSA_GUARDED_BY(mutex) = nullptr;
+    bool is_writing_file TSA_GUARDED_BY(mutex) = false;
+    bool finalized TSA_GUARDED_BY(mutex) = false;
     mutable std::mutex mutex;
 };
 

--- a/src/IO/tests/gtest_archive_reader_and_writer.cpp
+++ b/src/IO/tests/gtest_archive_reader_and_writer.cpp
@@ -102,7 +102,8 @@ TEST_P(ArchiveReaderAndWriterTest, EmptyArchive)
 {
     /// Make an archive.
     {
-        createArchiveWriter(getPathToArchive());
+        auto writer = createArchiveWriter(getPathToArchive());
+        writer->finalize();
     }
 
     /// The created archive can be found in the local filesystem.
@@ -132,7 +133,9 @@ TEST_P(ArchiveReaderAndWriterTest, SingleFileInArchive)
         {
             auto out = writer->writeFile("a.txt");
             writeString(contents, *out);
+            out->finalize();
         }
+        writer->finalize();
     }
 
     /// Read the archive.
@@ -198,11 +201,14 @@ TEST_P(ArchiveReaderAndWriterTest, TwoFilesInArchive)
         {
             auto out = writer->writeFile("a.txt");
             writeString(a_contents, *out);
+            out->finalize();
         }
         {
             auto out = writer->writeFile("b/c.txt");
             writeString(c_contents, *out);
+            out->finalize();
         }
+        writer->finalize();
     }
 
     /// Read the archive.
@@ -281,11 +287,14 @@ TEST_P(ArchiveReaderAndWriterTest, InMemory)
         {
             auto out = writer->writeFile("a.txt");
             writeString(a_contents, *out);
+            out->finalize();
         }
         {
             auto out = writer->writeFile("b.txt");
             writeString(b_contents, *out);
+            out->finalize();
         }
+        writer->finalize();
     }
 
     /// The created archive is really in memory.
@@ -335,7 +344,9 @@ TEST_P(ArchiveReaderAndWriterTest, Password)
         {
             auto out = writer->writeFile("a.txt");
             writeString(contents, *out);
+            out->finalize();
         }
+        writer->finalize();
     }
 
     /// Read the archive.

--- a/tests/integration/test_backup_restore_s3/test.py
+++ b/tests/integration/test_backup_restore_s3/test.py
@@ -445,3 +445,10 @@ def test_backup_with_fs_cache(
     # see MergeTreeData::initializeDirectoriesAndFormatVersion()
     if "CachedWriteBufferCacheWriteBytes" in restore_events:
         assert restore_events["CachedWriteBufferCacheWriteBytes"] <= 1
+
+
+def test_backup_to_zip():
+    storage_policy = "default"
+    backup_name = new_backup_name()
+    backup_destination = f"S3('http://minio1:9001/root/data/backups/{backup_name}.zip', 'minio', 'minio123')"
+    check_backup_and_restore(storage_policy, backup_destination)


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Added explicit `finalize()` function in `ZipArchiveWriter`.
Simplify too complicated code in `ZipArchiveWriter`.
This PR fixes https://github.com/ClickHouse/ClickHouse/issues/58074
