### PR TITLE
Document functions `trunc` and `truncate`.

### DIFF
--- a/docs/en/sql-reference/functions/rounding-functions.md
+++ b/docs/en/sql-reference/functions/rounding-functions.md
@@ -26,6 +26,37 @@ Returns the smallest round number that is greater than or equal to `x`. In every
 
 Returns the round number with largest absolute value that has an absolute value less than or equal to `x`‘s. In every other way, it is the same as the ’floor’ function (see above).
 
+**Syntax**
+
+```sql
+trunc(input, precision)
+```
+
+Alias: `truncate`.
+
+**Parameters**
+
+- `input`: A float type [Float](/docs/en/sql-reference/data-types/float.md).
+- `precision`: A decimal type [Decimal](/docs/en/sql-reference/data-types/decimal.md).
+
+**Returned value**
+
+- A [Float64](/docs/en/sql-reference/data-types/float.md) value.
+
+**Example**
+
+Query:
+
+```sql
+SELECT trunc(123.45, 1) as res;
+```
+
+```response
+┌───res─┐
+│ 123.4 │
+└───────┘
+```
+
 ## round(x\[, N\])
 
 Rounds a value to a specified number of decimal places.

--- a/docs/en/sql-reference/functions/rounding-functions.md
+++ b/docs/en/sql-reference/functions/rounding-functions.md
@@ -48,7 +48,7 @@ Alias: `truncate`.
 Query:
 
 ```sql
-SELECT trunc(123.45, 1) as res;
+SELECT trunc(123.499, 1) as res;
 ```
 
 ```response


### PR DESCRIPTION
Document functions `trunc` and `truncate`.

Fixes https://github.com/ClickHouse/clickhouse-docs/issues/2027

### Changelog category (leave one):

- Documentation (changelog entry is not required)