### PR TITLE
rabbitmq: fix having neither acked nor nacked messages

### DIFF
--- a/src/Storages/RabbitMQ/RabbitMQConsumer.h
+++ b/src/Storages/RabbitMQ/RabbitMQConsumer.h
@@ -50,7 +50,9 @@ public:
         UInt64 delivery_tag = 0;
         String channel_id;
     };
+
     const MessageData & currentMessage() { return current; }
+    const String & getChannelID() const { return channel_id; }
 
     /// Return read buffer containing next available message
     /// or nullptr if there are no messages to process.
@@ -63,6 +65,7 @@ public:
     bool isConsumerStopped() const { return stopped.load(); }
 
     bool ackMessages(const CommitInfo & commit_info);
+    bool nackMessages(const CommitInfo & commit_info);
 
     bool hasPendingMessages() { return !received.empty(); }
 

--- a/src/Storages/RabbitMQ/RabbitMQSource.cpp
+++ b/src/Storages/RabbitMQ/RabbitMQSource.cpp
@@ -129,12 +129,6 @@ Chunk RabbitMQSource::generateImpl()
         return {};
     }
 
-    if (consumer->needChannelUpdate())
-    {
-        LOG_TRACE(log, "Channel {} is in error state, will update", consumer->getChannelID());
-        consumer->updateChannel(storage.getConnection());
-    }
-
     /// Currently it is one time usage source: to make sure data is flushed
     /// strictly by timeout or by block size.
     is_finished = true;

--- a/src/Storages/RabbitMQ/RabbitMQSource.cpp
+++ b/src/Storages/RabbitMQ/RabbitMQSource.cpp
@@ -120,12 +120,6 @@ Chunk RabbitMQSource::generateImpl()
     {
         auto timeout = std::chrono::milliseconds(context->getSettingsRef().rabbitmq_max_wait_ms.totalMilliseconds());
         consumer = storage.popConsumer(timeout);
-
-        if (consumer->needChannelUpdate())
-        {
-            LOG_TRACE(log, "Channel {} is in error state, will update", consumer->getChannelID());
-            consumer->updateChannel(storage.getConnection());
-        }
     }
 
     if (is_finished || !consumer || consumer->isConsumerStopped())
@@ -133,6 +127,12 @@ Chunk RabbitMQSource::generateImpl()
         LOG_TRACE(log, "RabbitMQSource is stopped (is_finished: {}, consumer_stopped: {})",
                   is_finished, consumer ? toString(consumer->isConsumerStopped()) : "No consumer");
         return {};
+    }
+
+    if (consumer->needChannelUpdate())
+    {
+        LOG_TRACE(log, "Channel {} is in error state, will update", consumer->getChannelID());
+        consumer->updateChannel(storage.getConnection());
     }
 
     /// Currently it is one time usage source: to make sure data is flushed

--- a/src/Storages/RabbitMQ/RabbitMQSource.h
+++ b/src/Storages/RabbitMQ/RabbitMQSource.h
@@ -33,6 +33,7 @@ public:
     bool needChannelUpdate();
     void updateChannel();
     bool sendAck();
+    bool sendNack();
 
 private:
     StorageRabbitMQ & storage;

--- a/src/Storages/RabbitMQ/StorageRabbitMQ.cpp
+++ b/src/Storages/RabbitMQ/StorageRabbitMQ.cpp
@@ -1061,7 +1061,8 @@ bool StorageRabbitMQ::tryStreamToViews()
     for (size_t i = 0; i < num_created_consumers; ++i)
     {
         auto source = std::make_shared<RabbitMQSource>(
-            *this, storage_snapshot, rabbitmq_context, column_names, block_size, max_execution_time_ms, rabbitmq_settings->rabbitmq_handle_error_mode, false);
+            *this, storage_snapshot, rabbitmq_context, column_names, block_size,
+            max_execution_time_ms, rabbitmq_settings->rabbitmq_handle_error_mode, false);
 
         sources.emplace_back(source);
         pipes.emplace_back(source);
@@ -1069,26 +1070,31 @@ bool StorageRabbitMQ::tryStreamToViews()
 
     block_io.pipeline.complete(Pipe::unitePipes(std::move(pipes)));
 
+    std::atomic_size_t rows = 0;
+    block_io.pipeline.setProgressCallback([&](const Progress & progress) { rows += progress.read_rows.load(); });
+
     if (!connection->getHandler().loopRunning())
         startLoop();
 
