### PR TITLE
Avoid running all checks when `aspell-dict.txt` was changed

### DIFF
--- a/tests/ci/pr_info.py
+++ b/tests/ci/pr_info.py
@@ -366,6 +366,7 @@ class PRInfo:
                 (ext in DIFF_IN_DOCUMENTATION_EXT and path_in_docs)
                 or "docker/docs" in f
                 or "docs_check.py" in f
+                or "aspell-dict.txt" in f
                 or ext == ".md"
             ):
                 return False


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Avoid running all checks when `aspell-dict.txt` was changed

For example in https://github.com/ClickHouse/ClickHouse/pull/59350 after changing `aspell-dict.txt` all tests were launched.

cc @Felixoid 
