### PR TITLE
Fix test_lost_part_other_replica

### DIFF
--- a/tests/integration/test_lost_part/test.py
+++ b/tests/integration/test_lost_part/test.py
@@ -90,7 +90,7 @@ def test_lost_part_same_replica(start_cluster):
             )
 
         assert node1.contains_in_log(
-            "Created empty part"
+            f"Created empty part {victim_part_from_the_middle}"
         ), f"Seems like empty part {victim_part_from_the_middle} is not created or log message changed"
 
         assert node1.query("SELECT COUNT() FROM mt0") == "4\n"
@@ -160,7 +160,9 @@ def test_lost_part_other_replica(start_cluster):
                 "SELECT * FROM system.replication_queue FORMAT Vertical"
             )
 
-        assert node1.contains_in_log("Created empty part") or node1.contains_in_log(
+        assert node1.contains_in_log(
+            f"Created empty part {victim_part_from_the_middle}"
+        ) or node1.contains_in_log(
             f"Part {victim_part_from_the_middle} looks broken. Removing it and will try to fetch."
         ), f"Seems like empty part {victim_part_from_the_middle} is not created or log message changed"
 


### PR DESCRIPTION
### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Fix test_lost_part_other_replica

### Documentation entry for user-facing changes

I started investigating this test because it was flaky in private from a few days ago. Surprisingly it wasn't flaky in public so I assumed it was some internal change.

After much time spent bisecting, it turns out it had nothing to do with private or public and the test wasn't flaky, it was just broken. No matter public or private I couldn't get the test to pass. The reason: I was running the test by itself, not inside the CI.

Why did it pass sometimes? Because we were looking for `Created empty part` in the logs, and since other test was running concurrently and generating this log too, the test would pass. It seems that starting in https://github.com/ClickHouse/ClickHouse/pull/60452 we might now log `Part {} looks broken. Removing it and will try to fetch` for this specific case instead cc @kssenii 



<details>
    <summary>CI Settings</summary>

**NOTE:** If your merge the PR with modified CI you **MUST KNOW** what you are doing
**NOTE:** Checked options will be applied if set before CI RunConfig/PrepareRunConfig step
- [x] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_unit--> Allow: Unit tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_include_aarch64--> Allow: All with aarch64
- [ ] <!---ci_include_asan--> Allow: All with ASAN
- [ ] <!---ci_include_tsan--> Allow: All with TSAN
- [ ] <!---ci_include_analyzer--> Allow: All with Analyzer
- [ ] <!---ci_include_azure --> Allow: All with Azure
- [ ] <!---ci_include_KEYWORD--> Allow: Add your option here
---
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_integration--> Exclude: Integration Tests
- [ ] <!---ci_exclude_stateless--> Exclude: Stateless tests
- [ ] <!---ci_exclude_stateful--> Exclude: Stateful tests
- [ ] <!---ci_exclude_performance--> Exclude: Performance tests
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan--> Exclude: All with TSAN
- [ ] <!---ci_exclude_msan--> Exclude: All with MSAN
- [ ] <!---ci_exclude_ubsan--> Exclude: All with UBSAN
- [ ] <!---ci_exclude_coverage--> Exclude: All with Coverage
- [ ] <!---ci_exclude_aarch64--> Exclude: All with Aarch64
---
- [ ] <!---do_not_test--> do not test (only style check)
- [ ] <!---no_merge_commit--> disable merge-commit (no merge from master before tests)
- [ ] <!---no_ci_cache--> disable CI cache (job reuse)
- [ ] <!---batch_0--> allow: batch 1 for multi-batch jobs
- [ ] <!---batch_1--> allow: batch 2
- [ ] <!---batch_2--> allow: batch 3
- [ ] <!---batch_3_4_5--> allow: batch 4, 5 and 6
</details>
