### PR TITLE
Significantly improves reading row-based formats with streaming (Kafka, Nuts, RabbitMQ, FileLog)

### DIFF
--- a/src/Columns/ColumnTuple.cpp
+++ b/src/Columns/ColumnTuple.cpp
@@ -169,7 +169,10 @@ void ColumnTuple::insertDefault()
 void ColumnTuple::popBack(size_t n)
 {
     for (auto & column : columns)
-        column->popBack(n);
+    {
+        if (column->size() >= n)
+            column->popBack(n);
+    }
 }
 
 StringRef ColumnTuple::serializeValueIntoArena(size_t n, Arena & arena, char const *& begin, const UInt8 *) const

--- a/src/Formats/FormatFactory.cpp
+++ b/src/Formats/FormatFactory.cpp
@@ -8,6 +8,7 @@
 #include <IO/WriteHelpers.h>
 #include <Processors/Formats/IRowInputFormat.h>
 #include <Processors/Formats/IRowOutputFormat.h>
+#include <Processors/Formats/InputFormatErrorsLogger.h>
 #include <Processors/Formats/Impl/MySQLOutputFormat.h>
 #include <Processors/Formats/Impl/ParallelFormattingOutputFormat.h>
 #include <Processors/Formats/Impl/ParallelParsingInputFormat.h>
@@ -356,9 +357,9 @@ InputFormatPtr FormatFactory::getInput(
     if (!settings.input_format_record_errors_file_path.toString().empty())
     {
         if (parallel_parsing)
-            format->setErrorsLogger(std::make_shared<ParallelInputFormatErrorsLogger>(context));
+            format->setErrorsHandler(std::make_shared<ParallelInputFormatErrorsLogger>(context));
         else
-            format->setErrorsLogger(std::make_shared<InputFormatErrorsLogger>(context));
+            format->setErrorsHandler(std::make_shared<InputFormatErrorsLogger>(context));
     }
 
 

--- a/src/IO/PeekableReadBuffer.h
+++ b/src/IO/PeekableReadBuffer.h
@@ -76,6 +76,8 @@ public:
 
     const ReadBuffer & getSubBuffer() const { return *sub_buf; }
 
+    bool nextRow() override { return sub_buf->nextRow(); }
+
 private:
     bool nextImpl() override;
 

--- a/src/IO/ReadBuffer.h
+++ b/src/IO/ReadBuffer.h
@@ -82,6 +82,14 @@ public:
         return res;
     }
 
