### PR TITLE
Fix primary key in materialized view

### DIFF
--- a/src/Storages/StorageMaterializedView.cpp
+++ b/src/Storages/StorageMaterializedView.cpp
@@ -91,7 +91,7 @@ StorageMaterializedView::StorageMaterializedView(
 {
     StorageInMemoryMetadata storage_metadata;
     storage_metadata.setColumns(columns_);
-    auto storage_def = query.storage;
+    auto * storage_def = query.storage;
     if (storage_def && storage_def->primary_key)
         storage_metadata.primary_key = KeyDescription::getKeyFromAST(storage_def->primary_key->ptr(),
                                                                      storage_metadata.columns,

--- a/src/Storages/StorageMaterializedView.cpp
+++ b/src/Storages/StorageMaterializedView.cpp
@@ -91,6 +91,12 @@ StorageMaterializedView::StorageMaterializedView(
 {
     StorageInMemoryMetadata storage_metadata;
     storage_metadata.setColumns(columns_);
+    auto storage_def = query.storage;
+    if (storage_def && storage_def->primary_key)
+        storage_metadata.primary_key = KeyDescription::getKeyFromAST(storage_def->primary_key->ptr(),
+                                                                     storage_metadata.columns,
+                                                                     local_context->getGlobalContext());
+
     if (query.sql_security)
         storage_metadata.setSQLSecurity(query.sql_security->as<ASTSQLSecurity &>());
 

--- a/tests/queries/0_stateless/03035_materialized_primary_key.reference
+++ b/tests/queries/0_stateless/03035_materialized_primary_key.reference
@@ -1,0 +1,3 @@
+test	id
+test_mv	
+test_mv_pk	value

--- a/tests/queries/0_stateless/03035_materialized_primary_key.sql
+++ b/tests/queries/0_stateless/03035_materialized_primary_key.sql
@@ -25,4 +25,4 @@ POPULATE AS SELECT value, id FROM test;
 
 SELECT name, primary_key
 FROM system.tables
-WHERE name LIKE 'test%';
+WHERE database = currentDatabase() AND name LIKE 'test%';

--- a/tests/queries/0_stateless/03035_materialized_primary_key.sql
+++ b/tests/queries/0_stateless/03035_materialized_primary_key.sql
@@ -1,0 +1,28 @@
+DROP TABLE IF EXISTS test;
+CREATE TABLE test
+(
+    id UInt64,
+    value String
+) ENGINE=MergeTree ORDER BY id;
+
+INSERT INTO test VALUES (1, 'Alice'), (2, 'Bob');
+
+DROP VIEW IF EXISTS test_mv;
+CREATE MATERIALIZED VIEW test_mv
+(
+    id UInt64,
+    value String
+) ENGINE=MergeTree
+ORDER BY id AS SELECT id, value FROM test;
+
+DROP VIEW IF EXISTS test_mv_pk;
+CREATE MATERIALIZED VIEW test_mv_pk
+(
+    value String,
+    id UInt64
+) ENGINE=MergeTree PRIMARY KEY value
+POPULATE AS SELECT value, id FROM test;
+
+SELECT name, primary_key
+FROM system.tables
+WHERE name LIKE 'test%';


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->

Fixes #62045

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix displaying of materialized_view primary_key in system.tables. Previously it was shown empty even when a CREATE query included PRIMARY KEY.

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

---
### Modify your CI run:
**NOTE:** If your merge the PR with modified CI you **MUST KNOW** what you are doing
**NOTE:** Checked options will be applied if set before CI RunConfig/PrepareRunConfig step

#### Include tests (required builds will be added automatically):
#- [ ] <!---ci_include_fast--> Fast test
- [ ] <!---ci_include_integration--> Integration Tests
- [ ] <!---ci_include_stateless--> Stateless tests
- [ ] <!---ci_include_stateful--> Stateful tests
- [ ] <!---ci_include_unit--> Unit tests
- [ ] <!---ci_include_performance--> Performance tests
- [ ] <!---ci_include_asan--> All with ASAN
- [ ] <!---ci_include_tsan--> All with TSAN
- [ ] <!---ci_include_analyzer--> All with Analyzer
- [ ] <!---ci_include_KEYWORD--> Add your option here

#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [ ] <!---ci_exclude_tsan--> All with TSAN
- [ ] <!---ci_exclude_msan--> All with MSAN
- [ ] <!---ci_exclude_ubsan--> All with UBSAN
- [ ] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64--> All with Aarch64
- [ ] <!---ci_exclude_KEYWORD--> Add your option here

#### Extra options:
- [ ] <!---do_not_test--> do not test (only style check)
- [ ] <!---no_merge_commit--> disable merge-commit (no merge from master before tests)
- [ ] <!---no_ci_cache--> disable CI cache (job reuse)

#### Only specified batches in multi-batch jobs:
- [ ] <!---batch_0--> 1
- [ ] <!---batch_1--> 2
- [ ] <!---batch_2--> 3
- [ ] <!---batch_3--> 4
