### PR TITLE
Function parseDateTimeBestEffort leap year bug fix

### DIFF
--- a/src/IO/parseDateTimeBestEffort.cpp
+++ b/src/IO/parseDateTimeBestEffort.cpp
@@ -585,8 +585,7 @@ ReturnType parseDateTimeBestEffortImpl(
     if (!year)
     {
         time_t now = time(nullptr);
-        UInt16 curr_year = local_time_zone.toYear(now);
-        year = now < local_time_zone.makeDateTime(curr_year, month, day_of_month, hour, minute, second) ? curr_year - 1 : curr_year;
+        year = local_time_zone.toYear(now);
     }
 
     auto is_leap_year = (year % 400 == 0) || (year % 100 != 0 && year % 4 == 0);


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Function `parseDateTimeBestEffort` leap year bug fix.
