### PR TITLE
Create and destroy hash maps on thread pool in ConcurrentHashJoin

### DIFF
--- a/src/Common/CurrentMetrics.cpp
+++ b/src/Common/CurrentMetrics.cpp
@@ -127,6 +127,9 @@
     M(DestroyAggregatesThreads, "Number of threads in the thread pool for destroy aggregate states.") \
     M(DestroyAggregatesThreadsActive, "Number of threads in the thread pool for destroy aggregate states running a task.") \
     M(DestroyAggregatesThreadsScheduled, "Number of queued or active jobs in the thread pool for destroy aggregate states.") \
+    M(ConcurrentHashJoinPoolThreads, "Number of threads in the thread pool for concurrent hash join.") \
+    M(ConcurrentHashJoinPoolThreadsActive, "Number of threads in the thread pool for concurrent hash join running a task.") \
+    M(ConcurrentHashJoinPoolThreadsScheduled, "Number of queued or active jobs in the thread pool for concurrent hash join.") \
     M(HashedDictionaryThreads, "Number of threads in the HashedDictionary thread pool.") \
     M(HashedDictionaryThreadsActive, "Number of threads in the HashedDictionary thread pool running a task.") \
     M(HashedDictionaryThreadsScheduled, "Number of queued or active jobs in the HashedDictionary thread pool.") \

--- a/src/Interpreters/ConcurrentHashJoin.cpp
+++ b/src/Interpreters/ConcurrentHashJoin.cpp
@@ -1,5 +1,3 @@
-#include <memory>
-#include <mutex>
 #include <Columns/ColumnSparse.h>
 #include <Columns/FilterDescription.h>
 #include <Columns/IColumn.h>
@@ -19,6 +17,17 @@
 #include <Common/WeakHash.h>
 #include <Common/typeid_cast.h>
 #include <DataTypes/DataTypeLowCardinality.h>
+#include <Common/ThreadPool.h>
+
+#include <memory>
+#include <mutex>
+
+namespace CurrentMetrics
+{
+extern const Metric ConcurrentHashJoinPoolThreads;
+extern const Metric ConcurrentHashJoinPoolThreadsActive;
+extern const Metric ConcurrentHashJoinPoolThreadsScheduled;
+}
 
 namespace DB
 {
@@ -36,20 +45,84 @@ static UInt32 toPowerOfTwo(UInt32 x)
     return static_cast<UInt32>(1) << (32 - std::countl_zero(x - 1));
 }
 
-ConcurrentHashJoin::ConcurrentHashJoin(ContextPtr context_, std::shared_ptr<TableJoin> table_join_, size_t slots_, const Block & right_sample_block, bool any_take_last_row_)
+ConcurrentHashJoin::ConcurrentHashJoin(
+    ContextPtr context_, std::shared_ptr<TableJoin> table_join_, size_t slots_, const Block & right_sample_block, bool any_take_last_row_)
     : context(context_)
     , table_join(table_join_)
     , slots(toPowerOfTwo(std::min<UInt32>(static_cast<UInt32>(slots_), 256)))
