### PR TITLE
Fix bugfix check (due to unknown commit_logs_cache_size_threshold)

### DIFF
--- a/docker/test/stateless/run.sh
+++ b/docker/test/stateless/run.sh
@@ -59,6 +59,16 @@ if [[ -n "$BUGFIX_VALIDATE_CHECK" ]] && [[ "$BUGFIX_VALIDATE_CHECK" -eq 1 ]]; th
     # it contains some new settings, but we can safely remove it
     rm /etc/clickhouse-server/users.d/s3_cache_new.xml
     rm /etc/clickhouse-server/config.d/zero_copy_destructive_operations.xml
+
+    function remove_keeper_config()
+    {
+        sudo cat /etc/clickhouse-server/config.d/keeper_port.xml \
+          | sed "/<$1>$2<\/$1>/d" \
+          > /etc/clickhouse-server/config.d/keeper_port.xml.tmp
+        sudo mv /etc/clickhouse-server/config.d/keeper_port.xml.tmp /etc/clickhouse-server/config.d/keeper_port.xml
+    }
+    # commit_logs_cache_size_threshold setting doesn't exist on some older versions
+    remove_keeper_config "commit_logs_cache_size_threshold" "[[:digit:]]\+"
 fi
 
 # For flaky check we also enable thread fuzzer

--- a/docker/test/stateless/run.sh
+++ b/docker/test/stateless/run.sh
@@ -69,6 +69,7 @@ if [[ -n "$BUGFIX_VALIDATE_CHECK" ]] && [[ "$BUGFIX_VALIDATE_CHECK" -eq 1 ]]; th
     }
     # commit_logs_cache_size_threshold setting doesn't exist on some older versions
     remove_keeper_config "commit_logs_cache_size_threshold" "[[:digit:]]\+"
+    remove_keeper_config "latest_logs_cache_size_threshold" "[[:digit:]]\+"
 fi
 
 # For flaky check we also enable thread fuzzer


### PR DESCRIPTION
Bugfix check is broken on CI [1], because of:

    2024.02.23 06:12:59.294500 [ 757 ] {} Application: Code: 115. DB::Exception: Unknown setting latest_logs_cache_size_threshold: in Coordination settings config. (UNKNOWN_SETTING), Stack trace (when copying this message, always include the lines below):

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/60031/89eb2a38c0a7c113b7b0a96c8069fea6eb48ae9d/bugfix_validation.html

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)