### PR TITLE
Fix 03002_part_log_rmt_fetch_mutate_error flakiness

### DIFF
--- a/tests/queries/0_stateless/03002_part_log_rmt_fetch_mutate_error.sql
+++ b/tests/queries/0_stateless/03002_part_log_rmt_fetch_mutate_error.sql
@@ -4,7 +4,7 @@
 drop table if exists rmt_master;
 drop table if exists rmt_slave;
 
-create table rmt_master (key Int) engine=ReplicatedMergeTree('/clickhouse/{database}', 'master') order by tuple() settings always_fetch_merged_part=0;
+create table rmt_master (key Int) engine=ReplicatedMergeTree('/clickhouse/{database}', 'master') order by tuple() settings always_fetch_merged_part=0, old_parts_lifetime=600;
 -- prefer_fetch_merged_part_*_threshold=0, consider this table as a "slave"
 create table rmt_slave (key Int) engine=ReplicatedMergeTree('/clickhouse/{database}', 'slave') order by tuple() settings prefer_fetch_merged_part_time_threshold=0, prefer_fetch_merged_part_size_threshold=0;
 


### PR DESCRIPTION
CI: https://s3.amazonaws.com/clickhouse-test-reports/61973/6cfd5b2165970a65a551117fe58e4b9d22237b8c/stateless_tests__debug__s3_storage__[3_6].html

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

#### CI Settings (Only check the boxes if you know what you are doing):
- [x] <!---ci_include_stateless--> Allow: Stateless tests