### PR TITLE
[RFC] Allow uuid in replica_path if CREATE TABLE explicitly has it

### DIFF
--- a/src/Parsers/ASTCreateQuery.h
+++ b/src/Parsers/ASTCreateQuery.h
@@ -96,6 +96,7 @@ public:
     bool is_populate{false};
     bool is_create_empty{false};    /// CREATE TABLE ... EMPTY AS SELECT ...
     bool replace_view{false}; /// CREATE OR REPLACE VIEW
+    bool has_uuid{false}; // CREATE TABLE x UUID '...'
 
     ASTColumns * columns_list = nullptr;
 

--- a/src/Parsers/ParserCreateQuery.cpp
+++ b/src/Parsers/ParserCreateQuery.cpp
@@ -684,6 +684,7 @@ bool ParserCreateTableQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expe
         query->database = table_id->getDatabase();
         query->table = table_id->getTable();
         query->uuid = table_id->uuid;
+        query->has_uuid = table_id->uuid != UUIDHelpers::Nil;
 
         if (query->database)
             query->children.push_back(query->database);
@@ -783,6 +784,7 @@ bool ParserCreateTableQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expe
     query->database = table_id->getDatabase();
     query->table = table_id->getTable();
     query->uuid = table_id->uuid;
+    query->has_uuid = table_id->uuid != UUIDHelpers::Nil;
     query->cluster = cluster_str;
 
     if (query->database)

--- a/src/Storages/MergeTree/registerStorageMergeTree.cpp
+++ b/src/Storages/MergeTree/registerStorageMergeTree.cpp
@@ -315,7 +315,8 @@ static StoragePtr create(const StorageFactory::Arguments & args)
         DatabaseCatalog::instance().getDatabase(args.table_id.database_name)->getEngineName() == "Replicated";
 
     /// Allow implicit {uuid} macros only for zookeeper_path in ON CLUSTER queries
-    bool allow_uuid_macro = is_on_cluster || is_replicated_database || args.query.attach;
+    /// and if UUID was explicitly passed in CREATE TABLE (like for ATTACH)
+    bool allow_uuid_macro = is_on_cluster || is_replicated_database || args.query.attach || args.query.has_uuid;
 
     auto expand_macro = [&] (ASTLiteral * ast_zk_path, ASTLiteral * ast_replica_name)
     {

--- a/tests/queries/0_stateless/02990_rmt_replica_path_uuid.reference
+++ b/tests/queries/0_stateless/02990_rmt_replica_path_uuid.reference
@@ -1,0 +1,4 @@
+aaaaaaaa-1111-2222-3333-aaaaaaaaaaaa
+/tables/default/aaaaaaaa-1111-2222-3333-aaaaaaaaaaaa/replicas/r1
+aaaaaaaa-1111-2222-3333-aaaaaaaaaaaa
+/tables/default/aaaaaaaa-1111-2222-3333-aaaaaaaaaaaa/replicas/r1

--- a/tests/queries/0_stateless/02990_rmt_replica_path_uuid.sql
+++ b/tests/queries/0_stateless/02990_rmt_replica_path_uuid.sql
@@ -1,0 +1,23 @@
+-- Tags: no-parallel, no-ordinary-database, no-replicated-database
+-- Tag no-parallel: static UUID
+-- Tag no-ordinary-database: requires UUID
+-- Tag no-replicated-database: executes with ON CLUSTER anyway
+
+-- Ignore "ATTACH TABLE query with full table definition is not recommended"
+-- Ignore BAD_ARGUMENTS
+SET send_logs_level='fatal';
+
+DROP TABLE IF EXISTS x;
+
+ATTACH TABLE x UUID 'aaaaaaaa-1111-2222-3333-aaaaaaaaaaaa' (key Int) ENGINE = ReplicatedMergeTree('/tables/{database}/{uuid}', 'r1') ORDER BY tuple();
+SELECT uuid FROM system.tables WHERE database = currentDatabase() and table = 'x';
+SELECT replica_path FROM system.replicas WHERE database = currentDatabase() and table = 'x';
+DROP TABLE x;
+
+-- {uuid} macro forbidden for CREATE TABLE without explicit UUID
+CREATE TABLE x (key Int) ENGINE = ReplicatedMergeTree('/tables/{database}/{uuid}', 'r1') ORDER BY tuple(); -- { serverError BAD_ARGUMENTS }
+
+CREATE TABLE x UUID 'aaaaaaaa-1111-2222-3333-aaaaaaaaaaaa' (key Int) ENGINE = ReplicatedMergeTree('/tables/{database}/{uuid}', 'r1') ORDER BY tuple();
+SELECT uuid FROM system.tables WHERE database = currentDatabase() and table = 'x';
+SELECT replica_path FROM system.replicas WHERE database = currentDatabase() and table = 'x';
+DROP TABLE x;


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Allow uuid in replica_path if CREATE TABLE explicitly has it

Right now the query with {uuid} macro without ON CLUSTER fails:

    CREATE TABLE x UUID 'aaaaaaaa-1111-2222-3333-aaaaaaaaaaaa' (key Int) ENGINE = ReplicatedMergeTree('/tables/{database}/{uuid}', 'r1') ORDER BY tuple();

There is a workaround right now to use ATTACH instead of CREATE, but ATTACH is not CREATE.

CREATE still useful for proper RESTORE without ON CLUSTER.

So this patch allows this syntax, but only if UUID had been explicitly passed in the query. This looks safe.

Fixes: https://github.com/ClickHouse/ClickHouse/issues/49404 (cc  @UnamedRus )
Cc: @tavplubix what do you think?