### PR TITLE
Tables system.backups and system.backup_log add query_id and error stacktrace

### DIFF
--- a/src/Backups/BackupOperationInfo.h
+++ b/src/Backups/BackupOperationInfo.h
@@ -20,6 +20,9 @@ struct BackupOperationInfo
     /// Base Backup Operation name, a string like "Disk('backups', 'my_base_backup')"
     String base_backup_name;
 
+    /// Query ID of a query that started backup
+    String query_id;
+
     /// This operation is internal and should not be shown in system.backups
     bool internal = false;
 

--- a/src/Backups/BackupsWorker.cpp
+++ b/src/Backups/BackupsWorker.cpp
@@ -440,7 +440,13 @@ OperationID BackupsWorker::startMakingBackup(const ASTPtr & query, const Context
 
     try
     {
-        addInfo(backup_id, backup_name_for_logging, base_backup_name, backup_settings.internal, context->getProcessListElement(), BackupStatus::CREATING_BACKUP);
+        addInfo(backup_id,
+            backup_name_for_logging,
+            base_backup_name,
+            context->getCurrentQueryId(),
+            backup_settings.internal,
+            context->getProcessListElement(),
+            BackupStatus::CREATING_BACKUP);
 
         /// Prepare context to use.
         ContextPtr context_in_use = context;
@@ -823,7 +829,13 @@ OperationID BackupsWorker::startRestoring(const ASTPtr & query, ContextMutablePt
         if (restore_settings.base_backup_info)
             base_backup_name = restore_settings.base_backup_info->toStringForLogging();
 
-        addInfo(restore_id, backup_name_for_logging, base_backup_name, restore_settings.internal, context->getProcessListElement(), BackupStatus::RESTORING);
+        addInfo(restore_id,
+            backup_name_for_logging,
+            base_backup_name,
+            context->getCurrentQueryId(),
+            restore_settings.internal,
+            context->getProcessListElement(),
+            BackupStatus::RESTORING);
 
         /// Prepare context to use.
         ContextMutablePtr context_in_use = context;
@@ -1108,13 +1120,15 @@ void BackupsWorker::restoreTablesData(const OperationID & restore_id, BackupPtr 
 }
 
 
-void BackupsWorker::addInfo(const OperationID & id, const String & name, const String & base_backup_name, bool internal, QueryStatusPtr process_list_element, BackupStatus status)
+void BackupsWorker::addInfo(const OperationID & id, const String & name, const String & base_backup_name, const String & query_id,
+                            bool internal, QueryStatusPtr process_list_element, BackupStatus status)
 {
     ExtendedOperationInfo extended_info;
     auto & info = extended_info.info;
     info.id = id;
     info.name = name;
     info.base_backup_name = base_backup_name;
+    info.query_id = query_id;
     info.internal = internal;
     info.status = status;
     info.start_time = std::chrono::system_clock::now();
@@ -1183,7 +1197,7 @@ void BackupsWorker::setStatus(const String & id, BackupStatus status, bool throw
 
     if (isFailedOrCancelled(status))
     {
-        info.error_message = getCurrentExceptionMessage(false);
+        info.error_message = getCurrentExceptionMessage(true /*with_stacktrace*/);
         info.exception = std::current_exception();
     }
 

--- a/src/Backups/BackupsWorker.h
+++ b/src/Backups/BackupsWorker.h
@@ -108,7 +108,8 @@ private:
     /// Run data restoring tasks which insert data to tables.
     void restoreTablesData(const BackupOperationID & restore_id, BackupPtr backup, DataRestoreTasks && tasks, ThreadPool & thread_pool, QueryStatusPtr process_list_element);
 
-    void addInfo(const BackupOperationID & id, const String & name, const String & base_backup_name, bool internal, QueryStatusPtr process_list_element, BackupStatus status);
+    void addInfo(const BackupOperationID & id, const String & name, const String & base_backup_name, const String & query_id,
+                bool internal, QueryStatusPtr process_list_element, BackupStatus status);
     void setStatus(const BackupOperationID & id, BackupStatus status, bool throw_if_error = true);
     void setStatusSafe(const String & id, BackupStatus status) { setStatus(id, status, false); }
     void setNumFilesAndSize(const BackupOperationID & id, size_t num_files, UInt64 total_size, size_t num_entries,

--- a/src/Interpreters/BackupLog.cpp
+++ b/src/Interpreters/BackupLog.cpp
@@ -28,6 +28,7 @@ ColumnsDescription BackupLogElement::getColumnsDescription()
         {"id", std::make_shared<DataTypeString>()},
         {"name", std::make_shared<DataTypeString>()},
         {"base_backup_name", std::make_shared<DataTypeString>()},
+        {"query_id", std::make_shared<DataTypeString>()},
         {"status", std::make_shared<DataTypeEnum8>(getBackupStatusEnumValues())},
         {"error", std::make_shared<DataTypeString>()},
         {"start_time", std::make_shared<DataTypeDateTime>()},
@@ -51,6 +52,7 @@ void BackupLogElement::appendToBlock(MutableColumns & columns) const
     columns[i++]->insert(info.id);
     columns[i++]->insert(info.name);
     columns[i++]->insert(info.base_backup_name);
+    columns[i++]->insert(info.query_id);
     columns[i++]->insert(static_cast<Int8>(info.status));
     columns[i++]->insert(info.error_message);
     columns[i++]->insert(static_cast<UInt32>(std::chrono::system_clock::to_time_t(info.start_time)));

--- a/src/Storages/System/StorageSystemBackups.cpp
+++ b/src/Storages/System/StorageSystemBackups.cpp
@@ -22,6 +22,7 @@ ColumnsDescription StorageSystemBackups::getColumnsDescription()
         {"id", std::make_shared<DataTypeString>(), "Operation ID, can be either passed via SETTINGS id=... or be randomly generated UUID."},
         {"name", std::make_shared<DataTypeString>(), "Operation name, a string like `Disk('backups', 'my_backup')`"},
         {"base_backup_name", std::make_shared<DataTypeString>(), "Base Backup Operation name, a string like `Disk('backups', 'my_base_backup')`"},
+        {"query_id", std::make_shared<DataTypeString>(), "Query ID of a query that started backup."},
         {"status", std::make_shared<DataTypeEnum8>(getBackupStatusEnumValues()), "Status of backup or restore operation."},
         {"error", std::make_shared<DataTypeString>(), "The error message if any."},
         {"start_time", std::make_shared<DataTypeDateTime>(), "The time when operation started."},
@@ -44,6 +45,7 @@ void StorageSystemBackups::fillData(MutableColumns & res_columns, ContextPtr con
     auto & column_id = assert_cast<ColumnString &>(*res_columns[column_index++]);
     auto & column_name = assert_cast<ColumnString &>(*res_columns[column_index++]);
     auto & column_base_backup_name = assert_cast<ColumnString &>(*res_columns[column_index++]);
+    auto & column_query_id = assert_cast<ColumnString &>(*res_columns[column_index++]);
     auto & column_status = assert_cast<ColumnInt8 &>(*res_columns[column_index++]);
     auto & column_error = assert_cast<ColumnString &>(*res_columns[column_index++]);
     auto & column_start_time = assert_cast<ColumnUInt32 &>(*res_columns[column_index++]);
@@ -62,6 +64,7 @@ void StorageSystemBackups::fillData(MutableColumns & res_columns, ContextPtr con
         column_id.insertData(info.id.data(), info.id.size());
         column_name.insertData(info.name.data(), info.name.size());
         column_base_backup_name.insertData(info.base_backup_name.data(), info.base_backup_name.size());
+        column_query_id.insertData(info.query_id.data(), info.query_id.size());
         column_status.insertValue(static_cast<Int8>(info.status));
         column_error.insertData(info.error_message.data(), info.error_message.size());
         column_start_time.insertValue(static_cast<UInt32>(std::chrono::system_clock::to_time_t(info.start_time)));


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Added  `query_id` column for tables `system.backups` and `system.backup_log`. Added error stacktrace  to `error` column.
