### PR TITLE
Speedup find_* keeper-client commands by making multiple async getChildren requests

### DIFF
--- a/programs/keeper-client/Commands.cpp
+++ b/programs/keeper-client/Commands.cpp
@@ -267,7 +267,7 @@ public:
         if (traverse_children)
         {
             /// Schedule traversal of each child
-            for (auto & child : response.names)
+            for (const auto & child : response.names)
             {
                 auto task = std::make_shared<TraversalTask>(path / child, this->shared_from_this());
                 ctx.new_tasks.push_back(task);

--- a/programs/keeper-client/Commands.cpp
+++ b/programs/keeper-client/Commands.cpp
@@ -375,14 +375,14 @@ void FindSuperNodes::execute(const ASTKeeperQuery * query, KeeperClient * client
 
     struct
     {
-        bool onListChildren(const fs::path & path, const Strings & children)
+        bool onListChildren(const fs::path & path, const Strings & children) const
         {
             if (children.size() >= threshold)
                 std::cout << static_cast<String>(path) << "\t" << children.size() << "\n";
             return true;
         }
 
-        void onFinishChildrenTraversal(const fs::path &, Int64) {}
+        void onFinishChildrenTraversal(const fs::path &, Int64) const {}
 
         size_t threshold;
     } ctx {.threshold = threshold };
@@ -461,7 +461,7 @@ void FindBigFamily::execute(const ASTKeeperQuery * query, KeeperClient * client)
     {
         std::vector<std::tuple<Int64, String>> result;
 
-        bool onListChildren(const fs::path &, const Strings &) { return true; }
+        bool onListChildren(const fs::path &, const Strings &) const { return true; }
 
         void onFinishChildrenTraversal(const fs::path & path, Int64 nodes_in_subtree)
         {

--- a/programs/keeper-client/Commands.cpp
+++ b/programs/keeper-client/Commands.cpp
@@ -11,7 +11,6 @@ namespace DB
 namespace ErrorCodes
 {
     extern const int LOGICAL_ERROR;
-    extern const int KEEPER_EXCEPTION;
 }
 
 bool LSCommand::parse(IParser::Pos & pos, std::shared_ptr<ASTKeeperQuery> & node, Expected & expected) const

--- a/programs/keeper-client/Commands.cpp
+++ b/programs/keeper-client/Commands.cpp
@@ -214,6 +214,141 @@ void GetStatCommand::execute(const ASTKeeperQuery * query, KeeperClient * client
     std::cout << "numChildren = " << stat.numChildren << "\n";
 }
 
+namespace
+{
+
+/// Helper class for parallelized tree traversal
+template <class UserCtx>
+struct TraversalTask : public std::enable_shared_from_this<TraversalTask<UserCtx>>
+{
+    using TraversalTaskPtr = std::shared_ptr<TraversalTask<UserCtx>>;
+
+    struct Ctx
+    {
+        std::deque<TraversalTaskPtr> new_tasks; /// Tasks for newly discovered children, that hasn't been started yet
+        std::deque<std::function<void(Ctx &)>> in_flight_list_requests;  /// In-flight getChildren requests
+        std::deque<std::function<void(Ctx &)>> finish_callbacks;    /// Callbacks to be called
+        KeeperClient * client;
+        UserCtx & user_ctx;
+    };
+
+private:
+    const fs::path path;
+    const TraversalTaskPtr parent;
+
+    Int64 child_tasks = 0;
+    Int64 nodes_in_subtree = 1;
+
+public:
+    TraversalTask(const fs::path & path_, TraversalTaskPtr parent_)
+        : path(path_)
+        , parent(parent_)
+    {
+    }
+
+    /// Start traversing the subtree
+    void onStart(Ctx & ctx)
+    {
+        /// tryGetChildren doesn't throw if the node is not found (was deleted in the meantime)
+        std::shared_ptr<std::future<Coordination::ListResponse>> list_request =
+            std::make_shared<std::future<Coordination::ListResponse>>(ctx.client->zookeeper->asyncTryGetChildren(path));
+        ctx.in_flight_list_requests.push_back([task = this->shared_from_this(), list_request](Ctx & ctx_) mutable
+        {
+            task->onGetChildren(ctx_, list_request->get());
+        });
+    }
+
+    /// Called when getChildren request returns
+    void onGetChildren(Ctx & ctx, const Coordination::ListResponse & response)
+    {
+        const bool traverse_children = ctx.user_ctx.onListChildren(path, response.names);
+
+        if (traverse_children)
+        {
+            /// Schedule traversal of each child
+            for (auto & child : response.names)
+            {
+                auto task = std::make_shared<TraversalTask>(path / child, this->shared_from_this());
+                ctx.new_tasks.push_back(task);
+            }
+            child_tasks = response.names.size();
+        }
+
+        if (child_tasks == 0)
+            finish(ctx);
+    }
+
+    /// Called when a child subtree has been traversed
+    void onChildTraversalFinished(Ctx & ctx, Int64 child_nodes_in_subtree)
+    {
+        nodes_in_subtree += child_nodes_in_subtree;
+
+        --child_tasks;
+
+        /// Finish if all children have been traversed
+        if (child_tasks == 0)
+            finish(ctx);
+    }
+
+private:
+    /// This node and all its children have been traversed
+    void finish(Ctx & ctx)
+    {
+        ctx.user_ctx.onFinishChildrenTraversal(path, nodes_in_subtree);
+
+        if (!parent)
+            return;
+
+        /// Notify the parent that we have finished traversing the subtree
+        ctx.finish_callbacks.push_back([p = this->parent, child_nodes_in_subtree = this->nodes_in_subtree](Ctx & ctx_)
+        {
+            p->onChildTraversalFinished(ctx_, child_nodes_in_subtree);
+        });
+    }
+};
+
+/// Traverses the tree in parallel and calls user callbacks
+/// Parallelization is achieved by sending multiple async getChildren requests to Keeper, but all processing is done in a single thread
+template <class UserCtx>
+void parallelized_traverse(const fs::path & path, KeeperClient * client, size_t max_in_flight_requests, UserCtx & ctx_)
+{
+    typename TraversalTask<UserCtx>::Ctx ctx{.client = client, .user_ctx = ctx_};
+
+    auto root_task = std::make_shared<TraversalTask<UserCtx>>(path, nullptr);
+
+    ctx.new_tasks.push_back(root_task);
+
+    /// Until there is something to do
+    while (!ctx.new_tasks.empty() || !ctx.in_flight_list_requests.empty() || !ctx.finish_callbacks.empty())
+    {
+        /// First process all finish callbacks, they don't wait for anything and allow to free memory
+        while (!ctx.finish_callbacks.empty())
+        {
+            auto callback = std::move(ctx.finish_callbacks.front());
+            ctx.finish_callbacks.pop_front();
+            callback(ctx);
+        }
+
+        /// Make new requests if there are less than max in flight
+        while (!ctx.new_tasks.empty() && ctx.in_flight_list_requests.size() < max_in_flight_requests)
+        {
+            auto task = std::move(ctx.new_tasks.front());
+            ctx.new_tasks.pop_front();
+            task->onStart(ctx);
+        }
+
+        /// Wait for first request in the queue to finish
+        if (!ctx.in_flight_list_requests.empty())
+        {
+            auto request = std::move(ctx.in_flight_list_requests.front());
+            ctx.in_flight_list_requests.pop_front();
+            request(ctx);
+        }
+    }
+}
+
+} /// anonymous namespace
+
 bool FindSuperNodes::parse(IParser::Pos & pos, std::shared_ptr<ASTKeeperQuery> & node, Expected & expected) const
 {
     ASTPtr threshold;
@@ -237,27 +372,23 @@ void FindSuperNodes::execute(const ASTKeeperQuery * query, KeeperClient * client
     auto threshold = query->args[0].safeGet<UInt64>();
     auto path = client->getAbsolutePath(query->args[1].safeGet<String>());
 
-    Coordination::Stat stat;
-    if (!client->zookeeper->exists(path, &stat))
-        return; /// It is ok if node was deleted meanwhile
-
-    if (stat.numChildren >= static_cast<Int32>(threshold))
-        std::cout << static_cast<String>(path) << "\t" << stat.numChildren << "\n";
-
-    Strings children;
-    auto status = client->zookeeper->tryGetChildren(path, children);
-    if (status == Coordination::Error::ZNONODE)
-        return; /// It is ok if node was deleted meanwhile
-    else if (status != Coordination::Error::ZOK)
-        throw DB::Exception(DB::ErrorCodes::KEEPER_EXCEPTION, "Error {} while getting children of {}", status, path.string());
-
-    std::sort(children.begin(), children.end());
-    auto next_query = *query;
-    for (const auto & child : children)
+    struct
     {
-        next_query.args[1] = DB::Field(path / child);
-        execute(&next_query, client);
-    }
+        std::vector<std::tuple<Int64, String>> result;
+
+        bool onListChildren(const fs::path & path, const Strings & children)
+        {
+            if (children.size() >= threshold)
+                std::cout << static_cast<String>(path) << "\t" << children.size() << "\n";
+            return true;
+        }
+
+        void onFinishChildrenTraversal(const fs::path &, Int64) {}
+
+        size_t threshold;
+    } ctx {.threshold = threshold };
+
+    parallelized_traverse(path, client, 50, ctx);
 }
 
 bool DeleteStaleBackups::parse(IParser::Pos & /* pos */, std::shared_ptr<ASTKeeperQuery> & /* node */, Expected & /* expected */) const
@@ -322,38 +453,28 @@ bool FindBigFamily::parse(IParser::Pos & pos, std::shared_ptr<ASTKeeperQuery> & 
     return true;
 }
 
-/// DFS the subtree and return the number of nodes in the subtree
-static Int64 traverse(const fs::path & path, KeeperClient * client, std::vector<std::tuple<Int64, String>> & result)
-{
-    Int64 nodes_in_subtree = 1;
-
-    Strings children;
-    auto status = client->zookeeper->tryGetChildren(path, children);
-    if (status == Coordination::Error::ZNONODE)
-        return 0;
-    else if (status != Coordination::Error::ZOK)
-        throw DB::Exception(DB::ErrorCodes::KEEPER_EXCEPTION, "Error {} while getting children of {}", status, path.string());
-
-    for (auto & child : children)
-        nodes_in_subtree += traverse(path / child, client, result);
-
-    result.emplace_back(nodes_in_subtree, path.string());
-
-    return nodes_in_subtree;
-}
-
 void FindBigFamily::execute(const ASTKeeperQuery * query, KeeperClient * client) const
 {
     auto path = client->getAbsolutePath(query->args[0].safeGet<String>());
     auto n = query->args[1].safeGet<UInt64>();
 
-    std::vector<std::tuple<Int64, String>> result;
+    struct
+    {
+        std::vector<std::tuple<Int64, String>> result;
 
-    traverse(path, client, result);
+        bool onListChildren(const fs::path &, const Strings &) { return true; }
 
-    std::sort(result.begin(), result.end(), std::greater());
-    for (UInt64 i = 0; i < std::min(result.size(), static_cast<size_t>(n)); ++i)
-        std::cout << std::get<1>(result[i]) << "\t" << std::get<0>(result[i]) << "\n";
+        void onFinishChildrenTraversal(const fs::path & path, Int64 nodes_in_subtree)
+        {
+            result.emplace_back(nodes_in_subtree, path.string());
+        }
+    } ctx;
+
+    parallelized_traverse(path, client, 50, ctx);
+
+    std::sort(ctx.result.begin(), ctx.result.end(), std::greater());
+    for (UInt64 i = 0; i < std::min(ctx.result.size(), static_cast<size_t>(n)); ++i)
+        std::cout << std::get<1>(ctx.result[i]) << "\t" << std::get<0>(ctx.result[i]) << "\n";
 }
 
 bool RMCommand::parse(IParser::Pos & pos, std::shared_ptr<ASTKeeperQuery> & node, Expected & expected) const

--- a/programs/keeper-client/Commands.cpp
+++ b/programs/keeper-client/Commands.cpp
@@ -229,6 +229,8 @@ struct TraversalTask : public std::enable_shared_from_this<TraversalTask<UserCtx
         std::deque<std::function<void(Ctx &)>> finish_callbacks;    /// Callbacks to be called
         KeeperClient * client;
         UserCtx & user_ctx;
+
+        Ctx(KeeperClient * client_, UserCtx & user_ctx_) : client(client_), user_ctx(user_ctx_) {}
     };
 
 private:
@@ -311,7 +313,7 @@ private:
 template <class UserCtx>
 void parallelized_traverse(const fs::path & path, KeeperClient * client, size_t max_in_flight_requests, UserCtx & ctx_)
 {
-    typename TraversalTask<UserCtx>::Ctx ctx{.client = client, .user_ctx = ctx_};
+    typename TraversalTask<UserCtx>::Ctx ctx(client, ctx_);
 
     auto root_task = std::make_shared<TraversalTask<UserCtx>>(path, nullptr);
 
@@ -373,8 +375,6 @@ void FindSuperNodes::execute(const ASTKeeperQuery * query, KeeperClient * client
 
     struct
     {
-        std::vector<std::tuple<Int64, String>> result;
-
         bool onListChildren(const fs::path & path, const Strings & children)
         {
             if (children.size() >= threshold)

--- a/programs/keeper-client/Commands.cpp
+++ b/programs/keeper-client/Commands.cpp
@@ -387,7 +387,7 @@ void FindSuperNodes::execute(const ASTKeeperQuery * query, KeeperClient * client
         size_t threshold;
     } ctx {.threshold = threshold };
 
-    parallelized_traverse(path, client, 50, ctx);
+    parallelized_traverse(path, client, /* max_in_flight_requests */ 50, ctx);
 }
 
 bool DeleteStaleBackups::parse(IParser::Pos & /* pos */, std::shared_ptr<ASTKeeperQuery> & /* node */, Expected & /* expected */) const
@@ -469,7 +469,7 @@ void FindBigFamily::execute(const ASTKeeperQuery * query, KeeperClient * client)
         }
     } ctx;
 
-    parallelized_traverse(path, client, 50, ctx);
+    parallelized_traverse(path, client, /* max_in_flight_requests */ 50, ctx);
 
     std::sort(ctx.result.begin(), ctx.result.end(), std::greater());
     for (UInt64 i = 0; i < std::min(ctx.result.size(), static_cast<size_t>(n)); ++i)

--- a/tests/integration/test_keeper_client/test.py
+++ b/tests/integration/test_keeper_client/test.py
@@ -61,7 +61,6 @@ def test_big_family(client: KeeperClient):
     )
 
     response = client.find_big_family("/test_big_family", 2)
-
     assert response == TSV(
         [
             ["/test_big_family", "11"],
@@ -87,7 +86,12 @@ def test_find_super_nodes(client: KeeperClient):
     client.cd("/test_find_super_nodes")
 
     response = client.find_super_nodes(4)
-    assert response == TSV(
+
+    # The order of the response is not guaranteed, so we need to sort it
+    normalized_response = response.strip().split("\n")
+    normalized_response.sort();
+
+    assert TSV(normalized_response) == TSV(
         [
             ["/test_find_super_nodes/1", "5"],
             ["/test_find_super_nodes/2", "4"],

--- a/tests/integration/test_keeper_client/test.py
+++ b/tests/integration/test_keeper_client/test.py
@@ -89,7 +89,7 @@ def test_find_super_nodes(client: KeeperClient):
 
     # The order of the response is not guaranteed, so we need to sort it
     normalized_response = response.strip().split("\n")
-    normalized_response.sort();
+    normalized_response.sort()
 
     assert TSV(normalized_response) == TSV(
         [

--- a/tests/queries/0_stateless/03135_keeper_client_find_commands.sh
+++ b/tests/queries/0_stateless/03135_keeper_client_find_commands.sh
@@ -21,7 +21,7 @@ $CLICKHOUSE_KEEPER_CLIENT -q "create $path/1/d/c 'foobar'"
 
 echo 'find_super_nodes'
 $CLICKHOUSE_KEEPER_CLIENT -q "find_super_nodes 1000000000"
-$CLICKHOUSE_KEEPER_CLIENT -q "find_super_nodes 3 $path"
+$CLICKHOUSE_KEEPER_CLIENT -q "find_super_nodes 3 $path" | sort
 
 echo 'find_big_family'
 $CLICKHOUSE_KEEPER_CLIENT -q "find_big_family $path 3"


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Speedup `find_super_nodes` and `find_big_family` keeper-client commands by making multiple asynchronous getChildren requests.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

<details>
    <summary>CI Settings</summary>

**NOTE:** If your merge the PR with modified CI you **MUST KNOW** what you are doing
**NOTE:** Checked options will be applied if set before CI RunConfig/PrepareRunConfig step
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_unit--> Allow: Unit tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_include_aarch64--> Allow: All with aarch64
- [ ] <!---ci_include_asan--> Allow: All with ASAN
- [ ] <!---ci_include_tsan--> Allow: All with TSAN
- [ ] <!---ci_include_analyzer--> Allow: All with Analyzer
- [ ] <!---ci_include_azure --> Allow: All with Azure
- [ ] <!---ci_include_KEYWORD--> Allow: Add your option here
---
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_integration--> Exclude: Integration Tests
- [ ] <!---ci_exclude_stateless--> Exclude: Stateless tests
- [ ] <!---ci_exclude_stateful--> Exclude: Stateful tests
- [ ] <!---ci_exclude_performance--> Exclude: Performance tests
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan--> Exclude: All with TSAN
- [ ] <!---ci_exclude_msan--> Exclude: All with MSAN
- [ ] <!---ci_exclude_ubsan--> Exclude: All with UBSAN
- [ ] <!---ci_exclude_coverage--> Exclude: All with Coverage
- [ ] <!---ci_exclude_aarch64--> Exclude: All with Aarch64
---
- [ ] <!---do_not_test--> do not test (only style check)
- [ ] <!---no_merge_commit--> disable merge-commit (no merge from master before tests)
- [ ] <!---no_ci_cache--> disable CI cache (job reuse)
- [ ] <!---batch_0--> allow: batch 1 for multi-batch jobs
- [ ] <!---batch_1--> allow: batch 2
- [ ] <!---batch_2--> allow: batch 3
- [ ] <!---batch_3_4_5--> allow: batch 4, 5 and 6
</details>
