### PR TITLE
Adds docs for version().

### DIFF
--- a/docs/en/sql-reference/functions/other-functions.md
+++ b/docs/en/sql-reference/functions/other-functions.md
@@ -780,8 +780,47 @@ If executed in the context of a distributed table, this function generates a nor
 
 ## version()
 
-Returns the server version as a string.
-If executed in the context of a distributed table, this function generates a normal column with values relevant to each shard. Otherwise it produces a constant value.
+Returns the current version of ClickHouse as a string in the form of:
+
+```plaintext
+major version`.minor version.patch version.the number of commits since the previous stable release
+```
+
+If executed in the context of a distributed table, this function generates a normal column with values relevant to each shard. Otherwise, it produces a constant value.
+
+**Syntax**
+
+```sql
+version()
+```
+
+**Arguments**
+
+None.
+
+**Returned value**
+
+Type: [String](../data-types/string)
+
+**Implementation details**
+
+None.
+
+**Example**
+
+Query:
+
+```sql
+SELECT version()
+```
+
+**Result**:
+
+```response
+┌─version()─┐
+│ 24.2.1.1  │
+└───────────┘
+```
 
 ## buildId()
 

--- a/docs/en/sql-reference/functions/other-functions.md
+++ b/docs/en/sql-reference/functions/other-functions.md
@@ -782,8 +782,13 @@ If executed in the context of a distributed table, this function generates a nor
 
 Returns the current version of ClickHouse as a string in the form of:
 
+- Major version
+- Minor version
+- Patch version
+- Number of commits since the previous stable release.
+
 ```plaintext
-major version`.minor version.patch version.the number of commits since the previous stable release
+major_version.minor_version.patch_version.number_of_commits_since_the_previous_stable_release
 ```
 
 If executed in the context of a distributed table, this function generates a normal column with values relevant to each shard. Otherwise, it produces a constant value.


### PR DESCRIPTION
### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

---

Adds docs for `version()` function. Closes https://github.com/ClickHouse/clickhouse-docs/issues/2037