### PR TITLE
Add metrics for PutObject and GetObject throttlers of ObjectStorage

### DIFF
--- a/src/Common/Throttler.cpp
+++ b/src/Common/Throttler.cpp
@@ -43,19 +43,7 @@ UInt64 Throttler::add(size_t amount)
     // Values obtained under lock to be checked after release
     size_t count_value;
     double tokens_value;
-    {
-        std::lock_guard lock(mutex);
-        auto now = clock_gettime_ns_adjusted(prev_ns);
-        if (max_speed)
-        {
-            double delta_seconds = prev_ns ? static_cast<double>(now - prev_ns) / NS : 0;
-            tokens = std::min<double>(tokens + max_speed * delta_seconds - amount, max_burst);
-        }
-        count += amount;
-        count_value = count;
-        tokens_value = tokens;
-        prev_ns = now;
-    }
+    addImpl(amount, count_value, tokens_value);
 
     if (limit && count_value > limit)
         throw Exception::createDeprecated(limit_exceeded_exception_message + std::string(" Maximum: ") + toString(limit), ErrorCodes::LIMIT_EXCEEDED);
@@ -77,6 +65,21 @@ UInt64 Throttler::add(size_t amount)
     return static_cast<UInt64>(sleep_time_ns);
 }
 
+void Throttler::addImpl(size_t amount, size_t & count_value, double & tokens_value)
+{
+    std::lock_guard lock(mutex);
+    auto now = clock_gettime_ns_adjusted(prev_ns);
+    if (max_speed)
+    {
+        double delta_seconds = prev_ns ? static_cast<double>(now - prev_ns) / NS : 0;
+        tokens = std::min<double>(tokens + max_speed * delta_seconds - amount, max_burst);
+    }
+    count += amount;
+    count_value = count;
+    tokens_value = tokens;
+    prev_ns = now;
+}
+
 void Throttler::reset()
 {
     std::lock_guard lock(mutex);
@@ -96,6 +99,16 @@ bool Throttler::isThrottling() const
         return parent->isThrottling();
 
     return false;
+}
+
+Int64 Throttler::getAvailable()
+{
+    // To update bucket state and receive current number of token in a thread-safe way
+    size_t count_value;
+    double tokens_value;
+    addImpl(0, count_value, tokens_value);
+
+    return static_cast<Int64>(tokens_value);
 }
 
 }

--- a/src/Common/Throttler.cpp
+++ b/src/Common/Throttler.cpp
@@ -104,8 +104,8 @@ bool Throttler::isThrottling() const
 Int64 Throttler::getAvailable()
 {
     // To update bucket state and receive current number of token in a thread-safe way
-    size_t count_value;
-    double tokens_value;
+    size_t count_value = 0;
+    double tokens_value = 0.0;
     addImpl(0, count_value, tokens_value);
 
     return static_cast<Int64>(tokens_value);

--- a/src/Common/Throttler.cpp
+++ b/src/Common/Throttler.cpp
@@ -41,8 +41,8 @@ Throttler::Throttler(size_t max_speed_, size_t limit_, const char * limit_exceed
 UInt64 Throttler::add(size_t amount)
 {
     // Values obtained under lock to be checked after release
-    size_t count_value;
-    double tokens_value;
+    size_t count_value = 0;
+    double tokens_value = 0.0;
     addImpl(amount, count_value, tokens_value);
 
     if (limit && count_value > limit)

--- a/src/Common/Throttler.h
+++ b/src/Common/Throttler.h
@@ -57,7 +57,13 @@ public:
     /// Is throttler already accumulated some sleep time and throttling.
     bool isThrottling() const;
 
+    Int64 getAvailable();
+    UInt64 getMaxSpeed() const { return static_cast<UInt64>(max_speed); }
+    UInt64 getMaxBurst() const { return static_cast<UInt64>(max_burst); }
+
 private:
+    void addImpl(size_t amount, size_t & count_value, double & tokens_value);
+
     size_t count{0};
     const size_t max_speed{0}; /// in tokens per second.
     const size_t max_burst{0}; /// in tokens.

--- a/src/IO/S3/Client.h
+++ b/src/IO/S3/Client.h
@@ -219,6 +219,9 @@ public:
         return client_configuration.for_disk_s3;
     }
 
+    ThrottlerPtr getPutRequestThrottler() const { return client_configuration.put_request_throttler; }
+    ThrottlerPtr getGetRequestThrottler() const { return client_configuration.get_request_throttler; }
+
 private:
     friend struct ::MockS3::Client;
 

--- a/src/Interpreters/ServerAsynchronousMetrics.cpp
+++ b/src/Interpreters/ServerAsynchronousMetrics.cpp
@@ -252,7 +252,7 @@ void ServerAsynchronousMetrics::updateImpl(TimePoint update_time, TimePoint curr
                     }
                 }
             }
