### PR TITLE
Fix use-of-uninitialized-value in HedgedConnections

### DIFF
--- a/src/Client/HedgedConnections.cpp
+++ b/src/Client/HedgedConnections.cpp
@@ -67,7 +67,6 @@ HedgedConnections::HedgedConnections(
     }
 
     active_connection_count = connections.size();
-    offsets_with_disabled_changing_replica = 0;
     pipeline_for_new_replicas.add([throttler_](ReplicaState & replica_) { replica_.connection->setThrottler(throttler_); });
 }
 

--- a/src/Client/HedgedConnections.h
+++ b/src/Client/HedgedConnections.h
@@ -178,12 +178,12 @@ private:
     std::queue<int> offsets_queue;
 
     /// The current number of valid connections to the replicas of this shard.
-    size_t active_connection_count;
+    size_t active_connection_count = 0;
 
     /// We count offsets in which we can't change replica anymore,
     /// it's needed to cancel choosing new replicas when we
     /// disabled replica changing in all offsets.
-    size_t offsets_with_disabled_changing_replica;
+    size_t offsets_with_disabled_changing_replica = 0;
 
     Pipeline pipeline_for_new_replicas;
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Report: [link](https://s3.amazonaws.com/clickhouse-test-reports/61604/e6256fa380721a2d60d29658ae0f8977db1a639e/ast_fuzzer__msan_.html)