+    bool write_failed = false;
+    try
     {
         CompletedPipelineExecutor executor(block_io.pipeline);
         executor.execute();
     }
+    catch (...)
+    {
+        tryLogCurrentException(__PRETTY_FUNCTION__);
+        write_failed = true;
+    }
+
+    LOG_TRACE(log, "Processed {} rows", rows);
 
     /* Note: sending ack() with loop running in another thread will lead to a lot of data races inside the library, but only in case
      * error occurs or connection is lost while ack is being sent
      */
     deactivateTask(looping_task, false, true);
     size_t queue_empty = 0;
-
-    if (!hasDependencies(getStorageID()))
-    {
-        /// Do not commit to rabbitmq if the dependency was removed.
-        LOG_TRACE(log, "No dependencies, reschedule");
-        return false;
-    }
 
     if (!connection->isConnected())
     {
@@ -1130,7 +1136,7 @@ bool StorageRabbitMQ::tryStreamToViews()
              *    the same channel will also commit all previously not-committed messages. Anyway I do not think that for ack frame this
              *    will ever happen.
              */
-            if (!source->sendAck())
+            if (write_failed ? source->sendNack() : source->sendAck())
             {
                 /// Iterate loop to activate error callbacks if they happened
                 connection->getHandler().iterateLoop();
@@ -1140,6 +1146,19 @@ bool StorageRabbitMQ::tryStreamToViews()
 
             connection->getHandler().iterateLoop();
         }
+    }
+
+    if (write_failed)
+    {
+        LOG_TRACE(log, "Write failed, reschedule");
+        return false;
+    }
+
+    if (!hasDependencies(getStorageID()))
+    {
+        /// Do not commit to rabbitmq if the dependency was removed.
+        LOG_TRACE(log, "No dependencies, reschedule");
+        return false;
     }
 
     if ((queue_empty == num_created_consumers) && (++read_attempts == MAX_FAILED_READ_ATTEMPTS))

--- a/src/Storages/RabbitMQ/StorageRabbitMQ.cpp
+++ b/src/Storages/RabbitMQ/StorageRabbitMQ.cpp
@@ -1084,7 +1084,7 @@ bool StorageRabbitMQ::tryStreamToViews()
     }
     catch (...)
     {
-        tryLogCurrentException(__PRETTY_FUNCTION__);
+        LOG_ERROR(log, "Failed to push to views. Error: {}", getCurrentExceptionMessage(true));
         write_failed = true;
     }
 

--- a/tests/integration/test_storage_rabbitmq/configs/mergetree.xml
+++ b/tests/integration/test_storage_rabbitmq/configs/mergetree.xml
@@ -1,0 +1,5 @@
+<clickhouse>
+    <merge_tree>
+        <parts_to_throw_insert>0</parts_to_throw_insert>
+    </merge_tree>
+</clickhouse>

--- a/tests/integration/test_storage_rabbitmq/test.py
+++ b/tests/integration/test_storage_rabbitmq/test.py
@@ -3549,3 +3549,6 @@ def test_attach_broken_table(rabbitmq_cluster):
     assert "CANNOT_CONNECT_RABBITMQ" in error
     error = instance.query_and_get_error("INSERT INTO rabbit_queue VALUES ('test')")
     assert "CANNOT_CONNECT_RABBITMQ" in error
+
+
+# TODO: add a test

--- a/tests/integration/test_storage_rabbitmq/test.py
+++ b/tests/integration/test_storage_rabbitmq/test.py
@@ -3576,11 +3576,11 @@ def test_rabbitmq_nack_failed_insert(rabbitmq_cluster):
     connection = pika.BlockingConnection(parameters)
     channel = connection.channel()
 
-    channel.exchange_declare(exchange='deadl')
+    channel.exchange_declare(exchange="deadl")
 
-    result = channel.queue_declare(queue='deadq')
+    result = channel.queue_declare(queue="deadq")
     queue_name = result.method.queue
