### PR TITLE
Add test for increase-always autoscaling lambda

### DIFF
--- a/tests/ci/autoscale_runners_lambda/app.py
+++ b/tests/ci/autoscale_runners_lambda/app.py
@@ -8,11 +8,10 @@ from pprint import pformat
 from typing import Any, List, Literal, Optional, Tuple
 
 import boto3  # type: ignore
-
 from lambda_shared import (
+    RUNNER_TYPE_LABELS,
     CHException,
     ClickHouseHelper,
-    RUNNER_TYPE_LABELS,
     get_parameter_from_ssm,
 )
 
@@ -115,6 +114,8 @@ def set_capacity(
         # Are we already at the capacity limits
         stop = stop or asg["MaxSize"] <= asg["DesiredCapacity"]
         # Let's calculate a new desired capacity
+        # (capacity_deficit + scale_up - 1) // scale_up : will increase min by 1
+        # if there is any capacity_deficit
         desired_capacity = (
             asg["DesiredCapacity"] + (capacity_deficit + scale_up - 1) // scale_up
         )

--- a/tests/ci/autoscale_runners_lambda/test_autoscale.py
+++ b/tests/ci/autoscale_runners_lambda/test_autoscale.py
@@ -4,7 +4,7 @@ import unittest
 from dataclasses import dataclass
 from typing import Any, List
 
-from app import set_capacity, Queue
+from app import Queue, set_capacity
 
 
 @dataclass
@@ -68,10 +68,16 @@ class TestSetCapacity(unittest.TestCase):
         test_cases = (
             # Do not change capacity
             TestCase("noqueue", 1, 13, 20, [Queue("in_progress", 155, "noqueue")], -1),
-            TestCase(
-                "w/reserve-1", 1, 13, 20, [Queue("queued", 15, "w/reserve-1")], 14
-            ),
+            TestCase("reserve", 1, 13, 20, [Queue("queued", 13, "reserve")], -1),
             # Increase capacity
+            TestCase(
+                "increase-always",
+                1,
+                13,
+                20,
+                [Queue("queued", 14, "increase-always")],
+                14,
+            ),
             TestCase("increase-1", 1, 13, 20, [Queue("queued", 23, "increase-1")], 17),
             TestCase(
                 "style-checker", 1, 13, 20, [Queue("queued", 33, "style-checker")], 20


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add comment and test for autoscaling lambda. Now, it increases the desired capacity at least for one on deficit.