### PR TITLE
fix: CNF with mutually exclusive atoms reduction

### DIFF
--- a/src/Analyzer/Passes/ConvertQueryToCNFPass.cpp
+++ b/src/Analyzer/Passes/ConvertQueryToCNFPass.cpp
@@ -99,6 +99,23 @@ bool checkIfGroupAlwaysTrueGraph(const Analyzer::CNF::OrGroup & group, const Com
     return false;
 }
 
+bool checkIfGroupAlwaysTrueAtoms(const Analyzer::CNF::OrGroup & group)
+{
+    /// Filters out groups containing mutually exclusive atoms,
+    /// since these groups are always True
+
+    for (const auto & atom : group)
+    {
+        auto negated(atom);
+        negated.negative = !atom.negative;
+        if (group.contains(negated))
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
 bool checkIfAtomAlwaysFalseFullMatch(const Analyzer::CNF::AtomicFormula & atom, const ConstraintsDescription::QueryTreeData & query_tree_constraints)
 {
     const auto constraint_atom_ids = query_tree_constraints.getAtomIds(atom.node_with_hash);
@@ -644,7 +661,8 @@ void optimizeWithConstraints(Analyzer::CNF & cnf, const QueryTreeNodes & table_e
         cnf.filterAlwaysTrueGroups([&](const auto & group)
            {
                /// remove always true groups from CNF
-               return !checkIfGroupAlwaysTrueFullMatch(group, query_tree_constraints) && !checkIfGroupAlwaysTrueGraph(group, compare_graph);
+               return !checkIfGroupAlwaysTrueFullMatch(group, query_tree_constraints)
+                   && !checkIfGroupAlwaysTrueGraph(group, compare_graph) && !checkIfGroupAlwaysTrueAtoms(group);
            })
            .filterAlwaysFalseAtoms([&](const Analyzer::CNF::AtomicFormula & atom)
            {

--- a/src/Interpreters/TreeCNFConverter.h
+++ b/src/Interpreters/TreeCNFConverter.h
@@ -164,6 +164,12 @@ public:
 
 void pushNotIn(CNFQuery::AtomicFormula & atom);
 
+/// Reduces CNF groups by removing mutually exclusive atoms
+/// found across groups, in case other atoms are identical.
+/// Might require multiple passes to complete reduction.
+///
+/// Example:
+/// (x OR y) AND (x OR !y) -> x
 template <typename TAndGroup>
 TAndGroup reduceOnceCNFStatements(const TAndGroup & groups)
 {
@@ -175,10 +181,19 @@ TAndGroup reduceOnceCNFStatements(const TAndGroup & groups)
         bool inserted = false;
         for (const auto & atom : group)
         {
-            copy.erase(atom);
             using AtomType = std::decay_t<decltype(atom)>;
             AtomType negative_atom(atom);
             negative_atom.negative = !atom.negative;
+
+            // Sikpping erase-insert for mutually exclusive atoms within
+            // signle group, since it won't insert negative atom, which
+            // will break the logic of this rule
+            if (copy.contains(negative_atom))
+            {
+                continue;
+            }
+
+            copy.erase(atom);
             copy.insert(negative_atom);
 
             if (groups.contains(copy))
@@ -209,6 +224,10 @@ bool isCNFGroupSubset(const TOrGroup & left, const TOrGroup & right)
     return true;
 }
 
+/// Removes CNF groups if subset group is found in CNF.
+///
+/// Example:
+/// (x OR y) AND (x) -> x
 template <typename TAndGroup>
 TAndGroup filterCNFSubsets(const TAndGroup & groups)
 {

--- a/src/Interpreters/TreeCNFConverter.h
+++ b/src/Interpreters/TreeCNFConverter.h
@@ -186,7 +186,7 @@ TAndGroup reduceOnceCNFStatements(const TAndGroup & groups)
             negative_atom.negative = !atom.negative;
 
             // Sikpping erase-insert for mutually exclusive atoms within
-            // signle group, since it won't insert negative atom, which
+            // single group, since it won't insert negative atom, which
             // will break the logic of this rule
             if (copy.contains(negative_atom))
             {

--- a/src/Interpreters/WhereConstraintsOptimizer.cpp
+++ b/src/Interpreters/WhereConstraintsOptimizer.cpp
@@ -91,6 +91,22 @@ bool checkIfGroupAlwaysTrueGraph(const CNFQuery::OrGroup & group, const Comparis
     return false;
 }
 
+bool checkIfGroupAlwaysTrueAtoms(const CNFQuery::OrGroup & group)
+{
+    /// Filters out groups containing mutually exclusive atoms,
+    /// since these groups are always True
+
+    for (const auto & atom : group)
+    {
+        auto negated(atom);
+        negated.negative = !atom.negative;
+        if (group.contains(negated))
+        {
+            return true;
+        }
+    }
+    return false;
+}
 
 bool checkIfAtomAlwaysFalseFullMatch(const CNFQuery::AtomicFormula & atom, const ConstraintsDescription & constraints_description)
 {
@@ -158,7 +174,8 @@ void WhereConstraintsOptimizer::perform()
             .filterAlwaysTrueGroups([&compare_graph, this](const auto & group)
             {
                 /// remove always true groups from CNF
-                return !checkIfGroupAlwaysTrueFullMatch(group, metadata_snapshot->getConstraints()) && !checkIfGroupAlwaysTrueGraph(group, compare_graph);
+                return !checkIfGroupAlwaysTrueFullMatch(group, metadata_snapshot->getConstraints())
+                    && !checkIfGroupAlwaysTrueGraph(group, compare_graph) && !checkIfGroupAlwaysTrueAtoms(group);
             })
             .filterAlwaysFalseAtoms([&compare_graph, this](const auto & atom)
             {

--- a/tests/queries/0_stateless/03161_cnf_reduction.reference
+++ b/tests/queries/0_stateless/03161_cnf_reduction.reference
@@ -1,0 +1,23 @@
+-- Expected plan with analyzer:
+SELECT id
+FROM `03161_table`
+WHERE f
+SETTINGS convert_query_to_cnf = 1, optimize_using_constraints = 1, allow_experimental_analyzer = 1
+
+-- Expected result with analyzer:
+1
+
+-- Expected plan w/o analyzer:
+SELECT id
+FROM `03161_table`
+WHERE f
+SETTINGS convert_query_to_cnf = 1, optimize_using_constraints = 1, allow_experimental_analyzer = 0
+
+-- Expected result w/o analyzer:
+1
+
+-- Reproducer from the issue with analyzer
+2
+
+-- Reproducer from the issue w/o analyzer
+2

--- a/tests/queries/0_stateless/03161_cnf_reduction.sql
+++ b/tests/queries/0_stateless/03161_cnf_reduction.sql
@@ -1,0 +1,72 @@
+DROP TABLE IF EXISTS 03161_table;
+
+CREATE TABLE 03161_table (id UInt32, f UInt8) ENGINE = Memory;
+
+INSERT INTO 03161_table VALUES (0, 0), (1, 1), (2, 0);
+
+SELECT '-- Expected plan with analyzer:';
+
+EXPLAIN SYNTAX
+SELECT id
+FROM 03161_table
+WHERE f AND (NOT(f) OR f)
+SETTINGS convert_query_to_cnf = 1, optimize_using_constraints = 1, allow_experimental_analyzer = 1;
+
+SELECT '';
+
+SELECT '-- Expected result with analyzer:';
+
+SELECT id
+FROM 03161_table
+WHERE f AND (NOT(f) OR f)
+SETTINGS convert_query_to_cnf = 1, optimize_using_constraints = 1, allow_experimental_analyzer = 1;
+
+SELECT '';
+
+SELECT '-- Expected plan w/o analyzer:';
+
+EXPLAIN SYNTAX
+SELECT id
+FROM 03161_table
+WHERE f AND (NOT(f) OR f)
+SETTINGS convert_query_to_cnf = 1, optimize_using_constraints = 1, allow_experimental_analyzer = 0;
+
+SELECT '';
+
+SELECT '-- Expected result w/o analyzer:';
+
+SELECT id
+FROM 03161_table
+WHERE f AND (NOT(f) OR f)
+SETTINGS convert_query_to_cnf = 1, optimize_using_constraints = 1, allow_experimental_analyzer = 0;
+
+DROP TABLE IF EXISTS 03161_table;
+
+-- Checking reproducer from GitHub issue
+-- https://github.com/ClickHouse/ClickHouse/issues/57400
+
+DROP TABLE IF EXISTS 03161_reproducer;
+
+CREATE TABLE 03161_reproducer (c0 UInt8, c1 UInt8, c2 UInt8, c3 UInt8, c4 UInt8, c5 UInt8, c6 UInt8, c7 UInt8, c8 UInt8, c9 UInt8) ENGINE = Memory;
+
+INSERT INTO 03161_reproducer VALUES (0, 0, 0, 0, 0, 0, 0, 0, 0, 0), (0, 0, 0, 0, 0, 0, 0, 0, 0, 1), (0, 0, 0, 0, 0, 0, 0, 0, 1, 0), (0, 0, 0, 0, 0, 0, 0, 0, 1, 1), (0, 0, 0, 0, 0, 0, 0, 1, 0, 0), (0, 0, 0, 0, 0, 0, 0, 1, 0, 1), (0, 0, 0, 0, 0, 0, 0, 1, 1, 0), (0, 0, 0, 0, 0, 0, 0, 1, 1, 1);
+
+SELECT '';
+
+SELECT '-- Reproducer from the issue with analyzer';
+
+SELECT count()
+FROM 03161_reproducer
+WHERE ((NOT c2) AND c2 AND (NOT c1)) OR ((NOT c2) AND c3 AND (NOT c5)) OR ((NOT c7) AND (NOT c8)) OR (c9 AND c6 AND c8 AND (NOT c8) AND (NOT c7))
+SETTINGS convert_query_to_cnf = 1, optimize_using_constraints = 1, allow_experimental_analyzer = 1;
+
+SELECT '';
+
+SELECT '-- Reproducer from the issue w/o analyzer';
+
+SELECT count()
+FROM 03161_reproducer
+WHERE ((NOT c2) AND c2 AND (NOT c1)) OR ((NOT c2) AND c3 AND (NOT c5)) OR ((NOT c7) AND (NOT c8)) OR (c9 AND c6 AND c8 AND (NOT c8) AND (NOT c7))
+SETTINGS convert_query_to_cnf = 1, optimize_using_constraints = 1, allow_experimental_analyzer = 0;
+
+DROP TABLE IF EXISTS 03161_reproducer;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed CNF simplification, in case any OR group contains mutually exclusive atoms.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

<details>
    <summary>CI Settings</summary>

**NOTE:** If your merge the PR with modified CI you **MUST KNOW** what you are doing
**NOTE:** Checked options will be applied if set before CI RunConfig/PrepareRunConfig step

#### Run these jobs only (required builds will be added automatically):
- [ ] <!---ci_include_integration--> Integration Tests
- [ ] <!---ci_include_stateless--> Stateless tests
- [ ] <!---ci_include_stateful--> Stateful tests
- [ ] <!---ci_include_unit--> Unit tests
- [ ] <!---ci_include_performance--> Performance tests
- [ ] <!---ci_include_aarch64--> All with aarch64
- [ ] <!---ci_include_asan--> All with ASAN
- [ ] <!---ci_include_tsan--> All with TSAN
- [ ] <!---ci_include_analyzer--> All with Analyzer
- [ ] <!---ci_include_azure --> All with Azure
- [ ] <!---ci_include_KEYWORD--> Add your option here

#### Deny these jobs:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [ ] <!---ci_exclude_tsan--> All with TSAN
- [ ] <!---ci_exclude_msan--> All with MSAN
- [ ] <!---ci_exclude_ubsan--> All with UBSAN
- [ ] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64--> All with Aarch64

#### Extra options:
- [ ] <!---do_not_test--> do not test (only style check)
- [ ] <!---no_merge_commit--> disable merge-commit (no merge from master before tests)
- [ ] <!---no_ci_cache--> disable CI cache (job reuse)

#### Only specified batches in multi-batch jobs:
- [ ] <!---batch_0--> 1
- [ ] <!---batch_1--> 2
- [ ] <!---batch_2--> 3
- [ ] <!---batch_3--> 4

</details>

Closes #57400 

Currently [reduceOnceCNFStatemtns](https://github.com/ClickHouse/ClickHouse/blob/3ff1b20e05c9281a4550b181a78b6a659365d69e/src/Interpreters/TreeCNFConverter.h#L168) may produce incorrect result in case any of statements is OR group with mutually exclusive atoms (e.g. `x OR !x`). Added an additional check to prevent incorrect results + prior filtering of such groups as "always true".
