### PR TITLE
Fix wrong log message in Fuzzer

### DIFF
--- a/docker/test/fuzzer/run-fuzzer.sh
+++ b/docker/test/fuzzer/run-fuzzer.sh
@@ -86,7 +86,7 @@ function download
 
     chmod +x clickhouse
     # clickhouse may be compressed - run once to decompress
-    ./clickhouse ||:
+    ./clickhouse --query "SELECT 1" ||:
     ln -s ./clickhouse ./clickhouse-server
     ln -s ./clickhouse ./clickhouse-client
     ln -s ./clickhouse ./clickhouse-local


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

This was looking strange:
```
2024-02-25 23:56:41	 + chmod +x clickhouse
2024-02-25 23:56:41	 + ./clickhouse
2024-02-25 23:57:15	 Decompressing the binary.........................
2024-02-25 23:57:15	 Code: 62. DB::Exception: Empty query. (SYNTAX_ERROR)
2024-02-25 23:57:15	 + :
```