### PR TITLE
Fix inconsistent aggregate function states in mixed x86-64 / ARM clusters

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -319,8 +319,8 @@ if (COMPILER_CLANG)
     endif()
 endif ()
 
-set (COMPILER_FLAGS "${COMPILER_FLAGS}")
-
+# Disable floating-point expression contraction in order to get consistent floating point calculation results across platforms
+set (COMPILER_FLAGS "${COMPILER_FLAGS} -ffp-contract=off")
 # Our built-in unwinder only supports DWARF version up to 4.
 set (DEBUG_INFO_FLAGS "-g")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -321,6 +321,7 @@ endif ()
 
 # Disable floating-point expression contraction in order to get consistent floating point calculation results across platforms
 set (COMPILER_FLAGS "${COMPILER_FLAGS} -ffp-contract=off")
+
 # Our built-in unwinder only supports DWARF version up to 4.
 set (DEBUG_INFO_FLAGS "-g")
 

--- a/cmake/linux/toolchain-aarch64.cmake
+++ b/cmake/linux/toolchain-aarch64.cmake
@@ -13,6 +13,6 @@ set (TOOLCHAIN_PATH "${CMAKE_CURRENT_LIST_DIR}/../../contrib/sysroot/linux-aarch
 
 set (CMAKE_SYSROOT "${TOOLCHAIN_PATH}/aarch64-linux-gnu/libc")
 
-set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -ffp-contract=off --gcc-toolchain=${TOOLCHAIN_PATH}")
-set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ffp-contract=off --gcc-toolchain=${TOOLCHAIN_PATH}")
+set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --gcc-toolchain=${TOOLCHAIN_PATH}")
+set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --gcc-toolchain=${TOOLCHAIN_PATH}")
 set (CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} --gcc-toolchain=${TOOLCHAIN_PATH}")

--- a/cmake/linux/toolchain-aarch64.cmake
+++ b/cmake/linux/toolchain-aarch64.cmake
@@ -13,6 +13,6 @@ set (TOOLCHAIN_PATH "${CMAKE_CURRENT_LIST_DIR}/../../contrib/sysroot/linux-aarch
 
 set (CMAKE_SYSROOT "${TOOLCHAIN_PATH}/aarch64-linux-gnu/libc")
 
-set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --gcc-toolchain=${TOOLCHAIN_PATH}")
-set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --gcc-toolchain=${TOOLCHAIN_PATH}")
+set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -ffp-contract=off --gcc-toolchain=${TOOLCHAIN_PATH}")
+set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ffp-contract=off --gcc-toolchain=${TOOLCHAIN_PATH}")
 set (CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} --gcc-toolchain=${TOOLCHAIN_PATH}")

--- a/tests/queries/0_stateless/02813_seriesDecomposeSTL.sql
+++ b/tests/queries/0_stateless/02813_seriesDecomposeSTL.sql
@@ -1,6 +1,3 @@
--- Tags: no-cpu-aarch64
--- Tag no-cpu-aarch64: values generated are slighly different on aarch64
-
 DROP TABLE IF EXISTS tb2;
 
 CREATE TABLE tb2 (`period` UInt32, `ts` Array(Float64)) ENGINE = Memory;


### PR DESCRIPTION
In mixed x86-64 / ARM clusters, aggregate function states can be created differently since ARM sometimes calculates slightly different floating-point results.

This [blog](https://altinity.com/blog/announcing-arm64-altinity-stable-builds-for-clickhouse) contains some related tests for the issue.

The fix is to use compiler flag `-ffp-contract=off` to make sure ARM floating-point calculation produce the same results as on x86-64.

The functional test `02813_seriesDecomposeSTL.sql` (which was disabled on ARM) can be used to test the fix, this PR enables it on ARM.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed potentially inconsistent aggregate function states in mixed x86-64 / ARM clusters.