### PR TITLE
Fix_max_query_size_for_kql_compound_operator:

### DIFF
--- a/src/Parsers/Kusto/ParserKQLQuery.cpp
+++ b/src/Parsers/Kusto/ParserKQLQuery.cpp
@@ -416,8 +416,9 @@ bool ParserKQLQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
                     ParserToken s_dash(TokenType::Minus);
                     if (s_dash.ignore(pos, expected))
                     {
-                        String tmp_op(op_pos_begin->begin, pos->end);
-                        kql_operator = tmp_op;
+                        if (!isValidKQLPos(pos))
+                            return false;
+                        kql_operator = String(op_pos_begin->begin, pos->end);
                     }
                     else
                         --pos;

--- a/tests/queries/0_stateless/02366_kql_mvexpand.sql
+++ b/tests/queries/0_stateless/02366_kql_mvexpand.sql
@@ -33,3 +33,7 @@ print '-- mv_expand_test_table | mv-expand with_itemindex=index c,d to typeof(bo
 mv_expand_test_table | mv-expand with_itemindex=index c,d to typeof(bool);
 print '-- mv_expand_test_table | mv-expand c to typeof(bool) --';
 mv_expand_test_table | mv-expand c to typeof(bool);
+SET max_query_size = 28;
+SET dialect='kusto';
+mv_expand_test_table | mv-expand c, d; -- { serverError 62 }
+SET max_query_size=262144;

--- a/tests/queries/0_stateless/02366_kql_mvexpand.sql
+++ b/tests/queries/0_stateless/02366_kql_mvexpand.sql
@@ -35,5 +35,5 @@ print '-- mv_expand_test_table | mv-expand c to typeof(bool) --';
 mv_expand_test_table | mv-expand c to typeof(bool);
 SET max_query_size = 28;
 SET dialect='kusto';
-mv_expand_test_table | mv-expand c, d; -- { serverError 62 }
+mv_expand_test_table | mv-expand c, d; -- { serverError SYNTAX_ERROR }
 SET max_query_size=262144;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Fix the issue of `max_query_size` for KQL compound operator like mv-expand. Related to #59626.
