### PR TITLE
Seperate max_execution_time and max_estimated_execution_time

### DIFF
--- a/docs/en/operations/settings/query-complexity.md
+++ b/docs/en/operations/settings/query-complexity.md
@@ -172,8 +172,7 @@ If you set `timeout_before_checking_execution_speed `to 0, ClickHouse will use c
 
 ## timeout_overflow_mode {#timeout-overflow-mode}
 
-What to do if the query is run longer than `max_execution_time` or the estimated running time is
-longer than `max_estimated_execution_time`: `throw` or `break`. By default, `throw`.
+What to do if the query is run longer than `max_execution_time` or the estimated running time is longer than `max_estimated_execution_time`: `throw` or `break`. By default, `throw`.
 
 # max_execution_time_leaf
 

--- a/docs/en/operations/settings/query-complexity.md
+++ b/docs/en/operations/settings/query-complexity.md
@@ -172,7 +172,8 @@ If you set `timeout_before_checking_execution_speed `to 0, ClickHouse will use c
 
 ## timeout_overflow_mode {#timeout-overflow-mode}
 
-What to do if the query is run longer than `max_execution_time`: `throw` or `break`. By default, `throw`.
+What to do if the query is run longer than `max_execution_time` or the estimated running time is
+longer than `max_estimated_execution_time`: `throw` or `break`. By default, `throw`.
 
 # max_execution_time_leaf
 
@@ -213,6 +214,10 @@ A maximum number of execution bytes per second. Checked on every data block when
 ## timeout_before_checking_execution_speed {#timeout-before-checking-execution-speed}
 
 Checks that execution speed is not too slow (no less than ‘min_execution_speed’), after the specified time in seconds has expired.
+
+## max_estimated_execution_time {#max_estimated_execution_time}
+
+Maximum query estimate execution time in seconds. Checked on every data block when ‘timeout_before_checking_execution_speed’ expires.
 
 ## max_columns_to_read {#max-columns-to-read}
 

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -404,6 +404,7 @@ class IColumn;
     M(UInt64, min_execution_speed_bytes, 0, "Minimum number of execution bytes per second.", 0) \
     M(UInt64, max_execution_speed_bytes, 0, "Maximum number of execution bytes per second.", 0) \
     M(Seconds, timeout_before_checking_execution_speed, 10, "Check that the speed is not too low after the specified time has elapsed.", 0) \
+    M(Seconds, max_estimated_execution_time, 0, "Maximum query estimate execution time in seconds.", 0) \
     \
     M(UInt64, max_columns_to_read, 0, "If a query requires reading more than specified number of columns, exception is thrown. Zero value means unlimited. This setting is useful to prevent too complex queries.", 0) \
     M(UInt64, max_temporary_columns, 0, "If a query generates more than the specified number of temporary columns in memory as a result of intermediate calculation, exception is thrown. Zero value means unlimited. This setting is useful to prevent too complex queries.", 0) \

--- a/src/Interpreters/IInterpreterUnionOrSelectQuery.cpp
+++ b/src/Interpreters/IInterpreterUnionOrSelectQuery.cpp
@@ -54,6 +54,7 @@ static StreamLocalLimits getLimitsForStorage(const Settings & settings, const Se
     limits.speed_limits.max_execution_rps = settings.max_execution_speed;
     limits.speed_limits.max_execution_bps = settings.max_execution_speed_bytes;
     limits.speed_limits.timeout_before_checking_execution_speed = settings.timeout_before_checking_execution_speed;
+    limits.speed_limits.max_estimated_execution_time = settings.max_estimated_execution_time;
 
     return limits;
 }

--- a/src/Planner/Utils.cpp
+++ b/src/Planner/Utils.cpp
@@ -179,6 +179,7 @@ StreamLocalLimits getLimitsForStorage(const Settings & settings, const SelectQue
     limits.speed_limits.max_execution_rps = settings.max_execution_speed;
     limits.speed_limits.max_execution_bps = settings.max_execution_speed_bytes;
     limits.speed_limits.timeout_before_checking_execution_speed = settings.timeout_before_checking_execution_speed;
+    limits.speed_limits.max_estimated_execution_time = settings.max_estimated_execution_time;
 
     return limits;
 }

--- a/src/QueryPipeline/ExecutionSpeedLimits.cpp
+++ b/src/QueryPipeline/ExecutionSpeedLimits.cpp
@@ -78,17 +78,17 @@ void ExecutionSpeedLimits::throttle(
                     read_bytes / elapsed_seconds,
                     min_execution_bps);
 
-            /// If the predicted execution time is longer than `max_execution_time`.
-            if (max_execution_time != 0 && total_rows_to_read && read_rows)
+            /// If the predicted execution time is longer than `max_estimated_execution_time`.
+            if (max_estimated_execution_time != 0 && total_rows_to_read && read_rows)
             {
                 double estimated_execution_time_seconds = elapsed_seconds * (static_cast<double>(total_rows_to_read) / read_rows);
 
-                if (timeout_overflow_mode == OverflowMode::THROW && estimated_execution_time_seconds > max_execution_time.totalSeconds())
+                if (timeout_overflow_mode == OverflowMode::THROW && estimated_execution_time_seconds > max_estimated_execution_time.totalSeconds())
                     throw Exception(
                         ErrorCodes::TOO_SLOW,
                         "Estimated query execution time ({} seconds) is too long. Maximum: {}. Estimated rows to process: {}",
                         estimated_execution_time_seconds,
-                        max_execution_time.totalSeconds(),
+                        max_estimated_execution_time.totalSeconds(),
                         total_rows_to_read);
             }
 

