### PR TITLE
Fix `AzureObjectStorage::exists` method

### DIFF
--- a/src/Disks/ObjectStorages/AzureBlobStorage/AzureBlobStorageAuth.cpp
+++ b/src/Disks/ObjectStorages/AzureBlobStorage/AzureBlobStorageAuth.cpp
@@ -181,7 +181,7 @@ std::unique_ptr<T> getAzureBlobStorageClientWithAuth(
     if (config.getBool(config_prefix + ".use_workload_identity", false))
     {
         auto workload_identity_credential = std::make_shared<Azure::Identity::WorkloadIdentityCredential>();
-        return std::make_unique<T>(url, workload_identity_credential);
+        return std::make_unique<T>(url, workload_identity_credential, client_options);
     }
 
     auto managed_identity_credential = std::make_shared<Azure::Identity::ManagedIdentityCredential>();

--- a/src/Disks/ObjectStorages/AzureBlobStorage/AzureObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/AzureBlobStorage/AzureObjectStorage.cpp
@@ -127,25 +127,22 @@ bool AzureObjectStorage::exists(const StoredObject & object) const
 {
     auto client_ptr = client.get();
 
-    /// What a shame, no Exists method...
-    Azure::Storage::Blobs::ListBlobsOptions options;
-    options.Prefix = object.remote_path;
-    options.PageSizeHint = 1;
-
-    ProfileEvents::increment(ProfileEvents::AzureListObjects);
+    ProfileEvents::increment(ProfileEvents::AzureGetProperties);
     if (client_ptr->GetClickhouseOptions().IsClientForDisk)
-        ProfileEvents::increment(ProfileEvents::DiskAzureListObjects);
+        ProfileEvents::increment(ProfileEvents::DiskAzureGetProperties);
 
-    auto blobs_list_response = client_ptr->ListBlobs(options);
-    auto blobs_list = blobs_list_response.Blobs;
-
-    for (const auto & blob : blobs_list)
+    try
     {
-        if (object.remote_path == blob.Name)
-            return true;
+        auto blob_client = client_ptr->GetBlobClient(object.remote_path);
+        blob_client.GetProperties();
+        return true;
     }
-
-    return false;
+    catch (const Azure::Storage::StorageException & e)
+    {
+        if (e.StatusCode == Azure::Core::Http::HttpStatusCode::NotFound)
+            return false;
+        throw;
+    }
 }
 
 ObjectStorageIteratorPtr AzureObjectStorage::iterate(const std::string & path_prefix, size_t max_keys) const
@@ -160,7 +157,9 @@ void AzureObjectStorage::listObjects(const std::string & path, RelativePathsWith
 {
     auto client_ptr = client.get();
 
-    /// What a shame, no Exists method...
+    /// NOTE: list doesn't work if endpoint contains non-empty prefix for blobs.
+    /// See AzureBlobStorageEndpoint and processAzureBlobStorageEndpoint for details.
+
     Azure::Storage::Blobs::ListBlobsOptions options;
     options.Prefix = path;
     if (max_keys)


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
