### PR TITLE
Insert synchronously if dependent MV deduplication is enabled

### DIFF
--- a/src/Interpreters/executeQuery.cpp
+++ b/src/Interpreters/executeQuery.cpp
@@ -933,6 +933,8 @@ static std::tuple<ASTPtr, BlockIO> executeQueryImpl(
                 reason = "asynchronous insert queue is not configured";
             else if (insert_query->select)
                 reason = "insert query has select";
+            else if (settings.deduplicate_blocks_in_dependent_materialized_views)
+                reason = "dependent materialized views block deduplication is enabled";
             else if (insert_query->hasInlinedData())
                 async_insert = true;
 

--- a/src/Server/TCPHandler.cpp
+++ b/src/Server/TCPHandler.cpp
@@ -933,7 +933,7 @@ void TCPHandler::processInsertQuery()
         if (auto table = DatabaseCatalog::instance().tryGetTable(insert_query.table_id, query_context))
             async_insert_enabled |= table->areAsynchronousInsertsEnabled();
 
-    if (insert_queue && async_insert_enabled && !insert_query.select)
+    if (insert_queue && async_insert_enabled && !insert_query.select && !settings.deduplicate_blocks_in_dependent_materialized_views)
     {
         auto result = processAsyncInsertQuery(*insert_queue);
         if (result.status == AsynchronousInsertQueue::PushResult::OK)

--- a/tests/queries/0_stateless/02985_disable_async_inserts_for_dependent_mv_dedup.reference
+++ b/tests/queries/0_stateless/02985_disable_async_inserts_for_dependent_mv_dedup.reference
@@ -1,0 +1,1 @@
+Values	Ok	4	Parsed

--- a/tests/queries/0_stateless/02985_disable_async_inserts_for_dependent_mv_dedup.sql
+++ b/tests/queries/0_stateless/02985_disable_async_inserts_for_dependent_mv_dedup.sql
@@ -1,0 +1,46 @@
+-- Tags: no-parallel
+
+SET async_insert = 1;
+SET insert_deduplicate = 1;
+SET deduplicate_blocks_in_dependent_materialized_views = 1;
+
+DROP TABLE IF EXISTS 02985_test;
+CREATE TABLE 02985_test
+(
+    d Date,
+    value UInt64
+) ENGINE = MergeTree ORDER BY tuple() SETTINGS non_replicated_deduplication_window = 1000;
+
+DROP VIEW IF EXISTS 02985_mv;
+CREATE MATERIALIZED VIEW 02985_mv
+ENGINE = SummingMergeTree ORDER BY d AS
+SELECT
+    d, sum(value) s
+FROM 02985_test GROUP BY d;
+
+-- Inserts are synchronous.
+INSERT INTO 02985_test (*)
+VALUES ('2024-01-01', 1), ('2024-01-01', 2), ('2024-01-02', 1);
+
+SYSTEM FLUSH LOGS;
+
+SELECT format, status, rows, data_kind  FROM system.asynchronous_insert_log
+WHERE database = currentDatabase() AND table = '02985_test';
+
+SET deduplicate_blocks_in_dependent_materialized_views = 0;
+
+-- Set a large value for async_insert_busy_timeout_max_ms to avoid flushing the entry synchronously.
+INSERT INTO 02985_test (*)
+SETTINGS
+    async_insert_busy_timeout_min_ms=200,
+    async_insert_busy_timeout_max_ms=100000
+VALUES ('2024-01-01', 1), ('2024-01-01', 2), ('2024-01-02', 1), ('2024-01-02', 4);
+
+SYSTEM FLUSH LOGS;
+
+SELECT format, status, rows, data_kind
+FROM system.asynchronous_insert_log
+WHERE database = currentDatabase() AND table = '02985_test';
+
+DROP VIEW IF EXISTS 02985_mv;
+DROP TABLE IF EXISTS 02985_test;


### PR DESCRIPTION

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Perform synchronous inserts if dependent MV deduplication is enabled through deduplicate_blocks_in_dependent_materialized_views=1. 

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
