### PR TITLE
added mlock and mlockall to aspell-dict to be ignored

### DIFF
--- a/utils/check-style/aspell-ignore/en/aspell-dict.txt
+++ b/utils/check-style/aspell-ignore/en/aspell-dict.txt
@@ -557,8 +557,6 @@ MinHash
 MinIO
 MinMax
 MindsDB
-mlock
-mlockall
 Mongodb
 Monotonicity
 MsgPack
@@ -2002,6 +2000,8 @@ minmax
 mins
 misconfiguration
 mispredictions
+mlock
+mlockall
 mmap
 mmapped
 modularization

--- a/utils/check-style/aspell-ignore/en/aspell-dict.txt
+++ b/utils/check-style/aspell-ignore/en/aspell-dict.txt
@@ -557,6 +557,8 @@ MinHash
 MinIO
 MinMax
 MindsDB
+mlock
+mlockall
 Mongodb
 Monotonicity
 MsgPack


### PR DESCRIPTION
Hi,

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

---
---

Cause this PR to fail since the words did not exist
https://github.com/ClickHouse/ClickHouse/pull/64854

<img width="952" alt="Screenshot 2024-06-06 at 2 14 13 AM" src="https://github.com/ClickHouse/ClickHouse/assets/115415312/360d4782-1425-4bf0-8d94-13e64e90a872">
