### PR TITLE
Analyzer: Clear list of broken integration tests

### DIFF
--- a/tests/analyzer_integration_broken_tests.txt
+++ b/tests/analyzer_integration_broken_tests.txt
@@ -1,1 +1,0 @@
-test_concurrent_backups_s3/test.py::test_concurrent_backups


### PR DESCRIPTION
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Remove `test_concurrent_backups_s3/test.py::test_concurrent_backups` from the list of broken tests, because this test is disabled in CI after #54043.