+    /// Faster streaming rows one-by-one using ReadBufferFromMemoryIterable,
+    /// that can incapsulate multiple rows, so that you don't need to do all
+    /// the preparation for each row.
+    ///
+    /// See:
+    /// - ReadBufferFromMemoryIterable
+    /// - IRowInputFormat
+    virtual bool nextRow() { return false; }
 
     inline void nextIfAtEnd()
     {

--- a/src/IO/ReadBufferFromMemoryIterable.cpp
+++ b/src/IO/ReadBufferFromMemoryIterable.cpp
@@ -1,0 +1,20 @@
+#include <string>
+#include <string_view>
+
+#include <IO/ReadBufferFromMemoryIterable.h>
+
+namespace DB
+{
+
+namespace ReadBufferFromMemoryIterableDetails
+{
+
+template <> const char * get_element_data(const std::string & element) { return element.data(); }
+template <> size_t get_element_size(const std::string & element) { return element.size(); }
+
+template <> const char * get_element_data(const std::string_view & element) { return element.data(); }
+template <> size_t get_element_size(const std::string_view & element) { return element.size(); }
+
+}
+
+}

--- a/src/IO/ReadBufferFromMemoryIterable.h
+++ b/src/IO/ReadBufferFromMemoryIterable.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <IO/ReadBuffer.h>
+#include <base/defines.h>
+
+
+namespace DB
+{
+
+namespace ReadBufferFromMemoryIterableDetails
+{
+
+template <class E> const char * get_element_data(const E & element);
+template <class E> size_t get_element_size(const E & element);
+
+}
+
+/** Same as ReadBufferFromMemory, but accept multiple buffers that will be fed one after another.
+ *  Used where you feed line by line for faster processing.
+ */
+template <class It>
+class ReadBufferFromMemoryIterable : public ReadBuffer
+{
+public:
+    ReadBufferFromMemoryIterable(It & begin_, It end_)
+        : ReadBuffer(nullptr, 0)
+        , it(begin_)
+        , end(end_)
+    {
+        chassert(it != end);
+    }
+
+    bool nextRow() override
+    {
+        is_eof = it == end;
+        return !is_eof;
+    }
+
+    bool nextImpl() override
+    {
+        if (it == end)
+            return false;
+        if (is_eof)
+            return false;
+
+        BufferBase::set(
+            const_cast<char *>(ReadBufferFromMemoryIterableDetails::get_element_data(*it)),
+            ReadBufferFromMemoryIterableDetails::get_element_size(*it),
+            0);
+        /// NOTE: it is important to seek the buffer in nextImpl() to make some progress
+        ++it;
+        is_eof = true;
+
+        return true;
+    }
+
+private:
+    It & it;
+    It end;
+    bool is_eof = false;
+};
+
+}

--- a/src/IO/tests/gtest_ReadBufferFromMemoryIterable.cpp
+++ b/src/IO/tests/gtest_ReadBufferFromMemoryIterable.cpp
@@ -1,0 +1,32 @@
+#include <gtest/gtest.h>
+#include <IO/ReadBufferFromMemoryIterable.h>
+#include <IO/ReadHelpers.h>
+
+TEST(ReadBufferFromMemoryIterable, General)
+{
+    std::vector<std::string_view> rows = {
+        {"foo"},
+        {"bar"},
+    };
+
+    auto it = rows.cbegin();
+    DB::ReadBufferFromMemoryIterable buffer(it, rows.cend());
+
+    String data;
+
+    DB::readString(data, buffer);
+    ASSERT_EQ(it, rows.cbegin()+1);
+    ASSERT_EQ(data, "foo");
+    ASSERT_EQ(buffer.eof(), true);
+    ASSERT_EQ(buffer.nextRow(), true);
+    ASSERT_EQ(buffer.eof(), false);
+    DB::readString(data, buffer);
+    ASSERT_EQ(it, rows.cend());
+    ASSERT_EQ(data, "bar");
+    ASSERT_EQ(buffer.eof(), true);
+    ASSERT_EQ(buffer.nextRow(), false);
+
+    ASSERT_EQ(it, rows.cend()) << "Not all rows had been read";
+    ASSERT_EQ(*(it-1), "bar");
+    ASSERT_EQ(*(it-2), "foo");
+}

--- a/src/Processors/Executors/StreamingFormatExecutor.h
+++ b/src/Processors/Executors/StreamingFormatExecutor.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <exception>
 #include <Processors/Formats/IInputFormat.h>
 #include <Processors/ISimpleTransform.h>
 #include <IO/EmptyReadBuffer.h>
@@ -19,13 +20,14 @@ public:
     /// and exception to rethrow it or add context to it.
     /// Should return number of new rows, which are added in callback
     /// to result columns in comparison to previous call of `execute`.
-    using ErrorCallback = std::function<size_t(const MutableColumns &, Exception &)>;
+    using ErrorCallback = std::function<void(std::exception_ptr)>;
 
     StreamingFormatExecutor(
         const Block & header_,
         InputFormatPtr format_,
-        ErrorCallback on_error_ = [](const MutableColumns &, Exception & e) -> size_t { throw std::move(e); },
+        ErrorCallback on_error_ = [](std::exception_ptr e) { std::rethrow_exception(e); },
         SimpleTransformPtr adding_defaults_transform_ = nullptr);
+    ~StreamingFormatExecutor();
 
     /// Returns numbers of new read rows.
     size_t execute();

--- a/src/Processors/Formats/IInputFormat.h
+++ b/src/Processors/Formats/IInputFormat.h
@@ -3,7 +3,7 @@
 #include <Formats/ColumnMapping.h>
 #include <IO/ReadBuffer.h>
 #include <Interpreters/Context.h>
-#include <Processors/Formats/InputFormatErrorsLogger.h>
+#include <Processors/Formats/IInputFormatErrorsHandler.h>
 #include <Processors/SourceWithKeyCondition.h>
 #include <Storages/MergeTree/KeyCondition.h>
 
@@ -60,7 +60,7 @@ public:
 
     void addBuffer(std::unique_ptr<ReadBuffer> buffer) { owned_buffers.emplace_back(std::move(buffer)); }
 
-    void setErrorsLogger(const InputFormatErrorsLoggerPtr & errors_logger_) { errors_logger = errors_logger_; }
+    void setErrorsHandler(const IInputFormatErrorsHandlerPtr & errors_handler_) { errors_handler = errors_handler_; }
 
     virtual size_t getApproxBytesReadForChunk() const { return 0; }
 
@@ -73,7 +73,7 @@ protected:
 
     ColumnMappingPtr column_mapping{};
 
-    InputFormatErrorsLoggerPtr errors_logger;
+    IInputFormatErrorsHandlerPtr errors_handler;
 
     bool need_only_count = false;
 

--- a/src/Processors/Formats/IInputFormatErrorsHandler.h
+++ b/src/Processors/Formats/IInputFormatErrorsHandler.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <base/types.h>
+
+namespace DB
+{
+
+class IInputFormatErrorsHandler
+{
+public:
+    struct ErrorEntry
+    {
+        time_t time;
+        size_t offset;
+        String reason;
+        String raw_data;
+    };
+
+    virtual ~IInputFormatErrorsHandler() = default;
+    virtual void logError(ErrorEntry entry) = 0;
+};
+using IInputFormatErrorsHandlerPtr = std::shared_ptr<IInputFormatErrorsHandler>;
+
+}

--- a/src/Processors/Formats/IRowInputFormat.cpp
+++ b/src/Processors/Formats/IRowInputFormat.cpp
@@ -90,7 +90,7 @@ void IRowInputFormat::logError()
 
     auto now_time = time(nullptr);
 
-    errors_logger->logError(InputFormatErrorsLogger::ErrorEntry{now_time, total_rows, diagnostic, raw_data});
+    errors_handler->logError(IInputFormatErrorsHandler::ErrorEntry{now_time, total_rows, diagnostic, raw_data});
 }
 
 Chunk IRowInputFormat::read()
@@ -178,7 +178,7 @@ Chunk IRowInputFormat::read()
                 if (params.allow_errors_num == 0 && params.allow_errors_ratio == 0)
                     throw;
 
-                if (errors_logger)
+                if (errors_handler)
                     logError();
 
                 ++num_errors;

--- a/src/Processors/Formats/IRowInputFormat.cpp
+++ b/src/Processors/Formats/IRowInputFormat.cpp
@@ -25,6 +25,7 @@ namespace ErrorCodes
     extern const int INCORRECT_NUMBER_OF_COLUMNS;
     extern const int ARGUMENT_OUT_OF_BOUND;
     extern const int INCORRECT_DATA;
+    extern const int SYNTAX_ERROR;
     extern const int CANNOT_PARSE_DOMAIN_VALUE_FROM_STRING;
     extern const int CANNOT_PARSE_IPV4;
     extern const int CANNOT_PARSE_IPV6;
@@ -51,6 +52,7 @@ bool isParseError(int code)
         || code == ErrorCodes::TOO_LARGE_STRING_SIZE
         || code == ErrorCodes::ARGUMENT_OUT_OF_BOUND       /// For Decimals
         || code == ErrorCodes::INCORRECT_DATA              /// For some ReadHelpers
+        || code == ErrorCodes::SYNTAX_ERROR                /// For Values format
         || code == ErrorCodes::CANNOT_PARSE_DOMAIN_VALUE_FROM_STRING
         || code == ErrorCodes::CANNOT_PARSE_IPV4
         || code == ErrorCodes::CANNOT_PARSE_IPV6

--- a/src/Processors/Formats/IRowInputFormat.cpp
+++ b/src/Processors/Formats/IRowInputFormat.cpp
@@ -163,8 +163,7 @@ Chunk IRowInputFormat::read()
                     break;
 
                 /// Next time we will read new message
-                if (in->eof())
-                    in->nextRow();
+                in->nextRow();
 
                 /// The case when there is no columns. Just count rows.
                 if (columns.empty())

