### PR TITLE
[Docs] add `anyXYZ` functions

### DIFF
--- a/docs/en/sql-reference/aggregate-functions/reference/any.md
+++ b/docs/en/sql-reference/aggregate-functions/reference/any.md
@@ -7,15 +7,50 @@ sidebar_position: 6
 
 Selects the first encountered value of a column.
 
-By default, it ignores NULL values and returns the first NOT NULL value found in the column. As [`first_value`](../../../sql-reference/aggregate-functions/reference/first_value.md) if supports `RESPECT NULLS`, in which case it will select the first value passed, independently on whether it's NULL or not.
+**Syntax**
 
+```sql
+any(column)
+```
+
+Aliases: `any_value`, [`first_value`](../reference/first_value.md).
+
+**Parameters**
+- `column`: The column name. 
+
+**Returned value**
+
+By default, it ignores NULL values and returns the first NOT NULL value found in the column. Like [`first_value`](../../../sql-reference/aggregate-functions/reference/first_value.md) it supports `RESPECT NULLS`, in which case it will select the first value passed, independently on whether it's NULL or not.
+
+:::note
 The return type of the function is the same as the input, except for LowCardinality which is discarded. This means that given no rows as input it will return the default value of that type (0 for integers, or Null for a Nullable() column). You might use the `-OrNull` [combinator](../../../sql-reference/aggregate-functions/combinators.md) ) to modify this behaviour.
+:::
 
+:::warning
 The query can be executed in any order and even in a different order each time, so the result of this function is indeterminate.
-To get a determinate result, you can use the ‘min’ or ‘max’ function instead of ‘any’.
+To get a determinate result, you can use the [`min`](../reference/min.md) or [`max`](../reference/max.md) function instead of `any`.
+:::
 
-In some cases, you can rely on the order of execution. This applies to cases when SELECT comes from a subquery that uses ORDER BY.
+**Implementation details**
+
+In some cases, you can rely on the order of execution. This applies to cases when `SELECT` comes from a subquery that uses `ORDER BY`.
 
 When a `SELECT` query has the `GROUP BY` clause or at least one aggregate function, ClickHouse (in contrast to MySQL) requires that all expressions in the `SELECT`, `HAVING`, and `ORDER BY` clauses be calculated from keys or from aggregate functions. In other words, each column selected from the table must be used either in keys or inside aggregate functions. To get behavior like in MySQL, you can put the other columns in the `any` aggregate function.
 
-- Alias: `any_value`, `first_value`.
+**Example**
+
+Query:
+
+```sql
+CREATE TABLE any_nulls (city Nullable(String)) ENGINE=Log;
+
+INSERT INTO any_nulls (city) VALUES (NULL), ('Amsterdam'), ('New York'), ('Tokyo'), ('Valencia'), (NULL);
+
+SELECT any(city) FROM any_nulls;
+```
+
+```response
+┌─any(city)─┐
+│ Amsterdam │
+└───────────┘
+```

--- a/docs/en/sql-reference/aggregate-functions/reference/any_respect_nulls.md
+++ b/docs/en/sql-reference/aggregate-functions/reference/any_respect_nulls.md
@@ -1,0 +1,44 @@
+---
+slug: /en/sql-reference/aggregate-functions/reference/any_respect_nulls
+sidebar_position: 103
+---
+
+# any_respect_nulls
+
+Selects the first encountered value of a column, irregardless of whether it is a `NULL` value or not.
+
+Alias: `any_value_respect_nulls`, `first_value_repect_nulls`.
+
+**Syntax**
+
+```sql
+any_respect_nulls(column)
+```
+
+**Parameters**
+- `column`: The column name. 
+
+**Returned value**
+
+- The last value encountered, irregardless of whether it is a `NULL` value or not.
+
+**Example**
+
+Query:
+
+```sql
+CREATE TABLE any_nulls (city Nullable(String)) ENGINE=Log;
+
+INSERT INTO any_nulls (city) VALUES (NULL), ('Amsterdam'), ('New York'), ('Tokyo'), ('Valencia'), (NULL);
+
+SELECT any(city), any_respect_nulls(city) FROM any_nulls;
+```
+
+```response
+┌─any(city)─┬─any_respect_nulls(city)─┐
+│ Amsterdam │ ᴺᵁᴸᴸ                    │
+└───────────┴─────────────────────────┘
+```
+
+**See Also**
+- [any](../reference/any.md)

