### PR TITLE
Fix macOS binary install directory

### DIFF
--- a/programs/install/Install.cpp
+++ b/programs/install/Install.cpp
@@ -46,12 +46,12 @@ INCBIN(resource_users_xml, SOURCE_DIR "/programs/server/users.xml");
   *
   * The following steps are performed:
   *
-  * - copying the binary to binary directory (/usr/local/bin (Apple macOS) or /usr/bin (Others)).
+  * - copying the binary to binary directory (/usr/bin/)
   * - creation of symlinks for tools.
   * - creation of clickhouse user and group.
-  * - creation of config directory (/etc/clickhouse-server).
+  * - creation of config directory (/etc/clickhouse-server/).
   * - creation of default configuration files.
-  * - creation of a directory for logs (/var/log/clickhouse-server).
+  * - creation of a directory for logs (/var/log/clickhouse-server/).
   * - creation of a data directory if not exists.
   * - setting a password for default user.
   * - choose an option to listen connections.
@@ -227,6 +227,7 @@ int mainEntryClickHouseInstall(int argc, char ** argv)
             ("help,h", "produce help message")
             ("prefix", po::value<std::string>()->default_value("/"), "prefix for all paths")
 #if defined (OS_DARWIN)
+            /// https://stackoverflow.com/a/36734569/22422288
             ("binary-path", po::value<std::string>()->default_value("usr/local/bin"), "where to install binaries")
 #else
             ("binary-path", po::value<std::string>()->default_value("usr/bin"), "where to install binaries")
@@ -1221,6 +1222,7 @@ int mainEntryClickHouseStart(int argc, char ** argv)
             ("help,h", "produce help message")
             ("prefix", po::value<std::string>()->default_value("/"), "prefix for all paths")
 #if defined (OS_DARWIN)
+            /// https://stackoverflow.com/a/36734569/22422288
             ("binary-path", po::value<std::string>()->default_value("usr/local/bin"), "directory with binary")
 #else
             ("binary-path", po::value<std::string>()->default_value("usr/bin"), "directory with binary")
@@ -1341,6 +1343,7 @@ int mainEntryClickHouseRestart(int argc, char ** argv)
             ("help,h", "produce help message")
             ("prefix", po::value<std::string>()->default_value("/"), "prefix for all paths")
 #if defined (OS_DARWIN)
+            /// https://stackoverflow.com/a/36734569/22422288
             ("binary-path", po::value<std::string>()->default_value("usr/local/bin"), "directory with binary")
 #else
             ("binary-path", po::value<std::string>()->default_value("usr/bin"), "directory with binary")

--- a/programs/install/Install.cpp
+++ b/programs/install/Install.cpp
@@ -46,7 +46,7 @@ INCBIN(resource_users_xml, SOURCE_DIR "/programs/server/users.xml");
   *
   * The following steps are performed:
   *
-  * - copying the binary to binary directory (/usr/bin).
+  * - copying the binary to binary directory (/usr/local/bin (Apple macOS) or /usr/bin (Others)).
   * - creation of symlinks for tools.
   * - creation of clickhouse user and group.
   * - creation of config directory (/etc/clickhouse-server).
@@ -226,7 +226,11 @@ int mainEntryClickHouseInstall(int argc, char ** argv)
         desc.add_options()
             ("help,h", "produce help message")
             ("prefix", po::value<std::string>()->default_value("/"), "prefix for all paths")
+#if defined (OS_DARWIN)
+            ("binary-path", po::value<std::string>()->default_value("usr/local/bin"), "where to install binaries")
+#else
             ("binary-path", po::value<std::string>()->default_value("usr/bin"), "where to install binaries")
+#endif
             ("config-path", po::value<std::string>()->default_value("etc/clickhouse-server"), "where to install configs")
             ("log-path", po::value<std::string>()->default_value("var/log/clickhouse-server"), "where to create log directory")
             ("data-path", po::value<std::string>()->default_value("var/lib/clickhouse"), "directory for data")
@@ -1216,7 +1220,11 @@ int mainEntryClickHouseStart(int argc, char ** argv)
         desc.add_options()
             ("help,h", "produce help message")
             ("prefix", po::value<std::string>()->default_value("/"), "prefix for all paths")
