### PR TITLE
Fix async loader stress test

### DIFF
--- a/src/Common/AsyncLoader.cpp
+++ b/src/Common/AsyncLoader.cpp
@@ -575,30 +575,24 @@ void AsyncLoader::finish(const LoadJobPtr & job, LoadStatus status, std::excepti
     // Update dependent jobs
     for (const auto & dpt : dependent)
     {
-        if (auto dpt_info = scheduled_jobs.find(dpt); dpt_info != scheduled_jobs.end())
-        {
-            dpt_info->second.dependencies_left--;
-            if (!dpt_info->second.isBlocked())
-                enqueue(dpt_info->second, dpt, lock);
+        auto dpt_info = scheduled_jobs.find(dpt);
+        if (dpt_info == scheduled_jobs.end())
+            continue;
+        dpt_info->second.dependencies_left--;
+        if (!dpt_info->second.isBlocked())
+            enqueue(dpt_info->second, dpt, lock);
 
-            if (status != LoadStatus::OK)
-            {
-                std::exception_ptr cancel;
-                NOEXCEPT_SCOPE({
-                    ALLOW_ALLOCATIONS_IN_SCOPE;
-                    if (dpt->dependency_failure)
-                        dpt->dependency_failure(dpt, job, cancel);
-                });
-                // Recurse into dependent job if it should be canceled
-                if (cancel)
-                    finish(dpt, LoadStatus::CANCELED, cancel, lock);
-            }
-        }
-        else
+        if (status != LoadStatus::OK)
         {
-            // Job has already been canceled. Do not enter twice into the same job during finish recursion.
-            // This happens in {A<-B; A<-C; B<-D; C<-D} graph for D if A is failed or canceled.
-            chassert(status == LoadStatus::CANCELED);
+            std::exception_ptr cancel;
+            NOEXCEPT_SCOPE({
+                ALLOW_ALLOCATIONS_IN_SCOPE;
+                if (dpt->dependency_failure)
+                    dpt->dependency_failure(dpt, job, cancel);
+            });
+            // Recurse into dependent job if it should be canceled
+            if (cancel)
+                finish(dpt, LoadStatus::CANCELED, cancel, lock);
         }
     }
 


### PR DESCRIPTION
Just remove a wrong chassert.
 
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
