### PR TITLE
Less contention in the cache, part 2 (radical)

### DIFF
--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -465,6 +465,7 @@ The server successfully detected this situation and will download merged part fr
     M(FilesystemCacheLockMetadataMicroseconds, "Lock filesystem cache metadata time") \
     M(FilesystemCacheLockCacheMicroseconds, "Lock filesystem cache time") \
     M(FilesystemCacheReserveMicroseconds, "Filesystem cache space reservation time") \
+    M(FilesystemCacheReserveLockFailed, "Filesystem cache space reservation didn't succeed due to the lock contention") \
     M(FilesystemCacheEvictMicroseconds, "Filesystem cache eviction time") \
     M(FilesystemCacheGetOrSetMicroseconds, "Filesystem cache getOrSet() time") \
     M(FilesystemCacheGetMicroseconds, "Filesystem cache get() time") \

--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -475,6 +475,7 @@ The server successfully detected this situation and will download merged part fr
     M(FileSegmentUseMicroseconds, "File segment use() time") \
     M(FileSegmentRemoveMicroseconds, "File segment remove() time") \
     M(FileSegmentHolderCompleteMicroseconds, "File segments holder complete() time") \
+    M(FileSegmentFailToIncreasePriority, "Number of times the priority was not increased due to a high contention on the cache lock") \
     M(FilesystemCacheHoldFileSegments, "Filesystem cache file segments count, which were hold") \
     M(FilesystemCacheUnusedHoldFileSegments, "Filesystem cache file segments count, which were hold, but not used (because of seek or LIMIT n, etc)") \
     \

--- a/src/Interpreters/Cache/FileCache.cpp
+++ b/src/Interpreters/Cache/FileCache.cpp
@@ -188,6 +188,11 @@ CacheGuard::Lock FileCache::lockCache() const
     return cache_guard.lock();
 }
 
+CacheGuard::Lock FileCache::tryLockCache() const
+{
+    return cache_guard.tryLock();
+}
+
 FileSegments FileCache::getImpl(const LockedKey & locked_key, const FileSegment::Range & range, size_t file_segments_limit) const
 {
     /// Given range = [left, right] and non-overlapping ordered set of file segments,

--- a/src/Interpreters/Cache/FileCache.h
+++ b/src/Interpreters/Cache/FileCache.h
@@ -173,6 +173,7 @@ public:
     void deactivateBackgroundOperations();
 
     CacheGuard::Lock lockCache() const;
+    CacheGuard::Lock tryLockCache() const;
 
     std::vector<FileSegment::Info> sync();
 

--- a/src/Interpreters/Cache/Guards.h
+++ b/src/Interpreters/Cache/Guards.h
@@ -65,10 +65,12 @@ struct CacheGuard : private boost::noncopyable
     /// so, we wouldn't be able to pass CacheGuard::Lock to a function which accepts KeyGuard::Lock, for example
     struct Lock : public std::unique_lock<std::mutex>
     {
-        explicit Lock(std::mutex & mutex_) : std::unique_lock<std::mutex>(mutex_) {}
+        using Base = std::unique_lock<std::mutex>;
+        using Base::Base;
     };
 
     Lock lock() { return Lock(mutex); }
+    Lock tryLock() { return Lock(mutex, std::try_to_lock); }
     std::mutex mutex;
 };
 


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Operations with the filesystem cache will suffer less from the lock contention (even less).