### PR TITLE
Update ReadBuffer for AzureBlobStorage

### DIFF
--- a/src/Backups/BackupIO_AzureBlobStorage.cpp
+++ b/src/Backups/BackupIO_AzureBlobStorage.cpp
@@ -89,7 +89,7 @@ std::unique_ptr<SeekableReadBuffer> BackupReaderAzureBlobStorage::readFile(const
         key = file_name;
     }
     return std::make_unique<ReadBufferFromAzureBlobStorage>(
-        client, key, read_settings, settings->max_single_read_retries,
+        client, key, read_settings,
         settings->max_single_download_retries);
 }
 
@@ -258,7 +258,7 @@ std::unique_ptr<ReadBuffer> BackupWriterAzureBlobStorage::readFile(const String 
     }
 
     return std::make_unique<ReadBufferFromAzureBlobStorage>(
-        client, key, read_settings, settings->max_single_read_retries,
+        client, key, read_settings,
         settings->max_single_download_retries);
 }
 

--- a/src/Disks/IO/ReadBufferFromAzureBlobStorage.cpp
+++ b/src/Disks/IO/ReadBufferFromAzureBlobStorage.cpp
@@ -93,7 +93,7 @@ bool ReadBufferFromAzureBlobStorage::nextImpl()
         data_capacity = internal_buffer.size();
     }
 
-    if (static_cast<size_t>(offset) == getFileSize())
+    if (static_cast<size_t>(offset) >= getFileSize())
         return false;
 
     bytes_read = readBytes();

--- a/src/Disks/IO/ReadBufferFromAzureBlobStorage.cpp
+++ b/src/Disks/IO/ReadBufferFromAzureBlobStorage.cpp
@@ -182,7 +182,7 @@ size_t ReadBufferFromAzureBlobStorage::readBytes()
     if (to_read_bytes)
         length = {static_cast<int64_t>(to_read_bytes)};
     download_options.Range = {static_cast<int64_t>(offset), length};
-    LOG_INFO(log, "Read bytes range is offset = {} and to_read_bytes = {}", offset, to_read_bytes);
+    LOG_INFO(log, "Read bytes range is offset = {}, read_until_position = {}, to_read_bytes = {}, data_capacity = {}, file_size = {}", offset, read_until_position, to_read_bytes, data_capacity, getFileSize());
 
 
     if (!blob_client)

--- a/src/Disks/IO/ReadBufferFromAzureBlobStorage.cpp
+++ b/src/Disks/IO/ReadBufferFromAzureBlobStorage.cpp
@@ -93,7 +93,7 @@ bool ReadBufferFromAzureBlobStorage::nextImpl()
         data_capacity = internal_buffer.size();
     }
 
-    if (offset == getFileSize())
+    if (static_cast<size_t>(offset) == getFileSize())
         return false;
 
     bytes_read = readBytes();

--- a/src/Disks/IO/ReadBufferFromAzureBlobStorage.cpp
+++ b/src/Disks/IO/ReadBufferFromAzureBlobStorage.cpp
@@ -70,6 +70,8 @@ void ReadBufferFromAzureBlobStorage::setReadUntilEnd()
 void ReadBufferFromAzureBlobStorage::setReadUntilPosition(size_t position)
 {
     read_until_position = position;
+    offset = getPosition();
+    resetWorkingBuffer();
     initialized = false;
 }
 

--- a/src/Disks/IO/ReadBufferFromAzureBlobStorage.cpp
+++ b/src/Disks/IO/ReadBufferFromAzureBlobStorage.cpp
@@ -169,7 +169,10 @@ size_t ReadBufferFromAzureBlobStorage::readBytes()
     /// 0 means read full file
     size_t to_read_bytes = 0;
     if (read_until_position != 0)
-        to_read_bytes = std::min(read_until_position - offset, data_capacity);
+    {
+        to_read_bytes = read_until_position - offset;
+        to_read_bytes = std::min(to_read_bytes, data_capacity);
+    }
 
     auto file_size = getFileSize();
     if (!to_read_bytes && (file_size > data_capacity))

--- a/src/Disks/IO/ReadBufferFromAzureBlobStorage.cpp
+++ b/src/Disks/IO/ReadBufferFromAzureBlobStorage.cpp
@@ -93,6 +93,9 @@ bool ReadBufferFromAzureBlobStorage::nextImpl()
         data_capacity = internal_buffer.size();
     }
 
+    if (offset == getFileSize())
+        return false;
+
     bytes_read = readBytes();
 
     if (bytes_read == 0)

--- a/src/Disks/IO/ReadBufferFromAzureBlobStorage.cpp
+++ b/src/Disks/IO/ReadBufferFromAzureBlobStorage.cpp
@@ -171,7 +171,7 @@ size_t ReadBufferFromAzureBlobStorage::readBytes()
     if (read_until_position != 0)
     {
         to_read_bytes = read_until_position - offset;
-        to_read_bytes = std::min(to_read_bytes, static_cast<int64_t>(offset));
+        to_read_bytes = std::min(to_read_bytes, static_cast<int64_t>(data_capacity));
     }
 
     if (!to_read_bytes && (getFileSize() > data_capacity))

