### PR TITLE
Test 02340_parts_refcnt_mergetree disable random settings

### DIFF
--- a/tests/queries/0_stateless/02340_parts_refcnt_mergetree.sh
+++ b/tests/queries/0_stateless/02340_parts_refcnt_mergetree.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, long
+# Tags: no-fasttest, long, no-random-settings
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Follow up #60548.
