### PR TITLE
CI: Do not upload binaries for special builds in PRs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -72,10 +72,10 @@ At a minimum, the following information should be added (but add more as needed)
 - [ ] <!---ci_exclude_aarch64--> Exclude: All with Aarch64
 ---
 - [ ] <!---do_not_test--> do not test (only style check)
+- [ ] <!---upload_all--> upload all binary artifacts from build jobs
 - [ ] <!---no_merge_commit--> disable merge-commit (no merge from master before tests)
 - [ ] <!---no_ci_cache--> disable CI cache (job reuse)
-- [ ] <!---batch_0--> allow: batch 1 for multi-batch jobs
-- [ ] <!---batch_1--> allow: batch 2
-- [ ] <!---batch_2--> allow: batch 3
-- [ ] <!---batch_3_4_5--> allow: batch 4, 5 and 6
+- [ ] <!---batch_0_1--> allow: batch 1, 2 for multi-batch jobs
+- [ ] <!---batch_2_3--> allow: batch 3, 4
+- [ ] <!---batch_4_5--> allow: batch 5, 6
 </details>

--- a/tests/ci/ci.py
+++ b/tests/ci/ci.py
@@ -895,9 +895,10 @@ class CiOptions:
                     for job in job_with_parents:
                         if job in jobs_to_do and job not in jobs_to_do_requested:
                             jobs_to_do_requested.append(job)
-            print(
-                f"WARNING: Include tags are set but no job configured - Invalid tags, probably [{self.include_keywords}]"
-            )
+            if not jobs_to_do_requested:
+                print(
+                    f"WARNING: Include tags are set but no job configured - Invalid tags, probably [{self.include_keywords}]"
+                )
             if JobNames.STYLE_CHECK not in jobs_to_do_requested:
                 # Style check must not be omitted
                 jobs_to_do_requested.append(JobNames.STYLE_CHECK)

--- a/tests/ci/ci.py
+++ b/tests/ci/ci.py
@@ -754,6 +754,7 @@ class CiOptions:
 
     do_not_test: bool = False
     no_ci_cache: bool = False
+    upload_all: bool = False
     no_merge_commit: bool = False
 
     def as_dict(self) -> Dict[str, Any]:
@@ -823,6 +824,9 @@ class CiOptions:
             elif match == CILabels.NO_CI_CACHE:
                 res.no_ci_cache = True
                 print("NOTE: CI Cache will be disabled")
+            elif match == CILabels.UPLOAD_ALL_ARTIFACTS:
+                res.upload_all = True
+                print("NOTE: All binary artifacts will be uploaded")
             elif match == CILabels.DO_NOT_TEST_LABEL:
                 res.do_not_test = True
             elif match == CILabels.NO_MERGE_COMMIT:
@@ -2191,6 +2195,7 @@ def main() -> int:
                     not pr_info.is_pr
                     or args.job_name
                     not in CI_CONFIG.get_builds_for_report(JobNames.BUILD_CHECK_SPECIAL)
+                    or CiOptions.create_from_run_config(indata).upload_all
                 )
 
                 build_name = args.job_name

--- a/tests/ci/ci_config.py
+++ b/tests/ci/ci_config.py
@@ -705,10 +705,7 @@ class CIConfig:
                     elif isinstance(config[job_name], BuildConfig):  # type: ignore
                         pass
                     elif isinstance(config[job_name], BuildReportConfig):  # type: ignore
-                        # add all build jobs as parents for build report check
-                        res.extend(
-                            [job for job in JobNames if job in self.build_config]
-                        )
+                        pass
                     else:
                         assert (
                             False

--- a/tests/ci/ci_config.py
+++ b/tests/ci/ci_config.py
@@ -47,6 +47,8 @@ class CILabels(metaclass=WithIter):
     DO_NOT_TEST_LABEL = "do_not_test"
     NO_MERGE_COMMIT = "no_merge_commit"
     NO_CI_CACHE = "no_ci_cache"
+    # to upload all binaries from build jobs
+    UPLOAD_ALL_ARTIFACTS = "upload_all"
     CI_SET_REDUCED = "ci_set_reduced"
     CI_SET_FAST = "ci_set_fast"
     CI_SET_ARM = "ci_set_arm"


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

### CI Settings:

**NOTE:** If your merge the PR with modified CI you **MUST KNOW** what you are doing
**NOTE:** Checked options will be applied if set before CI RunConfig/PrepareRunConfig step
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_unit--> Allow: Unit tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_include_aarch64--> Allow: All with aarch64
- [ ] <!---ci_include_asan--> Allow: All with ASAN
- [ ] <!---ci_include_tsan--> Allow: All with TSAN
- [ ] <!---ci_include_analyzer--> Allow: All with Analyzer
- [x] <!---ci_include_special --> Allow: special report
- [x] <!---ci_include_darwin_aarch64--> one build
---
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_integration--> Exclude: Integration Tests
- [ ] <!---ci_exclude_stateless--> Exclude: Stateless tests
- [ ] <!---ci_exclude_stateful--> Exclude: Stateful tests
- [ ] <!---ci_exclude_performance--> Exclude: Performance tests
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan--> Exclude: All with TSAN
- [ ] <!---ci_exclude_msan--> Exclude: All with MSAN
- [ ] <!---ci_exclude_ubsan--> Exclude: All with UBSAN
- [ ] <!---ci_exclude_coverage--> Exclude: All with Coverage
- [ ] <!---ci_exclude_aarch64--> Exclude: All with Aarch64
---
- [ ] <!---do_not_test--> do not test (only style check)
- [ ] <!---upload_all--> upload all binary artifacts from build jobs
- [ ] <!---no_merge_commit--> disable merge-commit (no merge from master before tests)
- [x] <!---no_ci_cache--> disable CI cache (job reuse)
- [ ] <!---batch_0_1--> allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> allow: batch 3, 4
- [ ] <!---batch_4_5--> allow: batch 5, 6
</details>
