### PR TITLE
Fix `test_placement_info`

### DIFF
--- a/tests/integration/helpers/mock_servers.py
+++ b/tests/integration/helpers/mock_servers.py
@@ -33,7 +33,7 @@ def start_mock_servers(cluster, script_dir, mocks, timeout=100):
 
         cluster.exec_in_container(
             container_id,
-            ["python", server_name, str(port)],
+            ["python3", server_name, str(port)],
             detach=True,
         )
 

--- a/tests/integration/test_placement_info/configs/imds_bootstrap.xml
+++ b/tests/integration/test_placement_info/configs/imds_bootstrap.xml
@@ -1,0 +1,9 @@
+<clickhouse>
+    <s3>
+        <use_environment_credentials>1</use_environment_credentials>
+    </s3>
+    <placement>
+        <use_imds>0</use_imds>
+        <availability_zone>ci-placeholder</availability_zone>
+    </placement>
+</clickhouse>

--- a/tests/integration/test_placement_info/test.py
+++ b/tests/integration/test_placement_info/test.py
@@ -2,16 +2,14 @@ import pytest
 from helpers.cluster import ClickHouseCluster
 from helpers.mock_servers import start_mock_servers
 import os
-import time
 
-METADATA_SERVER_HOSTNAME = "resolver"
+METADATA_SERVER_HOSTNAME = "node_imds"
 METADATA_SERVER_PORT = 8080
 
 cluster = ClickHouseCluster(__file__)
 node_imds = cluster.add_instance(
     "node_imds",
-    with_minio=True,
-    main_configs=["configs/imds.xml"],
+    main_configs=["configs/imds_bootstrap.xml"],
     env_variables={
         "AWS_EC2_METADATA_SERVICE_ENDPOINT": f"http://{METADATA_SERVER_HOSTNAME}:{METADATA_SERVER_PORT}",
     },
@@ -32,10 +30,10 @@ node_missing_value = cluster.add_instance(
 )
 
 
-def start_metadata_server():
+def start_metadata_server(started_cluster):
     script_dir = os.path.join(os.path.dirname(__file__), "metadata_servers")
     start_mock_servers(
-        cluster,
+        started_cluster,
         script_dir,
         [
             (
@@ -51,13 +49,15 @@ def start_metadata_server():
 def start_cluster():
     try:
         cluster.start()
-        start_metadata_server()
-        yield
+        start_metadata_server(cluster)
+        yield cluster
     finally:
         cluster.shutdown()
 
 
 def test_placement_info_from_imds():
+    with open(os.path.join(os.path.dirname(__file__), "configs/imds.xml"), "r") as f:
+        node_imds.replace_config("/etc/clickhouse-server/config.d/imds.xml", f.read())
     node_imds.stop_clickhouse(kill=True)
     node_imds.start_clickhouse()
 

--- a/tests/integration/test_placement_info/test.py
+++ b/tests/integration/test_placement_info/test.py
@@ -57,7 +57,9 @@ def start_cluster():
 
 def test_placement_info_from_imds():
     with open(os.path.join(os.path.dirname(__file__), "configs/imds.xml"), "r") as f:
-        node_imds.replace_config("/etc/clickhouse-server/config.d/imds_bootstrap.xml", f.read())
+        node_imds.replace_config(
+            "/etc/clickhouse-server/config.d/imds_bootstrap.xml", f.read()
+        )
     node_imds.stop_clickhouse(kill=True)
     node_imds.start_clickhouse()
 

--- a/tests/integration/test_placement_info/test.py
+++ b/tests/integration/test_placement_info/test.py
@@ -57,7 +57,7 @@ def start_cluster():
 
 def test_placement_info_from_imds():
     with open(os.path.join(os.path.dirname(__file__), "configs/imds.xml"), "r") as f:
-        node_imds.replace_config("/etc/clickhouse-server/config.d/imds.xml", f.read())
+        node_imds.replace_config("/etc/clickhouse-server/config.d/imds_bootstrap.xml", f.read())
     node_imds.stop_clickhouse(kill=True)
     node_imds.start_clickhouse()
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

