### PR TITLE
Do not try to write columns.txt if it does not exists for write-once storages

### DIFF
--- a/src/Storages/MergeTree/DataPartStorageOnDiskBase.cpp
+++ b/src/Storages/MergeTree/DataPartStorageOnDiskBase.cpp
@@ -229,7 +229,7 @@ bool DataPartStorageOnDiskBase::isBroken() const
 
 bool DataPartStorageOnDiskBase::isReadonly() const
 {
-    return volume->getDisk()->isReadOnly();
+    return volume->getDisk()->isReadOnly() || volume->getDisk()->isWriteOnce();
 }
 
 void DataPartStorageOnDiskBase::syncRevision(UInt64 revision) const


### PR DESCRIPTION
Remember that write-once does not allows move:

    [local] 2024.06.03 17:21:22.520165 [ 10032 ] {c923ec81-c802-407f-8078-a5b46cec4d21} <Error> DiskObjectStorageTransaction: An error occurred while executing transaction's operation #0 (PureMetadataObjectStorageOperation): Code: 48. DB::Exception: Operation is not implemented. (NOT_IMPLEMENTED), Stack trace (when copying this message, always include the lines below):

    0. /src/ch/clickhouse/contrib/llvm-project/libcxx/include/exception:141: Poco::Exception::Exception(String const&, int) @ 0x00000000143113d6
    1. /src/ch/clickhouse/src/Common/Exception.cpp:101: DB::Exception::Exception(DB::Exception::MessageMasked&&, int, bool) @ 0x000000000ae2fd6c
    2. /src/ch/clickhouse/contrib/llvm-project/libcxx/include/string:1499: DB::Exception::Exception(PreformattedMessage&&, int) @ 0x0000000006133a61
    3. /src/ch/clickhouse/contrib/llvm-project/libcxx/include/vector:434: DB::Exception::Exception<>(int, FormatStringHelperImpl<>) @ 0x000000000613f0dc
    4. /src/ch/clickhouse/src/Disks/ObjectStorages/IMetadataStorage.h:164: DB::IMetadataTransaction::throwNotImplemented() @ 0x000000000f895364
    7. /src/ch/clickhouse/contrib/llvm-project/libcxx/include/__memory/shared_ptr.h:701: DB::(anonymous namespace)::PureMetadataObjectStorageOperation::execute(std::shared_ptr<DB::IMetadataTransaction>) @ 0x000000000f84ddde
    8. /src/ch/clickhouse/src/Disks/ObjectStorages/DiskObjectStorageTransaction.cpp:946: DB::DiskObjectStorageTransaction::commit() @ 0x000000000f84d74f
    9. /src/ch/clickhouse/contrib/llvm-project/libcxx/include/__memory/shared_ptr.h:701: DB::DiskObjectStorage::moveFile(String const&, String const&, bool) @ 0x000000000f83c472
    10. /src/ch/clickhouse/contrib/llvm-project/libcxx/include/string:1499: DB::DataPartStorageOnDiskFull::moveFile(String const&, String const&) @ 0x00000000111b541a
    11. /src/ch/clickhouse/src/Storages/MergeTree/IMergeTreeDataPart.cpp:1053: DB::IMergeTreeDataPart::writeColumns(DB::NamesAndTypesList const&, DB::WriteSettings const&) @ 0x00000000111f28be
    12. /src/ch/clickhouse/contrib/llvm-project/libcxx/include/__memory/shared_ptr.h:701: DB::IMergeTreeDataPart::loadColumns(bool) @ 0x00000000111e9883
    13. /src/ch/clickhouse/src/Storages/MergeTree/IMergeTreeDataPart.cpp:714: DB::IMergeTreeDataPart::loadColumnsChecksumsIndexes(bool, bool) @ 0x00000000111e8b12
    14. /src/ch/clickhouse/src/Storages/MergeTree/MergeTreeData.cpp:0: DB::MergeTreeData::loadDataPart(DB::MergeTreePartInfo const&, String const&, std::shared_ptr<DB::IDisk> const&, DB::MergeTreeDataPartState, std::mutex&) @ 0x00000000112849d0

Note, that DataPartStorageOnDiskBase::isReadonly() is used only in loadColumns() for calling writeColumns() in case of columns.txt does not exists

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Do not try to write columns.txt if it does not exist for write-once storages