### PR TITLE
Fix flaky test_broken_projestions/test.py::test_broken_ignored_replic…

### DIFF
--- a/tests/integration/test_broken_projections/test.py
+++ b/tests/integration/test_broken_projections/test.py
@@ -223,14 +223,17 @@ def check(node, table, check_result, expect_broken_part="", expected_error=""):
         query_id = node.query(
             f"SELECT queryID() FROM (SELECT c FROM '{table}' WHERE d == 12 ORDER BY c)"
         ).strip()
-        node.query("SYSTEM FLUSH LOGS")
-        res = node.query(
-            f"""
-        SELECT query, splitByChar('.', arrayJoin(projections))[-1]
-        FROM system.query_log
-        WHERE query_id='{query_id}' AND type='QueryFinish'
-        """
-        )
+        for _ in range(10):
+            node.query("SYSTEM FLUSH LOGS")
+            res = node.query(
+                f"""
+            SELECT query, splitByChar('.', arrayJoin(projections))[-1]
+            FROM system.query_log
+            WHERE query_id='{query_id}' AND type='QueryFinish'
+            """
+            )
+            if res != "":
+                break
         if res == "":
             res = node.query(
                 """
@@ -238,7 +241,7 @@ def check(node, table, check_result, expect_broken_part="", expected_error=""):
                 FROM system.query_log ORDER BY query_start_time_microseconds DESC
             """
             )
-            print(f"LOG: {res}")
+            print(f"Looked for query id {query_id}, but to no avail: {res}")
             assert False
         assert "proj1" in res
 
@@ -250,14 +253,17 @@ def check(node, table, check_result, expect_broken_part="", expected_error=""):
         query_id = node.query(
             f"SELECT queryID() FROM (SELECT d FROM '{table}' WHERE c == 12 ORDER BY d)"
         ).strip()
-        node.query("SYSTEM FLUSH LOGS")
-        res = node.query(
-            f"""
-        SELECT query, splitByChar('.', arrayJoin(projections))[-1]
-        FROM system.query_log
-        WHERE query_id='{query_id}' AND type='QueryFinish'
-        """
-        )
+        for _ in range(10):
+            node.query("SYSTEM FLUSH LOGS")
+            res = node.query(
+                f"""
+            SELECT query, splitByChar('.', arrayJoin(projections))[-1]
+            FROM system.query_log
+            WHERE query_id='{query_id}' AND type='QueryFinish'
+            """
+            )
+            if res != "":
+                break
         if res == "":
             res = node.query(
                 """
@@ -265,7 +271,7 @@ def check(node, table, check_result, expect_broken_part="", expected_error=""):
                 FROM system.query_log ORDER BY query_start_time_microseconds DESC
             """
             )
-            print(f"LOG: {res}")
+            print(f"Looked for query id {query_id}, but to no avail: {res}")
             assert False
         assert "proj2" in res
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

This is strange that there was no record by certain query_id even after system flush logs, but according to debug logging in test it was there after the second try (second try was the printing of debug info before abort) https://pastila.nl/?0075caf2/3ff9b5c94c6925196627cd3d80fe494b#8Kb3T85WOEfDlrf6RR0gaQ==

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

---
### Modify your CI run:
**NOTE:** If your merge the PR with modified CI you **MUST KNOW** what you are doing
**NOTE:** Set desired options before CI starts or re-push after updates

#### Run only:
- [x] <!---ci_set_integration--> Integration tests
- [ ] <!---ci_set_arm--> Integration tests (arm64)
- [ ] <!---ci_set_stateless--> Stateless tests (release)
- [ ] <!---ci_set_stateless_asan--> Stateless tests (asan)
- [ ] <!---ci_set_stateful--> Stateful tests (release)
- [ ] <!---ci_set_stateful_asan--> Stateful tests (asan)
- [ ] <!---ci_set_reduced--> No sanitizers
- [ ] <!---ci_set_analyzer--> Tests with analyzer
- [ ] <!---ci_set_fast--> Fast tests
- [ ] <!---job_package_debug--> Only package_debug build
- [ ] <!---PLACE_YOUR_TAG_CONFIGURED_IN_ci_config.py_FILE_HERE--> Add your CI variant description here

#### CI options:
- [ ] <!---do_not_test--> do not test (only style check)
- [ ] <!---no_merge_commit--> disable merge-commit (no merge from master before tests)
- [ ] <!---no_ci_cache--> disable CI cache (job reuse)

#### Only specified batches in multi-batch jobs:
- [ ] <!---batch_0--> 1
- [ ] <!---batch_1--> 2
- [ ] <!---batch_2--> 3
- [ ] <!---batch_3--> 4

