### PR TITLE
Draft: Adding metrics to debug ThreadPool misbehaviour

### DIFF
--- a/programs/copier/Internals.h
+++ b/programs/copier/Internals.h
@@ -14,7 +14,6 @@
 #include <Poco/Util/HelpFormatter.h>
 #include <boost/algorithm/string.hpp>
 #include <Common/logger_useful.h>
-#include <Common/ThreadPool.h>
 #include <Common/Exception.h>
 #include <Common/ZooKeeper/ZooKeeper.h>
 #include <Common/ZooKeeper/KeeperException.h>

--- a/src/Common/CurrentMetrics.cpp
+++ b/src/Common/CurrentMetrics.cpp
@@ -72,9 +72,9 @@
     M(GlobalThread, "Number of threads in global thread pool.") \
     M(GlobalThreadActive, "Number of threads in global thread pool running a task.") \
     M(GlobalThreadScheduled, "Number of queued or active jobs in global thread pool.") \
-    M(LocalThread, "Number of threads in local thread pools. The threads in local thread pools are taken from the global thread pool.") \
-    M(LocalThreadActive, "Number of threads in local thread pools running a task.") \
-    M(LocalThreadScheduled, "Number of queued or active jobs in local thread pools.") \
+    M(LocalThread, "Obsolete. Number of threads in all local thread pools. The threads in local thread pools are taken from the global thread pool.") /* see https://github.com/ClickHouse/ClickHouse/pull/47880 */ \
+    M(LocalThreadActive, "Obsolete. Number of threads in local thread pools running a task.") \
+    M(LocalThreadScheduled, "Obsolete. Number of queued or active jobs in local thread pools.") \
     M(MergeTreeDataSelectExecutorThreads, "Number of threads in the MergeTreeDataSelectExecutor thread pool.") \
     M(MergeTreeDataSelectExecutorThreadsActive, "Number of threads in the MergeTreeDataSelectExecutor thread pool running a task.") \
     M(MergeTreeDataSelectExecutorThreadsScheduled, "Number of queued or active jobs in the MergeTreeDataSelectExecutor thread pool.") \

--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -72,6 +72,13 @@
     M(NetworkReceiveBytes, "Total number of bytes received from network. Only ClickHouse-related network interaction is included, not by 3rd party libraries.") \
     M(NetworkSendBytes, "Total number of bytes send to network. Only ClickHouse-related network interaction is included, not by 3rd party libraries.") \
     \
+    M(GlobalThreadPoolExpansions, "Counts the total number of times new threads were added to the global thread pool. This metric indicates the frequency of global thread pool expansions to accommodate increased processing demands.") \
+    M(GlobalThreadPoolShrinks, "Counts the total number of times the global thread pool was shrunk by removing threads, triggered when the number of idle threads exceeded max_thread_pool_free_size. This metric highlights the adjustments in the global thread pool size in response to decreased thread utilization") \
+    M(GlobalThreadPoolJobScheduleMicroseconds, "Total time spent waiting to schedule a job in the global thread pool. This metric accounts for the time elapsed from the moment a job scheduling request is made until the job is successfully queued in the global thread pool, reflecting the responsiveness and scheduling efficiency of the pool.") \
+    M(LocalThreadPoolExpansions, "Counts the total number of times threads were borrowed from the global thread pool to expand local thread pools.") \
+    M(LocalThreadPoolShrinks, "Counts the total number of times threads were returned to the global thread pool from local thread pools.") \
+    M(LocalThreadPoolJobScheduleMicroseconds, "Total time spent waiting to schedule a job in a local thread pool. This metric measures the time elapsed from when a job scheduling request is initiated until the job is successfully queued in the local thread pool. Shows how much time the jobs were waiting for a free slot in the local pool.") \
+    \
     M(DiskS3GetRequestThrottlerCount, "Number of DiskS3 GET and SELECT requests passed through throttler.") \
     M(DiskS3GetRequestThrottlerSleepMicroseconds, "Total time a query was sleeping to conform DiskS3 GET and SELECT request throttling.") \
     M(DiskS3PutRequestThrottlerCount, "Number of DiskS3 PUT, COPY, POST and LIST requests passed through throttler.") \

