### PR TITLE
Do not retry queries if container is down in integration tests

### DIFF
--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -3484,6 +3484,10 @@ class ClickHouseInstance:
                 if check_callback(result):
                     return result
                 time.sleep(sleep_time)
+            except QueryRuntimeException as ex:
+                # Container is down, this is likely due to server crash.
+                if "No route to host" in str(ex):
+                    raise
             except Exception as ex:
                 # logging.debug("Retry {} got exception {}".format(i + 1, ex))
                 time.sleep(sleep_time)


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)