### PR TITLE
Fix loop() table function crashing on empty table name

### DIFF
--- a/src/TableFunctions/TableFunctionLoop.cpp
+++ b/src/TableFunctions/TableFunctionLoop.cpp
@@ -108,7 +108,7 @@ namespace DB
             bool is_insert_query) const
     {
         StoragePtr storage;
-        if (!loop_table_name.empty())
+        if (!inner_table_function_ast)
         {
             String database_name = loop_database_name;
             if (database_name.empty())
@@ -119,7 +119,6 @@ namespace DB
             if (!storage)
                 throw Exception(ErrorCodes::UNKNOWN_TABLE, "Table '{}' not found in database '{}'", loop_table_name, database_name);
         }
-
         else
         {
             auto inner_table_function = TableFunctionFactory::instance().get(inner_table_function_ast, context);

--- a/tests/queries/0_stateless/03147_table_function_loop.sql
+++ b/tests/queries/0_stateless/03147_table_function_loop.sql
@@ -12,3 +12,5 @@ USE 03147_db;
 SELECT * FROM loop(03147_db.t) LIMIT 15;
 SELECT * FROM loop(t) LIMIT 15;
 SELECT * FROM loop(03147_db, t) LIMIT 15;
+
+SELECT * FROM loop('', '') -- { serverError UNKNOWN_TABLE }


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix (unreleased) `loop()` table function crashing on empty table name.