--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -75,9 +75,14 @@
     M(GlobalThreadPoolExpansions, "Counts the total number of times new threads were added to the global thread pool. This metric indicates the frequency of global thread pool expansions to accommodate increased processing demands.") \
     M(GlobalThreadPoolShrinks, "Counts the total number of times the global thread pool was shrunk by removing threads, triggered when the number of idle threads exceeded max_thread_pool_free_size. This metric highlights the adjustments in the global thread pool size in response to decreased thread utilization") \
     M(GlobalThreadPoolJobScheduleMicroseconds, "Total time spent waiting to schedule a job in the global thread pool. This metric accounts for the time elapsed from the moment a job scheduling request is made until the job is successfully queued in the global thread pool, reflecting the responsiveness and scheduling efficiency of the pool.") \
+    M(GlobalThreadPoolThreadCreationMicroseconds, "") \
+    M(GlobalThreadPoolJobScheduleLockWaitMicroseconds, "") \
+    \
     M(LocalThreadPoolExpansions, "Counts the total number of times threads were borrowed from the global thread pool to expand local thread pools.") \
     M(LocalThreadPoolShrinks, "Counts the total number of times threads were returned to the global thread pool from local thread pools.") \
     M(LocalThreadPoolJobScheduleMicroseconds, "Total time spent waiting to schedule a job in a local thread pool. This metric measures the time elapsed from when a job scheduling request is initiated until the job is successfully queued in the local thread pool. Shows how much time the jobs were waiting for a free slot in the local pool.") \
+    M(LocalThreadPoolThreadCreationMicroseconds, "") \
+    M(LocalThreadPoolJobScheduleLockWaitMicroseconds, "") \
     \
     M(DiskS3GetRequestThrottlerCount, "Number of DiskS3 GET and SELECT requests passed through throttler.") \
     M(DiskS3GetRequestThrottlerSleepMicroseconds, "Total time a query was sleeping to conform DiskS3 GET and SELECT request throttling.") \

--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -77,12 +77,18 @@
     M(GlobalThreadPoolJobScheduleMicroseconds, "Total time spent waiting to schedule a job in the global thread pool. This metric accounts for the time elapsed from the moment a job scheduling request is made until the job is successfully queued in the global thread pool, reflecting the responsiveness and scheduling efficiency of the pool.") \
     M(GlobalThreadPoolThreadCreationMicroseconds, "") \
     M(GlobalThreadPoolJobScheduleLockWaitMicroseconds, "") \
+    M(GlobalThreadPoolJobEmplacementMicroseconds, "") \
+    M(GlobalThreadPoolCondVarWaitingMicroseconds, "") \
+    M(GlobalThreadPoolJobsCounter, "") \
     \
     M(LocalThreadPoolExpansions, "Counts the total number of times threads were borrowed from the global thread pool to expand local thread pools.") \
     M(LocalThreadPoolShrinks, "Counts the total number of times threads were returned to the global thread pool from local thread pools.") \
     M(LocalThreadPoolJobScheduleMicroseconds, "Total time spent waiting to schedule a job in a local thread pool. This metric measures the time elapsed from when a job scheduling request is initiated until the job is successfully queued in the local thread pool. Shows how much time the jobs were waiting for a free slot in the local pool.") \
     M(LocalThreadPoolThreadCreationMicroseconds, "") \
     M(LocalThreadPoolJobScheduleLockWaitMicroseconds, "") \
+    M(LocalThreadPoolJobEmplacementMicroseconds, "") \
+    M(LocalThreadPoolCondVarWaitingMicroseconds, "") \
+    M(LocalThreadPoolJobsCounter, "") \
     \
     M(DiskS3GetRequestThrottlerCount, "Number of DiskS3 GET and SELECT requests passed through throttler.") \
     M(DiskS3GetRequestThrottlerSleepMicroseconds, "Total time a query was sleeping to conform DiskS3 GET and SELECT request throttling.") \

--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -80,6 +80,9 @@
     M(GlobalThreadPoolJobEmplacementMicroseconds, "") \
     M(GlobalThreadPoolCondVarWaitingMicroseconds, "") \
     M(GlobalThreadPoolJobsCounter, "") \
