### PR TITLE
[Docs] update `Svg` documentation

### DIFF
--- a/docs/en/sql-reference/functions/geo/svg.md
+++ b/docs/en/sql-reference/functions/geo/svg.md
@@ -18,7 +18,7 @@ Aliases: `SVG`, `svg`
 
 **Parameters**
 
-- `geometry` - Geo data. [Geo](../../data-types/geo).
+- `geometry` — Geo data. [Geo](../../data-types/geo).
 - `style` — Optional style name. [String](../../data-types/string).
 
 **Returned value**

--- a/docs/en/sql-reference/functions/geo/svg.md
+++ b/docs/en/sql-reference/functions/geo/svg.md
@@ -4,48 +4,72 @@ sidebar_label: SVG
 title: "Functions for Generating SVG images from Geo data"
 ---
 
-## Syntax
+## Svg
+
+Returns a string of select SVG element tags from Geo data.
+
+**Syntax**
 
 ``` sql
-SVG(geometry,[style])
+Svg(geometry,[style])
 ```
 
-### Parameters
+Aliases: `SVG`, `svg`
 
-- `geometry` — Geo data
-- `style` — Optional style name
+**Parameters**
 
-### Returned value
+- `geometry` - Geo data. [Geo](../../data-types/geo).
+- `style` — Optional style name. [String](../../data-types/string).
+
+**Returned value**
 
 - The SVG representation of the geometry:
   - SVG circle
   - SVG polygon
   - SVG path
 
-Type: String
+Type: [String](../../data-types/string)
 
-## Examples
+**Examples**
 
-### Circle
+**Circle**
+
+Query:
+
 ```sql
 SELECT SVG((0., 0.))
 ```
+
+Result:
+
 ```response
 <circle cx="0" cy="0" r="5" style=""/>
 ```
 
-### Polygon
+**Polygon**
+
+Query:
+
 ```sql
 SELECT SVG([(0., 0.), (10, 0), (10, 10), (0, 10)])
 ```
+
+Result:
+
 ```response
 <polygon points="0,0 0,10 10,10 10,0 0,0" style=""/>
 ```
 
-### Path
+**Path**
+
+Query:
+
 ```sql
 SELECT SVG([[(0., 0.), (10, 0), (10, 10), (0, 10)], [(4., 4.), (5, 4), (5, 5), (4, 5)]])
 ```
+
+Result:
+
 ```response
 <g fill-rule="evenodd"><path d="M 0,0 L 0,10 L 10,10 L 10,0 L 0,0M 4,4 L 5,4 L 5,5 L 4,5 L 4,4 z " style=""/></g>
 ```


### PR DESCRIPTION
Closes [#2019](https://github.com/ClickHouse/clickhouse-docs/issues/2019) as part of the [functions project](https://github.com/ClickHouse/clickhouse-docs/issues/1833) to add missing functions to documentation or supplement existing ones.

This PR:
- add aliases for Svg
- update formatting of page to match the template for functions [here](https://github.com/ClickHouse/clickhouse-docs/issues/1833/)
- add links to types

### Changelog category (leave one):
- Documentation (changelog entry is not required)
