### PR TITLE
independent registration of database engines

### DIFF
--- a/programs/copier/ClusterCopierApp.cpp
+++ b/programs/copier/ClusterCopierApp.cpp
@@ -2,6 +2,7 @@
 #include <Common/ZooKeeper/ZooKeeper.h>
 #include <Common/StatusFile.h>
 #include <Common/TerminalSize.h>
+#include <Databases/registerDatabases.h>
 #include <IO/ConnectionTimeouts.h>
 #include <Formats/registerFormats.h>
 #include <Common/scope_guard_safe.h>
@@ -159,6 +160,7 @@ void ClusterCopierApp::mainImpl()
     registerFunctions();
     registerAggregateFunctions();
     registerTableFunctions();
+    registerDatabases();
     registerStorages();
     registerDictionaries();
     registerDisks(/* global_skip_access_check= */ true);

--- a/programs/format/Format.cpp
+++ b/programs/format/Format.cpp
@@ -17,6 +17,7 @@
 
 #include <Interpreters/Context.h>
 #include <Functions/FunctionFactory.h>
+#include <Databases/registerDatabases.h>
 #include <Functions/registerFunctions.h>
 #include <AggregateFunctions/AggregateFunctionFactory.h>
 #include <AggregateFunctions/registerAggregateFunctions.h>
@@ -130,6 +131,7 @@ int mainEntryClickHouseFormat(int argc, char ** argv)
             registerFunctions();
             registerAggregateFunctions();
             registerTableFunctions();
+            registerDatabases();
             registerStorages();
             registerFormats();
 

--- a/programs/local/LocalServer.cpp
+++ b/programs/local/LocalServer.cpp
@@ -10,18 +10,17 @@
 #include <Poco/Logger.h>
 #include <Poco/NullChannel.h>
 #include <Poco/SimpleFileChannel.h>
+#include <Databases/registerDatabases.h>
 #include <Databases/DatabaseFilesystem.h>
 #include <Databases/DatabaseMemory.h>
 #include <Databases/DatabasesOverlay.h>
 #include <Storages/System/attachSystemTables.h>
 #include <Storages/System/attachInformationSchemaTables.h>
 #include <Interpreters/DatabaseCatalog.h>
-#include <Interpreters/JIT/CompiledExpressionCache.h>
 #include <Interpreters/ProcessList.h>
 #include <Interpreters/loadMetadata.h>
 #include <base/getFQDNOrHostName.h>
 #include <Common/scope_guard_safe.h>
-#include <Interpreters/Session.h>
 #include <Access/AccessControl.h>
 #include <Common/PoolId.h>
 #include <Common/Exception.h>
@@ -32,11 +31,9 @@
 #include <Common/quoteString.h>
 #include <Common/randomSeed.h>
 #include <Common/ThreadPool.h>
-#include <Loggers/Loggers.h>
 #include <Loggers/OwnFormattingChannel.h>
 #include <Loggers/OwnPatternFormatter.h>
 #include <IO/ReadBufferFromFile.h>
-#include <IO/ReadBufferFromString.h>
 #include <IO/WriteBufferFromFileDescriptor.h>
 #include <IO/UseSSL.h>
 #include <IO/SharedThreadPools.h>
@@ -489,6 +486,7 @@ try
     registerFunctions();
     registerAggregateFunctions();
     registerTableFunctions();
+    registerDatabases();
     registerStorages();
     registerDictionaries();
     registerDisks(/* global_skip_access_check= */ true);

--- a/programs/local/LocalServer.cpp
+++ b/programs/local/LocalServer.cpp
@@ -17,10 +17,12 @@
 #include <Storages/System/attachSystemTables.h>
 #include <Storages/System/attachInformationSchemaTables.h>
 #include <Interpreters/DatabaseCatalog.h>
+#include <Interpreters/JIT/CompiledExpressionCache.h>
 #include <Interpreters/ProcessList.h>
 #include <Interpreters/loadMetadata.h>
 #include <base/getFQDNOrHostName.h>
 #include <Common/scope_guard_safe.h>
+#include <Interpreters/Session.h>
 #include <Access/AccessControl.h>
 #include <Common/PoolId.h>
 #include <Common/Exception.h>
@@ -31,9 +33,11 @@
 #include <Common/quoteString.h>
 #include <Common/randomSeed.h>
 #include <Common/ThreadPool.h>
+#include <Loggers/Loggers.h>
 #include <Loggers/OwnFormattingChannel.h>
 #include <Loggers/OwnPatternFormatter.h>
 #include <IO/ReadBufferFromFile.h>
+#include <IO/ReadBufferFromString.h>
 #include <IO/WriteBufferFromFileDescriptor.h>
 #include <IO/UseSSL.h>
 #include <IO/SharedThreadPools.h>

--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -72,6 +72,7 @@
 #include <TableFunctions/registerTableFunctions.h>
 #include <Formats/registerFormats.h>
 #include <Storages/registerStorages.h>
+#include <Databases/registerDatabases.h>
 #include <Dictionaries/registerDictionaries.h>
 #include <Disks/registerDisks.h>
 #include <IO/Resource/registerSchedulerNodes.h>
@@ -648,6 +649,7 @@ try
     registerFunctions();
     registerAggregateFunctions();
     registerTableFunctions();
+    registerDatabases();
     registerStorages();
     registerDictionaries();
     registerDisks(/* global_skip_access_check= */ false);

--- a/src/Databases/DatabaseAtomic.cpp
+++ b/src/Databases/DatabaseAtomic.cpp
@@ -1,6 +1,7 @@
 #include <Databases/DatabaseAtomic.h>
 #include <Databases/DatabaseOnDisk.h>
 #include <Databases/DatabaseReplicated.h>
+#include <Databases/DatabaseFactory.h>
 #include <IO/ReadHelpers.h>
 #include <IO/WriteHelpers.h>
 #include <IO/ReadBufferFromFile.h>
@@ -622,4 +623,16 @@ void DatabaseAtomic::checkDetachedTableNotInUse(const UUID & uuid)
     assertDetachedTableNotInUse(uuid);
 }
 
+void registerDatabaseAtomic(DatabaseFactory & factory)
+{
+    auto create_fn = [](const DatabaseFactory::Arguments & args)
+    {
+        return make_shared<DatabaseAtomic>(
+            args.database_name,
+            args.metadata_path,
+            args.uuid,
+            args.context);
+    };
+    factory.registerDatabase("Atomic", create_fn);
+}
 }

--- a/src/Databases/DatabaseDictionary.cpp
+++ b/src/Databases/DatabaseDictionary.cpp
@@ -1,4 +1,5 @@
 #include <Databases/DatabaseDictionary.h>
+#include <Databases/DatabaseFactory.h>
 #include <Interpreters/Context.h>
 #include <Interpreters/ExternalDictionariesLoader.h>
 #include <Dictionaries/DictionaryStructure.h>
@@ -140,4 +141,14 @@ void DatabaseDictionary::shutdown()
 {
 }
 
+void registerDatabaseDictionary(DatabaseFactory & factory)
+{
+    auto create_fn = [](const DatabaseFactory::Arguments & args)
+    {
+        return make_shared<DatabaseDictionary>(
+            args.database_name,
+            args.context);
+    };
+    factory.registerDatabase("Dictionary", create_fn);
+}
 }

--- a/src/Databases/DatabaseFactory.cpp
+++ b/src/Databases/DatabaseFactory.cpp
@@ -121,8 +121,8 @@ DatabasePtr DatabaseFactory::get(const ASTCreateQuery & create, const String & m
 
 void DatabaseFactory::registerDatabase(const std::string & name, CreatorFn creator_fn)
 {
-    if (!databases.emplace(name, Creator{std::move(creator_fn)}).second)
-        throw Exception(ErrorCodes::LOGICAL_ERROR, "DatabaseFactory: the database name '{}' is not unique", name);
+    if (!database_engines.emplace(name, Creator{std::move(creator_fn)}).second)
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "DatabaseFactory: the database engine name '{}' is not unique", name);
 }
 
 DatabaseFactory & DatabaseFactory::instance()
