### PR TITLE
Fix max num to warn message

### DIFF
--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -907,7 +907,7 @@ Strings Context::getWarnings() const
         if (CurrentMetrics::get(CurrentMetrics::AttachedTable) > static_cast<Int64>(shared->max_table_num_to_warn))
             common_warnings.emplace_back(fmt::format("The number of attached tables is more than {}", shared->max_table_num_to_warn));
         if (CurrentMetrics::get(CurrentMetrics::AttachedDatabase) > static_cast<Int64>(shared->max_database_num_to_warn))
-            common_warnings.emplace_back(fmt::format("The number of attached databases is more than {}", shared->max_table_num_to_warn));
+            common_warnings.emplace_back(fmt::format("The number of attached databases is more than {}", shared->max_database_num_to_warn));
         if (CurrentMetrics::get(CurrentMetrics::PartsActive) > static_cast<Int64>(shared->max_part_num_to_warn))
             common_warnings.emplace_back(fmt::format("The number of active parts is more than {}", shared->max_part_num_to_warn));
     }

--- a/tests/config/config.d/max_num_to_warn.xml
+++ b/tests/config/config.d/max_num_to_warn.xml
@@ -1,5 +1,5 @@
 <clickhouse>
-    <max_table_num_to_warn>10</max_table_num_to_warn>
-    <max_database_num_to_warn>10</max_database_num_to_warn>
+    <max_table_num_to_warn>5</max_table_num_to_warn>
+    <max_database_num_to_warn>2</max_database_num_to_warn>
     <max_part_num_to_warn>10</max_part_num_to_warn>
 </clickhouse>

--- a/tests/queries/0_stateless/02931_max_num_to_warn.reference
+++ b/tests/queries/0_stateless/02931_max_num_to_warn.reference
@@ -1,3 +1,3 @@
-The number of attached tables is more than 10
-The number of attached databases is more than 10
+The number of attached tables is more than 5
+The number of attached databases is more than 2
 The number of active parts is more than 10

--- a/tests/queries/0_stateless/02931_max_num_to_warn.sql
+++ b/tests/queries/0_stateless/02931_max_num_to_warn.sql
@@ -37,7 +37,7 @@ INSERT INTO test_max_num_to_warn_02931.test_max_num_to_warn_9 VALUES (1, 'Hello'
 INSERT INTO test_max_num_to_warn_02931.test_max_num_to_warn_10 VALUES (1, 'Hello');
 INSERT INTO test_max_num_to_warn_02931.test_max_num_to_warn_11 VALUES (1, 'Hello');
 
-SELECT * FROM system.warnings where message in ('The number of attached tables is more than 10', 'The number of attached databases is more than 10', 'The number of active parts is more than 10');
+SELECT * FROM system.warnings where message in ('The number of attached tables is more than 5', 'The number of attached databases is more than 2', 'The number of active parts is more than 10');
 
 DROP DATABASE IF EXISTS test_max_num_to_warn_02931;
 DROP DATABASE IF EXISTS test_max_num_to_warn_1;


### PR DESCRIPTION
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Fix minor issue when displaying `max_database_num_to_warn` warning and improve tests