### PR TITLE
Fixed version for `kazoo` in integration runner

### DIFF
--- a/docker/test/integration/runner/Dockerfile
+++ b/docker/test/integration/runner/Dockerfile
@@ -79,7 +79,7 @@ RUN python3 -m pip install --no-cache-dir \
     grpcio \
     grpcio-tools \
     kafka-python \
-    kazoo \
+    kazoo=2.9.0 \
     lz4 \
     minio \
     nats-py \


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


New version of `kazoo` for some reason makes Keeper integration tests flaky.
It seems closing session doesn't wait until the session is actually closed on the Keeper/ZK side and it continues to execute code instantly after it.
If the code relies on the fact that the session is closed (e.g. cleaned ephemeral nodes) it will fail.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
