### PR TITLE
Fix potential endless loop during merge

### DIFF
--- a/src/Processors/Merges/Algorithms/MergedData.h
+++ b/src/Processors/Merges/Algorithms/MergedData.h
@@ -100,7 +100,7 @@ public:
         merged_rows = 0;
         sum_blocks_granularity = 0;
         ++total_chunks;
-        total_allocated_bytes += chunk.allocatedBytes();
+        total_allocated_bytes += chunk.bytes();
         need_flush = false;
 
         return chunk;
@@ -122,7 +122,7 @@ public:
         {
             size_t merged_bytes = 0;
             for (const auto & column : columns)
-                merged_bytes += column->allocatedBytes();
+                merged_bytes += column->byteSize();
             if (merged_bytes >= max_block_size_bytes)
                 return true;
         }

--- a/src/Processors/Transforms/ColumnGathererTransform.h
+++ b/src/Processors/Transforms/ColumnGathererTransform.h
@@ -147,7 +147,7 @@ void ColumnGathererStream::gather(Column & column_res)
 
 
     /// We use do ... while here to ensure there will be at least one iteration of this loop.
-    /// Because the column_res.allocatedBytes() could be bigger than block_preferred_size_bytes already at this point.
+    /// Because the column_res.byteSize() could be bigger than block_preferred_size_bytes already at this point.
     do
     {
         if (row_source_pos >= row_sources_end)
@@ -195,7 +195,7 @@ void ColumnGathererStream::gather(Column & column_res)
         }
 
         source.pos += len;
-    } while (column_res.size() < block_preferred_size_rows && column_res.allocatedBytes() < block_preferred_size_bytes);
+    } while (column_res.size() < block_preferred_size_rows && column_res.byteSize() < block_preferred_size_bytes);
 }
 
 }

--- a/src/Processors/Transforms/ColumnGathererTransform.h
+++ b/src/Processors/Transforms/ColumnGathererTransform.h
@@ -145,10 +145,14 @@ void ColumnGathererStream::gather(Column & column_res)
 
     next_required_source = -1;
 
-    while (row_source_pos < row_sources_end
-        && column_res.size() < block_preferred_size_rows
-        && column_res.allocatedBytes() < block_preferred_size_bytes)
+
+    /// We use do ... while here to ensure there will be at least one iteration of this loop.
+    /// Because the column_res.allocatedBytes() could be bigger than block_preferred_size_bytes already at this point.
+    do
     {
+        if (row_source_pos < row_sources_end)
+            break;
+
         RowSourcePart row_source = *row_source_pos;
         size_t source_num = row_source.getSourceNum();
         Source & source = sources[source_num];
@@ -191,7 +195,7 @@ void ColumnGathererStream::gather(Column & column_res)
         }
 
         source.pos += len;
-    }
+    } while (column_res.size() < block_preferred_size_rows && column_res.allocatedBytes() < block_preferred_size_bytes);
 }
 
 }

--- a/src/Processors/Transforms/ColumnGathererTransform.h
+++ b/src/Processors/Transforms/ColumnGathererTransform.h
@@ -150,7 +150,7 @@ void ColumnGathererStream::gather(Column & column_res)
     /// Because the column_res.allocatedBytes() could be bigger than block_preferred_size_bytes already at this point.
     do
     {
-        if (row_source_pos < row_sources_end)
+        if (row_source_pos >= row_sources_end)
             break;
 
         RowSourcePart row_source = *row_source_pos;


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
In case when `merge_max_block_size_bytes` is small enough and tables contain wide rows (strings or tuples) background merges may stuck in an endless loop. This behaviour is fixed. Follow-up for https://github.com/ClickHouse/ClickHouse/pull/59340