### PR TITLE
CI: fix docker build job name

### DIFF
--- a/tests/ci/docker_images_check.py
+++ b/tests/ci/docker_images_check.py
@@ -25,7 +25,6 @@ from stopwatch import Stopwatch
 from tee_popen import TeePopen
 from upload_result_helper import upload_results
 
-NAME = "Push to Dockerhub"
 TEMP_PATH = Path(RUNNER_TEMP) / "docker_images_check"
 TEMP_PATH.mkdir(parents=True, exist_ok=True)
 
@@ -177,6 +176,9 @@ def main():
     stopwatch = Stopwatch()
 
     args = parse_args()
+
+    NAME = f"Push to Dockerhub {args.suffix}"
+
     if args.push:
         logging.info("login to docker hub")
         docker_login()


### PR DESCRIPTION
 #do_not_test

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- arm and amd docker build jobs use similar job names and thus overwrite job reports
- aarch64 and amd64 suffixes added to fix this

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
