### PR TITLE
Add settings for better control of indexes type in Arrow dictionary

### DIFF
--- a/docker/test/stateless/Dockerfile
+++ b/docker/test/stateless/Dockerfile
@@ -46,7 +46,7 @@ RUN apt-get update -y \
             p7zip-full \
     && apt-get clean
 
-RUN pip3 install numpy scipy pandas Jinja2
+RUN pip3 install numpy scipy pandas Jinja2 pyarrow
 
 RUN mkdir -p /tmp/clickhouse-odbc-tmp \
    && wget -nv -O - ${odbc_driver_url} | tar --strip-components=1 -xz -C /tmp/clickhouse-odbc-tmp \

--- a/docs/en/interfaces/formats.md
+++ b/docs/en/interfaces/formats.md
@@ -2356,6 +2356,8 @@ $ clickhouse-client --query="SELECT * FROM {some_table} FORMAT Arrow" > {filenam
 ### Arrow format settings {#parquet-format-settings}
 
 - [output_format_arrow_low_cardinality_as_dictionary](/docs/en/operations/settings/settings-formats.md/#output_format_arrow_low_cardinality_as_dictionary) - enable output ClickHouse LowCardinality type as Dictionary Arrow type. Default value - `false`.
+- [output_format_arrow_use_64_bit_indexes_for_dictionary](/docs/en/operations/settings/settings-formats.md/#output_format_arrow_use_64_bit_indexes_for_dictionary) - use 64-bit integer type for Dictionary indexes. Default value - `false`.
+- [output_format_arrow_use_signed_indexes_for_dictionary](/docs/en/operations/settings/settings-formats.md/#output_format_arrow_use_signed_indexes_for_dictionary) - use signed integer type for Dictionary indexes. Default value - `true`.
 - [output_format_arrow_string_as_string](/docs/en/operations/settings/settings-formats.md/#output_format_arrow_string_as_string) - use Arrow String type instead of Binary for String columns. Default value - `false`.
 - [input_format_arrow_case_insensitive_column_matching](/docs/en/operations/settings/settings-formats.md/#input_format_arrow_case_insensitive_column_matching) - ignore case when matching Arrow columns with ClickHouse columns. Default value - `false`.
 - [input_format_arrow_allow_missing_columns](/docs/en/operations/settings/settings-formats.md/#input_format_arrow_allow_missing_columns) - allow missing columns while reading Arrow data. Default value - `false`.

--- a/docs/en/operations/settings/settings-formats.md
+++ b/docs/en/operations/settings/settings-formats.md
@@ -1269,6 +1269,28 @@ Possible values:
 
 Default value: `0`.
 
+### output_format_arrow_use_signed_indexes_for_dictionary {#output_format_arrow_use_signed_indexes_for_dictionary}
+
+Allows to use signed integer types instead of unsigned in `DICTIONARY` type of the [Arrow](../../interfaces/formats.md/#data-format-arrow) format during  [LowCardinality](../../sql-reference/data-types/lowcardinality.md) output when `output_format_arrow_low_cardinality_as_dictionary` is enabled.
+
+Possible values:
+
+- 0 — Unsigned integer types are used for indexes in `DICTIONARY` type.
+- 1 — Signed integer types are used for indexes in `DICTIONARY` type.
+
+Default value: `1`.
+
+### output_format_arrow_use_64_bit_indexes_for_dictionary {#output_format_arrow_use_64_bit_indexes_for_dictionary}
+
+Allows to always use 64-bit integer type in `DICTIONARY` type of the [Arrow](../../interfaces/formats.md/#data-format-arrow) format during  [LowCardinality](../../sql-reference/data-types/lowcardinality.md) output when `output_format_arrow_low_cardinality_as_dictionary` is enabled.
+
+Possible values:
+
+- 0 — Type for indexes in `DICTIONARY` type is determined automatically.
+- 1 — 64-bit integer type is used for indexes in `DICTIONARY` type.
+
+Default value: `0`.
+
 ### output_format_arrow_string_as_string {#output_format_arrow_string_as_string}
 
 Use Arrow String type instead of Binary for String columns.

--- a/docs/en/operations/settings/settings-formats.md
+++ b/docs/en/operations/settings/settings-formats.md
@@ -1271,7 +1271,7 @@ Default value: `0`.
 
 ### output_format_arrow_use_signed_indexes_for_dictionary {#output_format_arrow_use_signed_indexes_for_dictionary}
 
-Allows to use signed integer types instead of unsigned in `DICTIONARY` type of the [Arrow](../../interfaces/formats.md/#data-format-arrow) format during  [LowCardinality](../../sql-reference/data-types/lowcardinality.md) output when `output_format_arrow_low_cardinality_as_dictionary` is enabled.
+Use signed integer types instead of unsigned in `DICTIONARY` type of the [Arrow](../../interfaces/formats.md/#data-format-arrow) format during  [LowCardinality](../../sql-reference/data-types/lowcardinality.md) output when `output_format_arrow_low_cardinality_as_dictionary` is enabled.
 
 Possible values:
 
@@ -1282,7 +1282,7 @@ Default value: `1`.
 
 ### output_format_arrow_use_64_bit_indexes_for_dictionary {#output_format_arrow_use_64_bit_indexes_for_dictionary}
 
-Allows to always use 64-bit integer type in `DICTIONARY` type of the [Arrow](../../interfaces/formats.md/#data-format-arrow) format during  [LowCardinality](../../sql-reference/data-types/lowcardinality.md) output when `output_format_arrow_low_cardinality_as_dictionary` is enabled.
+Use 64-bit integer type in `DICTIONARY` type of the [Arrow](../../interfaces/formats.md/#data-format-arrow) format during  [LowCardinality](../../sql-reference/data-types/lowcardinality.md) output when `output_format_arrow_low_cardinality_as_dictionary` is enabled.
 
 Possible values:
 

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -1100,6 +1100,8 @@ class IColumn;
     M(UInt64, cross_to_inner_join_rewrite, 1, "Use inner join instead of comma/cross join if there're joining expressions in the WHERE section. Values: 0 - no rewrite, 1 - apply if possible for comma/cross, 2 - force rewrite all comma joins, cross - if possible", 0) \
     \
     M(Bool, output_format_arrow_low_cardinality_as_dictionary, false, "Enable output LowCardinality type as Dictionary Arrow type", 0) \
+    M(Bool, output_format_arrow_use_signed_indexes_for_dictionary, true, "Use signed integers for dictionary indexes in Arrow format", 0) \
+    M(Bool, output_format_arrow_use_64_bit_indexes_for_dictionary, false, "Always use 64 bit integers for dictionary indexes in Arrow format", 0) \
     M(Bool, output_format_arrow_string_as_string, false, "Use Arrow String type instead of Binary for String columns", 0) \
     M(Bool, output_format_arrow_fixed_string_as_fixed_byte_array, true, "Use Arrow FIXED_SIZE_BINARY type instead of Binary for FixedString columns.", 0) \
     M(ArrowCompression, output_format_arrow_compression_method, "lz4_frame", "Compression method for Arrow output format. Supported codecs: lz4_frame, zstd, none (uncompressed)", 0) \

--- a/src/Core/SettingsChangesHistory.h
+++ b/src/Core/SettingsChangesHistory.h
@@ -82,7 +82,8 @@ namespace SettingsChangesHistory
 static std::map<ClickHouseVersion, SettingsChangesHistory::SettingsChanges> settings_changes_history =
 {
     {"24.1", {{"print_pretty_type_names", false, true, "Better user experience."},
-              {"input_format_json_read_bools_as_strings", false, true, "Allow to read bools as strings in JSON formats by default"}}},
+              {"input_format_json_read_bools_as_strings", false, true, "Allow to read bools as strings in JSON formats by default"},
+              {"output_format_arrow_use_signed_indexes_for_dictionary", false, true, "Use signed indexes type for Arrow dictionaries by default as it's recommended"}}},
     {"23.12", {{"allow_suspicious_ttl_expressions", true, false, "It is a new setting, and in previous versions the behavior was equivalent to allowing."},
               {"input_format_parquet_allow_missing_columns", false, true, "Allow missing columns in Parquet files by default"},
               {"input_format_orc_allow_missing_columns", false, true, "Allow missing columns in ORC files by default"},

--- a/src/Formats/FormatFactory.cpp
+++ b/src/Formats/FormatFactory.cpp
@@ -182,6 +182,8 @@ FormatSettings getFormatSettings(ContextPtr context, const Settings & settings)
     format_settings.with_types_use_header = settings.input_format_with_types_use_header;
     format_settings.write_statistics = settings.output_format_write_statistics;
     format_settings.arrow.low_cardinality_as_dictionary = settings.output_format_arrow_low_cardinality_as_dictionary;
+    format_settings.arrow.use_signed_indexes_for_dictionary = settings.output_format_arrow_use_signed_indexes_for_dictionary;
+    format_settings.arrow.use_64_bit_indexes_for_dictionary = settings.output_format_arrow_use_64_bit_indexes_for_dictionary;
     format_settings.arrow.allow_missing_columns = settings.input_format_arrow_allow_missing_columns;
     format_settings.arrow.skip_columns_with_unsupported_types_in_schema_inference = settings.input_format_arrow_skip_columns_with_unsupported_types_in_schema_inference;
     format_settings.arrow.skip_columns_with_unsupported_types_in_schema_inference = settings.input_format_arrow_skip_columns_with_unsupported_types_in_schema_inference;

--- a/src/Formats/FormatSettings.h
+++ b/src/Formats/FormatSettings.h
@@ -122,6 +122,8 @@ struct FormatSettings
     {
         UInt64 row_group_size = 1000000;
         bool low_cardinality_as_dictionary = false;
+        bool use_signed_indexes_for_dictionary = false;
+        bool use_64_bit_indexes_for_dictionary = false;
         bool allow_missing_columns = false;
         bool skip_columns_with_unsupported_types_in_schema_inference = false;
         bool case_insensitive_column_matching = false;

--- a/src/Processors/Formats/Impl/ArrowBlockOutputFormat.cpp
+++ b/src/Processors/Formats/Impl/ArrowBlockOutputFormat.cpp
@@ -53,9 +53,14 @@ void ArrowBlockOutputFormat::consume(Chunk chunk)
         ch_column_to_arrow_column = std::make_unique<CHColumnToArrowColumn>(
             header,
             "Arrow",
-            format_settings.arrow.low_cardinality_as_dictionary,
-            format_settings.arrow.output_string_as_string,
-            format_settings.arrow.output_fixed_string_as_fixed_byte_array);
+            CHColumnToArrowColumn::Settings
+            {
+                format_settings.arrow.output_string_as_string,
+                format_settings.arrow.output_fixed_string_as_fixed_byte_array,
+                format_settings.arrow.low_cardinality_as_dictionary,
+                format_settings.arrow.use_signed_indexes_for_dictionary,
+                format_settings.arrow.use_64_bit_indexes_for_dictionary
+            });
     }
 
     auto chunks = std::vector<Chunk>();

--- a/src/Processors/Formats/Impl/CHColumnToArrowColumn.cpp
+++ b/src/Processors/Formats/Impl/CHColumnToArrowColumn.cpp
@@ -200,8 +200,7 @@ namespace DB
         String format_name,
         size_t start,
         size_t end,
-        bool output_string_as_string,
-        bool output_fixed_string_as_fixed_byte_array,
+        const CHColumnToArrowColumn::Settings & settings,
         std::unordered_map<String, MutableColumnPtr> & dictionary_values);
 
     template <typename Builder>
@@ -214,8 +213,7 @@ namespace DB
         String format_name,
         size_t start,
         size_t end,
-        bool output_string_as_string,
-        bool output_fixed_string_as_fixed_byte_array,
+        const CHColumnToArrowColumn::Settings & settings,
         std::unordered_map<String, MutableColumnPtr> & dictionary_values)
     {
         const auto * column_array = assert_cast<const ColumnArray *>(column.get());
@@ -236,7 +234,7 @@ namespace DB
             /// Pass null null_map, because fillArrowArray will decide whether nested_type is nullable, if nullable, it will create a new null_map from nested_column
             /// Note that it is only needed by gluten(https://github.com/oap-project/gluten), because array type in gluten is by default nullable.
             /// And it does not influence the original ClickHouse logic, because null_map passed to fillArrowArrayWithArrayColumnData is always nullptr for ClickHouse doesn't allow nullable complex types including array type.
-            fillArrowArray(column_name, nested_column, nested_type, nullptr, value_builder, format_name, offsets[array_idx - 1], offsets[array_idx], output_string_as_string, output_fixed_string_as_fixed_byte_array, dictionary_values);
+            fillArrowArray(column_name, nested_column, nested_type, nullptr, value_builder, format_name, offsets[array_idx - 1], offsets[array_idx], settings, dictionary_values);
         }
     }
 
@@ -249,8 +247,7 @@ namespace DB
         String format_name,
         size_t start,
         size_t end,
-        bool output_string_as_string,
-        bool output_fixed_string_as_fixed_byte_array,
+        const CHColumnToArrowColumn::Settings & settings,
         std::unordered_map<String, MutableColumnPtr> & dictionary_values)
     {
         const auto * column_tuple = assert_cast<const ColumnTuple *>(column.get());
@@ -269,8 +266,7 @@ namespace DB
                 builder.field_builder(static_cast<int>(i)),
                 format_name,
                 start, end,
-                output_string_as_string,
-                output_fixed_string_as_fixed_byte_array,
+                settings,
                 dictionary_values);
         }
 
@@ -360,13 +356,15 @@ namespace DB
     static void checkIfIndexesTypeIsExceeded(const std::shared_ptr<arrow::DataType> & arrow_type, size_t dict_size)
     {
         const auto & dict_indexes_arrow_type = assert_cast<const arrow::DictionaryType *>(arrow_type.get())->index_type();
-        /// We use UInt32 or UInt64 type for indexes. It makes sense to check overflow only for UInt32.
+        /// We can use Int32/UInt32/Int64/UInt64 type for indexes.
+        const auto * indexes_int32_type = typeid_cast<const arrow::Int32Type *>(dict_indexes_arrow_type.get());
         const auto * indexes_uint32_type = typeid_cast<const arrow::UInt32Type *>(dict_indexes_arrow_type.get());
-        if (indexes_uint32_type && dict_size > UINT32_MAX)
+        const auto * indexes_int64_type = typeid_cast<const arrow::UInt32Type *>(dict_indexes_arrow_type.get());
+        if ((indexes_int32_type && dict_size > INT32_MAX) || (indexes_uint32_type && dict_size > UINT32_MAX) || (indexes_int64_type && dict_size > INT64_MAX))
             throw Exception(
                 ErrorCodes::ILLEGAL_COLUMN,
                 "Cannot convert ClickHouse LowCardinality column to Arrow Dictionary column:"
-                " resulting dictionary size exceeds the max value of index type UInt32");
+                " resulting dictionary size exceeds the max value of index type {}", dict_indexes_arrow_type->name());
     }
 
     template<typename ValueType>
@@ -379,8 +377,7 @@ namespace DB
         String format_name,
         size_t start,
         size_t end,
-        bool output_string_as_string,
-        bool output_fixed_string_as_fixed_byte_array,
+        const CHColumnToArrowColumn::Settings & settings,
         std::unordered_map<String, MutableColumnPtr> & dictionary_values)
     {
         const auto * column_lc = assert_cast<const ColumnLowCardinality *>(column.get());
@@ -422,7 +419,7 @@ namespace DB
 
         auto dict_column = dynamic_cast<IColumnUnique &>(*dict_values).getNestedNotNullableColumn();
         const auto & dict_type = removeNullable(assert_cast<const DataTypeLowCardinality *>(column_type.get())->getDictionaryType());
-        fillArrowArray(column_name, dict_column, dict_type, nullptr, values_builder.get(), format_name, is_nullable, dict_column->size(), output_string_as_string, output_fixed_string_as_fixed_byte_array, dictionary_values);
+        fillArrowArray(column_name, dict_column, dict_type, nullptr, values_builder.get(), format_name, is_nullable, dict_column->size(), settings, dictionary_values);
         std::shared_ptr<arrow::Array> arrow_dict_array;
         status = values_builder->Finish(&arrow_dict_array);
         checkStatus(status, column->getName(), format_name);
@@ -462,8 +459,7 @@ namespace DB
         String format_name,
         size_t start,
         size_t end,
-        bool output_string_as_string,
-        bool output_fixed_string_as_fixed_byte_array,
+        const CHColumnToArrowColumn::Settings & settings,
         std::unordered_map<String, MutableColumnPtr> & dictionary_values)
     {
         auto value_type = assert_cast<arrow::DictionaryType *>(array_builder->type().get())->value_type();
@@ -471,7 +467,7 @@ namespace DB
 #define DISPATCH(ARROW_TYPE_ID, ARROW_TYPE) \
         if (arrow::Type::ARROW_TYPE_ID == value_type->id()) \
         { \
-            fillArrowArrayWithLowCardinalityColumnDataImpl<ARROW_TYPE>(column_name, column, column_type, null_bytemap, array_builder, format_name, start, end, output_string_as_string, output_fixed_string_as_fixed_byte_array, dictionary_values); \
+            fillArrowArrayWithLowCardinalityColumnDataImpl<ARROW_TYPE>(column_name, column, column_type, null_bytemap, array_builder, format_name, start, end, settings, dictionary_values); \
             return; \
         }
 
@@ -694,8 +690,7 @@ namespace DB
         String format_name,
         size_t start,
         size_t end,
-        bool output_string_as_string,
-        bool output_fixed_string_as_fixed_byte_array,
+        const CHColumnToArrowColumn::Settings & settings,
         std::unordered_map<String, MutableColumnPtr> & dictionary_values)
     {
         switch (column_type->getTypeId())
@@ -707,12 +702,12 @@ namespace DB
                 DataTypePtr nested_type = assert_cast<const DataTypeNullable *>(column_type.get())->getNestedType();
                 const ColumnPtr & null_column = column_nullable->getNullMapColumnPtr();
                 const PaddedPODArray<UInt8> & bytemap = assert_cast<const ColumnVector<UInt8> &>(*null_column).getData();
-                fillArrowArray(column_name, nested_column, nested_type, &bytemap, array_builder, format_name, start, end, output_string_as_string, output_fixed_string_as_fixed_byte_array, dictionary_values);
+                fillArrowArray(column_name, nested_column, nested_type, &bytemap, array_builder, format_name, start, end, settings, dictionary_values);
                 break;
             }
             case TypeIndex::String:
             {
-                if (output_string_as_string)
+                if (settings.output_string_as_string)
                     fillArrowArrayWithStringColumnData<ColumnString, arrow::StringBuilder>(column, null_bytemap, format_name, array_builder, start, end);
                 else
                     fillArrowArrayWithStringColumnData<ColumnString, arrow::BinaryBuilder>(column, null_bytemap, format_name, array_builder, start, end);
@@ -720,9 +715,9 @@ namespace DB
             }
             case TypeIndex::FixedString:
             {
-                if (output_fixed_string_as_fixed_byte_array)
+                if (settings.output_fixed_string_as_fixed_byte_array)
                     fillArrowArrayWithFixedStringColumnData(column, null_bytemap, format_name, array_builder, start, end);
-                else if (output_string_as_string)
+                else if (settings.output_string_as_string)
                     fillArrowArrayWithStringColumnData<ColumnFixedString, arrow::StringBuilder>(column, null_bytemap, format_name, array_builder, start, end);
                 else
                     fillArrowArrayWithStringColumnData<ColumnFixedString, arrow::BinaryBuilder>(column, null_bytemap, format_name, array_builder, start, end);
@@ -744,19 +739,19 @@ namespace DB
                 fillArrowArrayWithDate32ColumnData(column, null_bytemap, format_name, array_builder, start, end);
                 break;
             case TypeIndex::Array:
-                fillArrowArrayWithArrayColumnData<arrow::ListBuilder>(column_name, column, column_type, null_bytemap, array_builder, format_name, start, end, output_string_as_string, output_fixed_string_as_fixed_byte_array, dictionary_values);
+                fillArrowArrayWithArrayColumnData<arrow::ListBuilder>(column_name, column, column_type, null_bytemap, array_builder, format_name, start, end, settings, dictionary_values);
                 break;
             case TypeIndex::Tuple:
-                fillArrowArrayWithTupleColumnData(column_name, column, column_type, null_bytemap, array_builder, format_name, start, end, output_string_as_string, output_fixed_string_as_fixed_byte_array, dictionary_values);
+                fillArrowArrayWithTupleColumnData(column_name, column, column_type, null_bytemap, array_builder, format_name, start, end, settings, dictionary_values);
                 break;
             case TypeIndex::LowCardinality:
-                fillArrowArrayWithLowCardinalityColumnData(column_name, column, column_type, null_bytemap, array_builder, format_name, start, end, output_string_as_string, output_fixed_string_as_fixed_byte_array, dictionary_values);
+                fillArrowArrayWithLowCardinalityColumnData(column_name, column, column_type, null_bytemap, array_builder, format_name, start, end, settings, dictionary_values);
                 break;
             case TypeIndex::Map:
             {
                 ColumnPtr column_array = assert_cast<const ColumnMap *>(column.get())->getNestedColumnPtr();
                 DataTypePtr array_type = assert_cast<const DataTypeMap *>(column_type.get())->getNestedType();
-                fillArrowArrayWithArrayColumnData<arrow::MapBuilder>(column_name, column_array, array_type, null_bytemap, array_builder, format_name, start, end, output_string_as_string, output_fixed_string_as_fixed_byte_array, dictionary_values);
+                fillArrowArrayWithArrayColumnData<arrow::MapBuilder>(column_name, column_array, array_type, null_bytemap, array_builder, format_name, start, end, settings, dictionary_values);
                 break;
             }
             case TypeIndex::Decimal32:
@@ -811,7 +806,7 @@ namespace DB
         }
     }
 
-    static std::shared_ptr<arrow::DataType> getArrowTypeForLowCardinalityIndexes(ColumnPtr indexes_column)
+    static std::shared_ptr<arrow::DataType> getArrowTypeForLowCardinalityIndexes(ColumnPtr indexes_column, const CHColumnToArrowColumn::Settings & settings)
     {
         switch (indexes_column->getDataType())
         {
@@ -827,12 +822,16 @@ namespace DB
             /// In most cases UInt32 should be enough (with more unique values using dictionary is quite meaningless).
             /// So we use minimum UInt32 type here (actually maybe even UInt16 will be enough).
             /// In case if it's exceeded during dictionary extension, an exception will be thrown.
+            /// There are also 2 settings that can change the indexes type that will be used for Dictionary indexes:
+            /// use_64_bit_indexes_for_dictionary and use_signed_indexes_for_dictionary.
             case TypeIndex::UInt8:
             case TypeIndex::UInt16:
             case TypeIndex::UInt32:
-                return arrow::uint32();
+                if (!settings.use_64_bit_indexes_for_dictionary)
+                    return settings.use_signed_indexes_for_dictionary ? arrow::int32() : arrow::uint32();
+                [[fallthrough]];
             case TypeIndex::UInt64:
-                return arrow::uint64();
+                return settings.use_signed_indexes_for_dictionary ? arrow::int64() : arrow::uint64();
             default:
                 throw Exception(ErrorCodes::LOGICAL_ERROR, "Indexes column for getUniqueIndex must be ColumnUInt, got {}.", indexes_column->getName());
         }
@@ -851,13 +850,13 @@ namespace DB
     }
 
     static std::shared_ptr<arrow::DataType> getArrowType(
-        DataTypePtr column_type, ColumnPtr column, const std::string & column_name, const std::string & format_name, bool output_string_as_string, bool output_fixed_string_as_fixed_byte_array, bool * out_is_column_nullable)
+        DataTypePtr column_type, ColumnPtr column, const std::string & column_name, const std::string & format_name, const CHColumnToArrowColumn::Settings & settings, bool * out_is_column_nullable)
     {
         if (column_type->isNullable())
         {
             DataTypePtr nested_type = assert_cast<const DataTypeNullable *>(column_type.get())->getNestedType();
             ColumnPtr nested_column = assert_cast<const ColumnNullable *>(column.get())->getNestedColumnPtr();
-            auto arrow_type = getArrowType(nested_type, nested_column, column_name, format_name, output_string_as_string, output_fixed_string_as_fixed_byte_array, out_is_column_nullable);
+            auto arrow_type = getArrowType(nested_type, nested_column, column_name, format_name, settings, out_is_column_nullable);
             *out_is_column_nullable = true;
             return arrow_type;
         }
@@ -891,7 +890,7 @@ namespace DB
         {
             auto nested_type = assert_cast<const DataTypeArray *>(column_type.get())->getNestedType();
             auto nested_column = assert_cast<const ColumnArray *>(column.get())->getDataPtr();
-            auto nested_arrow_type = getArrowType(nested_type, nested_column, column_name, format_name, output_string_as_string, output_fixed_string_as_fixed_byte_array, out_is_column_nullable);
+            auto nested_arrow_type = getArrowType(nested_type, nested_column, column_name, format_name, settings, out_is_column_nullable);
             return arrow::list(nested_arrow_type);
         }
 
@@ -904,7 +903,7 @@ namespace DB
             std::vector<std::shared_ptr<arrow::Field>> nested_fields;
             for (size_t i = 0; i != nested_types.size(); ++i)
             {
-                auto nested_arrow_type = getArrowType(nested_types[i], tuple_column->getColumnPtr(i), nested_names[i], format_name, output_string_as_string, output_fixed_string_as_fixed_byte_array, out_is_column_nullable);
+                auto nested_arrow_type = getArrowType(nested_types[i], tuple_column->getColumnPtr(i), nested_names[i], format_name, settings, out_is_column_nullable);
                 nested_fields.push_back(std::make_shared<arrow::Field>(nested_names[i], nested_arrow_type, *out_is_column_nullable));
             }
             return arrow::struct_(nested_fields);
@@ -917,8 +916,8 @@ namespace DB
             const auto & nested_column = lc_column->getDictionary().getNestedColumn();
             const auto & indexes_column = lc_column->getIndexesPtr();
             return arrow::dictionary(
-                getArrowTypeForLowCardinalityIndexes(indexes_column),
-                getArrowType(nested_type, nested_column, column_name, format_name, output_string_as_string, output_fixed_string_as_fixed_byte_array, out_is_column_nullable));
+                getArrowTypeForLowCardinalityIndexes(indexes_column, settings),
+                getArrowType(nested_type, nested_column, column_name, format_name, settings, out_is_column_nullable));
         }
 
         if (isMap(column_type))
@@ -929,8 +928,8 @@ namespace DB
 
             const auto & columns =  assert_cast<const ColumnMap *>(column.get())->getNestedData().getColumns();
             return arrow::map(
-                getArrowType(key_type, columns[0], column_name, format_name, output_string_as_string, output_fixed_string_as_fixed_byte_array, out_is_column_nullable),
-                getArrowType(val_type, columns[1], column_name, format_name, output_string_as_string, output_fixed_string_as_fixed_byte_array, out_is_column_nullable));
+                getArrowType(key_type, columns[0], column_name, format_name, settings, out_is_column_nullable),
+                getArrowType(val_type, columns[1], column_name, format_name, settings, out_is_column_nullable));
         }
 
         if (isDateTime64(column_type))
@@ -939,13 +938,13 @@ namespace DB
             return arrow::timestamp(getArrowTimeUnit(datetime64_type), datetime64_type->getTimeZone().getTimeZone());
         }
 
