### PR TITLE
Move tests 02942_variant_cast and 02944_variant_as_common_type to analyzer_tech_debt.txt

### DIFF
--- a/tests/analyzer_tech_debt.txt
+++ b/tests/analyzer_tech_debt.txt
@@ -9,3 +9,5 @@
 01287_max_execution_speed
 # Check after ConstantNode refactoring
 02154_parser_backtracking
+02944_variant_as_common_type
+02942_variant_cast

--- a/tests/queries/0_stateless/02942_variant_cast.sql
+++ b/tests/queries/0_stateless/02942_variant_cast.sql
@@ -1,5 +1,4 @@
 set allow_experimental_variant_type=1;
-set allow_experimental_analyzer=0; -- It's currently doesn't work with analyzer because of the way it works with constants, but it will be refactored and fixed in future
 
 select NULL::Variant(String, UInt64);
 select 42::UInt64::Variant(String, UInt64);

--- a/tests/queries/0_stateless/02944_variant_as_common_type.sql
+++ b/tests/queries/0_stateless/02944_variant_as_common_type.sql
@@ -1,5 +1,3 @@
-set allow_experimental_analyzer=0; -- The result type for if function with constant is different with analyzer. It wil be fixed after refactoring around constants in analyzer.
-
 set allow_experimental_variant_type=1;
 set use_variant_as_common_type=1;
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

See https://github.com/ClickHouse/ClickHouse/pull/63643#discussion_r1604802538
