### PR TITLE
Include multiline logs in fuzzer fatal.log report

### DIFF
--- a/docker/test/fuzzer/run-fuzzer.sh
+++ b/docker/test/fuzzer/run-fuzzer.sh
@@ -386,7 +386,8 @@ if [ -f core.zst ]; then
     CORE_LINK='<a href="core.zst">core.zst</a>'
 fi
 
-sed -n '/<Fatal>/,/^$/p' s.log | rg "(^[^202])|<Fatal>" server.log > fatal.log ||:
+# Keep all the lines in the paragraphs containing <Fatal> that either contain <Fatal> or don't start with 20... (year)
+sed -n '/<Fatal>/,/^$/p' s.log | awk '/<Fatal>/ || !/^20/' server.log > fatal.log ||:
 FATAL_LINK=''
 if [ -s fatal.log ]; then
     FATAL_LINK='<a href="fatal.log">fatal.log</a>'

--- a/docker/test/fuzzer/run-fuzzer.sh
+++ b/docker/test/fuzzer/run-fuzzer.sh
@@ -386,7 +386,7 @@ if [ -f core.zst ]; then
     CORE_LINK='<a href="core.zst">core.zst</a>'
 fi
 
-rg --text -F '<Fatal>' server.log > fatal.log ||:
+sed -n '/<Fatal>/,/^$/p' s.log | rg "(^[^202])|<Fatal>" server.log > fatal.log ||:
 FATAL_LINK=''
 if [ -s fatal.log ]; then
     FATAL_LINK='<a href="fatal.log">fatal.log</a>'


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

Before: Include all lines including `<Fatal>` from server.log
Now: Get the **paragraphs** having `<Fatal>`. Keep the lines that either contain `<Fatal>` or that don't start with `202` (logs look like `2024.03.03 22:51:24...`) 


