### PR TITLE
Inhibit randomization in some tests

### DIFF
--- a/tests/queries/0_stateless/02450_kill_distributed_query_deadlock.sh
+++ b/tests/queries/0_stateless/02450_kill_distributed_query_deadlock.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: long
+# Tags: long, no-random-settings, no-debug
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/02943_variant_type_with_different_local_and_global_order.sh
+++ b/tests/queries/0_stateless/02943_variant_type_with_different_local_and_global_order.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: long
+# Tags: long, no-debug
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # reset --log_comment
@@ -74,11 +74,11 @@ run 0
 $CH_CLIENT -q "drop table test;"
 
 echo "MergeTree compact"
-$CH_CLIENT -q "create table test (id UInt64, v Variant(UInt64, String, Array(UInt64))) engine=MergeTree order by id settings min_rows_for_wide_part=100000000, min_bytes_for_wide_part=1000000000;"
+$CH_CLIENT -q "create table test (id UInt64, v Variant(UInt64, String, Array(UInt64))) engine=MergeTree order by id settings min_rows_for_wide_part=100000000, min_bytes_for_wide_part=1000000000, index_granularity = 8192, index_granularity_bytes = '10Mi';"
 run 1
 $CH_CLIENT -q "drop table test;"
 
 echo "MergeTree wide"
-$CH_CLIENT -q "create table test (id UInt64, v Variant(UInt64, String, Array(UInt64))) engine=MergeTree order by id settings min_rows_for_wide_part=1, min_bytes_for_wide_part=1;"
+$CH_CLIENT -q "create table test (id UInt64, v Variant(UInt64, String, Array(UInt64))) engine=MergeTree order by id settings min_rows_for_wide_part=1, min_bytes_for_wide_part=1, index_granularity = 8192, index_granularity_bytes = '10Mi';"
 run 1
 $CH_CLIENT -q "drop table test;"

--- a/tests/queries/1_stateful/00037_uniq_state_merge1.sql
+++ b/tests/queries/1_stateful/00037_uniq_state_merge1.sql
@@ -1,1 +1,2 @@
+SET max_bytes_before_external_group_by = '1G';
 SELECT k, any(u) AS u, uniqMerge(us) AS us FROM (SELECT domain(URL) AS k, uniq(UserID) AS u, uniqState(UserID) AS us FROM test.hits GROUP BY k) GROUP BY k ORDER BY u DESC, k ASC LIMIT 100

--- a/tests/queries/1_stateful/00038_uniq_state_merge2.sql
+++ b/tests/queries/1_stateful/00038_uniq_state_merge2.sql
@@ -1,1 +1,2 @@
+SET max_bytes_before_external_group_by = '1G';
 SELECT topLevelDomain(concat('http://', k)) AS tld, sum(u) AS u, uniqMerge(us) AS us FROM (SELECT domain(URL) AS k, uniq(UserID) AS u, uniqState(UserID) AS us FROM test.hits GROUP BY k) GROUP BY tld ORDER BY u DESC, tld ASC LIMIT 100


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

https://s3.amazonaws.com/clickhouse-test-reports/59972/83a184d9281bcd7eda2ed0e9daa508715e9d7a8a/stateful_tests__debug__parallelreplicas_.html

https://s3.amazonaws.com/clickhouse-test-reports/59975/a7c7a5a671076dfd9be8fb3787a88ef55a392142/stateless_tests__debug__s3_storage__[4_6].html

https://s3.amazonaws.com/clickhouse-test-reports/59951/824ee3efc27a5eeab3fb6a7e1bd5e4a786f3689b/stateless_tests__debug__[2_5].html