### PR TITLE
Fix flaky test_parallel_replicas_custom_key_failover

### DIFF
--- a/tests/integration/test_parallel_replicas_custom_key_failover/test.py
+++ b/tests/integration/test_parallel_replicas_custom_key_failover/test.py
@@ -81,9 +81,9 @@ def test_parallel_replicas_custom_key_failover(
                 "parallel_replicas_custom_key": custom_key,
                 "parallel_replicas_custom_key_filter_type": filter_type,
                 "use_hedged_requests": use_hedged_requests,
-                "max_replica_delay_for_distributed_queries": 0, # avoid considering replica delay on connection choice
-                                                                # otherwise connection will not be distributed evenly among available nodes
-                                                                # and so custom key secondary queries
+                "max_replica_delay_for_distributed_queries": 0,  # avoid considering replica delay on connection choice
+                # otherwise connection will not be distributed evenly among available nodes
+                # and so custom key secondary queries
                 # "async_socket_for_remote": 0,
                 # "async_query_sending_for_remote": 0,
             },

--- a/tests/integration/test_parallel_replicas_custom_key_failover/test.py
+++ b/tests/integration/test_parallel_replicas_custom_key_failover/test.py
@@ -81,6 +81,9 @@ def test_parallel_replicas_custom_key_failover(
                 "parallel_replicas_custom_key": custom_key,
                 "parallel_replicas_custom_key_filter_type": filter_type,
                 "use_hedged_requests": use_hedged_requests,
+                "max_replica_delay_for_distributed_queries": 0, # avoid considering replica delay on connection choice
+                                                                # otherwise connection will not be distributed evenly among available nodes
+                                                                # and so custom key secondary queries
                 # "async_socket_for_remote": 0,
                 # "async_query_sending_for_remote": 0,
             },
@@ -106,6 +109,7 @@ def test_parallel_replicas_custom_key_failover(
             == "subqueries\t4\n"
         )
 
+        # check queries distribution among nodes, it should be even
         assert (
             node1.query(
                 f"SELECT h, count() FROM clusterAllReplicas({cluster}, system.query_log) WHERE initial_query_id = '{query_id}' AND type ='QueryFinish' GROUP BY hostname() as h ORDER BY h SETTINGS skip_unavailable_shards=1"

--- a/tests/integration/test_parallel_replicas_custom_key_failover/test.py
+++ b/tests/integration/test_parallel_replicas_custom_key_failover/test.py
@@ -82,9 +82,10 @@ def test_parallel_replicas_custom_key_failover(
                 "parallel_replicas_custom_key_filter_type": filter_type,
                 "use_hedged_requests": use_hedged_requests,
                 # fmt: off
-                "max_replica_delay_for_distributed_queries": 0, # avoid considering replica delay on connection choice
-                                                                # otherwise connection will not be distributed evenly among available nodes
-                                                                # and so custom key secondary queries
+                "max_replica_delay_for_distributed_queries": 0,
+                # avoid considering replica delay on connection choice
+                # otherwise connection will not be distributed evenly among available nodes
+                # and so custom key secondary queries
                 # fmt: on
             },
         )

--- a/tests/integration/test_parallel_replicas_custom_key_failover/test.py
+++ b/tests/integration/test_parallel_replicas_custom_key_failover/test.py
@@ -81,11 +81,11 @@ def test_parallel_replicas_custom_key_failover(
                 "parallel_replicas_custom_key": custom_key,
                 "parallel_replicas_custom_key_filter_type": filter_type,
                 "use_hedged_requests": use_hedged_requests,
-                "max_replica_delay_for_distributed_queries": 0,  # avoid considering replica delay on connection choice
-                # otherwise connection will not be distributed evenly among available nodes
-                # and so custom key secondary queries
-                # "async_socket_for_remote": 0,
-                # "async_query_sending_for_remote": 0,
+                # fmt: off
+                "max_replica_delay_for_distributed_queries": 0, # avoid considering replica delay on connection choice
+                                                                # otherwise connection will not be distributed evenly among available nodes
+                                                                # and so custom key secondary queries
+                # fmt: on
             },
         )
         == expected_result

