### PR TITLE
Fix 01246_buffer_flush flakiness (by tuning timeouts)

### DIFF
--- a/tests/queries/0_stateless/01246_buffer_flush.sql
+++ b/tests/queries/0_stateless/01246_buffer_flush.sql
@@ -9,14 +9,14 @@ create table data_01256 as system.numbers Engine=Memory();
 
 select 'min';
 create table buffer_01256 as system.numbers Engine=Buffer(currentDatabase(), data_01256, 1,
-    2, 100, /* time */
+    5, 100, /* time */
     4, 100, /* rows */
     1, 1e6  /* bytes */
 );
 insert into buffer_01256 select * from system.numbers limit 5;
 select count() from data_01256;
--- sleep 2 (min time) + 1 (round up) + bias (1) = 4
-select sleepEachRow(2) from numbers(2) FORMAT Null;
+-- It is enough to ensure that the buffer will be flushed earlier then 2*min_time (10 sec)
+select sleepEachRow(9) FORMAT Null SETTINGS function_sleep_max_microseconds_per_block=10e6;
 select count() from data_01256;
 drop table buffer_01256;
 


### PR DESCRIPTION
CI: https://s3.amazonaws.com/clickhouse-test-reports/0/efb31c1d3f79e04a94087e883bc19553c5604268/stateless_tests__tsan__[3_5].html (cc @alexey-milovidov )

```
2024.06.14 09:42:08.255603 [ 2128 ] {0017dceb-df44-45b1-a5e8-42a52adc1d15} <Debug> executeQuery: (from [::1]:33350) (comment: 01246_buffer_flush.sql) insert into buffer_01256 select * from system.numbers limit 5; (stage: Complete)
...
2024.06.14 09:42:08.282011 [ 2128 ] {b0a59862-2e66-4664-aa16-8707a6bc0fec} <Debug> executeQuery: (from [::1]:33350) (comment: 01246_buffer_flush.sql) -- sleep 2 (min time) + 1 (round up) + bias (1) = 4
2024.06.14 09:42:12.296662 [ 2128 ] {6e273925-4bee-4e65-bf91-222c14dd2b00} <Debug> executeQuery: (from [::1]:33350) (comment: 01246_buffer_flush.sql) select count() from data_01256; (stage: Complete)
...
2024.06.14 09:42:12.666403 [ 935 ] {} <Debug> StorageBuffer (test_74dkdipr.buffer_01256): Flushing buffer with 5 rows, 40 bytes, age 3 seconds, took 1391 ms (bg).
2024.06.14 09:42:12.666584 [ 935 ] {} <Trace> StorageBuffer (test_74dkdipr.buffer_01256)/Bg: Execution took 1391 ms.
```

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)