### PR TITLE
Refactor OptimizeDateOrDateTimeConverterWithPreimageVisitor

### DIFF
--- a/tests/queries/0_stateless/02785_date_predicate_optimizations_ast_query_tree_rewrite.reference
+++ b/tests/queries/0_stateless/02785_date_predicate_optimizations_ast_query_tree_rewrite.reference
@@ -24,21 +24,21 @@ QUERY id: 0
                 FUNCTION id: 12, function_name: less, function_type: ordinary, result_type: UInt8
                   ARGUMENTS
                     LIST id: 13, nodes: 2
-                      COLUMN id: 14, column_name: date1, result_type: Date, source_id: 3
-                      CONSTANT id: 15, constant_value: \'1994-01-01\', constant_value_type: String
-          FUNCTION id: 16, function_name: and, function_type: ordinary, result_type: UInt8
+                      COLUMN id: 10, column_name: date1, result_type: Date, source_id: 3
+                      CONSTANT id: 14, constant_value: \'1994-01-01\', constant_value_type: String
+          FUNCTION id: 15, function_name: and, function_type: ordinary, result_type: UInt8
             ARGUMENTS
-              LIST id: 17, nodes: 2
-                FUNCTION id: 18, function_name: greaterOrEquals, function_type: ordinary, result_type: UInt8
+              LIST id: 16, nodes: 2
+                FUNCTION id: 17, function_name: greaterOrEquals, function_type: ordinary, result_type: UInt8
                   ARGUMENTS
-                    LIST id: 19, nodes: 2
-                      COLUMN id: 20, column_name: id, result_type: UInt32, source_id: 3
-                      CONSTANT id: 21, constant_value: UInt64_1, constant_value_type: UInt8
-                FUNCTION id: 22, function_name: lessOrEquals, function_type: ordinary, result_type: UInt8
+                    LIST id: 18, nodes: 2
+                      COLUMN id: 19, column_name: id, result_type: UInt32, source_id: 3
+                      CONSTANT id: 20, constant_value: UInt64_1, constant_value_type: UInt8
+                FUNCTION id: 21, function_name: lessOrEquals, function_type: ordinary, result_type: UInt8
                   ARGUMENTS
-                    LIST id: 23, nodes: 2
-                      COLUMN id: 20, column_name: id, result_type: UInt32, source_id: 3
-                      CONSTANT id: 24, constant_value: UInt64_3, constant_value_type: UInt8
+                    LIST id: 22, nodes: 2
+                      COLUMN id: 19, column_name: id, result_type: UInt32, source_id: 3
+                      CONSTANT id: 23, constant_value: UInt64_3, constant_value_type: UInt8
   SETTINGS allow_experimental_analyzer=1
 SELECT value1
 FROM date_t
@@ -66,21 +66,21 @@ QUERY id: 0
                 FUNCTION id: 12, function_name: greaterOrEquals, function_type: ordinary, result_type: UInt8
                   ARGUMENTS
                     LIST id: 13, nodes: 2
-                      COLUMN id: 14, column_name: date1, result_type: Date, source_id: 3
-                      CONSTANT id: 15, constant_value: \'1994-01-01\', constant_value_type: String
-          FUNCTION id: 16, function_name: and, function_type: ordinary, result_type: UInt8
+                      COLUMN id: 10, column_name: date1, result_type: Date, source_id: 3
+                      CONSTANT id: 14, constant_value: \'1994-01-01\', constant_value_type: String
+          FUNCTION id: 15, function_name: and, function_type: ordinary, result_type: UInt8
             ARGUMENTS
-              LIST id: 17, nodes: 2
-                FUNCTION id: 18, function_name: greaterOrEquals, function_type: ordinary, result_type: UInt8
+              LIST id: 16, nodes: 2
+                FUNCTION id: 17, function_name: greaterOrEquals, function_type: ordinary, result_type: UInt8
                   ARGUMENTS
-                    LIST id: 19, nodes: 2
-                      COLUMN id: 20, column_name: id, result_type: UInt32, source_id: 3
-                      CONSTANT id: 21, constant_value: UInt64_1, constant_value_type: UInt8
-                FUNCTION id: 22, function_name: lessOrEquals, function_type: ordinary, result_type: UInt8
+                    LIST id: 18, nodes: 2
+                      COLUMN id: 19, column_name: id, result_type: UInt32, source_id: 3
+                      CONSTANT id: 20, constant_value: UInt64_1, constant_value_type: UInt8
+                FUNCTION id: 21, function_name: lessOrEquals, function_type: ordinary, result_type: UInt8
                   ARGUMENTS
-                    LIST id: 23, nodes: 2
-                      COLUMN id: 20, column_name: id, result_type: UInt32, source_id: 3
-                      CONSTANT id: 24, constant_value: UInt64_3, constant_value_type: UInt8
+                    LIST id: 22, nodes: 2
+                      COLUMN id: 19, column_name: id, result_type: UInt32, source_id: 3
+                      CONSTANT id: 23, constant_value: UInt64_3, constant_value_type: UInt8
   SETTINGS allow_experimental_analyzer=1
 SELECT value1
 FROM date_t
@@ -244,21 +244,21 @@ QUERY id: 0
                 FUNCTION id: 12, function_name: less, function_type: ordinary, result_type: UInt8
                   ARGUMENTS
                     LIST id: 13, nodes: 2
