### PR TITLE
update cppkafka to v0.4.1

### DIFF
--- a/src/Storages/Kafka/KafkaConsumer.cpp
+++ b/src/Storages/Kafka/KafkaConsumer.cpp
@@ -599,23 +599,13 @@ void KafkaConsumer::setExceptionInfo(const std::string & text, bool with_stacktr
     exceptions_buffer.push_back({enriched_text, static_cast<UInt64>(Poco::Timestamp().epochTime())});
 }
 
-/*
- * Needed until
- * https://github.com/mfontanini/cppkafka/pull/309
- * is merged,
- * because consumer->get_member_id() contains a leak
- */
 std::string KafkaConsumer::getMemberId() const
 {
     if (!consumer)
         return "";
 
-    char * memberid_ptr = rd_kafka_memberid(consumer->get_handle());
-    std::string memberid_string = memberid_ptr;
-    rd_kafka_mem_free(nullptr, memberid_ptr);
-    return memberid_string;
+    return consumer->get_member_id();
 }
-
 
 KafkaConsumer::Stat KafkaConsumer::getStat() const
 {


### PR DESCRIPTION
Update cppkafka to v0.4.1 because it has https://github.com/mfontanini/cppkafka/pull/309 .

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
