### PR TITLE
Analyzer: fix tuple comparison when result is always null

### DIFF
--- a/src/Analyzer/Passes/ComparisonTupleEliminationPass.cpp
+++ b/src/Analyzer/Passes/ComparisonTupleEliminationPass.cpp
@@ -1,6 +1,8 @@
 #include <Analyzer/Passes/ComparisonTupleEliminationPass.h>
 
 #include <DataTypes/DataTypeTuple.h>
+#include <DataTypes/DataTypeNullable.h>
+#include <DataTypes/DataTypeNothing.h>
 
 #include <Functions/FunctionFactory.h>
 
@@ -50,6 +52,13 @@ public:
         const auto & rhs_argument = arguments[1];
         const auto & rhs_argument_result_type = rhs_argument->getResultType();
         if (!isTuple(rhs_argument_result_type))
+            return;
+
+        if (function_node->getResultType()->equals(DataTypeNullable(std::make_shared<DataTypeNothing>())))
+            /** The function `equals` can return Nullable(Nothing), e.g., in the case of (a, b) == (NULL, 1).
+              * On the other hand, `AND` returns Nullable(UInt8), so we would need to convert types.
+              * It's better to just skip this trivial case.
+              */
             return;
 
         auto lhs_argument_node_type = lhs_argument->getNodeType();

--- a/src/Storages/MergeTree/KeyCondition.cpp
+++ b/src/Storages/MergeTree/KeyCondition.cpp
@@ -3,6 +3,7 @@
 #include <DataTypes/DataTypesNumber.h>
 #include <DataTypes/DataTypeLowCardinality.h>
 #include <DataTypes/DataTypeNullable.h>
+#include <DataTypes/DataTypeNothing.h>
 #include <DataTypes/DataTypeString.h>
 #include <DataTypes/FieldToDataType.h>
 #include <DataTypes/getLeastSupertype.h>
@@ -1642,6 +1643,15 @@ static void castValueToType(const DataTypePtr & desired_type, Field & src_value,
 
 bool KeyCondition::extractAtomFromTree(const RPNBuilderTreeNode & node, RPNElement & out)
 {
+    const auto * node_dag = node.getDAGNode();
+    if (node_dag && node_dag->result_type->equals(DataTypeNullable(std::make_shared<DataTypeNothing>())))
+    {
+        /// If the inferred result type is Nullable(Nothing) at the query analysis stage,
+        /// we don't analyze this node further as its condition will always be false.
+        out.function = RPNElement::ALWAYS_FALSE;
+        return true;
+    }
+
     /** Functions < > = != <= >= in `notIn` isNull isNotNull, where one argument is a constant, and the other is one of columns of key,
       *  or itself, wrapped in a chain of possibly-monotonic functions,
       *  (for example, if the table has ORDER BY time, we will check the conditions like

--- a/tests/queries/0_stateless/02030_tuple_filter.sql
+++ b/tests/queries/0_stateless/02030_tuple_filter.sql
@@ -33,6 +33,7 @@ SET force_primary_key = 0;
 
 SELECT * FROM test_tuple_filter WHERE (1, value) = (id, 'A');
 SELECT * FROM test_tuple_filter WHERE tuple(id) = tuple(1);
+SELECT * FROM test_tuple_filter WHERE (id, (id, id) = (1, NULL)) == (NULL, NULL);
 
 SELECT * FROM test_tuple_filter WHERE (log_date, value) = tuple('2021-01-01'); -- { serverError 43 }
 SELECT * FROM test_tuple_filter WHERE (id, value) = tuple(1); -- { serverError 43 }

--- a/tests/queries/0_stateless/02862_index_inverted_incorrect_args.sql
+++ b/tests/queries/0_stateless/02862_index_inverted_incorrect_args.sql
@@ -3,7 +3,7 @@ DROP TABLE IF EXISTS tab;
 SET allow_experimental_inverted_index=1;
 CREATE TABLE tab (`k` UInt64, `s` Map(String, String), INDEX af mapKeys(s) TYPE inverted(2) GRANULARITY 1) ENGINE = MergeTree ORDER BY k SETTINGS index_granularity = 2, index_granularity_bytes = '10Mi';
 INSERT INTO tab (k) VALUES (0);
-SELECT * FROM tab PREWHERE (s[NULL]) = 'Click a03' SETTINGS allow_experimental_analyzer=1; -- { serverError ILLEGAL_TYPE_OF_COLUMN_FOR_FILTER }
+SELECT * FROM tab PREWHERE (s[NULL]) = 'Click a03' SETTINGS allow_experimental_analyzer=1;
 SELECT * FROM tab PREWHERE (s[1]) = 'Click a03' SETTINGS allow_experimental_analyzer=1; -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
 SELECT * FROM tab PREWHERE (s['foo']) = 'Click a03' SETTINGS allow_experimental_analyzer=1;
 DROP TABLE tab;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)

