### PR TITLE
Fix read_rows count with external group by

### DIFF
--- a/src/Processors/ISource.h
+++ b/src/Processors/ISource.h
@@ -44,7 +44,7 @@ public:
     void setStorageLimits(const std::shared_ptr<const StorageLimitsList> & storage_limits_) override;
 
     /// Default implementation for all the sources.
-    std::optional<ReadProgress> getReadProgress() final;
+    std::optional<ReadProgress> getReadProgress() override;
 
     void addTotalRowsApprox(size_t value);
     void addTotalBytes(size_t value);

--- a/src/Processors/Transforms/AggregatingTransform.cpp
+++ b/src/Processors/Transforms/AggregatingTransform.cpp
@@ -80,6 +80,8 @@ namespace
             return convertToChunk(block);
         }
 
+        std::optional<ReadProgress> getReadProgress() override { return std::nullopt; }
+
     private:
         TemporaryFileStream * tmp_stream;
     };


### PR DESCRIPTION

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Caught by `02122_parallel_formatting_Template` with `max_bytes_before_external_group_by` randomization