### PR TITLE
Fix `ASTAlterCommand::formatImpl` in case of column specific settings…

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -491,11 +491,11 @@ jobs:
       run_command: |
         TEMP_PATH="${TEMP_PATH}/integration" \
           python3 integration_test_check.py "Integration $CHECK_NAME" \
-            --validate-bugfix --post-commit-status=file || echo 'ignore exit code'
+            --validate-bugfix --post-commit-status=file || echo "ignore exit code"
 
         TEMP_PATH="${TEMP_PATH}/stateless" \
           python3 functional_test_check.py "Stateless $CHECK_NAME" "$KILL_TIMEOUT" \
-            --validate-bugfix --post-commit-status=file || echo 'ignore exit code'
+            --validate-bugfix --post-commit-status=file || echo "ignore exit code"
 
         python3 bugfix_validate_check.py "${TEMP_PATH}/stateless/functional_commit_status.tsv" "${TEMP_PATH}/integration/integration_commit_status.tsv"
 ##############################################################################################

--- a/docs/en/sql-reference/statements/alter/column.md
+++ b/docs/en/sql-reference/statements/alter/column.md
@@ -139,8 +139,8 @@ ALTER TABLE visits COMMENT COLUMN browser 'This column shows the browser used fo
 ## MODIFY COLUMN
 
 ``` sql
-MODIFY COLUMN [IF EXISTS] name [type] [default_expr] [codec] [TTL] [AFTER name_after | FIRST]
-ALTER COLUMN [IF EXISTS] name TYPE [type] [default_expr] [codec] [TTL] [AFTER name_after | FIRST]
+MODIFY COLUMN [IF EXISTS] name [type] [default_expr] [codec] [TTL] [settings] [AFTER name_after | FIRST]
+ALTER COLUMN [IF EXISTS] name TYPE [type] [default_expr] [codec] [TTL] [settings] [AFTER name_after | FIRST]
 ```
 
 This query changes the `name` column properties:
@@ -153,9 +153,13 @@ This query changes the `name` column properties:
 
 - TTL
 
