### PR TITLE
Do not pull mutations if pulling replication log had been stopped

### DIFF
--- a/src/Storages/MergeTree/ReplicatedMergeTreeQueue.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeQueue.cpp
@@ -860,6 +860,9 @@ ActiveDataPartSet getPartNamesToMutate(
 
 int32_t ReplicatedMergeTreeQueue::updateMutations(zkutil::ZooKeeperPtr zookeeper, Coordination::WatchCallbackPtr watch_callback)
 {
+    if (pull_log_blocker.isCancelled())
+        throw Exception(ErrorCodes::ABORTED, "Log pulling is cancelled");
+
     std::lock_guard lock(update_mutations_mutex);
 
     Coordination::Stat mutations_stat;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Do not pull mutations if pulling replication log had been stopped (`SYSTEM STOP PULLING REPLICATION LOG`)

Right now, mutations can be pulled even after:

    SYSTEM STOP PULLING REPLICATION LOG

Since they pulled from two places:
- `StorageReplicatedMergeTree::mutationsUpdatingTask()`
- `ReplicatedMergeTreeQueue::pullLogsToQueue()`

And only the last one checks action blocker.

Cc: @tavplubix 