### PR TITLE
Simplify the importing GPG keys approach

### DIFF
--- a/docs/en/getting-started/install.md
+++ b/docs/en/getting-started/install.md
@@ -79,10 +79,7 @@ It is recommended to use official pre-compiled `deb` packages for Debian or Ubun
 #### Setup the Debian repository
 ``` bash
 sudo apt-get install -y apt-transport-https ca-certificates dirmngr
-GNUPGHOME=$(mktemp -d)
-sudo GNUPGHOME="$GNUPGHOME" gpg --no-default-keyring --keyring /usr/share/keyrings/clickhouse-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8919F6BD2B48D754
-sudo rm -rf "$GNUPGHOME"
-sudo chmod +r /usr/share/keyrings/clickhouse-keyring.gpg
+sudo gpg --no-default-keyring --keyring /usr/share/keyrings/clickhouse-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8919F6BD2B48D754
 
 echo "deb [signed-by=/usr/share/keyrings/clickhouse-keyring.gpg] https://packages.clickhouse.com/deb stable main" | sudo tee \
     /etc/apt/sources.list.d/clickhouse.list


### PR DESCRIPTION
### Changelog category (leave one):
- Documentation (changelog entry is not required)

After testing the following Debian-based distributions, it's not necessary to create the temporary directory for GPG when importing the GPG keys.

And the keyring file permission is configured correctly after importing the GPG key.

These distributions I tested are as follows:

- Ubuntu 18.04, 20.04 and 22.04
- Debian 10, 11 and 12

And related command executing outputs are as follows:

```sh
$ sudo gpg --no-default-keyring --keyring /usr/share/keyrings/clickhouse-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8919F6BD2B48D754
gpg: keybox '/usr/share/keyrings/clickhouse-keyring.gpg' created
gpg: /root/.gnupg/trustdb.gpg: trustdb created
gpg: key 8919F6BD2B48D754: public key "ClickHouse Inc. Repositories Key <packages@clickhouse.com>" imported
gpg: Total number processed: 1
gpg:               imported: 1
$ ls -al /usr/share/keyrings/clickhouse-keyring.gpg
-rw-r--r-- 1 root root 4203 Feb 26 08:49 /usr/share/keyrings/clickhouse-keyring.gpg
```

BTW, after digging the temporary directory issue, it's about the `GPG` version. And it's not related to the distributions.