-                      COLUMN id: 14, column_name: date1, result_type: Date, source_id: 3
-                      CONSTANT id: 15, constant_value: \'1998-01-01\', constant_value_type: String
-          FUNCTION id: 16, function_name: and, function_type: ordinary, result_type: UInt8
+                      COLUMN id: 10, column_name: date1, result_type: Date, source_id: 3
+                      CONSTANT id: 14, constant_value: \'1998-01-01\', constant_value_type: String
+          FUNCTION id: 15, function_name: and, function_type: ordinary, result_type: UInt8
             ARGUMENTS
-              LIST id: 17, nodes: 2
-                FUNCTION id: 18, function_name: greaterOrEquals, function_type: ordinary, result_type: UInt8
+              LIST id: 16, nodes: 2
+                FUNCTION id: 17, function_name: greaterOrEquals, function_type: ordinary, result_type: UInt8
                   ARGUMENTS
-                    LIST id: 19, nodes: 2
-                      COLUMN id: 20, column_name: id, result_type: UInt32, source_id: 3
-                      CONSTANT id: 21, constant_value: UInt64_1, constant_value_type: UInt8
-                FUNCTION id: 22, function_name: lessOrEquals, function_type: ordinary, result_type: UInt8
+                    LIST id: 18, nodes: 2
+                      COLUMN id: 19, column_name: id, result_type: UInt32, source_id: 3
+                      CONSTANT id: 20, constant_value: UInt64_1, constant_value_type: UInt8
+                FUNCTION id: 21, function_name: lessOrEquals, function_type: ordinary, result_type: UInt8
                   ARGUMENTS
-                    LIST id: 23, nodes: 2
-                      COLUMN id: 20, column_name: id, result_type: UInt32, source_id: 3
-                      CONSTANT id: 24, constant_value: UInt64_3, constant_value_type: UInt8
+                    LIST id: 22, nodes: 2
+                      COLUMN id: 19, column_name: id, result_type: UInt32, source_id: 3
+                      CONSTANT id: 23, constant_value: UInt64_3, constant_value_type: UInt8
   SETTINGS allow_experimental_analyzer=1
 SELECT value1
 FROM date_t
@@ -289,34 +289,34 @@ QUERY id: 0
                       FUNCTION id: 14, function_name: less, function_type: ordinary, result_type: UInt8
                         ARGUMENTS
                           LIST id: 15, nodes: 2
-                            COLUMN id: 16, column_name: date1, result_type: Date, source_id: 3
-                            CONSTANT id: 17, constant_value: \'1994-01-01\', constant_value_type: String
-                FUNCTION id: 18, function_name: and, function_type: ordinary, result_type: UInt8
+                            COLUMN id: 12, column_name: date1, result_type: Date, source_id: 3
+                            CONSTANT id: 16, constant_value: \'1994-01-01\', constant_value_type: String
+                FUNCTION id: 17, function_name: and, function_type: ordinary, result_type: UInt8
                   ARGUMENTS
-                    LIST id: 19, nodes: 2
-                      FUNCTION id: 20, function_name: greaterOrEquals, function_type: ordinary, result_type: UInt8
+                    LIST id: 18, nodes: 2
+                      FUNCTION id: 19, function_name: greaterOrEquals, function_type: ordinary, result_type: UInt8
                         ARGUMENTS
-                          LIST id: 21, nodes: 2
-                            COLUMN id: 22, column_name: date1, result_type: Date, source_id: 3
-                            CONSTANT id: 23, constant_value: \'1994-01-01\', constant_value_type: String
-                      FUNCTION id: 24, function_name: less, function_type: ordinary, result_type: UInt8
+                          LIST id: 20, nodes: 2
+                            COLUMN id: 12, column_name: date1, result_type: Date, source_id: 3
+                            CONSTANT id: 21, constant_value: \'1994-01-01\', constant_value_type: String
+                      FUNCTION id: 22, function_name: less, function_type: ordinary, result_type: UInt8
                         ARGUMENTS
-                          LIST id: 25, nodes: 2
-                            COLUMN id: 26, column_name: date1, result_type: Date, source_id: 3
-                            CONSTANT id: 27, constant_value: \'1995-01-01\', constant_value_type: String
-          FUNCTION id: 28, function_name: and, function_type: ordinary, result_type: UInt8
+                          LIST id: 23, nodes: 2
+                            COLUMN id: 12, column_name: date1, result_type: Date, source_id: 3
+                            CONSTANT id: 24, constant_value: \'1995-01-01\', constant_value_type: String
+          FUNCTION id: 25, function_name: and, function_type: ordinary, result_type: UInt8
             ARGUMENTS
-              LIST id: 29, nodes: 2
-                FUNCTION id: 30, function_name: greaterOrEquals, function_type: ordinary, result_type: UInt8
+              LIST id: 26, nodes: 2
+                FUNCTION id: 27, function_name: greaterOrEquals, function_type: ordinary, result_type: UInt8
                   ARGUMENTS
-                    LIST id: 31, nodes: 2
-                      COLUMN id: 32, column_name: id, result_type: UInt32, source_id: 3
-                      CONSTANT id: 33, constant_value: UInt64_1, constant_value_type: UInt8
-                FUNCTION id: 34, function_name: lessOrEquals, function_type: ordinary, result_type: UInt8
+                    LIST id: 28, nodes: 2
+                      COLUMN id: 29, column_name: id, result_type: UInt32, source_id: 3
+                      CONSTANT id: 30, constant_value: UInt64_1, constant_value_type: UInt8
+                FUNCTION id: 31, function_name: lessOrEquals, function_type: ordinary, result_type: UInt8
                   ARGUMENTS
