### PR TITLE
io_uring: add basic io_uring clickhouse perf test

### DIFF
--- a/tests/performance/io_uring.xml
+++ b/tests/performance/io_uring.xml
@@ -1,0 +1,13 @@
+<test>
+    <settings>
+        <local_filesystem_read_method>io_uring</local_filesystem_read_method>
+    </settings>
+
+    <create_query>CREATE TABLE hits_none (WatchID UInt64 CODEC(NONE)) ENGINE = MergeTree ORDER BY tuple()</create_query>
+    <fill_query>INSERT INTO hits_none SELECT WatchID FROM test.hits</fill_query>
+    <fill_query>OPTIMIZE TABLE hits_none FINAL</fill_query>
+
+    <query short="1"><![CDATA[SELECT sum(WatchID) FROM hits_none]]></query>
+
+    <drop_query>DROP TABLE hits_none</drop_query>
+</test>

--- a/tests/performance/io_uring.xml
+++ b/tests/performance/io_uring.xml
@@ -3,11 +3,5 @@
         <local_filesystem_read_method>io_uring</local_filesystem_read_method>
     </settings>
 
-    <create_query>CREATE TABLE hits_none (WatchID UInt64 CODEC(NONE)) ENGINE = MergeTree ORDER BY tuple()</create_query>
-    <fill_query>INSERT INTO hits_none SELECT WatchID FROM test.hits</fill_query>
-    <fill_query>OPTIMIZE TABLE hits_none FINAL</fill_query>
-
-    <query short="1"><![CDATA[SELECT sum(WatchID) FROM hits_none]]></query>
-
-    <drop_query>DROP TABLE hits_none</drop_query>
+    <query short="1"><![CDATA[SELECT sum(WatchID) FROM test.hits]]></query>
 </test>


### PR DESCRIPTION
Add a basic isolated io_uring Clickhouse perf test, similar to `tests/performance/mmap_io.xml`, to get a rough understanding of the performance of Clickhouse on io_uring, aligned to the current testing strategy.

### Changelog category (leave one):

- Not for changelog (changelog entry is not required)

