### PR TITLE
Throw on query timeout in ZooKeeperRetries

### DIFF
--- a/src/Common/ZooKeeper/ZooKeeperRetries.h
+++ b/src/Common/ZooKeeper/ZooKeeperRetries.h
@@ -5,8 +5,6 @@
 #include <Common/ZooKeeper/KeeperException.h>
 #include <Common/logger_useful.h>
 
-#include <memory>
-
 namespace DB
 {
 
@@ -220,8 +218,8 @@ private:
             return false;
         }
 
-        if (process_list_element && !process_list_element->checkTimeLimitSoft())
-            return false;
+        if (process_list_element)
+            process_list_element->checkTimeLimit();
 
         /// retries
         logLastError("will retry due to error");


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Fixes https://github.com/ClickHouse/ClickHouse/issues/60882 and makes it better in general

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
