### PR TITLE
Fix logical error on bad compatibility setting value type

### DIFF
--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -15,6 +15,7 @@ namespace ErrorCodes
     extern const int THERE_IS_NO_PROFILE;
     extern const int NO_ELEMENTS_IN_CONFIG;
     extern const int UNKNOWN_ELEMENT_IN_CONFIG;
+    extern const int BAD_ARGUMENTS;
 }
 
 IMPLEMENT_SETTINGS_TRAITS(SettingsTraits, LIST_OF_SETTINGS)

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -114,7 +114,11 @@ std::vector<String> Settings::getAllRegisteredNames() const
 void Settings::set(std::string_view name, const Field & value)
 {
     if (name == "compatibility")
+    {
+        if (value.getType() != Field::Types::Which::String)
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Unexpected type of value for setting 'compatibility'. Expected String, got {}", value.getTypeName());
         applyCompatibilitySetting(value.get<String>());
+    }
     /// If we change setting that was changed by compatibility setting before
     /// we should remove it from settings_changed_by_compatibility_setting,
     /// otherwise the next time we will change compatibility setting

--- a/tests/queries/0_stateless/03003_compatibility_setting_bad_value.sql
+++ b/tests/queries/0_stateless/03003_compatibility_setting_bad_value.sql
@@ -1,2 +1,2 @@
-select 42 settings compatibility=NULL;  -- {clientError BAD_GET}
+select 42 settings compatibility=NULL;  -- {clientError BAD_ARGUMENTS}
 

--- a/tests/queries/0_stateless/03003_compatibility_setting_bad_value.sql
+++ b/tests/queries/0_stateless/03003_compatibility_setting_bad_value.sql
@@ -1,0 +1,2 @@
+select 42 settings compatibility=NULL;  -- {clientError BAD_GET}
+


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix logical error on bad compatibility setting value type. Closes https://github.com/ClickHouse/ClickHouse/issues/60590

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
