### PR TITLE
Revert "Use CH Buffer for HTTP out stream, add metrics for interfaces"

### DIFF
--- a/programs/library-bridge/LibraryBridgeHandlers.cpp
+++ b/programs/library-bridge/LibraryBridgeHandlers.cpp
@@ -2,7 +2,6 @@
 
 #include "CatBoostLibraryHandler.h"
 #include "CatBoostLibraryHandlerFactory.h"
-#include "Common/ProfileEvents.h"
 #include "ExternalDictionaryLibraryHandler.h"
 #include "ExternalDictionaryLibraryHandlerFactory.h"
 
@@ -45,7 +44,7 @@ namespace
         response.setStatusAndReason(HTTPResponse::HTTP_INTERNAL_SERVER_ERROR);
 
         if (!response.sent())
-            *response.send() << message << '\n';
+            *response.send() << message << std::endl;
 
         LOG_WARNING(&Poco::Logger::get("LibraryBridge"), fmt::runtime(message));
     }
@@ -97,7 +96,7 @@ ExternalDictionaryLibraryBridgeRequestHandler::ExternalDictionaryLibraryBridgeRe
 }
 
 
-void ExternalDictionaryLibraryBridgeRequestHandler::handleRequest(HTTPServerRequest & request, HTTPServerResponse & response, const ProfileEvents::Event & /*write_event*/)
+void ExternalDictionaryLibraryBridgeRequestHandler::handleRequest(HTTPServerRequest & request, HTTPServerResponse & response)
 {
     LOG_TRACE(log, "Request URI: {}", request.getURI());
     HTMLForm params(getContext()->getSettingsRef(), request);
@@ -385,7 +384,7 @@ ExternalDictionaryLibraryBridgeExistsHandler::ExternalDictionaryLibraryBridgeExi
 }
 
 
-void ExternalDictionaryLibraryBridgeExistsHandler::handleRequest(HTTPServerRequest & request, HTTPServerResponse & response, const ProfileEvents::Event & /*write_event*/)
+void ExternalDictionaryLibraryBridgeExistsHandler::handleRequest(HTTPServerRequest & request, HTTPServerResponse & response)
 {
     try
     {
@@ -424,7 +423,7 @@ CatBoostLibraryBridgeRequestHandler::CatBoostLibraryBridgeRequestHandler(
 }
 
 
-void CatBoostLibraryBridgeRequestHandler::handleRequest(HTTPServerRequest & request, HTTPServerResponse & response, const ProfileEvents::Event & /*write_event*/)
+void CatBoostLibraryBridgeRequestHandler::handleRequest(HTTPServerRequest & request, HTTPServerResponse & response)
 {
     LOG_TRACE(log, "Request URI: {}", request.getURI());
     HTMLForm params(getContext()->getSettingsRef(), request);
@@ -622,7 +621,7 @@ CatBoostLibraryBridgeExistsHandler::CatBoostLibraryBridgeExistsHandler(size_t ke
 }
 
 
-void CatBoostLibraryBridgeExistsHandler::handleRequest(HTTPServerRequest & request, HTTPServerResponse & response, const ProfileEvents::Event & /*write_event*/)
+void CatBoostLibraryBridgeExistsHandler::handleRequest(HTTPServerRequest & request, HTTPServerResponse & response)
 {
     try
     {

--- a/programs/library-bridge/LibraryBridgeHandlers.h
+++ b/programs/library-bridge/LibraryBridgeHandlers.h
@@ -20,7 +20,7 @@ class ExternalDictionaryLibraryBridgeRequestHandler : public HTTPRequestHandler,
 public:
     ExternalDictionaryLibraryBridgeRequestHandler(size_t keep_alive_timeout_, ContextPtr context_);
 
-    void handleRequest(HTTPServerRequest & request, HTTPServerResponse & response, const ProfileEvents::Event & write_event) override;
+    void handleRequest(HTTPServerRequest & request, HTTPServerResponse & response) override;
 
 private:
     static constexpr inline auto FORMAT = "RowBinary";
@@ -36,7 +36,7 @@ class ExternalDictionaryLibraryBridgeExistsHandler : public HTTPRequestHandler, 
 public:
     ExternalDictionaryLibraryBridgeExistsHandler(size_t keep_alive_timeout_, ContextPtr context_);
 
-    void handleRequest(HTTPServerRequest & request, HTTPServerResponse & response, const ProfileEvents::Event & write_event) override;
+    void handleRequest(HTTPServerRequest & request, HTTPServerResponse & response) override;
 
 private:
     const size_t keep_alive_timeout;
@@ -65,7 +65,7 @@ class CatBoostLibraryBridgeRequestHandler : public HTTPRequestHandler, WithConte
 public:
     CatBoostLibraryBridgeRequestHandler(size_t keep_alive_timeout_, ContextPtr context_);
 
-    void handleRequest(HTTPServerRequest & request, HTTPServerResponse & response, const ProfileEvents::Event & write_event) override;
+    void handleRequest(HTTPServerRequest & request, HTTPServerResponse & response) override;
 
 private:
     const size_t keep_alive_timeout;
@@ -79,7 +79,7 @@ class CatBoostLibraryBridgeExistsHandler : public HTTPRequestHandler, WithContex
 public:
     CatBoostLibraryBridgeExistsHandler(size_t keep_alive_timeout_, ContextPtr context_);
 
-    void handleRequest(HTTPServerRequest & request, HTTPServerResponse & response, const ProfileEvents::Event & write_event) override;
+    void handleRequest(HTTPServerRequest & request, HTTPServerResponse & response) override;
 
 private:
     const size_t keep_alive_timeout;

--- a/programs/odbc-bridge/ColumnInfoHandler.cpp
+++ b/programs/odbc-bridge/ColumnInfoHandler.cpp
@@ -69,7 +69,7 @@ namespace
 }
 
 
-void ODBCColumnsInfoHandler::handleRequest(HTTPServerRequest & request, HTTPServerResponse & response, const ProfileEvents::Event & /*write_event*/)
+void ODBCColumnsInfoHandler::handleRequest(HTTPServerRequest & request, HTTPServerResponse & response)
 {
     HTMLForm params(getContext()->getSettingsRef(), request, request.getStream());
     LOG_TRACE(log, "Request URI: {}", request.getURI());
@@ -78,7 +78,7 @@ void ODBCColumnsInfoHandler::handleRequest(HTTPServerRequest & request, HTTPServ
     {
         response.setStatusAndReason(Poco::Net::HTTPResponse::HTTP_INTERNAL_SERVER_ERROR);
         if (!response.sent())
-            *response.send() << message << '\n';
+            *response.send() << message << std::endl;
         LOG_WARNING(log, fmt::runtime(message));
     };
 

--- a/programs/odbc-bridge/ColumnInfoHandler.h
+++ b/programs/odbc-bridge/ColumnInfoHandler.h
@@ -23,7 +23,7 @@ public:
     {
     }
 
-    void handleRequest(HTTPServerRequest & request, HTTPServerResponse & response, const ProfileEvents::Event & write_event) override;
+    void handleRequest(HTTPServerRequest & request, HTTPServerResponse & response) override;
 
 private:
     Poco::Logger * log;

--- a/programs/odbc-bridge/IdentifierQuoteHandler.cpp
+++ b/programs/odbc-bridge/IdentifierQuoteHandler.cpp
@@ -21,7 +21,7 @@
 
 namespace DB
 {
-void IdentifierQuoteHandler::handleRequest(HTTPServerRequest & request, HTTPServerResponse & response, const ProfileEvents::Event & /*write_event*/)
+void IdentifierQuoteHandler::handleRequest(HTTPServerRequest & request, HTTPServerResponse & response)
 {
     HTMLForm params(getContext()->getSettingsRef(), request, request.getStream());
     LOG_TRACE(log, "Request URI: {}", request.getURI());
@@ -30,7 +30,7 @@ void IdentifierQuoteHandler::handleRequest(HTTPServerRequest & request, HTTPServ
     {
         response.setStatusAndReason(Poco::Net::HTTPResponse::HTTP_INTERNAL_SERVER_ERROR);
         if (!response.sent())
-            response.send()->writeln(message);
+            *response.send() << message << std::endl;
         LOG_WARNING(log, fmt::runtime(message));
     };
 

--- a/programs/odbc-bridge/IdentifierQuoteHandler.h
+++ b/programs/odbc-bridge/IdentifierQuoteHandler.h
@@ -21,7 +21,7 @@ public:
     {
     }
 
-    void handleRequest(HTTPServerRequest & request, HTTPServerResponse & response, const ProfileEvents::Event & write_event) override;
+    void handleRequest(HTTPServerRequest & request, HTTPServerResponse & response) override;
 
 private:
     Poco::Logger * log;

--- a/programs/odbc-bridge/MainHandler.cpp
+++ b/programs/odbc-bridge/MainHandler.cpp
@@ -46,12 +46,12 @@ void ODBCHandler::processError(HTTPServerResponse & response, const std::string 
 {
     response.setStatusAndReason(HTTPResponse::HTTP_INTERNAL_SERVER_ERROR);
     if (!response.sent())
-        *response.send() << message << '\n';
+        *response.send() << message << std::endl;
     LOG_WARNING(log, fmt::runtime(message));
 }
 
 
-void ODBCHandler::handleRequest(HTTPServerRequest & request, HTTPServerResponse & response, const ProfileEvents::Event & /*write_event*/)
+void ODBCHandler::handleRequest(HTTPServerRequest & request, HTTPServerResponse & response)
 {
     HTMLForm params(getContext()->getSettingsRef(), request);
     LOG_TRACE(log, "Request URI: {}", request.getURI());

--- a/programs/odbc-bridge/MainHandler.h
+++ b/programs/odbc-bridge/MainHandler.h
@@ -30,7 +30,7 @@ public:
     {
     }
 
-    void handleRequest(HTTPServerRequest & request, HTTPServerResponse & response, const ProfileEvents::Event & write_event) override;
+    void handleRequest(HTTPServerRequest & request, HTTPServerResponse & response) override;
 
 private:
     Poco::Logger * log;

--- a/programs/odbc-bridge/PingHandler.cpp
+++ b/programs/odbc-bridge/PingHandler.cpp
@@ -6,7 +6,7 @@
 
 namespace DB
 {
-void PingHandler::handleRequest(HTTPServerRequest & /* request */, HTTPServerResponse & response, const ProfileEvents::Event & /*write_event*/)
+void PingHandler::handleRequest(HTTPServerRequest & /* request */, HTTPServerResponse & response)
 {
     try
     {

--- a/programs/odbc-bridge/PingHandler.h
+++ b/programs/odbc-bridge/PingHandler.h
@@ -10,7 +10,7 @@ class PingHandler : public HTTPRequestHandler
 {
 public:
     explicit PingHandler(size_t keep_alive_timeout_) : keep_alive_timeout(keep_alive_timeout_) {}
-    void handleRequest(HTTPServerRequest & request, HTTPServerResponse & response, const ProfileEvents::Event & write_event) override;
+    void handleRequest(HTTPServerRequest & request, HTTPServerResponse & response) override;
 
 private:
     size_t keep_alive_timeout;

--- a/programs/odbc-bridge/SchemaAllowedHandler.cpp
+++ b/programs/odbc-bridge/SchemaAllowedHandler.cpp
@@ -29,7 +29,7 @@ namespace
 }
 
 
-void SchemaAllowedHandler::handleRequest(HTTPServerRequest & request, HTTPServerResponse & response, const ProfileEvents::Event & /*write_event*/)
+void SchemaAllowedHandler::handleRequest(HTTPServerRequest & request, HTTPServerResponse & response)
 {
     HTMLForm params(getContext()->getSettingsRef(), request, request.getStream());
     LOG_TRACE(log, "Request URI: {}", request.getURI());
@@ -38,7 +38,7 @@ void SchemaAllowedHandler::handleRequest(HTTPServerRequest & request, HTTPServer
     {
         response.setStatusAndReason(Poco::Net::HTTPResponse::HTTP_INTERNAL_SERVER_ERROR);
         if (!response.sent())
-            *response.send() << message << '\n';
+            *response.send() << message << std::endl;
         LOG_WARNING(log, fmt::runtime(message));
     };
 

--- a/programs/odbc-bridge/SchemaAllowedHandler.h
+++ b/programs/odbc-bridge/SchemaAllowedHandler.h
@@ -24,7 +24,7 @@ public:
     {
     }
 
-    void handleRequest(HTTPServerRequest & request, HTTPServerResponse & response, const ProfileEvents::Event & write_event) override;
+    void handleRequest(HTTPServerRequest & request, HTTPServerResponse & response) override;
 
 private:
     Poco::Logger * log;

--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -152,18 +152,6 @@ namespace ProfileEvents
 {
     extern const Event MainConfigLoads;
     extern const Event ServerStartupMilliseconds;
-    extern const Event InterfaceNativeSendBytes;
-    extern const Event InterfaceNativeReceiveBytes;
-    extern const Event InterfaceHTTPSendBytes;
-    extern const Event InterfaceHTTPReceiveBytes;
-    extern const Event InterfacePrometheusSendBytes;
-    extern const Event InterfacePrometheusReceiveBytes;
-    extern const Event InterfaceInterserverSendBytes;
-    extern const Event InterfaceInterserverReceiveBytes;
-    extern const Event InterfaceMySQLSendBytes;
-    extern const Event InterfaceMySQLReceiveBytes;
-    extern const Event InterfacePostgreSQLSendBytes;
-    extern const Event InterfacePostgreSQLReceiveBytes;
 }
 
 namespace fs = std::filesystem;
@@ -2059,7 +2047,7 @@ std::unique_ptr<TCPProtocolStackFactory> Server::buildProtocolStackFromConfig(
     auto create_factory = [&](const std::string & type, const std::string & conf_name) -> TCPServerConnectionFactory::Ptr
     {
         if (type == "tcp")
-            return TCPServerConnectionFactory::Ptr(new TCPHandlerFactory(*this, false, false, ProfileEvents::InterfaceNativeReceiveBytes, ProfileEvents::InterfaceNativeSendBytes));
+            return TCPServerConnectionFactory::Ptr(new TCPHandlerFactory(*this, false, false));
 
         if (type == "tls")
 #if USE_SSL
@@ -2071,20 +2059,20 @@ std::unique_ptr<TCPProtocolStackFactory> Server::buildProtocolStackFromConfig(
         if (type == "proxy1")
             return TCPServerConnectionFactory::Ptr(new ProxyV1HandlerFactory(*this, conf_name));
         if (type == "mysql")
-            return TCPServerConnectionFactory::Ptr(new MySQLHandlerFactory(*this, ProfileEvents::InterfaceMySQLReceiveBytes, ProfileEvents::InterfaceMySQLSendBytes));
+            return TCPServerConnectionFactory::Ptr(new MySQLHandlerFactory(*this));
         if (type == "postgres")
-            return TCPServerConnectionFactory::Ptr(new PostgreSQLHandlerFactory(*this, ProfileEvents::InterfacePostgreSQLReceiveBytes, ProfileEvents::InterfacePostgreSQLSendBytes));
+            return TCPServerConnectionFactory::Ptr(new PostgreSQLHandlerFactory(*this));
         if (type == "http")
             return TCPServerConnectionFactory::Ptr(
-                new HTTPServerConnectionFactory(httpContext(), http_params, createHandlerFactory(*this, config, async_metrics, "HTTPHandler-factory"), ProfileEvents::InterfaceHTTPReceiveBytes, ProfileEvents::InterfaceHTTPSendBytes)
+                new HTTPServerConnectionFactory(httpContext(), http_params, createHandlerFactory(*this, config, async_metrics, "HTTPHandler-factory"))
             );
         if (type == "prometheus")
             return TCPServerConnectionFactory::Ptr(
-                new HTTPServerConnectionFactory(httpContext(), http_params, createHandlerFactory(*this, config, async_metrics, "PrometheusHandler-factory"), ProfileEvents::InterfacePrometheusReceiveBytes, ProfileEvents::InterfacePrometheusSendBytes)
+                new HTTPServerConnectionFactory(httpContext(), http_params, createHandlerFactory(*this, config, async_metrics, "PrometheusHandler-factory"))
             );
         if (type == "interserver")
             return TCPServerConnectionFactory::Ptr(
-                new HTTPServerConnectionFactory(httpContext(), http_params, createHandlerFactory(*this, config, async_metrics, "InterserverIOHTTPHandler-factory"), ProfileEvents::InterfaceInterserverReceiveBytes, ProfileEvents::InterfaceInterserverSendBytes)
+                new HTTPServerConnectionFactory(httpContext(), http_params, createHandlerFactory(*this, config, async_metrics, "InterserverIOHTTPHandler-factory"))
             );
 
         throw Exception(ErrorCodes::INVALID_CONFIG_PARAMETER, "Protocol configuration error, unknown protocol name '{}'", type);
@@ -2217,7 +2205,7 @@ void Server::createServers(
                     port_name,
                     "http://" + address.toString(),
                     std::make_unique<HTTPServer>(
-                        httpContext(), createHandlerFactory(*this, config, async_metrics, "HTTPHandler-factory"), server_pool, socket, http_params, ProfileEvents::InterfaceHTTPReceiveBytes, ProfileEvents::InterfaceHTTPSendBytes));
+                        httpContext(), createHandlerFactory(*this, config, async_metrics, "HTTPHandler-factory"), server_pool, socket, http_params));
             });
         }
 
@@ -2237,7 +2225,7 @@ void Server::createServers(
                     port_name,
                     "https://" + address.toString(),
                     std::make_unique<HTTPServer>(
-                        httpContext(), createHandlerFactory(*this, config, async_metrics, "HTTPSHandler-factory"), server_pool, socket, http_params, ProfileEvents::InterfaceHTTPReceiveBytes, ProfileEvents::InterfaceHTTPSendBytes));
+                        httpContext(), createHandlerFactory(*this, config, async_metrics, "HTTPSHandler-factory"), server_pool, socket, http_params));
 #else
                 UNUSED(port);
                 throw Exception(ErrorCodes::SUPPORT_IS_DISABLED, "HTTPS protocol is disabled because Poco library was built without NetSSL support.");
@@ -2260,7 +2248,7 @@ void Server::createServers(
                     port_name,
                     "native protocol (tcp): " + address.toString(),
                     std::make_unique<TCPServer>(
-                        new TCPHandlerFactory(*this, /* secure */ false, /* proxy protocol */ false, ProfileEvents::InterfaceNativeReceiveBytes, ProfileEvents::InterfaceNativeSendBytes),
+                        new TCPHandlerFactory(*this, /* secure */ false, /* proxy protocol */ false),
                         server_pool,
                         socket,
                         new Poco::Net::TCPServerParams));
@@ -2282,7 +2270,7 @@ void Server::createServers(
                     port_name,
                     "native protocol (tcp) with PROXY: " + address.toString(),
                     std::make_unique<TCPServer>(
-                        new TCPHandlerFactory(*this, /* secure */ false, /* proxy protocol */ true, ProfileEvents::InterfaceNativeReceiveBytes, ProfileEvents::InterfaceNativeSendBytes),
+                        new TCPHandlerFactory(*this, /* secure */ false, /* proxy protocol */ true),
                         server_pool,
                         socket,
                         new Poco::Net::TCPServerParams));
@@ -2305,7 +2293,7 @@ void Server::createServers(
                     port_name,
                     "secure native protocol (tcp_secure): " + address.toString(),
                     std::make_unique<TCPServer>(
-                        new TCPHandlerFactory(*this, /* secure */ true, /* proxy protocol */ false, ProfileEvents::InterfaceNativeReceiveBytes, ProfileEvents::InterfaceNativeSendBytes),
+                        new TCPHandlerFactory(*this, /* secure */ true, /* proxy protocol */ false),
                         server_pool,
                         socket,
                         new Poco::Net::TCPServerParams));
@@ -2329,7 +2317,7 @@ void Server::createServers(
                     listen_host,
                     port_name,
                     "MySQL compatibility protocol: " + address.toString(),
-                    std::make_unique<TCPServer>(new MySQLHandlerFactory(*this, ProfileEvents::InterfaceMySQLReceiveBytes, ProfileEvents::InterfaceMySQLSendBytes), server_pool, socket, new Poco::Net::TCPServerParams));
+                    std::make_unique<TCPServer>(new MySQLHandlerFactory(*this), server_pool, socket, new Poco::Net::TCPServerParams));
             });
         }
 
@@ -2346,7 +2334,7 @@ void Server::createServers(
                     listen_host,
                     port_name,
                     "PostgreSQL compatibility protocol: " + address.toString(),
-                    std::make_unique<TCPServer>(new PostgreSQLHandlerFactory(*this, ProfileEvents::InterfacePostgreSQLReceiveBytes, ProfileEvents::InterfacePostgreSQLSendBytes), server_pool, socket, new Poco::Net::TCPServerParams));
+                    std::make_unique<TCPServer>(new PostgreSQLHandlerFactory(*this), server_pool, socket, new Poco::Net::TCPServerParams));
             });
         }
 
@@ -2380,7 +2368,7 @@ void Server::createServers(
                     port_name,
                     "Prometheus: http://" + address.toString(),
                     std::make_unique<HTTPServer>(
-                        httpContext(), createHandlerFactory(*this, config, async_metrics, "PrometheusHandler-factory"), server_pool, socket, http_params, ProfileEvents::InterfacePrometheusReceiveBytes, ProfileEvents::InterfacePrometheusSendBytes));
+                        httpContext(), createHandlerFactory(*this, config, async_metrics, "PrometheusHandler-factory"), server_pool, socket, http_params));
             });
         }
     }
