### PR TITLE
Fix libbcrypt for FreeBSD build

### DIFF
--- a/contrib/libbcrypt-cmake/CMakeLists.txt
+++ b/contrib/libbcrypt-cmake/CMakeLists.txt
@@ -7,7 +7,7 @@ endif()
 
 set (LIBRARY_DIR "${ClickHouse_SOURCE_DIR}/contrib/libbcrypt")
 
-set(SRCS 
+set(SRCS
     "${LIBRARY_DIR}/bcrypt.c"
     "${LIBRARY_DIR}/crypt_blowfish/crypt_blowfish.c"
     "${LIBRARY_DIR}/crypt_blowfish/crypt_gensalt.c"
@@ -16,4 +16,13 @@ set(SRCS
 
 add_library(_bcrypt ${SRCS})
 target_include_directories(_bcrypt SYSTEM PUBLIC "${LIBRARY_DIR}")
+# Avoid conflicts for crypt_r on FreeBSD [1]:
+#
+# - char *crypt_r(__const char *key, __const char *setting, void *data);
+# - char *crypt_r(const char *, const char *, struct crypt_data *);
+#
+#   [1]: https://github.com/freebsd/freebsd-src/commit/5f521d7ba72145092ea23ff6081d8791ad6c1f9d
+#
+# NOTE: ow-crypt.h is unsed only internally, so PRIVATE is enough
+target_compile_definitions(_bcrypt PRIVATE -D__SKIP_GNU)
 add_library(ch_contrib::bcrypt ALIAS _bcrypt)


### PR DESCRIPTION
Right now it fails due to [1] with the following error:

    /usr/work/ClickHouse/contrib/libbcrypt/crypt_blowfish/ow-crypt.h:27:14: error: conflicting types for 'crypt_r'
       27 | extern char *crypt_r(__const char *key, __const char *setting, void *data);
          |              ^
    /usr/include/unistd.h:500:7: note: previous declaration is here
      500 | char    *crypt_r(const char *, const char *, struct crypt_data *);
          |          ^

  [1]: https://github.com/freebsd/freebsd-src/commit/5f521d7ba72145092ea23ff6081d8791ad6c1f9d

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Refs: https://github.com/ClickHouse/ClickHouse/issues/62628