### PR TITLE
Fix type inference for float (in case of small buffer)

### DIFF
--- a/src/IO/readFloatText.h
+++ b/src/IO/readFloatText.h
@@ -320,10 +320,12 @@ static inline void readUIntTextUpToNSignificantDigits(T & x, ReadBuffer & buf)
 
 
 template <typename T, typename ReturnType, bool allow_exponent = true>
-ReturnType readFloatTextFastImpl(T & x, ReadBuffer & in)
+ReturnType readFloatTextFastImpl(T & x, ReadBuffer & in, bool & has_fractional)
 {
     static_assert(std::is_same_v<T, double> || std::is_same_v<T, float>, "Argument for readFloatTextImpl must be float or double");
     static_assert('a' > '.' && 'A' > '.' && '\n' < '.' && '\t' < '.' && '\'' < '.' && '"' < '.', "Layout of char is not like ASCII");
+
+    has_fractional = false;
 
     static constexpr bool throw_exception = std::is_same_v<ReturnType, void>;
 
@@ -377,6 +379,7 @@ ReturnType readFloatTextFastImpl(T & x, ReadBuffer & in)
 
     if (checkChar('.', in))
     {
+        has_fractional = true;
         auto after_point_count = in.count();
 
         while (!in.eof() && *in.position() == '0')
@@ -394,6 +397,7 @@ ReturnType readFloatTextFastImpl(T & x, ReadBuffer & in)
     {
         if (checkChar('e', in) || checkChar('E', in))
         {
+            has_fractional = true;
             if (in.eof())
             {
                 if constexpr (throw_exception)
@@ -420,10 +424,14 @@ ReturnType readFloatTextFastImpl(T & x, ReadBuffer & in)
     }
 
     if (after_point)
+    {
         x += static_cast<T>(shift10(after_point, after_point_exponent));
+    }
 
     if (exponent)
+    {
         x = static_cast<T>(shift10(x, exponent));
+    }
 
     if (negative)
         x = -x;
@@ -590,8 +598,16 @@ ReturnType readFloatTextSimpleImpl(T & x, ReadBuffer & buf)
 template <typename T> void readFloatTextPrecise(T & x, ReadBuffer & in) { readFloatTextPreciseImpl<T, void>(x, in); }
 template <typename T> bool tryReadFloatTextPrecise(T & x, ReadBuffer & in) { return readFloatTextPreciseImpl<T, bool>(x, in); }
 
-template <typename T> void readFloatTextFast(T & x, ReadBuffer & in) { readFloatTextFastImpl<T, void>(x, in); }
-template <typename T> bool tryReadFloatTextFast(T & x, ReadBuffer & in) { return readFloatTextFastImpl<T, bool>(x, in); }
+template <typename T> void readFloatTextFast(T & x, ReadBuffer & in)
+{
+    bool has_fractional;
+    readFloatTextFastImpl<T, void>(x, in, has_fractional);
+}
+template <typename T> bool tryReadFloatTextFast(T & x, ReadBuffer & in)
+{
+    bool has_fractional;
+    return readFloatTextFastImpl<T, bool>(x, in, has_fractional);
+}
 
 template <typename T> void readFloatTextSimple(T & x, ReadBuffer & in) { readFloatTextSimpleImpl<T, void>(x, in); }
 template <typename T> bool tryReadFloatTextSimple(T & x, ReadBuffer & in) { return readFloatTextSimpleImpl<T, bool>(x, in); }
@@ -603,6 +619,21 @@ template <typename T> void readFloatText(T & x, ReadBuffer & in) { readFloatText
 template <typename T> bool tryReadFloatText(T & x, ReadBuffer & in) { return tryReadFloatTextFast(x, in); }
 
 /// Don't read exponent part of the number.
-template <typename T> bool tryReadFloatTextNoExponent(T & x, ReadBuffer & in) { return readFloatTextFastImpl<T, bool, false>(x, in); }
+template <typename T> bool tryReadFloatTextNoExponent(T & x, ReadBuffer & in)
+{
+    bool has_fractional;
+    return readFloatTextFastImpl<T, bool, false>(x, in, has_fractional);
+}
+
+/// With a @has_fractional flag
+/// Used for input_format_try_infer_integers
+template <typename T> bool tryReadFloatTextExt(T & x, ReadBuffer & in, bool & has_fractional)
+{
+    return readFloatTextFastImpl<T, bool>(x, in, has_fractional);
+}
+template <typename T> bool tryReadFloatTextExtNoExponent(T & x, ReadBuffer & in, bool & has_fractional)
+{
+    return readFloatTextFastImpl<T, bool, false>(x, in, has_fractional);
+}
 
 }

--- a/tests/queries/0_stateless/03170_float_schema_inference_small_block.reference
+++ b/tests/queries/0_stateless/03170_float_schema_inference_small_block.reference
@@ -1,0 +1,15 @@
+Int64
+x	Nullable(Int64)					
+x	Nullable(Int64)					
+x	Nullable(Int64)					
+Float64
+x	Nullable(Float64)					
+x	Nullable(Float64)					
+x	Nullable(Float64)					
+x	Nullable(Float64)					
+Float64.explicit File
+x	Nullable(Float64)					
+Float64.pipe
+x	Nullable(Float64)					
+Float64.default max_read_buffer_size
+x	Nullable(Float64)					

--- a/tests/queries/0_stateless/03170_float_schema_inference_small_block.sh
+++ b/tests/queries/0_stateless/03170_float_schema_inference_small_block.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+# do not fallback to float always
+echo "Int64"
+$CLICKHOUSE_LOCAL --storage_file_read_method read --max_read_buffer_size 1 --input-format JSONEachRow 'desc "table"' <<<'{"x" : 1}'
+$CLICKHOUSE_LOCAL --storage_file_read_method read --max_read_buffer_size 1 --input-format JSONEachRow 'desc "table"' <<<'{"x" : +1}'
+$CLICKHOUSE_LOCAL --storage_file_read_method read --max_read_buffer_size 1 --input-format JSONEachRow 'desc "table"' <<<'{"x" : -1}'
+
+echo "Float64"
+$CLICKHOUSE_LOCAL --storage_file_read_method read --max_read_buffer_size 1 --input-format JSONEachRow 'desc "table"' <<<'{"x" : 1.1}'
+$CLICKHOUSE_LOCAL --storage_file_read_method read --max_read_buffer_size 1 --input-format JSONEachRow 'desc "table"' <<<'{"x" : +1.1}'
+$CLICKHOUSE_LOCAL --storage_file_read_method read --max_read_buffer_size 1 --input-format JSONEachRow 'desc "table"' <<<'{"x" : 1.111}'
+$CLICKHOUSE_LOCAL --storage_file_read_method read --max_read_buffer_size 1 --input-format JSONEachRow 'desc "table"' <<<'{"x" : +1.111}'
+
+# this is requried due to previously clickhouse-local does not interprets
+# --max_read_buffer_size for fds [1]
+#
+#   [1]: https://github.com/ClickHouse/ClickHouse/pull/64532
+echo "Float64.explicit File"
+tmp_path=$(mktemp "$CUR_DIR/03170_float_schema_inference_small_block.json.XXXXXX")
+trap 'rm -f $tmp_path' EXIT
+cat > "$tmp_path" <<<'{"x" : 1.111}'
+$CLICKHOUSE_LOCAL --storage_file_read_method read --max_read_buffer_size 1 --input-format JSONEachRow 'desc "table"' --file "$tmp_path"
+
+echo "Float64.pipe"
+echo '{"x" : 1.1}' | $CLICKHOUSE_LOCAL --storage_file_read_method read --max_read_buffer_size 1 --input-format JSONEachRow 'desc "table"'
+echo "Float64.default max_read_buffer_size"
+echo '{"x" : 1.1}' | $CLICKHOUSE_LOCAL --storage_file_read_method read --input-format JSONEachRow 'desc "table"'


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix type inference for float (in case of small buffer, i.e. `--max_read_buffer_size 1`)

In case of small buffer (i.e. --max_read_buffer_size 1) the pos() will
be always point to this one byte, so, comparing pos() will be always
evaluated to true.

And we cannot use count() as well, since in case of big buffer it will
be the same, plus, in case of reading extra byte for checking for '.'
the count() will be different, but it does not mean that the byte had
been interpreted (and allowing 1 byte of difference will not work almost
always, since it will read max_read_buffer_size bytes).

So instead, expose the has_fractional flag from the read helpers for
float, via two new methods:
- tryReadFloatTextExt
- tryReadFloatTextExtNoExponent

Where "ext" stands for "extended", which means expose extra information.

Cc: @Avogar 