### PR TITLE
[Docs] add missing `UTCTimestamp` function

### DIFF
--- a/docs/en/sql-reference/functions/date-time-functions.md
+++ b/docs/en/sql-reference/functions/date-time-functions.md
@@ -3959,7 +3959,7 @@ Result:
 Returns the current date and time at the moment of query analysis. The function is a constant expression.
 
 :::note
-This function gives the same result that `now('UTC')` would. It was added only for MySQL support and `now` is the preferred usage.
+This function gives the same result that `now('UTC')` would. It was added only for MySQL support and [`now`](#now-now) is the preferred usage.
 :::
 
 **Syntax**

--- a/docs/en/sql-reference/functions/date-time-functions.md
+++ b/docs/en/sql-reference/functions/date-time-functions.md
@@ -3953,6 +3953,43 @@ Result:
 │                                                 2023-03-16 18:00:00.000 │
 └─────────────────────────────────────────────────────────────────────────┘
 ```
+
+## UTCTimestamp
+
+Returns the current date and time at the moment of query analysis. The function is a constant expression.
+
+:::note
+This function gives the same result that `now('UTC')` would. It was added only for MySQL support and `now` is the preferred usage.
+:::
+
+**Syntax**
+
+```sql
+UTCTimestamp()
+```
+
+Alias: `UTC_timestamp`.
+
+**Returned value**
+
+- Returns the current date and time at the moment of query analysis. [DateTime](../data-types/datetime.md).
+
+**Example**
+
+Query:
+
+```sql
+SELECT UTCTimestamp();
+```
+
+Result:
+
+```response
+┌──────UTCTimestamp()─┐
+│ 2024-05-28 08:32:09 │
+└─────────────────────┘
+```
+
 ## timeDiff
 
 Returns the difference between two dates or dates with time values. The difference is calculated in units of seconds. It is same as `dateDiff` and was added only for MySQL support. `dateDiff` is preferred.

--- a/utils/check-style/aspell-ignore/en/aspell-dict.txt
+++ b/utils/check-style/aspell-ignore/en/aspell-dict.txt
@@ -2789,6 +2789,7 @@ urls
 usearch
 userspace
 userver
+UTCTimestamp
 utils
 uuid
 uuidv


### PR DESCRIPTION
Closes [#1923](https://github.com/ClickHouse/clickhouse-docs/issues/1923) as part of the [missing functions project](https://github.com/ClickHouse/clickhouse-docs/issues/1833).

Adds:
- `UTCTimestamp` function.

### Changelog category (leave one):
- Documentation (changelog entry is not required)