### PR TITLE
fix(rust): Fix skim's panic handler

### DIFF
--- a/rust/skim/src/lib.rs
+++ b/rust/skim/src/lib.rs
@@ -1,7 +1,7 @@
-use skim::prelude::*;
-use term::terminfo::TermInfo;
 use cxx::{CxxString, CxxVector};
+use skim::prelude::*;
 use std::panic;
+use term::terminfo::TermInfo;
 
 #[cxx::bridge]
 mod ffi {
@@ -16,7 +16,7 @@ struct Item {
 }
 impl Item {
     fn new(text: String) -> Self {
-        return Self{
+        Self {
             // Text that will be printed by skim, and will be used for matching.
             //
             // Text that will be shown should not contains new lines since in this case skim may
@@ -24,16 +24,16 @@ impl Item {
             text_no_newlines: text.replace("\n", " "),
             // This will be used when the match had been selected.
             orig_text: text,
-        };
+        }
     }
 }
 impl SkimItem for Item {
     fn text(&self) -> Cow<str> {
-        return Cow::Borrowed(&self.text_no_newlines);
+        Cow::Borrowed(&self.text_no_newlines)
     }
 
     fn output(&self) -> Cow<str> {
-        return Cow::Borrowed(&self.orig_text);
+        Cow::Borrowed(&self.orig_text)
     }
 }
 
@@ -88,14 +88,11 @@ fn skim_impl(prefix: &CxxString, words: &CxxVector<CxxString>) -> Result<String,
     if output.selected_items.is_empty() {
         return Err("No items had been selected".to_string());
     }
-    return Ok(output.selected_items[0].output().to_string());
+    Ok(output.selected_items[0].output().to_string())
 }
 
 fn skim(prefix: &CxxString, words: &CxxVector<CxxString>) -> Result<String, String> {
-    let ret = panic::catch_unwind(|| {
-        return skim_impl(prefix, words);
-    });
-    return match ret {
+    match panic::catch_unwind(|| skim_impl(prefix, words)) {
         Err(err) => {
             let e = if let Some(s) = err.downcast_ref::<String>() {
                 format!("{}", s)
@@ -105,7 +102,7 @@ fn skim(prefix: &CxxString, words: &CxxVector<CxxString>) -> Result<String, Stri
                 format!("Unknown panic type: {:?}", err.type_id())
             };
             Err(format!("Rust panic: {:?}", e))
-        },
+        }
         Ok(res) => res,
     }
 }


### PR DESCRIPTION
~Building on https://github.com/ClickHouse/ClickHouse/pull/60615, `skim` seems to have the same issue, so thought I'd fix here too. Weirdly I get a build error so let's see if CI passes~

After reviewing the PR above, this is now purely a code cleanliness change — fine to close if it's not worthwhile (though the code is slightly better, I would vote to merge...)

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