+#if defined (OS_DARWIN)
+            ("binary-path", po::value<std::string>()->default_value("usr/local/bin"), "directory with binary")
+#else
             ("binary-path", po::value<std::string>()->default_value("usr/bin"), "directory with binary")
+#endif
             ("config-path", po::value<std::string>()->default_value("etc/clickhouse-server"), "directory with configs")
             ("pid-path", po::value<std::string>()->default_value("var/run/clickhouse-server"), "directory for pid file")
             ("user", po::value<std::string>()->default_value(DEFAULT_CLICKHOUSE_SERVER_USER), "clickhouse user")
@@ -1332,7 +1340,11 @@ int mainEntryClickHouseRestart(int argc, char ** argv)
         desc.add_options()
             ("help,h", "produce help message")
             ("prefix", po::value<std::string>()->default_value("/"), "prefix for all paths")
+#if defined (OS_DARWIN)
+            ("binary-path", po::value<std::string>()->default_value("usr/local/bin"), "directory with binary")
+#else
             ("binary-path", po::value<std::string>()->default_value("usr/bin"), "directory with binary")
+#endif
             ("config-path", po::value<std::string>()->default_value("etc/clickhouse-server"), "directory with configs")
             ("pid-path", po::value<std::string>()->default_value("var/run/clickhouse-server"), "directory for pid file")
             ("user", po::value<std::string>()->default_value(DEFAULT_CLICKHOUSE_SERVER_USER), "clickhouse user")


### PR DESCRIPTION
`/usr/bin` is not a suitable installation directory for macOS since El Capitan: https://stackoverflow.com/a/36734569/22422288

This patch re-enables `sudo ./clickhouse --install` on MacOS:

<details>
<summary>before this patch</summary>

```
re@192 ck % ./clickhouse --install
Copying ClickHouse binary to /usr/bin/clickhouse.new
Install must be run as root: sudo ./clickhouse install
Code: 76. DB::ErrnoException: Cannot open file /usr/bin/clickhouse.new: , errno: 1, strerror: Operation not permitted. (CANNOT_OPEN_FILE) (version 24.4.1.725 (official build))

re@192 ck % ls /usr/bin/clickhouse.new /usr/bin/clickhouse
ls: /usr/bin/clickhouse: No such file or directory
ls: /usr/bin/clickhouse.new: No such file or directory

re@192 ck % sudo ./clickhouse --install
Password:
Copying ClickHouse binary to /usr/bin/clickhouse.new
Code: 76. DB::ErrnoException: Cannot open file /usr/bin/clickhouse.new: , errno: 1, strerror: Operation not permitted. (CANNOT_OPEN_FILE) (version 24.4.1.725 (official build))

re@192 ck % sudo ./clickhouse --install
Copying ClickHouse binary to /usr/bin/clickhouse.new
Code: 76. DB::ErrnoException: Cannot open file /usr/bin/clickhouse.new: , errno: 1, strerror: Operation not permitted. (CANNOT_OPEN_FILE) (version 24.4.1.725 (official build))
re@192 ck %
```
</details>


<details>
<summary>after this patch</summary>

