### PR TITLE
Fix OptimizeDateOrDateTimeConverterWithPreimageVisitor with null arguments

### DIFF
--- a/src/Analyzer/Passes/OptimizeDateOrDateTimeConverterWithPreimagePass.cpp
+++ b/src/Analyzer/Passes/OptimizeDateOrDateTimeConverterWithPreimagePass.cpp
@@ -56,6 +56,9 @@ public:
             {"greaterOrEquals", "lessOrEquals"},
         };
 
+        if (!getSettings().optimize_time_filter_with_preimage)
+            return;
+
         const auto * function = node->as<FunctionNode>();
 
         if (!function || !swap_relations.contains(function->getFunctionName()))
@@ -67,8 +70,13 @@ public:
         size_t func_id = function->getArguments().getNodes().size();
 
         for (size_t i = 0; i < function->getArguments().getNodes().size(); i++)
+        {
             if (const auto * func = function->getArguments().getNodes()[i]->as<FunctionNode>())
+            {
                 func_id = i;
+                break;
+            }
+        }
 
         if (func_id == function->getArguments().getNodes().size())
             return;

--- a/src/Analyzer/Passes/OptimizeDateOrDateTimeConverterWithPreimagePass.cpp
+++ b/src/Analyzer/Passes/OptimizeDateOrDateTimeConverterWithPreimagePass.cpp
@@ -2,10 +2,10 @@
 
 #include <Functions/FunctionFactory.h>
 
-#include <Analyzer/InDepthQueryTreeVisitor.h>
 #include <Analyzer/ColumnNode.h>
 #include <Analyzer/ConstantNode.h>
 #include <Analyzer/FunctionNode.h>
+#include <Analyzer/InDepthQueryTreeVisitor.h>
 #include <Common/DateLUT.h>
 #include <Common/DateLUTImpl.h>
 
