### PR TITLE
Fix for custom cached disk creation

### DIFF
--- a/docker/test/stateless/run.sh
+++ b/docker/test/stateless/run.sh
@@ -100,12 +100,12 @@ if [[ -n "$USE_DATABASE_REPLICATED" ]] && [[ "$USE_DATABASE_REPLICATED" -eq 1 ]]
     mv /etc/clickhouse-server2/config.d/filesystem_caches_path.xml.tmp /etc/clickhouse-server2/config.d/filesystem_caches_path.xml
 
     sudo cat /etc/clickhouse-server1/config.d/filesystem_caches_path.xml \
-    | sed "s|<custom_cached_disks_base_directory>/var/lib/clickhouse/filesystem_caches/</custom_cached_disks_base_directory>|<custom_cached_disks_base_directory>/var/lib/clickhouse/filesystem_caches_1/</custom_cached_disks_base_directory>|" \
+    | sed "s|<custom_cached_disks_base_directory replace=\"replace\">/var/lib/clickhouse/filesystem_caches/</custom_cached_disks_base_directory>|<custom_cached_disks_base_directory replace=\"replace\">/var/lib/clickhouse/filesystem_caches_1/</custom_cached_disks_base_directory>|" \
     > /etc/clickhouse-server1/config.d/filesystem_caches_path.xml.tmp
     mv /etc/clickhouse-server1/config.d/filesystem_caches_path.xml.tmp /etc/clickhouse-server1/config.d/filesystem_caches_path.xml
 
     sudo cat /etc/clickhouse-server2/config.d/filesystem_caches_path.xml \
-    | sed "s|<custom_cached_disks_base_directory>/var/lib/clickhouse/filesystem_caches/</custom_cached_disks_base_directory>|<custom_cached_disks_base_directory>/var/lib/clickhouse/filesystem_caches_2/</custom_cached_disks_base_directory>|" \
+    | sed "s|<custom_cached_disks_base_directory replace=\"replace\">/var/lib/clickhouse/filesystem_caches/</custom_cached_disks_base_directory>|<custom_cached_disks_base_directory replace=\"replace\">/var/lib/clickhouse/filesystem_caches_2/</custom_cached_disks_base_directory>|" \
     > /etc/clickhouse-server2/config.d/filesystem_caches_path.xml.tmp
     mv /etc/clickhouse-server2/config.d/filesystem_caches_path.xml.tmp /etc/clickhouse-server2/config.d/filesystem_caches_path.xml
 

--- a/docker/test/stateless/run.sh
+++ b/docker/test/stateless/run.sh
@@ -99,6 +99,16 @@ if [[ -n "$USE_DATABASE_REPLICATED" ]] && [[ "$USE_DATABASE_REPLICATED" -eq 1 ]]
     > /etc/clickhouse-server2/config.d/filesystem_caches_path.xml.tmp
     mv /etc/clickhouse-server2/config.d/filesystem_caches_path.xml.tmp /etc/clickhouse-server2/config.d/filesystem_caches_path.xml
 
+    sudo cat /etc/clickhouse-server1/config.d/filesystem_caches_path.xml \
+    | sed "s|<custom_cached_disks_base_directory>/var/lib/clickhouse/filesystem_caches/</custom_cached_disks_base_directory>|<custom_cached_disks_base_directory>/var/lib/clickhouse/filesystem_caches_1/</custom_cached_disks_base_directory>|" \
+    > /etc/clickhouse-server1/config.d/filesystem_caches_path.xml.tmp
+    mv /etc/clickhouse-server1/config.d/filesystem_caches_path.xml.tmp /etc/clickhouse-server1/config.d/filesystem_caches_path.xml
+
+    sudo cat /etc/clickhouse-server2/config.d/filesystem_caches_path.xml \
+    | sed "s|<custom_cached_disks_base_directory>/var/lib/clickhouse/filesystem_caches/</custom_cached_disks_base_directory>|<custom_cached_disks_base_directory>/var/lib/clickhouse/filesystem_caches_2/</custom_cached_disks_base_directory>|" \
+    > /etc/clickhouse-server2/config.d/filesystem_caches_path.xml.tmp
+    mv /etc/clickhouse-server2/config.d/filesystem_caches_path.xml.tmp /etc/clickhouse-server2/config.d/filesystem_caches_path.xml
+
     mkdir -p /var/run/clickhouse-server1
     sudo chown clickhouse:clickhouse /var/run/clickhouse-server1
     sudo -E -u clickhouse /usr/bin/clickhouse server --config /etc/clickhouse-server1/config.xml --daemon \

