### PR TITLE
Ecloud EOS Storage support

### DIFF
--- a/src/IO/S3/URI.cpp
+++ b/src/IO/S3/URI.cpp
@@ -35,7 +35,7 @@ URI::URI(const std::string & uri_)
     /// Case when bucket name represented in domain name of S3 URL.
     /// E.g. (https://bucket-name.s3.Region.amazonaws.com/key)
     /// https://docs.aws.amazon.com/AmazonS3/latest/dev/VirtualHosting.html#virtual-hosted-style-access
-    static const RE2 virtual_hosted_style_pattern(R"((.+)\.(s3|cos|obs|oss)([.\-][a-z0-9\-.:]+))");
+    static const RE2 virtual_hosted_style_pattern(R"((.+)\.(s3|cos|obs|oss|eos)([.\-][a-z0-9\-.:]+))");
 
     /// Case when bucket name and key represented in path of S3 URL.
     /// E.g. (https://s3.Region.amazonaws.com/bucket-name/key)
@@ -47,6 +47,7 @@ URI::URI(const std::string & uri_)
     static constexpr auto COS = "COS";
     static constexpr auto OBS = "OBS";
     static constexpr auto OSS = "OSS";
+    static constexpr auto EOS = "EOS";
 
     uri = Poco::URI(uri_);
 
@@ -114,7 +115,7 @@ URI::URI(const std::string & uri_)
         }
 
         boost::to_upper(name);
-        if (name != S3 && name != COS && name != OBS && name != OSS)
+        if (name != S3 && name != COS && name != OBS && name != OSS && name != EOS)
             throw Exception(ErrorCodes::BAD_ARGUMENTS,
                             "Object storage system name is unrecognized in virtual hosted style S3 URI: {}",
                             quoteString(name));
@@ -125,6 +126,8 @@ URI::URI(const std::string & uri_)
             storage_name = OBS;
         else if (name == OSS)
             storage_name = OSS;
+        else if (name == EOS)
+            storage_name = EOS;
         else
             storage_name = COSN;
     }


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Improve S3 compatible, add Ecloud EOS storage support.

### Description

https://ecloud.10086.cn/portal/product/eos

Refer:
Huawei: https://github.com/ClickHouse/ClickHouse/pull/29511
Aliyun: https://github.com/ClickHouse/ClickHouse/pull/31286

Throw exception when query from eos
```
SELECT count()
FROM s3('https://xxxxx.eos.jinan-4.cmecloud.cn/data/trips_*.csv.lz4', 'xxxxx', 'xxxx', 'CSV')

Query id: c3f0fa30-3981-45f5-a72d-742a88ceac7c


Elapsed: 0.037 sec. 

Received exception:
Code: 499. DB::Exception: Could3 not list objects in bucket 'data' with prefix 'trips_', S3 exception: `NoSuchKey`, message: ''. (S3_ERROR)
```

After patch
```
SELECT count()
FROM s3('https://xxxxx.eos.jinan-4.cmecloud.cn/trips_*.csv.lz4', 'xxxxx', 'xxxxx', 'CSV')

Query id: d42bfbbd-a021-4a72-9628-f6782ba1d3cc

┌─count()─┐
│       1 │
└─────────┘

1 row in set. Elapsed: 0.031 sec. 

```


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
