### PR TITLE
Fix memory leak in groupArraySorted

### DIFF
--- a/src/AggregateFunctions/AggregateFunctionGroupArraySorted.cpp
+++ b/src/AggregateFunctions/AggregateFunctionGroupArraySorted.cpp
@@ -53,6 +53,7 @@ enum class GroupArraySortedStrategy
     sort
 };
 
+
 constexpr size_t group_array_sorted_sort_strategy_max_elements_threshold = 1000000;
 
 template <typename T, GroupArraySortedStrategy strategy>
@@ -207,6 +208,14 @@ struct GroupArraySortedData
 
             for (size_t i = 0; i < values.size(); ++i)
                 result_array_data[result_array_data_insert_begin + i] = values[i];
+        }
+    }
+
+    ~GroupArraySortedData()
+    {
+        for (auto & value : values)
+        {
+            value.~T();
         }
     }
 };

--- a/tests/queries/0_stateless/03094_grouparraysorted_memory.sql
+++ b/tests/queries/0_stateless/03094_grouparraysorted_memory.sql
@@ -1,0 +1,36 @@
+CREATE TABLE 03094_grouparrysorted_dest
+(
+    ServiceName LowCardinality(String) CODEC(ZSTD(1)),
+    -- aggregates
+    SlowSpans AggregateFunction(groupArraySorted(100),
+        Tuple(NegativeDurationNs Int64, Timestamp DateTime64(9), TraceId String, SpanId String)
+    ) CODEC(ZSTD(1))
+)
+ENGINE = AggregatingMergeTree()
+ORDER BY (ServiceName);
+
+CREATE TABLE 03094_grouparrysorted_src
+(
+    ServiceName String,
+    Duration Int64,
+    Timestamp DateTime64(9),
+    TraceId String,
+    SpanId String
+)
+ENGINE = MergeTree()
+ORDER BY ();
+
+CREATE MATERIALIZED VIEW 03094_grouparrysorted_mv TO 03094_grouparrysorted_dest
+AS SELECT
+   ServiceName,
+   groupArraySortedState(100)(
+                         CAST(
+                             tuple(-Duration, Timestamp, TraceId, SpanId),
+                             'Tuple(NegativeDurationNs Int64, Timestamp DateTime64(9), TraceId String, SpanId String)'
+                         )) as SlowSpans
+FROM 03094_grouparrysorted_src
+GROUP BY
+    ServiceName;
+
+
+INSERT INTO 03094_grouparrysorted_src SELECT * FROM generateRandom() LIMIT 5000000;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix memory leak in groupArraySorted. Fix https://github.com/ClickHouse/ClickHouse/issues/62536

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

---
### Modify your CI run:
**NOTE:** If your merge the PR with modified CI you **MUST KNOW** what you are doing
**NOTE:** Checked options will be applied if set before CI RunConfig/PrepareRunConfig step

#### Include tests (required builds will be added automatically):
- [ ] <!---ci_include_fast--> Fast test
- [ ] <!---ci_include_integration--> Integration Tests
- [ ] <!---ci_include_stateless--> Stateless tests
- [ ] <!---ci_include_stateful--> Stateful tests
- [ ] <!---ci_include_unit--> Unit tests
- [ ] <!---ci_include_performance--> Performance tests
- [ ] <!---ci_include_asan--> All with ASAN
- [ ] <!---ci_include_tsan--> All with TSAN
- [ ] <!---ci_include_analyzer--> All with Analyzer
- [ ] <!---ci_include_KEYWORD--> Add your option here

#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [ ] <!---ci_exclude_tsan--> All with TSAN
- [ ] <!---ci_exclude_msan--> All with MSAN
- [ ] <!---ci_exclude_ubsan--> All with UBSAN
- [ ] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64--> All with Aarch64
- [ ] <!---ci_exclude_KEYWORD--> Add your option here

#### Extra options:
- [ ] <!---do_not_test--> do not test (only style check)
- [ ] <!---no_merge_commit--> disable merge-commit (no merge from master before tests)
- [ ] <!---no_ci_cache--> disable CI cache (job reuse)

#### Only specified batches in multi-batch jobs:
- [ ] <!---batch_0--> 1
- [ ] <!---batch_1--> 2
- [ ] <!---batch_2--> 3
- [ ] <!---batch_3--> 4
