### PR TITLE
Fix optimize_skip_unused_shards_rewrite_in for composite sharding key

### DIFF
--- a/src/Interpreters/ClusterProxy/executeQuery.cpp
+++ b/src/Interpreters/ClusterProxy/executeQuery.cpp
@@ -245,7 +245,12 @@ void executeQuery(
             const auto & shard_info = cluster->getShardsInfo()[i];
 
             auto query_for_shard = query_info.query_tree->clone();
-            if (sharding_key_expr && query_info.optimized_cluster && settings.optimize_skip_unused_shards_rewrite_in && shards > 1)
+            if (sharding_key_expr &&
+                query_info.optimized_cluster &&
+                settings.optimize_skip_unused_shards_rewrite_in &&
+                shards > 1 &&
+                /// TODO: support composite sharding key
+                sharding_key_expr->getRequiredColumns().size() == 1)
             {
                 OptimizeShardingKeyRewriteInVisitor::Data visitor_data{
                     sharding_key_expr,
@@ -281,7 +286,12 @@ void executeQuery(
             const auto & shard_info = cluster->getShardsInfo()[i];
 
             ASTPtr query_ast_for_shard = query_info.query->clone();
-            if (sharding_key_expr && query_info.optimized_cluster && settings.optimize_skip_unused_shards_rewrite_in && shards > 1)
+            if (sharding_key_expr &&
+                query_info.optimized_cluster &&
+                settings.optimize_skip_unused_shards_rewrite_in &&
+                shards > 1 &&
+                /// TODO: support composite sharding key
+                sharding_key_expr->getRequiredColumns().size() == 1)
             {
                 OptimizeShardingKeyRewriteInVisitor::Data visitor_data{
                     sharding_key_expr,

--- a/src/Interpreters/ClusterProxy/executeQuery.cpp
+++ b/src/Interpreters/ClusterProxy/executeQuery.cpp
@@ -249,7 +249,6 @@ void executeQuery(
             {
                 OptimizeShardingKeyRewriteInVisitor::Data visitor_data{
                     sharding_key_expr,
-                    sharding_key_expr->getSampleBlock().getByPosition(0).type,
                     sharding_key_column_name,
                     shard_info,
                     not_optimized_cluster->getSlotToShard(),
@@ -286,7 +285,6 @@ void executeQuery(
             {
                 OptimizeShardingKeyRewriteInVisitor::Data visitor_data{
                     sharding_key_expr,
-                    sharding_key_expr->getSampleBlock().getByPosition(0).type,
                     sharding_key_column_name,
                     shard_info,
                     not_optimized_cluster->getSlotToShard(),

--- a/src/Interpreters/OptimizeShardingKeyRewriteInVisitor.h
+++ b/src/Interpreters/OptimizeShardingKeyRewriteInVisitor.h
@@ -28,8 +28,6 @@ struct OptimizeShardingKeyRewriteInMatcher
     {
         /// Expression of sharding_key for the Distributed() table
         const ExpressionActionsPtr & sharding_key_expr;
-        /// Type of sharding_key column.
-        const DataTypePtr & sharding_key_type;
         /// Name of the column for sharding_expr
         const std::string & sharding_key_column_name;
         /// Info for the current shard (to compare shard_num with calculated)

--- a/tests/queries/0_stateless/03033_dist_settings.optimize_skip_unused_shards_rewrite_in_composite_sharding_key.reference
+++ b/tests/queries/0_stateless/03033_dist_settings.optimize_skip_unused_shards_rewrite_in_composite_sharding_key.reference
@@ -1,0 +1,10 @@
+-- { echoOn }
+SELECT shardNum(), count() FROM dt WHERE (tag_id, tag_name) IN ((1, 'foo1'), (1, 'foo2')) GROUP BY 1 ORDER BY 1;
+1	2
+2	2
+SELECT shardNum(), count() FROM dt WHERE tag_id IN (1, 1) AND tag_name IN ('foo1', 'foo2') GROUP BY 1 ORDER BY 1;
+1	2
+2	2
+SELECT shardNum(), count() FROM dt WHERE tag_id = 1 AND tag_name IN ('foo1', 'foo2') GROUP BY 1 ORDER BY 1;
+1	2
+2	2

--- a/tests/queries/0_stateless/03033_dist_settings.optimize_skip_unused_shards_rewrite_in_composite_sharding_key.sql
+++ b/tests/queries/0_stateless/03033_dist_settings.optimize_skip_unused_shards_rewrite_in_composite_sharding_key.sql
@@ -1,0 +1,14 @@
+DROP TABLE IF EXISTS t;
+DROP TABLE IF EXISTS dt;
+
+CREATE TABLE t (tag_id UInt64, tag_name String) ENGINE = MergeTree ORDER BY tuple();
+CREATE TABLE dt AS t ENGINE = Distributed('test_cluster_two_shards_localhost', currentDatabase(), 't', cityHash64(concat(tag_id, tag_name)));
+
+INSERT INTO dt SETTINGS distributed_foreground_insert=1 VALUES (1, 'foo1'); -- shard0
+INSERT INTO dt SETTINGS distributed_foreground_insert=1 VALUES (1, 'foo2'); -- shard1
+
+SET optimize_skip_unused_shards=1, optimize_skip_unused_shards_rewrite_in=1;
+-- { echoOn }
+SELECT shardNum(), count() FROM dt WHERE (tag_id, tag_name) IN ((1, 'foo1'), (1, 'foo2')) GROUP BY 1 ORDER BY 1;
+SELECT shardNum(), count() FROM dt WHERE tag_id IN (1, 1) AND tag_name IN ('foo1', 'foo2') GROUP BY 1 ORDER BY 1;
+SELECT shardNum(), count() FROM dt WHERE tag_id = 1 AND tag_name IN ('foo1', 'foo2') GROUP BY 1 ORDER BY 1;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix optimize_skip_unused_shards_rewrite_in for composite sharding key (could lead to `NOT_FOUND_COLUMN_IN_BLOCK` and `TYPE_MISMATCH`)

There were two problems:
- first the type of the sharding key column may be incorrect (first patch)
- the second is that composite keys simply does not work and throws `Not found column X in block`, for now I simply disabled this optimization for this case and left a todo

Fixes: https://github.com/ClickHouse/ClickHouse/issues/57081 (cc @nickitat @FrankChen021 )