### PR TITLE
Strict aliasing for Int8

### DIFF
--- a/base/base/CMakeLists.txt
+++ b/base/base/CMakeLists.txt
@@ -17,6 +17,7 @@ set (SRCS
     getMemoryAmount.cpp
     getPageSize.cpp
     getThreadId.cpp
+    int8_to_string.cpp
     JSON.cpp
     mremap.cpp
     phdr_cache.cpp

--- a/base/base/int8_to_string.cpp
+++ b/base/base/int8_to_string.cpp
@@ -1,0 +1,9 @@
+#include <base/int8_to_string.h>
+
+namespace std
+{
+std::string to_string(Int8 v)
+{
+    return to_string(int8_t{v});
+}
+}

--- a/base/base/int8_to_string.cpp
+++ b/base/base/int8_to_string.cpp
@@ -2,7 +2,7 @@
 
 namespace std
 {
-std::string to_string(Int8 v)
+std::string to_string(Int8 v) /// NOLINT (cert-dcl58-cpp)
 {
     return to_string(int8_t{v});
 }

--- a/base/base/int8_to_string.h
+++ b/base/base/int8_to_string.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <base/defines.h>
+#include <base/types.h>
+
+#include <fmt/format.h>
+
+template <>
+struct fmt::formatter<Int8>
+{
+    constexpr auto parse(format_parse_context & ctx)
+    {
+        const auto * it = ctx.begin();
+        const auto * end = ctx.end();
+
+        /// Only support {}.
+        if (it != end && *it != '}')
+            throw format_error("invalid format");
+
+        return it;
+    }
+
+    template <typename FormatContext>
+    auto format(const Int8 & value, FormatContext & ctx) -> decltype(ctx.out())
+    {
+        return format<FormatContext>(int8_t{value}, ctx);
+    }
+};
+
+
+namespace std
+{
+std::string to_string(Int8 v);
+}

--- a/base/base/int8_to_string.h
+++ b/base/base/int8_to_string.h
@@ -13,5 +13,5 @@ struct fmt::formatter<Int8> : fmt::formatter<int8_t>
 
 namespace std
 {
-std::string to_string(Int8 v);
+std::string to_string(Int8 v); /// NOLINT (cert-dcl58-cpp)
 }

--- a/base/base/int8_to_string.h
+++ b/base/base/int8_to_string.h
@@ -6,25 +6,8 @@
 #include <fmt/format.h>
 
 template <>
-struct fmt::formatter<Int8>
+struct fmt::formatter<Int8> : fmt::formatter<int8_t>
 {
-    constexpr auto parse(format_parse_context & ctx)
-    {
-        const auto * it = ctx.begin();
-        const auto * end = ctx.end();
-
-        /// Only support {}.
-        if (it != end && *it != '}')
-            throw format_error("invalid format");
-
-        return it;
-    }
-
-    template <typename FormatContext>
-    auto format(const Int8 & value, FormatContext & ctx) -> decltype(ctx.out())
-    {
-        return format<FormatContext>(int8_t{value}, ctx);
-    }
 };
 
 

--- a/base/base/types.h
+++ b/base/base/types.h
@@ -3,14 +3,29 @@
 #include <cstdint>
 #include <string>
 
-/// This is needed for more strict aliasing. https://godbolt.org/z/xpJBSb https://stackoverflow.com/a/57453713
+/// Using char8_t more strict aliasing (https://stackoverflow.com/a/57453713)
 using UInt8 = char8_t;
+
+/// Same for using signed _BitInt(8) (there isn't a signed char8_t, which would be more convenient)
+/// See https://godbolt.org/z/fafnWEnnf
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wbit-int-extension"
+using Int8 = signed _BitInt(8);
+#pragma clang diagnostic pop
+
+namespace std
+{
+template <>
+struct hash<Int8>
+{
+    size_t operator()(const Int8 x) const { return std::hash<int8_t>()(int8_t{x}); }
+};
+}
 
 using UInt16 = uint16_t;
 using UInt32 = uint32_t;
 using UInt64 = uint64_t;
 
-using Int8 = int8_t;
 using Int16 = int16_t;
 using Int32 = int32_t;
 using Int64 = int64_t;

--- a/base/base/types.h
+++ b/base/base/types.h
@@ -16,7 +16,7 @@ using Int8 = signed _BitInt(8);
 namespace std
 {
 template <>
-struct hash<Int8>
+struct hash<Int8> /// NOLINT (cert-dcl58-cpp)
 {
     size_t operator()(const Int8 x) const { return std::hash<int8_t>()(int8_t{x}); }
 };

--- a/src/Common/Exception.h
+++ b/src/Common/Exception.h
@@ -9,10 +9,11 @@
 
 #include <base/defines.h>
 #include <base/errnoToString.h>
+#include <base/int8_to_string.h>
 #include <base/scope_guard.h>
-#include <Common/LoggingFormatStringHelpers.h>
-#include <Common/Logger.h>
 #include <Common/AtomicLogger.h>
+#include <Common/Logger.h>
+#include <Common/LoggingFormatStringHelpers.h>
 #include <Common/StackTrace.h>
 
 #include <fmt/format.h>

--- a/src/Core/Field.h
+++ b/src/Core/Field.h
@@ -216,9 +216,8 @@ using NearestFieldType = typename NearestFieldTypeImpl<T>::Type;
 template <> struct NearestFieldTypeImpl<char> { using Type = std::conditional_t<is_signed_v<char>, Int64, UInt64>; };
 template <> struct NearestFieldTypeImpl<signed char> { using Type = Int64; };
 template <> struct NearestFieldTypeImpl<unsigned char> { using Type = UInt64; };
-#ifdef __cpp_char8_t
 template <> struct NearestFieldTypeImpl<char8_t> { using Type = UInt64; };
-#endif
+template <> struct NearestFieldTypeImpl<Int8> { using Type = Int64; };
 
 template <> struct NearestFieldTypeImpl<UInt16> { using Type = UInt64; };
 template <> struct NearestFieldTypeImpl<UInt32> { using Type = UInt64; };

--- a/src/Functions/divide/divide.cpp
+++ b/src/Functions/divide/divide.cpp
@@ -49,9 +49,9 @@ template void divideImpl<uint32_t, char8_t, uint32_t>(const uint32_t * __restric
 template void divideImpl<int64_t, int64_t, int64_t>(const int64_t * __restrict, int64_t, int64_t * __restrict, size_t);
 template void divideImpl<int64_t, int32_t, int64_t>(const int64_t * __restrict, int32_t, int64_t * __restrict, size_t);
 template void divideImpl<int64_t, int16_t, int64_t>(const int64_t * __restrict, int16_t, int64_t * __restrict, size_t);
-template void divideImpl<int64_t, int8_t, int64_t>(const int64_t * __restrict, int8_t, int64_t * __restrict, size_t);
+template void divideImpl<int64_t, Int8, int64_t>(const int64_t * __restrict, Int8, int64_t * __restrict, size_t);
 
 template void divideImpl<int32_t, int64_t, int32_t>(const int32_t * __restrict, int64_t, int32_t * __restrict, size_t);
 template void divideImpl<int32_t, int32_t, int32_t>(const int32_t * __restrict, int32_t, int32_t * __restrict, size_t);
 template void divideImpl<int32_t, int16_t, int32_t>(const int32_t * __restrict, int16_t, int32_t * __restrict, size_t);
-template void divideImpl<int32_t, int8_t, int32_t>(const int32_t * __restrict, int8_t, int32_t * __restrict, size_t);
+template void divideImpl<int32_t, Int8, int32_t>(const int32_t * __restrict, Int8, int32_t * __restrict, size_t);

--- a/src/Functions/divide/divideImpl.cpp
+++ b/src/Functions/divide/divideImpl.cpp
@@ -12,6 +12,10 @@
 
 #include <libdivide.h>
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wbit-int-extension"
+using Int8 = signed _BitInt(8);
+#pragma clang diagnostic pop
 
 namespace NAMESPACE
 {
@@ -62,11 +66,11 @@ template void divideImpl<uint32_t, char8_t, uint32_t>(const uint32_t * __restric
 template void divideImpl<int64_t, int64_t, int64_t>(const int64_t * __restrict, int64_t, int64_t * __restrict, size_t);
 template void divideImpl<int64_t, int32_t, int64_t>(const int64_t * __restrict, int32_t, int64_t * __restrict, size_t);
 template void divideImpl<int64_t, int16_t, int64_t>(const int64_t * __restrict, int16_t, int64_t * __restrict, size_t);
-template void divideImpl<int64_t, int8_t, int64_t>(const int64_t * __restrict, int8_t, int64_t * __restrict, size_t);
+template void divideImpl<int64_t, Int8, int64_t>(const int64_t * __restrict, Int8, int64_t * __restrict, size_t);
 
 template void divideImpl<int32_t, int64_t, int32_t>(const int32_t * __restrict, int64_t, int32_t * __restrict, size_t);
 template void divideImpl<int32_t, int32_t, int32_t>(const int32_t * __restrict, int32_t, int32_t * __restrict, size_t);
 template void divideImpl<int32_t, int16_t, int32_t>(const int32_t * __restrict, int16_t, int32_t * __restrict, size_t);
-template void divideImpl<int32_t, int8_t, int32_t>(const int32_t * __restrict, int8_t, int32_t * __restrict, size_t);
+template void divideImpl<int32_t, Int8, int32_t>(const int32_t * __restrict, Int8, int32_t * __restrict, size_t);
 
 }

--- a/src/Functions/if.cpp
+++ b/src/Functions/if.cpp
@@ -230,13 +230,8 @@ inline void fillConstantConstant(const ArrayCond & cond, A a, B b, ArrayResult &
 {
     size_t size = cond.size();
 
-    /// Int8(alias type of uint8_t) has special aliasing properties that prevents compiler from auto-vectorizing for below codes, refer to https://gist.github.com/alexei-zaripov/dcc14c78819c5f1354afe8b70932007c
-    ///
-    /// for (size_t i = 0; i < size; ++i)
-    ///     res[i] = cond[i] ? static_cast<Int8>(a) : static_cast<Int8>(b);
-    ///
-    /// Therefore, we manually optimize it by avoiding branch miss when ResultType is Int8. Other types like (U)Int128|256 or Decimal128/256 also benefit from this optimization.
-    if constexpr (std::is_same_v<ResultType, Int8> || is_over_big_int<ResultType>)
+    /// We manually optimize the loop for types like (U)Int128|256 or Decimal128/256 to avoid branches
+    if constexpr (is_over_big_int<ResultType>)
     {
         alignas(64) const ResultType ab[2] = {static_cast<ResultType>(a), static_cast<ResultType>(b)};
         for (size_t i = 0; i < size; ++i)

--- a/src/Processors/Formats/Impl/CHColumnToArrowColumn.cpp
+++ b/src/Processors/Formats/Impl/CHColumnToArrowColumn.cpp
@@ -130,6 +130,11 @@ namespace DB
                 reinterpret_cast<const uint8_t *>(internal_data.data() + start),
                 end - start,
                 reinterpret_cast<const uint8_t *>(arrow_null_bytemap_raw_ptr));
+        else if constexpr (std::is_same_v<NumericType, Int8>)
+            status = builder.AppendValues(
+                reinterpret_cast<const int8_t *>(internal_data.data() + start),
+                end - start,
+                reinterpret_cast<const uint8_t *>(arrow_null_bytemap_raw_ptr));
         else
             status = builder.AppendValues(internal_data.data() + start, end - start, reinterpret_cast<const uint8_t *>(arrow_null_bytemap_raw_ptr));
         checkStatus(status, write_column->getName(), format_name);

--- a/src/Storages/PostgreSQL/MaterializedPostgreSQLConsumer.cpp
+++ b/src/Storages/PostgreSQL/MaterializedPostgreSQLConsumer.cpp
@@ -313,7 +313,7 @@ void MaterializedPostgreSQLConsumer::readTupleData(
                 Int32 col_len = readInt32(message, pos, size);
                 String value;
                 for (Int32 i = 0; i < col_len; ++i)
-                    value += readInt8(message, pos, size);
+                    value += static_cast<char>(readInt8(message, pos, size));
 
                 insertValue(storage_data, value, column_idx);
                 break;


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Improve performance of Int8 type by implementing strict aliasing

### Documentation entry for user-facing changes

Replace the internal representation of Int8 from `int8_t` (signed char) to `_BitInt(8)`. The new representation cannot alias with other types which allows more compiler optimizations to take place.

* 24.1:
```
:) Select sum(number::Int8) from numbers(1_000_000_000);

SELECT sum(CAST(number, 'Int8'))
FROM numbers(1000000000)

Query id: 87c0cae8-ee12-4ba2-bc21-0c9683d5b5c8

┌─sum(CAST(number, 'Int8'))─┐
│                -500000000 │
└───────────────────────────┘

1 row in set. Elapsed: 0.448 sec. Processed 892.96 million rows, 7.14 GB (1.99 billion rows/s., 15.95 GB/s.)
Peak memory usage: 68.08 KiB.
```

* PR: 
```
:) Select sum(number::Int8) from numbers(1_000_000_000);

SELECT sum(CAST(number, 'Int8'))
FROM numbers(1000000000)

Query id: 5b6a1491-f37a-413b-91f2-4a47baf06bb3

┌─sum(CAST(number, 'Int8'))─┐
│                -500000000 │
└───────────────────────────┘

1 row in set. Elapsed: 0.230 sec. Processed 870.86 million rows, 6.97 GB (3.79 billion rows/s., 30.31 GB/s.)
Peak memory usage: 68.08 KiB.
```

I tried using `unsigned _BitInt(8)` for UInt8 for consistency but not having integer promotion for it was a humongous PITA, so it's much better to keep char8_t. Int8 only required some minimal changes (so far)
