### PR TITLE
[Docs] add kostikConsistentHash

### DIFF
--- a/docs/en/sql-reference/functions/distance-functions.md
+++ b/docs/en/sql-reference/functions/distance-functions.md
@@ -82,44 +82,6 @@ Result:
 └──────────────────┘
 ```
 
-## L2SquaredNorm
-
-Calculates the square root of the sum of the squares of the vector values (the [L2Norm](#l2norm)) squared.
-
-**Syntax**
-
-```sql
-L2SquaredNorm(vector)
-```
-
-Alias: `normL2Squared`.
-
-***Arguments**
-
-- `vector` — [Tuple](../../sql-reference/data-types/tuple.md) or [Array](../../sql-reference/data-types/array.md).
-
-**Returned value**
-
-- L2-norm squared.
-
-Type: [Float](../../sql-reference/data-types/float.md).
-
-**Example**
-
-Query:
-
-```sql
-SELECT L2SquaredNorm((1, 2));
-```
-
-Result:
-
-```text
-┌─L2SquaredNorm((1, 2))─┐
-│                     5 │
-└───────────────────────┘
-```
-
 ## LinfNorm
 
 Calculates the maximum of absolute values of a vector.

--- a/docs/en/sql-reference/functions/distance-functions.md
+++ b/docs/en/sql-reference/functions/distance-functions.md
@@ -82,6 +82,44 @@ Result:
 └──────────────────┘
 ```
 
+## L2SquaredNorm
+
+Calculates the square root of the sum of the squares of the vector values (the [L2Norm](#l2norm)) squared.
+
+**Syntax**
+
+```sql
+L2SquaredNorm(vector)
+```
+
+Alias: `normL2Squared`.
+
+***Arguments**
+
+- `vector` — [Tuple](../../sql-reference/data-types/tuple.md) or [Array](../../sql-reference/data-types/array.md).
+
+**Returned value**
+
+- L2-norm squared.
+
+Type: [Float](../../sql-reference/data-types/float.md).
+
+**Example**
+
+Query:
+
+```sql
+SELECT L2SquaredNorm((1, 2));
+```
+
+Result:
+
+```text
+┌─L2SquaredNorm((1, 2))─┐
+│                     5 │
+└───────────────────────┘
+```
+
 ## LinfNorm
 
 Calculates the maximum of absolute values of a vector.

--- a/docs/en/sql-reference/functions/hash-functions.md
+++ b/docs/en/sql-reference/functions/hash-functions.md
@@ -594,6 +594,45 @@ Calculates JumpConsistentHash form a UInt64.
 Accepts two arguments: a UInt64-type key and the number of buckets. Returns Int32.
 For more information, see the link: [JumpConsistentHash](https://arxiv.org/pdf/1406.2294.pdf)
 
+## kostikConsistentHash
+
+An O(1) time and space consistent hash algorithm by Konstantin 'kostik' Oblakov. Previously `yandexConsistentHash`. 
+
+**Syntax**
+
+```sql
+kostikConsistentHash(input, n)
+```
+
+Alias: `yandexConsistentHash` (left for backwards compatibility sake).
+
+**Parameters**
+
+- `input`: A UInt64-type key [UInt64](/docs/en/sql-reference/data-types/int-uint.md).
+- `n`: Number of buckets. [UInt16](/docs/en/sql-reference/data-types/int-uint.md).
+
+**Returned value**
+
+- A [UInt16](/docs/en/sql-reference/data-types/int-uint.md) data type hash value.
+
+**Implementation details**
+
+It is efficient only if n <= 32768. 
+
+**Example**
+
+Query:
+
+```sql
+SELECT kostikConsistentHash(16045690984833335023, 2);
+```
+
+```response
+┌─kostikConsistentHash(16045690984833335023, 2)─┐
+│                                             1 │
+└───────────────────────────────────────────────┘
+```
+
 ## murmurHash2_32, murmurHash2_64
 
 Produces a [MurmurHash2](https://github.com/aappleby/smhasher) hash value.

--- a/utils/check-style/aspell-ignore/en/aspell-dict.txt
+++ b/utils/check-style/aspell-ignore/en/aspell-dict.txt
@@ -452,6 +452,9 @@ Khanna
 KittenHouse
 Klickhouse
 Kolmogorov
+Konstantin
+kostik
+kostikConsistentHash
 Korzeniewski
 Kubernetes
 LDAP
@@ -655,6 +658,7 @@ OTLP
 OUTFILE
 ObjectId
 Observability
+Oblakov
 Octonica
 Ok
 OnTime


### PR DESCRIPTION
Closes [#1969](https://github.com/ClickHouse/clickhouse-docs/issues/1969) as part of the [functions project](https://github.com/ClickHouse/clickhouse-docs/issues/1833) to document missing or incomplete functions in the documentation. 

This PR adds:
- `kostikConsistentHash` (alias: `yandexConsistentHash`)

### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Documentation entry for user-facing changes

- [X] Documentation is written (mandatory for new features)