### PR TITLE
Fix HostResolver behavior on fail

### DIFF
--- a/src/Common/CurrentMetrics.cpp
+++ b/src/Common/CurrentMetrics.cpp
@@ -285,6 +285,7 @@
     M(HTTPConnectionsTotal, "Total count of all sessions: stored in the pool and actively used right now for http hosts") \
     \
     M(AddressesActive, "Total count of addresses which are used for creation connections with connection pools") \
+    M(AddressesBanned, "Total count of addresses which are banned as faulty for creation connections with connection pools") \
 
 
 #ifdef APPLY_FOR_EXTERNAL_METRICS

--- a/src/Common/HostResolvePool.cpp
+++ b/src/Common/HostResolvePool.cpp
@@ -160,14 +160,10 @@ void HostResolver::setFail(const Poco::Net::IPAddress & address)
         if (it == records.end())
             return;
 
-        while (it != records.end() && it->address == address)
-        {
-            it->failed = true;
-            it->fail_time = now;
-            if (it->fail_count < RECORD_FAIL_COUNT_LIMIT)
-                ++it->fail_count;
-            ++it;
-        }
+        it->failed = true;
+        it->fail_time = now;
+        if (it->fail_count < RECORD_FAIL_COUNT_LIMIT)
+            ++it->fail_count;
     }
 
     ProfileEvents::increment(metrics.failed);

--- a/src/Common/HostResolvePool.cpp
+++ b/src/Common/HostResolvePool.cpp
@@ -8,6 +8,8 @@
 #include <Common/MemoryTrackerSwitcher.h>
 
 #include <mutex>
+#include <algorithm>
+
 
 namespace ProfileEvents
 {
@@ -19,6 +21,7 @@ namespace ProfileEvents
 namespace CurrentMetrics
 {
     extern const Metric AddressesActive;
+    extern const Metric AddressesBanned;
 }
 
 namespace DB
@@ -36,6 +39,7 @@ HostResolverMetrics HostResolver::getMetrics()
         .expired = ProfileEvents::AddressesExpired,
         .failed = ProfileEvents::AddressesMarkedAsFailed,
         .active_count = CurrentMetrics::AddressesActive,
+        .banned_count = CurrentMetrics::AddressesBanned,
     };
 }
 
@@ -47,7 +51,7 @@ HostResolver::WeakPtr HostResolver::getWeakFromThis()
 HostResolver::HostResolver(String host_, Poco::Timespan history_)
     : host(std::move(host_))
     , history(history_)
-    , resolve_function([](const String & host_to_resolve) { return DNSResolver::instance().resolveHostAll(host_to_resolve); })
+    , resolve_function([](const String & host_to_resolve) { return DNSResolver::instance().resolveHostAllInOriginOrder(host_to_resolve); })
 {
     update();
 }