@@ -14,20 +14,19 @@ namespace DB
 
 namespace ErrorCodes
 {
-    extern const int LOGICAL_ERROR;
+extern const int LOGICAL_ERROR;
 }
 
 namespace
 {
 
-class OptimizeDateOrDateTimeConverterWithPreimageVisitor : public InDepthQueryTreeVisitorWithContext<OptimizeDateOrDateTimeConverterWithPreimageVisitor>
+class OptimizeDateOrDateTimeConverterWithPreimageVisitor
+    : public InDepthQueryTreeVisitorWithContext<OptimizeDateOrDateTimeConverterWithPreimageVisitor>
 {
 public:
     using Base = InDepthQueryTreeVisitorWithContext<OptimizeDateOrDateTimeConverterWithPreimageVisitor>;
 
-    explicit OptimizeDateOrDateTimeConverterWithPreimageVisitor(ContextPtr context)
-        : Base(std::move(context))
-    {}
+    explicit OptimizeDateOrDateTimeConverterWithPreimageVisitor(ContextPtr context) : Base(std::move(context)) { }
 
     static bool needChildVisit(QueryTreeNodePtr & node, QueryTreeNodePtr & /*child*/)
     {
@@ -41,9 +40,7 @@ public:
         };
 
         if (const auto * function = node->as<FunctionNode>())
-        {
             return !relations.contains(function->getFunctionName());
-        }
 
         return true;
     }
@@ -61,62 +58,70 @@ public:
 
         const auto * function = node->as<FunctionNode>();
 
-        if (!function || !swap_relations.contains(function->getFunctionName())) return;
+        if (!function || !swap_relations.contains(function->getFunctionName()))
+            return;
 
-        if (function->getArguments().getNodes().size() != 2) return;
+        if (function->getArguments().getNodes().size() != 2)
+            return;
 
         size_t func_id = function->getArguments().getNodes().size();
 
         for (size_t i = 0; i < function->getArguments().getNodes().size(); i++)
-        {
             if (const auto * func = function->getArguments().getNodes()[i]->as<FunctionNode>())
-            {
                 func_id = i;
-            }
-        }
 
-        if (func_id == function->getArguments().getNodes().size()) return;
+        if (func_id == function->getArguments().getNodes().size())
+            return;
 
         size_t literal_id = 1 - func_id;
         const auto * literal = function->getArguments().getNodes()[literal_id]->as<ConstantNode>();
 
-        if (!literal || literal->getValue().getType() != Field::Types::UInt64) return;
+        if (!literal || literal->getValue().getType() != Field::Types::UInt64)
+            return;
 
-        String comparator = literal_id > func_id ? function->getFunctionName(): swap_relations.at(function->getFunctionName());
+        String comparator = literal_id > func_id ? function->getFunctionName() : swap_relations.at(function->getFunctionName());
 
         const auto * func_node = function->getArguments().getNodes()[func_id]->as<FunctionNode>();
         /// Currently we only handle single-argument functions.
-        if (!func_node || func_node->getArguments().getNodes().size() != 1) return;
+        if (!func_node || func_node->getArguments().getNodes().size() != 1)
+            return;
 
         const auto * column_id = func_node->getArguments().getNodes()[0]->as<ColumnNode>();
-        if (!column_id) return;
+        if (!column_id)
+            return;
 
         if (column_id->getColumnName() == "__grouping_set")
             return;
 
         const auto * column_type = column_id->getColumnType().get();
-        if (!isDateOrDate32(column_type) && !isDateTime(column_type) && !isDateTime64(column_type)) return;
+        if (!isDateOrDate32(column_type) && !isDateTime(column_type) && !isDateTime64(column_type))
+            return;
 
         const auto & converter = FunctionFactory::instance().tryGet(func_node->getFunctionName(), getContext());
-        if (!converter) return;
+        if (!converter)
+            return;
 
         ColumnsWithTypeAndName args;
         args.emplace_back(column_id->getColumnType(), "tmp");
         auto converter_base = converter->build(args);
-        if (!converter_base || !converter_base->hasInformationAboutPreimage()) return;
+        if (!converter_base || !converter_base->hasInformationAboutPreimage())
+            return;
 
         auto preimage_range = converter_base->getPreimage(*(column_id->getColumnType()), literal->getValue());
-        if (!preimage_range) return;
+        if (!preimage_range)
+            return;
 
         const auto new_node = generateOptimizedDateFilter(comparator, *column_id, *preimage_range);
 
-        if (!new_node) return;
+        if (!new_node)
+            return;
 
         node = new_node;
     }
 
 private:
-    QueryTreeNodePtr generateOptimizedDateFilter(const String & comparator, const ColumnNode & column_node, const std::pair<Field, Field>& range) const
+    QueryTreeNodePtr
+    generateOptimizedDateFilter(const String & comparator, const ColumnNode & column_node, const std::pair<Field, Field> & range) const
     {
         const DateLUTImpl & date_lut = DateLUT::instance("UTC");
 
@@ -133,7 +138,8 @@ private:
             start_date_or_date_time = date_lut.timeToString(range.first.get<DateLUTImpl::Time>());
             end_date_or_date_time = date_lut.timeToString(range.second.get<DateLUTImpl::Time>());
         }
