### PR TITLE
Always build protoc for the host independently

### DIFF
--- a/contrib/google-protobuf-cmake/CMakeLists.txt
+++ b/contrib/google-protobuf-cmake/CMakeLists.txt
@@ -327,65 +327,43 @@ add_library(protobuf::libprotoc ALIAS _libprotoc)
 
 set(protoc_files ${protobuf_source_dir}/src/google/protobuf/compiler/main.cc)
 
-if (CMAKE_HOST_SYSTEM_NAME STREQUAL CMAKE_SYSTEM_NAME
-    AND CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL CMAKE_SYSTEM_PROCESSOR)
+# Build 'protoc' for host arch
+set (PROTOC_BUILD_DIR "${protobuf_binary_dir}/build")
 
-    add_executable(protoc ${protoc_files})
-    target_link_libraries(protoc _libprotoc
-        _libprotobuf
-        pthread
-        utf8_validity
-        ${protobuf_absl_used_targets})
-    add_executable(protobuf::protoc ALIAS protoc)
+if (NOT EXISTS "${PROTOC_BUILD_DIR}/protoc")
 
-    if (ENABLE_FUZZING)
-        # `protoc` will be built with sanitizer and it could fail during ClickHouse build
-        # It easily reproduces in oss-fuzz building pipeline
-        # To avoid this we can try to build `protoc` without any sanitizer with option `-fno-sanitize=all`, but
-        # it this case we will face with linker errors, because libcxx still will be built with sanitizer
-        # So, we can simply suppress all of these failures with a combination this flag and an environment variable
-        # export MSAN_OPTIONS=exit_code=0
-        target_compile_options(protoc PRIVATE "-fsanitize-recover=all")
-    endif()
-else ()
-    # Build 'protoc' for host arch
-    set (PROTOC_BUILD_DIR "${protobuf_binary_dir}/build")
+    # This is quite ugly but I cannot make dependencies work propery.
 
-    if (NOT EXISTS "${PROTOC_BUILD_DIR}/protoc")
+    set(abseil_source_dir "${ClickHouse_SOURCE_DIR}/contrib/abseil-cpp")
 
-        # This is quite ugly but I cannot make dependencies work propery.
+    execute_process(
+        COMMAND mkdir -p ${PROTOC_BUILD_DIR}
+        COMMAND_ECHO STDOUT)
 
-        set(abseil_source_dir "${ClickHouse_SOURCE_DIR}/contrib/abseil-cpp")
+    execute_process(
+        COMMAND ${CMAKE_COMMAND}
+            "-G${CMAKE_GENERATOR}"
+            "-DCMAKE_MAKE_PROGRAM=${CMAKE_MAKE_PROGRAM}"
+            "-DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}"
+            "-DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}"
+            "-Dprotobuf_BUILD_TESTS=0"
+            "-Dprotobuf_BUILD_CONFORMANCE=0"
+            "-Dprotobuf_BUILD_EXAMPLES=0"
+            "-Dprotobuf_BUILD_PROTOC_BINARIES=1"
+            "-DABSL_ROOT_DIR=${abseil_source_dir}"
+            "-DABSL_ENABLE_INSTALL=0"
+            "${protobuf_source_dir}"
+        WORKING_DIRECTORY "${PROTOC_BUILD_DIR}"
+        COMMAND_ECHO STDOUT)
 
