### PR TITLE
31363 format template configure in settings

### DIFF
--- a/docs/en/interfaces/formats.md
+++ b/docs/en/interfaces/formats.md
@@ -253,7 +253,7 @@ This format is also available under the name `TSVRawWithNamesAndNames`.
 
 This format allows specifying a custom format string with placeholders for values with a specified escaping rule.
 
-It uses settings `format_template_resultset`, `format_template_row`, `format_template_rows_between_delimiter` and some settings of other formats (e.g. `output_format_json_quote_64bit_integers` when using `JSON` escaping, see further)
+It uses settings `format_template_resultset`, `format_template_row` (`format_schema_rows_template`), `format_template_rows_between_delimiter` and some settings of other formats (e.g. `output_format_json_quote_64bit_integers` when using `JSON` escaping, see further)
 
 Setting `format_template_row` specifies the path to the file containing format strings for rows with the following syntax:
 
@@ -278,6 +278,8 @@ So, for the following format string:
 the values of `SearchPhrase`, `c` and `price` columns, which are escaped as `Quoted`, `Escaped` and `JSON` will be printed (for select) or will be expected (for insert) between `Search phrase:`, `, count:`, `, ad price: $` and `;` delimiters respectively. For example:
 
 `Search phrase: 'bathroom interior design', count: 2166, ad price: $3;`
+
+In cases where it is challenging or not possible to deploy format output configuration for the template format to a directory on all nodes in a cluste, or if the format is trivial then `format_schema_rows_template` can be used to pass the template string directly in the query, rather than a path to the file which contains it.
 
 The `format_template_rows_between_delimiter` setting specifies the delimiter between rows, which is printed (or expected) after every row except the last one (`\n` by default)
 

--- a/docs/en/operations/settings/settings-formats.md
+++ b/docs/en/operations/settings/settings-formats.md
@@ -1668,6 +1668,10 @@ Path to file which contains format string for rows (for Template format).
 
 Delimiter between rows (for Template format).
 
+### format_schema_rows_template {#format_schema_rows_template}
+
+Format string for rows (for Template format)
+
 ## CustomSeparated format settings {custom-separated-format-settings}
 
 ### format_custom_escaping_rule {#format_custom_escaping_rule}

--- a/docs/ru/interfaces/formats.md
+++ b/docs/ru/interfaces/formats.md
@@ -201,7 +201,7 @@ SELECT * FROM nestedt FORMAT TSV
 
 Этот формат позволяет указать произвольную форматную строку, в которую подставляются значения, сериализованные выбранным способом.
 
-Для этого используются настройки `format_template_resultset`, `format_template_row`, `format_template_rows_between_delimiter` и настройки экранирования других форматов (например, `output_format_json_quote_64bit_integers` при экранировании как в `JSON`, см. далее)
+Для этого используются настройки `format_template_resultset`, `format_template_row` (`format_schema_rows_template`), `format_template_rows_between_delimiter` и настройки экранирования других форматов (например, `output_format_json_quote_64bit_integers` при экранировании как в `JSON`, см. далее)
 
 Настройка `format_template_row` задаёт путь к файлу, содержащему форматную строку для строк таблицы, которая должна иметь вид:
 
@@ -226,6 +226,8 @@ SELECT * FROM nestedt FORMAT TSV
     между разделителями `Search phrase: `, `, count: `, `, ad price: $` и `;` при выводе будут подставлены (при вводе - будут ожидаться) значения столбцов `SearchPhrase`, `c` и `price`, сериализованные как `Quoted`, `Escaped` и `JSON` соответственно, например:
 
     `Search phrase: 'bathroom interior design', count: 2166, ad price: $3;`
+
+В тех случаях, когда не удобно или не возможно указать произвольную форматную строку в файле, можно использовать `format_schema_rows_template` указать произвольную форматную строку в запросе.    
 
 Настройка `format_template_rows_between_delimiter` задаёт разделитель между строками, который выводится (или ожмдается при вводе) после каждой строки, кроме последней. По умолчанию `\n`.
 

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -1078,8 +1078,8 @@ class IColumn;
     M(String, format_schema, "", "Schema identifier (used by schema-based formats)", 0) \
     M(String, format_template_resultset, "", "Path to file which contains format string for result set (for Template format)", 0) \
     M(String, format_template_row, "", "Path to file which contains format string for rows (for Template format)", 0) \
-    M(String, format_template_rows_between_delimiter, "\n", "Delimiter between rows (for Template format)", 0) \
     M(String, format_schema_rows_template, "\n", "Format string for rows (for Template format)", 0) \
