### PR TITLE
Correct the COVID-19 open dataset date column type

### DIFF
--- a/docs/en/getting-started/example-datasets/covid19.md
+++ b/docs/en/getting-started/example-datasets/covid19.md
@@ -28,7 +28,7 @@ The CSV file has 10 columns:
 
 ```response
 ┌─name─────────────────┬─type─────────────┐
-│ date                 │ Nullable(String) │
+│ date                 │ Nullable(Date)   │
 │ location_key         │ Nullable(String) │
 │ new_confirmed        │ Nullable(Int64)  │
 │ new_deceased         │ Nullable(Int64)  │


### PR DESCRIPTION
### Changelog category (leave one):

- Documentation (changelog entry is not required)

As title, correct the COVID-19 open dataset date column type. And my running SQL outputs are as follows:

```sh
ubuntu-s-2vcpu-4gb-amd-sgp1-01 :) DESCRIBE url(
    'https://storage.googleapis.com/covid19-open-data/v3/epidemiology.csv',
    'CSVWithNames'
);

DESCRIBE TABLE url('https://storage.googleapis.com/covid19-open-data/v3/epidemiology.csv', 'CSVWithNames')

Query id: e76e8215-281b-4ff7-a21a-e07da0c2159d

┌─name─────────────────┬─type─────────────┬─default_type─┬─default_expression─┬─comment─┬─codec_expression─┬─ttl_expression─┐
│ date                 │ Nullable(Date)   │              │                    │         │                  │                │
│ location_key         │ Nullable(String) │              │                    │         │                  │                │
│ new_confirmed        │ Nullable(Int64)  │              │                    │         │                  │                │
│ new_deceased         │ Nullable(Int64)  │              │                    │         │                  │                │
│ new_recovered        │ Nullable(Int64)  │              │                    │         │                  │                │
│ new_tested           │ Nullable(Int64)  │              │                    │         │                  │                │
│ cumulative_confirmed │ Nullable(Int64)  │              │                    │         │                  │                │
│ cumulative_deceased  │ Nullable(Int64)  │              │                    │         │                  │                │
│ cumulative_recovered │ Nullable(Int64)  │              │                    │         │                  │                │
│ cumulative_tested    │ Nullable(Int64)  │              │                    │         │                  │                │
└──────────────────────┴──────────────────┴──────────────┴────────────────────┴─────────┴──────────────────┴────────────────┘

10 rows in set. Elapsed: 0.204 sec.

ubuntu-s-2vcpu-4gb-amd-sgp1-01 :)
```