### PR TITLE
Remove some magic_enum from headers

### DIFF
--- a/src/Common/IntervalKind.cpp
+++ b/src/Common/IntervalKind.cpp
@@ -1,6 +1,8 @@
 #include <Common/IntervalKind.h>
 #include <Common/Exception.h>
 
+#include <base/EnumReflection.h>
+
 
 namespace DB
 {
@@ -8,6 +10,11 @@ namespace ErrorCodes
 {
     extern const int SYNTAX_ERROR;
     extern const int BAD_ARGUMENTS;
+}
+
+std::string_view IntervalKind::toString() const
+{
+    return magic_enum::enum_name(kind);
 }
 
 Int64 IntervalKind::toAvgNanoseconds() const

--- a/src/Common/IntervalKind.h
+++ b/src/Common/IntervalKind.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <base/types.h>
-#include <base/EnumReflection.h>
 
 namespace DB
 {
@@ -27,7 +26,7 @@ struct IntervalKind
     IntervalKind(Kind kind_ = Kind::Second) : kind(kind_) {} /// NOLINT
     operator Kind() const { return kind; } /// NOLINT
 
-    constexpr std::string_view toString() const { return magic_enum::enum_name(kind); }
+    std::string_view toString() const;
 
     /// Returns number of nanoseconds in one interval.
     /// For `Month`, `Quarter` and `Year` the function returns an average number of nanoseconds.

--- a/src/Storages/MergeTree/MergeTreeDataPartType.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataPartType.cpp
@@ -1,0 +1,47 @@
+#include <base/types.h>
+#include <Common/Exception.h>
+
+#include <magic_enum.hpp>
+
+#include <Storages/MergeTree/MergeTreeDataPartType.h>
+
+namespace DB
+{
+
+namespace ErrorCodes
+{
+extern const int BAD_ARGUMENTS;
+}
+
+template <typename E>
+requires std::is_enum_v<E>
+static E parseEnum(const String & str)
+{
+    auto value = magic_enum::enum_cast<E>(str);
+    if (!value || *value == E::Unknown)
+        throw DB::Exception(ErrorCodes::BAD_ARGUMENTS, "Unexpected string {} for enum {}", str, magic_enum::enum_type_name<E>());
+
+    return *value;
+}
+
+String MergeTreeDataPartType::toString() const
+{
+    return String(magic_enum::enum_name(value));
+}
+
+void MergeTreeDataPartType::fromString(const String & str)
+{
+    value = parseEnum<Value>(str);
+}
+
+String MergeTreeDataPartStorageType::toString() const
+{
+    return String(magic_enum::enum_name(value));
+}
+
+void MergeTreeDataPartStorageType::fromString(const String & str)
+{
+    value = parseEnum<Value>(str);
+}
+
+}

--- a/src/Storages/MergeTree/MergeTreeDataPartType.h
+++ b/src/Storages/MergeTree/MergeTreeDataPartType.h
@@ -1,29 +1,9 @@
 #pragma once
 
-#include <Common/Exception.h>
 #include <base/types.h>
-#include <magic_enum.hpp>
 
 namespace DB
 {
-
-namespace ErrorCodes
-{
-    extern const int BAD_ARGUMENTS;
-}
-
-template <typename E>
-requires std::is_enum_v<E>
-static E parseEnum(const String & str)
-{
-    auto value = magic_enum::enum_cast<E>(str);
-    if (!value || *value == E::Unknown)
-        throw DB::Exception(ErrorCodes::BAD_ARGUMENTS,
-            "Unexpected string {} for enum {}", str, magic_enum::enum_type_name<E>());
-
-    return *value;
-}
-
 /// It's a bug in clang with three-way comparison operator
 /// https://github.com/llvm/llvm-project/issues/55919
 #pragma clang diagnostic push
@@ -51,8 +31,8 @@ public:
     auto operator<=>(const MergeTreeDataPartType &) const = default;
 
     Value getValue() const { return value; }
-    String toString() const { return String(magic_enum::enum_name(value)); }
-    void fromString(const String & str) { value = parseEnum<Value>(str); }
+    String toString() const;
+    void fromString(const String & str);
 
 private:
     Value value;
@@ -74,8 +54,8 @@ public:
     auto operator<=>(const MergeTreeDataPartStorageType &) const = default;
 
     Value getValue() const { return value; }
-    String toString() const { return String(magic_enum::enum_name(value)); }
-    void fromString(const String & str) { value = parseEnum<Value>(str); }
+    String toString() const;
+    void fromString(const String & str);
 
 private:
     Value value;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Remove some magic_enum from headers

### Documentation entry for user-facing changes


