### PR TITLE
Fix http exception codes.

### DIFF
--- a/src/Server/HTTPHandler.cpp
+++ b/src/Server/HTTPHandler.cpp
@@ -884,7 +884,9 @@ void HTTPHandler::processQuery(
     {
         if (settings.http_write_exception_in_output_format && output_format.supportsWritingException())
         {
-            ExecutionStatus status = ExecutionStatus::fromCurrentException("", false);
+            bool with_stacktrace = (params.getParsed<bool>("stacktrace", false) && server.config().getBool("enable_http_stacktrace", true));
+
+            ExecutionStatus status = ExecutionStatus::fromCurrentException("", with_stacktrace);
             formatExceptionForClient(status.code, request, response, used_output);
 
             output_format.setException(getCurrentExceptionMessage(false));

--- a/src/Server/HTTPHandler.h
+++ b/src/Server/HTTPHandler.h
@@ -148,6 +148,12 @@ private:
         HTTPServerResponse & response,
         Output & used_output);
 
+    void formatExceptionForClient(
+        int exception_code,
+        HTTPServerRequest & request,
+        HTTPServerResponse & response,
+        Output & used_output);
+
     static void pushDelayedResults(Output & used_output);
 };
 

--- a/tests/queries/0_stateless/02899_use_default_format_on_http_exception.reference
+++ b/tests/queries/0_stateless/02899_use_default_format_on_http_exception.reference
@@ -1,25 +1,47 @@
-INSERT WITH default_format=JSON
+SELECT missing column WITH default_format=JSON
+404NotFound
 Content-Type:application/json;charset=UTF-8
-"exception":"Code:62.
+X-ClickHouse-Ex---tion-Code:47
+"exception":"Code:47.
+
+INSERT WITH default_format=JSON
+501NotImplemented
+Content-Type:application/json;charset=UTF-8
+X-ClickHouse-Ex---tion-Code:48
+"exception":"Code:48.
 
 INSERT WITH default_format=XML
+501NotImplemented
 Content-Type:application/xml;charset=UTF-8
-<exception>Code:62.DB::Ex---tion:
+X-ClickHouse-Ex---tion-Code:48
+<exception>Code:48.DB::Ex---tion:
 
 INSERT WITH default_format=BADFORMAT
+501NotImplemented
 Content-Type:text/plain;charset=UTF-8
-X-ClickHouse-Ex---tion-Code:62
-Code:62.DB::Ex---tion:
+X-ClickHouse-Ex---tion-Code:48
+Code:48.DB::Ex---tion:
+
+SELECT missing column WITH X-ClickHouse-Format: JSON
+404NotFound
+Content-Type:application/json;charset=UTF-8
+X-ClickHouse-Ex---tion-Code:47
+"exception":"Code:47.
 
 INSERT WITH X-ClickHouse-Format: JSON
+501NotImplemented
 Content-Type:application/json;charset=UTF-8
-"exception":"Code:62.
+X-ClickHouse-Ex---tion-Code:48
+"exception":"Code:48.
 
 INSERT WITH X-ClickHouse-Format: XML
+501NotImplemented
 Content-Type:application/xml;charset=UTF-8
-<exception>Code:62.DB::Ex---tion:
+X-ClickHouse-Ex---tion-Code:48
+<exception>Code:48.DB::Ex---tion:
 
 INSERT WITH X-ClickHouse-Format: BADFORMAT
+501NotImplemented
 Content-Type:text/plain;charset=UTF-8
-X-ClickHouse-Ex---tion-Code:62
-Code:62.DB::Ex---tion:
+X-ClickHouse-Ex---tion-Code:48
+Code:48.DB::Ex---tion:

--- a/tests/queries/0_stateless/02899_use_default_format_on_http_exception.sh
+++ b/tests/queries/0_stateless/02899_use_default_format_on_http_exception.sh
@@ -6,28 +6,44 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 CH_URL="$CLICKHOUSE_URL&http_write_exception_in_output_format=1"
 
+echo "SELECT missing column WITH default_format=JSON"
+echo "SELECT x FROM system.numbers LIMIT 1;"\
+  | ${CLICKHOUSE_CURL} -sS "${CH_URL}&default_format=JSON" -i --data-binary @- \
+  | grep 'HTTP/1.1\|xception\|Content-Type' | sed 's/Exception/Ex---tion/;s/HTTP\/1.1//;s/\r//' | awk '{ print $1 $2 $3 }'
+echo ""
 echo "INSERT WITH default_format=JSON"
 echo "INSERT INTO system.numbers Select * from numbers(10);" \
-  | ${CLICKHOUSE_CURL} -sS "${CH_URL}&default_format=JSON" -i | grep 'xception\|Content-Type' | sed 's/Exception/Ex---tion/' | awk '{ print $1 $2 $3 }'
+  | ${CLICKHOUSE_CURL} -sS "${CH_URL}&default_format=JSON" -i --data-binary @- \
+  | grep 'HTTP/1.1\|xception\|Content-Type' | sed 's/Exception/Ex---tion/;s/HTTP\/1.1//;s/\r//' | awk '{ print $1 $2 $3 }'
 echo ""
 echo "INSERT WITH default_format=XML"
 echo "INSERT INTO system.numbers Select * from numbers(10);" \
-  | ${CLICKHOUSE_CURL} -sS "${CH_URL}&default_format=XML" -i | grep 'xception\|Content-Type' | sed 's/Exception/Ex---tion/' | awk '{ print $1 $2 $3 }'
+  | ${CLICKHOUSE_CURL} -sS "${CH_URL}&default_format=XML" -i --data-binary @- \
+  | grep 'HTTP/1.1\|xception\|Content-Type' | sed 's/Exception/Ex---tion/;s/HTTP\/1.1//;s/\r//' | awk '{ print $1 $2 $3 }'
 echo ""
 echo "INSERT WITH default_format=BADFORMAT"
 echo "INSERT INTO system.numbers Select * from numbers(10);" \
-  | ${CLICKHOUSE_CURL} -sS "${CH_URL}&default_format=BADFORMAT" -i | grep 'xception\|Content-Type' | sed 's/Exception/Ex---tion/' | awk '{ print $1 $2 $3 }'
+  | ${CLICKHOUSE_CURL} -sS "${CH_URL}&default_format=BADFORMAT" -i --data-binary @- \
+  | grep 'HTTP/1.1\|xception\|Content-Type' | sed 's/Exception/Ex---tion/;s/HTTP\/1.1//;s/\r//' | awk '{ print $1 $2 $3 }'
 
 
+echo ""
+echo "SELECT missing column WITH X-ClickHouse-Format: JSON"
+echo "SELECT x FROM system.numbers LIMIT 1;"\
+  | ${CLICKHOUSE_CURL} -sS "${CH_URL}" -H 'X-ClickHouse-Format: JSON' -i --data-binary @- \
+  | grep 'HTTP/1.1\|xception\|Content-Type' | sed 's/Exception/Ex---tion/;s/HTTP\/1.1//;s/\r//' | awk '{ print $1 $2 $3 }'
 echo ""
 echo "INSERT WITH X-ClickHouse-Format: JSON"
 echo "INSERT INTO system.numbers Select * from numbers(10);" \
-  | ${CLICKHOUSE_CURL} -sS "${CH_URL}" -H 'X-ClickHouse-Format: JSON' -i | grep 'xception\|Content-Type' | sed 's/Exception/Ex---tion/' | awk '{ print $1 $2 $3 }'
+  | ${CLICKHOUSE_CURL} -sS "${CH_URL}" -H 'X-ClickHouse-Format: JSON' -i --data-binary @- \
+  | grep 'HTTP/1.1\|xception\|Content-Type' | sed 's/Exception/Ex---tion/;s/HTTP\/1.1//;s/\r//' | awk '{ print $1 $2 $3 }'
 echo ""
 echo "INSERT WITH X-ClickHouse-Format: XML"
 echo "INSERT INTO system.numbers Select * from numbers(10);" \
-  | ${CLICKHOUSE_CURL} -sS "${CH_URL}" -H 'X-ClickHouse-Format: XML' -i | grep 'xception\|Content-Type' | sed 's/Exception/Ex---tion/' | awk '{ print $1 $2 $3 }'
+  | ${CLICKHOUSE_CURL} -sS "${CH_URL}" -H 'X-ClickHouse-Format: XML' -i --data-binary @- \
+  | grep 'HTTP/1.1\|xception\|Content-Type' | sed 's/Exception/Ex---tion/;s/HTTP\/1.1//;s/\r//' | awk '{ print $1 $2 $3 }'
 echo ""
 echo "INSERT WITH X-ClickHouse-Format: BADFORMAT"
 echo "INSERT INTO system.numbers Select * from numbers(10);" \
-  | ${CLICKHOUSE_CURL} -sS "${CH_URL}" -H 'X-ClickHouse-Format: BADFORMAT' -i | grep 'xception\|Content-Type' | sed 's/Exception/Ex---tion/' | awk '{ print $1 $2 $3 }'
+  | ${CLICKHOUSE_CURL} -sS "${CH_URL}" -H 'X-ClickHouse-Format: BADFORMAT' -i --data-binary @- \
+  | grep 'HTTP/1.1\|xception\|Content-Type' | sed 's/Exception/Ex---tion/;s/HTTP\/1.1//;s/\r//' | awk '{ print $1 $2 $3 }'


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed a minor bug that caused all http return codes to be 200 (success) instead of a relevant code on exception.

### Documentation entry for user-facing changes

In https://github.com/ClickHouse/ClickHouse/pull/55739 it was made possible to provide the exception response back to the client in the form of the set default format. 

This, however, introduced a small problem where exceptions were being returned as success (200). This is because the `output_format.finalize()` posts the response back to the client before various status messages are set, include exception codes.

The adjustment in this PR moves the formatting of header information into a separate function that can be called from both the exception lambda and from `trySendExceptionToClient`.

I have expanded the functional test `02899_use_default_format_on_http_exception` to reflect this change, and fixed a small problem in the test that caused queries to be empty (i.e., added `--data-binary @-`).

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
