### PR TITLE
Update tzdata to 2024a

### DIFF
--- a/src/Core/SettingsFields.cpp
+++ b/src/Core/SettingsFields.cpp
@@ -8,7 +8,9 @@
 #include <IO/ReadHelpers.h>
 #include <IO/ReadBufferFromString.h>
 #include <IO/WriteHelpers.h>
+
 #include <boost/algorithm/string/predicate.hpp>
+#include <cctz/time_zone.h>
 
 #include <cmath>
 
@@ -542,6 +544,13 @@ void SettingFieldTimezone::readBinary(ReadBuffer & in)
     String str;
     readStringBinary(str, in);
     *this = std::move(str);
+}
+
+void SettingFieldTimezone::validateTimezone(const std::string & tz_str)
+{
+    cctz::time_zone validated_tz;
+    if (!tz_str.empty() && !cctz::load_time_zone(tz_str, &validated_tz))
+        throw DB::Exception(DB::ErrorCodes::BAD_ARGUMENTS, "Invalid time zone: {}", tz_str);
 }
 
 String SettingFieldCustom::toString() const

--- a/src/Core/SettingsFields.h
+++ b/src/Core/SettingsFields.h
@@ -6,7 +6,6 @@
 #include <Core/Field.h>
 #include <Core/MultiEnum.h>
 #include <boost/range/adaptor/map.hpp>
-#include <cctz/time_zone.h>
 #include <chrono>
 #include <unordered_map>
 #include <string_view>
@@ -608,12 +607,7 @@ struct SettingFieldTimezone
     void readBinary(ReadBuffer & in);
 
 private:
-    void validateTimezone(const std::string & tz_str)
-    {
-        cctz::time_zone validated_tz;
-        if (!tz_str.empty() && !cctz::load_time_zone(tz_str, &validated_tz))
-            throw DB::Exception(DB::ErrorCodes::BAD_ARGUMENTS, "Invalid time zone: {}", tz_str);
-    }
+    void validateTimezone(const std::string & tz_str);
 };
 
 /// Can keep a value of any type. Used for user-defined settings.


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Update tzdata to 2024a

### Documentation entry for user-facing changes

Although it's an improvement, backporting to keep stable releases up to date with the latest changes.

```
SELECT timeZoneOffset(now('Asia/Almaty')) / 3600 AS offset

Query id: 7f8d389e-5d45-4361-a170-57a1f4958f9b

┌─offset─┐
│      5 │
└────────┘
```

Closes https://github.com/ClickHouse/ClickHouse/issues/60750