### PR TITLE
Make table functions always report engine 'StorageProxy' in system.tables

### DIFF
--- a/src/Storages/StorageTableFunction.h
+++ b/src/Storages/StorageTableFunction.h
@@ -63,14 +63,6 @@ public:
     StoragePolicyPtr getStoragePolicy() const override { return nullptr; }
     bool storesDataOnDisk() const override { return false; }
 
-    String getName() const override
-    {
-        std::lock_guard lock{nested_mutex};
-        if (nested)
-            return nested->getName();
-        return StorageProxy::getName();
-    }
-
     void startup() override { }
     void shutdown(bool is_drop) override
     {

--- a/src/Storages/System/StorageSystemTables.cpp
+++ b/src/Storages/System/StorageSystemTables.cpp
@@ -146,7 +146,7 @@ ColumnPtr getFilteredTables(const ActionsDAG::Node * predicate, const ColumnPtr 
                 filter_by_engine = true;
 
         if (filter_by_engine)
-            engine_column= ColumnString::create();
+            engine_column = ColumnString::create();
     }
 
     for (size_t database_idx = 0; database_idx < filtered_databases_column->size(); ++database_idx)

--- a/tests/queries/0_stateless/02888_system_tables_with_inaccessible_table_function.reference
+++ b/tests/queries/0_stateless/02888_system_tables_with_inaccessible_table_function.reference
@@ -10,3 +10,4 @@ tablefunc03	StorageProxy		CREATE TABLE default.tablefunc03 (`a` Int32) AS sqlite
 tablefunc04	StorageProxy		CREATE TABLE default.tablefunc04 (`a` Int32) AS mongodb(\'127.0.0.1:27017\', \'test\', \'my_collection\', \'test_user\', \'[HIDDEN]\', \'a Int\')	[]	1	1
 tablefunc05	StorageProxy		CREATE TABLE default.tablefunc05 (`a` Int32) AS redis(\'127.0.0.1:6379\', \'key\', \'key UInt32\')	[]	1	1
 tablefunc06	StorageProxy		CREATE TABLE default.tablefunc06 (`a` Int32) AS s3(\'http://some_addr:9000/cloud-storage-01/data.tsv\', \'M9O7o0SX5I4udXhWxI12\', \'[HIDDEN]\', \'TSV\')	[]	1	1
+StorageProxy

--- a/tests/queries/0_stateless/02888_system_tables_with_inaccessible_table_function.sql
+++ b/tests/queries/0_stateless/02888_system_tables_with_inaccessible_table_function.sql
@@ -21,7 +21,7 @@ SELECT name, engine, engine_full, create_table_query, data_paths, notEmpty([meta
     WHERE name like '%tablefunc%' and database=currentDatabase()
     ORDER BY name;
 
-DETACH TABLE {CLICKHOUSE_DATABASE:Identifier}.tablefunc01; 
+DETACH TABLE {CLICKHOUSE_DATABASE:Identifier}.tablefunc01;
 DETACH TABLE {CLICKHOUSE_DATABASE:Identifier}.tablefunc02;
 DETACH TABLE {CLICKHOUSE_DATABASE:Identifier}.tablefunc03;
 DETACH TABLE {CLICKHOUSE_DATABASE:Identifier}.tablefunc04;
@@ -39,5 +39,8 @@ SELECT name, engine, engine_full, create_table_query, data_paths, notEmpty([meta
     FROM system.tables
     WHERE name like '%tablefunc%' and database=currentDatabase()
     ORDER BY name;
+
+SELECT count() FROM {CLICKHOUSE_DATABASE:Identifier}.tablefunc01; -- { serverError POSTGRESQL_CONNECTION_FAILURE }
+SELECT engine FROM system.tables WHERE name = 'tablefunc01' and database=currentDatabase();
 
 DROP DATABASE IF EXISTS {CLICKHOUSE_DATABASE:Identifier};


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

For table-function-based tables, the `engine` shown in `system.tables` could change over time. E.g. (edited):
```
:) CREATE TABLE a (a int) AS s3('http://some_addr/some_bucket/data.tsv', '', '', 'TSV');
:) select engine from system.tables where database = 'default' and name = 'a'
   ┌─engine───────┐
1. │ StorageProxy │
   └──────────────┘
:) select count() from a
:) select engine from system.tables where database = 'default' and name = 'a'
   ┌─engine─┐
1. │ S3     │
   └────────┘
```

This behavior (a) seems weird, and (b) made 02888_system_tables_with_inaccessible_table_function flaky. This PR makes the engine always be reported as 'StorageProxy'.

(Alternatively we could propagate the underlying engine name, probably by adding a new virtual function in `ITableFunction` and implementing it in all ~32 table functions. Or report the table function name instead of IStorage's name, that would be trivial. LMK if you think we should do that instead of 'StorageProxy'.)