### PR TITLE
Fix url encoding issue

### DIFF
--- a/tests/ci/pr_info.py
+++ b/tests/ci/pr_info.py
@@ -3,15 +3,20 @@ import json
 import logging
 import os
 from typing import Dict, List, Set, Union
+from urllib.parse import quote
 
+# isort: off
+# for some reason this line moves to the end
 from unidiff import PatchSet  # type: ignore
+
+# isort: on
 
 from build_download_helper import get_gh_api
 from env_helper import (
-    GITHUB_REPOSITORY,
-    GITHUB_SERVER_URL,
-    GITHUB_RUN_URL,
     GITHUB_EVENT_PATH,
+    GITHUB_REPOSITORY,
+    GITHUB_RUN_URL,
+    GITHUB_SERVER_URL,
 )
 
 FORCE_TESTS_LABEL = "force tests"
@@ -295,9 +300,10 @@ class PRInfo:
 
     @staticmethod
     def compare_url(first: str, second: str) -> str:
+        """the first and second are URL encoded to not fail on '#' and other symbols"""
         return (
             "https://api.github.com/repos/"
-            f"{GITHUB_REPOSITORY}/compare/{first}...{second}"
+            f"{GITHUB_REPOSITORY}/compare/{quote(first)}...{quote(second)}"
         )
 
     def fetch_changed_files(self):


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
In #59088 we faced the issue with special symbols in a branch name. It addresses it 