@@ -142,372 +142,60 @@ static inline ValueType safeGetLiteralValue(const ASTPtr &ast, const String &eng
 
 DatabasePtr DatabaseFactory::getImpl(const ASTCreateQuery & create, const String & metadata_path, ContextPtr context)
 {
-    auto * engine_define = create.storage;
+    auto * storage = create.storage;
     const String & database_name = create.getDatabase();
-    const String & engine_name = engine_define->engine->name;
+    const String & engine_name = storage->engine->name;
     const UUID & uuid = create.uuid;
-
-    static const std::unordered_set<std::string_view> database_engines{"Ordinary", "Atomic", "Memory",
-        "Dictionary", "Lazy", "Replicated", "MySQL", "MaterializeMySQL", "MaterializedMySQL",
-        "PostgreSQL", "MaterializedPostgreSQL", "SQLite", "Filesystem", "S3", "HDFS"};
-
-    if (!database_engines.contains(engine_name))
-        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Database engine name `{}` does not exist", engine_name);
-
-    static const std::unordered_set<std::string_view> engines_with_arguments{"MySQL", "MaterializeMySQL", "MaterializedMySQL",
-        "Lazy", "Replicated", "PostgreSQL", "MaterializedPostgreSQL", "SQLite", "Filesystem", "S3", "HDFS"};
-
-    static const std::unordered_set<std::string_view> engines_with_table_overrides{"MaterializeMySQL", "MaterializedMySQL", "MaterializedPostgreSQL"};
-    bool engine_may_have_arguments = engines_with_arguments.contains(engine_name);
-
-    if (engine_define->engine->arguments && !engine_may_have_arguments)
-        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Database engine `{}` cannot have arguments", engine_name);
-
-    bool has_unexpected_element = engine_define->engine->parameters || engine_define->partition_by ||
-                                  engine_define->primary_key || engine_define->order_by ||
-                                  engine_define->sample_by;
-    bool may_have_settings = endsWith(engine_name, "MySQL") || engine_name == "Replicated" || engine_name == "MaterializedPostgreSQL";
-
-    if (has_unexpected_element || (!may_have_settings && engine_define->settings))
-        throw Exception(ErrorCodes::UNKNOWN_ELEMENT_IN_AST,
-                        "Database engine `{}` cannot have parameters, primary_key, order_by, sample_by, settings", engine_name);
-
-    if (create.table_overrides && !engines_with_table_overrides.contains(engine_name))
-        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Database engine `{}` cannot have table overrides", engine_name);
-
-    if (engine_name == "Ordinary")
-    {
-        if (!create.attach && !context->getSettingsRef().allow_deprecated_database_ordinary)
-            throw Exception(ErrorCodes::UNKNOWN_DATABASE_ENGINE,
-                            "Ordinary database engine is deprecated (see also allow_deprecated_database_ordinary setting)");
-
-        return std::make_shared<DatabaseOrdinary>(database_name, metadata_path, context);
-    }
-
-    if (engine_name == "Atomic")
-        return std::make_shared<DatabaseAtomic>(database_name, metadata_path, uuid, context);
-    else if (engine_name == "Memory")
-        return std::make_shared<DatabaseMemory>(database_name, context);
-    else if (engine_name == "Dictionary")
-        return std::make_shared<DatabaseDictionary>(database_name, context);
-
-#if USE_MYSQL
-
-    else if (engine_name == "MySQL" || engine_name == "MaterializeMySQL" || engine_name == "MaterializedMySQL")
-    {
-        const ASTFunction * engine = engine_define->engine;
-        if (!engine->arguments)
-            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Engine `{}` must have arguments", engine_name);
-
-        StorageMySQL::Configuration configuration;
-        ASTs & arguments = engine->arguments->children;
-        auto mysql_settings = std::make_unique<MySQLSettings>();
-
-        if (auto named_collection = tryGetNamedCollectionWithOverrides(arguments, context))
-        {
-            configuration = StorageMySQL::processNamedCollectionResult(*named_collection, *mysql_settings, context, false);
-        }
-        else
-        {
-            if (arguments.size() != 4)
-                throw Exception(ErrorCodes::BAD_ARGUMENTS,
-                    "MySQL database require mysql_hostname, mysql_database_name, mysql_username, mysql_password arguments.");
-
-
-            arguments[1] = evaluateConstantExpressionOrIdentifierAsLiteral(arguments[1], context);
-            const auto & host_port = safeGetLiteralValue<String>(arguments[0], engine_name);
-
-            if (engine_name == "MySQL")
-            {
-                size_t max_addresses = context->getSettingsRef().glob_expansion_max_elements;
-                configuration.addresses = parseRemoteDescriptionForExternalDatabase(host_port, max_addresses, 3306);
-            }
-            else
-            {
-                const auto & [remote_host, remote_port] = parseAddress(host_port, 3306);
-                configuration.host = remote_host;
-                configuration.port = remote_port;
-            }
-
-            configuration.database = safeGetLiteralValue<String>(arguments[1], engine_name);
-            configuration.username = safeGetLiteralValue<String>(arguments[2], engine_name);
-            configuration.password = safeGetLiteralValue<String>(arguments[3], engine_name);
-        }
-
-        try
-        {
-            if (engine_name == "MySQL")
-            {
-                mysql_settings->loadFromQueryContext(context, *engine_define);
-                if (engine_define->settings)
-                    mysql_settings->loadFromQuery(*engine_define);
-
-                auto mysql_pool = createMySQLPoolWithFailover(configuration, *mysql_settings);
-
-                return std::make_shared<DatabaseMySQL>(
-                    context, database_name, metadata_path, engine_define, configuration.database,
-                    std::move(mysql_settings), std::move(mysql_pool), create.attach);
-            }
-
-            MySQLClient client(configuration.host, configuration.port, configuration.username, configuration.password);
-            auto mysql_pool = mysqlxx::Pool(configuration.database, configuration.host, configuration.username, configuration.password, configuration.port);
-
-            auto materialize_mode_settings = std::make_unique<MaterializedMySQLSettings>();
-
-            if (engine_define->settings)
-                materialize_mode_settings->loadFromQuery(*engine_define);
-
-            if (uuid == UUIDHelpers::Nil)
-            {
-                auto print_create_ast = create.clone();
-                print_create_ast->as<ASTCreateQuery>()->attach = false;
-                throw Exception(ErrorCodes::NOT_IMPLEMENTED,
-                        "The MaterializedMySQL database engine no longer supports Ordinary databases. To re-create the database, delete "
-                        "the old one by executing \"rm -rf {}{{,.sql}}\", then re-create the database with the following query: {}",
-                        metadata_path,
-                        queryToString(print_create_ast));
-            }
-
-            return std::make_shared<DatabaseMaterializedMySQL>(
-                context, database_name, metadata_path, uuid, configuration.database, std::move(mysql_pool),
-                std::move(client), std::move(materialize_mode_settings));
-        }
-        catch (...)
-        {
-            const auto & exception_message = getCurrentExceptionMessage(true);
-            throw Exception(ErrorCodes::CANNOT_CREATE_DATABASE, "Cannot create MySQL database, because {}", exception_message);
-        }
-    }
-#endif
-
-    else if (engine_name == "Lazy")
-    {
-        const ASTFunction * engine = engine_define->engine;
-
-        if (!engine->arguments || engine->arguments->children.size() != 1)
-            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Lazy database require cache_expiration_time_seconds argument");
-
-        const auto & arguments = engine->arguments->children;
-
-        const auto cache_expiration_time_seconds = safeGetLiteralValue<UInt64>(arguments[0], "Lazy");
-        return std::make_shared<DatabaseLazy>(database_name, metadata_path, cache_expiration_time_seconds, context);
-    }
-
-    else if (engine_name == "Replicated")
-    {
-        const ASTFunction * engine = engine_define->engine;
-
-        if (!engine->arguments || engine->arguments->children.size() != 3)
-            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Replicated database requires 3 arguments: zookeeper path, shard name and replica name");
-
-        auto & arguments = engine->arguments->children;
-        for (auto & engine_arg : arguments)
-            engine_arg = evaluateConstantExpressionOrIdentifierAsLiteral(engine_arg, context);
-
-        String zookeeper_path = safeGetLiteralValue<String>(arguments[0], "Replicated");
-        String shard_name = safeGetLiteralValue<String>(arguments[1], "Replicated");
-        String replica_name  = safeGetLiteralValue<String>(arguments[2], "Replicated");
-
-        zookeeper_path = context->getMacros()->expand(zookeeper_path);
-        shard_name = context->getMacros()->expand(shard_name);
-        replica_name = context->getMacros()->expand(replica_name);
-
-        DatabaseReplicatedSettings database_replicated_settings{};
-        if (engine_define->settings)
-            database_replicated_settings.loadFromQuery(*engine_define);
-
-        return std::make_shared<DatabaseReplicated>(database_name, metadata_path, uuid,
-                                                    zookeeper_path, shard_name, replica_name,
-                                                    std::move(database_replicated_settings), context);
-    }
-
-#if USE_LIBPQXX
-
-    else if (engine_name == "PostgreSQL")
-    {
-        const ASTFunction * engine = engine_define->engine;
-        if (!engine->arguments)
-            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Engine `{}` must have arguments", engine_name);
-
-        ASTs & engine_args = engine->arguments->children;
-        auto use_table_cache = false;
-        StoragePostgreSQL::Configuration configuration;
-
-        if (auto named_collection = tryGetNamedCollectionWithOverrides(engine_args, context))
-        {
-            configuration = StoragePostgreSQL::processNamedCollectionResult(*named_collection, context, false);
-            use_table_cache = named_collection->getOrDefault<UInt64>("use_table_cache", 0);
-        }
-        else
-        {
-            if (engine_args.size() < 4 || engine_args.size() > 6)
-                throw Exception(ErrorCodes::BAD_ARGUMENTS,
-                                "PostgreSQL Database require `host:port`, `database_name`, `username`, `password`"
-                                "[, `schema` = "", `use_table_cache` = 0");
-
-            for (auto & engine_arg : engine_args)
-                engine_arg = evaluateConstantExpressionOrIdentifierAsLiteral(engine_arg, context);
-
-            const auto & host_port = safeGetLiteralValue<String>(engine_args[0], engine_name);
-            size_t max_addresses = context->getSettingsRef().glob_expansion_max_elements;
-
-            configuration.addresses = parseRemoteDescriptionForExternalDatabase(host_port, max_addresses, 5432);
-            configuration.database = safeGetLiteralValue<String>(engine_args[1], engine_name);
-            configuration.username = safeGetLiteralValue<String>(engine_args[2], engine_name);
-            configuration.password = safeGetLiteralValue<String>(engine_args[3], engine_name);
-
-            bool is_deprecated_syntax = false;
-            if (engine_args.size() >= 5)
-            {
-                auto arg_value = engine_args[4]->as<ASTLiteral>()->value;
-                if (arg_value.getType() == Field::Types::Which::String)
-                {
-                    configuration.schema = safeGetLiteralValue<String>(engine_args[4], engine_name);
-                }
-                else
-                {
-                    use_table_cache = safeGetLiteralValue<UInt8>(engine_args[4], engine_name);
-                    LOG_WARNING(&Poco::Logger::get("DatabaseFactory"), "A deprecated syntax of PostgreSQL database engine is used");
-                    is_deprecated_syntax = true;
-                }
-            }
-
-            if (!is_deprecated_syntax && engine_args.size() >= 6)
-                use_table_cache = safeGetLiteralValue<UInt8>(engine_args[5], engine_name);
-        }
-
-        const auto & settings = context->getSettingsRef();
-        auto pool = std::make_shared<postgres::PoolWithFailover>(
-            configuration,
-            settings.postgresql_connection_pool_size,
-            settings.postgresql_connection_pool_wait_timeout,
-            POSTGRESQL_POOL_WITH_FAILOVER_DEFAULT_MAX_TRIES,
-            settings.postgresql_connection_pool_auto_close_connection);
-
-        return std::make_shared<DatabasePostgreSQL>(
-            context, metadata_path, engine_define, database_name, configuration, pool, use_table_cache);
-    }
-    else if (engine_name == "MaterializedPostgreSQL")
-    {
-        const ASTFunction * engine = engine_define->engine;
-        if (!engine->arguments)
-            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Engine `{}` must have arguments", engine_name);
-
-        ASTs & engine_args = engine->arguments->children;
-        StoragePostgreSQL::Configuration configuration;
-
-        if (auto named_collection = tryGetNamedCollectionWithOverrides(engine_args, context))
-        {
-            configuration = StoragePostgreSQL::processNamedCollectionResult(*named_collection, context, false);
-        }
-        else
-        {
-            if (engine_args.size() != 4)
-                throw Exception(ErrorCodes::BAD_ARGUMENTS,
-                                "MaterializedPostgreSQL Database require `host:port`, `database_name`, `username`, `password`.");
-
-            for (auto & engine_arg : engine_args)
-                engine_arg = evaluateConstantExpressionOrIdentifierAsLiteral(engine_arg, context);
-
-            auto parsed_host_port = parseAddress(safeGetLiteralValue<String>(engine_args[0], engine_name), 5432);
-
-            configuration.host = parsed_host_port.first;
-            configuration.port = parsed_host_port.second;
-            configuration.database = safeGetLiteralValue<String>(engine_args[1], engine_name);
-            configuration.username = safeGetLiteralValue<String>(engine_args[2], engine_name);
-            configuration.password = safeGetLiteralValue<String>(engine_args[3], engine_name);
-        }
-
-        auto connection_info = postgres::formatConnectionString(
-            configuration.database, configuration.host, configuration.port, configuration.username, configuration.password);
-
-        auto postgresql_replica_settings = std::make_unique<MaterializedPostgreSQLSettings>();
-        if (engine_define->settings)
-            postgresql_replica_settings->loadFromQuery(*engine_define);
-
-        return std::make_shared<DatabaseMaterializedPostgreSQL>(
-                context, metadata_path, uuid, create.attach,
-                database_name, configuration.database, connection_info,
-                std::move(postgresql_replica_settings));
-    }
-
-
-#endif
-
-#if USE_SQLITE
-    else if (engine_name == "SQLite")
-    {
-        const ASTFunction * engine = engine_define->engine;
-
-        if (!engine->arguments || engine->arguments->children.size() != 1)
-            throw Exception(ErrorCodes::BAD_ARGUMENTS, "SQLite database requires 1 argument: database path");
-
-        const auto & arguments = engine->arguments->children;
-
-        String database_path = safeGetLiteralValue<String>(arguments[0], "SQLite");
-
-        return std::make_shared<DatabaseSQLite>(context, engine_define, create.attach, database_path);
-    }
-#endif
-
-    else if (engine_name == "Filesystem")
-    {
-        const ASTFunction * engine = engine_define->engine;
-
-        /// If init_path is empty, then the current path will be used
-        std::string init_path;
-
-        if (engine->arguments && !engine->arguments->children.empty())
-        {
-            if (engine->arguments->children.size() != 1)
-                throw Exception(ErrorCodes::BAD_ARGUMENTS, "Filesystem database requires at most 1 argument: filesystem_path");
-
-            const auto & arguments = engine->arguments->children;
-            init_path = safeGetLiteralValue<String>(arguments[0], engine_name);
-        }
-
-        return std::make_shared<DatabaseFilesystem>(database_name, init_path, context);
-    }
-
-#if USE_AWS_S3
-    else if (engine_name == "S3")
-    {
-        const ASTFunction * engine = engine_define->engine;
-
-        DatabaseS3::Configuration config;
-
-        if (engine->arguments && !engine->arguments->children.empty())
-        {
-            ASTs & engine_args = engine->arguments->children;
-            config = DatabaseS3::parseArguments(engine_args, context);
-        }
-
-        return std::make_shared<DatabaseS3>(database_name, config, context);
-    }
-#endif
-
-#if USE_HDFS
-    else if (engine_name == "HDFS")
-    {
-        const ASTFunction * engine = engine_define->engine;
-
-        /// If source_url is empty, then table name must contain full url
-        std::string source_url;
-
-        if (engine->arguments && !engine->arguments->children.empty())
-        {
-            if (engine->arguments->children.size() != 1)
-                throw Exception(ErrorCodes::BAD_ARGUMENTS, "HDFS database requires at most 1 argument: source_url");
-
-            const auto & arguments = engine->arguments->children;
-            source_url = safeGetLiteralValue<String>(arguments[0], engine_name);
-        }
-
-        return std::make_shared<DatabaseHDFS>(database_name, source_url, context);
-    }
-#endif
-
-    throw Exception(ErrorCodes::UNKNOWN_DATABASE_ENGINE, "Unknown database engine: {}", engine_name);
+    const ASTFunction & engine_def = *storage->engine;
+
+    bool has_engine_args = false;
+    if (engine_def.arguments)
+        has_engine_args = true;
+
+    if(!database_engines.contains(engine_name))
+        throw Exception(ErrorCodes::UNKNOWN_DATABASE_ENGINE, "Unknown database engine: {}", engine_name);
+
+    ASTs empty_engine_args;
+    Arguments arguments{
+        .engine_name = engine_name,
+        .engine_args = has_engine_args ? storage->engine->arguments->children : empty_engine_args,
+        .create_query = create,
+        .database_name = database_name,
+        .metadata_path = metadata_path,
+        .uuid = uuid,
+        .context = context};
+
+    assert(arguments.getContext() == arguments.getContext()->getGlobalContext());
+
+    auto res = database_engines.at(engine_name).creator_fn(arguments);
+
+    return res;
+
+    /// TODO: move validation to respective engines
+//    static const std::unordered_set<std::string_view> database_engines{"Ordinary", "Atomic", "Memory",
+//        "Dictionary", "Lazy", "Replicated", "MySQL", "MaterializeMySQL", "MaterializedMySQL",
+//        "PostgreSQL", "MaterializedPostgreSQL", "SQLite", "Filesystem", "S3", "HDFS"};
+
+//    static const std::unordered_set<std::string_view> engines_with_arguments{"MySQL", "MaterializeMySQL", "MaterializedMySQL",
+//        "Lazy", "Replicated", "PostgreSQL", "MaterializedPostgreSQL", "SQLite", "Filesystem", "S3", "HDFS"};
+//
+//    static const std::unordered_set<std::string_view> engines_with_table_overrides{"MaterializeMySQL", "MaterializedMySQL", "MaterializedPostgreSQL"};
+//    bool engine_may_have_arguments = engines_with_arguments.contains(engine_name);
+//
+//    if (engine_define->engine->arguments && !engine_may_have_arguments)
+//        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Database engine `{}` cannot have arguments", engine_name);
+//
+//    bool has_unexpected_element = engine_define->engine->parameters || engine_define->partition_by ||
+//                                  engine_define->primary_key || engine_define->order_by ||
+//                                  engine_define->sample_by;
+//    bool may_have_settings = endsWith(engine_name, "MySQL") || engine_name == "Replicated" || engine_name == "MaterializedPostgreSQL";
+//
+//    if (has_unexpected_element || (!may_have_settings && engine_define->settings))
+//        throw Exception(ErrorCodes::UNKNOWN_ELEMENT_IN_AST,
+//                        "Database engine `{}` cannot have parameters, primary_key, order_by, sample_by, settings", engine_name);
+//
+//    if (create.table_overrides && !engines_with_table_overrides.contains(engine_name))
+//        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Database engine `{}` cannot have table overrides", engine_name);
 }
 
 }

