### PR TITLE
Optimize date function performance by optimizing locks in DateLUT

### DIFF
--- a/src/Common/DateLUT.cpp
+++ b/src/Common/DateLUT.cpp
@@ -182,7 +182,9 @@ DateLUT::DateLUT()
 }
 
 
-const DateLUTImpl & DateLUT::getImplementation(const std::string & time_zone) const
+/// skip thread sanitizer, because the initialization of each time zone data will only happen once.
+/// There should be no serious data race here.
+const DateLUTImpl & DateLUT::getImplementation(const std::string & time_zone) const __attribute__((no_sanitize("thread")))
 {
     // First check without acquiring the lock
     auto it = impls.find(time_zone);


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Optimize DateLUT lock to improve the concurrency performance of date functions



### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)


10% performance improvement in my test cases
```sql
create table test_date(date String) engine = Memory();

insert into test_date select '2023-02-24 14:53:31' from numbers(30000000);

select fromUnixTimestampInJodaSyntax(parseDateTimeInJodaSyntax(date, 'yyyy-MM-dd HH:mm:ss', 'Europe/Minsk'), 'yyyy-MM-dd HH:mm:ss', 'UTC') from test_date settings max_threads=10 format Null;
```

before:

```
localhost:9000, queries: 100, QPS: 2.046, RPS: 61387601.355, MiB/s: 1639.226, result RPS: 0.000, result MiB/s: 0.000.

0.000%          1.353 sec.      
10.000%         2.117 sec.      
20.000%         2.196 sec.      
30.000%         2.246 sec.      
40.000%         2.331 sec.      
50.000%         2.407 sec.      
60.000%         2.460 sec.      
70.000%         2.524 sec.      
80.000%         2.643 sec.      
90.000%         2.774 sec.      
95.000%         2.922 sec.      
99.000%         3.067 sec.      
99.900%         3.165 sec.      
99.990%         3.165 sec. 
```
after:
```
localhost:9000, queries: 100, QPS: 2.238, RPS: 67132481.680, MiB/s: 1792.631, result RPS: 0.000, result MiB/s: 0.000.

0.000%          1.499 sec.      
10.000%         1.864 sec.      
20.000%         1.972 sec.      
30.000%         2.052 sec.      
40.000%         2.118 sec.      
50.000%         2.153 sec.      
60.000%         2.210 sec.      
70.000%         2.303 sec.      
80.000%         2.437 sec.      
90.000%         2.603 sec.      
95.000%         2.722 sec.      
99.000%         3.108 sec.      
99.900%         3.239 sec.      
99.990%         3.239 sec. 
```

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

---
### Modify your CI run:
**NOTE:** If your merge the PR with modified CI you **MUST KNOW** what you are doing
**NOTE:** Checked options will be applied if set before CI RunConfig/PrepareRunConfig step

#### Include tests (required builds will be added automatically):
- [ ] <!---ci_include_fast--> Fast test
- [ ] <!---ci_include_integration--> Integration Tests
- [ ] <!---ci_include_stateless--> Stateless tests
- [ ] <!---ci_include_stateful--> Stateful tests
- [ ] <!---ci_include_unit--> Unit tests
- [ ] <!---ci_include_performance--> Performance tests
- [ ] <!---ci_include_asan--> All with ASAN
- [ ] <!---ci_include_tsan--> All with TSAN
- [ ] <!---ci_include_analyzer--> All with Analyzer
- [ ] <!---ci_include_KEYWORD--> Add your option here

#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [ ] <!---ci_exclude_tsan--> All with TSAN
- [ ] <!---ci_exclude_msan--> All with MSAN
- [ ] <!---ci_exclude_ubsan--> All with UBSAN
- [ ] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64--> All with Aarch64
- [ ] <!---ci_exclude_KEYWORD--> Add your option here

#### Extra options:
- [ ] <!---do_not_test--> do not test (only style check)
- [ ] <!---no_merge_commit--> disable merge-commit (no merge from master before tests)
- [ ] <!---no_ci_cache--> disable CI cache (job reuse)

#### Only specified batches in multi-batch jobs:
- [ ] <!---batch_0--> 1
- [ ] <!---batch_1--> 2
- [ ] <!---batch_2--> 3
- [ ] <!---batch_3--> 4
