### PR TITLE
Fix 02943_rmt_alter_metadata_merge_checksum_mismatch flakiness

### DIFF
--- a/tests/queries/0_stateless/02943_rmt_alter_metadata_merge_checksum_mismatch.sh
+++ b/tests/queries/0_stateless/02943_rmt_alter_metadata_merge_checksum_mismatch.sh
@@ -82,6 +82,8 @@ $CLICKHOUSE_CLIENT -q "optimize table $success_replica final settings optimize_t
 
 $CLICKHOUSE_CLIENT -nm --insert_keeper_fault_injection_probability=0 -q "
     insert into $success_replica (key) values (2); -- part all_2_2_0
+    -- Avoid 'Cannot select parts for optimization: Entry for part all_2_2_0 hasn't been read from the replication log yet'
+    system sync replica $success_replica pull;
     optimize table $success_replica final settings optimize_throw_if_noop=1, alter_sync=1; -- part all_0_2_2_1
     system sync replica $failed_replica pull;
 "


### PR DESCRIPTION
CI: https://s3.amazonaws.com/clickhouse-test-reports/60225/082a686cd1e450e18876d7a67d679c2905ec8589/fast_test.html

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)