### PR TITLE
Add checksum validating before extracting archive

### DIFF
--- a/docs/en/getting-started/example-datasets/nyc-taxi.md
+++ b/docs/en/getting-started/example-datasets/nyc-taxi.md
@@ -248,6 +248,9 @@ Some of the files might not download fully. Check the file sizes and re-download
 
 ``` bash
 $ curl -O https://datasets.clickhouse.com/trips_mergetree/partitions/trips_mergetree.tar
+# Validate the checksum
+$ md5sum trips_mergetree.tar
+# Checksum should be equal to: f3b8d469b41d9a82da064ded7245d12c
 $ tar xvf trips_mergetree.tar -C /var/lib/clickhouse # path to ClickHouse data directory
 $ # check permissions of unpacked data, fix if required
 $ sudo service clickhouse-server restart


### PR DESCRIPTION
### Changelog category (leave one):

- Documentation (changelog entry is not required)

Adding the checksum validating step because the TAR archive file size is too large.

And it should validate contents before extracting the archive.

My test script is as follows:

```shell
$ curl -O https://datasets.clickhouse.com/trips_mergetree/partitions/trips_mergetree.tar
$ ls -alh trips_mergetree.tar
-rw-r--r-- 1 root root 131G Feb  7  2022 trips_mergetree.tar
$ md5sum trips_mergetree.tar
f3b8d469b41d9a82da064ded7245d12c  trips_mergetree.tar
```

If someone can help me to check that again, I'll appreciate that :).