### PR TITLE
Add test with two filesystem caches

### DIFF
--- a/tests/integration/test_temporary_data_in_cache/configs/config.d/storage_configuration.xml
+++ b/tests/integration/test_temporary_data_in_cache/configs/config.d/storage_configuration.xml
@@ -3,18 +3,33 @@
         <disks>
             <local_disk>
                 <type>local_blob_storage</type>
-                <path>/local_disk/</path>
+                <path>/local_disk/disk1/</path>
             </local_disk>
 
             <tiny_local_cache>
                 <type>cache</type>
                 <disk>local_disk</disk>
-                <path>/tiny_local_cache/</path>
+                <path>/tiny_local_cache/cache1</path>
                 <max_size>10M</max_size>
                 <max_file_segment_size>1M</max_file_segment_size>
                 <boundary_alignment>1M</boundary_alignment>
                 <cache_on_write_operations>1</cache_on_write_operations>
             </tiny_local_cache>
+
+            <local_disk2>
+                <type>local_blob_storage</type>
+                <path>/local_disk/disk2/</path>
+            </local_disk2>
+
+            <tiny_local_cache2>
+                <type>cache</type>
+                <disk>local_disk2</disk>
+                <path>/tiny_local_cache/cache2</path>
+                <max_size>10M</max_size>
+                <max_file_segment_size>1M</max_file_segment_size>
+                <boundary_alignment>1M</boundary_alignment>
+                <cache_on_write_operations>1</cache_on_write_operations>
+            </tiny_local_cache2>
 
             <!-- Used to check free space in `/tiny_local_cache` using `system.disks` -->
             <!-- Entry about tiny_local_cache shows incorrect info due to it uses DiskObjectStorage under the hood -->
@@ -32,6 +47,13 @@
                     </main>
                 </volumes>
             </tiny_local_cache>
+            <tiny_local_cache2>
+                <volumes>
+                    <main>
+                        <disk>tiny_local_cache2</disk>
+                    </main>
+                </volumes>
+            </tiny_local_cache2>
         </policies>
     </storage_configuration>
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...


Should we handle the case when two cases points into the same disk or folder?

We may end in situation when `CurrentMetric_FilesystemCacheSize` is bigger than  `CurrentMetric_FilesystemCacheSizeLimit`

Added test fails with `No space left on device`:

<details>
<summary>Error message</summary>



