### PR TITLE
Replace lambdas with pointers to members to simplify stacks 

### DIFF
--- a/src/Storages/MergeTree/MergeTask.cpp
+++ b/src/Storages/MergeTree/MergeTask.cpp
@@ -436,7 +436,7 @@ MergeTask::StageRuntimeContextPtr MergeTask::VerticalMergeStage::getContextForNe
 bool MergeTask::ExecuteAndFinalizeHorizontalPart::execute()
 {
     assert(subtasks_iterator != subtasks.end());
-    if ((*subtasks_iterator)())
+    if ((this->**subtasks_iterator)())
         return true;
 
     /// Move to the next subtask in an array of subtasks
@@ -827,7 +827,7 @@ bool MergeTask::MergeProjectionsStage::finalizeProjectionsAndWholeMerge() const
 bool MergeTask::VerticalMergeStage::execute()
 {
     assert(subtasks_iterator != subtasks.end());
-    if ((*subtasks_iterator)())
+    if ((this->**subtasks_iterator)())
         return true;
 
     /// Move to the next subtask in an array of subtasks
@@ -838,7 +838,7 @@ bool MergeTask::VerticalMergeStage::execute()
 bool MergeTask::MergeProjectionsStage::execute()
 {
     assert(subtasks_iterator != subtasks.end());
-    if ((*subtasks_iterator)())
+    if ((this->**subtasks_iterator)())
         return true;
 
     /// Move to the next subtask in an array of subtasks

--- a/src/Storages/MergeTree/MergeTask.h
+++ b/src/Storages/MergeTree/MergeTask.h
@@ -246,15 +246,15 @@ private:
         bool prepare();
         bool executeImpl();
 
-        using ExecuteAndFinalizeHorizontalPartSubtasks = std::array<std::function<bool()>, 2>;
+        using ExecuteAndFinalizeHorizontalPartSubtasks = std::array<bool(ExecuteAndFinalizeHorizontalPart::*)(), 2>;
 
-        ExecuteAndFinalizeHorizontalPartSubtasks subtasks
+        const ExecuteAndFinalizeHorizontalPartSubtasks subtasks
         {
-            [this] () { return prepare(); },
-            [this] () { return executeImpl(); }
+            &ExecuteAndFinalizeHorizontalPart::prepare,
+            &ExecuteAndFinalizeHorizontalPart::executeImpl
         };
 
-        ExecuteAndFinalizeHorizontalPartSubtasks::iterator subtasks_iterator = subtasks.begin();
+        ExecuteAndFinalizeHorizontalPartSubtasks::const_iterator subtasks_iterator = subtasks.begin();
 
 
         MergeAlgorithm chooseMergeAlgorithm() const;
@@ -323,16 +323,16 @@ private:
         bool executeVerticalMergeForAllColumns() const;
         bool finalizeVerticalMergeForAllColumns() const;
 
-        using VerticalMergeStageSubtasks = std::array<std::function<bool()>, 3>;
+        using VerticalMergeStageSubtasks = std::array<bool(VerticalMergeStage::*)()const, 3>;
 
-        VerticalMergeStageSubtasks subtasks
+        const VerticalMergeStageSubtasks subtasks
         {
-            [this] () { return prepareVerticalMergeForAllColumns(); },
-            [this] () { return executeVerticalMergeForAllColumns(); },
-            [this] () { return finalizeVerticalMergeForAllColumns(); }
+            &VerticalMergeStage::prepareVerticalMergeForAllColumns,
+            &VerticalMergeStage::executeVerticalMergeForAllColumns,
+            &VerticalMergeStage::finalizeVerticalMergeForAllColumns
         };
 
-        VerticalMergeStageSubtasks::iterator subtasks_iterator = subtasks.begin();
+        VerticalMergeStageSubtasks::const_iterator subtasks_iterator = subtasks.begin();
 
         void prepareVerticalMergeForOneColumn() const;
         bool executeVerticalMergeForOneColumn() const;
@@ -373,16 +373,16 @@ private:
         bool executeProjections() const;
         bool finalizeProjectionsAndWholeMerge() const;
 
-        using MergeProjectionsStageSubtasks = std::array<std::function<bool()>, 3>;
+        using MergeProjectionsStageSubtasks = std::array<bool(MergeProjectionsStage::*)()const, 3>;
 
-        MergeProjectionsStageSubtasks subtasks
+        const MergeProjectionsStageSubtasks subtasks
         {
-            [this] () { return mergeMinMaxIndexAndPrepareProjections(); },
-            [this] () { return executeProjections(); },
-            [this] () { return finalizeProjectionsAndWholeMerge(); }
+            &MergeProjectionsStage::mergeMinMaxIndexAndPrepareProjections,
+            &MergeProjectionsStage::executeProjections,
+            &MergeProjectionsStage::finalizeProjectionsAndWholeMerge
         };
 
-        MergeProjectionsStageSubtasks::iterator subtasks_iterator = subtasks.begin();
+        MergeProjectionsStageSubtasks::const_iterator subtasks_iterator = subtasks.begin();
 
         MergeProjectionsRuntimeContextPtr ctx;
         GlobalRuntimeContextPtr global_ctx;
@@ -392,14 +392,14 @@ private:
 
     using Stages = std::array<StagePtr, 3>;
 
-    Stages stages
+    const Stages stages
     {
         std::make_shared<ExecuteAndFinalizeHorizontalPart>(),
         std::make_shared<VerticalMergeStage>(),
         std::make_shared<MergeProjectionsStage>()
     };
 
-    Stages::iterator stages_iterator = stages.begin();
+    Stages::const_iterator stages_iterator = stages.begin();
 
     /// Check for persisting block number column
     static bool supportsBlockNumberColumn(GlobalRuntimeContextPtr global_ctx)

--- a/src/Storages/MergeTree/MergeTask.h
+++ b/src/Storages/MergeTree/MergeTask.h
@@ -246,6 +246,7 @@ private:
         bool prepare();
         bool executeImpl();
 
+        /// NOTE: Using pointer-to-member instead of std::function and lambda makes stacktraces much more concise and readable
         using ExecuteAndFinalizeHorizontalPartSubtasks = std::array<bool(ExecuteAndFinalizeHorizontalPart::*)(), 2>;
 
         const ExecuteAndFinalizeHorizontalPartSubtasks subtasks
@@ -323,6 +324,7 @@ private:
         bool executeVerticalMergeForAllColumns() const;
         bool finalizeVerticalMergeForAllColumns() const;
 
+        /// NOTE: Using pointer-to-member instead of std::function and lambda makes stacktraces much more concise and readable
         using VerticalMergeStageSubtasks = std::array<bool(VerticalMergeStage::*)()const, 3>;
 
         const VerticalMergeStageSubtasks subtasks
@@ -373,6 +375,7 @@ private:
         bool executeProjections() const;
         bool finalizeProjectionsAndWholeMerge() const;
 
+        /// NOTE: Using pointer-to-member instead of std::function and lambda makes stacktraces much more concise and readable
         using MergeProjectionsStageSubtasks = std::array<bool(MergeProjectionsStage::*)()const, 3>;
 
         const MergeProjectionsStageSubtasks subtasks


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
This is a cosmetic change that simplifies how stack traces look in debugger.
Before:
```
* thread #610, name = 'MergeMutate', stop reason = breakpoint 2.1
  * frame #0: 0x00000000116e985a clickhouse`DB::MergeTask::ExecuteAndFinalizeHorizontalPart::prepare(this=0x00007ffe5505b6f8) at MergeTask.cpp:139:21
    frame #1: 0x00000000116fb469 clickhouse`bool std::__1::__function::__policy_invoker<bool ()>::__call_impl<std::__1::__function::__default_alloc_func<DB::MergeTask::ExecuteAndFinalizeHorizontalPart::subtasks::'lambda'(), bool ()>>(std::__1::__function::__policy_storage const*) [inlined] DB::MergeTask::ExecuteAndFinalizeHorizontalPart::subtasks::'lambda'(this=<unavailable>)::operator()() const at MergeTask.h:253:32
    frame #2: 0x00000000116fb464 clickhouse`bool std::__1::__function::__policy_invoker<bool ()>::__call_impl<std::__1::__function::__default_alloc_func<DB::MergeTask::ExecuteAndFinalizeHorizontalPart::subtasks::'lambda'(), bool ()>>(std::__1::__function::__policy_storage const*) [inlined] decltype(std::declval<DB::MergeTask::ExecuteAndFinalizeHorizontalPart::subtasks::'lambda'()&>()()) std::__1::__invoke[abi:v15000]<DB::MergeTask::ExecuteAndFinalizeHorizontalPart::subtasks::'lambda'()&>(__f=<unavailable>) at invoke.h:394:23
    frame #3: 0x00000000116fb464 clickhouse`bool std::__1::__function::__policy_invoker<bool ()>::__call_impl<std::__1::__function::__default_alloc_func<DB::MergeTask::ExecuteAndFinalizeHorizontalPart::subtasks::'lambda'(), bool ()>>(std::__1::__function::__policy_storage const*) [inlined] bool std::__1::__invoke_void_return_wrapper<bool, false>::__call<DB::MergeTask::ExecuteAndFinalizeHorizontalPart::subtasks::'lambda'()&>(__args=<unavailable>) at invoke.h:470:16
    frame #4: 0x00000000116fb464 clickhouse`bool std::__1::__function::__policy_invoker<bool ()>::__call_impl<std::__1::__function::__default_alloc_func<DB::MergeTask::ExecuteAndFinalizeHorizontalPart::subtasks::'lambda'(), bool ()>>(std::__1::__function::__policy_storage const*) [inlined] std::__1::__function::__default_alloc_func<DB::MergeTask::ExecuteAndFinalizeHorizontalPart::subtasks::'lambda'(), bool ()>::operator()[abi:v15000](this=<unavailable>) at function.h:235:12
    frame #5: 0x00000000116fb464 clickhouse`bool std::__1::__function::__policy_invoker<bool ()>::__call_impl<std::__1::__function::__default_alloc_func<DB::MergeTask::ExecuteAndFinalizeHorizontalPart::subtasks::'lambda'(), bool ()>>(__buf=<unavailable>) at function.h:716:16
    frame #6: 0x00000000116f206b clickhouse`DB::MergeTask::ExecuteAndFinalizeHorizontalPart::execute() [inlined] std::__1::__function::__policy_func<bool ()>::operator()[abi:v15000](this=<unavailable>) const at function.h:848:16
    frame #7: 0x00000000116f2068 clickhouse`DB::MergeTask::ExecuteAndFinalizeHorizontalPart::execute() [inlined] std::__1::function<bool ()>::operator()(this=<unavailable>) const at function.h:1187:12
    frame #8: 0x00000000116f2068 clickhouse`DB::MergeTask::ExecuteAndFinalizeHorizontalPart::execute(this=0x00007ffe5505b6f8) at MergeTask.cpp:442:9
...
```
After
```
* thread #606, name = 'MergeMutate', stop reason = breakpoint 1.1
  * frame #0: 0x00000000116e981a clickhouse`DB::MergeTask::ExecuteAndFinalizeHorizontalPart::prepare(this=0x00007fff536c8168) at MergeTask.cpp:139:21
    frame #1: 0x00000000116f2040 clickhouse`DB::MergeTask::ExecuteAndFinalizeHorizontalPart::execute(this=0x00007fff536c8168) at MergeTask.cpp:442:9

...
``` 