### PR TITLE
Small fix in Keeper

### DIFF
--- a/src/Coordination/KeeperServer.cpp
+++ b/src/Coordination/KeeperServer.cpp
@@ -630,6 +630,10 @@ nuraft::cb_func::ReturnCode KeeperServer::callbackFunc(nuraft::cb_func::Type typ
         const auto preprocess_logs = [&]
         {
             auto lock = raft_instance->lockRaft();
+
+            if (keeper_context->local_logs_preprocessed)
+                return;
+
             keeper_context->local_logs_preprocessed = true;
             auto log_store = state_manager->load_log_store();
             auto log_entries = log_store->log_entries(state_machine->last_commit_index() + 1, log_store->next_slot());


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Fix https://s3.amazonaws.com/clickhouse-test-reports/0/c7b9f4aaed9c5861ad74320bbcd8b00264743810/integration_tests__tsan__[5_6].html

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
