### PR TITLE
[Docs] add `mortonEncode` and `mortonDecode`

### DIFF
--- a/docs/en/sql-reference/functions/encoding-functions.md
+++ b/docs/en/sql-reference/functions/encoding-functions.md
@@ -515,6 +515,8 @@ Query:
 SELECT mortonEncode((1,2), 1024, 16);
 ```
 
+Result:
+
 ```response
 1572864
 ```
@@ -531,6 +533,8 @@ Query:
 SELECT mortonEncode(1);
 ```
 
+Result:
+
 ```response
 1
 ```
@@ -545,8 +549,47 @@ Query:
 SELECT mortonEncode(tuple(2), 128);
 ```
 
+Result:
+
 ```response
 32768
+```
+
+**Example**
+
+You can also use column names in the function.
+
+Query:
+
+First create the table and insert some data.
+
+```sql
+create table morton_numbers(
+    n1 UInt32,
+    n2 UInt32,
+    n3 UInt16,
+    n4 UInt16,
+    n5 UInt8,
+    n6 UInt8,
+    n7 UInt8,
+    n8 UInt8
+)
+Engine=MergeTree()
+ORDER BY n1 SETTINGS index_granularity = 8192, index_granularity_bytes = '10Mi';
+insert into morton_numbers (*) values(1,2,3,4,5,6,7,8);
+```
+Use column names instead of constants as function arguments to `mortonEncode`
+
+Query:
+
+```sql
+SELECT mortonEncode(n1, n2, n3, n4, n5, n6, n7, n8) FROM morton_numbers;
+```
+
+Result:
+
+```response
+2155374165
 ```
 
 **implementation details**
@@ -589,6 +632,8 @@ Query:
 SELECT mortonDecode(3, 53);
 ```
 
+Result:
+
 ```response
 ["1","2","3"]
 ```
@@ -615,6 +660,8 @@ Query:
 SELECT mortonDecode(1, 1);
 ```
 
+Result:
+
 ```response
 ["1"]
 ```
@@ -629,8 +676,46 @@ Query:
 SELECT mortonDecode(tuple(2), 32768);
 ```
 
+Result:
+
 ```response
 ["128"]
+```
+
+**Example**
+
+You can also use column names in the function.
+
+First create the table and insert some data.
+
+Query:
+```sql
+create table morton_numbers(
+    n1 UInt32,
+    n2 UInt32,
+    n3 UInt16,
+    n4 UInt16,
+    n5 UInt8,
+    n6 UInt8,
+    n7 UInt8,
+    n8 UInt8
+)
+Engine=MergeTree()
+ORDER BY n1 SETTINGS index_granularity = 8192, index_granularity_bytes = '10Mi';
+insert into morton_numbers (*) values(1,2,3,4,5,6,7,8);
+```
+Use column names instead of constants as function arguments to `mortonDecode`
+
+Query:
+
+```sql
+select untuple(mortonDecode(8, mortonEncode(n1, n2, n3, n4, n5, n6, n7, n8))) from morton_numbers;
+```
+
+Result:
+
+```response
+1	2	3	4	5	6	7	8
 ```
 
 

--- a/docs/en/sql-reference/functions/encoding-functions.md
+++ b/docs/en/sql-reference/functions/encoding-functions.md
@@ -551,7 +551,7 @@ SELECT mortonEncode(tuple(2), 128);
 
 **implementation details**
 
-Please note that you can fit only so much bits of information into Morton code as [UInt64](../../sql-reference/data-types/int-uint.md) has. Two arguments will have a range of maximum 2^32 (64/2) each, three arguments a range of max 2^21 (64/3) each and so on. All overflow will be clamped to zero.
+Please note that you can fit only so many bits of information into Morton code as [UInt64](../../sql-reference/data-types/int-uint.md) has. Two arguments will have a range of maximum 2^32 (64/2) each, three arguments a range of max 2^21 (64/3) each and so on. All overflow will be clamped to zero.
 
 ## mortonDecode
 

--- a/docs/en/sql-reference/functions/encoding-functions.md
+++ b/docs/en/sql-reference/functions/encoding-functions.md
@@ -478,12 +478,12 @@ SELECT mortonEncode(1, 2, 3);
 
 Accepts a range mask ([tuple](../../sql-reference/data-types/tuple.md)) as a first argument and up to 8 [unsigned integers](../../sql-reference/data-types/int-uint.md) as other arguments.
 
-Each number in the mask configures the amount of range expansion:
-1 - no expansion
-2 - 2x expansion
-3 - 3x expansion
-...
-Up to 8x expansion.
+Each number in the mask configures the amount of range expansion:<br/>
+1 - no expansion<br/>
+2 - 2x expansion<br/>
+3 - 3x expansion<br/>
+...<br/>
+Up to 8x expansion.<br/>
 
 **Syntax**
 
@@ -596,12 +596,12 @@ SELECT mortonDecode(3, 53);
 ### Expanded mode
 
 Accepts a range mask (tuple) as a first argument and the code as the second argument.
-Each number in the mask configures the amount of range shrink
-1 - no shrink
-2 - 2x shrink
-3 - 3x shrink
-...
-Up to 8x shrink.
+Each number in the mask configures the amount of range shrink:<br/>
+1 - no shrink<br/>
+2 - 2x shrink<br/> 
+3 - 3x shrink<br/>
+...<br/>
+Up to 8x shrink.<br/>
 
 Range expansion can be beneficial when you need a similar distribution for arguments with wildly different ranges (or cardinality)
 For example: 'IP Address' (0...FFFFFFFF) and 'Country code' (0...FF).

--- a/docs/en/sql-reference/functions/encoding-functions.md
+++ b/docs/en/sql-reference/functions/encoding-functions.md
@@ -469,6 +469,7 @@ Query:
 ```sql
 SELECT mortonEncode(1, 2, 3);
 ```
+Result:
 
 ```response
 53

--- a/utils/check-style/aspell-ignore/en/aspell-dict.txt
+++ b/utils/check-style/aspell-ignore/en/aspell-dict.txt
@@ -260,6 +260,7 @@ ExactEdgeLengthRads
 ExecutablePool
 ExtType
 ExternalDistributed
+FFFFFFFF
 FFFD
 FIPS
 FOSDEM
@@ -546,6 +547,8 @@ MinIO
 MinMax
 MindsDB
 Mongodb
+mortonDecode
+mortonEncode
 MsgPack
 MultiPolygon
 Multiline
@@ -2741,6 +2744,7 @@ xz
 yaml
 yandex
 youtube
+ZCurve
 zLib
 zLinux
 zabbix


### PR DESCRIPTION
Closes [#1984](https://github.com/ClickHouse/clickhouse-docs/issues/1984) as part of the project to document missing or incomplete functions in the documentation.

- Added `mortonEncode` and `mortonDecode` to the docs (documentation was already written in the .cpp file, just needed to be replicated with some format tweaks).

### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Documentation entry for user-facing changes

- [X] Documentation is written (mandatory for new features)

