### PR TITLE
Add retries to `02908_many_requests_to_system_replicas`

### DIFF
--- a/tests/queries/0_stateless/02908_many_requests_to_system_replicas.sh
+++ b/tests/queries/0_stateless/02908_many_requests_to_system_replicas.sh
@@ -12,22 +12,34 @@ CONCURRENCY=200
 
 echo "Creating $NUM_TABLES tables"
 
+function get_done_or_die_trying()
+{
+  # Sometimes curl produces errors like 'Recv failure: Connection reset by peer' and fails test, let's add a little bit of retries
+  for _ in $(seq 1 10)
+  do
+    curl "$CLICKHOUSE_URL" --silent --fail --show-error --data "$1" &>/dev/null && return
+  done
+
+  echo "Cannot successfully make request"
+  exit 1
+}
+
 function init_table()
 {
     set -e
     i=$1
-    curl $CLICKHOUSE_URL --silent --fail --show-error --data "CREATE TABLE test_02908_r1_$i (a UInt64) ENGINE=ReplicatedMergeTree('/02908/{database}/test_$i', 'r1') ORDER BY tuple()" 2>&1
-    curl $CLICKHOUSE_URL --silent --fail --show-error --data "CREATE TABLE test_02908_r2_$i (a UInt64) ENGINE=ReplicatedMergeTree('/02908/{database}/test_$i', 'r2') ORDER BY tuple()" 2>&1
-    curl $CLICKHOUSE_URL --silent --fail --show-error --data "CREATE TABLE test_02908_r3_$i (a UInt64) ENGINE=ReplicatedMergeTree('/02908/{database}/test_$i', 'r3') ORDER BY tuple()" 2>&1
+    get_done_or_die_trying "CREATE TABLE test_02908_r1_$i (a UInt64) ENGINE=ReplicatedMergeTree('/02908/{database}/test_$i', 'r1') ORDER BY tuple()"
+    get_done_or_die_trying "CREATE TABLE test_02908_r2_$i (a UInt64) ENGINE=ReplicatedMergeTree('/02908/{database}/test_$i', 'r2') ORDER BY tuple()"
+    get_done_or_die_trying "CREATE TABLE test_02908_r3_$i (a UInt64) ENGINE=ReplicatedMergeTree('/02908/{database}/test_$i', 'r3') ORDER BY tuple()"
 
-    curl $CLICKHOUSE_URL --silent --fail --show-error --data "INSERT INTO test_02908_r1_$i  SELECT rand64() FROM numbers(5);" 2>&1
+    get_done_or_die_trying "INSERT INTO test_02908_r1_$i  SELECT rand64() FROM numbers(5);"
 }
 
 export init_table;
 
-for i in `seq 1 $NUM_TABLES`;
+for i in $(seq 1 $NUM_TABLES)
 do
-    init_table $i &
+    init_table "$i" &
 done
 
 wait;
@@ -35,15 +47,15 @@ wait;
 
 echo "Making $CONCURRENCY requests to system.replicas"
 
-for i in `seq 1 $CONCURRENCY`;
+for i in $(seq 1 $CONCURRENCY)
 do
-    curl $CLICKHOUSE_URL --silent --fail --show-error --data "SELECT * FROM system.replicas WHERE database=currentDatabase() FORMAT Null;" 2>&1 || echo "query $i failed" &
+    curl "$CLICKHOUSE_URL" --silent --fail --show-error --data "SELECT * FROM system.replicas WHERE database=currentDatabase() FORMAT Null;" 2>&1 || echo "query $i failed" &
 done
 
 echo "Query system.replicas while waiting for other concurrent requests to finish"
 # lost_part_count column is read from ZooKeeper
-curl $CLICKHOUSE_URL --silent --fail --show-error --data "SELECT sum(lost_part_count) FROM system.replicas WHERE database=currentDatabase();" 2>&1;
+curl "$CLICKHOUSE_URL" --silent --fail --show-error --data "SELECT sum(lost_part_count) FROM system.replicas WHERE database=currentDatabase();" 2>&1;
 # is_leader column is filled without ZooKeeper
-curl $CLICKHOUSE_URL --silent --fail --show-error --data "SELECT sum(is_leader) FROM system.replicas WHERE database=currentDatabase();" 2>&1;
+curl "$CLICKHOUSE_URL" --silent --fail --show-error --data "SELECT sum(is_leader) FROM system.replicas WHERE database=currentDatabase();" 2>&1;
 
 wait;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


---

Often errors look the following:

```
2024-03-10 18:52:04 --- /usr/share/clickhouse-test/queries/0_stateless/02908_many_requests_to_system_replicas.reference	2024-03-10 18:33:34.651733404 +0500
2024-03-10 18:52:04 +++ /tmp/clickhouse-test/0_stateless/02908_many_requests_to_system_replicas.stdout	2024-03-10 18:51:53.215842065 +0500
2024-03-10 18:52:04 @@ -1,5 +1,7 @@
2024-03-10 18:52:04  Creating 300 tables
2024-03-10 18:52:04 +curl: (56) Recv failure: Connection reset by peer
2024-03-10 18:52:04 +curl: (56) Recv failure: Connection reset by peer
2024-03-10 18:52:04  Making 200 requests to system.replicas
2024-03-10 18:52:04  Query system.replicas while waiting for other concurrent requests to finish
2024-03-10 18:52:04  0
2024-03-10 18:52:04 -900
2024-03-10 18:52:04 +898
```

so we're getting errors from curl during tables creation. I think some retries there wouldn't harm.

Fixes #57443