### PR TITLE
Fix possible crash with SYSTEM UNLOAD PRIMARY KEY

### DIFF
--- a/src/Processors/QueryPlan/PartsSplitter.cpp
+++ b/src/Processors/QueryPlan/PartsSplitter.cpp
@@ -128,15 +128,21 @@ class IndexAccess
 public:
     explicit IndexAccess(const RangesInDataParts & parts_) : parts(parts_)
     {
-        /// Some suffix of index columns might not be loaded (see `primary_key_ratio_of_unique_prefix_values_to_skip_suffix_columns`)
-        /// and we need to use the same set of index columns across all parts.
+        /// Indices might be reloaded during the process and the reload might produce a different value
+        /// (change in `primary_key_ratio_of_unique_prefix_values_to_skip_suffix_columns`). Also, some suffix of index
+        /// columns might not be loaded (same setting) so we keep a reference to the current indices and
+        /// track the minimal subset of loaded columns across all parts.
+        indices.reserve(parts.size());
         for (const auto & part : parts)
-            loaded_columns = std::min(loaded_columns, part.data_part->getIndex()->size());
+            indices.push_back(part.data_part->getIndex());
+
+        for (const auto & index : indices)
+            loaded_columns = std::min(loaded_columns, index->size());
     }
 
     Values getValue(size_t part_idx, size_t mark) const
     {
-        const auto & index = parts[part_idx].data_part->getIndex();
+        const auto & index = indices[part_idx];
         chassert(index->size() >= loaded_columns);
         Values values(loaded_columns);
         for (size_t i = 0; i < loaded_columns; ++i)
@@ -206,6 +212,7 @@ public:
     }
 private:
     const RangesInDataParts & parts;
+    std::vector<IMergeTreeDataPart::Index> indices;
     size_t loaded_columns = std::numeric_limits<size_t>::max();
 };
 

--- a/src/Storages/MergeTree/IMergeTreeDataPart.h
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.h
@@ -369,7 +369,7 @@ public:
 
     Index getIndex() const;
     void setIndex(const Columns & cols_);
-    void setIndex(Columns && index_);
+    void setIndex(Columns && cols_);
     void unloadIndex();
 
     /// For data in RAM ('index')

--- a/src/Storages/MergeTree/IMergeTreeDataPart.h
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.h
@@ -79,7 +79,7 @@ public:
     using ColumnSizeByName = std::unordered_map<std::string, ColumnSize>;
     using NameToNumber = std::unordered_map<std::string, size_t>;
 
-    using Index = std::shared_ptr<Columns>;
+    using Index = std::shared_ptr<const Columns>;
     using IndexSizeByName = std::unordered_map<std::string, ColumnSize>;
 
     using Type = MergeTreeDataPartType;
@@ -368,7 +368,8 @@ public:
     int32_t metadata_version;
 
     Index getIndex() const;
-    void setIndex(Index index_);
+    void setIndex(const Columns & index_);
+    void setIndex(Columns && index_);
     void unloadIndex();
 
     /// For data in RAM ('index')

--- a/src/Storages/MergeTree/IMergeTreeDataPart.h
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.h
@@ -368,7 +368,7 @@ public:
     int32_t metadata_version;
 
     Index getIndex() const;
-    void setIndex(const Columns & index_);
+    void setIndex(const Columns & cols_);
     void setIndex(Columns && index_);
     void unloadIndex();
 

