### PR TITLE
Make every style-checker runner types scaling-out very quickly

### DIFF
--- a/tests/ci/autoscale_runners_lambda/app.py
+++ b/tests/ci/autoscale_runners_lambda/app.py
@@ -142,7 +142,7 @@ def set_capacity(
 
         logging.info(
             "The ASG %s capacity will be increased to %s, current capacity=%s, "
-            "effective capacity=%sm maximum capacity=%s, running jobs=%s, queue size=%s",
+            "effective capacity=%s, maximum capacity=%s, running jobs=%s, queue size=%s",
             asg["AutoScalingGroupName"],
             desired_capacity,
             effective_capacity,

--- a/tests/ci/autoscale_runners_lambda/app.py
+++ b/tests/ci/autoscale_runners_lambda/app.py
@@ -51,7 +51,7 @@ class Queue:
     label: str
 
 
-def get_scales() -> Tuple[int, int]:
+def get_scales(runner_type: str) -> Tuple[int, int]:
     "returns the multipliers for scaling down and up ASG by types"
     # Scaling down is quicker on the lack of running jobs than scaling up on
     # queue
@@ -63,8 +63,12 @@ def get_scales() -> Tuple[int, int]:
     # 10. I am trying 7 now.
     # 7 still looks a bit slow, so I try 6
     # Let's have it the same as the other ASG
+    #
+    # All type of style-checkers should be added very quickly to not block the workflows
     # UPDATE THE COMMENT ON CHANGES
     scale_up = 3
+    if "style" in runner_type:
+        scale_up = 1
     return scale_down, scale_up
 
 
@@ -95,7 +99,7 @@ def set_capacity(
             continue
         raise ValueError("Queue status is not in ['in_progress', 'queued']")
 
-    scale_down, scale_up = get_scales()
+    scale_down, scale_up = get_scales(runner_type)
     # With lyfecycle hooks some instances are actually free because some of
     # them are in 'Terminating:Wait' state
     effective_capacity = max(

--- a/tests/ci/autoscale_runners_lambda/test_autoscale.py
+++ b/tests/ci/autoscale_runners_lambda/test_autoscale.py
@@ -80,7 +80,7 @@ class TestSetCapacity(unittest.TestCase):
             ),
             TestCase("increase-1", 1, 13, 20, [Queue("queued", 23, "increase-1")], 17),
             TestCase(
-                "style-checker", 1, 13, 20, [Queue("queued", 33, "style-checker")], 20
+                "style-checker", 1, 13, 20, [Queue("queued", 19, "style-checker")], 19
             ),
             TestCase("increase-2", 1, 13, 20, [Queue("queued", 18, "increase-2")], 15),
             TestCase("increase-3", 1, 13, 20, [Queue("queued", 183, "increase-3")], 20),


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Scale-out all style-checker ASGs to the necessary number of runners immediately