### PR TITLE
WIP: Date Functions: Allow using any weekday as start-of-the-week

### DIFF
--- a/tests/queries/0_stateless/02784_week_start_functions.reference
+++ b/tests/queries/0_stateless/02784_week_start_functions.reference
@@ -1,0 +1,13 @@
+-----backwards-compatible function calls-----
+toWeek	2016-12-27	52	52	1
+toYearWeek	2016-12-27	201652	201652	201701
+toDayOfWeek	2016-12-27	2	2	1	2	3
+toStartOfWeek	2016-12-27	2016-12-25	2016-12-26	2016-12-26
+toLastDayOfWeek	2016-12-27	2016-12-31	2017-01-01	2017-01-01
+toStartOfInterval	2016-12-27	2016-12-26
+toRelativeWeekNum	2016-12-27	2023-06-19 02:25:16	2452	2451	2789	2788
+dateDiff	0	1
+formatDateTimeInJodaSyntax	2016-12-27	2016-12-27 00:00:00	2016	52	2	Tue
+parseDateTimeInJodaSyntax	2016-12-27 00:00:00
+parseDateTimeInJodaSyntax	2016-12-27 00:00:00
+-----new functionality-----

--- a/tests/queries/0_stateless/02784_week_start_functions.sql
+++ b/tests/queries/0_stateless/02784_week_start_functions.sql
@@ -1,0 +1,67 @@
+SELECT '-----backwards-compatible function calls-----' AS COMMENT;
+SELECT 'toWeek' AS fn, toDate('2016-12-27') AS date,
+    toWeek(date) AS week0,
+    toWeek(date, 1) AS week1,
+    toWeek(date, 9) AS week9;
+SELECT 'toYearWeek' AS fn, toDate('2016-12-27') AS date,
+    toYearWeek(date) AS yearWeek0,
+    toYearWeek(date, 1) AS yearWeek1,
+    toYearWeek(date, 9) AS yearWeek9;
+SELECT 'toDayOfWeek' AS fn, toDate('2016-12-27') AS date,
+    toDayOfWeek(date) AS `day`,
+    toDayOfWeek(date, 0) AS day0,
+    toDayOfWeek(date, 1) AS day1,
+    toDayOfWeek(date, 2) AS day2,
+    toDayOfWeek(date, 3) AS day3;
+SELECT 'toStartOfWeek' AS fn, toDate('2016-12-27') AS date,
+    toStartOfWeek(date) AS weekStart0,
+    toStartOfWeek(date, 1) AS weekStart1,
+    toStartOfWeek(date, 9) AS weekStart9;
+SELECT 'toLastDayOfWeek' AS fn, toDate('2016-12-27') AS date,
+    toLastDayOfWeek(date) AS weekEnd0,
+    toLastDayOfWeek(date, 1) AS weekEnd1,
+    toLastDayOfWeek(date, 9) AS weekEnd9;
+SELECT 'toStartOfInterval' AS fn, toDate('2016-12-27') AS date,
+    toStartOfInterval(date, INTERVAL 1 week) AS weekStartInterval0;
+SELECT 'toRelativeWeekNum' AS fn, toDate('2016-12-27') AS date,
+    NOW() AS date2,
+    toRelativeWeekNum(date) AS relWeek0,
+    toRelativeWeekNum(date - INTERVAL 1 week) AS relWeek1,
+    toRelativeWeekNum(toStartOfWeek(date2)) AS relWeekNow0,
+    toRelativeWeekNum(toStartOfWeek(date2) - INTERVAL 1 week) AS relWeekNow1;
+
+
+-- Taken from https://github.com/ClickHouse/ClickHouse/issues/45583:
+-- returns 0
+SELECT 'dateDiff' AS fn,
+    dateDiff(
+        'week',
+        toDateTime('2023-01-23 00:00:00', 'UTC'),
+        -- Monday
+        toDateTime('2023-01-24 00:00:00', 'UTC')
+    ) AS dateDiff0,
+    -- returns 1
+    dateDiff(
+        'week',
+        toDateTime('2023-01-22 00:00:00', 'UTC'),
+        toDateTime('2023-01-23 00:00:00', 'UTC') -- Monday
+    ) AS dateDiff1;
+
+-- Joda Syntax support
+SELECT 'formatDateTimeInJodaSyntax' AS fn, toDate('2016-12-27') AS date,
+    formatDateTimeInJodaSyntax(date, 'yyyy-MM-dd HH:mm:ss') AS syntax,
+    formatDateTimeInJodaSyntax(date, 'x') AS weekYear,
+    formatDateTimeInJodaSyntax(date, 'w') AS yearWeek,
+    formatDateTimeInJodaSyntax(date, 'e') AS weekDayNum,
+    formatDateTimeInJodaSyntax(date, 'E') AS weekDayText;
+SELECT 'parseDateTimeInJodaSyntax' as fn,
+    parseDateTimeInJodaSyntax('2016 52 2', 'xxxx w e') as parsed0;
+SELECT 'parseDateTimeInJodaSyntax' as fn,
+    parseDateTimeInJodaSyntax('2016 52 Tue', 'xxxx w E') as parsed0;
+
+-- TODO: enable_extended_results_for_datetime_functions setting
+-- TODO: timezone?
+-- TODO: formatDateTimeInJodaSyntax support for week formatting
+-- TODO: wrong link in parseDateTimeInJodaSyntax docs
+
+-- SELECT '-----new functionality-----' AS COMMENT;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
Addresses #50887. PR created for technical discussions and discovery. Work will be slow FYI.

