### PR TITLE
MergeTree read apply LIMIT for limit only queries

### DIFF
--- a/src/Processors/QueryPlan/ReadFromMergeTree.cpp
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.cpp
@@ -423,8 +423,9 @@ Pipe ReadFromMergeTree::readFromPool(
       * execution for big tables with small limit.
       */
     bool use_prefetched_read_pool = query_info.limit == 0 && (allow_prefetched_remote || allow_prefetched_local);
+    (void)(use_prefetched_read_pool);
 
-    if (use_prefetched_read_pool)
+    // if (use_prefetched_read_pool)
     {
         pool = std::make_shared<MergeTreePrefetchedReadPool>(
             std::move(parts_with_range),
@@ -437,19 +438,19 @@ Pipe ReadFromMergeTree::readFromPool(
             pool_settings,
             context);
     }
-    else
-    {
-        pool = std::make_shared<MergeTreeReadPool>(
-            std::move(parts_with_range),
-            storage_snapshot,
-            prewhere_info,
-            actions_settings,
-            reader_settings,
-            required_columns,
-            virt_column_names,
-            pool_settings,
-            context);
-    }
+    // else
+    // {
+    //     pool = std::make_shared<MergeTreeReadPool>(
+    //         std::move(parts_with_range),
+    //         storage_snapshot,
+    //         prewhere_info,
+    //         actions_settings,
+    //         reader_settings,
+    //         required_columns,
+    //         virt_column_names,
+    //         pool_settings,
+    //         context);
+    // }
 
     LOG_DEBUG(log, "Reading approx. {} rows with {} streams", total_rows, pool_settings.threads);
 
@@ -1604,7 +1605,15 @@ ReadFromMergeTree::AnalysisResultPtr ReadFromMergeTree::selectRangesToReadImpl(
           * For query with FINAL we cannot apply LIMIT.
           */
         if (query_info.limit > 0 && !query_info.isFinal())
+        {
+            Stopwatch apply_limit_watch;
+            apply_limit_watch.start();
+
             result.parts_with_ranges = MergeTreeDataSelectExecutor::applyLimitForRangesInDataParts(std::move(result.parts_with_ranges), query_info.limit);
+
+            apply_limit_watch.stop();
+            std::cerr << "MergeTreeDataSelectExecutor::applyLimitForRangesInDataParts elapsed ms " << apply_limit_watch.elapsedMilliseconds() << '\n';
+        }
     }
 
     size_t sum_marks_pk = total_marks_pk;

--- a/src/Processors/QueryPlan/ReadFromMergeTree.cpp
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.cpp
@@ -1600,8 +1600,10 @@ ReadFromMergeTree::AnalysisResultPtr ReadFromMergeTree::selectRangesToReadImpl(
             result.index_stats,
             indexes->use_skip_indexes);
 
-        /// Apply LIMIT for LIMIT only queries
-        if (query_info.limit > 0)
+        /** Apply LIMIT for LIMIT only queries.
+          * For query with FINAL we cannot apply LIMIT.
+          */
+        if (query_info.limit > 0 && !query_info.isFinal())
             result.parts_with_ranges = MergeTreeDataSelectExecutor::applyLimitForRangesInDataParts(std::move(result.parts_with_ranges), query_info.limit);
     }
 

--- a/src/Processors/QueryPlan/ReadFromMergeTree.cpp
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.cpp
@@ -1599,6 +1599,10 @@ ReadFromMergeTree::AnalysisResultPtr ReadFromMergeTree::selectRangesToReadImpl(
             num_streams,
             result.index_stats,
             indexes->use_skip_indexes);
+
+        /// Apply LIMIT for LIMIT only queries
+        if (query_info.limit > 0)
+            result.parts_with_ranges = MergeTreeDataSelectExecutor::applyLimitForRangesInDataParts(std::move(result.parts_with_ranges), query_info.limit);
     }
 
     size_t sum_marks_pk = total_marks_pk;

--- a/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
@@ -840,6 +840,13 @@ RangesInDataParts MergeTreeDataSelectExecutor::applyLimitForRangesInDataParts(
     RangesInDataParts && parts_with_ranges,
     size_t limit)
 {
+    std::cerr << "MergeTreeDataSelectExecutor::applyLimitForRangesInDataParts parts with ranges before " << parts_with_ranges.size() << '\n';
+    for (auto & part_with_ranges : parts_with_ranges)
+    {
+        std::cerr << "Part with range " << part_with_ranges.data_part->name;
+        std::cerr << " ranges " << part_with_ranges.getDescription().describe() << '\n';
+    }
+
     chassert(limit > 0);
     RangesInDataParts result_parts_with_ranges;
     size_t remaining_limit = limit;
@@ -901,6 +908,13 @@ RangesInDataParts MergeTreeDataSelectExecutor::applyLimitForRangesInDataParts(
         }
 
         result_part_with_ranges.ranges.erase(ranges_it, ranges_end_it);
+    }
+
+    std::cerr << "MergeTreeDataSelectExecutor::applyLimitForRangesInDataParts parts with ranges after " << result_parts_with_ranges.size() << '\n';
+    for (auto & part_with_ranges : result_parts_with_ranges)
+    {
+        std::cerr << "Part with range " << part_with_ranges.data_part->name;
+        std::cerr << " ranges " << part_with_ranges.getDescription().describe() << '\n';
     }
 
     return result_parts_with_ranges;

