### PR TITLE
Fix incorrect result when reading from MV with parallel replicas and new analyzer

### DIFF
--- a/src/Planner/findParallelReplicasQuery.cpp
+++ b/src/Planner/findParallelReplicasQuery.cpp
@@ -1,24 +1,25 @@
-#include <Planner/findQueryForParallelReplicas.h>
-#include <Interpreters/ClusterProxy/SelectStreamFactory.h>
-#include <Interpreters/InterpreterSelectQueryAnalyzer.h>
-#include <Processors/QueryPlan/JoinStep.h>
-#include <Processors/QueryPlan/CreatingSetsStep.h>
-#include <Storages/buildQueryTreeForShard.h>
-#include <Interpreters/ClusterProxy/executeQuery.h>
-#include <Planner/PlannerJoinTree.h>
-#include <Planner/Utils.h>
 #include <Analyzer/ArrayJoinNode.h>
 #include <Analyzer/InDepthQueryTreeVisitor.h>
 #include <Analyzer/JoinNode.h>
 #include <Analyzer/QueryNode.h>
 #include <Analyzer/TableNode.h>
 #include <Analyzer/UnionNode.h>
+#include <Interpreters/ClusterProxy/SelectStreamFactory.h>
+#include <Interpreters/ClusterProxy/executeQuery.h>
+#include <Interpreters/InterpreterSelectQueryAnalyzer.h>
 #include <Parsers/ASTSubquery.h>
 #include <Parsers/queryToString.h>
+#include <Planner/PlannerJoinTree.h>
+#include <Planner/Utils.h>
+#include <Planner/findQueryForParallelReplicas.h>
+#include <Processors/QueryPlan/CreatingSetsStep.h>
 #include <Processors/QueryPlan/ExpressionStep.h>
 #include <Processors/QueryPlan/FilterStep.h>
+#include <Processors/QueryPlan/JoinStep.h>
 #include <Storages/MergeTree/MergeTreeData.h>
 #include <Storages/StorageDummy.h>
+#include <Storages/StorageMaterializedView.h>
+#include <Storages/buildQueryTreeForShard.h>
 
 namespace DB
 {
@@ -316,7 +317,8 @@ static const TableNode * findTableForParallelReplicas(const IQueryTreeNode * que
             case QueryTreeNodeType::TABLE:
             {
                 const auto & table_node = query_tree_node->as<TableNode &>();
-                const auto & storage = table_node.getStorage();
+                const auto * as_mat_view = typeid_cast<const StorageMaterializedView *>(table_node.getStorage().get());
+                const auto & storage = as_mat_view ? as_mat_view->getTargetTable() : table_node.getStorage();
                 if (std::dynamic_pointer_cast<MergeTreeData>(storage) || typeid_cast<const StorageDummy *>(storage.get()))
                     return &table_node;
 

--- a/tests/queries/0_stateless/03143_parallel_replicas_mat_view_bug.reference
+++ b/tests/queries/0_stateless/03143_parallel_replicas_mat_view_bug.reference
@@ -1,2 +1,1 @@
 test
-test

--- a/tests/queries/0_stateless/03143_parallel_replicas_mat_view_bug.reference
+++ b/tests/queries/0_stateless/03143_parallel_replicas_mat_view_bug.reference
@@ -1,0 +1,2 @@
+test
+test

--- a/tests/queries/0_stateless/03143_parallel_replicas_mat_view_bug.sql
+++ b/tests/queries/0_stateless/03143_parallel_replicas_mat_view_bug.sql
@@ -1,0 +1,13 @@
+DROP TABLE IF EXISTS mv_table;
+DROP TABLE IF EXISTS null_table;
+
+SET cluster_for_parallel_replicas='parallel_replicas', max_parallel_replicas=4, allow_experimental_parallel_reading_from_replicas=1;
+SET allow_experimental_analyzer=1;
+
+CREATE TABLE null_table (str String) ENGINE = Null;
+CREATE MATERIALIZED VIEW mv_table (str String) ENGINE = ReplicatedMergeTree('/clickhouse/tables/{database}/03143_parallel_replicas_mat_view_bug', '{replica}') ORDER BY str AS SELECT str AS str FROM null_table;
+INSERT INTO null_table VALUES ('test');
+
+SELECT * FROM mv_table;
+
+SELECT * FROM merge('xxx', '^.inner_id.*');

--- a/tests/queries/0_stateless/03143_parallel_replicas_mat_view_bug.sql
+++ b/tests/queries/0_stateless/03143_parallel_replicas_mat_view_bug.sql
@@ -9,5 +9,3 @@ CREATE MATERIALIZED VIEW mv_table (str String) ENGINE = ReplicatedMergeTree('/cl
 INSERT INTO null_table VALUES ('test');
 
 SELECT * FROM mv_table;
-
-SELECT * FROM merge('xxx', '^.inner_id.*');


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix incorrect select query result when parallel replicas were used to read from a Materialized View.

---

The problem is that to use PRs on a follower we need to find a table to be read with PRs and match it. And this procedure is completely disconnected with how initiator decides whether to use PRs or not. For the latter it is basically just "I see a MergeTree table and all the required settings are enabled". Thus if `findTableForParallelReplicas` fails to found the needed table we will end up executing normal distributed subquery on the replicas, meaning each one will read the whole table without syncing anyhow with the initiator. sɐɔᴉldǝɹ oʇ uɐld ʎɹǝnb puǝs oʇ pǝǝu ǝM