### PR TITLE
Fix restoring parts while readonly

### DIFF
--- a/src/Common/randomDelay.cpp
+++ b/src/Common/randomDelay.cpp
@@ -1,0 +1,39 @@
+#include <Common/randomDelay.h>
+
+#include <Common/logger_useful.h>
+#include <Common/randomNumber.h>
+#include <base/sleep.h>
+
+
+void randomDelayForMaxMilliseconds(uint64_t milliseconds, LoggerPtr log, const char * start_of_message)
+{
+    if (milliseconds)
+    {
+        auto count = randomNumber() % milliseconds;
+
+        if (log)
+        {
+            if (start_of_message && !*start_of_message)
+                start_of_message = nullptr;
+
+            LOG_TEST(log, "{}{}Sleeping for {} milliseconds",
+                     (start_of_message ? start_of_message : ""),
+                     (start_of_message ? ": " : ""),
+                     count);
+        }
+
+        sleepForMilliseconds(count);
+
+        if (log)
+        {
+            LOG_TEST(log, "{}{}Awaking after sleeping",
+                     (start_of_message ? start_of_message : ""),
+                     (start_of_message ? ": " : ""));
+        }
+    }
+}
+
+void randomDelayForMaxSeconds(uint64_t seconds, LoggerPtr log, const char * start_of_message)
+{
+    randomDelayForMaxMilliseconds(seconds * 1000, log, start_of_message);
+}

--- a/src/Common/randomDelay.h
+++ b/src/Common/randomDelay.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include <Common/Logger.h>
+
+/// Sleeps for random duration between 0 and a specified number of milliseconds, optionally outputs a logging message about that.
+/// This function can be used to add random delays in tests.
+void randomDelayForMaxMilliseconds(uint64_t milliseconds, LoggerPtr log = nullptr, const char * start_of_message = nullptr);
+void randomDelayForMaxSeconds(uint64_t seconds, LoggerPtr log = nullptr, const char * start_of_message = nullptr);

--- a/src/Storages/MergeTree/DataPartsExchange.cpp
+++ b/src/Storages/MergeTree/DataPartsExchange.cpp
@@ -16,6 +16,7 @@
 #include <Storages/MergeTree/DataPartStorageOnDiskFull.h>
 #include <Common/CurrentMetrics.h>
 #include <Common/NetException.h>
+#include <Common/randomDelay.h>
 #include <Disks/IO/createReadBufferFromFileBase.h>
 #include <base/scope_guard.h>
 #include <Poco/Net/HTTPRequest.h>
@@ -119,6 +120,10 @@ void Service::processQuery(const HTMLForm & params, ReadBuffer & /*body*/, Write
     response.addCookie({"server_protocol_version", toString(std::min(client_protocol_version, REPLICATION_PROTOCOL_VERSION_WITH_METADATA_VERSION))});
 
     LOG_TRACE(log, "Sending part {}", part_name);
+
+    static const auto test_delay = data.getContext()->getConfigRef().getUInt64("test.data_parts_exchange.delay_before_sending_part_ms", 0);
+    if (test_delay)
+        randomDelayForMaxMilliseconds(test_delay, log, "DataPartsExchange: Before sending part");
 
     MergeTreeData::DataPartPtr part;
 

--- a/src/Storages/MergeTree/ReplicatedMergeTreeSink.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeSink.cpp
@@ -799,8 +799,8 @@ std::pair<std::vector<String>, bool> ReplicatedMergeTreeSinkImpl<async_insert>::
                 throw Exception(
                     ErrorCodes::TABLE_IS_READ_ONLY, "Table is in readonly mode due to shutdown: replica_path={}", storage.replica_path);
 
-            /// When we attach existing parts it's okay to be in read-only mode
-            /// For example during RESTORE REPLICA.
+            /// Usually parts should not be attached in read-only mode. So we retry until the table is not read-only.
+            /// However there is one case when it's necessary to attach in read-only mode - during execution of the RESTORE REPLICA command.
             if (!allow_attach_while_readonly)
             {
                 retries_ctl.setUserError(

--- a/src/Storages/MergeTree/ReplicatedMergeTreeSink.h
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeSink.h
@@ -45,7 +45,8 @@ public:
         ContextPtr context_,
         // special flag to determine the ALTER TABLE ATTACH PART without the query context,
         // needed to set the special LogEntryType::ATTACH_PART
-        bool is_attach_ = false);
+        bool is_attach_ = false,
+        bool allow_attach_while_readonly_ = false);
 
     ~ReplicatedMergeTreeSinkImpl() override;
 
@@ -93,8 +94,7 @@ private:
         const ZooKeeperWithFaultInjectionPtr & zookeeper,
         MergeTreeData::MutableDataPartPtr & part,
         const BlockIDsType & block_id,
-        size_t replicas_num,
-        bool writing_existing_part);
+        size_t replicas_num);
 
 
     /// Wait for quorum to be satisfied on path (quorum_path) form part (part_name)