--- a/src/QueryPipeline/ExecutionSpeedLimits.h
+++ b/src/QueryPipeline/ExecutionSpeedLimits.h
@@ -21,6 +21,7 @@ public:
     size_t max_execution_bps = 0;
 
     Poco::Timespan max_execution_time = 0;
+    Poco::Timespan max_estimated_execution_time = 0;
     /// Verify that the speed is not too low after the specified time has elapsed.
     Poco::Timespan timeout_before_checking_execution_speed = 0;
 

--- a/src/QueryPipeline/RemoteQueryExecutor.cpp
+++ b/src/QueryPipeline/RemoteQueryExecutor.cpp
@@ -696,6 +696,7 @@ void RemoteQueryExecutor::sendExternalTables()
         limits.mode = LimitsMode::LIMITS_TOTAL;
         limits.speed_limits.max_execution_time = settings.max_execution_time;
         limits.timeout_overflow_mode = settings.timeout_overflow_mode;
+        limits.speed_limits.max_estimated_execution_time = settings.max_estimated_execution_time;
 
         for (size_t i = 0; i < count; ++i)
         {

--- a/tests/queries/0_stateless/02896_max_execution_time_with_break_overflow_mode.sql
+++ b/tests/queries/0_stateless/02896_max_execution_time_with_break_overflow_mode.sql
@@ -4,7 +4,10 @@
 SELECT * FROM numbers(100000000) SETTINGS max_block_size=1, max_execution_time=13, timeout_overflow_mode='break' FORMAT Null;
 
 -- Query returns an error when runtime is estimated after 10 sec of execution
-SELECT * FROM numbers(100000000) SETTINGS max_block_size=1, max_execution_time=13, timeout_overflow_mode='throw' FORMAT Null; -- { serverError TOO_SLOW }
+SELECT * FROM numbers(100000000) SETTINGS max_block_size=1, max_estimated_execution_time=13, timeout_overflow_mode='throw' FORMAT Null; -- { serverError TOO_SLOW }
+
+-- Query returns an error after timeout
+SELECT * FROM numbers(100000000) SETTINGS max_block_size=1, max_execution_time=13, timeout_overflow_mode='throw' FORMAT Null; -- { serverError TIMEOUT_EXCEEDED }
 
 -- Query returns timeout error before its full execution time is estimated
 SELECT * FROM numbers(100000000) SETTINGS max_block_size=1, max_execution_time=2, timeout_overflow_mode='throw' FORMAT Null; -- { serverError TIMEOUT_EXCEEDED }

--- a/tests/queries/0_stateless/02896_max_execution_time_with_break_overflow_mode.sql
+++ b/tests/queries/0_stateless/02896_max_execution_time_with_break_overflow_mode.sql
@@ -1,13 +1,10 @@
 -- Tags: no-fasttest
 
 -- Query stops after timeout without an error
-SELECT * FROM numbers(100000000) SETTINGS max_block_size=1, max_execution_time=13, timeout_overflow_mode='break' FORMAT Null;
+SELECT * FROM numbers(100000000) SETTINGS max_block_size=1, max_execution_time=2, timeout_overflow_mode='break' FORMAT Null;
 
--- Query returns an error when runtime is estimated after 10 sec of execution
-SELECT * FROM numbers(100000000) SETTINGS max_block_size=1, max_estimated_execution_time=13, timeout_overflow_mode='throw' FORMAT Null; -- { serverError TOO_SLOW }
-
--- Query returns an error after timeout
-SELECT * FROM numbers(100000000) SETTINGS max_block_size=1, max_execution_time=13, timeout_overflow_mode='throw' FORMAT Null; -- { serverError TIMEOUT_EXCEEDED }
+-- Query returns an error when runtime is estimated after timeout_before_checking_execution_speed passed
+SELECT * FROM numbers(100000000) SETTINGS max_block_size=1, timeout_before_checking_execution_speed=1, max_estimated_execution_time=2, timeout_overflow_mode='throw' FORMAT Null; -- { serverError TOO_SLOW }
 
 -- Query returns timeout error before its full execution time is estimated
-SELECT * FROM numbers(100000000) SETTINGS max_block_size=1, max_execution_time=2, timeout_overflow_mode='throw' FORMAT Null; -- { serverError TIMEOUT_EXCEEDED }
+SELECT * FROM numbers(100000000) SETTINGS max_block_size=1, timeout_before_checking_execution_speed=1, max_execution_time=2, timeout_overflow_mode='throw' FORMAT Null; -- { serverError TIMEOUT_EXCEEDED }


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Adding a setting `max_estimated_execution_time` to separate `max_execution_time` and `max_estimated_execution_time`.

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
Related issue https://github.com/ClickHouse/ClickHouse/issues/12169

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