-        else [[unlikely]] return {};
+        else [[unlikely]]
+            return {};
 
         if (comparator == "equals")
         {
@@ -174,7 +180,8 @@ private:
         else if (comparator == "greater")
         {
             const auto new_date_filter = std::make_shared<FunctionNode>("greaterOrEquals");
-            new_date_filter->getArguments().getNodes().push_back(std::make_shared<ColumnNode>(column_node.getColumn(), column_node.getColumnSource()));
+            new_date_filter->getArguments().getNodes().push_back(
+                std::make_shared<ColumnNode>(column_node.getColumn(), column_node.getColumnSource()));
             new_date_filter->getArguments().getNodes().push_back(std::make_shared<ConstantNode>(end_date_or_date_time));
             resolveOrdinaryFunctionNode(*new_date_filter, new_date_filter->getFunctionName());
 
@@ -183,7 +190,8 @@ private:
         else if (comparator == "lessOrEquals")
         {
             const auto new_date_filter = std::make_shared<FunctionNode>("less");
-            new_date_filter->getArguments().getNodes().push_back(std::make_shared<ColumnNode>(column_node.getColumn(), column_node.getColumnSource()));
+            new_date_filter->getArguments().getNodes().push_back(
+                std::make_shared<ColumnNode>(column_node.getColumn(), column_node.getColumnSource()));
             new_date_filter->getArguments().getNodes().push_back(std::make_shared<ConstantNode>(end_date_or_date_time));
             resolveOrdinaryFunctionNode(*new_date_filter, new_date_filter->getFunctionName());
 
@@ -192,7 +200,8 @@ private:
         else if (comparator == "less" || comparator == "greaterOrEquals")
         {
             const auto new_date_filter = std::make_shared<FunctionNode>(comparator);
-            new_date_filter->getArguments().getNodes().push_back(std::make_shared<ColumnNode>(column_node.getColumn(), column_node.getColumnSource()));
+            new_date_filter->getArguments().getNodes().push_back(
+                std::make_shared<ColumnNode>(column_node.getColumn(), column_node.getColumnSource()));
             new_date_filter->getArguments().getNodes().push_back(std::make_shared<ConstantNode>(start_date_or_date_time));
             resolveOrdinaryFunctionNode(*new_date_filter, new_date_filter->getFunctionName());
 
@@ -200,7 +209,8 @@ private:
         }
         else [[unlikely]]
         {
-            throw Exception(ErrorCodes::LOGICAL_ERROR,
+            throw Exception(
+                ErrorCodes::LOGICAL_ERROR,
                 "Expected equals, notEquals, less, lessOrEquals, greater, greaterOrEquals. Actual {}",
                 comparator);
         }

--- a/src/Analyzer/Passes/OptimizeDateOrDateTimeConverterWithPreimagePass.cpp
+++ b/src/Analyzer/Passes/OptimizeDateOrDateTimeConverterWithPreimagePass.cpp
@@ -84,7 +84,7 @@ public:
         size_t literal_id = 1 - func_id;
         const auto * literal = function->getArguments().getNodes()[literal_id]->as<ConstantNode>();
 
-        if (!literal || literal->getValue().getType() != Field::Types::UInt64)
+        if (!literal || !literal->getResultType()->isValueRepresentedByUnsignedInteger())
             return;
 
         String comparator = literal_id > func_id ? function->getFunctionName() : swap_relations.at(function->getFunctionName());

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -592,6 +592,7 @@ class IColumn;
     M(Bool, optimize_using_constraints, false, "Use constraints for query optimization", 0)                                                                                                                                           \
     M(Bool, optimize_substitute_columns, false, "Use constraints for column substitution", 0)                                                                                                                                         \
     M(Bool, optimize_append_index, false, "Use constraints in order to append index condition (indexHint)", 0) \
+    M(Bool, optimize_time_filter_with_preimage, true, "Optimize Date and DateTime predicates by converting functions into equivalent comparisons without conversions (e.g. toYear(col) = 2023 -> col >= '2023-01-01' AND col <= '2023-12-31')", 0) \
     M(Bool, normalize_function_names, true, "Normalize function names to their canonical names", 0) \
     M(Bool, enable_early_constant_folding, true, "Enable query optimization where we analyze function and subqueries results and rewrite query if there are constants there", 0) \
     M(Bool, deduplicate_blocks_in_dependent_materialized_views, false, "Should deduplicate blocks for materialized views if the block is not a duplicate for the table. Use true to always deduplicate in dependent tables.", 0) \

--- a/src/Core/SettingsChangesHistory.h
+++ b/src/Core/SettingsChangesHistory.h
@@ -103,6 +103,7 @@ static std::map<ClickHouseVersion, SettingsChangesHistory::SettingsChanges> sett
               {"min_external_table_block_size_rows", DEFAULT_INSERT_BLOCK_SIZE, DEFAULT_INSERT_BLOCK_SIZE, "Squash blocks passed to external table to specified size in rows, if blocks are not big enough"},
               {"min_external_table_block_size_bytes", DEFAULT_INSERT_BLOCK_SIZE * 256, DEFAULT_INSERT_BLOCK_SIZE * 256, "Squash blocks passed to external table to specified size in bytes, if blocks are not big enough."},
               {"parallel_replicas_prefer_local_join", true, true, "If true, and JOIN can be executed with parallel replicas algorithm, and all storages of right JOIN part are *MergeTree, local JOIN will be used instead of GLOBAL JOIN."},
+              {"optimize_time_filter_with_preimage", true, true, "Optimize Date and DateTime predicates by converting functions into equivalent comparisons without conversions (e.g. toYear(col) = 2023 -> col >= '2023-01-01' AND col <= '2023-12-31')"},
               {"extract_key_value_pairs_max_pairs_per_row", 0, 0, "Max number of pairs that can be produced by the `extractKeyValuePairs` function. Used as a safeguard against consuming too much memory."},
               {"mysql_map_string_to_text_in_show_columns", false, true, "Reduce the configuration effort to connect ClickHouse with BI tools."},
               {"mysql_map_fixed_string_to_text_in_show_columns", false, true, "Reduce the configuration effort to connect ClickHouse with BI tools."},

--- a/src/Interpreters/TreeOptimizer.cpp
+++ b/src/Interpreters/TreeOptimizer.cpp
@@ -755,7 +755,8 @@ void TreeOptimizer::apply(ASTPtr & query, TreeRewriterResult & result,
         rewriteSumFunctionWithSumAndCount(query, tables_with_columns);
 
     /// Rewrite date filters to avoid the calls of converters such as toYear, toYYYYMM, etc.
-    optimizeDateFilters(select_query, tables_with_columns, context);
+    if (!settings.optimize_time_filter_with_preimage)
+        optimizeDateFilters(select_query, tables_with_columns, context);
 
     /// GROUP BY injective function elimination.
     optimizeGroupBy(select_query, context);

--- a/src/Interpreters/TreeOptimizer.cpp
+++ b/src/Interpreters/TreeOptimizer.cpp
@@ -755,7 +755,7 @@ void TreeOptimizer::apply(ASTPtr & query, TreeRewriterResult & result,
         rewriteSumFunctionWithSumAndCount(query, tables_with_columns);
 
     /// Rewrite date filters to avoid the calls of converters such as toYear, toYYYYMM, etc.
-    if (!settings.optimize_time_filter_with_preimage)
+    if (settings.optimize_time_filter_with_preimage)
         optimizeDateFilters(select_query, tables_with_columns, context);
 
     /// GROUP BY injective function elimination.

--- a/tests/queries/0_stateless/02999_analyzer_preimage_null.reference
+++ b/tests/queries/0_stateless/02999_analyzer_preimage_null.reference
@@ -1,0 +1,121 @@
+-- { echoOn }
+EXPLAIN QUERY TREE run_passes = 1
+SELECT *
+FROM date_t__fuzz_0
+WHERE ((toYear(date1) AS b) != toNullable(1993)) AND (id <= b);
+QUERY id: 0
+  PROJECTION COLUMNS
+    id UInt32
+    value1 String
+    date1 Date
+  PROJECTION
+    LIST id: 1, nodes: 3
+      COLUMN id: 2, column_name: id, result_type: UInt32, source_id: 3
+      COLUMN id: 4, column_name: value1, result_type: String, source_id: 3
+      COLUMN id: 5, column_name: date1, result_type: Date, source_id: 3
+  JOIN TREE
+    TABLE id: 3, alias: __table1, table_name: default.date_t__fuzz_0
+  WHERE
+    FUNCTION id: 6, function_name: and, function_type: ordinary, result_type: Nullable(UInt8)
+      ARGUMENTS
+        LIST id: 7, nodes: 2
+          FUNCTION id: 8, function_name: notEquals, function_type: ordinary, result_type: Nullable(UInt8)
+            ARGUMENTS
+              LIST id: 9, nodes: 2
+                FUNCTION id: 10, function_name: toYear, function_type: ordinary, result_type: UInt16
+                  ARGUMENTS
+                    LIST id: 11, nodes: 1
+                      COLUMN id: 12, column_name: date1, result_type: Date, source_id: 3
+                CONSTANT id: 13, constant_value: UInt64_1993, constant_value_type: Nullable(UInt16)
+                  EXPRESSION
+                    FUNCTION id: 14, function_name: toNullable, function_type: ordinary, result_type: Nullable(UInt16)
+                      ARGUMENTS
+                        LIST id: 15, nodes: 1
+                          CONSTANT id: 16, constant_value: UInt64_1993, constant_value_type: UInt16
+          FUNCTION id: 17, function_name: lessOrEquals, function_type: ordinary, result_type: UInt8
+            ARGUMENTS
+              LIST id: 18, nodes: 2
+                COLUMN id: 19, column_name: id, result_type: UInt32, source_id: 3
+                FUNCTION id: 10, function_name: toYear, function_type: ordinary, result_type: UInt16
+                  ARGUMENTS
+                    LIST id: 11, nodes: 1
+                      COLUMN id: 12, column_name: date1, result_type: Date, source_id: 3
+EXPLAIN QUERY TREE run_passes = 1
+SELECT *
+FROM date_t__fuzz_0
+WHERE ((toYear(date1) AS b) != 1993) AND (id <= b) SETTINGS optimize_time_filter_with_preimage=0;
+QUERY id: 0
+  PROJECTION COLUMNS
+    id UInt32
+    value1 String
+    date1 Date
+  PROJECTION
+    LIST id: 1, nodes: 3
+      COLUMN id: 2, column_name: id, result_type: UInt32, source_id: 3
+      COLUMN id: 4, column_name: value1, result_type: String, source_id: 3
+      COLUMN id: 5, column_name: date1, result_type: Date, source_id: 3
+  JOIN TREE
+    TABLE id: 3, alias: __table1, table_name: default.date_t__fuzz_0
+  WHERE
+    FUNCTION id: 6, function_name: and, function_type: ordinary, result_type: UInt8
+      ARGUMENTS
+        LIST id: 7, nodes: 2
+          FUNCTION id: 8, function_name: notEquals, function_type: ordinary, result_type: UInt8
+            ARGUMENTS
+              LIST id: 9, nodes: 2
+                FUNCTION id: 10, function_name: toYear, function_type: ordinary, result_type: UInt16
+                  ARGUMENTS
+                    LIST id: 11, nodes: 1
+                      COLUMN id: 12, column_name: date1, result_type: Date, source_id: 3
+                CONSTANT id: 13, constant_value: UInt64_1993, constant_value_type: UInt16
+          FUNCTION id: 14, function_name: lessOrEquals, function_type: ordinary, result_type: UInt8
+            ARGUMENTS
+              LIST id: 15, nodes: 2
+                COLUMN id: 16, column_name: id, result_type: UInt32, source_id: 3
+                FUNCTION id: 10, function_name: toYear, function_type: ordinary, result_type: UInt16
+                  ARGUMENTS
+                    LIST id: 11, nodes: 1
+                      COLUMN id: 12, column_name: date1, result_type: Date, source_id: 3
+  SETTINGS optimize_time_filter_with_preimage=0
+EXPLAIN QUERY TREE run_passes = 1
+SELECT *
+FROM date_t__fuzz_0
+WHERE ((toYear(date1) AS b) != 1993) AND (id <= b) SETTINGS optimize_time_filter_with_preimage=1;
+QUERY id: 0
+  PROJECTION COLUMNS
+    id UInt32
+    value1 String
+    date1 Date
+  PROJECTION
+    LIST id: 1, nodes: 3
+      COLUMN id: 2, column_name: id, result_type: UInt32, source_id: 3
+      COLUMN id: 4, column_name: value1, result_type: String, source_id: 3
+      COLUMN id: 5, column_name: date1, result_type: Date, source_id: 3
+  JOIN TREE
+    TABLE id: 3, alias: __table1, table_name: default.date_t__fuzz_0
+  WHERE
+    FUNCTION id: 6, function_name: and, function_type: ordinary, result_type: UInt8
+      ARGUMENTS
+        LIST id: 7, nodes: 2
+          FUNCTION id: 8, function_name: or, function_type: ordinary, result_type: UInt8
+            ARGUMENTS
+              LIST id: 9, nodes: 2
+                FUNCTION id: 10, function_name: less, function_type: ordinary, result_type: UInt8
+                  ARGUMENTS
+                    LIST id: 11, nodes: 2
+                      COLUMN id: 12, column_name: date1, result_type: Date, source_id: 3
+                      CONSTANT id: 13, constant_value: \'1993-01-01\', constant_value_type: String
+                FUNCTION id: 14, function_name: greaterOrEquals, function_type: ordinary, result_type: UInt8
+                  ARGUMENTS
+                    LIST id: 15, nodes: 2
+                      COLUMN id: 16, column_name: date1, result_type: Date, source_id: 3
+                      CONSTANT id: 17, constant_value: \'1994-01-01\', constant_value_type: String
+          FUNCTION id: 18, function_name: lessOrEquals, function_type: ordinary, result_type: UInt8
+            ARGUMENTS
+              LIST id: 19, nodes: 2
+                COLUMN id: 20, column_name: id, result_type: UInt32, source_id: 3
+                FUNCTION id: 21, function_name: toYear, function_type: ordinary, result_type: UInt16
+                  ARGUMENTS
+                    LIST id: 22, nodes: 1
+                      COLUMN id: 23, column_name: date1, result_type: Date, source_id: 3
+  SETTINGS optimize_time_filter_with_preimage=1

--- a/tests/queries/0_stateless/02999_analyzer_preimage_null.sql
+++ b/tests/queries/0_stateless/02999_analyzer_preimage_null.sql
@@ -1,0 +1,20 @@
+SET allow_experimental_analyzer=1;
+SET optimize_time_filter_with_preimage=1;
+
+CREATE TABLE date_t__fuzz_0 (`id` UInt32, `value1` String, `date1` Date) ENGINE = ReplacingMergeTree ORDER BY id SETTINGS allow_nullable_key=1;
+
+-- { echoOn }
+EXPLAIN QUERY TREE run_passes = 1
+SELECT *
+FROM date_t__fuzz_0
+WHERE ((toYear(date1) AS b) != toNullable(1993)) AND (id <= b);
+
+EXPLAIN QUERY TREE run_passes = 1
+SELECT *
+FROM date_t__fuzz_0
+WHERE ((toYear(date1) AS b) != 1993) AND (id <= b) SETTINGS optimize_time_filter_with_preimage=0;
+
+EXPLAIN QUERY TREE run_passes = 1
+SELECT *
+FROM date_t__fuzz_0
+WHERE ((toYear(date1) AS b) != 1993) AND (id <= b) SETTINGS optimize_time_filter_with_preimage=1;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Fix OptimizeDateOrDateTimeConverterWithPreimageVisitor with null arguments

### Documentation entry for user-facing changes

* Fixes style
* Adds a setting to control this optimization
* Fixes the fuzzer report: https://s3.amazonaws.com/clickhouse-test-reports/0/f69bfa452633d2fcc2052a258f7202666053c787/ast_fuzzer__debug_.html
