### PR TITLE
Resubmit http_external_tables_memory_tracking test

### DIFF
--- a/tests/queries/0_stateless/02152_http_external_tables_memory_tracking.reference
+++ b/tests/queries/0_stateless/02152_http_external_tables_memory_tracking.reference
@@ -1,0 +1,16 @@
+Checking input_format_parallel_parsing=false&
+1
+Checking input_format_parallel_parsing=false&cancel_http_readonly_queries_on_client_close=1&readonly=1
+1
+Checking input_format_parallel_parsing=false&send_progress_in_http_headers=true
+1
+Checking input_format_parallel_parsing=false&cancel_http_readonly_queries_on_client_close=1&readonly=1&send_progress_in_http_headers=true
+1
+Checking input_format_parallel_parsing=true&
+1
+Checking input_format_parallel_parsing=true&cancel_http_readonly_queries_on_client_close=1&readonly=1
+1
+Checking input_format_parallel_parsing=true&send_progress_in_http_headers=true
+1
+Checking input_format_parallel_parsing=true&cancel_http_readonly_queries_on_client_close=1&readonly=1&send_progress_in_http_headers=true
+1

--- a/tests/queries/0_stateless/02152_http_external_tables_memory_tracking.sh
+++ b/tests/queries/0_stateless/02152_http_external_tables_memory_tracking.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Tags: no-tsan, no-cpu-aarch64, no-parallel
+# TSan does not supports tracing.
+# trace_log doesn't work on aarch64
+
+# Regression for proper release of Context,
+# via tracking memory of external tables.
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+tmp_file=$(mktemp "$CURDIR/clickhouse.XXXXXX.csv")
+trap 'rm $tmp_file' EXIT
+
+$CLICKHOUSE_CLIENT -q "SELECT toString(number) FROM numbers(1e6) FORMAT TSV" > "$tmp_file"
+
+function run_and_check()
+{
+    local query_id
+    query_id="$(${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}" --data-binary @- <<<'SELECT generateUUIDv4()')"
+
+    echo "Checking $*"
+
+    # Run query with external table (implicit StorageMemory user)
+    $CLICKHOUSE_CURL -sS -F "s=@$tmp_file;" "$CLICKHOUSE_URL&s_structure=key+Int&query=SELECT+count()+FROM+s&memory_profiler_sample_probability=1&max_untracked_memory=0&query_id=$query_id&$*" -o /dev/null
+
+    ${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}" --data-binary @- <<<'SYSTEM FLUSH LOGS'
+
+    # Check that temporary table had been destroyed.
+    ${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&allow_introspection_functions=1" --data-binary @- <<<"
+    WITH arrayStringConcat(arrayMap(x -> demangle(addressToSymbol(x)), trace), '\n') AS sym
+    SELECT count()>0 FROM system.trace_log
+    WHERE
+        sym LIKE '%DB::StorageMemory::drop%\n%TemporaryTableHolder::~TemporaryTableHolder%' AND
+        query_id = '$query_id'
+    "
+}
+
+for input_format_parallel_parsing in false true; do
+    query_args_variants=(
+        ""
+        "cancel_http_readonly_queries_on_client_close=1&readonly=1"
+        "send_progress_in_http_headers=true"
+        # nested progress callback
+        "cancel_http_readonly_queries_on_client_close=1&readonly=1&send_progress_in_http_headers=true"
+    )
+    for query_args in "${query_args_variants[@]}"; do
+        run_and_check "input_format_parallel_parsing=$input_format_parallel_parsing&$query_args"
+    done
+done


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Latest failures was due to io_uring, others due to timeouts for querying system.trace_log and resolve stack traces in debug builds (so I disable this test under debug build), and in release build the test was ["really" flaky](https://s3.amazonaws.com/clickhouse-test-reports/0/07ffbc9f2a397bea5a5f97039ea037c96a9eba7c/stateless_tests__release_.html), and I've verified it, and it should find the proper record, since after I downloaded the artifacts I found it, so there is something else wrong

Reverts: https://github.com/ClickHouse/ClickHouse/pull/60690 (cc @alexey-milovidov )