### PR TITLE
Add validate checksum nyc library

### DIFF
--- a/docs/en/getting-started/example-datasets/menus.md
+++ b/docs/en/getting-started/example-datasets/menus.md
@@ -18,6 +18,9 @@ Run the command:
 
 ```bash
 wget https://s3.amazonaws.com/menusdata.nypl.org/gzips/2021_08_01_07_01_17_data.tgz
+# Option: Validate the checksum
+md5sum 2021_08_01_07_01_17_data.tgz
+# Checksum should be equal to: db6126724de939a5481e3160a2d67d15
 ```
 
 Replace the link to the up to date link from http://menus.nypl.org/data if needed.


### PR DESCRIPTION
### Changelog category (leave one):
- Documentation (changelog entry is not required)

It should be great to add the `checksum` option to validate the `2021_08_01_07_01_17_data.tgz` file is downloaded correctly.

