### PR TITLE
Fix parsing of nested proto messages

### DIFF
--- a/src/Formats/ProtobufSerializer.cpp
+++ b/src/Formats/ProtobufSerializer.cpp
@@ -3736,6 +3736,7 @@ namespace
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "ClickHouse doesn't support type recursion ({})", field_descriptor->full_name());
         }
         pending_resolution.emplace(field_descriptor);
+        SCOPE_EXIT({ pending_resolution.erase(field_descriptor); });
 
         if (allow_repeat && field_descriptor->is_map())
         {

--- a/tests/queries/0_stateless/03130_nested_type.reference
+++ b/tests/queries/0_stateless/03130_nested_type.reference
@@ -1,0 +1,1 @@
+inner	Tuple(\n    a Tuple(\n        seconds Int64,\n        nanos Int32),\n    b Tuple(\n        seconds Int64,\n        nanos Int32),\n    c Tuple(\n        seconds Int64,\n        nanos Int32))					

--- a/tests/queries/0_stateless/03130_nested_type.sh
+++ b/tests/queries/0_stateless/03130_nested_type.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+SCHEMADIR="$CUR_DIR/format_schemas"
+$CLICKHOUSE_LOCAL -q "DESCRIBE TABLE file('nonexist', 'Protobuf') SETTINGS format_schema='$SCHEMADIR/03130_nested_schema.proto:Outer'"

--- a/tests/queries/0_stateless/format_schemas/03130_nested_schema.proto
+++ b/tests/queries/0_stateless/format_schemas/03130_nested_schema.proto
@@ -1,0 +1,16 @@
+syntax = "proto3";
+
+message Duration {
+  int64 seconds = 1;
+  int32 nanos = 2;
+}
+
+message Inner {
+    Duration a = 7;
+    Duration b = 8;
+    Duration c = 9;
+}
+
+message Outer {
+    Inner inner = 6;
+}


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Fix parsing of nested proto messages

### Documentation entry for user-facing changes

If a nested type had to resolve the same type twice, we'd throw a recursive error incorrectly as we failed to clean up the resolution set.

Introduced in https://github.com/ClickHouse/ClickHouse/pull/62506 (unreleased yet)