### PR TITLE
Avoid `IsADirectoryError: Is a directory contrib/azure`

### DIFF
--- a/tests/ci/style_check.py
+++ b/tests/ci/style_check.py
@@ -100,20 +100,28 @@ def is_python(file: Union[Path, str]) -> bool:
     """returns if the changed file in the repository is python script"""
     # WARNING: python-magic v2:0.4.24-2 is used in ubuntu 22.04,
     # and `Support os.PathLike values in magic.from_file` is only from 0.4.25
-    return bool(
-        magic.from_file(os.path.join(REPO_COPY, file), mime=True)
-        == "text/x-script.python"
-    )
+    try:
+        return bool(
+            magic.from_file(os.path.join(REPO_COPY, file), mime=True)
+            == "text/x-script.python"
+        )
+    except IsADirectoryError:
+        # Process submodules w/o errors
+        return False
 
 
 def is_shell(file: Union[Path, str]) -> bool:
     """returns if the changed file in the repository is shell script"""
     # WARNING: python-magic v2:0.4.24-2 is used in ubuntu 22.04,
     # and `Support os.PathLike values in magic.from_file` is only from 0.4.25
-    return bool(
-        magic.from_file(os.path.join(REPO_COPY, file), mime=True)
-        == "text/x-shellscript"
-    )
+    try:
+        return bool(
+            magic.from_file(os.path.join(REPO_COPY, file), mime=True)
+            == "text/x-shellscript"
+        )
+    except IsADirectoryError:
+        # Process submodules w/o errors
+        return False
 
 
 def main():

--- a/tests/ci/style_check.py
+++ b/tests/ci/style_check.py
@@ -143,8 +143,8 @@ def main():
     run_python_check = True
     if CI and pr_info.number > 0:
         pr_info.fetch_changed_files()
-        run_cpp_check = not any(
-            is_python(file) or is_shell(file) for file in pr_info.changed_files
+        run_cpp_check = any(
+            not (is_python(file) or is_shell(file)) for file in pr_info.changed_files
         )
         run_shell_check = any(is_shell(file) for file in pr_info.changed_files)
         run_python_check = any(is_python(file) for file in pr_info.changed_files)


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix CI for changed submodules.