### PR TITLE
add tests for 'boom filter index with map'

### DIFF
--- a/tests/queries/0_stateless/03167_boom_filter_index_with_map.reference.j2
+++ b/tests/queries/0_stateless/03167_boom_filter_index_with_map.reference.j2
@@ -1,0 +1,4 @@
+{% for type in ['Int8', 'Int16', 'Int32', 'Int64', 'UInt8', 'UInt16', 'UInt32', 'UInt64'] -%}
+{'xxx':56}
+{56:'xxx'}
+{% endfor -%}

--- a/tests/queries/0_stateless/03167_boom_filter_index_with_map.sql.j2
+++ b/tests/queries/0_stateless/03167_boom_filter_index_with_map.sql.j2
@@ -1,0 +1,31 @@
+DROP TABLE IF EXISTS boom_filter_map_1;
+DROP TABLE IF EXISTS boom_filter_map_2;
+
+{% for type in ['Int8', 'Int16', 'Int32', 'Int64', 'UInt8', 'UInt16', 'UInt32', 'UInt64'] -%}
+
+CREATE TABLE boom_filter_map_1
+(
+    `m` Map(String, {{ type }}),
+    INDEX index_models_value_bloom_filter mapValues(m) TYPE bloom_filter GRANULARITY 1
+)
+    ENGINE = MergeTree
+ORDER BY tuple();
+
+CREATE TABLE boom_filter_map_2
+(
+    `m` Map({{ type }}, String),
+    INDEX index_models_value_bloom_filter mapKeys(m) TYPE bloom_filter GRANULARITY 1
+)
+    ENGINE = MergeTree
+ORDER BY tuple();
+
+INSERT INTO boom_filter_map_1 (m) values (map('xxx', 56));
+INSERT INTO boom_filter_map_2 (m) values (map(56, 'xxx'));
+
+SELECT m FROM boom_filter_map_1 WHERE  (m['xxx']) = 56;
+SELECT m FROM boom_filter_map_2 WHERE  (m[56]) = 'xxx';
+
+DROP TABLE IF EXISTS boom_filter_map_1;
+DROP TABLE IF EXISTS boom_filter_map_2;
+
+{% endfor -%}


### PR DESCRIPTION
add tests for 'boom filter index with map'
For example:

create database db;

CREATE TABLE db.t1
(
m Map(LowCardinality(String), Int64),
INDEX index_models_value_bloom_filter mapValues(m) TYPE bloom_filter GRANULARITY 1
)
ENGINE = MergeTree
ORDER BY tuple()
SETTINGS index_granularity = 8192;

insert into db.t1 (m) values (map('xxx', 56));

SELECT m
FROM db.t1
WHERE (m['xxx']) = 56

The result could be:

┌─m──────────┐

│ {'xxx':56} │
└────────────┘
But it gives results:

Received exception from server (version 24.3.3):
Code: 170. DB::Exception: Received from localhost:29000. DB::Exception: Bad get: has UInt64, requested Int64. (BAD_GET)


Related issues:
https://github.com/ClickHouse/ClickHouse/pull/65197

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_normal_builds--> Allow: Normal Builds
- [ ] <!---ci_set_special_builds--> Allow: Special Builds
- [ ] <!---ci_set_non_required--> Allow: All NOT Required Checks
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
