### PR TITLE
Fix integration-tests logs compression

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -83,7 +83,7 @@ jobs:
         ${{secrets.ROBOT_CLICKHOUSE_SSH_KEY}}
         RCSK
   FastTest:
-    needs: [RunConfig, StyleCheck]
+    needs: [RunConfig, BuildDockers]
     if: ${{ !failure() && !cancelled() && contains(fromJson(needs.RunConfig.outputs.data).jobs_data.jobs_to_do, 'Fast test') }}
     uses: ./.github/workflows/reusable_test.yml
     with:

--- a/tests/ci/integration_tests_runner.py
+++ b/tests/ci/integration_tests_runner.py
@@ -13,13 +13,13 @@ import string
 import subprocess
 import sys
 import time
-from typing import Any, Dict
 import zlib  # for crc32
 from collections import defaultdict
 from itertools import chain
+from typing import Any, Dict
 
-from integration_test_images import IMAGES
 from env_helper import CI
+from integration_test_images import IMAGES
 
 MAX_RETRY = 1
 NUM_WORKERS = 5
@@ -397,9 +397,9 @@ class ClickhouseIntegrationTestsRunner:
 
     @staticmethod
     def _compress_logs(directory, relpaths, result_path):
-        retcode = subprocess.call(  # STYLE_CHECK_ALLOW_SUBPROCESS_CHECK_CALL
-            f"sudo tar --use-compress-program='zstd --threads=0' -cf {result_path} -C "
-            f"{directory} {' '.join(relpaths)}",
+        retcode = subprocess.call(
+            f"sudo tar --use-compress-program='zstd --threads=0' "
+            f"-cf {result_path} -C {directory} {' '.join(relpaths)}",
             shell=True,
         )
         # tar return 1 when the files are changed on compressing, we ignore it
@@ -432,9 +432,7 @@ class ClickhouseIntegrationTestsRunner:
             "Getting all tests to the file %s with cmd: \n%s", out_file_full, cmd
         )
         with open(out_file_full, "wb") as ofd:
-            subprocess.check_call(  # STYLE_CHECK_ALLOW_SUBPROCESS_CHECK_CALL
-                cmd, shell=True, stdout=ofd, stderr=ofd
-            )
+            subprocess.check_call(cmd, shell=True, stdout=ofd, stderr=ofd)
 
         all_tests = set()
         with open(out_file_full, "r", encoding="utf-8") as all_tests_fd:
@@ -1007,9 +1005,7 @@ def run():
     if CI:
         # Avoid overlaps with previous runs
         logging.info("Clearing dmesg before run")
-        subprocess.check_call(  # STYLE_CHECK_ALLOW_SUBPROCESS_CHECK_CALL
-            "sudo -E dmesg --clear", shell=True
-        )
+        subprocess.check_call("sudo -E dmesg --clear", shell=True)
 
     state, description, test_results, _ = runner.run_impl(repo_path, build_path)
     logging.info("Tests finished")
@@ -1017,9 +1013,7 @@ def run():
     if CI:
         # Dump dmesg (to capture possible OOMs)
         logging.info("Dumping dmesg")
-        subprocess.check_call(  # STYLE_CHECK_ALLOW_SUBPROCESS_CHECK_CALL
-            "sudo -E dmesg -T", shell=True
-        )
+        subprocess.check_call("sudo -E dmesg -T", shell=True)
 
     status = (state, description)
     out_results_file = os.path.join(str(runner.path()), "test_results.tsv")

--- a/tests/ci/integration_tests_runner.py
+++ b/tests/ci/integration_tests_runner.py
@@ -398,7 +398,7 @@ class ClickhouseIntegrationTestsRunner:
     @staticmethod
     def _compress_logs(directory, relpaths, result_path):
         retcode = subprocess.call(  # STYLE_CHECK_ALLOW_SUBPROCESS_CHECK_CALL
-            f"tar --use-compress-program='zstd --threads=0' -cf {result_path} -C "
+            f"sudo tar --use-compress-program='zstd --threads=0' -cf {result_path} -C "
             f"{directory} {' '.join(relpaths)}",
             shell=True,
         )


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
In https://github.com/ClickHouse/ClickHouse/pull/61658, we moved to better scripts' processing, but the compression there was done as sudo previously. This PR restores it.

### Note
It is tested in https://github.com/ClickHouse/ClickHouse/pull/60312