### PR TITLE
Remove aliases from fiter condition.

### DIFF
--- a/src/Interpreters/ActionsDAG.h
+++ b/src/Interpreters/ActionsDAG.h
@@ -195,6 +195,8 @@ public:
     /// Remove actions that are not needed to compute output nodes with required names
     void removeUnusedActions(const NameSet & required_names, bool allow_remove_inputs = true, bool allow_constant_folding = true);
 
+    void removeAliasesForFilter(const std::string & filter_name);
+
     /// Transform the current DAG in a way that leaf nodes get folded into their parents. It's done
     /// because each projection can provide some columns as inputs to substitute certain sub-DAGs
     /// (expressions). Consider the following example:

--- a/src/Processors/QueryPlan/FilterStep.cpp
+++ b/src/Processors/QueryPlan/FilterStep.cpp
@@ -50,6 +50,8 @@ FilterStep::FilterStep(
     , filter_column_name(std::move(filter_column_name_))
     , remove_filter_column(remove_filter_column_)
 {
+    actions_dag = actions_dag->clone();
+    actions_dag->removeAliasesForFilter(filter_column_name);
 }
 
 void FilterStep::transformPipeline(QueryPipelineBuilder & pipeline, const BuildQueryPipelineSettings & settings)

--- a/tests/queries/0_stateless/01655_plan_optimizations.reference
+++ b/tests/queries/0_stateless/01655_plan_optimizations.reference
@@ -44,12 +44,10 @@ Filter
 9	10	1
 > one condition of filter should be pushed down after aggregating, other condition is aliased
 Filter column
-ALIAS notEquals(s, 4) :: 1 -> and(notEquals(y, 0), notEquals(s, 4))
 Aggregating
 Filter column: notEquals(y, 0)
 > (analyzer) one condition of filter should be pushed down after aggregating, other condition is aliased
 Filter column
-ALIAS notEquals(__table1.s, 4_UInt8) :: 0 -> and(notEquals(__table1.y, 0_UInt8), notEquals(__table1.s, 4_UInt8))
 Aggregating
 Filter column: notEquals(__table1.y, 0_UInt8)
 0	1
@@ -63,12 +61,10 @@ Filter column: notEquals(__table1.y, 0_UInt8)
 9	10
 > one condition of filter should be pushed down after aggregating, other condition is casted
 Filter column
-FUNCTION and(minus(s, 4) :: 1, 1 :: 3) -> and(notEquals(y, 0), minus(s, 4)) UInt8 : 2
 Aggregating
 Filter column: notEquals(y, 0)
 > (analyzer) one condition of filter should be pushed down after aggregating, other condition is casted
 Filter column
-FUNCTION and(minus(__table1.s, 4_UInt8) :: 0, 1 :: 3) -> and(notEquals(__table1.y, 0_UInt8), minus(__table1.s, 4_UInt8)) UInt8 : 2
 Aggregating
 Filter column: notEquals(__table1.y, 0_UInt8)
 0	1
@@ -82,12 +78,10 @@ Filter column: notEquals(__table1.y, 0_UInt8)
 9	10
 > one condition of filter should be pushed down after aggregating, other two conditions are ANDed
 Filter column
-FUNCTION and(minus(s, 8) :: 1, minus(s, 4) :: 2) -> and(notEquals(y, 0), minus(s, 8), minus(s, 4))
 Aggregating
 Filter column: notEquals(y, 0)
 > (analyzer) one condition of filter should be pushed down after aggregating, other two conditions are ANDed
 Filter column
-FUNCTION and(minus(__table1.s, 8_UInt8) :: 0, minus(__table1.s, 4_UInt8) :: 2) -> and(notEquals(__table1.y, 0_UInt8), minus(__table1.s, 8_UInt8), minus(__table1.s, 4_UInt8))
 Aggregating
 Filter column: notEquals(__table1.y, 0_UInt8)
 0	1
@@ -100,12 +94,10 @@ Filter column: notEquals(__table1.y, 0_UInt8)
 9	10
 > two conditions of filter should be pushed down after aggregating and ANDed, one condition is aliased
 Filter column
-ALIAS notEquals(s, 8) :: 1 -> and(notEquals(y, 0), notEquals(s, 8), minus(y, 4))
 Aggregating
 Filter column: and(notEquals(y, 0), minus(y, 4))
 > (analyzer) two conditions of filter should be pushed down after aggregating and ANDed, one condition is aliased
 Filter column
-ALIAS notEquals(__table1.s, 8_UInt8) :: 0 -> and(notEquals(__table1.y, 0_UInt8), notEquals(__table1.s, 8_UInt8), minus(__table1.y, 4_UInt8))
 Aggregating
 Filter column: and(notEquals(__table1.y, 0_UInt8), minus(__table1.y, 4_UInt8))
 0	1

--- a/tests/queries/0_stateless/01655_plan_optimizations.reference
+++ b/tests/queries/0_stateless/01655_plan_optimizations.reference
@@ -44,10 +44,12 @@ Filter
 9	10	1
 > one condition of filter should be pushed down after aggregating, other condition is aliased
 Filter column
+ALIAS notEquals(s, 4) :: 4 -> and(notEquals(y, 0), notEquals(s, 4)) UInt8 : 2
 Aggregating
 Filter column: notEquals(y, 0)
 > (analyzer) one condition of filter should be pushed down after aggregating, other condition is aliased
 Filter column
+ALIAS notEquals(__table1.s, 4_UInt8) :: 1 -> and(notEquals(__table1.y, 0_UInt8), notEquals(__table1.s, 4_UInt8))
 Aggregating
 Filter column: notEquals(__table1.y, 0_UInt8)
 0	1
@@ -61,10 +63,12 @@ Filter column: notEquals(__table1.y, 0_UInt8)
 9	10
 > one condition of filter should be pushed down after aggregating, other condition is casted
 Filter column
+FUNCTION and(minus(s, 4) :: 5, 1 :: 3) -> and(notEquals(y, 0), minus(s, 4))
 Aggregating
 Filter column: notEquals(y, 0)
 > (analyzer) one condition of filter should be pushed down after aggregating, other condition is casted
 Filter column
+FUNCTION and(minus(__table1.s, 4_UInt8) :: 1, 1 :: 3) -> and(notEquals(__table1.y, 0_UInt8), minus(__table1.s, 4_UInt8))
 Aggregating
 Filter column: notEquals(__table1.y, 0_UInt8)
 0	1
@@ -78,10 +82,12 @@ Filter column: notEquals(__table1.y, 0_UInt8)
 9	10
 > one condition of filter should be pushed down after aggregating, other two conditions are ANDed
 Filter column
+FUNCTION and(minus(s, 8) :: 5, minus(s, 4) :: 2) -> and(notEquals(y, 0), minus(s, 8), minus(s, 4))
 Aggregating
 Filter column: notEquals(y, 0)
 > (analyzer) one condition of filter should be pushed down after aggregating, other two conditions are ANDed
 Filter column
+FUNCTION and(minus(__table1.s, 8_UInt8) :: 1, minus(__table1.s, 4_UInt8) :: 2) -> and(notEquals(__table1.y, 0_UInt8), minus(__table1.s, 8_UInt8), minus(__table1.s, 4_UInt8))
 Aggregating
 Filter column: notEquals(__table1.y, 0_UInt8)
 0	1
@@ -94,10 +100,12 @@ Filter column: notEquals(__table1.y, 0_UInt8)
 9	10
 > two conditions of filter should be pushed down after aggregating and ANDed, one condition is aliased
 Filter column
+ALIAS notEquals(s, 8) :: 4 -> and(notEquals(y, 0), notEquals(s, 8), minus(y, 4))
 Aggregating
 Filter column: and(notEquals(y, 0), minus(y, 4))
 > (analyzer) two conditions of filter should be pushed down after aggregating and ANDed, one condition is aliased
 Filter column
+ALIAS notEquals(__table1.s, 8_UInt8) :: 1 -> and(notEquals(__table1.y, 0_UInt8), notEquals(__table1.s, 8_UInt8), minus(__table1.y, 4_UInt8))
 Aggregating
 Filter column: and(notEquals(__table1.y, 0_UInt8), minus(__table1.y, 4_UInt8))
 0	1

--- a/tests/queries/0_stateless/01655_plan_optimizations.sh
+++ b/tests/queries/0_stateless/01655_plan_optimizations.sh
@@ -49,14 +49,14 @@ $CLICKHOUSE_CLIENT --allow_experimental_analyzer=0 -q "
         select sum(x) as s, y from (select number as x, number + 1 as y from numbers(10)) group by y
     ) where y != 0 and s != 4
     settings enable_optimize_predicate_expression=0" |
