### PR TITLE
Fixing client options in clickhouse-test.

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -2900,7 +2900,7 @@ def get_additional_client_options(args):
     if args.client_option:
         client_options = " ".join("--" + option for option in args.client_option)
         if "CLICKHOUSE_CLIENT_OPT" in os.environ:
-            return os.environ["CLICKHOUSE_CLIENT_OPT"] + client_options
+            return os.environ["CLICKHOUSE_CLIENT_OPT"] + ' ' + client_options
         else:
             return client_options
     else:


### PR DESCRIPTION

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Was broken, eg
```
./clickhouse-test 02404_memory_bound_merging --client-option allow_experimental_analyzer=1
[ FAIL ] - return code: 1
Code: 467. DB::Exception: Cannot parse bool from string '1--allow_experimental_analyzer=1'. (CANNOT_PARSE_BOOL)

```