### PR TITLE
Fix fault handler in case of thread (for fault handler) cannot be spawned

### DIFF
--- a/src/Daemon/BaseDaemon.cpp
+++ b/src/Daemon/BaseDaemon.cpp
@@ -281,7 +281,15 @@ public:
 
                 /// This allows to receive more signals if failure happens inside onFault function.
                 /// Example: segfault while symbolizing stack trace.
-                std::thread([=, this] { onFault(sig, info, context, stack_trace, thread_frame_pointers, thread_num, thread_ptr); }).detach();
+                try
+                {
+                    std::thread([=, this] { onFault(sig, info, context, stack_trace, thread_frame_pointers, thread_num, thread_ptr); }).detach();
+                }
+                catch (...)
+                {
+                    /// Likely cannot allocate thread
+                    onFault(sig, info, context, stack_trace, thread_frame_pointers, thread_num, thread_ptr);
+                }
             }
         }
     }


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)