### PR TITLE
Fix perf tests duration (checks.test_duration_ms)

### DIFF
--- a/tests/performance/scripts/compare.sh
+++ b/tests/performance/scripts/compare.sh
@@ -1223,7 +1223,7 @@ create table ci_checks engine File(TSVWithNamesAndTypes, 'ci-checks.tsv')
             select
                 test || ' #' || toString(query_index) || '::' || test_desc_.1 test_name,
                 'slower' test_status,
-                test_desc_.2 test_duration_ms,
+                test_desc_.2*1e3 test_duration_ms,
                 'https://s3.amazonaws.com/clickhouse-test-reports/$PR_TO_TEST/$SHA_TO_TEST/${CLICKHOUSE_PERFORMANCE_COMPARISON_CHECK_NAME_PREFIX}/report.html#changes-in-performance.' || test || '.' || toString(query_index) report_url
             from queries
             array join map('old', left, 'new', right) as test_desc_
@@ -1232,7 +1232,7 @@ create table ci_checks engine File(TSVWithNamesAndTypes, 'ci-checks.tsv')
             select
                 test || ' #' || toString(query_index) || '::' || test_desc_.1 test_name,
                 'unstable' test_status,
-                test_desc_.2 test_duration_ms,
+                test_desc_.2*1e3 test_duration_ms,
                 'https://s3.amazonaws.com/clickhouse-test-reports/$PR_TO_TEST/$SHA_TO_TEST/${CLICKHOUSE_PERFORMANCE_COMPARISON_CHECK_NAME_PREFIX}/report.html#unstable-queries.' || test || '.' || toString(query_index) report_url
             from queries
             array join map('old', left, 'new', right) as test_desc_


### PR DESCRIPTION
The column in the source was seconds in Float32, we need to convert it to milliseconds in UInt64.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Follow-up for: https://github.com/ClickHouse/ClickHouse/pull/58348 (cc @alexey-milovidov )