### PR TITLE
Fix `system.part_log` for async insert with deduplication

### DIFF
--- a/tests/queries/0_stateless/03014_async_with_dedup_part_log_rmt.reference
+++ b/tests/queries/0_stateless/03014_async_with_dedup_part_log_rmt.reference
@@ -1,0 +1,5 @@
+-- Inserted part --
+0	1
+-- Deduplicated part --
+0	1
+389	1

--- a/tests/queries/0_stateless/03014_async_with_dedup_part_log_rmt.sql
+++ b/tests/queries/0_stateless/03014_async_with_dedup_part_log_rmt.sql
@@ -1,0 +1,24 @@
+CREATE TABLE 03014_async_with_dedup_part_log (x UInt64)
+ENGINE=ReplicatedMergeTree('/clickhouse/table/{database}/03014_async_with_dedup_part_log', 'r1') ORDER BY tuple();
+
+SET async_insert = 1;
+SET wait_for_async_insert = 1;
+SET async_insert_deduplicate = 1;
+
+SELECT '-- Inserted part --';
+INSERT INTO 03014_async_with_dedup_part_log VALUES (2);
+
+SYSTEM FLUSH LOGS;
+SELECT error, count() FROM system.part_log
+WHERE table = '03014_async_with_dedup_part_log' and database = currentDatabase()
+GROUP BY error
+ORDER BY error;
+
+SELECT '-- Deduplicated part --';
+INSERT INTO 03014_async_with_dedup_part_log VALUES (2);
+
+SYSTEM FLUSH LOGS;
+SELECT error, count() FROM system.part_log
+WHERE table = '03014_async_with_dedup_part_log' and database = currentDatabase()
+GROUP BY error
+ORDER BY error;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add parts to `system.part_log` when created using async insert with deduplication. 

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
