### PR TITLE
Build improvements by removing magic enum from header and apply some explicit template instantiation

### DIFF
--- a/src/Common/ExternalLoaderStatus.cpp
+++ b/src/Common/ExternalLoaderStatus.cpp
@@ -1,0 +1,18 @@
+#include <Common/ExternalLoaderStatus.h>
+
+#include <base/EnumReflection.h>
+
+namespace DB
+{
+
+std::vector<std::pair<String, Int8>> getExternalLoaderStatusEnumAllPossibleValues()
+{
+    std::vector<std::pair<String, Int8>> out;
+    out.reserve(magic_enum::enum_count<ExternalLoaderStatus>());
+
+    for (const auto & [value, str] : magic_enum::enum_entries<ExternalLoaderStatus>())
+        out.emplace_back(std::string{str}, static_cast<Int8>(value));
+
+    return out;
+}
+}

--- a/src/Common/ExternalLoaderStatus.cpp
+++ b/src/Common/ExternalLoaderStatus.cpp
@@ -15,4 +15,5 @@ std::vector<std::pair<String, Int8>> getExternalLoaderStatusEnumAllPossibleValue
 
     return out;
 }
+
 }

--- a/src/Common/ExternalLoaderStatus.h
+++ b/src/Common/ExternalLoaderStatus.h
@@ -1,30 +1,20 @@
 #pragma once
 
 #include <vector>
-#include <base/EnumReflection.h>
 #include <base/types.h>
 
 namespace DB
 {
-    enum class ExternalLoaderStatus : int8_t
-    {
-        NOT_LOADED, /// Object hasn't been tried to load. This is an initial state.
-        LOADED, /// Object has been loaded successfully.
-        FAILED, /// Object has been failed to load.
-        LOADING, /// Object is being loaded right now for the first time.
-        FAILED_AND_RELOADING, /// Object was failed to load before and it's being reloaded right now.
-        LOADED_AND_RELOADING, /// Object was loaded successfully before and it's being reloaded right now.
-        NOT_EXIST, /// Object with this name wasn't found in the configuration.
-    };
+enum class ExternalLoaderStatus : int8_t
+{
+    NOT_LOADED, /// Object hasn't been tried to load. This is an initial state.
+    LOADED, /// Object has been loaded successfully.
+    FAILED, /// Object has been failed to load.
+    LOADING, /// Object is being loaded right now for the first time.
+    FAILED_AND_RELOADING, /// Object was failed to load before and it's being reloaded right now.
+    LOADED_AND_RELOADING, /// Object was loaded successfully before and it's being reloaded right now.
+    NOT_EXIST, /// Object with this name wasn't found in the configuration.
+};
 
-    inline std::vector<std::pair<String, Int8>> getStatusEnumAllPossibleValues()
-    {
-        std::vector<std::pair<String, Int8>> out;
-        out.reserve(magic_enum::enum_count<ExternalLoaderStatus>());
-
-        for (const auto & [value, str] : magic_enum::enum_entries<ExternalLoaderStatus>())
-            out.emplace_back(std::string{str}, static_cast<Int8>(value));
-
-        return out;
-    }
+std::vector<std::pair<String, Int8>> getExternalLoaderStatusEnumAllPossibleValues();
 }

--- a/src/Core/SettingsEnums.cpp
+++ b/src/Core/SettingsEnums.cpp
@@ -18,6 +18,16 @@ namespace ErrorCodes
     extern const int UNKNOWN_UNION;
 }
 
