### PR TITLE
Analyzer: Fix test_replicating_constants/test.py::test_different_versions

### DIFF
--- a/tests/analyzer_integration_broken_tests.txt
+++ b/tests/analyzer_integration_broken_tests.txt
@@ -10,7 +10,6 @@ test_merge_table_over_distributed/test.py::test_select_table_name_from_merge_ove
 test_mutations_with_merge_tree/test.py::test_mutations_with_merge_background_task
 test_mysql_database_engine/test.py::test_mysql_ddl_for_mysql_database
 test_passing_max_partitions_to_read_remotely/test.py::test_default_database_on_cluster
-test_replicating_constants/test.py::test_different_versions
 test_select_access_rights/test_main.py::test_alias_columns
 test_settings_profile/test.py::test_show_profiles
 test_shard_level_const_function/test.py::test_remote

--- a/tests/integration/test_replicating_constants/test.py
+++ b/tests/integration/test_replicating_constants/test.py
@@ -8,7 +8,7 @@ node1 = cluster.add_instance("node1", with_zookeeper=True)
 node2 = cluster.add_instance(
     "node2",
     with_zookeeper=True,
-    image="yandex/clickhouse-server",
+    image="clickhouse/clickhouse-server",
     tag="22.3",
     with_installed_binary=True,
 )

--- a/tests/integration/test_replicating_constants/test.py
+++ b/tests/integration/test_replicating_constants/test.py
@@ -9,9 +9,8 @@ node2 = cluster.add_instance(
     "node2",
     with_zookeeper=True,
     image="yandex/clickhouse-server",
-    tag="19.16.9.37",
+    tag="22.3",
     with_installed_binary=True,
-    allow_analyzer=False,
 )
 
 

--- a/tests/integration/test_replicating_constants/test.py
+++ b/tests/integration/test_replicating_constants/test.py
@@ -9,7 +9,7 @@ node2 = cluster.add_instance(
     "node2",
     with_zookeeper=True,
     image="clickhouse/clickhouse-server",
-    tag="22.3",
+    tag="23.3",
     with_installed_binary=True,
 )
 


### PR DESCRIPTION
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Fix `test_replicating_constants/test.py::test_different_versions`.