### PR TITLE
Don't use default cluster in test test_distibuted_settings

### DIFF
--- a/tests/integration/test_distributed_config/configs/clusters.xml
+++ b/tests/integration/test_distributed_config/configs/clusters.xml
@@ -1,0 +1,12 @@
+<clickhouse>
+    <remote_servers>
+        <localhost_cluster>
+            <shard>
+                <replica>
+                    <host>localhost</host>
+                    <port>9000</port>
+                </replica>
+            </shard>
+        </localhost_cluster>
+    </remote_servers>
+</clickhouse>

--- a/tests/integration/test_distributed_config/test.py
+++ b/tests/integration/test_distributed_config/test.py
@@ -3,7 +3,7 @@ from helpers.cluster import ClickHouseCluster
 import logging
 
 cluster = ClickHouseCluster(__file__)
-node = cluster.add_instance("node", main_configs=["configs/overrides.xml"])
+node = cluster.add_instance("node", main_configs=["configs/overrides.xml", "configs/clusters.xml"])
 
 
 @pytest.fixture(scope="module")
@@ -23,7 +23,7 @@ def test_distibuted_settings(start_cluster):
     node.query(
         """
         CREATE TABLE data_1 (key Int) ENGINE Memory();
-        CREATE TABLE dist_1 as data_1 ENGINE Distributed(default, default, data_1) SETTINGS flush_on_detach = true;
+        CREATE TABLE dist_1 as data_1 ENGINE Distributed(localhost_cluster, default, data_1) SETTINGS flush_on_detach = true;
         SYSTEM STOP DISTRIBUTED SENDS dist_1;
         INSERT INTO dist_1 SETTINGS prefer_localhost_replica=0 VALUES (1);
         DETACH TABLE dist_1;
@@ -36,7 +36,7 @@ def test_distibuted_settings(start_cluster):
     node.query(
         """
         CREATE TABLE data_2 (key Int) ENGINE Memory();
-        CREATE TABLE dist_2 as data_2 ENGINE Distributed(default, default, data_2);
+        CREATE TABLE dist_2 as data_2 ENGINE Distributed(localhost_cluster, default, data_2);
         SYSTEM STOP DISTRIBUTED SENDS dist_2;
         INSERT INTO dist_2 SETTINGS prefer_localhost_replica=0 VALUES (2);
         DETACH TABLE dist_2;

--- a/tests/integration/test_distributed_config/test.py
+++ b/tests/integration/test_distributed_config/test.py
@@ -3,7 +3,9 @@ from helpers.cluster import ClickHouseCluster
 import logging
 
 cluster = ClickHouseCluster(__file__)
-node = cluster.add_instance("node", main_configs=["configs/overrides.xml", "configs/clusters.xml"])
+node = cluster.add_instance(
+    "node", main_configs=["configs/overrides.xml", "configs/clusters.xml"]
+)
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

We don't have default cluster in private config and this test fails