### PR TITLE
Fix DWARFBlockInputFormat using wrong base address sometimes

### DIFF
--- a/src/Processors/Formats/Impl/DWARFBlockInputFormat.cpp
+++ b/src/Processors/Formats/Impl/DWARFBlockInputFormat.cpp
@@ -308,6 +308,41 @@ static inline void throwIfError(llvm::Error & e, const char * what)
     throw Exception(ErrorCodes::CANNOT_PARSE_DWARF, "Failed to parse {}: {}", what, llvm::toString(std::move(e)));
 }
 
+llvm::DWARFFormValue DWARFBlockInputFormat::parseAttribute(
+    const llvm::DWARFAbbreviationDeclaration::AttributeSpec & attr, uint64_t * offset,
+    const UnitState & unit) const
+{
+    auto val = llvm::DWARFFormValue::createFromSValue(
+        attr.Form, attr.isImplicitConst() ? attr.getImplicitConstValue() : 0);
+    if (!val.extractValue(*extractor, offset, unit.dwarf_unit->getFormParams(), unit.dwarf_unit))
+        throw Exception(ErrorCodes::CANNOT_PARSE_DWARF,
+            "Failed to parse attribute {} of form {} at offset {}",
+                llvm::dwarf::AttributeString(attr.Attr), attr.Form, *offset);
+    return val;
+}
+
+void DWARFBlockInputFormat::skipAttribute(
+    const llvm::DWARFAbbreviationDeclaration::AttributeSpec & attr, uint64_t * offset,
+    const UnitState & unit) const
+{
+    if (!llvm::DWARFFormValue::skipValue(
+        attr.Form, *extractor, offset, unit.dwarf_unit->getFormParams()))
+            throw Exception(ErrorCodes::CANNOT_PARSE_DWARF,
+                "Failed to skip attribute {} of form {} at offset {}",
+                llvm::dwarf::AttributeString(attr.Attr), attr.Form, *offset);
+}
+
+uint64_t DWARFBlockInputFormat::parseAddress(llvm::dwarf::Attribute attr, const llvm::DWARFFormValue & val, const UnitState & unit)
+{
+    if (val.getForm() == llvm::dwarf::DW_FORM_addr)
+        return val.getRawUValue();
+    if (val.getForm() == llvm::dwarf::DW_FORM_addrx ||
+        (val.getForm() >= llvm::dwarf::DW_FORM_addrx1 &&
+         val.getForm() <= llvm::dwarf::DW_FORM_addrx4))
+        return fetchFromDebugAddr(unit.debug_addr_base, val.getRawUValue());
+    throw Exception(ErrorCodes::CANNOT_PARSE_DWARF, "Form {} for {} is not supported", llvm::dwarf::FormEncodingString(val.getForm()), llvm::dwarf::AttributeString(attr));
+}
+
 Chunk DWARFBlockInputFormat::parseEntries(UnitState & unit)
 {
     const auto & header = getPort().getHeader();
@@ -315,7 +350,6 @@ Chunk DWARFBlockInputFormat::parseEntries(UnitState & unit)
     std::array<bool, COL_COUNT> need{};
     for (const std::string & name : header.getNames())
         need[column_name_to_idx.at(name)] = true;
-    auto form_params = unit.dwarf_unit->getFormParams();
 
     /// For parallel arrays, we nominate one of them to be responsible for populating the offsets vector.
     need[COL_ATTR_NAME] = need[COL_ATTR_NAME] || need[COL_ATTR_FORM] || need[COL_ATTR_INT] || need[COL_ATTR_STR];
@@ -396,32 +430,26 @@ Chunk DWARFBlockInputFormat::parseEntries(UnitState & unit)
                 /// rely on them. (Why couldn't DWARF just promise that these attributes must appear
                 /// before any attributes that depend on them?)
                 uint64_t offset = unit.offset;
+                std::optional<llvm::DWARFFormValue> low_pc;
                 for (auto attr : abbrev->attributes())
                 {
                     if (attr.Attr == llvm::dwarf::DW_AT_addr_base ||
                         attr.Attr == llvm::dwarf::DW_AT_rnglists_base)
                     {
-                        auto val = llvm::DWARFFormValue::createFromSValue(
-                            attr.Form, attr.isImplicitConst() ? attr.getImplicitConstValue() : 0);
-                        if (!val.extractValue(*extractor, &offset, form_params, unit.dwarf_unit))
-                            throw Exception(ErrorCodes::CANNOT_PARSE_DWARF,
-                                "Failed to parse attribute {} of form {} at offset {}",
-                                llvm::dwarf::AttributeString(attr.Attr), attr.Form, unit.offset);
-                        uint64_t v = val.getRawUValue();
+                        auto val = parseAttribute(attr, &offset, unit);
                         if (attr.Attr == llvm::dwarf::DW_AT_addr_base)
-                            unit.addr_base = v;
+                            unit.debug_addr_base = val.getRawUValue();
                         else
-                            unit.rnglists_base = v;
+                            unit.rnglists_base = val.getRawUValue();
                     }
+                    else if (attr.Attr == llvm::dwarf::DW_AT_low_pc)
+                        low_pc = parseAttribute(attr, &offset, unit);
                     else
-                    {
-                        if (!llvm::DWARFFormValue::skipValue(
-                                attr.Form, *extractor, &offset, form_params))
-                            throw Exception(ErrorCodes::CANNOT_PARSE_DWARF,
-                                "Failed to skip attribute {} of form {} at offset {}",
-                                llvm::dwarf::AttributeString(attr.Attr), attr.Form, offset);
-                    }
+                        skipAttribute(attr, &offset, unit);
                 }
+                /// May use addr_base.
+                if (low_pc.has_value())
+                    unit.base_address = parseAddress(llvm::dwarf::DW_AT_low_pc, *low_pc, unit);
             }
 
             bool need_name = need[COL_NAME];
