### PR TITLE
Support backups for compressed in-memory tables

### DIFF
--- a/programs/server/config.xml
+++ b/programs/server/config.xml
@@ -1562,6 +1562,10 @@
         <max_entry_size_in_rows>30000000</max_entry_size_in_rows>
     </query_cache>
 
+    <backups>
+        <allowed_path>backups</allowed_path>
+    </backups>
+
     <!-- This allows to disable exposing addresses in stack traces for security reasons.
          Please be aware that it does not improve security much, but makes debugging much harder.
          The addresses that are small offsets from zero will be displayed nevertheless to show nullptr dereferences.

--- a/src/Formats/NativeWriter.cpp
+++ b/src/Formats/NativeWriter.cpp
@@ -49,8 +49,9 @@ static void writeData(const ISerialization & serialization, const ColumnPtr & co
 {
     /** If there are columns-constants - then we materialize them.
       * (Since the data type does not know how to serialize / deserialize constants.)
+      * The same for compressed columns in-memory.
       */
-    ColumnPtr full_column = column->convertToFullColumnIfConst();
+    ColumnPtr full_column = column->convertToFullColumnIfConst()->decompress();
 
     ISerialization::SerializeBinaryBulkSettings settings;
     settings.getter = [&ostr](ISerialization::SubstreamPath) -> WriteBuffer * { return &ostr; };

--- a/tests/queries/0_stateless/02973_backup_of_in_memory_compressed.reference
+++ b/tests/queries/0_stateless/02973_backup_of_in_memory_compressed.reference
@@ -1,0 +1,2 @@
+0
+1000000	Hello, world	Hello, world

--- a/tests/queries/0_stateless/02973_backup_of_in_memory_compressed.sh
+++ b/tests/queries/0_stateless/02973_backup_of_in_memory_compressed.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Tags: no-parallel
+# Because we are creating a backup with fixed path.
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+$CLICKHOUSE_CLIENT --multiquery "
+DROP TABLE IF EXISTS test;
+CREATE TABLE test (x String) ENGINE = Memory SETTINGS compress = 1;
+INSERT INTO test SELECT 'Hello, world' FROM numbers(1000000);
+"
+
+$CLICKHOUSE_CLIENT --multiquery "
+BACKUP TABLE test TO File('test.zip');
+" --format Null
+
+$CLICKHOUSE_CLIENT --multiquery "
+TRUNCATE TABLE test;
+SELECT count() FROM test;
+"
+
+$CLICKHOUSE_CLIENT --multiquery "
+RESTORE TABLE test FROM File('test.zip');
+" --format Null
+
+$CLICKHOUSE_CLIENT --multiquery "
+SELECT count(), min(x), max(x) FROM test;
+DROP TABLE test;
+"

--- a/tests/queries/0_stateless/02973_backup_of_in_memory_compressed.sh
+++ b/tests/queries/0_stateless/02973_backup_of_in_memory_compressed.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: no-parallel
+# Tags: no-parallel, no-fasttest
 # Because we are creating a backup with fixed path.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Support backups for compressed in-memory tables. This closes #57893.