-                    LIST id: 35, nodes: 2
-                      COLUMN id: 32, column_name: id, result_type: UInt32, source_id: 3
-                      CONSTANT id: 36, constant_value: UInt64_3, constant_value_type: UInt8
+                    LIST id: 32, nodes: 2
+                      COLUMN id: 29, column_name: id, result_type: UInt32, source_id: 3
+                      CONSTANT id: 33, constant_value: UInt64_3, constant_value_type: UInt8
   SETTINGS allow_experimental_analyzer=1
 SELECT
     value1,
@@ -346,26 +346,26 @@ QUERY id: 0
                 FUNCTION id: 11, function_name: greaterOrEquals, function_type: ordinary, result_type: UInt8
                   ARGUMENTS
                     LIST id: 12, nodes: 2
-                      COLUMN id: 13, column_name: date1, result_type: Date, source_id: 3
-                      CONSTANT id: 14, constant_value: \'1993-01-01\', constant_value_type: String
-                FUNCTION id: 15, function_name: less, function_type: ordinary, result_type: UInt8
+                      COLUMN id: 6, column_name: date1, result_type: Date, source_id: 3
+                      CONSTANT id: 13, constant_value: \'1993-01-01\', constant_value_type: String
+                FUNCTION id: 14, function_name: less, function_type: ordinary, result_type: UInt8
                   ARGUMENTS
-                    LIST id: 16, nodes: 2
-                      COLUMN id: 17, column_name: date1, result_type: Date, source_id: 3
-                      CONSTANT id: 18, constant_value: \'1994-01-01\', constant_value_type: String
-          FUNCTION id: 19, function_name: and, function_type: ordinary, result_type: UInt8
+                    LIST id: 15, nodes: 2
+                      COLUMN id: 6, column_name: date1, result_type: Date, source_id: 3
+                      CONSTANT id: 16, constant_value: \'1994-01-01\', constant_value_type: String
+          FUNCTION id: 17, function_name: and, function_type: ordinary, result_type: UInt8
             ARGUMENTS
-              LIST id: 20, nodes: 2
-                FUNCTION id: 21, function_name: greaterOrEquals, function_type: ordinary, result_type: UInt8
+              LIST id: 18, nodes: 2
+                FUNCTION id: 19, function_name: greaterOrEquals, function_type: ordinary, result_type: UInt8
                   ARGUMENTS
-                    LIST id: 22, nodes: 2
-                      COLUMN id: 23, column_name: id, result_type: UInt32, source_id: 3
-                      CONSTANT id: 24, constant_value: UInt64_1, constant_value_type: UInt8
-                FUNCTION id: 25, function_name: lessOrEquals, function_type: ordinary, result_type: UInt8
+                    LIST id: 20, nodes: 2
+                      COLUMN id: 21, column_name: id, result_type: UInt32, source_id: 3
+                      CONSTANT id: 22, constant_value: UInt64_1, constant_value_type: UInt8
+                FUNCTION id: 23, function_name: lessOrEquals, function_type: ordinary, result_type: UInt8
                   ARGUMENTS
-                    LIST id: 26, nodes: 2
-                      COLUMN id: 23, column_name: id, result_type: UInt32, source_id: 3
-                      CONSTANT id: 27, constant_value: UInt64_3, constant_value_type: UInt8
+                    LIST id: 24, nodes: 2
+                      COLUMN id: 21, column_name: id, result_type: UInt32, source_id: 3
+                      CONSTANT id: 25, constant_value: UInt64_3, constant_value_type: UInt8
   SETTINGS allow_experimental_analyzer=1
 SELECT value1
 FROM date_t
@@ -425,22 +425,22 @@ QUERY id: 0
           FUNCTION id: 10, function_name: less, function_type: ordinary, result_type: UInt8
             ARGUMENTS
               LIST id: 11, nodes: 2
-                COLUMN id: 12, column_name: date1, result_type: Date, source_id: 3
-                CONSTANT id: 13, constant_value: \'1994-01-01\', constant_value_type: String
+                COLUMN id: 8, column_name: date1, result_type: Date, source_id: 3
+                CONSTANT id: 12, constant_value: \'1994-01-01\', constant_value_type: String
   WHERE
-    FUNCTION id: 14, function_name: and, function_type: ordinary, result_type: UInt8
+    FUNCTION id: 13, function_name: and, function_type: ordinary, result_type: UInt8
       ARGUMENTS
-        LIST id: 15, nodes: 2
-          FUNCTION id: 16, function_name: greaterOrEquals, function_type: ordinary, result_type: UInt8
+        LIST id: 14, nodes: 2
+          FUNCTION id: 15, function_name: greaterOrEquals, function_type: ordinary, result_type: UInt8
             ARGUMENTS
-              LIST id: 17, nodes: 2
-                COLUMN id: 18, column_name: id, result_type: UInt32, source_id: 3
-                CONSTANT id: 19, constant_value: UInt64_1, constant_value_type: UInt8
-          FUNCTION id: 20, function_name: lessOrEquals, function_type: ordinary, result_type: UInt8
+              LIST id: 16, nodes: 2
+                COLUMN id: 17, column_name: id, result_type: UInt32, source_id: 3
+                CONSTANT id: 18, constant_value: UInt64_1, constant_value_type: UInt8
+          FUNCTION id: 19, function_name: lessOrEquals, function_type: ordinary, result_type: UInt8
             ARGUMENTS
-              LIST id: 21, nodes: 2
-                COLUMN id: 18, column_name: id, result_type: UInt32, source_id: 3
-                CONSTANT id: 22, constant_value: UInt64_3, constant_value_type: UInt8
+              LIST id: 20, nodes: 2
+                COLUMN id: 17, column_name: id, result_type: UInt32, source_id: 3
+                CONSTANT id: 21, constant_value: UInt64_3, constant_value_type: UInt8
   SETTINGS allow_experimental_analyzer=1
 SELECT value1
 FROM date_t
