### PR TITLE
Increase max_bytes_before_external_group_by for 00165_jit_aggregate_functions

### DIFF
--- a/tests/queries/1_stateful/00082_quantiles.sql
+++ b/tests/queries/1_stateful/00082_quantiles.sql
@@ -1,3 +1,6 @@
+-- The test uses quite a bit of memory. A low max_bytes_before_external_group_by value will lead to high disk usage
+-- which in CI leads to timeouts
+SET max_bytes_before_external_group_by=0;
 SELECT CounterID AS k, quantileExact(0.5)(ResolutionWidth) FROM test.hits GROUP BY k ORDER BY count() DESC, CounterID LIMIT 10;
 SELECT CounterID AS k, quantilesExact(0.1, 0.5, 0.9, 0.99, 0.999)(ResolutionWidth) FROM test.hits GROUP BY k ORDER BY count() DESC, CounterID LIMIT 10;
 

--- a/tests/queries/1_stateful/00165_jit_aggregate_functions.sql
+++ b/tests/queries/1_stateful/00165_jit_aggregate_functions.sql
@@ -1,6 +1,8 @@
 SET compile_aggregate_expressions = 1;
 SET min_count_to_compile_aggregate_expression = 0;
-SET max_bytes_before_external_group_by='200M'; -- might be randomized to 1 leading to timeout
+-- The test uses many aggregations. A low max_bytes_before_external_group_by value will lead to high disk usage
+-- which in CI leads to timeouts
+SET max_bytes_before_external_group_by=0;
 
 SELECT 'Aggregation using JIT compilation';
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

https://s3.amazonaws.com/clickhouse-test-reports/58971/6792f72c6bfd0906c30d7ac0977b7ba2298712d8/stateful_tests__debug__parallelreplicas_.html

In local env (Debug, 1 thread) with 200M: 25secs
In local env (Debug, 1 thread) with 0: 8.5 secs