### PR TITLE
Fix use-of-uninitialized-value in parseDateTimeBestEffort

### DIFF
--- a/src/IO/parseDateTimeBestEffort.cpp
+++ b/src/IO/parseDateTimeBestEffort.cpp
@@ -147,6 +147,9 @@ ReturnType parseDateTimeBestEffortImpl(
             {
                 has_comma_between_date_and_time = true;
                 ++in.position();
+
+                if (in.eof())
+                    break;
             }
         }
 

--- a/tests/queries/0_stateless/03014_msan_parse_date_time.sql
+++ b/tests/queries/0_stateless/03014_msan_parse_date_time.sql
@@ -1,0 +1,1 @@
+SELECT parseDateTimeBestEffort(toFixedString('01/12/2017,', 11)); -- { serverError CANNOT_PARSE_DATETIME }


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Report: [link](https://s3.amazonaws.com/clickhouse-test-reports/0/2a4116cfb3ecea753563c3d4e1b456cffa062a7c/ast_fuzzer__msan_.html)