### PR TITLE
Allow to create MaterializedMySQL database without connection to MySQL

### DIFF
--- a/docs/en/engines/database-engines/materialized-mysql.md
+++ b/docs/en/engines/database-engines/materialized-mysql.md
@@ -51,6 +51,9 @@ ENGINE = MaterializedMySQL('host:port', ['database' | database], 'user', 'passwo
 ### allows_query_when_mysql_lost
 `allows_query_when_mysql_lost` — Allows to query a materialized table when MySQL is lost. Default: `0` (`false`).
 
+### allow_startup_database_without_connection_to_mysql
+`allow_startup_database_without_connection_to_mysql` — Allow to create and attach database without available connection to MySQL. Default: `0` (`false`).
+
 ### materialized_mysql_tables_list
 
 `materialized_mysql_tables_list` — a comma-separated list of mysql database tables, which will be replicated by MaterializedMySQL database engine. Default value: empty list — means whole tables will be replicated.

--- a/src/Databases/MySQL/DatabaseMaterializedMySQL.cpp
+++ b/src/Databases/MySQL/DatabaseMaterializedMySQL.cpp
@@ -81,12 +81,9 @@ LoadTaskPtr DatabaseMaterializedMySQL::startupDatabaseAsync(AsyncLoader & async_
         base->goals(),
         TablesLoaderBackgroundStartupPoolId,
         fmt::format("startup MaterializedMySQL database {}", getDatabaseName()),
-        [this, mode] (AsyncLoader &, const LoadJobPtr &)
+        [this] (AsyncLoader &, const LoadJobPtr &)
         {
             LOG_TRACE(log, "Starting MaterializeMySQL database");
-            if (mode < LoadingStrictnessLevel::FORCE_ATTACH)
-                materialize_thread.assertMySQLAvailable();
-
             materialize_thread.startSynchronization();
             started_up = true;
         });

--- a/src/Databases/MySQL/MaterializedMySQLSettings.h
+++ b/src/Databases/MySQL/MaterializedMySQLSettings.h
@@ -22,6 +22,7 @@ class ASTStorage;
     M(UInt64, max_milliseconds_to_wait_in_binlog_queue, 10000, "Max milliseconds to wait when max bytes exceeded in a binlog queue.", 0) \
     M(UInt64, max_bytes_in_binlog_dispatcher_buffer, DBMS_DEFAULT_BUFFER_SIZE, "Max bytes in the binlog dispatcher's buffer before it is flushed to attached binlogs.", 0) \
     M(UInt64, max_flush_milliseconds_in_binlog_dispatcher, 1000, "Max milliseconds in the binlog dispatcher's buffer to wait before it is flushed to attached binlogs.", 0) \
+    M(Bool, allow_startup_database_without_connection_to_mysql, false, "Allow to create and attach database without available connection to MySQL.", 0) \
 
     DECLARE_SETTINGS_TRAITS(MaterializedMySQLSettingsTraits, LIST_OF_MATERIALIZE_MODE_SETTINGS)
 

--- a/tests/integration/test_materialized_mysql_database/materialized_with_ddl.py
+++ b/tests/integration/test_materialized_mysql_database/materialized_with_ddl.py
@@ -3425,8 +3425,21 @@ def mysql_create_database_without_connection(clickhouse_node, mysql_node, servic
 
     clickhouse_node.cluster.pause_container(service_name)
 
+    assert "ConnectionFailed:" in clickhouse_node.query_and_get_error(
+        """
+        CREATE DATABASE create_without_connection
+        ENGINE = MaterializedMySQL('{}:3306', 'create_without_connection', 'root', 'clickhouse')
+        """.format(
+            service_name
+        )
+    )
+
     clickhouse_node.query(
-        "CREATE DATABASE create_without_connection ENGINE = MaterializedMySQL('{}:3306', 'create_without_connection', 'root', 'clickhouse') SETTINGS max_wait_time_when_mysql_unavailable=-1".format(
+        """
+        CREATE DATABASE create_without_connection
+        ENGINE = MaterializedMySQL('{}:3306', 'create_without_connection', 'root', 'clickhouse')
+        SETTINGS allow_startup_database_without_connection_to_mysql=1
+        """.format(
             service_name
         )
     )

--- a/tests/integration/test_materialized_mysql_database/materialized_with_ddl.py
+++ b/tests/integration/test_materialized_mysql_database/materialized_with_ddl.py
@@ -3413,3 +3413,29 @@ def gtid_after_attach_test(clickhouse_node, mysql_node, replication):
         interval_seconds=1,
         retry_count=300,
     )
+
+
+def mysql_create_database_without_connection(clickhouse_node, mysql_node, service_name):
+    mysql_node.query("DROP DATABASE IF EXISTS create_without_connection")
+    clickhouse_node.query("DROP DATABASE IF EXISTS create_without_connection")
+    mysql_node.query("CREATE DATABASE create_without_connection")
+    mysql_node.query(
+        "CREATE TABLE create_without_connection.test ( `id` int(11) NOT NULL, PRIMARY KEY (`id`) ) ENGINE=InnoDB;"
+    )
+
+    clickhouse_node.cluster.pause_container(service_name)
+
+    clickhouse_node.query(
+        "CREATE DATABASE create_without_connection ENGINE = MaterializedMySQL('{}:3306', 'create_without_connection', 'root', 'clickhouse') SETTINGS max_wait_time_when_mysql_unavailable=-1".format(
+            service_name
+        )
+    )
+
+    clickhouse_node.cluster.unpause_container(service_name)
+    mysql_node.alloc_connection()
+
+    check_query(
+        clickhouse_node,
+        "SHOW TABLES FROM create_without_connection FORMAT TSV",
+        "test\n",
+    )

--- a/tests/integration/test_materialized_mysql_database/test.py
+++ b/tests/integration/test_materialized_mysql_database/test.py
@@ -721,3 +721,11 @@ def test_binlog_client(started_cluster, started_mysql_8_0, replication):
     materialized_with_ddl.gtid_after_attach_test(
         node_db, started_mysql_8_0, replication
     )
+
+
+def test_create_database_without_mysql_connection(
+    started_cluster, started_mysql_8_0, clickhouse_node: ClickHouseInstance
+):
+    materialized_with_ddl.mysql_create_database_without_connection(
+        clickhouse_node, started_mysql_8_0, "mysql80"
+    )


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Allowed to create MaterializedMySQL database without connection to MySQL

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

It is possible to create MaterializedPostgreSQL database without connection, so maybe we should allow to do so for MaterializedMySQL too.

<details>
    <summary>Modify your CI run</summary>

**NOTE:** If your merge the PR with modified CI you **MUST KNOW** what you are doing
**NOTE:** Checked options will be applied if set before CI RunConfig/PrepareRunConfig step

#### Include tests (required builds will be added automatically):
- [ ] <!---ci_include_fast--> Fast test
- [ ] <!---ci_include_integration--> Integration Tests
- [ ] <!---ci_include_stateless--> Stateless tests
- [ ] <!---ci_include_stateful--> Stateful tests
- [ ] <!---ci_include_unit--> Unit tests
- [ ] <!---ci_include_performance--> Performance tests
- [ ] <!---ci_include_asan--> All with ASAN
- [ ] <!---ci_include_tsan--> All with TSAN
- [ ] <!---ci_include_analyzer--> All with Analyzer
- [ ] <!---ci_include_azure --> All with Azure
- [ ] <!---ci_include_KEYWORD--> Add your option here

#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [ ] <!---ci_exclude_tsan--> All with TSAN
- [ ] <!---ci_exclude_msan--> All with MSAN
- [ ] <!---ci_exclude_ubsan--> All with UBSAN
- [ ] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64--> All with Aarch64
- [ ] <!---ci_exclude_KEYWORD--> Add your option here

#### Extra options:
- [ ] <!---do_not_test--> do not test (only style check)
- [ ] <!---no_merge_commit--> disable merge-commit (no merge from master before tests)
- [ ] <!---no_ci_cache--> disable CI cache (job reuse)

#### Only specified batches in multi-batch jobs:
- [ ] <!---batch_0--> 1
- [ ] <!---batch_1--> 2
- [ ] <!---batch_2--> 3
- [ ] <!---batch_3--> 4

