### PR TITLE
CI: remove Integration tests asan and release from PR wf

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -734,14 +734,6 @@ jobs:
 #############################################################################################
 ############################# INTEGRATION TESTS #############################################
 #############################################################################################
-  IntegrationTestsAsan:
-    needs: [RunConfig, BuilderDebAsan]
-    if: ${{ !failure() && !cancelled() }}
-    uses: ./.github/workflows/reusable_test.yml
-    with:
-      test_name: Integration tests (asan)
-      runner_type: stress-tester
-      data: ${{ needs.RunConfig.outputs.data }}
   IntegrationTestsAnalyzerAsan:
     needs: [RunConfig, BuilderDebAsan]
     if: ${{ !failure() && !cancelled() }}
@@ -756,14 +748,6 @@ jobs:
     uses: ./.github/workflows/reusable_test.yml
     with:
       test_name: Integration tests (tsan)
-      runner_type: stress-tester
-      data: ${{ needs.RunConfig.outputs.data }}
-  IntegrationTestsRelease:
-    needs: [RunConfig, BuilderDebRelease]
-    if: ${{ !failure() && !cancelled() }}
-    uses: ./.github/workflows/reusable_test.yml
-    with:
-      test_name: Integration tests (release)
       runner_type: stress-tester
       data: ${{ needs.RunConfig.outputs.data }}
   IntegrationTestsAarch64:
@@ -909,10 +893,8 @@ jobs:
       - ASTFuzzerTestTsan
       - ASTFuzzerTestMSan
       - ASTFuzzerTestUBSan
-      - IntegrationTestsAsan
       - IntegrationTestsAnalyzerAsan
       - IntegrationTestsTsan
-      - IntegrationTestsRelease
       - IntegrationTestsAarch64
       - IntegrationTestsFlakyCheck
       - PerformanceComparisonX86

--- a/tests/ci/ci.py
+++ b/tests/ci/ci.py
@@ -645,12 +645,18 @@ class CiCache:
             return {}
         poll_interval_sec = 300
         TIMEOUT = 3600
+        MAX_ROUNDS_TO_WAIT = 6
+        MAX_JOB_NUM_TO_WAIT = 3
         await_finished: Dict[str, List[int]] = {}
         round_cnt = 0
-        while len(jobs_with_params) > 4 and round_cnt < 5:
+        while (
+            len(jobs_with_params) > MAX_JOB_NUM_TO_WAIT
+            and round_cnt < MAX_ROUNDS_TO_WAIT
+        ):
             round_cnt += 1
             GHActions.print_in_group(
-                f"Wait pending jobs, round [{round_cnt}]:", list(jobs_with_params)
+                f"Wait pending jobs, round [{round_cnt}/{MAX_ROUNDS_TO_WAIT}]:",
+                list(jobs_with_params),
             )
             # this is initial approach to wait pending jobs:
             # start waiting for the next TIMEOUT seconds if there are more than X(=4) jobs to wait

--- a/tests/ci/ci_config.py
+++ b/tests/ci/ci_config.py
@@ -1013,7 +1013,7 @@ CI_CONFIG = CIConfig(
         ),
         JobNames.INTEGRATION_TEST_ASAN: TestConfig(
             Build.PACKAGE_ASAN,
-            job_config=JobConfig(num_batches=4, **integration_test_common_params),  # type: ignore
+            job_config=JobConfig(num_batches=4, **integration_test_common_params, release_only=True),  # type: ignore
         ),
         JobNames.INTEGRATION_TEST_ASAN_ANALYZER: TestConfig(
             Build.PACKAGE_ASAN,
@@ -1028,12 +1028,9 @@ CI_CONFIG = CIConfig(
             # add [run_by_label="test arm"] to not run in regular pr workflow by default
             job_config=JobConfig(num_batches=6, **integration_test_common_params, run_by_label="test arm"),  # type: ignore
         ),
-        # FIXME: currently no wf has this job. Try to enable
-        # "Integration tests (msan)": TestConfig(Build.PACKAGE_MSAN, job_config=JobConfig(num_batches=6, **integration_test_common_params) # type: ignore
-        # ),
         JobNames.INTEGRATION_TEST: TestConfig(
             Build.PACKAGE_RELEASE,
-            job_config=JobConfig(num_batches=4, **integration_test_common_params),  # type: ignore
+            job_config=JobConfig(num_batches=4, **integration_test_common_params, release_only=True),  # type: ignore
         ),
         JobNames.INTEGRATION_TEST_FLAKY: TestConfig(
             Build.PACKAGE_ASAN, job_config=JobConfig(pr_only=True, **integration_test_common_params)  # type: ignore


### PR DESCRIPTION
 #do_not_test

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Integration tests release, asan removed
- Increased ci awaiting time for up to 5 * 60 min


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
