### PR TITLE
Avoid throwing ABORTED on normal situations

### DIFF
--- a/src/Storages/MergeTree/MergeTreeBackgroundExecutor.cpp
+++ b/src/Storages/MergeTree/MergeTreeBackgroundExecutor.cpp
@@ -187,7 +187,7 @@ void MergeTreeBackgroundExecutor<Queue>::removeTasksCorrespondingToStorage(Stora
         {
             /// An exception context is needed to proper delete write buffers without finalization
             /// See WriteBuffer::~WriteBuffer for more context
-            throw std::runtime_error("");
+            throw std::runtime_error("Storage is about to be deleted. Done pending task as if it was aborted.");
         }
         catch (...)
         {

--- a/src/Storages/MergeTree/MergeTreeBackgroundExecutor.cpp
+++ b/src/Storages/MergeTree/MergeTreeBackgroundExecutor.cpp
@@ -186,7 +186,8 @@ void MergeTreeBackgroundExecutor<Queue>::removeTasksCorrespondingToStorage(Stora
         try
         {
             /// An exception context is needed to proper delete write buffers without finalization
-            throw Exception(ErrorCodes::ABORTED, "Storage is about to be deleted. Done pending task as if it was aborted.");
+            /// See WriteBuffer::~WriteBuffer for more context
+            throw std::runtime_error("");
         }
         catch (...)
         {


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

Throwing `ErrorCodes::ABORTED` means errors get added to system.errors, which is wrong for expected behaviour. Moreover, this is only necessary to workaround an internal check. Using std::exception does not count anything in system.errors.

cc @CheSema 
Closes https://github.com/ClickHouse/ClickHouse/issues/51543

