### PR TITLE
Add support for reading and writing backups as tar archives

### DIFF
--- a/contrib/libarchive-cmake/CMakeLists.txt
+++ b/contrib/libarchive-cmake/CMakeLists.txt
@@ -157,7 +157,7 @@ if (TARGET ch_contrib::zlib)
 endif()
 
 if (TARGET ch_contrib::zstd)
-    target_compile_definitions(_libarchive PUBLIC HAVE_ZSTD_H=1 HAVE_LIBZSTD=1)
+    target_compile_definitions(_libarchive PUBLIC HAVE_ZSTD_H=1 HAVE_LIBZSTD=1 HAVE_LIBZSTD_COMPRESSOR=1)
     target_link_libraries(_libarchive PRIVATE ch_contrib::zstd)
 endif()
 

--- a/docs/en/operations/backup.md
+++ b/docs/en/operations/backup.md
@@ -187,7 +187,7 @@ To change the compression method, the correct file suffix should be appended to 
 BACKUP TABLE test.table TO Disk('backups', '1.tar.gz')
 ```
 
-The supported compression file suffixes are `.gz` `.bz2` and `.lzma`.
+The supported compression file suffixes are `tar.gz`, `.tgz` `tar.bz2`, `tar.lzma`, `.tar.zst`, `.tzst` and `.tar.xz`.
 
 
 ### Check the status of backups

--- a/docs/en/operations/backup.md
+++ b/docs/en/operations/backup.md
@@ -168,6 +168,20 @@ RESTORE TABLE test.table PARTITIONS '2', '3'
   FROM Disk('backups', 'filename.zip')
 ```
 
+### Backups as tar archives
+
+Backups can also be stored as tar archives. The functionality is the same as for zip, except that compressing the archive or adding a password is not supported. 
+
+Write a backup as a tar:
+```
+BACKUP TABLE test.table TO Disk('backups', '1.tar')
+```
+
+Corresponding restore:
+```
+RESTORE TABLE test.table FROM Disk('backups', '1.tar')
+```
+
 ### Check the status of backups
 
 The backup command returns an `id` and `status`, and that `id` can be used to get the status of the backup.  This is very useful to check the progress of long ASYNC backups.  The example below shows a failure that happened when trying to overwrite an existing backup file:

--- a/docs/en/operations/backup.md
+++ b/docs/en/operations/backup.md
@@ -170,7 +170,7 @@ RESTORE TABLE test.table PARTITIONS '2', '3'
 
 ### Backups as tar archives
 
