### PR TITLE
Improve performance upper/lower by executing in place and cpu dynamic dispatch

### DIFF
--- a/src/Functions/FunctionStringToString.h
+++ b/src/Functions/FunctionStringToString.h
@@ -1,11 +1,13 @@
 #pragma once
 
-#include <DataTypes/DataTypeString.h>
-#include <Columns/ColumnString.h>
 #include <Columns/ColumnFixedString.h>
+#include <Columns/ColumnString.h>
+#include <DataTypes/DataTypeString.h>
 #include <Functions/FunctionHelpers.h>
 #include <Functions/IFunction.h>
+#include <Functions/LowerUpperImpl.h>
 #include <Interpreters/Context_fwd.h>
+#include <iostream>
 
 
 namespace DB
@@ -61,6 +63,30 @@ public:
 
     ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr &, size_t /*input_rows_count*/) const override
     {
+        if constexpr (IsLowerUpper<Impl>::value)
+        {
+            // std::cout << "is lower upper:" << arguments[0].column->use_count() << std::endl;
+            // std::cout << StackTrace().toString() << std::endl;
+            if (arguments[0].column->use_count() == 1)
+            {
+                // std::cout << "execute in place" << std::endl;
+                MutableColumnPtr mutable_column = arguments[0].column->assumeMutable();
+                if (ColumnString * col = typeid_cast<ColumnString *>(mutable_column.get()))
+                {
+                    Impl::vectorInPlace(col->getChars(), col->getOffsets());
+                    return std::move(mutable_column);
+                }
+                else if (ColumnFixedString * col_fixed = typeid_cast<ColumnFixedString *>(mutable_column.get()))
+                {
+                    Impl::vectorFixedInPlace(col_fixed->getChars(), col_fixed->getN());
+                    return std::move(mutable_column);
+                }
+                else
+                    throw Exception(
+                        ErrorCodes::ILLEGAL_COLUMN, "Illegal column {} of argument of function {}", mutable_column->getName(), getName());
+            }
+        }
+
         const ColumnPtr column = arguments[0].column;
         if (const ColumnString * col = checkAndGetColumn<ColumnString>(column.get()))
         {

--- a/src/Functions/LowerUpperImpl.h
+++ b/src/Functions/LowerUpperImpl.h
@@ -10,11 +10,9 @@
 namespace DB
 {
 
-namespace
-{
 DECLARE_DEFAULT_CODE(
 template <char not_case_lower_bound, char not_case_upper_bound>
-void arrayImpl(const UInt8 * src, const UInt8 * src_end, UInt8 * dst)
+static void arrayImpl(const UInt8 * src, const UInt8 * src_end, UInt8 * dst)
 {
     static constexpr auto flip_case_mask = 'A' ^ 'a';
      for (; src < src_end; ++src, ++dst)
@@ -26,7 +24,7 @@ void arrayImpl(const UInt8 * src, const UInt8 * src_end, UInt8 * dst)
 
 DECLARE_AVX512BW_SPECIFIC_CODE(
 template <char not_case_lower_bound, char not_case_upper_bound>
-void arrayImpl(const UInt8 * src, const UInt8 * src_end, UInt8 * dst)
+static void arrayImpl(const UInt8 * src, const UInt8 * src_end, UInt8 * dst)
 {
     static constexpr auto flip_case_mask = 'A' ^ 'a';
 
@@ -62,7 +60,7 @@ void arrayImpl(const UInt8 * src, const UInt8 * src_end, UInt8 * dst)
 
 DECLARE_AVX2_SPECIFIC_CODE(
 template <char not_case_lower_bound, char not_case_upper_bound>
-void arrayImpl(const UInt8 * src, const UInt8 * src_end, UInt8 * dst)
+static void arrayImpl(const UInt8 * src, const UInt8 * src_end, UInt8 * dst)
 {
     static constexpr auto flip_case_mask = 'A' ^ 'a';
 
@@ -103,7 +101,7 @@ void arrayImpl(const UInt8 * src, const UInt8 * src_end, UInt8 * dst)
 
 DECLARE_SSE42_SPECIFIC_CODE(
 template <char not_case_lower_bound, char not_case_upper_bound>
-void arrayImpl(const UInt8 * src, const UInt8 * src_end, UInt8 * dst)
+static void arrayImpl(const UInt8 * src, const UInt8 * src_end, UInt8 * dst)
 {
     static constexpr auto flip_case_mask = 'A' ^ 'a';
 
@@ -143,7 +141,7 @@ void arrayImpl(const UInt8 * src, const UInt8 * src_end, UInt8 * dst)
 })
 
 template <char not_case_lower_bound, char not_case_upper_bound>
-void array(const UInt8 * src, const UInt8 * src_end, UInt8 * dst)
+static void array(const UInt8 * src, const UInt8 * src_end, UInt8 * dst)
 {
 #if USE_MULTITARGET_CODE
     if (isArchSupported(TargetArch::AVX512BW))
@@ -155,8 +153,6 @@ void array(const UInt8 * src, const UInt8 * src_end, UInt8 * dst)
     else
 #endif
     TargetSpecific::Default::arrayImpl<not_case_lower_bound, not_case_upper_bound>(src, src_end, dst);
-}
-
 }
 
 template <char not_case_lower_bound, char not_case_upper_bound>
@@ -188,7 +184,6 @@ struct LowerUpperImpl
     {
         array<not_case_lower_bound, not_case_upper_bound>(data.data(), data.data() + data.size(), data.data());
     }
-
 };
 
 template <typename T>

--- a/src/Functions/LowerUpperImpl.h
+++ b/src/Functions/LowerUpperImpl.h
@@ -1,9 +1,163 @@
 #pragma once
 #include <Columns/ColumnString.h>
+#include <Common/TargetSpecific.h>
+
+#if USE_MULTITARGET_CODE
+#include <immintrin.h>
+#endif
 
 
 namespace DB
 {
+
+namespace
+{
+DECLARE_DEFAULT_CODE(
+template <char not_case_lower_bound, char not_case_upper_bound>
+void arrayImpl(const UInt8 * src, const UInt8 * src_end, UInt8 * dst)
+{
+    static constexpr auto flip_case_mask = 'A' ^ 'a';
+     for (; src < src_end; ++src, ++dst)
+        if (*src >= not_case_lower_bound && *src <= not_case_upper_bound)
+            *dst = *src ^ flip_case_mask;
+        else
+            *dst = *src;
+})
+
+DECLARE_AVX512BW_SPECIFIC_CODE(
+template <char not_case_lower_bound, char not_case_upper_bound>
+void arrayImpl(const UInt8 * src, const UInt8 * src_end, UInt8 * dst)
+{
+    static constexpr auto flip_case_mask = 'A' ^ 'a';
+
+    const auto byte_avx512 = sizeof(__m512i);
+    const auto src_end_avx = src_end - (src_end - src) % byte_avx512;
+    if (src < src_end_avx)
+    {
+        const auto v_not_case_lower_bound = _mm512_set1_epi8(not_case_lower_bound - 1);
+        const auto v_not_case_upper_bound = _mm512_set1_epi8(not_case_upper_bound + 1);
+
+        for (; src < src_end_avx; src += byte_avx512, dst += byte_avx512)
+        {
+            const auto chars = _mm512_loadu_si512(reinterpret_cast<const __m512i *>(src));
+
+            const auto is_not_case
+                    = _mm512_mask_cmplt_epi8_mask(_mm512_cmpgt_epi8_mask(chars, v_not_case_lower_bound),
+                    chars, v_not_case_upper_bound);
+
+            const auto xor_mask = _mm512_maskz_set1_epi8(is_not_case, flip_case_mask);
+
+            const auto cased_chars = _mm512_xor_si512(chars, xor_mask);
+
+            _mm512_storeu_si512(reinterpret_cast<__m512i *>(dst), cased_chars);
+        }
+    }
+
+    for (; src < src_end; ++src, ++dst)
+        if (*src >= not_case_lower_bound && *src <= not_case_upper_bound)
+            *dst = *src ^ flip_case_mask;
+        else
+            *dst = *src;
+})
+
+DECLARE_AVX2_SPECIFIC_CODE(
+template <char not_case_lower_bound, char not_case_upper_bound>
+void arrayImpl(const UInt8 * src, const UInt8 * src_end, UInt8 * dst)
+{
+    static constexpr auto flip_case_mask = 'A' ^ 'a';
+
+    const auto bytes_avx = sizeof(__m256i);
+    const auto * src_end_avx = src_end - (src_end - src) % bytes_avx;
+    if (src < src_end_avx)
+    {
+        const auto v_not_case_lower_bound = _mm256_set1_epi8(not_case_lower_bound - 1);
+        const auto v_not_case_upper_bound = _mm256_set1_epi8(not_case_upper_bound + 1);
+        const auto v_flip_case_mask = _mm256_set1_epi8(flip_case_mask);
+
+        for (; src < src_end_avx; src += bytes_avx, dst += bytes_avx)
+        {
+            /// load 32 sequential 8-bit characters
+            const auto chars = _mm256_loadu_si256(reinterpret_cast<const __m256i *>(src));
+
+            /// find which 8-bit sequences belong to range [case_lower_bound, case_upper_bound]
+            const auto is_not_case
+                = _mm256_and_si256(_mm256_cmpgt_epi8(chars, v_not_case_lower_bound), _mm256_cmpgt_epi8(v_not_case_upper_bound, chars));
+
+            /// keep `flip_case_mask` only where necessary, zero out elsewhere
+            const auto xor_mask = _mm256_and_si256(v_flip_case_mask, is_not_case);
+
+            /// flip case by applying calculated mask
+            const auto cased_chars = _mm256_xor_si256(chars, xor_mask);
+
+            /// store result back to destination
+            _mm256_storeu_si256(reinterpret_cast<__m256i *>(dst), cased_chars);
+        }
+    }
+
+    for (; src < src_end; ++src, ++dst)
+        if (*src >= not_case_lower_bound && *src <= not_case_upper_bound)
+            *dst = *src ^ flip_case_mask;
+        else
+            *dst = *src;
+})
+
+DECLARE_SSE42_SPECIFIC_CODE(
+template <char not_case_lower_bound, char not_case_upper_bound>
+void arrayImpl(const UInt8 * src, const UInt8 * src_end, UInt8 * dst)
+{
+    static constexpr auto flip_case_mask = 'A' ^ 'a';
+
+    const auto bytes_sse = sizeof(__m128i);
+    const auto * src_end_sse = src_end - (src_end - src) % bytes_sse;
+    if (src < src_end_sse)
+    {
+        const auto v_not_case_lower_bound = _mm_set1_epi8(not_case_lower_bound - 1);
+        const auto v_not_case_upper_bound = _mm_set1_epi8(not_case_upper_bound + 1);
+        const auto v_flip_case_mask = _mm_set1_epi8(flip_case_mask);
+
+        for (; src < src_end_sse; src += bytes_sse, dst += bytes_sse)
+        {
+            /// load 16 sequential 8-bit characters
+            const auto chars = _mm_loadu_si128(reinterpret_cast<const __m128i *>(src));
+
+            /// find which 8-bit sequences belong to range [case_lower_bound, case_upper_bound]
+            const auto is_not_case
+                = _mm_and_si128(_mm_cmpgt_epi8(chars, v_not_case_lower_bound), _mm_cmplt_epi8(chars, v_not_case_upper_bound));
+
+            /// keep `flip_case_mask` only where necessary, zero out elsewhere
+            const auto xor_mask = _mm_and_si128(v_flip_case_mask, is_not_case);
+
+            /// flip case by applying calculated mask
+            const auto cased_chars = _mm_xor_si128(chars, xor_mask);
+
+            /// store result back to destination
+            _mm_storeu_si128(reinterpret_cast<__m128i *>(dst), cased_chars);
+        }
+    }
+
+    for (; src < src_end; ++src, ++dst)
+        if (*src >= not_case_lower_bound && *src <= not_case_upper_bound)
+            *dst = *src ^ flip_case_mask;
+        else
+            *dst = *src;
+})
+
+template <char not_case_lower_bound, char not_case_upper_bound>
+void array(const UInt8 * src, const UInt8 * src_end, UInt8 * dst)
+{
+#if USE_MULTITARGET_CODE
+    if (isArchSupported(TargetArch::AVX512BW))
+        TargetSpecific::AVX512BW::arrayImpl<not_case_lower_bound, not_case_upper_bound>(src, src_end, dst);
+    else if (isArchSupported(TargetArch::AVX2))
+        TargetSpecific::AVX2::arrayImpl<not_case_lower_bound, not_case_upper_bound>(src, src_end, dst);
+    else if (isArchSupported(TargetArch::SSE42))
+        TargetSpecific::SSE42::arrayImpl<not_case_lower_bound, not_case_upper_bound>(src, src_end, dst);
+    else
+#endif
+    TargetSpecific::Default::arrayImpl<not_case_lower_bound, not_case_upper_bound>(src, src_end, dst);
+}
+
+}
 
 template <char not_case_lower_bound, char not_case_upper_bound>
 struct LowerUpperImpl
@@ -15,85 +169,32 @@ struct LowerUpperImpl
     {
         res_data.resize(data.size());
         res_offsets.assign(offsets);
-        array(data.data(), data.data() + data.size(), res_data.data());
+        array<not_case_lower_bound, not_case_upper_bound>(data.data(), data.data() + data.size(), res_data.data());
     }
+
+    static void vectorInPlace(ColumnString::Chars & data, ColumnString::Offsets & /*offsets*/)
+    {
+        array<not_case_lower_bound, not_case_upper_bound>(data.data(), data.data() + data.size(), data.data());
+    }
+
 
     static void vectorFixed(const ColumnString::Chars & data, size_t /*n*/, ColumnString::Chars & res_data)
     {
         res_data.resize(data.size());
-        array(data.data(), data.data() + data.size(), res_data.data());
+        array<not_case_lower_bound, not_case_upper_bound>(data.data(), data.data() + data.size(), res_data.data());
     }
 
-private:
-    static void array(const UInt8 * src, const UInt8 * src_end, UInt8 * dst)
+    static void vectorFixedInPlace(ColumnString::Chars & data, size_t /*n*/)
     {
-        const auto flip_case_mask = 'A' ^ 'a';
-
-#if defined(__AVX512F__) && defined(__AVX512BW__) /// check if avx512 instructions are compiled
-        if (isArchSupported(TargetArch::AVX512BW))
-        {
-            /// check if cpu support avx512 dynamically, haveAVX512BW contains check of haveAVX512F
-            const auto byte_avx512 = sizeof(__m512i);
-            const auto src_end_avx = src_end - (src_end - src) % byte_avx512;
-            if (src < src_end_avx)
-            {
-                const auto v_not_case_lower_bound = _mm512_set1_epi8(not_case_lower_bound - 1);
-                const auto v_not_case_upper_bound = _mm512_set1_epi8(not_case_upper_bound + 1);
-
-                for (; src < src_end_avx; src += byte_avx512, dst += byte_avx512)
-                {
-                    const auto chars = _mm512_loadu_si512(reinterpret_cast<const __m512i *>(src));
-
-                    const auto is_not_case
-                            = _mm512_mask_cmplt_epi8_mask(_mm512_cmpgt_epi8_mask(chars, v_not_case_lower_bound),
-                            chars, v_not_case_upper_bound);
-
-                    const auto xor_mask = _mm512_maskz_set1_epi8(is_not_case, flip_case_mask);
-
-                    const auto cased_chars = _mm512_xor_si512(chars, xor_mask);
-
-                    _mm512_storeu_si512(reinterpret_cast<__m512i *>(dst), cased_chars);
-                }
-            }
-        }
-#endif
-
-#ifdef __SSE2__
-        const auto bytes_sse = sizeof(__m128i);
-        const auto * src_end_sse = src_end - (src_end - src) % bytes_sse;
-        if (src < src_end_sse)
-        {
-            const auto v_not_case_lower_bound = _mm_set1_epi8(not_case_lower_bound - 1);
-            const auto v_not_case_upper_bound = _mm_set1_epi8(not_case_upper_bound + 1);
-            const auto v_flip_case_mask = _mm_set1_epi8(flip_case_mask);
-
-            for (; src < src_end_sse; src += bytes_sse, dst += bytes_sse)
-            {
-                /// load 16 sequential 8-bit characters
-                const auto chars = _mm_loadu_si128(reinterpret_cast<const __m128i *>(src));
-
-                /// find which 8-bit sequences belong to range [case_lower_bound, case_upper_bound]
-                const auto is_not_case
-                    = _mm_and_si128(_mm_cmpgt_epi8(chars, v_not_case_lower_bound), _mm_cmplt_epi8(chars, v_not_case_upper_bound));
-
-                /// keep `flip_case_mask` only where necessary, zero out elsewhere
-                const auto xor_mask = _mm_and_si128(v_flip_case_mask, is_not_case);
-
-                /// flip case by applying calculated mask
-                const auto cased_chars = _mm_xor_si128(chars, xor_mask);
-
-                /// store result back to destination
-                _mm_storeu_si128(reinterpret_cast<__m128i *>(dst), cased_chars);
-            }
-        }
-#endif
-
-        for (; src < src_end; ++src, ++dst)
-            if (*src >= not_case_lower_bound && *src <= not_case_upper_bound)
-                *dst = *src ^ flip_case_mask;
-            else
-                *dst = *src;
+        array<not_case_lower_bound, not_case_upper_bound>(data.data(), data.data() + data.size(), data.data());
     }
+
 };
+
+template <typename T>
+struct IsLowerUpper: std::false_type {};
+
+template <char not_case_lower_bound, char not_case_upper_bound>
+struct IsLowerUpper<LowerUpperImpl<not_case_lower_bound, not_case_upper_bound>> : std::true_type {};
 
 }


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Improve performance upper/lower by executing in place and cpu dynamic dispatch 

TODO: apply it for other string functions like `initcap` and `substring`


A simple test shows 1.49x speedup. 
```
Q:  select lower(materialize('hello world')) from numbers(100000000) format Null;

baseline: 
0 rows in set. Elapsed: 0.484 sec. Processed 100.00 million rows, 800.00 MB (206.48 million rows/s., 1.65 GB/s.)
Peak memory usage: 4.51 MiB. 

opt1: execute lower/upper in place if needed
0 rows in set. Elapsed: 0.397 sec. Processed 100.00 million rows, 800.00 MB (251.89 million rows/s., 2.02 GB/s.)
Peak memory usage: 4.50 MiB. 

opt2: opt1 + cpu dynamic dispatch 
0 rows in set. Elapsed: 0.324 sec. Processed 100.00 million rows, 800.00 MB (308.31 million rows/s., 2.47 GB/s.)
Peak memory usage: 4.50 MiB. 
```