### PR TITLE
CI: ci cache. step 1

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -319,22 +319,15 @@ jobs:
       run_command: |
         python3 build_report_check.py "$CHECK_NAME"
   MarkReleaseReady:
+    needs: [RunConfig, BuilderBinDarwin, BuilderBinDarwinAarch64, BuilderDebRelease, BuilderDebAarch64]
     if: ${{ !failure() && !cancelled() }}
-    needs:
-      - BuilderBinDarwin
-      - BuilderBinDarwinAarch64
-      - BuilderDebRelease
-      - BuilderDebAarch64
-    runs-on: [self-hosted, style-checker]
-    steps:
-      - name: Check out repository code
-        uses: ClickHouse/checkout@v1
-        with:
-          clear-repository: true
-      - name: Mark Commit Release Ready
-        run: |
-          cd "$GITHUB_WORKSPACE/tests/ci"
-          python3 mark_release_ready.py
+    uses: ./.github/workflows/reusable_test.yml
+    with:
+      test_name: Mark Commit Release Ready
+      runner_type: style-checker
+      data: ${{ needs.RunConfig.outputs.data }}
+      run_command: |
+        python3 mark_release_ready.py
 ############################################################################################
 #################################### INSTALL PACKAGES ######################################
 ############################################################################################

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -35,7 +35,7 @@ jobs:
       - name: PrepareRunConfig
         id: runconfig
         run: |
-            python3 "$GITHUB_WORKSPACE/tests/ci/ci.py" --configure --rebuild-all-binaries --outfile ${{ runner.temp }}/ci_run_data.json
+            python3 "$GITHUB_WORKSPACE/tests/ci/ci.py" --configure --outfile ${{ runner.temp }}/ci_run_data.json
 
             echo "::group::CI configuration"
             python3 -m json.tool ${{ runner.temp }}/ci_run_data.json

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -491,10 +491,12 @@ jobs:
       run_command: |
         TEMP_PATH="${TEMP_PATH}/integration" \
           python3 integration_test_check.py "Integration $CHECK_NAME" \
-            --validate-bugfix --post-commit-status=file || echo 'ignore exit code'; \
+            --validate-bugfix --post-commit-status=file || echo "ignore exit code"
+
         TEMP_PATH="${TEMP_PATH}/stateless" \
           python3 functional_test_check.py "Stateless $CHECK_NAME" "$KILL_TIMEOUT" \
-            --validate-bugfix --post-commit-status=file || echo 'ignore exit code'; \
+            --validate-bugfix --post-commit-status=file || echo "ignore exit code"
+
         python3 bugfix_validate_check.py "${TEMP_PATH}/stateless/functional_commit_status.tsv" "${TEMP_PATH}/integration/integration_commit_status.tsv"
 ##############################################################################################
 ############################ FUNCTIONAl STATEFUL TESTS #######################################

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -491,12 +491,10 @@ jobs:
       run_command: |
         TEMP_PATH="${TEMP_PATH}/integration" \
           python3 integration_test_check.py "Integration $CHECK_NAME" \
-            --validate-bugfix --post-commit-status=file || echo 'ignore exit code'
-
+            --validate-bugfix --post-commit-status=file || echo 'ignore exit code'; \
         TEMP_PATH="${TEMP_PATH}/stateless" \
           python3 functional_test_check.py "Stateless $CHECK_NAME" "$KILL_TIMEOUT" \
-            --validate-bugfix --post-commit-status=file || echo 'ignore exit code'
-
+            --validate-bugfix --post-commit-status=file || echo 'ignore exit code'; \
         python3 bugfix_validate_check.py "${TEMP_PATH}/stateless/functional_commit_status.tsv" "${TEMP_PATH}/integration/integration_commit_status.tsv"
 ##############################################################################################
 ############################ FUNCTIONAl STATEFUL TESTS #######################################

--- a/.github/workflows/release_branches.yml
+++ b/.github/workflows/release_branches.yml
@@ -41,7 +41,7 @@ jobs:
         id: runconfig
         run: |
             echo "::group::configure CI run"
-            python3 "$GITHUB_WORKSPACE/tests/ci/ci.py" --configure --rebuild-all-binaries --outfile ${{ runner.temp }}/ci_run_data.json
+            python3 "$GITHUB_WORKSPACE/tests/ci/ci.py" --configure --outfile ${{ runner.temp }}/ci_run_data.json
             echo "::endgroup::"
             echo "::group::CI run configure results"
             python3 -m json.tool ${{ runner.temp }}/ci_run_data.json

--- a/tests/ci/ci.py
+++ b/tests/ci/ci.py
@@ -1,5 +1,7 @@
 import argparse
 import concurrent.futures
+from dataclasses import asdict, dataclass
+from enum import Enum
 import json
 import logging
 import os
@@ -7,12 +9,13 @@ import re
 import subprocess
 import sys
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Optional
+import time
+from typing import Any, Dict, List, Optional, Sequence, Union
 
 import docker_images_helper
 import upload_result_helper
 from build_check import get_release_or_pr
