### PR TITLE
Fix Logical error: Bad cast for Buffer table with prewhere.

### DIFF
--- a/src/Storages/StorageBuffer.cpp
+++ b/src/Storages/StorageBuffer.cpp
@@ -302,6 +302,8 @@ void StorageBuffer::read(
                 auto src_table_query_info = query_info;
                 if (src_table_query_info.prewhere_info)
                 {
+                    src_table_query_info.prewhere_info = src_table_query_info.prewhere_info->clone();
+
                     auto actions_dag = ActionsDAG::makeConvertingActions(
                             header_after_adding_defaults.getColumnsWithTypeAndName(),
                             header.getColumnsWithTypeAndName(),

--- a/tests/queries/0_stateless/00910_buffer_prewhere_different_types.sql
+++ b/tests/queries/0_stateless/00910_buffer_prewhere_different_types.sql
@@ -2,7 +2,13 @@ DROP TABLE IF EXISTS buffer_table1__fuzz_28;
 DROP TABLE IF EXISTS merge_tree_table1;
 
 CREATE TABLE merge_tree_table1 (`x` UInt32) ENGINE = MergeTree ORDER BY x;
+
+CREATE TABLE buffer_table1__fuzz_24 (`s` Nullable(Int128), `x` Nullable(FixedString(17))) ENGINE = Buffer(currentDatabase(), 'merge_tree_table1', 16, 10, 60, 10, 1000, 1048576, 2097152);
+SELECT s FROM buffer_table1__fuzz_24 PREWHERE factorial(toNullable(10)); -- { serverError ILLEGAL_TYPE_OF_COLUMN_FOR_FILTER }
+
 INSERT INTO merge_tree_table1 VALUES (1), (2), (3), (4), (5), (6), (7), (8), (9), (10);
+
+SELECT s FROM buffer_table1__fuzz_24 PREWHERE factorial(toNullable(10)); -- { serverError ILLEGAL_TYPE_OF_COLUMN_FOR_FILTER }
 
 SET send_logs_level='error';
 


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix `Logical error: Bad cast` for `Buffer` table with `PREWHERE`

Fixes #64172