### PR TITLE
Fix azure flaky test

### DIFF
--- a/tests/integration/test_backup_restore_azure_blob_storage/test.py
+++ b/tests/integration/test_backup_restore_azure_blob_storage/test.py
@@ -162,30 +162,7 @@ def put_azure_file_content(filename, port, data):
 
     blob_client = container_client.get_blob_client(filename)
     buf = io.BytesIO(data)
-    blob_client.upload_blob(buf)
-
-
-@pytest.fixture(autouse=True, scope="function")
-def delete_all_files(cluster):
-    port = cluster.env_variables["AZURITE_PORT"]
-    connection_string = (
-        f"DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;"
-        f"AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;"
-        f"BlobEndpoint=http://127.0.0.1:{port}/devstoreaccount1;"
-    )
-    blob_service_client = BlobServiceClient.from_connection_string(connection_string)
-    containers = blob_service_client.list_containers()
-    for container in containers:
-        container_client = blob_service_client.get_container_client(container)
-        blob_list = container_client.list_blobs()
-        for blob in blob_list:
-            print(blob)
-            blob_client = container_client.get_blob_client(blob)
-            blob_client.delete_blob()
-
-        assert len(list(container_client.list_blobs())) == 0
-
-    yield
+    blob_client.upload_blob(buf)g
 
 
 def test_backup_restore(cluster):

--- a/tests/integration/test_backup_restore_azure_blob_storage/test.py
+++ b/tests/integration/test_backup_restore_azure_blob_storage/test.py
@@ -162,7 +162,7 @@ def put_azure_file_content(filename, port, data):
 
     blob_client = container_client.get_blob_client(filename)
     buf = io.BytesIO(data)
-    blob_client.upload_blob(buf)g
+    blob_client.upload_blob(buf)
 
 
 def test_backup_restore(cluster):


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Follow-up for https://github.com/ClickHouse/ClickHouse/pull/63158
Removed delete_all_files as this test uses disk and check_access files are created which interrupt with delete_all_files logic. Also this function is not needed for this test.