### PR TITLE
Cancel PipelineExecutor properly in case of exception in spawnThreads

### DIFF
--- a/src/Processors/Executors/PipelineExecutor.cpp
+++ b/src/Processors/Executors/PipelineExecutor.cpp
@@ -410,7 +410,7 @@ void PipelineExecutor::executeImpl(size_t num_threads, bool concurrency_control)
             cancel();
             throw;
         }
-        
+
         tasks.processAsyncTasks();
         pool->wait();
     }

--- a/src/Processors/Executors/PipelineExecutor.cpp
+++ b/src/Processors/Executors/PipelineExecutor.cpp
@@ -399,7 +399,18 @@ void PipelineExecutor::executeImpl(size_t num_threads, bool concurrency_control)
 
     if (num_threads > 1)
     {
-        spawnThreads(); // start at least one thread
+        try
+        {
+            spawnThreads(); // start at least one thread
+        }
+        catch (...)
+        {
+            /// spawnThreads can throw an exception, for example CANNOT_SCHEDULE_TASK.
+            /// We should cancel execution properly before rethrow.
+            cancel();
+            throw;
+        }
+        
         tasks.processAsyncTasks();
         pool->wait();
     }


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Very similar to https://github.com/ClickHouse/ClickHouse/pull/57104, it could lead to crash in fiber because RemoteQueryExecutor is not cancelled properly.