### PR TITLE
Debug fuzzer failures

### DIFF
--- a/docker/test/fuzzer/run-fuzzer.sh
+++ b/docker/test/fuzzer/run-fuzzer.sh
@@ -345,7 +345,7 @@ quit
         echo "failure" > status.txt
         { rg -ao "Found error:.*" fuzzer.log \
             || rg -ao "Exception:.*" fuzzer.log \
-            || echo "Fuzzer failed ($fuzzer_exit_code). See the logs." ; } \
+            || echo "Fuzzer fucked up with error code: ($fuzzer_exit_code). Its process died somehow when the server stayed alive. The server log probably won't tell you much so try to find information in other files." ; } \
             | tail -1 > description.txt
     fi
 

--- a/docker/test/fuzzer/run-fuzzer.sh
+++ b/docker/test/fuzzer/run-fuzzer.sh
@@ -343,10 +343,9 @@ quit
         # which is confusing.
         task_exit_code=$fuzzer_exit_code
         echo "failure" > status.txt
-        { rg -ao "Found error:.*" fuzzer.log \
-            || rg -ao "Exception:.*" fuzzer.log \
-            || echo "Fuzzer fucked up with error code: ($fuzzer_exit_code). Its process died somehow when the server stayed alive. The server log probably won't tell you much so try to find information in other files." ; } \
-            | tail -1 > description.txt
+        echo "Achtung!" > description.txt
+        echo "Fuzzer went wrong with error code: ($fuzzer_exit_code). Its process died somehow when the server stayed alive. The server log probably won't tell you much so try to find information in other files." >>description.txt
+        { rg -ao "Found error:.*" fuzzer.log || rg -ao "Exception:.*" fuzzer.log; } | tail -1 >>description.txt
     fi
 
     if test -f core.*; then

--- a/src/Parsers/ASTAlterQuery.cpp
+++ b/src/Parsers/ASTAlterQuery.cpp
@@ -634,6 +634,7 @@ void ASTAlterQuery::formatQueryImpl(const FormatSettings & settings, FormatState
             settings.ostr << '.';
         }
 
+        chassert(table);
         table->formatImpl(settings, state, frame);
     }
     else if (alter_object == AlterObjectType::DATABASE && database)

--- a/src/Parsers/ASTCheckQuery.h
+++ b/src/Parsers/ASTCheckQuery.h
@@ -53,6 +53,7 @@ protected:
                 settings.ostr << '.';
             }
 
+            chassert(table);
             table->formatImpl(settings, state, frame);
         }
 

--- a/src/Parsers/ASTCreateIndexQuery.cpp
+++ b/src/Parsers/ASTCreateIndexQuery.cpp
@@ -52,6 +52,7 @@ void ASTCreateIndexQuery::formatQueryImpl(const FormatSettings & settings, Forma
             settings.ostr << '.';
         }
 
+        chassert(table);
         table->formatImpl(settings, state, frame);
     }
 

--- a/src/Parsers/ASTCreateQuery.cpp
+++ b/src/Parsers/ASTCreateQuery.cpp
@@ -337,6 +337,7 @@ void ASTCreateQuery::formatQueryImpl(const FormatSettings & settings, FormatStat
             settings.ostr << '.';
         }
 
+        chassert(table);
         table->formatImpl(settings, state, frame);
 
         if (uuid != UUIDHelpers::Nil)
@@ -370,6 +371,7 @@ void ASTCreateQuery::formatQueryImpl(const FormatSettings & settings, FormatStat
             settings.ostr << '.';
         }
 
+        chassert(table);
         table->formatImpl(settings, state, frame);
 
         if (uuid != UUIDHelpers::Nil)

--- a/src/Parsers/ASTDeleteQuery.cpp
+++ b/src/Parsers/ASTDeleteQuery.cpp
@@ -40,6 +40,7 @@ void ASTDeleteQuery::formatQueryImpl(const FormatSettings & settings, FormatStat
         settings.ostr << '.';
     }
 
+    chassert(table);
     table->formatImpl(settings, state, frame);
 
     formatOnCluster(settings);

--- a/src/Parsers/ASTDropIndexQuery.cpp
+++ b/src/Parsers/ASTDropIndexQuery.cpp
@@ -47,6 +47,7 @@ void ASTDropIndexQuery::formatQueryImpl(const FormatSettings & settings, FormatS
             settings.ostr << '.';
         }
 
+        chassert(table);
         table->formatImpl(settings, state, frame);
     }
 

--- a/src/Parsers/ASTDropQuery.cpp
+++ b/src/Parsers/ASTDropQuery.cpp
@@ -76,6 +76,7 @@ void ASTDropQuery::formatQueryImpl(const FormatSettings & settings, FormatState 
             settings.ostr << '.';
         }
 
+        chassert(table);
         table->formatImpl(settings, state, frame);
     }
 

--- a/src/Parsers/ASTInsertQuery.cpp
+++ b/src/Parsers/ASTInsertQuery.cpp
@@ -74,6 +74,7 @@ void ASTInsertQuery::formatImpl(const FormatSettings & settings, FormatState & s
             settings.ostr << '.';
         }
 
