### PR TITLE
Fix fasttest by pinning pip dependencies

### DIFF
--- a/docker/test/fasttest/Dockerfile
+++ b/docker/test/fasttest/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update \
         zstd \
     --yes --no-install-recommends
 
-RUN pip3 install numpy scipy pandas Jinja2
+RUN pip3 install numpy==1.26.3 scipy==1.12.0 pandas==1.5.3 Jinja2==3.1.3
 
 ARG odbc_driver_url="https://github.com/ClickHouse/clickhouse-odbc/releases/download/v1.1.4.20200302/clickhouse-odbc-1.1.4-Linux.tar.gz"
 


### PR DESCRIPTION
After image update it prints the following warning:

    /ClickHouse/tests/queries/0_stateless/01558_ttest_scipy.python:5: DeprecationWarning:
    Pyarrow will become a required dependency of pandas in the next major release of pandas (pandas 3.0),
    (to allow more performant data types, such as the Arrow string type, and better interoperability with other libraries)
    but was not found to be installed on your system.
    If this would cause problems for you,
    please provide us feedback at https://github.com/pandas-dev/pandas/issues/54466

Pyarrow can be added as well, but according to the comment in the issue it bloats the image size 170%, so let's simply downgrade it for now and see how that issue will be resolved (or the warning could be suppressed of course).

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
