### PR TITLE
Instrument SCOPE_GUARD in WriteBufferToFileSegment::nextImpl()

### DIFF
--- a/base/base/scope_guard.h
+++ b/base/base/scope_guard.h
@@ -47,10 +47,7 @@ public:
     requires std::is_convertible_v<G, F>
     constexpr BasicScopeGuard(G && function_) : function{std::move(function_)} {} // NOLINT(google-explicit-constructor, bugprone-forwarding-reference-overload, bugprone-move-forwarding-reference, cppcoreguidelines-missing-std-forward)
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wperformance-noexcept-destructor"
     ~BasicScopeGuard() noexcept(Noexcept) { invoke(); } // NOLINT
-#pragma clang diagnostic pop
 
     static constexpr bool is_nullable = std::is_constructible_v<bool, F>;
 

--- a/base/base/scope_guard.h
+++ b/base/base/scope_guard.h
@@ -47,7 +47,10 @@ public:
     requires std::is_convertible_v<G, F>
     constexpr BasicScopeGuard(G && function_) : function{std::move(function_)} {} // NOLINT(google-explicit-constructor, bugprone-forwarding-reference-overload, bugprone-move-forwarding-reference, cppcoreguidelines-missing-std-forward)
 
-    ~BasicScopeGuard() noexcept(Noexcept) { invoke(); }
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wperformance-noexcept-destructor"
+    ~BasicScopeGuard() noexcept(Noexcept) { invoke(); } // NOLINT
+#pragma clang diagnostic pop
 
     static constexpr bool is_nullable = std::is_constructible_v<bool, F>;
 

--- a/base/base/scope_guard.h
+++ b/base/base/scope_guard.h
@@ -4,7 +4,7 @@
 #include <memory>
 #include <utility>
 
-template <class F>
+template <class F, bool Noexcept = true>
 class [[nodiscard]] BasicScopeGuard
 {
 public:
@@ -47,7 +47,7 @@ public:
     requires std::is_convertible_v<G, F>
     constexpr BasicScopeGuard(G && function_) : function{std::move(function_)} {} // NOLINT(google-explicit-constructor, bugprone-forwarding-reference-overload, bugprone-move-forwarding-reference, cppcoreguidelines-missing-std-forward)
 
-    ~BasicScopeGuard() { invoke(); }
+    ~BasicScopeGuard() noexcept(Noexcept) { invoke(); }
 
     static constexpr bool is_nullable = std::is_constructible_v<bool, F>;
 
@@ -107,6 +107,9 @@ private:
 using scope_guard = BasicScopeGuard<std::function<void(void)>>;
 
 
+/// SCOPE_EXIT has noexcept(true) destructor, i.e. the program will terminate if an exception is thrown
+/// out of the body.
+
 template <class F>
 inline BasicScopeGuard<F> make_scope_guard(F && function_) { return std::forward<F>(function_); }
 
@@ -114,3 +117,15 @@ inline BasicScopeGuard<F> make_scope_guard(F && function_) { return std::forward
 const auto scope_exit##n = make_scope_guard([&] { __VA_ARGS__; })
 #define SCOPE_EXIT_FWD(n, ...) SCOPE_EXIT_CONCAT(n, __VA_ARGS__)
 #define SCOPE_EXIT(...) SCOPE_EXIT_FWD(__LINE__, __VA_ARGS__)
+
+/// SCOPE_EXIT_MAY_THROW has noexcept(false) destructor, i.e. throwing an exception out of the body
+/// is ok unless there's already another uncaught exception (std::uncaught_exceptions() != 0, which means
+/// this destructor was called during stack unwinding caused by an exception).
+
+template <class F>
+inline BasicScopeGuard<F, false> make_scope_guard_may_throw(F && function_) { return std::forward<F>(function_); }
+
+#define SCOPE_EXIT_CONCAT_MAY_THROW(n, ...) \
+const auto scope_exit##n = make_scope_guard_may_throw([&] { __VA_ARGS__; })
+#define SCOPE_EXIT_FWD_MAY_THROW(n, ...) SCOPE_EXIT_CONCAT_MAY_THROW(n, __VA_ARGS__)
+#define SCOPE_EXIT_MAY_THROW(...) SCOPE_EXIT_FWD_MAY_THROW(__LINE__, __VA_ARGS__)

--- a/src/Common/Exception.h
+++ b/src/Common/Exception.h
@@ -27,6 +27,12 @@ class AtomicLogger;
 
 [[noreturn]] void abortOnFailedAssertion(const String & description);
 
+#ifdef ABORT_ON_LOGICAL_ERROR
+#  define MAYBE_ABORT_ON_FAILED_ASSERTION(description) abortOnFailedAssertion(description)
+#else
+#  define MAYBE_ABORT_ON_FAILED_ASSERTION(description) do {} while (false)
+#endif
+
 /// This flag can be set for testing purposes - to check that no exceptions are thrown.
 extern bool terminate_on_any_exception;
 

--- a/src/Common/scope_guard_safe.h
+++ b/src/Common/scope_guard_safe.h
@@ -63,3 +63,19 @@
         DB::tryLogCurrentException(__PRETTY_FUNCTION__);          \
     }                                                             \
 )
