### PR TITLE
DisksApp.cpp: fix typo (specifiged → specified)

### DIFF
--- a/programs/disks/DisksApp.cpp
+++ b/programs/disks/DisksApp.cpp
@@ -160,7 +160,7 @@ int DisksApp::main(const std::vector<String> & /*args*/)
     }
     else
     {
-        throw Exception(ErrorCodes::BAD_ARGUMENTS, "No config-file specifiged");
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "No config-file specified");
     }
 
     if (config().has("save-logs"))


### PR DESCRIPTION
How to reproduce:

```
% clickhouse disks list
DB::Exception: No config-file specifiged
```

ClickHouse version:

```
% clickhouse server --version
ClickHouse server version 23.12.2.59 (official build).
```