### PR TITLE
Fix 01244_optimize_distributed_group_by_sharding_key by ordering output

### DIFF
--- a/tests/queries/0_stateless/01244_optimize_distributed_group_by_sharding_key.reference
+++ b/tests/queries/0_stateless/01244_optimize_distributed_group_by_sharding_key.reference
@@ -60,8 +60,8 @@ LIMIT OFFSET
 OFFSET distributed_push_down_limit=0
 1	1
 OFFSET distributed_push_down_limit=1
-1	1
 1	0
+1	1
 1	1
 WHERE LIMIT OFFSET
 1	1

--- a/tests/queries/0_stateless/01244_optimize_distributed_group_by_sharding_key.sql
+++ b/tests/queries/0_stateless/01244_optimize_distributed_group_by_sharding_key.sql
@@ -69,7 +69,7 @@ select count(), * from dist_01247 group by number limit 1 offset 1;
 select 'OFFSET distributed_push_down_limit=0';
 select count(), * from dist_01247 group by number offset 1 settings distributed_push_down_limit=0;
 select 'OFFSET distributed_push_down_limit=1';
-select count(), * from dist_01247 group by number offset 1 settings distributed_push_down_limit=1;
+select count(), * from dist_01247 group by number order by count(), number offset 1 settings distributed_push_down_limit=1;
 -- this will emulate different data on for different shards
 select 'WHERE LIMIT OFFSET';
 select count(), * from dist_01247 where number = _shard_num-1 group by number order by number limit 1 offset 1;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
A follow-up for #61089