### PR TITLE
Restriction for the access key id for s3.

### DIFF
--- a/src/IO/S3/Client.cpp
+++ b/src/IO/S3/Client.cpp
@@ -115,7 +115,7 @@ void validateCredentials(const Aws::Auth::AWSCredentials& auth_credentials)
     /// Follow https://docs.aws.amazon.com/IAM/latest/APIReference/API_AccessKey.html
     if (!std::all_of(auth_credentials.GetAWSAccessKeyId().begin(), auth_credentials.GetAWSAccessKeyId().end(), isWordCharASCII))
     {
-        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Access key id has invalid character");
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Access key id has an invalid character");
     }
 }
 

--- a/src/IO/S3/Client.cpp
+++ b/src/IO/S3/Client.cpp
@@ -113,7 +113,7 @@ void validateCredentials(const Aws::Auth::AWSCredentials& auth_credentials)
         return;
     }
     /// Follow https://docs.aws.amazon.com/IAM/latest/APIReference/API_AccessKey.html
-    const auto * ACCESS_KEY_ID_REGEX = R"(\w+)";
+    const auto * ACCESS_KEY_ID_REGEX = R"\w+";
     if (!re2::RE2::FullMatch(auth_credentials.GetAWSAccessKeyId(), ACCESS_KEY_ID_REGEX))
     {
         throw Exception(ErrorCodes::BAD_ARGUMENTS, "Access key id has invalid character");

--- a/src/IO/S3/Client.cpp
+++ b/src/IO/S3/Client.cpp
@@ -24,7 +24,6 @@
 
 #include <Common/logger_useful.h>
 #include <Common/ProxyConfigurationResolverProvider.h>
-#include <Common/re2.h>
 
 #include <base/sleep.h>
 
@@ -114,7 +113,7 @@ void validateCredentials(const Aws::Auth::AWSCredentials& auth_credentials)
         return;
     }
     /// Follow https://docs.aws.amazon.com/IAM/latest/APIReference/API_AccessKey.html
-    if (!std::all_of(auth_credentials.GetAWSAccessKeyId().begin(), auth_credentials.GetAWSAccessKeyId().end(),isWordCharASCII))
+    if (!std::all_of(auth_credentials.GetAWSAccessKeyId().begin(), auth_credentials.GetAWSAccessKeyId().end(), isWordCharASCII))
     {
         throw Exception(ErrorCodes::BAD_ARGUMENTS, "Access key id has invalid character");
     }

--- a/src/IO/S3/Client.cpp
+++ b/src/IO/S3/Client.cpp
@@ -28,6 +28,7 @@
 
 #include <base/sleep.h>
 
+#include <algorithm>
 
 namespace ProfileEvents
 {
@@ -113,8 +114,7 @@ void validateCredentials(const Aws::Auth::AWSCredentials& auth_credentials)
         return;
     }
     /// Follow https://docs.aws.amazon.com/IAM/latest/APIReference/API_AccessKey.html
-    const auto * ACCESS_KEY_ID_REGEX = R"\w+";
-    if (!re2::RE2::FullMatch(auth_credentials.GetAWSAccessKeyId(), ACCESS_KEY_ID_REGEX))
+    if (!std::all_of(auth_credentials.GetAWSAccessKeyId().begin(), auth_credentials.GetAWSAccessKeyId().end(),isWordCharASCII))
     {
         throw Exception(ErrorCodes::BAD_ARGUMENTS, "Access key id has invalid character");
     }

--- a/tests/queries/0_stateless/02966_s3_access_key_id_restriction.sql
+++ b/tests/queries/0_stateless/02966_s3_access_key_id_restriction.sql
@@ -1,3 +1,5 @@
+-- Tags: no-fasttest
+
 select * from s3('http://localhost:11111/test/a.tsv', '\ninjection\n', 'admin'); -- { serverError 36 }
 select * from deltaLake('http://localhost:11111/test/a.tsv', '\ninjection\n', 'admin'); -- { serverError 36 }
 select * from hudi('http://localhost:11111/test/a.tsv', '\ninjection\n', 'admin'); -- { serverError 36 }

--- a/tests/queries/0_stateless/02966_s3_access_key_id_restriction.sql
+++ b/tests/queries/0_stateless/02966_s3_access_key_id_restriction.sql
@@ -1,0 +1,4 @@
+select * from s3('http://localhost:11111/test/a.tsv', '\ninjection\n', 'admin'); -- { serverError 36 }
+select * from deltaLake('http://localhost:11111/test/a.tsv', '\ninjection\n', 'admin'); -- { serverError 36 }
+select * from hudi('http://localhost:11111/test/a.tsv', '\ninjection\n', 'admin'); -- { serverError 36 }
+select * from iceberg('http://localhost:11111/test/a.tsv', '\ninjection\n', 'admin'); -- { serverError 36 }


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Prevent specifying  an `access_key_id` that does not match the correct [correct pattern]( https://docs.aws.amazon.com/IAM/latest/APIReference/API_AccessKey.html).

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
Example
```
select * from s3('http://localhost:11111/test/a.tsv', '\nsomethingstrage\n', 'admin');  <-  does not match with \w+ pattern.
```

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
