### PR TITLE
Reduce iterations in 01383_log_broken_table

### DIFF
--- a/tests/queries/0_stateless/01383_log_broken_table.sh
+++ b/tests/queries/0_stateless/01383_log_broken_table.sh
@@ -20,6 +20,7 @@ function test_func()
         MAX_MEM=$((2 * $MAX_MEM))
 
         $CLICKHOUSE_CLIENT --query "INSERT INTO log SELECT number, number, number FROM numbers(1000000)" --max_memory_usage $MAX_MEM > "${CLICKHOUSE_TMP}"/insert_result 2>&1
+        RES=$?
 
         grep -o -F 'Memory limit' "${CLICKHOUSE_TMP}"/insert_result || cat "${CLICKHOUSE_TMP}"/insert_result
 
@@ -27,7 +28,7 @@ function test_func()
 
         cat "${CLICKHOUSE_TMP}"/select_result
 
-        [[ $MAX_MEM -gt 200000000 ]] && break;
+        { [[ $RES -eq 0 ]] || [[ $MAX_MEM -gt 200000000 ]]; } && break;
     done
 
     $CLICKHOUSE_CLIENT --query "DROP TABLE log";


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

Sometimes it's [too slow](https://s3.amazonaws.com/clickhouse-test-reports/60138/29e43cc3953ee1f8b464e897cc7c0a7d80913de2/stateless_tests__debug__[3_5].html). As we are incrementing memory per iteration, we can stop looping as soon as one of the inserts succeeds.