### PR TITLE
Replace deprecated distutils by vendored packaging

### DIFF
--- a/tests/ci/compatibility_check.py
+++ b/tests/ci/compatibility_check.py
@@ -4,9 +4,13 @@ import argparse
 import logging
 import subprocess
 import sys
-from distutils.version import StrictVersion
 from pathlib import Path
 from typing import List, Tuple
+
+# isort: off
+from pip._vendor.packaging.version import Version
+
+# isort: on
 
 from build_download_helper import download_builds_filter
 from docker_images_helper import DockerImage, get_docker_image, pull_image
@@ -38,7 +42,7 @@ def process_glibc_check(log_path: Path, max_glibc_version: str) -> TestResults:
                 _, version = symbol_with_glibc.split("@GLIBC_")
                 if version == "PRIVATE":
                     test_results.append(TestResult(symbol_with_glibc, "FAIL"))
-                elif StrictVersion(version) > max_glibc_version:
+                elif Version(version) > Version(max_glibc_version):
                     test_results.append(TestResult(symbol_with_glibc, "FAIL"))
     if not test_results:
         test_results.append(TestResult("glibc check", "OK"))


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
A second attempt to get rid of deprecated `distutils`. They will be removed from Python 3.12, so we must move forward. Here's the first attempt #55842