-    grep -o "Aggregating\|Filter column\|Filter column: notEquals(y, 0)\|ALIAS notEquals(s, 4) :: 1 -> and(notEquals(y, 0), notEquals(s, 4))"
+    grep -o "Aggregating\|Filter column\|Filter column: notEquals(y, 0)\|ALIAS notEquals(s, 4) :: 4 -> and(notEquals(y, 0), notEquals(s, 4)) UInt8 : 2"
 echo "> (analyzer) one condition of filter should be pushed down after aggregating, other condition is aliased"
 $CLICKHOUSE_CLIENT --allow_experimental_analyzer=1 -q "
     explain actions = 1 select s, y from (
         select sum(x) as s, y from (select number as x, number + 1 as y from numbers(10)) group by y
     ) where y != 0 and s != 4
     settings enable_optimize_predicate_expression=0" |
-        grep -o "Aggregating\|Filter column\|Filter column: notEquals(__table1.y, 0_UInt8)\|ALIAS notEquals(__table1.s, 4_UInt8) :: 0 -> and(notEquals(__table1.y, 0_UInt8), notEquals(__table1.s, 4_UInt8))"
+        grep -o "Aggregating\|Filter column\|Filter column: notEquals(__table1.y, 0_UInt8)\|ALIAS notEquals(__table1.s, 4_UInt8) :: 1 -> and(notEquals(__table1.y, 0_UInt8), notEquals(__table1.s, 4_UInt8))"
 $CLICKHOUSE_CLIENT -q "
     select s, y from (
         select sum(x) as s, y from (select number as x, number + 1 as y from numbers(10)) group by y
@@ -69,14 +69,14 @@ $CLICKHOUSE_CLIENT --allow_experimental_analyzer=0 -q "
         select sum(x) as s, y from (select number as x, number + 1 as y from numbers(10)) group by y
     ) where y != 0 and s - 4
     settings enable_optimize_predicate_expression=0" |
