### PR TITLE
Update developer docs to warn CI will fail without unique filenames for .tmp files

### DIFF
--- a/docs/en/development/tests.md
+++ b/docs/en/development/tests.md
@@ -109,6 +109,9 @@ Do not check for a particular wording of error message, it may change in the fut
 
 If you want to use distributed queries in functional tests, you can leverage `remote` table function with `127.0.0.{1..2}` addresses for the server to query itself; or you can use predefined test clusters in server configuration file like `test_shard_localhost`. Remember to add the words `shard` or `distributed` to the test name, so that it is run in CI in correct configurations, where the server is configured to support distributed queries.
 
+### Working with Temporary Files
+
+Sometimes in a shell test you may need to create a file on the fly to work with. Keep in mind that some CI checks run tests in parallel, so if you are creating or removing a temporary file in your script without a unique name this can cause some of the CI checks, such as Flaky, to fail. To get around this you should use environment variable `$CLICKHOUSE_TEST_UNIQUE_NAME` to give temporary files a name unique to the test that is running. That way you can be sure that the file you are creating during setup or removing during cleanup is the file only in use by that test and not some other test which is running in parallel. 
 
 ## Known Bugs {#known-bugs}
 


### PR DESCRIPTION
I ran into this issue in #59088 and @Avogar pointed out that some CI checks will fail due to parallel nature if temporary files created or removed in shell scripts don't have a unique name. It's probably obvious to regular contributors but I thought it might be nice to add a small note to the developer documentation for new contributors / for general information. 

### Changelog category (leave one):
- Documentation (changelog entry is not required)