--- a/src/Storages/MergeTree/MergedBlockOutputStream.cpp
+++ b/src/Storages/MergeTree/MergedBlockOutputStream.cpp
@@ -181,7 +181,7 @@ MergedBlockOutputStream::Finalizer MergedBlockOutputStream::finalizePartAsync(
 
     new_part->rows_count = rows_count;
     new_part->modification_time = time(nullptr);
-    new_part->setIndex(std::make_shared<Columns>(writer->releaseIndexColumns()));
+    new_part->setIndex(writer->releaseIndexColumns());
     new_part->checksums = checksums;
     new_part->setBytesOnDisk(checksums.getTotalSizeOnDisk());
     new_part->setBytesUncompressedOnDisk(checksums.getTotalSizeUncompressedOnDisk());

--- a/src/Storages/MergeTree/MutateTask.cpp
+++ b/src/Storages/MergeTree/MutateTask.cpp
@@ -935,7 +935,7 @@ void finalizeMutatedPart(
 
     new_data_part->rows_count = source_part->rows_count;
     new_data_part->index_granularity = source_part->index_granularity;
-    new_data_part->setIndex(source_part->getIndex());
+    new_data_part->setIndex(*source_part->getIndex());
     new_data_part->minmax_idx = source_part->minmax_idx;
     new_data_part->modification_time = time(nullptr);
 

--- a/tests/queries/0_stateless/03151_unload_index_race.sh
+++ b/tests/queries/0_stateless/03151_unload_index_race.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest, long, no-parallel
+# Disable parallel since it creates 10 different threads querying and might overload the server
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+$CLICKHOUSE_CLIENT -q "create table t(a UInt32, b UInt32, c UInt32) engine=MergeTree order by (a, b, c) settings index_granularity=1;"
+$CLICKHOUSE_CLIENT -q "system stop merges t;"
+
+# In this part a only changes 10% of the time, b 50% of the time, c all the time
+$CLICKHOUSE_CLIENT -q "insert into t select intDiv(number, 10), intDiv(number, 2), number from numbers_mt(100);"
+$CLICKHOUSE_CLIENT -q "insert into t select intDiv(number, 10), intDiv(number, 2), number from numbers_mt(100);"
+$CLICKHOUSE_CLIENT -q "insert into t select intDiv(number, 10), intDiv(number, 2), number from numbers_mt(100);"
+$CLICKHOUSE_CLIENT -q "insert into t select intDiv(number, 10), intDiv(number, 2), number from numbers_mt(100);"
+$CLICKHOUSE_CLIENT -q "insert into t select intDiv(number, 10), intDiv(number, 2), number from numbers_mt(100);"
+
+# In this part a only changes 33% of the time, b 50% of the time, c 10 % of the time
+$CLICKHOUSE_CLIENT -q "insert into t select intDiv(number, 3), intDiv(number, 2), intDiv(number, 3) from numbers_mt(100);"
+$CLICKHOUSE_CLIENT -q "insert into t select intDiv(number, 3), intDiv(number, 2), intDiv(number, 3) from numbers_mt(100);"
+$CLICKHOUSE_CLIENT -q "insert into t select intDiv(number, 3), intDiv(number, 2), intDiv(number, 3) from numbers_mt(100);"
+$CLICKHOUSE_CLIENT -q "insert into t select intDiv(number, 3), intDiv(number, 2), intDiv(number, 3) from numbers_mt(100);"
+$CLICKHOUSE_CLIENT -q "insert into t select intDiv(number, 3), intDiv(number, 2), intDiv(number, 3) from numbers_mt(100);"
+
+# In this part a changes 100% of the time
+$CLICKHOUSE_CLIENT -q "insert into t Select number, number, number from numbers_mt(100);"
+$CLICKHOUSE_CLIENT -q "insert into t Select number, number, number from numbers_mt(100);"
+$CLICKHOUSE_CLIENT -q "insert into t Select number, number, number from numbers_mt(100);"
+$CLICKHOUSE_CLIENT -q "insert into t Select number, number, number from numbers_mt(100);"
+$CLICKHOUSE_CLIENT -q "insert into t Select number, number, number from numbers_mt(100);"
+
+
+# In this part a changes 100% of the time
+$CLICKHOUSE_CLIENT -q "insert into t Select 0, intDiv(number, 10), intDiv(number, 2) from numbers_mt(100);"
+$CLICKHOUSE_CLIENT -q "insert into t Select 0, intDiv(number, 10), intDiv(number, 2) from numbers_mt(100);"
+$CLICKHOUSE_CLIENT -q "insert into t Select 0, intDiv(number, 10), intDiv(number, 2) from numbers_mt(100);"
+$CLICKHOUSE_CLIENT -q "insert into t Select 0, intDiv(number, 10), intDiv(number, 2) from numbers_mt(100);"
+$CLICKHOUSE_CLIENT -q "insert into t Select 0, intDiv(number, 10), intDiv(number, 2) from numbers_mt(100);"
+
+function thread_alter_settings()
+{
+    local TIMELIMIT=$((SECONDS+$1))
+    while [ $SECONDS -lt "$TIMELIMIT" ]; do
+        $CLICKHOUSE_CLIENT -n --query "ALTER TABLE t MODIFY SETTING primary_key_ratio_of_unique_prefix_values_to_skip_suffix_columns=0.$RANDOM"
+        $CLICKHOUSE_CLIENT -n --query "SYSTEM UNLOAD PRIMARY KEY t"
+        sleep 0.0$RANDOM
+    done
+}
+
+function thread_query_table()
+{
+    local TIMELIMIT=$((SECONDS+$1))
+    while [ $SECONDS -lt "$TIMELIMIT" ]; do
+        COUNT=$($CLICKHOUSE_CLIENT -n --query "SELECT count() FROM t where not ignore(*);")
+        if [ "$COUNT" -ne "2000" ];  then
+          echo "$COUNT"
+        fi
+    done
+}
+
+export -f thread_alter_settings
+export -f thread_query_table
+
+TIMEOUT=10
+
+thread_alter_settings $TIMEOUT &
+for i in $(seq 1 10);
+do
+  thread_query_table $TIMEOUT &
+done
+
+wait
+
+$CLICKHOUSE_CLIENT -q "SELECT count() FROM t FORMAT Null"

--- a/tests/queries/0_stateless/03151_unload_index_race.sh
+++ b/tests/queries/0_stateless/03151_unload_index_race.sh
@@ -65,7 +65,7 @@ export -f thread_query_table
 TIMEOUT=10
 
 thread_alter_settings $TIMEOUT &
-for i in $(seq 1 10);
+for _ in $(seq 1 10);
 do
   thread_query_table $TIMEOUT &
 done


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Fix possible crash with SYSTEM UNLOAD PRIMARY KEY

A combination of `SYSTEM UNLOAD PRIMARY KEY table` and `ALTER TABLE t MODIFY SETTING primary_key_ratio_of_unique_prefix_values_to_skip_suffix_columns` could crash the server.

Also, change the getIndex() API to something less error-prone. The fact that we had `TSA_SUPPRESS_WARNING_FOR_READ` was a smell, since it meant we had to trust the caller to not modify the contents of the pointer. Let's see if the CI agrees (it seems it was a compiler version specific warning).


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

<details>
    <summary>Modify your CI run</summary>

**NOTE:** If your merge the PR with modified CI you **MUST KNOW** what you are doing
**NOTE:** Checked options will be applied if set before CI RunConfig/PrepareRunConfig step

#### Include tests (required builds will be added automatically):
- [ ] <!---ci_include_fast--> Fast test
- [ ] <!---ci_include_integration--> Integration Tests
- [ ] <!---ci_include_stateless--> Stateless tests
- [ ] <!---ci_include_stateful--> Stateful tests
- [ ] <!---ci_include_unit--> Unit tests
- [ ] <!---ci_include_performance--> Performance tests
- [ ] <!---ci_include_asan--> All with ASAN
- [ ] <!---ci_include_tsan--> All with TSAN
- [ ] <!---ci_include_analyzer--> All with Analyzer
- [ ] <!---ci_include_azure --> All with Azure
- [ ] <!---ci_include_KEYWORD--> Add your option here

#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [ ] <!---ci_exclude_tsan--> All with TSAN
- [ ] <!---ci_exclude_msan--> All with MSAN
- [ ] <!---ci_exclude_ubsan--> All with UBSAN
- [ ] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64--> All with Aarch64
- [ ] <!---ci_exclude_KEYWORD--> Add your option here

#### Extra options:
- [ ] <!---do_not_test--> do not test (only style check)
- [ ] <!---no_merge_commit--> disable merge-commit (no merge from master before tests)
- [ ] <!---no_ci_cache--> disable CI cache (job reuse)

#### Only specified batches in multi-batch jobs:
- [ ] <!---batch_0--> 1
- [ ] <!---batch_1--> 2
- [ ] <!---batch_2--> 3
- [ ] <!---batch_3--> 4

</details>
