### PR TITLE
Fix logs test for binary data by converting it to a valid UTF8 string.

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -2549,15 +2549,15 @@ def reportLogStats(args):
         WITH
             240 AS mins,
             (
-                SELECT (count(), sum(length(message)))
+                SELECT (count(), sum(length(toValidUTF8(message))))
                 FROM system.text_log
                 WHERE (now() - toIntervalMinute(mins)) < event_time
             ) AS total
         SELECT
             count() AS count,
             round(count / (total.1), 3) AS `count_%`,
-            formatReadableSize(sum(length(message))) AS size,
-            round(sum(length(message)) / (total.2), 3) AS `size_%`,
+            formatReadableSize(sum(length(toValidUTF8(message)))) AS size,
+            round(sum(length(toValidUTF8(message))) / (total.2), 3) AS `size_%`,
             countDistinct(logger_name) AS uniq_loggers,
             countDistinct(thread_id) AS uniq_threads,
             groupArrayDistinct(toString(level)) AS levels,
@@ -2580,8 +2580,8 @@ def reportLogStats(args):
             240 AS mins
         SELECT
             count() AS count,
-            substr(replaceRegexpAll(message, '[^A-Za-z]+', ''), 1, 32) AS pattern,
-            substr(any(message), 1, 256) as runtime_message,
+            substr(replaceRegexpAll(toValidUTF8(message), '[^A-Za-z]+', ''), 1, 32) AS pattern,
+            substr(any(toValidUTF8(message)), 1, 256) as runtime_message,
             any((extract(source_file, '/[a-zA-Z0-9_]+\\.[a-z]+'), source_line)) as line
         FROM system.text_log
         WHERE (now() - toIntervalMinute(mins)) < event_time AND message_format_string = ''
@@ -2596,7 +2596,7 @@ def reportLogStats(args):
     print("\n")
 
     query = """
-        SELECT message_format_string, count(), any(message) AS any_message
+        SELECT message_format_string, count(), any(toValidUTF8(message)) AS any_message
         FROM system.text_log
         WHERE (now() - toIntervalMinute(240)) < event_time
         AND (message NOT LIKE (replaceRegexpAll(message_format_string, '{[:.0-9dfx]*}', '%') AS s))
@@ -2631,8 +2631,8 @@ def reportLogStats(args):
               'Unknown identifier: ''{}''', 'User name is empty', 'Expected function, got: {}',
               'Attempt to read after eof', 'String size is too big ({}), maximum: {}'
         ) AS known_short_messages
-        SELECT count() AS c, message_format_string, substr(any(message), 1, 120),
-            min(if(length(regexpExtract(message, '(.*)\\([A-Z0-9_]+\\)')) as prefix_len > 0, prefix_len, length(message)) - 26 AS length_without_exception_boilerplate) AS min_length_without_exception_boilerplate
+        SELECT count() AS c, message_format_string, substr(any(toValidUTF8(message)), 1, 120),
+            min(if(length(regexpExtract(toValidUTF8(message), '(.*)\\([A-Z0-9_]+\\)')) as prefix_len > 0, prefix_len, length(toValidUTF8(message))) - 26 AS length_without_exception_boilerplate) AS min_length_without_exception_boilerplate
         FROM system.text_log
         WHERE (now() - toIntervalMinute(240)) < event_time
             AND (length(message_format_string) < 16

--- a/tests/queries/0_stateless/00002_log_and_exception_messages_formatting.sql
+++ b/tests/queries/0_stateless/00002_log_and_exception_messages_formatting.sql
@@ -194,7 +194,7 @@ select 'exceptions shorter than 30',
     (uniqExact(message_format_string) as c) <= max_messages,
     c <= max_messages ? [] : groupUniqArray(message_format_string)
     from logs
-    where message ilike '%DB::Exception%' and if(length(extract(message, '(.*)\\([A-Z0-9_]+\\)')) as pref > 0, pref, length(message)) < 30 + 26 and message_format_string not in known_short_messages;
+    where message ilike '%DB::Exception%' and if(length(extract(toValidUTF8(message), '(.*)\\([A-Z0-9_]+\\)')) as pref > 0, pref, length(toValidUTF8(message))) < 30 + 26 and message_format_string not in known_short_messages;
 
 -- Avoid too noisy messages: top 1 message frequency must be less than 30%. We should reduce the threshold
 WITH 0.30 as threshold
@@ -252,7 +252,7 @@ select 'number of noisy messages',
 -- Each message matches its pattern (returns 0 rows)
 -- Note: maybe we should make it stricter ('Code:%Exception: '||s||'%'), but it's not easy because of addMessage
 select 'incorrect patterns', greatest(uniqExact(message_format_string), 15) from (
-    select message_format_string, any(message) as any_message from logs
+    select message_format_string, any(toValidUTF8(message)) as any_message from logs
     where ((rand() % 8) = 0)
     and message not like (replaceRegexpAll(message_format_string, '{[:.0-9dfx]*}', '%') as s)
     and message not like (s || ' (skipped % similar messages)')


### PR DESCRIPTION
If a binary data was present in the message, the regular expression was broken causing test flakiness.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)