### PR TITLE
Fix untracked memory in `MemoryTrackerSwitcher`

### DIFF
--- a/src/Common/MemoryTrackerSwitcher.h
+++ b/src/Common/MemoryTrackerSwitcher.h
@@ -15,6 +15,7 @@ struct MemoryTrackerSwitcher
             return;
 
         auto * thread_tracker = CurrentThread::getMemoryTracker();
+
         prev_untracked_memory = current_thread->untracked_memory;
         prev_memory_tracker_parent = thread_tracker->getParent();
 
@@ -31,8 +32,10 @@ struct MemoryTrackerSwitcher
         CurrentThread::flushUntrackedMemory();
         auto * thread_tracker = CurrentThread::getMemoryTracker();
 
-        current_thread->untracked_memory = prev_untracked_memory;
+        /// It is important to set untracked memory after the call of
+        /// 'setParent' because it may flush untracked memory to the wrong parent.
         thread_tracker->setParent(prev_memory_tracker_parent);
+        current_thread->untracked_memory = prev_untracked_memory;
     }
 
 private:


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed possible incorrect memory tracking in several kinds of queries: queries that read any data from S3, queries via http protocol, asynchronous inserts.


#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_non_required--> Allow: All NOT Required Checks
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_integration--> Exclude: Integration Tests
- [ ] <!---ci_exclude_stateless--> Exclude: Stateless tests
- [ ] <!---ci_exclude_stateful--> Exclude: Stateful tests
- [ ] <!---ci_exclude_performance--> Exclude: Performance tests
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_aarch64--> Exclude: All with Aarch64
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
