### PR TITLE
Don't allow the same expression in ORDER BY with and without WITH FILL

### DIFF
--- a/src/Processors/Transforms/FillingTransform.cpp
+++ b/src/Processors/Transforms/FillingTransform.cpp
@@ -237,10 +237,21 @@ FillingTransform::FillingTransform(
     }
     logDebug("fill description", dumpSortDescription(fill_description));
 
-    std::set<size_t> unique_positions;
+    std::unordered_set<size_t> ordinary_sort_positions;
+    for (const auto & desc : sort_description)
+    {
+        if (!desc.with_fill)
+            ordinary_sort_positions.insert(header_.getPositionByName(desc.column_name));
+    }
+
+    std::unordered_set<size_t> unique_positions;
     for (auto pos : fill_column_positions)
+    {
         if (!unique_positions.insert(pos).second)
             throw Exception(ErrorCodes::INVALID_WITH_FILL_EXPRESSION, "Multiple WITH FILL for identical expressions is not supported in ORDER BY");
+        if (ordinary_sort_positions.contains(pos))
+            throw Exception(ErrorCodes::INVALID_WITH_FILL_EXPRESSION, "ORDER BY containing the same expression with and without WITH FILL is not supported");
+    }
 
     if (use_with_fill_by_sorting_prefix)
     {

--- a/src/Processors/Transforms/FillingTransform.cpp
+++ b/src/Processors/Transforms/FillingTransform.cpp
@@ -250,7 +250,7 @@ FillingTransform::FillingTransform(
         if (!unique_positions.insert(pos).second)
             throw Exception(ErrorCodes::INVALID_WITH_FILL_EXPRESSION, "Multiple WITH FILL for identical expressions is not supported in ORDER BY");
         if (ordinary_sort_positions.contains(pos))
-            throw Exception(ErrorCodes::INVALID_WITH_FILL_EXPRESSION, "ORDER BY containing the same expression with and without WITH FILL is not supported");
+            throw Exception(ErrorCodes::INVALID_WITH_FILL_EXPRESSION, "ORDER BY containing the same expression with and without WITH FILL modifier is not supported");
     }
 
     if (use_with_fill_by_sorting_prefix)

--- a/tests/queries/0_stateless/03015_with_fill_invalid_expression.sql
+++ b/tests/queries/0_stateless/03015_with_fill_invalid_expression.sql
@@ -1,0 +1,2 @@
+select number as x, number + 1 as y from numbers(5) where number % 3 == 1 order by y, x with fill from 1 to 4, y with fill from 2 to 5; -- {serverError INVALID_WITH_FILL_EXPRESSION}
+


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Don't allow the same expression in ORDER BY with and without WITH FILL. Such invalid expression could lead to logical error `Invalid number of rows in Chunk`.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
