### PR TITLE
Follow-up to #58482

### DIFF
--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -4006,9 +4006,13 @@ MergeTreeData::PartsToRemoveFromZooKeeper MergeTreeData::removePartsInRangeFromW
         /// We don't need to commit it to zk, and don't even need to activate it.
 
         MergeTreePartInfo empty_info = drop_range;
-        empty_info.min_block = empty_info.level = empty_info.mutation = 0;
+        empty_info.level = empty_info.mutation = 0;
+        empty_info.min_block = MergeTreePartInfo::MAX_BLOCK_NUMBER;
         for (const auto & part : parts_to_remove)
         {
+            /// We still have to take min_block into account to avoid creating multiple covering ranges
+            /// that intersect each other
+            empty_info.min_block = std::min(empty_info.min_block, part->info.min_block);
             empty_info.level = std::max(empty_info.level, part->info.level);
             empty_info.mutation = std::max(empty_info.mutation, part->info.mutation);
         }


### PR DESCRIPTION

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Follow-up to https://github.com/ClickHouse/ClickHouse/pull/58482
Fixes `00626_replace_partition_from_table_zookeeper`: https://s3.amazonaws.com/clickhouse-test-reports/58572/7a42fb832f5a27f02ab3e85cdb062812aae40c4a/fast_test.html
