### PR TITLE
Make fs caches with the same path use the same cache objects

### DIFF
--- a/src/Interpreters/Cache/FileCacheFactory.cpp
+++ b/src/Interpreters/Cache/FileCacheFactory.cpp
@@ -50,12 +50,35 @@ FileCachePtr FileCacheFactory::getOrCreate(
 {
     std::lock_guard lock(mutex);
 
-    auto it = caches_by_name.find(cache_name);
+    auto it = std::find_if(caches_by_name.begin(), caches_by_name.end(), [&](const auto & cache_by_name)
+    {
+        return cache_by_name.second->getSettings().base_path == file_cache_settings.base_path;
+    });
+
     if (it == caches_by_name.end())
     {
         auto cache = std::make_shared<FileCache>(cache_name, file_cache_settings);
-        it = caches_by_name.emplace(
-            cache_name, std::make_unique<FileCacheData>(cache, file_cache_settings, config_path)).first;
+
+        bool inserted;
+        std::tie(it, inserted) = caches_by_name.emplace(
+            cache_name, std::make_unique<FileCacheData>(cache, file_cache_settings, config_path));
+
+        if (!inserted)
+        {
+            throw Exception(ErrorCodes::BAD_ARGUMENTS,
+                            "Cache with name {} exists, but it has a different path", cache_name);
+        }
+    }
+    else if (it->second->getSettings() != file_cache_settings)
+    {
+        throw Exception(ErrorCodes::BAD_ARGUMENTS,
+                        "Found more than one cache configuration with the same path, "
+                        "but with different cache settings ({} and {})",
+                        it->first, cache_name);
+    }
+    else if (it->first != cache_name)
+    {
+        caches_by_name.emplace(cache_name, it->second);
     }
 
     return it->second->cache;
@@ -69,12 +92,33 @@ FileCachePtr FileCacheFactory::create(
     std::lock_guard lock(mutex);
 
     auto it = caches_by_name.find(cache_name);
+
     if (it != caches_by_name.end())
         throw Exception(ErrorCodes::BAD_ARGUMENTS, "Cache with name {} already exists", cache_name);
 
-    auto cache = std::make_shared<FileCache>(cache_name, file_cache_settings);
-    it = caches_by_name.emplace(
-        cache_name, std::make_unique<FileCacheData>(cache, file_cache_settings, config_path)).first;
+    it = std::find_if(caches_by_name.begin(), caches_by_name.end(), [&](const auto & cache_by_name)
+    {
+        return cache_by_name.second->getSettings().base_path == file_cache_settings.base_path;
+    });
+
+    if (it == caches_by_name.end())
+    {
+        auto cache = std::make_shared<FileCache>(cache_name, file_cache_settings);
+        it = caches_by_name.emplace(
+            cache_name, std::make_unique<FileCacheData>(cache, file_cache_settings, config_path)).first;
+    }
+    else if (it->second->getSettings() != file_cache_settings)
+    {
+        throw Exception(ErrorCodes::BAD_ARGUMENTS,
+                        "Found more than one cache configuration with the same path, "
+                        "but with different cache settings ({} and {})",
+                        it->first, cache_name);
+    }
+    else
+    {
+        [[maybe_unused]] bool inserted = caches_by_name.emplace(cache_name, it->second).second;
+        chassert(inserted);
+    }
 
     return it->second->cache;
 }
@@ -98,10 +142,13 @@ void FileCacheFactory::updateSettingsFromConfig(const Poco::Util::AbstractConfig
         caches_by_name_copy = caches_by_name;
     }
 
+    std::unordered_set<std::string> checked_paths;
     for (const auto & [_, cache_info] : caches_by_name_copy)
     {
-        if (cache_info->config_path.empty())
+        if (cache_info->config_path.empty() || checked_paths.contains(cache_info->config_path))
             continue;
+
+        checked_paths.emplace(cache_info->config_path);
 
         FileCacheSettings new_settings;
         new_settings.loadFromConfig(config, cache_info->config_path);

--- a/src/Interpreters/Cache/IFileCachePriority.cpp
+++ b/src/Interpreters/Cache/IFileCachePriority.cpp
@@ -13,7 +13,7 @@ namespace DB
 IFileCachePriority::IFileCachePriority(size_t max_size_, size_t max_elements_)
     : max_size(max_size_), max_elements(max_elements_)
 {
-    CurrentMetrics::set(CurrentMetrics::FilesystemCacheSizeLimit, max_size_);
+    CurrentMetrics::add(CurrentMetrics::FilesystemCacheSizeLimit, max_size_);
 }
 
 IFileCachePriority::Entry::Entry(

--- a/tests/integration/test_filesystem_cache/config.d/storage_conf_2.xml
+++ b/tests/integration/test_filesystem_cache/config.d/storage_conf_2.xml
@@ -1,0 +1,24 @@
+<clickhouse>
+    <storage_configuration>
+        <disks>
+            <hdd_blob>
+                <type>local_blob_storage</type>
+                <path>/</path>
+            </hdd_blob>
+            <cache1>
+                <type>cache</type>
+                <disk>hdd_blob</disk>
+                <path>/cache1/</path>
+                <max_size>1Mi</max_size>
+                <cache_on_write_operations>1</cache_on_write_operations>
+            </cache1>
+            <cache2>
+                <type>cache</type>
+                <disk>hdd_blob</disk>
+                <path>/cache1/</path>
+                <max_size>1Mi</max_size>
+                <cache_on_write_operations>1</cache_on_write_operations>
+            </cache2>
+        </disks>
+    </storage_configuration>
+</clickhouse>


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Make caches with the same path use the same cache objects. This behaviour existed before, but was broken in https://github.com/ClickHouse/ClickHouse/pull/48805 (in 23.4). If such caches with the same path have different set of cache settings, an exception will be thrown, that this is not allowed.