### PR TITLE
[SUCCESS EXPERIMENT] Test submodules-retries feature of ClickHouse/checkout

### DIFF
--- a/.github/workflows/reusable_build.yml
+++ b/.github/workflows/reusable_build.yml
@@ -43,7 +43,7 @@ jobs:
     runs-on: [self-hosted, '${{inputs.runner_type}}']
     steps:
       - name: Check out repository code
-        uses: ClickHouse/checkout@v1
+        uses: ClickHouse/checkout@submodules-retries
         with:
           clear-repository: true
           ref: ${{ fromJson(inputs.data).git_ref }}


### PR DESCRIPTION
Tags: #no_ci_cache #job_package_debug

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Test changes from https://github.com/ClickHouse/checkout/pull/6