### PR TITLE
Rename aggregate_function_group_array_has_limit_size

### DIFF
--- a/src/Core/ServerSettings.h
+++ b/src/Core/ServerSettings.h
@@ -3,6 +3,7 @@
 
 #include <Core/BaseSettings.h>
 #include <Core/Defines.h>
+#include <Core/SettingsEnums.h>
 
 
 namespace Poco::Util
@@ -51,7 +52,7 @@ namespace DB
     M(UInt64, max_temporary_data_on_disk_size, 0, "The maximum amount of storage that could be used for external aggregation, joins or sorting., ", 0) \
     M(String, temporary_data_in_cache, "", "Cache disk name for temporary data.", 0) \
     M(UInt64, aggregate_function_group_array_max_element_size, 0xFFFFFF, "Max array element size in bytes for groupArray function. This limit is checked at serialization and help to avoid large state size.", 0) \
-    M(Bool, aggregate_function_group_array_has_limit_size, false, "When the max array element size is exceeded, a `Too large array size` exception will be thrown by default. When set to true, no exception will be thrown, and the excess elements will be discarded.", 0) \
+    M(GroupArrayActionWhenLimitReached, aggregate_function_group_array_action_when_limit_is_reached, GroupArrayActionWhenLimitReached::THROW, "Action to execute when max array element size is exceeded in groupArray: `throw` exception, or `discard` extra values", 0) \
     M(UInt64, max_server_memory_usage, 0, "Maximum total memory usage of the server in bytes. Zero means unlimited.", 0) \
     M(Double, max_server_memory_usage_to_ram_ratio, 0.9, "Same as max_server_memory_usage but in to RAM ratio. Allows to lower max memory on low-memory systems.", 0) \
     M(UInt64, merges_mutations_memory_usage_soft_limit, 0, "Maximum total memory usage for merges and mutations in bytes. Zero means unlimited.", 0) \

--- a/src/Core/SettingsEnums.cpp
+++ b/src/Core/SettingsEnums.cpp
@@ -229,4 +229,9 @@ IMPLEMENT_SETTING_ENUM(SQLSecurityType, ErrorCodes::BAD_ARGUMENTS,
     {{"DEFINER", SQLSecurityType::DEFINER},
      {"INVOKER", SQLSecurityType::INVOKER},
      {"NONE", SQLSecurityType::NONE}})
+
+IMPLEMENT_SETTING_ENUM(
+    GroupArrayActionWhenLimitReached,
+    ErrorCodes::BAD_ARGUMENTS,
+    {{"throw", GroupArrayActionWhenLimitReached::THROW}, {"discard", GroupArrayActionWhenLimitReached::DISCARD}})
 }

--- a/src/Core/SettingsEnums.h
+++ b/src/Core/SettingsEnums.h
@@ -370,4 +370,12 @@ DECLARE_SETTING_ENUM(SchemaInferenceMode)
 DECLARE_SETTING_ENUM_WITH_RENAME(DateTimeOverflowBehavior, FormatSettings::DateTimeOverflowBehavior)
 
 DECLARE_SETTING_ENUM(SQLSecurityType)
+
+enum class GroupArrayActionWhenLimitReached : uint8_t
+{
+    THROW,
+    DISCARD
+};
+DECLARE_SETTING_ENUM(GroupArrayActionWhenLimitReached)
+
 }

--- a/tests/integration/test_group_array_element_size/configs/group_array_max_element_size.xml
+++ b/tests/integration/test_group_array_element_size/configs/group_array_max_element_size.xml
@@ -1,4 +1,4 @@
 <clickhouse>
     <aggregate_function_group_array_max_element_size>10</aggregate_function_group_array_max_element_size>
-    <aggregate_function_group_array_has_limit_size>false</aggregate_function_group_array_has_limit_size>
+    <aggregate_function_group_array_action_when_limit_is_reached>throw</aggregate_function_group_array_action_when_limit_is_reached>
 </clickhouse>

--- a/tests/integration/test_group_array_element_size/test.py
+++ b/tests/integration/test_group_array_element_size/test.py
@@ -80,8 +80,8 @@ def test_limit_size(started_cluster):
 
     node2.replace_in_config(
         "/etc/clickhouse-server/config.d/group_array_max_element_size.xml",
-        "false",
-        "true",
+        "throw",
+        "discard",
     )
 
     node2.restart_clickhouse()
@@ -91,8 +91,8 @@ def test_limit_size(started_cluster):
 
     node2.replace_in_config(
         "/etc/clickhouse-server/config.d/group_array_max_element_size.xml",
-        "true",
-        "false",
+        "discard",
+        "throw",
     )
 
     node2.restart_clickhouse()


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Changed the unreleased setting `aggregate_function_group_array_has_limit_size` to `aggregate_function_group_array_action_when_limit_is_reached`.

### Documentation entry for user-facing changes

Introduced in https://github.com/ClickHouse/ClickHouse/pull/63516 and unreleased.