### PR TITLE
Analyzer: Fix test_user_defined_object_persistence

### DIFF
--- a/tests/analyzer_integration_broken_tests.txt
+++ b/tests/analyzer_integration_broken_tests.txt
@@ -16,7 +16,6 @@ test_settings_profile/test.py::test_show_profiles
 test_shard_level_const_function/test.py::test_remote
 test_sql_user_defined_functions_on_cluster/test.py::test_sql_user_defined_functions_on_cluster
 test_storage_rabbitmq/test.py::test_rabbitmq_materialized_view
-test_user_defined_object_persistence/test.py::test_persistence
 test_wrong_db_or_table_name/test.py::test_wrong_table_name
 test_zookeeper_config/test.py::test_chroot_with_same_root
 test_zookeeper_config/test.py::test_chroot_with_different_root

--- a/tests/integration/test_user_defined_object_persistence/test.py
+++ b/tests/integration/test_user_defined_object_persistence/test.py
@@ -35,9 +35,16 @@ def test_persistence():
 
     instance.restart_clickhouse()
 
-    assert "Unknown function MySum1" in instance.query_and_get_error(
-        "SELECT MySum1(1, 2)"
+    error_message = instance.query_and_get_error("SELECT MySum1(1, 2)")
+    assert (
+        "Unknown function MySum1" in error_message
+        or "Function with name 'MySum1' does not exists. In scope SELECT MySum1(1, 2)"
+        in error_message
     )
-    assert "Unknown function MySum2" in instance.query_and_get_error(
-        "SELECT MySum2(1, 2)"
+
+    error_message = instance.query_and_get_error("SELECT MySum2(1, 2)")
+    assert (
+        "Unknown function MySum2" in error_message
+        or "Function with name 'MySum2' does not exists. In scope SELECT MySum2(1, 2)"
+        in error_message
     )


### PR DESCRIPTION
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Fix `test_user_defined_object_persistence`.