--- a/docs/en/sql-reference/aggregate-functions/reference/anylast.md
+++ b/docs/en/sql-reference/aggregate-functions/reference/anylast.md
@@ -5,5 +5,35 @@ sidebar_position: 104
 
 # anyLast
 
-Selects the last value encountered.
-The result is just as indeterminate as for the [any](../../../sql-reference/aggregate-functions/reference/any.md) function.
+Selects the last value encountered. The result is just as indeterminate as for the [any](../../../sql-reference/aggregate-functions/reference/any.md) function.
+
+**Syntax**
+
+```sql
+anyLast(column)
+```
+
+**Parameters**
+- `column`: The column name. 
+
+**Returned value**
+
+- The last value encountered.
+
+**Example**
+
+Query:
+
+```sql
+CREATE TABLE any_last_nulls (city Nullable(String)) ENGINE=Log;
+
+INSERT INTO any_last_nulls (city) VALUES ('Amsterdam'),(NULL),('New York'),('Tokyo'),('Valencia'),(NULL);
+
+SELECT anyLast(city) FROM any_last_nulls;
+```
+
+```response
+┌─anyLast(city)─┐
+│ Valencia      │
+└───────────────┘
+```

--- a/docs/en/sql-reference/aggregate-functions/reference/anylast_respect_nulls.md
+++ b/docs/en/sql-reference/aggregate-functions/reference/anylast_respect_nulls.md
@@ -1,0 +1,39 @@
+---
+slug: /en/sql-reference/aggregate-functions/reference/anylast_respect_nulls
+sidebar_position: 104
+---
+
+# anyLast_respect_nulls
+
+Selects the last value encountered, irregardless of whether it is `NULL` or not.
+
+**Syntax**
+
+```sql
+anyLast_respect_nulls(column)
+```
+
+**Parameters**
+- `column`: The column name. 
+
+**Returned value**
+
+- The last value encountered, irregardless of whether it is `NULL` or not.
+
+**Example**
+
+Query:
+
+```sql
+CREATE TABLE any_last_nulls (city Nullable(String)) ENGINE=Log;
+
+INSERT INTO any_last_nulls (city) VALUES ('Amsterdam'),(NULL),('New York'),('Tokyo'),('Valencia'),(NULL);
+
+SELECT anyLast(city), anyLast_respect_nulls(city) FROM any_last_nulls;
+```
+
+```response
+┌─anyLast(city)─┬─anyLast_respect_nulls(city)─┐
+│ Valencia      │ ᴺᵁᴸᴸ                        │
+└───────────────┴─────────────────────────────┘
+```

--- a/docs/en/sql-reference/aggregate-functions/reference/index.md
+++ b/docs/en/sql-reference/aggregate-functions/reference/index.md
@@ -35,8 +35,10 @@ Standard aggregate functions:
 
 ClickHouse-specific aggregate functions:
 
+- [any](/docs/en/sql-reference/aggregate-functions/reference/any_respect_nulls.md)
 - [anyHeavy](/docs/en/sql-reference/aggregate-functions/reference/anyheavy.md)
 - [anyLast](/docs/en/sql-reference/aggregate-functions/reference/anylast.md)
+- [anyLast](/docs/en/sql-reference/aggregate-functions/reference/anylast_respect_nulls.md)
 - [boundingRatio](/docs/en/sql-reference/aggregate-functions/reference/boundrat.md)
 - [first_value](/docs/en/sql-reference/aggregate-functions/reference/first_value.md)
 - [last_value](/docs/en/sql-reference/aggregate-functions/reference/last_value.md)


### PR DESCRIPTION
Closes [#1933](https://github.com/ClickHouse/clickhouse-docs/issues/1933) as part of the [functions project](https://github.com/ClickHouse/clickhouse-docs/issues/1833) to document missing or insufficiently documented functions.

This PR adds:
- `anyLast`
- `anyLast_respect_nulls`
- `any_respect_nulls`

Updates:
- `any` (alias: `any_value`)

### Changelog category (leave one):
- Documentation (changelog entry is not required)