### PR TITLE
Do not fail the build if ci-logs is not healthy

### DIFF
--- a/tests/ci/ci.py
+++ b/tests/ci/ci.py
@@ -1,8 +1,5 @@
 import argparse
 import concurrent.futures
-from copy import deepcopy
-from dataclasses import asdict, dataclass
-from enum import Enum
 import json
 import logging
 import os
@@ -11,17 +8,21 @@ import re
 import subprocess
 import sys
 import time
+from copy import deepcopy
+from dataclasses import asdict, dataclass
+from enum import Enum
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence, Set, Union
 
 import docker_images_helper
 import upload_result_helper
 from build_check import get_release_or_pr
-from ci_config import CI_CONFIG, Build, Labels, JobNames
+from ci_config import CI_CONFIG, Build, JobNames, Labels
 from ci_utils import GHActions, is_hex, normalize_string
 from clickhouse_helper import (
     CiLogsCredentials,
     ClickHouseHelper,
+    InsertException,
     get_instance_id,
     get_instance_type,
     prepare_tests_results_for_clickhouse,
@@ -1504,7 +1505,10 @@ def _upload_build_profile_data(
             profile_data_file.stat().st_size,
             query,
         )
-        ch_helper.insert_file(url, auth, query, profile_data_file)
+        try:
+            ch_helper.insert_file(url, auth, query, profile_data_file)
+        except InsertException:
+            logging.error("Failed to insert profile data for the build, continue")
 
         query = f"""INSERT INTO binary_sizes
             (
@@ -1530,7 +1534,10 @@ def _upload_build_profile_data(
             binary_sizes_file.stat().st_size,
             query,
         )
-        ch_helper.insert_file(url, auth, query, binary_sizes_file)
+        try:
+            ch_helper.insert_file(url, auth, query, binary_sizes_file)
+        except InsertException:
+            logging.error("Failed to insert binary_size_file for the build, continue")
 
 
 def _run_test(job_name: str, run_command: str) -> int:


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Avoid situations like https://github.com/ClickHouse/ClickHouse/actions/runs/8064238811/job/22029154629?pr=60444#step:9:127