### PR TITLE
Enable async insert by default

### DIFF
--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -775,7 +775,7 @@ class IColumn;
     M(Bool, merge_tree_determine_task_size_by_prewhere_columns, true, "Whether to use only prewhere columns size to determine reading task size.", 0) \
     M(UInt64, merge_tree_compact_parts_min_granules_to_multibuffer_read, 16, "Only available in ClickHouse Cloud", 0) \
     \
-    M(Bool, async_insert, false, "If true, data from INSERT query is stored in queue and later flushed to table in background. If wait_for_async_insert is false, INSERT query is processed almost instantly, otherwise client will wait until data will be flushed to table", 0) \
+    M(Bool, async_insert, true, "If true, data from INSERT query is stored in queue and later flushed to table in background. If wait_for_async_insert is false, INSERT query is processed almost instantly, otherwise client will wait until data will be flushed to table", 0) \
     M(Bool, wait_for_async_insert, true, "If true wait for processing of asynchronous insertion", 0) \
     M(Seconds, wait_for_async_insert_timeout, DBMS_DEFAULT_LOCK_ACQUIRE_TIMEOUT_SEC, "Timeout for waiting for processing asynchronous insertion", 0) \
     M(UInt64, async_insert_max_data_size, 10485760, "Maximum size in bytes of unparsed data collected per query before being inserted", 0) \

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -80,6 +80,8 @@ static std::initializer_list<std::pair<ClickHouseVersion, SettingsChangesHistory
             {"database_replicated_allow_replicated_engine_arguments", 1, 0, "Don't allow explicit arguments by default"},
             {"database_replicated_allow_explicit_uuid", 0, 0, "Added a new setting to disallow explicitly specifying table UUID"},
             {"parallel_replicas_local_plan", false, false, "Use local plan for local replica in a query with parallel replicas"},
+            {"output_format_identifier_quoting_style", "Backticks", "Backticks", "New setting."},
+            {"async_insert", false, true, "Enable asynchronous inserts by default."},
         }
     },
     {"24.8",

--- a/tests/queries/0_stateless/02156_async_insert_query_log.reference
+++ b/tests/queries/0_stateless/02156_async_insert_query_log.reference
@@ -1,4 +1,4 @@
 1	a
 2	b
-INSERT INTO async_inserts_2156 VALUES 	1	Insert	1
-INSERT INTO async_inserts_2156 VALUES 	1	Insert	1
+INSERT INTO async_inserts_2156 VALUES 	1	Insert
+INSERT INTO async_inserts_2156 VALUES 	1	Insert

--- a/tests/queries/0_stateless/02156_async_insert_query_log.sh
+++ b/tests/queries/0_stateless/02156_async_insert_query_log.sh
@@ -15,7 +15,7 @@ ${CLICKHOUSE_CLIENT} -q "SELECT * FROM async_inserts_2156 ORDER BY id"
 ${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH LOGS"
 
 ${CLICKHOUSE_CLIENT} -q "SELECT query, arrayExists(x -> x LIKE '%async_inserts_2156', tables), \
-        query_kind, Settings['async_insert'] FROM system.query_log \
+        query_kind FROM system.query_log \
     WHERE event_date >= yesterday() AND current_database = '$CLICKHOUSE_DATABASE' \
     AND query ILIKE 'INSERT INTO async_inserts_2156 VALUES%' AND type = 'QueryFinish' \
     ORDER BY query_start_time_microseconds"

--- a/tests/queries/0_stateless/02896_leading_zeroes_no_octal.sql
+++ b/tests/queries/0_stateless/02896_leading_zeroes_no_octal.sql
@@ -102,13 +102,13 @@ INSERT INTO t_leading_zeroes_f VALUES (2069, '0x01P-01', 0x01P-01, 0.5, 'Hex sho
 
 -- Binary should not work with input_format_values_interpret_expressions = 0
 
-INSERT INTO t_leading_zeroes_f VALUES (2050, '0b10000', 0b10000, 16, 'Binary should not be parsed'); -- { clientError SYNTAX_ERROR }
-INSERT INTO t_leading_zeroes_f VALUES (2051, '-0b10000', -0b10000, -16, 'Binary should not be parsed'); -- { clientError SYNTAX_ERROR }
-INSERT INTO t_leading_zeroes_f VALUES (2052, '+0b10000', +0b10000, 16, 'Binary should not be parsed'); -- { clientError SYNTAX_ERROR }
+INSERT INTO t_leading_zeroes_f VALUES (2050, '0b10000', 0b10000, 16, 'Binary should not be parsed'); -- { serverError SYNTAX_ERROR }
+INSERT INTO t_leading_zeroes_f VALUES (2051, '-0b10000', -0b10000, -16, 'Binary should not be parsed'); -- { serverError SYNTAX_ERROR }
+INSERT INTO t_leading_zeroes_f VALUES (2052, '+0b10000', +0b10000, 16, 'Binary should not be parsed'); -- { serverError SYNTAX_ERROR }
 
-INSERT INTO t_leading_zeroes VALUES (1050, '0b10000', 0b10000, 16, 'Binary should not be parsed'); -- { clientError SYNTAX_ERROR }
-INSERT INTO t_leading_zeroes VALUES (1051, '-0b10000', -0b10000, -16, 'Binary should not be parsed'); -- { clientError SYNTAX_ERROR }
-INSERT INTO t_leading_zeroes VALUES (1052, '+0b10000', +0b10000, 16, 'Binary should not be parsed'); -- { clientError SYNTAX_ERROR }
+INSERT INTO t_leading_zeroes VALUES (1050, '0b10000', 0b10000, 16, 'Binary should not be parsed'); -- { serverError SYNTAX_ERROR }
+INSERT INTO t_leading_zeroes VALUES (1051, '-0b10000', -0b10000, -16, 'Binary should not be parsed'); -- { serverError SYNTAX_ERROR }
+INSERT INTO t_leading_zeroes VALUES (1052, '+0b10000', +0b10000, 16, 'Binary should not be parsed'); -- { serverError SYNTAX_ERROR }
 
 
 

--- a/tests/queries/0_stateless/03036_udf_user_defined_directory_in_client.reference
+++ b/tests/queries/0_stateless/03036_udf_user_defined_directory_in_client.reference
@@ -1,1 +1,1 @@
-Unknown function
+OK

--- a/tests/queries/0_stateless/03036_udf_user_defined_directory_in_client.sh
+++ b/tests/queries/0_stateless/03036_udf_user_defined_directory_in_client.sh
@@ -8,7 +8,7 @@ ${CLICKHOUSE_CLIENT} --query "DROP TABLE IF EXISTS test"
 ${CLICKHOUSE_CLIENT} --query "CREATE TABLE test (s String) ENGINE = Memory"
 
 # Calling an unknown function should not lead to creation of a 'user_defined' directory in the current directory
-${CLICKHOUSE_CLIENT} --query "INSERT INTO test VALUES (xyz('abc'))" 2>&1 | grep -o -F 'Unknown function'
+(( $(${CLICKHOUSE_CLIENT} --query "INSERT INTO test VALUES (xyz('abc'))" 2>&1 | grep -o -F -c 'Unknown function') >= 1 )) && echo "OK" || echo "FAIL"
 
 ls -ld user_defined 2> /dev/null
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Enable asynchronous inserts by default.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
