### PR TITLE
Make userspace page cache work with 'web' disks

### DIFF
--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -355,8 +355,6 @@ The server successfully detected this situation and will download merged part fr
     M(PerfLocalMemoryReferences, "Local NUMA node memory reads") \
     M(PerfLocalMemoryMisses, "Local NUMA node memory read misses") \
     \
-    M(CreatedHTTPConnections, "Total amount of created HTTP connections (counter increase every time connection is created).") \
-    \
     M(CannotWriteToWriteBufferDiscard, "Number of stack traces dropped by query profiler or signal handler because pipe is full or cannot write to pipe.") \
     M(QueryProfilerSignalOverruns, "Number of times we drop processing of a query profiler signal due to overrun plus the number of signals that OS has not delivered due to overrun.") \
     M(QueryProfilerConcurrencyOverruns, "Number of times we drop processing of a query profiler signal due to too many concurrent query profilers in other threads, which may indicate overload.") \
@@ -435,8 +433,6 @@ The server successfully detected this situation and will download merged part fr
     M(ReadBufferFromS3RequestsErrors, "Number of exceptions while reading from S3.") \
     M(ReadBufferFromS3ResetSessions, "Number of HTTP sessions that were reset in ReadBufferFromS3.") \
     M(ReadBufferFromS3PreservedSessions, "Number of HTTP sessions that were preserved in ReadBufferFromS3.") \
-    \
-    M(ReadWriteBufferFromHTTPPreservedSessions, "Number of HTTP sessions that were preserved in ReadWriteBufferFromHTTP.") \
     \
     M(WriteBufferFromS3Microseconds, "Time spent on writing to S3.") \
     M(WriteBufferFromS3Bytes, "Bytes written to S3.") \

--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -722,6 +722,9 @@ The server successfully detected this situation and will download merged part fr
     M(AddressesDiscovered, "Total count of new addresses in dns resolve results for http connections") \
     M(AddressesExpired, "Total count of expired addresses which is no longer presented in dns resolve results for http connections") \
     M(AddressesMarkedAsFailed, "Total count of addresses which has been marked as faulty due to connection errors for http connections") \
+    \
+    M(ReadWriteBufferFromHTTPRequestsSent, "Number of HTTP requests sent by ReadWriteBufferFromHTTP") \
+    M(ReadWriteBufferFromHTTPBytes, "Total size of payload bytes received and sent by ReadWriteBufferFromHTTP. Doesn't include HTTP headers.") \
 
 
 #ifdef APPLY_FOR_EXTERNAL_EVENTS

--- a/src/Coordination/KeeperConstants.cpp
+++ b/src/Coordination/KeeperConstants.cpp
@@ -111,7 +111,6 @@
     M(PerfLocalMemoryReferences) \
     M(PerfLocalMemoryMisses) \
 \
-    M(CreatedHTTPConnections) \
     M(CannotWriteToWriteBufferDiscard) \
 \
     M(S3ReadMicroseconds) \
@@ -180,8 +179,6 @@
     M(ReadBufferFromS3RequestsErrors) \
     M(ReadBufferFromS3ResetSessions) \
     M(ReadBufferFromS3PreservedSessions) \
-\
-    M(ReadWriteBufferFromHTTPPreservedSessions) \
 \
     M(WriteBufferFromS3Microseconds) \
     M(WriteBufferFromS3Bytes) \