@@ -123,6 +123,7 @@ private:
     UInt64 cache_version = 0;
 
     bool is_attach = false;
+    bool allow_attach_while_readonly = false;
     bool quorum_parallel = false;
     const bool deduplicate = true;
     bool last_block_is_duplicate = false;

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -18,6 +18,7 @@
 #include <Common/typeid_cast.h>
 #include <Common/ThreadFuzzer.h>
 #include <Common/FailPoint.h>
+#include <Common/randomDelay.h>
 
 #include <Core/ServerUUID.h>
 
@@ -3093,6 +3094,10 @@ void StorageReplicatedMergeTree::cloneReplica(const String & source_replica, Coo
     Strings active_parts = get_part_set.getParts();
 
     /// Remove local parts if source replica does not have them, because such parts will never be fetched by other replicas.
+    static const auto test_delay = getContext()->getConfigRef().getUInt64("test.clone_replica.delay_before_removing_local_parts_ms", 0);
+    if (test_delay)
+        randomDelayForMaxMilliseconds(test_delay, log.load(), "cloneReplica: Before removing local parts");
+
     Strings local_parts_in_zk = zookeeper->getChildren(fs::path(replica_path) / "parts");
     Strings parts_to_remove_from_zk;
 

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -6512,7 +6512,7 @@ PartitionCommandsResultInfo StorageReplicatedMergeTree::attachPartition(
     /// TODO Allow to use quorum here.
     ReplicatedMergeTreeSink output(*this, metadata_snapshot, /* quorum */ 0, /* quorum_timeout_ms */ 0, /* max_parts_per_block */ 0,
                                    /* quorum_parallel */ false, query_context->getSettingsRef().insert_deduplicate,
-                                   /* majority_quorum */ false, query_context, /*is_attach*/true);
+                                   /* majority_quorum */ false, query_context, /* is_attach */ true, /* allow_attach_while_readonly */ true);
 
     for (size_t i = 0; i < loaded_parts.size(); ++i)
     {
@@ -10500,7 +10500,11 @@ void StorageReplicatedMergeTree::restoreDataFromBackup(RestorerFromBackup & rest
 void StorageReplicatedMergeTree::attachRestoredParts(MutableDataPartsVector && parts)
 {
     auto metadata_snapshot = getInMemoryMetadataPtr();
-    auto sink = std::make_shared<ReplicatedMergeTreeSink>(*this, metadata_snapshot, 0, 0, 0, false, false, false,  getContext(), /*is_attach*/true);
+
+    auto sink = std::make_shared<ReplicatedMergeTreeSink>(
+        *this, metadata_snapshot, /* quorum */ 0, /* quorum_timeout_ms */ 0, /* max_parts_per_block */ 0, /* quorum_parallel */ false,
+        /* deduplicate */ false, /* majority_quorum */ false, getContext(), /* is_attach */ true, /* allow_attach_while_readonly */ false);
+
     for (auto part : parts)
         sink->writeExistingPart(part);
 }

--- a/tests/integration/test_backup_restore_on_cluster/configs/cluster.xml
+++ b/tests/integration/test_backup_restore_on_cluster/configs/cluster.xml
@@ -20,21 +20,5 @@
                 </replica>
             </shard>
         </cluster1>
-        <cluster3>
-            <shard>
-                <replica>
-                    <host>node1</host>
-                    <port>9000</port>
-                </replica>
-                <replica>
-                    <host>node2</host>
-                    <port>9000</port>
-                </replica>
-                <replica>
-                    <host>node3</host>
-                    <port>9000</port>
-                </replica>
-            </shard>
-        </cluster3>
     </remote_servers>
 </clickhouse>

--- a/tests/integration/test_backup_restore_on_cluster/configs/cluster3.xml
+++ b/tests/integration/test_backup_restore_on_cluster/configs/cluster3.xml
@@ -1,0 +1,20 @@
+<clickhouse>
+    <remote_servers>
+        <cluster3>
+            <shard>
+                <replica>
+                    <host>node1</host>
+                    <port>9000</port>
+                </replica>
+                <replica>
+                    <host>node2</host>
+                    <port>9000</port>
+                </replica>
+                <replica>
+                    <host>node3</host>
+                    <port>9000</port>
+                </replica>
+            </shard>
+        </cluster3>
+    </remote_servers>
+</clickhouse>

--- a/tests/integration/test_backup_restore_on_cluster/configs/slow_replicated_merge_tree.xml
+++ b/tests/integration/test_backup_restore_on_cluster/configs/slow_replicated_merge_tree.xml
@@ -1,0 +1,10 @@
+<clickhouse>
+    <test>
+        <data_parts_exchange>
+            <delay_before_sending_part_ms>250</delay_before_sending_part_ms>
+        </data_parts_exchange>
+        <clone_replica>
+            <delay_before_removing_local_parts_ms>250</delay_before_removing_local_parts_ms>
+        </clone_replica>
+    </test>
+</clickhouse>

--- a/tests/integration/test_backup_restore_on_cluster/test.py
+++ b/tests/integration/test_backup_restore_on_cluster/test.py
@@ -10,7 +10,8 @@ from helpers.test_tools import TSV, assert_eq_with_retry
 cluster = ClickHouseCluster(__file__)
 
 main_configs = [
-    "configs/remote_servers.xml",
+    "configs/cluster.xml",
+    "configs/cluster3.xml",
     "configs/replicated_access_storage.xml",
     "configs/replicated_user_defined_sql_objects.xml",
     "configs/backups_disk.xml",

--- a/tests/integration/test_backup_restore_on_cluster/test_slow_rmt.py
+++ b/tests/integration/test_backup_restore_on_cluster/test_slow_rmt.py
@@ -96,7 +96,7 @@ def test_replicated_database_async():
 
     node1.query("DROP DATABASE mydb ON CLUSTER 'cluster' SYNC")
 
-    [id, status] = node1.query(
+    id, status = node1.query(
         f"RESTORE DATABASE mydb ON CLUSTER 'cluster' FROM {backup_name} ASYNC"
     ).split("\t")
 

--- a/tests/integration/test_backup_restore_on_cluster/test_slow_rmt.py
+++ b/tests/integration/test_backup_restore_on_cluster/test_slow_rmt.py
@@ -82,7 +82,7 @@ def test_replicated_database_async():
     node1.query("SYSTEM SYNC REPLICA ON CLUSTER 'cluster' mydb.tbl")
 
     backup_name = new_backup_name()
-    [id, status] = node1.query(
+    id, status = node1.query(
         f"BACKUP DATABASE mydb ON CLUSTER 'cluster' TO {backup_name} ASYNC"
     ).split("\t")
 

--- a/tests/integration/test_backup_restore_on_cluster/test_slow_rmt.py
+++ b/tests/integration/test_backup_restore_on_cluster/test_slow_rmt.py
@@ -1,0 +1,119 @@
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+from helpers.test_tools import TSV, assert_eq_with_retry, exec_query_with_retry
+
+
+cluster = ClickHouseCluster(__file__)
+
+main_configs = [
+    "configs/backups_disk.xml",
+    "configs/cluster.xml",
+    "configs/slow_replicated_merge_tree.xml",
+]
+
+user_configs = [
+    "configs/allow_database_types.xml",
+    "configs/zookeeper_retries.xml",
+]
+
+node1 = cluster.add_instance(
+    "node1",
+    main_configs=main_configs,
+    user_configs=user_configs,
+    external_dirs=["/backups/"],
+    macros={"replica": "node1", "shard": "shard1"},
+    with_zookeeper=True,
+)
+
+node2 = cluster.add_instance(
+    "node2",
+    main_configs=main_configs,
+    user_configs=user_configs,
+    external_dirs=["/backups/"],
+    macros={"replica": "node2", "shard": "shard1"},
+    with_zookeeper=True,
+)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def start_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+@pytest.fixture(autouse=True)
+def drop_after_test():
+    try:
+        yield
+    finally:
+        node1.query("DROP DATABASE IF EXISTS mydb ON CLUSTER 'cluster' SYNC")
+
+
+backup_id_counter = 0
+
+
+def new_backup_name():
+    global backup_id_counter
+    backup_id_counter += 1
+    return f"Disk('backups', '{backup_id_counter}')"
+
+
+def test_replicated_database_async():
+    node1.query(
+        "CREATE DATABASE mydb ON CLUSTER 'cluster' ENGINE=Replicated('/clickhouse/path/','{shard}','{replica}')"
+    )
+
+    node1.query("CREATE TABLE mydb.tbl(x UInt8) ENGINE=ReplicatedMergeTree ORDER BY x")
+
+    node1.query(
+        "CREATE TABLE mydb.tbl2(y String) ENGINE=ReplicatedMergeTree ORDER BY y"
+    )
+
+    node2.query("SYSTEM SYNC DATABASE REPLICA mydb")
+
+    node1.query("INSERT INTO mydb.tbl VALUES (1)")
+    node1.query("INSERT INTO mydb.tbl VALUES (22)")
+    node2.query("INSERT INTO mydb.tbl2 VALUES ('a')")
+    node2.query("INSERT INTO mydb.tbl2 VALUES ('bb')")
+    node1.query("SYSTEM SYNC REPLICA ON CLUSTER 'cluster' mydb.tbl")
+
+    backup_name = new_backup_name()
+    [id, status] = node1.query(
+        f"BACKUP DATABASE mydb ON CLUSTER 'cluster' TO {backup_name} ASYNC"
+    ).split("\t")
+
+    assert status == "CREATING_BACKUP\n" or status == "BACKUP_CREATED\n"
+
+    assert_eq_with_retry(
+        node1,
+        f"SELECT status, error FROM system.backups WHERE id='{id}'",
+        TSV([["BACKUP_CREATED", ""]]),
+    )
+
+    node1.query("DROP DATABASE mydb ON CLUSTER 'cluster' SYNC")
+
+    [id, status] = node1.query(
+        f"RESTORE DATABASE mydb ON CLUSTER 'cluster' FROM {backup_name} ASYNC"
+    ).split("\t")
+
+    assert status == "RESTORING\n" or status == "RESTORED\n"
+
+    assert_eq_with_retry(
+        node1,
+        f"SELECT status, error FROM system.backups WHERE id='{id}'",
+        TSV([["RESTORED", ""]]),
+    )
+
+    # exec_query_with_retry() is here because `SYSTEM SYNC REPLICA` can throw `TABLE_IS_READ_ONLY`
+    # if any of these tables didn't start completely yet.
+    exec_query_with_retry(node1, "SYSTEM SYNC REPLICA ON CLUSTER 'cluster' mydb.tbl")
+    exec_query_with_retry(node1, "SYSTEM SYNC REPLICA ON CLUSTER 'cluster' mydb.tbl2")
+
+    assert node1.query("SELECT * FROM mydb.tbl ORDER BY x") == TSV([1, 22])
+    assert node2.query("SELECT * FROM mydb.tbl2 ORDER BY y") == TSV(["a", "bb"])
+    assert node2.query("SELECT * FROM mydb.tbl ORDER BY x") == TSV([1, 22])
+    assert node1.query("SELECT * FROM mydb.tbl2 ORDER BY y") == TSV(["a", "bb"])


### PR DESCRIPTION
### Changelog category:
- Bug Fix

### Changelog entry:
This PR makes `RESTORE ON CLUSTER` wait for each `ReplicatedMergeTree` table to stop being readonly before attaching any restored parts to it. Earlier it didn't wait and it could try to attach some parts at nearly the same time as checking other replicas during the table's startup. In rare cases some parts could be not attached at all during `RESTORE ON CLUSTER` because of that issue.

The issue was found by analyzing a failure of test `test_backup_restore_on_cluster/test.py::test_replicated_database_async` ([see](https://s3.amazonaws.com/clickhouse-test-reports/0/134215e3c3637b89f1f0989dfdbd0d73bbf145e7/integration_tests__release__[1_4].html)).