### PR TITLE
Optimize DB::combineFilters with BMI2/SSE intrinsics

### DIFF
--- a/src/Common/TargetSpecific.h
+++ b/src/Common/TargetSpecific.h
@@ -105,7 +105,7 @@ String toString(TargetArch arch);
 #define AVX512VBMI_FUNCTION_SPECIFIC_ATTRIBUTE __attribute__((target("sse,sse2,sse3,ssse3,sse4,popcnt,avx,avx2,avx512f,avx512bw,avx512vl,avx512vbmi")))
 #define AVX512BW_FUNCTION_SPECIFIC_ATTRIBUTE __attribute__((target("sse,sse2,sse3,ssse3,sse4,popcnt,avx,avx2,avx512f,avx512bw")))
 #define AVX512_FUNCTION_SPECIFIC_ATTRIBUTE __attribute__((target("sse,sse2,sse3,ssse3,sse4,popcnt,avx,avx2,avx512f")))
-#define AVX2_FUNCTION_SPECIFIC_ATTRIBUTE __attribute__((target("sse,sse2,sse3,ssse3,sse4,popcnt,avx,avx2")))
+#define AVX2_FUNCTION_SPECIFIC_ATTRIBUTE __attribute__((target("sse,sse2,sse3,ssse3,sse4,popcnt,avx,avx2,bmi2")))
 #define AVX_FUNCTION_SPECIFIC_ATTRIBUTE __attribute__((target("sse,sse2,sse3,ssse3,sse4,popcnt,avx"))
 #define SSE42_FUNCTION_SPECIFIC_ATTRIBUTE __attribute__((target("sse,sse2,sse3,ssse3,sse4,popcnt")))
 #define DEFAULT_FUNCTION_SPECIFIC_ATTRIBUTE
@@ -119,7 +119,7 @@ String toString(TargetArch arch);
 #   define BEGIN_AVX512F_SPECIFIC_CODE \
         _Pragma("clang attribute push(__attribute__((target(\"sse,sse2,sse3,ssse3,sse4,popcnt,avx,avx2,avx512f\"))),apply_to=function)")
 #   define BEGIN_AVX2_SPECIFIC_CODE \
-        _Pragma("clang attribute push(__attribute__((target(\"sse,sse2,sse3,ssse3,sse4,popcnt,avx,avx2\"))),apply_to=function)")
+        _Pragma("clang attribute push(__attribute__((target(\"sse,sse2,sse3,ssse3,sse4,popcnt,avx,avx2,bmi2\"))),apply_to=function)")
 #   define BEGIN_AVX_SPECIFIC_CODE \
         _Pragma("clang attribute push(__attribute__((target(\"sse,sse2,sse3,ssse3,sse4,popcnt,avx\"))),apply_to=function)")
 #   define BEGIN_SSE42_SPECIFIC_CODE \
@@ -137,7 +137,7 @@ String toString(TargetArch arch);
 #define AVX512VBMI_FUNCTION_SPECIFIC_ATTRIBUTE __attribute__((target("sse,sse2,sse3,ssse3,sse4,popcnt,avx,avx2,avx512f,avx512bw,avx512vl,avx512vbmi,tune=native")))
 #define AVX512BW_FUNCTION_SPECIFIC_ATTRIBUTE __attribute__((target("sse,sse2,sse3,ssse3,sse4,popcnt,avx,avx2,avx512f,avx512bw,tune=native")))
 #define AVX512_FUNCTION_SPECIFIC_ATTRIBUTE __attribute__((target("sse,sse2,sse3,ssse3,sse4,popcnt,avx,avx2,avx512f,tune=native")))
-#define AVX2_FUNCTION_SPECIFIC_ATTRIBUTE __attribute__((target("sse,sse2,sse3,ssse3,sse4,popcnt,avx,avx2,tune=native")))
+#define AVX2_FUNCTION_SPECIFIC_ATTRIBUTE __attribute__((target("sse,sse2,sse3,ssse3,sse4,popcnt,avx,avx2,bmi2,tune=native")))
 #define AVX_FUNCTION_SPECIFIC_ATTRIBUTE __attribute__((target("sse,sse2,sse3,ssse3,sse4,popcnt,avx,tune=native")))
 #define SSE42_FUNCTION_SPECIFIC_ATTRIBUTE __attribute__((target("sse,sse2,sse3,ssse3,sse4,popcnt",tune=native)))
 #define DEFAULT_FUNCTION_SPECIFIC_ATTRIBUTE
@@ -156,7 +156,7 @@ String toString(TargetArch arch);
         _Pragma("GCC target(\"sse,sse2,sse3,ssse3,sse4,popcnt,avx,avx2,avx512f,tune=native\")")
 #   define BEGIN_AVX2_SPECIFIC_CODE \
         _Pragma("GCC push_options") \
-        _Pragma("GCC target(\"sse,sse2,sse3,ssse3,sse4,popcnt,avx,avx2,tune=native\")")
+        _Pragma("GCC target(\"sse,sse2,sse3,ssse3,sse4,popcnt,avx,avx2,bmi2,tune=native\")")
 #   define BEGIN_AVX_SPECIFIC_CODE \
         _Pragma("GCC push_options") \
         _Pragma("GCC target(\"sse,sse2,sse3,ssse3,sse4,popcnt,avx,tune=native\")")

--- a/src/Storages/MergeTree/MergeTreeRangeReader.cpp
+++ b/src/Storages/MergeTree/MergeTreeRangeReader.cpp
@@ -1283,6 +1283,81 @@ inline void combineFiltersImpl(UInt8 * first_begin, const UInt8 * first_end, con
 }
 )
 
