### PR TITLE
Do not reinitialize ZooKeeperWithFaultInjection on each chunk

### DIFF
--- a/src/Storages/System/StorageSystemZooKeeper.cpp
+++ b/src/Storages/System/StorageSystemZooKeeper.cpp
@@ -220,6 +220,7 @@ private:
     const UInt64 max_block_size;
     Paths paths;
     ContextPtr context;
+    ZooKeeperWithFaultInjection::Ptr zookeeper;
     bool started = false;
 };
 
@@ -484,7 +485,6 @@ Chunk SystemZooKeeperSource::generate()
         settings.insert_keeper_retry_initial_backoff_ms,
         settings.insert_keeper_retry_max_backoff_ms);
 
-    ZooKeeperWithFaultInjection::Ptr zookeeper;
     /// Handles reconnects when needed
     auto get_zookeeper = [&] ()
     {


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Initialize ZooKeeperWithFaultInjection when reading from system.zookeeper once per query instead of on each chunk.
