### PR TITLE
CI: CI running status fix

### DIFF
--- a/tests/ci/commit_status_helper.py
+++ b/tests/ci/commit_status_helper.py
@@ -84,7 +84,7 @@ def get_commit(gh: Github, commit_sha: str, retry_count: int = RETRY) -> Commit:
 
 def post_commit_status(
     commit: Commit,
-    state: StatusType,
+    state: Union[StatusType, str],
     report_url: Optional[str] = None,
     description: Optional[str] = None,
     check_name: Optional[str] = None,

--- a/tests/ci/finish_check.py
+++ b/tests/ci/finish_check.py
@@ -15,7 +15,7 @@ from commit_status_helper import (
 )
 from get_robot_token import get_best_robot_token
 from pr_info import PRInfo
-from report import PENDING
+from report import PENDING, SUCCESS, FAILURE
 from synchronizer_utils import SYNC_BRANCH_PREFIX
 from env_helper import GITHUB_REPOSITORY, GITHUB_UPSTREAM_REPOSITORY
 
@@ -59,16 +59,40 @@ def main():
                 can_set_green_mergeable_status=True,
             )
 
-        statuses = [s for s in statuses if s.context == StatusNames.CI]
-        if not statuses:
+        ci_running_statuses = [s for s in statuses if s.context == StatusNames.CI]
+        if not ci_running_statuses:
             return
         # Take the latest status
-        status = statuses[-1]
-        if status.state == PENDING:
+        ci_status = ci_running_statuses[-1]
+
+        has_failure = False
+        has_pending = False
+        for status in statuses:
+            if status.context in (StatusNames.MERGEABLE, StatusNames.CI):
+                # do not account these statuses
+                continue
+            if status.state == PENDING:
+                if status.context == StatusNames.SYNC:
+                    # do not account sync status if pending - it's a different WF
+                    continue
+                has_pending = True
+            elif status.state == SUCCESS:
+                continue
+            else:
+                has_failure = True
+
+        ci_state = SUCCESS
+        if has_failure:
+            ci_state = FAILURE
+        elif has_pending:
+            print("ERROR: CI must not have pending jobs by the time of finish check")
+            ci_state = FAILURE
+
+        if ci_status.state == PENDING:
             post_commit_status(
                 commit,
-                state,  # map Mergeable Check status to CI Running
-                status.target_url,
+                ci_state,
+                ci_status.target_url,
                 "All checks finished",
                 StatusNames.CI,
                 pr_info,


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
By the end of CI, CI_Running status must be SUCCESS or FAILURE never PENDING

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

<details>
    <summary>CI Settings</summary>

**NOTE:** If your merge the PR with modified CI you **MUST KNOW** what you are doing
**NOTE:** Checked options will be applied if set before CI RunConfig/PrepareRunConfig step
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_unit--> Allow: Unit tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_include_aarch64--> Allow: All with aarch64
- [ ] <!---ci_include_asan--> Allow: All with ASAN
- [ ] <!---ci_include_tsan--> Allow: All with TSAN
- [ ] <!---ci_include_analyzer--> Allow: All with Analyzer
- [ ] <!---ci_include_azure --> Allow: All with Azure
- [ ] <!---ci_include_KEYWORD--> Allow: Add your option here
---
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_integration--> Exclude: Integration Tests
- [ ] <!---ci_exclude_stateless--> Exclude: Stateless tests
- [ ] <!---ci_exclude_stateful--> Exclude: Stateful tests
- [ ] <!---ci_exclude_performance--> Exclude: Performance tests
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan--> Exclude: All with TSAN
- [ ] <!---ci_exclude_msan--> Exclude: All with MSAN
- [ ] <!---ci_exclude_ubsan--> Exclude: All with UBSAN
- [ ] <!---ci_exclude_coverage--> Exclude: All with Coverage
- [ ] <!---ci_exclude_aarch64--> Exclude: All with Aarch64
---
- [x] <!---do_not_test--> do not test (only style check)
- [ ] <!---upload_all--> upload all binary artifacts from build jobs
- [ ] <!---no_merge_commit--> disable merge-commit (no merge from master before tests)
- [ ] <!---no_ci_cache--> disable CI cache (job reuse)
- [ ] <!---batch_0_1--> allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> allow: batch 3, 4
- [ ] <!---batch_4_5--> allow: batch 5, 6
</details>
