### PR TITLE
contrib/curl: Add illumos support

### DIFF
--- a/contrib/curl-cmake/curl_config.h
+++ b/contrib/curl-cmake/curl_config.h
@@ -51,3 +51,8 @@
 #define USE_OPENSSL
 #define USE_THREADS_POSIX
 #define USE_ARES
+
+#ifdef __illumos__
+#define HAVE_POSIX_STRERROR_R 1
+#define HAVE_STRERROR_R 1
+#endif


### PR DESCRIPTION
A couple of extra definitions are required to build contrib/curl
on illumos.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
