### PR TITLE
Check for missing Upload ID in CreateMultipartUpload reply

### DIFF
--- a/src/IO/S3/copyS3File.cpp
+++ b/src/IO/S3/copyS3File.cpp
@@ -154,16 +154,13 @@ namespace
                 ProfileEvents::increment(ProfileEvents::WriteBufferFromS3RequestsErrors, 1);
                 throw S3Exception(outcome.GetError().GetMessage(), outcome.GetError().GetErrorType());
             }
-            else if (outcome.GetResult().GetUploadId().empty())
+            multipart_upload_id = outcome.GetResult().GetUploadId();
+            if (multipart_upload_id.empty())
             {
                 ProfileEvents::increment(ProfileEvents::WriteBufferFromS3RequestsErrors, 1);
                 throw Exception(ErrorCodes::S3_ERROR, "Invalid CreateMultipartUpload result: missing UploadId.");
             }
-            else
-            {
-                multipart_upload_id = outcome.GetResult().GetUploadId();
-                LOG_TRACE(log, "Multipart upload was created. Bucket: {}, Key: {}, Upload id: {}", dest_bucket, dest_key, multipart_upload_id);
-            }
+            LOG_TRACE(log, "Multipart upload was created. Bucket: {}, Key: {}, Upload id: {}", dest_bucket, dest_key, multipart_upload_id);
         }
 
         void completeMultipartUpload()

--- a/src/IO/S3/copyS3File.cpp
+++ b/src/IO/S3/copyS3File.cpp
@@ -149,15 +149,20 @@ namespace
                                            dest_bucket, dest_key, /* local_path_ */ {}, /* data_size */ 0,
                                            outcome.IsSuccess() ? nullptr : &outcome.GetError());
 
-            if (outcome.IsSuccess())
-            {
-                multipart_upload_id = outcome.GetResult().GetUploadId();
-                LOG_TRACE(log, "Multipart upload has created. Bucket: {}, Key: {}, Upload id: {}", dest_bucket, dest_key, multipart_upload_id);
-            }
-            else
+            if (!outcome.IsSuccess())
             {
                 ProfileEvents::increment(ProfileEvents::WriteBufferFromS3RequestsErrors, 1);
                 throw S3Exception(outcome.GetError().GetMessage(), outcome.GetError().GetErrorType());
+            }
+            else if (outcome.GetResult().GetUploadId().empty())
+            {
+                ProfileEvents::increment(ProfileEvents::WriteBufferFromS3RequestsErrors, 1);
+                throw Exception(ErrorCodes::S3_ERROR, "Invalid CreateMultipartUpload result: missing UploadId.");
+            }
+            else
+            {
+                multipart_upload_id = outcome.GetResult().GetUploadId();
+                LOG_TRACE(log, "Multipart upload was created. Bucket: {}, Key: {}, Upload id: {}", dest_bucket, dest_key, multipart_upload_id);
             }
         }
 

--- a/src/IO/WriteBufferFromS3.cpp
+++ b/src/IO/WriteBufferFromS3.cpp
@@ -413,7 +413,13 @@ void WriteBufferFromS3::createMultipartUpload()
 
     multipart_upload_id = outcome.GetResult().GetUploadId();
 
-    LOG_TRACE(limitedLog, "Multipart upload has created. {}", getShortLogDetails());
+    if (multipart_upload_id.empty())
+    {
+        ProfileEvents::increment(ProfileEvents::WriteBufferFromS3RequestsErrors, 1);
+        throw Exception(ErrorCodes::S3_ERROR, "Invalid CreateMultipartUpload result: missing UploadId.");
+    }
+
+    LOG_TRACE(limitedLog, "Multipart upload was created. {}", getShortLogDetails());
 }
 
 void WriteBufferFromS3::abortMultipartUpload()


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

We saw a LOGICAL_ERROR `Unable to write a part without multipart_upload_id` with stack trace:
```
0. DB::Exception::Exception(DB::Exception::MessageMasked&&, int, bool) @ 0x000000000cc51a5b
1. DB::Exception::Exception<String const&, String const&>(int, FormatStringHelperImpl<std::type_identity<String const&>::type, std::type_identity<String const&>::type>, String const&, String const&) @ 0x00000000076ec91d
2. DB::WriteBufferFromS3::writeMultipartUpload() @ 0x000000000fe5566e
3. DB::WriteBufferFromS3::nextImpl() @ 0x000000000fe51bc2
4. DB::WriteBufferFromFileDecorator::nextImpl() @ 0x00000000104485ef
5. DB::WriteBuffer::write(char const*, unsigned long) @ 0x00000000076f5f8d
[...]
```

It probably means that an empty id was assigned by `multipart_upload_id = outcome.GetResult().GetUploadId()`. This PR adds a check there.