### PR TITLE
Document REPLACE PARTITION as atomic

### DIFF
--- a/docs/en/sql-reference/statements/alter/partition.md
+++ b/docs/en/sql-reference/statements/alter/partition.md
@@ -139,7 +139,7 @@ For the query to run successfully, the following conditions must be met:
 ALTER TABLE table2 [ON CLUSTER cluster] REPLACE PARTITION partition_expr FROM table1
 ```
 
-This query copies the data partition from the `table1` to `table2` and replaces existing partition in the `table2`.
+This query copies the data partition from `table1` to `table2` and replaces the existing partition in `table2`. The operation is atomic.
 
 Note that:
 


### PR DESCRIPTION
`REPLACE PARTITION` is atomic as per conversation with @al13n321 and @nikitamikhaylov (but see also the original PR for it which explicitly mentions atomicity: https://github.com/ClickHouse/ClickHouse/pull/2217).

### Changelog category (leave one):
- Documentation (changelog entry is not required)