--- a/src/Processors/Formats/IRowInputFormat.cpp
+++ b/src/Processors/Formats/IRowInputFormat.cpp
@@ -28,6 +28,7 @@ namespace ErrorCodes
     extern const int CANNOT_PARSE_DOMAIN_VALUE_FROM_STRING;
     extern const int CANNOT_PARSE_IPV4;
     extern const int CANNOT_PARSE_IPV6;
+    extern const int UNKNOWN_TYPE;
     extern const int UNKNOWN_ELEMENT_OF_ENUM;
 }
 
@@ -50,6 +51,7 @@ bool isParseError(int code)
         || code == ErrorCodes::CANNOT_PARSE_DOMAIN_VALUE_FROM_STRING
         || code == ErrorCodes::CANNOT_PARSE_IPV4
         || code == ErrorCodes::CANNOT_PARSE_IPV6
+        || code == ErrorCodes::UNKNOWN_TYPE
         || code == ErrorCodes::UNKNOWN_ELEMENT_OF_ENUM;
 }
 

--- a/src/Processors/Formats/IRowInputFormat.cpp
+++ b/src/Processors/Formats/IRowInputFormat.cpp
@@ -29,6 +29,7 @@ namespace ErrorCodes
     extern const int CANNOT_PARSE_IPV4;
     extern const int CANNOT_PARSE_IPV6;
     extern const int UNKNOWN_TYPE;
+    extern const int UNKNOWN_PROTOBUF_FORMAT;
     extern const int EMPTY_DATA_PASSED;
     extern const int UNKNOWN_ELEMENT_OF_ENUM;
 }
@@ -53,6 +54,7 @@ bool isParseError(int code)
         || code == ErrorCodes::CANNOT_PARSE_IPV4
         || code == ErrorCodes::CANNOT_PARSE_IPV6
         || code == ErrorCodes::UNKNOWN_TYPE
+        || code == ErrorCodes::UNKNOWN_PROTOBUF_FORMAT
         || code == ErrorCodes::EMPTY_DATA_PASSED
         || code == ErrorCodes::UNKNOWN_ELEMENT_OF_ENUM;
 }

--- a/src/Processors/Formats/IRowInputFormat.cpp
+++ b/src/Processors/Formats/IRowInputFormat.cpp
@@ -28,6 +28,7 @@ namespace ErrorCodes
     extern const int CANNOT_PARSE_DOMAIN_VALUE_FROM_STRING;
     extern const int CANNOT_PARSE_IPV4;
     extern const int CANNOT_PARSE_IPV6;
+    extern const int ATTEMPT_TO_READ_AFTER_EOF;
     extern const int UNKNOWN_TYPE;
     extern const int UNKNOWN_PROTOBUF_FORMAT;
     extern const int EMPTY_DATA_PASSED;
@@ -53,6 +54,7 @@ bool isParseError(int code)
         || code == ErrorCodes::CANNOT_PARSE_DOMAIN_VALUE_FROM_STRING
         || code == ErrorCodes::CANNOT_PARSE_IPV4
         || code == ErrorCodes::CANNOT_PARSE_IPV6
+        || code == ErrorCodes::ATTEMPT_TO_READ_AFTER_EOF
         || code == ErrorCodes::UNKNOWN_TYPE
         || code == ErrorCodes::UNKNOWN_PROTOBUF_FORMAT
         || code == ErrorCodes::EMPTY_DATA_PASSED

--- a/src/Processors/Formats/IRowInputFormat.cpp
+++ b/src/Processors/Formats/IRowInputFormat.cpp
@@ -29,6 +29,7 @@ namespace ErrorCodes
     extern const int CANNOT_PARSE_IPV4;
     extern const int CANNOT_PARSE_IPV6;
     extern const int UNKNOWN_TYPE;
+    extern const int EMPTY_DATA_PASSED;
     extern const int UNKNOWN_ELEMENT_OF_ENUM;
 }
 
@@ -52,6 +53,7 @@ bool isParseError(int code)
         || code == ErrorCodes::CANNOT_PARSE_IPV4
         || code == ErrorCodes::CANNOT_PARSE_IPV6
         || code == ErrorCodes::UNKNOWN_TYPE
+        || code == ErrorCodes::EMPTY_DATA_PASSED
         || code == ErrorCodes::UNKNOWN_ELEMENT_OF_ENUM;
 }
 

--- a/src/Processors/Formats/IRowInputFormat.h
+++ b/src/Processors/Formats/IRowInputFormat.h
@@ -42,7 +42,7 @@ public:
 
     IRowInputFormat(Block header, ReadBuffer & in_, Params params_);
 
-    Chunk read() override;
+    Chunk read() final;
 
     void resetParser() override;
 

--- a/src/Processors/Formats/Impl/ArrowBlockInputFormat.cpp
+++ b/src/Processors/Formats/Impl/ArrowBlockInputFormat.cpp
@@ -19,7 +19,7 @@ namespace DB
 
 namespace ErrorCodes
 {
-    extern const int UNKNOWN_EXCEPTION;
+    extern const int INCORRECT_DATA;
     extern const int CANNOT_READ_ALL_DATA;
 }
 
