### PR TITLE
Added MemoryDumpCollector

### DIFF
--- a/programs/server/config.xml
+++ b/programs/server/config.xml
@@ -1084,6 +1084,21 @@
         <flush_on_crash>false</flush_on_crash>
     </trace_log>
 
+    <!-- MemoryDump log. Stores allocations from whole process collected by memory dumper.
+        See enable_memory_dump_collector and memory_dump_interval_ms settings. -->
+    <memory_dump_log>
+        <database>system</database>
+        <table>memory_dump_log</table>
+
+        <partition_by>toYYYYMM(event_date)</partition_by>
+        <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+        <max_size_rows>1048576</max_size_rows>
+        <reserved_size_rows>8192</reserved_size_rows>
+        <buffer_size_rows_flush_threshold>524288</buffer_size_rows_flush_threshold>
+        <!-- Indication whether logs should be dumped to the disk in case of a crash -->
+        <flush_on_crash>false</flush_on_crash>
+    </memory_dump_log>
+
     <!-- Query thread log. Has information about all threads participated in query execution.
          Used only for queries with setting log_query_threads = 1. -->
     <query_thread_log>

--- a/src/Common/AllocationTrace.h
+++ b/src/Common/AllocationTrace.h
@@ -1,4 +1,5 @@
 #pragma once
+
 #include <cstddef>
 #include <base/defines.h>
 
