### PR TITLE
Add `SHOW WARNINGS` support in MySQL interface

### DIFF
--- a/src/Server/MySQLHandler.cpp
+++ b/src/Server/MySQLHandler.cpp
@@ -61,6 +61,8 @@ namespace ErrorCodes
 static const size_t PACKET_HEADER_SIZE = 4;
 static const size_t SSL_REQUEST_PAYLOAD_SIZE = 32;
 
+static String showWarningsReplacementQuery(const String & query);
+static String showCountWarningsReplacementQuery(const String & query);
 static String selectEmptyReplacementQuery(const String & query);
 static String showTableStatusReplacementQuery(const String & query);
 static String killConnectionIdReplacementQuery(const String & query);
@@ -86,6 +88,8 @@ MySQLHandler::MySQLHandler(
     if (ssl_enabled)
         server_capabilities |= CLIENT_SSL;
 
+    replacements.emplace("SHOW WARNINGS", showWarningsReplacementQuery);
+    replacements.emplace("SHOW COUNT(*) WARNINGS", showCountWarningsReplacementQuery);
     replacements.emplace("KILL QUERY", killConnectionIdReplacementQuery);
     replacements.emplace("SHOW TABLE STATUS LIKE", showTableStatusReplacementQuery);
     replacements.emplace("SHOW VARIABLES", selectEmptyReplacementQuery);
@@ -542,6 +546,18 @@ static bool isFederatedServerSetupSetCommand(const String & query)
         "|(^(SET SESSION TRANSACTION ISOLATION LEVEL(.*)))", regexp_options);
     assert(expr.ok());
     return re2::RE2::FullMatch(query, expr);
+}
+
+/// Always return an empty set with appropriate column definitions for SHOW WARNINGS queries
+/// See also: https://dev.mysql.com/doc/refman/8.0/en/show-warnings.html
+static String showWarningsReplacementQuery([[maybe_unused]] const String & query)
+{
+    return "SELECT '' AS Level, 0::UInt32 AS Code, '' AS Message WHERE false";
+}
+
+static String showCountWarningsReplacementQuery([[maybe_unused]] const String & query)
+{
+    return "SELECT 0::UInt64 AS `@@session.warning_count`";
 }
 
 /// Replace "[query(such as SHOW VARIABLES...)]" into "".

--- a/tests/queries/0_stateless/02968_mysql_show_warnings.reference
+++ b/tests/queries/0_stateless/02968_mysql_show_warnings.reference
@@ -1,0 +1,6 @@
+@@session.warning_count
+0
+@@session.warning_count
+0
+@@warning_count
+0

--- a/tests/queries/0_stateless/02968_mysql_show_warnings.sh
+++ b/tests/queries/0_stateless/02968_mysql_show_warnings.sh
@@ -2,8 +2,6 @@
 # Tags: no-fasttest
 # Tag no-fasttest: requires mysql client
 
-# Tests the override of certain MySQL proprietary settings to ClickHouse native settings
-
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CURDIR"/../shell_config.sh

--- a/tests/queries/0_stateless/02968_mysql_show_warnings.sh
+++ b/tests/queries/0_stateless/02968_mysql_show_warnings.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest
+# Tag no-fasttest: requires mysql client
+
+# Tests the override of certain MySQL proprietary settings to ClickHouse native settings
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+${MYSQL_CLIENT} --execute "SHOW WARNINGS;"
+${MYSQL_CLIENT} --execute "show warnings;"
+${MYSQL_CLIENT} --execute "SHOW WARNINGS LIMIT 100;"
+${MYSQL_CLIENT} --execute "show warnings limit 100;"
+${MYSQL_CLIENT} --execute "SHOW WARNINGS LIMIT 100 OFFSET 100;"
+${MYSQL_CLIENT} --execute "show warnings limit 100 offset 100;"
+${MYSQL_CLIENT} --execute "SHOW COUNT(*) WARNINGS;"
+${MYSQL_CLIENT} --execute "show count(*) warnings;"
+${MYSQL_CLIENT} --execute "SELECT @@session.warning_count;"


### PR DESCRIPTION
`SHOW WARNINGS` is a rather popular query that is sent by a lot of different tools (DBeaver, DataGrip...) and, while it is almost always non-fatal if it fails, it produces unnecessary errors in the log. 

This PR adds minimal support for it, so the statement does not fail. As discussed with @rschu1ze, we add it for compatibility reasons and with correct column definitions, though we always return an empty set.

See also: https://dev.mysql.com/doc/refman/8.0/en/show-warnings.html

### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
MySQL interface gained compatibility with `SHOW WARNINGS`/`SHOW COUNT(*) WARNINGS` queries, though the returned result is always an empty set.