### PR TITLE
fix `forget_partition` test

### DIFF
--- a/tests/queries/0_stateless/02995_forget_partition.sh
+++ b/tests/queries/0_stateless/02995_forget_partition.sh
@@ -25,7 +25,7 @@ alter table forget_partition drop partition '20240101';
 alter table forget_partition drop partition '20240102';
 """
 
-# DROP PARTITION do not wait for a part to be removed from memory due to possible concurrent SELECTs, so we have to do waitg manually here
+# DROP PARTITION do not wait for a part to be removed from memory due to possible concurrent SELECTs, so we have to do wait manually here
 #${CLICKHOUSE_CLIENT} -q "select * from system.parts where database=currentDatabase() and table='forget_partition' and (partition='20240101' or partition='20240102') FORMAT Vertical"
 while [[ $(${CLICKHOUSE_CLIENT} -q "select count() from system.parts where database=currentDatabase() and table='forget_partition' and partition='20240101'") != 0 ]]; do sleep 0.1; done
 

--- a/tests/queries/0_stateless/02995_forget_partition.sh
+++ b/tests/queries/0_stateless/02995_forget_partition.sh
@@ -26,7 +26,6 @@ alter table forget_partition drop partition '20240102';
 """
 
 # DROP PARTITION do not wait for a part to be removed from memory due to possible concurrent SELECTs, so we have to do wait manually here
-#${CLICKHOUSE_CLIENT} -q "select * from system.parts where database=currentDatabase() and table='forget_partition' and (partition='20240101' or partition='20240102') FORMAT Vertical"
 while [[ $(${CLICKHOUSE_CLIENT} -q "select count() from system.parts where database=currentDatabase() and table='forget_partition' and partition='20240101'") != 0 ]]; do sleep 0.1; done
 
 ${CLICKHOUSE_CLIENT} --multiline --multiquery -q """

--- a/tests/queries/0_stateless/02995_forget_partition.sh
+++ b/tests/queries/0_stateless/02995_forget_partition.sh
@@ -1,5 +1,12 @@
--- Tags: zookeeper, no-replicated-database
+#!/usr/bin/env bash
+# Tags: zookeeper, no-replicated-database
 
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+
+${CLICKHOUSE_CLIENT} --multiline --multiquery -q """
 drop table if exists forget_partition;
 
 create table forget_partition
@@ -16,7 +23,13 @@ insert into forget_partition select number, '2024-01-01' + interval number day, 
 
 alter table forget_partition drop partition '20240101';
 alter table forget_partition drop partition '20240102';
+"""
 
+# DROP PARTITION do not wait for a part to be removed from memory due to possible concurrent SELECTs, so we have to do waitg manually here
+#${CLICKHOUSE_CLIENT} -q "select * from system.parts where database=currentDatabase() and table='forget_partition' and (partition='20240101' or partition='20240102') FORMAT Vertical"
+while [[ $(${CLICKHOUSE_CLIENT} -q "select count() from system.parts where database=currentDatabase() and table='forget_partition' and partition='20240101'") != 0 ]]; do sleep 0.1; done
+
+${CLICKHOUSE_CLIENT} --multiline --multiquery -q """
 set allow_unrestricted_reads_from_keeper=1;
 
 select '---before---';
@@ -31,3 +44,4 @@ select '---after---';
 select name from system.zookeeper where path = '/test/02995/' || currentDatabase() || '/rmt/block_numbers' order by name;
 
 drop table forget_partition;
+"""


### PR DESCRIPTION
The problem was that `DROP PARTITION` does not wait for a part to be removed from memory due to possible concurrent SELECTs, so we have to do wait manually

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
