### PR TITLE
Updated a list of trusted contributors

### DIFF
--- a/tests/ci/lambda_shared_package/lambda_shared/pr.py
+++ b/tests/ci/lambda_shared_package/lambda_shared/pr.py
@@ -43,7 +43,7 @@ TRUSTED_CONTRIBUTORS = {
         "tsolodov",  # ClickHouse, Inc
         "kitaisreal",
         "k-morozov",  # Konstantin Morozov, Yandex Cloud
-        "justindeguzman", # ClickHouse, Inc
+        "justindeguzman",  # ClickHouse, Inc
     ]
 }
 

--- a/tests/ci/lambda_shared_package/lambda_shared/pr.py
+++ b/tests/ci/lambda_shared_package/lambda_shared/pr.py
@@ -43,6 +43,7 @@ TRUSTED_CONTRIBUTORS = {
         "tsolodov",  # ClickHouse, Inc
         "kitaisreal",
         "k-morozov",  # Konstantin Morozov, Yandex Cloud
+        "justindeguzman", # ClickHouse, Inc
     ]
 }
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Added @justindeguzman to the list of trusted contributors. 