### PR TITLE
Better fuzzer logs

### DIFF
--- a/docker/test/fuzzer/run-fuzzer.sh
+++ b/docker/test/fuzzer/run-fuzzer.sh
@@ -173,16 +173,15 @@ function fuzz
 
     mkdir -p /var/run/clickhouse-server
 
-    # NOTE: we use process substitution here to preserve keep $! as a pid of clickhouse-server
-    # server.log -> CH logs
-    # stderr.log -> Process logs (sanitizer)
+    # server.log -> All server logs, including sanitizer
+    # stderr.log -> Process logs (sanitizer) only
     clickhouse-server \
         --config-file db/config.xml \
         --pid-file /var/run/clickhouse-server/clickhouse-server.pid \
         --  --path db \
             --logger.console=0 \
-            --logger.log=server.log > stderr.log 2>&1 &
-    server_pid=$!
+            --logger.log=server.log 2>&1 | tee -a stderr.log >> server.log 2>&1 &
+    server_pid=$(pidof clickhouse-server)
 
     kill -0 $server_pid
 
@@ -310,7 +309,7 @@ quit
     if [ "$server_died" == 1 ]
     then
         # The server has died.
-        if ! rg --text -o 'Received signal.*|Logical error.*|Assertion.*failed|Failed assertion.*|.*runtime error: .*|.*is located.*|(SUMMARY|ERROR): [a-zA-Z]+Sanitizer:.*|.*_LIBCPP_ASSERT.*|.*Child process was terminated by signal 9.*' server.log stderr.log > description.txt
+        if ! rg --text -o 'Received signal.*|Logical error.*|Assertion.*failed|Failed assertion.*|.*runtime error: .*|.*is located.*|(SUMMARY|ERROR): [a-zA-Z]+Sanitizer:.*|.*_LIBCPP_ASSERT.*|.*Child process was terminated by signal 9.*' server.log > description.txt
         then
             echo "Lost connection to server. See the logs." > description.txt
         fi


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

Followup to https://github.com/ClickHouse/ClickHouse/pull/61333

2 changes:
* Don't output filename in the description (e.g `server.log:Logical error: \'Not-`).
* Duplicate sanitizer / stderr logs in both a separate file and in server.log. This is necessary so it's easier to match sanitizer reports with the exact running query in the server logs. If they are separate is not as easy to do.
