### PR TITLE
Allow KILL QUERY for backups

### DIFF
--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -1990,6 +1990,12 @@ try
             else
                 LOG_INFO(log, "Closed all listening sockets.");
 
+            /// Wait for unfinished backups and restores.
+            /// This must be done after closing listening sockets (no more backups/restores) but before ProcessList::killAllQueries
+            /// (because killAllQueries() will cancel all running backups/restores).
+            if (server_settings.shutdown_wait_backups_and_restores)
+                global_context->waitAllBackupsAndRestores();
+
             /// Killing remaining queries.
             if (!server_settings.shutdown_wait_unfinished_queries)
                 global_context->getProcessList().killAllQueries();

--- a/src/Backups/BackupCoordinationRemote.cpp
+++ b/src/Backups/BackupCoordinationRemote.cpp
@@ -162,7 +162,8 @@ BackupCoordinationRemote::BackupCoordinationRemote(
     const Strings & all_hosts_,
     const String & current_host_,
     bool plain_backup_,
-    bool is_internal_)
+    bool is_internal_,
+    QueryStatusPtr process_list_element_)
     : root_zookeeper_path(root_zookeeper_path_)
     , zookeeper_path(root_zookeeper_path_ + "/backup-" + backup_uuid_)
     , keeper_settings(keeper_settings_)
@@ -177,6 +178,7 @@ BackupCoordinationRemote::BackupCoordinationRemote(
         log,
         get_zookeeper_,
         keeper_settings,
+        process_list_element_,
         [my_zookeeper_path = zookeeper_path, my_current_host = current_host, my_is_internal = is_internal]
         (WithRetries::FaultyKeeper & zk)
         {

--- a/src/Backups/BackupCoordinationRemote.h
+++ b/src/Backups/BackupCoordinationRemote.h
@@ -30,7 +30,8 @@ public:
         const Strings & all_hosts_,
         const String & current_host_,
         bool plain_backup_,
-        bool is_internal_);
+        bool is_internal_,
+        QueryStatusPtr process_list_element_);
 
     ~BackupCoordinationRemote() override;
 