-from ci_config import CI_CONFIG, JobNames, Labels
+from ci_config import CI_CONFIG, Build, Labels, JobNames
 from clickhouse_helper import (
     CiLogsCredentials,
     ClickHouseHelper,
@@ -29,10 +32,11 @@ from commit_status_helper import (
     set_status_comment,
     update_mergeable_check,
 )
-from digest_helper import DockerDigester, JobDigester
+from digest_helper import JOB_DIGEST_LEN, DockerDigester, JobDigester
 from env_helper import (
     CI,
     GITHUB_JOB_API_URL,
+    GITHUB_RUN_URL,
     REPO_COPY,
     REPORT_PATH,
     S3_BUILDS_BUCKET,
@@ -46,6 +50,561 @@ from pr_info import PRInfo
 from report import SUCCESS, BuildResult, JobReport
 from s3_helper import S3Helper
 from version_helper import get_version_from_repo
+
+
+@dataclass
+class PendingState:
+    updated_at: float
+    run_url: str
+
+
+class CiCache:
+    """
+    CI cache is a bunch of records. Record is a file stored under special location on s3.
+    The file name has following format
+
+        <RECORD_TYPE>_[<ATTRIBUTES>]-<JOB_NAME>_<JOB_DIGEST>_<BATCH>_<NUM_BATCHES>.ci
+
+    RECORD_TYPE:
+        SUCCESSFUL - for successfuly finished jobs
+        PENDING - for pending jobs
+
+    ATTRIBUTES:
+        master - for jobs being executed on the master branch (not a PR branch)
+    """
+
+    _S3_CACHE_PREFIX = "CI_cache_v1"
+    # record file name prefix for done jobs
+    # _CACHE_RECORD_PREFIX_SUCCESSFUL = "successful"
+    # record file name prefix for pending jobs
+    # _CACHE_RECORD_PREFIX_PENDING = "pending"
+    _CACHE_BUILD_REPORT_PREFIX = "build_report"
+    _RECORD_FILE_EXTENSION = ".ci"
+    _LOCAL_CACHE_PATH = Path(TEMP_PATH) / "ci_cache"
+    _ATTRIBUTE_RELEASE = "release"
+    # divider symbol 1
+    _DIV1 = "--"
+    # divider symbol 2
+    _DIV2 = "_"
+    assert _DIV1 != _DIV2
+
+    class RecordType(Enum):
+        SUCCESSFUL = "successful"
+        PENDING = "pending"
+
+    @dataclass
+    class Record:
+        record_type: "CiCache.RecordType"
+        job_name: str
+        job_digest: str
+        batch: int
+        num_batches: int
+        release_branch: bool
+        file: str = ""
+
+        def to_str_key(self):
+            """other fields must not be included in the hash str"""
+            return "_".join(
+                [self.job_name, self.job_digest, str(self.batch), str(self.num_batches)]
+            )
+
+    class JobType(Enum):
+        DOCS = "DOCS"
+        SRCS = "SRCS"
+
+        @classmethod
+        def is_docs_job(cls, job_name: str) -> bool:
+            return job_name == JobNames.DOCS_CHECK
+
+        @classmethod
+        def is_srcs_job(cls, job_name: str) -> bool:
+            return not cls.is_docs_job(job_name)
+
+        @classmethod
+        def get_type_by_name(cls, job_name: str) -> "CiCache.JobType":
+            res = cls.SRCS
+            if cls.is_docs_job(job_name):
+                res = cls.DOCS
+            elif cls.is_srcs_job(job_name):
+                res = cls.SRCS
+            else:
+                assert False
+            return res
+
+    def __init__(
+        self,
+        s3: S3Helper,
+        job_digests: Dict[str, str],
+    ):
+        self.s3 = s3
+        # self.build_digest = job_digests[JobNames.PACKAGE_RELEASE]
+        # self.docs_digest = job_digests[JobNames.DOCS_CHECK]
+        self.job_digests = job_digests
+        # self.build_path = f"{self._S3_CACHE_PREFIX}/BUILD-{self.build_digest}/"
+        # self.docs_path = f"{self._S3_CACHE_PREFIX}/DOCS-{self.docs_digest}/"
+        self.cache_s3_paths = {
+            job_type: f"{self._S3_CACHE_PREFIX}/{job_type.value}-{self.job_digests[self._get_reference_job_name(job_type)]}/"
+            for job_type in self.JobType
+        }
+        self.s3_record_prefixes = {
+            record_type: record_type.value for record_type in self.RecordType
+        }
+        self.records: Dict["CiCache.RecordType", Dict[str, "CiCache.Record"]] = {
+            record_type: {} for record_type in self.RecordType
+        }
+
+        self.cache_updated = False
+        self.cache_data_fetched = True
+        if not self._LOCAL_CACHE_PATH.exists():
+            self._LOCAL_CACHE_PATH.mkdir(parents=True, exist_ok=True)
+
+    def _get_reference_job_name(self, job_type: JobType) -> str:
+        res = Build.PACKAGE_RELEASE
+        if job_type == self.JobType.DOCS:
+            res = JobNames.DOCS_CHECK
+        elif job_type == self.JobType.SRCS:
+            res = Build.PACKAGE_RELEASE
+        else:
+            assert False
+        return res
+
+    def _get_record_file_name(
+        self,
+        record_type: RecordType,
+        job_name: str,
+        batch: int,
+        num_batches: int,
+        release_branch: bool,
+    ) -> str:
+        prefix = self.s3_record_prefixes[record_type]
+        prefix_extended = (
+            self._DIV2.join([prefix, self._ATTRIBUTE_RELEASE])
+            if release_branch
+            else prefix
+        )
+        job_name = self._DIV2.join(
+            [job_name, self.job_digests[job_name], str(batch), str(num_batches)]
+        )
+        file_name = self._DIV1.join([prefix_extended, job_name])
+        file_name += self._RECORD_FILE_EXTENSION
+        return file_name
+
+    def _get_record_s3_path(self, job_name: str) -> str:
+        return self.cache_s3_paths[self.JobType.get_type_by_name(job_name)]
+
+    def update(self):
+        """
+        Pulls cache records from s3. Only records name w/o content.
+        """
+        for record_type in self.RecordType:
+            prefix = self.s3_record_prefixes[record_type]
+            cache_list = self.records[record_type]
+            for job_type in self.JobType:
+                path = self.cache_s3_paths[job_type]
+                records = self.s3.list_prefix(f"{path}{prefix}", S3_BUILDS_BUCKET)
+                records = [record.split("/")[-1] for record in records]
+                print(f"::group::Cache records for {job_type.value} type jobs")
+                print(records)
+                print("::endgroup::")
+                for file in records:
+                    assert file.endswith(self._RECORD_FILE_EXTENSION)
+                    file = file.replace(self._RECORD_FILE_EXTENSION, "")
+                    release_branch = False
+                    assert len(file.split(self._DIV1)) == 2, f"BUG: {file}"
+                    prefix_extended, job_suffix = file.split(self._DIV1)
+                    assert (
+                        len(prefix_extended.split(self._DIV2)) <= 2
+                    ), f"BUG: {file} {prefix_extended}"
+                    if len(prefix_extended.split(self._DIV2)) > 1:
+                        assert (
+                            prefix_extended.split(self._DIV2)[1]
+                            == self._ATTRIBUTE_RELEASE
+                        ), "BUG, no other attributes currently supported"
+                        release_branch = True
+
+                    job_properties = job_suffix.split(self._DIV2)
+                    assert len(job_properties) >= 4, "BUG"
+                    job_name, job_digest, batch, num_batches = (
+                        self._DIV2.join(job_properties[:-3]),
+                        job_properties[-3],
+                        int(job_properties[-2]),
+                        int(job_properties[-1]),
+                    )
+                    assert (
+                        len(job_digest) == JOB_DIGEST_LEN
+                    ), f"Invalid digest: {job_digest}"
+                    if (
+                        job_name not in self.job_digests
+                        or self.job_digests[job_name] != job_digest
+                    ):
+                        # skip records we are not interested in
+                        continue
+                    record = self.Record(
+                        record_type,
+                        job_name,
+                        job_digest,
+                        batch,
+                        num_batches,
+                        release_branch,
+                        file="",
+                    )
+                    if record.to_str_key() not in cache_list:
+                        cache_list[record.to_str_key()] = record
+                        self.cache_data_fetched = False
+                    elif (
+                        not cache_list[record.to_str_key()].release_branch
+                        and record.release_branch
+                    ):
+                        # replace a non-release record with a release one
+                        cache_list[record.to_str_key()] = record
+                        self.cache_data_fetched = False
+
+        self.cache_updated = True
+        return self
+
+    def fetch_records_data(self):
+        """
+        Pulls CommitStatusData for all cached jobs from s3
+        """
+        if not self.cache_updated:
+            self.update()
+
+        if self.cache_data_fetched:
+            # there are no record w/o underling data - no need to fetch
+            return self
+
+        # clean up
+        for file in self._LOCAL_CACHE_PATH.glob("*.ci"):
+            file.unlink()
+
+        # download all record files
+        for job_type in self.JobType:
+            path = self.cache_s3_paths[job_type]
+            for record_type in self.RecordType:
+                prefix = self.s3_record_prefixes[record_type]
+                _ = self.s3.download_files(
+                    bucket=S3_BUILDS_BUCKET,
+                    s3_path=f"{path}{prefix}",
+                    file_suffix=self._RECORD_FILE_EXTENSION,
+                    local_directory=self._LOCAL_CACHE_PATH,
+                )
+
+        # validate we have files for all records and save file names meanwhile
+        for record_type in self.RecordType:
+            record_list = self.records[record_type]
+            for _, record in record_list.items():
+                record_file_name = self._get_record_file_name(
+                    record_type,
+                    record.job_name,
+                    record.batch,
+                    record.num_batches,
+                    record.release_branch,
+                )
+                assert (
+                    self._LOCAL_CACHE_PATH / record_file_name
+                ).is_file(), f"BUG. Record file must be present: {self._LOCAL_CACHE_PATH / record_file_name}"
+                record.file = record_file_name
+
+        self.cache_data_fetched = True
+        return self
+
+    def exist(
+        self,
+        record_type: "CiCache.RecordType",
+        job: str,
+        batch: int,
+        num_batches: int,
+        release_branch: bool,
+    ) -> bool:
+        if not self.cache_updated:
+            self.update()
+        record_key = self.Record(
+            record_type,
+            job,
+            self.job_digests[job],
+            batch,
+            num_batches,
+            release_branch,
+        ).to_str_key()
+        res = record_key in self.records[record_type]
+        if release_branch:
+            return res and self.records[record_type][record_key].release_branch
+        else:
+            return res
+
+    def push(
+        self,
+        record_type: "CiCache.RecordType",
+        job: str,
+        batches: Union[int, Sequence[int]],
+        num_batches: int,
+        status: Union[CommitStatusData, PendingState],
+        release_branch: bool = False,
+    ) -> None:
+        """
+        Pushes a cache record (CommitStatusData)
+        @release_branch adds "release" attribute to a record
+        """
+        if isinstance(batches, int):
+            batches = [batches]
+        for batch in batches:
+            record_file = self._LOCAL_CACHE_PATH / self._get_record_file_name(
+                record_type, job, batch, num_batches, release_branch
+            )
+            record_s3_path = self._get_record_s3_path(job)
+            if record_type == self.RecordType.SUCCESSFUL:
+                assert isinstance(status, CommitStatusData)
+                status.dump_to_file(record_file)
+            elif record_type == self.RecordType.PENDING:
+                assert isinstance(status, PendingState)
+                with open(record_file, "w") as json_file:
+                    json.dump(asdict(status), json_file)
+            else:
+                assert False
+
+            _ = self.s3.upload_file(
+                bucket=S3_BUILDS_BUCKET,
+                file_path=record_file,
+                s3_path=record_s3_path + record_file.name,
+            )
+            record = self.Record(
+                record_type,
+                job,
+                self.job_digests[job],
+                batch,
+                num_batches,
+                release_branch,
+                file=record_file.name,
+            )
+            if (
+                record.release_branch
+                or record.to_str_key() not in self.records[record_type]
+            ):
+                self.records[record_type][record.to_str_key()] = record
+
+    def get(
+        self, record_type: "CiCache.RecordType", job: str, batch: int, num_batches: int
+    ) -> Optional[Union[CommitStatusData, PendingState]]:
+        """
+        Gets a cache record data for a job, or None if a cache miss
+        """
+        assert (
+            record_type == self.RecordType.SUCCESSFUL
+        ), "FIXME: Not support for other type currently"
+
+        if not self.cache_data_fetched:
+            self.fetch_records_data()
+
+        record_key = self.Record(
+            record_type,
+            job,
+            self.job_digests[job],
+            batch,
+            num_batches,
+            release_branch=False,
+        ).to_str_key()
+
+        if record_key not in self.records[record_type]:
+            return None
+
+        record_file_name = self.records[record_type][record_key].file
+
+        res = CommitStatusData.load_from_file(
+            self._LOCAL_CACHE_PATH / record_file_name
+        )  # type: CommitStatusData
+        assert res.status == "success", "BUG!"
+        return res
+
+    def delete(
+        self,
+        record_type: "CiCache.RecordType",
+        job: str,
+        batch: int,
+        num_batches: int,
+        release_branch: bool,
+    ) -> None:
+        """
+        deletes record from the cache
+        """
+        raise NotImplementedError("Let's try make cache push-and-read-only")
+        # assert (
+        #     record_type == self.RecordType.PENDING
+        # ), "FIXME: delete is supported for pending records only"
+        # record_file_name = self._get_record_file_name(
+        #     self.RecordType.PENDING,
+        #     job,
+        #     batch,
+        #     num_batches,
+        #     release_branch=release_branch,
+        # )
+        # record_s3_path = self._get_record_s3_path(job)
+        # self.s3.delete_file_from_s3(S3_BUILDS_BUCKET, record_s3_path + record_file_name)
+
+        # record_key = self.Record(
+        #     record_type,
+        #     job,
+        #     self.job_digests[job],
+        #     batch,
+        #     num_batches,
+        #     release_branch=False,
+        # ).to_str_key()
+
+        # if record_key in self.records[record_type]:
+        #     del self.records[record_type][record_key]
+
+    def is_successful(
+        self, job: str, batch: int, num_batches: int, release_branch: bool
+    ) -> bool:
+        """
+        checks if a given job have already been done successfuly
+        """
+        return self.exist(
+            self.RecordType.SUCCESSFUL, job, batch, num_batches, release_branch
+        )
+
+    def is_pending(
+        self, job: str, batch: int, num_batches: int, release_branch: bool
+    ) -> bool:
+        """
+        check pending record in the cache for a given job
+        @release_branch - checks that "release" attribute is set for a record
+        """
+        if self.is_successful(job, batch, num_batches, release_branch):
+            # successful record is present - not pending
+            return False
+
+        return self.exist(
+            self.RecordType.PENDING, job, batch, num_batches, release_branch
+        )
+
+    def push_successful(
+        self,
+        job: str,
+        batch: int,
+        num_batches: int,
+        job_status: CommitStatusData,
+        release_branch: bool = False,
+    ) -> None:
+        """
+        Pushes a cache record (CommitStatusData)
+        @release_branch adds "release" attribute to a record
+        """
+        self.push(
+            self.RecordType.SUCCESSFUL,
+            job,
+            [batch],
+            num_batches,
+            job_status,
+            release_branch,
+        )
+
+    def push_pending(
+        self, job: str, batches: List[int], num_batches: int, release_branch: bool
+    ) -> None:
+        """
+        pushes pending record for a job to the cache
+        """
+        pending_state = PendingState(time.time(), run_url=GITHUB_RUN_URL)
+        self.push(
+            self.RecordType.PENDING,
+            job,
+            batches,
+            num_batches,
+            pending_state,
+            release_branch,
+        )
+
+    def get_successful(
+        self, job: str, batch: int, num_batches: int
+    ) -> Optional[CommitStatusData]:
+        """
+        Gets a cache record (CommitStatusData) for a job, or None if a cache miss
+        """
+        res = self.get(self.RecordType.SUCCESSFUL, job, batch, num_batches)
+        assert res is None or isinstance(res, CommitStatusData)
+        return res
+
+    def delete_pending(
+        self, job: str, batch: int, num_batches: int, release_branch: bool
+    ) -> None:
+        """
+        deletes pending record from the cache
+        """
+        self.delete(self.RecordType.PENDING, job, batch, num_batches, release_branch)
+
+    def download_build_reports(self, file_prefix: str = "") -> List[str]:
+        """
+        not ideal class for this method,
+        but let it be as we store build reports in CI cache directory on s3
+        and CiCache knows where exactly
+
+        @file_prefix allows to filter out reports by git head_ref
+        """
+        report_path = Path(REPORT_PATH)
+        report_path.mkdir(exist_ok=True, parents=True)
+        path = (
+            self._get_record_s3_path(Build.PACKAGE_RELEASE)
+            + self._CACHE_BUILD_REPORT_PREFIX
+        )
+        if file_prefix:
+            path += "_" + file_prefix
+        reports_files = self.s3.download_files(
+            bucket=S3_BUILDS_BUCKET,
+            s3_path=path,
+            file_suffix=".json",
+            local_directory=report_path,
+        )
+        return reports_files
+
+    def upload_build_report(self, build_result: BuildResult) -> str:
+        result_json_path = build_result.write_json(Path(TEMP_PATH))
+        s3_path = (
+            self._get_record_s3_path(Build.PACKAGE_RELEASE) + result_json_path.name
+        )
+        return self.s3.upload_file(
+            bucket=S3_BUILDS_BUCKET, file_path=result_json_path, s3_path=s3_path
+        )
+
+    # def await_jobs(self, jobs_with_params: Dict[str, Dict[str, Any]]) -> List[str]:
+    # if not jobs_with_params:
+    #     return []
+    # print(f"Start awaiting jobs [{list(jobs_with_params)}]")
+    # poll_interval_sec = 180
+    # start_at = int(time.time())
+    # TIMEOUT = 3000
+    # expired_sec = 0
+    # done_jobs = []  # type: List[str]
+    # while expired_sec < TIMEOUT and jobs_with_params:
+    #     time.sleep(poll_interval_sec)
+    #     self.update()
+    #     pending_finished: List[str] = []
+    #     for job_name in jobs_with_params:
+    #         num_batches = jobs_with_params[job_name]["num_batches"]
+    #         for batch in jobs_with_params[job_name]["batches"]:
+    #             if self.is_pending(job_name, batch, num_batches):
+    #                 continue
+    #             print(
+    #                 f"Job [{job_name}_[{batch}/{num_batches}]] is not pending anymore"
+    #             )
+    #             pending_finished.append(job_name)
+    #     if pending_finished:
+    #         # restart timer
+    #         start_at = int(time.time())
+    #         expired_sec = 0
+    #         # remove finished jobs from awaiting list
+    #         for job in pending_finished:
+    #             del jobs_with_params[job]
+    #             done_jobs.append(job)
+    #     else:
+    #         expired_sec = int(time.time()) - start_at
+    #     print(f"  ...awaiting continues... time left [{TIMEOUT - expired_sec}]")
+    # if done_jobs:
+    #     print(
+    #         f"Awaiting OK. Left jobs: [{list(jobs_with_params)}], finished jobs: [{done_jobs}]"
+    #     )
+    # else:
+    #     print("Awaiting FAILED. No job has finished.")
+    # return done_jobs
 
 
 def get_check_name(check_name: str, batch: int, num_batches: int) -> str:
@@ -156,12 +715,6 @@ def parse_args(parser: argparse.ArgumentParser) -> argparse.Namespace:
         help="will create run config for rebuilding all dockers, used in --configure action (for nightly docker job)",
     )
     parser.add_argument(
-        "--rebuild-all-binaries",
-        action="store_true",
-        default=False,
-        help="will create run config without skipping build jobs in any case, used in --configure action (for release branches)",
-    )
-    parser.add_argument(
         "--commit-message",
         default="",
         help="debug option to test commit message processing",
@@ -169,23 +722,8 @@ def parse_args(parser: argparse.ArgumentParser) -> argparse.Namespace:
     return parser.parse_args()
 
 
-def get_file_flag_name(
-    job_name: str, digest: str, batch: int = 0, num_batches: int = 1
-) -> str:
-    if num_batches < 2:
-        return f"job_{job_name}_{digest}.ci"
-    else:
-        return f"job_{job_name}_{digest}_{batch}_{num_batches}.ci"
-
-
-def get_s3_path(build_digest: str) -> str:
-    return f"CI_data/BUILD-{build_digest}/"
-
-
-def get_s3_path_docs(digest: str) -> str:
-    return f"CI_data/DOCS-{digest}/"
-
-
+# FIXME: rewrite the docker job as regular reusable_test job and move interaction with docker hub inside job script
+#   that way run config will be more clean, workflow more generic and less api calls to dockerhub
 def check_missing_images_on_dockerhub(
     image_name_tag: Dict[str, str], arch: Optional[str] = None
 ) -> Dict[str, str]:
@@ -260,13 +798,91 @@ def check_missing_images_on_dockerhub(
     return result
 
 
-def _check_and_update_for_early_style_check(run_config: dict) -> None:
+def _pre_action(s3, indata, pr_info):
+    CommitStatusData.cleanup()
+    JobReport.cleanup()
+    BuildResult.cleanup()
+    ci_cache = CiCache(s3, indata["jobs_data"]["digests"])
+
+    # for release/master branches reports must be from the same branches
+    report_prefix = pr_info.head_ref if pr_info.number == 0 else ""
+    reports_files = ci_cache.download_build_reports(file_prefix=report_prefix)
+    print(f"Pre action done. Report files [{reports_files}] have been downloaded")
+
+
+def _mark_success_action(
+    s3: S3Helper,
+    indata: Dict[str, Any],
+    pr_info: PRInfo,
+    job: str,
+    batch: int,
+) -> None:
+    ci_cache = CiCache(s3, indata["jobs_data"]["digests"])
+    job_config = CI_CONFIG.get_job_config(job)
+    num_batches = job_config.num_batches
+    # if batch is not provided - set to 0
+    batch = 0 if batch == -1 else batch
+    assert (
+        0 <= batch < num_batches
+    ), f"--batch must be provided and in range [0, {num_batches}) for {job}"
+
+    # FIXME: find generic design for propagating and handling job status (e.g. stop using statuses in GH api)
+    #   now job ca be build job w/o status data, any other job that exit with 0 with or w/o status data
+    if CI_CONFIG.is_build_job(job):
+        # there is no status for build jobs
+        # create dummy success to mark it as done
+        # FIXME: consider creating commit status for build jobs too, to treat everything the same way
+        CommitStatusData("success", "dummy description", "dummy_url").dump_status()
+
+    job_status = None
+    if CommitStatusData.exist():
+        # normal scenario
+        job_status = CommitStatusData.load_status()
+    else:
+        # apparently exit after rerun-helper check
+        # do nothing, exit without failure
+        print(f"ERROR: no status file for job [{job}]")
+
+    if job_config.run_always or job_config.run_by_label:
+        print(f"Job [{job}] runs always or by label in CI - do not cache")
+    else:
+        if pr_info.is_master():
+            # pending enabled for master branch jobs only
+            ci_cache.delete_pending(job, batch, num_batches, release_branch=True)
+        if job_status and job_status.is_ok():
+            ci_cache.push_successful(
+                job, batch, num_batches, job_status, pr_info.is_release()
+            )
+            print(f"Job [{job}] is ok")
+        elif job_status:
+            print(f"Job [{job}] is not ok, status [{job_status.status}]")
+
+
+def _print_results(result: Any, outfile: Optional[str], pretty: bool = False) -> None:
+    if outfile:
+        with open(outfile, "w") as f:
+            if isinstance(result, str):
+                print(result, file=f)
+            elif isinstance(result, dict):
+                print(json.dumps(result, indent=2 if pretty else None), file=f)
+            else:
+                raise AssertionError(f"Unexpected type for 'res': {type(result)}")
+    else:
+        if isinstance(result, str):
+            print(result)
+        elif isinstance(result, dict):
+            print(json.dumps(result, indent=2 if pretty else None))
+        else:
+            raise AssertionError(f"Unexpected type for 'res': {type(result)}")
+
+
+def _check_and_update_for_early_style_check(jobs_data: dict, docker_data: dict) -> None:
     """
     This is temporary hack to start style check before docker build if possible
     FIXME: need better solution to do style check as soon as possible and as fast as possible w/o dependency on docker job
     """
-    jobs_to_do = run_config.get("jobs_data", {}).get("jobs_to_do", [])
-    docker_to_build = run_config.get("docker_data", {}).get("missing_multi", [])
+    jobs_to_do = jobs_data.get("jobs_to_do", [])
+    docker_to_build = docker_data.get("missing_multi", [])
     if (
         JobNames.STYLE_CHECK in jobs_to_do
         and docker_to_build
@@ -276,13 +892,16 @@ def _check_and_update_for_early_style_check(run_config: dict) -> None:
         jobs_to_do[index] = "Style check early"
 
 
-def _update_config_for_docs_only(run_config: dict) -> None:
+def _update_config_for_docs_only(jobs_data: dict) -> None:
     DOCS_CHECK_JOBS = [JobNames.DOCS_CHECK, JobNames.STYLE_CHECK]
     print(f"NOTE: Will keep only docs related jobs: [{DOCS_CHECK_JOBS}]")
-    jobs_to_do = run_config.get("jobs_data", {}).get("jobs_to_do", [])
-    run_config["jobs_data"]["jobs_to_do"] = [
-        job for job in jobs_to_do if job in DOCS_CHECK_JOBS
-    ]
+    jobs_to_do = jobs_data.get("jobs_to_do", [])
+    jobs_data["jobs_to_do"] = [job for job in jobs_to_do if job in DOCS_CHECK_JOBS]
+    jobs_data["jobs_to_wait"] = {
+        job: params
+        for job, params in jobs_data["jobs_to_wait"].items()
+        if job in DOCS_CHECK_JOBS
+    }
 
 
 def _configure_docker_jobs(
@@ -351,14 +970,11 @@ def _configure_docker_jobs(
 
 
 def _configure_jobs(
-    build_digest: str,
-    docs_digest: str,
     job_digester: JobDigester,
     s3: S3Helper,
-    rebuild_all_binaries: bool,
-    pr_labels: Iterable[str],
+    pr_info: PRInfo,
     commit_tokens: List[str],
-    ci_cache_enabled: bool,
+    ci_cache_disabled: bool,
 ) -> Dict:
     ## a. digest each item from the config
     job_digester = JobDigester()
@@ -374,19 +990,12 @@ def _configure_jobs(
         print(f"    job [{job.rjust(50)}] has digest [{digest}]")
     print("::endgroup::")
 
-    ## b. check if we have something done
-    if ci_cache_enabled:
-        done_files = []
-    else:
-        path = get_s3_path(build_digest)
-        done_files = s3.list_prefix(path)
-        done_files = [file.split("/")[-1] for file in done_files]
-        # print(f"S3 CI files for the build [{build_digest}]: {done_files}")
-        docs_path = get_s3_path_docs(docs_digest)
-        done_files_docs = s3.list_prefix(docs_path)
-        done_files_docs = [file.split("/")[-1] for file in done_files_docs]
-        # print(f"S3 CI files for the docs [{docs_digest}]: {done_files_docs}")
-        done_files += done_files_docs
+    ## b. check what we need to run
+    ci_cache = None
+    if not ci_cache_disabled:
+        ci_cache = CiCache(s3, digests)
+
+    jobs_to_wait: Dict[str, Dict[str, Any]] = {}
 
     for job in digests:
         digest = digests[job]
@@ -394,22 +1003,37 @@ def _configure_jobs(
         num_batches: int = job_config.num_batches
         batches_to_do: List[int] = []
 
-        if job_config.run_by_label:
-            # this job controlled by label, add to todo if it's labe is set in pr
-            if job_config.run_by_label in pr_labels:
-                for batch in range(num_batches):  # type: ignore
+        for batch in range(num_batches):  # type: ignore
+            if job_config.pr_only and pr_info.is_release():
+                continue
+            if job_config.run_by_label:
+                # this job controlled by label, add to todo if its label is set in pr
+                if job_config.run_by_label in pr_info.labels:
                     batches_to_do.append(batch)
-        elif job_config.run_always:
-            # always add to todo
-            batches_to_do.append(batch)
-        else:
-            # this job controlled by digest, add to todo if it's not successfully done before
-            for batch in range(num_batches):  # type: ignore
-                success_flag_name = get_file_flag_name(job, digest, batch, num_batches)
-                if success_flag_name not in done_files or (
-                    rebuild_all_binaries and CI_CONFIG.is_build_job(job)
-                ):
-                    batches_to_do.append(batch)
+            elif job_config.run_always:
+                # always add to todo
+                batches_to_do.append(batch)
+            elif not ci_cache:
+                batches_to_do.append(batch)
+            elif not ci_cache.is_successful(
+                job,
+                batch,
+                num_batches,
+                release_branch=pr_info.is_release()
+                and job_config.mandatory_for_release,
+            ):
+                # ci cache is enabled and job is not in the cache - add
+                batches_to_do.append(batch)
+
+                # check if it's pending in the cache
+                if ci_cache.is_pending(job, batch, num_batches, release_branch=False):
+                    if job in jobs_to_wait:
+                        jobs_to_wait[job]["batches"].append(batch)
+                    else:
+                        jobs_to_wait[job] = {
+                            "batches": [batch],
+                            "num_batches": num_batches,
+                        }
 
         if batches_to_do:
             jobs_to_do.append(job)
@@ -420,11 +1044,11 @@ def _configure_jobs(
         else:
             jobs_to_skip.append(job)
 
-    ## c. check CI controlling labels commit messages
-    if pr_labels:
+    ## c. check CI controlling labels and commit messages
+    if pr_info.labels:
         jobs_requested_by_label = []  # type: List[str]
         ci_controlling_labels = []  # type: List[str]
-        for label in pr_labels:
+        for label in pr_info.labels:
             label_config = CI_CONFIG.get_label_config(label)
             if label_config:
                 jobs_requested_by_label += label_config.run_jobs
@@ -434,6 +1058,8 @@ def _configure_jobs(
             print(
                 f"    :   following jobs will be executed: [{jobs_requested_by_label}]"
             )
+            # so far there is only "do not test" label in the config that runs only Style check.
+            #  check later if we need to filter out requested jobs using ci cache. right now we do it:
             jobs_to_do = [job for job in jobs_requested_by_label if job in jobs_to_do]
 
     if commit_tokens:
@@ -482,68 +1108,39 @@ def _configure_jobs(
         "digests": digests,
         "jobs_to_do": jobs_to_do,
         "jobs_to_skip": jobs_to_skip,
+        "jobs_to_wait": jobs_to_wait,
         "jobs_params": {
             job: params for job, params in jobs_params.items() if job in jobs_to_do
         },
     }
 
 
-def _update_gh_statuses(indata: Dict, s3: S3Helper) -> None:
+def _update_gh_statuses_action(indata: Dict, s3: S3Helper) -> None:
     if indata["ci_flags"][Labels.NO_CI_CACHE]:
         print("CI cache is disabled - skip restoring commit statuses from CI cache")
         return
-
-    temp_path = Path(TEMP_PATH)
-    if not temp_path.exists():
-        temp_path.mkdir(parents=True, exist_ok=True)
-
-    # clean up before start
-    for file in temp_path.glob("*.ci"):
-        file.unlink()
-
-    # download all metadata files
-    path = get_s3_path(indata["build"])
-    files = s3.download_files(  # type: ignore
-        bucket=S3_BUILDS_BUCKET,
-        s3_path=path,
-        file_suffix=".ci",
-        local_directory=temp_path,
-    )
-    print(f"CI metadata files [{files}]")
-    path = get_s3_path_docs(indata["docs"])
-    files_docs = s3.download_files(  # type: ignore
-        bucket=S3_BUILDS_BUCKET,
-        s3_path=path,
-        file_suffix=".ci",
-        local_directory=temp_path,
-    )
-    print(f"CI docs metadata files [{files_docs}]")
-    files += files_docs
-
-    # parse CI metadata
     job_digests = indata["jobs_data"]["digests"]
+    ci_cache = CiCache(s3, job_digests).update().fetch_records_data()
+
     # create GH status
     pr_info = PRInfo()
     commit = get_commit(Github(get_best_robot_token(), per_page=100), pr_info.sha)
 
-    def run_create_status(job, digest, batch, num_batches):
-        success_flag_name = get_file_flag_name(job, digest, batch, num_batches)
-        if success_flag_name in files:
-            print(f"Going to re-create GH status for job [{job}] sha [{pr_info.sha}]")
-            job_status = CommitStatusData.load_from_file(
-                f"{TEMP_PATH}/{success_flag_name}"
-            )  # type: CommitStatusData
-            assert job_status.status == SUCCESS, "BUG!"
-            commit.create_status(
-                state=job_status.status,
-                target_url=job_status.report_url,
-                description=format_description(
-                    f"Reused from [{job_status.pr_num}-{job_status.sha[0:8]}]: "
-                    f"{job_status.description}"
-                ),
-                context=get_check_name(job, batch=batch, num_batches=num_batches),
-            )
-            print(f"GH status re-created from file [{success_flag_name}]")
+    def _run_create_status(job: str, batch: int, num_batches: int) -> None:
+        job_status = ci_cache.get_successful(job, batch, num_batches)
+        if not job_status:
+            return
+        print(f"Going to re-create GH status for job [{job}] sha [{pr_info.sha}]")
+        assert job_status.status == "success", "BUG!"
+        commit.create_status(
+            state=job_status.status,
+            target_url=job_status.report_url,
+            description=format_description(
+                f"Reused from [{job_status.pr_num}-{job_status.sha[0:8]}]: "
+                f"{job_status.description}"
+            ),
+            context=get_check_name(job, batch=batch, num_batches=num_batches),
+        )
 
     with concurrent.futures.ThreadPoolExecutor() as executor:
         futures = []
@@ -551,12 +1148,9 @@ def _update_gh_statuses(indata: Dict, s3: S3Helper) -> None:
             if CI_CONFIG.is_build_job(job):
                 # no GH status for build jobs
                 continue
-            digest = job_digests[job]
             num_batches = CI_CONFIG.get_job_config(job).num_batches
             for batch in range(num_batches):
-                future = executor.submit(
-                    run_create_status, job, digest, batch, num_batches
-                )
+                future = executor.submit(_run_create_status, job, batch, num_batches)
                 futures.append(future)
         done, _ = concurrent.futures.wait(futures)
         for future in done:
@@ -567,11 +1161,6 @@ def _update_gh_statuses(indata: Dict, s3: S3Helper) -> None:
     print("Going to update overall CI report")
     set_status_comment(commit, pr_info)
     print("... CI report update - done")
-
-    # clean up
-    ci_files = list(temp_path.glob("*.ci"))
-    for file in ci_files:
-        file.unlink()
 
 
 def _fetch_commit_tokens(message: str) -> List[str]:
@@ -584,7 +1173,7 @@ def _fetch_commit_tokens(message: str) -> List[str]:
 def _upload_build_artifacts(
     pr_info: PRInfo,
     build_name: str,
-    build_digest: str,
+    ci_cache: CiCache,
     job_report: JobReport,
     s3: S3Helper,
     s3_destination: str,
@@ -640,12 +1229,8 @@ def _upload_build_artifacts(
         head_ref=pr_info.head_ref,
         pr_number=pr_info.number,
     )
-    result_json_path = build_result.write_json()
-    s3_path = get_s3_path(build_digest) + result_json_path.name
-    build_report_url = s3.upload_file(
-        bucket=S3_BUILDS_BUCKET, file_path=result_json_path, s3_path=s3_path
-    )
-    print(f"Report file [{result_json_path}] has been uploaded to [{build_report_url}]")
+    report_url = ci_cache.upload_build_report(build_result)
+    print(f"Report file has been uploaded to [{report_url}]")
 
     # Upload head master binaries
     static_bin_name = CI_CONFIG.build_config[build_name].static_binary_name
@@ -852,9 +1437,6 @@ def main() -> int:
 
     ### CONFIGURE action: start
     if args.configure:
-        docker_data = {}
-        git_ref = git_runner.run(f"{GIT_PREFIX} rev-parse HEAD")
-
         # if '#no_merge_commit' is set in commit message - set git ref to PR branch head to avoid merge-commit
         tokens = []
         ci_flags = {
@@ -875,6 +1457,9 @@ def main() -> int:
         if Labels.NO_CI_CACHE in tokens:
             ci_flags[Labels.NO_CI_CACHE] = True
             print("NOTE: Disable CI Cache")
+
+        docker_data = {}
+        git_ref = git_runner.run(f"{GIT_PREFIX} rev-parse HEAD")
 
         # let's get CH version
         version = get_version_from_repo(git=Git(True)).string
@@ -897,19 +1482,48 @@ def main() -> int:
         )
         jobs_data = (
             _configure_jobs(
-                build_digest,
-                docs_digest,
                 job_digester,
                 s3,
-                # FIXME: add suport for master wf w/o rebuilds
-                args.rebuild_all_binaries or pr_info.is_master(),
-                pr_info.labels,
+                pr_info,
                 tokens,
                 ci_flags[Labels.NO_CI_CACHE],
             )
             if not args.skip_jobs
             else {}
         )
+
+        # FIXME: Early style check manipulates with job names might be not robust with await feature
+        if pr_info.number != 0 and not args.docker_digest_or_latest:
+            # FIXME: it runs style check before docker build if possible (style-check images is not changed)
+            #    find a way to do style check always before docker build and others
+            _check_and_update_for_early_style_check(jobs_data, docker_data)
+        if args.skip_jobs and pr_info.has_changes_in_documentation_only():
+            _update_config_for_docs_only(jobs_data)
+
+        # TODO: await pending jobs
+        # wait for pending jobs to be finished, await_jobs is a long blocking call if any job has to be awaited
+        ci_cache = CiCache(s3, jobs_data["digests"])
+        # awaited_jobs = ci_cache.await_jobs(jobs_data.get("jobs_to_wait", {}))
+        # for job in awaited_jobs:
+        #     jobs_to_do = jobs_data["jobs_to_do"]
+        #     if job in jobs_to_do:
+        #         jobs_to_do.remove(job)
+        #     else:
+        #         assert False, "BUG"
+
+        # set planned jobs as pending in the CI cache if on the master
+        if pr_info.is_master():
+            for job in jobs_data["jobs_to_do"]:
+                config = CI_CONFIG.get_job_config(job)
+                if config.run_always or config.run_by_label:
+                    continue
+                job_params = jobs_data["jobs_params"][job]
+                ci_cache.push_pending(
+                    job,
+                    job_params["batches"],
+                    config.num_batches,
+                    release_branch=pr_info.is_release(),
+                )
 
         # conclude results
         result["git_ref"] = git_ref
@@ -919,49 +1533,12 @@ def main() -> int:
         result["ci_flags"] = ci_flags
         result["jobs_data"] = jobs_data
         result["docker_data"] = docker_data
-        if (
-            not args.skip_jobs
-            and pr_info.number != 0
-            and not args.docker_digest_or_latest
-        ):
-            # FIXME: it runs style check before docker build if possible (style-check images is not changed)
-            #    find a way to do style check always before docker build and others
-            _check_and_update_for_early_style_check(result)
-        if not args.skip_jobs and pr_info.has_changes_in_documentation_only():
-            _update_config_for_docs_only(result)
     ### CONFIGURE action: end
 
     ### PRE action: start
     elif args.pre:
-        CommitStatusData.cleanup()
-        JobReport.cleanup()
-        BuildResult.cleanup()
-
         assert indata, "Run config must be provided via --infile"
-        report_path = Path(REPORT_PATH)
-        report_path.mkdir(exist_ok=True, parents=True)
-        path = get_s3_path(indata["build"])
-        reports_files = s3.download_files(  # type: ignore
-            bucket=S3_BUILDS_BUCKET,
-            s3_path=path,
-            file_suffix=".json",
-            local_directory=report_path,
-        )
-        # for release/master branches reports must be created on the same branches
-        files = []
-        if pr_info.number == 0:
-            for file in reports_files:
-                if pr_info.head_ref not in file:
-                    # keep reports from the same branch only, if not in a PR
-                    (report_path / file).unlink()
-                    print(f"drop report: [{report_path / file}]")
-                else:
-                    files.append(file)
-            reports_files = files
-        print(
-            f"Pre action done. Report files [{reports_files}] have been downloaded from [{path}] to [{report_path}]"
-        )
-    ### PRE action: end
+        _pre_action(s3, indata, pr_info)
 
     ### RUN action: start
     elif args.run:
@@ -993,6 +1570,9 @@ def main() -> int:
                 print("::endgroup::")
         else:
             # this is a test job - check if GH commit status is present
+
+            # rerun helper check
+            # FIXME: remove rerun_helper check and rely on ci cache only
             commit = get_commit(
                 Github(get_best_robot_token(), per_page=100), pr_info.sha
             )
@@ -1004,6 +1584,38 @@ def main() -> int:
                 print("::group::Commit Status")
                 print(status)
                 print("::endgroup::")
+
+            # ci cache check
+            elif not indata["ci_flags"][Labels.NO_CI_CACHE]:
+                ci_cache = CiCache(s3, indata["jobs_data"]["digests"]).update()
+                job_config = CI_CONFIG.get_job_config(check_name)
+                if ci_cache.is_successful(
+                    check_name,
+                    args.batch,
+                    job_config.num_batches,
+                    job_config.mandatory_for_release,
+                ):
+                    job_status = ci_cache.get_successful(
+                        check_name, args.batch, job_config.num_batches
+                    )
+                    assert job_status, "BUG"
+                    commit.create_status(
+                        state=job_status.status,
+                        target_url=job_status.report_url,
+                        description=format_description(
+                            f"Reused from [{job_status.pr_num}-{job_status.sha[0:8]}]: "
+                            f"{job_status.description}"
+                        ),
+                        context=get_check_name(
+                            check_name,
+                            batch=args.batch,
+                            num_batches=job_config.num_batches,
+                        ),
+                    )
+                    previous_status = job_status.status
+                    print("::group::Commit Status Data")
+                    print(job_status)
+                    print("::endgroup::")
 
         if previous_status:
             print(
@@ -1019,15 +1631,15 @@ def main() -> int:
 
     ### POST action: start
     elif args.post:
-        assert (
-            not CI_CONFIG.is_build_job(args.job_name) or indata
-        ), "--infile with config must be provided for POST action of a build type job [{args.job_name}]"
         job_report = JobReport.load() if JobReport.exist() else None
         if job_report:
             ch_helper = ClickHouseHelper()
             check_url = ""
 
             if CI_CONFIG.is_build_job(args.job_name):
+                assert (
+                    indata
+                ), "--infile with config must be provided for POST action of a build type job [{args.job_name}]"
                 build_name = args.job_name
                 s3_path_prefix = "/".join(
                     (
@@ -1039,7 +1651,7 @@ def main() -> int:
                 log_url = _upload_build_artifacts(
                     pr_info,
                     build_name,
-                    build_digest=indata["build"],  # type: ignore
+                    ci_cache=CiCache(s3, indata["jobs_data"]["digests"]),
                     job_report=job_report,
                     s3=s3,
                     s3_destination=s3_path_prefix,
@@ -1116,80 +1728,16 @@ def main() -> int:
     ### MARK SUCCESS action: start
     elif args.mark_success:
         assert indata, "Run config must be provided via --infile"
-        job = args.job_name
-        job_config = CI_CONFIG.get_job_config(job)
-        num_batches = job_config.num_batches
-        assert (
-            num_batches <= 1 or 0 <= args.batch < num_batches
-        ), f"--batch must be provided and in range [0, {num_batches}) for {job}"
-
-        # FIXME: find generic design for propagating and handling job status (e.g. stop using statuses in GH api)
-        #   now job ca be build job w/o status data, any other job that exit with 0 with or w/o status data
-        if CI_CONFIG.is_build_job(job):
-            # there is no status for build jobs
-            # create dummy success to mark it as done
-            job_status = CommitStatusData(
-                status="success", description="dummy status", report_url="dummy_url"
-            )
-        else:
-            if not CommitStatusData.is_present():
-                # apparently exit after rerun-helper check
-                # do nothing, exit without failure
-                print(f"ERROR: no status file for job [{job}]")
-                job_status = CommitStatusData(
-                    status="dummy failure",
-                    description="dummy status",
-                    report_url="dummy_url",
-                )
-            else:
-                # normal case
-                job_status = CommitStatusData.load_status()
-
-        # Storing job data (report_url) to restore OK GH status on job results reuse
-        if job_config.run_always:
-            print(f"Job [{job}] runs always in CI - do not mark as done")
-        elif job_status.is_ok():
-            success_flag_name = get_file_flag_name(
-                job, indata["jobs_data"]["digests"][job], args.batch, num_batches
-            )
-            if not CI_CONFIG.is_docs_job(job):
-                path = get_s3_path(indata["build"]) + success_flag_name
-            else:
-                path = get_s3_path_docs(indata["docs"]) + success_flag_name
-            job_status.dump_to_file(success_flag_name)
-            _ = s3.upload_file(
-                bucket=S3_BUILDS_BUCKET, file_path=success_flag_name, s3_path=path
-            )
-            os.remove(success_flag_name)
-            print(
-                f"Job [{job}] with digest [{indata['jobs_data']['digests'][job]}] {f'and batch {args.batch}/{num_batches}' if num_batches > 1 else ''} marked as successful. path: [{path}]"
-            )
-        else:
-            print(f"Job [{job}] is not ok, status [{job_status.status}]")
-    ### MARK SUCCESS action: end
+        _mark_success_action(s3, indata, pr_info, args.job_name, args.batch)
 
     ### UPDATE GH STATUSES action: start
     elif args.update_gh_statuses:
         assert indata, "Run config must be provided via --infile"
-        _update_gh_statuses(indata=indata, s3=s3)
-    ### UPDATE GH STATUSES action: end
+        _update_gh_statuses_action(indata=indata, s3=s3)
 
     ### print results
-    if args.outfile:
-        with open(args.outfile, "w") as f:
-            if isinstance(result, str):
-                print(result, file=f)
-            elif isinstance(result, dict):
-                print(json.dumps(result, indent=2 if args.pretty else None), file=f)
-            else:
-                raise AssertionError(f"Unexpected type for 'res': {type(result)}")
-    else:
-        if isinstance(result, str):
-            print(result)
-        elif isinstance(result, dict):
-            print(json.dumps(result, indent=2 if args.pretty else None))
-        else:
-            raise AssertionError(f"Unexpected type for 'res': {type(result)}")
+    _print_results(result, args.outfile, args.pretty)
+
     return exit_code
 
 

--- a/tests/ci/ci_config.py
+++ b/tests/ci/ci_config.py
@@ -186,8 +186,8 @@ class JobConfig:
     # to run always regardless of the job digest or/and label
     run_always: bool = False
     # if the job needs to be run on the release branch, including master (e.g. building packages, docker server).
-    # NOTE: Subsequent runs with the similar digest are still considered skippable regardless of the branch.
-    mandatory_for_release: bool = False
+    # NOTE: Subsequent runs on the same branch with the similar digest are still considered skippable.
+    required_on_release_branch: bool = False
     # job is for pr workflow only
     pr_only: bool = False
 
@@ -206,7 +206,7 @@ class BuildConfig:
     static_binary_name: str = ""
     job_config: JobConfig = field(
         default_factory=lambda: JobConfig(
-            mandatory_for_release=True,
+            required_on_release_branch=True,
             digest=DigestConfig(
                 include_paths=[
                     "./src",
@@ -796,18 +796,18 @@ CI_CONFIG = CiConfig(
     },
     other_jobs_configs={
         JobNames.MARK_RELEASE_READY: TestConfig(
-            "", job_config=JobConfig(mandatory_for_release=True)
+            "", job_config=JobConfig(required_on_release_branch=True)
         ),
         JobNames.DOCKER_SERVER: TestConfig(
             "",
             job_config=JobConfig(
-                mandatory_for_release=True,
+                required_on_release_branch=True,
                 digest=DigestConfig(
                     include_paths=[
                         "tests/ci/docker_server.py",
                         "./docker/server",
                     ]
-                )
+                ),
             ),
         ),
         JobNames.DOCKER_KEEPER: TestConfig(
@@ -1009,13 +1009,13 @@ CI_CONFIG = CiConfig(
         JobNames.COMPATIBILITY_TEST: TestConfig(
             Build.PACKAGE_RELEASE,
             job_config=JobConfig(
-                mandatory_for_release=True, digest=compatibility_check_digest
+                required_on_release_branch=True, digest=compatibility_check_digest
             ),
         ),
         JobNames.COMPATIBILITY_TEST_ARM: TestConfig(
             Build.PACKAGE_AARCH64,
             job_config=JobConfig(
-                mandatory_for_release=True, digest=compatibility_check_digest
+                required_on_release_branch=True, digest=compatibility_check_digest
             ),
         ),
         JobNames.UNIT_TEST: TestConfig(

--- a/tests/ci/ci_config.py
+++ b/tests/ci/ci_config.py
@@ -11,6 +11,10 @@ from integration_test_images import IMAGES
 
 
 class Labels(metaclass=WithIter):
+    """
+    Label names or commit tokens in normalized form
+    """
+
     DO_NOT_TEST_LABEL = "do_not_test"
     NO_MERGE_COMMIT = "no_merge_commit"
     NO_CI_CACHE = "no_ci_cache"
@@ -111,7 +115,6 @@ class JobNames(metaclass=WithIter):
     PERFORMANCE_TEST_AMD64 = "Performance Comparison"
     PERFORMANCE_TEST_ARM64 = "Performance Comparison Aarch64"
 
-    SQL_LANCER_TEST = "SQLancer (release)"
     SQL_LOGIC_TEST = "Sqllogic test (release)"
 
     SQLANCER = "SQLancer (release)"
@@ -131,6 +134,8 @@ class JobNames(metaclass=WithIter):
 
     DOCS_CHECK = "Docs check"
     BUGFIX_VALIDATE = "tests bugfix validate check"
+
+    MARK_RELEASE_READY = "Mark Commit Release Ready"
 
 
 # dynamically update JobName with Build jobs
@@ -156,7 +161,7 @@ class DigestConfig:
 @dataclass
 class LabelConfig:
     """
-    class to configure different CI scenarious per GH label or commit message token
+    configures different CI scenarious per GH label
     """
 
     run_jobs: Iterable[str] = frozenset()
@@ -165,19 +170,26 @@ class LabelConfig:
 @dataclass
 class JobConfig:
     """
-    contains config parameter relevant for job execution in CI workflow
-    @digest - configures digest calculation for the job
-    @run_command - will be triggered for the job if omited in CI workflow yml
-    @timeout
-    @num_batches - sets number of batches for multi-batch job
+    contains config parameters for job execution in CI workflow
     """
 
+    # configures digest calculation for the job
     digest: DigestConfig = field(default_factory=DigestConfig)
+    # will be triggered for the job if omited in CI workflow yml
     run_command: str = ""
+    # job timeout
     timeout: Optional[int] = None
+    # sets number of batches for multi-batch job
     num_batches: int = 1
+    # label that enables job in CI, if set digest won't be used
     run_by_label: str = ""
+    # to run always regardless of the job digest or/and label
     run_always: bool = False
+    # if the job needs to be run on the release branch, including master (e.g. building packages, docker server).
+    # NOTE: Subsequent runs with the similar digest are still considered skippable regardless of the branch.
+    mandatory_for_release: bool = False
+    # job is for pr workflow only
+    pr_only: bool = False
 
 
 @dataclass
@@ -194,6 +206,7 @@ class BuildConfig:
     static_binary_name: str = ""
     job_config: JobConfig = field(
         default_factory=lambda: JobConfig(
+            mandatory_for_release=True,
             digest=DigestConfig(
                 include_paths=[
                     "./src",
@@ -614,6 +627,8 @@ CI_CONFIG = CiConfig(
                             "tsan",
                             "msan",
                             "ubsan",
+                            # skip build report jobs as not all builds will be done
+                            "build check",
                         )
                     ]
                 )
@@ -780,9 +795,13 @@ CI_CONFIG = CiConfig(
         ),
     },
     other_jobs_configs={
+        JobNames.MARK_RELEASE_READY: TestConfig(
+            "", job_config=JobConfig(mandatory_for_release=True)
+        ),
         JobNames.DOCKER_SERVER: TestConfig(
             "",
             job_config=JobConfig(
+                mandatory_for_release=True,
                 digest=DigestConfig(
                     include_paths=[
                         "tests/ci/docker_server.py",
@@ -799,7 +818,7 @@ CI_CONFIG = CiConfig(
                         "tests/ci/docker_server.py",
                         "./docker/keeper",
                     ]
-                )
+                ),
             ),
         ),
         JobNames.DOCS_CHECK: TestConfig(
@@ -814,11 +833,12 @@ CI_CONFIG = CiConfig(
         JobNames.FAST_TEST: TestConfig(
             "",
             job_config=JobConfig(
+                pr_only=True,
                 digest=DigestConfig(
                     include_paths=["./tests/queries/0_stateless/"],
                     exclude_files=[".md"],
                     docker=["clickhouse/fasttest"],
-                )
+                ),
             ),
         ),
         JobNames.STYLE_CHECK: TestConfig(
@@ -988,11 +1008,15 @@ CI_CONFIG = CiConfig(
         ),
         JobNames.COMPATIBILITY_TEST: TestConfig(
             Build.PACKAGE_RELEASE,
-            job_config=JobConfig(digest=compatibility_check_digest),
+            job_config=JobConfig(
+                mandatory_for_release=True, digest=compatibility_check_digest
+            ),
         ),
         JobNames.COMPATIBILITY_TEST_ARM: TestConfig(
             Build.PACKAGE_AARCH64,
-            job_config=JobConfig(digest=compatibility_check_digest),
+            job_config=JobConfig(
+                mandatory_for_release=True, digest=compatibility_check_digest
+            ),
         ),
         JobNames.UNIT_TEST: TestConfig(
             Build.BINARY_RELEASE, job_config=JobConfig(**unit_test_common_params)  # type: ignore

--- a/tests/ci/ci_utils.py
+++ b/tests/ci/ci_utils.py
@@ -1,6 +1,6 @@
 from contextlib import contextmanager
 import os
-from typing import Union, Iterator
+from typing import List, Union, Iterator
 from pathlib import Path
 
 
@@ -17,3 +17,21 @@ def cd(path: Union[Path, str]) -> Iterator[None]:
         yield
     finally:
         os.chdir(oldpwd)
+
+
+def is_hex(s):
+    try:
+        int(s, 16)
+        return True
+    except ValueError:
+        return False
+
+
+class GHActions:
+    @staticmethod
+    def print_in_group(group_name: str, lines: Union[str, List[str]]) -> None:
+        lines = list(lines)
+        print(f"::group::{group_name}")
+        for line in lines:
+            print(line)
+        print("::endgroup::")

--- a/tests/ci/commit_status_helper.py
+++ b/tests/ci/commit_status_helper.py
@@ -350,7 +350,7 @@ class CommitStatusData:
         return cls.load_from_file(STATUS_FILE_PATH)
 
     @classmethod
-    def is_present(cls) -> bool:
+    def exist(cls) -> bool:
         return STATUS_FILE_PATH.is_file()
 
     def dump_status(self) -> None:

--- a/tests/ci/performance_comparison_check.py
+++ b/tests/ci/performance_comparison_check.py
@@ -29,7 +29,7 @@ from tee_popen import TeePopen
 from clickhouse_helper import get_instance_type, get_instance_id
 from stopwatch import Stopwatch
 from build_download_helper import download_builds_filter
-from report import JobReport
+from report import SUCCESS, JobReport
 
 IMAGE_NAME = "clickhouse/performance-comparison"
 
@@ -223,7 +223,7 @@ def main():
             message = message_match.group(1).strip()
 
         # TODO: Remove me, always green mode for the first time, unless errors
-        status = "success"
+        status = SUCCESS
         if "errors" in message.lower() or too_many_slow(message.lower()):
             status = "failure"
         # TODO: Remove until here
@@ -249,7 +249,7 @@ def main():
         check_name=check_name_with_group,
     ).dump()
 
-    if status == "error":
+    if status != SUCCESS:
         sys.exit(1)
 
 

--- a/tests/ci/pr_info.py
+++ b/tests/ci/pr_info.py
@@ -287,9 +287,9 @@ class PRInfo:
             self.fetch_changed_files()
 
     def is_master(self) -> bool:
-        return self.number == 0 and self.base_ref == "master"
+        return self.number == 0 and self.head_ref == "master"
 
-    def is_release(self) -> bool:
+    def is_release_branch(self) -> bool:
         return self.number == 0
 
     def is_scheduled(self):

--- a/tests/ci/pr_info.py
+++ b/tests/ci/pr_info.py
@@ -289,6 +289,9 @@ class PRInfo:
     def is_master(self) -> bool:
         return self.number == 0 and self.base_ref == "master"
 
+    def is_release(self) -> bool:
+        return self.number == 0
+
     def is_scheduled(self):
         return self.event_type == EventType.SCHEDULE
 

--- a/tests/ci/s3_helper.py
+++ b/tests/ci/s3_helper.py
@@ -107,6 +107,9 @@ class S3Helper:
         logging.info("Upload %s to %s. Meta: %s", file_path, url, metadata)
         return url
 
+    def delete_file_from_s3(self, bucket_name: str, s3_path: str) -> None:
+        self.client.delete_object(Bucket=bucket_name, Key=s3_path)
+
     def upload_test_report_to_s3(self, file_path: Path, s3_path: str) -> str:
         if CI:
             return self._upload_file_to_s3(S3_TEST_REPORTS_BUCKET, file_path, s3_path)

--- a/tests/ci/test_ci_cache.py
+++ b/tests/ci/test_ci_cache.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python
+
+from hashlib import md5
+from pathlib import Path
+from typing import Dict, Set
+import unittest
+from ci_config import Build, JobNames
+from s3_helper import S3Helper
+from ci import CiCache
+from digest_helper import JOB_DIGEST_LEN
+from commit_status_helper import CommitStatusData
+from env_helper import S3_BUILDS_BUCKET
+
+
+def _create_mock_digest_1(string):
+    return md5((string).encode("utf-8")).hexdigest()[:JOB_DIGEST_LEN]
+
+
+def _create_mock_digest_2(string):
+    return md5((string + "+nonce").encode("utf-8")).hexdigest()[:JOB_DIGEST_LEN]
+
+
+DIGESTS = {job: _create_mock_digest_1(job) for job in JobNames}
+DIGESTS2 = {job: _create_mock_digest_2(job) for job in JobNames}
+
+
+# pylint:disable=protected-access
+class S3HelperTestMock(S3Helper):
+    def __init__(self) -> None:
+        super().__init__()
+        self.files_on_s3_paths = {}  # type: Dict[str, Set[str]]
+
+    def list_prefix(self, s3_prefix_path, bucket=S3_BUILDS_BUCKET):
+        assert bucket == S3_BUILDS_BUCKET
+        file_prefix = Path(s3_prefix_path).name
+        path = str(Path(s3_prefix_path).parent)
+        return [
+            path + "/" + file
+            for file in self.files_on_s3_paths[path]
+            if file.startswith(file_prefix)
+        ]
+
+    def upload_file(self, bucket, file_path, s3_path):
+        assert bucket == S3_BUILDS_BUCKET
+        file_path = Path(file_path).name
+        assert (
+            file_path in s3_path
+        ), f"Record file name [{file_path}] must be part of a path on s3 [{s3_path}]"
+        s3_path = str(Path(s3_path).parent)
+        if s3_path in self.files_on_s3_paths:
+            self.files_on_s3_paths[s3_path].add(file_path)
+        else:
+            self.files_on_s3_paths[s3_path] = set([file_path])
+
+    def download_files(self, bucket, s3_path, file_suffix, local_directory):
+        assert bucket == S3_BUILDS_BUCKET
+        assert file_suffix == CiCache._RECORD_FILE_EXTENSION
+        assert local_directory == CiCache._LOCAL_CACHE_PATH
+        assert CiCache._S3_CACHE_PREFIX in s3_path
+        assert "BUILD-" in s3_path or "DOCS-" in s3_path
+
+
+# pylint:disable=protected-access
+class TestCiCache(unittest.TestCase):
+    def test_cache(self):
+        s3_mock = S3HelperTestMock()
+        ci_cache = CiCache(s3_mock, DIGESTS)
+        # immitate another CI run is using cache
+        ci_cache_2 = CiCache(s3_mock, DIGESTS2)
+        NUM_BATCHES = 10
+
+        DOCS_JOBS_NUM = 1
+        assert len(set(job for job in JobNames)) == len(list(job for job in JobNames))
+        NONDOCS_JOBS_NUM = len(set(job for job in JobNames)) - DOCS_JOBS_NUM
+
+        PR_NUM = 123456
+        status = CommitStatusData(
+            status="success",
+            report_url="dummy url",
+            description="OK OK OK",
+            sha="deadbeaf2",
+            pr_num=PR_NUM,
+        )
+
+        ### add some pending statuses for two batches and on non-release branch
+        for job in JobNames:
+            ci_cache.push_pending(job, [0, 1], NUM_BATCHES, release_branch=False)
+            ci_cache_2.push_pending(job, [0, 1], NUM_BATCHES, release_branch=False)
+
+        ### add success status for 0 batch, non-release branch
+        for job in JobNames:
+            ci_cache.push_successful(job, 0, NUM_BATCHES, status, release_branch=False)
+            ci_cache_2.push_successful(
+                job, 0, NUM_BATCHES, status, release_branch=False
+            )
+
+        ### check all expected directories were created on s3 mock
+        expected_build_path_1 = f"{CiCache.JobType.SRCS.value}-{_create_mock_digest_1(Build.PACKAGE_RELEASE)}"
+        expected_docs_path_1 = (
+            f"{CiCache.JobType.DOCS.value}-{_create_mock_digest_1(JobNames.DOCS_CHECK)}"
+        )
+        expected_build_path_2 = f"{CiCache.JobType.SRCS.value}-{_create_mock_digest_2(Build.PACKAGE_RELEASE)}"
+        expected_docs_path_2 = (
+            f"{CiCache.JobType.DOCS.value}-{_create_mock_digest_2(JobNames.DOCS_CHECK)}"
+        )
+        self.assertCountEqual(
+            list(s3_mock.files_on_s3_paths.keys()),
+            [
+                f"{CiCache._S3_CACHE_PREFIX}/{expected_build_path_1}",
+                f"{CiCache._S3_CACHE_PREFIX}/{expected_docs_path_1}",
+                f"{CiCache._S3_CACHE_PREFIX}/{expected_build_path_2}",
+                f"{CiCache._S3_CACHE_PREFIX}/{expected_docs_path_2}",
+            ],
+        )
+
+        ### check number of cache files is as expected
+        FILES_PER_JOB = 3  # 1 successful + 2 pending batches = 3
+        self.assertEqual(
+            len(
+                s3_mock.files_on_s3_paths[
+                    f"{CiCache._S3_CACHE_PREFIX}/{expected_build_path_1}"
+                ]
+            ),
+            NONDOCS_JOBS_NUM * FILES_PER_JOB,
+        )
+        self.assertEqual(
+            len(
+                s3_mock.files_on_s3_paths[
+                    f"{CiCache._S3_CACHE_PREFIX}/{expected_docs_path_1}"
+                ]
+            ),
+            DOCS_JOBS_NUM * FILES_PER_JOB,
+        )
+        self.assertEqual(
+            len(
+                s3_mock.files_on_s3_paths[
+                    f"{CiCache._S3_CACHE_PREFIX}/{expected_build_path_2}"
+                ]
+            ),
+            NONDOCS_JOBS_NUM * FILES_PER_JOB,
+        )
+        self.assertEqual(
+            len(
+                s3_mock.files_on_s3_paths[
+                    f"{CiCache._S3_CACHE_PREFIX}/{expected_docs_path_2}"
+                ]
+            ),
+            DOCS_JOBS_NUM * FILES_PER_JOB,
+        )
+
+        ### check statuses for all jobs in cache
+        for job in JobNames:
+            self.assertEqual(
+                ci_cache.is_successful(job, 0, NUM_BATCHES, release_branch=False), True
+            )
+            self.assertEqual(
+                ci_cache.is_successful(job, 0, NUM_BATCHES, release_branch=True), False
+            )
+            self.assertEqual(
+                ci_cache.is_successful(
+                    job, batch=1, num_batches=NUM_BATCHES, release_branch=False
+                ),
+                False,
+            )  # false - it's pending
+            self.assertEqual(
+                ci_cache.is_successful(
+                    job,
+                    batch=NUM_BATCHES,
+                    num_batches=NUM_BATCHES,
+                    release_branch=False,
+                ),
+                False,
+            )  # false - no such record
+            self.assertEqual(
+                ci_cache.is_pending(job, 0, NUM_BATCHES, release_branch=False), False
+            )  # false, it's successful, success has more priority than pending
+            self.assertEqual(
+                ci_cache.is_pending(job, 1, NUM_BATCHES, release_branch=False), True
+            )  # true
+            self.assertEqual(
+                ci_cache.is_pending(job, 1, NUM_BATCHES, release_branch=True), False
+            )  # false, not pending job on release_branch
+
+            status2 = ci_cache.get_successful(job, 0, NUM_BATCHES)
+            assert status2 and status2.pr_num == PR_NUM
+            status2 = ci_cache.get_successful(job, 1, NUM_BATCHES)
+            assert status2 is None
+
+        ### add some more pending statuses for two batches and for a release branch
+        for job in JobNames:
+            ci_cache.push_pending(
+                job, batches=[0, 1], num_batches=NUM_BATCHES, release_branch=True
+            )
+
+        ### add success statuses for 0 batch and release branch
+        PR_NUM = 234
+        status = CommitStatusData(
+            status="success",
+            report_url="dummy url",
+            description="OK OK OK",
+            sha="deadbeaf2",
+            pr_num=PR_NUM,
+        )
+        for job in JobNames:
+            ci_cache.push_successful(job, 0, NUM_BATCHES, status, release_branch=True)
+
+        ### check number of cache files is as expected
+        FILES_PER_JOB = 6  # 1 successful + 1 successful_release + 2 pending batches + 2 pending batches release = 6
+        self.assertEqual(
+            len(
+                s3_mock.files_on_s3_paths[
+                    f"{CiCache._S3_CACHE_PREFIX}/{expected_build_path_1}"
+                ]
+            ),
+            NONDOCS_JOBS_NUM * FILES_PER_JOB,
+        )
+        self.assertEqual(
+            len(
+                s3_mock.files_on_s3_paths[
+                    f"{CiCache._S3_CACHE_PREFIX}/{expected_docs_path_1}"
+                ]
+            ),
+            DOCS_JOBS_NUM * FILES_PER_JOB,
+        )
+
+        ### check statuses
+        for job in JobNames:
+            self.assertEqual(ci_cache.is_successful(job, 0, NUM_BATCHES, False), True)
+            self.assertEqual(ci_cache.is_successful(job, 0, NUM_BATCHES, True), True)
+            self.assertEqual(ci_cache.is_successful(job, 1, NUM_BATCHES, False), False)
+            self.assertEqual(ci_cache.is_successful(job, 1, NUM_BATCHES, True), False)
+            self.assertEqual(
+                ci_cache.is_pending(job, 0, NUM_BATCHES, False), False
+            )  # it's success, not pending
+            self.assertEqual(
+                ci_cache.is_pending(job, 0, NUM_BATCHES, True), False
+            )  # it's success, not pending
+            self.assertEqual(ci_cache.is_pending(job, 1, NUM_BATCHES, False), True)
+            self.assertEqual(ci_cache.is_pending(job, 1, NUM_BATCHES, True), True)
+
+            status2 = ci_cache.get_successful(job, 0, NUM_BATCHES)
+            assert status2 and status2.pr_num == PR_NUM
+            status2 = ci_cache.get_successful(job, 1, NUM_BATCHES)
+            assert status2 is None
+
+        ### check some job values which are not in the cache
+        self.assertEqual(ci_cache.is_successful(job, 0, NUM_BATCHES + 1, False), False)
+        self.assertEqual(
+            ci_cache.is_successful(job, NUM_BATCHES - 1, NUM_BATCHES, False), False
+        )
+        self.assertEqual(ci_cache.is_pending(job, 0, NUM_BATCHES + 1, False), False)
+        self.assertEqual(
+            ci_cache.is_pending(job, NUM_BATCHES - 1, NUM_BATCHES, False), False
+        )
+
+
+if __name__ == "__main__":
+    TestCiCache().test_cache()


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- created CI cache class which manages job's cached statuses
- added functionality to mark jobs as pending, to enable awaiting on them later (step 2)

Bug fix:
- ensure that "Build Report check", "Build special report check" on the master  could be reused only from master


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
