### PR TITLE
CI: build_report job no dependcies on yml

### DIFF
--- a/.github/workflows/backport_branches.yml
+++ b/.github/workflows/backport_branches.yml
@@ -166,14 +166,8 @@ jobs:
     uses: ./.github/workflows/reusable_test.yml
     with:
       test_name: ClickHouse build check
-      runner_type: style-checker
+      runner_type: style-checker-aarch64
       data: ${{ needs.RunConfig.outputs.data }}
-      additional_envs: |
-        NEEDS_DATA<<NDENV
-        ${{ toJSON(needs) }}
-        NDENV
-      run_command: |
-        python3 build_report_check.py "$CHECK_NAME"
   BuilderSpecialReport:
     # run report check for failed builds to indicate the CI error
     if: ${{ !cancelled() }}
@@ -184,14 +178,8 @@ jobs:
     uses: ./.github/workflows/reusable_test.yml
     with:
       test_name: ClickHouse special build check
-      runner_type: style-checker
+      runner_type: style-checker-aarch64
       data: ${{ needs.RunConfig.outputs.data }}
-      additional_envs: |
-        NEEDS_DATA<<NDENV
-        ${{ toJSON(needs) }}
-        NDENV
-      run_command: |
-        python3 build_report_check.py "$CHECK_NAME"
 ############################################################################################
 #################################### INSTALL PACKAGES ######################################
 ############################################################################################

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -269,26 +269,18 @@ jobs:
     if: ${{ !cancelled() }}
     needs:
       - RunConfig
-      - BuilderBinRelease
       - BuilderDebAarch64
       - BuilderDebAsan
       - BuilderDebDebug
       - BuilderDebMsan
       - BuilderDebRelease
-      - BuilderDebReleaseCoverage
       - BuilderDebTsan
       - BuilderDebUBsan
     uses: ./.github/workflows/reusable_test.yml
     with:
       test_name: ClickHouse build check
-      runner_type: style-checker
+      runner_type: style-checker-aarch64
       data: ${{ needs.RunConfig.outputs.data }}
-      additional_envs: |
-        NEEDS_DATA<<NDENV
-        ${{ toJSON(needs) }}
-        NDENV
-      run_command: |
-        python3 build_report_check.py "$CHECK_NAME"
   BuilderSpecialReport:
     # run report check for failed builds to indicate the CI error
     if: ${{ !cancelled() }}
@@ -305,17 +297,13 @@ jobs:
       - BuilderBinAarch64V80Compat
       - BuilderBinClangTidy
       - BuilderBinAmd64Musl
+      - BuilderDebReleaseCoverage
+      - BuilderBinRelease
     uses: ./.github/workflows/reusable_test.yml
     with:
       test_name: ClickHouse special build check
-      runner_type: style-checker
+      runner_type: style-checker-aarch64
       data: ${{ needs.RunConfig.outputs.data }}
-      additional_envs: |
-        NEEDS_DATA<<NDENV
-        ${{ toJSON(needs) }}
-        NDENV
-      run_command: |
-        python3 build_report_check.py "$CHECK_NAME"
   MarkReleaseReady:
     if: ${{ ! (contains(needs.*.result, 'skipped') || contains(needs.*.result, 'failure')) }}
     needs:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -301,13 +301,11 @@ jobs:
     if: ${{ !cancelled() }}
     needs:
       - RunConfig
-      - BuilderBinRelease
       - BuilderDebAarch64
       - BuilderDebAsan
       - BuilderDebDebug
       - BuilderDebMsan
       - BuilderDebRelease
-      - BuilderDebReleaseCoverage
       - BuilderDebTsan
       - BuilderDebUBsan
     uses: ./.github/workflows/reusable_test.yml
@@ -315,12 +313,6 @@ jobs:
       test_name: ClickHouse build check
       runner_type: style-checker
       data: ${{ needs.RunConfig.outputs.data }}
