### PR TITLE
Fix `00191_aggregating_merge_tree_and_final`

### DIFF
--- a/tests/queries/0_stateless/00191_aggregating_merge_tree_and_final.sql
+++ b/tests/queries/0_stateless/00191_aggregating_merge_tree_and_final.sql
@@ -7,9 +7,9 @@ INSERT INTO aggregating_00191 (k, u) SELECT intDiv(number, 100) AS k, uniqState(
 
 SELECT k, finalizeAggregation(u) FROM aggregating_00191 FINAL order by k;
 
-OPTIMIZE TABLE aggregating_00191;
+OPTIMIZE TABLE aggregating_00191 FINAL;
 
-SELECT k, finalizeAggregation(u) FROM aggregating_00191;
+SELECT k, finalizeAggregation(u) FROM aggregating_00191 order by k;
 SELECT k, finalizeAggregation(u) FROM aggregating_00191 FINAL order by k;
 
 DROP TABLE aggregating_00191;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

---

It became flaky after we merged https://github.com/ClickHouse/ClickHouse/pull/39663. When external aggregation happens it seems like we get more than one part, and because we used `OPTIMIZE` without `FINAL` data wasn't properly merged.
`order by` on the line 12 is not needed by now, but let's add it just in case.