### PR TITLE
Add combining http parameters with queries, new handler for accessing tables as files 

### DIFF
--- a/src/Interpreters/executeQuery.cpp
+++ b/src/Interpreters/executeQuery.cpp
@@ -687,673 +687,6 @@ void validateAnalyzerSettings(ASTPtr ast, bool context_value)
     }
 }
 
-static std::tuple<ASTPtr, BlockIO> executeQueryImpl(
-    const char * begin,
-    const char * end,
-    ContextMutablePtr context,
-    QueryFlags flags,
-    QueryProcessingStage::Enum stage,
-    ReadBuffer * istr)
-{
-    const bool internal = flags.internal;
-
-    /// query_span is a special span, when this function exits, it's lifetime is not ended, but ends when the query finishes.
-    /// Some internal queries might call this function recursively by setting 'internal' parameter to 'true',
-    /// to make sure SpanHolders in current stack ends in correct order, we disable this span for these internal queries
-    ///
-    /// This does not have impact on the final span logs, because these internal queries are issued by external queries,
-    /// we still have enough span logs for the execution of external queries.
-    std::shared_ptr<OpenTelemetry::SpanHolder> query_span = internal ? nullptr : std::make_shared<OpenTelemetry::SpanHolder>("query");
-    if (query_span && query_span->trace_id != UUID{})
-        LOG_TRACE(getLogger("executeQuery"), "Query span trace_id for opentelemetry log: {}", query_span->trace_id);
-
-    /// Used for logging query start time in system.query_log
-    auto query_start_time = std::chrono::system_clock::now();
-
-    /// Used for:
-    /// * Setting the watch in QueryStatus (controls timeouts and progress) and the output formats
-    /// * Logging query duration (system.query_log)
-    Stopwatch start_watch{CLOCK_MONOTONIC};
-
-    const auto & client_info = context->getClientInfo();
-
-    if (!internal && client_info.initial_query_start_time == 0)
-    {
-        // If it's not an internal query and we don't see an initial_query_start_time yet, initialize it
-        // to current time. Internal queries are those executed without an independent client context,
-        // thus should not set initial_query_start_time, because it might introduce data race. It's also
-        // possible to have unset initial_query_start_time for non-internal and non-initial queries. For
-        // example, the query is from an initiator that is running an old version of clickhouse.
-        // On the other hand, if it's initialized then take it as the start of the query
-        context->setInitialQueryStartTime(query_start_time);
-    }
-
-    assert(internal || CurrentThread::get().getQueryContext());
-    assert(internal || CurrentThread::get().getQueryContext()->getCurrentQueryId() == CurrentThread::getQueryId());
-
-    const Settings & settings = context->getSettingsRef();
-
-    size_t max_query_size = settings.max_query_size;
-    /// Don't limit the size of internal queries or distributed subquery.
-    if (internal || client_info.query_kind == ClientInfo::QueryKind::SECONDARY_QUERY)
-        max_query_size = 0;
-
-    ASTPtr ast;
-    String query;
-    String query_for_logging;
-    size_t log_queries_cut_to_length = context->getSettingsRef().log_queries_cut_to_length;
-
-    /// Parse the query from string.
-    try
-    {
-        if (settings.dialect == Dialect::kusto && !internal)
-        {
-            ParserKQLStatement parser(end, settings.allow_settings_after_format_in_insert);
-            /// TODO: parser should fail early when max_query_size limit is reached.
-            ast = parseKQLQuery(parser, begin, end, "", max_query_size, settings.max_parser_depth, settings.max_parser_backtracks);
-        }
-        else if (settings.dialect == Dialect::prql && !internal)
-        {
-            ParserPRQLQuery parser(max_query_size, settings.max_parser_depth, settings.max_parser_backtracks);
-            ast = parseQuery(parser, begin, end, "", max_query_size, settings.max_parser_depth, settings.max_parser_backtracks);
-        }
-        else
-        {
-            ParserQuery parser(end, settings.allow_settings_after_format_in_insert);
-            /// TODO: parser should fail early when max_query_size limit is reached.
-            ast = parseQuery(parser, begin, end, "", max_query_size, settings.max_parser_depth, settings.max_parser_backtracks);
-
-#ifndef NDEBUG
-            /// Verify that AST formatting is consistent:
-            /// If you format AST, parse it back, and format it again, you get the same string.
-
-            String formatted1 = ast->formatWithPossiblyHidingSensitiveData(0, true, true);
-
-            /// The query can become more verbose after formatting, so:
-            size_t new_max_query_size = max_query_size > 0 ? (1000 + 2 * max_query_size) : 0;
-
-            ASTPtr ast2;
-            try
-            {
-                ast2 = parseQuery(parser,
-                    formatted1.data(),
-                    formatted1.data() + formatted1.size(),
-                    "", new_max_query_size, settings.max_parser_depth, settings.max_parser_backtracks);
-            }
-            catch (const Exception & e)
-            {
-                if (e.code() == ErrorCodes::SYNTAX_ERROR)
-                    /// Don't print the original query text because it may contain sensitive data.
-                    throw Exception(ErrorCodes::LOGICAL_ERROR,
-                        "Inconsistent AST formatting: the query:\n{}\ncannot parse.",
-                        formatted1);
-                else
-                    throw;
-            }
-
-            chassert(ast2);
-
-            String formatted2 = ast2->formatWithPossiblyHidingSensitiveData(0, true, true);
-
-            if (formatted1 != formatted2)
-                throw Exception(ErrorCodes::LOGICAL_ERROR,
-                    "Inconsistent AST formatting: the query:\n{}\nWas parsed and formatted back as:\n{}",
-                    formatted1, formatted2);
-#endif
-        }
-
-        const char * query_end = end;
-        if (const auto * insert_query = ast->as<ASTInsertQuery>(); insert_query && insert_query->data)
-            query_end = insert_query->data;
-
-        bool is_create_parameterized_view = false;
-        if (const auto * create_query = ast->as<ASTCreateQuery>())
-        {
-            is_create_parameterized_view = create_query->isParameterizedView();
-        }
-        else if (const auto * explain_query = ast->as<ASTExplainQuery>())
-        {
-            if (!explain_query->children.empty())
-                if (const auto * create_of_explain_query = explain_query->children[0]->as<ASTCreateQuery>())
-                    is_create_parameterized_view = create_of_explain_query->isParameterizedView();
-        }
-
-        /// Replace ASTQueryParameter with ASTLiteral for prepared statements.
-        /// Even if we don't have parameters in query_context, check that AST doesn't have unknown parameters
-        bool probably_has_params = find_first_symbols<'{'>(begin, end) != end;
-        if (!is_create_parameterized_view && probably_has_params)
-        {
-            ReplaceQueryParameterVisitor visitor(context->getQueryParameters());
-            visitor.visit(ast);
-            if (visitor.getNumberOfReplacedParameters())
-                query = serializeAST(*ast);
-            else
-                query.assign(begin, query_end);
-        }
-        else
-        {
-            /// Copy query into string. It will be written to log and presented in processlist. If an INSERT query, string will not include data to insertion.
-            query.assign(begin, query_end);
-        }
-
-        /// Wipe any sensitive information (e.g. passwords) from the query.
-        /// MUST go before any modification (except for prepared statements,
-        /// since it substitute parameters and without them query does not contain
-        /// parameters), to keep query as-is in query_log and server log.
-        if (ast->hasSecretParts())
-        {
-            /// IAST::formatForLogging() wipes secret parts in AST and then calls wipeSensitiveDataAndCutToLength().
-            query_for_logging = ast->formatForLogging(log_queries_cut_to_length);
-        }
-        else
-        {
-            query_for_logging = wipeSensitiveDataAndCutToLength(query, log_queries_cut_to_length);
-        }
-    }
-    catch (...)
-    {
-        /// Anyway log the query.
-        if (query.empty())
-            query.assign(begin, std::min(end - begin, static_cast<ptrdiff_t>(max_query_size)));
-
-        query_for_logging = wipeSensitiveDataAndCutToLength(query, log_queries_cut_to_length);
-        logQuery(query_for_logging, context, internal, stage);
-
-        if (!internal)
-            logExceptionBeforeStart(query_for_logging, context, ast, query_span, start_watch.elapsedMilliseconds());
-        throw;
-    }
-
-    /// Avoid early destruction of process_list_entry if it was not saved to `res` yet (in case of exception)
-    ProcessList::EntryPtr process_list_entry;
-    BlockIO res;
-    auto implicit_txn_control = std::make_shared<bool>(false);
-    String query_database;
-    String query_table;
-
-    auto execute_implicit_tcl_query = [implicit_txn_control](const ContextMutablePtr & query_context, ASTTransactionControl::QueryType tcl_type)
-    {
-        /// Unset the flag on COMMIT and ROLLBACK
-        SCOPE_EXIT({ if (tcl_type != ASTTransactionControl::BEGIN) *implicit_txn_control = false; });
-
-        ASTPtr tcl_ast = std::make_shared<ASTTransactionControl>(tcl_type);
-        InterpreterTransactionControlQuery tc(tcl_ast, query_context);
-        tc.execute();
-
-        /// Set the flag after successful BIGIN
-        if (tcl_type == ASTTransactionControl::BEGIN)
-            *implicit_txn_control = true;
-    };
-
-    try
-    {
-        if (auto txn = context->getCurrentTransaction())
-        {
-            chassert(txn->getState() != MergeTreeTransaction::COMMITTING);
-            chassert(txn->getState() != MergeTreeTransaction::COMMITTED);
-            if (txn->getState() == MergeTreeTransaction::ROLLED_BACK && !ast->as<ASTTransactionControl>() && !ast->as<ASTExplainQuery>())
-                throw Exception(
-                    ErrorCodes::INVALID_TRANSACTION,
-                    "Cannot execute query because current transaction failed. Expecting ROLLBACK statement");
-        }
-
-        /// Interpret SETTINGS clauses as early as possible (before invoking the corresponding interpreter),
-        /// to allow settings to take effect.
-        InterpreterSetQuery::applySettingsFromQuery(ast, context);
-        validateAnalyzerSettings(ast, context->getSettingsRef().allow_experimental_analyzer);
-
-        if (auto * insert_query = ast->as<ASTInsertQuery>())
-            insert_query->tail = istr;
-
-        /// There is an option of probabilistic logging of queries.
-        /// If it is used - do the random sampling and "collapse" the settings.
-        /// It allows to consistently log queries with all the subqueries in distributed query processing
-        /// (subqueries on remote nodes will receive these "collapsed" settings)
-        if (!internal && settings.log_queries && settings.log_queries_probability < 1.0)
-        {
-            std::bernoulli_distribution should_write_log{settings.log_queries_probability};
-
-            context->setSetting("log_queries", should_write_log(thread_local_rng));
-            context->setSetting("log_queries_probability", 1.0);
-        }
-
-        if (const auto * query_with_table_output = dynamic_cast<const ASTQueryWithTableAndOutput *>(ast.get()))
-        {
-            query_database = query_with_table_output->getDatabase();
-            query_table = query_with_table_output->getTable();
-        }
-
-        logQuery(query_for_logging, context, internal, stage);
-
-        /// Propagate WITH statement to children ASTSelect.
-        if (settings.enable_global_with_statement)
-        {
-            ApplyWithGlobalVisitor::visit(ast);
-        }
-
-        {
-            SelectIntersectExceptQueryVisitor::Data data{settings.intersect_default_mode, settings.except_default_mode};
-            SelectIntersectExceptQueryVisitor{data}.visit(ast);
-        }
-
-        {
-            /// Normalize SelectWithUnionQuery
-            NormalizeSelectWithUnionQueryVisitor::Data data{settings.union_default_mode};
-            NormalizeSelectWithUnionQueryVisitor{data}.visit(ast);
-        }
-
-        /// Check the limits.
-        checkASTSizeLimits(*ast, settings);
-
-        /// Put query to process list. But don't put SHOW PROCESSLIST query itself.
-        if (!internal && !ast->as<ASTShowProcesslistQuery>())
-        {
-            /// processlist also has query masked now, to avoid secrets leaks though SHOW PROCESSLIST by other users.
-            process_list_entry = context->getProcessList().insert(query_for_logging, ast.get(), context, start_watch.getStart());
-            context->setProcessListElement(process_list_entry->getQueryStatus());
-        }
-
-        /// Load external tables if they were provided
-        context->initializeExternalTablesIfSet();
-
-        auto * insert_query = ast->as<ASTInsertQuery>();
-        bool async_insert_enabled = settings.async_insert;
-
-        /// Resolve database before trying to use async insert feature - to properly hash the query.
-        if (insert_query)
-        {
-            if (insert_query->table_id)
-                insert_query->table_id = context->resolveStorageID(insert_query->table_id);
-            else if (auto table = insert_query->getTable(); !table.empty())
-                insert_query->table_id = context->resolveStorageID(StorageID{insert_query->getDatabase(), table});
-
-            if (insert_query->table_id)
-                if (auto table = DatabaseCatalog::instance().tryGetTable(insert_query->table_id, context))
-                    async_insert_enabled |= table->areAsynchronousInsertsEnabled();
-        }
-
-        if (insert_query && insert_query->select)
-        {
-            /// Prepare Input storage before executing interpreter if we already got a buffer with data.
-            if (istr)
-            {
-                ASTPtr input_function;
-                insert_query->tryFindInputFunction(input_function);
-                if (input_function)
-                {
-                    StoragePtr storage = context->executeTableFunction(input_function, insert_query->select->as<ASTSelectQuery>());
-                    auto & input_storage = dynamic_cast<StorageInput &>(*storage);
-                    auto input_metadata_snapshot = input_storage.getInMemoryMetadataPtr();
-                    auto pipe = getSourceFromASTInsertQuery(
-                        ast, true, input_metadata_snapshot->getSampleBlock(), context, input_function);
-                    input_storage.setPipe(std::move(pipe));
-                }
-            }
-        }
-        else
-        {
-            /// reset Input callbacks if query is not INSERT SELECT
-            context->resetInputCallbacks();
-        }
-
-        StreamLocalLimits limits;
-        std::shared_ptr<const EnabledQuota> quota;
-        std::unique_ptr<IInterpreter> interpreter;
-
-        bool async_insert = false;
-        auto * queue = context->tryGetAsynchronousInsertQueue();
-        auto logger = getLogger("executeQuery");
-
-        if (insert_query && async_insert_enabled)
-        {
-            String reason;
-
-            if (!queue)
-                reason = "asynchronous insert queue is not configured";
-            else if (insert_query->select)
-                reason = "insert query has select";
-            else if (insert_query->hasInlinedData())
-                async_insert = true;
-
-            if (!reason.empty())
-                LOG_DEBUG(logger, "Setting async_insert=1, but INSERT query will be executed synchronously (reason: {})", reason);
-        }
-
-        bool quota_checked = false;
-        std::unique_ptr<ReadBuffer> insert_data_buffer_holder;
-
-        if (async_insert)
-        {
-            if (context->getCurrentTransaction() && settings.throw_on_unsupported_query_inside_transaction)
-                throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Async inserts inside transactions are not supported");
-            if (settings.implicit_transaction && settings.throw_on_unsupported_query_inside_transaction)
-                throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Async inserts with 'implicit_transaction' are not supported");
-
-            /// Let's agree on terminology and say that a mini-INSERT is an asynchronous INSERT
-            /// which typically contains not a lot of data inside and a big-INSERT in an INSERT
-            /// which was formed by concatenating several mini-INSERTs together.
-            /// In case when the client had to retry some mini-INSERTs then they will be properly deduplicated
-            /// by the source tables. This functionality is controlled by a setting `async_insert_deduplicate`.
-            /// But then they will be glued together into a block and pushed through a chain of Materialized Views if any.
-            /// The process of forming such blocks is not deteministic so each time we retry mini-INSERTs the resulting
-            /// block may be concatenated differently.
-            /// That's why deduplication in dependent Materialized Views doesn't make sense in presence of async INSERTs.
-            if (settings.throw_if_deduplication_in_dependent_materialized_views_enabled_with_async_insert &&
-                settings.deduplicate_blocks_in_dependent_materialized_views)
-                throw Exception(ErrorCodes::SUPPORT_IS_DISABLED,
-                        "Deduplication is dependent materialized view cannot work together with async inserts. "\
-                        "Please disable eiher `deduplicate_blocks_in_dependent_materialized_views` or `async_insert` setting.");
-
-            quota = context->getQuota();
-            if (quota)
-            {
-                quota_checked = true;
-                quota->used(QuotaType::QUERY_INSERTS, 1);
-                quota->used(QuotaType::QUERIES, 1);
-                quota->checkExceeded(QuotaType::ERRORS);
-            }
-
-            auto result = queue->pushQueryWithInlinedData(ast, context);
-
-            if (result.status == AsynchronousInsertQueue::PushResult::OK)
-            {
-                if (settings.wait_for_async_insert)
-                {
-                    auto timeout = settings.wait_for_async_insert_timeout.totalMilliseconds();
-                    auto source = std::make_shared<WaitForAsyncInsertSource>(std::move(result.future), timeout);
-                    res.pipeline = QueryPipeline(Pipe(std::move(source)));
-                }
-
-                const auto & table_id = insert_query->table_id;
-                if (!table_id.empty())
-                    context->setInsertionTable(table_id);
-            }
-            else if (result.status == AsynchronousInsertQueue::PushResult::TOO_MUCH_DATA)
-            {
-                async_insert = false;
-                insert_data_buffer_holder = std::move(result.insert_data_buffer);
-
-                if (insert_query->data)
-                {
-                    /// Reset inlined data because it will be
-                    /// available from tail read buffer.
-                    insert_query->end = insert_query->data;
-                    insert_query->data = nullptr;
-                }
-
-                insert_query->tail = insert_data_buffer_holder.get();
-                LOG_DEBUG(logger, "Setting async_insert=1, but INSERT query will be executed synchronously because it has too much data");
-            }
-        }
-
-        QueryCachePtr query_cache = context->getQueryCache();
-        const bool can_use_query_cache = query_cache != nullptr
-            && settings.use_query_cache
-            && !internal
-            && client_info.query_kind == ClientInfo::QueryKind::INITIAL_QUERY
-            && (ast->as<ASTSelectQuery>() || ast->as<ASTSelectWithUnionQuery>());
-        QueryCache::Usage query_cache_usage = QueryCache::Usage::None;
-
-        if (!async_insert)
-        {
-            /// If it is a non-internal SELECT, and passive (read) use of the query cache is enabled, and the cache knows the query, then set
-            /// a pipeline with a source populated by the query cache.
-            auto get_result_from_query_cache = [&]()
-            {
-                if (can_use_query_cache && settings.enable_reads_from_query_cache)
-                {
-                    QueryCache::Key key(ast, context->getUserID(), context->getCurrentRoles());
-                    QueryCache::Reader reader = query_cache->createReader(key);
-                    if (reader.hasCacheEntryForKey())
-                    {
-                        QueryPipeline pipeline;
-                        pipeline.readFromQueryCache(reader.getSource(), reader.getSourceTotals(), reader.getSourceExtremes());
-                        res.pipeline = std::move(pipeline);
-                        query_cache_usage = QueryCache::Usage::Read;
-                        return true;
-                    }
-                }
-                return false;
-            };
-
-            if (!get_result_from_query_cache())
-            {
-                /// We need to start the (implicit) transaction before getting the interpreter as this will get links to the latest snapshots
-                if (!context->getCurrentTransaction() && settings.implicit_transaction && !ast->as<ASTTransactionControl>())
-                {
-                    try
-                    {
-                        if (context->isGlobalContext())
-                            throw Exception(ErrorCodes::LOGICAL_ERROR, "Global context cannot create transactions");
-
-                        execute_implicit_tcl_query(context, ASTTransactionControl::BEGIN);
-                    }
-                    catch (Exception & e)
-                    {
-                        e.addMessage("while starting a transaction with 'implicit_transaction'");
-                        throw;
-                    }
-                }
-
-                interpreter = InterpreterFactory::instance().get(ast, context, SelectQueryOptions(stage).setInternal(internal));
-
-                const auto & query_settings = context->getSettingsRef();
-                if (context->getCurrentTransaction() && query_settings.throw_on_unsupported_query_inside_transaction)
-                {
-                    if (!interpreter->supportsTransactions())
-                        throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Transactions are not supported for this type of query ({})", ast->getID());
-
-                }
-
-                // InterpreterSelectQueryAnalyzer does not build QueryPlan in the constructor.
-                // We need to force to build it here to check if we need to ignore quota.
-                if (auto * interpreter_with_analyzer = dynamic_cast<InterpreterSelectQueryAnalyzer *>(interpreter.get()))
-                    interpreter_with_analyzer->getQueryPlan();
-
-                if (!interpreter->ignoreQuota() && !quota_checked)
-                {
-                    quota = context->getQuota();
-                    if (quota)
-                    {
-                        if (ast->as<ASTSelectQuery>() || ast->as<ASTSelectWithUnionQuery>())
-                        {
-                            quota->used(QuotaType::QUERY_SELECTS, 1);
-                        }
-                        else if (ast->as<ASTInsertQuery>())
-                        {
-                            quota->used(QuotaType::QUERY_INSERTS, 1);
-                        }
-                        quota->used(QuotaType::QUERIES, 1);
-                        quota->checkExceeded(QuotaType::ERRORS);
-                    }
-                }
-
-                if (!interpreter->ignoreLimits())
-                {
-                    limits.mode = LimitsMode::LIMITS_CURRENT;
-                    limits.size_limits = SizeLimits(settings.max_result_rows, settings.max_result_bytes, settings.result_overflow_mode);
-                }
-
-                if (auto * insert_interpreter = typeid_cast<InterpreterInsertQuery *>(&*interpreter))
-                {
-                    /// Save insertion table (not table function). TODO: support remote() table function.
-                    auto table_id = insert_interpreter->getDatabaseTable();
-                    if (!table_id.empty())
-                        context->setInsertionTable(std::move(table_id), insert_interpreter->getInsertColumnNames());
-
-                    if (insert_data_buffer_holder)
-                        insert_interpreter->addBuffer(std::move(insert_data_buffer_holder));
-                }
-
-                if (auto * create_interpreter = typeid_cast<InterpreterCreateQuery *>(&*interpreter))
-                    create_interpreter->setIsRestoreFromBackup(flags.distributed_backup_restore);
-
-                {
-                    std::unique_ptr<OpenTelemetry::SpanHolder> span;
-                    if (OpenTelemetry::CurrentContext().isTraceEnabled())
-                    {
-                        auto * raw_interpreter_ptr = interpreter.get();
-                        String class_name(demangle(typeid(*raw_interpreter_ptr).name()));
-                        span = std::make_unique<OpenTelemetry::SpanHolder>(class_name + "::execute()");
-                    }
-
-                    res = interpreter->execute();
-
-                    /// If it is a non-internal SELECT query, and active (write) use of the query cache is enabled, then add a processor on
-                    /// top of the pipeline which stores the result in the query cache.
-                    if (can_use_query_cache && settings.enable_writes_to_query_cache)
-                    {
-                        /// Only use the query cache if the query does not contain non-deterministic functions or system tables (which are typically non-deterministic)
-
-                        const bool ast_contains_nondeterministic_functions = astContainsNonDeterministicFunctions(ast, context);
-                        const bool ast_contains_system_tables = astContainsSystemTables(ast, context);
-
-                        const QueryCacheNondeterministicFunctionHandling nondeterministic_function_handling = settings.query_cache_nondeterministic_function_handling;
-                        const QueryCacheSystemTableHandling system_table_handling = settings.query_cache_system_table_handling;
-
-                        if (ast_contains_nondeterministic_functions && nondeterministic_function_handling == QueryCacheNondeterministicFunctionHandling::Throw)
-                            throw Exception(ErrorCodes::QUERY_CACHE_USED_WITH_NONDETERMINISTIC_FUNCTIONS,
-                                "The query result was not cached because the query contains a non-deterministic function."
-                                " Use setting `query_cache_nondeterministic_function_handling = 'save'` or `= 'ignore'` to cache the query result regardless or to omit caching");
-
-                        if (ast_contains_system_tables && system_table_handling == QueryCacheSystemTableHandling::Throw)
-                            throw Exception(ErrorCodes::QUERY_CACHE_USED_WITH_SYSTEM_TABLE,
-                                "The query result was not cached because the query contains a system table."
-                                " Use setting `query_cache_system_table_handling = 'save'` or `= 'ignore'` to cache the query result regardless or to omit caching");
-
-                        if ((!ast_contains_nondeterministic_functions || nondeterministic_function_handling == QueryCacheNondeterministicFunctionHandling::Save)
-                            && (!ast_contains_system_tables || system_table_handling == QueryCacheSystemTableHandling::Save))
-                        {
-                            QueryCache::Key key(
-                                ast, res.pipeline.getHeader(),
-                                context->getUserID(), context->getCurrentRoles(),
-                                settings.query_cache_share_between_users,
-                                std::chrono::system_clock::now() + std::chrono::seconds(settings.query_cache_ttl),
-                                settings.query_cache_compress_entries);
-
-                            const size_t num_query_runs = settings.query_cache_min_query_runs ? query_cache->recordQueryRun(key) : 1; /// try to avoid locking a mutex in recordQueryRun()
-                            if (num_query_runs <= settings.query_cache_min_query_runs)
-                            {
-                                LOG_TRACE(getLogger("QueryCache"),
-                                        "Skipped insert because the query ran {} times but the minimum required number of query runs to cache the query result is {}",
-                                        num_query_runs, settings.query_cache_min_query_runs);
-                            }
-                            else
-                            {
-                                auto query_cache_writer = std::make_shared<QueryCache::Writer>(query_cache->createWriter(
-                                                 key,
-                                                 std::chrono::milliseconds(settings.query_cache_min_query_duration.totalMilliseconds()),
-                                                 settings.query_cache_squash_partial_results,
-                                                 settings.max_block_size,
-                                                 settings.query_cache_max_size_in_bytes,
-                                                 settings.query_cache_max_entries));
-                                res.pipeline.writeResultIntoQueryCache(query_cache_writer);
-                                query_cache_usage = QueryCache::Usage::Write;
-                            }
-                        }
-                    }
-
-                }
-            }
-        }
-
-        if (process_list_entry)
-        {
-            /// Query was killed before execution
-            if (process_list_entry->getQueryStatus()->isKilled())
-                throw Exception(ErrorCodes::QUERY_WAS_CANCELLED,
-                    "Query '{}' is killed in pending state", process_list_entry->getQueryStatus()->getInfo().client_info.current_query_id);
-        }
-
-        /// Hold element of process list till end of query execution.
-        res.process_list_entry = process_list_entry;
-
-        auto & pipeline = res.pipeline;
-
-        if (pipeline.pulling() || pipeline.completed())
-        {
-            /// Limits on the result, the quota on the result, and also callback for progress.
-            /// Limits apply only to the final result.
-            pipeline.setProgressCallback(context->getProgressCallback());
-            pipeline.setProcessListElement(context->getProcessListElement());
-            if (stage == QueryProcessingStage::Complete && pipeline.pulling())
-                pipeline.setLimitsAndQuota(limits, quota);
-        }
-        else if (pipeline.pushing())
-        {
-            pipeline.setProcessListElement(context->getProcessListElement());
-        }
-
-        /// Everything related to query log.
-        {
-            QueryLogElement elem = logQueryStart(
-                query_start_time,
-                context,
-                query_for_logging,
-                ast,
-                pipeline,
-                interpreter,
-                internal,
-                query_database,
-                query_table,
-                async_insert);
-            /// Also make possible for caller to log successful query finish and exception during execution.
-            auto finish_callback = [elem,
-                                    context,
-                                    ast,
-                                    query_cache_usage,
-                                    internal,
-                                    implicit_txn_control,
-                                    execute_implicit_tcl_query,
-                                    pulling_pipeline = pipeline.pulling(),
-                                    query_span](QueryPipeline & query_pipeline) mutable
-            {
-                if (query_cache_usage == QueryCache::Usage::Write)
-                    /// Trigger the actual write of the buffered query result into the query cache. This is done explicitly to prevent
-                    /// partial/garbage results in case of exceptions during query execution.
-                    query_pipeline.finalizeWriteInQueryCache();
-
-                logQueryFinish(elem, context, ast, query_pipeline, pulling_pipeline, query_span, query_cache_usage, internal);
-
-                if (*implicit_txn_control)
-                    execute_implicit_tcl_query(context, ASTTransactionControl::COMMIT);
-            };
-
-            auto exception_callback =
-                [start_watch, elem, context, ast, internal, my_quota(quota), implicit_txn_control, execute_implicit_tcl_query, query_span](
-                    bool log_error) mutable
-            {
-                if (*implicit_txn_control)
-                    execute_implicit_tcl_query(context, ASTTransactionControl::ROLLBACK);
-                else if (auto txn = context->getCurrentTransaction())
-                    txn->onException();
-
-                if (my_quota)
-                    my_quota->used(QuotaType::ERRORS, 1, /* check_exceeded = */ false);
-
-                logQueryException(elem, context, start_watch, ast, query_span, internal, log_error);
-            };
-
-            res.finish_callback = std::move(finish_callback);
-            res.exception_callback = std::move(exception_callback);
-        }
-    }
-    catch (...)
-    {
-        if (*implicit_txn_control)
-            execute_implicit_tcl_query(context, ASTTransactionControl::ROLLBACK);
-        else if (auto txn = context->getCurrentTransaction())
-            txn->onException();
-
-        if (!internal)
-            logExceptionBeforeStart(query_for_logging, context, ast, query_span, start_watch.elapsedMilliseconds());
-
-        throw;
-    }
-
-    return std::make_tuple(std::move(ast), std::move(res));
-}
-
 static BlockIO
 executeQueryImpl(QueryData & query_data, ContextMutablePtr context, QueryFlags flags, QueryProcessingStage::Enum stage)
 {
@@ -1371,10 +704,6 @@ executeQueryImpl(QueryData & query_data, ContextMutablePtr context, QueryFlags f
     std::shared_ptr<OpenTelemetry::SpanHolder> query_span = internal ? nullptr : std::make_shared<OpenTelemetry::SpanHolder>("query");
     if (query_span && query_span->trace_id != UUID{})
         LOG_TRACE(getLogger("executeQuery"), "Query span trace_id for opentelemetry log: {}", query_span->trace_id);
-
-    WriteBufferFromOwnString query_buffer;
-    formatAST(*ast, query_buffer, false);
-    std::string query_str = query_buffer.str();
 
     /// Used for logging query start time in system.query_log
     auto query_start_time = std::chrono::system_clock::now();
@@ -1669,7 +998,6 @@ executeQueryImpl(QueryData & query_data, ContextMutablePtr context, QueryFlags f
                         throw;
                     }
                 }
-
                 interpreter = InterpreterFactory::instance().get(ast, context, SelectQueryOptions(stage).setInternal(internal));
 
                 const auto & query_settings = context->getSettingsRef();
@@ -1925,204 +1253,13 @@ size_t getMaxQuerySize(ContextMutablePtr context, QueryFlags flags)
     return context->getSettingsRef().max_query_size;
 }
 
