### PR TITLE
Fix logical error when reloading config with customly created web disk broken after #56367

### DIFF
--- a/tests/integration/test_disk_over_web_server/test.py
+++ b/tests/integration/test_disk_over_web_server/test.py
@@ -44,7 +44,7 @@ def cluster():
             "node5",
             main_configs=["configs/storage_conf.xml"],
             with_nginx=True,
-            allow_analyzer=False,
+            use_old_analyzer=True,
         )
 
         cluster.start()

--- a/tests/integration/test_disk_over_web_server/test.py
+++ b/tests/integration/test_disk_over_web_server/test.py
@@ -40,6 +40,12 @@ def cluster():
             image="clickhouse/clickhouse-server",
             tag=CLICKHOUSE_CI_MIN_TESTED_VERSION,
         )
+        cluster.add_instance(
+            "node5",
+            main_configs=["configs/storage_conf.xml"],
+            with_nginx=True,
+            allow_analyzer=False,
+        )
 
         cluster.start()
 
@@ -390,3 +396,21 @@ def test_page_cache(cluster):
 
         node.query("DROP TABLE test{} SYNC".format(i))
         print(f"Ok {i}")
+
+
+def test_config_reload(cluster):
+    node1 = cluster.instances["node5"]
+    table_name = "config_reload"
+
+    global uuids
+    node1.query(
+        f"""
+        DROP TABLE IF EXISTS {table_name};
+        CREATE TABLE {table_name} UUID '{uuids[0]}'
+        (id Int32) ENGINE = MergeTree() ORDER BY id
+        SETTINGS disk = disk(type=web, endpoint='http://nginx:80/test1/');
+    """
+    )
+
+    node1.query("SYSTEM RELOAD CONFIG")
+    node1.query(f"DROP TABLE {table_name} SYNC")


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Looks like it was broken in https://github.com/ClickHouse/ClickHouse/pull/56367. 
Not for changelog because this is visible only in debug build - ` Logical error: 'false && "Tasks in BackgroundSchedulePool cannot throw"`. 
But in non-debug build there will be `void DB::BackgroundSchedulePoolTaskInfo::execute(): Code: 48. DB::Exception: Only read-only operations are supported in WebObjectStorage. (NOT_IMPLEMENTED),`

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

<details>
    <summary>Modify your CI run</summary>

**NOTE:** If your merge the PR with modified CI you **MUST KNOW** what you are doing
**NOTE:** Checked options will be applied if set before CI RunConfig/PrepareRunConfig step

#### Include tests (required builds will be added automatically):
- [ ] <!---ci_include_fast--> Fast test
- [x] <!---ci_include_integration--> Integration Tests
- [ ] <!---ci_include_stateless--> Stateless tests
- [ ] <!---ci_include_stateful--> Stateful tests
- [ ] <!---ci_include_unit--> Unit tests
- [ ] <!---ci_include_performance--> Performance tests
- [ ] <!---ci_include_asan--> All with ASAN
- [ ] <!---ci_include_tsan--> All with TSAN
- [ ] <!---ci_include_analyzer--> All with Analyzer
- [ ] <!---ci_include_azure --> All with Azure
- [ ] <!---ci_include_KEYWORD--> Add your option here

#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [ ] <!---ci_exclude_tsan--> All with TSAN
- [ ] <!---ci_exclude_msan--> All with MSAN
- [ ] <!---ci_exclude_ubsan--> All with UBSAN
- [ ] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64--> All with Aarch64
- [ ] <!---ci_exclude_KEYWORD--> Add your option here

#### Extra options:
- [ ] <!---do_not_test--> do not test (only style check)
- [ ] <!---no_merge_commit--> disable merge-commit (no merge from master before tests)
- [ ] <!---no_ci_cache--> disable CI cache (job reuse)

#### Only specified batches in multi-batch jobs:
- [ ] <!---batch_0--> 1
- [ ] <!---batch_1--> 2
- [ ] <!---batch_2--> 3
- [ ] <!---batch_3--> 4

<details>
