### PR TITLE
Clarify sentence about clusterAllReplicas

### DIFF
--- a/docs/en/sql-reference/table-functions/cluster.md
+++ b/docs/en/sql-reference/table-functions/cluster.md
@@ -5,7 +5,7 @@ sidebar_label: cluster
 title: "cluster, clusterAllReplicas"
 ---
 
-Allows to access all shards in an existing cluster which configured in `remote_servers` section without creating a [Distributed](../../engines/table-engines/special/distributed.md) table. One replica of each shard is queried.
+Allows to access all shards (configured in the `remote_servers` section) of a cluster without creating a [Distributed](../../engines/table-engines/special/distributed.md) table. Only one replica of each shard is queried.
 
 `clusterAllReplicas` function — same as `cluster`, but all replicas are queried. Each replica in a cluster is used as a separate shard/connection.
 


### PR DESCRIPTION
The explanation about `clusterAllReplicas` is not clear. This change tries to simplify the sentence and clarify the explanation.

### Changelog category (leave one):
- Documentation (changelog entry is not required)