### PR TITLE
tests: fix 02981_vertical_merges_memory_usage flakiness

### DIFF
--- a/tests/queries/0_stateless/02981_vertical_merges_memory_usage.sql
+++ b/tests/queries/0_stateless/02981_vertical_merges_memory_usage.sql
@@ -13,8 +13,8 @@ SETTINGS
     merge_max_block_size = 8192,
     merge_max_block_size_bytes = '10M';
 
-INSERT INTO t_vertical_merge_memory SELECT number, arrayMap(x -> repeat('a', 50), range(1000)) FROM numbers(30000);
-INSERT INTO t_vertical_merge_memory SELECT number, arrayMap(x -> repeat('a', 50), range(1000)) FROM numbers(30000);
+INSERT INTO t_vertical_merge_memory SELECT number, arrayMap(x -> repeat('a', 50), range(1000)) FROM numbers(3000);
+INSERT INTO t_vertical_merge_memory SELECT number, arrayMap(x -> repeat('a', 50), range(1000)) FROM numbers(3000);
 
 OPTIMIZE TABLE t_vertical_merge_memory FINAL;
 


### PR DESCRIPTION
Note, that I've checked this change by reverting #59340, i.e.

    diff --git a/src/Processors/Transforms/ColumnGathererTransform.h b/src/Processors/Transforms/ColumnGathererTransform.h
    index 4e56cffa46a..dd3c555f361 100644
    --- a/src/Processors/Transforms/ColumnGathererTransform.h
    +++ b/src/Processors/Transforms/ColumnGathererTransform.h
    @@ -195,7 +195,7 @@ void ColumnGathererStream::gather(Column & column_res)
             }

             source.pos += len;
    -    } while (column_res.size() < block_preferred_size_rows && column_res.byteSize() < block_preferred_size_bytes);
    +    } while (true);
     }

     }

And it fails:

    02981_vertical_merges_memory_usage:                                     [ FAIL ] - result differs with reference:
    --- /src/ch/clickhouse/tests/queries/0_stateless/02981_vertical_merges_memory_usage.reference   2024-02-13 10:37:54.771393874 +0100
    +++ /src/ch/clickhouse/tests/queries/0_stateless/02981_vertical_merges_memory_usage.stdout      2024-02-13 10:41:06.781109565 +0100
    @@ -1 +1 @@
    -Vertical       OK
    +Vertical       FAIL: memory usage: 626.59 MiB

<details>

<summary>profile events</summary>

```
62|azat@s1:~/ch/tmp/59176$ ch local --file query_log.tsv.zst -q "select pe.1, pe.2 from table array join ProfileEvents as pe where log_comment = '02981_vertical_merges_memory_usage.sql' and query ilike '%optimize%' and type != 'QueryStart' and pe.1 like '%sec%' format PrettyCompact " 
┌─tupleElement(pe, 1)─────────────────────────────┬─tupleElement(pe, 2)─┐
│ OpenedFileCacheMicroseconds                     │                 424 │
│ DiskReadElapsedMicroseconds                     │                 156 │
│ DiskWriteElapsedMicroseconds                    │                 246 │
│ WaitMarksLoadMicroseconds                       │                  31 │
│ MergesTimeMilliseconds                          │              311365 │
│ ContextLockWaitMicroseconds                     │                  83 │
│ PartsLockHoldMicroseconds                       │                1112 │
│ PartsLockWaitMicroseconds                       │                   6 │
│ RealTimeMicroseconds                            │           314597588 │
│ UserTimeMicroseconds                            │           117020905 │
│ SystemTimeMicroseconds                          │           108054354 │
│ OSCPUWaitMicroseconds                           │            22556998 │
│ OSCPUVirtualTimeMicroseconds                    │           225101823 │
│ S3ReadMicroseconds                              │               16548 │
│ S3WriteMicroseconds                             │              159243 │
│ DiskS3ReadMicroseconds                          │               16548 │
│ DiskS3WriteMicroseconds                         │              159243 │
│ ReadBufferFromS3Microseconds                    │              161374 │
│ ReadBufferFromS3InitMicroseconds                │               41964 │
│ WriteBufferFromS3Microseconds                   │              460579 │
│ WriteBufferFromS3WaitInflightLimitMicroseconds  │                   1 │
│ CachedReadBufferReadFromSourceMicroseconds      │              161560 │
│ CachedReadBufferCreateBufferMicroseconds        │                 270 │
│ FilesystemCacheLockKeyMicroseconds              │                  11 │
│ FilesystemCacheLockMetadataMicroseconds         │                 178 │
│ FilesystemCacheLockCacheMicroseconds            │                   1 │
│ FilesystemCacheReserveMicroseconds              │                  27 │
│ FilesystemCacheGetMicroseconds                  │                 509 │
│ FileSegmentCompleteMicroseconds                 │                 705 │
│ FileSegmentLockMicroseconds                     │                 130 │
│ FileSegmentUseMicroseconds                      │                  21 │
│ FileSegmentHolderCompleteMicroseconds           │                1318 │
│ ThreadpoolReaderTaskMicroseconds                │              165175 │
│ ThreadpoolReaderPrepareMicroseconds             │                   8 │
│ ThreadpoolReaderSubmitLookupInCacheMicroseconds │                 888 │
│ FileSegmentWaitReadBufferMicroseconds           │                 332 │
│ AsynchronousRemoteReadWaitMicroseconds          │               24965 │
│ SynchronousRemoteReadWaitMicroseconds           │               24024 │
└─────────────────────────────────────────────────┴─────────────────────┘
```

</details>

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Fixes: https://github.com/ClickHouse/ClickHouse/issues/59648
Cc: @CurtizJ 