### PR TITLE
[Docs] add uniqCombined64 function

### DIFF
--- a/docs/en/sql-reference/aggregate-functions/reference/uniqcombined.md
+++ b/docs/en/sql-reference/aggregate-functions/reference/uniqcombined.md
@@ -46,7 +46,21 @@ Compared to the [uniq](../../../sql-reference/aggregate-functions/reference/uniq
 
 **Example**
 
+Query:
 
+```sql
+SELECT uniqCombined(number) FROM numbers(1e6);
+```
+
+Result:
+
+```response
+┌─uniqCombined(number)─┐
+│              1001148 │ -- 1.00 million
+└──────────────────────┘
+```
+
+See the example section of [uniqCombined64](../../../sql-reference/aggregate-functions/reference/uniqcombined64.md#agg_function-uniqcombined64) for an example of the difference between `uniqCombined` and `uniqCombined64` for much larger inputs.
 
 **See Also**
 

--- a/docs/en/sql-reference/aggregate-functions/reference/uniqcombined.md
+++ b/docs/en/sql-reference/aggregate-functions/reference/uniqcombined.md
@@ -29,13 +29,13 @@ The `uniqCombined` function:
 
 - Calculates a hash (64-bit hash for `String` and 32-bit otherwise) for all parameters in the aggregate, then uses it in calculations.
 - Uses a combination of three algorithms: array, hash table, and HyperLogLog with an error correction table.
-        - For a small number of distinct elements, an array is used. 
-        - When the set size is larger, a hash table is used. 
-        - For a larger number of elements, HyperLogLog is used, which will occupy a fixed amount of memory.
+    - For a small number of distinct elements, an array is used. 
+    - When the set size is larger, a hash table is used. 
+    - For a larger number of elements, HyperLogLog is used, which will occupy a fixed amount of memory.
 - Provides the result deterministically (it does not depend on the query processing order).
 
 :::note    
-Since it uses 32-bit hash for non-`String` type, the result will have very high error for cardinalities significantly larger than `UINT_MAX` (error will raise quickly after a few tens of billions of distinct values), hence in this case you should use [uniqCombined64](../../../sql-reference/aggregate-functions/reference/uniqcombined64.md#agg_function-uniqcombined64)
+Since it uses a 32-bit hash for non-`String` types, the result will have very high error for cardinalities significantly larger than `UINT_MAX` (error will raise quickly after a few tens of billions of distinct values), hence in this case you should use [uniqCombined64](../../../sql-reference/aggregate-functions/reference/uniqcombined64.md#agg_function-uniqcombined64).
 :::
 
 Compared to the [uniq](../../../sql-reference/aggregate-functions/reference/uniq.md#agg_function-uniq) function, the `uniqCombined` function:

--- a/docs/en/sql-reference/aggregate-functions/reference/uniqcombined.md
+++ b/docs/en/sql-reference/aggregate-functions/reference/uniqcombined.md
@@ -15,9 +15,9 @@ The `uniqCombined` function is a good choice for calculating the number of diffe
 
 **Arguments**
 
-The function takes a variable number of parameters. Parameters can be `Tuple`, `Array`, `Date`, `DateTime`, `String`, or numeric types.
+- `HLL_precision`: The base-2 logarithm of the number of cells in [HyperLogLog](https://en.wikipedia.org/wiki/HyperLogLog). Optional, you can use the function as `uniqCombined(x[, ...])`. The default value for `HLL_precision` is 17, which is effectively 96 KiB of space (2^17 cells, 6 bits each).
+- `X`: A variable number of parameters. Parameters can be `Tuple`, `Array`, `Date`, `DateTime`, `String`, or numeric types.
 
-`HLL_precision` is the base-2 logarithm of the number of cells in [HyperLogLog](https://en.wikipedia.org/wiki/HyperLogLog). Optional, you can use the function as `uniqCombined(x[, ...])`. The default value for `HLL_precision` is 17, which is effectively 96 KiB of space (2^17 cells, 6 bits each).
 
 **Returned value**
 
@@ -25,25 +25,28 @@ The function takes a variable number of parameters. Parameters can be `Tuple`, `
 
 **Implementation details**
 
-Function:
+The `uniqCombined` function:
 
 - Calculates a hash (64-bit hash for `String` and 32-bit otherwise) for all parameters in the aggregate, then uses it in calculations.
-
 - Uses a combination of three algorithms: array, hash table, and HyperLogLog with an error correction table.
-
-        For a small number of distinct elements, an array is used. When the set size is larger, a hash table is used. For a larger number of elements, HyperLogLog is used, which will occupy a fixed amount of memory.
-
+        - For a small number of distinct elements, an array is used. 
+        - When the set size is larger, a hash table is used. 
+        - For a larger number of elements, HyperLogLog is used, which will occupy a fixed amount of memory.
 - Provides the result deterministically (it does not depend on the query processing order).
 
 :::note    
 Since it uses 32-bit hash for non-`String` type, the result will have very high error for cardinalities significantly larger than `UINT_MAX` (error will raise quickly after a few tens of billions of distinct values), hence in this case you should use [uniqCombined64](../../../sql-reference/aggregate-functions/reference/uniqcombined64.md#agg_function-uniqcombined64)
 :::
 
-Compared to the [uniq](../../../sql-reference/aggregate-functions/reference/uniq.md#agg_function-uniq) function, the `uniqCombined`:
+Compared to the [uniq](../../../sql-reference/aggregate-functions/reference/uniq.md#agg_function-uniq) function, the `uniqCombined` function:
 
 - Consumes several times less memory.
 - Calculates with several times higher accuracy.
 - Usually has slightly lower performance. In some scenarios, `uniqCombined` can perform better than `uniq`, for example, with distributed queries that transmit a large number of aggregation states over the network.
+
+**Example**
+
+
 
 **See Also**
 

--- a/docs/en/sql-reference/aggregate-functions/reference/uniqcombined64.md
+++ b/docs/en/sql-reference/aggregate-functions/reference/uniqcombined64.md
@@ -5,4 +5,78 @@ sidebar_position: 193
 
 # uniqCombined64
 
-Same as [uniqCombined](../../../sql-reference/aggregate-functions/reference/uniqcombined.md#agg_function-uniqcombined), but uses 64-bit hash for all data types.
+Calculates the approximate number of different argument values. It is the same as [uniqCombined](../../../sql-reference/aggregate-functions/reference/uniqcombined.md#agg_function-uniqcombined), but uses a 64-bit hash for all data types rather than just for the String data type.
+
+``` sql
+uniqCombined64(HLL_precision)(x[, ...])
+```
+
+**Parameters**
+
+- `HLL_precision`: The base-2 logarithm of the number of cells in [HyperLogLog](https://en.wikipedia.org/wiki/HyperLogLog). Optionally, you can use the function as `uniqCombined64(x[, ...])`. The default value for `HLL_precision` is 17, which is effectively 96 KiB of space (2^17 cells, 6 bits each).
+- `X`: A variable number of parameters. Parameters can be `Tuple`, `Array`, `Date`, `DateTime`, `String`, or numeric types.
+
+**Returned value**
+
+- A number [UInt64](../../../sql-reference/data-types/int-uint.md)-type number.
+
+**Implementation details**
+
+The `uniqCombined64` function:
+- Calculates a hash (64-bit hash for all data types) for all parameters in the aggregate, then uses it in calculations.
+- Uses a combination of three algorithms: array, hash table, and HyperLogLog with an error correction table.
+    - For a small number of distinct elements, an array is used. 
+    - When the set size is larger, a hash table is used. 
+    - For a larger number of elements, HyperLogLog is used, which will occupy a fixed amount of memory.
+- Provides the result deterministically (it does not depend on the query processing order).
+
+:::note
+Since it uses 64-bit hash for all types, the result does not suffer from very high error for cardinalities significantly larger than `UINT_MAX` like [uniqCombined](../../../sql-reference/aggregate-functions/reference/uniqcombined.md) does, which uses a 32-bit hash for non-`String` types.
+:::
+
+Compared to the [uniq](../../../sql-reference/aggregate-functions/reference/uniq.md#agg_function-uniq) function, the `uniqCombined64` function:
+
+- Consumes several times less memory.
+- Calculates with several times higher accuracy.
+
+**Example**
+
+In the example below `uniqCombined64` is run on `1e10` different numbers returning a very close approximation of the number of different argument values. 
+
+Query:
+
+```sql
+SELECT uniqCombined64(number) FROM numbers(1e10);
+```
+
+Result:
+
+```response
+┌─uniqCombined64(number)─┐
+│             9998568925 │ -- 10.00 billion
+└────────────────────────┘
+```
+
+By comparison the `uniqCombined` function returns a rather poor approximation for an input this size.
+
+Query:
+
+```sql
+SELECT uniqCombined(number) FROM numbers(1e10);
+```
+
+Result:
+
+```response
+┌─uniqCombined(number)─┐
+│           5545308725 │ -- 5.55 billion
+└──────────────────────┘
+```
+
+**See Also**
+
+- [uniq](../../../sql-reference/aggregate-functions/reference/uniq.md#agg_function-uniq)
+- [uniqCombined](../../../sql-reference/aggregate-functions/reference/uniqcombined.md)
+- [uniqHLL12](../../../sql-reference/aggregate-functions/reference/uniqhll12.md#agg_function-uniqhll12)
+- [uniqExact](../../../sql-reference/aggregate-functions/reference/uniqexact.md#agg_function-uniqexact)
+- [uniqTheta](../../../sql-reference/aggregate-functions/reference/uniqthetasketch.md#agg_function-uniqthetasketch)


### PR DESCRIPTION
Closes [#2032](https://github.com/ClickHouse/clickhouse-docs/issues/2032) as part of the [function project](https://github.com/ClickHouse/clickhouse-docs/issues/1833) to document missing or incomplete functions. 

This PR:
- adds documentation for `uniqCombined64`
- makes a few small updates to `uniqCombined` function to make it easier to read:

Currently:

![uniqCombined_before](https://github.com/ClickHouse/ClickHouse/assets/41984034/4a47e73f-ee2c-40d3-9407-6d7cc965e5a0)

Updated:

![image](https://github.com/ClickHouse/ClickHouse/assets/41984034/e4191a14-cd99-4d78-8cc4-2d22c7d2218d)

### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Documentation entry for user-facing changes

- [X] Documentation is written (mandatory for new features)