### PR TITLE
Maintain function alias in RewriteSumFunctionWithSumAndCountVisitor

### DIFF
--- a/src/Interpreters/RewriteSumFunctionWithSumAndCountVisitor.cpp
+++ b/src/Interpreters/RewriteSumFunctionWithSumAndCountVisitor.cpp
@@ -100,7 +100,10 @@ void RewriteSumFunctionWithSumAndCountMatcher::visit(const ASTFunction & functio
         if (!new_ast)
             return;
         else
+        {
+            new_ast->setAlias(ast->tryGetAlias());
             ast = new_ast;
+        }
     }
     else if (column_id == 1)
     {
@@ -116,7 +119,10 @@ void RewriteSumFunctionWithSumAndCountMatcher::visit(const ASTFunction & functio
         if (!new_ast)
             return;
         else
+        {
+            new_ast->setAlias(ast->tryGetAlias());
             ast = new_ast;
+        }
     }
 }
 

--- a/tests/queries/0_stateless/02931_rewrite_sum_column_and_constant.reference
+++ b/tests/queries/0_stateless/02931_rewrite_sum_column_and_constant.reference
@@ -47,24 +47,24 @@ SELECT sum(uint64) + (1 * count(uint64))
 FROM test_table
 WHERE ((uint64 + 1) AS i) > 0
 EXPLAIN SYNTAX (SELECT sum(uint64 + 1) AS j from test_table having j > 0);
-SELECT sum(uint64) + (1 * count(uint64))
+SELECT sum(uint64) + (1 * count(uint64)) AS j
 FROM test_table
-HAVING (sum(uint64) + (1 * count(uint64))) > 0
+HAVING j > 0
 EXPLAIN SYNTAX (SELECT sum(uint64 + 1 AS i) j from test_table where i > 0 having j > 0);
-SELECT sum(uint64) + (1 * count(uint64))
+SELECT sum(uint64) + (1 * count(uint64)) AS j
 FROM test_table
 WHERE ((uint64 + 1) AS i) > 0
-HAVING (sum(uint64) + (1 * count(uint64))) > 0
+HAVING j > 0
 EXPLAIN SYNTAX (SELECT sum((uint64 AS m) + (1 AS n)) j from test_table where m > 0 and n > 0 having j > 0);
-SELECT sum(uint64) + ((1 AS n) * count(uint64))
+SELECT sum(uint64) + ((1 AS n) * count(uint64)) AS j
 FROM test_table
 WHERE ((uint64 AS m) > 0) AND (n > 0)
-HAVING (sum(uint64) + (n * count(uint64))) > 0
+HAVING j > 0
 EXPLAIN SYNTAX (SELECT sum(((uint64 AS m) + (1 AS n)) AS i) j from test_table where m > 0 and n > 0 and i > 0 having j > 0);
-SELECT sum(uint64) + ((1 AS n) * count(uint64))
+SELECT sum(uint64) + ((1 AS n) * count(uint64)) AS j
 FROM test_table
 WHERE ((uint64 AS m) > 0) AND (n > 0) AND (((m + n) AS i) > 0)
-HAVING (sum(uint64) + (n * count(uint64))) > 0
+HAVING j > 0
 SELECT sum(1 + uint64 AS i) from test_table where i > 0;
 20
 SELECT sum(1 + uint64) AS j from test_table having j > 0;
@@ -80,24 +80,24 @@ SELECT (1 * count(uint64)) + sum(uint64)
 FROM test_table
 WHERE ((1 + uint64) AS i) > 0
 EXPLAIN SYNTAX (SELECT sum(1 + uint64) AS j from test_table having j > 0);
-SELECT (1 * count(uint64)) + sum(uint64)
+SELECT (1 * count(uint64)) + sum(uint64) AS j
 FROM test_table
-HAVING ((1 * count(uint64)) + sum(uint64)) > 0
+HAVING j > 0
 EXPLAIN SYNTAX (SELECT sum(1 + uint64 AS i) j from test_table where i > 0 having j > 0);
-SELECT (1 * count(uint64)) + sum(uint64)
+SELECT (1 * count(uint64)) + sum(uint64) AS j
 FROM test_table
 WHERE ((1 + uint64) AS i) > 0