@@ -479,8 +479,8 @@ QUERY id: 0
           FUNCTION id: 19, function_name: less, function_type: ordinary, result_type: UInt8
             ARGUMENTS
               LIST id: 20, nodes: 2
-                COLUMN id: 21, column_name: date1, result_type: Date, source_id: 3
-                CONSTANT id: 22, constant_value: \'1994-01-01\', constant_value_type: String
+                COLUMN id: 17, column_name: date1, result_type: Date, source_id: 3
+                CONSTANT id: 21, constant_value: \'1994-01-01\', constant_value_type: String
   SETTINGS allow_experimental_analyzer=1
 SELECT value1
 FROM date_t
@@ -582,21 +582,21 @@ QUERY id: 0
                 FUNCTION id: 12, function_name: less, function_type: ordinary, result_type: UInt8
                   ARGUMENTS
                     LIST id: 13, nodes: 2
-                      COLUMN id: 14, column_name: date1, result_type: Date, source_id: 3
-                      CONSTANT id: 15, constant_value: \'1994-01-01\', constant_value_type: String
-          FUNCTION id: 16, function_name: and, function_type: ordinary, result_type: UInt8
+                      COLUMN id: 10, column_name: date1, result_type: Date, source_id: 3
+                      CONSTANT id: 14, constant_value: \'1994-01-01\', constant_value_type: String
+          FUNCTION id: 15, function_name: and, function_type: ordinary, result_type: UInt8
             ARGUMENTS
-              LIST id: 17, nodes: 2
-                FUNCTION id: 18, function_name: greaterOrEquals, function_type: ordinary, result_type: UInt8
+              LIST id: 16, nodes: 2
+                FUNCTION id: 17, function_name: greaterOrEquals, function_type: ordinary, result_type: UInt8
                   ARGUMENTS
-                    LIST id: 19, nodes: 2
-                      COLUMN id: 20, column_name: id, result_type: UInt32, source_id: 3
-                      CONSTANT id: 21, constant_value: UInt64_1, constant_value_type: UInt8
-                FUNCTION id: 22, function_name: lessOrEquals, function_type: ordinary, result_type: UInt8
+                    LIST id: 18, nodes: 2
+                      COLUMN id: 19, column_name: id, result_type: UInt32, source_id: 3
+                      CONSTANT id: 20, constant_value: UInt64_1, constant_value_type: UInt8
+                FUNCTION id: 21, function_name: lessOrEquals, function_type: ordinary, result_type: UInt8
                   ARGUMENTS
-                    LIST id: 23, nodes: 2
-                      COLUMN id: 20, column_name: id, result_type: UInt32, source_id: 3
-                      CONSTANT id: 24, constant_value: UInt64_3, constant_value_type: UInt8
+                    LIST id: 22, nodes: 2
+                      COLUMN id: 19, column_name: id, result_type: UInt32, source_id: 3
+                      CONSTANT id: 23, constant_value: UInt64_3, constant_value_type: UInt8
   SETTINGS allow_experimental_analyzer=1
 SELECT value1
 FROM date_t
@@ -624,21 +624,21 @@ QUERY id: 0
                 FUNCTION id: 12, function_name: less, function_type: ordinary, result_type: UInt8
                   ARGUMENTS
                     LIST id: 13, nodes: 2
-                      COLUMN id: 14, column_name: date1, result_type: Date, source_id: 3
-                      CONSTANT id: 15, constant_value: \'1992-04-01\', constant_value_type: String
-          FUNCTION id: 16, function_name: and, function_type: ordinary, result_type: UInt8
+                      COLUMN id: 10, column_name: date1, result_type: Date, source_id: 3
+                      CONSTANT id: 14, constant_value: \'1992-04-01\', constant_value_type: String
+          FUNCTION id: 15, function_name: and, function_type: ordinary, result_type: UInt8
             ARGUMENTS
-              LIST id: 17, nodes: 2
-                FUNCTION id: 18, function_name: greaterOrEquals, function_type: ordinary, result_type: UInt8
+              LIST id: 16, nodes: 2
+                FUNCTION id: 17, function_name: greaterOrEquals, function_type: ordinary, result_type: UInt8
                   ARGUMENTS
-                    LIST id: 19, nodes: 2
-                      COLUMN id: 20, column_name: id, result_type: UInt32, source_id: 3
-                      CONSTANT id: 21, constant_value: UInt64_1, constant_value_type: UInt8
-                FUNCTION id: 22, function_name: lessOrEquals, function_type: ordinary, result_type: UInt8
+                    LIST id: 18, nodes: 2
+                      COLUMN id: 19, column_name: id, result_type: UInt32, source_id: 3
+                      CONSTANT id: 20, constant_value: UInt64_1, constant_value_type: UInt8
+                FUNCTION id: 21, function_name: lessOrEquals, function_type: ordinary, result_type: UInt8
                   ARGUMENTS
-                    LIST id: 23, nodes: 2
-                      COLUMN id: 20, column_name: id, result_type: UInt32, source_id: 3
-                      CONSTANT id: 24, constant_value: UInt64_3, constant_value_type: UInt8
+                    LIST id: 22, nodes: 2
+                      COLUMN id: 19, column_name: id, result_type: UInt32, source_id: 3
+                      CONSTANT id: 23, constant_value: UInt64_3, constant_value_type: UInt8
   SETTINGS allow_experimental_analyzer=1
 SELECT value1
 FROM date_t