--- a/src/Disks/IO/ReadBufferFromRemoteFSGather.cpp
+++ b/src/Disks/IO/ReadBufferFromRemoteFSGather.cpp
@@ -87,7 +87,7 @@ SeekableReadBufferPtr ReadBufferFromRemoteFSGather::createImplementationBuffer(c
             cache_key,
             settings.remote_fs_cache,
             FileCache::getCommonUser(),
-            [=, this]() { return read_buffer_creator(/* restricted_seek */true, object_path); },
+            [=, this]() { return read_buffer_creator(/* restricted_seek */true, object); },
             settings,
             query_id,
             object.bytes_size,
@@ -102,14 +102,14 @@ SeekableReadBufferPtr ReadBufferFromRemoteFSGather::createImplementationBuffer(c
     /// former doesn't support seeks.
     if (with_page_cache && !buf)
     {
-        auto inner = read_buffer_creator(/* restricted_seek */false, object_path);
+        auto inner = read_buffer_creator(/* restricted_seek */false, object);
         auto cache_key = FileChunkAddress { .path = cache_path_prefix + object_path };
         buf = std::make_unique<CachedInMemoryReadBufferFromFile>(
             cache_key, settings.page_cache, std::move(inner), settings);
     }
 
     if (!buf)
-        buf = read_buffer_creator(/* restricted_seek */true, object_path);
+        buf = read_buffer_creator(/* restricted_seek */true, object);
 
     if (read_until_position > start_offset && read_until_position < start_offset + object.bytes_size)
         buf->setReadUntilPosition(read_until_position - start_offset);

--- a/src/Disks/IO/ReadBufferFromRemoteFSGather.h
+++ b/src/Disks/IO/ReadBufferFromRemoteFSGather.h
@@ -21,7 +21,7 @@ class ReadBufferFromRemoteFSGather final : public ReadBufferFromFileBase
 friend class ReadIndirectBufferFromRemoteFS;
 
 public:
-    using ReadBufferCreator = std::function<std::unique_ptr<ReadBufferFromFileBase>(bool restricted_seek, const std::string & path)>;
+    using ReadBufferCreator = std::function<std::unique_ptr<ReadBufferFromFileBase>(bool restricted_seek, const StoredObject & object)>;
 
     ReadBufferFromRemoteFSGather(
         ReadBufferCreator && read_buffer_creator_,

--- a/src/Disks/IO/ReadBufferFromWebServer.cpp
+++ b/src/Disks/IO/ReadBufferFromWebServer.cpp
@@ -21,10 +21,11 @@ namespace ErrorCodes
 ReadBufferFromWebServer::ReadBufferFromWebServer(
     const String & url_,
     ContextPtr context_,
+    size_t file_size_,
     const ReadSettings & settings_,
     bool use_external_buffer_,
     size_t read_until_position_)
-    : ReadBufferFromFileBase(settings_.remote_fs_buffer_size, nullptr, 0)
+    : ReadBufferFromFileBase(settings_.remote_fs_buffer_size, nullptr, 0, file_size_)
     , log(getLogger("ReadBufferFromWebServer"))
     , context(context_)
     , url(url_)
@@ -36,7 +37,7 @@ ReadBufferFromWebServer::ReadBufferFromWebServer(
 }
 
 
-std::unique_ptr<ReadBuffer> ReadBufferFromWebServer::initialize()
+std::unique_ptr<SeekableReadBuffer> ReadBufferFromWebServer::initialize()
 {
     Poco::URI uri(url);
     if (read_until_position)
@@ -119,9 +120,8 @@ bool ReadBufferFromWebServer::nextImpl()
 
     auto result = impl->next();
 
-    BufferBase::set(impl->buffer().begin(), impl->buffer().size(), impl->offset());
-
-    chassert(working_buffer.begin() == impl->buffer().begin());
+    working_buffer = impl->buffer();
+    pos = impl->position();
 
     if (result)
         offset += working_buffer.size();
@@ -132,16 +132,29 @@ bool ReadBufferFromWebServer::nextImpl()
 
 off_t ReadBufferFromWebServer::seek(off_t offset_, int whence)
 {
-    if (impl)
-        throw Exception(ErrorCodes::CANNOT_SEEK_THROUGH_FILE, "Seek is allowed only before first read attempt from the buffer");
-
     if (whence != SEEK_SET)
         throw Exception(ErrorCodes::CANNOT_SEEK_THROUGH_FILE, "Only SEEK_SET mode is allowed");
 
     if (offset_ < 0)
         throw Exception(ErrorCodes::SEEK_POSITION_OUT_OF_BOUND, "Seek position is out of bounds. Offset: {}", offset_);
 
-    offset = offset_;
+    if (impl)
+    {
+        if (use_external_buffer)
+        {
+            impl->set(internal_buffer.begin(), internal_buffer.size());
+        }
+
+        impl->seek(offset_, SEEK_SET);
+
+        working_buffer = impl->buffer();
+        pos = impl->position();
+        offset = offset_ + available();
+    }
+    else
+    {
+        offset = offset_;
+    }
 
     return offset;
 }

--- a/src/Disks/IO/ReadBufferFromWebServer.h
+++ b/src/Disks/IO/ReadBufferFromWebServer.h
@@ -20,6 +20,7 @@ public:
     explicit ReadBufferFromWebServer(
         const String & url_,
         ContextPtr context_,
+        size_t file_size_,
         const ReadSettings & settings_ = {},
         bool use_external_buffer_ = false,
         size_t read_until_position = 0);
@@ -39,7 +40,7 @@ public:
     bool supportsRightBoundedReads() const override { return true; }
 
 private:
-    std::unique_ptr<ReadBuffer> initialize();
+    std::unique_ptr<SeekableReadBuffer> initialize();
 
     LoggerPtr log;
     ContextPtr context;
@@ -47,7 +48,7 @@ private:
     const String url;
     size_t buf_size;
 
-    std::unique_ptr<ReadBuffer> impl;
+    std::unique_ptr<SeekableReadBuffer> impl;
 
     ReadSettings read_settings;
 

--- a/src/Disks/ObjectStorages/AzureBlobStorage/AzureObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/AzureBlobStorage/AzureObjectStorage.cpp
@@ -206,11 +206,11 @@ std::unique_ptr<ReadBufferFromFileBase> AzureObjectStorage::readObjects( /// NOL
 
     auto read_buffer_creator =
         [this, settings_ptr, disk_read_settings]
-        (bool restricted_seek, const std::string & path) -> std::unique_ptr<ReadBufferFromFileBase>
+        (bool restricted_seek, const StoredObject & object_) -> std::unique_ptr<ReadBufferFromFileBase>
     {
         return std::make_unique<ReadBufferFromAzureBlobStorage>(
             client.get(),
-            path,
+            object_.remote_path,
             disk_read_settings,
             settings_ptr->max_single_read_retries,
             settings_ptr->max_single_download_retries,

--- a/src/Disks/ObjectStorages/HDFS/HDFSObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/HDFS/HDFSObjectStorage.cpp
@@ -60,8 +60,9 @@ std::unique_ptr<ReadBufferFromFileBase> HDFSObjectStorage::readObjects( /// NOLI
     auto disk_read_settings = patchSettings(read_settings);
     auto read_buffer_creator =
         [this, disk_read_settings]
-        (bool /* restricted_seek */, const std::string & path) -> std::unique_ptr<ReadBufferFromFileBase>
+        (bool /* restricted_seek */, const StoredObject & object_) -> std::unique_ptr<ReadBufferFromFileBase>
     {
+        auto path = object_.remote_path;
         size_t begin_of_path = path.find('/', path.find("//") + 2);
         auto hdfs_path = path.substr(begin_of_path);
         auto hdfs_uri = path.substr(0, begin_of_path);

--- a/src/Disks/ObjectStorages/HDFS/HDFSObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/HDFS/HDFSObjectStorage.cpp
@@ -62,7 +62,7 @@ std::unique_ptr<ReadBufferFromFileBase> HDFSObjectStorage::readObjects( /// NOLI
         [this, disk_read_settings]
         (bool /* restricted_seek */, const StoredObject & object_) -> std::unique_ptr<ReadBufferFromFileBase>
     {
-        auto path = object_.remote_path;
+        const auto & path = object_.remote_path;
         size_t begin_of_path = path.find('/', path.find("//") + 2);
         auto hdfs_path = path.substr(begin_of_path);
         auto hdfs_uri = path.substr(0, begin_of_path);

--- a/src/Disks/ObjectStorages/Local/LocalObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/Local/LocalObjectStorage.cpp
@@ -52,8 +52,7 @@ std::unique_ptr<ReadBufferFromFileBase> LocalObjectStorage::readObjects( /// NOL
         [=] (bool /* restricted_seek */, const StoredObject & object)
         -> std::unique_ptr<ReadBufferFromFileBase>
     {
-        auto & file_path = object.remote_path;
-        return createReadBufferFromFileBase(file_path, modified_settings, read_hint, file_size);
+        return createReadBufferFromFileBase(object.remote_path, modified_settings, read_hint, file_size);
     };
 
     switch (read_settings.remote_fs_method)

--- a/src/Disks/ObjectStorages/Local/LocalObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/Local/LocalObjectStorage.cpp
@@ -49,9 +49,10 @@ std::unique_ptr<ReadBufferFromFileBase> LocalObjectStorage::readObjects( /// NOL
     auto modified_settings = patchSettings(read_settings);
     auto global_context = Context::getGlobalContextInstance();
     auto read_buffer_creator =
-        [=] (bool /* restricted_seek */, const std::string & file_path)
+        [=] (bool /* restricted_seek */, const StoredObject & object)
         -> std::unique_ptr<ReadBufferFromFileBase>
     {
+        auto & file_path = object.remote_path;
         return createReadBufferFromFileBase(file_path, modified_settings, read_hint, file_size);
     };
 

--- a/src/Disks/ObjectStorages/S3/S3ObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/S3/S3ObjectStorage.cpp
@@ -172,8 +172,9 @@ std::unique_ptr<ReadBufferFromFileBase> S3ObjectStorage::readObjects( /// NOLINT
 
     auto read_buffer_creator =
         [this, settings_ptr, disk_read_settings]
-        (bool restricted_seek, const std::string & path) -> std::unique_ptr<ReadBufferFromFileBase>
+        (bool restricted_seek, const StoredObject & object_) -> std::unique_ptr<ReadBufferFromFileBase>
     {
+        auto & path = object_.remote_path;
         return std::make_unique<ReadBufferFromS3>(
             client.get(),
             uri.bucket,

--- a/src/Disks/ObjectStorages/S3/S3ObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/S3/S3ObjectStorage.cpp
@@ -174,11 +174,10 @@ std::unique_ptr<ReadBufferFromFileBase> S3ObjectStorage::readObjects( /// NOLINT
         [this, settings_ptr, disk_read_settings]
         (bool restricted_seek, const StoredObject & object_) -> std::unique_ptr<ReadBufferFromFileBase>
     {
-        auto & path = object_.remote_path;
         return std::make_unique<ReadBufferFromS3>(
             client.get(),
             uri.bucket,
-            path,
+            object_.remote_path,
             uri.version_id,
             settings_ptr->request_settings,
             disk_read_settings,

--- a/src/Disks/ObjectStorages/Web/WebObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/Web/WebObjectStorage.cpp
@@ -253,14 +253,15 @@ std::unique_ptr<ReadBufferFromFileBase> WebObjectStorage::readObject( /// NOLINT
     size_t object_size = object.bytes_size;
     auto read_buffer_creator =
          [this, read_settings, object_size]
-         (bool /* restricted_seek */, const std::string & path_) -> std::unique_ptr<ReadBufferFromFileBase>
+         (bool /* restricted_seek */, const StoredObject & object_) -> std::unique_ptr<ReadBufferFromFileBase>
      {
-         return std::make_unique<ReadBufferFromWebServer>(
-             fs::path(url) / path_,
-             getContext(),
-             object_size,
-             read_settings,
-             /* use_external_buffer */true);
+        auto & path_ = object_.remote_path;
+        return std::make_unique<ReadBufferFromWebServer>(
+            fs::path(url) / path_,
+            getContext(),
+            object_size,
+            read_settings,
+            /* use_external_buffer */true);
      };
 
     auto global_context = Context::getGlobalContextInstance();

--- a/src/Disks/ObjectStorages/Web/WebObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/Web/WebObjectStorage.cpp
@@ -255,9 +255,8 @@ std::unique_ptr<ReadBufferFromFileBase> WebObjectStorage::readObject( /// NOLINT
          [this, read_settings, object_size]
          (bool /* restricted_seek */, const StoredObject & object_) -> std::unique_ptr<ReadBufferFromFileBase>
      {
-        auto & path_ = object_.remote_path;
         return std::make_unique<ReadBufferFromWebServer>(
-            fs::path(url) / path_,
+            fs::path(url) / object_.remote_path,
             getContext(),
             object_size,
             read_settings,

--- a/src/Disks/ObjectStorages/Web/WebObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/Web/WebObjectStorage.cpp
@@ -250,13 +250,15 @@ std::unique_ptr<ReadBufferFromFileBase> WebObjectStorage::readObject( /// NOLINT
     std::optional<size_t>,
     std::optional<size_t>) const
 {
+    size_t object_size = object.bytes_size;
     auto read_buffer_creator =
-         [this, read_settings]
+         [this, read_settings, object_size]
          (bool /* restricted_seek */, const std::string & path_) -> std::unique_ptr<ReadBufferFromFileBase>
      {
          return std::make_unique<ReadBufferFromWebServer>(
              fs::path(url) / path_,
              getContext(),
+             object_size,
              read_settings,
              /* use_external_buffer */true);
      };

--- a/src/IO/ReadWriteBufferFromHTTP.cpp
+++ b/src/IO/ReadWriteBufferFromHTTP.cpp
@@ -8,6 +8,8 @@
 namespace ProfileEvents
 {
     extern const Event ReadBufferSeekCancelConnection;
+    extern const Event ReadWriteBufferFromHTTPRequestsSent;
+    extern const Event ReadWriteBufferFromHTTPBytes;
 }
 
 
@@ -245,6 +247,8 @@ ReadWriteBufferFromHTTP::CallResult ReadWriteBufferFromHTTP::callImpl(
 
     auto session = makeHTTPSession(connection_group, uri_, timeouts, proxy_config);
 
+    ProfileEvents::increment(ProfileEvents::ReadWriteBufferFromHTTPRequestsSent);
+
     auto & stream_out = session->sendRequest(request);
     if (out_stream_callback)
         out_stream_callback(stream_out);
@@ -480,6 +484,8 @@ bool ReadWriteBufferFromHTTP::nextImpl()
             BufferBase::set(impl->buffer().begin(), impl->buffer().size(), impl->offset());
 
             offset_from_begin_pos += working_buffer.size();
+
+            ProfileEvents::increment(ProfileEvents::ReadWriteBufferFromHTTPBytes, working_buffer.size());
         },
         /*on_retry=*/ [&] ()
         {
@@ -528,6 +534,8 @@ size_t ReadWriteBufferFromHTTP::readBigAt(char * to, size_t n, size_t offset, co
 
             copyFromIStreamWithProgressCallback(*result.response_stream, to, n, progress_callback, &bytes_copied, &is_canceled);
 
+            ProfileEvents::increment(ProfileEvents::ReadWriteBufferFromHTTPBytes, bytes_copied);
+
             offset += bytes_copied;
             total_bytes_copied += bytes_copied;
             to += bytes_copied;
@@ -536,6 +544,8 @@ size_t ReadWriteBufferFromHTTP::readBigAt(char * to, size_t n, size_t offset, co
         },
         /*on_retry=*/ [&] ()
         {
+            ProfileEvents::increment(ProfileEvents::ReadWriteBufferFromHTTPBytes, bytes_copied);
+
             offset += bytes_copied;
             total_bytes_copied += bytes_copied;
             to += bytes_copied;

--- a/src/IO/ReadWriteBufferFromHTTP.cpp
+++ b/src/IO/ReadWriteBufferFromHTTP.cpp
@@ -574,7 +574,7 @@ off_t ReadWriteBufferFromHTTP::seek(off_t offset_, int whence)
     if (impl)
     {
         auto position = getPosition();
-        if (offset_ > position)
+        if (offset_ >= position)
         {
             size_t diff = offset_ - position;
             if (diff < read_settings.remote_read_min_bytes_for_seek)

--- a/src/Storages/StorageS3.cpp
+++ b/src/Storages/StorageS3.cpp
@@ -727,11 +727,10 @@ std::unique_ptr<ReadBuffer> StorageS3Source::createAsyncS3ReadBuffer(
         [this, read_settings, object_size]
         (bool restricted_seek, const StoredObject & object) -> std::unique_ptr<ReadBufferFromFileBase>
     {
-        auto & path = object.remote_path;
         return std::make_unique<ReadBufferFromS3>(
             client,
             bucket,
-            path,
+            object.remote_path,
             version_id,
             request_settings,
             read_settings,

--- a/src/Storages/StorageS3.cpp
+++ b/src/Storages/StorageS3.cpp
@@ -725,8 +725,9 @@ std::unique_ptr<ReadBuffer> StorageS3Source::createAsyncS3ReadBuffer(
     auto context = getContext();
     auto read_buffer_creator =
         [this, read_settings, object_size]
-        (bool restricted_seek, const std::string & path) -> std::unique_ptr<ReadBufferFromFileBase>
+        (bool restricted_seek, const StoredObject & object) -> std::unique_ptr<ReadBufferFromFileBase>
     {
+        auto & path = object.remote_path;
         return std::make_unique<ReadBufferFromS3>(
             client,
             bucket,

--- a/tests/integration/test_disk_over_web_server/configs/storage_conf_web.xml
+++ b/tests/integration/test_disk_over_web_server/configs/storage_conf_web.xml
@@ -29,4 +29,6 @@
             </cached_web>
         </policies>
     </storage_configuration>
+
+    <query_log></query_log>
 </clickhouse>

--- a/tests/integration/test_disk_over_web_server/test.py
+++ b/tests/integration/test_disk_over_web_server/test.py
@@ -322,3 +322,56 @@ def test_replicated_database(cluster):
 
     node1.query("DROP DATABASE rdb SYNC")
     node2.query("DROP DATABASE rdb SYNC")
+
+def test_page_cache(cluster):
+    node = cluster.instances["node2"]
+    global uuids
+    assert len(uuids) == 3
+    for i in range(3):
+        node.query(
+            """
+            CREATE TABLE test{} UUID '{}'
+            (id Int32) ENGINE = MergeTree() ORDER BY id
+            SETTINGS storage_policy = 'web';
+        """.format(
+                i, uuids[i], i, i
+            )
+        )
+
+        result1 = node.query(f"SELECT sum(cityHash64(*)) FROM test{i} SETTINGS use_page_cache_for_disks_without_file_cache=1 -- test cold cache")
+        result2 = node.query(f"SELECT sum(cityHash64(*)) FROM test{i} SETTINGS use_page_cache_for_disks_without_file_cache=1 -- test warm cache")
+        result3 = node.query(f"SELECT sum(cityHash64(*)) FROM test{i} SETTINGS use_page_cache_for_disks_without_file_cache=0 -- test no cache")
+
+        assert result1 == result3
+        assert result2 == result3
+
+        node.query("SYSTEM FLUSH LOGS")
+
+        def get_profile_events(query_name):
+            print(f"asdqwe {query_name}")
+            text = node.query(f"SELECT ProfileEvents.Names, ProfileEvents.Values FROM system.query_log ARRAY JOIN ProfileEvents WHERE query LIKE '% -- {query_name}' AND type = 'QueryFinish'")
+            res = {}
+            for line in text.split("\n"):
+                if line == "":
+                    continue
+                name, value = line.split("\t")
+                print(f"asdqwe {name} = {int(value)}")
+                res[name] = int(value)
+            return res
+
+        ev1 = get_profile_events("test cold cache")
+        assert ev1.get('PageCacheChunkMisses', 0) > 0
+        assert ev1.get('DiskConnectionsCreated', 0) + ev1.get('DiskConnectionsReused', 0) > 0
+
+        ev2 = get_profile_events("test warm cache")
+        assert ev2.get('PageCacheChunkDataHits', 0) > 0
+        assert ev2.get('PageCacheChunkMisses', 0) == 0
+        assert ev2.get('DiskConnectionsCreated', 0) + ev2.get('DiskConnectionsReused', 0) == 0
+
+        ev3 = get_profile_events("test no cache")
+        assert ev3.get('PageCacheChunkDataHits', 0) == 0
+        assert ev3.get('PageCacheChunkMisses', 0) == 0
+        assert ev3.get('DiskConnectionsCreated', 0) + ev3.get('DiskConnectionsReused', 0) > 0
+
+        node.query("DROP TABLE test{} SYNC".format(i))
+        print(f"Ok {i}")


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Userspace page cache works with static web storage (`disk(type = web)`) now. Use client setting `use_page_cache_for_disks_without_file_cache=1` to enable.

Closes https://github.com/ClickHouse/ClickHouse/issues/61474

```
:) select sum(ignore(*)) from uk_price_paid settings use_page_cache_for_disks_without_file_cache=0

SELECT sum(ignore(*))
FROM uk_price_paid
SETTINGS use_page_cache_for_disks_without_file_cache = 0

Query id: 8f22c410-6627-406b-9185-a3e5aba2030e

┌─sum(ignore(price, date, postcode1, postcode2, type, is_new, duration, addr1, addr2, street, locality, town, district, county))─┐
│                                                                                                                              0 │
└────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘

1 row in set. Elapsed: 0.972 sec. Processed 27.91 million rows, 1.24 GB (28.72 million rows/s., 1.27 GB/s.)
Peak memory usage: 87.18 MiB.

:) select sum(ignore(*)) from uk_price_paid settings use_page_cache_for_disks_without_file_cache=1

SELECT sum(ignore(*))
FROM uk_price_paid
SETTINGS use_page_cache_for_disks_without_file_cache = 1

Query id: abb429c8-6fdb-4939-9b67-92226ac2877c

┌─sum(ignore(price, date, postcode1, postcode2, type, is_new, duration, addr1, addr2, street, locality, town, district, county))─┐
│                                                                                                                              0 │
└────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘

1 row in set. Elapsed: 0.688 sec. Processed 27.91 million rows, 1.24 GB (40.56 million rows/s., 1.80 GB/s.)
Peak memory usage: 148.41 MiB.

:) select sum(ignore(*)) from uk_price_paid settings use_page_cache_for_disks_without_file_cache=1

SELECT sum(ignore(*))
FROM uk_price_paid
SETTINGS use_page_cache_for_disks_without_file_cache = 1

Query id: a21093c7-f802-4131-b3ab-358971b4c6bb

┌─sum(ignore(price, date, postcode1, postcode2, type, is_new, duration, addr1, addr2, street, locality, town, district, county))─┐
│                                                                                                                              0 │
└────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘

1 row in set. Elapsed: 0.218 sec. Processed 27.91 million rows, 1.24 GB (128.25 million rows/s., 5.68 GB/s.)
Peak memory usage: 199.04 MiB.
```

The third query made no HTTP requests.