--- a/programs/server/config.xml
+++ b/programs/server/config.xml
@@ -440,7 +440,7 @@
     <!-- Cache size in elements for compiled expressions.-->
     <compiled_expression_cache_elements_size>10000</compiled_expression_cache_elements_size>
 
-    <!-- Cache path for custom (created from AST) cached disks -->
+    <!-- Cache path for custom (created from SQL) cached disks -->
     <custom_cached_disks_base_directory>/var/lib/clickhouse/caches/</custom_cached_disks_base_directory>
 
     <validate_tcp_client_information>false</validate_tcp_client_information>

--- a/programs/server/config.xml
+++ b/programs/server/config.xml
@@ -440,6 +440,9 @@
     <!-- Cache size in elements for compiled expressions.-->
     <compiled_expression_cache_elements_size>10000</compiled_expression_cache_elements_size>
 
+    <!-- Cache path for custom (created from AST) cached disks -->
+    <custom_cached_disks_base_directory>/var/lib/clickhouse/caches/</custom_cached_disks_base_directory>
+
     <validate_tcp_client_information>false</validate_tcp_client_information>
 
     <!-- Path to data directory, with trailing slash. -->

--- a/src/Disks/DiskEncrypted.cpp
+++ b/src/Disks/DiskEncrypted.cpp
@@ -455,7 +455,8 @@ void registerDiskEncrypted(DiskFactory & factory, bool global_skip_access_check)
         const Poco::Util::AbstractConfiguration & config,
         const String & config_prefix,
         ContextPtr context,
-        const DisksMap & map) -> DiskPtr
+        const DisksMap & map,
+        bool, bool) -> DiskPtr
     {
         bool skip_access_check = global_skip_access_check || config.getBool(config_prefix + ".skip_access_check", false);
         DiskPtr disk = std::make_shared<DiskEncrypted>(name, config, config_prefix, map);

--- a/src/Disks/DiskFactory.cpp
+++ b/src/Disks/DiskFactory.cpp
@@ -25,7 +25,9 @@ DiskPtr DiskFactory::create(
     const Poco::Util::AbstractConfiguration & config,
     const String & config_prefix,
     ContextPtr context,
-    const DisksMap & map) const
+    const DisksMap & map,
+    bool attach,
+    bool custom_disk) const
 {
     const auto disk_type = config.getString(config_prefix + ".type", "local");
 
@@ -37,7 +39,7 @@ DiskPtr DiskFactory::create(
     }
 
     const auto & disk_creator = found->second;
-    return disk_creator(name, config, config_prefix, context, map);
+    return disk_creator(name, config, config_prefix, context, map, attach, custom_disk);
 }
 
 }

--- a/src/Disks/DiskFactory.h
+++ b/src/Disks/DiskFactory.h
@@ -27,7 +27,9 @@ public:
         const Poco::Util::AbstractConfiguration & config,
         const String & config_prefix,
         ContextPtr context,
-        const DisksMap & map)>;
+        const DisksMap & map,
+        bool attach,
+        bool custom_disk)>;
 
     static DiskFactory & instance();
 
@@ -38,7 +40,9 @@ public:
         const Poco::Util::AbstractConfiguration & config,
         const String & config_prefix,
         ContextPtr context,
-        const DisksMap & map) const;
+        const DisksMap & map,
+        bool attach = false,
+        bool custom_disk = false) const;
 
 private:
     using DiskTypeRegistry = std::unordered_map<String, Creator>;

