### PR TITLE
Fix example 3 and tweak formatting

### DIFF
--- a/docs/en/operations/utilities/clickhouse-format.md
+++ b/docs/en/operations/utilities/clickhouse-format.md
@@ -27,7 +27,7 @@ $ clickhouse-format --query "select number from numbers(10) where number%2 order
 
 Result:
 
-```sql
+```bash
 SELECT number
 FROM numbers(10)
 WHERE number % 2
@@ -49,22 +49,20 @@ SELECT sum(number) FROM numbers(5)
 3. Multiqueries:
 
 ```bash
-$ clickhouse-format -n <<< "SELECT * FROM (SELECT 1 AS x UNION ALL SELECT 1 UNION DISTINCT SELECT 3);"
+$ clickhouse-format -n <<< "SELECT min(number) FROM numbers(5); SELECT max(number) FROM numbers(5);"
 ```
 
 Result:
 
-```sql
-SELECT *
-FROM
-(
-    SELECT 1 AS x
-    UNION ALL
-    SELECT 1
-    UNION DISTINCT
-    SELECT 3
-)
+```
+SELECT min(number)
+FROM numbers(5)
 ;
+
+SELECT max(number)
+FROM numbers(5)
+;
+
 ```
 
 4. Obfuscating:
@@ -75,7 +73,7 @@ $ clickhouse-format --seed Hello --obfuscate <<< "SELECT cost_first_screen BETWE
 
 Result:
 
-```sql
+```
 SELECT treasury_mammoth_hazelnut BETWEEN nutmeg AND span, CASE WHEN chive >= 116 THEN switching ELSE ANYTHING END;
 ```
 
@@ -87,7 +85,7 @@ $ clickhouse-format --seed World --obfuscate <<< "SELECT cost_first_screen BETWE
 
 Result:
 
-```sql
+```
 SELECT horse_tape_summer BETWEEN folklore AND moccasins, CASE WHEN intestine >= 116 THEN nonconformist ELSE FORESTRY END;
 ```
 
@@ -99,7 +97,7 @@ $ clickhouse-format --backslash <<< "SELECT * FROM (SELECT 1 AS x UNION ALL SELE
 
 Result:
 
-```sql
+```
 SELECT * \
 FROM  \
 ( \


### PR DESCRIPTION
### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Documentation entry for user-facing changes

Edited docs/en/operations/utilities/clickhouse-format.md

* example 3 is about having several SQL queries in the same input, made an example illustrating that
* removed the sql marker for all results except example 2 to emphasize when you would get colorized output in the terminal

