### PR TITLE
Fix StorageURL doing some of the query execution in single thread

### DIFF
--- a/src/Storages/StorageURL.cpp
+++ b/src/Storages/StorageURL.cpp
@@ -904,6 +904,7 @@ public:
         , context(std::move(context_))
         , max_block_size(max_block_size_)
         , num_streams(num_streams_)
+        , max_num_streams(num_streams_)
     {
     }
 
@@ -920,6 +921,7 @@ private:
 
     size_t max_block_size;
     size_t num_streams;
+    const size_t max_num_streams;
 
     std::shared_ptr<StorageURLSource::IteratorWrapper> iterator_wrapper;
     bool is_url_with_globs = false;
@@ -1093,8 +1095,8 @@ void ReadFromURL::initializePipeline(QueryPipelineBuilder & pipeline, const Buil
     auto pipe = Pipe::unitePipes(std::move(pipes));
     size_t output_ports = pipe.numOutputPorts();
     const bool parallelize_output = context->getSettingsRef().parallelize_output_from_storages;
-    if (parallelize_output && storage->parallelizeOutputAfterReading(context) && output_ports > 0 && output_ports < num_streams)
-        pipe.resize(num_streams);
+    if (parallelize_output && storage->parallelizeOutputAfterReading(context) && output_ports > 0 && output_ports < max_num_streams)
+        pipe.resize(max_num_streams);
 
     if (pipe.empty())
         pipe = Pipe(std::make_shared<NullSource>(info.source_header));

--- a/tests/queries/0_stateless/02723_parallelize_output_setting.reference
+++ b/tests/queries/0_stateless/02723_parallelize_output_setting.reference
@@ -5,3 +5,7 @@ select startsWith(trimLeft(explain),'Resize') as resize from (explain pipeline s
 -- no Resize in pipeline
 set parallelize_output_from_storages=0;
 select startsWith(trimLeft(explain),'Resize') as resize from (explain pipeline select * from file(data_02723.csv)) where resize;
+-- Data from URL source is immediately resized to max_treads streams, before any ExpressionTransform.
+set parallelize_output_from_storages=1;
+select match(arrayStringConcat(groupArray(explain), ''), '.*Resize 1 → 2 *URL 0 → 1 *$') from (explain pipeline select x, count() from url('https://example.com', Parquet, 'x Int64') group by x order by count() limit 10);
+1

--- a/tests/queries/0_stateless/02723_parallelize_output_setting.sql
+++ b/tests/queries/0_stateless/02723_parallelize_output_setting.sql
@@ -10,3 +10,6 @@ select startsWith(trimLeft(explain),'Resize') as resize from (explain pipeline s
 set parallelize_output_from_storages=0;
 select startsWith(trimLeft(explain),'Resize') as resize from (explain pipeline select * from file(data_02723.csv)) where resize;
 
+-- Data from URL source is immediately resized to max_treads streams, before any ExpressionTransform.
+set parallelize_output_from_storages=1;
+select match(arrayStringConcat(groupArray(explain), ''), '.*Resize 1 → 2 *URL 0 → 1 *$') from (explain pipeline select x, count() from url('https://example.com', Parquet, 'x Int64') group by x order by count() limit 10);

--- a/tests/queries/0_stateless/02723_parallelize_output_setting.sql
+++ b/tests/queries/0_stateless/02723_parallelize_output_setting.sql
@@ -1,4 +1,4 @@
--- Tags: no-parallel
+-- Tags: no-parallel, no-fasttest
 
 insert into function file(data_02723.csv) select number from numbers(5) settings engine_file_truncate_on_insert=1;
 


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed queries that read a Parquet file over HTTP (url()/URL()) executing in one thread instead of max_threads.

https://github.com/ClickHouse/ClickHouse/pull/58353 accidentally changed num_streams behavior in StorageURL. It's supposed to create `min(num_streams, num_files)` StorageURLSource-s, then resize the pipeline to num_streams, so that the rest of query execution is multithreaded even if there's only one file to read.

Before the fix:
```
EXPLAIN PIPELINE
SELECT     
    UserID,                                    
    toMinute(CAST(EventTime, 'DateTime')) AS m,
    SearchPhrase,          
    COUNT(*)
FROM url('https://clickhouse-public-datasets-us-west-2.s3.us-west-2.amazonaws.com/hits.parquet')
GROUP BY   
    UserID,
    m,
    SearchPhrase
ORDER BY COUNT(*) DESC
LIMIT 10
SETTINGS max_threads = 64

Query id: b576c185-98f8-4d8d-9bfb-e1079bdd3734

┌─explain────────────────────────────────┐
│ (Expression)                           │
│ ExpressionTransform                    │
│   (Limit)                              │
│   Limit                                │
│     (Sorting)                          │
│     MergingSortedTransform 64 → 1      │
│       MergeSortingTransform × 64       │
│         LimitsCheckingTransform × 64   │
│           PartialSortingTransform × 64 │
│             (Expression)               │
│             ExpressionTransform × 64   │
│               (Aggregating)            │
│               Resize 1 → 64            │
│                 AggregatingTransform   │
│                   (Expression)         │
│                   ExpressionTransform  │
│                     (ReadFromURL)      │
│                     URL 0 → 1          │
└────────────────────────────────────────┘
```

After the fix:
```
┌─explain──────────────────────────────────────┐
│ (Expression)                                 │
│ ExpressionTransform                          │
│   (Limit)                                    │
│   Limit                                      │
│     (Sorting)                                │
│     MergingSortedTransform 64 → 1            │
│       MergeSortingTransform × 64             │
│         LimitsCheckingTransform × 64         │
│           PartialSortingTransform × 64       │
│             (Expression)                     │
│             ExpressionTransform × 64         │
│               (Aggregating)                  │
│               Resize 64 → 64                 │
│                 AggregatingTransform × 64    │
│                   StrictResize 64 → 64       │
│                     (Expression)             │
│                     ExpressionTransform × 64 │
│                       (ReadFromURL)          │
│                       Resize 1 → 64          │
│                         URL 0 → 1            │
└──────────────────────────────────────────────┘
```

Old version before https://github.com/ClickHouse/ClickHouse/pull/58353:
```
┌─explain──────────────────────────────────────┐
│ (Expression)                                 │
│ ExpressionTransform                          │
│   (Limit)                                    │
│   Limit                                      │
│     (Sorting)                                │
│     MergingSortedTransform 64 → 1            │
│       MergeSortingTransform × 64             │
│         LimitsCheckingTransform × 64         │
│           PartialSortingTransform × 64       │
│             (Expression)                     │
│             ExpressionTransform × 64         │
│               (Aggregating)                  │
│               Resize 64 → 64                 │
│                 AggregatingTransform × 64    │
│                   StrictResize 64 → 64       │
│                     (Expression)             │
│                     ExpressionTransform × 64 │
│                       (ReadFromStorage)      │
│                       Resize 1 → 64          │
│                         URL 0 → 1            │
└──────────────────────────────────────────────┘
```

Benchmark: https://pastila.nl/?cafebabe/6ae75c0a672707eb39dee0de241cb628.html#GhbniwKxvMQSvZPyWQgL5w==