### PR TITLE
Small follow-up to `std::regex` --> `re2` conversion (#58458)

### DIFF
--- a/src/Server/MySQLHandler.cpp
+++ b/src/Server/MySQLHandler.cpp
@@ -535,7 +535,7 @@ static bool isFederatedServerSetupSetCommand(const String & query)
         "|(^(SET @@(.*)))"
         "|(^(SET SESSION TRANSACTION ISOLATION LEVEL(.*)))", regexp_options);
     assert(expr.ok());
-    return re2::RE2::PartialMatch(query, expr);
+    return re2::RE2::FullMatch(query, expr);
 }
 
 /// Replace "[query(such as SHOW VARIABLES...)]" into "".


### PR DESCRIPTION
Follow up to #58458

In MySQLHandler.cpp,
    `return 1 == std::regex_match(query, expr);`
was converted to
    `return re2::RE2::PartialMatch(query, expr);`

Should have been `FullMatch(query, expr)`

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)