+    M(GlobalThreadPoolWorkerLoops, "") \
+    M(GlobalThreadPoolWorkerLockWaitMicroseconds, "") \
+    M(GlobalThreadPoolWorkerLockHoldingMicroseconds, "") \
     \
     M(LocalThreadPoolExpansions, "Counts the total number of times threads were borrowed from the global thread pool to expand local thread pools.") \
     M(LocalThreadPoolShrinks, "Counts the total number of times threads were returned to the global thread pool from local thread pools.") \
@@ -89,6 +92,9 @@
     M(LocalThreadPoolJobEmplacementMicroseconds, "") \
     M(LocalThreadPoolCondVarWaitingMicroseconds, "") \
     M(LocalThreadPoolJobsCounter, "") \
+    M(LocalThreadPoolWorkerLoops, "") \
+    M(LocalThreadPoolWorkerLockWaitMicroseconds, "") \
+    M(LocalThreadPoolWorkerLockHoldingMicroseconds, "") \
     \
     M(DiskS3GetRequestThrottlerCount, "Number of DiskS3 GET and SELECT requests passed through throttler.") \
     M(DiskS3GetRequestThrottlerSleepMicroseconds, "Total time a query was sleeping to conform DiskS3 GET and SELECT request throttling.") \

--- a/src/Common/ThreadPool.cpp
+++ b/src/Common/ThreadPool.cpp
@@ -568,8 +568,9 @@ template class ThreadPoolImpl<std::thread>;
 template class ThreadPoolImpl<ThreadFromGlobalPoolImpl<false>>;
 template class ThreadFromGlobalPoolImpl<true>;
 