@@ -117,7 +117,7 @@ static std::shared_ptr<arrow::RecordBatchReader> createStreamReader(ReadBuffer &
 {
     auto stream_reader_status = arrow::ipc::RecordBatchStreamReader::Open(std::make_unique<ArrowInputStreamFromReadBuffer>(in));
     if (!stream_reader_status.ok())
-        throw Exception(ErrorCodes::UNKNOWN_EXCEPTION,
+        throw Exception(ErrorCodes::INCORRECT_DATA,
                         "Error while opening a table: {}", stream_reader_status.status().ToString());
     return *stream_reader_status;
 }
@@ -130,7 +130,7 @@ static std::shared_ptr<arrow::ipc::RecordBatchFileReader> createFileReader(ReadB
 
     auto file_reader_status = arrow::ipc::RecordBatchFileReader::Open(arrow_file);
     if (!file_reader_status.ok())
-        throw Exception(ErrorCodes::UNKNOWN_EXCEPTION,
+        throw Exception(ErrorCodes::INCORRECT_DATA,
             "Error while opening a table: {}", file_reader_status.status().ToString());
     return *file_reader_status;
 }

--- a/src/Processors/Formats/Impl/ParallelParsingInputFormat.cpp
+++ b/src/Processors/Formats/Impl/ParallelParsingInputFormat.cpp
@@ -91,7 +91,7 @@ void ParallelParsingInputFormat::parserThreadFunction(ThreadGroupPtr thread_grou
 
         InputFormatPtr input_format = internal_parser_creator(read_buffer);
         input_format->setRowsReadBefore(unit.offset);
-        input_format->setErrorsLogger(errors_logger);
+        input_format->setErrorsHandler(errors_handler);
         InternalParser parser(input_format);
 
         unit.chunk_ext.chunk.clear();

--- a/src/Processors/Formats/Impl/ProtobufRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/ProtobufRowInputFormat.cpp
@@ -41,6 +41,7 @@ void ProtobufRowInputFormat::createReaderAndSerializer()
 }
 
 bool ProtobufRowInputFormat::readRow(MutableColumns & columns, RowReadExtension & row_read_extension)
+try
 {
     if (!reader)
         createReaderAndSerializer();
@@ -60,6 +61,11 @@ bool ProtobufRowInputFormat::readRow(MutableColumns & columns, RowReadExtension 
         row_read_extension.read_columns[column_idx] = false;
     return true;
 }
+catch (...)
+{
+    resetParserOnError();
+    throw;
+}
 
 void ProtobufRowInputFormat::setReadBuffer(ReadBuffer & in_)
 {
@@ -78,14 +84,14 @@ void ProtobufRowInputFormat::syncAfterError()
     reader->endMessage(true);
 }
 
-void ProtobufRowInputFormat::resetParser()
+void ProtobufRowInputFormat::resetParserOnError()
 {
-    IRowInputFormat::resetParser();
     serializer.reset();
     reader.reset();
 }
 
 size_t ProtobufRowInputFormat::countRows(size_t max_block_size)
+try
 {
     if (!reader)
         createReaderAndSerializer();
@@ -99,6 +105,11 @@ size_t ProtobufRowInputFormat::countRows(size_t max_block_size)
     }
 
     return num_rows;
+}
+catch (...)
+{
+    resetParserOnError();
+    throw;
 }
 
 void registerInputFormatProtobuf(FormatFactory & factory)

--- a/src/Processors/Formats/Impl/ProtobufRowInputFormat.h
+++ b/src/Processors/Formats/Impl/ProtobufRowInputFormat.h
@@ -41,12 +41,12 @@ public:
     String getName() const override { return "ProtobufRowInputFormat"; }
 
     void setReadBuffer(ReadBuffer & in_) override;
-    void resetParser() override;
 
 private:
     bool readRow(MutableColumns & columns, RowReadExtension & row_read_extension) override;
     bool allowSyncAfterError() const override;
     void syncAfterError() override;
+    void resetParserOnError();
 
     bool supportsCountRows() const override { return true; }
     size_t countRows(size_t max_block_size) override;

--- a/src/Processors/tests/gtest_StreamingFormatExecutor.cpp
+++ b/src/Processors/tests/gtest_StreamingFormatExecutor.cpp
@@ -1,0 +1,98 @@
+#include <exception>
+#include <memory>
+#include <gtest/gtest.h>
+#include <Processors/Executors/StreamingFormatExecutor.h>
+#include <Formats/FormatSettings.h>
+#include <Processors/Formats/IRowInputFormat.h>
+#include <Processors/Formats/Impl/TabSeparatedRowInputFormat.h>
+#include <IO/ReadBufferFromMemoryIterable.h>
+#include <Columns/ColumnsNumber.h>
+#include <DataTypes/DataTypesNumber.h>
+#include <Common/Exception.h>
+
+using namespace DB;
+
+class StreamingFormatExecutorTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        input_params.max_block_size = 100;
+        format_settings.tsv.try_detect_header = true;
+
+        on_error = [&](std::exception_ptr e)
+        {
+            errors.push_back(getExceptionMessage(e, false));
+        };
+    }
+
+    Block header = {ColumnWithTypeAndName(ColumnUInt8::create(), std::make_shared<DataTypeUInt8>(), "x")};
+    FormatSettings format_settings;
+    RowInputFormatParams input_params;
+
+    std::vector<std::string> errors;
+    StreamingFormatExecutor::ErrorCallback on_error;
+
+    EmptyReadBuffer empty_buf;
+};
+
+
+TEST_F(StreamingFormatExecutorTest, ReadBufferFromMemoryIterableNoErrors)
+{
+    auto format = std::make_shared<TabSeparatedRowInputFormat>(
+            header, empty_buf, input_params, false, false, false, format_settings);
+    StreamingFormatExecutor executor(header, format, on_error);
+
+    std::vector<std::string_view> rows = {
+        {"0"},
+        {"1"},
+    };
+    auto it = rows.cbegin();
+    DB::ReadBufferFromMemoryIterable buffer(it, rows.cend());
+
+    size_t num_rows = executor.execute(buffer);
+    ASSERT_EQ(it, rows.cend()) << fmt::format("Not all rows had been read, left: {}", rows.cend() - it);
+    ASSERT_EQ(num_rows, rows.size());
+    ASSERT_EQ(errors.size(), 0);
+
+    auto block = executor.getResultColumns();
+    ASSERT_EQ(block.size(), header.columns());
+    auto & column = block[0];
+    ASSERT_EQ(column->size(), rows.size());
+    const auto & column_data = assert_cast<const ColumnUInt8 *>(column.get())->getData();
+    ASSERT_EQ(column_data[0], 0);
+    ASSERT_EQ(column_data[1], 1);
+
+    ASSERT_EQ(errors.size(), 0);
+}
+
+TEST_F(StreamingFormatExecutorTest, ReadBufferFromMemoryIterableWithErrors)
+{
+    input_params.allow_errors_num = 1;
+    auto format = std::make_shared<TabSeparatedRowInputFormat>(
+            header, empty_buf, input_params, false, false, false, format_settings);
+    StreamingFormatExecutor executor(header, format, on_error);
+
+    std::vector<std::string_view> rows = {
+        {"0"},
+        {"foo"},
+        {"1"},
+    };
+    auto it = rows.cbegin();
+    DB::ReadBufferFromMemoryIterable buffer(it, rows.cend());
+
+    size_t num_rows = executor.execute(buffer);
+    ASSERT_EQ(it, rows.cend()) << fmt::format("Not all rows had been read, left: {}", rows.cend() - it);
+    ASSERT_EQ(num_rows, rows.size() - errors.size());
+
+    auto block = executor.getResultColumns();
+    ASSERT_EQ(block.size(), header.columns());
+    auto & column = block[0];
+    ASSERT_EQ(column->size(), rows.size() - errors.size());
+    const auto & column_data = assert_cast<const ColumnUInt8 *>(column.get())->getData();
+    ASSERT_EQ(column_data[0], 0);
+    ASSERT_EQ(column_data[1], 1);
+
+    ASSERT_EQ(errors.size(), 1);
+    ASSERT_TRUE(errors.front().contains("Cannot parse input: expected '\\n' before: 'foo'. (CANNOT_PARSE_INPUT_ASSERTION_FAILED)")) << errors.front();
+}

--- a/src/Storages/FileLog/FileLogSource.cpp
+++ b/src/Storages/FileLog/FileLogSource.cpp
@@ -83,32 +83,21 @@ Chunk FileLogSource::generate()
     auto input_format = FormatFactory::instance().getInput(
         storage.getFormatName(), empty_buf, non_virtual_header, context, max_block_size, std::nullopt, 1);
 
-    std::optional<String> exception_message;
+    std::vector<String> exception_messages;
     size_t total_rows = 0;
 
-    auto on_error = [&](const MutableColumns & result_columns, Exception & e)
+    size_t input_format_allow_errors_num = context->getSettingsRef().input_format_allow_errors_num;
+    size_t num_rows_with_errors = 0;
+    auto on_error = [&](std::exception_ptr e)
     {
-        if (handle_error_mode == StreamingHandleErrorMode::STREAM)
+        if (handle_error_mode != StreamingHandleErrorMode::STREAM)
         {
-            exception_message = e.message();
-            for (const auto & column : result_columns)
-            {
-                // We could already push some rows to result_columns
-                // before exception, we need to fix it.
-                auto cur_rows = column->size();
-                if (cur_rows > total_rows)
-                    column->popBack(cur_rows - total_rows);
+            if (input_format_allow_errors_num >= ++num_rows_with_errors)
+                return;
 
-                // All data columns will get default value in case of error.
-                column->insertDefault();
-            }
-
-            return 1;
+            std::rethrow_exception(e);
         }
-        else
-        {
-            throw std::move(e);
-        }
+        exception_messages.emplace_back(getExceptionMessage(e, false));
     };
 
     StreamingFormatExecutor executor(non_virtual_header, input_format, on_error);
@@ -118,34 +107,32 @@ Chunk FileLogSource::generate()
     Stopwatch watch;
     while (true)
     {
-        exception_message.reset();
+        exception_messages.clear();
         size_t new_rows = 0;
         if (auto buf = consumer->consume())
             new_rows = executor.execute(*buf);
 
-        if (new_rows)
+        if (new_rows || !exception_messages.empty())
         {
             auto file_name = consumer->getFileName();
             auto offset = consumer->getOffset();
-            for (size_t i = 0; i < new_rows; ++i)
+
+            size_t new_rows_with_errors = new_rows + exception_messages.size();
+            virtual_columns[0]->insertMany(file_name, new_rows_with_errors);
+            virtual_columns[1]->insertMany(offset, new_rows_with_errors);
+
+            if (handle_error_mode == StreamingHandleErrorMode::STREAM)
             {
-                virtual_columns[0]->insert(file_name);
-                virtual_columns[1]->insert(offset);
-                if (handle_error_mode == StreamingHandleErrorMode::STREAM)
-                {
-                    if (exception_message)
-                    {
-                        const auto & current_record = consumer->getCurrentRecord();
-                        virtual_columns[2]->insertData(current_record.data(), current_record.size());
-                        virtual_columns[3]->insertData(exception_message->data(), exception_message->size());
-                    }
-                    else
-                    {
-                        virtual_columns[2]->insertDefault();
-                        virtual_columns[3]->insertDefault();
-                    }
-                }
+                virtual_columns[2]->insertManyDefaults(new_rows);
+                virtual_columns[3]->insertManyDefaults(new_rows);
+
+                const auto & current_record = consumer->getCurrentRecord();
+                virtual_columns[2]->insertMany(Field(current_record.data(), current_record.size()), exception_messages.size());
+
+                for (const auto & exception_message : exception_messages)
+                    virtual_columns[3]->insertData(exception_message.data(), exception_message.size());
             }
+
             total_rows = total_rows + new_rows;
         }
         else /// poll succeed, but parse failed
@@ -169,6 +156,17 @@ Chunk FileLogSource::generate()
 
     auto result_block = non_virtual_header.cloneWithColumns(executor.getResultColumns());
     auto virtual_block = virtual_header.cloneWithColumns(std::move(virtual_columns));
+
+    size_t result_block_rows = result_block.rows();
+    size_t virtual_block_rows = virtual_block.rows();
+    size_t errors = virtual_block_rows - result_block_rows;
+    if (errors)
+    {
+        auto result_columns = result_block.mutateColumns();
+        for (auto & column : result_columns)
+            column->insertManyDefaults(errors);
+        result_block.setColumns(std::move(result_columns));
+    }
 
     for (const auto & column : virtual_block.getColumnsWithTypeAndName())
         result_block.insert(column);

--- a/src/Storages/FileLog/StorageFileLog.cpp
+++ b/src/Storages/FileLog/StorageFileLog.cpp
@@ -1027,7 +1027,7 @@ NamesAndTypesList StorageFileLog::getVirtuals() const
 
 ContextMutablePtr StorageFileLog::addSettings(ContextPtr local_context) const
 {
-    auto modified_context = Context::createCopy(getContext());
+    auto modified_context = Context::createCopy(local_context);
     Settings settings = modified_context->getSettings();
     settings.input_format_skip_unknown_fields = true;
     settings.input_format_allow_errors_ratio = 0.;

--- a/src/Storages/FileLog/StorageFileLog.h
+++ b/src/Storages/FileLog/StorageFileLog.h
@@ -212,6 +212,8 @@ private:
         UInt64 inode = 0;
     };
     ReadMetadataResult readMetadata(const String & filename) const;
+
+    ContextMutablePtr addSettings(ContextPtr context) const;
 };
 
 }

