### PR TITLE
Fix "invalid escape sequence" in clickhouse-test

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -2574,7 +2574,7 @@ def reportLogStats(args):
             count() AS count,
             substr(replaceRegexpAll(message, '[^A-Za-z]+', ''), 1, 32) AS pattern,
             substr(any(message), 1, 256) as runtime_message,
-            any((extract(source_file, '\/[a-zA-Z0-9_]+\.[a-z]+'), source_line)) as line
+            any((extract(source_file, '/[a-zA-Z0-9_]+\\.[a-z]+'), source_line)) as line
         FROM system.text_log
         WHERE (now() - toIntervalMinute(mins)) < event_time AND message_format_string = ''
         GROUP BY pattern


### PR DESCRIPTION
python error:

    /src/ch/clickhouse/.cmake/../tests/clickhouse-test:2570: SyntaxWarning: invalid escape sequence '\/'

And also remove unnecessary escaping of `/`.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Cc: @tavplubix 