### PR TITLE
Remove finalize() from ~WriteBufferFromEncryptedFile

### DIFF
--- a/src/Disks/tests/gtest_disk_encrypted.cpp
+++ b/src/Disks/tests/gtest_disk_encrypted.cpp
@@ -100,6 +100,7 @@ TEST_F(DiskEncryptedTest, WriteAndRead)
     {
         auto buf = encrypted_disk->writeFile("a.txt", DBMS_DEFAULT_BUFFER_SIZE, WriteMode::Rewrite, {});
         writeString(std::string_view{"Some text"}, *buf);
+        buf->finalize();
     }
 
     /// Now we have one file.
@@ -130,6 +131,7 @@ TEST_F(DiskEncryptedTest, Append)
     {
         auto buf = encrypted_disk->writeFile("a.txt", DBMS_DEFAULT_BUFFER_SIZE, WriteMode::Append, {});
         writeString(std::string_view{"Some text"}, *buf);
+        buf->finalize();
     }
 
     EXPECT_EQ(encrypted_disk->getFileSize("a.txt"), 9);
@@ -140,6 +142,7 @@ TEST_F(DiskEncryptedTest, Append)
     {
         auto buf = encrypted_disk->writeFile("a.txt", DBMS_DEFAULT_BUFFER_SIZE, WriteMode::Append, {});
         writeString(std::string_view{" Another text"}, *buf);
+        buf->finalize();
     }
 
     EXPECT_EQ(encrypted_disk->getFileSize("a.txt"), 22);
@@ -156,6 +159,7 @@ TEST_F(DiskEncryptedTest, Truncate)
     {
         auto buf = encrypted_disk->writeFile("a.txt", DBMS_DEFAULT_BUFFER_SIZE, WriteMode::Append, {});
         writeString(std::string_view{"Some text"}, *buf);
+        buf->finalize();
     }
 
     EXPECT_EQ(encrypted_disk->getFileSize("a.txt"), 9);
@@ -185,6 +189,7 @@ TEST_F(DiskEncryptedTest, ZeroFileSize)
     /// Write nothing to a file.
     {
         auto buf = encrypted_disk->writeFile("a.txt", DBMS_DEFAULT_BUFFER_SIZE, WriteMode::Rewrite, {});
+        buf->finalize();
     }
 
     EXPECT_EQ(encrypted_disk->getFileSize("a.txt"), 0);
@@ -194,6 +199,7 @@ TEST_F(DiskEncryptedTest, ZeroFileSize)
     /// Append the file with nothing.
     {
         auto buf = encrypted_disk->writeFile("a.txt", DBMS_DEFAULT_BUFFER_SIZE, WriteMode::Append, {});
+        buf->finalize();
     }
 
     EXPECT_EQ(encrypted_disk->getFileSize("a.txt"), 0);
@@ -219,6 +225,7 @@ TEST_F(DiskEncryptedTest, AnotherFolder)
     {
         auto buf = encrypted_disk->writeFile("a.txt", DBMS_DEFAULT_BUFFER_SIZE, WriteMode::Rewrite, {});
         writeString(std::string_view{"Some text"}, *buf);
+        buf->finalize();
     }
 
     /// Now we have one file.
@@ -239,10 +246,13 @@ TEST_F(DiskEncryptedTest, RandomIV)
     {
         auto buf = encrypted_disk->writeFile("a.txt", DBMS_DEFAULT_BUFFER_SIZE, WriteMode::Rewrite, {});
         writeString(std::string_view{"Some text"}, *buf);
+        buf->finalize();
     }
+
     {
         auto buf = encrypted_disk->writeFile("b.txt", DBMS_DEFAULT_BUFFER_SIZE, WriteMode::Rewrite, {});
         writeString(std::string_view{"Some text"}, *buf);
+        buf->finalize();
     }
 
     /// Now we have two files.

--- a/src/IO/WriteBufferFromEncryptedFile.cpp
+++ b/src/IO/WriteBufferFromEncryptedFile.cpp
@@ -1,4 +1,5 @@
 #include <IO/WriteBufferFromEncryptedFile.h>
+#include <Common/logger_useful.h>
 
 #if USE_SSL
 
@@ -21,7 +22,9 @@ WriteBufferFromEncryptedFile::WriteBufferFromEncryptedFile(
 
 WriteBufferFromEncryptedFile::~WriteBufferFromEncryptedFile()
 {
-    finalize();
+    /// That destructor could be call with finalized=false in case of exceptions.
+    if (!finalized)
+        LOG_INFO(log, "WriteBufferFromEncryptedFile is not finalized in destructor");
 }
 
 void WriteBufferFromEncryptedFile::finalizeBefore()

--- a/src/IO/WriteBufferFromEncryptedFile.h
+++ b/src/IO/WriteBufferFromEncryptedFile.h
@@ -39,6 +39,8 @@ private:
     bool flush_header = false;
 
     FileEncryption::Encryptor encryptor;
+
+    Poco::Logger * log = &Poco::Logger::get("WriteBufferFromEncryptedFile");
 };
 
 }


### PR DESCRIPTION
### Changelog category:
- Not for changelog

Remove `finalize()` from `~WriteBufferFromEncryptedFile`.