### PR TITLE
Decrease logging level for http retriable errors to Info

### DIFF
--- a/src/IO/ReadWriteBufferFromHTTP.cpp
+++ b/src/IO/ReadWriteBufferFromHTTP.cpp
@@ -552,7 +552,7 @@ bool ReadWriteBufferFromHTTPBase<UpdatableSessionPtr>::nextImpl()
             if (!can_retry_request)
                 throw;
 
-            LOG_WARNING(
+            LOG_INFO(
                 log,
                 "HTTP request to `{}` failed at try {}/{} with bytes read: {}/{}. "
                 "Error: {}. (Current backoff wait is {}/{} ms)",

--- a/tests/queries/1_stateful/00157_cache_dictionary.sql
+++ b/tests/queries/1_stateful/00157_cache_dictionary.sql
@@ -1,8 +1,5 @@
 -- Tags: no-tsan, no-parallel
 
--- Suppress "ReadWriteBufferFromHTTP: HTTP request to `{}` failed at try 1/10 with bytes read: 311149/378695. Error: DB::HTTPException: Received error from remote server {}. (Current backoff wait is 100/10000 ms)" errors
-SET send_logs_level='error';
-
 DROP TABLE IF EXISTS test.hits_1m;
 
 CREATE TABLE test.hits_1m AS test.hits


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Followup for https://github.com/ClickHouse/ClickHouse/pull/59920. No point in fixing each test individually. For example: https://s3.amazonaws.com/clickhouse-test-reports/0/926295f763294d2f547d05d6acf7e44bd4e38752/stateful_tests__debug_.html