### PR TITLE
Fix optimize_if_chain_to_multiif const NULL handling

### DIFF
--- a/src/Analyzer/QueryTreePassManager.cpp
+++ b/src/Analyzer/QueryTreePassManager.cpp
@@ -147,7 +147,7 @@ private:
                     continue;
 
                 throw Exception(ErrorCodes::LOGICAL_ERROR,
-                    "Function {} expects {} argument to have {} type but receives {} after running {} pass",
+                    "Function {} expects argument {} to have {} type but receives {} after running {} pass",
                     function->toAST()->formatForErrorMessage(),
                     i + 1,
                     expected_argument_type->getName(),

--- a/src/Functions/if.cpp
+++ b/src/Functions/if.cpp
@@ -1278,16 +1278,16 @@ public:
     /// Get result types by argument types. If the function does not apply to these arguments, throw an exception.
     DataTypePtr getReturnTypeImpl(const DataTypes & arguments) const override
     {
-        if (arguments[0]->onlyNull())
-            return arguments[2];
+        if (!arguments[0]->onlyNull())
+        {
+            if (arguments[0]->isNullable())
+                return getReturnTypeImpl({
+                    removeNullable(arguments[0]), arguments[1], arguments[2]});
 
-        if (arguments[0]->isNullable())
-            return getReturnTypeImpl({
-                removeNullable(arguments[0]), arguments[1], arguments[2]});
-
-        if (!WhichDataType(arguments[0]).isUInt8())
-            throw Exception(ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT, "Illegal type {} of first argument (condition) of function if. "
-                "Must be UInt8.", arguments[0]->getName());
+            if (!WhichDataType(arguments[0]).isUInt8())
+                throw Exception(ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT, "Illegal type {} of first argument (condition) of function if. "
+                    "Must be UInt8.", arguments[0]->getName());
+        }
 
         if (use_variant_when_no_common_type)
             return getLeastSupertypeOrVariant(DataTypes{arguments[1], arguments[2]});

--- a/src/Interpreters/OptimizeIfWithConstantConditionVisitor.cpp
+++ b/src/Interpreters/OptimizeIfWithConstantConditionVisitor.cpp
@@ -27,6 +27,11 @@ static bool tryExtractConstValueFromCondition(const ASTPtr & condition, bool & v
             value = literal->value.get<Int64>();
             return true;
         }
+        if (literal->value.getType() == Field::Types::Null)
+        {
+            value = false;
+            return true;
+        }
     }
 
     /// cast of numeric constant in condition to UInt8

--- a/tests/queries/0_stateless/02944_variant_as_common_type_analyzer.reference
+++ b/tests/queries/0_stateless/02944_variant_as_common_type_analyzer.reference
@@ -1,0 +1,103 @@
+Variant(Array(UInt8), String)	[1,2,3]
+Variant(Array(UInt8), String)	[1,2,3]
+Variant(Array(UInt8), String)	str_1
+Variant(Array(UInt8), String)	str_1
+Variant(Array(UInt8), String)	str_1
+Variant(Array(UInt8), String)	str_1
+Variant(Array(UInt8), String)	str_1
+Variant(Array(UInt8), String)	str_1
+Variant(Array(UInt8), String)	[1,2,3]
+Variant(Array(UInt8), String)	[1,2,3]
+Variant(Array(UInt8), String)	str_1
+Variant(Array(UInt8), String)	str_1
+Variant(Array(UInt8), String)	str_1
+Variant(Array(UInt8), String)	str_1
+Variant(Array(UInt8), String)	str_1
+Variant(Array(UInt8), String)	str_1
+Variant(Array(UInt8), String)	[1,2,3]
+Variant(Array(UInt8), String)	[1,2,3]
+Variant(Array(UInt8), String)	str_1
+Variant(Array(UInt8), String)	str_1
+Variant(Array(UInt8), String)	str_1
+Variant(Array(UInt8), String)	str_1
+Variant(Array(UInt8), String)	str_1
+Variant(Array(UInt8), String)	str_1
+Variant(Array(UInt64), String)	str_0
+Variant(Array(UInt64), String)	str_1
+Variant(Array(UInt64), String)	str_2
+Variant(Array(UInt64), String)	str_3
+Variant(Array(UInt64), String)	str_0
+Variant(Array(UInt64), String)	str_1
+Variant(Array(UInt64), String)	str_2
+Variant(Array(UInt64), String)	str_3
+Variant(Array(UInt64), String)	[0]
+Variant(Array(UInt64), String)	[0,1]
+Variant(Array(UInt64), String)	[0,1,2]
+Variant(Array(UInt64), String)	[0,1,2,3]
+Variant(Array(UInt64), String)	[0]
+Variant(Array(UInt64), String)	[0,1]
+Variant(Array(UInt64), String)	[0,1,2]
+Variant(Array(UInt64), String)	[0,1,2,3]
+Variant(Array(UInt64), String)	str_0
+Variant(Array(UInt64), String)	str_1
+Variant(Array(UInt64), String)	str_2
+Variant(Array(UInt64), String)	str_3
+Variant(Array(UInt64), String)	str_0
+Variant(Array(UInt64), String)	str_1
+Variant(Array(UInt64), String)	str_2
+Variant(Array(UInt64), String)	str_3
+Variant(Array(UInt64), String)	str_0
+Variant(Array(UInt64), String)	str_1
+Variant(Array(UInt64), String)	str_2
+Variant(Array(UInt64), String)	str_3
+Variant(Array(UInt64), String)	str_0
+Variant(Array(UInt64), String)	str_1
+Variant(Array(UInt64), String)	str_2
+Variant(Array(UInt64), String)	str_3
+Variant(Array(UInt64), String)	str_0
+Variant(Array(UInt64), String)	[0,1]
+Variant(Array(UInt64), String)	str_2
+Variant(Array(UInt64), String)	[0,1,2,3]
+Variant(Array(UInt64), String)	str_0
+Variant(Array(UInt64), String)	[0,1]
+Variant(Array(UInt64), String)	str_2
+Variant(Array(UInt64), String)	[0,1,2,3]
+Variant(Array(UInt64), String)	str_0
+Variant(Array(UInt64), String)	[0,1]
+Variant(Array(UInt64), String)	str_2
+Variant(Array(UInt64), String)	[0,1,2,3]
+Variant(Array(UInt64), String)	str_0
+Variant(Array(UInt64), String)	[0,1]
+Variant(Array(UInt64), String)	str_2
+Variant(Array(UInt64), String)	[0,1,2,3]
+Variant(Array(UInt64), String, UInt64)	[0]
+Variant(Array(UInt64), String, UInt64)	1
+Variant(Array(UInt64), String, UInt64)	str_2
+Variant(Array(UInt64), String, UInt64)	[0,1,2,3]
+Variant(Array(UInt64), String, UInt64)	4
+Variant(Array(UInt64), String, UInt64)	str_5
+Variant(Array(UInt64), String, UInt64)	[0]
+Variant(Array(UInt64), String, UInt64)	1
+Variant(Array(UInt64), String, UInt64)	str_2
+Variant(Array(UInt64), String, UInt64)	[0,1,2,3]
+Variant(Array(UInt64), String, UInt64)	4
+Variant(Array(UInt64), String, UInt64)	str_5
+Variant(Array(UInt64), String, UInt64)	[0]
+Variant(Array(UInt64), String, UInt64)	1
+Variant(Array(UInt64), String, UInt64)	str_2
+Variant(Array(UInt64), String, UInt64)	[0,1,2,3]
+Variant(Array(UInt64), String, UInt64)	4
+Variant(Array(UInt64), String, UInt64)	str_5
+Variant(Array(UInt64), String, UInt64)	[0]
+Variant(Array(UInt64), String, UInt64)	1
+Variant(Array(UInt64), String, UInt64)	str_2
+Variant(Array(UInt64), String, UInt64)	[0,1,2,3]
+Variant(Array(UInt64), String, UInt64)	4
+Variant(Array(UInt64), String, UInt64)	str_5
+Array(Variant(String, UInt8))	[1,'str_1',2,'str_2']
+Array(Variant(Array(String), Array(UInt8)))	[[1,2,3],['str_1','str_2','str_3']]
+Array(Variant(Array(UInt8), Array(Variant(Array(String), Array(UInt8)))))	[[[1,2,3],['str_1','str_2','str_3']],[1,2,3]]
+Array(Variant(Array(Array(UInt8)), Array(UInt8)))	[[1,2,3],[[1,2,3]]]
+Map(String, Variant(String, UInt8))	{'a':1,'b':'str_1'}
+Map(String, Variant(Map(String, Variant(String, UInt8)), UInt8))	{'a':1,'b':{'c':2,'d':'str_1'}}
+Map(String, Variant(Array(Array(UInt8)), Array(UInt8), UInt8))	{'a':1,'b':[1,2,3],'c':[[4,5,6]]}

--- a/tests/queries/0_stateless/02944_variant_as_common_type_analyzer.sql
+++ b/tests/queries/0_stateless/02944_variant_as_common_type_analyzer.sql
@@ -1,0 +1,79 @@
+-- this test is just like 02944_variant_as_common_type, but with different expected output, because
+-- analyzer changes some return types. Specifically, if(c, x, y) always casts to the common type of
+-- x and y, even if c is constant.
+set allow_experimental_analyzer=1;
+
+set allow_experimental_variant_type=1;
+set use_variant_as_common_type=1;
+
+select toTypeName(res), if(1, [1,2,3], 'str_1') as res;
+select toTypeName(res), if(1, [1,2,3], 'str_1'::Nullable(String)) as res;
+
+select toTypeName(res), if(0, [1,2,3], 'str_1') as res;
+select toTypeName(res), if(0, [1,2,3], 'str_1'::Nullable(String)) as res;
+
+select toTypeName(res), if(NULL, [1,2,3], 'str_1') as res;
+select toTypeName(res), if(NULL, [1,2,3], 'str_1'::Nullable(String)) as res;
+
+select toTypeName(res), if(materialize(NULL::Nullable(UInt8)), [1,2,3], 'str_1') as res;
+select toTypeName(res), if(materialize(NULL::Nullable(UInt8)), [1,2,3], 'str_1'::Nullable(String)) as res;
+
+select toTypeName(res), if(1, materialize([1,2,3]), 'str_1') as res;
+select toTypeName(res), if(1, materialize([1,2,3]), 'str_1'::Nullable(String)) as res;
+
+select toTypeName(res), if(0, materialize([1,2,3]), 'str_1') as res;
+select toTypeName(res), if(0, materialize([1,2,3]), 'str_1'::Nullable(String)) as res;
+
+select toTypeName(res), if(NULL, materialize([1,2,3]), 'str_1') as res;
+select toTypeName(res), if(NULL, materialize([1,2,3]), 'str_1'::Nullable(String)) as res;
+
+select toTypeName(res), if(materialize(NULL::Nullable(UInt8)), materialize([1,2,3]), 'str_1') as res;
+select toTypeName(res), if(materialize(NULL::Nullable(UInt8)), materialize([1,2,3]), 'str_1'::Nullable(String)) as res;
+
+select toTypeName(res), if(1, [1,2,3], materialize('str_1')) as res;
+select toTypeName(res), if(1, [1,2,3], materialize('str_1')::Nullable(String)) as res;
+
+select toTypeName(res), if(0, [1,2,3], materialize('str_1')) as res;
+select toTypeName(res), if(0, [1,2,3], materialize('str_1')::Nullable(String)) as res;
+
+select toTypeName(res), if(NULL, [1,2,3], materialize('str_1')) as res;
+select toTypeName(res), if(NULL, [1,2,3], materialize('str_1')::Nullable(String)) as res;
+
+select toTypeName(res), if(materialize(NULL::Nullable(UInt8)), [1,2,3], materialize('str_1')) as res;
+select toTypeName(res), if(materialize(NULL::Nullable(UInt8)), [1,2,3], materialize('str_1')::Nullable(String)) as res;
+
+
+select toTypeName(res), if(0, range(number + 1), 'str_' || toString(number)) as res from numbers(4);
+select toTypeName(res), if(0, range(number + 1), ('str_' || toString(number))::Nullable(String)) as res from numbers(4);
+
+select toTypeName(res), if(1, range(number + 1), 'str_' || toString(number)) as res from numbers(4);
+select toTypeName(res), if(1, range(number + 1), ('str_' || toString(number))::Nullable(String)) as res from numbers(4);
+
+select toTypeName(res), if(NULL, range(number + 1), 'str_' || toString(number)) as res from numbers(4);
+select toTypeName(res), if(NULL, range(number + 1), ('str_' || toString(number))::Nullable(String)) as res from numbers(4);
+
+select toTypeName(res), if(materialize(NULL::Nullable(UInt8)), range(number + 1), 'str_' || toString(number)) as res from numbers(4);
+select toTypeName(res), if(materialize(NULL::Nullable(UInt8)), range(number + 1), ('str_' || toString(number))::Nullable(String)) as res from numbers(4);
+
+select toTypeName(res), if(number % 2, range(number + 1), 'str_' || toString(number)) as res from numbers(4);
+select toTypeName(res), if(number % 2, range(number + 1), ('str_' || toString(number))::Nullable(String)) as res from numbers(4);
+
+select toTypeName(res), if(number % 2, range(number + 1), ('str_' || toString(number))::LowCardinality(String)) as res from numbers(4);
+select toTypeName(res), if(number % 2, range(number + 1), ('str_' || toString(number))::LowCardinality(Nullable(String))) as res from numbers(4);
+
+
+select toTypeName(res), multiIf(number % 3 == 0, range(number + 1), number % 3 == 1, number, 'str_' || toString(number)) as res from numbers(6);
+select toTypeName(res), multiIf(number % 3 == 0, range(number + 1), number % 3 == 1, number,  ('str_' || toString(number))::Nullable(String)) as res from numbers(6);
+select toTypeName(res), multiIf(number % 3 == 0, range(number + 1), number % 3 == 1, number, ('str_' || toString(number))::LowCardinality(String)) as res from numbers(6);
+select toTypeName(res), multiIf(number % 3 == 0, range(number + 1), number % 3 == 1, number, ('str_' || toString(number))::LowCardinality(Nullable(String))) as res from numbers(6);
+
+
+select toTypeName(res), array(1, 'str_1', 2, 'str_2') as res;
+select toTypeName(res), array([1, 2, 3], ['str_1', 'str_2', 'str_3']) as res;
+select toTypeName(res), array(array([1, 2, 3], ['str_1', 'str_2', 'str_3']), [1, 2, 3]) as res;
+select toTypeName(res), array([1, 2, 3], [[1, 2, 3]]) as res;
+
+select toTypeName(res), map('a', 1, 'b', 'str_1') as res;
+select toTypeName(res), map('a', 1, 'b', map('c', 2, 'd', 'str_1')) as res;
+select toTypeName(res), map('a', 1, 'b', [1, 2, 3], 'c', [[4, 5, 6]]) as res;
+


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

`if()` had a weird, likely unintentional, special case. `if(x, a, b)` finds the common type for <a ,b>, then casts the result to that type, or throws an error if no common type exists. It does that even if `x` is constant. BUT it doesn't do that if `x` is a constant NULL; instead, it just returns `b` without any checking or casting.

`multiIf()` doesn't have this special case. So the optimization `optimize_if_chain_to_multiif` that converts `if()` to `multiIf()` was sometimes changing types and breaking the query. This PR removes the special handling of constant NULL in `if()`; now it treats constant NULL the same way as constant 0.

This should fix 02100_now64_types_bug