### PR TITLE
[RFC] Send LOGICAL_ERRORs to sentry

### DIFF
--- a/docs/en/operations/server-configuration-parameters/settings.md
+++ b/docs/en/operations/server-configuration-parameters/settings.md
@@ -1517,6 +1517,7 @@ The server will need access to the public Internet via IPv4 (at the time of writ
 Keys:
 
 - `enabled` – Boolean flag to enable the feature, `false` by default. Set to `true` to allow sending crash reports.
+- `send_logical_errors` – `LOGICAL_ERROR` is like an `assert`, it is a bug in ClickHouse. This boolean flag enables sending this exceptions to sentry (default: `false`).
 - `endpoint` – You can override the Sentry endpoint URL for sending crash reports. It can be either a separate Sentry account or your self-hosted Sentry instance. Use the [Sentry DSN](https://docs.sentry.io/error-reporting/quickstart/?platform=native#configure-the-sdk) syntax.
 - `anonymize` - Avoid attaching the server hostname to the crash report.
 - `http_proxy` - Configure HTTP proxy for sending crash reports.

--- a/programs/server/config.xml
+++ b/programs/server/config.xml
@@ -1536,6 +1536,8 @@
         <!-- Default endpoint should be changed to different Sentry DSN only if you have -->
         <!-- some in-house engineers or hired consultants who're going to debug ClickHouse issues for you -->
         <endpoint>https://6f33034cfe684dd7a3ab9875e57b1c8d@o388870.ingest.sentry.io/5226277</endpoint>
+        <!-- Send LOGICAL_ERRORs as well (default: false) -->
+        <send_logical_errors>false</send_logical_errors>
     </send_crash_reports>
 
     <!-- Uncomment to disable ClickHouse internal DNS caching. -->

--- a/src/Common/Exception.cpp
+++ b/src/Common/Exception.cpp
@@ -61,10 +61,13 @@ void handle_error_code([[maybe_unused]] const std::string & msg, int code, bool 
         abortOnFailedAssertion(msg);
 #else
         /// In release builds send it to sentry (if it is configured)
-        SentryWriter::FramePointers frame_pointers;
-        for (size_t i = 0; i < trace.size(); ++i)
-            frame_pointers[i] = trace[i];
-        SentryWriter::onFault(-code, msg, frame_pointers, /* offset= */ 0, trace.size());
+        if (auto * sentry = SentryWriter::getInstance())
+        {
+            SentryWriter::FramePointers frame_pointers;
+            for (size_t i = 0; i < trace.size(); ++i)
+                frame_pointers[i] = trace[i];
+            sentry->onFault(-code, msg, frame_pointers, /* offset= */ 0, trace.size());
+        }
 #endif
     }
 

--- a/src/Common/Exception.cpp
+++ b/src/Common/Exception.cpp
@@ -5,7 +5,6 @@
 #include <IO/WriteHelpers.h>
 #include <base/demangle.h>
 #include <Common/AtomicLogger.h>
-#include <Daemon/SentryWriter.h>
 #include <Common/ErrorCodes.h>
 #include <Common/Exception.h>
 #include <Common/LockMemoryExceptionInThread.h>
@@ -48,28 +47,23 @@ void abortOnFailedAssertion(const String & description)
 bool terminate_on_any_exception = false;
 static int terminate_status_code = 128 + SIGABRT;
 thread_local bool update_error_statistics = true;
+std::function<void(const std::string & msg, int code, bool remote, const Exception::FramePointers & trace)> Exception::callback = {};
 
 /// - Aborts the process if error code is LOGICAL_ERROR.
 /// - Increments error codes statistics.
-void handle_error_code([[maybe_unused]] const std::string & msg, int code, bool remote, const Exception::FramePointers & trace)
+void handle_error_code(const std::string & msg, int code, bool remote, const Exception::FramePointers & trace)
 {
+    // In debug builds and builds with sanitizers, treat LOGICAL_ERROR as an assertion failure.
+    // Log the message before we fail.
+#ifdef ABORT_ON_LOGICAL_ERROR
     if (code == ErrorCodes::LOGICAL_ERROR)
     {
-        // In debug builds and builds with sanitizers, treat LOGICAL_ERROR as an assertion failure.
-        // Log the message before we fail.
-#ifdef ABORT_ON_LOGICAL_ERROR
         abortOnFailedAssertion(msg);
-#else
-        /// In release builds send it to sentry (if it is configured)
-        if (auto * sentry = SentryWriter::getInstance())
-        {
-            SentryWriter::FramePointers frame_pointers;
-            for (size_t i = 0; i < trace.size(); ++i)
-                frame_pointers[i] = trace[i];
-            sentry->onFault(-code, msg, frame_pointers, /* offset= */ 0, trace.size());
-        }
-#endif
     }
+#endif
+
+    if (Exception::callback)
+        Exception::callback(msg, code, remote, trace);
 
     if (!update_error_statistics) [[unlikely]]
         return;

--- a/src/Common/Exception.h
+++ b/src/Common/Exception.h
@@ -72,6 +72,8 @@ public:
     /// Collect call stacks of all previous jobs' schedulings leading to this thread job's execution
     static thread_local bool enable_job_stack_trace;
     static thread_local std::vector<StackTrace::FramePointers> thread_frame_pointers;
+    /// Callback for any exception
+    static std::function<void(const std::string & msg, int code, bool remote, const Exception::FramePointers & trace)> callback;
 
 protected:
     // used to remove the sensitive information from exceptions if query_masking_rules is configured

--- a/src/Daemon/BaseDaemon.cpp
+++ b/src/Daemon/BaseDaemon.cpp
@@ -497,7 +497,7 @@ private:
         /// Send crash report to developers (if configured)
         if (sig != SanitizerTrap)
         {
-            SentryWriter::onFault(sig, error_message, stack_trace);
+            SentryWriter::onFault(sig, error_message, stack_trace.getFramePointers(), stack_trace.getOffset(), stack_trace.getSize());
 
             /// Advice the user to send it manually.
             if (std::string_view(VERSION_OFFICIAL).contains("official build"))

--- a/src/Daemon/BaseDaemon.cpp
+++ b/src/Daemon/BaseDaemon.cpp
@@ -497,7 +497,8 @@ private:
         /// Send crash report to developers (if configured)
         if (sig != SanitizerTrap)
         {
-            SentryWriter::onFault(sig, error_message, stack_trace.getFramePointers(), stack_trace.getOffset(), stack_trace.getSize());
+            if (auto * sentry = SentryWriter::getInstance())
+                sentry->onFault(sig, error_message, stack_trace.getFramePointers(), stack_trace.getOffset(), stack_trace.getSize());
 
             /// Advice the user to send it manually.
             if (std::string_view(VERSION_OFFICIAL).contains("official build"))
@@ -1014,7 +1015,7 @@ extern const char * GIT_HASH;
 
 void BaseDaemon::initializeTerminationAndSignalProcessing()
 {
-    SentryWriter::initialize(config());
+    SentryWriter::initializeInstance(config());
     std::set_terminate(terminate_handler);
 
     /// We want to avoid SIGPIPE when working with sockets and pipes, and just handle return value/errno instead.

--- a/src/Daemon/BaseDaemon.cpp
+++ b/src/Daemon/BaseDaemon.cpp
@@ -499,7 +499,7 @@ private:
         if (sig != SanitizerTrap)
         {
             if (auto * sentry = SentryWriter::getInstance())
-                sentry->onFault(sig, error_message, stack_trace.getFramePointers(), stack_trace.getOffset(), stack_trace.getSize());
+                sentry->onSignal(sig, error_message, stack_trace.getFramePointers(), stack_trace.getOffset(), stack_trace.getSize());
 
             /// Advice the user to send it manually.
             if (std::string_view(VERSION_OFFICIAL).contains("official build"))
@@ -1030,7 +1030,7 @@ void BaseDaemon::initializeTerminationAndSignalProcessing()
                     SentryWriter::FramePointers frame_pointers;
                     for (size_t i = 0; i < trace.size(); ++i)
                         frame_pointers[i] = trace[i];
-                    sentry->onFault(-code, msg, frame_pointers, /* offset= */ 0, trace.size());
+                    sentry->onException(code, msg, frame_pointers, /* offset= */ 0, trace.size());
                 }
             };
         }

--- a/src/Daemon/SentryWriter.h
+++ b/src/Daemon/SentryWriter.h
@@ -25,10 +25,15 @@ public:
     /// @return nullptr if initializeInstance() was not called (i.e. for non-server) or SentryWriter object
     static SentryWriter * getInstance();
 
-    /// Not signal safe and can't be called from a signal handler
-    /// @param sig_or_error - signal if >= 0, otherwise exception code
-    void onFault(
-        int sig_or_error,
+    void onSignal(
+        int sig,
+        const std::string & error_message,
+        const FramePointers & frame_pointers,
+        size_t offset,
+        size_t size);
+
+    void onException(
+        int code,
         const std::string & error_message,
         const FramePointers & frame_pointers,
         size_t offset,
@@ -43,4 +48,20 @@ private:
     std::string server_data_path;
 
     explicit SentryWriter(Poco::Util::LayeredConfiguration & config);
+
+    enum Type
+    {
+        SIGNAL,
+        EXCEPTION,
+    };
+
+    /// Not signal safe and can't be called from a signal handler
+    /// @param sig_or_error - signal if >= 0, otherwise exception code
+    void sendError(
+        Type type,
+        int sig_or_error,
+        const std::string & error_message,
+        const FramePointers & frame_pointers,
+        size_t offset,
+        size_t size);
 };

--- a/src/Daemon/SentryWriter.h
+++ b/src/Daemon/SentryWriter.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <Common/StackTrace.h>
 
 
 namespace Poco { namespace Util { class LayeredConfiguration; }}
@@ -19,9 +20,14 @@ namespace SentryWriter
     void initialize(Poco::Util::LayeredConfiguration & config);
     void shutdown();
 
+    using FramePointers = StackTrace::FramePointers;
+
     /// Not signal safe and can't be called from a signal handler
+    /// @param sig_or_error - signal if >= 0, otherwise exception code
     void onFault(
-        int sig,
+        int sig_or_error,
         const std::string & error_message,
-        const StackTrace & stack_trace);
+        const FramePointers & frame_pointers,
+        size_t offset,
+        size_t size);
 }

--- a/src/Daemon/SentryWriter.h
+++ b/src/Daemon/SentryWriter.h
@@ -7,7 +7,8 @@
 namespace Poco { namespace Util { class LayeredConfiguration; }}
 
 
-/// \brief Sends crash reports to ClickHouse core developer team via https://sentry.io
+/// \brief Sends crash reports and LOGICAL_ERRORs (if "send_logical_errors" is
+/// enabled) to ClickHouse core developer team via https://sentry.io
 ///
 /// This feature can enabled with "send_crash_reports.enabled" server setting,
 /// in this case reports are sent only for official ClickHouse builds.


### PR DESCRIPTION
**Thoughts on this one?**

This is like an assert() in the code, so it is useful to know about them
as well.

This is not enabled by default, to turn it ON, set `send_crash_reports.send_logical_errors=true` in config

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)