### PR TITLE
Minor: Replace boost::algorithm::ends_with() by std::string::ends_with()

### DIFF
--- a/src/IO/S3/tests/gtest_aws_s3_client.cpp
+++ b/src/IO/S3/tests/gtest_aws_s3_client.cpp
@@ -8,7 +8,7 @@
 
 #include <memory>
 
-#include <boost/algorithm/string.hpp>
+#include <boost/algorithm/string/split.hpp>
 
 #include <Poco/URI.h>
 

--- a/utils/check-marks/main.cpp
+++ b/utils/check-marks/main.cpp
@@ -23,7 +23,7 @@ static void checkByCompressedReadBuffer(const std::string & mrk_path, const std:
     DB::CompressedReadBufferFromFile bin_in(DB::createReadBufferFromFileBase(bin_path, /* settings= */ {}));
 
     DB::WriteBufferFromFileDescriptor out(STDOUT_FILENO);
-    bool mrk2_format = boost::algorithm::ends_with(mrk_path, ".mrk2");
+    bool mrk2_format = mrk_path.ends_with(".mrk2");
 
     for (size_t mark_num = 0; !mrk_in.eof(); ++mark_num)
     {


### PR DESCRIPTION
Follow-up to #60450, forgot about `ends_with()`

@evillique Like to approve? Ty.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)