### PR TITLE
Fix possible connections data-race for distributed_foreground_insert/distributed_background_insert_batch

### DIFF
--- a/src/Storages/Distributed/DistributedAsyncInsertBatch.cpp
+++ b/src/Storages/Distributed/DistributedAsyncInsertBatch.cpp
@@ -203,10 +203,9 @@ void DistributedAsyncInsertBatch::readText(ReadBuffer & in)
 
 void DistributedAsyncInsertBatch::sendBatch(const SettingsChanges & settings_changes)
 {
+    IConnectionPool::Entry connection;
     std::unique_ptr<RemoteInserter> remote;
     bool compression_expected = false;
-
-    IConnectionPool::Entry connection;
 
     /// Since the batch is sent as a whole (in case of failure, the whole batch
     /// will be repeated), we need to mark the whole batch as failed in case of


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix possible connections data-race for distributed_foreground_insert/distributed_background_insert_batch that leads to crashes

Previously connection will marked as not in use earlier than RemoteInserter, while it still may use it and this will lead to crashes, like in [1].

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/61832/d0cd8d0d7f74ff251d52e1871cba57d26a51873b/stateless_tests_flaky_check__asan_.html

I was able to reproduce the crash locally by running the test 03030_system_flush_distributed_settings in parallel.

Fixes: #45491