### PR TITLE
Fix AST parsing of invalid type names

### DIFF
--- a/src/Interpreters/executeQuery.cpp
+++ b/src/Interpreters/executeQuery.cpp
@@ -783,6 +783,7 @@ static std::tuple<ASTPtr, BlockIO> executeQueryImpl(
             catch (const Exception & e)
             {
                 if (e.code() == ErrorCodes::SYNTAX_ERROR)
+                    /// Don't print the original query text because it may contain sensitive data.
                     throw Exception(ErrorCodes::LOGICAL_ERROR,
                         "Inconsistent AST formatting: the query:\n{}\ncannot parse.",
                         formatted1);

--- a/tests/queries/0_stateless/03144_fuzz_quoted_type_name.sql
+++ b/tests/queries/0_stateless/03144_fuzz_quoted_type_name.sql
@@ -1,0 +1,7 @@
+create table t (x 123) engine Memory; -- { clientError 62 }
+create table t (x `a.b`) engine Memory; -- { clientError 62 }
+create table t (x Array(`a.b`)) engine Memory; -- { clientError 62 }
+
+create table t (x Array(`ab`)) engine Memory; -- { serverError 50 }
+create table t (x `ab`) engine Memory; -- { serverError 50 }
+create table t (x `Int64`) engine Memory;

--- a/tests/queries/0_stateless/03144_fuzz_quoted_type_name.sql
+++ b/tests/queries/0_stateless/03144_fuzz_quoted_type_name.sql
@@ -1,7 +1,7 @@
-create table t (x 123) engine Memory; -- { clientError 62 }
-create table t (x `a.b`) engine Memory; -- { clientError 62 }
-create table t (x Array(`a.b`)) engine Memory; -- { clientError 62 }
+create table t (x 123) engine Memory; -- { clientError SYNTAX_ERROR }
+create table t (x `a.b`) engine Memory; -- { clientError SYNTAX_ERROR }
+create table t (x Array(`a.b`)) engine Memory; -- { clientError SYNTAX_ERROR }
 
-create table t (x Array(`ab`)) engine Memory; -- { serverError 50 }
-create table t (x `ab`) engine Memory; -- { serverError 50 }
+create table t (x Array(`ab`)) engine Memory; -- { serverError UNKNOWN_TYPE }
+create table t (x `ab`) engine Memory; -- { serverError UNKNOWN_TYPE }
 create table t (x `Int64`) engine Memory;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

https://s3.amazonaws.com/clickhouse-test-reports/63210/def04d25684ea7fc256b169b3d1468c0f32eb27b/ast_fuzzer__debug_/fatal.log

Quoted type name is formatted as unquoted. If it has weird characters, it then fails to parse. Here's a crude fix.