### PR TITLE
Decrease logging level for http retriable errors to Warning (and fix 00157_cache_dictionary flakiness)

### DIFF
--- a/src/IO/ReadWriteBufferFromHTTP.cpp
+++ b/src/IO/ReadWriteBufferFromHTTP.cpp
@@ -552,7 +552,7 @@ bool ReadWriteBufferFromHTTPBase<UpdatableSessionPtr>::nextImpl()
             if (!can_retry_request)
                 throw;
 
-            LOG_ERROR(
+            LOG_WARNING(
                 log,
                 "HTTP request to `{}` failed at try {}/{} with bytes read: {}/{}. "
                 "Error: {}. (Current backoff wait is {}/{} ms)",

--- a/tests/queries/1_stateful/00157_cache_dictionary.sql
+++ b/tests/queries/1_stateful/00157_cache_dictionary.sql
@@ -1,5 +1,8 @@
 -- Tags: no-tsan, no-parallel
 
+-- Suppress "ReadWriteBufferFromHTTP: HTTP request to `{}` failed at try 1/10 with bytes read: 311149/378695. Error: DB::HTTPException: Received error from remote server {}. (Current backoff wait is 100/10000 ms)" errors
+SET send_logs_level='error';
+
 DROP TABLE IF EXISTS test.hits_1m;
 
 CREATE TABLE test.hits_1m AS test.hits


### PR DESCRIPTION
Messages like this:

    2024-02-12 21:25:24 [5c66f008cd40] 2024.02.12 14:25:01.596769 [ 2530 ] {e71fcb6d-356d-4962-95bd-ef8b8c504e11} <Error> ReadWriteBufferFromHTTP: HTTP request to `https://clickhouse-datasets-web.s3.us-east-1.amazonaws.com/store/78e/78ebf6a1-d987-4579-b3ec-00c1a087b1f3/201403_1_1_2/UserAgent.bin` failed at try 1/10 with bytes read: 311149/378695. Error: DB::HTTPException: Received error from remote server /store/78e/78ebf6a1-d987-4579-b3ec-00c1a087b1f3/201403_1_1_2/UserAgent.bin. HTTP status code: 500 Internal Server Error, body: <?xml version="1.0" encoding="UTF-8"?>

Also fix `00157_cache_dictionary` flakiness

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)