### PR TITLE
generate key for clickhouse_remove_objects_capability

### DIFF
--- a/src/Disks/ObjectStorages/ObjectStorageFactory.cpp
+++ b/src/Disks/ObjectStorages/ObjectStorageFactory.cpp
@@ -96,10 +96,10 @@ S3::URI getS3URI(const Poco::Util::AbstractConfiguration & config, const std::st
 }
 
 void checkS3Capabilities(
-    S3ObjectStorage & storage, const S3Capabilities s3_capabilities, const String & name, const String & key_with_trailing_slash)
+    S3ObjectStorage & storage, const S3Capabilities s3_capabilities, const String & name)
 {
     /// If `support_batch_delete` is turned on (default), check and possibly switch it off.
-    if (s3_capabilities.support_batch_delete && !checkBatchRemove(storage, key_with_trailing_slash))
+    if (s3_capabilities.support_batch_delete && !checkBatchRemove(storage))
     {
         LOG_WARNING(
             getLogger("S3ObjectStorage"),
@@ -134,7 +134,7 @@ void registerS3ObjectStorage(ObjectStorageFactory & factory)
 
         /// NOTE: should we still perform this check for clickhouse-disks?
         if (!skip_access_check)
-            checkS3Capabilities(*object_storage, s3_capabilities, name, uri.key);
+            checkS3Capabilities(*object_storage, s3_capabilities, name);
 
         return object_storage;
     });
@@ -170,7 +170,7 @@ void registerS3PlainObjectStorage(ObjectStorageFactory & factory)
 
         /// NOTE: should we still perform this check for clickhouse-disks?
         if (!skip_access_check)
-            checkS3Capabilities(*object_storage, s3_capabilities, name, uri.key);
+            checkS3Capabilities(*object_storage, s3_capabilities, name);
 
         return object_storage;
     });

--- a/src/Disks/ObjectStorages/S3/DiskS3Utils.h
+++ b/src/Disks/ObjectStorages/S3/DiskS3Utils.h
@@ -18,7 +18,7 @@ ObjectStorageKeysGeneratorPtr getKeyGenerator(
     const String & config_prefix);
 
 class S3ObjectStorage;
-bool checkBatchRemove(S3ObjectStorage & storage, const std::string & key_with_trailing_slash);
+bool checkBatchRemove(S3ObjectStorage & storage);
 
 }
 


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
instead using a constant key, now object storage generates key for determining remove objects capability.