### PR TITLE
Fix test test_stop_other_host_during_backup

### DIFF
--- a/tests/integration/test_backup_restore_on_cluster/test.py
+++ b/tests/integration/test_backup_restore_on_cluster/test.py
@@ -1087,9 +1087,11 @@ def test_stop_other_host_during_backup(kill):
     status = node1.query(f"SELECT status FROM system.backups WHERE id='{id}'").strip()
 
     if kill:
-        assert status in ["BACKUP_CREATED", "BACKUP_FAILED"]
+        expected_statuses = ["BACKUP_CREATED", "BACKUP_FAILED"]
     else:
-        assert status == "BACKUP_CREATED"
+        expected_statuses = ["BACKUP_CREATED", "BACKUP_CANCELLED"]
+
+    assert status in expected_statuses
 
     node2.start_clickhouse()
 


### PR DESCRIPTION
### Changelog category:
- Not for changelog

Fix test `test_backup_restore_on_cluster/test.py::test_stop_other_host_during_backup[False]` (see [failure](https://s3.amazonaws.com/clickhouse-test-reports/59341/c2b7d2047ed09fac37ae85d69d4191a14eb2d31f/integration_tests__asan__analyzer__[5_6].html))