### PR TITLE
Allow queuing in restore pool

### DIFF
--- a/src/Backups/BackupsWorker.cpp
+++ b/src/Backups/BackupsWorker.cpp
@@ -327,7 +327,7 @@ public:
                 metric_active_threads = CurrentMetrics::RestoreThreadsActive;
                 metric_active_threads = CurrentMetrics::RestoreThreadsScheduled;
                 max_threads = num_restore_threads;
-                use_queue = (thread_pool_id != ThreadPoolId::RESTORE);
+                use_queue = true;
                 break;
             }
         }


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix deadlock during `restore database` execution if `restore_threads` was set to 1.