### PR TITLE
Fix duplicate slugs in docs

### DIFF
--- a/docs/ru/operations/utilities/backupview.md
+++ b/docs/ru/operations/utilities/backupview.md
@@ -1,5 +1,5 @@
 ---
-slug: /en/operations/utilities/backupview
+slug: /ru/operations/utilities/backupview
 title: clickhouse_backupview
 ---
 

--- a/docs/ru/sql-reference/functions/null-functions.md
+++ b/docs/ru/sql-reference/functions/null-functions.md
@@ -1,5 +1,5 @@
 ---
-slug: /ru/sql-reference/functions/functions-for-nulls
+slug: /ru/sql-reference/functions/null-functions
 sidebar_position: 63
 sidebar_label: "Функции для работы с Nullable-аргументами"
 ---

--- a/docs/zh/sql-reference/functions/null-functions.md
+++ b/docs/zh/sql-reference/functions/null-functions.md
@@ -1,5 +1,5 @@
 ---
-slug: /zh/sql-reference/functions/functions-for-nulls
+slug: /zh/sql-reference/functions/null-functions
 ---
 # Nullable处理函数 {#nullablechu-li-han-shu}
 


### PR DESCRIPTION

### Changelog category (leave one):
- Documentation (changelog entry is not required)

It's wrong, and also causing a warning during the build process.