```
re@192 build % cd programs       
re@192 programs % sudo ./clickhouse install
Copying ClickHouse binary to /usr/local/bin/clickhouse.new
Renaming /usr/local/bin/clickhouse.new to /usr/local/bin/clickhouse.
Creating symlink /usr/local/bin/clickhouse-server to /usr/local/bin/clickhouse.
Creating symlink /usr/local/bin/clickhouse-client to /usr/local/bin/clickhouse.
Creating symlink /usr/local/bin/clickhouse-local to /usr/local/bin/clickhouse.
Creating symlink /usr/local/bin/clickhouse-benchmark to /usr/local/bin/clickhouse.
Creating symlink /usr/local/bin/clickhouse-obfuscator to /usr/local/bin/clickhouse.
Creating symlink /usr/local/bin/clickhouse-git-import to /usr/local/bin/clickhouse.
Creating symlink /usr/local/bin/clickhouse-compressor to /usr/local/bin/clickhouse.
Creating symlink /usr/local/bin/clickhouse-format to /usr/local/bin/clickhouse.
Creating symlink /usr/local/bin/clickhouse-extract-from-config to /usr/local/bin/clickhouse.
Creating symlink /usr/local/bin/clickhouse-keeper to /usr/local/bin/clickhouse.
Creating symlink /usr/local/bin/clickhouse-keeper-converter to /usr/local/bin/clickhouse.
Creating symlink /usr/local/bin/clickhouse-disks to /usr/local/bin/clickhouse.
Creating symlink /usr/local/bin/ch to /usr/local/bin/clickhouse.
Creating symlink /usr/local/bin/chl to /usr/local/bin/clickhouse.
Creating symlink /usr/local/bin/chc to /usr/local/bin/clickhouse.
Will not create a dedicated clickhouse group.
Will not create a dedicated clickhouse user.
Creating config directory /etc/clickhouse-server.
Creating config directory /etc/clickhouse-server/config.d that is used for tweaks of main server configuration.
Creating config directory /etc/clickhouse-server/users.d that is used for tweaks of users configuration.
Data path configuration override is saved to file /etc/clickhouse-server/config.d/data-paths.xml.
Log path configuration override is saved to file /etc/clickhouse-server/config.d/logger.xml.
User directory path configuration override is saved to file /etc/clickhouse-server/config.d/user-directories.xml.
OpenSSL path configuration override is saved to file /etc/clickhouse-server/config.d/openssl.xml.
Creating log directory /var/log/clickhouse-server.
Creating data directory /var/lib/clickhouse.
Creating pid directory /var/run/clickhouse-server.
Enter password for the default user: 
Password for the default user is an empty string. See /etc/clickhouse-server/users.xml and /etc/clickhouse-server/users.d to change it.

ClickHouse has been successfully installed.

Start clickhouse-server with:
 sudo clickhouse start

Start clickhouse-client with:
 clickhouse-client

re@192 programs % sudo clickhouse start
Will run /usr/local/bin/clickhouse-server --config-file /etc/clickhouse-server/config.xml --pid-file /var/run/clickhouse-server/clickhouse-server.pid --daemon
Waiting for server to start
Waiting for server to start
Server started
re@192 programs % /usr/local/bin/clickhouse-client
ClickHouse client version 24.4.1.1.
Connecting to localhost:9000 as user default.
Connected to ClickHouse server version 24.4.1.

Warnings:
 * Maximum number of threads is lower than 30000. There could be problems with handling a lot of simultaneous queries.

localhost :) Bye.
re@192 programs % 


```

</details>



### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Changed the default installation directory on macOS from `/usr/bin` to `/usr/local/bin`. This is necessary because Apple's System Integrity Protection introduced with macOS El Capitan (2015) prevents writing into `/usr/bin`, even with `sudo`.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

---
### Modify your CI run:
**NOTE:** If your merge the PR with modified CI you **MUST KNOW** what you are doing
**NOTE:** Checked options will be applied if set before CI RunConfig/PrepareRunConfig step

#### Include tests (required builds will be added automatically):
- [ ] <!---ci_include_fast--> Fast test
- [ ] <!---ci_include_integration--> Integration Tests
- [ ] <!---ci_include_stateless--> Stateless tests
- [ ] <!---ci_include_stateful--> Stateful tests
- [ ] <!---ci_include_unit--> Unit tests
- [ ] <!---ci_include_performance--> Performance tests
- [ ] <!---ci_include_asan--> All with ASAN
- [ ] <!---ci_include_tsan--> All with TSAN
- [ ] <!---ci_include_analyzer--> All with Analyzer
- [ ] <!---ci_include_KEYWORD--> Add your option here

#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [ ] <!---ci_exclude_tsan--> All with TSAN
- [ ] <!---ci_exclude_msan--> All with MSAN
- [ ] <!---ci_exclude_ubsan--> All with UBSAN
- [ ] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64--> All with Aarch64
- [ ] <!---ci_exclude_KEYWORD--> Add your option here

#### Extra options:
- [ ] <!---do_not_test--> do not test (only style check)
- [ ] <!---no_merge_commit--> disable merge-commit (no merge from master before tests)
- [ ] <!---no_ci_cache--> disable CI cache (job reuse)

#### Only specified batches in multi-batch jobs:
- [ ] <!---batch_0--> 1
- [ ] <!---batch_1--> 2
- [ ] <!---batch_2--> 3
- [ ] <!---batch_3--> 4
