### PR TITLE
Fix logical error 'numbers_storage.step != UInt64{0}'

### DIFF
--- a/src/TableFunctions/TableFunctionNumbers.cpp
+++ b/src/TableFunctions/TableFunctionNumbers.cpp
@@ -20,6 +20,7 @@ namespace ErrorCodes
 {
 extern const int NUMBER_OF_ARGUMENTS_DOESNT_MATCH;
 extern const int ILLEGAL_TYPE_OF_ARGUMENT;
+extern const int BAD_ARGUMENTS;
 }
 
 namespace
@@ -77,6 +78,9 @@ StoragePtr TableFunctionNumbers<multithreaded>::executeImpl(
         UInt64 offset = arguments.size() >= 2 ? evaluateArgument(context, arguments[0]) : 0;
         UInt64 length = arguments.size() >= 2 ? evaluateArgument(context, arguments[1]) : evaluateArgument(context, arguments[0]);
         UInt64 step = arguments.size() == 3 ? evaluateArgument(context, arguments[2]) : 1;
+
+        if (!step)
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Table function {} requires step to be a positive number", getName());
 
         auto res = std::make_shared<StorageSystemNumbers>(
             StorageID(getDatabaseName(), table_name), multithreaded, std::string{"number"}, length, offset, step);

--- a/tests/queries/0_stateless/03037_zero_step_in_numbers_table_function.sql
+++ b/tests/queries/0_stateless/03037_zero_step_in_numbers_table_function.sql
@@ -1,0 +1,2 @@
+select * from numbers(1, 10, 0); -- {serverError BAD_ARGUMENTS}
+


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

