### PR TITLE
Fix analyzer: group by positional arguments pointing to tuple resolved second time

### DIFF
--- a/src/Analyzer/Passes/QueryAnalysisPass.cpp
+++ b/src/Analyzer/Passes/QueryAnalysisPass.cpp
@@ -6726,11 +6726,11 @@ void QueryAnalyzer::resolveGroupByNode(QueryNode & query_node_typed, IdentifierR
                 expandTuplesInList(group_by_list);
             }
 
-            resolveExpressionNodeList(grouping_sets_keys_list_node, scope, false /*allow_lambda_expression*/, false /*allow_table_expression*/);
-
             if (scope.group_by_use_nulls)
                 for (const auto & group_by_elem : grouping_sets_keys_list_node->as<ListNode &>().getNodes())
                     nullable_group_by_keys.push_back(group_by_elem->clone());
+
+            resolveExpressionNodeList(grouping_sets_keys_list_node, scope, false /*allow_lambda_expression*/, false /*allow_table_expression*/);
         }
 
         for (auto & nullable_group_by_key : nullable_group_by_keys)

--- a/src/Analyzer/Passes/QueryAnalysisPass.cpp
+++ b/src/Analyzer/Passes/QueryAnalysisPass.cpp
@@ -6689,9 +6689,6 @@ void QueryAnalyzer::resolveGroupByNode(QueryNode & query_node_typed, IdentifierR
         QueryTreeNodes nullable_group_by_keys;
         for (auto & grouping_sets_keys_list_node : query_node_typed.getGroupBy().getNodes())
         {
-            if (settings.enable_positional_arguments)
-                replaceNodesWithPositionalArguments(grouping_sets_keys_list_node, query_node_typed.getProjection().getNodes(), scope);
-
             // Remove redundant calls to `tuple` function. It simplifies checking if expression is an aggregation key.
             // It's required to support queries like: SELECT number FROM numbers(3) GROUP BY (number, number % 2)
             auto & group_by_list = grouping_sets_keys_list_node->as<ListNode &>().getNodes();
@@ -6702,6 +6699,9 @@ void QueryAnalyzer::resolveGroupByNode(QueryNode & query_node_typed, IdentifierR
                     nullable_group_by_keys.push_back(group_by_elem->clone());
 
             resolveExpressionNodeList(grouping_sets_keys_list_node, scope, false /*allow_lambda_expression*/, false /*allow_table_expression*/);
+
+            if (settings.enable_positional_arguments)
+                replaceNodesWithPositionalArguments(grouping_sets_keys_list_node, query_node_typed.getProjection().getNodes(), scope);
         }
 
         for (auto & nullable_group_by_key : nullable_group_by_keys)
@@ -6709,9 +6709,6 @@ void QueryAnalyzer::resolveGroupByNode(QueryNode & query_node_typed, IdentifierR
     }
     else
     {
-        if (settings.enable_positional_arguments)
-            replaceNodesWithPositionalArguments(query_node_typed.getGroupByNode(), query_node_typed.getProjection().getNodes(), scope);
-
         // Remove redundant calls to `tuple` function. It simplifies checking if expression is an aggregation key.
         // It's required to support queries like: SELECT number FROM numbers(3) GROUP BY (number, number % 2)
         auto & group_by_list = query_node_typed.getGroupBy().getNodes();
@@ -6725,6 +6722,9 @@ void QueryAnalyzer::resolveGroupByNode(QueryNode & query_node_typed, IdentifierR
         }
 
         resolveExpressionNodeList(query_node_typed.getGroupByNode(), scope, false /*allow_lambda_expression*/, false /*allow_table_expression*/);
+
+        if (settings.enable_positional_arguments)
+            replaceNodesWithPositionalArguments(query_node_typed.getGroupByNode(), query_node_typed.getProjection().getNodes(), scope);
 
         for (auto & nullable_group_by_key : nullable_group_by_keys)
             scope.nullable_group_by_keys.insert(std::move(nullable_group_by_key));


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix analyzer - group by positional arguments already resolved in projection.

closes #62374

Example:
```
SELECT tuple(mapSort(k -> k, map('a', 4))), 1 GROUP BY 1;

Received exception from server (version 24.3.2):
Code: 49. DB::Exception: Received from localhost:9000. DB::Exception: Bad cast from type DB::ColumnNode to DB::IdentifierNode. (LOGICAL_ERROR)
(query: SELECT tuple(mapSort(k -> k, map('a', 4))), 1 GROUP BY 1)
```
Cause: `GROUP BY` positional arguments first replaced by nodes from projection and then if tuple is expanded into list of expressions (which already are resolved in projection) and then group by arguments list is resolved causing an attempt to resolve already resolved expressions.
