### PR TITLE
main: rm wrong comment

### DIFF
--- a/programs/main.cpp
+++ b/programs/main.cpp
@@ -487,7 +487,6 @@ int main(int argc_, char ** argv_)
     /// Interpret binary without argument or with arguments starts with dash
     /// ('-') as clickhouse-local for better usability:
     ///
-    ///     clickhouse # dumps help
     ///     clickhouse -q 'select 1' # use local
     ///     clickhouse # spawn local
     ///     clickhouse local # spawn local


### PR DESCRIPTION
Remove wrong comment line and make the comment unambiguous.
 
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)
