### PR TITLE
[Docs] add L2SquaredNorm function

### DIFF
--- a/docs/en/sql-reference/functions/distance-functions.md
+++ b/docs/en/sql-reference/functions/distance-functions.md
@@ -81,6 +81,43 @@ Result:
 │ 2.23606797749979 │
 └──────────────────┘
 ```
+## L2SquaredNorm
+
+Calculates the square root of the sum of the squares of the vector values (the [L2Norm](#l2norm)) squared.
+
+**Syntax**
+
+```sql
+L2SquaredNorm(vector)
+```
+
+Alias: `normL2Squared`.
+
+***Arguments**
+
+- `vector` — [Tuple](../../sql-reference/data-types/tuple.md) or [Array](../../sql-reference/data-types/array.md).
+
+**Returned value**
+
+- L2-norm squared.
+
+Type: [Float](../../sql-reference/data-types/float.md).
+
+**Example**
+
+Query:
+
+```sql
+SELECT L2SquaredNorm((1, 2));
+```
+
+Result:
+
+```text
+┌─L2SquaredNorm((1, 2))─┐
+│                     5 │
+└───────────────────────┘
+```
 
 ## LinfNorm
 

--- a/utils/check-style/aspell-ignore/en/aspell-dict.txt
+++ b/utils/check-style/aspell-ignore/en/aspell-dict.txt
@@ -860,6 +860,7 @@ Soundex
 SpanKind
 Spearman's
 SquaredDistance
+SquaredNorm
 StartTLS
 StartTime
 StartupSystemTables


### PR DESCRIPTION
Closes [#1988](https://github.com/ClickHouse/clickhouse-docs/issues/1988), Closes [#1921](https://github.com/ClickHouse/clickhouse-docs/issues/1921) as part of the [functions project](https://github.com/ClickHouse/clickhouse-docs/issues/1833) to document missing and incomplete functions in the documentation. 

- Adds `L2SquaredNorm` (alias `normL2Squared`) function which was missing from the documentation. 

### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Documentation entry for user-facing changes

- [X] Documentation is written (mandatory for new features)