### PR TITLE
Stateless test to validate projections work after attach

### DIFF
--- a/tests/queries/0_stateless/02998_projection_after_attach_partition.reference
+++ b/tests/queries/0_stateless/02998_projection_after_attach_partition.reference
@@ -23,20 +23,3 @@ EXPLAIN SELECT * FROM visits_order_dst WHERE user_name='another_user2';
 Expression ((Projection + Before ORDER BY))
   Filter
     ReadFromMergeTree (user_name_projection)
-DROP TABLE IF EXISTS visits_order;
-DROP TABLE IF EXISTS visits_order_dst;
-CREATE TABLE visits_order
-(
-    user_id UInt64,
-    user_name String,
-    some_int UInt64
-) ENGINE = MergeTree() PRIMARY KEY user_id PARTITION BY user_id;
-CREATE TABLE visits_order_dst
-(
-    user_id UInt64,
-    user_name String,
-    some_int UInt64
-) ENGINE = MergeTree() PRIMARY KEY user_id PARTITION BY user_id;
-ALTER TABLE visits_order ADD PROJECTION user_name_projection (SELECT * ORDER BY user_name);
-ALTER TABLE visits_order_dst ATTACH PARTITION ID '2' FROM visits_order -- {serverError 36};
-

--- a/tests/queries/0_stateless/02998_projection_after_attach_partition.reference
+++ b/tests/queries/0_stateless/02998_projection_after_attach_partition.reference
@@ -19,7 +19,13 @@ INSERT INTO visits_order SELECT 2, 'user2', number from numbers(1, 10);
 INSERT INTO visits_order SELECT 2, 'another_user2', number*2 from numbers(1, 10);
 INSERT INTO visits_order SELECT 2, 'yet_another_user2', number*3 from numbers(1, 10);
 ALTER TABLE visits_order_dst ATTACH PARTITION ID '2' FROM visits_order;
+SET allow_experimental_analyzer=0;
 EXPLAIN SELECT * FROM visits_order_dst WHERE user_name='another_user2';
 Expression ((Projection + Before ORDER BY))
+  Filter
+    ReadFromMergeTree (user_name_projection)
+SET allow_experimental_analyzer=1;
+EXPLAIN SELECT * FROM visits_order_dst WHERE user_name='another_user2';
+Expression ((Project names + Projection))
   Filter
     ReadFromMergeTree (user_name_projection)

--- a/tests/queries/0_stateless/02998_projection_after_attach_partition.reference
+++ b/tests/queries/0_stateless/02998_projection_after_attach_partition.reference
@@ -1,0 +1,3 @@
+Expression ((Projection + Before ORDER BY))
+  Filter
+    ReadFromMergeTree (user_name_projection)

--- a/tests/queries/0_stateless/02998_projection_after_attach_partition.reference
+++ b/tests/queries/0_stateless/02998_projection_after_attach_partition.reference
@@ -1,3 +1,42 @@
+-- { echoOn }
+DROP TABLE IF EXISTS visits_order;
+DROP TABLE IF EXISTS visits_order_dst;
+CREATE TABLE visits_order
+(
+    user_id UInt64,
+    user_name String,
+    some_int UInt64
+) ENGINE = MergeTree() PRIMARY KEY user_id PARTITION BY user_id;
+CREATE TABLE visits_order_dst
+(
+    user_id UInt64,
+    user_name String,
+    some_int UInt64
+) ENGINE = MergeTree() PRIMARY KEY user_id PARTITION BY user_id;
+ALTER TABLE visits_order ADD PROJECTION user_name_projection (SELECT * ORDER BY user_name);
+ALTER TABLE visits_order_dst ADD PROJECTION user_name_projection (SELECT * ORDER BY user_name);
+INSERT INTO visits_order SELECT 2, 'user2', number from numbers(1, 10);
+INSERT INTO visits_order SELECT 2, 'another_user2', number*2 from numbers(1, 10);
+INSERT INTO visits_order SELECT 2, 'yet_another_user2', number*3 from numbers(1, 10);
+ALTER TABLE visits_order_dst ATTACH PARTITION ID '2' FROM visits_order;
+EXPLAIN SELECT * FROM visits_order_dst WHERE user_name='another_user2';
 Expression ((Projection + Before ORDER BY))
   Filter
     ReadFromMergeTree (user_name_projection)
+DROP TABLE IF EXISTS visits_order;
+DROP TABLE IF EXISTS visits_order_dst;
+CREATE TABLE visits_order
+(
+    user_id UInt64,
+    user_name String,
+    some_int UInt64
+) ENGINE = MergeTree() PRIMARY KEY user_id PARTITION BY user_id;
+CREATE TABLE visits_order_dst
+(
+    user_id UInt64,
+    user_name String,
+    some_int UInt64
+) ENGINE = MergeTree() PRIMARY KEY user_id PARTITION BY user_id;
+ALTER TABLE visits_order ADD PROJECTION user_name_projection (SELECT * ORDER BY user_name);
+ALTER TABLE visits_order_dst ATTACH PARTITION ID '2' FROM visits_order -- {serverError 36};
+

