### PR TITLE
fix: empty used_dictionaries in system.query_log

### DIFF
--- a/docs/en/operations/system-tables/query_log.md
+++ b/docs/en/operations/system-tables/query_log.md
@@ -108,7 +108,7 @@ Columns:
 - `used_aggregate_function_combinators` ([Array(String)](../../sql-reference/data-types/array.md)) — Canonical names of `aggregate functions combinators`, which were used during query execution.
 - `used_database_engines` ([Array(String)](../../sql-reference/data-types/array.md)) — Canonical names of `database engines`, which were used during query execution.
 - `used_data_type_families` ([Array(String)](../../sql-reference/data-types/array.md)) — Canonical names of `data type families`, which were used during query execution.
-- `used_dictionaries` ([Array(String)](../../sql-reference/data-types/array.md)) — Canonical names of `dictionaries`, which were used during query execution.
+- `used_dictionaries` ([Array(String)](../../sql-reference/data-types/array.md)) — Canonical names of `dictionaries`, which were used during query execution. For dictionaries configured using an XML file this is the name of the dictionary, and for dictionaries created by an SQL statement, the canonical name is the fully qualified object name.
 - `used_formats` ([Array(String)](../../sql-reference/data-types/array.md)) — Canonical names of `formats`, which were used during query execution.
 - `used_functions` ([Array(String)](../../sql-reference/data-types/array.md)) — Canonical names of `functions`, which were used during query execution.
 - `used_storages` ([Array(String)](../../sql-reference/data-types/array.md)) — Canonical names of `storages`, which were used during query execution.

--- a/src/Dictionaries/IDictionary.h
+++ b/src/Dictionaries/IDictionary.h
@@ -69,6 +69,15 @@ public:
         return dictionary_id.getNameForLogs();
     }
 
