### PR TITLE
Keep exception format string in retries ctl

### DIFF
--- a/src/Backups/BackupCoordinationStageSync.cpp
+++ b/src/Backups/BackupCoordinationStageSync.cpp
@@ -154,7 +154,7 @@ BackupCoordinationStageSync::State BackupCoordinationStageSync::readCurrentState
                 /// If the "alive" node doesn't exist then we don't have connection to the corresponding host.
                 /// This node is ephemeral so probably it will be recreated soon. We use zookeeper retries to wait.
                 /// In worst case when we won't manage to see the alive node for a long time we will just abort the backup.
-                const auto * const suffix suffix = retries_ctl.isLastRetry() ? "" : ", will retry";
+                const auto * const suffix = retries_ctl.isLastRetry() ? "" : ", will retry";
                 if (started)
                     retries_ctl.setUserError(Exception(ErrorCodes::FAILED_TO_SYNC_BACKUP_OR_RESTORE,
                                                        "Lost connection to host {}{}", host, suffix));

--- a/src/Backups/BackupCoordinationStageSync.cpp
+++ b/src/Backups/BackupCoordinationStageSync.cpp
@@ -154,7 +154,7 @@ BackupCoordinationStageSync::State BackupCoordinationStageSync::readCurrentState
                 /// If the "alive" node doesn't exist then we don't have connection to the corresponding host.
                 /// This node is ephemeral so probably it will be recreated soon. We use zookeeper retries to wait.
                 /// In worst case when we won't manage to see the alive node for a long time we will just abort the backup.
-                const auto suffix = retries_ctl.isLastRetry() ? "" : ", will retry";
+                const auto * const suffix suffix = retries_ctl.isLastRetry() ? "" : ", will retry";
                 if (started)
                     retries_ctl.setUserError(Exception(ErrorCodes::FAILED_TO_SYNC_BACKUP_OR_RESTORE,
                                                        "Lost connection to host {}{}", host, suffix));

--- a/src/Backups/BackupCoordinationStageSync.cpp
+++ b/src/Backups/BackupCoordinationStageSync.cpp
@@ -154,14 +154,14 @@ BackupCoordinationStageSync::State BackupCoordinationStageSync::readCurrentState
                 /// If the "alive" node doesn't exist then we don't have connection to the corresponding host.
                 /// This node is ephemeral so probably it will be recreated soon. We use zookeeper retries to wait.
                 /// In worst case when we won't manage to see the alive node for a long time we will just abort the backup.
-                String message;
+                const auto suffix = retries_ctl.isLastRetry() ? "" : ", will retry";
                 if (started)
-                    message = fmt::format("Lost connection to host {}", host);
+                    retries_ctl.setUserError(Exception(ErrorCodes::FAILED_TO_SYNC_BACKUP_OR_RESTORE,
+                                                       "Lost connection to host {}{}", host, suffix));
                 else
-                    message = fmt::format("No connection to host {} yet", host);
-                if (!retries_ctl.isLastRetry())
-                    message += ", will retry";
-                retries_ctl.setUserError(ErrorCodes::FAILED_TO_SYNC_BACKUP_OR_RESTORE, message);
+                    retries_ctl.setUserError(Exception(ErrorCodes::FAILED_TO_SYNC_BACKUP_OR_RESTORE,
+                                                       "No connection to host {} yet{}", host, suffix));
+
                 state.disconnected_host = host;
                 return state;
             }

--- a/src/Storages/MergeTree/ReplicatedMergeTreeSink.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeSink.cpp
@@ -776,7 +776,7 @@ std::pair<std::vector<String>, bool> ReplicatedMergeTreeSinkImpl<async_insert>::
             if (!writing_existing_part)
             {
                 retries_ctl.setUserError(
-                    ErrorCodes::TABLE_IS_READ_ONLY, "Table is in readonly mode: replica_path={}", storage.replica_path);
+                    Exception(ErrorCodes::TABLE_IS_READ_ONLY, "Table is in readonly mode: replica_path={}", storage.replica_path));
                 return CommitRetryContext::LOCK_AND_COMMIT;
             }
         }
