### PR TITLE
CI: Fix job failures due to jepsen artifacts

### DIFF
--- a/tests/jepsen.clickhouse/project.clj
+++ b/tests/jepsen.clickhouse/project.clj
@@ -13,4 +13,7 @@
                  [com.hierynomus/sshj "0.34.0"]
                  [com.clickhouse/clickhouse-jdbc "0.3.2-patch11"]
                  [org.apache.zookeeper/zookeeper "3.6.1" :exclusions [org.slf4j/slf4j-log4j12]]]
-  :repl-options {:init-ns jepsen.clickhouse-keeper.main})
+  :repl-options {:init-ns jepsen.clickhouse-keeper.main}
+  ;; otherwise, target artifacts will be created under the repo root, so that checkout with clear might fail in ci
+  :target-path "/tmp/jepsen_clickhouse"
+)


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
change target path in jepsen config so that artifacts created in docker temp directory
```
Cleaning the repository
Warning: Unable to clean or reset the repository. The repository will be recreated instead.
Deleting the contents of '/home/ubuntu/actions-runner/_work/ClickHouse/ClickHouse'
Error: File was unable to be removed Error: EACCES: permission denied, rmdir '/home/ubuntu/actions-runner/_work/ClickHouse/ClickHouse/tests/jepsen.clickhouse/target/classes'
```
### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
