### PR TITLE
Fix filling parts columns from metadata (when columns.txt does not exists)

### DIFF
--- a/src/Storages/MergeTree/IMergeTreeDataPart.cpp
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.cpp
@@ -1577,7 +1577,7 @@ void IMergeTreeDataPart::loadColumns(bool require)
             if (getFileNameForColumn(column))
                 loaded_columns.push_back(column);
 
-        if (columns.empty())
+        if (loaded_columns.empty())
             throw Exception(ErrorCodes::NO_FILE_IN_DATA_PART, "No columns in part {}", name);
 
         if (!is_readonly_storage)

--- a/src/Storages/MergeTree/MergeTreeDataPartWide.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataPartWide.cpp
@@ -298,6 +298,11 @@ std::optional<time_t> MergeTreeDataPartWide::getColumnModificationTime(const Str
 std::optional<String> MergeTreeDataPartWide::getFileNameForColumn(const NameAndTypePair & column) const
 {
     std::optional<String> filename;
+
+    /// Fallback for the case when serializations was not loaded yet (called from loadColumns())
+    if (getSerializations().empty())
+        return getStreamNameForColumn(column, {}, DATA_FILE_EXTENSION, getDataPartStorage());
+
     getSerialization(column.name)->enumerateStreams([&](const ISerialization::SubstreamPath & substream_path)
     {
         if (!filename.has_value())
@@ -309,6 +314,7 @@ std::optional<String> MergeTreeDataPartWide::getFileNameForColumn(const NameAndT
                 filename = getStreamNameForColumn(column, substream_path, DATA_FILE_EXTENSION, getDataPartStorage());
         }
     });
+
     return filename;
 }
 

--- a/tests/integration/test_max_suspicious_broken_parts/test.py
+++ b/tests/integration/test_max_suspicious_broken_parts/test.py
@@ -25,7 +25,7 @@ def break_part(table, part_name):
         [
             "bash",
             "-c",
-            f"rm /var/lib/clickhouse/data/default/{table}/{part_name}/columns.txt",
+            f"rm /var/lib/clickhouse/data/default/{table}/{part_name}/primary.cidx",
         ]
     )
 


### PR DESCRIPTION
The getFileNameForColumn() inside IMergeTreeDataPart::loadColumns()
requries serializations that will be filled only at the end of
loadColumns() (setColumns()):

    (lldb) bt
    * thread 718, name = 'ActiveParts', stop reason = breakpoint 1.1
      * frame 0: 0x00000000111e50dc clickhouse`DB::IMergeTreeDataPart::getSerialization(this=0x00007ffd18c39918, column_name="key") const + 124 at IMergeTreeDataPart.cpp:508
        frame 1: 0x0000000011340f57 clickhouse`DB::MergeTreeDataPartWide::getFileNameForColumn(this=0x00007ffd18c39918, column=<unavailable>) const + 55 at MergeTreeDataPartWide.cpp:301
        frame 2: 0x00000000111e9a2b clickhouse`DB::IMergeTreeDataPart::loadColumns(this=0x00007ffd18c39918, require=false) + 1067 at IMergeTreeDataPart.cpp:1577
        frame 3: 0x00000000111e8d52 clickhouse`DB::IMergeTreeDataPart::loadColumnsChecksumsIndexes(this=0x00007ffd18c39918, require_columns_checksums=<unavailable>, check_consistency=true) + 82 at IMergeTreeDataPart.cpp:713
        frame 4: 0x0000000011284c10 clickhouse`DB::MergeTreeData::loadDataPart(this=0x00007ffcf9242e40, part_info=0x00007ffcf937c298, part_name="2024", part_disk_ptr=std::__1::shared_ptr<DB::IDisk>::element_type @ 0x00007ffcf925af18 strong=11 weak=2, to_state=Active, part_loading_mutex=0x00007ffef97efeb0) + 3152 at MergeTreeData.cpp:1435

So let's add fallback into the getFileNameForColumn() in case of
serializations was not filled yet.

Note, that it is OK to add this check as a generic, since after
loadColumns() serializations cannot be empty, since loadColumns() does
not allows this (there is only one more caller of
getFileNameForColumn() - loadIndexGranularity())

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix filling parts columns from metadata (when columns.txt does not exists)

Cc: @CurtizJ 