### PR TITLE
Fix signal handler for sanitizer signals

### DIFF
--- a/src/Daemon/BaseDaemon.cpp
+++ b/src/Daemon/BaseDaemon.cpp
@@ -275,7 +275,10 @@ public:
                 }
 
                 readPODBinary(stack_trace, in);
-                readVectorBinary(thread_frame_pointers, in);
+
+                if (sig != SanitizerTrap)
+                    readVectorBinary(thread_frame_pointers, in);
+
                 readBinary(thread_num, in);
                 readPODBinary(thread_ptr, in);
 
@@ -542,6 +545,16 @@ private:
 
 
 #if defined(SANITIZER)
+
+template <typename T>
+struct ValueHolder
+{
+    ValueHolder(T value_) : value(value_)
+    {}
+
+    T value;
+};
+
 extern "C" void __sanitizer_set_death_callback(void (*)());
 
 /// Sanitizers may not expect some function calls from death callback.
@@ -559,10 +572,13 @@ static DISABLE_SANITIZER_INSTRUMENTATION void sanitizerDeathCallback()
 
     const StackTrace stack_trace;
 
-    int sig = SignalListener::SanitizerTrap;
-    writeBinary(sig, out);
+    writeBinary(SignalListener::SanitizerTrap, out);
     writePODBinary(stack_trace, out);
-    writeBinary(UInt32(getThreadId()), out);
+    /// We create a dummy struct with a constructor so DISABLE_SANITIZER_INSTRUMENTATION is not applied to it
+    /// otherwise, Memory sanitizer can't know that values initiialized inside this function are actually initialized
+    /// because instrumentations are disabled leading to false positives later on
+    ValueHolder<UInt32> thread_id{static_cast<UInt32>(getThreadId())};
+    writeBinary(thread_id.value, out);
     writePODBinary(current_thread, out);
 
     out.next();


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

This PR fixes 2 issues:

- signal handler currently gets stuck when reading info about sanitizer signal

The problem here is the introduced `thread_frame_pointers` which we don't write in `sanitizerDeathCallback`

- MSan generates false positive for all variables initialized inside `sanitizerDeathCallback` because we disable instrumentation

This leads to cases like this for MSan where we get `use-of-uninitialized-value` after MSan triggers on something else:
https://s3.amazonaws.com/clickhouse-test-reports/0/7ba425a76dac1f3eb7fc434102125afb73307d5e/stress_test__msan_.html

Couldn't find a better way to avoid this case...