@@ -2426,9 +2414,7 @@ void Server::createInterserverServers(
                         createHandlerFactory(*this, config, async_metrics, "InterserverIOHTTPHandler-factory"),
                         server_pool,
                         socket,
-                        http_params,
-                        ProfileEvents::InterfaceInterserverReceiveBytes,
-                        ProfileEvents::InterfaceInterserverSendBytes));
+                        http_params));
             });
         }
 
@@ -2451,9 +2437,7 @@ void Server::createInterserverServers(
                         createHandlerFactory(*this, config, async_metrics, "InterserverIOHTTPSHandler-factory"),
                         server_pool,
                         socket,
-                        http_params,
-                        ProfileEvents::InterfaceInterserverReceiveBytes,
-                        ProfileEvents::InterfaceInterserverSendBytes));
+                        http_params));
 #else
                 UNUSED(port);
                 throw Exception(ErrorCodes::SUPPORT_IS_DISABLED, "SSL support for TCP protocol is disabled because Poco library was built without NetSSL support.");

--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -587,19 +587,6 @@ The server successfully detected this situation and will download merged part fr
     M(LogError, "Number of log messages with level Error") \
     M(LogFatal, "Number of log messages with level Fatal") \
     \
-    M(InterfaceHTTPSendBytes, "Number of bytes sent through HTTP interfaces") \
-    M(InterfaceHTTPReceiveBytes, "Number of bytes received through HTTP interfaces") \
-    M(InterfaceNativeSendBytes, "Number of bytes sent through native interfaces") \
-    M(InterfaceNativeReceiveBytes, "Number of bytes received through native interfaces") \
-    M(InterfacePrometheusSendBytes, "Number of bytes sent through Prometheus interfaces") \
-    M(InterfacePrometheusReceiveBytes, "Number of bytes received through Prometheus interfaces") \
-    M(InterfaceInterserverSendBytes, "Number of bytes sent through interserver interfaces") \
-    M(InterfaceInterserverReceiveBytes, "Number of bytes received through interserver interfaces") \
-    M(InterfaceMySQLSendBytes, "Number of bytes sent through MySQL interfaces") \
-    M(InterfaceMySQLReceiveBytes, "Number of bytes received through MySQL interfaces") \
-    M(InterfacePostgreSQLSendBytes, "Number of bytes sent through PostgreSQL interfaces") \
-    M(InterfacePostgreSQLReceiveBytes, "Number of bytes received through PostgreSQL interfaces") \
-    \
     M(ParallelReplicasUsedCount, "Number of replicas used to execute a query with task-based parallel replicas") \
 
 #ifdef APPLY_FOR_EXTERNAL_EVENTS

--- a/src/IO/BrotliWriteBuffer.cpp
+++ b/src/IO/BrotliWriteBuffer.cpp
@@ -13,14 +13,33 @@ namespace ErrorCodes
 }
 
 
-BrotliWriteBuffer::BrotliStateWrapper::BrotliStateWrapper()
-: state(BrotliEncoderCreateInstance(nullptr, nullptr, nullptr))
+class BrotliWriteBuffer::BrotliStateWrapper
 {
-}
+public:
+    BrotliStateWrapper()
+    : state(BrotliEncoderCreateInstance(nullptr, nullptr, nullptr))
+    {
+    }
 
-BrotliWriteBuffer::BrotliStateWrapper::~BrotliStateWrapper()
+    ~BrotliStateWrapper()
+    {
+        BrotliEncoderDestroyInstance(state);
+    }
+
+    BrotliEncoderState * state;
+};
+
+BrotliWriteBuffer::BrotliWriteBuffer(std::unique_ptr<WriteBuffer> out_, int compression_level, size_t buf_size, char * existing_memory, size_t alignment)
+    : WriteBufferWithOwnMemoryDecorator(std::move(out_), buf_size, existing_memory, alignment)
+    , brotli(std::make_unique<BrotliStateWrapper>())
+    , in_available(0)
+    , in_data(nullptr)
+    , out_capacity(0)
+    , out_data(nullptr)
 {
-    BrotliEncoderDestroyInstance(state);
+    BrotliEncoderSetParameter(brotli->state, BROTLI_PARAM_QUALITY, static_cast<uint32_t>(compression_level));
+    // Set LZ77 window size. According to brotli sources default value is 24 (c/tools/brotli.c:81)
+    BrotliEncoderSetParameter(brotli->state, BROTLI_PARAM_LGWIN, 24);
 }
 
 BrotliWriteBuffer::~BrotliWriteBuffer() = default;
@@ -39,20 +58,18 @@ void BrotliWriteBuffer::nextImpl()
     {
         do
         {
-            const auto * in_data_ptr = in_data;
             out->nextIfAtEnd();
             out_data = reinterpret_cast<unsigned char *>(out->position());
             out_capacity = out->buffer().end() - out->position();
 
             int result = BrotliEncoderCompressStream(
                     brotli->state,
-                    BROTLI_OPERATION_PROCESS,
+                    in_available ? BROTLI_OPERATION_PROCESS : BROTLI_OPERATION_FINISH,
                     &in_available,
                     &in_data,
                     &out_capacity,
                     &out_data,
                     nullptr);
-            total_in += in_data - in_data_ptr;
 
             out->position() = out->buffer().end() - out_capacity;
 
@@ -74,10 +91,6 @@ void BrotliWriteBuffer::nextImpl()
 void BrotliWriteBuffer::finalizeBefore()
 {
     next();
-
-    /// Don't write out if no data was ever compressed
-    if (!compress_empty && total_in == 0)
-        return;
 
     while (true)
     {

--- a/src/IO/BrotliWriteBuffer.h
+++ b/src/IO/BrotliWriteBuffer.h
@@ -4,38 +4,18 @@
 #include <IO/BufferWithOwnMemory.h>
 #include <IO/WriteBufferDecorator.h>
 
-#include "config.h"
-
-#if USE_BROTLI
-#    include <brotli/encode.h>
-
 namespace DB
 {
-
 
 class BrotliWriteBuffer : public WriteBufferWithOwnMemoryDecorator
 {
 public:
-    template<typename WriteBufferT>
     BrotliWriteBuffer(
-        WriteBufferT && out_,
+        std::unique_ptr<WriteBuffer> out_,
         int compression_level,
         size_t buf_size = DBMS_DEFAULT_BUFFER_SIZE,
         char * existing_memory = nullptr,
-        size_t alignment = 0,
-        bool compress_empty_ = true)
-    : WriteBufferWithOwnMemoryDecorator(std::move(out_), buf_size, existing_memory, alignment)
-    , brotli(std::make_unique<BrotliStateWrapper>())
-    , in_available(0)
-    , in_data(nullptr)
-    , out_capacity(0)
-    , out_data(nullptr)
-    , compress_empty(compress_empty_)
-    {
-        BrotliEncoderSetParameter(brotli->state, BROTLI_PARAM_QUALITY, static_cast<uint32_t>(compression_level));
-        // Set LZ77 window size. According to brotli sources default value is 24 (c/tools/brotli.c:81)
-        BrotliEncoderSetParameter(brotli->state, BROTLI_PARAM_LGWIN, 24);
-    }
+        size_t alignment = 0);
 
     ~BrotliWriteBuffer() override;
 
@@ -44,15 +24,7 @@ private:
 
     void finalizeBefore() override;
 
-    class BrotliStateWrapper
-    {
-    public:
-        BrotliStateWrapper();
-        ~BrotliStateWrapper();
-
-        BrotliEncoderState * state;
-    };
-
+    class BrotliStateWrapper;
     std::unique_ptr<BrotliStateWrapper> brotli;
 
 
@@ -61,12 +33,6 @@ private:
 
     size_t out_capacity;
     uint8_t * out_data;
-
-protected:
-    UInt64 total_in = 0;
-    bool compress_empty = true;
 };
 
 }
-
-#endif

--- a/src/IO/BufferBase.h
+++ b/src/IO/BufferBase.h
@@ -2,7 +2,6 @@
 
 #include <Core/Defines.h>
 #include <algorithm>
-#include <memory>
 
 
 namespace DB

--- a/src/IO/Bzip2WriteBuffer.cpp
+++ b/src/IO/Bzip2WriteBuffer.cpp
@@ -15,22 +15,34 @@ namespace ErrorCodes
 }
 
 
-Bzip2WriteBuffer::Bzip2StateWrapper::Bzip2StateWrapper(int compression_level)
+class Bzip2WriteBuffer::Bzip2StateWrapper
 {
-    memset(&stream, 0, sizeof(stream));
+public:
+    explicit Bzip2StateWrapper(int compression_level)
+    {
+        memset(&stream, 0, sizeof(stream));
 
-    int ret = BZ2_bzCompressInit(&stream, compression_level, 0, 0);
+        int ret = BZ2_bzCompressInit(&stream, compression_level, 0, 0);
 
-    if (ret != BZ_OK)
-        throw Exception(
-            ErrorCodes::BZIP2_STREAM_ENCODER_FAILED,
-            "bzip2 stream encoder init failed: error code: {}",
-            ret);
-}
+        if (ret != BZ_OK)
+            throw Exception(
+                ErrorCodes::BZIP2_STREAM_ENCODER_FAILED,
+                "bzip2 stream encoder init failed: error code: {}",
+                ret);
+    }
 
-Bzip2WriteBuffer::Bzip2StateWrapper::~Bzip2StateWrapper()
+    ~Bzip2StateWrapper()
+    {
+        BZ2_bzCompressEnd(&stream);
+    }
+
+    bz_stream stream;
+};
+
+Bzip2WriteBuffer::Bzip2WriteBuffer(std::unique_ptr<WriteBuffer> out_, int compression_level, size_t buf_size, char * existing_memory, size_t alignment)
+    : WriteBufferWithOwnMemoryDecorator(std::move(out_), buf_size, existing_memory, alignment)
+    , bz(std::make_unique<Bzip2StateWrapper>(compression_level))
 {
-    BZ2_bzCompressEnd(&stream);
 }
 
 Bzip2WriteBuffer::~Bzip2WriteBuffer() = default;
@@ -65,8 +77,6 @@ void Bzip2WriteBuffer::nextImpl()
 
         }
         while (bz->stream.avail_in > 0);
-
-        total_in += offset();
     }
     catch (...)
     {
@@ -79,10 +89,6 @@ void Bzip2WriteBuffer::nextImpl()
 void Bzip2WriteBuffer::finalizeBefore()
 {
     next();
-
-    /// Don't write out if no data was ever compressed
-    if (!compress_empty && total_in == 0)
-        return;
 
     out->nextIfAtEnd();
     bz->stream.next_out = out->position();

--- a/src/IO/Bzip2WriteBuffer.h
+++ b/src/IO/Bzip2WriteBuffer.h
@@ -4,29 +4,18 @@
 #include <IO/BufferWithOwnMemory.h>
 #include <IO/WriteBufferDecorator.h>
 
-#include "config.h"
-
-#if USE_BZIP2
-#    include <bzlib.h>
-
 namespace DB
 {
 
 class Bzip2WriteBuffer : public WriteBufferWithOwnMemoryDecorator
 {
 public:
-    template<typename WriteBufferT>
     Bzip2WriteBuffer(
-        WriteBufferT && out_,
+        std::unique_ptr<WriteBuffer> out_,
         int compression_level,
         size_t buf_size = DBMS_DEFAULT_BUFFER_SIZE,
         char * existing_memory = nullptr,
-        size_t alignment = 0,
-        bool compress_empty_ = true)
-    : WriteBufferWithOwnMemoryDecorator(std::move(out_), buf_size, existing_memory, alignment), bz(std::make_unique<Bzip2StateWrapper>(compression_level))
-    , compress_empty(compress_empty_)
-    {
-    }
+        size_t alignment = 0);
 
     ~Bzip2WriteBuffer() override;
 
@@ -35,20 +24,8 @@ private:
 
     void finalizeBefore() override;
 
-    class Bzip2StateWrapper
-    {
-    public:
-        explicit Bzip2StateWrapper(int compression_level);
-        ~Bzip2StateWrapper();
-
-        bz_stream stream;
-    };
-
+    class Bzip2StateWrapper;
     std::unique_ptr<Bzip2StateWrapper> bz;
-    bool compress_empty = true;
-    UInt64 total_in = 0;
 };
 
 }
-
-#endif

--- a/src/IO/CompressionMethod.cpp
+++ b/src/IO/CompressionMethod.cpp
@@ -169,66 +169,37 @@ std::unique_ptr<ReadBuffer> wrapReadBufferWithCompressionMethod(
     return createCompressedWrapper(std::move(nested), method, buf_size, existing_memory, alignment, zstd_window_log_max);
 }
 
-
-template<typename WriteBufferT>
-std::unique_ptr<WriteBuffer> createWriteCompressedWrapper(
-    WriteBufferT && nested, CompressionMethod method, int level, size_t buf_size, char * existing_memory, size_t alignment, bool compress_empty)
+std::unique_ptr<WriteBuffer> wrapWriteBufferWithCompressionMethod(
+    std::unique_ptr<WriteBuffer> nested, CompressionMethod method, int level, size_t buf_size, char * existing_memory, size_t alignment)
 {
     if (method == DB::CompressionMethod::Gzip || method == CompressionMethod::Zlib)
-        return std::make_unique<ZlibDeflatingWriteBuffer>(std::forward<WriteBufferT>(nested), method, level, buf_size, existing_memory, alignment, compress_empty);
+        return std::make_unique<ZlibDeflatingWriteBuffer>(std::move(nested), method, level, buf_size, existing_memory, alignment);
 
 #if USE_BROTLI
     if (method == DB::CompressionMethod::Brotli)
-        return std::make_unique<BrotliWriteBuffer>(std::forward<WriteBufferT>(nested), level, buf_size, existing_memory, alignment, compress_empty);
+        return std::make_unique<BrotliWriteBuffer>(std::move(nested), level, buf_size, existing_memory, alignment);
 #endif
     if (method == CompressionMethod::Xz)
-        return std::make_unique<LZMADeflatingWriteBuffer>(std::forward<WriteBufferT>(nested), level, buf_size, existing_memory, alignment, compress_empty);
+        return std::make_unique<LZMADeflatingWriteBuffer>(std::move(nested), level, buf_size, existing_memory, alignment);
 
     if (method == CompressionMethod::Zstd)
-        return std::make_unique<ZstdDeflatingWriteBuffer>(std::forward<WriteBufferT>(nested), level, buf_size, existing_memory, alignment, compress_empty);
+        return std::make_unique<ZstdDeflatingWriteBuffer>(std::move(nested), level, buf_size, existing_memory, alignment);
 
     if (method == CompressionMethod::Lz4)
-        return std::make_unique<Lz4DeflatingWriteBuffer>(std::forward<WriteBufferT>(nested), level, buf_size, existing_memory, alignment, compress_empty);
+        return std::make_unique<Lz4DeflatingWriteBuffer>(std::move(nested), level, buf_size, existing_memory, alignment);
 
 #if USE_BZIP2
     if (method == CompressionMethod::Bzip2)
-        return std::make_unique<Bzip2WriteBuffer>(std::forward<WriteBufferT>(nested), level, buf_size, existing_memory, alignment, compress_empty);
+        return std::make_unique<Bzip2WriteBuffer>(std::move(nested), level, buf_size, existing_memory, alignment);
 #endif
 #if USE_SNAPPY
     if (method == CompressionMethod::Snappy)
         throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Unsupported compression method");
 #endif
-
-    throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Unsupported compression method");
-}
-
-
-std::unique_ptr<WriteBuffer> wrapWriteBufferWithCompressionMethod(
-    std::unique_ptr<WriteBuffer> nested,
-    CompressionMethod method,
-    int level,
-    size_t buf_size,
-    char * existing_memory,
-    size_t alignment,
-    bool compress_empty)
-{
     if (method == CompressionMethod::None)
         return nested;
-    return createWriteCompressedWrapper(nested, method, level, buf_size, existing_memory, alignment, compress_empty);
-}
 
-
-std::unique_ptr<WriteBuffer> wrapWriteBufferWithCompressionMethod(
-    WriteBuffer * nested,
-    CompressionMethod method,
-    int level,
-    size_t buf_size,
-    char * existing_memory,
-    size_t alignment,
-    bool compress_empty)
-{
-    assert(method != CompressionMethod::None);
-    return createWriteCompressedWrapper(nested, method, level, buf_size, existing_memory, alignment, compress_empty);
+    throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Unsupported compression method");
 }
 
 }

