### PR TITLE
Update clickhouse-test help section

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -2950,7 +2950,7 @@ def parse_args():
 
     parser.add_argument("--extract_from_config", help="extract-from-config program")
     parser.add_argument(
-        "--configclient", help="Client config (if you use not default ports)"
+        "--configclient", help="Client config (if you do not use default ports)"
     )
     parser.add_argument(
         "--configserver",
@@ -2970,7 +2970,7 @@ def parse_args():
     parser.add_argument(
         "--global_time_limit",
         type=int,
-        help="Stop if executing more than specified time (after current test finished)",
+        help="Stop if executing more than specified time (after current test is finished)",
     )
     parser.add_argument("test", nargs="*", help="Optional test case name regex")
     parser.add_argument(


### PR DESCRIPTION
Fixed a couple of linguistic errors.

Changelog category (leave one):

Not for changelog (changelog entry is not required)