### PR TITLE
Fallback action-runner to autoupdate when it's unable to start

### DIFF
--- a/tests/ci/worker/init_runner.sh
+++ b/tests/ci/worker/init_runner.sh
@@ -318,7 +318,7 @@ while true; do
 
         if ! is_job_assigned; then
             RUNNER_AGE=$(( $(date +%s) - $(stat -c +%Y /proc/"$RUNNER_PID" 2>/dev/null || date +%s) ))
-            echo "The runner is launched $RUNNER_AGE seconds ago and still has hot received the job"
+            echo "The runner is launched $RUNNER_AGE seconds ago and still hasn't received a job"
             if (( 60 < RUNNER_AGE )); then
                 echo "Attempt to delete the runner for a graceful shutdown"
                 sudo -u ubuntu ./config.sh remove --token "$(get_runner_token)" \
@@ -354,11 +354,11 @@ while true; do
             --labels "$LABELS" --work _work --name "$INSTANCE_ID"
         )
         if (( ATTEMPT > 1 )); then
-            echo 'The runner failed to start at least once. Removing it and then configuring with autoudate enabled.'
+            echo 'The runner failed to start at least once. Removing it and then configuring with autoupdate enabled.'
             sudo -u ubuntu ./config.sh remove "${token_args[@]}"
             sudo -u ubuntu ./config.sh "${config_args[@]}"
         else
-            echo "Configure runner with disable autoupdate"
+            echo "Configure runner with disabled autoupdate"
             config_args+=("--disableupdate")
             sudo -u ubuntu ./config.sh "${config_args[@]}"
         fi

--- a/tests/ci/worker/init_runner.sh
+++ b/tests/ci/worker/init_runner.sh
@@ -312,6 +312,8 @@ while true; do
         no_terminating_metadata || terminate_on_event
         check_spot_instance_is_old && terminate_and_exit
         check_proceed_spot_termination force
+        # There were some failures to start the Job because of trash in _work
+        rm -rf _work
 
         echo "Going to configure runner"
         sudo -u ubuntu ./config.sh --url $RUNNER_URL --token "$(get_runner_token)" \

--- a/tests/ci/worker/prepare-ci-ami.sh
+++ b/tests/ci/worker/prepare-ci-ami.sh
@@ -9,7 +9,7 @@ set -xeuo pipefail
 
 echo "Running prepare script"
 export DEBIAN_FRONTEND=noninteractive
