### PR TITLE
Fix bad formatting of the `timeDiff` compatibility alias

### DIFF
--- a/src/Functions/dateDiff.cpp
+++ b/src/Functions/dateDiff.cpp
@@ -412,14 +412,14 @@ private:
 };
 
 
-/** TimeDiff(t1, t2)
+/** timeDiff(t1, t2)
   * t1 and t2 can be Date or DateTime
   */
 class FunctionTimeDiff : public IFunction
 {
     using ColumnDateTime64 = ColumnDecimal<DateTime64>;
 public:
-    static constexpr auto name = "TimeDiff";
+    static constexpr auto name = "timeDiff";
     static FunctionPtr create(ContextPtr) { return std::make_shared<FunctionTimeDiff>(); }
 
     String getName() const override


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
