### PR TITLE
[Docs] document `hasXYZ`

### DIFF
--- a/docs/en/sql-reference/functions/other-functions.md
+++ b/docs/en/sql-reference/functions/other-functions.md
@@ -543,11 +543,53 @@ You can get similar result by using the [ternary operator](../../sql-reference/f
 
 Returns 1 if the Float32 and Float64 argument is NaN, otherwise this function 0.
 
-## hasColumnInTable(\[‘hostname’\[, ‘username’\[, ‘password’\]\],\] ‘database’, ‘table’, ‘column’)
+## hasColumnInTable
 
-Given the database name, the table name, and the column name as constant strings, returns 1 if the given column exists, otherwise 0. If parameter `hostname` is given, the check is performed on a remote server.
-If the table does not exist, an exception is thrown.
+Given the database name, the table name, and the column name as constant strings, returns 1 if the given column exists, otherwise 0.
+
+**Syntax**
+
+```sql
+hasColumnInTable(\[‘hostname’\[, ‘username’\[, ‘password’\]\],\] ‘database’, ‘table’, ‘column’)
+```
+
+**Parameters**
+
+- `database` : name of the database. [String literal](../syntax#syntax-string-literal)
+- `table` : name of the table. [String literal](../syntax#syntax-string-literal) 
+- `column` : name of the column. [String literal](../syntax#syntax-string-literal)
+- `hostname` : remote server name to perform the check on. [String literal](../syntax#syntax-string-literal)
+- `username` : username for remote server. [String literal](../syntax#syntax-string-literal)
+- `password` : password for remote server. [String literal](../syntax#syntax-string-literal)
+
+**Returned value**
+
+- `1` if the given column exists.
+- `0`, otherwise. 
+
+**Implementation details**
+
 For elements in a nested data structure, the function checks for the existence of a column. For the nested data structure itself, the function returns 0.
+
+**Example**
+
+Query:
+
+```sql
+SELECT hasColumnInTable('system','metrics','metric')
+```
+
+```response
+1
+```
+
+```sql
+SELECT hasColumnInTable('system','metrics','non-existing_column')
+```
+
+```response
+0
+```
 
 ## bar
 

--- a/docs/en/sql-reference/functions/other-functions.md
+++ b/docs/en/sql-reference/functions/other-functions.md
@@ -593,7 +593,7 @@ SELECT hasColumnInTable('system','metrics','non-existing_column')
 
 ## hasThreadFuzzer
 
-Returns whether Thread Fuzzer is effective. It can be used in tests to prevent too long runs.
+Returns whether Thread Fuzzer is effective. It can be used in tests to prevent runs from being too long.
 
 **Syntax**
 

--- a/docs/en/sql-reference/functions/other-functions.md
+++ b/docs/en/sql-reference/functions/other-functions.md
@@ -591,6 +591,16 @@ SELECT hasColumnInTable('system','metrics','non-existing_column')
 0
 ```
 
+## hasThreadFuzzer
+
+Returns whether Thread Fuzzer is effective. It can be used in tests to prevent too long runs.
+
+**Syntax**
+
+```sql
+hasThreadFuzzer();
+```
+
 ## bar
 
 Builds a bar chart.

--- a/docs/en/sql-reference/functions/string-search-functions.md
+++ b/docs/en/sql-reference/functions/string-search-functions.md
@@ -662,8 +662,10 @@ Type: `UInt8`.
 
 **Examples**
 
+Query:
+
 ``` sql
-SELECT hasSubsequence('garbage', 'arg') ;
+SELECT hasSubsequence('garbage', 'arg');
 ```
 
 Result:
@@ -678,13 +680,115 @@ Result:
 
 Like [hasSubsequence](#hasSubsequence) but searches case-insensitively.
 
+**Syntax**
+
+``` sql
+hasSubsequence(haystack, needle)
+```
+
+**Arguments**
+
+- `haystack` — String in which the search is performed. [String](../../sql-reference/syntax.md#syntax-string-literal).
+- `needle` — Subsequence to be searched. [String](../../sql-reference/syntax.md#syntax-string-literal).
+
+**Returned values**
+
+- 1, if needle is a subsequence of haystack.
+- 0, otherwise.
+
+Type: `UInt8`.
+
+**Examples**
+
+Query:
+
+``` sql
+SELECT hasSubsequenceCaseInsensitive('garbage', 'ARG');
+```
+
+Result:
+
+``` text
+┌─hasSubsequenceCaseInsensitive('garbage', 'ARG')─┐
+│                                               1 │
+└─────────────────────────────────────────────────┘
+```
+
 ## hasSubsequenceUTF8
 
 Like [hasSubsequence](#hasSubsequence) but assumes `haystack` and `needle` are UTF-8 encoded strings.
 
+**Syntax**
+
+``` sql
+hasSubsequenceUTF8(haystack, needle)
+```
+
+**Arguments**
+
+- `haystack` — String in which the search is performed. UTF-8 encoded [String](../../sql-reference/syntax.md#syntax-string-literal).
+- `needle` — Subsequence to be searched. UTF-8 encoded [String](../../sql-reference/syntax.md#syntax-string-literal).
+
+**Returned values**
+
+- 1, if needle is a subsequence of haystack.
+- 0, otherwise.
+
+Type: `UInt8`.
+
+Query:
+
+**Examples**
+
+``` sql
+select hasSubsequenceUTF8('ClickHouse - столбцовая система управления базами данных', 'система');
+```
+
+Result:
+
+``` text
+┌─hasSubsequenceUTF8('ClickHouse - столбцовая система управления базами данных', 'система')─┐
+│                                                                                         1 │
+└───────────────────────────────────────────────────────────────────────────────────────────┘
+```
+
 ## hasSubsequenceCaseInsensitiveUTF8
 
 Like [hasSubsequenceUTF8](#hasSubsequenceUTF8) but searches case-insensitively.
+
+**Syntax**
+
+``` sql
+hasSubsequenceCaseInsensitiveUTF8(haystack, needle)
+```
+
+**Arguments**
+
+- `haystack` — String in which the search is performed. UTF-8 encoded [String](../../sql-reference/syntax.md#syntax-string-literal).
+- `needle` — Subsequence to be searched. UTF-8 encoded [String](../../sql-reference/syntax.md#syntax-string-literal).
+
+**Returned values**
+
+- 1, if needle is a subsequence of haystack.
+- 0, otherwise.
+
+Type: `UInt8`.
+
+**Examples**
+
+Query:
+
+``` sql
+select hasSubsequenceCaseInsensitiveUTF8('ClickHouse - столбцовая система управления базами данных', 'СИСТЕМА');
+```
+
+Result:
+
+``` text
+┌─hasSubsequenceCaseInsensitiveUTF8('ClickHouse - столбцовая система управления базами данных', 'СИСТЕМА')─┐
+│                                                                                                        1 │
+└──────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+```
 
 ## hasToken
 

--- a/docs/en/sql-reference/functions/string-search-functions.md
+++ b/docs/en/sql-reference/functions/string-search-functions.md
@@ -683,7 +683,7 @@ Like [hasSubsequence](#hasSubsequence) but searches case-insensitively.
 **Syntax**
 
 ``` sql
-hasSubsequence(haystack, needle)
+hasSubsequenceCaseInsensitive(haystack, needle)
 ```
 
 **Arguments**
@@ -908,7 +908,7 @@ Returns 1 if a given token is present in a haystack, 0 otherwise. Ignores case a
 **Syntax**
 
 ```sql
-hasTokenCaseInsensitive(haystack, token)
+hasTokenCaseInsensitiveOrNull(haystack, token)
 ```
 
 **Parameters**

--- a/docs/en/sql-reference/functions/string-search-functions.md
+++ b/docs/en/sql-reference/functions/string-search-functions.md
@@ -685,3 +685,154 @@ Like [hasSubsequence](#hasSubsequence) but assumes `haystack` and `needle` are U
 ## hasSubsequenceCaseInsensitiveUTF8
 
 Like [hasSubsequenceUTF8](#hasSubsequenceUTF8) but searches case-insensitively.
+
+## hasToken
+
+Returns 1 if a given token is present in a haystack, or 0 otherwise.
+
+**Syntax**
+
+```sql
+hasToken(haystack, token)
+```
+
+**Parameters**
+
+- `haystack`: String in which the search is performed. [String](../../sql-reference/syntax.md#syntax-string-literal).
+- `token`: Maximal length substring between two non alphanumeric ASCII characters (or boundaries of haystack).
+
+**Returned value**
+
+- 1, if the token is present in the haystack.
+- 0, if the token is not present.
+
+**Implementation details**
+
+Token must be a constant string. Supported by tokenbf_v1 index specialization.
+
+**Example**
+
+Query:
+
+```sql
+SELECT hasToken('Hello World','Hello');
+```
+
+```response
+1
+```
+
+## hasTokenOrNull
+
+Returns 1 if a given token is present, 0 if not present, and null if the token is ill-formed.
+
+**Syntax**
+
+```sql
+hasTokenOrNull(haystack, token)
+```
+
+**Parameters**
+
+- `haystack`: String in which the search is performed. [String](../../sql-reference/syntax.md#syntax-string-literal).
+- `token`: Maximal length substring between two non alphanumeric ASCII characters (or boundaries of haystack).
+
+**Returned value**
+
+- 1, if the token is present in the haystack.
+- 0, if the token is not present in the haystack.
+- null, if the token is ill-formed.
+
+**Implementation details**
+
+Token must be a constant string. Supported by tokenbf_v1 index specialization.
+
+**Example**
+
+Where `hasToken` would throw an error for an ill-formed token, `hasTokenOrNull` returns `null` for an ill-formed token.
+
+Query:
+
+```sql
+SELECT hasTokenOrNull('Hello World','Hello,World');
+```
+
+```response
+null
+```
+
+## hasTokenCaseInsensitive
+
+Returns 1 if a given token is present in a haystack, 0 otherwise. Ignores case.
+
+**Syntax**
+
+```sql
+hasTokenCaseInsensitive(haystack, token)
+```
+
+**Parameters**
+
+- `haystack`: String in which the search is performed. [String](../../sql-reference/syntax.md#syntax-string-literal).
+- `token`: Maximal length substring between two non alphanumeric ASCII characters (or boundaries of haystack).
+
+**Returned value**
+
+- 1, if the token is present in the haystack.
+- 0, otherwise.
+
+**Implementation details**
+
+Token must be a constant string. Supported by tokenbf_v1 index specialization.
+
+**Example**
+
+Query:
+
+```sql
+SELECT hasTokenCaseInsensitive('Hello World','hello');
+```
+
+```response
+1
+```
+
+## hasTokenCaseInsensitiveOrNull
+
+Returns 1 if a given token is present in a haystack, 0 otherwise. Ignores case and returns null if the token is ill-formed.
+
+**Syntax**
+
+```sql
+hasTokenCaseInsensitive(haystack, token)
+```
+
+**Parameters**
+
+- `haystack`: String in which the search is performed. [String](../../sql-reference/syntax.md#syntax-string-literal).
+- `token`: Maximal length substring between two non alphanumeric ASCII characters (or boundaries of haystack).
+
+**Returned value**
+
+- 1, if the token is present in the haystack.
+- 0, if token is not present.
+- null, if the token is ill-formed.
+
+**Implementation details**
+
+Token must be a constant string. Supported by tokenbf_v1 index specialization.
+
+**Example**
+
+
+Where `hasTokenCaseInsensitive` would throw an error for an ill-formed token, `hasTokenCaseInsensitiveOrNull` returns `null` for an ill-formed token.
+
+Query:
+
+```sql
+SELECT hasTokenCaseInsensitiveOrNull('Hello World','hello,world');
+```
+
+```response
+null
+```

--- a/utils/check-style/aspell-ignore/en/aspell-dict.txt
+++ b/utils/check-style/aspell-ignore/en/aspell-dict.txt
@@ -1673,6 +1673,7 @@ hasSubsequenceCaseInsensitiveUTF
 hasSubsequenceUTF
 hasSubstr
 hasToken
+hasThreadFuzzer
 hasTokenCaseInsensitive
 hasTokenCaseInsensitiveOrNull
 hasTokenOrNull


### PR DESCRIPTION
Closes [#1962](https://github.com/ClickHouse/clickhouse-docs/issues/1962) as part of the project to document missing functions, or functions which don't adhere to the documentation template for functions (missing syntax, example etc).

### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Documentation entry for user-facing changes

- [X] Documentation is written (mandatory for new features)
- [X] hasColumnInTable →functions/other (format update needed)
- [X] hasSubsequenceCaseInsensitive →functions/string-search-functions (format update needed)
- [X] hasSubsequenceCaseInsensitiveUTF8→ functions/string-search-functions (format update needed)
- [X] hasSubsequenceUTF8 →functions/string-search-functions (format update needed)
- [X] hasThreadFuzzer →previously didn't exist yet
- [X] hasToken → previously didn't exist yet
- [X] hasTokenCaseInsensitive →previously didn't exist yet
- [X] hasTokenCaseInsensitiveOrNull →previously didn't exist yet
- [X] hasTokenOrNull →previously didn't exist yet