### PR TITLE
Fix timeout for prometheus exporter for HTTP/1.1 (due to keep-alive)

### DIFF
--- a/src/Server/HTTP/WriteBufferFromHTTPServerResponse.cpp
+++ b/src/Server/HTTP/WriteBufferFromHTTPServerResponse.cpp
@@ -19,6 +19,13 @@ void WriteBufferFromHTTPServerResponse::startSendHeaders()
 
         if (response.getChunkedTransferEncoding())
             setChunked();
+        else if (response.getContentLength() == Poco::Net::HTTPMessage::UNKNOWN_CONTENT_LENGTH)
+        {
+            /// In case there is no Content-Length we cannot use keep-alive,
+            /// since there is no way to know when the server send all the
+            /// data, so "Connection: close" should be sent.
+            response.setKeepAlive(false);
+        }
 
         if (add_cors_header)
             response.set("Access-Control-Allow-Origin", "*");

--- a/src/Server/PrometheusRequestHandler.cpp
+++ b/src/Server/PrometheusRequestHandler.cpp
@@ -23,6 +23,10 @@ void PrometheusRequestHandler::handleRequest(HTTPServerRequest & request, HTTPSe
         const auto & config = server.config();
         unsigned keep_alive_timeout = config.getUInt("keep_alive_timeout", DEFAULT_HTTP_KEEP_ALIVE_TIMEOUT);
 
+        /// In order to make keep-alive works.
+        if (request.getVersion() == HTTPServerRequest::HTTP_1_1)
+            response.setChunkedTransferEncoding(true);
+
         setResponseDefaultHeaders(response, keep_alive_timeout);
 
         response.setContentType("text/plain; version=0.0.4; charset=UTF-8");

--- a/tests/integration/test_prometheus_endpoint/test.py
+++ b/tests/integration/test_prometheus_endpoint/test.py
@@ -40,6 +40,8 @@ def get_and_check_metrics(retries):
             response = requests.get(
                 "http://{host}:{port}/metrics".format(host=node.ip_address, port=8001),
                 allow_redirects=False,
+                # less then default keep-alive timeout (10 seconds)
+                timeout=5,
             )
 
             if response.status_code != 200:


### PR DESCRIPTION
### Changelog category (leave one):
- Not For Changelog

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
(unreleased, remove from changelog) Fix timeout for prometheus exporter for HTTP/1.1 (due to keep-alive)

Before:

    $ time curl -s --http1.1 127.1:9363/metrics > /dev/null
    real    0m10.018s # default keep_alive_timeout is 10 seconds
    user    0m0.005s
    sys     0m0.001s

After

    $ time curl -s --http1.1 127.1:9363/metrics > /dev/null
    real    0m0.008s
    user    0m0.006s
    sys     0m0.000s

And if you will look at the test_prometheus_endpoint, you will see that it takes > 30 seconds (it obtains metrics 3 times), after this patch it should be finished more or less instantly.

Introduced by: #58475, #56064 (cc @yakov-olkhovskiy)