### PR TITLE
Fix "Invalid storage definition in metadata file" for parameterized views

### DIFF
--- a/src/Databases/DatabaseOnDisk.cpp
+++ b/src/Databases/DatabaseOnDisk.cpp
@@ -83,7 +83,13 @@ std::pair<String, StoragePtr> createTableFromAST(
     ColumnsDescription columns;
     ConstraintsDescription constraints;
 
-    if (!ast_create_query.is_dictionary)
+    bool has_columns = true;
+    if (ast_create_query.is_dictionary)
+        has_columns = false;
+    if (ast_create_query.isParameterizedView())
+        has_columns = false;
+
+    if (has_columns)
     {
         /// We do not directly use `InterpreterCreateQuery::execute`, because
         /// - the database has not been loaded yet;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix "Invalid storage definition in metadata file" for parameterized views

Fixes: https://github.com/ClickHouse/ClickHouse/issues/60349