### PR TITLE
fix flaky 02949_ttl_group_by_bug

### DIFF
--- a/tests/queries/0_stateless/02949_ttl_group_by_bug.sql
+++ b/tests/queries/0_stateless/02949_ttl_group_by_bug.sql
@@ -2,7 +2,7 @@ DROP TABLE IF EXISTS ttl_group_by_bug;
 
 CREATE TABLE ttl_group_by_bug
 (key UInt32, ts DateTime, value UInt32, min_value UInt32 default value, max_value UInt32 default value)
-ENGINE = MergeTree() PARTITION BY toYYYYMM(ts)
+ENGINE = MergeTree()
 ORDER BY (key, toStartOfInterval(ts, toIntervalMinute(3)), ts)
 TTL ts + INTERVAL 5 MINUTE GROUP BY key, toStartOfInterval(ts, toIntervalMinute(3))
 SET value = sum(value), min_value = min(min_value), max_value = max(max_value),  ts=min(toStartOfInterval(ts, toIntervalMinute(3)));


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
close https://github.com/ClickHouse/ClickHouse/issues/60627
it only fails when the inserted data falls to different partitions, which makes no sense if we wanna check the order.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
