### PR TITLE
[Docs] add `flameGraph` aggregate function to docs

### DIFF
--- a/docs/en/sql-reference/aggregate-functions/reference/flame_graph.md
+++ b/docs/en/sql-reference/aggregate-functions/reference/flame_graph.md
@@ -26,7 +26,7 @@ Only allocations which were not freed are shown. Non mapped deallocations are ig
 
 ## Returned value
 
-- An array of strings for use with [flamegraph.pl util](https://github.com/brendangregg/FlameGraph). [Array](../../data-types/array.md)([String](../../data-types/string.md)).
+- An array of strings for use with [flamegraph.pl utility](https://github.com/brendangregg/FlameGraph). [Array](../../data-types/array.md)([String](../../data-types/string.md)).
 
 ## Examples
 

--- a/docs/en/sql-reference/aggregate-functions/reference/flame_graph.md
+++ b/docs/en/sql-reference/aggregate-functions/reference/flame_graph.md
@@ -5,7 +5,7 @@ sidebar_position: 110
 
 # flameGraph
 
-Aggregate function which builds a [flamegraph](https://www.brendangregg.com/flamegraphs.html) using the list of stacktraces. Outputs an array of strings which can be used by [flamegraph.pl util](https://github.com/brendangregg/FlameGraph) to render an SVG of the flamegraph.
+Aggregate function which builds a [flamegraph](https://www.brendangregg.com/flamegraphs.html) using the list of stacktraces. Outputs an array of strings which can be used by [flamegraph.pl utility](https://github.com/brendangregg/FlameGraph) to render an SVG of the flamegraph.
 
 ## Syntax
 

--- a/docs/en/sql-reference/aggregate-functions/reference/flame_graph.md
+++ b/docs/en/sql-reference/aggregate-functions/reference/flame_graph.md
@@ -1,0 +1,95 @@
+---
+slug: /en/sql-reference/aggregate-functions/reference/flamegraph
+sidebar_position: 110
+---
+
+# flameGraph
+
+Aggregate function which builds a [flamegraph](https://www.brendangregg.com/flamegraphs.html) using the list of stacktraces. Outputs an array of strings which can be used by [flamegraph.pl util](https://github.com/brendangregg/FlameGraph) to render an SVG of the flamegraph.
+
+## Syntax
+
+```sql
+flameGraph(traces, [size], [ptr])
+```
+
+## Parameters
+
+- `traces` — a stacktrace. [Array](../../data-types/array.md)([UInt64](../../data-types/int-uint.md)).
+- `size` — an allocation size for memory profiling. (optional - default `1`). [UInt64](../../data-types/int-uint.md).
+- `ptr` — an allocation address. (optional - default `0`). [UInt64](../../data-types/int-uint.md).
+
+:::note
+In the case where `ptr != 0`, a flameGraph will map allocations (size > 0) and deallocations (size < 0) with the same size and ptr.
+Only allocations which were not freed are shown. Non mapped deallocations are ignored.
+:::
+
+## Returned value
+
+- An array of strings for use with [flamegraph.pl util](https://github.com/brendangregg/FlameGraph). [Array](../../data-types/array.md)([String](../../data-types/string.md)).
+
+## Examples
+
+### Building a flamegraph based on a CPU query profiler
+
+```sql
+SET query_profiler_cpu_time_period_ns=10000000;
+SELECT SearchPhrase, COUNT(DISTINCT UserID) AS u FROM hits WHERE SearchPhrase <> '' GROUP BY SearchPhrase ORDER BY u DESC LIMIT 10;
+```
+
+```text
+clickhouse client --allow_introspection_functions=1 -q "select arrayJoin(flameGraph(arrayReverse(trace))) from system.trace_log where trace_type = 'CPU' and query_id = 'xxx'" | ~/dev/FlameGraph/flamegraph.pl  > flame_cpu.svg
+```
+
+### Building a flamegraph based on a memory query profiler, showing all allocations
+
+```sql
+SET memory_profiler_sample_probability=1, max_untracked_memory=1;
+SELECT SearchPhrase, COUNT(DISTINCT UserID) AS u FROM hits WHERE SearchPhrase <> '' GROUP BY SearchPhrase ORDER BY u DESC LIMIT 10;
+```
+
+```text
+clickhouse client --allow_introspection_functions=1 -q "select arrayJoin(flameGraph(trace, size)) from system.trace_log where trace_type = 'MemorySample' and query_id = 'xxx'" | ~/dev/FlameGraph/flamegraph.pl --countname=bytes --color=mem > flame_mem.svg
+```
+
+### Building a flamegraph based on a memory query profiler, showing allocations which were not deallocated in query context
+
+```sql
+SET memory_profiler_sample_probability=1, max_untracked_memory=1, use_uncompressed_cache=1, merge_tree_max_rows_to_use_cache=100000000000, merge_tree_max_bytes_to_use_cache=1000000000000;
+SELECT SearchPhrase, COUNT(DISTINCT UserID) AS u FROM hits WHERE SearchPhrase <> '' GROUP BY SearchPhrase ORDER BY u DESC LIMIT 10;
+```
+
+```text
+clickhouse client --allow_introspection_functions=1 -q "SELECT arrayJoin(flameGraph(trace, size, ptr)) FROM system.trace_log WHERE trace_type = 'MemorySample' AND query_id = 'xxx'" | ~/dev/FlameGraph/flamegraph.pl --countname=bytes --color=mem > flame_mem_untracked.svg
+```
+
+### Build a flamegraph based on memory query profiler, showing active allocations at the fixed point of time
+
+```sql
+SET memory_profiler_sample_probability=1, max_untracked_memory=1;
+SELECT SearchPhrase, COUNT(DISTINCT UserID) AS u FROM hits WHERE SearchPhrase <> '' GROUP BY SearchPhrase ORDER BY u DESC LIMIT 10;
+```
+
+- 1 - Memory usage per second
+
+```sql
+SELECT event_time, m, formatReadableSize(max(s) as m) FROM (SELECT event_time, sum(size) OVER (ORDER BY event_time) AS s FROM system.trace_log WHERE query_id = 'xxx' AND trace_type = 'MemorySample') GROUP BY event_time ORDER BY event_time;
+```
+
+- 2 - Find a time point with maximal memory usage
+
+```sql
+SELECT argMax(event_time, s), max(s) FROM (SELECT event_time, sum(size) OVER (ORDER BY event_time) AS s FROM system.trace_log WHERE query_id = 'xxx' AND trace_type = 'MemorySample');
+```
+
+-  3 - Fix active allocations at fixed point of time
+
+```text
+clickhouse client --allow_introspection_functions=1 -q "SELECT arrayJoin(flameGraph(trace, size, ptr)) FROM (SELECT * FROM system.trace_log WHERE trace_type = 'MemorySample' AND query_id = 'xxx' AND event_time <= 'yyy' ORDER BY event_time)" | ~/dev/FlameGraph/flamegraph.pl --countname=bytes --color=mem > flame_mem_time_point_pos.svg
+```
+
+- 4 - Find deallocations at fixed point of time
+
+```text
+clickhouse client --allow_introspection_functions=1 -q "SELECT arrayJoin(flameGraph(trace, -size, ptr)) FROM (SELECT * FROM system.trace_log WHERE trace_type = 'MemorySample' AND query_id = 'xxx' AND event_time > 'yyy' ORDER BY event_time desc)" | ~/dev/FlameGraph/flamegraph.pl --countname=bytes --color=mem > flame_mem_time_point_neg.svg
+```

--- a/docs/en/sql-reference/aggregate-functions/reference/index.md
+++ b/docs/en/sql-reference/aggregate-functions/reference/index.md
@@ -58,6 +58,7 @@ ClickHouse-specific aggregate functions:
 - [topKWeighted](../reference/topkweighted.md)
 - [deltaSum](../reference/deltasum.md)
 - [deltaSumTimestamp](../reference/deltasumtimestamp.md)
+- [flameGraph](../reference/flame_graph.md)
 - [groupArray](../reference/grouparray.md)
 - [groupArrayLast](../reference/grouparraylast.md)
 - [groupUniqArray](../reference/groupuniqarray.md)

--- a/utils/check-style/aspell-ignore/en/aspell-dict.txt
+++ b/utils/check-style/aspell-ignore/en/aspell-dict.txt
@@ -222,6 +222,7 @@ DatabaseOrdinaryThreadsActive
 DateTime
 DateTimes
 DbCL
+deallocated
 Decrypted
 Deduplicate
 Deduplication
@@ -293,6 +294,7 @@ FilesystemMainPathUsedBytes
 FilesystemMainPathUsedINodes
 FixedString
 FlameGraph
+flameGraph
 Flink
 ForEach
 FreeBSD


### PR DESCRIPTION
Adds documentation for missing `flameGraph` aggregate function. Closes [#1954](https://github.com/ClickHouse/clickhouse-docs/issues/1954).

### Changelog category (leave one):
- Documentation (changelog entry is not required)