@@ -666,21 +666,21 @@ QUERY id: 0
                 FUNCTION id: 12, function_name: greaterOrEquals, function_type: ordinary, result_type: UInt8
                   ARGUMENTS
                     LIST id: 13, nodes: 2
-                      COLUMN id: 14, column_name: date1, result_type: Date, source_id: 3
-                      CONSTANT id: 15, constant_value: \'1992-04-01\', constant_value_type: String
-          FUNCTION id: 16, function_name: and, function_type: ordinary, result_type: UInt8
+                      COLUMN id: 10, column_name: date1, result_type: Date, source_id: 3
+                      CONSTANT id: 14, constant_value: \'1992-04-01\', constant_value_type: String
+          FUNCTION id: 15, function_name: and, function_type: ordinary, result_type: UInt8
             ARGUMENTS
-              LIST id: 17, nodes: 2
-                FUNCTION id: 18, function_name: greaterOrEquals, function_type: ordinary, result_type: UInt8
+              LIST id: 16, nodes: 2
+                FUNCTION id: 17, function_name: greaterOrEquals, function_type: ordinary, result_type: UInt8
                   ARGUMENTS
-                    LIST id: 19, nodes: 2
-                      COLUMN id: 20, column_name: id, result_type: UInt32, source_id: 3
-                      CONSTANT id: 21, constant_value: UInt64_1, constant_value_type: UInt8
-                FUNCTION id: 22, function_name: lessOrEquals, function_type: ordinary, result_type: UInt8
+                    LIST id: 18, nodes: 2
+                      COLUMN id: 19, column_name: id, result_type: UInt32, source_id: 3
+                      CONSTANT id: 20, constant_value: UInt64_1, constant_value_type: UInt8
+                FUNCTION id: 21, function_name: lessOrEquals, function_type: ordinary, result_type: UInt8
                   ARGUMENTS
-                    LIST id: 23, nodes: 2
-                      COLUMN id: 20, column_name: id, result_type: UInt32, source_id: 3
-                      CONSTANT id: 24, constant_value: UInt64_3, constant_value_type: UInt8
+                    LIST id: 22, nodes: 2
+                      COLUMN id: 19, column_name: id, result_type: UInt32, source_id: 3
+                      CONSTANT id: 23, constant_value: UInt64_3, constant_value_type: UInt8
   SETTINGS allow_experimental_analyzer=1
 SELECT value1
 FROM date_t
@@ -847,26 +847,26 @@ QUERY id: 0
                       FUNCTION id: 14, function_name: greaterOrEquals, function_type: ordinary, result_type: UInt8
                         ARGUMENTS
                           LIST id: 15, nodes: 2
-                            COLUMN id: 16, column_name: date1, result_type: Date, source_id: 3
-                            CONSTANT id: 17, constant_value: \'1993-01-01\', constant_value_type: String
-                      FUNCTION id: 18, function_name: less, function_type: ordinary, result_type: UInt8
+                            COLUMN id: 10, column_name: date1, result_type: Date, source_id: 3
+                            CONSTANT id: 16, constant_value: \'1993-01-01\', constant_value_type: String
+                      FUNCTION id: 17, function_name: less, function_type: ordinary, result_type: UInt8
                         ARGUMENTS
-                          LIST id: 19, nodes: 2
-                            COLUMN id: 20, column_name: date1, result_type: Date, source_id: 3
-                            CONSTANT id: 21, constant_value: \'1994-01-01\', constant_value_type: String
-          FUNCTION id: 22, function_name: and, function_type: ordinary, result_type: UInt8
+                          LIST id: 18, nodes: 2
+                            COLUMN id: 10, column_name: date1, result_type: Date, source_id: 3
+                            CONSTANT id: 19, constant_value: \'1994-01-01\', constant_value_type: String
+          FUNCTION id: 20, function_name: and, function_type: ordinary, result_type: UInt8
             ARGUMENTS
-              LIST id: 23, nodes: 2
-                FUNCTION id: 24, function_name: greaterOrEquals, function_type: ordinary, result_type: UInt8
+              LIST id: 21, nodes: 2
+                FUNCTION id: 22, function_name: greaterOrEquals, function_type: ordinary, result_type: UInt8
                   ARGUMENTS
-                    LIST id: 25, nodes: 2
-                      COLUMN id: 26, column_name: id, result_type: UInt32, source_id: 3
-                      CONSTANT id: 27, constant_value: UInt64_1, constant_value_type: UInt8
-                FUNCTION id: 28, function_name: lessOrEquals, function_type: ordinary, result_type: UInt8
+                    LIST id: 23, nodes: 2
+                      COLUMN id: 24, column_name: id, result_type: UInt32, source_id: 3
+                      CONSTANT id: 25, constant_value: UInt64_1, constant_value_type: UInt8
+                FUNCTION id: 26, function_name: lessOrEquals, function_type: ordinary, result_type: UInt8
                   ARGUMENTS
-                    LIST id: 29, nodes: 2
-                      COLUMN id: 26, column_name: id, result_type: UInt32, source_id: 3
-                      CONSTANT id: 30, constant_value: UInt64_3, constant_value_type: UInt8
+                    LIST id: 27, nodes: 2
+                      COLUMN id: 24, column_name: id, result_type: UInt32, source_id: 3
+                      CONSTANT id: 28, constant_value: UInt64_3, constant_value_type: UInt8
   SETTINGS allow_experimental_analyzer=1
 SELECT value1
 FROM datetime_t
@@ -894,21 +894,21 @@ QUERY id: 0
                 FUNCTION id: 12, function_name: less, function_type: ordinary, result_type: UInt8
                   ARGUMENTS
                     LIST id: 13, nodes: 2