-      additional_envs: |
-        NEEDS_DATA<<NDENV
-        ${{ toJSON(needs) }}
-        NDENV
-      run_command: |
-        python3 build_report_check.py "$CHECK_NAME"
   BuilderSpecialReport:
     # run report check for failed builds to indicate the CI error
     if: ${{ !cancelled() }}
@@ -336,17 +328,13 @@ jobs:
       - BuilderBinAmd64Compat
       - BuilderBinAarch64V80Compat
       - BuilderBinClangTidy
+      - BuilderDebReleaseCoverage
+      - BuilderBinRelease
     uses: ./.github/workflows/reusable_test.yml
     with:
       test_name: ClickHouse special build check
       runner_type: style-checker
       data: ${{ needs.RunConfig.outputs.data }}
-      additional_envs: |
-        NEEDS_DATA<<NDENV
-        ${{ toJSON(needs) }}
-        NDENV
-      run_command: |
-        python3 build_report_check.py "$CHECK_NAME"
 ############################################################################################
 #################################### INSTALL PACKAGES ######################################
 ############################################################################################

--- a/.github/workflows/release_branches.yml
+++ b/.github/workflows/release_branches.yml
@@ -191,14 +191,8 @@ jobs:
     uses: ./.github/workflows/reusable_test.yml
     with:
       test_name: ClickHouse build check
-      runner_type: style-checker
+      runner_type: style-checker-aarch64
       data: ${{ needs.RunConfig.outputs.data }}
-      additional_envs: |
-        NEEDS_DATA<<NDENV
-        ${{ toJSON(needs) }}
-        NDENV
-      run_command: |
-        python3 build_report_check.py "$CHECK_NAME"
   BuilderSpecialReport:
     # run report check for failed builds to indicate the CI error
     if: ${{ !cancelled() }}
@@ -209,14 +203,8 @@ jobs:
     uses: ./.github/workflows/reusable_test.yml
     with:
       test_name: ClickHouse special build check
-      runner_type: style-checker
+      runner_type: style-checker-aarch64
       data: ${{ needs.RunConfig.outputs.data }}
-      additional_envs: |
-        NEEDS_DATA<<NDENV
-        ${{ toJSON(needs) }}
-        NDENV
-      run_command: |
-        python3 build_report_check.py "$CHECK_NAME"
   MarkReleaseReady:
     if: ${{ ! (contains(needs.*.result, 'skipped') || contains(needs.*.result, 'failure')) }}
     needs:
@@ -224,7 +212,7 @@ jobs:
       - BuilderBinDarwinAarch64
       - BuilderDebRelease
       - BuilderDebAarch64
-    runs-on: [self-hosted, style-checker]
+    runs-on: [self-hosted, style-checker-aarch64]
     steps:
       - name: Check out repository code
         uses: ClickHouse/checkout@v1

--- a/tests/ci/build_report_check.py
+++ b/tests/ci/build_report_check.py
@@ -1,13 +1,12 @@
 #!/usr/bin/env python3
 
-import json
 import logging
 import os
 import sys
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import List
 
-from ci_config import CI_CONFIG
+from ci_config import CI_CONFIG, Build
 from env_helper import (
     GITHUB_JOB_URL,
     GITHUB_REPOSITORY,
@@ -46,77 +45,43 @@ def main():
     )
 
     build_check_name = sys.argv[1]