@@ -62,6 +66,12 @@ HostResolver::HostResolver(
 HostResolver::~HostResolver()
 {
     std::lock_guard lock(mutex);
+
+    auto banned_count = 0;
+    for (const auto & rec: records)
+        banned_count += rec.failed;
+    CurrentMetrics::sub(metrics.banned_count, banned_count);
+
     CurrentMetrics::sub(metrics.active_count, records.size());
     records.clear();
 }
@@ -113,6 +123,7 @@ void HostResolver::updateWeights()
 
     if (getTotalWeight() == 0 && !records.empty())
     {
+        CurrentMetrics::sub(metrics.banned_count, records.size());
         for (auto & rec : records)
             rec.failed = false;
 
@@ -158,7 +169,8 @@ void HostResolver::setFail(const Poco::Net::IPAddress & address)
         if (it == records.end())
             return;
 
-        it->setFail(now);
+        if (it->setFail(now))
+            CurrentMetrics::add(metrics.banned_count);
     }
 
     ProfileEvents::increment(metrics.failed);
@@ -215,17 +227,20 @@ void HostResolver::updateImpl(Poco::Timestamp now, std::vector<Poco::Net::IPAddr
             {
                 CurrentMetrics::sub(metrics.active_count, 1);
                 ProfileEvents::increment(metrics.expired, 1);
+                if (it_before->failed)
+                    CurrentMetrics::sub(metrics.banned_count);
             }
             ++it_before;
         }
         else if (it_before == records.end() || (it_next != next_gen.end() && *it_next < it_before->address))
         {
-            CurrentMetrics::add(metrics.active_count, 1);
-            ProfileEvents::increment(metrics.discovered, 1);
+            /// there are could be duplicates in next_gen vector
             if (merged.empty() || merged.back().address != *it_next)
+            {
+                CurrentMetrics::add(metrics.active_count, 1);
+                ProfileEvents::increment(metrics.discovered, 1);
                 merged.push_back(Record(*it_next, now));
-            else
-                merged.back().resolve_time = now;
+            }
             ++it_next;
         }
         else
@@ -239,9 +254,22 @@ void HostResolver::updateImpl(Poco::Timestamp now, std::vector<Poco::Net::IPAddr
     }
 
     for (auto & rec : merged)
-        rec.cleanTimeoutedFailedFlag(now, history);
+    {
+            if (!rec.failed)
+                continue;
+
+            /// Exponential increased time for each consecutive fail
+            auto banned_until = now - Poco::Timespan(history.totalMicroseconds() * (1ull << (rec.consecutive_fail_count - 1)));
+            if (rec.fail_time < banned_until)
+            {
+                rec.failed = false;
+                CurrentMetrics::sub(metrics.banned_count);
+            }
+    }
 
     chassert(std::is_sorted(merged.begin(), merged.end()));
+    // check that merged contains unuque elements
+    chassert(std::adjacent_find(merged.begin(), merged.end()) == merged.end());
 
     last_resolve_time = now;
     records.swap(merged);

--- a/src/Common/HostResolvePool.h
+++ b/src/Common/HostResolvePool.h
@@ -42,6 +42,7 @@ struct HostResolverMetrics
 };
 
 constexpr size_t DEFAULT_RESOLVE_TIME_HISTORY_SECONDS = 2*60;
+constexpr size_t RECORD_FAIL_COUNT_LIMIT = 6;
 
 
 class HostResolver : public std::enable_shared_from_this<HostResolver>
@@ -141,6 +142,7 @@ protected:
         size_t usage = 0;
         bool failed = false;
         Poco::Timestamp fail_time = 0;
+        size_t fail_count = 0;
 
         size_t weight_prefix_sum;
 

--- a/src/Common/tests/gtest_resolve_pool.cpp
+++ b/src/Common/tests/gtest_resolve_pool.cpp
@@ -2,7 +2,9 @@
 #include <base/sleep.h>
 #include <Common/CurrentThread.h>
 #include <Common/HostResolvePool.h>
+#include "base/defines.h"
 
+#include <optional>
 #include <thread>
 #include <gtest/gtest.h>
 
@@ -29,8 +31,9 @@ protected:
         DB::CurrentThread::getProfileEvents().reset();
 
         ASSERT_EQ(0, CurrentMetrics::get(metrics.active_count));
+        ASSERT_EQ(0, CurrentMetrics::get(metrics.banned_count));
 
-        addresses = std::set<String>{"127.0.0.1", "127.0.0.2", "127.0.0.3"};
+        addresses = std::multiset<String>{"127.0.0.1", "127.0.0.2", "127.0.0.3"};
         // Code here will be called immediately after the constructor (right
         // before each test).
     }
@@ -58,7 +61,7 @@ protected:
     }
 
     DB::HostResolverMetrics metrics = DB::HostResolver::getMetrics();
-    std::set<String> addresses;
+    std::multiset<String> addresses;
 };
 
 TEST_F(ResolvePoolTest, CanResolve)
@@ -160,7 +163,7 @@ TEST_F(ResolvePoolTest, CanMerge)
     ASSERT_EQ(addresses.size(), DB::CurrentThread::getProfileEvents()[metrics.discovered]);
 
     auto old_addresses = addresses;
-    addresses = std::set<String>{"127.0.0.4", "127.0.0.5"};
+    addresses = std::multiset<String>{"127.0.0.4", "127.0.0.5"};
 
 
     resolver->update();
@@ -229,6 +232,7 @@ TEST_F(ResolvePoolTest, CanFail)
 
     ASSERT_EQ(1, DB::CurrentThread::getProfileEvents()[metrics.failed]);
     ASSERT_EQ(addresses.size(), CurrentMetrics::get(metrics.active_count));
+    ASSERT_EQ(1, CurrentMetrics::get(metrics.banned_count));
     ASSERT_EQ(addresses.size(), DB::CurrentThread::getProfileEvents()[metrics.discovered]);
 
     for (size_t i = 0; i < 1000; ++i)
