### PR TITLE
Improve query performance in case of very small blocks

### DIFF
--- a/src/QueryPipeline/ReadProgressCallback.cpp
+++ b/src/QueryPipeline/ReadProgressCallback.cpp
@@ -126,8 +126,6 @@ bool ReadProgressCallback::onProgress(uint64_t read_rows, uint64_t read_bytes, c
 
         CurrentThread::updatePerformanceCountersIfNeeded();
 
-        std::lock_guard lock(limits_and_quotas_mutex);
-
         /// TODO: Should be done in PipelineExecutor.
         for (const auto & limits : storage_limits)
             limits.local_limits.speed_limits.throttle(progress.read_rows, progress.read_bytes, total_rows, total_stopwatch.elapsedMicroseconds(), limits.local_limits.timeout_overflow_mode);

--- a/src/QueryPipeline/ReadProgressCallback.h
+++ b/src/QueryPipeline/ReadProgressCallback.h
@@ -41,7 +41,6 @@ private:
     /// The total number of bytes to read. For progress bar.
     std::atomic_size_t total_bytes = 0;
 
-    std::mutex limits_and_quotas_mutex;
     Stopwatch total_stopwatch{CLOCK_MONOTONIC_COARSE};  /// Including waiting time
 
     bool update_profile_events = true;

--- a/tests/performance/small_block_contention.xml
+++ b/tests/performance/small_block_contention.xml
@@ -1,0 +1,3 @@
+<test>
+    <query>select sum(number) from numbers_mt(200000) settings max_threads=100, max_block_size = 1 format Null</query>
+</test>


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Improve query performance in case of very small blocks

Remove lock from the ReadProgressCallback

It looks redundant (added in 5ef51ed), though it has "fix tests" in the
log message, but CI reports is not available for the commits from that
PR [1], so let's try.

  [1]: https://github.com/ClickHouse/ClickHouse/pull/37543

Also this can be a big problem, since the code under that lock
(throttling or quotas with previous implementation that uses
boost::atomic_shared_ptr) may sleep.

Some numbers:

    run                     | time
    ------------------------|------
    max_threads=100 before  | 23.1
    max_threads=100 after   | 15.1
    max_threads=4500 before | 4.5
    max_threads=4500 after  | 2.3

Query:

    select sum(number) from numbers_mt(2000000) settings max_threads=X, max_block_size = 1