### PR TITLE
Update 01158_zookeeper_log_long.sql

### DIFF
--- a/tests/queries/0_stateless/01158_zookeeper_log_long.sql
+++ b/tests/queries/0_stateless/01158_zookeeper_log_long.sql
@@ -26,7 +26,7 @@ from system.zookeeper_log where path like '/test/01158/' || currentDatabase() ||
 order by xid, type, request_idx;
 
 select 'parts';
-select type, has_watch, op_num, replace(path, toString(serverUUID()), '<uuid>'), is_ephemeral, is_sequential, version, requests_size, request_idx, error, watch_type,
+select type, has_watch, op_num, replace(path, toString(serverUUID()), '<uuid>'), is_ephemeral, is_sequential, if(startsWith(path, '/clickhouse/sessions'), 1, version), requests_size, request_idx, error, watch_type,
        watch_state, path_created, stat_version, stat_cversion, stat_dataLength, stat_numChildren
 from system.zookeeper_log
 where (session_id, xid) in (select session_id, xid from system.zookeeper_log where path='/test/01158/' || currentDatabase() || '/rmt/replicas/1/parts/all_0_0_0')


### PR DESCRIPTION

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


The version may be different if we had connection loss in tests