### PR TITLE
Add some missing LLVM includes

### DIFF
--- a/src/Common/ConcurrencyControl.h
+++ b/src/Common/ConcurrencyControl.h
@@ -1,10 +1,11 @@
 #pragma once
 
+#include <list>
+#include <memory>
+#include <mutex>
+#include <optional>
 #include <base/types.h>
 #include <boost/core/noncopyable.hpp>
-#include <mutex>
-#include <memory>
-#include <list>
 
 
 namespace DB

--- a/src/Coordination/RaftServerConfig.h
+++ b/src/Coordination/RaftServerConfig.h
@@ -4,6 +4,8 @@
 #include <fmt/core.h>
 #include <libnuraft/srv_config.hxx>
 
+#include <optional>
+
 namespace DB
 {
 // default- and copy-constructible version of nuraft::srv_config

--- a/src/Functions/keyvaluepair/impl/NeedleFactory.h
+++ b/src/Functions/keyvaluepair/impl/NeedleFactory.h
@@ -3,6 +3,7 @@
 #include <Functions/keyvaluepair/impl/Configuration.h>
 #include <base/find_symbols.h>
 
+#include <iterator>
 #include <vector>
 
 namespace DB

--- a/src/Interpreters/Cache/FileCacheSettings.h
+++ b/src/Interpreters/Cache/FileCacheSettings.h
@@ -1,8 +1,9 @@
 #pragma once
 
+#include <functional>
+#include <string>
 #include <Core/Defines.h>
 #include <Interpreters/Cache/FileCache_fwd.h>
-#include <string>
 
 namespace Poco { namespace Util { class AbstractConfiguration; } } // NOLINT(cppcoreguidelines-virtual-class-destructor)
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

Add some missing includes that appear when you remove transitive includes in libc++ (`_LIBCPP_REMOVE_TRANSITIVE_INCLUDES`). I'm not enabling the flag since it will also require updating some submodules and it does not improve compilation times.
