### PR TITLE
Fix flaky test_postgresql_replica_database_engine_2/test.py::test_dependent_loading

### DIFF
--- a/tests/integration/test_postgresql_replica_database_engine_2/test.py
+++ b/tests/integration/test_postgresql_replica_database_engine_2/test.py
@@ -1093,6 +1093,8 @@ def test_dependent_loading(started_cluster):
         f"SELECT toDateTime64('{nested_time}', 6) < toDateTime64('{time}', 6)"
     )
 
+    instance.query(f"DROP TABLE {table} SYNC")
+
 
 if __name__ == "__main__":
     cluster.start()


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Fixes failure like: 
```
    def drop_postgres_db(self, database_name=""):
        database_name = self.database_or_default(database_name)
>       self.cursor.execute(f'DROP DATABASE IF EXISTS "{database_name}" WITH (FORCE)')
E       psycopg2.errors.ObjectInUse: database "postgres_database" is used by an active logical replication slot
E       DETAIL:  There is 1 active slot.
```
