### PR TITLE
Fix possible CHECKSUM_DOESNT_MATCH (and others) during replicated fetches

### DIFF
--- a/src/Common/FailPoint.cpp
+++ b/src/Common/FailPoint.cpp
@@ -39,6 +39,7 @@ static struct InitFiu
     REGULAR(replicated_merge_tree_commit_zk_fail_when_recovering_from_hw_fault) \
     REGULAR(use_delayed_remote_source) \
     REGULAR(cluster_discovery_faults) \
+    REGULAR(replicated_sends_failpoint) \
     ONCE(smt_commit_merge_mutate_zk_fail_after_op) \
     ONCE(smt_commit_merge_mutate_zk_fail_before_op) \
     ONCE(smt_commit_write_zk_fail_after_op) \

--- a/src/IO/copyData.cpp
+++ b/src/IO/copyData.cpp
@@ -109,4 +109,9 @@ void copyDataWithThrottler(ReadBuffer & from, WriteBuffer & to, size_t bytes, co
     copyDataImpl(from, to, true, bytes, &is_cancelled, throttler);
 }
 
+void copyDataWithThrottler(ReadBuffer & from, WriteBuffer & to, std::function<void()> cancellation_hook, ThrottlerPtr throttler)
+{
+    copyDataImpl(from, to, false, std::numeric_limits<size_t>::max(), cancellation_hook, throttler);
+}
+
 }

--- a/src/IO/copyData.h
+++ b/src/IO/copyData.h
@@ -33,5 +33,6 @@ void copyDataMaxBytes(ReadBuffer & from, WriteBuffer & to, size_t max_bytes);
 /// Same as above but also use throttler to limit maximum speed
 void copyDataWithThrottler(ReadBuffer & from, WriteBuffer & to, const std::atomic<int> & is_cancelled, ThrottlerPtr throttler);
 void copyDataWithThrottler(ReadBuffer & from, WriteBuffer & to, size_t bytes, const std::atomic<int> & is_cancelled, ThrottlerPtr throttler);
+void copyDataWithThrottler(ReadBuffer & from, WriteBuffer & to, std::function<void()> cancellation_hook, ThrottlerPtr throttler);
 
 }

--- a/src/Server/HTTP/HTTPServerResponse.cpp
+++ b/src/Server/HTTP/HTTPServerResponse.cpp
@@ -62,6 +62,7 @@ std::shared_ptr<WriteBufferFromPocoSocket> HTTPServerResponse::send()
         stream = std::make_shared<WriteBufferFromPocoSocket>(session.socket(), write_event);
     }
 
+    send_started = true;
     return stream;
 }
 
@@ -96,7 +97,14 @@ std::pair<std::shared_ptr<WriteBufferFromPocoSocket>, std::shared_ptr<WriteBuffe
     else
         stream = std::make_shared<WriteBufferFromPocoSocket>(session.socket(), write_event);
 
+    send_started = true;
     return std::make_pair(header_stream, stream);
+}
+
+void HTTPServerResponse::beginWrite(std::ostream & ostr) const
+{
+    HTTPResponse::beginWrite(ostr);
+    send_started = true;
 }
 
 void HTTPServerResponse::sendBuffer(const void * buffer, std::size_t length)

--- a/src/Server/HTTP/HTTPServerResponse.h
+++ b/src/Server/HTTP/HTTPServerResponse.h
@@ -209,6 +209,10 @@ public:
     /// or redirect() has been called.
     std::pair<std::shared_ptr<WriteBufferFromPocoSocket>, std::shared_ptr<WriteBufferFromPocoSocket>> beginSend();
 
+    /// Override to correctly mark that the data send had been started for
+    /// zero-copy response (i.e. replicated fetches).
+    void beginWrite(std::ostream & ostr) const;
+
     /// Sends the response header to the client, followed
     /// by the contents of the given buffer.
     ///
@@ -229,7 +233,7 @@ public:
     /// according to the given realm.
 
     /// Returns true if the response (header) has been sent.
-    bool sent() const { return !!stream; }
+    bool sent() const { return send_started; }
 
     /// Sets the status code, which must be one of
     /// HTTP_MOVED_PERMANENTLY (301), HTTP_FOUND (302),
@@ -251,6 +255,7 @@ private:
     ProfileEvents::Event write_event;
     std::shared_ptr<WriteBufferFromPocoSocket> stream;
     std::shared_ptr<WriteBufferFromPocoSocket> header_stream;
+    mutable bool send_started = false;
 };
 
 }

