### PR TITLE
Fix curl url in .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -102,7 +102,7 @@
 	url = https://github.com/awslabs/aws-checksums
 [submodule "contrib/curl"]
 	path = contrib/curl
-	url = https://github.com/curl/curl
+	url = https://github.com/ClickHouse/curl
 [submodule "contrib/icudata"]
 	path = contrib/icudata
 	url = https://github.com/ClickHouse/icudata


### PR DESCRIPTION
### Changelog category:
- Not for changelog (changelog entry is not required)

Fix `curl` url in `.gitmodules`.
We forked `curl` but forgot to change `.gitmodules`.