### PR TITLE
Fixing NULL random seed for generateRandom with analyzer.

### DIFF
--- a/src/Storages/checkAndGetLiteralArgument.cpp
+++ b/src/Storages/checkAndGetLiteralArgument.cpp
@@ -1,5 +1,6 @@
 #include <Storages/checkAndGetLiteralArgument.h>
 #include <Core/Field.h>
+#include <Parsers/ASTFunction.h>
 
 namespace DB
 {
@@ -12,8 +13,14 @@ namespace ErrorCodes
 template <typename T>
 T checkAndGetLiteralArgument(const ASTPtr & arg, const String & arg_name)
 {
-    if (arg && arg->as<ASTLiteral>())
-        return checkAndGetLiteralArgument<T>(*arg->as<ASTLiteral>(), arg_name);
+    if (arg)
+    {
+        if (const auto * func = arg->as<const ASTFunction>(); func && func->name == "_CAST")
+            return checkAndGetLiteralArgument<T>(func->arguments->children.at(0), arg_name);
+
+        if (arg->as<ASTLiteral>())
+            return checkAndGetLiteralArgument<T>(*arg->as<ASTLiteral>(), arg_name);
+    }
 
     throw Exception(
         ErrorCodes::BAD_ARGUMENTS,

--- a/src/TableFunctions/TableFunctionGenerateRandom.cpp
+++ b/src/TableFunctions/TableFunctionGenerateRandom.cpp
@@ -4,6 +4,7 @@
 #include <Storages/checkAndGetLiteralArgument.h>
 
 #include <Parsers/ASTExpressionList.h>
+#include <Parsers/ASTFunction.h>
 #include <Parsers/ASTLiteral.h>
 
 #include <TableFunctions/ITableFunction.h>
@@ -88,7 +89,11 @@ void TableFunctionGenerateRandom::parseArguments(const ASTPtr & ast_function, Co
     // All the arguments must be literals.
     for (const auto & arg : args)
     {
-        if (!arg->as<const ASTLiteral>())
+        const IAST * arg_raw = arg.get();
+        if (const auto * func = arg_raw->as<const ASTFunction>(); func && func->name == "_CAST")
+            arg_raw = func->arguments->children.at(0).get();
+
+        if (!arg_raw->as<const ASTLiteral>())
         {
             throw Exception(ErrorCodes::BAD_ARGUMENTS,
                 "All arguments of table function '{}' except structure argument must be literals. "
@@ -107,7 +112,11 @@ void TableFunctionGenerateRandom::parseArguments(const ASTPtr & ast_function, Co
 
     if (args.size() >= arg_index + 1)
     {
-        const auto & literal = args[arg_index]->as<const ASTLiteral &>();
+        const IAST * arg_raw = args[arg_index].get();
+        if (const auto * func = arg_raw->as<const ASTFunction>(); func && func->name == "_CAST")
+            arg_raw = func->arguments->children.at(0).get();
+
+        const auto & literal = arg_raw->as<const ASTLiteral &>();
         ++arg_index;
         if (!literal.value.isNull())
             random_seed = checkAndGetLiteralArgument<UInt64>(literal, "random_seed");

--- a/tests/queries/0_stateless/01087_table_function_generate.sql
+++ b/tests/queries/0_stateless/01087_table_function_generate.sql
@@ -195,3 +195,5 @@ SELECT a, b, c, d, e, f, g, hex(h) FROM test_table_2 ORDER BY a, b, c, d, e, f, 
 SELECT '-';
 
 DROP TABLE IF EXISTS test_table_2;
+
+select * from generateRandom('x UInt64', Null, 10, 2) limit 2 format Null;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix `generateRandom` with `NULL` in the seed argument. Fixes https://github.com/ClickHouse/ClickHouse/issues/62092
