### PR TITLE
Make `MergeTreePrefetchedReadPool` safer

### DIFF
--- a/src/Storages/MergeTree/MergeTreePrefetchedReadPool.cpp
+++ b/src/Storages/MergeTree/MergeTreePrefetchedReadPool.cpp
@@ -46,49 +46,30 @@ bool MergeTreePrefetchedReadPool::TaskHolder::operator<(const TaskHolder & other
 }
 
 
-MergeTreePrefetchedReadPool::PrefetchedReaders::~PrefetchedReaders()
-{
-    for (auto & prefetch_future : prefetch_futures)
-        if (prefetch_future.valid())
-            prefetch_future.wait();
-}
-
 MergeTreePrefetchedReadPool::PrefetchedReaders::PrefetchedReaders(
+    ThreadPool & pool,
     MergeTreeReadTask::Readers readers_,
     Priority priority_,
-    MergeTreePrefetchedReadPool & pool_)
+    MergeTreePrefetchedReadPool & read_prefetch)
     : is_valid(true)
     , readers(std::move(readers_))
+    , prefetch_runner(pool, "Prefetch")
 {
-    try
+    prefetch_runner(read_prefetch.createPrefetchedTask(readers.main.get(), priority_));
+
+    for (const auto & reader : readers.prewhere)
+        prefetch_runner(read_prefetch.createPrefetchedTask(reader.get(), priority_));
+
+    fiu_do_on(FailPoints::prefetched_reader_pool_failpoint,
     {
-        prefetch_futures.reserve(1 + readers.prewhere.size());
-
-        prefetch_futures.push_back(pool_.createPrefetchedFuture(readers.main.get(), priority_));
-
-        for (const auto & reader : readers.prewhere)
-            prefetch_futures.push_back(pool_.createPrefetchedFuture(reader.get(), priority_));
-
-        fiu_do_on(FailPoints::prefetched_reader_pool_failpoint,
-        {
-            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Failpoint for prefetched reader enabled");
-        });
-    }
-    catch (...) /// in case of memory exceptions we have to wait
-    {
-        for (auto & prefetch_future : prefetch_futures)
-            if (prefetch_future.valid())
-                prefetch_future.wait();
-
-        throw;
-    }
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Failpoint for prefetched reader enabled");
+    });
 }
 
 void MergeTreePrefetchedReadPool::PrefetchedReaders::wait()
 {
     ProfileEventTimeIncrement<Microseconds> watch(ProfileEvents::WaitPrefetchTaskMicroseconds);
-    for (auto & prefetch_future : prefetch_futures)
-        prefetch_future.wait();
+    prefetch_runner.waitForAllToFinish();
 }
 
 MergeTreeReadTask::Readers MergeTreePrefetchedReadPool::PrefetchedReaders::get()
@@ -96,13 +77,7 @@ MergeTreeReadTask::Readers MergeTreePrefetchedReadPool::PrefetchedReaders::get()
     SCOPE_EXIT({ is_valid = false; });
     ProfileEventTimeIncrement<Microseconds> watch(ProfileEvents::WaitPrefetchTaskMicroseconds);
 
-    /// First wait for completion of all futures.
-    for (auto & prefetch_future : prefetch_futures)
-        prefetch_future.wait();
-
-    /// Then rethrow first exception if any.
-    for (auto & prefetch_future : prefetch_futures)
-        prefetch_future.get();
+    prefetch_runner.waitForAllToFinishAndRethrowFirstError();
 
     return std::move(readers);
 }
@@ -139,7 +114,7 @@ MergeTreePrefetchedReadPool::MergeTreePrefetchedReadPool(
     fillPerThreadTasks(pool_settings.threads, pool_settings.sum_marks);
 }
 
