### PR TITLE
Make ZooKeeper actually sequentialy consistent

### DIFF
--- a/src/Common/ZooKeeper/ZooKeeperImpl.cpp
+++ b/src/Common/ZooKeeper/ZooKeeperImpl.cpp
@@ -401,6 +401,9 @@ ZooKeeper::ZooKeeper(
         keeper_feature_flags.logFlags(log);
 
         ProfileEvents::increment(ProfileEvents::ZooKeeperInit);
+
+        /// Avoid stale reads after connecting
+        sync("/", [](const SyncResponse &){});
     }
     catch (...)
     {


### PR DESCRIPTION

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Allowing stale reads after reconnecting to another replica is error-prone 