### PR TITLE
Fix crash when indexHint() is used

### DIFF
--- a/src/Interpreters/ActionsDAG.cpp
+++ b/src/Interpreters/ActionsDAG.cpp
@@ -2542,10 +2542,16 @@ ActionsDAGPtr ActionsDAG::buildFilterActionsDAG(
                     {
                         if (const auto * index_hint = typeid_cast<const FunctionIndexHint *>(adaptor->getFunction().get()))
                         {
-                            auto index_hint_filter_dag = buildFilterActionsDAG(index_hint->getActions()->getOutputs(),
-                                node_name_to_input_node_column,
-                                context,
-                                false /*single_output_condition_node*/);
+                            ActionsDAGPtr index_hint_filter_dag;
+                            const auto & index_hint_args = index_hint->getActions()->getOutputs();
+
+                            if (index_hint_args.empty())
+                                index_hint_filter_dag = std::make_shared<ActionsDAG>();
+                            else
+                                index_hint_filter_dag = buildFilterActionsDAG(index_hint_args,
+                                    node_name_to_input_node_column,
+                                    context,
+                                    false /*single_output_condition_node*/);
 
                             auto index_hint_function_clone = std::make_shared<FunctionIndexHint>();
                             index_hint_function_clone->setActions(std::move(index_hint_filter_dag));

--- a/src/Storages/MergeTree/RPNBuilder.h
+++ b/src/Storages/MergeTree/RPNBuilder.h
@@ -229,6 +229,12 @@ private:
                         rpn_elements.emplace_back(std::move(element));
                 }
 
+                if (arguments_size == 0 && function_node.getFunctionName() == "indexHint")
+                {
+                    element.function = RPNElement::ALWAYS_TRUE;
+                    rpn_elements.emplace_back(std::move(element));
+                }
+
                 return;
             }
         }

--- a/tests/queries/0_stateless/02967_index_hint_crash.sql
+++ b/tests/queries/0_stateless/02967_index_hint_crash.sql
@@ -1,0 +1,16 @@
+CREATE TABLE tab
+(
+    `foo` Array(LowCardinality(String)),
+    INDEX idx foo TYPE bloom_filter GRANULARITY 1
+)
+ENGINE = MergeTree
+PRIMARY KEY tuple();
+
+INSERT INTO tab SELECT if(number % 2, ['value'], [])
+FROM system.numbers
+LIMIT 10000;
+
+SELECT *
+FROM tab
+PREWHERE indexHint()
+FORMAT Null;


### PR DESCRIPTION
### Changelog category (leave one):

- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Fix crash when `indexHint` function is used without arguments in the filters.