@@ -444,11 +472,7 @@ Chunk DWARFBlockInputFormat::parseEntries(UnitState & unit)
 
             for (auto attr : abbrev->attributes())
             {
-                auto val = llvm::DWARFFormValue::createFromSValue(attr.Form, attr.isImplicitConst() ? attr.getImplicitConstValue() : 0);
-                /// This is relatively slow, maybe we should reimplement it.
-                if (!val.extractValue(*extractor, &unit.offset, form_params, unit.dwarf_unit))
-                    throw Exception(ErrorCodes::CANNOT_PARSE_DWARF, "Failed to parse attribute {} of form {} at offset {}",
-                        llvm::dwarf::AttributeString(attr.Attr), attr.Form, unit.offset);
+                auto val = parseAttribute(attr, &unit.offset, unit);
 
                 if (need[COL_ATTR_NAME])
                     col_attr_name->insertValue(attr.Attr);
@@ -542,16 +566,7 @@ Chunk DWARFBlockInputFormat::parseEntries(UnitState & unit)
 
                         if (need_ranges && (attr.Attr == llvm::dwarf::DW_AT_low_pc || attr.Attr == llvm::dwarf::DW_AT_high_pc))
                         {
-                            UInt64 addr;
-                            if (val.getForm() == llvm::dwarf::DW_FORM_addr)
-                                addr = val.getRawUValue();
-                            else if (val.getForm() == llvm::dwarf::DW_FORM_addrx ||
-                                (val.getForm() >= llvm::dwarf::DW_FORM_addrx1 &&
-                                 val.getForm() <= llvm::dwarf::DW_FORM_addrx4))
-                                addr = fetchFromDebugAddr(unit.addr_base, val.getRawUValue());
-                            else
-                                throw Exception(ErrorCodes::CANNOT_PARSE_DWARF, "Form {} for {} is not supported", llvm::dwarf::FormEncodingString(val.getForm()), llvm::dwarf::AttributeString(attr.Attr));
-
+                            UInt64 addr = parseAddress(attr.Attr, val, unit);
                             if (attr.Attr == llvm::dwarf::DW_AT_low_pc)
                                 low_pc = addr;
                             else
@@ -645,7 +660,7 @@ Chunk DWARFBlockInputFormat::parseEntries(UnitState & unit)
             if (need_ranges)
             {
                 if (ranges.has_value())
-                    parseRanges(*ranges, ranges_rnglistx, low_pc, unit, col_ranges_start, col_ranges_end);
+                    parseRanges(*ranges, ranges_rnglistx, unit, col_ranges_start, col_ranges_end);
                 else if (low_pc.has_value())
                 {
                     UInt64 high;
@@ -810,12 +825,12 @@ uint64_t DWARFBlockInputFormat::fetchFromDebugAddr(uint64_t addr_base, uint64_t 
 }
 
 void DWARFBlockInputFormat::parseRanges(
-    uint64_t offset, bool form_rnglistx, std::optional<uint64_t> low_pc, const UnitState & unit, const ColumnVector<UInt64>::MutablePtr & col_ranges_start,
+    uint64_t offset, bool form_rnglistx, const UnitState & unit, const ColumnVector<UInt64>::MutablePtr & col_ranges_start,
     const ColumnVector<UInt64>::MutablePtr & col_ranges_end) const
 {
     llvm::Optional<llvm::object::SectionedAddress> base_addr;
-    if (low_pc.has_value())
-        base_addr = llvm::object::SectionedAddress{.Address = *low_pc};
+    if (unit.base_address != UINT64_MAX)
+        base_addr = llvm::object::SectionedAddress{.Address = unit.base_address};
 
     llvm::DWARFAddressRangesVector ranges;
 
@@ -860,7 +875,7 @@ void DWARFBlockInputFormat::parseRanges(
 
         auto lookup_addr = [&](uint32_t idx) -> llvm::Optional<llvm::object::SectionedAddress>
             {
-                uint64_t addr = fetchFromDebugAddr(unit.addr_base, idx);
+                uint64_t addr = fetchFromDebugAddr(unit.debug_addr_base, idx);
                 return llvm::object::SectionedAddress{.Address = addr};
             };
         ranges = list.getAbsoluteRanges(base_addr, /*AddressByteSize*/ 8, lookup_addr);

--- a/src/Processors/Formats/Impl/DWARFBlockInputFormat.h
+++ b/src/Processors/Formats/Impl/DWARFBlockInputFormat.h
@@ -54,8 +54,10 @@ private:
         ColumnPtr filename_table; // from .debug_line
         size_t filename_table_size = 0;
         /// Starting offset of this unit's data in .debug_addr and .debug_rnglists sections.
-        uint64_t addr_base = UINT64_MAX;
+        uint64_t debug_addr_base = UINT64_MAX;
         uint64_t rnglists_base = UINT64_MAX;
+        /// "Base address" for parsing range lists. Not to be confused with "addr base".
+        uint64_t base_address = UINT64_MAX;
 
         uint64_t offset = 0;
         std::vector<StackEntry> stack;
@@ -103,11 +105,18 @@ private:
     void parseFilenameTable(UnitState & unit, uint64_t offset);
     Chunk parseEntries(UnitState & unit);
 
+    llvm::DWARFFormValue parseAttribute(
+        const llvm::DWARFAbbreviationDeclaration::AttributeSpec & attr, uint64_t * offset,
+        const UnitState & unit) const;
+    void skipAttribute(
+        const llvm::DWARFAbbreviationDeclaration::AttributeSpec & attr, uint64_t * offset,
+        const UnitState & unit) const;
+    uint64_t parseAddress(llvm::dwarf::Attribute attr, const llvm::DWARFFormValue & val, const UnitState & unit);
     /// Parse .debug_addr entry.
     uint64_t fetchFromDebugAddr(uint64_t addr_base, uint64_t idx) const;
     /// Parse .debug_ranges (DWARF4) or .debug_rnglists (DWARF5) entry.
     void parseRanges(
-        uint64_t offset, bool form_rnglistx, std::optional<uint64_t> low_pc, const UnitState & unit,
+        uint64_t offset, bool form_rnglistx, const UnitState & unit,
         const ColumnVector<UInt64>::MutablePtr & col_ranges_start,
         const ColumnVector<UInt64>::MutablePtr & col_ranges_end) const;
 };


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

I misread the spec: in `.debug_rnglists`, the default base address is the DW_AT_low_pc attribute of the *compilation unit*, not of the entry that owns the ranges.

(In https://dwarfstd.org/doc/DWARF5.pdf : page 53: "If there is no preceding base address entry, then the applicable base address defaults to the base address of the compilation unit", page 66: "The base address of a compilation unit is defined as the value of the DW_AT_low_pc attribute, if present; otherwise, it is undefined.")