### PR TITLE
Fix race in refreshable materialized views causing SELECT to fail sometimes

### DIFF
--- a/src/Storages/StorageMaterializedView.cpp
+++ b/src/Storages/StorageMaterializedView.cpp
@@ -153,7 +153,7 @@ StorageMaterializedView::StorageMaterializedView(
 
     if (query.refresh_strategy)
     {
-        fixed_uuid = query.refresh_strategy->append;
+        fixed_uuid = false;
         refresher = RefreshTask::create(
             *this,
             getContext(),

--- a/src/Storages/StorageMaterializedView.h
+++ b/src/Storages/StorageMaterializedView.h
@@ -111,6 +111,10 @@ private:
 
     bool has_inner_table = false;
 
+    /// If false, inner table is replaced on each refresh. In that case, target_table_id doesn't
+    /// have UUID, and we do inner table lookup by name instead.
+    bool fixed_uuid = true;
+
     friend class RefreshTask;
 
     void checkStatementCanBeForwarded() const;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Failed like this: https://s3.amazonaws.com/clickhouse-test-reports/60771/e4fb99245b9e86a2b9c1321523ad484e2e3cff40/stateless_tests_flaky_check__asan_.html

Refresh renames the table, then separately updates its uuid in MV's target_table_id field. If a SELECT happens in the brief moment between these two operations, it does a table lookup with outdated uuid.

https://github.com/ClickHouse/ClickHouse/pull/60669 already fixes this, but it'll be a while until it's reviewed, so here's a smaller PR with a minimal fix.