### PR TITLE
Fix timeout in 01732_race_condition_storage_join_long

### DIFF
--- a/tests/queries/0_stateless/01732_race_condition_storage_join_long.sh
+++ b/tests/queries/0_stateless/01732_race_condition_storage_join_long.sh
@@ -15,7 +15,7 @@ echo "
 
 function read_thread_big()
 {
-    while true; do 
+    while true; do
         echo "
             SELECT * FROM ( SELECT number AS x FROM numbers(100000) ) AS t1 ALL FULL JOIN storage_join_race USING (x) FORMAT Null;
         " | $CLICKHOUSE_CLIENT -n
@@ -24,7 +24,7 @@ function read_thread_big()
 
 function read_thread_small()
 {
-    while true; do 
+    while true; do
         echo "
             SELECT * FROM ( SELECT number AS x FROM numbers(10) ) AS t1 ALL FULL JOIN storage_join_race USING (x) FORMAT Null;
         " | $CLICKHOUSE_CLIENT -n
@@ -51,8 +51,11 @@ timeout $TIMEOUT bash -c read_thread_big 2> /dev/null &
 timeout $TIMEOUT bash -c read_thread_small 2> /dev/null &
 timeout $TIMEOUT bash -c read_thread_select 2> /dev/null &
 
+# Run insert query with a sleep to make sure that it is executed all the time during the read queries.
 echo "
-    INSERT INTO storage_join_race SELECT number AS x, number AS y FROM numbers (10000000);
+    INSERT INTO storage_join_race
+        SELECT number AS x, sleepEachRow(0.1) + number AS y FROM numbers ($TIMEOUT * 10)
+        SETTINGS function_sleep_max_microseconds_per_block = 100000000, max_block_size = 10;
 " | $CLICKHOUSE_CLIENT -n
 
 wait


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)

Close https://github.com/ClickHouse/ClickHouse/issues/57715


