### PR TITLE
Do not load marks for merges and mutations

### DIFF
--- a/src/Interpreters/ThreadStatusExt.cpp
+++ b/src/Interpreters/ThreadStatusExt.cpp
@@ -151,15 +151,21 @@ ThreadGroupSwitcher::ThreadGroupSwitcher(ThreadGroupPtr thread_group)
     /// might be nullptr
     prev_thread_group = CurrentThread::getGroup();
 
-    CurrentThread::detachFromGroupIfNotDetached();
-    CurrentThread::attachToGroup(thread_group);
+    if (thread_group != prev_thread_group)
+    {
+        CurrentThread::detachFromGroupIfNotDetached();
+        CurrentThread::attachToGroup(thread_group);
+    }
 }
 
 ThreadGroupSwitcher::~ThreadGroupSwitcher()
 {
-    CurrentThread::detachFromGroupIfNotDetached();
-    if (prev_thread_group)
-        CurrentThread::attachToGroup(prev_thread_group);
+    if (CurrentThread::getGroup() != prev_thread_group)
+    {
+        CurrentThread::detachFromGroupIfNotDetached();
+        if (prev_thread_group)
+            CurrentThread::attachToGroup(prev_thread_group);
+    }
 }
 
 void ThreadStatus::attachInternalProfileEventsQueue(const InternalProfileEventsQueuePtr & profile_queue)

--- a/src/Storages/MergeTree/MergePlainMergeTreeTask.cpp
+++ b/src/Storages/MergeTree/MergePlainMergeTreeTask.cpp
@@ -38,19 +38,17 @@ bool MergePlainMergeTreeTask::executeStep()
     /// Make out memory tracker a parent of current thread memory tracker
     std::optional<ThreadGroupSwitcher> switcher;
     if (merge_list_entry)
