### PR TITLE
Fix parsing of `CREATE INDEX` query

### DIFF
--- a/tests/queries/0_stateless/03146_create_index_compatibility.reference
+++ b/tests/queries/0_stateless/03146_create_index_compatibility.reference
@@ -1,0 +1,1 @@
+CREATE TABLE default.t_index_3146\n(\n    `a` UInt64,\n    `b` UInt64,\n    INDEX i1 a TYPE minmax GRANULARITY 1,\n    INDEX i2 (a, b) TYPE minmax GRANULARITY 1,\n    INDEX i3 (a, b) TYPE minmax GRANULARITY 1,\n    INDEX i4 a TYPE minmax GRANULARITY 1\n)\nENGINE = MergeTree\nORDER BY tuple()\nSETTINGS index_granularity = 8192

--- a/tests/queries/0_stateless/03146_create_index_compatibility.sql
+++ b/tests/queries/0_stateless/03146_create_index_compatibility.sql
@@ -1,0 +1,17 @@
+DROP TABLE IF EXISTS t_index_3146;
+
+CREATE TABLE t_index_3146 (a UInt64, b UInt64) ENGINE = MergeTree ORDER BY tuple();
+
+SET allow_create_index_without_type = 1;
+
+CREATE INDEX i1 ON t_index_3146 (a) TYPE minmax;
+CREATE INDEX i2 ON t_index_3146 (a, b) TYPE minmax;
+CREATE INDEX i3 ON t_index_3146 (a DESC, b ASC) TYPE minmax;
+CREATE INDEX i4 ON t_index_3146 a TYPE minmax;
+CREATE INDEX i5 ON t_index_3146 (a); -- ignored
+CREATE INDEX i6 ON t_index_3146 (a DESC, b ASC); -- ignored
+CREATE INDEX i7 ON t_index_3146; -- { clientError SYNTAX_ERROR }
+CREATE INDEX i8 ON t_index_3146 a, b TYPE minmax; -- { clientError SYNTAX_ERROR }
+
+SHOW CREATE TABLE t_index_3146;
+DROP TABLE t_index_3146;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Fixes #63023

<details>
    <summary>Modify your CI run</summary>

**NOTE:** If your merge the PR with modified CI you **MUST KNOW** what you are doing
**NOTE:** Checked options will be applied if set before CI RunConfig/PrepareRunConfig step

#### Include tests (required builds will be added automatically):
- [ ] <!---ci_include_fast--> Fast test
- [ ] <!---ci_include_integration--> Integration Tests
- [ ] <!---ci_include_stateless--> Stateless tests
- [ ] <!---ci_include_stateful--> Stateful tests
- [ ] <!---ci_include_unit--> Unit tests
- [ ] <!---ci_include_performance--> Performance tests
- [ ] <!---ci_include_asan--> All with ASAN
- [ ] <!---ci_include_tsan--> All with TSAN
- [ ] <!---ci_include_analyzer--> All with Analyzer
- [ ] <!---ci_include_azure --> All with Azure
- [ ] <!---ci_include_KEYWORD--> Add your option here

#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [ ] <!---ci_exclude_tsan--> All with TSAN
- [ ] <!---ci_exclude_msan--> All with MSAN
- [ ] <!---ci_exclude_ubsan--> All with UBSAN
- [ ] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64--> All with Aarch64
- [ ] <!---ci_exclude_KEYWORD--> Add your option here

#### Extra options:
- [ ] <!---do_not_test--> do not test (only style check)
- [ ] <!---no_merge_commit--> disable merge-commit (no merge from master before tests)
- [ ] <!---no_ci_cache--> disable CI cache (job reuse)

#### Only specified batches in multi-batch jobs:
- [ ] <!---batch_0--> 1
- [ ] <!---batch_1--> 2
- [ ] <!---batch_2--> 3
- [ ] <!---batch_3--> 4

<details>