--- a/src/Backups/BackupEntriesCollector.cpp
+++ b/src/Backups/BackupEntriesCollector.cpp
@@ -87,6 +87,7 @@ BackupEntriesCollector::BackupEntriesCollector(
     , backup_coordination(backup_coordination_)
     , read_settings(read_settings_)
     , context(context_)
+    , process_list_element(context->getProcessListElement())
     , on_cluster_first_sync_timeout(context->getConfigRef().getUInt64("backups.on_cluster_first_sync_timeout", 180000))
     , collect_metadata_timeout(context->getConfigRef().getUInt64(
           "backups.collect_metadata_timeout", context->getConfigRef().getUInt64("backups.consistent_metadata_snapshot_timeout", 600000)))
@@ -158,8 +159,9 @@ BackupEntries BackupEntriesCollector::run()
 Strings BackupEntriesCollector::setStage(const String & new_stage, const String & message)
 {
     LOG_TRACE(log, "Setting stage: {}", new_stage);
-    current_stage = new_stage;
+    checkQueryNotCancelled();
 
+    current_stage = new_stage;
     backup_coordination->setStage(new_stage, message);
 
     if (new_stage == Stage::formatGatheringMetadata(0))
@@ -177,6 +179,12 @@ Strings BackupEntriesCollector::setStage(const String & new_stage, const String 
     {
         return backup_coordination->waitForStage(new_stage);
     }
+}
+
+void BackupEntriesCollector::checkQueryNotCancelled() const
+{
+    if (process_list_element)
+        process_list_element->checkTimeLimit();
 }
 
 /// Calculates the root path for collecting backup entries,
@@ -413,6 +421,8 @@ void BackupEntriesCollector::gatherDatabaseMetadata(
     bool all_tables,
     const std::set<DatabaseAndTableName> & except_table_names)
 {
+    checkQueryNotCancelled();
+
     auto it = database_infos.find(database_name);
     if (it == database_infos.end())
     {
@@ -491,6 +501,8 @@ void BackupEntriesCollector::gatherDatabaseMetadata(
 
 void BackupEntriesCollector::gatherTablesMetadata()
 {
+    checkQueryNotCancelled();
+
     table_infos.clear();
     for (const auto & [database_name, database_info] : database_infos)
     {
@@ -551,6 +563,8 @@ std::vector<std::pair<ASTPtr, StoragePtr>> BackupEntriesCollector::findTablesInD
 {
     const auto & database_info = database_infos.at(database_name);
     const auto & database = database_info.database;
+
+    checkQueryNotCancelled();
 
     auto filter_by_table_name = [my_database_info = &database_info](const String & table_name)
     {
@@ -629,8 +643,12 @@ void BackupEntriesCollector::lockTablesForReading()
     for (auto & [table_name, table_info] : table_infos)
     {
         auto storage = table_info.storage;
-        if (storage)
-            table_info.table_lock = storage->tryLockForShare(context->getInitialQueryId(), context->getSettingsRef().lock_acquire_timeout);
+        if (!storage)
+            continue;
+
+        checkQueryNotCancelled();
+
+        table_info.table_lock = storage->tryLockForShare(context->getInitialQueryId(), context->getSettingsRef().lock_acquire_timeout);
     }
 
     std::erase_if(
@@ -734,6 +752,7 @@ void BackupEntriesCollector::makeBackupEntriesForDatabasesDefs()
             continue; /// We store CREATE DATABASE queries only if there was BACKUP DATABASE specified.
 
         LOG_TRACE(log, "Adding the definition of database {} to backup", backQuoteIfNeed(database_name));
+        checkQueryNotCancelled();
 
         ASTPtr new_create_query = database_info.create_database_query;
         adjustCreateQueryForBackup(new_create_query, context->getGlobalContext(), nullptr);
@@ -750,6 +769,7 @@ void BackupEntriesCollector::makeBackupEntriesForTablesDefs()
     for (auto & [table_name, table_info] : table_infos)
     {
         LOG_TRACE(log, "Adding the definition of {} to backup", tableNameWithTypeToString(table_name.database, table_name.table, false));
+        checkQueryNotCancelled();
 
         ASTPtr new_create_query = table_info.create_table_query;
         adjustCreateQueryForBackup(new_create_query, context->getGlobalContext(), &table_info.replicated_table_shared_id);
@@ -802,6 +822,7 @@ void BackupEntriesCollector::makeBackupEntriesForTableData(const QualifiedTableN
     }
 
     LOG_TRACE(log, "Collecting data of {} for backup", tableNameWithTypeToString(table_name.database, table_name.table, false));
+    checkQueryNotCancelled();
 
     try
     {
@@ -861,13 +882,17 @@ void BackupEntriesCollector::addPostTask(std::function<void()> task)
 void BackupEntriesCollector::runPostTasks()
 {
     LOG_TRACE(log, "Will run {} post tasks", post_tasks.size());
+
     /// Post collecting tasks can add other post collecting tasks, our code is fine with that.
     while (!post_tasks.empty())
     {
+        checkQueryNotCancelled();
+
         auto task = std::move(post_tasks.front());
         post_tasks.pop();
         std::move(task)();
     }
+
     LOG_TRACE(log, "All post tasks successfully executed");
 }
 

--- a/src/Backups/BackupEntriesCollector.h
+++ b/src/Backups/BackupEntriesCollector.h
@@ -101,7 +101,7 @@ private:
     Strings setStage(const String & new_stage, const String & message = "");
 
     /// Throws an exception if the BACKUP query was cancelled.
-    void checkQueryNotCancelled() const;
+    void checkIsQueryCancelled() const;
 
     const ASTBackupQuery::Elements backup_query_elements;
     const BackupSettings backup_settings;

--- a/src/Backups/BackupEntriesCollector.h
+++ b/src/Backups/BackupEntriesCollector.h
@@ -22,6 +22,9 @@ class IDatabase;
 using DatabasePtr = std::shared_ptr<IDatabase>;
 struct StorageID;
 enum class AccessEntityType;
+class QueryStatus;
+using QueryStatusPtr = std::shared_ptr<QueryStatus>;
+
 
 /// Collects backup entries for all databases and tables which should be put to a backup.
 class BackupEntriesCollector : private boost::noncopyable
@@ -97,11 +100,15 @@ private:
 
     Strings setStage(const String & new_stage, const String & message = "");
 
+    /// Throws an exception if the BACKUP query was cancelled.
+    void checkQueryNotCancelled() const;
+
     const ASTBackupQuery::Elements backup_query_elements;
     const BackupSettings backup_settings;
     std::shared_ptr<IBackupCoordination> backup_coordination;
     const ReadSettings read_settings;
     ContextPtr context;
+    QueryStatusPtr process_list_element;
 
     /// The time a BACKUP ON CLUSTER or RESTORE ON CLUSTER command will wait until all the nodes receive the BACKUP (or RESTORE) query and start working.
     /// This setting is similar to `distributed_ddl_task_timeout`.

--- a/src/Backups/BackupFileInfo.cpp
+++ b/src/Backups/BackupFileInfo.cpp
@@ -7,6 +7,8 @@
 #include <Common/scope_guard_safe.h>
 #include <Common/setThreadName.h>
 #include <Common/ThreadPool.h>
+#include <Interpreters/ProcessList.h>
+
 #include <base/hex.h>
 
 
@@ -203,7 +205,7 @@ BackupFileInfo buildFileInfoForBackupEntry(
     return info;
 }
 
-BackupFileInfos buildFileInfosForBackupEntries(const BackupEntries & backup_entries, const BackupPtr & base_backup, const ReadSettings & read_settings, ThreadPool & thread_pool)
+BackupFileInfos buildFileInfosForBackupEntries(const BackupEntries & backup_entries, const BackupPtr & base_backup, const ReadSettings & read_settings, ThreadPool & thread_pool, QueryStatusPtr process_list_element)
 {
     BackupFileInfos infos;
     infos.resize(backup_entries.size());
@@ -225,7 +227,7 @@ BackupFileInfos buildFileInfosForBackupEntries(const BackupEntries & backup_entr
             ++num_active_jobs;
         }
 
-        auto job = [&mutex, &num_active_jobs, &event, &exception, &infos, &backup_entries, &read_settings, &base_backup, &thread_group, i, log]()
+        auto job = [&mutex, &num_active_jobs, &event, &exception, &infos, &backup_entries, &read_settings, &base_backup, &thread_group, &process_list_element, i, log]()
         {
             SCOPE_EXIT_SAFE({
                 std::lock_guard lock{mutex};
@@ -249,6 +251,9 @@ BackupFileInfos buildFileInfosForBackupEntries(const BackupEntries & backup_entr
                     if (exception)
                         return;
                 }
+
+                if (process_list_element)
+                    process_list_element->checkTimeLimit();
 
                 infos[i] = buildFileInfoForBackupEntry(name, entry, base_backup, read_settings, log);
             }

--- a/src/Backups/BackupFileInfo.h
+++ b/src/Backups/BackupFileInfo.h
@@ -14,6 +14,8 @@ using BackupPtr = std::shared_ptr<const IBackup>;
 using BackupEntryPtr = std::shared_ptr<const IBackupEntry>;
 using BackupEntries = std::vector<std::pair<String, BackupEntryPtr>>;
 struct ReadSettings;
+class QueryStatus;
+using QueryStatusPtr = std::shared_ptr<QueryStatus>;
 
 
 /// Information about a file stored in a backup.
@@ -78,6 +80,6 @@ using BackupFileInfos = std::vector<BackupFileInfo>;
 BackupFileInfo buildFileInfoForBackupEntry(const String & file_name, const BackupEntryPtr & backup_entry, const BackupPtr & base_backup, const ReadSettings & read_settings, Poco::Logger * log);
 
 /// Builds a vector of BackupFileInfos for specified backup entries.
-BackupFileInfos buildFileInfosForBackupEntries(const BackupEntries & backup_entries, const BackupPtr & base_backup, const ReadSettings & read_settings, ThreadPool & thread_pool);
+BackupFileInfos buildFileInfosForBackupEntries(const BackupEntries & backup_entries, const BackupPtr & base_backup, const ReadSettings & read_settings, ThreadPool & thread_pool, QueryStatusPtr process_list_element);
 
 }

--- a/src/Backups/BackupStatus.cpp
+++ b/src/Backups/BackupStatus.cpp
@@ -21,12 +21,16 @@ std::string_view toString(BackupStatus backup_status)
             return "BACKUP_CREATED";
         case BackupStatus::BACKUP_FAILED:
             return "BACKUP_FAILED";
+        case BackupStatus::BACKUP_CANCELLED:
+            return "BACKUP_CANCELLED";
         case BackupStatus::RESTORING:
             return "RESTORING";
         case BackupStatus::RESTORED:
             return "RESTORED";
         case BackupStatus::RESTORE_FAILED:
             return "RESTORE_FAILED";
+        case BackupStatus::RESTORE_CANCELLED:
+            return "RESTORE_CANCELLED";
         default:
             break;
     }

--- a/src/Backups/BackupStatus.h
+++ b/src/Backups/BackupStatus.h
@@ -18,6 +18,10 @@ enum class BackupStatus
     RESTORED,
     RESTORE_FAILED,
 
+    /// Statuses used after a BACKUP or RESTORE operation was cancelled.
+    BACKUP_CANCELLED,
+    RESTORE_CANCELLED,
+
     MAX,
 };
 

--- a/src/Backups/BackupsWorker.cpp
+++ b/src/Backups/BackupsWorker.cpp
@@ -178,6 +178,11 @@ namespace
         return isFinishedSuccessfully(status) || isFailedOrCancelled(status);
     }
 
+    bool isBackupStatus(BackupStatus status)
+    {
+        return (status == BackupStatus::CREATING_BACKUP) || (status == BackupStatus::BACKUP_CREATED) || (status == BackupStatus::BACKUP_FAILED) || (status == BackupStatus::BACKUP_CANCELLED);
+    }
+
     BackupStatus getBackupStatusFromCurrentException()
     {
         if (getCurrentExceptionCode() == ErrorCodes::QUERY_WAS_CANCELLED)
@@ -370,14 +375,15 @@ private:
 };
 
 
-BackupsWorker::BackupsWorker(ContextPtr global_context, size_t num_backup_threads, size_t num_restore_threads, bool allow_concurrent_backups_, bool allow_concurrent_restores_, bool test_inject_sleep_)
+BackupsWorker::BackupsWorker(ContextMutablePtr global_context, size_t num_backup_threads, size_t num_restore_threads, bool allow_concurrent_backups_, bool allow_concurrent_restores_, bool test_inject_sleep_)
     : thread_pools(std::make_unique<ThreadPools>(num_backup_threads, num_restore_threads))
     , allow_concurrent_backups(allow_concurrent_backups_)
     , allow_concurrent_restores(allow_concurrent_restores_)
     , test_inject_sleep(test_inject_sleep_)
     , log(&Poco::Logger::get("BackupsWorker"))
+    , backup_log(global_context->getBackupLog())
+    , process_list(global_context->getProcessList())
 {
-    backup_log = global_context->getBackupLog();
 }
 
 
@@ -434,7 +440,7 @@ OperationID BackupsWorker::startMakingBackup(const ASTPtr & query, const Context
 
     try
     {
-        addInfo(backup_id, backup_name_for_logging, base_backup_name, backup_settings.internal, BackupStatus::CREATING_BACKUP);
+        addInfo(backup_id, backup_name_for_logging, base_backup_name, backup_settings.internal, context->getProcessListElement(), BackupStatus::CREATING_BACKUP);
 
         /// Prepare context to use.
         ContextPtr context_in_use = context;
@@ -819,7 +825,7 @@ OperationID BackupsWorker::startRestoring(const ASTPtr & query, ContextMutablePt
         if (restore_settings.base_backup_info)
             base_backup_name = restore_settings.base_backup_info->toString();
 
-        addInfo(restore_id, backup_name_for_logging, base_backup_name, restore_settings.internal, BackupStatus::RESTORING);
+        addInfo(restore_id, backup_name_for_logging, base_backup_name, restore_settings.internal, context->getProcessListElement(), BackupStatus::RESTORING);
 
         /// Prepare context to use.
         ContextMutablePtr context_in_use = context;
@@ -1106,9 +1112,10 @@ void BackupsWorker::restoreTablesData(const OperationID & restore_id, BackupPtr 
 }
 
 
-void BackupsWorker::addInfo(const OperationID & id, const String & name, const String & base_backup_name, bool internal, BackupStatus status)
+void BackupsWorker::addInfo(const OperationID & id, const String & name, const String & base_backup_name, bool internal, QueryStatusPtr process_list_element, BackupStatus status)
 {
-    BackupOperationInfo info;
+    ExtendedOperationInfo extended_info;
+    auto & info = extended_info.info;
     info.id = id;
     info.name = name;
     info.base_backup_name = base_backup_name;
@@ -1116,7 +1123,16 @@ void BackupsWorker::addInfo(const OperationID & id, const String & name, const S
     info.status = status;
     info.start_time = std::chrono::system_clock::now();
 
-    if (isFinalStatus(status))
+    bool is_final_status = isFinalStatus(status);
+
+    if (process_list_element)
+    {
+        info.profile_counters = process_list_element->getInfo(/* get_thread_list= */ false, /* get_profile_events= */ true, /* get_settings= */ false).profile_counters;
+        if (!is_final_status)
+            extended_info.process_list_element = process_list_element;
+    }
+
+    if (is_final_status)
         info.end_time = info.start_time;
 
     std::lock_guard lock{infos_mutex};
@@ -1125,7 +1141,7 @@ void BackupsWorker::addInfo(const OperationID & id, const String & name, const S
     if (it != infos.end())
     {
         /// It's better not allow to overwrite the current status if it's in progress.
-        auto current_status = it->second.status;
+        auto current_status = it->second.info.status;
         if (!isFinalStatus(current_status))
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "Cannot start a backup or restore: ID {} is already in use", id);
     }
@@ -1133,7 +1149,7 @@ void BackupsWorker::addInfo(const OperationID & id, const String & name, const S
     if (backup_log)
         backup_log->add(BackupLogElement{info});
 
-    infos[id] = std::move(info);
+    infos[id] = std::move(extended_info);
 
     num_active_backups += getNumActiveBackupsChange(status);
     num_active_restores += getNumActiveRestoresChange(status);
@@ -1152,13 +1168,21 @@ void BackupsWorker::setStatus(const String & id, BackupStatus status, bool throw
             return;
     }
 
-    auto & info = it->second;
+    auto & extended_info = it->second;
+    auto & info = extended_info.info;
+
     auto old_status = info.status;
-
     info.status = status;
-    info.profile_counters = std::make_shared<ProfileEvents::Counters::Snapshot>(CurrentThread::getProfileEvents().getPartiallyAtomicSnapshot());
+    bool is_final_status = isFinalStatus(status);
 
-    if (isFinalStatus(status))
+    if (extended_info.process_list_element)
+    {
+        info.profile_counters = extended_info.process_list_element->getInfo(/* get_thread_list= */ false, /* get_profile_events= */ true, /* get_settings= */ false).profile_counters;
+        if (is_final_status)
+            extended_info.process_list_element = nullptr;
+    }
+
+    if (is_final_status)
         info.end_time = std::chrono::system_clock::now();
 
     if (isFailedOrCancelled(status))
@@ -1172,6 +1196,9 @@ void BackupsWorker::setStatus(const String & id, BackupStatus status, bool throw
 
     num_active_backups += getNumActiveBackupsChange(status) - getNumActiveBackupsChange(old_status);
     num_active_restores += getNumActiveRestoresChange(status) - getNumActiveRestoresChange(old_status);
+
+    if (status != old_status)
+        status_changed.notify_all();
 }
 
 
@@ -1185,7 +1212,7 @@ void BackupsWorker::setNumFilesAndSize(const OperationID & id, size_t num_files,
     if (it == infos.end())
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Unknown backup ID {}", id);
 
-    auto & info = it->second;
+    auto & info = it->second.info;
     info.num_files = num_files;
     info.total_size = total_size;
     info.num_entries = num_entries;
@@ -1203,21 +1230,96 @@ void BackupsWorker::maybeSleepForTesting() const
 }
 
 
-void BackupsWorker::wait(const OperationID & id, bool rethrow_exception)
+void BackupsWorker::wait(const OperationID & backup_or_restore_id, bool rethrow_exception)
 {
     std::unique_lock lock{infos_mutex};
     status_changed.wait(lock, [&]
     {
-        auto it = infos.find(id);
+        auto it = infos.find(backup_or_restore_id);
         if (it == infos.end())
-            throw Exception(ErrorCodes::LOGICAL_ERROR, "Unknown backup ID {}", id);
-        const auto & info = it->second;
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "Unknown backup ID {}", backup_or_restore_id);
+        const auto & info = it->second.info;
         auto current_status = info.status;
         if (rethrow_exception && isFailedOrCancelled(current_status))
             std::rethrow_exception(info.exception);
-        return isFinalStatus(current_status);
+        if (isFinalStatus(current_status))
+            return true;
+        LOG_INFO(log, "Waiting {} {}", isBackupStatus(info.status) ? "backup" : "restore", info.name);
+        return false;
     });
 }
+
+void BackupsWorker::waitAll()
+{
+    std::vector<OperationID> current_operations;
+    {
+        std::lock_guard lock{infos_mutex};
+        for (const auto & [id, extended_info] : infos)
+            if (!isFinalStatus(extended_info.info.status))
+                current_operations.push_back(id);
+    }
+
+    if (current_operations.empty())
+        return;
+
+    LOG_INFO(log, "Waiting for running backups and restores to finish");
+
+    for (const auto & id : current_operations)
+        wait(id, /* rethrow_exception= */ false);
+
+    LOG_INFO(log, "Backups and restores finished");
+}
+
+void BackupsWorker::cancel(const BackupOperationID & backup_or_restore_id, bool wait_)
+{
+    QueryStatusPtr process_list_element;
+    {
+        std::unique_lock lock{infos_mutex};
+        auto it = infos.find(backup_or_restore_id);
+        if (it == infos.end())
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "Unknown backup ID {}", backup_or_restore_id);
+
+        const auto & extended_info = it->second;
+        const auto & info = extended_info.info;
+        if (isFinalStatus(info.status) || !extended_info.process_list_element)
+            return;
+
+        LOG_INFO(log, "Cancelling {} {}", isBackupStatus(info.status) ? "backup" : "restore", info.name);
+        process_list_element = extended_info.process_list_element;
+    }
+
+    process_list.sendCancelToQuery(process_list_element);
+
+    if (wait_)
+        wait(backup_or_restore_id, /* rethrow_exception= */ false);
+}
+
+
+void BackupsWorker::cancelAll(bool wait_)
+{
+    std::vector<OperationID> current_operations;
+    {
+        std::lock_guard lock{infos_mutex};
+        for (const auto & [id, extended_info] : infos)
+            if (!isFinalStatus(extended_info.info.status))
+                current_operations.push_back(id);
+    }
+
+    if (current_operations.empty())
+        return;
+
+    LOG_INFO(log, "Cancelling running backups and restores");
+
+    for (const auto & id : current_operations)
+        cancel(id, /* wait= */ false);
+
+    if (wait_)
+        for (const auto & id : current_operations)
+            wait(id, /* rethrow_exception= */ false);
+
+    LOG_INFO(log, "Backups and restores finished or stopped");
+}
+
 
 BackupOperationInfo BackupsWorker::getInfo(const OperationID & id) const
 {
@@ -1225,15 +1327,16 @@ BackupOperationInfo BackupsWorker::getInfo(const OperationID & id) const
     auto it = infos.find(id);
     if (it == infos.end())
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Unknown backup ID {}", id);
-    return it->second;
+    return it->second.info;
 }
 
 std::vector<BackupOperationInfo> BackupsWorker::getAllInfos() const
 {
     std::vector<BackupOperationInfo> res_infos;
     std::lock_guard lock{infos_mutex};
-    for (const auto & info : infos | boost::adaptors::map_values)
+    for (const auto & extended_info : infos | boost::adaptors::map_values)
     {
+        const auto & info = extended_info.info;
         if (!info.internal)
             res_infos.push_back(info);
     }
@@ -1242,14 +1345,11 @@ std::vector<BackupOperationInfo> BackupsWorker::getAllInfos() const
 
 void BackupsWorker::shutdown()
 {
-    bool has_active_backups_and_restores = (num_active_backups || num_active_restores);
-    if (has_active_backups_and_restores)
-        LOG_INFO(log, "Waiting for {} backups and {} restores to be finished", num_active_backups, num_active_restores);
+    /// Cancel running backups and restores.
+    cancelAll(/* wait= */ true);
 
+    /// Wait for our thread pools (it must be done before destroying them).
     thread_pools->wait();
-
-    if (has_active_backups_and_restores)
-        LOG_INFO(log, "All backup and restore tasks have finished");
 }
 
 }

--- a/src/Backups/BackupsWorker.cpp
+++ b/src/Backups/BackupsWorker.cpp
@@ -529,18 +529,16 @@ void BackupsWorker::doBackup(
     bool called_async)
 {
     SCOPE_EXIT_SAFE(
-        if (called_async)
+        if (called_async && thread_group)
             CurrentThread::detachFromGroupIfNotDetached();
     );
 
     try
     {
+        if (called_async && thread_group)
+            CurrentThread::attachToGroup(thread_group);
         if (called_async)
-        {
-            if (thread_group)
-                CurrentThread::attachToGroup(thread_group);
             setThreadName("BackupWorker");
-        }
 
         bool on_cluster = !backup_query->cluster.empty();
         assert(mutable_context || (!on_cluster && !called_async));
@@ -908,18 +906,16 @@ void BackupsWorker::doRestore(
     bool called_async)
 {
     SCOPE_EXIT_SAFE(
-        if (called_async)
+        if (called_async && thread_group)
             CurrentThread::detachFromGroupIfNotDetached();
     );
 
     try
     {
+        if (called_async && thread_group)
+            CurrentThread::attachToGroup(thread_group);
         if (called_async)
-        {
-            if (thread_group)
-                CurrentThread::attachToGroup(thread_group);
             setThreadName("RestoreWorker");
-        }
 
         /// Open the backup for reading.
         BackupFactory::CreateParams backup_open_params;

--- a/src/Backups/BackupsWorker.h
+++ b/src/Backups/BackupsWorker.h
@@ -35,7 +35,7 @@ using QueryStatusPtr = std::shared_ptr<QueryStatus>;
 class BackupsWorker
 {
 public:
-    BackupsWorker(ContextPtr global_context, size_t num_backup_threads, size_t num_restore_threads, bool allow_concurrent_backups_, bool allow_concurrent_restores_);
+    BackupsWorker(ContextPtr global_context, size_t num_backup_threads, size_t num_restore_threads, bool allow_concurrent_backups_, bool allow_concurrent_restores_, bool test_inject_sleep_);
     ~BackupsWorker();
 
     /// Waits until all tasks have been completed.
@@ -95,11 +95,16 @@ private:
     enum class ThreadPoolId;
     ThreadPool & getThreadPool(ThreadPoolId thread_pool_id);
 
+    /// Waits for some time if `test_inject_sleep` is true.
+    void maybeSleepForTesting() const;
+
     class ThreadPools;
     std::unique_ptr<ThreadPools> thread_pools;
 
     const bool allow_concurrent_backups;
     const bool allow_concurrent_restores;
+    const bool test_inject_sleep;
+
     Poco::Logger * log;
 
     std::unordered_map<BackupOperationID, BackupOperationInfo> infos;

--- a/src/Backups/BackupsWorker.h
+++ b/src/Backups/BackupsWorker.h
@@ -26,6 +26,9 @@ using BackupEntries = std::vector<std::pair<String, std::shared_ptr<const IBacku
 using DataRestoreTasks = std::vector<std::function<void()>>;
 struct ReadSettings;
 class BackupLog;
+class QueryStatus;
+using QueryStatusPtr = std::shared_ptr<QueryStatus>;
+
 
 /// Manager of backups and restores: executes backups and restores' threads in the background.
 /// Keeps information about backups and restores started in this session.
@@ -63,10 +66,10 @@ private:
         bool called_async);
 
     /// Builds file infos for specified backup entries.
-    void buildFileInfosForBackupEntries(const BackupPtr & backup, const BackupEntries & backup_entries, const ReadSettings & read_settings, std::shared_ptr<IBackupCoordination> backup_coordination);
+    void buildFileInfosForBackupEntries(const BackupPtr & backup, const BackupEntries & backup_entries, const ReadSettings & read_settings, std::shared_ptr<IBackupCoordination> backup_coordination, QueryStatusPtr process_list_element);
 
     /// Write backup entries to an opened backup.
-    void writeBackupEntries(BackupMutablePtr backup, BackupEntries && backup_entries, const BackupOperationID & backup_id, std::shared_ptr<IBackupCoordination> backup_coordination, bool internal);
+    void writeBackupEntries(BackupMutablePtr backup, BackupEntries && backup_entries, const BackupOperationID & backup_id, std::shared_ptr<IBackupCoordination> backup_coordination, bool internal, QueryStatusPtr process_list_element);
 
     BackupOperationID startRestoring(const ASTPtr & query, ContextMutablePtr context);
 
@@ -81,7 +84,7 @@ private:
         bool called_async);
 
     /// Run data restoring tasks which insert data to tables.
-    void restoreTablesData(const BackupOperationID & restore_id, BackupPtr backup, DataRestoreTasks && tasks, ThreadPool & thread_pool);
+    void restoreTablesData(const BackupOperationID & restore_id, BackupPtr backup, DataRestoreTasks && tasks, ThreadPool & thread_pool, QueryStatusPtr process_list_element);
 
     void addInfo(const BackupOperationID & id, const String & name, const String & base_backup_name, bool internal, BackupStatus status);
     void setStatus(const BackupOperationID & id, BackupStatus status, bool throw_if_error = true);

--- a/src/Backups/BackupsWorker.h
+++ b/src/Backups/BackupsWorker.h
@@ -26,6 +26,8 @@ using BackupEntries = std::vector<std::pair<String, std::shared_ptr<const IBacku
 using DataRestoreTasks = std::vector<std::function<void()>>;
 struct ReadSettings;
 class BackupLog;
+class ThreadGroup;
+using ThreadGroupPtr = std::shared_ptr<ThreadGroup>;
 class QueryStatus;
 using QueryStatusPtr = std::shared_ptr<QueryStatus>;
 
@@ -63,6 +65,7 @@ private:
         std::shared_ptr<IBackupCoordination> backup_coordination,
         const ContextPtr & context,
         ContextMutablePtr mutable_context,
+        ThreadGroupPtr thread_group,
         bool called_async);
 
     /// Builds file infos for specified backup entries.
@@ -81,6 +84,7 @@ private:
         RestoreSettings restore_settings,
         std::shared_ptr<IRestoreCoordination> restore_coordination,
         ContextMutablePtr context,
+        ThreadGroupPtr thread_group,
         bool called_async);
 
     /// Run data restoring tasks which insert data to tables.

--- a/src/Backups/RestoreCoordinationRemote.cpp
+++ b/src/Backups/RestoreCoordinationRemote.cpp
@@ -21,7 +21,8 @@ RestoreCoordinationRemote::RestoreCoordinationRemote(
     const String & restore_uuid_,
     const Strings & all_hosts_,
     const String & current_host_,
-    bool is_internal_)
+    bool is_internal_,
+    QueryStatusPtr process_list_element_)
     : get_zookeeper(get_zookeeper_)
     , root_zookeeper_path(root_zookeeper_path_)
     , keeper_settings(keeper_settings_)
@@ -36,6 +37,7 @@ RestoreCoordinationRemote::RestoreCoordinationRemote(
         log,
         get_zookeeper_,
         keeper_settings,
+        process_list_element_,
         [my_zookeeper_path = zookeeper_path, my_current_host = current_host, my_is_internal = is_internal]
         (WithRetries::FaultyKeeper & zk)
         {

--- a/src/Backups/RestoreCoordinationRemote.h
+++ b/src/Backups/RestoreCoordinationRemote.h
@@ -21,7 +21,8 @@ public:
         const String & restore_uuid_,
         const Strings & all_hosts_,
         const String & current_host_,
-        bool is_internal_);
+        bool is_internal_,
+        QueryStatusPtr process_list_element_);
 
     ~RestoreCoordinationRemote() override;
 

--- a/src/Backups/RestorerFromBackup.cpp
+++ b/src/Backups/RestorerFromBackup.cpp
@@ -140,7 +140,7 @@ RestorerFromBackup::DataRestoreTasks RestorerFromBackup::run(Mode mode)
 void RestorerFromBackup::setStage(const String & new_stage, const String & message)
 {
     LOG_TRACE(log, "Setting stage: {}", new_stage);
-    checkQueryNotCancelled();
+    checkIsQueryCancelled();
 
     current_stage = new_stage;
 
@@ -154,7 +154,7 @@ void RestorerFromBackup::setStage(const String & new_stage, const String & messa
     }
 }
 
-void RestorerFromBackup::checkQueryNotCancelled() const
+void RestorerFromBackup::checkIsQueryCancelled() const
 {
     if (process_list_element)
         process_list_element->checkTimeLimit();
@@ -573,7 +573,7 @@ void RestorerFromBackup::createDatabase(const String & database_name) const
     if (database_info.is_predefined_database)
         return;
 
-    checkQueryNotCancelled();
+    checkIsQueryCancelled();
 
     auto create_database_query = typeid_cast<std::shared_ptr<ASTCreateQuery>>(database_info.create_database_query->clone());
 
@@ -721,7 +721,7 @@ void RestorerFromBackup::createTable(const QualifiedTableName & table_name)
     if (table_info.is_predefined_table)
         return;
 
-    checkQueryNotCancelled();
+    checkIsQueryCancelled();
 
     auto create_table_query = typeid_cast<std::shared_ptr<ASTCreateQuery>>(table_info.create_table_query->clone());
 
@@ -804,7 +804,7 @@ void RestorerFromBackup::insertDataToTable(const QualifiedTableName & table_name
     auto & table_info = table_infos.at(table_name);
     auto storage = table_info.storage;
 
-    checkQueryNotCancelled();
+    checkIsQueryCancelled();
 
     try
     {

--- a/src/Backups/RestorerFromBackup.cpp
+++ b/src/Backups/RestorerFromBackup.cpp
@@ -16,6 +16,7 @@
 #include <Interpreters/DatabaseCatalog.h>
 #include <Interpreters/Context.h>
 #include <Interpreters/InterpreterCreateQuery.h>
+#include <Interpreters/ProcessList.h>
 #include <Databases/IDatabase.h>
 #include <Databases/DDLDependencyVisitor.h>
 #include <Storages/IStorage.h>
@@ -85,6 +86,7 @@ RestorerFromBackup::RestorerFromBackup(
     , restore_coordination(restore_coordination_)
     , backup(backup_)
     , context(context_)
+    , process_list_element(context->getProcessListElement())
     , on_cluster_first_sync_timeout(context->getConfigRef().getUInt64("backups.on_cluster_first_sync_timeout", 180000))
     , create_table_timeout(context->getConfigRef().getUInt64("backups.create_table_timeout", 300000))
     , log(&Poco::Logger::get("RestorerFromBackup"))
@@ -138,6 +140,8 @@ RestorerFromBackup::DataRestoreTasks RestorerFromBackup::run(Mode mode)
 void RestorerFromBackup::setStage(const String & new_stage, const String & message)
 {
     LOG_TRACE(log, "Setting stage: {}", new_stage);
+    checkQueryNotCancelled();
+
     current_stage = new_stage;
 
     if (restore_coordination)
@@ -148,6 +152,12 @@ void RestorerFromBackup::setStage(const String & new_stage, const String & messa
         else
             restore_coordination->waitForStage(new_stage);
     }
+}
+
+void RestorerFromBackup::checkQueryNotCancelled() const
+{
+    if (process_list_element)
+        process_list_element->checkTimeLimit();
 }
 
 void RestorerFromBackup::findRootPathsInBackup()
@@ -563,6 +573,8 @@ void RestorerFromBackup::createDatabase(const String & database_name) const
     if (database_info.is_predefined_database)
         return;
 
+    checkQueryNotCancelled();
+
     auto create_database_query = typeid_cast<std::shared_ptr<ASTCreateQuery>>(database_info.create_database_query->clone());
 
     /// Generate a new UUID for a database.
@@ -709,6 +721,8 @@ void RestorerFromBackup::createTable(const QualifiedTableName & table_name)
     if (table_info.is_predefined_table)
         return;
 
+    checkQueryNotCancelled();
+
     auto create_table_query = typeid_cast<std::shared_ptr<ASTCreateQuery>>(table_info.create_table_query->clone());
 
     /// Generate a new UUID for a table (the same table on different hosts must use the same UUID, `restore_coordination` will make it so).
@@ -789,6 +803,8 @@ void RestorerFromBackup::insertDataToTable(const QualifiedTableName & table_name
 
     auto & table_info = table_infos.at(table_name);
     auto storage = table_info.storage;
+
+    checkQueryNotCancelled();
 
     try
     {

--- a/src/Backups/RestorerFromBackup.h
+++ b/src/Backups/RestorerFromBackup.h
@@ -111,7 +111,7 @@ private:
     void setStage(const String & new_stage, const String & message = "");
 
     /// Throws an exception if the RESTORE query was cancelled.
-    void checkQueryNotCancelled() const;
+    void checkIsQueryCancelled() const;
 
     struct DatabaseInfo
     {

--- a/src/Backups/RestorerFromBackup.h
+++ b/src/Backups/RestorerFromBackup.h
@@ -21,6 +21,8 @@ using DatabasePtr = std::shared_ptr<IDatabase>;
 class AccessRestorerFromBackup;
 struct IAccessEntity;
 using AccessEntityPtr = std::shared_ptr<const IAccessEntity>;
+class QueryStatus;
+using QueryStatusPtr = std::shared_ptr<QueryStatus>;
 
 
 /// Restores the definition of databases and tables and prepares tasks to restore the data of the tables.
@@ -74,6 +76,7 @@ private:
     std::shared_ptr<IRestoreCoordination> restore_coordination;
     BackupPtr backup;
     ContextMutablePtr context;
+    QueryStatusPtr process_list_element;
     std::chrono::milliseconds on_cluster_first_sync_timeout;
     std::chrono::milliseconds create_table_timeout;
     Poco::Logger * log;
@@ -106,6 +109,9 @@ private:
     DataRestoreTasks getDataRestoreTasks();
 
     void setStage(const String & new_stage, const String & message = "");
+
+    /// Throws an exception if the RESTORE query was cancelled.
+    void checkQueryNotCancelled() const;
 
     struct DatabaseInfo
     {

--- a/src/Backups/WithRetries.cpp
+++ b/src/Backups/WithRetries.cpp
@@ -21,10 +21,11 @@ WithRetries::KeeperSettings WithRetries::KeeperSettings::fromContext(ContextPtr 
 }
 
 WithRetries::WithRetries(
-    Poco::Logger * log_, zkutil::GetZooKeeper get_zookeeper_, const KeeperSettings & settings_, RenewerCallback callback_)
+    Poco::Logger * log_, zkutil::GetZooKeeper get_zookeeper_, const KeeperSettings & settings_, QueryStatusPtr process_list_element_, RenewerCallback callback_)
     : log(log_)
     , get_zookeeper(get_zookeeper_)
     , settings(settings_)
+    , process_list_element(process_list_element_)
     , callback(callback_)
     , global_zookeeper_retries_info(
           settings.keeper_max_retries, settings.keeper_retry_initial_backoff_ms, settings.keeper_retry_max_backoff_ms)
@@ -32,7 +33,7 @@ WithRetries::WithRetries(
 
 WithRetries::RetriesControlHolder::RetriesControlHolder(const WithRetries * parent, const String & name)
     : info(parent->global_zookeeper_retries_info)
-    , retries_ctl(name, parent->log, info, nullptr)
+    , retries_ctl(name, parent->log, info, parent->process_list_element)
     , faulty_zookeeper(parent->getFaultyZooKeeper())
 {}
 

--- a/src/Backups/WithRetries.h
+++ b/src/Backups/WithRetries.h
@@ -52,7 +52,7 @@ public:
     };
 
     RetriesControlHolder createRetriesControlHolder(const String & name);
-    WithRetries(Poco::Logger * log, zkutil::GetZooKeeper get_zookeeper_, const KeeperSettings & settings, RenewerCallback callback);
+    WithRetries(Poco::Logger * log, zkutil::GetZooKeeper get_zookeeper_, const KeeperSettings & settings, QueryStatusPtr process_list_element_, RenewerCallback callback);
 
     /// Used to re-establish new connection inside a retry loop.
     void renewZooKeeper(FaultyKeeper my_faulty_zookeeper) const;
@@ -65,6 +65,8 @@ private:
     Poco::Logger * log;
     zkutil::GetZooKeeper get_zookeeper;
     KeeperSettings settings;
+    QueryStatusPtr process_list_element;
+
     /// This callback is called each time when a new [Zoo]Keeper session is created.
     /// In backups it is primarily used to re-create an ephemeral node to signal the coordinator
     /// that the host is alive and able to continue writing the backup.

--- a/src/Core/ServerSettings.h
+++ b/src/Core/ServerSettings.h
@@ -40,6 +40,7 @@ namespace DB
     M(UInt64, backup_threads, 16, "The maximum number of threads to execute BACKUP requests.", 0) \
     M(UInt64, max_backup_bandwidth_for_server, 0, "The maximum read speed in bytes per second for all backups on server. Zero means unlimited.", 0) \
     M(UInt64, restore_threads, 16, "The maximum number of threads to execute RESTORE requests.", 0) \
+    M(Bool, shutdown_wait_backups_and_restores, true, "If set to true ClickHouse will wait for running backups and restores to finish before shutdown.", 0) \
     M(Int32, max_connections, 1024, "Max server connections.", 0) \
     M(UInt32, asynchronous_metrics_update_period_s, 1, "Period in seconds for updating asynchronous metrics.", 0) \
     M(UInt32, asynchronous_heavy_metrics_update_period_s, 120, "Period in seconds for updating heavy asynchronous metrics.", 0) \

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -2547,6 +2547,12 @@ BackupsWorker & Context::getBackupsWorker() const
     return *shared->backups_worker;
 }
 
+void Context::waitAllBackupsAndRestores() const
+{
+    if (shared->backups_worker)
+        shared->backups_worker->waitAll();
+}
+
 
 void Context::setProgressCallback(ProgressCallback callback)
 {

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -2535,12 +2535,13 @@ BackupsWorker & Context::getBackupsWorker() const
         const auto & config = getConfigRef();
         const bool allow_concurrent_backups = config.getBool("backups.allow_concurrent_backups", true);
         const bool allow_concurrent_restores = config.getBool("backups.allow_concurrent_restores", true);
+        const bool test_inject_sleep = config.getBool("backups.test_inject_sleep", false);
 
         const auto & settings_ref = getSettingsRef();
         UInt64 backup_threads = config.getUInt64("backup_threads", settings_ref.backup_threads);
         UInt64 restore_threads = config.getUInt64("restore_threads", settings_ref.restore_threads);
 
-        shared->backups_worker.emplace(getGlobalContext(), backup_threads, restore_threads, allow_concurrent_backups, allow_concurrent_restores);
+        shared->backups_worker.emplace(getGlobalContext(), backup_threads, restore_threads, allow_concurrent_backups, allow_concurrent_restores, test_inject_sleep);
     });
 
     return *shared->backups_worker;

--- a/src/Interpreters/Context.h
+++ b/src/Interpreters/Context.h
@@ -817,6 +817,7 @@ public:
 #endif
 
     BackupsWorker & getBackupsWorker() const;
+    void waitAllBackupsAndRestores() const;
 
     /// I/O formats.
     InputFormatPtr getInputFormat(const String & name, ReadBuffer & buf, const Block & sample, UInt64 max_block_size,

--- a/src/Interpreters/ProcessList.h
+++ b/src/Interpreters/ProcessList.h
@@ -118,6 +118,11 @@ protected:
     /// Be careful using it. For example, queries field of ProcessListForUser could be modified concurrently.
     const ProcessListForUser * getUserProcessList() const { return user_process_list; }
 
+    /// Sets an entry in the ProcessList associated with this QueryStatus.
+    /// Be careful using it (this function contains no synchronization).
+    /// A weak pointer is used here because it's a ProcessListEntry which owns this QueryStatus, and not vice versa.
+    void setProcessListEntry(std::weak_ptr<ProcessListEntry> process_list_entry_);
+
     mutable std::mutex executors_mutex;
 
     struct ExecutorHolder
@@ -147,6 +152,8 @@ protected:
     QueryStreamsStatus query_streams_status{NotInitialized};
 
     ProcessListForUser * user_process_list = nullptr;
+
+    std::weak_ptr<ProcessListEntry> process_list_entry;
 
     OvercommitTracker * global_overcommit_tracker = nullptr;
 
@@ -218,6 +225,9 @@ public:
     CancellationCode cancelQuery(bool kill);
 
     bool isKilled() const { return is_killed; }
+
+    /// Returns an entry in the ProcessList associated with this QueryStatus. The function can return nullptr.
+    std::shared_ptr<ProcessListEntry> getProcessListEntry() const;
 
     bool isAllDataSent() const { return is_all_data_sent; }
     void setAllDataSent() { is_all_data_sent = true; }

--- a/src/Interpreters/ProcessList.h
+++ b/src/Interpreters/ProcessList.h
@@ -460,6 +460,7 @@ public:
 
     /// Try call cancel() for input and output streams of query with specified id and user
     CancellationCode sendCancelToQuery(const String & current_query_id, const String & current_user, bool kill = false);
+    CancellationCode sendCancelToQuery(QueryStatusPtr elem, bool kill = false);
 
     void killAllQueries();
 };

--- a/src/Storages/StorageKeeperMap.cpp
+++ b/src/Storages/StorageKeeperMap.cpp
@@ -779,6 +779,7 @@ void StorageKeeperMap::backupData(BackupEntriesCollector & backup_entries_collec
             &Poco::Logger::get(fmt::format("StorageKeeperMapBackup ({})", getStorageID().getNameForLogs())),
             [&] { return getClient(); },
             WithRetries::KeeperSettings::fromContext(backup_entries_collector.getContext()),
+            backup_entries_collector.getContext()->getProcessListElement(),
             [](WithRetries::FaultyKeeper &) {}
         );
 
@@ -810,6 +811,7 @@ void StorageKeeperMap::restoreDataFromBackup(RestorerFromBackup & restorer, cons
         &Poco::Logger::get(fmt::format("StorageKeeperMapRestore ({})", getStorageID().getNameForLogs())),
         [&] { return getClient(); },
         WithRetries::KeeperSettings::fromContext(restorer.getContext()),
+        restorer.getContext()->getProcessListElement(),
         [](WithRetries::FaultyKeeper &) {}
     );
 

--- a/tests/integration/test_backup_restore_new/configs/shutdown_cancel_backups.xml
+++ b/tests/integration/test_backup_restore_new/configs/shutdown_cancel_backups.xml
@@ -1,0 +1,3 @@
+<clickhouse>
+    <shutdown_wait_backups_and_restores>false</shutdown_wait_backups_and_restores>
+</clickhouse>

--- a/tests/integration/test_backup_restore_new/configs/slow_backups.xml
+++ b/tests/integration/test_backup_restore_new/configs/slow_backups.xml
@@ -1,0 +1,7 @@
+<clickhouse>
+    <backups>
+        <test_inject_sleep>true</test_inject_sleep>
+    </backups>
+    <backup_threads>2</backup_threads>
+    <restore_threads>2</restore_threads>
+</clickhouse>

--- a/tests/integration/test_backup_restore_new/test_cancel_backup.py
+++ b/tests/integration/test_backup_restore_new/test_cancel_backup.py
@@ -83,7 +83,7 @@ def cancel_backup(backup_id):
     )
     assert (
         node.query(f"SELECT status FROM system.backups WHERE id='{backup_id}'")
-        == "BACKUP_FAILED\n"
+        == "BACKUP_CANCELLED\n"
     )
     expected_error = "QUERY_WAS_CANCELLED"
     assert expected_error in node.query(
@@ -149,7 +149,7 @@ def cancel_restore(restore_id):
     )
     assert (
         node.query(f"SELECT status FROM system.backups WHERE id='{restore_id}'")
-        == "RESTORE_FAILED\n"
+        == "RESTORE_CANCELLED\n"
     )
     expected_error = "QUERY_WAS_CANCELLED"
     assert expected_error in node.query(

--- a/tests/integration/test_backup_restore_new/test_cancel_backup.py
+++ b/tests/integration/test_backup_restore_new/test_cancel_backup.py
@@ -1,0 +1,199 @@
+import pytest
+from helpers.cluster import ClickHouseCluster
+from helpers.test_tools import TSV, assert_eq_with_retry
+import uuid
+
+
+cluster = ClickHouseCluster(__file__)
+
+main_configs = [
+    "configs/backups_disk.xml",
+    "configs/slow_backups.xml",
+]
+
+node = cluster.add_instance(
+    "node",
+    main_configs=main_configs,
+    external_dirs=["/backups/"],
+)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def start_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+@pytest.fixture(autouse=True)
+def drop_after_test():
+    try:
+        yield
+    finally:
+        node.query("DROP TABLE IF EXISTS tbl SYNC")
+
+
+# Generate the backup name.
+def get_backup_name(backup_id):
+    return f"Disk('backups', '{backup_id}')"
+
+
+# Start making a backup asynchronously.
+def start_backup(backup_id):
+    node.query(
+        f"BACKUP TABLE tbl TO {get_backup_name(backup_id)} SETTINGS id='{backup_id}' ASYNC"
+    )
+
+    assert (
+        node.query(f"SELECT status FROM system.backups WHERE id='{backup_id}'")
+        == "CREATING_BACKUP\n"
+    )
+    assert (
+        node.query(
+            f"SELECT count() FROM system.processes WHERE query_kind='Backup' AND query LIKE '%{backup_id}%'"
+        )
+        == "1\n"
+    )
+
+
+# Wait for the backup to be completed.
+def wait_backup(backup_id):
+    assert_eq_with_retry(
+        node,
+        f"SELECT status FROM system.backups WHERE id='{backup_id}'",
+        "BACKUP_CREATED",
+        retry_count=60,
+        sleep_time=5,
+    )
+
+    backup_duration = int(
+        node.query(
+            f"SELECT end_time - start_time FROM system.backups WHERE id='{backup_id}'"
+        )
+    )
+    assert backup_duration >= 3  # Backup is not expected to be too quick in this test.
+
+
+# Cancel the specified backup.
+def cancel_backup(backup_id):
+    node.query(
+        f"KILL QUERY WHERE query_kind='Backup' AND query LIKE '%{backup_id}%' SYNC"
+    )
+    assert (
+        node.query(f"SELECT status FROM system.backups WHERE id='{backup_id}'")
+        == "BACKUP_FAILED\n"
+    )
+    expected_error = "QUERY_WAS_CANCELLED"
+    assert expected_error in node.query(
+        f"SELECT error FROM system.backups WHERE id='{backup_id}'"
+    )
+    assert (
+        node.query(
+            f"SELECT count() FROM system.processes WHERE query_kind='Backup' AND query LIKE '%{backup_id}%'"
+        )
+        == "0\n"
+    )
+    node.query("SYSTEM FLUSH LOGS")
+    kill_duration_ms = int(
+        node.query(
+            f"SELECT query_duration_ms FROM system.query_log WHERE query_kind='KillQuery' AND query LIKE '%{backup_id}%' AND type='QueryFinish'"
+        )
+    )
+    assert kill_duration_ms < 2000  # Query must be cancelled quickly
+
+
+# Start restoring from a backup.
+def start_restore(restore_id, backup_id):
+    node.query(
+        f"RESTORE TABLE tbl FROM {get_backup_name(backup_id)} SETTINGS id='{restore_id}' ASYNC"
+    )
+
+    assert (
+        node.query(f"SELECT status FROM system.backups WHERE id='{restore_id}'")
+        == "RESTORING\n"
+    )
+    assert (
+        node.query(
+            f"SELECT count() FROM system.processes WHERE query_kind='Restore' AND query LIKE '%{restore_id}%'"
+        )
+        == "1\n"
+    )
+
+
+# Wait for the restore operation to be completed.
+def wait_restore(restore_id):
+    assert_eq_with_retry(
+        node,
+        f"SELECT status FROM system.backups WHERE id='{restore_id}'",
+        "RESTORED",
+        retry_count=60,
+        sleep_time=5,
+    )
+
+    restore_duration = int(
+        node.query(
+            f"SELECT end_time - start_time FROM system.backups WHERE id='{restore_id}'"
+        )
+    )
+    assert (
+        restore_duration >= 3
+    )  # Restore is not expected to be too quick in this test.
+
+
+# Cancel the specified restore operation.
+def cancel_restore(restore_id):
+    node.query(
+        f"KILL QUERY WHERE query_kind='Restore' AND query LIKE '%{restore_id}%' SYNC"
+    )
+    assert (
+        node.query(f"SELECT status FROM system.backups WHERE id='{restore_id}'")
+        == "RESTORE_FAILED\n"
+    )
+    expected_error = "QUERY_WAS_CANCELLED"
+    assert expected_error in node.query(
+        f"SELECT error FROM system.backups WHERE id='{restore_id}'"
+    )
+    assert (
+        node.query(
+            f"SELECT count() FROM system.processes WHERE query_kind='Restore' AND query LIKE '%{restore_id}%'"
+        )
+        == "0\n"
+    )
+    node.query("SYSTEM FLUSH LOGS")
+    kill_duration_ms = int(
+        node.query(
+            f"SELECT query_duration_ms FROM system.query_log WHERE query_kind='KillQuery' AND query LIKE '%{restore_id}%' AND type='QueryFinish'"
+        )
+    )
+    assert kill_duration_ms < 2000  # Query must be cancelled quickly
+
+
+def test_cancel_backup():
+    # We use partitioning so backups would contain more files.
+    node.query(
+        "CREATE TABLE tbl (x UInt64) ENGINE=MergeTree() ORDER BY tuple() PARTITION BY x%5"
+    )
+
+    node.query(f"INSERT INTO tbl SELECT number FROM numbers(500)")
+
+    try_backup_id_1 = uuid.uuid4().hex
+    start_backup(try_backup_id_1)
+    cancel_backup(try_backup_id_1)
+
+    backup_id = uuid.uuid4().hex
+    start_backup(backup_id)
+    wait_backup(backup_id)
+
+    node.query(f"DROP TABLE tbl SYNC")
+
+    try_restore_id_1 = uuid.uuid4().hex
+    start_restore(try_restore_id_1, backup_id)
+    cancel_restore(try_restore_id_1)
+
+    node.query(f"DROP TABLE tbl SYNC")
+
+    restore_id = uuid.uuid4().hex
+    start_restore(restore_id, backup_id)
+    wait_restore(restore_id)

--- a/tests/integration/test_backup_restore_new/test_shutdown_wait_backup.py
+++ b/tests/integration/test_backup_restore_new/test_shutdown_wait_backup.py
@@ -1,0 +1,82 @@
+import pytest
+from helpers.cluster import ClickHouseCluster
+from helpers.test_tools import TSV, assert_eq_with_retry
+import uuid
+
+
+cluster = ClickHouseCluster(__file__)
+
+main_configs = [
+    "configs/backups_disk.xml",
+    "configs/slow_backups.xml",
+]
+
+node = cluster.add_instance(
+    "node",
+    main_configs=main_configs,
+    external_dirs=["/backups/"],
+    stay_alive=True,
+)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def start_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+@pytest.fixture(autouse=True)
+def drop_after_test():
+    try:
+        yield
+    finally:
+        node.query("DROP TABLE IF EXISTS tbl SYNC")
+
+
+# Generate the backup name.
+def get_backup_name(backup_id):
+    return f"Disk('backups', '{backup_id}')"
+
+
+# Start making a backup asynchronously.
+def start_backup(backup_id):
+    node.query(
+        f"BACKUP TABLE tbl TO {get_backup_name(backup_id)} SETTINGS id='{backup_id}' ASYNC"
+    )
+
+    assert (
+        node.query(f"SELECT status FROM system.backups WHERE id='{backup_id}'")
+        == "CREATING_BACKUP\n"
+    )
+    assert (
+        node.query(
+            f"SELECT count() FROM system.processes WHERE query_kind='Backup' AND query LIKE '%{backup_id}%'"
+        )
+        == "1\n"
+    )
+
+
+# Test that shutdown doesn't cancel a running backup and waits until it finishes.
+def test_shutdown_wait_backup():
+    node.query(
+        "CREATE TABLE tbl (x UInt64) ENGINE=MergeTree() ORDER BY tuple() PARTITION BY x%5"
+    )
+
+    node.query(f"INSERT INTO tbl SELECT number FROM numbers(500)")
+
+    backup_id = uuid.uuid4().hex
+    start_backup(backup_id)
+
+    node.restart_clickhouse()  # Must wait for the backup.
+
+    # The information about this backup must be stored in system.backup_log
+    assert node.query(
+        f"SELECT status FROM system.backup_log WHERE id='{backup_id}' ORDER BY status"
+    ) == TSV(["CREATING_BACKUP", "BACKUP_CREATED"])
+
+    # The table can be restored from this backup.
+    node.query("DROP TABLE tbl SYNC")
+    node.query(f"RESTORE TABLE tbl FROM {get_backup_name(backup_id)}")


### PR DESCRIPTION
### Changelog category:
- Improvement

### Changelog entry:
Allow `KILL QUERY` to cancel backups / restores. This PR also makes running backups and restores visible in `system.processes`. Also there is a new setting in the server configuration now - `shutdown_wait_backups_and_restores` (default=true) which makes the server either wait on shutdown for all running backups and restores to finish or just cancel them.