### PR TITLE
Fix: check constant arguments at the beginning of function execution

### DIFF
--- a/tests/queries/0_stateless/03013_func_args_const.sql
+++ b/tests/queries/0_stateless/03013_func_args_const.sql
@@ -1,0 +1,1 @@
+SELECT trunc(materialize(toLowCardinality(0)), materialize(toLowCardinality(0))); -- { serverError ILLEGAL_COLUMN }


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Function arguments which supposed to be constant should always be checked.

closes #61531