-HAVING ((1 * count(uint64)) + sum(uint64)) > 0
+HAVING j > 0
 EXPLAIN SYNTAX (SELECT sum((1 AS m) + (uint64 AS n)) j from test_table where m > 0 and n > 0 having j > 0);
-SELECT ((1 AS m) * count(uint64)) + sum(uint64)
+SELECT ((1 AS m) * count(uint64)) + sum(uint64) AS j
 FROM test_table
 WHERE (m > 0) AND ((uint64 AS n) > 0)
-HAVING ((m * count(uint64)) + sum(uint64)) > 0
+HAVING j > 0
 EXPLAIN SYNTAX (SELECT sum(((1 AS m) + (uint64 AS n)) AS i) j from test_table where m > 0 and n > 0 and i > 0 having j > 0);
-SELECT ((1 AS m) * count(uint64)) + sum(uint64)
+SELECT ((1 AS m) * count(uint64)) + sum(uint64) AS j
 FROM test_table
 WHERE (m > 0) AND ((uint64 AS n) > 0) AND (((m + n) AS i) > 0)
-HAVING ((m * count(uint64)) + sum(uint64)) > 0
+HAVING j > 0
 SELECT sum(uint64 - 1 AS i) from test_table where i > 0;
 10
 SELECT sum(uint64 - 1) AS j from test_table having j > 0;
@@ -113,24 +113,24 @@ SELECT sum(uint64) - (1 * count(uint64))
 FROM test_table
 WHERE ((uint64 - 1) AS i) > 0
 EXPLAIN SYNTAX (SELECT sum(uint64 - 1) AS j from test_table having j > 0);
-SELECT sum(uint64) - (1 * count(uint64))
+SELECT sum(uint64) - (1 * count(uint64)) AS j
 FROM test_table
-HAVING (sum(uint64) - (1 * count(uint64))) > 0
+HAVING j > 0
 EXPLAIN SYNTAX (SELECT sum(uint64 - 1 AS i) j from test_table where i > 0 having j > 0);
-SELECT sum(uint64) - (1 * count(uint64))
+SELECT sum(uint64) - (1 * count(uint64)) AS j
 FROM test_table
 WHERE ((uint64 - 1) AS i) > 0
-HAVING (sum(uint64) - (1 * count(uint64))) > 0
+HAVING j > 0
 EXPLAIN SYNTAX (SELECT sum((uint64 AS m) - (1 AS n)) j from test_table where m > 0 and n > 0 having j > 0);
-SELECT sum(uint64) - ((1 AS n) * count(uint64))
+SELECT sum(uint64) - ((1 AS n) * count(uint64)) AS j
 FROM test_table
 WHERE ((uint64 AS m) > 0) AND (n > 0)
-HAVING (sum(uint64) - (n * count(uint64))) > 0
+HAVING j > 0
 EXPLAIN SYNTAX (SELECT sum(((uint64 AS m) - (1 AS n)) AS i) j from test_table where m > 0 and n > 0 and i > 0 having j > 0);
-SELECT sum(uint64) - ((1 AS n) * count(uint64))
+SELECT sum(uint64) - ((1 AS n) * count(uint64)) AS j
 FROM test_table
 WHERE ((uint64 AS m) > 0) AND (n > 0) AND (((m - n) AS i) > 0)
-HAVING (sum(uint64) - (n * count(uint64))) > 0
+HAVING j > 0
 SELECT sum(1 - uint64 AS i) from test_table;
 -10
 SELECT sum(1 - uint64) AS j from test_table;
@@ -146,24 +146,24 @@ SELECT (1 * count(uint64)) - sum(uint64)
 FROM test_table
 WHERE ((1 - uint64) AS i) > 0
 EXPLAIN SYNTAX (SELECT sum(1 - uint64) AS j from test_table having j < 0);
-SELECT (1 * count(uint64)) - sum(uint64)
+SELECT (1 * count(uint64)) - sum(uint64) AS j
 FROM test_table
