### PR TITLE
(wip) Use approximate cardinalities for row order optimization

### DIFF
--- a/docs/en/operations/settings/merge-tree-settings.md
+++ b/docs/en/operations/settings/merge-tree-settings.md
@@ -974,7 +974,7 @@ Default value: false
 
 - [exclude_deleted_rows_for_part_size_in_merge](#exclude_deleted_rows_for_part_size_in_merge) setting
 
-### allow_experimental_optimized_row_order
+### allow_experimental_optimized_row_order {#allow_experimental_optimized_row_order}
 
 Controls if the row order should be optimized during inserts to improve the compressability of the newly inserted table part.
 
@@ -1017,3 +1017,20 @@ Compression rates of LZ4 or ZSTD improve on average by 20-40%.
 
 This setting works best for tables with no primary key or a low-cardinality primary key, i.e. a table with only few distinct primary key values.
 High-cardinality primary keys, e.g. involving timestamp columns of type `DateTime64`, are not expected to benefit from this setting.
+
+Possible values:
+
+- true, false
+
+Default: false
+
+### calculate_precise_cardinalities_for_optimized_row_order
+
+Controls if precise or estimated cardinalities are used for [row order optimization](#allow_experimental_optimized_row_order).
+This is an expert-level setting which should not be changed without good reason.
+
+Possible values:
+
+- true, false
+
+Default: true

--- a/src/Columns/ColumnDecimal.h
+++ b/src/Columns/ColumnDecimal.h
@@ -97,7 +97,7 @@ public:
                         size_t limit, int nan_direction_hint, IColumn::Permutation & res) const override;
     void updatePermutation(IColumn::PermutationSortDirection direction, IColumn::PermutationSortStability stability,
                         size_t limit, int, IColumn::Permutation & res, EqualRanges& equal_ranges) const override;
-    size_t estimateCardinalityInPermutedRange(const IColumn::Permutation & permutation, const EqualRange & equal_range) const override;
+    size_t estimateCardinalityInPermutedRange(const IColumn::Permutation & permutation, const EqualRange & equal_range, bool precise) const override;
 
 
     MutableColumnPtr cloneResized(size_t size) const override;

--- a/src/Columns/ColumnFixedString.h
+++ b/src/Columns/ColumnFixedString.h
@@ -142,7 +142,7 @@ public:
     void updatePermutation(IColumn::PermutationSortDirection direction, IColumn::PermutationSortStability stability,
                     size_t limit, int nan_direction_hint, Permutation & res, EqualRanges & equal_ranges) const override;
 
-    size_t estimateCardinalityInPermutedRange(const Permutation & permutation, const EqualRange & equal_range) const override;
+    size_t estimateCardinalityInPermutedRange(const Permutation & permutation, const EqualRange & equal_range, bool precise) const override;
 
     void insertRangeFrom(const IColumn & src, size_t start, size_t length) override;
 

--- a/src/Columns/ColumnLowCardinality.h
+++ b/src/Columns/ColumnLowCardinality.h
@@ -145,7 +145,7 @@ public:
     void updatePermutationWithCollation(const Collator & collator, IColumn::PermutationSortDirection direction, IColumn::PermutationSortStability stability,
                         size_t limit, int nan_direction_hint, Permutation & res, EqualRanges& equal_ranges) const override;
 
-    size_t estimateCardinalityInPermutedRange(const Permutation & permutation, const EqualRange & equal_range) const override;
+    size_t estimateCardinalityInPermutedRange(const Permutation & permutation, const EqualRange & equal_range, bool precise) const override;
 
     ColumnPtr replicate(const Offsets & offsets) const override
     {

--- a/src/Columns/ColumnNullable.h
+++ b/src/Columns/ColumnNullable.h
@@ -109,7 +109,7 @@ public:
                         size_t limit, int null_direction_hint, Permutation & res) const override;
     void updatePermutationWithCollation(const Collator & collator, IColumn::PermutationSortDirection direction, IColumn::PermutationSortStability stability,
                         size_t limit, int null_direction_hint, Permutation & res, EqualRanges& equal_ranges) const override;
-    size_t estimateCardinalityInPermutedRange(const Permutation & permutation, const EqualRange & equal_range) const override;
+    size_t estimateCardinalityInPermutedRange(const Permutation & permutation, const EqualRange & equal_range, bool precise) const override;
     void reserve(size_t n) override;
     void shrinkToFit() override;
     void ensureOwnership() override;

--- a/src/Columns/ColumnString.cpp
+++ b/src/Columns/ColumnString.cpp
@@ -7,6 +7,7 @@
 #include <Common/Arena.h>
 #include <Common/HashTable/StringHashSet.h>
 #include <Common/HashTable/Hash.h>
+#include <Common/HyperLogLogCounter.h>
 #include <Common/WeakHash.h>
 #include <Common/assert_cast.h>
 #include <Common/memcmpSmall.h>
@@ -482,22 +483,36 @@ void ColumnString::updatePermutationWithCollation(const Collator & collator, Per
             DefaultPartialSort());
 }
 