```
E           helpers.client.QueryRuntimeException: Client failed! Return code: 75, stderr: Received exception from server (version 23.12.1):
E           Code: 75. DB::Exception: Received from 172.16.1.2:9000. DB::ErrnoException. DB::ErrnoException: Cannot write to file /local_disk/disk2/oipygreqdlxddfxvavrvthijqmhuuwik: , errno: 28, strerror: No space left on device
E           Total space: 50.00 MiB
E           Available space: 0.00 B
E           Total inodes: 8.99 million
E           Available inodes: 8.99 million
E           Mount point: /local_disk
E           Filesystem: tmpfs. Stack trace:
E           
E           0. ./contrib/llvm-project/libcxx/include/exception:134: Poco::Exception::Exception(String const&, int) @ 0x0000000013d37d12 in /usr/bin/clickhouse
E           1. ./_build/release/./src/Common/Exception.cpp:96: DB::Exception::Exception(DB::Exception::MessageMasked&&, int, bool) @ 0x000000000b1f51b7 in /usr/bin/clickhouse
E           2. ./contrib/llvm-project/libcxx/include/string:1499: DB::ErrnoException::ErrnoException(String&&, int, int) @ 0x000000000b234f4d in /usr/bin/clickhouse
E           3. ./src/Common/Exception.h:0: void DB::ErrnoException::throwFromPath<String&>(int, String const&, FormatStringHelperImpl<std::type_identity<String&>::type>, String&) @ 0x000000000b23ed2e in /usr/bin/clickhouse
E           4. ./_build/release/./src/IO/WriteBufferFromFileDescriptor.cpp:0: DB::WriteBufferFromFileDescriptor::nextImpl() @ 0x000000000b25b355 in /usr/bin/clickhouse
E           5. ./src/IO/WriteBuffer.h:65: DB::WriteBufferFromFileDecorator::nextImpl() @ 0x000000000f9ae7d7 in /usr/bin/clickhouse
E           6. ./src/IO/WriteBuffer.h:65: DB::HashingWriteBuffer::nextImpl() @ 0x0000000010eee001 in /usr/bin/clickhouse
E           7. DB::WriteBuffer::write(char const*, unsigned long) @ 0x00000000065c67bb in /usr/bin/clickhouse
E           8. ./_build/release/./src/Compression/CompressedWriteBuffer.cpp:58: DB::CompressedWriteBuffer::nextImpl() @ 0x000000000f726aff in /usr/bin/clickhouse
E           9. ./src/IO/WriteBuffer.h:65: DB::HashingWriteBuffer::nextImpl() @ 0x0000000010eee001 in /usr/bin/clickhouse
E           10. ./src/IO/WriteBuffer.h:65: void std::__function::__policy_invoker<void (DB::ISerialization::SubstreamPath const&)>::__call_impl<std::__function::__default_alloc_func<DB::MergeTreeDataPartWriterWide::getCurrentMarksForColumn(DB::NameAndTypePair const&, std::set<String, std::less<String>, std::allocator<String>>&)::$_0, void (DB::ISerialization::SubstreamPath const&)>>(std::__function::__policy_storage const*, DB::ISerialization::SubstreamPath const&) @ 0x000000001105f937 in /usr/bin/clickhouse
E           11. ./contrib/llvm-project/libcxx/include/vector:1613: DB::ISerialization::enumerateStreams(DB::ISerialization::EnumerateStreamsSettings&, std::function<void (DB::ISerialization::SubstreamPath const&)> const&, DB::ISerialization::SubstreamData const&) const @ 0x000000000f876733 in /usr/bin/clickhouse
E           12. ./contrib/llvm-project/libcxx/include/__memory/shared_ptr.h:701: DB::ISerialization::enumerateStreams(std::function<void (DB::ISerialization::SubstreamPath const&)> const&, std::shared_ptr<DB::IDataType const> const&, COW<DB::IColumn>::immutable_ptr<DB::IColumn> const&) const @ 0x000000000f8768a2 in /usr/bin/clickhouse
E           13. ./contrib/boost/boost/smart_ptr/intrusive_ptr.hpp:100: DB::MergeTreeDataPartWriterWide::getCurrentMarksForColumn(DB::NameAndTypePair const&, std::set<String, std::less<String>, std::allocator<String>>&) @ 0x000000001105bf58 in /usr/bin/clickhouse
E           14. ./contrib/llvm-project/libcxx/include/unordered_map:1805: DB::MergeTreeDataPartWriterWide::writeColumn(DB::NameAndTypePair const&, DB::IColumn const&, std::set<String, std::less<String>, std::allocator<String>>&, std::vector<DB::Granule, std::allocator<DB::Granule>> const&) @ 0x000000001105b48d in /usr/bin/clickhouse
E           15. ./_build/release/./src/Storages/MergeTree/MergeTreeDataPartWriterWide.cpp:259: DB::MergeTreeDataPartWriterWide::write(DB::Block const&, DB::PODArray<unsigned long, 4096ul, Allocator<false, false>, 63ul, 64ul> const*) @ 0x000000001105a09a in /usr/bin/clickhouse
E           16. ./_build/release/./src/Storages/MergeTree/MergedBlockOutputStream.cpp:333: DB::MergedBlockOutputStream::writeWithPermutation(DB::Block const&, DB::PODArray<unsigned long, 4096ul, Allocator<false, false>, 63ul, 64ul> const*) @ 0x0000000011185dfb in /usr/bin/clickhouse
E           17. ./_build/release/./src/Storages/MergeTree/MergeTreeDataWriter.cpp:0: DB::MergeTreeDataWriter::writeTempPartImpl(DB::BlockWithPartition&, std::shared_ptr<DB::StorageInMemoryMetadata const> const&, std::shared_ptr<DB::Context const>, long, bool) @ 0x00000000111b7127 in /usr/bin/clickhouse
E           18. ./_build/release/./src/Storages/MergeTree/MergeTreeDataWriter.cpp:385: DB::MergeTreeDataWriter::writeTempPart(DB::BlockWithPartition&, std::shared_ptr<DB::StorageInMemoryMetadata const> const&, std::shared_ptr<DB::Context const>) @ 0x00000000111b4f3f in /usr/bin/clickhouse
E           19. ./_build/release/./src/Storages/MergeTree/MergeTreeSink.cpp:87: DB::MergeTreeSink::consume(DB::Chunk) @ 0x00000000112afeb1 in /usr/bin/clickhouse
E           20. ./contrib/llvm-project/libcxx/include/__memory/shared_ptr.h:701: DB::SinkToStorage::onConsume(DB::Chunk) @ 0x00000000117a50d5 in /usr/bin/clickhouse
E           21. ./contrib/llvm-project/libcxx/include/__memory/shared_ptr.h:701: void std::__function::__policy_invoker<void ()>::__call_impl<std::__function::__default_alloc_func<DB::ExceptionKeepingTransform::work()::$_1, void ()>>(std::__function::__policy_storage const*) @ 0x00000000116f36cb in /usr/bin/clickhouse
E           22. ./_build/release/./src/Processors/Transforms/ExceptionKeepingTransform.cpp:102: DB::runStep(std::function<void ()>, DB::ThreadStatus*, std::atomic<unsigned long>*) @ 0x00000000116f3550 in /usr/bin/clickhouse
E           23. ./contrib/llvm-project/libcxx/include/__functional/function.h:818: ? @ 0x00000000116f2f6b in /usr/bin/clickhouse
E           24. ./_build/release/./src/Processors/Executors/ExecutionThreadContext.cpp:0: DB::ExecutionThreadContext::executeTask() @ 0x00000000114b878d in /usr/bin/clickhouse
E           25. ./_build/release/./src/Processors/Executors/PipelineExecutor.cpp:273: DB::PipelineExecutor::executeSingleThread(unsigned long) @ 0x00000000114b08cc in /usr/bin/clickhouse
E           26. ./contrib/llvm-project/libcxx/include/__memory/shared_ptr.h:701: DB::PipelineExecutor::executeImpl(unsigned long, bool) @ 0x00000000114af69a in /usr/bin/clickhouse
E           27. ./contrib/llvm-project/libcxx/include/__memory/unique_ptr.h:274: DB::PipelineExecutor::execute(unsigned long, bool) @ 0x00000000114af47d in /usr/bin/clickhouse
E           28. ./_build/release/./src/Processors/Executors/CompletedPipelineExecutor.cpp:0: void std::__function::__policy_invoker<void ()>::__call_impl<std::__function::__default_alloc_func<ThreadFromGlobalPoolImpl<true>::ThreadFromGlobalPoolImpl<DB::CompletedPipelineExecutor::execute()::$_0>(DB::CompletedPipelineExecutor::execute()::$_0&&)::'lambda'(), void ()>>(std::__function::__policy_storage const*) @ 0x00000000114ae86e in /usr/bin/clickhouse
E           29. ./base/base/../base/wide_integer_impl.h:809: ThreadPoolImpl<std::thread>::worker(std::__list_iterator<std::thread, void*>) @ 0x000000000b2bc242 in /usr/bin/clickhouse
E           30. ./contrib/llvm-project/libcxx/include/__memory/unique_ptr.h:302: void* std::__thread_proxy[abi:v15000]<std::tuple<std::unique_ptr<std::__thread_struct, std::default_delete<std::__thread_struct>>, void ThreadPoolImpl<std::thread>::scheduleImpl<void>(std::function<void ()>, Priority, std::optional<unsigned long>, bool)::'lambda0'()>>(void*) @ 0x000000000b2c064e in /usr/bin/clickhouse
E           31. ? @ 0x00007f165ae23ac3 in ?
E           . (CANNOT_WRITE_TO_FILE_DESCRIPTOR)
E           (query: INSERT INTO test_two_caches_tiny_local_cache2 SELECT number, number FROM numbers(1024 * 1024))

```


</details>