### PR TITLE
fix: optimize_read_in_order for nullable keys

### DIFF
--- a/src/Processors/QueryPlan/Optimizations/optimizeReadInOrder.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeReadInOrder.cpp
@@ -22,6 +22,7 @@
 #include <Processors/QueryPlan/TotalsHavingStep.h>
 #include <Processors/QueryPlan/UnionStep.h>
 #include <Processors/QueryPlan/WindowStep.h>
+#include "Storages/KeyDescription.h"
 #include <Storages/StorageMerge.h>
 #include <Common/typeid_cast.h>
 
@@ -332,8 +333,7 @@ InputOrderInfoPtr buildInputOrderInfo(
     const FixedColumns & fixed_columns,
     const ActionsDAGPtr & dag,
     const SortDescription & description,
-    const ActionsDAG & sorting_key_dag,
-    const Names & sorting_key_columns,
+    const KeyDescription & sorting_key,
     size_t limit)
 {
     //std::cerr << "------- buildInputOrderInfo " << std::endl;
@@ -342,6 +342,8 @@ InputOrderInfoPtr buildInputOrderInfo(
 
     MatchedTrees::Matches matches;
     FixedColumns fixed_key_columns;
+
+    const auto & sorting_key_dag = sorting_key.expression->getActionsDAG();
 
     if (dag)
     {
@@ -371,14 +373,20 @@ InputOrderInfoPtr buildInputOrderInfo(
     size_t next_description_column = 0;
     size_t next_sort_key = 0;
 
-    while (next_description_column < description.size() && next_sort_key < sorting_key_columns.size())
+    while (next_description_column < description.size() && next_sort_key < sorting_key.column_names.size())
     {
-        const auto & sorting_key_column = sorting_key_columns[next_sort_key];
+        const auto & sorting_key_column = sorting_key.column_names[next_sort_key];
         const auto & sort_column_description = description[next_description_column];
 
         /// If required order depend on collation, it cannot be matched with primary key order.
         /// Because primary keys cannot have collations.
         if (sort_column_description.collator)
+            break;
+
+        /// Since sorting key columns are always sorted with NULLS LAST, reading in order
+        /// supported only for ASC NULLS LAST ("in order"), and DESC NULLS FIRST ("reverse")
+        const auto column_is_nullable = sorting_key.data_types[next_sort_key]->isNullable();
+        if (column_is_nullable && sort_column_description.nulls_direction != 1)
             break;
 
         /// Direction for current sort key.
@@ -691,12 +699,11 @@ InputOrderInfoPtr buildInputOrderInfo(
     size_t limit)
 {
     const auto & sorting_key = reading->getStorageMetadata()->getSortingKey();
-    const auto & sorting_key_columns = sorting_key.column_names;
 
     return buildInputOrderInfo(
         fixed_columns,
         dag, description,
-        sorting_key.expression->getActionsDAG(), sorting_key_columns,
+        sorting_key,
         limit);
 }
 
@@ -714,15 +721,14 @@ InputOrderInfoPtr buildInputOrderInfo(
     {
         auto storage = std::get<StoragePtr>(table);
         const auto & sorting_key = storage->getInMemoryMetadataPtr()->getSortingKey();
-        const auto & sorting_key_columns = sorting_key.column_names;
 
-        if (sorting_key_columns.empty())
+        if (sorting_key.column_names.empty())
             return nullptr;
 
         auto table_order_info = buildInputOrderInfo(
             fixed_columns,
             dag, description,
-            sorting_key.expression->getActionsDAG(), sorting_key_columns,
+            sorting_key,
             limit);
 
         if (!table_order_info)

--- a/tests/queries/0_stateless/03164_optimize_read_in_order_nullable.reference
+++ b/tests/queries/0_stateless/03164_optimize_read_in_order_nullable.reference
@@ -1,0 +1,32 @@
+-- Reproducer result:
+\N	Mark	50
+1	John	33
+2	Ksenia	48
+
+-- Read in order, no sort required:
+0	0
+1	\N
+4	4
+\N	2
+\N	\N
+
+-- Read in order, partial sort for second key:
+0	0
+1	\N
+4	4
+\N	\N
+\N	2
+
+-- No reading in order, sort for first key:
+\N	2
+\N	\N
+0	0
+1	\N
+4	4
+
+-- Reverse order, partial sort for the second key:
+\N	2
+\N	\N
+4	4
+1	\N
+0	0

--- a/tests/queries/0_stateless/03164_optimize_read_in_order_nullable.sql
+++ b/tests/queries/0_stateless/03164_optimize_read_in_order_nullable.sql
@@ -1,0 +1,55 @@
+-- Reproducer from https://github.com/ClickHouse/ClickHouse/issues/63460
+DROP TABLE IF EXISTS 03164_users;
+CREATE TABLE 03164_users (uid Nullable(Int16), name String, age Int16) ENGINE=MergeTree ORDER BY (uid) SETTINGS allow_nullable_key=1;
+
+INSERT INTO 03164_users VALUES (1, 'John', 33);
+INSERT INTO 03164_users VALUES (2, 'Ksenia', 48);
+INSERT INTO 03164_users VALUES (NULL, 'Mark', 50);
+OPTIMIZE TABLE 03164_users FINAL;
+
+SELECT '-- Reproducer result:';
+
+SELECT * FROM 03164_users ORDER BY uid ASC NULLS FIRST LIMIT 10 SETTINGS optimize_read_in_order = 1;
+
+DROP TABLE IF EXISTS 03164_users;
+
+DROP TABLE IF EXISTS 03164_multi_key;
+CREATE TABLE 03164_multi_key (c1 Nullable(UInt32), c2 Nullable(UInt32)) ENGINE = MergeTree ORDER BY (c1, c2) SETTINGS allow_nullable_key=1;
+
+INSERT INTO 03164_multi_key VALUES (0, 0), (1, NULL), (NULL, 2), (NULL, NULL), (4, 4);
+-- Just in case
+OPTIMIZE TABLE 03164_multi_key FINAL;
+
+SELECT '';
+SELECT '-- Read in order, no sort required:';
+
+SELECT c1, c2
+FROM 03164_multi_key
+ORDER BY c1 ASC NULLS LAST, c2 ASC NULLS LAST
+SETTINGS optimize_read_in_order = 1;
+
+SELECT '';
+SELECT '-- Read in order, partial sort for second key:';
+
+SELECT c1, c2
+FROM 03164_multi_key
+ORDER BY c1 ASC NULLS LAST, c2 ASC NULLS FIRST
+SETTINGS optimize_read_in_order = 1;
+
+SELECT '';
+SELECT '-- No reading in order, sort for first key:';
+
+SELECT c1, c2
+FROM 03164_multi_key
+ORDER BY c1 ASC NULLS FIRST, c2 ASC NULLS LAST
+SETTINGS optimize_read_in_order = 1;
+
+SELECT '';
+SELECT '-- Reverse order, partial sort for the second key:';
+
+SELECT c1, c2
+FROM 03164_multi_key
+ORDER BY c1 DESC NULLS FIRST, c2 DESC NULLS LAST
+SETTINGS optimize_read_in_order = 1;
+
+DROP TABLE IF EXISTS 03164_multi_key;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed `optimize_read_in_order` behaviour for ORDER BY ... NULLS FIRST / LAST on tables with nullable keys

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

<details>
    <summary>CI Settings</summary>

**NOTE:** If your merge the PR with modified CI you **MUST KNOW** what you are doing
**NOTE:** Checked options will be applied if set before CI RunConfig/PrepareRunConfig step
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_unit--> Allow: Unit tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_include_aarch64--> Allow: All with aarch64
- [ ] <!---ci_include_asan--> Allow: All with ASAN
- [ ] <!---ci_include_tsan--> Allow: All with TSAN
- [ ] <!---ci_include_analyzer--> Allow: All with Analyzer
- [ ] <!---ci_include_azure --> Allow: All with Azure
- [ ] <!---ci_include_KEYWORD--> Allow: Add your option here
---
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_integration--> Exclude: Integration Tests
- [ ] <!---ci_exclude_stateless--> Exclude: Stateless tests
- [ ] <!---ci_exclude_stateful--> Exclude: Stateful tests
- [ ] <!---ci_exclude_performance--> Exclude: Performance tests
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan--> Exclude: All with TSAN
- [ ] <!---ci_exclude_msan--> Exclude: All with MSAN
- [ ] <!---ci_exclude_ubsan--> Exclude: All with UBSAN
- [ ] <!---ci_exclude_coverage--> Exclude: All with Coverage
- [ ] <!---ci_exclude_aarch64--> Exclude: All with Aarch64
---
- [ ] <!---do_not_test--> do not test (only style check)
- [ ] <!---no_merge_commit--> disable merge-commit (no merge from master before tests)
- [ ] <!---no_ci_cache--> disable CI cache (job reuse)
- [ ] <!---batch_0--> allow: batch 1 for multi-batch jobs
- [ ] <!---batch_1--> allow: batch 2
- [ ] <!---batch_2--> allow: batch 3
- [ ] <!---batch_3_4_5--> allow: batch 4, 5 and 6
</details>

Closes #63460
