### PR TITLE
Revert "Backport #63836 to 24.2: Fix `test_short_strings_aggregation` for arm"

### DIFF
--- a/tests/integration/test_backward_compatibility/test_short_strings_aggregation.py
+++ b/tests/integration/test_backward_compatibility/test_short_strings_aggregation.py
@@ -1,14 +1,13 @@
 import pytest
 
-from helpers.cluster import ClickHouseCluster, CLICKHOUSE_CI_MIN_TESTED_VERSION, is_arm
+from helpers.cluster import ClickHouseCluster, CLICKHOUSE_CI_MIN_TESTED_VERSION
 
-# For arm version see https://github.com/ClickHouse/ClickHouse/pull/59132
 cluster = ClickHouseCluster(__file__)
 node1 = cluster.add_instance(
     "node1",
     with_zookeeper=False,
     image="clickhouse/clickhouse-server",
-    tag="24.1" if is_arm() else CLICKHOUSE_CI_MIN_TESTED_VERSION,
+    tag=CLICKHOUSE_CI_MIN_TESTED_VERSION,
     stay_alive=True,
     with_installed_binary=True,
     allow_analyzer=False,
@@ -17,7 +16,7 @@ node2 = cluster.add_instance(
     "node2",
     with_zookeeper=False,
     image="clickhouse/clickhouse-server",
-    tag="24.1" if is_arm() else CLICKHOUSE_CI_MIN_TESTED_VERSION,
+    tag=CLICKHOUSE_CI_MIN_TESTED_VERSION,
     stay_alive=True,
     with_installed_binary=True,
     allow_analyzer=False,


### PR DESCRIPTION
Reverts ClickHouse/ClickHouse#63877