### PR TITLE
xray: rename cmake file and build only on amd64 linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,7 +122,7 @@ add_library(global-libs INTERFACE)
 
 include (cmake/sanitize.cmake)
 
-include (cmake/instrument.cmake)
+include (cmake/xray_instrumentation.cmake)
 
 option(ENABLE_COLORED_BUILD "Enable colors in compiler output" ON)
 

--- a/cmake/xray_instrumentation.cmake
+++ b/cmake/xray_instrumentation.cmake
@@ -7,7 +7,7 @@ if (NOT ENABLE_XRAY)
     return()
 endif()
 
-if (NOT (ARCH_AMD64 AND (OS_LINUX OR OS_FREEBSD)))
+if (NOT (ARCH_AMD64 AND OS_LINUX))
     message (STATUS "Not using LLVM XRay, only amd64 Linux or FreeBSD are supported")
     return()
 endif()


### PR DESCRIPTION
@rschu1ze This PR addresses your comments on https://github.com/ClickHouse/ClickHouse/pull/64592, I agree.

### Changelog category (leave one):

- Build/Testing/Packaging Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

- Support LLVM XRay on Linux amd64 only.
