### PR TITLE
io_uring: improve resumbits visibility

### DIFF
--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -631,7 +631,8 @@ The server successfully detected this situation and will download merged part fr
     \
     M(ServerStartupMilliseconds, "Time elapsed from starting server to listening to sockets in milliseconds")\
     M(IOUringSQEsSubmitted, "Total number of io_uring SQEs submitted") \
-    M(IOUringSQEsResubmits, "Total number of io_uring SQE resubmits performed") \
+    M(IOUringSQEsResubmitsAsync, "Total number of asychronous io_uring SQE resubmits performed") \
+    M(IOUringSQEsResubmitsSync, "Total number of synchronous io_uring SQE resubmits performed") \
     M(IOUringCQEsCompleted, "Total number of successfully completed io_uring CQEs") \
     M(IOUringCQEsFailed, "Total number of completed io_uring CQEs with failures") \
     \

--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -631,7 +631,7 @@ The server successfully detected this situation and will download merged part fr
     \
     M(ServerStartupMilliseconds, "Time elapsed from starting server to listening to sockets in milliseconds")\
     M(IOUringSQEsSubmitted, "Total number of io_uring SQEs submitted") \
-    M(IOUringSQEsResubmitsAsync, "Total number of asychronous io_uring SQE resubmits performed") \
+    M(IOUringSQEsResubmitsAsync, "Total number of asynchronous io_uring SQE resubmits performed") \
     M(IOUringSQEsResubmitsSync, "Total number of synchronous io_uring SQE resubmits performed") \
     M(IOUringCQEsCompleted, "Total number of successfully completed io_uring CQEs") \
     M(IOUringCQEsFailed, "Total number of completed io_uring CQEs with failures") \

--- a/src/Coordination/KeeperConstants.cpp
+++ b/src/Coordination/KeeperConstants.cpp
@@ -258,7 +258,8 @@
     M(KeeperExistsRequest) \
 \
     M(IOUringSQEsSubmitted) \
-    M(IOUringSQEsResubmits) \
+    M(IOUringSQEsResubmitsAsync) \
+    M(IOUringSQEsResubmitsSync) \
     M(IOUringCQEsCompleted) \
     M(IOUringCQEsFailed) \
 \

--- a/src/Disks/IO/IOUringReader.cpp
+++ b/src/Disks/IO/IOUringReader.cpp
@@ -22,7 +22,8 @@ namespace ProfileEvents
     extern const Event AsynchronousReaderIgnoredBytes;
 
     extern const Event IOUringSQEsSubmitted;
-    extern const Event IOUringSQEsResubmits;
+    extern const Event IOUringSQEsResubmitsAsync;
+    extern const Event IOUringSQEsResubmitsSync;
     extern const Event IOUringCQEsCompleted;
     extern const Event IOUringCQEsFailed;
 }
@@ -149,10 +150,12 @@ int IOUringReader::submitToRing(EnqueuedRequest & enqueued)
     io_uring_prep_read(sqe, fd, request.buf, static_cast<unsigned>(request.size - enqueued.bytes_read), request.offset + enqueued.bytes_read);
     int ret = 0;
 
-    do
+    ret = io_uring_submit(&ring);
+    while (ret == -EINTR || ret == -EAGAIN)
     {
+        ProfileEvents::increment(ProfileEvents::IOUringSQEsResubmitsSync);
         ret = io_uring_submit(&ring);
-    } while (ret == -EINTR || ret == -EAGAIN);
+    }
 
     if (ret > 0 && !enqueued.resubmitting)
     {
@@ -266,7 +269,7 @@ void IOUringReader::monitorRing()
         if (cqe->res == -EAGAIN || cqe->res == -EINTR)
         {
             enqueued.resubmitting = true;
-            ProfileEvents::increment(ProfileEvents::IOUringSQEsResubmits);
+            ProfileEvents::increment(ProfileEvents::IOUringSQEsResubmitsAsync);
 
             ret = submitToRing(enqueued);
             if (ret <= 0)
@@ -310,6 +313,7 @@ void IOUringReader::monitorRing()
             // potential short read, re-submit
             enqueued.resubmitting = true;
             enqueued.bytes_read += bytes_read;
+            ProfileEvents::increment(ProfileEvents::IOUringSQEsResubmitsAsync);
 
             ret = submitToRing(enqueued);
             if (ret <= 0)


### PR DESCRIPTION
Improve io_uring resubmits visibility:

- Add new profile event for synchronous resubmits with Sync suffix
- Rename existing profile event for resubmits to have Async suffix
- Add missing increment on async short read resumbit

### Changelog category (leave one):

- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Improve io_uring resubmits visibility. Rename profile event `IOUringSQEsResubmits` -> `IOUringSQEsResubmitsAsync` and add a new one `IOUringSQEsResubmitsSync`.
