### PR TITLE
Fix one phony case

### DIFF
--- a/contrib/avro-cmake/CMakeLists.txt
+++ b/contrib/avro-cmake/CMakeLists.txt
@@ -59,15 +59,3 @@ target_link_libraries (_avrocpp PRIVATE boost::headers_only boost::iostreams)
 target_compile_definitions (_avrocpp PUBLIC SNAPPY_CODEC_AVAILABLE)
 target_include_directories (_avrocpp PRIVATE ${SNAPPY_INCLUDE_DIR})
 target_link_libraries (_avrocpp PRIVATE ch_contrib::snappy)
-
-# create a symlink to include headers with <avro/...>
-set(AVRO_INCLUDE_DIR "${CMAKE_CURRENT_BINARY_DIR}/include")
-ADD_CUSTOM_COMMAND(OUTPUT "${AVRO_INCLUDE_DIR}"
-        COMMAND ${CMAKE_COMMAND} -E make_directory "${AVRO_INCLUDE_DIR}"
-        COMMAND ${CMAKE_COMMAND} -E create_symlink "${AVROCPP_ROOT_DIR}/api" "${AVRO_INCLUDE_DIR}/avro"
-        DEPENDS "${AVROCPP_ROOT_DIR}/api"
-)
-ADD_CUSTOM_TARGET(avro_symlink_headers ALL
-        DEPENDS "${AVRO_INCLUDE_DIR}")
-add_dependencies(_avrocpp avro_symlink_headers)
-target_include_directories(_avrocpp SYSTEM BEFORE PUBLIC "${AVRO_INCLUDE_DIR}")

--- a/contrib/avro-cmake/CMakeLists.txt
+++ b/contrib/avro-cmake/CMakeLists.txt
@@ -62,9 +62,12 @@ target_link_libraries (_avrocpp PRIVATE ch_contrib::snappy)
 
 # create a symlink to include headers with <avro/...>
 set(AVRO_INCLUDE_DIR "${CMAKE_CURRENT_BINARY_DIR}/include")
-ADD_CUSTOM_TARGET(avro_symlink_headers ALL
-    COMMAND ${CMAKE_COMMAND} -E make_directory "${AVRO_INCLUDE_DIR}"
-    COMMAND ${CMAKE_COMMAND} -E create_symlink "${AVROCPP_ROOT_DIR}/api" "${AVRO_INCLUDE_DIR}/avro"
+ADD_CUSTOM_COMMAND(OUTPUT "${AVRO_INCLUDE_DIR}"
+        COMMAND ${CMAKE_COMMAND} -E make_directory "${AVRO_INCLUDE_DIR}"
+        COMMAND ${CMAKE_COMMAND} -E create_symlink "${AVROCPP_ROOT_DIR}/api" "${AVRO_INCLUDE_DIR}/avro"
+        DEPENDS "${AVROCPP_ROOT_DIR}/api"
 )
+ADD_CUSTOM_TARGET(avro_symlink_headers ALL
+        DEPENDS "${AVRO_INCLUDE_DIR}")
 add_dependencies(_avrocpp avro_symlink_headers)
 target_include_directories(_avrocpp SYSTEM BEFORE PUBLIC "${AVRO_INCLUDE_DIR}")


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes


Found this when working on https://github.com/ClickHouse/ClickHouse/pull/62297. Without this the command is considered dirty and rechecked every time although nothing should be done:

```
$ ninja -v -d explain clickhouse
ninja explain: output /mnt/ch/ClickHouse/build/CMakeFiles/VerifyGlobs.cmake_force of phony edge with no inputs doesn't exist
ninja explain: /mnt/ch/ClickHouse/build/CMakeFiles/VerifyGlobs.cmake_force is dirty
ninja explain: /mnt/ch/ClickHouse/build/CMakeFiles/cmake.verify_globs is dirty
[0/2] /usr/bin/cmake -P /mnt/ch/ClickHouse/build/CMakeFiles/VerifyGlobs.cmake
ninja explain: output contrib/avro-cmake/CMakeFiles/avro_symlink_headers doesn't exist
ninja explain: contrib/avro-cmake/CMakeFiles/avro_symlink_headers is dirty
[1/1] cd /mnt/ch/ClickHouse/build/contrib/avro-cmake && /usr/bin/cmake -E make_directory /mnt/ch/ClickHouse/build/contrib/avro-cmake/include && /usr/bin/cmake -E create_symlink /mnt/ch/ClickHouse/contrib/avro/lang/c++/api /mnt/ch/ClickHouse/build/contrib/avro-cmake/include/avro
```


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

---
### Modify your CI run:
**NOTE:** If your merge the PR with modified CI you **MUST KNOW** what you are doing
**NOTE:** Checked options will be applied if set before CI RunConfig/PrepareRunConfig step

#### Include tests (required builds will be added automatically):
- [ ] <!---ci_include_fast--> Fast test
- [ ] <!---ci_include_integration--> Integration Tests
- [ ] <!---ci_include_stateless--> Stateless tests
- [ ] <!---ci_include_stateful--> Stateful tests
- [ ] <!---ci_include_unit--> Unit tests
- [ ] <!---ci_include_performance--> Performance tests
- [ ] <!---ci_include_asan--> All with ASAN
- [ ] <!---ci_include_tsan--> All with TSAN
- [ ] <!---ci_include_analyzer--> All with Analyzer
- [ ] <!---ci_include_KEYWORD--> Add your option here

#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [ ] <!---ci_exclude_tsan--> All with TSAN
- [ ] <!---ci_exclude_msan--> All with MSAN
- [ ] <!---ci_exclude_ubsan--> All with UBSAN
- [ ] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64--> All with Aarch64
- [ ] <!---ci_exclude_KEYWORD--> Add your option here

#### Extra options:
- [ ] <!---do_not_test--> do not test (only style check)
- [ ] <!---no_merge_commit--> disable merge-commit (no merge from master before tests)
- [ ] <!---no_ci_cache--> disable CI cache (job reuse)

#### Only specified batches in multi-batch jobs:
- [ ] <!---batch_0--> 1
- [ ] <!---batch_1--> 2
- [ ] <!---batch_2--> 3
- [ ] <!---batch_3--> 4
