### PR TITLE
fix zero copy lock, add randomization storage_metadata_write_full_obj…

### DIFF
--- a/docker/test/stateless/stress_tests.lib
+++ b/docker/test/stateless/stress_tests.lib
@@ -142,6 +142,10 @@ EOL
 </clickhouse>
 EOL
 
+    if [[ -n "$USE_S3_STORAGE_FOR_MERGE_TREE" ]] && [[ "$USE_S3_STORAGE_FOR_MERGE_TREE" -eq 1 ]]; then
+        # We randomize setting storage_metadata_write_full_object_key, it is supposed to have no effect on the tests
+        randomize_config_boolean_value storage_metadata_write_full_object_key storage_metadata
+    fi
 }
 
 function stop()

--- a/src/Disks/ObjectStorages/DiskObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/DiskObjectStorage.cpp
@@ -258,12 +258,6 @@ String DiskObjectStorage::getUniqueId(const String & path) const
 
 bool DiskObjectStorage::checkUniqueId(const String & id) const
 {
-    if (!id.starts_with(object_key_prefix))
-    {
-        LOG_DEBUG(log, "Blob with id {} doesn't start with blob storage prefix {}, Stack {}", id, object_key_prefix, StackTrace().toString());
-        return false;
-    }
-
     auto object = StoredObject(id);
     return object_storage->exists(object);
 }

--- a/src/Storages/StorageReplicatedMergeTree.h
+++ b/src/Storages/StorageReplicatedMergeTree.h
@@ -288,7 +288,7 @@ public:
         std::optional<HardlinkedFiles> hardlinked_files,
         Coordination::Requests & requests) const;
 
-    zkutil::EphemeralNodeHolderPtr lockSharedDataTemporary(const String & part_name, const String & part_id, const DiskPtr & disk) const;
+    zkutil::EphemeralNodeHolderPtr lockSharedDataTemporary(const String & part_name, const String & part_unique_key, const DiskPtr & disk) const;
 
     /// Unlock shared data part in zookeeper
     /// Return true if data unlocked
@@ -301,7 +301,7 @@ public:
     /// Return true if data unlocked
     /// Return false if data is still used by another node
     static std::pair<bool, NameSet> unlockSharedDataByID(
-        String part_id,
+        String part_unique_id,
         const String & table_uuid,
         const MergeTreePartInfo & part_info,
         const String & replica_name_,

--- a/tests/config/config.d/storage_metadata.xml
+++ b/tests/config/config.d/storage_metadata.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<clickhouse>
+    <storage_metadata_write_full_object_key>0</storage_metadata_write_full_object_key>
+</clickhouse>

--- a/tests/config/install.sh
+++ b/tests/config/install.sh
@@ -142,6 +142,7 @@ fi
 
 if [[ -n "$USE_S3_STORAGE_FOR_MERGE_TREE" ]] && [[ "$USE_S3_STORAGE_FOR_MERGE_TREE" -eq 1 ]]; then
     ln -sf $SRC_PATH/config.d/s3_storage_policy_by_default.xml $DEST_SERVER_PATH/config.d/
+    ln -sf $SRC_PATH/config.d/storage_metadata.xml $DEST_SERVER_PATH/config.d/
 fi
 
 ARM="aarch64"

--- a/tests/integration/test_remote_blobs_naming/configs/storage_conf.xml
+++ b/tests/integration/test_remote_blobs_naming/configs/storage_conf.xml
@@ -9,17 +9,17 @@
         <disks>
             <s3>
                 <type>s3</type>
-                <endpoint>http://minio1:9001/root/data/</endpoint>
+                <endpoint>http://minio1:9001/root/old-style-prefix/with-several-section/</endpoint>
                 <access_key_id>minio</access_key_id>
                 <secret_access_key>minio123</secret_access_key>
             </s3>
             <s3_plain>
-               <type>s3_plain</type>
-               <endpoint>http://minio1:9001/root/data/s3_pain_key_prefix</endpoint>
-               <access_key_id>minio</access_key_id>
-               <secret_access_key>minio123</secret_access_key>
-               <s3_allow_native_copy>true</s3_allow_native_copy>
-           </s3_plain>
+                <type>s3_plain</type>
+                <endpoint>http://minio1:9001/root/data/s3_pain_key_prefix</endpoint>
+                <access_key_id>minio</access_key_id>
+                <secret_access_key>minio123</secret_access_key>
+                <s3_allow_native_copy>true</s3_allow_native_copy>
+            </s3_plain>
         </disks>
 
         <policies>
@@ -38,6 +38,13 @@
                     </main>
                 </volumes>
             </s3_plain>
+            <s3_template_key>
+                <volumes>
+                    <main>
+                        <disk>s3</disk>
+                    </main>
+                </volumes>
+            </s3_template_key>
         </policies>
     </storage_configuration>
 

--- a/tests/integration/test_remote_blobs_naming/test_backward_compatibility.py
+++ b/tests/integration/test_remote_blobs_naming/test_backward_compatibility.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
-
+from contextlib import contextmanager
+from difflib import unified_diff
 import logging
+import re
 import pytest
 
 import os
@@ -200,44 +202,183 @@ def test_write_new_format(cluster):
     assert remote == object_key
 
 
-@pytest.mark.parametrize("storage_policy", ["s3", "s3_plain"])
-def test_replicated_merge_tree(cluster, storage_policy):
-    if storage_policy == "s3_plain":
-        # MergeTree table doesn't work on s3_plain. Rename operation is not implemented
-        return
+@contextmanager
+def drop_table_scope(nodes, tables, create_statements):
+    try:
+        for node in nodes:
+            for statement in create_statements:
+                node.query(statement)
+        yield
+    finally:
+        for node in nodes:
+            for table in tables:
+                node.query(f"DROP TABLE IF EXISTS {table} SYNC")
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        ("s3", False),
+        ("s3", True),
+    ],
+)
+def test_replicated_merge_tree(cluster, test_case):
+    storage_policy, zero_copy = test_case
 
     node_old = cluster.instances["node"]
     node_new = cluster.instances["new_node"]
 