--- a/src/Storages/MergeTree/DataPartsExchange.cpp
+++ b/src/Storages/MergeTree/DataPartsExchange.cpp
@@ -762,9 +762,11 @@ void Fetcher::downloadBaseOrProjectionPartToDisk(
 
         if (expected_hash != hashing_out.getHash())
             throw Exception(ErrorCodes::CHECKSUM_DOESNT_MATCH,
-                "Checksum mismatch for file {} transferred from {}",
+                "Checksum mismatch for file {} transferred from {} (0x{} vs 0x{})",
                 (fs::path(data_part_storage->getFullPath()) / file_name).string(),
-                replica_path);
+                replica_path,
+                getHexUIntLowercase(expected_hash),
+                getHexUIntLowercase(hashing_out.getHash()));
 
         if (file_name != "checksums.txt" &&
             file_name != "columns.txt" &&

--- a/src/Storages/MergeTree/DataPartsExchange.cpp
+++ b/src/Storages/MergeTree/DataPartsExchange.cpp
@@ -18,12 +18,14 @@
 #include <Common/CurrentMetrics.h>
 #include <Common/NetException.h>
 #include <Common/randomDelay.h>
+#include <Common/FailPoint.h>
+#include <Common/thread_local_rng.h>
 #include <Disks/IO/createReadBufferFromFileBase.h>
 #include <base/scope_guard.h>
 #include <Poco/Net/HTTPRequest.h>
 #include <boost/algorithm/string/join.hpp>
 #include <base/sort.h>
-
+#include <random>
 
 namespace fs = std::filesystem;
 
@@ -47,6 +49,12 @@ namespace ErrorCodes
     extern const int LOGICAL_ERROR;
     extern const int S3_ERROR;
     extern const int ZERO_COPY_REPLICATION_ERROR;
+    extern const int FAULT_INJECTED;
+}
+
+namespace FailPoints
+{
+    extern const char replicated_sends_failpoint[];
 }
 
 namespace DataPartsExchange
@@ -298,11 +306,23 @@ MergeTreeData::DataPart::Checksums Service::sendPartFromDisk(
 
         auto file_in = desc.input_buffer_getter();
         HashingWriteBuffer hashing_out(out);
-        copyDataWithThrottler(*file_in, hashing_out, blocker.getCounter(), data.getSendsThrottler());
-        hashing_out.finalize();
 
-        if (blocker.isCancelled())
-            throw Exception(ErrorCodes::ABORTED, "Transferring part to replica was cancelled");
+        const auto & is_cancelled = blocker.getCounter();
+        auto cancellation_hook = [&]()
+        {
+            if (is_cancelled)
+                throw Exception(ErrorCodes::ABORTED, "Transferring part to replica was cancelled");
+
+            fiu_do_on(FailPoints::replicated_sends_failpoint,
+            {
+                std::bernoulli_distribution fault(0.1);
+                if (fault(thread_local_rng))
+                    throw Exception(ErrorCodes::FAULT_INJECTED, "Failpoint replicated_sends_failpoint is triggered");
+            });
+        };
+        copyDataWithThrottler(*file_in, hashing_out, cancellation_hook, data.getSendsThrottler());
+
+        hashing_out.finalize();
 
         if (hashing_out.count() != desc.file_size)
             throw Exception(

--- a/tests/queries/0_stateless/03141_fetches_errors_stress.reference
+++ b/tests/queries/0_stateless/03141_fetches_errors_stress.reference
@@ -1,0 +1,6 @@
+-- { echoOn }
+select table, errorCodeToName(error), count() from system.part_log where database = currentDatabase() and error > 0 and errorCodeToName(error) not in ('FAULT_INJECTED', 'NO_REPLICA_HAS_PART', 'ATTEMPT_TO_READ_AFTER_EOF') group by 1, 2 order by 1, 2;
+select count() from data_r1;
+100000
+select count() from data_r2;
+100000

--- a/tests/queries/0_stateless/03141_fetches_errors_stress.sql
+++ b/tests/queries/0_stateless/03141_fetches_errors_stress.sql
@@ -1,0 +1,19 @@
+-- Tags: no-parallel
+-- Tag no-parallel -- due to failpoints
+
+create table data_r1 (key Int, value String) engine=ReplicatedMergeTree('/tables/{database}/data', '{table}') order by tuple();
+create table data_r2 (key Int, value String) engine=ReplicatedMergeTree('/tables/{database}/data', '{table}') order by tuple();
+
+system enable failpoint replicated_sends_failpoint;
+insert into data_r1 select number, randomPrintableASCII(100) from numbers(100_000) settings max_block_size=1000, min_insert_block_size_rows=1000;
+system disable failpoint replicated_sends_failpoint;
+
+system sync replica data_r2;
+
+system flush logs;
+select event_time_microseconds, logger_name, message from system.text_log where level = 'Error' and message like '%Malformed chunked encoding%' order by 1 format LineAsString;
+
+-- { echoOn }
+select table, errorCodeToName(error), count() from system.part_log where database = currentDatabase() and error > 0 and errorCodeToName(error) not in ('FAULT_INJECTED', 'NO_REPLICA_HAS_PART', 'ATTEMPT_TO_READ_AFTER_EOF') group by 1, 2 order by 1, 2;
+select count() from data_r1;
+select count() from data_r2;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix possible CHECKSUM_DOESNT_MATCH (and others) during replicated fetches

Previously HTTP server didn't try to send an exception if something had
been written to the client already, but after rewriting to "zero-copy"
HTTP implementation (back in #19516) this got broken, and you can get
pretty "dangerous" at least at first glance errors, like:
- Malformed chunked encoding
- or most likely to CHECKSUM_DOESNT_MATCH error

This is not crucial because it will never pass checksum checks, but
still icky. So let's fix it.

P.S. this PR also adds failpoint for the test, but maybe it does not worth it, then I can drop the failpoint and the test itself.