### PR TITLE
Remove useless param, fix typo and query result

### DIFF
--- a/docs/en/getting-started/example-datasets/opensky.md
+++ b/docs/en/getting-started/example-datasets/opensky.md
@@ -7,7 +7,7 @@ title: "Crowdsourced air traffic data from The OpenSky Network 2020"
 
 The data in this dataset is derived and cleaned from the full OpenSky dataset to illustrate the development of air traffic during the COVID-19 pandemic. It spans all flights seen by the network's more than 2500 members since 1 January 2019. More data will be periodically included in the dataset until the end of the COVID-19 pandemic.
 
-Source: https://zenodo.org/record/5092942#.YRBCyTpRXYd
+Source: https://zenodo.org/records/5092942
 
 Martin Strohmeier, Xavier Olive, Jannis Luebbe, Matthias Schaefer, and Vincent Lenders
 "Crowdsourced air traffic data from the OpenSky Network 2019–2020"
@@ -19,7 +19,7 @@ https://doi.org/10.5194/essd-13-357-2021
 Run the command:
 
 ```bash
-wget -O- https://zenodo.org/record/5092942 | grep -oP 'https://zenodo.org/record/5092942/files/flightlist_\d+_\d+\.csv\.gz' | xargs wget
+wget -O- https://zenodo.org/records/5092942 | grep -oE 'https://zenodo.org/records/5092942/files/flightlist_[0-9]+_[0-9]+\.csv\.gz' | xargs wget
 ```
 
 Download will take about 2 minutes with good internet connection. There are 30 files with total size of 4.3 GB.
@@ -134,7 +134,7 @@ Result:
 
 ```text
 ┌─avg(geoDistance(longitude_1, latitude_1, longitude_2, latitude_2))─┐
-│                                                 1041090.6465708319 │
+│                                                 1041090.6360469435 │
 └────────────────────────────────────────────────────────────────────┘
 ```
 

--- a/docs/en/getting-started/example-datasets/opensky.md
+++ b/docs/en/getting-started/example-datasets/opensky.md
@@ -127,15 +127,15 @@ Average flight distance is around 1000 km.
 Query:
 
 ```sql
-SELECT avg(geoDistance(longitude_1, latitude_1, longitude_2, latitude_2)) FROM opensky;
+SELECT round(avg(geoDistance(longitude_1, latitude_1, longitude_2, latitude_2)), 2) FROM opensky;
 ```
 
 Result:
 
 ```text
-┌─avg(geoDistance(longitude_1, latitude_1, longitude_2, latitude_2))─┐
-│                                                 1041090.6360469435 │
-└────────────────────────────────────────────────────────────────────┘
+   ┌─round(avg(geoDistance(longitude_1, latitude_1, longitude_2, latitude_2)), 2)─┐
+1. │                                                                   1041090.67 │ -- 1.04 million
+   └──────────────────────────────────────────────────────────────────────────────┘
 ```
 
 ### Most busy origin airports and the average distance seen {#busy-airports-average-distance}


### PR DESCRIPTION
### Changelog category (leave one):
- Documentation (changelog entry is not required)

Improving the `opensky` example dataset documentation.

1. The `#.YRBCyTpRXYd` is not necessary and it's fine to remove.
2. Fix typo for downloading dataset record URL.
3. Correct the query result.

The original link pattern is not correct and it will not match any link:

```bash
$ wget -O- https://zenodo.org/record/5092942 | grep -oP 'https://zenodo.org/records/5092942/files/flightlist_\d+_\d+\.csv\.gz' | xargs wget
Saving to: ‘STDOUT’

-                          100%[========================================>] 946.23K   535KB/s    in 1.8s

2024-04-08 13:47:23 (535 KB/s) - written to stdout [968942/968942]

wget: missing URL
Usage: wget [OPTION]... [URL]...

Try `wget --help' for more options.
```

After fixing the typo, it can match these files:

```bash
$ wget -O- https://zenodo.org/record/5092942 | grep -oP 'https://zenodo.org/record/5092942/files/flightlist_\d+_\d+\.csv\.gz' | xargs wget
Resolving zenodo.org (zenodo.org)... 188.185.79.172, 188.184.98.238, 188.184.103.159, ...
Connecting to zenodo.org (zenodo.org)|188.185.79.172|:443... connected.
HTTP request sent, awaiting response... 301 MOVED PERMANENTLY
Location: /records/5092942 [following]
--2024-04-08 13:28:52--  https://zenodo.org/records/5092942
Reusing existing connection to zenodo.org:443.
HTTP request sent, awaiting response... 200 OK
Length: 968893 (946K) [text/html]
Saving to: ‘STDOUT’

-                          100%[========================================>] 946.18K   490KB/s    in 1.9s

2024-04-08 13:28:55 (490 KB/s) - written to stdout [968893/968893]

--2024-04-08 13:28:55--  https://zenodo.org/records/5092942/files/flightlist_20190501_20190531.csv.gz
Resolving zenodo.org (zenodo.org)... 188.184.103.159, 188.184.98.238, 188.185.79.172, ...
Connecting to zenodo.org (zenodo.org)|188.184.103.159|:443... connected.
.......
```

When executing the `SELECT avg(geoDistance(longitude_1, latitude_1, longitude_2, latitude_2)) FROM opensky;` query, it's different from original query result.

The original query result seems to be incorrect and it is as follows:

```
┌─avg(geoDistance(longitude_1, latitude_1, longitude_2, latitude_2))─┐
│                                                 1041090.6465708319 │
└────────────────────────────────────────────────────────────────────┘
```

And I retrieve the actual query result that is as follows:

```
┌─avg(geoDistance(longitude_1, latitude_1, longitude_2, latitude_2))─┐
│                                                 1041090.6360469435 │
└────────────────────────────────────────────────────────────────────┘
```