### PR TITLE
Fix syntax and doc

### DIFF
--- a/docs/en/operations/query-cache.md
+++ b/docs/en/operations/query-cache.md
@@ -29,8 +29,8 @@ Transactionally inconsistent caching is traditionally provided by client tools o
 the same caching logic and configuration is often duplicated. With ClickHouse's query cache, the caching logic moves to the server side.
 This reduces maintenance effort and avoids redundancy.
 
-:::security consideration
-The cached query result is tied to the user executing it. Authorization checks are performed when the query is executed. This means that if there are any alterations to the user's role or permissions between the time the query is cached and when the cache is accessed, the result will not reflect these changes. We recommend using different users to distinguish between different levels of access, instead of actively toggling roles for a single user between queries, as this practice may lead to unexpected query results.
+:::note
+Security consideration: The cached query result is tied to the user executing it. Authorization checks are performed when the query is executed. This means that if there are any alterations to the user's role or permissions between the time the query is cached and when the cache is accessed, the result will not reflect these changes. We recommend using different users to distinguish between different levels of access, instead of actively toggling roles for a single user between queries, as this practice may lead to unexpected query results.
 :::
 
 ## Configuration Settings and Usage

--- a/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
@@ -928,7 +928,7 @@ RangesInDataParts MergeTreeDataSelectExecutor::filterPartsByPrimaryKeyAndSkipInd
 
         Strings forced_indices;
         {
-            Tokens tokens(indices.data(), &indices[indices.size()], settings.max_query_size);
+            Tokens tokens(indices.data(), indices.data() + indices.size(), settings.max_query_size);
             IParser::Pos pos(tokens, static_cast<unsigned>(settings.max_parser_depth));
             Expected expected;
             if (!parseIdentifiersOrStringLiterals(pos, expected, forced_indices))


### PR DESCRIPTION
From Alexey: 

> C++ and C explicitly permits taking the address and pointer comparison with the position at the end of a buffer in memory. C++ standard library does not allow the subscript operator on the end of the buffer, we should use .data() + .size() instead, which will compile to the same machine code.

And while at it, i saw the doc i last updated had the wrong markdown syntax so fixing that too.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)