### PR TITLE
Fix deadlock in `CacheDictionaryUpdateQueue` in case of exception in constructor

### DIFF
--- a/src/Dictionaries/CacheDictionaryUpdateQueue.cpp
+++ b/src/Dictionaries/CacheDictionaryUpdateQueue.cpp
@@ -36,8 +36,16 @@ CacheDictionaryUpdateQueue<dictionary_key_type>::CacheDictionaryUpdateQueue(
     , update_queue(configuration.max_update_queue_size)
     , update_pool(CurrentMetrics::CacheDictionaryThreads, CurrentMetrics::CacheDictionaryThreadsActive, CurrentMetrics::CacheDictionaryThreadsScheduled, configuration.max_threads_for_updates)
 {
-    for (size_t i = 0; i < configuration.max_threads_for_updates; ++i)
-        update_pool.scheduleOrThrowOnError([this] { updateThreadFunction(); });
+    try
+    {
+        for (size_t i = 0; i < configuration.max_threads_for_updates; ++i)
+            update_pool.scheduleOrThrowOnError([this] { updateThreadFunction(); });
+    }
+    catch (...)
+    {
+        stopAndWait();
+        throw;
+    }
 }
 
 template <DictionaryKeyType dictionary_key_type>


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Fixes: #63284

---

> in case of exception we will immediately try to destroy thread pool in ctor. this in turn will wait for all already running threads to finish (thread.join). but the code is written in a way that thread function won't stop until !update_queue.isFinished().
I guess I will just add explicit call to stopAndWait() in case of exception in ctor