-size_t ColumnString::estimateCardinalityInPermutedRange(const Permutation & permutation, const EqualRange & equal_range) const
+size_t ColumnString::estimateCardinalityInPermutedRange(const Permutation & permutation, const EqualRange & equal_range, bool precise) const
 {
     const size_t range_size = equal_range.size();
     if (range_size <= 1)
         return range_size;
 
-    /// TODO use sampling if the range is too large (e.g. 16k elements, but configurable)
-    StringHashSet elements;
-    bool inserted = false;
-    for (size_t i = equal_range.from; i < equal_range.to; ++i)
+    if (precise)
     {
-        size_t permuted_i = permutation[i];
-        StringRef value = getDataAt(permuted_i);
-        elements.emplace(value, inserted);
+        StringHashSet elements;
+        for (size_t i = equal_range.from; i < equal_range.to; ++i)
+        {
+            size_t permuted_i = permutation[i];
+            StringRef value = getDataAt(permuted_i);
+            bool inserted;
+            elements.emplace(value, inserted);
+        }
+        return elements.size();
     }
-    return elements.size();
+    else
+    {
+        HyperLogLogCounter<8> counter;
+        for (size_t i = equal_range.from; i < equal_range.to; ++i)
+        {
+            size_t permuted_i = permutation[i];
+            StringRef value = getDataAt(permuted_i);
+            UInt64 hash = sipHash64(value);
+            counter.insertHash(static_cast<UInt32>(hash));
+        }
+        return counter.size();
+    }
 }
 
 ColumnPtr ColumnString::replicate(const Offsets & replicate_offsets) const

--- a/src/Columns/ColumnString.h
+++ b/src/Columns/ColumnString.h
@@ -260,7 +260,7 @@ public:
     void updatePermutationWithCollation(const Collator & collator, IColumn::PermutationSortDirection direction, IColumn::PermutationSortStability stability,
                     size_t limit, int, Permutation & res, EqualRanges & equal_ranges) const override;
 
-    size_t estimateCardinalityInPermutedRange(const Permutation & permutation, const EqualRange & equal_range) const override;
+    size_t estimateCardinalityInPermutedRange(const Permutation & permutation, const EqualRange & equal_range, bool precise) const override;
 
     ColumnPtr replicate(const Offsets & replicate_offsets) const override;
 

--- a/src/Columns/ColumnVector.cpp
+++ b/src/Columns/ColumnVector.cpp
@@ -15,6 +15,7 @@
 #include <Common/Exception.h>
 #include <Common/HashTable/Hash.h>
 #include <Common/HashTable/StringHashSet.h>
+#include <Common/HyperLogLogCounter.h>
 #include <Common/NaNUtils.h>
 #include <Common/RadixSort.h>
 #include <Common/SipHash.h>
@@ -415,22 +416,36 @@ void ColumnVector<T>::updatePermutation(IColumn::PermutationSortDirection direct
 }
 
 template<typename T>
