### PR TITLE
Don't run 01459_manual_write_to_replicas in debug build as it's too slow

### DIFF
--- a/tests/queries/0_stateless/01459_manual_write_to_replicas.sh
+++ b/tests/queries/0_stateless/01459_manual_write_to_replicas.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: replica, no-parallel
+# Tags: replica, no-parallel, no-debug
 
 set -e
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Closes https://github.com/ClickHouse/ClickHouse/issues/56931