### PR TITLE
[Docs] update roundXYZ

### DIFF
--- a/docs/en/sql-reference/functions/rounding-functions.md
+++ b/docs/en/sql-reference/functions/rounding-functions.md
@@ -262,6 +262,8 @@ Query:
 SELECT *, roundAge(*) FROM system.numbers WHERE number IN (0, 5, 20, 31, 37, 54, 72);
 ```
 
+Result:
+
 ```response
 ┌─number─┬─roundAge(number)─┐
 │      0 │                0 │
@@ -274,6 +276,42 @@ SELECT *, roundAge(*) FROM system.numbers WHERE number IN (0, 5, 20, 31, 37, 54,
 └────────┴──────────────────┘
 ```
 
-## roundDown(num, arr)
+## roundDown
 
 Accepts a number and rounds it down to an element in the specified array. If the value is less than the lowest bound, the lowest bound is returned.
+
+**Syntax**
+
+```sql
+roundDown(num, arr)
+```
+
+**Parameters**
+
+- `age`: A number representing an age in years. [Numeric](../data-types/int-uint.md).
+- `arr`: Array of elements to round `age` down to. [Array](../data-types/array.md)([Numeric](../data-types/int-uint.md))
+
+**Returned value**
+
+- Number rounded down to an element in `arr`. If the value is less than the lowest bound, the lowest bound is returned. [Numeric](../data-types/int-uint.md).
+
+**Example**
+
+Query:
+
+```sql
+SELECT *, roundDown(*, [3, 4, 5]) FROM system.numbers WHERE number IN (0, 1, 2, 3, 4, 5)
+```
+
+Result:
+
+```response
+┌─number─┬─roundDown(number, [3, 4, 5])─┐
+│      0 │                            3 │
+│      1 │                            3 │
+│      2 │                            3 │
+│      3 │                            3 │
+│      4 │                            4 │
+│      5 │                            5 │
+└────────┴──────────────────────────────┘
+```

--- a/docs/en/sql-reference/functions/rounding-functions.md
+++ b/docs/en/sql-reference/functions/rounding-functions.md
@@ -230,16 +230,49 @@ Accepts a number. If the number is less than one, it returns 0. Otherwise, it ro
 
 Accepts a number. If the number is less than one, it returns 0. Otherwise, it rounds the number down to numbers from the set: 1, 10, 30, 60, 120, 180, 240, 300, 600, 1200, 1800, 3600, 7200, 18000, 36000. 
 
-## roundAge(num)
+## roundAge
 
-Accepts a number. If the number is
-- smaller than 1, it returns 0,
-- between 1 and 17, it returns 17,
-- between 18 and 24, it returns 18,
-- between 25 and 34, it returns 25,
-- between 35 and 44, it returns 35,
-- between 45 and 54, it returns 45,
-- larger than 55, it returns 55.
+Accepts a number within various commonly used ranges of human age and returns either a maximum or a minimum within that range.
+
+**Syntax**
+
+```sql
+roundAge(num)
+```
+
+**Parameters**
+
+- `age`: A number representing an age in years. [Numeric](../data-types/int-uint.md).
+
+**Returned value**
+
+- Returns `0`, for $age \lt 1$.
+- Returns `17`, for $1 \leq age \leq 17$.
+- Returns `18`, for $18 \leq age \leq 24$.
+- Returns `25`, for $25 \leq age \leq 34$.
+- Returns `35`, for $35 \leq age \leq 44$.
+- Returns `45`, for $45 \leq age \leq 54$.
+- Returns `55`, for $age \geq 55$.
+
+**Example**
+
+Query:
+
+```sql
+SELECT *, roundAge(*) FROM system.numbers WHERE number IN (0, 5, 20, 31, 37, 54, 72);
+```
+
+```response
+┌─number─┬─roundAge(number)─┐
+│      0 │                0 │
+│      5 │               17 │
+│     20 │               18 │
+│     31 │               25 │
+│     37 │               35 │
+│     54 │               45 │
+│     72 │               55 │
+└────────┴──────────────────┘
+```
 
 ## roundDown(num, arr)
 

--- a/docs/en/sql-reference/functions/rounding-functions.md
+++ b/docs/en/sql-reference/functions/rounding-functions.md
@@ -79,9 +79,9 @@ round(expression [, decimal_places])
 
 The rounded number of the same type as the input number.
 
-### Examples
+**Examples**
 
-**Example of use with Float**
+Example of usage with Float:
 
 ``` sql
 SELECT number / 2 AS x, round(x) FROM system.numbers LIMIT 3;
@@ -95,7 +95,7 @@ SELECT number / 2 AS x, round(x) FROM system.numbers LIMIT 3;
 └─────┴──────────────────────────┘
 ```
 
-**Example of use with Decimal**
+Example of usage with Decimal:
 
 ``` sql
 SELECT cast(number / 2 AS  Decimal(10,4)) AS x, round(x) FROM system.numbers LIMIT 3;
@@ -124,9 +124,7 @@ SELECT cast(number / 2 AS  Decimal(10,4)) AS x, round(x) FROM system.numbers LIM
 └────────┴──────────────────────────────────────────────────┘
 ```
 
-**Examples of rounding**
-
-Rounding to the nearest number.
+Examples of rounding to the nearest number:
 
 ``` text
 round(3.2, 0) = 3
@@ -183,9 +181,7 @@ roundBankers(expression [, decimal_places])
 
 A value rounded by the banker’s rounding method.
 
-### Examples
-
-**Example of use**
+**Examples**
 
 Query:
 
@@ -210,7 +206,7 @@ Result:
 └─────┴───┘
 ```
 
-**Examples of Banker’s rounding**
+Examples of Banker’s rounding:
 
 ``` text
 roundBankers(0.4) = 0

--- a/docs/en/sql-reference/functions/rounding-functions.md
+++ b/docs/en/sql-reference/functions/rounding-functions.md
@@ -222,13 +222,49 @@ roundBankers(10.755, 2) = 10.76
 
 - [round](#rounding_functions-round)
 
-## roundToExp2(num)
+## roundToExp2
 
-Accepts a number. If the number is less than one, it returns 0. Otherwise, it rounds the number down to the nearest (whole non-negative) degree of two.
+Accepts a number. If the number is less than one, it returns `0`. Otherwise, it rounds the number down to the nearest (whole non-negative) degree of two.
+
+**Syntax**
+
+```sql
+roundToExp2(num)
+```
+
+**Parameters**
+
+- `num`: A number representing an age in years. [UInt](../data-types/int-uint.md)/[Float](../data-types/float.md).
+
+**Returned value**
+
+- `0`, for `num` $\lt 1$. [UInt8](../data-types/int-uint.md).
+- `num` rounded down to the nearest (whole non-negative) degree of two. [UInt](../data-types/int-uint.md)/[Float](../data-types/float.md) equivalent to the input type.
+
+**Example**
+
+Query:
+
+```sql
+SELECT *, roundToExp2(*) FROM system.numbers WHERE number IN (0, 2, 5, 10, 19, 50)
+```
+
+Result:
+
+```response
+┌─number─┬─roundToExp2(number)─┐
+│      0 │                   0 │
+│      2 │                   2 │
+│      5 │                   4 │
+│     10 │                   8 │
+│     19 │                  16 │
+│     50 │                  32 │
+└────────┴─────────────────────┘
+```
 
 ## roundDuration
 
-Accepts a number. If the number is less than one, it returns `0`. Otherwise, it rounds the number down to numbers from the set: $\set{1, 10, 30, 60, 120, 180, 240, 300, 600, 1200, 1800, 3600, 7200, 18000, 36000}$. 
+Accepts a number. If the number is less than one, it returns `0`. Otherwise, it rounds the number down to numbers from the set of commonly used durations: `1, 10, 30, 60, 120, 180, 240, 300, 600, 1200, 1800, 3600, 7200, 18000, 36000`. 
 
 **Syntax**
 
@@ -238,12 +274,14 @@ roundDuration(num)
 
 **Parameters**
 
-- `age`: A number representing an age in years. [Numeric](../data-types/int-uint.md).
+- `num`: A number to round to one of the numbers in the set of common durations. [UInt](../data-types/int-uint.md)/[Float](../data-types/float.md).
 
 **Returned value**
 
 - `0`, for `num` $\lt 1$.
-- One of $\set{1, 10, 30, 60, 120, 180, 240, 300, 600, 1200, 1800, 3600, 7200, 18000, 36000}$, otherwise. [UInt8](../data-types/int-uint.md).
+- Otherwise, one of: `1, 10, 30, 60, 120, 180, 240, 300, 600, 1200, 1800, 3600, 7200, 18000, 36000`. [UInt16](../data-types/int-uint.md).
+
+**Example**
 
 Query:
 
@@ -286,7 +324,7 @@ roundAge(num)
 
 **Parameters**
 
-- `age`: A number representing an age in years. [Numeric](../data-types/int-uint.md).
+- `age`: A number representing an age in years. [UInt](../data-types/int-uint.md)/[Float](../data-types/float.md).
 
 **Returned value**
 
@@ -297,6 +335,8 @@ roundAge(num)
 - Returns `35`, for $35 \leq age \leq 44$.
 - Returns `45`, for $45 \leq age \leq 54$.
 - Returns `55`, for $age \geq 55$.
+
+Type: [UInt8](../data-types/int-uint.md).
 
 **Example**
 
@@ -332,12 +372,12 @@ roundDown(num, arr)
 
 **Parameters**
 
-- `age`: A number representing an age in years. [Numeric](../data-types/int-uint.md).
-- `arr`: Array of elements to round `age` down to. [Array](../data-types/array.md)([Numeric](../data-types/int-uint.md))
+- `num`: A number to round down. [Numeric](../data-types/int-uint.md).
+- `arr`: Array of elements to round `age` down to. [Array](../data-types/array.md) of [UInt](../data-types/int-uint.md)/[Float](../data-types/float.md) type.
 
 **Returned value**
 
-- Number rounded down to an element in `arr`. If the value is less than the lowest bound, the lowest bound is returned. [Numeric](../data-types/int-uint.md).
+- Number rounded down to an element in `arr`. If the value is less than the lowest bound, the lowest bound is returned. [UInt](../data-types/int-uint.md)/[Float](../data-types/float.md) type deduced from the type of `arr`.
 
 **Example**
 

--- a/docs/en/sql-reference/functions/rounding-functions.md
+++ b/docs/en/sql-reference/functions/rounding-functions.md
@@ -226,9 +226,53 @@ roundBankers(10.755, 2) = 10.76
 
 Accepts a number. If the number is less than one, it returns 0. Otherwise, it rounds the number down to the nearest (whole non-negative) degree of two.
 
-## roundDuration(num)
+## roundDuration
 
-Accepts a number. If the number is less than one, it returns 0. Otherwise, it rounds the number down to numbers from the set: 1, 10, 30, 60, 120, 180, 240, 300, 600, 1200, 1800, 3600, 7200, 18000, 36000. 
+Accepts a number. If the number is less than one, it returns `0`. Otherwise, it rounds the number down to numbers from the set: $\set{1, 10, 30, 60, 120, 180, 240, 300, 600, 1200, 1800, 3600, 7200, 18000, 36000}$. 
+
+**Syntax**
+
+```sql
+roundDuration(num)
+```
+
+**Parameters**
+
+- `age`: A number representing an age in years. [Numeric](../data-types/int-uint.md).
+
+**Returned value**
+
+- `0`, for `num` $\lt 1$.
+- One of $\set{1, 10, 30, 60, 120, 180, 240, 300, 600, 1200, 1800, 3600, 7200, 18000, 36000}$, otherwise. [UInt8](../data-types/int-uint.md).
+
+Query:
+
+```sql
+SELECT *, roundDuration(*) FROM system.numbers WHERE number IN (0, 9, 19, 47, 101, 149, 205, 271, 421, 789, 1423, 2345, 4567, 9876, 24680, 42573)
+```
+
+Result:
+
+```response
+┌─number─┬─roundDuration(number)─┐
+│      0 │                     0 │
+│      9 │                     1 │
+│     19 │                    10 │
+│     47 │                    30 │
+│    101 │                    60 │
+│    149 │                   120 │
+│    205 │                   180 │
+│    271 │                   240 │
+│    421 │                   300 │
+│    789 │                   600 │
+│   1423 │                  1200 │
+│   2345 │                  1800 │
+│   4567 │                  3600 │
+│   9876 │                  7200 │
+│  24680 │                 18000 │
+│  42573 │                 36000 │
+└────────┴───────────────────────┘
+```
 
 ## roundAge
 


### PR DESCRIPTION
Closes [#2006](https://github.com/ClickHouse/clickhouse-docs/issues/2006) as part of the [functions project](https://github.com/ClickHouse/clickhouse-docs/issues/1833) to document missing functions or ones which have insufficient documentation. Updates the following functions:

-  roundAge
-  roundDown
-  roundDuration
-  roundToExp2

also makes a small change to the formatting of existing functions [here](https://clickhouse.com/docs/en/sql-reference/functions/rounding-functions#roundagenum) so that 'examples' don't show as a subheading anymore.

![image](https://github.com/ClickHouse/ClickHouse/assets/41984034/e20d9d3b-f9c8-41fa-81a9-a6279bc7214b)


### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Documentation entry for user-facing changes

- [X] Documentation is written (mandatory for new features)
