### PR TITLE
Fix `01417_freeze_partition_verbose`

### DIFF
--- a/src/Disks/ObjectStorages/Web/WebObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/Web/WebObjectStorage.cpp
@@ -86,6 +86,10 @@ WebObjectStorage::loadFiles(const String & path, const std::unique_lock<std::sha
             loaded_files.emplace_back(file_path);
         }
 
+        /// Check for not found url after read attempt, because of delayed initialization.
+        if (metadata_buf->hasNotFoundURL())
+            return {};
+
         auto [it, inserted] = files.add(path, FileData::createDirectoryInfo(true));
         if (!inserted)
         {

--- a/src/IO/ReadWriteBufferFromHTTP.cpp
+++ b/src/IO/ReadWriteBufferFromHTTP.cpp
@@ -449,6 +449,7 @@ bool ReadWriteBufferFromHTTP::nextImpl()
                     if (http_skip_not_found_url && e.getHTTPStatus() == Poco::Net::HTTPResponse::HTTPStatus::HTTP_NOT_FOUND)
                     {
                         next_result = false;
+                        has_not_found_url = true;
                         return;
                     }
 
@@ -740,4 +741,3 @@ ReadWriteBufferFromHTTP::HTTPFileInfo ReadWriteBufferFromHTTP::parseFileInfo(con
 }
 
 }
-

--- a/src/IO/ReadWriteBufferFromHTTP.h
+++ b/src/IO/ReadWriteBufferFromHTTP.h
@@ -79,6 +79,7 @@ private:
 
     const bool use_external_buffer;
     const bool http_skip_not_found_url;
+    bool has_not_found_url = false;
 
     std::function<void(std::ostream &)> out_stream_callback;
 
@@ -182,6 +183,8 @@ public:
     const std::string & getCompressionMethod() const;
 
     std::optional<time_t> tryGetLastModificationTime();
+
+    bool hasNotFoundURL() const { return has_not_found_url; }
 
     HTTPFileInfo getFileInfo();
     static HTTPFileInfo parseFileInfo(const Poco::Net::HTTPResponse & response, size_t requested_range_begin);


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


After https://github.com/ClickHouse/ClickHouse/pull/58845/files#diff-64938a2d590929ddef45935da30a0458bcf7181c6585f34fdf7cebff96be3990L47-L105 method `exists` in `DiskWeb` warked incorrectly, which affected this code for unfreeze https://github.com/ClickHouse/ClickHouse/blob/ad363fe2541096bf27cce0681ed6e62b2e1a580c/src/Storages/Freeze.cpp#L176-L179