### PR TITLE
Some small improvements to version_helper from #57203

### DIFF
--- a/tests/ci/release.py
+++ b/tests/ci/release.py
@@ -122,7 +122,7 @@ class Release:
         self.version = get_version_from_repo(git=self._git)
 
     def get_stable_release_type(self) -> str:
-        if self.version.minor % 5 == 3:  # our 3 and 8 are LTS
+        if self.version.is_lts:
             return VersionType.LTS
         return VersionType.STABLE
 

--- a/tests/ci/version_helper.py
+++ b/tests/ci/version_helper.py
@@ -139,6 +139,11 @@ class ClickHouseVersion:
             (str(self.major), str(self.minor), str(self.patch), str(self.tweak))
         )
 
+    @property
+    def is_lts(self) -> bool:
+        """our X.3 and X.8 are LTS"""
+        return self.minor % 5 == 3
+
     def as_dict(self) -> VERSIONS:
         return {
             "revision": self.revision,
@@ -314,7 +319,9 @@ def get_supported_versions(
                 if version.major == sv.major and version.minor == sv.minor
             }:
                 supported_stable.add(version)
-        if version.description == VersionType.LTS and len(supported_lts) < 2:
+        if (version.description == VersionType.LTS or version.is_lts) and len(
+            supported_lts
+        ) < 2:
             if not {
                 sv
                 for sv in supported_lts

--- a/tests/ci/version_helper.py
+++ b/tests/ci/version_helper.py
@@ -2,7 +2,7 @@
 import logging
 import os.path as p
 from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser, ArgumentTypeError
-from typing import Any, Dict, List, Literal, Optional, Tuple, Union
+from typing import Any, Dict, Iterable, List, Literal, Optional, Set, Tuple, Union
 
 from git_helper import TWEAK, Git, get_tags, git_runner, removeprefix
 
@@ -120,6 +120,7 @@ class ClickHouseVersion:
 
     @property
     def githash(self) -> str:
+        "returns the CURRENT git SHA1"
         if self._git is not None:
             return self._git.sha
         return "0000000000000000000000000000000000000000"
@@ -180,6 +181,21 @@ class ClickHouseVersion:
 
     def __le__(self, other: "ClickHouseVersion") -> bool:
         return self == other or self < other
+
+    def __hash__(self):
+        return hash(self.__repr__)
+
+    def __str__(self):
+        return f"{self.string}"
+
+    def __repr__(self):
+        return (
+            f"<ClickHouseVersion({self.major},{self.minor},{self.patch},{self.tweak},"
+            f"'{self.description}')>"
+        )
+
+
+ClickHouseVersions = List[ClickHouseVersion]
 
 
 class VersionType:
@@ -267,7 +283,7 @@ def version_arg(version: str) -> ClickHouseVersion:
     raise ArgumentTypeError(f"version {version} does not match tag of plain version")
 
 
-def get_tagged_versions() -> List[ClickHouseVersion]:
+def get_tagged_versions() -> ClickHouseVersions:
     versions = []
     for tag in get_tags():
         try:
@@ -276,6 +292,38 @@ def get_tagged_versions() -> List[ClickHouseVersion]:
         except Exception:
             continue
     return sorted(versions)
+
+
+def get_supported_versions(
+    versions: Optional[Iterable[ClickHouseVersion]] = None,
+) -> Set[ClickHouseVersion]:
+    supported_stable = set()  # type: Set[ClickHouseVersion]
+    supported_lts = set()  # type: Set[ClickHouseVersion]
+    if versions:
+        versions = list(versions)
+    else:
+        # checks that repo is not shallow in background
+        versions = get_tagged_versions()
+    versions.sort()
+    versions.reverse()
+    for version in versions:
+        if len(supported_stable) < 3:
+            if not {
+                sv
+                for sv in supported_stable
+                if version.major == sv.major and version.minor == sv.minor
+            }:
+                supported_stable.add(version)
+        if version.description == VersionType.LTS and len(supported_lts) < 2:
+            if not {
+                sv
+                for sv in supported_lts
+                if version.major == sv.major and version.minor == sv.minor
+            }:
+                supported_lts.add(version)
+        if len(supported_stable) == 3 and len(supported_lts) == 2:
+            break
+    return supported_lts.union(supported_stable)
 
 
 def update_cmake_version(


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Decoupled changes from #57203