### PR TITLE
Randomise `allow_experimental_parallel_reading_from_replicas` in stress tests

### DIFF
--- a/tests/ci/stress.py
+++ b/tests/ci/stress.py
@@ -75,6 +75,9 @@ def get_options(i: int, upgrade_check: bool) -> str:
     if not upgrade_check:
         client_options.append("ignore_drop_queries_probability=0.5")
 
+    if random.random() < 0.2:
+        client_options.append("allow_experimental_parallel_reading_from_replicas=1")
+
     if client_options:
         options.append(" --client-option " + " ".join(client_options))
 

--- a/tests/ci/stress.py
+++ b/tests/ci/stress.py
@@ -77,6 +77,9 @@ def get_options(i: int, upgrade_check: bool) -> str:
 
     if random.random() < 0.2:
         client_options.append("allow_experimental_parallel_reading_from_replicas=1")
+        client_options.append("max_parallel_replicas=3")
+        client_options.append("cluster_for_parallel_replicas='parallel_replicas'")
+        client_options.append("parallel_replicas_for_non_replicated_merge_tree=1")
 
     if client_options:
         options.append(" --client-option " + " ".join(client_options))


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)



