### PR TITLE
Another fix for `SumIfToCountIfPass`

### DIFF
--- a/src/Analyzer/Passes/SumIfToCountIfPass.cpp
+++ b/src/Analyzer/Passes/SumIfToCountIfPass.cpp
@@ -97,12 +97,14 @@ public:
         if (!if_true_condition_constant_node || !if_false_condition_constant_node)
             return;
 
+        if (auto constant_type = if_true_condition_constant_node->getResultType(); !isNativeInteger(constant_type))
+            return;
+
+        if (auto constant_type = if_false_condition_constant_node->getResultType(); !isNativeInteger(constant_type))
+            return;
+
         const auto & if_true_condition_constant_value_literal = if_true_condition_constant_node->getValue();
         const auto & if_false_condition_constant_value_literal = if_false_condition_constant_node->getValue();
-
-        if (!isInt64OrUInt64FieldType(if_true_condition_constant_value_literal.getType()) ||
-            !isInt64OrUInt64FieldType(if_false_condition_constant_value_literal.getType()))
-            return;
 
         auto if_true_condition_value = if_true_condition_constant_value_literal.get<UInt64>();
         auto if_false_condition_value = if_false_condition_constant_value_literal.get<UInt64>();

--- a/tests/queries/0_stateless/03010_sum_to_to_count_if_nullable.reference
+++ b/tests/queries/0_stateless/03010_sum_to_to_count_if_nullable.reference
@@ -1,5 +1,6 @@
 (5,NULL)
 (5,NULL)
+((6150),3)
 (5,NULL)
 QUERY id: 0
   PROJECTION COLUMNS
@@ -66,3 +67,48 @@ QUERY id: 0
       ARGUMENTS
         LIST id: 19, nodes: 1
           CONSTANT id: 20, constant_value: UInt64_10, constant_value_type: UInt8
+((6150),3)
+QUERY id: 0
+  PROJECTION COLUMNS
+    ((sum(if(equals(modulo(number, 2), 0), toNullable(0), 123))), toUInt8(3)) Tuple(Tuple(Nullable(UInt64)), UInt8)
+  PROJECTION
+    LIST id: 1, nodes: 1
+      FUNCTION id: 2, function_name: tuple, function_type: ordinary, result_type: Tuple(Tuple(Nullable(UInt64)), UInt8)
+        ARGUMENTS
+          LIST id: 3, nodes: 2
+            FUNCTION id: 4, function_name: tuple, function_type: ordinary, result_type: Tuple(Nullable(UInt64))
+              ARGUMENTS
+                LIST id: 5, nodes: 1
+                  FUNCTION id: 6, function_name: sum, function_type: aggregate, nulls_action : IGNORE_NULLS, result_type: Nullable(UInt64)
+                    ARGUMENTS
+                      LIST id: 7, nodes: 1
+                        FUNCTION id: 8, function_name: if, function_type: ordinary, result_type: Nullable(UInt8)
+                          ARGUMENTS
+                            LIST id: 9, nodes: 3
+                              FUNCTION id: 10, function_name: equals, function_type: ordinary, result_type: UInt8
+                                ARGUMENTS
+                                  LIST id: 11, nodes: 2
+                                    FUNCTION id: 12, function_name: modulo, function_type: ordinary, result_type: UInt8
+                                      ARGUMENTS
+                                        LIST id: 13, nodes: 2
+                                          COLUMN id: 14, column_name: number, result_type: UInt64, source_id: 15
+                                          CONSTANT id: 16, constant_value: UInt64_2, constant_value_type: UInt8
+                                    CONSTANT id: 17, constant_value: UInt64_0, constant_value_type: UInt8
+                              CONSTANT id: 18, constant_value: UInt64_0, constant_value_type: Nullable(UInt8)
+                                EXPRESSION
+                                  FUNCTION id: 19, function_name: toNullable, function_type: ordinary, result_type: Nullable(UInt8)
+                                    ARGUMENTS
+                                      LIST id: 20, nodes: 1
+                                        CONSTANT id: 21, constant_value: UInt64_0, constant_value_type: UInt8
+                              CONSTANT id: 22, constant_value: UInt64_123, constant_value_type: UInt8
+            CONSTANT id: 23, constant_value: UInt64_3, constant_value_type: UInt8
+              EXPRESSION
+                FUNCTION id: 24, function_name: toUInt8, function_type: ordinary, result_type: UInt8
+                  ARGUMENTS
+                    LIST id: 25, nodes: 1
+                      CONSTANT id: 26, constant_value: UInt64_3, constant_value_type: UInt8
+  JOIN TREE
+    TABLE_FUNCTION id: 15, alias: __table1, table_function_name: numbers
+      ARGUMENTS
+        LIST id: 27, nodes: 1
+          CONSTANT id: 28, constant_value: UInt64_100, constant_value_type: UInt8

--- a/tests/queries/0_stateless/03010_sum_to_to_count_if_nullable.sql
+++ b/tests/queries/0_stateless/03010_sum_to_to_count_if_nullable.sql
@@ -3,9 +3,12 @@ SET optimize_rewrite_sum_if_to_count_if = 1;
 SET allow_experimental_analyzer = 0;
 SELECT (sumIf(toNullable(1), (number % 2) = 0), NULL) FROM numbers(10);
 SELECT (sum(if((number % 2) = 0, toNullable(1), 0)), NULL) FROM numbers(10);
+SELECT (tuple(sum(if((number % 2) = 0, toNullable(0), 123)) IGNORE NULLS), toUInt8(3)) FROM numbers(100);
 
 SET allow_experimental_analyzer = 1;
 SELECT (sumIf(toNullable(1), (number % 2) = 0), NULL) FROM numbers(10);
 EXPLAIN QUERY TREE SELECT (sumIf(toNullable(1), (number % 2) = 0), NULL) FROM numbers(10);
 SELECT (sum(if((number % 2) = 0, toNullable(1), 0)), NULL) FROM numbers(10);
 EXPLAIN QUERY TREE SELECT (sum(if((number % 2) = 0, toNullable(1), 0)), NULL) FROM numbers(10);
+SELECT (tuple(sum(if((number % 2) = 0, toNullable(0), 123)) IGNORE NULLS), toUInt8(3)) FROM numbers(100);
+EXPLAIN QUERY TREE SELECT (tuple(sum(if((number % 2) = 0, toNullable(0), 123)) IGNORE NULLS), toUInt8(3)) FROM numbers(100);


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Close https://github.com/ClickHouse/ClickHouse/issues/61624

Interesting how I did add tests for `sum(if...` but because of the numbers I chose it got transformed to `sumOrNullIf` so it didn't test what it needed. 

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