@@ -243,15 +247,20 @@ TEST_F(ResolvePoolTest, CanFail)
 TEST_F(ResolvePoolTest, CanFailAndHeal)
 {
     auto resolver = make_resolver();
+    ASSERT_EQ(0, CurrentMetrics::get(metrics.banned_count));
 
     auto failed_addr = resolver->resolve();
     failed_addr.setFail();
+    ASSERT_EQ(1, CurrentMetrics::get(metrics.banned_count));
 
     while (true)
     {
         auto next_addr = resolver->resolve();
         if (*failed_addr == *next_addr)
+        {
+            ASSERT_EQ(0, CurrentMetrics::get(metrics.banned_count));
             break;
+        }
     }
 }
 
@@ -276,4 +285,124 @@ TEST_F(ResolvePoolTest, CanExpire)
 
     ASSERT_EQ(addresses.size() + 1, DB::CurrentThread::getProfileEvents()[metrics.discovered]);
     ASSERT_EQ(1, DB::CurrentThread::getProfileEvents()[metrics.expired]);
+}
+
+
+TEST_F(ResolvePoolTest, DuplicatesInAddresses)
+{
+    auto resolver = make_resolver();
+
+    size_t unuque_addresses = addresses.size();
+
+    ASSERT_EQ(3, unuque_addresses);
+    ASSERT_EQ(3, DB::CurrentThread::getProfileEvents()[metrics.discovered]);
+
+    ASSERT_TRUE(!addresses.empty());
+    addresses.insert(*addresses.begin());
+    addresses.insert(*addresses.begin());
+
+    size_t total_addresses = addresses.size();
+
+    ASSERT_EQ(addresses.count(*addresses.begin()), 3);
+    ASSERT_EQ(unuque_addresses + 2, total_addresses);
+
+    resolver->update();
+    ASSERT_EQ(3, DB::CurrentThread::getProfileEvents()[metrics.discovered]);
+}
+
+void check_no_failed_address(size_t iteration, auto & resolver, auto & addresses, auto & failed_addr, auto & metrics)
+{
+    ASSERT_EQ(iteration, DB::CurrentThread::getProfileEvents()[metrics.failed]);
+    for (size_t i = 0; i < 100; ++i)
+    {
+        auto next_addr = resolver->resolve();
+        ASSERT_TRUE(addresses.contains(*next_addr));
+        ASSERT_NE(*next_addr, *failed_addr);
+    }
+}
+
+TEST_F(ResolvePoolTest, BannedForConsiquenceFail)
+{
+    size_t history_ms = 5;
+    auto resolver = make_resolver(history_ms);
+
+
+    auto failed_addr = resolver->resolve();
+    ASSERT_TRUE(addresses.contains(*failed_addr));
+
+    failed_addr.setFail();
+    ASSERT_EQ(3, CurrentMetrics::get(metrics.active_count));
+    ASSERT_EQ(1, CurrentMetrics::get(metrics.banned_count));
+    check_no_failed_address(1, resolver, addresses, failed_addr, metrics);
+
+    sleepForMilliseconds(history_ms + 1);
+    resolver->update();
+    ASSERT_EQ(3, CurrentMetrics::get(metrics.active_count));
+    ASSERT_EQ(0, CurrentMetrics::get(metrics.banned_count));
+
+    failed_addr.setFail();
+    check_no_failed_address(2, resolver, addresses, failed_addr, metrics);
+
+    sleepForMilliseconds(history_ms + 1);
+    resolver->update();
+    ASSERT_EQ(3, CurrentMetrics::get(metrics.active_count));
+    ASSERT_EQ(1, CurrentMetrics::get(metrics.banned_count));
+
+    // ip still banned adter history_ms + update, because it was his second consiquent fail
+    check_no_failed_address(2, resolver, addresses, failed_addr, metrics);
+}
+
+TEST_F(ResolvePoolTest, NoAditionalBannForConcurrentFail)
+{
+    size_t history_ms = 5;
+    auto resolver = make_resolver(history_ms);
+
+    auto failed_addr = resolver->resolve();
+    ASSERT_TRUE(addresses.contains(*failed_addr));
+
+    failed_addr.setFail();
+    failed_addr.setFail();
+    failed_addr.setFail();
+
+    ASSERT_EQ(3, CurrentMetrics::get(metrics.active_count));
+    ASSERT_EQ(1, CurrentMetrics::get(metrics.banned_count));
+    check_no_failed_address(3, resolver, addresses, failed_addr, metrics);
+
+    sleepForMilliseconds(history_ms + 1);
+    resolver->update();
+    // ip is cleared after just 1 history_ms interval.
+    ASSERT_EQ(3, CurrentMetrics::get(metrics.active_count));
+    ASSERT_EQ(0, CurrentMetrics::get(metrics.banned_count));
+}
+
+TEST_F(ResolvePoolTest, StillBannedAfterSuccess)
+{
+    size_t history_ms = 5;
+    auto resolver = make_resolver(history_ms);
+
+    auto failed_addr = resolver->resolve();
+    ASSERT_TRUE(addresses.contains(*failed_addr));
+
+    std::optional<decltype(resolver->resolve())> again_addr;
+    while (true)
+    {
+        auto addr = resolver->resolve();
+        if (*addr == *failed_addr)
+        {
+            again_addr.emplace(std::move(addr));
+            break;
+        }
+    }
+    chassert(again_addr);
+
+    failed_addr.setFail();
+
+    ASSERT_EQ(3, CurrentMetrics::get(metrics.active_count));
+    ASSERT_EQ(1, CurrentMetrics::get(metrics.banned_count));
+    check_no_failed_address(1, resolver, addresses, failed_addr, metrics);
+
+    again_addr = std::nullopt; // success;
+
+    ASSERT_EQ(3, CurrentMetrics::get(metrics.active_count));
+    ASSERT_EQ(1, CurrentMetrics::get(metrics.banned_count));
 }

