### PR TITLE
Revert "CI: disable ARM integration test cases with libunwind crash"

### DIFF
--- a/tests/integration/test_crash_log/test.py
+++ b/tests/integration/test_crash_log/test.py
@@ -39,10 +39,6 @@ def wait_for_clickhouse_stop(started_node):
     assert result == "OK", "ClickHouse process is still running"
 
 
-@pytest.mark.skipif(
-    helpers.cluster.is_arm(),
-    reason="Fails on ARM, issue https://github.com/ClickHouse/ClickHouse/issues/63855",
-)
 def test_pkill(started_node):
     if (
         started_node.is_built_with_thread_sanitizer()
@@ -63,10 +59,6 @@ def test_pkill(started_node):
         )
 
 
-@pytest.mark.skipif(
-    helpers.cluster.is_arm(),
-    reason="Fails on ARM, issue https://github.com/ClickHouse/ClickHouse/issues/63855",
-)
 def test_pkill_query_log(started_node):
     for signal in ["SEGV", "4"]:
         # force create query_log if it was not created

--- a/tests/integration/test_send_crash_reports/test.py
+++ b/tests/integration/test_send_crash_reports/test.py
@@ -35,10 +35,6 @@ def started_node():
             pass
 
 
-@pytest.mark.skipif(
-    helpers.cluster.is_arm(),
-    reason="Fails on ARM, issue https://github.com/ClickHouse/ClickHouse/issues/63855",
-)
 def test_send_segfault(started_node):
     # NOTE: another option is to increase waiting time.
     if (


### PR DESCRIPTION
Let's try re-run after https://github.com/ClickHouse/ClickHouse/pull/63865

Reverts ClickHouse/ClickHouse#63867

Fixes: https://github.com/ClickHouse/ClickHouse/issues/63855

#job_style_check
#job_Integration_tests_aarch64
#job_Integration_tests_release