### PR TITLE
CI: Fix pending status for build report in backports

### DIFF
--- a/tests/ci/build_report_check.py
+++ b/tests/ci/build_report_check.py
@@ -51,7 +51,7 @@ def main():
     builds_for_check = CI_CONFIG.get_builds_for_report(
         build_check_name,
         release=pr_info.is_release(),
-        backport=pr_info.head_ref.startswith("backport"),
+        backport=pr_info.head_ref.startswith("backport/"),
     )
     required_builds = len(builds_for_check)
     missing_builds = 0

--- a/tests/ci/ci_config.py
+++ b/tests/ci/ci_config.py
@@ -586,7 +586,7 @@ class CIConfig:
                 Build.PACKAGE_TSAN,
                 Build.PACKAGE_DEBUG,
             ]
-        if release and report_name == JobNames.BUILD_CHECK_SPECIAL:
+        if (release or backport) and report_name == JobNames.BUILD_CHECK_SPECIAL:
             return [
                 Build.BINARY_DARWIN,
                 Build.BINARY_DARWIN_AARCH64,


### PR DESCRIPTION
 #do_not_test

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
set limited number of builds for "special build check" report in backports

bug: https://s3.amazonaws.com/clickhouse-test-reports/60721/8412f8ae7e7d54fa34117c348c8af40f62b70684/clickhouse_special_build_check/report.html 

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
