### PR TITLE
Fix CREATE TABLE w/o columns definition for ReplicatedMergeTree

### DIFF
--- a/src/Storages/MergeTree/registerStorageMergeTree.cpp
+++ b/src/Storages/MergeTree/registerStorageMergeTree.cpp
@@ -588,7 +588,7 @@ static StoragePtr create(const StorageFactory::Arguments & args)
         FunctionNameNormalizer().visit(partition_key.get());
         auto primary_key_asts = metadata.primary_key.expression_list_ast->children;
         metadata.minmax_count_projection.emplace(ProjectionDescription::getMinMaxCountProjection(
-            args.columns, partition_key, minmax_columns, primary_key_asts, context));
+            columns, partition_key, minmax_columns, primary_key_asts, context));
 
         if (args.storage_def->sample_by)
             metadata.sampling_key = KeyDescription::getKeyFromAST(args.storage_def->sample_by->ptr(), metadata.columns, context);
@@ -697,7 +697,7 @@ static StoragePtr create(const StorageFactory::Arguments & args)
         FunctionNameNormalizer().visit(partition_key.get());
         auto primary_key_asts = metadata.primary_key.expression_list_ast->children;
         metadata.minmax_count_projection.emplace(ProjectionDescription::getMinMaxCountProjection(
-            args.columns, partition_key, minmax_columns, primary_key_asts, context));
+            columns, partition_key, minmax_columns, primary_key_asts, context));
 
         const auto * ast = engine_args[arg_num]->as<ASTLiteral>();
         if (ast && ast->value.getType() == Field::Types::UInt64)

--- a/tests/queries/0_stateless/03032_rmt_create_columns_from_replica.reference
+++ b/tests/queries/0_stateless/03032_rmt_create_columns_from_replica.reference
@@ -1,0 +1,7 @@
+CREATE TABLE default.data_r2
+(
+    `key` Int32
+)
+ENGINE = ReplicatedMergeTree('/tables/default', 'r2')
+ORDER BY tuple()
+SETTINGS index_granularity = 8192

--- a/tests/queries/0_stateless/03032_rmt_create_columns_from_replica.sql
+++ b/tests/queries/0_stateless/03032_rmt_create_columns_from_replica.sql
@@ -1,0 +1,5 @@
+drop table if exists data_r1;
+drop table if exists data_r2;
+create table data_r1 (key Int) engine=ReplicatedMergeTree('/tables/{database}', 'r1') order by tuple();
+create table data_r2 engine=ReplicatedMergeTree('/tables/{database}', 'r2') order by tuple();
+show create data_r2 format LineAsString;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix CREATE TABLE w/o columns definition for ReplicatedMergeTree (columns will be obtained from replica)