-std::unique_ptr<GlobalThreadPool> GlobalThreadPool::the_instance;
-
+/// std::unique_ptr<GlobalThreadPool> GlobalThreadPool::the_instance;
+std::vector<std::unique_ptr<GlobalThreadPool>> GlobalThreadPool::the_pools;
+size_t GlobalThreadPool::next_pool_index = 0;
 
 GlobalThreadPool::GlobalThreadPool(
     size_t max_threads_,
@@ -589,30 +590,34 @@ GlobalThreadPool::GlobalThreadPool(
 
 void GlobalThreadPool::initialize(size_t max_threads, size_t max_free_threads, size_t queue_size)
 {
-    if (the_instance)
-    {
+    if (!the_pools.empty()) {
         throw DB::Exception(DB::ErrorCodes::LOGICAL_ERROR,
-            "The global thread pool is initialized twice");
+            "The global thread pools are already initialized");
     }
 
-    the_instance.reset(new GlobalThreadPool(max_threads, max_free_threads, queue_size, false /*shutdown_on_exception*/));
+    next_pool_index = 0;
+
+    // Initialize 5 instances of GlobalThreadPool
+    for (int i = 0; i < 5; ++i) {
+        the_pools.push_back(std::make_unique<GlobalThreadPool>(max_threads, max_free_threads, queue_size, false));
+    }
 }
 
 GlobalThreadPool & GlobalThreadPool::instance()
 {
-    if (!the_instance)
-    {
-        // Allow implicit initialization. This is needed for old code that is
-        // impractical to redo now, especially Arcadia users and unit tests.
-        initialize();
+    if (the_pools.empty()) {
+        initialize(); // Default initialization if not already done
     }
 
-    return *the_instance;
+    GlobalThreadPool &pool = *the_pools[next_pool_index];
+    next_pool_index = (next_pool_index + 1) % the_pools.size(); // Round-robin selection
+    return pool;
 }
 void GlobalThreadPool::shutdown()
 {
-    if (the_instance)
-    {
-        the_instance->finalize();
+    for (auto &pool : the_pools) {
+        if (pool) {
+            pool->finalize();
+        }
     }
 }

--- a/src/Common/ThreadPool.h
+++ b/src/Common/ThreadPool.h
@@ -167,18 +167,18 @@ using FreeThreadPool = ThreadPoolImpl<std::thread>;
   */
 class GlobalThreadPool : public FreeThreadPool, private boost::noncopyable
 {
-    static std::unique_ptr<GlobalThreadPool> the_instance;
-
+public:
     GlobalThreadPool(
         size_t max_threads_,
         size_t max_free_threads_,
         size_t queue_size_,
-        bool shutdown_on_exception_);
-
-public:
+        const bool shutdown_on_exception_);
     static void initialize(size_t max_threads = 10000, size_t max_free_threads = 1000, size_t queue_size = 10000);
-    static GlobalThreadPool & instance();
-    static void shutdown();
+    static GlobalThreadPool &instance();
+    void shutdown();
+private:
+    static std::vector<std::unique_ptr<GlobalThreadPool>> the_pools;
+    static size_t next_pool_index; // For round-robin selection
 };
 
 

--- a/src/Common/ThreadPool.h
+++ b/src/Common/ThreadPool.h
@@ -115,7 +115,6 @@ private:
     mutable std::mutex mutex;
     std::condition_variable job_finished;
     std::condition_variable new_job_or_shutdown;
-    std::condition_variable no_jobs;
 
     Metric metric_threads;
     Metric metric_active_threads;

--- a/src/Common/ThreadPool.h
+++ b/src/Common/ThreadPool.h
@@ -115,6 +115,7 @@ private:
     mutable std::mutex mutex;
     std::condition_variable job_finished;
     std::condition_variable new_job_or_shutdown;
+    std::condition_variable no_jobs;
 
     Metric metric_threads;
     Metric metric_active_threads;
@@ -139,8 +140,8 @@ private:
 
     void worker(typename std::list<Thread>::iterator thread_it);
 
-    /// Tries to start new threads if there are scheduled jobs and the limit `max_threads` is not reached. Must be called with `mutex` locked.
-    void startNewThreadsNoLock();
+    /// starts one thread (unless limit is reached). Must be called with `mutex` locked.
+    void createThreadNoLock();
 
     void finalize();
     void onDestroy();

--- a/src/Common/ThreadPool.h
+++ b/src/Common/ThreadPool.h
@@ -167,18 +167,18 @@ using FreeThreadPool = ThreadPoolImpl<std::thread>;
   */
 class GlobalThreadPool : public FreeThreadPool, private boost::noncopyable
 {
-public:
+    static std::unique_ptr<GlobalThreadPool> the_instance;
+
     GlobalThreadPool(
         size_t max_threads_,
         size_t max_free_threads_,
         size_t queue_size_,
-        const bool shutdown_on_exception_);
+        bool shutdown_on_exception_);
+
+public:
     static void initialize(size_t max_threads = 10000, size_t max_free_threads = 1000, size_t queue_size = 10000);
-    static GlobalThreadPool &instance();
-    void shutdown();
-private:
-    static std::vector<std::unique_ptr<GlobalThreadPool>> the_pools;
-    static size_t next_pool_index; // For round-robin selection
+    static GlobalThreadPool & instance();
+    static void shutdown();
 };
 
 

--- a/src/Daemon/BaseDaemon.h
+++ b/src/Daemon/BaseDaemon.h
@@ -10,7 +10,6 @@
 #include <atomic>
 #include <chrono>
 #include <Poco/Process.h>
-#include <Poco/ThreadPool.h>
 #include <Poco/Util/Application.h>
 #include <Poco/Util/ServerApplication.h>
 #include <Poco/Net/SocketAddress.h>

--- a/src/Databases/DatabaseOnDisk.cpp
+++ b/src/Databases/DatabaseOnDisk.cpp
@@ -19,6 +19,7 @@
 #include <Common/logger_useful.h>
 #include <Common/filesystemHelpers.h>
 #include <Common/CurrentMetrics.h>
+#include <Common/ThreadPool.h>
 #include <Common/assert_cast.h>
 #include <Databases/DatabaseOrdinary.h>
 #include <Databases/DatabaseAtomic.h>

--- a/src/Databases/DatabaseOrdinary.h
+++ b/src/Databases/DatabaseOrdinary.h
@@ -1,8 +1,6 @@
 #pragma once
 
 #include <Databases/DatabaseOnDisk.h>
-#include <Common/ThreadPool.h>
-
 
 namespace DB
 {

--- a/src/Databases/MySQL/MySQLBinlogEventsDispatcher.cpp
+++ b/src/Databases/MySQL/MySQLBinlogEventsDispatcher.cpp
@@ -1,6 +1,8 @@
 #include "MySQLBinlogEventsDispatcher.h"
 #include <boost/algorithm/string/join.hpp>
 #include <Common/logger_useful.h>
+#include <Common/ThreadPool.h>
+
 
 namespace DB::ErrorCodes
 {

--- a/src/Databases/MySQL/MySQLBinlogEventsDispatcher.h
+++ b/src/Databases/MySQL/MySQLBinlogEventsDispatcher.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <Databases/MySQL/MySQLBinlog.h>
-#include <Common/ThreadPool.h>
+#include <Common/ThreadPool_fwd.h>
 #include <Poco/Logger.h>
 #include <base/unit.h>
 

--- a/src/Dictionaries/CacheDictionary.h
+++ b/src/Dictionaries/CacheDictionary.h
@@ -11,7 +11,6 @@
 
 
 #include <Common/randomSeed.h>
-#include <Common/ThreadPool.h>
 #include <Common/SharedMutex.h>
 #include <Common/CurrentMetrics.h>
 

--- a/src/Disks/ObjectStorages/IObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/IObjectStorage.cpp
@@ -6,6 +6,7 @@
 #include <IO/ReadBufferFromFileBase.h>
 #include <Interpreters/Context.h>
 #include <Disks/ObjectStorages/ObjectStorageIterator.h>
+#include <Common/ThreadPool.h>
 
 
 namespace DB

--- a/src/Disks/ObjectStorages/IObjectStorage.h
+++ b/src/Disks/ObjectStorages/IObjectStorage.h
@@ -20,7 +20,7 @@
 #include <Interpreters/Context_fwd.h>
 #include <Core/Types.h>
 #include <Disks/DirectoryIterator.h>
-#include <Common/ThreadPool.h>
+#include <Common/ThreadPool_fwd.h>
 #include <Interpreters/threadPoolCallbackRunner.h>
 
 

--- a/src/Disks/ObjectStorages/IObjectStorage.h
+++ b/src/Disks/ObjectStorages/IObjectStorage.h
@@ -15,7 +15,6 @@
 
 #include <Disks/ObjectStorages/StoredObject.h>
 #include <Disks/DiskType.h>
-#include <Common/ThreadPool_fwd.h>
 #include <Common/ObjectStorageKey.h>
 #include <Disks/WriteMode.h>
 #include <Interpreters/Context_fwd.h>

--- a/src/Interpreters/Aggregator.cpp
+++ b/src/Interpreters/Aggregator.cpp
@@ -24,6 +24,7 @@
 #include <Disks/TemporaryFileOnDisk.h>
 #include <Interpreters/TemporaryDataOnDisk.h>
 #include <Common/Stopwatch.h>
+#include <Common/ThreadPool.h>
 #include <Common/setThreadName.h>
 #include <Common/formatReadable.h>
 #include <Common/logger_useful.h>

--- a/src/Interpreters/Aggregator.h
+++ b/src/Interpreters/Aggregator.h
@@ -13,7 +13,7 @@
 #include <Common/HashTable/StringHashMap.h>
 #include <Common/HashTable/TwoLevelStringHashMap.h>
 
-#include <Common/ThreadPool.h>
+#include <Common/ThreadPool_fwd.h>
 #include <Common/ColumnsHashing.h>
 #include <Common/assert_cast.h>
 #include <Common/filesystemHelpers.h>

--- a/src/Interpreters/Cache/FileCache.h
+++ b/src/Interpreters/Cache/FileCache.h
@@ -8,7 +8,6 @@
 
 #include <IO/ReadSettings.h>
 
-#include <Common/ThreadPool.h>
 #include <Common/StatusFile.h>
 #include <Interpreters/Cache/LRUFileCachePriority.h>
 #include <Interpreters/Cache/FileCache_fwd.h>

--- a/src/Processors/Formats/Impl/ParallelParsingInputFormat.h
+++ b/src/Processors/Formats/Impl/ParallelParsingInputFormat.h
@@ -3,7 +3,7 @@
 #include <Processors/Formats/IInputFormat.h>
 #include <Formats/FormatFactory.h>
 #include <Common/CurrentThread.h>
-#include <Common/ThreadPool.h>
+#include <Common/ThreadPool_fwd.h>
 #include <Common/setThreadName.h>
 #include <Common/logger_useful.h>
 #include <Common/CurrentMetrics.h>

--- a/src/Processors/Formats/Impl/ParquetBlockOutputFormat.cpp
+++ b/src/Processors/Formats/Impl/ParquetBlockOutputFormat.cpp
@@ -7,6 +7,7 @@
 #include <parquet/arrow/writer.h>
 #include "ArrowBufferedStreams.h"
 #include "CHColumnToArrowColumn.h"
+#include <Common/ThreadPool.h>
 
 
 namespace CurrentMetrics

--- a/src/Processors/Formats/Impl/ParquetBlockOutputFormat.h
+++ b/src/Processors/Formats/Impl/ParquetBlockOutputFormat.h
@@ -6,7 +6,7 @@
 #include <Processors/Formats/IOutputFormat.h>
 #include <Processors/Formats/Impl/Parquet/Write.h>
 #include <Formats/FormatSettings.h>
-#include <Common/ThreadPool.h>
+#include <Common/ThreadPool_fwd.h>
 
 namespace arrow
 {

--- a/src/Processors/Merges/Algorithms/FinishAggregatingInOrderAlgorithm.h
+++ b/src/Processors/Merges/Algorithms/FinishAggregatingInOrderAlgorithm.h
@@ -4,7 +4,6 @@
 #include <Processors/Merges/Algorithms/MergedData.h>
 #include <Core/SortDescription.h>
 #include <Core/Block.h>
-#include <Common/ThreadPool.h>
 
 namespace DB
 {

--- a/src/Processors/Sources/ShellCommandSource.cpp
+++ b/src/Processors/Sources/ShellCommandSource.cpp
@@ -14,6 +14,7 @@
 #include <Processors/Executors/CompletedPipelineExecutor.h>
 #include <Interpreters/Context.h>
 #include <boost/circular_buffer.hpp>
+#include <Common/ThreadPool.h>
 
 
 namespace DB

--- a/src/Processors/Sources/ShellCommandSource.h
+++ b/src/Processors/Sources/ShellCommandSource.h
@@ -6,7 +6,6 @@
 
 #include <Common/ShellCommandSettings.h>
 #include <Common/ShellCommand.h>
-#include <Common/ThreadPool.h>
 
 #include <IO/ReadHelpers.h>
 #include <Processors/ISimpleTransform.h>

--- a/src/Storages/Cache/ExternalDataSourceCache.h
+++ b/src/Storages/Cache/ExternalDataSourceCache.h
@@ -23,8 +23,6 @@
 #include <Poco/Logger.h>
 #include <Common/ErrorCodes.h>
 #include <Common/LRUResourceCache.h>
-#include <Common/ThreadPool.h>
-
 
 namespace DB
 {

--- a/utils/keeper-bench/Runner.cpp
+++ b/utils/keeper-bench/Runner.cpp
@@ -8,6 +8,7 @@
 #include "IO/ReadBufferFromString.h"
 #include <IO/WriteBufferFromFile.h>
 #include <IO/WriteBufferFromString.h>
+#include <Common/ThreadPool.h>
 #include <IO/copyData.h>
 
 

--- a/utils/keeper-bench/Runner.h
+++ b/utils/keeper-bench/Runner.h
@@ -6,7 +6,7 @@
 #include <Common/Config/ConfigProcessor.h>
 #include <Common/ZooKeeper/ZooKeeperCommon.h>
 #include <Common/Stopwatch.h>
-#include <Common/ThreadPool.h>
+#include <Common/ThreadPool_fwd.h>
 #include <Common/InterruptListener.h>
 #include <Common/CurrentMetrics.h>
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Adding few metrics to debug issues with the slow schedule in the thread pool in conditions of high thead usage.
I hope adding a timer inside the scheduleImpl will not impact the performance too much (let's check it).


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
