### PR TITLE
Support single-argument version for the merge table function

### DIFF
--- a/docs/en/sql-reference/table-functions/merge.md
+++ b/docs/en/sql-reference/table-functions/merge.md
@@ -11,11 +11,11 @@ Creates a temporary [Merge](../../engines/table-engines/special/merge.md) table.
 **Syntax**
 
 ```sql
-merge('db_name', 'tables_regexp')
+merge(['db_name',] 'tables_regexp')
 ```
 **Arguments**
 
-- `db_name` — Possible values:
+- `db_name` — Possible values (optional, default is `currentDatabase()`):
     - database name,
     - constant expression that returns a string with a database name, for example, `currentDatabase()`,
     - `REGEXP(expression)`, where `expression` is a regular expression to match the DB names.

--- a/src/TableFunctions/TableFunctionMerge.cpp
+++ b/src/TableFunctions/TableFunctionMerge.cpp
@@ -88,26 +88,38 @@ void TableFunctionMerge::parseArguments(const ASTPtr & ast_function, ContextPtr 
 
     if (args_func.size() != 1)
         throw Exception(ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH,
-                        "Table function 'merge' requires exactly 2 arguments - name "
-                        "of source database and regexp for table names.");
+                        "Table function 'merge' from 1 to 2 parameters: "
+                        "merge(['db_name',] 'tables_regexp')");
 
     ASTs & args = args_func.at(0)->children;
 
-    if (args.size() != 2)
+    if (args.size() == 1)
+    {
+        database_is_regexp = false;
+        source_database_name_or_regexp = context->getCurrentDatabase();
+
+        args[0] = evaluateConstantExpressionAsLiteral(args[0], context);
+        source_table_regexp = checkAndGetLiteralArgument<String>(args[0], "table_name_regexp");
+    }
+    else if (args.size() == 2)
+    {
+        auto [is_regexp, database_ast] = StorageMerge::evaluateDatabaseName(args[0], context);
+
+        database_is_regexp = is_regexp;
+
+        if (!is_regexp)
+            args[0] = database_ast;
+        source_database_name_or_regexp = checkAndGetLiteralArgument<String>(database_ast, "database_name");
+
+        args[1] = evaluateConstantExpressionAsLiteral(args[1], context);
+        source_table_regexp = checkAndGetLiteralArgument<String>(args[1], "table_name_regexp");
+    }
+    else
+    {
         throw Exception(ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH,
-                        "Table function 'merge' requires exactly 2 arguments - name "
-                        "of source database and regexp for table names.");
-
-    auto [is_regexp, database_ast] = StorageMerge::evaluateDatabaseName(args[0], context);
-
-    database_is_regexp = is_regexp;
-
-    if (!is_regexp)
-        args[0] = database_ast;
-    source_database_name_or_regexp = checkAndGetLiteralArgument<String>(database_ast, "database_name");
-
-    args[1] = evaluateConstantExpressionAsLiteral(args[1], context);
-    source_table_regexp = checkAndGetLiteralArgument<String>(args[1], "table_name_regexp");
+                        "Table function 'merge' from 1 to 2 parameters: "
+                        "merge(['db_name',] 'tables_regexp')");
+    }
 }
 
 

--- a/src/TableFunctions/TableFunctionMerge.cpp
+++ b/src/TableFunctions/TableFunctionMerge.cpp
@@ -88,7 +88,7 @@ void TableFunctionMerge::parseArguments(const ASTPtr & ast_function, ContextPtr 
 
     if (args_func.size() != 1)
         throw Exception(ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH,
-                        "Table function 'merge' from 1 to 2 parameters: "
+                        "Table function 'merge' requires from 1 to 2 parameters: "
                         "merge(['db_name',] 'tables_regexp')");
 
     ASTs & args = args_func.at(0)->children;
@@ -117,7 +117,7 @@ void TableFunctionMerge::parseArguments(const ASTPtr & ast_function, ContextPtr 
     else
     {
         throw Exception(ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH,
-                        "Table function 'merge' from 1 to 2 parameters: "
+                        "Table function 'merge' requires from 1 to 2 parameters: "
                         "merge(['db_name',] 'tables_regexp')");
     }
 }

--- a/tests/queries/0_stateless/01902_table_function_merge_db_params.reference
+++ b/tests/queries/0_stateless/01902_table_function_merge_db_params.reference
@@ -1,0 +1,6 @@
+01902_db_params	t	0
+01902_db_params	t	1
+01902_db_params	t	2
+01902_db_params	t	0
+01902_db_params	t	1
+01902_db_params	t	2

--- a/tests/queries/0_stateless/01902_table_function_merge_db_params.sql
+++ b/tests/queries/0_stateless/01902_table_function_merge_db_params.sql
@@ -1,0 +1,13 @@
+DROP DATABASE IF EXISTS 01902_db_params;
+CREATE DATABASE 01902_db_params;
+CREATE TABLE 01902_db_params.t(n Int8) ENGINE=MergeTree ORDER BY n;
+INSERT INTO 01902_db_params.t SELECT * FROM numbers(3);
+SELECT _database, _table, n FROM merge(REGEXP('^01902_db_params'), '^t') ORDER BY _database, _table, n;
+
+SELECT _database, _table, n FROM merge() ORDER BY _database, _table, n; -- {serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH}
+SELECT _database, _table, n FROM merge('^t') ORDER BY _database, _table, n; -- {serverError BAD_ARGUMENTS}
+
+USE 01902_db_params;
+SELECT _database, _table, n FROM merge('^t') ORDER BY _database, _table, n;
+
+DROP DATABASE 01902_db_params;


### PR DESCRIPTION
Close #60301 
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- New Feature


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Support single-argument version for the merge table function, as `merge(['db_name', ] 'tables_regexp')`

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
