### PR TITLE
[Docs] add missing `tanh`

### DIFF
--- a/docs/en/sql-reference/functions/math-functions.md
+++ b/docs/en/sql-reference/functions/math-functions.md
@@ -557,6 +557,37 @@ Result:
 │        0 │
 └──────────┘
 ```
+## tanh
+
+Returns the [hyperbolic tangent](https://www.mathworks.com/help/matlab/ref/tanh.html).
+
+**Syntax**
+
+``` sql
+tanh(x)
+```
+
+**Arguments**
+
+- `x` — The angle, in radians. Values from the interval: `-∞ < x < +∞`. [Float64](../../sql-reference/data-types/float.md#float32-float64).
+
+**Returned value**
+
+- Values from the interval: `-1 < tanh(x) < 1`.
+
+Type: [Float64](../../sql-reference/data-types/float.md#float32-float64).
+
+**Example**
+
+``` sql
+SELECT tanh(0);
+```
+
+Result:
+
+```result
+0
+```
 
 ## atanh
 

--- a/utils/check-style/aspell-ignore/en/aspell-dict.txt
+++ b/utils/check-style/aspell-ignore/en/aspell-dict.txt
@@ -949,6 +949,7 @@ TablesLoaderForegroundThreads
 TablesLoaderForegroundThreadsActive
 TablesToDropQueueSize
 TargetSpecific
+tanh
 Telegraf
 TemplateIgnoreSpaces
 TemporaryFilesForAggregation


### PR DESCRIPTION
Closes [#2020](https://github.com/ClickHouse/clickhouse-docs/issues/2020) as part of the [functions project](https://github.com/ClickHouse/clickhouse-docs/issues/1833) to add missing functions to the documentation and supplement incomplete functions.

- Adds missing `tanh` function.

### Changelog category (leave one):
- Documentation (changelog entry is not required)