### PR TITLE
[Docs] add `sigmoid` function

### DIFF
--- a/docs/en/sql-reference/functions/math-functions.md
+++ b/docs/en/sql-reference/functions/math-functions.md
@@ -914,3 +914,39 @@ Result:
 │                               11 │
 └──────────────────────────────────┘
 ```
+
+## sigmoid
+
+Returns the [sigmoid function](https://en.wikipedia.org/wiki/Sigmoid_function).
+
+**Syntax**
+
+```sql
+sigmoid(x)
+```
+
+**Parameters**
+
+- `x` — input value. Values from the interval: `-∞ < x < +∞`. [(U)Int*](../../sql-reference/data-types/int-uint.md), [Float*](../../sql-reference/data-types/float.md) or [Decimal*](../../sql-reference/data-types/decimal.md).
+
+**Returned value**
+
+- Corresponding value along the sigmoid curve between 0 and 1. [Float64](../../sql-reference/data-types/float.md)
+
+Type: [Float*](../../sql-reference/data-types/float.md#float32-float64).
+
+**Example**
+
+Query:
+
+``` sql
+SELECT Round(sigmoid(x),5) FROM (SELECT arrayJoin([-1, 0, 1]) AS x);
+```
+
+Result:
+
+```result
+0.26894
+0.5
+0.73106
+```

--- a/docs/en/sql-reference/functions/math-functions.md
+++ b/docs/en/sql-reference/functions/math-functions.md
@@ -931,9 +931,7 @@ sigmoid(x)
 
 **Returned value**
 
-- Corresponding value along the sigmoid curve between 0 and 1. [Float64](../../sql-reference/data-types/float.md)
-
-Type: [Float*](../../sql-reference/data-types/float.md#float32-float64).
+- Corresponding value along the sigmoid curve between 0 and 1. [Float64](../../sql-reference/data-types/float.md).
 
 **Example**
 

--- a/docs/en/sql-reference/functions/math-functions.md
+++ b/docs/en/sql-reference/functions/math-functions.md
@@ -938,7 +938,7 @@ sigmoid(x)
 Query:
 
 ``` sql
-SELECT Round(sigmoid(x),5) FROM (SELECT arrayJoin([-1, 0, 1]) AS x);
+SELECT round(sigmoid(x), 5) FROM (SELECT arrayJoin([-1, 0, 1]) AS x);
 ```
 
 Result:

--- a/utils/check-style/aspell-ignore/en/aspell-dict.txt
+++ b/utils/check-style/aspell-ignore/en/aspell-dict.txt
@@ -879,6 +879,7 @@ Simhash
 SimpleAggregateFunction
 SimpleState
 SipHash
+sigmoid
 Smirnov's
 Smirnov'test
 Soundex


### PR DESCRIPTION
Closes [#2010](https://github.com/ClickHouse/clickhouse-docs/issues/2010) as part of the [functions project](https://github.com/ClickHouse/clickhouse-docs/issues/1833) to document missing functions.

Adds previously missing:
- `sigmoid`

### Changelog category (leave one):
- Documentation (changelog entry is not required)