### PR TITLE
Fix SIGSEGV in ColumnTuple::popBack() when columns contains different number of rows

### DIFF
--- a/src/Columns/ColumnTuple.cpp
+++ b/src/Columns/ColumnTuple.cpp
@@ -169,7 +169,10 @@ void ColumnTuple::insertDefault()
 void ColumnTuple::popBack(size_t n)
 {
     for (auto & column : columns)
-        column->popBack(n);
+    {
+        if (column->size() >= n)
+            column->popBack(n);
+    }
 }
 
 StringRef ColumnTuple::serializeValueIntoArena(size_t n, Arena & arena, char const *& begin, const UInt8 *) const


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix SIGSEGV in ColumnTuple::popBack() when columns contains different number of rows

The problem is that during parsing you can fill only one column of tuple, but not the other, so you don't need to touch other columns, since it may leads to crash, like:

    [localhost] 2024.02.11 19:50:57.660127 [ 9168 ] {e666eadd-ed94-4091-bf2a-a7057d6d102b} <Error> executeQuery: Code: 173. DB::Exception: Amount of memory requested to allocate is more than allowed: (in file/uri /src/ch/clickhouse/.cmake-llvm16/.server/user_files/02475_data.bsonEachRow): While executing BSONEachRowRowInputFormat: While executing File. (CANNOT_ALLOCATE_MEMORY) (version 24.2.1.1) (from [::1]:55432) (comment: 02475_bson_each_row_format.sh) (in query: select * from file(02475_data.bsonEachRow, auto, 'tuple Tuple(x UInt64, b String)')), Stack trace (when copying this message, always include the lines below):

    0. /src/ch/clickhouse/contrib/llvm-project/libcxx/include/exception:141: Poco::Exception::Exception(String const&, int) @ 0x0000000014d1d536 in /src/ch/clickhouse/.cmake-llvm16/programs/clickhouse
    1. /src/ch/clickhouse/src/Common/Exception.cpp:96: DB::Exception::Exception(DB::Exception::MessageMasked&&, int, bool) @ 0x000000000b6a30ca in /src/ch/clickhouse/.cmake-llvm16/programs/clickhouse
    2. /src/ch/clickhouse/contrib/llvm-project/libcxx/include/string:1499: DB::Exception::Exception<>(int, FormatStringHelperImpl<>) @ 0x000000000625a017 in /src/ch/clickhouse/.cmake-llvm16/programs/clickhouse
    3. /src/ch/clickhouse/src/Common/PODArray.cpp:29: DB::PODArrayDetails::byte_size(unsigned long, unsigned long) @ 0x000000000b6be4ca in /src/ch/clickhouse/.cmake-llvm16/programs/clickhouse
    4. /src/ch/clickhouse/src/Common/PODArray.h:250: DB::ColumnString::popBack(unsigned long) @ 0x00000000114bddbd in /src/ch/clickhouse/.cmake-llvm16/programs/clickhouse
    5. /src/ch/clickhouse/contrib/llvm-project/libcxx/include/__iterator/wrap_iter.h:100: DB::ColumnTuple::popBack(unsigned long) @ 0x00000000114dd88f in /src/ch/clickhouse/.cmake-llvm16/programs/clickhouse
    6. /src/ch/clickhouse/src/Processors/Formats/IRowInputFormat.cpp:0: DB::IRowInputFormat::read() @ 0x000000001227136f in /src/ch/clickhouse/.cmake-llvm16/programs/clickhouse
    7. /src/ch/clickhouse/src/Processors/Formats/IInputFormat.cpp:19: DB::IInputFormat::generate() @ 0x000000001226d3c7 in /src/ch/clickhouse/.cmake-llvm16/programs/clickhouse
    8. /src/ch/clickhouse/src/Processors/Chunk.h:90: DB::ISource::tryGenerate() @ 0x000000001224b2c7 in /src/ch/clickhouse/.cmake-llvm16/programs/clickhouse
    9. /src/ch/clickhouse/contrib/llvm-project/libcxx/include/optional:344: DB::ISource::work() @ 0x000000001224aed4 in /src/ch/clickhouse/.cmake-llvm16/programs/clickhouse
    10. /src/ch/clickhouse/src/Processors/Executors/ExecutionThreadContext.cpp:0: DB::ExecutionThreadContext::executeTask() @ 0x00000000122638f9 in /src/ch/clickhouse/.cmake-llvm16/programs/clickhouse
    11. /src/ch/clickhouse/src/Processors/Executors/PipelineExecutor.cpp:273: DB::PipelineExecutor::executeStepImpl(unsigned long, std::atomic<bool>*) @ 0x000000001225ab10 in /src/ch/clickhouse/.cmake-llvm16/programs/clickhouse
    12. /src/ch/clickhouse/contrib/llvm-project/libcxx/include/atomic:958: DB::PipelineExecutor::executeStep(std::atomic<bool>*) @ 0x000000001225a41a in /src/ch/clickhouse/.cmake-llvm16/programs/clickhouse
    13. /src/ch/clickhouse/src/Processors/Executors/PullingPipelineExecutor.cpp:54: DB::PullingPipelineExecutor::pull(DB::Chunk&) @ 0x0000000012267a40 in /src/ch/clickhouse/.cmake-llvm16/programs/clickhouse
    14. /src/ch/clickhouse/src/Storages/StorageFile.cpp:1249: DB::StorageFileSource::generate() @ 0x000000001174b5e3 in /src/ch/clickhouse/.cmake-llvm16/programs/clickhouse
    15. /src/ch/clickhouse/src/Processors/Chunk.h:90: DB::ISource::tryGenerate() @ 0x000000001224b2c7 in /src/ch/clickhouse/.cmake-llvm16/programs/clickhouse
    16. /src/ch/clickhouse/contrib/llvm-project/libcxx/include/optional:344: DB::ISource::work() @ 0x000000001224aed4 in /src/ch/clickhouse/.cmake-llvm16/programs/clickhouse
    17. /src/ch/clickhouse/src/Processors/Executors/ExecutionThreadContext.cpp:0: DB::ExecutionThreadContext::executeTask() @ 0x00000000122638f9 in /src/ch/clickhouse/.cmake-llvm16/programs/clickhouse
    18. /src/ch/clickhouse/src/Processors/Executors/PipelineExecutor.cpp:273: DB::PipelineExecutor::executeStepImpl(unsigned long, std::atomic<bool>*) @ 0x000000001225ab10 in /src/ch/clickhouse/.cmake-llvm16/programs/clickhouse
    19. /src/ch/clickhouse/contrib/llvm-project/libcxx/include/__memory/shared_ptr.h:701: DB::PipelineExecutor::executeImpl(unsigned long, bool) @ 0x000000001225a10b in /src/ch/clickhouse/.cmake-llvm16/programs/clickhouse
    20. /src/ch/clickhouse/contrib/llvm-project/libcxx/include/__memory/unique_ptr.h:274: DB::PipelineExecutor::execute(unsigned long, bool) @ 0x0000000012259e53 in /src/ch/clickhouse/.cmake-llvm16/programs/clickhouse
    21. /src/ch/clickhouse/src/Processors/Executors/PullingAsyncPipelineExecutor.cpp:0: void std::__function::__policy_invoker<void ()>::__call_impl<std::__function::__default_alloc_func<ThreadFromGlobalPoolImpl<true>::ThreadFromGlobalPoolImpl<DB::PullingAsyncPipelineExecutor::pull(DB::Chunk&, unsigned long)::$_0>(DB::PullingAsyncPipelineExecutor::pull(DB::Chunk&, unsigned long)::$_0&&)::'lambda'(), void ()>>(std::__function::__policy_storage const*) @ 0x0000000012266cff in /src/ch/clickhouse/.cmake-llvm16/programs/clickhouse
    22. /src/ch/clickhouse/base/base/../base/wide_integer_impl.h:810: ThreadPoolImpl<std::thread>::worker(std::__list_iterator<std::thread, void*>) @ 0x000000000b77ebc6 in /src/ch/clickhouse/.cmake-llvm16/programs/clickhouse
    23. /src/ch/clickhouse/contrib/llvm-project/libcxx/include/__memory/unique_ptr.h:302: void* std::__thread_proxy[abi:v15000]<std::tuple<std::unique_ptr<std::__thread_struct, std::default_delete<std::__thread_struct>>, void ThreadPoolImpl<std::thread>::scheduleImpl<void>(std::function<void ()>, Priority, std::optional<unsigned long>, bool)::'lambda0'()>>(void*) @ 0x000000000b782d62 in /src/ch/clickhouse/.cmake-llvm16/programs/clickhouse
    24. ? @ 0x00007ffff7e3a55a
    25. ? @ 0x00007ffff7eb7a3c

CI: https://s3.amazonaws.com/clickhouse-test-reports/59482/f1555be976706f2436c2d5b0c64788a583d3899c/fast_test.html