### PR TITLE
Remove original article because it's redundant

### DIFF
--- a/docs/en/development/architecture.md
+++ b/docs/en/development/architecture.md
@@ -276,5 +276,3 @@ Besides, each replica stores its state in ZooKeeper as the set of parts and its 
 :::note
 The ClickHouse cluster consists of independent shards, and each shard consists of replicas. The cluster is **not elastic**, so after adding a new shard, data is not rebalanced between shards automatically. Instead, the cluster load is supposed to be adjusted to be uneven. This implementation gives you more control, and it is ok for relatively small clusters, such as tens of nodes. But for clusters with hundreds of nodes that we are using in production, this approach becomes a significant drawback. We should implement a table engine that spans across the cluster with dynamically replicated regions that could be split and balanced between clusters automatically.
 :::
-
-[Original article](https://clickhouse.com/docs/en/development/architecture/)

--- a/docs/en/interfaces/postgresql.md
+++ b/docs/en/interfaces/postgresql.md
@@ -69,5 +69,3 @@ psql "port=9005 host=127.0.0.1 user=alice dbname=default sslcert=/path/to/certif
 ```
 
 View the [PostgreSQL docs](https://jdbc.postgresql.org/documentation/head/ssl-client.html) for more details on their SSL settings.
-
-[Original article](https://clickhouse.com/docs/en/interfaces/postgresql)

--- a/docs/en/operations/system-tables/crash-log.md
+++ b/docs/en/operations/system-tables/crash-log.md
@@ -49,5 +49,3 @@ build_id:
 
 **See also**
 - [trace_log](../../operations/system-tables/trace_log.md) system table
-
-[Original article](https://clickhouse.com/docs/en/operations/system-tables/crash-log)

--- a/docs/en/operations/tips.md
+++ b/docs/en/operations/tips.md
@@ -297,8 +297,6 @@ end script
 
 If you use antivirus software configure it to skip folders with ClickHouse datafiles (`/var/lib/clickhouse`) otherwise performance may be reduced and you may experience unexpected errors during data ingestion and background merges.
 
-[Original article](https://clickhouse.com/docs/en/operations/tips/)
-
 ## Related Content
 
 - [Getting started with ClickHouse? Here are 13 "Deadly Sins" and how to avoid them](https://clickhouse.com/blog/common-getting-started-issues-with-clickhouse)

--- a/docs/en/sql-reference/statements/select/union.md
+++ b/docs/en/sql-reference/statements/select/union.md
@@ -83,6 +83,3 @@ Queries that are parts of `UNION/UNION ALL/UNION DISTINCT` can be run simultaneo
 
 - [insert_null_as_default](../../../operations/settings/settings.md#insert_null_as_default) setting.
 - [union_default_mode](../../../operations/settings/settings.md#union-default-mode) setting.
-
-
-[Original article](https://clickhouse.com/docs/en/sql-reference/statements/select/union/) <!-- hide -->


### PR DESCRIPTION
### Changelog category (leave one):

- Documentation (changelog entry is not required)

These original article links can be removed because these referenced links are equal to current links.

It should be fine to be removed because they're redundant.