### PR TITLE
Improve exception handling in case of receive timeout while reading (parts of) the request body

### DIFF
--- a/src/Server/HTTPHandler.cpp
+++ b/src/Server/HTTPHandler.cpp
@@ -1046,12 +1046,21 @@ void HTTPHandler::formatExceptionForClient(int exception_code, HTTPServerRequest
 
     /// FIXME: make sure that no one else is reading from the same stream at the moment.
 
-    /// If HTTP method is POST and Keep-Alive is turned on, we should read the whole request body
+    /// If HTTP method is POST and Keep-Alive is turned on, we should try to read the whole request body
     /// to avoid reading part of the current request body in the next request.
     if (request.getMethod() == Poco::Net::HTTPRequest::HTTP_POST && response.getKeepAlive()
-        && exception_code != ErrorCodes::HTTP_LENGTH_REQUIRED && !request.getStream().eof())
+        && exception_code != ErrorCodes::HTTP_LENGTH_REQUIRED)
     {
-        request.getStream().ignoreAll();
+        try
+        {
+            if (!request.getStream().eof())
+                request.getStream().ignoreAll();
+        }
+        catch (...)
+        {
+            tryLogCurrentException(log, "Cannot read remaining request body during exception handling");
+            response.setKeepAlive(false);
+        }
     }
 
     if (exception_code == ErrorCodes::REQUIRED_PASSWORD)

--- a/tests/queries/0_stateless/02403_big_http_chunk_size.python
+++ b/tests/queries/0_stateless/02403_big_http_chunk_size.python
@@ -16,7 +16,7 @@ def main():
     sock.settimeout(60)
     s = "POST / HTTP/1.1\r\n"
     s += "Host: %s\r\n" % host
-    s += "Content-type: multipart/form-data\r\n"
+    s += "Content-type: multipart/form-data; boundary=--b3f1zid8kqwy\r\n"
     s += "Transfer-encoding: chunked\r\n"
     s += "\r\n"
     s += "ffffffffffffffff"

--- a/tests/queries/0_stateless/02403_big_http_chunk_size.reference
+++ b/tests/queries/0_stateless/02403_big_http_chunk_size.reference
@@ -1,3 +1,3 @@
-HTTP/1.1 200 OK
+HTTP/1.1 500 Internal Server Error
 encoding type chunked
-error code 1000
+error code 69


### PR DESCRIPTION
Closes #65117

Before:
```
$ curl -v -H 'Content-Length: 1010' -X POST localhost:8123/?user=default -d "INSERT INTO test VALUES\r\n"
< HTTP/1.1 200 OK
< Date: Tue, 11 Jun 2024 16:42:15 GMT
< Connection: Keep-Alive
< Content-Type: text/plain; charset=UTF-8
< Transfer-Encoding: chunked
< X-ClickHouse-Exception-Code: 209
< Keep-Alive: timeout=30
< X-ClickHouse-Summary: {"read_rows":"0","read_bytes":"0","written_rows":"0","written_bytes":"0","total_rows_to_read":"0","result_rows":"0","result_bytes":"0","elapsed_ns":"60101112983"}
< 
* Connection #0 to host localhost left intact
```

After:
```
$ curl -v -H 'Content-Length: 1010' -X POST localhost:8123/?user=default -d "INSERT INTO test VALUES\r\n"

< HTTP/1.1 503 Service Unavailable
< Date: Tue, 11 Jun 2024 16:44:20 GMT
< Connection: Close
< Content-Type: text/plain; charset=UTF-8
< Transfer-Encoding: chunked
< X-ClickHouse-Exception-Code: 209
< X-ClickHouse-Summary: {"read_rows":"0","read_bytes":"0","written_rows":"0","written_bytes":"0","total_rows_to_read":"0","result_rows":"0","result_bytes":"0","elapsed_ns":"60070837558"}
< 
Code: 209. DB::NetException: Timeout exceeded while reading from socket (peer: [::1]:58858, local: [::1]:8123, 30000 ms). (SOCKET_TIMEOUT) (version 24.6.1.1)
* Closing connection
```

Note: We send a request with less data in the request body than advertised via the `Content-Length` header to force a receive timeout, in real cases this usually happens in case of network problems.

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Respond with 5xx instead of 200 OK in case of receive timeout while reading (parts of) the request body from the client socket

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_normal_builds--> Allow: Normal Builds
- [ ] <!---ci_set_special_builds--> Allow: Special Builds
- [ ] <!---ci_set_non_required--> Allow: All NOT Required Checks
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