-            catch(...)
+            catch (...)
             {
                 // Skip disk than do not have s3 throttlers
             }

--- a/src/Interpreters/ServerAsynchronousMetrics.cpp
+++ b/src/Interpreters/ServerAsynchronousMetrics.cpp
@@ -253,7 +253,7 @@ void ServerAsynchronousMetrics::updateImpl(TimePoint update_time, TimePoint curr
                     }
                 }
             }
-            catch (...)
+            catch (...) // NOLINT(bugprone-empty-catch)
             {
                 // Skip disk that do not have s3 throttlers
             }

--- a/src/Interpreters/ServerAsynchronousMetrics.cpp
+++ b/src/Interpreters/ServerAsynchronousMetrics.cpp
@@ -232,6 +232,7 @@ void ServerAsynchronousMetrics::updateImpl(TimePoint update_time, TimePoint curr
                         "Available bytes on the disk (virtual filesystem) without the reservations for merges, fetches, and moves. Remote filesystems may not provide this information." };
             }
 
+#if USE_AWS_S3
             try
             {
                 if (auto s3_client = disk->getS3StorageClient())
@@ -256,6 +257,7 @@ void ServerAsynchronousMetrics::updateImpl(TimePoint update_time, TimePoint curr
             {
                 // Skip disk than do not have s3 throttlers
             }
+#endif
         }
     }
 

--- a/src/Interpreters/ServerAsynchronousMetrics.cpp
+++ b/src/Interpreters/ServerAsynchronousMetrics.cpp
@@ -210,27 +210,27 @@ void ServerAsynchronousMetrics::updateImpl(TimePoint update_time, TimePoint curr
             auto total = disk->getTotalSpace();
 
             /// Some disks don't support information about the space.
-            if (!total)
-                continue;
-
-            auto available = disk->getAvailableSpace();
-            auto unreserved = disk->getUnreservedSpace();
-
-            new_values[fmt::format("DiskTotal_{}", name)] = { *total,
-                "The total size in bytes of the disk (virtual filesystem). Remote filesystems may not provide this information." };
-
-            if (available)
+            if (total)
             {
-                new_values[fmt::format("DiskUsed_{}", name)] = { *total - *available,
-                    "Used bytes on the disk (virtual filesystem). Remote filesystems not always provide this information." };
+                auto available = disk->getAvailableSpace();
+                auto unreserved = disk->getUnreservedSpace();
 
-                new_values[fmt::format("DiskAvailable_{}", name)] = { *available,
-                    "Available bytes on the disk (virtual filesystem). Remote filesystems may not provide this information." };
+                new_values[fmt::format("DiskTotal_{}", name)] = { *total,
+                    "The total size in bytes of the disk (virtual filesystem). Remote filesystems may not provide this information." };
+
+                if (available)
+                {
+                    new_values[fmt::format("DiskUsed_{}", name)] = { *total - *available,
+                        "Used bytes on the disk (virtual filesystem). Remote filesystems not always provide this information." };
+
+                    new_values[fmt::format("DiskAvailable_{}", name)] = { *available,
+                        "Available bytes on the disk (virtual filesystem). Remote filesystems may not provide this information." };
+                }
+
+                if (unreserved)
+                    new_values[fmt::format("DiskUnreserved_{}", name)] = { *unreserved,
+                        "Available bytes on the disk (virtual filesystem) without the reservations for merges, fetches, and moves. Remote filesystems may not provide this information." };
             }
-
-            if (unreserved)
-                new_values[fmt::format("DiskUnreserved_{}", name)] = { *unreserved,
-                    "Available bytes on the disk (virtual filesystem) without the reservations for merges, fetches, and moves. Remote filesystems may not provide this information." };
 
             try
             {

--- a/src/Interpreters/ServerAsynchronousMetrics.cpp
+++ b/src/Interpreters/ServerAsynchronousMetrics.cpp
@@ -254,7 +254,7 @@ void ServerAsynchronousMetrics::updateImpl(TimePoint update_time, TimePoint curr
             }
             catch (...)
             {
-                // Skip disk than do not have s3 throttlers
+                // Skip disk that do not have s3 throttlers
             }
         }
     }


### PR DESCRIPTION

### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Added server Asynchronous metrics `DiskGetObjectThrottler*` and `DiskGetObjectThrottler*` reflecting request per second rate limit defined with `s3_max_get_rps` and `s3_max_put_rps` disk settings and currently available number of requests that could be sent without hitting throttling limit on the disk. Metrics are defined for every disk that has a configured limit. 

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_normal_builds--> Allow: Normal Builds
- [ ] <!---ci_set_special_builds--> Allow: Special Builds
- [ ] <!---ci_set_non_required--> Allow: All NOT Required Checks
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
