### PR TITLE
Rollback azurite to working version

### DIFF
--- a/docker/test/stateless/Dockerfile
+++ b/docker/test/stateless/Dockerfile
@@ -89,7 +89,7 @@ ENV MINIO_ROOT_USER="clickhouse"
 ENV MINIO_ROOT_PASSWORD="clickhouse"
 ENV EXPORT_S3_STORAGE_POLICIES=1
 
-RUN npm install -g azurite \
+RUN npm install -g azurite@3.29.0 \
     && npm install -g tslib
 
 COPY run.sh /

--- a/docker/test/stateless/Dockerfile
+++ b/docker/test/stateless/Dockerfile
@@ -89,8 +89,8 @@ ENV MINIO_ROOT_USER="clickhouse"
 ENV MINIO_ROOT_PASSWORD="clickhouse"
 ENV EXPORT_S3_STORAGE_POLICIES=1
 
-RUN npm install -g azurite@3.29.0 \
-    && npm install -g tslib
+RUN npm install -g azurite@3.30.0 \
+    && npm install -g tslib && npm install -g node
 
 COPY run.sh /
 COPY setup_minio.sh /


### PR DESCRIPTION
(cherry picked from commit 967e51c1d6b9478a119a492ffa25449162854be2)

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

New version is fantatish (at least with Ubuntu 22.04.4 LTS):
```
azurite --version
/usr/local/lib/node_modules/azurite/dist/src/common/persistence/MemoryExtentStore.js:53
        return this._chunks.get(categoryName)?.chunks.get(id);
                                              ^

SyntaxError: Unexpected token '.'
    at wrapSafe (internal/modules/cjs/loader.js:915:16)
    at Module._compile (internal/modules/cjs/loader.js:963:27)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1027:10)
    at Module.load (internal/modules/cjs/loader.js:863:32)
    at Function.Module._load (internal/modules/cjs/loader.js:708:14)
    at Module.require (internal/modules/cjs/loader.js:887:19)
    at require (internal/modules/cjs/helpers.js:74:18)
    at Object.<anonymous> (/usr/local/lib/node_modules/azurite/dist/src/common/ConfigurationBase.js:7:29)
    at Module._compile (internal/modules/cjs/loader.js:999:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1027:10)
```