### PR TITLE
Trivial optimize on ifNotNull with intel AVX2 

### DIFF
--- a/src/Functions/isNotNull.cpp
+++ b/src/Functions/isNotNull.cpp
@@ -1,30 +1,31 @@
-#include <Functions/IFunction.h>
-#include <Functions/FunctionHelpers.h>
-#include <Functions/FunctionFactory.h>
-#include <DataTypes/DataTypesNumber.h>
-#include <Core/ColumnNumbers.h>
-#include <Columns/ColumnNullable.h>
 #include <Columns/ColumnLowCardinality.h>
+#include <Columns/ColumnNullable.h>
 #include <Columns/ColumnVariant.h>
+#include <Core/ColumnNumbers.h>
+#include <DataTypes/DataTypesNumber.h>
+#include <Functions/FunctionFactory.h>
+#include <Functions/FunctionHelpers.h>
+#include <Functions/IFunction.h>
+#include <Functions/PerformanceAdaptors.h>
 #include <Common/assert_cast.h>
-
 
 namespace DB
 {
 namespace
 {
 
+
+#define DECLARE_SEVERAL_IMPLEMENTATIONS(...) \
+DECLARE_DEFAULT_CODE      (__VA_ARGS__) \
+DECLARE_AVX2_SPECIFIC_CODE(__VA_ARGS__)
+
+DECLARE_SEVERAL_IMPLEMENTATIONS(
 /// Implements the function isNotNull which returns true if a value
 /// is not null, false otherwise.
 class FunctionIsNotNull : public IFunction
 {
 public:
     static constexpr auto name = "isNotNull";
-
-    static FunctionPtr create(ContextPtr)
-    {
-        return std::make_shared<FunctionIsNotNull>();
-    }
 
     std::string getName() const override
     {
@@ -52,9 +53,9 @@ public:
             const auto & discriminators = checkAndGetColumn<ColumnVariant>(*elem.column)->getLocalDiscriminators();
             auto res = DataTypeUInt8().createColumn();
             auto & data = typeid_cast<ColumnUInt8 &>(*res).getData();
-            data.reserve(discriminators.size());
-            for (auto discr : discriminators)
-                data.push_back(discr != ColumnVariant::NULL_DISCRIMINATOR);
+            data.resize(discriminators.size());
+            for (size_t i = 0; i < discriminators.size(); ++i)
+                data[i] = discriminators[i] != ColumnVariant::NULL_DISCRIMINATOR;
             return res;
         }
 
@@ -64,9 +65,9 @@ public:
             const size_t null_index = low_cardinality_column->getDictionary().getNullValueIndex();
             auto res = DataTypeUInt8().createColumn();
             auto & data = typeid_cast<ColumnUInt8 &>(*res).getData();
-            data.reserve(low_cardinality_column->size());
+            data.resize(low_cardinality_column->size());
             for (size_t i = 0; i != low_cardinality_column->size(); ++i)
-                data.push_back(low_cardinality_column->getIndexAt(i) != null_index);
+                data[i] = (low_cardinality_column->getIndexAt(i) != null_index);
             return res;
         }
 
@@ -88,6 +89,64 @@ public:
             return DataTypeUInt8().createColumnConst(elem.column->size(), 1u);
         }
     }
+
+private:
+    MULTITARGET_FUNCTION_AVX2_SSE42(
+    MULTITARGET_FUNCTION_HEADER(static void NO_INLINE), vectorImpl, MULTITARGET_FUNCTION_BODY((const PaddedPODArray<UInt8> & null_map, PaddedPODArray<UInt8> & res) /// NOLINT
+    {
+        size_t size = null_map.size();
+        for (size_t i = 0; i < size; ++i)
+            res[i] = !null_map[i];
+    }))
+
+    static void NO_INLINE vector(const PaddedPODArray<UInt8> & null_map, PaddedPODArray<UInt8> & res)
+    {
+#if USE_MULTITARGET_CODE
+        if (isArchSupported(TargetArch::AVX2))
+        {
+            vectorImplAVX2(null_map, res);
+            return;
+        }
+
+        if (isArchSupported(TargetArch::SSE42))
+        {
+            vectorImplSSE42(null_map, res);
+            return;
+        }
+#endif
+        vectorImpl(null_map, res);
+    }
+};
+
+) // DECLARE_SEVERAL_IMPLEMENTATIONS
+#undef DECLARE_SEVERAL_IMPLEMENTATIONS
+
+class FunctionIsNotNull : public TargetSpecific::Default::FunctionIsNotNull
+{
+public:
+    explicit FunctionIsNotNull(ContextPtr context) : selector(context)
+    {
+        selector.registerImplementation<TargetArch::Default,
+            TargetSpecific::Default::FunctionIsNotNull>();
+
+    #if USE_MULTITARGET_CODE
+        selector.registerImplementation<TargetArch::AVX2,
+            TargetSpecific::AVX2::FunctionIsNotNull>();
+    #endif
+    }
+
+    ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type, size_t input_rows_count) const override
+    {
+        return selector.selectAndExecute(arguments, result_type, input_rows_count);
+    }
+
+    static FunctionPtr create(ContextPtr context)
+    {
+        return std::make_shared<FunctionIsNotNull>(context);
+    }
+
+private:
+    ImplementationSelector<IFunction> selector;
 };
 
 }


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement



### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Optimized function `isNotNull` with AVX2.

### Details:

Micro benchmarks: https://github.com/bigo-sg/gluten/commit/b1fbaaeb6d1e3edd83c4158993c31e6a2adc5d3d 
``` 
Run on (32 X 2100 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x16)
  L1 Instruction 32 KiB (x16)
  L2 Unified 1024 KiB (x16)
  L3 Unified 11264 KiB (x2)
Load Average: 4.47, 4.43, 4.74
-------------------------------------------------------------------
Benchmark                         Time             CPU   Iterations
-------------------------------------------------------------------
BM_isNotNull                   3884 ns         3884 ns       180237
BM_isNotNullSSE42              3893 ns         3893 ns       179702
BM_isNotNullAVX2               2983 ns         2982 ns       236436
BM_isNotNullAVX512F            2856 ns         2855 ns       239358
BM_isNotNullAVX512BW           2968 ns         2968 ns       238690
``` 

Use AVX2 for isNotNull is fast enough to avoid too much code.  Let's see if performance test in CI shows any benefit 