--- a/src/IO/CompressionMethod.h
+++ b/src/IO/CompressionMethod.h
@@ -61,22 +61,13 @@ std::unique_ptr<ReadBuffer> wrapReadBufferWithCompressionMethod(
     char * existing_memory = nullptr,
     size_t alignment = 0);
 
+
 std::unique_ptr<WriteBuffer> wrapWriteBufferWithCompressionMethod(
     std::unique_ptr<WriteBuffer> nested,
     CompressionMethod method,
     int level,
     size_t buf_size = DBMS_DEFAULT_BUFFER_SIZE,
     char * existing_memory = nullptr,
-    size_t alignment = 0,
-    bool compress_empty = true);
-
-std::unique_ptr<WriteBuffer> wrapWriteBufferWithCompressionMethod(
-    WriteBuffer * nested,
-    CompressionMethod method,
-    int level,
-    size_t buf_size = DBMS_DEFAULT_BUFFER_SIZE,
-    char * existing_memory = nullptr,
-    size_t alignment = 0,
-    bool compress_empty = true);
+    size_t alignment = 0);
 
 }

--- a/src/IO/LZMADeflatingWriteBuffer.cpp
+++ b/src/IO/LZMADeflatingWriteBuffer.cpp
@@ -7,7 +7,9 @@ namespace ErrorCodes
     extern const int LZMA_STREAM_ENCODER_FAILED;
 }
 
-void LZMADeflatingWriteBuffer::initialize(int compression_level)
+LZMADeflatingWriteBuffer::LZMADeflatingWriteBuffer(
+    std::unique_ptr<WriteBuffer> out_, int compression_level, size_t buf_size, char * existing_memory, size_t alignment)
+    : WriteBufferWithOwnMemoryDecorator(std::move(out_), buf_size, existing_memory, alignment)
 {
 
     lstr = LZMA_STREAM_INIT;
@@ -91,10 +93,6 @@ void LZMADeflatingWriteBuffer::nextImpl()
 void LZMADeflatingWriteBuffer::finalizeBefore()
 {
     next();
-
-    /// Don't write out if no data was ever compressed
-    if (!compress_empty && lstr.total_out == 0)
-        return;
 
     do
     {

--- a/src/IO/LZMADeflatingWriteBuffer.h
+++ b/src/IO/LZMADeflatingWriteBuffer.h
@@ -14,32 +14,22 @@ namespace DB
 class LZMADeflatingWriteBuffer : public WriteBufferWithOwnMemoryDecorator
 {
 public:
-    template<typename WriteBufferT>
     LZMADeflatingWriteBuffer(
-        WriteBufferT && out_,
+        std::unique_ptr<WriteBuffer> out_,
         int compression_level,
         size_t buf_size = DBMS_DEFAULT_BUFFER_SIZE,
         char * existing_memory = nullptr,
-        size_t alignment = 0,
-        bool compress_empty_ = true)
-    : WriteBufferWithOwnMemoryDecorator(std::move(out_), buf_size, existing_memory, alignment), compress_empty(compress_empty_)
-    {
-        initialize(compression_level);
-    }
+        size_t alignment = 0);
 
     ~LZMADeflatingWriteBuffer() override;
 
 private:
-    void initialize(int compression_level);
-
     void nextImpl() override;
 
     void finalizeBefore() override;
     void finalizeAfter() override;
 
     lzma_stream lstr;
-
-    bool compress_empty = true;
 };
 
 }

--- a/src/IO/Lz4DeflatingWriteBuffer.cpp
+++ b/src/IO/Lz4DeflatingWriteBuffer.cpp
@@ -63,8 +63,11 @@ namespace ErrorCodes
     extern const int LZ4_ENCODER_FAILED;
 }
 
+Lz4DeflatingWriteBuffer::Lz4DeflatingWriteBuffer(
+    std::unique_ptr<WriteBuffer> out_, int compression_level, size_t buf_size, char * existing_memory, size_t alignment)
+    : WriteBufferWithOwnMemoryDecorator(std::move(out_), buf_size, existing_memory, alignment)
+    , tmp_memory(buf_size)
 
-void Lz4DeflatingWriteBuffer::initialize(int compression_level)
 {
     kPrefs = {
         {LZ4F_max256KB,
@@ -102,7 +105,7 @@ void Lz4DeflatingWriteBuffer::nextImpl()
 
     if (first_time)
     {
-        auto sink = SinkToOut(out, tmp_memory, LZ4F_HEADER_SIZE_MAX);
+        auto sink = SinkToOut(out.get(), tmp_memory, LZ4F_HEADER_SIZE_MAX);
         chassert(sink.getCapacity() >= LZ4F_HEADER_SIZE_MAX);
 
         /// write frame header and check for errors
@@ -128,7 +131,7 @@ void Lz4DeflatingWriteBuffer::nextImpl()
         /// Ensure that there is enough space for compressed block of minimal size
         size_t min_compressed_block_size = LZ4F_compressBound(1, &kPrefs);
 
-        auto sink = SinkToOut(out, tmp_memory, min_compressed_block_size);
+        auto sink = SinkToOut(out.get(), tmp_memory, min_compressed_block_size);
         chassert(sink.getCapacity() >= min_compressed_block_size);
 
         /// LZ4F_compressUpdate compresses whole input buffer at once so we need to shink it manually
@@ -160,12 +163,8 @@ void Lz4DeflatingWriteBuffer::finalizeBefore()
 {
     next();
 
-    /// Don't write out if no data was ever compressed
-    if (!compress_empty && first_time)
-        return;
-
     auto suffix_size = LZ4F_compressBound(0, &kPrefs);
-    auto sink = SinkToOut(out, tmp_memory, suffix_size);
+    auto sink = SinkToOut(out.get(), tmp_memory, suffix_size);
     chassert(sink.getCapacity() >= suffix_size);
 
     /// compression end

--- a/src/IO/Lz4DeflatingWriteBuffer.h
+++ b/src/IO/Lz4DeflatingWriteBuffer.h
@@ -14,26 +14,16 @@ namespace DB
 class Lz4DeflatingWriteBuffer : public WriteBufferWithOwnMemoryDecorator
 {
 public:
-    template<typename WriteBufferT>
     Lz4DeflatingWriteBuffer(
-        WriteBufferT && out_,
+        std::unique_ptr<WriteBuffer> out_,
         int compression_level,
         size_t buf_size = DBMS_DEFAULT_BUFFER_SIZE,
         char * existing_memory = nullptr,
-        size_t alignment = 0,
-        bool compress_empty_ = true)
-    : WriteBufferWithOwnMemoryDecorator(std::move(out_), buf_size, existing_memory, alignment)
-    , tmp_memory(buf_size)
-    , compress_empty(compress_empty_)
-    {
-        initialize(compression_level);
-    }
+        size_t alignment = 0);
 
     ~Lz4DeflatingWriteBuffer() override;
 
 private:
-    void initialize(int compression_level);
-
     void nextImpl() override;
 
     void finalizeBefore() override;
@@ -45,6 +35,5 @@ private:
     Memory<> tmp_memory;
 
     bool first_time = true;
-    bool compress_empty = true;
 };
 }

--- a/src/IO/ReadBufferFromPocoSocket.cpp
+++ b/src/IO/ReadBufferFromPocoSocket.cpp
@@ -99,9 +99,6 @@ bool ReadBufferFromPocoSocket::nextImpl()
     if (bytes_read < 0)
         throw NetException(ErrorCodes::CANNOT_READ_FROM_SOCKET, "Cannot read from socket ({})", peer_address.toString());
 
-    if (read_event != ProfileEvents::end())
-        ProfileEvents::increment(read_event, bytes_read);
-
     if (bytes_read)
         working_buffer.resize(bytes_read);
     else
@@ -114,15 +111,8 @@ ReadBufferFromPocoSocket::ReadBufferFromPocoSocket(Poco::Net::Socket & socket_, 
     : BufferWithOwnMemory<ReadBuffer>(buf_size)
     , socket(socket_)
     , peer_address(socket.peerAddress())
-    , read_event(ProfileEvents::end())
     , socket_description("socket (" + peer_address.toString() + ")")
 {
-}
-
-ReadBufferFromPocoSocket::ReadBufferFromPocoSocket(Poco::Net::Socket & socket_, const ProfileEvents::Event & read_event_, size_t buf_size)
-    : ReadBufferFromPocoSocket(socket_, buf_size)
-{
-    read_event = read_event_;
 }
 
 bool ReadBufferFromPocoSocket::poll(size_t timeout_microseconds) const

--- a/src/IO/ReadBufferFromPocoSocket.h
+++ b/src/IO/ReadBufferFromPocoSocket.h
@@ -20,13 +20,10 @@ protected:
       */
     Poco::Net::SocketAddress peer_address;
 
-    ProfileEvents::Event read_event;
-
     bool nextImpl() override;
 
 public:
     explicit ReadBufferFromPocoSocket(Poco::Net::Socket & socket_, size_t buf_size = DBMS_DEFAULT_BUFFER_SIZE);
-    explicit ReadBufferFromPocoSocket(Poco::Net::Socket & socket_, const ProfileEvents::Event & read_event_, size_t buf_size = DBMS_DEFAULT_BUFFER_SIZE);
 
     bool poll(size_t timeout_microseconds) const;
 

--- a/src/IO/WriteBufferDecorator.h
+++ b/src/IO/WriteBufferDecorator.h
@@ -12,21 +12,13 @@ class WriteBuffer;
 
 /// WriteBuffer that decorates data and delegates it to underlying buffer.
 /// It's used for writing compressed and encrypted data
-/// This class can own or not own underlying buffer - constructor will differentiate
-/// std::unique_ptr<WriteBuffer> for owning and WriteBuffer* for not owning.
 template <class Base>
 class WriteBufferDecorator : public Base
 {
 public:
     template <class ... BaseArgs>
     explicit WriteBufferDecorator(std::unique_ptr<WriteBuffer> out_, BaseArgs && ... args)
-        : Base(std::forward<BaseArgs>(args)...), owning_holder(std::move(out_)), out(owning_holder.get())
-    {
-    }
-
-    template <class ... BaseArgs>
-    explicit WriteBufferDecorator(WriteBuffer * out_, BaseArgs && ... args)
-        : Base(std::forward<BaseArgs>(args)...), out(out_)
+        : Base(std::forward<BaseArgs>(args)...), out(std::move(out_))
     {
     }
 
@@ -46,7 +38,7 @@ public:
         }
     }
 
-    WriteBuffer * getNestedBuffer() { return out; }
+    WriteBuffer * getNestedBuffer() { return out.get(); }
 
 protected:
     /// Do some finalization before finalization of underlying buffer.
@@ -55,8 +47,7 @@ protected:
     /// Do some finalization after finalization of underlying buffer.
     virtual void finalizeAfter() {}
 
-    std::unique_ptr<WriteBuffer> owning_holder;
-    WriteBuffer * out;
+    std::unique_ptr<WriteBuffer> out;
 };
 
 using WriteBufferWithOwnMemoryDecorator = WriteBufferDecorator<BufferWithOwnMemory<WriteBuffer>>;

--- a/src/IO/WriteBufferFromEncryptedFile.h
+++ b/src/IO/WriteBufferFromEncryptedFile.h
@@ -28,7 +28,7 @@ public:
 
     void sync() override;
 
-    std::string getFileName() const override { return assert_cast<WriteBufferFromFileBase *>(out)->getFileName(); }
+    std::string getFileName() const override { return assert_cast<WriteBufferFromFileBase *>(out.get())->getFileName(); }
 
 private:
     void nextImpl() override;

--- a/src/IO/WriteBufferFromPocoSocket.cpp
+++ b/src/IO/WriteBufferFromPocoSocket.cpp
@@ -34,97 +34,6 @@ namespace ErrorCodes
     extern const int LOGICAL_ERROR;
 }
 
-ssize_t WriteBufferFromPocoSocket::socketSendBytesImpl(const char * ptr, size_t size)
-{
-    ssize_t res = 0;
-
-    /// If async_callback is specified, set socket to non-blocking mode
-    /// and try to write data to it, if socket is not ready for writing,
-    /// run async_callback and try again later.
-    /// It is expected that file descriptor may be polled externally.
-    /// Note that send timeout is not checked here. External code should check it while polling.
-    if (async_callback)
-    {
-        socket.setBlocking(false);
-        /// Set socket to blocking mode at the end.
-        SCOPE_EXIT(socket.setBlocking(true));
-        bool secure = socket.secure();
-        res = socket.impl()->sendBytes(ptr, static_cast<int>(size));
-
-        /// Check EAGAIN and ERR_SSL_WANT_WRITE/ERR_SSL_WANT_READ for secure socket (writing to secure socket can read too).
-        while (res < 0 && (errno == EAGAIN || (secure && (checkSSLWantRead(res) || checkSSLWantWrite(res)))))
-        {
-            /// In case of ERR_SSL_WANT_READ we should wait for socket to be ready for reading, otherwise - for writing.
-            if (secure && checkSSLWantRead(res))
-                async_callback(socket.impl()->sockfd(), socket.getReceiveTimeout(), AsyncEventTimeoutType::RECEIVE, socket_description, AsyncTaskExecutor::Event::READ | AsyncTaskExecutor::Event::ERROR);
-            else
-                async_callback(socket.impl()->sockfd(), socket.getSendTimeout(), AsyncEventTimeoutType::SEND, socket_description, AsyncTaskExecutor::Event::WRITE | AsyncTaskExecutor::Event::ERROR);
-
-            /// Try to write again.
-            res = socket.impl()->sendBytes(ptr, static_cast<int>(size));
-        }
-    }
-    else
-    {
-        res = socket.impl()->sendBytes(ptr, static_cast<int>(size));
-    }
-
-    return res;
-}
-
-void WriteBufferFromPocoSocket::socketSendBytes(const char * ptr, size_t size)
-{
-    if (!size)
-        return;
-
-    Stopwatch watch;
-    size_t bytes_written = 0;
-
-    SCOPE_EXIT({
-        ProfileEvents::increment(ProfileEvents::NetworkSendElapsedMicroseconds, watch.elapsedMicroseconds());
-        ProfileEvents::increment(ProfileEvents::NetworkSendBytes, bytes_written);
-        if (write_event != ProfileEvents::end())
-            ProfileEvents::increment(write_event, bytes_written);
-    });
-
-    while (bytes_written < size)
-    {
-        ssize_t res = 0;
-
-        /// Add more details to exceptions.
-        try
-        {
-            CurrentMetrics::Increment metric_increment(CurrentMetrics::NetworkSend);
-            if (size > INT_MAX)
-                throw Exception(ErrorCodes::LOGICAL_ERROR, "Buffer overflow");
-
-            res = socketSendBytesImpl(ptr + bytes_written, size - bytes_written);
-        }
-        catch (const Poco::Net::NetException & e)
-        {
-            throw NetException(ErrorCodes::NETWORK_ERROR, "{}, while writing to socket ({} -> {})", e.displayText(),
-                               our_address.toString(), peer_address.toString());
-        }
-        catch (const Poco::TimeoutException &)
-        {
-            throw NetException(ErrorCodes::SOCKET_TIMEOUT, "Timeout exceeded while writing to socket ({}, {} ms)",
-                peer_address.toString(),
-                socket.impl()->getSendTimeout().totalMilliseconds());
-        }
-        catch (const Poco::IOException & e)
-        {
-            throw NetException(ErrorCodes::NETWORK_ERROR, "{}, while writing to socket ({} -> {})", e.displayText(),
-                               our_address.toString(), peer_address.toString());
-        }
-
-        if (res < 0)
-            throw NetException(ErrorCodes::CANNOT_WRITE_TO_SOCKET, "Cannot write to socket ({} -> {})",
-                               our_address.toString(), peer_address.toString());
-
-        bytes_written += res;
-    }
-}
-
 void WriteBufferFromPocoSocket::nextImpl()
 {
     if (!offset())
@@ -151,7 +60,36 @@ void WriteBufferFromPocoSocket::nextImpl()
             if (size > INT_MAX)
                 throw Exception(ErrorCodes::LOGICAL_ERROR, "Buffer overflow");
 
-            res = socketSendBytesImpl(pos, size);
+            /// If async_callback is specified, set socket to non-blocking mode
+            /// and try to write data to it, if socket is not ready for writing,
+            /// run async_callback and try again later.
+            /// It is expected that file descriptor may be polled externally.
+            /// Note that send timeout is not checked here. External code should check it while polling.
+            if (async_callback)
+            {
+                socket.setBlocking(false);
+                /// Set socket to blocking mode at the end.
+                SCOPE_EXIT(socket.setBlocking(true));
+                bool secure = socket.secure();
+                res = socket.impl()->sendBytes(pos, static_cast<int>(size));
+
+                /// Check EAGAIN and ERR_SSL_WANT_WRITE/ERR_SSL_WANT_READ for secure socket (writing to secure socket can read too).
+                while (res < 0 && (errno == EAGAIN || (secure && (checkSSLWantRead(res) || checkSSLWantWrite(res)))))
+                {
+                    /// In case of ERR_SSL_WANT_READ we should wait for socket to be ready for reading, otherwise - for writing.
+                    if (secure && checkSSLWantRead(res))
+                        async_callback(socket.impl()->sockfd(), socket.getReceiveTimeout(), AsyncEventTimeoutType::RECEIVE, socket_description, AsyncTaskExecutor::Event::READ | AsyncTaskExecutor::Event::ERROR);
+                    else
+                        async_callback(socket.impl()->sockfd(), socket.getSendTimeout(), AsyncEventTimeoutType::SEND, socket_description, AsyncTaskExecutor::Event::WRITE | AsyncTaskExecutor::Event::ERROR);
+
+                    /// Try to write again.
+                    res = socket.impl()->sendBytes(pos, static_cast<int>(size));
+                }
+            }
+            else
+            {
+                res = socket.impl()->sendBytes(pos, static_cast<int>(size));
+            }
         }
         catch (const Poco::Net::NetException & e)
         {
@@ -185,12 +123,6 @@ WriteBufferFromPocoSocket::WriteBufferFromPocoSocket(Poco::Net::Socket & socket_
     , our_address(socket.address())
     , socket_description("socket (" + peer_address.toString() + ")")
 {
-}
-
-WriteBufferFromPocoSocket::WriteBufferFromPocoSocket(Poco::Net::Socket & socket_, const ProfileEvents::Event & write_event_, size_t buf_size)
-    : WriteBufferFromPocoSocket(socket_, buf_size)
-{
-    write_event = write_event_;
 }
 
 WriteBufferFromPocoSocket::~WriteBufferFromPocoSocket()

--- a/src/IO/WriteBufferFromPocoSocket.h
+++ b/src/IO/WriteBufferFromPocoSocket.h
@@ -17,32 +17,13 @@ class WriteBufferFromPocoSocket : public BufferWithOwnMemory<WriteBuffer>
 {
 public:
     explicit WriteBufferFromPocoSocket(Poco::Net::Socket & socket_, size_t buf_size = DBMS_DEFAULT_BUFFER_SIZE);
-    explicit WriteBufferFromPocoSocket(Poco::Net::Socket & socket_, const ProfileEvents::Event & write_event_, size_t buf_size = DBMS_DEFAULT_BUFFER_SIZE);
 
     ~WriteBufferFromPocoSocket() override;
 
     void setAsyncCallback(AsyncCallback async_callback_) { async_callback = std::move(async_callback_); }
 
-    using WriteBuffer::write;
-    void write(const std::string & str) { WriteBuffer::write(str.c_str(), str.size()); }
-    void write(std::string_view str) { WriteBuffer::write(str.data(), str.size()); }
-    void write(const char * str) { WriteBuffer::write(str, strlen(str)); }
-    void writeln(const std::string & str) { write(str); WriteBuffer::write("\n", 1); }
-    void writeln(std::string_view str) { write(str); WriteBuffer::write("\n", 1); }
-    void writeln(const char * str) { write(str); WriteBuffer::write("\n", 1); }
-
 protected:
     void nextImpl() override;
-
-    void socketSendBytes(const char * ptr, size_t size);
-    void socketSendStr(const std::string & str)
-    {
-        return socketSendBytes(str.data(), str.size());
-    }
-    void socketSendStr(const char * ptr)
-    {
-        return socketSendBytes(ptr, strlen(ptr));
-    }
 
     Poco::Net::Socket & socket;
 
@@ -53,13 +34,9 @@ protected:
     Poco::Net::SocketAddress peer_address;
     Poco::Net::SocketAddress our_address;
 
-    ProfileEvents::Event write_event;
-
 private:
     AsyncCallback async_callback;
     std::string socket_description;
-
-    ssize_t socketSendBytesImpl(const char * ptr, size_t size);
 };
 
 }

--- a/src/IO/WriteHelpers.h
+++ b/src/IO/WriteHelpers.h
@@ -63,7 +63,9 @@ namespace ErrorCodes
 
 inline void writeChar(char x, WriteBuffer & buf)
 {
-    buf.write(x);
+    buf.nextIfAtEnd();
+    *buf.position() = x;
+    ++buf.position();
 }
 
 /// Write the same character n times.

--- a/src/IO/ZlibDeflatingWriteBuffer.cpp
+++ b/src/IO/ZlibDeflatingWriteBuffer.cpp
@@ -10,6 +10,36 @@ namespace ErrorCodes
     extern const int ZLIB_DEFLATE_FAILED;
 }
 
+
+ZlibDeflatingWriteBuffer::ZlibDeflatingWriteBuffer(
+        std::unique_ptr<WriteBuffer> out_,
+        CompressionMethod compression_method,
+        int compression_level,
+        size_t buf_size,
+        char * existing_memory,
+        size_t alignment)
+    : WriteBufferWithOwnMemoryDecorator(std::move(out_), buf_size, existing_memory, alignment)
+{
+    zstr.zalloc = nullptr;
+    zstr.zfree = nullptr;
+    zstr.opaque = nullptr;
+    zstr.next_in = nullptr;
+    zstr.avail_in = 0;
+    zstr.next_out = nullptr;
+    zstr.avail_out = 0;
+
+    int window_bits = 15;
+    if (compression_method == CompressionMethod::Gzip)
+    {
+        window_bits += 16;
+    }
+
+    int rc = deflateInit2(&zstr, compression_level, Z_DEFLATED, window_bits, 8, Z_DEFAULT_STRATEGY);
+
+    if (rc != Z_OK)
+        throw Exception(ErrorCodes::ZLIB_DEFLATE_FAILED, "deflateInit2 failed: {}; zlib version: {}", zError(rc), ZLIB_VERSION);
+}
+
 void ZlibDeflatingWriteBuffer::nextImpl()
 {
     if (!offset())
@@ -51,10 +81,6 @@ ZlibDeflatingWriteBuffer::~ZlibDeflatingWriteBuffer()
 void ZlibDeflatingWriteBuffer::finalizeBefore()
 {
     next();
-
-    /// Don't write out if no data was ever compressed
-    if (!compress_empty && zstr.total_out == 0)
-        return;
 
     /// https://github.com/zlib-ng/zlib-ng/issues/494
     do

--- a/src/IO/ZlibDeflatingWriteBuffer.h
+++ b/src/IO/ZlibDeflatingWriteBuffer.h
@@ -12,45 +12,17 @@
 namespace DB
 {
 
-namespace ErrorCodes
-{
-    extern const int ZLIB_DEFLATE_FAILED;
-}
-
 /// Performs compression using zlib library and writes compressed data to out_ WriteBuffer.
 class ZlibDeflatingWriteBuffer : public WriteBufferWithOwnMemoryDecorator
 {
 public:
-    template<typename WriteBufferT>
     ZlibDeflatingWriteBuffer(
-            WriteBufferT && out_,
+            std::unique_ptr<WriteBuffer> out_,
             CompressionMethod compression_method,
             int compression_level,
             size_t buf_size = DBMS_DEFAULT_BUFFER_SIZE,
             char * existing_memory = nullptr,
-            size_t alignment = 0,
-            bool compress_empty_ = true)
-    : WriteBufferWithOwnMemoryDecorator(std::move(out_), buf_size, existing_memory, alignment), compress_empty(compress_empty_)
-    {
-        zstr.zalloc = nullptr;
-        zstr.zfree = nullptr;
-        zstr.opaque = nullptr;
-        zstr.next_in = nullptr;
-        zstr.avail_in = 0;
-        zstr.next_out = nullptr;
-        zstr.avail_out = 0;
-
-        int window_bits = 15;
-        if (compression_method == CompressionMethod::Gzip)
-        {
-            window_bits += 16;
-        }
-
-        int rc = deflateInit2(&zstr, compression_level, Z_DEFLATED, window_bits, 8, Z_DEFAULT_STRATEGY);
-
-        if (rc != Z_OK)
-            throw Exception(ErrorCodes::ZLIB_DEFLATE_FAILED, "deflateInit2 failed: {}; zlib version: {}", zError(rc), ZLIB_VERSION);
-    }
+            size_t alignment = 0);
 
     ~ZlibDeflatingWriteBuffer() override;
 
@@ -64,7 +36,6 @@ private:
     virtual void finalizeAfter() override;
 
     z_stream zstr;
-    bool compress_empty = true;
 };
 
 }

--- a/src/IO/ZstdDeflatingWriteBuffer.h
+++ b/src/IO/ZstdDeflatingWriteBuffer.h
@@ -14,18 +14,12 @@ namespace DB
 class ZstdDeflatingWriteBuffer : public WriteBufferWithOwnMemoryDecorator
 {
 public:
-    template<typename WriteBufferT>
     ZstdDeflatingWriteBuffer(
-        WriteBufferT && out_,
+        std::unique_ptr<WriteBuffer> out_,
         int compression_level,
         size_t buf_size = DBMS_DEFAULT_BUFFER_SIZE,
         char * existing_memory = nullptr,
-        size_t alignment = 0,
-        bool compress_empty_ = true)
-    : WriteBufferWithOwnMemoryDecorator(std::move(out_), buf_size, existing_memory, alignment), compress_empty(compress_empty_)
-    {
-        initialize(compression_level);
-    }
+        size_t alignment = 0);
 
     ~ZstdDeflatingWriteBuffer() override;
 
@@ -35,8 +29,6 @@ public:
     }
 
 private:
-    void initialize(int compression_level);
-
     void nextImpl() override;
 
     /// Flush all pending data and write zstd footer to the underlying buffer.
@@ -50,9 +42,6 @@ private:
     ZSTD_CCtx * cctx;
     ZSTD_inBuffer input;
     ZSTD_outBuffer output;
-
-    size_t total_out = 0;
-    bool compress_empty = true;
 };
 
 }

