### PR TITLE
Fix 02475_bson_each_row_format flakiness (due to small parsing block)

### DIFF
--- a/tests/queries/0_stateless/02475_bson_each_row_format.sh
+++ b/tests/queries/0_stateless/02475_bson_each_row_format.sh
@@ -5,6 +5,12 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CURDIR"/../shell_config.sh
 
+# In case of parallel parsing and small block
+# (--min_chunk_bytes_for_parallel_parsing) we may have multiple blocks, and
+# this will break sorting order, so let's limit number of threads to avoid
+# reordering.
+CLICKHOUSE_CLIENT+="--allow_repeated_settings --max_threads 1"
+
 echo "Integers"
 $CLICKHOUSE_CLIENT -q "insert into function file(02475_data.bsonEachRow) select number::Bool as bool, number::Int8 as int8, number::UInt8 as uint8, number::Int16 as int16, number::UInt16 as uint16, number::Int32 as int32, number::UInt32 as uint32, number::Int64 as int64, number::UInt64 as uint64 from numbers(5) settings engine_file_truncate_on_insert=1"
 $CLICKHOUSE_CLIENT -q "select * from file(02475_data.bsonEachRow, auto, 'bool Bool, int8 Int8, uint8 UInt8, int16 Int16, uint16 UInt16, int32 Int32, uint32 UInt32, int64 Int64, uint64 UInt64')"


### PR DESCRIPTION
CI: https://s3.amazonaws.com/clickhouse-test-reports/59170/c82050d1925439f0ede2b32acb5b1b8df4acae5d/stateless_tests__release_/run.log

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)