--- a/tests/queries/0_stateless/02998_projection_after_attach_partition.sql
+++ b/tests/queries/0_stateless/02998_projection_after_attach_partition.sql
@@ -26,23 +26,3 @@ INSERT INTO visits_order SELECT 2, 'yet_another_user2', number*3 from numbers(1,
 ALTER TABLE visits_order_dst ATTACH PARTITION ID '2' FROM visits_order;
 
 EXPLAIN SELECT * FROM visits_order_dst WHERE user_name='another_user2';
-
-DROP TABLE IF EXISTS visits_order;
-DROP TABLE IF EXISTS visits_order_dst;
-
-CREATE TABLE visits_order
-(
-    user_id UInt64,
-    user_name String,
-    some_int UInt64
-) ENGINE = MergeTree() PRIMARY KEY user_id PARTITION BY user_id;
-
-CREATE TABLE visits_order_dst
-(
-    user_id UInt64,
-    user_name String,
-    some_int UInt64
-) ENGINE = MergeTree() PRIMARY KEY user_id PARTITION BY user_id;
-
-ALTER TABLE visits_order ADD PROJECTION user_name_projection (SELECT * ORDER BY user_name);
-ALTER TABLE visits_order_dst ATTACH PARTITION ID '2' FROM visits_order -- {serverError 36};

--- a/tests/queries/0_stateless/02998_projection_after_attach_partition.sql
+++ b/tests/queries/0_stateless/02998_projection_after_attach_partition.sql
@@ -1,0 +1,47 @@
+DROP TABLE IF EXISTS visits_order;
+DROP TABLE IF EXISTS visits_order_dst;
+
+CREATE TABLE visits_order
+(
+    user_id UInt64,
+    user_name String,
+    some_int UInt64
+) ENGINE = MergeTree() PRIMARY KEY user_id PARTITION BY user_id;
+
+CREATE TABLE visits_order_dst
+(
+    user_id UInt64,
+    user_name String,
+    some_int UInt64
+) ENGINE = MergeTree() PRIMARY KEY user_id PARTITION BY user_id;
+
+ALTER TABLE visits_order ADD PROJECTION user_name_projection (SELECT * ORDER BY user_name);
+ALTER TABLE visits_order_dst ADD PROJECTION user_name_projection (SELECT * ORDER BY user_name);
+
+INSERT INTO visits_order SELECT 2, 'user2', number from numbers(1, 10);
+INSERT INTO visits_order SELECT 2, 'another_user2', number*2 from numbers(1, 10);
+INSERT INTO visits_order SELECT 2, 'yet_another_user2', number*3 from numbers(1, 10);
+
+ALTER TABLE visits_order_dst ATTACH PARTITION ID '2' FROM visits_order;
+
+EXPLAIN SELECT * FROM visits_order_dst WHERE user_name='another_user2';
+
+DROP TABLE IF EXISTS visits_order;
+DROP TABLE IF EXISTS visits_order_dst;
+
+CREATE TABLE visits_order
+(
+    user_id UInt64,
+    user_name String,
+    some_int UInt64
+) ENGINE = MergeTree() PRIMARY KEY user_id PARTITION BY user_id;
+
+CREATE TABLE visits_order_dst
+(
+    user_id UInt64,
+    user_name String,
+    some_int UInt64
+) ENGINE = MergeTree() PRIMARY KEY user_id PARTITION BY user_id;
+
+ALTER TABLE visits_order ADD PROJECTION user_name_projection (SELECT * ORDER BY user_name);
+ALTER TABLE visits_order_dst ATTACH PARTITION ID '2' FROM visits_order -- {serverError 36};

--- a/tests/queries/0_stateless/02998_projection_after_attach_partition.sql
+++ b/tests/queries/0_stateless/02998_projection_after_attach_partition.sql
@@ -1,3 +1,4 @@
+-- { echoOn }
 DROP TABLE IF EXISTS visits_order;
 DROP TABLE IF EXISTS visits_order_dst;
 

--- a/tests/queries/0_stateless/02998_projection_after_attach_partition.sql
+++ b/tests/queries/0_stateless/02998_projection_after_attach_partition.sql
@@ -25,4 +25,10 @@ INSERT INTO visits_order SELECT 2, 'yet_another_user2', number*3 from numbers(1,
 
 ALTER TABLE visits_order_dst ATTACH PARTITION ID '2' FROM visits_order;
 
+SET allow_experimental_analyzer=0;
+
+EXPLAIN SELECT * FROM visits_order_dst WHERE user_name='another_user2';
+
+SET allow_experimental_analyzer=1;
+
 EXPLAIN SELECT * FROM visits_order_dst WHERE user_name='another_user2';


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add test that validates projections still work after attach partition

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
