### PR TITLE
Installation test has wrong check_state

### DIFF
--- a/tests/ci/install_check.py
+++ b/tests/ci/install_check.py
@@ -333,11 +333,9 @@ def main():
         test_results.extend(test_install_tgz(docker_images[RPM_IMAGE]))
 
     state = SUCCESS
-    test_status = OK
     description = "Packages installed successfully"
     if FAIL in (result.status for result in test_results):
         state = FAILURE
-        test_status = FAIL
         description = "Failed to install packages: " + ", ".join(
             result.name for result in test_results
         )
@@ -365,7 +363,7 @@ def main():
     prepared_events = prepare_tests_results_for_clickhouse(
         pr_info,
         test_results,
-        test_status,
+        state,
         stopwatch.duration_seconds,
         stopwatch.start_time_str,
         report_url,


### PR DESCRIPTION
Fix the only [place](https://play.clickhouse.com/play?user=play#U0VMRUNUIGNoZWNrX3N0YXR1cywgYmFzZV9yZWYsIGhlYWRfcmVmLCBhbnkocmVwb3J0X3VybCkgRlJPTSBjaGVja3MgV0hFUkUgY2hlY2tfc3RhdHVzIE5PVCBJTiAoJ2Vycm9yJywgJ3N1Y2Nlc3MnLCAnZmFpbHVyZScsICdwZW5kaW5nJykgQU5EIHRvRGF0ZShjaGVja19zdGFydF90aW1lKSA+PSB0b0RhdGUoJzIwMjQtMDQtMDEnKSBHUk9VUCBCWSBBTEw=) where check_state is not in the [valid set](https://play.clickhouse.com/play?user=play#U0VMRUNUIGNoZWNrX3N0YXR1cyBGUk9NIGNoZWNrcyBXSEVSRSAgdG9EYXRlKGNoZWNrX3N0YXJ0X3RpbWUpID09IHRvRGF0ZSgnMjAyNC0wNS0xNicpIEdST1VQIEJZIEFMTA==) of commit statuses

Follow up of https://github.com/ClickHouse/ClickHouse/pull/63982