@@ -1075,10 +1075,10 @@ std::pair<std::vector<String>, bool> ReplicatedMergeTreeSinkImpl<async_insert>::
             new_retry_controller.actionAfterLastFailedRetry([&]
             {
                 /// We do not know whether or not data has been inserted in other replicas
-                new_retry_controller.setUserError(
+                new_retry_controller.setUserError(Exception(
                     ErrorCodes::UNKNOWN_STATUS_OF_INSERT,
                     "Unknown quorum status. The data was inserted in the local replica but we could not verify quorum. Reason: {}",
-                    new_retry_controller.getLastKeeperErrorMessage());
+                    new_retry_controller.getLastKeeperErrorMessage()));
             });
 
             new_retry_controller.retryLoop([&]()

--- a/src/Storages/MergeTree/ZooKeeperRetries.h
+++ b/src/Storages/MergeTree/ZooKeeperRetries.h
@@ -112,7 +112,7 @@ public:
         return false;
     }
 
-    void setUserError(std::exception_ptr exception, int code, std::string message)
+    void setUserError(std::exception_ptr exception, int code, const std::string & message)
     {
         if (logger)
             LOG_TRACE(logger, "ZooKeeperRetriesControl: {}: setUserError: error={} message={}", name, code, message);
@@ -127,21 +127,9 @@ public:
         keeper_error = KeeperError{};
     }
 
-    template <typename... Args>
-    void setUserError(std::exception_ptr exception, int code, fmt::format_string<Args...> fmt, Args &&... args)
+    void setUserError(const Exception & exception)
     {
-        setUserError(exception, code, fmt::format(fmt, std::forward<Args>(args)...));
-    }
-
-    void setUserError(int code, std::string message)
-    {
-        setUserError(std::make_exception_ptr(Exception::createDeprecated(message, code)), code, message);
-    }
-
-    template <typename... Args>
-    void setUserError(int code, fmt::format_string<Args...> fmt, Args &&... args)
-    {
-        setUserError(code, fmt::format(fmt, std::forward<Args>(args)...));
+        setUserError(std::make_exception_ptr(exception), exception.code(), exception.message());
     }
 
     void setKeeperError(std::exception_ptr exception, Coordination::Error code, std::string message)
@@ -157,23 +145,6 @@ public:
         keeper_error.message = std::move(message);
         keeper_error.exception = exception;
         user_error = UserError{};
-    }
-
-    template <typename... Args>
-    void setKeeperError(std::exception_ptr exception, Coordination::Error code, fmt::format_string<Args...> fmt, Args &&... args)
-    {
-        setKeeperError(exception, code, fmt::format(fmt, std::forward<Args>(args)...));
-    }
-
-    void setKeeperError(Coordination::Error code, std::string message)
-    {
-        setKeeperError(std::make_exception_ptr(zkutil::KeeperException::createDeprecated(message, code)), code, message);
-    }
-
-    template <typename... Args>
-    void setKeeperError(Coordination::Error code, fmt::format_string<Args...> fmt, Args &&... args)
-    {
-        setKeeperError(code, fmt::format(fmt, std::forward<Args>(args)...));
     }
 
     void stopRetries() { stop_retries = true; }


