### PR TITLE
Fix crash in function `formatRow` with `JSON` format and HTTP  interface

### DIFF
--- a/src/Functions/formatRow.cpp
+++ b/src/Functions/formatRow.cpp
@@ -38,8 +38,14 @@ public:
         : format_name(std::move(format_name_))
         , arguments_column_names(std::move(arguments_column_names_))
         , context(std::move(context_))
+        , format_settings(getFormatSettings(context))
     {
         FormatFactory::instance().checkFormatName(format_name);
+
+        /// We don't need handling exceptions while formatting as a row.
+        /// But it can be enabled in query sent via http interface.
+        format_settings.json.valid_output_on_exception = false;
+        format_settings.xml.valid_output_on_exception = false;
     }
 
     String getName() const override { return name; }
@@ -68,7 +74,6 @@ public:
         }
 
         materializeBlockInplace(arg_columns);
-        auto format_settings = getFormatSettings(context);
         auto out = FormatFactory::instance().getOutputFormat(format_name, buffer, arg_columns, context, format_settings);
 
         /// This function make sense only for row output formats.
@@ -104,6 +109,7 @@ private:
     String format_name;
     Names arguments_column_names;
     ContextPtr context;
+    FormatSettings format_settings;
 };
 
 template <bool no_newline>

--- a/tests/queries/0_stateless/03129_format_row_json_http.reference
+++ b/tests/queries/0_stateless/03129_format_row_json_http.reference
@@ -1,0 +1,15 @@
+{"number":"0"}\n
+{"number":"1"}\n
+{"number":"2"}\n
+{"number":"3"}\n
+{"number":"4"}\n
+{"number":"5"}\n
+{"number":"6"}\n
+{"number":"7"}\n
+{"number":"8"}\n
+{"number":"9"}\n
+{"number":"10"}\n
+{"number":"11"}\n
+{"number":"12"}\n
+{"number":"13"}\n
+{"number":"14"}\n

--- a/tests/queries/0_stateless/03129_format_row_json_http.sh
+++ b/tests/queries/0_stateless/03129_format_row_json_http.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+$CLICKHOUSE_CURL -sS "$CLICKHOUSE_URL" --data-binary "SELECT formatRow('JSONEachRow', number) as test FROM (SELECT number FROM numbers(15))"


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed crash in function `formatRow` with `JSON` format in queries executed via the HTTP interface.

Fixes #62794.

---
### Modify your CI run:
**NOTE:** If your merge the PR with modified CI you **MUST KNOW** what you are doing
**NOTE:** Checked options will be applied if set before CI RunConfig/PrepareRunConfig step

#### Include tests (required builds will be added automatically):
- [ ] <!---ci_include_fast--> Fast test
- [ ] <!---ci_include_integration--> Integration Tests
- [ ] <!---ci_include_stateless--> Stateless tests
- [ ] <!---ci_include_stateful--> Stateful tests
- [ ] <!---ci_include_unit--> Unit tests
- [ ] <!---ci_include_performance--> Performance tests
- [ ] <!---ci_include_asan--> All with ASAN
- [ ] <!---ci_include_tsan--> All with TSAN
- [ ] <!---ci_include_analyzer--> All with Analyzer
- [ ] <!---ci_include_KEYWORD--> Add your option here

#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [ ] <!---ci_exclude_tsan--> All with TSAN
- [ ] <!---ci_exclude_msan--> All with MSAN
- [ ] <!---ci_exclude_ubsan--> All with UBSAN
- [ ] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64--> All with Aarch64
- [ ] <!---ci_exclude_KEYWORD--> Add your option here

#### Extra options:
- [ ] <!---do_not_test--> do not test (only style check)
- [ ] <!---no_merge_commit--> disable merge-commit (no merge from master before tests)
- [ ] <!---no_ci_cache--> disable CI cache (job reuse)

#### Only specified batches in multi-batch jobs:
- [ ] <!---batch_0--> 1
- [ ] <!---batch_1--> 2
- [ ] <!---batch_2--> 3
- [ ] <!---batch_3--> 4
