### PR TITLE
Fix unwind on SIGSEGV on aarch64 (due to small stack for signal)

### DIFF
--- a/src/Common/ThreadStatus.cpp
+++ b/src/Common/ThreadStatus.cpp
@@ -23,6 +23,13 @@ thread_local ThreadStatus constinit * current_thread = nullptr;
 namespace
 {
 
+#if defined(__aarch64__)
+/// For aarch64 16K is not enough (likely due to tons of registers)
+static constexpr size_t UNWIND_MINSIGSTKSZ = 32 << 10;
+#else
+static constexpr size_t UNWIND_MINSIGSTKSZ = 16 << 10;
+#endif
+
 /// Alternative stack for signal handling.
 ///
 /// This stack should not be located in the TLS (thread local storage), since:
@@ -50,7 +57,7 @@ struct ThreadStack
         free(data);
     }
 
-    static size_t getSize() { return std::max<size_t>(16 << 10, MINSIGSTKSZ); }
+    static size_t getSize() { return std::max<size_t>(UNWIND_MINSIGSTKSZ, MINSIGSTKSZ); }
     void * getData() const { return data; }
 
 private:

--- a/tests/integration/test_crash_log/test.py
+++ b/tests/integration/test_crash_log/test.py
@@ -39,10 +39,6 @@ def wait_for_clickhouse_stop(started_node):
     assert result == "OK", "ClickHouse process is still running"
 
 
-@pytest.mark.skipif(
-    helpers.cluster.is_arm(),
-    reason="Fails on ARM, issue https://github.com/ClickHouse/ClickHouse/issues/63855",
-)
 def test_pkill(started_node):
     if (
         started_node.is_built_with_thread_sanitizer()
@@ -63,10 +59,6 @@ def test_pkill(started_node):
         )
 
 
-@pytest.mark.skipif(
-    helpers.cluster.is_arm(),
-    reason="Fails on ARM, issue https://github.com/ClickHouse/ClickHouse/issues/63855",
-)
 def test_pkill_query_log(started_node):
     for signal in ["SEGV", "4"]:
         # force create query_log if it was not created

--- a/tests/integration/test_send_crash_reports/test.py
+++ b/tests/integration/test_send_crash_reports/test.py
@@ -35,10 +35,6 @@ def started_node():
             pass
 
 
-@pytest.mark.skipif(
-    helpers.cluster.is_arm(),
-    reason="Fails on ARM, issue https://github.com/ClickHouse/ClickHouse/issues/63855",
-)
 def test_send_segfault(started_node):
     # NOTE: another option is to increase waiting time.
     if (


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix unwind on SIGSEGV on aarch64 (due to small stack for signal)

Only SIGSEGV uses alternative stack (sigaltstack()), which is very
small, 16K, and for aarch64 it is likely not enough for unwinding
(likely due to lots of registers on this platform):

    (gdb) bt
    #0  libunwind::CFI_Parser<libunwind::LocalAddressSpace>::parseFDEInstructions (addressSpace=..., fdeInfo=..., cieInfo=..., upToPC=<optimized out>, arch=4, results=<optimized out>) at ./contrib/libunwind/src/DwarfParser.hpp:561

And this is:

    554       case DW_CFA_remember_state: {
    555         // Avoid operator new because that would be an upward dependency.
    556         // Avoid malloc because it needs heap allocation.
    557         PrologInfoStackEntry *entry =
    558             (PrologInfoStackEntry *)_LIBUNWIND_REMEMBER_ALLOC(
    559                 sizeof(PrologInfoStackEntry));
    560         if (entry != NULL) {
    561           entry->next = rememberStack.entry;
    ^^^
    562           entry->info = *results;
    563           rememberStack.entry = entry;
    564         } else {
    565           return false;
    566         }
    567         _LIBUNWIND_TRACE_DWARF("DW_CFA_remember_state\n");
    568         break;
    569       }

Fixes: https://github.com/ClickHouse/ClickHouse/issues/63855 (cc @maxknv)
Reverts: https://github.com/ClickHouse/ClickHouse/pull/63867
Supersedes: https://github.com/ClickHouse/ClickHouse/pull/63959 (cc @alesapin )

#job_style_check
#job_Integration_tests_aarch64
#job_Integration_tests_release
