### PR TITLE
Document functions `upper` and `upperUTF8`

### DIFF
--- a/docs/en/sql-reference/functions/string-functions.md
+++ b/docs/en/sql-reference/functions/string-functions.md
@@ -325,12 +325,12 @@ upperUTF8(input)
 Query:
 
 ``` sql
-SELECT upperUTF8('value') as Upperutf8;
+SELECT upperUTF8('München') as Upperutf8;
 ```
 
 ``` response
 ┌─Upperutf8─┐
-│ VALUE     │
+│ MÜNCHEN   │
 └───────────┘
 ```
 

--- a/docs/en/sql-reference/functions/string-functions.md
+++ b/docs/en/sql-reference/functions/string-functions.md
@@ -260,7 +260,35 @@ Alias: `lcase`
 
 Converts the ASCII Latin symbols in a string to uppercase.
 
+**Syntax**
+
+``` sql
+upper(input)
+```
+
 Alias: `ucase`
+
+**Parameters**
+
+- `input`: A string type [String](/docs/en/sql-reference/data-types/string.md).
+
+**Returned value**
+
+- A [String](/docs/en/sql-reference/data-types/string.md) data type value.
+
+**Examples**
+
+Query:
+
+``` sql
+SELECT upper('value') as Upper;
+```
+
+``` response
+┌─Upper─┐
+│ VALUE │
+└───────┘
+```
 
 ## lowerUTF8
 
@@ -277,6 +305,34 @@ Converts a string to uppercase, assuming that the string contains valid UTF-8 en
 Does not detect the language, e.g. for Turkish the result might not be exactly correct (i/İ vs. i/I).
 
 If the length of the UTF-8 byte sequence is different for upper and lower case of a code point, the result may be incorrect for this code point.
+
+**Syntax**
+
+``` sql
+upperUTF8(input)
+```
+
+**Parameters**
+
+- `input`: A string type [String](/docs/en/sql-reference/data-types/string.md).
+
+**Returned value**
+
+- A [String](/docs/en/sql-reference/data-types/string.md) data type value.
+
+**Example**
+
+Query:
+
+``` sql
+SELECT upperUTF8('value') as Upperutf8;
+```
+
+``` response
+┌─Upperutf8─┐
+│ VALUE     │
+└───────────┘
+```
 
 ## isValidUTF8
 


### PR DESCRIPTION
Document functions `upper` and `upperUTF8`

Fixes https://github.com/ClickHouse/clickhouse-docs/issues/2033

### Changelog category (leave one):

- Documentation (changelog entry is not required)