### PR TITLE
io_uring: refactor get reader from context

### DIFF
--- a/programs/keeper/CMakeLists.txt
+++ b/programs/keeper/CMakeLists.txt
@@ -148,6 +148,7 @@ if (BUILD_STANDALONE_KEEPER)
         ${CMAKE_CURRENT_SOURCE_DIR}/../../src/Disks/IO/createReadBufferFromFileBase.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../../src/Disks/IO/ReadBufferFromRemoteFSGather.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../../src/Disks/IO/IOUringReader.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../../src/Disks/IO/getIOUringReader.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../../src/Disks/IO/WriteBufferFromTemporaryFile.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../../src/Disks/IO/WriteBufferWithFinalizeCallback.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../../src/Disks/IO/AsynchronousBoundedReadBuffer.cpp

--- a/src/Coordination/Standalone/Context.cpp
+++ b/src/Coordination/Standalone/Context.cpp
@@ -304,7 +304,7 @@ IAsynchronousReader & Context::getThreadPoolReader(FilesystemReaderType type) co
 }
 
 #if USE_LIBURING
-IOUringReader & Context::getIOURingReader() const
+IOUringReader & Context::getIOUringReader() const
 {
     callOnce(shared->io_uring_reader_initialized, [&] {
         shared->io_uring_reader = createIOUringReader();

--- a/src/Coordination/Standalone/Context.cpp
+++ b/src/Coordination/Standalone/Context.cpp
@@ -5,6 +5,7 @@
 #include <Common/ThreadPool.h>
 #include <Common/callOnce.h>
 #include <Disks/IO/IOUringReader.h>
+#include <Disks/IO/getIOUringReader.h>
 
 #include <Core/ServerSettings.h>
 
@@ -306,7 +307,7 @@ IAsynchronousReader & Context::getThreadPoolReader(FilesystemReaderType type) co
 IOUringReader & Context::getIOURingReader() const
 {
     callOnce(shared->io_uring_reader_initialized, [&] {
-        shared->io_uring_reader = std::make_unique<IOUringReader>(512);
+        shared->io_uring_reader = createIOUringReader();
     });
 
     return *shared->io_uring_reader;

--- a/src/Coordination/Standalone/Context.h
+++ b/src/Coordination/Standalone/Context.h
@@ -137,7 +137,7 @@ public:
 
     IAsynchronousReader & getThreadPoolReader(FilesystemReaderType type) const;
 #if USE_LIBURING
-    IOUringReader & getIOURingReader() const;
+    IOUringReader & getIOUringReader() const;
 #endif
     std::shared_ptr<AsyncReadCounters> getAsyncReadCounters() const;
     ThreadPool & getThreadPoolWriter() const;

--- a/src/Disks/IO/IOUringReader.cpp
+++ b/src/Disks/IO/IOUringReader.cpp
@@ -1,5 +1,4 @@
 #include "IOUringReader.h"
-#include <memory>
 
 #if USE_LIBURING
 
@@ -13,6 +12,7 @@
 #include <Common/ThreadPool.h>
 #include <Common/logger_useful.h>
 #include <future>
+#include <memory>
 
 namespace ProfileEvents
 {

--- a/src/Disks/IO/createReadBufferFromFileBase.cpp
+++ b/src/Disks/IO/createReadBufferFromFileBase.cpp
@@ -4,7 +4,7 @@
 #include <IO/MMapReadBufferFromFileWithCache.h>
 #include <IO/AsynchronousReadBufferFromFile.h>
 #include <Disks/IO/IOUringReader.h>
-#include <Disks/IO/IOUringReader.h>
+#include <Disks/IO/getIOUringReader.h>
 #include <Disks/IO/ThreadPoolReader.h>
 #include <Disks/IO/getThreadPoolReader.h>
 #include <IO/AsynchronousReader.h>
@@ -100,7 +100,7 @@ std::unique_ptr<ReadBufferFromFileBase> createReadBufferFromFileBase(
         else if (settings.local_fs_method == LocalFSReadMethod::io_uring)
         {
 #if USE_LIBURING
-            auto & reader = getIOURingReaderOrThrow();
+            auto & reader = getIOUringReaderOrThrow();
             res = std::make_unique<AsynchronousReadBufferFromFileWithDescriptorsCache>(
                 reader,
                 settings.priority,

--- a/src/Disks/IO/createReadBufferFromFileBase.cpp
+++ b/src/Disks/IO/createReadBufferFromFileBase.cpp
@@ -4,9 +4,9 @@
 #include <IO/MMapReadBufferFromFileWithCache.h>
 #include <IO/AsynchronousReadBufferFromFile.h>
 #include <Disks/IO/IOUringReader.h>
+#include <Disks/IO/IOUringReader.h>
 #include <Disks/IO/ThreadPoolReader.h>
 #include <Disks/IO/getThreadPoolReader.h>
-#include <IO/SynchronousReader.h>
 #include <IO/AsynchronousReader.h>
 #include <Common/ProfileEvents.h>
 #include "config.h"
@@ -100,14 +100,7 @@ std::unique_ptr<ReadBufferFromFileBase> createReadBufferFromFileBase(
         else if (settings.local_fs_method == LocalFSReadMethod::io_uring)
         {
 #if USE_LIBURING
-            auto global_context = Context::getGlobalContextInstance();
-            if (!global_context)
-                throw Exception(ErrorCodes::LOGICAL_ERROR, "Cannot obtain io_uring reader (global context not initialized)");
-
-            auto & reader = global_context->getIOURingReader();
-            if (!reader.isSupported())
-                throw Exception(ErrorCodes::UNSUPPORTED_METHOD, "io_uring is not supported by this system");
-
+            auto & reader = getIOURingReaderOrThrow();
             res = std::make_unique<AsynchronousReadBufferFromFileWithDescriptorsCache>(
                 reader,
                 settings.priority,

--- a/src/Disks/IO/getIOUringReader.cpp
+++ b/src/Disks/IO/getIOUringReader.cpp
@@ -1,7 +1,8 @@
-#include "getIOUringReader.h"
+#include <Disks/IO/getIOUringReader.h>
 
 #if USE_LIBURING
 
+#include <Interpreters/Context.h>
 #include <Common/ErrorCodes.h>
 
 namespace DB
@@ -20,8 +21,8 @@ std::unique_ptr<IOUringReader> createIOUringReader()
 
 IOUringReader & getIOUringReaderOrThrow(ContextPtr context)
 {
-    auto reader = context->getIOUringReader();
-    if (!reader.isSupported)
+    auto & reader = context->getIOUringReader();
+    if (!reader.isSupported())
     {
         throw Exception(ErrorCodes::UNSUPPORTED_METHOD, "io_uring is not supported by this system");
     }
@@ -33,7 +34,7 @@ IOUringReader & getIOUringReaderOrThrow()
     auto context = Context::getGlobalContextInstance();
     if (!context)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Global context not initialized");
-    return getIOUringReaderOrThrow(context)
+    return getIOUringReaderOrThrow(context);
 }
 
 }

--- a/src/Disks/IO/getIOUringReader.cpp
+++ b/src/Disks/IO/getIOUringReader.cpp
@@ -1,0 +1,40 @@
+#include "getIOUringReader.h"
+
+#if USE_LIBURING
+
+#include <Common/ErrorCodes.h>
+
+namespace DB
+{
+
+namespace ErrorCodes
+{
+    extern const int LOGICAL_ERROR;
+    extern const int UNSUPPORTED_METHOD;
+}
+
+std::unique_ptr<IOUringReader> createIOUringReader()
+{
+    return std::make_unique<IOUringReader>(512);
+}
+
+IOUringReader & getIOUringReaderOrThrow(ContextPtr context)
+{
+    auto reader = context->getIOUringReader();
+    if (!reader.isSupported)
+    {
+        throw Exception(ErrorCodes::UNSUPPORTED_METHOD, "io_uring is not supported by this system");
+    }
+    return reader;
+}
+
+IOUringReader & getIOUringReaderOrThrow()
+{
+    auto context = Context::getGlobalContextInstance();
+    if (!context)
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Global context not initialized");
+    return getIOUringReaderOrThrow(context)
+}
+
+}
+#endif

--- a/src/Disks/IO/getIOUringReader.h
+++ b/src/Disks/IO/getIOUringReader.h
@@ -6,6 +6,7 @@
 
 #include <Interpreters/Context_fwd.h>
 #include <Disks/IO/IOUringReader.h>
+#include <memory>
 
 namespace DB
 {

--- a/src/Disks/IO/getIOUringReader.h
+++ b/src/Disks/IO/getIOUringReader.h
@@ -5,6 +5,7 @@
 #if USE_LIBURING
 
 #include <Interpreters/Context_fwd.h>
+#include <Disks/IO/IOUringReader.h>
 
 namespace DB
 {

--- a/src/Disks/IO/getIOUringReader.h
+++ b/src/Disks/IO/getIOUringReader.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "config.h"
+
+#if USE_LIBURING
+
+#include <Interpreters/Context_fwd.h>
+
+namespace DB
+{
+
+std::unique_ptr<IOUringReader> createIOUringReader();
+
+IOUringReader & getIOUringReaderOrThrow(ContextPtr);
+
+IOUringReader & getIOUringReaderOrThrow();
+
+}
+#endif

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -5176,10 +5176,10 @@ IAsynchronousReader & Context::getThreadPoolReader(FilesystemReaderType type) co
 }
 
 #if USE_LIBURING
-IOUringReader & Context::getIOURingReader() const
+IOUringReader & Context::getIOUringReader() const
 {
     callOnce(shared->io_uring_reader_initialized, [&] {
-        shared->io_uring_reader = createIOUringReader()
+        shared->io_uring_reader = createIOUringReader();
     });
 
     return *shared->io_uring_reader;

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -37,6 +37,7 @@
 #include <Disks/ObjectStorages/IObjectStorage.h>
 #include <Disks/StoragePolicy.h>
 #include <Disks/IO/IOUringReader.h>
+#include <Disks/IO/getIOUringReader.h>
 #include <IO/SynchronousReader.h>
 #include <TableFunctions/TableFunctionFactory.h>
 #include <Interpreters/ActionLocksManager.h>
@@ -5178,7 +5179,7 @@ IAsynchronousReader & Context::getThreadPoolReader(FilesystemReaderType type) co
 IOUringReader & Context::getIOURingReader() const
 {
     callOnce(shared->io_uring_reader_initialized, [&] {
-        shared->io_uring_reader = std::make_unique<IOUringReader>(512);
+        shared->io_uring_reader = createIOUringReader()
     });
 
     return *shared->io_uring_reader;

--- a/src/Interpreters/Context.h
+++ b/src/Interpreters/Context.h
@@ -1243,7 +1243,7 @@ public:
 
     IAsynchronousReader & getThreadPoolReader(FilesystemReaderType type) const;
 #if USE_LIBURING
-    IOUringReader & getIOURingReader() const;
+    IOUringReader & getIOUringReader() const;
 #endif
 
     std::shared_ptr<AsyncReadCounters> getAsyncReadCounters() const;

--- a/src/Storages/StorageFile.cpp
+++ b/src/Storages/StorageFile.cpp
@@ -283,7 +283,7 @@ std::unique_ptr<ReadBuffer> selectReadBuffer(
     else if (read_method == LocalFSReadMethod::io_uring && !use_table_fd)
     {
 #if USE_LIBURING
-        auto & reader = getIOURingReaderOrThrow(context);
+        auto & reader = getIOUringReaderOrThrow(context);
         res = std::make_unique<AsynchronousReadBufferFromFileWithDescriptorsCache>(
             reader,
             Priority{},

--- a/src/Storages/StorageFile.cpp
+++ b/src/Storages/StorageFile.cpp
@@ -28,6 +28,7 @@
 #include <IO/PeekableReadBuffer.h>
 #include <IO/AsynchronousReadBufferFromFile.h>
 #include <Disks/IO/IOUringReader.h>
+#include <Disks/IO/getIOUringReader.h>
 
 #include <Formats/FormatFactory.h>
 #include <Formats/ReadSchemaUtils.h>
@@ -282,10 +283,7 @@ std::unique_ptr<ReadBuffer> selectReadBuffer(
     else if (read_method == LocalFSReadMethod::io_uring && !use_table_fd)
     {
 #if USE_LIBURING
-        auto & reader = context->getIOURingReader();
-        if (!reader.isSupported())
-            throw Exception(ErrorCodes::UNSUPPORTED_METHOD, "io_uring is not supported by this system");
-
+        auto & reader = getIOURingReaderOrThrow(context);
         res = std::make_unique<AsynchronousReadBufferFromFileWithDescriptorsCache>(
             reader,
             Priority{},


### PR DESCRIPTION
Refactor IOUringReader creation logic, similar to `src/Disks/IO/getThreadPoolReader.h`, to remove code duplication.
 
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)