-    grep -o "Aggregating\|Filter column\|Filter column: notEquals(y, 0)\|FUNCTION and(minus(s, 4) :: 1, 1 :: 3) -> and(notEquals(y, 0), minus(s, 4)) UInt8 : 2"
+    grep -o "Aggregating\|Filter column\|Filter column: notEquals(y, 0)\|FUNCTION and(minus(s, 4) :: 5, 1 :: 3) -> and(notEquals(y, 0), minus(s, 4))"
 echo "> (analyzer) one condition of filter should be pushed down after aggregating, other condition is casted"
 $CLICKHOUSE_CLIENT --allow_experimental_analyzer=1 -q "
     explain actions = 1 select s, y from (
         select sum(x) as s, y from (select number as x, number + 1 as y from numbers(10)) group by y
     ) where y != 0 and s - 4
     settings enable_optimize_predicate_expression=0" |
-        grep -o "Aggregating\|Filter column\|Filter column: notEquals(__table1.y, 0_UInt8)\|FUNCTION and(minus(__table1.s, 4_UInt8) :: 0, 1 :: 3) -> and(notEquals(__table1.y, 0_UInt8), minus(__table1.s, 4_UInt8)) UInt8 : 2"
+        grep -o "Aggregating\|Filter column\|Filter column: notEquals(__table1.y, 0_UInt8)\|FUNCTION and(minus(__table1.s, 4_UInt8) :: 1, 1 :: 3) -> and(notEquals(__table1.y, 0_UInt8), minus(__table1.s, 4_UInt8))"
 $CLICKHOUSE_CLIENT -q "
     select s, y from (
         select sum(x) as s, y from (select number as x, number + 1 as y from numbers(10)) group by y
@@ -89,14 +89,14 @@ $CLICKHOUSE_CLIENT --allow_experimental_analyzer=0 --convert_query_to_cnf=0 -q "
         select sum(x) as s, y from (select number as x, number + 1 as y from numbers(10)) group by y
     ) where y != 0 and s - 8 and s - 4
     settings enable_optimize_predicate_expression=0" |
-    grep -o "Aggregating\|Filter column\|Filter column: notEquals(y, 0)\|FUNCTION and(minus(s, 8) :: 1, minus(s, 4) :: 2) -> and(notEquals(y, 0), minus(s, 8), minus(s, 4))"
+    grep -o "Aggregating\|Filter column\|Filter column: notEquals(y, 0)\|FUNCTION and(minus(s, 8) :: 5, minus(s, 4) :: 2) -> and(notEquals(y, 0), minus(s, 8), minus(s, 4))"
 echo "> (analyzer) one condition of filter should be pushed down after aggregating, other two conditions are ANDed"
 $CLICKHOUSE_CLIENT --allow_experimental_analyzer=1 --convert_query_to_cnf=0 -q "
     explain actions = 1 select s, y from (
         select sum(x) as s, y from (select number as x, number + 1 as y from numbers(10)) group by y
     ) where y != 0 and s - 8 and s - 4
     settings enable_optimize_predicate_expression=0" |
-        grep -o "Aggregating\|Filter column\|Filter column: notEquals(__table1.y, 0_UInt8)\|FUNCTION and(minus(__table1.s, 8_UInt8) :: 0, minus(__table1.s, 4_UInt8) :: 2) -> and(notEquals(__table1.y, 0_UInt8), minus(__table1.s, 8_UInt8), minus(__table1.s, 4_UInt8))"
+        grep -o "Aggregating\|Filter column\|Filter column: notEquals(__table1.y, 0_UInt8)\|FUNCTION and(minus(__table1.s, 8_UInt8) :: 1, minus(__table1.s, 4_UInt8) :: 2) -> and(notEquals(__table1.y, 0_UInt8), minus(__table1.s, 8_UInt8), minus(__table1.s, 4_UInt8))"
 $CLICKHOUSE_CLIENT -q "
     select s, y from (
         select sum(x) as s, y from (select number as x, number + 1 as y from numbers(10)) group by y
@@ -109,14 +109,14 @@ $CLICKHOUSE_CLIENT --allow_experimental_analyzer=0 --convert_query_to_cnf=0 -q "
         select sum(x) as s, y from (select number as x, number + 1 as y from numbers(10)) group by y
     ) where y != 0 and s != 8 and y - 4
     settings enable_optimize_predicate_expression=0" |
-    grep -o "Aggregating\|Filter column\|Filter column: and(notEquals(y, 0), minus(y, 4))\|ALIAS notEquals(s, 8) :: 1 -> and(notEquals(y, 0), notEquals(s, 8), minus(y, 4))"
+    grep -o "Aggregating\|Filter column\|Filter column: and(notEquals(y, 0), minus(y, 4))\|ALIAS notEquals(s, 8) :: 4 -> and(notEquals(y, 0), notEquals(s, 8), minus(y, 4))"
 echo "> (analyzer) two conditions of filter should be pushed down after aggregating and ANDed, one condition is aliased"
 $CLICKHOUSE_CLIENT --allow_experimental_analyzer=1 --convert_query_to_cnf=0 -q "
     explain actions = 1 select s, y from (
         select sum(x) as s, y from (select number as x, number + 1 as y from numbers(10)) group by y
     ) where y != 0 and s != 8 and y - 4
     settings enable_optimize_predicate_expression=0" |