+    , pool(
+          CurrentMetrics::ConcurrentHashJoinPoolThreads,
+          CurrentMetrics::ConcurrentHashJoinPoolThreadsActive,
+          CurrentMetrics::ConcurrentHashJoinPoolThreadsScheduled,
+          slots)
 {
-    for (size_t i = 0; i < slots; ++i)
-    {
-        auto inner_hash_join = std::make_shared<InternalHashJoin>();
+    hash_joins.resize(slots);
 
-        inner_hash_join->data = std::make_unique<HashJoin>(table_join_, right_sample_block, any_take_last_row_, 0, fmt::format("concurrent{}", i));
-        /// Non zero `max_joined_block_rows` allows to process block partially and return not processed part.
-        /// TODO: It's not handled properly in ConcurrentHashJoin case, so we set it to 0 to disable this feature.
-        inner_hash_join->data->setMaxJoinedBlockRows(0);
-        hash_joins.emplace_back(std::move(inner_hash_join));
+    try
+    {
+        for (size_t i = 0; i < slots; ++i)
+        {
+            pool.trySchedule(
+                [&, idx = i, thread_group = CurrentThread::getGroup()]()
+                {
+                    SCOPE_EXIT_SAFE({
+                        if (thread_group)
+                            CurrentThread::detachFromGroupIfNotDetached();
+                    });
+
+                    if (thread_group)
+                        CurrentThread::attachToGroupIfDetached(thread_group);
+
+                    setThreadName("ConcurrentJoin");
+
+                    auto inner_hash_join = std::make_shared<InternalHashJoin>();
+
+                    inner_hash_join->data = std::make_unique<HashJoin>(
+                        table_join_, right_sample_block, any_take_last_row_, 0, fmt::format("concurrent{}", idx));
+                    /// Non zero `max_joined_block_rows` allows to process block partially and return not processed part.
+                    /// TODO: It's not handled properly in ConcurrentHashJoin case, so we set it to 0 to disable this feature.
+                    inner_hash_join->data->setMaxJoinedBlockRows(0);
+                    hash_joins[idx] = std::move(inner_hash_join);
+                });
+        }
+
+        pool.wait();
+    }
+    catch (...)
+    {
+        tryLogCurrentException(__PRETTY_FUNCTION__);
+        pool.wait();
+        throw;
+    }
+}
+
+ConcurrentHashJoin::~ConcurrentHashJoin()
+{
+    try
+    {
+        for (size_t i = 0; i < slots; ++i)
+        {
+            pool.trySchedule(
+                [join = std::move(hash_joins[i]), thread_group = CurrentThread::getGroup()]()
+                {
+                    SCOPE_EXIT_SAFE({
+                        if (thread_group)
+                            CurrentThread::detachFromGroupIfNotDetached();
+                    });
+
+                    if (thread_group)
+                        CurrentThread::attachToGroupIfDetached(thread_group);
+
+                    setThreadName("ConcurrentJoin");
+                });
+        }
+
+        pool.wait();
+    }
+    catch (...)
+    {
+        tryLogCurrentException(__PRETTY_FUNCTION__);
+        pool.wait();
     }
 }
 

--- a/src/Interpreters/ConcurrentHashJoin.h
+++ b/src/Interpreters/ConcurrentHashJoin.h
@@ -39,7 +39,7 @@ public:
         const Block & right_sample_block,
         bool any_take_last_row_ = false);
 
-    ~ConcurrentHashJoin() override = default;
+    ~ConcurrentHashJoin() override;
 
     std::string getName() const override { return "ConcurrentHashJoin"; }
     const TableJoin & getTableJoin() const override { return *table_join; }
@@ -66,6 +66,7 @@ private:
     ContextPtr context;
     std::shared_ptr<TableJoin> table_join;
     size_t slots;
+    ThreadPool pool;
     std::vector<std::shared_ptr<InternalHashJoin>> hash_joins;
 
     std::mutex totals_mutex;

--- a/src/Interpreters/ConcurrentHashJoin.h
+++ b/src/Interpreters/ConcurrentHashJoin.h
@@ -10,6 +10,7 @@
 #include <base/defines.h>
 #include <base/types.h>
 #include <Common/Stopwatch.h>
+#include <Common/ThreadPool_fwd.h>
 
 namespace DB
 {
@@ -66,7 +67,7 @@ private:
     ContextPtr context;
     std::shared_ptr<TableJoin> table_join;
     size_t slots;
-    ThreadPool pool;
+    std::unique_ptr<ThreadPool> pool;
     std::vector<std::shared_ptr<InternalHashJoin>> hash_joins;
 
     std::mutex totals_mutex;


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Use a thread pool to initialize and destroy hash tables inside `ConcurrentHashJoin`.
