### PR TITLE
Fuzzer: Try a different way to wait for the server

### DIFF
--- a/docker/test/fuzzer/run-fuzzer.sh
+++ b/docker/test/fuzzer/run-fuzzer.sh
@@ -181,7 +181,15 @@ function fuzz
         --  --path db \
             --logger.console=0 \
             --logger.log=server.log 2>&1 | tee -a stderr.log >> server.log 2>&1 &
-    server_pid=$(pidof clickhouse-server)
+    for _ in {1..30}
+    do
+        if clickhouse-client --query "select 1"
+        then
+            break
+        fi
+        sleep 1
+    done
+    server_pid=$(cat /var/run/clickhouse-server/clickhouse-server.pid)
 
     kill -0 $server_pid
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Report: https://github.com/ClickHouse/ClickHouse/actions/runs/8368362348/job/22916404621

To be honest, I don't know what's going wrong in this report. AFAIK `clickhouse-server` process should always exists even though it's created and sent to background (`&`), but the report complains about `pidof clickhouse-server` failing. I've executed a similar setup (`clickhouse-server | tee &; pidof clickhouse-server` locally and it's worked without issues thousands of times so I'm surely missing something. 
