### PR TITLE
Speed up `replaceRegexpAll` and `replaceAll` by replacing underlying regexp library

### DIFF
--- a/src/Common/OptimizedRegularExpression.cpp
+++ b/src/Common/OptimizedRegularExpression.cpp
@@ -639,7 +639,8 @@ bool OptimizedRegularExpression::match(const char * subject, size_t subject_size
 }
 
 
-unsigned OptimizedRegularExpression::match(const char * subject, size_t subject_size, MatchVec & matches, unsigned limit) const
+unsigned OptimizedRegularExpression::match(
+    std::string_view text, const char * subject, size_t subject_size, MatchVec & matches, unsigned limit) const
 {
     const UInt8 * haystack = reinterpret_cast<const UInt8 *>(subject);
     const UInt8 * haystack_end = haystack + subject_size;
@@ -694,9 +695,9 @@ unsigned OptimizedRegularExpression::match(const char * subject, size_t subject_
         DB::PODArrayWithStackMemory<std::string_view, 128> pieces(limit);
 
         if (!re2->Match(
-            {subject, subject_size},
-            0,
-            subject_size,
+            text,
+            subject - text.data(),
+            subject - text.data() + subject_size,
             re2::RE2::UNANCHORED,
             pieces.data(),
             static_cast<int>(pieces.size())))
@@ -710,7 +711,7 @@ unsigned OptimizedRegularExpression::match(const char * subject, size_t subject_
             {
                 if (pieces[i].empty())
                 {
-                    matches[i].offset = std::string::npos;
+                    matches[i].offset = pieces[i].data() - subject;
                     matches[i].length = 0;
                 }
                 else

--- a/src/Common/OptimizedRegularExpression.h
+++ b/src/Common/OptimizedRegularExpression.h
@@ -79,7 +79,7 @@ public:
 
     unsigned match(const char * subject, size_t subject_size, MatchVec & matches, unsigned limit) const
     {
-        std::string_view text{subject, subject};
+        std::string_view text{subject, subject_size};
         return match(text, subject, subject_size, matches, limit);
     }
 

--- a/src/Common/OptimizedRegularExpression.h
+++ b/src/Common/OptimizedRegularExpression.h
@@ -75,7 +75,13 @@ public:
 
     bool match(const char * subject, size_t subject_size) const;
     bool match(const char * subject, size_t subject_size, Match & match) const;
-    unsigned match(const char * subject, size_t subject_size, MatchVec & matches, unsigned limit) const;
+    unsigned match(std::string_view text, const char * subject, size_t subject_size, MatchVec & matches, unsigned limit) const;
+
+    unsigned match(const char * subject, size_t subject_size, MatchVec & matches, unsigned limit) const
+    {
+        std::string_view text{subject, subject};
+        return match(text, subject, subject_size, matches, limit);
+    }
 
     unsigned getNumberOfSubpatterns() const { return number_of_subpatterns; }
 

--- a/src/Functions/ReplaceRegexpImpl.h
+++ b/src/Functions/ReplaceRegexpImpl.h
@@ -36,7 +36,8 @@ static constexpr ReplaceStringTraits::Replace convertToReplaceStringTraits(Repla
         case ReplaceRegexpTraits::Replace::All:
             return ReplaceStringTraits::Replace::All;
     }
-    UNREACHABLE();
+
+    std::unreachable();
 }
 
 /** Replace all matches of regexp 'needle' to string 'replacement'.

--- a/src/Functions/ReplaceRegexpImpl.h
+++ b/src/Functions/ReplaceRegexpImpl.h
@@ -27,9 +27,7 @@ struct ReplaceRegexpTraits
     };
 };
 
-namespace
-{
-constexpr ReplaceStringTraits::Replace convertToReplaceStringTraits(ReplaceRegexpTraits::Replace replace)
+static constexpr ReplaceStringTraits::Replace convertToReplaceStringTraits(ReplaceRegexpTraits::Replace replace)
 {
     switch (replace)
     {
@@ -39,8 +37,6 @@ constexpr ReplaceStringTraits::Replace convertToReplaceStringTraits(ReplaceRegex
             return ReplaceStringTraits::Replace::All;
     }
     UNREACHABLE();
-}
-
 }
 
 /** Replace all matches of regexp 'needle' to string 'replacement'.

--- a/src/Functions/ReplaceRegexpImpl.h
+++ b/src/Functions/ReplaceRegexpImpl.h
@@ -129,23 +129,21 @@ struct ReplaceRegexpImpl
 
             if (searcher->match(haystack, haystack_data + match_pos, haystack_length - match_pos, matches, num_captures))
             {
+                const auto & match = matches[0]; /// Complete match (\0)
+                // std::cout << "match_pos:" << match_pos << ", match offset:" << match.offset << ", copy_pos:" << copy_pos << ", bytes_to_copy:" << bytes_to_copy << std::endl;
                 // std::cout << "match_pos:" << match_pos << ", length:" << haystack_length - match_pos << ", match size:" << matches.size() << std::endl;
                 // for (size_t i = 0; i < matches.size(); ++i)
                 // {
                 //     std::cout << i << ":" << std::string(haystack_data + match_pos + matches[i].offset, matches[i].length) << std::endl;
                 // }
 
-                const auto & match = matches[0]; /// Complete match (\0)
-                size_t bytes_to_copy = match_pos + match.offset - copy_pos;
-                // std::cout << "match_pos:" << match_pos << ", match offset:" << match.offset << ", copy_pos:" << copy_pos << ", bytes_to_copy:" << bytes_to_copy << std::endl;
-
                 /// Copy prefix before current match without modification
+                size_t bytes_to_copy = match_pos + match.offset - copy_pos;
                 res_data.resize(res_data.size() + bytes_to_copy);
                 memcpySmallAllowReadWriteOverflow15(&res_data[res_offset], haystack_data + copy_pos, bytes_to_copy);
                 std::string_view prefix{haystack_data + copy_pos, bytes_to_copy};
                 res_offset += bytes_to_copy;
                 copy_pos += bytes_to_copy;
-                match_pos = copy_pos;
 
                 /// Substitute inside current match using instructions
                 for (const auto & instr : instructions)

--- a/src/Functions/ReplaceStringImpl.h
+++ b/src/Functions/ReplaceStringImpl.h
@@ -47,7 +47,7 @@ struct ReplaceStringImpl
         ColumnString::Offset res_offset = 0;
         res_data.reserve(haystack_data.size());
         const size_t haystack_size = haystack_offsets.size();
-        res_offsets.resize(haystack_size);
+        res_offsets.resize_exact(haystack_size);
 
         /// The current index in the array of strings.
         size_t i = 0;
@@ -61,7 +61,7 @@ struct ReplaceStringImpl
 
             /// Copy the data without changing
             res_data.resize(res_data.size() + (match - pos));
-            memcpy(&res_data[res_offset], pos, match - pos);
+            memcpySmallAllowReadWriteOverflow15(&res_data[res_offset], pos, match - pos);
 
             /// Determine which index it belongs to.
             while (i < haystack_offsets.size() && begin + haystack_offsets[i] <= match)
@@ -82,7 +82,7 @@ struct ReplaceStringImpl
             if (match + needle.size() < begin + haystack_offsets[i])
             {
                 res_data.resize(res_data.size() + replacement.size());
-                memcpy(&res_data[res_offset], replacement.data(), replacement.size());
+                memcpySmallAllowReadWriteOverflow15(&res_data[res_offset], replacement.data(), replacement.size());
                 res_offset += replacement.size();
                 pos = match + needle.size();
                 if constexpr (replace == ReplaceStringTraits::Replace::First)
@@ -97,7 +97,7 @@ struct ReplaceStringImpl
             if (can_finish_current_string)
             {
                 res_data.resize(res_data.size() + (begin + haystack_offsets[i] - pos));
-                memcpy(&res_data[res_offset], pos, (begin + haystack_offsets[i] - pos));
+                memcpySmallAllowReadWriteOverflow15(&res_data[res_offset], pos, (begin + haystack_offsets[i] - pos));
                 res_offset += (begin + haystack_offsets[i] - pos);
                 res_offsets[i] = res_offset;
                 pos = begin + haystack_offsets[i];
@@ -113,7 +113,7 @@ struct ReplaceStringImpl
         ColumnString::Chars & output, ColumnString::Offset & output_offset)
     {
         output.resize(output.size() + what_size);
-        memcpy(&output[output_offset], what_start, what_size);
+        memcpySmallAllowReadWriteOverflow15(&output[output_offset], what_start, what_size);
         output_offset += what_size;
     }
 
@@ -131,7 +131,7 @@ struct ReplaceStringImpl
         const size_t haystack_size = haystack_offsets.size();
 
         res_data.reserve(haystack_data.size());
-        res_offsets.resize(haystack_size);
+        res_offsets.resize_exact(haystack_size);
 
         ColumnString::Offset res_offset = 0;
 
@@ -205,7 +205,7 @@ struct ReplaceStringImpl
         const size_t haystack_size = haystack_offsets.size();
 
         res_data.reserve(haystack_data.size());
-        res_offsets.resize(haystack_size);
+        res_offsets.resize_exact(haystack_size);
 
         ColumnString::Offset res_offset = 0;
 
@@ -275,7 +275,7 @@ struct ReplaceStringImpl
         const size_t haystack_size = haystack_offsets.size();
 
         res_data.reserve(haystack_data.size());
-        res_offsets.resize(haystack_size);
+        res_offsets.resize_exact(haystack_size);
 
         ColumnString::Offset res_offset = 0;
 
@@ -357,7 +357,7 @@ struct ReplaceStringImpl
         ColumnString::Offset res_offset = 0;
         size_t haystack_size = haystack_data.size() / n;
         res_data.reserve(haystack_data.size());
-        res_offsets.resize(haystack_size);
+        res_offsets.resize_exact(haystack_size);
 
         /// The current index in the string array.
         size_t i = 0;
@@ -374,7 +374,7 @@ struct ReplaceStringImpl
     { \
         const size_t len = begin + n * (i + 1) - pos; \
         res_data.resize(res_data.size() + len + 1); \
-        memcpy(&res_data[res_offset], pos, len); \
+        memcpySmallAllowReadWriteOverflow15(&res_data[res_offset], pos, len); \
         res_offset += len; \
         res_data[res_offset++] = 0; \
         res_offsets[i] = res_offset; \
@@ -395,7 +395,7 @@ struct ReplaceStringImpl
 
             /// Copy unchanged part of current string.
             res_data.resize(res_data.size() + (match - pos));
-            memcpy(&res_data[res_offset], pos, match - pos);
+            memcpySmallAllowReadWriteOverflow15(&res_data[res_offset], pos, match - pos);
             res_offset += (match - pos);
 
             /// Is it true that this string no longer needs to perform conversions.
@@ -405,7 +405,7 @@ struct ReplaceStringImpl
             if (match + needle.size() <= begin + n * (i + 1))
             {
                 res_data.resize(res_data.size() + replacement.size());
-                memcpy(&res_data[res_offset], replacement.data(), replacement.size());
+                memcpySmallAllowReadWriteOverflow15(&res_data[res_offset], replacement.data(), replacement.size());
                 res_offset += replacement.size();
                 pos = match + needle.size();
                 if (replace == ReplaceStringTraits::Replace::First || pos == begin + n * (i + 1))

--- a/src/Functions/extract.cpp
+++ b/src/Functions/extract.cpp
@@ -35,7 +35,7 @@ struct ExtractImpl
 
             unsigned count
                 = regexp.match(reinterpret_cast<const char *>(&data[prev_offset]), cur_offset - prev_offset - 1, matches, capture + 1);
-            if (count > capture && matches[capture].offset != std::string::npos)
+            if (count > capture && matches[capture].length)
             {
                 const auto & match = matches[capture];
                 res_data.resize(res_offset + match.length + 1);

--- a/src/Functions/extractAll.cpp
+++ b/src/Functions/extractAll.cpp
@@ -94,7 +94,7 @@ public:
         if (!re->match(pos, end - pos, matches) || !matches[0].length)
             return false;
 
-        if (matches[capture].offset == std::string::npos)
+        if (!matches[capture].length)
         {
             /// Empty match.
             token_begin = pos;

--- a/src/Functions/regexpExtract.cpp
+++ b/src/Functions/regexpExtract.cpp
@@ -109,7 +109,7 @@ private:
         ColumnString::Offsets & res_offsets,
         size_t & res_offset)
     {
-        if (match_index < matches.size() && matches[match_index].offset != std::string::npos)
+        if (match_index < matches.size() && matches[match_index].length)
         {
             const auto & match = matches[match_index];
             res_data.resize(res_offset + match.length + 1);

--- a/tests/performance/replace.xml
+++ b/tests/performance/replace.xml
@@ -1,0 +1,19 @@
+<test>
+    <!-- trivial replaceRegexpAll -->>
+    <query>with 'Many years later as he faced the firing squad, Colonel Aureliano Buendia was to remember that distant afternoon when his father took him to discover ice.' as s select replaceRegexpAll(materialize(s), ' ', '\n') as w from numbers(1000000)</query>
+
+    <!-- trivial replaceRegexOne -->>
+    <query>with 'Many years later as he faced the firing squad, Colonel Aureliano Buendia was to remember that distant afternoon when his father took him to discover ice.' as s select replaceRegexpOne(materialize(s), ' ', '\n') as w from numbers(1000000)</query>
+
+    <!-- non-trivial replaceRegexpAll -->>
+    <query>with 'Many years later as he faced the firing squad, Colonel Aureliano Buendia was to remember that distant afternoon when his father took him to discover ice.' as s select replaceRegexpAll(materialize(s), '\s+', '\\0\n') as w from numbers(100000)</query>
+
+    <!-- non-trivial replaceRegexOne -->>
+    <query>with 'Many years later as he faced the firing squad, Colonel Aureliano Buendia was to remember that distant afternoon when his father took him to discover ice.' as s select replaceRegexpOne(materialize(s), '\s+', '\\0\n') as w from numbers(100000)</query>
+
+    <!-- replaceAll -->>
+    <query>with 'Many years later as he faced the firing squad, Colonel Aureliano Buendia was to remember that distant afternoon when his father took him to discover ice.' as s select replaceAll(materialize(s), ' ', '\n') as w from numbers(1000000)</query>
+
+    <!-- replaceOne -->>
+    <query>with 'Many years later as he faced the firing squad, Colonel Aureliano Buendia was to remember that distant afternoon when his father took him to discover ice.' as s select replaceOne(materialize(s), ' ', '\n') as w from numbers(1000000)</query>
+</test>


### PR DESCRIPTION
- Transform `replaceRegexp(One|All)` to `replace(One|All)` if `pattern` is trivial and `replacement` doesn't contain any captured substitutions. 
- Replace underlying regexp library from `re2` to `OptimizedRegularExpression`. 
- Add a new interface `unsigned match(std::string_view text, const char * subject, size_t subject_size, MatchVec & matches, unsigned limit) const` in `OptimizedRegularExpression` to process cases like:  `select replaceRegexpAll('Hello, World!', '^', 'here: ')`, making it compatiable with original `re2` library. 
- Replace offset value `std::string::npos` with its actual value. It makes sense because even when captured pieces are empty, we still want to know its position for later replacement.


#### Why we need to add a new interface `unsigned match(std::string_view text, const char * subject, size_t subject_size, MatchVec & matches, unsigned limit) const`? 

We have to add a new interface to make sure `OptimizedRegularExpression` have the same functionality with previous regexp library `re2`. 

When invoking `unsigned match(std::string_view text, const char * subject, size_t subject_size, MatchVec & matches, unsigned limit) const`.
- `text`:  the whole input: 'Hello, World!'
- `subject`: pointer to suffix of text after we have processed some prefix of text. In function `regexpRegexpAll`, above `match` method maybe called multiple times. Each time we have the same `text` but different `subject`.
- `subject_size`: suffix length

Consider case: `select replaceRegexpAll('Hello, World!', '^', 'here: ')` . The pattern `^` refers to the beginning of `text` 'Hello, World!', it should be matched only once. But old interface in `OptimizedRegularExpression` doesn't meet the the requirement. 

If we use the new interface above, valid match will only happend once, which makes replacement happen only once. The output matches are:
- First time: subject = haystack_data, length(matches) = 1 and matches[0]: offset 0, length 0
- Second time: subject = haystack_data + 1, length(matches) = 1, length(matches) = 0. 

And the sql will outcome correct output. 

If we use the old interface `unsigned match(const char * subject, size_t subject_size, MatchVec & matches, unsigned limit) const`, it will be invoked multiple times, which makes replacement happen multiple times. The output matches are: 
- First time: subject = haystack_data, length(matches) = 1 and matches[0]: offset 0, length 0
- Second time: subject = haystack_data + 1, length(matches) = 1 and matches[0]: offset 0, length 0
- Multiple loops until  subject reaches end of haystack_data

It is obvious that the sql generate wrong output under current condition.  


### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Speed up `replaceRegexp` by 1.8x (4.41x especially when needle and replacement are trivail ) and `replaceAll` by 1.10x 