--- a/src/Databases/DatabaseFactory.cpp
+++ b/src/Databases/DatabaseFactory.cpp
@@ -182,8 +182,6 @@ DatabasePtr DatabaseFactory::getImpl(const ASTCreateQuery & create, const String
         .uuid = create.uuid,
         .context = context};
 
-    assert(arguments.getContext() == arguments.getContext()->getGlobalContext());
-
     // creator_fn creates and returns a DatabasePtr with the supplied arguments
     auto creator_fn = database_engines.at(engine_name);
 

--- a/src/Databases/DatabaseFactory.cpp
+++ b/src/Databases/DatabaseFactory.cpp
@@ -119,6 +119,18 @@ DatabasePtr DatabaseFactory::get(const ASTCreateQuery & create, const String & m
     return impl;
 }
 
+void DatabaseFactory::registerDatabase(const std::string & name, CreatorFn creator_fn)
+{
+    if (!databases.emplace(name, Creator{std::move(creator_fn)}).second)
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "DatabaseFactory: the database name '{}' is not unique", name);
+}
+
+DatabaseFactory & DatabaseFactory::instance()
+{
+    static DatabaseFactory db_fact;
+    return db_fact;
+}
+
 template <typename ValueType>
 static inline ValueType safeGetLiteralValue(const ASTPtr &ast, const String &engine_name)
 {

--- a/src/Databases/DatabaseFactory.h
+++ b/src/Databases/DatabaseFactory.h
@@ -45,14 +45,14 @@ public:
     {
         CreatorFn creator_fn;
     };
-    using Databases = std::unordered_map<std::string, Creator>;
+    using DatabaseEngines = std::unordered_map<std::string, Creator>;
 
     void registerDatabase(const std::string & name, CreatorFn creator_fn);
 
-    const Databases & getAllDatabases() const { return databases; }
+    const DatabaseEngines & getAllDatabases() const { return database_engines; }
 
 private:
-    Databases databases;
+    DatabaseEngines database_engines;
 };
 
 }

