### PR TITLE
Fix system.parts for non-Atomic/Ordinary database engine (i.e. Memory)

### DIFF
--- a/src/Storages/System/StorageSystemPartsBase.cpp
+++ b/src/Storages/System/StorageSystemPartsBase.cpp
@@ -138,7 +138,7 @@ StoragesInfoStream::StoragesInfoStream(const SelectQueryInfo & query_info, Conte
 
                     String engine_name = storage->getName();
                     UUID storage_uuid = storage->getStorageID().uuid;
-                    if (database->getEngineName() == "Ordinary")
+                    if (storage_uuid == UUIDHelpers::Nil)
                     {
                         SipHash hash;
                         hash.update(database_name);

--- a/tests/queries/0_stateless/02956_clickhouse_local_system_parts.reference
+++ b/tests/queries/0_stateless/02956_clickhouse_local_system_parts.reference
@@ -1,1 +1,2 @@
 test	all_1_1_0	1
+test2	all_1_1_0	1

--- a/tests/queries/0_stateless/02956_clickhouse_local_system_parts.sh
+++ b/tests/queries/0_stateless/02956_clickhouse_local_system_parts.sh
@@ -5,4 +5,12 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CUR_DIR"/../shell_config.sh
 
-$CLICKHOUSE_LOCAL --multiquery "CREATE TABLE test (x UInt8) ENGINE = MergeTree ORDER BY (); INSERT INTO test SELECT 1; SELECT table, name, rows FROM system.parts WHERE database = currentDatabase();"
+$CLICKHOUSE_LOCAL --multiquery "
+    CREATE TABLE test (x UInt8) ENGINE = MergeTree ORDER BY ();
+    INSERT INTO test SELECT 1;
+
+    CREATE TABLE test2 (x UInt8) ENGINE = MergeTree ORDER BY ();
+    INSERT INTO test2 SELECT 1;
+
+    SELECT table, name, rows FROM system.parts WHERE database = currentDatabase();
+"


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix system.parts for non-Atomic/Ordinary database engine (i.e. Memory - major user is `clickhouse-local`)

Previously the code assumes that only Ordinary do not have UUID, while this is not true, Memory (at least) does not has it as well.

One of the major users of Memory engine is clickhouse-local.

Refs: https://github.com/ClickHouse/ClickHouse/pull/58359 (cc @alexey-milovidov )