### PR TITLE
Fix undefined-behavior in case of too big max_execution_time setting

### DIFF
--- a/src/Core/SettingsFields.cpp
+++ b/src/Core/SettingsFields.cpp
@@ -21,6 +21,7 @@ namespace ErrorCodes
     extern const int CANNOT_PARSE_BOOL;
     extern const int CANNOT_PARSE_NUMBER;
     extern const int CANNOT_CONVERT_TYPE;
+    extern const int BAD_ARGUMENTS;
 }
 
 
@@ -268,6 +269,10 @@ namespace
         if (d != 0.0 && !std::isnormal(d))
             throw Exception(
                 ErrorCodes::CANNOT_PARSE_NUMBER, "A setting's value in seconds must be a normal floating point number or zero. Got {}", d);
+        if (d * 1000000 > std::numeric_limits<Poco::Timespan::TimeDiff>::max() || d * 1000000 < std::numeric_limits<Poco::Timespan::TimeDiff>::min())
+            throw Exception(
+                ErrorCodes::BAD_ARGUMENTS, "Cannot convert seconds to microseconds: the setting's value in seconds is too big: {}", d);
+
         return static_cast<Poco::Timespan::TimeDiff>(d * 1000000);
     }
 

--- a/tests/queries/0_stateless/03000_too_big_max_execution_time_setting.sql
+++ b/tests/queries/0_stateless/03000_too_big_max_execution_time_setting.sql
@@ -1,2 +1,2 @@
-select 1 settings max_execution_time = 9223372036854775808; -- {clientError CANNOT_PARSE_NUMBER}
+select 1 settings max_execution_time = 9223372036854775808; -- {clientError BAD_ARGUMENTS}
 

--- a/tests/queries/0_stateless/03000_too_big_max_execution_time_setting.sql
+++ b/tests/queries/0_stateless/03000_too_big_max_execution_time_setting.sql
@@ -1,0 +1,2 @@
+select 1 settings max_execution_time = 9223372036854775808; -- {clientError CANNOT_PARSE_NUMBER}
+


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

https://s3.amazonaws.com/clickhouse-test-reports/60372/5fffe2508c2192b51254eb187dbf4430829ad23c/ast_fuzzer__ubsan_.html

```
/build/src/Core/SettingsFields.cpp:271:54: runtime error: -9.22337e+24 is outside the range of representable values of type 'long'
```