### PR TITLE
#54767 Remove extraneous volumes in Keeper image

### DIFF
--- a/docker/keeper/Dockerfile
+++ b/docker/keeper/Dockerfile
@@ -85,6 +85,6 @@ RUN arch=${TARGETARCH:-amd64} \
 
 EXPOSE 2181 10181 44444 9181
 
-VOLUME /var/lib/clickhouse /var/log/clickhouse-keeper /etc/clickhouse-keeper
+VOLUME /var/lib/clickhouse
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/keeper/Dockerfile
+++ b/docker/keeper/Dockerfile
@@ -44,7 +44,10 @@ ARG DIRECT_DOWNLOAD_URLS=""
 # We do that in advance at the begining of Dockerfile before any packages will be
 # installed to prevent picking those uid / gid by some unrelated software.
 # The same uid / gid (101) is used both for alpine and ubuntu.
-
+ARG DEFAULT_UID="101"
+ARG DEFAULT_GID="101"
+RUN addgroup -S -g "${DEFAULT_GID}" clickhouse && \
+    adduser -S -h "/var/lib/clickhouse" -s /bin/bash -G clickhouse -g "ClickHouse keeper" -u "${DEFAULT_UID}" clickhouse
 
 ARG TARGETARCH
 RUN arch=${TARGETARCH:-amd64} \
