### PR TITLE
Update min. clang version in Getting Started docs

### DIFF
--- a/docs/en/development/developer-instruction.md
+++ b/docs/en/development/developer-instruction.md
@@ -91,7 +91,7 @@ If you use Arch or Gentoo, you probably know it yourself how to install CMake.
 
 ## C++ Compiler {#c-compiler}
 
-Compilers Clang starting from version 15 is supported for building ClickHouse.
+Compilers Clang starting from version 16 is supported for building ClickHouse.
 
 Clang should be used instead of gcc. Though, our continuous integration (CI) platform runs checks for about a dozen of build combinations.
 


### PR DESCRIPTION
### Issue
Building config with `cmake` fails due for reason:
```
CMake Error at cmake/tools.cmake:33 (message):
  Compilation with Clang version 15.0.7 is unsupported, the minimum required
  version is 16.
Call Stack (most recent call first):
  CMakeLists.txt:18 (include)
```

Disregard, if this is not related to Clickhouse's `cmake` setup.

**Note:** Unable to add label `pr-documentation` to PR.

### Changelog category:
- Documentation (changelog entry is not required)

### Changelog entry:
- Update min. clang version in Getting Started docs
- Also checked RU version but doesn't appear to specify version requirement



### Documentation entry for user-facing changes

- [x] Documentation is written