-        execute_process(
-            COMMAND mkdir -p ${PROTOC_BUILD_DIR}
-            COMMAND_ECHO STDOUT)
-
-        execute_process(
-            COMMAND ${CMAKE_COMMAND}
-                "-G${CMAKE_GENERATOR}"
-                "-DCMAKE_MAKE_PROGRAM=${CMAKE_MAKE_PROGRAM}"
-                "-DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}"
-                "-DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}"
-                "-Dprotobuf_BUILD_TESTS=0"
-                "-Dprotobuf_BUILD_CONFORMANCE=0"
-                "-Dprotobuf_BUILD_EXAMPLES=0"
-                "-Dprotobuf_BUILD_PROTOC_BINARIES=1"
-                "-DABSL_ROOT_DIR=${abseil_source_dir}"
-                "-DABSL_ENABLE_INSTALL=0"
-                "${protobuf_source_dir}"
-            WORKING_DIRECTORY "${PROTOC_BUILD_DIR}"
-            COMMAND_ECHO STDOUT)
-
-        execute_process(
-            COMMAND ${CMAKE_COMMAND} --build "${PROTOC_BUILD_DIR}"
-            COMMAND_ECHO STDOUT)
-    endif ()
-
-    add_executable(protoc IMPORTED GLOBAL)
-    set_target_properties (protoc PROPERTIES IMPORTED_LOCATION "${PROTOC_BUILD_DIR}/protoc")
-    add_dependencies(protoc "${PROTOC_BUILD_DIR}/protoc")
+    execute_process(
+        COMMAND ${CMAKE_COMMAND} --build "${PROTOC_BUILD_DIR}"
+        COMMAND_ECHO STDOUT)
 endif ()
+
+add_executable(protoc IMPORTED GLOBAL)
+set_target_properties (protoc PROPERTIES IMPORTED_LOCATION "${PROTOC_BUILD_DIR}/protoc")
+add_dependencies(protoc "${PROTOC_BUILD_DIR}/protoc")
 
 include("${ClickHouse_SOURCE_DIR}/contrib/google-protobuf-cmake/protobuf_generate.cmake")
 

--- a/src/Storages/MergeTree/MergeTreeIndexSet.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexSet.cpp
@@ -108,7 +108,6 @@ void MergeTreeIndexGranuleSet::deserializeBinary(ReadBuffer & istr, MergeTreeInd
         const auto & type = column.type;
         ColumnPtr new_column = type->createColumn();
 
-
         ISerialization::DeserializeBinaryBulkSettings settings;
         settings.getter = [&](ISerialization::SubstreamPath) -> ReadBuffer * { return &istr; };
         settings.position_independent_encoding = false;


### PR DESCRIPTION
### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Simplify build by always building `protoc` (a build tool) independently.


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

<details>
    <summary>Modify your CI run</summary>

**NOTE:** If your merge the PR with modified CI you **MUST KNOW** what you are doing
**NOTE:** Checked options will be applied if set before CI RunConfig/PrepareRunConfig step

#### Include tests (required builds will be added automatically):
- [ ] <!---ci_include_fast--> Fast test
- [ ] <!---ci_include_integration--> Integration Tests
- [ ] <!---ci_include_stateless--> Stateless tests
- [ ] <!---ci_include_stateful--> Stateful tests
- [ ] <!---ci_include_unit--> Unit tests
- [ ] <!---ci_include_performance--> Performance tests
- [ ] <!---ci_include_asan--> All with ASAN
- [ ] <!---ci_include_tsan--> All with TSAN
- [ ] <!---ci_include_analyzer--> All with Analyzer
- [ ] <!---ci_include_azure --> All with Azure
- [ ] <!---ci_include_KEYWORD--> Add your option here

#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [ ] <!---ci_exclude_tsan--> All with TSAN
- [ ] <!---ci_exclude_msan--> All with MSAN
- [ ] <!---ci_exclude_ubsan--> All with UBSAN
- [ ] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64--> All with Aarch64
- [ ] <!---ci_exclude_KEYWORD--> Add your option here

#### Extra options:
- [ ] <!---do_not_test--> do not test (only style check)
- [ ] <!---no_merge_commit--> disable merge-commit (no merge from master before tests)
- [ ] <!---no_ci_cache--> disable CI cache (job reuse)

#### Only specified batches in multi-batch jobs:
- [ ] <!---batch_0--> 1
- [ ] <!---batch_1--> 2
- [ ] <!---batch_2--> 3
- [ ] <!---batch_3--> 4

</details>
