### PR TITLE
Do not rebuild a lambda package if it is updated

### DIFF
--- a/tests/ci/team_keys_lambda/build_and_deploy_archive.sh
+++ b/tests/ci/team_keys_lambda/build_and_deploy_archive.sh
@@ -17,6 +17,18 @@ DOCKER_IMAGE="public.ecr.aws/lambda/python:${PY_VERSION}"
 LAMBDA_NAME=${DIR_NAME//_/-}
 # The name of directory with lambda code
 PACKAGE=lambda-package
+
+# Do not rebuild and deploy the archive if it's newer than sources
+if [ -e "$PACKAGE.zip" ] && [ -z "$FORCE" ]; then
+  REBUILD=""
+  for src in app.py build_and_deploy_archive.sh requirements.txt lambda_shared/*; do
+    if [ "$src" -nt "$PACKAGE.zip" ]; then
+      REBUILD=1
+    fi
+  done
+  [ -n "$REBUILD" ] || exit 0
+fi
+
 rm -rf "$PACKAGE" "$PACKAGE".zip
 mkdir "$PACKAGE"
 cp app.py "$PACKAGE"


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
If the archive exists and is newer than every source, we don't need to build it again