### PR TITLE
Enable ordinary databases while restoration

### DIFF
--- a/src/Backups/RestorerFromBackup.cpp
+++ b/src/Backups/RestorerFromBackup.cpp
@@ -573,11 +573,12 @@ void RestorerFromBackup::createDatabase(const String & database_name) const
     create_database_query->if_not_exists = (restore_settings.create_table == RestoreTableCreationMode::kCreateIfNotExists);
 
     LOG_TRACE(log, "Creating database {}: {}", backQuoteIfNeed(database_name), serializeAST(*create_database_query));
-
+    auto query_context = Context::createCopy(context);
+    query_context->setSetting("allow_deprecated_database_ordinary", 1);
     try
     {
         /// Execute CREATE DATABASE query.
-        InterpreterCreateQuery interpreter{create_database_query, context};
+        InterpreterCreateQuery interpreter{create_database_query, query_context};
         interpreter.setInternal(true);
         interpreter.execute();
     }


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):

- Bug Fix (user-visible misbehavior in an official stable release)



### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

- While `restore` is underway in Clickhouse, restore should allow the database with an `ordinary` engine.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
