### PR TITLE
Fix flaky tests (stateless, integration)

### DIFF
--- a/tests/integration/compose/docker_compose_mysql.yml
+++ b/tests/integration/compose/docker_compose_mysql.yml
@@ -22,3 +22,4 @@ services:
             - type: ${MYSQL_LOGS_FS:-tmpfs}
               source: ${MYSQL_LOGS:-}
               target: /mysql/
+        user: ${MYSQL_DOCKER_USER}

--- a/tests/integration/compose/docker_compose_mysql_8_0.yml
+++ b/tests/integration/compose/docker_compose_mysql_8_0.yml
@@ -21,3 +21,4 @@ services:
             - type: ${MYSQL8_LOGS_FS:-tmpfs}
               source: ${MYSQL8_LOGS:-}
               target: /mysql/
+        user: ${MYSQL8_DOCKER_USER}

--- a/tests/integration/compose/docker_compose_mysql_cluster.yml
+++ b/tests/integration/compose/docker_compose_mysql_cluster.yml
@@ -22,6 +22,7 @@ services:
             - type: ${MYSQL_CLUSTER_LOGS_FS:-tmpfs}
               source: ${MYSQL_CLUSTER_LOGS:-}
               target: /mysql/
+        user: ${MYSQL_CLUSTER_DOCKER_USER}
     mysql3:
         image: mysql:8.0
         restart: always
@@ -44,6 +45,7 @@ services:
             - type: ${MYSQL_CLUSTER_LOGS_FS:-tmpfs}
               source: ${MYSQL_CLUSTER_LOGS:-}
               target: /mysql/
+        user: ${MYSQL_CLUSTER_DOCKER_USER}
     mysql4:
         image: mysql:8.0
         restart: always
@@ -66,3 +68,4 @@ services:
             - type: ${MYSQL_CLUSTER_LOGS_FS:-tmpfs}
               source: ${MYSQL_CLUSTER_LOGS:-}
               target: /mysql/
+        user: ${MYSQL_CLUSTER_DOCKER_USER}

--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -1047,6 +1047,8 @@ class ClickHouseCluster:
         env_variables["MYSQL_ROOT_HOST"] = "%"
         env_variables["MYSQL_LOGS"] = self.mysql57_logs_dir
         env_variables["MYSQL_LOGS_FS"] = "bind"
+        env_variables["MYSQL_DOCKER_USER"] = str(os.getuid())
+
         self.base_cmd.extend(
             ["--file", p.join(docker_compose_yml_dir, "docker_compose_mysql.yml")]
         )
@@ -1069,6 +1071,8 @@ class ClickHouseCluster:
         env_variables["MYSQL8_ROOT_HOST"] = "%"
         env_variables["MYSQL8_LOGS"] = self.mysql8_logs_dir
         env_variables["MYSQL8_LOGS_FS"] = "bind"
+        env_variables["MYSQL8_DOCKER_USER"] = str(os.getuid())
+
         self.base_cmd.extend(
             ["--file", p.join(docker_compose_yml_dir, "docker_compose_mysql_8_0.yml")]
         )
@@ -1090,6 +1094,7 @@ class ClickHouseCluster:
         env_variables["MYSQL_CLUSTER_ROOT_HOST"] = "%"
         env_variables["MYSQL_CLUSTER_LOGS"] = self.mysql_cluster_logs_dir
         env_variables["MYSQL_CLUSTER_LOGS_FS"] = "bind"
