### PR TITLE
Add the permanent approach for setting THP

### DIFF
--- a/docs/en/operations/tips.md
+++ b/docs/en/operations/tips.md
@@ -111,6 +111,14 @@ On newer Linux kernels transparent huge pages are alright.
 $ echo 'madvise' | sudo tee /sys/kernel/mm/transparent_hugepage/enabled
 ```
 
+If you want to modify the transparent huge pages setting permanently, editing the `/etc/default/grub` to add the `transparent_hugepage=never` to the `GRUB_CMDLINE_LINUX_DEFAULT` option:
+
+```bash
+$ GRUB_CMDLINE_LINUX_DEFAULT="transparent_hugepage=madvise ..."
+```
+
+After that, run the `sudo update-grub` command then reboot to take effect.
+
 ## Hypervisor configuration
 
 If you are using OpenStack, set


### PR DESCRIPTION
### Changelog category (leave one):

- Documentation (changelog entry is not required)

According to the approach about setting transparent huge page, it cannot keep the setting after rebooting.

Adding the permanent approach when users want to set the transparent huge page permanently.