### PR TITLE
Stream rows when reading from system.replicas

### DIFF
--- a/tests/queries/0_stateless/02908_many_requests_to_system_replicas.reference
+++ b/tests/queries/0_stateless/02908_many_requests_to_system_replicas.reference
@@ -1,4 +1,8 @@
 Creating 300 tables
+900	2700	2700
+900	2700	2700
+900	2700	2700
+900	2700	2700
 Making 200 requests to system.replicas
 Query system.replicas while waiting for other concurrent requests to finish
 0

--- a/tests/queries/0_stateless/02908_many_requests_to_system_replicas.reference
+++ b/tests/queries/0_stateless/02908_many_requests_to_system_replicas.reference
@@ -1,8 +1,8 @@
 Creating 300 tables
-900	2700	2700
-900	2700	2700
-900	2700	2700
-900	2700	2700
+900	1	1
+900	1	1
+900	1	1
+900	1	1
 Making 200 requests to system.replicas
 Query system.replicas while waiting for other concurrent requests to finish
 0

--- a/tests/queries/0_stateless/02908_many_requests_to_system_replicas.sh
+++ b/tests/queries/0_stateless/02908_many_requests_to_system_replicas.sh
@@ -46,10 +46,10 @@ wait;
 
 
 # Check results with different max_block_size
-$CLICKHOUSE_CLIENT -q 'SELECT count(), sum(total_replicas), sum(active_replicas) FROM system.replicas WHERE database=currentDatabase()'
-$CLICKHOUSE_CLIENT -q 'SELECT count(), sum(total_replicas), sum(active_replicas) FROM system.replicas WHERE database=currentDatabase() SETTINGS max_block_size=1'
-$CLICKHOUSE_CLIENT -q 'SELECT count(), sum(total_replicas), sum(active_replicas) FROM system.replicas WHERE database=currentDatabase() SETTINGS max_block_size=77'
-$CLICKHOUSE_CLIENT -q 'SELECT count(), sum(total_replicas), sum(active_replicas) FROM system.replicas WHERE database=currentDatabase() SETTINGS max_block_size=11111'
+$CLICKHOUSE_CLIENT -q 'SELECT count(), sum(total_replicas) >= 2700, sum(active_replicas) >= 2700 FROM system.replicas WHERE database=currentDatabase()'
+$CLICKHOUSE_CLIENT -q 'SELECT count(), sum(total_replicas) >= 2700, sum(active_replicas) >= 2700 FROM system.replicas WHERE database=currentDatabase() SETTINGS max_block_size=1'
+$CLICKHOUSE_CLIENT -q 'SELECT count(), sum(total_replicas) >= 2700, sum(active_replicas) >= 2700 FROM system.replicas WHERE database=currentDatabase() SETTINGS max_block_size=77'
+$CLICKHOUSE_CLIENT -q 'SELECT count(), sum(total_replicas) >= 2700, sum(active_replicas) >= 2700 FROM system.replicas WHERE database=currentDatabase() SETTINGS max_block_size=11111'
 
 
 echo "Making $CONCURRENCY requests to system.replicas"

--- a/tests/queries/0_stateless/02908_many_requests_to_system_replicas.sh
+++ b/tests/queries/0_stateless/02908_many_requests_to_system_replicas.sh
@@ -45,6 +45,13 @@ done
 wait;
 
 
+# Check results with different max_block_size
+$CLICKHOUSE_CLIENT -q 'SELECT count(), sum(total_replicas), sum(active_replicas) FROM system.replicas WHERE database=currentDatabase()'
+$CLICKHOUSE_CLIENT -q 'SELECT count(), sum(total_replicas), sum(active_replicas) FROM system.replicas WHERE database=currentDatabase() SETTINGS max_block_size=1'
+$CLICKHOUSE_CLIENT -q 'SELECT count(), sum(total_replicas), sum(active_replicas) FROM system.replicas WHERE database=currentDatabase() SETTINGS max_block_size=77'
+$CLICKHOUSE_CLIENT -q 'SELECT count(), sum(total_replicas), sum(active_replicas) FROM system.replicas WHERE database=currentDatabase() SETTINGS max_block_size=11111'
+
+
 echo "Making $CONCURRENCY requests to system.replicas"
 
 for i in $(seq 1 $CONCURRENCY)


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