-    channel.queue_bind(exchange='deadl', routing_key='', queue=queue_name)
+    channel.queue_bind(exchange="deadl", routing_key="", queue=queue_name)
 
     instance3.query(
         f"""
@@ -3620,6 +3620,7 @@ def test_rabbitmq_nack_failed_insert(rabbitmq_cluster):
     instance3.restart_clickhouse()
 
     count = [0]
+
     def on_consume(channel, method, properties, body):
         channel.basic_publish(exchange=exchange, routing_key="", body=body)
         count[0] += 1

--- a/tests/integration/test_storage_rabbitmq/test.py
+++ b/tests/integration/test_storage_rabbitmq/test.py
@@ -3601,7 +3601,9 @@ def test_rabbitmq_nack_failed_insert(rabbitmq_cluster):
 
     connection.close()
 
-    instance3.wait_for_log_line("Failed to push to views. Error: Code: 252. DB::Exception: Too many parts")
+    instance3.wait_for_log_line(
+        "Failed to push to views. Error: Code: 252. DB::Exception: Too many parts"
+    )
 
     instance3.replace_in_config(
         "/etc/clickhouse-server/config.d/mergetree.xml",

--- a/tests/integration/test_storage_rabbitmq/test.py
+++ b/tests/integration/test_storage_rabbitmq/test.py
@@ -37,6 +37,18 @@ instance2 = cluster.add_instance(
     with_rabbitmq=True,
 )
 
+instance3 = cluster.add_instance(
+    "instance3",
+    user_configs=["configs/users.xml"],
+    main_configs=[
+        "configs/rabbitmq.xml",
+        "configs/macros.xml",
+        "configs/named_collection.xml",
+        "configs/mergetree.xml",
+    ],
+    with_rabbitmq=True,
+)
+
 # Helpers
 
 
@@ -84,6 +96,7 @@ def rabbitmq_cluster():
         cluster.start()
         logging.debug("rabbitmq_id is {}".format(instance.cluster.rabbitmq_docker_id))
         instance.query("CREATE DATABASE test")
+        instance3.query("CREATE DATABASE test")
 
         yield cluster
 
@@ -3551,4 +3564,64 @@ def test_attach_broken_table(rabbitmq_cluster):
     assert "CANNOT_CONNECT_RABBITMQ" in error
 
 
-# TODO: add a test
+def test_rabbitmq_nack_failed_insert(rabbitmq_cluster):
+    table_name = "nack_failed_insert"
+    exchange = f"{table_name}_exchange"
+    instance3.query(
+        f"""
+        CREATE TABLE test.{table_name} (key UInt64, value UInt64)
+            ENGINE = RabbitMQ
+            SETTINGS rabbitmq_host_port = '{rabbitmq_cluster.rabbitmq_host}:5672',
+                     rabbitmq_flush_interval_ms=1000,
+                     rabbitmq_exchange_name = '{exchange}',
+                     rabbitmq_format = 'JSONEachRow';
+
+        DROP TABLE IF EXISTS test.view;
+        CREATE TABLE test.view (key UInt64, value UInt64)
+            ENGINE = MergeTree()
+            ORDER BY key;
+
+        DROP TABLE IF EXISTS test.consumer;
+        CREATE MATERIALIZED VIEW test.consumer TO test.view AS
+            SELECT * FROM test.{table_name};
+        """
+    )
+
+    credentials = pika.PlainCredentials("root", "clickhouse")
+    parameters = pika.ConnectionParameters(
+        rabbitmq_cluster.rabbitmq_ip, rabbitmq_cluster.rabbitmq_port, "/", credentials
+    )
+    connection = pika.BlockingConnection(parameters)
+    channel = connection.channel()
+
+    num_rows = 25
+    for i in range(num_rows):
+        message = json.dumps({"key": i, "value": i}) + "\n"
+        channel.basic_publish(exchange=exchange, routing_key="", body=message)
+
+    connection.close()
+
+    instance3.wait_for_log_line("Failed to push to views. Error: Code: 252. DB::Exception: Too many parts")
+
+    instance3.replace_in_config(
+        "/etc/clickhouse-server/config.d/mergetree.xml",
+        "parts_to_throw_insert>1",
+        "parts_to_throw_insert>10",
+    )
+    attempt = 0
+    count = 0
+    while attempt < 100:
+        count = int(instance3.query("SELECT count() FROM test.view"))
+        if count == num_rows:
+            break
+        attempt += 1
+
+    assert count == num_rows
+
+    instance3.query(
+        f"""
+        DROP TABLE test.consumer;
+        DROP TABLE test.view;
+        DROP TABLE test.{table_name};
+    """
+    )


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix having neigher acked nor nacked messages. If exception happens during read-write phase, messages will be nacked.