### PR TITLE
Added mlock_executable parameter

### DIFF
--- a/docs/en/operations/server-configuration-parameters/settings.md
+++ b/docs/en/operations/server-configuration-parameters/settings.md
@@ -1206,6 +1206,16 @@ Expired time for HSTS in seconds. The default value is 0 means clickhouse disabl
 <hsts_max_age>600000</hsts_max_age>
 ```
 
+## mlock_executable {#mlock_executable}
+
+Perform mlockall after startup to lower first queries latency and to prevent clickhouse executable from being paged out under high IO load. Enabling this option is recommended but will lead to increased startup time for up to a few seconds.
+Keep in mind that this parameter would not work without "CAP_IPC_LOCK" capability.
+**Example**
+
+``` xml
+<mlock_executable>false</mlock_executable>
+```
+
 ## include_from {#include_from}
 
 The path to the file with substitutions. Both XML and YAML formats are supported.


### PR DESCRIPTION
### Changelog category (leave one):
- Documentation (changelog entry is not required)

---
---

Hi
Added documentation for the "mlock_executable" parameter in the global setting file
the parameter was tested on v24.5.1 and worked. There was no mention about it.

p.s:
Sorry if I did not add this in the previous MR, I did not think they were related.
[https://github.com/ClickHouse/ClickHouse/pull/64852](url)