--- a/src/Storages/Kafka/KafkaConsumer.h
+++ b/src/Storages/Kafka/KafkaConsumer.h
@@ -184,7 +184,7 @@ private:
     std::atomic<UInt64> last_rebalance_timestamp_usec = 0;
     std::atomic<UInt64> num_rebalance_assignments = 0;
     std::atomic<UInt64> num_rebalance_revocations = 0;
-    std::atomic<bool> in_use = 0;
+    std::atomic<bool> in_use = false;
     /// Last used time (for TTL)
     std::atomic<UInt64> last_used_usec = 0;
 

--- a/src/Storages/Kafka/KafkaConsumer.h
+++ b/src/Storages/Kafka/KafkaConsumer.h
@@ -109,6 +109,15 @@ public:
     auto currentTimestamp() const { return current[-1].get_timestamp(); }
     const auto & currentHeaderList() const { return current[-1].get_header_list(); }
     const cppkafka::Buffer & currentPayload() const { return current[-1].get_payload(); }
+
+    String topic(size_t i) const { return messages[i].get_topic(); }
+    String key(size_t i) const { return messages[i].get_key(); }
+    auto offset(size_t i) const { return messages[i].get_offset(); }
+    auto partition(size_t i) const { return messages[i].get_partition(); }
+    auto timestamp(size_t i) const { return messages[i].get_timestamp(); }
+    const auto & headerList(size_t i) const { return messages[i].get_header_list(); }
+    const cppkafka::Buffer & payload(size_t i) const { return messages[i].get_payload(); }
+
     void setExceptionInfo(const cppkafka::Error & err, bool with_stacktrace = true);
     void setExceptionInfo(const std::string & text, bool with_stacktrace = true);
     void setRDKafkaStat(const std::string & stat_json_string)