-        if (isFixedString(column_type) && output_fixed_string_as_fixed_byte_array)
+        if (isFixedString(column_type) && settings.output_fixed_string_as_fixed_byte_array)
         {
             size_t fixed_length = assert_cast<const DataTypeFixedString *>(column_type.get())->getN();
             return arrow::fixed_size_binary(static_cast<int32_t>(fixed_length));
         }
 
-        if (isStringOrFixedString(column_type) && output_string_as_string)
+        if (isStringOrFixedString(column_type) && settings.output_string_as_string)
             return arrow::utf8();
 
         if (isBool(column_type))
@@ -972,22 +971,14 @@ namespace DB
             column_type->getName(), column_name, format_name);
     }
 
-    CHColumnToArrowColumn::CHColumnToArrowColumn(
-        const Block & header,
-        const std::string & format_name_,
-        bool low_cardinality_as_dictionary_,
-        bool output_string_as_string_,
-        bool output_fixed_string_as_fixed_byte_array_)
-        : format_name(format_name_)
-        , low_cardinality_as_dictionary(low_cardinality_as_dictionary_)
-        , output_string_as_string(output_string_as_string_)
-        , output_fixed_string_as_fixed_byte_array(output_fixed_string_as_fixed_byte_array_)
+    CHColumnToArrowColumn::CHColumnToArrowColumn(const Block & header, const std::string & format_name_, const Settings & settings_)
+        : format_name(format_name_), settings(settings_)
     {
         arrow_fields.reserve(header.columns());
         header_columns.reserve(header.columns());
         for (auto column : header.getColumnsWithTypeAndName())
         {
-            if (!low_cardinality_as_dictionary)
+            if (!settings.low_cardinality_as_dictionary)
             {
                 column.type = recursiveRemoveLowCardinality(column.type);
                 column.column = recursiveRemoveLowCardinality(column.column);
@@ -1013,7 +1004,7 @@ namespace DB
                 const ColumnWithTypeAndName & header_column = header_columns[column_i];
                 auto column = chunk.getColumns()[column_i];
 
-                if (!low_cardinality_as_dictionary)
+                if (!settings.low_cardinality_as_dictionary)
                     column = recursiveRemoveLowCardinality(column);
 
                 if (!is_arrow_fields_initialized)
@@ -1024,8 +1015,7 @@ namespace DB
                         column,
                         header_column.name,
                         format_name,
-                        output_string_as_string,
-                        output_fixed_string_as_fixed_byte_array,
+                        settings,
                         &is_column_nullable);
                     arrow_fields.emplace_back(std::make_shared<arrow::Field>(header_column.name, arrow_type, is_column_nullable));
                 }
@@ -1044,8 +1034,7 @@ namespace DB
                     format_name,
                     0,
                     column->size(),
-                    output_string_as_string,
-                    output_fixed_string_as_fixed_byte_array,
+                    settings,
                     dictionary_values);
 
                 std::shared_ptr<arrow::Array> arrow_array;

