### PR TITLE
JOIN filter push down equivalent columns fix

### DIFF
--- a/src/Processors/QueryPlan/Optimizations/filterPushDown.cpp
+++ b/src/Processors/QueryPlan/Optimizations/filterPushDown.cpp
@@ -262,10 +262,6 @@ static size_t tryPushDownOverJoinStep(QueryPlan::Node * parent_node, QueryPlan::
         {
             const auto & left_table_key_name = join_clause.key_names_left[i];
             const auto & right_table_key_name = join_clause.key_names_right[i];
-
-            if (!join_header.has(left_table_key_name) || !join_header.has(right_table_key_name))
-                continue;
-
             const auto & left_table_column = left_stream_input_header.getByName(left_table_key_name);
             const auto & right_table_column = right_stream_input_header.getByName(right_table_key_name);
 
@@ -338,9 +334,9 @@ static size_t tryPushDownOverJoinStep(QueryPlan::Node * parent_node, QueryPlan::
     auto join_filter_push_down_actions = filter->getExpression()->splitActionsForJOINFilterPushDown(filter->getFilterColumnName(),
         filter->removesFilterColumn(),
         left_stream_available_columns_to_push_down,
-        left_stream_input_header.getColumnsWithTypeAndName(),
+        left_stream_input_header,
         right_stream_available_columns_to_push_down,
-        right_stream_input_header.getColumnsWithTypeAndName(),
+        right_stream_input_header,
         equivalent_columns_to_push_down,
         equivalent_left_stream_column_to_right_stream_column,
         equivalent_right_stream_column_to_left_stream_column);

--- a/tests/queries/0_stateless/03152_join_filter_push_down_equivalent_columns.reference
+++ b/tests/queries/0_stateless/03152_join_filter_push_down_equivalent_columns.reference
@@ -1,0 +1,91 @@
+-- { echoOn }
+
+EXPLAIN header = 1, indexes = 1
+SELECT name FROM users INNER JOIN users2 USING name WHERE users.name ='Alice';
+Expression ((Project names + (Projection + )))
+Header: name String
+  Join (JOIN FillRightFirst)
+  Header: __table1.name String
+    Filter (( + Change column names to column identifiers))
+    Header: __table1.name String
+      ReadFromMergeTree (default.users)
+      Header: name String
+      Indexes:
+        PrimaryKey
+          Keys: 
+            name
+          Condition: (name in [\'Alice\', \'Alice\'])
+          Parts: 1/3
+          Granules: 1/3
+    Filter (( + Change column names to column identifiers))
+    Header: __table2.name String
+      ReadFromMergeTree (default.users2)
+      Header: name String
+      Indexes:
+        PrimaryKey
+          Keys: 
+            name
+          Condition: (name in [\'Alice\', \'Alice\'])
+          Parts: 1/3
+          Granules: 1/3
+SELECT '--';
+--
+EXPLAIN header = 1, indexes = 1
+SELECT name FROM users LEFT JOIN users2 USING name WHERE users.name ='Alice';
+Expression ((Project names + (Projection + )))
+Header: name String
+  Join (JOIN FillRightFirst)
+  Header: __table1.name String
+    Filter (( + Change column names to column identifiers))
+    Header: __table1.name String
+      ReadFromMergeTree (default.users)
+      Header: name String
+      Indexes:
+        PrimaryKey
+          Keys: 
+            name
+          Condition: (name in [\'Alice\', \'Alice\'])
+          Parts: 1/3
+          Granules: 1/3
+    Filter (( + Change column names to column identifiers))
+    Header: __table2.name String
+      ReadFromMergeTree (default.users2)
+      Header: name String
+      Indexes:
+        PrimaryKey
+          Keys: 
+            name
+          Condition: (name in [\'Alice\', \'Alice\'])
+          Parts: 1/3
+          Granules: 1/3
+SELECT '--';
+--
+EXPLAIN header = 1, indexes = 1
+SELECT name FROM users RIGHT JOIN users2 USING name WHERE users2.name ='Alice';
+Expression ((Project names + (Projection + )))
+Header: name String
+  Join (JOIN FillRightFirst)
+  Header: __table1.name String
+          __table2.name String
+    Filter (( + Change column names to column identifiers))
+    Header: __table1.name String
+      ReadFromMergeTree (default.users)
+      Header: name String
+      Indexes:
+        PrimaryKey
+          Keys: 
+            name
+          Condition: (name in [\'Alice\', \'Alice\'])
+          Parts: 1/3
+          Granules: 1/3
+    Filter (( + Change column names to column identifiers))
+    Header: __table2.name String
+      ReadFromMergeTree (default.users2)
+      Header: name String
+      Indexes:
+        PrimaryKey
+          Keys: 
+            name
+          Condition: (name in [\'Alice\', \'Alice\'])
+          Parts: 1/3
+          Granules: 1/3

--- a/tests/queries/0_stateless/03152_join_filter_push_down_equivalent_columns.sql
+++ b/tests/queries/0_stateless/03152_join_filter_push_down_equivalent_columns.sql
@@ -1,0 +1,33 @@
+DROP TABLE IF EXISTS users;
+CREATE TABLE users (uid Int16, name String, age Int16) ENGINE=MergeTree order by (uid, name);
+
+INSERT INTO users VALUES (1231, 'John', 33);
+INSERT INTO users VALUES (6666, 'Ksenia', 48);
+INSERT INTO users VALUES (8888, 'Alice', 50);
+
+DROP TABLE IF EXISTS users2;
+CREATE TABLE users2 (uid Int16, name String, age2 Int16) ENGINE=MergeTree order by (uid, name);
+
+INSERT INTO users2 VALUES (1231, 'John', 33);
+INSERT INTO users2 VALUES (6666, 'Ksenia', 48);
+INSERT INTO users2 VALUES (8888, 'Alice', 50);
+
+-- { echoOn }
+
+EXPLAIN header = 1, indexes = 1
+SELECT name FROM users INNER JOIN users2 USING name WHERE users.name ='Alice';
+
+SELECT '--';
+
+EXPLAIN header = 1, indexes = 1
+SELECT name FROM users LEFT JOIN users2 USING name WHERE users.name ='Alice';
+
+SELECT '--';
+
+EXPLAIN header = 1, indexes = 1
+SELECT name FROM users RIGHT JOIN users2 USING name WHERE users2.name ='Alice';
+
+-- { echoOff }
+
+DROP TABLE users;
+DROP TABLE users2;

--- a/tests/queries/0_stateless/03152_join_filter_push_down_equivalent_columns.sql
+++ b/tests/queries/0_stateless/03152_join_filter_push_down_equivalent_columns.sql
@@ -1,3 +1,5 @@
+SET allow_experimental_analyzer = 1;
+
 DROP TABLE IF EXISTS users;
 CREATE TABLE users (uid Int16, name String, age Int16) ENGINE=MergeTree order by (uid, name);
 


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Allow JOIN filter push down to both streams if only single equivalent column is used in query. Closes #63799.
