### PR TITLE
CI: fix build_report selection in case of job reuse

### DIFF
--- a/tests/ci/report.py
+++ b/tests/ci/report.py
@@ -401,30 +401,40 @@ class BuildResult:
     @classmethod
     def load_any(cls, build_name: str, pr_number: int, head_ref: str):  # type: ignore
         """
-        loads report from suitable report file with the following priority:
-            1. report from PR with the same @pr_number
-            2. report from branch with the same @head_ref
-            3. report from the master
-            4. any other report
+        loads build report from one of all available report files (matching the job digest)
+        with the following priority:
+            1. report for the current PR @pr_number (might happen in PR' wf with or without job reuse)
+            2. report for the current branch @head_ref (might happen in release/master' wf with or without job reuse)
+            3. report for master branch (might happen in any workflow in case of job reuse)
+            4. any other report (job reuse from another PR, if master report is not available yet)
         """
-        reports = []
+        pr_report = None
+        ref_report = None
+        master_report = None
+        any_report = None
         for file in Path(REPORT_PATH).iterdir():
             if f"{build_name}.json" in file.name:
-                reports.append(file)
-        if not reports:
-            return None
-        file_path = None
-        for file in reports:
-            if pr_number and f"_{pr_number}_" in file.name:
-                file_path = file
-                break
-            if f"_{head_ref}_" in file.name:
-                file_path = file
-                break
+                any_report = file
             if "_master_" in file.name:
-                file_path = file
-                break
-        return cls.load_from_file(file_path or reports[-1])
+                master_report = file
+            elif f"_{head_ref}_" in file.name:
+                ref_report = file
+            elif pr_number and f"_{pr_number}_" in file.name:
+                pr_report = file
+
+        if not any_report:
+            return None
+
+        if pr_report:
+            file_path = pr_report
+        elif ref_report:
+            file_path = ref_report
+        elif master_report:
+            file_path = master_report
+        else:
+            file_path = any_report
+
+        return cls.load_from_file(file_path)
 
     @classmethod
     def load_from_file(cls, file: Union[Path, str]):  # type: ignore


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

<details>
    <summary>CI Settings</summary>

**NOTE:** If your merge the PR with modified CI you **MUST KNOW** what you are doing
**NOTE:** Checked options will be applied if set before CI RunConfig/PrepareRunConfig step
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [x] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_unit--> Allow: Unit tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_include_aarch64--> Allow: All with aarch64
- [ ] <!---ci_include_asan--> Allow: All with ASAN
- [ ] <!---ci_include_tsan--> Allow: All with TSAN
- [ ] <!---ci_include_analyzer--> Allow: All with Analyzer
- [ ] <!---ci_include_azure --> Allow: All with Azure
- [ ] <!---ci_include_KEYWORD--> Allow: Add your option here
---
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_integration--> Exclude: Integration Tests
- [ ] <!---ci_exclude_stateless--> Exclude: Stateless tests
- [ ] <!---ci_exclude_stateful--> Exclude: Stateful tests
- [ ] <!---ci_exclude_performance--> Exclude: Performance tests
- [x] <!---ci_exclude_asan--> Exclude: All with ASAN
- [x] <!---ci_exclude_tsan--> Exclude: All with TSAN
- [x] <!---ci_exclude_msan--> Exclude: All with MSAN
- [x] <!---ci_exclude_ubsan--> Exclude: All with UBSAN
- [x] <!---ci_exclude_coverage--> Exclude: All with Coverage
- [x] <!---ci_exclude_aarch64--> Exclude: All with Aarch64
---
- [x] <!---do_not_test--> do not test (only style check)
- [ ] <!---no_merge_commit--> disable merge-commit (no merge from master before tests)
- [ ] <!---no_ci_cache--> disable CI cache (job reuse)
- [x] <!---batch_0--> allow: batch 1 for multi-batch jobs
- [ ] <!---batch_1--> allow: batch 2
- [ ] <!---batch_2--> allow: batch 3
- [ ] <!---batch_3_4_5--> allow: batch 4, 5 and 6
</details>
