### PR TITLE
Allow user to set content-type header when using JSON output format families

### DIFF
--- a/docs/en/operations/settings/settings-formats.md
+++ b/docs/en/operations/settings/settings-formats.md
@@ -710,6 +710,27 @@ Controls validation of UTF-8 sequences in JSON output formats, doesn't impact fo
 
 Disabled by default.
 
+## output_format_json_content_type_header {#output_format_json_content_type_header}
+
+Allow user to set Content-Type header when using JSON output format e.g. `JSONEachRow` [JSONEachRow](../../interfaces/formats.md/#jsoneachrow) format in URL function.
+This setting is useful when using materialized view with URL table engine to push data to external service
+
+Default value: ``. 
+
+**Example of a query with the enabled setting**
+
+Query:
+
+```sql
+CREATE MATERIALIZED VIEW default.test
+ENGINE = URL('http://external/service', 'JSONEachRow')
+SETTINGS output_format_json_named_tuples_as_objects = 1,
+    output_format_json_array_of_rows = 0,
+    output_format_json_content_type_header = 'application/json; charset=UTF-8' 
+AS
+    SELECT number FROM numbers(10)
+```
+
 ## format_json_object_each_row_column_for_object_name {#format_json_object_each_row_column_for_object_name}
 
 The name of column that will be used for storing/writing object names in [JSONObjectEachRow](../../interfaces/formats.md/#jsonobjecteachrow) format.

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -1188,6 +1188,7 @@ class IColumn;
     M(Bool, output_format_json_skip_null_value_in_named_tuples, false, "Skip key value pairs with null value when serialize named tuple columns as JSON objects. It is only valid when output_format_json_named_tuples_as_objects is true.", 0) \
     M(Bool, output_format_json_array_of_rows, false, "Output a JSON array of all rows in JSONEachRow(Compact) format.", 0) \
     M(Bool, output_format_json_validate_utf8, false, "Validate UTF-8 sequences in JSON output formats, doesn't impact formats JSON/JSONCompact/JSONColumnsWithMetadata, they always validate utf8", 0) \
+    M(String, output_format_json_content_type_header, "", "Set Content-Type header of JSON output format HTTP request.", 0) \
     \
     M(String, format_json_object_each_row_column_for_object_name, "", "The name of column that will be used as object names in JSONObjectEachRow format. Column type should be String", 0) \
     \

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -94,8 +94,8 @@ static std::initializer_list<std::pair<ClickHouseVersion, SettingsChangesHistory
             {"type_json_skip_duplicated_paths", false, false, "Allow to skip duplicated paths during JSON parsing"},
             {"join_output_by_rowlist_perkey_rows_threshold", 0, 5, "The lower limit of per-key average rows in the right table to determine whether to output by row list in hash join."},
             {"allow_experimental_vector_similarity_index", false, false, "Added new setting to allow experimental vector similarity indexes"},
-            {"input_format_try_infer_datetimes_only_datetime64", true, false, "Allow to infer DateTime instead of DateTime64 in data formats"}
-            {"output_format_json_content_type_header", "", "", "Allow user to set Content-Type header when using JSON output format."},
+            {"input_format_try_infer_datetimes_only_datetime64", true, false, "Allow to infer DateTime instead of DateTime64 in data formats"},
+            {"output_format_json_content_type_header", "", "", "Allow user to set Content-Type header when using JSON output format."}
         }
     },
     {"24.7",

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -95,6 +95,7 @@ static std::initializer_list<std::pair<ClickHouseVersion, SettingsChangesHistory
             {"join_output_by_rowlist_perkey_rows_threshold", 0, 5, "The lower limit of per-key average rows in the right table to determine whether to output by row list in hash join."},
             {"allow_experimental_vector_similarity_index", false, false, "Added new setting to allow experimental vector similarity indexes"},
             {"input_format_try_infer_datetimes_only_datetime64", true, false, "Allow to infer DateTime instead of DateTime64 in data formats"}
+            {"output_format_json_content_type_header", "", "", "Allow user to set Content-Type header when using JSON output format."},
         }
     },
     {"24.7",

--- a/src/Formats/FormatFactory.cpp
+++ b/src/Formats/FormatFactory.cpp
@@ -125,6 +125,7 @@ FormatSettings getFormatSettings(const ContextPtr & context, const Settings & se
     format_settings.input_allow_errors_ratio = settings.input_format_allow_errors_ratio;
     format_settings.json.max_depth = settings.input_format_json_max_depth;
     format_settings.json.array_of_rows = settings.output_format_json_array_of_rows;
+    format_settings.json.content_type = settings.output_format_json_content_type_header;
     format_settings.json.escape_forward_slashes = settings.output_format_json_escape_forward_slashes;
     format_settings.json.write_named_tuples_as_objects = settings.output_format_json_named_tuples_as_objects;
     format_settings.json.skip_null_value_in_named_tuples = settings.output_format_json_skip_null_value_in_named_tuples;

--- a/src/Formats/FormatSettings.h
+++ b/src/Formats/FormatSettings.h
@@ -237,6 +237,7 @@ struct FormatSettings
         bool throw_on_bad_escape_sequence = true;
         bool ignore_unnecessary_fields = true;
         bool type_json_skip_duplicated_paths = false;
+        String content_type{};
     } json{};
 
     struct

--- a/src/Functions/visitParamExtractString.cpp
+++ b/src/Functions/visitParamExtractString.cpp
@@ -16,7 +16,7 @@ struct ExtractString
             res_data.resize(old_size);
     }
 
