### PR TITLE
Fix TableFunctionExecutable::skipAnalysisForArguments

### DIFF
--- a/src/TableFunctions/TableFunctionExecutable.cpp
+++ b/src/TableFunctions/TableFunctionExecutable.cpp
@@ -71,6 +71,9 @@ std::vector<size_t> TableFunctionExecutable::skipAnalysisForArguments(const Quer
     const auto & table_function_node_arguments = table_function_node.getArguments().getNodes();
     size_t table_function_node_arguments_size = table_function_node_arguments.size();
 
+    if (table_function_node_arguments_size <= 2)
+        return {};
+
     std::vector<size_t> result_indexes;
     result_indexes.reserve(table_function_node_arguments_size - 2);
     for (size_t i = 2; i < table_function_node_arguments_size; ++i)

--- a/tests/queries/0_stateless/03006_analyzer_executable_table_function.sql
+++ b/tests/queries/0_stateless/03006_analyzer_executable_table_function.sql
@@ -1,0 +1,4 @@
+SELECT
+    toFixedString(toFixedString(toLowCardinality(toFixedString('--------------------', toNullable(20))), toLowCardinality(20)), 20),
+    *
+FROM executable('data String', SETTINGS max_command_execution_time = 100); -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH}


### PR DESCRIPTION
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Closes #60760.