### PR TITLE
Fix test test_system_clusters_actual_information flakiness

### DIFF
--- a/tests/integration/test_system_clusters_actual_information/test.py
+++ b/tests/integration/test_system_clusters_actual_information/test.py
@@ -12,20 +12,11 @@ cluster = ClickHouseCluster(__file__)
 node = cluster.add_instance(
     "node", with_zookeeper=True, main_configs=["configs/remote_servers.xml"]
 )
-node_1 = cluster.add_instance("node_1", with_zookeeper=True)
-
 
 @pytest.fixture(scope="module")
 def started_cluster():
     try:
         cluster.start()
-        node_1.query_with_retry("DROP TABLE IF EXISTS replicated")
-
-        node_1.query_with_retry(
-            """CREATE TABLE replicated (id UInt32, date Date) ENGINE =
-            ReplicatedMergeTree('/clickhouse/tables/replicated', 'node_1')  ORDER BY id PARTITION BY toYYYYMM(date)"""
-        )
-
         node.query_with_retry(
             "CREATE TABLE distributed (id UInt32, date Date) ENGINE = Distributed('test_cluster', 'default', 'replicated')"
         )
@@ -37,8 +28,6 @@ def started_cluster():
 
 
 def test(started_cluster):
-    cluster.pause_container("node_1")
-
     node.query("SYSTEM RELOAD CONFIG")
     error = node.query_and_get_error(
         "SELECT count() FROM distributed SETTINGS receive_timeout=1, handshake_timeout_ms=1"
@@ -67,5 +56,3 @@ def test(started_cluster):
 
     assert recovery_time == 0
     assert errors_count == 0
-
-    cluster.unpause_container("node_1")

--- a/tests/integration/test_system_clusters_actual_information/test.py
+++ b/tests/integration/test_system_clusters_actual_information/test.py
@@ -13,6 +13,7 @@ node = cluster.add_instance(
     "node", with_zookeeper=True, main_configs=["configs/remote_servers.xml"]
 )
 
+
 @pytest.fixture(scope="module")
 def started_cluster():
     try:


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Closes https://github.com/ClickHouse/ClickHouse/issues/55168