--- a/src/Databases/DatabaseFactory.h
+++ b/src/Databases/DatabaseFactory.h
@@ -34,7 +34,7 @@ public:
     {
         const String & engine_name;
         ASTs & engine_args;
-        ASTStorage * storage_def;
+        ASTStorage * storage;
         const ASTCreateQuery & create_query;
         const String & database_name;
         const String & metadata_path;
@@ -48,15 +48,9 @@ public:
 
     using CreatorFn = std::function<DatabasePtr(const Arguments & arguments)>;
 
-    struct Creator
-    {
-        CreatorFn creator_fn;
-    };
-    using DatabaseEngines = std::unordered_map<std::string, Creator>;
+    using DatabaseEngines = std::unordered_map<std::string, CreatorFn>;
 
     void registerDatabase(const std::string & name, CreatorFn creator_fn);
-
-    const DatabaseEngines & getAllDatabases() const { return database_engines; }
 
 private:
     DatabaseEngines database_engines;

--- a/src/Databases/DatabaseFactory.h
+++ b/src/Databases/DatabaseFactory.h
@@ -2,20 +2,27 @@
 
 #include <Interpreters/Context_fwd.h>
 #include <Databases/IDatabase.h>
-
-#if USE_MYSQL
-#    include <Parsers/ASTCreateQuery.h>
-#    include <Core/MySQL/MySQLClient.h>
-#    include <Core/MySQL/MySQLClient.h>
-#    include <Databases/MySQL/MaterializedMySQLSettings.h>
-#    include <Storages/MySQL/MySQLSettings.h>
-#    include <mysqlxx/PoolWithFailover.h>
-#endif
+#include <Parsers/ASTCreateQuery.h>
+#include <Parsers/ASTLiteral.h>
 
 namespace DB
 {
 
+namespace ErrorCodes
+{
+    extern const int BAD_ARGUMENTS;
+}
+
 class ASTCreateQuery;
+
+template <typename ValueType>
+static inline ValueType safeGetLiteralValue(const ASTPtr &ast, const String &engine_name)
+{
+    if (!ast || !ast->as<ASTLiteral>())
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Database engine {} requested literal argument.", engine_name);
+
+    return ast->as<ASTLiteral>()->value.safeGet<ValueType>();
+}
 
 class DatabaseFactory : private boost::noncopyable
 {

--- a/src/Databases/DatabaseFactory.h
+++ b/src/Databases/DatabaseFactory.h
@@ -3,6 +3,15 @@
 #include <Interpreters/Context_fwd.h>
 #include <Databases/IDatabase.h>
 
+#if USE_MYSQL
+#    include <Parsers/ASTCreateQuery.h>
+#    include <Core/MySQL/MySQLClient.h>
+#    include <Core/MySQL/MySQLClient.h>
+#    include <Databases/MySQL/MaterializedMySQLSettings.h>
+#    include <Storages/MySQL/MySQLSettings.h>
+#    include <mysqlxx/PoolWithFailover.h>
+#endif
+
 namespace DB
 {
 
@@ -16,11 +25,14 @@ public:
 
     struct Arguments
     {
+        const String & engine_name;
+        ASTs & engine_args;
+        ASTStorage * storage_def;
+        const ASTCreateQuery & create_query;
         const String & database_name;
         const String & metadata_path;
         const UUID & uuid;
-        const ContextPtr & context;
-        const UInt64 & cache_expiration_time_seconds;
+        ContextPtr & context;
     };
 
     DatabasePtr get(const ASTCreateQuery & create, const String & metadata_path, ContextPtr context);

--- a/src/Databases/DatabaseFilesystem.cpp
+++ b/src/Databases/DatabaseFilesystem.cpp
@@ -1,3 +1,4 @@
+#include <Databases/DatabaseFactory.h>
 #include <Databases/DatabaseFilesystem.h>
 
 #include <IO/Operators.h>
@@ -237,4 +238,15 @@ DatabaseTablesIteratorPtr DatabaseFilesystem::getTablesIterator(ContextPtr, cons
     return std::make_unique<DatabaseTablesSnapshotIterator>(Tables{}, getDatabaseName());
 }
 
+void registerDatabaseFilesystem(DatabaseFactory & factory)
+{
+    auto create_fn = [](const DatabaseFactory::Arguments & args)
+    {
+        return make_shared<DatabaseFilesystem>(
+            args.database_name,
+            args.metadata_path,
+            args.context);
+    };
+    factory.registerDatabase("FileSystem", create_fn);
+}
 }

--- a/src/Databases/DatabaseHDFS.cpp
+++ b/src/Databases/DatabaseHDFS.cpp
@@ -238,15 +238,6 @@ DatabaseTablesIteratorPtr DatabaseHDFS::getTablesIterator(ContextPtr, const Filt
     return std::make_unique<DatabaseTablesSnapshotIterator>(Tables{}, getDatabaseName());
 }
 
-template <typename ValueType>
-static inline ValueType safeGetLiteralValue(const ASTPtr &ast, const String &engine_name)
-{
-    if (!ast || !ast->as<ASTLiteral>())
-        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Database engine {} requested literal argument.", engine_name);
-
-    return ast->as<ASTLiteral>()->value.safeGet<ValueType>();
-}
-
 void registerDatabaseHDFS(DatabaseFactory & factory)
 {
     auto create_fn = [](const DatabaseFactory::Arguments & args)

--- a/src/Databases/DatabaseLazy.cpp
+++ b/src/Databases/DatabaseLazy.cpp
@@ -36,6 +36,7 @@ namespace ErrorCodes
     extern const int UNKNOWN_TABLE;
     extern const int UNSUPPORTED_METHOD;
     extern const int LOGICAL_ERROR;
+    extern const int BAD_ARGUMENTS;
 }
 
 
@@ -354,15 +355,6 @@ const StoragePtr & DatabaseLazyIterator::table() const
     if (!current_storage)
         current_storage = database.tryGetTable(*iterator);
     return current_storage;
-}
-
-template <typename ValueType>
-static inline ValueType safeGetLiteralValue(const ASTPtr &ast, const String &engine_name)
-{
-    if (!ast || !ast->as<ASTLiteral>())
-        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Database engine {} requested literal argument.", engine_name);
-
-    return ast->as<ASTLiteral>()->value.safeGet<ValueType>();
 }
 
 void registerDatabaseLazy(DatabaseFactory & factory)

--- a/src/Databases/DatabaseLazy.cpp
+++ b/src/Databases/DatabaseLazy.cpp
@@ -1,4 +1,5 @@
 #include <Core/Settings.h>
+#include <Databases/DatabaseFactory.h>
 #include <Databases/DatabaseLazy.h>
 #include <Databases/DatabaseOnDisk.h>
 #include <Databases/DatabasesCommon.h>
@@ -354,4 +355,16 @@ const StoragePtr & DatabaseLazyIterator::table() const
     return current_storage;
 }
 
+void registerDatabaseLazy(DatabaseFactory & factory)
+{
+    auto create_fn = [](const DatabaseFactory::Arguments & args)
+    {
+        return make_shared<DatabaseLazy>(
+            args.database_name,
+            args.metadata_path,
+            args.cache_expiration_time_seconds,
+            args.context);
+    };
+    factory.registerDatabase("Lazy", create_fn);
+}
 }

