### PR TITLE
Improvement: move self-extracted binary instead copying.

### DIFF
--- a/utils/self-extracting-executable/decompressor.cpp
+++ b/utils/self-extracting-executable/decompressor.cpp
@@ -322,6 +322,8 @@ int decompressFiles(int input_fd, char * path, char * name, bool & have_compress
             return 1;
         }
 
+        if (0 != munmap(output, le64toh(file_info.uncompressed_size)))
+            perror("munmap");
         if (0 != fsync(output_fd))
             perror("fsync");
         if (0 != close(output_fd))
@@ -528,10 +530,10 @@ int main(int/* argc*/, char* argv[])
         (void)snprintf(decompressed_name, decompressed_name_len + 1, decompressed_name_fmt, self, decompressed_suffix);
 
         std::error_code ec;
-        std::filesystem::copy_file(static_cast<char *>(decompressed_name), static_cast<char *>(self), ec);
-        if (ec)
+
+        if (link(decompressed_name, self))
         {
-            std::cerr << ec.message() << std::endl;
+            perror("link");
             return 1;
         }
 


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
After self-extraction temporary binary is moved instead copying.
