### PR TITLE
[Docs] add missing arrayXYZ functions

### DIFF
--- a/docs/en/sql-reference/functions/array-functions.md
+++ b/docs/en/sql-reference/functions/array-functions.md
@@ -784,7 +784,7 @@ Returns the dot product of two arrays.
 arrayDotProduct(vector1, vector2)
 ```
 
-Alias: `scalarProduct`
+Alias: `scalarProduct`, `dotProduct`
 
 **Parameters**
 

--- a/docs/en/sql-reference/functions/array-functions.md
+++ b/docs/en/sql-reference/functions/array-functions.md
@@ -952,7 +952,7 @@ arrayEnumerateUniqRanked(clear_depth, arr, max_array_depth)
 **Parameters**
 
 - `clear_depth`: Enumerate elements at the specified level separately. Positive [Integer](../data-types/int-uint.md) less than or equal to `max_arr_depth`.
-- `arr`: N-dimensional array to enumerate. [Array](../data-types/array.md)
+- `arr`: N-dimensional array to enumerate. [Array](../data-types/array.md).
 - `max_array_depth`: The maximum effective depth. Positive [Integer](../data-types/int-uint.md) less than or equal to the depth of `arr`.
 
 **Example**
@@ -971,7 +971,7 @@ Result:
 [1,1,2]
 ```
 
-In this example, `arrayEnumerateUniqRanked` is used to obtain an array indicating, for each element of the multidimensional array, what its position is among elements of the same value. For the first row of the passed array,`[1,2,3]`, the corresponding result is `[1,1,1]`, indicating that this is the first time `1`,`2` and `3` are encountered. For the second row of the provided array,`[2,2,1]`, the corresponding result is `[2,3,3]`, indicating that the number `2` is encountered for a second and third time, and `1` is encountered for the second time. Likewise, for the third row of the provided array `[3]` the corresponding result is `[2]` indicating that the number `3` is encountered for the second time. 
+In this example, `arrayEnumerateUniqRanked` is used to obtain an array indicating, for each element of the multidimensional array, what its position is among elements of the same value. For the first row of the passed array,`[1,2,3]`, the corresponding result is `[1,1,1]`, indicating that this is the first time `1`,`2` and `3` are encountered. For the second row of the provided array,`[2,2,1]`, the corresponding result is `[2,3,3]`, indicating that `2` is encountered for a second and third time, and `1` is encountered for the second time. Likewise, for the third row of the provided array `[3]` the corresponding result is `[2]` indicating that `3` is encountered for the second time. 
 
 Query:
 
@@ -1417,7 +1417,7 @@ Same as `arrayReverseSort` with additional `limit` argument allowing partial sor
 ## arrayShuffle
 
 Returns an array of the same size as the original array containing the elements in shuffled order.
-Elements are being reordered in such a way that each possible permutation of those elements has equal probability of appearance.
+Elements are reordered in such a way that each possible permutation of those elements has equal probability of appearance.
 
 **Syntax**
 
@@ -1427,8 +1427,10 @@ arrayShuffle(arr, seed)
 
 **Parameters**
 
-- `arr`: The array to partially shuffle. [Array](../data-types/array.md)
-- `seed` (optional): seed to be used with random number generation. If not provided a random one is used. [UInt or Int](../data-types/int-uint.md)
+- `arr`: The array to partially shuffle. [Array](../data-types/array.md).
+- `seed` (optional): seed to be used with random number generation. If not provided a random one is used. [UInt or Int](../data-types/int-uint.md).
+
+**Returned value**
 
 - Array with elements shuffled.
 
@@ -1440,7 +1442,7 @@ This function will not materialize constants.
 
 **Examples**
 
-In this example, `arrayShuffle` is used with providing a `seed` and will use its own randomly generated one. 
+In this example, `arrayShuffle` is used without providing a `seed` and will therefore generate one randomly itself. 
 
 Query:
 
@@ -1472,7 +1474,7 @@ Result:
 
 ## arrayPartialShuffle
 
