### PR TITLE
Dashboard page cache query

### DIFF
--- a/src/Storages/System/StorageSystemDashboards.cpp
+++ b/src/Storages/System/StorageSystemDashboards.cpp
@@ -338,7 +338,7 @@ ORDER BY t WITH FILL STEP {rounding:UInt32}
         {
             { "dashboard", "Cloud overview" },
             { "title", "Page cache hit rate" },
-            { "query", "SELECT \n  toStartOfInterval(event_time, INTERVAL {rounding:UInt32} SECOND)::INT AS t,\n  avg(metric)\nFROM (\n  SELECT event_time, greatest(0, (sum(ProfileEvent_OSReadChars) - sum(ProfileEvent_OSReadBytes)) / (sum(ProfileEvent_OSReadChars) + sum(ProfileEvent_ReadBufferFromS3Bytes))) AS metric \n  FROM clusterAllReplicas(default, merge('system', '^metric_log'))\n  WHERE event_date >= toDate(now() - {seconds:UInt32})\n    AND event_time >= now() - {seconds:UInt32}\n  GROUP BY event_time)\nGROUP BY t\nORDER BY t WITH FILL STEP {rounding:UInt32} SETTINGS skip_unavailable_shards = 1" }
+            { "query", "SELECT \n  toStartOfInterval(event_time, INTERVAL {rounding:UInt32} SECOND)::INT AS t,\n  avg(metric)\nFROM (\n  SELECT event_time, greatest(0, (sum(ProfileEvent_OSReadChars) - sum(ProfileEvent_OSReadBytes) - sum(ProfileEvent_ReadBufferFromS3Bytes)) / (sum(ProfileEvent_OSReadChars))) AS metric \n  FROM clusterAllReplicas(default, merge('system', '^metric_log'))\n  WHERE event_date >= toDate(now() - {seconds:UInt32})\n    AND event_time >= now() - {seconds:UInt32}\n  GROUP BY event_time)\nGROUP BY t\nORDER BY t WITH FILL STEP {rounding:UInt32} SETTINGS skip_unavailable_shards = 1" }
         },
         {
             { "dashboard", "Cloud overview" },


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

It would be great if someone with better internal knowledge could confirm this, but so far, I have found that:
* `OSReadChars` contains all read bytes, including disks (and filesystem cache), page cache, remote filesystem (aka S3), and even temporary files.
* `OSReadBytes` contains all read bytes from disk (not including page cache, remote filesystem, and temporary files)

If that's true to compute page cache bytes, we have to:

```
page cache bytes = OSReadChars - OSReadBytes - ReadBufferFromS3Bytes
```

Maybe we should also subtract `ExternalProcessingCompressedBytesTotal` and others but leave them out of the equation for simplicity.

cc @serxa 