### PR TITLE
Avoid crashing on column type mismatch in a few dozen places

### DIFF
--- a/src/Columns/ColumnArray.cpp
+++ b/src/Columns/ColumnArray.cpp
@@ -1283,7 +1283,7 @@ ColumnPtr ColumnArray::replicateTuple(const Offsets & replicate_offsets) const
 
 size_t ColumnArray::getNumberOfDimensions() const
 {
-    const auto * nested_array = checkAndGetColumn<ColumnArray>(*data);
+    const auto * nested_array = checkAndGetColumn<ColumnArray>(&*data);
     if (!nested_array)
         return 1;
     return 1 + nested_array->getNumberOfDimensions();   /// Every modern C++ compiler optimizes tail recursion.

--- a/src/Columns/ColumnLowCardinality.cpp
+++ b/src/Columns/ColumnLowCardinality.cpp
@@ -903,7 +903,7 @@ ColumnPtr ColumnLowCardinality::cloneWithDefaultOnNull() const
 
 bool isColumnLowCardinalityNullable(const IColumn & column)
 {
-    if (const auto * lc_column = checkAndGetColumn<ColumnLowCardinality>(column))
+    if (const auto * lc_column = checkAndGetColumn<ColumnLowCardinality>(&column))
         return lc_column->nestedIsNullable();
     return false;
 }

--- a/src/Columns/ColumnUnique.h
+++ b/src/Columns/ColumnUnique.h
@@ -376,7 +376,7 @@ size_t ColumnUnique<ColumnType>::uniqueInsertFrom(const IColumn & src, size_t n)
     if (is_nullable && src.isNullAt(n))
         return getNullValueIndex();
 
-    if (const auto * nullable = checkAndGetColumn<ColumnNullable>(src))
+    if (const auto * nullable = checkAndGetColumn<ColumnNullable>(&src))
         return uniqueInsertFrom(nullable->getNestedColumn(), n);
 
     auto ref = src.getDataAt(n);
@@ -569,7 +569,7 @@ MutableColumnPtr ColumnUnique<ColumnType>::uniqueInsertRangeImpl(
         return nullptr;
     };
 
-    if (const auto * nullable_column = checkAndGetColumn<ColumnNullable>(src))
+    if (const auto * nullable_column = checkAndGetColumn<ColumnNullable>(&src))
     {
         src_column = typeid_cast<const ColumnType *>(&nullable_column->getNestedColumn());
         null_map = &nullable_column->getNullMapData();

--- a/src/Columns/FilterDescription.cpp
+++ b/src/Columns/FilterDescription.cpp
@@ -32,7 +32,7 @@ ConstantFilterDescription::ConstantFilterDescription(const IColumn & column)
 
         if (!typeid_cast<const ColumnUInt8 *>(column_nested.get()))
         {
-            const ColumnNullable * column_nested_nullable = checkAndGetColumn<ColumnNullable>(*column_nested);
+            const ColumnNullable * column_nested_nullable = checkAndGetColumn<ColumnNullable>(&*column_nested);
             if (!column_nested_nullable || !typeid_cast<const ColumnUInt8 *>(&column_nested_nullable->getNestedColumn()))
             {
                 throw Exception(ErrorCodes::ILLEGAL_TYPE_OF_COLUMN_FOR_FILTER,
@@ -66,7 +66,7 @@ FilterDescription::FilterDescription(const IColumn & column_)
         return;
     }
 
-    if (const auto * nullable_column = checkAndGetColumn<ColumnNullable>(column))
+    if (const auto * nullable_column = checkAndGetColumn<ColumnNullable>(&column))
     {
         ColumnPtr nested_column = nullable_column->getNestedColumnPtr();
         MutableColumnPtr mutable_holder = IColumn::mutate(std::move(nested_column));

--- a/src/Columns/IColumn.h
+++ b/src/Columns/IColumn.h
@@ -640,12 +640,16 @@ template <>
 struct IsMutableColumns<> { static const bool value = true; };
 
 
+/// Throws LOGICAL_ERROR if the type doesn't match.
 template <typename Type>
-const Type * checkAndGetColumn(const IColumn & column)
+const Type & checkAndGetColumn(const IColumn & column)
 {
-    return typeid_cast<const Type *>(&column);
+    return typeid_cast<const Type &>(column);
 }
 
+/// Returns nullptr if the type doesn't match.
+/// If you're going to dereference the returned pointer without checking for null, use the
+/// `const IColumn &` overload above instead.
 template <typename Type>
 const Type * checkAndGetColumn(const IColumn * column)
 {

--- a/src/Columns/MaskOperations.cpp
+++ b/src/Columns/MaskOperations.cpp
@@ -205,10 +205,10 @@ static MaskInfo extractMaskImpl(
     auto column = col->convertToFullColumnIfLowCardinality();
 
     /// Special implementation for Null and Const columns.
-    if (column->onlyNull() || checkAndGetColumn<ColumnConst>(*column))
+    if (column->onlyNull() || checkAndGetColumn<ColumnConst>(&*column))
         return extractMaskFromConstOrNull<inverted>(mask, column, null_value, nulls);
 
-    if (const auto * nullable_column = checkAndGetColumn<ColumnNullable>(*column))
+    if (const auto * nullable_column = checkAndGetColumn<ColumnNullable>(&*column))
     {
         const PaddedPODArray<UInt8> & null_map = nullable_column->getNullMapData();
         return extractMaskImpl<inverted>(mask, nullable_column->getNestedColumnPtr(), null_value, &null_map, nulls);

--- a/src/Common/ColumnsHashing.h
+++ b/src/Common/ColumnsHashing.h
@@ -44,8 +44,8 @@ struct HashMethodOneNumber
     {
         if constexpr (nullable)
         {
-            const auto * null_column = checkAndGetColumn<ColumnNullable>(key_columns[0]);
-            vec = null_column->getNestedColumnPtr()->getRawData().data();
+            const auto & null_column = checkAndGetColumn<ColumnNullable>(*key_columns[0]);
+            vec = null_column.getNestedColumnPtr()->getRawData().data();
         }
         else
         {
@@ -57,8 +57,8 @@ struct HashMethodOneNumber
     {
         if constexpr (nullable)
         {
-            const auto * null_column = checkAndGetColumn<ColumnNullable>(column);
-            vec = null_column->getNestedColumnPtr()->getRawData().data();
+            const auto & null_column = checkAndGetColumn<ColumnNullable>(*column);
+            vec = null_column.getNestedColumnPtr()->getRawData().data();
         }
         else
         {
@@ -105,7 +105,7 @@ struct HashMethodString
         const IColumn * column;
         if constexpr (nullable)
         {
-            column = checkAndGetColumn<ColumnNullable>(key_columns[0])->getNestedColumnPtr().get();
+            column = checkAndGetColumn<ColumnNullable>(*key_columns[0]).getNestedColumnPtr().get();
         }
         else
         {
@@ -153,7 +153,7 @@ struct HashMethodFixedString
         const IColumn * column;
         if constexpr (nullable)
         {
-            column = checkAndGetColumn<ColumnNullable>(key_columns[0])->getNestedColumnPtr().get();
+            column = checkAndGetColumn<ColumnNullable>(*key_columns[0]).getNestedColumnPtr().get();
         }
         else
         {

--- a/src/Common/ColumnsHashingImpl.h
+++ b/src/Common/ColumnsHashingImpl.h
@@ -305,7 +305,7 @@ protected:
         }
 
         if constexpr (nullable)
-            null_map = &checkAndGetColumn<ColumnNullable>(column)->getNullMapColumn();
+            null_map = &checkAndGetColumn<ColumnNullable>(*column).getNullMapColumn();
     }
 
     template <typename Data, typename KeyHolder>

--- a/src/Core/DecimalComparison.h
+++ b/src/Core/DecimalComparison.h
@@ -170,11 +170,11 @@ private:
 
             if (c0_is_const && c1_is_const)
             {
-                const ColumnConst * c0_const = checkAndGetColumnConst<ColVecA>(c0.get());
-                const ColumnConst * c1_const = checkAndGetColumnConst<ColVecB>(c1.get());
+                const ColumnConst & c0_const = checkAndGetColumnConst<ColVecA>(*c0);
+                const ColumnConst & c1_const = checkAndGetColumnConst<ColVecB>(*c1);
 
-                A a = c0_const->template getValue<A>();
-                B b = c1_const->template getValue<B>();
+                A a = c0_const.template getValue<A>();
+                B b = c1_const.template getValue<B>();
                 UInt8 res = apply<scale_left, scale_right>(a, b, scale);
                 return DataTypeUInt8().createColumnConst(c0->size(), toField(res));
             }
@@ -184,8 +184,8 @@ private:
 
             if (c0_is_const)
             {
-                const ColumnConst * c0_const = checkAndGetColumnConst<ColVecA>(c0.get());
-                A a = c0_const->template getValue<A>();
+                const ColumnConst & c0_const = checkAndGetColumnConst<ColVecA>(*c0);
+                A a = c0_const.template getValue<A>();
                 if (const ColVecB * c1_vec = checkAndGetColumn<ColVecB>(c1.get()))
                     constantVector<scale_left, scale_right>(a, c1_vec->getData(), vec_res, scale);
                 else
@@ -193,8 +193,8 @@ private:
             }
             else if (c1_is_const)
             {
-                const ColumnConst * c1_const = checkAndGetColumnConst<ColVecB>(c1.get());
-                B b = c1_const->template getValue<B>();
+                const ColumnConst & c1_const = checkAndGetColumnConst<ColVecB>(*c1);
+                B b = c1_const.template getValue<B>();
                 if (const ColVecA * c0_vec = checkAndGetColumn<ColVecA>(c0.get()))
                     vectorConstant<scale_left, scale_right>(c0_vec->getData(), b, vec_res, scale);
                 else

--- a/src/DataTypes/ObjectUtils.cpp
+++ b/src/DataTypes/ObjectUtils.cpp
@@ -47,7 +47,7 @@ size_t getNumberOfDimensions(const IDataType & type)
 
 size_t getNumberOfDimensions(const IColumn & column)
 {
-    if (const auto * column_array = checkAndGetColumn<ColumnArray>(column))
+    if (const auto * column_array = checkAndGetColumn<ColumnArray>(&column))
         return column_array->getNumberOfDimensions();
     return 0;
 }

--- a/src/DataTypes/Serializations/SerializationBool.cpp
+++ b/src/DataTypes/Serializations/SerializationBool.cpp
@@ -28,7 +28,7 @@ constexpr char str_false[6] = "false";
 const ColumnUInt8 * checkAndGetSerializeColumnType(const IColumn & column)
 {
     const auto * col = checkAndGetColumn<ColumnUInt8>(&column);
-    if (!checkAndGetColumn<ColumnUInt8>(&column))
+    if (!col)
         throw Exception(ErrorCodes::ILLEGAL_COLUMN, "Bool type can only serialize columns of type UInt8.{}", column.getName());
     return col;
 }
@@ -36,7 +36,7 @@ const ColumnUInt8 * checkAndGetSerializeColumnType(const IColumn & column)
 ColumnUInt8 * checkAndGetDeserializeColumnType(IColumn & column)
 {
     auto * col =  typeid_cast<ColumnUInt8 *>(&column);
-    if (!checkAndGetColumn<ColumnUInt8>(&column))
+    if (!col)
         throw Exception(ErrorCodes::ILLEGAL_COLUMN, "Bool type can only deserialize columns of type UInt8.{}",
                         column.getName());
     return col;

--- a/src/DataTypes/Serializations/SerializationInterval.cpp
+++ b/src/DataTypes/Serializations/SerializationInterval.cpp
@@ -17,7 +17,7 @@ namespace ErrorCodes
 void SerializationKustoInterval::serializeText(
     const IColumn & column, const size_t row, WriteBuffer & ostr, const FormatSettings &) const
 {
-    const auto * interval_column = checkAndGetColumn<ColumnInterval>(column);
+    const auto * interval_column = checkAndGetColumn<ColumnInterval>(&column);
     if (!interval_column)
         throw Exception(ErrorCodes::ILLEGAL_COLUMN, "Expected column of underlying type of Interval");
 

--- a/src/DataTypes/Serializations/SerializationLowCardinality.cpp
+++ b/src/DataTypes/Serializations/SerializationLowCardinality.cpp
@@ -477,7 +477,7 @@ void SerializationLowCardinality::serializeBinaryBulkWithMultipleStreams(
                             settings.low_cardinality_max_dictionary_size);
     }
 
-    if (const auto * nullable_keys = checkAndGetColumn<ColumnNullable>(*keys))
+    if (const auto * nullable_keys = checkAndGetColumn<ColumnNullable>(&*keys))
         keys = nullable_keys->getNestedColumnPtr();
 
     bool need_additional_keys = !keys->empty();

--- a/src/Dictionaries/HierarchyDictionariesUtils.cpp
+++ b/src/Dictionaries/HierarchyDictionariesUtils.cpp
@@ -95,7 +95,7 @@ namespace
                 parent_key_column_non_null = parent_key_column_typed->getNestedColumnPtr();
             }
 
-            const auto * parent_key_column_typed = checkAndGetColumn<ColumnVector<UInt64>>(*parent_key_column_non_null);
+            const auto * parent_key_column_typed = checkAndGetColumn<ColumnVector<UInt64>>(&*parent_key_column_non_null);
             if (!parent_key_column_typed)
                 throw Exception(ErrorCodes::UNSUPPORTED_METHOD,
                     "Parent key column should be UInt64. Actual {}",
@@ -166,7 +166,7 @@ ColumnPtr getKeysHierarchyDefaultImplementation(
     valid_keys = 0;
 
     key_column = key_column->convertToFullColumnIfConst();
-    const auto * key_column_typed = checkAndGetColumn<ColumnVector<UInt64>>(*key_column);
+    const auto * key_column_typed = checkAndGetColumn<ColumnVector<UInt64>>(&*key_column);
     if (!key_column_typed)
         throw Exception(ErrorCodes::UNSUPPORTED_METHOD, "Key column should be UInt64");
 
@@ -224,11 +224,11 @@ ColumnUInt8::Ptr getKeysIsInHierarchyDefaultImplementation(
     key_column = key_column->convertToFullColumnIfConst();
     in_key_column = in_key_column->convertToFullColumnIfConst();
 
-    const auto * key_column_typed = checkAndGetColumn<ColumnVector<UInt64>>(*key_column);
+    const auto * key_column_typed = checkAndGetColumn<ColumnVector<UInt64>>(&*key_column);
     if (!key_column_typed)
         throw Exception(ErrorCodes::UNSUPPORTED_METHOD, "Key column should be UInt64");
 
-    const auto * in_key_column_typed = checkAndGetColumn<ColumnVector<UInt64>>(*in_key_column);
+    const auto * in_key_column_typed = checkAndGetColumn<ColumnVector<UInt64>>(&*in_key_column);
     if (!in_key_column_typed)
         throw Exception(ErrorCodes::UNSUPPORTED_METHOD, "Key column should be UInt64");
 

--- a/src/Formats/insertNullAsDefaultIfNeeded.cpp
+++ b/src/Formats/insertNullAsDefaultIfNeeded.cpp
@@ -19,45 +19,45 @@ bool insertNullAsDefaultIfNeeded(ColumnWithTypeAndName & input_column, const Col
     if (isArray(input_column.type) && isArray(header_column.type))
     {
         ColumnWithTypeAndName nested_input_column;
-        const auto * array_input_column = checkAndGetColumn<ColumnArray>(input_column.column.get());
-        nested_input_column.column = array_input_column->getDataPtr();
+        const auto & array_input_column = checkAndGetColumn<ColumnArray>(*input_column.column);
+        nested_input_column.column = array_input_column.getDataPtr();
         nested_input_column.type = checkAndGetDataType<DataTypeArray>(input_column.type.get())->getNestedType();
 
         ColumnWithTypeAndName nested_header_column;
-        nested_header_column.column = checkAndGetColumn<ColumnArray>(header_column.column.get())->getDataPtr();
+        nested_header_column.column = checkAndGetColumn<ColumnArray>(*header_column.column).getDataPtr();
         nested_header_column.type = checkAndGetDataType<DataTypeArray>(header_column.type.get())->getNestedType();
 
         if (!insertNullAsDefaultIfNeeded(nested_input_column, nested_header_column, 0, nullptr))
             return false;
 
-        input_column.column = ColumnArray::create(nested_input_column.column, array_input_column->getOffsetsPtr());
+        input_column.column = ColumnArray::create(nested_input_column.column, array_input_column.getOffsetsPtr());
         input_column.type = std::make_shared<DataTypeArray>(std::move(nested_input_column.type));
         return true;
     }
 
     if (isTuple(input_column.type) && isTuple(header_column.type))
     {
-        const auto * tuple_input_column = checkAndGetColumn<ColumnTuple>(input_column.column.get());
-        const auto * tuple_input_type = checkAndGetDataType<DataTypeTuple>(input_column.type.get());
-        const auto * tuple_header_column = checkAndGetColumn<ColumnTuple>(header_column.column.get());
-        const auto * tuple_header_type = checkAndGetDataType<DataTypeTuple>(header_column.type.get());
+        const auto & tuple_input_column = checkAndGetColumn<ColumnTuple>(*input_column.column);
+        const auto & tuple_input_type = checkAndGetDataType<DataTypeTuple>(*input_column.type);
+        const auto & tuple_header_column = checkAndGetColumn<ColumnTuple>(*header_column.column);
+        const auto & tuple_header_type = checkAndGetDataType<DataTypeTuple>(*header_column.type);
 
-        if (tuple_input_type->getElements().size() != tuple_header_type->getElements().size())
+        if (tuple_input_type.getElements().size() != tuple_header_type.getElements().size())
             return false;
 
         Columns nested_input_columns;
-        nested_input_columns.reserve(tuple_input_type->getElements().size());
+        nested_input_columns.reserve(tuple_input_type.getElements().size());
         DataTypes nested_input_types;
-        nested_input_types.reserve(tuple_input_type->getElements().size());
+        nested_input_types.reserve(tuple_input_type.getElements().size());
         bool changed = false;
-        for (size_t i = 0; i != tuple_input_type->getElements().size(); ++i)
+        for (size_t i = 0; i != tuple_input_type.getElements().size(); ++i)
         {
             ColumnWithTypeAndName nested_input_column;
-            nested_input_column.column = tuple_input_column->getColumnPtr(i);
-            nested_input_column.type = tuple_input_type->getElement(i);
+            nested_input_column.column = tuple_input_column.getColumnPtr(i);
+            nested_input_column.type = tuple_input_type.getElement(i);
             ColumnWithTypeAndName nested_header_column;
-            nested_header_column.column = tuple_header_column->getColumnPtr(i);
-            nested_header_column.type = tuple_header_type->getElement(i);
+            nested_header_column.column = tuple_header_column.getColumnPtr(i);
+            nested_header_column.type = tuple_header_type.getElement(i);
             changed |= insertNullAsDefaultIfNeeded(nested_input_column, nested_header_column, 0, nullptr);
             nested_input_columns.push_back(std::move(nested_input_column.column));
             nested_input_types.push_back(std::move(nested_input_column.type));
@@ -74,12 +74,12 @@ bool insertNullAsDefaultIfNeeded(ColumnWithTypeAndName & input_column, const Col
     if (isMap(input_column.type) && isMap(header_column.type))
     {
         ColumnWithTypeAndName nested_input_column;
-        nested_input_column.column = checkAndGetColumn<ColumnMap>(input_column.column.get())->getNestedColumnPtr();
-        nested_input_column.type = checkAndGetDataType<DataTypeMap>(input_column.type.get())->getNestedType();
+        nested_input_column.column = checkAndGetColumn<ColumnMap>(*input_column.column).getNestedColumnPtr();
+        nested_input_column.type = checkAndGetDataType<DataTypeMap>(*input_column.type).getNestedType();
 
         ColumnWithTypeAndName nested_header_column;
-        nested_header_column.column = checkAndGetColumn<ColumnMap>(header_column.column.get())->getNestedColumnPtr();
-        nested_header_column.type = checkAndGetDataType<DataTypeMap>(header_column.type.get())->getNestedType();
+        nested_header_column.column = checkAndGetColumn<ColumnMap>(*header_column.column).getNestedColumnPtr();
+        nested_header_column.type = checkAndGetDataType<DataTypeMap>(*header_column.type).getNestedType();
 
         if (!insertNullAsDefaultIfNeeded(nested_input_column, nested_header_column, 0, nullptr))
             return false;

--- a/src/Functions/FunctionBase64Conversion.h
+++ b/src/Functions/FunctionBase64Conversion.h
@@ -111,9 +111,9 @@ public:
     ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr &, size_t input_rows_count) const override
     {
         const auto & input_column = arguments[0].column;
-        if (const auto * src_column_as_fixed_string = checkAndGetColumn<ColumnFixedString>(*input_column))
+        if (const auto * src_column_as_fixed_string = checkAndGetColumn<ColumnFixedString>(&*input_column))
             return execute(*src_column_as_fixed_string, input_rows_count);
-        else if (const auto * src_column_as_string = checkAndGetColumn<ColumnString>(*input_column))
+        else if (const auto * src_column_as_string = checkAndGetColumn<ColumnString>(&*input_column))
             return execute(*src_column_as_string, input_rows_count);
 
         throw Exception(

--- a/src/Functions/FunctionBinaryArithmetic.h
+++ b/src/Functions/FunctionBinaryArithmetic.h
@@ -1767,8 +1767,8 @@ public:
         {
             if (const auto * col_right_const = checkAndGetColumnConst<ColumnFixedString>(col_right_raw))
             {
-                const auto * col_left = checkAndGetColumn<ColumnFixedString>(col_left_const->getDataColumn());
-                const auto * col_right = checkAndGetColumn<ColumnFixedString>(col_right_const->getDataColumn());
+                const auto * col_left = &checkAndGetColumn<ColumnFixedString>(col_left_const->getDataColumn());
+                const auto * col_right = &checkAndGetColumn<ColumnFixedString>(col_right_const->getDataColumn());
 
                 if (col_left->getN() != col_right->getN())
                     return nullptr;
@@ -1805,11 +1805,11 @@ public:
 
         const auto * col_left = is_left_column_const
                         ? checkAndGetColumn<ColumnFixedString>(
-                            checkAndGetColumnConst<ColumnFixedString>(col_left_raw)->getDataColumn())
+                            &checkAndGetColumnConst<ColumnFixedString>(col_left_raw)->getDataColumn())
                         : checkAndGetColumn<ColumnFixedString>(col_left_raw);
         const auto * col_right = is_right_column_const
                         ? checkAndGetColumn<ColumnFixedString>(
-                            checkAndGetColumnConst<ColumnFixedString>(col_right_raw)->getDataColumn())
+                            &checkAndGetColumnConst<ColumnFixedString>(col_right_raw)->getDataColumn())
                         : checkAndGetColumn<ColumnFixedString>(col_right_raw);
 
         if (col_left && col_right)
@@ -1881,8 +1881,8 @@ public:
         {
             if (const auto * col_right_const = checkAndGetColumnConst<ColumnString>(col_right_raw))
             {
-                const auto * col_left = checkAndGetColumn<ColumnString>(col_left_const->getDataColumn());
-                const auto * col_right = checkAndGetColumn<ColumnString>(col_right_const->getDataColumn());
+                const auto * col_left = &checkAndGetColumn<ColumnString>(col_left_const->getDataColumn());
+                const auto * col_right = &checkAndGetColumn<ColumnString>(col_right_const->getDataColumn());
 
                 std::string_view a = col_left->getDataAt(0).toView();
                 std::string_view b = col_right->getDataAt(0).toView();
@@ -1897,10 +1897,10 @@ public:
         const bool is_right_column_const = checkAndGetColumnConst<ColumnString>(col_right_raw) != nullptr;
 
         const auto * col_left = is_left_column_const
-            ? checkAndGetColumn<ColumnString>(checkAndGetColumnConst<ColumnString>(col_left_raw)->getDataColumn())
+            ? &checkAndGetColumn<ColumnString>(checkAndGetColumnConst<ColumnString>(col_left_raw)->getDataColumn())
             : checkAndGetColumn<ColumnString>(col_left_raw);
         const auto * col_right = is_right_column_const
-            ? checkAndGetColumn<ColumnString>(checkAndGetColumnConst<ColumnString>(col_right_raw)->getDataColumn())
+            ? &checkAndGetColumn<ColumnString>(checkAndGetColumnConst<ColumnString>(col_right_raw)->getDataColumn())
             : checkAndGetColumn<ColumnString>(col_right_raw);
 
         if (col_left && col_right)
@@ -1948,7 +1948,7 @@ ColumnPtr executeStringInteger(const ColumnsWithTypeAndName & arguments, const A
 
         const ColumnConst * const col_left_const = checkAndGetColumnConst<LeftColumnType>(col_left_raw);
 
-        const auto * col_left = col_left_const ? checkAndGetColumn<LeftColumnType>(col_left_const->getDataColumn())
+        const auto * col_left = col_left_const ? &checkAndGetColumn<LeftColumnType>(col_left_const->getDataColumn())
                                                : checkAndGetColumn<LeftColumnType>(col_left_raw);
 
         if (!col_left)
@@ -2231,7 +2231,7 @@ ColumnPtr executeStringInteger(const ColumnsWithTypeAndName & arguments, const A
 
             bool is_const = checkColumnConst<ColumnNullable>(right_argument.column.get());
             const ColumnNullable * nullable_column = is_const ? checkAndGetColumnConstData<ColumnNullable>(right_argument.column.get())
-                                                              : checkAndGetColumn<ColumnNullable>(*right_argument.column);
+                                                              : checkAndGetColumn<ColumnNullable>(right_argument.column.get());
 
             const auto & null_bytemap = nullable_column->getNullMapData();
             auto res = executeImpl2(createBlockWithNestedColumns(arguments), removeNullable(result_type), input_rows_count, &null_bytemap);

--- a/src/Functions/FunctionHelpers.cpp
+++ b/src/Functions/FunctionHelpers.cpp
@@ -58,14 +58,14 @@ ColumnWithTypeAndName columnGetNested(const ColumnWithTypeAndName & col)
         {
             return ColumnWithTypeAndName{nullptr, nested_type, col.name};
         }
-        else if (const auto * nullable = checkAndGetColumn<ColumnNullable>(*col.column))
+        else if (const auto * nullable = checkAndGetColumn<ColumnNullable>(&*col.column))
         {
             const auto & nested_col = nullable->getNestedColumnPtr();
             return ColumnWithTypeAndName{nested_col, nested_type, col.name};
         }
-        else if (const auto * const_column = checkAndGetColumn<ColumnConst>(*col.column))
+        else if (const auto * const_column = checkAndGetColumn<ColumnConst>(&*col.column))
         {
-            const auto * nullable_column = checkAndGetColumn<ColumnNullable>(const_column->getDataColumn());
+            const auto * nullable_column = checkAndGetColumn<ColumnNullable>(&const_column->getDataColumn());
 
             ColumnPtr nullable_res;
             if (nullable_column)
@@ -226,7 +226,7 @@ ColumnPtr wrapInNullable(const ColumnPtr & src, const ColumnsWithTypeAndName & a
 
     if (src->onlyNull())
         return src;
-    else if (const auto * nullable = checkAndGetColumn<ColumnNullable>(*src))
+    else if (const auto * nullable = checkAndGetColumn<ColumnNullable>(&*src))
     {
         src_not_nullable = nullable->getNestedColumnPtr();
         result_null_map_column = nullable->getNullMapColumnPtr();
@@ -247,7 +247,7 @@ ColumnPtr wrapInNullable(const ColumnPtr & src, const ColumnsWithTypeAndName & a
         if (isColumnConst(*elem.column))
             continue;
 
-        if (const auto * nullable = checkAndGetColumn<ColumnNullable>(*elem.column))
+        if (const auto * nullable = checkAndGetColumn<ColumnNullable>(&*elem.column))
         {
             const ColumnPtr & null_map_column = nullable->getNullMapColumnPtr();
             if (!result_null_map_column)

--- a/src/Functions/FunctionHelpers.h
+++ b/src/Functions/FunctionHelpers.h
@@ -15,6 +15,11 @@
 namespace DB
 {
 
+namespace ErrorCodes
+{
+    extern const int LOGICAL_ERROR;
+}
+
 class IFunction;
 
 /// Methods, that helps dispatching over real column types.

--- a/src/Functions/FunctionHelpers.h
+++ b/src/Functions/FunctionHelpers.h
@@ -25,6 +25,13 @@ const Type * checkAndGetDataType(const IDataType * data_type)
     return typeid_cast<const Type *>(data_type);
 }
 
+/// Throws on mismatch.
+template <typename Type>
+const Type & checkAndGetDataType(const IDataType & data_type)
+{
+    return typeid_cast<const Type &>(data_type);
+}
+
 template <typename... Types>
 bool checkDataTypes(const IDataType * data_type)
 {
@@ -34,13 +41,27 @@ bool checkDataTypes(const IDataType * data_type)
 template <typename Type>
 const ColumnConst * checkAndGetColumnConst(const IColumn * column)
 {
-    if (!column || !isColumnConst(*column))
+    if (!column)
         return {};
 
-    const ColumnConst * res = assert_cast<const ColumnConst *>(column);
+    const ColumnConst * res = checkAndGetColumn<ColumnConst>(column);
+    if (!res)
+        return {};
 
     if (!checkColumn<Type>(&res->getDataColumn()))
         return {};
+
+    return res;
+}
+
+template <typename Type>
+const ColumnConst & checkAndGetColumnConst(const IColumn & column)
+{
+    const ColumnConst & res = checkAndGetColumn<ColumnConst>(column);
+
+    const auto & data_column = res.getDataColumn();
+    if (!checkColumn<Type>(&data_column))
+        throw DB::Exception(DB::ErrorCodes::LOGICAL_ERROR, "Unexpected const column type: expected {}, got {}", demangle(typeid(Type).name()), demangle(typeid(data_column).name()));
 
     return res;
 }

--- a/src/Functions/FunctionUnixTimestamp64.h
+++ b/src/Functions/FunctionUnixTimestamp64.h
@@ -140,7 +140,7 @@ public:
         const auto & src = arguments[0];
         const auto & col = *src.column;
 
-        if (!checkAndGetColumn<ColumnVector<T>>(col))
+        if (!checkAndGetColumn<ColumnVector<T>>(&col))
             return false;
 
         auto & result_data = result_column->getData();

--- a/src/Functions/FunctionsBitmap.h
+++ b/src/Functions/FunctionsBitmap.h
@@ -193,8 +193,8 @@ private:
         const ColumnArray * array = typeid_cast<const ColumnArray *>(arguments[0].column.get());
         const ColumnPtr & mapped = array->getDataPtr();
         const ColumnArray::Offsets & offsets = array->getOffsets();
-        const ColumnVector<T> * column = checkAndGetColumn<ColumnVector<T>>(&*mapped);
-        const typename ColumnVector<T>::Container & input_data = column->getData();
+        const ColumnVector<T> & column = checkAndGetColumn<ColumnVector<T>>(*mapped);
+        const typename ColumnVector<T>::Container & input_data = column.getData();
 
         // output data
         Array params_row;

--- a/src/Functions/FunctionsCodingIP.cpp
+++ b/src/Functions/FunctionsCodingIP.cpp
@@ -536,7 +536,7 @@ public:
         const auto & col_type_name = arguments[0];
         const ColumnPtr & column = col_type_name.column;
 
-        if (const auto * col_in = checkAndGetColumn<ColumnIPv4>(*column))
+        if (const auto * col_in = checkAndGetColumn<ColumnIPv4>(&*column))
         {
             auto col_res = ColumnIPv6::create();
 
@@ -551,7 +551,7 @@ public:
             return col_res;
         }
 
-        if (const auto * col_in = checkAndGetColumn<ColumnUInt32>(*column))
+        if (const auto * col_in = checkAndGetColumn<ColumnUInt32>(&*column))
         {
             auto col_res = ColumnFixedString::create(IPV6_BINARY_LENGTH);
 

--- a/src/Functions/FunctionsConversion.cpp
+++ b/src/Functions/FunctionsConversion.cpp
@@ -3302,7 +3302,7 @@ private:
             /// both columns have type UInt8, but we shouldn't use identity wrapper,
             /// because Bool column can contain only 0 and 1.
             auto res_column = to_type->createColumn();
-            const auto & data_from = checkAndGetColumn<ColumnUInt8>(arguments[0].column.get())->getData();
+            const auto & data_from = checkAndGetColumn<ColumnUInt8>(*arguments[0].column).getData();
             auto & data_to = assert_cast<ColumnUInt8 *>(res_column.get())->getData();
             data_to.resize(data_from.size());
             for (size_t i = 0; i != data_from.size(); ++i)

--- a/src/Functions/FunctionsRound.h
+++ b/src/Functions/FunctionsRound.h
@@ -467,28 +467,28 @@ struct Dispatcher
 
     static ColumnPtr apply(const IColumn * col_general, Scale scale_arg)
     {
-        const auto * const col = checkAndGetColumn<ColumnVector<T>>(col_general);
+        const auto & col = checkAndGetColumn<ColumnVector<T>>(*col_general);
         auto col_res = ColumnVector<T>::create();
 
         typename ColumnVector<T>::Container & vec_res = col_res->getData();
-        vec_res.resize(col->getData().size());
+        vec_res.resize(col.getData().size());
 
         if (!vec_res.empty())
         {
             if (scale_arg == 0)
             {
                 size_t scale = 1;
-                FunctionRoundingImpl<ScaleMode::Zero>::apply(col->getData(), scale, vec_res);
+                FunctionRoundingImpl<ScaleMode::Zero>::apply(col.getData(), scale, vec_res);
             }
             else if (scale_arg > 0)
             {
                 size_t scale = intExp10(scale_arg);
-                FunctionRoundingImpl<ScaleMode::Positive>::apply(col->getData(), scale, vec_res);
+                FunctionRoundingImpl<ScaleMode::Positive>::apply(col.getData(), scale, vec_res);
             }
             else
             {
                 size_t scale = intExp10(-scale_arg);
-                FunctionRoundingImpl<ScaleMode::Negative>::apply(col->getData(), scale, vec_res);
+                FunctionRoundingImpl<ScaleMode::Negative>::apply(col.getData(), scale, vec_res);
             }
         }
 
@@ -502,14 +502,14 @@ struct Dispatcher<T, rounding_mode, tie_breaking_mode>
 public:
     static ColumnPtr apply(const IColumn * col_general, Scale scale_arg)
     {
-        const auto * const col = checkAndGetColumn<ColumnDecimal<T>>(col_general);
-        const typename ColumnDecimal<T>::Container & vec_src = col->getData();
+        const auto & col = checkAndGetColumn<ColumnDecimal<T>>(*col_general);
+        const typename ColumnDecimal<T>::Container & vec_src = col.getData();
 
-        auto col_res = ColumnDecimal<T>::create(vec_src.size(), col->getScale());
+        auto col_res = ColumnDecimal<T>::create(vec_src.size(), col.getScale());
         auto & vec_res = col_res->getData();
 
         if (!vec_res.empty())
-            DecimalRoundingImpl<T, rounding_mode, tie_breaking_mode>::apply(col->getData(), col->getScale(), vec_res, scale_arg);
+            DecimalRoundingImpl<T, rounding_mode, tie_breaking_mode>::apply(col.getData(), col.getScale(), vec_res, scale_arg);
 
         return col_res;
     }

--- a/src/Functions/FunctionsStringHash.h
+++ b/src/Functions/FunctionsStringHash.h
@@ -153,8 +153,8 @@ public:
             auto col_res = ColumnVector<UInt64>::create();
             auto & vec_res = col_res->getData();
             vec_res.resize(column->size());
-            const ColumnString * col_str_vector = checkAndGetColumn<ColumnString>(&*column);
-            Impl::apply(col_str_vector->getChars(), col_str_vector->getOffsets(), shingle_size, vec_res);
+            const ColumnString & col_str_vector = checkAndGetColumn<ColumnString>(*column);
+            Impl::apply(col_str_vector.getChars(), col_str_vector.getOffsets(), shingle_size, vec_res);
             return col_res;
         }
         else if constexpr (is_arg) // Min hash arg
@@ -170,8 +170,8 @@ public:
             auto min_tuple = ColumnTuple::create(std::move(min_columns));
             auto max_tuple = ColumnTuple::create(std::move(max_columns));
 
-            const ColumnString * col_str_vector = checkAndGetColumn<ColumnString>(&*column);
-            Impl::apply(col_str_vector->getChars(), col_str_vector->getOffsets(), shingle_size, num_hashes, nullptr, nullptr, min_tuple.get(), max_tuple.get());
+            const ColumnString & col_str_vector = checkAndGetColumn<ColumnString>(*column);
+            Impl::apply(col_str_vector.getChars(), col_str_vector.getOffsets(), shingle_size, num_hashes, nullptr, nullptr, min_tuple.get(), max_tuple.get());
 
             MutableColumns tuple_columns;
             tuple_columns.emplace_back(std::move(min_tuple));
@@ -186,8 +186,8 @@ public:
             auto & vec_h2 = col_h2->getData();
             vec_h1.resize(column->size());
             vec_h2.resize(column->size());
-            const ColumnString * col_str_vector = checkAndGetColumn<ColumnString>(&*column);
-            Impl::apply(col_str_vector->getChars(), col_str_vector->getOffsets(), shingle_size, num_hashes, &vec_h1, &vec_h2, nullptr, nullptr);
+            const ColumnString & col_str_vector = checkAndGetColumn<ColumnString>(*column);
+            Impl::apply(col_str_vector.getChars(), col_str_vector.getOffsets(), shingle_size, num_hashes, &vec_h1, &vec_h2, nullptr, nullptr);
             MutableColumns tuple_columns;
             tuple_columns.emplace_back(std::move(col_h1));
             tuple_columns.emplace_back(std::move(col_h2));

--- a/src/Functions/Kusto/KqlArraySort.cpp
+++ b/src/Functions/Kusto/KqlArraySort.cpp
@@ -158,12 +158,12 @@ public:
                 auto out_tmp = ColumnArray::create(nested_types[i]->createColumn());
 
                 size_t array_size = tuple_coulmn->size();
-                const auto * arr = checkAndGetColumn<ColumnArray>(tuple_coulmn.get());
+                const auto & arr = checkAndGetColumn<ColumnArray>(*tuple_coulmn);
 
                 for (size_t j = 0; j < array_size; ++j)
                 {
                     Field arr_field;
-                    arr->get(j, arr_field);
+                    arr.get(j, arr_field);
                     out_tmp->insert(arr_field);
                 }
 

--- a/src/Functions/MultiMatchAllIndicesImpl.h
+++ b/src/Functions/MultiMatchAllIndicesImpl.h
@@ -185,7 +185,7 @@ struct MultiMatchAllIndicesImpl
         size_t prev_haystack_offset = 0;
         size_t prev_needles_offset = 0;
 
-        const ColumnString * needles_data_string = checkAndGetColumn<ColumnString>(&needles_data);
+        const ColumnString & needles_data_string = checkAndGetColumn<ColumnString>(needles_data);
 
         std::vector<std::string_view> needles;
 
@@ -195,7 +195,7 @@ struct MultiMatchAllIndicesImpl
 
             for (size_t j = prev_needles_offset; j < needles_offsets[i]; ++j)
             {
-                needles.emplace_back(needles_data_string->getDataAt(j).toView());
+                needles.emplace_back(needles_data_string.getDataAt(j).toView());
             }
 
             if (needles.empty())

--- a/src/Functions/MultiMatchAnyImpl.h
+++ b/src/Functions/MultiMatchAnyImpl.h
@@ -212,7 +212,7 @@ struct MultiMatchAnyImpl
         size_t prev_haystack_offset = 0;
         size_t prev_needles_offset = 0;
 
-        const ColumnString * needles_data_string = checkAndGetColumn<ColumnString>(&needles_data);
+        const ColumnString & needles_data_string = checkAndGetColumn<ColumnString>(needles_data);
 
         std::vector<std::string_view> needles;
 
@@ -221,7 +221,7 @@ struct MultiMatchAnyImpl
             needles.reserve(needles_offsets[i] - prev_needles_offset);
 
             for (size_t j = prev_needles_offset; j < needles_offsets[i]; ++j)
-                needles.emplace_back(needles_data_string->getDataAt(j).toView());
+                needles.emplace_back(needles_data_string.getDataAt(j).toView());
 
             if (needles.empty())
             {

--- a/src/Functions/MultiSearchAllPositionsImpl.h
+++ b/src/Functions/MultiSearchAllPositionsImpl.h
@@ -89,7 +89,7 @@ struct MultiSearchAllPositionsImpl
 
         offsets_res.reserve(haystack_offsets.size());
 
-        const ColumnString * needles_data_string = checkAndGetColumn<ColumnString>(&needles_data);
+        const ColumnString & needles_data_string = checkAndGetColumn<ColumnString>(needles_data);
 
         std::vector<std::string_view> needles;
 
@@ -99,7 +99,7 @@ struct MultiSearchAllPositionsImpl
 
             for (size_t j = prev_needles_offset; j < needles_offsets[i]; ++j)
             {
-                needles.emplace_back(needles_data_string->getDataAt(j).toView());
+                needles.emplace_back(needles_data_string.getDataAt(j).toView());
             }
 
             const size_t needles_size = needles.size();

--- a/src/Functions/MultiSearchFirstIndexImpl.h
+++ b/src/Functions/MultiSearchFirstIndexImpl.h
@@ -88,7 +88,7 @@ struct MultiSearchFirstIndexImpl
         size_t prev_haystack_offset = 0;
         size_t prev_needles_offset = 0;
 
-        const ColumnString * needles_data_string = checkAndGetColumn<ColumnString>(&needles_data);
+        const ColumnString & needles_data_string = checkAndGetColumn<ColumnString>(needles_data);
 
         std::vector<std::string_view> needles;
 
@@ -98,7 +98,7 @@ struct MultiSearchFirstIndexImpl
 
             for (size_t j = prev_needles_offset; j < needles_offsets[i]; ++j)
             {
-                needles.emplace_back(needles_data_string->getDataAt(j).toView());
+                needles.emplace_back(needles_data_string.getDataAt(j).toView());
             }
 
             auto searcher = Impl::createMultiSearcherInBigHaystack(needles); // sub-optimal

--- a/src/Functions/MultiSearchFirstPositionImpl.h
+++ b/src/Functions/MultiSearchFirstPositionImpl.h
@@ -97,7 +97,7 @@ struct MultiSearchFirstPositionImpl
         size_t prev_haystack_offset = 0;
         size_t prev_needles_offset = 0;
 
-        const ColumnString * needles_data_string = checkAndGetColumn<ColumnString>(&needles_data);
+        const ColumnString & needles_data_string = checkAndGetColumn<ColumnString>(needles_data);
 
         std::vector<std::string_view> needles;
 
@@ -112,7 +112,7 @@ struct MultiSearchFirstPositionImpl
 
             for (size_t j = prev_needles_offset; j < needles_offsets[i]; ++j)
             {
-                needles.emplace_back(needles_data_string->getDataAt(j).toView());
+                needles.emplace_back(needles_data_string.getDataAt(j).toView());
             }
 
             auto searcher = Impl::createMultiSearcherInBigHaystack(needles); // sub-optimal

--- a/src/Functions/MultiSearchImpl.h
+++ b/src/Functions/MultiSearchImpl.h
@@ -87,7 +87,7 @@ struct MultiSearchImpl
         size_t prev_haystack_offset = 0;
         size_t prev_needles_offset = 0;
 
-        const ColumnString * needles_data_string = checkAndGetColumn<ColumnString>(&needles_data);
+        const ColumnString & needles_data_string = checkAndGetColumn<ColumnString>(needles_data);
 
         std::vector<std::string_view> needles;
 
@@ -97,7 +97,7 @@ struct MultiSearchImpl
 
             for (size_t j = prev_needles_offset; j < needles_offsets[i]; ++j)
             {
-                needles.emplace_back(needles_data_string->getDataAt(j).toView());
+                needles.emplace_back(needles_data_string.getDataAt(j).toView());
             }
 
             const auto * const haystack = &haystack_data[prev_haystack_offset];

--- a/src/Functions/URL/FirstSignificantSubdomainCustomImpl.h
+++ b/src/Functions/URL/FirstSignificantSubdomainCustomImpl.h
@@ -69,7 +69,7 @@ public:
         const ColumnConst * column_tld_list_name = checkAndGetColumnConstStringOrFixedString(arguments[1].column.get());
         FirstSignificantSubdomainCustomLookup tld_lookup(column_tld_list_name->getValue<String>());
 
-        if (const ColumnString * col = checkAndGetColumn<ColumnString>(*arguments[0].column))
+        if (const ColumnString * col = checkAndGetColumn<ColumnString>(&*arguments[0].column))
         {
             auto col_res = ColumnString::create();
             vector(tld_lookup, col->getChars(), col->getOffsets(), col_res->getChars(), col_res->getOffsets());

--- a/src/Functions/UTCTimestampTransform.cpp
+++ b/src/Functions/UTCTimestampTransform.cpp
@@ -80,14 +80,14 @@ namespace
             const DateLUTImpl & utc_time_zone = DateLUT::instance("UTC");
             if (WhichDataType(arg1.type).isDateTime())
             {
-                const auto * date_time_col = checkAndGetColumn<ColumnDateTime>(arg1.column.get());
-                size_t col_size = date_time_col->size();
+                const auto & date_time_col = checkAndGetColumn<ColumnDateTime>(*arg1.column);
+                size_t col_size = date_time_col.size();
                 using ColVecTo = DataTypeDateTime::ColumnType;
                 typename ColVecTo::MutablePtr result_column = ColVecTo::create(col_size);
                 typename ColVecTo::Container & result_data = result_column->getData();
                 for (size_t i = 0; i < col_size; ++i)
                 {
-                    UInt32 date_time_val = date_time_col->getElement(i);
+                    UInt32 date_time_val = date_time_col.getElement(i);
                     LocalDateTime date_time(date_time_val, Name::to ? utc_time_zone : DateLUT::instance(time_zone_val));
                     time_t time_val = date_time.to_time_t(Name::from ? utc_time_zone : DateLUT::instance(time_zone_val));
                     result_data[i] = static_cast<UInt32>(time_val);
@@ -96,8 +96,8 @@ namespace
             }
             else if (WhichDataType(arg1.type).isDateTime64())
             {
-                const auto * date_time_col = checkAndGetColumn<ColumnDateTime64>(arg1.column.get());
-                size_t col_size = date_time_col->size();
+                const auto & date_time_col = checkAndGetColumn<ColumnDateTime64>(*arg1.column);
+                size_t col_size = date_time_col.size();
                 const DataTypeDateTime64 * date_time_type = static_cast<const DataTypeDateTime64 *>(arg1.type.get());
                 UInt32 col_scale = date_time_type->getScale();
                 Int64 scale_multiplier = DecimalUtils::scaleMultiplier<Int64>(col_scale);
@@ -106,7 +106,7 @@ namespace
                 typename ColDecimalTo::Container & result_data = result_column->getData();
                 for (size_t i = 0; i < col_size; ++i)
                 {
-                    DateTime64 date_time_val = date_time_col->getElement(i);
+                    DateTime64 date_time_val = date_time_col.getElement(i);
                     Int64 seconds = date_time_val.value / scale_multiplier;
                     Int64 micros = date_time_val.value % scale_multiplier;
                     LocalDateTime date_time(seconds, Name::to ? utc_time_zone : DateLUT::instance(time_zone_val));

--- a/src/Functions/array/FunctionArrayMapped.h
+++ b/src/Functions/array/FunctionArrayMapped.h
@@ -317,7 +317,7 @@ public:
                             ErrorCodes::ILLEGAL_COLUMN, "Expected Array column, found {}", column_array_ptr->getName());
 
                     column_array_ptr = recursiveRemoveLowCardinality(column_const_array->convertToFullColumn());
-                    column_array = checkAndGetColumn<ColumnArray>(column_array_ptr.get());
+                    column_array = &checkAndGetColumn<ColumnArray>(*column_array_ptr);
                 }
 
                 if (!array_type)

--- a/src/Functions/array/arrayCompact.cpp
+++ b/src/Functions/array/arrayCompact.cpp
@@ -34,7 +34,7 @@ struct ArrayCompactImpl
         using ColVecType = ColumnVectorOrDecimal<T>;
 
         const ColVecType * check_values_column = checkAndGetColumn<ColVecType>(mapped.get());
-        const ColVecType * src_values_column = checkAndGetColumn<ColVecType>(array.getData());
+        const ColVecType * src_values_column = checkAndGetColumn<ColVecType>(&array.getData());
 
         if (!src_values_column || !check_values_column)
             return false;

--- a/src/Functions/array/arrayDistinct.cpp
+++ b/src/Functions/array/arrayDistinct.cpp
@@ -89,20 +89,20 @@ private:
 ColumnPtr FunctionArrayDistinct::executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type, size_t /*input_rows_count*/) const
 {
     ColumnPtr array_ptr = arguments[0].column;
-    const ColumnArray * array = checkAndGetColumn<ColumnArray>(array_ptr.get());
+    const ColumnArray & array = checkAndGetColumn<ColumnArray>(*array_ptr);
 
     const auto & return_type = result_type;
 
     auto res_ptr = return_type->createColumn();
     ColumnArray & res = assert_cast<ColumnArray &>(*res_ptr);
 
-    const IColumn & src_data = array->getData();
-    const ColumnArray::Offsets & offsets = array->getOffsets();
+    const IColumn & src_data = array.getData();
+    const ColumnArray::Offsets & offsets = array.getOffsets();
 
     IColumn & res_data = res.getData();
     ColumnArray::Offsets & res_offsets = res.getOffsets();
 
-    const ColumnNullable * nullable_col = checkAndGetColumn<ColumnNullable>(src_data);
+    const ColumnNullable * nullable_col = checkAndGetColumn<ColumnNullable>(&src_data);
 
     const IColumn * inner_col;
 

--- a/src/Functions/array/arrayElement.cpp
+++ b/src/Functions/array/arrayElement.cpp
@@ -1538,9 +1538,9 @@ ColumnPtr FunctionArrayElement::executeMap2(const ColumnsWithTypeAndName & argum
         return nullptr;
 
     const ColumnArray * col_map_nested = &col_map->getNestedColumn();
-    const ColumnTuple * col_map_kv = checkAndGetColumn<ColumnTuple>(col_map_nested->getDataPtr().get());
-    ColumnPtr col_map_keys = col_map_kv->getColumnPtr(0);
-    ColumnPtr col_map_values = col_map_kv->getColumnPtr(1);
+    const ColumnTuple & col_map_kv = checkAndGetColumn<ColumnTuple>(*col_map_nested->getDataPtr());
+    ColumnPtr col_map_keys = col_map_kv.getColumnPtr(0);
+    ColumnPtr col_map_values = col_map_kv.getColumnPtr(1);
 
     const DataTypeMap & map_type
         = typeid_cast<const DataTypeMap &>(*typeid_cast<const DataTypeArray &>(*arguments[0].type).getNestedType());

--- a/src/Functions/array/arrayEnumerateExtended.h
+++ b/src/Functions/array/arrayEnumerateExtended.h
@@ -165,7 +165,7 @@ ColumnPtr FunctionArrayEnumerateExtended<Derived>::executeImpl(const ColumnsWith
 
     for (size_t i = 0; i < num_arguments; ++i)
     {
-        if (const auto * nullable_col = checkAndGetColumn<ColumnNullable>(*data_columns[i]))
+        if (const auto * nullable_col = checkAndGetColumn<ColumnNullable>(data_columns[i]))
         {
             if (num_arguments == 1)
                 data_columns[i] = &nullable_col->getNestedColumn();

--- a/src/Functions/array/arrayIndex.h
+++ b/src/Functions/array/arrayIndex.h
@@ -506,10 +506,10 @@ private:
         const ColumnNullable * nullable = nullptr;
 
         if (col_array)
-            nullable = checkAndGetColumn<ColumnNullable>(col_array->getData());
+            nullable = checkAndGetColumn<ColumnNullable>(&col_array->getData());
 
         const auto & arg_column = arguments[1].column;
-        const ColumnNullable * arg_nullable = checkAndGetColumn<ColumnNullable>(*arg_column);
+        const ColumnNullable * arg_nullable = checkAndGetColumn<ColumnNullable>(&*arg_column);
 
         if (!nullable && !arg_nullable)
         {
@@ -738,7 +738,7 @@ private:
 
         const auto [null_map_data, null_map_item] = getNullMaps(arguments);
 
-        if (const ColumnConst * col_arg_const = checkAndGetColumn<ColumnConst>(*arguments[1].column))
+        if (const ColumnConst * col_arg_const = checkAndGetColumn<ColumnConst>(&*arguments[1].column))
         {
             const IColumnUnique & col_lc_dict = col_lc->getDictionary();
 
@@ -754,7 +754,7 @@ private:
             if (!col_arg_cloned->isNullAt(0))
             {
                 if (col_arg_cloned->isNullable())
-                    col_arg_cloned = checkAndGetColumn<ColumnNullable>(*col_arg_cloned)->getNestedColumnPtr();
+                    col_arg_cloned = checkAndGetColumn<ColumnNullable>(*col_arg_cloned).getNestedColumnPtr();
 
                 StringRef elem = col_arg_cloned->getDataAt(0);
 
@@ -786,7 +786,7 @@ private:
         else if (col_lc->nestedIsNullable()) // LowCardinality(Nullable(T)) and U
         {
             const ColumnPtr left_casted = col_lc->convertToFullColumnIfLowCardinality(); // Nullable(T)
-            const ColumnNullable& left_nullable = *checkAndGetColumn<ColumnNullable>(left_casted.get());
+            const ColumnNullable & left_nullable = checkAndGetColumn<ColumnNullable>(*left_casted);
 
             const NullMap * const null_map_left_casted = &left_nullable.getNullMapColumn().getData();
 

--- a/src/Functions/array/arrayJaccardIndex.cpp
+++ b/src/Functions/array/arrayJaccardIndex.cpp
@@ -97,8 +97,8 @@ public:
         {
             if (const ColumnConst * col_const = typeid_cast<const ColumnConst *>(col.column.get()))
             {
-                const ColumnArray * col_const_array = checkAndGetColumn<ColumnArray>(col_const->getDataColumnPtr().get());
-                return {col_const_array, true};
+                const ColumnArray & col_const_array = checkAndGetColumn<ColumnArray>(*col_const->getDataColumnPtr());
+                return {&col_const_array, true};
             }
             else if (const ColumnArray * col_non_const_array = checkAndGetColumn<ColumnArray>(col.column.get()))
                 return {col_non_const_array, false};
@@ -128,8 +128,8 @@ public:
         vectorWithEmptyIntersect<left_is_const, right_is_const>(left_array->getOffsets(), right_array->getOffsets(), vec_res); \
     else \
     { \
-        const ColumnArray * intersect_column_array = checkAndGetColumn<ColumnArray>(intersect_column.column.get()); \
-        vector<left_is_const, right_is_const>(intersect_column_array->getOffsets(), left_array->getOffsets(), right_array->getOffsets(), vec_res); \
+        const ColumnArray & intersect_column_array = checkAndGetColumn<ColumnArray>(*intersect_column.column); \
+        vector<left_is_const, right_is_const>(intersect_column_array.getOffsets(), left_array->getOffsets(), right_array->getOffsets(), vec_res); \
     }
 
         if (!left_is_const && !right_is_const)

--- a/src/Functions/array/arrayUniq.cpp
+++ b/src/Functions/array/arrayUniq.cpp
@@ -162,7 +162,7 @@ ColumnPtr FunctionArrayUniq::executeImpl(const ColumnsWithTypeAndName & argument
 
     for (size_t i = 0; i < num_arguments; ++i)
     {
-        if (const auto * nullable_col = checkAndGetColumn<ColumnNullable>(*data_columns[i]))
+        if (const auto * nullable_col = checkAndGetColumn<ColumnNullable>(data_columns[i]))
         {
             if (num_arguments == 1)
                 data_columns[i] = &nullable_col->getNestedColumn();

--- a/src/Functions/array/emptyArrayToSingle.cpp
+++ b/src/Functions/array/emptyArrayToSingle.cpp
@@ -391,7 +391,7 @@ ColumnPtr FunctionEmptyArrayToSingle::executeImpl(const ColumnsWithTypeAndName &
     const IColumn * inner_col;
     IColumn * inner_res_col;
 
-    const auto * nullable_col = checkAndGetColumn<ColumnNullable>(src_data);
+    const auto * nullable_col = checkAndGetColumn<ColumnNullable>(&src_data);
     if (nullable_col)
     {
         inner_col = &nullable_col->getNestedColumn();

--- a/src/Functions/array/range.cpp
+++ b/src/Functions/array/range.cpp
@@ -404,7 +404,7 @@ private:
         {
             if (!col.type->isNullable())
                 return;
-            const ColumnNullable * nullable_col = checkAndGetColumn<ColumnNullable>(*col.column);
+            const ColumnNullable * nullable_col = checkAndGetColumn<ColumnNullable>(col.column.get());
             if (!nullable_col)
                 nullable_col = checkAndGetColumnConstData<ColumnNullable>(col.column.get());
             if (!nullable_col)
@@ -421,8 +421,8 @@ private:
             const auto * col = arguments[0].column.get();
             if (arguments[0].type->isNullable())
             {
-                const auto * nullable = checkAndGetColumn<ColumnNullable>(*arguments[0].column);
-                col = nullable->getNestedColumnPtr().get();
+                const auto & nullable = checkAndGetColumn<ColumnNullable>(*arguments[0].column);
+                col = nullable.getNestedColumnPtr().get();
             }
 
             if (!((res = executeInternal<UInt8>(col)) || (res = executeInternal<UInt16>(col)) || (res = executeInternal<UInt32>(col))

--- a/src/Functions/arrayStringConcat.cpp
+++ b/src/Functions/arrayStringConcat.cpp
@@ -183,7 +183,7 @@ public:
         const ColumnString & col_string = assert_cast<const ColumnString &>(*str_subcolumn.get());
 
         auto col_res = ColumnString::create();
-        if (const ColumnNullable * col_nullable = checkAndGetColumn<ColumnNullable>(col_arr.getData()))
+        if (const ColumnNullable * col_nullable = checkAndGetColumn<ColumnNullable>(&col_arr.getData()))
             executeInternal(col_string, col_arr, delimiter, *col_res, col_nullable->getNullMapData().data());
         else
             executeInternal(col_string, col_arr, delimiter, *col_res);

--- a/src/Functions/assumeNotNull.cpp
+++ b/src/Functions/assumeNotNull.cpp
@@ -54,7 +54,7 @@ public:
         if (arguments[0].type->onlyNull() && !col->empty())
             throw Exception(ErrorCodes::ILLEGAL_COLUMN, "Cannot create non-empty column with type Nothing");
 
-        if (const auto * nullable_col = checkAndGetColumn<ColumnNullable>(*col))
+        if (const auto * nullable_col = checkAndGetColumn<ColumnNullable>(&*col))
             return nullable_col->getNestedColumnPtr();
         else
             return col;

--- a/src/Functions/coalesce.cpp
+++ b/src/Functions/coalesce.cpp
@@ -157,12 +157,12 @@ public:
         /// if last argument is not nullable, result should be also not nullable
         if (!multi_if_args.back().column->isNullable() && res->isNullable())
         {
-            if (const auto * column_lc = checkAndGetColumn<ColumnLowCardinality>(*res))
-                res = checkAndGetColumn<ColumnNullable>(*column_lc->convertToFullColumn())->getNestedColumnPtr();
-            else if (const auto * column_const = checkAndGetColumn<ColumnConst>(*res))
-                res = checkAndGetColumn<ColumnNullable>(column_const->getDataColumn())->getNestedColumnPtr();
+            if (const auto * column_lc = checkAndGetColumn<ColumnLowCardinality>(&*res))
+                res = checkAndGetColumn<ColumnNullable>(*column_lc->convertToFullColumn()).getNestedColumnPtr();
+            else if (const auto * column_const = checkAndGetColumn<ColumnConst>(&*res))
+                res = checkAndGetColumn<ColumnNullable>(column_const->getDataColumn()).getNestedColumnPtr();
             else
-                res = checkAndGetColumn<ColumnNullable>(*res)->getNestedColumnPtr();
+                res = checkAndGetColumn<ColumnNullable>(&*res)->getNestedColumnPtr();
         }
 
         return res;

--- a/src/Functions/fromModifiedJulianDay.cpp
+++ b/src/Functions/fromModifiedJulianDay.cpp
@@ -34,8 +34,8 @@ namespace DB
         ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr &, size_t input_rows_count) const override
         {
             using ColVecType = typename FromDataType::ColumnType;
-            const ColVecType * col_from = checkAndGetColumn<ColVecType>(arguments[0].column.get());
-            const typename ColVecType::Container & vec_from = col_from->getData();
+            const ColVecType & col_from = checkAndGetColumn<ColVecType>(*arguments[0].column);
+            const typename ColVecType::Container & vec_from = col_from.getData();
 
             auto col_to = ColumnString::create();
             ColumnString::Chars & data_to = col_to->getChars();

--- a/src/Functions/grouping.h
+++ b/src/Functions/grouping.h
@@ -55,7 +55,7 @@ public:
     template <typename AggregationKeyChecker>
     ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, size_t input_rows_count, AggregationKeyChecker checker) const
     {
-        const auto * grouping_set_column = checkAndGetColumn<ColumnUInt64>(arguments[0].column.get());
+        const auto & grouping_set_column = checkAndGetColumn<ColumnUInt64>(*arguments[0].column);
 
         auto result = ColumnUInt64::create();
         auto & result_data = result->getData();
@@ -64,7 +64,7 @@ public:
         const auto * result_table = likely(force_compatibility) ? COMPATIBLE_MODE : INCOMPATIBLE_MODE;
         for (size_t i = 0; i < input_rows_count; ++i)
         {
-            UInt64 set_index = grouping_set_column->getElement(i);
+            UInt64 set_index = grouping_set_column.getElement(i);
 
             UInt64 value = 0;
             for (auto index : arguments_indexes)

--- a/src/Functions/hasColumnInTable.cpp
+++ b/src/Functions/hasColumnInTable.cpp
@@ -88,8 +88,8 @@ ColumnPtr FunctionHasColumnInTable::executeImpl(const ColumnsWithTypeAndName & a
 {
     auto get_string_from_columns = [&](const ColumnWithTypeAndName & column) -> String
     {
-        const ColumnConst * const_column = checkAndGetColumnConst<ColumnString>(column.column.get());
-        return const_column->getValue<String>();
+        const ColumnConst & const_column = checkAndGetColumnConst<ColumnString>(*column.column);
+        return const_column.getValue<String>();
     };
 
     size_t arg = 0;

--- a/src/Functions/if.cpp
+++ b/src/Functions/if.cpp
@@ -948,12 +948,12 @@ private:
         bool cond_is_const = false;
         bool cond_is_true = false;
         bool cond_is_false = false;
-        if (const auto * const_arg = checkAndGetColumn<ColumnConst>(*arg_cond.column))
+        if (const auto * const_arg = checkAndGetColumn<ColumnConst>(&*arg_cond.column))
         {
             cond_is_const = true;
             not_const_condition = const_arg->getDataColumnPtr();
             ColumnPtr data_column = const_arg->getDataColumnPtr();
-            if (const auto * const_nullable_arg = checkAndGetColumn<ColumnNullable>(*data_column))
+            if (const auto * const_nullable_arg = checkAndGetColumn<ColumnNullable>(&*data_column))
             {
                 data_column = const_nullable_arg->getNestedColumnPtr();
                 if (!data_column->empty())
@@ -962,7 +962,7 @@ private:
 
             if (!data_column->empty())
             {
-                cond_is_true = !cond_is_null && checkAndGetColumn<ColumnUInt8>(*data_column)->getBool(0);
+                cond_is_true = !cond_is_null && checkAndGetColumn<ColumnUInt8>(*data_column).getBool(0);
                 cond_is_false = !cond_is_null && !cond_is_true;
             }
         }
@@ -975,12 +975,12 @@ private:
         else if (cond_is_false || cond_is_null)
             return castColumn(column2, result_type);
 
-        if (const auto * nullable = checkAndGetColumn<ColumnNullable>(*not_const_condition))
+        if (const auto * nullable = checkAndGetColumn<ColumnNullable>(&*not_const_condition))
         {
             ColumnPtr new_cond_column = nullable->getNestedColumnPtr();
             size_t column_size = arg_cond.column->size();
 
-            if (checkAndGetColumn<ColumnUInt8>(*new_cond_column))
+            if (checkAndGetColumn<ColumnUInt8>(&*new_cond_column))
             {
                 auto nested_column_copy = new_cond_column->cloneResized(new_cond_column->size());
                 typeid_cast<ColumnUInt8 *>(nested_column_copy.get())->applyZeroMap(nullable->getNullMapData());
@@ -1027,12 +1027,12 @@ private:
     /// Const(size = 0, Int32(size = 1))
     static ColumnPtr recursiveGetNestedColumnWithoutNullable(const ColumnPtr & column)
     {
-        if (const auto * nullable = checkAndGetColumn<ColumnNullable>(*column))
+        if (const auto * nullable = checkAndGetColumn<ColumnNullable>(&*column))
         {
             /// Nullable cannot contain Nullable
             return nullable->getNestedColumnPtr();
         }
-        else if (const auto * column_const = checkAndGetColumn<ColumnConst>(*column))
+        else if (const auto * column_const = checkAndGetColumn<ColumnConst>(&*column))
         {
             /// Save Constant, but remove Nullable
             return ColumnConst::create(recursiveGetNestedColumnWithoutNullable(column_const->getDataColumnPtr()), column->size());
@@ -1051,8 +1051,8 @@ private:
         const ColumnWithTypeAndName & arg_then = arguments[1];
         const ColumnWithTypeAndName & arg_else = arguments[2];
 
-        const auto * then_is_nullable = checkAndGetColumn<ColumnNullable>(*arg_then.column);
-        const auto * else_is_nullable = checkAndGetColumn<ColumnNullable>(*arg_else.column);
+        const auto * then_is_nullable = checkAndGetColumn<ColumnNullable>(&*arg_then.column);
+        const auto * else_is_nullable = checkAndGetColumn<ColumnNullable>(&*arg_else.column);
 
         if (!then_is_nullable && !else_is_nullable)
             return nullptr;

--- a/src/Functions/isNotNull.cpp
+++ b/src/Functions/isNotNull.cpp
@@ -46,7 +46,7 @@ public:
 
         if (isVariant(elem.type))
         {
-            const auto & discriminators = checkAndGetColumn<ColumnVariant>(*elem.column)->getLocalDiscriminators();
+            const auto & discriminators = checkAndGetColumn<ColumnVariant>(*elem.column).getLocalDiscriminators();
             auto res = DataTypeUInt8().createColumn();
             auto & data = typeid_cast<ColumnUInt8 &>(*res).getData();
             data.resize(discriminators.size());
@@ -57,17 +57,17 @@ public:
 
         if (elem.type->isLowCardinalityNullable())
         {
-            const auto * low_cardinality_column = checkAndGetColumn<ColumnLowCardinality>(*elem.column);
-            const size_t null_index = low_cardinality_column->getDictionary().getNullValueIndex();
+            const auto & low_cardinality_column = checkAndGetColumn<ColumnLowCardinality>(*elem.column);
+            const size_t null_index = low_cardinality_column.getDictionary().getNullValueIndex();
             auto res = DataTypeUInt8().createColumn();
             auto & data = typeid_cast<ColumnUInt8 &>(*res).getData();
-            data.resize(low_cardinality_column->size());
-            for (size_t i = 0; i != low_cardinality_column->size(); ++i)
-                data[i] = (low_cardinality_column->getIndexAt(i) != null_index);
+            data.resize(low_cardinality_column.size());
+            for (size_t i = 0; i != low_cardinality_column.size(); ++i)
+                data[i] = (low_cardinality_column.getIndexAt(i) != null_index);
             return res;
         }
 
-        if (const auto * nullable = checkAndGetColumn<ColumnNullable>(*elem.column))
+        if (const auto * nullable = checkAndGetColumn<ColumnNullable>(&*elem.column))
         {
             /// Return the negated null map.
             auto res_column = ColumnUInt8::create(input_rows_count);

--- a/src/Functions/isNull.cpp
+++ b/src/Functions/isNull.cpp
@@ -48,7 +48,7 @@ public:
 
         if (isVariant(elem.type))
         {
-            const auto & discriminators = checkAndGetColumn<ColumnVariant>(*elem.column)->getLocalDiscriminators();
+            const auto & discriminators = checkAndGetColumn<ColumnVariant>(*elem.column).getLocalDiscriminators();
             auto res = DataTypeUInt8().createColumn();
             auto & data = typeid_cast<ColumnUInt8 &>(*res).getData();
             data.reserve(discriminators.size());
@@ -59,17 +59,17 @@ public:
 
         if (elem.type->isLowCardinalityNullable())
         {
-            const auto * low_cardinality_column = checkAndGetColumn<ColumnLowCardinality>(*elem.column);
-            size_t null_index = low_cardinality_column->getDictionary().getNullValueIndex();
+            const auto & low_cardinality_column = checkAndGetColumn<ColumnLowCardinality>(*elem.column);
+            size_t null_index = low_cardinality_column.getDictionary().getNullValueIndex();
             auto res = DataTypeUInt8().createColumn();
             auto & data = typeid_cast<ColumnUInt8 &>(*res).getData();
-            data.reserve(low_cardinality_column->size());
-            for (size_t i = 0; i != low_cardinality_column->size(); ++i)
-                data.push_back(low_cardinality_column->getIndexAt(i) == null_index);
+            data.reserve(low_cardinality_column.size());
+            for (size_t i = 0; i != low_cardinality_column.size(); ++i)
+                data.push_back(low_cardinality_column.getIndexAt(i) == null_index);
             return res;
         }
 
-        if (const auto * nullable = checkAndGetColumn<ColumnNullable>(*elem.column))
+        if (const auto * nullable = checkAndGetColumn<ColumnNullable>(&*elem.column))
         {
             /// Merely return the embedded null map.
             return nullable->getNullMapColumnPtr();

--- a/src/Functions/minSampleSize.cpp
+++ b/src/Functions/minSampleSize.cpp
@@ -102,14 +102,14 @@ struct ContinuousImpl
         auto baseline_argument = arguments[0];
         baseline_argument.column = baseline_argument.column->convertToFullColumnIfConst();
         auto baseline_column_untyped = castColumnAccurate(baseline_argument, float_64_type);
-        const auto * baseline_column = checkAndGetColumn<ColumnVector<Float64>>(*baseline_column_untyped);
-        const auto & baseline_column_data = baseline_column->getData();
+        const auto & baseline_column = checkAndGetColumn<ColumnVector<Float64>>(*baseline_column_untyped);
+        const auto & baseline_column_data = baseline_column.getData();
 
         auto sigma_argument = arguments[1];
         sigma_argument.column = sigma_argument.column->convertToFullColumnIfConst();
         auto sigma_column_untyped = castColumnAccurate(sigma_argument, float_64_type);
-        const auto * sigma_column = checkAndGetColumn<ColumnVector<Float64>>(*sigma_column_untyped);
-        const auto & sigma_column_data = sigma_column->getData();
+        const auto & sigma_column = checkAndGetColumn<ColumnVector<Float64>>(*sigma_column_untyped);
+        const auto & sigma_column_data = sigma_column.getData();
 
         const IColumn & col_mde = *arguments[2].column;
         const IColumn & col_power = *arguments[3].column;

--- a/src/Functions/multiIf.cpp
+++ b/src/Functions/multiIf.cpp
@@ -198,7 +198,7 @@ public:
                 if (cond_col->onlyNull())
                     continue;
 
-                if (const auto * column_const = checkAndGetColumn<ColumnConst>(*cond_col))
+                if (const auto * column_const = checkAndGetColumn<ColumnConst>(&*cond_col))
                 {
                     Field value = column_const->getField();
 

--- a/src/Functions/readWkt.cpp
+++ b/src/Functions/readWkt.cpp
@@ -51,14 +51,14 @@ public:
 
     ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr & /*result_type*/, size_t input_rows_count) const override
     {
-        const auto * column_string = checkAndGetColumn<ColumnString>(arguments[0].column.get());
+        const auto & column_string = checkAndGetColumn<ColumnString>(*arguments[0].column);
 
         Serializer serializer;
         Geometry geometry;
 
         for (size_t i = 0; i < input_rows_count; ++i)
         {
-            const auto & str = column_string->getDataAt(i).toString();
+            const auto & str = column_string.getDataAt(i).toString();
             boost::geometry::read_wkt(str, geometry);
             serializer.add(geometry);
         }

--- a/src/Functions/repeat.cpp
+++ b/src/Functions/repeat.cpp
@@ -238,9 +238,9 @@ public:
                 {
                     using DataType = std::decay_t<decltype(type)>;
                     using T = typename DataType::FieldType;
-                    const ColumnVector<T> * column = checkAndGetColumn<ColumnVector<T>>(col_num.get());
+                    const ColumnVector<T> & column = checkAndGetColumn<ColumnVector<T>>(*col_num);
                     auto col_res = ColumnString::create();
-                    RepeatImpl::vectorStrVectorRepeat(col->getChars(), col->getOffsets(), col_res->getChars(), col_res->getOffsets(), column->getData());
+                    RepeatImpl::vectorStrVectorRepeat(col->getChars(), col->getOffsets(), col_res->getChars(), col_res->getOffsets(), column.getData());
                     res = std::move(col_res);
                     return true;
                 }))
@@ -258,9 +258,9 @@ public:
                 {
                     using DataType = std::decay_t<decltype(type)>;
                     using T = typename DataType::FieldType;
-                    const ColumnVector<T> * column = checkAndGetColumn<ColumnVector<T>>(col_num.get());
+                    const ColumnVector<T> & column = checkAndGetColumn<ColumnVector<T>>(*col_num);
                     auto col_res = ColumnString::create();
-                    RepeatImpl::constStrVectorRepeat(copy_str, col_res->getChars(), col_res->getOffsets(), column->getData());
+                    RepeatImpl::constStrVectorRepeat(copy_str, col_res->getChars(), col_res->getOffsets(), column.getData());
                     res = std::move(col_res);
                     return true;
                 }))

--- a/src/Functions/seriesOutliersDetectTukey.cpp
+++ b/src/Functions/seriesOutliersDetectTukey.cpp
@@ -61,10 +61,10 @@ public:
     ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr &, size_t input_rows_count) const override
     {
         ColumnPtr col = arguments[0].column;
-        const ColumnArray * col_arr = checkAndGetColumn<ColumnArray>(col.get());
+        const ColumnArray & col_arr = checkAndGetColumn<ColumnArray>(*col);
 
-        const IColumn & arr_data = col_arr->getData();
-        const ColumnArray::Offsets & arr_offsets = col_arr->getOffsets();
+        const IColumn & arr_data = col_arr.getData();
+        const ColumnArray::Offsets & arr_offsets = col_arr.getOffsets();
 
         ColumnPtr col_res;
         if (input_rows_count == 0)

--- a/src/Functions/seriesPeriodDetectFFT.cpp
+++ b/src/Functions/seriesPeriodDetectFFT.cpp
@@ -61,10 +61,10 @@ public:
     ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr &, size_t input_rows_count) const override
     {
         ColumnPtr array_ptr = arguments[0].column;
-        const ColumnArray * array = checkAndGetColumn<ColumnArray>(array_ptr.get());
+        const ColumnArray & array = checkAndGetColumn<ColumnArray>(*array_ptr);
 
-        const IColumn & src_data = array->getData();
-        const ColumnArray::Offsets & offsets = array->getOffsets();
+        const IColumn & src_data = array.getData();
+        const ColumnArray::Offsets & offsets = array.getOffsets();
 
         auto res = ColumnFloat64::create(input_rows_count);
         auto & res_data = res->getData();

--- a/src/Functions/space.cpp
+++ b/src/Functions/space.cpp
@@ -57,14 +57,14 @@ public:
     template <typename DataType>
     bool executeConstant(ColumnPtr col_times, ColumnString::Offsets & res_offsets, ColumnString::Chars & res_chars) const
     {
-        const ColumnConst * col_times_const = checkAndGetColumn<ColumnConst>(col_times.get());
+        const ColumnConst & col_times_const = checkAndGetColumn<ColumnConst>(*col_times);
 
-        const ColumnPtr & col_times_const_internal = col_times_const->getDataColumnPtr();
+        const ColumnPtr & col_times_const_internal = col_times_const.getDataColumnPtr();
         if (!checkAndGetColumn<typename DataType::ColumnType>(col_times_const_internal.get()))
             return false;
 
         using T = typename DataType::FieldType;
-        T times = col_times_const->getValue<T>();
+        T times = col_times_const.getValue<T>();
 
         if (times < 1)
             times = 0;

--- a/src/Functions/toStartOfInterval.cpp
+++ b/src/Functions/toStartOfInterval.cpp
@@ -164,7 +164,7 @@ private:
 
         if (isDateTime64(time_column_type))
         {
-            const auto * time_column_vec = checkAndGetColumn<ColumnDateTime64>(time_column_col);
+            const auto * time_column_vec = checkAndGetColumn<ColumnDateTime64>(&time_column_col);
             auto scale = assert_cast<const DataTypeDateTime64 &>(time_column_type).getScale();
 
             if (time_column_vec)
@@ -172,13 +172,13 @@ private:
         }
         else if (isDateTime(time_column_type))
         {
-            const auto * time_column_vec = checkAndGetColumn<ColumnDateTime>(time_column_col);
+            const auto * time_column_vec = checkAndGetColumn<ColumnDateTime>(&time_column_col);
             if (time_column_vec)
                 return dispatchForIntervalColumn(assert_cast<const DataTypeDateTime &>(time_column_type), *time_column_vec, interval_column, result_type, time_zone);
         }
         else if (isDate(time_column_type))
         {
-            const auto * time_column_vec = checkAndGetColumn<ColumnDate>(time_column_col);
+            const auto * time_column_vec = checkAndGetColumn<ColumnDate>(&time_column_col);
             if (time_column_vec)
                 return dispatchForIntervalColumn(assert_cast<const DataTypeDate &>(time_column_type), *time_column_vec, interval_column, result_type, time_zone);
         }

--- a/src/Functions/ztest.cpp
+++ b/src/Functions/ztest.cpp
@@ -98,23 +98,23 @@ public:
         static const auto uint64_data_type = std::make_shared<DataTypeNumber<UInt64>>();
 
         auto column_successes_x = castColumnAccurate(arguments[0], uint64_data_type);
-        const auto & data_successes_x = checkAndGetColumn<ColumnVector<UInt64>>(column_successes_x.get())->getData();
+        const auto & data_successes_x = checkAndGetColumn<ColumnVector<UInt64>>(*column_successes_x).getData();
 
         auto column_successes_y = castColumnAccurate(arguments[1], uint64_data_type);
-        const auto & data_successes_y = checkAndGetColumn<ColumnVector<UInt64>>(column_successes_y.get())->getData();
+        const auto & data_successes_y = checkAndGetColumn<ColumnVector<UInt64>>(*column_successes_y).getData();
 
         auto column_trials_x = castColumnAccurate(arguments[2], uint64_data_type);
-        const auto & data_trials_x = checkAndGetColumn<ColumnVector<UInt64>>(column_trials_x.get())->getData();
+        const auto & data_trials_x = checkAndGetColumn<ColumnVector<UInt64>>(*column_trials_x).getData();
 
         auto column_trials_y = castColumnAccurate(arguments[3], uint64_data_type);
-        const auto & data_trials_y = checkAndGetColumn<ColumnVector<UInt64>>(column_trials_y.get())->getData();
+        const auto & data_trials_y = checkAndGetColumn<ColumnVector<UInt64>>(*column_trials_y).getData();
 
         static const auto float64_data_type = std::make_shared<DataTypeNumber<Float64>>();
 
         auto column_confidence_level = castColumnAccurate(arguments[4], float64_data_type);
-        const auto & data_confidence_level = checkAndGetColumn<ColumnVector<Float64>>(column_confidence_level.get())->getData();
+        const auto & data_confidence_level = checkAndGetColumn<ColumnVector<Float64>>(*column_confidence_level).getData();
 
-        String usevar = checkAndGetColumnConst<ColumnString>(arguments[5].column.get())->getValue<String>();
+        String usevar = checkAndGetColumnConst<ColumnString>(*arguments[5].column).getValue<String>();
 
         if (usevar != UNPOOLED && usevar != POOLED)
             throw Exception{ErrorCodes::BAD_ARGUMENTS,

--- a/src/Interpreters/BloomFilterHash.h
+++ b/src/Interpreters/BloomFilterHash.h
@@ -108,7 +108,7 @@ struct BloomFilterHash
         {
             const auto * array_col = typeid_cast<const ColumnArray *>(column.get());
 
-            if (checkAndGetColumn<ColumnNullable>(array_col->getData()))
+            if (checkAndGetColumn<ColumnNullable>(&array_col->getData()))
                 throw Exception(ErrorCodes::BAD_ARGUMENTS, "Unexpected type {} of bloom filter index.", data_type->getName());
 
             const auto & offsets = array_col->getOffsets();

--- a/src/Interpreters/HashJoin.cpp
+++ b/src/Interpreters/HashJoin.cpp
@@ -216,7 +216,7 @@ static void correctNullabilityInplace(ColumnWithTypeAndName & column, bool nulla
     {
         /// We have to replace values masked by NULLs with defaults.
         if (column.column)
-            if (const auto * nullable_column = checkAndGetColumn<ColumnNullable>(*column.column))
+            if (const auto * nullable_column = checkAndGetColumn<ColumnNullable>(&*column.column))
                 column.column = JoinCommon::filterWithBlanks(column.column, nullable_column->getNullMapColumn().getData(), true);
 
         JoinCommon::removeColumnNullability(column);

--- a/src/Interpreters/InterpreterCheckQuery.cpp
+++ b/src/Interpreters/InterpreterCheckQuery.cpp
@@ -334,10 +334,10 @@ public:
         if ((columns.size() != 3 && columns.size() != 5) || column_position_to_check >= columns.size())
             throw Exception(ErrorCodes::LOGICAL_ERROR, "Wrong number of columns: {}, position {}", columns.size(), column_position_to_check);
 
-        const auto * col = checkAndGetColumn<ColumnUInt8>(columns[column_position_to_check].get());
-        for (size_t i = 0; i < col->size(); ++i)
+        const auto & col = checkAndGetColumn<ColumnUInt8>(*columns[column_position_to_check]);
+        for (size_t i = 0; i < col.size(); ++i)
         {
-            if (col->getElement(i) == 0)
+            if (col.getElement(i) == 0)
             {
                 result_value = 0;
                 return;

--- a/src/Interpreters/MergeJoin.cpp
+++ b/src/Interpreters/MergeJoin.cpp
@@ -80,8 +80,8 @@ int nullableCompareAt(const IColumn & left_column, const IColumn & right_column,
 
     if constexpr (has_left_nulls && has_right_nulls)
     {
-        const auto * left_nullable = checkAndGetColumn<ColumnNullable>(left_column);
-        const auto * right_nullable = checkAndGetColumn<ColumnNullable>(right_column);
+        const auto * left_nullable = checkAndGetColumn<ColumnNullable>(&left_column);
+        const auto * right_nullable = checkAndGetColumn<ColumnNullable>(&right_column);
 
         if (left_nullable && right_nullable)
         {
@@ -99,7 +99,7 @@ int nullableCompareAt(const IColumn & left_column, const IColumn & right_column,
 
     if constexpr (has_left_nulls)
     {
-        if (const auto * left_nullable = checkAndGetColumn<ColumnNullable>(left_column))
+        if (const auto * left_nullable = checkAndGetColumn<ColumnNullable>(&left_column))
         {
             if (left_column.isNullAt(lhs_pos))
                 return null_direction_hint;
@@ -109,7 +109,7 @@ int nullableCompareAt(const IColumn & left_column, const IColumn & right_column,
 
     if constexpr (has_right_nulls)
     {
-        if (const auto * right_nullable = checkAndGetColumn<ColumnNullable>(right_column))
+        if (const auto * right_nullable = checkAndGetColumn<ColumnNullable>(&right_column))
         {
             if (right_column.isNullAt(rhs_pos))
                 return -null_direction_hint;

--- a/src/Interpreters/NullableUtils.cpp
+++ b/src/Interpreters/NullableUtils.cpp
@@ -12,7 +12,7 @@ ColumnPtr extractNestedColumnsAndNullMap(ColumnRawPtrs & key_columns, ConstNullM
     if (key_columns.size() == 1)
     {
         auto & column = key_columns[0];
-        if (const auto * column_nullable = checkAndGetColumn<ColumnNullable>(*column))
+        if (const auto * column_nullable = checkAndGetColumn<ColumnNullable>(&*column))
         {
             null_map_holder = column_nullable->getNullMapColumnPtr();
             null_map = &column_nullable->getNullMapData();
@@ -23,7 +23,7 @@ ColumnPtr extractNestedColumnsAndNullMap(ColumnRawPtrs & key_columns, ConstNullM
     {
         for (auto & column : key_columns)
         {
-            if (const auto * column_nullable = checkAndGetColumn<ColumnNullable>(*column))
+            if (const auto * column_nullable = checkAndGetColumn<ColumnNullable>(&*column))
             {
                 column = &column_nullable->getNestedColumn();
 

--- a/src/Interpreters/SetVariants.cpp
+++ b/src/Interpreters/SetVariants.cpp
@@ -74,7 +74,7 @@ typename SetVariantsTemplate<Variant>::Type SetVariantsTemplate<Variant>::choose
 
     for (const auto & col : key_columns)
     {
-        if (const auto * nullable = checkAndGetColumn<ColumnNullable>(*col))
+        if (const auto * nullable = checkAndGetColumn<ColumnNullable>(&*col))
         {
             nested_key_columns.push_back(&nullable->getNestedColumn());
             has_nullable_key = true;

--- a/src/Interpreters/SetVariants.h
+++ b/src/Interpreters/SetVariants.h
@@ -80,7 +80,7 @@ protected:
 
         for (const auto & col : key_columns)
         {
-            if (const auto * nullable = checkAndGetColumn<ColumnNullable>(*col))
+            if (const auto * nullable = checkAndGetColumn<ColumnNullable>(&*col))
             {
                 actual_columns.push_back(&nullable->getNestedColumn());
                 null_maps.push_back(&nullable->getNullMapColumn());

--- a/src/Processors/Transforms/CheckConstraintsTransform.cpp
+++ b/src/Processors/Transforms/CheckConstraintsTransform.cpp
@@ -57,7 +57,7 @@ void CheckConstraintsTransform::onConsume(Chunk chunk)
 
             auto result_column = res_column.column->convertToFullColumnIfConst()->convertToFullColumnIfLowCardinality();
 
-            if (const auto * column_nullable = checkAndGetColumn<ColumnNullable>(*result_column))
+            if (const auto * column_nullable = checkAndGetColumn<ColumnNullable>(&*result_column))
             {
                 const auto & nested_column = column_nullable->getNestedColumnPtr();
 

--- a/src/Processors/Transforms/MergeJoinTransform.cpp
+++ b/src/Processors/Transforms/MergeJoinTransform.cpp
@@ -48,8 +48,8 @@ int nullableCompareAt(const IColumn & left_column, const IColumn & right_column,
 {
     if constexpr (has_left_nulls && has_right_nulls)
     {
-        const auto * left_nullable = checkAndGetColumn<ColumnNullable>(left_column);
-        const auto * right_nullable = checkAndGetColumn<ColumnNullable>(right_column);
+        const auto * left_nullable = checkAndGetColumn<ColumnNullable>(&left_column);
+        const auto * right_nullable = checkAndGetColumn<ColumnNullable>(&right_column);
 
         if (left_nullable && right_nullable)
         {
@@ -67,7 +67,7 @@ int nullableCompareAt(const IColumn & left_column, const IColumn & right_column,
 
     if constexpr (has_left_nulls)
     {
-        if (const auto * left_nullable = checkAndGetColumn<ColumnNullable>(left_column))
+        if (const auto * left_nullable = checkAndGetColumn<ColumnNullable>(&left_column))
         {
             if (left_nullable->isNullAt(lhs_pos))
                 return null_direction_hint;
@@ -77,7 +77,7 @@ int nullableCompareAt(const IColumn & left_column, const IColumn & right_column,
 
     if constexpr (has_right_nulls)
     {
-        if (const auto * right_nullable = checkAndGetColumn<ColumnNullable>(right_column))
+        if (const auto * right_nullable = checkAndGetColumn<ColumnNullable>(&right_column))
         {
             if (right_nullable->isNullAt(rhs_pos))
                 return -null_direction_hint;

--- a/src/Processors/Transforms/WindowTransform.cpp
+++ b/src/Processors/Transforms/WindowTransform.cpp
@@ -2516,7 +2516,7 @@ struct WindowFunctionNonNegativeDerivative final : public StatefulWindowFunction
         if (ts_scale_multiplier)
         {
             const auto & column = transform->blockAt(transform->current_row.block).input_columns[workspace.argument_column_indices[ARGUMENT_TIMESTAMP]];
-            const auto & curr_timestamp = checkAndGetColumn<DataTypeDateTime64::ColumnType>(column.get())->getInt(transform->current_row.row);
+            const auto & curr_timestamp = checkAndGetColumn<DataTypeDateTime64::ColumnType>(*column).getInt(transform->current_row.row);
 
             Float64 time_elapsed = curr_timestamp - state.previous_timestamp;
             result = (time_elapsed > 0) ? (metric_diff * ts_scale_multiplier / time_elapsed  * interval_duration) : 0;

--- a/src/Storages/MergeTree/MergeTreeIndexBloomFilter.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexBloomFilter.cpp
@@ -865,8 +865,8 @@ void MergeTreeIndexAggregatorBloomFilter::update(const Block & block, size_t * p
         const auto & column_and_type = block.getByName(index_columns_name[column]);
         auto index_column = BloomFilterHash::hashWithColumn(column_and_type.type, column_and_type.column, *pos, max_read_rows);
 
-        const auto & index_col = checkAndGetColumn<ColumnUInt64>(index_column.get());
-        const auto & index_data = index_col->getData();
+        const auto & index_col = checkAndGetColumn<ColumnUInt64>(*index_column);
+        const auto & index_data = index_col.getData();
         for (const auto & hash: index_data)
             column_hashes[column].insert(hash);
     }

--- a/src/Storages/MergeTree/MergeTreeIndexSet.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexSet.cpp
@@ -305,7 +305,7 @@ bool MergeTreeIndexConditionSet::mayBeTrueOnGranule(MergeTreeIndexGranulePtr idx
 
     const NullMap * null_map = nullptr;
 
-    if (const auto * col_nullable = checkAndGetColumn<ColumnNullable>(*column))
+    if (const auto * col_nullable = checkAndGetColumn<ColumnNullable>(&*column))
     {
         col_uint8 = typeid_cast<const ColumnUInt8 *>(&col_nullable->getNestedColumn());
         null_map = &col_nullable->getNullMapData();


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

The only non-mechanical changes are in `IColumn.h` and `FunctionHelpers.h`, no need to review everything else (unless you suspect that I'm trying to sneak a backdoor in here :P ).

`checkAndGetColumn()` returns null pointer if types don't match. Some call sites dereferenced it without checking for null. For most call sites it's obviously fine; e.g. `if (col->isNullable()) checkAndGetColumn<ColumnNullable>(col)` - here types will always match. But occasionally there are bugs, e.g. https://github.com/ClickHouse/ClickHouse/pull/61966 . It would be better to throw than to crash in those cases. Since `checkAndGetColumn()` already does a runtime type check even in release builds, it's easy and cheap to avoid crashing - just add another version of `checkAndGetColumn()` that throws instead of returning null, and use that version at the call sites that dereference the returned pointer without checking. This PR does exactly that.

`checkAndGetColumn()` had two overloads: one taking `IColumn` by pointer, the other by reference. But they both returned a nullable pointer. This PR makes the reference overload return a reference and throw on mismatch, just like `typeid_cast`. Then I manually looked at all ~960 call sites to find the ones that dereference the returned pointer without checking, and made them use the throwing overload.