-    grep -o "Aggregating\|Filter column\|Filter column: and(notEquals(__table1.y, 0_UInt8), minus(__table1.y, 4_UInt8))\|ALIAS notEquals(__table1.s, 8_UInt8) :: 0 -> and(notEquals(__table1.y, 0_UInt8), notEquals(__table1.s, 8_UInt8), minus(__table1.y, 4_UInt8))"
+    grep -o "Aggregating\|Filter column\|Filter column: and(notEquals(__table1.y, 0_UInt8), minus(__table1.y, 4_UInt8))\|ALIAS notEquals(__table1.s, 8_UInt8) :: 1 -> and(notEquals(__table1.y, 0_UInt8), notEquals(__table1.s, 8_UInt8), minus(__table1.y, 4_UInt8))"
 $CLICKHOUSE_CLIENT -q "
     select s, y from (
         select sum(x) as s, y from (select number as x, number + 1 as y from numbers(10)) group by y

--- a/tests/queries/0_stateless/02317_distinct_in_order_optimization_explain.reference
+++ b/tests/queries/0_stateless/02317_distinct_in_order_optimization_explain.reference
@@ -87,7 +87,7 @@ Sorting (Stream): a ASC, b ASC
 Sorting (Stream): __table1.a ASC, __table1.b ASC
 Sorting (Stream): __table1.a ASC, __table1.b ASC
 Sorting (Stream): __table1.a ASC, __table1.b ASC
-Sorting (Stream): __table1.a ASC, b ASC
+Sorting (Stream): a ASC, b ASC
 -- disabled, check that sorting description for ReadFromMergeTree match ORDER BY columns
 Sorting (Stream): __table1.a ASC
 Sorting (Stream): __table1.a ASC

--- a/tests/queries/0_stateless/02675_predicate_push_down_filled_join_fix.reference
+++ b/tests/queries/0_stateless/02675_predicate_push_down_filled_join_fix.reference
@@ -24,10 +24,10 @@ Positions: 3 0 1
     Actions: INPUT : 0 -> id UInt64 : 0
              INPUT : 1 -> value String : 1
              COLUMN Const(UInt8) -> 0_UInt8 UInt8 : 2
-             ALIAS id :: 0 -> __table1.id UInt64 : 3
-             ALIAS value :: 1 -> __table1.value String : 0
-             FUNCTION equals(__table1.id : 3, 0_UInt8 :: 2) -> equals(__table1.id, 0_UInt8) UInt8 : 1
-    Positions: 1 3 0
+             ALIAS id : 0 -> __table1.id UInt64 : 3
+             ALIAS value :: 1 -> __table1.value String : 4
+             FUNCTION equals(id :: 0, 0_UInt8 :: 2) -> equals(__table1.id, 0_UInt8) UInt8 : 1
+    Positions: 1 3 4
       ReadFromMergeTree (default.test_table)
       Header: id UInt64
               value String

--- a/tests/queries/0_stateless/03036_join_filter_push_down_equivalent_sets.reference
+++ b/tests/queries/0_stateless/03036_join_filter_push_down_equivalent_sets.reference
@@ -33,10 +33,10 @@ Positions: 4 2 0 1
     Actions: INPUT : 0 -> id UInt64 : 0
              INPUT : 1 -> value String : 1
              COLUMN Const(UInt8) -> 5_UInt8 UInt8 : 2
-             ALIAS id :: 0 -> __table1.id UInt64 : 3
-             ALIAS value :: 1 -> __table1.value String : 0
-             FUNCTION equals(__table1.id : 3, 5_UInt8 :: 2) -> equals(__table1.id, 5_UInt8) UInt8 : 1
-    Positions: 1 3 0
+             ALIAS id : 0 -> __table1.id UInt64 : 3
+             ALIAS value :: 1 -> __table1.value String : 4
+             FUNCTION equals(id :: 0, 5_UInt8 :: 2) -> equals(__table1.id, 5_UInt8) UInt8 : 1
+    Positions: 1 3 4
       ReadFromMergeTree (default.test_table_1)
       Header: id UInt64
               value String
@@ -50,10 +50,10 @@ Positions: 4 2 0 1
     Actions: INPUT : 0 -> id UInt64 : 0
              INPUT : 1 -> value String : 1
              COLUMN Const(UInt8) -> 5_UInt8 UInt8 : 2
-             ALIAS id :: 0 -> __table2.id UInt64 : 3
-             ALIAS value :: 1 -> __table2.value String : 0
-             FUNCTION equals(__table2.id : 3, 5_UInt8 :: 2) -> equals(__table2.id, 5_UInt8) UInt8 : 1
-    Positions: 1 3 0
+             ALIAS id : 0 -> __table2.id UInt64 : 3
+             ALIAS value :: 1 -> __table2.value String : 4
+             FUNCTION equals(id :: 0, 5_UInt8 :: 2) -> equals(__table2.id, 5_UInt8) UInt8 : 1
+    Positions: 1 3 4
       ReadFromMergeTree (default.test_table_2)
       Header: id UInt64
               value String
@@ -100,10 +100,10 @@ Positions: 4 2 0 1
     Actions: INPUT : 0 -> id UInt64 : 0
              INPUT : 1 -> value String : 1
              COLUMN Const(UInt8) -> 5_UInt8 UInt8 : 2
-             ALIAS id :: 0 -> __table1.id UInt64 : 3
-             ALIAS value :: 1 -> __table1.value String : 0
-             FUNCTION equals(__table1.id : 3, 5_UInt8 :: 2) -> equals(__table1.id, 5_UInt8) UInt8 : 1
-    Positions: 1 3 0
+             ALIAS id : 0 -> __table1.id UInt64 : 3
+             ALIAS value :: 1 -> __table1.value String : 4
+             FUNCTION equals(id :: 0, 5_UInt8 :: 2) -> equals(__table1.id, 5_UInt8) UInt8 : 1
+    Positions: 1 3 4
       ReadFromMergeTree (default.test_table_1)
       Header: id UInt64
               value String
@@ -117,10 +117,10 @@ Positions: 4 2 0 1
     Actions: INPUT : 0 -> id UInt64 : 0
              INPUT : 1 -> value String : 1
              COLUMN Const(UInt8) -> 5_UInt8 UInt8 : 2
-             ALIAS id :: 0 -> __table2.id UInt64 : 3
-             ALIAS value :: 1 -> __table2.value String : 0
-             FUNCTION equals(__table2.id : 3, 5_UInt8 :: 2) -> equals(__table2.id, 5_UInt8) UInt8 : 1
-    Positions: 1 3 0
+             ALIAS id : 0 -> __table2.id UInt64 : 3
+             ALIAS value :: 1 -> __table2.value String : 4
+             FUNCTION equals(id :: 0, 5_UInt8 :: 2) -> equals(__table2.id, 5_UInt8) UInt8 : 1
+    Positions: 1 3 4
       ReadFromMergeTree (default.test_table_2)
       Header: id UInt64
               value String
@@ -168,12 +168,12 @@ Positions: 4 2 0 1
              INPUT : 1 -> value String : 1
              COLUMN Const(UInt8) -> 6_UInt8 UInt8 : 2
              COLUMN Const(UInt8) -> 5_UInt8 UInt8 : 3
-             ALIAS id :: 0 -> __table1.id UInt64 : 4
-             ALIAS value :: 1 -> __table1.value String : 0
-             FUNCTION equals(__table1.id : 4, 6_UInt8 :: 2) -> equals(__table1.id, 6_UInt8) UInt8 : 1
-             FUNCTION equals(__table1.id : 4, 5_UInt8 :: 3) -> equals(__table1.id, 5_UInt8) UInt8 : 2
+             ALIAS id : 0 -> __table1.id UInt64 : 4
+             ALIAS value :: 1 -> __table1.value String : 5
+             FUNCTION equals(id : 0, 6_UInt8 :: 2) -> equals(__table1.id, 6_UInt8) UInt8 : 1
+             FUNCTION equals(id :: 0, 5_UInt8 :: 3) -> equals(__table1.id, 5_UInt8) UInt8 : 2
              FUNCTION and(equals(__table1.id, 5_UInt8) :: 2, equals(__table1.id, 6_UInt8) :: 1) -> and(equals(__table1.id, 5_UInt8), equals(__table1.id, 6_UInt8)) UInt8 : 3
-    Positions: 3 4 0
+    Positions: 3 4 5
       ReadFromMergeTree (default.test_table_1)
       Header: id UInt64
               value String
@@ -188,12 +188,12 @@ Positions: 4 2 0 1
              INPUT : 1 -> value String : 1
              COLUMN Const(UInt8) -> 5_UInt8 UInt8 : 2
              COLUMN Const(UInt8) -> 6_UInt8 UInt8 : 3
-             ALIAS id :: 0 -> __table2.id UInt64 : 4
-             ALIAS value :: 1 -> __table2.value String : 0
-             FUNCTION equals(__table2.id : 4, 5_UInt8 :: 2) -> equals(__table2.id, 5_UInt8) UInt8 : 1
-             FUNCTION equals(__table2.id : 4, 6_UInt8 :: 3) -> equals(__table2.id, 6_UInt8) UInt8 : 2
+             ALIAS id : 0 -> __table2.id UInt64 : 4
+             ALIAS value :: 1 -> __table2.value String : 5
+             FUNCTION equals(id : 0, 5_UInt8 :: 2) -> equals(__table2.id, 5_UInt8) UInt8 : 1
+             FUNCTION equals(id :: 0, 6_UInt8 :: 3) -> equals(__table2.id, 6_UInt8) UInt8 : 2
              FUNCTION and(equals(__table2.id, 6_UInt8) :: 2, equals(__table2.id, 5_UInt8) :: 1) -> and(equals(__table2.id, 6_UInt8), equals(__table2.id, 5_UInt8)) UInt8 : 3
-    Positions: 3 4 0
+    Positions: 3 4 5
       ReadFromMergeTree (default.test_table_2)
       Header: id UInt64
               value String
@@ -237,10 +237,10 @@ Positions: 4 2 0 1
     Actions: INPUT : 0 -> id UInt64 : 0
              INPUT : 1 -> value String : 1
              COLUMN Const(UInt8) -> 5_UInt8 UInt8 : 2
-             ALIAS id :: 0 -> __table1.id UInt64 : 3
-             ALIAS value :: 1 -> __table1.value String : 0
-             FUNCTION equals(__table1.id : 3, 5_UInt8 :: 2) -> equals(__table1.id, 5_UInt8) UInt8 : 1
-    Positions: 1 3 0
+             ALIAS id : 0 -> __table1.id UInt64 : 3
+             ALIAS value :: 1 -> __table1.value String : 4
+             FUNCTION equals(id :: 0, 5_UInt8 :: 2) -> equals(__table1.id, 5_UInt8) UInt8 : 1
+    Positions: 1 3 4
       ReadFromMergeTree (default.test_table_1)
       Header: id UInt64
               value String
@@ -254,10 +254,10 @@ Positions: 4 2 0 1
     Actions: INPUT : 0 -> id UInt64 : 0
              INPUT : 1 -> value String : 1
              COLUMN Const(UInt8) -> 5_UInt8 UInt8 : 2
-             ALIAS id :: 0 -> __table2.id UInt64 : 3
-             ALIAS value :: 1 -> __table2.value String : 0
-             FUNCTION equals(__table2.id : 3, 5_UInt8 :: 2) -> equals(__table2.id, 5_UInt8) UInt8 : 1
-    Positions: 1 3 0
+             ALIAS id : 0 -> __table2.id UInt64 : 3
+             ALIAS value :: 1 -> __table2.value String : 4
+             FUNCTION equals(id :: 0, 5_UInt8 :: 2) -> equals(__table2.id, 5_UInt8) UInt8 : 1
+    Positions: 1 3 4
       ReadFromMergeTree (default.test_table_2)
       Header: id UInt64
               value String
@@ -452,10 +452,10 @@ Positions: 4 2 0 1
     Actions: INPUT : 0 -> id UInt64 : 0
              INPUT : 1 -> value String : 1
              COLUMN Const(UInt8) -> 5_UInt8 UInt8 : 2
-             ALIAS id :: 0 -> __table1.id UInt64 : 3
-             ALIAS value :: 1 -> __table1.value String : 0
-             FUNCTION equals(__table1.id : 3, 5_UInt8 :: 2) -> equals(__table1.id, 5_UInt8) UInt8 : 1
-    Positions: 1 3 0
+             ALIAS id : 0 -> __table1.id UInt64 : 3
+             ALIAS value :: 1 -> __table1.value String : 4
+             FUNCTION equals(id :: 0, 5_UInt8 :: 2) -> equals(__table1.id, 5_UInt8) UInt8 : 1
+    Positions: 1 3 4
       ReadFromMergeTree (default.test_table_1)
       Header: id UInt64
               value String
@@ -469,10 +469,10 @@ Positions: 4 2 0 1
     Actions: INPUT : 0 -> id UInt64 : 0
              INPUT : 1 -> value String : 1
              COLUMN Const(UInt8) -> 5_UInt8 UInt8 : 2
-             ALIAS id :: 0 -> __table2.id UInt64 : 3
-             ALIAS value :: 1 -> __table2.value String : 0
-             FUNCTION equals(__table2.id : 3, 5_UInt8 :: 2) -> equals(__table2.id, 5_UInt8) UInt8 : 1
-    Positions: 1 3 0
+             ALIAS id : 0 -> __table2.id UInt64 : 3
+             ALIAS value :: 1 -> __table2.value String : 4
+             FUNCTION equals(id :: 0, 5_UInt8 :: 2) -> equals(__table2.id, 5_UInt8) UInt8 : 1
+    Positions: 1 3 4
       ReadFromMergeTree (default.test_table_2)
       Header: id UInt64
               value String

--- a/tests/queries/0_stateless/03130_convert_outer_join_to_inner_join.reference
+++ b/tests/queries/0_stateless/03130_convert_outer_join_to_inner_join.reference
@@ -25,13 +25,12 @@ Positions: 4 0 2 1
     Header: __table1.id UInt64
             __table1.value String
     Actions: INPUT : 1 -> value String : 0
-             INPUT :: 0 -> __table1.id UInt64 : 1
-             INPUT :: 2 -> id UInt64 : 2
-             ALIAS value :: 0 -> __table1.value String : 3
-    Positions: 1 3
+             INPUT : 0 -> id UInt64 : 1
+             ALIAS value :: 0 -> __table1.value String : 2
+             ALIAS id :: 1 -> __table1.id UInt64 : 0
+    Positions: 0 2
       ReadFromMergeTree (default.test_table_1)
-      Header: __table1.id UInt64
-              id UInt64
+      Header: id UInt64
               value String
       ReadType: Default
       Parts: 1
@@ -42,20 +41,18 @@ Positions: 4 0 2 1
         Prewhere filter column: notEquals(__table1.id, 0_UInt8) (removed)
         Actions: INPUT : 0 -> id UInt64 : 0
                  COLUMN Const(UInt8) -> 0_UInt8 UInt8 : 1
-                 ALIAS id : 0 -> __table1.id UInt64 : 2
-                 FUNCTION notEquals(__table1.id : 2, 0_UInt8 :: 1) -> notEquals(__table1.id, 0_UInt8) UInt8 : 3
-        Positions: 2 0 3
+                 FUNCTION notEquals(id : 0, 0_UInt8 :: 1) -> notEquals(__table1.id, 0_UInt8) UInt8 : 2
+        Positions: 0 2
     Expression
     Header: __table2.id UInt64
             __table2.value String
     Actions: INPUT : 1 -> value String : 0
-             INPUT :: 0 -> __table2.id UInt64 : 1
-             INPUT :: 2 -> id UInt64 : 2
-             ALIAS value :: 0 -> __table2.value String : 3
-    Positions: 1 3
+             INPUT : 0 -> id UInt64 : 1
+             ALIAS value :: 0 -> __table2.value String : 2
+             ALIAS id :: 1 -> __table2.id UInt64 : 0
+    Positions: 0 2
       ReadFromMergeTree (default.test_table_2)
-      Header: __table2.id UInt64
-              id UInt64
+      Header: id UInt64
               value String
       ReadType: Default
       Parts: 1
@@ -66,9 +63,8 @@ Positions: 4 0 2 1
         Prewhere filter column: notEquals(__table2.id, 0_UInt8) (removed)
         Actions: INPUT : 0 -> id UInt64 : 0
                  COLUMN Const(UInt8) -> 0_UInt8 UInt8 : 1
-                 ALIAS id : 0 -> __table2.id UInt64 : 2
-                 FUNCTION notEquals(__table2.id : 2, 0_UInt8 :: 1) -> notEquals(__table2.id, 0_UInt8) UInt8 : 3
-        Positions: 2 0 3
+                 FUNCTION notEquals(id : 0, 0_UInt8 :: 1) -> notEquals(__table2.id, 0_UInt8) UInt8 : 2
+        Positions: 0 2
 --
 2	Value_2	2	Value_2
 --
@@ -99,13 +95,12 @@ Positions: 4 0 2 1
     Header: __table1.id UInt64
             __table1.value String
     Actions: INPUT : 1 -> value String : 0
-             INPUT :: 0 -> __table1.id UInt64 : 1
-             INPUT :: 2 -> id UInt64 : 2
-             ALIAS value :: 0 -> __table1.value String : 3
-    Positions: 1 3
+             INPUT : 0 -> id UInt64 : 1
+             ALIAS value :: 0 -> __table1.value String : 2
+             ALIAS id :: 1 -> __table1.id UInt64 : 0
+    Positions: 0 2
       ReadFromMergeTree (default.test_table_1)
-      Header: __table1.id UInt64
-              id UInt64
+      Header: id UInt64
               value String
       ReadType: Default
       Parts: 1
@@ -116,20 +111,18 @@ Positions: 4 0 2 1
         Prewhere filter column: notEquals(__table1.id, 0_UInt8) (removed)
         Actions: INPUT : 0 -> id UInt64 : 0
                  COLUMN Const(UInt8) -> 0_UInt8 UInt8 : 1
-                 ALIAS id : 0 -> __table1.id UInt64 : 2
-                 FUNCTION notEquals(__table1.id : 2, 0_UInt8 :: 1) -> notEquals(__table1.id, 0_UInt8) UInt8 : 3
-        Positions: 2 0 3
+                 FUNCTION notEquals(id : 0, 0_UInt8 :: 1) -> notEquals(__table1.id, 0_UInt8) UInt8 : 2
+        Positions: 0 2
     Expression
     Header: __table2.id UInt64
             __table2.value String
     Actions: INPUT : 1 -> value String : 0
-             INPUT :: 0 -> __table2.id UInt64 : 1
-             INPUT :: 2 -> id UInt64 : 2
-             ALIAS value :: 0 -> __table2.value String : 3
-    Positions: 1 3
+             INPUT : 0 -> id UInt64 : 1
+             ALIAS value :: 0 -> __table2.value String : 2
+             ALIAS id :: 1 -> __table2.id UInt64 : 0
+    Positions: 0 2
       ReadFromMergeTree (default.test_table_2)
-      Header: __table2.id UInt64
-              id UInt64
+      Header: id UInt64
               value String
       ReadType: Default
       Parts: 1
@@ -140,9 +133,8 @@ Positions: 4 0 2 1
         Prewhere filter column: notEquals(__table2.id, 0_UInt8) (removed)
         Actions: INPUT : 0 -> id UInt64 : 0
                  COLUMN Const(UInt8) -> 0_UInt8 UInt8 : 1
-                 ALIAS id : 0 -> __table2.id UInt64 : 2
-                 FUNCTION notEquals(__table2.id : 2, 0_UInt8 :: 1) -> notEquals(__table2.id, 0_UInt8) UInt8 : 3
-        Positions: 2 0 3
+                 FUNCTION notEquals(id : 0, 0_UInt8 :: 1) -> notEquals(__table2.id, 0_UInt8) UInt8 : 2
+        Positions: 0 2
 --
 2	Value_2	2	Value_2
 --
@@ -173,13 +165,12 @@ Positions: 4 0 2 1
     Header: __table1.id UInt64
             __table1.value String
     Actions: INPUT : 1 -> value String : 0
-             INPUT :: 0 -> __table1.id UInt64 : 1
-             INPUT :: 2 -> id UInt64 : 2
-             ALIAS value :: 0 -> __table1.value String : 3
-    Positions: 1 3
+             INPUT : 0 -> id UInt64 : 1
+             ALIAS value :: 0 -> __table1.value String : 2
+             ALIAS id :: 1 -> __table1.id UInt64 : 0
+    Positions: 0 2
       ReadFromMergeTree (default.test_table_1)
-      Header: __table1.id UInt64
-              id UInt64
+      Header: id UInt64
               value String
       ReadType: Default
       Parts: 1
@@ -190,22 +181,20 @@ Positions: 4 0 2 1
         Prewhere filter column: and(notEquals(__table1.id, 0_UInt8), notEquals(__table1.id, 0_UInt8)) (removed)
         Actions: INPUT : 0 -> id UInt64 : 0
                  COLUMN Const(UInt8) -> 0_UInt8 UInt8 : 1
-                 ALIAS id : 0 -> __table1.id UInt64 : 2
-                 FUNCTION notEquals(__table1.id : 2, 0_UInt8 : 1) -> notEquals(__table1.id, 0_UInt8) UInt8 : 3
-                 FUNCTION notEquals(__table1.id : 2, 0_UInt8 :: 1) -> notEquals(__table1.id, 0_UInt8) UInt8 : 4
-                 FUNCTION and(notEquals(__table1.id, 0_UInt8) :: 4, notEquals(__table1.id, 0_UInt8) :: 3) -> and(notEquals(__table1.id, 0_UInt8), notEquals(__table1.id, 0_UInt8)) UInt8 : 1
-        Positions: 2 0 1
+                 FUNCTION notEquals(id : 0, 0_UInt8 : 1) -> notEquals(__table1.id, 0_UInt8) UInt8 : 2
+                 FUNCTION notEquals(id : 0, 0_UInt8 :: 1) -> notEquals(__table1.id, 0_UInt8) UInt8 : 3
+                 FUNCTION and(notEquals(__table1.id, 0_UInt8) :: 3, notEquals(__table1.id, 0_UInt8) :: 2) -> and(notEquals(__table1.id, 0_UInt8), notEquals(__table1.id, 0_UInt8)) UInt8 : 1
+        Positions: 0 1
     Expression
     Header: __table2.id UInt64
             __table2.value String
     Actions: INPUT : 1 -> value String : 0
-             INPUT :: 0 -> __table2.id UInt64 : 1
-             INPUT :: 2 -> id UInt64 : 2
-             ALIAS value :: 0 -> __table2.value String : 3
-    Positions: 1 3
+             INPUT : 0 -> id UInt64 : 1
+             ALIAS value :: 0 -> __table2.value String : 2
+             ALIAS id :: 1 -> __table2.id UInt64 : 0
+    Positions: 0 2
       ReadFromMergeTree (default.test_table_2)
-      Header: __table2.id UInt64
-              id UInt64
+      Header: id UInt64
               value String
       ReadType: Default
       Parts: 1
@@ -216,10 +205,9 @@ Positions: 4 0 2 1
         Prewhere filter column: and(notEquals(__table2.id, 0_UInt8), notEquals(__table2.id, 0_UInt8)) (removed)
         Actions: INPUT : 0 -> id UInt64 : 0
                  COLUMN Const(UInt8) -> 0_UInt8 UInt8 : 1
-                 ALIAS id : 0 -> __table2.id UInt64 : 2
-                 FUNCTION notEquals(__table2.id : 2, 0_UInt8 : 1) -> notEquals(__table2.id, 0_UInt8) UInt8 : 3
-                 FUNCTION notEquals(__table2.id : 2, 0_UInt8 :: 1) -> notEquals(__table2.id, 0_UInt8) UInt8 : 4
-                 FUNCTION and(notEquals(__table2.id, 0_UInt8) :: 4, notEquals(__table2.id, 0_UInt8) :: 3) -> and(notEquals(__table2.id, 0_UInt8), notEquals(__table2.id, 0_UInt8)) UInt8 : 1
-        Positions: 2 0 1
+                 FUNCTION notEquals(id : 0, 0_UInt8 : 1) -> notEquals(__table2.id, 0_UInt8) UInt8 : 2
+                 FUNCTION notEquals(id : 0, 0_UInt8 :: 1) -> notEquals(__table2.id, 0_UInt8) UInt8 : 3
+                 FUNCTION and(notEquals(__table2.id, 0_UInt8) :: 3, notEquals(__table2.id, 0_UInt8) :: 2) -> and(notEquals(__table2.id, 0_UInt8), notEquals(__table2.id, 0_UInt8)) UInt8 : 1
+        Positions: 0 1
 --
 2	Value_2	2	Value_2

--- a/tests/queries/0_stateless/03156_analyzer_array_join_distributed.sql
+++ b/tests/queries/0_stateless/03156_analyzer_array_join_distributed.sql
@@ -8,3 +8,21 @@ SELECT s, arr, a FROM remote('127.0.0.{1,2}', currentDatabase(), arrays_test) AR
 
 SELECT s, arr FROM remote('127.0.0.2', currentDatabase(), arrays_test) ARRAY JOIN arr WHERE arr < 3 ORDER BY arr;
 SELECT s, arr FROM remote('127.0.0.{1,2}', currentDatabase(), arrays_test) ARRAY JOIN arr WHERE arr < 3 ORDER BY arr;
+
+create table hourly(
+  hour datetime,
+  `metric.names` Array(String),
+  `metric.values` Array(Int64)
+) Engine=Memory
+as select '2020-01-01', ['a', 'b'], [1,2];
+
+SELECT
+     toDate(hour) AS day,
+     `metric.names`,
+     sum(`metric.values`)
+FROM remote('127.0.0.{1,2}', currentDatabase(), hourly)
+ARRAY JOIN metric
+GROUP BY
+     day,
+     metric.names;
+ORDER BY metric.names;

--- a/tests/queries/0_stateless/03156_analyzer_array_join_distributed.sql
+++ b/tests/queries/0_stateless/03156_analyzer_array_join_distributed.sql
@@ -8,21 +8,3 @@ SELECT s, arr, a FROM remote('127.0.0.{1,2}', currentDatabase(), arrays_test) AR
 
 SELECT s, arr FROM remote('127.0.0.2', currentDatabase(), arrays_test) ARRAY JOIN arr WHERE arr < 3 ORDER BY arr;
 SELECT s, arr FROM remote('127.0.0.{1,2}', currentDatabase(), arrays_test) ARRAY JOIN arr WHERE arr < 3 ORDER BY arr;
-
-create table hourly(
-  hour datetime,
-  `metric.names` Array(String),
-  `metric.values` Array(Int64)
-) Engine=Memory
-as select '2020-01-01', ['a', 'b'], [1,2];
-
-SELECT
-     toDate(hour) AS day,
-     `metric.names`,
-     sum(`metric.values`)
-FROM remote('127.0.0.{1,2}', currentDatabase(), hourly)
-ARRAY JOIN metric
-GROUP BY
-     day,
-     metric.names;
-ORDER BY metric.names;


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Remove ALIAS nodes from the filter expression. This slightly improves performance for queries with `PREWHERE` (with new analyzer).