### PR TITLE
Improve performance of `(to|from)_utc_timestamp` functions

### DIFF
--- a/src/Functions/UTCTimestampTransform.cpp
+++ b/src/Functions/UTCTimestampTransform.cpp
@@ -67,7 +67,7 @@ namespace
             return date_time_type;
         }
 
-        ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type, size_t) const override
+        ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr &, size_t) const override
         {
             if (arguments.size() != 2)
                 throw Exception(ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH, "Function {}'s arguments number must be 2.", name);
@@ -77,24 +77,33 @@ namespace
             if (!time_zone_const_col)
                 throw Exception(ErrorCodes::ILLEGAL_COLUMN, "Illegal column {} of 2nd argument of function {}. Excepted const(String).", arg2.column->getName(), name);
             String time_zone_val = time_zone_const_col->getDataAt(0).toString();
-            auto column = result_type->createColumn();
             if (WhichDataType(arg1.type).isDateTime())
             {
                 const auto * date_time_col = checkAndGetColumn<ColumnDateTime>(arg1.column.get());
-                for (size_t i = 0; i < date_time_col->size(); ++i)
+                size_t col_size = date_time_col->size();
+                using ColVecTo = DataTypeDateTime::ColumnType;
+                typename ColVecTo::MutablePtr result_column = ColVecTo::create(col_size);
+                typename ColVecTo::Container & result_data = result_column->getData();
+                for (size_t i = 0; i < col_size; ++i)
                 {
                     UInt32 date_time_val = date_time_col->getElement(i);
                     LocalDateTime date_time(date_time_val, Name::to ? DateLUT::instance("UTC") : DateLUT::instance(time_zone_val));
                     time_t time_val = date_time.to_time_t(Name::from ? DateLUT::instance("UTC") : DateLUT::instance(time_zone_val));
-                    column->insert(time_val);
+                    result_data[i] = static_cast<UInt32>(time_val);
                 }
+                return result_column;
             }
             else if (WhichDataType(arg1.type).isDateTime64())
             {
                 const auto * date_time_col = checkAndGetColumn<ColumnDateTime64>(arg1.column.get());
+                size_t col_size = date_time_col->size();
                 const DataTypeDateTime64 * date_time_type = static_cast<const DataTypeDateTime64 *>(arg1.type.get());
-                Int64 scale_multiplier = DecimalUtils::scaleMultiplier<Int64>(date_time_type->getScale());
-                for (size_t i = 0; i < date_time_col->size(); ++i)
+                UInt32 col_scale = date_time_type->getScale();
+                Int64 scale_multiplier = DecimalUtils::scaleMultiplier<Int64>(col_scale);
+                using ColDecimalTo = DataTypeDateTime64::ColumnType;
+                typename ColDecimalTo::MutablePtr result_column = ColDecimalTo::create(col_size, col_scale);
+                typename ColDecimalTo::Container & result_data = result_column->getData();
+                for (size_t i = 0; i < col_size; ++i)
                 {
                     DateTime64 date_time_val = date_time_col->getElement(i);
                     Int64 seconds = date_time_val.value / scale_multiplier;
@@ -102,12 +111,12 @@ namespace
                     LocalDateTime date_time(seconds, Name::to ? DateLUT::instance("UTC") : DateLUT::instance(time_zone_val));
                     time_t time_val = date_time.to_time_t(Name::from ? DateLUT::instance("UTC") : DateLUT::instance(time_zone_val));
                     DateTime64 date_time_64(time_val * scale_multiplier + micros);
-                    column->insert(date_time_64);
+                    result_data[i] = date_time_64;
                 }
+                return result_column;
             }
             else
                 throw Exception(ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT, "Function {}'s 1st argument can only be datetime/datatime64. ", name);
-            return column;
         }
 
     };

--- a/src/Functions/UTCTimestampTransform.cpp
+++ b/src/Functions/UTCTimestampTransform.cpp
@@ -77,8 +77,7 @@ namespace
             if (!time_zone_const_col)
                 throw Exception(ErrorCodes::ILLEGAL_COLUMN, "Illegal column {} of 2nd argument of function {}. Excepted const(String).", arg2.column->getName(), name);
             String time_zone_val = time_zone_const_col->getDataAt(0).toString();
