### PR TITLE
Fix segfault in SquashingTransform

### DIFF
--- a/src/Interpreters/SquashingTransform.cpp
+++ b/src/Interpreters/SquashingTransform.cpp
@@ -6,6 +6,7 @@ namespace DB
 namespace ErrorCodes
 {
     extern const int SIZES_OF_COLUMNS_DOESNT_MATCH;
+    extern const int LOGICAL_ERROR;
 }
 
 SquashingTransform::SquashingTransform(size_t min_block_size_rows_, size_t min_block_size_bytes_)

--- a/src/Interpreters/SquashingTransform.cpp
+++ b/src/Interpreters/SquashingTransform.cpp
@@ -89,13 +89,25 @@ void SquashingTransform::append(ReferenceType input_block)
 
     assert(blocksHaveEqualStructure(input_block, accumulated_block));
 
-    for (size_t i = 0, size = accumulated_block.columns(); i < size; ++i)
+    try
     {
-        const auto source_column = input_block.getByPosition(i).column;
+        for (size_t i = 0, size = accumulated_block.columns(); i < size; ++i)
+        {
+            const auto source_column = input_block.getByPosition(i).column;
 
-        auto mutable_column = IColumn::mutate(std::move(accumulated_block.getByPosition(i).column));
-        mutable_column->insertRangeFrom(*source_column, 0, source_column->size());
-        accumulated_block.getByPosition(i).column = std::move(mutable_column);
+            auto mutable_column = IColumn::mutate(std::move(accumulated_block.getByPosition(i).column));
+            mutable_column->insertRangeFrom(*source_column, 0, source_column->size());
+            accumulated_block.getByPosition(i).column = std::move(mutable_column);
+        }
+    }
+    catch (...)
+    {
+        /// add() may be called again even after a previous add() threw an exception.
+        /// Keep accumulated_block in a valid state.
+        /// Seems ok to discard accumulated data because we're throwing an exception, which the caller will
+        /// hopefully interpret to mean "this block and all *previous* blocks are potentially lost".
+        accumulated_block.clear();
+        throw;
     }
 }
 
@@ -107,6 +119,9 @@ bool SquashingTransform::isEnoughSize(const Block & block)
 
     for (const auto & [column, type, name] : block)
     {
+        if (!column)
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "Invalid column in block.");
+
         if (!rows)
             rows = column->size();
         else if (rows != column->size())


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Saw a crash with this stack trace:
```
2024.03.20 01:11:46.140446 [ 106721 ] {} <Fatal> BaseDaemon: Stack trace: 0x0000000012b9d10e 0x0000000012b9ccff 0x000000001333ec1a 0x000000000eb12610 0x00000000130469d2 0x0000000013062a3a 0x0000000013059050 0x000000001305a158 0x000000000cb41381 0x000000000cb44bba 0x000000000cb439be 0x00007f1c73e17ac3 0x00007f1c73ea9850
2024.03.20 01:11:46.140605 [ 106721 ] {} <Fatal> BaseDaemon: 2. DB::SquashingTransform::isEnoughSize(DB::Block const&) @ 0x0000000012b9d10e in /usr/bin/clickhouse
2024.03.20 01:11:46.143198 [ 106721 ] {} <Fatal> BaseDaemon: 3. DB::Block DB::SquashingTransform::addImpl<DB::Block&&>(DB::Block&&) @ 0x0000000012b9ccff in /usr/bin/clickhouse
2024.03.20 01:11:46.143308 [ 106721 ] {} <Fatal> BaseDaemon: 4. DB::SimpleSquashingChunksTransform::transform(DB::Chunk&) @ 0x000000001333ec1a in /usr/bin/clickhouse
2024.03.20 01:11:46.145061 [ 106721 ] {} <Fatal> BaseDaemon: 5. DB::ISimpleTransform::transform(DB::Chunk&, DB::Chunk&) @ 0x000000000eb12610 in /usr/bin/clickhouse
2024.03.20 01:11:46.145147 [ 106721 ] {} <Fatal> BaseDaemon: 6. DB::ISimpleTransform::work() @ 0x00000000130469d2 in /usr/bin/clickhouse
2024.03.20 01:11:46.145217 [ 106721 ] {} <Fatal> BaseDaemon: 7. DB::ExecutionThreadContext::executeTask() @ 0x0000000013062a3a in /usr/bin/clickhouse
2024.03.20 01:11:46.145274 [ 106721 ] {} <Fatal> BaseDaemon: 8. DB::PipelineExecutor::executeStepImpl(unsigned long, std::atomic<bool>*) @ 0x0000000013059050 in /usr/bin/clickhouse
2024.03.20 01:11:46.145334 [ 106721 ] {} <Fatal> BaseDaemon: 9. void std::__function::__policy_invoker<void ()>::__call_impl<std::__function::__default_alloc_func<DB::PipelineExecutor::spawnThreads()::$_0, void ()>>(std::__function::__policy_storage const*) @ 0x000000001305a158 in /usr/bin/clickhouse
2024.03.20 01:11:46.145402 [ 106721 ] {} <Fatal> BaseDaemon: 10. ThreadPoolImpl<ThreadFromGlobalPoolImpl<false>>::worker(std::__list_iterator<ThreadFromGlobalPoolImpl<false>, void*>) @ 0x000000000cb41381 in /usr/bin/clickhouse
2024.03.20 01:11:46.145472 [ 106721 ] {} <Fatal> BaseDaemon: 11. void std::__function::__policy_invoker<void ()>::__call_impl<std::__function::__default_alloc_func<ThreadFromGlobalPoolImpl<false>::ThreadFromGlobalPoolImpl<void ThreadPoolImpl<ThreadFromGlobalPoolImpl<false>>::scheduleImpl<void>(std::function<void ()>, Priority, std::optional<unsigned long>, bool)::'lambda0'()>(void&&)::'lambda'(), void ()>>(std::__function::__policy_storage const*) @ 0x000000000cb44bba in /usr/bin/clickhouse
2024.03.20 01:11:46.145535 [ 106721 ] {} <Fatal> BaseDaemon: 12. void* std::__thread_proxy[abi:v15000]<std::tuple<std::unique_ptr<std::__thread_struct, std::default_delete<std::__thread_struct>>, void ThreadPoolImpl<std::thread>::scheduleImpl<void>(std::function<void ()>, Priority, std::optional<unsigned long>, bool)::'lambda0'()>>(void*) @ 0x000000000cb439be in /usr/bin/clickhouse
2024.03.20 01:11:46.145616 [ 106721 ] {} <Fatal> BaseDaemon: 13. ? @ 0x00007f1c73e17ac3
2024.03.20 01:11:46.145662 [ 106721 ] {} <Fatal> BaseDaemon: 14. ? @ 0x00007f1c73ea9850
```

It looks like SquashingTransform assumes that if add() throws an exception then it won't be called again. But the caller SimpleSquashingChunksTransform doesn't seem to have such guarantee (a comment says "Doesn't care about propagating exceptions").

I didn't figure out what the conventions are about propagating exceptions in pipelines. It's complicated. There are two squashing transforms, differing in how they propagate exceptions. I couldn't even figure out why this needs to be any more complex than just "if any processor throws an exception, this processor is not touched again, and the whole pipeline execution stops soon after".

This PR just makes SquashingTransform discard the accumulated block if we failed to append to it. I *guess* that's correct.