--- a/src/Processors/Formats/Impl/CHColumnToArrowColumn.h
+++ b/src/Processors/Formats/Impl/CHColumnToArrowColumn.h
@@ -14,7 +14,24 @@ namespace DB
 class CHColumnToArrowColumn
 {
 public:
-    CHColumnToArrowColumn(const Block & header, const std::string & format_name_, bool low_cardinality_as_dictionary_, bool output_string_as_string_, bool output_fixed_string_as_fixed_byte_array_);
+    struct Settings
+    {
+        /// Output columns with String data type as Arrow::String type.
+        /// By default Arrow::Binary is used.
+        bool output_string_as_string = false;
+
+        /// Output columns with String data type as Arrow::FixedByteArray type.
+        bool output_fixed_string_as_fixed_byte_array = true;
+
+        /// Output LowCardinality type as Arrow::Dictionary type.
+        bool low_cardinality_as_dictionary = false;
+        /// Use Int types for indexes in Arrow::Dictionary instead of UInt
+        bool use_signed_indexes_for_dictionary = false;
+        /// Always use (U)Int64 type for indexes in Arrow::Dictionary.
+        bool use_64_bit_indexes_for_dictionary = false;
+    };
+
+    CHColumnToArrowColumn(const Block & header, const std::string & format_name_, const Settings & settings_);
 
     void chChunkToArrowTable(std::shared_ptr<arrow::Table> & res, const std::vector<Chunk> & chunk, size_t columns_num);
 
@@ -22,7 +39,8 @@ private:
     ColumnsWithTypeAndName header_columns;
     std::vector<std::shared_ptr<arrow::Field>> arrow_fields;
     const std::string format_name;
-    bool low_cardinality_as_dictionary;
+    Settings settings;
+
     /// Map {column name : arrow dictionary}.
     /// To avoid converting dictionary from LowCardinality to Arrow
     /// Dictionary every chunk we save it and reuse.
@@ -32,13 +50,6 @@ private:
     /// because LowCardinality column from header always has indexes type UInt8, so, we should get
     /// proper indexes type from first chunk of data.
     bool is_arrow_fields_initialized = false;
-
-    /// Output columns with String data type as Arrow::String type.
-    /// By default Arrow::Binary is used.
-    bool output_string_as_string = false;
-
-    /// Output columns with String data type as Arrow::FixedByteArray type.
-    bool output_fixed_string_as_fixed_byte_array = true;
 };
 
 }

