### PR TITLE
[Docs] Incorrect sample syntax for cutToFirstSignificantSubdomainCust…

### DIFF
--- a/docs/en/sql-reference/functions/url-functions.md
+++ b/docs/en/sql-reference/functions/url-functions.md
@@ -152,7 +152,7 @@ Configuration example:
 **Syntax**
 
 ``` sql
-cutToFirstSignificantSubdomain(URL, TLD)
+cutToFirstSignificantSubdomainCustom(URL, TLD)
 ```
 
 **Arguments**


### PR DESCRIPTION
…om(URL, TLD)

### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Incorrect sample syntax for cutToFirstSignificantSubdomainCustom(URL, TLD)
