### PR TITLE
Followup for CLICKHOUSE_CLIENT_OPT in clickhouse-test #61596

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -2896,17 +2896,8 @@ def find_clickhouse_command(binary, command):
     return binary + " " + command
 
 
-def get_additional_client_options(args):
-    if args.client_option:
-        client_options = " ".join("--" + option for option in args.client_option)
-        if "CLICKHOUSE_CLIENT_OPT" in os.environ:
-            return os.environ["CLICKHOUSE_CLIENT_OPT"] + " " + client_options
-        else:
-            return client_options
-    else:
-        if "CLICKHOUSE_CLIENT_OPT" in os.environ:
-            return os.environ["CLICKHOUSE_CLIENT_OPT"]
-    return ""
+def get_additional_client_options(_args):
+    return os.environ.get("CLICKHOUSE_CLIENT_OPT", "")
 
 
 def get_additional_client_options_url(args):
@@ -3359,6 +3350,10 @@ if __name__ == "__main__":
             os.environ["CLICKHOUSE_CLIENT_OPT"] += " "
         else:
             os.environ["CLICKHOUSE_CLIENT_OPT"] = ""
+
+        os.environ["CLICKHOUSE_CLIENT_OPT"] += " ".join(
+            "--" + option for option in (args.client_option or [])
+        )
 
         if args.secure:
             os.environ["CLICKHOUSE_CLIENT_OPT"] += " --secure "


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Followup for https://github.com/ClickHouse/ClickHouse/pull/61596

@jsc0218 I decided that it's better to keep everything in `CLICKHOUSE_CLIENT_OPT` as it was before but without duplication (what was because of adding  `args.client_option` to `CLICKHOUSE_CLIENT_OPT` twice)