### PR TITLE
Revert "Resubmit 'Update invalidate_query_response on dictionary startup'"

### DIFF
--- a/src/Interpreters/ExternalLoader.cpp
+++ b/src/Interpreters/ExternalLoader.cpp
@@ -996,14 +996,6 @@ private:
             if (!new_object && !new_exception)
                 throw Exception(ErrorCodes::LOGICAL_ERROR, "No object created and no exception raised for {}", type_name);
 
-            if (!info->object && new_object)
-            {
-                /// If we loaded the object for the first time then we should set `invalidate_query_response` to the current value.
-                /// Otherwise we will immediately try to reload the object again despite the fact that it was just loaded.
-                bool is_modified = new_object->isModified();
-                LOG_TRACE(log, "Object '{}' was{} modified", name, (is_modified ? "" : " not"));
-            }
-
             /// Saving the result of the loading.
             {
                 LoadingGuardForAsyncLoad lock(async, mutex);


### PR DESCRIPTION
Reverts ClickHouse/ClickHouse#62050

Checking as it seems it has broken test_odbc_interaction/test.py::test_sqlite_odbc_hashed_dictionary