--- a/src/Storages/Kafka/KafkaConsumer.h
+++ b/src/Storages/Kafka/KafkaConsumer.h
@@ -193,7 +193,7 @@ private:
     void resetIfStopped();
     /// Return number of messages with an error.
     size_t filterMessageErrors();
-    ReadBufferPtr getNextMessage();
+    ReadBufferPtr getMessages();
 };
 
 }

--- a/src/Storages/Kafka/StorageKafka.cpp
+++ b/src/Storages/Kafka/StorageKafka.cpp
@@ -1,3 +1,4 @@
+#include <limits>
 #include <Storages/Kafka/StorageKafka.h>
 #include <Storages/Kafka/parseSyslogLevel.h>
 
@@ -337,7 +338,7 @@ StorageKafka::StorageKafka(
 
     if (kafka_settings->kafka_handle_error_mode == StreamingHandleErrorMode::STREAM)
     {
-        kafka_settings->input_format_allow_errors_num = 0;
+        kafka_settings->input_format_allow_errors_num = std::numeric_limits<UInt64>::max();
         kafka_settings->input_format_allow_errors_ratio = 0;
     }
 

--- a/src/Storages/NATS/StorageNATS.cpp
+++ b/src/Storages/NATS/StorageNATS.cpp
@@ -162,7 +162,7 @@ ContextMutablePtr StorageNATS::addSettings(ContextPtr local_context) const
     if (nats_settings->nats_handle_error_mode == StreamingHandleErrorMode::DEFAULT)
         modified_context->setSetting("input_format_allow_errors_num", nats_settings->nats_skip_broken_messages.value);
     else
-        modified_context->setSetting("input_format_allow_errors_num", Field{0});
+        modified_context->setSetting("input_format_allow_errors_num", Field{std::numeric_limits<UInt64>::max()});
 
     /// Since we are reusing the same context for all queries executed simultaneously, we don't want to used shared `analyze_count`
     modified_context->setSetting("max_analyze_depth", Field{0});

--- a/src/Storages/RabbitMQ/RabbitMQSource.cpp
+++ b/src/Storages/RabbitMQ/RabbitMQSource.cpp
@@ -1,3 +1,4 @@
+#include <exception>
 #include <Storages/RabbitMQ/RabbitMQSource.h>
 
 #include <Formats/FormatFactory.h>
@@ -134,32 +135,21 @@ Chunk RabbitMQSource::generateImpl()
     auto input_format = FormatFactory::instance().getInput(
         storage.getFormatName(), empty_buf, non_virtual_header, context, max_block_size, std::nullopt, 1);
 
-    std::optional<String> exception_message;
+    std::vector<String> exception_messages;
     size_t total_rows = 0;
 
-    auto on_error = [&](const MutableColumns & result_columns, Exception & e)
+    size_t input_format_allow_errors_num = context->getSettingsRef().input_format_allow_errors_num;
+    size_t num_rows_with_errors = 0;
+    auto on_error = [&](std::exception_ptr e)
     {
-        if (handle_error_mode == StreamingHandleErrorMode::STREAM)
+        if (handle_error_mode != StreamingHandleErrorMode::STREAM)
         {
-            exception_message = e.message();
-            for (const auto & column : result_columns)
-            {
-                // We could already push some rows to result_columns
-                // before exception, we need to fix it.
-                auto cur_rows = column->size();
-                if (cur_rows > total_rows)
-                    column->popBack(cur_rows - total_rows);
+            if (input_format_allow_errors_num >= ++num_rows_with_errors)
+                return;
 
-                // All data columns will get default value in case of error.
-                column->insertDefault();
-            }
-
-            return 1;
+            std::rethrow_exception(e);
         }
-        else
-        {
-            throw std::move(e);
-        }
+        exception_messages.emplace_back(getExceptionMessage(e, false));
     };
 
     StreamingFormatExecutor executor(non_virtual_header, input_format, on_error);
@@ -167,7 +157,7 @@ Chunk RabbitMQSource::generateImpl()
     RabbitMQConsumer::CommitInfo current_commit_info;
     while (true)
     {
-        exception_message.reset();
+        exception_messages.clear();
         size_t new_rows = 0;
 
         if (consumer->hasPendingMessages())
@@ -176,35 +166,34 @@ Chunk RabbitMQSource::generateImpl()
                 new_rows = executor.execute(*buf);
         }
 
-        if (new_rows)
+        if (new_rows || !exception_messages.empty())
         {
             const auto exchange_name = storage.getExchange();
             const auto & message = consumer->currentMessage();
 
-            for (size_t i = 0; i < new_rows; ++i)
+            size_t new_rows_with_errors = new_rows + exception_messages.size();
+            /// FIXME: we can do better, get information from particular message
+            virtual_columns[0]->insertMany(exchange_name, new_rows_with_errors);
+            virtual_columns[1]->insertMany(message.channel_id, new_rows_with_errors);
+            virtual_columns[2]->insertMany(message.delivery_tag, new_rows_with_errors);
+            virtual_columns[3]->insertMany(message.redelivered, new_rows_with_errors);
+            virtual_columns[4]->insertMany(message.message_id, new_rows_with_errors);
+            virtual_columns[5]->insertMany(message.timestamp, new_rows_with_errors);
+
+            if (handle_error_mode == StreamingHandleErrorMode::STREAM)
             {
-                virtual_columns[0]->insert(exchange_name);
-                virtual_columns[1]->insert(message.channel_id);
-                virtual_columns[2]->insert(message.delivery_tag);
-                virtual_columns[3]->insert(message.redelivered);
-                virtual_columns[4]->insert(message.message_id);
-                virtual_columns[5]->insert(message.timestamp);
-                if (handle_error_mode == StreamingHandleErrorMode::STREAM)
+                virtual_columns[6]->insertManyDefaults(new_rows);
+                virtual_columns[7]->insertManyDefaults(new_rows);
+
+                /// FIXME: we can do better, by reusing reason/row from ErrorEntry
+                virtual_columns[6]->insertMany(Field(message.message.data(), message.message.size()), exception_messages.size());
+                for (const auto & exception_message : exception_messages)
                 {
-                    if (exception_message)
-                    {
-                        virtual_columns[6]->insertData(message.message.data(), message.message.size());
-                        virtual_columns[7]->insertData(exception_message->data(), exception_message->size());
-                    }
-                    else
-                    {
-                        virtual_columns[6]->insertDefault();
-                        virtual_columns[7]->insertDefault();
-                    }
+                    virtual_columns[7]->insertData(exception_message.data(), exception_message.size());
                 }
             }
 
-            total_rows += new_rows;
+            total_rows += new_rows_with_errors;
             current_commit_info = {message.delivery_tag, message.channel_id};
         }
         else if (total_rows == 0)
@@ -243,7 +232,17 @@ Chunk RabbitMQSource::generateImpl()
     if (total_rows == 0)
         return {};
 
-    auto result_columns  = executor.getResultColumns();
+    auto result_columns = executor.getResultColumns();
+
+    size_t result_block_rows = result_columns.front()->size();
+    size_t virtual_block_rows = virtual_columns.front()->size();
+    size_t errors = virtual_block_rows - result_block_rows;
+    if (errors)
+    {
+        for (auto & column : result_columns)
+            column->insertManyDefaults(errors);
+    }
+
     for (auto & column : virtual_columns)
         result_columns.push_back(std::move(column));
 

--- a/src/Storages/RabbitMQ/StorageRabbitMQ.cpp
+++ b/src/Storages/RabbitMQ/StorageRabbitMQ.cpp
@@ -243,7 +243,7 @@ ContextMutablePtr StorageRabbitMQ::addSettings(ContextPtr local_context) const
     if (rabbitmq_settings->rabbitmq_handle_error_mode == StreamingHandleErrorMode::DEFAULT)
         modified_context->setSetting("input_format_allow_errors_num", rabbitmq_settings->rabbitmq_skip_broken_messages.value);
     else
-        modified_context->setSetting("input_format_allow_errors_num", Field(0));
+        modified_context->setSetting("input_format_allow_errors_num", Field(std::numeric_limits<UInt64>::max()));
 
     /// Since we are reusing the same context for all queries executed simultaneously, we don't want to used shared `analyze_count`
     modified_context->setSetting("max_analyze_depth", Field{0});

--- a/tests/integration/test_storage_kafka/test.py
+++ b/tests/integration/test_storage_kafka/test.py
@@ -414,7 +414,7 @@ def test_kafka_settings_new_syntax(kafka_cluster):
                      kafka_row_delimiter = '\\n',
                      kafka_commit_on_select = 1,
                      kafka_client_id = '{kafka_client_id} test 1234',
-                     kafka_skip_broken_messages = 1;
+                     kafka_skip_broken_messages = 2;
         """
     )
 
@@ -456,8 +456,7 @@ def test_kafka_settings_predefined_macros(kafka_cluster):
                      kafka_format = '{kafka_format_json_each_row}',
                      kafka_row_delimiter = '\\n',
                      kafka_commit_on_select = 1,
-                     kafka_client_id = '{database}_{table} test 1234',
-                     kafka_skip_broken_messages = 1;
+                     kafka_client_id = '{database}_{table} test 1234';
         """
     )
 

