### PR TITLE
Docs: Update type of two column in `system.query_log/text_log`

### DIFF
--- a/docs/en/operations/system-tables/query_log.md
+++ b/docs/en/operations/system-tables/query_log.md
@@ -42,7 +42,7 @@ Columns:
     - `'ExceptionWhileProcessing' = 4` — Exception during the query execution.
 - `event_date` ([Date](../../sql-reference/data-types/date.md)) — Query starting date.
 - `event_time` ([DateTime](../../sql-reference/data-types/datetime.md)) — Query starting time.
-- `event_time_microseconds` ([DateTime](../../sql-reference/data-types/datetime.md)) — Query starting time with microseconds precision.
+- `event_time_microseconds` ([DateTime64](../../sql-reference/data-types/datetime64.md)) — Query starting time with microseconds precision.
 - `query_start_time` ([DateTime](../../sql-reference/data-types/datetime.md)) — Start time of query execution.
 - `query_start_time_microseconds` ([DateTime64](../../sql-reference/data-types/datetime64.md)) — Start time of query execution with microsecond precision.
 - `query_duration_ms` ([UInt64](../../sql-reference/data-types/int-uint.md#uint-ranges)) — Duration of query execution in milliseconds.

--- a/docs/en/operations/system-tables/text_log.md
+++ b/docs/en/operations/system-tables/text_log.md
@@ -10,7 +10,7 @@ Columns:
 - `hostname` ([LowCardinality(String)](../../sql-reference/data-types/string.md)) — Hostname of the server executing the query.
 - `event_date` (Date) — Date of the entry.
 - `event_time` (DateTime) — Time of the entry.
-- `event_time_microseconds` (DateTime) — Time of the entry with microseconds precision.
+- `event_time_microseconds` (DateTime64) — Time of the entry with microseconds precision.
 - `microseconds` (UInt32) — Microseconds of the entry.
 - `thread_name` (String) — Name of the thread from which the logging was done.
 - `thread_id` (UInt64) — OS thread ID.


### PR DESCRIPTION
### Changelog category (leave one):
- Documentation (changelog entry is not required)