### PR TITLE
Fix INSERT into SQLite with single quote (by escaping single quotes with a quote instead of backslash)

### DIFF
--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -1146,6 +1146,8 @@ class IColumn;
     M(Bool, output_format_sql_insert_use_replace, false, "Use REPLACE statement instead of INSERT", 0) \
     M(Bool, output_format_sql_insert_quote_names, true, "Quote column names with '`' characters", 0) \
     \
+    M(Bool, output_format_values_escape_quote_with_quote, false, "If true escape ' with '', otherwise quoted with \\'", 0) \
+    \
     M(Bool, output_format_bson_string_as_string, false, "Use BSON String type instead of Binary for String columns.", 0) \
     M(Bool, input_format_bson_skip_fields_with_unsupported_types_in_schema_inference, false, "Skip fields with unsupported types while schema inference for format BSON.", 0) \
     \

--- a/src/DataTypes/Serializations/SerializationString.cpp
+++ b/src/DataTypes/Serializations/SerializationString.cpp
@@ -334,9 +334,12 @@ bool SerializationString::tryDeserializeTextEscaped(IColumn & column, ReadBuffer
     return read<bool>(column, [&](ColumnString::Chars & data) { readEscapedStringInto(data, istr); return true; });
 }
 
-void SerializationString::serializeTextQuoted(const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettings &) const
+void SerializationString::serializeTextQuoted(const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettings & settings) const
 {
-    writeQuotedString(assert_cast<const ColumnString &>(column).getDataAt(row_num), ostr);
+    if (settings.values.escape_quote_with_quote)
+        writeQuotedStringPostgreSQL(assert_cast<const ColumnString &>(column).getDataAt(row_num).toView(), ostr);
+    else
+        writeQuotedString(assert_cast<const ColumnString &>(column).getDataAt(row_num), ostr);
 }
 
 

--- a/src/Formats/FormatFactory.cpp
+++ b/src/Formats/FormatFactory.cpp
@@ -181,6 +181,7 @@ FormatSettings getFormatSettings(ContextPtr context, const Settings & settings)
     format_settings.values.allow_data_after_semicolon = settings.input_format_values_allow_data_after_semicolon;
     format_settings.values.deduce_templates_of_expressions = settings.input_format_values_deduce_templates_of_expressions;
     format_settings.values.interpret_expressions = settings.input_format_values_interpret_expressions;
+    format_settings.values.escape_quote_with_quote = settings.output_format_values_escape_quote_with_quote;
     format_settings.with_names_use_header = settings.input_format_with_names_use_header;
     format_settings.with_types_use_header = settings.input_format_with_types_use_header;
     format_settings.write_statistics = settings.output_format_write_statistics;

--- a/src/Formats/FormatSettings.h
+++ b/src/Formats/FormatSettings.h
@@ -361,6 +361,7 @@ struct FormatSettings
         bool deduce_templates_of_expressions = true;
         bool accurate_types_of_literals = true;
         bool allow_data_after_semicolon = false;
+        bool escape_quote_with_quote = false;
     } values;
 
     enum class ORCCompression

--- a/src/Storages/StorageSQLite.h
+++ b/src/Storages/StorageSQLite.h
@@ -47,10 +47,13 @@ public:
         const String & table);
 
 private:
+    friend class SQLiteSink; /// for write_context
+
     String remote_table_name;
     String database_path;
     SQLitePtr sqlite_db;
     LoggerPtr log;
+    ContextPtr write_context;
 };
 
 }

--- a/tests/queries/0_stateless/01889_sqlite_read_write.reference
+++ b/tests/queries/0_stateless/01889_sqlite_read_write.reference
@@ -29,7 +29,7 @@ CREATE TABLE default.sqlite_table3\n(\n    `col1` String,\n    `col2` Int32\n)\n
 not a null	2
 	3
 	4
-line6	6
+line\'6	6
 	7
 test table function
 line1	1

--- a/tests/queries/0_stateless/01889_sqlite_read_write.sh
+++ b/tests/queries/0_stateless/01889_sqlite_read_write.sh
@@ -76,7 +76,7 @@ ${CLICKHOUSE_CLIENT} --query='DROP TABLE IF EXISTS sqlite_table3'
 ${CLICKHOUSE_CLIENT} --query="CREATE TABLE sqlite_table3 (col1 String, col2 Int32) ENGINE = SQLite('${DB_PATH}', 'table3')"
 
 ${CLICKHOUSE_CLIENT} --query='SHOW CREATE TABLE sqlite_table3;' | sed -r 's/(.*SQLite)(.*)/\1/'
-${CLICKHOUSE_CLIENT} --query="INSERT INTO sqlite_table3 VALUES ('line6', 6);"
+${CLICKHOUSE_CLIENT} --query="INSERT INTO sqlite_table3 VALUES ('line\'6', 6);"
 ${CLICKHOUSE_CLIENT} --query="INSERT INTO sqlite_table3 VALUES (NULL, 7);"
 
 ${CLICKHOUSE_CLIENT} --query='SELECT * FROM sqlite_table3 ORDER BY col2'

--- a/tests/queries/0_stateless/02993_values_escape_quote.reference
+++ b/tests/queries/0_stateless/02993_values_escape_quote.reference
@@ -1,0 +1,3 @@
+('foo')('foo\'bar')('foo\'\'bar')
+output_format_values_escape_quote_with_quote=1
+('foo')('foo''bar')('foo''''bar')

--- a/tests/queries/0_stateless/02993_values_escape_quote.sql
+++ b/tests/queries/0_stateless/02993_values_escape_quote.sql
@@ -1,0 +1,12 @@
+select 'foo' format Values;
+select 'foo\'bar' format Values;
+select 'foo\'\'bar' format Values;
+
+select '\noutput_format_values_escape_quote_with_quote=1' format LineAsString;
+set output_format_values_escape_quote_with_quote=1;
+
+select 'foo' format Values;
+select 'foo\'bar' format Values;
+select 'foo\'\'bar' format Values;
+-- fix no newline at end of file
+select '' format LineAsString;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix INSERT into SQLite with single quote (by properly escaping single quotes with a quote instead of backslash)