+/* The BMI2 intrinsic, _pdep_u64 (unsigned __int64 a, unsigned __int64 mask), works
+ * by copying contiguous low-order bits from unsigned 64-bit integer a to destination
+ * at the corresponding bit locations specified by mask. To implement the column
+ * combination with the intrinsic, 8 contiguous bytes would be loaded from second_begin
+ * as a UInt64 and act the first operand, meanwhile the mask should be constructed from
+ * first_begin so that the bytes to be replaced (non-zero elements) are mapped to 0xFF
+ * at the exact bit locations and 0x00 otherwise.
+ *
+ * The construction of mask employs the SSE intrinsic, mm_cmpeq_epi8(__m128i a, __m128i
+ * b), which compares packed 8-bit integers in first_begin and packed 0s and outputs
+ * 0xFF for equality and 0x00 for inequality. The result's negation then creates the
+ * desired bit masks for _pdep_u64.
+ *
+ * The below example visualizes how this optimization applies to the combination of
+ * two quadwords from first_begin and second_begin.
+ *
+ *                                      Addr  high                           low
+ *                                      <----------------------------------------
+ * first_begin............................0x00 0x11 0x12 0x00 0x00 0x13 0x14 0x15
+ *     |      mm_cmpeq_epi8(src, 0)        |    |    |    |    |    |    |    |
+ *     v                                   v    v    v    v    v    v    v    v
+ *  inv_mask..............................0xFF 0x00 0x00 0xFF 0xFF 0x00 0x00 0x00
+ *     |      (negation)                   |    |    |    |    |    |    |    |
+ *     v                                   v    v    v    v    v    v    v    v
+ *    mask-------------------------+......0x00 0xFF 0xFF 0x00 0x00 0xFF 0xFF 0xFF
+ *                                 |            |    |              |    |    |
+ *                                 v            v    v              v    v    v
+ *    dst = pdep_u64(second_begin, mask)..0x00 0x05 0x04 0x00 0x00 0x03 0x02 0x01
+ *                        ^                     ^    ^              ^    ^    ^
+ *                        |                     |    |              |    |    |
+ *                        |                     |    +---------+    |    |    |
+ *     +------------------+                     +---------+    |    |    |    |
+ *     |                                                  |    |    |    |    |
+ * second_begin...........................0x00 0x00 0x00 0x05 0x04 0x03 0x02 0x01
+ *
+ * References:
+ * 1. https://www.felixcloutier.com/x86/pdep
+ * 2. https://www.felixcloutier.com/x86/pcmpeqb:pcmpeqw:pcmpeqd
+ */
+DECLARE_AVX2_SPECIFIC_CODE(
+inline void combineFiltersImpl(UInt8 * first_begin, const UInt8 * first_end, const UInt8 * second_begin)
+{
+    constexpr size_t XMM_VEC_SIZE_IN_BYTES = 16;
+    const __m128i zero16 = _mm_setzero_si128();
+
+    while (first_begin + XMM_VEC_SIZE_IN_BYTES <= first_end)
+    {
+        __m128i src = _mm_loadu_si128(reinterpret_cast<__m128i *>(first_begin));
+        __m128i inv_mask = _mm_cmpeq_epi8(src, zero16);
+
+        UInt64 masks[] = {
+            ~static_cast<UInt64>(_mm_extract_epi64(inv_mask, 0)),
+            ~static_cast<UInt64>(_mm_extract_epi64(inv_mask, 1)),
+        };
+
+        for (const auto & mask: masks)
+        {
+            UInt64 dst = _pdep_u64(unalignedLoad<UInt64>(second_begin), mask);
+            unalignedStore<UInt64>(first_begin, dst);
+
+            first_begin += sizeof(UInt64);
+            second_begin += std::popcount(mask) / 8;
+        }
+    }
+
+    for (/* empty */; first_begin < first_end; ++first_begin)
+    {
+        if (*first_begin)
+        {
+            *first_begin = *second_begin++;
+        }
+    }
+}
+)
+
 /// Second filter size must be equal to number of 1s in the first filter.
 /// The result has size equal to first filter size and contains 1s only where both filters contain 1s.
 static ColumnPtr combineFilters(ColumnPtr first, ColumnPtr second)
@@ -1329,6 +1404,10 @@ static ColumnPtr combineFilters(ColumnPtr first, ColumnPtr second)
     if (isArchSupported(TargetArch::AVX512VBMI2))
     {
         TargetSpecific::AVX512VBMI2::combineFiltersImpl(first_data.begin(), first_data.end(), second_data);
+    }
+    else if (isArchSupported(TargetArch::AVX2))
+    {
+        TargetSpecific::AVX2::combineFiltersImpl(first_data.begin(), first_data.end(), second_data);
     }
     else
 #endif


### PR DESCRIPTION
As a follow-up of https://github.com/ClickHouse/ClickHouse/pull/56079, the function is optimized with the BMI2 and SSE intrinsics so that devices without AVX512 support could also accelerate the column combinations via data parallelism.
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
The performance experiments of **OnTime** on the Intel server with up to AVX2 (and BMI2) support show that this change could effectively improve the QPS of **Q2** and **Q3** by **5.0%** and **3.7%**  through reducing the cycle ratio of the hotspot, **_DB::MergeTreeRangeReader::ReadResult::optimize_**, **from 11.48% to 1.09%** and **from 8.09% to 0.67%** respectively while having no impact on others.



> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
