### PR TITLE
initialization ConnectionTimeouts

### DIFF
--- a/src/Access/ExternalAuthenticators.cpp
+++ b/src/Access/ExternalAuthenticators.cpp
@@ -243,7 +243,7 @@ HTTPAuthClientParams parseHTTPAuthParams(const Poco::Util::AbstractConfiguration
     size_t receive_timeout_ms = config.getInt(prefix + ".receive_timeout_ms", 1000);
     size_t send_timeout_ms = config.getInt(prefix + ".send_timeout_ms", 1000);
     http_auth_params.timeouts = ConnectionTimeouts()
-        .withAnyConnectionTimeout(Poco::Timespan(connection_timeout_ms * 1000))
+        .withConnectionTimeout(Poco::Timespan(connection_timeout_ms * 1000))
         .withReceiveTimeout(Poco::Timespan(receive_timeout_ms * 1000))
         .withSendTimeout(Poco::Timespan(send_timeout_ms * 1000));
 

--- a/src/Access/ExternalAuthenticators.cpp
+++ b/src/Access/ExternalAuthenticators.cpp
@@ -242,7 +242,10 @@ HTTPAuthClientParams parseHTTPAuthParams(const Poco::Util::AbstractConfiguration
     size_t connection_timeout_ms = config.getInt(prefix + ".connection_timeout_ms", 1000);
     size_t receive_timeout_ms = config.getInt(prefix + ".receive_timeout_ms", 1000);
     size_t send_timeout_ms = config.getInt(prefix + ".send_timeout_ms", 1000);
-    http_auth_params.timeouts = ConnectionTimeouts{connection_timeout_ms, receive_timeout_ms, send_timeout_ms};
+    http_auth_params.timeouts = ConnectionTimeouts()
+        .withAnyConnectionTimeout(Poco::Timespan(connection_timeout_ms * 1000))
+        .withReceiveTimeout(Poco::Timespan(receive_timeout_ms * 1000))
+        .withSendTimeout(Poco::Timespan(send_timeout_ms * 1000));
 
     http_auth_params.max_tries = config.getInt(prefix + ".max_tries", 3);
     http_auth_params.retry_initial_backoff_ms = config.getInt(prefix + ".retry_initial_backoff_ms", 50);

--- a/src/Client/ConnectionParameters.cpp
+++ b/src/Client/ConnectionParameters.cpp
@@ -104,7 +104,7 @@ ConnectionParameters::ConnectionParameters(const Poco::Util::AbstractConfigurati
                   ? Protocol::Compression::Enable : Protocol::Compression::Disable;
 
     timeouts = ConnectionTimeouts()
-            .withAnyConnectionTimeout(
+            .withConnectionTimeout(
                 Poco::Timespan(config.getInt("connect_timeout", DBMS_DEFAULT_CONNECT_TIMEOUT_SEC), 0))
             .withSendTimeout(
                 Poco::Timespan(config.getInt("send_timeout", DBMS_DEFAULT_SEND_TIMEOUT_SEC), 0))

--- a/src/Client/ConnectionParameters.cpp
+++ b/src/Client/ConnectionParameters.cpp
@@ -103,14 +103,19 @@ ConnectionParameters::ConnectionParameters(const Poco::Util::AbstractConfigurati
     compression = config.getBool("compression", host != "localhost" && !isLocalAddress(DNSResolver::instance().resolveHost(host)))
                   ? Protocol::Compression::Enable : Protocol::Compression::Disable;
 
-    timeouts = ConnectionTimeouts(
-            Poco::Timespan(config.getInt("connect_timeout", DBMS_DEFAULT_CONNECT_TIMEOUT_SEC), 0),
-            Poco::Timespan(config.getInt("send_timeout", DBMS_DEFAULT_SEND_TIMEOUT_SEC), 0),
-            Poco::Timespan(config.getInt("receive_timeout", DBMS_DEFAULT_RECEIVE_TIMEOUT_SEC), 0),
-            Poco::Timespan(config.getInt("tcp_keep_alive_timeout", 0), 0),
-            Poco::Timespan(config.getInt("handshake_timeout_ms", DBMS_DEFAULT_RECEIVE_TIMEOUT_SEC * 1000), 0));
-
-    timeouts.sync_request_timeout = Poco::Timespan(config.getInt("sync_request_timeout", DBMS_DEFAULT_SYNC_REQUEST_TIMEOUT_SEC), 0);
+    timeouts = ConnectionTimeouts()
+            .withAnyConnectionTimeout(
+                Poco::Timespan(config.getInt("connect_timeout", DBMS_DEFAULT_CONNECT_TIMEOUT_SEC), 0))
+            .withSendTimeout(
+                Poco::Timespan(config.getInt("send_timeout", DBMS_DEFAULT_SEND_TIMEOUT_SEC), 0))
+            .withReceiveTimeout(
+                Poco::Timespan(config.getInt("receive_timeout", DBMS_DEFAULT_RECEIVE_TIMEOUT_SEC), 0))
+            .withTcpKeepAliveTimeout(
+                Poco::Timespan(config.getInt("tcp_keep_alive_timeout", DEFAULT_TCP_KEEP_ALIVE_TIMEOUT), 0))
+            .withHandshakeTimeout(
+                Poco::Timespan(config.getInt("handshake_timeout_ms", DBMS_DEFAULT_RECEIVE_TIMEOUT_SEC * 1000) * 1000))
+            .withSyncRequestTimeout(
+                Poco::Timespan(config.getInt("sync_request_timeout", DBMS_DEFAULT_SYNC_REQUEST_TIMEOUT_SEC), 0));
 }
 
 ConnectionParameters::ConnectionParameters(const Poco::Util::AbstractConfiguration & config,

--- a/src/Common/RemoteProxyConfigurationResolver.cpp
+++ b/src/Common/RemoteProxyConfigurationResolver.cpp
@@ -50,11 +50,10 @@ ProxyConfiguration RemoteProxyConfigurationResolver::resolve()
 
     /// 1 second is enough for now.
     /// TODO: Make timeouts configurable.
-    ConnectionTimeouts timeouts(
-        Poco::Timespan(1000000), /// Connection timeout.
-        Poco::Timespan(1000000), /// Send timeout.
-        Poco::Timespan(1000000)  /// Receive timeout.
-    );
+    auto timeouts = ConnectionTimeouts()
+        .withAnyConnectionTimeout(1)
+        .withSendTimeout(1)
+        .withReceiveTimeout(1);
 
     try
     {

--- a/src/Common/RemoteProxyConfigurationResolver.cpp
+++ b/src/Common/RemoteProxyConfigurationResolver.cpp
@@ -51,7 +51,7 @@ ProxyConfiguration RemoteProxyConfigurationResolver::resolve()
     /// 1 second is enough for now.
     /// TODO: Make timeouts configurable.
     auto timeouts = ConnectionTimeouts()
-        .withAnyConnectionTimeout(1)
+        .withConnectionTimeout(1)
         .withSendTimeout(1)
         .withReceiveTimeout(1);
 

--- a/src/Core/Defines.h
+++ b/src/Core/Defines.h
@@ -8,9 +8,11 @@ namespace DB
 
 static constexpr auto DBMS_DEFAULT_PORT = 9000;
 static constexpr auto DBMS_DEFAULT_SECURE_PORT = 9440;
+
 static constexpr auto DBMS_DEFAULT_CONNECT_TIMEOUT_SEC = 10;
 static constexpr auto DBMS_DEFAULT_SEND_TIMEOUT_SEC = 300;
 static constexpr auto DBMS_DEFAULT_RECEIVE_TIMEOUT_SEC = 300;
+
 /// Timeout for synchronous request-result protocol call (like Ping or TablesStatus).
 static constexpr auto DBMS_DEFAULT_SYNC_REQUEST_TIMEOUT_SEC = 5;
 static constexpr auto DBMS_DEFAULT_POLL_INTERVAL = 10;
@@ -51,6 +53,7 @@ static constexpr auto DEFAULT_HTTP_READ_BUFFER_CONNECTION_TIMEOUT = 1;
 /// the number is unmotivated
 static constexpr auto DEFAULT_COUNT_OF_HTTP_CONNECTIONS_PER_ENDPOINT = 15;
 
+static constexpr auto DEFAULT_TCP_KEEP_ALIVE_TIMEOUT = 290;
 static constexpr auto DEFAULT_HTTP_KEEP_ALIVE_TIMEOUT = 30;
 
 static constexpr auto DBMS_DEFAULT_PATH = "/var/lib/clickhouse/";

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -62,7 +62,7 @@ class IColumn;
     M(Milliseconds, connect_timeout_with_failover_secure_ms, 1000, "Connection timeout for selecting first healthy replica (for secure connections).", 0) \
     M(Seconds, receive_timeout, DBMS_DEFAULT_RECEIVE_TIMEOUT_SEC, "Timeout for receiving data from network, in seconds. If no bytes were received in this interval, exception is thrown. If you set this setting on client, the 'send_timeout' for the socket will be also set on the corresponding connection end on the server.", 0) \
     M(Seconds, send_timeout, DBMS_DEFAULT_SEND_TIMEOUT_SEC, "Timeout for sending data to network, in seconds. If client needs to sent some data, but it did not able to send any bytes in this interval, exception is thrown. If you set this setting on client, the 'receive_timeout' for the socket will be also set on the corresponding connection end on the server.", 0) \
-    M(Seconds, tcp_keep_alive_timeout, 290 /* less than DBMS_DEFAULT_RECEIVE_TIMEOUT_SEC */, "The time in seconds the connection needs to remain idle before TCP starts sending keepalive probes", 0) \
+    M(Seconds, tcp_keep_alive_timeout, DEFAULT_TCP_KEEP_ALIVE_TIMEOUT /* less than DBMS_DEFAULT_RECEIVE_TIMEOUT_SEC */, "The time in seconds the connection needs to remain idle before TCP starts sending keepalive probes", 0) \
     M(Milliseconds, hedged_connection_timeout_ms, 50, "Connection timeout for establishing connection with replica for Hedged requests", 0) \
     M(Milliseconds, receive_data_timeout_ms, 2000, "Connection timeout for receiving first packet of data or packet with positive progress from replica", 0) \
     M(Bool, use_hedged_requests, true, "Use hedged requests for distributed queries", 0) \

--- a/src/Disks/IO/ReadBufferFromWebServer.cpp
+++ b/src/Disks/IO/ReadBufferFromWebServer.cpp
@@ -56,15 +56,16 @@ std::unique_ptr<ReadBuffer> ReadBufferFromWebServer::initialize()
     const auto & settings = context->getSettingsRef();
     const auto & server_settings = context->getServerSettings();
 
+    auto connection_timeouts = ConnectionTimeouts::getHTTPTimeouts(settings, server_settings.keep_alive_timeout);
+    connection_timeouts.withConnectionTimeout(std::max<Poco::Timespan>(settings.http_connection_timeout, Poco::Timespan(20, 0)));
+    connection_timeouts.withSslConnectionTimeout(std::max<Poco::Timespan>(settings.http_connection_timeout, Poco::Timespan(20, 0)));
+    connection_timeouts.withReceiveTimeout(std::max<Poco::Timespan>(settings.http_receive_timeout, Poco::Timespan(20, 0)));
+
     auto res = std::make_unique<ReadWriteBufferFromHTTP>(
         uri,
         Poco::Net::HTTPRequest::HTTP_GET,
         ReadWriteBufferFromHTTP::OutStreamCallback(),
-        ConnectionTimeouts(std::max(Poco::Timespan(settings.http_connection_timeout.totalSeconds(), 0), Poco::Timespan(20, 0)),
-                           settings.http_send_timeout,
-                           std::max(Poco::Timespan(settings.http_receive_timeout.totalSeconds(), 0), Poco::Timespan(20, 0)),
-                           settings.tcp_keep_alive_timeout,
-                           server_settings.keep_alive_timeout),
+        connection_timeouts,
         credentials,
         0,
         buf_size,

--- a/src/Disks/IO/ReadBufferFromWebServer.cpp
+++ b/src/Disks/IO/ReadBufferFromWebServer.cpp
@@ -58,7 +58,6 @@ std::unique_ptr<ReadBuffer> ReadBufferFromWebServer::initialize()
 
     auto connection_timeouts = ConnectionTimeouts::getHTTPTimeouts(settings, server_settings.keep_alive_timeout);
     connection_timeouts.withConnectionTimeout(std::max<Poco::Timespan>(settings.http_connection_timeout, Poco::Timespan(20, 0)));
-    connection_timeouts.withSslConnectionTimeout(std::max<Poco::Timespan>(settings.http_connection_timeout, Poco::Timespan(20, 0)));
     connection_timeouts.withReceiveTimeout(std::max<Poco::Timespan>(settings.http_receive_timeout, Poco::Timespan(20, 0)));
 
     auto res = std::make_unique<ReadWriteBufferFromHTTP>(

--- a/src/IO/ConnectionTimeouts.cpp
+++ b/src/IO/ConnectionTimeouts.cpp
@@ -17,7 +17,7 @@ Poco::Timespan ConnectionTimeouts::saturate(Poco::Timespan timespan, Poco::Times
 ConnectionTimeouts ConnectionTimeouts::getTCPTimeoutsWithoutFailover(const Settings & settings)
 {
     return ConnectionTimeouts()
-        .withAnyConnectionTimeout(settings.connect_timeout)
+        .withConnectionTimeout(settings.connect_timeout)
         .withSendTimeout(settings.send_timeout)
         .withReceiveTimeout(settings.receive_timeout)
         .withTcpKeepAliveTimeout(settings.tcp_keep_alive_timeout)
@@ -30,14 +30,14 @@ ConnectionTimeouts ConnectionTimeouts::getTCPTimeoutsWithoutFailover(const Setti
 ConnectionTimeouts ConnectionTimeouts::getTCPTimeoutsWithFailover(const Settings & settings)
 {
     return getTCPTimeoutsWithoutFailover(settings)
-        .withConnectionTimeout(settings.connect_timeout_with_failover_ms)
-        .withSslConnectionTimeout(settings.connect_timeout_with_failover_secure_ms);
+        .withUnsecureConnectionTimeout(settings.connect_timeout_with_failover_ms)
+        .withSecureConnectionTimeout(settings.connect_timeout_with_failover_secure_ms);
 }
 
 ConnectionTimeouts ConnectionTimeouts::getHTTPTimeouts(const Settings & settings, Poco::Timespan http_keep_alive_timeout)
 {
     return ConnectionTimeouts()
-        .withAnyConnectionTimeout(settings.http_connection_timeout)
+        .withConnectionTimeout(settings.http_connection_timeout)
         .withSendTimeout(settings.http_send_timeout)
         .withReceiveTimeout(settings.http_receive_timeout)
         .withHttpKeepAliveTimeout(http_keep_alive_timeout)

--- a/src/IO/ConnectionTimeouts.cpp
+++ b/src/IO/ConnectionTimeouts.cpp
@@ -5,81 +5,6 @@
 namespace DB
 {
 
-ConnectionTimeouts::ConnectionTimeouts(
-    Poco::Timespan connection_timeout_,
-    Poco::Timespan send_timeout_,
-    Poco::Timespan receive_timeout_)
-    : connection_timeout(connection_timeout_)
-    , send_timeout(send_timeout_)
-    , receive_timeout(receive_timeout_)
-    , tcp_keep_alive_timeout(0)
-    , http_keep_alive_timeout(0)
-    , secure_connection_timeout(connection_timeout)
-    , hedged_connection_timeout(receive_timeout_)
-    , receive_data_timeout(receive_timeout_)
-    , handshake_timeout(receive_timeout_)
-{
-}
-
-ConnectionTimeouts::ConnectionTimeouts(
-    Poco::Timespan connection_timeout_,
-    Poco::Timespan send_timeout_,
-    Poco::Timespan receive_timeout_,
-    Poco::Timespan tcp_keep_alive_timeout_,
-    Poco::Timespan handshake_timeout_)
-    : connection_timeout(connection_timeout_)
-    , send_timeout(send_timeout_)
-    , receive_timeout(receive_timeout_)
-    , tcp_keep_alive_timeout(tcp_keep_alive_timeout_)
-    , http_keep_alive_timeout(0)
-    , secure_connection_timeout(connection_timeout)
-    , hedged_connection_timeout(receive_timeout_)
-    , receive_data_timeout(receive_timeout_)
-    , handshake_timeout(handshake_timeout_)
-{
-}
-
-ConnectionTimeouts::ConnectionTimeouts(
-    Poco::Timespan connection_timeout_,
-    Poco::Timespan send_timeout_,
-    Poco::Timespan receive_timeout_,
-    Poco::Timespan tcp_keep_alive_timeout_,
-    Poco::Timespan http_keep_alive_timeout_,
-    Poco::Timespan handshake_timeout_)
-    : connection_timeout(connection_timeout_)
-    , send_timeout(send_timeout_)
-    , receive_timeout(receive_timeout_)
-    , tcp_keep_alive_timeout(tcp_keep_alive_timeout_)
-    , http_keep_alive_timeout(http_keep_alive_timeout_)
-    , secure_connection_timeout(connection_timeout)
-    , hedged_connection_timeout(receive_timeout_)
-    , receive_data_timeout(receive_timeout_)
-    , handshake_timeout(handshake_timeout_)
-{
-}
-
-ConnectionTimeouts::ConnectionTimeouts(
-    Poco::Timespan connection_timeout_,
-    Poco::Timespan send_timeout_,
-    Poco::Timespan receive_timeout_,
-    Poco::Timespan tcp_keep_alive_timeout_,
-    Poco::Timespan http_keep_alive_timeout_,
-    Poco::Timespan secure_connection_timeout_,
-    Poco::Timespan hedged_connection_timeout_,
-    Poco::Timespan receive_data_timeout_,
-    Poco::Timespan handshake_timeout_)
-    : connection_timeout(connection_timeout_)
-    , send_timeout(send_timeout_)
-    , receive_timeout(receive_timeout_)
-    , tcp_keep_alive_timeout(tcp_keep_alive_timeout_)
-    , http_keep_alive_timeout(http_keep_alive_timeout_)
-    , secure_connection_timeout(secure_connection_timeout_)
-    , hedged_connection_timeout(hedged_connection_timeout_)
-    , receive_data_timeout(receive_data_timeout_)
-    , handshake_timeout(handshake_timeout_)
-{
-}
-
 Poco::Timespan ConnectionTimeouts::saturate(Poco::Timespan timespan, Poco::Timespan limit)
 {
     if (limit.totalMicroseconds() == 0)
@@ -88,49 +13,36 @@ Poco::Timespan ConnectionTimeouts::saturate(Poco::Timespan timespan, Poco::Times
         return (timespan > limit) ? limit : timespan;
 }
 
-ConnectionTimeouts ConnectionTimeouts::getSaturated(Poco::Timespan limit) const
-{
-    return ConnectionTimeouts(saturate(connection_timeout, limit),
-                              saturate(send_timeout, limit),
-                              saturate(receive_timeout, limit),
-                              saturate(tcp_keep_alive_timeout, limit),
-                              saturate(http_keep_alive_timeout, limit),
-                              saturate(secure_connection_timeout, limit),
-                              saturate(hedged_connection_timeout, limit),
-                              saturate(receive_data_timeout, limit),
-                              saturate(handshake_timeout, limit));
-}
-
 /// Timeouts for the case when we have just single attempt to connect.
 ConnectionTimeouts ConnectionTimeouts::getTCPTimeoutsWithoutFailover(const Settings & settings)
 {
-    return ConnectionTimeouts(settings.connect_timeout, settings.send_timeout, settings.receive_timeout, settings.tcp_keep_alive_timeout, settings.handshake_timeout_ms);
+    return ConnectionTimeouts()
+        .withAnyConnectionTimeout(settings.connect_timeout)
+        .withSendTimeout(settings.send_timeout)
+        .withReceiveTimeout(settings.receive_timeout)
+        .withTcpKeepAliveTimeout(settings.tcp_keep_alive_timeout)
+        .withHandshakeTimeout(settings.handshake_timeout_ms)
+        .withHedgedConnectionTimeout(settings.hedged_connection_timeout_ms)
+        .withReceiveDataTimeout(settings.receive_data_timeout_ms);
 }
 
 /// Timeouts for the case when we will try many addresses in a loop.
 ConnectionTimeouts ConnectionTimeouts::getTCPTimeoutsWithFailover(const Settings & settings)
 {
-    return ConnectionTimeouts(
-        settings.connect_timeout_with_failover_ms,
-        settings.send_timeout,
-        settings.receive_timeout,
-        settings.tcp_keep_alive_timeout,
-        0,
-        settings.connect_timeout_with_failover_secure_ms,
-        settings.hedged_connection_timeout_ms,
-        settings.receive_data_timeout_ms,
-        settings.handshake_timeout_ms);
+    return getTCPTimeoutsWithoutFailover(settings)
+        .withConnectionTimeout(settings.connect_timeout_with_failover_ms)
+        .withSslConnectionTimeout(settings.connect_timeout_with_failover_secure_ms);
 }
 
 ConnectionTimeouts ConnectionTimeouts::getHTTPTimeouts(const Settings & settings, Poco::Timespan http_keep_alive_timeout)
 {
-    return ConnectionTimeouts(
-        settings.http_connection_timeout,
-        settings.http_send_timeout,
-        settings.http_receive_timeout,
-        settings.tcp_keep_alive_timeout,
-        http_keep_alive_timeout,
-        settings.http_receive_timeout);
+    return ConnectionTimeouts()
+        .withAnyConnectionTimeout(settings.http_connection_timeout)
+        .withSendTimeout(settings.http_send_timeout)
+        .withReceiveTimeout(settings.http_receive_timeout)
+        .withHttpKeepAliveTimeout(http_keep_alive_timeout)
+        .withTcpKeepAliveTimeout(settings.tcp_keep_alive_timeout)
+        .withHandshakeTimeout(settings.handshake_timeout_ms);
 }
 
 ConnectionTimeouts ConnectionTimeouts::getFetchPartHTTPTimeouts(const ServerSettings & server_settings, const Settings & user_settings)
@@ -224,11 +136,9 @@ ConnectionTimeouts ConnectionTimeouts::getAdaptiveTimeouts(const String & method
 
     auto [send, recv] = SendReceiveTimeoutsForFirstAttempt::getSendReceiveTimeout(method, first_byte);
 
-    auto aggressive = *this;
-    aggressive.send_timeout = saturate(send, send_timeout);
-    aggressive.receive_timeout = saturate(recv, receive_timeout);
-
-    return aggressive;
+    return ConnectionTimeouts(*this)
+        .withSendTimeout(saturate(send, send_timeout))
+        .withReceiveTimeout(saturate(recv, receive_timeout));
 }
 
 }

--- a/src/IO/ConnectionTimeouts.h
+++ b/src/IO/ConnectionTimeouts.h
@@ -12,12 +12,12 @@ namespace DB
 struct Settings;
 
 #define APPLY_FOR_ALL_CONNECTION_TIMEOUT_MEMBERS(M) \
-    M(connection_timeout, withConnectionTimeout) \
+    M(connection_timeout, withUnsecureConnectionTimeout) \
+    M(secure_connection_timeout, withSecureConnectionTimeout) \
     M(send_timeout, withSendTimeout) \
     M(receive_timeout, withReceiveTimeout) \
     M(tcp_keep_alive_timeout, withTcpKeepAliveTimeout) \
     M(http_keep_alive_timeout, withHttpKeepAliveTimeout) \
-    M(secure_connection_timeout, withSslConnectionTimeout) \
     M(hedged_connection_timeout, withHedgedConnectionTimeout) \
     M(receive_data_timeout, withReceiveDataTimeout) \
     M(handshake_timeout, withHandshakeTimeout) \
@@ -66,8 +66,8 @@ struct ConnectionTimeouts
 APPLY_FOR_ALL_CONNECTION_TIMEOUT_MEMBERS(DECLARE_BUILDER_FOR_MEMBER)
 #undef DECLARE_BUILDER_FOR_MEMBER
 
-    ConnectionTimeouts & withAnyConnectionTimeout(size_t seconds);
-    ConnectionTimeouts & withAnyConnectionTimeout(Poco::Timespan span);
+    ConnectionTimeouts & withConnectionTimeout(size_t seconds);
+    ConnectionTimeouts & withConnectionTimeout(Poco::Timespan span);
 };
 
 #define DEFINE_BUILDER_FOR_MEMBER(member, setter_func) \
@@ -77,10 +77,10 @@ APPLY_FOR_ALL_CONNECTION_TIMEOUT_MEMBERS(DECLARE_BUILDER_FOR_MEMBER)
     } \
     inline ConnectionTimeouts & ConnectionTimeouts::setter_func(Poco::Timespan span) \
     { \
-        member = span \
+        member = span; \
         return *this; \
     } \
-                                                            \
+
     APPLY_FOR_ALL_CONNECTION_TIMEOUT_MEMBERS(DEFINE_BUILDER_FOR_MEMBER)
 
 #undef DEFINE_BUILDER_FOR_MEMBER
@@ -99,12 +99,12 @@ APPLY_FOR_ALL_CONNECTION_TIMEOUT_MEMBERS(SATURATE_MEMBER);
 
 #undef APPLY_FOR_ALL_CONNECTION_TIMEOUT_MEMBERS
 
-inline ConnectionTimeouts & ConnectionTimeouts::withAnyConnectionTimeout(size_t seconds)
+inline ConnectionTimeouts & ConnectionTimeouts::withConnectionTimeout(size_t seconds)
 {
-    return withAnyConnectionTimeout(Poco::Timespan(seconds, 0));
+    return withConnectionTimeout(Poco::Timespan(seconds, 0));
 }
 
-inline ConnectionTimeouts & ConnectionTimeouts::withAnyConnectionTimeout(Poco::Timespan span) \
+inline ConnectionTimeouts & ConnectionTimeouts::withConnectionTimeout(Poco::Timespan span)
 {
     connection_timeout = span;
     secure_connection_timeout = span;

--- a/src/IO/ConnectionTimeouts.h
+++ b/src/IO/ConnectionTimeouts.h
@@ -11,53 +11,39 @@ namespace DB
 
 struct Settings;
 
+#define APPLY_FOR_ALL_CONNECTION_TIMEOUT_MEMBERS(M) \
+    M(connection_timeout, withConnectionTimeout) \
+    M(send_timeout, withSendTimeout) \
+    M(receive_timeout, withReceiveTimeout) \
+    M(tcp_keep_alive_timeout, withTcpKeepAliveTimeout) \
+    M(http_keep_alive_timeout, withHttpKeepAliveTimeout) \
+    M(secure_connection_timeout, withSslConnectionTimeout) \
+    M(hedged_connection_timeout, withHedgedConnectionTimeout) \
+    M(receive_data_timeout, withReceiveDataTimeout) \
+    M(handshake_timeout, withHandshakeTimeout) \
+    M(sync_request_timeout, withSyncRequestTimeout) \
+
+
 struct ConnectionTimeouts
 {
-    Poco::Timespan connection_timeout;
-    Poco::Timespan send_timeout;
-    Poco::Timespan receive_timeout;
-    Poco::Timespan tcp_keep_alive_timeout;
-    Poco::Timespan http_keep_alive_timeout;
-    Poco::Timespan secure_connection_timeout;
+    Poco::Timespan connection_timeout = Poco::Timespan(DBMS_DEFAULT_CONNECT_TIMEOUT_SEC, 0);
+    Poco::Timespan secure_connection_timeout = Poco::Timespan(DBMS_DEFAULT_CONNECT_TIMEOUT_SEC, 0);
+
+    Poco::Timespan send_timeout = Poco::Timespan(DBMS_DEFAULT_SEND_TIMEOUT_SEC, 0);
+    Poco::Timespan receive_timeout = Poco::Timespan(DBMS_DEFAULT_RECEIVE_TIMEOUT_SEC, 0);
+
+    Poco::Timespan tcp_keep_alive_timeout = Poco::Timespan(DEFAULT_TCP_KEEP_ALIVE_TIMEOUT, 0);
+    Poco::Timespan http_keep_alive_timeout = Poco::Timespan(DEFAULT_HTTP_KEEP_ALIVE_TIMEOUT, 0);
 
     /// Timeouts for HedgedConnections
-    Poco::Timespan hedged_connection_timeout;
-    Poco::Timespan receive_data_timeout;
-
+    Poco::Timespan hedged_connection_timeout = Poco::Timespan(DBMS_DEFAULT_RECEIVE_TIMEOUT_SEC, 0);
+    Poco::Timespan receive_data_timeout = Poco::Timespan(DBMS_DEFAULT_RECEIVE_TIMEOUT_SEC, 0);
     /// Timeout for receiving HELLO packet
-    Poco::Timespan handshake_timeout;
-
+    Poco::Timespan handshake_timeout = Poco::Timespan(DBMS_DEFAULT_RECEIVE_TIMEOUT_SEC, 0);
     /// Timeout for synchronous request-result protocol call (like Ping or TablesStatus)
     Poco::Timespan sync_request_timeout = Poco::Timespan(DBMS_DEFAULT_SYNC_REQUEST_TIMEOUT_SEC, 0);
 
     ConnectionTimeouts() = default;
-
-    ConnectionTimeouts(Poco::Timespan connection_timeout_,
-                       Poco::Timespan send_timeout_,
-                       Poco::Timespan receive_timeout_);
-
-    ConnectionTimeouts(Poco::Timespan connection_timeout_,
-                       Poco::Timespan send_timeout_,
-                       Poco::Timespan receive_timeout_,
-                       Poco::Timespan tcp_keep_alive_timeout_,
-                       Poco::Timespan handshake_timeout_);
-
-    ConnectionTimeouts(Poco::Timespan connection_timeout_,
-                       Poco::Timespan send_timeout_,
-                       Poco::Timespan receive_timeout_,
-                       Poco::Timespan tcp_keep_alive_timeout_,
-                       Poco::Timespan http_keep_alive_timeout_,
-                       Poco::Timespan handshake_timeout_);
-
-    ConnectionTimeouts(Poco::Timespan connection_timeout_,
-                       Poco::Timespan send_timeout_,
-                       Poco::Timespan receive_timeout_,
-                       Poco::Timespan tcp_keep_alive_timeout_,
-                       Poco::Timespan http_keep_alive_timeout_,
-                       Poco::Timespan secure_connection_timeout_,
-                       Poco::Timespan hedged_connection_timeout_,
-                       Poco::Timespan receive_data_timeout_,
-                       Poco::Timespan handshake_timeout_);
 
     static Poco::Timespan saturate(Poco::Timespan timespan, Poco::Timespan limit);
     ConnectionTimeouts getSaturated(Poco::Timespan limit) const;
@@ -72,6 +58,57 @@ struct ConnectionTimeouts
     static ConnectionTimeouts getFetchPartHTTPTimeouts(const ServerSettings & server_settings, const Settings & user_settings);
 
     ConnectionTimeouts getAdaptiveTimeouts(const String & method, bool first_attempt, bool first_byte) const;
+
+#define DECLARE_BUILDER_FOR_MEMBER(member, setter_func) \
+    ConnectionTimeouts & setter_func(size_t seconds); \
+    ConnectionTimeouts & setter_func(Poco::Timespan span); \
+
+APPLY_FOR_ALL_CONNECTION_TIMEOUT_MEMBERS(DECLARE_BUILDER_FOR_MEMBER)
+#undef DECLARE_BUILDER_FOR_MEMBER
+
+    ConnectionTimeouts & withAnyConnectionTimeout(size_t seconds);
+    ConnectionTimeouts & withAnyConnectionTimeout(Poco::Timespan span);
 };
+
+#define DEFINE_BUILDER_FOR_MEMBER(member, setter_func) \
+    inline ConnectionTimeouts & ConnectionTimeouts::setter_func(size_t seconds) \
+    { \
+        return setter_func(Poco::Timespan(seconds, 0)); \
+    } \
+    inline ConnectionTimeouts & ConnectionTimeouts::setter_func(Poco::Timespan span) \
+    { \
+        member = span \
+        return *this; \
+    } \
+                                                            \
+    APPLY_FOR_ALL_CONNECTION_TIMEOUT_MEMBERS(DEFINE_BUILDER_FOR_MEMBER)
+
+#undef DEFINE_BUILDER_FOR_MEMBER
+
+
+inline ConnectionTimeouts ConnectionTimeouts::getSaturated(Poco::Timespan limit) const
+{
+#define SATURATE_MEMBER(member, setter_func) \
+    .setter_func(saturate(member, limit))
+
+    return ConnectionTimeouts(*this)
+APPLY_FOR_ALL_CONNECTION_TIMEOUT_MEMBERS(SATURATE_MEMBER);
+
+#undef SATURETE_MEMBER
+}
+
+#undef APPLY_FOR_ALL_CONNECTION_TIMEOUT_MEMBERS
+
+inline ConnectionTimeouts & ConnectionTimeouts::withAnyConnectionTimeout(size_t seconds)
+{
+    return withAnyConnectionTimeout(Poco::Timespan(seconds, 0));
+}
+
+inline ConnectionTimeouts & ConnectionTimeouts::withAnyConnectionTimeout(Poco::Timespan span) \
+{
+    connection_timeout = span;
+    secure_connection_timeout = span;
+    return *this;
+}
 
 }

--- a/src/IO/S3/PocoHTTPClient.cpp
+++ b/src/IO/S3/PocoHTTPClient.cpp
@@ -140,16 +140,22 @@ void PocoHTTPClientConfiguration::updateSchemeAndRegion()
     }
 }
 
+ConnectionTimeouts getTimeoutsFromConfiguration(const PocoHTTPClientConfiguration & client_configuration)
+{
+    return ConnectionTimeouts()
+        .withAnyConnectionTimeout(Poco::Timespan(client_configuration.connectTimeoutMs * 1000))
+        .withSendTimeout(Poco::Timespan(client_configuration.requestTimeoutMs * 1000))
+        .withReceiveTimeout(Poco::Timespan(client_configuration.requestTimeoutMs * 1000))
+        .withTcpKeepAliveTimeout(Poco::Timespan(
+            client_configuration.enableTcpKeepAlive ? client_configuration.tcpKeepAliveIntervalMs * 1000 : 0))
+        .withHttpKeepAliveTimeout(Poco::Timespan(
+            client_configuration.http_keep_alive_timeout_ms * 1000)); /// flag indicating whether keep-alive is enabled is set to each session upon creation
+}
 
 PocoHTTPClient::PocoHTTPClient(const PocoHTTPClientConfiguration & client_configuration)
     : per_request_configuration(client_configuration.per_request_configuration)
     , error_report(client_configuration.error_report)
-    , timeouts(ConnectionTimeouts(
-          Poco::Timespan(client_configuration.connectTimeoutMs * 1000), /// connection timeout.
-          Poco::Timespan(client_configuration.requestTimeoutMs * 1000), /// send timeout.
-          Poco::Timespan(client_configuration.requestTimeoutMs * 1000), /// receive timeout.
-          Poco::Timespan(client_configuration.enableTcpKeepAlive ? client_configuration.tcpKeepAliveIntervalMs * 1000 : 0),
-          Poco::Timespan(client_configuration.http_keep_alive_timeout_ms * 1000))) /// flag indicating whether keep-alive is enabled is set to each session upon creation
+    , timeouts(getTimeoutsFromConfiguration(client_configuration))
     , remote_host_filter(client_configuration.remote_host_filter)
     , s3_max_redirects(client_configuration.s3_max_redirects)
     , s3_use_adaptive_timeouts(client_configuration.s3_use_adaptive_timeouts)

--- a/src/IO/S3/PocoHTTPClient.cpp
+++ b/src/IO/S3/PocoHTTPClient.cpp
@@ -143,7 +143,7 @@ void PocoHTTPClientConfiguration::updateSchemeAndRegion()
 ConnectionTimeouts getTimeoutsFromConfiguration(const PocoHTTPClientConfiguration & client_configuration)
 {
     return ConnectionTimeouts()
-        .withAnyConnectionTimeout(Poco::Timespan(client_configuration.connectTimeoutMs * 1000))
+        .withConnectionTimeout(Poco::Timespan(client_configuration.connectTimeoutMs * 1000))
         .withSendTimeout(Poco::Timespan(client_configuration.requestTimeoutMs * 1000))
         .withReceiveTimeout(Poco::Timespan(client_configuration.requestTimeoutMs * 1000))
         .withTcpKeepAliveTimeout(Poco::Timespan(

--- a/src/Processors/Formats/Impl/AvroRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/AvroRowInputFormat.cpp
@@ -987,7 +987,10 @@ private:
                 LOG_TRACE((&Poco::Logger::get("AvroConfluentRowInputFormat")), "Fetching schema id = {} from url {}", id, url.toString());
 
                 /// One second for connect/send/receive. Just in case.
-                ConnectionTimeouts timeouts({1, 0}, {1, 0}, {1, 0});
+                auto timeouts = ConnectionTimeouts()
+                    .withAnyConnectionTimeout(1)
+                    .withSendTimeout(1)
+                    .withReceiveTimeout(1);
 
                 Poco::Net::HTTPRequest request(Poco::Net::HTTPRequest::HTTP_GET, url.getPathAndQuery(), Poco::Net::HTTPRequest::HTTP_1_1);
                 request.setHost(url.getHost());

--- a/src/Processors/Formats/Impl/AvroRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/AvroRowInputFormat.cpp
@@ -988,7 +988,7 @@ private:
 
                 /// One second for connect/send/receive. Just in case.
                 auto timeouts = ConnectionTimeouts()
-                    .withAnyConnectionTimeout(1)
+                    .withConnectionTimeout(1)
                     .withSendTimeout(1)
                     .withReceiveTimeout(1);
 

--- a/src/Processors/QueryPlan/ReadFromRemote.cpp
+++ b/src/Processors/QueryPlan/ReadFromRemote.cpp
@@ -156,9 +156,9 @@ void ReadFromRemote::addLazyPipe(Pipes & pipes, const ClusterProxy::SelectStream
         -> QueryPipelineBuilder
     {
         auto current_settings = my_context->getSettingsRef();
-        auto timeouts = ConnectionTimeouts::getTCPTimeoutsWithFailover(
-            current_settings).getSaturated(
-                current_settings.max_execution_time);
+        auto timeouts = ConnectionTimeouts::getTCPTimeoutsWithFailover(current_settings)
+                            .getSaturated(current_settings.max_execution_time);
+
         std::vector<ConnectionPoolWithFailover::TryResult> try_results;
         try
         {


### PR DESCRIPTION
fix initialization `http_keep_alive_timeout` in ConnectionTimeouts

also fixes wrond initialization `Poco::Timespan`
- `http_auth_params.timeouts = ConnectionTimeouts{connection_timeout_ms, receive_timeout_ms, send_timeout_ms};`
- `Poco::Timespan(config.getInt("handshake_timeout_ms", DBMS_DEFAULT_RECEIVE_TIMEOUT_SEC * 1000), 0));`

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)