--- a/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
@@ -882,14 +882,15 @@ RangesInDataParts MergeTreeDataSelectExecutor::applyLimitForRangesInDataParts(
             }
 
             const auto & marks_rows_partial_sums = part_index_granularity.getMarksRowsPartialSums();
+            size_t mark_range_partial_sum_start = range.begin > 0 ? marks_rows_partial_sums[range.begin - 1] : 0;
             auto range_begin_it = marks_rows_partial_sums.begin() + range.begin;
             auto range_end_it = marks_rows_partial_sums.begin() + range.end;
             auto it = std::lower_bound(range_begin_it, range_end_it, remaining_limit, [&](size_t limit_value, size_t partial_sum_value)
             {
-                return limit_value < (partial_sum_value - *range_begin_it);
+                return limit_value < (partial_sum_value - mark_range_partial_sum_start);
             });
 
-            size_t new_range_end = it - range_begin_it;
+            size_t new_range_end = (it - range_begin_it) + 1;
             chassert(new_range_end <= range.end);
 
             MarkRange new_range{range.begin, new_range_end};

--- a/src/Storages/MergeTree/MergeTreeDataSelectExecutor.h
+++ b/src/Storages/MergeTree/MergeTreeDataSelectExecutor.h
@@ -204,6 +204,12 @@ public:
         ReadFromMergeTree::IndexStats & index_stats,
         bool use_skip_indexes);
 
+    /// Apply LIMIT to parts with ranges for LIMIT only queries.
+    /// Example: SELECT id, value FROM test_table LIMIT 10;
+    static RangesInDataParts applyLimitForRangesInDataParts(
+        RangesInDataParts && parts_with_ranges,
+        size_t limit);
+
     /// Create expression for sampling.
     /// Also, calculate _sample_factor if needed.
     /// Also, update key condition with selected sampling range.

--- a/src/Storages/MergeTree/MergeTreeIndexGranularity.h
+++ b/src/Storages/MergeTree/MergeTreeIndexGranularity.h
@@ -13,10 +13,6 @@ namespace DB
 /// all values in inner vector would have constant stride (default 8192).
 class MergeTreeIndexGranularity
 {
-private:
-    std::vector<size_t> marks_rows_partial_sums;
-    bool initialized = false;
-
 public:
     MergeTreeIndexGranularity() = default;
     explicit MergeTreeIndexGranularity(const std::vector<size_t> & marks_rows_partial_sums_);
@@ -70,6 +66,8 @@ public:
         return getLastMarkRows() == 0;
     }
 
+    const std::vector<size_t> & getMarksRowsPartialSums() const { return marks_rows_partial_sums; }
+
     bool empty() const
     {
         return marks_rows_partial_sums.empty();
@@ -95,6 +93,10 @@ public:
 
     /// Add `size` of marks with `fixed_granularity` rows
     void resizeWithFixedGranularity(size_t size, size_t fixed_granularity);
+
+private:
+    std::vector<size_t> marks_rows_partial_sums;
+    bool initialized = false;
 };
 
 }

--- a/tests/queries/0_stateless/01913_exact_rows_before_limit.reference
+++ b/tests/queries/0_stateless/01913_exact_rows_before_limit.reference
@@ -32,7 +32,7 @@
 
 	"rows": 1,
 
-	"rows_before_limit_at_least": 20000
+	"rows_before_limit_at_least": 10000
 }
 {
 	"meta":
@@ -68,5 +68,5 @@
 
 	"rows": 1,
 
-	"rows_before_limit_at_least": 20000
+	"rows_before_limit_at_least": 8192
 }

--- a/tests/queries/0_stateless/02582_async_reading_with_small_limit.reference
+++ b/tests/queries/0_stateless/02582_async_reading_with_small_limit.reference
@@ -3,5 +3,4 @@ ExpressionTransform
   (Limit)
   Limit
     (ReadFromMergeTree)
-    Concat 3 → 1
-      MergeTreeSelect(pool: ReadPoolInOrder, algorithm: InOrder) × 3 0 → 1
+    MergeTreeSelect(pool: ReadPoolInOrder, algorithm: InOrder) 0 → 1


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
MergeTree read apply LIMIT for limit only queries.
