### PR TITLE
Disable test 02998_primary_key_skip_columns.sql in sanitizer builds as it can be slow

### DIFF
--- a/tests/queries/0_stateless/02998_primary_key_skip_columns.sql
+++ b/tests/queries/0_stateless/02998_primary_key_skip_columns.sql
@@ -1,3 +1,5 @@
+-- Tags: no-asan, no-tsan, no-msan, no-ubsan
+
 DROP TABLE IF EXISTS test;
 
 CREATE TABLE test (a UInt64, b UInt64, c UInt64) ENGINE = MergeTree ORDER BY (a, b, c) SETTINGS index_granularity = 1, primary_key_ratio_of_unique_prefix_values_to_skip_suffix_columns = 1;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

