### PR TITLE
Fix: IAST::clone() for RENAME

### DIFF
--- a/src/Parsers/ASTRenameQuery.h
+++ b/src/Parsers/ASTRenameQuery.h
@@ -66,7 +66,7 @@ public:
     {
         auto res = std::make_shared<ASTRenameQuery>(*this);
         cloneOutputOptions(*res);
-        for(auto & element : res->elements)
+        for (auto & element : res->elements)
         {
             element.from = element.from.clone();
             element.to = element.to.clone();

--- a/src/Parsers/ASTRenameQuery.h
+++ b/src/Parsers/ASTRenameQuery.h
@@ -35,6 +35,11 @@ public:
             tryGetIdentifierNameInto(table, name);
             return name;
         }
+
+        Table clone() const
+        {
+            return Table{.database = database->clone(), .table = table->clone()};
+        }
     };
 
     struct Element
@@ -61,6 +66,11 @@ public:
     {
         auto res = std::make_shared<ASTRenameQuery>(*this);
         cloneOutputOptions(*res);
+        for(auto & element : res->elements)
+        {
+            element.from = element.from.clone();
+            element.to = element.to.clone();
+        }
         return res;
     }
 

--- a/src/Processors/Executors/PipelineExecutor.h
+++ b/src/Processors/Executors/PipelineExecutor.h
@@ -7,7 +7,6 @@
 #include <Common/ConcurrencyControl.h>
 
 #include <queue>
-#include <mutex>
 #include <memory>
 
 

--- a/src/Server/HTTP/WriteBufferFromHTTPServerResponse.h
+++ b/src/Server/HTTP/WriteBufferFromHTTPServerResponse.h
@@ -11,7 +11,6 @@
 #include <Common/Stopwatch.h>
 
 #include <mutex>
-#include <optional>
 
 
 namespace DB

--- a/src/Server/HTTPHandler.h
+++ b/src/Server/HTTPHandler.h
@@ -32,7 +32,7 @@ class HTTPHandler : public HTTPRequestHandler
 {
 public:
     HTTPHandler(IServer & server_, const std::string & name, const std::optional<String> & content_type_override_);
-    virtual ~HTTPHandler() override;
+    ~HTTPHandler() override;
 
     void handleRequest(HTTPServerRequest & request, HTTPServerResponse & response, const ProfileEvents::Event & write_event) override;
 


### PR DESCRIPTION
Fixes error from AST Fuzzer (see [report](https://s3.amazonaws.com/clickhouse-test-reports/60077/b6277d5e87367c2eda974ca09f1c174563ab80d6/ast_fuzzer__asan_.html)) for `RENAME`:
`"Found error: IAST::clone() is broken for some AST node. This is a bug. The original AST ('dump before fuzz') and its cloned copy ('dump of cloned AST') refer to the same nodes, which must never happen. This means that their parent node doesn't implement clone() correctly."` 

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