-                      COLUMN id: 14, column_name: date1, result_type: DateTime, source_id: 3
-                      CONSTANT id: 15, constant_value: \'1994-01-01 00:00:00\', constant_value_type: String
-          FUNCTION id: 16, function_name: and, function_type: ordinary, result_type: UInt8
+                      COLUMN id: 10, column_name: date1, result_type: DateTime, source_id: 3
+                      CONSTANT id: 14, constant_value: \'1994-01-01 00:00:00\', constant_value_type: String
+          FUNCTION id: 15, function_name: and, function_type: ordinary, result_type: UInt8
             ARGUMENTS
-              LIST id: 17, nodes: 2
-                FUNCTION id: 18, function_name: greaterOrEquals, function_type: ordinary, result_type: UInt8
+              LIST id: 16, nodes: 2
+                FUNCTION id: 17, function_name: greaterOrEquals, function_type: ordinary, result_type: UInt8
                   ARGUMENTS
-                    LIST id: 19, nodes: 2
-                      COLUMN id: 20, column_name: id, result_type: UInt32, source_id: 3
-                      CONSTANT id: 21, constant_value: UInt64_1, constant_value_type: UInt8
-                FUNCTION id: 22, function_name: lessOrEquals, function_type: ordinary, result_type: UInt8
+                    LIST id: 18, nodes: 2
+                      COLUMN id: 19, column_name: id, result_type: UInt32, source_id: 3
+                      CONSTANT id: 20, constant_value: UInt64_1, constant_value_type: UInt8
+                FUNCTION id: 21, function_name: lessOrEquals, function_type: ordinary, result_type: UInt8
                   ARGUMENTS
-                    LIST id: 23, nodes: 2
-                      COLUMN id: 20, column_name: id, result_type: UInt32, source_id: 3
-                      CONSTANT id: 24, constant_value: UInt64_3, constant_value_type: UInt8
+                    LIST id: 22, nodes: 2
+                      COLUMN id: 19, column_name: id, result_type: UInt32, source_id: 3
+                      CONSTANT id: 23, constant_value: UInt64_3, constant_value_type: UInt8
   SETTINGS allow_experimental_analyzer=1
 SELECT value1
 FROM datetime_t
@@ -936,21 +936,21 @@ QUERY id: 0
                 FUNCTION id: 12, function_name: less, function_type: ordinary, result_type: UInt8
                   ARGUMENTS
                     LIST id: 13, nodes: 2
-                      COLUMN id: 14, column_name: date1, result_type: DateTime, source_id: 3
-                      CONSTANT id: 15, constant_value: \'1994-01-01 00:00:00\', constant_value_type: String
-          FUNCTION id: 16, function_name: and, function_type: ordinary, result_type: UInt8
+                      COLUMN id: 10, column_name: date1, result_type: DateTime, source_id: 3
+                      CONSTANT id: 14, constant_value: \'1994-01-01 00:00:00\', constant_value_type: String
+          FUNCTION id: 15, function_name: and, function_type: ordinary, result_type: UInt8
             ARGUMENTS
-              LIST id: 17, nodes: 2
-                FUNCTION id: 18, function_name: greaterOrEquals, function_type: ordinary, result_type: UInt8
+              LIST id: 16, nodes: 2
+                FUNCTION id: 17, function_name: greaterOrEquals, function_type: ordinary, result_type: UInt8
                   ARGUMENTS
-                    LIST id: 19, nodes: 2
-                      COLUMN id: 20, column_name: id, result_type: UInt32, source_id: 3
-                      CONSTANT id: 21, constant_value: UInt64_1, constant_value_type: UInt8
-                FUNCTION id: 22, function_name: lessOrEquals, function_type: ordinary, result_type: UInt8
+                    LIST id: 18, nodes: 2
+                      COLUMN id: 19, column_name: id, result_type: UInt32, source_id: 3
+                      CONSTANT id: 20, constant_value: UInt64_1, constant_value_type: UInt8
+                FUNCTION id: 21, function_name: lessOrEquals, function_type: ordinary, result_type: UInt8
                   ARGUMENTS
-                    LIST id: 23, nodes: 2
-                      COLUMN id: 20, column_name: id, result_type: UInt32, source_id: 3
-                      CONSTANT id: 24, constant_value: UInt64_3, constant_value_type: UInt8
+                    LIST id: 22, nodes: 2
+                      COLUMN id: 19, column_name: id, result_type: UInt32, source_id: 3
+                      CONSTANT id: 23, constant_value: UInt64_3, constant_value_type: UInt8
   SETTINGS allow_experimental_analyzer=1
 SELECT value1
 FROM date32_t
@@ -978,21 +978,21 @@ QUERY id: 0
                 FUNCTION id: 12, function_name: less, function_type: ordinary, result_type: UInt8
                   ARGUMENTS
                     LIST id: 13, nodes: 2
-                      COLUMN id: 14, column_name: date1, result_type: Date32, source_id: 3
-                      CONSTANT id: 15, constant_value: \'1994-01-01\', constant_value_type: String
-          FUNCTION id: 16, function_name: and, function_type: ordinary, result_type: UInt8
+                      COLUMN id: 10, column_name: date1, result_type: Date32, source_id: 3
+                      CONSTANT id: 14, constant_value: \'1994-01-01\', constant_value_type: String
+          FUNCTION id: 15, function_name: and, function_type: ordinary, result_type: UInt8
             ARGUMENTS
