### PR TITLE
Remove extensively aggressive check

### DIFF
--- a/src/Interpreters/executeQuery.cpp
+++ b/src/Interpreters/executeQuery.cpp
@@ -722,7 +722,7 @@ static std::tuple<ASTPtr, BlockIO> executeQueryImpl(
             /// TODO: parser should fail early when max_query_size limit is reached.
             ast = parseQuery(parser, begin, end, "", max_query_size, settings.max_parser_depth);
 
-#ifndef NDEBUG
+#if 0
             /// Verify that AST formatting is consistent:
             /// If you format AST, parse it back, and format it again, you get the same string.
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
