### PR TITLE
Fix columns after executing MODIFY QUERY for a materialized view with internal table

### DIFF
--- a/tests/queries/0_stateless/02932_refreshable_materialized_views.reference
+++ b/tests/queries/0_stateless/02932_refreshable_materialized_views.reference
@@ -4,7 +4,7 @@ CREATE MATERIALIZED VIEW default.a\nREFRESH AFTER 2 SECOND\n(\n    `x` UInt64\n)
 <3: time difference at least>	1000
 <4: next refresh in>	2
 <4.5: altered>	Scheduled	Finished	2052-01-01 00:00:00
-CREATE MATERIALIZED VIEW default.a\nREFRESH EVERY 2 YEAR\n(\n    `x` Int16\n)\nENGINE = Memory\nAS SELECT x * 2 AS x\nFROM default.src
+CREATE MATERIALIZED VIEW default.a\nREFRESH EVERY 2 YEAR\n(\n    `x` UInt64\n)\nENGINE = Memory\nAS SELECT x * 2 AS x\nFROM default.src
 <5: no refresh>	3
 <6: refreshed>	2
 <7: refreshed>	Scheduled	Finished	2054-01-01 00:00:00

--- a/tests/queries/0_stateless/03001_backup_matview_after_modify_query.reference
+++ b/tests/queries/0_stateless/03001_backup_matview_after_modify_query.reference
@@ -1,0 +1,16 @@
+mv before:
+timestamp	c12
+DateTime	Nullable(String)
+2024-02-22 00:00:00	00
+2024-02-22 00:00:01	11
+2024-02-22 00:00:02	22
+
+BACKUP_CREATED
+RESTORED
+
+mv after:
+timestamp	c12
+DateTime	Nullable(String)
+2024-02-22 00:00:00	00
+2024-02-22 00:00:01	11
+2024-02-22 00:00:02	22

--- a/tests/queries/0_stateless/03001_backup_matview_after_modify_query.sh
+++ b/tests/queries/0_stateless/03001_backup_matview_after_modify_query.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Tags: no-ordinary-database, no-replicated-database
+# Tag no-ordinary-database: TO DO
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+db="$CLICKHOUSE_DATABASE"
+db_2="${db}_2"
+backup_name="${db}_backup"
+
+${CLICKHOUSE_CLIENT} --multiquery "
+DROP TABLE IF EXISTS src;
+DROP TABLE IF EXISTS mv;
+CREATE TABLE src(Timestamp DateTime64(9), c1 String, c2 String) ENGINE=MergeTree ORDER BY Timestamp;
+"
+
+${CLICKHOUSE_CLIENT} -q "CREATE MATERIALIZED VIEW mv(timestamp DateTime, c12 Nullable(String)) ENGINE=MergeTree ORDER BY timestamp AS SELECT Timestamp as timestamp, c1 || c2 as c12 FROM src"
+
+${CLICKHOUSE_CLIENT} -q "INSERT INTO src SELECT '2024-02-22'::DateTime + number, number, number FROM numbers(3)"
+
+echo 'mv before:'
+${CLICKHOUSE_CLIENT} -q "SELECT * FROM ${db}.mv ORDER BY timestamp FORMAT TSVWithNamesAndTypes"
+
+${CLICKHOUSE_CLIENT} -q "ALTER TABLE mv MODIFY QUERY SELECT Timestamp as timestamp, c1 || c2 as c12 FROM src"
+
+echo
+${CLICKHOUSE_CLIENT} -q "BACKUP DATABASE $db TO Disk('backups', '${backup_name}')" | grep -o "BACKUP_CREATED"
+${CLICKHOUSE_CLIENT} -q "RESTORE DATABASE $db AS ${db_2} FROM Disk('backups', '${backup_name}')" | grep -o "RESTORED"
+
+echo $'\nmv after:'
+${CLICKHOUSE_CLIENT} -q "SELECT * FROM ${db_2}.mv ORDER BY timestamp FORMAT TSVWithNamesAndTypes"
+
+${CLICKHOUSE_CLIENT} -q "DROP DATABASE ${db_2}"

--- a/tests/queries/0_stateless/03001_matview_columns_after_modify_query.reference
+++ b/tests/queries/0_stateless/03001_matview_columns_after_modify_query.reference
@@ -1,0 +1,86 @@
+src:
+Timestamp	c1	c2
+DateTime64(9)	String	String
+2024-02-22 00:00:00.000000000	0	0
+2024-02-22 00:00:01.000000000	1	1
+2024-02-22 00:00:02.000000000	2	2
+
+mv:
+timestamp	c12
+DateTime	Nullable(String)
+2024-02-22 00:00:00	00
+2024-02-22 00:00:01	11
+2024-02-22 00:00:02	22
+
+inner:
+timestamp	c12
+DateTime	Nullable(String)
+2024-02-22 00:00:00	00
+2024-02-22 00:00:01	11
+2024-02-22 00:00:02	22
+
+Test 1. MODIFY QUERY doesn't change columns.
+
+mv:
+timestamp	c12
+DateTime	Nullable(String)
+2024-02-22 00:00:00	00
+2024-02-22 00:00:01	11
+2024-02-22 00:00:02	22
+
+inner:
+timestamp	c12
+DateTime	Nullable(String)
+2024-02-22 00:00:00	00
+2024-02-22 00:00:01	11
+2024-02-22 00:00:02	22
+
+Test 2. MODIFY QUERY with explicit data types doesn't change columns.
+
+mv:
+timestamp	c12
+DateTime	Nullable(String)
+2024-02-22 00:00:00	00
+2024-02-22 00:00:01	11
+2024-02-22 00:00:02	22
+
+inner:
+timestamp	c12
+DateTime	Nullable(String)
+2024-02-22 00:00:00	00
+2024-02-22 00:00:01	11
+2024-02-22 00:00:02	22
+
+Test 3. MODIFY QUERY can even fix wrong columns.
+
+Before MODIFY QUERY:
+
+mv:
+timestamp	c12
+DateTime64(9)	String
+2024-02-22 00:00:00.000000000	00
+2024-02-22 00:00:01.000000000	11
+2024-02-22 00:00:02.000000000	22
+
+inner:
+timestamp	c12
+DateTime	Nullable(String)
+2024-02-22 00:00:00	00
+2024-02-22 00:00:01	11
+2024-02-22 00:00:02	22
+
+After MODIFY QUERY:
+
+mv:
+timestamp	c12
+DateTime	Nullable(String)
+2024-02-22 00:00:00	00
+2024-02-22 00:00:01	11
+2024-02-22 00:00:02	22
+
+inner:
+timestamp	c12
+DateTime	Nullable(String)
+2024-02-22 00:00:00	00
+2024-02-22 00:00:01	11
+2024-02-22 00:00:02	22

