### PR TITLE
Throws obfuscated email address elements into codeblocks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ curl https://clickhouse.com/ | sh
 
 ## Upcoming Events
 
-Keep an eye out for upcoming meetups around the world. Somewhere else you want us to be? Please feel free to reach out to tyler <at> clickhouse <dot> com.
+Keep an eye out for upcoming meetups around the world. Somewhere else you want us to be? Please feel free to reach out to tyler `<at>` clickhouse `<dot>` com.
 
 ## Recent Recordings
 * **Recent Meetup Videos**: [Meetup Playlist](https://www.youtube.com/playlist?list=PL0Z2YDlm0b3iNDUzpY1S3L_iV4nARda_U) Whenever possible recordings of the ClickHouse Community Meetups are edited and presented as individual talks. Current featuring "Modern SQL in 2023", "Fast, Concurrent, and Consistent Asynchronous INSERTS in ClickHouse", and "Full-Text Indices: Design and Experiments"


### PR DESCRIPTION
The line:

> [...] tyler <at> clickhouse <dot> com.

in the `README.md` isn't being rendered by GitHub. I'm guessing they're just escaping any tags that don't have a closing tag, or something like that.

<img width="1044" alt="Screenshot 2024-01-09 at 2 29 15 PM" src="https://github.com/ClickHouse/ClickHouse/assets/9611008/17020b34-a4fe-4063-a3b3-2f62a8b16448">

Anyway, this PR just throws those obfuscated elements into `code` tags.

---

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->

### Changelog category (leave one):

- Documentation (changelog entry is not required)

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)