### PR TITLE
Fix finished_mutations_to_keep=0 for MergeTree (as docs says 0 is to keep everything)

### DIFF
--- a/src/Storages/StorageMergeTree.cpp
+++ b/src/Storages/StorageMergeTree.cpp
@@ -1479,8 +1479,11 @@ UInt64 StorageMergeTree::getCurrentMutationVersion(
 
 size_t StorageMergeTree::clearOldMutations(bool truncate)
 {
-    size_t finished_mutations_to_keep = truncate ? 0 : getSettings()->finished_mutations_to_keep;
+    size_t finished_mutations_to_keep = getSettings()->finished_mutations_to_keep;
+    if (!truncate && !finished_mutations_to_keep)
+        return 0;
 
+    finished_mutations_to_keep = truncate ? 0 : finished_mutations_to_keep;
     std::vector<MergeTreeMutationEntry> mutations_to_delete;
     {
         std::lock_guard lock(currently_processing_in_background_mutex);

--- a/src/Storages/StorageMergeTree.cpp
+++ b/src/Storages/StorageMergeTree.cpp
@@ -1902,8 +1902,6 @@ void StorageMergeTree::dropPart(const String & part_name, bool detach, ContextPt
         }
     }
 
-    /// Old part objects is needed to be destroyed before clearing them from filesystem.
-    clearOldMutations(true);
     clearOldPartsFromFilesystem();
     clearEmptyParts();
 }
@@ -1988,8 +1986,6 @@ void StorageMergeTree::dropPartition(const ASTPtr & partition, bool detach, Cont
         }
     }
 
-    /// Old parts are needed to be destroyed before clearing them from filesystem.
-    clearOldMutations(true);
     clearOldPartsFromFilesystem();
     clearEmptyParts();
 }

--- a/tests/integration/test_replicated_zero_copy_projection_mutation/test.py
+++ b/tests/integration/test_replicated_zero_copy_projection_mutation/test.py
@@ -131,14 +131,13 @@ def test_all_projection_files_are_dropped_when_part_is_dropped(
             """
         )
 
-        objects_empty_table = list_objects(cluster)
-
         node.query(
             "ALTER TABLE test_all_projection_files_are_dropped ADD projection b_order (SELECT a, b ORDER BY b)"
         )
         node.query(
             "ALTER TABLE test_all_projection_files_are_dropped MATERIALIZE projection b_order"
         )
+        objects_empty_table = list_objects(cluster)
 
         node.query(
             """

--- a/tests/queries/0_stateless/02994_merge_tree_mutations_cleanup.reference
+++ b/tests/queries/0_stateless/02994_merge_tree_mutations_cleanup.reference
@@ -1,0 +1,4 @@
+mutations after ALTER for data_rmt	1
+mutations after cleanup for data_rmt	1
+mutations after ALTER for data_mt	1
+mutations after cleanup for data_mt	1

--- a/tests/queries/0_stateless/02994_merge_tree_mutations_cleanup.sql.j2
+++ b/tests/queries/0_stateless/02994_merge_tree_mutations_cleanup.sql.j2
@@ -1,0 +1,14 @@
+drop table if exists data_rmt;
+drop table if exists data_mt;
+
+create table data_rmt (key Int) engine=ReplicatedMergeTree('/tables/{database}/data', '{table}') order by tuple() settings finished_mutations_to_keep=0, merge_tree_clear_old_parts_interval_seconds=1;
+create table data_mt (key Int) engine=MergeTree() order by tuple() settings finished_mutations_to_keep=0, merge_tree_clear_old_parts_interval_seconds=1;
+
+{% for table in ['data_rmt', 'data_mt'] %}
+alter table {{table}} delete where 1;
+select 'mutations after ALTER for {{table}}', count() from system.mutations where database = currentDatabase() and table = '{{table}}';
+-- merge_tree_clear_old_parts_interval_seconds=1, but wait few seconds more
+select sleep(5) settings function_sleep_max_microseconds_per_block=10e6 format Null;
+select 'mutations after cleanup for {{table}}', count() from system.mutations where database = currentDatabase() and table = '{{table}}';
+drop table {{table}};
+{% endfor %}

--- a/tests/queries/0_stateless/02994_merge_tree_mutations_cleanup.sql.j2
+++ b/tests/queries/0_stateless/02994_merge_tree_mutations_cleanup.sql.j2
@@ -5,7 +5,7 @@ create table data_rmt (key Int) engine=ReplicatedMergeTree('/tables/{database}/d
 create table data_mt (key Int) engine=MergeTree() order by tuple() settings finished_mutations_to_keep=0, merge_tree_clear_old_parts_interval_seconds=1;
 
 {% for table in ['data_rmt', 'data_mt'] %}
-alter table {{table}} delete where 1;
+alter table {{table}} delete where 1 settings mutations_sync = 1;
 select 'mutations after ALTER for {{table}}', count() from system.mutations where database = currentDatabase() and table = '{{table}}';
 -- merge_tree_clear_old_parts_interval_seconds=1, but wait few seconds more
 select sleep(5) settings function_sleep_max_microseconds_per_block=10e6 format Null;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix finished_mutations_to_keep=0 for MergeTree (as docs says 0 is to keep everything)