### PR TITLE
chore(ci-workers): remove reusable from tailscale key

### DIFF
--- a/tests/ci/worker/prepare-ci-ami.sh
+++ b/tests/ci/worker/prepare-ci-ami.sh
@@ -183,7 +183,7 @@ setup_tailscale() {
     # Clean possible garbage from the runner type
     RUNNER_TYPE=${RUNNER_TYPE//[^0-9a-z]/-}
     TS_AUTHKEY=$(TS_API_CLIENT_ID="$TS_API_CLIENT_ID" TS_API_CLIENT_SECRET="$TS_API_CLIENT_SECRET" \
-                 get-authkey -tags tag:svc-core-ci-github -reusable -ephemeral)
+                 get-authkey -tags tag:svc-core-ci-github -ephemeral)
     tailscale up --ssh --auth-key="$TS_AUTHKEY" --hostname="ci-runner-$RUNNER_TYPE-$INSTANCE_ID"
 }
 


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

Requested by Tailscale.