### PR TITLE
`uniqExact` state parallel merging for distributed queries

### DIFF
--- a/src/AggregateFunctions/AggregateFunctionUniq.h
+++ b/src/AggregateFunctions/AggregateFunctionUniq.h
@@ -350,7 +350,7 @@ struct Adder
 
         if constexpr (Data::is_able_to_parallelize_merge)
         {
-            if (data.set.isSingleLevel() && data.set.size() > 100'000)
+            if (data.set.isSingleLevel() && data.set.worthConvertingToTwoLevel(data.set.size()))
                 data.set.convertToTwoLevel();
         }
     }

--- a/src/AggregateFunctions/UniqExactSet.h
+++ b/src/AggregateFunctions/UniqExactSet.h
@@ -152,7 +152,10 @@ public:
     {
         size_t new_size = 0;
         auto * const position = in.position();
-        DB::readVarUInt(new_size, in);
+        readVarUInt(new_size, in);
+        if (new_size > 100'000'000'000)
+            throw DB::Exception(
+                DB::ErrorCodes::TOO_LARGE_ARRAY_SIZE, "The size of serialized hash table is suspiciously large: {}", new_size);
 
         if (worthConvertingToTwoLevel(new_size))
         {

--- a/src/AggregateFunctions/UniqExactSet.h
+++ b/src/AggregateFunctions/UniqExactSet.h
@@ -11,6 +11,11 @@
 namespace DB
 {
 
+namespace ErrorCodes
+{
+extern const int TOO_LARGE_ARRAY_SIZE;
+}
+
 template <typename SingleLevelSet, typename TwoLevelSet>
 class UniqExactSet
 {

--- a/src/AggregateFunctions/UniqExactSet.h
+++ b/src/AggregateFunctions/UniqExactSet.h
@@ -15,6 +15,7 @@ template <typename SingleLevelSet, typename TwoLevelSet>
 class UniqExactSet
 {
     static_assert(std::is_same_v<typename SingleLevelSet::value_type, typename TwoLevelSet::value_type>);
+    static_assert(std::is_same_v<typename SingleLevelSet::Cell::State, HashTableNoState>);
 
 public:
     using value_type = typename SingleLevelSet::value_type;
@@ -147,7 +148,28 @@ public:
         }
     }
 
-    void read(ReadBuffer & in) { asSingleLevel().read(in); }
+    void read(ReadBuffer & in)
+    {
+        size_t new_size = 0;
+        auto * const position = in.position();
+        DB::readVarUInt(new_size, in);
+
+        if (worthConvertingToTwoLevel(new_size))
+        {
+            two_level_set = std::make_shared<TwoLevelSet>(new_size);
+            for (size_t i = 0; i < new_size; ++i)
+            {
+                typename SingleLevelSet::Cell x;
+                x.read(in);
+                asTwoLevel().insert(x.getValue());
+            }
+        }
+        else
+        {
+            in.position() = position; // Rollback position
+            asSingleLevel().read(in);
+        }
+    }
 
     void write(WriteBuffer & out) const
     {
@@ -165,6 +187,8 @@ public:
     {
         return two_level_set ? two_level_set : std::make_shared<TwoLevelSet>(asSingleLevel());
     }
+
+    static bool worthConvertingToTwoLevel(size_t size) { return size > 100'000; }
 
     void convertToTwoLevel()
     {

--- a/tests/performance/uniq_without_key_dist.xml
+++ b/tests/performance/uniq_without_key_dist.xml
@@ -1,0 +1,22 @@
+<test>
+    <substitutions>
+        <substitution>
+           <name>uniq_keys</name>
+           <values>
+               <value>100000</value>
+               <value>250000</value>
+               <value>500000</value>
+               <value>1000000</value>
+               <value>5000000</value>
+           </values>
+        </substitution>
+    </substitutions>
+
+    <create_query>create table t_{uniq_keys}(a UInt64) engine=MergeTree order by tuple()</create_query>
+
+    <fill_query>insert into t_{uniq_keys} select number % {uniq_keys} from numbers_mt(5e7)</fill_query>
+
+    <query>SELECT uniqExact(a) FROM remote('127.0.0.{{1,2}}', default, t_{uniq_keys}) SETTINGS max_threads=5</query>
+
+    <drop_query>drop table t_{uniq_keys}</drop_query>
+</test>


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Large aggregation states of `uniqExact` will be merged in parallel in distrubuted queries.
