### PR TITLE
Split update_mergeable_check into two functions to force trigger the status

### DIFF
--- a/tests/ci/cache_utils.py
+++ b/tests/ci/cache_utils.py
@@ -123,6 +123,13 @@ class Cache:
                 local_s3_cache = Path(url[7:])
                 if local_s3_cache.is_file():
                     shutil.copy2(local_s3_cache, compressed_cache)
+                else:
+                    logging.warning(
+                        "The local cache file %s does not exist, creating empty directory",
+                        local_s3_cache,
+                    )
+                    self.directory.mkdir(parents=True, exist_ok=True)
+                    return
             else:
                 download_build_with_progress(url, compressed_cache)
         except DownloadException as e:
@@ -155,7 +162,7 @@ class Cache:
                 logging.info("Remote cache %s already exist, won't reupload", s3_path)
                 return
 
-        logging.info("Compressing cargo cache")
+        logging.info("Compressing cache")
         archive_path = self.temp_path / self.archive_name
         compress_fast(self.directory, archive_path)
         logging.info("Uploading %s to S3 path %s", archive_path, s3_path)

--- a/tests/ci/commit_status_helper.py
+++ b/tests/ci/commit_status_helper.py
@@ -425,13 +425,14 @@ def set_mergeable_check(
 ) -> None:
     commit.create_status(
         context=MERGEABLE_NAME,
-        description=description,
+        description=format_description(description),
         state=state,
         target_url=GITHUB_JOB_URL(),
     )
 
 
 def update_mergeable_check(commit: Commit, pr_info: PRInfo, check_name: str) -> None:
+    "check if the check_name in REQUIRED_CHECKS and then trigger update"
     not_run = (
         pr_info.labels.intersection({SKIP_MERGEABLE_CHECK_LABEL, "release"})
         or check_name not in REQUIRED_CHECKS
@@ -445,7 +446,11 @@ def update_mergeable_check(commit: Commit, pr_info: PRInfo, check_name: str) -> 
     logging.info("Update Mergeable Check by %s", check_name)
 
     statuses = get_commit_filtered_statuses(commit)
+    trigger_mergeable_check(commit, statuses)
 
+
+def trigger_mergeable_check(commit: Commit, statuses: CommitStatuses) -> None:
+    """calculate and update MERGEABLE_NAME"""
     required_checks = [
         status for status in statuses if status.context in REQUIRED_CHECKS
     ]


### PR DESCRIPTION


<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
