### PR TITLE
CI: fix pr check status to not fail mergeable check

### DIFF
--- a/tests/ci/run_check.py
+++ b/tests/ci/run_check.py
@@ -180,15 +180,15 @@ def main():
         )
         print("::notice ::Cannot run")
         sys.exit(1)
-    else:
-        post_commit_status(
-            commit,
-            SUCCESS,
-            "",
-            "ok",
-            PR_CHECK,
-            pr_info,
-        )
+ 
+    post_commit_status(
+        commit,
+        SUCCESS,
+        "",
+        "ok",
+        PR_CHECK,
+        pr_info,
+    )
 
     ci_report_url = create_ci_report(pr_info, [])
     print("::notice ::Can run")

--- a/tests/ci/run_check.py
+++ b/tests/ci/run_check.py
@@ -27,7 +27,7 @@ from lambda_shared_package.lambda_shared.pr import (
     check_pr_description,
 )
 from pr_info import PRInfo
-from report import FAILURE, PENDING
+from report import FAILURE, PENDING, SUCCESS
 
 TRUSTED_ORG_IDS = {
     54801242,  # clickhouse
@@ -180,6 +180,15 @@ def main():
         )
         print("::notice ::Cannot run")
         sys.exit(1)
+    else:
+        post_commit_status(
+            commit,
+            SUCCESS,
+            "",
+            "ok",
+            PR_CHECK,
+            pr_info,
+        )
 
     ci_report_url = create_ci_report(pr_info, [])
     print("::notice ::Can run")


### PR DESCRIPTION
 #do_not_test

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix: if pr check failed on the first attempt it will always set Mergeable check to fail on the next attempts.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