-QueryData getQueryData(
-    const char * begin,
-    const char * end,
-    ReadBuffer & istr,
-    ContextMutablePtr context,
-    QueryFlags flags,
-    const QueryProcessingStage::Enum stage
-)
-{
-    const auto & settings = context->getSettingsRef();
-
-    const auto internal = flags.internal;
-    const auto log_queries_cut_to_length = settings.log_queries_cut_to_length;
-
-    const auto max_query_size = getMaxQuerySize(context, flags);
-
-    /// Used for logging query start time in system.query_log
-    auto query_start_time = std::chrono::system_clock::now();
-
-    /// Used for:
-    /// * Setting the watch in QueryStatus (controls timeouts and progress) and the output formats
-    /// * Logging query duration (system.query_log)
-    Stopwatch start_watch{CLOCK_MONOTONIC};
-
-    const auto & client_info = context->getClientInfo();
-
-    /// query_span is a special span, when this function exits, it's lifetime is not ended, but ends when the query finishes.
-    /// Some internal queries might call this function recursively by setting 'internal' parameter to 'true',
-    /// to make sure SpanHolders in current stack ends in correct order, we disable this span for these internal queries
-    ///
-    /// This does not have impact on the final span logs, because these internal queries are issued by external queries,
-    /// we still have enough span logs for the execution of external queries.
-    std::shared_ptr<OpenTelemetry::SpanHolder> query_span = internal ? nullptr : std::make_shared<OpenTelemetry::SpanHolder>("query");
-    if (query_span && query_span->trace_id != UUID{})
-        LOG_TRACE(getLogger("executeQuery"), "Query span trace_id for opentelemetry log: {}", query_span->trace_id);
-
-    if (!internal && client_info.initial_query_start_time == 0)
-    {
-        // If it's not an internal query and we don't see an initial_query_start_time yet, initialize it
-        // to current time. Internal queries are those executed without an independent client context,
-        // thus should not set initial_query_start_time, because it might introduce data race. It's also
-        // possible to have unset initial_query_start_time for non-internal and non-initial queries. For
-        // example, the query is from an initiator that is running an old version of clickhouse.
-        // On the other hand, if it's initialized then take it as the start of the query
-        context->setInitialQueryStartTime(query_start_time);
-    }
-
-    assert(internal || CurrentThread::get().getQueryContext());
-    assert(internal || CurrentThread::get().getQueryContext()->getCurrentQueryId() == CurrentThread::getQueryId());
-
-    ASTPtr ast;
-    String query;
-    String query_for_logging;
-
-    try
-    {
-        /// Parse the query from string.
-        if (settings.dialect == Dialect::kusto && !internal)
-        {
-            ParserKQLStatement parser(end, settings.allow_settings_after_format_in_insert);
-            /// TODO: parser should fail early when max_query_size limit is reached.
-            ast = parseKQLQuery(parser, begin, end, "", max_query_size, settings.max_parser_depth, settings.max_parser_backtracks);
-        }
-        else if (settings.dialect == Dialect::prql && !internal)
-        {
-            ParserPRQLQuery parser(max_query_size, settings.max_parser_depth, settings.max_parser_backtracks);
-            ast = parseQuery(parser, begin, end, "", max_query_size, settings.max_parser_depth, settings.max_parser_backtracks);
-        }
-        else
-        {
-            ParserQuery parser(end, settings.allow_settings_after_format_in_insert);
-            /// TODO: parser should fail early when max_query_size limit is reached.
-            ast = parseQuery(parser, begin, end, "", max_query_size, settings.max_parser_depth, settings.max_parser_backtracks);
-
-#ifndef NDEBUG
-            /// Verify that AST formatting is consistent:
-            /// If you format AST, parse it back, and format it again, you get the same string.
-
-            String formatted1 = ast->formatWithPossiblyHidingSensitiveData(0, true, true);
-
-            /// The query can become more verbose after formatting, so:
-            size_t new_max_query_size = max_query_size > 0 ? (1000 + 2 * max_query_size) : 0;
-
-            ASTPtr ast2;
-            try
-            {
-                ast2 = parseQuery(
-                    parser,
-                    formatted1.data(),
-                    formatted1.data() + formatted1.size(),
-                    "",
-                    new_max_query_size,
-                    settings.max_parser_depth,
-                    settings.max_parser_backtracks);
-            }
-            catch (const Exception & e)
-            {
-                if (e.code() == ErrorCodes::SYNTAX_ERROR)
-                    /// Don't print the original query text because it may contain sensitive data.
-                    throw Exception(ErrorCodes::LOGICAL_ERROR, "Inconsistent AST formatting: the query:\n{}\ncannot parse.", formatted1);
-                else
-                    throw;
-            }
-
-            chassert(ast2);
-
-            String formatted2 = ast2->formatWithPossiblyHidingSensitiveData(0, true, true);
-
-            if (formatted1 != formatted2)
-                throw Exception(
-                    ErrorCodes::LOGICAL_ERROR,
-                    "Inconsistent AST formatting: the query:\n{}\nWas parsed and formatted back as:\n{}",
-                    formatted1,
-                    formatted2);
-#endif
-        }
-
-        const char * query_end = end;
-        if (const auto * insert_query = ast->as<ASTInsertQuery>(); insert_query && insert_query->data)
-            query_end = insert_query->data;
-
-        bool is_create_parameterized_view = false;
-        if (const auto * create_query = ast->as<ASTCreateQuery>())
-            is_create_parameterized_view = create_query->isParameterizedView();
-        else if (const auto * explain_query = ast->as<ASTExplainQuery>())
-        {
-            assert(!explain_query->children.empty());
-            if (const auto * create_of_explain_query = explain_query->children[0]->as<ASTCreateQuery>())
-                is_create_parameterized_view = create_of_explain_query->isParameterizedView();
-        }
-
-        /// Replace ASTQueryParameter with ASTLiteral for prepared statements.
-        /// Even if we don't have parameters in query_context, check that AST doesn't have unknown parameters
-        bool probably_has_params = find_first_symbols<'{'>(begin, end) != end;
-        if (!is_create_parameterized_view && probably_has_params)
-        {
-            ReplaceQueryParameterVisitor visitor(context->getQueryParameters());
-            visitor.visit(ast);
-            if (visitor.getNumberOfReplacedParameters())
-                query = serializeAST(*ast);
-            else
-                query.assign(begin, query_end);
-        }
-        else
-        {
-            /// Copy query into string. It will be written to log and presented in processlist. If an INSERT query, string will not include data to insertion.
-            query.assign(begin, query_end);
-        }
-
-        /// Wipe any sensitive information (e.g. passwords) from the query.
-        /// MUST go before any modification (except for prepared statements,
-        /// since it substitute parameters and without them query does not contain
-        /// parameters), to keep query as-is in query_log and server log.
-        if (ast->hasSecretParts())
-        {
-            /// IAST::formatForLogging() wipes secret parts in AST and then calls wipeSensitiveDataAndCutToLength().
-            query_for_logging = ast->formatForLogging(log_queries_cut_to_length);
-        }
-        else
-        {
-            query_for_logging = wipeSensitiveDataAndCutToLength(query, log_queries_cut_to_length);
-        }
-
-        if (auto * insert_query = ast->as<ASTInsertQuery>())
-            insert_query->tail = &istr;
-    }
-    catch (...)
-    {
-        /// Anyway log the query.
-        query = String(begin, std::min(end - begin, static_cast<ptrdiff_t>(getMaxQuerySize(context, flags))));
-
-        query_for_logging = wipeSensitiveDataAndCutToLength(query, context->getSettingsRef().log_queries_cut_to_length);
-        logQuery(query_for_logging, context, internal, stage);
-
-        if (!internal)
-            logExceptionBeforeStart(query_for_logging, context, nullptr, query_span, start_watch.elapsedMilliseconds());
-        throw;
-    }
-
-    return QueryData{.ast = ast, .istr = nullptr, .query = query, .query_for_logging = query_for_logging};
-}
-
 QueryData getQueryData(ReadBuffer & istr, ContextMutablePtr context, QueryFlags flags, const QueryProcessingStage::Enum stage)
 {
-    PODArray<char> parse_buf;
+    auto parse_buf = std::make_unique<PODArray<char>>();
     const char * begin;
     const char * end;
 
-    try
-    {
-        istr.nextIfAtEnd();
-    }
-    catch (...)
-    {
-        /// If buffer contains invalid data and we failed to decompress, we still want to have some information about the query in the log.
-        logQuery("<cannot parse>", context, /* internal = */ false, QueryProcessingStage::Complete);
-        throw;
-    }
+    istr.nextIfAtEnd();
 
     const auto max_query_size = getMaxQuerySize(context, flags);
 
@@ -2138,13 +1275,13 @@ QueryData getQueryData(ReadBuffer & istr, ContextMutablePtr context, QueryFlags 
         /// FIXME: this is an extra copy not required for async insertion.
 
         /// If not - copy enough data into 'parse_buf'.
-        WriteBufferFromVector<PODArray<char>> out(parse_buf);
+        WriteBufferFromVector<PODArray<char>> out(*parse_buf);
         LimitReadBuffer limit(istr, max_query_size + 1, /* trow_exception */ false, /* exact_limit */ {});
         copyData(limit, out);
         out.finalize();
 
-        begin = parse_buf.data();
-        end = begin + parse_buf.size();
+        begin = parse_buf->data();
+        end = begin + parse_buf->size();
     }
 
     const auto & settings = context->getSettingsRef();
@@ -2315,7 +1452,30 @@ QueryData getQueryData(ReadBuffer & istr, ContextMutablePtr context, QueryFlags 
         throw;
     }
 
-    return QueryData{.ast = ast, .istr = nullptr, .query = query, .query_for_logging = query_for_logging};
+    return QueryData{
+        .ast = ast,
+        .istr = wrapReadBufferReference(istr),
+        .parse_buf = std::move(parse_buf),
+        .query = query,
+        .query_for_logging = query_for_logging};
+}
+
+std::pair<ASTPtr, BlockIO> executeQuery(const String & query, ContextMutablePtr context, QueryFlags flags, QueryProcessingStage::Enum stage)
+{
+    auto istr = std::make_unique<ReadBufferFromString>(query);
+    auto query_data = getQueryData(*istr, context, flags, stage);
+
+    auto res = executeQueryImpl(query_data, context, flags, stage);
+
+    if (const auto * ast_query_with_output = dynamic_cast<const ASTQueryWithOutput *>(query_data.ast.get()))
+    {
+        String format_name = ast_query_with_output->format ? getIdentifierName(ast_query_with_output->format) : context->getDefaultFormat();
+
+        if (format_name == "Null")
+            res.null_format = true;
+    }
+
+    return std::make_pair(query_data.ast, std::move(res));
 }
 
 void executeQuery(
@@ -2328,8 +1488,7 @@ void executeQuery(
     const std::optional<FormatSettings> & output_format_settings,
     HandleExceptionInOutputFormatFunc handle_exception_in_output_format)
 {
-    QueryResultDetails result_details
-    {
+    QueryResultDetails result_details{
         .query_id = context->getClientInfo().current_query_id,
         .timezone = DateLUT::instance().getTimeZone(),
     };
@@ -2393,45 +1552,8 @@ void executeQuery(
         }
     };
 
-    PODArray<char> parse_buf;
-    const char * begin;
-    const char * end;
 
-    try
-    {
-        istr.nextIfAtEnd();
-    }
-    catch (...)
-    {
-        /// If buffer contains invalid data and we failed to decompress, we still want to have some information about the query in the log.
-        logQuery("<cannot parse>", context, /* internal = */ false, QueryProcessingStage::Complete);
-        throw;
-    }
-
-    const auto max_query_size = getMaxQuerySize(context, flags);
-
-    if (istr.buffer().end() - istr.position() > static_cast<ssize_t>(max_query_size))
-    {
-        /// If remaining buffer space in 'istr' is enough to parse query up to 'max_query_size' bytes, then parse inplace.
-        begin = istr.position();
-        end = istr.buffer().end();
-        istr.position() += end - begin;
-    }
-    else
-    {
-        /// FIXME: this is an extra copy not required for async insertion.
-
-        /// If not - copy enough data into 'parse_buf'.
-        WriteBufferFromVector<PODArray<char>> out(parse_buf);
-        LimitReadBuffer limit(istr, max_query_size + 1, /* trow_exception */ false, /* exact_limit */ {});
-        copyData(limit, out);
-        out.finalize();
-
-        begin = parse_buf.data();
-        end = begin + parse_buf.size();
-    }
-
-    auto query_data = getQueryData(begin, end, istr, context, flags, QueryProcessingStage::Complete);
+    auto query_data = getQueryData(istr, context, flags, QueryProcessingStage::Complete);
 
     auto ast = query_data.ast;
     BlockIO streams;
@@ -2491,13 +1613,12 @@ void executeQuery(
                     std::make_unique<WriteBufferFromFile>(out_file, DBMS_DEFAULT_BUFFER_SIZE, O_WRONLY | O_EXCL | O_CREAT),
                     chooseCompressionMethod(out_file, compression_method),
                     /* compression level = */ static_cast<int>(settings.output_format_compression_level),
-                    /* zstd_window_log = */ static_cast<int>(settings.output_format_compression_zstd_window_log)
-                );
+                    /* zstd_window_log = */ static_cast<int>(settings.output_format_compression_zstd_window_log));
             }
 
             format_name = ast_query_with_output && (ast_query_with_output->format != nullptr)
