### PR TITLE
[docs] pin the gimli-rs/addr2line version in allocation-profiling.md

### DIFF
--- a/docs/en/operations/allocation-profiling.md
+++ b/docs/en/operations/allocation-profiling.md
@@ -59,10 +59,10 @@ For that, we need to use `jemalloc`'s tool called [jeprof](https://github.com/je
 If that’s the case, we recommend installing an [alternative implementation](https://github.com/gimli-rs/addr2line) of the tool.
 
 ```
-git clone https://github.com/gimli-rs/addr2line
+git clone https://github.com/gimli-rs/addr2line.git --depth=1 --branch=0.23.0
 cd addr2line
-cargo b --examples -r
-cp ./target/release/examples/addr2line path/to/current/addr2line
+cargo build --features bin --release
+cp ./target/release/addr2line path/to/current/addr2line
 ```
 :::
 


### PR DESCRIPTION


after upstream changed the folder, the build command is broken: https://github.com/gimli-rs/addr2line/pull/291/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R70-R72

for a more stable way, I intend to pin the version

```
~/addr2line$ tree -L 3
.
├── benches
│   └── bench.rs
├── benchmark.sh
├── bench.plot.r
├── Cargo.lock
├── Cargo.toml
├── CHANGELOG.md
├── coverage.sh
├── fixtures
│   └── addr2line-release
├── LICENSE-APACHE
├── LICENSE-MIT
├── README.md
├── rustfmt.toml
├── src
│   ├── bin
│   │   └── addr2line.rs
│   ├── frame.rs
│   ├── function.rs
│   ├── lazy.rs
│   ├── lib.rs
│   ├── line.rs
│   ├── loader.rs
│   ├── lookup.rs
│   └── unit.rs
├── target
│   ├── CACHEDIR.TAG
│   └── release
│       ├── addr2line
│       ├── addr2line.d
│       ├── build
│       ├── deps
│       ├── examples
│       ├── incremental
│       ├── libaddr2line.d
│       └── libaddr2line.rlib
└── tests
    ├── auxiliary
    │   ├── Cargo.toml
    │   └── src
    ├── correctness.rs
    ├── output_equivalence.rs
    └── parse.rs

13 directories, 30 files

~/addr2line$ ls -lh target/release/addr2line

-rwxrwxr-x 2 user user 27M Jun 18 10:48 target/release/addr2line

~/addr2line$ target/release/addr2line --version
addr2line 0.23.0

~/addr2line$ file target/release/addr2line 
target/release/addr2line: ELF 64-bit LSB pie executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, BuildID[sha1]=921b50da62ae847b51fb6fed406dadbc98dc60a0, for GNU/Linux 3.2.0, with debug_info, not stripped
```



<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):

- Documentation (changelog entry is not required)



### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_normal_builds--> Allow: Normal Builds
- [ ] <!---ci_set_special_builds--> Allow: Special Builds
- [ ] <!---ci_set_non_required--> Allow: All NOT Required Checks
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
