### PR TITLE
Don't suggest installing with Homebrew as it can't be run as a service

### DIFF
--- a/docs/en/getting-started/install.md
+++ b/docs/en/getting-started/install.md
@@ -375,10 +375,6 @@ request](https://github.com/ClickHouse/ClickHouse/commits/master) and find CI ch
 https://s3.amazonaws.com/clickhouse/builds/PRs/.../.../binary_aarch64_v80compat/clickhouse". You can then click the link to download the
 build.
 
-### macOS-only: Install with Homebrew
-
-To install ClickHouse using [homebrew](https://brew.sh/), see [here](https://formulae.brew.sh/cask/clickhouse).
-
 ## Launch {#launch}
 
 To start the server as a daemon, run:


### PR DESCRIPTION
Hi! Currently, the directions for installing recommend Homebrew. IMO, this is really unhelpful and confusing advice as the [Homebrew package doesn't support running Clickhouse as a service](https://github.com/Homebrew/homebrew-cask/issues/167899#issuecomment-1971339721). Running as a service is a very useful feature for a database running locally in development.