### PR TITLE
Trivial optimize of function coalesce. 

### DIFF
--- a/src/Functions/coalesce.cpp
+++ b/src/Functions/coalesce.cpp
@@ -29,7 +29,12 @@ public:
         return std::make_shared<FunctionCoalesce>(context);
     }
 
-    explicit FunctionCoalesce(ContextPtr context_) : context(context_) {}
+    explicit FunctionCoalesce(ContextPtr context_)
+        : context(context_)
+        , is_not_null(FunctionFactory::instance().get("isNotNull", context))
+        , assume_not_null(FunctionFactory::instance().get("assumeNotNull", context))
+    {
+    }
 
     std::string getName() const override
     {
@@ -110,8 +115,7 @@ public:
                 break;
         }
 
-        auto is_not_null = FunctionFactory::instance().get("isNotNull", context);
-        auto assume_not_null = FunctionFactory::instance().get("assumeNotNull", context);
+
 
         ColumnsWithTypeAndName multi_if_args;
         ColumnsWithTypeAndName tmp_args(1);
@@ -170,6 +174,8 @@ public:
 
 private:
     ContextPtr context;
+    FunctionOverloadResolverPtr is_not_null;
+    FunctionOverloadResolverPtr assume_not_null;
 };
 
 }

--- a/src/Functions/coalesce.cpp
+++ b/src/Functions/coalesce.cpp
@@ -33,6 +33,8 @@ public:
         : context(context_)
         , is_not_null(FunctionFactory::instance().get("isNotNull", context))
         , assume_not_null(FunctionFactory::instance().get("assumeNotNull", context))
+        , if_function(FunctionFactory::instance().get("if", context))
+        , multi_if_function(FunctionFactory::instance().get("multiIf", context))
     {
     }
 
@@ -150,13 +152,8 @@ public:
         /// If there was only two arguments (3 arguments passed to multiIf)
         /// use function "if" instead, because it's implemented more efficient.
         /// TODO: make "multiIf" the same efficient.
-        FunctionOverloadResolverPtr if_function;
-        if (multi_if_args.size() == 3)
-            if_function = FunctionFactory::instance().get("if", context);
-        else
-            if_function = FunctionFactory::instance().get("multiIf", context);
-
-        ColumnPtr res = if_function->build(multi_if_args)->execute(multi_if_args, result_type, input_rows_count);
+        FunctionOverloadResolverPtr if_or_multi_if = multi_if_args.size() == 3 ? if_function : multi_if_function;
+        ColumnPtr res = if_or_multi_if->build(multi_if_args)->execute(multi_if_args, result_type, input_rows_count);
 
         /// if last argument is not nullable, result should be also not nullable
         if (!multi_if_args.back().column->isNullable() && res->isNullable())
@@ -176,6 +173,8 @@ private:
     ContextPtr context;
     FunctionOverloadResolverPtr is_not_null;
     FunctionOverloadResolverPtr assume_not_null;
+    FunctionOverloadResolverPtr if_function;
+    FunctionOverloadResolverPtr multi_if_function;
 };
 
 }

--- a/src/Functions/coalesce.cpp
+++ b/src/Functions/coalesce.cpp
@@ -116,7 +116,6 @@ public:
         }
 
 
-
         ColumnsWithTypeAndName multi_if_args;
         ColumnsWithTypeAndName tmp_args(1);
 

--- a/tests/performance/coalesce.xml
+++ b/tests/performance/coalesce.xml
@@ -1,0 +1,3 @@
+<test>
+    <query>select coalesce(materialize(null), -1) from numbers(1000000000) format Null settings max_block_size = 8192</query>
+</test>


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Reuse the result of `FunctionFactory::instance().get("isNotNull", context)` and `FunctionFactory::instance().get("assumeNotNull", context)`. Make sure it is called once during the lifetime of `FunctionCoalesce`. 


Notice that the cost of `FunctionFactory::instance().get` can't be ignored during the execution of function `coalesce`. In my tests: 
- `executeImpl` costs 68068 ns
- `FunctionFactory::instance().get` inside `executeImpl` costs 9537 ns, which is 14% of `executeImpl`

``` sql 
select coalesce(materialize(null), -1) from numbers(1000000000) format Null settings max_block_size = 8192;  
Old: 0 rows in set. Elapsed: 2.478 sec. Processed 1.00 billion rows, 8.00 GB (403.61 million rows/s., 3.23 GB/s.)
New: 0 rows in set. Elapsed: 2.321 sec. Processed 1.00 billion rows, 8.00 GB (430.86 million rows/s., 3.45 GB/s.)
```  





