### PR TITLE
ASTLiteral support custom type

### DIFF
--- a/src/Interpreters/ActionsVisitor.cpp
+++ b/src/Interpreters/ActionsVisitor.cpp
@@ -1323,7 +1323,9 @@ void ActionsMatcher::visit(const ASTLiteral & literal, const ASTPtr & /* ast */,
     Data & data)
 {
     DataTypePtr type;
-    if (data.getContext()->getSettingsRef().allow_experimental_variant_type && data.getContext()->getSettingsRef().use_variant_as_common_type)
+    if (literal.custom_type)
+        type = literal.custom_type;
+    else if (data.getContext()->getSettingsRef().allow_experimental_variant_type && data.getContext()->getSettingsRef().use_variant_as_common_type)
         type = applyVisitor(FieldToDataType<LeastSupertypeOnError::Variant>(), literal.value);
     else
         type = applyVisitor(FieldToDataType(), literal.value);

--- a/src/Interpreters/tests/gtest_actions_visitor.cpp
+++ b/src/Interpreters/tests/gtest_actions_visitor.cpp
@@ -1,0 +1,73 @@
+#include <iostream>
+#include <memory>
+#include <DataTypes/DataTypeDate32.h>
+#include <DataTypes/DataTypesNumber.h>
+#include <Parsers/ASTLiteral.h>
+#include <Interpreters/ActionsDAG.h>
+#include <Interpreters/ActionsVisitor.h>
+#include <Common/tests/gtest_global_context.h>
+#include <gtest/gtest.h>
+
+using namespace DB;
+
+
+TEST(ActionsVisitor, VisitLiteral)
+{
+    DataTypePtr date_type = std::make_shared<DataTypeDate32>();
+    DataTypePtr expect_type = std::make_shared<DataTypeInt16>();
+    const NamesAndTypesList name_and_types =
+    {
+        {"year", date_type}
+    };
+
+    const auto ast = std::make_shared<ASTLiteral>(19870);
+    auto context = Context::createCopy(getContext().context);
+    NamesAndTypesList aggregation_keys;
+    ColumnNumbersList aggregation_keys_indexes_list;
+    AggregationKeysInfo info(aggregation_keys, aggregation_keys_indexes_list, GroupByKind::NONE);
+    SizeLimits size_limits_for_set;
+    ActionsMatcher::Data visitor_data(
+        context,
+        size_limits_for_set,
+        size_t(0),
+        name_and_types,
+        std::make_shared<ActionsDAG>(name_and_types),
+        std::make_shared<PreparedSets>(),
+        false /* no_subqueries */,
+        false /* no_makeset */,
+        false /* only_consts */,
+        info);
+    ActionsVisitor(visitor_data).visit(ast);
+    auto actions = visitor_data.getActions();
+    ASSERT_EQ(actions->getResultColumns().back().type->getTypeId(), expect_type->getTypeId());
+}
+
+TEST(ActionsVisitor, VisitLiteralWithType)
+{
+    DataTypePtr date_type = std::make_shared<DataTypeDate32>();
+    const NamesAndTypesList name_and_types =
+    {
+        {"year", date_type}
+    };
+
+    const auto ast = std::make_shared<ASTLiteral>(19870, date_type);
+    auto context = Context::createCopy(getContext().context);
+    NamesAndTypesList aggregation_keys;
+    ColumnNumbersList aggregation_keys_indexes_list;
+    AggregationKeysInfo info(aggregation_keys, aggregation_keys_indexes_list, GroupByKind::NONE);
+    SizeLimits size_limits_for_set;
+    ActionsMatcher::Data visitor_data(
+        context,
+        size_limits_for_set,
+        size_t(0),
+        name_and_types,
+        std::make_shared<ActionsDAG>(name_and_types),
+        std::make_shared<PreparedSets>(),
+        false /* no_subqueries */,
+        false /* no_makeset */,
+        false /* only_consts */,
+        info);
+    ActionsVisitor(visitor_data).visit(ast);
+    auto actions = visitor_data.getActions();
+    ASSERT_EQ(actions->getResultColumns().back().type->getTypeId(), date_type->getTypeId());
+}

--- a/src/Parsers/ASTLiteral.h
+++ b/src/Parsers/ASTLiteral.h
@@ -18,7 +18,7 @@ class ASTLiteral : public ASTWithAlias
 public:
     explicit ASTLiteral(Field value_) : value(std::move(value_)) {}
 
-    // This methond and the custom_type are only for Apache Gluten,
+    // This methond and the custom_type are only used for Apache Gluten,
     explicit ASTLiteral(Field value_, DataTypePtr & type_) : value(std::move(value_))
     {
         custom_type = type_;

--- a/src/Parsers/ASTLiteral.h
+++ b/src/Parsers/ASTLiteral.h
@@ -17,6 +17,8 @@ class ASTLiteral : public ASTWithAlias
 {
 public:
     explicit ASTLiteral(Field value_) : value(std::move(value_)) {}
+
+    // This methond and the custom_type are only for Apache Gluten,
     explicit ASTLiteral(Field value_, DataTypePtr & type_) : value(std::move(value_))
     {
         custom_type = type_;

--- a/src/Parsers/ASTLiteral.h
+++ b/src/Parsers/ASTLiteral.h
@@ -4,6 +4,7 @@
 #include <Parsers/ASTWithAlias.h>
 #include <Parsers/TokenIterator.h>
 #include <Common/FieldVisitorDump.h>
+#include <DataTypes/IDataType.h>
 
 #include <optional>
 
@@ -16,8 +17,13 @@ class ASTLiteral : public ASTWithAlias
 {
 public:
     explicit ASTLiteral(Field value_) : value(std::move(value_)) {}
+    explicit ASTLiteral(Field value_, DataTypePtr & type_) : value(std::move(value_))
+    {
+        custom_type = type_;
+    }
 
     Field value;
+    DataTypePtr custom_type;
 
     /// For ConstantExpressionTemplate
     std::optional<TokenIterator> begin;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add support for custom type to ASTLiteral, or else the type may be lost when parse the ast. E.g. set a ASTLiteral to DataTime32 with value 19870, then it will be parsed to Int16.