+        env_variables["MYSQL_CLUSTER_DOCKER_USER"] = str(os.getuid())
 
         self.base_cmd.extend(
             [

--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -3476,6 +3476,7 @@ class ClickHouseInstance:
     ):
         # logging.debug(f"Executing query {sql} on {self.name}")
         result = None
+        exception_msg = ""
         for i in range(retry_count):
             try:
                 result = self.query(
@@ -3493,17 +3494,19 @@ class ClickHouseInstance:
                     return result
                 time.sleep(sleep_time)
             except QueryRuntimeException as ex:
+                exception_msg = f"{type(ex).__name__}: {str(ex)}"
                 # Container is down, this is likely due to server crash.
                 if "No route to host" in str(ex):
                     raise
                 time.sleep(sleep_time)
             except Exception as ex:
                 # logging.debug("Retry {} got exception {}".format(i + 1, ex))
+                exception_msg = f"{type(ex).__name__}: {str(ex)}"
                 time.sleep(sleep_time)
 
         if result is not None:
             return result
-        raise Exception("Can't execute query {}".format(sql))
+        raise Exception(f"Can't execute query {sql}\n{exception_msg}")
 
     # As query() but doesn't wait response and returns response handler
     def get_query_request(self, sql, *args, **kwargs):

--- a/tests/integration/test_backup_restore_on_cluster/test.py
+++ b/tests/integration/test_backup_restore_on_cluster/test.py
@@ -457,6 +457,7 @@ def test_replicated_database_async():
     )
 
     node1.query("SYSTEM SYNC REPLICA ON CLUSTER 'cluster' mydb.tbl")
+    node1.query("SYSTEM SYNC REPLICA ON CLUSTER 'cluster' mydb.tbl2")
 
     assert node1.query("SELECT * FROM mydb.tbl ORDER BY x") == TSV([1, 22])
     assert node2.query("SELECT * FROM mydb.tbl2 ORDER BY y") == TSV(["a", "bb"])

--- a/tests/integration/test_grpc_protocol/test.py
+++ b/tests/integration/test_grpc_protocol/test.py
@@ -392,6 +392,9 @@ def test_progress():
         ),
     ]
 
+    # Stats data can be returned, which broke the test
+    results = [i for i in results if not isinstance(i, clickhouse_grpc_pb2.Stats)]
+
     assert results == expected_results
 
 

--- a/tests/integration/test_merges_memory_limit/test.py
+++ b/tests/integration/test_merges_memory_limit/test.py
@@ -32,7 +32,11 @@ def test_memory_limit_success():
     )
 
     _, error = node.query_and_get_answer_with_error(
-        "SYSTEM START MERGES test_merge_oom;SET optimize_throw_if_noop=1;OPTIMIZE TABLE test_merge_oom FINAL"
+        """
+        SET optimize_throw_if_noop=1;
+        SYSTEM START MERGES test_merge_oom;
+        OPTIMIZE TABLE test_merge_oom FINAL;
+        """
     )
 
     assert not error

--- a/tests/integration/test_mysql57_database_engine/test.py
+++ b/tests/integration/test_mysql57_database_engine/test.py
@@ -1021,7 +1021,9 @@ def test_restart_server(started_cluster):
                 clickhouse_node, mysql_node, action="REJECT --reject-with tcp-reset"
             )
             clickhouse_node.restart_clickhouse()
-            clickhouse_node.query_and_get_error("SHOW TABLES FROM test_restart")
+            clickhouse_node.query_and_get_error_with_retry(
+                "SHOW TABLES FROM test_restart"
+            )
         assert "test_table" in clickhouse_node.query("SHOW TABLES FROM test_restart")
 
 

