### PR TITLE
Fix system.s3queue_log

### DIFF
--- a/src/Interpreters/S3QueueLog.cpp
+++ b/src/Interpreters/S3QueueLog.cpp
@@ -28,7 +28,9 @@ ColumnsDescription S3QueueLogElement::getColumnsDescription()
         {"hostname", std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeString>())},
         {"event_date", std::make_shared<DataTypeDate>()},
         {"event_time", std::make_shared<DataTypeDateTime>()},
-        {"table_uuid", std::make_shared<DataTypeString>()},
+        {"database", std::make_shared<DataTypeString>()},
+        {"table", std::make_shared<DataTypeString>()},
+        {"uuid", std::make_shared<DataTypeString>()},
         {"file_name", std::make_shared<DataTypeString>()},
         {"rows_processed", std::make_shared<DataTypeUInt64>()},
         {"status", status_datatype},
@@ -45,7 +47,9 @@ void S3QueueLogElement::appendToBlock(MutableColumns & columns) const
     columns[i++]->insert(getFQDNOrHostName());
     columns[i++]->insert(DateLUT::instance().toDayNum(event_time).toUnderType());
     columns[i++]->insert(event_time);
-    columns[i++]->insert(table_uuid);
+    columns[i++]->insert(database);
+    columns[i++]->insert(table);
+    columns[i++]->insert(uuid);
     columns[i++]->insert(file_name);
     columns[i++]->insert(rows_processed);
     columns[i++]->insert(status);

--- a/src/Interpreters/S3QueueLog.h
+++ b/src/Interpreters/S3QueueLog.h
@@ -12,7 +12,11 @@ namespace DB
 struct S3QueueLogElement
 {
     time_t event_time{};
-    std::string table_uuid;
+
+    std::string database;
+    std::string table;
+    std::string uuid;
+
     std::string file_name;
     size_t rows_processed = 0;
 

--- a/src/Storages/S3Queue/S3QueueSource.cpp
+++ b/src/Storages/S3Queue/S3QueueSource.cpp
@@ -352,7 +352,11 @@ void StorageS3QueueSource::applyActionAfterProcessing(const String & path)
     }
 }
 
-void StorageS3QueueSource::appendLogElement(const std::string & filename, S3QueueFilesMetadata::FileStatus & file_status_, size_t processed_rows, bool processed)
+void StorageS3QueueSource::appendLogElement(
+    const std::string & filename,
+    S3QueueFilesMetadata::FileStatus & file_status_,
+    size_t processed_rows,
+    bool processed)
 {
     if (!s3_queue_log)
         return;
@@ -363,6 +367,9 @@ void StorageS3QueueSource::appendLogElement(const std::string & filename, S3Queu
         elem = S3QueueLogElement
         {
             .event_time = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now()),
+            .database = storage_id.database_name,
+            .table = storage_id.table_name,
+            .uuid = toString(storage_id.uuid),
             .file_name = filename,
             .rows_processed = processed_rows,
             .status = processed ? S3QueueLogElement::S3QueueStatus::Processed : S3QueueLogElement::S3QueueStatus::Failed,


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix non-filled column `table_uuid` in `system.s3queue_log`. Added columns `database` and `table`. Renamed `table_uuid` to `uuid`.