### PR TITLE
Ensure backup lock files are cleaned up on error

### DIFF
--- a/src/Backups/BackupFactory.cpp
+++ b/src/Backups/BackupFactory.cpp
@@ -21,7 +21,10 @@ BackupMutablePtr BackupFactory::createBackup(const CreateParams & params) const
     auto it = creators.find(engine_name);
     if (it == creators.end())
         throw Exception(ErrorCodes::BACKUP_ENGINE_NOT_FOUND, "Not found backup engine '{}'", engine_name);
-    return (it->second)(params);
+
+    auto backup = (it->second)(params);
+    backup->open();
+    return backup;
 }
 
 void BackupFactory::registerBackupEngine(const String & engine_name, const CreatorFn & creator_fn)

--- a/src/Backups/BackupImpl.h
+++ b/src/Backups/BackupImpl.h
@@ -56,6 +56,7 @@ public:
 
     ~BackupImpl() override;
 
+    void open() override;
     const String & getNameForLogging() const override { return backup_name_for_logging; }
     OpenMode getOpenMode() const override { return open_mode; }
     time_t getTimestamp() const override { return timestamp; }
@@ -86,7 +87,6 @@ public:
     void tryRemoveAllFiles() override;
 
 private:
-    void open();
     void close();
 
     void openArchive();

--- a/src/Backups/IBackup.h
+++ b/src/Backups/IBackup.h
@@ -24,6 +24,11 @@ class IBackup : public std::enable_shared_from_this<IBackup>
 public:
     virtual ~IBackup() = default;
 
+    // Open the backup for reading and create a lock file.
+    // This needs to be called explicitly, and is not handled by the constructor,
+    // to avoid leaving lock files around if the constructor throws an exception.
+    virtual void open() = 0;
+
     /// Name of the backup.
     //virtual const String & getName() const = 0;
     virtual const String & getNameForLogging() const = 0;


### PR DESCRIPTION
Moves backup open routine out of the `BackupImpl` constructor.

This ensures that if there is an exception thrown in the constructor, that ClickHouse does not leave lock files around. Since lock file cleanup is currently done in the `BackupImpl` destructor, it does not get called when the constructor fails. Moving `BackupImpl::open` to be called separately in `BackupFactory::createBackup` seems like a simple way to fix this.

I have seen this issue occur in older versions (23.8.x) when backups to S3 failed to open the base backup and left a lock file on S3, but that should to be fixed by #56516. Now to reproduce this issue you would need something like `BackupImpl::readBackupMetadata()` to throw an exception during `open()`.

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Ensure lock files are cleaned up after backup initialization failure.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

---
### Modify your CI run:
**NOTE:** If your merge the PR with modified CI you **MUST KNOW** what you are doing
**NOTE:** Checked options will be applied if set before CI RunConfig/PrepareRunConfig step

#### Include tests (required builds will be added automatically):
- [ ] <!---ci_include_fast--> Fast test
- [ ] <!---ci_include_integration--> Integration Tests
- [ ] <!---ci_include_stateless--> Stateless tests
- [ ] <!---ci_include_stateful--> Stateful tests
- [ ] <!---ci_include_unit--> Unit tests
- [ ] <!---ci_include_performance--> Performance tests
- [ ] <!---ci_include_asan--> All with ASAN
- [ ] <!---ci_include_tsan--> All with TSAN
- [ ] <!---ci_include_analyzer--> All with Analyzer
- [ ] <!---ci_include_KEYWORD--> Add your option here

#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [ ] <!---ci_exclude_tsan--> All with TSAN
- [ ] <!---ci_exclude_msan--> All with MSAN
- [ ] <!---ci_exclude_ubsan--> All with UBSAN
- [ ] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64--> All with Aarch64
- [ ] <!---ci_exclude_KEYWORD--> Add your option here

#### Extra options:
- [ ] <!---do_not_test--> do not test (only style check)
- [ ] <!---no_merge_commit--> disable merge-commit (no merge from master before tests)
- [ ] <!---no_ci_cache--> disable CI cache (job reuse)

#### Only specified batches in multi-batch jobs:
- [ ] <!---batch_0--> 1
- [ ] <!---batch_1--> 2
- [ ] <!---batch_2--> 3
- [ ] <!---batch_3--> 4
