### PR TITLE
Modify cmake command for building clickhouse on MacOS

### DIFF
--- a/docs/en/development/build-osx.md
+++ b/docs/en/development/build-osx.md
@@ -55,9 +55,7 @@ To build using Homebrew's vanilla Clang compiler (the only **recommended** way):
 cd ClickHouse
 mkdir build
 export PATH=$(brew --prefix llvm)/bin:$PATH
-export CC=$(brew --prefix llvm)/bin/clang
-export CXX=$(brew --prefix llvm)/bin/clang++
-cmake -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -S . -B build
+cmake -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_C_COMPILER=$(brew --prefix llvm)/bin/clang -DCMAKE_CXX_COMPILER=$(brew --prefix llvm)/bin/clang++ -S . -B build
 cmake --build build
 # The resulting binary will be created at: build/programs/clickhouse
 ```


### PR DESCRIPTION
This seems subtle, but for some reason it makes a big difference. If you set the environment variables before running `cmake`, they get ignored. After many, many attempts I finally figured out this solution - which worked great on my Mac.

### Changelog category (leave one):
- Documentation (changelog entry is not required)
