### PR TITLE
Attempt to fix 02228_merge_tree_insert_memory_usage.sql flakiness for s3

### DIFF
--- a/tests/queries/0_stateless/02228_merge_tree_insert_memory_usage.sql
+++ b/tests/queries/0_stateless/02228_merge_tree_insert_memory_usage.sql
@@ -1,4 +1,5 @@
--- Tags: long, no-parallel
+-- Tags: long, no-parallel, no-s3-storage
+-- no-s3-storage: Avoid flakiness due to cache / buffer usage
 SET insert_keeper_fault_injection_probability=0; -- to succeed this test can require too many retries due to 100 partitions, so disable fault injections
 
 -- regression for MEMORY_LIMIT_EXCEEDED error because of deferred final part flush


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Attempt to fix 02228_merge_tree_insert_memory_usage.sql flakiness for s3

### Documentation entry for user-facing changes

After recent changes to reduce the size of the test to fix timeouts, the test became flaky due to reaching the memory limits. AFAICT [it happens](https://play.clickhouse.com/play?user=play#c2VsZWN0IHB1bGxfcmVxdWVzdF9udW1iZXIgYXMgcHIsIGNoZWNrX3N0YXJ0X3RpbWUsIGNoZWNrX25hbWUsIHRlc3RfbmFtZSwgdGVzdF9zdGF0dXMgYXMgc3RhdHVzLCByZXBvcnRfdXJsCmZyb20gY2hlY2tzCndoZXJlIGNoZWNrX3N0YXJ0X3RpbWUgPiBub3coKSAtIElOVEVSVkFMIDMwIERBWSBhbmQgdGVzdF9uYW1lIGxpa2UgJyUwMjIyOF9tZXJnZV90cmVlX2luc2VydF9tZW1vcnlfdXNhZ2UlJyBhbmQgc3RhdHVzID09ICdGQUlMJwpvcmRlciBieSBjaGVja19zdGFydF90aW1lIGRlc2M=) basically in Azure and TSAN+s3 runs. Since controlling how much memory will be used in the case of object storage is extremely hard (cache, prefetching, buffers...), just disable the test for s3. It's irrelevant for what it's being tested.