### PR TITLE
Try to fix flaky s3 tests test_seekable_formats and test_seekable_formats_url

### DIFF
--- a/tests/integration/helpers/test_tools.py
+++ b/tests/integration/helpers/test_tools.py
@@ -139,7 +139,7 @@ def assert_logs_contain_with_retry(instance, substring, retry_count=20, sleep_ti
 
 
 def exec_query_with_retry(
-    instance, query, retry_count=40, sleep_time=0.5, silent=False, settings={}
+    instance, query, retry_count=40, sleep_time=0.5, silent=False, settings={}, timeout=30
 ):
     exception = None
     for cnt in range(retry_count):

--- a/tests/integration/helpers/test_tools.py
+++ b/tests/integration/helpers/test_tools.py
@@ -139,7 +139,13 @@ def assert_logs_contain_with_retry(instance, substring, retry_count=20, sleep_ti
 
 
 def exec_query_with_retry(
-    instance, query, retry_count=40, sleep_time=0.5, silent=False, settings={}, timeout=30
+    instance,
+    query,
+    retry_count=40,
+    sleep_time=0.5,
+    silent=False,
+    settings={},
+    timeout=30,
 ):
     exception = None
     for cnt in range(retry_count):

--- a/tests/integration/helpers/test_tools.py
+++ b/tests/integration/helpers/test_tools.py
@@ -144,7 +144,7 @@ def exec_query_with_retry(
     exception = None
     for cnt in range(retry_count):
         try:
-            res = instance.query(query, timeout=30, settings=settings)
+            res = instance.query(query, timeout=timeout, settings=settings)
             if not silent:
                 logging.debug(f"Result of {query} on {cnt} try is {res}")
             break

--- a/tests/integration/test_storage_s3/test.py
+++ b/tests/integration/test_storage_s3/test.py
@@ -1133,6 +1133,7 @@ def test_seekable_formats(started_cluster):
     exec_query_with_retry(
         instance,
         f"insert into table function {table_function} SELECT number, randomString(100) FROM numbers(1000000) settings s3_truncate_on_insert=1",
+        timeout=100,
     )
 
     result = instance.query(f"SELECT count() FROM {table_function}")
@@ -1142,6 +1143,7 @@ def test_seekable_formats(started_cluster):
     exec_query_with_retry(
         instance,
         f"insert into table function {table_function} SELECT number, randomString(100) FROM numbers(1500000) settings s3_truncate_on_insert=1",
+        timeout=100,
     )
 
     result = instance.query(
@@ -1169,6 +1171,7 @@ def test_seekable_formats_url(started_cluster):
     exec_query_with_retry(
         instance,
         f"insert into table function {table_function} SELECT number, randomString(100) FROM numbers(1500000) settings s3_truncate_on_insert=1",
+        timeout=100,
     )
 
     result = instance.query(f"SELECT count() FROM {table_function}")
@@ -1178,6 +1181,7 @@ def test_seekable_formats_url(started_cluster):
     exec_query_with_retry(
         instance,
         f"insert into table function {table_function} SELECT number, randomString(100) FROM numbers(1500000) settings s3_truncate_on_insert=1",
+        timeout=100,
     )
 
     table_function = f"url('http://{started_cluster.minio_host}:{started_cluster.minio_port}/{bucket}/test_parquet', 'Parquet', 'a Int32, b String')"


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

In builds with tsan these tests fails with timeout due to serve slowness: https://s3.amazonaws.com/clickhouse-test-reports/63425/216cd83b8ed6da5506d315b643a23f9e7b56b8bc/integration_tests__tsan__[5_6]//home/ubuntu/actions-runner/_work/_temp/test/output_dir/integration_run_parallel4_0.log
It happens in `exec_query_with_retry` when we have default timeput 30 seconds. Let's increase this timeout