### PR TITLE
Respect CMAKE_OSX_DEPLOYMENT_TARGET for Rust targets

### DIFF
--- a/rust/CMakeLists.txt
+++ b/rust/CMakeLists.txt
@@ -14,6 +14,11 @@ macro(configure_rustc)
         set(RUST_CFLAGS "${RUST_CFLAGS} --sysroot ${CMAKE_SYSROOT}")
     endif()
 
+    if (CMAKE_OSX_DEPLOYMENT_TARGET)
+        set(RUST_CXXFLAGS "${RUST_CXXFLAGS} -mmacosx-version-min=${CMAKE_OSX_DEPLOYMENT_TARGET}")
+        set(RUST_CFLAGS "${RUST_CFLAGS} -mmacosx-version-min=${CMAKE_OSX_DEPLOYMENT_TARGET}")
+    endif()
+
     if (USE_MUSL)
         set(RUST_CXXFLAGS "${RUST_CXXFLAGS} -D_LIBCPP_HAS_MUSL_LIBC=1")
     endif ()
@@ -25,13 +30,22 @@ macro(configure_rustc)
         set(RUSTCWRAPPER "")
     endif()
 
-    set(RUSTFLAGS "[]")
+    set(RUSTFLAGS)
+    if (CMAKE_OSX_DEPLOYMENT_TARGET)
+        list(APPEND RUSTFLAGS "-C" "link-arg=-mmacosx-version-min=${CMAKE_OSX_DEPLOYMENT_TARGET}")
+    endif()
+
     set(RUST_CARGO_BUILD_STD "")
     # For more info: https://doc.rust-lang.org/beta/unstable-book/compiler-flags/sanitizer.html#memorysanitizer
     if (SANITIZE STREQUAL "memory")
         set(RUST_CARGO_BUILD_STD "build-std = [\"std\", \"panic_abort\", \"core\", \"alloc\"]")
-        set(RUSTFLAGS "[\"-Zsanitizer=memory\", \"-Zsanitizer-memory-track-origins\"]")
+        list(APPEND RUSTFLAGS "-Zsanitizer=memory" "-Zsanitizer-memory-track-origins")
     endif()
+
+    list(TRANSFORM RUSTFLAGS PREPEND "\"")
+    list(TRANSFORM RUSTFLAGS APPEND "\"")
+    list(JOIN RUSTFLAGS "," RUSTFLAGS)
+    set(RUSTFLAGS "[${RUSTFLAGS}]")
 
     message(STATUS "RUST_CFLAGS: ${RUST_CFLAGS}")
     message(STATUS "RUST_CXXFLAGS: ${RUST_CXXFLAGS}")


### PR DESCRIPTION
This should fix the following warnings:

    ld: warning: object file (rust/prql/Debug/lib_ch_rust_prql.a[74](aarch_aapcs64.o)) was built for newer 'macOS' version (14.0) than being linked (11.0)
    ld: warning: object file (rust/skim/Debug/lib_ch_rust_skim_rust.a[40](c0e230e4543ad627-lib.rs.o)) was built for newer 'macOS' version (14.0) than being linked (11.0)
    ld: warning: object file (rust/skim/Debug/lib_ch_rust_skim_rust.a[46](6c3a6ae2099d4914-cxx.o)) was built for newer 'macOS' version (14.0) than being linked (11.0)

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Follow-up for: https://github.com/ClickHouse/ClickHouse/pull/59272