### PR TITLE
Fix long shutdown of FileLog storage

### DIFF
--- a/src/Storages/FileLog/DirectoryWatcherBase.h
+++ b/src/Storages/FileLog/DirectoryWatcherBase.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Core/BackgroundSchedulePool.h>
+#include <Common/PipeFDs.h>
 
 #include <atomic>
 #include <memory>
@@ -85,10 +86,6 @@ public:
 
     void watchFunc();
 
-protected:
-    void start();
-    void stop();
-
 private:
     FileLogDirectoryWatcher & owner;
 
@@ -102,7 +99,11 @@ private:
     int event_mask;
     uint64_t milliseconds_to_wait;
 
-    int fd;
+    int inotify_fd;
+    PipeFDs event_pipe;
+
+    void start();
+    void stop();
 };
 
 }


### PR DESCRIPTION
Previously it was possible to wait up to
poll_directory_watch_events_backoff_max (default is 32000) on shutdown, because it was not possible to stop poll of inotify.

Before (takes 3 seconds):

    2024.02.12 11:27:55.058192 [ 10134 ] {} <Trace> StorageFileLog (file_log): Waiting for cleanup
    2024.02.12 11:27:58.178021 [ 10271 ] {} <Trace> directory_watch: Execution took 7519 ms.

After:

    2024.02.12 11:33:29.722403 [ 15866 ] {} <Trace> StorageFileLog (file_log): Waiting for cleanup
    2024.02.12 11:33:29.722473 [ 15956 ] {} <Trace> directory_watch: Execution took 6399 ms.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)