### PR TITLE
Reduce flakiness of 02932_refreshable_materialized_views

### DIFF
--- a/tests/queries/0_stateless/02932_refreshable_materialized_views.reference
+++ b/tests/queries/0_stateless/02932_refreshable_materialized_views.reference
@@ -1,5 +1,5 @@
 <1: created view>	a	[]		1
-CREATE MATERIALIZED VIEW default.a\nREFRESH AFTER 1 SECOND\n(\n    `x` UInt64\n)\nENGINE = Memory\nAS SELECT number AS x\nFROM numbers(2)\nUNION ALL\nSELECT rand64() AS x
+CREATE MATERIALIZED VIEW default.a\nREFRESH AFTER 2 SECOND\n(\n    `x` UInt64\n)\nENGINE = Memory\nAS SELECT number AS x\nFROM numbers(2)\nUNION ALL\nSELECT rand64() AS x
 <2: refreshed>	3	1	1
 <3: time difference at least>	500
 <4: next refresh in>	1
@@ -16,8 +16,8 @@ CREATE MATERIALIZED VIEW default.b\nREFRESH EVERY 2 YEAR DEPENDS ON default.a\n(
 <10: waiting>	b	WaitingForDependencies	['default.a']	2054-01-01 00:00:00
 <11: chain-refreshed a>	4
 <12: chain-refreshed b>	40
-<13: chain-refreshed>	a	Scheduled	[]	Finished	2054-01-01 00:00:01	2056-01-01 00:00:00	
-<13: chain-refreshed>	b	Scheduled	['default.a']	Finished	2054-01-24 23:22:21	2056-01-01 00:00:00	
+<13: chain-refreshed>	a	Scheduled	[]	Finished	2054-01-01 00:00:01	2056-01-01 00:00:00
+<13: chain-refreshed>	b	Scheduled	['default.a']	Finished	2054-01-24 23:22:21	2056-01-01 00:00:00
 <14: waiting for next cycle>	a	Scheduled	[]	2058-01-01 00:00:00
 <14: waiting for next cycle>	b	WaitingForDependencies	['default.a']	2060-01-01 00:00:00
 <15: chain-refreshed a>	6

--- a/tests/queries/0_stateless/02932_refreshable_materialized_views.reference
+++ b/tests/queries/0_stateless/02932_refreshable_materialized_views.reference
@@ -1,8 +1,8 @@
 <1: created view>	a	[]		1
 CREATE MATERIALIZED VIEW default.a\nREFRESH AFTER 2 SECOND\n(\n    `x` UInt64\n)\nENGINE = Memory\nAS SELECT number AS x\nFROM numbers(2)\nUNION ALL\nSELECT rand64() AS x
 <2: refreshed>	3	1	1
-<3: time difference at least>	500
-<4: next refresh in>	1
+<3: time difference at least>	1000
+<4: next refresh in>	2
 <4.5: altered>	Scheduled	Finished	2052-01-01 00:00:00
 CREATE MATERIALIZED VIEW default.a\nREFRESH EVERY 2 YEAR\n(\n    `x` Int16\n)\nENGINE = Memory\nAS SELECT x * 2 AS x\nFROM default.src
 <5: no refresh>	3
@@ -16,8 +16,8 @@ CREATE MATERIALIZED VIEW default.b\nREFRESH EVERY 2 YEAR DEPENDS ON default.a\n(
 <10: waiting>	b	WaitingForDependencies	['default.a']	2054-01-01 00:00:00
 <11: chain-refreshed a>	4
 <12: chain-refreshed b>	40
-<13: chain-refreshed>	a	Scheduled	[]	Finished	2054-01-01 00:00:01	2056-01-01 00:00:00
-<13: chain-refreshed>	b	Scheduled	['default.a']	Finished	2054-01-24 23:22:21	2056-01-01 00:00:00
+<13: chain-refreshed>	a	Scheduled	[]	Finished	2054-01-01 00:00:01	2056-01-01 00:00:00	
+<13: chain-refreshed>	b	Scheduled	['default.a']	Finished	2054-01-24 23:22:21	2056-01-01 00:00:00	
 <14: waiting for next cycle>	a	Scheduled	[]	2058-01-01 00:00:00
 <14: waiting for next cycle>	b	WaitingForDependencies	['default.a']	2060-01-01 00:00:00
 <15: chain-refreshed a>	6

--- a/tests/queries/0_stateless/02932_refreshable_materialized_views.sh
+++ b/tests/queries/0_stateless/02932_refreshable_materialized_views.sh
@@ -18,7 +18,7 @@ $CLICKHOUSE_CLIENT -nq "create view refreshes as select * from system.view_refre
 # Basic refreshing.
 $CLICKHOUSE_CLIENT -nq "
     create materialized view a
-        refresh after 1 second
+        refresh after 2 second
         engine Memory
         empty
         as select number as x from numbers(2) union all select rand64() as x"
@@ -29,6 +29,7 @@ while [ "`$CLICKHOUSE_CLIENT -nq "select last_refresh_result from refreshes -- $
 do
     sleep 0.1
 done
+start_time="`$CLICKHOUSE_CLIENT -nq "select reinterpret(now64(), 'Int64')"`"
 # Check table contents.
 $CLICKHOUSE_CLIENT -nq "select '<2: refreshed>', count(), sum(x=0), sum(x=1) from a"
 # Wait for table contents to change.
@@ -39,7 +40,6 @@ do
     [ "$res2" == "$res1" ] || break
     sleep 0.1
 done
-time2="`$CLICKHOUSE_CLIENT -nq "select reinterpret(now64(), 'Int64')"`"
 # Wait for another change.
 while :
 do
@@ -47,11 +47,11 @@ do
     [ "$res3" == "$res2" ] || break
     sleep 0.1
 done
-# Check that the two changes were at least 500ms apart, in particular that we're not refreshing
+# Check that the two changes were at least 1 second apart, in particular that we're not refreshing
 # like crazy. This is potentially flaky, but we need at least one test that uses non-mocked timer
 # to make sure the clock+timer code works at all. If it turns out flaky, increase refresh period above.
 $CLICKHOUSE_CLIENT -nq "
-    select '<3: time difference at least>', min2(reinterpret(now64(), 'Int64') - $time2, 500);
+    select '<3: time difference at least>', min2(reinterpret(now64(), 'Int64') - $start_time, 1000);
     select '<4: next refresh in>', next_refresh_time-last_refresh_time from refreshes;"
 
 # Create a source table from which views will read.

--- a/tests/queries/0_stateless/02932_refreshable_materialized_views.sh
+++ b/tests/queries/0_stateless/02932_refreshable_materialized_views.sh
@@ -61,7 +61,7 @@ $CLICKHOUSE_CLIENT -nq "
 # Switch to fake clock, change refresh schedule, change query.
 $CLICKHOUSE_CLIENT -nq "
     system test view a set fake time '2050-01-01 00:00:01';"
-while [ "`$CLICKHOUSE_CLIENT -nq "select status, last_refresh_time, next_refresh_time from refreshes -- $LINENO" | xargs`" != 'Scheduled 2050-01-01 00:00:01 2050-01-01 00:00:02' ]
+while [ "`$CLICKHOUSE_CLIENT -nq "select status, last_refresh_time, next_refresh_time from refreshes -- $LINENO" | xargs`" != 'Scheduled 2050-01-01 00:00:01 2050-01-01 00:00:03' ]
 do
     sleep 0.1
 done


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Failed like this: https://s3.amazonaws.com/clickhouse-test-reports/0/bae4783fe9bd25decc41383a1234b0e936284c21/stateless_tests__aarch64_.html

The test foresaw this and had this comment:
```
# Check that the two changes were at least 500ms apart, in particular that we're not refreshing
# like crazy. This is potentially flaky, but we need at least one test that uses non-mocked timer
# to make sure the clock+timer code works at all. If it turns out flaky, increase refresh period above.
```

This PR increases refresh period above. And also moves one of the `now64()` calls higher up to make the check less sensitive to slow queries (previously this check could fail if a simple query takes a long time, e.g. because the server is overloaded).