### PR TITLE
Document function `translateUTF8`

### DIFF
--- a/docs/en/sql-reference/functions/string-replace-functions.md
+++ b/docs/en/sql-reference/functions/string-replace-functions.md
@@ -215,11 +215,11 @@ translateUTF8(s, from, to)
 Query:
 
 ``` sql
-SELECT translateUTF8('Hello, World!', 'delor', 'DELOR') AS res;
+SELECT translateUTF8('Münchener Straße', 'üß', 'us') AS res;
 ```
 
 ``` response
-┌─res───────────┐
-│ HELLO, WORLD! │
-└───────────────┘
+┌─res──────────────┐
+│ Munchener Strase │
+└──────────────────┘
 ```

--- a/docs/en/sql-reference/functions/string-replace-functions.md
+++ b/docs/en/sql-reference/functions/string-replace-functions.md
@@ -193,3 +193,33 @@ Result:
 ## translateUTF8
 
 Like [translate](#translate) but assumes `s`, `from` and `to` are UTF-8 encoded strings.
+
+**Syntax**
+
+``` sql
+translateUTF8(s, from, to)
+```
+
+**Parameters**
+
+- `s`: A string type [String](/docs/en/sql-reference/data-types/string.md).
+- `from`: A string type [String](/docs/en/sql-reference/data-types/string.md).
+- `to`: A string type [String](/docs/en/sql-reference/data-types/string.md).
+
+**Returned value**
+
+- `s`: A string type [String](/docs/en/sql-reference/data-types/string.md).
+
+**Examples**
+
+Query:
+
+``` sql
+SELECT translateUTF8('Hello, World!', 'delor', 'DELOR') AS res;
+```
+
+``` response
+┌─res───────────┐
+│ HELLO, WORLD! │
+└───────────────┘
+```


### PR DESCRIPTION
Document function `translateUTF8`.

Fixes https://github.com/ClickHouse/clickhouse-docs/issues/2026

### Changelog category (leave one):

- Documentation (changelog entry is not required)