-size_t ColumnVector<T>::estimateCardinalityInPermutedRange(const IColumn::Permutation & permutation, const EqualRange & equal_range) const
+size_t ColumnVector<T>::estimateCardinalityInPermutedRange(const IColumn::Permutation & permutation, const EqualRange & equal_range, bool precise) const
 {
     const size_t range_size = equal_range.size();
     if (range_size <= 1)
         return range_size;
 
-    /// TODO use sampling if the range is too large (e.g. 16k elements, but configurable)
-    StringHashSet elements;
-    bool inserted = false;
-    for (size_t i = equal_range.from; i < equal_range.to; ++i)
+    if (precise)
     {
-        size_t permuted_i = permutation[i];
-        StringRef value = getDataAt(permuted_i);
-        elements.emplace(value, inserted);
+        StringHashSet elements;
+        for (size_t i = equal_range.from; i < equal_range.to; ++i)
+        {
+            size_t permuted_i = permutation[i];
+            StringRef value = getDataAt(permuted_i);
+            bool inserted;
+            elements.emplace(value, inserted);
+        }
+        return elements.size();
     }
-    return elements.size();
+    else
+    {
+        HyperLogLogCounter<8> counter;
+        for (size_t i = equal_range.from; i < equal_range.to; ++i)
+        {
+            size_t permuted_i = permutation[i];
+            UInt64 value = get64(permuted_i);
+            UInt64 hash = sipHash64(value);
+            counter.insertHash(static_cast<UInt32>(hash));
+        }
+        return counter.size();
+    }
 }
 
 template <typename T>

--- a/src/Columns/ColumnVector.h
+++ b/src/Columns/ColumnVector.h
@@ -161,7 +161,7 @@ public:
     void updatePermutation(IColumn::PermutationSortDirection direction, IColumn::PermutationSortStability stability,
                     size_t limit, int nan_direction_hint, IColumn::Permutation & res, EqualRanges& equal_ranges) const override;
 
-    size_t estimateCardinalityInPermutedRange(const IColumn::Permutation & permutation, const EqualRange & equal_range) const override;
+    size_t estimateCardinalityInPermutedRange(const IColumn::Permutation & permutation, const EqualRange & equal_range, bool precise) const override;
 
     void reserve(size_t n) override
     {

--- a/src/Columns/IColumn.cpp
+++ b/src/Columns/IColumn.cpp
@@ -83,7 +83,7 @@ ColumnPtr IColumn::createWithOffsets(const Offsets & offsets, const ColumnConst 
     return res;
 }
 
-size_t IColumn::estimateCardinalityInPermutedRange(const IColumn::Permutation & /*permutation*/, const EqualRange & equal_range) const
+size_t IColumn::estimateCardinalityInPermutedRange(const IColumn::Permutation & /*permutation*/, const EqualRange & equal_range, bool /*precise*/) const
 {
     return equal_range.size();
 }

--- a/src/Columns/IColumn.h
+++ b/src/Columns/IColumn.h
@@ -408,7 +408,8 @@ public:
     }
 
     /// Estimate the cardinality (number of unique values) of the values in 'equal_range' after permutation, formally: |{ column[permutation[r]] : r in equal_range }|.