-std::future<void> MergeTreePrefetchedReadPool::createPrefetchedFuture(IMergeTreeReader * reader, Priority priority)
+std::function<void()> MergeTreePrefetchedReadPool::createPrefetchedTask(IMergeTreeReader * reader, Priority priority)
 {
     /// In order to make a prefetch we need to wait for marks to be loaded. But we just created
     /// a reader (which starts loading marks in its constructor), then if we do prefetch right
@@ -147,14 +122,12 @@ std::future<void> MergeTreePrefetchedReadPool::createPrefetchedFuture(IMergeTree
     /// only inside this MergeTreePrefetchedReadPool, where read tasks are created and distributed,
     /// and we cannot block either, therefore make prefetch inside the pool and put the future
     /// into the thread task. When a thread calls getTask(), it will wait for it is not ready yet.
-    auto task = [=, context = getContext()]() mutable
+    return [=, context = getContext()]() mutable
     {
         /// For async read metrics in system.query_log.
         PrefetchIncrement watch(context->getAsyncReadCounters());
         reader->prefetchBeginOfRange(priority);
     };
-
-    return scheduleFromThreadPoolUnsafe<void>(std::move(task), prefetch_threadpool, "ReadPrepare", priority);
 }
 
 void MergeTreePrefetchedReadPool::createPrefetchedReadersForTask(ThreadTask & task)
@@ -164,7 +137,7 @@ void MergeTreePrefetchedReadPool::createPrefetchedReadersForTask(ThreadTask & ta
 
     auto extras = getExtras();
     auto readers = MergeTreeReadTask::createReaders(task.read_info, extras, task.ranges);
-    task.readers_future = std::make_unique<PrefetchedReaders>(std::move(readers), task.priority, *this);
+    task.readers_future = std::make_unique<PrefetchedReaders>(prefetch_threadpool, std::move(readers), task.priority, *this);
 }
 
 void MergeTreePrefetchedReadPool::startPrefetches()

--- a/src/Storages/MergeTree/MergeTreePrefetchedReadPool.cpp
+++ b/src/Storages/MergeTree/MergeTreePrefetchedReadPool.cpp
@@ -53,7 +53,7 @@ MergeTreePrefetchedReadPool::PrefetchedReaders::PrefetchedReaders(
     MergeTreePrefetchedReadPool & read_prefetch)
     : is_valid(true)
     , readers(std::move(readers_))
-    , prefetch_runner(pool, "Prefetch")
+    , prefetch_runner(pool, "ReadPrepare")
 {
     prefetch_runner(read_prefetch.createPrefetchedTask(readers.main.get(), priority_));
 

--- a/src/Storages/MergeTree/MergeTreeReadPoolBase.cpp
+++ b/src/Storages/MergeTree/MergeTreeReadPoolBase.cpp
@@ -6,6 +6,11 @@
 namespace DB
 {
 
+namespace ErrorCodes
+{
+    extern const int LOGICAL_ERROR;
+}
+
 MergeTreeReadPoolBase::MergeTreeReadPoolBase(
     RangesInDataParts && parts_,
     VirtualFields shared_virtual_fields_,
@@ -48,6 +53,19 @@ void MergeTreeReadPoolBase::fillPerPartInfos()
         MergeTreeReadTaskInfo read_task_info;
 
         read_task_info.data_part = part_with_ranges.data_part;
+
+        const auto & data_part = read_task_info.data_part;
+        if (data_part->isProjectionPart())
+        {
+            read_task_info.parent_part = data_part->storage.getPartIfExists(
+                data_part->getParentPartName(),
+                {MergeTreeDataPartState::PreActive, MergeTreeDataPartState::Active, MergeTreeDataPartState::Outdated});
+
+            if (!read_task_info.parent_part)
+                throw Exception(ErrorCodes::LOGICAL_ERROR, "Did not find parent part {} for projection part {}",
+                            data_part->getParentPartName(), data_part->getDataPartStorage().getFullPath());
+        }
+
         read_task_info.part_index_in_query = part_with_ranges.part_index_in_query;
         read_task_info.alter_conversions = part_with_ranges.alter_conversions;
 

--- a/src/Storages/MergeTree/MergeTreeReadTask.h
+++ b/src/Storages/MergeTree/MergeTreeReadTask.h
@@ -56,6 +56,8 @@ struct MergeTreeReadTaskInfo
 {
     /// Data part which should be read while performing this task
     DataPartPtr data_part;
+    /// Parent part of the projection part
+    DataPartPtr parent_part;
     /// For `part_index` virtual column
     size_t part_index_in_query;
     /// Alter converversionss that should be applied on-fly for part.


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Avoid segafult in `MergeTreePrefetchedReadPool` while fetching projection parts.

I used `ThreadPoolCallbackRunnerLocal` to make it safer in general and I added parent part to `MergeTreeReadTaskInfo` in case we need to access it while reading a projection part.

Based on my understanding, we don't keep snapshot of all parts throughout the query execution but only up to initialization. https://github.com/ClickHouse/ClickHouse/blob/master/src/Processors/QueryPlan/ReadFromMergeTree.cpp#L1978


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

<details>
    <summary>Modify your CI run</summary>

**NOTE:** If your merge the PR with modified CI you **MUST KNOW** what you are doing
**NOTE:** Checked options will be applied if set before CI RunConfig/PrepareRunConfig step

#### Include tests (required builds will be added automatically):
- [ ] <!---ci_include_fast--> Fast test
- [ ] <!---ci_include_integration--> Integration Tests
- [ ] <!---ci_include_stateless--> Stateless tests
- [ ] <!---ci_include_stateful--> Stateful tests
- [ ] <!---ci_include_unit--> Unit tests
- [ ] <!---ci_include_performance--> Performance tests
- [ ] <!---ci_include_asan--> All with ASAN
- [ ] <!---ci_include_tsan--> All with TSAN
- [ ] <!---ci_include_analyzer--> All with Analyzer
- [ ] <!---ci_include_azure --> All with Azure
- [ ] <!---ci_include_KEYWORD--> Add your option here

#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [ ] <!---ci_exclude_tsan--> All with TSAN
- [ ] <!---ci_exclude_msan--> All with MSAN
- [ ] <!---ci_exclude_ubsan--> All with UBSAN
- [ ] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64--> All with Aarch64
- [ ] <!---ci_exclude_KEYWORD--> Add your option here

#### Extra options:
- [ ] <!---do_not_test--> do not test (only style check)
- [ ] <!---no_merge_commit--> disable merge-commit (no merge from master before tests)
- [ ] <!---no_ci_cache--> disable CI cache (job reuse)

#### Only specified batches in multi-batch jobs:
- [ ] <!---batch_0--> 1
- [ ] <!---batch_1--> 2
- [ ] <!---batch_2--> 3
- [ ] <!---batch_3--> 4

<details>
