### PR TITLE
flatten_nested is broken with replicated database.

### DIFF
--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -694,7 +694,7 @@ ColumnsDescription InterpreterCreateQuery::getColumnsDescription(
         res.add(std::move(column));
     }
 
-    if (mode <= LoadingStrictnessLevel::SECONDARY_CREATE && context_->getSettingsRef().flatten_nested)
+    if (mode <= LoadingStrictnessLevel::SECONDARY_CREATE && !is_restore_from_backup && context_->getSettingsRef().flatten_nested)
         res.flattenNested();
 
 

--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -505,7 +505,7 @@ ASTPtr InterpreterCreateQuery::formatProjections(const ProjectionsDescription & 
 }
 
 ColumnsDescription InterpreterCreateQuery::getColumnsDescription(
-    const ASTExpressionList & columns_ast, ContextPtr context_, LoadingStrictnessLevel mode)
+    const ASTExpressionList & columns_ast, ContextPtr context_, LoadingStrictnessLevel mode, bool is_restore_from_backup)
 {
     /// First, deduce implicit types.
 
@@ -514,7 +514,7 @@ ColumnsDescription InterpreterCreateQuery::getColumnsDescription(
 
     ASTPtr default_expr_list = std::make_shared<ASTExpressionList>();
     NamesAndTypesList column_names_and_types;
-    bool make_columns_nullable = mode <= LoadingStrictnessLevel::CREATE && context_->getSettingsRef().data_type_default_nullable;
+    bool make_columns_nullable = mode <= LoadingStrictnessLevel::SECONDARY_CREATE && !is_restore_from_backup && context_->getSettingsRef().data_type_default_nullable;
     bool has_columns_with_default_without_type = false;
 
     for (const auto & ast : columns_ast.children)
@@ -739,7 +739,7 @@ InterpreterCreateQuery::TableProperties InterpreterCreateQuery::getTableProperti
 
         if (create.columns_list->columns)
         {
-            properties.columns = getColumnsDescription(*create.columns_list->columns, getContext(), mode);
+            properties.columns = getColumnsDescription(*create.columns_list->columns, getContext(), mode, is_restore_from_backup);
         }
 
         if (create.columns_list->indices)

--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -694,7 +694,7 @@ ColumnsDescription InterpreterCreateQuery::getColumnsDescription(
         res.add(std::move(column));
     }
 
-    if (mode <= LoadingStrictnessLevel::CREATE && context_->getSettingsRef().flatten_nested)
+    if (mode <= LoadingStrictnessLevel::SECONDARY_CREATE && context_->getSettingsRef().flatten_nested)
         res.flattenNested();
 
 

--- a/src/Interpreters/InterpreterCreateQuery.h
+++ b/src/Interpreters/InterpreterCreateQuery.h
@@ -74,7 +74,7 @@ public:
 
     /// Obtain information about columns, their types, default values and column comments,
     ///  for case when columns in CREATE query is specified explicitly.
-    static ColumnsDescription getColumnsDescription(const ASTExpressionList & columns, ContextPtr context, LoadingStrictnessLevel mode);
+    static ColumnsDescription getColumnsDescription(const ASTExpressionList & columns, ContextPtr context, LoadingStrictnessLevel mode, bool is_restore_from_backup = false);
     static ConstraintsDescription getConstraintsDescription(const ASTExpressionList * constraints);
 
     static void prepareOnClusterQuery(ASTCreateQuery & create, ContextPtr context, const String & cluster_name);


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
flatten_nested is broken with replicated database


```
2024.05.13 13:19:00.061428 [ 674 ] {d6a83a5e-a847-464b-a4ad-f8a417b5b9a1} <Error> executeQuery: Code: 122. DB::Exception: Table columns structure in ZooKeeper is different from local table structure. Local columns:
columns format version: 1
2 columns:
`d` Date
`CAST([(k, toString(i32))], 'Nested(a UInt64, b String)')` Nested(a UInt64, b String)

Zookeeper columns:
columns format version: 1
3 columns:
`d` Date
`CAST([(k, toString(i32))], 'Nested(a UInt64, b String)').a` Array(UInt64)
`CAST([(k, toString(i32))], 'Nested(a UInt64, b String)').b` Array(String)
. (INCOMPATIBLE_COLUMNS) (version 24.5.1.1) (from 0.0.0.0:0) (in query: /* ddl_entry=query-0000000004 */ CREATE MATERIALIZED VIEW create_replicated_table.mv UUID 'b139728f-4128-4b5e-ad02-037a548eaa16' TO INNER UUID '730ac357-4b0a-45a4-bf3a-965792811d96' (`d` Date, `CAST([(k, toString(i32))], 'Nested(a UInt64, b String)')` Nested(a UInt64, b String)) ENGINE = ReplicatedMergeTree ORDER BY tuple() AS SELECT d, CAST([(k, toString(i32))], 'Nested(a UInt64, b String)') FROM create_replicated_table.replicated_table), Stack trace (when copying this message, always include the lines below):

0. ./contrib/llvm-project/libcxx/include/exception:141: Poco::Exception::Exception(String const&, int) @ 0x00000000118fecb2
1. ./build/./src/Common/Exception.cpp:101: DB::Exception::Exception(DB::Exception::MessageMasked&&, int, bool) @ 0x000000000a6d66d9
2. DB::Exception::Exception(PreformattedMessage&&, int) @ 0x0000000005c1adcc
3. DB::Exception::Exception<String, String>(int, FormatStringHelperImpl<std::type_identity<String>::type, std::type_identity<String>::type>, String&&, String&&) @ 0x0000000005c1c32b
4. ./build/./src/Storages/StorageReplicatedMergeTree.cpp:0: DB::StorageReplicatedMergeTree::checkTableStructure(String const&, std::shared_ptr<DB::StorageInMemoryMetadata const> const&, bool) @ 0x000000000fdd8c71
5. ./build/./src/Storages/StorageReplicatedMergeTree.cpp:520: DB::StorageReplicatedMergeTree::StorageReplicatedMergeTree(String const&, String const&, DB::LoadingStrictnessLevel, DB::StorageID const&, String const&, DB::StorageInMemoryMetadata const&, std::shared_ptr<DB::Context>, String const&, DB::MergeTreeData::MergingParams const&, std::unique_ptr<DB::MergeTreeSettings, std::default_delete<DB::MergeTreeSettings>>, DB::RenamingRestrictions, bool) @ 0x000000000fdcdc02
6. ./contrib/llvm-project/libcxx/include/__memory/shared_ptr.h:1460: std::shared_ptr<DB::StorageReplicatedMergeTree> std::allocate_shared[abi:v15000]<DB::StorageReplicatedMergeTree, std::allocator<DB::StorageReplicatedMergeTree>, String&, String&, DB::LoadingStrictnessLevel const&, DB::StorageID const&, String const&, DB::StorageInMemoryMetadata&, std::shared_ptr<DB::Context>&, String&, DB::MergeTreeData::MergingParams&, std::unique_ptr<DB::MergeTreeSettings, std::default_delete<DB::MergeTreeSettings>>, DB::RenamingRestrictions&, bool&, void>(std::allocator<DB::StorageReplicatedMergeTree> const&, String&, String&, DB::LoadingStrictnessLevel const&, DB::StorageID const&, String const&, DB::StorageInMemoryMetadata&, std::shared_ptr<DB::Context>&, String&, DB::MergeTreeData::MergingParams&, std::unique_ptr<DB::MergeTreeSettings, std::default_delete<DB::MergeTreeSettings>>&&, DB::RenamingRestrictions&, bool&) @ 0x000000001056f36a
7. ./build/./src/Storages/MergeTree/registerStorageMergeTree.cpp:0: DB::create(DB::StorageFactory::Arguments const&) @ 0x000000001056b589
8. ./build/./src/Storages/StorageFactory.cpp:224: DB::StorageFactory::get(DB::ASTCreateQuery const&, String const&, std::shared_ptr<DB::Context>, std::shared_ptr<DB::Context>, DB::ColumnsDescription const&, DB::ConstraintsDescription const&, DB::LoadingStrictnessLevel) const @ 0x000000000fce05a3
9. ./contrib/llvm-project/libcxx/include/__utility/swap.h:37: DB::InterpreterCreateQuery::doCreateTable(DB::ASTCreateQuery&, DB::InterpreterCreateQuery::TableProperties const&, std::unique_ptr<DB::DDLGuard, std::default_delete<DB::DDLGuard>>&, DB::LoadingStrictnessLevel) @ 0x000000000f13cc1a
10. ./build/./src/Interpreters/InterpreterCreateQuery.cpp:0: DB::InterpreterCreateQuery::createTable(DB::ASTCreateQuery&) @ 0x000000000f1355e7
11. ./build/./src/Interpreters/InterpreterCreateQuery.cpp:1785: DB::InterpreterCreateQuery::execute() @ 0x000000000f141858
12. ./build/./src/Storages/StorageMaterializedView.cpp:0: DB::StorageMaterializedView::StorageMaterializedView(DB::StorageID const&, std::shared_ptr<DB::Context const>, DB::ASTCreateQuery const&, DB::ColumnsDescription const&, DB::LoadingStrictnessLevel, String const&) @ 0x000000000fd70d8e
13. ./contrib/llvm-project/libcxx/include/__memory/construct_at.h:35: std::shared_ptr<DB::StorageMaterializedView> std::allocate_shared[abi:v15000]<DB::StorageMaterializedView, std::allocator<DB::StorageMaterializedView>, DB::StorageID const&, std::shared_ptr<DB::Context>, DB::ASTCreateQuery const&, DB::ColumnsDescription const&, DB::LoadingStrictnessLevel const&, String const&, void>(std::allocator<DB::StorageMaterializedView> const&, DB::StorageID const&, std::shared_ptr<DB::Context>&&, DB::ASTCreateQuery const&, DB::ColumnsDescription const&, DB::LoadingStrictnessLevel const&, String const&) @ 0x000000000fd79aa0
14. ./build/./src/Storages/StorageMaterializedView.cpp:691: std::shared_ptr<DB::IStorage> std::__function::__policy_invoker<std::shared_ptr<DB::IStorage> (DB::StorageFactory::Arguments const&)>::__call_impl<std::__function::__default_alloc_func<DB::registerStorageMaterializedView(DB::StorageFactory&)::$_0, std::shared_ptr<DB::IStorage> (DB::StorageFactory::Arguments const&)>>(std::__function::__policy_storage const*, DB::StorageFactory::Arguments const&) @ 0x000000000fd78f8b
15. ./build/./src/Storages/StorageFactory.cpp:224: DB::StorageFactory::get(DB::ASTCreateQuery const&, String const&, std::shared_ptr<DB::Context>, std::shared_ptr<DB::Context>, DB::ColumnsDescription const&, DB::ConstraintsDescription const&, DB::LoadingStrictnessLevel) const @ 0x000000000fce05a3
16. ./contrib/llvm-project/libcxx/include/__utility/swap.h:37: DB::InterpreterCreateQuery::doCreateTable(DB::ASTCreateQuery&, DB::InterpreterCreateQuery::TableProperties const&, std::unique_ptr<DB::DDLGuard, std::default_delete<DB::DDLGuard>>&, DB::LoadingStrictnessLevel) @ 0x000000000f13cc1a
17. ./build/./src/Interpreters/InterpreterCreateQuery.cpp:0: DB::InterpreterCreateQuery::createTable(DB::ASTCreateQuery&) @ 0x000000000f1355e7
18. ./build/./src/Interpreters/InterpreterCreateQuery.cpp:1785: DB::InterpreterCreateQuery::execute() @ 0x000000000f141858
19. ./build/./src/Interpreters/executeQuery.cpp:0: DB::executeQueryImpl(char const*, char const*, std::shared_ptr<DB::Context>, DB::QueryFlags, DB::QueryProcessingStage::Enum, DB::ReadBuffer*) @ 0x000000000f7bc62b
20. ./contrib/llvm-project/libcxx/include/__memory/shared_ptr.h:612: DB::executeQuery(DB::ReadBuffer&, DB::WriteBuffer&, bool, std::shared_ptr<DB::Context>, std::function<void (DB::QueryResultDetails const&)>, DB::QueryFlags, std::optional<DB::FormatSettings> const&, std::function<void (DB::IOutputFormat&, String const&, std::shared_ptr<DB::Context const> const&, std::optional<DB::FormatSettings> const&)>) @ 0x000000000f7bfd8f
21. ./contrib/llvm-project/libcxx/include/__functional/function.h:818: ? @ 0x000000000eb23eb5
22. ./contrib/llvm-project/libcxx/include/__memory/shared_ptr.h:701: DB::DDLWorker::processTask(DB::DDLTaskBase&, std::shared_ptr<zkutil::ZooKeeper> const&) @ 0x000000000eb223e0
23. ./contrib/llvm-project/libcxx/include/__memory/unique_ptr.h:302: DB::DDLWorker::scheduleTasks(bool) @ 0x000000000eb1fc23
24. ./contrib/llvm-project/libcxx/include/__memory/shared_ptr.h:593: DB::DDLWorker::runMainThread() @ 0x000000000eb19d3e
25. ./contrib/llvm-project/libcxx/include/__functional/invoke.h:0: ? @ 0x000000000eb31142
26. ./base/base/../base/wide_integer_impl.h:817: ThreadPoolImpl<std::thread>::worker(std::__list_iterator<std::thread, void*>) @ 0x000000000a77dec2
27. ./contrib/llvm-project/libcxx/include/__memory/unique_ptr.h:302: void* std::__thread_proxy[abi:v15000]<std::tuple<std::unique_ptr<std::__thread_struct, std::default_delete<std::__thread_struct>>, void ThreadPoolImpl<std::thread>::scheduleImpl<void>(std::function<void ()>, Priority, std::optional<unsigned long>, bool)::'lambda0'()>>(void*) @ 0x000000000a7822ae
28. ? @ 0x00007f7f32ddbac3
29. ? @ 0x00007f7f32e6d850
```