### PR TITLE
Update settings.md to correct the description for setting `max_concurrent_queries_for_user`

### DIFF
--- a/docs/en/operations/settings/settings.md
+++ b/docs/en/operations/settings/settings.md
@@ -755,7 +755,7 @@ By default: 1,000,000. It only works when reading from MergeTree engines.
 
 ## max_concurrent_queries_for_user {#max-concurrent-queries-for-user}
 
-The maximum number of simultaneously processed queries related to MergeTree table per user.
+The maximum number of simultaneously processed queries per user.
 
 Possible values:
 


### PR DESCRIPTION
Update settings.md to correct the description for setting `max_concurrent_queries_for_user` by removing `merge tree table` words.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
