### PR TITLE
[Docs] add missing `left`, `right` functions and their variants.

### DIFF
--- a/docs/en/sql-reference/functions/string-functions.md
+++ b/docs/en/sql-reference/functions/string-functions.md
@@ -104,7 +104,7 @@ Alias:
 
 ## left
 
-Returns the substring of a string `s` which starts at the specified byte index `offset` from the left.
+Returns a substring of string `s` with a specified `offset` starting from the left.
 
 **Syntax**
 
@@ -151,7 +151,7 @@ He
 
 ## leftUTF8
 
-Returns the substring of a UTF-8 encoded string `s` which starts at the specified byte index `offset` from the left.
+Returns a substring of a UTF-8 encoded string `s` with a specified `offset` starting from the left.
 
 **Syntax**
 
@@ -272,7 +272,7 @@ Result:
 
 ## right
 
-Returns the substring of a string `s` which starts at the specified byte index `offset` from the right.
+Returns a substring of string `s` with a specified `offset` starting from the right.
 
 **Syntax**
 
@@ -319,7 +319,7 @@ lo
 
 ## rightUTF8
 
-Returns the substring of a UTF-8 encoded string `s` which starts at the specified byte index `offset` from the right.
+Returns a substring of UTF-8 encoded string `s` with a specified `offset` starting from the right.
 
 **Syntax**
 

--- a/docs/en/sql-reference/functions/string-functions.md
+++ b/docs/en/sql-reference/functions/string-functions.md
@@ -102,6 +102,100 @@ Alias:
 - `CHAR_LENGTH`
 - `CHARACTER_LENGTH`
 
+## left
+
+Returns the substring of a string `s` which starts at the specified byte index `offset` from the left.
+
+**Syntax**
+
+``` sql
+left(s, offset)
+```
+
+**Parameters**
+
+- `s`: The string to calculate a substring from. [String](../../sql-reference/data-types/string.md) or [FixedString](../../sql-reference/data-types/fixedstring.md).
+- `offset`: The number of bytes of the offset. [UInt*](../data-types/int-uint).
+
+**Returned value**
+
+- For positive `offset`: A substring of `s` with `offset` many bytes, starting from the left of the string.
+- For negative `offset`: A substring of `s` with `length(s) - |offset|` bytes, starting from the left of the string.
+- An empty string if `length` is 0.
+
+**Example**
+
+Query:
+
+```sql
+SELECT left('Hello', 3);
+```
+
+Result:
+
+```response
+Hel
+```
+
+Query:
+
+```sql
+SELECT left('Hello', -3);
+```
+
+Result:
+
+```response
+He
+```
+
+## leftUTF8
+
+Returns the substring of a UTF-8 encoded string `s` which starts at the specified byte index `offset` from the left.
+
+**Syntax**
+
+``` sql
+leftUTF8(s, offset)
+```
+
+**Parameters**
+
+- `s`: The UTF-8 encoded string to calculate a substring from. [String](../../sql-reference/data-types/string.md) or [FixedString](../../sql-reference/data-types/fixedstring.md).
+- `offset`: The number of bytes of the offset. [UInt*](../data-types/int-uint).
+
+**Returned value**
+
+- For positive `offset`: A substring of `s` with `offset` many bytes, starting from the left of the string.
+- For negative `offset`: A substring of `s` with `length(s) - |offset|` bytes, starting from the left of the string.
+- An empty string if `length` is 0.
+
+**Example**
+
+Query:
+
+```sql
+SELECT leftUTF8('Привет', 4);
+```
+
+Result:
+
+```response
+Прив
+```
+
+Query:
+
+```sql
+SELECT leftUTF8('Привет', -4);
+```
+
+Result:
+
+```response
+Пр
+```
+
 ## leftPad
 
 Pads a string from the left with spaces or with a specified string (multiple times, if needed) until the resulting string reaches the specified `length`.
@@ -174,6 +268,100 @@ Result:
 ┌─leftPadUTF8('абвг', 7, '*')─┬─leftPadUTF8('дежз', 7)─┐
 │ ***абвг                     │    дежз                │
 └─────────────────────────────┴────────────────────────┘
+```
+
+## right
+
+Returns the substring of a string `s` which starts at the specified byte index `offset` from the right.
+
+**Syntax**
+
+``` sql
+right(s, offset)
+```
+
+**Parameters**
+
+- `s`: The string to calculate a substring from. [String](../../sql-reference/data-types/string.md) or [FixedString](../../sql-reference/data-types/fixedstring.md).
+- `offset`: The number of bytes of the offset. [UInt*](../data-types/int-uint).
+
+**Returned value**
+
+- For positive `offset`: A substring of `s` with `offset` many bytes, starting from the right of the string.
+- For negative `offset`: A substring of `s` with `length(s) - |offset|` bytes, starting from the right of the string.
+- An empty string if `length` is 0.
+
+**Example**
+
+Query:
+
+```sql
+SELECT right('Hello', 3);
+```
+
+Result:
+
+```response
+llo
+```
+
+Query:
+
+```sql
+SELECT right('Hello', -3);
+```
+
+Result:
+
+```response
+lo
+```
+
+## rightUTF8
+
+Returns the substring of a UTF-8 encoded string `s` which starts at the specified byte index `offset` from the right.
+
+**Syntax**
+
+``` sql
+rightUTF8(s, offset)
+```
+
+**Parameters**
+
+- `s`: The UTF-8 encoded string to calculate a substring from. [String](../../sql-reference/data-types/string.md) or [FixedString](../../sql-reference/data-types/fixedstring.md).
+- `offset`: The number of bytes of the offset. [UInt*](../data-types/int-uint).
+
+**Returned value**
+
+- For positive `offset`: A substring of `s` with `offset` many bytes, starting from the right of the string.
+- For negative `offset`: A substring of `s` with `length(s) - |offset|` bytes, starting from the right of the string.
+- An empty string if `length` is 0.
+
+**Example**
+
+Query:
+
+```sql
+SELECT rightUTF8('Привет', 4);
+```
+
+Result:
+
+```response
+ивет
+```
+
+Query:
+
+```sql
+SELECT rightUTF8('Привет', -4);
+```
+
+Result:
+
+```response
+ет
 ```
 
 ## rightPad

--- a/utils/check-style/aspell-ignore/en/aspell-dict.txt
+++ b/utils/check-style/aspell-ignore/en/aspell-dict.txt
@@ -1833,6 +1833,7 @@ laravel
 largestTriangleThreeBuckets
 latencies
 ldap
+leftUTF
 leftPad
 leftPadUTF
 lemmatization
@@ -2306,6 +2307,7 @@ retriable
 reverseUTF
 rightPad
 rightPadUTF
+rightUTF
 risc
 riscv
 ro


### PR DESCRIPTION
This PR closes [#1975](https://github.com/ClickHouse/clickhouse-docs/issues/1975) and [#2005](https://github.com/ClickHouse/clickhouse-docs/issues/2005) as part of the [functions project](https://github.com/ClickHouse/clickhouse-docs/issues/1833) to document missing functions. 

Adds the following functions which were missing:
- `left`
- `leftUTF8`
- `right`
- `rightUTF8`

### Changelog category (leave one):
- Documentation (changelog entry is not required)