### PR TITLE
Using Required-start/stop to improve init script

### DIFF
--- a/packages/clickhouse-server.init
+++ b/packages/clickhouse-server.init
@@ -1,10 +1,11 @@
 #!/bin/sh
 ### BEGIN INIT INFO
 # Provides:          clickhouse-server
+# Required-Start:    $network
+# Required-Stop:     $network
+# Should-Start:      $time
 # Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6
-# Should-Start:      $time $network
-# Should-Stop:       $network
 # Short-Description: clickhouse-server daemon
 ### END INIT INFO
 #


### PR DESCRIPTION
### Changelog category (leave one):
- Build/Testing/Packaging Improvement

Some configurations should replace the `Should-Start` and `ShouldStop` with the `Required-Start` and `Required-Stop` configurations.

According to the [reference](https://wiki.debian.org/LSBInitScripts), the service can still be run if the facilities is configured in the  `Should-Start` configuration.

It should use the `Required-Start` configuration to let the network service be required before starting the ClickHouse server daemon.

According to the [systemd.unit](https://www.freedesktop.org/software/systemd/man/latest/systemd.unit.html) reference, the `ShouldStart` is equivalent to the `Wants` configuration. And the `Required-Start`  is equivalent to the `Requires`.

These improvements are referred by the `clickhouse-server.service` file.

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Make `network` service be required when using the rc init script to start the ClickHouse server daemon.