### PR TITLE
[minor] Do not run clickhouse-local if it's disabled in CMAKE

### DIFF
--- a/programs/main.cpp
+++ b/programs/main.cpp
@@ -509,9 +509,10 @@ int main(int argc_, char ** argv_)
     ///     clickhouse # spawn local
     ///     clickhouse local # spawn local
     ///
+#if ENABLE_CLICKHOUSE_LOCAL
     if (main_func == printHelp && !argv.empty() && (argv.size() == 1 || argv[1][0] == '-'))
         main_func = mainEntryClickHouseLocal;
-
+#endif
     return main_func(static_cast<int>(argv.size()), argv.data());
 }
 #endif


### PR DESCRIPTION
If ENABLE_CLICKHOUSE_LOCAL is disabled in cmake, don't run `clickhouse-local` as the default binary.
This fixed the following compile-time error (compile with ENABLE_CLICKHOUSE_LOCAL=0):
```
/home/anton/clickhouse/programs/main.cpp:513:21: error: use of undeclared identifier 'mainEntryClickHouseLocal'
        main_func = mainEntryClickHouseLocal;
                    ^
1 error generated.
ninja: build stopped: subcommand failed.
```

### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Do not run clickhouse-local by default if it's disabled

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
