### PR TITLE
Add missing includes when _LIBCPP_REMOVE_TRANSITIVE_INCLUDES enabled

### DIFF
--- a/src/Common/FileChecker.h
+++ b/src/Common/FileChecker.h
@@ -3,6 +3,7 @@
 #include <Storages/CheckResults.h>
 #include <map>
 #include <base/types.h>
+#include <memory>
 #include <mutex>
 
 namespace Poco { class Logger; }

--- a/src/Common/ProxyConfigurationResolverProvider.h
+++ b/src/Common/ProxyConfigurationResolverProvider.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <atomic>
 #include <base/types.h>
 #include <Poco/Util/AbstractConfiguration.h>
 #include <Common/ProxyConfigurationResolver.h>

--- a/src/Common/ProxyConfigurationResolverProvider.h
+++ b/src/Common/ProxyConfigurationResolverProvider.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <atomic>
 #include <base/types.h>
 #include <Poco/Util/AbstractConfiguration.h>
 #include <Common/ProxyConfigurationResolver.h>

--- a/src/Common/ProxyListConfigurationResolver.h
+++ b/src/Common/ProxyListConfigurationResolver.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <atomic>
 #include <base/types.h>
 
 #include <Common/ProxyConfigurationResolver.h>

--- a/src/Storages/StorageLogSettings.h
+++ b/src/Storages/StorageLogSettings.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 #include <base/types.h>
 
 namespace DB


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Documentation entry for user-facing changes

After defining `_LIBCPP_REMOVE_TRANSITIVE_INCLUDES` in libc++, some of the transitive includes will disappear. 
Therefore, we have to include them explicitly.
