### PR TITLE
Fix StorageURL forgetting headers on server restart

### DIFF
--- a/src/Storages/StorageFactory.h
+++ b/src/Storages/StorageFactory.h
@@ -31,6 +31,7 @@ public:
     struct Arguments
     {
         const String & engine_name;
+        /// Mutable to allow replacing constant expressions with literals, and other transformations.
         ASTs & engine_args;
         ASTStorage * storage_def;
         const ASTCreateQuery & query;

--- a/src/Storages/StorageURL.h
+++ b/src/Storages/StorageURL.h
@@ -294,7 +294,10 @@ public:
 
     static Configuration getConfiguration(ASTs & args, ContextPtr context);
 
-    static ASTs::iterator collectHeaders(ASTs & url_function_args, HTTPHeaderEntries & header_entries, ContextPtr context);
+    /// Does evaluateConstantExpressionOrIdentifierAsLiteral() on all arguments.
+    /// If `headers(...)` argument is present, parses it and moves it to the end of the array.
+    /// Returns number of arguments excluding `headers(...)`.
+    static size_t evalArgsAndCollectHeaders(ASTs & url_function_args, HTTPHeaderEntries & header_entries, ContextPtr context);
 
     static void processNamedCollectionResult(Configuration & configuration, const NamedCollection & collection);
 };

