### PR TITLE
Do not retry queries if container is down in integration tests (resubmit)

### DIFF
--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -3489,6 +3489,11 @@ class ClickHouseInstance:
                 if check_callback(result):
                     return result
                 time.sleep(sleep_time)
+            except QueryRuntimeException as ex:
+                # Container is down, this is likely due to server crash.
+                if "No route to host" in str(ex):
+                    raise
+                time.sleep(sleep_time)
             except Exception as ex:
                 # logging.debug("Retry {} got exception {}".format(i + 1, ex))
                 time.sleep(sleep_time)


### PR DESCRIPTION
This version contains proper `sleep` for `QueryRuntimeException`

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Resubmits https://github.com/ClickHouse/ClickHouse/pull/60109
Reverts https://github.com/ClickHouse/ClickHouse/pull/60215
Cc: @tavplubix, @antonio2368, @alexey-milovidov 