### PR TITLE
fix: `Content-Encoding` was not sent on progress

### DIFF
--- a/src/Server/HTTP/WriteBufferFromHTTPServerResponse.cpp
+++ b/src/Server/HTTP/WriteBufferFromHTTPServerResponse.cpp
@@ -83,7 +83,11 @@ void WriteBufferFromHTTPServerResponse::finishSendHeaders()
         return;
 
     if (!headers_started_sending)
+    {
+        if (compression_method != CompressionMethod::None)
+            response.set("Content-Encoding", toContentEncodingName(compression_method));
         startSendHeaders();
+    }
 
     writeHeaderSummary();
     writeExceptionCode();
@@ -105,7 +109,13 @@ void WriteBufferFromHTTPServerResponse::nextImpl()
         initialized = true;
 
         if (compression_method != CompressionMethod::None)
-            response.set("Content-Encoding", toContentEncodingName(compression_method));
+        {
+            /// If we've already sent headers, just send the `Content-Encoding` down the socket directly
+            if (headers_started_sending)
+                socketSendStr("Content-Encoding: " + toContentEncodingName(compression_method) + "\r\n");
+            else
+                response.set("Content-Encoding", toContentEncodingName(compression_method));
+        }
 
         startSendHeaders();
         finishSendHeaders();
@@ -178,8 +188,12 @@ void WriteBufferFromHTTPServerResponse::finalizeImpl()
         /// If no body data just send header
         startSendHeaders();
 
+        /// `finalizeImpl` must be idempotent, so set `initialized` here to not send stuff twice
         if (!initialized && offset() && compression_method != CompressionMethod::None)
+        {
+            initialized = true;
             socketSendStr("Content-Encoding: " + toContentEncodingName(compression_method) + "\r\n");
+        }
 
         finishSendHeaders();
     }

--- a/tests/queries/0_stateless/03172_http_content_encoding.reference
+++ b/tests/queries/0_stateless/03172_http_content_encoding.reference
@@ -1,0 +1,2 @@
+< Content-Encoding: zstd
+< Content-Encoding: zstd

--- a/tests/queries/0_stateless/03172_http_content_encoding.sh
+++ b/tests/queries/0_stateless/03172_http_content_encoding.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+URL="${CLICKHOUSE_PORT_HTTP_PROTO}://${CLICKHOUSE_HOST}:${CLICKHOUSE_PORT_HTTP}/"
+
+# with progress
+${CLICKHOUSE_CURL} -vsS "${URL}?send_progress_in_http_headers=1&enable_http_compression=1&wait_end_of_query=0" -o /dev/null \
+  -H 'Accept-Encoding: zstd' --compressed --data-binary @- <<< "select distinct sleep(.1),name from generateRandom('name String',1,1000,2) limit 100009 format TSV" 2>&1 \
+  | perl -lnE 'print if /Content-Encoding/';
+# no progress
+${CLICKHOUSE_CURL} -vsS "${URL}?send_progress_in_http_headers=0&enable_http_compression=1&wait_end_of_query=0" -o /dev/null \
+  -H 'Accept-Encoding: zstd' --compressed --data-binary @- <<< "select distinct sleep(.1),name from generateRandom('name String',1,1000,2) limit 100009 format TSV" 2>&1 \
+  | perl -lnE 'print if /Content-Encoding/';


### PR DESCRIPTION
fixes: #64802

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Fixed `Content-Encoding` not sent in some compressed responses.

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_normal_builds--> Allow: Normal Builds
- [ ] <!---ci_set_special_builds--> Allow: Special Builds
- [ ] <!---ci_set_non_required--> Allow: All NOT Required Checks
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