-    {
         switcher.emplace((*merge_list_entry)->thread_group);
-    }
 
     switch (state)
     {
-        case State::NEED_PREPARE :
+        case State::NEED_PREPARE:
         {
             prepare();
             state = State::NEED_EXECUTE;
             return true;
         }
-        case State::NEED_EXECUTE :
+        case State::NEED_EXECUTE:
         {
             try
             {
@@ -66,7 +64,7 @@ bool MergePlainMergeTreeTask::executeStep()
                 throw;
             }
         }
-        case State::NEED_FINISH :
+        case State::NEED_FINISH:
         {
             finish();
 

--- a/src/Storages/MergeTree/MergeTask.h
+++ b/src/Storages/MergeTree/MergeTask.h
@@ -56,7 +56,6 @@ using MergeTaskPtr = std::shared_ptr<MergeTask>;
 class MergeTask
 {
 public:
-
     MergeTask(
         FutureMergedMutatedPartPtr future_part_,
         StorageMetadataPtr metadata_snapshot_,

--- a/src/Storages/MergeTree/MergeTreeReaderCompact.h
+++ b/src/Storages/MergeTree/MergeTreeReaderCompact.h
@@ -51,7 +51,9 @@ private:
     std::unique_ptr<CachedCompressedReadBuffer> cached_buffer;
     std::unique_ptr<CompressedReadBufferFromFile> non_cached_buffer;
 
-    MergeTreeMarksLoader marks_loader;
+    /// Used to load marks - optional, because if we read the whole part, it is unneeded.
+    size_t marks_count;
+    std::optional<MergeTreeMarksLoader> marks_loader;
 
     /// Storage columns with collected separate arrays of Nested to columns of Nested type.
     /// They maybe be needed for finding offsets of missed Nested columns in parts.

--- a/src/Storages/MergeTree/MergeTreeReaderStream.h
+++ b/src/Storages/MergeTree/MergeTreeReaderStream.h
@@ -63,8 +63,8 @@ private:
 
     bool is_low_cardinality_dictionary = false;
 
+    /// Total marks in the data part.
     size_t marks_count;
-
 
     ReadBuffer * data_buffer;
     CompressedReadBufferBase * compressed_data_buffer;
@@ -79,7 +79,8 @@ private:
     std::unique_ptr<CachedCompressedReadBuffer> cached_buffer;
     std::unique_ptr<CompressedReadBufferFromFile> non_cached_buffer;
 
-    MergeTreeMarksLoader marks_loader;
+    /// Used to load marks - optional, because if we read the whole part, it is unneeded.
+    std::optional<MergeTreeMarksLoader> marks_loader;
 };
 
 }

--- a/src/Storages/MergeTree/MergeTreeReaderStream.h
+++ b/src/Storages/MergeTree/MergeTreeReaderStream.h
@@ -38,10 +38,9 @@ public:
 
     void seekToStart();
 
-    /**
-     * Does buffer need to know something about mark ranges bounds it is going to read?
-     * (In case of MergeTree* tables). Mostly needed for reading from remote fs.
-     */
+    /** Does buffer need to know something about mark ranges bounds it is going to read?
+      * (In case of MergeTree* tables). Mostly needed for reading from remote fs.
+      */
     void adjustRightMark(size_t right_mark);
 
     ReadBuffer * getDataBuffer();

--- a/src/Storages/MergeTree/MergeTreeReaderWide.cpp
+++ b/src/Storages/MergeTree/MergeTreeReaderWide.cpp
@@ -271,7 +271,7 @@ static ReadBuffer * getStream(
     MergeTreeReaderStream & stream = *it->second;
     stream.adjustRightMark(current_task_last_mark);
 
-    if (seek_to_start)
+    if (seek_to_start || from_mark == 0)
         stream.seekToStart();
     else if (seek_to_mark)
         stream.seekToMark(from_mark);

--- a/src/Storages/MergeTree/MutateTask.cpp
+++ b/src/Storages/MergeTree/MutateTask.cpp
@@ -1005,7 +1005,6 @@ using MutationContextPtr = std::shared_ptr<MutationContext>;
 class MergeProjectionPartsTask : public IExecutableTask
 {
 public:
-
     MergeProjectionPartsTask(
         String name_,
         MergeTreeData::MutableDataPartsVector && parts_,

--- a/src/Storages/MergeTree/ReplicatedMergeMutateTaskBase.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeMutateTaskBase.cpp
@@ -161,7 +161,6 @@ bool ReplicatedMergeMutateTaskBase::executeImpl()
         return false;
     };
 
-
     auto execute_fetch = [&] (bool need_to_check_missing_part) -> bool
     {
         if (storage.executeFetch(entry, need_to_check_missing_part))
@@ -170,10 +169,9 @@ bool ReplicatedMergeMutateTaskBase::executeImpl()
         return false;
     };
 
-
     switch (state)
     {
-        case State::NEED_PREPARE :
+        case State::NEED_PREPARE:
         {
             {
                 auto res = checkExistingPart();
@@ -193,7 +191,7 @@ bool ReplicatedMergeMutateTaskBase::executeImpl()
             state = State::NEED_EXECUTE_INNER_MERGE;
             return true;
         }
-        case State::NEED_EXECUTE_INNER_MERGE :
+        case State::NEED_EXECUTE_INNER_MERGE:
         {
             try
             {
@@ -212,7 +210,7 @@ bool ReplicatedMergeMutateTaskBase::executeImpl()
 
             return true;
         }
-        case State::NEED_FINALIZE :
+        case State::NEED_FINALIZE:
         {
             try
             {
@@ -228,7 +226,7 @@ bool ReplicatedMergeMutateTaskBase::executeImpl()
 
             return remove_processed_entry();
         }
-        case State::SUCCESS :
+        case State::SUCCESS:
         {
             throw Exception(ErrorCodes::LOGICAL_ERROR, "Do not call execute on previously succeeded task");
         }


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Avoid reading marks if we read the whole part, such as in the case of merges and mutations.