--- a/src/Interpreters/Session.cpp
+++ b/src/Interpreters/Session.cpp
@@ -112,7 +112,8 @@ public:
                 throw Exception(ErrorCodes::SESSION_NOT_FOUND, "Session {} not found", session_id);
 
             /// Create a new session from current context.
-            it = sessions.insert(std::make_pair(key, std::make_shared<NamedSessionData>(key, global_context, timeout, *this))).first;
+            auto context = Context::createCopy(global_context);
+            it = sessions.insert(std::make_pair(key, std::make_shared<NamedSessionData>(key, context, timeout, *this))).first;
             const auto & session = it->second;
 
             if (!thread.joinable())
@@ -127,7 +128,7 @@ public:
             /// Use existing session.
             const auto & session = it->second;
 
-            LOG_TRACE(log, "Reuse session from storage with session_id: {}, user_id: {}", key.second, key.first);
+            LOG_TEST(log, "Reuse session from storage with session_id: {}, user_id: {}", key.second, key.first);
 
             if (!session.unique())
                 throw Exception(ErrorCodes::SESSION_IS_LOCKED, "Session {} is locked by a concurrent client", session_id);
@@ -702,10 +703,6 @@ void Session::releaseSessionID()
 {
     if (!named_session)
         return;
-
-    prepared_client_info = getClientInfo();
-    session_context.reset();
-
     named_session->release();
     named_session = nullptr;
 }

--- a/src/Interpreters/Session.h
+++ b/src/Interpreters/Session.h
@@ -8,7 +8,6 @@
 
 #include <chrono>
 #include <memory>
-#include <mutex>
 #include <optional>
 
 namespace Poco::Net { class SocketAddress; }

--- a/src/Server/HTTP/HTTPRequestHandler.h
+++ b/src/Server/HTTP/HTTPRequestHandler.h
@@ -13,8 +13,7 @@ class HTTPRequestHandler : private boost::noncopyable
 public:
     virtual ~HTTPRequestHandler() = default;
 
-    virtual void handleRequest(HTTPServerRequest & request, HTTPServerResponse & response, const ProfileEvents::Event & write_event) = 0;
-    virtual void handleRequest(HTTPServerRequest & request, HTTPServerResponse & response) { handleRequest(request, response, ProfileEvents::end()); }
+    virtual void handleRequest(HTTPServerRequest & request, HTTPServerResponse & response) = 0;
 };
 
 }

--- a/src/Server/HTTP/HTTPServer.cpp
+++ b/src/Server/HTTP/HTTPServer.cpp
@@ -10,10 +10,8 @@ HTTPServer::HTTPServer(
     HTTPRequestHandlerFactoryPtr factory_,
     Poco::ThreadPool & thread_pool,
     Poco::Net::ServerSocket & socket_,
-    Poco::Net::HTTPServerParams::Ptr params,
-    const ProfileEvents::Event & read_event,
-    const ProfileEvents::Event & write_event)
-    : TCPServer(new HTTPServerConnectionFactory(context, params, factory_, read_event, write_event), thread_pool, socket_, params), factory(factory_)
+    Poco::Net::HTTPServerParams::Ptr params)
+    : TCPServer(new HTTPServerConnectionFactory(context, params, factory_), thread_pool, socket_, params), factory(factory_)
 {
 }
 

--- a/src/Server/HTTP/HTTPServer.h
+++ b/src/Server/HTTP/HTTPServer.h
@@ -20,9 +20,7 @@ public:
         HTTPRequestHandlerFactoryPtr factory,
         Poco::ThreadPool & thread_pool,
         Poco::Net::ServerSocket & socket,
-        Poco::Net::HTTPServerParams::Ptr params,
-        const ProfileEvents::Event & read_event_ = ProfileEvents::end(),
-        const ProfileEvents::Event & write_event_ = ProfileEvents::end());
+        Poco::Net::HTTPServerParams::Ptr params);
 
     ~HTTPServer() override;
 

--- a/src/Server/HTTP/HTTPServerConnection.cpp
+++ b/src/Server/HTTP/HTTPServerConnection.cpp
@@ -11,10 +11,8 @@ HTTPServerConnection::HTTPServerConnection(
     TCPServer & tcp_server_,
     const Poco::Net::StreamSocket & socket,
     Poco::Net::HTTPServerParams::Ptr params_,
-    HTTPRequestHandlerFactoryPtr factory_,
-    const ProfileEvents::Event & read_event_,
-    const ProfileEvents::Event & write_event_)
-    : TCPServerConnection(socket), context(std::move(context_)), tcp_server(tcp_server_), params(params_), factory(factory_), read_event(read_event_), write_event(write_event_), stopped(false)
+    HTTPRequestHandlerFactoryPtr factory_)
+    : TCPServerConnection(socket), context(std::move(context_)), tcp_server(tcp_server_), params(params_), factory(factory_), stopped(false)
 {
     poco_check_ptr(factory);
 }
@@ -32,7 +30,7 @@ void HTTPServerConnection::run()
             if (!stopped && tcp_server.isOpen() && session.connected())
             {
                 HTTPServerResponse response(session);
-                HTTPServerRequest request(context, response, session, read_event);
+                HTTPServerRequest request(context, response, session);
 
                 Poco::Timestamp now;
 
@@ -67,7 +65,7 @@ void HTTPServerConnection::run()
                         if (request.getExpectContinue() && response.getStatus() == Poco::Net::HTTPResponse::HTTP_OK)
                             response.sendContinue();
 
-                        handler->handleRequest(request, response, write_event);
+                        handler->handleRequest(request, response);
                         session.setKeepAlive(params->getKeepAlive() && response.getKeepAlive() && session.canKeepAlive());
                     }
                     else

--- a/src/Server/HTTP/HTTPServerConnection.h
+++ b/src/Server/HTTP/HTTPServerConnection.h
@@ -19,9 +19,7 @@ public:
         TCPServer & tcp_server,
         const Poco::Net::StreamSocket & socket,
         Poco::Net::HTTPServerParams::Ptr params,
-        HTTPRequestHandlerFactoryPtr factory,
-        const ProfileEvents::Event & read_event_ = ProfileEvents::end(),
-        const ProfileEvents::Event & write_event_ = ProfileEvents::end());
+        HTTPRequestHandlerFactoryPtr factory);
 
     HTTPServerConnection(
         HTTPContextPtr context_,
@@ -29,10 +27,8 @@ public:
         const Poco::Net::StreamSocket & socket_,
         Poco::Net::HTTPServerParams::Ptr params_,
         HTTPRequestHandlerFactoryPtr factory_,
-        const String & forwarded_for_,
-        const ProfileEvents::Event & read_event_ = ProfileEvents::end(),
-        const ProfileEvents::Event & write_event_ = ProfileEvents::end())
-    : HTTPServerConnection(context_, tcp_server_, socket_, params_, factory_, read_event_, write_event_)
+        const String & forwarded_for_)
+    : HTTPServerConnection(context_, tcp_server_, socket_, params_, factory_)
     {
         forwarded_for = forwarded_for_;
     }
@@ -48,8 +44,6 @@ private:
     Poco::Net::HTTPServerParams::Ptr params;
     HTTPRequestHandlerFactoryPtr factory;
     String forwarded_for;
-    ProfileEvents::Event read_event;
-    ProfileEvents::Event write_event;
     bool stopped;
     std::mutex mutex;  // guards the |factory| with assumption that creating handlers is not thread-safe.
 };

--- a/src/Server/HTTP/HTTPServerConnectionFactory.cpp
+++ b/src/Server/HTTP/HTTPServerConnectionFactory.cpp
@@ -5,20 +5,20 @@
 namespace DB
 {
 HTTPServerConnectionFactory::HTTPServerConnectionFactory(
-    HTTPContextPtr context_, Poco::Net::HTTPServerParams::Ptr params_, HTTPRequestHandlerFactoryPtr factory_, const ProfileEvents::Event & read_event_, const ProfileEvents::Event & write_event_)
-    : context(std::move(context_)), params(params_), factory(factory_), read_event(read_event_), write_event(write_event_)
+    HTTPContextPtr context_, Poco::Net::HTTPServerParams::Ptr params_, HTTPRequestHandlerFactoryPtr factory_)
+    : context(std::move(context_)), params(params_), factory(factory_)
 {
     poco_check_ptr(factory);
 }
 
 Poco::Net::TCPServerConnection * HTTPServerConnectionFactory::createConnection(const Poco::Net::StreamSocket & socket, TCPServer & tcp_server)
 {
-    return new HTTPServerConnection(context, tcp_server, socket, params, factory, read_event, write_event);
+    return new HTTPServerConnection(context, tcp_server, socket, params, factory);
 }
 
 Poco::Net::TCPServerConnection * HTTPServerConnectionFactory::createConnection(const Poco::Net::StreamSocket & socket, TCPServer & tcp_server, TCPProtocolStackData & stack_data)
 {
-    return new HTTPServerConnection(context, tcp_server, socket, params, factory, stack_data.forwarded_for, read_event, write_event);
+    return new HTTPServerConnection(context, tcp_server, socket, params, factory, stack_data.forwarded_for);
 }
 
 }

--- a/src/Server/HTTP/HTTPServerConnectionFactory.h
+++ b/src/Server/HTTP/HTTPServerConnectionFactory.h
@@ -12,7 +12,7 @@ namespace DB
 class HTTPServerConnectionFactory : public TCPServerConnectionFactory
 {
 public:
-    HTTPServerConnectionFactory(HTTPContextPtr context, Poco::Net::HTTPServerParams::Ptr params, HTTPRequestHandlerFactoryPtr factory, const ProfileEvents::Event & read_event_ = ProfileEvents::end(), const ProfileEvents::Event & write_event_ = ProfileEvents::end());
+    HTTPServerConnectionFactory(HTTPContextPtr context, Poco::Net::HTTPServerParams::Ptr params, HTTPRequestHandlerFactoryPtr factory);
 
     Poco::Net::TCPServerConnection * createConnection(const Poco::Net::StreamSocket & socket, TCPServer & tcp_server) override;
     Poco::Net::TCPServerConnection * createConnection(const Poco::Net::StreamSocket & socket, TCPServer & tcp_server, TCPProtocolStackData & stack_data) override;
@@ -21,8 +21,6 @@ private:
     HTTPContextPtr context;
     Poco::Net::HTTPServerParams::Ptr params;
     HTTPRequestHandlerFactoryPtr factory;
-    ProfileEvents::Event read_event;
-    ProfileEvents::Event write_event;
 };
 
 }