+template <typename Type>
+constexpr auto getEnumValues()
+{
+    std::array<std::pair<std::string_view, Type>, magic_enum::enum_count<Type>()> enum_values{};
+    size_t index = 0;
+    for (auto value : magic_enum::enum_values<Type>())
+        enum_values[index++] = std::pair{magic_enum::enum_name(value), value};
+    return enum_values;
+}
+
 IMPLEMENT_SETTING_ENUM(LoadBalancing, ErrorCodes::UNKNOWN_LOAD_BALANCING,
     {{"random",           LoadBalancing::RANDOM},
      {"nearest_hostname", LoadBalancing::NEAREST_HOSTNAME},

--- a/src/Core/SettingsFields.h
+++ b/src/Core/SettingsFields.h
@@ -7,9 +7,7 @@
 #include <Core/MultiEnum.h>
 #include <boost/range/adaptor/map.hpp>
 #include <chrono>
-#include <unordered_map>
 #include <string_view>
-#include <magic_enum.hpp>
 
 
 namespace DB
@@ -380,79 +378,6 @@ void SettingFieldEnum<EnumT, Traits>::readBinary(ReadBuffer & in)
     *this = Traits::fromString(SettingFieldEnumHelpers::readBinary(in));
 }
 
-template <typename Type>
-constexpr auto getEnumValues()
-{
-    std::array<std::pair<std::string_view, Type>, magic_enum::enum_count<Type>()> enum_values{};
-    size_t index = 0;
-    for (auto value : magic_enum::enum_values<Type>())
-        enum_values[index++] = std::pair{magic_enum::enum_name(value), value};
-    return enum_values;
-}
-
-/// NOLINTNEXTLINE
-#define DECLARE_SETTING_ENUM(ENUM_TYPE) \
-    DECLARE_SETTING_ENUM_WITH_RENAME(ENUM_TYPE, ENUM_TYPE)
-
-/// NOLINTNEXTLINE
-#define DECLARE_SETTING_ENUM_WITH_RENAME(NEW_NAME, ENUM_TYPE) \
-    struct SettingField##NEW_NAME##Traits \
-    { \
-        using EnumType = ENUM_TYPE; \
-        using EnumValuePairs = std::pair<const char *, EnumType>[]; \
-        static const String & toString(EnumType value); \
-        static EnumType fromString(std::string_view str); \
-    }; \
-    \
-    using SettingField##NEW_NAME = SettingFieldEnum<ENUM_TYPE, SettingField##NEW_NAME##Traits>;
-
-/// NOLINTNEXTLINE
-#define IMPLEMENT_SETTING_ENUM(NEW_NAME, ERROR_CODE_FOR_UNEXPECTED_NAME, ...) \
-    IMPLEMENT_SETTING_ENUM_IMPL(NEW_NAME, ERROR_CODE_FOR_UNEXPECTED_NAME, EnumValuePairs, __VA_ARGS__)
-
-/// NOLINTNEXTLINE
-#define IMPLEMENT_SETTING_AUTO_ENUM(NEW_NAME, ERROR_CODE_FOR_UNEXPECTED_NAME) \
-    IMPLEMENT_SETTING_ENUM_IMPL(NEW_NAME, ERROR_CODE_FOR_UNEXPECTED_NAME, , getEnumValues<EnumType>())
-
-/// NOLINTNEXTLINE
-#define IMPLEMENT_SETTING_ENUM_IMPL(NEW_NAME, ERROR_CODE_FOR_UNEXPECTED_NAME, PAIRS_TYPE, ...) \
-    const String & SettingField##NEW_NAME##Traits::toString(typename SettingField##NEW_NAME::EnumType value) \
-    { \
-        static const std::unordered_map<EnumType, String> map = [] { \
-            std::unordered_map<EnumType, String> res; \
-            for (const auto & [name, val] : PAIRS_TYPE __VA_ARGS__) \
-                res.emplace(val, name); \
-            return res; \
-        }(); \
-        auto it = map.find(value); \
-        if (it != map.end()) \
-            return it->second; \
-        throw Exception(ERROR_CODE_FOR_UNEXPECTED_NAME, \
-            "Unexpected value of " #NEW_NAME ":{}", std::to_string(std::underlying_type_t<EnumType>(value))); \
-    } \
-    \
-    typename SettingField##NEW_NAME::EnumType SettingField##NEW_NAME##Traits::fromString(std::string_view str) \
-    { \
-        static const std::unordered_map<std::string_view, EnumType> map = [] { \
-            std::unordered_map<std::string_view, EnumType> res; \
-            for (const auto & [name, val] : PAIRS_TYPE __VA_ARGS__) \
-                res.emplace(name, val); \
-            return res; \
-        }(); \
-        auto it = map.find(str); \
-        if (it != map.end()) \
-            return it->second; \
-        String msg; \
-        bool need_comma = false; \
-        for (auto & name : map | boost::adaptors::map_keys) \
-        { \
-            if (std::exchange(need_comma, true)) \
-                msg += ", "; \
-            msg += "'" + String{name} + "'"; \
-        } \
-        throw Exception(ERROR_CODE_FOR_UNEXPECTED_NAME, "Unexpected value of " #NEW_NAME ": '{}'. Must be one of [{}]", String{str}, msg); \
-    }
-
 // Mostly like SettingFieldEnum, but can have multiple enum values (or none) set at once.
 template <typename Enum, typename Traits>
 struct SettingFieldMultiEnum
@@ -542,42 +467,6 @@ void SettingFieldMultiEnum<EnumT, Traits>::readBinary(ReadBuffer & in)
 {
     parseFromString(SettingFieldEnumHelpers::readBinary(in));
 }
-
-/// NOLINTNEXTLINE
-#define DECLARE_SETTING_MULTI_ENUM(ENUM_TYPE) \
-    DECLARE_SETTING_MULTI_ENUM_WITH_RENAME(ENUM_TYPE, ENUM_TYPE)
-
-/// NOLINTNEXTLINE
-#define DECLARE_SETTING_MULTI_ENUM_WITH_RENAME(ENUM_TYPE, NEW_NAME) \
-    struct SettingField##NEW_NAME##Traits \
-    { \
-        using EnumType = ENUM_TYPE; \
-        using EnumValuePairs = std::pair<const char *, EnumType>[]; \
-        static size_t getEnumSize(); \
-        static const String & toString(EnumType value); \
-        static EnumType fromString(std::string_view str); \
-    }; \
-    \
-    using SettingField##NEW_NAME = SettingFieldMultiEnum<ENUM_TYPE, SettingField##NEW_NAME##Traits>; \
-    using NEW_NAME##List = typename SettingField##NEW_NAME::ValueType;
-
-/// NOLINTNEXTLINE
-#define IMPLEMENT_SETTING_MULTI_ENUM(ENUM_TYPE, ERROR_CODE_FOR_UNEXPECTED_NAME, ...) \
-    IMPLEMENT_SETTING_MULTI_ENUM_WITH_RENAME(ENUM_TYPE, ERROR_CODE_FOR_UNEXPECTED_NAME, __VA_ARGS__)
-
-/// NOLINTNEXTLINE
-#define IMPLEMENT_SETTING_MULTI_ENUM_WITH_RENAME(NEW_NAME, ERROR_CODE_FOR_UNEXPECTED_NAME, ...) \
-    IMPLEMENT_SETTING_ENUM(NEW_NAME, ERROR_CODE_FOR_UNEXPECTED_NAME, __VA_ARGS__)\
-    size_t SettingField##NEW_NAME##Traits::getEnumSize() {\
-        return std::initializer_list<std::pair<const char*, NEW_NAME>> __VA_ARGS__ .size();\
-    }
-
-/// NOLINTNEXTLINE
-#define IMPLEMENT_SETTING_MULTI_AUTO_ENUM(NEW_NAME, ERROR_CODE_FOR_UNEXPECTED_NAME) \
-    IMPLEMENT_SETTING_AUTO_ENUM(NEW_NAME, ERROR_CODE_FOR_UNEXPECTED_NAME)\
-    size_t SettingField##NEW_NAME##Traits::getEnumSize() {\
-        return getEnumValues<EnumType>().size();\
-    }
 
 /// Setting field for specifying user-defined timezone. It is basically a string, but it needs validation.
 struct SettingFieldTimezone

--- a/src/Dictionaries/DictionaryStructure.h
+++ b/src/Dictionaries/DictionaryStructure.h
@@ -41,33 +41,6 @@ enum class AttributeUnderlyingType : TypeIndexUnderlying
 
 #undef map_item
 
-
-#define CALL_FOR_ALL_DICTIONARY_ATTRIBUTE_TYPES(M) \
-    M(UInt8) \
-    M(UInt16) \
-    M(UInt32) \
-    M(UInt64) \
-    M(UInt128) \
-    M(UInt256) \
-    M(Int8) \
-    M(Int16) \
-    M(Int32) \
-    M(Int64) \
-    M(Int128) \
-    M(Int256) \
-    M(Decimal32) \
-    M(Decimal64) \
-    M(Decimal128) \
-    M(Decimal256) \
-    M(DateTime64) \
-    M(Float32) \
-    M(Float64) \
-    M(UUID) \
-    M(IPv4) \
-    M(IPv6) \
-    M(String) \
-    M(Array)
-
 /// Min and max lifetimes for a dictionary or its entry
 using DictionaryLifetime = ExternalLoadableLifetime;
 

--- a/src/IO/UncompressedCache.cpp
+++ b/src/IO/UncompressedCache.cpp
@@ -1,0 +1,11 @@
+#include <IO/UncompressedCache.h>
+
+namespace DB
+{
+template class CacheBase<UInt128, UncompressedCacheCell, UInt128TrivialHash, UncompressedSizeWeightFunction>;
+
+UncompressedCache::UncompressedCache(const String & cache_policy, size_t max_size_in_bytes, double size_ratio)
+    : Base(cache_policy, max_size_in_bytes, 0, size_ratio)
+{
+}
+}

--- a/src/IO/UncompressedCache.h
+++ b/src/IO/UncompressedCache.h
@@ -33,6 +33,7 @@ struct UncompressedSizeWeightFunction
     }
 };
 
