### PR TITLE
Fix completion of available ClickHouse tools

### DIFF
--- a/programs/bash-completion/completions/clickhouse
+++ b/programs/bash-completion/completions/clickhouse
@@ -3,7 +3,7 @@
 function _clickhouse_get_utils()
 {
     local cmd=$1 && shift
-    "$cmd" --help |& awk '/^clickhouse.*args/ { print $2 }'
+    "$cmd" help |& awk '/^clickhouse.*args/ { print $2 }'
 }
 
 function _complete_for_clickhouse_entrypoint_bin()

--- a/programs/main.cpp
+++ b/programs/main.cpp
@@ -487,7 +487,7 @@ int main(int argc_, char ** argv_)
     /// Interpret binary without argument or with arguments starts with dash
     /// ('-') as clickhouse-local for better usability:
     ///
-    ///     clickhouse # dumps help
+    ///     clickhouse help # dumps help
     ///     clickhouse -q 'select 1' # use local
     ///     clickhouse # spawn local
     ///     clickhouse local # spawn local


### PR DESCRIPTION
Now clickhouse --help/ch --help will print --help for clickhouse-local, let's use just "clickhouse help" to get help with list of available tools in clickhouse binary itself.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)