### PR TITLE
Nanoseconds time precision for local files structure cache

### DIFF
--- a/base/base/TimeSpec.h
+++ b/base/base/TimeSpec.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <tuple>
+#include <sys/time.h>
+
+/// Wrapper class for the `timespec` structure that provides easy construction
+/// from `time_t` and enables comparison operations.
+struct TimeSpec
+{
+public:
+    TimeSpec() = default;
+
+    explicit TimeSpec(const timespec & ts_)
+        : ts(ts_)
+    {}
+    explicit TimeSpec(const time_t & time)
+    {
+        ts.tv_sec = time;
+        ts.tv_nsec = 0;
+    }
+
+    explicit operator timespec() const { return ts; }
+    timespec getTimeSpec() const { return ts; }
+
+    auto operator<=>(const TimeSpec & rhs) const
+    {
+        return std::tie(ts.tv_sec, ts.tv_nsec)
+           <=> std::tie(rhs.ts.tv_sec, rhs.ts.tv_nsec);
+    }
+
+private:
+    ::timespec ts{};
+};

--- a/src/Storages/Cache/SchemaCache.cpp
+++ b/src/Storages/Cache/SchemaCache.cpp
@@ -53,9 +53,12 @@ void SchemaCache::addUnlocked(const Key & key, const std::optional<ColumnsDescri
         return;
     }
 
-    time_t now = std::time(nullptr);
+    struct timespec now_ts;
+    /// CLOCK_REALTIME is used here since it is compared to file mtime
+    clock_gettime(CLOCK_REALTIME, &now_ts);
+
     auto it = queue.insert(queue.end(), key);
-    data[key] = {SchemaInfo{columns, num_rows, now}, it};
+    data[key] = {SchemaInfo{columns, num_rows, TimeSpec(now_ts)}, it};
     checkOverflow();
 }
 

--- a/src/Storages/Cache/SchemaCache.h
+++ b/src/Storages/Cache/SchemaCache.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Storages/ColumnsDescription.h>
+#include <base/TimeSpec.h>
 #include <unordered_map>
 #include <list>
 #include <mutex>
@@ -51,10 +52,10 @@ public:
     {
         std::optional<ColumnsDescription> columns;
         std::optional<size_t> num_rows;
-        time_t registration_time;
+        TimeSpec registration_time;
     };
 
-    using LastModificationTimeGetter = std::function<std::optional<time_t>()>;
+    using LastModificationTimeGetter = std::function<std::optional<TimeSpec>()>;
 
     /// Add new key or update existing with a schema
     void addColumns(const Key & key, const ColumnsDescription & columns);

--- a/src/Storages/HDFS/StorageHDFS.cpp
+++ b/src/Storages/HDFS/StorageHDFS.cpp
@@ -349,16 +349,16 @@ namespace
             auto & schema_cache = StorageHDFS::getSchemaCache(getContext());
             for (const auto & path_with_info : paths_with_info_)
             {
-                auto get_last_mod_time = [&]() -> std::optional<time_t>
+                auto get_last_mod_time = [&]() -> std::optional<TimeSpec>
                 {
                     if (path_with_info.info)
-                        return path_with_info.info->last_mod_time;
+                        return TimeSpec(path_with_info.info->last_mod_time);
 
                     auto builder = createHDFSBuilder(uri_without_path + "/", getContext()->getGlobalContext()->getConfigRef());
                     auto fs = createHDFSFS(builder.get());
                     HDFSFileInfoPtr hdfs_info(hdfsGetPathInfo(fs.get(), path_with_info.path.c_str()));
                     if (hdfs_info)
-                        return hdfs_info->mLastMod;
+                        return TimeSpec(hdfs_info->mLastMod);
 
                     return std::nullopt;
                 };
@@ -696,10 +696,10 @@ void HDFSSource::addNumRowsToCache(const String & path, size_t num_rows)
 std::optional<size_t> HDFSSource::tryGetNumRowsFromCache(const StorageHDFS::PathWithInfo & path_with_info)
 {
     auto cache_key = getKeyForSchemaCache(path_with_info.path, storage->format_name, std::nullopt, getContext());
-    auto get_last_mod_time = [&]() -> std::optional<time_t>
+    auto get_last_mod_time = [&]() -> std::optional<TimeSpec>
     {
         if (path_with_info.info)
-            return path_with_info.info->last_mod_time;
+            return TimeSpec(path_with_info.info->last_mod_time);
         return std::nullopt;
     };
 

--- a/src/Storages/StorageAzureBlob.cpp
+++ b/src/Storages/StorageAzureBlob.cpp
@@ -1132,11 +1132,11 @@ std::optional<size_t> StorageAzureBlobSource::tryGetNumRowsFromCache(const DB::R
 {
     String source = fs::path(connection_url) / container / path_with_metadata.relative_path;
     auto cache_key = getKeyForSchemaCache(source, format, format_settings, getContext());
-    auto get_last_mod_time = [&]() -> std::optional<time_t>
+    auto get_last_mod_time = [&]() -> std::optional<TimeSpec>
     {
         auto last_mod = path_with_metadata.metadata.last_modified;
         if (last_mod)
-            return last_mod->epochTime();
+            return TimeSpec(last_mod->epochTime());
         return std::nullopt;
     };
 
@@ -1394,10 +1394,10 @@ namespace
             auto & schema_cache = StorageAzureBlob::getSchemaCache(getContext());
             for (auto it = begin; it < end; ++it)
             {
-                auto get_last_mod_time = [&] -> std::optional<time_t>
+                auto get_last_mod_time = [&] -> std::optional<TimeSpec>
                 {
                     if (it->metadata.last_modified)
-                        return it->metadata.last_modified->epochTime();
+                        return TimeSpec(it->metadata.last_modified->epochTime());
                     return std::nullopt;
                 };
 

--- a/src/Storages/StorageFile.h
+++ b/src/Storages/StorageFile.h
@@ -264,7 +264,7 @@ private:
 
     void addNumRowsToCache(const String & path, size_t num_rows) const;
 
-    std::optional<size_t> tryGetNumRowsFromCache(const String & path, time_t last_mod_time) const;
+    std::optional<size_t> tryGetNumRowsFromCache(const String & path, TimeSpec ts) const;
 
     std::shared_ptr<StorageFile> storage;
     FilesIteratorPtr files_iterator;


### PR DESCRIPTION
### Checklist
- [ ] use modification time instead of current time for initial cache entry

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Nanoseconds time precision for local files structure cache

Refs: https://github.com/ClickHouse/ClickHouse/pull/59874