### PR TITLE
Using straightforward approach to import GPG key

### DIFF
--- a/docs/en/getting-started/install.md
+++ b/docs/en/getting-started/install.md
@@ -78,8 +78,8 @@ It is recommended to use official pre-compiled `deb` packages for Debian or Ubun
 
 #### Setup the Debian repository
 ``` bash
-sudo apt-get install -y apt-transport-https ca-certificates dirmngr
-sudo gpg --no-default-keyring --keyring /usr/share/keyrings/clickhouse-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8919F6BD2B48D754
+sudo apt-get install -y apt-transport-https ca-certificates dirmngr curl gpg
+curl -fsSL 'https://packages.clickhouse.com/rpm/lts/repodata/repomd.xml.key' | sudo gpg --dearmor -o /usr/share/keyrings/clickhouse-keyring.gpg
 
 echo "deb [signed-by=/usr/share/keyrings/clickhouse-keyring.gpg] https://packages.clickhouse.com/deb stable main" | sudo tee \
     /etc/apt/sources.list.d/clickhouse.list

--- a/docs/en/getting-started/install.md
+++ b/docs/en/getting-started/install.md
@@ -78,7 +78,7 @@ It is recommended to use official pre-compiled `deb` packages for Debian or Ubun
 
 #### Setup the Debian repository
 ``` bash
-sudo apt-get install -y apt-transport-https ca-certificates dirmngr curl gpg
+sudo apt-get install -y apt-transport-https ca-certificates curl gnupg
 curl -fsSL 'https://packages.clickhouse.com/rpm/lts/repodata/repomd.xml.key' | sudo gpg --dearmor -o /usr/share/keyrings/clickhouse-keyring.gpg
 
 echo "deb [signed-by=/usr/share/keyrings/clickhouse-keyring.gpg] https://packages.clickhouse.com/deb stable main" | sudo tee \


### PR DESCRIPTION
### Changelog category (leave one):

- Documentation (changelog entry is not required)

According to the [comment](https://github.com/ClickHouse/ClickHouse/pull/61207#issuecomment-1991688104), I think it should use the straightforward approach to import the GPG key.

And it has been tested in many Ubuntu-based distributions.