### PR TITLE
Fix stress tests for analyzer due to experimental WINDOW VIEW (by disabling it)

### DIFF
--- a/docker/test/stress/run.sh
+++ b/docker/test/stress/run.sh
@@ -87,6 +87,25 @@ if [ "$cache_policy" = "SLRU" ]; then
     mv /etc/clickhouse-server/config.d/storage_conf.xml.tmp /etc/clickhouse-server/config.d/storage_conf.xml
 fi
 
+# Disable experimental WINDOW VIEW tests for stress tests, since they may be
+# created with old analyzer and then, after server restart it will refuse to
+# start.
+# FIXME: remove once the support for WINDOW VIEW will be implemented in analyzer.
+sudo cat /etc/clickhouse-server/users.d/stress_tests_overrides.xml <<EOL
+<clickhouse>
+    <profiles>
+        <default>
+            <allow_experimental_window_view>false</allow_experimental_window_view>
+            <constraints>
+               <allow_experimental_window_view>
+                   <readonly/>
+               </allow_experimental_window_view>
+            </constraints>
+        </default>
+    </profiles>
+</clickhouse>
+EOL
+
 start_server
 
 clickhouse-client --query "SHOW TABLES FROM datasets"


### PR DESCRIPTION
CI found [1]:

    2024.03.28 13:16:00.797344 [ 99740 ] {} <Error> Application: Caught exception while loading metadata: Code: 695. DB::Exception: Load job 'load table 01069_window_view_proc_tumble_watch.wv' failed: Code: 1. DB::Exception: Experimental WINDOW VIEW feature is not supported with new infrastructure for query analysis (the setting 'allow_experimental_analyzer'): Cannot attach table `01069_window_view_proc_tumble_watch`.`wv` from metadata file /var/lib/clickhouse/store/dd8/dd82a4f5-5485-4747-9172-8976d1194c54/wv.sql from query ATTACH WINDOW VIEW `01069_window_view_proc_tumble_watch`.wv UUID '35cc7d27-df3b-4569-9cb9-2ccf6cb1ff4c' (`count` UInt64) ENGINE = Memory AS SELECT count(a) AS count FROM `01069_window_view_proc_tumble_watch`.mt GROUP BY tumble(timestamp, toIntervalSecond('1'), 'US/Samoa') AS wid. (UNSUPPORTED_METHOD), Stack trace (when copying this message, always include the lines below):

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/61997/ced095394b6fb6d50ed8b6834bd5911ad4702c6e/stateless_tests__tsan__s3_storage__[5_5].html

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)