+
+/// Same as SCOPE_EXIT() but logs exceptions, and tries not to crash on exception in release build.
+/// Treats exception as a logical error: starts the log messages with "LOGICAL_ERROR" (to trigger an
+/// alert) and aborts if ABORT_ON_LOGICAL_ERROR.
+#define SCOPE_EXIT_CHECKED(...) SCOPE_EXIT(                          \
+    try                                                              \
+    {                                                                \
+        __VA_ARGS__;                                                 \
+    }                                                                \
+    catch (...)                                                      \
+    {                                                                \
+        DB::tryLogCurrentException(__PRETTY_FUNCTION__, "LOGICAL_ERROR: exception in SCOPE_EXIT"); \
+        MAYBE_ABORT_ON_FAILED_ASSERTION("exception in scope guard"); \
+        throw;                                                       \
+    }                                                                \
+)

--- a/src/Interpreters/Cache/FileSegment.cpp
+++ b/src/Interpreters/Cache/FileSegment.cpp
@@ -572,6 +572,9 @@ void FileSegment::setDownloadedUnlocked(const FileSegmentGuard::Lock &)
 
     if (cache_writer)
     {
+        /// Note: this shouldn't throw because (1) we called cache_writer->next() after every write
+        /// to cache_writer, so there are no bytes to flush, and (2) cache_writer is a
+        /// WriteBufferFromFile, and its finalize() doesn't do anything if there's nothing to flush.
         cache_writer->finalize();
         cache_writer.reset();
         remote_file_reader.reset();

--- a/src/Interpreters/Cache/WriteBufferToFileSegment.cpp
+++ b/src/Interpreters/Cache/WriteBufferToFileSegment.cpp
@@ -5,8 +5,7 @@
 #include <IO/SwapHelper.h>
 #include <IO/ReadBufferFromFile.h>
 
-#include <base/scope_guard.h>
-
+#include <Common/scope_guard_safe.h>
 #include <Common/CurrentThread.h>
 #include <Common/formatReadable.h>
 #include <Common/logger_useful.h>
@@ -61,7 +60,7 @@ void WriteBufferToFileSegment::nextImpl()
                         downloader, file_segment->getInfoForLog());
     }
 
-    SCOPE_EXIT({
+    SCOPE_EXIT_CHECKED({
         if (file_segment->isDownloader())
             file_segment->completePartAndResetDownloader();
         else


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

We saw an std::terminate there, because some exception was thrown out of SCOPE_EXIT. It's difficult to investigate because there's no information about the exception. This PR logs some.

Adds a macro SCOPE_EXIT_CHECKED that logs and rethrows exceptions instead of crashing (but crashes in debug build). Maybe we should make it the default, by renaming it to SCOPE_EXIT and renaming SCOPE_EXIT to something else.