### PR TITLE
Add a temporary known host for git over ssh

### DIFF
--- a/tests/ci/cherry_pick.py
+++ b/tests/ci/cherry_pick.py
@@ -33,9 +33,10 @@ from subprocess import CalledProcessError
 from typing import List, Optional
 
 import __main__
+
 from env_helper import TEMP_PATH
 from get_robot_token import get_best_robot_token
-from git_helper import git_runner, is_shallow
+from git_helper import GIT_PREFIX, git_runner, is_shallow
 from github_helper import GitHub, PullRequest, PullRequests, Repository
 from lambda_shared_package.lambda_shared.pr import Labels
 from ssh import SSHKey
@@ -104,10 +105,6 @@ close it.
 
         self.backport_created_label = backport_created_label
 
-        self.git_prefix = (  # All commits to cherrypick are done as robot-clickhouse
-            "git -c user.email=robot-clickhouse@users.noreply.github.com "
-            "-c user.name=robot-clickhouse -c commit.gpgsign=false"
-        )
         self.pre_check()
 
     def pre_check(self):
@@ -190,17 +187,17 @@ close it.
     def create_cherrypick(self):
         # First, create backport branch:
         # Checkout release branch with discarding every change
-        git_runner(f"{self.git_prefix} checkout -f {self.name}")
+        git_runner(f"{GIT_PREFIX} checkout -f {self.name}")
         # Create or reset backport branch
-        git_runner(f"{self.git_prefix} checkout -B {self.backport_branch}")
+        git_runner(f"{GIT_PREFIX} checkout -B {self.backport_branch}")
         # Merge all changes from PR's the first parent commit w/o applying anything
         # It will allow to create a merge commit like it would be a cherry-pick
         first_parent = git_runner(f"git rev-parse {self.pr.merge_commit_sha}^1")
-        git_runner(f"{self.git_prefix} merge -s ours --no-edit {first_parent}")
+        git_runner(f"{GIT_PREFIX} merge -s ours --no-edit {first_parent}")
 
         # Second step, create cherrypick branch
         git_runner(
-            f"{self.git_prefix} branch -f "
+            f"{GIT_PREFIX} branch -f "
             f"{self.cherrypick_branch} {self.pr.merge_commit_sha}"
         )
 
@@ -209,7 +206,7 @@ close it.
         # manually to the release branch already
         try:
             output = git_runner(
-                f"{self.git_prefix} merge --no-commit --no-ff {self.cherrypick_branch}"
+                f"{GIT_PREFIX} merge --no-commit --no-ff {self.cherrypick_branch}"
             )
             # 'up-to-date', 'up to date', who knows what else (╯°v°)╯ ^┻━┻
             if output.startswith("Already up") and output.endswith("date."):
@@ -223,14 +220,14 @@ close it.
                 return
         except CalledProcessError:
             # There are most probably conflicts, they'll be resolved in PR
-            git_runner(f"{self.git_prefix} reset --merge")
+            git_runner(f"{GIT_PREFIX} reset --merge")
         else:
             # There are changes to apply, so continue
-            git_runner(f"{self.git_prefix} reset --merge")
+            git_runner(f"{GIT_PREFIX} reset --merge")
 
         # Push, create the cherrypick PR, lable and assign it
         for branch in [self.cherrypick_branch, self.backport_branch]:
