### PR TITLE
QueryFuzzer: replace element randomly when AST part buffer is full

### DIFF
--- a/src/Client/QueryFuzzer.cpp
+++ b/src/Client/QueryFuzzer.cpp
@@ -1232,7 +1232,7 @@ void QueryFuzzer::addTableLike(ASTPtr ast)
         const auto iter = std::next(table_like.begin(), fuzz_rand() % table_like.size());
         const auto ast_del = *iter;
         table_like.erase(iter);
-        table_like_map.erase(ast_del.first);    
+        table_like_map.erase(ast_del.first);
     }
 
     const auto name = ast->formatForErrorMessage();

--- a/src/Client/QueryFuzzer.cpp
+++ b/src/Client/QueryFuzzer.cpp
@@ -1227,12 +1227,6 @@ void QueryFuzzer::collectFuzzInfoMain(ASTPtr ast)
 {
     collectFuzzInfoRecurse(ast);
 
-    aliases.clear();
-    for (const auto & alias : aliases_set)
-    {
-        aliases.push_back(alias);
-    }
-
     column_like.clear();
     for (const auto & [name, value] : column_like_map)
     {
@@ -1285,16 +1279,6 @@ void QueryFuzzer::addColumnLike(ASTPtr ast)
 
 void QueryFuzzer::collectFuzzInfoRecurse(ASTPtr ast)
 {
-    if (auto * impl = dynamic_cast<ASTWithAlias *>(ast.get()))
-    {
-        if (aliases_set.size() > 1000)
-        {
-            aliases_set.clear();
-        }
-
-        aliases_set.insert(impl->alias);
-    }
-
     if (typeid_cast<ASTLiteral *>(ast.get()))
     {
         addColumnLike(ast);

--- a/src/Client/QueryFuzzer.cpp
+++ b/src/Client/QueryFuzzer.cpp
@@ -232,7 +232,7 @@ ASTPtr QueryFuzzer::getRandomColumnLike()
         return nullptr;
     }
 
-    ASTPtr new_ast = column_like[fuzz_rand() % column_like.size()]->clone();
+    ASTPtr new_ast = column_like[fuzz_rand() % column_like.size()].second->clone();
     new_ast->setAlias("");
 
     return new_ast;
@@ -272,7 +272,7 @@ void QueryFuzzer::replaceWithTableLike(ASTPtr & ast)
         return;
     }
 
-    ASTPtr new_ast = table_like[fuzz_rand() % table_like.size()]->clone();
+    ASTPtr new_ast = table_like[fuzz_rand() % table_like.size()].second->clone();
 
     std::string old_alias = ast->tryGetAlias();
     new_ast->setAlias(old_alias);
@@ -1214,51 +1214,46 @@ void QueryFuzzer::fuzz(ASTPtr & ast)
     }
 }
 
