### PR TITLE
Refactor stacktrace symbolizer to avoid copy-paste

### DIFF
--- a/src/Common/StackTrace.cpp
+++ b/src/Common/StackTrace.cpp
@@ -32,6 +32,10 @@ std::atomic<bool> show_addresses = true;
 
 bool shouldShowAddress(const void * addr)
 {
+    /// Likely inline frame
+    if (!addr)
+        return false;
+
     /// If the address is less than 4096, most likely it is a nullptr dereference with offset,
     /// and showing this offset is secure nevertheless.
     /// NOTE: 4096 is the page size on x86 and it can be different on other systems,
@@ -203,20 +207,24 @@ static void * getCallerAddress(const ucontext_t & context)
 #endif
 }
 
-// FIXME: looks like this is used only for Sentry but duplicates the whole algo, maybe replace?
-void StackTrace::symbolize(
-    const StackTrace::FramePointers & frame_pointers, [[maybe_unused]] size_t offset, size_t size, StackTrace::Frames & frames)
+void StackTrace::forEachFrame(
+    const StackTrace::FramePointers & frame_pointers,
+    size_t offset,
+    size_t size,
+    std::function<void(const Frame &)> callback,
+    bool fatal)
 {
 #if defined(__ELF__) && !defined(OS_FREEBSD)
     const DB::SymbolIndex & symbol_index = DB::SymbolIndex::instance();
     std::unordered_map<std::string, DB::Dwarf> dwarfs;
 
-    for (size_t i = 0; i < offset; ++i)
-        frames[i].virtual_addr = frame_pointers[i];
+    using enum DB::Dwarf::LocationInfoMode;
+    const auto mode = fatal ? FULL_WITH_INLINE : FAST;
 
     for (size_t i = offset; i < size; ++i)
     {
-        StackTrace::Frame & current_frame = frames[i];
+        StackTrace::Frame current_frame;
+        std::vector<DB::Dwarf::SymbolizedFrame> inline_frames;
         current_frame.virtual_addr = frame_pointers[i];
         const auto * object = symbol_index.findObject(current_frame.virtual_addr);
         uintptr_t virtual_offset = object ? uintptr_t(object->address_begin) : 0;
@@ -230,26 +238,41 @@ void StackTrace::symbolize(
                 auto dwarf_it = dwarfs.try_emplace(object->name, object->elf).first;
 
                 DB::Dwarf::LocationInfo location;
-                std::vector<DB::Dwarf::SymbolizedFrame> inline_frames;
                 if (dwarf_it->second.findAddress(
-                        uintptr_t(current_frame.physical_addr), location, DB::Dwarf::LocationInfoMode::FAST, inline_frames))
+                        uintptr_t(current_frame.physical_addr), location, mode, inline_frames))
                 {
                     current_frame.file = location.file.toString();
                     current_frame.line = location.line;
                 }
             }
         }
-        else
-            current_frame.object = "?";
 
         if (const auto * symbol = symbol_index.findSymbol(current_frame.virtual_addr))
             current_frame.symbol = demangle(symbol->name);
-        else
-            current_frame.symbol = "?";
+
+        for (const auto & frame : inline_frames)
+        {
+            StackTrace::Frame current_inline_frame;
+            const String file_for_inline_frame = frame.location.file.toString();
+
+            current_inline_frame.file = "inlined from " + file_for_inline_frame;
+            current_inline_frame.line = frame.location.line;
+            current_inline_frame.symbol = frame.name;
+
+            callback(current_inline_frame);
+        }
+
+        callback(current_frame);
     }
 #else
-    for (size_t i = 0; i < size; ++i)
-        frames[i].virtual_addr = frame_pointers[i];
+    UNUSED(fatal);
+
+    for (size_t i = offset; i < size; ++i)
+    {
+        StackTrace::Frame current_frame;
+        current_frame.virtual_addr = frame_pointers[i];
+        callback(current_frame);
+    }
 #endif
 }
 