--- a/src/Processors/Formats/Impl/ParquetBlockOutputFormat.cpp
+++ b/src/Processors/Formats/Impl/ParquetBlockOutputFormat.cpp
@@ -302,9 +302,11 @@ void ParquetBlockOutputFormat::writeUsingArrow(std::vector<Chunk> chunks)
         ch_column_to_arrow_column = std::make_unique<CHColumnToArrowColumn>(
             header,
             "Parquet",
-            false,
-            format_settings.parquet.output_string_as_string,
-            format_settings.parquet.output_fixed_string_as_fixed_byte_array);
+            CHColumnToArrowColumn::Settings
+            {
+                .output_string_as_string = format_settings.parquet.output_string_as_string,
+                .output_fixed_string_as_fixed_byte_array = format_settings.parquet.output_fixed_string_as_fixed_byte_array
+            });
     }
 
     ch_column_to_arrow_column->chChunkToArrowTable(arrow_table, chunks, columns_num);

--- a/tests/queries/0_stateless/02962_arrow_dictionary_indexes_types.reference
+++ b/tests/queries/0_stateless/02962_arrow_dictionary_indexes_types.reference
@@ -1,0 +1,4 @@
+lc: dictionary<values=binary, indices=int64, ordered=0> not null
+lc: dictionary<values=binary, indices=int32, ordered=0> not null
+lc: dictionary<values=binary, indices=uint64, ordered=0> not null
+lc: dictionary<values=binary, indices=uint32, ordered=0> not null

