### PR TITLE
Use max_query_size from context in DDLLogEntry instead of hardcoded 4096

### DIFF
--- a/src/Interpreters/DDLTask.cpp
+++ b/src/Interpreters/DDLTask.cpp
@@ -74,6 +74,8 @@ void DDLLogEntry::setSettingsIfRequired(ContextPtr context)
 
     if (version >= SETTINGS_IN_ZK_VERSION)
         settings.emplace(context->getSettingsRef().changes());
+
+    max_query_size = context->getSettingsRef().max_query_size;
 }
 
 String DDLLogEntry::toString() const
@@ -148,9 +150,8 @@ void DDLLogEntry::parse(const String & data)
             String settings_str;
             rb >> "settings: " >> settings_str >> "\n";
             ParserSetQuery parser{true};
-            constexpr UInt64 max_size = 4096;
             constexpr UInt64 max_depth = 16;
-            ASTPtr settings_ast = parseQuery(parser, settings_str, max_size, max_depth);
+            ASTPtr settings_ast = parseQuery(parser, settings_str, max_query_size, max_depth);
             settings.emplace(std::move(settings_ast->as<ASTSetQuery>()->changes));
         }
     }

--- a/src/Interpreters/DDLTask.cpp
+++ b/src/Interpreters/DDLTask.cpp
@@ -74,8 +74,6 @@ void DDLLogEntry::setSettingsIfRequired(ContextPtr context)
 
     if (version >= SETTINGS_IN_ZK_VERSION)
         settings.emplace(context->getSettingsRef().changes());
-
-    max_query_size = context->getSettingsRef().max_query_size;
 }
 
 String DDLLogEntry::toString() const
@@ -151,7 +149,7 @@ void DDLLogEntry::parse(const String & data)
             rb >> "settings: " >> settings_str >> "\n";
             ParserSetQuery parser{true};
             constexpr UInt64 max_depth = 16;
-            ASTPtr settings_ast = parseQuery(parser, settings_str, max_query_size, max_depth);
+            ASTPtr settings_ast = parseQuery(parser, settings_str, Context::getGlobalContextInstance()->getSettingsRef().max_query_size, max_depth);
             settings.emplace(std::move(settings_ast->as<ASTSetQuery>()->changes));
         }
     }

--- a/src/Interpreters/DDLTask.h
+++ b/src/Interpreters/DDLTask.h
@@ -89,6 +89,7 @@ struct DDLLogEntry
     OpenTelemetry::TracingContext tracing_context;
     String initial_query_id;
     bool is_backup_restore = false;
+    size_t max_query_size = DBMS_DEFAULT_MAX_QUERY_SIZE;
 
     void setSettingsIfRequired(ContextPtr context);
     String toString() const;

--- a/src/Interpreters/DDLTask.h
+++ b/src/Interpreters/DDLTask.h
@@ -89,7 +89,6 @@ struct DDLLogEntry
     OpenTelemetry::TracingContext tracing_context;
     String initial_query_id;
     bool is_backup_restore = false;
-    size_t max_query_size = DBMS_DEFAULT_MAX_QUERY_SIZE;
 
     void setSettingsIfRequired(ContextPtr context);
     String toString() const;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Use max_query_size from context in parsing changed settings in DDLWorker. Previously with large number of changed settings DDLWorker could fail with `Max query size exceeded` error and don't process log entries.