### PR TITLE
Adds note on supported PostgreSQL versions.

### DIFF
--- a/docs/en/engines/table-engines/integrations/postgresql.md
+++ b/docs/en/engines/table-engines/integrations/postgresql.md
@@ -8,6 +8,10 @@ sidebar_label: PostgreSQL
 
 The PostgreSQL engine allows to perform `SELECT` and `INSERT` queries on data that is stored on a remote PostgreSQL server.
 
+:::note
+Currently, only PostgreSQL versions 12 and up are supported.
+:::
+
 ## Creating a Table {#creating-a-table}
 
 ``` sql


### PR DESCRIPTION
### Changelog category (leave one):
- Documentation (changelog entry is not required)

Adds a note that PostgreSQL versions 12 and up are supported.