-                                    ? getIdentifierName(ast_query_with_output->format)
-                                    : context->getDefaultFormat();
+                ? getIdentifierName(ast_query_with_output->format)
+                : context->getDefaultFormat();
 
             output_format = FormatFactory::instance().getOutputFormatParallelIfPossible(
                 format_name,
@@ -2512,12 +1633,13 @@ void executeQuery(
             auto previous_progress_callback = context->getProgressCallback();
 
             /// NOTE Progress callback takes shared ownership of 'out'.
-            pipeline.setProgressCallback([output_format, previous_progress_callback] (const Progress & progress)
-            {
-                if (previous_progress_callback)
-                    previous_progress_callback(progress);
-                output_format->onProgress(progress);
-            });
+            pipeline.setProgressCallback(
+                [output_format, previous_progress_callback](const Progress & progress)
+                {
+                    if (previous_progress_callback)
+                        previous_progress_callback(progress);
+                    output_format->onProgress(progress);
+                });
 
             result_details.content_type = output_format->getContentType();
             result_details.format = format_name;
@@ -2568,245 +1690,6 @@ void executeQuery(
 
     streams.onFinish();
 }
-
-std::pair<ASTPtr, BlockIO> executeQuery(
-    const String & query,
-    ContextMutablePtr context,
-    QueryFlags flags,
-    QueryProcessingStage::Enum stage)
-{
-    ASTPtr ast;
-    BlockIO res;
-
-    std::tie(ast, res) = executeQueryImpl(query.data(), query.data() + query.size(), context, flags, stage, nullptr);
-
-    if (const auto * ast_query_with_output = dynamic_cast<const ASTQueryWithOutput *>(ast.get()))
-    {
-        String format_name = ast_query_with_output->format
-                ? getIdentifierName(ast_query_with_output->format)
-                : context->getDefaultFormat();
-
-        if (format_name == "Null")
-            res.null_format = true;
-    }
-
-    return std::make_pair(std::move(ast), std::move(res));
-}
-
-// void executeQuery(
-//     ReadBuffer & istr,
-//     WriteBuffer & ostr,
-//     bool allow_into_outfile,
-//     ContextMutablePtr context,
-//     SetResultDetailsFunc set_result_details,
-//     QueryFlags flags,
-//     const std::optional<FormatSettings> & output_format_settings,
-//     HandleExceptionInOutputFormatFunc handle_exception_in_output_format)
-// {
-//     QueryResultDetails result_details
-//     {
-//         .query_id = context->getClientInfo().current_query_id,
-//         .timezone = DateLUT::instance().getTimeZone(),
-//     };
-
-//     /// Set the result details in case of any exception raised during query execution
-//     SCOPE_EXIT({
-//         if (set_result_details == nullptr)
-//             /// Either the result_details have been set in the flow below or the caller of this function does not provide this callback
-//             return;
-
-//         try
-//         {
-//             set_result_details(result_details);
-//         }
-//         catch (...)
-//         {
-//             /// This exception can be ignored.
-//             /// because if the code goes here, it means there's already an exception raised during query execution,
-//             /// and that exception will be propagated to outer caller,
-//             /// there's no need to report the exception thrown here.
-//         }
-//     });
-
-//     OutputFormatPtr output_format;
-//     String format_name;
-
-//     auto update_format_on_exception_if_needed = [&]()
-//     {
-//         if (!output_format)
-//         {
-//             try
-//             {
-//                 format_name = context->getDefaultFormat();
-//                 output_format = FormatFactory::instance().getOutputFormat(format_name, ostr, {}, context, output_format_settings);
-//                 if (output_format && output_format->supportsWritingException())
-//                 {
-//                     /// Force an update of the headers before we start writing
-//                     result_details.content_type = output_format->getContentType();
-//                     result_details.format = format_name;
-
-//                     fiu_do_on(FailPoints::execute_query_calling_empty_set_result_func_on_exception, {
-//                         // it will throw std::bad_function_call
-//                         set_result_details = nullptr;
-//                         set_result_details(result_details);
-//                     });
-
-//                     if (set_result_details)
-//                     {
-//                         /// reset set_result_details func to avoid calling in SCOPE_EXIT()
-//                         auto set_result_details_copy = set_result_details;
-//                         set_result_details = nullptr;
-//                         set_result_details_copy(result_details);
-//                     }
-//                 }
-//             }
-//             catch (const DB::Exception & e)
-//             {
-//                 /// Ignore this exception and report the original one
-//                 LOG_WARNING(getLogger("executeQuery"), getExceptionMessageAndPattern(e, true));
-//             }
-//         }
-//     };
-
-//     ASTPtr ast;
-//     BlockIO streams;
-
-//     try
-//     {
-//         std::tie(ast, streams) = executeQueryImpl(istr, context, flags, QueryProcessingStage::Complete);
-//     }
-//     catch (...)
-//     {
-//         if (handle_exception_in_output_format)
-//         {
-//             update_format_on_exception_if_needed();
-//             if (output_format)
-//                 handle_exception_in_output_format(*output_format, format_name, context, output_format_settings);
-//         }
-//         /// The timezone was already set before query was processed,
-//         /// But `session_timezone` setting could be modified in the query itself, so we update the value.
-//         result_details.timezone = DateLUT::instance().getTimeZone();
-//         throw;
-//     }
-
-//     WriteBufferFromOwnString query_buffer;
-//     formatAST(*ast, query_buffer, false);
-//     std::string query_str = query_buffer.str();
-
-//     /// The timezone was already set before query was processed,
-//     /// But `session_timezone` setting could be modified in the query itself, so we update the value.
-//     result_details.timezone = DateLUT::instance().getTimeZone();
-
-//     auto & pipeline = streams.pipeline;
-
-//     std::unique_ptr<WriteBuffer> compressed_buffer;
-//     try
-//     {
-//         if (pipeline.pushing())
-//         {
-//             auto pipe = getSourceFromASTInsertQuery(ast, true, pipeline.getHeader(), context, nullptr);
-//             pipeline.complete(std::move(pipe));
-//         }
-//         else if (pipeline.pulling())
-//         {
-//             const ASTQueryWithOutput * ast_query_with_output = dynamic_cast<const ASTQueryWithOutput *>(ast.get());
-
-//             WriteBuffer * out_buf = &ostr;
-//             if (ast_query_with_output && ast_query_with_output->out_file)
-//             {
-//                 if (!allow_into_outfile)
-//                     throw Exception(ErrorCodes::INTO_OUTFILE_NOT_ALLOWED, "INTO OUTFILE is not allowed");
-
-//                 const auto & out_file = typeid_cast<const ASTLiteral &>(*ast_query_with_output->out_file).value.safeGet<std::string>();
-
-//                 std::string compression_method;
-//                 if (ast_query_with_output->compression)
-//                 {
-//                     const auto & compression_method_node = ast_query_with_output->compression->as<ASTLiteral &>();
-//                     compression_method = compression_method_node.value.safeGet<std::string>();
-//                 }
-//                 const auto & settings = context->getSettingsRef();
-//                 compressed_buffer = wrapWriteBufferWithCompressionMethod(
-//                     std::make_unique<WriteBufferFromFile>(out_file, DBMS_DEFAULT_BUFFER_SIZE, O_WRONLY | O_EXCL | O_CREAT),
-//                     chooseCompressionMethod(out_file, compression_method),
-//                     /* compression level = */ static_cast<int>(settings.output_format_compression_level),
-//                     /* zstd_window_log = */ static_cast<int>(settings.output_format_compression_zstd_window_log)
-//                 );
-//             }
-
-//             format_name = ast_query_with_output && (ast_query_with_output->format != nullptr)
-//                                     ? getIdentifierName(ast_query_with_output->format)
-//                                     : context->getDefaultFormat();
-
-//             output_format = FormatFactory::instance().getOutputFormatParallelIfPossible(
-//                 format_name,
-//                 compressed_buffer ? *compressed_buffer : *out_buf,
-//                 materializeBlock(pipeline.getHeader()),
-//                 context,
-//                 output_format_settings);
-
-//             output_format->setAutoFlush();
-
-//             /// Save previous progress callback if any. TODO Do it more conveniently.
-//             auto previous_progress_callback = context->getProgressCallback();
-
-//             /// NOTE Progress callback takes shared ownership of 'out'.
-//             pipeline.setProgressCallback([output_format, previous_progress_callback] (const Progress & progress)
-//             {
-//                 if (previous_progress_callback)
-//                     previous_progress_callback(progress);
-//                 output_format->onProgress(progress);
-//             });
-
-//             result_details.content_type = output_format->getContentType();
-//             result_details.format = format_name;
-
-//             pipeline.complete(output_format);
-//         }
-//         else
-//         {
-//             pipeline.setProgressCallback(context->getProgressCallback());
-//         }
-
-//         if (set_result_details)
-//         {
-//             /// The call of set_result_details itself might throw exception,
-//             /// in such case there's no need to call this function again in the SCOPE_EXIT defined above.
-//             /// So the callback is cleared before its execution.
-//             auto set_result_details_copy = set_result_details;
-//             set_result_details = nullptr;
-
-//             set_result_details_copy(result_details);
-//         }
-
-//         if (pipeline.initialized())
-//         {
-//             CompletedPipelineExecutor executor(pipeline);
-//             executor.execute();
-//         }
-//         else
-//         {
-//             /// It's possible to have queries without input and output.
-//         }
-//     }
-//     catch (...)
-//     {
-//         /// first execute on exception callback, it includes updating query_log
-//         /// otherwise closing record ('ExceptionWhileProcessing') can be not appended in query_log
-//         /// due to possible exceptions in functions called below (passed as parameter here)
-//         streams.onException();
-
-//         if (handle_exception_in_output_format)
-//         {
-//             update_format_on_exception_if_needed();
-//             if (output_format)
-//                 handle_exception_in_output_format(*output_format, format_name, context, output_format_settings);
-//         }
-//         throw;
-//     }
-
-//     streams.onFinish();
-// }
 
 void executeQuery(
     QueryData & query_data,

--- a/src/Interpreters/executeQuery.cpp
+++ b/src/Interpreters/executeQuery.cpp
@@ -103,6 +103,7 @@ namespace ErrorCodes
     extern const int LOGICAL_ERROR;
     extern const int NOT_IMPLEMENTED;
     extern const int QUERY_WAS_CANCELLED;
+    extern const int INCORRECT_DATA;
     extern const int SYNTAX_ERROR;
     extern const int SUPPORT_IS_DISABLED;
     extern const int INCORRECT_QUERY;
@@ -1101,7 +1102,7 @@ static std::tuple<ASTPtr, BlockIO> executeQueryImpl(
             {
                 if (can_use_query_cache && settings.enable_reads_from_query_cache)
                 {
-                    QueryCache::Key key(ast, context->getCurrentDatabase(), context->getUserID(), context->getCurrentRoles());
+                    QueryCache::Key key(ast, context->getUserID(), context->getCurrentRoles());
                     QueryCache::Reader reader = query_cache->createReader(key);
                     if (reader.hasCacheEntryForKey())
                     {
@@ -1224,7 +1225,7 @@ static std::tuple<ASTPtr, BlockIO> executeQueryImpl(
                             && (!ast_contains_system_tables || system_table_handling == QueryCacheSystemTableHandling::Save))
                         {
                             QueryCache::Key key(
-                                ast, context->getCurrentDatabase(), res.pipeline.getHeader(),
+                                ast, res.pipeline.getHeader(),
                                 context->getUserID(), context->getCurrentRoles(),
                                 settings.query_cache_share_between_users,
                                 std::chrono::system_clock::now() + std::chrono::seconds(settings.query_cache_ttl),
@@ -1353,40 +1354,760 @@ static std::tuple<ASTPtr, BlockIO> executeQueryImpl(
     return std::make_tuple(std::move(ast), std::move(res));
 }
 
-
-std::pair<ASTPtr, BlockIO> executeQuery(
-    const String & query,
-    ContextMutablePtr context,
-    QueryFlags flags,
-    QueryProcessingStage::Enum stage)
+static BlockIO
+executeQueryImpl(QueryData & query_data, ContextMutablePtr context, QueryFlags flags, QueryProcessingStage::Enum stage)
 {
-    ASTPtr ast;
-    BlockIO res;
+    auto ast = query_data.ast;
+    auto query_for_logging = query_data.query_for_logging;
 
-    std::tie(ast, res) = executeQueryImpl(query.data(), query.data() + query.size(), context, flags, stage, nullptr);
+    const bool internal = flags.internal;
 
-    if (const auto * ast_query_with_output = dynamic_cast<const ASTQueryWithOutput *>(ast.get()))
+    /// query_span is a special span, when this function exits, it's lifetime is not ended, but ends when the query finishes.
+    /// Some internal queries might call this function recursively by setting 'internal' parameter to 'true',
+    /// to make sure SpanHolders in current stack ends in correct order, we disable this span for these internal queries
+    ///
+    /// This does not have impact on the final span logs, because these internal queries are issued by external queries,
+    /// we still have enough span logs for the execution of external queries.
+    std::shared_ptr<OpenTelemetry::SpanHolder> query_span = internal ? nullptr : std::make_shared<OpenTelemetry::SpanHolder>("query");
+    if (query_span && query_span->trace_id != UUID{})
+        LOG_TRACE(getLogger("executeQuery"), "Query span trace_id for opentelemetry log: {}", query_span->trace_id);
+
+    WriteBufferFromOwnString query_buffer;
+    formatAST(*ast, query_buffer, false);
+    std::string query_str = query_buffer.str();
+
+    /// Used for logging query start time in system.query_log
+    auto query_start_time = std::chrono::system_clock::now();
+
+    /// Used for:
+    /// * Setting the watch in QueryStatus (controls timeouts and progress) and the output formats
+    /// * Logging query duration (system.query_log)
+    Stopwatch start_watch{CLOCK_MONOTONIC};
+
+    const auto & client_info = context->getClientInfo();
+
+    if (!internal && client_info.initial_query_start_time == 0)
     {
-        String format_name = ast_query_with_output->format
-                ? getIdentifierName(ast_query_with_output->format)
-                : context->getDefaultFormat();
-
-        if (format_name == "Null")
-            res.null_format = true;
+        // If it's not an internal query and we don't see an initial_query_start_time yet, initialize it
+        // to current time. Internal queries are those executed without an independent client context,
+        // thus should not set initial_query_start_time, because it might introduce data race. It's also
+        // possible to have unset initial_query_start_time for non-internal and non-initial queries. For
+        // example, the query is from an initiator that is running an old version of clickhouse.
+        // On the other hand, if it's initialized then take it as the start of the query
+        context->setInitialQueryStartTime(query_start_time);
     }
 
-    return std::make_pair(std::move(ast), std::move(res));
+    assert(internal || CurrentThread::get().getQueryContext());
+    assert(internal || CurrentThread::get().getQueryContext()->getCurrentQueryId() == CurrentThread::getQueryId());
+
+    const Settings & settings = context->getSettingsRef();
+
+    /// Avoid early destruction of process_list_entry if it was not saved to `res` yet (in case of exception)
+    ProcessList::EntryPtr process_list_entry;
+    BlockIO res;
+    auto implicit_txn_control = std::make_shared<bool>(false);
+    String query_database;
+    String query_table;
+
+    auto execute_implicit_tcl_query = [implicit_txn_control](const ContextMutablePtr & query_context, ASTTransactionControl::QueryType tcl_type)
+    {
+        /// Unset the flag on COMMIT and ROLLBACK
+        SCOPE_EXIT({ if (tcl_type != ASTTransactionControl::BEGIN) *implicit_txn_control = false; });
+
+        ASTPtr tcl_ast = std::make_shared<ASTTransactionControl>(tcl_type);
+        InterpreterTransactionControlQuery tc(tcl_ast, query_context);
+        tc.execute();
+
+        /// Set the flag after successful BIGIN
+        if (tcl_type == ASTTransactionControl::BEGIN)
+            *implicit_txn_control = true;
+    };
+
+    try
+    {
+        if (auto txn = context->getCurrentTransaction())
+        {
+            chassert(txn->getState() != MergeTreeTransaction::COMMITTING);
+            chassert(txn->getState() != MergeTreeTransaction::COMMITTED);
+            if (txn->getState() == MergeTreeTransaction::ROLLED_BACK && !ast->as<ASTTransactionControl>() && !ast->as<ASTExplainQuery>())
+                throw Exception(
+                    ErrorCodes::INVALID_TRANSACTION,
+                    "Cannot execute query because current transaction failed. Expecting ROLLBACK statement");
+        }
+
+        /// Interpret SETTINGS clauses as early as possible (before invoking the corresponding interpreter),
+        /// to allow settings to take effect.
+        InterpreterSetQuery::applySettingsFromQuery(ast, context);
+        validateAnalyzerSettings(ast, context->getSettingsRef().allow_experimental_analyzer);
+
+        /// There is an option of probabilistic logging of queries.
+        /// If it is used - do the random sampling and "collapse" the settings.
+        /// It allows to consistently log queries with all the subqueries in distributed query processing
+        /// (subqueries on remote nodes will receive these "collapsed" settings)
+        if (!internal && settings.log_queries && settings.log_queries_probability < 1.0)
+        {
+            std::bernoulli_distribution should_write_log{settings.log_queries_probability};
+
+            context->setSetting("log_queries", should_write_log(thread_local_rng));
+            context->setSetting("log_queries_probability", 1.0);
+        }
+
+        if (const auto * query_with_table_output = dynamic_cast<const ASTQueryWithTableAndOutput *>(ast.get()))
+        {
+            query_database = query_with_table_output->getDatabase();
+            query_table = query_with_table_output->getTable();
+        }
+
+        logQuery(query_for_logging, context, internal, stage);
+
+        /// Propagate WITH statement to children ASTSelect.
+        if (settings.enable_global_with_statement)
+        {
+            ApplyWithGlobalVisitor::visit(ast);
+        }
+
+        {
+            SelectIntersectExceptQueryVisitor::Data data{settings.intersect_default_mode, settings.except_default_mode};
+            SelectIntersectExceptQueryVisitor{data}.visit(ast);
+        }
+
+        {
+            /// Normalize SelectWithUnionQuery
+            NormalizeSelectWithUnionQueryVisitor::Data data{settings.union_default_mode};
+            NormalizeSelectWithUnionQueryVisitor{data}.visit(ast);
+        }
+
+        /// Check the limits.
+        checkASTSizeLimits(*ast, settings);
+
+        /// Put query to process list. But don't put SHOW PROCESSLIST query itself.
+        if (!internal && !ast->as<ASTShowProcesslistQuery>())
+        {
+            /// processlist also has query masked now, to avoid secrets leaks though SHOW PROCESSLIST by other users.
+            process_list_entry = context->getProcessList().insert(query_for_logging, ast.get(), context, start_watch.getStart());
+            context->setProcessListElement(process_list_entry->getQueryStatus());
+        }
+
+        /// Load external tables if they were provided
+        context->initializeExternalTablesIfSet();
+
+        auto * insert_query = ast->as<ASTInsertQuery>();
+        bool async_insert_enabled = settings.async_insert;
+
+        /// Resolve database before trying to use async insert feature - to properly hash the query.
+        if (insert_query)
+        {
+            if (insert_query->table_id)
+                insert_query->table_id = context->resolveStorageID(insert_query->table_id);
+            else if (auto table = insert_query->getTable(); !table.empty())
+                insert_query->table_id = context->resolveStorageID(StorageID{insert_query->getDatabase(), table});
+
+            if (insert_query->table_id)
+                if (auto table = DatabaseCatalog::instance().tryGetTable(insert_query->table_id, context))
+                    async_insert_enabled |= table->areAsynchronousInsertsEnabled();
+        }
+
+        if (insert_query && insert_query->select)
+        {
+            /// Prepare Input storage before executing interpreter if we already got a buffer with data.
+            if (query_data.istr)
+            {
+                ASTPtr input_function;
+                insert_query->tryFindInputFunction(input_function);
+                if (input_function)
+                {
+                    StoragePtr storage = context->executeTableFunction(input_function, insert_query->select->as<ASTSelectQuery>());
+                    auto & input_storage = dynamic_cast<StorageInput &>(*storage);
+                    auto input_metadata_snapshot = input_storage.getInMemoryMetadataPtr();
+                    auto pipe = getSourceFromASTInsertQuery(
+                        ast, true, input_metadata_snapshot->getSampleBlock(), context, input_function);
+                    input_storage.setPipe(std::move(pipe));
+                }
+            }
+        }
+        else
+        {
+            /// reset Input callbacks if query is not INSERT SELECT
+            context->resetInputCallbacks();
+        }
+
+        StreamLocalLimits limits;
+        std::shared_ptr<const EnabledQuota> quota;
+        std::unique_ptr<IInterpreter> interpreter;
+
+        bool async_insert = false;
+        auto * queue = context->tryGetAsynchronousInsertQueue();
+        auto logger = getLogger("executeQuery");
+
+        if (insert_query && async_insert_enabled)
+        {
+            String reason;
+
+            if (!queue)
+                reason = "asynchronous insert queue is not configured";
+            else if (insert_query->select)
+                reason = "insert query has select";
+            else if (insert_query->hasInlinedData())
+                async_insert = true;
+
+            if (!reason.empty())
+                LOG_DEBUG(logger, "Setting async_insert=1, but INSERT query will be executed synchronously (reason: {})", reason);
+        }
+
+        bool quota_checked = false;
+        std::unique_ptr<ReadBuffer> insert_data_buffer_holder;
+
+        if (async_insert)
+        {
+            if (context->getCurrentTransaction() && settings.throw_on_unsupported_query_inside_transaction)
+                throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Async inserts inside transactions are not supported");
+            if (settings.implicit_transaction && settings.throw_on_unsupported_query_inside_transaction)
+                throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Async inserts with 'implicit_transaction' are not supported");
+
+            /// Let's agree on terminology and say that a mini-INSERT is an asynchronous INSERT
+            /// which typically contains not a lot of data inside and a big-INSERT in an INSERT
+            /// which was formed by concatenating several mini-INSERTs together.
+            /// In case when the client had to retry some mini-INSERTs then they will be properly deduplicated
+            /// by the source tables. This functionality is controlled by a setting `async_insert_deduplicate`.
+            /// But then they will be glued together into a block and pushed through a chain of Materialized Views if any.
+            /// The process of forming such blocks is not deteministic so each time we retry mini-INSERTs the resulting
+            /// block may be concatenated differently.
+            /// That's why deduplication in dependent Materialized Views doesn't make sense in presence of async INSERTs.
+            if (settings.throw_if_deduplication_in_dependent_materialized_views_enabled_with_async_insert &&
+                settings.deduplicate_blocks_in_dependent_materialized_views)
+                throw Exception(ErrorCodes::SUPPORT_IS_DISABLED,
+                        "Deduplication is dependent materialized view cannot work together with async inserts. "\
+                        "Please disable eiher `deduplicate_blocks_in_dependent_materialized_views` or `async_insert` setting.");
+
+            quota = context->getQuota();
+            if (quota)
+            {
+                quota_checked = true;
+                quota->used(QuotaType::QUERY_INSERTS, 1);
+                quota->used(QuotaType::QUERIES, 1);
+                quota->checkExceeded(QuotaType::ERRORS);
+            }
+
+            auto result = queue->pushQueryWithInlinedData(ast, context);
+
+            if (result.status == AsynchronousInsertQueue::PushResult::OK)
+            {
+                if (settings.wait_for_async_insert)
+                {
+                    auto timeout = settings.wait_for_async_insert_timeout.totalMilliseconds();
+                    auto source = std::make_shared<WaitForAsyncInsertSource>(std::move(result.future), timeout);
+                    res.pipeline = QueryPipeline(Pipe(std::move(source)));
+                }
+
+                const auto & table_id = insert_query->table_id;
+                if (!table_id.empty())
+                    context->setInsertionTable(table_id);
+            }
+            else if (result.status == AsynchronousInsertQueue::PushResult::TOO_MUCH_DATA)
+            {
+                async_insert = false;
+                insert_data_buffer_holder = std::move(result.insert_data_buffer);
+
+                if (insert_query->data)
+                {
+                    /// Reset inlined data because it will be
+                    /// available from tail read buffer.
+                    insert_query->end = insert_query->data;
+                    insert_query->data = nullptr;
+                }
+
+                insert_query->tail = insert_data_buffer_holder.get();
+                LOG_DEBUG(logger, "Setting async_insert=1, but INSERT query will be executed synchronously because it has too much data");
+            }
+        }
+
+        QueryCachePtr query_cache = context->getQueryCache();
+        const bool can_use_query_cache = query_cache != nullptr
+            && settings.use_query_cache
+            && !internal
+            && client_info.query_kind == ClientInfo::QueryKind::INITIAL_QUERY
+            && (ast->as<ASTSelectQuery>() || ast->as<ASTSelectWithUnionQuery>());
+        QueryCache::Usage query_cache_usage = QueryCache::Usage::None;
+
+        if (!async_insert)
+        {
+            /// If it is a non-internal SELECT, and passive (read) use of the query cache is enabled, and the cache knows the query, then set
+            /// a pipeline with a source populated by the query cache.
+            auto get_result_from_query_cache = [&]()
+            {
+                if (can_use_query_cache && settings.enable_reads_from_query_cache)
+                {
+                    QueryCache::Key key(ast, context->getUserID(), context->getCurrentRoles());
+                    QueryCache::Reader reader = query_cache->createReader(key);
+                    if (reader.hasCacheEntryForKey())
+                    {
+                        QueryPipeline pipeline;
+                        pipeline.readFromQueryCache(reader.getSource(), reader.getSourceTotals(), reader.getSourceExtremes());
+                        res.pipeline = std::move(pipeline);
+                        query_cache_usage = QueryCache::Usage::Read;
+                        return true;
+                    }
+                }
+                return false;
+            };
+
+            if (!get_result_from_query_cache())
+            {
+                /// We need to start the (implicit) transaction before getting the interpreter as this will get links to the latest snapshots
+                if (!context->getCurrentTransaction() && settings.implicit_transaction && !ast->as<ASTTransactionControl>())
+                {
+                    try
+                    {
+                        if (context->isGlobalContext())
+                            throw Exception(ErrorCodes::LOGICAL_ERROR, "Global context cannot create transactions");
+
+                        execute_implicit_tcl_query(context, ASTTransactionControl::BEGIN);
+                    }
+                    catch (Exception & e)
+                    {
+                        e.addMessage("while starting a transaction with 'implicit_transaction'");
+                        throw;
+                    }
+                }
+
+                interpreter = InterpreterFactory::instance().get(ast, context, SelectQueryOptions(stage).setInternal(internal));
+
+                const auto & query_settings = context->getSettingsRef();
+                if (context->getCurrentTransaction() && query_settings.throw_on_unsupported_query_inside_transaction)
+                {
+                    if (!interpreter->supportsTransactions())
+                        throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Transactions are not supported for this type of query ({})", ast->getID());
+
+                }
+
+                // InterpreterSelectQueryAnalyzer does not build QueryPlan in the constructor.
+                // We need to force to build it here to check if we need to ignore quota.
+                if (auto * interpreter_with_analyzer = dynamic_cast<InterpreterSelectQueryAnalyzer *>(interpreter.get()))
+                    interpreter_with_analyzer->getQueryPlan();
+
+                if (!interpreter->ignoreQuota() && !quota_checked)
+                {
+                    quota = context->getQuota();
+                    if (quota)
+                    {
+                        if (ast->as<ASTSelectQuery>() || ast->as<ASTSelectWithUnionQuery>())
+                        {
+                            quota->used(QuotaType::QUERY_SELECTS, 1);
+                        }
+                        else if (ast->as<ASTInsertQuery>())
+                        {
+                            quota->used(QuotaType::QUERY_INSERTS, 1);
+                        }
+                        quota->used(QuotaType::QUERIES, 1);
+                        quota->checkExceeded(QuotaType::ERRORS);
+                    }
+                }
+
+                if (!interpreter->ignoreLimits())
+                {
+                    limits.mode = LimitsMode::LIMITS_CURRENT;
+                    limits.size_limits = SizeLimits(settings.max_result_rows, settings.max_result_bytes, settings.result_overflow_mode);
+                }
+
+                if (auto * insert_interpreter = typeid_cast<InterpreterInsertQuery *>(&*interpreter))
+                {
+                    /// Save insertion table (not table function). TODO: support remote() table function.
+                    auto table_id = insert_interpreter->getDatabaseTable();
+                    if (!table_id.empty())
+                        context->setInsertionTable(std::move(table_id), insert_interpreter->getInsertColumnNames());
+
+                    if (insert_data_buffer_holder)
+                        insert_interpreter->addBuffer(std::move(insert_data_buffer_holder));
+                }
+
+                if (auto * create_interpreter = typeid_cast<InterpreterCreateQuery *>(&*interpreter))
+                    create_interpreter->setIsRestoreFromBackup(flags.distributed_backup_restore);
+
+                {
+                    std::unique_ptr<OpenTelemetry::SpanHolder> span;
+                    if (OpenTelemetry::CurrentContext().isTraceEnabled())
+                    {
+                        auto * raw_interpreter_ptr = interpreter.get();
+                        String class_name(demangle(typeid(*raw_interpreter_ptr).name()));
+                        span = std::make_unique<OpenTelemetry::SpanHolder>(class_name + "::execute()");
+                    }
+
+                    res = interpreter->execute();
+
+                    /// If it is a non-internal SELECT query, and active (write) use of the query cache is enabled, then add a processor on
+                    /// top of the pipeline which stores the result in the query cache.
+                    if (can_use_query_cache && settings.enable_writes_to_query_cache)
+                    {
+                        /// Only use the query cache if the query does not contain non-deterministic functions or system tables (which are typically non-deterministic)
+
+                        const bool ast_contains_nondeterministic_functions = astContainsNonDeterministicFunctions(ast, context);
+                        const bool ast_contains_system_tables = astContainsSystemTables(ast, context);
+
+                        const QueryCacheNondeterministicFunctionHandling nondeterministic_function_handling = settings.query_cache_nondeterministic_function_handling;
+                        const QueryCacheSystemTableHandling system_table_handling = settings.query_cache_system_table_handling;
+
+                        if (ast_contains_nondeterministic_functions && nondeterministic_function_handling == QueryCacheNondeterministicFunctionHandling::Throw)
+                            throw Exception(ErrorCodes::QUERY_CACHE_USED_WITH_NONDETERMINISTIC_FUNCTIONS,
+                                "The query result was not cached because the query contains a non-deterministic function."
+                                " Use setting `query_cache_nondeterministic_function_handling = 'save'` or `= 'ignore'` to cache the query result regardless or to omit caching");
+
+                        if (ast_contains_system_tables && system_table_handling == QueryCacheSystemTableHandling::Throw)
+                            throw Exception(ErrorCodes::QUERY_CACHE_USED_WITH_SYSTEM_TABLE,
+                                "The query result was not cached because the query contains a system table."
+                                " Use setting `query_cache_system_table_handling = 'save'` or `= 'ignore'` to cache the query result regardless or to omit caching");
+
+                        if ((!ast_contains_nondeterministic_functions || nondeterministic_function_handling == QueryCacheNondeterministicFunctionHandling::Save)
+                            && (!ast_contains_system_tables || system_table_handling == QueryCacheSystemTableHandling::Save))
+                        {
+                            QueryCache::Key key(
+                                ast, res.pipeline.getHeader(),
+                                context->getUserID(), context->getCurrentRoles(),
+                                settings.query_cache_share_between_users,
+                                std::chrono::system_clock::now() + std::chrono::seconds(settings.query_cache_ttl),
+                                settings.query_cache_compress_entries);
+
+                            const size_t num_query_runs = settings.query_cache_min_query_runs ? query_cache->recordQueryRun(key) : 1; /// try to avoid locking a mutex in recordQueryRun()
+                            if (num_query_runs <= settings.query_cache_min_query_runs)
+                            {
+                                LOG_TRACE(getLogger("QueryCache"),
+                                        "Skipped insert because the query ran {} times but the minimum required number of query runs to cache the query result is {}",
+                                        num_query_runs, settings.query_cache_min_query_runs);
+                            }
+                            else
+                            {
+                                auto query_cache_writer = std::make_shared<QueryCache::Writer>(query_cache->createWriter(
+                                                 key,
+                                                 std::chrono::milliseconds(settings.query_cache_min_query_duration.totalMilliseconds()),
+                                                 settings.query_cache_squash_partial_results,
+                                                 settings.max_block_size,
+                                                 settings.query_cache_max_size_in_bytes,
+                                                 settings.query_cache_max_entries));
+                                res.pipeline.writeResultIntoQueryCache(query_cache_writer);
+                                query_cache_usage = QueryCache::Usage::Write;
+                            }
+                        }
+                    }
+
+                }
+            }
+        }
+        // Here we check if our our projections contain force_optimize_projection_name
+        if (!settings.force_optimize_projection_name.value.empty())
+        {
+            bool found = false;
+            std::set<std::string> projections;
+            {
+                const auto & access_info = context->getQueryAccessInfo();
+                std::lock_guard lock(access_info.mutex);
+                projections = access_info.projections;
+            }
+
+            for (const auto &projection : projections)
+            {
+                // projection value has structure like: <db_name>.<table_name>.<projection_name>
+                // We need to get only the projection name
+                size_t last_dot_pos = projection.find_last_of('.');
+                std::string projection_name = (last_dot_pos != std::string::npos) ? projection.substr(last_dot_pos + 1) : projection;
+                if (settings.force_optimize_projection_name.value == projection_name)
+                {
+                    found = true;
+                    break;
+                }
+            }
+
+            if (!found)
+                throw Exception(ErrorCodes::INCORRECT_DATA, "Projection {} is specified in setting force_optimize_projection_name but not used",
+                                settings.force_optimize_projection_name.value);
+        }
+
+        if (process_list_entry)
+        {
+            /// Query was killed before execution
+            if (process_list_entry->getQueryStatus()->isKilled())
+                throw Exception(ErrorCodes::QUERY_WAS_CANCELLED,
+                    "Query '{}' is killed in pending state", process_list_entry->getQueryStatus()->getInfo().client_info.current_query_id);
+        }
+
+        /// Hold element of process list till end of query execution.
+        res.process_list_entry = process_list_entry;
+
+        auto & pipeline = res.pipeline;
+
+        if (pipeline.pulling() || pipeline.completed())
+        {
+            /// Limits on the result, the quota on the result, and also callback for progress.
+            /// Limits apply only to the final result.
+            pipeline.setProgressCallback(context->getProgressCallback());
+            pipeline.setProcessListElement(context->getProcessListElement());
+            if (stage == QueryProcessingStage::Complete && pipeline.pulling())
+                pipeline.setLimitsAndQuota(limits, quota);
+        }
+        else if (pipeline.pushing())
+        {
+            pipeline.setProcessListElement(context->getProcessListElement());
+        }
+
+        /// Everything related to query log.
+        {
+            QueryLogElement elem = logQueryStart(
+                query_start_time,
+                context,
+                query_for_logging,
+                ast,
+                pipeline,
+                interpreter,
+                internal,
+                query_database,
+                query_table,
+                async_insert);
+            /// Also make possible for caller to log successful query finish and exception during execution.
+            auto finish_callback = [elem,
+                                    context,
+                                    ast,
+                                    query_cache_usage,
+                                    internal,
+                                    implicit_txn_control,
+                                    execute_implicit_tcl_query,
+                                    pulling_pipeline = pipeline.pulling(),
+                                    query_span](QueryPipeline & query_pipeline) mutable
+            {
+                if (query_cache_usage == QueryCache::Usage::Write)
+                    /// Trigger the actual write of the buffered query result into the query cache. This is done explicitly to prevent
+                    /// partial/garbage results in case of exceptions during query execution.
+                    query_pipeline.finalizeWriteInQueryCache();
+
+                logQueryFinish(elem, context, ast, query_pipeline, pulling_pipeline, query_span, query_cache_usage, internal);
+
+                if (*implicit_txn_control)
+                    execute_implicit_tcl_query(context, ASTTransactionControl::COMMIT);
+            };
+
+            auto exception_callback =
+                [start_watch, elem, context, ast, internal, my_quota(quota), implicit_txn_control, execute_implicit_tcl_query, query_span](
+                    bool log_error) mutable
+            {
+                if (*implicit_txn_control)
+                    execute_implicit_tcl_query(context, ASTTransactionControl::ROLLBACK);
+                else if (auto txn = context->getCurrentTransaction())
+                    txn->onException();
+
+                if (my_quota)
+                    my_quota->used(QuotaType::ERRORS, 1, /* check_exceeded = */ false);
+
+                logQueryException(elem, context, start_watch, ast, query_span, internal, log_error);
+            };
+
+            res.finish_callback = std::move(finish_callback);
+            res.exception_callback = std::move(exception_callback);
+        }
+    }
+    catch (...)
+    {
+        if (*implicit_txn_control)
+            execute_implicit_tcl_query(context, ASTTransactionControl::ROLLBACK);
+        else if (auto txn = context->getCurrentTransaction())
+            txn->onException();
+
+        if (!internal)
+            logExceptionBeforeStart(query_for_logging, context, ast, query_span, start_watch.elapsedMilliseconds());
+
+        throw;
+    }
+
+    return res;
 }
 
-void executeQuery(
+size_t getMaxQuerySize(ContextMutablePtr context, QueryFlags flags)
+{
+    if (flags.internal || context->getClientInfo().query_kind == ClientInfo::QueryKind::SECONDARY_QUERY)
+        return 0;
+
+    return context->getSettingsRef().max_query_size;
+}
+
+QueryData getQueryData(
+    const char * begin,
+    const char * end,
     ReadBuffer & istr,
-    WriteBuffer & ostr,
-    bool allow_into_outfile,
     ContextMutablePtr context,
-    SetResultDetailsFunc set_result_details,
     QueryFlags flags,
-    const std::optional<FormatSettings> & output_format_settings,
-    HandleExceptionInOutputFormatFunc handle_exception_in_output_format)
+    const QueryProcessingStage::Enum stage
+)
+{
+    const auto & settings = context->getSettingsRef();
+
+    const auto internal = flags.internal;
+    const auto log_queries_cut_to_length = settings.log_queries_cut_to_length;
+
+    const auto max_query_size = getMaxQuerySize(context, flags);
+
+    /// Used for logging query start time in system.query_log
+    auto query_start_time = std::chrono::system_clock::now();
+
+    /// Used for:
+    /// * Setting the watch in QueryStatus (controls timeouts and progress) and the output formats
+    /// * Logging query duration (system.query_log)
+    Stopwatch start_watch{CLOCK_MONOTONIC};
+
+    const auto & client_info = context->getClientInfo();
+
+    /// query_span is a special span, when this function exits, it's lifetime is not ended, but ends when the query finishes.
+    /// Some internal queries might call this function recursively by setting 'internal' parameter to 'true',
+    /// to make sure SpanHolders in current stack ends in correct order, we disable this span for these internal queries
+    ///
+    /// This does not have impact on the final span logs, because these internal queries are issued by external queries,
+    /// we still have enough span logs for the execution of external queries.
+    std::shared_ptr<OpenTelemetry::SpanHolder> query_span = internal ? nullptr : std::make_shared<OpenTelemetry::SpanHolder>("query");
+    if (query_span && query_span->trace_id != UUID{})
+        LOG_TRACE(getLogger("executeQuery"), "Query span trace_id for opentelemetry log: {}", query_span->trace_id);
+
+    if (!internal && client_info.initial_query_start_time == 0)
+    {
+        // If it's not an internal query and we don't see an initial_query_start_time yet, initialize it
+        // to current time. Internal queries are those executed without an independent client context,
+        // thus should not set initial_query_start_time, because it might introduce data race. It's also
+        // possible to have unset initial_query_start_time for non-internal and non-initial queries. For
+        // example, the query is from an initiator that is running an old version of clickhouse.
+        // On the other hand, if it's initialized then take it as the start of the query
+        context->setInitialQueryStartTime(query_start_time);
+    }
+
+    assert(internal || CurrentThread::get().getQueryContext());
+    assert(internal || CurrentThread::get().getQueryContext()->getCurrentQueryId() == CurrentThread::getQueryId());
+
+    ASTPtr ast;
+    String query;
+    String query_for_logging;
+
+    try
+    {
+        /// Parse the query from string.
+        if (settings.dialect == Dialect::kusto && !internal)
+        {
+            ParserKQLStatement parser(end, settings.allow_settings_after_format_in_insert);
+            /// TODO: parser should fail early when max_query_size limit is reached.
+            ast = parseKQLQuery(parser, begin, end, "", max_query_size, settings.max_parser_depth, settings.max_parser_backtracks);
+        }
+        else if (settings.dialect == Dialect::prql && !internal)
+        {
+            ParserPRQLQuery parser(max_query_size, settings.max_parser_depth, settings.max_parser_backtracks);
+            ast = parseQuery(parser, begin, end, "", max_query_size, settings.max_parser_depth, settings.max_parser_backtracks);
+        }
+        else
+        {
+            ParserQuery parser(end, settings.allow_settings_after_format_in_insert);
+            /// TODO: parser should fail early when max_query_size limit is reached.
+            ast = parseQuery(parser, begin, end, "", max_query_size, settings.max_parser_depth, settings.max_parser_backtracks);
+
+#ifndef NDEBUG
+            /// Verify that AST formatting is consistent:
+            /// If you format AST, parse it back, and format it again, you get the same string.
+
+            String formatted1 = ast->formatWithPossiblyHidingSensitiveData(0, true, true);
+
+            /// The query can become more verbose after formatting, so:
+            size_t new_max_query_size = max_query_size > 0 ? (1000 + 2 * max_query_size) : 0;
+
+            ASTPtr ast2;
+            try
+            {
+                ast2 = parseQuery(
+                    parser,
+                    formatted1.data(),
+                    formatted1.data() + formatted1.size(),
+                    "",
+                    new_max_query_size,
+                    settings.max_parser_depth,
+                    settings.max_parser_backtracks);
+            }
+            catch (const Exception & e)
+            {
+                if (e.code() == ErrorCodes::SYNTAX_ERROR)
+                    /// Don't print the original query text because it may contain sensitive data.
+                    throw Exception(ErrorCodes::LOGICAL_ERROR, "Inconsistent AST formatting: the query:\n{}\ncannot parse.", formatted1);
+                else
+                    throw;
+            }
+
+            chassert(ast2);
+
+            String formatted2 = ast2->formatWithPossiblyHidingSensitiveData(0, true, true);
+
+            if (formatted1 != formatted2)
+                throw Exception(
+                    ErrorCodes::LOGICAL_ERROR,
+                    "Inconsistent AST formatting: the query:\n{}\nWas parsed and formatted back as:\n{}",
+                    formatted1,
+                    formatted2);
+#endif
+        }
+
+        const char * query_end = end;
+        if (const auto * insert_query = ast->as<ASTInsertQuery>(); insert_query && insert_query->data)
+            query_end = insert_query->data;
+
+        bool is_create_parameterized_view = false;
+        if (const auto * create_query = ast->as<ASTCreateQuery>())
+            is_create_parameterized_view = create_query->isParameterizedView();
+        else if (const auto * explain_query = ast->as<ASTExplainQuery>())
+        {
+            assert(!explain_query->children.empty());
+            if (const auto * create_of_explain_query = explain_query->children[0]->as<ASTCreateQuery>())
+                is_create_parameterized_view = create_of_explain_query->isParameterizedView();
+        }
+
+        /// Replace ASTQueryParameter with ASTLiteral for prepared statements.
+        /// Even if we don't have parameters in query_context, check that AST doesn't have unknown parameters
+        bool probably_has_params = find_first_symbols<'{'>(begin, end) != end;
+        if (!is_create_parameterized_view && probably_has_params)
+        {
+            ReplaceQueryParameterVisitor visitor(context->getQueryParameters());
+            visitor.visit(ast);
+            if (visitor.getNumberOfReplacedParameters())
+                query = serializeAST(*ast);
+            else
+                query.assign(begin, query_end);
+        }
+        else
+        {
+            /// Copy query into string. It will be written to log and presented in processlist. If an INSERT query, string will not include data to insertion.
+            query.assign(begin, query_end);
+        }
+
+        /// Wipe any sensitive information (e.g. passwords) from the query.
+        /// MUST go before any modification (except for prepared statements,
+        /// since it substitute parameters and without them query does not contain
+        /// parameters), to keep query as-is in query_log and server log.
+        if (ast->hasSecretParts())
+        {
+            /// IAST::formatForLogging() wipes secret parts in AST and then calls wipeSensitiveDataAndCutToLength().
+            query_for_logging = ast->formatForLogging(log_queries_cut_to_length);
+        }
+        else
+        {
+            query_for_logging = wipeSensitiveDataAndCutToLength(query, log_queries_cut_to_length);
+        }
+
+        if (auto * insert_query = ast->as<ASTInsertQuery>())
+            insert_query->tail = &istr;
+    }
+    catch (...)
+    {
+        /// Anyway log the query.
+        query = String(begin, std::min(end - begin, static_cast<ptrdiff_t>(getMaxQuerySize(context, flags))));
+
+        query_for_logging = wipeSensitiveDataAndCutToLength(query, context->getSettingsRef().log_queries_cut_to_length);
+        logQuery(query_for_logging, context, internal, stage);
+
+        if (!internal)
+            logExceptionBeforeStart(query_for_logging, context, nullptr, query_span, start_watch.elapsedMilliseconds());
+        throw;
+    }
+
+    return QueryData{.ast = ast, .istr = nullptr, .query = query, .query_for_logging = query_for_logging};
+}
+
+QueryData getQueryData(ReadBuffer & istr, ContextMutablePtr context, QueryFlags flags, const QueryProcessingStage::Enum stage)
 {
     PODArray<char> parse_buf;
     const char * begin;
@@ -1403,7 +2124,7 @@ void executeQuery(
         throw;
     }
 
-    size_t max_query_size = context->getSettingsRef().max_query_size;
+    const auto max_query_size = getMaxQuerySize(context, flags);
 
     if (istr.buffer().end() - istr.position() > static_cast<ssize_t>(max_query_size))
     {
@@ -1426,6 +2147,187 @@ void executeQuery(
         end = begin + parse_buf.size();
     }
 
+    const auto & settings = context->getSettingsRef();
+
+    const auto internal = flags.internal;
+    const auto log_queries_cut_to_length = settings.log_queries_cut_to_length;
+
+    /// Used for logging query start time in system.query_log
+    auto query_start_time = std::chrono::system_clock::now();
+
+    /// Used for:
+    /// * Setting the watch in QueryStatus (controls timeouts and progress) and the output formats
+    /// * Logging query duration (system.query_log)
+    Stopwatch start_watch{CLOCK_MONOTONIC};
+
+    const auto & client_info = context->getClientInfo();
+
+    /// query_span is a special span, when this function exits, it's lifetime is not ended, but ends when the query finishes.
+    /// Some internal queries might call this function recursively by setting 'internal' parameter to 'true',
+    /// to make sure SpanHolders in current stack ends in correct order, we disable this span for these internal queries
+    ///
+    /// This does not have impact on the final span logs, because these internal queries are issued by external queries,
+    /// we still have enough span logs for the execution of external queries.
+    std::shared_ptr<OpenTelemetry::SpanHolder> query_span = internal ? nullptr : std::make_shared<OpenTelemetry::SpanHolder>("query");
+    if (query_span && query_span->trace_id != UUID{})
+        LOG_TRACE(getLogger("executeQuery"), "Query span trace_id for opentelemetry log: {}", query_span->trace_id);
+
+    if (!internal && client_info.initial_query_start_time == 0)
+    {
+        // If it's not an internal query and we don't see an initial_query_start_time yet, initialize it
+        // to current time. Internal queries are those executed without an independent client context,
+        // thus should not set initial_query_start_time, because it might introduce data race. It's also
+        // possible to have unset initial_query_start_time for non-internal and non-initial queries. For
+        // example, the query is from an initiator that is running an old version of clickhouse.
+        // On the other hand, if it's initialized then take it as the start of the query
+        context->setInitialQueryStartTime(query_start_time);
+    }
+
+    assert(internal || CurrentThread::get().getQueryContext());
+    assert(internal || CurrentThread::get().getQueryContext()->getCurrentQueryId() == CurrentThread::getQueryId());
+
+    ASTPtr ast;
+    String query;
+    String query_for_logging;
+
+    try
+    {
+        /// Parse the query from string.
+        if (settings.dialect == Dialect::kusto && !internal)
+        {
+            ParserKQLStatement parser(end, settings.allow_settings_after_format_in_insert);
+            /// TODO: parser should fail early when max_query_size limit is reached.
+            ast = parseKQLQuery(parser, begin, end, "", max_query_size, settings.max_parser_depth, settings.max_parser_backtracks);
+        }
+        else if (settings.dialect == Dialect::prql && !internal)
+        {
+            ParserPRQLQuery parser(max_query_size, settings.max_parser_depth, settings.max_parser_backtracks);
+            ast = parseQuery(parser, begin, end, "", max_query_size, settings.max_parser_depth, settings.max_parser_backtracks);
+        }
+        else
+        {
+            ParserQuery parser(end, settings.allow_settings_after_format_in_insert);
+            /// TODO: parser should fail early when max_query_size limit is reached.
+            ast = parseQuery(parser, begin, end, "", max_query_size, settings.max_parser_depth, settings.max_parser_backtracks);
+
+#ifndef NDEBUG
+            /// Verify that AST formatting is consistent:
+            /// If you format AST, parse it back, and format it again, you get the same string.
+
+            String formatted1 = ast->formatWithPossiblyHidingSensitiveData(0, true, true);
+
+            /// The query can become more verbose after formatting, so:
+            size_t new_max_query_size = max_query_size > 0 ? (1000 + 2 * max_query_size) : 0;
+
+            ASTPtr ast2;
+            try
+            {
+                ast2 = parseQuery(
+                    parser,
+                    formatted1.data(),
+                    formatted1.data() + formatted1.size(),
+                    "",
+                    new_max_query_size,
+                    settings.max_parser_depth,
+                    settings.max_parser_backtracks);
+            }
+            catch (const Exception & e)
+            {
+                if (e.code() == ErrorCodes::SYNTAX_ERROR)
+                    /// Don't print the original query text because it may contain sensitive data.
+                    throw Exception(ErrorCodes::LOGICAL_ERROR, "Inconsistent AST formatting: the query:\n{}\ncannot parse.", formatted1);
+                else
+                    throw;
+            }
+
+            chassert(ast2);
+
+            String formatted2 = ast2->formatWithPossiblyHidingSensitiveData(0, true, true);
+
+            if (formatted1 != formatted2)
+                throw Exception(
+                    ErrorCodes::LOGICAL_ERROR,
+                    "Inconsistent AST formatting: the query:\n{}\nWas parsed and formatted back as:\n{}",
+                    formatted1,
+                    formatted2);
+#endif
+        }
+
+        const char * query_end = end;
+        if (const auto * insert_query = ast->as<ASTInsertQuery>(); insert_query && insert_query->data)
+            query_end = insert_query->data;
+
+        bool is_create_parameterized_view = false;
+        if (const auto * create_query = ast->as<ASTCreateQuery>())
+            is_create_parameterized_view = create_query->isParameterizedView();
+        else if (const auto * explain_query = ast->as<ASTExplainQuery>())
+        {
+            assert(!explain_query->children.empty());
+            if (const auto * create_of_explain_query = explain_query->children[0]->as<ASTCreateQuery>())
+                is_create_parameterized_view = create_of_explain_query->isParameterizedView();
+        }
+
+        /// Replace ASTQueryParameter with ASTLiteral for prepared statements.
+        /// Even if we don't have parameters in query_context, check that AST doesn't have unknown parameters
+        bool probably_has_params = find_first_symbols<'{'>(begin, end) != end;
+        if (!is_create_parameterized_view && probably_has_params)
+        {
+            ReplaceQueryParameterVisitor visitor(context->getQueryParameters());
+            visitor.visit(ast);
+            if (visitor.getNumberOfReplacedParameters())
+                query = serializeAST(*ast);
+            else
+                query.assign(begin, query_end);
+        }
+        else
+        {
+            /// Copy query into string. It will be written to log and presented in processlist. If an INSERT query, string will not include data to insertion.
+            query.assign(begin, query_end);
+        }
+
+        /// Wipe any sensitive information (e.g. passwords) from the query.
+        /// MUST go before any modification (except for prepared statements,
+        /// since it substitute parameters and without them query does not contain
+        /// parameters), to keep query as-is in query_log and server log.
+        if (ast->hasSecretParts())
+        {
+            /// IAST::formatForLogging() wipes secret parts in AST and then calls wipeSensitiveDataAndCutToLength().
+            query_for_logging = ast->formatForLogging(log_queries_cut_to_length);
+        }
+        else
+        {
+            query_for_logging = wipeSensitiveDataAndCutToLength(query, log_queries_cut_to_length);
+        }
+
+        if (auto * insert_query = ast->as<ASTInsertQuery>())
+            insert_query->tail = &istr;
+    }
+    catch (...)
+    {
+        /// Anyway log the query.
+        query = String(begin, std::min(end - begin, static_cast<ptrdiff_t>(getMaxQuerySize(context, flags))));
+
+        query_for_logging = wipeSensitiveDataAndCutToLength(query, context->getSettingsRef().log_queries_cut_to_length);
+        logQuery(query_for_logging, context, internal, stage);
+
+        if (!internal)
+            logExceptionBeforeStart(query_for_logging, context, nullptr, query_span, start_watch.elapsedMilliseconds());
+        throw;
+    }
+
+    return QueryData{.ast = ast, .istr = nullptr, .query = query, .query_for_logging = query_for_logging};
+}
+
+void executeQuery(
+    ReadBuffer & istr,
+    WriteBuffer & ostr,
+    bool allow_into_outfile,
+    ContextMutablePtr context,
+    SetResultDetailsFunc set_result_details,
+    QueryFlags flags,
+    const std::optional<FormatSettings> & output_format_settings,
+    HandleExceptionInOutputFormatFunc handle_exception_in_output_format)
+{
     QueryResultDetails result_details
     {
         .query_id = context->getClientInfo().current_query_id,
@@ -1451,8 +2353,6 @@ void executeQuery(
         }
     });
 
-    ASTPtr ast;
-    BlockIO streams;
     OutputFormatPtr output_format;
     String format_name;
 
@@ -1493,9 +2393,52 @@ void executeQuery(
         }
     };
 
+    PODArray<char> parse_buf;
+    const char * begin;
+    const char * end;
+
     try
     {
-        std::tie(ast, streams) = executeQueryImpl(begin, end, context, flags, QueryProcessingStage::Complete, &istr);
+        istr.nextIfAtEnd();
+    }
+    catch (...)
+    {
+        /// If buffer contains invalid data and we failed to decompress, we still want to have some information about the query in the log.
+        logQuery("<cannot parse>", context, /* internal = */ false, QueryProcessingStage::Complete);
+        throw;
+    }
+
+    const auto max_query_size = getMaxQuerySize(context, flags);
+
+    if (istr.buffer().end() - istr.position() > static_cast<ssize_t>(max_query_size))
+    {
+        /// If remaining buffer space in 'istr' is enough to parse query up to 'max_query_size' bytes, then parse inplace.
+        begin = istr.position();
+        end = istr.buffer().end();
+        istr.position() += end - begin;
+    }
+    else
+    {
+        /// FIXME: this is an extra copy not required for async insertion.
+
+        /// If not - copy enough data into 'parse_buf'.
+        WriteBufferFromVector<PODArray<char>> out(parse_buf);
+        LimitReadBuffer limit(istr, max_query_size + 1, /* trow_exception */ false, /* exact_limit */ {});
+        copyData(limit, out);
+        out.finalize();
+
+        begin = parse_buf.data();
+        end = begin + parse_buf.size();
+    }
+
+    auto query_data = getQueryData(begin, end, istr, context, flags, QueryProcessingStage::Complete);
+
+    auto ast = query_data.ast;
+    BlockIO streams;
+
+    try
+    {
+        streams = executeQueryImpl(query_data, context, flags, QueryProcessingStage::Complete);
     }
     catch (...)
     {
@@ -1575,6 +2518,455 @@ void executeQuery(
                     previous_progress_callback(progress);
                 output_format->onProgress(progress);
             });
+
+            result_details.content_type = output_format->getContentType();
+            result_details.format = format_name;
+
+            pipeline.complete(output_format);
+        }
+        else
+        {
+            pipeline.setProgressCallback(context->getProgressCallback());
+        }
+
+        if (set_result_details)
+        {
+            /// The call of set_result_details itself might throw exception,
+            /// in such case there's no need to call this function again in the SCOPE_EXIT defined above.
+            /// So the callback is cleared before its execution.
+            auto set_result_details_copy = set_result_details;
+            set_result_details = nullptr;
+
+            set_result_details_copy(result_details);
+        }
+
+        if (pipeline.initialized())
+        {
+            CompletedPipelineExecutor executor(pipeline);
+            executor.execute();
+        }
+        else
+        {
+            /// It's possible to have queries without input and output.
+        }
+    }
+    catch (...)
+    {
+        /// first execute on exception callback, it includes updating query_log
+        /// otherwise closing record ('ExceptionWhileProcessing') can be not appended in query_log
+        /// due to possible exceptions in functions called below (passed as parameter here)
+        streams.onException();
+
+        if (handle_exception_in_output_format)
+        {
+            update_format_on_exception_if_needed();
+            if (output_format)
+                handle_exception_in_output_format(*output_format, format_name, context, output_format_settings);
+        }
+        throw;
+    }
+
+    streams.onFinish();
+}
+
+std::pair<ASTPtr, BlockIO> executeQuery(
+    const String & query,
+    ContextMutablePtr context,
+    QueryFlags flags,
+    QueryProcessingStage::Enum stage)
+{
+    ASTPtr ast;
+    BlockIO res;
+
+    std::tie(ast, res) = executeQueryImpl(query.data(), query.data() + query.size(), context, flags, stage, nullptr);
+
+    if (const auto * ast_query_with_output = dynamic_cast<const ASTQueryWithOutput *>(ast.get()))
+    {
+        String format_name = ast_query_with_output->format
+                ? getIdentifierName(ast_query_with_output->format)
+                : context->getDefaultFormat();
+
+        if (format_name == "Null")
+            res.null_format = true;
+    }
+
+    return std::make_pair(std::move(ast), std::move(res));
+}
+
+// void executeQuery(
+//     ReadBuffer & istr,
+//     WriteBuffer & ostr,
+//     bool allow_into_outfile,
+//     ContextMutablePtr context,
+//     SetResultDetailsFunc set_result_details,
+//     QueryFlags flags,
+//     const std::optional<FormatSettings> & output_format_settings,
+//     HandleExceptionInOutputFormatFunc handle_exception_in_output_format)
+// {
+//     QueryResultDetails result_details
+//     {
+//         .query_id = context->getClientInfo().current_query_id,
+//         .timezone = DateLUT::instance().getTimeZone(),
+//     };
+
+//     /// Set the result details in case of any exception raised during query execution
+//     SCOPE_EXIT({
+//         if (set_result_details == nullptr)
+//             /// Either the result_details have been set in the flow below or the caller of this function does not provide this callback
+//             return;
+
+//         try
+//         {
+//             set_result_details(result_details);
+//         }
+//         catch (...)
+//         {
+//             /// This exception can be ignored.
+//             /// because if the code goes here, it means there's already an exception raised during query execution,
+//             /// and that exception will be propagated to outer caller,
+//             /// there's no need to report the exception thrown here.
+//         }
+//     });
+
+//     OutputFormatPtr output_format;
+//     String format_name;
+
+//     auto update_format_on_exception_if_needed = [&]()
+//     {
+//         if (!output_format)
+//         {
+//             try
+//             {
+//                 format_name = context->getDefaultFormat();
+//                 output_format = FormatFactory::instance().getOutputFormat(format_name, ostr, {}, context, output_format_settings);
+//                 if (output_format && output_format->supportsWritingException())
+//                 {
+//                     /// Force an update of the headers before we start writing
+//                     result_details.content_type = output_format->getContentType();
+//                     result_details.format = format_name;
+
+//                     fiu_do_on(FailPoints::execute_query_calling_empty_set_result_func_on_exception, {
+//                         // it will throw std::bad_function_call
+//                         set_result_details = nullptr;
+//                         set_result_details(result_details);
+//                     });
+
+//                     if (set_result_details)
+//                     {
+//                         /// reset set_result_details func to avoid calling in SCOPE_EXIT()
+//                         auto set_result_details_copy = set_result_details;
+//                         set_result_details = nullptr;
+//                         set_result_details_copy(result_details);
+//                     }
+//                 }
+//             }
+//             catch (const DB::Exception & e)
+//             {
+//                 /// Ignore this exception and report the original one
+//                 LOG_WARNING(getLogger("executeQuery"), getExceptionMessageAndPattern(e, true));
+//             }
+//         }
+//     };
+
+//     ASTPtr ast;
+//     BlockIO streams;
+
+//     try
+//     {
+//         std::tie(ast, streams) = executeQueryImpl(istr, context, flags, QueryProcessingStage::Complete);
+//     }
+//     catch (...)
+//     {
+//         if (handle_exception_in_output_format)
+//         {
+//             update_format_on_exception_if_needed();
+//             if (output_format)
+//                 handle_exception_in_output_format(*output_format, format_name, context, output_format_settings);
+//         }
+//         /// The timezone was already set before query was processed,
+//         /// But `session_timezone` setting could be modified in the query itself, so we update the value.
+//         result_details.timezone = DateLUT::instance().getTimeZone();
+//         throw;
+//     }
+
+//     WriteBufferFromOwnString query_buffer;
+//     formatAST(*ast, query_buffer, false);
+//     std::string query_str = query_buffer.str();
+
+//     /// The timezone was already set before query was processed,
+//     /// But `session_timezone` setting could be modified in the query itself, so we update the value.
+//     result_details.timezone = DateLUT::instance().getTimeZone();
+
+//     auto & pipeline = streams.pipeline;
+
+//     std::unique_ptr<WriteBuffer> compressed_buffer;
+//     try
+//     {
+//         if (pipeline.pushing())
+//         {
+//             auto pipe = getSourceFromASTInsertQuery(ast, true, pipeline.getHeader(), context, nullptr);
+//             pipeline.complete(std::move(pipe));
+//         }
+//         else if (pipeline.pulling())
+//         {
+//             const ASTQueryWithOutput * ast_query_with_output = dynamic_cast<const ASTQueryWithOutput *>(ast.get());
+
+//             WriteBuffer * out_buf = &ostr;
+//             if (ast_query_with_output && ast_query_with_output->out_file)
+//             {
+//                 if (!allow_into_outfile)
+//                     throw Exception(ErrorCodes::INTO_OUTFILE_NOT_ALLOWED, "INTO OUTFILE is not allowed");
+
+//                 const auto & out_file = typeid_cast<const ASTLiteral &>(*ast_query_with_output->out_file).value.safeGet<std::string>();
+
+//                 std::string compression_method;
+//                 if (ast_query_with_output->compression)
+//                 {
+//                     const auto & compression_method_node = ast_query_with_output->compression->as<ASTLiteral &>();
+//                     compression_method = compression_method_node.value.safeGet<std::string>();
+//                 }
+//                 const auto & settings = context->getSettingsRef();
+//                 compressed_buffer = wrapWriteBufferWithCompressionMethod(
+//                     std::make_unique<WriteBufferFromFile>(out_file, DBMS_DEFAULT_BUFFER_SIZE, O_WRONLY | O_EXCL | O_CREAT),
+//                     chooseCompressionMethod(out_file, compression_method),
+//                     /* compression level = */ static_cast<int>(settings.output_format_compression_level),
+//                     /* zstd_window_log = */ static_cast<int>(settings.output_format_compression_zstd_window_log)
+//                 );
+//             }
+
+//             format_name = ast_query_with_output && (ast_query_with_output->format != nullptr)
+//                                     ? getIdentifierName(ast_query_with_output->format)
+//                                     : context->getDefaultFormat();
+
+//             output_format = FormatFactory::instance().getOutputFormatParallelIfPossible(
+//                 format_name,
+//                 compressed_buffer ? *compressed_buffer : *out_buf,
+//                 materializeBlock(pipeline.getHeader()),
+//                 context,
+//                 output_format_settings);
+
+//             output_format->setAutoFlush();
+
+//             /// Save previous progress callback if any. TODO Do it more conveniently.
+//             auto previous_progress_callback = context->getProgressCallback();
+
+//             /// NOTE Progress callback takes shared ownership of 'out'.
+//             pipeline.setProgressCallback([output_format, previous_progress_callback] (const Progress & progress)
+//             {
+//                 if (previous_progress_callback)
+//                     previous_progress_callback(progress);
+//                 output_format->onProgress(progress);
+//             });
+
+//             result_details.content_type = output_format->getContentType();
+//             result_details.format = format_name;
+
+//             pipeline.complete(output_format);
+//         }
+//         else
+//         {
+//             pipeline.setProgressCallback(context->getProgressCallback());
+//         }
+
+//         if (set_result_details)
+//         {
+//             /// The call of set_result_details itself might throw exception,
+//             /// in such case there's no need to call this function again in the SCOPE_EXIT defined above.
+//             /// So the callback is cleared before its execution.
+//             auto set_result_details_copy = set_result_details;
+//             set_result_details = nullptr;
+
+//             set_result_details_copy(result_details);
+//         }
+
+//         if (pipeline.initialized())
+//         {
+//             CompletedPipelineExecutor executor(pipeline);
+//             executor.execute();
+//         }
+//         else
+//         {
+//             /// It's possible to have queries without input and output.
+//         }
+//     }
+//     catch (...)
+//     {
+//         /// first execute on exception callback, it includes updating query_log
+//         /// otherwise closing record ('ExceptionWhileProcessing') can be not appended in query_log
+//         /// due to possible exceptions in functions called below (passed as parameter here)
+//         streams.onException();
+
+//         if (handle_exception_in_output_format)
+//         {
+//             update_format_on_exception_if_needed();
+//             if (output_format)
+//                 handle_exception_in_output_format(*output_format, format_name, context, output_format_settings);
+//         }
+//         throw;
+//     }
+
+//     streams.onFinish();
+// }
+
+void executeQuery(
+    QueryData & query_data,
+    WriteBuffer & ostr,
+    bool allow_into_outfile,
+    ContextMutablePtr context,
+    SetResultDetailsFunc set_result_details,
+    QueryFlags flags,
+    const std::optional<FormatSettings> & output_format_settings,
+    HandleExceptionInOutputFormatFunc handle_exception_in_output_format)
+{
+    QueryResultDetails result_details{
+        .query_id = context->getClientInfo().current_query_id,
+        .timezone = DateLUT::instance().getTimeZone(),
+    };
+
+    /// Set the result details in case of any exception raised during query execution
+    SCOPE_EXIT({
+        if (set_result_details == nullptr)
+            /// Either the result_details have been set in the flow below or the caller of this function does not provide this callback
+            return;
+
+        try
+        {
+            set_result_details(result_details);
+        }
+        catch (...)
+        {
+            /// This exception can be ignored.
+            /// because if the code goes here, it means there's already an exception raised during query execution,
+            /// and that exception will be propagated to outer caller,
+            /// there's no need to report the exception thrown here.
+        }
+    });
+
+    auto & ast = query_data.ast;
+    BlockIO streams;
+
+    OutputFormatPtr output_format;
+    String format_name;
+
+    auto update_format_on_exception_if_needed = [&]()
+    {
+        if (!output_format)
+        {
+            try
+            {
+                format_name = context->getDefaultFormat();
+                output_format = FormatFactory::instance().getOutputFormat(format_name, ostr, {}, context, output_format_settings);
+                if (output_format && output_format->supportsWritingException())
+                {
+                    /// Force an update of the headers before we start writing
+                    result_details.content_type = output_format->getContentType();
+                    result_details.format = format_name;
+
+                    fiu_do_on(FailPoints::execute_query_calling_empty_set_result_func_on_exception, {
+                        // it will throw std::bad_function_call
+                        set_result_details = nullptr;
+                        set_result_details(result_details);
+                    });
+
+                    if (set_result_details)
+                    {
+                        /// reset set_result_details func to avoid calling in SCOPE_EXIT()
+                        auto set_result_details_copy = set_result_details;
+                        set_result_details = nullptr;
+                        set_result_details_copy(result_details);
+                    }
+                }
+            }
+            catch (const DB::Exception & e)
+            {
+                /// Ignore this exception and report the original one
+                LOG_WARNING(getLogger("executeQuery"), getExceptionMessageAndPattern(e, true));
+            }
+        }
+    };
+
+    try
+    {
+        streams = executeQueryImpl(query_data, context, flags, QueryProcessingStage::Complete);
+    }
+    catch (...)
+    {
+        if (handle_exception_in_output_format)
+        {
+            update_format_on_exception_if_needed();
+            if (output_format)
+                handle_exception_in_output_format(*output_format, format_name, context, output_format_settings);
+        }
+        /// The timezone was already set before query was processed,
+        /// But `session_timezone` setting could be modified in the query itself, so we update the value.
+        result_details.timezone = DateLUT::instance().getTimeZone();
+        throw;
+    }
+
+    /// The timezone was already set before query was processed,
+    /// But `session_timezone` setting could be modified in the query itself, so we update the value.
+    result_details.timezone = DateLUT::instance().getTimeZone();
+
+    auto & pipeline = streams.pipeline;
+
+    std::unique_ptr<WriteBuffer> compressed_buffer;
+    try
+    {
+        if (pipeline.pushing())
+        {
+            auto pipe = getSourceFromASTInsertQuery(ast, true, pipeline.getHeader(), context, nullptr);
+            pipeline.complete(std::move(pipe));
+        }
+        else if (pipeline.pulling())
+        {
+            const ASTQueryWithOutput * ast_query_with_output = dynamic_cast<const ASTQueryWithOutput *>(ast.get());
+
+            WriteBuffer * out_buf = &ostr;
+            if (ast_query_with_output && ast_query_with_output->out_file)
+            {
+                if (!allow_into_outfile)
+                    throw Exception(ErrorCodes::INTO_OUTFILE_NOT_ALLOWED, "INTO OUTFILE is not allowed");
+
+                const auto & out_file = typeid_cast<const ASTLiteral &>(*ast_query_with_output->out_file).value.safeGet<std::string>();
+
+                std::string compression_method;
+                if (ast_query_with_output->compression)
+                {
+                    const auto & compression_method_node = ast_query_with_output->compression->as<ASTLiteral &>();
+                    compression_method = compression_method_node.value.safeGet<std::string>();
+                }
+                const auto & settings = context->getSettingsRef();
+                compressed_buffer = wrapWriteBufferWithCompressionMethod(
+                    std::make_unique<WriteBufferFromFile>(out_file, DBMS_DEFAULT_BUFFER_SIZE, O_WRONLY | O_EXCL | O_CREAT),
+                    chooseCompressionMethod(out_file, compression_method),
+                    /* compression level = */ static_cast<int>(settings.output_format_compression_level),
+                    /* zstd_window_log = */ static_cast<int>(settings.output_format_compression_zstd_window_log));
+            }
+
+            format_name = ast_query_with_output && (ast_query_with_output->format != nullptr)
+                ? getIdentifierName(ast_query_with_output->format)
+                : context->getDefaultFormat();
+
+            output_format = FormatFactory::instance().getOutputFormatParallelIfPossible(
+                format_name,
+                compressed_buffer ? *compressed_buffer : *out_buf,
+                materializeBlock(pipeline.getHeader()),
+                context,
+                output_format_settings);
+
+            output_format->setAutoFlush();
+
+            /// Save previous progress callback if any. TODO Do it more conveniently.
+            auto previous_progress_callback = context->getProgressCallback();
+
+            /// NOTE Progress callback takes shared ownership of 'out'.
+            pipeline.setProgressCallback(
+                [output_format, previous_progress_callback](const Progress & progress)
+                {
+                    if (previous_progress_callback)
+                        previous_progress_callback(progress);
+                    output_format->onProgress(progress);
+                });
 
             result_details.content_type = output_format->getContentType();
             result_details.format = format_name;

--- a/src/Interpreters/executeQuery.h
+++ b/src/Interpreters/executeQuery.h
@@ -36,22 +36,28 @@ struct QueryFlags
     bool distributed_backup_restore = false; /// If true, this query is a part of backup restore.
 };
 
-struct QueryData
+class QueryData
 {
-    ASTPtr ast;
+public:
+    QueryData() = delete;
 
-    std::unique_ptr<ReadBuffer> istr;
-    std::unique_ptr<PODArray<char>> parse_buf;
+    QueryData(
+        ReadBuffer & istr,
+        ContextMutablePtr context,
+        QueryFlags flags_ = {},
+        const QueryProcessingStage::Enum stage_ = QueryProcessingStage::Enum::Complete);
+
+    QueryData(ASTPtr ast_);
+
+    ASTPtr ast;
+    std::unique_ptr<ReadBuffer> input_buf;
 
     std::string query;
     std::string query_for_logging;
-};
 
-QueryData getQueryData(
-    ReadBuffer & istr,
-    ContextMutablePtr context,
-    QueryFlags flags = {},
-    const QueryProcessingStage::Enum stage = QueryProcessingStage::Enum::Complete);
+private:
+    std::unique_ptr<PODArray<char>> parse_buf;
+};
 
 /// Parse and execute a query.
 void executeQuery(

--- a/src/Interpreters/executeQuery.h
+++ b/src/Interpreters/executeQuery.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "Parsers/IAST_fwd.h"
 #include <Core/QueryProcessingStage.h>
 #include <Formats/FormatSettings.h>
 #include <Interpreters/Context_fwd.h>

--- a/src/Interpreters/executeQuery.h
+++ b/src/Interpreters/executeQuery.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "Parsers/IAST_fwd.h"
 #include <Core/QueryProcessingStage.h>
 #include <Formats/FormatSettings.h>
 #include <Interpreters/Context_fwd.h>
@@ -35,6 +36,19 @@ struct QueryFlags
     bool distributed_backup_restore = false; /// If true, this query is a part of backup restore.
 };
 
+struct QueryData
+{
+    ASTPtr ast;
+    std::unique_ptr<ReadBuffer> istr;
+    std::string query;
+    std::string query_for_logging;
+};
+
+QueryData getQueryData(
+    ReadBuffer & istr,
+    ContextMutablePtr context,
+    QueryFlags flags = {},
+    const QueryProcessingStage::Enum stage = QueryProcessingStage::Enum::Complete);
 
 /// Parse and execute a query.
 void executeQuery(
@@ -48,6 +62,15 @@ void executeQuery(
     HandleExceptionInOutputFormatFunc handle_exception_in_output_format = {} /// If a non-empty callback is passed, it will be called on exception with created output format.
 );
 
+void executeQuery(
+    QueryData & query_data,
+    WriteBuffer & ostr,
+    bool allow_into_outfile,
+    ContextMutablePtr context,
+    SetResultDetailsFunc set_result_details,
+    QueryFlags flags = {},
+    const std::optional<FormatSettings> & output_format_settings = std::nullopt,
+    HandleExceptionInOutputFormatFunc handle_exception_in_output_format = {});
 
 /// More low-level function for server-to-server interaction.
 /// Prepares a query for execution but doesn't execute it.

--- a/src/Interpreters/executeQuery.h
+++ b/src/Interpreters/executeQuery.h
@@ -39,7 +39,10 @@ struct QueryFlags
 struct QueryData
 {
     ASTPtr ast;
+
     std::unique_ptr<ReadBuffer> istr;
+    std::unique_ptr<PODArray<char>> parse_buf;
+
     std::string query;
     std::string query_for_logging;
 };

--- a/src/Server/HTTP/HTTPQuery.h
+++ b/src/Server/HTTP/HTTPQuery.h
@@ -15,6 +15,7 @@ struct HTTPQueryAST
     std::vector<ASTPtr> order_expressions;
 };
 
-HTTPQueryAST getHTTPQueryAST(HTMLForm & params);
+template <typename T>
+HTTPQueryAST getHTTPQueryAST(const T & params);
 
 }

--- a/src/Server/HTTP/HTTPQueryAST.cpp
+++ b/src/Server/HTTP/HTTPQueryAST.cpp
@@ -1,0 +1,104 @@
+#include "HTTPQueryAST.h"
+
+#include <Parsers/CommonParsers.h>
+#include <Parsers/ExpressionListParsers.h>
+#include <Parsers/IAST.h>
+#include <Parsers/IParser.h>
+#include <Parsers/TokenIterator.h>
+
+namespace DB
+{
+
+namespace
+{
+
+static constexpr auto kColumns = "columns";
+static constexpr auto kSelect = "select";
+static constexpr auto kWhere = "where";
+static constexpr auto kOrder = "order";
+
+template <typename T>
+ASTPtr parseExpression(const std::string & expression, const std::optional<ParserKeyword> & keyword = std::nullopt)
+{
+    ASTPtr ast;
+    Tokens tokens(expression.c_str(), expression.c_str() + expression.size());
+    IParser::Pos pos(tokens, 0, 0);
+    Expected expected;
+
+    ParserKeyword s_select(Keyword::SELECT);
+
+    if (keyword.has_value())
+        s_select.ignore(pos, expected);
+
+    T(false).parse(pos, ast, expected);
+    return ast;
+}
+
+ASTPtr parseSelect(const std::string & select)
+{
+    ParserKeyword s_select(Keyword::SELECT);
+
+    ASTPtr result;
+    Tokens tokens(select.c_str(), select.c_str() + select.size());
+    IParser::Pos pos(tokens, 0, 0);
+    Expected expected;
+
+    s_select.ignore(pos, expected);
+
+    ParserNotEmptyExpressionList(false).parse(pos, result, expected);
+    return result;
+}
+
+ASTPtr parseColumns(const std::string & columns)
+{
+    ASTPtr result;
+    Tokens tokens(columns.c_str(), columns.c_str() + columns.size());
+    IParser::Pos pos(tokens, 0, 0);
+    Expected expected;
+
+    ParserNotEmptyExpressionList(false).parse(pos, result, expected);
+    return result;
+}
+
+ASTPtr parseWhere(const std::string & where)
+{
+    ASTPtr result;
+    Tokens tokens(where.c_str(), where.c_str() + where.size());
+    IParser::Pos pos(tokens, 0, 0);
+    Expected expected;
+
+    ParserExpressionWithOptionalAlias(false).parse(pos, result, expected);
+    return result;
+}
+
+ASTPtr parseOrder(const std::string & order)
+{
+    ASTPtr result;
+    Tokens tokens(order.c_str(), order.c_str() + order.size());
+    IParser::Pos pos(tokens, 0, 0);
+    Expected expected;
+
+    ParserOrderByExpressionList().parse(pos, result, expected);
+    return result;
+}
+
+}
+
+HTTPQueryAST getHTTPQueryAST(HTMLForm & params)
+{
+    HTTPQueryAST result;
+
+    for (const auto & [key, value] : params)
+        if (key == kColumns)
+            result.select_expressions.push_back(parseColumns(value));
+        else if (key == kSelect)
+            result.select_expressions.push_back(parseSelect(value));
+        else if (key == kWhere)
+            result.where_expressions.push_back(parseWhere(value));
+        else if (key == kOrder)
+            result.order_expressions.push_back(parseOrder(value));
+
+    return result;
+}
+
+}

--- a/src/Server/HTTP/HTTPQueryAST.h
+++ b/src/Server/HTTP/HTTPQueryAST.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <optional>
+
+#include <Parsers/IAST_fwd.h>
+#include <Server/HTTP/HTMLForm.h>
+
+namespace DB
+{
+
+struct HTTPQueryAST
+{
+    std::vector<ASTPtr> select_expressions;
+    std::vector<ASTPtr> where_expressions;
+    std::vector<ASTPtr> order_expressions;
+};
+
+HTTPQueryAST getHTTPQueryAST(HTMLForm & params);
+
+}

--- a/src/Server/HTTPHandler.h
+++ b/src/Server/HTTPHandler.h
@@ -1,13 +1,14 @@
 #pragma once
 
+#include <Compression/CompressedWriteBuffer.h>
 #include <Core/Names.h>
+#include <IO/CascadeWriteBuffer.h>
+#include <Interpreters/executeQuery.h>
 #include <Server/HTTP/HTMLForm.h>
 #include <Server/HTTP/HTTPRequestHandler.h>
 #include <Server/HTTP/WriteBufferFromHTTPServerResponse.h>
 #include <Common/CurrentMetrics.h>
 #include <Common/CurrentThread.h>
-#include <IO/CascadeWriteBuffer.h>
-#include <Compression/CompressedWriteBuffer.h>
 #include <Common/re2.h>
 
 namespace CurrentMetrics
@@ -41,7 +42,13 @@ public:
 
     virtual bool customizeQueryParam(ContextMutablePtr context, const std::string & key, const std::string & value) = 0;
 
-    virtual std::string getQuery(HTTPServerRequest & request, HTMLForm & params, ContextMutablePtr context) = 0;
+    virtual std::string getQuery(HTTPServerRequest & /* request */, HTMLForm & /* params */, ContextMutablePtr /* context */) { return ""; }
+
+    virtual std::shared_ptr<QueryData>
+    getQueryAST(HTTPServerRequest & /* request */, HTMLForm & /* params */, ContextMutablePtr /* context */)
+    {
+        return nullptr;
+    }
 
 private:
     struct Output

--- a/src/Server/HTTPHandler.h
+++ b/src/Server/HTTPHandler.h
@@ -167,7 +167,7 @@ private:
 
 class DynamicQueryHandler : public HTTPHandler
 {
-protected:
+private:
     std::string param_name;
 public:
     explicit DynamicQueryHandler(IServer & server_, const std::string & param_name_ = "query", const std::optional<String>& content_type_override_ = std::nullopt);

--- a/src/Server/HTTPHandler.h
+++ b/src/Server/HTTPHandler.h
@@ -167,7 +167,7 @@ private:
 
 class DynamicQueryHandler : public HTTPHandler
 {
-private:
+protected:
     std::string param_name;
 public:
     explicit DynamicQueryHandler(IServer & server_, const std::string & param_name_ = "query", const std::optional<String>& content_type_override_ = std::nullopt);

--- a/src/Server/HTTPHandlerFactory.cpp
+++ b/src/Server/HTTPHandlerFactory.cpp
@@ -14,6 +14,7 @@
 #include "InterserverIOHTTPHandler.h"
 #include "PrometheusRequestHandler.h"
 #include "WebUIRequestHandler.h"
+#include "TabularHandler.h"
 
 
 namespace DB
@@ -255,6 +256,12 @@ void addCommonDefaultHandlersFactory(HTTPRequestHandlerFactoryMain & factory, IS
     js_handler->attachNonStrictPath("/js/");
     js_handler->allowGetAndHeadRequest();
     factory.addHandler(js_handler);
+
+    auto tabular_handler = std::make_shared<HandlingRuleHTTPHandlerFactory<TabularHandler>>(server);
+    tabular_handler->attachNonStrictPath("/tabular");
+    tabular_handler->allowGetAndHeadRequest();
+    factory.addPathToHints("/tabular");
+    factory.addHandler(tabular_handler);
 }
 
 void addDefaultHandlersFactory(

--- a/src/Server/TabularHandler.cpp
+++ b/src/Server/TabularHandler.cpp
@@ -1,0 +1,98 @@
+#include "TabularHandler.h"
+#include "Parsers/ASTAsterisk.h"
+#include "Parsers/ASTExpressionList.h"
+#include "Parsers/ASTIdentifier.h"
+#include "Parsers/ASTTablesInSelectQuery.h"
+#include "Interpreters/executeQuery.h"
+
+#include <Parsers/ASTSelectQuery.h>
+#include "Parsers/ExpressionListParsers.h"
+#include "Parsers/formatAST.h"
+
+#include <optional>
+#include <string>
+#include <vector>
+
+#include <Interpreters/Context.h>
+#include <Poco/URI.h>
+
+namespace DB
+{
+
+static const std::unordered_set<std::string> kQueryParameters = {"where", "columns", "select", "order", "format", "query"};
+static constexpr auto kWhere = "where";
+
+TabularHandler::TabularHandler(IServer & server_, const std::optional<String> & content_type_override_)
+    : HTTPHandler(server_, "TabularHandler", content_type_override_), log(getLogger("TabularHandler"))
+{
+}
+
+std::string TabularHandler::getQuery(HTTPServerRequest & request, HTMLForm & /*params*/, ContextMutablePtr context)
+{
+    auto uri = Poco::URI(request.getURI());
+
+    std::vector<std::string> path_segments;
+    uri.getPathSegments(path_segments);
+
+    const auto database = path_segments[1];
+    const auto table_with_format = path_segments[2];
+
+    auto pos = table_with_format.rfind('.');
+    std::string table = table_with_format.substr(0, pos);
+    std::string format = table_with_format.substr(pos + 1);
+
+    auto select_query = std::make_shared<ASTSelectQuery>();
+
+    auto select_expression_list = std::make_shared<ASTExpressionList>();
+    select_expression_list->children.push_back(std::make_shared<ASTAsterisk>());
+    select_query->setExpression(ASTSelectQuery::Expression::SELECT, select_expression_list);
+
+    auto table_expression = std::make_shared<ASTTableExpression>();
+    table_expression->database_and_table_name = std::make_shared<ASTTableIdentifier>(database, table);
+    auto tables_in_select_query = std::make_shared<ASTTablesInSelectQuery>();
+    auto tables_in_select_element = std::make_shared<ASTTablesInSelectQueryElement>();
+    tables_in_select_element->table_expression = table_expression;
+    tables_in_select_query->children.push_back(tables_in_select_element);
+    select_query->setExpression(ASTSelectQuery::Expression::TABLES, tables_in_select_query);
+
+    const auto & query_parameters = context->getQueryParameters();
+
+    if (query_parameters.contains(kWhere))
+    {
+        const auto & where_raw = query_parameters.at(kWhere);
+        ASTPtr where_expression;
+        Tokens tokens(where_raw.c_str(), where_raw.c_str() + where_raw.size());
+        IParser::Pos new_pos(tokens, 0, 0);
+        Expected expected;
+
+        ParserExpressionWithOptionalAlias(false).parse(new_pos, where_expression, expected);
+        select_query->setExpression(ASTSelectQuery::Expression::WHERE, std::move(where_expression));
+    }
+
+    // Convert AST to query string
+    WriteBufferFromOwnString query_buffer;
+    formatAST(*select_query, query_buffer, false);
+    std::string query_str = query_buffer.str();
+
+    // Append FORMAT clause
+    query_str += " FORMAT " + format;
+
+    LOG_INFO(log, "TabularHandler LOG {}", query_str);
+
+    return query_str;
+    // LOG_INFO(log, "TabularHandler LOG {}", request.getURI());
+}
+
+
+bool TabularHandler::customizeQueryParam(ContextMutablePtr context, const std::string & key, const std::string & value)
+{
+    if (kQueryParameters.contains(key) && !context->getQueryParameters().contains(key))
+    {
+        context->setQueryParameter(key, value);
+        return true;
+    }
+
+    return false;
+}
+
+} // namespace DB

--- a/src/Server/TabularHandler.cpp
+++ b/src/Server/TabularHandler.cpp
@@ -14,7 +14,7 @@
 #include <Parsers/formatAST.h>
 
 #include <Interpreters/Context.h>
-#include <Server/HTTP/HTTPQueryAST.h>
+#include <Server/HTTP/HTTPQuery.h>
 #include <Poco/URI.h>
 
 namespace DB

--- a/src/Server/TabularHandler.cpp
+++ b/src/Server/TabularHandler.cpp
@@ -1,92 +1,100 @@
 #include "TabularHandler.h"
-#include "Parsers/ASTAsterisk.h"
-#include "Parsers/ASTExpressionList.h"
-#include "Parsers/ASTIdentifier.h"
-#include "Parsers/ASTTablesInSelectQuery.h"
-#include "Interpreters/executeQuery.h"
 
-#include <Parsers/ASTSelectQuery.h>
-#include "Parsers/ExpressionListParsers.h"
-#include "Parsers/formatAST.h"
-
-#include <optional>
 #include <string>
+#include <unordered_set>
 #include <vector>
 
+#include <Parsers/ASTAsterisk.h>
+#include <Parsers/ASTExpressionList.h>
+#include <Parsers/ASTIdentifier.h>
+#include <Parsers/ASTTablesInSelectQuery.h>
+
+#include <Parsers/ASTSelectQuery.h>
+#include <Parsers/ExpressionListParsers.h>
+#include <Parsers/formatAST.h>
+
 #include <Interpreters/Context.h>
+#include <Server/HTTP/HTTPQueryAST.h>
 #include <Poco/URI.h>
 
 namespace DB
 {
 
-static const std::unordered_set<std::string> kQueryParameters = {"where", "columns", "select", "order", "format", "query"};
-static constexpr auto kWhere = "where";
+static constexpr auto kFormat = "format";
 
 TabularHandler::TabularHandler(IServer & server_, const std::optional<String> & content_type_override_)
-    : HTTPHandler(server_, "TabularHandler", content_type_override_), log(getLogger("TabularHandler"))
+    : HTTPHandler(server_, "TabularHandler", content_type_override_)
 {
 }
 
-std::string TabularHandler::getQuery(HTTPServerRequest & request, HTMLForm & /*params*/, ContextMutablePtr context)
+std::shared_ptr<QueryData> TabularHandler::getQueryAST(HTTPServerRequest & request, HTMLForm & params, ContextMutablePtr context)
 {
     auto uri = Poco::URI(request.getURI());
 
     std::vector<std::string> path_segments;
     uri.getPathSegments(path_segments);
 
-    const auto database = path_segments[1];
-    const auto table_with_format = path_segments[2];
+    std::string database = "default";
+    std::string table_with_format;
 
-    auto pos = table_with_format.rfind('.');
-    std::string table = table_with_format.substr(0, pos);
-    std::string format = table_with_format.substr(pos + 1);
+    if (path_segments.size() == 3)
+    {
+        database = path_segments[1];
+        table_with_format = path_segments[2];
+    }
+    else
+    {
+        table_with_format = path_segments[1];
+    }
+
+    std::string format = "";
+    std::string table;
+
+    auto pos = table_with_format.find('.');
+    if (pos != std::string::npos)
+    {
+        table = table_with_format.substr(0, pos);
+        format = table_with_format.substr(pos + 1);
+    }
+    else
+    {
+        table = table_with_format;
+    }
 
     auto select_query = std::make_shared<ASTSelectQuery>();
 
-    auto select_expression_list = std::make_shared<ASTExpressionList>();
-    select_expression_list->children.push_back(std::make_shared<ASTAsterisk>());
-    select_query->setExpression(ASTSelectQuery::Expression::SELECT, select_expression_list);
+    const auto & query_parameters = context->getQueryParameters();
+
+    if (query_parameters.contains(kFormat))
+        format = query_parameters.at(kFormat);
+
+    auto http_query_ast = getHTTPQueryAST(params);
+    if (http_query_ast.select_expressions.empty())
+    {
+        auto select_expression_list = std::make_shared<ASTExpressionList>();
+        select_expression_list->children.push_back(std::make_shared<ASTAsterisk>());
+        select_query->setExpression(ASTSelectQuery::Expression::SELECT, std::move(select_expression_list));
+    }
+
+    auto tables_in_select_query = std::make_shared<ASTTablesInSelectQuery>();
+    auto tables_in_select_element = std::make_shared<ASTTablesInSelectQueryElement>();
 
     auto table_expression = std::make_shared<ASTTableExpression>();
     table_expression->database_and_table_name = std::make_shared<ASTTableIdentifier>(database, table);
-    auto tables_in_select_query = std::make_shared<ASTTablesInSelectQuery>();
-    auto tables_in_select_element = std::make_shared<ASTTablesInSelectQueryElement>();
-    tables_in_select_element->table_expression = table_expression;
-    tables_in_select_query->children.push_back(tables_in_select_element);
-    select_query->setExpression(ASTSelectQuery::Expression::TABLES, tables_in_select_query);
 
-    const auto & query_parameters = context->getQueryParameters();
+    tables_in_select_element->table_expression = std::move(table_expression);
+    tables_in_select_query->children.push_back(std::move(tables_in_select_element));
+    select_query->setExpression(ASTSelectQuery::Expression::TABLES, std::move(tables_in_select_query));
 
-    if (query_parameters.contains(kWhere))
-    {
-        const auto & where_raw = query_parameters.at(kWhere);
-        ASTPtr where_expression;
-        Tokens tokens(where_raw.c_str(), where_raw.c_str() + where_raw.size());
-        IParser::Pos new_pos(tokens, 0, 0);
-        Expected expected;
+    context->setDefaultFormat(format);
 
-        ParserExpressionWithOptionalAlias(false).parse(new_pos, where_expression, expected);
-        select_query->setExpression(ASTSelectQuery::Expression::WHERE, std::move(where_expression));
-    }
-
-    // Convert AST to query string
-    WriteBufferFromOwnString query_buffer;
-    formatAST(*select_query, query_buffer, false);
-    std::string query_str = query_buffer.str();
-
-    // Append FORMAT clause
-    query_str += " FORMAT " + format;
-
-    LOG_INFO(log, "TabularHandler LOG {}", query_str);
-
-    return query_str;
-    // LOG_INFO(log, "TabularHandler LOG {}", request.getURI());
+    return std::make_shared<QueryData>(select_query);
 }
 
 
 bool TabularHandler::customizeQueryParam(ContextMutablePtr context, const std::string & key, const std::string & value)
 {
-    if (kQueryParameters.contains(key) && !context->getQueryParameters().contains(key))
+    if (key == kFormat && !context->getQueryParameters().contains(key))
     {
         context->setQueryParameter(key, value);
         return true;

--- a/src/Server/TabularHandler.h
+++ b/src/Server/TabularHandler.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <optional>
+#include <string>
+
+#include <Interpreters/Context_fwd.h>
+#include <Server/HTTPHandler.h>
+#include <Poco/Logger.h>
+
+namespace DB
+{
+
+class TabularHandler : public HTTPHandler
+{
+private:
+    LoggerPtr log;
+
+    std::optional<std::string> where;
+
+public:
+    TabularHandler(IServer & server_, const std::optional<String> & content_type_override_ = std::nullopt);
+
+    std::string getQuery(HTTPServerRequest & request, HTMLForm & params, ContextMutablePtr context) override;
+
+    bool customizeQueryParam(ContextMutablePtr context, const std::string & key, const std::string & value) override;
+};
+
+}

--- a/src/Server/TabularHandler.h
+++ b/src/Server/TabularHandler.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 #include <optional>
 #include <string>
 
@@ -12,15 +13,10 @@ namespace DB
 
 class TabularHandler : public HTTPHandler
 {
-private:
-    LoggerPtr log;
-
-    std::optional<std::string> where;
-
 public:
     TabularHandler(IServer & server_, const std::optional<String> & content_type_override_ = std::nullopt);
 
-    std::string getQuery(HTTPServerRequest & request, HTMLForm & params, ContextMutablePtr context) override;
+    std::shared_ptr<QueryData> getQueryAST(HTTPServerRequest & request, HTMLForm & params, ContextMutablePtr context) override;
 
     bool customizeQueryParam(ContextMutablePtr context, const std::string & key, const std::string & value) override;
 };

--- a/tests/integration/test_http_tabular_handler/test.py
+++ b/tests/integration/test_http_tabular_handler/test.py
@@ -1,0 +1,150 @@
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+
+
+cluster = ClickHouseCluster(__file__)
+instance = cluster.add_instance("instance")
+
+URL_PREFIX = "tabular"
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_nodes():
+    try:
+        cluster.start()
+
+        instance.http_query(
+            """
+            CREATE TABLE
+                number (a UInt8, b UInt8)
+            ENGINE = Memory
+            """,
+            method="POST",
+        )
+        instance.http_query(
+            """
+            INSERT INTO
+                number
+            VALUES
+                (1, 2), (1, 3), (2, 3),
+                (2, 1), (3, 4), (3, 1), (3, 5)
+            """,
+            method="POST",
+        )
+
+        yield cluster
+
+    finally:
+        cluster.shutdown()
+
+
+def test_happy_result():
+    response = instance.http_request(
+        url=f"{URL_PREFIX}/number.csv", params={"limit": 3}
+    )
+
+    assert response.status_code == 200
+    assert response.content == b"1,2\n1,3\n2,3\n"
+
+
+@pytest.mark.parametrize(
+    ["url", "params", "sql_query"],
+    [
+        pytest.param(
+            "number.csv",
+            {"limit": 3},
+            "SELECT * FROM number LIMIT 3 FORMAT CSV",
+            id="default",
+        ),
+        pytest.param(
+            "system/numbers.tsv",
+            {"limit": 10},
+            "SELECT * FROM system.numbers LIMIT 10 FORMAT TSV",
+            id="database",
+        ),
+        pytest.param(
+            "default/number",
+            {"limit": 10, "format": "tsv"},
+            "SELECT * FROM number LIMIT 10 FORMAT TSV",
+            id="no format",
+        ),
+        pytest.param(
+            "number",
+            {"columns": "a"},
+            "SELECT a FROM number",
+            id="one column",
+        ),
+        pytest.param(
+            "number",
+            {"columns": "a", "select": "SELECT b +  11"},
+            "SELECT a, b + 11 FROM number",
+            id="two columns",
+        ),
+        pytest.param(
+            "number",
+            {"columns": "a", "select": "SELECT b +  11", "where": "a>1 AND b<=3"},
+            "SELECT a, b + 11 FROM number WHERE a > 1 AND b <= 3",
+            id="where",
+        ),
+        pytest.param(
+            "number",
+            {
+                "columns": "a",
+                "select": "SELECT b +  11",
+                "where": "a>1 AND b<=3",
+                "order": "a DESC, b ASC",
+            },
+            "SELECT a, b + 11 FROM number WHERE a > 1 AND b <= 3 ORDER BY a DESC, b",
+            id="order by",
+        ),
+    ],
+)
+def test_scenarios(url, params, sql_query):
+    response = instance.http_request(
+        url=f"{URL_PREFIX}/{url}",
+        params=params,
+    )
+    response.encoding = "UTF-8"
+
+    expected_response = instance.http_query(sql_query, method="POST")
+
+    assert response.status_code == 200
+    assert response.text == expected_response
+
+
+@pytest.mark.parametrize(
+    ["query", "params", "sql_query"],
+    [
+        pytest.param("SELECT * FROM number", {}, "SELECT * FROM number", id="default"),
+        pytest.param(
+            "SELECT a FROM number",
+            {"columns": "b", "limit": 3},
+            "SELECT a, b FROM number LIMIT 3",
+            id="columns",
+        ),
+        pytest.param(
+            "SELECT a FROM number",
+            {"select": "SELECT a * b, a + b, a / b, 5"},
+            "SELECT a, a * b, a + b, a / b, 5 FROM number",
+            id="select",
+        ),
+        pytest.param(
+            "SELECT * FROM number WHERE a > 1",
+            {"where": "b <= 3"},
+            "SELECT * FROM number WHERE a > 1 AND b <= 3",
+            id="where",
+        ),
+        pytest.param(
+            "SELECT * FROM number WHERE a > 1 ORDER BY a ASC",
+            {"where": "b <= 10", "order": "b DESC"},
+            "SELECT * FROM number WHERE a > 1 AND b <= 10 ORDER BY a ASC, b DESC",
+            id="order by",
+        ),
+    ],
+)
+def test_combining_params(query, params, sql_query):
+    response = instance.http_query(query, params=params, method="POST")
+    expected_response = instance.http_query(sql_query, method="POST")
+
+    assert response == expected_response


### PR DESCRIPTION
### Changelog category:
- New Feature

### Changelog entry:

Added a new handler with `tabular` prefix, which supports accessing tables as files. The URL path contains the name of the database, tables, and an optional format

Added combining HTTP requests with query parameters such as `where`, `select`, etc

Added new parameter  `execute`, which indicates whether the request should be executed or returned in text format

### Documentation entry for user-facing changes

Queries like `tabular/database/table.csv` are now supported, which are equal to the SQL query `SELECT * FROM database.table FORMAT CSV`

Additional parameters can be specified in the path, such as `select`, `columns`, `where`, `order`, which are combined with the query. For example `tabular/table?columns=a,b&where=a>1&order=a ASC, b DESC` is equel to `SELECT a,b FROM table WHERE a > 1 ORDER BY a ASC, b DESC`.

Also support column names in query as filters (only `=` and `>=`/`<=` operations) like `?a=2&b<=3&c>=5`

Resolves #46925 

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

<details>
    <summary>CI Settings</summary>

**NOTE:** If your merge the PR with modified CI you **MUST KNOW** what you are doing
**NOTE:** Checked options will be applied if set before CI RunConfig/PrepareRunConfig step

#### Run these jobs only (required builds will be added automatically):
- [ ] <!---ci_include_integration--> Integration Tests
- [ ] <!---ci_include_stateless--> Stateless tests
- [ ] <!---ci_include_stateful--> Stateful tests
- [ ] <!---ci_include_unit--> Unit tests
- [ ] <!---ci_include_performance--> Performance tests
- [ ] <!---ci_include_aarch64--> All with aarch64
- [ ] <!---ci_include_asan--> All with ASAN
- [ ] <!---ci_include_tsan--> All with TSAN
- [ ] <!---ci_include_analyzer--> All with Analyzer
- [ ] <!---ci_include_azure --> All with Azure
- [ ] <!---ci_include_KEYWORD--> Add your option here

#### Deny these jobs:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [ ] <!---ci_exclude_tsan--> All with TSAN
- [ ] <!---ci_exclude_msan--> All with MSAN
- [ ] <!---ci_exclude_ubsan--> All with UBSAN
- [ ] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64--> All with Aarch64

#### Extra options:
- [ ] <!---do_not_test--> do not test (only style check)
- [ ] <!---no_merge_commit--> disable merge-commit (no merge from master before tests)
- [ ] <!---no_ci_cache--> disable CI cache (job reuse)

#### Only specified batches in multi-batch jobs:
- [ ] <!---batch_0--> 1
- [ ] <!---batch_1--> 2
- [ ] <!---batch_2--> 3
- [ ] <!---batch_3--> 4

</details>