+extern template class CacheBase<UInt128, UncompressedCacheCell, UInt128TrivialHash, UncompressedSizeWeightFunction>;
 
 /** Cache of decompressed blocks for implementation of CachedCompressedReadBuffer. thread-safe.
   */
@@ -42,8 +43,7 @@ private:
     using Base = CacheBase<UInt128, UncompressedCacheCell, UInt128TrivialHash, UncompressedSizeWeightFunction>;
 
 public:
-    UncompressedCache(const String & cache_policy, size_t max_size_in_bytes, double size_ratio)
-        : Base(cache_policy, max_size_in_bytes, 0, size_ratio) {}
+    UncompressedCache(const String & cache_policy, size_t max_size_in_bytes, double size_ratio);
 
     /// Calculate key from path to file and offset.
     static UInt128 hash(const String & path_to_file, size_t offset)

--- a/src/IO/WriteHelpers.h
+++ b/src/IO/WriteHelpers.h
@@ -19,7 +19,6 @@
 #include <base/find_symbols.h>
 #include <base/StringRef.h>
 #include <base/DecomposedFloat.h>
-#include <base/EnumReflection.h>
 
 #include <Core/DecimalFunctions.h>
 #include <Core/Types.h>

--- a/src/Parsers/ASTTablesInSelectQuery.h
+++ b/src/Parsers/ASTTablesInSelectQuery.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <base/EnumReflection.h>
-
 #include <Core/Joins.h>
 
 #include <Parsers/IAST.h>

