### PR TITLE
Fix race in `ReplicatedMergeTreeLogEntryData`

### DIFF
--- a/src/Common/CopyableAtomic.h
+++ b/src/Common/CopyableAtomic.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <atomic>
+#include <utility>
+
+namespace DB
+{
+
+template <typename T>
+struct CopyableAtomic
+{
+    CopyableAtomic(const CopyableAtomic & other)
+        : value(other.value.load())
+    {}
+
+    explicit CopyableAtomic(T && value_)
+        : value(std::forward<T>(value_))
+    {}
+
+    CopyableAtomic & operator=(const CopyableAtomic & other)
+    {
+        value = other.value.load();
+        return *this;
+    }
+
+    CopyableAtomic & operator=(bool value_)
+    {
+        value = value_;
+        return *this;
+    }
+
+    explicit operator T() const { return value; }
+
+    const T & getValue() const { return value; }
+
+    std::atomic<T> value;
+};
+
+}

--- a/src/Storages/MergeTree/ReplicatedMergeTreeLogEntry.h
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeLogEntry.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <Common/CopyableAtomic.h>
 #include <Common/Exception.h>
 #include <Common/ZooKeeper/Types.h>
 #include <base/types.h>
@@ -173,36 +174,7 @@ struct ReplicatedMergeTreeLogEntryData
     size_t quorum = 0;
 
     /// Used only in tests for permanent fault injection for particular queue entry.
-    struct CopyableAtomicFlag
-    {
-        CopyableAtomicFlag() = default;
-
-        CopyableAtomicFlag(const CopyableAtomicFlag & other)
-            : value(other.value.load())
-        {}
-
-        explicit CopyableAtomicFlag(bool value_)
-            : value(value_)
-        {}
-
-        CopyableAtomicFlag & operator=(const CopyableAtomicFlag & other)
-        {
-            value = other.value.load();
-            return *this;
-        }
-
-        CopyableAtomicFlag & operator=(bool value_)
-        {
-            value = value_;
-            return *this;
-        }
-
-        explicit operator bool() const { return value; }
-
-        std::atomic<bool> value = false;
-    };
-
-    CopyableAtomicFlag fault_injected;
+    CopyableAtomic<bool> fault_injected{false};
 
     /// If this MUTATE_PART entry caused by alter(modify/drop) query.
     bool isAlterMutation() const


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

https://s3.amazonaws.com/clickhouse-test-reports/0/224dad9e168dc6eeb0baa2e0ba3313b7c4c94188/stress_test__azure__tsan_/stderr.log

Used only for fault injection.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

<details>
    <summary>Modify your CI run</summary>

**NOTE:** If your merge the PR with modified CI you **MUST KNOW** what you are doing
**NOTE:** Checked options will be applied if set before CI RunConfig/PrepareRunConfig step

#### Include tests (required builds will be added automatically):
- [ ] <!---ci_include_fast--> Fast test
- [ ] <!---ci_include_integration--> Integration Tests
- [ ] <!---ci_include_stateless--> Stateless tests
- [ ] <!---ci_include_stateful--> Stateful tests
- [ ] <!---ci_include_unit--> Unit tests
- [ ] <!---ci_include_performance--> Performance tests
- [ ] <!---ci_include_asan--> All with ASAN
- [ ] <!---ci_include_tsan--> All with TSAN
- [ ] <!---ci_include_analyzer--> All with Analyzer
- [ ] <!---ci_include_azure --> All with Azure
- [ ] <!---ci_include_KEYWORD--> Add your option here

#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [ ] <!---ci_exclude_tsan--> All with TSAN
- [ ] <!---ci_exclude_msan--> All with MSAN
- [ ] <!---ci_exclude_ubsan--> All with UBSAN
- [ ] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64--> All with Aarch64
- [ ] <!---ci_exclude_KEYWORD--> Add your option here

#### Extra options:
- [ ] <!---do_not_test--> do not test (only style check)
- [ ] <!---no_merge_commit--> disable merge-commit (no merge from master before tests)
- [ ] <!---no_ci_cache--> disable CI cache (job reuse)

#### Only specified batches in multi-batch jobs:
- [ ] <!---batch_0--> 1
- [ ] <!---batch_1--> 2
- [ ] <!---batch_2--> 3
- [ ] <!---batch_3--> 4

</details>
