### PR TITLE
Avoid NOT_IMPLEMENTED errors in MetadataStorageFromStaticFilesWebServer

### DIFF
--- a/src/Disks/ObjectStorages/Web/MetadataStorageFromStaticFilesWebServer.cpp
+++ b/src/Disks/ObjectStorages/Web/MetadataStorageFromStaticFilesWebServer.cpp
@@ -129,4 +129,14 @@ void MetadataStorageFromStaticFilesWebServerTransaction::createDirectoryRecursiv
     /// Noop.
 }
 
+void MetadataStorageFromStaticFilesWebServerTransaction::removeDirectory(const std::string &)
+{
+    /// Noop.
+}
+
+void MetadataStorageFromStaticFilesWebServerTransaction::removeRecursive(const std::string &)
+{
+    /// Noop.
+}
+
 }

--- a/src/Disks/ObjectStorages/Web/MetadataStorageFromStaticFilesWebServer.h
+++ b/src/Disks/ObjectStorages/Web/MetadataStorageFromStaticFilesWebServer.h
@@ -86,6 +86,10 @@ public:
 
     void createDirectoryRecursive(const std::string & path) override;
 
+    void removeDirectory(const std::string & path) override;
+
+    void removeRecursive(const std::string & path) override;
+
     void commit() override
     {
         /// Nothing to commit.


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Fixes `01417_freeze_partition_verbose`.