### PR TITLE
Do not rewrite sum() to count() if return value differs in analyzer

### DIFF
--- a/src/Analyzer/Passes/NormalizeCountVariantsPass.cpp
+++ b/src/Analyzer/Passes/NormalizeCountVariantsPass.cpp
@@ -7,6 +7,7 @@
 #include <Analyzer/ConstantNode.h>
 #include <Analyzer/FunctionNode.h>
 #include <Interpreters/Context.h>
+#include <DataTypes/DataTypesNumber.h>
 
 namespace DB
 {
@@ -30,6 +31,11 @@ public:
             return;
 
         if (function_node->getArguments().getNodes().size() != 1)
+            return;
+
+        /// forbid the optimization if return value of sum() and count() differs:
+        /// count() returns only UInt64 type, while sum() could return Nullable().
+        if (!function_node->getResultType()->equals(DataTypeUInt64()))
             return;
 
         auto & first_argument = function_node->getArguments().getNodes()[0];

--- a/src/Analyzer/QueryTreePassManager.cpp
+++ b/src/Analyzer/QueryTreePassManager.cpp
@@ -61,7 +61,7 @@ namespace ErrorCodes
 namespace
 {
 
-#ifndef NDEBUG
+#if defined(ABORT_ON_LOGICAL_ERROR)
 
 /** This visitor checks if Query Tree structure is valid after each pass
   * in debug build.
@@ -184,7 +184,7 @@ void QueryTreePassManager::run(QueryTreeNodePtr query_tree_node)
     for (size_t i = 0; i < passes_size; ++i)
     {
         passes[i]->run(query_tree_node, current_context);
-#ifndef NDEBUG
+#if defined(ABORT_ON_LOGICAL_ERROR)
         ValidationChecker(passes[i]->getName()).visit(query_tree_node);
 #endif
     }
@@ -209,7 +209,7 @@ void QueryTreePassManager::run(QueryTreeNodePtr query_tree_node, size_t up_to_pa
     for (size_t i = 0; i < up_to_pass_index; ++i)
     {
         passes[i]->run(query_tree_node, current_context);
-#ifndef NDEBUG
+#if defined(ABORT_ON_LOGICAL_ERROR)
         ValidationChecker(passes[i]->getName()).visit(query_tree_node);
 #endif
     }

--- a/tests/queries/0_stateless/02991_count_rewrite_analyzer.reference
+++ b/tests/queries/0_stateless/02991_count_rewrite_analyzer.reference
@@ -1,0 +1,4 @@
+Nullable(UInt64)
+UInt64
+Nullable(UInt64)
+UInt64

--- a/tests/queries/0_stateless/02991_count_rewrite_analyzer.sql
+++ b/tests/queries/0_stateless/02991_count_rewrite_analyzer.sql
@@ -1,0 +1,7 @@
+-- Regression test for https://github.com/ClickHouse/ClickHouse/issues/59919
+SET allow_experimental_analyzer=1;
+
+SELECT toTypeName(sum(toNullable('a') IN toNullable('a'))) AS x;
+SELECT toTypeName(count(toNullable('a') IN toNullable('a'))) AS x;
+SELECT toTypeName(sum(toFixedString('a', toLowCardinality(toNullable(1))) IN toFixedString('a', 1))) AS x;
+SELECT toTypeName(count(toFixedString('a', toLowCardinality(toNullable(1))) IN toFixedString('a', 1))) AS x;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Do not rewrite sum() to count() if return value differs in analyzer

Fixes: https://github.com/ClickHouse/ClickHouse/issues/59919
Cc: @kitaisreal 