### PR TITLE
CI: fix status and report for docker server jobs

### DIFF
--- a/.github/workflows/backport_branches.yml
+++ b/.github/workflows/backport_branches.yml
@@ -138,19 +138,26 @@ jobs:
 ############################################################################################
 ##################################### Docker images  #######################################
 ############################################################################################
-  DockerServerImages:
+  DockerServerImage:
     needs: [RunConfig, BuilderDebRelease, BuilderDebAarch64]
     if: ${{ !failure() && !cancelled() }}
     uses: ./.github/workflows/reusable_test.yml
     with:
-      test_name: Docker server and keeper images
+      test_name: Docker server image
       runner_type: style-checker
       data: ${{ needs.RunConfig.outputs.data }}
-      checkout_depth: 0  # It MUST BE THE SAME for all dependencies and the job itself
       run_command: |
-        cd "$GITHUB_WORKSPACE/tests/ci"
         python3 docker_server.py --release-type head --no-push \
           --image-repo clickhouse/clickhouse-server --image-path docker/server --allow-build-reuse
+  DockerKeeperImage:
+    needs: [RunConfig, BuilderDebRelease, BuilderDebAarch64]
+    if: ${{ !failure() && !cancelled() }}
+    uses: ./.github/workflows/reusable_test.yml
+    with:
+      test_name: Docker keeper image
+      runner_type: style-checker
+      data: ${{ needs.RunConfig.outputs.data }}
+      run_command: |
         python3 docker_server.py --release-type head --no-push \
           --image-repo clickhouse/clickhouse-keeper --image-path docker/keeper --allow-build-reuse
 ############################################################################################

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -242,20 +242,26 @@ jobs:
 ############################################################################################
 ##################################### Docker images  #######################################
 ############################################################################################
-  DockerServerImages:
+  DockerServerImage:
     needs: [RunConfig, BuilderDebRelease, BuilderDebAarch64]
     if: ${{ !failure() && !cancelled() }}
     uses: ./.github/workflows/reusable_test.yml
     with:
-      test_name: Docker server and keeper images
+      test_name: Docker server image
       runner_type: style-checker
       data: ${{ needs.RunConfig.outputs.data }}
-      # FIXME: avoid using 0 checkout
-      checkout_depth: 0  # It MUST BE THE SAME for all dependencies and the job itself
       run_command: |
-        cd "$GITHUB_WORKSPACE/tests/ci"
         python3 docker_server.py --release-type head \
           --image-repo clickhouse/clickhouse-server --image-path docker/server --allow-build-reuse
+  DockerKeeperImage:
+    needs: [RunConfig, BuilderDebRelease, BuilderDebAarch64]
+    if: ${{ !failure() && !cancelled() }}
+    uses: ./.github/workflows/reusable_test.yml
+    with:
+      test_name: Docker keeper image
+      runner_type: style-checker
+      data: ${{ needs.RunConfig.outputs.data }}
+      run_command: |
         python3 docker_server.py --release-type head \
           --image-repo clickhouse/clickhouse-keeper --image-path docker/keeper --allow-build-reuse
 ############################################################################################

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -273,19 +273,26 @@ jobs:
 ############################################################################################
 ##################################### Docker images  #######################################
 ############################################################################################
-  DockerServerImages:
+  DockerServerImage:
     needs: [RunConfig, BuilderDebRelease, BuilderDebAarch64]
     if: ${{ !failure() && !cancelled() }}
     uses: ./.github/workflows/reusable_test.yml
     with:
-      test_name: Docker server and keeper images
+      test_name: Docker server image
       runner_type: style-checker
       data: ${{ needs.RunConfig.outputs.data }}
-      checkout_depth: 0  # It MUST BE THE SAME for all dependencies and the job itself
       run_command: |
-        cd "$GITHUB_WORKSPACE/tests/ci"
         python3 docker_server.py --release-type head --no-push \
           --image-repo clickhouse/clickhouse-server --image-path docker/server --allow-build-reuse
+  DockerKeeperImage:
+    needs: [RunConfig, BuilderDebRelease, BuilderDebAarch64]
+    if: ${{ !failure() && !cancelled() }}
+    uses: ./.github/workflows/reusable_test.yml
+    with:
+      test_name: Docker keeper image
+      runner_type: style-checker
+      data: ${{ needs.RunConfig.outputs.data }}
+      run_command: |
         python3 docker_server.py --release-type head --no-push \
           --image-repo clickhouse/clickhouse-keeper --image-path docker/keeper --allow-build-reuse
 ############################################################################################

--- a/.github/workflows/release_branches.yml
+++ b/.github/workflows/release_branches.yml
@@ -153,19 +153,26 @@ jobs:
 ############################################################################################
 ##################################### Docker images  #######################################
 ############################################################################################
