### PR TITLE
Fix writing ORC statistics for unsigned types

### DIFF
--- a/src/Processors/Formats/Impl/NativeORCBlockInputFormat.cpp
+++ b/src/Processors/Formats/Impl/NativeORCBlockInputFormat.cpp
@@ -269,7 +269,12 @@ convertFieldToORCLiteral(const orc::Type & orc_type, const Field & field, DataTy
             case orc::SHORT:
             case orc::INT:
             case orc::LONG: {
-                /// May throw exception
+                /// May throw exception.
+                ///
+                /// In particular, it'll throw if we request the column as unsigned, like this:
+                ///   SELECT * FROM file('t.orc', ORC, 'x UInt8') WHERE x > 10
+                /// We have to reject this, otherwise it would miss values > 127 (because
+                /// they're treated as negative by ORC).
                 auto val = field.get<Int64>();
                 return orc::Literal(val);
             }

--- a/src/Processors/Formats/Impl/ORCBlockOutputFormat.cpp
+++ b/src/Processors/Formats/Impl/ORCBlockOutputFormat.cpp
@@ -315,18 +315,20 @@ void ORCBlockOutputFormat::writeColumn(
     if (null_bytemap)
         orc_column.hasNulls = true;
 
+    /// ORC doesn't have unsigned types, so cast everything to signed and sign-extend to Int64 to
+    /// make the ORC library calculate min and max correctly.
     switch (type->getTypeId())
     {
         case TypeIndex::Enum8: [[fallthrough]];
         case TypeIndex::Int8:
         {
             /// Note: Explicit cast to avoid clang-tidy error: 'signed char' to 'long' conversion; consider casting to 'unsigned char' first.
-            writeNumbers<Int8, orc::LongVectorBatch>(orc_column, column, null_bytemap, [](const Int8 & value){ return static_cast<int64_t>(value); });
+            writeNumbers<Int8, orc::LongVectorBatch>(orc_column, column, null_bytemap, [](const Int8 & value){ return Int64(Int8(value)); });
             break;
         }
         case TypeIndex::UInt8:
         {
-            writeNumbers<UInt8, orc::LongVectorBatch>(orc_column, column, null_bytemap, [](const UInt8 & value){ return value; });
+            writeNumbers<UInt8, orc::LongVectorBatch>(orc_column, column, null_bytemap, [](const UInt8 & value){ return Int64(Int8(value)); });
             break;
         }
         case TypeIndex::Enum16: [[fallthrough]];
@@ -338,7 +340,7 @@ void ORCBlockOutputFormat::writeColumn(
         case TypeIndex::Date: [[fallthrough]];
         case TypeIndex::UInt16:
         {
-            writeNumbers<UInt16, orc::LongVectorBatch>(orc_column, column, null_bytemap, [](const UInt16 & value){ return value; });
+            writeNumbers<UInt16, orc::LongVectorBatch>(orc_column, column, null_bytemap, [](const UInt16 & value){ return Int64(Int16(value)); });
             break;
         }
         case TypeIndex::Date32: [[fallthrough]];
@@ -349,12 +351,12 @@ void ORCBlockOutputFormat::writeColumn(
         }
         case TypeIndex::UInt32:
         {
-            writeNumbers<UInt32, orc::LongVectorBatch>(orc_column, column, null_bytemap, [](const UInt32 & value){ return value; });
+            writeNumbers<UInt32, orc::LongVectorBatch>(orc_column, column, null_bytemap, [](const UInt32 & value){ return Int64(Int32(value)); });
             break;
         }
         case TypeIndex::IPv4:
         {
-            writeNumbers<IPv4, orc::LongVectorBatch>(orc_column, column, null_bytemap, [](const IPv4 & value){ return value.toUnderType(); });
+            writeNumbers<IPv4, orc::LongVectorBatch>(orc_column, column, null_bytemap, [](const IPv4 & value){ return Int64(Int32(value.toUnderType())); });
             break;
         }
         case TypeIndex::Int64:

--- a/tests/queries/0_stateless/02892_orc_filter_pushdown.reference
+++ b/tests/queries/0_stateless/02892_orc_filter_pushdown.reference
@@ -1,8 +1,4 @@
 number	Nullable(Int64)					
-u8	Nullable(Int8)					
-u16	Nullable(Int16)					
-u32	Nullable(Int32)					
-u64	Nullable(Int64)					
 i8	Nullable(Int8)					
 i16	Nullable(Int16)					
 i32	Nullable(Int32)					
@@ -22,34 +18,34 @@ d64	Nullable(Decimal(18, 10))
 d128	Nullable(Decimal(38, 20))					
 -- Go over all types individually
 -- { echoOn }
-select count(), sum(number) from file('02892.orc') where indexHint(u8 in (10, 15, 250));
-800	4229600
-select count(1), min(u8), max(u8) from file('02892.orc') where u8 in (10, 15, 250);
-66	10	15
+select count(), sum(number) from file('02892.orc') where indexHint(i8 in (10, 15, -6));
+1100	5744450
+select count(1), min(i8), max(i8) from file('02892.orc') where i8 in (10, 15, -6);
+99	-6	15
 select count(), sum(number) from file('02892.orc') where indexHint(i8 between -3 and 2);
 1000	4999500
 select count(1), min(i8), max(i8) from file('02892.orc') where i8 between -3 and 2;
 208	-3	2
-select count(), sum(number) from file('02892.orc') where indexHint(u16 between 4000 and 61000 or u16 == 42);
-1800	6479100
-select count(1), min(u16), max(u16) from file('02892.orc') where u16 between 4000 and 61000 or u16 == 42;
+select count(), sum(number) from file('02892.orc') where indexHint(i16 between 4000 and 61000 or i16 == 42);
+1200	1099400
+select count(1), min(i16), max(i16) from file('02892.orc') where i16 between 4000 and 61000 or i16 == 42;
 1002	42	5000
 select count(), sum(number) from file('02892.orc') where indexHint(i16 between -150 and 250);
 500	2474750
 select count(1), min(i16), max(i16) from file('02892.orc') where i16 between -150 and 250;
 401	-150	250
-select count(), sum(number) from file('02892.orc') where indexHint(u32 in (42, 4294966296));
-200	999900
-select count(1), min(u32), max(u32) from file('02892.orc') where u32 in (42, 4294966296);
-1	42	42
+select count(), sum(number) from file('02892.orc') where indexHint(i32 in (42, -1000));
+200	1099900
+select count(1), min(i32), max(i32) from file('02892.orc') where i32 in (42, -1000);
+2	-1000	42
 select count(), sum(number) from file('02892.orc') where indexHint(i32 between -150 and 250);
 500	2474750
 select count(1), min(i32), max(i32) from file('02892.orc') where i32 between -150 and 250;
 401	-150	250
-select count(), sum(number) from file('02892.orc') where indexHint(u64 in (42, 18446744073709550616));
-100	494950
-select count(1), min(u64), max(u64) from file('02892.orc') where u64 in (42, 18446744073709550616);
-1	42	42
+select count(), sum(number) from file('02892.orc') where indexHint(i64 in (42, -1000));
+200	1099900
+select count(1), min(i64), max(i64) from file('02892.orc') where i64 in (42, -1000);
+2	-1000	42
 select count(), sum(number) from file('02892.orc') where indexHint(i64 between -150 and 250);
 500	2474750
 select count(1), min(i64), max(i64) from file('02892.orc') where i64 between -150 and 250;
@@ -111,21 +107,21 @@ select count(), sum(number) from file('02892.orc') where indexHint(0);
 0	\N
 select count(), min(number), max(number) from file('02892.orc') where indexHint(0);
 0	\N	\N
-select count(), sum(number) from file('02892.orc') where indexHint(s like '99%' or u64 == 2000);
+select count(), sum(number) from file('02892.orc') where indexHint(s like '99%' or i64 == 2000);
 300	1204850
-select count(), min(s), max(s) from file('02892.orc') where (s like '99%' or u64 == 2000);
+select count(), min(s), max(s) from file('02892.orc') where (s like '99%' or i64 == 2000);
 12	2000	999
 select count(), sum(number) from file('02892.orc') where indexHint(s like 'z%');
 0	\N
 select count(), min(s), max(s) from file('02892.orc') where (s like 'z%');
 0	\N	\N
-select count(), sum(number) from file('02892.orc') where indexHint(u8 == 10 or 1 == 1);
+select count(), sum(number) from file('02892.orc') where indexHint(i8 == 10 or 1 == 1);
 10000	49995000
-select count(), min(u8), max(u8) from file('02892.orc') where (u8 == 10 or 1 == 1);
+select count(), min(i8), max(i8) from file('02892.orc') where (i8 == 10 or 1 == 1);
 10000	-128	127
-select count(), sum(number) from file('02892.orc') where indexHint(u8 < 0);
+select count(), sum(number) from file('02892.orc') where indexHint(i8 < 0);
 5300	26042350
-select count(), min(u8), max(u8) from file('02892.orc') where (u8 < 0);
+select count(), min(i8), max(i8) from file('02892.orc') where (i8 < 0);
 5001	-128	-1
 -- { echoOn }
 select count(), sum(number) from file('02892.orc') where indexHint(sometimes_null is NULL);

--- a/tests/queries/0_stateless/02892_orc_filter_pushdown.sql
+++ b/tests/queries/0_stateless/02892_orc_filter_pushdown.sql
@@ -1,4 +1,4 @@
--- Tags: no-fasttest, no-parallel, no-cpu-aarch64
+-- Tags: no-fasttest, no-parallel
 
 set output_format_orc_string_as_string = 1;
 set output_format_orc_row_index_stride = 100;

--- a/tests/queries/0_stateless/02892_orc_filter_pushdown.sql
+++ b/tests/queries/0_stateless/02892_orc_filter_pushdown.sql
@@ -16,15 +16,9 @@ SET session_timezone = 'UTC';
 
 -- Try all the types.
 insert into function file('02892.orc')
-    -- Use negative numbers to test sign extension for signed types and lack of sign extension for
-    -- unsigned types.
     with 5000 - number as n
 select
     number,
-    intDiv(n, 11)::UInt8 as u8,
-    n::UInt16 u16,
-    n::UInt32 as u32,
-    n::UInt64 as u64,
     intDiv(n, 11)::Int8 as i8,
     n::Int16 i16,
     n::Int32 as i32,
@@ -50,26 +44,26 @@ desc file('02892.orc');
 
 -- Go over all types individually
 -- { echoOn }
-select count(), sum(number) from file('02892.orc') where indexHint(u8 in (10, 15, 250));
-select count(1), min(u8), max(u8) from file('02892.orc') where u8 in (10, 15, 250);
+select count(), sum(number) from file('02892.orc') where indexHint(i8 in (10, 15, -6));
+select count(1), min(i8), max(i8) from file('02892.orc') where i8 in (10, 15, -6);
 
 select count(), sum(number) from file('02892.orc') where indexHint(i8 between -3 and 2);
 select count(1), min(i8), max(i8) from file('02892.orc') where i8 between -3 and 2;
 
-select count(), sum(number) from file('02892.orc') where indexHint(u16 between 4000 and 61000 or u16 == 42);
-select count(1), min(u16), max(u16) from file('02892.orc') where u16 between 4000 and 61000 or u16 == 42;
+select count(), sum(number) from file('02892.orc') where indexHint(i16 between 4000 and 61000 or i16 == 42);
+select count(1), min(i16), max(i16) from file('02892.orc') where i16 between 4000 and 61000 or i16 == 42;
 
 select count(), sum(number) from file('02892.orc') where indexHint(i16 between -150 and 250);
 select count(1), min(i16), max(i16) from file('02892.orc') where i16 between -150 and 250;
 
-select count(), sum(number) from file('02892.orc') where indexHint(u32 in (42, 4294966296));
-select count(1), min(u32), max(u32) from file('02892.orc') where u32 in (42, 4294966296);
+select count(), sum(number) from file('02892.orc') where indexHint(i32 in (42, -1000));
+select count(1), min(i32), max(i32) from file('02892.orc') where i32 in (42, -1000);
 
 select count(), sum(number) from file('02892.orc') where indexHint(i32 between -150 and 250);
 select count(1), min(i32), max(i32) from file('02892.orc') where i32 between -150 and 250;
 
-select count(), sum(number) from file('02892.orc') where indexHint(u64 in (42, 18446744073709550616));
-select count(1), min(u64), max(u64) from file('02892.orc') where u64 in (42, 18446744073709550616);
+select count(), sum(number) from file('02892.orc') where indexHint(i64 in (42, -1000));
+select count(1), min(i64), max(i64) from file('02892.orc') where i64 in (42, -1000);
 
 select count(), sum(number) from file('02892.orc') where indexHint(i64 between -150 and 250);
 select count(1), min(i64), max(i64) from file('02892.orc') where i64 between -150 and 250;
@@ -117,17 +111,17 @@ select count(1), min(d128), max(128) from file('02892.orc') where (d128 between 
 select count(), sum(number) from file('02892.orc') where indexHint(0);
 select count(), min(number), max(number) from file('02892.orc') where indexHint(0);
 
-select count(), sum(number) from file('02892.orc') where indexHint(s like '99%' or u64 == 2000);
-select count(), min(s), max(s) from file('02892.orc') where (s like '99%' or u64 == 2000);
+select count(), sum(number) from file('02892.orc') where indexHint(s like '99%' or i64 == 2000);
+select count(), min(s), max(s) from file('02892.orc') where (s like '99%' or i64 == 2000);
 
 select count(), sum(number) from file('02892.orc') where indexHint(s like 'z%');
 select count(), min(s), max(s) from file('02892.orc') where (s like 'z%');
 
-select count(), sum(number) from file('02892.orc') where indexHint(u8 == 10 or 1 == 1);
-select count(), min(u8), max(u8) from file('02892.orc') where (u8 == 10 or 1 == 1);
+select count(), sum(number) from file('02892.orc') where indexHint(i8 == 10 or 1 == 1);
+select count(), min(i8), max(i8) from file('02892.orc') where (i8 == 10 or 1 == 1);
 
-select count(), sum(number) from file('02892.orc') where indexHint(u8 < 0);
-select count(), min(u8), max(u8) from file('02892.orc') where (u8 < 0);
+select count(), sum(number) from file('02892.orc') where indexHint(i8 < 0);
+select count(), min(i8), max(i8) from file('02892.orc') where (i8 < 0);
 -- { echoOff }
 
 -- Nullable and LowCardinality.

--- a/tests/queries/0_stateless/03164_orc_signedness.reference
+++ b/tests/queries/0_stateless/03164_orc_signedness.reference
@@ -1,0 +1,41 @@
+-- { echoOn }
+select x from file('i8.orc') where indexHint(x = -128);
+-128
+select x from file('i8.orc') where indexHint(x = 128);
+select x from file('u8.orc') where indexHint(x = -128);
+-128
+select x from file('u8.orc') where indexHint(x = 128);
+select x from file('i16.orc') where indexHint(x = -32768);
+-32768
+select x from file('i16.orc') where indexHint(x = 32768);
+select x from file('u16.orc') where indexHint(x = -32768);
+-32768
+select x from file('u16.orc') where indexHint(x = 32768);
+select x from file('i32.orc') where indexHint(x = -2147483648);
+-2147483648
+select x from file('i32.orc') where indexHint(x = 2147483648);
+select x from file('u32.orc') where indexHint(x = -2147483648);
+-2147483648
+select x from file('u32.orc') where indexHint(x = 2147483648);
+select x from file('i64.orc') where indexHint(x = -9223372036854775808);
+-9223372036854775808
+select x from file('i64.orc') where indexHint(x = 9223372036854775808);
+-9223372036854775808
+select x from file('u64.orc') where indexHint(x = -9223372036854775808);
+-9223372036854775808
+select x from file('u64.orc') where indexHint(x = 9223372036854775808);
+-9223372036854775808
+select x from file('u8.orc', ORC, 'x UInt8') where indexHint(x > 10);
+128
+select x from file('u8.orc', ORC, 'x UInt64') where indexHint(x > 10);
+18446744073709551488
+select x from file('u16.orc', ORC, 'x UInt16') where indexHint(x > 10);
+32768
+select x from file('u16.orc', ORC, 'x UInt64') where indexHint(x > 10);
+18446744073709518848
+select x from file('u32.orc', ORC, 'x UInt32') where indexHint(x > 10);
+2147483648
+select x from file('u32.orc', ORC, 'x UInt64') where indexHint(x > 10);
+18446744071562067968
+select x from file('u64.orc', ORC, 'x UInt64') where indexHint(x > 10);
+9223372036854775808

--- a/tests/queries/0_stateless/03164_orc_signedness.sql
+++ b/tests/queries/0_stateless/03164_orc_signedness.sql
@@ -1,3 +1,5 @@
+-- Tags: no-fasttest, no-parallel
+
 set input_format_orc_filter_push_down = 1;
 set engine_file_truncate_on_insert = 1;
 

--- a/tests/queries/0_stateless/03164_orc_signedness.sql
+++ b/tests/queries/0_stateless/03164_orc_signedness.sql
@@ -1,0 +1,40 @@
+set input_format_orc_filter_push_down = 1;
+set engine_file_truncate_on_insert = 1;
+
+insert into function file('i8.orc') select materialize(-128)::Int8 as x;
+insert into function file('u8.orc') select materialize(128)::UInt8 as x;
+insert into function file('i16.orc') select materialize(-32768)::Int16 as x;
+insert into function file('u16.orc') select materialize(32768)::UInt16 as x;
+insert into function file('i32.orc') select materialize(-2147483648)::Int32 as x;
+insert into function file('u32.orc') select materialize(2147483648)::UInt32 as x;
+insert into function file('i64.orc') select materialize(-9223372036854775808)::Int64 as x;
+insert into function file('u64.orc') select materialize(9223372036854775808)::UInt64 as x;
+
+-- { echoOn }
+select x from file('i8.orc') where indexHint(x = -128);
+select x from file('i8.orc') where indexHint(x = 128);
+select x from file('u8.orc') where indexHint(x = -128);
+select x from file('u8.orc') where indexHint(x = 128);
+
+select x from file('i16.orc') where indexHint(x = -32768);
+select x from file('i16.orc') where indexHint(x = 32768);
+select x from file('u16.orc') where indexHint(x = -32768);
+select x from file('u16.orc') where indexHint(x = 32768);
+
+select x from file('i32.orc') where indexHint(x = -2147483648);
+select x from file('i32.orc') where indexHint(x = 2147483648);
+select x from file('u32.orc') where indexHint(x = -2147483648);
+select x from file('u32.orc') where indexHint(x = 2147483648);
+
+select x from file('i64.orc') where indexHint(x = -9223372036854775808);
+select x from file('i64.orc') where indexHint(x = 9223372036854775808);
+select x from file('u64.orc') where indexHint(x = -9223372036854775808);
+select x from file('u64.orc') where indexHint(x = 9223372036854775808);
+
+select x from file('u8.orc', ORC, 'x UInt8') where indexHint(x > 10);
+select x from file('u8.orc', ORC, 'x UInt64') where indexHint(x > 10);
+select x from file('u16.orc', ORC, 'x UInt16') where indexHint(x > 10);
+select x from file('u16.orc', ORC, 'x UInt64') where indexHint(x > 10);
+select x from file('u32.orc', ORC, 'x UInt32') where indexHint(x > 10);
+select x from file('u32.orc', ORC, 'x UInt64') where indexHint(x > 10);
+select x from file('u64.orc', ORC, 'x UInt64') where indexHint(x > 10);


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed ORC statistics calculation, when writing, for unsigned types on all platforms and Int8 on ARM.

ORC doesn't have unsigned types. We were casting unsigned -> signed incorrectly (without sign-extension), so the orc library could write a file where the statistics don't match the data (e.g. maximum = 200 for type BYTE - this should be impossible, but it can be represented in the file because statistics are always 64-bit).

Also https://github.com/ClickHouse/orc/pull/13 fixes the library. When calculating min/max, it was casting BYTE values to `char`, which might be unsigned.