### PR TITLE
Fix possible NULL dereference during symbolizing inline frames

### DIFF
--- a/src/Common/StackTrace.cpp
+++ b/src/Common/StackTrace.cpp
@@ -296,6 +296,9 @@ constexpr std::pair<std::string_view, std::string_view> replacements[]
 // Replace parts from @c replacements with shorter aliases
 String demangleAndCollapseNames(std::string_view file, const char * const symbol_name)
 {
+    if (!symbol_name)
+        return "?";
+
     std::string_view file_copy = file;
     if (auto trim_pos = file.find_last_of('/'); trim_pos != file.npos)
         file_copy.remove_suffix(file.size() - trim_pos);


### PR DESCRIPTION
It is possible sometimes:

<details>

```
2024.01.02 15:18:49.542342 [ 102142 ] {} <Fatal> BaseDaemon: Address: NULL pointer. Access: read. Address not mapped to object.
2024.01.02 15:18:49.542356 [ 102142 ] {} <Fatal> BaseDaemon: Stack trace: 0x0000000012817007 0x00000000120b3e88 0x000000001209c3e8 0x000000001209b7f3 0x000000001213d936 0x0000000011f71042 0x0000000011f6dd22 0x0000
000012496116 0x000000001249181c 0x00000000133197ec 0x000000001332bc79 0x0000000015d0eb14 0x0000000015d0fd11 0x0000000015e1b367 0x0000000015e195fc 0x00007f011cb31fa3 0x00007f011ca624cf
2024.01.02 15:18:50.052773 [ 102142 ] {} <Fatal> BaseDaemon: 2.1. inlined from ./build_docker/./contrib/llvm-project/libcxx/include/__memory/shared_ptr.h:603: shared_ptr<DB::Context, void>
2024.01.02 15:18:50.052829 [ 102142 ] {} <Fatal> BaseDaemon: 2.2. inlined from ./build_docker/./src/Planner/PlannerContext.h:56: DB::PlannerContext::getQueryContext() const
2024.01.02 15:18:50.052853 [ 102142 ] {} <Fatal> BaseDaemon: 2.3. inlined from ./build_docker/./src/Storages/StorageDistributed.cpp:666: DB::(anonymous namespace)::buildQueryTreeDistributed(DB::SelectQueryInfo&, s
td::shared_ptr<DB::StorageSnapshot> const&, DB::StorageID const&, std::shared_ptr<DB::IAST> const&)
2024.01.02 15:18:50.052872 [ 102142 ] {} <Fatal> BaseDaemon: 2. ./build_docker/./src/Storages/StorageDistributed.cpp:743: DB::StorageDistributed::read(DB::QueryPlan&, std::vector<String, std::allocator<String>> co
nst&, std::shared_ptr<DB::StorageSnapshot> const&, DB::SelectQueryInfo&, std::shared_ptr<DB::Context const>, DB::QueryProcessingStage::Enum, unsigned long, unsigned long) @ 0x0000000012817007 in /usr/lib/debug/usr
/bin/clickhouse.debug
2024.01.02 15:18:50.211769 [ 102142 ] {} <Fatal> BaseDaemon: 3.1. inlined from ./build_docker/./contrib/llvm-project/libcxx/include/__memory/shared_ptr.h:815: std::shared_ptr<DB::Context>::operator->[abi:v15000]()
 const
2024.01.02 15:18:50.211815 [ 102142 ] {} <Fatal> BaseDaemon: 3. ./build_docker/./src/Interpreters/InterpreterSelectQuery.cpp:2488: DB::InterpreterSelectQuery::executeFetchColumns(DB::QueryProcessingStage::Enum, DB
::QueryPlan&) @ 0x00000000120b3e88 in /usr/lib/debug/usr/bin/clickhouse.debug
2024.01.02 15:18:50.295382 [ 102142 ] {} <Fatal> BaseDaemon: 4. ./build_docker/./src/Interpreters/InterpreterSelectQuery.cpp:1444: DB::InterpreterSelectQuery::executeImpl(DB::QueryPlan&, std::optional<DB::Pipe>) @
 0x000000001209c3e8 in /usr/lib/debug/usr/bin/clickhouse.debug
2024.01.02 15:18:50.375779 [ 102142 ] {} <Fatal> BaseDaemon: 5.1. inlined from ./build_docker/./contrib/llvm-project/libcxx/include/optional:260: ~__optional_destruct_base
2024.01.02 15:18:50.375820 [ 102142 ] {} <Fatal> BaseDaemon: 5. ./build_docker/./src/Interpreters/InterpreterSelectQuery.cpp:868: DB::InterpreterSelectQuery::buildQueryPlan(DB::QueryPlan&) @ 0x000000001209b7f3 in
/usr/lib/debug/usr/bin/clickhouse.debug
2024.01.02 15:18:50.403975 [ 102142 ] {} <Fatal> BaseDaemon: 6. ./build_docker/./src/Interpreters/InterpreterSelectWithUnionQuery.cpp:0: DB::InterpreterSelectWithUnionQuery::buildQueryPlan(DB::QueryPlan&) @ 0x0000
00001213d936 in /usr/lib/debug/usr/bin/clickhouse.debug
2024.01.02 15:18:50.432051 [ 102142 ] {} <Fatal> BaseDaemon: 7.1. inlined from ./build_docker/./contrib/llvm-project/libcxx/include/__memory/shared_ptr.h:603: shared_ptr<DB::Context, void>
2024.01.02 15:18:50.432472 [ 102143 ] {} <Fatal> BaseDaemon: ########## Short fault info ############
2024.01.02 15:18:50.432500 [ 102143 ] {} <Fatal> BaseDaemon: (version 23.9.2.56 (official build), build id: 76109A79FA62B9BC630A6C39438DEA7D28147B68, git hash: a1bf3f1de55abf2354dc498ffbee270be043d633) (from threa
d 102142) Received signal 11
2024.01.02 15:18:50.432516 [ 102143 ] {} <Fatal> BaseDaemon: Signal description: Segmentation fault
2024.01.02 15:18:50.432526 [ 102143 ] {} <Fatal> BaseDaemon: Address: NULL pointer. Access: read. Address not mapped to object.
2024.01.02 15:18:50.432539 [ 102143 ] {} <Fatal> BaseDaemon: Stack trace: 0x00007f011cac5181 0x0000000015ccd934 0x000000000c76771e 0x000000000ca0fe32 0x000000000ca0ccf5 0x00007f011cb31fa3 0x00007f011ca624cf
2024.01.02 15:18:50.432547 [ 102143 ] {} <Fatal> BaseDaemon: ########################################
2024.01.02 15:18:50.432565 [ 102143 ] {} <Fatal> BaseDaemon: (version 23.9.2.56 (official build), build id: 76109A79FA62B9BC630A6C39438DEA7D28147B68, git hash: a1bf3f1de55abf2354dc498ffbee270be043d633) (from threa
d 102142) (no query) Received signal Segmentation fault (11)
```

```
2024.01.02 15:18:50.432588 [ 102143 ] {} <Fatal> BaseDaemon: Address: NULL pointer. Access: read. Address not mapped to object.
2024.01.02 15:18:50.432601 [ 102143 ] {} <Fatal> BaseDaemon: Stack trace: 0x00007f011cac5181 0x0000000015ccd934 0x000000000c76771e 0x000000000ca0fe32 0x000000000ca0ccf5 0x00007f011cb31fa3 0x00007f011ca624cf
2024.01.02 15:18:50.432638 [ 102143 ] {} <Fatal> BaseDaemon: 2. ? @ 0x000000000015c181 in /usr/lib/x86_64-linux-gnu/libc-2.28.so
2024.01.02 15:18:50.446953 [ 102143 ] {} <Fatal> BaseDaemon: 3.1. inlined from ./build_docker/./contrib/llvm-project/libcxx/include/string:1955: String::__init(char const*, unsigned long)
2024.01.02 15:18:50.446981 [ 102143 ] {} <Fatal> BaseDaemon: 3.2. inlined from ./build_docker/./contrib/llvm-project/libcxx/include/string:843: basic_string<std::nullptr_t>
2024.01.02 15:18:50.446998 [ 102143 ] {} <Fatal> BaseDaemon: 3. ./build_docker/./base/base/demangle.cpp:25: demangle(char const*, int&) @ 0x0000000015ccd934 in /usr/lib/debug/usr/bin/clickhouse.debug
2024.01.02 15:18:50.458431 [ 102143 ] {} <Fatal> BaseDaemon: 4. ./build_docker/./src/Common/StackTrace.cpp:389: void toStringEveryLineImpl<std::function<void (std::basic_string_view<char, std::char_traits<char>>)>>(bool, StackTraceRefTriple const&, std::function<void (std::basic_string_view<char, std::char_traits<char>>)>&&) (.llvm.10713299015003964940) @ 0x000000000c76771e in /usr/lib/debug/usr/bin/clickhouse.debug
2024.01.02 15:18:50.474955 [ 102143 ] {} <Fatal> BaseDaemon: 5.1. inlined from ./build_docker/./contrib/llvm-project/libcxx/include/__functional/function.h:818: ~__policy_func
2024.01.02 15:18:50.474997 [ 102143 ] {} <Fatal> BaseDaemon: 5.2. inlined from ./build_docker/./contrib/llvm-project/libcxx/include/__functional/function.h:1174: ~function
2024.01.02 15:18:50.475010 [ 102143 ] {} <Fatal> BaseDaemon: 5. ./build_docker/./src/Daemon/BaseDaemon.cpp:415: SignalListener::onFault(int, siginfo_t const&, ucontext_t*, StackTrace const&, std::vector<std::array<void*, 45ul>, std::allocator<std::array<void*, 45ul>>> const&, unsigned int, DB::ThreadStatus*) const @ 0x000000000ca0fe32 in /usr/lib/debug/usr/bin/clickhouse.debug
2024.01.02 15:18:50.512270 [ 102143 ] {} <Fatal> BaseDaemon: 6.1. inlined from ./build_docker/./src/Daemon/BaseDaemon.cpp:284: operator()
2024.01.02 15:18:50.512591 [ 102143 ] {} <Fatal> BaseDaemon: 6.2. inlined from ./build_docker/./contrib/llvm-project/libcxx/include/__functional/invoke.h:394: decltype(std::declval<SignalListener::run()::'lambda'()>()()) std::__invoke[abi:v15000]<SignalListener::run()::'lambda'()>(SignalListener::run()::'lambda'()&&)
2024.01.02 15:18:50.512648 [ 102143 ] {} <Fatal> BaseDaemon: 6.3. inlined from ./build_docker/./contrib/llvm-project/libcxx/include/thread:284: void std::__thread_execute[abi:v15000]<std::unique_ptr<std::__thread_struct, std::default_delete<std::__thread_struct>>, SignalListener::run()::'lambda'()>(std::tuple<std::unique_ptr<std::__thread_struct, std::default_delete<std::__thread_struct>>, SignalListener::run()::'lambda'()>&, std::__tuple_indices<>)
2024.01.02 15:18:50.512664 [ 102143 ] {} <Fatal> BaseDaemon: 6. ./build_docker/./contrib/llvm-project/libcxx/include/thread:295: void* std::__thread_proxy[abi:v15000]<std::tuple<std::unique_ptr<std::__thread_struct, std::default_delete<std::__thread_struct>>, SignalListener::run()::'lambda'()>>(void*) @ 0x000000000ca0ccf5 in /usr/lib/debug/usr/bin/clickhouse.debug
2024.01.02 15:18:50.512698 [ 102143 ] {} <Fatal> BaseDaemon: 7. start_thread @ 0x0000000000007fa3 in /usr/lib/x86_64-linux-gnu/libpthread-2.28.so
2024.01.02 15:18:50.512721 [ 102143 ] {} <Fatal> BaseDaemon: 8. ? @ 0x00000000000f94cf in /usr/lib/x86_64-linux-gnu/libc-2.28.so
2024.01.02 15:18:50.666148 [ 102143 ] {} <Fatal> BaseDaemon: Integrity check of the executable successfully passed (checksum: 3A99FBFAA2DA54D46975E9ABC04E53E0)
2024.01.02 15:18:50.746677 [ 102143 ] {} <Fatal> BaseDaemon: Report this error to https://github.com/ClickHouse/ClickHouse/issues
```

</details>

**The problem is actually here** - https://github.com/ClickHouse/ClickHouse/blob/5e467b69c8f212b07375dd3008bcc02afbb64357/src/Common/StackTrace.cpp#L405

Though to be precise here - https://github.com/azat/ClickHouse/blob/4d734cf1e5bc764024945209973ab1f317016932/src/Common/StackTrace.cpp#L389

See also - https://github.com/ClickHouse/ClickHouse/blob/5e467b69c8f212b07375dd3008bcc02afbb64357/src/Common/Dwarf.cpp#L1161

_(It is not obvious from the patch, so will post a snippet)_

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix possible server crash during symbolizing inline frames