### PR TITLE
Fix broken multi-column aggregation on s390x

### DIFF
--- a/src/Interpreters/AggregationCommon.h
+++ b/src/Interpreters/AggregationCommon.h
@@ -90,10 +90,7 @@ void fillFixedBatch(size_t keys_size, const ColumnRawPtrs & key_columns, const S
             /// Note: here we violate strict aliasing.
             /// It should be ok as log as we do not reffer to any value from `out` before filling.
             const char * source = static_cast<const ColumnFixedSizeHelper *>(column)->getRawDataBegin<sizeof(T)>();
-            size_t offset_to = offset;
-            if constexpr (std::endian::native == std::endian::big)
-                offset_to = sizeof(Key) - sizeof(T) - offset;
-            T * dest = reinterpret_cast<T *>(reinterpret_cast<char *>(out.data()) + offset_to);
+            T * dest = reinterpret_cast<T *>(reinterpret_cast<char *>(out.data()) + offset);
             fillFixedBatch<T, sizeof(Key) / sizeof(T)>(num_rows, reinterpret_cast<const T *>(source), dest); /// NOLINT(bugprone-sizeof-expression)
             offset += sizeof(T);
         }

--- a/src/Interpreters/AggregationMethod.cpp
+++ b/src/Interpreters/AggregationMethod.cpp
@@ -160,10 +160,7 @@ void AggregationMethodKeysFixed<TData, has_nullable_keys, has_low_cardinality,co
         else
         {
             size_t size = key_sizes[i];
-            size_t offset_to = pos;
-            if constexpr (std::endian::native == std::endian::big)
-                offset_to = sizeof(Key) - size - pos;
-            observed_column->insertData(reinterpret_cast<const char *>(&key) + offset_to, size);
+            observed_column->insertData(reinterpret_cast<const char *>(&key) + pos, size);
             pos += size;
         }
     }


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
The optimization implemented in [PR 55809](https://github.com/ClickHouse/ClickHouse/pull/55809) breaks aggregation of multiple columns on s390x due to the change of order of columns in intermediate results.

For example: 

`SELECT n, k FROM(SELECT number AS n, toFixedString(materialize('   '), 3) AS k FROM system.numbers LIMIT 1) GROUP BY n,k;`

The correct result should be:

```
   ┌─n─┬─k───┐
1. │ 0 │     │
   └───┴─────┘

```
But it gives wrong results:

```
   ┌───────────────────n─┬─k─┐
1. │ 2314885392840523776 │   │
   └─────────────────────┴───┘

```
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed broken multiple columns aggregation on s390x.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_normal_builds--> Allow: Normal Builds
- [ ] <!---ci_set_special_builds--> Allow: Special Builds
- [ ] <!---ci_set_non_required--> Allow: All NOT Required Checks
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