--- a/src/Databases/DatabaseMemory.cpp
+++ b/src/Databases/DatabaseMemory.cpp
@@ -1,5 +1,6 @@
 #include <base/scope_guard.h>
 #include <Common/logger_useful.h>
+#include <Databases/DatabaseFactory.h>
 #include <Databases/DatabaseMemory.h>
 #include <Databases/DatabasesCommon.h>
 #include <Databases/DDLDependencyVisitor.h>
@@ -207,6 +208,17 @@ std::vector<std::pair<ASTPtr, StoragePtr>> DatabaseMemory::getTablesForBackup(co
     }
 
     return res;
+}
+
+void registerDatabaseMemory(DatabaseFactory & factory)
+{
+    auto create_fn = [](const DatabaseFactory::Arguments & args)
+    {
+        return make_shared<DatabaseMemory>(
+            args.database_name,
+            args.context);
+    };
+    factory.registerDatabase("Memory", create_fn);
 }
 
 }

--- a/src/Databases/DatabaseOrdinary.cpp
+++ b/src/Databases/DatabaseOrdinary.cpp
@@ -38,6 +38,7 @@ namespace DB
 namespace ErrorCodes
 {
     extern const int LOGICAL_ERROR;
+    extern const int UNKNOWN_DATABASE_ENGINE;
 }
 
 static constexpr size_t METADATA_FILE_BUFFER_SIZE = 32768;
@@ -326,6 +327,10 @@ void registerDatabaseOrdinary(DatabaseFactory & factory)
 {
     auto create_fn = [](const DatabaseFactory::Arguments & args)
     {
+        if (!args.create_query.attach && !args.context->getSettingsRef().allow_deprecated_database_ordinary)
+            throw Exception(
+                ErrorCodes::UNKNOWN_DATABASE_ENGINE,
+                "Ordinary database engine is deprecated (see also allow_deprecated_database_ordinary setting)");
         return make_shared<DatabaseOrdinary>(
             args.database_name,
             args.metadata_path,

--- a/src/Databases/DatabaseOrdinary.cpp
+++ b/src/Databases/DatabaseOrdinary.cpp
@@ -1,6 +1,7 @@
 #include <filesystem>
 
 #include <Core/Settings.h>
+#include <Databases/DatabaseFactory.h>
 #include <Databases/DatabaseOnDisk.h>
 #include <Databases/DatabaseOrdinary.h>
 #include <Databases/DatabasesCommon.h>
@@ -321,4 +322,15 @@ void DatabaseOrdinary::commitAlterTable(const StorageID &, const String & table_
     }
 }
 
+void registerDatabaseOrdinary(DatabaseFactory & factory)
+{
+    auto create_fn = [](const DatabaseFactory::Arguments & args)
+    {
+        return make_shared<DatabaseOrdinary>(
+            args.database_name,
+            args.metadata_path,
+            args.context);
+    };
+    factory.registerDatabase("Ordinary", create_fn);
+}
 }

--- a/src/Databases/DatabaseReplicated.cpp
+++ b/src/Databases/DatabaseReplicated.cpp
@@ -1653,15 +1653,6 @@ bool DatabaseReplicated::shouldReplicateQuery(const ContextPtr & query_context, 
     return true;
 }
 
-template <typename ValueType>
-static inline ValueType safeGetLiteralValue(const ASTPtr &ast, const String &engine_name)
-{
-    if (!ast || !ast->as<ASTLiteral>())
-        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Database engine {} requested literal argument.", engine_name);
-
-    return ast->as<ASTLiteral>()->value.safeGet<ValueType>();
-}
-
 void registerDatabaseReplicated(DatabaseFactory & factory)
 {
     auto create_fn = [](const DatabaseFactory::Arguments & args)

--- a/src/Databases/DatabaseReplicated.cpp
+++ b/src/Databases/DatabaseReplicated.cpp
@@ -13,6 +13,7 @@
 #include <Common/ZooKeeper/Types.h>
 #include <Common/ZooKeeper/ZooKeeper.h>
 #include <Common/PoolId.h>
+#include <Databases/DatabaseFactory.h>
 #include <Databases/DatabaseReplicated.h>
 #include <Databases/DatabaseReplicatedWorker.h>
 #include <Databases/DDLDependencyVisitor.h>
@@ -1652,4 +1653,50 @@ bool DatabaseReplicated::shouldReplicateQuery(const ContextPtr & query_context, 
     return true;
 }
 
+template <typename ValueType>
+static inline ValueType safeGetLiteralValue(const ASTPtr &ast, const String &engine_name)
+{
+    if (!ast || !ast->as<ASTLiteral>())
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Database engine {} requested literal argument.", engine_name);
+
+    return ast->as<ASTLiteral>()->value.safeGet<ValueType>();
+}
+
+void registerDatabaseReplicated(DatabaseFactory & factory)
+{
+    auto create_fn = [](const DatabaseFactory::Arguments & args)
+    {
+        auto * engine_define = args.create_query.storage;
+        const ASTFunction * engine = engine_define->engine;
+
+        if (!engine->arguments || engine->arguments->children.size() != 3)
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Replicated database requires 3 arguments: zookeeper path, shard name and replica name");
+
+        auto & arguments = engine->arguments->children;
+        for (auto & engine_arg : arguments)
+            engine_arg = evaluateConstantExpressionOrIdentifierAsLiteral(engine_arg, args.context);
+
+        String zookeeper_path = safeGetLiteralValue<String>(arguments[0], "Replicated");
+        String shard_name = safeGetLiteralValue<String>(arguments[1], "Replicated");
+        String replica_name  = safeGetLiteralValue<String>(arguments[2], "Replicated");
+
+        zookeeper_path = args.context->getMacros()->expand(zookeeper_path);
+        shard_name = args.context->getMacros()->expand(shard_name);
+        replica_name = args.context->getMacros()->expand(replica_name);
+
+        DatabaseReplicatedSettings database_replicated_settings{};
+        if (engine_define->settings)
+            database_replicated_settings.loadFromQuery(*engine_define);
+
+        return std::make_shared<DatabaseReplicated>(
+            args.database_name,
+            args.metadata_path,
+            args.uuid,
+            zookeeper_path,
+            shard_name,
+            replica_name,
+            std::move(database_replicated_settings), args.context);
+    };
+    factory.registerDatabase("Replicated", create_fn);
+}
 }

--- a/src/Databases/DatabaseS3.cpp
+++ b/src/Databases/DatabaseS3.cpp
@@ -2,6 +2,7 @@
 
 #if USE_AWS_S3
 
+#include <Databases/DatabaseFactory.h>
 #include <Databases/DatabaseS3.h>
 
 #include <Interpreters/Context.h>
@@ -307,6 +308,24 @@ DatabaseTablesIteratorPtr DatabaseS3::getTablesIterator(ContextPtr, const Filter
     return std::make_unique<DatabaseTablesSnapshotIterator>(Tables{}, getDatabaseName());
 }
 
-}
+void registerDatabaseS3(DatabaseFactory & factory)
+{
+    auto create_fn = [](const DatabaseFactory::Arguments & args)
+    {
+        auto * engine_define = args.create_query.storage;
+        const ASTFunction * engine = engine_define->engine;
 
+        DatabaseS3::Configuration config;
+
+        if (engine->arguments && !engine->arguments->children.empty())
+        {
+            ASTs & engine_args = engine->arguments->children;
+            config = DatabaseS3::parseArguments(engine_args, args.context);
+        }
+
+        return std::make_shared<DatabaseS3>(args.database_name, config, args.context);
+    };
+    factory.registerDatabase("S3", create_fn);
+}
+}
 #endif

--- a/src/Databases/MySQL/DatabaseMaterializedMySQL.cpp
+++ b/src/Databases/MySQL/DatabaseMaterializedMySQL.cpp
@@ -6,7 +6,6 @@
 #    include <Common/parseRemoteDescription.h>
 #    include <Databases/MySQL/DatabaseMaterializedMySQL.h>
 
-#    include <Interpreters/Context.h>
 #    include <Interpreters/evaluateConstantExpression.h>
 #    include <Databases/DatabaseFactory.h>
 #    include <Databases/MySQL/DatabaseMaterializedTablesIterator.h>
@@ -16,7 +15,6 @@
 #    include <Parsers/queryToString.h>
 #    include <Storages/StorageMySQL.h>
 #    include <Storages/StorageMaterializedMySQL.h>
-#    include <Storages/MySQL/MySQLHelpers.h>
 #    include <Storages/NamedCollectionsHelpers.h>
 #    include <Common/setThreadName.h>
 #    include <Common/PoolId.h>