@@ -8,11 +9,12 @@
 struct AllocationTrace
 {
     AllocationTrace() = default;
-    explicit AllocationTrace(double sample_probability_) : sample_probability(sample_probability_) {}
+
+    explicit AllocationTrace(double sample_probability_);
 
     ALWAYS_INLINE void onAlloc(void * ptr, size_t size) const
     {
-        if (likely(sample_probability <= 0))
+        if (likely(sample_probability <= 0 && memory_dumper_enabled == false))
             return;
 
         onAllocImpl(ptr, size);
@@ -20,15 +22,18 @@ struct AllocationTrace
 
     ALWAYS_INLINE void onFree(void * ptr, size_t size) const
     {
-        if (likely(sample_probability <= 0))
+        if (likely(sample_probability <= 0 && memory_dumper_enabled == false))
             return;
 
         onFreeImpl(ptr, size);
     }
 
 private:
+    void onAllocImpl(void * ptr, size_t size) const;
+
+    void onFreeImpl(void * ptr, size_t size) const;
+
     double sample_probability = 0;
 
-    void onAllocImpl(void * ptr, size_t size) const;
-    void onFreeImpl(void * ptr, size_t size) const;
+    bool memory_dumper_enabled = false;
 };

--- a/src/Common/MemoryDumper.cpp
+++ b/src/Common/MemoryDumper.cpp
@@ -1,0 +1,85 @@
+#include "MemoryDumper.h"
+
+#include <Common/MemoryTrackerBlockerInThread.h>
+
+MemoryDumper & MemoryDumper::instance()
+{
+    static MemoryDumper detector;
+    return detector;
+};
+
+bool MemoryDumper::isEnabled() const
+{
+    return enabled.load(std::memory_order_acquire);
+}
+
+void MemoryDumper::enable()
+{
+    enabled.store(true, std::memory_order_release);
+}
+
+void MemoryDumper::disable()
+{
+    enabled.store(false, std::memory_order_release);
+}
+
+void MemoryDumper::onAllocation(void * ptr, size_t size)
+{
+    if (!enabled.load(std::memory_order_acquire))
+        return;
+
+    MemoryTrackerBlockerInThread untrack_lock(VariableContext::Global);
+
+    String query_id;
+    UInt64 thread_id;
+
+    if (DB::CurrentThread::isInitialized())
+    {
+        query_id = DB::CurrentThread::getQueryId();
+        thread_id = DB::CurrentThread::get().thread_id;
+    }
+    else
+    {
+        thread_id = DB::MainThreadStatus::get()->thread_id;
+    }
+
+    StackTrace trace;
+
+    uint64_t raw_ptr = reinterpret_cast<uint64_t>(ptr);
+    size_t hash_map_index = intHash64(raw_ptr) % TwoLevelHashMapSize;
+    auto & allocation_hash_map = allocation_two_level_hash_map[hash_map_index];
+    std::lock_guard<std::mutex> lock(allocation_hash_map.mutex);
+    if (!allocation_hash_map.ptr_to_allocation)
+        allocation_hash_map.ptr_to_allocation.emplace();
+
+    auto memory_allocation_entry = makePairNoInit(ptr, MemoryAllocation{thread_id, std::move(query_id), raw_ptr, size, std::move(trace)});
+    allocation_hash_map.ptr_to_allocation->insert(memory_allocation_entry);
+}
+
+void MemoryDumper::onDeallocation(void * ptr, size_t)
+{
+    if (!enabled.load(std::memory_order_acquire))
+        return;
+
+    size_t hash_map_index = intHash64(reinterpret_cast<uint64_t>(ptr)) % TwoLevelHashMapSize;
+    auto & allocation_hash_map = allocation_two_level_hash_map[hash_map_index];
+    std::lock_guard<std::mutex> lock(allocation_hash_map.mutex);
+    if (!allocation_hash_map.ptr_to_allocation)
+        return;
+
+    allocation_hash_map.ptr_to_allocation->erase(ptr);
+}
+
+void MemoryDumper::dump(std::vector<MemoryAllocation> & result_memory_allocations)
+{
+    MemoryTrackerBlockerInThread untrack_lock(VariableContext::Global);
+    for (auto & allocation_hash_map : allocation_two_level_hash_map)
+    {
+        std::lock_guard<std::mutex> lock(allocation_hash_map.mutex);
+        if (!allocation_hash_map.ptr_to_allocation)
+            allocation_hash_map.ptr_to_allocation.emplace();
+
+        for (auto & [key, value] : *allocation_hash_map.ptr_to_allocation)
+            result_memory_allocations.push_back(value);
+    }
+}

--- a/src/Common/MemoryDumper.h
+++ b/src/Common/MemoryDumper.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <atomic>
+#include <mutex>
+
+#include <base/types.h>
+#include <Common/StackTrace.h>
+#include <Common/HashTable/HashMap.h>
+
+struct MemoryAllocation
+{
+    UInt64 thread_id;
+    String query_id;
+    UInt64 ptr;
+    size_t size = 0;
+    StackTrace stack_trace;
+};
+
+class MemoryDumper
+{
+public:
+    static MemoryDumper & instance();
+
+    bool isEnabled() const;
+
+    void enable();
+
+    void disable();
+
+    void onAllocation(void * ptr, size_t size);
+
+    void onDeallocation(void * ptr, size_t size);
+
+    void dump(std::vector<MemoryAllocation> & result_memory_allocations);
+
+    MemoryDumper() = default;
+
+private:
+    std::atomic<bool> enabled = false;
+
+    std::string dump_file_name;
+
+    struct AllocationHashMap
+    {
+        std::mutex mutex;
+        /// Initialize hash map lazily to avoid abort during recursive initialization
+        std::optional<HashMap<void *, MemoryAllocation>> ptr_to_allocation;
+    };
+
+    static constexpr size_t TwoLevelHashMapSize = 512;
+    std::array<AllocationHashMap, TwoLevelHashMapSize> allocation_two_level_hash_map;
+};

--- a/src/Common/MemoryTrackerBlockerInThread.h
+++ b/src/Common/MemoryTrackerBlockerInThread.h
@@ -29,4 +29,5 @@ public:
 
     friend class MemoryTracker;
     friend struct AllocationTrace;
+    friend class MemoryDumper;
 };

