### PR TITLE
No debug symbols in Rust

### DIFF
--- a/rust/prql/Cargo.toml
+++ b/rust/prql/Cargo.toml
@@ -13,7 +13,7 @@ serde_json = "1.0"
 crate-type = ["staticlib"]
 
 [profile.release]
-debug = true
+debug = false
 
 [profile.release-thinlto]
 inherits = "release"

--- a/rust/skim/Cargo.toml
+++ b/rust/skim/Cargo.toml
@@ -17,7 +17,7 @@ cxx-build = "1.0.83"
 crate-type = ["staticlib"]
 
 [profile.release]
-debug = true
+debug = false
 
 [profile.release-thinlto]
 inherits = "release"

--- a/tests/ci/ci_config.py
+++ b/tests/ci/ci_config.py
@@ -213,6 +213,7 @@ class BuildConfig:
                     "./programs",
                     "./packages",
                     "./docker/packager/packager",
+                    "./rust",
                 ],
                 exclude_files=[".md"],
                 docker=["clickhouse/binary-builder"],


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Lower the binary size. Continuation of #56476.