--- a/src/Server/HTTP/HTTPServerRequest.cpp
+++ b/src/Server/HTTP/HTTPServerRequest.cpp
@@ -22,7 +22,7 @@
 
 namespace DB
 {
-HTTPServerRequest::HTTPServerRequest(HTTPContextPtr context, HTTPServerResponse & response, Poco::Net::HTTPServerSession & session, const ProfileEvents::Event & read_event)
+HTTPServerRequest::HTTPServerRequest(HTTPContextPtr context, HTTPServerResponse & response, Poco::Net::HTTPServerSession & session)
     : max_uri_size(context->getMaxUriSize())
     , max_fields_number(context->getMaxFields())
     , max_field_name_size(context->getMaxFieldNameSize())
@@ -41,7 +41,7 @@ HTTPServerRequest::HTTPServerRequest(HTTPContextPtr context, HTTPServerResponse 
     session.socket().setReceiveTimeout(receive_timeout);
     session.socket().setSendTimeout(send_timeout);
 
-    auto in = std::make_unique<ReadBufferFromPocoSocket>(session.socket(), read_event);
+    auto in = std::make_unique<ReadBufferFromPocoSocket>(session.socket());
     socket = session.socket().impl();
 
     readRequest(*in);  /// Try parse according to RFC7230

--- a/src/Server/HTTP/HTTPServerRequest.h
+++ b/src/Server/HTTP/HTTPServerRequest.h
@@ -4,7 +4,6 @@
 #include <IO/ReadBuffer.h>
 #include <Server/HTTP/HTTPRequest.h>
 #include <Server/HTTP/HTTPContext.h>
-#include <Common/ProfileEvents.h>
 #include "config.h"
 
 #include <Poco/Net/HTTPServerSession.h>
@@ -20,7 +19,7 @@ class ReadBufferFromPocoSocket;
 class HTTPServerRequest : public HTTPRequest
 {
 public:
-    HTTPServerRequest(HTTPContextPtr context, HTTPServerResponse & response, Poco::Net::HTTPServerSession & session, const ProfileEvents::Event & read_event = ProfileEvents::end());
+    HTTPServerRequest(HTTPContextPtr context, HTTPServerResponse & response, Poco::Net::HTTPServerSession & session);
 
     /// FIXME: it's a little bit inconvenient interface. The rationale is that all other ReadBuffer's wrap each other
     ///        via unique_ptr - but we can't inherit HTTPServerRequest from ReadBuffer and pass it around,

--- a/src/Server/HTTP/HTTPServerResponse.cpp
+++ b/src/Server/HTTP/HTTPServerResponse.cpp
@@ -9,15 +9,12 @@
 #include <Poco/Net/HTTPHeaderStream.h>
 #include <Poco/Net/HTTPStream.h>
 #include <Poco/StreamCopier.h>
-#include <sstream>
 
 
 namespace DB
 {
 
-HTTPServerResponse::HTTPServerResponse(Poco::Net::HTTPServerSession & session_, const ProfileEvents::Event & write_event_)
-    : session(session_)
-    , write_event(write_event_)
+HTTPServerResponse::HTTPServerResponse(Poco::Net::HTTPServerSession & session_) : session(session_)
 {
 }
 
@@ -27,45 +24,42 @@ void HTTPServerResponse::sendContinue()
     hs << getVersion() << " 100 Continue\r\n\r\n";
 }
 
-std::shared_ptr<WriteBufferFromPocoSocket> HTTPServerResponse::send()
+std::shared_ptr<std::ostream> HTTPServerResponse::send()
 {
     poco_assert(!stream);
 
     if ((request && request->getMethod() == HTTPRequest::HTTP_HEAD) || getStatus() < 200 || getStatus() == HTTPResponse::HTTP_NO_CONTENT
         || getStatus() == HTTPResponse::HTTP_NOT_MODIFIED)
     {
-        // Send header
-        Poco::Net::HTTPHeaderOutputStream hs(session);
-        write(hs);
-        stream = std::make_shared<WriteBufferFromPocoSocket>(session.socket(), write_event);
+        Poco::CountingOutputStream cs;
+        write(cs);
+        stream = std::make_shared<Poco::Net::HTTPFixedLengthOutputStream>(session, cs.chars());
+        write(*stream);
     }
     else if (getChunkedTransferEncoding())
     {
-        // Send header
         Poco::Net::HTTPHeaderOutputStream hs(session);
         write(hs);
-        stream = std::make_shared<HTTPWriteBufferChunked>(session.socket(), write_event);
+        stream = std::make_shared<Poco::Net::HTTPChunkedOutputStream>(session);
     }
     else if (hasContentLength())
     {
-        // Send header
-        Poco::Net::HTTPHeaderOutputStream hs(session);
-        write(hs);
-        stream = std::make_shared<HTTPWriteBufferFixedLength>(session.socket(), getContentLength(), write_event);
+        Poco::CountingOutputStream cs;
+        write(cs);
+        stream = std::make_shared<Poco::Net::HTTPFixedLengthOutputStream>(session, getContentLength64() + cs.chars());
+        write(*stream);
     }
     else
     {
+        stream = std::make_shared<Poco::Net::HTTPOutputStream>(session);
         setKeepAlive(false);
-        // Send header
-        Poco::Net::HTTPHeaderOutputStream hs(session);
-        write(hs);
-        stream = std::make_shared<WriteBufferFromPocoSocket>(session.socket(), write_event);
+        write(*stream);
     }
 
     return stream;
 }
 
-std::pair<std::shared_ptr<WriteBufferFromPocoSocket>, std::shared_ptr<WriteBufferFromPocoSocket>> HTTPServerResponse::beginSend()
+std::pair<std::shared_ptr<std::ostream>, std::shared_ptr<std::ostream>> HTTPServerResponse::beginSend()
 {
     poco_assert(!stream);
     poco_assert(!header_stream);
@@ -77,39 +71,40 @@ std::pair<std::shared_ptr<WriteBufferFromPocoSocket>, std::shared_ptr<WriteBuffe
     {
         throw Poco::Exception("HTTPServerResponse::beginSend is invalid for HEAD request");
     }
-
-    if (hasContentLength())
+    else if (getChunkedTransferEncoding())
+    {
+        header_stream = std::make_shared<Poco::Net::HTTPHeaderOutputStream>(session);
+        beginWrite(*header_stream);
+        stream = std::make_shared<Poco::Net::HTTPChunkedOutputStream>(session);
+    }
+    else if (hasContentLength())
     {
         throw Poco::Exception("HTTPServerResponse::beginSend is invalid for response with Content-Length header");
     }
-
-    // Write header to buffer
-    std::stringstream header; //STYLE_CHECK_ALLOW_STD_STRING_STREAM
-    beginWrite(header);
-    // Send header
-    auto str = header.str();
-    header_stream = std::make_shared<WriteBufferFromPocoSocket>(session.socket(), write_event, str.size());
-    header_stream->write(str);
-
-    if (getChunkedTransferEncoding())
-        stream = std::make_shared<HTTPWriteBufferChunked>(session.socket(), write_event);
     else
-        stream = std::make_shared<WriteBufferFromPocoSocket>(session.socket(), write_event);
+    {
+        stream = std::make_shared<Poco::Net::HTTPOutputStream>(session);
+        header_stream = stream;
+        setKeepAlive(false);
+        beginWrite(*stream);
+    }
 
     return std::make_pair(header_stream, stream);
 }
 
 void HTTPServerResponse::sendBuffer(const void * buffer, std::size_t length)
 {
+    poco_assert(!stream);
+
     setContentLength(static_cast<int>(length));
     setChunkedTransferEncoding(false);
-    // Send header
-    Poco::Net::HTTPHeaderOutputStream hs(session);
-    write(hs);
-    hs.flush();
 
+    stream = std::make_shared<Poco::Net::HTTPHeaderOutputStream>(session);
+    write(*stream);
     if (request && request->getMethod() != HTTPRequest::HTTP_HEAD)
-        WriteBufferFromPocoSocket(session.socket(), write_event).write(static_cast<const char *>(buffer), length);
+    {
+        stream->write(static_cast<const char *>(buffer), static_cast<std::streamsize>(length));
+    }
 }
 
 void HTTPServerResponse::requireAuthentication(const std::string & realm)

--- a/src/Server/HTTP/HTTPServerResponse.h
+++ b/src/Server/HTTP/HTTPServerResponse.h
@@ -1,12 +1,9 @@
 #pragma once
 
-#include <IO/WriteBufferFromPocoSocket.h>
 #include <Server/HTTP/HTTPResponse.h>
 
 #include <Poco/Net/HTTPServerSession.h>
 #include <Poco/Net/HTTPResponse.h>
-#include <Poco/Net/StreamSocket.h>
-#include <Poco/NumberFormatter.h>
 
 #include <memory>
 
@@ -14,182 +11,12 @@
 namespace DB
 {
 
-
-class HTTPWriteBufferChunked : public WriteBufferFromPocoSocket
-{
-    using WriteBufferFromPocoSocket::WriteBufferFromPocoSocket;
-protected:
-    void nextImpl() override
-    {
-        if (offset() == 0)
-            return;
-
-        std::string chunk_header;
-        Poco::NumberFormatter::appendHex(chunk_header, offset());
-        chunk_header.append("\r\n", 2);
-        socketSendBytes(chunk_header.data(), static_cast<int>(chunk_header.size()));
-        WriteBufferFromPocoSocket::nextImpl();
-        socketSendBytes("\r\n", 2);
-    }
-
-    void finalizeImpl() override
-    {
-        WriteBufferFromPocoSocket::finalizeImpl();
-        socketSendBytes("0\r\n\r\n", 5);
-    }
-};
-
-class HTTPWriteBufferFixedLength : public WriteBufferFromPocoSocket
-{
-public:
-    explicit HTTPWriteBufferFixedLength(Poco::Net::Socket & socket_, size_t fixed_length_, size_t buf_size = DBMS_DEFAULT_BUFFER_SIZE)
-        : WriteBufferFromPocoSocket(socket_, buf_size)
-    {
-        fixed_length = fixed_length_;
-    }
-    explicit HTTPWriteBufferFixedLength(Poco::Net::Socket & socket_, size_t fixed_length_, const ProfileEvents::Event & write_event_, size_t buf_size = DBMS_DEFAULT_BUFFER_SIZE)
-        : WriteBufferFromPocoSocket(socket_, write_event_, buf_size)
-    {
-        fixed_length = fixed_length_;
-    }
-protected:
-    void nextImpl() override
-    {
-        if (count_length >= fixed_length || offset() == 0)
-            return;
-
-        if (count_length + offset() > fixed_length)
-            pos -= offset() - (fixed_length - count_length);
-
-        count_length += offset();
-
-        WriteBufferFromPocoSocket::nextImpl();
-    }
-private:
-    size_t fixed_length;
-    size_t count_length = 0;
-};
-
-/// Universal HTTP buffer, can be switched for different Transfer-Encoding/Content-Length on the fly
-/// so it can be used to output HTTP header and then switched to appropriate mode for body
-class HTTPWriteBuffer : public WriteBufferFromPocoSocket
-{
-public:
-    explicit HTTPWriteBuffer(Poco::Net::Socket & socket_, size_t buf_size = DBMS_DEFAULT_BUFFER_SIZE)
-        : WriteBufferFromPocoSocket(socket_, buf_size)
-    {
-    }
-    explicit HTTPWriteBuffer(Poco::Net::Socket & socket_, const ProfileEvents::Event & write_event_, size_t buf_size = DBMS_DEFAULT_BUFFER_SIZE)
-        : WriteBufferFromPocoSocket(socket_, write_event_, buf_size)
-    {
-    }
-
-    void setChunked(size_t buf_size = DBMS_DEFAULT_BUFFER_SIZE)
-    {
-        chunked = true;
-        resizeIfNeeded(buf_size);
-    }
-
-    bool isChunked()
-    {
-        return chunked;
-    }
-
-    void setFixedLength(size_t length)
-    {
-        chunked = false;
-        fixed_length = length;
-        count_length = 0;
-        resizeIfNeeded(length);
-    }
-
-    size_t isFixedLength()
-    {
-        return chunked ? 0 : fixed_length;
-    }
-
-    void setPlain(size_t buf_size = DBMS_DEFAULT_BUFFER_SIZE)
-    {
-        chunked = false;
-        fixed_length = 0;
-        count_length = 0;
-        resizeIfNeeded(buf_size);
-    }
-
-    bool isPlain()
-    {
-        return !(isChunked() || isFixedLength());
-    }
-
-protected:
-    void finalizeImpl() override
-    {
-        WriteBufferFromPocoSocket::finalizeImpl();
-        if (chunked)
-            socketSendBytes("0\r\n\r\n", 5);
-    }
-
-    void nextImpl() override
-    {
-        if (chunked)
-            return nextImplChunked();
-
-        if (fixed_length)
-            return nextImplFixedLength();
-
-        WriteBufferFromPocoSocket::nextImpl();
-    }
-
-    void nextImplFixedLength()
-    {
-        if (count_length >= fixed_length || offset() == 0)
-            return;
-
-        if (count_length + offset() > fixed_length)
-            pos -= offset() - (fixed_length - count_length);
-
-        count_length += offset();
-
-        WriteBufferFromPocoSocket::nextImpl();
-    }
-
-    void nextImplChunked()
-    {
-        if (offset() == 0)
-            return;
-
-        std::string chunk_header;
-        Poco::NumberFormatter::appendHex(chunk_header, offset());
-        chunk_header.append("\r\n", 2);
-        socketSendBytes(chunk_header.data(), static_cast<int>(chunk_header.size()));
-        WriteBufferFromPocoSocket::nextImpl();
-        socketSendBytes("\r\n", 2);
-    }
-
-    void resizeIfNeeded(size_t buf_size = DBMS_DEFAULT_BUFFER_SIZE)
-    {
-        if (!buf_size)
-            return;
-
-        auto data_size = offset();
-        assert(data_size <= buf_size);
-
-        memory.resize(buf_size);
-        set(memory.data(), memory.size(), data_size);
-    }
-private:
-    bool chunked = false;
-    size_t fixed_length = 0;
-    size_t count_length = 0;
-};
-
-
 class HTTPServerRequest;
 
 class HTTPServerResponse : public HTTPResponse
 {
 public:
-    explicit HTTPServerResponse(Poco::Net::HTTPServerSession & session, const ProfileEvents::Event & write_event_ = ProfileEvents::end());
+    explicit HTTPServerResponse(Poco::Net::HTTPServerSession & session);
 
     void sendContinue(); /// Sends a 100 Continue response to the client.
 
@@ -199,7 +26,7 @@ public:
     ///
     /// Must not be called after beginSend(), sendFile(), sendBuffer()
     /// or redirect() has been called.
-    std::shared_ptr<WriteBufferFromPocoSocket> send();
+    std::shared_ptr<std::ostream> send(); /// TODO: use some WriteBuffer implementation here.
 
     /// Sends the response headers to the client
     /// but do not finish headers with \r\n,
@@ -207,7 +34,7 @@ public:
     ///
     /// Must not be called after send(), sendFile(), sendBuffer()
     /// or redirect() has been called.
-    std::pair<std::shared_ptr<WriteBufferFromPocoSocket>, std::shared_ptr<WriteBufferFromPocoSocket>> beginSend();
+    std::pair<std::shared_ptr<std::ostream>, std::shared_ptr<std::ostream>> beginSend(); /// TODO: use some WriteBuffer implementation here.
 
     /// Sends the response header to the client, followed
     /// by the contents of the given buffer.
@@ -231,16 +58,13 @@ public:
     /// Returns true if the response (header) has been sent.
     bool sent() const { return !!stream; }
 
-    Poco::Net::StreamSocket & getSocket() { return session.socket(); }
-
     void attachRequest(HTTPServerRequest * request_) { request = request_; }
 
 private:
     Poco::Net::HTTPServerSession & session;
     HTTPServerRequest * request = nullptr;
-    ProfileEvents::Event write_event;
-    std::shared_ptr<WriteBufferFromPocoSocket> stream;
-    std::shared_ptr<WriteBufferFromPocoSocket> header_stream;
+    std::shared_ptr<std::ostream> stream;
+    std::shared_ptr<std::ostream> header_stream;
 };
 
 }

--- a/src/Server/HTTP/WriteBufferFromHTTPServerResponse.cpp
+++ b/src/Server/HTTP/WriteBufferFromHTTPServerResponse.cpp
@@ -1,14 +1,16 @@
 #include <Server/HTTP/WriteBufferFromHTTPServerResponse.h>
+
 #include <IO/HTTPCommon.h>
 #include <IO/Progress.h>
 #include <IO/WriteBufferFromString.h>
 #include <IO/WriteHelpers.h>
-#include <memory>
-#include <sstream>
-#include <string>
 
 namespace DB
 {
+
+namespace ErrorCodes
+{
+}
 
 
 void WriteBufferFromHTTPServerResponse::startSendHeaders()
@@ -17,33 +19,27 @@ void WriteBufferFromHTTPServerResponse::startSendHeaders()
     {
         headers_started_sending = true;
 
-        if (response.getChunkedTransferEncoding())
-            setChunked();
-
         if (add_cors_header)
             response.set("Access-Control-Allow-Origin", "*");
 
         setResponseDefaultHeaders(response, keep_alive_timeout);
 
-        std::stringstream header; //STYLE_CHECK_ALLOW_STD_STRING_STREAM
-        response.beginWrite(header);
-        auto header_str = header.str();
-        socketSendBytes(header_str.data(), header_str.size());
+        if (!is_http_method_head)
+            std::tie(response_header_ostr, response_body_ostr) = response.beginSend();
     }
 }
 
 void WriteBufferFromHTTPServerResponse::writeHeaderProgressImpl(const char * header_name)
 {
-    if (is_http_method_head || headers_finished_sending || !headers_started_sending)
+    if (headers_finished_sending)
         return;
 
     WriteBufferFromOwnString progress_string_writer;
 
     accumulated_progress.writeJSON(progress_string_writer);
 
-    socketSendBytes(header_name, strlen(header_name));
-    socketSendBytes(progress_string_writer.str().data(), progress_string_writer.str().size());
-    socketSendBytes("\r\n", 2);
+    if (response_header_ostr)
+        *response_header_ostr << header_name << progress_string_writer.str() << "\r\n" << std::flush;
 }
 
 void WriteBufferFromHTTPServerResponse::writeHeaderSummary()
@@ -61,30 +57,30 @@ void WriteBufferFromHTTPServerResponse::writeExceptionCode()
 {
     if (headers_finished_sending || !exception_code)
         return;
-    if (headers_started_sending)
-    {
-        socketSendBytes("X-ClickHouse-Exception-Code: ", sizeof("X-ClickHouse-Exception-Code: ") - 1);
-        auto str_code = std::to_string(exception_code);
-        socketSendBytes(str_code.data(), str_code.size());
-        socketSendBytes("\r\n", 2);
-    }
+    if (response_header_ostr)
+        *response_header_ostr << "X-ClickHouse-Exception-Code: " << exception_code << "\r\n" << std::flush;
 }
 
 void WriteBufferFromHTTPServerResponse::finishSendHeaders()
 {
-    if (headers_finished_sending)
-        return;
+    if (!headers_finished_sending)
+    {
+        writeHeaderSummary();
+        writeExceptionCode();
+        headers_finished_sending = true;
 
-    if (!headers_started_sending)
-        startSendHeaders();
-
-    writeHeaderSummary();
-    writeExceptionCode();
-
-    headers_finished_sending = true;
-
-    /// Send end of headers delimiter.
-    socketSendBytes("\r\n", 2);
+        if (!is_http_method_head)
+        {
+            /// Send end of headers delimiter.
+            if (response_header_ostr)
+                *response_header_ostr << "\r\n" << std::flush;
+        }
+        else
+        {
+            if (!response_body_ostr)
+                response_body_ostr = response.send();
+        }
+    }
 }
 
 
@@ -93,19 +89,47 @@ void WriteBufferFromHTTPServerResponse::nextImpl()
     if (!initialized)
     {
         std::lock_guard lock(mutex);
+
         /// Initialize as early as possible since if the code throws,
         /// next() should not be called anymore.
         initialized = true;
 
-        if (compression_method != CompressionMethod::None)
-            response.set("Content-Encoding", toContentEncodingName(compression_method));
-
         startSendHeaders();
+
+        if (!out && !is_http_method_head)
+        {
+            if (compress)
+            {
+                auto content_encoding_name = toContentEncodingName(compression_method);
+
+                *response_header_ostr << "Content-Encoding: " << content_encoding_name << "\r\n";
+            }
+
+            /// We reuse our buffer in "out" to avoid extra allocations and copies.
+
+            if (compress)
+                out = wrapWriteBufferWithCompressionMethod(
+                    std::make_unique<WriteBufferFromOStream>(*response_body_ostr),
+                    compress ? compression_method : CompressionMethod::None,
+                    compression_level,
+                    working_buffer.size(),
+                    working_buffer.begin());
+            else
+                out = std::make_unique<WriteBufferFromOStream>(
+                    *response_body_ostr,
+                    working_buffer.size(),
+                    working_buffer.begin());
+        }
+
         finishSendHeaders();
     }
 
-    if (!is_http_method_head)
-        HTTPWriteBuffer::nextImpl();
+    if (out)
+    {
+        out->buffer() = buffer();
+        out->position() = position();
+        out->next();
+    }
 }
 
 
@@ -113,11 +137,14 @@ WriteBufferFromHTTPServerResponse::WriteBufferFromHTTPServerResponse(
     HTTPServerResponse & response_,
     bool is_http_method_head_,
     UInt64 keep_alive_timeout_,
-    const ProfileEvents::Event & write_event_)
-    : HTTPWriteBuffer(response_.getSocket(), write_event_)
+    bool compress_,
+    CompressionMethod compression_method_)
+    : BufferWithOwnMemory<WriteBuffer>(DBMS_DEFAULT_BUFFER_SIZE)
     , response(response_)
     , is_http_method_head(is_http_method_head_)
     , keep_alive_timeout(keep_alive_timeout_)
+    , compress(compress_)
+    , compression_method(compression_method_)
 {
 }
 
@@ -142,15 +169,6 @@ void WriteBufferFromHTTPServerResponse::onProgress(const Progress & progress)
     }
 }
 
