### PR TITLE
*wip* Query cache persistence

### DIFF
--- a/base/base/cgroupsv2.cpp
+++ b/base/base/cgroupsv2.cpp
@@ -1,9 +1,6 @@
 #include <base/cgroupsv2.h>
-
 #include <base/defines.h>
-
 #include <fstream>
-#include <sstream>
 
 
 bool cgroupsV2Enabled()

--- a/programs/local/LocalServer.cpp
+++ b/programs/local/LocalServer.cpp
@@ -678,7 +678,7 @@ void LocalServer::processConfig()
     global_context->setMMappedFileCache(mmap_cache_size);
 
     /// Initialize a dummy query cache.
-    global_context->setQueryCache(0, 0, 0, 0);
+    global_context->setQueryCache(0, 0, 0, 0, {});
 
 #if USE_EMBEDDED_COMPILER
     size_t compiled_expression_cache_max_size_in_bytes = config().getUInt64("compiled_expression_cache_size", DEFAULT_COMPILED_EXPRESSION_CACHE_MAX_SIZE);

--- a/src/Interpreters/Cache/QueryCache.h
+++ b/src/Interpreters/Cache/QueryCache.h
@@ -9,6 +9,7 @@
 #include <QueryPipeline/Pipe.h>
 #include <base/UUID.h>
 
+#include <filesystem>
 #include <optional>
 
 namespace DB
@@ -192,7 +193,12 @@ public:
         friend class QueryCache; /// for createReader()
     };
 
-    QueryCache(size_t max_size_in_bytes, size_t max_entries, size_t max_entry_size_in_bytes_, size_t max_entry_size_in_rows_);
+    QueryCache(size_t max_size_in_bytes, size_t max_entries, size_t max_entry_size_in_bytes_, size_t max_entry_size_in_rows_, const std::optional<std::filesystem::path> & path_);
+
+    void shutdown();
+
+    void readCacheEntriesFromPersistence();
+    void writeCacheEntriesToPersistence();
 
     void updateConfiguration(size_t max_size_in_bytes, size_t max_entries, size_t max_entry_size_in_bytes_, size_t max_entry_size_in_rows_);
 
@@ -212,6 +218,9 @@ public:
 
 private:
     Cache cache; /// has its own locking --> not protected by mutex
+
+    const std::optional<std::filesystem::path> path; /// directory containing persisted query cache entries which are loaded/stored on
+                                                     /// database startup/shutdown (only set if query cache persistence is configured)
 
     mutable std::mutex mutex;
 

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -2955,14 +2955,18 @@ void Context::clearMMappedFileCache() const
         shared->mmap_cache->clear();
 }
 
-void Context::setQueryCache(size_t max_size_in_bytes, size_t max_entries, size_t max_entry_size_in_bytes, size_t max_entry_size_in_rows)
+void Context::setQueryCache(size_t max_size_in_bytes, size_t max_entries, size_t max_entry_size_in_bytes, size_t max_entry_size_in_rows, bool persist_cache)
 {
     std::lock_guard lock(shared->mutex);
 
     if (shared->query_cache)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Query cache has been already created.");
 
-    shared->query_cache = std::make_shared<QueryCache>(max_size_in_bytes, max_entries, max_entry_size_in_bytes, max_entry_size_in_rows);
+    std::optional<fs::path> query_cache_path;
+    if (persist_cache)
+        query_cache_path = fs::path(shared->path) / "query_cache";
+
+    shared->query_cache = std::make_shared<QueryCache>(max_size_in_bytes, max_entries, max_entry_size_in_bytes, max_entry_size_in_rows, query_cache_path);
 }
 
 void Context::updateQueryCacheConfiguration(const Poco::Util::AbstractConfiguration & config)

--- a/src/Interpreters/Context.h
+++ b/src/Interpreters/Context.h
@@ -1001,7 +1001,7 @@ public:
     std::shared_ptr<MMappedFileCache> getMMappedFileCache() const;
     void clearMMappedFileCache() const;
 
-    void setQueryCache(size_t max_size_in_bytes, size_t max_entries, size_t max_entry_size_in_bytes, size_t max_entry_size_in_rows);
+    void setQueryCache(size_t max_size_in_bytes, size_t max_entries, size_t max_entry_size_in_bytes, size_t max_entry_size_in_rows, bool persist_cache);
     void updateQueryCacheConfiguration(const Poco::Util::AbstractConfiguration & config);
     std::shared_ptr<QueryCache> getQueryCache() const;
     void clearQueryCache() const;


### PR DESCRIPTION
Fixes: #58228
Fixes: #52141

*30% done, not review-able yet. Uploading it as PR only in case my laptop catches fire.*

The server now stores/loads the content of the query cache (i.e. cached query results) to/from disk during server shutdown/startup.

The data is stored in subdirectory `query_cache/` relative to the base directory (`<path>...</path>`) in the server configuration).

To support future changes of the persistence format, a file `query_cache/format_version.txt` stores the version of the data, e.g. `1`. Backward compatibility will likely not be implemented, i.e. future ClickHouse versions which support query cache persistence format versions > 1 will not be able to read earlier formats (existing data will simply be deleted).

In format v1, query cache entries are serialized like this:
- For each query result, a sub-folder is created, with the AST tree hash as folder name, e.g. `query_cache/496d3a8d63e7/`.
- [...]

Query cache serialization/deserialization can be enabled using a server setting (default: true):

```xml
<query_cache>
    <persist_cache>true</persist_cache>
</query_cache>
```

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)