--- a/src/Storages/MarkCache.cpp
+++ b/src/Storages/MarkCache.cpp
@@ -1,0 +1,11 @@
+#include <Storages/MarkCache.h>
+
+namespace DB
+{
+template class CacheBase<UInt128, MarksInCompressedFile, UInt128TrivialHash, MarksWeightFunction>;
+
+MarkCache::MarkCache(const String & cache_policy, size_t max_size_in_bytes, double size_ratio)
+    : Base(cache_policy, max_size_in_bytes, 0, size_ratio)
+{
+}
+}

--- a/src/Storages/MarkCache.h
+++ b/src/Storages/MarkCache.h
@@ -31,7 +31,7 @@ struct MarksWeightFunction
     }
 };
 
-
+extern template class CacheBase<UInt128, MarksInCompressedFile, UInt128TrivialHash, MarksWeightFunction>;
 /** Cache of 'marks' for StorageMergeTree.
   * Marks is an index structure that addresses ranges in column file, corresponding to ranges of primary key.
   */
@@ -41,8 +41,7 @@ private:
     using Base = CacheBase<UInt128, MarksInCompressedFile, UInt128TrivialHash, MarksWeightFunction>;
 
 public:
-    MarkCache(const String & cache_policy, size_t max_size_in_bytes, double size_ratio)
-        : Base(cache_policy, max_size_in_bytes, 0, size_ratio) {}
+    MarkCache(const String & cache_policy, size_t max_size_in_bytes, double size_ratio);
 
     /// Calculate key from path to file and offset.
     static UInt128 hash(const String & path_to_file)

--- a/src/Storages/System/StorageSystemDictionaries.cpp
+++ b/src/Storages/System/StorageSystemDictionaries.cpp
@@ -66,7 +66,7 @@ ColumnsDescription StorageSystemDictionaries::getColumnsDescription()
         {"database", std::make_shared<DataTypeString>(), "Name of the database containing the dictionary created by DDL query. Empty string for other dictionaries."},
         {"name", std::make_shared<DataTypeString>(), "Dictionary name."},
         {"uuid", std::make_shared<DataTypeUUID>(), "Dictionary UUID."},
-        {"status", std::make_shared<DataTypeEnum8>(getStatusEnumAllPossibleValues()),
+        {"status", std::make_shared<DataTypeEnum8>(getExternalLoaderStatusEnumAllPossibleValues()),
             "Dictionary status. Possible values: "
             "NOT_LOADED — Dictionary was not loaded because it was not used, "
             "LOADED — Dictionary loaded successfully, "


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):


This PR addresses two things:
1. remove some `magic_enum` inclusion from headers
2. explicitly instantiate some `CacheBase` templates

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
