### PR TITLE
[Docs] update `today` function

### DIFF
--- a/docs/en/sql-reference/functions/date-time-functions.md
+++ b/docs/en/sql-reference/functions/date-time-functions.md
@@ -2315,8 +2315,10 @@ SELECT today();
 
 **Result**:
 
-```response
+Running the query above on the 3rd of March 2024 would have returned the following response:
 
+```response
+2024-03-03
 ```
 
 ## yesterday {#yesterday}

--- a/docs/en/sql-reference/functions/date-time-functions.md
+++ b/docs/en/sql-reference/functions/date-time-functions.md
@@ -2310,7 +2310,7 @@ Type: [DateTime](../../sql-reference/data-types/datetime.md).
 Query:
 
 ```sql
-SELECT today();
+SELECT today() AS today, curdate() AS curdate, current_date() AS current_date FORMAT Pretty
 ```
 
 **Result**:
@@ -2318,7 +2318,11 @@ SELECT today();
 Running the query above on the 3rd of March 2024 would have returned the following response:
 
 ```response
-2024-03-03
+┏━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━━━┓
+┃      today ┃    curdate ┃ current_date ┃
+┡━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━━━┩
+│ 2024-03-03 │ 2024-03-03 │   2024-03-03 │
+└────────────┴────────────┴──────────────┘
 ```
 
 ## yesterday {#yesterday}

--- a/docs/en/sql-reference/functions/date-time-functions.md
+++ b/docs/en/sql-reference/functions/date-time-functions.md
@@ -2287,10 +2287,37 @@ Result:
 
 ## today {#today}
 
-Accepts zero arguments and returns the current date at one of the moments of query analysis.
-The same as ‘toDate(now())’.
+Returns the current date at moment of query analysis. It is the same as ‘toDate(now())’ and has aliases: `curdate`, `current_date`.
 
-Aliases: `curdate`, `current_date`.
+**Syntax**
+
+```sql
+today()
+```
+
+**Arguments**
+
+- None
+
+**Returned value**
+
+- Current date
+
+Type: [DateTime](../../sql-reference/data-types/datetime.md).
+
+**Example**
+
+Query:
+
+```sql
+SELECT today();
+```
+
+**Result**:
+
+```response
+
+```
 
 ## yesterday {#yesterday}
 


### PR DESCRIPTION
Closes [2023](https://github.com/ClickHouse/clickhouse-docs/issues/2023) as part of the project to document functions which are either missing  from documentation or do not match the standard format. Updates existing documentation for the `today` function to make it match standard documentation format of functions.

### Changelog category (leave one):
- Documentation (changelog entry is not required)
