### PR TITLE
ReplicatedMergeTree invalid metadata_version fix

### DIFF
--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -513,8 +513,15 @@ StorageReplicatedMergeTree::StorageReplicatedMergeTree(
             if (same_structure)
             {
                 Coordination::Stat metadata_stat;
-                current_zookeeper->get(zookeeper_path + "/metadata", &metadata_stat);
+                current_zookeeper->get(fs::path(zookeeper_path) / "metadata", &metadata_stat);
+
+                /** We change metadata_snapshot so that `createReplica` method will create `metadata_version` node in ZooKeeper
+                  * with version of table '/metadata' node in Zookeeper.
+                  *
+                  * Otherwise `metadata_version` for not first replica will be initialized with 0 by default.
+                  */
                 setInMemoryMetadata(metadata_snapshot->withMetadataVersion(metadata_stat.version));
+                metadata_snapshot = getInMemoryMetadataPtr();
             }
         }
         catch (Coordination::Exception & e)

--- a/tests/queries/0_stateless/02989_replicated_merge_tree_invalid_metadata_version.reference
+++ b/tests/queries/0_stateless/02989_replicated_merge_tree_invalid_metadata_version.reference
@@ -1,5 +1,10 @@
 Row 1:
 ──────
+name:    metadata
+version: 1
+--
+Row 1:
+──────
 name:  metadata_version
 value: 1
 --

--- a/tests/queries/0_stateless/02989_replicated_merge_tree_invalid_metadata_version.reference
+++ b/tests/queries/0_stateless/02989_replicated_merge_tree_invalid_metadata_version.reference
@@ -1,0 +1,9 @@
+Row 1:
+──────
+name:  metadata_version
+value: 1
+--
+id	UInt64					
+value	String					
+insert_time	DateTime					
+insert_time_updated	DateTime					

--- a/tests/queries/0_stateless/02989_replicated_merge_tree_invalid_metadata_version.sql
+++ b/tests/queries/0_stateless/02989_replicated_merge_tree_invalid_metadata_version.sql
@@ -9,6 +9,10 @@ CREATE TABLE test_table_replicated
 
 ALTER TABLE test_table_replicated ADD COLUMN insert_time DateTime;
 
+SELECT name, version FROM system.zookeeper
+WHERE path = '/clickhouse/tables/' || currentDatabase() ||'/test_table_replicated/'
+AND name = 'metadata' FORMAT Vertical;
+
 DROP TABLE test_table_replicated;
 
 CREATE TABLE test_table_replicated
@@ -17,6 +21,8 @@ CREATE TABLE test_table_replicated
     value String,
     insert_time DateTime
 ) ENGINE=ReplicatedMergeTree('/clickhouse/tables/{database}/test_table_replicated', '2_replica') ORDER BY id;
+
+SELECT '--';
 
 SELECT name, value FROM system.zookeeper
 WHERE path = '/clickhouse/tables/' || currentDatabase() ||'/test_table_replicated/replicas/2_replica'

--- a/tests/queries/0_stateless/02989_replicated_merge_tree_invalid_metadata_version.sql
+++ b/tests/queries/0_stateless/02989_replicated_merge_tree_invalid_metadata_version.sql
@@ -1,0 +1,33 @@
+-- Tags: zookeeper
+
+DROP TABLE IF EXISTS test_table_replicated;
+CREATE TABLE test_table_replicated
+(
+    id UInt64,
+    value String
+) ENGINE=ReplicatedMergeTree('/clickhouse/tables/{database}/test_table_replicated', '1_replica') ORDER BY id;
+
+ALTER TABLE test_table_replicated ADD COLUMN insert_time DateTime;
+
+DROP TABLE test_table_replicated;
+
+CREATE TABLE test_table_replicated
+(
+    id UInt64,
+    value String,
+    insert_time DateTime
+) ENGINE=ReplicatedMergeTree('/clickhouse/tables/{database}/test_table_replicated', '2_replica') ORDER BY id;
+
+SELECT name, value FROM system.zookeeper
+WHERE path = '/clickhouse/tables/' || currentDatabase() ||'/test_table_replicated/replicas/2_replica'
+AND name = 'metadata_version' FORMAT Vertical;
+
+SYSTEM RESTART REPLICA test_table_replicated;
+
+ALTER TABLE test_table_replicated ADD COLUMN insert_time_updated DateTime;
+
+SELECT '--';
+
+DESCRIBE test_table_replicated;
+
+DROP TABLE test_table_replicated;

--- a/tests/queries/0_stateless/02989_replicated_merge_tree_invalid_metadata_version.sql
+++ b/tests/queries/0_stateless/02989_replicated_merge_tree_invalid_metadata_version.sql
@@ -13,14 +13,15 @@ SELECT name, version FROM system.zookeeper
 WHERE path = '/clickhouse/tables/' || currentDatabase() ||'/test_table_replicated/'
 AND name = 'metadata' FORMAT Vertical;
 
-DROP TABLE test_table_replicated;
-
-CREATE TABLE test_table_replicated
+DROP TABLE IF EXISTS test_table_replicated_second;
+CREATE TABLE test_table_replicated_second
 (
     id UInt64,
     value String,
     insert_time DateTime
 ) ENGINE=ReplicatedMergeTree('/clickhouse/tables/{database}/test_table_replicated', '2_replica') ORDER BY id;
+
+DROP TABLE test_table_replicated;
 
 SELECT '--';
 
@@ -28,12 +29,12 @@ SELECT name, value FROM system.zookeeper
 WHERE path = '/clickhouse/tables/' || currentDatabase() ||'/test_table_replicated/replicas/2_replica'
 AND name = 'metadata_version' FORMAT Vertical;
 
-SYSTEM RESTART REPLICA test_table_replicated;
+SYSTEM RESTART REPLICA test_table_replicated_second;
 
-ALTER TABLE test_table_replicated ADD COLUMN insert_time_updated DateTime;
+ALTER TABLE test_table_replicated_second ADD COLUMN insert_time_updated DateTime;
 
 SELECT '--';
 
-DESCRIBE test_table_replicated;
+DESCRIBE test_table_replicated_second;
 
-DROP TABLE test_table_replicated;
+DROP TABLE test_table_replicated_second;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
ReplicatedMergeTree fix invalid `metadata_version` node initialization in Zookeeper during creation of non first replica. Closes #54902.