--- a/tests/integration/test_storage_kafka/test.py
+++ b/tests/integration/test_storage_kafka/test.py
@@ -433,10 +433,11 @@ def test_kafka_settings_new_syntax(kafka_cluster):
     kafka_produce(kafka_cluster, "new", messages)
 
     result = ""
-    while True:
+    for i in range(60):
         result += instance.query("SELECT * FROM test.kafka", ignore_error=True)
         if kafka_check_result(result):
             break
+        time.sleep(1)
 
     kafka_check_result(result, True)
 

--- a/tests/queries/0_stateless/02889_file_log_save_errors.reference
+++ b/tests/queries/0_stateless/02889_file_log_save_errors.reference
@@ -1,20 +1,20 @@
-Cannot parse input: expected \'{\' before: \'Error 0\': (at row 1)\n	Error 0	a.jsonl
-Cannot parse input: expected \'{\' before: \'Error 1\': (at row 1)\n	Error 1	a.jsonl
-Cannot parse input: expected \'{\' before: \'Error 2\': (at row 1)\n	Error 2	a.jsonl
-Cannot parse input: expected \'{\' before: \'Error 3\': (at row 1)\n	Error 3	a.jsonl
-Cannot parse input: expected \'{\' before: \'Error 4\': (at row 1)\n	Error 4	a.jsonl
-Cannot parse input: expected \'{\' before: \'Error 5\': (at row 1)\n	Error 5	a.jsonl
-Cannot parse input: expected \'{\' before: \'Error 6\': (at row 1)\n	Error 6	a.jsonl
-Cannot parse input: expected \'{\' before: \'Error 7\': (at row 1)\n	Error 7	a.jsonl
-Cannot parse input: expected \'{\' before: \'Error 8\': (at row 1)\n	Error 8	a.jsonl
-Cannot parse input: expected \'{\' before: \'Error 9\': (at row 1)\n	Error 9	a.jsonl
-Cannot parse input: expected \'{\' before: \'Error 10\': (at row 1)\n	Error 10	b.jsonl
-Cannot parse input: expected \'{\' before: \'Error 11\': (at row 1)\n	Error 11	b.jsonl
-Cannot parse input: expected \'{\' before: \'Error 12\': (at row 1)\n	Error 12	b.jsonl
-Cannot parse input: expected \'{\' before: \'Error 13\': (at row 1)\n	Error 13	b.jsonl
-Cannot parse input: expected \'{\' before: \'Error 14\': (at row 1)\n	Error 14	b.jsonl
-Cannot parse input: expected \'{\' before: \'Error 15\': (at row 1)\n	Error 15	b.jsonl
-Cannot parse input: expected \'{\' before: \'Error 16\': (at row 1)\n	Error 16	b.jsonl
-Cannot parse input: expected \'{\' before: \'Error 17\': (at row 1)\n	Error 17	b.jsonl
-Cannot parse input: expected \'{\' before: \'Error 18\': (at row 1)\n	Error 18	b.jsonl
-Cannot parse input: expected \'{\' before: \'Error 19\': (at row 1)\n	Error 19	b.jsonl
+Cannot parse input: expected \'{\' before: \'Error 0\'.	Error 0	a.jsonl
+Cannot parse input: expected \'{\' before: \'Error 1\'.	Error 1	a.jsonl
+Cannot parse input: expected \'{\' before: \'Error 2\'.	Error 2	a.jsonl
+Cannot parse input: expected \'{\' before: \'Error 3\'.	Error 3	a.jsonl
+Cannot parse input: expected \'{\' before: \'Error 4\'.	Error 4	a.jsonl
+Cannot parse input: expected \'{\' before: \'Error 5\'.	Error 5	a.jsonl
+Cannot parse input: expected \'{\' before: \'Error 6\'.	Error 6	a.jsonl
+Cannot parse input: expected \'{\' before: \'Error 7\'.	Error 7	a.jsonl
+Cannot parse input: expected \'{\' before: \'Error 8\'.	Error 8	a.jsonl
+Cannot parse input: expected \'{\' before: \'Error 9\'.	Error 9	a.jsonl
+Cannot parse input: expected \'{\' before: \'Error 10\'.	Error 10	b.jsonl
+Cannot parse input: expected \'{\' before: \'Error 11\'.	Error 11	b.jsonl
+Cannot parse input: expected \'{\' before: \'Error 12\'.	Error 12	b.jsonl
+Cannot parse input: expected \'{\' before: \'Error 13\'.	Error 13	b.jsonl
+Cannot parse input: expected \'{\' before: \'Error 14\'.	Error 14	b.jsonl
+Cannot parse input: expected \'{\' before: \'Error 15\'.	Error 15	b.jsonl
+Cannot parse input: expected \'{\' before: \'Error 16\'.	Error 16	b.jsonl
+Cannot parse input: expected \'{\' before: \'Error 17\'.	Error 17	b.jsonl
+Cannot parse input: expected \'{\' before: \'Error 18\'.	Error 18	b.jsonl
+Cannot parse input: expected \'{\' before: \'Error 19\'.	Error 19	b.jsonl

