### PR TITLE
[Docs] add missing `flattenTuple` function

### DIFF
--- a/docs/en/sql-reference/functions/tuple-functions.md
+++ b/docs/en/sql-reference/functions/tuple-functions.md
@@ -858,7 +858,7 @@ Result:
 
 ## flattenTuple
 
-Returns a flattened `output` Tuple from a nested named `input` Tuple. Elements of the `output` Tuple are the paths from the original `Tuple`. For instance: `Tuple(a Int, Tuple(b Int, c Int)) -> Tuple(a Int, b Int, c Int)`. `flattenTuple` can be used to select all paths from type `Object` as separate columns.
+Returns a flattened `output` tuple from a nested named `input` tuple. Elements of the `output` tuple are the paths from the original `input` tuple. For instance: `Tuple(a Int, Tuple(b Int, c Int)) -> Tuple(a Int, b Int, c Int)`. `flattenTuple` can be used to select all paths from type `Object` as separate columns.
 
 **Syntax**
 
@@ -868,11 +868,11 @@ flattenTuple(input)
 
 **Parameters**
 
-- `input`: Nested named Tuple to flatten. [Tuple](../data-types/tuple).
+- `input`: Nested named tuple to flatten. [Tuple](../data-types/tuple).
 
 **Returned value**
 
-- `output` Tuple whose elements are paths from the original `input`. [Tuple](../data-types/tuple).
+- `output` tuple whose elements are paths from the original `input`. [Tuple](../data-types/tuple).
 
 **Example**
 

--- a/docs/en/sql-reference/functions/tuple-functions.md
+++ b/docs/en/sql-reference/functions/tuple-functions.md
@@ -856,6 +856,42 @@ Result:
 └─────────────────────────────────────┘
 ```
 
+## flattenTuple
+
+Returns a flattened `output` Tuple from a nested named `input` Tuple. Elements of the `output` Tuple are the paths from the original `Tuple`. For instance: `Tuple(a Int, Tuple(b Int, c Int)) -> Tuple(a Int, b Int, c Int)`. `flattenTuple` can be used to select all paths from type `Object` as separate columns.
+
+**Syntax**
+
+```sql
+flattenTuple(input)
+```
+
+**Parameters**
+
+- `input`: Nested named Tuple to flatten. [Tuple](../data-types/tuple).
+
+**Returned value**
+
+- `output` Tuple whose elements are paths from the original `input`. [Tuple](../data-types/tuple).
+
+**Examples**
+
+Query:
+
+``` sql
+CREATE TABLE t_flatten_tuple(t Tuple(t1 Nested(a UInt32, s String), b UInt32, t2 Tuple(k String, v UInt32))) ENGINE = Memory;
+INSERT INTO t_flatten_tuple VALUES (([(1, 'a'), (2, 'b')], 3, ('c', 4)));
+SELECT flattenTuple(t) FROM t_flatten_tuple;
+```
+
+Result:
+
+``` text
+┌─flattenTuple(t)───────────┐
+│ ([1,2],['a','b'],3,'c',4) │
+└───────────────────────────┘
+```
+
 ## Distance functions
 
 All supported functions are described in [distance functions documentation](../../sql-reference/functions/distance-functions.md).

--- a/docs/en/sql-reference/functions/tuple-functions.md
+++ b/docs/en/sql-reference/functions/tuple-functions.md
@@ -874,7 +874,7 @@ flattenTuple(input)
 
 - `output` Tuple whose elements are paths from the original `input`. [Tuple](../data-types/tuple).
 
-**Examples**
+**Example**
 
 Query:
 

--- a/utils/check-style/aspell-ignore/en/aspell-dict.txt
+++ b/utils/check-style/aspell-ignore/en/aspell-dict.txt
@@ -1566,6 +1566,7 @@ firstSignificantSubdomainCustom
 fixedstring
 flamegraph
 flatbuffers
+flattenTuple
 flink
 fluentd
 fmtlib


### PR DESCRIPTION
Closes [#1955](https://github.com/ClickHouse/clickhouse-docs/issues/1955) as part of the [functions project](https://github.com/ClickHouse/clickhouse-docs/issues/1833) to document missing functions. 

- Adds missing `flattenTuple` function. 

### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Documentation entry for user-facing changes

- [X] Documentation is written (mandatory for new features)