### PR TITLE
test for #56564

### DIFF
--- a/tests/queries/0_stateless/02428_parameterized_view_param_in_select_section.reference
+++ b/tests/queries/0_stateless/02428_parameterized_view_param_in_select_section.reference
@@ -1,0 +1,6 @@
+1	1
+1	test
+1	test
+1	1
+1	test
+1	test

--- a/tests/queries/0_stateless/02428_parameterized_view_param_in_select_section.sql
+++ b/tests/queries/0_stateless/02428_parameterized_view_param_in_select_section.sql
@@ -1,0 +1,58 @@
+-- https://github.com/ClickHouse/ClickHouse/issues/56564
+
+create table t(z String, ts DateTime) Engine=Memory as 
+select '1', '2020-01-01 00:00:00';
+
+CREATE VIEW v1 AS
+SELECT z, 'test' = {m:String} AS c
+FROM t 
+WHERE ts > '2019-01-01 00:00:00'
+GROUP BY z, c;
+
+CREATE VIEW v2 AS
+SELECT z, {m:String} AS c
+FROM t 
+WHERE ts > '2019-01-01 00:00:00'
+GROUP BY z, c;
+
+CREATE VIEW v3 AS
+SELECT z, {m:String} 
+FROM t;
+  
+select * from v1(m='test');
+select * from v2(m='test');
+select * from v3(m='test');
+
+drop table t;
+drop view v1;
+drop view v2;
+drop view v3;
+
+create table t(z String, ts DateTime) Engine=MergeTree ORDER BY z as 
+select '1', '2020-01-01 00:00:00';
+
+CREATE VIEW v1 AS
+SELECT z, 'test' = {m:String} AS c
+FROM t 
+WHERE ts > '2019-01-01 00:00:00'
+GROUP BY z, c;
+
+CREATE VIEW v2 AS
+SELECT z, {m:String} AS c
+FROM t 
+WHERE ts > '2019-01-01 00:00:00'
+GROUP BY z, c;
+
+CREATE VIEW v3 AS
+SELECT z, {m:String} 
+FROM t;
+  
+select * from v1(m='test');
+select * from v2(m='test');
+select * from v3(m='test');
+
+drop table t;
+drop view v1;
+drop view v2;
+drop view v3;
+


### PR DESCRIPTION
test for #56564

It seems after #54211 Clickhouse started to support parameters in SELECT section in Parametrized views.
Like `CREATE VIEW q AS SELECT {m:String}`.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