+- Column-level Settings
+
 For examples of columns compression CODECS modifying, see [Column Compression Codecs](../create/table.md/#codecs).
 
 For examples of columns TTL modifying, see [Column TTL](/docs/en/engines/table-engines/mergetree-family/mergetree.md/#mergetree-column-ttl).
+
+For examples of colum-level settings modifying, see [Column-level Settings](/docs/en/engines/table-engines/mergetree-family/mergetree.md/#column-level-settings).
 
 If the `IF EXISTS` clause is specified, the query won’t return an error if the column does not exist.
 
@@ -209,7 +213,7 @@ The `ALTER` query for changing columns is replicated. The instructions are saved
 
 ## MODIFY COLUMN REMOVE
 
-Removes one of the column properties: `DEFAULT`, `ALIAS`, `MATERIALIZED`, `CODEC`, `COMMENT`, `TTL`, `SETTING`.
+Removes one of the column properties: `DEFAULT`, `ALIAS`, `MATERIALIZED`, `CODEC`, `COMMENT`, `TTL`, `SETTINGS`.
 
 Syntax:
 
@@ -237,7 +241,7 @@ Modify a column setting.
 Syntax:
 
 ```sql
-ALTER TABLE table_name MODIFY COLUMN MODIFY SETTING name=value,...;
+ALTER TABLE table_name MODIFY COLUMN column_name MODIFY SETTING name=value,...;
 ```
 
 **Example**
@@ -245,7 +249,7 @@ ALTER TABLE table_name MODIFY COLUMN MODIFY SETTING name=value,...;
 Modify column's `max_compress_block_size` to `1MB`:
 
 ```sql
-ALTER TABLE table_name MODIFY COLUMN MODIFY SETTING max_compress_block_size = 1048576;
+ALTER TABLE table_name MODIFY COLUMN column_name MODIFY SETTING max_compress_block_size = 1048576;
 ```
 
 ## MODIFY COLUMN RESET SETTING
@@ -255,21 +259,21 @@ Reset a column setting, also removes the setting declaration in the column expre
 Syntax:
 
 ```sql
-ALTER TABLE table_name MODIFY COLUMN RESET SETTING name,...;
+ALTER TABLE table_name MODIFY COLUMN column_name RESET SETTING name,...;
 ```
 
 **Example**
 
-Remove column setting `max_compress_block_size` to `1MB`:
+Reset column setting `max_compress_block_size` to it's default value:
 
 ```sql
-ALTER TABLE table_name MODIFY COLUMN REMOVE SETTING max_compress_block_size;
+ALTER TABLE table_name MODIFY COLUMN column_name RESET SETTING max_compress_block_size;
 ```
 
 ## MATERIALIZE COLUMN
 
 Materializes or updates a column with an expression for a default value (`DEFAULT` or `MATERIALIZED`).
-It is used if it is necessary to add or update a column with a complicated expression, because evaluating such an expression directly on `SELECT` executing turns out to be expensive. 
+It is used if it is necessary to add or update a column with a complicated expression, because evaluating such an expression directly on `SELECT` executing turns out to be expensive.
 Implemented as a [mutation](/docs/en/sql-reference/statements/alter/index.md#mutations).
 
 Syntax:

--- a/docs/en/sql-reference/statements/alter/column.md
+++ b/docs/en/sql-reference/statements/alter/column.md
@@ -159,7 +159,7 @@ For examples of columns compression CODECS modifying, see [Column Compression Co
 
 For examples of columns TTL modifying, see [Column TTL](/docs/en/engines/table-engines/mergetree-family/mergetree.md/#mergetree-column-ttl).
 
-For examples of colum-level settings modifying, see [Column-level Settings](/docs/en/engines/table-engines/mergetree-family/mergetree.md/#column-level-settings).
+For examples of column-level settings modifying, see [Column-level Settings](/docs/en/engines/table-engines/mergetree-family/mergetree.md/#column-level-settings).
 
 If the `IF EXISTS` clause is specified, the query won’t return an error if the column does not exist.
 

--- a/src/Parsers/ASTAlterQuery.cpp
+++ b/src/Parsers/ASTAlterQuery.cpp
@@ -104,12 +104,14 @@ void ASTAlterCommand::formatImpl(const FormatSettings & settings, FormatState & 
         {
             settings.ostr << (settings.hilite ? hilite_keyword : "") << " REMOVE " << remove_property;
         }
-        else if (settings_changes) {
-            settings.ostr << (settings.hilite ? hilite_keyword : "") << "MODIFY SETTING " << (settings.hilite ? hilite_none : "");
+        else if (settings_changes)
+        {
+            settings.ostr << (settings.hilite ? hilite_keyword : "") << " MODIFY SETTING " << (settings.hilite ? hilite_none : "");
             settings_changes->formatImpl(settings, state, frame);
         }
-        else if (settings_resets) {
-            settings.ostr << (settings.hilite ? hilite_keyword : "") << "RESET SETTING " << (settings.hilite ? hilite_none : "");
+        else if (settings_resets)
+        {
+            settings.ostr << (settings.hilite ? hilite_keyword : "") << " RESET SETTING " << (settings.hilite ? hilite_none : "");
             settings_resets->formatImpl(settings, state, frame);
         }
         else

--- a/src/Parsers/ASTAlterQuery.cpp
+++ b/src/Parsers/ASTAlterQuery.cpp
@@ -104,6 +104,14 @@ void ASTAlterCommand::formatImpl(const FormatSettings & settings, FormatState & 
         {
             settings.ostr << (settings.hilite ? hilite_keyword : "") << " REMOVE " << remove_property;
         }
+        else if (settings_changes) {
+            settings.ostr << (settings.hilite ? hilite_keyword : "") << "MODIFY SETTING " << (settings.hilite ? hilite_none : "");
+            settings_changes->formatImpl(settings, state, frame);
+        }
+        else if (settings_resets) {
+            settings.ostr << (settings.hilite ? hilite_keyword : "") << "RESET SETTING " << (settings.hilite ? hilite_none : "");
+            settings_resets->formatImpl(settings, state, frame);
+        }
         else
         {
             if (first)

--- a/tests/queries/0_stateless/02870_per_column_settings.reference
+++ b/tests/queries/0_stateless/02870_per_column_settings.reference
@@ -1,8 +1,8 @@
 CREATE TABLE default.tab\n(\n    `id` UInt64,\n    `long_string` String SETTINGS (min_compress_block_size = 163840, max_compress_block_size = 163840),\n    `v1` String,\n    `v2` UInt64,\n    `v3` Float32,\n    `v4` Float64\n)\nENGINE = ReplicatedMergeTree(\'/clickhouse/tables/default/tab/2870\', \'r1\')\nORDER BY id\nSETTINGS min_bytes_for_wide_part = 1, index_granularity = 8192
 1000
-ALTER TABLE tab\n    MODIFY COLUMN `long_string`MODIFY SETTING min_compress_block_size = 8192
+ALTER TABLE tab\n    MODIFY COLUMN `long_string` MODIFY SETTING min_compress_block_size = 8192
 CREATE TABLE default.tab\n(\n    `id` UInt64,\n    `long_string` String SETTINGS (min_compress_block_size = 8192, max_compress_block_size = 163840),\n    `v1` String,\n    `v2` UInt64,\n    `v3` Float32,\n    `v4` Float64\n)\nENGINE = ReplicatedMergeTree(\'/clickhouse/tables/default/tab/2870\', \'r1\')\nORDER BY id\nSETTINGS min_bytes_for_wide_part = 1, index_granularity = 8192
-ALTER TABLE tab\n    MODIFY COLUMN `long_string`RESET SETTING min_compress_block_size
+ALTER TABLE tab\n    MODIFY COLUMN `long_string` RESET SETTING min_compress_block_size
 CREATE TABLE default.tab\n(\n    `id` UInt64,\n    `long_string` String SETTINGS (max_compress_block_size = 163840),\n    `v1` String,\n    `v2` UInt64,\n    `v3` Float32,\n    `v4` Float64\n)\nENGINE = ReplicatedMergeTree(\'/clickhouse/tables/default/tab/2870\', \'r1\')\nORDER BY id\nSETTINGS min_bytes_for_wide_part = 1, index_granularity = 8192
 ALTER TABLE tab\n    MODIFY COLUMN `long_string` REMOVE SETTINGS
 CREATE TABLE default.tab\n(\n    `id` UInt64,\n    `long_string` String,\n    `v1` String,\n    `v2` UInt64,\n    `v3` Float32,\n    `v4` Float64\n)\nENGINE = ReplicatedMergeTree(\'/clickhouse/tables/default/tab/2870\', \'r1\')\nORDER BY id\nSETTINGS min_bytes_for_wide_part = 1, index_granularity = 8192

--- a/tests/queries/0_stateless/02870_per_column_settings.reference
+++ b/tests/queries/0_stateless/02870_per_column_settings.reference
@@ -1,10 +1,14 @@
 CREATE TABLE default.tab\n(\n    `id` UInt64,\n    `long_string` String SETTINGS (min_compress_block_size = 163840, max_compress_block_size = 163840),\n    `v1` String,\n    `v2` UInt64,\n    `v3` Float32,\n    `v4` Float64\n)\nENGINE = ReplicatedMergeTree(\'/clickhouse/tables/default/tab/2870\', \'r1\')\nORDER BY id\nSETTINGS min_bytes_for_wide_part = 1, index_granularity = 8192
 1000
+ALTER TABLE tab\n    MODIFY COLUMN `long_string`MODIFY SETTING min_compress_block_size = 8192
 CREATE TABLE default.tab\n(\n    `id` UInt64,\n    `long_string` String SETTINGS (min_compress_block_size = 8192, max_compress_block_size = 163840),\n    `v1` String,\n    `v2` UInt64,\n    `v3` Float32,\n    `v4` Float64\n)\nENGINE = ReplicatedMergeTree(\'/clickhouse/tables/default/tab/2870\', \'r1\')\nORDER BY id\nSETTINGS min_bytes_for_wide_part = 1, index_granularity = 8192
+ALTER TABLE tab\n    MODIFY COLUMN `long_string`RESET SETTING min_compress_block_size
 CREATE TABLE default.tab\n(\n    `id` UInt64,\n    `long_string` String SETTINGS (max_compress_block_size = 163840),\n    `v1` String,\n    `v2` UInt64,\n    `v3` Float32,\n    `v4` Float64\n)\nENGINE = ReplicatedMergeTree(\'/clickhouse/tables/default/tab/2870\', \'r1\')\nORDER BY id\nSETTINGS min_bytes_for_wide_part = 1, index_granularity = 8192
+ALTER TABLE tab\n    MODIFY COLUMN `long_string` REMOVE SETTINGS
 CREATE TABLE default.tab\n(\n    `id` UInt64,\n    `long_string` String,\n    `v1` String,\n    `v2` UInt64,\n    `v3` Float32,\n    `v4` Float64\n)\nENGINE = ReplicatedMergeTree(\'/clickhouse/tables/default/tab/2870\', \'r1\')\nORDER BY id\nSETTINGS min_bytes_for_wide_part = 1, index_granularity = 8192
+ALTER TABLE tab\n    MODIFY COLUMN `long_string` String SETTINGS (min_compress_block_size = 163840, max_compress_block_size = 163840)
 CREATE TABLE default.tab\n(\n    `id` UInt64,\n    `long_string` String SETTINGS (min_compress_block_size = 163840, max_compress_block_size = 163840),\n    `v1` String,\n    `v2` UInt64,\n    `v3` Float32,\n    `v4` Float64\n)\nENGINE = ReplicatedMergeTree(\'/clickhouse/tables/default/tab/2870\', \'r1\')\nORDER BY id\nSETTINGS min_bytes_for_wide_part = 1, index_granularity = 8192
---- 
+---
 (0,0)	0
 (1,1)	1
 (2,2)	2
@@ -15,4 +19,4 @@ CREATE TABLE default.tab\n(\n    `id` UInt64,\n    `long_string` String SETTINGS
 (7,7)	7
 (8,8)	8
 (9,9)	9
---- 
+---

--- a/tests/queries/0_stateless/02870_per_column_settings.sql
+++ b/tests/queries/0_stateless/02870_per_column_settings.sql
@@ -23,21 +23,25 @@ SHOW CREATE tab;
 INSERT INTO TABLE tab SELECT number, randomPrintableASCII(1000), randomPrintableASCII(10), rand(number), rand(number+1), rand(number+2) FROM numbers(1000);
 SELECT count() FROM tab;
 
+SELECT formatQuery('ALTER TABLE tab MODIFY COLUMN long_string MODIFY SETTING min_compress_block_size = 8192;');
 ALTER TABLE tab MODIFY COLUMN long_string MODIFY SETTING min_compress_block_size = 8192;
 SHOW CREATE tab;
 
+SELECT formatQuery('ALTER TABLE tab MODIFY COLUMN long_string RESET SETTING min_compress_block_size;');
 ALTER TABLE tab MODIFY COLUMN long_string RESET SETTING min_compress_block_size;
 SHOW CREATE tab;
 
+SELECT formatQuery('ALTER TABLE tab MODIFY COLUMN long_string REMOVE SETTINGS;');
 ALTER TABLE tab MODIFY COLUMN long_string REMOVE SETTINGS;
 SHOW CREATE tab;
 
+SELECT formatQuery('ALTER TABLE tab MODIFY COLUMN long_string String SETTINGS (min_compress_block_size = 163840, max_compress_block_size = 163840);');
 ALTER TABLE tab MODIFY COLUMN long_string String SETTINGS (min_compress_block_size = 163840, max_compress_block_size = 163840);
 SHOW CREATE tab;
 
 DROP TABLE tab;
 
-SELECT '--- ';
+SELECT '---';
 
 SET allow_experimental_object_type = 1;
 
@@ -56,7 +60,7 @@ SELECT tup, json.key AS key FROM tab ORDER BY key LIMIT 10;
 
 DROP TABLE tab;
 
-SELECT '--- ';
+SELECT '---';
 
 -- Unsupported column-level settings are rejected
 CREATE TABLE tab


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Fix formatting of alter commands in case of column specific settings 

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)
