### PR TITLE
Docs: Fix documented default value of server setting `cgroup_memory_watcher_soft_limit_ratio`

### DIFF
--- a/docs/en/operations/server-configuration-parameters/settings.md
+++ b/docs/en/operations/server-configuration-parameters/settings.md
@@ -523,7 +523,7 @@ See settings `cgroups_memory_usage_observer_wait_time` and `cgroup_memory_watche
 
 Type: Double
 
-Default: 0.95
+Default: 0.9
 
 ## max_table_size_to_drop
 


### PR DESCRIPTION
See https://github.com/ClickHouse/ClickHouse/blob/b50117780c8a11b0a374f66e1667661041132e26/src/Core/ServerSettings.h#L60

### Changelog category (leave one):
- Documentation (changelog entry is not required)