### PR TITLE
DiskApp: fix 'list --recursive /' and crash on invalid arguments

### DIFF
--- a/programs/disks/CommandList.cpp
+++ b/programs/disks/CommandList.cpp
@@ -84,7 +84,7 @@ private:
 
         for (const auto & file_name : file_names)
         {
-            auto path = relative_path + "/" + file_name;
+            auto path = relative_path.empty() ? file_name : (relative_path + "/" + file_name);
             if (disk->isDirectory(path))
                 listRecursive(disk, path);
         }

--- a/programs/disks/DisksApp.cpp
+++ b/programs/disks/DisksApp.cpp
@@ -97,7 +97,8 @@ void DisksApp::processOptions()
 
 DisksApp::~DisksApp()
 {
-    global_context->shutdown();
+    if (global_context)
+        global_context->shutdown();
 }
 
 void DisksApp::init(std::vector<String> & common_arguments)


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Closes https://github.com/ClickHouse/ClickHouse/issues/63255
And probably (3) from https://github.com/ClickHouse/ClickHouse/issues/56791 - segfaulting if arguments are invalid instead of printing an error message.