### PR TITLE
Support for Enum in function `transform`

### DIFF
--- a/src/Functions/transform.cpp
+++ b/src/Functions/transform.cpp
@@ -91,19 +91,6 @@ namespace
 
             const auto type_arr_from_nested = type_arr_from->getNestedType();
 
-            auto src = tryGetLeastSupertype(DataTypes{type_x, type_arr_from_nested});
-            if (!src
-                /// Compatibility with previous versions, that allowed even UInt64 with Int64,
-                /// regardless of ambiguous conversions.
-                && !isNativeNumber(type_x) && !isNativeNumber(type_arr_from_nested))
-            {
-                throw Exception(
-                    ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT,
-                    "First argument and elements of array "
-                    "of the second argument of function {} must have compatible types",
-                    getName());
-            }
-
             const DataTypeArray * type_arr_to = checkAndGetDataType<DataTypeArray>(arguments[2].get());
 
             if (!type_arr_to)
@@ -766,15 +753,18 @@ namespace
                 }
             }
 
+            WhichDataType which(from_type);
+
             /// Note: Doesn't check the duplicates in the `from` array.
             /// Field may be of Float type, but for the purpose of bitwise equality we can treat them as UInt64
-            if (WhichDataType which(from_type); isNativeNumber(which) || which.isDecimal32() || which.isDecimal64())
+            if (isNativeNumber(which) || which.isDecimal32() || which.isDecimal64() || which.isEnum())
             {
                 cache.table_num_to_idx = std::make_unique<Cache::NumToIdx>();
                 auto & table = *cache.table_num_to_idx;
                 for (size_t i = 0; i < size; ++i)
                 {
-                    if (applyVisitor(FieldVisitorAccurateEquals(), (*cache.from_column)[i], (*from_column_uncasted)[i]))
+                    if (which.isEnum() /// The correctness of strings are already checked by casting them to the Enum type.
+                        || applyVisitor(FieldVisitorAccurateEquals(), (*cache.from_column)[i], (*from_column_uncasted)[i]))
                     {
                         UInt64 key = 0;
                         auto * dst = reinterpret_cast<char *>(&key);

--- a/tests/queries/0_stateless/02958_transform_enum.reference
+++ b/tests/queries/0_stateless/02958_transform_enum.reference
@@ -1,2 +1,4 @@
 Hello	123
 world	456
+Hello	test
+world	best

--- a/tests/queries/0_stateless/02958_transform_enum.reference
+++ b/tests/queries/0_stateless/02958_transform_enum.reference
@@ -1,0 +1,2 @@
+Hello	123
+world	456

--- a/tests/queries/0_stateless/02958_transform_enum.sql
+++ b/tests/queries/0_stateless/02958_transform_enum.sql
@@ -1,0 +1,2 @@
+WITH arrayJoin(['Hello', 'world'])::Enum('Hello', 'world') AS x SELECT x, transform(x, ['Hello', 'world'], [123, 456], 0);
+WITH arrayJoin(['Hello', 'world'])::Enum('Hello', 'world') AS x SELECT x, transform(x, ['Hello', 'world', 'goodbye'], [123, 456], 0); -- { serverError UNKNOWN_ELEMENT_OF_ENUM }

--- a/tests/queries/0_stateless/02958_transform_enum.sql
+++ b/tests/queries/0_stateless/02958_transform_enum.sql
@@ -1,2 +1,3 @@
 WITH arrayJoin(['Hello', 'world'])::Enum('Hello', 'world') AS x SELECT x, transform(x, ['Hello', 'world'], [123, 456], 0);
 WITH arrayJoin(['Hello', 'world'])::Enum('Hello', 'world') AS x SELECT x, transform(x, ['Hello', 'world', 'goodbye'], [123, 456], 0); -- { serverError UNKNOWN_ELEMENT_OF_ENUM }
+WITH arrayJoin(['Hello', 'world'])::Enum('Hello', 'world') AS x SELECT x, transform(x, ['Hello', 'world'], ['test', 'best']::Array(Enum('test' = 123, 'best' = 456, '' = 0)), ''::Enum('test' = 123, 'best' = 456, '' = 0)) AS y;


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Support for `Enum` data types in function `transform`. This closes #58241