### PR TITLE
Added listen_try and  listen_reuse_port parameters

### DIFF
--- a/docs/en/operations/server-configuration-parameters/settings.md
+++ b/docs/en/operations/server-configuration-parameters/settings.md
@@ -1355,7 +1355,7 @@ Examples:
 
 ## listen_try {#listen_try}
 
-Server does not exit if IPv6 or IPv4 networks are unavailable while trying to listen.
+The server will not exit if IPv6 or IPv4 networks are unavailable while trying to listen.
 
 Examples:
 
@@ -1365,7 +1365,7 @@ Examples:
 
 ## listen_reuse_port {#listen_reuse_port}
 
-Allow multiple servers to listen on the same address:port. Enabling this setting is not recommended.
+Allow multiple servers to listen on the same address:port. Requests will be routed to a random server by the operating system. Enabling this setting is not recommended.
 
 Examples:
 

--- a/docs/en/operations/server-configuration-parameters/settings.md
+++ b/docs/en/operations/server-configuration-parameters/settings.md
@@ -1353,6 +1353,26 @@ Examples:
 <listen_host>127.0.0.1</listen_host>
 ```
 
+## listen_try {#listen_try}
+
+Server does not exit if IPv6 or IPv4 networks are unavailable while trying to listen.
+
+Examples:
+
+``` xml
+<listen_try>0</listen_try>
+```
+
+## listen_reuse_port {#listen_reuse_port}
+
+Allow multiple servers to listen on the same address:port. Enabling this setting is not recommended.
+
+Examples:
+
+``` xml
+<listen_reuse_port>0</listen_reuse_port>
+```
+
 ## listen_backlog {#listen_backlog}
 
 Backlog (queue size of pending connections) of the listen socket.


### PR DESCRIPTION
### Changelog category (leave one):
- Documentation (changelog entry is not required)

---

Hi
Added documentation for the following parameters
in the global setting file
listen_try
listen_reuse_port

the settings were added in version 18.6 and are still valid (tested on v24.5.1) but there is no mention about them.
