### PR TITLE
Delay reading from StorageKafka to allow multiple reads in materialized views

### DIFF
--- a/src/Storages/Kafka/StorageKafka.h
+++ b/src/Storages/Kafka/StorageKafka.h
@@ -20,6 +20,7 @@ namespace DB
 {
 
 class StorageSystemKafkaConsumers;
+class ReadFromStorageKafkaStep;
 
 struct StorageKafkaInterceptors;
 
@@ -48,7 +49,8 @@ public:
     void startup() override;
     void shutdown(bool is_drop) override;
 
-    Pipe read(
+    void read(
+        QueryPlan & query_plan,
         const Names & column_names,
         const StorageSnapshotPtr & storage_snapshot,
         SelectQueryInfo & query_info,
@@ -86,6 +88,8 @@ public:
     SafeConsumers getSafeConsumers() { return {shared_from_this(), std::unique_lock(mutex), consumers};  }
 
 private:
+    friend class ReadFromStorageKafkaStep;
+
     // Configuration and state
     std::unique_ptr<KafkaSettings> kafka_settings;
     Macros::MacroExpansionInfo macros_info;

--- a/tests/integration/test_storage_kafka/test.py
+++ b/tests/integration/test_storage_kafka/test.py
@@ -4930,6 +4930,77 @@ def test_formats_errors(kafka_cluster):
         instance.query(f"DROP TABLE test.{table_name}")
         instance.query("DROP TABLE test.view")
 
+def test_multiple_read_in_materialized_views(kafka_cluster, max_retries=15):
+    admin_client = KafkaAdminClient(
+        bootstrap_servers="localhost:{}".format(kafka_cluster.kafka_port)
+    )
+
+    topic = "multiple_read_from_mv"
+    kafka_create_topic(admin_client, topic)
+
+    instance.query(
+        f"""
+        DROP TABLE IF EXISTS test.kafka_multiple_read_input;
+        DROP TABLE IF EXISTS test.kafka_multiple_read_table;
+        DROP TABLE IF EXISTS test.kafka_multiple_read_mv;
+
+        CREATE TABLE test.kafka_multiple_read_input (id Int64)
+        ENGINE = Kafka
+        SETTINGS
+            kafka_broker_list = 'kafka1:19092',
+            kafka_topic_list = '{topic}',
+            kafka_group_name = '{topic}',
+            kafka_format = 'JSONEachRow';
+
+        CREATE TABLE test.kafka_multiple_read_table (id Int64)
+        ENGINE = MergeTree
+        ORDER BY id;
+
+
+        CREATE MATERIALIZED VIEW IF NOT EXISTS test.kafka_multiple_read_mv TO test.kafka_multiple_read_table AS
+        SELECT id
+        FROM test.kafka_multiple_read_input
+        WHERE id NOT IN (
+            SELECT id
+            FROM test.kafka_multiple_read_table
+            WHERE id IN (
+                SELECT id
+                FROM test.kafka_multiple_read_input
+            )
+        );
+        """
+    )
+
+    kafka_produce(kafka_cluster, topic, [json.dumps({"id": 42}), json.dumps({"id": 43})])
+
+    expected_result = "42\n43\n"
+    res = instance.query_with_retry(
+        f"SELECT id FROM test.kafka_multiple_read_table ORDER BY id",
+        retry_count=30,
+        sleep_time=0.5,
+        check_callback=lambda res: res == expected_result,
+    )
+    assert res == expected_result
+
+    # Verify that the query deduplicates the records as it meant to be
+    messages = []
+    for i in range(0,10):
+        messages.append(json.dumps({"id": 42}))
+        messages.append(json.dumps({"id": 43}))
+
+    messages.append(json.dumps({"id": 44}))
+
+    kafka_produce(kafka_cluster, topic, messages)
+
+    expected_result = "42\n43\n44\n"
+    res = instance.query_with_retry(
+        f"SELECT id FROM test.kafka_multiple_read_table ORDER BY id",
+        retry_count=30,
+        sleep_time=0.5,
+        check_callback=lambda res: res == expected_result,
+    )
+    assert res == expected_result
+
 
 if __name__ == "__main__":
     cluster.start()

--- a/tests/integration/test_storage_kafka/test.py
+++ b/tests/integration/test_storage_kafka/test.py
@@ -892,12 +892,14 @@ def test_kafka_formats(kafka_cluster):
 """
 
     expected_rows_count = raw_expected.count("\n")
-    instance.query_with_retry(
+    result_checker = lambda res: res.count("\n") == expected_rows_count
+    res = instance.query_with_retry(
         f"SELECT * FROM test.kafka_{list(all_formats.keys())[-1]}_mv;",
         retry_count=30,
         sleep_time=1,
-        check_callback=lambda res: res.count("\n") == expected_rows_count,
+        check_callback=result_checker,
     )
+    assert result_checker(res)
 
     for format_name, format_opts in list(all_formats.items()):
         logging.debug(("Checking {}".format(format_name)))
@@ -3808,12 +3810,14 @@ def test_kafka_formats_with_broken_message(kafka_cluster):
 """
 
     expected_rows_count = raw_expected.count("\n")
-    instance.query_with_retry(
+    result_checker = lambda res: res.count("\n") == expected_rows_count
+    res = instance.query_with_retry(
         f"SELECT * FROM test.kafka_data_{list(all_formats.keys())[-1]}_mv;",
         retry_count=30,
         sleep_time=1,
-        check_callback=lambda res: res.count("\n") == expected_rows_count,
+        check_callback=result_checker,
     )
+    assert result_checker(res)
 
     for format_name, format_opts in list(all_formats.items()):
         logging.debug(f"Checking {format_name}")

--- a/tests/integration/test_storage_kafka/test.py
+++ b/tests/integration/test_storage_kafka/test.py
@@ -4934,6 +4934,7 @@ def test_formats_errors(kafka_cluster):
         instance.query(f"DROP TABLE test.{table_name}")
         instance.query("DROP TABLE test.view")
 
+
 def test_multiple_read_in_materialized_views(kafka_cluster, max_retries=15):
     admin_client = KafkaAdminClient(
         bootstrap_servers="localhost:{}".format(kafka_cluster.kafka_port)
@@ -4975,7 +4976,9 @@ def test_multiple_read_in_materialized_views(kafka_cluster, max_retries=15):
         """
     )
 
-    kafka_produce(kafka_cluster, topic, [json.dumps({"id": 42}), json.dumps({"id": 43})])
+    kafka_produce(
+        kafka_cluster, topic, [json.dumps({"id": 42}), json.dumps({"id": 43})]
+    )
 
     expected_result = "42\n43\n"
     res = instance.query_with_retry(
@@ -4988,7 +4991,7 @@ def test_multiple_read_in_materialized_views(kafka_cluster, max_retries=15):
 
     # Verify that the query deduplicates the records as it meant to be
     messages = []
-    for i in range(0,10):
+    for i in range(0, 10):
         messages.append(json.dumps({"id": 42}))
         messages.append(json.dumps({"id": 43}))
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix reading multiple times from KafkaEngine in materialized views.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

Closes #58405.