+        chassert(table);
         table->formatImpl(settings, state, frame);
     }
 

--- a/src/Parsers/ASTOptimizeQuery.cpp
+++ b/src/Parsers/ASTOptimizeQuery.cpp
@@ -15,6 +15,7 @@ void ASTOptimizeQuery::formatQueryImpl(const FormatSettings & settings, FormatSt
         settings.ostr << '.';
     }
 
+    chassert(table);
     table->formatImpl(settings, state, frame);
 
     formatOnCluster(settings);

--- a/src/Parsers/ASTQueryWithTableAndOutput.h
+++ b/src/Parsers/ASTQueryWithTableAndOutput.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "base/defines.h"
+#include <base/defines.h>
 #include <Parsers/IAST.h>
 #include <Parsers/ASTQueryWithOutput.h>
 #include <Core/UUID.h>

--- a/src/Parsers/ASTQueryWithTableAndOutput.h
+++ b/src/Parsers/ASTQueryWithTableAndOutput.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "base/defines.h"
 #include <Parsers/IAST.h>
 #include <Parsers/ASTQueryWithOutput.h>
 #include <Core/UUID.h>
@@ -61,6 +62,7 @@ protected:
             settings.ostr << '.';
         }
 
+        chassert(table);
         table->formatImpl(settings, state, frame);
     }
 };

--- a/src/Parsers/ASTRenameQuery.h
+++ b/src/Parsers/ASTRenameQuery.h
@@ -127,6 +127,7 @@ protected:
                 settings.ostr << '.';
             }
 
+            chassert(it->from.table);
             it->from.table->formatImpl(settings, state, frame);
 
             settings.ostr << (settings.hilite ? hilite_keyword : "") << (exchange ? " AND " : " TO ") << (settings.hilite ? hilite_none : "");
@@ -137,6 +138,7 @@ protected:
                 settings.ostr << '.';
             }
 
+            chassert(it->to.table);
             it->to.table->formatImpl(settings, state, frame);
 
         }

--- a/src/Parsers/ASTSystemQuery.cpp
+++ b/src/Parsers/ASTSystemQuery.cpp
@@ -114,6 +114,7 @@ void ASTSystemQuery::formatImpl(const FormatSettings & settings, FormatState & s
             settings.ostr << '.';
         }
 
+        chassert(table);
         table->formatImpl(settings, state, frame);
         return settings.ostr;
     };

--- a/src/Parsers/ASTUndropQuery.cpp
+++ b/src/Parsers/ASTUndropQuery.cpp
@@ -36,6 +36,7 @@ void ASTUndropQuery::formatQueryImpl(const FormatSettings & settings, FormatStat
             settings.ostr << '.';
         }
 
+        chassert(table);
         table->formatImpl(settings, state, frame);
     }
 

--- a/src/Parsers/ASTWatchQuery.h
+++ b/src/Parsers/ASTWatchQuery.h
@@ -52,6 +52,7 @@ protected:
             settings.ostr << '.';
         }
 
+        chassert(table);
         table->formatImpl(settings, state, frame);
 
         if (is_watch_events)


### PR DESCRIPTION
Attempt to debug fuzzer failures like this: https://s3.amazonaws.com/clickhouse-test-reports/61058/7365da9293adf2b63bef173769e171581d727d82/ast_fuzzer__debug_.html

The logs say nothing to me and looks like this code path was triggered https://github.com/ClickHouse/ClickHouse/blob/12ecfbb0d02c83f61a39668ac730ab0021fd5b9b/docker/test/fuzzer/run-fuzzer.sh#L332-L343

There was an attempt to run the fuzzer itself under GDB https://github.com/ClickHouse/ClickHouse/pull/60654 but even after this change the nothing was clear, moreover the GDB says there was `No stack`.

```
2024-03-07 22:10:50	 + task_exit_code=134
2024-03-07 22:10:50	 + echo failure
2024-03-07 22:10:50	 script.gdb:13: Error in sourced command file:
2024-03-07 22:10:50	 No stack.
```

Trying to debug core itself: 
```
Core was generated by `clickhouse-client --max_memory_usage_in_client=1000000000 --receive_timeout=10'.
Program terminated with signal SIGABRT, Aborted.

