### PR TITLE
Analyzer: fix storage replacement with insertion block

### DIFF
--- a/src/Analyzer/Utils.cpp
+++ b/src/Analyzer/Utils.cpp
@@ -354,13 +354,13 @@ QueryTreeNodes extractTrueTableExpressions(const QueryTreeNodePtr & tree)
             }
             case QueryTreeNodeType::UNION:
             {
-                for (auto union_node : node_to_process->as<UnionNode>()->getQueries().getNodes())
+                for (const auto & union_node : node_to_process->as<UnionNode>()->getQueries().getNodes())
                     nodes_to_process.push_front(union_node);
                 break;
             }
             case QueryTreeNodeType::TABLE_FUNCTION:
             {
-                for (auto argument_node : node_to_process->as<TableFunctionNode>()->getArgumentsNode()->getChildren())
+                for (const auto & argument_node : node_to_process->as<TableFunctionNode>()->getArgumentsNode()->getChildren())
                     nodes_to_process.push_front(argument_node);
                 break;
             }

--- a/src/Analyzer/Utils.cpp
+++ b/src/Analyzer/Utils.cpp
@@ -446,7 +446,6 @@ QueryTreeNodes extractTableExpressions(const QueryTreeNodePtr & join_tree_node, 
 
 QueryTreeNodePtr extractLeftTableExpression(const QueryTreeNodePtr & join_tree_node)
 {
-std::cout << "\033[1;31m" << "+++ JOO extractLeftTableExpression 0" << "\033[0m" << std::endl;
     QueryTreeNodePtr result;
 
     std::deque<QueryTreeNodePtr> nodes_to_process;
@@ -458,7 +457,7 @@ std::cout << "\033[1;31m" << "+++ JOO extractLeftTableExpression 0" << "\033[0m"
         nodes_to_process.pop_front();
 
         auto node_type = node_to_process->getNodeType();
-std::cout << "\033[1;31m" << "+++ JOO extractLeftTableExpression " << static_cast<int>(node_type) << "\033[0m" << std::endl;
+
         switch (node_type)
         {
             case QueryTreeNodeType::TABLE:

--- a/src/Analyzer/Utils.cpp
+++ b/src/Analyzer/Utils.cpp
@@ -360,8 +360,7 @@ QueryTreeNodes extractAllTableReferences(const QueryTreeNodePtr & tree)
             }
             case QueryTreeNodeType::TABLE_FUNCTION:
             {
-                for (const auto & argument_node : node_to_process->as<TableFunctionNode>()->getArgumentsNode()->getChildren())
-                    nodes_to_process.push_back(argument_node);
+                // Arguments of table function can't contain TableNodes.
                 break;
             }
             case QueryTreeNodeType::ARRAY_JOIN:

--- a/src/Analyzer/Utils.h
+++ b/src/Analyzer/Utils.h
@@ -50,6 +50,9 @@ std::optional<bool> tryExtractConstantFromConditionNode(const QueryTreeNodePtr &
   */
 void addTableExpressionOrJoinIntoTablesInSelectQuery(ASTPtr & tables_in_select_query_ast, const QueryTreeNodePtr & table_expression, const IQueryTreeNode::ConvertToASTOptions & convert_to_ast_options);
 
+/// Extract table expressions from tree
+QueryTreeNodes extractTrueTableExpressions(const QueryTreeNodePtr & tree);
+
 /// Extract table, table function, query, union from join tree
 QueryTreeNodes extractTableExpressions(const QueryTreeNodePtr & join_tree_node, bool add_array_join = false);
 

--- a/src/Analyzer/Utils.h
+++ b/src/Analyzer/Utils.h
@@ -50,13 +50,13 @@ std::optional<bool> tryExtractConstantFromConditionNode(const QueryTreeNodePtr &
   */
 void addTableExpressionOrJoinIntoTablesInSelectQuery(ASTPtr & tables_in_select_query_ast, const QueryTreeNodePtr & table_expression, const IQueryTreeNode::ConvertToASTOptions & convert_to_ast_options);
 
-/// Extract table expressions from tree
-QueryTreeNodes extractTrueTableExpressions(const QueryTreeNodePtr & tree);
+/// Extract all TableNodes from the query tree.
+QueryTreeNodes extractAllTableReferences(const QueryTreeNodePtr & tree);
 
-/// Extract table, table function, query, union from join tree
+/// Extract table, table function, query, union from join tree.
 QueryTreeNodes extractTableExpressions(const QueryTreeNodePtr & join_tree_node, bool add_array_join = false);
 
-/// Extract left table expression from join tree
+/// Extract left table expression from join tree.
 QueryTreeNodePtr extractLeftTableExpression(const QueryTreeNodePtr & join_tree_node);
 
 /** Build table expressions stack that consists from table, table function, query, union, join, array join from join tree.

--- a/src/Interpreters/InterpreterSelectQueryAnalyzer.cpp
+++ b/src/Interpreters/InterpreterSelectQueryAnalyzer.cpp
@@ -1,4 +1,3 @@
-#include <Analyzer/IQueryTreeNode.h>
 #include <Interpreters/InterpreterFactory.h>
 #include <Interpreters/InterpreterSelectQueryAnalyzer.h>
 
@@ -75,7 +74,7 @@ ContextMutablePtr buildContext(const ContextPtr & context, const SelectQueryOpti
 
 void replaceStorageInQueryTree(QueryTreeNodePtr & query_tree, const ContextPtr & context, const StoragePtr & storage)
 {
-    auto nodes = extractTrueTableExpressions(query_tree);
+    auto nodes = extractAllTableReferences(query_tree);
     IQueryTreeNode::ReplacementMap replacement_map;
 
     for (auto & node : nodes)
@@ -90,9 +89,6 @@ void replaceStorageInQueryTree(QueryTreeNodePtr & query_tree, const ContextPtr &
 
         if (auto table_expression_modifiers = table_node.getTableExpressionModifiers())
             replacement_table_expression->setTableExpressionModifiers(*table_expression_modifiers);
-
-        if (node->hasAlias())
-            replacement_table_expression->setAlias(node->getAlias() + "_replacement");
 
         replacement_map.emplace(node.get(), std::move(replacement_table_expression));
     }

--- a/src/Interpreters/InterpreterSelectQueryAnalyzer.cpp
+++ b/src/Interpreters/InterpreterSelectQueryAnalyzer.cpp
@@ -78,7 +78,7 @@ void replaceStorageInQueryTree(QueryTreeNodePtr & query_tree, const ContextPtr &
 {
     auto nodes = extractTrueTableExpressions(query_tree);
     IQueryTreeNode::ReplacementMap replacement_map;
-    
+
     for (auto & node : nodes)
     {
         auto & table_node = node->as<TableNode &>();
@@ -117,12 +117,10 @@ QueryTreeNodePtr buildQueryTreeAndRunPasses(const ASTPtr & query,
         query_tree_pass_manager.runOnlyResolve(query_tree);
     else
         query_tree_pass_manager.run(query_tree);
-std::cout << "\033[1;31m" << "+++ JOO query_tree\n" << query_tree->dumpTree() << "\033[0m" << std::endl;
-    if (storage) {
+
+    if (storage)
         replaceStorageInQueryTree(query_tree, context, storage);
-//        replaceStorageInQueryTree(query_tree, context, storage, false);
-    }
-std::cout << "\033[1;31m" << "+++ JOO query_tree NEW\n" << query_tree->dumpTree() << "\033[0m" << std::endl;
+
     return query_tree;
 }
 

--- a/src/Interpreters/InterpreterSelectQueryAnalyzer.cpp
+++ b/src/Interpreters/InterpreterSelectQueryAnalyzer.cpp
@@ -1,5 +1,4 @@
-#include "Analyzer/IQueryTreeNode.h"
-#include "Analyzer/JoinNode.h"
+#include <Analyzer/IQueryTreeNode.h>
 #include <Interpreters/InterpreterFactory.h>
 #include <Interpreters/InterpreterSelectQueryAnalyzer.h>
 


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix analyzer - insertion from select with subquery referencing insertion table should process only insertion block for all table expressions.
Fixes #58080.
follow-up #50857
