### PR TITLE
Improve aliases for clickhouse binary

### DIFF
--- a/programs/bash-completion/completions/ch
+++ b/programs/bash-completion/completions/ch
@@ -1,0 +1,1 @@
+clickhouse

--- a/programs/bash-completion/completions/chc
+++ b/programs/bash-completion/completions/chc
@@ -1,0 +1,2 @@
+[[ -v $_CLICKHOUSE_COMPLETION_LOADED ]] || source "$(dirname "${BASH_SOURCE[0]}")/clickhouse-bootstrap"
+_complete_clickhouse_generic chc

--- a/programs/bash-completion/completions/chl
+++ b/programs/bash-completion/completions/chl
@@ -1,0 +1,2 @@
+[[ -v $_CLICKHOUSE_COMPLETION_LOADED ]] || source "$(dirname "${BASH_SOURCE[0]}")/clickhouse-bootstrap"
+_complete_clickhouse_generic chl

--- a/programs/bash-completion/completions/clickhouse
+++ b/programs/bash-completion/completions/clickhouse
@@ -31,3 +31,4 @@ function _complete_for_clickhouse_entrypoint_bin()
 }
 
 _complete_clickhouse_generic clickhouse _complete_for_clickhouse_entrypoint_bin
+_complete_clickhouse_generic ch _complete_for_clickhouse_entrypoint_bin

--- a/programs/main.cpp
+++ b/programs/main.cpp
@@ -158,7 +158,6 @@ std::pair<std::string_view, MainFunc> clickhouse_applications[] =
 std::pair<std::string_view, std::string_view> clickhouse_short_names[] =
 {
 #if ENABLE_CLICKHOUSE_LOCAL
-    {"ch", "local"},
     {"chl", "local"},
 #endif
 #if ENABLE_CLICKHOUSE_CLIENT

--- a/programs/main.cpp
+++ b/programs/main.cpp
@@ -501,6 +501,17 @@ int main(int argc_, char ** argv_)
         }
     }
 
+    /// Interpret binary without argument or with arguments starts with dash
+    /// ('-') as clickhouse-local for better usability:
+    ///
+    ///     clickhouse # dumps help
+    ///     clickhouse -q 'select 1' # use local
+    ///     clickhouse # spawn local
+    ///     clickhouse local # spawn local
+    ///
+    if (main_func == printHelp && !argv.empty() && (argv.size() == 1 || argv[1][0] == '-'))
+        main_func = mainEntryClickHouseLocal;
+
     return main_func(static_cast<int>(argv.size()), argv.data());
 }
 #endif


### PR DESCRIPTION
### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Improve aliases for clickhouse binary (now `ch`/`clickhouse` is `clickhouse-local` or `clickhouse` depends on the arguments) and add bash completion for new aliases.

Follow-up for: https://github.com/ClickHouse/ClickHouse/pull/56634 (cc @alexey-milovidov )
_P.S. changelog entry copied from https://github.com/ClickHouse/ClickHouse/pull/56634_