Example from https://s3.amazonaws.com/clickhouse-test-reports/60724/b41b935a6a9d386c259e71d5ae5be530076fb89d/ast_fuzzer__debug_.html:
```
$ sed -n '/<Fatal>/,/^$/p' s.log | rg "(^[^202])|<Fatal>"
2024.03.03 22:51:24.296711 [ 301 ] {99a24b5e-5820-4467-86aa-08e1a2d90e76} <Fatal> : Logical error: 'Inconsistent AST formatting: the query:
SELECT ((('a', 10) AS x).1) = toFixedString('a', toNullable(1)) FROM remote('127.0.0.{1,2,3}') GROUP BY 'a'
Was parsed and formatted back as:
SELECT (tuple(('a', 10) AS x).1) = toFixedString('a', toNullable(1)) FROM remote('127.0.0.{1,2,3}') GROUP BY 'a''.
2024.03.03 22:51:24.298090 [ 1026 ] {} <Fatal> BaseDaemon: ########## Short fault info ############
2024.03.03 22:51:24.298182 [ 1026 ] {} <Fatal> BaseDaemon: (version 24.3.1.1 (official build), build id: 7BF5FD36AE86A6DCA9768742B3C9998EC194FE7E, git hash: 356e8cae39b4e61910cbd39500445620cad1c681) (from thread 301) Received signal 6
2024.03.03 22:51:24.298225 [ 1026 ] {} <Fatal> BaseDaemon: Signal description: Aborted
2024.03.03 22:51:24.298251 [ 1026 ] {} <Fatal> BaseDaemon: 
2024.03.03 22:51:24.298302 [ 1026 ] {} <Fatal> BaseDaemon: Stack trace: 0x00007fe3e13999fc 0x00007fe3e1345476 0x00007fe3e132b7f3 0x00000000136fea7f 0x00000000136feb15 0x00000000136ff051 0x000000000a9e0bca 0x0000000012024eec 0x000000001c64e7e3 0x000000001c64cf8a 0x000000001ddc9752 0x000000001ddde5c5 0x000000002317f9f9 0x000000002318025c 0x00000000233575d4 0x000000002335437a 0x00000000233530be 0x00007fe3e1397ac3 0x00007fe3e1429850
2024.03.03 22:51:24.298353 [ 1026 ] {} <Fatal> BaseDaemon: ########################################
2024.03.03 22:51:24.298492 [ 1026 ] {} <Fatal> BaseDaemon: (version 24.3.1.1 (official build), build id: 7BF5FD36AE86A6DCA9768742B3C9998EC194FE7E, git hash: 356e8cae39b4e61910cbd39500445620cad1c681) (from thread 301) (query_id: 99a24b5e-5820-4467-86aa-08e1a2d90e76) (query: ) Received signal Aborted (6)
2024.03.03 22:51:24.298644 [ 1026 ] {} <Fatal> BaseDaemon: 
2024.03.03 22:51:24.298746 [ 1026 ] {} <Fatal> BaseDaemon: Stack trace: 0x00007fe3e13999fc 0x00007fe3e1345476 0x00007fe3e132b7f3 0x00000000136fea7f 0x00000000136feb15 0x00000000136ff051 0x000000000a9e0bca 0x0000000012024eec 0x000000001c64e7e3 0x000000001c64cf8a 0x000000001ddc9752 0x000000001ddde5c5 0x000000002317f9f9 0x000000002318025c 0x00000000233575d4 0x000000002335437a 0x00000000233530be 0x00007fe3e1397ac3 0x00007fe3e1429850
2024.03.03 22:51:24.298871 [ 1026 ] {} <Fatal> BaseDaemon: 4. ? @ 0x00007fe3e13999fc
2024.03.03 22:51:24.298948 [ 1026 ] {} <Fatal> BaseDaemon: 5. ? @ 0x00007fe3e1345476
2024.03.03 22:51:24.299059 [ 1026 ] {} <Fatal> BaseDaemon: 6. ? @ 0x00007fe3e132b7f3
2024.03.03 22:51:24.367566 [ 1026 ] {} <Fatal> BaseDaemon: 7. /build/src/Common/Exception.cpp:0: DB::abortOnFailedAssertion(String const&) @ 0x00000000136fea7f
2024.03.03 22:51:24.435001 [ 1026 ] {} <Fatal> BaseDaemon: 8. /build/src/Common/Exception.cpp:63: DB::handle_error_code(String const&, int, bool, std::vector<void*, std::allocator<void*>> const&) @ 0x00000000136feb15
2024.03.03 22:51:24.491183 [ 1026 ] {} <Fatal> BaseDaemon: 9. /build/src/Common/Exception.cpp:100: DB::Exception::Exception(DB::Exception::MessageMasked&&, int, bool) @ 0x00000000136ff051
2024.03.03 22:51:24.549551 [ 1026 ] {} <Fatal> BaseDaemon: 10. /build/src/Common/Exception.h:90: DB::Exception::Exception(String&&, int, bool) @ 0x000000000a9e0bca
2024.03.03 22:51:24.633517 [ 1026 ] {} <Fatal> BaseDaemon: 11. /build/src/Common/Exception.h:109: DB::Exception::Exception<String&, String&>(int, FormatStringHelperImpl<std::type_identity<String&>::type, std::type_identity<String&>::type>, String&, String&) @ 0x0000000012024eec
2024.03.03 22:51:24.830907 [ 1026 ] {} <Fatal> BaseDaemon: 12. /build/src/Interpreters/executeQuery.cpp:762: DB::executeQueryImpl(char const*, char const*, std::shared_ptr<DB::Context>, DB::QueryFlags, DB::QueryProcessingStage::Enum, DB::ReadBuffer*) @ 0x000000001c64e7e3
2024.03.03 22:51:25.038152 [ 1026 ] {} <Fatal> BaseDaemon: 13. /build/src/Interpreters/executeQuery.cpp:1326: DB::executeQuery(String const&, std::shared_ptr<DB::Context>, DB::QueryFlags, DB::QueryProcessingStage::Enum) @ 0x000000001c64cf8a
2024.03.03 22:51:25.243706 [ 1026 ] {} <Fatal> BaseDaemon: 14. /build/src/Server/TCPHandler.cpp:518: DB::TCPHandler::runImpl() @ 0x000000001ddc9752
2024.03.03 22:51:25.472174 [ 1026 ] {} <Fatal> BaseDaemon: 15. /build/src/Server/TCPHandler.cpp:2312: DB::TCPHandler::run() @ 0x000000001ddde5c5
2024.03.03 22:51:25.490188 [ 1026 ] {} <Fatal> BaseDaemon: 16. /build/base/poco/Net/src/TCPServerConnection.cpp:43: Poco::Net::TCPServerConnection::start() @ 0x000000002317f9f9
2024.03.03 22:51:25.513286 [ 1026 ] {} <Fatal> BaseDaemon: 17. /build/base/poco/Net/src/TCPServerDispatcher.cpp:115: Poco::Net::TCPServerDispatcher::run() @ 0x000000002318025c
2024.03.03 22:51:25.537548 [ 1026 ] {} <Fatal> BaseDaemon: 18. /build/base/poco/Foundation/src/ThreadPool.cpp:188: Poco::PooledThread::run() @ 0x00000000233575d4
2024.03.03 22:51:25.561420 [ 1026 ] {} <Fatal> BaseDaemon: 19. /build/base/poco/Foundation/src/Thread.cpp:46: Poco::(anonymous namespace)::RunnableHolder::run() @ 0x000000002335437a
2024.03.03 22:51:25.584092 [ 1026 ] {} <Fatal> BaseDaemon: 20. /build/base/poco/Foundation/src/Thread_POSIX.cpp:335: Poco::ThreadImpl::runnableEntry(void*) @ 0x00000000233530be
2024.03.03 22:51:25.584252 [ 1026 ] {} <Fatal> BaseDaemon: 21. ? @ 0x00007fe3e1397ac3
2024.03.03 22:51:25.584368 [ 1026 ] {} <Fatal> BaseDaemon: 22. ? @ 0x00007fe3e1429850
2024.03.03 22:51:26.991939 [ 1026 ] {} <Fatal> BaseDaemon: Integrity check of the executable successfully passed (checksum: 9ED3E5877C20066680BCDC7A6966C0F4)
2024.03.03 22:51:28.289815 [ 1026 ] {} <Fatal> BaseDaemon: Report this error to https://github.com/ClickHouse/ClickHouse/issues
2024.03.03 22:51:28.290341 [ 1026 ] {} <Fatal> BaseDaemon: Changed settings: receive_timeout = 10., receive_data_timeout_ms = 10000, alter_sync = 2, allow_suspicious_low_cardinality_types = true, log_queries = true, distributed_product_mode = 'local', table_function_remote_max_addresses = 200, max_execution_time = 10., max_memory_usage = 10000000000, log_comment = '/workspace/ch/tests/queries/0_stateless/02887_tuple_element_distributed.sql', send_logs_level = 'fatal', allow_introspection_functions = true, optimize_on_insert = false, allow_deprecated_syntax_for_merge_tree = true
2024.03.03 22:51:35.917090 [ 164 ] {} <Fatal> Application: Child process was terminated by signal 6.
```