### PR TITLE
Docs: Reference `IS [NOT] NULL` operators from `is[Not]Null` functions

### DIFF
--- a/docs/en/sql-reference/functions/functions-for-nulls.md
+++ b/docs/en/sql-reference/functions/functions-for-nulls.md
@@ -10,11 +10,13 @@ sidebar_label: Nullable
 
 Returns whether the argument is [NULL](../../sql-reference/syntax.md#null).
 
+See also operator [`IS NULL`](../operators/index.md#is_null).
+
 ``` sql
 isNull(x)
 ```
 
-Alias: `IS NULL`.
+Alias: `ISNULL`
 
 **Arguments**
 
@@ -54,11 +56,11 @@ Result:
 
 Returns whether the argument is not [NULL](../../sql-reference/syntax.md#null-literal).
 
+See also operator [`IS NOT NULL`](../operators/index.md#is_not_null).
+
 ``` sql
 isNotNull(x)
 ```
-
-Alias: `IS NOT NULL`.
 
 **Arguments:**
 
@@ -101,8 +103,6 @@ Returns whether the argument is 0 (zero) or [NULL](../../sql-reference/syntax.md
 ``` sql
 isZeroOrNull(x)
 ```
-
-Alias: `x = 0 OR x IS NULL`.
 
 **Arguments:**
 

--- a/docs/en/sql-reference/functions/functions-for-nulls.md
+++ b/docs/en/sql-reference/functions/functions-for-nulls.md
@@ -14,7 +14,7 @@ Returns whether the argument is [NULL](../../sql-reference/syntax.md#null).
 isNull(x)
 ```
 
-Alias: `ISNULL`.
+Alias: `IS NULL`.
 
 **Arguments**
 
@@ -58,6 +58,8 @@ Returns whether the argument is not [NULL](../../sql-reference/syntax.md#null-li
 isNotNull(x)
 ```
 
+Alias: `IS NOT NULL`.
+
 **Arguments:**
 
 - `x` — A value of non-compound data type.
@@ -99,6 +101,8 @@ Returns whether the argument is 0 (zero) or [NULL](../../sql-reference/syntax.md
 ``` sql
 isZeroOrNull(x)
 ```
+
+Alias: `x = 0 OR x IS NULL`.
 
 **Arguments:**
 

--- a/docs/en/sql-reference/functions/functions-for-nulls.md
+++ b/docs/en/sql-reference/functions/functions-for-nulls.md
@@ -16,7 +16,7 @@ See also operator [`IS NULL`](../operators/index.md#is_null).
 isNull(x)
 ```
 
-Alias: `ISNULL`
+Alias: `ISNULL`.
 
 **Arguments**
 

--- a/docs/en/sql-reference/operators/index.md
+++ b/docs/en/sql-reference/operators/index.md
@@ -353,7 +353,7 @@ For efficiency, the `and` and `or` functions accept any number of arguments. The
 
 ClickHouse supports the `IS NULL` and `IS NOT NULL` operators.
 
-### IS NULL
+### IS NULL {#is_null}
 
 - For [Nullable](../../sql-reference/data-types/nullable.md) type values, the `IS NULL` operator returns:
     - `1`, if the value is `NULL`.
@@ -374,7 +374,7 @@ SELECT x+100 FROM t_null WHERE y IS NULL
 └──────────────┘
 ```
 
-### IS NOT NULL
+### IS NOT NULL {#is_not_null}
 
 - For [Nullable](../../sql-reference/data-types/nullable.md) type values, the `IS NOT NULL` operator returns:
     - `0`, if the value is `NULL`.


### PR DESCRIPTION
### Changelog category (leave one):
- Documentation (changelog entry is not required)