### PR TITLE
Change back how receive_timeout is handled for INSERTs

### DIFF
--- a/src/Server/TCPHandler.cpp
+++ b/src/Server/TCPHandler.cpp
@@ -795,6 +795,8 @@ bool TCPHandler::readDataNext()
 
             /// We accept and process data.
             read_ok = receivePacket();
+            /// Reset the timeout on Ping packet (NOTE: there is no Ping for INSERT queries yet).
+            watch.restart();
             break;
         }
 


### PR DESCRIPTION
Right now the receive_timeout for INSERT works as a timeout for receiving data block, however this is not very convenient, since sometimes server may not send data for quite some time (i.e. due to in order aggregation), Ping packets is there for a reason (also Progress and ProfileEvents as well, though the purpose is different).

Initially this special handling of receive_timeout had been added in 6a5ef9be832820b2482c257626f794a43f1f980a ("dbms: fixed error with hanging INSERTs [#METR-16514]"), but the behaviour was different, since that time the receivePacket() was outside loop, only poll() was there, and that was the workaround for poll() timeout (which does not triggers the socket timeout).

But in fabd7193bd687ee4b10ca826303399ff35e3d3dd ("Code cleanups and improvements"), receivePacket() had been moved into the loop, and so this changed the behaviour of the timeout to current one.

Though all of this will not help for INSERT queries anyway, since there are no Ping packets for them. Yet.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Change back how receive_timeout is handled for INSERTs

Cc: @alexey-milovidov (as author of the original change)