+    zk_table_path = f"/clickhouse/tables/test_replicated_merge_tree_{storage_policy}{'_zero_copy' if zero_copy else ''}"
     create_table_statement = f"""
-        CREATE TABLE test_replicated_merge_tree (
-            id Int64,
-            val String
-        ) ENGINE=ReplicatedMergeTree('/clickhouse/tables/test_replicated_merge_tree_{storage_policy}', '{{replica}}')
-        PARTITION BY id
-        ORDER BY (id, val)
-        SETTINGS
-            storage_policy='{storage_policy}'
-        """
+                CREATE TABLE test_replicated_merge_tree (
+                    id Int64,
+                    val String
+                ) ENGINE=ReplicatedMergeTree('{zk_table_path}', '{{replica}}')
+                PARTITION BY id
+                ORDER BY (id, val)
+                SETTINGS
+                    storage_policy='{storage_policy}',
+                    allow_remote_fs_zero_copy_replication='{1 if zero_copy else 0}'
+                """
 
-    node_old.query(create_table_statement)
-    node_new.query(create_table_statement)
+    with drop_table_scope(
+        [node_old, node_new], ["test_replicated_merge_tree"], [create_table_statement]
+    ):
+        node_old.query("INSERT INTO test_replicated_merge_tree VALUES (0, 'a')")
+        node_new.query("INSERT INTO test_replicated_merge_tree VALUES (1, 'b')")
 
-    node_old.query("INSERT INTO test_replicated_merge_tree VALUES (0, 'a')")
-    node_new.query("INSERT INTO test_replicated_merge_tree VALUES (1, 'b')")
+        # node_old have to fetch metadata from node_new and vice versa
+        node_old.query("SYSTEM SYNC REPLICA test_replicated_merge_tree")
+        node_new.query("SYSTEM SYNC REPLICA test_replicated_merge_tree")
 
-    # node_old have to fetch metadata from node_new and vice versa
-    node_old.query("SYSTEM SYNC REPLICA test_replicated_merge_tree")
-    node_new.query("SYSTEM SYNC REPLICA test_replicated_merge_tree")
+        count_old = node_old.query(
+            "SELECT count() FROM test_replicated_merge_tree"
+        ).strip()
+        count_new = node_new.query(
+            "SELECT count() FROM test_replicated_merge_tree"
+        ).strip()
 
-    count_old = node_old.query("SELECT count() FROM test_replicated_merge_tree").strip()
-    count_new = node_new.query("SELECT count() FROM test_replicated_merge_tree").strip()
+        assert count_old == "2"
+        assert count_new == "2"
 
-    assert count_old == "2"
-    assert count_new == "2"
+        if not zero_copy:
+            return
 
-    node_old.query("DROP TABLE test_replicated_merge_tree SYNC")
-    node_new.query("DROP TABLE test_replicated_merge_tree SYNC")
+        def get_remote_pathes(node, table_name, only_remote_path=True):
+            uuid = node.query(
+                f"""
+                SELECT uuid
+                FROM system.tables
+                WHERE name = '{table_name}'
+                """
+            ).strip()
+            assert uuid
+            return node.query(
+                f"""
+                SELECT {"remote_path" if only_remote_path else "*"}
+                FROM system.remote_data_paths
+                WHERE
+                    local_path LIKE '%{uuid}%'
+                    AND local_path NOT LIKE '%format_version.txt%'
+                ORDER BY ALL
+                """
+            ).strip()
+
+        remote_pathes_old = get_remote_pathes(node_old, "test_replicated_merge_tree")
+        remote_pathes_new = get_remote_pathes(node_new, "test_replicated_merge_tree")
+
+        assert len(remote_pathes_old) > 0
+        assert remote_pathes_old == remote_pathes_new, (
+            str(unified_diff(remote_pathes_old, remote_pathes_new))
+            + "\n\nold:\n"
+            + get_remote_pathes(node_old, "test_replicated_merge_tree", False)
+            + "\n\nnew:\n"
+            + get_remote_pathes(node_new, "test_replicated_merge_tree", False)
+        )
+
+        def count_lines_with(lines, pattern):
+            return sum([1 for x in lines if pattern in x])
+
+        remote_paths_with_old_format = count_lines_with(
+            remote_pathes_old.split(), "old-style-prefix"
+        )
+        remote_paths_with_new_format = count_lines_with(
+            remote_pathes_old.split(), "new-style-prefix"
+        )
+
+        assert remote_paths_with_old_format == len(remote_pathes_old.split())
+        assert remote_paths_with_new_format == 0
+
+        parts = (
+            node_old.query(
+                """
+                SELECT name
+                FROM system.parts
+                WHERE
+                    table = 'test_replicated_merge_tree'
+                    AND active
+                ORDER BY ALL
+                """
+            )
+            .strip()
+            .split()
+        )
+
+        table_shared_uuid = node_old.query(
+            f"""
+            SELECT value
+            FROM system.zookeeper
+            WHERE path='{zk_table_path}' and name='table_shared_id'
+            """
+        ).strip()
+
+        part_blobs = {}
+        blobs_replicas = {}
+
+        for part in parts:
+            blobs = (
+                node_old.query(
+                    f"""
+                    SELECT name
+                    FROM system.zookeeper
+                    WHERE path='/clickhouse/zero_copy/zero_copy_s3/{table_shared_uuid}/{part}'
+                    ORDER BY ALL
+                    """
+                )
+                .strip()
+                .split()
+            )
+
+            for blob in blobs:
+                replicas = (
+                    node_old.query(
+                        f"""
+                        SELECT name
+                        FROM system.zookeeper
+                        WHERE path='/clickhouse/zero_copy/zero_copy_s3/{table_shared_uuid}/{part}/{blob}'
+                        ORDER BY ALL
+                        """
+                    )
+                    .strip()
+                    .split()
+                )
+                assert blob not in blobs_replicas
+                blobs_replicas[blob] = replicas
+
+            assert part not in part_blobs
+            part_blobs[part] = blobs
+
+        assert len(part_blobs.keys()) == len(parts), (
+            str(part_blobs) + " == " + str(parts)
+        )
+        assert len(part_blobs.keys()) == 2, str(part_blobs)
+        assert len(blobs_replicas.keys()) == 2, str(blobs_replicas)
+
+        for replicas in blobs_replicas.values():
+            assert len(replicas) == 2, str(replicas)
+
+        for blob in blobs_replicas.keys():
+            assert re.match("[a-z]{3}_[a-z]{29}", blob), str(blobs_replicas)
 
 
 def switch_config_write_full_object_key(node, enable):

--- a/tests/integration/test_replicated_zero_copy_projection_mutation/test.py
+++ b/tests/integration/test_replicated_zero_copy_projection_mutation/test.py
@@ -248,6 +248,9 @@ def test_hardlinks_preserved_when_projection_dropped(
             .strip()
             .split()
         )
+        assert len(hardlinks) == 1
+        hardlinks = hardlinks[0].replace("\\n", "\n").split()
+
         assert len(hardlinks) > 0, ",".join(hardlinks)
         assert any(["proj/" in x for x in hardlinks]), ",".join(hardlinks)
 


### PR DESCRIPTION
I made a bug here https://github.com/ClickHouse/ClickHouse/pull/55566
This PR is fixing it.

Format of zero copy lock has to be preserved no matter how metadata format is changed.
test_replicated_merge_tree checks the format of zero copy lock.

Also settings `storage_metadata_write_full_object_key` is randomized in stress tests.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)