### PR TITLE
Teach the fuzzer to use other numeric types

### DIFF
--- a/src/Client/QueryFuzzer.cpp
+++ b/src/Client/QueryFuzzer.cpp
@@ -974,7 +974,7 @@ ASTPtr QueryFuzzer::reverseLiteralFuzzing(ASTPtr child)
             "toFixedString", /// Same as toDecimal
             "toInt128",
             "toInt256",
-            "toLowCardinality"
+            "toLowCardinality",
             "toNullable",
             "toUInt128",
             "toUInt256"};

--- a/src/Client/QueryFuzzer.cpp
+++ b/src/Client/QueryFuzzer.cpp
@@ -914,6 +914,38 @@ ASTPtr QueryFuzzer::fuzzLiteralUnderExpressionList(ASTPtr child)
         child = makeASTFunction(
             "toFixedString", std::make_shared<ASTLiteral>(value), std::make_shared<ASTLiteral>(static_cast<UInt64>(value.size())));
     }
+    else if (type == Field::Types::Which::UInt64 && fuzz_rand() % 7 == 0)
+    {
+        child = makeASTFunction(fuzz_rand() % 2 == 0 ? "toUInt128" : "toUInt256", std::make_shared<ASTLiteral>(l->value.get<UInt64>()));
+    }
+    else if (type == Field::Types::Which::Int64 && fuzz_rand() % 7 == 0)
+    {
+        child = makeASTFunction(fuzz_rand() % 2 == 0 ? "toInt128" : "toInt256", std::make_shared<ASTLiteral>(l->value.get<Int64>()));
+    }
+    else if (type == Field::Types::Which::Float64 && fuzz_rand() % 7 == 0)
+    {
+        int decimal = fuzz_rand() % 4;
+        if (decimal == 0)
+            child = makeASTFunction(
+                "toDecimal32",
+                std::make_shared<ASTLiteral>(l->value.get<Float64>()),
+                std::make_shared<ASTLiteral>(static_cast<UInt64>(fuzz_rand() % 9)));
+        else if (decimal == 1)
+            child = makeASTFunction(
+                "toDecimal64",
+                std::make_shared<ASTLiteral>(l->value.get<Float64>()),
+                std::make_shared<ASTLiteral>(static_cast<UInt64>(fuzz_rand() % 18)));
+        else if (decimal == 2)
+            child = makeASTFunction(
+                "toDecimal128",
+                std::make_shared<ASTLiteral>(l->value.get<Float64>()),
+                std::make_shared<ASTLiteral>(static_cast<UInt64>(fuzz_rand() % 38)));
+        else
+            child = makeASTFunction(
+                "toDecimal256",
+                std::make_shared<ASTLiteral>(l->value.get<Float64>()),
+                std::make_shared<ASTLiteral>(static_cast<UInt64>(fuzz_rand() % 76)));
+    }
 
     if (fuzz_rand() % 7 == 0)
         child = makeASTFunction("toNullable", child);
@@ -933,7 +965,19 @@ ASTPtr QueryFuzzer::reverseLiteralFuzzing(ASTPtr child)
 {
     if (auto * function = child.get()->as<ASTFunction>())
     {
-        std::unordered_set<String> can_be_reverted{"toNullable", "toLowCardinality", "materialize"};
+        const std::unordered_set<String> can_be_reverted{
+            "materialize",
+            "toDecimal32", /// Keeping the first parameter only should be ok (valid query most of the time)
+            "toDecimal64",
+            "toDecimal128",
+            "toDecimal256",
+            "toFixedString", /// Same as toDecimal
+            "toInt128",
+            "toInt256",
+            "toLowCardinality"
+            "toNullable",
+            "toUInt128",
+            "toUInt256"};
         if (can_be_reverted.contains(function->name) && function->children.size() == 1)
         {
             if (fuzz_rand() % 7 == 0)


### PR DESCRIPTION
### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Teach the fuzzer to use other numeric types

### Documentation entry for user-facing changes

Adding `toLowCardinality` and `toFixedString` was a big help to uncover a large number of issues. Let's see if casting to other numeric types helps too.
