### PR TITLE
Fix passing projections/indexes/primary key from columns list from CREATE query into inner table of MV

### DIFF
--- a/src/Databases/DatabaseOnDisk.cpp
+++ b/src/Databases/DatabaseOnDisk.cpp
@@ -94,7 +94,7 @@ std::pair<String, StoragePtr> createTableFromAST(
                 throw Exception(ErrorCodes::LOGICAL_ERROR, "Invalid storage definition in metadata file: "
                                                            "it's a bug or result of manual intervention in metadata files");
 
-            if (!StorageFactory::instance().checkIfStorageSupportsSchemaInterface(ast_create_query.storage->engine->name))
+            if (!StorageFactory::instance().getStorageFeatures(ast_create_query.storage->engine->name).supports_schema_inference)
                 throw Exception(ErrorCodes::EMPTY_LIST_OF_COLUMNS_PASSED, "Missing definition of columns.");
             /// Leave columns empty.
         }

--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -853,7 +853,7 @@ InterpreterCreateQuery::TableProperties InterpreterCreateQuery::getTableProperti
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Unexpected application state. CREATE query is missing either its storage or engine.");
     /// We can have queries like "CREATE TABLE <table> ENGINE=<engine>" if <engine>
     /// supports schema inference (will determine table structure in it's constructor).
-    else if (!StorageFactory::instance().checkIfStorageSupportsSchemaInterface(create.storage->engine->name))
+    else if (!StorageFactory::instance().getStorageFeatures(create.storage->engine->name).supports_schema_inference)
         throw Exception(ErrorCodes::INCORRECT_QUERY, "Incorrect CREATE query: required list of column descriptions or AS section or SELECT.");
 
     /// Even if query has list of columns, canonicalize it (unfold Nested columns).

--- a/src/Parsers/ASTCreateQuery.cpp
+++ b/src/Parsers/ASTCreateQuery.cpp
@@ -139,6 +139,8 @@ ASTPtr ASTColumns::clone() const
         res->set(res->projections, projections->clone());
     if (primary_key)
         res->set(res->primary_key, primary_key->clone());
+    if (primary_key_from_columns)
+        res->set(res->primary_key_from_columns, primary_key_from_columns->clone());
 
     return res;
 }

--- a/src/Parsers/ParserCreateQuery.cpp
+++ b/src/Parsers/ParserCreateQuery.cpp
@@ -1551,6 +1551,29 @@ bool ParserCreateViewQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expec
     if (comment)
         query->set(query->comment, comment);
 
+    if (query->columns_list && query->columns_list->primary_key)
+    {
+        /// If engine is not set will use default one
+        if (!query->storage)
+            query->set(query->storage, std::make_shared<ASTStorage>());
+        else if (query->storage->primary_key)
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Multiple primary keys are not allowed.");
+
+        query->storage->primary_key = query->columns_list->primary_key;
+
+    }
+
+    if (query->columns_list && (query->columns_list->primary_key_from_columns))
+    {
+        /// If engine is not set will use default one
+        if (!query->storage)
+            query->set(query->storage, std::make_shared<ASTStorage>());
+        else if (query->storage->primary_key)
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Multiple primary keys are not allowed.");
+
+        query->storage->primary_key = query->columns_list->primary_key_from_columns;
+    }
+
     tryGetIdentifierNameInto(as_database, query->as_database);
     tryGetIdentifierNameInto(as_table, query->as_table);
     query->set(query->select, select);

--- a/src/Storages/StorageFactory.cpp
+++ b/src/Storages/StorageFactory.cpp
@@ -253,4 +253,13 @@ AccessType StorageFactory::getSourceAccessType(const String & table_engine) cons
     return it->second.features.source_access_type;
 }
 
+
+const StorageFactory::StorageFeatures & StorageFactory::getStorageFeatures(const String & storage_name) const
+{
+    auto it = storages.find(storage_name);
+    if (it == storages.end())
+        throw Exception(ErrorCodes::UNKNOWN_STORAGE, "Unknown table engine {}", storage_name);
+    return it->second.features;
+}
+
 }

