### PR TITLE
Do not interpret binary if clickhouse-local is disabled

### DIFF
--- a/programs/main.cpp
+++ b/programs/main.cpp
@@ -501,6 +501,7 @@ int main(int argc_, char ** argv_)
         }
     }
 
+#if ENABLE_CLICKHOUSE_LOCAL
     /// Interpret binary without argument or with arguments starts with dash
     /// ('-') as clickhouse-local for better usability:
     ///
@@ -511,6 +512,7 @@ int main(int argc_, char ** argv_)
     ///
     if (main_func == printHelp && !argv.empty() && (argv.size() == 1 || argv[1][0] == '-'))
         main_func = mainEntryClickHouseLocal;
+#endif
 
     return main_func(static_cast<int>(argv.size()), argv.data());
 }


### PR DESCRIPTION
### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix compilation when cmake option ENABLE_CLICKHOUSE_LOCAL=OFF 

Follow-up for: https://github.com/ClickHouse/ClickHouse/pull/58344 (cc @azat )