### PR TITLE
Fix `02982_comments_in_system_tables`

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -2494,7 +2494,8 @@ def main(args):
                     time DateTime,
                     test_name String,
                     coverage Array(UInt64)
-                ) ENGINE = MergeTree ORDER BY test_name;
+                ) ENGINE = MergeTree ORDER BY test_name
+                COMMENT 'Contains information about per-test coverage from the CI, but used only for exporting to the CI cluster';
             """,
         )
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

If the table is created by clickhouse-test, then it doesn't have a comment thus `02982_comments_in_system_tables` fails. Issue introduced by https://github.com/ClickHouse/ClickHouse/pull/58792.