### PR TITLE
Do not create new release in release branch automatically

### DIFF
--- a/tests/ci/release.py
+++ b/tests/ci/release.py
@@ -406,7 +406,7 @@ class Release:
     def _bump_release_branch(self):
         # Update only git, original version stays the same
         self._git.update()
-        new_version = self.version.patch_update()
+        new_version = self.version.copy()
         version_type = self.get_stable_release_type()
         pr_labels = f"--label {Labels.RELEASE}"
         if version_type == VersionType.LTS:
@@ -432,9 +432,10 @@ class Release:
                         "changes with it.'",
                         dry_run=self.dry_run,
                     )
-                    with self._create_gh_release(False):
-                        # Here the release branch part is done
-                        yield
+                    # Here the release branch part is done.
+                    # We don't create a release itself automatically to have a
+                    # safe window to backport possible bug fixes.
+                    yield
 
     @contextmanager
     def _bump_version_in_master(self, helper_branch: str) -> Iterator[None]:

--- a/tests/ci/version_helper.py
+++ b/tests/ci/version_helper.py
@@ -165,6 +165,21 @@ class ClickHouseVersion:
         self._description = version_type
         self._describe = f"v{self.string}-{version_type}"
 
+    def copy(self) -> "ClickHouseVersion":
+        copy = ClickHouseVersion(
+            self.major,
+            self.minor,
+            self.patch,
+            self.revision,
+            self._git,
+            str(self.tweak),
+        )
+        try:
+            copy.with_description(self.description)
+        except ValueError:
+            pass
+        return copy
+
     def __eq__(self, other: Any) -> bool:
         if not isinstance(self, type(other)):
             return NotImplemented


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add `ClickHouseVersion.copy` method. Create a branch release in advance without spinning out the release to increase the stability.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

<details>
    <summary>Modify your CI run</summary>

**NOTE:** If your merge the PR with modified CI you **MUST KNOW** what you are doing
**NOTE:** Checked options will be applied if set before CI RunConfig/PrepareRunConfig step

#### Include tests (required builds will be added automatically):
- [ ] <!---ci_include_fast--> Fast test
- [ ] <!---ci_include_integration--> Integration Tests
- [ ] <!---ci_include_stateless--> Stateless tests
- [ ] <!---ci_include_stateful--> Stateful tests
- [ ] <!---ci_include_unit--> Unit tests
- [ ] <!---ci_include_performance--> Performance tests
- [ ] <!---ci_include_asan--> All with ASAN
- [ ] <!---ci_include_tsan--> All with TSAN
- [ ] <!---ci_include_analyzer--> All with Analyzer
- [ ] <!---ci_include_azure --> All with Azure
- [ ] <!---ci_include_KEYWORD--> Add your option here

#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [ ] <!---ci_exclude_tsan--> All with TSAN
- [ ] <!---ci_exclude_msan--> All with MSAN
- [ ] <!---ci_exclude_ubsan--> All with UBSAN
- [ ] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64--> All with Aarch64
- [ ] <!---ci_exclude_KEYWORD--> Add your option here

#### Extra options:
- [ ] <!---do_not_test--> do not test (only style check)
- [ ] <!---no_merge_commit--> disable merge-commit (no merge from master before tests)
- [ ] <!---no_ci_cache--> disable CI cache (job reuse)

#### Only specified batches in multi-batch jobs:
- [ ] <!---batch_0--> 1
- [ ] <!---batch_1--> 2
- [ ] <!---batch_2--> 3
- [ ] <!---batch_3--> 4

</details>
