### PR TITLE
Unquote FLAG_LATEST to fix issue with empty argument

### DIFF
--- a/.github/workflows/reusable_docker.yml
+++ b/.github/workflows/reusable_docker.yml
@@ -63,4 +63,4 @@ jobs:
           python3 docker_manifests_merge.py --suffix amd64 --suffix aarch64 \
             --image-tags '${{ toJson(fromJson(inputs.data).docker_data.images) }}' \
             --missing-images '${{ toJson(fromJson(inputs.data).docker_data.missing_multi) }}' \
-            "$FLAG_LATEST"
+            $FLAG_LATEST


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix the bug caused by my suggestion https://github.com/ClickHouse/ClickHouse/actions/runs/7792048834/job/21250007538?pr=51243#step:4:59 

It was quoted to avoid [SC2086](https://www.shellcheck.net/wiki/SC2086), but when the `FLAG_LATEST` does not contain spaces, it's fine.