### PR TITLE
Remove context from comparison functions.

### DIFF
--- a/src/Functions/FunctionsComparison.h
+++ b/src/Functions/FunctionsComparison.h
@@ -643,13 +643,12 @@ class FunctionComparison : public IFunction
 {
 public:
     static constexpr auto name = Name::name;
-    static FunctionPtr create(ContextPtr context) { return std::make_shared<FunctionComparison>(context); }
+    static FunctionPtr create(ContextPtr context) { return std::make_shared<FunctionComparison>(decimalCheckComparisonOverflow(context)); }
 
-    explicit FunctionComparison(ContextPtr context_)
-        : context(context_), check_decimal_overflow(decimalCheckComparisonOverflow(context)) {}
+    explicit FunctionComparison(bool check_decimal_overflow_)
+        : check_decimal_overflow(check_decimal_overflow_) {}
 
 private:
-    ContextPtr context;
     bool check_decimal_overflow = true;
 
     template <typename T0, typename T1>
@@ -1190,7 +1189,7 @@ public:
 
         if (left_tuple && right_tuple)
         {
-            auto func = FunctionToOverloadResolverAdaptor(FunctionComparison<Op, Name>::create(context));
+            auto func = FunctionToOverloadResolverAdaptor(std::make_shared<FunctionComparison<Op, Name>>(check_decimal_overflow));
 
             bool has_nullable = false;
             bool has_null = false;

--- a/src/Functions/equals.cpp
+++ b/src/Functions/equals.cpp
@@ -1,5 +1,6 @@
 #include <Functions/FunctionFactory.h>
 #include <Functions/FunctionsComparison.h>
+#include <Functions/FunctionsLogical.h>
 
 
 namespace DB
@@ -16,9 +17,16 @@ template <>
 ColumnPtr FunctionComparison<EqualsOp, NameEquals>::executeTupleImpl(
     const ColumnsWithTypeAndName & x, const ColumnsWithTypeAndName & y, size_t tuple_size, size_t input_rows_count) const
 {
+    FunctionOverloadResolverPtr func_builder_equals
+        = std::make_unique<FunctionToOverloadResolverAdaptor>(std::make_shared<FunctionEquals>(check_decimal_overflow));
+
+
+    FunctionOverloadResolverPtr func_builder_and
+        = std::make_unique<FunctionToOverloadResolverAdaptor>(std::make_shared<FunctionAnd>());
+
     return executeTupleEqualityImpl(
-        FunctionFactory::instance().get("equals", context),
-        FunctionFactory::instance().get("and", context),
+        func_builder_equals,
+        func_builder_and,
         x, y, tuple_size, input_rows_count);
 }
 

--- a/src/Functions/greater.cpp
+++ b/src/Functions/greater.cpp
@@ -1,11 +1,14 @@
 #include <Functions/FunctionFactory.h>
 #include <Functions/FunctionsComparison.h>
+#include <Functions/FunctionsLogical.h>
+
 
 
 namespace DB
 {
 
 using FunctionGreater = FunctionComparison<GreaterOp, NameGreater>;
+using FunctionEquals = FunctionComparison<EqualsOp, NameEquals>;
 
 REGISTER_FUNCTION(Greater)
 {
@@ -16,14 +19,24 @@ template <>
 ColumnPtr FunctionComparison<GreaterOp, NameGreater>::executeTupleImpl(
     const ColumnsWithTypeAndName & x, const ColumnsWithTypeAndName & y, size_t tuple_size, size_t input_rows_count) const
 {
-    auto greater = FunctionFactory::instance().get("greater", context);
+    FunctionOverloadResolverPtr greater
+        = std::make_unique<FunctionToOverloadResolverAdaptor>(std::make_shared<FunctionGreater>(check_decimal_overflow));
+
+    FunctionOverloadResolverPtr func_builder_or
+        = std::make_unique<FunctionToOverloadResolverAdaptor>(std::make_shared<FunctionOr>());
+
+    FunctionOverloadResolverPtr func_builder_and
+        = std::make_unique<FunctionToOverloadResolverAdaptor>(std::make_shared<FunctionAnd>());
+
+    FunctionOverloadResolverPtr func_builder_equals
+        = std::make_unique<FunctionToOverloadResolverAdaptor>(std::make_shared<FunctionEquals>(check_decimal_overflow));
 
     return executeTupleLessGreaterImpl(
         greater,
         greater,
-        FunctionFactory::instance().get("and", context),
-        FunctionFactory::instance().get("or", context),
-        FunctionFactory::instance().get("equals", context),
+        func_builder_and,
+        func_builder_or,
+        func_builder_equals,
         x, y, tuple_size, input_rows_count);
 }
 

--- a/src/Functions/greater.cpp
+++ b/src/Functions/greater.cpp
@@ -2,8 +2,6 @@
 #include <Functions/FunctionsComparison.h>
 #include <Functions/FunctionsLogical.h>
 
-
-
 namespace DB
 {
 

--- a/src/Functions/greaterOrEquals.cpp
+++ b/src/Functions/greaterOrEquals.cpp
@@ -1,11 +1,14 @@
 #include <Functions/FunctionFactory.h>
 #include <Functions/FunctionsComparison.h>
+#include <Functions/FunctionsLogical.h>
 
 
 namespace DB
 {
 
 using FunctionGreaterOrEquals = FunctionComparison<GreaterOrEqualsOp, NameGreaterOrEquals>;
+using FunctionGreater = FunctionComparison<GreaterOp, NameGreater>;
+using FunctionEquals = FunctionComparison<EqualsOp, NameEquals>;
 
 REGISTER_FUNCTION(GreaterOrEquals)
 {
@@ -16,12 +19,28 @@ template <>
 ColumnPtr FunctionComparison<GreaterOrEqualsOp, NameGreaterOrEquals>::executeTupleImpl(
     const ColumnsWithTypeAndName & x, const ColumnsWithTypeAndName & y, size_t tuple_size, size_t input_rows_count) const
 {
+
+    FunctionOverloadResolverPtr greater
+        = std::make_unique<FunctionToOverloadResolverAdaptor>(std::make_shared<FunctionGreater>(check_decimal_overflow));
+
+    FunctionOverloadResolverPtr greater_or_equals
+        = std::make_unique<FunctionToOverloadResolverAdaptor>(std::make_shared<FunctionGreaterOrEquals>(check_decimal_overflow));
+
+    FunctionOverloadResolverPtr func_builder_or
+        = std::make_unique<FunctionToOverloadResolverAdaptor>(std::make_shared<FunctionOr>());
+
+    FunctionOverloadResolverPtr func_builder_and
+        = std::make_unique<FunctionToOverloadResolverAdaptor>(std::make_shared<FunctionAnd>());
+
+    FunctionOverloadResolverPtr func_builder_equals
+        = std::make_unique<FunctionToOverloadResolverAdaptor>(std::make_shared<FunctionEquals>(check_decimal_overflow));
+
     return executeTupleLessGreaterImpl(
-        FunctionFactory::instance().get("greater", context),
-        FunctionFactory::instance().get("greaterOrEquals", context),
-        FunctionFactory::instance().get("and", context),
-        FunctionFactory::instance().get("or", context),
-        FunctionFactory::instance().get("equals", context),
+        greater,
+        greater_or_equals,
+        func_builder_and,
+        func_builder_or,
+        func_builder_equals,
         x, y, tuple_size, input_rows_count);
 }
 

--- a/src/Functions/less.cpp
+++ b/src/Functions/less.cpp
@@ -1,11 +1,13 @@
 #include <Functions/FunctionFactory.h>
 #include <Functions/FunctionsComparison.h>
+#include <Functions/FunctionsLogical.h>
 
 
 namespace DB
 {
 
 using FunctionLess = FunctionComparison<LessOp, NameLess>;
+using FunctionEquals = FunctionComparison<EqualsOp, NameEquals>;
 
 REGISTER_FUNCTION(Less)
 {
@@ -16,14 +18,24 @@ template <>
 ColumnPtr FunctionComparison<LessOp, NameLess>::executeTupleImpl(
     const ColumnsWithTypeAndName & x, const ColumnsWithTypeAndName & y, size_t tuple_size, size_t input_rows_count) const
 {
-    auto less = FunctionFactory::instance().get("less", context);
+    FunctionOverloadResolverPtr less
+        = std::make_unique<FunctionToOverloadResolverAdaptor>(std::make_shared<FunctionLess>(check_decimal_overflow));
+
+    FunctionOverloadResolverPtr func_builder_or
+        = std::make_unique<FunctionToOverloadResolverAdaptor>(std::make_shared<FunctionOr>());
+
+    FunctionOverloadResolverPtr func_builder_and
+        = std::make_unique<FunctionToOverloadResolverAdaptor>(std::make_shared<FunctionAnd>());
+
+    FunctionOverloadResolverPtr func_builder_equals
+        = std::make_unique<FunctionToOverloadResolverAdaptor>(std::make_shared<FunctionEquals>(check_decimal_overflow));
 
     return executeTupleLessGreaterImpl(
         less,
         less,
-        FunctionFactory::instance().get("and", context),
-        FunctionFactory::instance().get("or", context),
-        FunctionFactory::instance().get("equals", context),
+        func_builder_and,
+        func_builder_or,
+        func_builder_equals,
         x, y, tuple_size, input_rows_count);
 }
 

--- a/src/Functions/lessOrEquals.cpp
+++ b/src/Functions/lessOrEquals.cpp
@@ -1,11 +1,14 @@
 #include <Functions/FunctionFactory.h>
 #include <Functions/FunctionsComparison.h>
+#include <Functions/FunctionsLogical.h>
 
 
 namespace DB
 {
 
 using FunctionLessOrEquals = FunctionComparison<LessOrEqualsOp, NameLessOrEquals>;
+using FunctionLess = FunctionComparison<LessOp, NameLess>;
+using FunctionEquals = FunctionComparison<EqualsOp, NameEquals>;
 
 REGISTER_FUNCTION(LessOrEquals)
 {
@@ -16,12 +19,27 @@ template <>
 ColumnPtr FunctionComparison<LessOrEqualsOp, NameLessOrEquals>::executeTupleImpl(
     const ColumnsWithTypeAndName & x, const ColumnsWithTypeAndName & y, size_t tuple_size, size_t input_rows_count) const
 {
+    FunctionOverloadResolverPtr less_or_equals
+        = std::make_unique<FunctionToOverloadResolverAdaptor>(std::make_shared<FunctionLessOrEquals>(check_decimal_overflow));
+
+    FunctionOverloadResolverPtr less
+        = std::make_unique<FunctionToOverloadResolverAdaptor>(std::make_shared<FunctionLess>(check_decimal_overflow));
+
+    FunctionOverloadResolverPtr func_builder_or
+        = std::make_unique<FunctionToOverloadResolverAdaptor>(std::make_shared<FunctionOr>());
+
+    FunctionOverloadResolverPtr func_builder_and
+        = std::make_unique<FunctionToOverloadResolverAdaptor>(std::make_shared<FunctionAnd>());
+
+    FunctionOverloadResolverPtr func_builder_equals
+        = std::make_unique<FunctionToOverloadResolverAdaptor>(std::make_shared<FunctionEquals>(check_decimal_overflow));
+
     return executeTupleLessGreaterImpl(
-        FunctionFactory::instance().get("less", context),
-        FunctionFactory::instance().get("lessOrEquals", context),
-        FunctionFactory::instance().get("and", context),
-        FunctionFactory::instance().get("or", context),
-        FunctionFactory::instance().get("equals", context),
+        less,
+        less_or_equals,
+        func_builder_and,
+        func_builder_or,
+        func_builder_equals,
         x, y, tuple_size, input_rows_count);
 }
 

--- a/src/Functions/notEquals.cpp
+++ b/src/Functions/notEquals.cpp
@@ -1,5 +1,7 @@
 #include <Functions/FunctionFactory.h>
 #include <Functions/FunctionsComparison.h>
+#include <Functions/FunctionsLogical.h>
+
 
 
 namespace DB
@@ -16,9 +18,15 @@ template <>
 ColumnPtr FunctionComparison<NotEqualsOp, NameNotEquals>::executeTupleImpl(
     const ColumnsWithTypeAndName & x, const ColumnsWithTypeAndName & y, size_t tuple_size, size_t input_rows_count) const
 {
+    FunctionOverloadResolverPtr func_builder_not_equals
+        = std::make_unique<FunctionToOverloadResolverAdaptor>(std::make_shared<FunctionNotEquals>(check_decimal_overflow));
+
+    FunctionOverloadResolverPtr func_builder_or
+        = std::make_unique<FunctionToOverloadResolverAdaptor>(std::make_shared<FunctionOr>());
+
     return executeTupleEqualityImpl(
-        FunctionFactory::instance().get("notEquals", context),
-        FunctionFactory::instance().get("or", context),
+        func_builder_not_equals,
+        func_builder_or,
         x, y, tuple_size, input_rows_count);
 }
 

--- a/src/Functions/notEquals.cpp
+++ b/src/Functions/notEquals.cpp
@@ -2,8 +2,6 @@
 #include <Functions/FunctionsComparison.h>
 #include <Functions/FunctionsLogical.h>
 
-
-
 namespace DB
 {
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