-export RUNNER_VERSION=2.315.0
+export RUNNER_VERSION=2.316.1
 export RUNNER_HOME=/home/ubuntu/actions-runner
 
 deb_arch() {

--- a/tests/ci/worker/prepare-ci-ami.sh
+++ b/tests/ci/worker/prepare-ci-ami.sh
@@ -155,30 +155,55 @@ apt-get install tailscale --yes --no-install-recommends
 
 # Create a common script for the instances
 mkdir /usr/local/share/scripts -p
-cat > /usr/local/share/scripts/init-network.sh << 'EOF'
-#!/usr/bin/env bash
+setup_cloudflare_dns() {
+    # Add cloudflare DNS as a fallback
+    # Get default gateway interface
+    local IFACE ETH_DNS CLOUDFLARE_NS new_dns
+    IFACE=$(ip --json route list | jq '.[]|select(.dst == "default").dev' --raw-output)
+    # `Link 2 (eth0): 172.31.0.2`
+    ETH_DNS=$(resolvectl dns "$IFACE") || :
+    CLOUDFLARE_NS=1.1.1.1
+    if [[ "$ETH_DNS" ]] && [[ "${ETH_DNS#*: }" != *"$CLOUDFLARE_NS"* ]]; then
+      # Cut the leading legend
+      ETH_DNS=${ETH_DNS#*: }
+      # shellcheck disable=SC2206
+      new_dns=(${ETH_DNS} "$CLOUDFLARE_NS")
+      resolvectl dns "$IFACE" "${new_dns[@]}"
+    fi
+}
 
-# Add cloudflare DNS as a fallback
-# Get default gateway interface
-IFACE=$(ip --json route list | jq '.[]|select(.dst == "default").dev' --raw-output)
-# `Link 2 (eth0): 172.31.0.2`
-ETH_DNS=$(resolvectl dns "$IFACE") || :
-CLOUDFLARE_NS=1.1.1.1
-if [[ "$ETH_DNS" ]] && [[ "${ETH_DNS#*: }" != *"$CLOUDFLARE_NS"* ]]; then
-  # Cut the leading legend
-  ETH_DNS=${ETH_DNS#*: }
-  # shellcheck disable=SC2206
-  new_dns=(${ETH_DNS} "$CLOUDFLARE_NS")
-  resolvectl dns "$IFACE" "${new_dns[@]}"
-fi
+setup_tailscale() {
+    # Setup tailscale, the very first action
+    local TS_API_CLIENT_ID TS_API_CLIENT_SECRET TS_AUTHKEY RUNNER_TYPE
+    TS_API_CLIENT_ID=$(aws ssm get-parameter --region us-east-1 --name /tailscale/api-client-id --query 'Parameter.Value' --output text --with-decryption)
+    TS_API_CLIENT_SECRET=$(aws ssm get-parameter --region us-east-1 --name /tailscale/api-client-secret --query 'Parameter.Value' --output text --with-decryption)
 
-# Setup tailscale, the very first action
-TS_API_CLIENT_ID=$(aws ssm get-parameter --region us-east-1 --name /tailscale/api-client-id --query 'Parameter.Value' --output text --with-decryption)
-TS_API_CLIENT_SECRET=$(aws ssm get-parameter --region us-east-1 --name /tailscale/api-client-secret --query 'Parameter.Value' --output text --with-decryption)
-export TS_API_CLIENT_ID TS_API_CLIENT_SECRET
-TS_AUTHKEY=$(get-authkey -tags tag:svc-core-ci-github -reusable -ephemeral)
-tailscale up --ssh --auth-key="$TS_AUTHKEY" --hostname="ci-runner-$INSTANCE_ID"
+    RUNNER_TYPE=$(/usr/local/bin/aws ec2 describe-tags --filters "Name=resource-id,Values=$INSTANCE_ID" --query "Tags[?Key=='github:runner-type'].Value" --output text)
+    RUNNER_TYPE=${RUNNER_TYPE:-unknown}
+    # Clean possible garbage from the runner type
+    RUNNER_TYPE=${RUNNER_TYPE//[^0-9a-z]/-}
+    TS_AUTHKEY=$(TS_API_CLIENT_ID="$TS_API_CLIENT_ID" TS_API_CLIENT_SECRET="$TS_API_CLIENT_SECRET" \
+                 get-authkey -tags tag:svc-core-ci-github -reusable -ephemeral)
+    tailscale up --ssh --auth-key="$TS_AUTHKEY" --hostname="ci-runner-$RUNNER_TYPE-$INSTANCE_ID"
+}
+
+cat > /usr/local/share/scripts/init-network.sh << EOF
+!/usr/bin/env bash
+$(declare -f setup_cloudflare_dns)
+
+$(declare -f setup_tailscale)
+
+# If the script is sourced, it will return now and won't execute functions
+return 0 &>/dev/null || :
+
+echo Setup Cloudflare DNS
+setup_cloudflare_dns
+
+echo Setup Tailscale VPN
+setup_tailscale
 EOF
+
+chmod +x /usr/local/share/scripts/init-network.sh
 
 
 # The following line is used in aws TOE check.


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Clean the `_work` directory between runner's launches. Fallback to auto-update actions runner if it fails to start. Make the `init-network.sh` sourceable and executable.

### TODO

- [ ] Add the tailscale hostname to the actions-hooks/pre-run.sh
- [ ] Make a file with tailscale hostname in setup_tailscale function to source
- [ ] On quick-finish jobs like `Cancel`, it finishes so quickly that the ATTEMPT is wrongly increased. Doesn't harm, though it should be improved.

### Note
On April 9th, the whole infrastructure failed because GitHub just passed responsibility for updating the runner software to users without any way to identify how soon the hard deprecation would be effective.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

---
### Modify your CI run:
**NOTE:** If your merge the PR with modified CI you **MUST KNOW** what you are doing
**NOTE:** Checked options will be applied if set before CI RunConfig/PrepareRunConfig step

#### Include tests (required builds will be added automatically):
- [ ] <!---ci_include_fast--> Fast test
- [ ] <!---ci_include_integration--> Integration Tests
- [ ] <!---ci_include_stateless--> Stateless tests
- [ ] <!---ci_include_stateful--> Stateful tests
- [ ] <!---ci_include_unit--> Unit tests
- [ ] <!---ci_include_performance--> Performance tests
- [ ] <!---ci_include_asan--> All with ASAN
- [ ] <!---ci_include_tsan--> All with TSAN
- [ ] <!---ci_include_analyzer--> All with Analyzer
- [ ] <!---ci_include_KEYWORD--> Add your option here

#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [ ] <!---ci_exclude_tsan--> All with TSAN
- [ ] <!---ci_exclude_msan--> All with MSAN
- [ ] <!---ci_exclude_ubsan--> All with UBSAN
- [ ] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64--> All with Aarch64
- [ ] <!---ci_exclude_KEYWORD--> Add your option here

#### Extra options:
- [ ] <!---do_not_test--> do not test (only style check)
- [ ] <!---no_merge_commit--> disable merge-commit (no merge from master before tests)
- [ ] <!---no_ci_cache--> disable CI cache (job reuse)

#### Only specified batches in multi-batch jobs:
- [ ] <!---batch_0--> 1
- [ ] <!---batch_1--> 2
- [ ] <!---batch_2--> 3
- [ ] <!---batch_3--> 4