-    static const FormatSettings::JSON constexpr default_json_settings;
+    static const FormatSettings::JSON inline default_json_settings;
 };
 
 struct NameSimpleJSONExtractString { static constexpr auto name = "simpleJSONExtractString"; };

--- a/src/Processors/Formats/Impl/JSONColumnsBlockOutputFormatBase.h
+++ b/src/Processors/Formats/Impl/JSONColumnsBlockOutputFormatBase.h
@@ -20,6 +20,13 @@ public:
 
     String getName() const override { return "JSONColumnsBlockOutputFormatBase"; }
 
+    String getContentType() const override
+    {
+        if (!format_settings.json.content_type.empty())
+            return format_settings.json.content_type;
+        return "application/json; charset=UTF-8";
+    }
+
 protected:
     void consume(Chunk chunk) override;
     void writeSuffix() override;

--- a/src/Processors/Formats/Impl/JSONCompactEachRowRowOutputFormat.h
+++ b/src/Processors/Formats/Impl/JSONCompactEachRowRowOutputFormat.h
@@ -25,6 +25,13 @@ public:
 
     String getName() const override { return "JSONCompactEachRowRowOutputFormat"; }
 
+    String getContentType() const override
+    {
+        if (!settings.json.content_type.empty())
+            return settings.json.content_type;
+        return RowOutputFormatWithExceptionHandlerAdaptor<RowOutputFormatWithUTF8ValidationAdaptor, bool>::getContentType();
+    }
+
 private:
     void writePrefix() override;
 

--- a/src/Processors/Formats/Impl/JSONEachRowRowOutputFormat.h
+++ b/src/Processors/Formats/Impl/JSONEachRowRowOutputFormat.h
@@ -27,6 +27,8 @@ public:
     /// Content-Type to set when sending HTTP response.
     String getContentType() const override
     {
+        if (!settings.json.content_type.empty())
+            return settings.json.content_type;
         return settings.json.array_of_rows ? "application/json; charset=UTF-8" : "application/x-ndjson; charset=UTF-8" ;
     }
 

--- a/src/Processors/Formats/Impl/JSONRowOutputFormat.h
+++ b/src/Processors/Formats/Impl/JSONRowOutputFormat.h
@@ -28,7 +28,12 @@ public:
 
     void onProgress(const Progress & value) override;
 
-    String getContentType() const override { return "application/json; charset=UTF-8"; }
+    String getContentType() const override
+    {
+        if (!settings.json.content_type.empty())
+            return settings.json.content_type;
+        return "application/json; charset=UTF-8";
+    }
 
     void setRowsBeforeLimit(size_t rows_before_limit_) override
     {

--- a/tests/queries/0_stateless/02935_http_content_type_setter_for_json.reference
+++ b/tests/queries/0_stateless/02935_http_content_type_setter_for_json.reference
@@ -1,0 +1,12 @@
+JSONStrings
+ Content-Type: custom-type
+JSON
+ Content-Type: custom-type
+JSONEachRow
+ Content-Type: custom-type
+JSONColumns
+ Content-Type: custom-type
+JSONCompact
+ Content-Type: custom-type
+JSONObjectEachRow
+ Content-Type: custom-type

--- a/tests/queries/0_stateless/02935_http_content_type_setter_for_json.sh
+++ b/tests/queries/0_stateless/02935_http_content_type_setter_for_json.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+# for frmt in JSONStrings JSON JSONEachRow JSONColumns JSONColumnsWithMetadata JSONCompact JSONCompactStrings JSONCompactColumns PrettyJSONEachRow JSONEachRowWithProgress JSONStringsEachRow JSONStringsEachRowWithProgress JSONCompactEachRow JSONCompactEachRowWithNames JSONCompactEachRowWithNamesAndTypes JSONCompactStringsEachRow JSONCompactStringsEachRowWithNames JSONCompactStringsEachRowWithNamesAndTypes JSONObjectEachRow
+for frmt in JSONStrings JSON JSONEachRow JSONColumns JSONCompact JSONObjectEachRow
+do
+  echo $frmt
+  url="${CLICKHOUSE_URL}/&output_format_json_content_type_header=custom-type&query=select+1+FORMAT+${frmt}"
+  (seq 1 200| xargs -n1 -P0 -Ixxx curl -Ss -v -o /dev/null ${url} 2>&1|grep -Eo " Content-Type:.*$")|strings|sort -u
+done


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- New Feature

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Allow user to set content-type header when using JSON output format families

### Documentation entry for user-facing changes

- [X] Documentation is written (mandatory for new features)