--- a/tests/queries/0_stateless/03001_matview_columns_after_modify_query.sh
+++ b/tests/queries/0_stateless/03001_matview_columns_after_modify_query.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+${CLICKHOUSE_CLIENT} --multiquery "
+DROP TABLE IF EXISTS src;
+DROP TABLE IF EXISTS mv;
+CREATE TABLE src(Timestamp DateTime64(9), c1 String, c2 String) ENGINE=MergeTree ORDER BY Timestamp;
+"
+
+${CLICKHOUSE_CLIENT} -q "CREATE MATERIALIZED VIEW mv(timestamp DateTime, c12 Nullable(String)) ENGINE=MergeTree ORDER BY timestamp AS SELECT Timestamp as timestamp, c1 || c2 as c12 FROM src"
+
+mv_uuid=$(${CLICKHOUSE_CLIENT} -q "SELECT uuid FROM system.tables WHERE table='mv' AND database=currentDatabase()")
+if [ "${mv_uuid}" != "00000000-0000-0000-0000-000000000000" ]; then
+    inner_table_name=".inner_id.${mv_uuid}"
+else
+    inner_table_name=".inner.mv"
+fi
+#echo "inner_table_name=$inner_table_name"
+
+${CLICKHOUSE_CLIENT} -q "INSERT INTO src SELECT '2024-02-22'::DateTime + number, number, number FROM numbers(3)"
+
+echo $'src:'
+${CLICKHOUSE_CLIENT} -q "SELECT * FROM src ORDER BY Timestamp FORMAT TSVWithNamesAndTypes"
+
+function show_mv_and_inner()
+{
+    echo $'\nmv:'
+    ${CLICKHOUSE_CLIENT} -q "SELECT * FROM mv ORDER BY timestamp FORMAT TSVWithNamesAndTypes"
+
+    echo $'\ninner:'
+    ${CLICKHOUSE_CLIENT} -q "SELECT * FROM \`$inner_table_name\` ORDER BY timestamp FORMAT TSVWithNamesAndTypes"
+}
+
+show_mv_and_inner
+
+#################
+
+echo $'\nTest 1. MODIFY QUERY doesn\'t change columns.'
+
+${CLICKHOUSE_CLIENT} -q "ALTER TABLE mv MODIFY QUERY SELECT Timestamp as timestamp, c1 || c2 as c12 FROM src"
+
+show_mv_and_inner
+
+#################
+
+echo $'\nTest 2. MODIFY QUERY with explicit data types doesn\'t change columns.'
+
+${CLICKHOUSE_CLIENT} -q "ALTER TABLE mv MODIFY QUERY SELECT Timestamp::DateTime64(9) as timestamp, (c1 || c2)::String as c12 FROM src"
+
+show_mv_and_inner
+
+#################
+
+echo $'\nTest 3. MODIFY QUERY can even fix wrong columns.' # We need that because of https://github.com/ClickHouse/ClickHouse/issues/60369
+
+mv_metadata_path=$(${CLICKHOUSE_CLIENT} -q "SELECT metadata_path FROM system.tables WHERE table='mv' AND database=currentDatabase()")
+${CLICKHOUSE_CLIENT} -q "DETACH TABLE mv"
+
+#cat $mv_metadata_path
+sed -i -e 's/`timestamp` DateTime,/`timestamp` DateTime64(9),/g' -e 's/`c12` Nullable(String)/`c12` String/g' "$mv_metadata_path"
+#cat $mv_metadata_path
+
+${CLICKHOUSE_CLIENT} -q "ATTACH TABLE mv"
+
+echo $'\nBefore MODIFY QUERY:'
+show_mv_and_inner
+
+${CLICKHOUSE_CLIENT} -q "ALTER TABLE mv MODIFY QUERY SELECT Timestamp as timestamp, c1 || c2 as c12 FROM src"
+
+echo $'\nAfter MODIFY QUERY:'
+show_mv_and_inner


### PR DESCRIPTION
### Changelog category:
- Bug Fix

### Changelog entry:
Fix columns after executing `ALTER TABLE MODIFY QUERY` for a materialized view with internal table. A materialized view must have the same columns as its internal table if any, however `MODIFY QUERY` could break that rule before this PR causing the materialized view to be inconsistent.

This PR fixes https://github.com/ClickHouse/ClickHouse/issues/60369