-            time_t date_time_val = LocalDateTime(0, DateLUT::instance(time_zone_val)).to_time_t();
-            time_t utc_time_val = LocalDateTime(0, DateLUT::instance("UTC")).to_time_t();
+            const DateLUTImpl & utc_time_zone = DateLUT::instance("UTC");
             if (WhichDataType(arg1.type).isDateTime())
             {
                 const auto * date_time_col = checkAndGetColumn<ColumnDateTime>(arg1.column.get());
@@ -88,8 +87,9 @@ namespace
                 typename ColVecTo::Container & result_data = result_column->getData();
                 for (size_t i = 0; i < col_size; ++i)
                 {
-                    UInt32 val = date_time_col->getElement(i);
-                    time_t time_val = Name::to ? val + utc_time_val - date_time_val : val + date_time_val - utc_time_val;
+                    UInt32 date_time_val = date_time_col->getElement(i);
+                    LocalDateTime date_time(date_time_val, Name::to ? utc_time_zone : DateLUT::instance(time_zone_val));
+                    time_t time_val = date_time.to_time_t(Name::from ? utc_time_zone : DateLUT::instance(time_zone_val));
                     result_data[i] = static_cast<UInt32>(time_val);
                 }
                 return result_column;
@@ -106,11 +106,12 @@ namespace
                 typename ColDecimalTo::Container & result_data = result_column->getData();
                 for (size_t i = 0; i < col_size; ++i)
                 {
-                    DateTime64 val = date_time_col->getElement(i);
-                    Int64 seconds = val.value / scale_multiplier;
-                    Int64 mills = val.value % scale_multiplier;
-                    time_t time_val = Name::from ? seconds + date_time_val - utc_time_val : seconds + utc_time_val - date_time_val;
-                    DateTime64 date_time_64(time_val * scale_multiplier + mills);
+                    DateTime64 date_time_val = date_time_col->getElement(i);
+                    Int64 seconds = date_time_val.value / scale_multiplier;
+                    Int64 micros = date_time_val.value % scale_multiplier;
+                    LocalDateTime date_time(seconds, Name::to ? utc_time_zone : DateLUT::instance(time_zone_val));
+                    time_t time_val = date_time.to_time_t(Name::from ? utc_time_zone : DateLUT::instance(time_zone_val));
+                    DateTime64 date_time_64(time_val * scale_multiplier + micros);
                     result_data[i] = date_time_64;
                 }
                 return result_column;

--- a/tests/performance/utc_timestamp_transform.xml
+++ b/tests/performance/utc_timestamp_transform.xml
@@ -1,0 +1,15 @@
+<test>
+    <create_query>CREATE TABLE test1(d DateTime) ENGINE Memory</create_query>
+    <create_query>CREATE TABLE test2(d DateTime64) ENGINE Memory</create_query>
+    <fill_query>INSERT INTO test1 SELECT toDateTime('2023-03-16 11:22:33') + number from numbers(10000000)</fill_query>
+    <fill_query>INSERT INTO test2 SELECT toDateTime64('2023-03-16 11:22:33', 3) + number from numbers(10000000);</fill_query>
+
+
+    <query tag="ToUtcTimestampDateTime">select count(1) from test1 where to_utc_timestamp(d, 'Etc/GMT+1') > '1990-01-01 12:00:00' SETTINGS max_threads=1</query>
+    <query tag="FromUtcTimestampDateTime">select count(1) from test1 where from_utc_timestamp(d, 'Etc/GMT+1') > '1990-01-01 12:00:00' SETTINGS max_threads=1</query>
+    <query tag="ToUtcTimestampDateTime64">select count(1) from test2 where to_utc_timestamp(d, 'Etc/GMT+1') > '1990-01-01 12:00:00' SETTINGS max_threads=1</query>
+    <query tag="FromUtcTimestampDateTime64">select count(1) from test2 where from_utc_timestamp(d, 'Etc/GMT+1') > '1990-01-01 12:00:00' SETTINGS max_threads=1</query>
+
+    <drop_query>DROP TABLE IF EXISTS test1</drop_query>
+    <drop_query>DROP TABLE IF EXISTS test2</drop_query>
+</test>

--- a/tests/performance/utc_timestamp_transform.xml
+++ b/tests/performance/utc_timestamp_transform.xml
@@ -2,8 +2,7 @@
     <create_query>CREATE TABLE test1(d DateTime) ENGINE Memory</create_query>
     <create_query>CREATE TABLE test2(d DateTime64) ENGINE Memory</create_query>
     <fill_query>INSERT INTO test1 SELECT toDateTime('2023-03-16 11:22:33') + number from numbers(10000000)</fill_query>
-    <fill_query>INSERT INTO test2 SELECT toDateTime64('2023-03-16 11:22:33', 3) + number from numbers(10000000);</fill_query>
-
+    <fill_query>INSERT INTO test2 SELECT toDateTime64('2023-03-16 11:22:33', 3) + number from numbers(10000000)</fill_query>
 
     <query tag="ToUtcTimestampDateTime">select count(1) from test1 where to_utc_timestamp(d, 'Etc/GMT+1') > '1990-01-01 12:00:00' SETTINGS max_threads=1</query>
     <query tag="FromUtcTimestampDateTime">select count(1) from test1 where from_utc_timestamp(d, 'Etc/GMT+1') > '1990-01-01 12:00:00' SETTINGS max_threads=1</query>


### PR DESCRIPTION
1.  reuse the instance of  `DateLUT.instance("UTC")`, no need to create new instance every time in the loop.

2. not use `column.insert` but to create column to a certain size,  and give value to its element in the loop.

And we have test the performance of the pr, the test table schema `(x DateTime)`, which has `10000000` rows,  and the test sql `select count(1) from test where to_utc_timestamp(x, 'Etc/GMT+1') > '1990-01-01 12:00:00' SETTINGS max_threads=1`.

Before this PR
```
1 row in set. Elapsed: 1.561 sec. Processed 10.00 million rows, 40.00 MB (6.40 million rows/s., 25.62 MB/s.)
1 row in set. Elapsed: 1.544 sec. Processed 10.00 million rows, 40.00 MB (6.48 million rows/s., 25.91 MB/s.)
1 row in set. Elapsed: 1.572 sec. Processed 10.00 million rows, 40.00 MB (6.36 million rows/s., 25.44 MB/s.)
```    

After this PR
```
1 row in set. Elapsed: 0.876 sec. Processed 10.00 million rows, 40.00 MB (11.42 million rows/s., 45.66 MB/s.)
1 row in set. Elapsed: 0.894 sec. Processed 10.00 million rows, 40.00 MB (11.19 million rows/s., 44.77 MB/s.)
1 row in set. Elapsed: 0.944 sec. Processed 10.00 million rows, 40.00 MB (10.59 million rows/s., 42.36 MB/s.)
```

### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Functions `to_utc_timestamp` and `from_utc_timestamp` are now about 2x faster.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

---
### Modify your CI run:
**NOTE:** If your merge the PR with modified CI you **MUST KNOW** what you are doing
**NOTE:** Checked options will be applied if set before CI RunConfig/PrepareRunConfig step

#### Include tests (required builds will be added automatically):
- [ ] <!---ci_include_fast--> Fast test
- [ ] <!---ci_include_integration--> Integration Tests
- [ ] <!---ci_include_stateless--> Stateless tests
- [ ] <!---ci_include_stateful--> Stateful tests
- [ ] <!---ci_include_unit--> Unit tests
- [ ] <!---ci_include_performance--> Performance tests
- [ ] <!---ci_include_asan--> All with ASAN
- [ ] <!---ci_include_tsan--> All with TSAN
- [ ] <!---ci_include_analyzer--> All with Analyzer
- [ ] <!---ci_include_KEYWORD--> Add your option here

#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [ ] <!---ci_exclude_tsan--> All with TSAN
- [ ] <!---ci_exclude_msan--> All with MSAN
- [ ] <!---ci_exclude_ubsan--> All with UBSAN
- [ ] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64--> All with Aarch64
- [ ] <!---ci_exclude_KEYWORD--> Add your option here

#### Extra options:
- [ ] <!---do_not_test--> do not test (only style check)
- [ ] <!---no_merge_commit--> disable merge-commit (no merge from master before tests)
- [ ] <!---no_ci_cache--> disable CI cache (job reuse)

#### Only specified batches in multi-batch jobs:
- [ ] <!---batch_0--> 1
- [ ] <!---batch_1--> 2
- [ ] <!---batch_2--> 3
- [ ] <!---batch_3--> 4
