### PR TITLE
Document `substringUTF8` and `substringIndexUTF8`

### DIFF
--- a/docs/en/sql-reference/functions/string-functions.md
+++ b/docs/en/sql-reference/functions/string-functions.md
@@ -686,7 +686,7 @@ Assumes that the string contains valid UTF-8 encoded text. If this assumption is
 **Example**
 
 ```sql
-SELECT substringIndexUTF8('www.clickhouse.com', '.', 2)
+SELECT substringIndexUTF8('www.straßen-in-europa.de', '.', 2)
 ```
 
 ```response

--- a/docs/en/sql-reference/functions/string-functions.md
+++ b/docs/en/sql-reference/functions/string-functions.md
@@ -621,9 +621,7 @@ SELECT 'Täglich grüßt das Murmeltier.' AS str,
 ```
 
 ```response
-┌─string───┬─substringUTF8('database', 5)─┬─substringUTF8('database', 5, 1)─┐
-│ database │ base                         │ b                               │
-└──────────┴──────────────────────────────┴─────────────────────────────────┘
+Täglich grüßt das Murmeltier.	grüßt das Murmeltier.	grüßt
 ```
 
 ## substringIndex

--- a/docs/en/sql-reference/functions/string-functions.md
+++ b/docs/en/sql-reference/functions/string-functions.md
@@ -688,7 +688,7 @@ SELECT substringIndexUTF8('www.straßen-in-europa.de', '.', 2)
 ```
 
 ```response
-www.clickhouse
+www.straßen-in-europa
 ```
 
 ## appendTrailingCharIfAbsent

--- a/docs/en/sql-reference/functions/string-functions.md
+++ b/docs/en/sql-reference/functions/string-functions.md
@@ -615,7 +615,9 @@ Assumes that the string contains valid UTF-8 encoded text. If this assumption is
 **Example**
 
 ```sql
-SELECT 'database' AS string, substringUTF8(string, 5), substringUTF8(string, 5, 1)
+SELECT 'Täglich grüßt das Murmeltier.' AS str,
+       substringUTF8(str, 9),
+       substringUTF8(str, 9, 5)
 ```
 
 ```response

--- a/docs/en/sql-reference/functions/string-functions.md
+++ b/docs/en/sql-reference/functions/string-functions.md
@@ -588,8 +588,41 @@ Result:
 
 ## substringUTF8
 
-Like `substring` but for Unicode code points. Assumes that the string contains valid UTF-8 encoded text. If this assumption is violated, no exception is thrown and the result is undefined.
+Returns the substring of a string `s` which starts at the specified byte index `offset` for Unicode code points. Byte counting starts from `1`. If `offset` is `0`, an empty string is returned. If `offset` is negative, the substring starts `pos` characters from the end of the string, rather than from the beginning. An optional argument `length` specifies the maximum number of bytes the returned substring may have.
 
+Assumes that the string contains valid UTF-8 encoded text. If this assumption is violated, no exception is thrown and the result is undefined.
+
+**Syntax**
+
+```sql
+substringUTF8(s, offset[, length])
+```
+
+**Arguments**
+
+- `s`: The string to calculate a substring from. [String](../../sql-reference/data-types/string.md), [FixedString](../../sql-reference/data-types/fixedstring.md) or [Enum](../../sql-reference/data-types/enum.md)
+- `offset`: The starting position of the substring in `s` . [(U)Int*](../../sql-reference/data-types/int-uint.md).
+- `length`: The maximum length of the substring. [(U)Int*](../../sql-reference/data-types/int-uint.md). Optional.
+
+**Returned value**
+
+A substring of `s` with `length` many bytes, starting at index `offset`.
+
+**Implementation details**
+
+Assumes that the string contains valid UTF-8 encoded text. If this assumption is violated, no exception is thrown and the result is undefined.
+
+**Example**
+
+```sql
+SELECT 'database' AS string, substringUTF8(string, 5), substringUTF8(string, 5, 1)
+```
+
+```response
+┌─string───┬─substringUTF8('database', 5)─┬─substringUTF8('database', 5, 1)─┐
+│ database │ base                         │ b                               │
+└──────────┴──────────────────────────────┴─────────────────────────────────┘
+```
 
 ## substringIndex
 
@@ -624,7 +657,39 @@ Result:
 
 ## substringIndexUTF8
 
-Like `substringIndex` but for Unicode code points. Assumes that the string contains valid UTF-8 encoded text. If this assumption is violated, no exception is thrown and the result is undefined.
+Returns the substring of `s` before `count` occurrences of the delimiter `delim`, specifically for Unicode code points.
+
+Assumes that the string contains valid UTF-8 encoded text. If this assumption is violated, no exception is thrown and the result is undefined.
+
+**Syntax**
+
+```sql
+substringIndexUTF8(s, delim, count)
+```
+
+**Arguments**
+
+- `s`: The string to extract substring from. [String](../../sql-reference/data-types/string.md).
+- `delim`: The character to split. [String](../../sql-reference/data-types/string.md).
+- `count`: The number of occurrences of the delimiter to count before extracting the substring. If count is positive, everything to the left of the final delimiter (counting from the left) is returned. If count is negative, everything to the right of the final delimiter (counting from the right) is returned. [UInt or Int](../data-types/int-uint.md)
+
+**Returned value**
+
+A substring [String](../../sql-reference/data-types/string.md) of `s` before `count` occurrences of `delim`.
+
+**Implementation details**
+
+Assumes that the string contains valid UTF-8 encoded text. If this assumption is violated, no exception is thrown and the result is undefined.
+
+**Example**
+
+```sql
+SELECT substringIndexUTF8('www.clickhouse.com', '.', 2)
+```
+
+```response
+www.clickhouse
+```
 
 ## appendTrailingCharIfAbsent
 


### PR DESCRIPTION
### Changelog category (leave one):

- Documentation (changelog entry is not required)

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

---

Closes https://github.com/ClickHouse/clickhouse-docs/issues/2016