### PR TITLE
[Docs] add `lowCardinalityKeys`, `lowCardinalityIndices` to docs

### DIFF
--- a/utils/check-style/aspell-ignore/en/aspell-dict.txt
+++ b/utils/check-style/aspell-ignore/en/aspell-dict.txt
@@ -1934,6 +1934,8 @@ london
 lookups
 loongarch
 lowcardinality
+lowCardinalityIndices
+lowCardinalityKeys
 lowerUTF
 lowercased
 lttb


### PR DESCRIPTION
Closes [#1978](https://github.com/ClickHouse/clickhouse-docs/issues/1978).

Adds to the docs:
- `lowCardinalityIndices`
- `lowCardinalityKeys`
- an example to `blockSize`

### Changelog category (leave one):
- Documentation (changelog entry is not required)