### PR TITLE
Disable max_bytes_before_external* in 00172_hits_joins

### DIFF
--- a/tests/queries/1_stateful/00172_hits_joins.sql.j2
+++ b/tests/queries/1_stateful/00172_hits_joins.sql.j2
@@ -4,6 +4,9 @@
 SET max_rows_in_join = '{% if join_algorithm == 'grace_hash' %}10K{% else %}0{% endif %}';
 SET grace_hash_join_initial_buckets = 4;
 
+-- Test is slow with external sort / group by
+SET max_bytes_before_external_sort = 0, max_bytes_before_external_group_by = 0;
+
 SELECT '--- {{ join_algorithm }} ---';
 
 SET join_algorithm = '{{ join_algorithm }}';


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

Test is slowed down after https://github.com/ClickHouse/ClickHouse/commit/bd5675f0fe8b274d81a2f7b20431de86402f735e and sometimes it leads to timeouts, e.g. https://s3.amazonaws.com/clickhouse-test-reports/58182/468b5e28133df8ace28be55f7d908ac1cc60c4ad/stateful_tests__debug_.html

(check out execution times before and after this commit for different checks:
https://play.clickhouse.com/play?user=play#U0VMRUNUCiAgICBjaGVja19uYW1lLAogICAgY2hlY2tfc3RhcnRfdGltZSBhcyB0cywKICAgIHRlc3RfZHVyYXRpb25fbXMgLyAxMDAwIEFTIGR1ciwKICAgIGlmKGNvbW1pdF9zaGEgPT0gJ2JkNTY3NWYwZmU4YjI3NGQ4MWEyZjdiMjA0MzFkZTg2NDAyZjczNWUnLCAnISEhISEhISEnLCBjb21taXRfc2hhKSBhcyBzaGEsCiAgICByZXBvcnRfdXJsLAogICAgdGVzdF9uYW1lCkZST00gY2hlY2tzCldIRVJFICgnMjAyMy0xMi0xOCcgPD0gY2hlY2tfc3RhcnRfdGltZSkgQU5EICh0ZXN0X25hbWUgTElLRSAnJTAwMTcyX2hpdHNfam9pbnMlJykKICAgIEFORCBwdWxsX3JlcXVlc3RfbnVtYmVyID0gMAogICAgQU5EIGNoZWNrX3N0YXJ0X3RpbWUgPiAwCk9SREVSIEJZIGNoZWNrX25hbWUgREVTQywgdHM=
)