### PR TITLE
[Docs] add missing `showCertificate`

### DIFF
--- a/docs/en/sql-reference/functions/other-functions.md
+++ b/docs/en/sql-reference/functions/other-functions.md
@@ -3301,3 +3301,13 @@ The setting is not enabled by default for security reasons, because some headers
 HTTP headers are case sensitive for this function.
 
 If the function is used in the context of a distributed query, it returns non-empty result only on the initiator node.
+
+## showCertificate
+
+Shows the current server's SSL certificate if it has been configured.
+
+**Syntax**
+
+```sql
+showCertificate()
+```

--- a/docs/en/sql-reference/functions/other-functions.md
+++ b/docs/en/sql-reference/functions/other-functions.md
@@ -3311,3 +3311,11 @@ Shows the current server's SSL certificate if it has been configured.
 ```sql
 showCertificate()
 ```
+
+**Parameters**
+
+- None.
+
+**Returned value**
+
+- SSL certificate. [String](../../sql-reference/data-types/string.md).

--- a/docs/en/sql-reference/functions/other-functions.md
+++ b/docs/en/sql-reference/functions/other-functions.md
@@ -3304,7 +3304,7 @@ If the function is used in the context of a distributed query, it returns non-em
 
 ## showCertificate
 
-Shows the current server's SSL certificate if it has been configured.
+Shows information about the current server's Secure Sockets Layer (SSL) certificate if it has been configured. See [Configuring SSL-TLS](https://clickhouse.com/docs/en/guides/sre/configuring-ssl) for more information on how to configure ClickHouse to use OpenSSL certificates to validate connections.
 
 **Syntax**
 
@@ -3312,10 +3312,20 @@ Shows the current server's SSL certificate if it has been configured.
 showCertificate()
 ```
 
-**Parameters**
-
-- None.
-
 **Returned value**
 
-- SSL certificate. [String](../../sql-reference/data-types/string.md).
+- Map of key-value pairs relating to the configured SSL certificate. [Map](../../sql-reference/data-types/map.md)([String](../../sql-reference/data-types/string.md), [String](../../sql-reference/data-types/string.md)).
+
+**Example**
+
+Query:
+
+```sql
+SELECT showCertificate() FORMAT LineAsString;
+```
+
+Result:
+
+```response
+{'version':'1','serial_number':'2D9071D64530052D48308473922C7ADAFA85D6C5','signature_algo':'sha256WithRSAEncryption','issuer':'/CN=marsnet.local CA','not_before':'May  7 17:01:21 2024 GMT','not_after':'May  7 17:01:21 2025 GMT','subject':'/CN=chnode1','pkey_algo':'rsaEncryption'}
+```

--- a/utils/check-style/aspell-ignore/en/aspell-dict.txt
+++ b/utils/check-style/aspell-ignore/en/aspell-dict.txt
@@ -2392,6 +2392,7 @@ sharded
 sharding
 shortcircuit
 shortkeys
+showCertificate
 shoutout
 simdjson
 simpleJSON


### PR DESCRIPTION
Closes [#2009](https://github.com/ClickHouse/clickhouse-docs/issues/2009) as part of [#1833](https://github.com/ClickHouse/clickhouse-docs/issues/1833) to document missing functions.

Adds missing
- `showCertificates`

### Changelog category (leave one):
- Documentation (changelog entry is not required)