### PR TITLE
[Docs] add `singleValueOrNull` to documentation

### DIFF
--- a/docs/en/sql-reference/aggregate-functions/reference/index.md
+++ b/docs/en/sql-reference/aggregate-functions/reference/index.md
@@ -92,6 +92,7 @@ ClickHouse-specific aggregate functions:
 - [quantileBFloat16Weighted](/docs/en/sql-reference/aggregate-functions/reference/quantilebfloat16.md#quantilebfloat16weighted)
 - [quantileDD](/docs/en/sql-reference/aggregate-functions/reference/quantileddsketch.md#quantileddsketch)
 - [simpleLinearRegression](/docs/en/sql-reference/aggregate-functions/reference/simplelinearregression.md)
+- [singleValueOrNull](/docs/en/sql-reference/aggregate-functions/reference/singlevalueornull.md)
 - [stochasticLinearRegression](/docs/en/sql-reference/aggregate-functions/reference/stochasticlinearregression.md)
 - [stochasticLogisticRegression](/docs/en/sql-reference/aggregate-functions/reference/stochasticlogisticregression.md)
 - [categoricalInformationValue](/docs/en/sql-reference/aggregate-functions/reference/categoricalinformationvalue.md)

--- a/docs/en/sql-reference/aggregate-functions/reference/singlevalueornull.md
+++ b/docs/en/sql-reference/aggregate-functions/reference/singlevalueornull.md
@@ -1,0 +1,57 @@
+---
+slug: /en/sql-reference/aggregate-functions/reference/singlevalueornull
+sidebar_position: 220
+---
+
+# singleValueOrNull
+
+The aggregate function `singleValueOrNull` is used to implement subquery operators, such as `x = ALL (SELECT ...)`. It checks if there is only one unique non-NULL value in the data.
+If there is only one unique value, it returns it. If there are zero or at least two distinct values, it returns NULL.
+
+**Syntax**
+
+``` sql
+singleValueOrNull(x)
+```
+
+**Parameters**
+
+- `x` — Column of any [data type](../../data-types/index.md).
+
+**Returned values**
+
+- The unique value, if there is only one unique non-NULL value in `x`.
+- `NULL`, if there are zero or at least two distinct values.
+
+**Examples**
+
+Query:
+
+``` sql
+CREATE TABLE test (x UInt8 NULL) ENGINE=Log;
+INSERT INTO test (x) VALUES (NULL), (NULL), (5), (NULL), (NULL);
+SELECT singleValueOrNull(x) FROM test;
+```
+
+Result:
+
+```response
+┌─singleValueOrNull(x)─┐
+│                    5 │
+└──────────────────────┘
+```
+
+Query:
+
+```sql
+INSERT INTO test (x) VALUES (10);
+SELECT singleValueOrNull(x) FROM test;
+```
+
+Result:
+
+```response
+┌─singleValueOrNull(x)─┐
+│                 ᴺᵁᴸᴸ │
+└──────────────────────┘
+```

--- a/utils/check-style/aspell-ignore/en/aspell-dict.txt
+++ b/utils/check-style/aspell-ignore/en/aspell-dict.txt
@@ -2396,6 +2396,7 @@ simpleaggregatefunction
 simplelinearregression
 simpod
 singlepart
+singleValueOrNull
 sinh
 sipHash
 siphash

--- a/utils/check-style/aspell-ignore/en/aspell-dict.txt
+++ b/utils/check-style/aspell-ignore/en/aspell-dict.txt
@@ -2397,6 +2397,7 @@ simplelinearregression
 simpod
 singlepart
 singleValueOrNull
+singlevalueornull
 sinh
 sipHash
 siphash


### PR DESCRIPTION
Closes [#2013](https://github.com/ClickHouse/clickhouse-docs/issues/2013) as part of the [functions project](https://github.com/ClickHouse/clickhouse-docs/issues/1833) to add missing or incomplete functions to the documentation.

Adds missing function:
- `singleValueOrNull`

### Changelog category (leave one):

- Documentation (changelog entry is not required)