-              LIST id: 17, nodes: 2
-                FUNCTION id: 18, function_name: greaterOrEquals, function_type: ordinary, result_type: UInt8
+              LIST id: 16, nodes: 2
+                FUNCTION id: 17, function_name: greaterOrEquals, function_type: ordinary, result_type: UInt8
                   ARGUMENTS
-                    LIST id: 19, nodes: 2
-                      COLUMN id: 20, column_name: id, result_type: UInt32, source_id: 3
-                      CONSTANT id: 21, constant_value: UInt64_1, constant_value_type: UInt8
-                FUNCTION id: 22, function_name: lessOrEquals, function_type: ordinary, result_type: UInt8
+                    LIST id: 18, nodes: 2
+                      COLUMN id: 19, column_name: id, result_type: UInt32, source_id: 3
+                      CONSTANT id: 20, constant_value: UInt64_1, constant_value_type: UInt8
+                FUNCTION id: 21, function_name: lessOrEquals, function_type: ordinary, result_type: UInt8
                   ARGUMENTS
-                    LIST id: 23, nodes: 2
-                      COLUMN id: 20, column_name: id, result_type: UInt32, source_id: 3
-                      CONSTANT id: 24, constant_value: UInt64_3, constant_value_type: UInt8
+                    LIST id: 22, nodes: 2
+                      COLUMN id: 19, column_name: id, result_type: UInt32, source_id: 3
+                      CONSTANT id: 23, constant_value: UInt64_3, constant_value_type: UInt8
   SETTINGS allow_experimental_analyzer=1
 SELECT value1
 FROM date32_t
@@ -1020,21 +1020,21 @@ QUERY id: 0
                 FUNCTION id: 12, function_name: less, function_type: ordinary, result_type: UInt8
                   ARGUMENTS
                     LIST id: 13, nodes: 2
-                      COLUMN id: 14, column_name: date1, result_type: Date32, source_id: 3
-                      CONSTANT id: 15, constant_value: \'1994-01-01\', constant_value_type: String
-          FUNCTION id: 16, function_name: and, function_type: ordinary, result_type: UInt8
+                      COLUMN id: 10, column_name: date1, result_type: Date32, source_id: 3
+                      CONSTANT id: 14, constant_value: \'1994-01-01\', constant_value_type: String
+          FUNCTION id: 15, function_name: and, function_type: ordinary, result_type: UInt8
             ARGUMENTS
-              LIST id: 17, nodes: 2
-                FUNCTION id: 18, function_name: greaterOrEquals, function_type: ordinary, result_type: UInt8
+              LIST id: 16, nodes: 2
+                FUNCTION id: 17, function_name: greaterOrEquals, function_type: ordinary, result_type: UInt8
                   ARGUMENTS
-                    LIST id: 19, nodes: 2
-                      COLUMN id: 20, column_name: id, result_type: UInt32, source_id: 3
-                      CONSTANT id: 21, constant_value: UInt64_1, constant_value_type: UInt8
-                FUNCTION id: 22, function_name: lessOrEquals, function_type: ordinary, result_type: UInt8
+                    LIST id: 18, nodes: 2
+                      COLUMN id: 19, column_name: id, result_type: UInt32, source_id: 3
+                      CONSTANT id: 20, constant_value: UInt64_1, constant_value_type: UInt8
+                FUNCTION id: 21, function_name: lessOrEquals, function_type: ordinary, result_type: UInt8
                   ARGUMENTS
-                    LIST id: 23, nodes: 2
-                      COLUMN id: 20, column_name: id, result_type: UInt32, source_id: 3
-                      CONSTANT id: 24, constant_value: UInt64_3, constant_value_type: UInt8
+                    LIST id: 22, nodes: 2
+                      COLUMN id: 19, column_name: id, result_type: UInt32, source_id: 3
+                      CONSTANT id: 23, constant_value: UInt64_3, constant_value_type: UInt8
   SETTINGS allow_experimental_analyzer=1
 SELECT value1
 FROM datetime64_t
@@ -1062,21 +1062,21 @@ QUERY id: 0
                 FUNCTION id: 12, function_name: less, function_type: ordinary, result_type: UInt8
                   ARGUMENTS
                     LIST id: 13, nodes: 2
-                      COLUMN id: 14, column_name: date1, result_type: DateTime64(3), source_id: 3
-                      CONSTANT id: 15, constant_value: \'1994-01-01 00:00:00\', constant_value_type: String
-          FUNCTION id: 16, function_name: and, function_type: ordinary, result_type: UInt8
+                      COLUMN id: 10, column_name: date1, result_type: DateTime64(3), source_id: 3
+                      CONSTANT id: 14, constant_value: \'1994-01-01 00:00:00\', constant_value_type: String
+          FUNCTION id: 15, function_name: and, function_type: ordinary, result_type: UInt8
             ARGUMENTS
-              LIST id: 17, nodes: 2
-                FUNCTION id: 18, function_name: greaterOrEquals, function_type: ordinary, result_type: UInt8
+              LIST id: 16, nodes: 2
+                FUNCTION id: 17, function_name: greaterOrEquals, function_type: ordinary, result_type: UInt8
                   ARGUMENTS
-                    LIST id: 19, nodes: 2
-                      COLUMN id: 20, column_name: id, result_type: UInt32, source_id: 3
-                      CONSTANT id: 21, constant_value: UInt64_1, constant_value_type: UInt8
-                FUNCTION id: 22, function_name: lessOrEquals, function_type: ordinary, result_type: UInt8
+                    LIST id: 18, nodes: 2
+                      COLUMN id: 19, column_name: id, result_type: UInt32, source_id: 3
+                      CONSTANT id: 20, constant_value: UInt64_1, constant_value_type: UInt8
+                FUNCTION id: 21, function_name: lessOrEquals, function_type: ordinary, result_type: UInt8
                   ARGUMENTS
