### PR TITLE
Resubmit 'Update invalidate_query_response on dictionary startup'

### DIFF
--- a/src/Interpreters/ExternalLoader.cpp
+++ b/src/Interpreters/ExternalLoader.cpp
@@ -996,6 +996,14 @@ private:
             if (!new_object && !new_exception)
                 throw Exception(ErrorCodes::LOGICAL_ERROR, "No object created and no exception raised for {}", type_name);
 
+            if (!info->object && new_object)
+            {
+                /// If we loaded the object for the first time then we should set `invalidate_query_response` to the current value.
+                /// Otherwise we will immediately try to reload the object again despite the fact that it was just loaded.
+                bool is_modified = new_object->isModified();
+                LOG_TRACE(log, "Object '{}' was{} modified", name, (is_modified ? "" : " not"));
+            }
+
             /// Saving the result of the loading.
             {
                 LoadingGuardForAsyncLoad lock(async, mutex);


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):

- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
* Dictionary source with `INVALIDATE_QUERY` is not reloaded twice on startup

Resubmit https://github.com/ClickHouse/ClickHouse/pull/55977#issuecomment-2025534936