### PR TITLE
Disable some tests for SMT

### DIFF
--- a/tests/queries/0_stateless/03002_part_log_rmt_fetch_merge_error.sql
+++ b/tests/queries/0_stateless/03002_part_log_rmt_fetch_merge_error.sql
@@ -1,4 +1,5 @@
--- Tags: no-replicated-database, no-parallel
+-- Tags: no-replicated-database, no-parallel, no-shared-merge-tree
+-- SMT: The merge process is completely different from RMT
 
 drop table if exists rmt_master;
 drop table if exists rmt_slave;

--- a/tests/queries/0_stateless/03002_part_log_rmt_fetch_mutate_error.sql
+++ b/tests/queries/0_stateless/03002_part_log_rmt_fetch_mutate_error.sql
@@ -1,4 +1,5 @@
--- Tags: no-replicated-database, no-parallel
+-- Tags: no-replicated-database, no-parallel, no-shared-merge-tree
+-- SMT: The merge process is completely different from RMT
 
 drop table if exists rmt_master;
 drop table if exists rmt_slave;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Disable some tests for SMT

### Documentation entry for user-facing changes

Introduced in https://github.com/ClickHouse/ClickHouse/pull/60659. SharedMergeTree merge process is completely different as it relies of shared storage.
