### PR TITLE
Fix: DISTINCT in subquery with analyzer

### DIFF
--- a/src/Analyzer/Passes/RemoveUnusedProjectionColumnsPass.cpp
+++ b/src/Analyzer/Passes/RemoveUnusedProjectionColumnsPass.cpp
@@ -148,6 +148,13 @@ void RemoveUnusedProjectionColumnsPass::run(QueryTreeNodePtr & query_tree_node, 
 
         for (auto & [query_or_union_node, used_columns] : visitor.query_or_union_node_to_used_columns)
         {
+            /// can't remove columns from distinct, see example - 03023_remove_unused_column_distinct.sql
+            if (auto * query_node = query_or_union_node->as<QueryNode>())
+            {
+                if (query_node->isDistinct())
+                    continue;
+            }
+
             auto used_projection_indexes = convertUsedColumnNamesToUsedProjectionIndexes(query_or_union_node, used_columns);
             updateUsedProjectionIndexes(query_or_union_node, used_projection_indexes);
 

--- a/tests/queries/0_stateless/03023_remove_unused_column_distinct.reference
+++ b/tests/queries/0_stateless/03023_remove_unused_column_distinct.reference
@@ -1,0 +1,6 @@
+product_0
+product_1
+product_0
+product_1
+product_0
+product_1

--- a/tests/queries/0_stateless/03023_remove_unused_column_distinct.sql
+++ b/tests/queries/0_stateless/03023_remove_unused_column_distinct.sql
@@ -1,0 +1,15 @@
+SELECT product_id
+FROM
+(
+    SELECT DISTINCT
+        product_id,
+        section_id
+    FROM
+    (
+        SELECT
+            concat('product_', number % 2) AS product_id,
+            concat('section_', number % 3) AS section_id
+        FROM numbers(10)
+    )
+)
+SETTINGS allow_experimental_analyzer = 1;


### PR DESCRIPTION
Fixes https://github.com/ClickHouse/ClickHouse/issues/59518

`RemoveUnusedProjectionColumnsPass` incorrectly removed columns, unused in outer query, from subqueries with `DISTINCT`

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
