### PR TITLE
Update tests with indexHint for analyzer.

### DIFF
--- a/tests/analyzer_tech_debt.txt
+++ b/tests/analyzer_tech_debt.txt
@@ -8,8 +8,6 @@
 01584_distributed_buffer_cannot_find_column
 01624_soft_constraints
 01656_test_query_log_factories_info
-01739_index_hint
-02880_indexHint__partition_id
 01747_join_view_filter_dictionary
 01761_cast_to_enum_nullable
 01925_join_materialized_columns

--- a/tests/queries/0_stateless/01739_index_hint.reference
+++ b/tests/queries/0_stateless/01739_index_hint.reference
@@ -35,6 +35,9 @@ SELECT count() FROM XXXX WHERE indexHint(t = toDateTime(0)) SETTINGS optimize_us
 drop table XXXX;
 CREATE TABLE XXXX (p Nullable(Int64), k Decimal(76, 39)) ENGINE = MergeTree PARTITION BY toDate(p) ORDER BY k SETTINGS index_granularity = 1, allow_nullable_key = 1;
 INSERT INTO XXXX FORMAT Values ('2020-09-01 00:01:02', 1), ('2020-09-01 20:01:03', 2), ('2020-09-02 00:01:03', 3);
-SELECT count() FROM XXXX WHERE indexHint(p = 1.) SETTINGS optimize_use_implicit_projections = 1;
+SELECT count() FROM XXXX WHERE indexHint(p = 1.) SETTINGS optimize_use_implicit_projections = 1, allow_experimental_analyzer=0;
 0
+-- TODO: optimize_use_implicit_projections ignores indexHint (with analyzer) because source columns might be aliased.
+SELECT count() FROM XXXX WHERE indexHint(p = 1.) SETTINGS optimize_use_implicit_projections = 1, allow_experimental_analyzer=1;
+3
 drop table XXXX;

--- a/tests/queries/0_stateless/01739_index_hint.sql
+++ b/tests/queries/0_stateless/01739_index_hint.sql
@@ -38,6 +38,8 @@ CREATE TABLE XXXX (p Nullable(Int64), k Decimal(76, 39)) ENGINE = MergeTree PART
 
 INSERT INTO XXXX FORMAT Values ('2020-09-01 00:01:02', 1), ('2020-09-01 20:01:03', 2), ('2020-09-02 00:01:03', 3);
 
-SELECT count() FROM XXXX WHERE indexHint(p = 1.) SETTINGS optimize_use_implicit_projections = 1;
+SELECT count() FROM XXXX WHERE indexHint(p = 1.) SETTINGS optimize_use_implicit_projections = 1, allow_experimental_analyzer=0;
+-- TODO: optimize_use_implicit_projections ignores indexHint (with analyzer) because source columns might be aliased.
+SELECT count() FROM XXXX WHERE indexHint(p = 1.) SETTINGS optimize_use_implicit_projections = 1, allow_experimental_analyzer=1;
 
 drop table XXXX;

--- a/tests/queries/0_stateless/02880_indexHint__partition_id.reference
+++ b/tests/queries/0_stateless/02880_indexHint__partition_id.reference
@@ -1,9 +1,10 @@
 -- { echoOn }
 select * from data prewhere indexHint(_partition_id = '1');
 1
-select count() from data prewhere indexHint(_partition_id = '1');
+-- TODO: optimize_use_implicit_projections ignores indexHint (with analyzer) because source columns might be aliased.
+select count() from data prewhere indexHint(_partition_id = '1') settings optimize_use_implicit_projections = 0;
 1
 select * from data where indexHint(_partition_id = '1');
 1
-select count() from data where indexHint(_partition_id = '1');
+select count() from data where indexHint(_partition_id = '1') settings optimize_use_implicit_projections = 0;
 1

--- a/tests/queries/0_stateless/02880_indexHint__partition_id.sql
+++ b/tests/queries/0_stateless/02880_indexHint__partition_id.sql
@@ -4,6 +4,7 @@ insert into data values (1)(2);
 
 -- { echoOn }
 select * from data prewhere indexHint(_partition_id = '1');
-select count() from data prewhere indexHint(_partition_id = '1');
+-- TODO: optimize_use_implicit_projections ignores indexHint (with analyzer) because source columns might be aliased.
+select count() from data prewhere indexHint(_partition_id = '1') settings optimize_use_implicit_projections = 0;
 select * from data where indexHint(_partition_id = '1');
-select count() from data where indexHint(_partition_id = '1');
+select count() from data where indexHint(_partition_id = '1') settings optimize_use_implicit_projections = 0;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

`indexHint` can't be used by `optimize_use_implicit_projections` optimization with enabled analyzer because source columns might have different aliases. Ignore this for now, cause `indexHint` does not guarantee anything anyway.