### PR TITLE
Hide credentials in system.backup_log base_backup_name column

### DIFF
--- a/src/Backups/BackupsWorker.cpp
+++ b/src/Backups/BackupsWorker.cpp
@@ -396,7 +396,7 @@ OperationID BackupsWorker::startMakingBackup(const ASTPtr & query, const Context
     String backup_name_for_logging = backup_info.toStringForLogging();
     String base_backup_name;
     if (backup_settings.base_backup_info)
-        base_backup_name = backup_settings.base_backup_info->toString();
+        base_backup_name = backup_settings.base_backup_info->toStringForLogging();
 
     try
     {
@@ -750,7 +750,7 @@ OperationID BackupsWorker::startRestoring(const ASTPtr & query, ContextMutablePt
         String backup_name_for_logging = backup_info.toStringForLogging();
         String base_backup_name;
         if (restore_settings.base_backup_info)
-            base_backup_name = restore_settings.base_backup_info->toString();
+            base_backup_name = restore_settings.base_backup_info->toStringForLogging();
 
         addInfo(restore_id, backup_name_for_logging, base_backup_name, restore_settings.internal, BackupStatus::RESTORING);
 

--- a/tests/integration/test_mask_sensitive_info/test.py
+++ b/tests/integration/test_mask_sensitive_info/test.py
@@ -132,7 +132,7 @@ def test_backup_table():
 
     setup_queries = [
         "CREATE TABLE backup_test (x int) ENGINE = MergeTree ORDER BY x",
-        "INSERT INTO backup_test SELECT * FROM numbers(10)"
+        "INSERT INTO backup_test SELECT * FROM numbers(10)",
     ]
 
     endpoints_with_credentials = [
@@ -150,10 +150,12 @@ def test_backup_table():
         # Run ASYNC so it returns the backup id
         return (
             f"BACKUP TABLE backup_test TO {endpoint_specs[0]} ASYNC",
-            f"BACKUP TABLE backup_test TO {endpoint_specs[1]} SETTINGS async=1, base_backup={endpoint_specs[0]}"
+            f"BACKUP TABLE backup_test TO {endpoint_specs[1]} SETTINGS async=1, base_backup={endpoint_specs[0]}",
         )
 
-    test_cases = [make_test_case(endpoint_spec) for endpoint_spec in endpoints_with_credentials]
+    test_cases = [
+        make_test_case(endpoint_spec) for endpoint_spec in endpoints_with_credentials
+    ]
     for base_query, inc_query in test_cases:
         node.query_and_get_answer_with_error(base_query)[0]
 
@@ -167,6 +169,7 @@ def test_backup_table():
 
         assert password not in base_backup_name
         assert password not in name
+
 
 def test_create_table():
     password = new_password()


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):

- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Hide credentials in `base_backup_name` column of `system.backup_log`.


Introduced in #58178.
<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

