### PR TITLE
Restore poco SUN files

### DIFF
--- a/base/poco/Foundation/include/Poco/FPEnvironment_SUN.h
+++ b/base/poco/Foundation/include/Poco/FPEnvironment_SUN.h
@@ -1,0 +1,75 @@
+//
+// FPEnvironment_SUN.h
+//
+// Library: Foundation
+// Package: Core
+// Module:  FPEnvironment
+//
+// Definitions of class FPEnvironmentImpl for Solaris.
+//
+// Copyright (c) 2005-2006, Applied Informatics Software Engineering GmbH.
+// and Contributors.
+//
+// SPDX-License-Identifier:	BSL-1.0
+//
+
+
+#ifndef Foundation_FPEnvironment_SUN_INCLUDED
+#define Foundation_FPEnvironment_SUN_INCLUDED
+
+
+#include <ieeefp.h>
+#include "Poco/Foundation.h"
+
+
+namespace Poco
+{
+
+
+class FPEnvironmentImpl
+{
+protected:
+    enum RoundingModeImpl
+    {
+        FP_ROUND_DOWNWARD_IMPL = FP_RM,
+        FP_ROUND_UPWARD_IMPL = FP_RP,
+        FP_ROUND_TONEAREST_IMPL = FP_RN,
+        FP_ROUND_TOWARDZERO_IMPL = FP_RZ
+    };
+    enum FlagImpl
+    {
+        FP_DIVIDE_BY_ZERO_IMPL = FP_X_DZ,
+        FP_INEXACT_IMPL = FP_X_IMP,
+        FP_OVERFLOW_IMPL = FP_X_OFL,
+        FP_UNDERFLOW_IMPL = FP_X_UFL,
+        FP_INVALID_IMPL = FP_X_INV
+    };
+    FPEnvironmentImpl();
+    FPEnvironmentImpl(const FPEnvironmentImpl & env);
+    ~FPEnvironmentImpl();
+    FPEnvironmentImpl & operator=(const FPEnvironmentImpl & env);
+    void keepCurrentImpl();
+    static void clearFlagsImpl();
+    static bool isFlagImpl(FlagImpl flag);
+    static void setRoundingModeImpl(RoundingModeImpl mode);
+    static RoundingModeImpl getRoundingModeImpl();
+    static bool isInfiniteImpl(float value);
+    static bool isInfiniteImpl(double value);
+    static bool isInfiniteImpl(long double value);
+    static bool isNaNImpl(float value);
+    static bool isNaNImpl(double value);
+    static bool isNaNImpl(long double value);
+    static float copySignImpl(float target, float source);
+    static double copySignImpl(double target, double source);
+    static long double copySignImpl(long double target, long double source);
+
+private:
+    fp_rnd _rnd;
+    fp_except _exc;
+};
+
+
+} // namespace Poco
+
+
+#endif // Foundation_FPEnvironment_SUN_INCLUDED

--- a/base/poco/Foundation/src/FPEnvironment_SUN.cpp
+++ b/base/poco/Foundation/src/FPEnvironment_SUN.cpp
@@ -1,0 +1,139 @@
+//
+// FPEnvironment_SUN.cpp
+//
+// Library: Foundation
+// Package: Core
+// Module:  FPEnvironment
+//
+// Copyright (c) 2005-2006, Applied Informatics Software Engineering GmbH.
+// and Contributors.
+//
+// SPDX-License-Identifier:	BSL-1.0
+//
+
+
+#include <math.h>
+#include "Poco/FPEnvironment_SUN.h"
+
+
+namespace Poco {
+
+
+FPEnvironmentImpl::FPEnvironmentImpl()
+{
+	_rnd = fpgetround();
+	_exc = fpgetmask();
+}
+
+
+FPEnvironmentImpl::FPEnvironmentImpl(const FPEnvironmentImpl& env)
+{
+	_rnd = env._rnd;
+	_exc = env._exc;
+}
+
+
+FPEnvironmentImpl::~FPEnvironmentImpl()
+{
+	fpsetround(_rnd);
+	fpsetmask(_exc);
+}
+
+
+FPEnvironmentImpl& FPEnvironmentImpl::operator = (const FPEnvironmentImpl& env)
+{
+	_rnd = env._rnd;
+	_exc = env._exc;
+	return *this;
+}
+
+
+bool FPEnvironmentImpl::isInfiniteImpl(float value)
+{
+	int cls = fpclass(value);
+	return cls == FP_PINF || cls == FP_NINF;
+}
+
+
+bool FPEnvironmentImpl::isInfiniteImpl(double value)
+{
+	int cls = fpclass(value);
+	return cls == FP_PINF || cls == FP_NINF;
+}
+
+
+bool FPEnvironmentImpl::isInfiniteImpl(long double value)
+{
+	int cls = fpclass(value);
+	return cls == FP_PINF || cls == FP_NINF;
+}
+
+
+bool FPEnvironmentImpl::isNaNImpl(float value)
+{
+	return isnanf(value) != 0;
+}
+
+
+bool FPEnvironmentImpl::isNaNImpl(double value)
+{
+	return isnan(value) != 0;
+}
+
+
+bool FPEnvironmentImpl::isNaNImpl(long double value)
+{
+	return isnan((double) value) != 0;
+}
+
+
+float FPEnvironmentImpl::copySignImpl(float target, float source)
+{
+	return (float) copysign(target, source);
+}
+
+
+double FPEnvironmentImpl::copySignImpl(double target, double source)
+{
+	return (float) copysign(target, source);
+}
+
+
+long double FPEnvironmentImpl::copySignImpl(long double target, long double source)
+{
+	return (source > 0 && target > 0) || (source < 0 && target < 0) ? target : -target;
+}
+
+
+void FPEnvironmentImpl::keepCurrentImpl()
+{
+	fpsetround(_rnd);
+	fpsetmask(_exc);
+}
+
+
+void FPEnvironmentImpl::clearFlagsImpl()
+{
+	fpsetsticky(0);
+}
+
+
+bool FPEnvironmentImpl::isFlagImpl(FlagImpl flag)
+{
+	return (fpgetsticky() & flag) != 0;
+}
+
+
+void FPEnvironmentImpl::setRoundingModeImpl(RoundingModeImpl mode)
+{
+	fpsetround((fp_rnd) mode);
+}
+
+
+FPEnvironmentImpl::RoundingModeImpl FPEnvironmentImpl::getRoundingModeImpl()
+{
+	return (FPEnvironmentImpl::RoundingModeImpl) fpgetround();
+}
+
+
+} // namespace Poco


### PR DESCRIPTION
I have been recently updating the version of ClickHouse that we run on the Oxide rack to v23.8 LTS. The operating system there is a fork of [illumos](https://www.illumos.org) and a number of patches to ClickHouse were necessary to get it to build there. I would like to upstream as many of these patches as possible to help maintain illumos support in ClickHouse and make future upgrades easier.

This is the first of these. Some files required for illumos/Solaris were removed as unused in 
https://github.com/ClickHouse/ClickHouse/commit/44afecf083b2cfa3d77d2e227f and this restores them.
I believe the removal was accidental as they are [still referenced from remaining code](https://github.com/ClickHouse/ClickHouse/blob/master/base/poco/Foundation/include/Poco/FPEnvironment.h#L29), and I have not seen anything around removing this platform.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
