### PR TITLE
Go back to upstream lz4 submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,7 +6,7 @@
 	url = https://github.com/facebook/zstd
 [submodule "contrib/lz4"]
 	path = contrib/lz4
-	url = https://github.com/ClickHouse/lz4
+	url = https://github.com/lz4/lz4
 [submodule "contrib/librdkafka"]
 	path = contrib/librdkafka
 	url = https://github.com/ClickHouse/librdkafka


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Go back to upstream lz4

### Documentation entry for user-facing changes

No code changes. After the latest merge and the update to our fork we were using the exact same code as upstream, so as a first step go back to upstream url. In the future we can upgrade the submodule if we want (but I didn't see anything useful in the newer commits except AIO with requires rewrites).

Closes https://github.com/ClickHouse/ClickHouse/issues/53815