### PR TITLE
Crash in Engine Merge if Row Policy does not have expression

### DIFF
--- a/src/Storages/StorageMerge.cpp
+++ b/src/Storages/StorageMerge.cpp
@@ -583,7 +583,7 @@ std::vector<ReadFromMerge::ChildPlan> ReadFromMerge::createChildrenPlans(SelectQ
             database_name,
             table_name,
             RowPolicyFilterType::SELECT_FILTER);
-        if (row_policy_filter_ptr)
+        if (row_policy_filter_ptr && row_policy_filter_ptr->expression)
         {
             row_policy_data_opt = RowPolicyData(row_policy_filter_ptr, storage, modified_context);
             row_policy_data_opt->extendNames(real_column_names);

--- a/src/Storages/StorageMerge.cpp
+++ b/src/Storages/StorageMerge.cpp
@@ -583,7 +583,7 @@ std::vector<ReadFromMerge::ChildPlan> ReadFromMerge::createChildrenPlans(SelectQ
             database_name,
             table_name,
             RowPolicyFilterType::SELECT_FILTER);
-        if (row_policy_filter_ptr && row_policy_filter_ptr->expression)
+        if (row_policy_filter_ptr && !row_policy_filter_ptr->empty())
         {
             row_policy_data_opt = RowPolicyData(row_policy_filter_ptr, storage, modified_context);
             row_policy_data_opt->extendNames(real_column_names);

--- a/tests/queries/0_stateless/02763_row_policy_storage_merge.reference
+++ b/tests/queries/0_stateless/02763_row_policy_storage_merge.reference
@@ -166,6 +166,10 @@ SELECT x, y from merge(currentDatabase(), 02763_merge
 4	14
 4	14
 4	14
+USING 0
+USING 1
+zzz
+====
 SETTINGS optimize_move_to_prewhere= 1
 SELECT * FROM 02763_merge_log_1
 3	13
@@ -312,3 +316,7 @@ SELECT x, y from merge(currentDatabase(), 02763_merge
 4	14
 4	14
 4	14
+USING 0
+USING 1
+zzz
+====

--- a/tests/queries/0_stateless/02763_row_policy_storage_merge.sql.j2
+++ b/tests/queries/0_stateless/02763_row_policy_storage_merge.sql.j2
@@ -129,6 +129,27 @@ SELECT x, lc, cnst from merge(currentDatabase(), '02763_merge_fancycols') ORDER 
 SELECT 'SELECT x, y from merge(currentDatabase(), 02763_merge';
 SELECT x, y from merge(currentDatabase(), '02763_merge') ORDER BY x SETTINGS optimize_move_to_prewhere= {{prew}};
 
+
+
+CREATE TABLE 02763_t1 ( b String ) ENGINE = MergeTree() ORDER BY tuple();
+INSERT INTO 02763_t1 VALUES('zzz');
+CREATE TABLE 02763_t2 AS 02763_t1 ENGINE = Merge(currentDatabase(), '02763_t1');
+
+SELECT 'USING 0';
+CREATE ROW POLICY OR REPLACE 02763_filter_t1 ON 02763_t1 USING 0 TO ALL;
+SELECT * FROM 02763_t2 SETTINGS optimize_move_to_prewhere= {{prew}};
+
+SELECT 'USING 1';
+CREATE ROW POLICY OR REPLACE 02763_filter_t1 ON 02763_t1 USING 1 TO ALL;
+SELECT * FROM 02763_t2 SETTINGS optimize_move_to_prewhere= {{prew}};
+
+
+DROP TABLE 02763_t1;
+DROP TABLE 02763_t2;
+SELECT '====';
+
+
+
 DROP TABLE 02763_merge_fancycols;
 
 DROP ROW POLICY 02763_filter_1 ON 02763_merge_log_1;
@@ -139,5 +160,7 @@ DROP ROW POLICY 02763_filter_4 ON 02763_merge_merge_1;
 
 DROP ROW POLICY 02763_filter_5 ON 02763_merge_fancycols;
 DROP ROW POLICY 02763_filter_6 ON 02763_merge_fancycols;
+
+DROP ROW POLICY 02763_filter_t1 ON 02763_t1;
 
 {% endfor %}


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixes Crash in Engine Merge if Row Policy does not have expression

Addresses https://github.com/ClickHouse/ClickHouse/issues/61949