### PR TITLE
docs: added hidden clickhouse-client shortkeys and aliases

### DIFF
--- a/docs/en/interfaces/cli.md
+++ b/docs/en/interfaces/cli.md
@@ -197,6 +197,29 @@ You can pass parameters to `clickhouse-client` (all parameters have a default va
 Instead of `--host`, `--port`, `--user` and `--password` options, ClickHouse client also supports connection strings (see next section).
 
 
+## Aliases {#cli_aliases}
+
+- `\l` - SHOW DATABASES
+- `\d` - SHOW TABLES
+- `\c <DATABASE>` - USE DATABASE
+- `.` - repeat the last query
+
+
+## Shortkeys {#shortkeys_aliases}
+
+- `Alt (Option) + Shift + e` - open editor with current query. It is possible to set up an environment variable - `EDITOR`, by default vim is used.
+- `Alt (Option) + #` - comment line.
+- `Ctrl + r` - fuzzy history search.
+
+:::tip
+To configure the correct work of meta key (Option) on MacOS:
+
+iTerm2: Go to Preferences -> Profile -> Keys -> Left Option key and click Esc+
+:::
+
+The full list with all available shortkeys - [replxx](https://github.com/AmokHuginnsson/replxx/blob/1f149bf/src/replxx_impl.cxx#L262).
+
+
 ## Connection string {#connection_string}
 
 clickhouse-client alternatively supports connecting to clickhouse server using a connection string similar to [MongoDB](https://www.mongodb.com/docs/manual/reference/connection-string/), [PostgreSQL](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING), [MySQL](https://dev.mysql.com/doc/refman/8.0/en/connecting-using-uri-or-key-value-pairs.html#connecting-using-uri). It has the following syntax:

--- a/utils/check-style/aspell-ignore/en/aspell-dict.txt
+++ b/utils/check-style/aspell-ignore/en/aspell-dict.txt
@@ -2703,3 +2703,6 @@ znode
 znodes
 zookeeperSessionUptime
 zstd
+iTerm
+shortkeys
+Shortkeys


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Documentation (changelog entry is not required)
