### PR TITLE
Remove unnecessary logging statements in MergeJoinTransform.cpp

### DIFF
--- a/src/Processors/Transforms/MergeJoinTransform.cpp
+++ b/src/Processors/Transforms/MergeJoinTransform.cpp
@@ -338,8 +338,6 @@ static void prepareChunk(Chunk & chunk)
 
 void MergeJoinAlgorithm::initialize(Inputs inputs)
 {
-    LOG_DEBUG(&Poco::Logger::get("XXXX"), "{}:{}: {} - '{}'", __FILE__, __LINE__, 0, inputs[0].chunk.dumpStructure());
-    LOG_DEBUG(&Poco::Logger::get("XXXX"), "{}:{}: {} - '{}'", __FILE__, __LINE__, 1, inputs[1].chunk.dumpStructure());
     if (inputs.size() != 2)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Two inputs are required, got {}", inputs.size());
 
@@ -351,8 +349,6 @@ void MergeJoinAlgorithm::initialize(Inputs inputs)
 
 void MergeJoinAlgorithm::consume(Input & input, size_t source_num)
 {
-    LOG_DEBUG(&Poco::Logger::get("XXXX"), "{}:{}: {} - '{}'", __FILE__, __LINE__, source_num, input.chunk.dumpStructure());
-
     if (input.skip_last_row)
         throw Exception(ErrorCodes::NOT_IMPLEMENTED, "skip_last_row is not supported");
 
@@ -816,15 +812,9 @@ IMergingAlgorithm::Status MergeJoinAlgorithm::merge()
     if (!cursors[1]->cursor.isValid() && !cursors[1]->fullyCompleted())
         return Status(1);
 
-    for (size_t i = 0; i < 2; ++i)
-    {
-        LOG_DEBUG(&Poco::Logger::get("XXXX"), "{}:{}: sampleColumns {} '{}'", __FILE__, __LINE__, i, cursors[i]->sampleBlock().dumpStructure());
-    }
-
 
     if (auto result = handleAllJoinState())
     {
-        LOG_DEBUG(&Poco::Logger::get("XXXX"), "{}:{}: '{}'", __FILE__, __LINE__, result ? result->chunk.dumpStructure() : "NA");
         return std::move(*result);
     }
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)


accidentally added in https://github.com/ClickHouse/ClickHouse/pull/62287/files