-    needs_data: Dict[str, Dict[str, Any]] = {}
-    required_builds = 0
-
-    # NEEDS_DATA is a next dict:
-    # {
-    #   "BuilderDebAarch64": {
-    #     "result": "skipped",
-    #     "outputs": {}
-    #   },
-    #   "BuilderDebAsan": {
-    #     "result": "success",
-    #     "outputs": {}
-    #   },
-    #   "BuilderDebDebug": {
-    #     "result": "skipped",
-    #     "outputs": {}
-    #   },
-    # }
-    if NEEDS_DATA:
-        needs_data = json.loads(NEEDS_DATA)
-    elif os.path.exists(NEEDS_DATA_PATH):
-        with open(NEEDS_DATA_PATH, "rb") as file_handler:
-            needs_data = json.load(file_handler)
-    else:
-        raise RuntimeError("NEEDS_DATA env var required")
-
-    # drop non build jobs if any
-    needs_data = {name: data for name, data in needs_data.items() if "Build" in name}
-
-    required_builds = len(needs_data)
-
-    if needs_data:
-        logging.info("The next builds are required: %s", ", ".join(needs_data))
 
     pr_info = PRInfo()
 
-    builds_for_check = CI_CONFIG.get_builds_for_report(build_check_name)
-    required_builds = required_builds or len(builds_for_check)
+    builds_for_check = CI_CONFIG.get_builds_for_report(
+        build_check_name,
+        release=pr_info.is_release(),
+        backport=pr_info.head_ref.startswith("backport"),
+    )
+    required_builds = len(builds_for_check)
+    missing_builds = 0
 
     # Collect reports from json artifacts
-    build_results = []
+    build_results = []  # type: List[BuildResult]
     for build_name in builds_for_check:
         build_result = BuildResult.load_any(
             build_name, pr_info.number, pr_info.head_ref
         )
         if not build_result:
-            logging.warning("Build results for %s are missing", build_name)
-            continue
-        assert (
-            pr_info.head_ref == build_result.head_ref or pr_info.number > 0
-        ), "BUG. if not a PR, report must be created on the same branch"
-        build_results.append(build_result)
-
-    # The code to collect missing reports for failed jobs
-    missing_job_names = [
-        name
-        for name, data in needs_data.items()
-        if not any(1 for br in build_results if br.job_name.startswith(name))
-        and data["result"] != "skipped"
-    ]
-    missing_builds = len(missing_job_names)
-    for job_name in reversed(missing_job_names):
-        build_result = BuildResult.missing_result("missing")
-        build_result.job_name = job_name
-        build_result.status = PENDING
-        logging.info(
-            "There is missing report for %s, created a dummy result %s",
-            job_name,
-            build_result,
-        )
-        build_results.insert(0, build_result)
+            if build_name == Build.FUZZERS:
+                logging.info("Build [%s] is missing - skip", Build.FUZZERS)
+                continue
+            logging.warning("Build results for %s is missing", build_name)
+            build_result = BuildResult.missing_result("missing")
+            build_result.job_name = build_name
+            build_result.status = PENDING
+            logging.info(
+                "There is missing report for %s, created a dummy result %s",
+                build_name,
+                build_result,
+            )
+            missing_builds += 1
+            build_results.insert(0, build_result)
+        else:
+            assert (
+                pr_info.head_ref == build_result.head_ref or pr_info.number > 0
+            ), "BUG. if not a PR, report must be created on the same branch"
+            build_results.append(build_result)
 
     # Calculate artifact groups like packages and binaries
     total_groups = sum(len(br.grouped_urls) for br in build_results)

--- a/tests/ci/pr_info.py
+++ b/tests/ci/pr_info.py
@@ -2,6 +2,7 @@
 import json
 import logging
 import os
+import re
 from typing import Dict, List, Set, Union
 from urllib.parse import quote
 
@@ -287,6 +288,11 @@ class PRInfo:
 
     def is_master(self) -> bool:
         return self.number == 0 and self.head_ref == "master"
+
+    def is_release(self) -> bool:
+        return self.number == 0 and bool(
+            re.match(r"^2[1-9]\.[1-9][0-9]*$", self.head_ref)
+        )
 
     def is_release_branch(self) -> bool:
         return self.number == 0


### PR DESCRIPTION
 #no_merge_comit
 #job_ClickHouse_build_check
 #job_ClickHouse_special_build_check
 #job_style_check

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
fix build_report job so that it's defined by ci_config only (not yml file)

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
