### PR TITLE
Fix groupArraySorted documentation

### DIFF
--- a/docs/en/sql-reference/aggregate-functions/reference/grouparraysorted.md
+++ b/docs/en/sql-reference/aggregate-functions/reference/grouparraysorted.md
@@ -14,8 +14,6 @@
 
  -   `N` – The number of elements to return.
 
- If the parameter is omitted, default value is the size of input.
-
  -   `column` – The value (Integer, String, Float and other Generic types).
 
  **Example**
@@ -36,13 +34,12 @@
  Gets all the String implementations of all numbers in column:
 
  ``` sql
-SELECT groupArraySorted(str) FROM (SELECT toString(number) as str FROM numbers(5));
+SELECT groupArraySorted(5)(str) FROM (SELECT toString(number) as str FROM numbers(5));
 
  ```
 
  ``` text
- ┌─groupArraySorted(str)────────┐
- │ ['0','1','2','3','4']        │
- └──────────────────────────────┘
+┌─groupArraySorted(5)(str)─┐
+│ ['0','1','2','3','4']    │
+└──────────────────────────┘
  ```
- 


### PR DESCRIPTION
### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

Closes https://github.com/ClickHouse/ClickHouse/issues/60923

The function initially (in an implementation that was reverted because it was buggy( had a default `N` parameter, but that's not true in the latest one.
