### PR TITLE
Try to fix `02908_many_requests_to_system_replicas` again

### DIFF
--- a/src/Storages/System/StorageSystemReplicas.cpp
+++ b/src/Storages/System/StorageSystemReplicas.cpp
@@ -135,8 +135,12 @@ public:
 
             auto & [_, storage, promise, with_zk_fields] = req;
 
-            auto get_status_task = [this, storage, with_zk_fields, promise] () mutable
+            auto get_status_task = [this, storage, with_zk_fields, promise, thread_group = CurrentThread::getGroup()]() mutable
             {
+                SCOPE_EXIT_SAFE(if (thread_group) CurrentThread::detachFromGroupIfNotDetached(););
+                if (thread_group)
+                    CurrentThread::attachToGroupIfDetached(thread_group);
+
                 try
                 {
                     ReplicatedTableStatus status;

--- a/tests/queries/0_stateless/02908_many_requests_to_system_replicas.reference
+++ b/tests/queries/0_stateless/02908_many_requests_to_system_replicas.reference
@@ -3,3 +3,4 @@ Making 200 requests to system.replicas
 Query system.replicas while waiting for other concurrent requests to finish
 0
 900
+1


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

---

It continues to fail in other place:

```
2024-03-20 04:00:06 --- /usr/share/clickhouse-test/queries/0_stateless/02908_many_requests_to_system_replicas.reference	2024-03-20 03:46:22.128718996 +1100
2024-03-20 04:00:06 +++ /tmp/clickhouse-test/0_stateless/02908_many_requests_to_system_replicas.stdout	2024-03-20 03:59:52.495496894 +1100
2024-03-20 04:00:06 @@ -1,5 +1,25 @@
2024-03-20 04:00:06  Creating 300 tables
2024-03-20 04:00:06  Making 200 requests to system.replicas
2024-03-20 04:00:06  Query system.replicas while waiting for other concurrent requests to finish
2024-03-20 04:00:06 +curl: (56) Recv failure:c uCroclnu:nr el(c:5t 6i()o5 n6R )ecr cueRvrcse luecf:rtva l  i(:bfl5 yau6( ir)5ple 6eu:R)er e reCcR
2024-03-20 04:00:06 +:ove n cCnfvoea ncifntlaeiuicorltneui :ror eneC: so renCetnos enebcntyte  icbpotyeni e oprrne
2024-03-20 04:00:06 +e esrree
2024-03-20 04:00:06 +ts ebty  bpye cepurer
2024-03-20 04:00:06 +elr:
2024-03-20 04:00:06 + (56) Recv faciulrulr:e :( 5C6o)n nReecctvi ofna irleusreet:  bCyo npneeecrt
2024-03-20 04:00:06 +ion reset by peer
2024-03-20 04:00:06 +curl: (56) Recv failure: Connection reset by peer
2024-03-20 04:00:06 +query 200 failed
2024-03-20 04:00:06 +query 161 failed
2024-03-20 04:00:06 +query 140 failed
2024-03-20 04:00:06 +query 168 failed
2024-03-20 04:00:06 +query 158 failed
2024-03-20 04:00:06 +query 176 failed
2024-03-20 04:00:06 +query 129 failed
2024-03-20 04:00:06 +curl: (56) Recv failure: Connection reset by peer
2024-03-20 04:00:06 +query 106 failed
2024-03-20 04:00:06 +query 75 failed
2024-03-20 04:00:06 +curl: (56) Recv failure: Connection reset by peer
2024-03-20 04:00:06 +query 194 failed
2024-03-20 04:00:06  0
2024-03-20 04:00:06  900
```