### PR TITLE
Fix finishing a failed RESTORE

### DIFF
--- a/src/Backups/RestorerFromBackup.cpp
+++ b/src/Backups/RestorerFromBackup.cpp
@@ -101,10 +101,12 @@ RestorerFromBackup::RestorerFromBackup(
 
 RestorerFromBackup::~RestorerFromBackup()
 {
-    if (!futures.empty())
+    /// If an exception occurs we can come here to the destructor having some tasks still unfinished.
+    /// We have to wait until they finish.
+    if (getNumFutures() > 0)
     {
-        LOG_ERROR(log, "RestorerFromBackup must not be destroyed while {} tasks are still running", futures.size());
-        chassert(false && "RestorerFromBackup must not be destroyed while some tasks are still running");
+        LOG_INFO(log, "Waiting for {} tasks to finish", getNumFutures());
+        waitFutures();
     }
 }
 


### PR DESCRIPTION
### Changelog category:
- Bug Fix

### Changelog entry:
Fix finishing a failed RESTORE.

This issue was found while investigating a [failure](https://s3.amazonaws.com/clickhouse-test-reports/61408/e08eaebc9946d39d19b4e995cfdc962719c55c44/integration_tests__tsan__[6_6].html) of the `test_backup_restore_new/test_cancel_backup.py` test.