### PR TITLE
Adjustable asynchronous insert timeouts

### DIFF
--- a/docs/en/operations/settings/settings.md
+++ b/docs/en/operations/settings/settings.md
@@ -1935,7 +1935,7 @@ Possible values:
 
 Default value: `450`.
 
-### async_insert_busy_timeout_ms {#async-insert-busy-timeout-ms}
+### async_insert_busy_timeout_max_ms {#async-insert-busy-timeout-max-ms}
 
 The maximum timeout in milliseconds since the first `INSERT` query before inserting collected data.
 
@@ -1945,6 +1945,61 @@ Possible values:
 - 0 — Timeout disabled.
 
 Default value: `200`.
+
+### async_insert_poll_timeout_ms {#async-insert-poll-timeout-ms}
+
+Timeout in milliseconds for polling data from asynchronous insert queue.
+
+Possible values:
+
+- Positive integer.
+
+Default value: `10`.
+
+### async_insert_use_adaptive_busy_timeout {#allow-experimental-async-insert-adaptive-busy-timeout}
+
+Use adaptive asynchronous insert timeout.
+
+Possible values:
+
+- 0 - Disabled.
+- 1 - Enabled.
+
+Default value: `0`.
+
+### async_insert_busy_timeout_min_ms {#async-insert-busy-timeout-min-ms}
+
+If adaptive asynchronous insert timeout is allowed through [async_insert_use_adaptive_busy_timeout](#allow-experimental-async-insert-adaptive-busy-timeout), the setting specifies the minimum value of the asynchronous insert timeout in milliseconds. It also serves as the initial value, which may be increased later by the adaptive algorithm, up to the [async_insert_busy_timeout_ms](#async_insert_busy_timeout_ms).
+
+Possible values:
+
+- Positive integer.
+
+Default value: `50`.
+
+### async_insert_busy_timeout_ms {#async-insert-busy-timeout-ms}
+
+Alias for [`async_insert_busy_timeout_max_ms`](#async_insert_busy_timeout_max_ms).
+
+### async_insert_busy_timeout_increase_rate {#async-insert-busy-timeout-increase-rate}
+
+If adaptive asynchronous insert timeout is allowed through [async_insert_use_adaptive_busy_timeout](#allow-experimental-async-insert-adaptive-busy-timeout), the setting specifies the exponential growth rate at which the adaptive asynchronous insert timeout increases.
+
+Possible values:
+
+- A positive floating-point number.
+
+Default value: `0.2`.
+
+### async_insert_busy_timeout_decrease_rate {#async-insert-busy-timeout-decrease-rate}
+
+If adaptive asynchronous insert timeout is allowed through [async_insert_use_adaptive_busy_timeout](#allow-experimental-async-insert-adaptive-busy-timeout), the setting specifies the exponential growth rate at which the adaptive asynchronous insert timeout decreases.
+
+Possible values:
+
+- A positive floating-point number.
+
+Default value: `0.2`.
 
 ### async_insert_stale_timeout_ms {#async-insert-stale-timeout-ms}
 

--- a/src/Common/CurrentMetrics.cpp
+++ b/src/Common/CurrentMetrics.cpp
@@ -143,6 +143,8 @@
     M(AsynchronousInsertThreads, "Number of threads in the AsynchronousInsert thread pool.") \
     M(AsynchronousInsertThreadsActive, "Number of threads in the AsynchronousInsert thread pool running a task.") \
     M(AsynchronousInsertThreadsScheduled, "Number of queued or active jobs in the AsynchronousInsert thread pool.") \
+    M(AsynchronousInsertQueueSize, "Number of pending tasks in the AsynchronousInsert queue.") \
+    M(AsynchronousInsertQueueBytes, "Number of pending bytes in the AsynchronousInsert queue.") \
     M(StartupSystemTablesThreads, "Number of threads in the StartupSystemTables thread pool.") \
     M(StartupSystemTablesThreadsActive, "Number of threads in the StartupSystemTables thread pool running a task.") \
     M(StartupSystemTablesThreadsScheduled, "Number of queued or active jobs in the StartupSystemTables thread pool.") \

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -751,6 +751,7 @@ class IColumn;
     M(UInt64, async_insert_max_data_size, 1000000, "Maximum size in bytes of unparsed data collected per query before being inserted", 0) \
     M(UInt64, async_insert_max_query_number, 450, "Maximum number of insert queries before being inserted", 0) \
     M(Milliseconds, async_insert_busy_timeout_ms, 200, "Maximum time to wait before dumping collected data per query since the first data appeared", 0) \
+    M(Milliseconds, async_insert_poll_timeout_ms, 10, "Timeout for polling data from asynchronous insert queue", 0) \
     \
     M(UInt64, remote_fs_read_max_backoff_ms, 10000, "Max wait time when trying to read data for remote disk", 0) \
     M(UInt64, remote_fs_read_backoff_max_tries, 5, "Max attempts to read with backoff", 0) \

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -750,8 +750,12 @@ class IColumn;
     M(Seconds, wait_for_async_insert_timeout, DBMS_DEFAULT_LOCK_ACQUIRE_TIMEOUT_SEC, "Timeout for waiting for processing asynchronous insertion", 0) \
     M(UInt64, async_insert_max_data_size, 1000000, "Maximum size in bytes of unparsed data collected per query before being inserted", 0) \
     M(UInt64, async_insert_max_query_number, 450, "Maximum number of insert queries before being inserted", 0) \
-    M(Milliseconds, async_insert_busy_timeout_ms, 200, "Maximum time to wait before dumping collected data per query since the first data appeared", 0) \
     M(Milliseconds, async_insert_poll_timeout_ms, 10, "Timeout for polling data from asynchronous insert queue", 0) \
+    M(Bool, async_insert_use_adaptive_busy_timeout, true, "If it is set to true, use adaptive busy timeout for asynchronous inserts", 0) \
+    M(Milliseconds, async_insert_busy_timeout_min_ms, 50, "If auto-adjusting is enabled through async_insert_use_adaptive_busy_timeout, minimum time to wait before dumping collected data per query since the first data appeared. It also serves as the initial value for the adaptive algorithm", 0) \
+    M(Milliseconds, async_insert_busy_timeout_max_ms, 200, "Maximum time to wait before dumping collected data per query since the first data appeared.", 0) ALIAS(async_insert_busy_timeout_ms) \
+    M(Double, async_insert_busy_timeout_increase_rate, 0.2, "The exponential growth rate at which the adaptive asynchronous insert timeout increases", 0) \
+    M(Double, async_insert_busy_timeout_decrease_rate, 0.2, "The exponential growth rate at which the adaptive asynchronous insert timeout decreases", 0) \
     \
     M(UInt64, remote_fs_read_max_backoff_ms, 10000, "Max wait time when trying to read data for remote disk", 0) \
     M(UInt64, remote_fs_read_backoff_max_tries, 5, "Max attempts to read with backoff", 0) \

--- a/src/Core/SettingsChangesHistory.h
+++ b/src/Core/SettingsChangesHistory.h
@@ -84,6 +84,12 @@ namespace SettingsChangesHistory
 /// It's used to implement `compatibility` setting (see https://github.com/ClickHouse/ClickHouse/issues/35972)
 static std::map<ClickHouseVersion, SettingsChangesHistory::SettingsChanges> settings_changes_history =
 {
+    {"24.2", {{"async_insert_poll_timeout_ms", 10, 10, "Timeout in milliseconds for polling data from asynchronous insert queue"},
+              {"async_insert_use_adaptive_busy_timeout", true, true, "Use adaptive asynchronous insert timeout"},
+              {"async_insert_busy_timeout_min_ms", 50, 50, "The minimum value of the asynchronous insert timeout in milliseconds; it also serves as the initial value, which may be increased later by the adaptive algorithm"},
+              {"async_insert_busy_timeout_max_ms", 200, 200, "The minimum value of the asynchronous insert timeout in milliseconds; async_insert_busy_timeout_ms is aliased to async_insert_busy_timeout_max_ms"},
+              {"async_insert_busy_timeout_increase_rate", 0.2, 0.2, "The exponential growth rate at which the adaptive asynchronous insert timeout increases"},
+              {"async_insert_busy_timeout_decrease_rate", 0.2, 0.2, "The exponential growth rate at which the adaptive asynchronous insert timeout decreases"}}},
     {"24.1", {{"print_pretty_type_names", false, true, "Better user experience."},
               {"input_format_json_read_bools_as_strings", false, true, "Allow to read bools as strings in JSON formats by default"},
               {"output_format_arrow_use_signed_indexes_for_dictionary", false, true, "Use signed indexes type for Arrow dictionaries by default as it's recommended"},

--- a/src/Interpreters/AsynchronousInsertLog.cpp
+++ b/src/Interpreters/AsynchronousInsertLog.cpp
@@ -32,8 +32,7 @@ ColumnsDescription AsynchronousInsertLogElement::getColumnsDescription()
             {"Preprocessed", static_cast<Int8>(DataKind::Preprocessed)},
         });
 
-    return ColumnsDescription
-    {
+    return ColumnsDescription{
         {"hostname", std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeString>())},
         {"event_date", std::make_shared<DataTypeDate>()},
         {"event_time", std::make_shared<DataTypeDateTime>()},
@@ -53,6 +52,7 @@ ColumnsDescription AsynchronousInsertLogElement::getColumnsDescription()
         {"flush_time", std::make_shared<DataTypeDateTime>()},
         {"flush_time_microseconds", std::make_shared<DataTypeDateTime64>(6)},
         {"flush_query_id", std::make_shared<DataTypeString>()},
+        {"timeout_milliseconds", std::make_shared<DataTypeUInt64>()},
     };
 }
 
@@ -80,6 +80,7 @@ void AsynchronousInsertLogElement::appendToBlock(MutableColumns & columns) const
     columns[i++]->insert(flush_time);
     columns[i++]->insert(flush_time_microseconds);
     columns[i++]->insert(flush_query_id);
+    columns[i++]->insert(timeout_milliseconds);
 }
 
 }

--- a/src/Interpreters/AsynchronousInsertLog.h
+++ b/src/Interpreters/AsynchronousInsertLog.h
@@ -38,6 +38,7 @@ struct AsynchronousInsertLogElement
     time_t flush_time{};
     Decimal64 flush_time_microseconds{};
     String flush_query_id;
+    UInt64 timeout_milliseconds = 0;
 
     static std::string name() { return "AsynchronousInsertLog"; }
     static ColumnsDescription getColumnsDescription();

--- a/src/Interpreters/AsynchronousInsertQueue.cpp
+++ b/src/Interpreters/AsynchronousInsertQueue.cpp
@@ -430,7 +430,7 @@ void AsynchronousInsertQueue::processBatchDeadlines(size_t shard_num)
             std::unique_lock lock(shard.mutex);
 
             shard.are_tasks_available.wait_for(lock,
-                Milliseconds(getContext()->getSettingsRef().async_insert_busy_timeout_ms), [&shard, this]
+                Milliseconds(getContext()->getSettingsRef().async_insert_poll_timeout_ms), [&shard, this]
             {
                 if (shutdown)
                     return true;

--- a/src/Interpreters/AsynchronousInsertQueue.h
+++ b/src/Interpreters/AsynchronousInsertQueue.h
@@ -53,6 +53,8 @@ public:
         Preprocessed = 1,
     };
 
+    static void validateSettings(const Settings & settings, LoggerPtr log);
+
     /// Force flush the whole queue.
     void flushAll();
 
@@ -187,6 +189,11 @@ private:
 
         Queue queue;
         QueueIteratorByKey iterators;
+
+        using OptionalTimePoint = std::optional<std::chrono::steady_clock::time_point>;
+        OptionalTimePoint last_insert_time;
+
+        std::chrono::milliseconds busy_timeout_ms;
     };
 
     const size_t pool_size;
@@ -217,6 +224,13 @@ private:
     LoggerPtr log = getLogger("AsynchronousInsertQueue");
 
     PushResult pushDataChunk(ASTPtr query, DataChunk chunk, ContextPtr query_context);
+
+    Milliseconds getBusyWaitTimeoutMs(
+        const Settings & settings,
+        const AsynchronousInsertQueue::QueueShard & shard,
+        size_t shard_num,
+        std::chrono::steady_clock::time_point now) const;
+
     void preprocessInsertQuery(const ASTPtr & query, const ContextPtr & query_context);
 
     void processBatchDeadlines(size_t shard_num);

--- a/src/Interpreters/AsynchronousInsertQueue.h
+++ b/src/Interpreters/AsynchronousInsertQueue.h
@@ -148,6 +148,9 @@ private:
             std::atomic_bool finished = false;
         };
 
+        InsertData() = default;
+        explicit InsertData(Milliseconds timeout_ms_) : timeout_ms(timeout_ms_) { }
+
         ~InsertData()
         {
             auto it = entries.begin();
@@ -165,6 +168,7 @@ private:
 
         std::list<EntryPtr> entries;
         size_t size_in_bytes = 0;
+        Milliseconds timeout_ms = Milliseconds::zero();
     };
 
     using InsertDataPtr = std::unique_ptr<InsertData>;
@@ -241,7 +245,7 @@ private:
     template <typename LogFunc>
     static Chunk processEntriesWithParsing(
         const InsertQuery & key,
-        const std::list<InsertData::EntryPtr> & entries,
+        const InsertDataPtr & data,
         const Block & header,
         const ContextPtr & insert_context,
         const LoggerPtr logger,
@@ -250,7 +254,7 @@ private:
     template <typename LogFunc>
     static Chunk processPreprocessedEntries(
         const InsertQuery & key,
-        const std::list<InsertData::EntryPtr> & entries,
+        const InsertDataPtr & data,
         const Block & header,
         const ContextPtr & insert_context,
         LogFunc && add_to_async_insert_log);

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -4862,12 +4862,9 @@ AsynchronousInsertQueue * Context::getAsynchronousInsertQueue() const
 
 void Context::setAsynchronousInsertQueue(const std::shared_ptr<AsynchronousInsertQueue> & ptr)
 {
-    using namespace std::chrono;
+    AsynchronousInsertQueue::validateSettings(settings, getLogger("Context"));
 
-    if (std::chrono::milliseconds(settings.async_insert_busy_timeout_ms) == 0ms)
-        throw Exception(ErrorCodes::INVALID_SETTING_VALUE, "Setting async_insert_busy_timeout_ms can't be zero");
-
-    if (std::chrono::milliseconds(settings.async_insert_poll_timeout_ms) == 0ms)
+    if (std::chrono::milliseconds(settings.async_insert_poll_timeout_ms) == std::chrono::milliseconds::zero())
         throw Exception(ErrorCodes::INVALID_SETTING_VALUE, "Setting async_insert_poll_timeout_ms can't be zero");
 
     shared->async_insert_queue = ptr;

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -4867,6 +4867,9 @@ void Context::setAsynchronousInsertQueue(const std::shared_ptr<AsynchronousInser
     if (std::chrono::milliseconds(settings.async_insert_busy_timeout_ms) == 0ms)
         throw Exception(ErrorCodes::INVALID_SETTING_VALUE, "Setting async_insert_busy_timeout_ms can't be zero");
 
+    if (std::chrono::milliseconds(settings.async_insert_poll_timeout_ms) == 0ms)
+        throw Exception(ErrorCodes::INVALID_SETTING_VALUE, "Setting async_insert_poll_timeout_ms can't be zero");
+
     shared->async_insert_queue = ptr;
 }
 

--- a/tests/integration/test_async_insert_adaptive_busy_timeout/configs/users.xml
+++ b/tests/integration/test_async_insert_adaptive_busy_timeout/configs/users.xml
@@ -1,0 +1,14 @@
+<clickhouse>
+    <profiles>
+        <default>
+            <allow_experimental_async_insert_adaptive_busy_timeout>1</allow_experimental_async_insert_adaptive_busy_timeout>
+        </default>
+    </profiles>
+
+    <users>
+        <default>
+            <password></password>
+            <profile>default</profile>
+        </default>
+    </users>
+</clickhouse>

--- a/tests/integration/test_async_insert_adaptive_busy_timeout/configs/users.xml
+++ b/tests/integration/test_async_insert_adaptive_busy_timeout/configs/users.xml
@@ -1,7 +1,7 @@
 <clickhouse>
     <profiles>
         <default>
-            <allow_experimental_async_insert_adaptive_busy_timeout>1</allow_experimental_async_insert_adaptive_busy_timeout>
+            <async_insert_use_adaptive_busy_timeout>1</async_insert_use_adaptive_busy_timeout>
         </default>
     </profiles>
 

--- a/tests/integration/test_async_insert_adaptive_busy_timeout/configs/zookeeper_config.xml
+++ b/tests/integration/test_async_insert_adaptive_busy_timeout/configs/zookeeper_config.xml
@@ -1,0 +1,8 @@
+<clickhouse>
+    <zookeeper>
+        <node index="1">
+            <host>zoo1</host>
+            <port>2181</port>
+        </node>
+    </zookeeper>
+</clickhouse>

--- a/tests/integration/test_async_insert_adaptive_busy_timeout/test.py
+++ b/tests/integration/test_async_insert_adaptive_busy_timeout/test.py
@@ -199,7 +199,7 @@ def test_compare_sequential_inserts_durations_for_adaptive_and_fixed_async_timeo
     )
 
     fixed_tm_settings = copy.copy(_query_settings)
-    fixed_tm_settings["allow_experimental_async_insert_adaptive_busy_timeout"] = 0
+    fixed_tm_settings["async_insert_use_adaptive_busy_timeout"] = 0
     fixed_tm_settings["async_insert_busy_timeout_ms"] = 200
 
     fixed_tm_run_duration = timeit.timeit(
@@ -267,7 +267,7 @@ def test_compare_parallel_inserts_durations_for_adaptive_and_fixed_async_timeout
     )
 
     fixed_tm_settings = copy.copy(_query_settings)
-    fixed_tm_settings["allow_experimental_async_insert_adaptive_busy_timeout"] = 0
+    fixed_tm_settings["async_insert_use_adaptive_busy_timeout"] = 0
     fixed_tm_settings["async_insert_busy_timeout_ms"] = 200
 
     fixed_tm_run_duration = timeit.timeit(

--- a/tests/integration/test_async_insert_adaptive_busy_timeout/test.py
+++ b/tests/integration/test_async_insert_adaptive_busy_timeout/test.py
@@ -1,0 +1,372 @@
+import copy
+import logging
+import pytest
+import random
+import timeit
+
+from math import floor
+from multiprocessing import Pool
+from itertools import repeat
+
+from helpers.cluster import ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__)
+
+
+node = cluster.add_instance(
+    "node",
+    main_configs=["configs/zookeeper_config.xml"],
+    user_configs=[
+        "configs/users.xml",
+    ],
+    with_zookeeper=True,
+)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def start_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+_query_settings = {"async_insert": 1, "wait_for_async_insert": 1}
+
+
+def _generate_values(size, min_int, max_int, array_size_range):
+    gen_tuple = lambda _min_int, _max_int, _array_size_range: (
+        random.randint(_min_int, _max_int),
+        [
+            random.randint(_min_int, _max_int)
+            for _ in range(random.randint(*_array_size_range))
+        ],
+    )
+
+    return map(lambda _: gen_tuple(min_int, max_int, array_size_range), range(size))
+
+
+def _insert_query(table_name, settings, *args, **kwargs):
+    settings_s = ", ".join("{}={}".format(k, settings[k]) for k in settings)
+    INSERT_QUERY = "INSERT INTO {} SETTINGS {} VALUES {}"
+    node.query(
+        INSERT_QUERY.format(
+            table_name,
+            settings_s,
+            ", ".join(map(str, _generate_values(*args, **kwargs))),
+        )
+    )
+
+
+def _insert_queries_sequentially(
+    table_name, settings, iterations, max_values_size, array_size_range
+):
+    for iter in range(iterations):
+        _insert_query(
+            table_name,
+            settings,
+            random.randint(1, max_values_size),
+            iter * max_values_size,
+            (iter + 1) * max_values_size - 1,
+            array_size_range,
+        )
+
+
+def _insert_queries_in_parallel(
+    table_name, settings, thread_num, tasks, max_values_size, array_size_range
+):
+    sizes = [random.randint(1, max_values_size) for _ in range(tasks)]
+    min_ints = [iter * max_values_size for iter in range(tasks)]
+    max_ints = [(iter + 1) * max_values_size - 1 for iter in range(tasks)]
+    with Pool(thread_num) as p:
+        p.starmap(
+            _insert_query,
+            zip(
+                repeat(table_name),
+                repeat(settings),
+                sizes,
+                min_ints,
+                max_ints,
+                repeat(array_size_range),
+            ),
+        )
+
+
+def test_with_merge_tree():
+    table_name = "async_insert_mt_table"
+    node.query(
+        "CREATE TABLE {} (a UInt64, b Array(UInt64)) ENGINE=MergeTree() ORDER BY a".format(
+            table_name
+        )
+    )
+
+    _insert_queries_sequentially(
+        table_name,
+        _query_settings,
+        iterations=100,
+        max_values_size=1000,
+        array_size_range=[10, 50],
+    )
+
+    node.query("DROP TABLE IF EXISTS {}".format(table_name))
+
+
+def test_with_merge_tree_multithread():
+    thread_num = 15
+    table_name = "async_insert_mt_multithread_table"
+    node.query(
+        "CREATE TABLE {} (a UInt64, b Array(UInt64)) ENGINE=MergeTree() ORDER BY a".format(
+            table_name
+        )
+    )
+
+    _insert_queries_in_parallel(
+        table_name,
+        _query_settings,
+        thread_num=15,
+        tasks=1000,
+        max_values_size=1000,
+        array_size_range=[10, 15],
+    )
+
+    node.query("DROP TABLE IF EXISTS {}".format(table_name))
+
+
+def test_with_replicated_merge_tree():
+    table_name = "async_insert_replicated_mt_table"
+
+    create_query = " ".join(
+        (
+            "CREATE TABLE {} (a UInt64, b Array(UInt64))".format(table_name),
+            "ENGINE=ReplicatedMergeTree('/clickhouse/tables/test/{}', 'node')".format(
+                table_name
+            ),
+            "ORDER BY a",
+        )
+    )
+
+    node.query(create_query)
+
+    settings = _query_settings
+    _insert_queries_sequentially(
+        table_name,
+        settings,
+        iterations=100,
+        max_values_size=1000,
+        array_size_range=[10, 50],
+    )
+
+    node.query("DROP TABLE IF EXISTS {}".format(table_name))
+
+
+def test_with_replicated_merge_tree_multithread():
+    thread_num = 15
+    table_name = "async_insert_replicated_mt_multithread_table"
+
+    create_query = " ".join(
+        (
+            "CREATE TABLE {} (a UInt64, b Array(UInt64))".format(table_name),
+            "ENGINE=ReplicatedMergeTree('/clickhouse/tables/test/{}', 'node')".format(
+                table_name
+            ),
+            "ORDER BY a",
+        )
+    )
+
+    node.query(create_query)
+
+    _insert_queries_in_parallel(
+        table_name,
+        _query_settings,
+        thread_num=15,
+        tasks=1000,
+        max_values_size=1000,
+        array_size_range=[10, 15],
+    )
+
+    node.query("DROP TABLE IF EXISTS {}".format(table_name))
+
+
+# Ensure that the combined duration of inserts with adaptive timeouts is less than
+# the combined duration for fixed timeouts.
+def test_compare_sequential_inserts_durations_for_adaptive_and_fixed_async_timeouts():
+    fixed_tm_table_name = "async_insert_mt_fixed_async_timeout"
+    node.query(
+        "CREATE TABLE {} (a UInt64, b Array(UInt64)) ENGINE=MergeTree() ORDER BY a".format(
+            fixed_tm_table_name
+        )
+    )
+
+    fixed_tm_settings = copy.copy(_query_settings)
+    fixed_tm_settings["allow_experimental_async_insert_adaptive_busy_timeout"] = 0
+    fixed_tm_settings["async_insert_busy_timeout_ms"] = 200
+
+    fixed_tm_run_duration = timeit.timeit(
+        lambda: _insert_queries_sequentially(
+            fixed_tm_table_name,
+            fixed_tm_settings,
+            iterations=100,
+            max_values_size=1000,
+            array_size_range=[10, 50],
+        ),
+        setup="pass",
+        number=3,
+    )
+
+    node.query("DROP TABLE IF EXISTS {}".format(fixed_tm_table_name))
+
+    logging.debug(
+        "Run duration with fixed asynchronous timeout is {} seconds".format(
+            fixed_tm_run_duration
+        )
+    )
+
+    adaptive_tm_table_name = "async_insert_mt_adaptive_async_timeout"
+    node.query(
+        "CREATE TABLE {} (a UInt64, b Array(UInt64)) ENGINE=MergeTree() ORDER BY a".format(
+            adaptive_tm_table_name
+        )
+    )
+
+    adaptive_tm_settings = copy.copy(_query_settings)
+    adaptive_tm_settings["async_insert_busy_timeout_min_ms"] = 10
+    adaptive_tm_settings["async_insert_busy_timeout_max_ms"] = 1000
+
+    adaptive_tm_run_duration = timeit.timeit(
+        lambda: _insert_queries_sequentially(
+            adaptive_tm_table_name,
+            adaptive_tm_settings,
+            iterations=100,
+            max_values_size=1000,
+            array_size_range=[10, 50],
+        ),
+        setup="pass",
+        number=3,
+    )
+
+    logging.debug(
+        "Run duration with adaptive asynchronous timeout is {} seconds.".format(
+            adaptive_tm_run_duration
+        )
+    )
+
+    node.query("DROP TABLE IF EXISTS {}".format(adaptive_tm_table_name))
+
+    assert adaptive_tm_run_duration <= fixed_tm_run_duration
+
+
+# Ensure that the combined duration of inserts with adaptive timeouts is less than
+# the combined duration for fixed timeouts.
+def test_compare_parallel_inserts_durations_for_adaptive_and_fixed_async_timeouts():
+    fixed_tm_table_name = "async_insert_mt_fixed_async_timeout"
+    node.query(
+        "CREATE TABLE {} (a UInt64, b Array(UInt64)) ENGINE=MergeTree() ORDER BY a".format(
+            fixed_tm_table_name
+        )
+    )
+
+    fixed_tm_settings = copy.copy(_query_settings)
+    fixed_tm_settings["allow_experimental_async_insert_adaptive_busy_timeout"] = 0
+    fixed_tm_settings["async_insert_busy_timeout_ms"] = 200
+
+    fixed_tm_run_duration = timeit.timeit(
+        lambda: _insert_queries_in_parallel(
+            fixed_tm_table_name,
+            fixed_tm_settings,
+            thread_num=15,
+            tasks=1000,
+            max_values_size=1000,
+            array_size_range=[10, 50],
+        ),
+        setup="pass",
+        number=3,
+    )
+
+    node.query("DROP TABLE IF EXISTS {}".format(fixed_tm_table_name))
+
+    logging.debug(
+        "Run duration with fixed asynchronous timeout is {} seconds".format(
+            fixed_tm_run_duration
+        )
+    )
+
+    adaptive_tm_table_name = "async_insert_mt_adaptive_async_timeout"
+    node.query(
+        "CREATE TABLE {} (a UInt64, b Array(UInt64)) ENGINE=MergeTree() ORDER BY a".format(
+            adaptive_tm_table_name
+        )
+    )
+
+    adaptive_tm_settings = copy.copy(_query_settings)
+    adaptive_tm_settings["async_insert_busy_timeout_min_ms"] = 10
+    adaptive_tm_settings["async_insert_busy_timeout_max_ms"] = 200
+
+    adaptive_tm_run_duration = timeit.timeit(
+        lambda: _insert_queries_in_parallel(
+            adaptive_tm_table_name,
+            adaptive_tm_settings,
+            thread_num=15,
+            tasks=100,
+            max_values_size=1000,
+            array_size_range=[10, 50],
+        ),
+        setup="pass",
+        number=3,
+    )
+
+    logging.debug(
+        "Run duration with adaptive asynchronous timeout is {} seconds.".format(
+            adaptive_tm_run_duration
+        )
+    )
+
+    node.query("DROP TABLE IF EXISTS {}".format(adaptive_tm_table_name))
+
+    assert adaptive_tm_run_duration <= fixed_tm_run_duration
+
+
+# Ensure that the delay converges to a minimum for sequential inserts and wait_for_async_insert=1.
+def test_change_queries_frequency():
+    table_name = "async_insert_mt_change_queries_frequencies"
+
+    create_query = " ".join(
+        (
+            "CREATE TABLE {} (a UInt64, b Array(UInt64))".format(table_name),
+            "ENGINE=ReplicatedMergeTree('/clickhouse/tables/test_frequencies/{}', 'node')".format(
+                table_name
+            ),
+            "ORDER BY a",
+        )
+    )
+
+    node.query(create_query)
+
+    settings = copy.copy(_query_settings)
+    min_ms = 50
+    settings["async_insert_busy_timeout_min_ms"] = min_ms
+    settings["async_insert_busy_timeout_max_ms"] = 2000
+
+    _insert_queries_in_parallel(
+        table_name,
+        settings,
+        thread_num=15,
+        tasks=2000,
+        max_values_size=1000,
+        array_size_range=[10, 15],
+    )
+
+    _insert_queries_sequentially(
+        table_name,
+        settings,
+        iterations=200,
+        max_values_size=1000,
+        array_size_range=[10, 50],
+    )
+
+    select_log_query = "SELECT timeout_milliseconds FROM system.asynchronous_insert_log ORDER BY event_time DESC LIMIT 50"
+    res = node.query(select_log_query)
+    for line in res.splitlines():
+        assert int(line) == min_ms
+
+    node.query("DROP TABLE IF EXISTS {}".format(table_name))

--- a/tests/queries/0_stateless/02015_async_inserts_2.sh
+++ b/tests/queries/0_stateless/02015_async_inserts_2.sh
@@ -5,7 +5,9 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CURDIR"/../shell_config.sh
 
-url="${CLICKHOUSE_URL}&async_insert=1&wait_for_async_insert=1&async_insert_busy_timeout_ms=600000&async_insert_max_query_number=3&async_insert_deduplicate=1"
+# With adaptive timeout enabled, the asynchronous queue can be flushed synchronously, depending on the elapsed since the last insert.
+# This may result in test flakiness.
+url="${CLICKHOUSE_URL}&async_insert=1&wait_for_async_insert=1&async_insert_busy_timeout_ms=600000&async_insert_max_query_number=3&async_insert_deduplicate=1&async_insert_use_adaptive_busy_timeout=0"
 
 ${CLICKHOUSE_CLIENT} -q "DROP TABLE IF EXISTS async_inserts"
 ${CLICKHOUSE_CLIENT} -q "CREATE TABLE async_inserts (id UInt32, s String) ENGINE = MergeTree ORDER BY id"

--- a/tests/queries/0_stateless/02134_async_inserts_formats.sh
+++ b/tests/queries/0_stateless/02134_async_inserts_formats.sh
@@ -4,7 +4,9 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CURDIR"/../shell_config.sh
 
-url="${CLICKHOUSE_URL}&async_insert=1&wait_for_async_insert=1"
+# With adaptive timeout enabled, the asynchronous queue can be flushed synchronously, depending on the elapsed since the last insert.
+# This may result in test flakiness.
+url="${CLICKHOUSE_URL}&async_insert=1&wait_for_async_insert=1&async_insert_use_adaptive_busy_timeout=0"
 
 ${CLICKHOUSE_CLIENT} -q "DROP TABLE IF EXISTS async_inserts"
 ${CLICKHOUSE_CLIENT} -q "CREATE TABLE async_inserts (id UInt32, s String) ENGINE = MergeTree ORDER BY id"

--- a/tests/queries/0_stateless/02726_async_insert_flush_queue.sql
+++ b/tests/queries/0_stateless/02726_async_insert_flush_queue.sql
@@ -6,7 +6,8 @@ CREATE TABLE t_async_inserts_flush (a UInt64) ENGINE = Memory;
 
 SET async_insert = 1;
 SET wait_for_async_insert = 0;
-SET async_insert_busy_timeout_ms = 1000000;
+SET async_insert_busy_timeout_min_ms = 1000000;
+SET async_insert_busy_timeout_max_ms = 10000000;
 
 INSERT INTO t_async_inserts_flush VALUES (1) (2);
 INSERT INTO t_async_inserts_flush FORMAT JSONEachRow {"a": 10} {"a": 20};

--- a/tests/queries/0_stateless/02810_async_insert_dedup_replicated_collapsing.sh
+++ b/tests/queries/0_stateless/02810_async_insert_dedup_replicated_collapsing.sh
@@ -7,7 +7,7 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 ${CLICKHOUSE_CLIENT} -q "DROP TABLE IF EXISTS 02810_async_insert_dedup_collapsing"
 ${CLICKHOUSE_CLIENT} -q "CREATE TABLE 02810_async_insert_dedup_collapsing (stringvalue String, sign Int8) ENGINE = ReplicatedCollapsingMergeTree('/clickhouse/{database}/02810_async_insert_dedup', 'r1', sign) ORDER BY stringvalue"
 
-url="${CLICKHOUSE_URL}&async_insert=1&wait_for_async_insert=1&async_insert_busy_timeout_ms=3000&async_insert_deduplicate=1"
+url="${CLICKHOUSE_URL}&async_insert=1&wait_for_async_insert=1&async_insert_busy_timeout_ms=3000&async_insert_use_adaptive_busy_timeout=0&async_insert_deduplicate=1"
 
 # insert value with same key and sign so it's collapsed on insert
 ${CLICKHOUSE_CURL} -sS "$url" -d "INSERT INTO 02810_async_insert_dedup_collapsing VALUES ('string1', 1)" &

--- a/tests/queries/0_stateless/02884_async_insert_native_protocol_1.sh
+++ b/tests/queries/0_stateless/02884_async_insert_native_protocol_1.sh
@@ -12,7 +12,7 @@ $CLICKHOUSE_CLIENT -n -q "
     CREATE TABLE t_async_insert_native_1 (id UInt64, s String) ENGINE = MergeTree ORDER BY id;
 "
 
-async_insert_options="--async_insert 1 --wait_for_async_insert 0 --async_insert_busy_timeout_ms 1000000"
+async_insert_options="--async_insert 1 --wait_for_async_insert 0 --async_insert_busy_timeout_min_ms 1000000 --async_insert_busy_timeout_max_ms 10000000"
 
 echo '{"id": 1, "s": "aaa"} {"id": 2, "s": "bbb"}' | $CLICKHOUSE_CLIENT $async_insert_options -q 'INSERT INTO t_async_insert_native_1 FORMAT JSONEachRow'
 $CLICKHOUSE_CLIENT $async_insert_options  -q 'INSERT INTO t_async_insert_native_1 FORMAT JSONEachRow {"id": 3, "s": "ccc"}'

--- a/tests/queries/0_stateless/02884_async_insert_native_protocol_3.sh
+++ b/tests/queries/0_stateless/02884_async_insert_native_protocol_3.sh
@@ -12,7 +12,7 @@ $CLICKHOUSE_CLIENT -n -q "
     CREATE TABLE t_async_insert_native_3 (id UInt64, s String) ENGINE = MergeTree ORDER BY id;
 "
 
-async_insert_options="--async_insert 1 --wait_for_async_insert 0 --async_insert_busy_timeout_ms 1000000"
+async_insert_options="--async_insert 1 --wait_for_async_insert 0 --async_insert_busy_timeout_min_ms 1000000 --async_insert_busy_timeout_max_ms 10000000"
 
 echo '{"id": 1, "s": "aaa"} {"id": 2, "s": "bbb"}' | $CLICKHOUSE_CLIENT $async_insert_options -q 'INSERT INTO t_async_insert_native_3 FORMAT JSONEachRow'
 echo "(3, 'ccc') (4, 'ddd') (5, 'eee')" | $CLICKHOUSE_CLIENT $async_insert_options -q 'INSERT INTO t_async_insert_native_3 FORMAT Values'

--- a/tests/queries/0_stateless/02884_async_insert_skip_settings.sql
+++ b/tests/queries/0_stateless/02884_async_insert_skip_settings.sql
@@ -9,7 +9,8 @@ ORDER BY id;
 SET async_insert = 1;
 SET async_insert_deduplicate = 1;
 SET wait_for_async_insert = 0;
-SET async_insert_busy_timeout_ms = 100000;
+SET async_insert_busy_timeout_min_ms = 100000;
+SET async_insert_busy_timeout_max_ms = 1000000;
 
 SET insert_deduplication_token = '1';
 SET log_comment = 'async_insert_skip_settings_1';

--- a/tests/queries/0_stateless/02968_adaptive_async_insert_timeout.sql
+++ b/tests/queries/0_stateless/02968_adaptive_async_insert_timeout.sql
@@ -1,0 +1,51 @@
+DROP TABLE IF EXISTS async_insert_mt_test;
+CREATE TABLE async_insert_mt_test (a UInt64, b Array(UInt64)) ENGINE=MergeTree() ORDER BY a;
+
+SET allow_experimental_async_insert_adaptive_busy_timeout = 1;
+
+INSERT INTO async_insert_mt_test
+    SETTINGS
+        async_insert=1,
+        wait_for_async_insert=1,
+        async_insert_busy_timeout_min_ms=10,
+        async_insert_busy_timeout_max_ms=500,
+        async_insert_busy_timeout_increase_rate=1.0,
+        async_insert_busy_timeout_decrease_rate=1.0
+    VALUES (3, []), (1, [1, 3]), (2, [7, 8]), (4, [5, 9]), (5, [2, 6]);
+
+
+INSERT INTO async_insert_mt_test
+    SETTINGS
+        async_insert=1,
+        wait_for_async_insert=1,
+        async_insert_busy_timeout_ms=500,
+        async_insert_busy_timeout_min_ms=500
+    VALUES (3, []), (1, [1, 3]), (2, [7, 8]), (4, [5, 9]), (5, [2, 6]);
+
+
+INSERT INTO async_insert_mt_test
+    SETTINGS
+        async_insert=1,
+        wait_for_async_insert=1,
+        async_insert_busy_timeout_ms=100,
+        async_insert_busy_timeout_min_ms=500
+    VALUES (3, []), (1, [1, 3]), (2, [7, 8]), (4, [5, 9]), (5, [2, 6]);
+
+
+INSERT INTO async_insert_mt_test
+    SETTINGS
+        async_insert=1,
+        wait_for_async_insert=1,
+        async_insert_busy_timeout_increase_rate=-1.0
+    VALUES (3, []), (1, [1, 3]), (2, [7, 8]), (4, [5, 9]), (5, [2, 6]); -- { serverError INVALID_SETTING_VALUE }
+
+
+INSERT INTO async_insert_mt_test
+    SETTINGS
+        async_insert=1,
+        wait_for_async_insert=1,
+        async_insert_busy_timeout_decrease_rate=-1.0
+    VALUES (3, []), (1, [1, 3]), (2, [7, 8]), (4, [5, 9]), (5, [2, 6]); -- { serverError INVALID_SETTING_VALUE }
+
+
+DROP TABLE IF EXISTS async_insert_mt_test;

--- a/tests/queries/0_stateless/02968_adaptive_async_insert_timeout.sql
+++ b/tests/queries/0_stateless/02968_adaptive_async_insert_timeout.sql
@@ -1,7 +1,7 @@
 DROP TABLE IF EXISTS async_insert_mt_test;
 CREATE TABLE async_insert_mt_test (a UInt64, b Array(UInt64)) ENGINE=MergeTree() ORDER BY a;
 
-SET allow_experimental_async_insert_adaptive_busy_timeout = 1;
+SET async_insert_use_adaptive_busy_timeout = 1;
 
 INSERT INTO async_insert_mt_test
     SETTINGS


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Implement auto-adjustment for asynchronous insert timeouts. The following settings are introduced: async_insert_poll_timeout_ms, async_insert_use_adaptive_busy_timeout, async_insert_busy_timeout_min_ms, async_insert_busy_timeout_max_ms, async_insert_busy_timeout_increase_rate, async_insert_busy_timeout_decrease_rate.

async_insert_busy_timeout_ms is aliased to async_insert_busy_timeout_max_ms.
### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
