### PR TITLE
xray: add global xray instrumentation support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@
 *.stderr
 *.stdout
 
+# llvm-xray logs
+xray-log.*
+
 /docs/build
 /docs/publish
 /docs/edit

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,6 +119,8 @@ add_library(global-libs INTERFACE)
 
 include (cmake/sanitize.cmake)
 
+include (cmake/instrument.cmake)
+
 option(ENABLE_COLORED_BUILD "Enable colors in compiler output" ON)
 
 set (CMAKE_COLOR_MAKEFILE ${ENABLE_COLORED_BUILD}) # works only for the makefile generator

--- a/cmake/instrument.cmake
+++ b/cmake/instrument.cmake
@@ -1,0 +1,20 @@
+# https://llvm.org/docs/XRay.html
+
+option (ENABLE_XRAY "Enable LLVM XRay" OFF)
+
+if (NOT ENABLE_XRAY)
+    message (STATUS "Not using LLVM XRay")
+    return()
+endif()
+
+if (NOT (ARCH_AMD64 AND (OS_LINUX OR OS_FREEBSD)))
+    message (STATUS "Not using LLVM XRay, only amd64 Linux or FreeBSD are supported")
+    return()
+endif()
+
+# The target clang must support xray, otherwise it should error on invalid option
+set (XRAY_FLAGS "-fxray-instrument -DUSE_XRAY")
+set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${XRAY_FLAGS}")
+set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${XRAY_FLAGS}")
+
+message (STATUS "Using LLVM XRay")

--- a/src/Daemon/BaseDaemon.cpp
+++ b/src/Daemon/BaseDaemon.cpp
@@ -738,6 +738,7 @@ std::string BaseDaemon::getDefaultConfigFileName() const
 
 void BaseDaemon::closeFDs()
 {
+#if !defined(USE_XRAY)
     /// NOTE: may benefit from close_range() (linux 5.9+)
 #if defined(OS_FREEBSD) || defined(OS_DARWIN)
     fs::path proc_path{"/dev/fd"};
@@ -785,13 +786,13 @@ void BaseDaemon::closeFDs()
             }
         }
     }
+#endif
 }
 
 
 void BaseDaemon::initialize(Application & self)
 {
     closeFDs();
-
     ServerApplication::initialize(self);
 
     /// now highest priority (lowest value) is PRIO_APPLICATION = -100, we want higher!


### PR DESCRIPTION
@alexey-milovidov I'm taking the XRay into Clickhouse task https://github.com/ClickHouse/ClickHouse/pull/34160
you can close the old PR.

It actually works, the `llvm-xray account` tests in the old PR missed (`--deduce-sibling-calls` or `-d`) and (`--keep-going` or `-k`). Here is a relevant test case I sent to llvm-project:  https://github.com/llvm/llvm-project/pull/93564.

Changes from old PR: 

- Set to OFF by default.
- Check OS on build by llvm docs.
- Add build messages.
- Move conditional closeFDs() from BaseDaemon::initialize to the callee because its also called directly.
 
Note: This is a global setup, like the old PR. 

Future PRs:

- Add `-fxray-function-groups=n` support to the build, for hash based sampling, maybe randomized with CMake's PRNG.
- Implement ThreadFuzzer with XRay.

### Changelog category (leave one):

- Build/Testing/Packaging Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Add support for LLVM XRay.