--- a/tests/queries/0_stateless/02889_file_log_save_errors.sh
+++ b/tests/queries/0_stateless/02889_file_log_save_errors.sh
@@ -38,7 +38,7 @@ while true; do
 	sleep 1
 done
 
-${CLICKHOUSE_CLIENT} --query "select * from log_errors order by file, record;"
+${CLICKHOUSE_CLIENT} --query "select * from log_errors order by file, record;" | sed -e 's/Code: 27. DB::Exception: //' -e 's/ (CANNOT_PARSE_INPUT_ASSERTION_FAILED) (version.*)//'
 ${CLICKHOUSE_CLIENT} --query "drop table file_log;"
 ${CLICKHOUSE_CLIENT} --query "drop table log_errors;"
 


### PR DESCRIPTION
### Checklist
- [ ] get info for virtual columns from proper message (right now it get this info from the last message, and tha's why some test fails)

**It will be great if someone will share other feedback, i.e. improvements for other formats (TSV, CSV, JSONEachRow, ...).**

### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Significantly improves reading row-based formats with streaming (Kafka, Nuts, RabbitMQ, FileLog)

Running format parser from scratch for each messages is too costly,
since formats implemented with batching in mind, and when you parse
single row the overhead is simply too high.

For example this patch **improves performance of ProtobufSingle 7-10x times**
for streaming with Kafka (**from 40K to 390K**).

This patch also changes how error handling works in
StreamingFormatExecutor, before it has separate callback, but now, since
we want to preserve parsing, it uses the same error handling that is
provided by IRowInputFormat, and adjusts
input_format_allow_errors_num=MAX, so that the parser will not stop.

Also now it uses isParseError() in StreamingFormatExecutor, since it
should ignore unknown errors.

Plus, now number of allowed errors is defined on a per-block basis, in
other words before, if you have row-based format, i.e. JSONEachRow, it
is enough to specify kafka_skip_broken_messages=1 to skip any errors,
while now this will not work, as it should (see changes in tests).

And also fix some magic consts in test_kafka_bad_messages test (some
substrings oddities).