### PR TITLE
MaterializedMySQL: Fix gtid_after_attach_test to retry on detach

### DIFF
--- a/tests/integration/test_materialized_mysql_database/materialized_with_ddl.py
+++ b/tests/integration/test_materialized_mysql_database/materialized_with_ddl.py
@@ -3379,7 +3379,7 @@ def gtid_after_attach_test(clickhouse_node, mysql_node, replication):
         f"CREATE TABLE {db}.t(id INT PRIMARY KEY AUTO_INCREMENT, score int, create_time DATETIME DEFAULT NOW())"
     )
 
-    db_count = 6
+    db_count = 4
     for i in range(db_count):
         replication.create_db_ch(
             f"{db}{i}",
@@ -3392,7 +3392,11 @@ def gtid_after_attach_test(clickhouse_node, mysql_node, replication):
         "t\n",
     )
     for i in range(int(db_count / 2)):
-        clickhouse_node.query(f"DETACH DATABASE {db}{i}")
+        check_query(
+            clickhouse_node,
+            f"DETACH DATABASE {db}{i}",
+            "",
+        )
 
     mysql_node.query(f"USE {db}")
     rows = 10000


### PR DESCRIPTION
Fixed a race when trying to detach the recently created database by retrying
Fixes: https://s3.amazonaws.com/clickhouse-test-reports/59166/383ae86ebb0da8a962521f55b08186331eb0f676/integration_tests__asan__analyzer__[4_6]//home/ubuntu/actions-runner/_work/_temp/test/output_dir/integration_run_parallel1_0.log

```
E           Code: 219. DB::Exception: Received from 172.16.5.4:9000. DB::Exception: Database gtid_after_attach_test1 cannot be detached, because some tables are still in use. Retry later.. Stack trace:
E           
```
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)