--- a/src/Storages/StorageFactory.h
+++ b/src/Storages/StorageFactory.h
@@ -129,12 +129,8 @@ public:
 
     AccessType getSourceAccessType(const String & table_engine) const;
 
-    bool checkIfStorageSupportsSchemaInterface(const String & storage_name)
-    {
-        if (storages.contains(storage_name))
-            return storages[storage_name].features.supports_schema_inference;
-        return false;
-    }
+    const StorageFeatures & getStorageFeatures(const String & storage_name) const;
+
 private:
     Storages storages;
 };

--- a/tests/queries/0_stateless/02982_create_mv_inner_extra.reference
+++ b/tests/queries/0_stateless/02982_create_mv_inner_extra.reference
@@ -1,0 +1,5 @@
+CREATE TABLE x (`key` String) ENGINE = MergeTree PRIMARY KEY key ORDER BY key SETTINGS index_granularity = 8192
+CREATE TABLE x (`key` String) ENGINE = MergeTree PRIMARY KEY tuple(key) ORDER BY tuple(key) SETTINGS index_granularity = 8192
+CREATE TABLE x (`key` String) ENGINE = Null
+CREATE TABLE x (`key` String, INDEX idx key TYPE bloom_filter GRANULARITY 1) ENGINE = MergeTree ORDER BY key SETTINGS index_granularity = 8192
+CREATE TABLE x (`key` String, PROJECTION p (SELECT uniqCombined(key))) ENGINE = MergeTree ORDER BY key SETTINGS index_granularity = 8192

--- a/tests/queries/0_stateless/02982_create_mv_inner_extra.sql
+++ b/tests/queries/0_stateless/02982_create_mv_inner_extra.sql
@@ -1,0 +1,58 @@
+-- Tags: no-random-merge-tree-settings
+
+DROP TABLE IF EXISTS data;
+DROP TABLE IF EXISTS mv_indexes;
+DROP TABLE IF EXISTS mv_no_indexes;
+DROP TABLE IF EXISTS mv_projections;
+DROP TABLE IF EXISTS mv_primary_key;
+DROP TABLE IF EXISTS mv_primary_key_from_column;
+
+CREATE TABLE data
+(
+    key String,
+)
+ENGINE = MergeTree
+ORDER BY key;
+
+CREATE MATERIALIZED VIEW mv_indexes
+(
+    key String,
+    INDEX idx key TYPE bloom_filter GRANULARITY 1
+)
+ENGINE = MergeTree
+ORDER BY key
+AS SELECT * FROM data;
+
+CREATE MATERIALIZED VIEW mv_no_indexes
+(
+    key String,
+    INDEX idx key TYPE bloom_filter GRANULARITY 1
+)
+ENGINE = Null
+AS SELECT * FROM data;
+
+CREATE MATERIALIZED VIEW mv_projections
+(
+    key String,
+    projection p (SELECT uniqCombined(key))
+)
+ENGINE = MergeTree
+ORDER BY key
+AS SELECT * FROM data;
+
+CREATE MATERIALIZED VIEW mv_primary_key
+(
+    key String,
+    PRIMARY KEY key
+)
+ENGINE = MergeTree
+AS SELECT * FROM data;
+
+CREATE MATERIALIZED VIEW mv_primary_key_from_column
+(
+    key String PRIMARY KEY
+)
+ENGINE = MergeTree
+AS SELECT * FROM data;
+
+SELECT replaceRegexpOne(create_table_query, 'CREATE TABLE [^ ]*', 'CREATE TABLE x') FROM system.tables WHERE database = currentDatabase() and table LIKE '.inner%' ORDER BY 1 FORMAT LineAsString;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix passing projections/indexes from CREATE query into inner table of MV

Before this patch any additional syntax, like:
- projections
- data skipping indexes
- primary key not as a storage argument (but in columns list)

Had not been passed to the inner table (in case MV had been created
without explicit TO table). Yes, this is not a "recommended" way of
using, but still, it should work.