### PR TITLE
Fix `02481_async_insert_dedup_token`

### DIFF
--- a/tests/queries/0_stateless/02481_async_insert_dedup.python
+++ b/tests/queries/0_stateless/02481_async_insert_dedup.python
@@ -119,7 +119,7 @@ q = queue.Queue(100)
 total_number = 10000
 
 use_token = False
-if len(sys.argv) > 3 and sys.argv[2] == "token":
+if len(sys.argv) >= 3 and sys.argv[2] == "token":
     use_token = True
 
 gen = Thread(target=generate_data, args=[q, total_number, use_token])


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


We didn't test async insert with deduplication tokens because of my stupid bug...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
