### PR TITLE
Update llvm/clang to 18.1.6

### DIFF
--- a/docker/test/fasttest/Dockerfile
+++ b/docker/test/fasttest/Dockerfile
@@ -1,5 +1,4 @@
-# rebuild in #33610
-#  docker build -t clickhouse/fasttest .
+# docker build -t clickhouse/fasttest .
 ARG FROM_TAG=latest
 FROM clickhouse/test-util:$FROM_TAG
 

--- a/docker/test/util/Dockerfile
+++ b/docker/test/util/Dockerfile
@@ -5,6 +5,14 @@ FROM ubuntu:22.04
 ARG apt_archive="http://archive.ubuntu.com"
 RUN sed -i "s|http://archive.ubuntu.com|$apt_archive|g" /etc/apt/sources.list
 
+# FIXME: rebuild for clang 18.1.3, that contains a workaround [1] for
+# sanitizers issue [2]:
+#
+# $ git tag --contains  c2a57034eff048cd36c563c8e0051db3a70991b3 | tail -1
+# llvmorg-18.1.3
+#
+#  [1]: https://github.com/llvm/llvm-project/commit/c2a57034eff048cd36c563c8e0051db3a70991b3
+#  [2]: https://github.com/ClickHouse/ClickHouse/issues/64086
 ENV DEBIAN_FRONTEND=noninteractive LLVM_VERSION=18
 
 RUN apt-get update \


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Update llvm/clang to 18.1.6

Note, that this was an attempt to fix https://github.com/ClickHouse/ClickHouse/issues/64086, since 18.1.3+ contains a workaround [1] for sanitizers issue [2]:

    $ git tag --contains  c2a57034eff048cd36c563c8e0051db3a70991b3 | tail -1
    llvmorg-18.1.3

 [1]: https://github.com/llvm/llvm-project/commit/c2a57034eff048cd36c563c8e0051db3a70991b3
 [2]: https://github.com/ClickHouse/ClickHouse/issues/64086

Since right now version is not enough:

    $ docker run --rm -it clickhouse/test-util llvm-nm-18 --version
    llvm-nm, compatible with GNU nm
    Ubuntu LLVM version 18.1.2
      Optimized build.

But it did not help.