### PR TITLE
Safer Rust (catch panic with catch_unwind())

### DIFF
--- a/rust/skim/src/lib.rs
+++ b/rust/skim/src/lib.rs
@@ -1,6 +1,7 @@
 use skim::prelude::*;
 use term::terminfo::TermInfo;
 use cxx::{CxxString, CxxVector};
+use std::panic;
 
 #[cxx::bridge]
 mod ffi {
@@ -36,7 +37,7 @@ impl SkimItem for Item {
     }
 }
 
-fn skim(prefix: &CxxString, words: &CxxVector<CxxString>) -> Result<String, String> {
+fn skim_impl(prefix: &CxxString, words: &CxxVector<CxxString>) -> Result<String, String> {
     // Let's check is terminal available. To avoid panic.
     if let Err(err) = TermInfo::from_env() {
         return Err(format!("{}", err));
@@ -88,4 +89,23 @@ fn skim(prefix: &CxxString, words: &CxxVector<CxxString>) -> Result<String, Stri
         return Err("No items had been selected".to_string());
     }
     return Ok(output.selected_items[0].output().to_string());
+}
+
+fn skim(prefix: &CxxString, words: &CxxVector<CxxString>) -> Result<String, String> {
+    let ret = panic::catch_unwind(|| {
+        return skim_impl(prefix, words);
+    });
+    return match ret {
+        Err(err) => {
+            let e = if let Some(s) = err.downcast_ref::<String>() {
+                format!("{}", s)
+            } else if let Some(s) = err.downcast_ref::<&str>() {
+                format!("{}", s)
+            } else {
+                format!("Unknown panic type: {:?}", err.type_id())
+            };
+            Err(format!("Rust panic: {:?}", e))
+        },
+        Ok(res) => res,
+    }
 }


### PR DESCRIPTION
Crossing boundaries of multiple languages is tricky, but we can do at least something about this, in particular, use catch_unwind() [1] to catch possible panic!()s.

  [1]: https://doc.rust-lang.org/std/panic/fn.catch_unwind.html

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Safer Rust (catch panic with catch_unwind())

Refs: https://github.com/ClickHouse/ClickHouse/issues/52053
Refs: https://github.com/ClickHouse/ClickHouse/issues/59374