-    virtual size_t estimateCardinalityInPermutedRange(const Permutation & permutation, const EqualRange & equal_range) const;
+    /// Don't take flag "precise" literally, it works in a best-effort manner: with precise = true the result may still be imprecise.
+    virtual size_t estimateCardinalityInPermutedRange(const Permutation & permutation, const EqualRange & equal_range, bool precise) const;
 
     /** Copies each element according offsets parameter.
       * (i-th element should be copied offsets[i] - offsets[i - 1] times.)

--- a/src/Common/HyperLogLogCounter.h
+++ b/src/Common/HyperLogLogCounter.h
@@ -301,6 +301,17 @@ public:
         update(bucket, rank);
     }
 
+    void ALWAYS_INLINE insertHash(HashValueType hash)
+    {
+        /// Divide hash to two sub-values. First is bucket number, second will be used to calculate rank.
+        HashValueType bucket = extractBitSequence(hash, 0, precision);
+        HashValueType tail = extractBitSequence(hash, precision, sizeof(HashValueType) * 8);
+        UInt8 rank = calculateRank(tail);
+
+        /// Update maximum rank for current bucket.
+        update(bucket, rank);
+    }
+
     UInt64 size() const
     {
         /// Normalizing factor for harmonic mean.

--- a/src/Storages/MergeTree/MergeTreeDataWriter.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataWriter.cpp
@@ -505,7 +505,7 @@ MergeTreeDataWriter::TemporaryPart MergeTreeDataWriter::writeTempPartImpl(
 
     if (data.getSettings()->allow_experimental_optimized_row_order)
     {
-        RowOrderOptimizer::optimize(block, sort_description, perm);
+        RowOrderOptimizer::optimize(block, sort_description, perm, data.getSettings()->calculate_precise_cardinalities_for_optimized_row_order);
         perm_ptr = &perm;
     }
 
@@ -732,7 +732,7 @@ MergeTreeDataWriter::TemporaryPart MergeTreeDataWriter::writeProjectionPartImpl(
 
     if (data.getSettings()->allow_experimental_optimized_row_order)
     {
-        RowOrderOptimizer::optimize(block, sort_description, perm);
+        RowOrderOptimizer::optimize(block, sort_description, perm, data.getSettings()->calculate_precise_cardinalities_for_optimized_row_order);
         perm_ptr = &perm;
     }
 

--- a/src/Storages/MergeTree/MergeTreeSettings.h
+++ b/src/Storages/MergeTree/MergeTreeSettings.h
@@ -200,6 +200,7 @@ struct Settings;
     M(Bool, force_read_through_cache_for_merges, false, "Force read-through filesystem cache for merges", 0) \
     M(Bool, allow_experimental_replacing_merge_with_cleanup, false, "Allow experimental CLEANUP merges for ReplacingMergeTree with is_deleted column.", 0) \
     M(Bool, allow_experimental_optimized_row_order, false, "Allow reshuffling of rows during part inserts and merges to improve the compressibility of the new part", 0) \
+    M(Bool, calculate_precise_cardinalities_for_optimized_row_order, true, "Controls if precise or estimated cardinalities are used to optimize the row order", 0) \
     \
     /** Compress marks and primary key. */ \
     M(Bool, compress_marks, true, "Marks support compression, reduce mark file size and speed up network transmission.", 0) \

--- a/src/Storages/MergeTree/RowOrderOptimizer.h
+++ b/src/Storages/MergeTree/RowOrderOptimizer.h
@@ -20,7 +20,7 @@ public:
     /// - Determine (estimate) for each equal range the cardinality of each non-sorting-key column.
     /// - The simple heuristics applied is that non-sorting key columns will be sorted (within each equal range) in order of ascending
     ///   cardinality. This maximizes the length of equal-value runs within the non-sorting-key columns, leading to better compressability.
-    static void optimize(const Block & block, const SortDescription & sort_description, IColumn::Permutation & permutation);
+    static void optimize(const Block & block, const SortDescription & sort_description, IColumn::Permutation & permutation, bool calculate_precise_cardinalities);
 };
 
 }

--- a/tests/queries/0_stateless/03166_optimize_row_order_during_insert.reference
+++ b/tests/queries/0_stateless/03166_optimize_row_order_during_insert.reference
@@ -4,6 +4,15 @@ Egor	2
 Igor	1
 Igor	2
 Igor	3
+Precise/imprecise cardinality estimation
+Egor	1	2	Say	Hello	2.1	Say	Hello
+Egor	5	6	Say	Hello	1.2	ClickHouse	Test
+Igor	3	4	Hello	World	3.2	Hello	World
+Igor	3	4	Hello	World	3.2	Hello	World
+Egor	1	2	Say	Hello	2.1	Say	Hello
+Egor	5	6	Say	Hello	1.2	ClickHouse	Test
+Igor	3	4	Hello	World	3.2	Hello	World
+Igor	3	4	Hello	World	3.2	Hello	World
 Cardinalities test
 Alex	1	63	0
 Alex	1	65	0

--- a/tests/queries/0_stateless/03166_optimize_row_order_during_insert.sql
+++ b/tests/queries/0_stateless/03166_optimize_row_order_during_insert.sql
@@ -1,5 +1,4 @@
--- Checks that no bad things happen when the table optimizes the row order to improve compressability during insert.
-
+-- Tests row order optimization during INSERTs to improve the compressability.
 
 -- Below SELECTs intentionally only ORDER BY the table primary key and rely on read-in-order optimization
 SET optimize_read_in_order = 1;
