### PR TITLE
GRPCServer: do not call value() on empty optional query_info

### DIFF
--- a/src/Server/GRPCServer.cpp
+++ b/src/Server/GRPCServer.cpp
@@ -419,7 +419,11 @@ namespace
         void read(GRPCQueryInfo & query_info_, const CompletionCallback & callback) override
         {
             if (!query_info.has_value())
+            {
                 callback(false);
+                return;
+            }
+
             query_info_ = std::move(query_info).value();
             query_info.reset();
             callback(true);
@@ -486,7 +490,11 @@ namespace
         void read(GRPCQueryInfo & query_info_, const CompletionCallback & callback) override
         {
             if (!query_info.has_value())
+            {
                 callback(false);
+                return;
+            }
+
             query_info_ = std::move(query_info).value();
             query_info.reset();
             callback(true);


### PR DESCRIPTION
Some times there is segmentation fault in GRPCServer. Like that [stack](https://pastila.nl/?0025ecec/254a91c3c9fd4f3bcd471db7d4d86d6d#9xcrMsZz/XaMdYj0CaX0BA==)
I tried to debug it. I haven't succeeded yet. But that looks like mistake for sure.

Because 
> query_info_ = std::move(query_info).value();
that ends up with abort call. 

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

