### PR TITLE
no smaller unit in date_trunc

### DIFF
--- a/src/Functions/date_trunc.cpp
+++ b/src/Functions/date_trunc.cpp
@@ -56,6 +56,10 @@ public:
             if (!IntervalKind::tryParseString(datepart_param, datepart_kind))
                 throw Exception(ErrorCodes::BAD_ARGUMENTS, "{} doesn't look like datepart name in {}", datepart_param, getName());
 
+            if (datepart_kind == IntervalKind::Kind::Nanosecond || datepart_kind == IntervalKind::Kind::Microsecond
+                || datepart_kind == IntervalKind::Kind::Millisecond)
+                throw Exception(ErrorCodes::BAD_ARGUMENTS, "{} doesn't support {}", getName(), datepart_param);
+
             result_type_is_date = (datepart_kind == IntervalKind::Kind::Year)
                 || (datepart_kind == IntervalKind::Kind::Quarter) || (datepart_kind == IntervalKind::Kind::Month)
                 || (datepart_kind == IntervalKind::Kind::Week);

--- a/tests/queries/0_stateless/02935_date_trunc_case_unsensitiveness.sql
+++ b/tests/queries/0_stateless/02935_date_trunc_case_unsensitiveness.sql
@@ -7,3 +7,6 @@ SELECT dateTrunc('Week', toDate('2022-03-01'));
 SELECT dateTrunc('day', toDateTime('2022-03-01 12:55:55'));
 SELECT dateTrunc('month', toDateTime64('2022-03-01 12:55:55', 2));
 SELECT dateTrunc('week', toDate('2022-03-01'));
+SELECT dateTrunc('Nanosecond', toDate('2022-03-01')); -- {  serverError 36 }
+SELECT dateTrunc('MicroSecond', toDate('2022-03-01')); -- {  serverError 36 }
+SELECT dateTrunc('MILLISECOND', toDate('2022-03-01')); -- {  serverError 36 }


### PR DESCRIPTION
solve this [incident](https://github.com/ClickHouse/clickhouse-core-incidents/issues/89). According to the [doc](https://clickhouse.com/docs/en/sql-reference/functions/date-time-functions#date_trunc), not all time units are supported.
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

---
### Modify your CI run:
**NOTE:** If your merge the PR with modified CI you **MUST KNOW** what you are doing
**NOTE:** Set desired options before CI starts or re-push after updates

#### Run only:
- [ ] <!---ci_set_integration--> Integration tests
- [ ] <!---ci_set_arm--> Integration tests (arm64)
- [ ] <!---ci_set_stateless--> Stateless tests (release)
- [ ] <!---ci_set_stateless_asan--> Stateless tests (asan)
- [ ] <!---ci_set_stateful--> Stateful tests (release)
- [ ] <!---ci_set_stateful_asan--> Stateful tests (asan)
- [ ] <!---ci_set_reduced--> No sanitizers
- [ ] <!---ci_set_analyzer--> Tests with analyzer
- [ ] <!---ci_set_fast--> Fast tests
- [ ] <!---job_package_debug--> Only package_debug build
- [ ] <!---PLACE_YOUR_TAG_CONFIGURED_IN_ci_config.py_FILE_HERE--> Add your CI variant description here

#### CI options:
- [ ] <!---do_not_test--> do not test (only style check)
- [ ] <!---no_merge_commit--> disable merge-commit (no merge from master before tests)
- [ ] <!---no_ci_cache--> disable CI cache (job reuse)

#### Only specified batches in multi-batch jobs:
- [ ] <!---batch_0--> 1
- [ ] <!---batch_1--> 2
- [ ] <!---batch_2--> 3
- [ ] <!---batch_3--> 4
