### PR TITLE
Ignore global profiler if system.trace_log is not enabled and fix really disable it for keeper standalone build

### DIFF
--- a/src/Common/ThreadPool.cpp
+++ b/src/Common/ThreadPool.cpp
@@ -494,8 +494,10 @@ void ThreadPoolImpl<Thread>::worker(typename std::list<Thread>::iterator thread_
 
 template class ThreadPoolImpl<std::thread>;
 template class ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>;
+template class ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, false>>;
 template class ThreadFromGlobalPoolImpl<true, true>;
 template class ThreadFromGlobalPoolImpl<true, false>;
+template class ThreadFromGlobalPoolImpl<false, false>;
 
 std::unique_ptr<GlobalThreadPool> GlobalThreadPool::the_instance;
 

--- a/src/Common/ThreadPool.h
+++ b/src/Common/ThreadPool.h
@@ -242,6 +242,11 @@ public:
                 if (unlikely(global_profiler_real_time_period != 0 || global_profiler_cpu_time_period != 0))
                     thread_status.initGlobalProfiler(global_profiler_real_time_period, global_profiler_cpu_time_period);
             }
+            else
+            {
+                UNUSED(global_profiler_real_time_period);
+                UNUSED(global_profiler_cpu_time_period);
+            }
 
             std::apply(function, arguments);
         },

--- a/src/Common/ThreadStatus.cpp
+++ b/src/Common/ThreadStatus.cpp
@@ -124,31 +124,6 @@ ThreadStatus::ThreadStatus(bool check_current_thread_on_destruction_)
 #endif
 }
 
