### PR TITLE
Tells reader how to show which settings have been changed from default.

### DIFF
--- a/docs/en/operations/settings/index.md
+++ b/docs/en/operations/settings/index.md
@@ -1,5 +1,5 @@
 ---
-sidebar_label: Settings Overview
+title: "Settings Overview"
 sidebar_position: 1
 slug: /en/operations/settings/
 pagination_next: en/operations/settings/settings
@@ -16,11 +16,34 @@ There are two main groups of ClickHouse settings:
 - Global server settings
 - Query-level settings
 
-The main distinction between global server settings and query-level settings is that
-global server settings must be set in configuration files while query-level settings
-can be set in configuration files or with SQL queries.
+The main distinction between global server settings and query-level settings is that global server settings must be set in configuration files, while query-level settings can be set in configuration files or with SQL queries.
 
 Read about [global server settings](/docs/en/operations/server-configuration-parameters/settings.md) to learn more about configuring your ClickHouse server at the global server level.
 
-Read about [query-level settings](/docs/en/operations/settings/settings-query-level.md) to learn more about configuring your ClickHouse server at the query-level.
+Read about [query-level settings](/docs/en/operations/settings/settings-query-level.md) to learn more about configuring your ClickHouse server at the query level.
 
+## See non-default settings
+
+To view which settings have been changed from their default value:
+
+```sql
+SELECT name, value FROM system.settings WHERE changed
+```
+
+If you haven't changed any settings from their default value, then ClickHouse will return nothing.
+
+To check the value of a particular setting, specify the `name` of the setting in your query:
+
+```sql
+SELECT name, value FROM system.settings WHERE name = 'max_threads'
+```
+
+This command should return something like:
+
+```response
+┌─name────────┬─value─────┐
+│ max_threads │ 'auto(8)' │
+└─────────────┴───────────┘
+
+1 row in set. Elapsed: 0.002 sec.
+```


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):

- Documentation (changelog entry is not required)


### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

---

Closes https://github.com/ClickHouse/clickhouse-docs/issues/1442

Adds an example in `/docs/en/operations/settings` to show users how to view all the settings they've changed (so that they aren't default anymore).