@@ -349,72 +372,52 @@ toStringEveryLineImpl([[maybe_unused]] bool fatal, const StackTraceRefTriple & s
     if (stack_trace.size == 0)
         return callback("<Empty trace>");
 
+    size_t frame_index = stack_trace.offset;
 #if defined(__ELF__) && !defined(OS_FREEBSD)
-
-    using enum DB::Dwarf::LocationInfoMode;
-    const auto mode = fatal ? FULL_WITH_INLINE : FAST;
-
-    const DB::SymbolIndex & symbol_index = DB::SymbolIndex::instance();
-    std::unordered_map<String, DB::Dwarf> dwarfs;
-
-    for (size_t i = stack_trace.offset; i < stack_trace.size; ++i)
+    size_t inline_frame_index = 0;
+    auto callback_wrapper = [&](const StackTrace::Frame & frame)
     {
-        std::vector<DB::Dwarf::SymbolizedFrame> inline_frames;
-        const void * virtual_addr = stack_trace.pointers[i];
-        const auto * object = symbol_index.findObject(virtual_addr);
-        uintptr_t virtual_offset = object ? uintptr_t(object->address_begin) : 0;
-        const void * physical_addr = reinterpret_cast<const void *>(uintptr_t(virtual_addr) - virtual_offset);
-
         DB::WriteBufferFromOwnString out;
-        out << i << ". ";
 
-        String file;
-        if (std::error_code ec; object && std::filesystem::exists(object->name, ec) && !ec)
+        /// Inline frame
+        if (!frame.virtual_addr)
         {
-            auto dwarf_it = dwarfs.try_emplace(object->name, object->elf).first;
-
-            DB::Dwarf::LocationInfo location;
-
-            if (dwarf_it->second.findAddress(uintptr_t(physical_addr), location, mode, inline_frames))
-            {
-                file = location.file.toString();
-                out << file << ":" << location.line << ": ";
-            }
+            out << frame_index << "." << inline_frame_index++ << ". ";
+        }
+        else
+        {
+            out << frame_index++ << ". ";
+            inline_frame_index = 0;
         }
 
-        if (const auto * const symbol = symbol_index.findSymbol(virtual_addr))
-            out << demangleAndCollapseNames(file, symbol->name);
+        if (frame.file.has_value() && frame.line.has_value())
+            out << *frame.file << ':' << *frame.line << ": ";
+
+        if (frame.symbol.has_value() && frame.file.has_value())
+            out << demangleAndCollapseNames(*frame.file, frame.symbol->data());
         else
             out << "?";
 
-        if (shouldShowAddress(physical_addr))
+        if (shouldShowAddress(frame.physical_addr))
         {
             out << " @ ";
-            DB::writePointerHex(physical_addr, out);
+            DB::writePointerHex(frame.physical_addr, out);
         }
 
-        out << " in " << (object ? object->name : "?");
-
-        for (size_t j = 0; j < inline_frames.size(); ++j)
-        {
-            const auto & frame = inline_frames[j];
-            const String file_for_inline_frame = frame.location.file.toString();
-            callback(fmt::format(
-                "{}.{}. inlined from {}:{}: {}",
-                i,
-                j + 1,
-                file_for_inline_frame,
-                frame.location.line,
-                demangleAndCollapseNames(file_for_inline_frame, frame.name)));
-        }
+        if (frame.object.has_value())
+            out << " in " << *frame.object;
 
         callback(out.str());
-    }
+    };
 #else
-    for (size_t i = stack_trace.offset; i < stack_trace.size; ++i)
-        if (const void * const addr = stack_trace.pointers[i]; shouldShowAddress(addr))
-            callback(fmt::format("{}. {}", i, addr));
+    auto callback_wrapper = [&](const StackTrace::Frame & frame)
+    {
+        if (frame.virtual_addr && shouldShowAddress(frame.virtual_addr))
+            callback(fmt::format("{}. {}", frame_index++, frame.virtual_addr));
+    };
 #endif
+
+    StackTrace::forEachFrame(stack_trace.pointers, stack_trace.offset, stack_trace.size, callback_wrapper, fatal);
 }
 
 void StackTrace::toStringEveryLine(std::function<void(std::string_view)> callback) const

--- a/src/Common/StackTrace.h
+++ b/src/Common/StackTrace.h
@@ -62,7 +62,14 @@ public:
 
     static std::string toString(void ** frame_pointers, size_t offset, size_t size);
     static void dropCache();
-    static void symbolize(const FramePointers & frame_pointers, size_t offset, size_t size, StackTrace::Frames & frames);
+
+    /// @param fatal - if true, will process inline frames (slower)
+    static void forEachFrame(
+        const FramePointers & frame_pointers,
+        size_t offset,
+        size_t size,
+        std::function<void(const Frame &)> callback,
+        bool fatal);
 
     void toStringEveryLine(std::function<void(std::string_view)> callback) const;
     static void toStringEveryLine(const FramePointers & frame_pointers, std::function<void(std::string_view)> callback);

--- a/src/Daemon/SentryWriter.cpp
+++ b/src/Daemon/SentryWriter.cpp
@@ -169,11 +169,9 @@ void SentryWriter::onFault(int sig, const std::string & error_message, const Sta
             };
 
             StackTrace::Frames frames;
-            StackTrace::symbolize(stack_trace.getFramePointers(), offset, stack_size, frames);
 
-            for (ssize_t i = stack_size - 1; i >= offset; --i)
+            auto sentry_add_stack_trace = [&](const StackTrace::Frame & current_frame)
             {
-                const StackTrace::Frame & current_frame = frames[i];
                 sentry_value_t sentry_frame = sentry_value_new_object();
                 UInt64 frame_ptr = reinterpret_cast<UInt64>(current_frame.virtual_addr);
 
@@ -190,7 +188,9 @@ void SentryWriter::onFault(int sig, const std::string & error_message, const Sta
                     sentry_value_set_by_key(sentry_frame, "lineno", sentry_value_new_int32(static_cast<int32_t>(current_frame.line.value())));
 
                 sentry_value_append(sentry_frames, sentry_frame);
-            }
+            };
+
+            StackTrace::forEachFrame(stack_trace.getFramePointers(), offset, stack_size, sentry_add_stack_trace, /* fatal= */ true);
         }
 
         /// Prepare data for https://develop.sentry.dev/sdk/event-payloads/threads/


### PR DESCRIPTION
Note, that this patch slightly changes the behavior, since now inline frames will be processed for sentry as well.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)