### PR TITLE
Fix llvm symbolizer on CI

### DIFF
--- a/docker/test/base/Dockerfile
+++ b/docker/test/base/Dockerfile
@@ -33,6 +33,9 @@ ENV TSAN_OPTIONS='halt_on_error=1 abort_on_error=1 history_size=7 memory_limit_m
 ENV UBSAN_OPTIONS='print_stacktrace=1'
 ENV MSAN_OPTIONS='abort_on_error=1 poison_in_dtor=1'
 
+# for external_symbolizer_path
+RUN ln -s /usr/bin/llvm-symbolizer-${LLVM_VERSION} /usr/bin/llvm-symbolizer
+
 RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && locale-gen en_US.UTF-8
 ENV LC_ALL en_US.UTF-8
 

--- a/docker/test/fasttest/Dockerfile
+++ b/docker/test/fasttest/Dockerfile
@@ -14,7 +14,6 @@ RUN apt-get update \
         libclang-${LLVM_VERSION}-dev \
         libclang-rt-${LLVM_VERSION}-dev \
         lld-${LLVM_VERSION} \
-        llvm-${LLVM_VERSION} \
         llvm-${LLVM_VERSION}-dev \
         lsof \
         ninja-build \
@@ -37,8 +36,6 @@ RUN pip3 install numpy==1.26.3 scipy==1.12.0 pandas==1.5.3 Jinja2==3.1.3
 
 # This symlink is required by gcc to find the lld linker
 RUN ln -s /usr/bin/lld-${LLVM_VERSION} /usr/bin/ld.lld
-# for external_symbolizer_path
-RUN ln -s /usr/bin/llvm-symbolizer-${LLVM_VERSION} /usr/bin/llvm-symbolizer
 # FIXME: workaround for "The imported target "merge-fdata" references the file" error
 # https://salsa.debian.org/pkg-llvm-team/llvm-toolchain/-/commit/992e52c0b156a5ba9c6a8a54f8c4857ddd3d371d
 RUN sed -i '/_IMPORT_CHECK_FILES_FOR_\(mlir-\|llvm-bolt\|merge-fdata\|MLIR\)/ {s|^|#|}' /usr/lib/llvm-${LLVM_VERSION}/lib/cmake/llvm/LLVMExports-*.cmake

--- a/docker/test/util/Dockerfile
+++ b/docker/test/util/Dockerfile
@@ -26,6 +26,8 @@ RUN apt-get update \
     && export CODENAME="$(lsb_release --codename --short | tr 'A-Z' 'a-z')" \
     && echo "deb https://apt.llvm.org/${CODENAME}/ llvm-toolchain-${CODENAME}-${LLVM_VERSION} main" >> \
         /etc/apt/sources.list \
+    && apt-get update \
+    && apt-get install --yes --no-install-recommends --verbose-versions llvm-${LLVM_VERSION} \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /var/cache/debconf /tmp/*
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

In #61011 the whole toolchain installation had been removed from the
base image to reduce image sizes, and this is a good thing indeed.

However it also breaks the symbolizer for sanitizers, which makes
stacktraces unreadable, so let's fix this by getting back llvm package,
this should be OK, since it's size is not gigabytes, but only 48MiB (at
least for llvm-14):

    # dpkg -L llvm-14| xargs file | grep -v directory | cut -d: -f1 | xargs du -sch | grep total
    48M     total

Fixes: https://github.com/ClickHouse/ClickHouse/pull/61011 (cc @Felixoid )