-            git_runner(f"{self.git_prefix} push -f {self.REMOTE} {branch}:{branch}")
+            git_runner(f"{GIT_PREFIX} push -f {self.REMOTE} {branch}:{branch}")
 
         self.cherrypick_pr = self.repo.create_pull(
             title=f"Cherry pick #{self.pr.number} to {self.name}: {self.pr.title}",
@@ -254,21 +251,19 @@ close it.
         # Checkout the backport branch from the remote and make all changes to
         # apply like they are only one cherry-pick commit on top of release
         logging.info("Creating backport for PR #%s", self.pr.number)
-        git_runner(f"{self.git_prefix} checkout -f {self.backport_branch}")
-        git_runner(
-            f"{self.git_prefix} pull --ff-only {self.REMOTE} {self.backport_branch}"
-        )
+        git_runner(f"{GIT_PREFIX} checkout -f {self.backport_branch}")
+        git_runner(f"{GIT_PREFIX} pull --ff-only {self.REMOTE} {self.backport_branch}")
         merge_base = git_runner(
-            f"{self.git_prefix} merge-base "
+            f"{GIT_PREFIX} merge-base "
             f"{self.REMOTE}/{self.name} {self.backport_branch}"
         )
-        git_runner(f"{self.git_prefix} reset --soft {merge_base}")
+        git_runner(f"{GIT_PREFIX} reset --soft {merge_base}")
         title = f"Backport #{self.pr.number} to {self.name}: {self.pr.title}"
-        git_runner(f"{self.git_prefix} commit --allow-empty -F -", input=title)
+        git_runner(f"{GIT_PREFIX} commit --allow-empty -F -", input=title)
 
         # Push with force, create the backport PR, lable and assign it
         git_runner(
-            f"{self.git_prefix} push -f {self.REMOTE} "
+            f"{GIT_PREFIX} push -f {self.REMOTE} "
             f"{self.backport_branch}:{self.backport_branch}"
         )
         self.backport_pr = self.repo.create_pull(
@@ -660,9 +655,11 @@ def main():
         args.repo,
         args.from_repo,
         args.dry_run,
-        args.must_create_backport_label
-        if isinstance(args.must_create_backport_label, list)
-        else [args.must_create_backport_label],
+        (
+            args.must_create_backport_label
+            if isinstance(args.must_create_backport_label, list)
+            else [args.must_create_backport_label]
+        ),
         args.backport_created_label,
     )
     # https://github.com/python/mypy/issues/3004

--- a/tests/ci/ci_config.py
+++ b/tests/ci/ci_config.py
@@ -1420,6 +1420,11 @@ class CheckDescription:
 
 CHECK_DESCRIPTIONS = [
     CheckDescription(
+        StatusNames.SYNC,
+        "A status of the workflow running in the cloud repository against the sync PR",
+        lambda x: x == StatusNames.SYNC,
+    ),
+    CheckDescription(
         "AST fuzzer",
         "Runs randomly generated queries to catch program errors. "
         "The build type is optionally given in parenthesis. "


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add a temporary known host for git over ssh

We have a lot of lines in scripts like `Permanently added 'github.com'`, so this change will create a file for the whole run.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

<details>
    <summary>CI Settings</summary>

**NOTE:** If your merge the PR with modified CI you **MUST KNOW** what you are doing
**NOTE:** Checked options will be applied if set before CI RunConfig/PrepareRunConfig step
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_unit--> Allow: Unit tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_include_aarch64--> Allow: All with aarch64
- [ ] <!---ci_include_asan--> Allow: All with ASAN
- [ ] <!---ci_include_tsan--> Allow: All with TSAN
- [ ] <!---ci_include_analyzer--> Allow: All with Analyzer
- [ ] <!---ci_include_azure --> Allow: All with Azure
- [ ] <!---ci_include_KEYWORD--> Allow: Add your option here
---
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_integration--> Exclude: Integration Tests
- [ ] <!---ci_exclude_stateless--> Exclude: Stateless tests
- [ ] <!---ci_exclude_stateful--> Exclude: Stateful tests
- [ ] <!---ci_exclude_performance--> Exclude: Performance tests
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan--> Exclude: All with TSAN
- [ ] <!---ci_exclude_msan--> Exclude: All with MSAN
- [ ] <!---ci_exclude_ubsan--> Exclude: All with UBSAN
- [ ] <!---ci_exclude_coverage--> Exclude: All with Coverage
- [ ] <!---ci_exclude_aarch64--> Exclude: All with Aarch64
---
- [ ] <!---do_not_test--> do not test (only style check)
- [ ] <!---no_merge_commit--> disable merge-commit (no merge from master before tests)
- [ ] <!---no_ci_cache--> disable CI cache (job reuse)
- [ ] <!---batch_0--> allow: batch 1 for multi-batch jobs
- [ ] <!---batch_1--> allow: batch 2
- [ ] <!---batch_2--> allow: batch 3
- [ ] <!---batch_3_4_5--> allow: batch 4, 5 and 6
</details>
