### PR TITLE
Make String a supertype for strings and enums

### DIFF
--- a/src/DataTypes/getLeastSupertype.cpp
+++ b/src/DataTypes/getLeastSupertype.cpp
@@ -474,16 +474,18 @@ DataTypePtr getLeastSupertype(const DataTypes & types)
         type_ids.insert(type->getTypeId());
 
     /// For String and FixedString, or for different FixedStrings, the common type is String.
-    /// No other types are compatible with Strings. TODO Enums?
+    /// If there are Enums and any type of Strings, the common type is String.
+    /// No other types are compatible with Strings.
     {
         size_t have_string = type_ids.count(TypeIndex::String);
         size_t have_fixed_string = type_ids.count(TypeIndex::FixedString);
+        size_t have_enums = type_ids.count(TypeIndex::Enum8) + type_ids.count(TypeIndex::Enum16);
 
         if (have_string || have_fixed_string)
         {
-            bool all_strings = type_ids.size() == (have_string + have_fixed_string);
-            if (!all_strings)
-                return throwOrReturn<on_error>(types, "because some of them are String/FixedString and some of them are not", ErrorCodes::NO_COMMON_TYPE);
+            bool all_compatible_with_string = type_ids.size() == (have_string + have_fixed_string + have_enums);
+            if (!all_compatible_with_string)
+                return throwOrReturn<on_error>(types, "because some of them are String/FixedString/Enum and some of them are not", ErrorCodes::NO_COMMON_TYPE);
 
             return std::make_shared<DataTypeString>();
         }

--- a/tests/queries/0_stateless/03003_enum_and_string_compatible.reference
+++ b/tests/queries/0_stateless/03003_enum_and_string_compatible.reference
@@ -1,0 +1,1 @@
+['Hello','Goodbye','test']

--- a/tests/queries/0_stateless/03003_enum_and_string_compatible.sql
+++ b/tests/queries/0_stateless/03003_enum_and_string_compatible.sql
@@ -1,0 +1,1 @@
+WITH 'Hello'::Enum8('Hello', 'World') AS enum1, 'test'::Enum8('test', 'best') AS enum2 SELECT [enum1, 'Goodbye', enum2];


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
String types and Enums can be used in the same context, such as: arrays, UNION queries, conditional expressions. This closes #60726.