### PR TITLE
Userspace page cache: don't collect stats if cache is unused

### DIFF
--- a/src/Common/PageCache.cpp
+++ b/src/Common/PageCache.cpp
@@ -199,16 +199,17 @@ PageCache::MemoryStats PageCache::getResidentSetSize() const
 {
     MemoryStats stats;
 
-    /// Don't spend time on reading smaps if page cache is not used.
-    if (mmaps.empty())
-        return stats;
-
 #ifdef OS_LINUX
     if (use_madv_free)
     {
         std::unordered_set<UInt64> cache_mmap_addrs;
         {
             std::lock_guard lock(global_mutex);
+
+            /// Don't spend time on reading smaps if page cache is not used.
+            if (mmaps.empty())
+                return stats;
+
             for (const auto & m : mmaps)
                 cache_mmap_addrs.insert(reinterpret_cast<UInt64>(m.ptr));
         }

--- a/src/Common/PageCache.cpp
+++ b/src/Common/PageCache.cpp
@@ -198,6 +198,11 @@ size_t PageCache::getPinnedSize() const
 PageCache::MemoryStats PageCache::getResidentSetSize() const
 {
     MemoryStats stats;
+
+    /// Don't spend time on reading smaps if page cache is not used.
+    if (mmaps.empty())
+        return stats;
+
 #ifdef OS_LINUX
     if (use_madv_free)
     {
@@ -258,7 +263,7 @@ PageCache::MemoryStats PageCache::getResidentSetSize() const
                 UInt64 addr = unhexUInt<UInt64>(s.c_str());
                 current_range_is_cache = cache_mmap_addrs.contains(addr);
             }
-            else if (s == "Rss:" || s == "LazyFree")
+            else if (s == "Rss:" || s == "LazyFree:")
             {
                 skip_whitespace();
                 size_t val;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

We saw some evidence that reading /proc/self/smaps takes longer than a second in some environments+workloads, so the async metrics thread 100%-s a cpu core. Here's a minimal change to avoid this at least if page cache is unused. This closes https://github.com/ClickHouse/ClickHouse/issues/63500

(I'm still figuring out how to fix it properly. Probably by finally giving up MADV_FREE.)