+    /// Returns fully qualified unquoted dictionary name
+    std::string getQualifiedName() const
+    {
+        std::lock_guard lock{mutex};
+        if (dictionary_id.database_name.empty())
+            return dictionary_id.table_name;
+        return dictionary_id.database_name + "." + dictionary_id.table_name;
+    }
+
     StorageID getDictionaryID() const
     {
         std::lock_guard lock{mutex};

--- a/src/Interpreters/ExternalDictionariesLoader.cpp
+++ b/src/Interpreters/ExternalDictionariesLoader.cpp
@@ -77,21 +77,23 @@ void ExternalDictionariesLoader::updateObjectFromConfigWithoutReloading(IExterna
 ExternalDictionariesLoader::DictPtr ExternalDictionariesLoader::getDictionary(const std::string & dictionary_name, ContextPtr local_context) const
 {
     std::string resolved_dictionary_name = resolveDictionaryName(dictionary_name, local_context->getCurrentDatabase());
+    auto dictionary = std::static_pointer_cast<const IDictionary>(load(resolved_dictionary_name));
 
     if (local_context->hasQueryContext() && local_context->getSettingsRef().log_queries)
-        local_context->getQueryContext()->addQueryFactoriesInfo(Context::QueryLogFactories::Dictionary, resolved_dictionary_name);
+        local_context->getQueryContext()->addQueryFactoriesInfo(Context::QueryLogFactories::Dictionary, dictionary->getQualifiedName());
 
-    return std::static_pointer_cast<const IDictionary>(load(resolved_dictionary_name));
+    return dictionary;
 }
 
 ExternalDictionariesLoader::DictPtr ExternalDictionariesLoader::tryGetDictionary(const std::string & dictionary_name, ContextPtr local_context) const
 {
     std::string resolved_dictionary_name = resolveDictionaryName(dictionary_name, local_context->getCurrentDatabase());
+    auto dictionary = std::static_pointer_cast<const IDictionary>(tryLoad(resolved_dictionary_name));
 
-    if (local_context->hasQueryContext() && local_context->getSettingsRef().log_queries)
-        local_context->getQueryContext()->addQueryFactoriesInfo(Context::QueryLogFactories::Dictionary, resolved_dictionary_name);
+    if (local_context->hasQueryContext() && local_context->getSettingsRef().log_queries && dictionary)
+        local_context->getQueryContext()->addQueryFactoriesInfo(Context::QueryLogFactories::Dictionary, dictionary->getQualifiedName());
 
-    return std::static_pointer_cast<const IDictionary>(tryLoad(resolved_dictionary_name));
+    return dictionary;
 }
 
 

--- a/src/Interpreters/ExternalDictionariesLoader.cpp
+++ b/src/Interpreters/ExternalDictionariesLoader.cpp
@@ -79,7 +79,7 @@ ExternalDictionariesLoader::DictPtr ExternalDictionariesLoader::getDictionary(co
     std::string resolved_dictionary_name = resolveDictionaryName(dictionary_name, local_context->getCurrentDatabase());
 
     if (local_context->hasQueryContext() && local_context->getSettingsRef().log_queries)
-        local_context->addQueryFactoriesInfo(Context::QueryLogFactories::Dictionary, resolved_dictionary_name);
+        local_context->getQueryContext()->addQueryFactoriesInfo(Context::QueryLogFactories::Dictionary, resolved_dictionary_name);
 
     return std::static_pointer_cast<const IDictionary>(load(resolved_dictionary_name));
 }
@@ -89,7 +89,7 @@ ExternalDictionariesLoader::DictPtr ExternalDictionariesLoader::tryGetDictionary
     std::string resolved_dictionary_name = resolveDictionaryName(dictionary_name, local_context->getCurrentDatabase());
 
     if (local_context->hasQueryContext() && local_context->getSettingsRef().log_queries)
-        local_context->addQueryFactoriesInfo(Context::QueryLogFactories::Dictionary, resolved_dictionary_name);
+        local_context->getQueryContext()->addQueryFactoriesInfo(Context::QueryLogFactories::Dictionary, resolved_dictionary_name);
 
     return std::static_pointer_cast<const IDictionary>(tryLoad(resolved_dictionary_name));
 }

--- a/tests/queries/0_stateless/03148_query_log_used_dictionaries.reference
+++ b/tests/queries/0_stateless/03148_query_log_used_dictionaries.reference
@@ -1,4 +1,4 @@
-simple_with_analyzer	1
-nested_with_analyzer	1
-simple_without_analyzer	1
-nested_without_analyzer	1
+simple_with_analyzer	['default.03148_dictionary']
+nested_with_analyzer	['default.03148_dictionary']
+simple_without_analyzer	['default.03148_dictionary']
+nested_without_analyzer	['default.03148_dictionary']

--- a/tests/queries/0_stateless/03148_query_log_used_dictionaries.reference
+++ b/tests/queries/0_stateless/03148_query_log_used_dictionaries.reference
@@ -1,0 +1,4 @@
+simple_with_analyzer	1
+nested_with_analyzer	1
+simple_without_analyzer	1
+nested_without_analyzer	1

--- a/tests/queries/0_stateless/03148_query_log_used_dictionaries.sql
+++ b/tests/queries/0_stateless/03148_query_log_used_dictionaries.sql
@@ -21,7 +21,7 @@ FORMAT Null;
 
 SYSTEM FLUSH LOGS;
 
-SELECT 'simple_with_analyzer', length(used_dictionaries) as used_dictionaries_qty
+SELECT log_comment, used_dictionaries
 FROM system.query_log
 WHERE current_database = currentDatabase()
   AND type = 'QueryFinish'
@@ -40,7 +40,7 @@ FORMAT Null;
 
 SYSTEM FLUSH LOGS;
 
-SELECT 'nested_with_analyzer', length(used_dictionaries) as used_dictionaries_qty
+SELECT log_comment, used_dictionaries
 FROM system.query_log
 WHERE current_database = currentDatabase()
   AND type = 'QueryFinish'
@@ -56,7 +56,7 @@ FORMAT Null;
 
 SYSTEM FLUSH LOGS;
 
-SELECT 'simple_without_analyzer', length(used_dictionaries) as used_dictionaries_qty
+SELECT log_comment, used_dictionaries
 FROM system.query_log
 WHERE current_database = currentDatabase()
   AND type = 'QueryFinish'
@@ -75,7 +75,7 @@ FORMAT Null;
 
 SYSTEM FLUSH LOGS;
 
-SELECT 'nested_without_analyzer', length(used_dictionaries) as used_dictionaries_qty
+SELECT log_comment, used_dictionaries
 FROM system.query_log
 WHERE current_database = currentDatabase()
   AND type = 'QueryFinish'

--- a/tests/queries/0_stateless/03148_query_log_used_dictionaries.sql
+++ b/tests/queries/0_stateless/03148_query_log_used_dictionaries.sql
@@ -1,0 +1,84 @@
+DROP DICTIONARY IF EXISTS 03148_dictionary;
+
+CREATE DICTIONARY 03148_dictionary (
+    id UInt64,
+    name String
+)
+PRIMARY KEY id
+SOURCE(CLICKHOUSE(
+    QUERY 'select 0 as id, ''name0'' as name'
+))
+LIFETIME(MIN 1 MAX 10)
+LAYOUT(HASHED);
+
+SELECT
+    dictGet('03148_dictionary', 'name', number) as dict_value
+FROM numbers(1)
+SETTINGS
+    allow_experimental_analyzer = 1,
+    log_comment = 'simple_with_analyzer'
+FORMAT Null;
+
+SYSTEM FLUSH LOGS;
+
+SELECT 'simple_with_analyzer', length(used_dictionaries) as used_dictionaries_qty
+FROM system.query_log
+WHERE current_database = currentDatabase()
+  AND type = 'QueryFinish'
+  AND log_comment = 'simple_with_analyzer';
+
+SELECT *
+FROM (
+    SELECT
+        dictGet('03148_dictionary', 'name', number) as dict_value
+    FROM numbers(1)
+) t
+SETTINGS
+    allow_experimental_analyzer = 1,
+    log_comment = 'nested_with_analyzer'
+FORMAT Null;
+
+SYSTEM FLUSH LOGS;
+
+SELECT 'nested_with_analyzer', length(used_dictionaries) as used_dictionaries_qty
+FROM system.query_log
+WHERE current_database = currentDatabase()
+  AND type = 'QueryFinish'
+  AND log_comment = 'nested_with_analyzer';
+
+SELECT
+    dictGet('03148_dictionary', 'name', number) as dict_value
+FROM numbers(1)
+SETTINGS
+    allow_experimental_analyzer = 0,
+    log_comment = 'simple_without_analyzer'
+FORMAT Null;
+
+SYSTEM FLUSH LOGS;
+
+SELECT 'simple_without_analyzer', length(used_dictionaries) as used_dictionaries_qty
+FROM system.query_log
+WHERE current_database = currentDatabase()
+  AND type = 'QueryFinish'
+  AND log_comment = 'simple_without_analyzer';
+
+SELECT *
+FROM (
+    SELECT
+        dictGet('03148_dictionary', 'name', number) as dict_value
+    FROM numbers(1)
+) t
+SETTINGS
+    allow_experimental_analyzer = 0,
+    log_comment = 'nested_without_analyzer'
+FORMAT Null;
+
+SYSTEM FLUSH LOGS;
+
+SELECT 'nested_without_analyzer', length(used_dictionaries) as used_dictionaries_qty
+FROM system.query_log
+WHERE current_database = currentDatabase()
+  AND type = 'QueryFinish'
+  AND log_comment = 'nested_without_analyzer';
+
+DROP DICTIONARY IF EXISTS 03148_dictionary;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix `system.query_log.used_dictionaries` logging

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

<details>
    <summary>Modify your CI run</summary>

**NOTE:** If your merge the PR with modified CI you **MUST KNOW** what you are doing
**NOTE:** Checked options will be applied if set before CI RunConfig/PrepareRunConfig step

#### Include tests (required builds will be added automatically):
- [ ] <!---ci_include_fast--> Fast test
- [ ] <!---ci_include_integration--> Integration Tests
- [ ] <!---ci_include_stateless--> Stateless tests
- [ ] <!---ci_include_stateful--> Stateful tests
- [ ] <!---ci_include_unit--> Unit tests
- [ ] <!---ci_include_performance--> Performance tests
- [ ] <!---ci_include_asan--> All with ASAN
- [ ] <!---ci_include_tsan--> All with TSAN
- [ ] <!---ci_include_analyzer--> All with Analyzer
- [ ] <!---ci_include_azure --> All with Azure
- [ ] <!---ci_include_KEYWORD--> Add your option here

#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [ ] <!---ci_exclude_tsan--> All with TSAN
- [ ] <!---ci_exclude_msan--> All with MSAN
- [ ] <!---ci_exclude_ubsan--> All with UBSAN
- [ ] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64--> All with Aarch64
- [ ] <!---ci_exclude_KEYWORD--> Add your option here

#### Extra options:
- [ ] <!---do_not_test--> do not test (only style check)
- [ ] <!---no_merge_commit--> disable merge-commit (no merge from master before tests)
- [ ] <!---no_ci_cache--> disable CI cache (job reuse)

#### Only specified batches in multi-batch jobs:
- [ ] <!---batch_0--> 1
- [ ] <!---batch_1--> 2
- [ ] <!---batch_2--> 3
- [ ] <!---batch_3--> 4

</details>

Closes #58843

Note: used_dictionaries now contains fully qualified object names for SQL-created dictionaries (instead of UUIDs). This part can be reverted if current behaviour with logging dictionary UUIDs is preferrable.