### PR TITLE
Ensure submodules are named consistently

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -161,7 +161,7 @@
 [submodule "contrib/xz"]
 	path = contrib/xz
 	url = https://github.com/xz-mirror/xz
-[submodule "abseil"]
+[submodule "contrib/abseil"]
 	path = contrib/abseil-cpp
 	url = https://github.com/ClickHouse/abseil-cpp.git
 [submodule "contrib/dragonbox"]

--- a/.gitmodules
+++ b/.gitmodules
@@ -161,7 +161,7 @@
 [submodule "contrib/xz"]
 	path = contrib/xz
 	url = https://github.com/xz-mirror/xz
-[submodule "contrib/abseil"]
+[submodule "contrib/abseil-cpp"]
 	path = contrib/abseil-cpp
 	url = https://github.com/ClickHouse/abseil-cpp.git
 [submodule "contrib/dragonbox"]

--- a/.gitmodules
+++ b/.gitmodules
@@ -91,13 +91,13 @@
 [submodule "contrib/aws"]
 	path = contrib/aws
 	url = https://github.com/ClickHouse/aws-sdk-cpp
-[submodule "aws-c-event-stream"]
+[submodule "contrib/aws-c-event-stream"]
 	path = contrib/aws-c-event-stream
 	url = https://github.com/awslabs/aws-c-event-stream
-[submodule "aws-c-common"]
+[submodule "contrib/aws-c-common"]
 	path = contrib/aws-c-common
 	url = https://github.com/awslabs/aws-c-common.git
-[submodule "aws-checksums"]
+[submodule "contrib/aws-checksums"]
 	path = contrib/aws-checksums
 	url = https://github.com/awslabs/aws-checksums
 [submodule "contrib/curl"]

--- a/utils/check-style/check-style
+++ b/utils/check-style/check-style
@@ -245,7 +245,12 @@ find $ROOT_PATH -name '.gitmodules' | while read i; do grep -F 'url = ' $i | gre
 
 # All submodules should be of this form: [submodule "contrib/libxyz"] (for consistency, the submodule name does matter too much)
 # - restrict the check to top-level .gitmodules file
-find $ROOT_PATH -maxdepth 1 -name '.gitmodules' | while read i; do grep -F '[submodule ' $i | grep -v -F 'contrib' && echo 'All submodules should have form [submodule "contrib/libxyz"]'; done
+git config --file "$ROOT_PATH/.gitmodules" --get-regexp 'submodule\..+\.path' | \
+while read -r line; do
+    name=${line#submodule.}; name=${name%.path*}
+    path=${line#* }
+    [ "$name" != "$path" ] && echo "Submodule name '$name' is not equal to it's path '$path'"
+done
 
 # There shouldn't be any code snippets under GPL or LGPL
 find $ROOT_PATH/{src,base,programs} -name '*.h' -or -name '*.cpp' 2>/dev/null | xargs grep -i -F 'General Public License' && echo "There shouldn't be any code snippets under GPL or LGPL"

--- a/utils/check-style/check-style
+++ b/utils/check-style/check-style
@@ -240,13 +240,12 @@ for test_case in "${tests_with_replicated_merge_tree[@]}"; do
     esac
 done
 
-# All the submodules should be from https://github.com/
-
+# All submodules should be from https://github.com/
 git config --file "$ROOT_PATH/.gitmodules" --get-regexp 'submodule\..+\.url' | \
 while read -r line; do 
     name=${line#submodule.}; name=${name%.url*}
     url=${line#* }
-    [[ "$url" != 'https://github.com/'* ]] && echo "All the submodules should be from https://github.com/, submodule '$name' has '$url'"
+    [[ "$url" != 'https://github.com/'* ]] && echo "All submodules should be from https://github.com/, submodule '$name' has '$url'"
 done
 
 # All submodules should be of this form: [submodule "contrib/libxyz"] (for consistency, the submodule name does matter too much)

--- a/utils/check-style/check-style
+++ b/utils/check-style/check-style
@@ -243,6 +243,10 @@ done
 # All the submodules should be from https://github.com/
 find $ROOT_PATH -name '.gitmodules' | while read i; do grep -F 'url = ' $i | grep -v -F 'https://github.com/' && echo 'All the submodules should be from https://github.com/'; done
 
+# All submodules should be of this form: [submodule "contrib/libxyz"] (for consistency, the submodule name does matter too much)
+# - restrict the check to top-level .gitmodules file
+find $ROOT_PATH -maxdepth 1 -name '.gitmodules' | while read i; do grep -F '[submodule ' $i | grep -v -F 'contrib' && echo 'All submodules should have form [submodule "contrib/libxyz"]'; done
+
 # There shouldn't be any code snippets under GPL or LGPL
 find $ROOT_PATH/{src,base,programs} -name '*.h' -or -name '*.cpp' 2>/dev/null | xargs grep -i -F 'General Public License' && echo "There shouldn't be any code snippets under GPL or LGPL"
 

--- a/utils/check-style/check-style
+++ b/utils/check-style/check-style
@@ -241,7 +241,13 @@ for test_case in "${tests_with_replicated_merge_tree[@]}"; do
 done
 
 # All the submodules should be from https://github.com/
-find $ROOT_PATH -name '.gitmodules' | while read i; do grep -F 'url = ' $i | grep -v -F 'https://github.com/' && echo 'All the submodules should be from https://github.com/'; done
+
+git config --file "$ROOT_PATH/.gitmodules" --get-regexp 'submodule\..+\.url' | \
+while read -r line; do 
+    name=${line#submodule.}; name=${name%.url*}
+    url=${line#* }
+    [[ "$url" != 'https://github.com/'* ]] && echo "All the submodules should be from https://github.com/, submodule '$name' has '$url'"
+done
 
 # All submodules should be of this form: [submodule "contrib/libxyz"] (for consistency, the submodule name does matter too much)
 # - restrict the check to top-level .gitmodules file


### PR DESCRIPTION
Follow-up to https://github.com/ClickHouse/ClickHouse/pull/65048/ where the abseil submodule name had no "contrib/" prefix.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### CI config
- [x] <!---jobs_package_asan--> Run only ASAN package
- [x] <!---jobs_style_check--> and Style check