### PR TITLE
CI: do not reuse builds on release branches

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -318,15 +318,19 @@ jobs:
       run_command: |
         python3 build_report_check.py "$CHECK_NAME"
   MarkReleaseReady:
-    needs: [RunConfig, BuilderBinDarwin, BuilderBinDarwinAarch64, BuilderDebRelease, BuilderDebAarch64]
-    if: ${{ !failure() && !cancelled() }}
-    uses: ./.github/workflows/reusable_test.yml
-    with:
-      test_name: Mark Commit Release Ready
-      runner_type: style-checker
-      data: ${{ needs.RunConfig.outputs.data }}
-      run_command: |
-        python3 mark_release_ready.py
+    needs:
+      - BuilderBinDarwin
+      - BuilderBinDarwinAarch64
+      - BuilderDebRelease
+      - BuilderDebAarch64
+    runs-on: [self-hosted, style-checker]
+    steps:
+      - name: Check out repository code
+        uses: ClickHouse/checkout@v1
+      - name: Mark Commit Release Ready
+        run: |
+          cd "$GITHUB_WORKSPACE/tests/ci"
+          python3 mark_release_ready.py
 ############################################################################################
 #################################### INSTALL PACKAGES ######################################
 ############################################################################################

--- a/.github/workflows/release_branches.yml
+++ b/.github/workflows/release_branches.yml
@@ -91,6 +91,8 @@ jobs:
       build_name: package_release
       checkout_depth: 0
       data: ${{ needs.RunConfig.outputs.data }}
+      # always rebuild on release branches to be able to publish from any commit
+      force: true
   BuilderDebAarch64:
     needs: [RunConfig, BuildDockers]
     if: ${{ !failure() && !cancelled() }}
@@ -99,6 +101,8 @@ jobs:
       build_name: package_aarch64
       checkout_depth: 0
       data: ${{ needs.RunConfig.outputs.data }}
+      # always rebuild on release branches to be able to publish from any commit
+      force: true
   BuilderDebAsan:
     needs: [RunConfig, BuildDockers]
     if: ${{ !failure() && !cancelled() }}
@@ -142,6 +146,8 @@ jobs:
       build_name: binary_darwin
       checkout_depth: 0
       data: ${{ needs.RunConfig.outputs.data }}
+      # always rebuild on release branches to be able to publish from any commit
+      force: true
   BuilderBinDarwinAarch64:
     needs: [RunConfig, BuildDockers]
     if: ${{ !failure() && !cancelled() }}
@@ -150,6 +156,8 @@ jobs:
       build_name: binary_darwin_aarch64
       checkout_depth: 0
       data: ${{ needs.RunConfig.outputs.data }}
+      # always rebuild on release branches to be able to publish from any commit
+      force: true
 ############################################################################################
 ##################################### Docker images  #######################################
 ############################################################################################
@@ -225,7 +233,6 @@ jobs:
       run_command: |
         python3 build_report_check.py "$CHECK_NAME"
   MarkReleaseReady:
-    if: ${{ !failure() && !cancelled() }}
     needs:
       - BuilderBinDarwin
       - BuilderBinDarwinAarch64
@@ -235,8 +242,6 @@ jobs:
     steps:
       - name: Check out repository code
         uses: ClickHouse/checkout@v1
-        with:
-          clear-repository: true
       - name: Mark Commit Release Ready
         run: |
           cd "$GITHUB_WORKSPACE/tests/ci"

--- a/.github/workflows/reusable_build.yml
+++ b/.github/workflows/reusable_build.yml
@@ -26,6 +26,10 @@ name: Build ClickHouse
         description: json ci data
         type: string
         required: true
+      force:
+        description: disallow job skipping
+        type: boolean
+        default: false
       additional_envs:
         description: additional ENV variables to setup the job
         type: string
@@ -33,7 +37,7 @@ name: Build ClickHouse
 jobs:
   Build:
     name: Build-${{inputs.build_name}}
-    if: contains(fromJson(inputs.data).jobs_data.jobs_to_do, inputs.build_name)
+    if: ${{ contains(fromJson(inputs.data).jobs_data.jobs_to_do, inputs.build_name) || inputs.force }}
     env:
       GITHUB_JOB_OVERRIDDEN: Build-${{inputs.build_name}}
     runs-on: [self-hosted, '${{inputs.runner_type}}']
@@ -78,7 +82,8 @@ jobs:
           python3 "$GITHUB_WORKSPACE/tests/ci/ci.py" \
             --infile ${{ toJson(inputs.data) }} \
             --job-name "$BUILD_NAME" \
-            --run
+            --run \
+            ${{ inputs.force && '--force' || '' }}
       - name: Post
         # it still be build report to upload for failed build job
         if: ${{ !cancelled() }}

--- a/tests/ci/ci.py
+++ b/tests/ci/ci.py
@@ -816,6 +816,12 @@ def parse_args(parser: argparse.ArgumentParser) -> argparse.Namespace:
         default=False,
         help="skip fetching data about job runs, used in --configure action (for debugging and nigthly ci)",
     )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        default=False,
+        help="Used with --run, force the job to run, omitting the ci cache",
+    )
     # FIXME: remove, not used
     parser.add_argument(
         "--rebuild-all-binaries",
@@ -1762,7 +1768,7 @@ def main() -> int:
                     previous_status = job_status.status
                     GHActions.print_in_group("Commit Status Data", job_status)
 
-        if previous_status:
+        if previous_status and not args.force:
             print(
                 f"Commit status or Build Report is already present - job will be skipped with status: [{previous_status}]"
             )

--- a/tests/ci/ci_config.py
+++ b/tests/ci/ci_config.py
@@ -140,8 +140,6 @@ class JobNames(metaclass=WithIter):
     DOCS_CHECK = "Docs check"
     BUGFIX_VALIDATE = "tests bugfix validate check"
 
-    MARK_RELEASE_READY = "Mark Commit Release Ready"
-
 
 # dynamically update JobName with Build jobs
 for attr_name in dir(Build):
@@ -828,9 +826,6 @@ CI_CONFIG = CiConfig(
         ),
     },
     other_jobs_configs={
-        JobNames.MARK_RELEASE_READY: TestConfig(
-            "", job_config=JobConfig(release_only=True)
-        ),
         JobNames.DOCKER_SERVER: TestConfig(
             "",
             job_config=JobConfig(


### PR DESCRIPTION
 #do_not_test

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