-HAVING ((1 * count(uint64)) - sum(uint64)) < 0
+HAVING j < 0
 EXPLAIN SYNTAX (SELECT sum(1 - uint64 AS i) j from test_table where i > 0 having j < 0);
-SELECT (1 * count(uint64)) - sum(uint64)
+SELECT (1 * count(uint64)) - sum(uint64) AS j
 FROM test_table
 WHERE ((1 - uint64) AS i) > 0
-HAVING ((1 * count(uint64)) - sum(uint64)) < 0
+HAVING j < 0
 EXPLAIN SYNTAX (SELECT sum((1 AS m) - (uint64 AS n)) j from test_table where m > 0 and n > 0 having j < 0);
-SELECT ((1 AS m) * count(uint64)) - sum(uint64)
+SELECT ((1 AS m) * count(uint64)) - sum(uint64) AS j
 FROM test_table
 WHERE (m > 0) AND ((uint64 AS n) > 0)
-HAVING ((m * count(uint64)) - sum(uint64)) < 0
+HAVING j < 0
 EXPLAIN SYNTAX (SELECT sum(((1 AS m) - (uint64 AS n)) AS i) j from test_table where m > 0 and n > 0 and i < 0 having j < 0);
-SELECT ((1 AS m) * count(uint64)) - sum(uint64)
+SELECT ((1 AS m) * count(uint64)) - sum(uint64) AS j
 FROM test_table
 WHERE (m > 0) AND ((uint64 AS n) > 0) AND (((m - n) AS i) < 0)
-HAVING ((m * count(uint64)) - sum(uint64)) < 0
+HAVING j < 0
 SELECT sum(uint64 + 2.11) From test_table;
 25.549999999999997
 SELECT sum(2.11 + uint64) From test_table;
@@ -473,4 +473,12 @@ SELECT (sum(decimal32) - (2 * count(decimal32))) - (sum(decimal32) - (3 * count(
 FROM test_table
 EXPLAIN SYNTAX (SELECT (2 * count(decimal32) - sum(decimal32)) + (3 * count(decimal32) - sum(decimal32)) From test_table);
 SELECT ((2 * count(decimal32)) - sum(decimal32)) + ((3 * count(decimal32)) - sum(decimal32))
+FROM test_table
+-- https://github.com/ClickHouse/ClickHouse/issues/59414
+SELECT sum(uint64 + 2) as j, j + 5 as t from test_table;
+25	30
+EXPLAIN SYNTAX SELECT sum(uint64 + 2) as j, j + 5 as t from test_table;
+SELECT
+    sum(uint64) + (2 * count(uint64)) AS j,
+    j + 5 AS t
 FROM test_table

--- a/tests/queries/0_stateless/02931_rewrite_sum_column_and_constant.sql
+++ b/tests/queries/0_stateless/02931_rewrite_sum_column_and_constant.sql
@@ -204,6 +204,11 @@ EXPLAIN SYNTAX (SELECT (sum(decimal32) + 2 * count(decimal32)) - (sum(decimal32)
 EXPLAIN SYNTAX (SELECT (sum(decimal32) - 2 * count(decimal32)) + (sum(decimal32) - 3 * count(decimal32)) From test_table);
 EXPLAIN SYNTAX (SELECT (sum(decimal32) - 2 * count(decimal32)) - (sum(decimal32) - 3 * count(decimal32)) From test_table);
 EXPLAIN SYNTAX (SELECT (2 * count(decimal32) - sum(decimal32)) + (3 * count(decimal32) - sum(decimal32)) From test_table);
+
+-- https://github.com/ClickHouse/ClickHouse/issues/59414
+SELECT sum(uint64 + 2) as j, j + 5 as t from test_table;
+EXPLAIN SYNTAX SELECT sum(uint64 + 2) as j, j + 5 as t from test_table;
 -- { echoOff }
+
 
 DROP TABLE IF EXISTS test_table;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Maintain function alias in RewriteSumFunctionWithSumAndCountVisitor

### Documentation entry for user-facing changes

Introduced in https://github.com/ClickHouse/ClickHouse/pull/57853.
Closes https://github.com/ClickHouse/ClickHouse/issues/59414
