### PR TITLE
[Docs] Use ReplicatedMergeTree not ReplicatedReplacingMergeTree for d…

### DIFF
--- a/docs/en/engines/table-engines/mergetree-family/replication.md
+++ b/docs/en/engines/table-engines/mergetree-family/replication.md
@@ -10,7 +10,7 @@ sidebar_label: Data Replication
 In ClickHouse Cloud replication is managed for you. Please create your tables without adding arguments.  For example, in the text below you would replace:
 
 ```sql
-ENGINE = ReplicatedReplacingMergeTree(
+ENGINE = ReplicatedMergeTree(
     '/clickhouse/tables/{shard}/table_name',
     '{replica}',
     ver
@@ -20,7 +20,7 @@ ENGINE = ReplicatedReplacingMergeTree(
 with:
 
 ```sql
-ENGINE = ReplicatedReplacingMergeTree
+ENGINE = ReplicatedMergeTree
 ```
 :::
 
@@ -140,11 +140,11 @@ The system monitors data synchronicity on replicas and is able to recover after 
 :::note
 In ClickHouse Cloud replication is managed for you. Please create your tables without adding arguments.  For example, in the text below you would replace:
 ```
-ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/{shard}/table_name', '{replica}', ver)
+ENGINE = ReplicatedMergeTree('/clickhouse/tables/{shard}/table_name', '{replica}', ver)
 ```
 with:
 ```
-ENGINE = ReplicatedReplacingMergeTree
+ENGINE = ReplicatedMergeTree
 ```
 :::
 
@@ -177,7 +177,7 @@ CREATE TABLE table_name
     CounterID UInt32,
     UserID UInt32,
     ver UInt16
-) ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/{shard}/table_name', '{replica}', ver)
+) ENGINE = ReplicatedMergeTree('/clickhouse/tables/{shard}/table_name', '{replica}', ver)
 PARTITION BY toYYYYMM(EventDate)
 ORDER BY (CounterID, EventDate, intHash32(UserID))
 SAMPLE BY intHash32(UserID);


### PR DESCRIPTION
…ata replication examples

A user had the following feedback:

> I was looking to understand the ReplicatedMergeTree engine for data replication. The examples in the public doc seem to alternate between ReplicatedReplacingMergeTree and ReplicatedMergeTree. I initially thought you can use ReplicatedMergeTree and ReplicatedReplacingMergeTree interchangeably and wasn't sure why the examples keep switching between the two.

To simplify and to reduce confusion, we should use `ReplicatedMergeTree` only for examples, which will not affect understanding of the data replication guide: https://clickhouse.com/docs/en/engines/table-engines/mergetree-family/replication

### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Use ReplicatedMergeTree not ReplicatedReplacingMergeTree for data replication examples
