### PR TITLE
Small README.md update for issue 58385

### DIFF
--- a/docker/packager/README.md
+++ b/docker/packager/README.md
@@ -3,10 +3,10 @@ compilers and build settings. Correctly configured Docker daemon is single depen
 
 Usage:
 
-Build deb package with `clang-14` in `debug` mode:
+Build deb package with `clang-17` in `debug` mode:
 ```
 $ mkdir deb/test_output
-$ ./packager --output-dir deb/test_output/ --package-type deb --compiler=clang-14 --debug-build
+$ ./packager --output-dir deb/test_output/ --package-type deb --compiler=clang-17 --debug-build
 $ ls -l deb/test_output
 -rw-r--r-- 1 root root      3730 clickhouse-client_22.2.2+debug_all.deb
 -rw-r--r-- 1 root root  84221888 clickhouse-common-static_22.2.2+debug_amd64.deb
@@ -17,11 +17,11 @@ $ ls -l deb/test_output
 
 ```
 
-Build ClickHouse binary with `clang-14` and `address` sanitizer in `relwithdebuginfo`
+Build ClickHouse binary with `clang-17` and `address` sanitizer in `relwithdebuginfo`
 mode:
 ```
 $ mkdir $HOME/some_clickhouse
-$ ./packager --output-dir=$HOME/some_clickhouse --package-type binary --compiler=clang-14 --sanitizer=address
+$ ./packager --output-dir=$HOME/some_clickhouse --package-type binary --compiler=clang-17 --sanitizer=address
 $ ls -l $HOME/some_clickhouse
 -rwxr-xr-x 1 root root 787061952  clickhouse
 lrwxrwxrwx 1 root root        10  clickhouse-benchmark -> clickhouse


### PR DESCRIPTION
### Changelog category (leave one):
- Documentation (changelog entry is not required)

I am opening a pullrequest for issue #58385, it's a really small change to  `README.md` in `docker/packager` to use `clang-17` rather than `clang-14` as you will get an error using `clang-14` now. (see issue for more details) 