warning: Unexpected size of section `.reg-xstate/1298' in core file.
#0  0x00007f78530bd9fc in ?? ()
[Current thread is 1 (LWP 1298)]
(gdb) bt
#0  0x00007f78530bd9fc in ?? ()
#1  0xa5a5a5a5a5a5a5a5 in ?? ()
#2  0xa5a5a5a5a5a5a5a5 in ?? ()
#3  0xa5a5a5a5a5a5a5a5 in ?? ()
#4  0xa5a5a5a5a5a5a5a5 in ?? ()
#5  0xa5a5a5a5a5a5a5a5 in ?? ()
#6  0xa5a5a5a5a5a5a5a5 in ?? ()
#7  0xa5a5a5a5a5a5a5a5 in ?? ()
#8  0xa5a5a5a5a5a5a5a5 in ?? ()
#9  0xa5a5a5a5a5a5a5a5 in ?? ()
#10 0xa5a5a5a5a5a5a5a5 in ?? ()
#11 0xa5a5a5a5a5a5a5a5 in ?? ()
#12 0xa5a5a5a5a5a5a5a5 in ?? ()
#13 0xa5a5a5a5a5a5a5a5 in ?? ()
#14 0xa5a5a5a5a5a5a5a5 in ?? ()
#15 0xa5a5a5a5a5a5a5a5 in ?? ()
#16 0xa5a5a5a5a5a5a5a5 in ?? ()
#17 0xa5a5a5a5a5a5a5a5 in ?? ()
#18 0x146cdf2028fc2400 in ?? ()
#19 0x00007f7852f37280 in ?? ()
#20 0x0000000000000006 in ?? ()
#21 0x00007ffc12d034c8 in ?? ()
#22 0x000000000a9d6980 in ?? ()
#23 0x0000000000000000 in ?? ()
```

However this trick helped: 
```
Core was generated by `clickhouse-client --max_memory_usage_in_client=1000000000 --receive_timeout=10'.
Program terminated with signal SIGABRT, Aborted.

warning: Unexpected size of section `.reg-xstate/1298' in core file.
#0  0x00007f78530bd9fc in ?? ()
[Current thread is 1 (LWP 1298)]
(gdb) file clickhouse
warning: exec file is newer than core file.
Reading symbols from clickhouse...
warning: Unexpected size of section `.reg-xstate/1298' in core file.
(gdb) set solib-search-path "/lib:/usr/lib/llvm/lib"
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
(gdb) bt
#0  __pthread_kill_implementation (no_tid=0, signo=6, threadid=140154764489344) at ./nptl/pthread_kill.c:44
#1  __pthread_kill_internal (signo=6, threadid=140154764489344) at ./nptl/pthread_kill.c:78
#2  __GI___pthread_kill (threadid=140154764489344, signo=signo@entry=6) at ./nptl/pthread_kill.c:89
#3  0x00007f7853069476 in __GI_raise (sig=sig@entry=6) at ../sysdeps/posix/raise.c:26
#4  0x00007f785304f7f3 in __GI_abort () at ./stdlib/abort.c:79
#5  0x0000000023382721 in Poco::SignalHandler::handleSignal (sig=11) at /build/base/poco/Foundation/src/SignalHandler.cpp:94
#6  <signal handler called>
#7  0x000000001ed2eeba in DB::ASTQueryWithTableAndOutputImpl<DB::ASTShowCreateDatabaseQueryIDAndQueryNames>::formatQueryImpl (this=0x7f7851c6b098, settings=..., state=..., frame=...)
    at /build/src/Parsers/ASTQueryWithTableAndOutput.h:64
#8  0x000000001ec4116f in DB::ASTQueryWithOutput::formatImpl (this=0x7f7851c6b098, s=..., state=..., frame=...) at /build/src/Parsers/ASTQueryWithOutput.cpp:40
#9  0x000000001baa556f in DB::IAST::format (this=0x7f7851c6b098, settings=...) at /build/src/Parsers/IAST.h:266
#10 0x000000001ecc9f0a in DB::IAST::formatWithPossiblyHidingSensitiveData (this=0x7f7851c6b098, max_length=0, one_line=true, show_secrets=false) at /build/src/Parsers/IAST.cpp:173
#11 0x000000001399d62c in DB::IAST::formatForErrorMessage (this=0x7f7851c6b098) at /build/src/Parsers/IAST.h:291
#12 0x0000000013992fee in DB::Client::processWithFuzzing (this=0x7ffc12cff590, full_query=...) at /build/programs/client/Client.cpp:818
#13 0x000000001dc2b355 in DB::ClientBase::executeMultiQuery (this=0x7ffc12cff590, all_queries_text=...) at /build/src/Client/ClientBase.cpp:2141
#14 0x000000001dc2cef5 in DB::ClientBase::processMultiQueryFromFile (this=0x7ffc12cff590, file_name=...) at /build/src/Client/ClientBase.cpp:2577
#15 0x000000001dc2f41a in DB::ClientBase::runNonInteractive (this=0x7ffc12cff590) at /build/src/Client/ClientBase.cpp:2594
#16 0x000000001398eb11 in DB::Client::main (this=0x7ffc12cff590) at /build/programs/client/Client.cpp:378
#17 0x00000000231d8705 in Poco::Util::Application::run (this=0x7ffc12cff590) at /build/base/poco/Util/src/Application.cpp:315
#18 0x000000001399ab09 in mainEntryClickHouseClient (argc=4765, argv=0x7f785236f600) at /build/programs/client/Client.cpp:1390
#19 0x000000000a9d6b82 in main (argc_=4765, argv_=0x7ffc12d034c8) at /build/programs/main.cpp:506
(gdb)
```

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
N/A
