### PR TITLE
Fix multiword types in data type function

### DIFF
--- a/src/Parsers/ParserCreateQuery.h
+++ b/src/Parsers/ParserCreateQuery.h
@@ -12,6 +12,7 @@
 #include <Parsers/ParserDataType.h>
 #include <Parsers/ParserSetQuery.h>
 #include <Poco/String.h>
+#include <DataTypes/DataTypeFactory.h>
 
 namespace DB
 {
@@ -70,6 +71,9 @@ bool IParserNameTypePair<NameParser>::parseImpl(Pos & pos, ASTPtr & node, Expect
     {
         auto name_type_pair = std::make_shared<ASTNameTypePair>();
         tryGetIdentifierNameInto(name, name_type_pair->name);
+        /// name should not be a type name, check if multiword type, like `INT UNSIGNED`
+        if (DataTypeFactory::instance().hasNameOrAlias(name_type_pair->name))
+            return false;
         name_type_pair->type = type;
         name_type_pair->children.push_back(type);
         node = name_type_pair;

--- a/tests/queries/0_stateless/01604_explain_ast_of_nonselect_query.reference
+++ b/tests/queries/0_stateless/01604_explain_ast_of_nonselect_query.reference
@@ -18,3 +18,34 @@ CreateFunctionQuery double (children 2)
     ExpressionList (children 2)
      Literal UInt64_2
      Identifier n
+CreateQuery  tt (children 3)
+ Identifier tt
+ Columns definition (children 1)
+  ExpressionList (children 4)
+   ColumnDeclaration a (children 1)
+    Function Nullable (children 1)
+     ExpressionList (children 1)
+      Function TINYINT UNSIGNED
+   ColumnDeclaration b (children 1)
+    Function Nested (children 1)
+     ExpressionList (children 2)
+      NameTypePair c (children 1)
+       Function Nullable (children 1)
+        ExpressionList (children 1)
+         Function INT UNSIGNED
+      NameTypePair d (children 1)
+       Function String
+   ColumnDeclaration e (children 1)
+    Function Tuple (children 1)
+     ExpressionList (children 2)
+      NameTypePair f (children 1)
+       Function TINYINT
+      NameTypePair g (children 1)
+       Function String
+   ColumnDeclaration h (children 1)
+    Function Tuple (children 1)
+     ExpressionList (children 2)
+      Function INT
+      Function String
+ Storage definition (children 1)
+  Function Memory

--- a/tests/queries/0_stateless/01604_explain_ast_of_nonselect_query.sql
+++ b/tests/queries/0_stateless/01604_explain_ast_of_nonselect_query.sql
@@ -1,3 +1,4 @@
 explain ast; -- { clientError 62 }
 explain ast alter table t1 delete where date = today();
 explain ast create function double AS  (n) -> 2*n;
+explain ast create table tt(a Nullable(TINYINT UNSIGNED), b Nested(c Nullable(INT UNSIGNED), d String), e Tuple(f TINYINT, g String), h Tuple(INT, String)) Engine=Memory;


### PR DESCRIPTION
close #44752 
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix multiword types in data type function, like `Nullable(INT UNSIGNED)`
