### PR TITLE
Fix insignificant UBSAN error in QueryAnalyzer::replaceNodesWithPositionalArguments()

### DIFF
--- a/src/Analyzer/Passes/QueryAnalysisPass.cpp
+++ b/src/Analyzer/Passes/QueryAnalysisPass.cpp
@@ -2329,7 +2329,7 @@ void QueryAnalyzer::replaceNodesWithPositionalArguments(QueryTreeNodePtr & node_
                 pos = value;
             else
             {
-                if (static_cast<size_t>(std::abs(value)) > projection_nodes.size())
+                if (value < -static_cast<Int64>(projection_nodes.size()))
                     throw Exception(
                         ErrorCodes::BAD_ARGUMENTS,
                         "Negative positional argument number {} is out of bounds. Expected in range [-{}, -1]. In scope {}",


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Error: https://s3.amazonaws.com/clickhouse-test-reports/63730/f6cc1051c162029c316d75feecd6efedf3781289/ast_fuzzer__ubsan_/stderr.log

Simplified query: `select 1 group by -9223372036854775808`

It actually works correctly ("Negative positional argument number -9223372036854775808 is out of bounds" exception), but UBSAN is not happy.

Avoid `std::abs()` on integers parsed from the query.