-void WriteBufferFromHTTPServerResponse::setExceptionCode(int exception_code_)
-{
-    std::lock_guard lock(mutex);
-    if (headers_started_sending)
-        exception_code = exception_code_;
-    else
-        response.set("X-ClickHouse-Exception-Code", toString<int>(exception_code_));
-}
-
 WriteBufferFromHTTPServerResponse::~WriteBufferFromHTTPServerResponse()
 {
     finalize();
@@ -158,20 +176,30 @@ WriteBufferFromHTTPServerResponse::~WriteBufferFromHTTPServerResponse()
 
 void WriteBufferFromHTTPServerResponse::finalizeImpl()
 {
-    if (!headers_finished_sending)
+    try
     {
-        std::lock_guard lock(mutex);
-        /// If no body data just send header
-        startSendHeaders();
-
-        if (!initialized && offset() && compression_method != CompressionMethod::None)
-            socketSendStr("Content-Encoding: " + toContentEncodingName(compression_method) + "\r\n");
-
-        finishSendHeaders();
+        next();
+        if (out)
+            out->finalize();
+        out.reset();
+        /// Catch write-after-finalize bugs.
+        set(nullptr, 0);
+    }
+    catch (...)
+    {
+        /// Avoid calling WriteBufferFromOStream::next() from dtor
+        /// (via WriteBufferFromHTTPServerResponse::next())
+        out.reset();
+        throw;
     }
 
-    if (!is_http_method_head)
-        HTTPWriteBuffer::finalizeImpl();
+    if (!offset())
+    {
+        /// If no remaining data, just send headers.
+        std::lock_guard lock(mutex);
+        startSendHeaders();
+        finishSendHeaders();
+    }
 }
 
 

--- a/src/Server/HTTP/WriteBufferFromHTTPServerResponse.h
+++ b/src/Server/HTTP/WriteBufferFromHTTPServerResponse.h
@@ -5,8 +5,8 @@
 #include <IO/HTTPCommon.h>
 #include <IO/Progress.h>
 #include <IO/WriteBuffer.h>
+#include <IO/WriteBufferFromOStream.h>
 #include <Server/HTTP/HTTPServerResponse.h>
-#include <Poco/Net/StreamSocket.h>
 #include <Common/NetException.h>
 #include <Common/Stopwatch.h>
 
@@ -17,25 +17,47 @@
 namespace DB
 {
 
-/// Postpone sending HTTP header until first data is flushed. This is needed in HTTP servers
-///  to change some HTTP headers (e.g. response code) before any data is sent to the client.
+/// The difference from WriteBufferFromOStream is that this buffer gets the underlying std::ostream
+/// (using response.send()) only after data is flushed for the first time. This is needed in HTTP
+/// servers to change some HTTP headers (e.g. response code) before any data is sent to the client
+/// (headers can't be changed after response.send() is called).
+///
+/// In short, it allows delaying the call to response.send().
+///
+/// Additionally, supports HTTP response compression (in this case corresponding Content-Encoding
+/// header will be set).
 ///
 /// Also this class write and flush special X-ClickHouse-Progress HTTP headers
 ///  if no data was sent at the time of progress notification.
 /// This allows to implement progress bar in HTTP clients.
-class WriteBufferFromHTTPServerResponse final : public HTTPWriteBuffer
+class WriteBufferFromHTTPServerResponse final : public BufferWithOwnMemory<WriteBuffer>
 {
 public:
     WriteBufferFromHTTPServerResponse(
         HTTPServerResponse & response_,
         bool is_http_method_head_,
         UInt64 keep_alive_timeout_,
-        const ProfileEvents::Event & write_event_ = ProfileEvents::end());
+        bool compress_ = false,        /// If true - set Content-Encoding header and compress the result.
+        CompressionMethod compression_method_ = CompressionMethod::None);
 
     ~WriteBufferFromHTTPServerResponse() override;
 
     /// Writes progress in repeating HTTP headers.
     void onProgress(const Progress & progress);
+
+    /// Turn compression on or off.
+    /// The setting has any effect only if HTTP headers haven't been sent yet.
+    void setCompression(bool enable_compression)
+    {
+        compress = enable_compression;
+    }
+
+    /// Set compression level if the compression is turned on.
+    /// The setting has any effect only if HTTP headers haven't been sent yet.
+    void setCompressionLevel(int level)
+    {
+        compression_level = level;
+    }
 
     /// Turn CORS on or off.
     /// The setting has any effect only if HTTP headers haven't been sent yet.
@@ -53,13 +75,7 @@ public:
         send_progress_interval_ms = send_progress_interval_ms_;
     }
 
-    /// Content-Encoding header will be set on first data package
-    void setCompressionMethodHeader(const CompressionMethod & compression_method_)
-    {
-        compression_method = compression_method_;
-    }
-
-    void setExceptionCode(int exception_code_);
+    void setExceptionCode(int exception_code_) { exception_code = exception_code_; }
 
 private:
     /// Send at least HTTP headers if no data has been sent yet.
@@ -92,7 +108,14 @@ private:
     bool is_http_method_head;
     bool add_cors_header = false;
     size_t keep_alive_timeout = 0;
+    bool compress = false;
+    CompressionMethod compression_method;
+    int compression_level = 1;
 
+    std::shared_ptr<std::ostream> response_body_ostr;
+    std::shared_ptr<std::ostream> response_header_ostr;
+
+    std::unique_ptr<WriteBuffer> out;
     bool initialized = false;
 
     bool headers_started_sending = false;
@@ -102,8 +125,6 @@ private:
     bool send_progress = false;
     size_t send_progress_interval_ms = 100;
     Stopwatch progress_watch;
-
-    CompressionMethod compression_method = CompressionMethod::None;
 
     int exception_code = 0;
 

--- a/src/Server/HTTPHandler.cpp
+++ b/src/Server/HTTPHandler.cpp
@@ -46,9 +46,7 @@
 #include <Poco/String.h>
 #include <Poco/Net/SocketAddress.h>
 
-#include <algorithm>
 #include <chrono>
-#include <memory>
 #include <sstream>
 
 #ifdef __clang__
@@ -303,7 +301,7 @@ void HTTPHandler::pushDelayedResults(Output & used_output)
     std::vector<WriteBufferPtr> write_buffers;
     ConcatReadBuffer::Buffers read_buffers;
 
-    auto * cascade_buffer = typeid_cast<CascadeWriteBuffer *>(used_output.out_maybe_delayed_and_compressed);
+    auto * cascade_buffer = typeid_cast<CascadeWriteBuffer *>(used_output.out_maybe_delayed_and_compressed.get());
     if (!cascade_buffer)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Expected CascadeWriteBuffer");
 
@@ -555,8 +553,7 @@ void HTTPHandler::processQuery(
     HTMLForm & params,
     HTTPServerResponse & response,
     Output & used_output,
-    std::optional<CurrentThread::QueryScope> & query_scope,
-    const ProfileEvents::Event & write_event)
+    std::optional<CurrentThread::QueryScope> & query_scope)
 {
     using namespace Poco::Net;
 
@@ -567,9 +564,6 @@ void HTTPHandler::processQuery(
 
     /// The user could specify session identifier and session timeout.
     /// It allows to modify settings, create temporary tables and reuse them in subsequent requests.
-
-    SCOPE_EXIT({ session->releaseSessionID(); });
-
     String session_id;
     std::chrono::steady_clock::duration session_timeout;
     bool session_is_set = params.has("session_id");
@@ -622,35 +616,15 @@ void HTTPHandler::processQuery(
     size_t buffer_size_http = DBMS_DEFAULT_BUFFER_SIZE;
     size_t buffer_size_memory = (buffer_size_total > buffer_size_http) ? buffer_size_total : 0;
 
-    bool enable_http_compression = params.getParsed<bool>("enable_http_compression", context->getSettingsRef().enable_http_compression);
-    Int64 http_zlib_compression_level = params.getParsed<Int64>("http_zlib_compression_level", context->getSettingsRef().http_zlib_compression_level);
-
-    used_output.out_holder =
-        std::make_shared<WriteBufferFromHTTPServerResponse>(
-            response,
-            request.getMethod() == HTTPRequest::HTTP_HEAD,
-            context->getServerSettings().keep_alive_timeout.totalSeconds(),
-            write_event);
-    used_output.out = used_output.out_holder;
-    used_output.out_maybe_compressed = used_output.out_holder;
-
-    if (client_supports_http_compression && enable_http_compression)
-    {
-        used_output.out_holder->setCompressionMethodHeader(http_response_compression_method);
-        used_output.wrap_compressed_holder =
-            wrapWriteBufferWithCompressionMethod(
-                used_output.out_holder.get(),
-                http_response_compression_method,
-                static_cast<int>(http_zlib_compression_level),
-                DBMS_DEFAULT_BUFFER_SIZE, nullptr, 0, false);
-        used_output.out = used_output.wrap_compressed_holder;
-    }
+    used_output.out = std::make_shared<WriteBufferFromHTTPServerResponse>(
+        response,
+        request.getMethod() == HTTPRequest::HTTP_HEAD,
+        context->getServerSettings().keep_alive_timeout.totalSeconds(),
+        client_supports_http_compression,
+        http_response_compression_method);
 
     if (internal_compression)
-    {
-        used_output.out_compressed_holder = std::make_shared<CompressedWriteBuffer>(*used_output.out);
-        used_output.out_maybe_compressed = used_output.out_compressed_holder;
-    }
+        used_output.out_maybe_compressed = std::make_shared<CompressedWriteBuffer>(*used_output.out);
     else
         used_output.out_maybe_compressed = used_output.out;
 
@@ -690,12 +664,12 @@ void HTTPHandler::processQuery(
             cascade_buffer2.emplace_back(push_memory_buffer_and_continue);
         }
 
-        used_output.out_delayed_and_compressed_holder = std::make_unique<CascadeWriteBuffer>(std::move(cascade_buffer1), std::move(cascade_buffer2));
-        used_output.out_maybe_delayed_and_compressed = used_output.out_delayed_and_compressed_holder.get();
+        used_output.out_maybe_delayed_and_compressed = std::make_shared<CascadeWriteBuffer>(
+            std::move(cascade_buffer1), std::move(cascade_buffer2));
     }
     else
     {
-        used_output.out_maybe_delayed_and_compressed = used_output.out_maybe_compressed.get();
+        used_output.out_maybe_delayed_and_compressed = used_output.out_maybe_compressed;
     }
 
     /// Request body can be compressed using algorithm specified in the Content-Encoding header.
@@ -824,8 +798,14 @@ void HTTPHandler::processQuery(
     const auto & query = getQuery(request, params, context);
     std::unique_ptr<ReadBuffer> in_param = std::make_unique<ReadBufferFromString>(query);
 
-    used_output.out_holder->setSendProgress(settings.send_progress_in_http_headers);
-    used_output.out_holder->setSendProgressInterval(settings.http_headers_progress_interval_ms);
+    /// HTTP response compression is turned on only if the client signalled that they support it
+    /// (using Accept-Encoding header) and 'enable_http_compression' setting is turned on.
+    used_output.out->setCompression(client_supports_http_compression && settings.enable_http_compression);
+    if (client_supports_http_compression)
+        used_output.out->setCompressionLevel(static_cast<int>(settings.http_zlib_compression_level));
+
+    used_output.out->setSendProgress(settings.send_progress_in_http_headers);
+    used_output.out->setSendProgressInterval(settings.http_headers_progress_interval_ms);
 
     /// If 'http_native_compression_disable_checksumming_on_decompress' setting is turned on,
     /// checksums of client data compressed with internal algorithm are not checked.
@@ -836,7 +816,7 @@ void HTTPHandler::processQuery(
     /// Note that whether the header is added is determined by the settings, and we can only get the user settings after authentication.
     /// Once the authentication fails, the header can't be added.
     if (settings.add_http_cors_header && !request.get("Origin", "").empty() && !config.has("http_options_response"))
-        used_output.out_holder->addHeaderCORS(true);
+        used_output.out->addHeaderCORS(true);
 
     auto append_callback = [my_context = context] (ProgressCallback callback)
     {
@@ -855,7 +835,7 @@ void HTTPHandler::processQuery(
     /// Note that we add it unconditionally so the progress is available for `X-ClickHouse-Summary`
     append_callback([&used_output](const Progress & progress)
     {
-        used_output.out_holder->onProgress(progress);
+        used_output.out->onProgress(progress);
     });
 
     if (settings.readonly > 0 && settings.cancel_http_readonly_queries_on_client_close)
@@ -908,8 +888,6 @@ void HTTPHandler::processQuery(
         {},
         handle_exception_in_output_format);
 
-    session->releaseSessionID();
-
     if (used_output.hasDelayed())
     {
         /// TODO: set Content-Length if possible
@@ -924,8 +902,10 @@ void HTTPHandler::trySendExceptionToClient(
     const std::string & s, int exception_code, HTTPServerRequest & request, HTTPServerResponse & response, Output & used_output)
 try
 {
-    if (used_output.out_holder)
-        used_output.out_holder->setExceptionCode(exception_code);
+    /// In case data has already been sent, like progress headers, try using the output buffer to
+    /// set the exception code since it will be able to append it if it hasn't finished writing headers
+    if (response.sent() && used_output.out)
+        used_output.out->setExceptionCode(exception_code);
     else
         response.set("X-ClickHouse-Exception-Code", toString<int>(exception_code));
 
@@ -950,10 +930,10 @@ try
         response.setStatusAndReason(exceptionCodeToHTTPStatus(exception_code));
     }
 
-    if (!used_output.out_holder && !used_output.exception_is_written)
+    if (!response.sent() && !used_output.out_maybe_compressed && !used_output.exception_is_written)
     {
         /// If nothing was sent yet and we don't even know if we must compress the response.
-        WriteBufferFromHTTPServerResponse(response, request.getMethod() == HTTPRequest::HTTP_HEAD, DEFAULT_HTTP_KEEP_ALIVE_TIMEOUT).writeln(s);
+        *response.send() << s << std::endl;
     }
     else if (used_output.out_maybe_compressed)
     {
@@ -963,8 +943,7 @@ try
             /// do not call finalize here for CascadeWriteBuffer used_output.out_maybe_delayed_and_compressed,
             /// exception is written into used_output.out_maybe_compressed later
             /// HTTPHandler::trySendExceptionToClient is called with exception context, it is Ok to destroy buffers
-            used_output.out_delayed_and_compressed_holder.reset();
-            used_output.out_maybe_delayed_and_compressed = nullptr;
+            used_output.out_maybe_delayed_and_compressed.reset();
         }
 
         if (!used_output.exception_is_written)
@@ -974,12 +953,12 @@ try
             /// Also HTTP code 200 could have already been sent.
 
             /// If buffer has data, and that data wasn't sent yet, then no need to send that data
-            bool data_sent = used_output.out_holder->count() != used_output.out_holder->offset();
+            bool data_sent = used_output.out->count() != used_output.out->offset();
 
             if (!data_sent)
             {
                 used_output.out_maybe_compressed->position() = used_output.out_maybe_compressed->buffer().begin();
-                used_output.out_holder->position() = used_output.out_holder->buffer().begin();
+                used_output.out->position() = used_output.out->buffer().begin();
             }
 
             writeString(s, *used_output.out_maybe_compressed);
@@ -1010,7 +989,7 @@ catch (...)
 }
 
 
-void HTTPHandler::handleRequest(HTTPServerRequest & request, HTTPServerResponse & response, const ProfileEvents::Event & write_event)
+void HTTPHandler::handleRequest(HTTPServerRequest & request, HTTPServerResponse & response)
 {
     setThreadName("HTTPHandler");
     ThreadStatus thread_status;
@@ -1099,7 +1078,7 @@ void HTTPHandler::handleRequest(HTTPServerRequest & request, HTTPServerResponse 
                             "is no Content-Length header for POST request");
         }
 
-        processQuery(request, params, response, used_output, query_scope, write_event);
+        processQuery(request, params, response, used_output, query_scope);
         if (request_credentials)
             LOG_DEBUG(log, "Authentication in progress...");
         else

--- a/src/Server/HTTPHandler.h
+++ b/src/Server/HTTPHandler.h
@@ -6,8 +6,6 @@
 #include <Server/HTTP/WriteBufferFromHTTPServerResponse.h>
 #include <Common/CurrentMetrics.h>
 #include <Common/CurrentThread.h>
-#include <IO/CascadeWriteBuffer.h>
-#include <Compression/CompressedWriteBuffer.h>
 
 #ifdef __clang__
 #  pragma clang diagnostic push
@@ -42,7 +40,7 @@ public:
     HTTPHandler(IServer & server_, const std::string & name, const std::optional<String> & content_type_override_);
     virtual ~HTTPHandler() override;
 
-    void handleRequest(HTTPServerRequest & request, HTTPServerResponse & response, const ProfileEvents::Event & write_event) override;
+    void handleRequest(HTTPServerRequest & request, HTTPServerResponse & response) override;
 
     /// This method is called right before the query execution.
     virtual void customizeContext(HTTPServerRequest & /* request */, ContextMutablePtr /* context */, ReadBuffer & /* body */) {}
@@ -63,22 +61,11 @@ private:
          * WriteBufferFromHTTPServerResponse out
          */
 
-        /// Holds original response buffer
-        std::shared_ptr<WriteBufferFromHTTPServerResponse> out_holder;
-        /// If HTTP compression is enabled holds compression wrapper over original response buffer
-        std::shared_ptr<WriteBuffer> wrap_compressed_holder;
-        /// Points either to out_holder or to wrap_compressed_holder
-        std::shared_ptr<WriteBuffer> out;
-
-        /// If internal compression is enabled holds compression wrapper over out buffer
-        std::shared_ptr<CompressedWriteBuffer> out_compressed_holder;
-        /// Points to 'out' or to CompressedWriteBuffer(*out)
+        std::shared_ptr<WriteBufferFromHTTPServerResponse> out;
+        /// Points to 'out' or to CompressedWriteBuffer(*out), depending on settings.
         std::shared_ptr<WriteBuffer> out_maybe_compressed;
-
-        /// If output should be delayed holds cascade buffer
-        std::unique_ptr<CascadeWriteBuffer> out_delayed_and_compressed_holder;
-        /// Points to out_maybe_compressed or to CascadeWriteBuffer.
-        WriteBuffer * out_maybe_delayed_and_compressed = nullptr;
+        /// Points to 'out' or to CompressedWriteBuffer(*out) or to CascadeWriteBuffer.
+        std::shared_ptr<WriteBuffer> out_maybe_delayed_and_compressed;
 
         bool finalized = false;
 
@@ -86,7 +73,7 @@ private:
 
         inline bool hasDelayed() const
         {
-            return out_maybe_delayed_and_compressed != out_maybe_compressed.get();
+            return out_maybe_delayed_and_compressed != out_maybe_compressed;
         }
 
         inline void finalize()
@@ -95,9 +82,11 @@ private:
                 return;
             finalized = true;
 
+            if (out_maybe_delayed_and_compressed)
+                out_maybe_delayed_and_compressed->finalize();
             if (out_maybe_compressed)
                 out_maybe_compressed->finalize();
-            else if (out)
+            if (out)
                 out->finalize();
         }
 
@@ -146,8 +135,7 @@ private:
         HTMLForm & params,
         HTTPServerResponse & response,
         Output & used_output,
-        std::optional<CurrentThread::QueryScope> & query_scope,
-        const ProfileEvents::Event & write_event);
+        std::optional<CurrentThread::QueryScope> & query_scope);
 
     void trySendExceptionToClient(
         const std::string & s,

--- a/src/Server/InterserverIOHTTPHandler.cpp
+++ b/src/Server/InterserverIOHTTPHandler.cpp
@@ -77,7 +77,7 @@ void InterserverIOHTTPHandler::processQuery(HTTPServerRequest & request, HTTPSer
 }
 
 
-void InterserverIOHTTPHandler::handleRequest(HTTPServerRequest & request, HTTPServerResponse & response, const ProfileEvents::Event & write_event)
+void InterserverIOHTTPHandler::handleRequest(HTTPServerRequest & request, HTTPServerResponse & response)
 {
     setThreadName("IntersrvHandler");
     ThreadStatus thread_status;
@@ -89,7 +89,7 @@ void InterserverIOHTTPHandler::handleRequest(HTTPServerRequest & request, HTTPSe
     Output used_output;
     const auto keep_alive_timeout = server.context()->getServerSettings().keep_alive_timeout.totalSeconds();
     used_output.out = std::make_shared<WriteBufferFromHTTPServerResponse>(
-        response, request.getMethod() == Poco::Net::HTTPRequest::HTTP_HEAD, keep_alive_timeout, write_event);
+        response, request.getMethod() == Poco::Net::HTTPRequest::HTTP_HEAD, keep_alive_timeout);
 
     auto write_response = [&](const std::string & message)
     {

--- a/src/Server/InterserverIOHTTPHandler.h
+++ b/src/Server/InterserverIOHTTPHandler.h
@@ -30,7 +30,7 @@ public:
     {
     }
 
-    void handleRequest(HTTPServerRequest & request, HTTPServerResponse & response, const ProfileEvents::Event & write_event) override;
+    void handleRequest(HTTPServerRequest & request, HTTPServerResponse & response) override;
 
 private:
     struct Output

--- a/src/Server/KeeperReadinessHandler.cpp
+++ b/src/Server/KeeperReadinessHandler.cpp
@@ -19,7 +19,7 @@
 namespace DB
 {
 
-void KeeperReadinessHandler::handleRequest(HTTPServerRequest & /*request*/, HTTPServerResponse & response, const ProfileEvents::Event & /*write_event*/)
+void KeeperReadinessHandler::handleRequest(HTTPServerRequest & /*request*/, HTTPServerResponse & response)
 {
     try
     {
@@ -58,7 +58,7 @@ void KeeperReadinessHandler::handleRequest(HTTPServerRequest & /*request*/, HTTP
             if (!response.sent())
             {
                 /// We have not sent anything yet and we don't even know if we need to compress response.
-                *response.send() << getCurrentExceptionMessage(false) << '\n';
+                *response.send() << getCurrentExceptionMessage(false) << std::endl;
             }
         }
         catch (...)

--- a/src/Server/KeeperReadinessHandler.h
+++ b/src/Server/KeeperReadinessHandler.h
@@ -22,7 +22,7 @@ public:
     {
     }
 
-    void handleRequest(HTTPServerRequest & request, HTTPServerResponse & response, const ProfileEvents::Event & write_event) override;
+    void handleRequest(HTTPServerRequest & request, HTTPServerResponse & response) override;
 };
 
 HTTPRequestHandlerFactoryPtr

--- a/src/Server/MySQLHandler.cpp
+++ b/src/Server/MySQLHandler.cpp
@@ -70,17 +70,13 @@ MySQLHandler::MySQLHandler(
     IServer & server_,
     TCPServer & tcp_server_,
     const Poco::Net::StreamSocket & socket_,
-    bool ssl_enabled, uint32_t connection_id_,
-    const ProfileEvents::Event & read_event_,
-    const ProfileEvents::Event & write_event_)
+    bool ssl_enabled, uint32_t connection_id_)
     : Poco::Net::TCPServerConnection(socket_)
     , server(server_)
     , tcp_server(tcp_server_)
     , log(&Poco::Logger::get("MySQLHandler"))
     , connection_id(connection_id_)
     , auth_plugin(new MySQLProtocol::Authentication::Native41())
-    , read_event(read_event_)
-    , write_event(write_event_)
 {
     server_capabilities = CLIENT_PROTOCOL_41 | CLIENT_SECURE_CONNECTION | CLIENT_PLUGIN_AUTH | CLIENT_PLUGIN_AUTH_LENENC_CLIENT_DATA | CLIENT_CONNECT_WITH_DB | CLIENT_DEPRECATE_EOF;
     if (ssl_enabled)
@@ -102,8 +98,8 @@ void MySQLHandler::run()
 
     session->setClientConnectionId(connection_id);
 
-    in = std::make_shared<ReadBufferFromPocoSocket>(socket(), read_event);
-    out = std::make_shared<WriteBufferFromPocoSocket>(socket(), write_event);
+    in = std::make_shared<ReadBufferFromPocoSocket>(socket());
+    out = std::make_shared<WriteBufferFromPocoSocket>(socket());
     packet_endpoint = std::make_shared<MySQLProtocol::PacketEndpoint>(*in, *out, sequence_id);
 
     try
@@ -493,10 +489,8 @@ MySQLHandlerSSL::MySQLHandlerSSL(
     bool ssl_enabled,
     uint32_t connection_id_,
     RSA & public_key_,
-    RSA & private_key_,
-    const ProfileEvents::Event & read_event_,
-    const ProfileEvents::Event & write_event_)
-    : MySQLHandler(server_, tcp_server_, socket_, ssl_enabled, connection_id_, read_event_, write_event_)
+    RSA & private_key_)
+    : MySQLHandler(server_, tcp_server_, socket_, ssl_enabled, connection_id_)
     , public_key(public_key_)
     , private_key(private_key_)
 {}

--- a/src/Server/MySQLHandler.h
+++ b/src/Server/MySQLHandler.h
@@ -42,9 +42,7 @@ public:
         TCPServer & tcp_server_,
         const Poco::Net::StreamSocket & socket_,
         bool ssl_enabled,
-        uint32_t connection_id_,
-        const ProfileEvents::Event & read_event_ = ProfileEvents::end(),
-        const ProfileEvents::Event & write_event_ = ProfileEvents::end());
+        uint32_t connection_id_);
 
     void run() final;
 
@@ -104,9 +102,6 @@ protected:
     std::shared_ptr<ReadBufferFromPocoSocket> in;
     std::shared_ptr<WriteBuffer> out;
     bool secure_connection = false;
-
-    ProfileEvents::Event read_event;
-    ProfileEvents::Event write_event;
 };
 
 #if USE_SSL
@@ -120,9 +115,7 @@ public:
         bool ssl_enabled,
         uint32_t connection_id_,
         RSA & public_key_,
-        RSA & private_key_,
-        const ProfileEvents::Event & read_event_ = ProfileEvents::end(),
-        const ProfileEvents::Event & write_event_ = ProfileEvents::end());
+        RSA & private_key_);
 
 private:
     void authPluginSSL() override;

--- a/src/Server/MySQLHandlerFactory.cpp
+++ b/src/Server/MySQLHandlerFactory.cpp
@@ -21,11 +21,9 @@ namespace ErrorCodes
     extern const int OPENSSL_ERROR;
 }
 
-MySQLHandlerFactory::MySQLHandlerFactory(IServer & server_, const ProfileEvents::Event & read_event_, const ProfileEvents::Event & write_event_)
+MySQLHandlerFactory::MySQLHandlerFactory(IServer & server_)
     : server(server_)
     , log(&Poco::Logger::get("MySQLHandlerFactory"))
-    , read_event(read_event_)
-    , write_event(write_event_)
 {
 #if USE_SSL
     try

--- a/src/Server/MySQLHandlerFactory.h
+++ b/src/Server/MySQLHandlerFactory.h
@@ -4,7 +4,6 @@
 #include <memory>
 #include <Server/IServer.h>
 #include <Server/TCPServerConnectionFactory.h>
-#include <Common/ProfileEvents.h>
 
 #include "config.h"
 
@@ -38,11 +37,8 @@ private:
 #endif
 
     std::atomic<unsigned> last_connection_id = 0;
-
-    ProfileEvents::Event read_event;
-    ProfileEvents::Event write_event;
 public:
-    explicit MySQLHandlerFactory(IServer & server_, const ProfileEvents::Event & read_event_ = ProfileEvents::end(), const ProfileEvents::Event & write_event_ = ProfileEvents::end());
+    explicit MySQLHandlerFactory(IServer & server_);
 
     void readRSAKeys();
 

--- a/src/Server/NotFoundHandler.cpp
+++ b/src/Server/NotFoundHandler.cpp
@@ -5,7 +5,7 @@
 
 namespace DB
 {
-void NotFoundHandler::handleRequest(HTTPServerRequest & request, HTTPServerResponse & response, const ProfileEvents::Event & /*write_event*/)
+void NotFoundHandler::handleRequest(HTTPServerRequest & request, HTTPServerResponse & response)
 {
     try
     {

--- a/src/Server/NotFoundHandler.h
+++ b/src/Server/NotFoundHandler.h
@@ -10,7 +10,7 @@ class NotFoundHandler : public HTTPRequestHandler
 {
 public:
     NotFoundHandler(std::vector<std::string> hints_) : hints(std::move(hints_)) {}
-    void handleRequest(HTTPServerRequest & request, HTTPServerResponse & response, const ProfileEvents::Event & write_event) override;
+    void handleRequest(HTTPServerRequest & request, HTTPServerResponse & response) override;
 private:
     std::vector<std::string> hints;
 };

--- a/src/Server/PostgreSQLHandler.cpp
+++ b/src/Server/PostgreSQLHandler.cpp
@@ -32,16 +32,12 @@ PostgreSQLHandler::PostgreSQLHandler(
     TCPServer & tcp_server_,
     bool ssl_enabled_,
     Int32 connection_id_,
-    std::vector<std::shared_ptr<PostgreSQLProtocol::PGAuthentication::AuthenticationMethod>> & auth_methods_,
-    const ProfileEvents::Event & read_event_,
-    const ProfileEvents::Event & write_event_)
+    std::vector<std::shared_ptr<PostgreSQLProtocol::PGAuthentication::AuthenticationMethod>> & auth_methods_)
     : Poco::Net::TCPServerConnection(socket_)
     , server(server_)
     , tcp_server(tcp_server_)
     , ssl_enabled(ssl_enabled_)
     , connection_id(connection_id_)
-    , read_event(read_event_)
-    , write_event(write_event_)
     , authentication_manager(auth_methods_)
 {
     changeIO(socket());
@@ -49,8 +45,8 @@ PostgreSQLHandler::PostgreSQLHandler(
 
 void PostgreSQLHandler::changeIO(Poco::Net::StreamSocket & socket)
 {
-    in = std::make_shared<ReadBufferFromPocoSocket>(socket, read_event);
-    out = std::make_shared<WriteBufferFromPocoSocket>(socket, write_event);
+    in = std::make_shared<ReadBufferFromPocoSocket>(socket);
+    out = std::make_shared<WriteBufferFromPocoSocket>(socket);
     message_transport = std::make_shared<PostgreSQLProtocol::Messaging::MessageTransport>(in.get(), out.get());
 }
 

--- a/src/Server/PostgreSQLHandler.h
+++ b/src/Server/PostgreSQLHandler.h
@@ -33,9 +33,7 @@ public:
         TCPServer & tcp_server_,
         bool ssl_enabled_,
         Int32 connection_id_,
-        std::vector<std::shared_ptr<PostgreSQLProtocol::PGAuthentication::AuthenticationMethod>> & auth_methods_,
-        const ProfileEvents::Event & read_event_ = ProfileEvents::end(),
-        const ProfileEvents::Event & write_event_ = ProfileEvents::end());
+        std::vector<std::shared_ptr<PostgreSQLProtocol::PGAuthentication::AuthenticationMethod>> & auth_methods_);
 
     void run() final;
 
@@ -52,9 +50,6 @@ private:
     std::shared_ptr<ReadBufferFromPocoSocket> in;
     std::shared_ptr<WriteBuffer> out;
     std::shared_ptr<PostgreSQLProtocol::Messaging::MessageTransport> message_transport;
-
-    ProfileEvents::Event read_event;
-    ProfileEvents::Event write_event;
 
 #if USE_SSL
     std::shared_ptr<Poco::Net::SecureStreamSocket> ss;

--- a/src/Server/PostgreSQLHandlerFactory.cpp
+++ b/src/Server/PostgreSQLHandlerFactory.cpp
@@ -5,11 +5,9 @@
 namespace DB
 {
 
-PostgreSQLHandlerFactory::PostgreSQLHandlerFactory(IServer & server_, const ProfileEvents::Event & read_event_, const ProfileEvents::Event & write_event_)
+PostgreSQLHandlerFactory::PostgreSQLHandlerFactory(IServer & server_)
     : server(server_)
     , log(&Poco::Logger::get("PostgreSQLHandlerFactory"))
-    , read_event(read_event_)
-    , write_event(write_event_)
 {
     auth_methods =
     {
@@ -22,7 +20,7 @@ Poco::Net::TCPServerConnection * PostgreSQLHandlerFactory::createConnection(cons
 {
     Int32 connection_id = last_connection_id++;
     LOG_TRACE(log, "PostgreSQL connection. Id: {}. Address: {}", connection_id, socket.peerAddress().toString());
-    return new PostgreSQLHandler(socket, server, tcp_server, ssl_enabled, connection_id, auth_methods, read_event, write_event);
+    return new PostgreSQLHandler(socket, server, tcp_server, ssl_enabled, connection_id, auth_methods);
 }
 
 }

--- a/src/Server/PostgreSQLHandlerFactory.h
+++ b/src/Server/PostgreSQLHandlerFactory.h
@@ -15,8 +15,6 @@ class PostgreSQLHandlerFactory : public TCPServerConnectionFactory
 private:
     IServer & server;
     Poco::Logger * log;
-    ProfileEvents::Event read_event;
-    ProfileEvents::Event write_event;
 
 #if USE_SSL
     bool ssl_enabled = true;
@@ -28,7 +26,7 @@ private:
     std::vector<std::shared_ptr<PostgreSQLProtocol::PGAuthentication::AuthenticationMethod>> auth_methods;
 
 public:
-    explicit PostgreSQLHandlerFactory(IServer & server_, const ProfileEvents::Event & read_event_ = ProfileEvents::end(), const ProfileEvents::Event & write_event_ = ProfileEvents::end());
+    explicit PostgreSQLHandlerFactory(IServer & server_);
 
     Poco::Net::TCPServerConnection * createConnection(const Poco::Net::StreamSocket & socket, TCPServer & server) override;
 };

--- a/src/Server/PrometheusRequestHandler.cpp
+++ b/src/Server/PrometheusRequestHandler.cpp
@@ -13,7 +13,7 @@
 
 namespace DB
 {
-void PrometheusRequestHandler::handleRequest(HTTPServerRequest & request, HTTPServerResponse & response, const ProfileEvents::Event & write_event)
+void PrometheusRequestHandler::handleRequest(HTTPServerRequest & request, HTTPServerResponse & response)
 {
     try
     {
@@ -27,7 +27,7 @@ void PrometheusRequestHandler::handleRequest(HTTPServerRequest & request, HTTPSe
 
         response.setContentType("text/plain; version=0.0.4; charset=UTF-8");
 
-        WriteBufferFromHTTPServerResponse wb(response, request.getMethod() == Poco::Net::HTTPRequest::HTTP_HEAD, keep_alive_timeout, write_event);
+        WriteBufferFromHTTPServerResponse wb(response, request.getMethod() == Poco::Net::HTTPRequest::HTTP_HEAD, keep_alive_timeout);
         try
         {
             metrics_writer.write(wb);

--- a/src/Server/PrometheusRequestHandler.h
+++ b/src/Server/PrometheusRequestHandler.h
@@ -22,7 +22,7 @@ public:
     {
     }
 
-    void handleRequest(HTTPServerRequest & request, HTTPServerResponse & response, const ProfileEvents::Event & write_event) override;
+    void handleRequest(HTTPServerRequest & request, HTTPServerResponse & response) override;
 };
 
 }

--- a/src/Server/ReplicasStatusHandler.cpp
+++ b/src/Server/ReplicasStatusHandler.cpp
@@ -22,7 +22,7 @@ ReplicasStatusHandler::ReplicasStatusHandler(IServer & server) : WithContext(ser
 {
 }
 
-void ReplicasStatusHandler::handleRequest(HTTPServerRequest & request, HTTPServerResponse & response, const ProfileEvents::Event & /*write_event*/)
+void ReplicasStatusHandler::handleRequest(HTTPServerRequest & request, HTTPServerResponse & response)
 {
     try
     {
@@ -113,7 +113,7 @@ void ReplicasStatusHandler::handleRequest(HTTPServerRequest & request, HTTPServe
             if (!response.sent())
             {
                 /// We have not sent anything yet and we don't even know if we need to compress response.
-                *response.send() << getCurrentExceptionMessage(false) << '\n';
+                *response.send() << getCurrentExceptionMessage(false) << std::endl;
             }
         }
         catch (...)

--- a/src/Server/ReplicasStatusHandler.h
+++ b/src/Server/ReplicasStatusHandler.h
@@ -14,7 +14,7 @@ class ReplicasStatusHandler : public HTTPRequestHandler, WithContext
 public:
     explicit ReplicasStatusHandler(IServer & server_);
 
-    void handleRequest(HTTPServerRequest & request, HTTPServerResponse & response, const ProfileEvents::Event & write_event) override;
+    void handleRequest(HTTPServerRequest & request, HTTPServerResponse & response) override;
 };
 
 

--- a/src/Server/StaticRequestHandler.cpp
+++ b/src/Server/StaticRequestHandler.cpp
@@ -33,11 +33,9 @@ namespace ErrorCodes
     extern const int INVALID_CONFIG_PARAMETER;
 }
 
-static inline std::unique_ptr<WriteBuffer>
+static inline WriteBufferPtr
 responseWriteBuffer(HTTPServerRequest & request, HTTPServerResponse & response, UInt64 keep_alive_timeout)
 {
-    auto buf = std::unique_ptr<WriteBuffer>(new WriteBufferFromHTTPServerResponse(response, request.getMethod() == HTTPRequest::HTTP_HEAD, keep_alive_timeout));
-
     /// The client can pass a HTTP header indicating supported compression method (gzip or deflate).
     String http_response_compression_methods = request.get("Accept-Encoding", "");
     CompressionMethod http_response_compression_method = CompressionMethod::None;
@@ -45,11 +43,14 @@ responseWriteBuffer(HTTPServerRequest & request, HTTPServerResponse & response, 
     if (!http_response_compression_methods.empty())
         http_response_compression_method = chooseHTTPCompressionMethod(http_response_compression_methods);
 
-    if (http_response_compression_method == CompressionMethod::None)
-        return buf;
+    bool client_supports_http_compression = http_response_compression_method != CompressionMethod::None;
 
-    response.set("Content-Encoding", toContentEncodingName(http_response_compression_method));
-    return wrapWriteBufferWithCompressionMethod(std::move(buf), http_response_compression_method, 1);
+    return std::make_shared<WriteBufferFromHTTPServerResponse>(
+        response,
+        request.getMethod() == Poco::Net::HTTPRequest::HTTP_HEAD,
+        keep_alive_timeout,
+        client_supports_http_compression,
+        http_response_compression_method);
 }
 
 static inline void trySendExceptionToClient(
@@ -68,7 +69,7 @@ static inline void trySendExceptionToClient(
         response.setStatusAndReason(Poco::Net::HTTPResponse::HTTP_INTERNAL_SERVER_ERROR);
 
         if (!response.sent())
-            *response.send() << s << '\n';
+            *response.send() << s << std::endl;
         else
         {
             if (out.count() != out.offset())
@@ -87,10 +88,10 @@ static inline void trySendExceptionToClient(
     }
 }
 
-void StaticRequestHandler::handleRequest(HTTPServerRequest & request, HTTPServerResponse & response, const ProfileEvents::Event & /*write_event*/)
+void StaticRequestHandler::handleRequest(HTTPServerRequest & request, HTTPServerResponse & response)
 {
     auto keep_alive_timeout = server.context()->getServerSettings().keep_alive_timeout.totalSeconds();
-    auto out = responseWriteBuffer(request, response, keep_alive_timeout);
+    const auto & out = responseWriteBuffer(request, response, keep_alive_timeout);
 
     try
     {

--- a/src/Server/StaticRequestHandler.h
+++ b/src/Server/StaticRequestHandler.h
@@ -29,7 +29,7 @@ public:
 
     void writeResponse(WriteBuffer & out);
 
-    void handleRequest(HTTPServerRequest & request, HTTPServerResponse & response, const ProfileEvents::Event & write_event) override;
+    void handleRequest(HTTPServerRequest & request, HTTPServerResponse & response) override;
 };
 
 }

--- a/src/Server/TCPHandler.cpp
+++ b/src/Server/TCPHandler.cpp
@@ -184,27 +184,23 @@ void validateClientInfo(const ClientInfo & session_client_info, const ClientInfo
 namespace DB
 {
 
-TCPHandler::TCPHandler(IServer & server_, TCPServer & tcp_server_, const Poco::Net::StreamSocket & socket_, bool parse_proxy_protocol_, std::string server_display_name_, const ProfileEvents::Event & read_event_, const ProfileEvents::Event & write_event_)
+TCPHandler::TCPHandler(IServer & server_, TCPServer & tcp_server_, const Poco::Net::StreamSocket & socket_, bool parse_proxy_protocol_, std::string server_display_name_)
     : Poco::Net::TCPServerConnection(socket_)
     , server(server_)
     , tcp_server(tcp_server_)
     , parse_proxy_protocol(parse_proxy_protocol_)
     , log(&Poco::Logger::get("TCPHandler"))
-    , read_event(read_event_)
-    , write_event(write_event_)
     , server_display_name(std::move(server_display_name_))
 {
 }
 
-TCPHandler::TCPHandler(IServer & server_, TCPServer & tcp_server_, const Poco::Net::StreamSocket & socket_, TCPProtocolStackData & stack_data, std::string server_display_name_, const ProfileEvents::Event & read_event_, const ProfileEvents::Event & write_event_)
+TCPHandler::TCPHandler(IServer & server_, TCPServer & tcp_server_, const Poco::Net::StreamSocket & socket_, TCPProtocolStackData & stack_data, std::string server_display_name_)
 : Poco::Net::TCPServerConnection(socket_)
     , server(server_)
     , tcp_server(tcp_server_)
     , log(&Poco::Logger::get("TCPHandler"))
     , forwarded_for(stack_data.forwarded_for)
     , certificate(stack_data.certificate)
-    , read_event(read_event_)
-    , write_event(write_event_)
     , default_database(stack_data.default_database)
     , server_display_name(std::move(server_display_name_))
 {
@@ -237,8 +233,8 @@ void TCPHandler::runImpl()
     socket().setSendTimeout(send_timeout);
     socket().setNoDelay(true);
 
-    in = std::make_shared<ReadBufferFromPocoSocket>(socket(), read_event);
-    out = std::make_shared<WriteBufferFromPocoSocket>(socket(), write_event);
+    in = std::make_shared<ReadBufferFromPocoSocket>(socket());
+    out = std::make_shared<WriteBufferFromPocoSocket>(socket());
 
     /// Support for PROXY protocol
     if (parse_proxy_protocol && !receiveProxyHeader())

--- a/src/Server/TCPHandler.h
+++ b/src/Server/TCPHandler.h
@@ -147,8 +147,8 @@ public:
       *  because it allows to check the IP ranges of the trusted proxy.
       * Proxy-forwarded (original client) IP address is used for quota accounting if quota is keyed by forwarded IP.
       */
-    TCPHandler(IServer & server_, TCPServer & tcp_server_, const Poco::Net::StreamSocket & socket_, bool parse_proxy_protocol_, std::string server_display_name_, const ProfileEvents::Event & read_event_ = ProfileEvents::end(), const ProfileEvents::Event & write_event_ = ProfileEvents::end());
-    TCPHandler(IServer & server_, TCPServer & tcp_server_, const Poco::Net::StreamSocket & socket_, TCPProtocolStackData & stack_data, std::string server_display_name_, const ProfileEvents::Event & read_event_ = ProfileEvents::end(), const ProfileEvents::Event & write_event_ = ProfileEvents::end());
+    TCPHandler(IServer & server_, TCPServer & tcp_server_, const Poco::Net::StreamSocket & socket_, bool parse_proxy_protocol_, std::string server_display_name_);
+    TCPHandler(IServer & server_, TCPServer & tcp_server_, const Poco::Net::StreamSocket & socket_, TCPProtocolStackData & stack_data, std::string server_display_name_);
     ~TCPHandler() override;
 
     void run() override;
@@ -190,9 +190,6 @@ private:
     /// Streams for reading/writing from/to client connection socket.
     std::shared_ptr<ReadBuffer> in;
     std::shared_ptr<WriteBuffer> out;
-
-    ProfileEvents::Event read_event;
-    ProfileEvents::Event write_event;
 
     /// Time after the last check to stop the request and send the progress.
     Stopwatch after_check_cancelled;

--- a/src/Server/TCPHandlerFactory.h
+++ b/src/Server/TCPHandlerFactory.h
@@ -21,9 +21,6 @@ private:
     Poco::Logger * log;
     std::string server_display_name;
 
-    ProfileEvents::Event read_event;
-    ProfileEvents::Event write_event;
-
     class DummyTCPHandler : public Poco::Net::TCPServerConnection
     {
     public:
@@ -36,11 +33,9 @@ public:
       * and set the information about forwarded address accordingly.
       * See https://github.com/wolfeidau/proxyv2/blob/master/docs/proxy-protocol.txt
       */
-    TCPHandlerFactory(IServer & server_, bool secure_, bool parse_proxy_protocol_, const ProfileEvents::Event & read_event_ = ProfileEvents::end(), const ProfileEvents::Event & write_event_ = ProfileEvents::end())
+    TCPHandlerFactory(IServer & server_, bool secure_, bool parse_proxy_protocol_)
         : server(server_), parse_proxy_protocol(parse_proxy_protocol_)
         , log(&Poco::Logger::get(std::string("TCP") + (secure_ ? "S" : "") + "HandlerFactory"))
-        , read_event(read_event_)
-        , write_event(write_event_)
     {
         server_display_name = server.config().getString("display_name", getFQDNOrHostName());
     }
@@ -50,7 +45,8 @@ public:
         try
         {
             LOG_TRACE(log, "TCP Request. Address: {}", socket.peerAddress().toString());
-            return new TCPHandler(server, tcp_server, socket, parse_proxy_protocol, server_display_name, read_event, write_event);
+
+            return new TCPHandler(server, tcp_server, socket, parse_proxy_protocol, server_display_name);
         }
         catch (const Poco::Net::NetException &)
         {
@@ -64,7 +60,8 @@ public:
         try
         {
             LOG_TRACE(log, "TCP Request. Address: {}", socket.peerAddress().toString());
-            return new TCPHandler(server, tcp_server, socket, stack_data, server_display_name, read_event, write_event);
+
+            return new TCPHandler(server, tcp_server, socket, stack_data, server_display_name);
         }
         catch (const Poco::Net::NetException &)
         {

--- a/src/Server/WebUIRequestHandler.cpp
+++ b/src/Server/WebUIRequestHandler.cpp
@@ -1,6 +1,5 @@
 #include "WebUIRequestHandler.h"
 #include "IServer.h"
-#include <Server/HTTP/WriteBufferFromHTTPServerResponse.h>
 
 #include <Poco/Net/HTTPServerResponse.h>
 #include <Poco/Util/LayeredConfiguration.h>
@@ -37,7 +36,7 @@ WebUIRequestHandler::WebUIRequestHandler(IServer & server_)
 }
 
 
-void WebUIRequestHandler::handleRequest(HTTPServerRequest & request, HTTPServerResponse & response, const ProfileEvents::Event & /*write_event*/)
+void WebUIRequestHandler::handleRequest(HTTPServerRequest & request, HTTPServerResponse & response)
 {
     auto keep_alive_timeout = server.context()->getServerSettings().keep_alive_timeout.totalSeconds();
 
@@ -51,7 +50,7 @@ void WebUIRequestHandler::handleRequest(HTTPServerRequest & request, HTTPServerR
     if (request.getURI().starts_with("/play"))
     {
         response.setStatusAndReason(Poco::Net::HTTPResponse::HTTP_OK);
-        WriteBufferFromHTTPServerResponse(response, request.getMethod() == HTTPRequest::HTTP_HEAD, keep_alive_timeout).write(reinterpret_cast<const char *>(gresource_play_htmlData), gresource_play_htmlSize);
+        *response.send() << std::string_view(reinterpret_cast<const char *>(gresource_play_htmlData), gresource_play_htmlSize);
     }
     else if (request.getURI().starts_with("/dashboard"))
     {
@@ -67,17 +66,17 @@ void WebUIRequestHandler::handleRequest(HTTPServerRequest & request, HTTPServerR
         static re2::RE2 uplot_url = R"(https://[^\s"'`]+u[Pp]lot[^\s"'`]*\.js)";
         RE2::Replace(&html, uplot_url, "/js/uplot.js");
 
-        WriteBufferFromHTTPServerResponse(response, request.getMethod() == HTTPRequest::HTTP_HEAD, keep_alive_timeout).write(html);
+        *response.send() << html;
     }
     else if (request.getURI().starts_with("/binary"))
     {
         response.setStatusAndReason(Poco::Net::HTTPResponse::HTTP_OK);
-        WriteBufferFromHTTPServerResponse(response, request.getMethod() == HTTPRequest::HTTP_HEAD, keep_alive_timeout).write(reinterpret_cast<const char *>(gresource_binary_htmlData), gresource_binary_htmlSize);
+        *response.send() << std::string_view(reinterpret_cast<const char *>(gresource_binary_htmlData), gresource_binary_htmlSize);
     }
     else if (request.getURI() == "/js/uplot.js")
     {
         response.setStatusAndReason(Poco::Net::HTTPResponse::HTTP_OK);
-        WriteBufferFromHTTPServerResponse(response, request.getMethod() == HTTPRequest::HTTP_HEAD, keep_alive_timeout).write(reinterpret_cast<const char *>(gresource_uplot_jsData), gresource_uplot_jsSize);
+        *response.send() << std::string_view(reinterpret_cast<const char *>(gresource_uplot_jsData), gresource_uplot_jsSize);
     }
     else
     {

--- a/src/Server/WebUIRequestHandler.h
+++ b/src/Server/WebUIRequestHandler.h
@@ -16,7 +16,7 @@ private:
 
 public:
     WebUIRequestHandler(IServer & server_);
-    void handleRequest(HTTPServerRequest & request, HTTPServerResponse & response, const ProfileEvents::Event & write_event) override;
+    void handleRequest(HTTPServerRequest & request, HTTPServerResponse & response) override;
 };
 
 }

--- a/tests/queries/0_stateless/02293_http_header_full_summary_without_progress.sh
+++ b/tests/queries/0_stateless/02293_http_header_full_summary_without_progress.sh
@@ -7,7 +7,7 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 
 CURL_OUTPUT=$(echo 'SELECT 1 + sleepEachRow(0.00002) FROM numbers(100000)' | \
-  ${CLICKHOUSE_CURL_COMMAND} -vsS "${CLICKHOUSE_URL}&wait_end_of_query=1&send_progress_in_http_headers=0&max_execution_time=1" --data-binary @- 2>&1)
+  ${CLICKHOUSE_CURL_COMMAND} -v "${CLICKHOUSE_URL}&wait_end_of_query=1&send_progress_in_http_headers=0&max_execution_time=1" --data-binary @- 2>&1)
 
 READ_ROWS=$(echo "${CURL_OUTPUT}" | \
   grep 'X-ClickHouse-Summary' | \

--- a/tests/queries/0_stateless/02373_progress_contain_result.sh
+++ b/tests/queries/0_stateless/02373_progress_contain_result.sh
@@ -5,5 +5,5 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../shell_config.sh
 
 echo 'SELECT 1 FROM numbers(100)' |
-  ${CLICKHOUSE_CURL_COMMAND} -vsS "${CLICKHOUSE_URL}&wait_end_of_query=1&send_progress_in_http_headers=0" --data-binary @- 2>&1 |
+  ${CLICKHOUSE_CURL_COMMAND} -v "${CLICKHOUSE_URL}&wait_end_of_query=1&send_progress_in_http_headers=0" --data-binary @- 2>&1 |
   grep 'X-ClickHouse-Summary' | sed 's/,\"elapsed_ns[^}]*//'


### PR DESCRIPTION
Reverts ClickHouse/ClickHouse#56064

Crash in its CI: https://s3.amazonaws.com/clickhouse-test-reports/56064/db97764e9886209a98812fd3a51548247cd4ff44/sqlancer__release_.html

Likely related crash in master: https://s3.amazonaws.com/clickhouse-test-reports/0/debbeb505dbf6a4f336bcab4a04b075fb641730c/stress_test__asan_.html