### PR TITLE
Fix scheduler fairness test

### DIFF
--- a/src/Common/Scheduler/Nodes/tests/ResourceTest.h
+++ b/src/Common/Scheduler/Nodes/tests/ResourceTest.h
@@ -282,7 +282,7 @@ struct ResourceTestManager : public ResourceTestBase
         return link_data[link];
     }
 
-    // Use at least two threads for each queue to avoid queue being deactivated:
+    // Use exactly two threads for each queue to avoid queue being deactivated (happens with 1 thread) and reordering (happens with >2 threads):
     // while the first request is executing, the second request is in queue - holding it active.
     // use onEnqueue() and onExecute() functions for this purpose.
     void onEnqueue(ResourceLink link)

--- a/src/Common/Scheduler/Nodes/tests/gtest_dynamic_resource_manager.cpp
+++ b/src/Common/Scheduler/Nodes/tests/gtest_dynamic_resource_manager.cpp
@@ -56,7 +56,7 @@ TEST(SchedulerDynamicResourceManager, Fairness)
         EXPECT_NEAR(cur_unfairness, 0, 1);
     };
 
-    constexpr size_t threads_per_queue = 3;
+    constexpr size_t threads_per_queue = 2;
     int requests_per_thread = 100;
     ResourceTest t(2 * threads_per_queue + 1);
 


### PR DESCRIPTION
Fixes https://github.com/ClickHouse/ClickHouse/issues/60145

Test hangs up in case when 3 threads are using the same scheduler queue.

https://pastila.nl/?0048b0bf/b7360f97b41a8796ee22fc327141d2d5#5UAp5G/dcUTTWXmDYC345g==

For example A1 thread missed its opportunity to use the queue A to either A2 or A0 repeatedly, which leads to hanging up because in the end of the test, there is no sibling thread, but there are tasks to execute.

https://pastila.nl/?000a65b0/c0f1cb7cc487fbac662b2a54eab1b2ce#B1y/yzm06nwHE3mV+zPMRQ==

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

