### PR TITLE
Fix broken cache for non-existing temp_path

### DIFF
--- a/tests/ci/cache_utils.py
+++ b/tests/ci/cache_utils.py
@@ -116,6 +116,7 @@ class Cache:
         self.s3_helper = s3_helper
 
     def _download(self, url: str, ignore_error: bool = False) -> None:
+        self.temp_path.mkdir(parents=True, exist_ok=True)
         compressed_cache = self.temp_path / self.archive_name
         try:
             if url.startswith("file://"):


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix the issue with the inability to download cache if `temp_path` does not exist.