### PR TITLE
[feature] A setting `http_response_headers`

### DIFF
--- a/docs/en/interfaces/http.md
+++ b/docs/en/interfaces/http.md
@@ -508,7 +508,7 @@ Now `rule` can configure `method`, `headers`, `url`, `handler`:
 
 - `headers` are responsible for matching the header part of the HTTP request. It is compatible with RE2’s regular expressions. It is an optional configuration. If it is not defined in the configuration file, it does not match the header portion of the HTTP request.
 
-- `handler` contains the main processing part. Now `handler` can configure `type`, `status`, `content_type`, `response_content`, `query`, `query_param_name`.
+- `handler` contains the main processing part. Now `handler` can configure `type`, `status`, `content_type`, `http_response_headers`, `response_content`, `query`, `query_param_name`.
     `type` currently supports three types: [predefined_query_handler](#predefined_query_handler), [dynamic_query_handler](#dynamic_query_handler), [static](#static).
 
     - `query` — use with `predefined_query_handler` type, executes query when the handler is called.
@@ -518,6 +518,8 @@ Now `rule` can configure `method`, `headers`, `url`, `handler`:
     - `status` — use with `static` type, response status code.
 
     - `content_type` — use with any type, response [content-type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type).
+
+    - `http_response_headers` — use with any type, response headers map. Could be used to set content type as well.
 
     - `response_content` — use with `static` type, response content sent to client, when using the prefix ‘file://’ or ‘config://’, find the content from the file or configuration sends to client.
 
@@ -616,6 +618,33 @@ Return a message.
                 <type>static</type>
                 <status>402</status>
                 <content_type>text/html; charset=UTF-8</content_type>
+                <http_response_headers>
+                    <Content-Language>en</Content-Language>
+                    <X-My-Custom-Header>43</X-My-Custom-Header>
+                </http_response_headers>
+                <response_content>Say Hi!</response_content>
+            </handler>
+        </rule>
+        <defaults/>
+</http_handlers>
+```
+
+`http_response_headers` could be used to set content type instead of `content_type`.
+
+``` xml
+<http_handlers>
+        <rule>
+            <methods>GET</methods>
+            <headers><XXX>xxx</XXX></headers>
+            <url>/hi</url>
+            <handler>
+                <type>static</type>
+                <status>402</status>
+                <http_response_headers>
+                    <Content-Type>text/html; charset=UTF-8</Content-Type>
+                    <Content-Language>en</Content-Language>
+                    <X-My-Custom-Header>43</X-My-Custom-Header>
+                </http_response_headers>
                 <response_content>Say Hi!</response_content>
             </handler>
         </rule>
@@ -696,6 +725,9 @@ Find the content from the file send to client.
             <handler>
                 <type>static</type>
                 <content_type>text/html; charset=UTF-8</content_type>
+                <http_response_headers>
+                    <ETag>737060cd8c284d8af7ad3082f209582d</ETag>
+                </http_response_headers>
                 <response_content>file:///absolute_path_file.html</response_content>
             </handler>
         </rule>
@@ -706,6 +738,9 @@ Find the content from the file send to client.
             <handler>
                 <type>static</type>
                 <content_type>text/html; charset=UTF-8</content_type>
+                <http_response_headers>
+                    <ETag>737060cd8c284d8af7ad3082f209582d</ETag>
+                </http_response_headers>
                 <response_content>file://./relative_path_file.html</response_content>
             </handler>
         </rule>

--- a/docs/ru/interfaces/http.md
+++ b/docs/ru/interfaces/http.md
@@ -414,6 +414,8 @@ $ curl -v 'http://localhost:8123/predefined_query'
 
     -   `content_type` — используется со всеми типами, возвращает [content-type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type).
 
+    -   `http_response_headers` — используется со всеми типами чтобы добавить кастомные хедеры в ответ. Может использоваться в том числе для задания хедера `Content-Type` вместо `content_type`.
+
     -   `response_content` — используется с типом`static`, содержимое ответа, отправленное клиенту, при использовании префикса ‘file://’ or ‘config://’, находит содержимое из файла или конфигурации, отправленного клиенту.
 
 Далее приведены методы настройки для различных типов.
@@ -509,6 +511,33 @@ max_final_threads   2
                 <type>static</type>
                 <status>402</status>
                 <content_type>text/html; charset=UTF-8</content_type>
+                <http_response_headers>
+                    <Content-Language>en</Content-Language>
+                    <X-My-Custom-Header>43</X-My-Custom-Header>
+                </http_response_headers>
+                <response_content>Say Hi!</response_content>
+            </handler>
+        </rule>
+        <defaults/>
+</http_handlers>
+```
+
+`http_response_headers` так же может использоваться для определения `Content-Type` вместо `content_type`.
+
+``` xml
+<http_handlers>
+        <rule>
+            <methods>GET</methods>
+            <headers><XXX>xxx</XXX></headers>
+            <url>/hi</url>
+            <handler>
+                <type>static</type>
+                <status>402</status>
+                <http_response_headers>
+                    <Content-Type>text/html; charset=UTF-8</Content-Type>
+                    <Content-Language>en</Content-Language>
+                    <X-My-Custom-Header>43</X-My-Custom-Header>
+                </http_response_headers>
                 <response_content>Say Hi!</response_content>
             </handler>
         </rule>
@@ -589,6 +618,9 @@ $ curl -v  -H 'XXX:xxx' 'http://localhost:8123/get_config_static_handler'
             <handler>
                 <type>static</type>
                 <content_type>text/html; charset=UTF-8</content_type>
+                <http_response_headers>
+                    <ETag>737060cd8c284d8af7ad3082f209582d</ETag>
+                </http_response_headers>
                 <response_content>file:///absolute_path_file.html</response_content>
             </handler>
         </rule>
@@ -599,6 +631,9 @@ $ curl -v  -H 'XXX:xxx' 'http://localhost:8123/get_config_static_handler'
             <handler>
                 <type>static</type>
                 <content_type>text/html; charset=UTF-8</content_type>
+                <http_response_headers>
+                    <ETag>737060cd8c284d8af7ad3082f209582d</ETag>
+                </http_response_headers>
                 <response_content>file://./relative_path_file.html</response_content>
             </handler>
         </rule>

--- a/src/Server/HTTPHandler.cpp
+++ b/src/Server/HTTPHandler.cpp
@@ -287,7 +287,7 @@ static std::chrono::steady_clock::duration parseSessionTimeout(const Poco::Util:
 }
 
 std::optional<std::unordered_map<String, String>>
-parseHttpResponseHeaders(const Poco::Util::AbstractConfiguration & config, const std::string & config_prefix);
+parseHTTPResponseHeaders(const Poco::Util::AbstractConfiguration & config, const std::string & config_prefix);
 
 void HTTPHandler::pushDelayedResults(Output & used_output)
 {
@@ -1346,7 +1346,7 @@ std::string PredefinedQueryHandler::getQuery(HTTPServerRequest & request, HTMLFo
 }
 
 std::optional<std::unordered_map<String, String>>
-parseHttpResponseHeaders(const Poco::Util::AbstractConfiguration & config, const std::string & config_prefix)
+parseHTTPResponseHeaders(const Poco::Util::AbstractConfiguration & config, const std::string & config_prefix)
 {
     std::unordered_map<String, String> http_response_headers_override;
     String http_response_headers_key = config_prefix + ".handler.http_response_headers";
@@ -1354,7 +1354,7 @@ parseHttpResponseHeaders(const Poco::Util::AbstractConfiguration & config, const
     if (config.has(http_response_headers_key))
     {
         Poco::Util::AbstractConfiguration::Keys keys;
-        config.keys(config_prefix + ".handler.http_response_headers", keys);
+        config.keys(http_response_headers_key, keys);
         for (const auto & key : keys)
             http_response_headers_override[key] = config.getString(http_response_headers_key_prefix + key);
     }
@@ -1372,7 +1372,7 @@ createDynamicHandlerFactory(IServer & server, const Poco::Util::AbstractConfigur
 {
     auto query_param_name = config.getString(config_prefix + ".handler.query_param_name", "query");
 
-    std::optional<std::unordered_map<String, String>> http_response_headers_override = parseHttpResponseHeaders(config, config_prefix);
+    std::optional<std::unordered_map<String, String>> http_response_headers_override = parseHTTPResponseHeaders(config, config_prefix);
 
     auto creator = [&server, query_param_name, http_response_headers_override]() -> std::unique_ptr<DynamicQueryHandler>
     { return std::make_unique<DynamicQueryHandler>(server, query_param_name, http_response_headers_override); };
@@ -1436,7 +1436,7 @@ createPredefinedHandlerFactory(IServer & server, const Poco::Util::AbstractConfi
             headers_name_with_regex.emplace(std::make_pair(header_name, regex));
     }
 
-    std::optional<std::unordered_map<String, String>> http_response_headers_override = parseHttpResponseHeaders(config, config_prefix);
+    std::optional<std::unordered_map<String, String>> http_response_headers_override = parseHTTPResponseHeaders(config, config_prefix);
 
     std::shared_ptr<HandlingRuleHTTPHandlerFactory<PredefinedQueryHandler>> factory;
 

--- a/src/Server/HTTPHandler.cpp
+++ b/src/Server/HTTPHandler.cpp
@@ -900,10 +900,9 @@ void HTTPHandler::processQuery(
     customizeContext(request, context, *in_post_maybe_compressed);
     in = has_external_data ? std::move(in_param) : std::make_unique<ConcatReadBuffer>(*in_param, *in_post_maybe_compressed);
 
-    if (http_response_headers_override) {
+    if (http_response_headers_override)
         for (auto [header_name, header_value] : *http_response_headers_override)
             response.set(header_name, header_value);
-    }
 
     auto set_query_result = [this, &response](const QueryResultDetails & details)
     {

--- a/src/Server/HTTPHandler.cpp
+++ b/src/Server/HTTPHandler.cpp
@@ -1,8 +1,8 @@
 #include <Server/HTTPHandler.h>
 
+#include <Access/AccessControl.h>
 #include <Access/Authentication.h>
 #include <Access/Credentials.h>
-#include <Access/AccessControl.h>
 #include <Access/ExternalAuthenticators.h>
 #include <Access/Role.h>
 #include <Access/User.h>
@@ -10,6 +10,7 @@
 #include <Compression/CompressedWriteBuffer.h>
 #include <Core/ExternalTable.h>
 #include <Disks/StoragePolicy.h>
+#include <Formats/FormatFactory.h>
 #include <IO/CascadeWriteBuffer.h>
 #include <IO/ConcatReadBuffer.h>
 #include <IO/MemoryReadWriteBuffer.h>
@@ -17,46 +18,47 @@
 #include <IO/WriteHelpers.h>
 #include <IO/copyData.h>
 #include <Interpreters/Context.h>
-#include <Interpreters/TemporaryDataOnDisk.h>
-#include <Parsers/QueryParameterVisitor.h>
-#include <Interpreters/executeQuery.h>
 #include <Interpreters/Session.h>
+#include <Interpreters/TemporaryDataOnDisk.h>
+#include <Interpreters/executeQuery.h>
+#include <Parsers/ASTSetQuery.h>
+#include <Parsers/QueryParameterVisitor.h>
+#include <Processors/Formats/IOutputFormat.h>
 #include <Server/HTTPHandlerFactory.h>
 #include <Server/HTTPHandlerRequestFilter.h>
 #include <Server/IServer.h>
-#include <Common/logger_useful.h>
 #include <Common/SettingsChanges.h>
 #include <Common/StringUtils.h>
 #include <Common/scope_guard_safe.h>
 #include <Common/setThreadName.h>
 #include <Common/typeid_cast.h>
-#include <Common/re2.h>
-#include <Parsers/ASTSetQuery.h>
-#include <Processors/Formats/IOutputFormat.h>
-#include <Formats/FormatFactory.h>
 
+#include <Server/HTTP/HTTPResponse.h>
 #include <base/getFQDNOrHostName.h>
 #include <base/scope_guard.h>
-#include <Server/HTTP/HTTPResponse.h>
 
 #include "config.h"
 
 #include <Poco/Base64Decoder.h>
 #include <Poco/Base64Encoder.h>
-#include <Poco/Net/HTTPBasicCredentials.h>
-#include <Poco/Net/HTTPStream.h>
 #include <Poco/MemoryStream.h>
+#include <Poco/Net/HTTPBasicCredentials.h>
+#include <Poco/Net/HTTPMessage.h>
+#include <Poco/Net/HTTPStream.h>
+#include <Poco/Net/SocketAddress.h>
 #include <Poco/StreamCopier.h>
 #include <Poco/String.h>
-#include <Poco/Net/SocketAddress.h>
 
 #include <algorithm>
 #include <chrono>
 #include <memory>
+#include <optional>
 #include <sstream>
+#include <unordered_map>
+#include <utility>
 
 #if USE_SSL
-#include <Poco/Net/X509Certificate.h>
+#    include <Poco/Net/X509Certificate.h>
 #endif
 
 
@@ -65,68 +67,68 @@ namespace DB
 
 namespace ErrorCodes
 {
-    extern const int BAD_ARGUMENTS;
-    extern const int LOGICAL_ERROR;
-    extern const int CANNOT_COMPILE_REGEXP;
-    extern const int CANNOT_OPEN_FILE;
-    extern const int CANNOT_PARSE_TEXT;
-    extern const int CANNOT_PARSE_ESCAPE_SEQUENCE;
-    extern const int CANNOT_PARSE_QUOTED_STRING;
-    extern const int CANNOT_PARSE_DATE;
-    extern const int CANNOT_PARSE_DATETIME;
-    extern const int CANNOT_PARSE_NUMBER;
-    extern const int CANNOT_PARSE_DOMAIN_VALUE_FROM_STRING;
-    extern const int CANNOT_PARSE_IPV4;
-    extern const int CANNOT_PARSE_IPV6;
-    extern const int CANNOT_PARSE_UUID;
-    extern const int CANNOT_PARSE_INPUT_ASSERTION_FAILED;
-    extern const int CANNOT_SCHEDULE_TASK;
-    extern const int DUPLICATE_COLUMN;
-    extern const int ILLEGAL_COLUMN;
-    extern const int THERE_IS_NO_COLUMN;
-    extern const int UNKNOWN_ELEMENT_IN_AST;
-    extern const int UNKNOWN_TYPE_OF_AST_NODE;
-    extern const int TOO_DEEP_AST;
-    extern const int TOO_BIG_AST;
-    extern const int UNEXPECTED_AST_STRUCTURE;
-    extern const int VALUE_IS_OUT_OF_RANGE_OF_DATA_TYPE;
+extern const int BAD_ARGUMENTS;
+extern const int LOGICAL_ERROR;
+extern const int CANNOT_SCHEDULE_TASK;
+extern const int CANNOT_PARSE_TEXT;
+extern const int CANNOT_PARSE_ESCAPE_SEQUENCE;
+extern const int CANNOT_PARSE_QUOTED_STRING;
+extern const int CANNOT_PARSE_DATE;
+extern const int CANNOT_PARSE_DATETIME;
+extern const int CANNOT_PARSE_NUMBER;
+extern const int CANNOT_PARSE_DOMAIN_VALUE_FROM_STRING;
+extern const int CANNOT_PARSE_IPV4;
+extern const int CANNOT_PARSE_IPV6;
+extern const int CANNOT_PARSE_UUID;
+extern const int CANNOT_PARSE_INPUT_ASSERTION_FAILED;
+extern const int CANNOT_OPEN_FILE;
+extern const int CANNOT_COMPILE_REGEXP;
+extern const int DUPLICATE_COLUMN;
+extern const int ILLEGAL_COLUMN;
+extern const int THERE_IS_NO_COLUMN;
+extern const int UNKNOWN_ELEMENT_IN_AST;
+extern const int UNKNOWN_TYPE_OF_AST_NODE;
+extern const int TOO_DEEP_AST;
+extern const int TOO_BIG_AST;
+extern const int UNEXPECTED_AST_STRUCTURE;
+extern const int VALUE_IS_OUT_OF_RANGE_OF_DATA_TYPE;
 
-    extern const int SYNTAX_ERROR;
+extern const int SYNTAX_ERROR;
 
-    extern const int INCORRECT_DATA;
-    extern const int TYPE_MISMATCH;
+extern const int INCORRECT_DATA;
+extern const int TYPE_MISMATCH;
 
-    extern const int UNKNOWN_TABLE;
-    extern const int UNKNOWN_FUNCTION;
-    extern const int UNKNOWN_IDENTIFIER;
-    extern const int UNKNOWN_TYPE;
-    extern const int UNKNOWN_STORAGE;
-    extern const int UNKNOWN_DATABASE;
-    extern const int UNKNOWN_SETTING;
-    extern const int UNKNOWN_DIRECTION_OF_SORTING;
-    extern const int UNKNOWN_AGGREGATE_FUNCTION;
-    extern const int UNKNOWN_FORMAT;
-    extern const int UNKNOWN_DATABASE_ENGINE;
-    extern const int UNKNOWN_TYPE_OF_QUERY;
-    extern const int UNKNOWN_ROLE;
-    extern const int NO_ELEMENTS_IN_CONFIG;
+extern const int UNKNOWN_TABLE;
+extern const int UNKNOWN_FUNCTION;
+extern const int UNKNOWN_IDENTIFIER;
+extern const int UNKNOWN_TYPE;
+extern const int UNKNOWN_STORAGE;
+extern const int UNKNOWN_DATABASE;
+extern const int UNKNOWN_SETTING;
+extern const int UNKNOWN_DIRECTION_OF_SORTING;
+extern const int UNKNOWN_AGGREGATE_FUNCTION;
+extern const int UNKNOWN_FORMAT;
+extern const int UNKNOWN_DATABASE_ENGINE;
+extern const int UNKNOWN_TYPE_OF_QUERY;
+extern const int UNKNOWN_ROLE;
+extern const int NO_ELEMENTS_IN_CONFIG;
 
-    extern const int QUERY_IS_TOO_LARGE;
+extern const int QUERY_IS_TOO_LARGE;
 
-    extern const int NOT_IMPLEMENTED;
-    extern const int SOCKET_TIMEOUT;
+extern const int NOT_IMPLEMENTED;
+extern const int SOCKET_TIMEOUT;
 
-    extern const int UNKNOWN_USER;
-    extern const int WRONG_PASSWORD;
-    extern const int REQUIRED_PASSWORD;
-    extern const int AUTHENTICATION_FAILED;
-    extern const int SET_NON_GRANTED_ROLE;
+extern const int UNKNOWN_USER;
+extern const int WRONG_PASSWORD;
+extern const int REQUIRED_PASSWORD;
+extern const int AUTHENTICATION_FAILED;
+extern const int SET_NON_GRANTED_ROLE;
 
-    extern const int INVALID_SESSION_TIMEOUT;
-    extern const int HTTP_LENGTH_REQUIRED;
-    extern const int SUPPORT_IS_DISABLED;
+extern const int INVALID_SESSION_TIMEOUT;
+extern const int HTTP_LENGTH_REQUIRED;
+extern const int SUPPORT_IS_DISABLED;
 
-    extern const int TIMEOUT_EXCEEDED;
+extern const int TIMEOUT_EXCEEDED;
 }
 
 namespace
@@ -145,9 +147,9 @@ bool tryAddHTTPOptionHeadersFromConfig(HTTPServerResponse & response, const Poco
                 if (config.getString("http_options_response." + config_key + ".name", "").empty())
                     LOG_WARNING(getLogger("processOptionsRequest"), "Empty header was found in config. It will not be processed.");
                 else
-                    response.add(config.getString("http_options_response." + config_key + ".name", ""),
-                                 config.getString("http_options_response." + config_key + ".value", ""));
-
+                    response.add(
+                        config.getString("http_options_response." + config_key + ".name", ""),
+                        config.getString("http_options_response." + config_key + ".value", ""));
             }
         }
         return true;
@@ -196,54 +198,37 @@ static Poco::Net::HTTPResponse::HTTPStatus exceptionCodeToHTTPStatus(int excepti
     {
         return HTTPResponse::HTTP_UNAUTHORIZED;
     }
-    else if (exception_code == ErrorCodes::UNKNOWN_USER ||
-             exception_code == ErrorCodes::WRONG_PASSWORD ||
-             exception_code == ErrorCodes::AUTHENTICATION_FAILED ||
-             exception_code == ErrorCodes::SET_NON_GRANTED_ROLE)
+    else if (
+        exception_code == ErrorCodes::UNKNOWN_USER || exception_code == ErrorCodes::WRONG_PASSWORD
+        || exception_code == ErrorCodes::AUTHENTICATION_FAILED || exception_code == ErrorCodes::SET_NON_GRANTED_ROLE)
     {
         return HTTPResponse::HTTP_FORBIDDEN;
     }
-    else if (exception_code == ErrorCodes::BAD_ARGUMENTS ||
-             exception_code == ErrorCodes::CANNOT_COMPILE_REGEXP ||
-             exception_code == ErrorCodes::CANNOT_PARSE_TEXT ||
-             exception_code == ErrorCodes::CANNOT_PARSE_ESCAPE_SEQUENCE ||
-             exception_code == ErrorCodes::CANNOT_PARSE_QUOTED_STRING ||
-             exception_code == ErrorCodes::CANNOT_PARSE_DATE ||
-             exception_code == ErrorCodes::CANNOT_PARSE_DATETIME ||
-             exception_code == ErrorCodes::CANNOT_PARSE_NUMBER ||
-             exception_code == ErrorCodes::CANNOT_PARSE_DOMAIN_VALUE_FROM_STRING ||
-             exception_code == ErrorCodes::CANNOT_PARSE_IPV4 ||
-             exception_code == ErrorCodes::CANNOT_PARSE_IPV6 ||
-             exception_code == ErrorCodes::CANNOT_PARSE_INPUT_ASSERTION_FAILED ||
-             exception_code == ErrorCodes::CANNOT_PARSE_UUID ||
-             exception_code == ErrorCodes::DUPLICATE_COLUMN ||
-             exception_code == ErrorCodes::ILLEGAL_COLUMN ||
-             exception_code == ErrorCodes::UNKNOWN_ELEMENT_IN_AST ||
-             exception_code == ErrorCodes::UNKNOWN_TYPE_OF_AST_NODE ||
-             exception_code == ErrorCodes::THERE_IS_NO_COLUMN ||
-             exception_code == ErrorCodes::TOO_DEEP_AST ||
-             exception_code == ErrorCodes::TOO_BIG_AST ||
-             exception_code == ErrorCodes::UNEXPECTED_AST_STRUCTURE ||
-             exception_code == ErrorCodes::SYNTAX_ERROR ||
-             exception_code == ErrorCodes::INCORRECT_DATA ||
-             exception_code == ErrorCodes::TYPE_MISMATCH ||
-             exception_code == ErrorCodes::VALUE_IS_OUT_OF_RANGE_OF_DATA_TYPE)
+    else if (
+        exception_code == ErrorCodes::BAD_ARGUMENTS || exception_code == ErrorCodes::CANNOT_COMPILE_REGEXP
+        || exception_code == ErrorCodes::CANNOT_PARSE_TEXT || exception_code == ErrorCodes::CANNOT_PARSE_ESCAPE_SEQUENCE
+        || exception_code == ErrorCodes::CANNOT_PARSE_QUOTED_STRING || exception_code == ErrorCodes::CANNOT_PARSE_DATE
+        || exception_code == ErrorCodes::CANNOT_PARSE_DATETIME || exception_code == ErrorCodes::CANNOT_PARSE_NUMBER
+        || exception_code == ErrorCodes::CANNOT_PARSE_DOMAIN_VALUE_FROM_STRING || exception_code == ErrorCodes::CANNOT_PARSE_IPV4
+        || exception_code == ErrorCodes::CANNOT_PARSE_IPV6 || exception_code == ErrorCodes::CANNOT_PARSE_INPUT_ASSERTION_FAILED
+        || exception_code == ErrorCodes::CANNOT_PARSE_UUID || exception_code == ErrorCodes::DUPLICATE_COLUMN
+        || exception_code == ErrorCodes::ILLEGAL_COLUMN || exception_code == ErrorCodes::UNKNOWN_ELEMENT_IN_AST
+        || exception_code == ErrorCodes::UNKNOWN_TYPE_OF_AST_NODE || exception_code == ErrorCodes::THERE_IS_NO_COLUMN
+        || exception_code == ErrorCodes::TOO_DEEP_AST || exception_code == ErrorCodes::TOO_BIG_AST
+        || exception_code == ErrorCodes::UNEXPECTED_AST_STRUCTURE || exception_code == ErrorCodes::SYNTAX_ERROR
+        || exception_code == ErrorCodes::INCORRECT_DATA || exception_code == ErrorCodes::TYPE_MISMATCH
+        || exception_code == ErrorCodes::VALUE_IS_OUT_OF_RANGE_OF_DATA_TYPE)
     {
         return HTTPResponse::HTTP_BAD_REQUEST;
     }
-    else if (exception_code == ErrorCodes::UNKNOWN_TABLE ||
-             exception_code == ErrorCodes::UNKNOWN_FUNCTION ||
-             exception_code == ErrorCodes::UNKNOWN_IDENTIFIER ||
-             exception_code == ErrorCodes::UNKNOWN_TYPE ||
-             exception_code == ErrorCodes::UNKNOWN_STORAGE ||
-             exception_code == ErrorCodes::UNKNOWN_DATABASE ||
-             exception_code == ErrorCodes::UNKNOWN_SETTING ||
-             exception_code == ErrorCodes::UNKNOWN_DIRECTION_OF_SORTING ||
-             exception_code == ErrorCodes::UNKNOWN_AGGREGATE_FUNCTION ||
-             exception_code == ErrorCodes::UNKNOWN_FORMAT ||
-             exception_code == ErrorCodes::UNKNOWN_DATABASE_ENGINE ||
-             exception_code == ErrorCodes::UNKNOWN_TYPE_OF_QUERY ||
-             exception_code == ErrorCodes::UNKNOWN_ROLE)
+    else if (
+        exception_code == ErrorCodes::UNKNOWN_TABLE || exception_code == ErrorCodes::UNKNOWN_FUNCTION
+        || exception_code == ErrorCodes::UNKNOWN_IDENTIFIER || exception_code == ErrorCodes::UNKNOWN_TYPE
+        || exception_code == ErrorCodes::UNKNOWN_STORAGE || exception_code == ErrorCodes::UNKNOWN_DATABASE
+        || exception_code == ErrorCodes::UNKNOWN_SETTING || exception_code == ErrorCodes::UNKNOWN_DIRECTION_OF_SORTING
+        || exception_code == ErrorCodes::UNKNOWN_AGGREGATE_FUNCTION || exception_code == ErrorCodes::UNKNOWN_FORMAT
+        || exception_code == ErrorCodes::UNKNOWN_DATABASE_ENGINE || exception_code == ErrorCodes::UNKNOWN_TYPE_OF_QUERY
+        || exception_code == ErrorCodes::UNKNOWN_ROLE)
     {
         return HTTPResponse::HTTP_NOT_FOUND;
     }
@@ -255,8 +240,7 @@ static Poco::Net::HTTPResponse::HTTPStatus exceptionCodeToHTTPStatus(int excepti
     {
         return HTTPResponse::HTTP_NOT_IMPLEMENTED;
     }
-    else if (exception_code == ErrorCodes::SOCKET_TIMEOUT ||
-             exception_code == ErrorCodes::CANNOT_OPEN_FILE)
+    else if (exception_code == ErrorCodes::SOCKET_TIMEOUT || exception_code == ErrorCodes::CANNOT_OPEN_FILE)
     {
         return HTTPResponse::HTTP_SERVICE_UNAVAILABLE;
     }
@@ -277,9 +261,7 @@ static Poco::Net::HTTPResponse::HTTPStatus exceptionCodeToHTTPStatus(int excepti
 }
 
 
-static std::chrono::steady_clock::duration parseSessionTimeout(
-    const Poco::Util::AbstractConfiguration & config,
-    const HTMLForm & params)
+static std::chrono::steady_clock::duration parseSessionTimeout(const Poco::Util::AbstractConfiguration & config, const HTMLForm & params)
 {
     unsigned session_timeout = config.getInt("default_session_timeout", 60);
 
@@ -293,14 +275,19 @@ static std::chrono::steady_clock::duration parseSessionTimeout(
             throw Exception(ErrorCodes::INVALID_SESSION_TIMEOUT, "Invalid session timeout: '{}'", session_timeout_str);
 
         if (session_timeout > max_session_timeout)
-            throw Exception(ErrorCodes::INVALID_SESSION_TIMEOUT, "Session timeout '{}' is larger than max_session_timeout: {}. "
+            throw Exception(
+                ErrorCodes::INVALID_SESSION_TIMEOUT,
+                "Session timeout '{}' is larger than max_session_timeout: {}. "
                 "Maximum session timeout could be modified in configuration file.",
-                session_timeout_str, max_session_timeout);
+                session_timeout_str,
+                max_session_timeout);
     }
 
     return std::chrono::seconds(session_timeout);
 }
 
+std::optional<std::unordered_map<String, String>>
+parseHttpResponseHeaders(const Poco::Util::AbstractConfiguration & config, const std::string & config_prefix);
 
 void HTTPHandler::pushDelayedResults(Output & used_output)
 {
@@ -338,11 +325,12 @@ void HTTPHandler::pushDelayedResults(Output & used_output)
 }
 
 
-HTTPHandler::HTTPHandler(IServer & server_, const std::string & name, const std::optional<String> & content_type_override_)
+HTTPHandler::HTTPHandler(
+    IServer & server_, const std::string & name, const std::optional<std::unordered_map<String, String>> & http_response_headers_override_)
     : server(server_)
     , log(getLogger(name))
     , default_settings(server.context()->getSettingsRef())
-    , content_type_override(content_type_override_)
+    , http_response_headers_override(http_response_headers_override_)
 {
     server_display_name = server.config().getString("display_name", getFQDNOrHostName());
 }
@@ -353,10 +341,7 @@ HTTPHandler::HTTPHandler(IServer & server_, const std::string & name, const std:
 HTTPHandler::~HTTPHandler() = default;
 
 
-bool HTTPHandler::authenticateUser(
-    HTTPServerRequest & request,
-    HTMLForm & params,
-    HTTPServerResponse & response)
+bool HTTPHandler::authenticateUser(HTTPServerRequest & request, HTMLForm & params, HTTPServerResponse & response)
 {
     using namespace Poco::Net;
 
@@ -383,31 +368,36 @@ bool HTTPHandler::authenticateUser(
     {
         /// It is prohibited to mix different authorization schemes.
         if (has_http_credentials)
-            throw Exception(ErrorCodes::AUTHENTICATION_FAILED,
-                            "Invalid authentication: it is not allowed "
-                            "to use SSL certificate authentication and Authorization HTTP header simultaneously");
+            throw Exception(
+                ErrorCodes::AUTHENTICATION_FAILED,
+                "Invalid authentication: it is not allowed "
+                "to use SSL certificate authentication and Authorization HTTP header simultaneously");
         if (has_credentials_in_query_params)
-            throw Exception(ErrorCodes::AUTHENTICATION_FAILED,
-                            "Invalid authentication: it is not allowed "
-                            "to use SSL certificate authentication and authentication via parameters simultaneously simultaneously");
+            throw Exception(
+                ErrorCodes::AUTHENTICATION_FAILED,
+                "Invalid authentication: it is not allowed "
+                "to use SSL certificate authentication and authentication via parameters simultaneously simultaneously");
 
         if (has_ssl_certificate_auth)
         {
 #if USE_SSL
             if (!password.empty())
-                throw Exception(ErrorCodes::AUTHENTICATION_FAILED,
-                                "Invalid authentication: it is not allowed "
-                                "to use SSL certificate authentication and authentication via password simultaneously");
+                throw Exception(
+                    ErrorCodes::AUTHENTICATION_FAILED,
+                    "Invalid authentication: it is not allowed "
+                    "to use SSL certificate authentication and authentication via password simultaneously");
 
             if (request.havePeerCertificate())
                 certificate_common_name = request.peerCertificate().commonName();
 
             if (certificate_common_name.empty())
-                throw Exception(ErrorCodes::AUTHENTICATION_FAILED,
-                                "Invalid authentication: SSL certificate authentication requires nonempty certificate's Common Name");
+                throw Exception(
+                    ErrorCodes::AUTHENTICATION_FAILED,
+                    "Invalid authentication: SSL certificate authentication requires nonempty certificate's Common Name");
 #else
-            throw Exception(ErrorCodes::SUPPORT_IS_DISABLED,
-                            "SSL certificate authentication disabled because ClickHouse was built without SSL library");
+            throw Exception(
+                ErrorCodes::SUPPORT_IS_DISABLED,
+                "SSL certificate authentication disabled because ClickHouse was built without SSL library");
 #endif
         }
     }
@@ -415,9 +405,10 @@ bool HTTPHandler::authenticateUser(
     {
         /// It is prohibited to mix different authorization schemes.
         if (has_credentials_in_query_params)
-            throw Exception(ErrorCodes::AUTHENTICATION_FAILED,
-                            "Invalid authentication: it is not allowed "
-                            "to use Authorization HTTP header and authentication via parameters simultaneously");
+            throw Exception(
+                ErrorCodes::AUTHENTICATION_FAILED,
+                "Invalid authentication: it is not allowed "
+                "to use Authorization HTTP header and authentication via parameters simultaneously");
 
         std::string scheme;
         std::string auth_info;
@@ -438,7 +429,8 @@ bool HTTPHandler::authenticateUser(
         }
         else
         {
-            throw Exception(ErrorCodes::AUTHENTICATION_FAILED, "Invalid authentication: '{}' HTTP Authorization scheme is not supported", scheme);
+            throw Exception(
+                ErrorCodes::AUTHENTICATION_FAILED, "Invalid authentication: '{}' HTTP Authorization scheme is not supported", scheme);
         }
     }
     else
@@ -464,7 +456,8 @@ bool HTTPHandler::authenticateUser(
 
         auto * gss_acceptor_context = dynamic_cast<GSSAcceptorContext *>(request_credentials.get());
         if (!gss_acceptor_context)
-            throw Exception(ErrorCodes::AUTHENTICATION_FAILED, "Invalid authentication: unexpected 'Negotiate' HTTP Authorization scheme expected");
+            throw Exception(
+                ErrorCodes::AUTHENTICATION_FAILED, "Invalid authentication: unexpected 'Negotiate' HTTP Authorization scheme expected");
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunreachable-code"
@@ -500,9 +493,10 @@ bool HTTPHandler::authenticateUser(
     if (params.has("quota_key"))
     {
         if (!quota_key.empty())
-            throw Exception(ErrorCodes::BAD_ARGUMENTS,
-                            "Invalid authentication: it is not allowed "
-                            "to use quota key as HTTP header and as parameter simultaneously");
+            throw Exception(
+                ErrorCodes::BAD_ARGUMENTS,
+                "Invalid authentication: it is not allowed "
+                "to use quota key as HTTP header and as parameter simultaneously");
 
         quota_key = params.get("quota_key");
     }
@@ -627,26 +621,29 @@ void HTTPHandler::processQuery(
     size_t buffer_size_memory = (buffer_size_total > buffer_size_http) ? buffer_size_total : 0;
 
     bool enable_http_compression = params.getParsed<bool>("enable_http_compression", context->getSettingsRef().enable_http_compression);
-    Int64 http_zlib_compression_level = params.getParsed<Int64>("http_zlib_compression_level", context->getSettingsRef().http_zlib_compression_level);
+    Int64 http_zlib_compression_level
+        = params.getParsed<Int64>("http_zlib_compression_level", context->getSettingsRef().http_zlib_compression_level);
 
-    used_output.out_holder =
-        std::make_shared<WriteBufferFromHTTPServerResponse>(
-            response,
-            request.getMethod() == HTTPRequest::HTTP_HEAD,
-            context->getServerSettings().keep_alive_timeout.totalSeconds(),
-            write_event);
+    used_output.out_holder = std::make_shared<WriteBufferFromHTTPServerResponse>(
+        response,
+        request.getMethod() == HTTPRequest::HTTP_HEAD,
+        context->getServerSettings().keep_alive_timeout.totalSeconds(),
+        write_event);
     used_output.out = used_output.out_holder;
     used_output.out_maybe_compressed = used_output.out_holder;
 
     if (client_supports_http_compression && enable_http_compression)
     {
         used_output.out_holder->setCompressionMethodHeader(http_response_compression_method);
-        used_output.wrap_compressed_holder =
-            wrapWriteBufferWithCompressionMethod(
-                used_output.out_holder.get(),
-                http_response_compression_method,
-                static_cast<int>(http_zlib_compression_level),
-                0, DBMS_DEFAULT_BUFFER_SIZE, nullptr, 0, false);
+        used_output.wrap_compressed_holder = wrapWriteBufferWithCompressionMethod(
+            used_output.out_holder.get(),
+            http_response_compression_method,
+            static_cast<int>(http_zlib_compression_level),
+            0,
+            DBMS_DEFAULT_BUFFER_SIZE,
+            nullptr,
+            0,
+            false);
         used_output.out = used_output.wrap_compressed_holder;
     }
 
@@ -670,16 +667,13 @@ void HTTPHandler::processQuery(
         {
             auto tmp_data = std::make_shared<TemporaryDataOnDisk>(server.context()->getTempDataOnDisk());
 
-            auto create_tmp_disk_buffer = [tmp_data] (const WriteBufferPtr &) -> WriteBufferPtr
-            {
-                return tmp_data->createRawStream();
-            };
+            auto create_tmp_disk_buffer = [tmp_data](const WriteBufferPtr &) -> WriteBufferPtr { return tmp_data->createRawStream(); };
 
             cascade_buffer2.emplace_back(std::move(create_tmp_disk_buffer));
         }
         else
         {
-            auto push_memory_buffer_and_continue = [next_buffer = used_output.out_maybe_compressed] (const WriteBufferPtr & prev_buf)
+            auto push_memory_buffer_and_continue = [next_buffer = used_output.out_maybe_compressed](const WriteBufferPtr & prev_buf)
             {
                 auto * prev_memory_buffer = typeid_cast<MemoryWriteBuffer *>(prev_buf.get());
                 if (!prev_memory_buffer)
@@ -694,7 +688,8 @@ void HTTPHandler::processQuery(
             cascade_buffer2.emplace_back(push_memory_buffer_and_continue);
         }
 
-        used_output.out_delayed_and_compressed_holder = std::make_unique<CascadeWriteBuffer>(std::move(cascade_buffer1), std::move(cascade_buffer2));
+        used_output.out_delayed_and_compressed_holder
+            = std::make_unique<CascadeWriteBuffer>(std::move(cascade_buffer1), std::move(cascade_buffer2));
         used_output.out_maybe_delayed_and_compressed = used_output.out_delayed_and_compressed_holder.get();
     }
     else
@@ -707,7 +702,8 @@ void HTTPHandler::processQuery(
     int zstd_window_log_max = static_cast<int>(context->getSettingsRef().zstd_window_log_max);
     auto in_post = wrapReadBufferWithCompressionMethod(
         wrapReadBufferReference(request.getStream()),
-        chooseCompressionMethod({}, http_request_compression_method_str), zstd_window_log_max);
+        chooseCompressionMethod({}, http_request_compression_method_str),
+        zstd_window_log_max);
 
     /// The data can also be compressed using incompatible internal algorithm. This is indicated by
     /// 'decompress' query parameter.
@@ -723,12 +719,26 @@ void HTTPHandler::processQuery(
 
     std::unique_ptr<ReadBuffer> in;
 
-    static const NameSet reserved_param_names{"compress", "decompress", "user", "password", "quota_key", "query_id", "stacktrace", "role",
-        "buffer_size", "wait_end_of_query", "session_id", "session_timeout", "session_check", "client_protocol_version", "close_session"};
+    static const NameSet reserved_param_names{
+        "compress",
+        "decompress",
+        "user",
+        "password",
+        "quota_key",
+        "query_id",
+        "stacktrace",
+        "role",
+        "buffer_size",
+        "wait_end_of_query",
+        "session_id",
+        "session_timeout",
+        "session_check",
+        "client_protocol_version",
+        "close_session"};
 
     Names reserved_param_suffixes;
 
-    auto param_could_be_skipped = [&] (const String & name)
+    auto param_could_be_skipped = [&](const String & name)
     {
         /// Empty parameter appears when URL like ?&a=b or a=b&&c=d. Just skip them for user's convenience.
         if (name.empty())
@@ -738,10 +748,8 @@ void HTTPHandler::processQuery(
             return true;
 
         for (const String & suffix : reserved_param_suffixes)
-        {
             if (endsWith(name, suffix))
                 return true;
-        }
 
         return false;
     };
@@ -859,47 +867,47 @@ void HTTPHandler::processQuery(
     if (settings.add_http_cors_header && !request.get("Origin", "").empty() && !config.has("http_options_response"))
         used_output.out_holder->addHeaderCORS(true);
 
-    auto append_callback = [my_context = context] (ProgressCallback callback)
+    auto append_callback = [my_context = context](ProgressCallback callback)
     {
         auto prev = my_context->getProgressCallback();
 
-        my_context->setProgressCallback([prev, callback] (const Progress & progress)
-        {
-            if (prev)
-                prev(progress);
+        my_context->setProgressCallback(
+            [prev, callback](const Progress & progress)
+            {
+                if (prev)
+                    prev(progress);
 
-            callback(progress);
-        });
+                callback(progress);
+            });
     };
 
     /// While still no data has been sent, we will report about query execution progress by sending HTTP headers.
     /// Note that we add it unconditionally so the progress is available for `X-ClickHouse-Summary`
-    append_callback([&used_output](const Progress & progress)
-    {
-        used_output.out_holder->onProgress(progress);
-    });
+    append_callback([&used_output](const Progress & progress) { used_output.out_holder->onProgress(progress); });
 
     if (settings.readonly > 0 && settings.cancel_http_readonly_queries_on_client_close)
     {
-        append_callback([&context, &request](const Progress &)
-        {
-            /// Assume that at the point this method is called no one is reading data from the socket any more:
-            /// should be true for read-only queries.
-            if (!request.checkPeerConnected())
-                context->killCurrentQuery();
-        });
+        append_callback(
+            [&context, &request](const Progress &)
+            {
+                /// Assume that at the point this method is called no one is reading data from the socket any more:
+                /// should be true for read-only queries.
+                if (!request.checkPeerConnected())
+                    context->killCurrentQuery();
+            });
     }
 
     customizeContext(request, context, *in_post_maybe_compressed);
     in = has_external_data ? std::move(in_param) : std::make_unique<ConcatReadBuffer>(*in_param, *in_post_maybe_compressed);
 
-    auto set_query_result = [&response, this] (const QueryResultDetails & details)
+    auto set_query_result = [&response, this](const QueryResultDetails & details)
     {
         response.add("X-ClickHouse-Query-Id", details.query_id);
+        if (http_response_headers_override)
+            for (auto [header_name, header_value] : *http_response_headers_override)
+                response.add(header_name, header_value);
 
-        if (content_type_override)
-            response.setContentType(*content_type_override);
-        else if (details.content_type)
+        if (response.getContentType() == Poco::Net::HTTPMessage::UNKNOWN_CONTENT_TYPE && details.content_type)
             response.setContentType(*details.content_type);
 
         if (details.format)
@@ -909,7 +917,10 @@ void HTTPHandler::processQuery(
             response.add("X-ClickHouse-Timezone", *details.timezone);
     };
 
-    auto handle_exception_in_output_format = [&](IOutputFormat & current_output_format, const String & format_name, const ContextPtr & context_, const std::optional<FormatSettings> & format_settings)
+    auto handle_exception_in_output_format = [&](IOutputFormat & current_output_format,
+                                                 const String & format_name,
+                                                 const ContextPtr & context_,
+                                                 const std::optional<FormatSettings> & format_settings)
     {
         if (settings.http_write_exception_in_output_format && current_output_format.supportsWritingException())
         {
@@ -929,7 +940,8 @@ void HTTPHandler::processQuery(
             }
             else
             {
-                bool with_stacktrace = (params.getParsed<bool>("stacktrace", false) && server.config().getBool("enable_http_stacktrace", true));
+                bool with_stacktrace
+                    = (params.getParsed<bool>("stacktrace", false) && server.config().getBool("enable_http_stacktrace", true));
                 ExecutionStatus status = ExecutionStatus::fromCurrentException("", with_stacktrace);
                 formatExceptionForClient(status.code, request, response, used_output);
                 current_output_format.setException(status.message);
@@ -970,7 +982,8 @@ try
     if (!used_output.out_holder && !used_output.exception_is_written)
     {
         /// If nothing was sent yet and we don't even know if we must compress the response.
-        WriteBufferFromHTTPServerResponse(response, request.getMethod() == HTTPRequest::HTTP_HEAD, DEFAULT_HTTP_KEEP_ALIVE_TIMEOUT).writeln(s);
+        WriteBufferFromHTTPServerResponse(response, request.getMethod() == HTTPRequest::HTTP_HEAD, DEFAULT_HTTP_KEEP_ALIVE_TIMEOUT)
+            .writeln(s);
     }
     else if (used_output.out_maybe_compressed)
     {
@@ -1034,7 +1047,8 @@ catch (...)
     }
 }
 
-void HTTPHandler::formatExceptionForClient(int exception_code, HTTPServerRequest & request, HTTPServerResponse & response, Output & used_output)
+void HTTPHandler::formatExceptionForClient(
+    int exception_code, HTTPServerRequest & request, HTTPServerResponse & response, Output & used_output)
 {
     if (used_output.out_holder)
         used_output.out_holder->setExceptionCode(exception_code);
@@ -1101,9 +1115,7 @@ void HTTPHandler::handleRequest(HTTPServerRequest & request, HTTPServerResponse 
             std::string opentelemetry_traceparent = request.get("traceparent");
             std::string error;
             if (!client_trace_context.parseTraceparentHeader(opentelemetry_traceparent, error))
-            {
                 LOG_DEBUG(log, "Failed to parse OpenTelemetry traceparent header '{}': {}", opentelemetry_traceparent, error);
-            }
             client_trace_context.tracestate = request.get("tracestate", "");
         }
 
@@ -1141,9 +1153,10 @@ void HTTPHandler::handleRequest(HTTPServerRequest & request, HTTPServerResponse 
         /// Workaround. Poco does not detect 411 Length Required case.
         if (request.getMethod() == HTTPRequest::HTTP_POST && !request.getChunkedTransferEncoding() && !request.hasContentLength())
         {
-            throw Exception(ErrorCodes::HTTP_LENGTH_REQUIRED,
-                            "The Transfer-Encoding is not chunked and there "
-                            "is no Content-Length header for POST request");
+            throw Exception(
+                ErrorCodes::HTTP_LENGTH_REQUIRED,
+                "The Transfer-Encoding is not chunked and there "
+                "is no Content-Length header for POST request");
         }
 
         processQuery(request, params, response, used_output, query_scope, write_event);
@@ -1155,7 +1168,8 @@ void HTTPHandler::handleRequest(HTTPServerRequest & request, HTTPServerResponse 
     catch (...)
     {
         SCOPE_EXIT({
-            request_credentials.reset(); // ...so that the next requests on the connection have to always start afresh in case of exceptions.
+            request_credentials
+                .reset(); // ...so that the next requests on the connection have to always start afresh in case of exceptions.
         });
 
         /// Check if exception was thrown in used_output.finalize().
@@ -1185,15 +1199,18 @@ void HTTPHandler::handleRequest(HTTPServerRequest & request, HTTPServerResponse 
     used_output.finalize();
 }
 
-DynamicQueryHandler::DynamicQueryHandler(IServer & server_, const std::string & param_name_, const std::optional<String>& content_type_override_)
-    : HTTPHandler(server_, "DynamicQueryHandler", content_type_override_), param_name(param_name_)
+DynamicQueryHandler::DynamicQueryHandler(
+    IServer & server_,
+    const std::string & param_name_,
+    const std::optional<std::unordered_map<String, String>> & http_response_headers_override_)
+    : HTTPHandler(server_, "DynamicQueryHandler", http_response_headers_override_), param_name(param_name_)
 {
 }
 
 bool DynamicQueryHandler::customizeQueryParam(ContextMutablePtr context, const std::string & key, const std::string & value)
 {
     if (key == param_name)
-        return true;    /// do nothing
+        return true; /// do nothing
 
     if (startsWith(key, QUERY_PARAMETER_NAME_PREFIX))
     {
@@ -1227,16 +1244,10 @@ std::string DynamicQueryHandler::getQuery(HTTPServerRequest & request, HTMLForm 
     std::string full_query;
     /// Params are of both form params POST and uri (GET params)
     for (const auto & it : params)
-    {
         if (it.first == param_name)
-        {
             full_query += it.second;
-        }
         else
-        {
             customizeQueryParam(context, it.first, it.second);
-        }
-    }
 
     return full_query;
 }
@@ -1247,8 +1258,8 @@ PredefinedQueryHandler::PredefinedQueryHandler(
     const std::string & predefined_query_,
     const CompiledRegexPtr & url_regex_,
     const std::unordered_map<String, CompiledRegexPtr> & header_name_with_regex_,
-    const std::optional<String> & content_type_override_)
-    : HTTPHandler(server_, "PredefinedQueryHandler", content_type_override_)
+    const std::optional<std::unordered_map<String, String>> & http_response_headers_override_)
+    : HTTPHandler(server_, "PredefinedQueryHandler", http_response_headers_override_)
     , receive_params(receive_params_)
     , predefined_query(predefined_query_)
     , url_regex(url_regex_)
@@ -1334,20 +1345,37 @@ std::string PredefinedQueryHandler::getQuery(HTTPServerRequest & request, HTMLFo
     return predefined_query;
 }
 
-HTTPRequestHandlerFactoryPtr createDynamicHandlerFactory(IServer & server,
-    const Poco::Util::AbstractConfiguration & config,
-    const std::string & config_prefix)
+std::optional<std::unordered_map<String, String>>
+parseHttpResponseHeaders(const Poco::Util::AbstractConfiguration & config, const std::string & config_prefix)
+{
+    std::unordered_map<String, String> http_response_headers_override;
+    String http_response_headers_key = config_prefix + ".handler.http_response_headers";
+    String http_response_headers_key_prefix = http_response_headers_key + ".";
+    if (config.has(http_response_headers_key))
+    {
+        Poco::Util::AbstractConfiguration::Keys keys;
+        config.keys(config_prefix + ".handler.http_response_headers", keys);
+        for (const auto & key : keys)
+            http_response_headers_override[key] = config.getString(http_response_headers_key_prefix + key);
+    }
+    if (config.has(config_prefix + ".handler.content_type"))
+        http_response_headers_override[Poco::Net::HTTPMessage::CONTENT_TYPE] = config.getString(config_prefix + ".handler.content_type");
+
+    if (http_response_headers_override.empty())
+        return std::nullopt;
+
+    return std::optional(std::move(http_response_headers_override));
+}
+
+HTTPRequestHandlerFactoryPtr
+createDynamicHandlerFactory(IServer & server, const Poco::Util::AbstractConfiguration & config, const std::string & config_prefix)
 {
     auto query_param_name = config.getString(config_prefix + ".handler.query_param_name", "query");
 
-    std::optional<String> content_type_override;
-    if (config.has(config_prefix + ".handler.content_type"))
-        content_type_override = config.getString(config_prefix + ".handler.content_type");
+    std::optional<std::unordered_map<String, String>> http_response_headers_override = parseHttpResponseHeaders(config, config_prefix);
 
-    auto creator = [&server, query_param_name, content_type_override] () -> std::unique_ptr<DynamicQueryHandler>
-    {
-        return std::make_unique<DynamicQueryHandler>(server, query_param_name, content_type_override);
-    };
+    auto creator = [&server, query_param_name, http_response_headers_override]() -> std::unique_ptr<DynamicQueryHandler>
+    { return std::make_unique<DynamicQueryHandler>(server, query_param_name, http_response_headers_override); };
 
     auto factory = std::make_shared<HandlingRuleHTTPHandlerFactory<DynamicQueryHandler>>(std::move(creator));
     factory->addFiltersFromConfig(config, config_prefix);
@@ -1357,11 +1385,14 @@ HTTPRequestHandlerFactoryPtr createDynamicHandlerFactory(IServer & server,
 static inline bool capturingNamedQueryParam(NameSet receive_params, const CompiledRegexPtr & compiled_regex)
 {
     const auto & capturing_names = compiled_regex->NamedCapturingGroups();
-    return std::count_if(capturing_names.begin(), capturing_names.end(), [&](const auto & iterator)
-    {
-        return std::count_if(receive_params.begin(), receive_params.end(),
-            [&](const auto & param_name) { return param_name == iterator.first; });
-    });
+    return std::count_if(
+        capturing_names.begin(),
+        capturing_names.end(),
+        [&](const auto & iterator)
+        {
+            return std::count_if(
+                receive_params.begin(), receive_params.end(), [&](const auto & param_name) { return param_name == iterator.first; });
+        });
 }
 
 static inline CompiledRegexPtr getCompiledRegex(const std::string & expression)
@@ -1369,15 +1400,18 @@ static inline CompiledRegexPtr getCompiledRegex(const std::string & expression)
     auto compiled_regex = std::make_shared<const re2::RE2>(expression);
 
     if (!compiled_regex->ok())
-        throw Exception(ErrorCodes::CANNOT_COMPILE_REGEXP, "Cannot compile re2: {} for http handling rule, error: {}. "
-            "Look at https://github.com/google/re2/wiki/Syntax for reference.", expression, compiled_regex->error());
+        throw Exception(
+            ErrorCodes::CANNOT_COMPILE_REGEXP,
+            "Cannot compile re2: {} for http handling rule, error: {}. "
+            "Look at https://github.com/google/re2/wiki/Syntax for reference.",
+            expression,
+            compiled_regex->error());
 
     return compiled_regex;
 }
 
-HTTPRequestHandlerFactoryPtr createPredefinedHandlerFactory(IServer & server,
-    const Poco::Util::AbstractConfiguration & config,
-    const std::string & config_prefix)
+HTTPRequestHandlerFactoryPtr
+createPredefinedHandlerFactory(IServer & server, const Poco::Util::AbstractConfiguration & config, const std::string & config_prefix)
 {
     if (!config.has(config_prefix + ".handler.query"))
         throw Exception(ErrorCodes::NO_ELEMENTS_IN_CONFIG, "There is no path '{}.handler.query' in configuration file.", config_prefix);
@@ -1402,9 +1436,7 @@ HTTPRequestHandlerFactoryPtr createPredefinedHandlerFactory(IServer & server,
             headers_name_with_regex.emplace(std::make_pair(header_name, regex));
     }
 
-    std::optional<String> content_type_override;
-    if (config.has(config_prefix + ".handler.content_type"))
-        content_type_override = config.getString(config_prefix + ".handler.content_type");
+    std::optional<std::unordered_map<String, String>> http_response_headers_override = parseHttpResponseHeaders(config, config_prefix);
 
     std::shared_ptr<HandlingRuleHTTPHandlerFactory<PredefinedQueryHandler>> factory;
 
@@ -1418,18 +1450,12 @@ HTTPRequestHandlerFactoryPtr createPredefinedHandlerFactory(IServer & server,
         auto regex = getCompiledRegex(url_expression);
         if (capturingNamedQueryParam(analyze_receive_params, regex))
         {
-            auto creator = [
-                &server,
-                analyze_receive_params,
-                predefined_query,
-                regex,
-                headers_name_with_regex,
-                content_type_override]
+            auto creator
+                = [&server, analyze_receive_params, predefined_query, regex, headers_name_with_regex, http_response_headers_override]
                 -> std::unique_ptr<PredefinedQueryHandler>
             {
                 return std::make_unique<PredefinedQueryHandler>(
-                    server, analyze_receive_params, predefined_query, regex,
-                    headers_name_with_regex, content_type_override);
+                    server, analyze_receive_params, predefined_query, regex, headers_name_with_regex, http_response_headers_override);
             };
             factory = std::make_shared<HandlingRuleHTTPHandlerFactory<PredefinedQueryHandler>>(std::move(creator));
             factory->addFiltersFromConfig(config, config_prefix);
@@ -1437,17 +1463,11 @@ HTTPRequestHandlerFactoryPtr createPredefinedHandlerFactory(IServer & server,
         }
     }
 
-    auto creator = [
-        &server,
-        analyze_receive_params,
-        predefined_query,
-        headers_name_with_regex,
-        content_type_override]
+    auto creator = [&server, analyze_receive_params, predefined_query, headers_name_with_regex, http_response_headers_override]
         -> std::unique_ptr<PredefinedQueryHandler>
     {
         return std::make_unique<PredefinedQueryHandler>(
-            server, analyze_receive_params, predefined_query, CompiledRegexPtr{},
-            headers_name_with_regex, content_type_override);
+            server, analyze_receive_params, predefined_query, CompiledRegexPtr{}, headers_name_with_regex, http_response_headers_override);
     };
 
     factory = std::make_shared<HandlingRuleHTTPHandlerFactory<PredefinedQueryHandler>>(std::move(creator));

--- a/src/Server/HTTPHandler.cpp
+++ b/src/Server/HTTPHandler.cpp
@@ -1,8 +1,8 @@
 #include <Server/HTTPHandler.h>
 
-#include <Access/AccessControl.h>
 #include <Access/Authentication.h>
 #include <Access/Credentials.h>
+#include <Access/AccessControl.h>
 #include <Access/ExternalAuthenticators.h>
 #include <Access/Role.h>
 #include <Access/User.h>
@@ -10,7 +10,6 @@
 #include <Compression/CompressedWriteBuffer.h>
 #include <Core/ExternalTable.h>
 #include <Disks/StoragePolicy.h>
-#include <Formats/FormatFactory.h>
 #include <IO/CascadeWriteBuffer.h>
 #include <IO/ConcatReadBuffer.h>
 #include <IO/MemoryReadWriteBuffer.h>
@@ -18,37 +17,38 @@
 #include <IO/WriteHelpers.h>
 #include <IO/copyData.h>
 #include <Interpreters/Context.h>
-#include <Interpreters/Session.h>
 #include <Interpreters/TemporaryDataOnDisk.h>
-#include <Interpreters/executeQuery.h>
-#include <Parsers/ASTSetQuery.h>
 #include <Parsers/QueryParameterVisitor.h>
-#include <Processors/Formats/IOutputFormat.h>
+#include <Interpreters/executeQuery.h>
+#include <Interpreters/Session.h>
 #include <Server/HTTPHandlerFactory.h>
 #include <Server/HTTPHandlerRequestFilter.h>
 #include <Server/IServer.h>
-#include "Common/logger_useful.h"
+#include <Common/logger_useful.h>
 #include <Common/SettingsChanges.h>
 #include <Common/StringUtils.h>
 #include <Common/scope_guard_safe.h>
 #include <Common/setThreadName.h>
 #include <Common/typeid_cast.h>
+#include <Parsers/ASTSetQuery.h>
+#include <Processors/Formats/IOutputFormat.h>
+#include <Formats/FormatFactory.h>
 
-#include <Server/HTTP/HTTPResponse.h>
 #include <base/getFQDNOrHostName.h>
 #include <base/scope_guard.h>
+#include <Server/HTTP/HTTPResponse.h>
 
 #include "config.h"
 
 #include <Poco/Base64Decoder.h>
 #include <Poco/Base64Encoder.h>
-#include <Poco/MemoryStream.h>
 #include <Poco/Net/HTTPBasicCredentials.h>
 #include <Poco/Net/HTTPMessage.h>
 #include <Poco/Net/HTTPStream.h>
-#include <Poco/Net/SocketAddress.h>
+#include <Poco/MemoryStream.h>
 #include <Poco/StreamCopier.h>
 #include <Poco/String.h>
+#include <Poco/Net/SocketAddress.h>
 
 #include <algorithm>
 #include <chrono>
@@ -59,7 +59,7 @@
 #include <utility>
 
 #if USE_SSL
-#    include <Poco/Net/X509Certificate.h>
+#include <Poco/Net/X509Certificate.h>
 #endif
 
 
@@ -68,68 +68,68 @@ namespace DB
 
 namespace ErrorCodes
 {
-extern const int BAD_ARGUMENTS;
-extern const int LOGICAL_ERROR;
-extern const int CANNOT_SCHEDULE_TASK;
-extern const int CANNOT_PARSE_TEXT;
-extern const int CANNOT_PARSE_ESCAPE_SEQUENCE;
-extern const int CANNOT_PARSE_QUOTED_STRING;
-extern const int CANNOT_PARSE_DATE;
-extern const int CANNOT_PARSE_DATETIME;
-extern const int CANNOT_PARSE_NUMBER;
-extern const int CANNOT_PARSE_DOMAIN_VALUE_FROM_STRING;
-extern const int CANNOT_PARSE_IPV4;
-extern const int CANNOT_PARSE_IPV6;
-extern const int CANNOT_PARSE_UUID;
-extern const int CANNOT_PARSE_INPUT_ASSERTION_FAILED;
-extern const int CANNOT_OPEN_FILE;
-extern const int CANNOT_COMPILE_REGEXP;
-extern const int DUPLICATE_COLUMN;
-extern const int ILLEGAL_COLUMN;
-extern const int THERE_IS_NO_COLUMN;
-extern const int UNKNOWN_ELEMENT_IN_AST;
-extern const int UNKNOWN_TYPE_OF_AST_NODE;
-extern const int TOO_DEEP_AST;
-extern const int TOO_BIG_AST;
-extern const int UNEXPECTED_AST_STRUCTURE;
-extern const int VALUE_IS_OUT_OF_RANGE_OF_DATA_TYPE;
+    extern const int BAD_ARGUMENTS;
+    extern const int LOGICAL_ERROR;
+    extern const int CANNOT_COMPILE_REGEXP;
+    extern const int CANNOT_OPEN_FILE;
+    extern const int CANNOT_PARSE_TEXT;
+    extern const int CANNOT_PARSE_ESCAPE_SEQUENCE;
+    extern const int CANNOT_PARSE_QUOTED_STRING;
+    extern const int CANNOT_PARSE_DATE;
+    extern const int CANNOT_PARSE_DATETIME;
+    extern const int CANNOT_PARSE_NUMBER;
+    extern const int CANNOT_PARSE_DOMAIN_VALUE_FROM_STRING;
+    extern const int CANNOT_PARSE_IPV4;
+    extern const int CANNOT_PARSE_IPV6;
+    extern const int CANNOT_PARSE_UUID;
+    extern const int CANNOT_PARSE_INPUT_ASSERTION_FAILED;
+    extern const int CANNOT_SCHEDULE_TASK;
+    extern const int DUPLICATE_COLUMN;
+    extern const int ILLEGAL_COLUMN;
+    extern const int THERE_IS_NO_COLUMN;
+    extern const int UNKNOWN_ELEMENT_IN_AST;
+    extern const int UNKNOWN_TYPE_OF_AST_NODE;
+    extern const int TOO_DEEP_AST;
+    extern const int TOO_BIG_AST;
+    extern const int UNEXPECTED_AST_STRUCTURE;
+    extern const int VALUE_IS_OUT_OF_RANGE_OF_DATA_TYPE;
 
-extern const int SYNTAX_ERROR;
+    extern const int SYNTAX_ERROR;
 
-extern const int INCORRECT_DATA;
-extern const int TYPE_MISMATCH;
+    extern const int INCORRECT_DATA;
+    extern const int TYPE_MISMATCH;
 
-extern const int UNKNOWN_TABLE;
-extern const int UNKNOWN_FUNCTION;
-extern const int UNKNOWN_IDENTIFIER;
-extern const int UNKNOWN_TYPE;
-extern const int UNKNOWN_STORAGE;
-extern const int UNKNOWN_DATABASE;
-extern const int UNKNOWN_SETTING;
-extern const int UNKNOWN_DIRECTION_OF_SORTING;
-extern const int UNKNOWN_AGGREGATE_FUNCTION;
-extern const int UNKNOWN_FORMAT;
-extern const int UNKNOWN_DATABASE_ENGINE;
-extern const int UNKNOWN_TYPE_OF_QUERY;
-extern const int UNKNOWN_ROLE;
-extern const int NO_ELEMENTS_IN_CONFIG;
+    extern const int UNKNOWN_TABLE;
+    extern const int UNKNOWN_FUNCTION;
+    extern const int UNKNOWN_IDENTIFIER;
+    extern const int UNKNOWN_TYPE;
+    extern const int UNKNOWN_STORAGE;
+    extern const int UNKNOWN_DATABASE;
+    extern const int UNKNOWN_SETTING;
+    extern const int UNKNOWN_DIRECTION_OF_SORTING;
+    extern const int UNKNOWN_AGGREGATE_FUNCTION;
+    extern const int UNKNOWN_FORMAT;
+    extern const int UNKNOWN_DATABASE_ENGINE;
+    extern const int UNKNOWN_TYPE_OF_QUERY;
+    extern const int UNKNOWN_ROLE;
+    extern const int NO_ELEMENTS_IN_CONFIG;
 
-extern const int QUERY_IS_TOO_LARGE;
+    extern const int QUERY_IS_TOO_LARGE;
 
-extern const int NOT_IMPLEMENTED;
-extern const int SOCKET_TIMEOUT;
+    extern const int NOT_IMPLEMENTED;
+    extern const int SOCKET_TIMEOUT;
 
-extern const int UNKNOWN_USER;
-extern const int WRONG_PASSWORD;
-extern const int REQUIRED_PASSWORD;
-extern const int AUTHENTICATION_FAILED;
-extern const int SET_NON_GRANTED_ROLE;
+    extern const int UNKNOWN_USER;
+    extern const int WRONG_PASSWORD;
+    extern const int REQUIRED_PASSWORD;
+    extern const int AUTHENTICATION_FAILED;
+    extern const int SET_NON_GRANTED_ROLE;
 
-extern const int INVALID_SESSION_TIMEOUT;
-extern const int HTTP_LENGTH_REQUIRED;
-extern const int SUPPORT_IS_DISABLED;
+    extern const int INVALID_SESSION_TIMEOUT;
+    extern const int HTTP_LENGTH_REQUIRED;
+    extern const int SUPPORT_IS_DISABLED;
 
-extern const int TIMEOUT_EXCEEDED;
+    extern const int TIMEOUT_EXCEEDED;
 }
 
 namespace
@@ -148,9 +148,9 @@ bool tryAddHTTPOptionHeadersFromConfig(HTTPServerResponse & response, const Poco
                 if (config.getString("http_options_response." + config_key + ".name", "").empty())
                     LOG_WARNING(getLogger("processOptionsRequest"), "Empty header was found in config. It will not be processed.");
                 else
-                    response.add(
-                        config.getString("http_options_response." + config_key + ".name", ""),
-                        config.getString("http_options_response." + config_key + ".value", ""));
+                    response.add(config.getString("http_options_response." + config_key + ".name", ""),
+                                 config.getString("http_options_response." + config_key + ".value", ""));
+
             }
         }
         return true;
@@ -199,37 +199,54 @@ static Poco::Net::HTTPResponse::HTTPStatus exceptionCodeToHTTPStatus(int excepti
     {
         return HTTPResponse::HTTP_UNAUTHORIZED;
     }
-    else if (
-        exception_code == ErrorCodes::UNKNOWN_USER || exception_code == ErrorCodes::WRONG_PASSWORD
-        || exception_code == ErrorCodes::AUTHENTICATION_FAILED || exception_code == ErrorCodes::SET_NON_GRANTED_ROLE)
+    else if (exception_code == ErrorCodes::UNKNOWN_USER ||
+             exception_code == ErrorCodes::WRONG_PASSWORD ||
+             exception_code == ErrorCodes::AUTHENTICATION_FAILED ||
+             exception_code == ErrorCodes::SET_NON_GRANTED_ROLE)
     {
         return HTTPResponse::HTTP_FORBIDDEN;
     }
-    else if (
-        exception_code == ErrorCodes::BAD_ARGUMENTS || exception_code == ErrorCodes::CANNOT_COMPILE_REGEXP
-        || exception_code == ErrorCodes::CANNOT_PARSE_TEXT || exception_code == ErrorCodes::CANNOT_PARSE_ESCAPE_SEQUENCE
-        || exception_code == ErrorCodes::CANNOT_PARSE_QUOTED_STRING || exception_code == ErrorCodes::CANNOT_PARSE_DATE
-        || exception_code == ErrorCodes::CANNOT_PARSE_DATETIME || exception_code == ErrorCodes::CANNOT_PARSE_NUMBER
-        || exception_code == ErrorCodes::CANNOT_PARSE_DOMAIN_VALUE_FROM_STRING || exception_code == ErrorCodes::CANNOT_PARSE_IPV4
-        || exception_code == ErrorCodes::CANNOT_PARSE_IPV6 || exception_code == ErrorCodes::CANNOT_PARSE_INPUT_ASSERTION_FAILED
-        || exception_code == ErrorCodes::CANNOT_PARSE_UUID || exception_code == ErrorCodes::DUPLICATE_COLUMN
-        || exception_code == ErrorCodes::ILLEGAL_COLUMN || exception_code == ErrorCodes::UNKNOWN_ELEMENT_IN_AST
-        || exception_code == ErrorCodes::UNKNOWN_TYPE_OF_AST_NODE || exception_code == ErrorCodes::THERE_IS_NO_COLUMN
-        || exception_code == ErrorCodes::TOO_DEEP_AST || exception_code == ErrorCodes::TOO_BIG_AST
-        || exception_code == ErrorCodes::UNEXPECTED_AST_STRUCTURE || exception_code == ErrorCodes::SYNTAX_ERROR
-        || exception_code == ErrorCodes::INCORRECT_DATA || exception_code == ErrorCodes::TYPE_MISMATCH
-        || exception_code == ErrorCodes::VALUE_IS_OUT_OF_RANGE_OF_DATA_TYPE)
+    else if (exception_code == ErrorCodes::BAD_ARGUMENTS ||
+             exception_code == ErrorCodes::CANNOT_COMPILE_REGEXP ||
+             exception_code == ErrorCodes::CANNOT_PARSE_TEXT ||
+             exception_code == ErrorCodes::CANNOT_PARSE_ESCAPE_SEQUENCE ||
+             exception_code == ErrorCodes::CANNOT_PARSE_QUOTED_STRING ||
+             exception_code == ErrorCodes::CANNOT_PARSE_DATE ||
+             exception_code == ErrorCodes::CANNOT_PARSE_DATETIME ||
+             exception_code == ErrorCodes::CANNOT_PARSE_NUMBER ||
+             exception_code == ErrorCodes::CANNOT_PARSE_DOMAIN_VALUE_FROM_STRING ||
+             exception_code == ErrorCodes::CANNOT_PARSE_IPV4 ||
+             exception_code == ErrorCodes::CANNOT_PARSE_IPV6 ||
+             exception_code == ErrorCodes::CANNOT_PARSE_INPUT_ASSERTION_FAILED ||
+             exception_code == ErrorCodes::CANNOT_PARSE_UUID ||
+             exception_code == ErrorCodes::DUPLICATE_COLUMN ||
+             exception_code == ErrorCodes::ILLEGAL_COLUMN ||
+             exception_code == ErrorCodes::UNKNOWN_ELEMENT_IN_AST ||
+             exception_code == ErrorCodes::UNKNOWN_TYPE_OF_AST_NODE ||
+             exception_code == ErrorCodes::THERE_IS_NO_COLUMN ||
+             exception_code == ErrorCodes::TOO_DEEP_AST ||
+             exception_code == ErrorCodes::TOO_BIG_AST ||
+             exception_code == ErrorCodes::UNEXPECTED_AST_STRUCTURE ||
+             exception_code == ErrorCodes::SYNTAX_ERROR ||
+             exception_code == ErrorCodes::INCORRECT_DATA ||
+             exception_code == ErrorCodes::TYPE_MISMATCH ||
+             exception_code == ErrorCodes::VALUE_IS_OUT_OF_RANGE_OF_DATA_TYPE)
     {
         return HTTPResponse::HTTP_BAD_REQUEST;
     }
-    else if (
-        exception_code == ErrorCodes::UNKNOWN_TABLE || exception_code == ErrorCodes::UNKNOWN_FUNCTION
-        || exception_code == ErrorCodes::UNKNOWN_IDENTIFIER || exception_code == ErrorCodes::UNKNOWN_TYPE
-        || exception_code == ErrorCodes::UNKNOWN_STORAGE || exception_code == ErrorCodes::UNKNOWN_DATABASE
-        || exception_code == ErrorCodes::UNKNOWN_SETTING || exception_code == ErrorCodes::UNKNOWN_DIRECTION_OF_SORTING
-        || exception_code == ErrorCodes::UNKNOWN_AGGREGATE_FUNCTION || exception_code == ErrorCodes::UNKNOWN_FORMAT
-        || exception_code == ErrorCodes::UNKNOWN_DATABASE_ENGINE || exception_code == ErrorCodes::UNKNOWN_TYPE_OF_QUERY
-        || exception_code == ErrorCodes::UNKNOWN_ROLE)
+    else if (exception_code == ErrorCodes::UNKNOWN_TABLE ||
+             exception_code == ErrorCodes::UNKNOWN_FUNCTION ||
+             exception_code == ErrorCodes::UNKNOWN_IDENTIFIER ||
+             exception_code == ErrorCodes::UNKNOWN_TYPE ||
+             exception_code == ErrorCodes::UNKNOWN_STORAGE ||
+             exception_code == ErrorCodes::UNKNOWN_DATABASE ||
+             exception_code == ErrorCodes::UNKNOWN_SETTING ||
+             exception_code == ErrorCodes::UNKNOWN_DIRECTION_OF_SORTING ||
+             exception_code == ErrorCodes::UNKNOWN_AGGREGATE_FUNCTION ||
+             exception_code == ErrorCodes::UNKNOWN_FORMAT ||
+             exception_code == ErrorCodes::UNKNOWN_DATABASE_ENGINE ||
+             exception_code == ErrorCodes::UNKNOWN_TYPE_OF_QUERY ||
+             exception_code == ErrorCodes::UNKNOWN_ROLE)
     {
         return HTTPResponse::HTTP_NOT_FOUND;
     }
@@ -241,7 +258,8 @@ static Poco::Net::HTTPResponse::HTTPStatus exceptionCodeToHTTPStatus(int excepti
     {
         return HTTPResponse::HTTP_NOT_IMPLEMENTED;
     }
-    else if (exception_code == ErrorCodes::SOCKET_TIMEOUT || exception_code == ErrorCodes::CANNOT_OPEN_FILE)
+    else if (exception_code == ErrorCodes::SOCKET_TIMEOUT ||
+             exception_code == ErrorCodes::CANNOT_OPEN_FILE)
     {
         return HTTPResponse::HTTP_SERVICE_UNAVAILABLE;
     }
@@ -262,7 +280,9 @@ static Poco::Net::HTTPResponse::HTTPStatus exceptionCodeToHTTPStatus(int excepti
 }
 
 
-static std::chrono::steady_clock::duration parseSessionTimeout(const Poco::Util::AbstractConfiguration & config, const HTMLForm & params)
+static std::chrono::steady_clock::duration parseSessionTimeout(
+    const Poco::Util::AbstractConfiguration & config,
+    const HTMLForm & params)
 {
     unsigned session_timeout = config.getInt("default_session_timeout", 60);
 
@@ -276,16 +296,14 @@ static std::chrono::steady_clock::duration parseSessionTimeout(const Poco::Util:
             throw Exception(ErrorCodes::INVALID_SESSION_TIMEOUT, "Invalid session timeout: '{}'", session_timeout_str);
 
         if (session_timeout > max_session_timeout)
-            throw Exception(
-                ErrorCodes::INVALID_SESSION_TIMEOUT,
-                "Session timeout '{}' is larger than max_session_timeout: {}. "
+            throw Exception(ErrorCodes::INVALID_SESSION_TIMEOUT, "Session timeout '{}' is larger than max_session_timeout: {}. "
                 "Maximum session timeout could be modified in configuration file.",
-                session_timeout_str,
-                max_session_timeout);
+                session_timeout_str, max_session_timeout);
     }
 
     return std::chrono::seconds(session_timeout);
 }
+
 
 void HTTPHandler::pushDelayedResults(Output & used_output)
 {
@@ -338,7 +356,10 @@ HTTPHandler::HTTPHandler(IServer & server_, const std::string & name, const HTTP
 HTTPHandler::~HTTPHandler() = default;
 
 
-bool HTTPHandler::authenticateUser(HTTPServerRequest & request, HTMLForm & params, HTTPServerResponse & response)
+bool HTTPHandler::authenticateUser(
+    HTTPServerRequest & request,
+    HTMLForm & params,
+    HTTPServerResponse & response)
 {
     using namespace Poco::Net;
 
@@ -365,36 +386,31 @@ bool HTTPHandler::authenticateUser(HTTPServerRequest & request, HTMLForm & param
     {
         /// It is prohibited to mix different authorization schemes.
         if (has_http_credentials)
-            throw Exception(
-                ErrorCodes::AUTHENTICATION_FAILED,
-                "Invalid authentication: it is not allowed "
-                "to use SSL certificate authentication and Authorization HTTP header simultaneously");
+            throw Exception(ErrorCodes::AUTHENTICATION_FAILED,
+                            "Invalid authentication: it is not allowed "
+                            "to use SSL certificate authentication and Authorization HTTP header simultaneously");
         if (has_credentials_in_query_params)
-            throw Exception(
-                ErrorCodes::AUTHENTICATION_FAILED,
-                "Invalid authentication: it is not allowed "
-                "to use SSL certificate authentication and authentication via parameters simultaneously simultaneously");
+            throw Exception(ErrorCodes::AUTHENTICATION_FAILED,
+                            "Invalid authentication: it is not allowed "
+                            "to use SSL certificate authentication and authentication via parameters simultaneously simultaneously");
 
         if (has_ssl_certificate_auth)
         {
 #if USE_SSL
             if (!password.empty())
-                throw Exception(
-                    ErrorCodes::AUTHENTICATION_FAILED,
-                    "Invalid authentication: it is not allowed "
-                    "to use SSL certificate authentication and authentication via password simultaneously");
+                throw Exception(ErrorCodes::AUTHENTICATION_FAILED,
+                                "Invalid authentication: it is not allowed "
+                                "to use SSL certificate authentication and authentication via password simultaneously");
 
             if (request.havePeerCertificate())
                 certificate_common_name = request.peerCertificate().commonName();
 
             if (certificate_common_name.empty())
-                throw Exception(
-                    ErrorCodes::AUTHENTICATION_FAILED,
-                    "Invalid authentication: SSL certificate authentication requires nonempty certificate's Common Name");
+                throw Exception(ErrorCodes::AUTHENTICATION_FAILED,
+                                "Invalid authentication: SSL certificate authentication requires nonempty certificate's Common Name");
 #else
-            throw Exception(
-                ErrorCodes::SUPPORT_IS_DISABLED,
-                "SSL certificate authentication disabled because ClickHouse was built without SSL library");
+            throw Exception(ErrorCodes::SUPPORT_IS_DISABLED,
+                            "SSL certificate authentication disabled because ClickHouse was built without SSL library");
 #endif
         }
     }
@@ -402,10 +418,9 @@ bool HTTPHandler::authenticateUser(HTTPServerRequest & request, HTMLForm & param
     {
         /// It is prohibited to mix different authorization schemes.
         if (has_credentials_in_query_params)
-            throw Exception(
-                ErrorCodes::AUTHENTICATION_FAILED,
-                "Invalid authentication: it is not allowed "
-                "to use Authorization HTTP header and authentication via parameters simultaneously");
+            throw Exception(ErrorCodes::AUTHENTICATION_FAILED,
+                            "Invalid authentication: it is not allowed "
+                            "to use Authorization HTTP header and authentication via parameters simultaneously");
 
         std::string scheme;
         std::string auth_info;
@@ -426,8 +441,7 @@ bool HTTPHandler::authenticateUser(HTTPServerRequest & request, HTMLForm & param
         }
         else
         {
-            throw Exception(
-                ErrorCodes::AUTHENTICATION_FAILED, "Invalid authentication: '{}' HTTP Authorization scheme is not supported", scheme);
+            throw Exception(ErrorCodes::AUTHENTICATION_FAILED, "Invalid authentication: '{}' HTTP Authorization scheme is not supported", scheme);
         }
     }
     else
@@ -453,8 +467,7 @@ bool HTTPHandler::authenticateUser(HTTPServerRequest & request, HTMLForm & param
 
         auto * gss_acceptor_context = dynamic_cast<GSSAcceptorContext *>(request_credentials.get());
         if (!gss_acceptor_context)
-            throw Exception(
-                ErrorCodes::AUTHENTICATION_FAILED, "Invalid authentication: unexpected 'Negotiate' HTTP Authorization scheme expected");
+            throw Exception(ErrorCodes::AUTHENTICATION_FAILED, "Invalid authentication: unexpected 'Negotiate' HTTP Authorization scheme expected");
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunreachable-code"
@@ -490,10 +503,9 @@ bool HTTPHandler::authenticateUser(HTTPServerRequest & request, HTMLForm & param
     if (params.has("quota_key"))
     {
         if (!quota_key.empty())
-            throw Exception(
-                ErrorCodes::BAD_ARGUMENTS,
-                "Invalid authentication: it is not allowed "
-                "to use quota key as HTTP header and as parameter simultaneously");
+            throw Exception(ErrorCodes::BAD_ARGUMENTS,
+                            "Invalid authentication: it is not allowed "
+                            "to use quota key as HTTP header and as parameter simultaneously");
 
         quota_key = params.get("quota_key");
     }
@@ -618,29 +630,26 @@ void HTTPHandler::processQuery(
     size_t buffer_size_memory = (buffer_size_total > buffer_size_http) ? buffer_size_total : 0;
 
     bool enable_http_compression = params.getParsed<bool>("enable_http_compression", context->getSettingsRef().enable_http_compression);
-    Int64 http_zlib_compression_level
-        = params.getParsed<Int64>("http_zlib_compression_level", context->getSettingsRef().http_zlib_compression_level);
+    Int64 http_zlib_compression_level = params.getParsed<Int64>("http_zlib_compression_level", context->getSettingsRef().http_zlib_compression_level);
 
-    used_output.out_holder = std::make_shared<WriteBufferFromHTTPServerResponse>(
-        response,
-        request.getMethod() == HTTPRequest::HTTP_HEAD,
-        context->getServerSettings().keep_alive_timeout.totalSeconds(),
-        write_event);
+    used_output.out_holder =
+        std::make_shared<WriteBufferFromHTTPServerResponse>(
+            response,
+            request.getMethod() == HTTPRequest::HTTP_HEAD,
+            context->getServerSettings().keep_alive_timeout.totalSeconds(),
+            write_event);
     used_output.out = used_output.out_holder;
     used_output.out_maybe_compressed = used_output.out_holder;
 
     if (client_supports_http_compression && enable_http_compression)
     {
         used_output.out_holder->setCompressionMethodHeader(http_response_compression_method);
-        used_output.wrap_compressed_holder = wrapWriteBufferWithCompressionMethod(
-            used_output.out_holder.get(),
-            http_response_compression_method,
-            static_cast<int>(http_zlib_compression_level),
-            0,
-            DBMS_DEFAULT_BUFFER_SIZE,
-            nullptr,
-            0,
-            false);
+        used_output.wrap_compressed_holder =
+            wrapWriteBufferWithCompressionMethod(
+                used_output.out_holder.get(),
+                http_response_compression_method,
+                static_cast<int>(http_zlib_compression_level),
+                0, DBMS_DEFAULT_BUFFER_SIZE, nullptr, 0, false);
         used_output.out = used_output.wrap_compressed_holder;
     }
 
@@ -664,13 +673,15 @@ void HTTPHandler::processQuery(
         {
             auto tmp_data = std::make_shared<TemporaryDataOnDisk>(server.context()->getTempDataOnDisk());
 
-            auto create_tmp_disk_buffer = [tmp_data](const WriteBufferPtr &) -> WriteBufferPtr { return tmp_data->createRawStream(); };
+            auto create_tmp_disk_buffer = [tmp_data] (const WriteBufferPtr &) -> WriteBufferPtr {
+                return tmp_data->createRawStream();
+            };
 
             cascade_buffer2.emplace_back(std::move(create_tmp_disk_buffer));
         }
         else
         {
-            auto push_memory_buffer_and_continue = [next_buffer = used_output.out_maybe_compressed](const WriteBufferPtr & prev_buf)
+            auto push_memory_buffer_and_continue = [next_buffer = used_output.out_maybe_compressed] (const WriteBufferPtr & prev_buf)
             {
                 auto * prev_memory_buffer = typeid_cast<MemoryWriteBuffer *>(prev_buf.get());
                 if (!prev_memory_buffer)
@@ -685,8 +696,7 @@ void HTTPHandler::processQuery(
             cascade_buffer2.emplace_back(push_memory_buffer_and_continue);
         }
 
-        used_output.out_delayed_and_compressed_holder
-            = std::make_unique<CascadeWriteBuffer>(std::move(cascade_buffer1), std::move(cascade_buffer2));
+        used_output.out_delayed_and_compressed_holder = std::make_unique<CascadeWriteBuffer>(std::move(cascade_buffer1), std::move(cascade_buffer2));
         used_output.out_maybe_delayed_and_compressed = used_output.out_delayed_and_compressed_holder.get();
     }
     else
@@ -699,8 +709,7 @@ void HTTPHandler::processQuery(
     int zstd_window_log_max = static_cast<int>(context->getSettingsRef().zstd_window_log_max);
     auto in_post = wrapReadBufferWithCompressionMethod(
         wrapReadBufferReference(request.getStream()),
-        chooseCompressionMethod({}, http_request_compression_method_str),
-        zstd_window_log_max);
+        chooseCompressionMethod({}, http_request_compression_method_str), zstd_window_log_max);
 
     /// The data can also be compressed using incompatible internal algorithm. This is indicated by
     /// 'decompress' query parameter.
@@ -708,8 +717,7 @@ void HTTPHandler::processQuery(
     bool is_in_post_compressed = false;
     if (params.getParsed<bool>("decompress", false))
     {
-        in_post_maybe_compressed
-            = std::make_unique<CompressedReadBuffer>(*in_post, /* allow_different_codecs_ = */ false, /* external_data_ = */ true);
+        in_post_maybe_compressed = std::make_unique<CompressedReadBuffer>(*in_post, /* allow_different_codecs_ = */ false, /* external_data_ = */ true);
         is_in_post_compressed = true;
     }
     else
@@ -717,26 +725,12 @@ void HTTPHandler::processQuery(
 
     std::unique_ptr<ReadBuffer> in;
 
-    static const NameSet reserved_param_names{
-        "compress",
-        "decompress",
-        "user",
-        "password",
-        "quota_key",
-        "query_id",
-        "stacktrace",
-        "role",
-        "buffer_size",
-        "wait_end_of_query",
-        "session_id",
-        "session_timeout",
-        "session_check",
-        "client_protocol_version",
-        "close_session"};
+    static const NameSet reserved_param_names{"compress", "decompress", "user", "password", "quota_key", "query_id", "stacktrace", "role",
+        "buffer_size", "wait_end_of_query", "session_id", "session_timeout", "session_check", "client_protocol_version", "close_session"};
 
     Names reserved_param_suffixes;
 
-    auto param_could_be_skipped = [&](const String & name)
+    auto param_could_be_skipped = [&] (const String & name)
     {
         /// Empty parameter appears when URL like ?&a=b or a=b&&c=d. Just skip them for user's convenience.
         if (name.empty())
@@ -746,8 +740,10 @@ void HTTPHandler::processQuery(
             return true;
 
         for (const String & suffix : reserved_param_suffixes)
+        {
             if (endsWith(name, suffix))
                 return true;
+        }
 
         return false;
     };
@@ -865,34 +861,35 @@ void HTTPHandler::processQuery(
     if (settings.add_http_cors_header && !request.get("Origin", "").empty() && !config.has("http_options_response"))
         used_output.out_holder->addHeaderCORS(true);
 
-    auto append_callback = [my_context = context](ProgressCallback callback)
+    auto append_callback = [my_context = context] (ProgressCallback callback)
     {
         auto prev = my_context->getProgressCallback();
 
-        my_context->setProgressCallback(
-            [prev, callback](const Progress & progress)
-            {
-                if (prev)
-                    prev(progress);
+        my_context->setProgressCallback([prev, callback] (const Progress & progress)
+        {
+            if (prev)
+                prev(progress);
 
-                callback(progress);
-            });
+            callback(progress);
+        });
     };
 
     /// While still no data has been sent, we will report about query execution progress by sending HTTP headers.
     /// Note that we add it unconditionally so the progress is available for `X-ClickHouse-Summary`
-    append_callback([&used_output](const Progress & progress) { used_output.out_holder->onProgress(progress); });
+    append_callback([&used_output](const Progress & progress)
+    {
+        used_output.out_holder->onProgress(progress);
+    });
 
     if (settings.readonly > 0 && settings.cancel_http_readonly_queries_on_client_close)
     {
-        append_callback(
-            [&context, &request](const Progress &)
-            {
-                /// Assume that at the point this method is called no one is reading data from the socket any more:
-                /// should be true for read-only queries.
-                if (!request.checkPeerConnected())
-                    context->killCurrentQuery();
-            });
+        append_callback([&context, &request](const Progress &)
+        {
+            /// Assume that at the point this method is called no one is reading data from the socket any more:
+            /// should be true for read-only queries.
+            if (!request.checkPeerConnected())
+                context->killCurrentQuery();
+        });
     }
 
     customizeContext(request, context, *in_post_maybe_compressed);
@@ -900,7 +897,7 @@ void HTTPHandler::processQuery(
 
     applyHTTPResponseHeaders(response, http_response_headers_override);
 
-    auto set_query_result = [this, &response](const QueryResultDetails & details)
+    auto set_query_result = [&response, this] (const QueryResultDetails & details)
     {
         response.add("X-ClickHouse-Query-Id", details.query_id);
 
@@ -915,10 +912,7 @@ void HTTPHandler::processQuery(
             response.add("X-ClickHouse-Timezone", *details.timezone);
     };
 
-    auto handle_exception_in_output_format = [&](IOutputFormat & current_output_format,
-                                                 const String & format_name,
-                                                 const ContextPtr & context_,
-                                                 const std::optional<FormatSettings> & format_settings)
+    auto handle_exception_in_output_format = [&](IOutputFormat & current_output_format, const String & format_name, const ContextPtr & context_, const std::optional<FormatSettings> & format_settings)
     {
         if (settings.http_write_exception_in_output_format && current_output_format.supportsWritingException())
         {
@@ -938,8 +932,7 @@ void HTTPHandler::processQuery(
             }
             else
             {
-                bool with_stacktrace
-                    = (params.getParsed<bool>("stacktrace", false) && server.config().getBool("enable_http_stacktrace", true));
+                bool with_stacktrace = (params.getParsed<bool>("stacktrace", false) && server.config().getBool("enable_http_stacktrace", true));
                 ExecutionStatus status = ExecutionStatus::fromCurrentException("", with_stacktrace);
                 formatExceptionForClient(status.code, request, response, used_output);
                 current_output_format.setException(status.message);
@@ -980,8 +973,7 @@ try
     if (!used_output.out_holder && !used_output.exception_is_written)
     {
         /// If nothing was sent yet and we don't even know if we must compress the response.
-        WriteBufferFromHTTPServerResponse(response, request.getMethod() == HTTPRequest::HTTP_HEAD, DEFAULT_HTTP_KEEP_ALIVE_TIMEOUT)
-            .writeln(s);
+        WriteBufferFromHTTPServerResponse(response, request.getMethod() == HTTPRequest::HTTP_HEAD, DEFAULT_HTTP_KEEP_ALIVE_TIMEOUT).writeln(s);
     }
     else if (used_output.out_maybe_compressed)
     {
@@ -1045,8 +1037,7 @@ catch (...)
     }
 }
 
-void HTTPHandler::formatExceptionForClient(
-    int exception_code, HTTPServerRequest & request, HTTPServerResponse & response, Output & used_output)
+void HTTPHandler::formatExceptionForClient(int exception_code, HTTPServerRequest & request, HTTPServerResponse & response, Output & used_output)
 {
     if (used_output.out_holder)
         used_output.out_holder->setExceptionCode(exception_code);
@@ -1113,14 +1104,18 @@ void HTTPHandler::handleRequest(HTTPServerRequest & request, HTTPServerResponse 
             std::string opentelemetry_traceparent = request.get("traceparent");
             std::string error;
             if (!client_trace_context.parseTraceparentHeader(opentelemetry_traceparent, error))
+            {
                 LOG_DEBUG(log, "Failed to parse OpenTelemetry traceparent header '{}': {}", opentelemetry_traceparent, error);
+            }
             client_trace_context.tracestate = request.get("tracestate", "");
         }
 
         // Setup tracing context for this thread
         auto context = session->sessionOrGlobalContext();
-        thread_trace_context = std::make_unique<OpenTelemetry::TracingContextHolder>(
-            "HTTPHandler", client_trace_context, context->getSettingsRef(), context->getOpenTelemetrySpanLog());
+        thread_trace_context = std::make_unique<OpenTelemetry::TracingContextHolder>("HTTPHandler",
+            client_trace_context,
+            context->getSettingsRef(),
+            context->getOpenTelemetrySpanLog());
         thread_trace_context->root_span.kind = OpenTelemetry::SpanKind::SERVER;
         thread_trace_context->root_span.addAttribute("clickhouse.uri", request.getURI());
 
@@ -1149,10 +1144,9 @@ void HTTPHandler::handleRequest(HTTPServerRequest & request, HTTPServerResponse 
         /// Workaround. Poco does not detect 411 Length Required case.
         if (request.getMethod() == HTTPRequest::HTTP_POST && !request.getChunkedTransferEncoding() && !request.hasContentLength())
         {
-            throw Exception(
-                ErrorCodes::HTTP_LENGTH_REQUIRED,
-                "The Transfer-Encoding is not chunked and there "
-                "is no Content-Length header for POST request");
+            throw Exception(ErrorCodes::HTTP_LENGTH_REQUIRED,
+                            "The Transfer-Encoding is not chunked and there "
+                            "is no Content-Length header for POST request");
         }
 
         processQuery(request, params, response, used_output, query_scope, write_event);
@@ -1164,8 +1158,7 @@ void HTTPHandler::handleRequest(HTTPServerRequest & request, HTTPServerResponse 
     catch (...)
     {
         SCOPE_EXIT({
-            request_credentials
-                .reset(); // ...so that the next requests on the connection have to always start afresh in case of exceptions.
+            request_credentials.reset(); // ...so that the next requests on the connection have to always start afresh in case of exceptions.
         });
 
         /// Check if exception was thrown in used_output.finalize().
@@ -1204,7 +1197,7 @@ DynamicQueryHandler::DynamicQueryHandler(
 bool DynamicQueryHandler::customizeQueryParam(ContextMutablePtr context, const std::string & key, const std::string & value)
 {
     if (key == param_name)
-        return true; /// do nothing
+        return true;    /// do nothing
 
     if (startsWith(key, QUERY_PARAMETER_NAME_PREFIX))
     {
@@ -1238,10 +1231,16 @@ std::string DynamicQueryHandler::getQuery(HTTPServerRequest & request, HTMLForm 
     std::string full_query;
     /// Params are of both form params POST and uri (GET params)
     for (const auto & it : params)
+    {
         if (it.first == param_name)
+        {
             full_query += it.second;
+        }
         else
+        {
             customizeQueryParam(context, it.first, it.second);
+        }
+    }
 
     return full_query;
 }
@@ -1339,8 +1338,9 @@ std::string PredefinedQueryHandler::getQuery(HTTPServerRequest & request, HTMLFo
     return predefined_query;
 }
 
-HTTPRequestHandlerFactoryPtr
-createDynamicHandlerFactory(IServer & server, const Poco::Util::AbstractConfiguration & config, const std::string & config_prefix)
+HTTPRequestHandlerFactoryPtr createDynamicHandlerFactory(IServer & server,
+    const Poco::Util::AbstractConfiguration & config,
+    const std::string & config_prefix)
 {
     auto query_param_name = config.getString(config_prefix + ".handler.query_param_name", "query");
 
@@ -1357,14 +1357,11 @@ createDynamicHandlerFactory(IServer & server, const Poco::Util::AbstractConfigur
 static inline bool capturingNamedQueryParam(NameSet receive_params, const CompiledRegexPtr & compiled_regex)
 {
     const auto & capturing_names = compiled_regex->NamedCapturingGroups();
-    return std::count_if(
-        capturing_names.begin(),
-        capturing_names.end(),
-        [&](const auto & iterator)
-        {
-            return std::count_if(
-                receive_params.begin(), receive_params.end(), [&](const auto & param_name) { return param_name == iterator.first; });
-        });
+    return std::count_if(capturing_names.begin(), capturing_names.end(), [&](const auto & iterator)
+    {
+        return std::count_if(receive_params.begin(), receive_params.end(),
+            [&](const auto & param_name) { return param_name == iterator.first; });
+    });
 }
 
 static inline CompiledRegexPtr getCompiledRegex(const std::string & expression)
@@ -1372,18 +1369,15 @@ static inline CompiledRegexPtr getCompiledRegex(const std::string & expression)
     auto compiled_regex = std::make_shared<const re2::RE2>(expression);
 
     if (!compiled_regex->ok())
-        throw Exception(
-            ErrorCodes::CANNOT_COMPILE_REGEXP,
-            "Cannot compile re2: {} for http handling rule, error: {}. "
-            "Look at https://github.com/google/re2/wiki/Syntax for reference.",
-            expression,
-            compiled_regex->error());
+        throw Exception(ErrorCodes::CANNOT_COMPILE_REGEXP, "Cannot compile re2: {} for http handling rule, error: {}. "
+            "Look at https://github.com/google/re2/wiki/Syntax for reference.", expression, compiled_regex->error());
 
     return compiled_regex;
 }
 
-HTTPRequestHandlerFactoryPtr
-createPredefinedHandlerFactory(IServer & server, const Poco::Util::AbstractConfiguration & config, const std::string & config_prefix)
+HTTPRequestHandlerFactoryPtr createPredefinedHandlerFactory(IServer & server,
+    const Poco::Util::AbstractConfiguration & config,
+    const std::string & config_prefix)
 {
     if (!config.has(config_prefix + ".handler.query"))
         throw Exception(ErrorCodes::NO_ELEMENTS_IN_CONFIG, "There is no path '{}.handler.query' in configuration file.", config_prefix);
@@ -1422,12 +1416,18 @@ createPredefinedHandlerFactory(IServer & server, const Poco::Util::AbstractConfi
         auto regex = getCompiledRegex(url_expression);
         if (capturingNamedQueryParam(analyze_receive_params, regex))
         {
-            auto creator
-                = [&server, analyze_receive_params, predefined_query, regex, headers_name_with_regex, http_response_headers_override]
+            auto creator = [
+                &server,
+                analyze_receive_params,
+                predefined_query,
+                regex,
+                headers_name_with_regex,
+                http_response_headers_override]
                 -> std::unique_ptr<PredefinedQueryHandler>
             {
                 return std::make_unique<PredefinedQueryHandler>(
-                    server, analyze_receive_params, predefined_query, regex, headers_name_with_regex, http_response_headers_override);
+                    server, analyze_receive_params, predefined_query, regex,
+                    headers_name_with_regex, http_response_headers_override);
             };
             factory = std::make_shared<HandlingRuleHTTPHandlerFactory<PredefinedQueryHandler>>(std::move(creator));
             factory->addFiltersFromConfig(config, config_prefix);
@@ -1435,11 +1435,17 @@ createPredefinedHandlerFactory(IServer & server, const Poco::Util::AbstractConfi
         }
     }
 
-    auto creator = [&server, analyze_receive_params, predefined_query, headers_name_with_regex, http_response_headers_override]
+    auto creator = [
+        &server,
+        analyze_receive_params,
+        predefined_query,
+        headers_name_with_regex,
+        http_response_headers_override]
         -> std::unique_ptr<PredefinedQueryHandler>
     {
         return std::make_unique<PredefinedQueryHandler>(
-            server, analyze_receive_params, predefined_query, CompiledRegexPtr{}, headers_name_with_regex, http_response_headers_override);
+            server, analyze_receive_params, predefined_query, CompiledRegexPtr{},
+            headers_name_with_regex, http_response_headers_override);
     };
 
     factory = std::make_shared<HandlingRuleHTTPHandlerFactory<PredefinedQueryHandler>>(std::move(creator));

--- a/src/Server/HTTPHandler.h
+++ b/src/Server/HTTPHandler.h
@@ -1,21 +1,27 @@
 #pragma once
 
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <Compression/CompressedWriteBuffer.h>
 #include <Core/Names.h>
+#include <IO/CascadeWriteBuffer.h>
 #include <Server/HTTP/HTMLForm.h>
 #include <Server/HTTP/HTTPRequestHandler.h>
 #include <Server/HTTP/WriteBufferFromHTTPServerResponse.h>
 #include <Common/CurrentMetrics.h>
 #include <Common/CurrentThread.h>
-#include <IO/CascadeWriteBuffer.h>
-#include <Compression/CompressedWriteBuffer.h>
 #include <Common/re2.h>
 
 namespace CurrentMetrics
 {
-    extern const Metric HTTPConnection;
+extern const Metric HTTPConnection;
 }
 
-namespace Poco { class Logger; }
+namespace Poco
+{
+class Logger;
+}
 
 namespace DB
 {
@@ -31,13 +37,16 @@ using CompiledRegexPtr = std::shared_ptr<const re2::RE2>;
 class HTTPHandler : public HTTPRequestHandler
 {
 public:
-    HTTPHandler(IServer & server_, const std::string & name, const std::optional<String> & content_type_override_);
+    HTTPHandler(
+        IServer & server_,
+        const std::string & name,
+        const std::optional<std::unordered_map<String, String>> & http_response_headers_override_);
     ~HTTPHandler() override;
 
     void handleRequest(HTTPServerRequest & request, HTTPServerResponse & response, const ProfileEvents::Event & write_event) override;
 
     /// This method is called right before the query execution.
-    virtual void customizeContext(HTTPServerRequest & /* request */, ContextMutablePtr /* context */, ReadBuffer & /* body */) {}
+    virtual void customizeContext(HTTPServerRequest & /* request */, ContextMutablePtr /* context */, ReadBuffer & /* body */) { }
 
     virtual bool customizeQueryParam(ContextMutablePtr context, const std::string & key, const std::string & value) = 0;
 
@@ -113,8 +122,8 @@ private:
     /// See settings http_max_fields, http_max_field_name_size, http_max_field_value_size in HTMLForm.
     const Settings & default_settings;
 
-    /// Overrides Content-Type provided by the format of the response.
-    std::optional<String> content_type_override;
+    /// Overrides for response headers.
+    std::optional<std::unordered_map<String, String>> http_response_headers_override;
 
     // session is reset at the end of each request/response.
     std::unique_ptr<Session> session;
@@ -128,10 +137,7 @@ private:
     // Returns false when the user is not authenticated yet, and the 'Negotiate' response is sent,
     //  the session and request_credentials instances are preserved.
     // Throws an exception if authentication failed.
-    bool authenticateUser(
-        HTTPServerRequest & request,
-        HTMLForm & params,
-        HTTPServerResponse & response);
+    bool authenticateUser(HTTPServerRequest & request, HTMLForm & params, HTTPServerResponse & response);
 
     /// Also initializes 'used_output'.
     void processQuery(
@@ -143,17 +149,9 @@ private:
         const ProfileEvents::Event & write_event);
 
     void trySendExceptionToClient(
-        const std::string & s,
-        int exception_code,
-        HTTPServerRequest & request,
-        HTTPServerResponse & response,
-        Output & used_output);
+        const std::string & s, int exception_code, HTTPServerRequest & request, HTTPServerResponse & response, Output & used_output);
 
-    void formatExceptionForClient(
-        int exception_code,
-        HTTPServerRequest & request,
-        HTTPServerResponse & response,
-        Output & used_output);
+    void formatExceptionForClient(int exception_code, HTTPServerRequest & request, HTTPServerResponse & response, Output & used_output);
 
     static void pushDelayedResults(Output & used_output);
 };
@@ -162,12 +160,16 @@ class DynamicQueryHandler : public HTTPHandler
 {
 private:
     std::string param_name;
+
 public:
-    explicit DynamicQueryHandler(IServer & server_, const std::string & param_name_ = "query", const std::optional<String>& content_type_override_ = std::nullopt);
+    explicit DynamicQueryHandler(
+        IServer & server_,
+        const std::string & param_name_ = "query",
+        const std::optional<std::unordered_map<String, String>> & http_response_headers_override_ = std::nullopt);
 
     std::string getQuery(HTTPServerRequest & request, HTMLForm & params, ContextMutablePtr context) override;
 
-    bool customizeQueryParam(ContextMutablePtr context, const std::string &key, const std::string &value) override;
+    bool customizeQueryParam(ContextMutablePtr context, const std::string & key, const std::string & value) override;
 };
 
 class PredefinedQueryHandler : public HTTPHandler
@@ -177,11 +179,15 @@ private:
     std::string predefined_query;
     CompiledRegexPtr url_regex;
     std::unordered_map<String, CompiledRegexPtr> header_name_with_capture_regex;
+
 public:
     PredefinedQueryHandler(
-        IServer & server_, const NameSet & receive_params_, const std::string & predefined_query_
-        , const CompiledRegexPtr & url_regex_, const std::unordered_map<String, CompiledRegexPtr> & header_name_with_regex_
-        , const std::optional<std::string> & content_type_override_);
+        IServer & server_,
+        const NameSet & receive_params_,
+        const std::string & predefined_query_,
+        const CompiledRegexPtr & url_regex_,
+        const std::unordered_map<String, CompiledRegexPtr> & header_name_with_regex_,
+        const std::optional<std::unordered_map<String, String>> & http_response_headers_override_ = std::nullopt);
 
     void customizeContext(HTTPServerRequest & request, ContextMutablePtr context, ReadBuffer & body) override;
 

--- a/src/Server/HTTPHandler.h
+++ b/src/Server/HTTPHandler.h
@@ -3,27 +3,24 @@
 #include <optional>
 #include <string>
 #include <unordered_map>
-#include <Compression/CompressedWriteBuffer.h>
 #include <Core/Names.h>
-#include <IO/CascadeWriteBuffer.h>
 #include <Server/HTTP/HTMLForm.h>
 #include <Server/HTTP/HTTPRequestHandler.h>
 #include <Server/HTTP/WriteBufferFromHTTPServerResponse.h>
 #include <Common/CurrentMetrics.h>
 #include <Common/CurrentThread.h>
+#include <IO/CascadeWriteBuffer.h>
+#include <Compression/CompressedWriteBuffer.h>
 #include <Common/re2.h>
 
 #include "HTTPResponseHeaderWriter.h"
 
 namespace CurrentMetrics
 {
-extern const Metric HTTPConnection;
+    extern const Metric HTTPConnection;
 }
 
-namespace Poco
-{
-class Logger;
-}
+namespace Poco { class Logger; }
 
 namespace DB
 {
@@ -45,7 +42,7 @@ public:
     void handleRequest(HTTPServerRequest & request, HTTPServerResponse & response, const ProfileEvents::Event & write_event) override;
 
     /// This method is called right before the query execution.
-    virtual void customizeContext(HTTPServerRequest & /* request */, ContextMutablePtr /* context */, ReadBuffer & /* body */) { }
+    virtual void customizeContext(HTTPServerRequest & /* request */, ContextMutablePtr /* context */, ReadBuffer & /* body */) {}
 
     virtual bool customizeQueryParam(ContextMutablePtr context, const std::string & key, const std::string & value) = 0;
 
@@ -85,7 +82,10 @@ private:
         bool exception_is_written = false;
         std::function<void(WriteBuffer &, const String &)> exception_writer;
 
-        bool hasDelayed() const { return out_maybe_delayed_and_compressed != out_maybe_compressed.get(); }
+        bool hasDelayed() const
+        {
+            return out_maybe_delayed_and_compressed != out_maybe_compressed.get();
+        }
 
         void finalize()
         {
@@ -99,7 +99,10 @@ private:
                 out->finalize();
         }
 
-        bool isFinalized() const { return finalized; }
+        bool isFinalized() const
+        {
+            return finalized;
+        }
     };
 
     IServer & server;
@@ -130,7 +133,10 @@ private:
     // Returns false when the user is not authenticated yet, and the 'Negotiate' response is sent,
     //  the session and request_credentials instances are preserved.
     // Throws an exception if authentication failed.
-    bool authenticateUser(HTTPServerRequest & request, HTMLForm & params, HTTPServerResponse & response);
+    bool authenticateUser(
+        HTTPServerRequest & request,
+        HTMLForm & params,
+        HTTPServerResponse & response);
 
     /// Also initializes 'used_output'.
     void processQuery(
@@ -142,9 +148,17 @@ private:
         const ProfileEvents::Event & write_event);
 
     void trySendExceptionToClient(
-        const std::string & s, int exception_code, HTTPServerRequest & request, HTTPServerResponse & response, Output & used_output);
+        const std::string & s,
+        int exception_code,
+        HTTPServerRequest & request,
+        HTTPServerResponse & response,
+        Output & used_output);
 
-    void formatExceptionForClient(int exception_code, HTTPServerRequest & request, HTTPServerResponse & response, Output & used_output);
+    void formatExceptionForClient(
+        int exception_code,
+        HTTPServerRequest & request,
+        HTTPServerResponse & response,
+        Output & used_output);
 
     static void pushDelayedResults(Output & used_output);
 };
@@ -162,7 +176,7 @@ public:
 
     std::string getQuery(HTTPServerRequest & request, HTMLForm & params, ContextMutablePtr context) override;
 
-    bool customizeQueryParam(ContextMutablePtr context, const std::string & key, const std::string & value) override;
+    bool customizeQueryParam(ContextMutablePtr context, const std::string &key, const std::string &value) override;
 };
 
 class PredefinedQueryHandler : public HTTPHandler

--- a/src/Server/HTTPHandlerFactory.cpp
+++ b/src/Server/HTTPHandlerFactory.cpp
@@ -1,18 +1,18 @@
 #include <memory>
 #include <Server/HTTPHandlerFactory.h>
 
-#include <Access/Credentials.h>
 #include <Server/HTTP/HTTPRequestHandler.h>
 #include <Server/IServer.h>
+#include <Access/Credentials.h>
 
 #include <Poco/Util/AbstractConfiguration.h>
 
 #include "HTTPHandler.h"
-#include "InterserverIOHTTPHandler.h"
-#include "PrometheusRequestHandler.h"
-#include "ReplicasStatusHandler.h"
 #include "Server/PrometheusMetricsWriter.h"
 #include "StaticRequestHandler.h"
+#include "ReplicasStatusHandler.h"
+#include "InterserverIOHTTPHandler.h"
+#include "PrometheusRequestHandler.h"
 #include "WebUIRequestHandler.h"
 
 
@@ -21,9 +21,9 @@ namespace DB
 
 namespace ErrorCodes
 {
-extern const int LOGICAL_ERROR;
-extern const int UNKNOWN_ELEMENT_IN_CONFIG;
-extern const int INVALID_CONFIG_PARAMETER;
+    extern const int LOGICAL_ERROR;
+    extern const int UNKNOWN_ELEMENT_IN_CONFIG;
+    extern const int INVALID_CONFIG_PARAMETER;
 }
 
 namespace
@@ -35,7 +35,10 @@ private:
     std::string url;
 
 public:
-    explicit RedirectRequestHandler(std::string url_) : url(std::move(url_)) { }
+    explicit RedirectRequestHandler(std::string url_)
+        : url(std::move(url_))
+    {
+    }
 
     void handleRequest(HTTPServerRequest &, HTTPServerResponse & response, const ProfileEvents::Event &) override
     {
@@ -43,8 +46,9 @@ public:
     }
 };
 
-HTTPRequestHandlerFactoryPtr
-createRedirectHandlerFactory(const Poco::Util::AbstractConfiguration & config, const std::string & config_prefix)
+HTTPRequestHandlerFactoryPtr createRedirectHandlerFactory(
+    const Poco::Util::AbstractConfiguration & config,
+    const std::string & config_prefix)
 {
     std::string url = config.getString(config_prefix + ".handler.location");
 
@@ -99,12 +103,8 @@ static inline auto createHandlersFactoryFromConfig(
             const auto & handler_type = config.getString(prefix + "." + key + ".handler.type", "");
 
             if (handler_type.empty())
-                throw Exception(
-                    ErrorCodes::INVALID_CONFIG_PARAMETER,
-                    "Handler type in config is not specified here: "
-                    "{}.{}.handler.type",
-                    prefix,
-                    key);
+                throw Exception(ErrorCodes::INVALID_CONFIG_PARAMETER, "Handler type in config is not specified here: "
+                    "{}.{}.handler.type", prefix, key);
 
             if (handler_type == "static")
             {
@@ -155,27 +155,19 @@ static inline auto createHandlersFactoryFromConfig(
                 main_handler_factory->addHandler(std::move(handler));
             }
             else
-                throw Exception(
-                    ErrorCodes::INVALID_CONFIG_PARAMETER,
-                    "Unknown handler type '{}' in config here: {}.{}.handler.type",
-                    handler_type,
-                    prefix,
-                    key);
+                throw Exception(ErrorCodes::INVALID_CONFIG_PARAMETER, "Unknown handler type '{}' in config here: {}.{}.handler.type",
+                    handler_type, prefix, key);
         }
         else
-            throw Exception(
-                ErrorCodes::UNKNOWN_ELEMENT_IN_CONFIG,
-                "Unknown element in config: "
-                "{}.{}, must be 'rule' or 'defaults'",
-                prefix,
-                key);
+            throw Exception(ErrorCodes::UNKNOWN_ELEMENT_IN_CONFIG, "Unknown element in config: "
+                "{}.{}, must be 'rule' or 'defaults'", prefix, key);
     }
 
     return main_handler_factory;
 }
 
-static inline HTTPRequestHandlerFactoryPtr createHTTPHandlerFactory(
-    IServer & server, const Poco::Util::AbstractConfiguration & config, const std::string & name, AsynchronousMetrics & async_metrics)
+static inline HTTPRequestHandlerFactoryPtr
+createHTTPHandlerFactory(IServer & server, const Poco::Util::AbstractConfiguration & config, const std::string & name, AsynchronousMetrics & async_metrics)
 {
     if (config.has("http_handlers"))
     {
@@ -202,8 +194,7 @@ static inline HTTPRequestHandlerFactoryPtr createInterserverHTTPHandlerFactory(I
 }
 
 
-HTTPRequestHandlerFactoryPtr createHandlerFactory(
-    IServer & server, const Poco::Util::AbstractConfiguration & config, AsynchronousMetrics & async_metrics, const std::string & name)
+HTTPRequestHandlerFactoryPtr createHandlerFactory(IServer & server, const Poco::Util::AbstractConfiguration & config, AsynchronousMetrics & async_metrics, const std::string & name)
 {
     if (name == "HTTPHandler-factory" || name == "HTTPSHandler-factory")
         return createHTTPHandlerFactory(server, config, name, async_metrics);
@@ -276,23 +267,28 @@ void addDefaultHandlersFactory(
 {
     addCommonDefaultHandlersFactory(factory, server);
 
-    auto dynamic_creator
-        = [&server]() -> std::unique_ptr<DynamicQueryHandler> { return std::make_unique<DynamicQueryHandler>(server, "query"); };
+    auto dynamic_creator = [&server] () -> std::unique_ptr<DynamicQueryHandler>
+    {
+        return std::make_unique<DynamicQueryHandler>(server, "query");
+    };
     auto query_handler = std::make_shared<HandlingRuleHTTPHandlerFactory<DynamicQueryHandler>>(std::move(dynamic_creator));
-    query_handler->addFilter(
-        [](const auto & request)
+    query_handler->addFilter([](const auto & request)
         {
-            bool path_matches_get_or_head
-                = startsWith(request.getURI(), "?") || startsWith(request.getURI(), "/?") || startsWith(request.getURI(), "/query?");
-            bool is_get_or_head_request
-                = request.getMethod() == Poco::Net::HTTPRequest::HTTP_GET || request.getMethod() == Poco::Net::HTTPRequest::HTTP_HEAD;
+            bool path_matches_get_or_head = startsWith(request.getURI(), "?")
+                            || startsWith(request.getURI(), "/?")
+                            || startsWith(request.getURI(), "/query?");
+            bool is_get_or_head_request = request.getMethod() == Poco::Net::HTTPRequest::HTTP_GET
+                            || request.getMethod() == Poco::Net::HTTPRequest::HTTP_HEAD;
 
-            bool path_matches_post_or_options = path_matches_get_or_head || request.getURI() == "/" || request.getURI().empty();
-            bool is_post_or_options_request
-                = request.getMethod() == Poco::Net::HTTPRequest::HTTP_POST || request.getMethod() == Poco::Net::HTTPRequest::HTTP_OPTIONS;
+            bool path_matches_post_or_options = path_matches_get_or_head
+                             || request.getURI() == "/"
+                             || request.getURI().empty();
+            bool is_post_or_options_request = request.getMethod() == Poco::Net::HTTPRequest::HTTP_POST
+                                    || request.getMethod() == Poco::Net::HTTPRequest::HTTP_OPTIONS;
 
             return (path_matches_get_or_head && is_get_or_head_request) || (path_matches_post_or_options && is_post_or_options_request);
-        });
+        }
+    );
     factory.addHandler(query_handler);
 
     /// We check that prometheus handler will be served on current (default) port.
@@ -300,8 +296,10 @@ void addDefaultHandlersFactory(
     if (config.has("prometheus") && config.getInt("prometheus.port", 0) == 0)
     {
         auto writer = std::make_shared<PrometheusMetricsWriter>(config, "prometheus", async_metrics);
-        auto creator = [&server, writer]() -> std::unique_ptr<PrometheusRequestHandler>
-        { return std::make_unique<PrometheusRequestHandler>(server, writer); };
+        auto creator = [&server, writer] () -> std::unique_ptr<PrometheusRequestHandler>
+        {
+            return std::make_unique<PrometheusRequestHandler>(server, writer);
+        };
         auto prometheus_handler = std::make_shared<HandlingRuleHTTPHandlerFactory<PrometheusRequestHandler>>(std::move(creator));
         prometheus_handler->attachStrictPath(config.getString("prometheus.endpoint", "/metrics"));
         prometheus_handler->allowGetAndHeadRequest();

--- a/src/Server/HTTPResponseHeaderWriter.cpp
+++ b/src/Server/HTTPResponseHeaderWriter.cpp
@@ -56,13 +56,13 @@ std::unordered_map<String, String> parseHTTPResponseHeaders(const std::string & 
 void applyHTTPResponseHeaders(Poco::Net::HTTPResponse & response, const HTTPResponseHeaderSetup & setup)
 {
     if (setup)
-        for (auto [header_name, header_value] : *setup)
+        for (const auto & [header_name, header_value] : *setup)
             response.set(header_name, header_value);
 }
 
 void applyHTTPResponseHeaders(Poco::Net::HTTPResponse & response, const std::unordered_map<String, String> & setup)
 {
-    for (auto [header_name, header_value] : setup)
+    for (const auto & [header_name, header_value] : setup)
         response.set(header_name, header_value);
 }
 

--- a/src/Server/HTTPResponseHeaderWriter.cpp
+++ b/src/Server/HTTPResponseHeaderWriter.cpp
@@ -1,0 +1,69 @@
+#include "HTTPResponseHeaderWriter.h"
+#include <unordered_map>
+#include <utility>
+#include <Poco/Net/HTTPMessage.h>
+
+namespace DB
+{
+
+std::unordered_map<String, String>
+baseParseHTTPResponseHeaders(const Poco::Util::AbstractConfiguration & config, const std::string & config_prefix)
+{
+    std::unordered_map<String, String> http_response_headers_override;
+    String http_response_headers_key = config_prefix + ".handler.http_response_headers";
+    String http_response_headers_key_prefix = http_response_headers_key + ".";
+    if (config.has(http_response_headers_key))
+    {
+        Poco::Util::AbstractConfiguration::Keys keys;
+        config.keys(http_response_headers_key, keys);
+        for (const auto & key : keys)
+        {
+            http_response_headers_override[key] = config.getString(http_response_headers_key_prefix + key);
+        }
+    }
+    if (config.has(config_prefix + ".handler.content_type"))
+        http_response_headers_override[Poco::Net::HTTPMessage::CONTENT_TYPE] = config.getString(config_prefix + ".handler.content_type");
+
+    return http_response_headers_override;
+}
+
+HTTPResponseHeaderSetup parseHTTPResponseHeaders(const Poco::Util::AbstractConfiguration & config, const std::string & config_prefix)
+{
+    std::unordered_map<String, String> http_response_headers_override = baseParseHTTPResponseHeaders(config, config_prefix);
+
+    if (http_response_headers_override.empty())
+        return {};
+
+    return std::move(http_response_headers_override);
+}
+
+std::unordered_map<String, String> parseHTTPResponseHeaders(
+    const Poco::Util::AbstractConfiguration & config, const std::string & config_prefix, const std::string & default_content_type)
+{
+    std::unordered_map<String, String> http_response_headers_override = baseParseHTTPResponseHeaders(config, config_prefix);
+
+    if (!http_response_headers_override.contains(Poco::Net::HTTPMessage::CONTENT_TYPE))
+        http_response_headers_override[Poco::Net::HTTPMessage::CONTENT_TYPE] = default_content_type;
+
+    return http_response_headers_override;
+}
+
+std::unordered_map<String, String> parseHTTPResponseHeaders(const std::string & default_content_type)
+{
+    return {{{Poco::Net::HTTPMessage::CONTENT_TYPE, default_content_type}}};
+}
+
+void applyHTTPResponseHeaders(Poco::Net::HTTPResponse & response, const HTTPResponseHeaderSetup & setup)
+{
+    if (setup)
+        for (auto [header_name, header_value] : *setup)
+            response.set(header_name, header_value);
+}
+
+void applyHTTPResponseHeaders(Poco::Net::HTTPResponse & response, const std::unordered_map<String, String> & setup)
+{
+    for (auto [header_name, header_value] : setup)
+        response.set(header_name, header_value);
+}
+
+}

--- a/src/Server/HTTPResponseHeaderWriter.h
+++ b/src/Server/HTTPResponseHeaderWriter.h
@@ -1,0 +1,23 @@
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <base/types.h>
+#include <Poco/Net/HTTPResponse.h>
+#include <Poco/Util/AbstractConfiguration.h>
+
+namespace DB
+{
+
+using HTTPResponseHeaderSetup = std::optional<std::unordered_map<String, String>>;
+
+HTTPResponseHeaderSetup parseHTTPResponseHeaders(const Poco::Util::AbstractConfiguration & config, const std::string & config_prefix);
+
+std::unordered_map<String, String> parseHTTPResponseHeaders(
+    const Poco::Util::AbstractConfiguration & config, const std::string & config_prefix, const std::string & default_content_type);
+
+std::unordered_map<String, String> parseHTTPResponseHeaders(const std::string & default_content_type);
+
+void applyHTTPResponseHeaders(Poco::Net::HTTPResponse & response, const HTTPResponseHeaderSetup & setup);
+
+void applyHTTPResponseHeaders(Poco::Net::HTTPResponse & response, const std::unordered_map<String, String> & setup);
+}

--- a/src/Server/HTTPResponseHeaderWriter.h
+++ b/src/Server/HTTPResponseHeaderWriter.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <optional>
 #include <string>
 #include <unordered_map>

--- a/src/Server/StaticRequestHandler.cpp
+++ b/src/Server/StaticRequestHandler.cpp
@@ -7,19 +7,19 @@
 #include <IO/HTTPCommon.h>
 #include <IO/ReadBufferFromFile.h>
 #include <IO/WriteBufferFromString.h>
-#include <IO/WriteHelpers.h>
 #include <IO/copyData.h>
-#include <Interpreters/Context.h>
+#include <IO/WriteHelpers.h>
 #include <Server/HTTP/WriteBufferFromHTTPServerResponse.h>
+#include <Interpreters/Context.h>
 
 #include <Common/Exception.h>
 
-#include <filesystem>
 #include <unordered_map>
-#include <Poco/Net/HTTPRequestHandlerFactory.h>
 #include <Poco/Net/HTTPServerRequest.h>
 #include <Poco/Net/HTTPServerResponse.h>
+#include <Poco/Net/HTTPRequestHandlerFactory.h>
 #include <Poco/Util/LayeredConfiguration.h>
+#include <filesystem>
 
 
 namespace fs = std::filesystem;
@@ -29,16 +29,15 @@ namespace DB
 
 namespace ErrorCodes
 {
-extern const int INCORRECT_FILE_NAME;
-extern const int HTTP_LENGTH_REQUIRED;
-extern const int INVALID_CONFIG_PARAMETER;
+    extern const int INCORRECT_FILE_NAME;
+    extern const int HTTP_LENGTH_REQUIRED;
+    extern const int INVALID_CONFIG_PARAMETER;
 }
 
 static inline std::unique_ptr<WriteBuffer>
 responseWriteBuffer(HTTPServerRequest & request, HTTPServerResponse & response, UInt64 keep_alive_timeout)
 {
-    auto buf = std::unique_ptr<WriteBuffer>(
-        new WriteBufferFromHTTPServerResponse(response, request.getMethod() == HTTPRequest::HTTP_HEAD, keep_alive_timeout));
+    auto buf = std::unique_ptr<WriteBuffer>(new WriteBufferFromHTTPServerResponse(response, request.getMethod() == HTTPRequest::HTTP_HEAD, keep_alive_timeout));
 
     /// The client can pass a HTTP header indicating supported compression method (gzip or deflate).
     String http_response_compression_methods = request.get("Accept-Encoding", "");
@@ -63,8 +62,8 @@ static inline void trySendExceptionToClient(
 
         /// If HTTP method is POST and Keep-Alive is turned on, we should read the whole request body
         /// to avoid reading part of the current request body in the next request.
-        if (request.getMethod() == Poco::Net::HTTPRequest::HTTP_POST && response.getKeepAlive() && !request.getStream().eof()
-            && exception_code != ErrorCodes::HTTP_LENGTH_REQUIRED)
+        if (request.getMethod() == Poco::Net::HTTPRequest::HTTP_POST
+            && response.getKeepAlive() && !request.getStream().eof() && exception_code != ErrorCodes::HTTP_LENGTH_REQUIRED)
             request.getStream().ignore(std::numeric_limits<std::streamsize>::max());
 
         response.setStatusAndReason(Poco::Net::HTTPResponse::HTTP_INTERNAL_SERVER_ERROR);
@@ -89,8 +88,7 @@ static inline void trySendExceptionToClient(
     }
 }
 
-void StaticRequestHandler::handleRequest(
-    HTTPServerRequest & request, HTTPServerResponse & response, const ProfileEvents::Event & /*write_event*/)
+void StaticRequestHandler::handleRequest(HTTPServerRequest & request, HTTPServerResponse & response, const ProfileEvents::Event & /*write_event*/)
 {
     auto keep_alive_timeout = server.context()->getServerSettings().keep_alive_timeout.totalSeconds();
     auto out = responseWriteBuffer(request, response, keep_alive_timeout);
@@ -103,12 +101,10 @@ void StaticRequestHandler::handleRequest(
             response.setChunkedTransferEncoding(true);
 
         /// Workaround. Poco does not detect 411 Length Required case.
-        if (request.getMethod() == Poco::Net::HTTPRequest::HTTP_POST && !request.getChunkedTransferEncoding()
-            && !request.hasContentLength())
-            throw Exception(
-                ErrorCodes::HTTP_LENGTH_REQUIRED,
-                "The Transfer-Encoding is not chunked and there "
-                "is no Content-Length header for POST request");
+        if (request.getMethod() == Poco::Net::HTTPRequest::HTTP_POST && !request.getChunkedTransferEncoding() && !request.hasContentLength())
+            throw Exception(ErrorCodes::HTTP_LENGTH_REQUIRED,
+                            "The Transfer-Encoding is not chunked and there "
+                            "is no Content-Length header for POST request");
 
         setResponseDefaultHeaders(response, keep_alive_timeout);
         response.setStatusAndReason(Poco::Net::HTTPResponse::HTTPStatus(status));
@@ -149,10 +145,9 @@ void StaticRequestHandler::writeResponse(WriteBuffer & out)
     else if (startsWith(response_expression, config_prefix))
     {
         if (response_expression.size() <= config_prefix.size())
-            throw Exception(
-                ErrorCodes::INVALID_CONFIG_PARAMETER,
-                "Static handling rule handler must contain a complete configuration path, for example: "
-                "config://config_key");
+            throw Exception(ErrorCodes::INVALID_CONFIG_PARAMETER,
+                            "Static handling rule handler must contain a complete configuration path, for example: "
+                            "config://config_key");
 
         const auto & config_path = response_expression.substr(config_prefix.size(), response_expression.size() - config_prefix.size());
         writeString(server.config().getRawString(config_path, "Ok.\n"), out);
@@ -167,8 +162,9 @@ StaticRequestHandler::StaticRequestHandler(
 {
 }
 
-HTTPRequestHandlerFactoryPtr
-createStaticHandlerFactory(IServer & server, const Poco::Util::AbstractConfiguration & config, const std::string & config_prefix)
+HTTPRequestHandlerFactoryPtr createStaticHandlerFactory(IServer & server,
+    const Poco::Util::AbstractConfiguration & config,
+    const std::string & config_prefix)
 {
     int status = config.getInt(config_prefix + ".handler.status", 200);
     std::string response_content = config.getRawString(config_prefix + ".handler.response_content", "Ok.\n");

--- a/src/Server/StaticRequestHandler.h
+++ b/src/Server/StaticRequestHandler.h
@@ -1,8 +1,8 @@
 #pragma once
 
+#include <unordered_map>
 #include <Server/HTTP/HTTPRequestHandler.h>
 #include <base/types.h>
-
 
 namespace DB
 {
@@ -17,15 +17,16 @@ private:
     IServer & server;
 
     int status;
-    String content_type;
+    /// Overrides for response headers.
+    std::unordered_map<String, String> http_response_headers_override;
     String response_expression;
 
 public:
     StaticRequestHandler(
         IServer & server,
         const String & expression,
-        int status_ = 200,
-        const String & content_type_ = "text/html; charset=UTF-8");
+        const std::unordered_map<String, String> & http_response_headers_override_,
+        int status_ = 200);
 
     void writeResponse(WriteBuffer & out);
 

--- a/tests/integration/test_http_handlers_config/test.py
+++ b/tests/integration/test_http_handlers_config/test.py
@@ -84,10 +84,7 @@ def test_dynamic_query_handler():
             headers={"XXX": "xxx"},
         )
         assert 200 == res_custom_ct.status_code
-        assert (
-            "application/whatever; charset=cp1337"
-            == res_custom_ct.headers["content-type"]
-        )
+        assert "application/whatever; charset=cp1337" == res_custom_ct.headers["content-type"]
         assert "it works" == res_custom_ct.headers["X-Test-Http-Response-Headers-Works"]
         assert "also works" == res_custom_ct.headers["X-Test-Http-Response-Headers-Even-Multiple"]
 

--- a/tests/integration/test_http_handlers_config/test.py
+++ b/tests/integration/test_http_handlers_config/test.py
@@ -88,6 +88,8 @@ def test_dynamic_query_handler():
             "application/whatever; charset=cp1337"
             == res_custom_ct.headers["content-type"]
         )
+        assert "it works" == res_custom_ct.headers["X-Test-Http-Response-Headers-Works"]
+        assert "also works" == res_custom_ct.headers["X-Test-Http-Response-Headers-Even-Multiple"]
 
 
 def test_predefined_query_handler():
@@ -146,6 +148,8 @@ def test_predefined_query_handler():
         )
         assert b"max_final_threads\t1\nmax_threads\t1\n" == res2.content
         assert "application/generic+one" == res2.headers["content-type"]
+        assert "it works" == res2.headers["X-Test-Http-Response-Headers-Works"]
+        assert "also works" == res2.headers["X-Test-Http-Response-Headers-Even-Multiple"]
 
         cluster.instance.query(
             "CREATE TABLE test_table (id UInt32, data String) Engine=TinyLog"
@@ -211,6 +215,18 @@ def test_fixed_static_handler():
             == cluster.instance.http_request(
                 "test_get_fixed_static_handler", method="GET", headers={"XXX": "xxx"}
             ).content
+        )
+        assert (
+            "it works"
+            == cluster.instance.http_request(
+                "test_get_fixed_static_handler", method="GET", headers={"XXX": "xxx"}
+            ).headers["X-Test-Http-Response-Headers-Works"]
+        )
+        assert (
+            "also works"
+            == cluster.instance.http_request(
+                "test_get_fixed_static_handler", method="GET", headers={"XXX": "xxx"}
+            ).headers["X-Test-Http-Response-Headers-Even-Multiple"]
         )
 
 

--- a/tests/integration/test_http_handlers_config/test.py
+++ b/tests/integration/test_http_handlers_config/test.py
@@ -84,9 +84,15 @@ def test_dynamic_query_handler():
             headers={"XXX": "xxx"},
         )
         assert 200 == res_custom_ct.status_code
-        assert "application/whatever; charset=cp1337" == res_custom_ct.headers["content-type"]
+        assert (
+            "application/whatever; charset=cp1337"
+            == res_custom_ct.headers["content-type"]
+        )
         assert "it works" == res_custom_ct.headers["X-Test-Http-Response-Headers-Works"]
-        assert "also works" == res_custom_ct.headers["X-Test-Http-Response-Headers-Even-Multiple"]
+        assert (
+            "also works"
+            == res_custom_ct.headers["X-Test-Http-Response-Headers-Even-Multiple"]
+        )
 
 
 def test_predefined_query_handler():
@@ -146,7 +152,9 @@ def test_predefined_query_handler():
         assert b"max_final_threads\t1\nmax_threads\t1\n" == res2.content
         assert "application/generic+one" == res2.headers["content-type"]
         assert "it works" == res2.headers["X-Test-Http-Response-Headers-Works"]
-        assert "also works" == res2.headers["X-Test-Http-Response-Headers-Even-Multiple"]
+        assert (
+            "also works" == res2.headers["X-Test-Http-Response-Headers-Even-Multiple"]
+        )
 
         cluster.instance.query(
             "CREATE TABLE test_table (id UInt32, data String) Engine=TinyLog"

--- a/tests/integration/test_http_handlers_config/test_dynamic_handler/config.xml
+++ b/tests/integration/test_http_handlers_config/test_dynamic_handler/config.xml
@@ -18,6 +18,10 @@
                 <type>dynamic_query_handler</type>
                 <query_param_name>get_dynamic_handler_query</query_param_name>
                 <content_type>application/whatever; charset=cp1337</content_type>
+                <http_response_headers>
+                  <X-Test-Http-Response-Headers-Works>it works</X-Test-Http-Response-Headers-Works>
+                  <X-Test-Http-Response-Headers-Even-Multiple>also works</X-Test-Http-Response-Headers-Even-Multiple>
+                </http_response_headers>
             </handler>
         </rule>
     </http_handlers>

--- a/tests/integration/test_http_handlers_config/test_predefined_handler/config.xml
+++ b/tests/integration/test_http_handlers_config/test_predefined_handler/config.xml
@@ -19,6 +19,10 @@
                 <type>predefined_query_handler</type>
                 <query>SELECT name, value FROM system.settings WHERE name = {setting_name_1:String} OR name = {setting_name_2:String}</query>
                 <content_type>application/generic+one</content_type>
+                <http_response_headers>
+                  <X-Test-Http-Response-Headers-Works>it works</X-Test-Http-Response-Headers-Works>
+                  <X-Test-Http-Response-Headers-Even-Multiple>also works</X-Test-Http-Response-Headers-Even-Multiple>
+                </http_response_headers>
             </handler>
         </rule>
         <rule>

--- a/tests/integration/test_http_handlers_config/test_static_handler/config.xml
+++ b/tests/integration/test_http_handlers_config/test_static_handler/config.xml
@@ -12,6 +12,10 @@
                 <status>402</status>
                 <content_type>text/html; charset=UTF-8</content_type>
                 <response_content>Test get static handler and fix content</response_content>
+                <http_response_headers>
+                  <X-Test-Http-Response-Headers-Works>it works</X-Test-Http-Response-Headers-Works>
+                  <X-Test-Http-Response-Headers-Even-Multiple>also works</X-Test-Http-Response-Headers-Even-Multiple>
+                </http_response_headers>
             </handler>
         </rule>
 


### PR DESCRIPTION
- Implementing https://github.com/ClickHouse/ClickHouse/issues/59620
- Deprecating `content_type` setting (still supported).

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Add `http_response_headers` setting to support custom response headers in custom HTTP handlers 

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