--- a/tests/queries/0_stateless/02962_arrow_dictionary_indexes_types.sh
+++ b/tests/queries/0_stateless/02962_arrow_dictionary_indexes_types.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+DATA_FILE=$CLICKHOUSE_TEST_UNIQUE_NAME.arrow
+
+$CLICKHOUSE_LOCAL -q "select toLowCardinality(toString(number)) as lc from numbers(1000) format Arrow settings output_format_arrow_low_cardinality_as_dictionary=1, output_format_arrow_use_signed_indexes_for_dictionary=1, output_format_arrow_use_64_bit_indexes_for_dictionary=1" > $DATA_FILE
+python3 -c "import pyarrow as pa; print(pa.ipc.open_file(pa.OSFile('$DATA_FILE', 'rb')).read_all().schema)"
+
+$CLICKHOUSE_LOCAL -q "select toLowCardinality(toString(number)) as lc from numbers(1000) format Arrow settings output_format_arrow_low_cardinality_as_dictionary=1, output_format_arrow_use_signed_indexes_for_dictionary=1, output_format_arrow_use_64_bit_indexes_for_dictionary=0" > $DATA_FILE
+python3 -c "import pyarrow as pa; print(pa.ipc.open_file(pa.OSFile('$DATA_FILE', 'rb')).read_all().schema)"
+
+$CLICKHOUSE_LOCAL -q "select toLowCardinality(toString(number)) as lc from numbers(1000) format Arrow settings output_format_arrow_low_cardinality_as_dictionary=1, output_format_arrow_use_signed_indexes_for_dictionary=0, output_format_arrow_use_64_bit_indexes_for_dictionary=1" > $DATA_FILE
+python3 -c "import pyarrow as pa; print(pa.ipc.open_file(pa.OSFile('$DATA_FILE', 'rb')).read_all().schema)"
+
+$CLICKHOUSE_LOCAL -q "select toLowCardinality(toString(number)) as lc from numbers(1000) format Arrow settings output_format_arrow_low_cardinality_as_dictionary=1, output_format_arrow_use_signed_indexes_for_dictionary=0, output_format_arrow_use_64_bit_indexes_for_dictionary=0" > $DATA_FILE
+python3 -c "import pyarrow as pa; print(pa.ipc.open_file(pa.OSFile('$DATA_FILE', 'rb')).read_all().schema)"
+
+rm $DATA_FILE
+


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add settings for better control of indexes type in Arrow dictionary. Use signed integer type for indexes by default as Arrow recommends. Closes https://github.com/ClickHouse/ClickHouse/issues/57401

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
