### PR TITLE
Avoid uncaught exception for onFault handler

### DIFF
--- a/src/Daemon/BaseDaemon.cpp
+++ b/src/Daemon/BaseDaemon.cpp
@@ -332,6 +332,7 @@ private:
         const std::vector<StackTrace::FramePointers> & thread_frame_pointers,
         UInt32 thread_num,
         ThreadStatus * thread_ptr) const
+    try
     {
         ThreadStatus thread_status;
 
@@ -542,6 +543,11 @@ private:
             thread_ptr->onFatalError();
 
         fatal_error_printed.test_and_set();
+    }
+    catch (...)
+    {
+        PreformattedMessage message = getCurrentExceptionMessageAndPattern(true);
+        LOG_FATAL(getLogger(__PRETTY_FUNCTION__), message);
     }
 };
 

--- a/src/Daemon/BaseDaemon.cpp
+++ b/src/Daemon/BaseDaemon.cpp
@@ -520,7 +520,7 @@ private:
             }
         }
 
-        /// ClickHouse Keeper does not link to some part of Settings.
+        /// ClickHouse Keeper does not link to some parts of Settings.
 #ifndef CLICKHOUSE_KEEPER_STANDALONE_BUILD
         /// List changed settings.
         if (!query_id.empty())
@@ -538,7 +538,7 @@ private:
         }
 #endif
 
-        /// When everything is done, we will try to send these error messages to client.
+        /// When everything is done, we will try to send these error messages to the client.
         if (thread_ptr)
             thread_ptr->onFatalError();
 
@@ -546,6 +546,7 @@ private:
     }
     catch (...)
     {
+        /// onFault is called from the std::thread, and it should catch all exceptions; otherwise, you can get unrelated fatal errors.
         PreformattedMessage message = getCurrentExceptionMessageAndPattern(true);
         LOG_FATAL(getLogger(__PRETTY_FUNCTION__), message);
     }


### PR DESCRIPTION
onFault() is called from the std::thread, and it should catch all exceptions, otherwise you can unrelated fatal errors.

<details>

