### PR TITLE
Fix FINAL modifier is not respected in CTE with analyzer

### DIFF
--- a/src/Analyzer/IdentifierNode.cpp
+++ b/src/Analyzer/IdentifierNode.cpp
@@ -56,7 +56,9 @@ void IdentifierNode::updateTreeHashImpl(HashState & state, CompareOptions) const
 
 QueryTreeNodePtr IdentifierNode::cloneImpl() const
 {
-    return std::make_shared<IdentifierNode>(identifier);
+    auto clone_identifier_node = std::make_shared<IdentifierNode>(identifier);
+    clone_identifier_node->table_expression_modifiers = table_expression_modifiers;
+    return clone_identifier_node;
 }
 
 ASTPtr IdentifierNode::toASTImpl(const ConvertToASTOptions & /* options */) const

--- a/tests/queries/0_stateless/03129_cte_with_final.reference
+++ b/tests/queries/0_stateless/03129_cte_with_final.reference
@@ -20,5 +20,5 @@ QUERY id: 0
           COLUMN id: 9, column_name: someCol, result_type: String, source_id: 8
           COLUMN id: 10, column_name: eventTime, result_type: DateTime, source_id: 8
       JOIN TREE
-        TABLE id: 8, alias: __table2, table_name: default.test, final: 1
+        TABLE id: 8, alias: __table2, table_name: default.t, final: 1
 1	first	2024-04-19 01:01:01

--- a/tests/queries/0_stateless/03129_cte_with_final.reference
+++ b/tests/queries/0_stateless/03129_cte_with_final.reference
@@ -1,0 +1,24 @@
+QUERY id: 0
+  PROJECTION COLUMNS
+    key Int64
+    someCol String
+    eventTime DateTime
+  PROJECTION
+    LIST id: 1, nodes: 3
+      COLUMN id: 2, column_name: key, result_type: Int64, source_id: 3
+      COLUMN id: 4, column_name: someCol, result_type: String, source_id: 3
+      COLUMN id: 5, column_name: eventTime, result_type: DateTime, source_id: 3
+  JOIN TREE
+    QUERY id: 3, alias: __table1, is_subquery: 1, is_cte: 1, cte_name: merged_test
+      PROJECTION COLUMNS
+        key Int64
+        someCol String
+        eventTime DateTime
+      PROJECTION
+        LIST id: 6, nodes: 3
+          COLUMN id: 7, column_name: key, result_type: Int64, source_id: 8
+          COLUMN id: 9, column_name: someCol, result_type: String, source_id: 8
+          COLUMN id: 10, column_name: eventTime, result_type: DateTime, source_id: 8
+      JOIN TREE
+        TABLE id: 8, alias: __table2, table_name: default.test, final: 1
+1	first	2024-04-19 01:01:01

--- a/tests/queries/0_stateless/03129_cte_with_final.sql
+++ b/tests/queries/0_stateless/03129_cte_with_final.sql
@@ -12,6 +12,8 @@ ORDER BY key;
 INSERT INTO t Values (1, 'first', '2024-04-19 01:01:01');
 INSERT INTO t Values (1, 'first', '2024-04-19 01:01:01');
 
+SET allow_experimental_analyzer = 1;
+
 EXPLAIN QUERY TREE passes=1
 WITH merged_test AS(
 	SELECT * FROM  t Final

--- a/tests/queries/0_stateless/03129_cte_with_final.sql
+++ b/tests/queries/0_stateless/03129_cte_with_final.sql
@@ -1,0 +1,22 @@
+CREATE OR REPLACE TABLE test
+(
+    `key` Int64,
+    `someCol` String,
+    `eventTime` DateTime
+)
+ENGINE = ReplacingMergeTree(eventTime)
+ORDER BY key;
+
+INSERT INTO test Values (1, 'first', '2024-04-19 01:01:01');
+INSERT INTO test Values (1, 'first', '2024-04-19 01:01:01');
+
+EXPLAIN QUERY TREE passes=1
+WITH merged_test AS(
+	SELECT * FROM  test Final
+)
+SELECT * FROM  merged_test;
+
+WITH merged_test AS(
+	SELECT * FROM  test Final
+)
+SELECT * FROM  merged_test;

--- a/tests/queries/0_stateless/03129_cte_with_final.sql
+++ b/tests/queries/0_stateless/03129_cte_with_final.sql
@@ -1,4 +1,6 @@
-CREATE OR REPLACE TABLE test
+DROP TABLE IF EXISTS t;
+
+CREATE TABLE t
 (
     `key` Int64,
     `someCol` String,
@@ -7,16 +9,18 @@ CREATE OR REPLACE TABLE test
 ENGINE = ReplacingMergeTree(eventTime)
 ORDER BY key;
 
-INSERT INTO test Values (1, 'first', '2024-04-19 01:01:01');
-INSERT INTO test Values (1, 'first', '2024-04-19 01:01:01');
+INSERT INTO t Values (1, 'first', '2024-04-19 01:01:01');
+INSERT INTO t Values (1, 'first', '2024-04-19 01:01:01');
 
 EXPLAIN QUERY TREE passes=1
 WITH merged_test AS(
-	SELECT * FROM  test Final
+	SELECT * FROM  t Final
 )
 SELECT * FROM  merged_test;
 
 WITH merged_test AS(
-	SELECT * FROM  test Final
+	SELECT * FROM  t Final
 )
 SELECT * FROM  merged_test;
+
+DROP TABLE t;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix an error when `FINAL` is not applied when specified in CTE (new analyzer). Fixes https://github.com/ClickHouse/ClickHouse/issues/62779


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

---
### Modify your CI run:
**NOTE:** If your merge the PR with modified CI you **MUST KNOW** what you are doing
**NOTE:** Checked options will be applied if set before CI RunConfig/PrepareRunConfig step

#### Include tests (required builds will be added automatically):
- [ ] <!---ci_include_fast--> Fast test
- [ ] <!---ci_include_integration--> Integration Tests
- [ ] <!---ci_include_stateless--> Stateless tests
- [ ] <!---ci_include_stateful--> Stateful tests
- [ ] <!---ci_include_unit--> Unit tests
- [ ] <!---ci_include_performance--> Performance tests
- [ ] <!---ci_include_asan--> All with ASAN
- [ ] <!---ci_include_tsan--> All with TSAN
- [ ] <!---ci_include_analyzer--> All with Analyzer
- [ ] <!---ci_include_KEYWORD--> Add your option here

#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [x] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [ ] <!---ci_exclude_tsan--> All with TSAN
- [ ] <!---ci_exclude_msan--> All with MSAN
- [ ] <!---ci_exclude_ubsan--> All with UBSAN
- [ ] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64--> All with Aarch64
- [ ] <!---ci_exclude_KEYWORD--> Add your option here

#### Extra options:
- [ ] <!---do_not_test--> do not test (only style check)
- [ ] <!---no_merge_commit--> disable merge-commit (no merge from master before tests)
- [ ] <!---no_ci_cache--> disable CI cache (job reuse)

#### Only specified batches in multi-batch jobs:
- [ ] <!---batch_0--> 1
- [ ] <!---batch_1--> 2
- [ ] <!---batch_2--> 3
- [ ] <!---batch_3--> 4
