### PR TITLE
Fix 03013_forbid_attach_table_if_active_replica_already_exists for private

### DIFF
--- a/tests/queries/0_stateless/03013_forbid_attach_table_if_active_replica_already_exists.sh
+++ b/tests/queries/0_stateless/03013_forbid_attach_table_if_active_replica_already_exists.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Tags: no-shared-merge-tree
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

