### PR TITLE
Remove do_not_test option from PR bodies

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -60,7 +60,6 @@ At a minimum, the following information should be added (but add more as needed)
 - [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
 - [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
 ---
-- [ ] <!---do_not_test--> Do not test
 - [ ] <!---upload_all--> Upload binaries for special builds
 - [ ] <!---no_merge_commit--> Disable merge-commit
 - [ ] <!---no_ci_cache--> Disable CI cache

--- a/tests/ci/ci_settings.py
+++ b/tests/ci/ci_settings.py
@@ -103,8 +103,6 @@ class CiSettings:
             elif match == CILabels.UPLOAD_ALL_ARTIFACTS:
                 res.upload_all = True
                 print("NOTE: All binary artifacts will be uploaded")
-            elif match == CILabels.DO_NOT_TEST_LABEL:
-                res.do_not_test = True
             elif match == CILabels.NO_MERGE_COMMIT:
                 res.no_merge_commit = True
                 print("NOTE: Merge Commit will be disabled")


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Remove do_not_test option from PR bodies

### Documentation entry for user-facing changes

It's been misused to break the CI multiple times. CI changes should run the CI