### PR DESCRIPTION

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Fixes `00002_log_and_exception_messages_formatting`:
```
2023-12-28 20:07:35 00002_log_and_exception_messages_formatting:                            [ FAIL ] 4.16 sec. - having exception in stdout: 
2023-12-28 20:07:35 runtime messages	0.001	[]
2023-12-28 20:07:35 runtime exceptions	0.05	[]
2023-12-28 20:07:35 unknown runtime exceptions	0.010494310668654354	[('Code: 242. DB::Exception: Table is in readonly mode: replica_path=/clickhouse/tables/00993_system_parts_race_condition_drop_zookeeper_test_czb2k8r2/alter_table/replicas/r_8. (TABLE_IS_READ_ONLY) (version 23.13.1.24) (from [::1]:38956) (comment: 00993_system_parts_race_condition_drop_zookeeper.sh) (in query: INSERT INTO alter_table_8 SELECT rand(1), rand(2), 1 / rand(3), toString(rand(4)), [rand(5), rand(6)], rand(7) % 2 ? NULL : generateUUIDv4(), (rand(8), rand(9)) FROM numbers(100000)), Stack trace (when copying this message, always include the lines below):\n\n0. ./build_docker/./src/Common/Exception.cpp:96: DB::Exception::Exception(DB::Exception::MessageMasked&&, int, bool) @ 0x000000000bae0748 in /usr/lib/debug/usr/bin/clickhouse.debug\n1. ./contrib/llvm-project/libcxx/include/string:1499: DB::ZooKeeperRetriesControl::setUserError(int, String) @ 0x000000000f03f004 in /usr/lib/debug/usr/bin/clickhouse.debug\n2. ./contrib/llvm-project/libcxx/include/string:1499: void DB::ZooKeeperRetriesControl::setUserError<String const&>(int, fmt::v8::basic_format_string<char, fmt::v8::type_identity<String const&>::type>, String const&) @ 0x0000000010d07760 in /usr/lib/debug/usr/bin/clickhouse.debug\n3. ./build_docker/./src/Storages/MergeTree/ReplicatedMergeTreeSink.cpp:0: DB::ReplicatedMergeTreeSinkImpl<false>::commitPart(std::shared_ptr<DB::ZooKeeperWithFaultInjection> const&, std::shared_ptr<DB::IMergeTreeDataPart>&, String const&, unsigned long, bool)::\'lambda1\'()::operator()() const @ 0x0000000010d090a0 in /usr/lib/debug/usr/bin/clickhouse.debug\n4. ./build_docker/./src/Storages/MergeTree/ReplicatedMergeTreeSink.cpp:0: DB::ReplicatedMergeTreeSinkImpl<false>::commitPart(std::shared_ptr<DB::ZooKeeperWithFaultInjection> const&, std::shared_ptr<DB::IMergeTreeDataPart>&, String const&, unsigned long, bool) @ 0x0000000010cff5bc in /usr/lib/debug/usr/bin/clickhouse.debug\n5. ./contrib/llvm-project/libcxx/include/vector:434: DB::ReplicatedMergeTreeSinkImpl<false>::finishDelayedChunk(std::shared_ptr<DB::ZooKeeperWithFaultInjection> const&) @ 0x0000000010cfe6d8 in /usr/lib/debug/usr/bin/clickhouse.debug\n6. ./build_docker/./src/Storages/MergeTree/ReplicatedMergeTreeSink.cpp:0: DB::ReplicatedMergeTreeSinkImpl<false>::consume(DB::Chunk) @ 0x0000000010cfba8c in /usr/lib/debug/usr/bin/clickhouse.debug\n7. ./contrib/llvm-project/libcxx/include/__memory/shared_ptr.h:701: DB::SinkToStorage::onConsume(DB::Chunk) @ 0x00000000112379ac in /usr/lib/debug/usr/bin/clickhouse.debug\n8. ./contrib/llvm-project/libcxx/include/__memory/shared_ptr.h:701: void std::__function::__policy_invoker<void ()>::__call_impl<std::__function::__default_alloc_func<DB::ExceptionKeepingTransform::work()::$_1, void ()>>(std::__function::__policy_storage const*) @ 0x000000001118a42c in /usr/lib/debug/usr/bin/clickhouse.debug\n9. ./build_docker/./src/Processors/Transforms/ExceptionKeepingTransform.cpp:121: DB::runStep(std::function<void ()>, DB::ThreadStatus*, std::atomic<unsigned long>*) @ 0x000000001118a124 in /usr/lib/debug/usr/bin/clickhouse.debug\n10. ./contrib/llvm-project/libcxx/include/__functional/function.h:818: ? @ 0x0000000011189888 in /usr/lib/debug/usr/bin/clickhouse.debug\n11. ./build_docker/./src/Processors/Executors/ExecutionThreadContext.cpp:52: DB::ExecutionThreadContext::executeTask() @ 0x0000000010f49b2c in /usr/lib/debug/usr/bin/clickhouse.debug\n12. ./build_docker/./src/Processors/Executors/PipelineExecutor.cpp:273: DB::PipelineExecutor::executeStepImpl(unsigned long, std::atomic<bool>*) @ 0x0000000010f41c94 in /usr/lib/debug/usr/bin/clickhouse.debug\n13. ./contrib/llvm-project/libcxx/include/__memory/shared_ptr.h:701: DB::PipelineExecutor::execute(unsigned long, bool) @ 0x0000000010f412a0 in /usr/lib/debug/usr/bin/clickhouse.debug\n14. ./build_docker/./src/Processors/Executors/CompletedPipelineExecutor.cpp:57: void std::__function::__policy_invoker<void 
...
```
