### PR TITLE
tests: fix 02322_sql_insert_format flakiness

### DIFF
--- a/tests/queries/0_stateless/02322_sql_insert_format.sql
+++ b/tests/queries/0_stateless/02322_sql_insert_format.sql
@@ -1,5 +1,7 @@
 -- Tags: no-parallel
 
+set schema_inference_use_cache_for_file=0;
+
 select number as x, number % 3 as y, 'Hello' as z from numbers(5) format SQLInsert;
 select number as x, number % 3 as y, 'Hello' as z from numbers(5) format SQLInsert settings output_format_sql_insert_max_batch_size=1;
 select number as x, number % 3 as y, 'Hello' as z from numbers(5) format SQLInsert settings output_format_sql_insert_max_batch_size=2;


### PR DESCRIPTION
02322_sql_insert_format failed from time to time [1] and I found only one reason - structure cache, I guess it may fail when the mtime was the same.

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/59857/46a9ced0f9031153538446f4b625e0cc34532a90/fast_test.html

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

[Play](https://play.clickhouse.com/play?user=play#U0VMRUNUIGNoZWNrX3N0YXJ0X3RpbWUsIGNoZWNrX25hbWUsIHRlc3RfbmFtZSwgcmVwb3J0X3VybApGUk9NIGNoZWNrcwpXSEVSRSB0ZXN0X25hbWUgTElLRSAnJTAyMzIyX3NxbF9pbnNlcnRfZm9ybWF0JScKICAgIEFORCBjaGVja19zdGFydF90aW1lID49IG5vdygpIC0gSU5URVJWQUwgOTAgREFZCi8vICAgIEFORCBwdWxsX3JlcXVlc3RfbnVtYmVyID0gMAogICAgQU5EIHRlc3Rfc3RhdHVzICE9ICdTS0lQUEVEJwogICAgQU5EIHRlc3Rfc3RhdHVzIExJS0UgJ0YlJwogICAgQU5EIGNoZWNrX3N0YXR1cyAhPSAnc3VjY2VzcycKT1JERVIgQlkgY2hlY2tfbmFtZSwgdGVzdF9uYW1lLCBjaGVja19zdGFydF90aW1l)