### PR TITLE
Fix tests flakiness due to long SYSTEM FLUSH LOGS (explicitly specify old_parts_lifetime)

### DIFF
--- a/tests/queries/0_stateless/02362_part_log_merge_algorithm.sql
+++ b/tests/queries/0_stateless/02362_part_log_merge_algorithm.sql
@@ -2,7 +2,8 @@ CREATE TABLE data_horizontal (
     key Int
 )
 Engine=MergeTree()
-ORDER BY key;
+ORDER BY key
+SETTINGS old_parts_lifetime=600;
 
 INSERT INTO data_horizontal VALUES (1);
 OPTIMIZE TABLE data_horizontal FINAL;
@@ -17,7 +18,8 @@ CREATE TABLE data_vertical
 ENGINE = MergeTree()
 ORDER BY key
 SETTINGS index_granularity_bytes = 0, enable_mixed_granularity_parts = 0, min_bytes_for_wide_part = 0,
-vertical_merge_algorithm_min_rows_to_activate = 1, vertical_merge_algorithm_min_columns_to_activate = 1;
+vertical_merge_algorithm_min_rows_to_activate = 1, vertical_merge_algorithm_min_columns_to_activate = 1,
+old_parts_lifetime=600;
 
 INSERT INTO data_vertical VALUES (1, '1');
 INSERT INTO data_vertical VALUES (2, '2');

--- a/tests/queries/0_stateless/02491_part_log_has_table_uuid.sql
+++ b/tests/queries/0_stateless/02491_part_log_has_table_uuid.sql
@@ -1,6 +1,6 @@
 -- Tags: no-ordinary-database
 
-create table data_02491 (key Int) engine=MergeTree() order by tuple();
+create table data_02491 (key Int) engine=MergeTree() order by tuple() settings old_parts_lifetime=600;
 insert into data_02491 values (1);
 optimize table data_02491 final;
 truncate table data_02491;


### PR DESCRIPTION
SYSTEM FLUSH LOGS can take awhile, which leads to that some parts may be removed in case of old_parts_lifetime randomized to 10 [1]:

    2024.05.10 21:17:49.920514 [ 14551 ] {c15b0b5e-a1d1-4c87-b983-61ab185d50c1} <Debug> executeQuery: (from [::1]:58902) (comment: 02362_part_log_merge_algorithm.sql) SYSTEM FLUSH LOGS; (stage: Complete)
    2024.05.10 21:17:59.216021 [ 1416 ] {} <Trace> test_9436z6sd.data_horizontal (80dc2a4b-5a0c-4e10-9956-2b0cc1fa0b49): Found 1 old parts to remove. Parts: [all_1_1_0]
    2024.05.10 21:17:59.216192 [ 1416 ] {} <Debug> test_9436z6sd.data_horizontal (80dc2a4b-5a0c-4e10-9956-2b0cc1fa0b49): Removing 1 parts from filesystem (serially): Parts: [all_1_1_0]
    2024.05.10 21:17:59.217760 [ 1416 ] {} <Debug> test_9436z6sd.data_horizontal (80dc2a4b-5a0c-4e10-9956-2b0cc1fa0b49): Removing 1 parts from memory: Parts: [all_1_1_0]
    2024.05.10 21:18:09.403934 [ 14551 ] {8e961419-d1d1-4c0b-b706-8a0b3cdbb1af} <Debug> executeQuery: (from [::1]:58902) (comment: 02362_part_log_merge_algorithm.sql) SELECT table, part_name, event_type, merge_algorithm FROM system.part_log WHERE event_date >= yesterday() AND database = currentDatabase() AND table = 'data_horizontal' ORDER BY event_time_microseconds; (stage: Complete)

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/63634/72f813a42067a94284bdac649751c52c056d53be/stateless_tests__debug__[1_5]/run.log

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
