### PR TITLE
Update the peter-evans/create-pull-request action to v6

### DIFF
--- a/.github/workflows/tags_stable.yml
+++ b/.github/workflows/tags_stable.yml
@@ -55,7 +55,7 @@ jobs:
         python3 ./utils/security-generator/generate_security.py > SECURITY.md
         git diff HEAD
     - name: Create Pull Request
-      uses: peter-evans/create-pull-request@v3
+      uses: peter-evans/create-pull-request@v6
       with:
         author: "robot-clickhouse <robot-clickhouse@users.noreply.github.com>"
         token: ${{ secrets.ROBOT_CLICKHOUSE_COMMIT_TOKEN }}


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Updated the heavily outdated peter-evans/create-pull-request@v3 to v6