### PR TITLE
Less threads in `clickhouse-local`

### DIFF
--- a/src/Functions/UserDefined/ExternalUserDefinedExecutableFunctionsLoader.cpp
+++ b/src/Functions/UserDefined/ExternalUserDefinedExecutableFunctionsLoader.cpp
@@ -100,7 +100,8 @@ ExternalUserDefinedExecutableFunctionsLoader::ExternalUserDefinedExecutableFunct
 {
     setConfigSettings({"function", "name", "database", "uuid"});
     enableAsyncLoading(false);
-    enablePeriodicUpdates(true);
+    if (getContext()->getApplicationType() == Context::ApplicationType::SERVER)
+        enablePeriodicUpdates(true);
     enableAlwaysLoadEverything(true);
 }
 

--- a/src/Interpreters/ExternalDictionariesLoader.cpp
+++ b/src/Interpreters/ExternalDictionariesLoader.cpp
@@ -27,7 +27,8 @@ ExternalDictionariesLoader::ExternalDictionariesLoader(ContextPtr global_context
 {
     setConfigSettings({"dictionary", "name", "database", "uuid"});
     enableAsyncLoading(true);
-    enablePeriodicUpdates(true);
+    if (getContext()->getApplicationType() == Context::ApplicationType::SERVER)
+        enablePeriodicUpdates(true);
 }
 
 ExternalLoader::LoadablePtr ExternalDictionariesLoader::create(


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Use one thread less in `clickhouse-local`.

Before:
```
$ strace -f -e trace=clone clickhouse-local --query "SELECT 1"
strace: Process 103056 attached
strace: Process 103057 attached
strace: Process 103058 attached
strace: Process 103059 attached
strace: Process 103060 attached
strace: Process 103061 attached
1
[pid 103060] +++ exited with 0 +++
[pid 103056] +++ exited with 0 +++
[pid 103061] +++ exited with 0 +++
[pid 103057] +++ exited with 0 +++
[pid 103059] +++ exited with 0 +++
[pid 103058] +++ exited with 0 +++
+++ exited with 0 +++
```

After:
```
$ strace -f -e trace=clone clickhouse-local --query "SELECT 1"
strace: Process 104149 attached
strace: Process 104150 attached
strace: Process 104151 attached
strace: Process 104152 attached
strace: Process 104153 attached
1
[pid 104153] +++ exited with 0 +++
[pid 104152] +++ exited with 0 +++
[pid 104149] +++ exited with 0 +++
[pid 104151] +++ exited with 0 +++
[pid 104150] +++ exited with 0 +++
+++ exited with 0 +++
```

See the difference?