### PR TITLE
Lower log levels for some Raft logs to new test level

### DIFF
--- a/src/Coordination/LoggerWrapper.h
+++ b/src/Coordination/LoggerWrapper.h
@@ -13,6 +13,7 @@ private:
 
     static inline const std::unordered_map<LogsLevel, Poco::Message::Priority> LEVELS =
     {
+        {LogsLevel::test, Poco::Message::Priority::PRIO_TEST},
         {LogsLevel::trace, Poco::Message::Priority::PRIO_TRACE},
         {LogsLevel::debug, Poco::Message::Priority::PRIO_DEBUG},
         {LogsLevel::information, Poco::Message::PRIO_INFORMATION},


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Related NuRaft PR: https://github.com/ClickHouse/NuRaft/pull/66

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