+    M(String, format_template_rows_between_delimiter, "\n", "Delimiter between rows (for Template format)", 0) \
     \
     M(EscapingRule, format_custom_escaping_rule, "Escaped", "Field escaping rule (for CustomSeparated format)", 0) \
     M(String, format_custom_field_delimiter, "\t", "Delimiter between fields (for CustomSeparated format)", 0) \

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -1079,6 +1079,7 @@ class IColumn;
     M(String, format_template_resultset, "", "Path to file which contains format string for result set (for Template format)", 0) \
     M(String, format_template_row, "", "Path to file which contains format string for rows (for Template format)", 0) \
     M(String, format_template_rows_between_delimiter, "\n", "Delimiter between rows (for Template format)", 0) \
+    M(String, format_schema_rows_template, "\n", "Format string for rows (for Template format)", 0) \
     \
     M(EscapingRule, format_custom_escaping_rule, "Escaped", "Field escaping rule (for CustomSeparated format)", 0) \
     M(String, format_custom_field_delimiter, "\t", "Delimiter between fields (for CustomSeparated format)", 0) \

--- a/src/Formats/FormatFactory.cpp
+++ b/src/Formats/FormatFactory.cpp
@@ -167,7 +167,6 @@ FormatSettings getFormatSettings(ContextPtr context, const Settings & settings)
     format_settings.template_settings.row_between_delimiter = settings.format_template_rows_between_delimiter;
     format_settings.template_settings.row_format = settings.format_template_row;
     format_settings.template_settings.row_format_schema = settings.format_schema_rows_template;
-    format_settings.template_settings.row_between_delimiter_schema = settings.format_schema_rows_between_delimiter;
     format_settings.tsv.crlf_end_of_line = settings.output_format_tsv_crlf_end_of_line;
     format_settings.tsv.empty_as_default = settings.input_format_tsv_empty_as_default;
     format_settings.tsv.enum_as_number = settings.input_format_tsv_enum_as_number;

--- a/src/Formats/FormatFactory.cpp
+++ b/src/Formats/FormatFactory.cpp
@@ -166,7 +166,8 @@ FormatSettings getFormatSettings(ContextPtr context, const Settings & settings)
     format_settings.template_settings.resultset_format = settings.format_template_resultset;
     format_settings.template_settings.row_between_delimiter = settings.format_template_rows_between_delimiter;
     format_settings.template_settings.row_format = settings.format_template_row;
-    format_settings.template_settings.row_format_schema_string = settings.format_schema_rows_template;
+    format_settings.template_settings.row_format_schema = settings.format_schema_rows_template;
+    format_settings.template_settings.row_between_delimiter_schema = settings.format_schema_rows_between_delimiter;
     format_settings.tsv.crlf_end_of_line = settings.output_format_tsv_crlf_end_of_line;
     format_settings.tsv.empty_as_default = settings.input_format_tsv_empty_as_default;
     format_settings.tsv.enum_as_number = settings.input_format_tsv_enum_as_number;

--- a/src/Formats/FormatFactory.cpp
+++ b/src/Formats/FormatFactory.cpp
@@ -166,6 +166,7 @@ FormatSettings getFormatSettings(ContextPtr context, const Settings & settings)
     format_settings.template_settings.resultset_format = settings.format_template_resultset;
     format_settings.template_settings.row_between_delimiter = settings.format_template_rows_between_delimiter;
     format_settings.template_settings.row_format = settings.format_template_row;
+    format_settings.template_settings.row_format_schema_string = settings.format_schema_rows_template;
     format_settings.tsv.crlf_end_of_line = settings.output_format_tsv_crlf_end_of_line;
     format_settings.tsv.empty_as_default = settings.input_format_tsv_empty_as_default;
     format_settings.tsv.enum_as_number = settings.input_format_tsv_enum_as_number;

--- a/src/Formats/FormatSettings.h
+++ b/src/Formats/FormatSettings.h
@@ -338,7 +338,7 @@ struct FormatSettings
         String resultset_format;
         String row_format;
         String row_between_delimiter;
-        String row_format_schema_string;
+        String row_format_schema;
     } template_settings;
 
     struct

--- a/src/Formats/FormatSettings.h
+++ b/src/Formats/FormatSettings.h
@@ -338,6 +338,7 @@ struct FormatSettings
         String resultset_format;
         String row_format;
         String row_between_delimiter;
+        String row_format_schema_string;
     } template_settings;
 
     struct