Plan is to allow setting start-of-the-week (SotW) as a global CH setting to streamline multiple date functions which will adhere to this value. Taking a cursory glance at [the docs](https://clickhouse.com/docs/en/sql-reference/functions/date-time-functions) tells me that all date functions that require a "week mode" have it optional, so the proposed setting's value will be the fallback when week mode is not provided.

## Scope of the PR

[Week mode](https://clickhouse.com/docs/en/sql-reference/functions/date-time-functions#toweek) encodes three settings:
1. Start of the week
2. Range (0-53 or 1-53), or in other words, whether to start from 0 or 1
3. How Week 1 is defined:
  a. With the SotW in this year
  b. With 4 or more days in this year
  c. Week contains January 1st

Although the scope of this PR is SotW, the other two settings are closely related and depend on SotW. So it makes sense to include them in the scope. This PR will address how to set all the above settings globally for all respective date functions.

## Unknowns:
- What to do about functions that have differing defaults? This could break backwards compatibility.
- I don't know which is better, to split the settings for ease of use or keep them combined like week mode to avoid polluting the list of settings.

## Affected Functions

### Functions that need changes

- [ ] toDayOfWeek
- [ ] toStartOfWeek
- [ ] toLastDayOfWeek
- [ ] toStartOfInterval
- [ ] toWeek
- [ ] toYearWeek
- [ ] date_diff
- [ ] date_trunc
- [ ] formatDateTime (%w: weekday as a integer number with Sunday as 0 (0-6))
  - https://dev.mysql.com/doc/refman/8.0/en/date-and-time-functions.html#function_date-format
  - https://dev.mysql.com/doc/refman/8.0/en/date-and-time-functions.html#function_week
- [ ] dateName

### Functions that _might_ need changes

- [ ] toStartOfISOYear
- [ ] toRelativeWeekNum
- [ ] toISOWeek
- [ ] toISOYear
- [ ] age
- [ ] date_add
- [ ] date_sub
- [ ] timestamp_add
- [ ] timestamp_sub
- [ ] addWeeks
- [ ] subtractWeeks
- [ ] formatDateTimeInJodaSyntax

### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Allow using weekdays other than Sunday & Monday as start-of-the-week in respective date functions. (#50887)

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
