### PR TITLE
fix database engine validation inside database factory

### DIFF
--- a/src/Databases/DatabaseFactory.cpp
+++ b/src/Databases/DatabaseFactory.cpp
@@ -1,54 +1,15 @@
-#include <Databases/DatabaseFactory.h>
-
 #include <filesystem>
+
+#include <Databases/DatabaseFactory.h>
 #include <Databases/DatabaseReplicated.h>
 #include <Interpreters/Context.h>
-#include <Interpreters/evaluateConstantExpression.h>
 #include <Parsers/ASTCreateQuery.h>
 #include <Parsers/ASTFunction.h>
 #include <Parsers/ASTLiteral.h>
 #include <Parsers/queryToString.h>
-#include <Storages/NamedCollectionsHelpers.h>
-#include <Common/logger_useful.h>
 #include <Common/Macros.h>
 #include <Common/filesystemHelpers.h>
-
-#include "config.h"
-
-#if USE_MYSQL
-#    include <Core/MySQL/MySQLClient.h>
-#    include <Databases/MySQL/DatabaseMySQL.h>
-#    include <Databases/MySQL/MaterializedMySQLSettings.h>
-#    include <Storages/MySQL/MySQLHelpers.h>
-#    include <Storages/MySQL/MySQLSettings.h>
-#    include <Storages/StorageMySQL.h>
-#    include <Databases/MySQL/DatabaseMaterializedMySQL.h>
-#    include <mysqlxx/Pool.h>
-#endif
-
-#if USE_MYSQL || USE_LIBPQXX
-#include <Common/parseRemoteDescription.h>
-#include <Common/parseAddress.h>
-#endif
-
-#if USE_LIBPQXX
-#include <Databases/PostgreSQL/DatabasePostgreSQL.h>
-#include <Databases/PostgreSQL/DatabaseMaterializedPostgreSQL.h>
-#include <Storages/PostgreSQL/MaterializedPostgreSQLSettings.h>
-#include <Storages/StoragePostgreSQL.h>
-#endif
-
-#if USE_SQLITE
-#include <Databases/SQLite/DatabaseSQLite.h>
-#endif
-
-#if USE_AWS_S3
-#include <Databases/DatabaseS3.h>
-#endif
-
-#if USE_HDFS
-#include <Databases/DatabaseHDFS.h>
-#endif
+#include <Common/logger_useful.h>
 
 namespace fs = std::filesystem;
 
@@ -163,7 +124,6 @@ DatabaseFactory & DatabaseFactory::instance()
     static DatabaseFactory db_fact;
     return db_fact;
 }
-
 
 DatabasePtr DatabaseFactory::getImpl(const ASTCreateQuery & create, const String & metadata_path, ContextPtr context)
 {

--- a/src/Databases/DatabaseFactory.cpp
+++ b/src/Databases/DatabaseFactory.cpp
@@ -131,6 +131,13 @@ void validate(const ASTCreateQuery & create_query)
 
 DatabasePtr DatabaseFactory::get(const ASTCreateQuery & create, const String & metadata_path, ContextPtr context)
 {
+    /// check if the database engine is a valid one before proceeding
+    if (!database_engines.contains(create.storage->engine->name))
+        throw Exception(ErrorCodes::UNKNOWN_DATABASE_ENGINE, "Unknown database engine: {}", create.storage->engine->name);
+
+    /// if the engine is found (i.e. registered with the factory instance), then validate if the
+    /// supplied engine arguments, settings and table overrides are valid for the engine.
+    validate(create);
     cckMetadataPathForOrdinary(create, metadata_path);
 
     DatabasePtr impl = getImpl(create, metadata_path, context);
@@ -163,13 +170,6 @@ DatabasePtr DatabaseFactory::getImpl(const ASTCreateQuery & create, const String
     auto * storage = create.storage;
     const String & database_name = create.getDatabase();
     const String & engine_name = storage->engine->name;
-
-    if (!database_engines.contains(engine_name))
-        throw Exception(ErrorCodes::UNKNOWN_DATABASE_ENGINE, "Unknown database engine: {}", engine_name);
-
-    /// if the engine is found (i.e. registered with the factory instance), then validate if the
-    /// supplied engine arguments, settings and table overrides are valid for the engine.
-    validate(create);
 
     bool has_engine_args = false;
     if (storage->engine->arguments)

--- a/src/Databases/DatabaseFactory.h
+++ b/src/Databases/DatabaseFactory.h
@@ -44,8 +44,6 @@ public:
 
     DatabasePtr get(const ASTCreateQuery & create, const String & metadata_path, ContextPtr context);
 
-    DatabasePtr getImpl(const ASTCreateQuery & create, const String & metadata_path, ContextPtr context);
-
     using CreatorFn = std::function<DatabasePtr(const Arguments & arguments)>;
 
     using DatabaseEngines = std::unordered_map<std::string, CreatorFn>;
@@ -56,6 +54,8 @@ public:
 
 private:
     DatabaseEngines database_engines;
+
+    DatabasePtr getImpl(const ASTCreateQuery & create, const String & metadata_path, ContextPtr context);
 };
 
 }

--- a/tests/queries/0_stateless/02960_validate_database_engines.sql
+++ b/tests/queries/0_stateless/02960_validate_database_engines.sql
@@ -1,0 +1,14 @@
+-- Tags: no-parallel
+
+DROP DATABASE IF EXISTS test2960_valid_database_engine;
+
+-- create database with valid engine. Should succeed.
+CREATE DATABASE test2960_valid_database_engine ENGINE = Atomic;
+
+-- create database with valid engine but arguments are not allowed. Should fail.
+CREATE DATABASE test2960_database_engine_args_not_allowed ENGINE = Atomic('foo', 'bar'); -- { serverError BAD_ARGUMENTS }
+
+-- create database with an invalid engine. Should fail.
+CREATE DATABASE test2960_invalid_database_engine ENGINE = Foo; -- { serverError UNKNOWN_DATABASE_ENGINE }
+
+DROP DATABASE IF EXISTS test2960_valid_database_engine;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Follow up fix for #58365. I realized that the validation for engine arguments should happen after it's been determined if the engine is valid. This sequence was misplaced during the refactoring. Added a test to ensure that this is the behavior.
cc: @alexey-milovidov

Before:
```
:)  CREATE DATABASE test_atomic ENGINE = Aatomic();

CREATE DATABASE test_atomic
ENGINE = Aatomic

Query id: 132f99a4-8ef5-4290-90a3-641ae71a7284

Elapsed: 0.007 sec. 

Received exception from server (version 24.1.1):
Code: 36. DB::Exception: Received from localhost:9000. DB::Exception: Database engine `Aatomic` cannot have arguments. (BAD_ARGUMENTS)
```

After:
```
:)  CREATE DATABASE test_atomic ENGINE = Aatomic;

CREATE DATABASE test_atomic
ENGINE = Aatomic

Query id: 5c53a4e7-c2a2-4c56-b3b0-5c90caf00351

Elapsed: 0.001 sec. 

Received exception from server (version 24.1.1):
Code: 336. DB::Exception: Received from localhost:9000. DB::Exception: Unknown database engine: Aatomic. (UNKNOWN_DATABASE_ENGINE)
```
> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
