### PR TITLE
Disallow s3queue sharded mode

### DIFF
--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -114,6 +114,7 @@ class IColumn;
     M(Bool, enable_s3_requests_logging, false, "Enable very explicit logging of S3 requests. Makes sense for debug only.", 0) \
     M(String, s3queue_default_zookeeper_path, "/clickhouse/s3queue/", "Default zookeeper path prefix for S3Queue engine", 0) \
     M(Bool, s3queue_enable_logging_to_s3queue_log, false, "Enable writing to system.s3queue_log. The value can be overwritten per table with table settings", 0) \
+    M(Bool, s3queue_allow_experimental_sharded_mode, false, "Enable experimental sharded mode of S3Queue table engine. It is experimental because it will be rewritten", 0) \
     M(UInt64, hdfs_replication, 0, "The actual number of replications can be specified when the hdfs file is created.", 0) \
     M(Bool, hdfs_truncate_on_insert, false, "Enables or disables truncate before insert in s3 engine tables", 0) \
     M(Bool, hdfs_create_new_file_on_insert, false, "Enables or disables creating a new file on each insert in hdfs engine tables", 0) \

--- a/src/Core/SettingsChangesHistory.h
+++ b/src/Core/SettingsChangesHistory.h
@@ -100,6 +100,7 @@ static std::map<ClickHouseVersion, SettingsChangesHistory::SettingsChanges> sett
               {"keeper_max_retries", 10, 10, "Max retries for general keeper operations"},
               {"keeper_retry_initial_backoff_ms", 100, 100, "Initial backoff timeout for general keeper operations"},
               {"keeper_retry_max_backoff_ms", 5000, 5000, "Max backoff timeout for general keeper operations"},
+              {"s3queue_allow_experimental_sharded_mode", false, false, "Enable experimental sharded mode of S3Queue table engine. It is experimental because it will be rewritten"},
               }},
     {"24.2", {{"allow_suspicious_variant_types", true, false, "Don't allow creating Variant type with suspicious variants by default"},
               {"validate_experimental_and_suspicious_types_inside_nested_types", false, true, "Validate usage of experimental and suspicious types inside nested types"},

--- a/src/Storages/S3Queue/StorageS3Queue.cpp
+++ b/src/Storages/S3Queue/StorageS3Queue.cpp
@@ -133,7 +133,7 @@ StorageS3Queue::StorageS3Queue(
     if (mode == LoadingStrictnessLevel::CREATE
         && !context_->getSettingsRef().s3queue_allow_experimental_sharded_mode
         && s3queue_settings->mode == S3QueueMode::ORDERED
-        && s3queue_settings->s3queue_total_shards_num)
+        && (s3queue_settings->s3queue_total_shards_num > 1 || s3queue_settings->s3queue_processing_threads_num > 1))
     {
         throw Exception(ErrorCodes::QUERY_NOT_ALLOWED, "S3Queue sharded mode is not allowed. To enable use `s3queue_allow_experimental_sharded_mode`");
     }

--- a/src/Storages/S3Queue/StorageS3Queue.h
+++ b/src/Storages/S3Queue/StorageS3Queue.h
@@ -37,7 +37,8 @@ public:
         const String & comment,
         ContextPtr context_,
         std::optional<FormatSettings> format_settings_,
-        ASTStorage * engine_args);
+        ASTStorage * engine_args,
+        LoadingStrictnessLevel mode);
 
     String getName() const override { return "S3Queue"; }
 

--- a/tests/integration/test_mask_sensitive_info/configs/users.xml
+++ b/tests/integration/test_mask_sensitive_info/configs/users.xml
@@ -2,7 +2,6 @@
     <profiles>
         <default>
             <s3_retry_attempts>5</s3_retry_attempts>
-            <s3queue_allow_experimental_sharded_mode>1</s3queue_allow_experimental_sharded_mode>
         </default>
     </profiles>
     <users>

--- a/tests/integration/test_mask_sensitive_info/configs/users.xml
+++ b/tests/integration/test_mask_sensitive_info/configs/users.xml
@@ -2,6 +2,7 @@
     <profiles>
         <default>
             <s3_retry_attempts>5</s3_retry_attempts>
+            <s3queue_allow_experimental_sharded_mode>1</s3queue_allow_experimental_sharded_mode>
         </default>
     </profiles>
     <users>

--- a/tests/integration/test_storage_s3_queue/configs/users.xml
+++ b/tests/integration/test_storage_s3_queue/configs/users.xml
@@ -3,6 +3,7 @@
         <default>
             <stream_like_engine_allow_direct_select>1</stream_like_engine_allow_direct_select>
             <s3queue_enable_logging_to_s3queue_log>1</s3queue_enable_logging_to_s3queue_log>
+            <s3queue_allow_experimental_sharded_mode>1</s3queue_allow_experimental_sharded_mode>
         </default>
     </profiles>
 </clickhouse>


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Disallow sharded mode of StorageS3 queue, because it will be rewritten.