### PR TITLE
Correct config key typo in S3 Table Engine documentation

### DIFF
--- a/docs/en/operations/storing-data.md
+++ b/docs/en/operations/storing-data.md
@@ -36,7 +36,7 @@ E.g. configuration option
 <s3>
     <type>s3</type>
     <endpoint>https://s3.eu-west-1.amazonaws.com/clickhouse-eu-west-1.clickhouse.com/data/</endpoint>
-    <use_invironment_credentials>1</use_invironment_credentials>
+    <use_environment_credentials>1</use_environment_credentials>
 </s3>
 ```
 
@@ -47,7 +47,7 @@ is equal to configuration (from `24.1`):
     <object_storage_type>s3</object_storage_type>
     <metadata_type>local</metadata_type>
     <endpoint>https://s3.eu-west-1.amazonaws.com/clickhouse-eu-west-1.clickhouse.com/data/</endpoint>
-    <use_invironment_credentials>1</use_invironment_credentials>
+    <use_environment_credentials>1</use_environment_credentials>
 </s3>
 ```
 
@@ -56,7 +56,7 @@ Configuration
 <s3_plain>
     <type>s3_plain</type>
     <endpoint>https://s3.eu-west-1.amazonaws.com/clickhouse-eu-west-1.clickhouse.com/data/</endpoint>
-    <use_invironment_credentials>1</use_invironment_credentials>
+    <use_environment_credentials>1</use_environment_credentials>
 </s3_plain>
 ```
 
@@ -67,7 +67,7 @@ is equal to
     <object_storage_type>s3</object_storage_type>
     <metadata_type>plain</metadata_type>
     <endpoint>https://s3.eu-west-1.amazonaws.com/clickhouse-eu-west-1.clickhouse.com/data/</endpoint>
-    <use_invironment_credentials>1</use_invironment_credentials>
+    <use_environment_credentials>1</use_environment_credentials>
 </s3_plain>
 ```
 
@@ -79,7 +79,7 @@ Example of full storage configuration will look like:
             <s3>
                 <type>s3</type>
                 <endpoint>https://s3.eu-west-1.amazonaws.com/clickhouse-eu-west-1.clickhouse.com/data/</endpoint>
-                <use_invironment_credentials>1</use_invironment_credentials>
+                <use_environment_credentials>1</use_environment_credentials>
             </s3>
         </disks>
         <policies>
@@ -105,7 +105,7 @@ Starting with 24.1 clickhouse version, it can also look like:
                 <object_storage_type>s3</object_storage_type>
                 <metadata_type>local</metadata_type>
                 <endpoint>https://s3.eu-west-1.amazonaws.com/clickhouse-eu-west-1.clickhouse.com/data/</endpoint>
-                <use_invironment_credentials>1</use_invironment_credentials>
+                <use_environment_credentials>1</use_environment_credentials>
             </s3>
         </disks>
         <policies>
@@ -324,7 +324,7 @@ Configuration:
 <s3_plain>
     <type>s3_plain</type>
     <endpoint>https://s3.eu-west-1.amazonaws.com/clickhouse-eu-west-1.clickhouse.com/data/</endpoint>
-    <use_invironment_credentials>1</use_invironment_credentials>
+    <use_environment_credentials>1</use_environment_credentials>
 </s3_plain>
 ```
 
@@ -337,7 +337,7 @@ Configuration:
     <object_storage_type>azure</object_storage_type>
     <metadata_type>plain</metadata_type>
     <endpoint>https://s3.eu-west-1.amazonaws.com/clickhouse-eu-west-1.clickhouse.com/data/</endpoint>
-    <use_invironment_credentials>1</use_invironment_credentials>
+    <use_environment_credentials>1</use_environment_credentials>
 </s3_plain>
 ```
 


### PR DESCRIPTION
The `use_environment_credentials` configuration key was incorrectly specified as `use_invironment_credentials` in documentation. This PR corrects the typo.

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Documentation (changelog entry is not required)

