### PR TITLE
Update default value for async_insert_deduplicate

### DIFF
--- a/docs/en/operations/settings/settings.md
+++ b/docs/en/operations/settings/settings.md
@@ -2037,7 +2037,7 @@ Possible values:
 - 0 — Disabled.
 - 1 — Enabled.
 
-Default value: 1.
+Default value: 0.
 
 By default, async inserts are inserted into replicated tables by the `INSERT` statement enabling [async_insert](#async-insert) are deduplicated (see [Data Replication](../../engines/table-engines/mergetree-family/replication.md)).
 For the replicated tables, by default, only 10000 of the most recent inserts for each partition are deduplicated (see [replicated_deduplication_window_for_async_inserts](merge-tree-settings.md/#replicated-deduplication-window-async-inserts), [replicated_deduplication_window_seconds_for_async_inserts](merge-tree-settings.md/#replicated-deduplication-window-seconds-async-inserts)).


### PR DESCRIPTION
### Changelog category (leave one):
- Documentation (changelog entry is not required)

async_insert_deduplicate is disabled by default. See https://github.com/ClickHouse/ClickHouse/blob/e83deb441035e2003be6fa004cf018be11031c8b/src/Core/Settings.h#L271