### PR TITLE
Fix 02981_vertical_merges_memory_usage with SharedMergeTree

### DIFF
--- a/tests/queries/0_stateless/02981_vertical_merges_memory_usage.sql
+++ b/tests/queries/0_stateless/02981_vertical_merges_memory_usage.sql
@@ -1,4 +1,4 @@
--- Tags: long
+-- Tags: long, no-random-merge-tree-settings
 
 DROP TABLE IF EXISTS t_vertical_merge_memory;
 
@@ -14,7 +14,7 @@ SETTINGS
     merge_max_block_size_bytes = '10M';
 
 INSERT INTO t_vertical_merge_memory SELECT number, arrayMap(x -> repeat('a', 50), range(1000)) FROM numbers(3000);
-INSERT INTO t_vertical_merge_memory SELECT number, arrayMap(x -> repeat('a', 50), range(1000)) FROM numbers(3000);
+INSERT INTO t_vertical_merge_memory SELECT number, arrayMap(x -> repeat('a', 50), range(1000)) FROM numbers(3001);
 
 OPTIMIZE TABLE t_vertical_merge_memory FINAL;
 

--- a/tests/queries/0_stateless/02981_vertical_merges_memory_usage.sql
+++ b/tests/queries/0_stateless/02981_vertical_merges_memory_usage.sql
@@ -14,6 +14,8 @@ SETTINGS
     merge_max_block_size_bytes = '10M';
 
 INSERT INTO t_vertical_merge_memory SELECT number, arrayMap(x -> repeat('a', 50), range(1000)) FROM numbers(3000);
+-- Why 3001? - Deduplication, which is off with normal MergeTree by default but on for ReplicatedMergeTree and SharedMergeTree.
+-- We automatically replace MergeTree with SharedMergeTree in ClickHouse Cloud.
 INSERT INTO t_vertical_merge_memory SELECT number, arrayMap(x -> repeat('a', 50), range(1000)) FROM numbers(3001);
 
 OPTIMIZE TABLE t_vertical_merge_memory FINAL;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes


