### PR TITLE
Prevent conversion to Replicated if zookeeper path already exists

### DIFF
--- a/tests/integration/test_modify_engine_on_restart/configs/config.d/clusters.xml
+++ b/tests/integration/test_modify_engine_on_restart/configs/config.d/clusters.xml
@@ -15,6 +15,8 @@
     </cluster>
 </remote_servers>
 
+<default_replica_path>/clickhouse/tables/{database}/{table}/{uuid}</default_replica_path>
+
 <macros>
         <shard>01</shard>
 </macros>

--- a/tests/integration/test_modify_engine_on_restart/configs/config.d/clusters.xml
+++ b/tests/integration/test_modify_engine_on_restart/configs/config.d/clusters.xml
@@ -15,8 +15,6 @@
     </cluster>
 </remote_servers>
 
-<default_replica_path>/clickhouse/tables/{database}/{table}/{uuid}</default_replica_path>
-
 <macros>
         <shard>01</shard>
 </macros>

--- a/tests/integration/test_modify_engine_on_restart/configs/config.d/clusters_zk_path.xml
+++ b/tests/integration/test_modify_engine_on_restart/configs/config.d/clusters_zk_path.xml
@@ -15,6 +15,6 @@
         <shard>01</shard>
 </macros>
 
-<default_replica_path>/lol/kek/'/{uuid}</default_replica_path>
+<default_replica_path>/clickhouse/'/{database}/{table}/{uuid}</default_replica_path>
 
 </clickhouse>

--- a/tests/integration/test_modify_engine_on_restart/test.py
+++ b/tests/integration/test_modify_engine_on_restart/test.py
@@ -1,5 +1,9 @@
 import pytest
-from test_modify_engine_on_restart.common import check_flags_deleted, set_convert_flags
+from test_modify_engine_on_restart.common import (
+    check_flags_deleted,
+    set_convert_flags,
+    get_table_path,
+)
 from helpers.cluster import ClickHouseCluster
 
 cluster = ClickHouseCluster(__file__)
@@ -120,7 +124,7 @@ def check_replica_added():
 
     q(
         ch2,
-        f"CREATE TABLE rmt ( A Int64, D Date, S String ) ENGINE ReplicatedMergeTree('/clickhouse/tables/{uuid}/{{shard}}', '{{replica}}') PARTITION BY toYYYYMM(D) ORDER BY A",
+        f"CREATE TABLE rmt ( A Int64, D Date, S String ) ENGINE ReplicatedMergeTree('/clickhouse/tables/{database_name}/rmt/{uuid}', '{{replica}}') PARTITION BY toYYYYMM(D) ORDER BY A",
     )
 
     ch2.query(database=database_name, sql="SYSTEM SYNC REPLICA rmt", timeout=20)
@@ -136,7 +140,7 @@ def check_replica_added():
 
 
 def test_modify_engine_on_restart(started_cluster):
-    ch1.query("CREATE DATABASE " + database_name + " ON CLUSTER cluster")
+    ch1.query("CREATE DATABASE IF NOT EXISTS " + database_name + " ON CLUSTER cluster")
 
     create_tables()
 
@@ -159,3 +163,38 @@ def test_modify_engine_on_restart(started_cluster):
     ch1.restart_clickhouse()
 
     check_tables(True)
+
+
+def test_modify_engine_fails_if_zk_path_exists(started_cluster):
+    ch1.query("CREATE DATABASE IF NOT EXISTS " + database_name + " ON CLUSTER cluster")
+
+    q(
+        ch1,
+        "CREATE TABLE already_exists_1 ( A Int64, D Date, S String ) ENGINE MergeTree() PARTITION BY toYYYYMM(D) ORDER BY A;",
+    )
+    uuid = q(
+        ch1,
+        f"SELECT uuid FROM system.tables WHERE table = 'already_exists_1' and database = '{database_name}'",
+    ).strip("'[]\n")
+
+    q(
+        ch1,
+        f"CREATE TABLE already_exists_2 ( A Int64, D Date, S String ) ENGINE ReplicatedMergeTree('/clickhouse/tables/{database_name}/already_exists_1/{uuid}', 'r2') PARTITION BY toYYYYMM(D) ORDER BY A;",
+    )
+
+    set_convert_flags(ch1, database_name, ["already_exists_1"])
+
+    table_data_path = get_table_path(ch1, "already_exists_1", database_name)
+
+    ch1.stop_clickhouse()
+    ch1.start_clickhouse(retry_start=False, expected_to_fail=True)
+
+    # Check if we can cancel convertation
+    ch1.exec_in_container(
+        [
+            "bash",
+            "-c",
+            f"rm {table_data_path}convert_to_replicated",
+        ]
+    )
+    ch1.start_clickhouse()

--- a/tests/integration/test_modify_engine_on_restart/test_unusual_path.py
+++ b/tests/integration/test_modify_engine_on_restart/test_unusual_path.py
@@ -1,0 +1,92 @@
+import pytest
+from test_modify_engine_on_restart.common import check_flags_deleted, set_convert_flags
+from helpers.cluster import ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__)
+ch1 = cluster.add_instance(
+    "ch1",
+    main_configs=[
+        "configs/config.d/clusters_zk_path.xml",
+        "configs/config.d/distributed_ddl.xml",
+    ],
+    with_zookeeper=True,
+    macros={"replica": "node1"},
+    stay_alive=True,
+)
+
+database_name = "modify_engine_unusual_path"
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+        yield cluster
+
+    finally:
+        cluster.shutdown()
+
+
+def q(node, query):
+    return node.query(database=database_name, sql=query)
+
+
+def create_tables():
+    # Check one argument
+    q(
+        ch1,
+        "CREATE TABLE replacing_ver ( A Int64, D Date, S String ) ENGINE = ReplacingMergeTree(D) PARTITION BY toYYYYMM(D) ORDER BY A",
+    )
+
+    # Check more than one argument
+    q(
+        ch1,
+        "CREATE TABLE collapsing_ver ( ID UInt64, Sign Int8, Version UInt8 ) ENGINE = VersionedCollapsingMergeTree(Sign, Version) ORDER BY ID",
+    )
+
+
+def check_tables():
+    # Check tables exists
+    assert (
+        q(
+            ch1,
+            "SHOW TABLES",
+        ).strip()
+        == "collapsing_ver\nreplacing_ver"
+    )
+
+    # Check engines
+    assert (
+        q(
+            ch1,
+            f"SELECT engine_full FROM system.tables WHERE database = '{database_name}' and name = 'replacing_ver'",
+        )
+        .strip()
+        .startswith(
+            "ReplicatedReplacingMergeTree(\\'/clickhouse/\\\\\\'/{database}/{table}/{uuid}\\', \\'{replica}\\', D)"
+        )
+    )
+    assert (
+        q(
+            ch1,
+            f"SELECT engine_full FROM system.tables WHERE database = '{database_name}' and name = 'collapsing_ver'",
+        )
+        .strip()
+        .startswith(
+            "ReplicatedVersionedCollapsingMergeTree(\\'/clickhouse/\\\\\\'/{database}/{table}/{uuid}\\', \\'{replica}\\', Sign, Version)"
+        )
+    )
+
+
+def test_modify_engine_on_restart_with_unusual_path(started_cluster):
+    ch1.query("CREATE DATABASE " + database_name)
+
+    create_tables()
+
+    set_convert_flags(ch1, database_name, ["replacing_ver", "collapsing_ver"])
+
+    ch1.restart_clickhouse()
+
+    check_flags_deleted(ch1, database_name, ["replacing_ver", "collapsing_ver"])
+
+    check_tables()

--- a/tests/integration/test_modify_engine_on_restart/test_zk_path.py
+++ b/tests/integration/test_modify_engine_on_restart/test_zk_path.py
@@ -1,6 +1,5 @@
 import pytest
 from test_modify_engine_on_restart.common import (
-    check_flags_deleted,
     get_table_path,
     set_convert_flags,
 )
@@ -18,7 +17,7 @@ ch1 = cluster.add_instance(
     stay_alive=True,
 )
 
-database_name = "modify_engine_unusual_path"
+database_name = "modify_engine_zk_path"
 
 
 @pytest.fixture(scope="module")
@@ -31,90 +30,25 @@ def started_cluster():
         cluster.shutdown()
 
 
-def q(node, query, database=database_name):
-    return node.query(database=database, sql=query)
-
-
-def create_tables():
-    # Check one argument
-    q(
-        ch1,
-        "CREATE TABLE replacing_ver ( A Int64, D Date, S String ) ENGINE = ReplacingMergeTree(D) PARTITION BY toYYYYMM(D) ORDER BY A",
-    )
-
-    # Check more than one argument
-    q(
-        ch1,
-        "CREATE TABLE collapsing_ver ( ID UInt64, Sign Int8, Version UInt8 ) ENGINE = VersionedCollapsingMergeTree(Sign, Version) ORDER BY ID",
-    )
-
-
-def check_tables():
-    # Check tables exists
-    assert (
-        q(
-            ch1,
-            "SHOW TABLES",
-        ).strip()
-        == "collapsing_ver\nreplacing_ver"
-    )
-
-    # Check engines
-    assert (
-        q(
-            ch1,
-            f"SELECT engine_full FROM system.tables WHERE database = '{database_name}' and name = 'replacing_ver'",
-        )
-        .strip()
-        .startswith(
-            "ReplicatedReplacingMergeTree(\\'/clickhouse/\\\\\\'/{database}/{table}/{uuid}\\', \\'{replica}\\', D)"
-        )
-    )
-    assert (
-        q(
-            ch1,
-            f"SELECT engine_full FROM system.tables WHERE database = '{database_name}' and name = 'collapsing_ver'",
-        )
-        .strip()
-        .startswith(
-            "ReplicatedVersionedCollapsingMergeTree(\\'/clickhouse/\\\\\\'/{database}/{table}/{uuid}\\', \\'{replica}\\', Sign, Version)"
-        )
-    )
-
-
-def test_modify_engine_on_restart_with_unusual_path(started_cluster):
-    ch1.query("CREATE DATABASE " + database_name)
-
-    create_tables()
-
-    set_convert_flags(ch1, database_name, ["replacing_ver", "collapsing_ver"])
-
-    ch1.restart_clickhouse()
-
-    check_flags_deleted(ch1, database_name, ["replacing_ver", "collapsing_ver"])
-
-    check_tables()
+def q(node, query):
+    return node.query(database=database_name, sql=query)
 
 
 def test_modify_engine_fails_if_zk_path_exists(started_cluster):
-    database_name = "zk_path"
-    ch1.query("CREATE DATABASE " + database_name + " ON CLUSTER cluster")
+    ch1.query("CREATE DATABASE " + database_name)
 
     q(
         ch1,
         "CREATE TABLE already_exists_1 ( A Int64, D Date, S String ) ENGINE MergeTree() PARTITION BY toYYYYMM(D) ORDER BY A;",
-        database_name,
     )
     uuid = q(
         ch1,
         f"SELECT uuid FROM system.tables WHERE table = 'already_exists_1' and database = '{database_name}'",
-        database_name,
     ).strip("'[]\n")
 
     q(
         ch1,
         f"CREATE TABLE already_exists_2 ( A Int64, D Date, S String ) ENGINE ReplicatedMergeTree('/clickhouse/\\'/{database_name}/already_exists_1/{uuid}', 'r2') PARTITION BY toYYYYMM(D) ORDER BY A;",
-        database_name,
     )
 
     set_convert_flags(ch1, database_name, ["already_exists_1"])


### PR DESCRIPTION
Currently it is possible to convert MergeTree to replicated if table's path in zookeeper already exist. The conversion is not intended to add replicas to existing tables, so this may cause a lot of troubles. It is also possible to create two replicas with the exact same path like here https://github.com/ClickHouse/ClickHouse/issues/62905

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
It is forbidden to convert MergeTree to replicated if the zookeeper path for this table already exists

