### PR TITLE
Better message for logging errors

### DIFF
--- a/src/Common/logger_useful.h
+++ b/src/Common/logger_useful.h
@@ -107,6 +107,18 @@ namespace impl
             (PRIORITY), _file_function.c_str(), __LINE__, _format_string);                                          \
         _channel->log(_poco_message);                                                                               \
     }                                                                                                               \
+    catch (const Poco::Exception & logger_exception)                                                                \
+    {                                                                                                               \
+        ::write(STDERR_FILENO, static_cast<const void *>(MESSAGE_FOR_EXCEPTION_ON_LOGGING), sizeof(MESSAGE_FOR_EXCEPTION_ON_LOGGING)); \
+        const std::string & logger_exception_message = logger_exception.message();                                  \
+        ::write(STDERR_FILENO, static_cast<const void *>(logger_exception_message.data()), logger_exception_message.size()); \
+    }                                                                                                               \
+    catch (const std::exception & logger_exception)                                                                 \
+    {                                                                                                               \
+        ::write(STDERR_FILENO, static_cast<const void *>(MESSAGE_FOR_EXCEPTION_ON_LOGGING), sizeof(MESSAGE_FOR_EXCEPTION_ON_LOGGING)); \
+        const char * logger_exception_message = logger_exception.what();                                            \
+        ::write(STDERR_FILENO, static_cast<const void *>(logger_exception_message), strlen(logger_exception_message)); \
+    }                                                                                                               \
     catch (...)                                                                                                     \
     {                                                                                                               \
         ::write(STDERR_FILENO, static_cast<const void *>(MESSAGE_FOR_EXCEPTION_ON_LOGGING), sizeof(MESSAGE_FOR_EXCEPTION_ON_LOGGING)); \


### PR DESCRIPTION
Right now it is possible to get something like this [1]:

    Failed to write a log message: src/Storages/Kafka/KafkaConsumer.cpp:342

Without any details (likely there are some issues with fmt).

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/61526/958659584957ff419a9305d9c7edee5703fedbdc/integration_tests__tsan__[6_6].html

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)