### PR TITLE
Analyzer: Fix test_sql_user_defined_functions_on_cluster

### DIFF
--- a/tests/analyzer_integration_broken_tests.txt
+++ b/tests/analyzer_integration_broken_tests.txt
@@ -9,4 +9,3 @@ test_merge_table_over_distributed/test.py::test_select_table_name_from_merge_ove
 test_passing_max_partitions_to_read_remotely/test.py::test_default_database_on_cluster
 test_select_access_rights/test_main.py::test_alias_columns
 test_settings_profile/test.py::test_show_profiles
-test_sql_user_defined_functions_on_cluster/test.py::test_sql_user_defined_functions_on_cluster

--- a/tests/integration/test_sql_user_defined_functions_on_cluster/test.py
+++ b/tests/integration/test_sql_user_defined_functions_on_cluster/test.py
@@ -1,5 +1,5 @@
 import pytest
-from helpers.cluster import ClickHouseCluster
+from helpers.cluster import ClickHouseCluster, ClickHouseInstance
 
 cluster = ClickHouseCluster(__file__)
 ch1 = cluster.add_instance(
@@ -24,15 +24,15 @@ def started_cluster():
 
 
 def test_sql_user_defined_functions_on_cluster():
-    assert "Unknown function test_function" in ch1.query_and_get_error(
-        "SELECT test_function(1);"
-    )
-    assert "Unknown function test_function" in ch2.query_and_get_error(
-        "SELECT test_function(1);"
-    )
-    assert "Unknown function test_function" in ch3.query_and_get_error(
-        "SELECT test_function(1);"
-    )
+    def check_function_does_not_exist(node : ClickHouseInstance):
+        error_message = node.query_and_get_error(
+            "SELECT test_function(1);"
+        )
+        assert "Unknown function test_function" in error_message or "Function with name 'test_function' does not exists. In scope SELECT test_function(1)" in error_message
+
+    check_function_does_not_exist(ch1)
+    check_function_does_not_exist(ch2)
+    check_function_does_not_exist(ch3)
 
     ch1.query_with_retry(
         "CREATE FUNCTION test_function ON CLUSTER 'cluster' AS x -> x + 1;"
@@ -43,12 +43,7 @@ def test_sql_user_defined_functions_on_cluster():
     assert ch3.query("SELECT test_function(1);") == "2\n"
 
     ch2.query_with_retry("DROP FUNCTION test_function ON CLUSTER 'cluster'")
-    assert "Unknown function test_function" in ch1.query_and_get_error(
-        "SELECT test_function(1);"
-    )
-    assert "Unknown function test_function" in ch2.query_and_get_error(
-        "SELECT test_function(1);"
-    )
-    assert "Unknown function test_function" in ch3.query_and_get_error(
-        "SELECT test_function(1);"
-    )
+
+    check_function_does_not_exist(ch1)
+    check_function_does_not_exist(ch2)
+    check_function_does_not_exist(ch3)

--- a/tests/integration/test_sql_user_defined_functions_on_cluster/test.py
+++ b/tests/integration/test_sql_user_defined_functions_on_cluster/test.py
@@ -24,11 +24,13 @@ def started_cluster():
 
 
 def test_sql_user_defined_functions_on_cluster():
-    def check_function_does_not_exist(node : ClickHouseInstance):
-        error_message = node.query_and_get_error(
-            "SELECT test_function(1);"
+    def check_function_does_not_exist(node: ClickHouseInstance):
+        error_message = node.query_and_get_error("SELECT test_function(1);")
+        assert (
+            "Unknown function test_function" in error_message
+            or "Function with name 'test_function' does not exists. In scope SELECT test_function(1)"
+            in error_message
         )
-        assert "Unknown function test_function" in error_message or "Function with name 'test_function' does not exists. In scope SELECT test_function(1)" in error_message
 
     check_function_does_not_exist(ch1)
     check_function_does_not_exist(ch2)


### PR DESCRIPTION
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Analyzer: Fix `test_sql_user_defined_functions_on_cluster/test.py::test_sql_user_defined_functions_on_cluster`.