### PR TITLE
Move a leaksan suppression from Poco into OpenSSL

### DIFF
--- a/base/poco/Crypto/src/OpenSSLInitializer.cpp
+++ b/base/poco/Crypto/src/OpenSSLInitializer.cpp
@@ -23,9 +23,6 @@
 #include <openssl/conf.h>
 #endif
 
-#if __has_feature(address_sanitizer)
-#include <sanitizer/lsan_interface.h>
-#endif
 
 using Poco::RandomInputStream;
 using Poco::Thread;
@@ -70,18 +67,12 @@ void OpenSSLInitializer::initialize()
 		SSL_library_init();
 		SSL_load_error_strings();
 		OpenSSL_add_all_algorithms();
-
+		
 		char seed[SEEDSIZE];
 		RandomInputStream rnd;
 		rnd.read(seed, sizeof(seed));
-        {
-#   if __has_feature(address_sanitizer)
-            /// Leak sanitizer (part of address sanitizer) thinks that a few bytes of memory in OpenSSL are allocated during but never released.
-            __lsan::ScopedDisabler lsan_disabler;
-#endif
-		    RAND_seed(seed, SEEDSIZE);
-        }
-
+		RAND_seed(seed, SEEDSIZE);
+		
 		int nMutexes = CRYPTO_num_locks();
 		_mutexes = new Poco::FastMutex[nMutexes];
 		CRYPTO_set_locking_callback(&OpenSSLInitializer::lock);
@@ -89,8 +80,8 @@ void OpenSSLInitializer::initialize()
 // https://sourceforge.net/p/poco/bugs/110/
 //
 // From http://www.openssl.org/docs/crypto/threads.html :
-// "If the application does not register such a callback using CRYPTO_THREADID_set_callback(),
-//  then a default implementation is used - on Windows and BeOS this uses the system's
+// "If the application does not register such a callback using CRYPTO_THREADID_set_callback(), 
+//  then a default implementation is used - on Windows and BeOS this uses the system's 
 //  default thread identifying APIs"
 		CRYPTO_set_id_callback(&OpenSSLInitializer::id);
 		CRYPTO_set_dynlock_create_callback(&OpenSSLInitializer::dynlockCreate);
@@ -109,7 +100,7 @@ void OpenSSLInitializer::uninitialize()
 		CRYPTO_set_locking_callback(0);
 		CRYPTO_set_id_callback(0);
 		delete [] _mutexes;
-
+		
 		CONF_modules_free();
 	}
 }

--- a/src/IO/S3/Client.cpp
+++ b/src/IO/S3/Client.cpp
@@ -30,10 +30,6 @@
 #include <base/sleep.h>
 
 
-#ifdef ADDRESS_SANITIZER
-#include <sanitizer/lsan_interface.h>
-#endif
-
 namespace ProfileEvents
 {
     extern const Event S3WriteRequestsErrors;
@@ -880,14 +876,7 @@ void ClientCacheRegistry::clearCacheForAll()
 ClientFactory::ClientFactory()
 {
     aws_options = Aws::SDKOptions{};
-    {
-#ifdef ADDRESS_SANITIZER
-        /// Leak sanitizer (part of address sanitizer) thinks that memory in OpenSSL (called by AWS SDK) is allocated but not
-        /// released. Actually, the memory is released at the end of the program (ClientFactory is a singleton, see the dtor).
-        __lsan::ScopedDisabler lsan_disabler;
-#endif
-        Aws::InitAPI(aws_options);
-    }
+    Aws::InitAPI(aws_options);
     Aws::Utils::Logging::InitializeAWSLogging(std::make_shared<AWSLogger>(false));
     Aws::Http::SetHttpClientFactory(std::make_shared<PocoHTTPClientFactory>());
 }


### PR DESCRIPTION
During the [boringssl --> OpenSSL transition](https://github.com/ClickHouse/ClickHouse/pull/59870), I suppressed a false positive leaksan finding in Poco ([commit](https://github.com/ClickHouse/ClickHouse/pull/59870/commits/2418d673f11d91eed2e2aa477e763769ef7cbd86)).

I noticed that it would have been more correct to apply the suppression directly in OpenSSL itself instead of in Poco. This PR fixes this.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)