### PR TITLE
Fix aggregation issue in mixed x86_64 and ARM clusters

### DIFF
--- a/src/Common/HashTable/StringHashTable.h
+++ b/src/Common/HashTable/StringHashTable.h
@@ -71,6 +71,28 @@ struct StringHashTableHash
         res = _mm_crc32_u64(res, key.c);
         return res;
     }
+#elif defined(__aarch64__) && defined(__ARM_FEATURE_CRC32)
+    size_t ALWAYS_INLINE operator()(StringKey8 key) const
+    {
+        size_t res = -1ULL;
+        res = __crc32cd(static_cast<UInt32>(res), key);
+        return res;
+    }
+    size_t ALWAYS_INLINE operator()(StringKey16 key) const
+    {
+        size_t res = -1ULL;
+        res = __crc32cd(static_cast<UInt32>(res), key.items[0]);
+        res = __crc32cd(static_cast<UInt32>(res), key.items[1]);
+        return res;
+    }
+    size_t ALWAYS_INLINE operator()(StringKey24 key) const
+    {
+        size_t res = -1ULL;
+        res = __crc32cd(static_cast<UInt32>(res), key.a);
+        res = __crc32cd(static_cast<UInt32>(res), key.b);
+        res = __crc32cd(static_cast<UInt32>(res), key.c);
+        return res;
+    }
 #elif defined(__s390x__) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
     size_t ALWAYS_INLINE operator()(StringKey8 key) const
     {


### PR DESCRIPTION
In mixed x86-64 / ARM clusters, distributed aggregation queries return incorrect results due to different hashes generated (`StringHashTableHash`) on both platforms.

The issue can be reproduced by the sql statements in "tests/integration/test_backward_compatability/test_short_strings_aggregation.py".

The fix is to use aarch64's `__crc32cd()` intrinsic which returns the same hash results as the hash on x86_64.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed wrong aggregation results in mixed x86_64 and ARM clusters.