### PR TITLE
`/binary` handler: allow specifying user/password/host

### DIFF
--- a/programs/server/binary.html
+++ b/programs/server/binary.html
@@ -60,8 +60,14 @@
         /// If it is hosted on server, assume that it is the address of ClickHouse.
         if (location.protocol != 'file:') {
             host = location.origin;
-            user = 'default';
             add_http_cors_header = false;
+        }
+
+        if (window.location.search) {
+            const params = new URLSearchParams(window.location.search);
+            if (params.has('host')) { host = params.get('host'); }
+            if (params.has('user')) { user = params.get('user'); }
+            if (params.has('password')) { password = params.get('password'); }
         }
 
         let map = L.map('space', {


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
`/binary` HTTP handler allows to specify user, host, and optionally, password in the query string.