### PR TITLE
[Docs] Add info on using select_sequential_consistency for INSERTS in…

### DIFF
--- a/docs/en/sql-reference/statements/insert-into.md
+++ b/docs/en/sql-reference/statements/insert-into.md
@@ -210,7 +210,7 @@ By default, services on ClickHouse Cloud provide multiple replicas for high avai
 
 After an `INSERT` succeeds, data is written to the underlying storage. However, it may take some time for replicas to receive these updates. Therefore, if you use a different connection that executes a `SELECT` query on one of these other replicas, the updated data may not yet be reflected.
 
-It is possible to use the `select_sequential_consistency` to force replicas to receive the latest updates. Here is an example of a SELECT query using this setting:
+It is possible to use the `select_sequential_consistency` to force the replica to receive the latest updates. Here is an example of a SELECT query using this setting:
 
 ```sql
 SELECT .... SETTINGS select_sequential_consistency = 1;

--- a/docs/en/sql-reference/statements/insert-into.md
+++ b/docs/en/sql-reference/statements/insert-into.md
@@ -204,6 +204,20 @@ Result:
 └─────┴───────────────────────┘
 ```
 
+## Inserts into ClickHouse Cloud
+
+By default, services on ClickHouse Cloud provide multiple replicas for high availability. When you connect to a service, a connection is established to one of these replicas.
+
+After an `INSERT` succeeds, data is written to the underlying storage. However, it may take some time for replicas to receive these updates. Therefore, if you use a different connection that executes a `SELECT` query on one of these other replicas, the updated data may not yet be reflected.
+
+It is possible to use the `select_sequential_consistency` to force replicas to receive the latest updates. Here is an example of a SELECT query using this setting:
+
+```sql
+SELECT .... SETTINGS select_sequential_consistency = 1;
+```
+
+Note that using `select_sequential_consistency` will increase the load on ClickHouse Keeper (used by ClickHouse Cloud internally) and may result in slower performance depending on the load on the service. We recommend against enabling this setting unless necessary. The recommended approach is to execute read/writes in the same session or to use a client driver that uses the native protocol (and thus supports sticky connections).
+
 ## Performance Considerations
 
 `INSERT` sorts the input data by primary key and splits them into partitions by a partition key. If you insert data into several partitions at once, it can significantly reduce the performance of the `INSERT` query. To avoid this:


### PR DESCRIPTION
### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Recommend using `select_sequential_consistency` in cloud if user requires all data to be received by all replicas immediately.