-  DockerServerImages:
+  DockerServerImage:
     needs: [RunConfig, BuilderDebRelease, BuilderDebAarch64]
     if: ${{ !failure() && !cancelled() }}
     uses: ./.github/workflows/reusable_test.yml
     with:
-      test_name: Docker server and keeper images
+      test_name: Docker server image
       runner_type: style-checker
       data: ${{ needs.RunConfig.outputs.data }}
-      checkout_depth: 0
       run_command: |
-        cd "$GITHUB_WORKSPACE/tests/ci"
         python3 docker_server.py --release-type head --no-push \
           --image-repo clickhouse/clickhouse-server --image-path docker/server --allow-build-reuse
+  DockerKeeperImage:
+    needs: [RunConfig, BuilderDebRelease, BuilderDebAarch64]
+    if: ${{ !failure() && !cancelled() }}
+    uses: ./.github/workflows/reusable_test.yml
+    with:
+      test_name: Docker keeper image
+      runner_type: style-checker
+      data: ${{ needs.RunConfig.outputs.data }}
+      run_command: |
         python3 docker_server.py --release-type head --no-push \
           --image-repo clickhouse/clickhouse-keeper --image-path docker/keeper --allow-build-reuse
 ############################################################################################
@@ -456,7 +463,8 @@ jobs:
   FinishCheck:
     if: ${{ !failure() && !cancelled() }}
     needs:
-      - DockerServerImages
+      - DockerServerImage
+      - DockerKeeperImage
       - BuilderReport
       - BuilderSpecialReport
       - MarkReleaseReady

--- a/tests/ci/ci_config.py
+++ b/tests/ci/ci_config.py
@@ -1136,12 +1136,12 @@ CHECK_DESCRIPTIONS = [
     CheckDescription(
         JobNames.DOCKER_SERVER,
         "The check to build and optionally push the mentioned image to docker hub",
-        lambda x: x.startswith("Docker server")
+        lambda x: x.startswith("Docker server"),
     ),
     CheckDescription(
         JobNames.DOCKER_KEEPER,
         "The check to build and optionally push the mentioned image to docker hub",
-        lambda x: x.startswith("Docker keeper")
+        lambda x: x.startswith("Docker keeper"),
     ),
     CheckDescription(
         "Docs Check", "Builds and tests the documentation", lambda x: x == "Docs Check"

--- a/tests/ci/ci_config.py
+++ b/tests/ci/ci_config.py
@@ -43,7 +43,8 @@ class Build(metaclass=WithIter):
 class JobNames(metaclass=WithIter):
     STYLE_CHECK = "Style check"
     FAST_TEST = "Fast tests"
-    DOCKER_SERVER = "Docker server and keeper images"
+    DOCKER_SERVER = "Docker server image"
+    DOCKER_KEEPER = "Docker keeper image"
     INSTALL_TEST_AMD = "Install packages (amd64)"
     INSTALL_TEST_ARM = "Install packages (arm64)"
 
@@ -786,6 +787,16 @@ CI_CONFIG = CiConfig(
                     include_paths=[
                         "tests/ci/docker_server.py",
                         "./docker/server",
+                    ]
+                )
+            ),
+        ),
+        JobNames.DOCKER_KEEPER: TestConfig(
+            "",
+            job_config=JobConfig(
+                digest=DigestConfig(
+                    include_paths=[
+                        "tests/ci/docker_server.py",
                         "./docker/keeper",
                     ]
                 )
@@ -922,7 +933,7 @@ CI_CONFIG = CiConfig(
             Build.PACKAGE_DEBUG,
             job_config=JobConfig(num_batches=6, **statless_test_common_params),  # type: ignore
         ),
-        JobNames.STATELESS_TEST_S3_DEBUG: TestConfig(
+        JobNames.STATELESS_TEST_S3_TSAN: TestConfig(
             Build.PACKAGE_TSAN,
             job_config=JobConfig(num_batches=5, **statless_test_common_params),  # type: ignore
         ),
@@ -1123,10 +1134,14 @@ CHECK_DESCRIPTIONS = [
         lambda x: x.startswith("Compatibility check"),
     ),
     CheckDescription(
-        "Docker image for servers",
+        JobNames.DOCKER_SERVER,
         "The check to build and optionally push the mentioned image to docker hub",
-        lambda x: x.startswith("Docker image")
-        and (x.endswith("building check") or x.endswith("build and push")),
+        lambda x: x.startswith("Docker server")
+    ),
+    CheckDescription(
+        JobNames.DOCKER_KEEPER,
+        "The check to build and optionally push the mentioned image to docker hub",
+        lambda x: x.startswith("Docker keeper")
     ),
     CheckDescription(
         "Docs Check", "Builds and tests the documentation", lambda x: x == "Docs Check"


### PR DESCRIPTION
 #no_merge_commit

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Create separate jobs for server and keeper to not mess up with GH status and report.html

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