-                    LIST id: 23, nodes: 2
-                      COLUMN id: 20, column_name: id, result_type: UInt32, source_id: 3
-                      CONSTANT id: 24, constant_value: UInt64_3, constant_value_type: UInt8
+                    LIST id: 22, nodes: 2
+                      COLUMN id: 19, column_name: id, result_type: UInt32, source_id: 3
+                      CONSTANT id: 23, constant_value: UInt64_3, constant_value_type: UInt8
   SETTINGS allow_experimental_analyzer=1
 SELECT value1
 FROM datetime64_t
@@ -1104,19 +1104,19 @@ QUERY id: 0
                 FUNCTION id: 12, function_name: less, function_type: ordinary, result_type: UInt8
                   ARGUMENTS
                     LIST id: 13, nodes: 2
-                      COLUMN id: 14, column_name: date1, result_type: DateTime64(3), source_id: 3
-                      CONSTANT id: 15, constant_value: \'1994-01-01 00:00:00\', constant_value_type: String
-          FUNCTION id: 16, function_name: and, function_type: ordinary, result_type: UInt8
+                      COLUMN id: 10, column_name: date1, result_type: DateTime64(3), source_id: 3
+                      CONSTANT id: 14, constant_value: \'1994-01-01 00:00:00\', constant_value_type: String
+          FUNCTION id: 15, function_name: and, function_type: ordinary, result_type: UInt8
             ARGUMENTS
-              LIST id: 17, nodes: 2
-                FUNCTION id: 18, function_name: greaterOrEquals, function_type: ordinary, result_type: UInt8
+              LIST id: 16, nodes: 2
+                FUNCTION id: 17, function_name: greaterOrEquals, function_type: ordinary, result_type: UInt8
                   ARGUMENTS
-                    LIST id: 19, nodes: 2
-                      COLUMN id: 20, column_name: id, result_type: UInt32, source_id: 3
-                      CONSTANT id: 21, constant_value: UInt64_1, constant_value_type: UInt8
-                FUNCTION id: 22, function_name: lessOrEquals, function_type: ordinary, result_type: UInt8
+                    LIST id: 18, nodes: 2
+                      COLUMN id: 19, column_name: id, result_type: UInt32, source_id: 3
+                      CONSTANT id: 20, constant_value: UInt64_1, constant_value_type: UInt8
+                FUNCTION id: 21, function_name: lessOrEquals, function_type: ordinary, result_type: UInt8
                   ARGUMENTS
-                    LIST id: 23, nodes: 2
-                      COLUMN id: 20, column_name: id, result_type: UInt32, source_id: 3
-                      CONSTANT id: 24, constant_value: UInt64_3, constant_value_type: UInt8
+                    LIST id: 22, nodes: 2
+                      COLUMN id: 19, column_name: id, result_type: UInt32, source_id: 3
+                      CONSTANT id: 23, constant_value: UInt64_3, constant_value_type: UInt8
   SETTINGS allow_experimental_analyzer=1

--- a/tests/queries/0_stateless/02999_analyzer_preimage_null.reference
+++ b/tests/queries/0_stateless/02999_analyzer_preimage_null.reference
@@ -108,14 +108,14 @@ QUERY id: 0
                 FUNCTION id: 14, function_name: greaterOrEquals, function_type: ordinary, result_type: UInt8
                   ARGUMENTS
                     LIST id: 15, nodes: 2
-                      COLUMN id: 16, column_name: date1, result_type: Date, source_id: 3
-                      CONSTANT id: 17, constant_value: \'1994-01-01\', constant_value_type: String
-          FUNCTION id: 18, function_name: lessOrEquals, function_type: ordinary, result_type: UInt8
+                      COLUMN id: 12, column_name: date1, result_type: Date, source_id: 3
+                      CONSTANT id: 16, constant_value: \'1994-01-01\', constant_value_type: String
+          FUNCTION id: 17, function_name: lessOrEquals, function_type: ordinary, result_type: UInt8
             ARGUMENTS
-              LIST id: 19, nodes: 2
-                COLUMN id: 20, column_name: id, result_type: UInt32, source_id: 3
-                FUNCTION id: 21, function_name: toYear, function_type: ordinary, result_type: UInt16
+              LIST id: 18, nodes: 2
+                COLUMN id: 19, column_name: id, result_type: UInt32, source_id: 3
+                FUNCTION id: 20, function_name: toYear, function_type: ordinary, result_type: UInt16
                   ARGUMENTS
-                    LIST id: 22, nodes: 1
-                      COLUMN id: 23, column_name: date1, result_type: Date, source_id: 3
+                    LIST id: 21, nodes: 1
+                      COLUMN id: 12, column_name: date1, result_type: Date, source_id: 3
   SETTINGS optimize_time_filter_with_preimage=1


### PR DESCRIPTION
The generateOptimizedDateFilter function is refactored to enhance the code readability. And this commit also fixes the duplicate creations of ColumnNode.

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
As the review comments in #52091 suggested, the implementation of date filter generation is not neat enough due to the duplicate code. In this refactoring work, we try to have `createFunctionNode` create a resolved function node with the given name and a variable number of arguments, so that the readability could be refined. And at the same time, we found that the original implementation may introduce potential issues by creating `ColumnNode` repeatedly with the same column source, leading to different `id` for the same column node. We've fixed this issue together with the `EXPLAIN QUERY TREE` tests.

The performance tests of SSB has shown that this code change would not lead to performance loss.

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
