### PR TITLE
[Docs] Specify cloud default value for date_time_input_format

### DIFF
--- a/docs/en/operations/settings/settings-formats.md
+++ b/docs/en/operations/settings/settings-formats.md
@@ -212,6 +212,8 @@ Possible values:
 
 Default value: `'basic'`.
 
+Cloud default value: `'best_effort'`.
+
 See also:
 
 - [DateTime data type.](../../sql-reference/data-types/datetime.md)


### PR DESCRIPTION
### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Specify cloud default value for date_time_input_format