### PR TITLE
Fix token extractor for startsWith and endsWith function

### DIFF
--- a/src/Interpreters/ITokenExtractor.h
+++ b/src/Interpreters/ITokenExtractor.h
@@ -37,6 +37,14 @@ struct ITokenExtractor
 
     virtual void stringLikeToBloomFilter(const char * data, size_t length, BloomFilter & bloom_filter) const = 0;
 
+    /// Special implementation for creating bloom filter for startsWith function.
+    /// It ignores the last token.
+    virtual void stringStartsWithToBloomFilter(const char * data, size_t length, BloomFilter & bloom_filter) const = 0;
+
+    /// Special implementation for creating bloom filter for endsWith function.
+    /// It ignores the first token.
+    virtual void stringEndsWithToBloomFilter(const char * data, size_t length, BloomFilter & bloom_filter) const = 0;
+
     virtual void stringToGinFilter(const char * data, size_t length, GinFilter & gin_filter) const = 0;
 
     virtual void stringPaddedToGinFilter(const char * data, size_t length, GinFilter & gin_filter) const
@@ -46,6 +54,9 @@ struct ITokenExtractor
 
     virtual void stringLikeToGinFilter(const char * data, size_t length, GinFilter & gin_filter) const = 0;
 
+    virtual void stringStartsWithToGinFilter(const char * data, size_t length, GinFilter & gin_filter) const = 0;
+
+    virtual void stringEndsWithToGinFilter(const char * data, size_t length, GinFilter & gin_filter) const = 0;
 };
 
 using TokenExtractorPtr = const ITokenExtractor *;
@@ -82,6 +93,39 @@ class ITokenExtractorHelper : public ITokenExtractor
             bloom_filter.add(token.c_str(), token.size());
     }
 
+    void stringStartsWithToBloomFilter(const char * data, size_t length, BloomFilter & bloom_filter) const override
+    {
+        size_t cur = 0;
+        size_t token_start = 0, prev_token_start = 0;
+        size_t token_len = 0, prev_token_len = 0;
+
+        while (cur < length && static_cast<const Derived *>(this)->nextInString(data, length, &cur, &token_start, &token_len))
+        {
+            if (prev_token_len > 0)
+            {
+                bloom_filter.add(data + prev_token_start, prev_token_len);
+            }
+            prev_token_start = token_start;
+            prev_token_len = token_len;
+        }
+    }
+
+    void stringEndsWithToBloomFilter(const char * data, size_t length, BloomFilter & bloom_filter) const override
+    {
+        size_t cur = 0;
+        size_t token_start = 0;
+        size_t token_len = 0;
+        bool first_token = true;
+
+        while (cur < length && static_cast<const Derived *>(this)->nextInString(data, length, &cur, &token_start, &token_len))
+        {
+            if (!first_token)
+                bloom_filter.add(data + token_start, token_len);
+            else
+                first_token = false;
+        }
+    }
+
     void stringToGinFilter(const char * data, size_t length, GinFilter & gin_filter) const override
     {
         gin_filter.setQueryString(data, length);
@@ -116,24 +160,60 @@ class ITokenExtractorHelper : public ITokenExtractor
         while (cur < length && static_cast<const Derived *>(this)->nextInStringLike(data, length, &cur, token))
             gin_filter.addTerm(token.c_str(), token.size());
     }
+
+    void stringStartsWithToGinFilter(const char * data, size_t length, GinFilter & gin_filter) const override
+    {
+        gin_filter.setQueryString(data, length);
+
+        size_t cur = 0;
+        size_t token_start = 0, prev_token_start = 0;
+        size_t token_len = 0, prev_token_len = 0;
+
+        while (cur < length && static_cast<const Derived *>(this)->nextInString(data, length, &cur, &token_start, &token_len))
+        {
+            if (prev_token_len > 0)
+            {
+                gin_filter.addTerm(data + prev_token_start, prev_token_len);
+            }
+            prev_token_start = token_start;
+            prev_token_len = token_len;
+        }
+    }
+
+    void stringEndsWithToGinFilter(const char * data, size_t length, GinFilter & gin_filter) const override
+    {
+        gin_filter.setQueryString(data, length);
+
+        size_t cur = 0;
+        size_t token_start = 0;
+        size_t token_len = 0;
+        bool first_token = true;
+
+        while (cur < length && static_cast<const Derived *>(this)->nextInString(data, length, &cur, &token_start, &token_len))
+        {
+            if (!first_token)
+                gin_filter.addTerm(data + token_start, token_len);
+            else
+                first_token = false;
+        }
+    }
 };
 
 
 /// Parser extracting all ngrams from string.
 struct NgramTokenExtractor final : public ITokenExtractorHelper<NgramTokenExtractor>
 {
-    explicit NgramTokenExtractor(size_t n_) : n(n_) {}
+    explicit NgramTokenExtractor(size_t n_) : n(n_) { }
 
     static const char * getName() { return "ngrambf_v1"; }
 
-    bool nextInString(const char * data, size_t length, size_t *  __restrict pos, size_t * __restrict token_start, size_t * __restrict token_length) const override;
+    bool nextInString(const char * data, size_t length, size_t * __restrict pos, size_t * __restrict token_start, size_t * __restrict token_length) const override;
 
     bool nextInStringLike(const char * data, size_t length, size_t * pos, String & token) const override;
 
     size_t getN() const { return n; }
 
 private:
-
     size_t n;
 };
 
