### PR TITLE
Updated a list of trusted contributors

### DIFF
--- a/tests/ci/lambda_shared_package/lambda_shared/pr.py
+++ b/tests/ci/lambda_shared_package/lambda_shared/pr.py
@@ -44,7 +44,7 @@ TRUSTED_CONTRIBUTORS = {
         "kitaisreal",
         "k-morozov",  # Konstantin Morozov, Yandex Cloud
         "justindeguzman",  # ClickHouse, Inc
-        "jrdi", # ClickHouse contributor, TinyBird
+        "jrdi",  # ClickHouse contributor, TinyBird
     ]
 }
 

--- a/tests/ci/lambda_shared_package/lambda_shared/pr.py
+++ b/tests/ci/lambda_shared_package/lambda_shared/pr.py
@@ -44,6 +44,7 @@ TRUSTED_CONTRIBUTORS = {
         "kitaisreal",
         "k-morozov",  # Konstantin Morozov, Yandex Cloud
         "justindeguzman",  # ClickHouse, Inc
+        "jrdi", # ClickHouse contributor, TinyBird
     ]
 }
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Added @jrdi to the list of trusted contributors.
