### PR TITLE
Don't parse data after format in INSERT SELECT FROM input()

### DIFF
--- a/src/Parsers/ParserInsertQuery.cpp
+++ b/src/Parsers/ParserInsertQuery.cpp
@@ -220,7 +220,7 @@ bool ParserInsertQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
     }
 
     /// In case of defined format, data follows it.
-    if (format && !infile)
+    if (format && !infile && !select)
     {
         Pos last_token = pos;
         --last_token;

--- a/tests/queries/0_stateless/02971_insert_select_input_parsing.reference
+++ b/tests/queries/0_stateless/02971_insert_select_input_parsing.reference
@@ -1,0 +1,2 @@
+line1
+line2

--- a/tests/queries/0_stateless/02971_insert_select_input_parsing.sh
+++ b/tests/queries/0_stateless/02971_insert_select_input_parsing.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+$CLICKHOUSE_CLIENT -q "drop table if exists test"
+$CLICKHOUSE_CLIENT -q "create table test (str String) engine=Memory()"
+echo -e "line1\nline2" | $CLICKHOUSE_CLIENT -q "insert into test select * from input() format LineAsString -- comment"
+$CLICKHOUSE_CLIENT -q "select * from test"
+$CLICKHOUSE_CLIENT -q "drop table test"


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Closes https://github.com/ClickHouse/ClickHouse/issues/59125

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
