### PR TITLE
Fix test_replicated_database::test_startup_without_zk flakiness

### DIFF
--- a/tests/integration/test_replicated_database/test.py
+++ b/tests/integration/test_replicated_database/test.py
@@ -1077,7 +1077,7 @@ def test_startup_without_zk(started_cluster):
         err = main_node.query_and_get_error(
             "CREATE DATABASE startup ENGINE = Replicated('/clickhouse/databases/startup', 'shard1', 'replica1');"
         )
-        assert "ZooKeeper" in err
+        assert "ZooKeeper" in err or "Coordination::Exception" in err
     main_node.query(
         "CREATE DATABASE startup ENGINE = Replicated('/clickhouse/databases/startup', 'shard1', 'replica1');"
     )


### PR DESCRIPTION
CI found [1]

    E           assert 'ZooKeeper' in "Received exception from server (version 24.1.1):\nCode: 999. DB::Exception: Received from 172.16.1.6:9000. Coordination::Exception. Coordination::Exception: Coordination error: Connection loss, path /clickhouse/databases/startup. Stack trace:\n\n0. ? @ 0x000000000c734f1b in /usr/bin/clickhouse\n1. ? @ 0x000000000fbef3f4 in /usr/bin/clickhouse\n2. ? @ 0x000000000fbeebc8 in /usr/bin/clickhouse\n3. ? @ 0x0000000012ded0f9 in /usr/bin/clickhouse\n4. ? @ 0x0000000012deaa71 in /usr/bin/clickhouse\n5. ? @ 0x00000000107e51e8 in /usr/bin/clickhouse\n6. ? @ 0x00000000107eb87a in /usr/bin/clickhouse\n7. ? @ 0x0000000011213ec3 in /usr/bin/clickhouse\n8. ? @ 0x00000000111e9acf in /usr/bin/clickhouse\n9. ? @ 0x000000001120e85e in /usr/bin/clickhouse\n10. ? @ 0x000000001174f0a2 in /usr/bin/clickhouse\n11. ? @ 0x0000000011748c9a in /usr/bin/clickhouse\n12. ? @ 0x00000000126fb5a9 in /usr/bin/clickhouse\n13. ? @ 0x00000000127130f9 in /usr/bin/clickhouse\n14. ? @ 0x000000001517bf12 in /usr/bin/clickhouse\n15. ? @ 0x000000001517cd11 in /usr/bin/clickhouse\n16. ? @ 0x00000000152740c7 in /usr/bin/clickhouse\n17. ? @ 0x00000000152726bc in /usr/bin/clickhouse\n18. ? @ 0x00007f7f36485ac3\n19. ? @ 0x00007f7f36517660\n. (KEEPER_EXCEPTION)\n(query: CREATE DATABASE startup ENGINE = Replicated('/clickhouse/databases/startup', 'shard1', 'replica1');)\n"

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/58610/441a3fbb9b1c088f528841727f013b829f63fc8a/integration_tests__release__[3_4]/integration_run_test_replicated_database_test_py_0.log

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Cc: @tavplubix 