@@ -14,11 +13,47 @@ CREATE TABLE tab (
     event Int8
 ) ENGINE = MergeTree
 ORDER BY name
-SETTINGS allow_experimental_optimized_row_order = true;
+SETTINGS allow_experimental_optimized_row_order = 1;
 INSERT INTO tab VALUES ('Igor', 3), ('Egor', 1), ('Egor', 2), ('Igor', 2), ('Igor', 1);
 
 SELECT * FROM tab ORDER BY name SETTINGS max_threads=1;
 
+DROP TABLE tab;
+
+SELECT 'Precise/imprecise cardinality estimation';
+
+-- Test that no bad things happen during the cardinality estimation for different data types.
+-- Test with precise and imprecise cardinalities
+CREATE TABLE tab (
+    name String,
+    u64 UInt64,
+    i8 Int8,
+    s String,
+    fs FixedString(5),
+    d Decimal32(3),
+    ns Nullable(String),
+    lcs LowCardinality(String)
+) ENGINE = MergeTree
+ORDER BY name
+SETTINGS allow_experimental_optimized_row_order = 1, calculate_precise_cardinalities_for_optimized_row_order = 1;
+INSERT INTO tab VALUES ('Igor', 3, 4, 'Hello', 'World', 3.2, 'Hello', 'World'), ('Egor', 1, 2, 'Say', 'Hello', 2.1, 'Say', 'Hello'), ('Igor', 3, 4, 'Hello', 'World', 3.2, 'Hello', 'World'), ('Egor', 5, 6, 'Say', 'Hello', 1.2, 'ClickHouse', 'Test');
+SELECT * FROM tab ORDER BY name SETTINGS max_threads=1;
+DROP TABLE tab;
+
+CREATE TABLE tab (
+    name String,
+    u64 UInt64,
+    i8 Int8,
+    s String,
+    fs FixedString(5),
+    d Decimal32(3),
+    ns Nullable(String),
+    lcs LowCardinality(String)
+) ENGINE = MergeTree
+ORDER BY name
+SETTINGS allow_experimental_optimized_row_order = 1, calculate_precise_cardinalities_for_optimized_row_order = 0;
+INSERT INTO tab VALUES ('Igor', 3, 4, 'Hello', 'World', 3.2, 'Hello', 'World'), ('Egor', 1, 2, 'Say', 'Hello', 2.1, 'Say', 'Hello'), ('Igor', 3, 4, 'Hello', 'World', 3.2, 'Hello', 'World'), ('Egor', 5, 6, 'Say', 'Hello', 1.2, 'ClickHouse', 'Test');
+SELECT * FROM tab ORDER BY name SETTINGS max_threads=1;
 DROP TABLE tab;
 
 -- Checks that RowOptimizer correctly selects the order for columns according to cardinality, with an empty ORDER BY.
@@ -34,7 +69,7 @@ CREATE TABLE tab (
     flag String
 ) ENGINE = MergeTree
 ORDER BY ()
-SETTINGS allow_experimental_optimized_row_order = True;
+SETTINGS allow_experimental_optimized_row_order = 1;
 INSERT INTO tab VALUES ('Bob', 4, 100, '1'), ('Nikita', 2, 54, '1'), ('Nikita', 1, 228, '1'), ('Alex', 4, 83, '1'), ('Alex', 4, 134, '1'), ('Alex', 1, 65, '0'), ('Alex', 4, 134, '1'), ('Bob', 2, 53, '0'), ('Alex', 4, 83, '0'), ('Alex', 1, 63, '1'), ('Bob', 2, 53, '1'), ('Alex', 4, 192, '1'), ('Alex', 2, 128, '1'), ('Nikita', 2, 148, '0'), ('Bob', 4, 177, '0'), ('Nikita', 1, 173, '0'), ('Alex', 1, 239, '0'), ('Alex', 1, 63, '0'), ('Alex', 2, 224, '1'), ('Bob', 4, 177, '0'), ('Alex', 2, 128, '1'), ('Alex', 4, 134, '0'), ('Alex', 4, 83, '1'), ('Bob', 4, 100, '0'), ('Nikita', 2, 54, '1'), ('Alex', 1, 239, '1'), ('Bob', 2, 187, '1'), ('Alex', 1, 65, '1'), ('Bob', 2, 53, '1'), ('Alex', 2, 224, '0'), ('Alex', 4, 192, '0'), ('Nikita', 1, 173, '1'), ('Nikita', 2, 148, '1'), ('Bob', 2, 187, '1'), ('Nikita', 2, 208, '1'), ('Nikita', 2, 208, '0'), ('Nikita', 1, 228, '0'), ('Nikita', 2, 148, '0');
 
 SELECT * FROM tab SETTINGS max_threads=1;
