### PR TITLE
Fix build on Mac using clang-18

### DIFF
--- a/src/Common/waitForPid.cpp
+++ b/src/Common/waitForPid.cpp
@@ -132,7 +132,9 @@ static PollPidResult pollPid(pid_t pid, int timeout_in_ms)
     if (kq == -1)
         return PollPidResult::FAILED;
 
-    struct kevent change = {.ident = 0};
+    struct kevent change;
+    change.ident = 0;
+
     EV_SET(&change, pid, EVFILT_PROC, EV_ADD, NOTE_EXIT, 0, NULL);
 
     int event_add_result = HANDLE_EINTR(kevent(kq, &change, 1, NULL, 0, NULL));
@@ -144,7 +146,9 @@ static PollPidResult pollPid(pid_t pid, int timeout_in_ms)
         return PollPidResult::FAILED;
     }
 
-    struct kevent event = {.ident = 0};
+    struct kevent event;
+    event.ident = 0;
+
     struct timespec remaining_timespec = {.tv_sec = timeout_in_ms / 1000, .tv_nsec = (timeout_in_ms % 1000) * 1000000};
     int ready = HANDLE_EINTR(kevent(kq, nullptr, 0, &event, 1, &remaining_timespec));
     PollPidResult result = ready < 0 ? PollPidResult::FAILED : PollPidResult::RESTART;


### PR DESCRIPTION
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix build on Mac using clang-18. This closes: https://github.com/ClickHouse/ClickHouse/issues/62938