### PR TITLE
Fix `01599_multiline_input_and_singleline_comments` 3 minute wait

### DIFF
--- a/tests/queries/0_stateless/01599_multiline_input_and_singleline_comments.sh
+++ b/tests/queries/0_stateless/01599_multiline_input_and_singleline_comments.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/expect -f
-# Tags: no-fasttest
-# Tag no-fasttest: 180 seconds running
 
 log_user 0
+
+# In some places `-timeout 1`` is used to avoid expect to always wait for the whole timeout
 set timeout 60
+
 match_max 100000
 
 if ![info exists env(CLICKHOUSE_PORT_TCP)] {set env(CLICKHOUSE_PORT_TCP) 9000}
@@ -13,11 +14,11 @@ expect ":) "
 
 # Make a query
 send -- "SELECT 1\r"
-expect ":-] "
+expect -timeout 1 ":-] "
 send -- "-- xxx\r"
-expect ":-] "
+expect -timeout 1 ":-] "
 send -- ", 2\r"
-expect ":-] "
+expect -timeout 1 ":-] "
 send -- ";\r"
 
 expect "│ 1 │ 2 │"

--- a/tests/queries/0_stateless/01599_multiline_input_and_singleline_comments.sh
+++ b/tests/queries/0_stateless/01599_multiline_input_and_singleline_comments.sh
@@ -2,7 +2,7 @@
 
 log_user 0
 
-# In some places `-timeout 1`` is used to avoid expect to always wait for the whole timeout
+# In some places `-timeout 1` is used to avoid expect to always wait for the whole timeout
 set timeout 60
 
 match_max 100000


### PR DESCRIPTION
According to [this](https://play.clickhouse.com/play?user=play#U0VMRUNUCiAgY2hlY2tfbmFtZSwKICB0ZXN0X25hbWUsCiAgY291bnQoKSBhcyBydW5zLAogIGF2Zyh0ZXN0X2R1cmF0aW9uX21zLzEwMDAuMCk6OkludDY0IGFzIGR1cmF0aW9uX3NlY29uZHMsCiAgcm91bmQoMTAwICogKGNvdW50SWYodGVzdF9zdGF0dXMgIT0gJ09LJyBBTkQgdGVzdF9zdGF0dXMgIT0gJ1NLSVBQRUQnKSBBUyBmKSAvIHJ1bnMsIDIpIGFzIGZwCkZST00gY2hlY2tzCldIRVJFCiAgICBjaGVja19uYW1lIGlsaWtlICclU3RhdGVsZXNzIHRlc3RzIChyZWxlYXNlKSUnCiAgICBBTkQgdGVzdF9uYW1lICE9ICcnCiAgICBBTkQgcHVsbF9yZXF1ZXN0X251bWJlciA9IDAKICAgIEFORCBjaGVja19zdGFydF90aW1lID4gdG9kYXkoKSAtIGludGVydmFsIDMwIGRheQpHUk9VUCBCWSBjaGVja19uYW1lLCB0ZXN0X25hbWUKT1JERVIgYnkgZHVyYXRpb25fc2Vjb25kcyBERVNDLCBjaGVja19uYW1lLCB0ZXN0X25hbWU=). This test is the longest we have at the moment. And looks like the wait is not necessary at all.

```
Row 1:
──────
check_name:       Stateless tests (release)
test_name:        01599_multiline_input_and_singleline_comments
runs:             424
duration_seconds: 180
fp:               0

Row 2:
──────
check_name:       Stateless tests (release)
test_name:        01111_create_drop_replicated_db_stress
runs:             424
duration_seconds: 146
fp:               0

Row 3:
──────
check_name:       Stateless tests (release)
test_name:        02232_dist_insert_send_logs_level_hung
runs:             424
duration_seconds: 143
fp:               0
```

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
