### PR TITLE
s3queue: fix bug (also fixes flaky test_storage_s3_queue/test.py::test_shards_distributed)

### DIFF
--- a/src/Storages/S3Queue/S3QueueFilesMetadata.cpp
+++ b/src/Storages/S3Queue/S3QueueFilesMetadata.cpp
@@ -699,7 +699,10 @@ void S3QueueFilesMetadata::setFileProcessedForOrderedModeImpl(
         {
             auto code = zk_client->tryMulti(requests, responses);
             if (code == Coordination::Error::ZOK)
+            {
+                LOG_TEST(log, "Moved file `{}` to processed", path);
                 return;
+            }
         }
 
         /// Failed to update max processed node, retry.

--- a/src/Storages/S3Queue/S3QueueSource.cpp
+++ b/src/Storages/S3Queue/S3QueueSource.cpp
@@ -80,6 +80,7 @@ StorageS3QueueSource::KeyWithInfoPtr StorageS3QueueSource::FileIterator::next(si
                     {
                         val = keys.front();
                         keys.pop_front();
+                        chassert(idx == metadata->getProcessingIdForPath(val->key));
                     }
                 }
                 else
@@ -103,7 +104,7 @@ StorageS3QueueSource::KeyWithInfoPtr StorageS3QueueSource::FileIterator::next(si
                             LOG_TEST(log, "Putting key {} into queue of processor {} (total: {})",
                                      val->key, processing_id_for_key, sharded_keys.size());
 
-                            if (auto it = sharded_keys.find(idx); it != sharded_keys.end())
+                            if (auto it = sharded_keys.find(processing_id_for_key); it != sharded_keys.end())
                             {
                                 it->second.push_back(val);
                             }
@@ -111,7 +112,7 @@ StorageS3QueueSource::KeyWithInfoPtr StorageS3QueueSource::FileIterator::next(si
                             {
                                 throw Exception(ErrorCodes::LOGICAL_ERROR,
                                                 "Processing id {} does not exist (Expected ids: {})",
-                                                idx, fmt::join(metadata->getProcessingIdsForShard(current_shard), ", "));
+                                                processing_id_for_key, fmt::join(metadata->getProcessingIdsForShard(current_shard), ", "));
                             }
                         }
                         continue;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix bug in `S3Queue` table engine with ordered parallel mode.