### PR TITLE
fix_client_abort: Resolve Client Abortion When Using KQL Table function

### DIFF
--- a/src/Parsers/Kusto/ParserKQLStatement.cpp
+++ b/src/Parsers/Kusto/ParserKQLStatement.cpp
@@ -7,6 +7,7 @@
 #include <Parsers/Kusto/ParserKQLStatement.h>
 #include <Parsers/Kusto/Utilities.h>
 #include <Parsers/ParserSetQuery.h>
+#include <Parsers/ASTLiteral.h>
 
 namespace DB
 {
@@ -62,49 +63,51 @@ bool ParserKQLWithUnionQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & exp
 
 bool ParserKQLTableFunction::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
 {
-    ParserKQLWithUnionQuery kql_p;
-    ASTPtr select;
-    ParserToken s_lparen(TokenType::OpeningRoundBracket);
+    ParserToken lparen(TokenType::OpeningRoundBracket);
 
-    auto begin = pos;
-    auto paren_count = 0;
+    ASTPtr string_literal;
+    ParserStringLiteral parser_string_literal;
+
+    if (!lparen.ignore(pos, expected))
+        return false;
+
+    size_t paren_count = 0;
     String kql_statement;
-
-    if (s_lparen.ignore(pos, expected))
+    if (parser_string_literal.parse(pos, string_literal, expected))
     {
-        if (pos->type == TokenType::HereDoc)
-        {
-            kql_statement = String(pos->begin + 2, pos->end - 2);
-        }
-        else
-        {
-            ++paren_count;
-            auto pos_start = pos;
-            while (isValidKQLPos(pos))
-            {
-                if (pos->type == TokenType::ClosingRoundBracket)
-                    --paren_count;
-                if (pos->type == TokenType::OpeningRoundBracket)
-                    ++paren_count;
-
-                if (paren_count == 0)
-                    break;
-                ++pos;
-            }
-            kql_statement = String(pos_start->begin, (--pos)->end);
-        }
-        ++pos;
-        Tokens token_kql(kql_statement.c_str(), kql_statement.c_str() + kql_statement.size());
-        IParser::Pos pos_kql(token_kql, pos.max_depth, pos.max_backtracks);
-
-        if (kql_p.parse(pos_kql, select, expected))
-        {
-            node = select;
-            ++pos;
-            return true;
-        }
+        kql_statement = typeid_cast<const ASTLiteral &>(*string_literal).value.safeGet<String>();
     }
-    pos = begin;
-    return false;
+    else
+    {
+        ++paren_count;
+        auto pos_start = pos;
+        while (isValidKQLPos(pos))
+        {
+            if (pos->type == TokenType::ClosingRoundBracket)
+                --paren_count;
+            if (pos->type == TokenType::OpeningRoundBracket)
+                ++paren_count;
+
+            if (paren_count == 0)
+                break;
+            ++pos;
+        }
+        if (!isValidKQLPos(pos))
+        {
+            return false;
+        }
+        --pos;
+        kql_statement = String(pos_start->begin, pos->end);
+        ++pos;
+    }
+
+    Tokens token_kql(kql_statement.data(), kql_statement.data() + kql_statement.size());
+    IParser::Pos pos_kql(token_kql, pos.max_depth, pos.max_backtracks);
+    Expected kql_expected;
+    kql_expected.enable_highlighting = false;
+    if (!ParserKQLWithUnionQuery().parse(pos_kql, node, kql_expected))
+        return false;
+    ++pos;
+    return true;
 }
 }


### PR DESCRIPTION

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):

- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
(Low-quality third-party Kusto Query Language). Resolve Client Abortion Issue When Using KQL Table Function in Interactive Mode

When typing a statement to call the KQL table function in interactive mode, the client aborts midway. This issue began occurring after the syntax highlighting feature was introduced (version 24.4 , 24.5). For example, if you type:

`select * from kql(t `

the client aborts unexpectedly

This PR fix the issue