### PR TITLE
Disable test_rabbitmq_select with TSAN

### DIFF
--- a/tests/integration/test_storage_rabbitmq/test.py
+++ b/tests/integration/test_storage_rabbitmq/test.py
@@ -110,7 +110,7 @@ def rabbitmq_setup_teardown():
     ],
 )
 def test_rabbitmq_select(rabbitmq_cluster, secure):
-    if secure and instance.is_built_with_thread_sanitizer():
+    if instance.is_built_with_thread_sanitizer():
         pytest.skip(
             "Data races: see https://github.com/ClickHouse/ClickHouse/issues/56866"
         )


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

Failing constantly (https://s3.amazonaws.com/clickhouse-test-reports/59388/6e82dc81fcf6daa0180ec09f82a1e367788864f6/integration_tests__tsan__[4_6]//home/ubuntu/actions-runner/_work/_temp/test/output_dir/integration_run_parallel3_0.log), now with unsecure port too.

References https://github.com/ClickHouse/ClickHouse/issues/56866

Maybe we should drop support of RabbitMQ if we are not going to fix it.