@@ -58,7 +93,7 @@ CREATE TABLE tab (
     flag Nullable(Int32)
 ) ENGINE = MergeTree
 ORDER BY (flag, money)
-SETTINGS allow_experimental_optimized_row_order = True, allow_nullable_key = True;
+SETTINGS allow_experimental_optimized_row_order = 1, allow_nullable_key = 1;
 INSERT INTO tab VALUES ('AB', 0, 42, Null), ('AB', 0, 42, Null), ('A', 1, 42, Null), ('AB', 1, 9.81, 0), ('B', 0, 42, Null), ('B', -1, 3.14, Null), ('B', 1, 2.7, 1), ('B', 0, 42, 1), ('A', 1, 42, 1), ('B', 1, 42, Null), ('B', 0, 2.7, 1), ('A', 0, 2.7, 1), ('B', 2, 3.14, Null), ('A', 0, 3.14, Null), ('A', 1, 2.7, 1), ('A', 1, 42, Null);
 
 SELECT * FROM tab ORDER BY (flag, money) SETTINGS max_threads=1;
@@ -89,7 +124,7 @@ CREATE TABLE tab (
     tuple_column Tuple(UInt256)
 ) ENGINE = MergeTree()
 ORDER BY (fixed_str, event_date)
-SETTINGS allow_experimental_optimized_row_order = True;
+SETTINGS allow_experimental_optimized_row_order = 1;
 
 INSERT INTO tab VALUES ('A', '2020-01-01', [0.0, 1.1], 10, 'some string', {'key':'value'}, (123)), ('A', '2020-01-01', [0.0, 1.1], NULL, 'example', {}, (26)), ('A', '2020-01-01', [2.2, 1.1], 1, 'some other string', {'key2':'value2'}, (5)), ('A', '2020-01-02', [0.0, 1.1], 10, 'some string', {'key':'value'}, (123)), ('A', '2020-01-02', [0.0, 2.2], 10, 'example', {}, (26)), ('A', '2020-01-02', [2.2, 1.1], 1, 'some other string', {'key2':'value2'}, (5)), ('B', '2020-01-04', [0.0, 1.1], 10, 'some string', {'key':'value'}, (123)), ('B', '2020-01-04', [0.0, 2.2], Null, 'example', {}, (26)), ('B', '2020-01-04', [2.2, 1.1], 1, 'some string', {'key2':'value2'}, (5)), ('B', '2020-01-05', [0.0, 1.1], 10, 'some string', {'key':'value'}, (123)), ('B', '2020-01-05', [0.0, 2.2], Null, 'example', {}, (26)), ('B', '2020-01-05', [2.2, 1.1], 1, 'some other string', {'key':'value'}, (5)), ('C', '2020-01-04', [0.0, 1.1], 10, 'some string', {'key':'value'}, (5)), ('C', '2020-01-04', [0.0, 2.2], Null, 'example', {}, (26)), ('C', '2020-01-04', [2.2, 1.1], 1, 'some other string', {'key2':'value2'}, (5));
 


### PR DESCRIPTION
TODO:
- https://github.com/ClickHouse/ClickHouse/pull/63578#issuecomment-2156712638
- rebase on top of merged https://github.com/ClickHouse/ClickHouse/pull/64814
- test push with row order optimization and approximate cardinality calculation enabled

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)