### PR TITLE
Fix possible loss of "Query was cancelled" message in client (fixes 03023_zeros_generate_random_with_limit_progress_bar flakiness)

### DIFF
--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -1188,7 +1188,10 @@ void ClientBase::receiveResult(ASTPtr parsed_query, Int32 signals_before_stop, b
         std::rethrow_exception(local_format_error);
 
     if (cancelled && is_interactive)
+    {
         std::cout << "Query was cancelled." << std::endl;
+        cancelled_printed = true;
+    }
 }
 
 
@@ -1302,8 +1305,13 @@ void ClientBase::onEndOfStream()
 
     resetOutput();
 
-    if (is_interactive && !written_first_block)
-        std::cout << "Ok." << std::endl;
+    if (is_interactive)
+    {
+        if (cancelled && !cancelled_printed)
+            std::cout << "Query was cancelled." << std::endl;
+        else if (!written_first_block)
+            std::cout << "Ok." << std::endl;
+    }
 }
 
 
@@ -1866,6 +1874,7 @@ void ClientBase::processParsedSingleQuery(const String & full_query, const Strin
     resetOutput();
     have_error = false;
     cancelled = false;
+    cancelled_printed = false;
     client_exception.reset();
     server_exception.reset();
 

--- a/src/Client/ClientBase.h
+++ b/src/Client/ClientBase.h
@@ -329,6 +329,7 @@ protected:
     bool allow_merge_tree_settings = false;
 
     bool cancelled = false;
+    bool cancelled_printed = false;
 
     /// Does log_comment has specified by user?
     bool has_log_comment = false;


### PR DESCRIPTION
Previously "Query was cancelled" had been printed only on new blocks, so if no new blocks will be arrived, then it will not print this message, and this is indeed why 03023_zeros_generate_random_with_limit_progress_bar was flaky [1]:

    2024-06-05 16:21:22 expect: does "\u258e\u001b[0m                    \u001b[2m(0.9 CPU)\u001b[0m 4%\u001b[K^C\r\u001b[1;31m\u2198\u001b[0m Progress: 404.74 thousand rows, 404.74 KB (806.77 thousand rows/s., 806.77 KB/s.) \u001b[0;32m\u2588\u258e\u001b[0m                    \u001b[2m(2.0 CPU)\u001b[0m 4%\u001b[K\r\u001b[KCancelling query.\r\n                                                                                                                        \r\u001b[1;32m\u2193\u001b[0m Progress: 404.74 thousand rows, 404.74 KB (806.15 thousand rows/s., 806.15 KB/s.) \u001b[0;32m\u2588\u258e\u001b[0m                    \u001b[2m(2.0 CPU)\u001b[0m 4%\u001b[K" (spawn_id exp4) match glob pattern "Query was cancelled."? no
    2024-06-05 16:21:22
    2024-06-05 16:21:22 [KOk.
    2024-06-05 16:21:22 , result:

As you can see it printed "Cancelling query" and "Ok" but not "Query was cancelled" due to this.

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/61973/6cfd5b2165970a65a551117fe58e4b9d22237b8c/stateless_tests__tsan__s3_storage__[1_5].html

A bit hackish with all this bool flags, but I guess it is OK.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix possible loss of "Query was cancelled" message in client

Cc: @alexey-milovidov (`03023_zeros_generate_random_with_limit_progress_bar` test)