<summary>stacktrace</summary>

    2024.04.08 13:15:29.526847 [ 2067427 ] {} <Fatal> BaseDaemon: (version 24.2.2.71 (official build), build id: 57F857DCFE8BA6838F6463E4665CD700852BFF0E, git hash: 9293d361e72be9f6ccfd444d504e2137b2e837cf) (from thread 2118603) Terminate called for uncaught exception:
    2024.04.08 13:15:29.526904 [ 2067427 ] {} <Fatal> BaseDaemon: Code: 210. DB::NetException: I/O error: Broken pipe, while writing to socket (10.61.7.253:9000 -> 10.101.53.134:46036). (NETWORK_ERROR), Stack trace (when copying this message, always include the lines below):
    2024.04.08 13:15:29.526983 [ 2067427 ] {} <Fatal> BaseDaemon:
    2024.04.08 13:15:29.527042 [ 2067427 ] {} <Fatal> BaseDaemon: 0. ./build_docker/./src/Common/Exception.cpp:96: DB::Exception::Exception(DB::Exception::MessageMasked&&, int, bool) @ 0x000000000cf5af1b
    2024.04.08 13:15:29.527061 [ 2067427 ] {} <Fatal> BaseDaemon: 1. ./contrib/llvm-project/libcxx/include/string:1499: DB::NetException::NetException<String, String, String>(int, FormatStringHelperImpl<std::type_identity<String>::type, std::type_identity<String>::type, std::type_identity<String>::type>, String&&, String&&, String&&) @ 0x000000000d07dfe1
    2024.04.08 13:15:29.527082 [ 2067427 ] {} <Fatal> BaseDaemon: 2. ./build_docker/./src/IO/WriteBufferFromPocoSocket.cpp:0: DB::WriteBufferFromPocoSocket::nextImpl() @ 0x000000000d07e97e
    2024.04.08 13:15:29.527125 [ 2067427 ] {} <Fatal> BaseDaemon: 3. ./src/IO/WriteBuffer.h:65: DB::TCPHandler::sendLogs() @ 0x0000000012fd31c1
    2024.04.08 13:15:29.527144 [ 2067427 ] {} <Fatal> BaseDaemon: 4. ./contrib/llvm-project/libcxx/include/atomic:958: void std::__function::__policy_invoker<void ()>::__call_impl<std::__function::__default_alloc_func<DB::TCPHandler::runImpl()::$_0, void ()>>(std::__function::__policy_storage const*) @ 0x0000000012fdcc6e
    2024.04.08 13:15:29.527163 [ 2067427 ] {} <Fatal> BaseDaemon: 5. ./contrib/llvm-project/libcxx/include/__functional/function.h:0: ? @ 0x000000000d25c65b
    2024.04.08 13:15:29.527182 [ 2067427 ] {} <Fatal> BaseDaemon: 6. ./build_docker/./src/Daemon/BaseDaemon.cpp:286: void* std::__thread_proxy[abi:v15000]<std::tuple<std::unique_ptr<std::__thread_struct, std::default_delete<std::__thread_struct>>, SignalListener::run()::'lambda'()>>(void*) @ 0x000000000d25e775
    2024.04.08 13:15:29.527191 [ 2067427 ] {} <Fatal> BaseDaemon: 7. ? @ 0x00007f0fe4906609
    2024.04.08 13:15:29.527211 [ 2067427 ] {} <Fatal> BaseDaemon: 8. ? @ 0x00007f0fe482b353

    2024.04.08 13:15:29.534235 [ 2118604 ] {} <Fatal> BaseDaemon: ########## Short fault info ############
    2024.04.08 13:15:29.534347 [ 2118604 ] {} <Fatal> BaseDaemon: (version 24.2.2.71 (official build), build id: 57F857DCFE8BA6838F6463E4665CD700852BFF0E, git hash: 9293d361e72be9f6ccfd444d504e2137b2e837cf) (from thread 2118603) Received signal 6
    2024.04.08 13:15:29.534476 [ 2118604 ] {} <Fatal> BaseDaemon: Signal description: Aborted
    2024.04.08 13:15:29.534484 [ 2118604 ] {} <Fatal> BaseDaemon:
    2024.04.08 13:15:29.534510 [ 2118604 ] {} <Fatal> BaseDaemon: Stack trace: 0x00007f0fe474f00b 0x00007f0fe472e859 0x000000000d24f72e 0x0000000017d15be3 0x0000000017d15818 0x0000000012fd350d 0x0000000012fdcc6e 0x000000000d25c65b 0x000000000d25e775 0x00007f0fe4906609 0x00007f0fe482b353
    2024.04.08 13:15:29.534531 [ 2118604 ] {} <Fatal> BaseDaemon: ########################################
    2024.04.08 13:15:29.534609 [ 2118604 ] {} <Fatal> BaseDaemon: (version 24.2.2.71 (official build), build id: 57F857DCFE8BA6838F6463E4665CD700852BFF0E, git hash: 9293d361e72be9f6ccfd444d504e2137b2e837cf) (from thread 2118603) (no query) Received signal Aborted (6)
    2024.04.08 13:15:29.534638 [ 2118604 ] {} <Fatal> BaseDaemon:
    2024.04.08 13:15:29.534663 [ 2118604 ] {} <Fatal> BaseDaemon: Stack trace: 0x00007f0fe474f00b 0x00007f0fe472e859 0x000000000d24f72e 0x0000000017d15be3 0x0000000017d15818 0x0000000012fd350d 0x0000000012fdcc6e 0x000000000d25c65b 0x000000000d25e775 0x00007f0fe4906609 0x00007f0fe482b353
    2024.04.08 13:15:29.534711 [ 2118604 ] {} <Fatal> BaseDaemon: 2. ? @ 0x00007f0fe474f00b
    2024.04.08 13:15:29.534728 [ 2118604 ] {} <Fatal> BaseDaemon: 3. ? @ 0x00007f0fe472e859
    2024.04.08 13:15:29.613230 [ 2118604 ] {} <Fatal> BaseDaemon: 4.0. inlined from ./contrib/llvm-project/libcxxabi/src/cxa_exception.cpp:670: __cxa_decrement_exception_refcount
    2024.04.08 13:15:29.613283 [ 2118604 ] {} <Fatal> BaseDaemon: 4.1. inlined from ./contrib/llvm-project/libcxx/src/support/runtime/exception_pointer_cxxabi.ipp:17: ~exception_ptr
    2024.04.08 13:15:29.613311 [ 2118604 ] {} <Fatal> BaseDaemon: 4. ./build_docker/./src/Daemon/BaseDaemon.cpp:591: terminate_handler() @ 0x000000000d24f72e
    2024.04.08 13:15:29.617590 [ 2118604 ] {} <Fatal> BaseDaemon: 5. ./build_docker/./contrib/llvm-project/libcxxabi/src/cxa_handlers.cpp:61: std::__terminate(void (*)()) @ 0x0000000017d15be3
    2024.04.08 13:15:29.619575 [ 2118604 ] {} <Fatal> BaseDaemon: 6. ./build_docker/./contrib/llvm-project/libcxxabi/src/cxa_exception.cpp:0: __cxa_rethrow @ 0x0000000017d15818
    2024.04.08 13:15:30.104097 [ 2118604 ] {} <Fatal> BaseDaemon: 7.0. inlined from ./src/IO/WriteBuffer.h:0: DB::WriteBuffer::next()
    2024.04.08 13:15:30.104331 [ 2118604 ] {} <Fatal> BaseDaemon: 7.1. inlined from ./build_docker/./src/Server/TCPHandler.cpp:2225: DB::TCPHandler::sendLogData(DB::Block const&)
    2024.04.08 13:15:30.104408 [ 2118604 ] {} <Fatal> BaseDaemon: 7. ./build_docker/./src/Server/TCPHandler.cpp:2303: DB::TCPHandler::sendLogs() @ 0x0000000012fd350d
    2024.04.08 13:15:30.217481 [ 2118604 ] {} <Fatal> BaseDaemon: 8.0. inlined from ./contrib/llvm-project/libcxx/include/atomic:958: double std::__cxx_atomic_load[abi:v15000]<double>(std::__cxx_atomic_base_impl<double> const*, std::memory_order)
    2024.04.08 13:15:30.217579 [ 2118604 ] {} <Fatal> BaseDaemon: 8.1. inlined from ./contrib/llvm-project/libcxx/include/atomic:1588: std::__atomic_base<double, false>::load[abi:v15000](std::memory_order) const
    2024.04.08 13:15:30.217617 [ 2118604 ] {} <Fatal> BaseDaemon: 8.2. inlined from ./src/Common/ThreadFuzzer.cpp:407: pthread_mutex_unlock
    2024.04.08 13:15:30.217644 [ 2118604 ] {} <Fatal> BaseDaemon: 8.3. inlined from ./contrib/llvm-project/libcxx/include/__threading_support:314: std::__libcpp_mutex_unlock[abi:v15000](pthread_mutex_t*)
    2024.04.08 13:15:30.217676 [ 2118604 ] {} <Fatal> BaseDaemon: 8.4. inlined from ./contrib/llvm-project/libcxx/src/mutex.cpp:52: std::mutex::unlock()
    2024.04.08 13:15:30.217699 [ 2118604 ] {} <Fatal> BaseDaemon: 8.5. inlined from ./contrib/llvm-project/libcxx/include/__mutex_base:100: ~lock_guard
    2024.04.08 13:15:30.217747 [ 2118604 ] {} <Fatal> BaseDaemon: 8.6. inlined from ./build_docker/./src/Server/TCPHandler.cpp:392: operator()
    2024.04.08 13:15:30.217776 [ 2118604 ] {} <Fatal> BaseDaemon: 8.7. inlined from ./contrib/llvm-project/libcxx/include/__functional/invoke.h:394: ?
    2024.04.08 13:15:30.217796 [ 2118604 ] {} <Fatal> BaseDaemon: 8.8. inlined from ./contrib/llvm-project/libcxx/include/__functional/invoke.h:479: ?
    2024.04.08 13:15:30.217859 [ 2118604 ] {} <Fatal> BaseDaemon: 8.9. inlined from ./contrib/llvm-project/libcxx/include/__functional/function.h:235: ?
    2024.04.08 13:15:30.217878 [ 2118604 ] {} <Fatal> BaseDaemon: 8. ./contrib/llvm-project/libcxx/include/__functional/function.h:716: ? @ 0x0000000012fdcc6e
    2024.04.08 13:15:30.240809 [ 2118604 ] {} <Fatal> BaseDaemon: 9. ./contrib/llvm-project/libcxx/include/__functional/function.h:0: ? @ 0x000000000d25c65b
    2024.04.08 13:15:30.283617 [ 2118604 ] {} <Fatal> BaseDaemon: 10.0. inlined from ./build_docker/./src/Daemon/BaseDaemon.cpp:286: operator()
    2024.04.08 13:15:30.283686 [ 2118604 ] {} <Fatal> BaseDaemon: 10.1. inlined from ./contrib/llvm-project/libcxx/include/__functional/invoke.h:394: ?
    2024.04.08 13:15:30.283725 [ 2118604 ] {} <Fatal> BaseDaemon: 10.2. inlined from ./contrib/llvm-project/libcxx/include/thread:284: void std::__thread_execute[abi:v15000]<std::unique_ptr<std::__thread_struct, std::default_delete<std::__thread_struct>>, SignalListener::run()::'lambda'()>(std::tuple<std::unique_ptr<std::__thread_struct, std::default_delete<std::__thread_struct>>, SignalListener::run()::'lambda'()>&, std::__tuple_indices<>)
    2024.04.08 13:15:30.283755 [ 2118604 ] {} <Fatal> BaseDaemon: 10. ./contrib/llvm-project/libcxx/include/thread:295: void* std::__thread_proxy[abi:v15000]<std::tuple<std::unique_ptr<std::__thread_struct, std::default_delete<std::__thread_struct>>, SignalListener::run()::'lambda'()>>(void*) @ 0x000000000d25e775
    2024.04.08 13:15:30.283799 [ 2118604 ] {} <Fatal> BaseDaemon: 11. ? @ 0x00007f0fe4906609
    2024.04.08 13:15:30.283821 [ 2118604 ] {} <Fatal> BaseDaemon: 12. ? @ 0x00007f0fe482b353
    2024.04.08 13:15:30.574588 [ 2118604 ] {} <Fatal> BaseDaemon: Integrity check of the executable successfully passed (checksum: 3485110FABDB0C94202BD684999A9814)
    2024.04.08 13:15:30.574704 [ 2118604 ] {} <Fatal> BaseDaemon: Report this error to https://github.com/ClickHouse/ClickHouse/issues

</details>

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)