### PR TITLE
Fix 02444_async_broken_outdated_part_loading flakiness

### DIFF
--- a/tests/queries/0_stateless/02444_async_broken_outdated_part_loading.sh
+++ b/tests/queries/0_stateless/02444_async_broken_outdated_part_loading.sh
@@ -6,7 +6,7 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../shell_config.sh
 
 $CLICKHOUSE_CLIENT -q "drop table if exists rmt sync;"
-$CLICKHOUSE_CLIENT -q "create table rmt (n int) engine=ReplicatedMergeTree('/test/02444/$CLICKHOUSE_TEST_ZOOKEEPER_PREFIX/rmt', '1') order by n"
+$CLICKHOUSE_CLIENT -q "create table rmt (n int) engine=ReplicatedMergeTree('/test/02444/$CLICKHOUSE_TEST_ZOOKEEPER_PREFIX/rmt', '1') order by n settings old_parts_lifetime=600"
 
 $CLICKHOUSE_CLIENT --insert_keeper_fault_injection_probability=0 -q "insert into rmt values (1);"
 $CLICKHOUSE_CLIENT --insert_keeper_fault_injection_probability=0 -q "insert into rmt values (2);"


### PR DESCRIPTION
It uses already removed path to detect the absolute path:

    2024.06.06 22:36:55.845743 [ 1055 ] {} <Debug> test_858tcd7j.rmt (8d64bafa-bedf-4015-9673-8911de129a8f): Removing 2 parts from memory: Parts: [all_0_0_0, all_1_1_0]
    2024.06.06 22:36:56.608589 [ 2065 ] {41c3a91d-2ee5-4006-bb79-92e7e8f005bb} <Debug> executeQuery: (from [::1]:48792) (comment: 02444_async_broken_outdated_part_loading.sh) select path from system.parts where database='test_858tcd7j' and table='rmt' and name='all_1_1_0' (stage: Complete)

CI: https://s3.amazonaws.com/clickhouse-test-reports/64856/d10027cc3b7737c524f4cfce262d46753fd03036/stateless_tests__debug__[5_5].html

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

#### CI Settings (Only check the boxes if you know what you are doing):
- [x] <!---ci_include_stateless--> Allow: Stateless tests