--- a/src/TableFunctions/TableFunctionS3.cpp
+++ b/src/TableFunctions/TableFunctionS3.cpp
@@ -67,22 +67,10 @@ void TableFunctionS3::parseArgumentsImpl(ASTs & args, const ContextPtr & context
     else
     {
 
-        auto * header_it = StorageURL::collectHeaders(args, configuration.headers_from_ast, context);
-        if (header_it != args.end())
-            args.erase(header_it);
+        size_t count = StorageURL::evalArgsAndCollectHeaders(args, configuration.headers_from_ast, context);
 
-        if (args.empty() || args.size() > 7)
+        if (count == 0 || count > 7)
             throw Exception(ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH, "The signature of table function {} shall be the following:\n{}", getName(), getSignature());
-
-        for (auto & arg : args)
-            arg = evaluateConstantExpressionOrIdentifierAsLiteral(arg, context);
-
-        /// Size -> argument indexes
-        static std::unordered_map<size_t, std::unordered_map<std::string_view, size_t>> size_to_args
-        {
-            {1, {{}}},
-            {7, {{"access_key_id", 1}, {"secret_access_key", 2}, {"session_token", 3}, {"format", 4}, {"structure", 5}, {"compression_method", 6}}}
-        };
 
         std::unordered_map<std::string_view, size_t> args_to_idx;
 
@@ -92,7 +80,7 @@ void TableFunctionS3::parseArgumentsImpl(ASTs & args, const ContextPtr & context
         /// - s3(source, format)
         /// - s3(source, NOSIGN)
         /// We can distinguish them by looking at the 2-nd argument: check if it's NOSIGN or not.
-        if (args.size() == 2)
+        if (count == 2)
         {
             auto second_arg = checkAndGetLiteralArgument<String>(args[1], "format/NOSIGN");
             if (boost::iequals(second_arg, "NOSIGN"))
@@ -102,10 +90,10 @@ void TableFunctionS3::parseArgumentsImpl(ASTs & args, const ContextPtr & context
         }
         /// For 3 arguments we support 3 possible variants:
         /// - s3(source, format, structure)
-        /// - s3(source, access_key_id, access_key_id)
+        /// - s3(source, access_key_id, secret_access_key)
         /// - s3(source, NOSIGN, format)
         /// We can distinguish them by looking at the 2-nd argument: check if it's a format name or not.
-        else if (args.size() == 3)
+        else if (count == 3)
         {
             auto second_arg = checkAndGetLiteralArgument<String>(args[1], "format/access_key_id/NOSIGN");
             if (boost::iequals(second_arg, "NOSIGN"))
@@ -120,11 +108,11 @@ void TableFunctionS3::parseArgumentsImpl(ASTs & args, const ContextPtr & context
         }
         /// For 4 arguments we support 4 possible variants:
         /// - s3(source, format, structure, compression_method),
-        /// - s3(source, access_key_id, access_key_id, format),
-        /// - s3(source, access_key_id, access_key_id, session_token)
+        /// - s3(source, access_key_id, secret_access_key, format),
+        /// - s3(source, access_key_id, secret_access_key, session_token)
         /// - s3(source, NOSIGN, format, structure)
         /// We can distinguish them by looking at the 2-nd and 4-th argument: check if it's a format name or not.
-        else if (args.size() == 4)
+        else if (count == 4)
         {
             auto second_arg = checkAndGetLiteralArgument<String>(args[1], "format/access_key_id/NOSIGN");
             if (boost::iequals(second_arg, "NOSIGN"))
@@ -150,12 +138,12 @@ void TableFunctionS3::parseArgumentsImpl(ASTs & args, const ContextPtr & context
             }
         }
         /// For 5 arguments we support 3 possible variants:
-        /// - s3(source, access_key_id, access_key_id, format, structure)
-        /// - s3(source, access_key_id, access_key_id, session_token, format)
+        /// - s3(source, access_key_id, secret_access_key, format, structure)
+        /// - s3(source, access_key_id, secret_access_key, session_token, format)
         /// - s3(source, NOSIGN, format, structure, compression_method)
         /// We can distinguish them by looking at the 2-nd argument: check if it's a NOSIGN keyword name or no,
         /// and by the 4-th argument, check if it's a format name or not
-        else if (args.size() == 5)
+        else if (count == 5)
         {
             auto second_arg = checkAndGetLiteralArgument<String>(args[1], "NOSIGN/access_key_id");
             if (boost::iequals(second_arg, "NOSIGN"))
@@ -177,10 +165,10 @@ void TableFunctionS3::parseArgumentsImpl(ASTs & args, const ContextPtr & context
             }
         }
         // For 6 arguments we support 2 possible variants:
-        /// - s3(source, access_key_id, access_key_id, format, structure, compression_method)
-        /// - s3(source, access_key_id, access_key_id, session_token, format, structure)
+        /// - s3(source, access_key_id, secret_access_key, format, structure, compression_method)
+        /// - s3(source, access_key_id, secret_access_key, session_token, format, structure)
         /// We can distinguish them by looking at the 4-th argument: check if it's a format name or not
-        else if (args.size() == 6)
+        else if (count == 6)
         {
             auto fourth_arg = checkAndGetLiteralArgument<String>(args[3], "format/session_token");
             if (fourth_arg == "auto" || FormatFactory::instance().getAllFormats().contains(fourth_arg))
@@ -192,9 +180,9 @@ void TableFunctionS3::parseArgumentsImpl(ASTs & args, const ContextPtr & context
                 args_to_idx = {{"access_key_id", 1}, {"secret_access_key", 2}, {"session_token", 3}, {"format", 4}, {"structure", 5}};
             }
         }
-        else
+        else if (count == 7)
         {
-            args_to_idx = size_to_args[args.size()];
+            args_to_idx = {{"access_key_id", 1}, {"secret_access_key", 2}, {"session_token", 3}, {"format", 4}, {"structure", 5}, {"compression_method", 6}};
         }
 
         /// This argument is always the first
@@ -262,24 +250,16 @@ void TableFunctionS3::addColumnsStructureToArguments(ASTs & args, const String &
     }
     else
     {
-        /// If arguments contain headers, just remove it and add to the end of arguments later
-        /// (header argument can be at any position).
         HTTPHeaderEntries tmp_headers;
-        auto * headers_it = StorageURL::collectHeaders(args, tmp_headers, context);
-        ASTPtr headers_ast;
-        if (headers_it != args.end())
-        {
-            headers_ast = *headers_it;
-            args.erase(headers_it);
-        }
+        size_t count = StorageURL::evalArgsAndCollectHeaders(args, tmp_headers, context);
 
-        if (args.empty() || args.size() > getMaxNumberOfArguments())
-            throw Exception(ErrorCodes::LOGICAL_ERROR, "Expected 1 to {} arguments in table function, got {}", getMaxNumberOfArguments(), args.size());
+        if (count == 0 || count > getMaxNumberOfArguments())
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "Expected 1 to {} arguments in table function, got {}", getMaxNumberOfArguments(), count);
 
         auto structure_literal = std::make_shared<ASTLiteral>(structure);
 
         /// s3(s3_url)
-        if (args.size() == 1)
+        if (count == 1)
         {
             /// Add format=auto before structure argument.
             args.push_back(std::make_shared<ASTLiteral>("auto"));
@@ -287,7 +267,7 @@ void TableFunctionS3::addColumnsStructureToArguments(ASTs & args, const String &
         }
         /// s3(s3_url, format) or s3(s3_url, NOSIGN)
         /// We can distinguish them by looking at the 2-nd argument: check if it's NOSIGN or not.
-        else if (args.size() == 2)
+        else if (count == 2)
         {
             auto second_arg = checkAndGetLiteralArgument<String>(args[1], "format/NOSIGN");
             /// If there is NOSIGN, add format=auto before structure.
@@ -296,10 +276,10 @@ void TableFunctionS3::addColumnsStructureToArguments(ASTs & args, const String &
             args.push_back(structure_literal);
         }
         /// s3(source, format, structure) or
-        /// s3(source, access_key_id, access_key_id) or
+        /// s3(source, access_key_id, secret_access_key) or
         /// s3(source, NOSIGN, format)
         /// We can distinguish them by looking at the 2-nd argument: check if it's NOSIGN, format name or neither.
-        else if (args.size() == 3)
+        else if (count == 3)
         {
             auto second_arg = checkAndGetLiteralArgument<String>(args[1], "format/NOSIGN");
             if (boost::iequals(second_arg, "NOSIGN"))
@@ -308,7 +288,7 @@ void TableFunctionS3::addColumnsStructureToArguments(ASTs & args, const String &
             }
             else if (second_arg == "auto" || FormatFactory::instance().getAllFormats().contains(second_arg))
             {
-                args.back() = structure_literal;
+                args[count - 1] = structure_literal;
             }
             else
             {
@@ -318,48 +298,45 @@ void TableFunctionS3::addColumnsStructureToArguments(ASTs & args, const String &
             }
         }
         /// s3(source, format, structure, compression_method) or
-        /// s3(source, access_key_id, access_key_id, format) or
+        /// s3(source, access_key_id, secret_access_key, format) or
         /// s3(source, NOSIGN, format, structure)
         /// We can distinguish them by looking at the 2-nd argument: check if it's NOSIGN, format name or neither.
-        else if (args.size() == 4)
+        else if (count == 4)
         {
             auto second_arg = checkAndGetLiteralArgument<String>(args[1], "format/NOSIGN");
             if (boost::iequals(second_arg, "NOSIGN"))
             {
-                args.back() = structure_literal;
+                args[count - 1] = structure_literal;
             }
             else if (second_arg == "auto" || FormatFactory::instance().getAllFormats().contains(second_arg))
             {
-                args[args.size() - 2] = structure_literal;
+                args[count - 2] = structure_literal;
             }
             else
             {
                 args.push_back(structure_literal);
             }
         }
-        /// s3(source, access_key_id, access_key_id, format, structure) or
+        /// s3(source, access_key_id, secret_access_key, format, structure) or
         /// s3(source, NOSIGN, format, structure, compression_method)
         /// We can distinguish them by looking at the 2-nd argument: check if it's a NOSIGN keyword name or not.
-        else if (args.size() == 5)
+        else if (count == 5)
         {
             auto sedond_arg = checkAndGetLiteralArgument<String>(args[1], "format/NOSIGN");
             if (boost::iequals(sedond_arg, "NOSIGN"))
             {
-                args[args.size() - 2] = structure_literal;
+                args[count - 2] = structure_literal;
             }
             else
             {
-                args.back() = structure_literal;
+                args[count - 1] = structure_literal;
             }
         }
-        /// s3(source, access_key_id, access_key_id, format, structure, compression)
-        else if (args.size() == 6)
+        /// s3(source, access_key_id, secret_access_key, format, structure, compression)
+        else if (count == 6)
         {
-            args[args.size() - 2] = structure_literal;
+            args[count - 2] = structure_literal;
         }
-
-        if (headers_ast)
-            args.push_back(headers_ast);
     }
 }
 

--- a/tests/queries/0_stateless/02968_url_args.reference
+++ b/tests/queries/0_stateless/02968_url_args.reference
@@ -1,0 +1,1 @@
+CREATE TABLE default.a\n(\n    `x` Int64\n)\nENGINE = URL(\'https://example.com/\', \'CSV\', headers(\'foo\' = \'bar\'))

--- a/tests/queries/0_stateless/02968_url_args.sql
+++ b/tests/queries/0_stateless/02968_url_args.sql
@@ -1,0 +1,2 @@
+create table a (x Int64) engine URL('https://example.com/', CSV, headers('foo' = 'bar'));
+show create a;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed URL and S3 engines losing the `headers` argument on server restart.

URL table with `headers` argument used to lose that argument on restart (i.e. before the restart it was sending requests with the headers, after restart - without the headers).

That's because arg parsing code was inadvertently removing the argument from the AST:
```
:) create table a (x Int64) engine URL('https://example.com/', CSV, headers('foo' = 'bar'))

CREATE TABLE a
(
    `x` Int64
)
ENGINE = URL('https://example.com/', CSV, headers('foo' = 'bar'))

Query id: 948d59db-9fbd-491e-9aef-29edc9f492af

Ok.

0 rows in set. Elapsed: 0.003 sec. 

:) show create a

SHOW CREATE TABLE a

Query id: d2796f60-cb9a-499e-88b8-4d8607ec8a04

┌─statement────────────────────────────────────────────────────────────────────────┐
│ CREATE TABLE default.a
(
    `x` Int64
)
ENGINE = URL('https://example.com/', 'CSV') │
└──────────────────────────────────────────────────────────────────────────────────┘

1 row in set. Elapsed: 0.001 sec. 

```