@@ -265,7 +263,8 @@ void registerDatabaseMaterializedMySQL(DatabaseFactory & factory)
             std::move(client),
             std::move(materialize_mode_settings));
     };
-    factory.registerDatabase("MySQL", create_fn);
+    factory.registerDatabase("MaterializeMySQL", create_fn);
+    factory.registerDatabase("MaterializedMySQL", create_fn);
 }
 
 }

--- a/src/Databases/MySQL/DatabaseMaterializedMySQL.cpp
+++ b/src/Databases/MySQL/DatabaseMaterializedMySQL.cpp
@@ -30,6 +30,7 @@ namespace DB
 namespace ErrorCodes
 {
     extern const int NOT_IMPLEMENTED;
+    extern const int BAD_ARGUMENTS;
 }
 
 DatabaseMaterializedMySQL::DatabaseMaterializedMySQL(
@@ -186,16 +187,6 @@ void DatabaseMaterializedMySQL::stopReplication()
     waitDatabaseStarted(/* no_throw = */ true);
     materialize_thread.stopSynchronization();
     started_up = false;
-}
-
-
-template <typename ValueType>
-static inline ValueType safeGetLiteralValue(const ASTPtr &ast, const String &engine_name)
-{
-    if (!ast || !ast->as<ASTLiteral>())
-        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Database engine {} requested literal argument.", engine_name);
-
-    return ast->as<ASTLiteral>()->value.safeGet<ValueType>();
 }
 
 void registerDatabaseMaterializedMySQL(DatabaseFactory & factory)

--- a/src/Databases/MySQL/DatabaseMySQL.cpp
+++ b/src/Databases/MySQL/DatabaseMySQL.cpp
@@ -2,6 +2,7 @@
 
 #if USE_MYSQL
 #    include <string>
+#    include <Databases/DatabaseFactory.h>
 #    include <DataTypes/DataTypeDateTime.h>
 #    include <DataTypes/DataTypeNullable.h>
 #    include <DataTypes/DataTypeString.h>
@@ -14,6 +15,7 @@
 #    include <QueryPipeline/QueryPipelineBuilder.h>
 #    include <IO/Operators.h>
 #    include <Interpreters/Context.h>
+#    include <Interpreters/evaluateConstantExpression.h>
 #    include <Parsers/ASTCreateQuery.h>
 #    include <Parsers/ASTFunction.h>
 #    include <Parsers/ParserCreateQuery.h>
@@ -21,8 +23,11 @@
 #    include <Parsers/queryToString.h>
 #    include <Storages/StorageMySQL.h>
 #    include <Storages/MySQL/MySQLSettings.h>
+#    include <Storages/MySQL/MySQLHelpers.h>
+#    include <Storages/NamedCollectionsHelpers.h>
 #    include <Common/escapeForFileName.h>
 #    include <Common/parseAddress.h>
+#    include <Common/parseRemoteDescription.h>
 #    include <Common/setThreadName.h>
 #    include <filesystem>
 #    include <Common/filesystemHelpers.h>
@@ -41,6 +46,7 @@ namespace ErrorCodes
     extern const int TABLE_IS_DROPPED;
     extern const int TABLE_ALREADY_EXISTS;
     extern const int UNEXPECTED_AST_STRUCTURE;
+    extern const int CANNOT_CREATE_DATABASE;
 }
 
 constexpr static const auto suffix = ".remove_flag";
@@ -504,6 +510,86 @@ void DatabaseMySQL::createTable(ContextPtr local_context, const String & table_n
     attachTable(local_context, table_name, storage, {});
 }
 
+template <typename ValueType>
+static inline ValueType safeGetLiteralValue(const ASTPtr &ast, const String &engine_name)
+{
+    if (!ast || !ast->as<ASTLiteral>())
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Database engine {} requested literal argument.", engine_name);
+
+    return ast->as<ASTLiteral>()->value.safeGet<ValueType>();
+}
+
+void registerDatabaseMySQL(DatabaseFactory & factory)
+{
+    auto create_fn = [](const DatabaseFactory::Arguments & args)
+    {
+        auto * engine_define = args.create_query.storage;
+        const ASTFunction * engine = engine_define->engine;
+        const String & engine_name = engine_define->engine->name;
+        if (!engine->arguments)
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Engine `{}` must have arguments", engine_name);
+
+        StorageMySQL::Configuration configuration;
+        ASTs & arguments = engine->arguments->children;
+        auto mysql_settings = std::make_unique<MySQLSettings>();
+
+        if (auto named_collection = tryGetNamedCollectionWithOverrides(arguments, args.context))
+        {
+            configuration = StorageMySQL::processNamedCollectionResult(*named_collection, *mysql_settings, args.context, false);
+        }
+        else
+        {
+            if (arguments.size() != 4)
+                throw Exception(
+                    ErrorCodes::BAD_ARGUMENTS,
+                    "MySQL database require mysql_hostname, mysql_database_name, mysql_username, mysql_password arguments.");
+
+
+            arguments[1] = evaluateConstantExpressionOrIdentifierAsLiteral(arguments[1], args.context);
+            const auto & host_port = safeGetLiteralValue<String>(arguments[0], engine_name);
+
+            if (engine_name == "MySQL")
+            {
+                size_t max_addresses = args.context->getSettingsRef().glob_expansion_max_elements;
+                configuration.addresses = parseRemoteDescriptionForExternalDatabase(host_port, max_addresses, 3306);
+            }
+            else
+            {
+                const auto & [remote_host, remote_port] = parseAddress(host_port, 3306);
+                configuration.host = remote_host;
+                configuration.port = remote_port;
+            }
+
+            configuration.database = safeGetLiteralValue<String>(arguments[1], engine_name);
+            configuration.username = safeGetLiteralValue<String>(arguments[2], engine_name);
+            configuration.password = safeGetLiteralValue<String>(arguments[3], engine_name);
+        }
+        mysql_settings->loadFromQueryContext(args.context, *engine_define);
+        if (engine_define->settings)
+            mysql_settings->loadFromQuery(*engine_define);
+
+        auto mysql_pool = createMySQLPoolWithFailover(configuration, *mysql_settings);
+
+        try
+        {
+            return make_shared<DatabaseMySQL>(
+                args.context,
+                args.database_name,
+                args.metadata_path,
+                engine_define,
+                configuration.database,
+                std::move(mysql_settings),
+                std::move(mysql_pool),
+                args.create_query.attach);
+        }
+        catch (...)
+        {
+            const auto & exception_message = getCurrentExceptionMessage(true);
+            throw Exception(ErrorCodes::CANNOT_CREATE_DATABASE, "Cannot create MySQL database, because {}", exception_message);
+        }
+    };
+    factory.registerDatabase("MySQL", create_fn);
+}
 }
 
 #endif

--- a/src/Databases/MySQL/DatabaseMySQL.cpp
+++ b/src/Databases/MySQL/DatabaseMySQL.cpp
@@ -47,6 +47,7 @@ namespace ErrorCodes
     extern const int TABLE_ALREADY_EXISTS;
     extern const int UNEXPECTED_AST_STRUCTURE;
     extern const int CANNOT_CREATE_DATABASE;
+    extern const int BAD_ARGUMENTS;
 }
 
 constexpr static const auto suffix = ".remove_flag";
@@ -508,15 +509,6 @@ void DatabaseMySQL::createTable(ContextPtr local_context, const String & table_n
                         "of type attach table database_name.table_name");
 
     attachTable(local_context, table_name, storage, {});
-}
-
-template <typename ValueType>
-static inline ValueType safeGetLiteralValue(const ASTPtr &ast, const String &engine_name)
-{
-    if (!ast || !ast->as<ASTLiteral>())
-        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Database engine {} requested literal argument.", engine_name);
-
-    return ast->as<ASTLiteral>()->value.safeGet<ValueType>();
 }
 
 void registerDatabaseMySQL(DatabaseFactory & factory)

--- a/src/Databases/PostgreSQL/DatabaseMaterializedPostgreSQL.cpp
+++ b/src/Databases/PostgreSQL/DatabaseMaterializedPostgreSQL.cpp
@@ -8,11 +8,15 @@
 #include <Common/logger_useful.h>
 #include <Common/Macros.h>
 #include <Common/PoolId.h>
+#include <Common/parseAddress.h>
+#include <Common/parseRemoteDescription.h>
 #include <Core/UUID.h>
 #include <DataTypes/DataTypeNullable.h>
 #include <DataTypes/DataTypeArray.h>
 #include <Databases/DatabaseOrdinary.h>
 #include <Databases/DatabaseAtomic.h>
+#include <Databases/DatabaseFactory.h>
+#include <Storages/NamedCollectionsHelpers.h>
 #include <Storages/StoragePostgreSQL.h>
 #include <Storages/AlterCommands.h>
 #include <Interpreters/Context.h>
@@ -21,6 +25,8 @@
 #include <Parsers/ParserCreateQuery.h>
 #include <Parsers/parseQuery.h>
 #include <Parsers/queryToString.h>