@@ -142,12 +222,20 @@ struct SplitTokenExtractor final : public ITokenExtractorHelper<SplitTokenExtrac
 {
     static const char * getName() { return "tokenbf_v1"; }
 
-    bool nextInString(const char * data, size_t length, size_t * __restrict pos, size_t * __restrict token_start, size_t * __restrict token_length) const override;
+    bool nextInString(
+        const char * data,
+        size_t length,
+        size_t * __restrict pos,
+        size_t * __restrict token_start,
+        size_t * __restrict token_length) const override;
 
-    bool nextInStringPadded(const char * data, size_t length, size_t * __restrict pos, size_t * __restrict token_start, size_t * __restrict token_length) const override;
+    bool nextInStringPadded(
+        const char * data,
+        size_t length,
+        size_t * __restrict pos,
+        size_t * __restrict token_start,
+        size_t * __restrict token_length) const override;
 
     bool nextInStringLike(const char * data, size_t length, size_t * __restrict pos, String & token) const override;
-
 };
-
 }

--- a/src/Storages/MergeTree/MergeTreeIndexBloomFilterText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexBloomFilterText.cpp
@@ -566,7 +566,7 @@ bool MergeTreeConditionBloomFilterText::traverseTreeEquals(
         out.function = RPNElement::FUNCTION_EQUALS;
         out.bloom_filter = std::make_unique<BloomFilter>(params);
         const auto & value = const_value.get<String>();
-        token_extractor->stringToBloomFilter(value.data(), value.size(), *out.bloom_filter);
+        token_extractor->stringStartsWithToBloomFilter(value.data(), value.size(), *out.bloom_filter);
         return true;
     }
     else if (function_name == "endsWith")
