### PR TITLE
[Docs] update `lower` function

### DIFF
--- a/docs/en/sql-reference/functions/string-functions.md
+++ b/docs/en/sql-reference/functions/string-functions.md
@@ -254,7 +254,35 @@ Result:
 
 Converts the ASCII Latin symbols in a string to lowercase.
 
+*Syntax**
+
+``` sql
+lower(input)
+```
+
 Alias: `lcase`
+
+**Parameters**
+
+- `input`: A string type [String](/docs/en/sql-reference/data-types/string.md).
+
+**Returned value**
+
+- A [String](/docs/en/sql-reference/data-types/string.md) data type value.
+
+**Example**
+
+Query:
+
+```sql
+SELECT lower('CLICKHOUSE');
+```
+
+```response
+┌─lower('CLICKHOUSE')─┐
+│ clickhouse          │
+└─────────────────────┘
+```
 
 ## upper
 
@@ -281,13 +309,13 @@ Alias: `ucase`
 Query:
 
 ``` sql
-SELECT upper('value') as Upper;
+SELECT upper('clickhouse');
 ```
 
 ``` response
-┌─Upper─┐
-│ VALUE │
-└───────┘
+┌─upper('clickhouse')─┐
+│ CLICKHOUSE          │
+└─────────────────────┘
 ```
 
 ## lowerUTF8


### PR DESCRIPTION
Closes [#1973](https://github.com/ClickHouse/clickhouse-docs/issues/1973) as part of the [functions project](https://github.com/ClickHouse/clickhouse-docs/issues/1833) to document missing and incomplete functions.

- Brings `lower` up to date with regards to format. 
- Updates the example of `upper` for consistency of the examples between `upper` and `lower`.

### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Documentation entry for user-facing changes

- [X] Documentation is written (mandatory for new features)