### PR TITLE
Aarch64 profiler

### DIFF
--- a/base/glibc-compatibility/musl/aarch64/syscall.s
+++ b/base/glibc-compatibility/musl/aarch64/syscall.s
@@ -2,6 +2,7 @@
 .hidden __syscall
 .type __syscall,%function
 __syscall:
+.cfi_startproc
 	uxtw x8,w0
 	mov x0,x1
 	mov x1,x2
@@ -12,3 +13,4 @@ __syscall:
 	mov x6,x7
 	svc 0
 	ret
+.cfi_endproc

--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -1881,7 +1881,6 @@ try
         {
             total_memory_tracker.setSampleMaxAllocationSize(server_settings.total_memory_profiler_sample_max_allocation_size);
         }
-
     }
 #endif
 
@@ -1894,10 +1893,6 @@ try
 #if defined(SANITIZER)
     LOG_INFO(log, "Query Profiler disabled because they cannot work under sanitizers"
         " when two different stack unwinding methods will interfere with each other.");
-#endif
-
-#if !defined(__x86_64__)
-    LOG_INFO(log, "Query Profiler and TraceCollector is only tested on x86_64. It also known to not work under qemu-user.");
 #endif
 
     if (!hasPHDRCache())

--- a/src/Interpreters/TraceCollector.cpp
+++ b/src/Interpreters/TraceCollector.cpp
@@ -6,7 +6,6 @@
 #include <IO/WriteBufferFromFileDescriptor.h>
 #include <IO/WriteHelpers.h>
 #include <Interpreters/TraceLog.h>
-#include <Poco/Logger.h>
 #include <Common/ProfileEvents.h>
 #include <Common/setThreadName.h>
 #include <Common/logger_useful.h>

--- a/tests/queries/0_stateless/00974_query_profiler.sql
+++ b/tests/queries/0_stateless/00974_query_profiler.sql
@@ -1,4 +1,4 @@
--- Tags: no-tsan, no-asan, no-ubsan, no-msan, no-debug, no-fasttest, no-cpu-aarch64
+-- Tags: no-tsan, no-asan, no-ubsan, no-msan, no-debug, no-fasttest
 -- Tag no-fasttest: Not sure why fail even in sequential mode. Disabled for now to make some progress.
 
 SET allow_introspection_functions = 1;

--- a/tests/queries/0_stateless/01092_memory_profiler.sql
+++ b/tests/queries/0_stateless/01092_memory_profiler.sql
@@ -1,4 +1,4 @@
--- Tags: no-tsan, no-asan, no-ubsan, no-msan, no-debug, no-parallel, no-fasttest, no-cpu-aarch64
+-- Tags: no-tsan, no-asan, no-ubsan, no-msan, no-debug, no-parallel, no-fasttest
 
 SET allow_introspection_functions = 1;
 

--- a/tests/queries/0_stateless/01526_max_untracked_memory.sh
+++ b/tests/queries/0_stateless/01526_max_untracked_memory.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
-# Tags: no-tsan, no-asan, no-ubsan, no-msan, no-cpu-aarch64
-# requires TraceCollector, does not available under sanitizers and aarch64
+# Tags: no-tsan, no-asan, no-ubsan, no-msan
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/01569_query_profiler_big_query_id.sh
+++ b/tests/queries/0_stateless/01569_query_profiler_big_query_id.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: no-tsan, no-asan, no-ubsan, no-msan, no-debug, no-cpu-aarch64
+# Tags: no-tsan, no-asan, no-ubsan, no-msan, no-debug
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
@@ -9,4 +9,3 @@ query_id="aggregating_merge_tree_simple_aggregate_function_string_query100_profi
 ${CLICKHOUSE_CLIENT} --query="select sleep(1)" --query_id="$query_id" --query_profiler_real_time_period_ns=10000000
 ${CLICKHOUSE_CLIENT} --query="system flush logs"
 ${CLICKHOUSE_CLIENT} --query="select count(*) > 1 from system.trace_log where query_id = '$query_id'"
-

--- a/tests/queries/0_stateless/02161_addressToLineWithInlines.sql
+++ b/tests/queries/0_stateless/02161_addressToLineWithInlines.sql
@@ -1,4 +1,4 @@
--- Tags: no-tsan, no-asan, no-ubsan, no-msan, no-debug, no-cpu-aarch64
+-- Tags: no-tsan, no-asan, no-ubsan, no-msan, no-debug
 
 SET allow_introspection_functions = 0;
 SELECT addressToLineWithInlines(1); -- { serverError 446 }

--- a/tests/queries/0_stateless/02252_jit_profile_events.sql
+++ b/tests/queries/0_stateless/02252_jit_profile_events.sql
@@ -1,4 +1,4 @@
--- Tags: no-fasttest, no-parallel, no-cpu-aarch64, no-msan
+-- Tags: no-fasttest, no-parallel, no-msan
 
 SET compile_expressions = 1;
 SET min_count_to_compile_expression = 0;

--- a/tests/queries/0_stateless/02818_memory_profiler_sample_min_max_allocation_size.sh
+++ b/tests/queries/0_stateless/02818_memory_profiler_sample_min_max_allocation_size.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
-# Tags: no-tsan, no-asan, no-ubsan, no-msan, no-cpu-aarch64, no-random-settings
-# requires TraceCollector, does not available under sanitizers and aarch64
+# Tags: no-tsan, no-asan, no-ubsan, no-msan, no-random-settings
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh


### PR DESCRIPTION
### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
The real-time query profiler now works on AArch64. In previous versions, it worked only when a program didn't spend time inside a syscall.