### PR TITLE
Support for `--output-format` in client

### DIFF
--- a/programs/client/Client.cpp
+++ b/programs/client/Client.cpp
@@ -1,4 +1,3 @@
-#include <boost/algorithm/string/join.hpp>
 #include <cstdlib>
 #include <fcntl.h>
 #include <map>
@@ -7,7 +6,6 @@
 #include <memory>
 #include <optional>
 #include <Common/ThreadStatus.h>
-#include <Common/scope_guard_safe.h>
 #include <boost/program_options.hpp>
 #include <boost/algorithm/string/replace.hpp>
 #include <filesystem>
@@ -44,8 +42,6 @@
 #include <Parsers/ASTSelectQuery.h>
 
 #include <Processors/Transforms/getSourceFromASTInsertQuery.h>
-
-#include <Interpreters/InterpreterSetQuery.h>
 
 #include <Functions/registerFunctions.h>
 #include <AggregateFunctions/registerAggregateFunctions.h>
@@ -1180,7 +1176,7 @@ void Client::processConfig()
 
     pager = config().getString("pager", "");
 
-    is_default_format = !config().has("vertical") && !config().has("format");
+    is_default_format = !config().has("vertical") && !config().has("output-format") && !config().has("format");
     if (is_default_format && checkIfStdoutIsRegularFile())
     {
         is_default_format = false;
@@ -1189,9 +1185,13 @@ void Client::processConfig()
         format = format_from_file_name ? *format_from_file_name : "TabSeparated";
     }
     else if (config().has("vertical"))
-        format = config().getString("format", "Vertical");
+    {
+        format = config().getString("output-format", config().getString("format", "Vertical"));
+    }
     else
-        format = config().getString("format", is_interactive ? "PrettyCompact" : "TabSeparated");
+    {
+        format = config().getString("output-format", config().getString("format", is_interactive ? "PrettyCompact" : "TabSeparated"));
+    }
 
     format_max_block_size = config().getUInt64("format_max_block_size",
         global_context->getSettingsRef().max_block_size);

--- a/programs/local/LocalServer.cpp
+++ b/programs/local/LocalServer.cpp
@@ -819,7 +819,6 @@ void LocalServer::addOptions(OptionsDescription & options_description)
         ("file,F", po::value<std::string>(), "path to file with data of the initial table (stdin if not specified)")
 
         ("input-format", po::value<std::string>(), "input format of the initial table data")
-        ("output-format", po::value<std::string>(), "default output format")
 
         ("logger.console", po::value<bool>()->implicit_value(true), "Log to console")
         ("logger.log", po::value<std::string>(), "Log file name")

--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -2892,7 +2892,8 @@ void ClientBase::init(int argc, char ** argv)
 
         ("suggestion_limit", po::value<int>()->default_value(10000), "Suggestion limit for how many databases, tables and columns to fetch.")
 
-        ("format,output-format,f", po::value<std::string>(), "default output format (and input format for clickhouse-local)")
+        ("format,f", po::value<std::string>(), "default output format (and input format for clickhouse-local)")
+        ("output-format", po::value<std::string>(), "default output format (this option has preference over --format)")
 
         ("vertical,E", "vertical output format, same as --format=Vertical or FORMAT Vertical or \\G at end of command")
         ("highlight", po::value<bool>()->default_value(true), "enable or disable basic syntax highlight in interactive command line")
@@ -2976,6 +2977,8 @@ void ClientBase::init(int argc, char ** argv)
         config().setBool("ignore-error", true);
     if (options.count("format"))
         config().setString("format", options["format"].as<std::string>());
+    if (options.count("output-format"))
+        config().setString("output-format", options["output-format"].as<std::string>());
     if (options.count("vertical"))
         config().setBool("vertical", true);
     if (options.count("stacktrace"))

--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -2892,7 +2892,8 @@ void ClientBase::init(int argc, char ** argv)
 
         ("suggestion_limit", po::value<int>()->default_value(10000), "Suggestion limit for how many databases, tables and columns to fetch.")
 
-        ("format,f", po::value<std::string>(), "default output format")
+        ("format,output-format,f", po::value<std::string>(), "default output format (and input format for clickhouse-local)")
+
         ("vertical,E", "vertical output format, same as --format=Vertical or FORMAT Vertical or \\G at end of command")
         ("highlight", po::value<bool>()->default_value(true), "enable or disable basic syntax highlight in interactive command line")
 

--- a/tests/queries/0_stateless/03020_output_format_client.reference
+++ b/tests/queries/0_stateless/03020_output_format_client.reference
@@ -1,0 +1,12 @@
+| x |
+|:-|
+| Hello, world |
+| x |
+|:-|
+| Hello, world |
+| x |
+|:-|
+| Hello, world |
+| x |
+|:-|
+| Hello, world |

--- a/tests/queries/0_stateless/03020_output_format_client.sh
+++ b/tests/queries/0_stateless/03020_output_format_client.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+# clickhouse-local has --input-format and --output-format parameters,
+# and also the --format parameter which is the default for both input and output formats, but has less preference.
+
+# clickhouse-client does not have the --input-format parameter.
+# However, it accepts both --format and --output-format for convenience.
+
+${CLICKHOUSE_LOCAL} --output-format Markdown --query "SELECT 'Hello, world' AS x"
+${CLICKHOUSE_CLIENT} --output-format Markdown --query "SELECT 'Hello, world' AS x"
+${CLICKHOUSE_LOCAL} --format Markdown --query "SELECT 'Hello, world' AS x"
+${CLICKHOUSE_CLIENT} --format Markdown --query "SELECT 'Hello, world' AS x"


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Similarly to `clickhouse-local`, `clickhouse-client` will accept the `--output-format` option as a synonym to the `--format` option. This closes #59848.


---
### Modify your CI run:
**NOTE:** If your merge the PR with modified CI you **MUST KNOW** what you are doing
**NOTE:** Set desired options before CI starts or re-push after updates

#### Run only:
- [ ] <!---ci_set_integration--> Integration tests
- [ ] <!---ci_set_arm--> Integration tests (arm64)
- [x] <!---ci_set_stateless--> Stateless tests (release)
- [x] <!---ci_set_stateless_asan--> Stateless tests (asan)
- [x] <!---ci_set_stateful--> Stateful tests (release)
- [x] <!---ci_set_stateful_asan--> Stateful tests (asan)
- [ ] <!---ci_set_reduced--> No sanitizers
- [x] <!---ci_set_analyzer--> Tests with analyzer
- [x] <!---ci_set_fast--> Fast tests
- [ ] <!---job_package_debug--> Only package_debug build
- [ ] <!---PLACE_YOUR_TAG_CONFIGURED_IN_ci_config.py_FILE_HERE--> Add your CI variant description here

#### CI options:
- [ ] <!---do_not_test--> do not test (only style check)
- [ ] <!---no_merge_commit--> disable merge-commit (no merge from master before tests)
- [ ] <!---no_ci_cache--> disable CI cache (job reuse)

#### Only specified batches in multi-batch jobs:
- [ ] <!---batch_0--> 1
- [ ] <!---batch_1--> 2
- [ ] <!---batch_2--> 3
- [ ] <!---batch_3--> 4
