### PR TITLE
Fix: 02496_remove_redundant_sorting_analyzer

### DIFF
--- a/tests/queries/0_stateless/02496_remove_redundant_sorting.reference
+++ b/tests/queries/0_stateless/02496_remove_redundant_sorting.reference
@@ -220,13 +220,16 @@ FROM
 )
 GROUP BY number
 ORDER BY number
+SETTINGS optimize_aggregators_of_group_by_keys=0 -- avoid removing any() as it depends on order and we need it for the test
 -- explain
 Expression (Projection)
   Sorting (Sorting for ORDER BY)
     Expression (Before ORDER BY)
       Aggregating
-        Expression ((Before GROUP BY + (Projection + (Before ORDER BY + (Projection + Before ORDER BY)))))
-          ReadFromSystemNumbers
+        Expression ((Before GROUP BY + Projection))
+          Sorting (Sorting for ORDER BY)
+            Expression ((Before ORDER BY + (Projection + Before ORDER BY)))
+              ReadFromSystemNumbers
 -- execute
 0
 1
@@ -289,13 +292,16 @@ FROM
     GROUP BY number
 )
 ORDER BY a ASC
+SETTINGS optimize_aggregators_of_group_by_keys=0 -- avoid removing any() as it depends on order and we need it for the test
 -- explain
 Expression (Projection)
   Sorting (Sorting for ORDER BY)
     Expression ((Before ORDER BY + (Projection + Before ORDER BY)))
       Aggregating
-        Expression ((Before GROUP BY + (Projection + Before ORDER BY)))
-          ReadFromSystemNumbers
+        Expression ((Before GROUP BY + Projection))
+          Sorting (Sorting for ORDER BY)
+            Expression (Before ORDER BY)
+              ReadFromSystemNumbers
 -- execute
 0
 1
@@ -321,14 +327,18 @@ FROM
 )
 WHERE a > 0
 ORDER BY a
+SETTINGS optimize_aggregators_of_group_by_keys=0 -- avoid removing any() as it depends on order and we need it for the test
 -- explain
 Expression (Projection)
   Sorting (Sorting for ORDER BY)
-    Expression ((Before ORDER BY + ))
-      Aggregating
-        Filter
-          Filter (( + (Before GROUP BY + (Projection + (Before ORDER BY + (Projection + Before ORDER BY))))))
-            ReadFromSystemNumbers
+    Expression (Before ORDER BY)
+      Filter ((WHERE + (Projection + Before ORDER BY)))
+        Filter (HAVING)
+          Aggregating
+            Expression ((Before GROUP BY + Projection))
+              Sorting (Sorting for ORDER BY)
+                Expression ((Before ORDER BY + (Projection + Before ORDER BY)))
+                  ReadFromSystemNumbers
 -- execute
 1
 2

--- a/tests/queries/0_stateless/02496_remove_redundant_sorting.sh
+++ b/tests/queries/0_stateless/02496_remove_redundant_sorting.sh
@@ -157,7 +157,8 @@ FROM
     ORDER BY number DESC
 )
 GROUP BY number
-ORDER BY number"
+ORDER BY number
+SETTINGS optimize_aggregators_of_group_by_keys=0 -- avoid removing any() as it depends on order and we need it for the test"
 run_query "$query"
 
 echo "-- query with aggregation function but w/o GROUP BY -> remove sorting"
@@ -200,7 +201,8 @@ FROM
     )
     GROUP BY number
 )
-ORDER BY a ASC"
+ORDER BY a ASC
+SETTINGS optimize_aggregators_of_group_by_keys=0 -- avoid removing any() as it depends on order and we need it for the test"
 run_query "$query"
 
 echo "-- Check that optimization works for subqueries as well, - main query have neither ORDER BY nor GROUP BY"
@@ -222,7 +224,8 @@ FROM
     GROUP BY number
 )
 WHERE a > 0
-ORDER BY a"
+ORDER BY a
+SETTINGS optimize_aggregators_of_group_by_keys=0 -- avoid removing any() as it depends on order and we need it for the test"
 run_query "$query"
 
 echo "-- GROUP BY in most inner query makes execution parallelized, and removing inner sorting steps will keep it that way. But need to correctly update data streams sorting properties after removing sorting steps"

--- a/tests/queries/0_stateless/02496_remove_redundant_sorting_analyzer.reference
+++ b/tests/queries/0_stateless/02496_remove_redundant_sorting_analyzer.reference
@@ -220,6 +220,7 @@ FROM
 )
 GROUP BY number
 ORDER BY number
+SETTINGS optimize_aggregators_of_group_by_keys=0 -- avoid removing any() as it depends on order and we need it for the test
 -- explain
 Expression (Project names)
   Sorting (Sorting for ORDER BY)
@@ -291,6 +292,7 @@ FROM
     GROUP BY number
 )
 ORDER BY a ASC
+SETTINGS optimize_aggregators_of_group_by_keys=0 -- avoid removing any() as it depends on order and we need it for the test
 -- explain
 Expression (Project names)
   Sorting (Sorting for ORDER BY)
@@ -325,6 +327,7 @@ FROM
 )
 WHERE a > 0
 ORDER BY a
+SETTINGS optimize_aggregators_of_group_by_keys=0 -- avoid removing any() as it depends on order and we need it for the test
 -- explain
 Expression (Project names)
   Sorting (Sorting for ORDER BY)


### PR DESCRIPTION
Related to https://github.com/ClickHouse/ClickHouse/pull/52230. Disabling `optimize_aggregators_of_group_by_keys` to avoid removing `any()` from aggregation, - it's necessary for some test queries

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
