### PR TITLE
Fix flaky checks

### DIFF
--- a/tests/ci/functional_test_check.py
+++ b/tests/ci/functional_test_check.py
@@ -231,7 +231,7 @@ def main():
     run_changed_tests = flaky_check or validate_bugfix_check
     pr_info = PRInfo(need_changed_files=run_changed_tests)
     tests_to_run = []
-    if run_changed_tests:
+    if validate_bugfix_check:
         assert (
             args.report_to_file
         ), "JobReport file path must be provided with --validate-bugfix"

--- a/tests/ci/functional_test_check.py
+++ b/tests/ci/functional_test_check.py
@@ -231,10 +231,10 @@ def main():
     run_changed_tests = flaky_check or validate_bugfix_check
     pr_info = PRInfo(need_changed_files=run_changed_tests)
     tests_to_run = []
-    if validate_bugfix_check:
-        assert (
-            args.report_to_file
-        ), "JobReport file path must be provided with --validate-bugfix"
+    assert (
+        not validate_bugfix_check or args.report_to_file
+    ), "JobReport file path must be provided with --validate-bugfix"
+    if run_changed_tests:
         tests_to_run = _get_statless_tests_to_run(pr_info)
 
     if "RUN_BY_HASH_NUM" in os.environ:


### PR DESCRIPTION
CI [1]:

    2024-03-02T22:23:37.4878824Z Going to start run command [python3 /home/ubuntu/actions-runner/_work/ClickHouse/ClickHouse/tests/ci/functional_test_check.py "$CHECK_NAME" $KILL_TIMEOUT]
    2024-03-02T22:23:37.7538256Z Runnin check [Stateless tests flaky check (asan)] with timeout [3600]
    2024-03-02T22:23:37.8790465Z Fetched info about 3 changed files
    2024-03-02T22:23:37.9160414Z Traceback (most recent call last):
    2024-03-02T22:23:37.9161715Z   File "/home/ubuntu/actions-runner/_work/ClickHouse/ClickHouse/tests/ci/functional_test_check.py", line 341, in <module>
    2024-03-02T22:23:37.9162714Z     main()
    2024-03-02T22:23:37.9163683Z   File "/home/ubuntu/actions-runner/_work/ClickHouse/ClickHouse/tests/ci/functional_test_check.py", line 235, in main
    2024-03-02T22:23:37.9164642Z     assert (
    2024-03-02T22:23:37.9165273Z AssertionError: JobReport file path must be provided with --validate-bugfix
    2024-03-02T22:23:37.9612679Z Run action failed for: [Stateless tests flaky check (asan)] with exit code [1]

  [1]: https://github.com/ClickHouse/ClickHouse/actions/runs/8125551797/job/22208766466?pr=60689

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Follow-up for: #59348 (cc @maxknv)