### PR TITLE
Fix build errors when linking OpenSSL dynamically

### DIFF
--- a/contrib/openssl-cmake/CMakeLists.txt
+++ b/contrib/openssl-cmake/CMakeLists.txt
@@ -1145,6 +1145,13 @@ set(CRYPTO_SRC
     ${OPENSSL_SOURCE_DIR}/ssl/record/methods/ssl3_cbc.c
 )
 
+if(NOT ENABLE_OPENSSL_DYNAMIC)
+    set(CRYPTO_SRC ${CRYPTO_SRC}
+        ${OPENSSL_SOURCE_DIR}/providers/fips/fips_entry.c
+        ${OPENSSL_SOURCE_DIR}/providers/fips/fipsprov.c
+    )
+endif()
+
 if(ARCH_AMD64)
     if (OS_DARWIN)
         set(CRYPTO_SRC ${CRYPTO_SRC}

--- a/contrib/openssl-cmake/CMakeLists.txt
+++ b/contrib/openssl-cmake/CMakeLists.txt
@@ -93,6 +93,7 @@ enable_language(ASM)
 
 if(COMPILER_CLANG)
     add_definitions(-Wno-unused-command-line-argument)
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -fuse-ld=lld")
 endif()
 
 if(ARCH_AMD64)
@@ -960,11 +961,6 @@ set(CRYPTO_SRC
     ${OPENSSL_SOURCE_DIR}/crypto/x509/x_req.c
     ${OPENSSL_SOURCE_DIR}/crypto/x509/x_x509.c
     ${OPENSSL_SOURCE_DIR}/crypto/x509/x_x509a.c
-    ${OPENSSL_SOURCE_DIR}/engines/e_capi.c
-    ${OPENSSL_SOURCE_DIR}/engines/e_dasync.c
-    ${OPENSSL_SOURCE_DIR}/engines/e_loader_attic.c
-    ${OPENSSL_SOURCE_DIR}/engines/e_ossltest.c
-    ${OPENSSL_SOURCE_DIR}/engines/e_padlock.c
     ${OPENSSL_SOURCE_DIR}/providers/baseprov.c
     ${OPENSSL_SOURCE_DIR}/providers/common/bio_prov.c
     ${OPENSSL_SOURCE_DIR}/providers/common/capabilities.c
@@ -985,8 +981,6 @@ set(CRYPTO_SRC
     ${OPENSSL_SOURCE_DIR}/providers/common/securitycheck.c
     ${OPENSSL_SOURCE_DIR}/providers/common/securitycheck_default.c
     ${OPENSSL_SOURCE_DIR}/providers/defltprov.c
-    ${OPENSSL_SOURCE_DIR}/providers/fips/fips_entry.c
-    ${OPENSSL_SOURCE_DIR}/providers/fips/fipsprov.c
     ${OPENSSL_SOURCE_DIR}/providers/implementations/asymciphers/rsa_enc.c
     ${OPENSSL_SOURCE_DIR}/providers/implementations/asymciphers/sm2_enc.c
     ${OPENSSL_SOURCE_DIR}/providers/implementations/ciphers/cipher_aes.c
@@ -1145,9 +1139,10 @@ set(CRYPTO_SRC
     ${OPENSSL_SOURCE_DIR}/providers/implementations/signature/sm2_sig.c
     ${OPENSSL_SOURCE_DIR}/providers/implementations/storemgmt/file_store.c
     ${OPENSSL_SOURCE_DIR}/providers/implementations/storemgmt/file_store_any2obj.c
-    ${OPENSSL_SOURCE_DIR}/providers/legacyprov.c
     ${OPENSSL_SOURCE_DIR}/providers/nullprov.c
     ${OPENSSL_SOURCE_DIR}/providers/prov_running.c
+    ${OPENSSL_SOURCE_DIR}/ssl/record/methods/tls_pad.c
+    ${OPENSSL_SOURCE_DIR}/ssl/record/methods/ssl3_cbc.c
 )
 
 if(ARCH_AMD64)

--- a/contrib/openssl-cmake/CMakeLists.txt
+++ b/contrib/openssl-cmake/CMakeLists.txt
@@ -1371,8 +1371,6 @@ set(SSL_SRC
     ${OPENSSL_SOURCE_DIR}/ssl/quic/uint_set.c
     ${OPENSSL_SOURCE_DIR}/ssl/record/rec_layer_d1.c
     ${OPENSSL_SOURCE_DIR}/ssl/record/rec_layer_s3.c
-    ${OPENSSL_SOURCE_DIR}/ssl/record/methods/tls_pad.c
-    ${OPENSSL_SOURCE_DIR}/ssl/record/methods/ssl3_cbc.c
     ${OPENSSL_SOURCE_DIR}/ssl/record/methods/dtls_meth.c
     ${OPENSSL_SOURCE_DIR}/ssl/record/methods/ssl3_meth.c
     ${OPENSSL_SOURCE_DIR}/ssl/record/methods/tls13_meth.c


### PR DESCRIPTION
(see https://github.com/ClickHouse/ClickHouse/pull/59870#issuecomment-2061746337)

The build for OpenSSL dynamic linking(`mkdir build; cd build; cmake .. -DENABLE_OPENSSL_DYNAMIC=1`) is broken due to the following reasons:
 - It picks up the GNU linker when using clang and generates linking errors,
 - undefined symbols,
 - duplicated symbols.

### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed build errors when OpenSSL is linked dynamically (note: this is generally unsupported and only required for s390x platforms).


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

---
### Modify your CI run:
**NOTE:** If your merge the PR with modified CI you **MUST KNOW** what you are doing
**NOTE:** Checked options will be applied if set before CI RunConfig/PrepareRunConfig step

#### Include tests (required builds will be added automatically):
- [ ] <!---ci_include_fast--> Fast test
- [ ] <!---ci_include_integration--> Integration Tests
- [ ] <!---ci_include_stateless--> Stateless tests
- [ ] <!---ci_include_stateful--> Stateful tests
- [ ] <!---ci_include_unit--> Unit tests
- [ ] <!---ci_include_performance--> Performance tests
- [ ] <!---ci_include_asan--> All with ASAN
- [ ] <!---ci_include_tsan--> All with TSAN
- [ ] <!---ci_include_analyzer--> All with Analyzer
- [ ] <!---ci_include_KEYWORD--> Add your option here

#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [ ] <!---ci_exclude_tsan--> All with TSAN
- [ ] <!---ci_exclude_msan--> All with MSAN
- [ ] <!---ci_exclude_ubsan--> All with UBSAN
- [ ] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64--> All with Aarch64
- [ ] <!---ci_exclude_KEYWORD--> Add your option here

#### Extra options:
- [ ] <!---do_not_test--> do not test (only style check)
- [ ] <!---no_merge_commit--> disable merge-commit (no merge from master before tests)
- [ ] <!---no_ci_cache--> disable CI cache (job reuse)

#### Only specified batches in multi-batch jobs:
- [ ] <!---batch_0--> 1
- [ ] <!---batch_1--> 2
- [ ] <!---batch_2--> 3
- [ ] <!---batch_3--> 4
