### PR TITLE
fs cache: fix data race in slru

### DIFF
--- a/src/Interpreters/Cache/FileCache.cpp
+++ b/src/Interpreters/Cache/FileCache.cpp
@@ -817,7 +817,7 @@ bool FileCache::tryReserve(FileSegment & file_segment, const size_t size, FileCa
     }
 
     file_segment.reserved_size += size;
-    chassert(file_segment.reserved_size == queue_iterator->getEntry().size);
+    chassert(file_segment.reserved_size == queue_iterator->getEntry()->size);
 
     if (query_context)
     {

--- a/src/Interpreters/Cache/FileSegment.cpp
+++ b/src/Interpreters/Cache/FileSegment.cpp
@@ -789,9 +789,9 @@ bool FileSegment::assertCorrectnessUnlocked(const FileSegmentGuard::Lock &) cons
 
         const auto & entry = it->getEntry();
         UNUSED(entry);
-        chassert(entry.size == reserved_size);
-        chassert(entry.key == key());
-        chassert(entry.offset == offset());
+        chassert(entry->size == reserved_size);
+        chassert(entry->key == key());
+        chassert(entry->offset == offset());
     };
 
     if (download_state == State::DOWNLOADED)

--- a/src/Interpreters/Cache/IFileCachePriority.h
+++ b/src/Interpreters/Cache/IFileCachePriority.h
@@ -31,13 +31,14 @@ public:
         std::atomic<size_t> size;
         size_t hits = 0;
     };
+    using EntryPtr = std::shared_ptr<Entry>;
 
     class Iterator
     {
     public:
         virtual ~Iterator() = default;
 
-        virtual const Entry & getEntry() const = 0;
+        virtual EntryPtr getEntry() const = 0;
 
         virtual size_t increasePriority(const CacheGuard::Lock &) = 0;
 

--- a/src/Interpreters/Cache/LRUFileCachePriority.h
+++ b/src/Interpreters/Cache/LRUFileCachePriority.h
@@ -15,7 +15,7 @@ class LRUFileCachePriority final : public IFileCachePriority
 {
 private:
     class LRUIterator;
-    using LRUQueue = std::list<Entry>;
+    using LRUQueue = std::list<EntryPtr>;
     friend class SLRUFileCachePriority;
 
 public:
@@ -76,7 +76,7 @@ private:
     void iterate(IterateFunc && func, const CacheGuard::Lock &);
 
     LRUIterator move(LRUIterator & it, LRUFileCachePriority & other, const CacheGuard::Lock &);
-    LRUIterator add(Entry && entry, const CacheGuard::Lock &);
+    LRUIterator add(EntryPtr entry, const CacheGuard::Lock &);
 };
 
 class LRUFileCachePriority::LRUIterator : public IFileCachePriority::Iterator
@@ -91,7 +91,7 @@ public:
     LRUIterator & operator =(const LRUIterator & other);
     bool operator ==(const LRUIterator & other) const;
 
-    const Entry & getEntry() const override { return *iterator; }
+    EntryPtr getEntry() const override { return *iterator; }
 
     size_t increasePriority(const CacheGuard::Lock &) override;
 

--- a/src/Interpreters/Cache/SLRUFileCachePriority.h
+++ b/src/Interpreters/Cache/SLRUFileCachePriority.h
@@ -11,10 +11,6 @@ namespace DB
 /// the head of the queue, and the record with the highest priority is stored at the tail.
 class SLRUFileCachePriority : public IFileCachePriority
 {
-private:
-    using LRUIterator = LRUFileCachePriority::LRUIterator;
-    using LRUQueue = std::list<Entry>;
-
 public:
     class SLRUIterator;
 
@@ -62,10 +58,10 @@ class SLRUFileCachePriority::SLRUIterator : public IFileCachePriority::Iterator
 public:
     SLRUIterator(
         SLRUFileCachePriority * cache_priority_,
-        LRUIterator && lru_iterator_,
+        LRUFileCachePriority::LRUIterator && lru_iterator_,
         bool is_protected_);
 
-    const Entry & getEntry() const override;
+    EntryPtr getEntry() const override;
 
     size_t increasePriority(const CacheGuard::Lock &) override;
 
@@ -81,7 +77,8 @@ private:
     void assertValid() const;
 
     SLRUFileCachePriority * cache_priority;
-    mutable LRUIterator lru_iterator;
+    LRUFileCachePriority::LRUIterator lru_iterator;
+    const EntryPtr entry;
     bool is_protected;
 };
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Closes https://github.com/ClickHouse/ClickHouse/issues/58071.
Marking PR as not for changelog because this data race arises only in debug build.