--- a/tests/integration/test_replicated_merge_tree_s3_zero_copy/test.py
+++ b/tests/integration/test_replicated_merge_tree_s3_zero_copy/test.py
@@ -213,9 +213,9 @@ def test_drop_table(cluster):
 
     node.query_with_retry(
         "system sync replica test_drop_table",
-        settings={"receive_timeout": 5},
-        sleep_time=5,
-        retry_count=10,
+        settings={"receive_timeout": 10},
+        sleep_time=3,
+        retry_count=20,
     )
     node2.query("drop table test_drop_table sync")
     assert "1000\t499500\n" == node.query(

--- a/tests/integration/test_runtime_configurable_cache_size/test.py
+++ b/tests/integration/test_runtime_configurable_cache_size/test.py
@@ -95,15 +95,15 @@ CONFIG_DIR = os.path.join(SCRIPT_DIR, "configs")
 
 
 def test_query_cache_size_is_runtime_configurable(start_cluster):
-    # the inital config specifies the maximum query cache size as 2, run 3 queries, expect 2 cache entries
+    # the initial config specifies the maximum query cache size as 2, run 3 queries, expect 2 cache entries
     node.query("SYSTEM DROP QUERY CACHE")
     node.query("SELECT 1 SETTINGS use_query_cache = 1, query_cache_ttl = 1")
     node.query("SELECT 2 SETTINGS use_query_cache = 1, query_cache_ttl = 1")
     node.query("SELECT 3 SETTINGS use_query_cache = 1, query_cache_ttl = 1")
 
-    time.sleep(2.0)
-    res = node.query(
-        "SELECT value FROM system.asynchronous_metrics WHERE metric = 'QueryCacheEntries'"
+    res = node.query_with_retry(
+        "SELECT value FROM system.asynchronous_metrics WHERE metric = 'QueryCacheEntries'",
+        check_callback=lambda result: result == "2\n",
     )
     assert res == "2\n"
 
@@ -116,9 +116,9 @@ def test_query_cache_size_is_runtime_configurable(start_cluster):
     node.query("SYSTEM RELOAD CONFIG")
 
     # check that eviction worked as expected
-    time.sleep(2.0)
-    res = node.query(
-        "SELECT value FROM system.asynchronous_metrics WHERE metric = 'QueryCacheEntries'"
+    res = node.query_with_retry(
+        "SELECT value FROM system.asynchronous_metrics WHERE metric = 'QueryCacheEntries'",
+        check_callback=lambda result: result == "2\n",
     )
     assert (
         res == "2\n"
@@ -131,9 +131,10 @@ def test_query_cache_size_is_runtime_configurable(start_cluster):
     # check that the new query cache maximum size is respected when more queries run
     node.query("SELECT 4 SETTINGS use_query_cache = 1, query_cache_ttl = 1")
     node.query("SELECT 5 SETTINGS use_query_cache = 1, query_cache_ttl = 1")
-    time.sleep(2.0)
-    res = node.query(
-        "SELECT value FROM system.asynchronous_metrics WHERE metric = 'QueryCacheEntries'"
+
+    res = node.query_with_retry(
+        "SELECT value FROM system.asynchronous_metrics WHERE metric = 'QueryCacheEntries'",
+        check_callback=lambda result: result == "1\n",
     )
     assert res == "1\n"
 

--- a/tests/integration/test_ttl_move/test.py
+++ b/tests/integration/test_ttl_move/test.py
@@ -1635,7 +1635,7 @@ def test_alter_with_merge_work(started_cluster, name, engine, positive):
         optimize_table(20)
 
         if positive:
-            assert check_used_disks_with_retry(node1, name, set(["external"]), 50)
+            assert check_used_disks_with_retry(node1, name, set(["external"]), 100)
         else:
             assert check_used_disks_with_retry(node1, name, set(["jbod1", "jbod2"]), 50)
 

--- a/tests/integration/test_undrop_query/configs/with_delay_config.xml
+++ b/tests/integration/test_undrop_query/configs/with_delay_config.xml
@@ -1,3 +1,3 @@
 <clickhouse>
-    <database_atomic_delay_before_drop_table_sec>5</database_atomic_delay_before_drop_table_sec>
+    <database_atomic_delay_before_drop_table_sec>3</database_atomic_delay_before_drop_table_sec>
 </clickhouse>

--- a/tests/integration/test_undrop_query/test.py
+++ b/tests/integration/test_undrop_query/test.py
@@ -1,7 +1,5 @@
 import pytest
 import uuid
-import random
-import logging
 import time
 
 from helpers.cluster import ClickHouseCluster
@@ -22,37 +20,29 @@ def started_cluster():
 
 
 def test_undrop_drop_and_undrop_loop(started_cluster):
-    count = 0
-    while count < 10:
-        random_sec = random.randint(0, 10)
-        table_uuid = uuid.uuid1().__str__()
-        logging.info(
-            "random_sec: " + random_sec.__str__() + ", table_uuid: " + table_uuid
-        )
+    # create, drop, undrop, drop, undrop table 5 times
+    for _ in range(5):
+        table_uuid = str(uuid.uuid1())
+        table = f"test_undrop_loop"
         node.query(
-            "create table test_undrop_loop"
-            + count.__str__()
-            + " UUID '"
-            + table_uuid
-            + "' (id Int32) Engine=MergeTree() order by id;"
+            f"CREATE TABLE {table} "
+            f"UUID '{table_uuid}' (id Int32) "
+            f"Engine=MergeTree() ORDER BY id"
         )
-        node.query("drop table test_undrop_loop" + count.__str__() + ";")
-        time.sleep(random_sec)
-        if random_sec >= 5:
-            error = node.query_and_get_error(
-                "undrop table test_undrop_loop"
-                + count.__str__()
-                + " uuid '"
-                + table_uuid
-                + "';"
-            )
-            assert "UNKNOWN_TABLE" in error
-        else:
-            node.query(
-                "undrop table test_undrop_loop"
-                + count.__str__()
-                + " uuid '"
-                + table_uuid
-                + "';"
-            )
-            count = count + 1
+
+        node.query(f"DROP TABLE {table}")
+        node.query(f"UNDROP TABLE {table} UUID '{table_uuid}'")
+
+        node.query(f"DROP TABLE {table}")
+        # database_atomic_delay_before_drop_table_sec=3
+        time.sleep(6)
+
+        """
+        Expect two things:
+        1. Table is dropped - UNKNOWN_TABLE in error
+        2. Table in process of dropping - Return code: 60.
+            The drop task of table ... (uuid) is in progress,
+            has been dropped or the database engine doesn't support it
+        """
+        error = node.query_and_get_error(f"UNDROP TABLE {table} UUID '{table_uuid}'")
+        assert "UNKNOWN_TABLE" in error or "The drop task of table" in error

--- a/tests/queries/0_stateless/02115_rewrite_local_join_right_distribute_table.sql
+++ b/tests/queries/0_stateless/02115_rewrite_local_join_right_distribute_table.sql
@@ -23,6 +23,10 @@ select t1.* from t1_all t1 join t2_all t2 on t1.a = t2.a ORDER BY t1.a;
 
 SELECT '-';
 
+-- make sure data is fully written when reading from distributed
+optimize table t1_local final;
+optimize table t2_local final;
+
 set distributed_product_mode = 'global';
 select * from t1_all t1 where t1.a in (select t2.a from t2_all t2);
 explain syntax select t1.* from t1_all t1 join t2_all t2 on t1.a = t2.a;

--- a/tests/queries/0_stateless/02475_bson_each_row_format.sh
+++ b/tests/queries/0_stateless/02475_bson_each_row_format.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: no-parallel
+# Tags: no-parallel, no-debug
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

Changes:
1. Set the host user for MySQL Docker containers. When running pytest locally, tests fail because of Permission denied: 'logs'.
2. Rich exception message raised from `ClickHouseInstance.query_with_retry()`
3. (attempt to) Fix some flaky integration and stateless tests

Failed reports is [here](https://play.clickhouse.com/play?user=play#U0VMRUNUIGNoZWNrX25hbWUsIHRlc3RfbmFtZSwgcmVwb3J0X3VybApGUk9NIGNoZWNrcwpXSEVSRSBjaGVja19uYW1lIExJS0UgJ0ludGVncmF0aW9uJScKICAgIEFORCBjaGVja19zdGFydF90aW1lID49IG5vdygpIC0gSU5URVJWQUwgNjAgSE9VUgogICAgQU5EIHB1bGxfcmVxdWVzdF9udW1iZXIgPSAwCiAgICBBTkQgdGVzdF9zdGF0dXMgIT0gJ1NLSVBQRUQnCiAgICBBTkQgdGVzdF9zdGF0dXMgTElLRSAnRiUnCiAgICBBTkQgY2hlY2tfc3RhdHVzICE9ICdzdWNjZXNzJwpPUkRFUiBCWSBjaGVja19uYW1lLCB0ZXN0X25hbWUsIGNoZWNrX3N0YXJ0X3RpbWU=)
