### PR TITLE
Avoid sending ComposeObject requests after upload to GCS

### DIFF
--- a/src/Backups/BackupIO_S3.cpp
+++ b/src/Backups/BackupIO_S3.cpp
@@ -69,10 +69,14 @@ namespace
         /// Requests in backups can be extremely long, set to one hour
         client_configuration.requestTimeoutMs = 60 * 60 * 1000;
 
+        S3::ClientSettings client_settings{
+            .use_virtual_addressing = s3_uri.is_virtual_hosted_style,
+            .disable_checksum = local_settings.s3_disable_checksum,
+        };
+
         return S3::ClientFactory::instance().create(
             client_configuration,
-            s3_uri.is_virtual_hosted_style,
-            local_settings.s3_disable_checksum,
+            client_settings,
             credentials.GetAWSAccessKeyId(),
             credentials.GetAWSSecretKey(),
             settings.auth_settings.server_side_encryption_customer_key_base64,

--- a/src/Backups/BackupIO_S3.cpp
+++ b/src/Backups/BackupIO_S3.cpp
@@ -72,6 +72,7 @@ namespace
         S3::ClientSettings client_settings{
             .use_virtual_addressing = s3_uri.is_virtual_hosted_style,
             .disable_checksum = local_settings.s3_disable_checksum,
+            .gcs_issue_compose_request = context->getConfigRef().getBool("s3.gcs_issue_compose_request", false),
         };
 
         return S3::ClientFactory::instance().create(

--- a/src/Coordination/KeeperSnapshotManagerS3.cpp
+++ b/src/Coordination/KeeperSnapshotManagerS3.cpp
@@ -13,6 +13,7 @@
 #include <IO/ReadBufferFromFile.h>
 #include <IO/ReadHelpers.h>
 #include <IO/S3/PocoHTTPClient.h>
+#include <IO/S3/Client.h>
 #include <IO/WriteHelpers.h>
 #include <IO/copyData.h>
 #include <Common/Macros.h>
@@ -98,10 +99,14 @@ void KeeperSnapshotManagerS3::updateS3Configuration(const Poco::Util::AbstractCo
 
         client_configuration.endpointOverride = new_uri.endpoint;
 
+        S3::ClientSettings client_settings{
+            .use_virtual_addressing = new_uri.is_virtual_hosted_style,
+            .disable_checksum = false,
+        };
+
         auto client = S3::ClientFactory::instance().create(
             client_configuration,
-            new_uri.is_virtual_hosted_style,
-            /* disable_checksum= */ false,
+            client_settings,
             credentials.GetAWSAccessKeyId(),
             credentials.GetAWSSecretKey(),
             auth_settings.server_side_encryption_customer_key_base64,

--- a/src/Coordination/KeeperSnapshotManagerS3.cpp
+++ b/src/Coordination/KeeperSnapshotManagerS3.cpp
@@ -102,6 +102,7 @@ void KeeperSnapshotManagerS3::updateS3Configuration(const Poco::Util::AbstractCo
         S3::ClientSettings client_settings{
             .use_virtual_addressing = new_uri.is_virtual_hosted_style,
             .disable_checksum = false,
+            .gcs_issue_compose_request = false,
         };
 
         auto client = S3::ClientFactory::instance().create(

--- a/src/Disks/ObjectStorages/S3/diskSettings.cpp
+++ b/src/Disks/ObjectStorages/S3/diskSettings.cpp
@@ -97,6 +97,7 @@ std::unique_ptr<S3::Client> getClient(
     S3::ClientSettings client_settings{
         .use_virtual_addressing = uri.is_virtual_hosted_style,
         .disable_checksum = local_settings.s3_disable_checksum,
+        .gcs_issue_compose_request = config.getBool("s3.gcs_issue_compose_request", false),
     };
 
     return S3::ClientFactory::instance().create(

--- a/src/Disks/ObjectStorages/S3/diskSettings.cpp
+++ b/src/Disks/ObjectStorages/S3/diskSettings.cpp
@@ -1,4 +1,5 @@
 #include <Disks/ObjectStorages/S3/diskSettings.h>
+#include "IO/S3/Client.h"
 
 #if USE_AWS_S3
 
@@ -93,10 +94,14 @@ std::unique_ptr<S3::Client> getClient(
     HTTPHeaderEntries headers = S3::getHTTPHeaders(config_prefix, config);
     S3::ServerSideEncryptionKMSConfig sse_kms_config = S3::getSSEKMSConfig(config_prefix, config);
 
+    S3::ClientSettings client_settings{
+        .use_virtual_addressing = uri.is_virtual_hosted_style,
+        .disable_checksum = local_settings.s3_disable_checksum,
+    };
+
     return S3::ClientFactory::instance().create(
         client_configuration,
-        uri.is_virtual_hosted_style,
-        local_settings.s3_disable_checksum,
+        client_settings,
         config.getString(config_prefix + ".access_key_id", ""),
         config.getString(config_prefix + ".secret_access_key", ""),
         config.getString(config_prefix + ".server_side_encryption_customer_key_base64", ""),

--- a/src/IO/S3/Client.cpp
+++ b/src/IO/S3/Client.cpp
@@ -413,7 +413,7 @@ Model::CompleteMultipartUploadOutcome Client::CompleteMultipartUpload(CompleteMu
             outcome = Aws::S3::Model::CompleteMultipartUploadOutcome(Aws::S3::Model::CompleteMultipartUploadResult());
     }
 
-    if (outcome.IsSuccess() && provider_type == ProviderType::GCS)
+    if (outcome.IsSuccess() && provider_type == ProviderType::GCS && client_settings.gcs_issue_compose_request)
     {
         /// For GCS we will try to compose object at the end, otherwise we cannot do a native copy
         /// for the object (e.g. for backups)

--- a/src/IO/S3/Client.h
+++ b/src/IO/S3/Client.h
@@ -195,7 +195,6 @@ public:
     Model::DeleteObjectsOutcome DeleteObjects(DeleteObjectsRequest & request) const;
 
     using ComposeObjectOutcome = Aws::Utils::Outcome<Aws::NoResult, Aws::S3::S3Error>;
-    ComposeObjectOutcome ComposeObject(ComposeObjectRequest & request) const;
 
     using Aws::S3::S3Client::EnableRequestProcessing;
     using Aws::S3::S3Client::DisableRequestProcessing;
@@ -235,6 +234,8 @@ private:
     using Aws::S3::S3Client::PutObject;
     using Aws::S3::S3Client::DeleteObject;
     using Aws::S3::S3Client::DeleteObjects;
+
+    ComposeObjectOutcome ComposeObject(ComposeObjectRequest & request) const;
 
     template <typename RequestType, typename RequestFn>
     std::invoke_result_t<RequestFn, RequestType>

--- a/src/IO/S3/Client.h
+++ b/src/IO/S3/Client.h
@@ -97,6 +97,16 @@ struct ClientSettings
     bool use_virtual_addressing;
     /// Disable checksum to avoid extra read of the input stream
     bool disable_checksum;
+    /// Should client send ComposeObject request after upload to GCS.
+    ///
+    /// Previously ComposeObject request was required to make Copy possible,
+    /// but not anymore (see [1]).
+    ///
+    ///   [1]: https://cloud.google.com/storage/docs/release-notes#June_23_2023
+    ///
+    /// Ability to enable it preserved since likely it is required for old
+    /// files.
+    bool gcs_issue_compose_request;
 };
 
 /// Client that improves the client from the AWS SDK

--- a/src/IO/S3/Client.h
+++ b/src/IO/S3/Client.h
@@ -92,6 +92,13 @@ private:
     std::unordered_map<ClientCache *, std::weak_ptr<ClientCache>> client_caches;
 };
 
+struct ClientSettings
+{
+    bool use_virtual_addressing;
+    /// Disable checksum to avoid extra read of the input stream
+    bool disable_checksum;
+};
+
 /// Client that improves the client from the AWS SDK
 /// - inject region and URI into requests so they are rerouted to the correct destination if needed
 /// - automatically detect endpoint and regions for each bucket and cache them
@@ -116,8 +123,7 @@ public:
             const std::shared_ptr<Aws::Auth::AWSCredentialsProvider> & credentials_provider,
             const PocoHTTPClientConfiguration & client_configuration,
             Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy sign_payloads,
-            bool use_virtual_addressing,
-            bool disable_checksum);
+            const ClientSettings & client_settings);
 
     std::unique_ptr<Client> clone() const;
 
@@ -211,8 +217,7 @@ private:
            const std::shared_ptr<Aws::Auth::AWSCredentialsProvider> & credentials_provider_,
            const PocoHTTPClientConfiguration & client_configuration,
            Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy sign_payloads,
-           bool use_virtual_addressing,
-           bool disable_checksum_);
+           const ClientSettings & client_settings_);
 
     Client(
         const Client & other, const PocoHTTPClientConfiguration & client_configuration);
@@ -259,8 +264,7 @@ private:
     std::shared_ptr<Aws::Auth::AWSCredentialsProvider> credentials_provider;
     PocoHTTPClientConfiguration client_configuration;
     Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy sign_payloads;
-    bool use_virtual_addressing;
-    bool disable_checksum;
+    ClientSettings client_settings;
 
     std::string explicit_region;
     mutable bool detect_region = true;
@@ -290,8 +294,7 @@ public:
 
     std::unique_ptr<S3::Client> create(
         const PocoHTTPClientConfiguration & cfg,
-        bool is_virtual_hosted_style,
-        bool disable_checksum,
+        ClientSettings client_settings,
         const String & access_key_id,
         const String & secret_access_key,
         const String & server_side_encryption_customer_key_base64,

--- a/src/IO/S3/tests/gtest_aws_s3_client.cpp
+++ b/src/IO/S3/tests/gtest_aws_s3_client.cpp
@@ -143,6 +143,7 @@ void testServerSideEncryption(
     DB::S3::ClientSettings client_settings{
         .use_virtual_addressing = uri.is_virtual_hosted_style,
         .disable_checksum = disable_checksum,
+        .gcs_issue_compose_request = false,
     };
 
     std::shared_ptr<DB::S3::Client> client = DB::S3::ClientFactory::instance().create(

--- a/src/IO/S3/tests/gtest_aws_s3_client.cpp
+++ b/src/IO/S3/tests/gtest_aws_s3_client.cpp
@@ -140,10 +140,14 @@ void testServerSideEncryption(
     bool use_environment_credentials = false;
     bool use_insecure_imds_request = false;
 
+    DB::S3::ClientSettings client_settings{
+        .use_virtual_addressing = uri.is_virtual_hosted_style,
+        .disable_checksum = disable_checksum,
+    };
+
     std::shared_ptr<DB::S3::Client> client = DB::S3::ClientFactory::instance().create(
         client_configuration,
-        uri.is_virtual_hosted_style,
-        disable_checksum,
+        client_settings,
         access_key_id,
         secret_access_key,
         server_side_encryption_customer_key_base64,

--- a/src/IO/tests/gtest_writebuffer_s3.cpp
+++ b/src/IO/tests/gtest_writebuffer_s3.cpp
@@ -213,6 +213,7 @@ struct Client : DB::S3::Client
                DB::S3::ClientSettings{
                    .use_virtual_addressing = true,
                    .disable_checksum= false,
+                   .gcs_issue_compose_request = false,
                })
         , store(mock_s3_store)
     {}

--- a/src/IO/tests/gtest_writebuffer_s3.cpp
+++ b/src/IO/tests/gtest_writebuffer_s3.cpp
@@ -210,10 +210,12 @@ struct Client : DB::S3::Client
                std::make_shared<Aws::Auth::SimpleAWSCredentialsProvider>("", ""),
                GetClientConfiguration(),
                Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy::Never,
-               /* use_virtual_addressing = */ true,
-               /* disable_checksum_= */ false)
+               DB::S3::ClientSettings{
+                   .use_virtual_addressing = true,
+                   .disable_checksum= false,
+               })
         , store(mock_s3_store)
-    { }
+    {}
 
     static std::shared_ptr<Client> CreateClient(String bucket = "mock-s3-bucket")
     {

--- a/src/Storages/StorageS3.cpp
+++ b/src/Storages/StorageS3.cpp
@@ -1464,6 +1464,7 @@ void StorageS3::Configuration::connect(ContextPtr context)
     S3::ClientSettings client_settings{
         .use_virtual_addressing = url.is_virtual_hosted_style,
         .disable_checksum = local_settings.s3_disable_checksum,
+        .gcs_issue_compose_request = context->getConfigRef().getBool("s3.gcs_issue_compose_request", false),
     };
 
     auto credentials = Aws::Auth::AWSCredentials(auth_settings.access_key_id, auth_settings.secret_access_key, auth_settings.session_token);

--- a/src/Storages/StorageS3.cpp
+++ b/src/Storages/StorageS3.cpp
@@ -1461,11 +1461,15 @@ void StorageS3::Configuration::connect(ContextPtr context)
 
     client_configuration.requestTimeoutMs = request_settings.request_timeout_ms;
 
+    S3::ClientSettings client_settings{
+        .use_virtual_addressing = url.is_virtual_hosted_style,
+        .disable_checksum = local_settings.s3_disable_checksum,
+    };
+
     auto credentials = Aws::Auth::AWSCredentials(auth_settings.access_key_id, auth_settings.secret_access_key, auth_settings.session_token);
     client = S3::ClientFactory::instance().create(
         client_configuration,
-        url.is_virtual_hosted_style,
-        local_settings.s3_disable_checksum,
+        client_settings,
         credentials.GetAWSAccessKeyId(),
         credentials.GetAWSSecretKey(),
         auth_settings.server_side_encryption_customer_key_base64,


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Avoid sending ComposeObject requests after upload to GCS

This should not be required anymore, but leave it as an option, since
likely this is required for old files.

ComposeObject had been added in https://github.com/ClickHouse/ClickHouse/pull/49693 (cc @antonio2368 )