### PR TITLE
Fix suppressions for librdkafka data-race for statistics code

### DIFF
--- a/cmake/sanitize.cmake
+++ b/cmake/sanitize.cmake
@@ -8,9 +8,6 @@ option (SANITIZE "Enable one of the code sanitizers" "")
 
 set (SAN_FLAGS "${SAN_FLAGS} -g -fno-omit-frame-pointer -DSANITIZER")
 
-# It's possible to pass an ignore list to sanitizers (-fsanitize-ignorelist). Intentionally not doing this because
-# 1. out-of-source suppressions are awkward 2. it seems ignore lists don't work after the Clang v16 upgrade (#49829)
-
 if (SANITIZE)
     if (SANITIZE STREQUAL "address")
         set (ASAN_FLAGS "-fsanitize=address -fsanitize-address-use-after-scope")

--- a/tests/tsan_ignorelist.txt
+++ b/tests/tsan_ignorelist.txt
@@ -7,4 +7,5 @@
 # https://github.com/ClickHouse/ClickHouse/issues/55629
 fun:rd_kafka_broker_set_nodename
 # https://github.com/ClickHouse/ClickHouse/issues/60443
-fun:rd_kafka_stats_emit_all
+fun:rd_avg_calc
+fun:rd_avg_rollover

--- a/tests/tsan_ignorelist.txt
+++ b/tests/tsan_ignorelist.txt
@@ -3,9 +3,13 @@
 #  [1]: https://clang.llvm.org/docs/SanitizerSpecialCaseList.html
 #  [2]: https://github.com/google/sanitizers/wiki/ThreadSanitizerSuppressions
 #
+# Caveats for generic entry "fun":
+# - does not work for __attribute__((__always_inline__))
+# - requires asterisk at the beginning *and* end for static functions
+#
 [thread]
 # https://github.com/ClickHouse/ClickHouse/issues/55629
 fun:rd_kafka_broker_set_nodename
 # https://github.com/ClickHouse/ClickHouse/issues/60443
-fun:rd_avg_calc
-fun:rd_avg_rollover
+fun:*rd_avg_calc*
+fun:*rd_avg_rollover*

--- a/tests/tsan_ignorelist.txt
+++ b/tests/tsan_ignorelist.txt
@@ -3,7 +3,7 @@
 #  [1]: https://clang.llvm.org/docs/SanitizerSpecialCaseList.html
 #  [2]: https://github.com/google/sanitizers/wiki/ThreadSanitizerSuppressions
 #
-
+[thread]
 # https://github.com/ClickHouse/ClickHouse/issues/55629
 fun:rd_kafka_broker_set_nodename
 # https://github.com/ClickHouse/ClickHouse/issues/60443

--- a/tests/ubsan_ignorelist.txt
+++ b/tests/ubsan_ignorelist.txt
@@ -6,7 +6,7 @@
 # See also [3] for all UBSan checks.
 #
 #   [3]: https://github.com/llvm-mirror/compiler-rt/blob/master/lib/ubsan/ubsan_checks.inc
-
+[undefined]
 # Some value is outside the range of representable values of type 'long' on user-provided data inside boost::geometry - ignore.
 src:*/Functions/pointInPolygon.cpp
 src:*/contrib/boost/boost/geometry/*

--- a/tests/ubsan_ignorelist.txt
+++ b/tests/ubsan_ignorelist.txt
@@ -6,6 +6,11 @@
 # See also [3] for all UBSan checks.
 #
 #   [3]: https://github.com/llvm-mirror/compiler-rt/blob/master/lib/ubsan/ubsan_checks.inc
+#
+# Caveats for generic entry "fun":
+# - does not work for __attribute__((__always_inline__))
+# - requires asterisk at the beginning *and* end for static functions
+#
 [undefined]
 # Some value is outside the range of representable values of type 'long' on user-provided data inside boost::geometry - ignore.
 src:*/Functions/pointInPolygon.cpp


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix suppressions for librdkafka data-race for statistics code

The problem is that ignorelist `fun` does not work recursively.

<details>

<summary>example</summary>

```c
// test.cpp

#include <thread>

bool flag = false;

// avoid mangling
extern "C" {

void set_flag_impl()
{
    flag = true;
}
void set_flag()
{
    set_flag_impl();
}
void set_flag_if()
{
    if (flag)
        flag = false;
}

}

int main()
{
    std::thread t1([]{ set_flag(); });
    std::thread t2([]{ set_flag_if(); });

    t1.join();
    t2.join();

    return 0;
}
```

```
// ignorelist
[thread]
fun:set_flag
```

```
$ clang++ -g -fno-omit-frame-pointer -fsanitize=thread -fsanitize-ignorelist=ignorelist -o test test.cpp && ./test
SUMMARY: ThreadSanitizer: data race /tmp/tsan-test/test.cpp:18:9 in set_flag_if
$ sed -i 's/set_flag/set_flag_impl/' ignorelist
$ clang++ -g -fno-omit-frame-pointer -fsanitize=thread -fsanitize-ignorelist=ignorelist -o test test.cpp && ./test
OK
```

</details>

Fixes: https://github.com/ClickHouse/ClickHouse/issues/60939 (cc @Algunenano )
Fixes: https://github.com/ClickHouse/ClickHouse/issues/60443
Fixes: https://github.com/ClickHouse/ClickHouse/pull/60604
Refs: https://github.com/ClickHouse/ClickHouse/pull/61828