+#include <Parsers/ASTFunction.h>
+#include <Interpreters/evaluateConstantExpression.h>
 #include <Interpreters/InterpreterAlterQuery.h>
 #include <Common/escapeForFileName.h>
 #include <Poco/DirectoryIterator.h>
@@ -471,6 +477,68 @@ DatabaseTablesIteratorPtr DatabaseMaterializedPostgreSQL::getTablesIterator(
     return DatabaseAtomic::getTablesIterator(StorageMaterializedPostgreSQL::makeNestedTableContext(local_context), filter_by_table_name);
 }
 
+template <typename ValueType>
+static inline ValueType safeGetLiteralValue(const ASTPtr &ast, const String &engine_name)
+{
+    if (!ast || !ast->as<ASTLiteral>())
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Database engine {} requested literal argument.", engine_name);
+
+    return ast->as<ASTLiteral>()->value.safeGet<ValueType>();
+}
+
+void registerDatabaseMaterializedPostgreSQL(DatabaseFactory & factory)
+{
+    auto create_fn = [](const DatabaseFactory::Arguments & args)
+    {
+        auto * engine_define = args.create_query.storage;
+        const ASTFunction * engine = engine_define->engine;
+        ASTs & engine_args = engine->arguments->children;
+        const String & engine_name = engine_define->engine->name;
+
+        if (!engine->arguments)
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Engine `{}` must have arguments", engine_name);
+
+        StoragePostgreSQL::Configuration configuration;
+
+        if (!engine->arguments)
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Engine `{}` must have arguments", engine_name);
+
+        if (auto named_collection = tryGetNamedCollectionWithOverrides(engine_args, args.context))
+        {
+            configuration = StoragePostgreSQL::processNamedCollectionResult(*named_collection, args.context, false);
+        }
+        else
+        {
+            if (engine_args.size() != 4)
+                throw Exception(ErrorCodes::BAD_ARGUMENTS,
+                                "MaterializedPostgreSQL Database require `host:port`, `database_name`, `username`, `password`.");
+
+            for (auto & engine_arg : engine_args)
+                engine_arg = evaluateConstantExpressionOrIdentifierAsLiteral(engine_arg, args.context);
+
+            auto parsed_host_port = parseAddress(safeGetLiteralValue<String>(engine_args[0], engine_name), 5432);
+
+            configuration.host = parsed_host_port.first;
+            configuration.port = parsed_host_port.second;
+            configuration.database = safeGetLiteralValue<String>(engine_args[1], engine_name);
+            configuration.username = safeGetLiteralValue<String>(engine_args[2], engine_name);
+            configuration.password = safeGetLiteralValue<String>(engine_args[3], engine_name);
+        }
+
+        auto connection_info = postgres::formatConnectionString(
+            configuration.database, configuration.host, configuration.port, configuration.username, configuration.password);
+
+        auto postgresql_replica_settings = std::make_unique<MaterializedPostgreSQLSettings>();
+        if (engine_define->settings)
+            postgresql_replica_settings->loadFromQuery(*engine_define);
+
+        return std::make_shared<DatabaseMaterializedPostgreSQL>(
+            args.context, args.metadata_path, args.uuid, args.create_query.attach,
+            args.database_name, configuration.database, connection_info,
+            std::move(postgresql_replica_settings));
+    };
+    factory.registerDatabase("MaterializedPostgreSQL", create_fn);
+}
 }
 
 #endif

--- a/src/Databases/PostgreSQL/DatabaseMaterializedPostgreSQL.cpp
+++ b/src/Databases/PostgreSQL/DatabaseMaterializedPostgreSQL.cpp
@@ -22,14 +22,11 @@
 #include <Interpreters/Context.h>
 #include <Parsers/ASTCreateQuery.h>
 #include <Parsers/ASTFunction.h>
-#include <Parsers/ParserCreateQuery.h>
 #include <Parsers/parseQuery.h>
 #include <Parsers/queryToString.h>
 #include <Interpreters/evaluateConstantExpression.h>
 #include <Interpreters/InterpreterAlterQuery.h>
 #include <Common/escapeForFileName.h>
-#include <Poco/DirectoryIterator.h>
-#include <Poco/File.h>
 
 namespace DB
 {

--- a/src/Databases/PostgreSQL/DatabaseMaterializedPostgreSQL.cpp
+++ b/src/Databases/PostgreSQL/DatabaseMaterializedPostgreSQL.cpp
@@ -25,7 +25,6 @@
 #include <Parsers/ParserCreateQuery.h>
 #include <Parsers/parseQuery.h>
 #include <Parsers/queryToString.h>
-#include <Parsers/ASTFunction.h>
 #include <Interpreters/evaluateConstantExpression.h>
 #include <Interpreters/InterpreterAlterQuery.h>
 #include <Common/escapeForFileName.h>
@@ -475,15 +474,6 @@ DatabaseTablesIteratorPtr DatabaseMaterializedPostgreSQL::getTablesIterator(
 {
     /// Modify context into nested_context and pass query to Atomic database.
     return DatabaseAtomic::getTablesIterator(StorageMaterializedPostgreSQL::makeNestedTableContext(local_context), filter_by_table_name);
-}
-
-template <typename ValueType>
-static inline ValueType safeGetLiteralValue(const ASTPtr &ast, const String &engine_name)
-{
-    if (!ast || !ast->as<ASTLiteral>())
-        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Database engine {} requested literal argument.", engine_name);
-
-    return ast->as<ASTLiteral>()->value.safeGet<ValueType>();
 }
 
 void registerDatabaseMaterializedPostgreSQL(DatabaseFactory & factory)

--- a/src/Databases/PostgreSQL/DatabasePostgreSQL.cpp
+++ b/src/Databases/PostgreSQL/DatabasePostgreSQL.cpp
@@ -482,15 +482,6 @@ ASTPtr DatabasePostgreSQL::getColumnDeclaration(const DataTypePtr & data_type) c
     return std::make_shared<ASTIdentifier>(data_type->getName());
 }
 
-template <typename ValueType>
-static inline ValueType safeGetLiteralValue(const ASTPtr &ast, const String &engine_name)
-{
-    if (!ast || !ast->as<ASTLiteral>())
-        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Database engine {} requested literal argument.", engine_name);
-
-    return ast->as<ASTLiteral>()->value.safeGet<ValueType>();
-}
-
 void registerDatabasePostgreSQL(DatabaseFactory & factory)
 {
     auto create_fn = [](const DatabaseFactory::Arguments & args)

--- a/src/Databases/PostgreSQL/DatabasePostgreSQL.cpp
+++ b/src/Databases/PostgreSQL/DatabasePostgreSQL.cpp
@@ -6,14 +6,18 @@
 
 #include <DataTypes/DataTypeNullable.h>
 #include <DataTypes/DataTypeArray.h>
+#include <Storages/NamedCollectionsHelpers.h>
 #include <Storages/StoragePostgreSQL.h>
 #include <Interpreters/Context.h>
+#include <Interpreters/evaluateConstantExpression.h>
 #include <Parsers/ASTCreateQuery.h>
 #include <Parsers/ASTFunction.h>
 #include <Parsers/ParserCreateQuery.h>
 #include <Parsers/parseQuery.h>
 #include <Parsers/queryToString.h>
 #include <Common/escapeForFileName.h>
+#include <Common/parseRemoteDescription.h>
+#include <Databases/DatabaseFactory.h>
 #include <Databases/PostgreSQL/fetchPostgreSQLTableStructure.h>
 #include <Common/quoteString.h>
 #include <Common/filesystemHelpers.h>
@@ -478,6 +482,92 @@ ASTPtr DatabasePostgreSQL::getColumnDeclaration(const DataTypePtr & data_type) c
     return std::make_shared<ASTIdentifier>(data_type->getName());
 }
 
+template <typename ValueType>
+static inline ValueType safeGetLiteralValue(const ASTPtr &ast, const String &engine_name)
+{
+    if (!ast || !ast->as<ASTLiteral>())
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Database engine {} requested literal argument.", engine_name);
+
+    return ast->as<ASTLiteral>()->value.safeGet<ValueType>();
+}
+
+void registerDatabasePostgreSQL(DatabaseFactory & factory)
+{
+    auto create_fn = [](const DatabaseFactory::Arguments & args)
+    {
+        auto * engine_define = args.create_query.storage;
+        const ASTFunction * engine = engine_define->engine;
+        ASTs & engine_args = engine->arguments->children;
+        const String & engine_name = engine_define->engine->name;
+
+        if (!engine->arguments)
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Engine `{}` must have arguments", engine_name);
+
+        auto use_table_cache = false;
+        StoragePostgreSQL::Configuration configuration;
+
+        if (auto named_collection = tryGetNamedCollectionWithOverrides(engine_args, args.context))
+        {
+            configuration = StoragePostgreSQL::processNamedCollectionResult(*named_collection, args.context, false);
+            use_table_cache = named_collection->getOrDefault<UInt64>("use_table_cache", 0);
+        }
+        else
+        {
+            if (engine_args.size() < 4 || engine_args.size() > 6)
+                throw Exception(ErrorCodes::BAD_ARGUMENTS,
+                                "PostgreSQL Database require `host:port`, `database_name`, `username`, `password`"
+                                "[, `schema` = "", `use_table_cache` = 0");
+
+            for (auto & engine_arg : engine_args)
+                engine_arg = evaluateConstantExpressionOrIdentifierAsLiteral(engine_arg, args.context);
+
+            const auto & host_port = safeGetLiteralValue<String>(engine_args[0], engine_name);
+            size_t max_addresses = args.context->getSettingsRef().glob_expansion_max_elements;
+
+            configuration.addresses = parseRemoteDescriptionForExternalDatabase(host_port, max_addresses, 5432);
+            configuration.database = safeGetLiteralValue<String>(engine_args[1], engine_name);
+            configuration.username = safeGetLiteralValue<String>(engine_args[2], engine_name);
+            configuration.password = safeGetLiteralValue<String>(engine_args[3], engine_name);
+
+            bool is_deprecated_syntax = false;
+            if (engine_args.size() >= 5)
+            {
+                auto arg_value = engine_args[4]->as<ASTLiteral>()->value;
+                if (arg_value.getType() == Field::Types::Which::String)
+                {
+                    configuration.schema = safeGetLiteralValue<String>(engine_args[4], engine_name);
+                }
+                else
+                {
+                    use_table_cache = safeGetLiteralValue<UInt8>(engine_args[4], engine_name);
+                    LOG_WARNING(&Poco::Logger::get("DatabaseFactory"), "A deprecated syntax of PostgreSQL database engine is used");
+                    is_deprecated_syntax = true;
+                }
+            }
+
+            if (!is_deprecated_syntax && engine_args.size() >= 6)
+                use_table_cache = safeGetLiteralValue<UInt8>(engine_args[5], engine_name);
+        }
+
+        const auto & settings = args.context->getSettingsRef();
+        auto pool = std::make_shared<postgres::PoolWithFailover>(
+            configuration,
+            settings.postgresql_connection_pool_size,
+            settings.postgresql_connection_pool_wait_timeout,
+            POSTGRESQL_POOL_WITH_FAILOVER_DEFAULT_MAX_TRIES,
+            settings.postgresql_connection_pool_auto_close_connection);
+
+        return std::make_shared<DatabasePostgreSQL>(
+            args.context,
+            args.metadata_path,
+            engine_define,
+            args.database_name,
+            configuration,
+            pool,
+            use_table_cache);
+    };
+    factory.registerDatabase("PostgreSQL", create_fn);
+}
 }
 
 #endif

