### PR TITLE
Fix clickhouse-test in case of missing .reference file

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -1641,8 +1641,8 @@ class TestCase:
 
             client_options = self.add_random_settings(client_options)
 
-            if not is_valid_utf_8(self.case_file) or not is_valid_utf_8(
-                self.reference_file
+            if not is_valid_utf_8(self.case_file) or (
+                self.reference_file and not is_valid_utf_8(self.reference_file)
             ):
                 proc, stdout, stderr, debug_log, total_time = self.run_single_test(
                     server_logs_level, client_options


### PR DESCRIPTION
Before it throws internal python error:

    $ ../tests/clickhouse-test 03033
    Using queries from '/src/ch/clickhouse/tests/queries' directory
    Connecting to ClickHouse server... OK
    Connected to server 24.3.1.1 @ 3fa6d23730d8e7a7c72b194ee4e04972b9941d68 master

    Running 1 stateless tests (MainProcess).

    03033_dist:                                                             [ UNKNOWN ] - Test internal error:
    TypeError
    expected str, bytes or os.PathLike object, not NoneType
      File "/src/ch/clickhouse/.cmake/../tests/clickhouse-test", line 1644, in run
        if not is_valid_utf_8(self.case_file) or not is_valid_utf_8(
                                                     ^^^^^^^^^^^^^^^

      File "/src/ch/clickhouse/.cmake/../tests/clickhouse-test", line 237, in is_valid_utf_8
        with open(fname, "rb") as f:
             ^^^^^^^^^^^^^^^^^

    0 tests passed. 0 tests skipped. 0.01 s elapsed (MainProcess).
    Won't run stateful tests because test data wasn't loaded.
    All tests have finished.

Now:

    $ ../tests/clickhouse-test 03033
    Using queries from '/src/ch/clickhouse/tests/queries' directory
    Connecting to ClickHouse server... OK
    Connected to server 24.3.1.1 @ 3fa6d23730d8e7a7c72b194ee4e04972b9941d68 master

    Running 1 stateless tests (MainProcess).

    03033_dist:                                                             [ UNKNOWN ] - no reference file

    0 tests passed. 0 tests skipped. 0.11 s elapsed (MainProcess).
    Won't run stateful tests because test data wasn't loaded.
    All tests have finished.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)