### PR TITLE
Job names

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -104,7 +104,7 @@ jobs:
     if: ${{ !failure() && !cancelled() }}
     uses: ./.github/workflows/reusable_test.yml
     with:
-      test_name: Fast tests
+      test_name: Fast test
       runner_type: builder
       data: ${{ needs.RunConfig.outputs.data }}
       run_command: |

--- a/tests/ci/ci.py
+++ b/tests/ci/ci.py
@@ -268,11 +268,11 @@ def _check_and_update_for_early_style_check(run_config: dict) -> None:
     jobs_to_do = run_config.get("jobs_data", {}).get("jobs_to_do", [])
     docker_to_build = run_config.get("docker_data", {}).get("missing_multi", [])
     if (
-        "Style check" in jobs_to_do
+        JobNames.STYLE_CHECK in jobs_to_do
         and docker_to_build
         and "clickhouse/style-test" not in docker_to_build
     ):
-        index = jobs_to_do.index("Style check")
+        index = jobs_to_do.index(JobNames.STYLE_CHECK)
         jobs_to_do[index] = "Style check early"
 
 

--- a/tests/ci/ci.py
+++ b/tests/ci/ci.py
@@ -10,7 +10,16 @@ from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional
 
 import docker_images_helper
-from ci_config import CI_CONFIG, Labels
+import upload_result_helper
+from build_check import get_release_or_pr
+from ci_config import CI_CONFIG, JobNames, Labels
+from clickhouse_helper import (
+    CiLogsCredentials,
+    ClickHouseHelper,
+    get_instance_id,
+    get_instance_type,
+    prepare_tests_results_for_clickhouse,
+)
 from commit_status_helper import (
     CommitStatusData,
     RerunHelper,
@@ -36,15 +45,6 @@ from github import Github
 from pr_info import PRInfo
 from report import SUCCESS, BuildResult, JobReport
 from s3_helper import S3Helper
-from clickhouse_helper import (
-    CiLogsCredentials,
-    ClickHouseHelper,
-    get_instance_id,
-    get_instance_type,
-    prepare_tests_results_for_clickhouse,
-)
-from build_check import get_release_or_pr
-import upload_result_helper
 from version_helper import get_version_from_repo
 
 
@@ -277,7 +277,7 @@ def _check_and_update_for_early_style_check(run_config: dict) -> None:
 
 
 def _update_config_for_docs_only(run_config: dict) -> None:
-    DOCS_CHECK_JOBS = ["Docs check", "Style check"]
+    DOCS_CHECK_JOBS = [JobNames.DOCS_CHECK, JobNames.STYLE_CHECK]
     print(f"NOTE: Will keep only docs related jobs: [{DOCS_CHECK_JOBS}]")
     jobs_to_do = run_config.get("jobs_data", {}).get("jobs_to_do", [])
     run_config["jobs_data"]["jobs_to_do"] = [
@@ -893,7 +893,7 @@ def main() -> int:
             CI_CONFIG.get_digest_config("package_release")
         )
         docs_digest = job_digester.get_job_digest(
-            CI_CONFIG.get_digest_config("Docs check")
+            CI_CONFIG.get_digest_config(JobNames.DOCS_CHECK)
         )
         jobs_data = (
             _configure_jobs(

--- a/tests/ci/ci_config.py
+++ b/tests/ci/ci_config.py
@@ -1231,10 +1231,10 @@ CHECK_DESCRIPTIONS = [
         lambda x: x.startswith("Stress test ("),
     ),
     CheckDescription(
-        "Style Check",
+        JobNames.STYLE_CHECK,
         "Runs a set of checks to keep the code style clean. If some of tests failed, "
         "see the related log from the report",
-        lambda x: x == "Style Check",
+        lambda x: x == JobNames.STYLE_CHECK,
     ),
     CheckDescription(
         "Unit tests",

--- a/tests/ci/ci_config.py
+++ b/tests/ci/ci_config.py
@@ -1144,7 +1144,9 @@ CHECK_DESCRIPTIONS = [
         lambda x: x.startswith("Docker keeper"),
     ),
     CheckDescription(
-        "Docs Check", "Builds and tests the documentation", lambda x: x == "Docs Check"
+        JobNames.DOCS_CHECK,
+        "Builds and tests the documentation",
+        lambda x: x == JobNames.DOCS_CHECK,
     ),
     CheckDescription(
         JobNames.FAST_TEST,

--- a/tests/ci/ci_config.py
+++ b/tests/ci/ci_config.py
@@ -6,8 +6,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Callable, Dict, Iterable, List, Literal, Optional, Union
 
-from integration_test_images import IMAGES
 from ci_utils import WithIter
+from integration_test_images import IMAGES
 
 
 class Labels(metaclass=WithIter):
@@ -42,7 +42,7 @@ class Build(metaclass=WithIter):
 
 class JobNames(metaclass=WithIter):
     STYLE_CHECK = "Style check"
-    FAST_TEST = "Fast tests"
+    FAST_TEST = "Fast test"
     DOCKER_SERVER = "Docker server image"
     DOCKER_KEEPER = "Docker keeper image"
     INSTALL_TEST_AMD = "Install packages (amd64)"
@@ -1147,7 +1147,7 @@ CHECK_DESCRIPTIONS = [
         "Docs Check", "Builds and tests the documentation", lambda x: x == "Docs Check"
     ),
     CheckDescription(
-        "Fast test",
+        JobNames.FAST_TEST,
         "Normally this is the first check that is ran for a PR. It builds ClickHouse "
         'and runs most of <a href="https://clickhouse.com/docs/en/development/tests'
         '#functional-tests">stateless functional tests</a>, '
@@ -1155,7 +1155,7 @@ CHECK_DESCRIPTIONS = [
         "Look at the report to see which tests fail, then reproduce the failure "
         'locally as described <a href="https://clickhouse.com/docs/en/development/'
         'tests#functional-test-locally">here</a>',
-        lambda x: x == "Fast test",
+        lambda x: x == JobNames.FAST_TEST,
     ),
     CheckDescription(
         "Flaky tests",

--- a/tests/ci/docs_check.py
+++ b/tests/ci/docs_check.py
@@ -6,14 +6,11 @@ import sys
 from pathlib import Path
 
 from docker_images_helper import get_docker_image, pull_image
-from env_helper import TEMP_PATH, REPO_COPY
+from env_helper import REPO_COPY, TEMP_PATH
 from pr_info import PRInfo
-from report import JobReport, TestResults, TestResult
+from report import JobReport, TestResult, TestResults
 from stopwatch import Stopwatch
 from tee_popen import TeePopen
-
-
-NAME = "Docs Check"
 
 
 def parse_args() -> argparse.Namespace:

--- a/tests/ci/fast_test_check.py
+++ b/tests/ci/fast_test_check.py
@@ -1,21 +1,19 @@
 #!/usr/bin/env python3
 import argparse
-import logging
-import subprocess
-import os
 import csv
+import logging
+import os
+import subprocess
 import sys
 from pathlib import Path
 from typing import Tuple
 
 from docker_images_helper import DockerImage, get_docker_image, pull_image
-from env_helper import S3_BUILDS_BUCKET, TEMP_PATH, REPO_COPY
+from env_helper import REPO_COPY, S3_BUILDS_BUCKET, TEMP_PATH
 from pr_info import FORCE_TESTS_LABEL, PRInfo
 from report import JobReport, TestResult, TestResults, read_test_results
 from stopwatch import Stopwatch
 from tee_popen import TeePopen
-
-NAME = "Fast test"
 
 # Will help to avoid errors like _csv.Error: field larger than field limit (131072)
 csv.field_size_limit(sys.maxsize)

--- a/tests/ci/style_check.py
+++ b/tests/ci/style_check.py
@@ -8,7 +8,6 @@ import sys
 from pathlib import Path
 from typing import List, Tuple
 
-
 from docker_images_helper import get_docker_image, pull_image
 from env_helper import REPO_COPY, TEMP_PATH
 from git_helper import GIT_PREFIX, git_runner
@@ -16,8 +15,6 @@ from pr_info import PRInfo
 from report import JobReport, TestResults, read_test_results
 from ssh import SSHKey
 from stopwatch import Stopwatch
-
-NAME = "Style Check"
 
 
 def process_result(


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed some inconsistency in jobs' naming.