--- a/src/Common/SystemLogBase.cpp
+++ b/src/Common/SystemLogBase.cpp
@@ -17,6 +17,7 @@
 #include <Interpreters/TransactionsInfoLog.h>
 #include <Interpreters/AsynchronousInsertLog.h>
 #include <Interpreters/BackupLog.h>
+#include <Interpreters/MemoryDumpLog.h>
 #include <IO/S3/BlobStorageLogWriter.h>
 
 #include <Common/MemoryTrackerBlockerInThread.h>

--- a/src/Common/SystemLogBase.h
+++ b/src/Common/SystemLogBase.h
@@ -32,7 +32,8 @@
     M(FilesystemReadPrefetchesLogElement) \
     M(AsynchronousInsertLogElement) \
     M(BackupLogElement) \
-    M(BlobStorageLogElement)
+    M(BlobStorageLogElement) \
+    M(MemoryDumpLogElement)
 
 namespace Poco
 {

--- a/src/Core/ServerSettings.h
+++ b/src/Core/ServerSettings.h
@@ -114,6 +114,8 @@ namespace DB
     M(Bool, validate_tcp_client_information, false, "Validate client_information in the query packet over the native TCP protocol.", 0) \
     M(Bool, storage_metadata_write_full_object_key, false, "Write disk metadata files with VERSION_FULL_OBJECT_KEY format", 0) \
     M(UInt64, max_materialized_views_count_for_table, 0, "A limit on the number of materialized views attached to a table.", 0) \
+    M(Bool, enable_memory_dump_collector, false, "Enable periodic with `memory_dump_interval_ms` interval memory dump collection.", 0) \
+    M(UInt64, memory_dump_interval_ms, 15000UL, "Interval for memory dump collection (in milliseconds).", 0) \
 
     /// If you add a setting which can be updated at runtime, please update 'changeable_settings' map in StorageSystemServerSettings.cpp
 

--- a/src/Interpreters/Context.h
+++ b/src/Interpreters/Context.h
@@ -96,6 +96,7 @@ class QueryViewsLog;
 class PartLog;
 class TextLog;
 class TraceLog;
+class MemoryDumpLog;
 class MetricLog;
 class AsynchronousMetricLog;
 class OpenTelemetrySpanLog;
@@ -1040,16 +1041,22 @@ public:
     /// Call after initialization before using trace collector.
     void initializeTraceCollector();
 
+    /// Call after initialization before using memory dump collector.
+    void initializeMemoryDumpCollector(UInt64 memory_dump_interval_ms);
+
     /// Call after unexpected crash happen.
     void handleCrash() const;
 
     bool hasTraceCollector() const;
+
+    bool hasMemoryDumpCollector() const;
 
     /// Nullptr if the query log is not ready for this moment.
     std::shared_ptr<QueryLog> getQueryLog() const;
     std::shared_ptr<QueryThreadLog> getQueryThreadLog() const;
     std::shared_ptr<QueryViewsLog> getQueryViewsLog() const;
     std::shared_ptr<TraceLog> getTraceLog() const;
+    std::shared_ptr<MemoryDumpLog> getMemoryDumpLog() const;
     std::shared_ptr<TextLog> getTextLog() const;
     std::shared_ptr<MetricLog> getMetricLog() const;
     std::shared_ptr<AsynchronousMetricLog> getAsynchronousMetricLog() const;

--- a/src/Interpreters/MemoryDumpCollector.cpp
+++ b/src/Interpreters/MemoryDumpCollector.cpp
@@ -1,0 +1,91 @@
+#include "MemoryDumpCollector.h"
+
+#include <Core/Field.h>
+#include <Interpreters/MemoryDumpLog.h>
+#include <Common/logger_useful.h>
+#include <Common/setThreadName.h>
+#include <Common/MemoryDumper.h>
+
+
+namespace DB
+{
+
+MemoryDumpCollector::MemoryDumpCollector(std::shared_ptr<MemoryDumpLog> memory_dump_log_, UInt64 memory_dump_interval_ms_)
+    : memory_dump_log(std::move(memory_dump_log_))
+    , memory_dump_interval_ms(memory_dump_interval_ms_)
+    , thread(ThreadFromGlobalPool(&MemoryDumpCollector::run, this))
+{
+    chassert(memory_dump_log);
+}
+
+MemoryDumpCollector::~MemoryDumpCollector()
+{
+    {
+        std::lock_guard<std::mutex> lock(cond_mutex);
+        stopped.store(true, std::memory_order_relaxed);
+    }
+
+    cond.notify_one();
+
+    if (thread.joinable())
+        thread.join();
+    else
+        LOG_ERROR(&Poco::Logger::get("MemoryDumpCollector"), "MemoryDumpCollector thread is malformed and cannot be joined");
+}
+
+void MemoryDumpCollector::run()
+{
+    setThreadName("MemoryDumper");
+
+    std::vector<MemoryAllocation> result_memory_allocations;
+
+    while (!stopped.load(std::memory_order_acquire))
+    {
+        {
+            std::unique_lock<std::mutex> lock(cond_mutex);
+            cond.wait_for(lock, std::chrono::milliseconds(memory_dump_interval_ms), [&]()
+            {
+                return stopped.load(std::memory_order_relaxed);
+            });
+        }
+
+        if (stopped.load(std::memory_order_acquire))
+            return;
+
+        result_memory_allocations.clear();
+        MemoryDumper::instance().dump(result_memory_allocations);
+
+        LOG_TRACE(&Poco::Logger::get("MemoryDumpCollector"), "Dump {} allocations", result_memory_allocations.size());
+
+        // time and time_in_microseconds are both being constructed from the same timespec so that the
+        // times will be equal up to the precision of a second.
+        struct timespec ts;
+        clock_gettime(CLOCK_REALTIME, &ts);
+
+        UInt64 time = static_cast<UInt64>(ts.tv_sec * 1000000000LL + ts.tv_nsec);
+        UInt64 time_in_microseconds = static_cast<UInt64>((ts.tv_sec * 1000000LL) + (ts.tv_nsec / 1000));
+
+        for (auto & memory_allocation : result_memory_allocations)
+        {
+            size_t stack_trace_size = memory_allocation.stack_trace.getSize();
+            size_t stack_trace_offset = memory_allocation.stack_trace.getOffset();
+
+            Array trace;
+            for (size_t i = stack_trace_offset; i < stack_trace_size; ++i)
+                trace.push_back(reinterpret_cast<uintptr_t>(memory_allocation.stack_trace.getFramePointers()[i]));
+
+            MemoryDumpLogElement element{time_t(time / 1000000000),
+                time_in_microseconds,
+                time,
+                memory_allocation.thread_id,
+                memory_allocation.query_id,
+                std::move(trace),
+                memory_allocation.size,
+                memory_allocation.ptr};
+
+            memory_dump_log->add(std::move(element));
+        }
+    }
+}
+
+}

--- a/src/Interpreters/MemoryDumpCollector.h
+++ b/src/Interpreters/MemoryDumpCollector.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <Common/ThreadPool.h>
+
+namespace DB
+{
+
+class MemoryDumpLog;
+
+class MemoryDumpCollector
+{
+public:
+    explicit MemoryDumpCollector(std::shared_ptr<MemoryDumpLog> memory_dump_log_, UInt64 memory_dump_interval_ms_);
+
+    ~MemoryDumpCollector();
+
+private:
+    std::shared_ptr<MemoryDumpLog> memory_dump_log;
+
+    UInt64 memory_dump_interval_ms;
+
+    ThreadFromGlobalPool thread;
+
+    std::condition_variable cond;
+    std::mutex cond_mutex;
+    std::atomic<bool> stopped{false};
+
+    void run();
+};
+
+}

--- a/src/Interpreters/MemoryDumpLog.cpp
+++ b/src/Interpreters/MemoryDumpLog.cpp
@@ -13,9 +13,9 @@
 namespace DB
 {
 
-NamesAndTypesList MemoryDumpLogElement::getNamesAndTypes()
+ColumnsDescription MemoryDumpLogElement::getColumnsDescription()
 {
-    return
+    return ColumnsDescription
     {
         {"hostname", std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeString>())},
         {"event_date", std::make_shared<DataTypeDate>()},

--- a/src/Interpreters/MemoryDumpLog.cpp
+++ b/src/Interpreters/MemoryDumpLog.cpp
@@ -1,0 +1,49 @@
+#include <base/getFQDNOrHostName.h>
+#include <Interpreters/MemoryDumpLog.h>
+#include <DataTypes/DataTypeArray.h>
+#include <DataTypes/DataTypeString.h>
+#include <DataTypes/DataTypesNumber.h>
+#include <DataTypes/DataTypeDate.h>
+#include <DataTypes/DataTypeDateTime.h>
+#include <DataTypes/DataTypeDateTime64.h>
+#include <DataTypes/DataTypeLowCardinality.h>
+#include <Common/ClickHouseRevision.h>
+
+
+namespace DB
+{
+
+NamesAndTypesList MemoryDumpLogElement::getNamesAndTypes()
+{
+    return
+    {
+        {"hostname", std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeString>())},
+        {"event_date", std::make_shared<DataTypeDate>()},
+        {"event_time", std::make_shared<DataTypeDateTime>()},
+        {"event_time_microseconds", std::make_shared<DataTypeDateTime64>(6)},
+        {"revision", std::make_shared<DataTypeUInt32>()},
+        {"thread_id", std::make_shared<DataTypeUInt64>()},
+        {"query_id", std::make_shared<DataTypeString>()},
+        {"trace", std::make_shared<DataTypeArray>(std::make_shared<DataTypeUInt64>())},
+        {"size", std::make_shared<DataTypeInt64>()},
+        {"ptr", std::make_shared<DataTypeUInt64>()},
+    };
+}
+
+void MemoryDumpLogElement::appendToBlock(MutableColumns & columns) const
+{
+    size_t i = 0;
+
+    columns[i++]->insert(getFQDNOrHostName());
+    columns[i++]->insert(DateLUT::instance().toDayNum(event_time).toUnderType());
+    columns[i++]->insert(event_time);
+    columns[i++]->insert(event_time_microseconds);
+    columns[i++]->insert(ClickHouseRevision::getVersionRevision());
+    columns[i++]->insert(thread_id);
+    columns[i++]->insertData(query_id.data(), query_id.size());
+    columns[i++]->insert(trace);
+    columns[i++]->insert(size);
+    columns[i++]->insert(ptr);
+}
+
+}

--- a/src/Interpreters/MemoryDumpLog.h
+++ b/src/Interpreters/MemoryDumpLog.h
@@ -4,7 +4,7 @@
 #include <Core/Field.h>
 #include <Core/NamesAndTypes.h>
 #include <Core/NamesAndAliases.h>
-
+#include <Storages/ColumnsDescription.h>
 
 namespace DB
 {
@@ -21,7 +21,7 @@ struct MemoryDumpLogElement
     UInt64 ptr{};
 
     static std::string name() { return "MemoryDumpLog"; }
-    static NamesAndTypesList getNamesAndTypes();
+    static ColumnsDescription getColumnsDescription();
     static NamesAndAliases getNamesAndAliases() { return {}; }
     void appendToBlock(MutableColumns & columns) const;
     static const char * getCustomColumnList() { return nullptr; }

--- a/src/Interpreters/MemoryDumpLog.h
+++ b/src/Interpreters/MemoryDumpLog.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <Interpreters/SystemLog.h>
+#include <Core/Field.h>
+#include <Core/NamesAndTypes.h>
+#include <Core/NamesAndAliases.h>
+
+
+namespace DB
+{
+
+struct MemoryDumpLogElement
+{
+    time_t event_time{};
+    Decimal64 event_time_microseconds{};
+    UInt64 timestamp_ns{};
+    UInt64 thread_id{};
+    String query_id{};
+    Array trace{};
+    UInt64 size{};
+    UInt64 ptr{};
+
+    static std::string name() { return "MemoryDumpLog"; }
+    static NamesAndTypesList getNamesAndTypes();
+    static NamesAndAliases getNamesAndAliases() { return {}; }
+    void appendToBlock(MutableColumns & columns) const;
+    static const char * getCustomColumnList() { return nullptr; }
+};
+
+class MemoryDumpLog : public SystemLog<MemoryDumpLogElement>
+{
+    using SystemLog<MemoryDumpLogElement>::SystemLog;
+};
+
+}

--- a/src/Interpreters/SystemLog.cpp
+++ b/src/Interpreters/SystemLog.cpp
@@ -23,6 +23,7 @@
 #include <Interpreters/S3QueueLog.h>
 #include <Interpreters/ZooKeeperLog.h>
 #include <Interpreters/BackupLog.h>
+#include <Interpreters/MemoryDumpLog.h>
 #include <Parsers/ASTCreateQuery.h>
 #include <Parsers/ASTFunction.h>
 #include <Parsers/ASTIndexDeclaration.h>
@@ -300,6 +301,7 @@ SystemLogs::SystemLogs(ContextPtr global_context, const Poco::Util::AbstractConf
     backup_log = createSystemLog<BackupLog>(global_context, "system", "backup_log", config, "backup_log", "Contains logging entries with the information about BACKUP and RESTORE operations.");
     s3_queue_log = createSystemLog<S3QueueLog>(global_context, "system", "s3queue_log", config, "s3queue_log", "Contains logging entries with the information files processes by S3Queue engine.");
     blob_storage_log = createSystemLog<BlobStorageLog>(global_context, "system", "blob_storage_log", config, "blob_storage_log", "Contains logging entries with information about various blob storage operations such as uploads and deletes.");
+    memory_dump_log = createSystemLog<MemoryDumpLog>(global_context, "system", "memory_dump_log", config, "memory_dump_log", "Contains memory dumps collected by memory dump collector.");
 
     if (query_log)
         logs.emplace_back(query_log.get());
@@ -344,6 +346,8 @@ SystemLogs::SystemLogs(ContextPtr global_context, const Poco::Util::AbstractConf
         logs.emplace_back(s3_queue_log.get());
     if (blob_storage_log)
         logs.emplace_back(blob_storage_log.get());
+    if (memory_dump_log)
+        logs.emplace_back(memory_dump_log.get());
 
     try
     {

--- a/src/Interpreters/SystemLog.h
+++ b/src/Interpreters/SystemLog.h
@@ -52,6 +52,7 @@ class AsynchronousInsertLog;
 class BackupLog;
 class S3QueueLog;
 class BlobStorageLog;
+class MemoryDumpLog;
 
 /// System logs should be destroyed in destructor of the last Context and before tables,
 ///  because SystemLog destruction makes insert query while flushing data into underlying tables
@@ -92,6 +93,8 @@ struct SystemLogs
     std::shared_ptr<BackupLog> backup_log;
     /// Log blob storage operations
     std::shared_ptr<BlobStorageLog> blob_storage_log;
+    /// Log memory dumps
+    std::shared_ptr<MemoryDumpLog> memory_dump_log;
 
     std::vector<ISystemLog *> logs;
 };


### PR DESCRIPTION
### Changelog category (leave one):
- New Feature

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Added MemoryDumpCollector that will periodically collect all allocations inside ClickHouse process with `memory_dump_interval_ms` interval, if server setting `enable_memory_dump_collector` is set. Added `system.memory_dump_log` table to store memory dumps.