--- a/tests/integration/test_host_resolver_fail_count/configs/config.d/cluster.xml
+++ b/tests/integration/test_host_resolver_fail_count/configs/config.d/cluster.xml
@@ -1,0 +1,12 @@
+<clickhouse>
+    <profiles>
+        <default>
+            <connect_timeout>5</connect_timeout>
+            <receive_timeout>5</receive_timeout>
+            <send_timeout>5</send_timeout>
+            <http_connection_timeout>5</http_connection_timeout>
+            <http_send_timeout>5</http_send_timeout>
+            <http_receive_timeout>5</http_receive_timeout>
+        </default>
+    </profiles>
+</clickhouse>

--- a/tests/integration/test_host_resolver_fail_count/configs/config.d/s3.xml
+++ b/tests/integration/test_host_resolver_fail_count/configs/config.d/s3.xml
@@ -1,0 +1,21 @@
+<clickhouse>
+    <storage_configuration>
+        <disks>
+            <s3>
+                <type>s3</type>
+                <endpoint>http://minio1:9001/root/data/</endpoint>
+                <access_key_id>minio</access_key_id>
+                <secret_access_key>minio123</secret_access_key>
+            </s3>
+        </disks>
+        <policies>
+            <s3>
+                <volumes>
+                    <main>
+                        <disk>s3</disk>
+                    </main>
+                </volumes>
+            </s3>
+        </policies>
+    </storage_configuration>
+</clickhouse>

--- a/tests/integration/test_host_resolver_fail_count/test_case.py
+++ b/tests/integration/test_host_resolver_fail_count/test_case.py
@@ -1,4 +1,5 @@
 """Test Interserver responses on configured IP."""
+
 import pytest
 import time
 from helpers.cluster import ClickHouseCluster
@@ -23,7 +24,7 @@ def start_cluster():
 
 
 # The same value as in ClickHouse, this can't be confugured via config now
-DEFAULT_RESOLVE_TIME_HISTORY_SECONDS = 2*60
+DEFAULT_RESOLVE_TIME_HISTORY_SECONDS = 2 * 60
 
 
 def test_host_resolver(start_cluster):
@@ -36,7 +37,7 @@ def test_host_resolver(start_cluster):
             (node.ip_address, "minio1"),  # no answer on 9001 port on this IP
         ]
     )
-    
+
     node.query("SYSTEM DROP DNS CACHE")
     node.query("SYSTEM DROP CONNECTIONS CACHE")
 