-Returns an array of the same size as the original array where elements in range [1..limit] are a random subset of the original array. Remaining (limit..n] shall contain the elements not in [1..limit] range in undefined order. Value of limit shall be in range [1..n]. Values outside of that range are equivalent to performing full [arrayShuffle](#arrayShuffle).
+Returns an array of the same size as the original array where elements in range `[1..limit]` are a random subset of the original array. Remaining `(limit..N]` shall contain the elements not in `[1..limit]` range in an undefined order.
 
 **Syntax**
 
@@ -1482,8 +1484,8 @@ arrayPartialShuffle(arr, limit, seed)
 
 **Parameters**
 
-- `arr`: The array to partially shuffle. [Array](../data-types/array.md)
-- `limit` (optional): Specifies how many times to limit element swaps to. [UInt or Int](../data-types/int-uint.md)
+- `arr`: The array size `N` to partially shuffle. [Array](../data-types/array.md)
+- `limit` (optional): Number to limit element swaps to, in the range `[1..N]`. [UInt or Int](../data-types/int-uint.md).
 - `seed` (optional): seed to be used with random number generation. If not provided a random one is used. [UInt or Int](../data-types/int-uint.md)
 
 **Returned value**
@@ -1494,6 +1496,8 @@ arrayPartialShuffle(arr, limit, seed)
 
 :::note 
 This function will not materialize constants.
+
+The value of `limit` shouuld be in the range `[1..N]`. Values outside of that range are equivalent to performing full [arrayShuffle](#arrayShuffle).
 :::
 
 **Examples**
@@ -1663,12 +1667,12 @@ arrayEnumerateDenseRanked(clear_depth, arr, max_array_depth)
 **Parameters**
 
 - `clear_depth`: Enumerate elements at the specified level separately. Positive [Integer](../data-types/int-uint.md) less than or equal to `max_arr_depth`.
-- `arr`: N-dimensional array to enumerate. [Array](../data-types/array.md)
+- `arr`: N-dimensional array to enumerate. [Array](../data-types/array.md).
 - `max_array_depth`: The maximum effective depth. Positive [Integer](../data-types/int-uint.md) less than or equal to the depth of `arr`.
 
 **Example**
 
-With `clear_depth`=1 and `max_array_depth`=1, the result is identical to what [arrayEnumerateDense](#arrayenumeratedense) would give.
+With `clear_depth=1` and `max_array_depth=1`, the result is identical to what [arrayEnumerateDense](#arrayenumeratedense) would give.
 
 Query:
 
@@ -1682,7 +1686,7 @@ Result:
 [1,2,1,3]
 ```
 
-In this example, `arrayEnumerateDenseRanked` is used to obtain an array indicating, for each element of the multidimensional array, what its position is among elements of the same value. For the first row of the passed array,`[10,10,30,20]`, the corresponding first row of the result is `[1,1,2,3]`, indicating that `10` is the first element encountered in position 1 and 2, `30` the second element encountered in position 3 and `20` is the third element encountered in position 4. For the second row, `[40, 50, 10, 30]`, the corresponding second row of the result is `[4,5,1,2]`, indicating that `40` and `50` are the fourth and fifth numbers encountered in position 1 and 2 of that row, that another `10` (the first encountered number) is in position 3 and `30` (the second number encountered) is in the last position. 
+In this example, `arrayEnumerateDenseRanked` is used to obtain an array indicating, for each element of the multidimensional array, what its position is among elements of the same value. For the first row of the passed array,`[10,10,30,20]`, the corresponding first row of the result is `[1,1,2,3]`, indicating that `10` is the first number encountered in position 1 and 2, `30` the second number encountered in position 3 and `20` is the third number encountered in position 4. For the second row, `[40, 50, 10, 30]`, the corresponding second row of the result is `[4,5,1,2]`, indicating that `40` and `50` are the fourth and fifth numbers encountered in position 1 and 2 of that row, that another `10` (the first encountered number) is in position 3 and `30` (the second number encountered) is in the last position. 
 
 
 Query:
@@ -2236,7 +2240,7 @@ arrayFirstOrNull(func, arr1, …)
 **Parameters**
 
 - `func`: lambda function.
-- `arr1`: array to operate on. [Array](../)
+- `arr1`: array to operate on. [Array](../data-types/array.md).
 
 **Returned value**
 
@@ -2292,7 +2296,7 @@ arrayLastOrNull(func, arr1, …)
 **Parameters**
 
 - `func`: lambda function.
-- `arr1`: array to operate on. [Array](../)
+- `arr1`: array to operate on. [Array](../data-types/array.md).
 
 **Returned value**
 

--- a/docs/en/sql-reference/functions/array-functions.md
+++ b/docs/en/sql-reference/functions/array-functions.md
@@ -1414,6 +1414,64 @@ SELECT arrayReverseSort((x, y) -> -y, [4, 3, 5], [1, 2, 3]) AS res;
 
 Same as `arrayReverseSort` with additional `limit` argument allowing partial sorting. Returns an array of the same size as the original array where elements in range `[1..limit]` are sorted in descending order. Remaining elements `(limit..N]` shall contain elements in unspecified order.
 
+## arrayPartialShuffle
+
+Returns an array of the same size as the original array where elements in range [1..limit] are a random subset of the original array. Remaining (limit..n] shall contain the elements not in [1..limit] range in undefined order. Value of limit shall be in range [1..n]. Values outside of that range are equivalent to performing full arrayShuffle.
+
+**Syntax**
+
+```sql
+arrayPartialShuffle(arr, limit, seed)
+```
+
+**Parameters**
+
+- `arr`: The array to partially shuffle. [Array](../data-types/array.md)
+- `limit` (optional): Specifies how many times to limit element swaps to. []()
+- `seed` (optional): seed to be used with random number generation. If not provided a random one is used. []()
+
+**Returned value**
+
+- Array with elements shuffled.
+
+**Implementation details**
+
+:::note 
+This function will not materialize constants.
+:::
+
+**Examples**
+
+In this example, `arrayPartialShuffle` is used without the `limit` and `seed` parameters. 
+
+Query:
+
+```sql
+SELECT arrayPartialShuffle([1, 2, 3, 4], 0);
+SELECT arrayPartialShuffle([1, 2, 3, 4]);
+```
+
+Note: When using [ClickHouse Fiddle](https://fiddle.clickhouse.com/), the exact response may differ due to random nature of the function.
+
+Result: 
+```response
+[3,1,2,4]
+[4,1,3,2]
+```
+
+In this example, the `arrayPartialShuffle` function is provided a `limit` and a `seed`. 
+
+Query:
+
+```sql
+SELECT arrayPartialShuffle([1,2,3,4,5,6,7,8,9,10], 5, 0xbad_cafe);
+```
+
+Result: 
+```response
+[10,9,4,2,5,6,7,8,3,1]
+```
+
 ## arrayUniq(arr, …)
 
 If one argument is passed, it counts the number of different elements in the array.

--- a/docs/en/sql-reference/functions/array-functions.md
+++ b/docs/en/sql-reference/functions/array-functions.md
@@ -939,6 +939,66 @@ SELECT arrayEnumerateUniq([1, 1, 1, 2, 2, 2], [1, 1, 2, 1, 1, 2]) AS res
 
 This is necessary when using ARRAY JOIN with a nested data structure and further aggregation across multiple elements in this structure.
 
+## arrayEnumerateUniqRanked
+
+Returns an array the same size as the source array, indicating for each element what its position is among elements with the same value. It allows for enumeration of a multidimensional array with the ability to specify how deep to look inside the array.
+
+**Syntax**
+
+```sql
+arrayEnumerateUniqRanked(clear_depth, arr, max_array_depth)
+```
+
+**Parameters**
+
+- `clear_depth`: Enumerate elements at the specified level separately. Positive [Integer](../data-types/int-uint.md) less than or equal to `max_arr_depth`.
+- `arr`: N-dimensional array to enumerate. [Array](../data-types/array.md)
+- `max_array_depth`: The maximum effective depth. Positive [Integer](../data-types/int-uint.md) less than or equal to the depth of `arr`.
+
+**Example**
+
+With `clear_depth=1` and `max_array_depth=1`, the result of `arrayEnumerateUniqRanked` is identical to that which [`arrayEnumerateUniq`](#arrayenumerateuniqarr) would give for the same array.
+
+Query:
+
+``` sql
+SELECT arrayEnumerateUniqRanked(1, [1,2,1], 1);
+```
+
+Result:
+
+``` text
+[1,1,2]
+```
+
+In this example, `arrayEnumerateUniqRanked` is used to obtain an array indicating, for each element of the multidimensional array, what its position is among elements of the same value. For the first row of the passed array,`[1,2,3]`, the corresponding result is `[1,1,1]`, indicating that this is the first time `1`,`2` and `3` are encountered. For the second row of the provided array,`[2,2,1]`, the corresponding result is `[2,3,3]`, indicating that the number `2` is encountered for a second and third time, and `1` is encountered for the second time. Likewise, for the third row of the provided array `[3]` the corresponding result is `[2]` indicating that the number `3` is encountered for the second time. 
+
+Query:
+
+``` sql
+SELECT arrayEnumerateUniqRanked(1, [[1,2,3],[2,2,1],[3]], 2);
+```
+
+Result:
+
+``` text
+[[1,1,1],[2,3,2],[2]]
+```
+
+Changing `clear_depth=2`, results in elements being enumerated seperately for each row.
+
+Query:
+
+``` sql
+SELECT arrayEnumerateUniqRanked(2, [[1,2,3],[2,2,1],[3]], 2);
+```
+
+Result:
+
+``` text
+[[1,1,1],[1,2,1],[1]]
+```
+
 ## arrayPopBack
 
 Removes the last item from the array.
@@ -1478,7 +1538,7 @@ Result:
 ```
 ## arrayEnumerateDenseRanked
 
-Enumerates distinct values of the passed multidimensional array, looking inside at the specified depths. 
+Returns an array the same size as the source array, indicating where each element first appears in the source array. It allows for enumeration of a multidimensional array with the ability to specify how deep to look inside the array.
 
 **Syntax**
 
@@ -1488,7 +1548,7 @@ arrayEnumerateDenseRanked(clear_depth, arr, max_array_depth)
 
 **Parameters**
 
-- `clear_depth`: Enumerate elements at the specified level separately. (The enumeration counter is reset for each new element). Positive [Integer](../data-types/int-uint.md) less than or equal to `max_arr_depth`.
+- `clear_depth`: Enumerate elements at the specified level separately. Positive [Integer](../data-types/int-uint.md) less than or equal to `max_arr_depth`.
 - `arr`: N-dimensional array to enumerate. [Array](../data-types/array.md)
 - `max_array_depth`: The maximum effective depth. Positive [Integer](../data-types/int-uint.md) less than or equal to the depth of `arr`.
 
@@ -1508,18 +1568,33 @@ Result:
 [1,2,1,3]
 ```
 
-`arrayEnumerateDenseRanked` can be used to enumerate multidimensional arrays.
+In this example, `arrayEnumerateDenseRanked` is used to obtain an array indicating, for each element of the multidimensional array, what its position is among elements of the same value. For the first row of the passed array,`[10,10,30,20]`, the corresponding first row of the result is `[1,1,2,3]`, indicating that `10` is the first element encountered in position 1 and 2, `30` the second element encountered in position 3 and `20` is the third element encountered in position 4. For the second row, `[40, 50, 10, 30]`, the corresponding second row of the result is `[4,5,1,2]`, indicating that `40` and `50` are the fourth and fifth numbers encountered in position 1 and 2 of that row, that another `10` (the first encountered number) is in position 3 and `30` (the second number encountered) is in the last position. 
+
 
 Query:
 
 ``` sql
-SELECT arrayEnumerateDenseRanked(2,[[10, 20, 10, 30],[40, 50, 60, 70]],2);
+SELECT arrayEnumerateDenseRanked(1,[[10,10,30,20],[40,50,10,30]],2);
 ```
 
 Result:
 
 ``` text
-[[1,2,1,3],[4,5,6,7]]
+[[1,1,2,3],[4,5,1,2]]
+```
+
+Changing `clear_depth=2` results in the enumeration occuring separetely for each row anew.
+
+Query:
+
+``` sql
+SELECT arrayEnumerateDenseRanked(2,[[10,10,30,20],[40,50,10,30]],2);
+```
+
+Result:
+
+``` text
+[[1,1,2,3],[1,2,3,4]]
 ```
 
 ## arrayIntersect(arr)

--- a/docs/en/sql-reference/functions/array-functions.md
+++ b/docs/en/sql-reference/functions/array-functions.md
@@ -1476,7 +1476,7 @@ Result:
 
 ## arrayPartialShuffle
 
-Given an input array of cardinality `N`, returns an array of size N where elements in the range `[1...limit]`are shuffled and the remaining elements in the range `(limit...n]` are unshuffled.
+Given an input array of cardinality `N`, returns an array of size N where elements in the range `[1...limit]` are shuffled and the remaining elements in the range `(limit...n]` are unshuffled.
 
 **Syntax**
 
@@ -1514,7 +1514,7 @@ SELECT arrayPartialShuffle([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 1)
 
 Result:
 
-The order of elements is preserved (`[2,3,4,5], [7,8,9,10]`) except for the 2 shuffled elements `[1, 6]`. No `seed` is provided so the function selects its own randomly.
+The order of elements is preserved (`[2,3,4,5], [7,8,9,10]`) except for the two shuffled elements `[1, 6]`. No `seed` is provided so the function selects its own randomly.
 
 ```response
 [6,2,3,4,5,1,7,8,9,10]
@@ -1528,7 +1528,7 @@ Query:
 SELECT arrayPartialShuffle([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 2);
 ```
 
-The order of elements is preserved (`[4, 5, 6, 7, 8], [10]`) except for the 4 shuffled elements `[1, 2, 3, 9]`.
+The order of elements is preserved (`[4, 5, 6, 7, 8], [10]`) except for the four shuffled elements `[1, 2, 3, 9]`.
 
 Result: 
 ```response

--- a/docs/en/sql-reference/functions/array-functions.md
+++ b/docs/en/sql-reference/functions/array-functions.md
@@ -774,6 +774,57 @@ Returns the number of elements for which `func(arr1[i], …, arrN[i])` returns s
 
 Note that the `arrayCount` is a [higher-order function](../../sql-reference/functions/index.md#higher-order-functions). You can pass a lambda function to it as the first argument.
 
+## arrayDotProduct
+
+**Syntax**
+
+```sql
+arrayDotProduct(vector1, vector2)
+```
+
+Alias: `scalarProduct`
+
+**Parameters**
+
+- `vector1`: First vector. [Array](../data-types/array.md) or [Tuple](../data-types/tuple.md) of numeric values.
+- `vector2`: Second vector. [Array](../data-types/array.md) or [Tuple](../data-types/tuple.md) of numeric values.
+
+Note:::
+The sizes of the two vectors must be equal. Arrays and Tuples may also contain mixed element types.
+:::
+
+**Returned value**
+
+- The dot product of the two vectors.
+
+Type: numeric - determined by the type of the arguments. If Arrays or Tuples contain mixed element types then the result type is the supertype.
+
+**Examples**
+
+Query:
+
+```sql
+SELECT arrayDotProduct([1, 2, 3], [4, 5, 6]) AS res, toTypeName(res);
+```
+
+Result:
+
+```response
+32	UInt16
+```
+
+Query:
+
+```sql
+SELECT dotProduct((1::UInt16, 2::UInt8, 3::Float32),(4::Int16, 5::Float32, 6::UInt8)) AS res, toTypeName(res);
+```
+
+Result:
+
+```response
+32	Float64
+```
+
 ## countEqual(arr, x)
 
 Returns the number of elements in the array equal to x. Equivalent to arrayCount (elem -\> elem = x, arr).
@@ -1652,7 +1703,7 @@ flatten(array_of_arrays)
 
 Alias: `flatten`.
 
-**Arguments**
+**Parameters**
 
 - `array_of_arrays` — [Array](../../sql-reference/data-types/array.md) of arrays. For example, `[[1,2,3], [4,5]]`.
 

--- a/docs/en/sql-reference/functions/array-functions.md
+++ b/docs/en/sql-reference/functions/array-functions.md
@@ -789,7 +789,7 @@ Alias: `scalarProduct`
 - `vector1`: First vector. [Array](../data-types/array.md) or [Tuple](../data-types/tuple.md) of numeric values.
 - `vector2`: Second vector. [Array](../data-types/array.md) or [Tuple](../data-types/tuple.md) of numeric values.
 
-Note:::
+:::note
 The sizes of the two vectors must be equal. Arrays and Tuples may also contain mixed element types.
 :::
 

--- a/docs/en/sql-reference/functions/array-functions.md
+++ b/docs/en/sql-reference/functions/array-functions.md
@@ -776,6 +776,8 @@ Note that the `arrayCount` is a [higher-order function](../../sql-reference/func
 
 ## arrayDotProduct
 
+Returns the dot product of two arrays.
+
 **Syntax**
 
 ```sql

--- a/docs/en/sql-reference/functions/array-functions.md
+++ b/docs/en/sql-reference/functions/array-functions.md
@@ -1424,7 +1424,7 @@ Elements are reordered in such a way that each possible permutation of those ele
 **Syntax**
 
 ```sql
-arrayShuffle(arr, seed)
+arrayShuffle(arr[, seed])
 ```
 
 **Parameters**
@@ -1476,12 +1476,12 @@ Result:
 
 ## arrayPartialShuffle
 
-Returns an array of the same size as the original array where elements in range `[1..limit]` are a random subset of the original array. Remaining `(limit..N]` shall contain the elements not in `[1..limit]` range in an undefined order.
+Given an input array of cardinality `N`, returns an array of size N where elements in the range `[1...limit]`are shuffled and the remaining elements in the range `(limit...n]` are unshuffled.
 
 **Syntax**
 
 ```sql
-arrayPartialShuffle(arr, limit, seed)
+arrayPartialShuffle(arr[, limit[, seed]])
 ```
 
 **Parameters**
@@ -1504,34 +1504,35 @@ The value of `limit` should be in the range `[1..N]`. Values outside of that ran
 
 **Examples**
 
-In this example, `arrayPartialShuffle` is used without the `limit` and `seed` parameters. 
+Note: when using [ClickHouse Fiddle](https://fiddle.clickhouse.com/), the exact response may differ due to random nature of the function. 
 
 Query:
 
 ```sql
-SELECT arrayPartialShuffle([1, 2, 3, 4], 0);
-SELECT arrayPartialShuffle([1, 2, 3, 4]);
+SELECT arrayPartialShuffle([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 1)
 ```
 
-Note: when using [ClickHouse Fiddle](https://fiddle.clickhouse.com/), the exact response may differ due to random nature of the function.
+Result:
 
-Result: 
+The order of elements is preserved (`[2,3,4,5], [7,8,9,10]`) except for the 2 shuffled elements `[1, 6]`. No `seed` is provided so the function selects its own randomly.
+
 ```response
-[3,1,2,4]
-[4,1,3,2]
+[6,2,3,4,5,1,7,8,9,10]
 ```
 
-In this example, the `arrayPartialShuffle` function is provided a `limit` and a `seed`. 
+In this example, the `limit` is increased to `2` and a `seed` value is provided. The order 
 
 Query:
 
 ```sql
-SELECT arrayPartialShuffle([1,2,3,4,5,6,7,8,9,10], 5, 0xbad_cafe);
+SELECT arrayPartialShuffle([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 2);
 ```
+
+The order of elements is preserved (`[4, 5, 6, 7, 8], [10]`) except for the 4 shuffled elements `[1, 2, 3, 9]`.
 
 Result: 
 ```response
-[10,9,4,2,5,6,7,8,3,1]
+[3,9,1,4,5,6,7,8,2,10]
 ```
 
 ## arrayUniq(arr, …)

--- a/docs/en/sql-reference/functions/array-functions.md
+++ b/docs/en/sql-reference/functions/array-functions.md
@@ -1414,9 +1414,65 @@ SELECT arrayReverseSort((x, y) -> -y, [4, 3, 5], [1, 2, 3]) AS res;
 
 Same as `arrayReverseSort` with additional `limit` argument allowing partial sorting. Returns an array of the same size as the original array where elements in range `[1..limit]` are sorted in descending order. Remaining elements `(limit..N]` shall contain elements in unspecified order.
 
+## arrayShuffle
+
+Returns an array of the same size as the original array containing the elements in shuffled order.
+Elements are being reordered in such a way that each possible permutation of those elements has equal probability of appearance.
+
+**Syntax**
+
+```sql
+arrayShuffle(arr, seed)
+```
+
+**Parameters**
+
+- `arr`: The array to partially shuffle. [Array](../data-types/array.md)
+- `seed` (optional): seed to be used with random number generation. If not provided a random one is used. [UInt or Int](../data-types/int-uint.md)
+
+- Array with elements shuffled.
+
+**Implementation details**
+
+:::note 
+This function will not materialize constants.
+:::
+
+**Examples**
+
+In this example, `arrayShuffle` is used with providing a `seed` and will use its own randomly generated one. 
+
+Query:
+
+```sql
+SELECT arrayShuffle([1, 2, 3, 4]);
+```
+
+Note: when using [ClickHouse Fiddle](https://fiddle.clickhouse.com/), the exact response may differ due to random nature of the function.
+
+Result: 
+
+```response
+[1,4,2,3]
+```
+
+In this example, `arrayShuffle` is provided a `seed` and will produce stable results.
+
+Query:
+
+```sql
+SELECT arrayShuffle([1, 2, 3, 4], 41);
+```
+
+Result: 
+
+```response
+[3,2,1,4]
+```
+
 ## arrayPartialShuffle
 
-Returns an array of the same size as the original array where elements in range [1..limit] are a random subset of the original array. Remaining (limit..n] shall contain the elements not in [1..limit] range in undefined order. Value of limit shall be in range [1..n]. Values outside of that range are equivalent to performing full arrayShuffle.
+Returns an array of the same size as the original array where elements in range [1..limit] are a random subset of the original array. Remaining (limit..n] shall contain the elements not in [1..limit] range in undefined order. Value of limit shall be in range [1..n]. Values outside of that range are equivalent to performing full [arrayShuffle](#arrayShuffle).
 
 **Syntax**
 
@@ -1427,12 +1483,12 @@ arrayPartialShuffle(arr, limit, seed)
 **Parameters**
 
 - `arr`: The array to partially shuffle. [Array](../data-types/array.md)
-- `limit` (optional): Specifies how many times to limit element swaps to. []()
-- `seed` (optional): seed to be used with random number generation. If not provided a random one is used. []()
+- `limit` (optional): Specifies how many times to limit element swaps to. [UInt or Int](../data-types/int-uint.md)
+- `seed` (optional): seed to be used with random number generation. If not provided a random one is used. [UInt or Int](../data-types/int-uint.md)
 
 **Returned value**
 
-- Array with elements shuffled.
+- Array with elements partially shuffled.
 
 **Implementation details**
 
@@ -1451,7 +1507,7 @@ SELECT arrayPartialShuffle([1, 2, 3, 4], 0);
 SELECT arrayPartialShuffle([1, 2, 3, 4]);
 ```
 
-Note: When using [ClickHouse Fiddle](https://fiddle.clickhouse.com/), the exact response may differ due to random nature of the function.
+Note: when using [ClickHouse Fiddle](https://fiddle.clickhouse.com/), the exact response may differ due to random nature of the function.
 
 Result: 
 ```response

--- a/docs/en/sql-reference/functions/array-functions.md
+++ b/docs/en/sql-reference/functions/array-functions.md
@@ -2239,8 +2239,8 @@ arrayFirstOrNull(func, arr1, …)
 
 **Parameters**
 
-- `func`: lambda function.
-- `arr1`: array to operate on. [Array](../data-types/array.md).
+- `func`: Lambda function. [Lambda function](../functions/#higher-order-functions---operator-and-lambdaparams-expr-function).
+- `arr1`: Array to operate on. [Array](../data-types/array.md).
 
 **Returned value**
 
@@ -2295,8 +2295,8 @@ arrayLastOrNull(func, arr1, …)
 
 **Parameters**
 
-- `func`: lambda function.
-- `arr1`: array to operate on. [Array](../data-types/array.md).
+- `func`: Lambda function. [Lambda function](../functions/#higher-order-functions---operator-and-lambdaparams-expr-function).
+- `arr1`: Array to operate on. [Array](../data-types/array.md).
 
 **Returned value**
 

--- a/docs/en/sql-reference/functions/array-functions.md
+++ b/docs/en/sql-reference/functions/array-functions.md
@@ -2131,9 +2131,21 @@ arrayFirstOrNull(func, arr1, …)
 
 **Implementation details**
 
-Note that the `arrayFirst` is a [higher-order function](../../sql-reference/functions/index.md#higher-order-functions). You must pass a lambda function to it as the first argument, and it can’t be omitted.
+Note that the `arrayFirstOrNull` is a [higher-order function](../../sql-reference/functions/index.md#higher-order-functions). You must pass a lambda function to it as the first argument, and it can’t be omitted.
 
 **Example**
+
+Query:
+
+```sql
+SELECT arrayFirstOrNull(x -> x >= 2, [1, 2, 3]);
+```
+
+Result:
+
+```response
+2
+```
 
 Query:
 
@@ -2155,7 +2167,53 @@ Note that the `arrayLast` is a [higher-order function](../../sql-reference/funct
 
 ## arrayLastOrNull
 
+Returns the last element in the `arr1` array for which `func(arr1[i], …, arrN[i])` returns something other than 0, otherwise returns `NULL`.
 
+**Syntax**
+
+```sql
+arrayLastOrNull(func, arr1, …)
+```
+
+**Parameters**
+
+- `func`: lambda function.
+- `arr1`: array to operate on. [Array](../)
+
+**Returned value**
+
+- The last element in the passed array.
+- Otherwise, returns `NULL`
+
+**Implementation details**
+
+Note that the `arrayLastOrNull` is a [higher-order function](../../sql-reference/functions/index.md#higher-order-functions). You must pass a lambda function to it as the first argument, and it can’t be omitted.
+
+**Example**
+
+Query:
+
+```sql
+SELECT arrayLastOrNull(x -> x >= 2, [1, 2, 3]);
+```
+
+Result:
+
+```response
+3
+```
+
+Query:
+
+```sql
+SELECT arrayLastOrNull(x -> x >= 2, emptyArrayUInt8());
+```
+
+Result:
+
+```response
+\N
+```
 
 ## arrayFirstIndex(func, arr1, …)
 

--- a/docs/en/sql-reference/functions/array-functions.md
+++ b/docs/en/sql-reference/functions/array-functions.md
@@ -1484,9 +1484,9 @@ arrayPartialShuffle(arr, limit, seed)
 
 **Parameters**
 
-- `arr`: The array size `N` to partially shuffle. [Array](../data-types/array.md)
-- `limit` (optional): Number to limit element swaps to, in the range `[1..N]`. [UInt or Int](../data-types/int-uint.md).
-- `seed` (optional): seed to be used with random number generation. If not provided a random one is used. [UInt or Int](../data-types/int-uint.md)
+- `arr`: The array size `N` to partially shuffle. [Array](../data-types/array.md).
+- `limit` (optional): The number to limit element swaps to, in the range `[1..N]`. [UInt or Int](../data-types/int-uint.md).
+- `seed` (optional): The seed value to be used with random number generation. If not provided a random one is used. [UInt or Int](../data-types/int-uint.md)
 
 **Returned value**
 
@@ -1497,7 +1497,7 @@ arrayPartialShuffle(arr, limit, seed)
 :::note 
 This function will not materialize constants.
 
-The value of `limit` shouuld be in the range `[1..N]`. Values outside of that range are equivalent to performing full [arrayShuffle](#arrayShuffle).
+The value of `limit` should be in the range `[1..N]`. Values outside of that range are equivalent to performing full [arrayShuffle](#arrayshuffle).
 :::
 
 **Examples**

--- a/docs/en/sql-reference/functions/array-functions.md
+++ b/docs/en/sql-reference/functions/array-functions.md
@@ -2109,13 +2109,53 @@ Note that the `arrayAll` is a [higher-order function](../../sql-reference/functi
 
 Returns the first element in the `arr1` array for which `func(arr1[i], …, arrN[i])` returns something other than 0.
 
+## arrayFirstOrNull
+
+Returns the first element in the `arr1` array for which `func(arr1[i], …, arrN[i])` returns something other than 0, otherwise it returns `NULL`.
+
+**Syntax**
+
+```sql
+arrayFirstOrNull(func, arr1, …)
+```
+
+**Parameters**
+
+- `func`: lambda function.
+- `arr1`: array to operate on. [Array](../)
+
+**Returned value**
+
+- The first element in the passed array.
+- Otherwise, returns `NULL`
+
+**Implementation details**
+
 Note that the `arrayFirst` is a [higher-order function](../../sql-reference/functions/index.md#higher-order-functions). You must pass a lambda function to it as the first argument, and it can’t be omitted.
+
+**Example**
+
+Query:
+
+```sql
+SELECT arrayFirstOrNull(x -> x >= 2, emptyArrayUInt8());
+```
+
+Result:
+
+```response
+\N
+```
 
 ## arrayLast(func, arr1, …)
 
 Returns the last element in the `arr1` array for which `func(arr1[i], …, arrN[i])` returns something other than 0.
 
 Note that the `arrayLast` is a [higher-order function](../../sql-reference/functions/index.md#higher-order-functions). You must pass a lambda function to it as the first argument, and it can’t be omitted.
+
+## arrayLastOrNull
+
+
 
 ## arrayFirstIndex(func, arr1, …)
 

--- a/docs/en/sql-reference/functions/array-functions.md
+++ b/docs/en/sql-reference/functions/array-functions.md
@@ -1451,20 +1451,75 @@ Result:
 └────────────────────────────────┘
 ```
 
-## arrayEnumerateDense(arr)
+## arrayEnumerateDense
 
 Returns an array of the same size as the source array, indicating where each element first appears in the source array.
 
-Example:
+**Syntax**
+
+```sql
+arrayEnumerateDense(arr)
+```
+
+**Example**
+
+Query:
 
 ``` sql
 SELECT arrayEnumerateDense([10, 20, 10, 30])
 ```
 
+Result:
+
 ``` text
 ┌─arrayEnumerateDense([10, 20, 10, 30])─┐
 │ [1,2,1,3]                             │
 └───────────────────────────────────────┘
+```
+## arrayEnumerateDenseRanked
+
+Enumerates distinct values of the passed multidimensional array, looking inside at the specified depths. 
+
+**Syntax**
+
+```sql
+arrayEnumerateDenseRanked(clear_depth, arr, max_array_depth)
+```
+
+**Parameters**
+
+- `clear_depth`: Enumerate elements at the specified level separately. (The enumeration counter is reset for each new element). Positive [Integer](../data-types/int-uint.md) less than or equal to `max_arr_depth`.
+- `arr`: N-dimensional array to enumerate. [Array](../data-types/array.md)
+- `max_array_depth`: The maximum effective depth. Positive [Integer](../data-types/int-uint.md) less than or equal to the depth of `arr`.
+
+**Example**
+
+With `clear_depth`=1 and `max_array_depth`=1, the result is identical to what [arrayEnumerateDense](#arrayenumeratedense) would give.
+
+Query:
+
+``` sql
+SELECT arrayEnumerateDenseRanked(1,[10, 20, 10, 30],1);
+```
+
+Result:
+
+``` text
+[1,2,1,3]
+```
+
+`arrayEnumerateDenseRanked` can be used to enumerate multidimensional arrays.
+
+Query:
+
+``` sql
+SELECT arrayEnumerateDenseRanked(2,[[10, 20, 10, 30],[40, 50, 60, 70]],2);
+```
+
+Result:
+
+``` text
+[[1,2,1,3],[4,5,6,7]]
 ```
 
 ## arrayIntersect(arr)

--- a/docs/en/sql-reference/functions/array-functions.md
+++ b/docs/en/sql-reference/functions/array-functions.md
@@ -2280,6 +2280,18 @@ Result:
 \N
 ```
 
+Query:
+
+```sql
+SELECT arrayLastOrNull((x,f) -> f, [1,2,3,NULL], [0,1,0,1]);
+```
+
+Result:
+
+```response
+\N
+```
+
 ## arrayLast(func, arr1, …)
 
 Returns the last element in the `arr1` array for which `func(arr1[i], …, arrN[i])` returns something other than 0.

--- a/docs/en/sql-reference/functions/array-functions.md
+++ b/docs/en/sql-reference/functions/array-functions.md
@@ -987,7 +987,7 @@ Result:
 [[1,1,1],[2,3,2],[2]]
 ```
 
-Changing `clear_depth=2`, results in elements being enumerated seperately for each row.
+Changing `clear_depth=2`, results in elements being enumerated separately for each row.
 
 Query:
 
@@ -1703,7 +1703,7 @@ Result:
 [[1,1,2,3],[4,5,1,2]]
 ```
 
-Changing `clear_depth=2` results in the enumeration occuring separetely for each row anew.
+Changing `clear_depth=2` results in the enumeration occurring separately for each row anew.
 
 Query:
 

--- a/docs/en/sql-reference/functions/tuple-functions.md
+++ b/docs/en/sql-reference/functions/tuple-functions.md
@@ -521,45 +521,6 @@ Result:
 └──────────────────────────────────┘
 ```
 
-## dotProduct
-
-Calculates the scalar product of two tuples of the same size.
-
-**Syntax**
-
-```sql
-dotProduct(tuple1, tuple2)
-```
-
-Alias: `scalarProduct`.
-
-**Arguments**
-
-- `tuple1` — First tuple. [Tuple](../../sql-reference/data-types/tuple.md).
-- `tuple2` — Second tuple. [Tuple](../../sql-reference/data-types/tuple.md).
-
-**Returned value**
-
-- Scalar product.
-
-Type: [Int/UInt](../../sql-reference/data-types/int-uint.md) or [Float](../../sql-reference/data-types/float.md).
-
-**Example**
-
-Query:
-
-```sql
-SELECT dotProduct((1, 2), (2, 3));
-```
-
-Result:
-
-```text
-┌─dotProduct((1, 2), (2, 3))─┐
-│                          8 │
-└────────────────────────────┘
-```
-
 ## tupleConcat
 
 Combines tuples passed as arguments.

--- a/utils/check-style/aspell-ignore/en/aspell-dict.txt
+++ b/utils/check-style/aspell-ignore/en/aspell-dict.txt
@@ -29,6 +29,13 @@ Alexey
 AnyEvent
 AppleClang
 Approximative
+arrayDotProduct
+arrayEnumerateDenseRanked
+arrayEnumerateUniqRanked
+arrayFirstOrNull
+arrayLastOrNull
+arrayPartialShuffle
+arrayShuffle
 ArrayJoin
 ArrowStream
 AsyncInsertCacheSize

--- a/utils/check-style/aspell-ignore/en/aspell-dict.txt
+++ b/utils/check-style/aspell-ignore/en/aspell-dict.txt
@@ -996,6 +996,7 @@ UncompressedCacheBytes
 UncompressedCacheCells
 UnidirectionalEdgeIsValid
 UniqThetaSketch
+unshuffled
 Updatable
 Uppercased
 Uptime


### PR DESCRIPTION
Closes [#1934](https://github.com/ClickHouse/clickhouse-docs/issues/1934) as part of the [functions project](https://github.com/ClickHouse/clickhouse-docs/issues/1833) to document missing functions. 

This PR adds documentation for the following functions listed in [#1934](https://github.com/ClickHouse/clickhouse-docs/issues/1934):

- [ ]  array → **already exists as** array(x1, …), operator \[x1, …\] [here](https://github.com/ClickHouse/ClickHouse/blob/300904dc830eadc27af34254c39b4bc15478a0ad/docs/en/sql-reference/functions/array-functions.md?plain=1#L564)
- [X]  arrayDotProduct
- [x]  arrayEnumerateDenseRanked
- [x]  arrayEnumerateUniqRanked
- [x]  arrayFirstOrNull
- [ ]  arrayFlatten → **already exists** [here](https://github.com/ClickHouse/ClickHouse/blob/300904dc830eadc27af34254c39b4bc15478a0ad/docs/en/sql-reference/functions/array-functions.md?plain=1#L1636)
- [x]  arrayLastOrNull
- [x]  arrayPartialShuffle
- [x]  arrayShuffle

### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Documentation entry for user-facing changes

- [X] Documentation is written (mandatory for new features)
