### PR TITLE
Check is Rust avaiable for build, if not, suggest a way to disable Rust support

### DIFF
--- a/rust/CMakeLists.txt
+++ b/rust/CMakeLists.txt
@@ -99,6 +99,19 @@ function(add_rust_subdirectory src)
     message(STATUS "Copy ${src} to ${dst}")
     file(COPY "${src}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}"
         PATTERN target EXCLUDE)
+
+    # Check is Rust available or not.
+    #
+    # `cargo update --dry-run` will not update anything, but will check the internet connectivity.
+    execute_process(COMMAND ${Rust_CARGO_CACHED} update --dry-run
+        WORKING_DIRECTORY "${dst}"
+        RESULT_VARIABLE CARGO_UPDATE_RESULT
+        OUTPUT_VARIABLE CARGO_UPDATE_STDOUT
+        ERROR_VARIABLE CARGO_UPDATE_STDERR)
+    if (CARGO_UPDATE_RESULT)
+        message(FATAL_ERROR "Rust (${Rust_CARGO_CACHED}) support is not available (likely there is no internet connectivity):\n${CARGO_UPDATE_STDERR}\nYou can disable Rust support with -DENABLE_RUST=OFF")
+    endif()
+
     add_subdirectory("${dst}" "${dst}")
 
     # cmake -E copy* do now know how to exclude files


### PR DESCRIPTION
Rust requires internet connection, so let's detect if it works, and if not, suggest building with -DENABLE_RUST=OFF, here is an example of the output in case of error:

    $ docker run --network=none ...
    -- Copy skim to /root/rust/skim
    CMake Error at rust/CMakeLists.txt:112 (message):
      Rust (/rust/rustup/toolchains/nightly-x86_64-unknown-linux-gnu/bin/cargo)
      support is not available (likely there is no internet connectivity):

          Updating git repository `https://github.com/azat-rust/tuikit.git`

      warning: spurious network error (3 tries remaining): failed to resolve
      address for github.com: Temporary failure in name resolution; class=Net
      (12)

      warning: spurious network error (2 tries remaining): failed to resolve
      address for github.com: Temporary failure in name resolution; class=Net
      (12)

      warning: spurious network error (1 tries remaining): failed to resolve
      address for github.com: Temporary failure in name resolution; class=Net
      (12)

      error: failed to load source for dependency `tuikit`

      Caused by:

        Unable to update https://github.com/azat-rust/tuikit.git?rev=e1994c0e03ff02c49cf1471f0cc3cbf185ce0104

      Caused by:

        failed to clone into: /rust/cargo/git/db/tuikit-c3ca927b4dbcf00d

      Caused by:

        network failure seems to have happened
        if a proxy or similar is necessary `net.git-fetch-with-cli` may help here
        https://doc.rust-lang.org/cargo/reference/config.html#netgit-fetch-with-cli

      Caused by:

        failed to resolve address for github.com: Temporary failure in name resolution; class=Net (12)

      You can disable Rust support with -DENABLE_RUST=OFF
    Call Stack (most recent call first):
      rust/CMakeLists.txt:129 (add_rust_subdirectory)

    -- Configuring incomplete, errors occurred!

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Fixes: #61741