### PR TITLE
Add sanity checks for function return types

### DIFF
--- a/src/Columns/ColumnFunction.cpp
+++ b/src/Columns/ColumnFunction.cpp
@@ -308,6 +308,13 @@ ColumnWithTypeAndName ColumnFunction::reduce() const
         ProfileEvents::increment(ProfileEvents::CompiledFunctionExecute);
 
     res.column = function->execute(columns, res.type, elements_size);
+    if (res.column->getDataType() != res.type->getColumnType())
+        throw Exception(
+            ErrorCodes::LOGICAL_ERROR,
+            "Unexpected return type from {}. Expected {}. Got {}",
+            function->getName(),
+            res.type->getColumnType(),
+            res.column->getDataType());
     if (recursively_convert_result_to_full_column_if_low_cardinality)
     {
         res.column = recursiveRemoveLowCardinality(res.column);

--- a/src/DataTypes/DataTypeDate.h
+++ b/src/DataTypes/DataTypeDate.h
@@ -12,6 +12,7 @@ public:
     static constexpr auto family_name = "Date";
 
     TypeIndex getTypeId() const override { return TypeIndex::Date; }
+    TypeIndex getColumnType() const override { return TypeIndex::UInt16; }
     const char * getFamilyName() const override { return family_name; }
 
     bool canBeUsedAsVersion() const override { return true; }

--- a/src/DataTypes/DataTypeDate32.h
+++ b/src/DataTypes/DataTypeDate32.h
@@ -12,6 +12,7 @@ public:
     static constexpr auto family_name = "Date32";
 
     TypeIndex getTypeId() const override { return TypeIndex::Date32; }
+    TypeIndex getColumnType() const override { return TypeIndex::Int32; }
     const char * getFamilyName() const override { return family_name; }
 
     Field getDefault() const override

--- a/src/DataTypes/DataTypeDateTime.h
+++ b/src/DataTypes/DataTypeDateTime.h
@@ -40,6 +40,7 @@ public:
     const char * getFamilyName() const override { return family_name; }
     String doGetName() const override;
     TypeIndex getTypeId() const override { return TypeIndex::DateTime; }
+    TypeIndex getColumnType() const override { return TypeIndex::UInt32; }
 
     bool canBeUsedAsVersion() const override { return true; }
     bool canBeInsideNullable() const override { return true; }

--- a/src/DataTypes/DataTypeEnum.h
+++ b/src/DataTypes/DataTypeEnum.h
@@ -54,6 +54,7 @@ public:
     const char * getFamilyName() const override;
 
     TypeIndex getTypeId() const override { return type_id; }
+    TypeIndex getColumnType() const override { return sizeof(FieldType) == 1 ? TypeIndex::Int8 : TypeIndex::Int16; }
 
     FieldType readValue(ReadBuffer & istr) const
     {

--- a/src/DataTypes/DataTypeInterval.h
+++ b/src/DataTypes/DataTypeInterval.h
@@ -28,6 +28,7 @@ public:
     std::string doGetName() const override { return fmt::format("Interval{}", kind.toString()); }
     const char * getFamilyName() const override { return "Interval"; }
     TypeIndex getTypeId() const override { return TypeIndex::Interval; }
+    TypeIndex getColumnType() const override { return TypeIndex::Int64; }
 
     bool equals(const IDataType & rhs) const override;
 

--- a/src/DataTypes/IDataType.h
+++ b/src/DataTypes/IDataType.h
@@ -86,6 +86,8 @@ public:
 
     /// Data type id. It's used for runtime type checks.
     virtual TypeIndex getTypeId() const = 0;
+    /// Storage type (e.g. Int64 for Interval)
+    virtual TypeIndex getColumnType() const { return getTypeId(); }
 
     bool hasSubcolumn(std::string_view subcolumn_name) const;
 

--- a/src/Interpreters/ActionsDAG.cpp
+++ b/src/Interpreters/ActionsDAG.cpp
@@ -282,6 +282,13 @@ const ActionsDAG::Node & ActionsDAG::addFunctionImpl(
         {
             size_t num_rows = arguments.empty() ? 0 : arguments.front().column->size();
             column = node.function->execute(arguments, node.result_type, num_rows, true);
+            if (column->getDataType() != node.result_type->getColumnType())
+                throw Exception(
+                    ErrorCodes::LOGICAL_ERROR,
+                    "Unexpected return type from {}. Expected {}. Got {}",
+                    node.function->getName(),
+                    node.result_type->getColumnType(),
+                    column->getDataType());
         }
         else
         {

--- a/src/Interpreters/ExpressionActions.cpp
+++ b/src/Interpreters/ExpressionActions.cpp
@@ -611,6 +611,13 @@ static void executeAction(const ExpressionActions::Action & action, ExecutionCon
                     ProfileEvents::increment(ProfileEvents::CompiledFunctionExecute);
 
                 res_column.column = action.node->function->execute(arguments, res_column.type, num_rows, dry_run);
+                if (res_column.column->getDataType() != res_column.type->getColumnType())
+                    throw Exception(
+                        ErrorCodes::LOGICAL_ERROR,
+                        "Unexpected return type from {}. Expected {}. Got {}",
+                        action.node->function->getName(),
+                        res_column.type->getColumnType(),
+                        res_column.column->getDataType());
             }
             break;
         }


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

Followup for https://github.com/ClickHouse/ClickHouse/pull/59356

Let's add some checks that function return the type they said they were going to return. It should help the fuzzer detect problems as it will trigger the assert/exception even if an empty column is returned.