@@ -575,7 +575,7 @@ bool MergeTreeConditionBloomFilterText::traverseTreeEquals(
         out.function = RPNElement::FUNCTION_EQUALS;
         out.bloom_filter = std::make_unique<BloomFilter>(params);
         const auto & value = const_value.get<String>();
-        token_extractor->stringToBloomFilter(value.data(), value.size(), *out.bloom_filter);
+        token_extractor->stringEndsWithToBloomFilter(value.data(), value.size(), *out.bloom_filter);
         return true;
     }
     else if (function_name == "multiSearchAny"

--- a/src/Storages/MergeTree/MergeTreeIndexFullText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexFullText.cpp
@@ -594,7 +594,7 @@ bool MergeTreeConditionFullText::traverseASTEquals(
         out.function = RPNElement::FUNCTION_EQUALS;
         out.gin_filter = std::make_unique<GinFilter>(params);
         const auto & value = const_value.get<String>();
-        token_extractor->stringToGinFilter(value.data(), value.size(), *out.gin_filter);
+        token_extractor->stringStartsWithToGinFilter(value.data(), value.size(), *out.gin_filter);
         return true;
     }
     else if (function_name == "endsWith")
@@ -603,7 +603,7 @@ bool MergeTreeConditionFullText::traverseASTEquals(
         out.function = RPNElement::FUNCTION_EQUALS;
         out.gin_filter = std::make_unique<GinFilter>(params);
         const auto & value = const_value.get<String>();
-        token_extractor->stringToGinFilter(value.data(), value.size(), *out.gin_filter);
+        token_extractor->stringEndsWithToGinFilter(value.data(), value.size(), *out.gin_filter);
         return true;
     }
     else if (function_name == "multiSearchAny")

--- a/tests/queries/0_stateless/03165_startsWith_and_endsWith_with_bloom_index.reference
+++ b/tests/queries/0_stateless/03165_startsWith_and_endsWith_with_bloom_index.reference
@@ -1,0 +1,8 @@
+2	Bob	Wall
+1	Alice Lennon	Heron Way
+3	Michael Jorden	3rd Street Northeast
+3	Michael Jorden	3rd Street Northeast
+2	Bob	Wall
+1	Alice Lennon	Heron Way
+3	Michael Jorden	3rd Street Northeast
+3	Michael Jorden	3rd Street Northeast

--- a/tests/queries/0_stateless/03165_startsWith_and_endsWith_with_bloom_index.sql
+++ b/tests/queries/0_stateless/03165_startsWith_and_endsWith_with_bloom_index.sql
@@ -1,0 +1,29 @@
+set allow_experimental_inverted_index=1;
+
+    DROP TABLE IF EXISTS example_table;
+
+CREATE TABLE example_table
+(
+    `id` UInt32,
+    `name` String,
+    `addr` String,
+    INDEX idx_name name TYPE tokenbf_v1(1024, 3, 0) GRANULARITY 1,
+    INDEX idx_addr addr TYPE full_text GRANULARITY 1
+)
+    ENGINE = MergeTree
+ORDER BY id
+SETTINGS index_granularity = 8192;
+
+INSERT INTO example_table (id, name, addr) VALUES (1, 'Alice Lennon', 'Heron Way'), (2, 'Bob','Wall'), (3, 'Michael Jorden', '3rd Street Northeast');
+
+SELECT * FROM example_table WHERE startsWith(name, 'Whoever');
+SELECT * FROM example_table WHERE startsWith(name, 'Bob');
+SELECT * FROM example_table WHERE startsWith(name, 'Alice');
+SELECT * FROM example_table WHERE startsWith(name, 'Michael Jor');
+SELECT * FROM example_table WHERE startsWith(name, 'Michael Jorden');
+
+SELECT * FROM example_table WHERE endsWith(addr, 'Whatever');
+SELECT * FROM example_table WHERE endsWith(addr, 'Wall');
+SELECT * FROM example_table WHERE endsWith(addr, 'Way');
+SELECT * FROM example_table WHERE endsWith(addr, 'eet Northeast');
+SELECT * FROM example_table WHERE endsWith(addr, 'Street Northeast');


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)



### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Fix the `token_extractor` used by the `startsWith` and `endsWith` functions for columns with `tokenbf_v1` or `full_text` indexes to return correct results.

### Documentation entry for user-facing changes

#### Issue Description

When creating a `tokenbf_v1` or `full_text` index on a column `name`, there are cases where using the `startsWith` and `endsWith` functions to search data does not correctly recall the data due to issues with the `token_extractor`.

#### Example

1. **Table Creation**

    ```sql
    CREATE TABLE default.example_table
    (
        `id` UInt32,
        `name` String,
        `addr` String,
        INDEX idx_name name TYPE tokenbf_v1(1024, 3, 0) GRANULARITY 1,
        INDEX idx_addr addr TYPE full_text GRANULARITY 1
    )
    ENGINE = MergeTree
    ORDER BY id
    SETTINGS index_granularity = 8192;
    ```

2. **Insert Data**

    ```sql
    INSERT INTO example_table (id, name, addr) VALUES
    (3, 'Michael Jorden', '3rd Street Northeast');
    ```

3. **Query**

    ```sql
    SELECT * FROM example_table WHERE startsWith(name, 'Michael Jor');
    ```
    This query fails to recall the data for 'Michael Jorden' because the query uses `stringToBloomFilter`, which recognizes 'Michael' and 'Jor' as two tokens and then adds them to the bloom filter. In this case, the last token should be ignored because the end of `startsWith` does not necessarily form a complete token.

    ```sql
    SELECT * FROM example_table WHERE endsWith(addr, 'eet Northeast');
    ```
    Similarly, this query fails to recall the data for '3rd Street Northeast' because `stringToGinFilter` recognizes 'eet' and 'Northeast' as two tokens and then adds them to the gin filter. Here, the first token should be ignored because the beginning of `endsWith` does not necessarily form a complete token.

#### Solution

I have added two types of `token_extractor` functions corresponding to the scenarios of `startsWith` (ignoring the last token) and `endsWith` (ignoring the first token).
#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_non_required--> Allow: All NOT Required Checks
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_integration--> Exclude: Integration Tests
- [ ] <!---ci_exclude_stateless--> Exclude: Stateless tests
- [ ] <!---ci_exclude_stateful--> Exclude: Stateful tests
- [ ] <!---ci_exclude_performance--> Exclude: Performance tests
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_aarch64--> Exclude: All with Aarch64
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
