### PR TITLE
Improve test test_reload_clusters_config

### DIFF
--- a/tests/integration/test_reload_clusters_config/test.py
+++ b/tests/integration/test_reload_clusters_config/test.py
@@ -14,6 +14,7 @@ node = cluster.add_instance(
     "node", with_zookeeper=True, main_configs=["configs/remote_servers.xml"]
 )
 
+
 @pytest.fixture(scope="module")
 def started_cluster():
     try:

--- a/tests/integration/test_reload_clusters_config/test.py
+++ b/tests/integration/test_reload_clusters_config/test.py
@@ -13,9 +13,6 @@ cluster = ClickHouseCluster(__file__)
 node = cluster.add_instance(
     "node", with_zookeeper=True, main_configs=["configs/remote_servers.xml"]
 )
-node_1 = cluster.add_instance("node_1", with_zookeeper=True)
-node_2 = cluster.add_instance("node_2", with_zookeeper=True)
-
 
 @pytest.fixture(scope="module")
 def started_cluster():
@@ -31,9 +28,6 @@ def started_cluster():
             """CREATE TABLE distributed2 (id UInt32) ENGINE =
             Distributed('test_cluster2', 'default', 'replicated')"""
         )
-
-        cluster.pause_container("node_1")
-        cluster.pause_container("node_2")
 
         yield cluster
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Sometimes it fails: https://s3.amazonaws.com/clickhouse-test-reports/60409/2ea20004efa68489e52c30bc27be7f1427cd0e5a/integration_tests__tsan__%5B3_6%5D.html
It happens because for some reason after `cluster.pause_container("node_1")` node `node_1` continued accepting connections. But actually in this test we don't need instances `node_1/node_2` to start up at all.