--- a/src/Disks/IO/ReadBufferFromAzureBlobStorage.cpp
+++ b/src/Disks/IO/ReadBufferFromAzureBlobStorage.cpp
@@ -23,7 +23,6 @@ namespace ErrorCodes
 {
     extern const int CANNOT_SEEK_THROUGH_FILE;
     extern const int SEEK_POSITION_OUT_OF_BOUND;
-    extern const int RECEIVED_EMPTY_DATA;
     extern const int LOGICAL_ERROR;
 }
 
@@ -196,7 +195,6 @@ size_t ReadBufferFromAzureBlobStorage::initialize()
     {
         try
         {
-            LOG_INFO(log, "Intialize buffer offset {}    read_until_position {}   data_capacity {} ",offset, read_until_position, data_capacity);
             auto download_response = blob_client->DownloadTo(reinterpret_cast<uint8_t *>(data_ptr), data_capacity, download_options);
             read_bytes = download_response.Value.ContentRange.Length.Value();
             break;

--- a/src/Disks/IO/ReadBufferFromAzureBlobStorage.h
+++ b/src/Disks/IO/ReadBufferFromAzureBlobStorage.h
@@ -21,7 +21,6 @@ public:
         std::shared_ptr<const Azure::Storage::Blobs::BlobContainerClient> blob_container_client_,
         const String & path_,
         const ReadSettings & read_settings_,
-        size_t max_single_read_retries_,
         size_t max_single_download_retries_,
         bool use_external_buffer_ = false,
         bool restricted_seek_ = false,
@@ -38,6 +37,7 @@ public:
     String getFileName() const override { return path; }
 
     void setReadUntilPosition(size_t position) override;
+
     void setReadUntilEnd() override;
 
     bool supportsRightBoundedReads() const override { return true; }
@@ -50,14 +50,12 @@ public:
 
 private:
 
-    void initialize();
+    size_t initialize();
 
-    std::unique_ptr<Azure::Core::IO::BodyStream> data_stream;
     std::shared_ptr<const Azure::Storage::Blobs::BlobContainerClient> blob_container_client;
     std::unique_ptr<Azure::Storage::Blobs::BlobClient> blob_client;
 
     const String path;
-    size_t max_single_read_retries;
     size_t max_single_download_retries;
     ReadSettings read_settings;
     std::vector<char> tmp_buffer;

--- a/src/Disks/IO/ReadBufferFromAzureBlobStorage.h
+++ b/src/Disks/IO/ReadBufferFromAzureBlobStorage.h
@@ -70,7 +70,6 @@ private:
     off_t read_until_position = 0;
 
     off_t offset = 0;
-    size_t total_size;
     bool initialized = false;
     char * data_ptr;
     size_t data_capacity;

--- a/src/Disks/IO/ReadBufferFromAzureBlobStorage.h
+++ b/src/Disks/IO/ReadBufferFromAzureBlobStorage.h
@@ -50,7 +50,7 @@ public:
 
 private:
 
-    size_t initialize();
+    size_t readBytes();
 
     std::shared_ptr<const Azure::Storage::Blobs::BlobContainerClient> blob_container_client;
     std::unique_ptr<Azure::Storage::Blobs::BlobClient> blob_client;

--- a/src/Disks/ObjectStorages/AzureBlobStorage/AzureObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/AzureBlobStorage/AzureObjectStorage.cpp
@@ -190,7 +190,7 @@ std::unique_ptr<ReadBufferFromFileBase> AzureObjectStorage::readObject( /// NOLI
     auto settings_ptr = settings.get();
 
     return std::make_unique<ReadBufferFromAzureBlobStorage>(
-        client.get(), object.remote_path, patchSettings(read_settings), settings_ptr->max_single_read_retries,
+        client.get(), object.remote_path, patchSettings(read_settings),
         settings_ptr->max_single_download_retries);
 }
 
@@ -212,7 +212,6 @@ std::unique_ptr<ReadBufferFromFileBase> AzureObjectStorage::readObjects( /// NOL
             client.get(),
             path,
             disk_read_settings,
-            settings_ptr->max_single_read_retries,
             settings_ptr->max_single_download_retries,
             /* use_external_buffer */true,
             restricted_seek);

--- a/src/IO/AzureBlobStorage/copyAzureBlobStorageFile.cpp
+++ b/src/IO/AzureBlobStorage/copyAzureBlobStorageFile.cpp
@@ -326,7 +326,7 @@ void copyAzureBlobStorageFile(
         LOG_TRACE(&Poco::Logger::get("copyAzureBlobStorageFile"), "Reading from Container: {}, Blob: {}", src_container_for_logging, src_blob);
         auto create_read_buffer = [&]
         {
-            return std::make_unique<ReadBufferFromAzureBlobStorage>(src_client, src_blob, read_settings, settings->max_single_read_retries,
+            return std::make_unique<ReadBufferFromAzureBlobStorage>(src_client, src_blob, read_settings,
             settings->max_single_download_retries);
         };
 


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Updated to use azure api DownloadTo instead of Download and ReadTo apis. DownloadTo reads to a buffer and uses parallel requests.