Now we get beautiful reports like this:
```
2024.03.21 13:39:21.289636 [ 770486 ] {} <Fatal> BaseDaemon: ########## Short fault info ############
2024.03.21 13:39:21.289822 [ 770486 ] {} <Fatal> BaseDaemon: (version 24.3.1.1, build id: 2F558060771AEDCD113774687B25FF93FB264EA9, git hash: 1219fdd061aa9fd28af6d9da87e9c718043ced16) (from thread 769751) Received signal -3
2024.03.21 13:39:21.289987 [ 770486 ] {} <Fatal> BaseDaemon: Signal description: sanitizer trap
2024.03.21 13:39:21.290070 [ 770486 ] {} <Fatal> BaseDaemon: Sanitizer trap.
2024.03.21 13:39:21.290158 [ 770486 ] {} <Fatal> BaseDaemon: Stack trace: 0x0000568e40bd7dfb 0x0000568e413907dd 0x0000568e41387ccf 0x0000568e28831f14 0x0000568e2884736a 0x0000568e582610b8 0x0000568e531b6790 0x0000568e5b8384e1 0x0000568e5b789013 0x0000568e5b7815e6 0x0000568e5b761582 0x0000568e5b7abedc 0x0000568e5e5a2900 0x0000568e5e5a3781 0x0000568e5ead86a6 0x0000568e5ead546e 0x0000568e5ead2352 0x00007832dd0c255a 0x00007832dd13fa3c
2024.03.21 13:39:21.290252 [ 770486 ] {} <Fatal> BaseDaemon: ########################################
2024.03.21 13:39:21.290531 [ 770486 ] {} <Fatal> BaseDaemon: (version 24.3.1.1, build id: 2F558060771AEDCD113774687B25FF93FB264EA9, git hash: 1219fdd061aa9fd28af6d9da87e9c718043ced16) (from thread 769751) (query_id: 55b5c5df-1897-4700-80aa-8e6a0c32608a) (query: SELECT 'a' AS key, 'b' as value GROUP BY key WITH CUBE SETTINGS group_by_use_nulls = 1, allow_experimental_analyzer = 1;) Received signal sanitizer trap (-3)
2024.03.21 13:39:21.290663 [ 770486 ] {} <Fatal> BaseDaemon: Sanitizer trap.
2024.03.21 13:39:21.290800 [ 770486 ] {} <Fatal> BaseDaemon: Stack trace: 0x0000568e40bd7dfb 0x0000568e413907dd 0x0000568e41387ccf 0x0000568e28831f14 0x0000568e2884736a 0x0000568e582610b8 0x0000568e531b6790 0x0000568e5b8384e1 0x0000568e5b789013 0x0000568e5b7815e6 0x0000568e5b761582 0x0000568e5b7abedc 0x0000568e5e5a2900 0x0000568e5e5a3781 0x0000568e5ead86a6 0x0000568e5ead546e 0x0000568e5ead2352 0x00007832dd0c255a 0x00007832dd13fa3c
2024.03.21 13:39:21.498813 [ 770486 ] {} <Fatal> BaseDaemon: 0. ./build/msan/./src/Common/StackTrace.cpp:349: StackTrace::tryCapture() @ 0x000000001f8abdfb
2024.03.21 13:39:22.082431 [ 770486 ] {} <Fatal> BaseDaemon: 1. ./src/Common/StackTrace.h:47: StackTrace::StackTrace() @ 0x00000000200647dd
2024.03.21 13:39:22.655809 [ 770486 ] {} <Fatal> BaseDaemon: 2. ./build/msan/./src/Daemon/BaseDaemon.cpp:575: sanitizerDeathCallback() @ 0x000000002005bccf
2024.03.21 13:39:22.658729 [ 770486 ] {} <Fatal> BaseDaemon: 3. /home/antonio/projects/llvm-project/compiler-rt/lib/sanitizer_common/sanitizer_termination.cpp:53: __sanitizer::Die() @ 0x0000000007505f14
2024.03.21 13:39:22.686481 [ 770486 ] {} <Fatal> BaseDaemon: 4. /home/antonio/projects/llvm-project/compiler-rt/lib/msan/msan.cpp:231: __msan_warning_with_origin_noreturn @ 0x000000000751b36a
2024.03.21 13:39:22.874263 [ 770486 ] {} <Fatal> BaseDaemon: 5.0. inlined from ./contrib/boost/boost/smart_ptr/intrusive_ptr.hpp:196: boost::intrusive_ptr<DB::IColumn const>::operator*() const
2024.03.21 13:39:22.874413 [ 770486 ] {} <Fatal> BaseDaemon: 5.1. inlined from ./src/Common/COW.h:213: COW<DB::IColumn>::chameleon_ptr<DB::IColumn>::operator*() const
2024.03.21 13:39:22.874503 [ 770486 ] {} <Fatal> BaseDaemon: 5.2. inlined from ./src/Columns/ColumnNullable.h:157: DB::ColumnNullable::getNestedColumn() const
2024.03.21 13:39:22.874591 [ 770486 ] {} <Fatal> BaseDaemon: 5. ./build/msan/./src/Columns/ColumnNullable.cpp:778: DB::ColumnNullable::checkConsistency() const @ 0x0000000036f350b8
2024.03.21 13:39:23.087439 [ 770486 ] {} <Fatal> BaseDaemon: 6. ./build/msan/./src/DataTypes/Serializations/SerializationNullable.cpp:0: DB::SerializationNullable::serializeBinaryBulkWithMultipleStreams(DB::IColumn const&, unsigned long, unsigned long, DB::ISerialization::SerializeBinaryBulkSettings&, std::shared_ptr<DB::ISerialization::SerializeBinaryBulkState>&) const @ 0x0000000031e8a790
2024.03.21 13:39:23.250922 [ 770486 ] {} <Fatal> BaseDaemon: 7.0. inlined from ./build/msan/./src/Formats/NativeWriter.cpp:64: DB::writeData(DB::ISerialization const&, COW<DB::IColumn>::immutable_ptr<DB::IColumn> const&, DB::WriteBuffer&, unsigned long, unsigned long)
2024.03.21 13:39:23.251035 [ 770486 ] {} <Fatal> BaseDaemon: 7. ./build/msan/./src/Formats/NativeWriter.cpp:164: DB::NativeWriter::write(DB::Block const&) @ 0x000000003a50c4e1
2024.03.21 13:39:24.297644 [ 770486 ] {} <Fatal> BaseDaemon: 8. ./build/msan/./src/Server/TCPHandler.cpp:0: DB::TCPHandler::sendData(DB::Block const&) @ 0x000000003a45d013
2024.03.21 13:39:25.256625 [ 770486 ] {} <Fatal> BaseDaemon: 9.0. inlined from ./contrib/llvm-project/libcxx/include/__mutex_base:143: ~unique_lock
2024.03.21 13:39:25.256757 [ 770486 ] {} <Fatal> BaseDaemon: 9. ./build/msan/./src/Server/TCPHandler.cpp:1058: DB::TCPHandler::processOrdinaryQueryWithProcessors() @ 0x000000003a4555e6
2024.03.21 13:39:26.003479 [ 770486 ] {} <Fatal> BaseDaemon: 10. ./build/msan/./src/Server/TCPHandler.cpp:0: DB::TCPHandler::runImpl() @ 0x000000003a435582
2024.03.21 13:39:27.262977 [ 770486 ] {} <Fatal> BaseDaemon: 11. ./build/msan/./src/Server/TCPHandler.cpp:0: DB::TCPHandler::run() @ 0x000000003a47fedc
2024.03.21 13:39:27.295625 [ 770486 ] {} <Fatal> BaseDaemon: 12. ./build/msan/./base/poco/Net/src/TCPServerConnection.cpp:57: Poco::Net::TCPServerConnection::start() @ 0x000000003d276900
2024.03.21 13:39:27.354920 [ 770486 ] {} <Fatal> BaseDaemon: 13.0. inlined from ./contrib/llvm-project/libcxx/include/__memory/unique_ptr.h:302: std::unique_ptr<Poco::Net::TCPServerConnection, std::default_delete<Poco::Net::TCPServerConnection>>::reset[abi:v15000](Poco::Net::TCPServerConnection*)
2024.03.21 13:39:27.355026 [ 770486 ] {} <Fatal> BaseDaemon: 13.1. inlined from ./contrib/llvm-project/libcxx/include/__memory/unique_ptr.h:259: ~unique_ptr
2024.03.21 13:39:27.355087 [ 770486 ] {} <Fatal> BaseDaemon: 13. ./build/msan/./base/poco/Net/src/TCPServerDispatcher.cpp:116: Poco::Net::TCPServerDispatcher::run() @ 0x000000003d277781
2024.03.21 13:39:27.423230 [ 770486 ] {} <Fatal> BaseDaemon: 14. ./build/msan/./base/poco/Foundation/src/ThreadPool.cpp:0: Poco::PooledThread::run() @ 0x000000003d7ac6a6
2024.03.21 13:39:27.495805 [ 770486 ] {} <Fatal> BaseDaemon: 15. ./build/msan/./base/poco/Foundation/src/Thread.cpp:46: Poco::(anonymous namespace)::RunnableHolder::run() @ 0x000000003d7a946e
2024.03.21 13:39:27.553060 [ 770486 ] {} <Fatal> BaseDaemon: 16. ./base/poco/Foundation/src/Thread_POSIX.cpp:350: Poco::ThreadImpl::runnableEntry(void*) @ 0x000000003d7a6352
2024.03.21 13:39:27.553125 [ 770486 ] {} <Fatal> BaseDaemon: 17. ? @ 0x00007832dd0c255a
2024.03.21 13:39:27.553176 [ 770486 ] {} <Fatal> BaseDaemon: 18. ? @ 0x00007832dd13fa3c
2024.03.21 13:39:27.553233 [ 770486 ] {} <Fatal> BaseDaemon: Integrity check of the executable skipped because the reference checksum could not be read.
2024.03.21 13:39:34.029370 [ 770486 ] {} <Fatal> BaseDaemon: Changed settings: group_by_use_nulls = true, log_queries = true, allow_experimental_analyzer = true, allow_introspection_functions = true
```

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
