### PR TITLE
[Docs] make `Float` page prettier

### DIFF
--- a/docs/en/sql-reference/data-types/float.md
+++ b/docs/en/sql-reference/data-types/float.md
@@ -20,7 +20,7 @@ CREATE TABLE IF NOT EXISTS float_vs_decimal
 Engine=MergeTree
 ORDER BY tuple();
 
-# Generate 1 000 000 random number with 2 decimal places and store them as a float and as a decimal
+# Generate 1 000 000 random numbers with 2 decimal places and store them as a float and as a decimal
 INSERT INTO float_vs_decimal SELECT round(randCanonical(), 3) AS res, res FROM system.numbers LIMIT 1000000;
 ```
 ```

--- a/docs/en/sql-reference/data-types/float.md
+++ b/docs/en/sql-reference/data-types/float.md
@@ -7,33 +7,43 @@ sidebar_label: Float32, Float64
 # Float32, Float64
 
 :::note
-If you need accurate calculations, in particular if you work with financial or business data requiring a high precision you should consider using Decimal instead. Floats might lead to inaccurate results as illustrated below:
+If you need accurate calculations, in particular if you work with financial or business data requiring a high precision, you should consider using [Decimal](../data-types/decimal.md) instead. 
 
-```
+[Floating Point Numbers](https://en.wikipedia.org/wiki/IEEE_754) might lead to inaccurate results as illustrated below:
+
+```sql
 CREATE TABLE IF NOT EXISTS float_vs_decimal
 (
    my_float Float64,
    my_decimal Decimal64(3)
-)Engine=MergeTree ORDER BY tuple()
+)
+Engine=MergeTree
+ORDER BY tuple();
 
-INSERT INTO float_vs_decimal SELECT round(randCanonical(), 3) AS res, res FROM system.numbers LIMIT 1000000; # Generate 1 000 000 random number with 2 decimal places and store them as a float and as a decimal
-
+# Generate 1 000 000 random number with 2 decimal places and store them as a float and as a decimal
+INSERT INTO float_vs_decimal SELECT round(randCanonical(), 3) AS res, res FROM system.numbers LIMIT 1000000;
+```
+```
 SELECT sum(my_float), sum(my_decimal) FROM float_vs_decimal;
-> 500279.56300000014	500279.563
+
+┌──────sum(my_float)─┬─sum(my_decimal)─┐
+│ 499693.60500000004 │      499693.605 │
+└────────────────────┴─────────────────┘
 
 SELECT sumKahan(my_float), sumKahan(my_decimal) FROM float_vs_decimal;
-> 500279.563	500279.563
+
+┌─sumKahan(my_float)─┬─sumKahan(my_decimal)─┐
+│         499693.605 │           499693.605 │
+└────────────────────┴──────────────────────┘
 ```
 :::
 
-[Floating point numbers](https://en.wikipedia.org/wiki/IEEE_754).
-
-Types are equivalent to types of C:
+The equivalent types in ClickHouse and in C are given below:
 
 - `Float32` — `float`.
 - `Float64` — `double`.
 
-Aliases:
+Float types in ClickHouse have the following aliases:
 
 - `Float32` — `FLOAT`, `REAL`, `SINGLE`.
 - `Float64` — `DOUBLE`, `DOUBLE PRECISION`.


### PR DESCRIPTION
The example on [Float32, Float64](https://clickhouse.com/docs/en/sql-reference/data-types/float) page looks like one that no person could possibly love:

![image](https://github.com/ClickHouse/ClickHouse/assets/41984034/eb802373-a7e0-4cdd-b0e9-4154cf30d6e6)

Better:

![image](https://github.com/ClickHouse/ClickHouse/assets/41984034/0407640c-4a6e-4770-b39d-76179e4432a4)

### Changelog category (leave one):
- Documentation (changelog entry is not required)
