### PR TITLE
Add sanity check for poll_max_batch_size FileLog setting

### DIFF
--- a/src/Storages/FileLog/FileLogSettings.cpp
+++ b/src/Storages/FileLog/FileLogSettings.cpp
@@ -11,6 +11,7 @@ namespace DB
 namespace ErrorCodes
 {
     extern const int UNKNOWN_SETTING;
+    extern const int INVALID_SETTING_VALUE;
 }
 
 IMPLEMENT_SETTINGS_TRAITS(FileLogSettingsTraits, LIST_OF_FILELOG_SETTINGS)
@@ -36,6 +37,11 @@ void FileLogSettings::loadFromQuery(ASTStorage & storage_def)
         settings_ast->is_standalone = false;
         storage_def.set(storage_def.settings, settings_ast);
     }
+
+    /// Check that batch size is not too high (the same as we check setting max_block_size).
+    constexpr UInt64 max_sane_block_rows_size = 4294967296; // 2^32
+    if (poll_max_batch_size > max_sane_block_rows_size)
+        throw Exception(ErrorCodes::INVALID_SETTING_VALUE, "Sanity check: 'poll_max_batch_size' value is too high ({})", poll_max_batch_size);
 }
 
 }

--- a/tests/queries/0_stateless/03010_file_log_large_poll_batch_size.sql
+++ b/tests/queries/0_stateless/03010_file_log_large_poll_batch_size.sql
@@ -1,0 +1,2 @@
+create table test (number UInt64) engine=FileLog('./user_files/data.jsonl', 'JSONEachRow') settings poll_max_batch_size=18446744073709; -- {serverError INVALID_SETTING_VALUE}
+


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Closes https://github.com/ClickHouse/ClickHouse/issues/49454