### PR TITLE
Fix another place with special symbols in the URL

### DIFF
--- a/tests/ci/workflow_approve_rerun_lambda/app.py
+++ b/tests/ci/workflow_approve_rerun_lambda/app.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
 
-from collections import namedtuple
 import fnmatch
 import json
 import time
+from collections import namedtuple
+from urllib.parse import quote
 
 import requests  # type: ignore
-
 from lambda_shared.pr import TRUSTED_CONTRIBUTORS
 from lambda_shared.token import get_cached_access_token
 
@@ -129,7 +129,7 @@ def _exec_post_with_retry(url, token, data=None):
 
 
 def _get_pull_requests_from(repo_url, owner, branch, token):
-    url = f"{repo_url}/pulls?head={owner}:{branch}"
+    url = f"{repo_url}/pulls?head={quote(owner)}:{quote(branch)}"
     return _exec_get_with_retry(url, token)
 
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Another broken place for `#` symbol in the branch name #59088