### PR TITLE
Add `client.id` to librdkafka logs

### DIFF
--- a/src/Storages/Kafka/StorageKafka.cpp
+++ b/src/Storages/Kafka/StorageKafka.cpp
@@ -915,11 +915,22 @@ void StorageKafka::updateGlobalConfiguration(cppkafka::Configuration & kafka_con
 #endif // USE_KRB5
 
     // No need to add any prefix, messages can be distinguished
-    kafka_config.set_log_callback([this](cppkafka::KafkaHandleBase &, int level, const std::string & facility, const std::string & message)
-    {
-        auto [poco_level, client_logs_level] = parseSyslogLevel(level);
-        LOG_IMPL(log, client_logs_level, poco_level, "[rdk:{}] {}", facility, message);
-    });
+    kafka_config.set_log_callback(
+        [this](cppkafka::KafkaHandleBase & handle, int level, const std::string & facility, const std::string & message)
+        {
+            auto [poco_level, client_logs_level] = parseSyslogLevel(level);
+            const auto & kafka_object_config = handle.get_configuration();
+            const std::string client_id_key{"client.id"};
+            chassert(kafka_object_config.has_property(client_id_key) && "Kafka configuration doesn't have expected client.id set");
+            LOG_IMPL(
+                log,
+                client_logs_level,
+                poco_level,
+                "[client.id:{}] [rdk:{}] {}",
+                kafka_object_config.get(client_id_key),
+                facility,
+                message);
+        });
 
     /// NOTE: statistics should be consumed, otherwise it creates too much
     /// entries in the queue, that leads to memory leak and slow shutdown.


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Add librdkafka's client identifier to log messages to be able to differentiate log messages from different consumers of a single table.

Logs before:
```
2024.04.20 10:46:03.467578 [ 700 ] {} <Debug> StorageKafka (kafka): [client.id:ClickHouse-instance-test-kafka-3] [rdk:CGRPOP] [thrd:main]: Group "consumer_hang" received op GET_SUBSCRIPTION in state query-coord (join-state init)
2024.04.20 10:46:03.467591 [ 700 ] {} <Debug> StorageKafka (kafka): [client.id:ClickHouse-instance-test-kafka-3] [rdk:CGRPQUERY] [thrd:main]: Group "consumer_hang": no broker available for coordinator query: intervaled in state query-coord
2024.04.20 10:46:03.467591 [ 698 ] {} <Debug> StorageKafka (kafka): [client.id:ClickHouse-instance-test-kafka-2] [rdk:SEND] [thrd:kafka1:19092/bootstrap]: kafka1:19092/bootstrap: Sent ApiVersionRequest (v0, 46 bytes @ 0, CorrId 2)
2024.04.20 10:46:03.467615 [ 700 ] {} <Debug> StorageKafka (kafka): [client.id:ClickHouse-instance-test-kafka-3] [rdk:CGRPOP] [thrd:main]: Group "consumer_hang" received op SUBSCRIBE in state query-coord (join-state init)
2024.04.20 10:46:03.467625 [ 700 ] {} <Debug> StorageKafka (kafka): [client.id:ClickHouse-instance-test-kafka-3] [rdk:SUBSCRIBE] [thrd:main]: Group "consumer_hang": subscribe to new subscription of 1 topics (join-state init)
2024.04.20 10:46:03.467633 [ 700 ] {} <Debug> StorageKafka (kafka): [client.id:ClickHouse-instance-test-kafka-3] [rdk:CGRPQUERY] [thrd:main]: Group "consumer_hang": no broker available for coordinator query: intervaled in state query-coord
2024.04.20 10:46:03.467641 [ 700 ] {} <Debug> StorageKafka (kafka): [client.id:ClickHouse-instance-test-kafka-3] [rdk:CGRPOP] [thrd:main]: Group "consumer_hang" received op GET_SUBSCRIPTION in state query-coord (join-state init)
2024.04.20 10:46:03.467658 [ 700 ] {} <Debug> StorageKafka (kafka): [client.id:ClickHouse-instance-test-kafka-3] [rdk:CGRPQUERY] [thrd:main]: Group "consumer_hang": no broker available for coordinator query: intervaled in state query-coord
```

Logs after:
```
2024.04.20 10:49:33.603682 [ 696 ] {} <Debug> StorageKafka (kafka): [rdk:CGRPSTATE] [thrd:main]: Group "consumer_hang" changed state query-coord -> wait-coord (join-state init)
2024.04.20 10:49:33.603702 [ 698 ] {} <Debug> StorageKafka (kafka): [rdk:SEND] [thrd:kafka1:19092/bootstrap]: kafka1:19092/bootstrap: Sent FindCoordinatorRequest (v2, 62 bytes @ 0, CorrId 4)
2024.04.20 10:49:33.603663 [ 700 ] {} <Debug> StorageKafka (kafka): [rdk:CGRPSTATE] [thrd:main]: Group "consumer_hang" changed state init -> query-coord (join-state init)
2024.04.20 10:49:33.603743 [ 700 ] {} <Debug> StorageKafka (kafka): [rdk:CGRPQUERY] [thrd:main]: Group "consumer_hang": no broker available for coordinator query: intervaled in state query-coord
2024.04.20 10:49:33.603756 [ 700 ] {} <Debug> StorageKafka (kafka): [rdk:CGRPOP] [thrd:main]: Group "consumer_hang" received op GET_SUBSCRIPTION in state query-coord (join-state init)
2024.04.20 10:49:33.603765 [ 700 ] {} <Debug> StorageKafka (kafka): [rdk:CGRPQUERY] [thrd:main]: Group "consumer_hang": no broker available for coordinator query: intervaled in state query-coord
```

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

---
### Modify your CI run:
**NOTE:** If your merge the PR with modified CI you **MUST KNOW** what you are doing
**NOTE:** Checked options will be applied if set before CI RunConfig/PrepareRunConfig step

#### Include tests (required builds will be added automatically):
- [ ] <!---ci_include_fast--> Fast test
- [ ] <!---ci_include_integration--> Integration Tests
- [ ] <!---ci_include_stateless--> Stateless tests
- [ ] <!---ci_include_stateful--> Stateful tests
- [ ] <!---ci_include_unit--> Unit tests
- [ ] <!---ci_include_performance--> Performance tests
- [ ] <!---ci_include_asan--> All with ASAN
- [ ] <!---ci_include_tsan--> All with TSAN
- [ ] <!---ci_include_analyzer--> All with Analyzer
- [ ] <!---ci_include_KEYWORD--> Add your option here

#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [ ] <!---ci_exclude_tsan--> All with TSAN
- [ ] <!---ci_exclude_msan--> All with MSAN
- [ ] <!---ci_exclude_ubsan--> All with UBSAN
- [ ] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64--> All with Aarch64
- [ ] <!---ci_exclude_KEYWORD--> Add your option here

#### Extra options:
- [ ] <!---do_not_test--> do not test (only style check)
- [ ] <!---no_merge_commit--> disable merge-commit (no merge from master before tests)
- [ ] <!---no_ci_cache--> disable CI cache (job reuse)

#### Only specified batches in multi-batch jobs:
- [ ] <!---batch_0--> 1
- [ ] <!---batch_1--> 2
- [ ] <!---batch_2--> 3
- [ ] <!---batch_3--> 4