-Backups can also be stored as tar archives. The functionality is the same as for zip, except that compressing the archive or adding a password is not supported. 
+Backups can also be stored as tar archives. The functionality is the same as for zip, except that a password is not supported. 
 
 Write a backup as a tar:
 ```
@@ -181,6 +181,14 @@ Corresponding restore:
 ```
 RESTORE TABLE test.table FROM Disk('backups', '1.tar')
 ```
+
+To change the compression method, the correct file suffix should be appended to the backup name. I.E to compress the tar archive using gzip:
+```
+BACKUP TABLE test.table TO Disk('backups', '1.tar.gz')
+```
+
+The supported compression file suffixes are `.gz` `.bz2` and `.lzma`.
+
 
 ### Check the status of backups
 

--- a/src/Backups/BackupImpl.cpp
+++ b/src/Backups/BackupImpl.cpp
@@ -927,7 +927,7 @@ void BackupImpl::writeFile(const BackupFileInfo & info, BackupEntryPtr entry)
 
     const auto write_info_to_archive = [&](const auto & file_name)
     {
-        auto out = archive_writer->writeFile(file_name);
+        auto out = archive_writer->writeFile(file_name, info.size);
         auto read_buffer = entry->getReadBuffer(writer->getReadSettings());
         if (info.base_size != 0)
             read_buffer->seek(info.base_size, SEEK_SET);

--- a/src/IO/Archives/IArchiveWriter.h
+++ b/src/IO/Archives/IArchiveWriter.h
@@ -22,6 +22,9 @@ public:
     /// of the function `writeFile()` should be destroyed before next call of `writeFile()`.
     virtual std::unique_ptr<WriteBufferFromFileBase> writeFile(const String & filename) = 0;
 
+    virtual std::unique_ptr<WriteBufferFromFileBase> writeFile(const String & filename, const size_t & size) = 0;
+
+
     /// Returns true if there is an active instance of WriteBuffer returned by writeFile().
     /// This function should be used mostly for debugging purposes.
     virtual bool isWritingFile() const = 0;

--- a/src/IO/Archives/IArchiveWriter.h
+++ b/src/IO/Archives/IArchiveWriter.h
@@ -24,7 +24,6 @@ public:
 
     virtual std::unique_ptr<WriteBufferFromFileBase> writeFile(const String & filename, size_t size) = 0;
 
-
     /// Returns true if there is an active instance of WriteBuffer returned by writeFile().
     /// This function should be used mostly for debugging purposes.
     virtual bool isWritingFile() const = 0;

--- a/src/IO/Archives/IArchiveWriter.h
+++ b/src/IO/Archives/IArchiveWriter.h
@@ -22,7 +22,7 @@ public:
     /// of the function `writeFile()` should be destroyed before next call of `writeFile()`.
     virtual std::unique_ptr<WriteBufferFromFileBase> writeFile(const String & filename) = 0;
 
-    virtual std::unique_ptr<WriteBufferFromFileBase> writeFile(const String & filename, const size_t & size) = 0;
+    virtual std::unique_ptr<WriteBufferFromFileBase> writeFile(const String & filename, size_t size) = 0;
 
 
     /// Returns true if there is an active instance of WriteBuffer returned by writeFile().

--- a/src/IO/Archives/LibArchiveReader.cpp
+++ b/src/IO/Archives/LibArchiveReader.cpp
@@ -23,7 +23,7 @@ class LibArchiveReader::StreamInfo
 public:
     explicit StreamInfo(std::unique_ptr<SeekableReadBuffer> read_buffer_) : read_buffer(std::move(read_buffer_)) { }
 
-    static ssize_t read([[maybe_unused]] struct archive * a, void * client_data, const void ** buff)
+    static ssize_t read(struct archive *, void * client_data, const void ** buff)
     {
         auto * read_stream = reinterpret_cast<StreamInfo *>(client_data);
         *buff = reinterpret_cast<void *>(read_stream->buf);

--- a/src/IO/Archives/LibArchiveReader.cpp
+++ b/src/IO/Archives/LibArchiveReader.cpp
@@ -460,7 +460,8 @@ std::vector<std::string> LibArchiveReader::getAllFiles(NameFilter filter)
 void LibArchiveReader::setPassword([[maybe_unused]] const String & password_)
 {
     if (password_.empty())
-        throw Exception(ErrorCodes::LOGICAL_ERROR, "Can not set password to {} archive", archive_name);
+        return;
+    throw Exception(ErrorCodes::LOGICAL_ERROR, "Cannot set password to {} archive", archive_name);
 }
 
 LibArchiveReader::Handle LibArchiveReader::acquireHandle()

--- a/src/IO/Archives/LibArchiveReader.cpp
+++ b/src/IO/Archives/LibArchiveReader.cpp
@@ -197,13 +197,18 @@ private:
             archive_read_support_filter_xz(archive);
             archive_read_support_filter_lz4(archive);
             archive_read_support_filter_zstd(archive);
+            archive_read_support_filter_lzma(archive);
             // Support tar, 7zip and zip
             archive_read_support_format_tar(archive);
             archive_read_support_format_7zip(archive);
             archive_read_support_format_zip(archive);
 
-            if (archive_read_open_filename(archive, path_to_archive.c_str(), 10240) != ARCHIVE_OK)
-                throw Exception(ErrorCodes::CANNOT_UNPACK_ARCHIVE, "Couldn't open archive {}: {}", quoteString(path_to_archive), archive_error_string(archive));
+            if (archive_read_open(archive, read_stream_, nullptr, StreamInfo::read, nullptr) != ARCHIVE_OK)
+                throw Exception(
+                    ErrorCodes::CANNOT_UNPACK_ARCHIVE,
+                    "Couldn't open archive {}: {}",
+                    quoteString(path_to_archive),
+                    archive_error_string(archive));
         }
         catch (...)
         {
@@ -219,8 +224,17 @@ private:
         auto * archive = archive_read_new();
         try
         {
-            archive_read_support_filter_all(archive);
-            archive_read_support_format_all(archive);
+            // Support for bzip2, gzip, lzip, xz, zstd and lz4
+            archive_read_support_filter_bzip2(archive);
+            archive_read_support_filter_gzip(archive);
+            archive_read_support_filter_xz(archive);
+            archive_read_support_filter_lz4(archive);
+            archive_read_support_filter_zstd(archive);
+            archive_read_support_filter_lzma(archive);
+            // Support tar, 7zip and zip
+            archive_read_support_format_tar(archive);
+            archive_read_support_format_7zip(archive);
+            archive_read_support_format_zip(archive);
             if (archive_read_open_filename(archive, path_to_archive_.c_str(), 10240) != ARCHIVE_OK)
                 throw Exception(
                     ErrorCodes::CANNOT_UNPACK_ARCHIVE,

--- a/src/IO/Archives/LibArchiveReader.cpp
+++ b/src/IO/Archives/LibArchiveReader.cpp
@@ -309,7 +309,6 @@ public:
     {
         throw Exception(ErrorCodes::UNSUPPORTED_METHOD, "getPosition not supported when reading from archive");
     }
-    
     String getFileName() const override { return handle.getFileName(); }
 
     size_t getFileSize() override { return handle.getFileInfo().uncompressed_size; }

--- a/src/IO/Archives/LibArchiveReader.cpp
+++ b/src/IO/Archives/LibArchiveReader.cpp
@@ -113,7 +113,7 @@ public:
     {
         std::unique_ptr<LibArchiveReader::StreamInfo> rs
             = archive_read_function ? std::make_unique<StreamInfo>(archive_read_function()) : nullptr;
-        auto archive = rs ? openWithReader(rs.get()) : openWithPath(path_to_archive);
+        auto * archive = rs ? openWithReader(rs.get()) : openWithPath(path_to_archive);
 
         SCOPE_EXIT(close(archive););
 

--- a/src/IO/Archives/LibArchiveReader.cpp
+++ b/src/IO/Archives/LibArchiveReader.cpp
@@ -121,7 +121,7 @@ public:
             close(archive);
         );
 
-        struct archive_entry * entry = nullptr;
+        Entry entry = nullptr;
 
         std::vector<std::string> files;
         int error = readNextHeader(archive, &entry);
@@ -132,7 +132,7 @@ public:
             if (!filter || filter(name))
                 files.push_back(std::move(name));
 
-            error = readNextHeader(current_archive, &entry);
+            error = readNextHeader(archive, &entry);
         }
 
         checkError(error);

--- a/src/IO/Archives/LibArchiveReader.cpp
+++ b/src/IO/Archives/LibArchiveReader.cpp
@@ -458,7 +458,7 @@ std::vector<std::string> LibArchiveReader::getAllFiles(NameFilter filter)
     return handle.getAllFiles(filter);
 }
 
-void LibArchiveReader::setPassword([[maybe_unused]] const String & password_)
+void LibArchiveReader::setPassword(const String & password_)
 {
     if (password_.empty())
         return;

--- a/src/IO/Archives/LibArchiveReader.cpp
+++ b/src/IO/Archives/LibArchiveReader.cpp
@@ -317,10 +317,7 @@ public:
     }
     bool checkIfActuallySeekable() override { return false; }
 
-    off_t getPosition() override
-    {
-        throw Exception(ErrorCodes::UNSUPPORTED_METHOD, "getPosition not supported when reading from archive");
-    }
+    off_t getPosition() override { throw Exception(ErrorCodes::UNSUPPORTED_METHOD, "getPosition not supported when reading from archive"); }
     String getFileName() const override { return handle.getFileName(); }
 
     size_t getFileSize() override { return handle.getFileInfo().uncompressed_size; }
@@ -456,7 +453,8 @@ std::unique_ptr<LibArchiveReader::FileEnumerator> LibArchiveReader::currentFile(
 {
     if (!dynamic_cast<ReadBufferFromLibArchive *>(read_buffer.get()))
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Wrong ReadBuffer passed to nextFile()");
-    auto read_buffer_from_libarchive = std::unique_ptr<ReadBufferFromLibArchive>(static_cast<ReadBufferFromLibArchive *>(read_buffer.release()));
+    auto read_buffer_from_libarchive
+        = std::unique_ptr<ReadBufferFromLibArchive>(static_cast<ReadBufferFromLibArchive *>(read_buffer.release()));
     auto handle = std::move(*read_buffer_from_libarchive).releaseHandle();
     return std::make_unique<FileEnumeratorImpl>(std::move(handle));
 }

--- a/src/IO/Archives/LibArchiveReader.cpp
+++ b/src/IO/Archives/LibArchiveReader.cpp
@@ -42,6 +42,7 @@ public:
     {
         current_archive = openWithPath(path_to_archive);
     }
+
     explicit Handle(std::string path_to_archive_, bool lock_on_reading_, const ReadArchiveFunction & archive_read_function_)
         : path_to_archive(std::move(path_to_archive_)), archive_read_function(archive_read_function_), lock_on_reading(lock_on_reading_)
     {

--- a/src/IO/Archives/LibArchiveReader.cpp
+++ b/src/IO/Archives/LibArchiveReader.cpp
@@ -297,9 +297,7 @@ public:
     {
         throw Exception(ErrorCodes::UNSUPPORTED_METHOD, "getPosition not supported when reading from archive");
     }
-
-    off_t getPosition() override { throw Exception(ErrorCodes::UNSUPPORTED_METHOD, "getPosition not supported when reading from archive"); }
-
+    
     String getFileName() const override { return handle.getFileName(); }
 
     size_t getFileSize() override { return handle.getFileInfo().uncompressed_size; }

--- a/src/IO/Archives/LibArchiveReader.cpp
+++ b/src/IO/Archives/LibArchiveReader.cpp
@@ -119,7 +119,7 @@ public:
         std::unique_ptr<LibArchiveReader::StreamInfo> rs;
         if(archive_read_function)
         {
-            read_stream = std::make_unique<StreamInfo>(archive_read_function());
+            rs = std::make_unique<StreamInfo>(archive_read_function());
             archive = openWithReader(&(*rs));
         }
         else

--- a/src/IO/Archives/LibArchiveReader.h
+++ b/src/IO/Archives/LibArchiveReader.h
@@ -3,6 +3,7 @@
 #include "config.h"
 #include <mutex>
 #include <IO/Archives/IArchiveReader.h>
+#include <IO/Archives/LibArchiveReader.h>
 
 
 namespace DB

--- a/src/IO/Archives/LibArchiveReader.h
+++ b/src/IO/Archives/LibArchiveReader.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "config.h"
-
+#include <mutex>
 #include <IO/Archives/IArchiveReader.h>
 
 
@@ -52,20 +52,31 @@ protected:
     /// Constructs an archive's reader that will read from a file in the local filesystem.
     LibArchiveReader(std::string archive_name_, bool lock_on_reading_, std::string path_to_archive_);
 
+    LibArchiveReader(std::string archive_name_, bool lock_on_reading_, std::string path_to_archive_, const ReadArchiveFunction & archive_read_function_);
+
 private:
     class ReadBufferFromLibArchive;
     class Handle;
     class FileEnumeratorImpl;
+    class StreamInfo;
+
+    Handle acquireHandle();
 
     const std::string archive_name;
     const bool lock_on_reading;
     const String path_to_archive;
+    const ReadArchiveFunction archive_read_function;
+    mutable std::mutex mutex;
+    
 };
 
 class TarArchiveReader : public LibArchiveReader
 {
 public:
     explicit TarArchiveReader(std::string path_to_archive) : LibArchiveReader("tar", /*lock_on_reading_=*/ true, std::move(path_to_archive)) { }
+
+    explicit TarArchiveReader(std::string path_to_archive, const ReadArchiveFunction & archive_read_function ) : LibArchiveReader("tar", /*lock_on_reading_=*/ true, std::move(path_to_archive), archive_read_function) { }
+
 };
 
 class SevenZipArchiveReader : public LibArchiveReader

--- a/src/IO/Archives/LibArchiveReader.h
+++ b/src/IO/Archives/LibArchiveReader.h
@@ -1,9 +1,9 @@
 #pragma once
 
-#include "config.h"
 #include <mutex>
 #include <IO/Archives/IArchiveReader.h>
 #include <IO/Archives/LibArchiveReader.h>
+#include "config.h"
 
 
 namespace DB
@@ -53,7 +53,8 @@ protected:
     /// Constructs an archive's reader that will read from a file in the local filesystem.
     LibArchiveReader(std::string archive_name_, bool lock_on_reading_, std::string path_to_archive_);
 
-    LibArchiveReader(std::string archive_name_, bool lock_on_reading_, std::string path_to_archive_, const ReadArchiveFunction & archive_read_function_);
+    LibArchiveReader(
+        std::string archive_name_, bool lock_on_reading_, std::string path_to_archive_, const ReadArchiveFunction & archive_read_function_);
 
 private:
     class ReadBufferFromLibArchive;
@@ -68,22 +69,28 @@ private:
     const String path_to_archive;
     const ReadArchiveFunction archive_read_function;
     mutable std::mutex mutex;
-    
 };
 
 class TarArchiveReader : public LibArchiveReader
 {
 public:
-    explicit TarArchiveReader(std::string path_to_archive) : LibArchiveReader("tar", /*lock_on_reading_=*/ true, std::move(path_to_archive)) { }
+    explicit TarArchiveReader(std::string path_to_archive) : LibArchiveReader("tar", /*lock_on_reading_=*/true, std::move(path_to_archive))
+    {
+    }
 
-    explicit TarArchiveReader(std::string path_to_archive, const ReadArchiveFunction & archive_read_function ) : LibArchiveReader("tar", /*lock_on_reading_=*/ true, std::move(path_to_archive), archive_read_function) { }
-
+    explicit TarArchiveReader(std::string path_to_archive, const ReadArchiveFunction & archive_read_function)
+        : LibArchiveReader("tar", /*lock_on_reading_=*/true, std::move(path_to_archive), archive_read_function)
+    {
+    }
 };
 
 class SevenZipArchiveReader : public LibArchiveReader
 {
 public:
-    explicit SevenZipArchiveReader(std::string path_to_archive) : LibArchiveReader("7z", /*lock_on_reading_=*/ false, std::move(path_to_archive)) { }
+    explicit SevenZipArchiveReader(std::string path_to_archive)
+        : LibArchiveReader("7z", /*lock_on_reading_=*/false, std::move(path_to_archive))
+    {
+    }
 };
 
 #endif

--- a/src/IO/Archives/LibArchiveWriter.cpp
+++ b/src/IO/Archives/LibArchiveWriter.cpp
@@ -92,7 +92,7 @@ private:
         {
             throw Exception(
                 ErrorCodes::CANNOT_PACK_ARCHIVE,
-                "Couldn't pack tar archive: Failed to write all bytes, {} of {} , filename={}",
+                "Couldn't pack tar archive: Failed to write all bytes, {} of {}, filename={}",
                 written,
                 to_write,
                 quoteString(filename));

--- a/src/IO/Archives/LibArchiveWriter.cpp
+++ b/src/IO/Archives/LibArchiveWriter.cpp
@@ -9,16 +9,13 @@
 
 #if USE_LIBARCHIVE
 
-// this implemation follows the ZipArchiveWriter implemation as closely as possible.  
+// this implemation follows the ZipArchiveWriter implemation as closely as possible.
 
 namespace DB
 {
 namespace ErrorCodes
 {
 extern const int CANNOT_PACK_ARCHIVE;
-extern const int LOGICAL_ERROR;
-extern const int CANNOT_READ_ALL_DATA;
-extern const int UNSUPPORTED_METHOD;
 extern const int NOT_IMPLEMENTED;
 }
 
@@ -135,8 +132,13 @@ private:
         }
         if (throw_if_error and bytes != expected_size)
         {
-            throw Exception(ErrorCodes::CANNOT_PACK_ARCHIVE, "Couldn't pack tar archive: Wrote {} of expected {} , filename={}", bytes, expected_size, quoteString(filename)); 
-        } 
+            throw Exception(
+                ErrorCodes::CANNOT_PACK_ARCHIVE,
+                "Couldn't pack tar archive: Wrote {} of expected {} , filename={}",
+                bytes,
+                expected_size,
+                quoteString(filename));
+        }
     }
 
     void endWritingFile()
@@ -188,7 +190,7 @@ LibArchiveWriter::LibArchiveWriter(const String & path_to_archive_, std::unique_
 LibArchiveWriter::~LibArchiveWriter()
 {
     if (!finalized && !std::uncaught_exceptions() && !std::current_exception())
-            chassert(false && "TarArchiveWriter is not finalized in destructor.");
+        chassert(false && "TarArchiveWriter is not finalized in destructor.");
     if (archive)
         archive_write_free(archive);
 }
@@ -240,12 +242,10 @@ void LibArchiveWriter::finalize()
 
 void LibArchiveWriter::setCompression(const String & compression_method_, int compression_level)
 {
-    // throw an error unless setCompression is passed the defualt value
+    // throw an error unless setCompression is passed the default value
     if (compression_method_.empty() == 0 && compression_level == -1)
-    {
-            return;
-    }
-    throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Tar archives are currenly supported without compression");
+        return;
+    throw Exception(ErrorCodes::NOT_IMPLEMENTED, "tar archives are currently supported without compression");
 }
 
 void LibArchiveWriter::setPassword([[maybe_unused]] const String & password_)

--- a/src/IO/Archives/LibArchiveWriter.cpp
+++ b/src/IO/Archives/LibArchiveWriter.cpp
@@ -243,7 +243,7 @@ void LibArchiveWriter::finalize()
 void LibArchiveWriter::setCompression(const String & compression_method_, int compression_level)
 {
     // throw an error unless setCompression is passed the default value
-    if (compression_method_.empty() == 0 && compression_level == -1)
+    if (compression_method_.empty() && compression_level == -1)
         return;
     throw Exception(ErrorCodes::NOT_IMPLEMENTED, "tar archives are currently supported without compression");
 }

--- a/src/IO/Archives/LibArchiveWriter.cpp
+++ b/src/IO/Archives/LibArchiveWriter.cpp
@@ -210,9 +210,8 @@ void LibArchiveWriter::endWritingFile()
 void LibArchiveWriter::startWritingFile()
 {
     std::lock_guard lock{mutex};
-    if (is_writing_file)
+    if (std::exchange(is_writing_file, true))
         throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Cannot write two files to a tar archive in parallel");
-    is_writing_file = true;
 }
 
 void LibArchiveWriter::finalize()

--- a/src/IO/Archives/LibArchiveWriter.cpp
+++ b/src/IO/Archives/LibArchiveWriter.cpp
@@ -244,7 +244,8 @@ void LibArchiveWriter::finalize()
 
 void LibArchiveWriter::setCompression(const String & compression_method_, int compression_level)
 {
-    if (compression_method_.size() == 0 and compression_level == 1)
+    // throw an error unless setCompression is passed the defualt value
+    if (compression_method_.size() == 0 and compression_level == -1)
     {
             return;
     }

--- a/src/IO/Archives/LibArchiveWriter.cpp
+++ b/src/IO/Archives/LibArchiveWriter.cpp
@@ -34,7 +34,7 @@ class LibArchiveWriter::StreamInfo
 {
 public:
     explicit StreamInfo(std::unique_ptr<WriteBuffer> archive_write_buffer_) : archive_write_buffer(std::move(archive_write_buffer_)) { }
-    static ssize_t memory_write([[maybe_unused]] struct archive * archive, void * client_data, const void * buff, size_t length)
+    static ssize_t memory_write(struct archive *, void * client_data, const void * buff, size_t length)
     {
         auto * stream_info = reinterpret_cast<StreamInfo *>(client_data);
         stream_info->archive_write_buffer->write(reinterpret_cast<const char *>(buff), length);

--- a/src/IO/Archives/LibArchiveWriter.cpp
+++ b/src/IO/Archives/LibArchiveWriter.cpp
@@ -34,7 +34,6 @@ class LibArchiveWriter::StreamInfo
 {
 public:
     explicit StreamInfo(std::unique_ptr<WriteBuffer> archive_write_buffer_) : archive_write_buffer(std::move(archive_write_buffer_)) { }
-
     static ssize_t memory_write([[maybe_unused]] struct archive * archive, void * client_data, const void * buff, size_t length)
     {
         auto * stream_info = reinterpret_cast<StreamInfo *>(client_data);

--- a/src/IO/Archives/LibArchiveWriter.cpp
+++ b/src/IO/Archives/LibArchiveWriter.cpp
@@ -240,12 +240,12 @@ void LibArchiveWriter::finalize()
     finalized = true;
 }
 
-void LibArchiveWriter::setCompression(const String & compression_method_, int compression_level)
+void LibArchiveWriter::setCompression(const String & compression_method_, int compression_level) 
 {
     // throw an error unless setCompression is passed the default value
     if (compression_method_.empty() && compression_level == -1)
         return;
-    throw Exception(ErrorCodes::NOT_IMPLEMENTED, "tar archives are currently supported without compression");
+    throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Compressing tar archives is currently not supported");
 }
 
 void LibArchiveWriter::setPassword([[maybe_unused]] const String & password_)

--- a/src/IO/Archives/LibArchiveWriter.cpp
+++ b/src/IO/Archives/LibArchiveWriter.cpp
@@ -123,7 +123,7 @@ private:
             return offset();
     }
 
-    void closeFile([[maybe_unused]] bool throw_if_error)
+    void closeFile(bool throw_if_error)
     {
         if (entry)
         {

--- a/src/IO/Archives/LibArchiveWriter.cpp
+++ b/src/IO/Archives/LibArchiveWriter.cpp
@@ -25,8 +25,7 @@ void checkResultCodeImpl(int code, const String & filename)
 {
     if (code == ARCHIVE_OK)
         return;
-    String message = "LibArchive Code = " + std::to_string(code);
-    throw Exception(ErrorCodes::CANNOT_PACK_ARCHIVE, "Couldn't pack archive: {}, filename={}", message, quoteString(filename));
+    throw Exception(ErrorCodes::CANNOT_PACK_ARCHIVE, "Couldn't pack archive: LibArchive Code = {}, filename={}", code, quoteString(filename));
 }
 }
 

--- a/src/IO/Archives/LibArchiveWriter.cpp
+++ b/src/IO/Archives/LibArchiveWriter.cpp
@@ -240,10 +240,10 @@ void LibArchiveWriter::finalize()
     finalized = true;
 }
 
-void LibArchiveWriter::setCompression(const String & compression_method_, int compression_level)
+void LibArchiveWriter::setCompression(const String & compression_method_, int compression_level_)
 {
     // throw an error unless setCompression is passed the default value
-    if (compression_method_.empty() && compression_level == -1)
+    if (compression_method_.empty() && compression_level_ == -1)
         return;
     throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Compressing tar archives is currently not supported");
 }

--- a/src/IO/Archives/LibArchiveWriter.cpp
+++ b/src/IO/Archives/LibArchiveWriter.cpp
@@ -37,7 +37,7 @@ public:
     explicit StreamInfo(std::unique_ptr<WriteBuffer> archive_write_buffer_) : archive_write_buffer(std::move(archive_write_buffer_)) { }
 
 
-    static ssize_t memory_write([[maybe_unused]] struct archive * a, void * client_data, const void * buff, size_t length)
+    static ssize_t memory_write([[maybe_unused]] struct archive * archive, void * client_data, const void * buff, size_t length)
     {
         auto * stream_info = reinterpret_cast<StreamInfo *>(client_data);
         stream_info->archive_write_buffer->write(reinterpret_cast<const char *>(buff), length);
@@ -57,7 +57,6 @@ public:
         archive = archive_writer_->getArchive();
         entry = nullptr;
     }
-
 
     ~WriteBufferFromLibArchive() override
     {
@@ -82,7 +81,6 @@ public:
     void sync() override { next(); }
     std::string getFileName() const override { return filename; }
 
-
 private:
     void nextImpl() override
     {
@@ -102,7 +100,6 @@ private:
                 quoteString(filename));
         }
     }
-
 
     void writeEntry()
     {
@@ -163,11 +160,6 @@ private:
     size_t expected_size;
 };
 
-LibArchiveWriter::LibArchiveWriter(const String & path_to_archive_) : path_to_archive(path_to_archive_)
-{
-    throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Not Implemented");
-}
-
 LibArchiveWriter::LibArchiveWriter(const String & path_to_archive_, std::unique_ptr<WriteBuffer> archive_write_buffer_)
     : path_to_archive(path_to_archive_)
 {
@@ -186,11 +178,9 @@ LibArchiveWriter::LibArchiveWriter(const String & path_to_archive_, std::unique_
     }
 }
 
-
 LibArchiveWriter::~LibArchiveWriter()
 {
-    if (!finalized && !std::uncaught_exceptions() && !std::current_exception())
-        chassert(false && "TarArchiveWriter is not finalized in destructor.");
+    chassert((finalized || std::uncaught_exceptions() || std::current_exception()) && "TarArchiveWriter is not finalized in destructor.");
     if (archive)
         archive_write_free(archive);
 }

--- a/src/IO/Archives/LibArchiveWriter.cpp
+++ b/src/IO/Archives/LibArchiveWriter.cpp
@@ -35,7 +35,6 @@ class LibArchiveWriter::StreamInfo
 public:
     explicit StreamInfo(std::unique_ptr<WriteBuffer> archive_write_buffer_) : archive_write_buffer(std::move(archive_write_buffer_)) { }
 
-
     static ssize_t memory_write([[maybe_unused]] struct archive * archive, void * client_data, const void * buff, size_t length)
     {
         auto * stream_info = reinterpret_cast<StreamInfo *>(client_data);

--- a/src/IO/Archives/LibArchiveWriter.cpp
+++ b/src/IO/Archives/LibArchiveWriter.cpp
@@ -248,7 +248,7 @@ void LibArchiveWriter::setCompression(const String & compression_method_, int co
     throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Compressing tar archives is currently not supported");
 }
 
-void LibArchiveWriter::setPassword([[maybe_unused]] const String & password_)
+void LibArchiveWriter::setPassword(const String & password_)
 {
     if (password_.empty())
         return;

--- a/src/IO/Archives/LibArchiveWriter.cpp
+++ b/src/IO/Archives/LibArchiveWriter.cpp
@@ -240,7 +240,7 @@ void LibArchiveWriter::finalize()
     finalized = true;
 }
 
-void LibArchiveWriter::setCompression(const String & compression_method_, int compression_level) 
+void LibArchiveWriter::setCompression(const String & compression_method_, int compression_level)
 {
     // throw an error unless setCompression is passed the default value
     if (compression_method_.empty() && compression_level == -1)

--- a/src/IO/Archives/LibArchiveWriter.cpp
+++ b/src/IO/Archives/LibArchiveWriter.cpp
@@ -1,0 +1,267 @@
+#include <IO/Archives/LibArchiveWriter.h>
+
+#include <filesystem>
+#include <IO/WriteBufferFromFileBase.h>
+#include <Common/quoteString.h>
+#include <Common/scope_guard_safe.h>
+
+#include <mutex>
+
+#if USE_LIBARCHIVE
+
+// this implemation follows the ZipArchiveWriter implemation as closely as possible.  
+
+namespace DB
+{
+namespace ErrorCodes
+{
+extern const int CANNOT_PACK_ARCHIVE;
+extern const int LOGICAL_ERROR;
+extern const int CANNOT_READ_ALL_DATA;
+extern const int UNSUPPORTED_METHOD;
+extern const int NOT_IMPLEMENTED;
+}
+
+namespace
+{
+void checkResultCodeImpl(int code, const String & filename)
+{
+    if (code == ARCHIVE_OK)
+        return;
+    String message = "LibArchive Code = " + std::to_string(code);
+    throw Exception(ErrorCodes::CANNOT_PACK_ARCHIVE, "Couldn't pack archive: {}, filename={}", message, quoteString(filename));
+}
+}
+
+// this is a thin wrapper for libarchive to be able to write the archive to a WriteBuffer
+class LibArchiveWriter::StreamInfo
+{
+public:
+    explicit StreamInfo(std::unique_ptr<WriteBuffer> archive_write_buffer_) : archive_write_buffer(std::move(archive_write_buffer_)) { }
+
+
+    static ssize_t memory_write([[maybe_unused]] struct archive * a, void * client_data, const void * buff, size_t length)
+    {
+        auto * stream_info = reinterpret_cast<StreamInfo *>(client_data);
+        stream_info->archive_write_buffer->write(reinterpret_cast<const char *>(buff), length);
+        return length;
+    }
+
+    std::unique_ptr<WriteBuffer> archive_write_buffer;
+};
+
+class LibArchiveWriter::WriteBufferFromLibArchive : public WriteBufferFromFileBase
+{
+public:
+    WriteBufferFromLibArchive(std::shared_ptr<LibArchiveWriter> archive_writer_, const String & filename_, const size_t & size_)
+        : WriteBufferFromFileBase(DBMS_DEFAULT_BUFFER_SIZE, nullptr, 0), archive_writer(archive_writer_), filename(filename_), size(size_)
+    {
+        startWritingFile();
+        a = archive_writer_->getArchive();
+        entry = nullptr;
+    }
+
+
+    ~WriteBufferFromLibArchive() override
+    {
+        try
+        {
+            closeFile(/* throw_if_error= */ false);
+            endWritingFile();
+        }
+        catch (...)
+        {
+            tryLogCurrentException("WriteBufferFromTarArchive");
+        }
+    }
+
+    void finalizeImpl() override
+    {
+        next();
+        closeFile(/* throw_if_error=*/true);
+        endWritingFile();
+    }
+
+    void sync() override { next(); }
+    std::string getFileName() const override { return filename; }
+
+
+private:
+    void nextImpl() override
+    {
+        if (!offset())
+            return;
+        if (entry == nullptr)
+            writeEntry();
+        ssize_t to_write = offset();
+        ssize_t written = archive_write_data(a, working_buffer.begin(), offset());
+        if (written != to_write)
+        {
+            throw Exception(
+                ErrorCodes::CANNOT_PACK_ARCHIVE,
+                "Couldn't pack tar archive: Failed to write all bytes, {} of {} , filename={}",
+                written,
+                to_write,
+                quoteString(filename));
+        }
+    }
+
+
+    void writeEntry()
+    {
+        expected_size = getSize();
+        entry = archive_entry_new();
+        archive_entry_set_pathname(entry, filename.c_str());
+        archive_entry_set_size(entry, expected_size);
+        archive_entry_set_filetype(entry, static_cast<__LA_MODE_T>(0100000));
+        archive_entry_set_perm(entry, 0644);
+        checkResult(archive_write_header(a, entry));
+    }
+
+    size_t getSize() const
+    {
+        if (size)
+            return size;
+        else
+            return offset();
+    }
+
+    void closeFile([[maybe_unused]] bool throw_if_error)
+    {
+        if (entry)
+        {
+            archive_entry_free(entry);
+            entry = nullptr;
+        }
+        if (throw_if_error and bytes != expected_size)
+        {
+            throw Exception(ErrorCodes::CANNOT_PACK_ARCHIVE, "Couldn't pack tar archive: Wrote {} of expected {} , filename={}", bytes, expected_size, quoteString(filename)); 
+        } 
+    }
+
+    void endWritingFile()
+    {
+        if (auto archive_writer_ptr = archive_writer.lock())
+            archive_writer_ptr->endWritingFile();
+    }
+
+    void startWritingFile()
+    {
+        if (auto archive_writer_ptr = archive_writer.lock())
+            archive_writer_ptr->startWritingFile();
+    }
+
+    void checkResult(int code) { checkResultCodeImpl(code, filename); }
+
+    std::weak_ptr<LibArchiveWriter> archive_writer;
+    const String filename;
+    struct archive_entry * entry;
+    struct archive * a;
+    size_t size;
+    size_t expected_size;
+};
+
+LibArchiveWriter::LibArchiveWriter(const String & path_to_archive_) : path_to_archive(path_to_archive_)
+{
+    throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Not Implemented");
+}
+
+LibArchiveWriter::LibArchiveWriter(const String & path_to_archive_, std::unique_ptr<WriteBuffer> archive_write_buffer_)
+    : path_to_archive(path_to_archive_)
+{
+    a = archive_write_new();
+    archive_write_set_format_pax_restricted(a);
+    //this allows use to write directly to a writer buffer rather than an intermediate buffer in LibArchive
+    //archive_write_set_bytes_per_block(a, 0);
+    if (archive_write_buffer_)
+    {
+        stream_info = std::make_unique<StreamInfo>(std::move(archive_write_buffer_));
+        archive_write_open2(a, &(*stream_info), nullptr, &StreamInfo::memory_write, nullptr, nullptr);
+    }
+    else
+    {
+        archive_write_open_filename(a, path_to_archive.c_str());
+    }
+}
+
+
+LibArchiveWriter::~LibArchiveWriter()
+{
+    if (!finalized)
+    {
+        if (!std::uncaught_exceptions() && std::current_exception() == nullptr)
+            chassert(false && "TarArchiveWriter is not finalized in destructor.");
+    }
+
+    if (a)
+        archive_write_free(a);
+}
+
+std::unique_ptr<WriteBufferFromFileBase> LibArchiveWriter::writeFile(const String & filename, const size_t & size)
+{
+    return std::make_unique<WriteBufferFromLibArchive>(std::static_pointer_cast<LibArchiveWriter>(shared_from_this()), filename, size);
+}
+
+std::unique_ptr<WriteBufferFromFileBase> LibArchiveWriter::writeFile(const String & filename)
+{
+    return std::make_unique<WriteBufferFromLibArchive>(std::static_pointer_cast<LibArchiveWriter>(shared_from_this()), filename, 0);
+}
+
+bool LibArchiveWriter::isWritingFile() const
+{
+    std::lock_guard lock{mutex};
+    return is_writing_file;
+}
+
+void LibArchiveWriter::endWritingFile()
+{
+    std::lock_guard lock{mutex};
+    is_writing_file = false;
+}
+
+void LibArchiveWriter::startWritingFile()
+{
+    std::lock_guard lock{mutex};
+    if (is_writing_file)
+        throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Cannot write two files to a tar archive in parallel");
+    is_writing_file = true;
+}
+
+void LibArchiveWriter::finalize()
+{
+    std::lock_guard lock{mutex};
+    if (finalized)
+        return;
+    if (a)
+        archive_write_close(a);
+    if (stream_info)
+    {
+        stream_info->archive_write_buffer->finalize();
+        stream_info.reset();
+    }
+    finalized = true;
+}
+
+void LibArchiveWriter::setCompression(const String & compression_method_, int compression_level)
+{
+    if (compression_method_.size() == 0 and compression_level == 1)
+    {
+            return;
+    }
+    throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Tar archives are currenly supported without compression");
+}
+
+void LibArchiveWriter::setPassword([[maybe_unused]] const String & password_)
+{
+    if (password_ == "")
+        return;
+    throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Setting a password is not currently supported for tar archives");
+}
+
+struct archive * LibArchiveWriter::getArchive()
+{
+    std::lock_guard lock{mutex};
+    return a;
+}
+}
+#endif

--- a/src/IO/Archives/LibArchiveWriter.h
+++ b/src/IO/Archives/LibArchiveWriter.h
@@ -59,13 +59,16 @@ private:
     class WriteBufferFromLibArchive;
     class StreamInfo;
 
-    struct archive * getArchive();
+    using Archive = struct archive *;
+    using Entry = struct archive_entry *;
+
+    Archive getArchive();
     void startWritingFile();
     void endWritingFile();
 
     String path_to_archive;
     std::unique_ptr<StreamInfo> stream_info TSA_GUARDED_BY(mutex) = nullptr;
-    struct archive * a TSA_GUARDED_BY(mutex) = nullptr;
+    Archive archive TSA_GUARDED_BY(mutex) = nullptr;
     bool is_writing_file TSA_GUARDED_BY(mutex) = false;
     bool finalized TSA_GUARDED_BY(mutex) = false;
     mutable std::mutex mutex;

--- a/src/IO/Archives/LibArchiveWriter.h
+++ b/src/IO/Archives/LibArchiveWriter.h
@@ -53,9 +53,9 @@ protected:
     using Archive = struct archive *;
     using Entry = struct archive_entry *;
 
-    /// derived classes must call createArcive. createArchive calls initArchive
+    /// derived classes must call createArchive. CreateArchive calls setFormatAndSettings.
     void createArchive();
-    virtual void setFormatAndSettings(Archive) = 0;
+    virtual void setFormatAndSettings() = 0;
 
     Archive archive = nullptr;
     String path_to_archive;

--- a/src/IO/Archives/LibArchiveWriter.h
+++ b/src/IO/Archives/LibArchiveWriter.h
@@ -46,14 +46,12 @@ public:
     /// (Unless an error appeared and the archive is in fact no longer needed.)
     void finalize() override;
 
-    static constexpr const int kDefaultCompressionLevel = -1;
-
     /// Sets compression method and level.
     /// Changing them will affect next file in the archive.
-    void setCompression(const String & /* compression_method */, int /* compression_level */ = kDefaultCompressionLevel) override;
+    void setCompression(const String & method, int level) override;
 
     /// Sets password. If the password is not empty it will enable encryption in the archive.
-    void setPassword(const String & /* password */) override;
+    void setPassword(const String & password) override;
 
 private:
     class WriteBufferFromLibArchive;

--- a/src/IO/Archives/LibArchiveWriter.h
+++ b/src/IO/Archives/LibArchiveWriter.h
@@ -35,7 +35,7 @@ public:
     /// passed in the the archive writer tries to infer the size by looking at the available
     /// data in the buffer, if next is called before all data is written to the buffer
     /// an exception is thrown.
-    std::unique_ptr<WriteBufferFromFileBase> writeFile(const String & filename, const size_t & size) override;
+    std::unique_ptr<WriteBufferFromFileBase> writeFile(const String & filename, size_t size) override;
 
 
     /// Returns true if there is an active instance of WriteBuffer returned by writeFile().

--- a/src/IO/Archives/LibArchiveWriter.h
+++ b/src/IO/Archives/LibArchiveWriter.h
@@ -1,0 +1,76 @@
+#pragma once
+
+#include "config.h"
+
+#if USE_LIBARCHIVE
+#    include <IO/Archives/ArchiveUtils.h>
+#    include <IO/Archives/IArchiveWriter.h>
+#    include <IO/WriteBufferFromFileBase.h>
+#    include <base/defines.h>
+
+
+namespace DB
+{
+class WriteBufferFromFileBase;
+
+/// Interface for writing an archive.
+class LibArchiveWriter : public IArchiveWriter
+{
+public:
+    /// Constructs an archive that will be written as a file in the local filesystem.
+    [[noreturn]] explicit LibArchiveWriter(const String & path_to_archive_);
+
+    /// Constructs an archive that will be written as a file in the local filesystem.
+    explicit LibArchiveWriter(const String & path_to_archive_, std::unique_ptr<WriteBuffer> archive_write_buffer_);
+
+    /// Call finalize() before destructing IArchiveWriter.
+    ~LibArchiveWriter() override;
+
+    /// Starts writing a file to the archive. The function returns a write buffer,
+    /// any data written to that buffer will be compressed and then put to the archive.
+    /// You can keep only one such buffer at a time, a buffer returned by previous call
+    /// of the function `writeFile()` should be destroyed before next call of `writeFile()`.
+    std::unique_ptr<WriteBufferFromFileBase> writeFile(const String & filename) override;
+    /// LibArchive needs to know the size of the file being written. If the file size is not
+    /// passed in the the archive writer tries to infer the size by looking at the available
+    /// data in the buffer, if next is called before all data is written to the buffer
+    /// an exception is thrown.
+    std::unique_ptr<WriteBufferFromFileBase> writeFile(const String & filename, const size_t & size) override;
+
+
+    /// Returns true if there is an active instance of WriteBuffer returned by writeFile().
+    /// This function should be used mostly for debugging purposes.
+    bool isWritingFile() const override;
+
+    /// Finalizes writing of the archive. This function must be always called at the end of writing.
+    /// (Unless an error appeared and the archive is in fact no longer needed.)
+    void finalize() override;
+
+    static constexpr const int kDefaultCompressionLevel = -1;
+
+    /// Sets compression method and level.
+    /// Changing them will affect next file in the archive.
+    void setCompression(const String & /* compression_method */, int /* compression_level */ = kDefaultCompressionLevel) override;
+
+    /// Sets password. If the password is not empty it will enable encryption in the archive.
+    void setPassword(const String & /* password */) override;
+
+private:
+    class WriteBufferFromLibArchive;
+    class StreamInfo;
+
+    struct archive * getArchive();
+    void startWritingFile();
+    void endWritingFile();
+
+    String path_to_archive;
+    std::unique_ptr<StreamInfo> stream_info TSA_GUARDED_BY(mutex) = nullptr;
+    struct archive * a TSA_GUARDED_BY(mutex) = nullptr;
+    bool is_writing_file TSA_GUARDED_BY(mutex) = false;
+    bool finalized TSA_GUARDED_BY(mutex) = false;
+    mutable std::mutex mutex;
+};
+
+}
+
+#endif

--- a/src/IO/Archives/LibArchiveWriter.h
+++ b/src/IO/Archives/LibArchiveWriter.h
@@ -48,7 +48,7 @@ public:
 
     /// Sets compression method and level.
     /// Changing them will affect next file in the archive.
-    void setCompression(const String & method, int level) override;
+    void setCompression(const String & compression_method_, int compression_level_) override;
 
     /// Sets password. If the password is not empty it will enable encryption in the archive.
     void setPassword(const String & password) override;

--- a/src/IO/Archives/LibArchiveWriter.h
+++ b/src/IO/Archives/LibArchiveWriter.h
@@ -53,7 +53,7 @@ protected:
     using Archive = struct archive *;
     using Entry = struct archive_entry *;
 
-    //derived classes must call createArcive. createArchive calls initArchive
+    /// derived classes must call createArcive. createArchive calls initArchive
     void createArchive();
     virtual void setFormatAndSettings(Archive) = 0;
 

--- a/src/IO/Archives/TarArchiveWriter.cpp
+++ b/src/IO/Archives/TarArchiveWriter.cpp
@@ -5,7 +5,6 @@ namespace DB
 {
 namespace ErrorCodes
 {
-extern const int CANNOT_PACK_ARCHIVE;
 extern const int NOT_IMPLEMENTED;
 }
 void TarArchiveWriter::setCompression(const String & compression_method_, int compression_level_)

--- a/src/IO/Archives/TarArchiveWriter.cpp
+++ b/src/IO/Archives/TarArchiveWriter.cpp
@@ -1,0 +1,37 @@
+#include <IO/Archives/TarArchiveWriter.h>
+
+#if USE_LIBARCHIVE
+namespace DB
+{
+namespace ErrorCodes
+{
+extern const int CANNOT_PACK_ARCHIVE;
+extern const int NOT_IMPLEMENTED;
+}
+void TarArchiveWriter::setCompression(const String & compression_method_, int compression_level_)
+{
+    // throw an error unless setCompression is passed the default value
+    if (compression_method_.empty() && compression_level_ == -1)
+        return;
+    throw Exception(
+        ErrorCodes::NOT_IMPLEMENTED, "Using compression_method and compression_level options are not supported for tar archives");
+}
+
+void TarArchiveWriter::setFormatAndSettings(Archive archive_)
+{
+    archive_write_set_format_pax_restricted(archive_);
+    inferCompressionFromPath();
+}
+
+void TarArchiveWriter::inferCompressionFromPath()
+{
+    if (path_to_archive.ends_with(".gz"))
+        archive_write_add_filter_gzip(archive);
+    else if (path_to_archive.ends_with(".bz2"))
+        archive_write_add_filter_bzip2(archive);
+    else if (path_to_archive.ends_with(".lzma"))
+        archive_write_add_filter_lzma(archive);
+    //else path ends in .tar and we dont do any compression
+}
+}
+#endif

--- a/src/IO/Archives/TarArchiveWriter.h
+++ b/src/IO/Archives/TarArchiveWriter.h
@@ -19,7 +19,7 @@ public:
     }
 
     void setCompression(const String & compression_method_, int compression_level_) override;
-    void setFormatAndSettings(Archive archive_) override;
+    void setFormatAndSettings() override;
     void inferCompressionFromPath();
 };
 }

--- a/src/IO/Archives/TarArchiveWriter.h
+++ b/src/IO/Archives/TarArchiveWriter.h
@@ -12,8 +12,6 @@ using namespace std::literals;
 class TarArchiveWriter : public LibArchiveWriter
 {
 public:
-    static constexpr std::array TarExtensions{".tar"sv, ".tar.gz"sv, ".tar.bz2"sv, ".tar.lzma"sv};
-
     explicit TarArchiveWriter(const String & path_to_archive_, std::unique_ptr<WriteBuffer> archive_write_buffer_)
         : LibArchiveWriter(path_to_archive_, std::move(archive_write_buffer_))
     {

--- a/src/IO/Archives/TarArchiveWriter.h
+++ b/src/IO/Archives/TarArchiveWriter.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "config.h"
+
+#if USE_LIBARCHIVE
+
+#    include <IO/Archives/LibArchiveWriter.h>
+namespace DB
+{
+using namespace std::literals;
+
+class TarArchiveWriter : public LibArchiveWriter
+{
+public:
+    static constexpr std::array TarExtensions{".tar"sv, ".tar.gz"sv, ".tar.bz2"sv, ".tar.lzma"sv};
+
+    explicit TarArchiveWriter(const String & path_to_archive_, std::unique_ptr<WriteBuffer> archive_write_buffer_)
+        : LibArchiveWriter(path_to_archive_, std::move(archive_write_buffer_))
+    {
+        createArchive();
+    }
+
+    void setCompression(const String & compression_method_, int compression_level_) override;
+    void setFormatAndSettings(Archive archive_) override;
+    void inferCompressionFromPath();
+};
+}
+#endif

--- a/src/IO/Archives/ZipArchiveWriter.cpp
+++ b/src/IO/Archives/ZipArchiveWriter.cpp
@@ -274,6 +274,11 @@ std::unique_ptr<WriteBufferFromFileBase> ZipArchiveWriter::writeFile(const Strin
     return std::make_unique<WriteBufferFromZipArchive>(std::static_pointer_cast<ZipArchiveWriter>(shared_from_this()), filename);
 }
 
+std::unique_ptr<WriteBufferFromFileBase> ZipArchiveWriter::writeFile(const String & filename, [[maybe_unused]] const size_t & size)
+{
+    return ZipArchiveWriter::writeFile(filename);
+}
+
 bool ZipArchiveWriter::isWritingFile() const
 {
     std::lock_guard lock{mutex};

--- a/src/IO/Archives/ZipArchiveWriter.cpp
+++ b/src/IO/Archives/ZipArchiveWriter.cpp
@@ -274,7 +274,7 @@ std::unique_ptr<WriteBufferFromFileBase> ZipArchiveWriter::writeFile(const Strin
     return std::make_unique<WriteBufferFromZipArchive>(std::static_pointer_cast<ZipArchiveWriter>(shared_from_this()), filename);
 }
 
-std::unique_ptr<WriteBufferFromFileBase> ZipArchiveWriter::writeFile(const String & filename, [[maybe_unused]] const size_t & size)
+std::unique_ptr<WriteBufferFromFileBase> ZipArchiveWriter::writeFile(const String & filename, [[maybe_unused]] size_t size)
 {
     return ZipArchiveWriter::writeFile(filename);
 }

--- a/src/IO/Archives/ZipArchiveWriter.h
+++ b/src/IO/Archives/ZipArchiveWriter.h
@@ -32,6 +32,9 @@ public:
     /// of the function `writeFile()` should be destroyed before next call of `writeFile()`.
     std::unique_ptr<WriteBufferFromFileBase> writeFile(const String & filename) override;
 
+    std::unique_ptr<WriteBufferFromFileBase> writeFile(const String & filename, const size_t & size) override;
+
+
     /// Returns true if there is an active instance of WriteBuffer returned by writeFile().
     /// This function should be used mostly for debugging purposes.
     bool isWritingFile() const override;

--- a/src/IO/Archives/ZipArchiveWriter.h
+++ b/src/IO/Archives/ZipArchiveWriter.h
@@ -32,7 +32,7 @@ public:
     /// of the function `writeFile()` should be destroyed before next call of `writeFile()`.
     std::unique_ptr<WriteBufferFromFileBase> writeFile(const String & filename) override;
 
-    std::unique_ptr<WriteBufferFromFileBase> writeFile(const String & filename, const size_t & size) override;
+    std::unique_ptr<WriteBufferFromFileBase> writeFile(const String & filename, size_t size) override;
 
 
     /// Returns true if there is an active instance of WriteBuffer returned by writeFile().

--- a/src/IO/Archives/createArchiveReader.cpp
+++ b/src/IO/Archives/createArchiveReader.cpp
@@ -48,7 +48,7 @@ std::shared_ptr<IArchiveReader> createArchiveReader(
                  tar_extensions.begin(), tar_extensions.end(), [&](const auto extension) { return path_to_archive.ends_with(extension); }))
     {
 #if USE_LIBARCHIVE
-        return std::make_shared<TarArchiveReader>(path_to_archive);
+        return std::make_shared<TarArchiveReader>(path_to_archive, archive_read_function);
 #else
         throw Exception(ErrorCodes::SUPPORT_IS_DISABLED, "libarchive library is disabled");
 #endif

--- a/src/IO/Archives/createArchiveReader.cpp
+++ b/src/IO/Archives/createArchiveReader.cpp
@@ -1,6 +1,6 @@
-#include <IO/Archives/createArchiveReader.h>
-#include <IO/Archives/ZipArchiveReader.h>
 #include <IO/Archives/LibArchiveReader.h>
+#include <IO/Archives/ZipArchiveReader.h>
+#include <IO/Archives/createArchiveReader.h>
 #include <Common/Exception.h>
 
 
@@ -8,8 +8,8 @@ namespace DB
 {
 namespace ErrorCodes
 {
-    extern const int CANNOT_UNPACK_ARCHIVE;
-    extern const int SUPPORT_IS_DISABLED;
+extern const int CANNOT_UNPACK_ARCHIVE;
+extern const int SUPPORT_IS_DISABLED;
 }
 
 
@@ -25,16 +25,8 @@ std::shared_ptr<IArchiveReader> createArchiveReader(
     [[maybe_unused]] size_t archive_size)
 {
     using namespace std::literals;
-    static constexpr std::array tar_extensions
-    {
-        ".tar"sv,
-        ".tar.gz"sv,
-        ".tgz"sv,
-        ".tar.zst"sv,
-        ".tzst"sv,
-        ".tar.xz"sv,
-        ".tar.bz2"sv
-    };
+    static constexpr std::array tar_extensions{
+        ".tar"sv, ".tar.gz"sv, ".tgz"sv, ".tar.zst"sv, ".tzst"sv, ".tar.xz"sv, ".tar.bz2"sv, ".tar.lzma"sv};
 
     if (path_to_archive.ends_with(".zip") || path_to_archive.ends_with(".zipx"))
     {

--- a/src/IO/Archives/createArchiveWriter.cpp
+++ b/src/IO/Archives/createArchiveWriter.cpp
@@ -25,7 +25,8 @@ std::shared_ptr<IArchiveWriter>
 createArchiveWriter(const String & path_to_archive, [[maybe_unused]] std::unique_ptr<WriteBuffer> archive_write_buffer)
 {
     using namespace std::literals;
-    static constexpr std::array tar_extensions{".tar"sv, ".tar.gz"sv, ".tar.bz2"sv, ".tar.lzma"sv};
+    static constexpr std::array tar_extensions{
+        ".tar"sv, ".tar.gz"sv, ".tgz"sv, ".tar.bz2"sv, ".tar.lzma"sv, ".tar.zst"sv, ".tzst"sv, ".tar.xz"sv};
     if (path_to_archive.ends_with(".zip") || path_to_archive.ends_with(".zipx"))
     {
 #if USE_MINIZIP

--- a/src/IO/Archives/createArchiveWriter.cpp
+++ b/src/IO/Archives/createArchiveWriter.cpp
@@ -34,7 +34,6 @@ createArchiveWriter(const String & path_to_archive, [[maybe_unused]] std::unique
         throw Exception(ErrorCodes::SUPPORT_IS_DISABLED, "minizip library is disabled");
 #endif
     }
-    //todo add support for extentsions i.e .gz
     else if (std::any_of(
                  tar_extensions.begin(), tar_extensions.end(), [&](const auto extension) { return path_to_archive.ends_with(extension); }))
     {
@@ -47,5 +46,4 @@ createArchiveWriter(const String & path_to_archive, [[maybe_unused]] std::unique
     else
         throw Exception(ErrorCodes::CANNOT_PACK_ARCHIVE, "Cannot determine the type of archive {}", path_to_archive);
 }
-
 }

--- a/src/IO/Archives/createArchiveWriter.cpp
+++ b/src/IO/Archives/createArchiveWriter.cpp
@@ -24,6 +24,8 @@ std::shared_ptr<IArchiveWriter> createArchiveWriter(const String & path_to_archi
 std::shared_ptr<IArchiveWriter>
 createArchiveWriter(const String & path_to_archive, [[maybe_unused]] std::unique_ptr<WriteBuffer> archive_write_buffer)
 {
+    using namespace std::literals;
+    static constexpr std::array tar_extensions{".tar"sv, ".tar.gz"sv, ".tar.bz2"sv, ".tar.lzma"sv};
     if (path_to_archive.ends_with(".zip") || path_to_archive.ends_with(".zipx"))
     {
 #if USE_MINIZIP
@@ -34,9 +36,7 @@ createArchiveWriter(const String & path_to_archive, [[maybe_unused]] std::unique
     }
     //todo add support for extentsions i.e .gz
     else if (std::any_of(
-                 TarArchiveWriter::TarExtensions.begin(),
-                 TarArchiveWriter::TarExtensions.end(),
-                 [&](const auto extension) { return path_to_archive.ends_with(extension); }))
+                 tar_extensions.begin(), tar_extensions.end(), [&](const auto extension) { return path_to_archive.ends_with(extension); }))
     {
 #if USE_LIBARCHIVE
         return std::make_shared<TarArchiveWriter>(path_to_archive, std::move(archive_write_buffer));

--- a/src/IO/Archives/createArchiveWriter.cpp
+++ b/src/IO/Archives/createArchiveWriter.cpp
@@ -1,5 +1,6 @@
-#include <IO/Archives/createArchiveWriter.h>
+#include <IO/Archives/LibArchiveWriter.h>
 #include <IO/Archives/ZipArchiveWriter.h>
+#include <IO/Archives/createArchiveWriter.h>
 #include <IO/WriteBuffer.h>
 #include <Common/Exception.h>
 
@@ -8,8 +9,8 @@ namespace DB
 {
 namespace ErrorCodes
 {
-    extern const int CANNOT_PACK_ARCHIVE;
-    extern const int SUPPORT_IS_DISABLED;
+extern const int CANNOT_PACK_ARCHIVE;
+extern const int SUPPORT_IS_DISABLED;
 }
 
 
@@ -19,9 +20,8 @@ std::shared_ptr<IArchiveWriter> createArchiveWriter(const String & path_to_archi
 }
 
 
-std::shared_ptr<IArchiveWriter> createArchiveWriter(
-    const String & path_to_archive,
-    [[maybe_unused]] std::unique_ptr<WriteBuffer> archive_write_buffer)
+std::shared_ptr<IArchiveWriter>
+createArchiveWriter(const String & path_to_archive, [[maybe_unused]] std::unique_ptr<WriteBuffer> archive_write_buffer)
 {
     if (path_to_archive.ends_with(".zip") || path_to_archive.ends_with(".zipx"))
     {
@@ -29,6 +29,15 @@ std::shared_ptr<IArchiveWriter> createArchiveWriter(
         return std::make_shared<ZipArchiveWriter>(path_to_archive, std::move(archive_write_buffer));
 #else
         throw Exception(ErrorCodes::SUPPORT_IS_DISABLED, "minizip library is disabled");
+#endif
+    }
+    //todo add support for extentsions i.e .gz
+    else if (path_to_archive.ends_with(".tar"))
+    {
+#if USE_LIBARCHIVE
+        return std::make_shared<LibArchiveWriter>(path_to_archive, std::move(archive_write_buffer));
+#else
+        throw Exception(ErrorCodes::SUPPORT_IS_DISABLED, "libarchive library is disabled");
 #endif
     }
     else

--- a/src/IO/Archives/createArchiveWriter.cpp
+++ b/src/IO/Archives/createArchiveWriter.cpp
@@ -1,4 +1,5 @@
 #include <IO/Archives/LibArchiveWriter.h>
+#include <IO/Archives/TarArchiveWriter.h>
 #include <IO/Archives/ZipArchiveWriter.h>
 #include <IO/Archives/createArchiveWriter.h>
 #include <IO/WriteBuffer.h>
@@ -32,10 +33,13 @@ createArchiveWriter(const String & path_to_archive, [[maybe_unused]] std::unique
 #endif
     }
     //todo add support for extentsions i.e .gz
-    else if (path_to_archive.ends_with(".tar"))
+    else if (std::any_of(
+                 TarArchiveWriter::TarExtensions.begin(),
+                 TarArchiveWriter::TarExtensions.end(),
+                 [&](const auto extension) { return path_to_archive.ends_with(extension); }))
     {
 #if USE_LIBARCHIVE
-        return std::make_shared<LibArchiveWriter>(path_to_archive, std::move(archive_write_buffer));
+        return std::make_shared<TarArchiveWriter>(path_to_archive, std::move(archive_write_buffer));
 #else
         throw Exception(ErrorCodes::SUPPORT_IS_DISABLED, "libarchive library is disabled");
 #endif

--- a/src/IO/Archives/hasRegisteredArchiveFileExtension.cpp
+++ b/src/IO/Archives/hasRegisteredArchiveFileExtension.cpp
@@ -7,7 +7,8 @@ namespace DB
 bool hasRegisteredArchiveFileExtension(const String & path)
 {
     return path.ends_with(".zip") || path.ends_with(".zipx") || path.ends_with(".tar") || path.ends_with(".tar.gz")
-        || path.ends_with(".tar.bz2") || path.ends_with(".tar.lzma");
+        || path.ends_with(".tar.bz2") || path.ends_with(".tar.lzma") || path.ends_with(".tar.zst") || path.ends_with(".tzst")
+        || path.ends_with(".tgz") || path.ends_with(".tar.xz");
 }
 
 }

--- a/src/IO/Archives/hasRegisteredArchiveFileExtension.cpp
+++ b/src/IO/Archives/hasRegisteredArchiveFileExtension.cpp
@@ -6,7 +6,7 @@ namespace DB
 
 bool hasRegisteredArchiveFileExtension(const String & path)
 {
-    return path.ends_with(".zip") || path.ends_with(".zipx");
+    return path.ends_with(".zip") || path.ends_with(".zipx") || path.ends_with(".tar");
 }
 
 }

--- a/src/IO/Archives/hasRegisteredArchiveFileExtension.cpp
+++ b/src/IO/Archives/hasRegisteredArchiveFileExtension.cpp
@@ -6,9 +6,10 @@ namespace DB
 
 bool hasRegisteredArchiveFileExtension(const String & path)
 {
-    return path.ends_with(".zip") || path.ends_with(".zipx") || path.ends_with(".tar") || path.ends_with(".tar.gz")
-        || path.ends_with(".tar.bz2") || path.ends_with(".tar.lzma") || path.ends_with(".tar.zst") || path.ends_with(".tzst")
-        || path.ends_with(".tgz") || path.ends_with(".tar.xz");
+    using namespace std::literals;
+    static constexpr std::array archive_extensions{
+        ".zip"sv, ".zipx"sv, ".tar"sv, ".tar.gz"sv, ".tgz"sv, ".tar.bz2"sv, ".tar.lzma"sv, ".tar.zst"sv, ".tzst"sv, ".tar.xz"sv};
+    return std::any_of(
+        archive_extensions.begin(), archive_extensions.end(), [&](const auto extension) { return path.ends_with(extension); });
 }
-
 }

--- a/src/IO/Archives/hasRegisteredArchiveFileExtension.cpp
+++ b/src/IO/Archives/hasRegisteredArchiveFileExtension.cpp
@@ -6,7 +6,8 @@ namespace DB
 
 bool hasRegisteredArchiveFileExtension(const String & path)
 {
-    return path.ends_with(".zip") || path.ends_with(".zipx") || path.ends_with(".tar");
+    return path.ends_with(".zip") || path.ends_with(".zipx") || path.ends_with(".tar") || path.ends_with(".tar.gz")
+        || path.ends_with(".tar.bz2") || path.ends_with(".tar.lzma");
 }
 
 }

--- a/src/IO/tests/gtest_archive_reader_and_writer.cpp
+++ b/src/IO/tests/gtest_archive_reader_and_writer.cpp
@@ -219,6 +219,10 @@ TEST_P(ArchiveReaderAndWriterTest, TwoFilesInArchive)
     ASSERT_TRUE(reader->fileExists("a.txt"));
     ASSERT_TRUE(reader->fileExists("b/c.txt"));
 
+    // Get all files
+    auto files = reader->getAllFiles();
+    EXPECT_EQ(files.size(), 2);
+
     EXPECT_EQ(reader->getFileInfo("a.txt").uncompressed_size, a_contents.size());
     EXPECT_EQ(reader->getFileInfo("b/c.txt").uncompressed_size, c_contents.size());
 
@@ -274,6 +278,10 @@ TEST_P(ArchiveReaderAndWriterTest, TwoFilesInArchive)
         enumerator = reader->nextFile(std::move(in));
         EXPECT_EQ(enumerator, nullptr);
     }
+    
+    // Get all files one last time
+    files = reader->getAllFiles();
+    EXPECT_EQ(files.size(), 2);
 }
 
 

--- a/src/IO/tests/gtest_archive_reader_and_writer.cpp
+++ b/src/IO/tests/gtest_archive_reader_and_writer.cpp
@@ -1,30 +1,29 @@
 #include <gtest/gtest.h>
 #include "config.h"
 
+#include <filesystem>
+#include <format>
 #include <IO/Archives/ArchiveUtils.h>
 #include <IO/Archives/IArchiveReader.h>
 #include <IO/Archives/IArchiveWriter.h>
 #include <IO/Archives/createArchiveReader.h>
 #include <IO/Archives/createArchiveWriter.h>
-#include <IO/ReadBufferFromFileBase.h>
 #include <IO/ReadBufferFromFile.h>
+#include <IO/ReadBufferFromFileBase.h>
 #include <IO/ReadBufferFromString.h>
 #include <IO/ReadHelpers.h>
-#include <IO/WriteBufferFromFileBase.h>
 #include <IO/WriteBufferFromFile.h>
+#include <IO/WriteBufferFromFileBase.h>
 #include <IO/WriteBufferFromString.h>
 #include <IO/WriteHelpers.h>
-#include <Common/Exception.h>
 #include <Poco/TemporaryFile.h>
-#include <filesystem>
-#include <format>
-
+#include <Common/Exception.h>
 
 
 namespace DB::ErrorCodes
 {
-    extern const int CANNOT_UNPACK_ARCHIVE;
-    extern const int LOGICAL_ERROR;
+extern const int CANNOT_UNPACK_ARCHIVE;
+extern const int LOGICAL_ERROR;
 }
 
 namespace fs = std::filesystem;
@@ -53,7 +52,8 @@ bool createArchiveWithFiles(const std::string & archivename, const std::map<std:
 
     archive_write_open_filename(a, archivename.c_str());
 
-    for (const auto & [filename, content] : files) {
+    for (const auto & [filename, content] : files)
+    {
         entry = archive_entry_new();
         archive_entry_set_pathname(entry, filename.c_str());
         archive_entry_set_size(entry, content.size());
@@ -63,12 +63,11 @@ bool createArchiveWithFiles(const std::string & archivename, const std::map<std:
         archive_write_data(a, content.c_str(), content.size());
         archive_entry_free(entry);
     }
-    
+
     archive_write_close(a);
     archive_write_free(a);
 
     return true;
-
 }
 
 class ArchiveReaderAndWriterTest : public ::testing::TestWithParam<const char *>
@@ -118,11 +117,13 @@ TEST_P(ArchiveReaderAndWriterTest, EmptyArchive)
 
     EXPECT_FALSE(reader->fileExists("nofile.txt"));
 
-    expectException(ErrorCodes::CANNOT_UNPACK_ARCHIVE, "File 'nofile.txt' was not found in archive",
-                    [&]{ reader->getFileInfo("nofile.txt"); });
+    expectException(
+        ErrorCodes::CANNOT_UNPACK_ARCHIVE, "File 'nofile.txt' was not found in archive", [&] { reader->getFileInfo("nofile.txt"); });
 
-    expectException(ErrorCodes::CANNOT_UNPACK_ARCHIVE, "File 'nofile.txt' was not found in archive",
-                    [&]{ reader->readFile("nofile.txt", /*throw_on_not_found=*/true); });
+    expectException(
+        ErrorCodes::CANNOT_UNPACK_ARCHIVE,
+        "File 'nofile.txt' was not found in archive",
+        [&] { reader->readFile("nofile.txt", /*throw_on_not_found=*/true); });
 
     EXPECT_EQ(reader->firstFile(), nullptr);
 }
@@ -186,11 +187,9 @@ TEST_P(ArchiveReaderAndWriterTest, SingleFileInArchive)
         auto enumerator = reader->firstFile();
         ASSERT_NE(enumerator, nullptr);
         EXPECT_FALSE(enumerator->nextFile());
-        expectException(ErrorCodes::CANNOT_UNPACK_ARCHIVE, "No current file",
-                        [&]{ enumerator->getFileName(); });
+        expectException(ErrorCodes::CANNOT_UNPACK_ARCHIVE, "No current file", [&] { enumerator->getFileName(); });
 
-        expectException(ErrorCodes::CANNOT_UNPACK_ARCHIVE, "No current file",
-                        [&] { reader->readFile(std::move(enumerator)); });
+        expectException(ErrorCodes::CANNOT_UNPACK_ARCHIVE, "No current file", [&] { reader->readFile(std::move(enumerator)); });
     }
 }
 
@@ -280,7 +279,7 @@ TEST_P(ArchiveReaderAndWriterTest, TwoFilesInArchive)
         enumerator = reader->nextFile(std::move(in));
         EXPECT_EQ(enumerator, nullptr);
     }
-    
+
     // Get all files one last time
     files = reader->getAllFiles();
     EXPECT_EQ(files.size(), 2);
@@ -313,7 +312,8 @@ TEST_P(ArchiveReaderAndWriterTest, InMemory)
     ASSERT_FALSE(fs::exists(getPathToArchive()));
 
     /// Read the archive.
-    auto read_archive_func = [&]() -> std::unique_ptr<SeekableReadBuffer> { return std::make_unique<ReadBufferFromString>(archive_in_memory); };
+    auto read_archive_func
+        = [&]() -> std::unique_ptr<SeekableReadBuffer> { return std::make_unique<ReadBufferFromString>(archive_in_memory); };
     auto reader = createArchiveReader(getPathToArchive(), read_archive_func, archive_in_memory.size());
 
     ASSERT_TRUE(reader->fileExists("a.txt"));
@@ -355,15 +355,13 @@ TEST_P(ArchiveReaderAndWriterTest, ManyFilesInMemory)
     {
         auto writer = createArchiveWriter(getPathToArchive(), std::make_unique<WriteBufferFromString>(archive_in_memory));
         {
-            for(int i = 0; i < files; i++)
+            for (int i = 0; i < files; i++)
             {
                 auto filename = std::format("{}.txt", i);
                 auto contents = std::format("The contents of {}.txt", i);
                 auto out = writer->writeFile(filename, times * contents.size());
-                for(int j = 0; j < times; j++)
-                {
+                for (int j = 0; j < times; j++)
                     writeString(contents, *out);
-                }
                 out->finalize();
             }
         }
@@ -374,10 +372,11 @@ TEST_P(ArchiveReaderAndWriterTest, ManyFilesInMemory)
     ASSERT_FALSE(fs::exists(getPathToArchive()));
 
     /// Read the archive.
-    auto read_archive_func = [&]() -> std::unique_ptr<SeekableReadBuffer> { return std::make_unique<ReadBufferFromString>(archive_in_memory); };
+    auto read_archive_func
+        = [&]() -> std::unique_ptr<SeekableReadBuffer> { return std::make_unique<ReadBufferFromString>(archive_in_memory); };
     auto reader = createArchiveReader(getPathToArchive(), read_archive_func, archive_in_memory.size());
 
-    for(int i = 0; i < files; i++)
+    for (int i = 0; i < files; i++)
     {
         auto filename = std::format("{}.txt", i);
         auto contents = std::format("The contents of {}.txt", i);
@@ -386,28 +385,29 @@ TEST_P(ArchiveReaderAndWriterTest, ManyFilesInMemory)
 
         {
             auto in = reader->readFile(filename, /*throw_on_not_found=*/true);
-            for(int j = 0; j < times; j++)
-            {
+            for (int j = 0; j < times; j++)
                 ASSERT_TRUE(checkString(String(contents), *in));
-            }
         }
     }
 }
 
 TEST_P(ArchiveReaderAndWriterTest, Password)
-{   
+{
     auto writer = createArchiveWriter(getPathToArchive());
     //don't support passwords for tar archives
-    if(getPathToArchive().ends_with(".tar") || getPathToArchive().ends_with(".tar.gz") || getPathToArchive().ends_with(".tar.bz2") || getPathToArchive().ends_with(".tar.lzma"))
+    if (getPathToArchive().ends_with(".tar") || getPathToArchive().ends_with(".tar.gz") || getPathToArchive().ends_with(".tar.bz2")
+        || getPathToArchive().ends_with(".tar.lzma") || getPathToArchive().ends_with(".tar.zst") || getPathToArchive().ends_with(".tar.xz"))
     {
-        expectException(ErrorCodes::NOT_IMPLEMENTED, "Setting a password is not currently supported for libarchive",
-                [&]{ writer->setPassword("a.txt"); });
+        expectException(
+            ErrorCodes::NOT_IMPLEMENTED,
+            "Setting a password is not currently supported for libarchive",
+            [&] { writer->setPassword("a.txt"); });
         writer->finalize();
     }
     else
     {
-    /// Make an archive.
-    std::string_view contents = "The contents of a.txt";
+        /// Make an archive.
+        std::string_view contents = "The contents of a.txt";
         {
             writer->setPassword("Qwe123");
             {
@@ -422,14 +422,14 @@ TEST_P(ArchiveReaderAndWriterTest, Password)
         auto reader = createArchiveReader(getPathToArchive());
 
         /// Try to read without a password.
-        expectException(ErrorCodes::CANNOT_UNPACK_ARCHIVE, "Password is required",
-                        [&]{ reader->readFile("a.txt", /*throw_on_not_found=*/true); });
+        expectException(
+            ErrorCodes::CANNOT_UNPACK_ARCHIVE, "Password is required", [&] { reader->readFile("a.txt", /*throw_on_not_found=*/true); });
 
         {
             /// Try to read with a wrong password.
             reader->setPassword("123Qwe");
-            expectException(ErrorCodes::CANNOT_UNPACK_ARCHIVE, "Wrong password",
-                            [&]{ reader->readFile("a.txt", /*throw_on_not_found=*/true); });
+            expectException(
+                ErrorCodes::CANNOT_UNPACK_ARCHIVE, "Wrong password", [&] { reader->readFile("a.txt", /*throw_on_not_found=*/true); });
         }
 
         {
@@ -446,8 +446,7 @@ TEST_P(ArchiveReaderAndWriterTest, Password)
 
 TEST_P(ArchiveReaderAndWriterTest, ArchiveNotExist)
 {
-    expectException(ErrorCodes::CANNOT_UNPACK_ARCHIVE, "Couldn't open",
-                    [&]{ createArchiveReader(getPathToArchive()); });
+    expectException(ErrorCodes::CANNOT_UNPACK_ARCHIVE, "Couldn't open", [&] { createArchiveReader(getPathToArchive()); });
 }
 
 
@@ -459,15 +458,13 @@ TEST_P(ArchiveReaderAndWriterTest, ManyFilesOnDisk)
     {
         auto writer = createArchiveWriter(getPathToArchive());
         {
-            for(int i = 0; i < files; i++)
+            for (int i = 0; i < files; i++)
             {
                 auto filename = std::format("{}.txt", i);
                 auto contents = std::format("The contents of {}.txt", i);
                 auto out = writer->writeFile(filename, times * contents.size());
-                for(int j = 0; j < times; j++)
-                {
+                for (int j = 0; j < times; j++)
                     writeString(contents, *out);
-                }
                 out->finalize();
             }
         }
@@ -480,7 +477,7 @@ TEST_P(ArchiveReaderAndWriterTest, ManyFilesOnDisk)
     /// Read the archive.
     auto reader = createArchiveReader(getPathToArchive());
 
-    for(int i = 0; i < files; i++)
+    for (int i = 0; i < files; i++)
     {
         auto filename = std::format("{}.txt", i);
         auto contents = std::format("The contents of {}.txt", i);
@@ -489,10 +486,8 @@ TEST_P(ArchiveReaderAndWriterTest, ManyFilesOnDisk)
 
         {
             auto in = reader->readFile(filename, /*throw_on_not_found=*/true);
-            for(int j = 0; j < times; j++)
-            {
+            for (int j = 0; j < times; j++)
                 ASSERT_TRUE(checkString(String(contents), *in));
-            }
         }
     }
 }
@@ -506,10 +501,8 @@ TEST_P(ArchiveReaderAndWriterTest, LargeFile)
         auto writer = createArchiveWriter(getPathToArchive());
         {
             auto out = writer->writeFile("a.txt", times * contents.size());
-            for(int i = 0; i < times; i++)
-            {
+            for (int i = 0; i < times; i++)
                 writeString(contents, *out);
-            }
             out->finalize();
         }
         writer->finalize();
@@ -526,10 +519,8 @@ TEST_P(ArchiveReaderAndWriterTest, LargeFile)
 
     {
         auto in = reader->readFile("a.txt", /*throw_on_not_found=*/true);
-        for(int i = 0; i < times; i++)
-        {
+        for (int i = 0; i < times; i++)
             ASSERT_TRUE(checkString(String(contents), *in));
-        }
     }
 
     {
@@ -543,7 +534,8 @@ TEST_P(ArchiveReaderAndWriterTest, LargeFile)
     }
 }
 
-TEST(TarArchiveReaderTest, FileExists) {
+TEST(TarArchiveReaderTest, FileExists)
+{
     String archive_path = "archive.tar";
     String filename = "file.txt";
     String contents = "test";
@@ -554,7 +546,8 @@ TEST(TarArchiveReaderTest, FileExists) {
     fs::remove(archive_path);
 }
 
-TEST(TarArchiveReaderTest, ReadFile) {
+TEST(TarArchiveReaderTest, ReadFile)
+{
     String archive_path = "archive.tar";
     String filename = "file.txt";
     String contents = "test";
@@ -568,7 +561,8 @@ TEST(TarArchiveReaderTest, ReadFile) {
     fs::remove(archive_path);
 }
 
-TEST(TarArchiveReaderTest, ReadTwoFiles) {
+TEST(TarArchiveReaderTest, ReadTwoFiles)
+{
     String archive_path = "archive.tar";
     String file1 = "file1.txt";
     String contents1 = "test1";
@@ -584,14 +578,15 @@ TEST(TarArchiveReaderTest, ReadTwoFiles) {
     readStringUntilEOF(str, *in);
     EXPECT_EQ(str, contents1);
     in = reader->readFile(file2, /*throw_on_not_found=*/true);
-    
+
     readStringUntilEOF(str, *in);
     EXPECT_EQ(str, contents2);
     fs::remove(archive_path);
 }
 
 
-TEST(TarArchiveReaderTest, CheckFileInfo) {
+TEST(TarArchiveReaderTest, CheckFileInfo)
+{
     String archive_path = "archive.tar";
     String filename = "file.txt";
     String contents = "test";
@@ -604,7 +599,8 @@ TEST(TarArchiveReaderTest, CheckFileInfo) {
     fs::remove(archive_path);
 }
 
-TEST(SevenZipArchiveReaderTest, FileExists) {
+TEST(SevenZipArchiveReaderTest, FileExists)
+{
     String archive_path = "archive.7z";
     String filename = "file.txt";
     String contents = "test";
@@ -615,7 +611,8 @@ TEST(SevenZipArchiveReaderTest, FileExists) {
     fs::remove(archive_path);
 }
 
-TEST(SevenZipArchiveReaderTest, ReadFile) {
+TEST(SevenZipArchiveReaderTest, ReadFile)
+{
     String archive_path = "archive.7z";
     String filename = "file.txt";
     String contents = "test";
@@ -629,7 +626,8 @@ TEST(SevenZipArchiveReaderTest, ReadFile) {
     fs::remove(archive_path);
 }
 
-TEST(SevenZipArchiveReaderTest, CheckFileInfo) {
+TEST(SevenZipArchiveReaderTest, CheckFileInfo)
+{
     String archive_path = "archive.7z";
     String filename = "file.txt";
     String contents = "test";
@@ -642,7 +640,8 @@ TEST(SevenZipArchiveReaderTest, CheckFileInfo) {
     fs::remove(archive_path);
 }
 
-TEST(SevenZipArchiveReaderTest, ReadTwoFiles) {
+TEST(SevenZipArchiveReaderTest, ReadTwoFiles)
+{
     String archive_path = "archive.7z";
     String file1 = "file1.txt";
     String contents1 = "test1";
@@ -658,28 +657,28 @@ TEST(SevenZipArchiveReaderTest, ReadTwoFiles) {
     readStringUntilEOF(str, *in);
     EXPECT_EQ(str, contents1);
     in = reader->readFile(file2, /*throw_on_not_found=*/true);
-    
+
     readStringUntilEOF(str, *in);
     EXPECT_EQ(str, contents2);
     fs::remove(archive_path);
 }
 
 
-
 namespace
 {
-    const char * supported_archive_file_exts[] =
-    {
-        #if USE_MINIZIP
-        ".zip",
-        #endif
-        #if USE_LIBARCHIVE
-        ".tar",
-        ".tar.gz",
-        ".tar.bz2",
-        ".tar.lzma",
-        #endif
-    };
+const char * supported_archive_file_exts[] = {
+#if USE_MINIZIP
+    ".zip",
+#endif
+#if USE_LIBARCHIVE
+    ".tar",
+    ".tar.gz",
+    ".tar.bz2",
+    ".tar.lzma",
+    ".tar.zst",
+    ".tar.xz",
+#endif
+};
 }
 
 INSTANTIATE_TEST_SUITE_P(All, ArchiveReaderAndWriterTest, ::testing::ValuesIn(supported_archive_file_exts));

--- a/src/IO/tests/gtest_archive_reader_and_writer.cpp
+++ b/src/IO/tests/gtest_archive_reader_and_writer.cpp
@@ -398,9 +398,9 @@ TEST_P(ArchiveReaderAndWriterTest, Password)
 {   
     auto writer = createArchiveWriter(getPathToArchive());
     //don't support passwords for tar archives
-    if(getPathToArchive().ends_with(".tar"))
+    if(getPathToArchive().ends_with(".tar") || getPathToArchive().ends_with(".tar.gz") || getPathToArchive().ends_with(".tar.bz2") || getPathToArchive().ends_with(".tar.lzma"))
     {
-        expectException(ErrorCodes::NOT_IMPLEMENTED, "Setting a password is not currently supported for tar archives",
+        expectException(ErrorCodes::NOT_IMPLEMENTED, "Setting a password is not currently supported for libarchive",
                 [&]{ writer->setPassword("a.txt"); });
         writer->finalize();
     }
@@ -675,6 +675,9 @@ namespace
         #endif
         #if USE_LIBARCHIVE
         ".tar",
+        ".tar.gz",
+        ".tar.bz2",
+        ".tar.lzma",
         #endif
     };
 }

--- a/tests/integration/test_backup_restore_new/test.py
+++ b/tests/integration/test_backup_restore_new/test.py
@@ -591,6 +591,57 @@ def test_zip_archive_with_bad_compression_method():
     )
 
 
+def test_tar_archive():
+    backup_name = f"Disk('backups', 'archive.tar')"
+    create_and_fill_table()
+
+    assert instance.query("SELECT count(), sum(x) FROM test.table") == "100\t4950\n"
+    instance.query(f"BACKUP TABLE test.table TO {backup_name}")
+
+    assert os.path.isfile(get_path_to_backup(backup_name))
+
+    instance.query("DROP TABLE test.table")
+    assert instance.query("EXISTS test.table") == "0\n"
+
+    instance.query(f"RESTORE TABLE test.table FROM {backup_name}")
+    assert instance.query("SELECT count(), sum(x) FROM test.table") == "100\t4950\n"
+
+
+def test_tar_archive_with_password():
+    backup_name = f"Disk('backups', 'archive_with_password.tar')"
+    create_and_fill_table()
+
+    assert instance.query("SELECT count(), sum(x) FROM test.table") == "100\t4950\n"
+
+    expected_error = "Setting a password is not currently supported for tar archives"
+    assert expected_error in instance.query_and_get_error(
+        f"BACKUP TABLE test.table TO {backup_name} SETTINGS id='tar_archive_with_password', password='password123'"
+    )
+    assert (
+        instance.query(
+            "SELECT status FROM system.backups WHERE id='tar_archive_with_password'"
+        )
+        == "BACKUP_FAILED\n"
+    )
+
+
+def test_tar_archive_with_bad_compression_method():
+    backup_name = f"Disk('backups', 'archive_with_bad_compression_method.tar')"
+    create_and_fill_table()
+
+    assert instance.query("SELECT count(), sum(x) FROM test.table") == "100\t4950\n"
+
+    expected_error = "Tar archives are currenly supported without compression"
+    assert expected_error in instance.query_and_get_error(
+        f"BACKUP TABLE test.table TO {backup_name} SETTINGS id='tar_archive_with_bad_compression_method', compression_method='foobar'"
+    )
+    assert (
+        instance.query(
+            "SELECT status FROM system.backups WHERE id='tar_archive_with_bad_compression_method'"
+        )
+        == "BACKUP_FAILED\n"
+    )
+
 def test_async():
     create_and_fill_table()
     assert instance.query("SELECT count(), sum(x) FROM test.table") == "100\t4950\n"

--- a/tests/integration/test_backup_restore_new/test.py
+++ b/tests/integration/test_backup_restore_new/test.py
@@ -607,13 +607,61 @@ def test_tar_archive():
     assert instance.query("SELECT count(), sum(x) FROM test.table") == "100\t4950\n"
 
 
+def test_tar_bz2_archive():
+    backup_name = f"Disk('backups', 'archive.tar.bz2')"
+    create_and_fill_table()
+
+    assert instance.query("SELECT count(), sum(x) FROM test.table") == "100\t4950\n"
+    instance.query(f"BACKUP TABLE test.table TO {backup_name}")
+
+    assert os.path.isfile(get_path_to_backup(backup_name))
+
+    instance.query("DROP TABLE test.table")
+    assert instance.query("EXISTS test.table") == "0\n"
+
+    instance.query(f"RESTORE TABLE test.table FROM {backup_name}")
+    assert instance.query("SELECT count(), sum(x) FROM test.table") == "100\t4950\n"
+
+
+def test_tar_gz_archive():
+    backup_name = f"Disk('backups', 'archive.tar.gz')"
+    create_and_fill_table()
+
+    assert instance.query("SELECT count(), sum(x) FROM test.table") == "100\t4950\n"
+    instance.query(f"BACKUP TABLE test.table TO {backup_name}")
+
+    assert os.path.isfile(get_path_to_backup(backup_name))
+
+    instance.query("DROP TABLE test.table")
+    assert instance.query("EXISTS test.table") == "0\n"
+
+    instance.query(f"RESTORE TABLE test.table FROM {backup_name}")
+    assert instance.query("SELECT count(), sum(x) FROM test.table") == "100\t4950\n"
+
+
+def test_tar_lzma_archive():
+    backup_name = f"Disk('backups', 'archive.tar.lzma')"
+    create_and_fill_table()
+
+    assert instance.query("SELECT count(), sum(x) FROM test.table") == "100\t4950\n"
+    instance.query(f"BACKUP TABLE test.table TO {backup_name}")
+
+    assert os.path.isfile(get_path_to_backup(backup_name))
+
+    instance.query("DROP TABLE test.table")
+    assert instance.query("EXISTS test.table") == "0\n"
+
+    instance.query(f"RESTORE TABLE test.table FROM {backup_name}")
+    assert instance.query("SELECT count(), sum(x) FROM test.table") == "100\t4950\n"
+
+
 def test_tar_archive_with_password():
     backup_name = f"Disk('backups', 'archive_with_password.tar')"
     create_and_fill_table()
 
     assert instance.query("SELECT count(), sum(x) FROM test.table") == "100\t4950\n"
 
-    expected_error = "Setting a password is not currently supported for tar archives"
+    expected_error = "Setting a password is not currently supported for libarchive"
     assert expected_error in instance.query_and_get_error(
         f"BACKUP TABLE test.table TO {backup_name} SETTINGS id='tar_archive_with_password', password='password123'"
     )

--- a/tests/integration/test_backup_restore_new/test.py
+++ b/tests/integration/test_backup_restore_new/test.py
@@ -679,7 +679,7 @@ def test_tar_archive_with_bad_compression_method():
 
     assert instance.query("SELECT count(), sum(x) FROM test.table") == "100\t4950\n"
 
-    expected_error = "Compressing tar archives is currently not supported"
+    expected_error = "Using compression_method and compression_level options are not supported for tar archives"
     assert expected_error in instance.query_and_get_error(
         f"BACKUP TABLE test.table TO {backup_name} SETTINGS id='tar_archive_with_bad_compression_method', compression_method='foobar'"
     )

--- a/tests/integration/test_backup_restore_new/test.py
+++ b/tests/integration/test_backup_restore_new/test.py
@@ -642,6 +642,7 @@ def test_tar_archive_with_bad_compression_method():
         == "BACKUP_FAILED\n"
     )
 
+
 def test_async():
     create_and_fill_table()
     assert instance.query("SELECT count(), sum(x) FROM test.table") == "100\t4950\n"

--- a/tests/integration/test_backup_restore_new/test.py
+++ b/tests/integration/test_backup_restore_new/test.py
@@ -655,6 +655,38 @@ def test_tar_lzma_archive():
     assert instance.query("SELECT count(), sum(x) FROM test.table") == "100\t4950\n"
 
 
+def test_tar_zst_archive():
+    backup_name = f"Disk('backups', 'archive.tar.zst')"
+    create_and_fill_table()
+
+    assert instance.query("SELECT count(), sum(x) FROM test.table") == "100\t4950\n"
+    instance.query(f"BACKUP TABLE test.table TO {backup_name}")
+
+    assert os.path.isfile(get_path_to_backup(backup_name))
+
+    instance.query("DROP TABLE test.table")
+    assert instance.query("EXISTS test.table") == "0\n"
+
+    instance.query(f"RESTORE TABLE test.table FROM {backup_name}")
+    assert instance.query("SELECT count(), sum(x) FROM test.table") == "100\t4950\n"
+
+
+def test_tar_xz_archive():
+    backup_name = f"Disk('backups', 'archive.tar.xz')"
+    create_and_fill_table()
+
+    assert instance.query("SELECT count(), sum(x) FROM test.table") == "100\t4950\n"
+    instance.query(f"BACKUP TABLE test.table TO {backup_name}")
+
+    assert os.path.isfile(get_path_to_backup(backup_name))
+
+    instance.query("DROP TABLE test.table")
+    assert instance.query("EXISTS test.table") == "0\n"
+
+    instance.query(f"RESTORE TABLE test.table FROM {backup_name}")
+    assert instance.query("SELECT count(), sum(x) FROM test.table") == "100\t4950\n"
+
+
 def test_tar_archive_with_password():
     backup_name = f"Disk('backups', 'archive_with_password.tar')"
     create_and_fill_table()

--- a/tests/integration/test_backup_restore_new/test.py
+++ b/tests/integration/test_backup_restore_new/test.py
@@ -631,7 +631,7 @@ def test_tar_archive_with_bad_compression_method():
 
     assert instance.query("SELECT count(), sum(x) FROM test.table") == "100\t4950\n"
 
-    expected_error = "tar archives are currenly supported without compression"
+    expected_error = "Compressing tar archives is currently not supported"
     assert expected_error in instance.query_and_get_error(
         f"BACKUP TABLE test.table TO {backup_name} SETTINGS id='tar_archive_with_bad_compression_method', compression_method='foobar'"
     )

--- a/tests/integration/test_backup_restore_new/test.py
+++ b/tests/integration/test_backup_restore_new/test.py
@@ -631,7 +631,7 @@ def test_tar_archive_with_bad_compression_method():
 
     assert instance.query("SELECT count(), sum(x) FROM test.table") == "100\t4950\n"
 
-    expected_error = "Tar archives are currenly supported without compression"
+    expected_error = "tar archives are currenly supported without compression"
     assert expected_error in instance.query_and_get_error(
         f"BACKUP TABLE test.table TO {backup_name} SETTINGS id='tar_archive_with_bad_compression_method', compression_method='foobar'"
     )

--- a/tests/integration/test_backup_restore_s3/test.py
+++ b/tests/integration/test_backup_restore_s3/test.py
@@ -482,6 +482,20 @@ def test_backup_to_tar_lzma():
     check_backup_and_restore(storage_policy, backup_destination)
 
 
+def test_backup_to_tar_zst():
+    storage_policy = "default"
+    backup_name = new_backup_name()
+    backup_destination = f"S3('http://minio1:9001/root/data/backups/{backup_name}.tar.zst', 'minio', 'minio123')"
+    check_backup_and_restore(storage_policy, backup_destination)
+
+
+def test_backup_to_tar_xz():
+    storage_policy = "default"
+    backup_name = new_backup_name()
+    backup_destination = f"S3('http://minio1:9001/root/data/backups/{backup_name}.tar.xz', 'minio', 'minio123')"
+    check_backup_and_restore(storage_policy, backup_destination)
+
+
 def test_user_specific_auth(start_cluster):
     def create_user(user):
         node.query(f"CREATE USER {user}")

--- a/tests/integration/test_backup_restore_s3/test.py
+++ b/tests/integration/test_backup_restore_s3/test.py
@@ -460,6 +460,28 @@ def test_backup_to_tar():
     backup_destination = f"S3('http://minio1:9001/root/data/backups/{backup_name}.tar', 'minio', 'minio123')"
     check_backup_and_restore(storage_policy, backup_destination)
 
+
+def test_backup_to_tar_gz():
+    storage_policy = "default"
+    backup_name = new_backup_name()
+    backup_destination = f"S3('http://minio1:9001/root/data/backups/{backup_name}.tar.gz', 'minio', 'minio123')"
+    check_backup_and_restore(storage_policy, backup_destination)
+
+
+def test_backup_to_tar_bz2():
+    storage_policy = "default"
+    backup_name = new_backup_name()
+    backup_destination = f"S3('http://minio1:9001/root/data/backups/{backup_name}.tar.bz2', 'minio', 'minio123')"
+    check_backup_and_restore(storage_policy, backup_destination)
+
+
+def test_backup_to_tar_lzma():
+    storage_policy = "default"
+    backup_name = new_backup_name()
+    backup_destination = f"S3('http://minio1:9001/root/data/backups/{backup_name}.tar.lzma', 'minio', 'minio123')"
+    check_backup_and_restore(storage_policy, backup_destination)
+
+
 def test_user_specific_auth(start_cluster):
     def create_user(user):
         node.query(f"CREATE USER {user}")

--- a/tests/integration/test_backup_restore_s3/test.py
+++ b/tests/integration/test_backup_restore_s3/test.py
@@ -453,6 +453,11 @@ def test_backup_to_zip():
     backup_destination = f"S3('http://minio1:9001/root/data/backups/{backup_name}.zip', 'minio', 'minio123')"
     check_backup_and_restore(storage_policy, backup_destination)
 
+def test_backup_to_tar():
+    storage_policy = "default"
+    backup_name = new_backup_name()
+    backup_destination = f"S3('http://minio1:9001/root/data/backups/{backup_name}.tar', 'minio', 'minio123')"
+    check_backup_and_restore(storage_policy, backup_destination)
 
 def test_user_specific_auth(start_cluster):
     def create_user(user):

--- a/tests/integration/test_backup_restore_s3/test.py
+++ b/tests/integration/test_backup_restore_s3/test.py
@@ -453,6 +453,7 @@ def test_backup_to_zip():
     backup_destination = f"S3('http://minio1:9001/root/data/backups/{backup_name}.zip', 'minio', 'minio123')"
     check_backup_and_restore(storage_policy, backup_destination)
 
+
 def test_backup_to_tar():
     storage_policy = "default"
     backup_name = new_backup_name()


### PR DESCRIPTION

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- New Feature


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Support reading and writing backups as tar archives.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

This change allows tables to be backed up as tar archives. I.E `BACKUP TABLE test.table TO Disk('backups', '1.tar')` and `RESTORE TABLE test.table FROM Disk('backups', '1.tar')`. Compressing the archives and setting passwords is not currently supported.

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

