### PR TITLE
Cancel MasterCI in PRs

### DIFF
--- a/tests/ci/cancel_and_rerun_workflow_lambda/app.py
+++ b/tests/ci/cancel_and_rerun_workflow_lambda/app.py
@@ -1,28 +1,24 @@
 #!/usr/bin/env python3
 
-from base64 import b64decode
-from collections import namedtuple
-from typing import Any, Dict, List, Optional, Tuple
-from threading import Thread
-from queue import Queue
 import json
 import re
 import time
+from base64 import b64decode
+from collections import namedtuple
+from queue import Queue
+from threading import Thread
+from typing import Any, Dict, List, Optional, Tuple
 
 import requests  # type: ignore
-
 from lambda_shared.pr import CATEGORY_TO_LABEL, check_pr_description
 from lambda_shared.token import get_cached_access_token
 
-
-NEED_RERUN_ON_EDITED = {
-    "PullRequestCI",
-    "DocsCheck",
-}
-
 NEED_RERUN_OR_CANCELL_WORKFLOWS = {
     "BackportPR",
-}.union(NEED_RERUN_ON_EDITED)
+    "DocsCheck",
+    "MasterCI",
+    "PullRequestCI",
+}
 
 MAX_RETRY = 5
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add `MasterCI` to cancelable workflows to not run them after merge.