### PR TITLE
Reduce the redundant `isDefault()` of `ColumnSparse::filter` to improve performance

### DIFF
--- a/src/Columns/ColumnSparse.cpp
+++ b/src/Columns/ColumnSparse.cpp
@@ -323,7 +323,9 @@ ColumnPtr ColumnSparse::filter(const Filter & filt, ssize_t) const
 
     size_t res_offset = 0;
     auto offset_it = begin();
-    for (size_t i = 0; i < _size; ++i, ++offset_it)
+    /// Replace the `++offset_it` with `offset_it.increaseCurrentRow()` and `offset_it.increaseCurrentOffset()`,
+    /// to remove the redundant `isDefault()` in `++` of `Interator` and reuse the following `isDefault()`.
+    for (size_t i = 0; i < _size; ++i, offset_it.increaseCurrentRow())
     {
         if (!offset_it.isDefault())
         {
@@ -338,6 +340,7 @@ ColumnPtr ColumnSparse::filter(const Filter & filt, ssize_t) const
             {
                 values_filter.push_back(0);
             }
+            offset_it.increaseCurrentOffset();
         }
         else
         {

--- a/src/Columns/ColumnSparse.h
+++ b/src/Columns/ColumnSparse.h
@@ -186,6 +186,8 @@ public:
         size_t ALWAYS_INLINE getValueIndex() const { return isDefault() ? 0 : current_offset + 1; }
         size_t ALWAYS_INLINE getCurrentRow() const { return current_row; }
         size_t ALWAYS_INLINE getCurrentOffset() const { return current_offset; }
+        size_t ALWAYS_INLINE increaseCurrentRow() { return ++current_row; }
+        size_t ALWAYS_INLINE increaseCurrentOffset() { return ++current_offset; }
 
         bool operator==(const Iterator & other) const
         {

--- a/tests/performance/sparse_column_filter.xml
+++ b/tests/performance/sparse_column_filter.xml
@@ -1,0 +1,42 @@
+<test>
+    <substitutions>
+        <substitution>
+            <name>serialization</name>
+            <values>
+                <value>sparse</value>
+            </values>
+        </substitution>
+        <substitution>
+            <name>ratio</name>
+            <values>
+                <value>10</value>
+                <value>100</value>
+                <value>1000</value>
+            </values>
+        </substitution>
+    </substitutions>
+
+    <create_query>
+        CREATE TABLE test_{serialization}_{ratio} (id UInt64, u8 UInt8, u64 UInt64, str String)
+        ENGINE = MergeTree ORDER BY id
+        SETTINGS ratio_of_defaults_for_sparse_serialization = 0.8
+    </create_query>
+
+    <create_query>SYSTEM STOP MERGES test_{serialization}_{ratio}</create_query>
+
+    <fill_query>
+        INSERT INTO test_{serialization}_{ratio} SELECT
+            number,
+            number % {ratio} = 0 ? rand(1) : 0,
+            number % {ratio} = 0 ? rand(2) : 0,
+            number % {ratio} = 0 ? randomPrintableASCII(64, 3) : ''
+        FROM numbers(100000000)
+    </fill_query>
+
+    <query>SELECT str, COUNT(DISTINCT id) as i FROM test_{serialization}_{ratio} WHERE notEmpty(str) GROUP BY str ORDER BY i DESC LIMIT 10</query>
+    <query>SELECT str, COUNT(DISTINCT u8) as u FROM test_{serialization}_{ratio} WHERE notEmpty(str) GROUP BY str ORDER BY u DESC LIMIT 10</query>
+    <query>SELECT str, COUNT(DISTINCT u64) as u FROM test_{serialization}_{ratio} WHERE notEmpty(str) GROUP BY str ORDER BY u DESC LIMIT 10</query>
+
+
+    <drop_query>DROP TABLE IF EXISTS test_{serialization}_{ratio}</drop_query>
+</test>


### PR DESCRIPTION
We have found that Q10 of ClickBench has cost more than 30% cycles on the `ColumnSparse::filter`.
![image](https://github.com/ClickHouse/ClickHouse/assets/49742809/6c9808d8-8827-4201-ba60-e6eaa7fd8369)

By investigating asm in the hotspot, most of the hotspot in `ColumnSparse::filter` is the method `isDefault()` in the Iterator. But there are twice `isDefault()` in the `for loop` -- `!offset_it.isDefault()` and another in the `++offset_it`.

The idea of the patch is to reduce the redundant `isDefault()`. Replace the `++offset_it` with `offset_it.increaseCurrentRow()` and `offset_it.increaseCurrentOffset()`, to remove the redundant `isDefault()` in `++` of `Interator` and reuse the following `isDefault()`.

Test the patch with Q10 of ClickBench on 80x2 vCPUs and the QPS has got **9.6%** performance gain.
The total cycles has reduced to **79.2%** and the cycles of `ColumnSparse::filter` has reduced to **46.4%**.
Besides, Q7, Q11, Q20 of ClickBench has got **7.3%, 8.7%, 7.3%** performance improvement and overall geomean has got **2.4%** gain.

<html xmlns:v="urn:schemas-microsoft-com:vml"
xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=Excel.Sheet>
<meta name=Generator content="Microsoft Excel 15">
<link id=Main-File rel=Main-File
href="file:///C:/Users/jiebinsu/AppData/Local/Temp/msohtmlclip1/01/clip.htm">
<link rel=File-List
href="file:///C:/Users/jiebinsu/AppData/Local/Temp/msohtmlclip1/01/clip_filelist.xml">
<style>
<!--table
	{mso-displayed-decimal-separator:"\.";
	mso-displayed-thousand-separator:"\,";}
@page
	{margin:.75in .7in .75in .7in;
	mso-header-margin:.3in;
	mso-footer-margin:.3in;}
tr
	{mso-height-source:auto;}
col
	{mso-width-source:auto;}
br
	{mso-data-placement:same-cell;}
td
	{padding-top:1px;
	padding-right:1px;
	padding-left:1px;
	mso-ignore:padding;
	color:black;
	font-size:11.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:Calibri, sans-serif;
	mso-font-charset:0;
	mso-number-format:General;
	text-align:general;
	vertical-align:bottom;
	border:none;
	mso-background-source:auto;
	mso-pattern:auto;
	mso-protection:locked visible;
	white-space:nowrap;
	mso-rotate:0;}
.xl65
	{border:.5pt solid windowtext;}
.xl66
	{mso-number-format:"0\.0%";
	border:.5pt solid windowtext;}
-->
</style>
</head>

<body link="#0563C1" vlink="#954F72">


QPS   (opt/base) | 109.6%
-- | --
CYCLES   (opt/base) | 79.2%
INSTRUCTIONS   (opt/base) | 81.5%
`FILTER`   CYCLES (opt/base) | 46.4%
`FILTER`   INSTRUCTIONS (opt/base) | 66.3%



</body>

</html>






<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Reduce redundant calls to `isDefault()` of `ColumnSparse::filter` to improve performance

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

<details>
    <summary>CI Settings</summary>

**NOTE:** If your merge the PR with modified CI you **MUST KNOW** what you are doing
**NOTE:** Checked options will be applied if set before CI RunConfig/PrepareRunConfig step
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_unit--> Allow: Unit tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_include_aarch64--> Allow: All with aarch64
- [ ] <!---ci_include_asan--> Allow: All with ASAN
- [ ] <!---ci_include_tsan--> Allow: All with TSAN
- [ ] <!---ci_include_analyzer--> Allow: All with Analyzer
- [ ] <!---ci_include_azure --> Allow: All with Azure
- [ ] <!---ci_include_KEYWORD--> Allow: Add your option here
---
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_integration--> Exclude: Integration Tests
- [ ] <!---ci_exclude_stateless--> Exclude: Stateless tests
- [ ] <!---ci_exclude_stateful--> Exclude: Stateful tests
- [ ] <!---ci_exclude_performance--> Exclude: Performance tests
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan--> Exclude: All with TSAN
- [ ] <!---ci_exclude_msan--> Exclude: All with MSAN
- [ ] <!---ci_exclude_ubsan--> Exclude: All with UBSAN
- [ ] <!---ci_exclude_coverage--> Exclude: All with Coverage
- [ ] <!---ci_exclude_aarch64--> Exclude: All with Aarch64
---
- [ ] <!---do_not_test--> do not test (only style check)
- [ ] <!---no_merge_commit--> disable merge-commit (no merge from master before tests)
- [ ] <!---no_ci_cache--> disable CI cache (job reuse)
- [ ] <!---batch_0--> allow: batch 1 for multi-batch jobs
- [ ] <!---batch_1--> allow: batch 2
- [ ] <!---batch_2--> allow: batch 3
- [ ] <!---batch_3_4_5--> allow: batch 4, 5 and 6
</details>
