### PR TITLE
Fix clickhouse-test client option and CLICKHOUSE_URL_PARAMS interference

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -2900,7 +2900,7 @@ def get_additional_client_options(args):
     if args.client_option:
         client_options = " ".join("--" + option for option in args.client_option)
         if "CLICKHOUSE_CLIENT_OPT" in os.environ:
-            return os.environ["CLICKHOUSE_CLIENT_OPT"] + client_options
+            return os.environ["CLICKHOUSE_CLIENT_OPT"] + " " + client_options
         else:
             return client_options
     else:
@@ -3360,7 +3360,6 @@ if __name__ == "__main__":
         else:
             os.environ["CLICKHOUSE_CLIENT_OPT"] = ""
 
-        os.environ["CLICKHOUSE_CLIENT_OPT"] += get_additional_client_options(args)
         if args.secure:
             os.environ["CLICKHOUSE_CLIENT_OPT"] += " --secure "
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