@@ -94,7 +95,9 @@ def test_host_resolver(start_cluster):
                     INSERT INTO test VALUES (101,{k})
                     """
         )
-        intermediate_fails = node.query("SELECT value FROM system.events WHERE event LIKE 'AddressesMarkedAsFailed'")
+        intermediate_fails = node.query(
+            "SELECT value FROM system.events WHERE event LIKE 'AddressesMarkedAsFailed'"
+        )
         k += 1
         if k >= limit:
             # Dead IP was not choosen for 100 iteration.

--- a/tests/integration/test_host_resolver_fail_count/test_case.py
+++ b/tests/integration/test_host_resolver_fail_count/test_case.py
@@ -1,0 +1,103 @@
+"""Test Interserver responses on configured IP."""
+import pytest
+import time
+from helpers.cluster import ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__)
+
+node = cluster.add_instance(
+    "node",
+    main_configs=["configs/config.d/cluster.xml", "configs/config.d/s3.xml"],
+    with_minio=True,
+)
+
+@pytest.fixture(scope="module")
+def start_cluster():
+    try:
+        cluster.start()
+        yield cluster
+
+    finally:
+        cluster.shutdown()
+
+# The same value as in ClickHouse, this can't be confugured via config now
+DEFAULT_RESOLVE_TIME_HISTORY_SECONDS = 2*60
+
+
+def test_host_resolver(start_cluster):
+    minio_ip = cluster.get_instance_ip("minio1")
+
+    # drop DNS cache    
+    node.set_hosts([
+        (minio_ip, "minio1"),
+        (node.ip_address, "minio1"), # no answer on 9001 port on this IP
+        ])
+    
+    node.query("SYSTEM DROP DNS CACHE")
+    node.query("SYSTEM DROP CONNECTIONS CACHE")
+
+    node.query("""
+                CREATE TABLE test (key UInt32, value UInt32)
+                Engine=MergeTree()
+                ORDER BY key PARTITION BY key
+                SETTINGS storage_policy='s3'
+                """)
+
+    initial_fails = "0\n"
+    k = 0
+    limit = 100
+    while initial_fails == "0\n":
+        node.query(f"""
+                    INSERT INTO test VALUES (0,{k})
+                    """)
+        # HostResolver chooses IP randomly, so on single call can choose worked ID
+        initial_fails = node.query("SELECT value FROM system.events WHERE event LIKE 'AddressesMarkedAsFailed'")
+        k += 1
+        if k >= limit:
+            # Dead IP was not choosen for 100 iteration.
+            # This is not expected, but not an error actually.
+            # And test should be stopped.
+            return
+
+    # initial_fails can be more than 1 if clickhouse does something in several parallel threads
+
+    for j in range(10):
+        for i in range(10):
+            node.query(f"""
+                        INSERT INTO test VALUES ({i+1},{j+1})
+                        """)
+            fails = node.query("SELECT value FROM system.events WHERE event LIKE 'AddressesMarkedAsFailed'")
+            assert fails == initial_fails
+
+    # Check that clickhouse tries to recheck IP after 2 minutes
+    time.sleep(DEFAULT_RESOLVE_TIME_HISTORY_SECONDS)
+
+    intermediate_fails = initial_fails
+    limit = k + 100
+    while intermediate_fails == initial_fails:
+        node.query(f"""
+                    INSERT INTO test VALUES (101,{k})
+                    """)
+        intermediate_fails = node.query("SELECT value FROM system.events WHERE event LIKE 'AddressesMarkedAsFailed'")
+        k += 1
+        if k >= limit:
+            # Dead IP was not choosen for 100 iteration.
+            # This is not expected, but not an error actually.
+            # And test should be stopped.
+            return
+
+    # After another 2 minutes shoudl not be new fails, next retry after 4 minutes
+    time.sleep(DEFAULT_RESOLVE_TIME_HISTORY_SECONDS)
+
+    initial_fails = intermediate_fails
+    limit = k + 100
+    while intermediate_fails == initial_fails:
+        node.query(f"""
+                    INSERT INTO test VALUES (102,{k})
+                    """)
+        intermediate_fails = node.query("SELECT value FROM system.events WHERE event LIKE 'AddressesMarkedAsFailed'")
+        k += 1
+        if k >= limit:
+            break
+
+    assert k == limit

--- a/tests/integration/test_host_resolver_fail_count/test_case.py
+++ b/tests/integration/test_host_resolver_fail_count/test_case.py
@@ -11,6 +11,7 @@ node = cluster.add_instance(
     with_minio=True,
 )
 
+
 @pytest.fixture(scope="module")
 def start_cluster():
     try:
@@ -20,6 +21,7 @@ def start_cluster():
     finally:
         cluster.shutdown()
 
+
 # The same value as in ClickHouse, this can't be confugured via config now
 DEFAULT_RESOLVE_TIME_HISTORY_SECONDS = 2*60
 
@@ -27,31 +29,39 @@ DEFAULT_RESOLVE_TIME_HISTORY_SECONDS = 2*60
 def test_host_resolver(start_cluster):
     minio_ip = cluster.get_instance_ip("minio1")
 
-    # drop DNS cache    
-    node.set_hosts([
-        (minio_ip, "minio1"),
-        (node.ip_address, "minio1"), # no answer on 9001 port on this IP
-        ])
+    # drop DNS cache
+    node.set_hosts(
+        [
+            (minio_ip, "minio1"),
+            (node.ip_address, "minio1"),  # no answer on 9001 port on this IP
+        ]
+    )
     
     node.query("SYSTEM DROP DNS CACHE")
     node.query("SYSTEM DROP CONNECTIONS CACHE")
 
-    node.query("""
+    node.query(
+        """
                 CREATE TABLE test (key UInt32, value UInt32)
                 Engine=MergeTree()
                 ORDER BY key PARTITION BY key
                 SETTINGS storage_policy='s3'
-                """)
+                """
+    )
 
     initial_fails = "0\n"
     k = 0
     limit = 100
     while initial_fails == "0\n":
-        node.query(f"""
+        node.query(
+            f"""
                     INSERT INTO test VALUES (0,{k})
-                    """)
+                    """
+        )
         # HostResolver chooses IP randomly, so on single call can choose worked ID
-        initial_fails = node.query("SELECT value FROM system.events WHERE event LIKE 'AddressesMarkedAsFailed'")
+        initial_fails = node.query(
+            "SELECT value FROM system.events WHERE event LIKE 'AddressesMarkedAsFailed'"
+        )
         k += 1
         if k >= limit:
             # Dead IP was not choosen for 100 iteration.
@@ -63,10 +73,14 @@ def test_host_resolver(start_cluster):
 
     for j in range(10):
         for i in range(10):
-            node.query(f"""
+            node.query(
+                f"""
                         INSERT INTO test VALUES ({i+1},{j+1})
-                        """)
-            fails = node.query("SELECT value FROM system.events WHERE event LIKE 'AddressesMarkedAsFailed'")
+                        """
+            )
+            fails = node.query(
+                "SELECT value FROM system.events WHERE event LIKE 'AddressesMarkedAsFailed'"
+            )
             assert fails == initial_fails
 
     # Check that clickhouse tries to recheck IP after 2 minutes
@@ -75,9 +89,11 @@ def test_host_resolver(start_cluster):
     intermediate_fails = initial_fails
     limit = k + 100
     while intermediate_fails == initial_fails:
-        node.query(f"""
+        node.query(
+            f"""
                     INSERT INTO test VALUES (101,{k})
-                    """)
+                    """
+        )
         intermediate_fails = node.query("SELECT value FROM system.events WHERE event LIKE 'AddressesMarkedAsFailed'")
         k += 1
         if k >= limit:
@@ -92,10 +108,14 @@ def test_host_resolver(start_cluster):
     initial_fails = intermediate_fails
     limit = k + 100
     while intermediate_fails == initial_fails:
-        node.query(f"""
+        node.query(
+            f"""
                     INSERT INTO test VALUES (102,{k})
-                    """)
-        intermediate_fails = node.query("SELECT value FROM system.events WHERE event LIKE 'AddressesMarkedAsFailed'")
+                    """
+        )
+        intermediate_fails = node.query(
+            "SELECT value FROM system.events WHERE event LIKE 'AddressesMarkedAsFailed'"
+        )
         k += 1
         if k >= limit:
             break


### PR DESCRIPTION
### Changelog category (leave one):

- Performance Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
HostResolver has each IP address several times.
If remote host has several IPs and by some reason (firewall rules for example) access on some IPs allowed and on others forbidden, than only first record of forbidden IPs marked as failed, and in each try these IPs have a chance to be chosen (and failed again).
Even if fix this, every 120 seconds DNS cache dropped, and IPs can be chosen again.

This fix
1. Allows only one record per IP in HostResoler
2. Adds exponential timeouts between reties of failed IPs

#### Include tests (required builds will be added automatically):
- [ ] <!---ci_include_performance--> Performance tests
