### PR TITLE
Fix test_mask_sensitive_info/test.py::test_create_table

### DIFF
--- a/tests/integration/test_mask_sensitive_info/test.py
+++ b/tests/integration/test_mask_sensitive_info/test.py
@@ -260,8 +260,9 @@ def test_create_table():
             "CREATE TABLE table16 (`x` int) ENGINE = DeltaLake('http://minio1:9001/root/data/test11.csv.gz', 'minio', '[HIDDEN]')",
             "CREATE TABLE table17 (x int) ENGINE = S3Queue('http://minio1:9001/root/data/', 'CSV') settings mode = 'ordered'",
             "CREATE TABLE table18 (x int) ENGINE = S3Queue('http://minio1:9001/root/data/', 'CSV', 'gzip') settings mode = 'ordered'",
-            "CREATE TABLE table19 (`x` int) ENGINE = S3Queue('http://minio1:9001/root/data/', 'minio', '[HIDDEN]', 'CSV') settings mode = 'ordered'",
-            "CREATE TABLE table20 (`x` int) ENGINE = S3Queue('http://minio1:9001/root/data/', 'minio', '[HIDDEN]', 'CSV', 'gzip') settings mode = 'ordered'",
+            # due to sensitive data substituion the query will be normalized, so not "settings" but "SETTINGS"
+            "CREATE TABLE table19 (`x` int) ENGINE = S3Queue('http://minio1:9001/root/data/', 'minio', '[HIDDEN]', 'CSV') SETTINGS mode = 'ordered'",
+            "CREATE TABLE table20 (`x` int) ENGINE = S3Queue('http://minio1:9001/root/data/', 'minio', '[HIDDEN]', 'CSV', 'gzip') SETTINGS mode = 'ordered'",
         ],
         must_not_contain=[password],
     )


### PR DESCRIPTION
CI: https://s3.amazonaws.com/clickhouse-test-reports/64887/5d01a2f7c8b41244ecad2cbf2c7f5ed7e6113cc9/integration_tests__asan__old_analyzer__[2_6].html

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Fixes: https://github.com/ClickHouse/ClickHouse/pull/64845 (cc @alexey-milovidov @kssenii )

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

<details>
    <summary>CI Settings</summary>

**NOTE:** If your merge the PR with modified CI you **MUST KNOW** what you are doing
**NOTE:** Checked options will be applied if set before CI RunConfig/PrepareRunConfig step
- [x] <!---ci_include_integration--> Allow: Integration Tests
</details>
