### PR TITLE
[Docs] add missing `countXYZ` functions

### DIFF
--- a/docs/en/sql-reference/functions/string-search-functions.md
+++ b/docs/en/sql-reference/functions/string-search-functions.md
@@ -1421,7 +1421,40 @@ Result:
 
 ## countMatchesCaseInsensitive
 
-Like `countMatches(haystack, pattern)` but matching ignores the case.
+Like [`countMatches`](#countmatches) but matching ignores the case.
+
+**Syntax**
+
+``` sql
+countMatchesCaseInsensitive(haystack, pattern)
+```
+
+**Arguments**
+
+- `haystack` — The string to search in. [String](../../sql-reference/syntax.md#syntax-string-literal).
+- `pattern` — The regular expression with [re2 syntax](https://github.com/google/re2/wiki/Syntax). [String](../../sql-reference/data-types/string.md).
+
+**Returned value**
+
+- The number of matches.
+
+Type: [UInt64](../../sql-reference/data-types/int-uint.md).
+
+**Examples**
+
+Query:
+
+``` sql
+SELECT countMatchesCaseInsensitive('AAAA', 'aa');
+```
+
+Result:
+
+``` text
+┌─countMatchesCaseInsensitive('AAAA', 'aa')────┐
+│                                            2 │
+└──────────────────────────────────────────────┘
+```
 
 ## regexpExtract
 

--- a/docs/en/sql-reference/functions/string-search-functions.md
+++ b/docs/en/sql-reference/functions/string-search-functions.md
@@ -1528,7 +1528,7 @@ Result:
 
 ## countMatchesCaseInsensitive
 
-Like [`countMatches`](#countmatches) but matching ignores the case.
+Returns the number of regular expression matches for a pattern in a haystack like [`countMatches`](#countmatches) but matching ignores the case.
 
 **Syntax**
 

--- a/docs/en/sql-reference/functions/string-search-functions.md
+++ b/docs/en/sql-reference/functions/string-search-functions.md
@@ -1322,7 +1322,7 @@ Result:
 
 ## countSubstrings
 
-Returns how often a substring `needle` occurs in string `haystack`.
+Returns how often a substring `needle` occurs in a string `haystack`.
 
 Functions [`countSubstringsCaseInsensitive`](#countsubstringscaseinsensitive) and [`countSubstringsCaseInsensitiveUTF8`](#countsubstringscaseinsensitiveutf8) provide case-insensitive and case-insensitive + UTF-8 variants of this function respectively.
 
@@ -1373,7 +1373,7 @@ Result:
 ```
 ## countSubstringsCaseInsensitive
 
-Returns how often a substring `needle` occurs in string `haystack`. Ignores case.
+Returns how often a substring `needle` occurs in a string `haystack`. Ignores case.
 
 **Syntax**
 
@@ -1395,6 +1395,8 @@ Type: [UInt64](../../sql-reference/data-types/int-uint.md).
 
 **Examples**
 
+Query:
+
 ``` sql
 SELECT countSubstringsCaseInsensitive('AAAA', 'aa');
 ```
@@ -1408,6 +1410,8 @@ Result:
 ```
 
 Example with `start_pos` argument:
+
+Query:
 
 ```sql
 SELECT countSubstringsCaseInsensitive('abc___ABC___abc', 'abc', 4);
@@ -1423,7 +1427,7 @@ Result:
 
 ## countSubstringsCaseInsensitiveUTF8
 
-Returns how often a substring `needle` occurs in string `haystack`. Ignores case and assumes that `haystack` is a UTF8 string.
+Returns how often a substring `needle` occurs in a string `haystack`. Ignores case and assumes that `haystack` is a UTF8 string.
 
 **Syntax**
 
@@ -1445,6 +1449,8 @@ Type: [UInt64](../../sql-reference/data-types/int-uint.md).
 
 **Examples**
 
+Query:
+
 ``` sql
 SELECT countSubstringsCaseInsensitiveUTF8('ложка, кошка, картошка', 'КА');
 ```
@@ -1458,6 +1464,8 @@ Result:
 ```
 
 Example with `start_pos` argument:
+
+Query:
 
 ```sql
 SELECT countSubstringsCaseInsensitiveUTF8('ложка, кошка, картошка', 'КА', 13);

--- a/docs/en/sql-reference/functions/string-search-functions.md
+++ b/docs/en/sql-reference/functions/string-search-functions.md
@@ -1322,9 +1322,9 @@ Result:
 
 ## countSubstrings
 
-Returns how often substring `needle` occurs in string `haystack`.
+Returns how often a substring `needle` occurs in string `haystack`.
 
-Functions `countSubstringsCaseInsensitive` and `countSubstringsCaseInsensitiveUTF8` provide a case-insensitive and case-insensitive + UTF-8 variants of this function.
+Functions [`countSubstringsCaseInsensitive`](#countsubstringscaseinsensitive) and [`countSubstringsCaseInsensitiveUTF8`](#countsubstringscaseinsensitiveutf8) provide case-insensitive and case-insensitive + UTF-8 variants of this function respectively.
 
 **Syntax**
 
@@ -1370,6 +1370,105 @@ Result:
 ┌─countSubstrings('abc___abc', 'abc', 4)─┐
 │                                      1 │
 └────────────────────────────────────────┘
+```
+## countSubstringsCaseInsensitive
+
+Returns how often a substring `needle` occurs in string `haystack`. Ignores case.
+
+**Syntax**
+
+``` sql
+countSubstringsCaseInsensitive(haystack, needle[, start_pos])
+```
+
+**Arguments**
+
+- `haystack` — String in which the search is performed. [String](../../sql-reference/syntax.md#syntax-string-literal).
+- `needle` — Substring to be searched. [String](../../sql-reference/syntax.md#syntax-string-literal).
+- `start_pos` – Position (1-based) in `haystack` at which the search starts. [UInt](../../sql-reference/data-types/int-uint.md). Optional.
+
+**Returned values**
+
+- The number of occurrences.
+
+Type: [UInt64](../../sql-reference/data-types/int-uint.md).
+
+**Examples**
+
+``` sql
+SELECT countSubstringsCaseInsensitive('AAAA', 'aa');
+```
+
+Result:
+
+``` text
+┌─countSubstringsCaseInsensitive('AAAA', 'aa')─┐
+│                                            2 │
+└──────────────────────────────────────────────┘
+```
+
+Example with `start_pos` argument:
+
+```sql
+SELECT countSubstringsCaseInsensitive('abc___ABC___abc', 'abc', 4);
+```
+
+Result:
+
+``` text
+┌─countSubstringsCaseInsensitive('abc___ABC___abc', 'abc', 4)─┐
+│                                                           2 │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## countSubstringsCaseInsensitiveUTF8
+
+Returns how often a substring `needle` occurs in string `haystack`. Ignores case and assumes that `haystack` is a UTF8 string.
+
+**Syntax**
+
+``` sql
+countSubstringsCaseInsensitiveUTF8(haystack, needle[, start_pos])
+```
+
+**Arguments**
+
+- `haystack` — UTF-8 string in which the search is performed. [String](../../sql-reference/syntax.md#syntax-string-literal).
+- `needle` — Substring to be searched. [String](../../sql-reference/syntax.md#syntax-string-literal).
+- `start_pos` – Position (1-based) in `haystack` at which the search starts. [UInt](../../sql-reference/data-types/int-uint.md). Optional.
+
+**Returned values**
+
+- The number of occurrences.
+
+Type: [UInt64](../../sql-reference/data-types/int-uint.md).
+
+**Examples**
+
+``` sql
+SELECT countSubstringsCaseInsensitiveUTF8('ложка, кошка, картошка', 'КА');
+```
+
+Result:
+
+``` text
+┌─countSubstringsCaseInsensitiveUTF8('ложка, кошка, картошка', 'КА')─┐
+│                                                                  4 │
+└────────────────────────────────────────────────────────────────────┘
+```
+
+Example with `start_pos` argument:
+
+```sql
+SELECT countSubstringsCaseInsensitiveUTF8('ложка, кошка, картошка', 'КА', 13);
+```
+
+Result:
+
+``` text
+┌─countSubstringsCaseInsensitiveUTF8('ложка, кошка, картошка', 'КА', 13)─┐
+│                                                                      2 │
+└────────────────────────────────────────────────────────────────────────┘
 ```
 
 ## countMatches

--- a/utils/check-style/aspell-ignore/en/aspell-dict.txt
+++ b/utils/check-style/aspell-ignore/en/aspell-dict.txt
@@ -1371,6 +1371,8 @@ countEqual
 countMatches
 countMatchesCaseInsensitive
 countSubstrings
+countSubstringsCaseInsensitive
+countSubstringsCaseInsensitiveUTF8
 covarPop
 covarSamp
 covariates

--- a/utils/check-style/aspell-ignore/en/aspell-dict.txt
+++ b/utils/check-style/aspell-ignore/en/aspell-dict.txt
@@ -1372,6 +1372,7 @@ countMatches
 countMatchesCaseInsensitive
 countSubstrings
 countSubstringsCaseInsensitive
+countSubstringsCaseInsensitiveUTF
 covarPop
 covarSamp
 covariates

--- a/utils/check-style/aspell-ignore/en/aspell-dict.txt
+++ b/utils/check-style/aspell-ignore/en/aspell-dict.txt
@@ -1372,7 +1372,6 @@ countMatches
 countMatchesCaseInsensitive
 countSubstrings
 countSubstringsCaseInsensitive
-countSubstringsCaseInsensitiveUTF8
 covarPop
 covarSamp
 covariates


### PR DESCRIPTION
Closes [#1938](https://github.com/ClickHouse/clickhouse-docs/issues/1938) as part of the [functions project](https://github.com/ClickHouse/clickhouse-docs/issues/1833) to document missing functions and supplement existing ones.

This PR:
- Adds missing functions `countSubstringsCaseInsensitive` and `countSubstringsCaseInsensitiveUTF8`
- Updates `countMatchesCaseInsensitive` 

### Changelog category (leave one):
- Documentation (changelog entry is not required)