### PR TITLE
Handle another case for preprocessing in Keeper

### DIFF
--- a/src/Coordination/KeeperServer.cpp
+++ b/src/Coordination/KeeperServer.cpp
@@ -660,6 +660,12 @@ nuraft::cb_func::ReturnCode KeeperServer::callbackFunc(nuraft::cb_func::Type typ
 
         switch (type)
         {
+            case nuraft::cb_func::PreAppendLogLeader:
+            {
+                /// we cannot preprocess anything new as leader because we don't have up-to-date in-memory state
+                /// until we preprocess all stored logs
+                return nuraft::cb_func::ReturnCode::ReturnNull;
+            }
             case nuraft::cb_func::InitialBatchCommited:
             {
                 preprocess_logs();


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Similar to this https://github.com/ClickHouse/ClickHouse/pull/58069 I added another case which was not handled correctly.

Should fix failure like this https://s3.amazonaws.com/clickhouse-test-reports/0/d7a35773c14adc9bad70cf5aaab8e33164ef88c6/integration_tests__asan__[3_4].html

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
