### PR TITLE
documenting alternative syntax that's supported for DATE_ADD, DATE_SUB

### DIFF
--- a/docs/en/sql-reference/functions/date-time-functions.md
+++ b/docs/en/sql-reference/functions/date-time-functions.md
@@ -1902,6 +1902,12 @@ If the addition results in a value outside the bounds of the data type, the resu
 date_add(unit, value, date)
 ```
 
+Alternative syntax:
+
+``` sql
+date_add(date, INTERVAL value unit)
+```
+
 Aliases: `dateAdd`, `DATE_ADD`.
 
 **Arguments**
@@ -1941,6 +1947,20 @@ Result:
 └───────────────────────────────────────────────┘
 ```
 
+```sql
+SELECT date_add(toDate('2018-01-01'), INTERVAL 3 YEAR);
+```
+
+Result:
+
+```text
+┌─plus(toDate('2018-01-01'), toIntervalYear(3))─┐
+│                                    2021-01-01 │
+└───────────────────────────────────────────────┘
+```
+
+
+
 **See Also**
 
 - [addDate](#addDate)
@@ -1956,6 +1976,13 @@ If the subtraction results in a value outside the bounds of the data type, the r
 ``` sql
 date_sub(unit, value, date)
 ```
+
+Alternative syntax:
+
+``` sql
+date_sub(date, INTERVAL value unit)
+```
+
 
 Aliases: `dateSub`, `DATE_SUB`.
 
@@ -1996,6 +2023,19 @@ Result:
 │                                     2015-01-01 │
 └────────────────────────────────────────────────┘
 ```
+
+``` sql
+SELECT date_sub(toDate('2018-01-01'), INTERVAL 3 YEAR);
+```
+
+Result:
+
+``` text
+┌─minus(toDate('2018-01-01'), toIntervalYear(3))─┐
+│                                     2015-01-01 │
+└────────────────────────────────────────────────┘
+```
+
 
 **See Also**
 


### PR DESCRIPTION
this is related to issue https://github.com/ClickHouse/ClickHouse/issues/25815 

i'm adding examples for:
date_add(date, INTERVAL value unit) and date_sub(date, INTERVAL value unit) 

both are covered with a test from https://github.com/ClickHouse/ClickHouse/blob/e3c09e97034b7d26b2280487fa8422a8037caa51/tests/queries/0_stateless/02160_special_functions.sql#L33 ; i think it's worth documenting them as the syntax is familiar to MySQL users [ https://dev.mysql.com/doc/refman/8.0/en/date-and-time-functions.html#function_date-add ]

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

documenting alternative syntax that's supported for DATE_ADD, DATE_SUB

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
