### PR TITLE
Fix build failed on clang-18

### DIFF
--- a/src/Disks/ObjectStorages/AzureBlobStorage/AzureBlobStorageAuth.cpp
+++ b/src/Disks/ObjectStorages/AzureBlobStorage/AzureBlobStorageAuth.cpp
@@ -188,7 +188,8 @@ Azure::Storage::Blobs::BlobClientOptions getAzureBlobClientOptions(const Poco::U
     retry_options.MaxRetryDelay = std::chrono::milliseconds(config.getUInt(config_prefix + ".retry_max_backoff_ms", 1000));
 
     using CurlOptions = Azure::Core::Http::CurlTransportOptions;
-    CurlOptions curl_options{.NoSignal = true};
+    CurlOptions curl_options;
+    curl_options.NoSignal = true;
 
     if (config.has(config_prefix + ".curl_ip_resolve"))
     {


### PR DESCRIPTION
![yB076LXRlb](https://github.com/ClickHouse/ClickHouse/assets/16730247/b2c07867-b331-47fa-8f42-d56fc711155e)
Fix the above compilation error on clang-18.
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


