### PR TITLE
Move connection drain from prepare to work

### DIFF
--- a/src/Processors/Sources/RemoteSource.cpp
+++ b/src/Processors/Sources/RemoteSource.cpp
@@ -90,6 +90,9 @@ ISource::Status RemoteSource::prepare()
 
 void RemoteSource::work()
 {
+    /// Connection drain is a heavy operation that may take a long time.
+    /// Therefore we move connection drain from prepare() to work(), and drain multiple connections in parallel.
+    /// See issue: https://github.com/ClickHouse/ClickHouse/issues/60844
     if (need_drain)
     {
         query_executor->finish();

--- a/src/Processors/Sources/RemoteSource.h
+++ b/src/Processors/Sources/RemoteSource.h
@@ -23,6 +23,7 @@ public:
     ~RemoteSource() override;
 
     Status prepare() override;
+    void work() override;
     String getName() const override { return "Remote"; }
 
     void setRowsBeforeLimitCounter(RowsBeforeLimitCounterPtr counter) override { rows_before_limit.swap(counter); }
@@ -40,6 +41,8 @@ protected:
 
 private:
     bool was_query_sent = false;
+    bool need_drain = false;
+    bool executor_finished = false;
     bool add_aggregation_info = false;
     RemoteQueryExecutorPtr query_executor;
     RowsBeforeLimitCounterPtr rows_before_limit;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Move connection drain from prepare to work, and drain multiple connections in parallel.

Resolves https://github.com/ClickHouse/ClickHouse/issues/60844
