### PR TITLE
Optional `client` argument for `S3Helper`

### DIFF
--- a/tests/ci/ci_config.py
+++ b/tests/ci/ci_config.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 
-from enum import Enum
 import logging
 from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser
 from dataclasses import dataclass, field
+from enum import Enum
 from pathlib import Path
 from typing import Callable, Dict, Iterable, List, Literal, Optional, Union
 
@@ -47,7 +47,7 @@ class JobConfig:
     @num_batches - sets number of batches for multi-batch job
     """
 
-    digest: DigestConfig = DigestConfig()
+    digest: DigestConfig = field(default_factory=DigestConfig)
     run_command: str = ""
     timeout: Optional[int] = None
     num_batches: int = 1
@@ -67,30 +67,32 @@ class BuildConfig:
     sparse_checkout: bool = False
     comment: str = ""
     static_binary_name: str = ""
-    job_config: JobConfig = JobConfig(
-        digest=DigestConfig(
-            include_paths=[
-                "./src",
-                "./contrib/*-cmake",
-                "./contrib/consistent-hashing",
-                "./contrib/murmurhash",
-                "./contrib/libfarmhash",
-                "./contrib/pdqsort",
-                "./contrib/cityhash102",
-                "./contrib/sparse-checkout",
-                "./contrib/libmetrohash",
-                "./contrib/update-submodules.sh",
-                "./contrib/CMakeLists.txt",
-                "./cmake",
-                "./base",
-                "./programs",
-                "./packages",
-                "./docker/packager/packager",
-            ],
-            exclude_files=[".md"],
-            docker=["clickhouse/binary-builder"],
-            git_submodules=True,
-        ),
+    job_config: JobConfig = field(
+        default_factory=lambda: JobConfig(
+            digest=DigestConfig(
+                include_paths=[
+                    "./src",
+                    "./contrib/*-cmake",
+                    "./contrib/consistent-hashing",
+                    "./contrib/murmurhash",
+                    "./contrib/libfarmhash",
+                    "./contrib/pdqsort",
+                    "./contrib/cityhash102",
+                    "./contrib/sparse-checkout",
+                    "./contrib/libmetrohash",
+                    "./contrib/update-submodules.sh",
+                    "./contrib/CMakeLists.txt",
+                    "./cmake",
+                    "./base",
+                    "./programs",
+                    "./packages",
+                    "./docker/packager/packager",
+                ],
+                exclude_files=[".md"],
+                docker=["clickhouse/binary-builder"],
+                git_submodules=True,
+            ),
+        )
     )
 
     def export_env(self, export: bool = False) -> str:
@@ -107,14 +109,14 @@ class BuildConfig:
 @dataclass
 class BuildReportConfig:
     builds: List[str]
-    job_config: JobConfig = JobConfig()
+    job_config: JobConfig = field(default_factory=JobConfig)
 
 
 @dataclass
 class TestConfig:
     required_build: str
     force_tests: bool = False
-    job_config: JobConfig = JobConfig()
+    job_config: JobConfig = field(default_factory=JobConfig)
 
 
 BuildConfigs = Dict[str, BuildConfig]

--- a/tests/ci/s3_helper.py
+++ b/tests/ci/s3_helper.py
@@ -5,20 +5,19 @@ import shutil
 import time
 from multiprocessing.dummy import Pool
 from pathlib import Path
-from typing import List, Union
+from typing import Any, List, Union
 
 import boto3  # type: ignore
 import botocore  # type: ignore
-
-from env_helper import (
-    S3_TEST_REPORTS_BUCKET,
-    S3_BUILDS_BUCKET,
-    RUNNER_TEMP,
-    CI,
-    S3_URL,
-    S3_DOWNLOAD,
-)
 from compress_files import compress_file_fast
+from env_helper import (
+    CI,
+    RUNNER_TEMP,
+    S3_BUILDS_BUCKET,
+    S3_DOWNLOAD,
+    S3_TEST_REPORTS_BUCKET,
+    S3_URL,
+)
 
 
 def _flatten_list(lst):
@@ -34,11 +33,14 @@ def _flatten_list(lst):
 class S3Helper:
     max_pool_size = 100
 
-    def __init__(self):
+    def __init__(self, client: Any = None, endpoint: str = S3_URL):
+        self.host = endpoint
+        if client is not None:
+            self.client = client
+            return
         config = botocore.config.Config(max_pool_connections=self.max_pool_size)
-        self.session = boto3.session.Session(region_name="us-east-1")
-        self.client = self.session.client("s3", endpoint_url=S3_URL, config=config)
-        self.host = S3_URL
+        session = boto3.session.Session(region_name="us-east-1")
+        self.client = session.client("s3", endpoint_url=endpoint, config=config)
 
     def _upload_file_to_s3(
         self, bucket_name: str, file_path: Path, s3_path: str
@@ -199,6 +201,7 @@ class S3Helper:
                     t = time.time()
             except Exception as ex:
                 logging.critical("Failed to upload file, expcetion %s", ex)
+                return ""
             return self.s3_url(bucket_name, s3_path)
 
         p = Pool(self.max_pool_size)


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix the issue with `ValueError: mutable default <class 'ci_config.DigestConfig'> for field digest is not allowed: use default_factory` in python 3.11; extend S3Helper to investigate issues in https://github.com/ClickHouse/ClickHouse/issues/58556 and https://github.com/yandex-cloud/geesefs/issues/52
