### PR TITLE
Call `getMaxFileDescriptorCount` once in Keeper

### DIFF
--- a/src/Common/getMaxFileDescriptorCount.cpp
+++ b/src/Common/getMaxFileDescriptorCount.cpp
@@ -3,17 +3,17 @@
 
 std::optional<size_t> getMaxFileDescriptorCount()
 {
+#if defined(OS_LINUX) || defined(OS_DARWIN)
+    /// We want to calculate it only once.
     static auto result = []() -> std::optional<size_t>
     {
-    #if defined(OS_LINUX) || defined(OS_DARWIN)
         rlimit rlim;
-        if (getrlimit(RLIMIT_NOFILE, &rlim))
+        if (0 != getrlimit(RLIMIT_NOFILE, &rlim))
             return std::nullopt;
         return rlim.rlim_max;
-    #else
-        return std::nullopt;
-    #endif
     }();
-
     return result;
+#else
+    return std::nullopt;
+#endif
 }

--- a/src/Common/getMaxFileDescriptorCount.h
+++ b/src/Common/getMaxFileDescriptorCount.h
@@ -1,6 +1,8 @@
 #pragma once
 
+#include <optional>
+
 /// Get process max file descriptor count
-/// @return -1 if os does not support ulimit command or some error occurs
-int getMaxFileDescriptorCount();
+/// @return std::nullopt if os does not support getrlimit command or some error occurs
+std::optional<size_t> getMaxFileDescriptorCount();
 

--- a/src/Coordination/FourLetterCommand.cpp
+++ b/src/Coordination/FourLetterCommand.cpp
@@ -300,7 +300,11 @@ String MonitorCommand::run()
 
 #if defined(OS_LINUX) || defined(OS_DARWIN)
     print(ret, "open_file_descriptor_count", getCurrentProcessFDCount());
-    print(ret, "max_file_descriptor_count", getMaxFileDescriptorCount());
+    auto max_file_descriptor_count = getMaxFileDescriptorCount();
+    if (max_file_descriptor_count.has_value())
+        print(ret, "max_file_descriptor_count", *max_file_descriptor_count);
+    else
+        print(ret, "max_file_descriptor_count", -1);
 #endif
 
     if (keeper_info.is_leader)

--- a/src/Coordination/KeeperAsynchronousMetrics.cpp
+++ b/src/Coordination/KeeperAsynchronousMetrics.cpp
@@ -22,7 +22,7 @@ void updateKeeperInformation(KeeperDispatcher & keeper_dispatcher, AsynchronousM
     size_t key_arena_size = 0;
     size_t latest_snapshot_size = 0;
     size_t open_file_descriptor_count = 0;
-    size_t max_file_descriptor_count = 0;
+    std::optional<size_t> max_file_descriptor_count = 0;
     size_t followers = 0;
     size_t synced_followers = 0;
     size_t zxid = 0;
@@ -78,7 +78,10 @@ void updateKeeperInformation(KeeperDispatcher & keeper_dispatcher, AsynchronousM
     new_values["KeeperLatestSnapshotSize"] = { latest_snapshot_size, "The uncompressed size in bytes of the latest snapshot created by ClickHouse Keeper." };
 
     new_values["KeeperOpenFileDescriptorCount"] = { open_file_descriptor_count, "The number of open file descriptors in ClickHouse Keeper." };
-    new_values["KeeperMaxFileDescriptorCount"] = { max_file_descriptor_count, "The maximum number of open file descriptors in ClickHouse Keeper." };
+    if (max_file_descriptor_count.has_value())
+        new_values["KeeperMaxFileDescriptorCount"] = { *max_file_descriptor_count, "The maximum number of open file descriptors in ClickHouse Keeper." };
+    else
+        new_values["KeeperMaxFileDescriptorCount"] = { -1, "The maximum number of open file descriptors in ClickHouse Keeper." };
 
     new_values["KeeperFollowers"] = { followers, "The number of followers of ClickHouse Keeper." };
     new_values["KeeperSyncedFollowers"] = { synced_followers, "The number of followers of ClickHouse Keeper who are also in-sync." };


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
