### PR TITLE
Add missing allow_experimental_full_text_index for 03165_string_functions_with_token_text_indexes (fixes CI)

### DIFF
--- a/tests/queries/0_stateless/03165_string_functions_with_token_text_indexes.sql
+++ b/tests/queries/0_stateless/03165_string_functions_with_token_text_indexes.sql
@@ -116,7 +116,7 @@ SELECT '';
 SELECT '-------- GIN filter --------';
 SELECT '';
 
-SET allow_experimental_inverted_index=1;
+SET allow_experimental_full_text_index=1;
 DROP TABLE IF EXISTS 03165_token_ft;
 CREATE TABLE 03165_token_ft
 (


### PR DESCRIPTION
Conflicts between #64720 and #64656

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

#### CI Settings (Only check the boxes if you know what you are doing):
- [x] <!---ci_include_stateless--> Allow: Stateless tests

**NOTE: I've enabled only stateless tests**

Cc: @rschu1ze, @jkartseva