### PR TITLE
Fix 01761_cast_to_enum_nullable with analyzer.

### DIFF
--- a/src/DataTypes/DataTypeNullable.cpp
+++ b/src/DataTypes/DataTypeNullable.cpp
@@ -4,6 +4,7 @@
 #include <DataTypes/Serializations/SerializationNullable.h>
 #include <DataTypes/DataTypeLowCardinality.h>
 #include <Columns/ColumnNullable.h>
+#include <Columns/ColumnConst.h>
 #include <Core/Field.h>
 #include <Parsers/IAST.h>
 #include <Common/typeid_cast.h>
@@ -54,6 +55,30 @@ size_t DataTypeNullable::getSizeOfValueInMemory() const
 bool DataTypeNullable::equals(const IDataType & rhs) const
 {
     return rhs.isNullable() && nested_data_type->equals(*static_cast<const DataTypeNullable &>(rhs).nested_data_type);
+}
+
+ColumnPtr DataTypeNullable::createColumnConst(size_t size, const Field & field) const
+{
+    if (onlyNull())
+    {
+        auto column = createColumn();
+        column->insert(field);
+        return ColumnConst::create(std::move(column), size);
+    }
+
+    auto column = nested_data_type->createColumn();
+    bool is_null = field.isNull();
+
+    if (is_null)
+        nested_data_type->insertDefaultInto(*column);
+    else
+        column->insert(field);
+
+    auto null_mask = ColumnUInt8::create();
+    null_mask->getData().push_back(is_null ? 1 : 0);
+
+    auto res = ColumnNullable::create(std::move(column), std::move(null_mask));
+    return ColumnConst::create(std::move(res), size);
 }
 
 SerializationPtr DataTypeNullable::doGetDefaultSerialization() const

--- a/src/DataTypes/DataTypeNullable.h
+++ b/src/DataTypes/DataTypeNullable.h
@@ -41,6 +41,7 @@ public:
     bool onlyNull() const override;
     bool canBeInsideLowCardinality() const override { return nested_data_type->canBeInsideLowCardinality(); }
     bool canBePromoted() const override { return nested_data_type->canBePromoted(); }
+    ColumnPtr createColumnConst(size_t size, const Field & field) const override;
 
     const DataTypePtr & getNestedType() const { return nested_data_type; }
 

--- a/tests/analyzer_tech_debt.txt
+++ b/tests/analyzer_tech_debt.txt
@@ -7,7 +7,6 @@
 01584_distributed_buffer_cannot_find_column
 01624_soft_constraints
 01747_join_view_filter_dictionary
-01761_cast_to_enum_nullable
 01925_join_materialized_columns
 01952_optimize_distributed_group_by_sharding_key
 02354_annoy


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

