### PR TITLE
tests: fix expected error for 03036_reading_s3_archives (fixes CI)

### DIFF
--- a/tests/queries/0_stateless/03036_reading_s3_archives.sql
+++ b/tests/queries/0_stateless/03036_reading_s3_archives.sql
@@ -18,5 +18,5 @@ CREATE table table_tar2star Engine S3(s3_conn, filename='03036_archive2.tar :: e
 SELECT id, data, _file, _path FROM table_tar2star ORDER BY (id, _file, _path);
 CREATE table table_tarstarglobs Engine S3(s3_conn, filename='03036_archive*.tar* :: example{2..3}.csv');
 SELECT id, data, _file, _path FROM table_tarstarglobs ORDER BY (id, _file, _path);
-CREATE table table_noexist Engine s3(s3_conn, filename='03036_archive2.zip :: nonexistent.csv'); -- { serverError INCORRECT_QUERY }
+CREATE table table_noexist Engine s3(s3_conn, filename='03036_archive2.zip :: nonexistent.csv'); -- { serverError UNKNOWN_STORAGE }
 SELECT id, data, _file, _path FROM s3(s3_conn, filename='03036_compressed_file_archive.zip :: example7.csv', format='CSV', structure='auto', compression_method='gz') ORDER BY (id, _file, _path)


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Conflicts of https://github.com/ClickHouse/ClickHouse/pull/62259 with https://github.com/ClickHouse/ClickHouse/pull/59183 (cc @alexey-milovidov )

CI: https://s3.amazonaws.com/clickhouse-test-reports/0/8e838c280569214b6fb49d3a01cb2ede5e1f15c5/stateless_tests__aarch64_.html