### PR TITLE
Fix mark release ready

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -327,6 +327,7 @@ jobs:
       run_command: |
         python3 build_report_check.py "$CHECK_NAME"
   MarkReleaseReady:
+    if: ${{ ! (contains(needs.*.result, 'skipped') || contains(needs.*.result, 'failure')) }}
     needs:
       - BuilderBinDarwin
       - BuilderBinDarwinAarch64

--- a/.github/workflows/release_branches.yml
+++ b/.github/workflows/release_branches.yml
@@ -228,6 +228,7 @@ jobs:
       run_command: |
         python3 build_report_check.py "$CHECK_NAME"
   MarkReleaseReady:
+    if: ${{ ! (contains(needs.*.result, 'skipped') || contains(needs.*.result, 'failure')) }}
     needs:
       - BuilderBinDarwin
       - BuilderBinDarwinAarch64

--- a/tests/ci/mark_release_ready.py
+++ b/tests/ci/mark_release_ready.py
@@ -56,7 +56,6 @@ def main():
         description,
         RELEASE_READY_STATUS,
         pr_info,
-        dump_to_file=True,
     )
 
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
The GH actions have a very ugly way of checking if all 1st level dependencies succeeded. The approach is tested in https://github.com/Felixoid/actions-experiments/commit/65f6be814e1eb143149fe7910742c9b518872e97

Besides that, unlock the way to mark any commit as ready for release locally.