### PR TITLE
CI: remove sqllancer, sqllogic, sqltest from pr wf

### DIFF
--- a/tests/ci/ci_config.py
+++ b/tests/ci/ci_config.py
@@ -473,21 +473,24 @@ perf_test_common_params = {
     "digest": perf_check_digest,
     "run_command": "performance_comparison_check.py",
 }
-sqllancer_test_common_params = {
-    "digest": sqllancer_check_digest,
-    "run_command": "sqlancer_check.py",
-    "run_always": True,
-}
-sqllogic_test_params = {
-    "digest": sqllogic_check_digest,
-    "run_command": "sqllogic_test.py",
-    "timeout": 10800,
-}
-sql_test_params = {
-    "digest": sqltest_check_digest,
-    "run_command": "sqltest.py",
-    "timeout": 10800,
-}
+sqllancer_test_common_params = JobConfig(
+    digest=sqllancer_check_digest,
+    run_command="sqlancer_check.py",
+    release_only=True,
+    run_always=True,
+)
+sqllogic_test_params = JobConfig(
+    digest=sqllogic_check_digest,
+    run_command="sqllogic_test.py",
+    timeout=10800,
+    release_only=True,
+)
+sql_test_params = JobConfig(
+    digest=sqltest_check_digest,
+    run_command="sqltest.py",
+    timeout=10800,
+    release_only=True,
+)
 clickbench_test_params = {
     "digest": DigestConfig(
         include_paths=[
@@ -1256,17 +1259,15 @@ CI_CONFIG = CIConfig(
             job_config=JobConfig(num_batches=4, run_by_label="pr-performance", **perf_test_common_params),  # type: ignore
         ),
         JobNames.SQLANCER: TestConfig(
-            Build.PACKAGE_RELEASE, job_config=JobConfig(**sqllancer_test_common_params)  # type: ignore
+            Build.PACKAGE_RELEASE, job_config=sqllancer_test_common_params
         ),
         JobNames.SQLANCER_DEBUG: TestConfig(
-            Build.PACKAGE_DEBUG, job_config=JobConfig(**sqllancer_test_common_params)  # type: ignore
+            Build.PACKAGE_DEBUG, job_config=sqllancer_test_common_params
         ),
         JobNames.SQL_LOGIC_TEST: TestConfig(
-            Build.PACKAGE_RELEASE, job_config=JobConfig(**sqllogic_test_params)  # type: ignore
+            Build.PACKAGE_RELEASE, job_config=sqllogic_test_params
         ),
-        JobNames.SQLTEST: TestConfig(
-            Build.PACKAGE_RELEASE, job_config=JobConfig(**sql_test_params)  # type: ignore
-        ),
+        JobNames.SQLTEST: TestConfig(Build.PACKAGE_RELEASE, job_config=sql_test_params),
         JobNames.CLCIKBENCH_TEST: TestConfig(
             Build.PACKAGE_RELEASE, job_config=JobConfig(**clickbench_test_params)  # type: ignore
         ),


### PR DESCRIPTION
 #no_ci_cache

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
