### PR TITLE
Fix 02790_async_queries_in_query_log (silent discard in MV column matching)

### DIFF
--- a/tests/queries/0_stateless/02790_async_queries_in_query_log.reference
+++ b/tests/queries/0_stateless/02790_async_queries_in_query_log.reference
@@ -68,9 +68,9 @@ type:           QueryFinish
 read_rows:      3
 read_bytes:     12
 written_rows:   6
-written_bytes:  12
+written_bytes:  24
 result_rows:    6
-result_bytes:   12
+result_bytes:   24
 query:          INSERT INTO default.async_insert_landing SETTINGS wait_for_async_insert = 1, async_insert = 1 FORMAT Values
 query_kind:     AsyncInsertFlush
 databases:      ['default']
@@ -84,12 +84,12 @@ Row 1:
 ──────
 view_name:      default.async_insert_mv
 view_type:      Materialized
-view_query:     SELECT id + throwIf(id = 42) FROM default.async_insert_landing
+view_query:     SELECT id + throwIf(id = 42) AS id FROM default.async_insert_landing
 view_target:    default.async_insert_target
 read_rows:      3
 read_bytes:     12
 written_rows:   3
-written_bytes:  0
+written_bytes:  12
 status:         QueryFinish
 exception_code: 0
 
@@ -98,6 +98,13 @@ Row 1:
 ──────
 database:     default
 table:        async_insert_landing
+partition_id: all
+rows:         3
+
+Row 2:
+──────
+database:     default
+table:        async_insert_target
 partition_id: all
 rows:         3
 
@@ -141,7 +148,7 @@ Row 1:
 ──────
 view_name:      default.async_insert_mv
 view_type:      Materialized
-view_query:     SELECT id + throwIf(id = 42) FROM default.async_insert_landing
+view_query:     SELECT id + throwIf(id = 42) AS id FROM default.async_insert_landing
 view_target:    default.async_insert_target
 read_rows:      3
 read_bytes:     12

--- a/tests/queries/0_stateless/02790_async_queries_in_query_log.sh
+++ b/tests/queries/0_stateless/02790_async_queries_in_query_log.sh
@@ -77,7 +77,7 @@ print_flush_query_logs ${query_id}
 
 
 ${CLICKHOUSE_CLIENT} -q "CREATE TABLE async_insert_target (id UInt32) ENGINE = MergeTree ORDER BY id"
-${CLICKHOUSE_CLIENT} -q "CREATE MATERIALIZED VIEW async_insert_mv TO async_insert_target AS SELECT id + throwIf(id = 42) FROM async_insert_landing"
+${CLICKHOUSE_CLIENT} -q "CREATE MATERIALIZED VIEW async_insert_mv TO async_insert_target AS SELECT id + throwIf(id = 42) AS id FROM async_insert_landing"
 
 query_id="$(random_str 10)"
 ${CLICKHOUSE_CLIENT} --query_id="${query_id}" -q "INSERT INTO async_insert_landing SETTINGS wait_for_async_insert=1, async_insert=1 values (11), (12), (13);"

--- a/tests/queries/0_stateless/02790_async_queries_in_query_log.sh
+++ b/tests/queries/0_stateless/02790_async_queries_in_query_log.sh
@@ -51,6 +51,7 @@ function print_flush_query_logs()
       WHERE
           event_date >= yesterday()
       AND initial_query_id = (SELECT flush_query_id FROM system.asynchronous_insert_log WHERE event_date >= yesterday() AND query_id = '$1')
+      ORDER BY view_name
       FORMAT Vertical"
 
     echo ""
@@ -65,6 +66,7 @@ function print_flush_query_logs()
       WHERE
           event_date >= yesterday()
       AND query_id = (SELECT flush_query_id FROM system.asynchronous_insert_log WHERE event_date >= yesterday() AND query_id = '$1')
+      ORDER BY table
       FORMAT Vertical"
 }
 


### PR DESCRIPTION
### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Fix 02790_async_queries_in_query_log

### Documentation entry for user-facing changes

I really dislike how we match columns in MV and discard values without any kind of notice or warning.