-void ThreadStatus::initGlobalProfiler([[maybe_unused]] UInt64 global_profiler_real_time_period, [[maybe_unused]] UInt64 global_profiler_cpu_time_period)
-{
-#if !defined(SANITIZER) && !defined(__APPLE__)
-    /// profilers are useless without trace collector
-    auto global_context_ptr = global_context.lock();
-    if (!global_context_ptr || !global_context_ptr->hasTraceCollector())
-        return;
-
-    try
-    {
-        if (global_profiler_real_time_period > 0)
-            query_profiler_real = std::make_unique<QueryProfilerReal>(thread_id,
-                /* period= */ static_cast<UInt32>(global_profiler_real_time_period));
-
-        if (global_profiler_cpu_time_period > 0)
-            query_profiler_cpu = std::make_unique<QueryProfilerCPU>(thread_id,
-                /* period= */ static_cast<UInt32>(global_profiler_cpu_time_period));
-    }
-    catch (...)
-    {
-        tryLogCurrentException("ThreadStatus", "Cannot initialize GlobalProfiler");
-    }
-#endif
-}
-
 ThreadGroupPtr ThreadStatus::getThreadGroup() const
 {
     chassert(current_thread == this);

--- a/src/Common/ThreadStatus.cpp
+++ b/src/Common/ThreadStatus.cpp
@@ -127,6 +127,11 @@ ThreadStatus::ThreadStatus(bool check_current_thread_on_destruction_)
 void ThreadStatus::initGlobalProfiler([[maybe_unused]] UInt64 global_profiler_real_time_period, [[maybe_unused]] UInt64 global_profiler_cpu_time_period)
 {
 #if !defined(SANITIZER) && !defined(CLICKHOUSE_KEEPER_STANDALONE_BUILD) && !defined(__APPLE__)
+    /// profilers are useless without trace collector
+    auto global_context_ptr = global_context.lock();
+    if (!global_context_ptr || !global_context_ptr->hasTraceCollector())
+        return;
+
     try
     {
         if (global_profiler_real_time_period > 0)

--- a/src/Common/ThreadStatus.cpp
+++ b/src/Common/ThreadStatus.cpp
@@ -126,7 +126,7 @@ ThreadStatus::ThreadStatus(bool check_current_thread_on_destruction_)
 
 void ThreadStatus::initGlobalProfiler([[maybe_unused]] UInt64 global_profiler_real_time_period, [[maybe_unused]] UInt64 global_profiler_cpu_time_period)
 {
-#if !defined(SANITIZER) && !defined(CLICKHOUSE_KEEPER_STANDALONE_BUILD) && !defined(__APPLE__)
+#if !defined(SANITIZER) && !defined(__APPLE__)
     /// profilers are useless without trace collector
     auto global_context_ptr = global_context.lock();
     if (!global_context_ptr || !global_context_ptr->hasTraceCollector())

--- a/src/Common/ZooKeeper/examples/CMakeLists.txt
+++ b/src/Common/ZooKeeper/examples/CMakeLists.txt
@@ -1,8 +1,16 @@
 clickhouse_add_executable(zkutil_test_commands zkutil_test_commands.cpp)
-target_link_libraries(zkutil_test_commands PRIVATE clickhouse_common_zookeeper_no_log)
+target_link_libraries(zkutil_test_commands PRIVATE
+    clickhouse_common_zookeeper_no_log
+    dbms)
 
 clickhouse_add_executable(zkutil_test_commands_new_lib zkutil_test_commands_new_lib.cpp)
-target_link_libraries(zkutil_test_commands_new_lib PRIVATE clickhouse_common_zookeeper_no_log clickhouse_compression string_utils)
+target_link_libraries(zkutil_test_commands_new_lib PRIVATE
+    clickhouse_common_zookeeper_no_log
+    clickhouse_compression
+    string_utils
+    dbms)
 
 clickhouse_add_executable(zkutil_test_async zkutil_test_async.cpp)
-target_link_libraries(zkutil_test_async PRIVATE clickhouse_common_zookeeper_no_log)
+target_link_libraries(zkutil_test_async PRIVATE
+    clickhouse_common_zookeeper_no_log
+    dbms)

--- a/src/Common/examples/parallel_aggregation.cpp
+++ b/src/Common/examples/parallel_aggregation.cpp
@@ -20,6 +20,9 @@
 #include <Common/CurrentMetrics.h>
 
 
+using ThreadFromGlobalPoolSimple = ThreadFromGlobalPoolImpl</* propagate_opentelemetry_context= */ false, /* global_trace_collector_allowed= */ false>;
+using SimpleThreadPool = ThreadPoolImpl<ThreadFromGlobalPoolSimple>;
+
 using Key = UInt64;
 using Value = UInt64;
 
@@ -255,7 +258,7 @@ int main(int argc, char ** argv)
 
     std::cerr << std::fixed << std::setprecision(2);
 
-    ThreadPool pool(CurrentMetrics::LocalThread, CurrentMetrics::LocalThreadActive, CurrentMetrics::LocalThreadScheduled, num_threads);
+    SimpleThreadPool pool(CurrentMetrics::LocalThread, CurrentMetrics::LocalThreadActive, CurrentMetrics::LocalThreadScheduled, num_threads);
 
     Source data(n);
 

--- a/src/Common/examples/parallel_aggregation2.cpp
+++ b/src/Common/examples/parallel_aggregation2.cpp
@@ -20,6 +20,9 @@
 #include <Common/CurrentMetrics.h>
 
 
+using ThreadFromGlobalPoolSimple = ThreadFromGlobalPoolImpl</* propagate_opentelemetry_context= */ false, /* global_trace_collector_allowed= */ false>;
+using SimpleThreadPool = ThreadPoolImpl<ThreadFromGlobalPoolSimple>;
+
 using Key = UInt64;
 using Value = UInt64;
 using Source = std::vector<Key>;
@@ -38,7 +41,7 @@ struct AggregateIndependent
     template <typename Creator, typename Updater>
     static void NO_INLINE execute(const Source & data, size_t num_threads, std::vector<std::unique_ptr<Map>> & results,
                         Creator && creator, Updater && updater,
-                        ThreadPool & pool)
+                        SimpleThreadPool & pool)
     {
         results.reserve(num_threads);
         for (size_t i = 0; i < num_threads; ++i)
@@ -76,7 +79,7 @@ struct AggregateIndependentWithSequentialKeysOptimization
     template <typename Creator, typename Updater>
     static void NO_INLINE execute(const Source & data, size_t num_threads, std::vector<std::unique_ptr<Map>> & results,
                         Creator && creator, Updater && updater,
-                        ThreadPool & pool)
+                        SimpleThreadPool & pool)
     {
         results.reserve(num_threads);
         for (size_t i = 0; i < num_threads; ++i)
@@ -124,7 +127,7 @@ struct MergeSequential
     template <typename Merger>
     static void NO_INLINE execute(Map ** source_maps, size_t num_maps, Map *& result_map,
                         Merger && merger,
-                        ThreadPool &)
+                        SimpleThreadPool &)
     {
         for (size_t i = 1; i < num_maps; ++i)
         {
@@ -144,7 +147,7 @@ struct MergeSequentialTransposed    /// In practice not better than usual.
     template <typename Merger>
     static void NO_INLINE execute(Map ** source_maps, size_t num_maps, Map *& result_map,
                         Merger && merger,
-                        ThreadPool &)
+                        SimpleThreadPool &)
     {
         std::vector<typename Map::iterator> iterators(num_maps);
         for (size_t i = 1; i < num_maps; ++i)
@@ -177,7 +180,7 @@ struct MergeParallelForTwoLevelTable
     template <typename Merger>
     static void NO_INLINE execute(Map ** source_maps, size_t num_maps, Map *& result_map,
                         Merger && merger,
-                        ThreadPool & pool)
+                        SimpleThreadPool & pool)
     {
         for (size_t bucket = 0; bucket < Map::NUM_BUCKETS; ++bucket)
             pool.scheduleOrThrowOnError([&, bucket, num_maps]
@@ -202,7 +205,7 @@ struct Work
     template <typename Creator, typename Updater, typename Merger>
     static void NO_INLINE execute(const Source & data, size_t num_threads,
                         Creator && creator, Updater && updater, Merger && merger,
-                        ThreadPool & pool)
+                        SimpleThreadPool & pool)
     {
         std::vector<std::unique_ptr<Map>> intermediate_results;
 
@@ -282,7 +285,7 @@ int main(int argc, char ** argv)
 
     std::cerr << std::fixed << std::setprecision(2);
 
-    ThreadPool pool(CurrentMetrics::LocalThread, CurrentMetrics::LocalThreadActive, CurrentMetrics::LocalThreadScheduled, num_threads);
+    SimpleThreadPool pool(CurrentMetrics::LocalThread, CurrentMetrics::LocalThreadActive, CurrentMetrics::LocalThreadScheduled, num_threads);
 
     Source data(n);
 

--- a/src/Common/examples/thread_creation_latency.cpp
+++ b/src/Common/examples/thread_creation_latency.cpp
@@ -14,6 +14,8 @@ int value = 0;
 static void f() { ++value; }
 static void * g(void *) { f(); return {}; }
 
+using ThreadFromGlobalPoolSimple = ThreadFromGlobalPoolImpl</* propagate_opentelemetry_context= */ false, /* global_trace_collector_allowed= */ false>;
+using SimpleThreadPool = ThreadPoolImpl<ThreadFromGlobalPoolSimple>;
 
 namespace CurrentMetrics
 {
@@ -72,7 +74,7 @@ int main(int argc, char ** argv)
 
     test(n, "Create and destroy ThreadPool each iteration", []
     {
-        ThreadPool tp(CurrentMetrics::LocalThread, CurrentMetrics::LocalThreadActive, CurrentMetrics::LocalThreadScheduled, 1);
+        SimpleThreadPool tp(CurrentMetrics::LocalThread, CurrentMetrics::LocalThreadActive, CurrentMetrics::LocalThreadScheduled, 1);
         tp.scheduleOrThrowOnError(f);
         tp.wait();
     });
@@ -93,7 +95,7 @@ int main(int argc, char ** argv)
     });
 
     {
-        ThreadPool tp(CurrentMetrics::LocalThread, CurrentMetrics::LocalThreadActive, CurrentMetrics::LocalThreadScheduled, 1);
+        SimpleThreadPool tp(CurrentMetrics::LocalThread, CurrentMetrics::LocalThreadActive, CurrentMetrics::LocalThreadScheduled, 1);
 
         test(n, "Schedule job for Threadpool each iteration", [&tp]
         {
@@ -103,7 +105,7 @@ int main(int argc, char ** argv)
     }
 
     {
-        ThreadPool tp(CurrentMetrics::LocalThread, CurrentMetrics::LocalThreadActive, CurrentMetrics::LocalThreadScheduled, 128);
+        SimpleThreadPool tp(CurrentMetrics::LocalThread, CurrentMetrics::LocalThreadActive, CurrentMetrics::LocalThreadScheduled, 128);
 
         test(n, "Schedule job for Threadpool with 128 threads each iteration", [&tp]
         {

--- a/src/Common/tests/gtest_rw_lock.cpp
+++ b/src/Common/tests/gtest_rw_lock.cpp
@@ -3,8 +3,8 @@
 #include <Common/Exception.h>
 #include <Common/RWLock.h>
 #include <Common/Stopwatch.h>
+#include <Core/Types.h>
 #include <base/types.h>
-#include <Common/ThreadPool.h>
 #include <base/phdr_cache.h>
 #include <random>
 #include <pcg_random.hpp>
@@ -541,7 +541,7 @@ TEST(Common, RWLockWriteLockTimeoutDuringWriteWithWaitingRead)
         events.add(wc ? "Locked wb" : "Failed to lock wb");
         EXPECT_EQ(wc, nullptr);
     });
-    
+
     std::thread rc_thread([&] ()
     {
         std::this_thread::sleep_for(std::chrono::duration<int, std::milli>(200));

--- a/src/Coordination/Standalone/Context.cpp
+++ b/src/Coordination/Standalone/Context.cpp
@@ -457,4 +457,9 @@ const ServerSettings & Context::getServerSettings() const
     return shared->server_settings;
 }
 
+bool Context::hasTraceCollector() const
+{
+    return false;
+}
+
 }

--- a/src/Coordination/Standalone/Context.h
+++ b/src/Coordination/Standalone/Context.h
@@ -163,6 +163,8 @@ public:
     zkutil::ZooKeeperPtr getZooKeeper() const;
 
     const ServerSettings & getServerSettings() const;
+
+    bool hasTraceCollector() const;
 };
 
 }

--- a/src/Coordination/Standalone/ThreadStatusExt.cpp
+++ b/src/Coordination/Standalone/ThreadStatusExt.cpp
@@ -1,4 +1,5 @@
 #include <Common/CurrentThread.h>
+#include <Common/ThreadStatus.h>
 
 namespace DB
 {
@@ -8,6 +9,10 @@ void CurrentThread::detachFromGroupIfNotDetached()
 }
 
 void CurrentThread::attachToGroup(const ThreadGroupPtr &)
+{
+}
+
+void ThreadStatus::initGlobalProfiler(UInt64 /*global_profiler_real_time_period*/, UInt64 /*global_profiler_cpu_time_period*/)
 {
 }
 

--- a/src/Databases/MySQL/tests/gtest_mysql_binlog.cpp
+++ b/src/Databases/MySQL/tests/gtest_mysql_binlog.cpp
@@ -1,4 +1,3 @@
-#include <Common/ThreadPool.h>
 #include <Databases/MySQL/MySQLBinlog.h>
 #include <Databases/MySQL/MySQLBinlogEventsDispatcher.h>
 #include <Databases/MySQL/MySQLBinlogClient.h>

--- a/src/Functions/CMakeLists.txt
+++ b/src/Functions/CMakeLists.txt
@@ -15,6 +15,8 @@ extract_into_parent_list(clickhouse_functions_sources dbms_sources
     checkHyperscanRegexp.cpp
     array/has.cpp
     CastOverloadResolver.cpp
+    # Provides dependency for cast - createFunctionBaseCast()
+    FunctionsConversion.cpp
 )
 extract_into_parent_list(clickhouse_functions_headers dbms_headers
     IFunction.h

--- a/src/Functions/CMakeLists.txt
+++ b/src/Functions/CMakeLists.txt
@@ -3,7 +3,7 @@ add_subdirectory(divide)
 include("${ClickHouse_SOURCE_DIR}/cmake/dbms_glob_sources.cmake")
 add_headers_and_sources(clickhouse_functions .)
 
-extract_into_parent_list(clickhouse_functions_sources dbms_sources
+set(DBMS_FUNCTIONS
     IFunction.cpp
     FunctionFactory.cpp
     FunctionHelpers.cpp
@@ -18,6 +18,7 @@ extract_into_parent_list(clickhouse_functions_sources dbms_sources
     # Provides dependency for cast - createFunctionBaseCast()
     FunctionsConversion.cpp
 )
+extract_into_parent_list(clickhouse_functions_sources dbms_sources ${DBMS_FUNCTIONS})
 extract_into_parent_list(clickhouse_functions_headers dbms_headers
     IFunction.h
     FunctionFactory.h
@@ -28,6 +29,10 @@ extract_into_parent_list(clickhouse_functions_headers dbms_headers
 )
 
 add_library(clickhouse_functions_obj OBJECT ${clickhouse_functions_headers} ${clickhouse_functions_sources})
+if (OMIT_HEAVY_DEBUG_SYMBOLS)
+    target_compile_options(clickhouse_functions_obj PRIVATE "-g0")
+    set_source_files_properties(${DBMS_FUNCTIONS} PROPERTIES COMPILE_FLAGS "-g0")
+endif()
 
 list (APPEND OBJECT_LIBS $<TARGET_OBJECTS:clickhouse_functions_obj>)
 
@@ -62,10 +67,6 @@ endif()
 
 if (TARGET OpenSSL::Crypto)
     list (APPEND PUBLIC_LIBS OpenSSL::Crypto)
-endif()
-
-if (OMIT_HEAVY_DEBUG_SYMBOLS)
-    target_compile_options(clickhouse_functions_obj PRIVATE "-g0")
 endif()
 
 if (TARGET ch_contrib::icu)

--- a/src/Interpreters/ThreadStatusExt.cpp
+++ b/src/Interpreters/ThreadStatusExt.cpp
@@ -458,6 +458,31 @@ void ThreadStatus::resetPerformanceCountersLastUsage()
         taskstats->reset();
 }
 
+void ThreadStatus::initGlobalProfiler([[maybe_unused]] UInt64 global_profiler_real_time_period, [[maybe_unused]] UInt64 global_profiler_cpu_time_period)
+{
+#if !defined(SANITIZER) && !defined(__APPLE__)
+    /// profilers are useless without trace collector
+    auto global_context_ptr = global_context.lock();
+    if (!global_context_ptr || !global_context_ptr->hasTraceCollector())
+        return;
+
+    try
+    {
+        if (global_profiler_real_time_period > 0)
+            query_profiler_real = std::make_unique<QueryProfilerReal>(thread_id,
+                /* period= */ static_cast<UInt32>(global_profiler_real_time_period));
+
+        if (global_profiler_cpu_time_period > 0)
+            query_profiler_cpu = std::make_unique<QueryProfilerCPU>(thread_id,
+                /* period= */ static_cast<UInt32>(global_profiler_cpu_time_period));
+    }
+    catch (...)
+    {
+        tryLogCurrentException("ThreadStatus", "Cannot initialize GlobalProfiler");
+    }
+#endif
+}
+
 void ThreadStatus::initQueryProfiler()
 {
     if (internal_thread)

--- a/utils/check-style/check-large-objects.sh
+++ b/utils/check-style/check-large-objects.sh
@@ -7,6 +7,8 @@ export LC_ALL=C # The "total" should be printed without localization
 TU_EXCLUDES=(
     AggregateFunctionUniq
     Aggregator
+    # FIXME: Exclude for now
+    FunctionsConversion
 )
 
 if find $1 -name '*.o' | xargs wc -c | grep --regexp='\.o$' | sort -rn | awk '{ if ($1 > 50000000) print }' \

--- a/utils/zookeeper-cli/CMakeLists.txt
+++ b/utils/zookeeper-cli/CMakeLists.txt
@@ -1,4 +1,6 @@
 clickhouse_add_executable(clickhouse-zookeeper-cli
     zookeeper-cli.cpp
     ${ClickHouse_SOURCE_DIR}/src/Client/LineReader.cpp)
-target_link_libraries(clickhouse-zookeeper-cli PRIVATE clickhouse_common_zookeeper_no_log)
+target_link_libraries(clickhouse-zookeeper-cli PRIVATE
+    clickhouse_common_zookeeper_no_log
+    dbms)

--- a/utils/zookeeper-dump-tree/CMakeLists.txt
+++ b/utils/zookeeper-dump-tree/CMakeLists.txt
@@ -1,2 +1,6 @@
 clickhouse_add_executable (zookeeper-dump-tree main.cpp ${SRCS})
-target_link_libraries(zookeeper-dump-tree PRIVATE clickhouse_common_zookeeper_no_log clickhouse_common_io boost::program_options)
+target_link_libraries(zookeeper-dump-tree PRIVATE
+    clickhouse_common_zookeeper_no_log
+    clickhouse_common_io
+    dbms
+    boost::program_options)

--- a/utils/zookeeper-remove-by-list/CMakeLists.txt
+++ b/utils/zookeeper-remove-by-list/CMakeLists.txt
@@ -1,2 +1,5 @@
 clickhouse_add_executable (zookeeper-remove-by-list main.cpp ${SRCS})
-target_link_libraries(zookeeper-remove-by-list PRIVATE clickhouse_common_zookeeper_no_log boost::program_options)
+target_link_libraries(zookeeper-remove-by-list PRIVATE
+    clickhouse_common_zookeeper_no_log
+    dbms
+    boost::program_options)


### PR DESCRIPTION
Note, there is no need to consider it as a bug-fix and backport it I guess, since by default it is turned OFF, so it should not be enabled for keeper standalone build.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Follow-up for: https://github.com/ClickHouse/ClickHouse/pull/62189 (cc @alesapin )