+#define AST_FUZZER_PART_TYPE_CAP 1000
+
 /*
  * This functions collects various parts of query that we can then substitute
  * to a query being fuzzed.
- *
- * TODO: we just stop remembering new parts after our corpus reaches certain size.
- * This is boring, should implement a random replacement of existing parst with
- * small probability. Do this after we add this fuzzer to CI and fix all the
- * problems it can routinely find even in this boring version.
  */
 void QueryFuzzer::collectFuzzInfoMain(ASTPtr ast)
 {
     collectFuzzInfoRecurse(ast);
-
-    column_like.clear();
-    for (const auto & [name, value] : column_like_map)
-    {
-        column_like.push_back(value);
-    }
-
-    table_like.clear();
-    for (const auto & [name, value] : table_like_map)
-    {
-        table_like.push_back(value);
-    }
 }
 
 void QueryFuzzer::addTableLike(ASTPtr ast)
 {
-    if (table_like_map.size() > 1000)
+    if (table_like_map.size() > AST_FUZZER_PART_TYPE_CAP)
     {
-        table_like_map.clear();
+        const auto iter = std::next(table_like.begin(), fuzz_rand() % table_like.size());
+        const auto ast_del = *iter;
+        table_like.erase(iter);
+        table_like_map.erase(ast_del.first);    
     }
 
     const auto name = ast->formatForErrorMessage();
     if (name.size() < 200)
     {
-        table_like_map.insert({name, ast});
+        const auto res = table_like_map.insert({name, ast});
+        if (res.second)
+        {
+            table_like.push_back({name, ast});
+        }
     }
 }
 
 void QueryFuzzer::addColumnLike(ASTPtr ast)
 {
-    if (column_like_map.size() > 1000)
+    if (column_like_map.size() > AST_FUZZER_PART_TYPE_CAP)
     {
-        column_like_map.clear();
+        const auto iter = std::next(column_like.begin(), fuzz_rand() % column_like.size());
+        const auto ast_del = *iter;
+        column_like.erase(iter);
+        column_like_map.erase(ast_del.first);
     }
 
     const auto name = ast->formatForErrorMessage();
@@ -1273,7 +1268,11 @@ void QueryFuzzer::addColumnLike(ASTPtr ast)
     }
     if (name.size() < 200)
     {
-        column_like_map.insert({name, ast});
+        const auto res = column_like_map.insert({name, ast});
+        if (res.second)
+        {
+            column_like.push_back({name, ast});
+        }
     }
 }
 

--- a/src/Client/QueryFuzzer.h
+++ b/src/Client/QueryFuzzer.h
@@ -50,9 +50,7 @@ struct QueryFuzzer
     // we are currently fuzzing. We add some part from each new query we are asked
     // to fuzz, and keep this state between queries, so the fuzzing output becomes
     // more interesting over time, as the queries mix.
-    std::unordered_set<std::string> aliases_set;
-    std::vector<std::string> aliases;
-
+    // The maps are used for collection, and the vectors are used for random access.
     std::unordered_map<std::string, ASTPtr> column_like_map;
     std::vector<ASTPtr> column_like;
 

--- a/src/Client/QueryFuzzer.h
+++ b/src/Client/QueryFuzzer.h
@@ -50,12 +50,12 @@ struct QueryFuzzer
     // we are currently fuzzing. We add some part from each new query we are asked
     // to fuzz, and keep this state between queries, so the fuzzing output becomes
     // more interesting over time, as the queries mix.
-    // The maps are used for collection, and the vectors are used for random access.
+    // The hash tables are used for collection, and the vectors are used for random access.
     std::unordered_map<std::string, ASTPtr> column_like_map;
-    std::vector<ASTPtr> column_like;
+    std::vector<std::pair<std::string, ASTPtr>> column_like;
 
     std::unordered_map<std::string, ASTPtr> table_like_map;
-    std::vector<ASTPtr> table_like;
+    std::vector<std::pair<std::string, ASTPtr>> table_like;
 
     // Some debug fields for detecting problematic ASTs with loops.
     // These are reset for each fuzzMain call.


### PR DESCRIPTION
Addressing a TODO:
```
 * TODO: we just stop remembering new parts after our corpus reaches certain size.
 * This is boring, should implement a random replacement of existing parst with
 * small probability. Do this after we add this fuzzer to CI and fix all the
 * problems it can routinely find even in this boring version.
```

I did a simple series of regression testing roughly comparing results of the following between old and new versions:
```
./build/programs/clickhouse client --query-fuzzer-runs 100 -q "SELECT (val + 257, (((tuple(NULL), 10.000100135803223), tuple(-inf)), '-1', (NULL, '0.10', NULL), NULL), (val + 9223372036854775807) = (rval * 100), tuple(65535), tuple(NULL), NULL, NULL), * FROM ( SELECT dummy AS val FROM system.one ) AS s1 ANY LEFT JOIN ( SELECT toLowCardinality(toNullable(dummy)) AS rval FROM system.one ) AS s2 ON (val + 100) = (rval * 7)"
```

Perf shouldn't be degraded, for example I did a simple non scientific series of `time` on 10k runs fuzzings and observed that.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)