### PR TITLE
Do not randomize split_ranges_probability in 00063_loyalty_joins

### DIFF
--- a/tests/queries/1_stateful/00062_loyalty.sql
+++ b/tests/queries/1_stateful/00062_loyalty.sql
@@ -1,1 +1,2 @@
 SELECT loyalty, count() AS c, bar(log(c + 1) * 1000, 0, log(6000) * 1000, 80) FROM (SELECT UserID, toInt8((yandex > google ? yandex / (yandex + google) : -google / (yandex + google)) * 10) AS loyalty FROM (SELECT UserID, sum(SearchEngineID = 2) AS yandex, sum(SearchEngineID = 3) AS google FROM test.hits WHERE SearchEngineID = 2 OR SearchEngineID = 3 GROUP BY UserID HAVING yandex + google > 10)) GROUP BY loyalty ORDER BY loyalty
+SETTINGS  merge_tree_read_split_ranges_into_intersecting_and_non_intersecting_injection_probability = 0.0;

--- a/tests/queries/1_stateful/00063_loyalty_joins.sql
+++ b/tests/queries/1_stateful/00063_loyalty_joins.sql
@@ -1,6 +1,8 @@
 SET any_join_distinct_right_table_keys = 1;
 SET joined_subquery_requires_alias = 0;
 
+SET merge_tree_read_split_ranges_into_intersecting_and_non_intersecting_injection_probability = 0.0;
+
 SELECT
     loyalty,
     count()

--- a/tests/queries/1_stateful/00065_loyalty_with_storage_join.sql
+++ b/tests/queries/1_stateful/00065_loyalty_with_storage_join.sql
@@ -1,5 +1,7 @@
 USE test;
 
+SET merge_tree_read_split_ranges_into_intersecting_and_non_intersecting_injection_probability = 0.0;
+
 DROP TABLE IF EXISTS join;
 CREATE TABLE join (UserID UInt64, loyalty Int8) ENGINE = Join(SEMI, LEFT, UserID);
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)

Not sure if it indicates a bug or not, but this setting is disabled in bunch of tests already...

Ref https://github.com/ClickHouse/ClickHouse/issues/62252