### PR TITLE
Handle different timestamp related aspects of zip-files

### DIFF
--- a/tests/ci/team_keys_lambda/build_and_deploy_archive.sh
+++ b/tests/ci/team_keys_lambda/build_and_deploy_archive.sh
@@ -22,18 +22,29 @@ mkdir "$PACKAGE"
 cp app.py "$PACKAGE"
 if [ -f requirements.txt ]; then
   VENV=lambda-venv
-  rm -rf "$VENV" lambda-package.zip
+  rm -rf "$VENV"
   docker run --net=host --rm --user="${UID}" -e HOME=/tmp --entrypoint=/bin/bash \
     --volume="${WORKDIR}/..:/ci" --workdir="/ci/${DIR_NAME}" "${DOCKER_IMAGE}" \
     -exc "
       '$PY_EXEC' -m venv '$VENV' &&
       source '$VENV/bin/activate' &&
-      pip install -r requirements.txt
+      pip install -r requirements.txt &&
+      # To have consistent pyc files
+      find '$VENV/lib' -name '*.pyc' -delete
+      find '$VENV/lib' ! -type d -exec touch -t 201212121212 {} +
+      python -m compileall
     "
   cp -rT "$VENV/lib/$PY_EXEC/site-packages/" "$PACKAGE"
   rm -r "$PACKAGE"/{pip,pip-*,setuptools,setuptools-*}
+  # zip stores metadata about timestamps
+  find "$PACKAGE" ! -type d -exec touch -t 201212121212 {} +
 fi
-( cd "$PACKAGE" && zip -9 -r ../"$PACKAGE".zip . )
+(
+  export LC_ALL=c
+  cd "$PACKAGE"
+  # zip uses random files order by default, so we sort the files alphabetically
+  find . ! -type d -print0 | sort -z | tr '\0' '\n' | zip -XD -0 ../"$PACKAGE".zip --names-stdin
+)
 
 ECHO=()
 if [ -n "$DRY_RUN" ]; then


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Python byte-code `pyc` stores the timestamps of `py` files, and zip archive stores the timestamps of every file. All files have the same timestamp now, so the lambda archive won't change the content after each compression.