--- a/src/Disks/DiskLocal.cpp
+++ b/src/Disks/DiskLocal.cpp
@@ -728,7 +728,8 @@ void registerDiskLocal(DiskFactory & factory, bool global_skip_access_check)
         const Poco::Util::AbstractConfiguration & config,
         const String & config_prefix,
         ContextPtr context,
-        const DisksMap & map) -> DiskPtr
+        const DisksMap & map,
+        bool, bool) -> DiskPtr
     {
         String path;
         UInt64 keep_free_space_bytes;

--- a/src/Disks/ObjectStorages/Cached/registerDiskCache.cpp
+++ b/src/Disks/ObjectStorages/Cached/registerDiskCache.cpp
@@ -23,8 +23,10 @@ void registerDiskCache(DiskFactory & factory, bool /* global_skip_access_check *
                     const Poco::Util::AbstractConfiguration & config,
                     const String & config_prefix,
                     ContextPtr context,
-                    const DisksMap & map) -> DiskPtr
-    {
+                    const DisksMap & map,
+                    bool attach,
+                    bool custom_disk) -> DiskPtr
+{
         auto disk_name = config.getString(config_prefix + ".disk", "");
         if (disk_name.empty())
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "Disk Cache requires `disk` field in config");
@@ -49,7 +51,40 @@ void registerDiskCache(DiskFactory & factory, bool /* global_skip_access_check *
             file_cache_settings.loadFromConfig(config, config_prefix);
 
         auto config_fs_caches_dir = context->getFilesystemCachesPath();
-        if (config_fs_caches_dir.empty())
+        if (custom_disk)
+        {
+            static constexpr auto custom_cached_disks_base_dir_in_config = "custom_cached_disks_base_directory";
+            auto custom_cached_disk_path_prefix = context->getConfigRef().getString(custom_cached_disks_base_dir_in_config, config_fs_caches_dir);
+            if (custom_cached_disk_path_prefix.empty())
+            {
+                if (!attach)
+                {
+                    throw Exception(
+                        ErrorCodes::BAD_ARGUMENTS,
+                        "Cannot create cached custom disk without either "
+                        "`filesystem_caches_path` (common for all filesystem caches) or"
+                        "`custom_cached_disks_base_directory` (common only for custom cached disks) in server configuration file");
+                }
+                if (fs::path(file_cache_settings.base_path).is_relative())
+                {
+                    /// Compatibility prefix.
+                    file_cache_settings.base_path = fs::path(context->getPath()) / "caches" / file_cache_settings.base_path;
+                }
+            }
+            else
+            {
+                if (fs::path(file_cache_settings.base_path).is_relative())
+                    file_cache_settings.base_path = fs::path(custom_cached_disk_path_prefix) / file_cache_settings.base_path;
+
+                if (!attach && !pathStartsWith(file_cache_settings.base_path, custom_cached_disk_path_prefix))
+                {
+                    throw Exception(ErrorCodes::BAD_ARGUMENTS,
+                                    "Filesystem cache path must lie inside `{}` (for disk: {})",
+                                    config_fs_caches_dir, name);
+                }
+            }
+        }
+        else if (config_fs_caches_dir.empty())
         {
             if (fs::path(file_cache_settings.base_path).is_relative())
                 file_cache_settings.base_path = fs::path(context->getPath()) / "caches" / file_cache_settings.base_path;
@@ -59,7 +94,7 @@ void registerDiskCache(DiskFactory & factory, bool /* global_skip_access_check *
             if (fs::path(file_cache_settings.base_path).is_relative())
                 file_cache_settings.base_path = fs::path(config_fs_caches_dir) / file_cache_settings.base_path;
 
-            if (!pathStartsWith(file_cache_settings.base_path, config_fs_caches_dir))
+            if (!attach && !pathStartsWith(file_cache_settings.base_path, config_fs_caches_dir))
             {
                 throw Exception(ErrorCodes::BAD_ARGUMENTS,
                                 "Filesystem cache path {} must lie inside default filesystem cache path `{}`",

--- a/src/Disks/ObjectStorages/RegisterDiskObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/RegisterDiskObjectStorage.cpp
@@ -45,7 +45,8 @@ void registerDiskObjectStorage(DiskFactory & factory, bool global_skip_access_ch
         const Poco::Util::AbstractConfiguration & config,
         const String & config_prefix,
         ContextPtr context,
-        const DisksMap & /*map*/) -> DiskPtr
+        const DisksMap & /* map */,
+        bool, bool) -> DiskPtr
     {
         bool skip_access_check = global_skip_access_check || config.getBool(config_prefix + ".skip_access_check", false);
         auto object_storage = ObjectStorageFactory::instance().create(name, config, config_prefix, context, skip_access_check);

--- a/src/Disks/getOrCreateDiskFromAST.cpp
+++ b/src/Disks/getOrCreateDiskFromAST.cpp
@@ -24,7 +24,7 @@ namespace ErrorCodes
 
 namespace
 {
-    std::string getOrCreateDiskFromDiskAST(const ASTFunction & function, ContextPtr context)
+    std::string getOrCreateDiskFromDiskAST(const ASTFunction & function, ContextPtr context, bool attach)
     {
         const auto * function_args_expr = assert_cast<const ASTExpressionList *>(function.arguments.get());
         const auto & function_args = function_args_expr->children;
@@ -46,7 +46,8 @@ namespace
         }
 
         auto result_disk = context->getOrCreateDisk(disk_name, [&](const DisksMap & disks_map) -> DiskPtr {
-            auto disk = DiskFactory::instance().create(disk_name, *config, "", context, disks_map);
+            auto disk = DiskFactory::instance().create(
+                disk_name, *config, "", context, disks_map, /* attach */attach, /* custom_disk */true);
             /// Mark that disk can be used without storage policy.
             disk->markDiskAsCustom();
             return disk;
@@ -55,16 +56,16 @@ namespace
         if (!result_disk->isCustomDisk())
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "Disk with name `{}` already exist", disk_name);
 
-        if (!result_disk->isRemote())
+        if (!attach && !result_disk->isRemote())
         {
-            static constexpr auto custom_disks_base_dir_in_config = "custom_local_disks_base_directory";
-            auto disk_path_expected_prefix = context->getConfigRef().getString(custom_disks_base_dir_in_config, "");
+            static constexpr auto custom_local_disks_base_dir_in_config = "custom_local_disks_base_directory";
+            auto disk_path_expected_prefix = context->getConfigRef().getString(custom_local_disks_base_dir_in_config, "");
 
             if (disk_path_expected_prefix.empty())
                 throw Exception(
                     ErrorCodes::BAD_ARGUMENTS,
                     "Base path for custom local disks must be defined in config file by `{}`",
-                    custom_disks_base_dir_in_config);
+                    custom_local_disks_base_dir_in_config);
 
             if (!pathStartsWith(result_disk->getPath(), disk_path_expected_prefix))
                 throw Exception(
@@ -82,6 +83,7 @@ namespace
         struct Data
         {
             ContextPtr context;
+            bool attach;
         };
 
         static bool needChildVisit(const ASTPtr &, const ASTPtr &) { return true; }
@@ -90,7 +92,7 @@ namespace
         {
             if (isDiskFunction(ast))
             {
-                auto disk_name = getOrCreateDiskFromDiskAST(*ast->as<ASTFunction>(), data.context);
+                auto disk_name = getOrCreateDiskFromDiskAST(*ast->as<ASTFunction>(), data.context, data.attach);
                 ast = std::make_shared<ASTLiteral>(disk_name);
             }
         }
@@ -101,14 +103,14 @@ namespace
 }
 
 
-std::string getOrCreateDiskFromDiskAST(const ASTPtr & disk_function, ContextPtr context)
+std::string getOrCreateDiskFromDiskAST(const ASTPtr & disk_function, ContextPtr context, bool attach)
 {
     if (!isDiskFunction(disk_function))
         throw Exception(ErrorCodes::BAD_ARGUMENTS, "Expected a disk function");
 
     auto ast = disk_function->clone();
 
-    FlattenDiskConfigurationVisitor::Data data{context};
+    FlattenDiskConfigurationVisitor::Data data{context, attach};
     FlattenDiskConfigurationVisitor{data}.visit(ast);
 
     auto disk_name = assert_cast<const ASTLiteral &>(*ast).value.get<String>();

--- a/src/Disks/getOrCreateDiskFromAST.h
+++ b/src/Disks/getOrCreateDiskFromAST.h
@@ -13,6 +13,6 @@ class ASTFunction;
  * add it to DiskSelector by a unique (but always the same for given configuration) disk name
  * and return this name.
  */
-std::string getOrCreateDiskFromDiskAST(const ASTPtr & disk_function, ContextPtr context);
+std::string getOrCreateDiskFromDiskAST(const ASTPtr & disk_function, ContextPtr context, bool attach);
 
 }

--- a/src/Interpreters/SystemLog.cpp
+++ b/src/Interpreters/SystemLog.cpp
@@ -660,7 +660,7 @@ ASTPtr SystemLog<LogElement>::getCreateTableQuery()
     if (endsWith(engine.name, "MergeTree"))
     {
         auto storage_settings = std::make_unique<MergeTreeSettings>(getContext()->getMergeTreeSettings());
-        storage_settings->loadFromQuery(*create->storage, getContext());
+        storage_settings->loadFromQuery(*create->storage, getContext(), false);
     }
 
     return create;

--- a/src/Storages/MergeTree/MergeTreeSettings.cpp
+++ b/src/Storages/MergeTree/MergeTreeSettings.cpp
@@ -44,7 +44,7 @@ void MergeTreeSettings::loadFromConfig(const String & config_elem, const Poco::U
     }
 }
 
-void MergeTreeSettings::loadFromQuery(ASTStorage & storage_def, ContextPtr context)
+void MergeTreeSettings::loadFromQuery(ASTStorage & storage_def, ContextPtr context, bool is_attach)
 {
     if (storage_def.settings)
     {
@@ -64,7 +64,7 @@ void MergeTreeSettings::loadFromQuery(ASTStorage & storage_def, ContextPtr conte
                         auto ast = dynamic_cast<const FieldFromASTImpl &>(custom.getImpl()).ast;
                         if (ast && isDiskFunction(ast))
                         {
-                            auto disk_name = getOrCreateDiskFromDiskAST(ast, context);
+                            auto disk_name = getOrCreateDiskFromDiskAST(ast, context, is_attach);
                             LOG_TRACE(&Poco::Logger::get("MergeTreeSettings"), "Created custom disk {}", disk_name);
                             value = disk_name;
                         }

--- a/src/Storages/MergeTree/MergeTreeSettings.h
+++ b/src/Storages/MergeTree/MergeTreeSettings.h
@@ -255,7 +255,7 @@ struct MergeTreeSettings : public BaseSettings<MergeTreeSettingsTraits>, public 
     void loadFromConfig(const String & config_elem, const Poco::Util::AbstractConfiguration & config);
 
     /// NOTE: will rewrite the AST to add immutable settings.
-    void loadFromQuery(ASTStorage & storage_def, ContextPtr context);
+    void loadFromQuery(ASTStorage & storage_def, ContextPtr context, bool is_attach);
 
     /// We check settings after storage creation
     static bool isReadonlySetting(const String & name)

--- a/src/Storages/MergeTree/registerStorageMergeTree.cpp
+++ b/src/Storages/MergeTree/registerStorageMergeTree.cpp
@@ -608,7 +608,7 @@ static StoragePtr create(const StorageFactory::Arguments & args)
             metadata.column_ttls_by_name[name] = new_ttl_entry;
         }
 
-        storage_settings->loadFromQuery(*args.storage_def, context);
+        storage_settings->loadFromQuery(*args.storage_def, context, args.attach);
 
         // updates the default storage_settings with settings specified via SETTINGS arg in a query
         if (args.storage_def->settings)

--- a/tests/config/config.d/filesystem_caches_path.xml
+++ b/tests/config/config.d/filesystem_caches_path.xml
@@ -1,3 +1,4 @@
 <clickhouse>
     <filesystem_caches_path>/var/lib/clickhouse/filesystem_caches/</filesystem_caches_path>
+    <custom_cached_disks_base_directory replace="replace">/var/lib/clickhouse/filesystem_caches/</custom_cached_disks_base_directory>
 </clickhouse>

--- a/tests/integration/helpers/0_common_instance_config.xml
+++ b/tests/integration/helpers/0_common_instance_config.xml
@@ -27,4 +27,6 @@
         <settings_constraints_replace_previous>true</settings_constraints_replace_previous>
         <role_cache_expiration_time_seconds>2</role_cache_expiration_time_seconds>
     </access_control_improvements>
+
+    <custom_cached_disks_base_directory remove="remove"/>
 </clickhouse>

--- a/tests/integration/helpers/0_common_instance_config.xml
+++ b/tests/integration/helpers/0_common_instance_config.xml
@@ -28,5 +28,5 @@
         <role_cache_expiration_time_seconds>2</role_cache_expiration_time_seconds>
     </access_control_improvements>
 
-    <custom_cached_disks_base_directory remove="remove"/>
+    <custom_cached_disks_base_directory replace="replace">/</custom_cached_disks_base_directory>
 </clickhouse>

--- a/tests/integration/test_filesystem_cache/config.d/remove_filesystem_caches_path.xml
+++ b/tests/integration/test_filesystem_cache/config.d/remove_filesystem_caches_path.xml
@@ -1,0 +1,3 @@
+<clickhouse>
+    <custom_cached_disks_base_directory remove="remove"/>
+</clickhouse>

--- a/tests/integration/test_filesystem_cache/test.py
+++ b/tests/integration/test_filesystem_cache/test.py
@@ -27,6 +27,14 @@ def cluster():
                 "config.d/storage_conf_2.xml",
             ],
         )
+        cluster.add_instance(
+            "node_no_filesystem_caches_path",
+            main_configs=[
+                "config.d/storage_conf.xml",
+                "config.d/remove_filesystem_caches_path.xml",
+            ],
+            stay_alive=True,
+        )
 
         logging.info("Starting cluster...")
         cluster.start()
@@ -197,7 +205,7 @@ def test_caches_with_the_same_configuration_2(cluster, node_name):
 
 
 def test_custom_cached_disk(cluster):
-    node = cluster.instances["node"]
+    node = cluster.instances["node_no_filesystem_caches_path"]
 
     assert "Cannot create cached custom disk without" in node.query_and_get_error(
         f"""
@@ -247,6 +255,13 @@ def test_custom_cached_disk(cluster):
         </clickhouse>
         " > /etc/clickhouse-server/config.d/custom_filesystem_caches_path.xml
         """,
+        ]
+    )
+    node.exec_in_container(
+        [
+            "bash",
+            "-c",
+            "rm /etc/clickhouse-server/config.d/remove_filesystem_caches_path.xml"
         ]
     )
     node.restart_clickhouse()

--- a/tests/integration/test_filesystem_cache/test.py
+++ b/tests/integration/test_filesystem_cache/test.py
@@ -261,7 +261,7 @@ def test_custom_cached_disk(cluster):
         [
             "bash",
             "-c",
-            "rm /etc/clickhouse-server/config.d/remove_filesystem_caches_path.xml"
+            "rm /etc/clickhouse-server/config.d/remove_filesystem_caches_path.xml",
         ]
     )
     node.restart_clickhouse()


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Make sure that for custom (created from SQL) disks ether `filesystem_caches_path` (a common directory prefix for all filesystem caches) or `custom_cached_disks_base_directory` (a common directory prefix for only filesystem caches created from custom disks) is specified in server config.  `custom_cached_disks_base_directory` has higher priority for custom disks over  `filesystem_caches_path`, which is used if the former one is absent.  Filesystem cache setting `path` must lie inside that directory, otherwise exception will be thrown preventing disk to be created. This will not affect disks created on an older version and server was upgraded - then the exception will not be thrown to allow the server to successfully start). `custom_cached_disks_base_directory` is added to default server config as `/var/lib/clickhouse/caches/`. Closes https://github.com/ClickHouse/ClickHouse/issues/57825.