### PR TITLE
Fix test test_input_format_parallel_parsing_memory_tracking

### DIFF
--- a/tests/integration/test_input_format_parallel_parsing_memory_tracking/test.py
+++ b/tests/integration/test_input_format_parallel_parsing_memory_tracking/test.py
@@ -41,7 +41,7 @@ def test_memory_tracking_total():
         [
             "bash",
             "-c",
-            "clickhouse local -q \"SELECT arrayStringConcat(arrayMap(x->toString(cityHash64(x)), range(1000)), ' ') from numbers(10000)\" > data.json",
+            "clickhouse local -q \"SELECT arrayStringConcat(arrayMap(x->toString(cityHash64(x)), range(1000)), ' ') from numbers(10000)\" > data.jsonl",
         ]
     )
 
@@ -56,7 +56,7 @@ def test_memory_tracking_total():
                     "--show-error",
                     "--data-binary",
                     "@data.json",
-                    "http://127.1:8123/?query=INSERT%20INTO%20null%20FORMAT%20TSV",
+                    "http://127.1:8123/?query=INSERT%20INTO%20null%20FORMAT%20JSONEachRow",
                 ]
             )
             == ""


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Was broken in https://github.com/ClickHouse/ClickHouse/pull/61036 (my fault, didn't check failed tests properly)