--- a/src/Databases/SQLite/DatabaseSQLite.cpp
+++ b/src/Databases/SQLite/DatabaseSQLite.cpp
@@ -22,6 +22,7 @@ namespace ErrorCodes
 {
     extern const int SQLITE_ENGINE_ERROR;
     extern const int UNKNOWN_TABLE;
+    extern const int BAD_ARGUMENTS;
 }
 
 DatabaseSQLite::DatabaseSQLite(
@@ -200,15 +201,6 @@ ASTPtr DatabaseSQLite::getCreateTableQueryImpl(const String & table_name, Contex
                                                             throw_on_error);
 
     return create_table_query;
-}
-
-template <typename ValueType>
-static inline ValueType safeGetLiteralValue(const ASTPtr &ast, const String &engine_name)
-{
-    if (!ast || !ast->as<ASTLiteral>())
-        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Database engine {} requested literal argument.", engine_name);
-
-    return ast->as<ASTLiteral>()->value.safeGet<ValueType>();
 }
 
 void registerDatabaseSQLite(DatabaseFactory & factory)

--- a/src/Databases/SQLite/DatabaseSQLite.cpp
+++ b/src/Databases/SQLite/DatabaseSQLite.cpp
@@ -10,7 +10,6 @@
 #include <Parsers/ASTCreateQuery.h>
 #include <Parsers/ASTColumnDeclaration.h>
 #include <Parsers/ASTFunction.h>
-#include <Interpreters/Context.h>
 #include <Storages/StorageSQLite.h>
 #include <Databases/SQLite/SQLiteUtils.h>
 

--- a/src/Databases/registerDatabases.cpp
+++ b/src/Databases/registerDatabases.cpp
@@ -11,7 +11,30 @@ void registerDatabaseDictionary(DatabaseFactory & factory);
 void registerDatabaseMemory(DatabaseFactory & factory);
 void registerDatabaseLazy(DatabaseFactory & factory);
 void registerDatabaseFilesystem(DatabaseFactory & factory);
+void registerDatabaseReplicated(DatabaseFactory & factory);
 
+#if USE_MYSQL
+void registerDatabaseMySQL(DatabaseFactory & factory);
+void registerDatabaseMaterializedMySQL(DatabaseFactory & factory);
+#endif
+
+#if USE_LIBPQXX
+void registerDatabasePostgreSQL(DatabaseFactory & factory);
+
+void registerDatabaseMaterializedPostgreSQL(DatabaseFactory & factory);
+#endif
+
+#if USE_SQLITE
+void registerDatabaseSQLite(DatabaseFactory & factory);
+#endif
+
+#if USE_AWS_S3
+void registerDatabaseS3(DatabaseFactory & factory);
+#endif
+
+#if USE_HDFS
+void registerDatabaseHDFS(DatabaseFactory & factory);
+#endif
 
 void registerDatabases()
 {
@@ -22,5 +45,28 @@ void registerDatabases()
     registerDatabaseMemory(factory);
     registerDatabaseLazy(factory);
     registerDatabaseFilesystem(factory);
+    registerDatabaseReplicated(factory);
+
+#if USE_MYSQL
+    registerDatabaseMySQL(factory);
+    registerDatabaseMaterializedMySQL(factory);
+#endif
+
+#if USE_LIBPQXX
+    registerDatabasePostgreSQL(factory);
+    registerDatabaseMaterializedPostgreSQL(factory);
+#endif
+
+#if USE_SQLITE
+    registerDatabaseSQLite(factory);
+#endif
+
+#if USE_AWS_S3
+    registerDatabaseS3(factory);
+#endif
+
+#if USE_HDFS
+    registerDatabaseHDFS(factory);
+#endif
 }
 }

--- a/src/Databases/registerDatabases.cpp
+++ b/src/Databases/registerDatabases.cpp
@@ -1,0 +1,26 @@
+#include <Databases/DatabaseFactory.h>
+#include <Databases/registerDatabases.h>
+
+
+namespace DB
+{
+
+void registerDatabaseAtomic(DatabaseFactory & factory);
+void registerDatabaseOrdinary(DatabaseFactory & factory);
+void registerDatabaseDictionary(DatabaseFactory & factory);
+void registerDatabaseMemory(DatabaseFactory & factory);
+void registerDatabaseLazy(DatabaseFactory & factory);
+void registerDatabaseFilesystem(DatabaseFactory & factory);
+
+
+void registerDatabases()
+{
+    auto & factory = DatabaseFactory::instance();
+    registerDatabaseAtomic(factory);
+    registerDatabaseOrdinary(factory);
+    registerDatabaseDictionary(factory);
+    registerDatabaseMemory(factory);
+    registerDatabaseLazy(factory);
+    registerDatabaseFilesystem(factory);
+}
+}

--- a/src/Databases/registerDatabases.h
+++ b/src/Databases/registerDatabases.h
@@ -1,3 +1,5 @@
+#pragma once
+
 namespace DB
 {
 void registerDatabases();

--- a/src/Databases/registerDatabases.h
+++ b/src/Databases/registerDatabases.h
@@ -1,0 +1,4 @@
+namespace DB
+{
+void registerDatabases();
+}

--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -282,7 +282,7 @@ BlockIO InterpreterCreateQuery::createDatabase(ASTCreateQuery & create)
     else if (create.uuid != UUIDHelpers::Nil && !DatabaseCatalog::instance().hasUUIDMapping(create.uuid))
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Cannot find UUID mapping for {}, it's a bug", create.uuid);
 
-    DatabasePtr database = DatabaseFactory::get(create, metadata_path / "", getContext());
+    DatabasePtr database = DatabaseFactory::instance().get(create, metadata_path / "", getContext());
 
     if (create.uuid != UUIDHelpers::Nil)
         create.setDatabase(TABLE_WITH_UUID_NAME_PLACEHOLDER);

--- a/src/Interpreters/fuzzers/execute_query_fuzzer.cpp
+++ b/src/Interpreters/fuzzers/execute_query_fuzzer.cpp
@@ -2,6 +2,7 @@
 #include <Interpreters/Context.h>
 #include "Processors/Executors/PullingPipelineExecutor.h"
 
+#include <Functions/registerDatabases.h>
 #include <Functions/registerFunctions.h>
 #include <AggregateFunctions/registerAggregateFunctions.h>
 #include <TableFunctions/registerTableFunctions.h>
@@ -31,6 +32,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t * data, size_t size)
             registerFunctions();
             registerAggregateFunctions();
             registerTableFunctions();
+            registerDatabases();
             registerStorages();
             registerDictionaries();
             registerDisks(/* global_skip_access_check= */ true);


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Allow registering database engines independently.

Rewrite DatabaseFactory to allow registering each database engine independently.

Related to #56557 and previously #9136 