### PR TITLE
Fix bug in new (not released yet) parallel replicas coordinator

### DIFF
--- a/src/Storages/MergeTree/ParallelReplicasReadingCoordinator.cpp
+++ b/src/Storages/MergeTree/ParallelReplicasReadingCoordinator.cpp
@@ -429,12 +429,17 @@ void DefaultCoordinator::handleInitialAllRangesAnnouncement(InitialAllRangesAnno
         setProgressCallback();
 
     /// Sift the queue to move out all invisible segments
-    for (const auto & segment : distribution_by_hash_queue[replica_num])
+    for (auto segment_it = distribution_by_hash_queue[replica_num].begin(); segment_it != distribution_by_hash_queue[replica_num].end();)
     {
-        if (!part_visibility[segment.info.getPartNameV1()].contains(replica_num))
+        if (!part_visibility[segment_it->info.getPartNameV1()].contains(replica_num))
         {
-            chassert(segment.ranges.size() == 1);
-            enqueueToStealerOrStealingQueue(segment.info, segment.ranges.front());
+            chassert(segment_it->ranges.size() == 1);
+            enqueueToStealerOrStealingQueue(segment_it->info, segment_it->ranges.front());
+            segment_it = distribution_by_hash_queue[replica_num].erase(segment_it);
+        }
+        else
+        {
+            ++segment_it;
         }
     }
 }
@@ -681,7 +686,7 @@ void DefaultCoordinator::enqueueSegment(const MergeTreePartInfo & info, const Ma
     {
         /// TODO: optimize me (maybe we can store something lighter than RangesInDataPartDescription)
         distribution_by_hash_queue[owner].insert(RangesInDataPartDescription{.info = info, .ranges = {segment}});
-        LOG_TEST(log, "Segment {} is added to its owner's ({}) queue", segment, owner);
+        LOG_TEST(log, "Segment {} of {} is added to its owner's ({}) queue", segment, info.getPartNameV1(), owner);
     }
     else
         enqueueToStealerOrStealingQueue(info, segment);
@@ -695,12 +700,12 @@ void DefaultCoordinator::enqueueToStealerOrStealingQueue(const MergeTreePartInfo
     if (possiblyCanReadPart(stealer_by_hash, info))
     {
         distribution_by_hash_queue[stealer_by_hash].insert(std::move(range));
-        LOG_TEST(log, "Segment {} is added to its stealer's ({}) queue", segment, stealer_by_hash);
+        LOG_TEST(log, "Segment {} of {} is added to its stealer's ({}) queue", segment, info.getPartNameV1(), stealer_by_hash);
     }
     else
     {
         ranges_for_stealing_queue.push_back(std::move(range));
-        LOG_TEST(log, "Segment {} is added to stealing queue", segment);
+        LOG_TEST(log, "Segment {} of {} is added to stealing queue", segment, info.getPartNameV1());
     }
 }
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

---

When we receive an announcement and figure out that replica doesn't see particular data part - we move this data part's segments out of the replica's queue. But forgot to remove them, so they were essentially copied.