### PR TITLE
Enable `optimize_throw_if_noop` in tests by default

### DIFF
--- a/tests/config/users.d/optimize_throw_if_noop.xml
+++ b/tests/config/users.d/optimize_throw_if_noop.xml
@@ -1,0 +1,7 @@
+<clickhouse>
+    <profiles>
+        <default>
+            <optimize_throw_if_noop>1</optimize_throw_if_noop>
+        </default>
+    </profiles>
+</clickhouse>


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

---

It won’t throw on `NOTHING_TO_MERGE`, so exceptions should only happen in cases when we anyway relied on `final` to produce a single part, but it wouldn’t do it.