--- a/src/Processors/Formats/Impl/TemplateBlockOutputFormat.cpp
+++ b/src/Processors/Formats/Impl/TemplateBlockOutputFormat.cpp
@@ -221,21 +221,14 @@ void registerOutputFormatTemplate(FormatFactory & factory)
         };
         if (settings.template_settings.row_format.empty())
         {
-            if (settings.template_settings.row_format_schema.empty())
-            {
-                throw Exception(DB::ErrorCodes::INVALID_TEMPLATE_FORMAT, "Expected either format_template_row or format_schema_rows_template");
-            }
-            else
-            {
-                row_format = ParsedTemplateFormatString();
-                row_format.parse(settings.template_settings.row_format_schema,idx_by_name);
-            }
+            row_format = ParsedTemplateFormatString();
+            row_format.parse(settings.template_settings.row_format_schema,idx_by_name);
         }
         else
         {
-            if (settings.template_settings.row_format_schema.empty())
+            if (!settings.template_settings.row_format_schema.empty())
             {
-                throw Exception(DB::ErrorCodes::INVALID_TEMPLATE_FORMAT, "Expected either format_template_row or format_schema_rows_template");
+                throw Exception(DB::ErrorCodes::INVALID_TEMPLATE_FORMAT, "Expected either format_template_row or format_schema_rows_template, but not both");
             }
             row_format = ParsedTemplateFormatString(
                 FormatSchemaInfo(settings.template_settings.row_format, "Template", false,

--- a/tests/queries/0_stateless/00937_format_schema_rows_template.reference
+++ b/tests/queries/0_stateless/00937_format_schema_rows_template.reference
@@ -1,0 +1,4 @@
+Question: 'How awesome is clickhouse?', Answer: 'unbelievably awesome!', Number of Likes: 456, Date: 2016-01-02;
+Question: 'How fast is clickhouse?', Answer: 'Lightning fast!', Number of Likes: 9876543210, Date: 2016-01-03;
+Question: 'Is it opensource', Answer: 'of course it is!', Number of Likes: 789, Date: 2016-01-04
+

--- a/tests/queries/0_stateless/00937_format_schema_rows_template.sh
+++ b/tests/queries/0_stateless/00937_format_schema_rows_template.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2016
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+# Test format_schema_rows_template setting 
+
+$CLICKHOUSE_CLIENT --query="DROP TABLE IF EXISTS template";
+$CLICKHOUSE_CLIENT --query="CREATE TABLE template (question String, answer String, likes UInt64, date Date) ENGINE = Memory";
+$CLICKHOUSE_CLIENT --query="INSERT INTO template VALUES
+('How awesome is clickhouse?', 'unbelievably awesome!', 456, '2016-01-02'),\
+('How fast is clickhouse?', 'Lightning fast!', 9876543210, '2016-01-03'),\
+('Is it opensource', 'of course it is!', 789, '2016-01-04')";
+
+$CLICKHOUSE_CLIENT --query="SELECT * FROM template GROUP BY question, answer, likes, date WITH TOTALS ORDER BY date LIMIT 3 FORMAT Template SETTINGS \
+format_schema_rows_template = 'Question: \${question:Quoted}, Answer: \${answer:Quoted}, Number of Likes: \${likes:Raw}, Date: \${date:Raw}', \
+format_template_rows_between_delimiter = ';\n'";
+
+echo -e "\n"
+
+# Test that if both format_schema_rows_template setting and format_template_row are provided, error is thrown 
+
+echo -ne 'Question: ${question:Quoted}, Answer: ${answer:Quoted}, Number of Likes: ${likes:Raw}, Date: ${date:Raw}' > "$CURDIR"/00937_template_output_format_row.tmp
+$CLICKHOUSE_CLIENT --query="SELECT * FROM template GROUP BY question, answer, likes, date WITH TOTALS ORDER BY date LIMIT 3 FORMAT Template SETTINGS \
+format_template_row = '$CURDIR/00937_template_output_format_row.tmp', \
+format_schema_rows_template = 'Question: \${question:Quoted}, Answer: \${answer:Quoted}, Number of Likes: \${likes:Raw}, Date: \${date:Raw}', \
+format_template_rows_between_delimiter = ';\n'"; -- { serverError 474 }
+
+$CLICKHOUSE_CLIENT --query="DROP TABLE template";
+rm "$CURDIR"/00937_template_output_format_row.tmp


### PR DESCRIPTION
Hi Clickhouse team, 
I'm opening a PR for this feature. Look forward to your feedback and fixing any issues. :) 

### Changelog category (leave one):
- New Feature

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
The user can now specify the template string directly in the query using `format_schema_rows_template` as an alternative to `format_template_row`

### Documentation entry for user-facing changes

- [X] Documentation is written - English and Russian. (То что написал на русском скорее всего есть ошибки, я не носитель русского... нужно помощь исправить пж)

- docs/en/interfaces/formats.md
- docs/ru/interfaces/formats.md
- docs/en/operations/settings/settings-formats.md

Example usage not yet added, I can add that if needed. 