--- a/tests/integration/test_parallel_replicas_custom_key_load_balancing/test.py
+++ b/tests/integration/test_parallel_replicas_custom_key_load_balancing/test.py
@@ -83,9 +83,9 @@ def test_parallel_replicas_custom_key_load_balancing(
                 "parallel_replicas_custom_key": custom_key,
                 "parallel_replicas_custom_key_filter_type": filter_type,
                 "use_hedged_requests": use_hedged_requests,
-                "max_replica_delay_for_distributed_queries": 0, # avoid considering replica delay on connection choice
-                                                                # otherwise connection will not be distributed evenly among available nodes
-                                                                # and so custom key secondary queries
+                "max_replica_delay_for_distributed_queries": 0,  # avoid considering replica delay on connection choice
+                # otherwise connection will not be distributed evenly among available nodes
+                # and so custom key secondary queries
                 # "async_socket_for_remote": 0,
                 # "async_query_sending_for_remote": 0,
             },

--- a/tests/integration/test_parallel_replicas_custom_key_load_balancing/test.py
+++ b/tests/integration/test_parallel_replicas_custom_key_load_balancing/test.py
@@ -83,11 +83,11 @@ def test_parallel_replicas_custom_key_load_balancing(
                 "parallel_replicas_custom_key": custom_key,
                 "parallel_replicas_custom_key_filter_type": filter_type,
                 "use_hedged_requests": use_hedged_requests,
-                "max_replica_delay_for_distributed_queries": 0,  # avoid considering replica delay on connection choice
-                # otherwise connection will not be distributed evenly among available nodes
-                # and so custom key secondary queries
-                # "async_socket_for_remote": 0,
-                # "async_query_sending_for_remote": 0,
+                # fmt: off
+                "max_replica_delay_for_distributed_queries": 0, # avoid considering replica delay on connection choice
+                                                                # otherwise connection will not be distributed evenly among available nodes
+                                                                # and so custom key secondary queries
+                # fmt: on
             },
         )
         == expected_result

--- a/tests/integration/test_parallel_replicas_custom_key_load_balancing/test.py
+++ b/tests/integration/test_parallel_replicas_custom_key_load_balancing/test.py
@@ -83,6 +83,9 @@ def test_parallel_replicas_custom_key_load_balancing(
                 "parallel_replicas_custom_key": custom_key,
                 "parallel_replicas_custom_key_filter_type": filter_type,
                 "use_hedged_requests": use_hedged_requests,
+                "max_replica_delay_for_distributed_queries": 0, # avoid considering replica delay on connection choice
+                                                                # otherwise connection will not be distributed evenly among available nodes
+                                                                # and so custom key secondary queries
                 # "async_socket_for_remote": 0,
                 # "async_query_sending_for_remote": 0,
             },
@@ -107,7 +110,7 @@ def test_parallel_replicas_custom_key_load_balancing(
         == "subqueries\t4\n"
     )
 
-    # check queries per node
+    # check queries distribution among nodes, it should be even
     assert (
         node1.query(
             f"SELECT h, count() FROM clusterAllReplicas({cluster}, system.query_log) WHERE initial_query_id = '{query_id}' AND type ='QueryFinish' GROUP BY hostname() as h ORDER BY h SETTINGS skip_unavailable_shards=1"

--- a/tests/integration/test_parallel_replicas_custom_key_load_balancing/test.py
+++ b/tests/integration/test_parallel_replicas_custom_key_load_balancing/test.py
@@ -84,9 +84,10 @@ def test_parallel_replicas_custom_key_load_balancing(
                 "parallel_replicas_custom_key_filter_type": filter_type,
                 "use_hedged_requests": use_hedged_requests,
                 # fmt: off
-                "max_replica_delay_for_distributed_queries": 0, # avoid considering replica delay on connection choice
-                                                                # otherwise connection will not be distributed evenly among available nodes
-                                                                # and so custom key secondary queries
+                "max_replica_delay_for_distributed_queries": 0,
+                # avoid considering replica delay on connection choice
+                # otherwise connection will not be distributed evenly among available nodes
+                # and so custom key secondary queries
                 # fmt: on
             },
         )


### PR DESCRIPTION
Follow-up #58909. Replicas delays can affect connection choice by connection pool, and therefore, make the test flaky. Zeroing `max_replica_delay_for_distributed_queries` should exclude replicas lag from consideration when choosing a connection.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)