@@ -71,20 +74,20 @@ RUN arch=${TARGETARCH:-amd64} \
         fi \
     ; done \
     && rm /tmp/*.tgz /install -r \
-    && addgroup -S -g 101 clickhouse \
-    && adduser -S -h /var/lib/clickhouse -s /bin/bash -G clickhouse -g "ClickHouse keeper" -u 101 clickhouse \
-    && mkdir -p /var/lib/clickhouse /var/log/clickhouse-keeper /etc/clickhouse-keeper \
-    && chown clickhouse:clickhouse /var/lib/clickhouse \
-    && chown root:clickhouse /var/log/clickhouse-keeper \
     && chmod +x /entrypoint.sh \
     && apk add --no-cache su-exec bash tzdata \
     && cp /usr/share/zoneinfo/UTC /etc/localtime \
-    && echo "UTC" > /etc/timezone \
-    && chmod ugo+Xrw -R /var/lib/clickhouse /var/log/clickhouse-keeper /etc/clickhouse-keeper
+    && echo "UTC" > /etc/timezone
 
+ARG DEFAULT_CONFIG_DIR="/etc/clickhouse-keeper"
+ARG DEFAULT_DATA_DIR="/var/lib/clickhouse-keeper"
+ARG DEFAULT_LOG_DIR="/var/log/clickhouse-keeper"
+RUN mkdir -p "${DEFAULT_DATA_DIR}" "${DEFAULT_LOG_DIR}" "${DEFAULT_CONFIG_DIR}" \
+    && chown clickhouse:clickhouse "${DEFAULT_DATA_DIR}" \
+    && chown root:clickhouse "${DEFAULT_LOG_DIR}" \
+    && chmod ugo+Xrw -R "${DEFAULT_DATA_DIR}" "${DEFAULT_LOG_DIR}" "${DEFAULT_CONFIG_DIR}"
 
+VOLUME "${DEFAULT_DATA_DIR}"
 EXPOSE 2181 10181 44444 9181
-
-VOLUME /var/lib/clickhouse
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/keeper/Dockerfile
+++ b/docker/keeper/Dockerfile
@@ -87,7 +87,8 @@ RUN mkdir -p "${DEFAULT_DATA_DIR}" "${DEFAULT_LOG_DIR}" "${DEFAULT_CONFIG_DIR}" 
     && chown root:clickhouse "${DEFAULT_LOG_DIR}" \
     && chmod ugo+Xrw -R "${DEFAULT_DATA_DIR}" "${DEFAULT_LOG_DIR}" "${DEFAULT_CONFIG_DIR}"
 
-VOLUME "${DEFAULT_DATA_DIR}"
+# /var/lib/clickhouse is necessary due to the current default configuration for Keeper
+VOLUME "${DEFAULT_DATA_DIR}" /var/lib/clickhouse
 EXPOSE 2181 10181 44444 9181
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/keeper/entrypoint.sh
+++ b/docker/keeper/entrypoint.sh
@@ -80,7 +80,7 @@ if [[ $# -lt 1 ]] || [[ "$1" == "--"* ]]; then
     # so the container can't be finished by ctrl+c
     export CLICKHOUSE_WATCHDOG_ENABLE
 
-    cd /var/lib/clickhouse
+    cd "${DATA_DIR}"
 
     # There is a config file. It is already tested with gosu (if it is readably by keeper user)
     if [ -f "$KEEPER_CONFIG" ]; then

--- a/docker/server/Dockerfile.alpine
+++ b/docker/server/Dockerfile.alpine
@@ -42,6 +42,10 @@ ARG DIRECT_DOWNLOAD_URLS=""
 # We do that in advance at the begining of Dockerfile before any packages will be
 # installed to prevent picking those uid / gid by some unrelated software.
 # The same uid / gid (101) is used both for alpine and ubuntu.
+ARG DEFAULT_UID="101"
+ARG DEFAULT_GID="101"
+RUN addgroup -S -g "${DEFAULT_GID}" clickhouse && \
+    adduser -S -h "/var/lib/clickhouse" -s /bin/bash -G clickhouse -g "ClickHouse server" -u "${DEFAULT_UID}" clickhouse
 
 RUN arch=${TARGETARCH:-amd64} \
     && cd /tmp \
@@ -66,23 +70,30 @@ RUN arch=${TARGETARCH:-amd64} \
         fi \
     ; done \
     && rm /tmp/*.tgz /install -r \
-    && addgroup -S -g 101 clickhouse \
-    && adduser -S -h /var/lib/clickhouse -s /bin/bash -G clickhouse -g "ClickHouse server" -u 101 clickhouse \
-    && mkdir -p /var/lib/clickhouse /var/log/clickhouse-server /etc/clickhouse-server/config.d /etc/clickhouse-server/users.d /etc/clickhouse-client /docker-entrypoint-initdb.d \
-    && chown clickhouse:clickhouse /var/lib/clickhouse \
-    && chown root:clickhouse /var/log/clickhouse-server \
     && chmod +x /entrypoint.sh \
     && apk add --no-cache bash tzdata \
     && cp /usr/share/zoneinfo/UTC /etc/localtime \
-    && echo "UTC" > /etc/timezone \
-    && chmod ugo+Xrw -R /var/lib/clickhouse /var/log/clickhouse-server /etc/clickhouse-server /etc/clickhouse-client
+    && echo "UTC" > /etc/timezone
 
-# we need to allow "others" access to clickhouse folder, because docker container
-# can be started with arbitrary uid (openshift usecase)
+ARG DEFAULT_CLIENT_CONFIG_DIR="/etc/clickhouse-client"
+ARG DEFAULT_SERVER_CONFIG_DIR="/etc/clickhouse-server"
+ARG DEFAULT_DATA_DIR="/var/lib/clickhouse"
+ARG DEFAULT_LOG_DIR="/var/log/clickhouse-server"
 
+# we need to allow "others" access to ClickHouse folders, because docker containers
+# can be started with arbitrary uids (OpenShift usecase)
+RUN mkdir -p \
+      "${DEFAULT_DATA_DIR}" \
+      "${DEFAULT_LOG_DIR}" \
+      "${DEFAULT_CLIENT_CONFIG_DIR}" \
+      "${DEFAULT_SERVER_CONFIG_DIR}/config.d" \
+      "${DEFAULT_SERVER_CONFIG_DIR}/users.d" \
+      /docker-entrypoint-initdb.d \
+    && chown clickhouse:clickhouse "${DEFAULT_DATA_DIR}" \
+    && chown root:clickhouse "${DEFAULT_LOG_DIR}" \
+    && chmod ugo+Xrw -R "${DEFAULT_DATA_DIR}" "${DEFAULT_LOG_DIR}" "${DEFAULT_CLIENT_CONFIG_DIR}" "${DEFAULT_SERVER_CONFIG_DIR}"
+
+VOLUME "${DEFAULT_DATA_DIR}"
 EXPOSE 9000 8123 9009
-
-VOLUME /var/lib/clickhouse \
-       /var/log/clickhouse-server
 
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Remove from the Keeper Docker image the volumes at /etc/clickhouse-keeper and /var/log/clickhouse-keeper

### Documentation entry for user-facing changes

Motivation: Fixes #54767.

In summary (more details in the issue), VOLUME directives in Docker images cannot be overriden by users (neither by extending the image, nor at runtime). Therefore, volumes that are not strictly necessary are:
- a mild security risk (they bypass runtime configurations, like read-only filesystem settings)
- a mild availability risk (/var/log/clickhouse-keeper could get filled upon misconfiguration and impact the host negatively)