### PR TITLE
Revert "Detect lexer errors early"

### DIFF
--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -44,12 +44,13 @@
 #include <Parsers/ASTIdentifier.h>
 #include <Parsers/ASTColumnDeclaration.h>
 #include <Parsers/ASTFunction.h>
-#include <Parsers/PRQL/ParserPRQLQuery.h>
 #include <Parsers/Kusto/ParserKQLStatement.h>
+#include <Parsers/PRQL/ParserPRQLQuery.h>
 #include <Parsers/Kusto/parseKQLQuery.h>
 
 #include <Processors/Formats/Impl/NullFormat.h>
 #include <Processors/Formats/IInputFormat.h>
+#include <Processors/Formats/IOutputFormat.h>
 #include <Processors/QueryPlan/QueryPlan.h>
 #include <Processors/QueryPlan/BuildQueryPipelineSettings.h>
 #include <Processors/QueryPlan/Optimizations/QueryPlanOptimizationSettings.h>

--- a/src/Parsers/ExpressionListParsers.cpp
+++ b/src/Parsers/ExpressionListParsers.cpp
@@ -2179,7 +2179,7 @@ public:
 
     bool parse(IParser::Pos & pos, Expected & expected, Action & /*action*/) override
     {
-        /// kql('table|project ...')
+        /// kql(table|project ...)
         /// 0. Parse the kql query
         /// 1. Parse closing token
         if (state == 0)

--- a/src/Parsers/Kusto/KQL_ReleaseNote.md
+++ b/src/Parsers/Kusto/KQL_ReleaseNote.md
@@ -853,7 +853,7 @@ Please note that the functions listed below only take constant parameters for no
 ## KQL() function
 
  - create table  
-  `CREATE TABLE kql_table4 ENGINE = Memory AS select *, now() as new_column From kql($$Customers | project LastName,Age$$);`  
+  `CREATE TABLE kql_table4 ENGINE = Memory AS select *, now() as new_column From kql(Customers | project LastName,Age);`  
    verify the content of `kql_table`  
     `select * from kql_table`
    
@@ -867,12 +867,12 @@ Please note that the functions listed below only take constant parameters for no
         Age Nullable(UInt8)
     ) ENGINE = Memory;
     ```
-    `INSERT INTO temp select * from kql($$Customers|project FirstName,LastName,Age$$);`  
+    `INSERT INTO temp select * from kql(Customers|project FirstName,LastName,Age);`  
     verify the content of `temp`   
         `select * from temp`
 
- - Select from kql(...)  
-    `Select * from kql($$Customers|project FirstName$$)`
+ - Select from kql()  
+    `Select * from kql(Customers|project FirstName)`
 
 ## KQL operators:
  - Tabular expression statements  
@@ -993,3 +993,4 @@ Please note that the functions listed below only take constant parameters for no
  - dcount()
  - dcountif()
  - bin
+ 

--- a/src/Parsers/Kusto/KustoFunctions/IParserKQLFunction.cpp
+++ b/src/Parsers/Kusto/KustoFunctions/IParserKQLFunction.cpp
@@ -301,8 +301,8 @@ String IParserKQLFunction::kqlCallToExpression(
         });
 
     const auto kql_call = std::format("{}({})", function_name, params_str);
-    Tokens call_tokens(kql_call.data(), kql_call.data() + kql_call.length(), 0, true);
-    IParser::Pos tokens_pos(call_tokens, max_depth, max_backtracks);
+    DB::Tokens call_tokens(kql_call.c_str(), kql_call.c_str() + kql_call.length());
+    DB::IParser::Pos tokens_pos(call_tokens, max_depth, max_backtracks);
     return DB::IParserKQLFunction::getExpression(tokens_pos);
 }
 

--- a/src/Parsers/Kusto/ParserKQLDistinct.cpp
+++ b/src/Parsers/Kusto/ParserKQLDistinct.cpp
@@ -11,7 +11,7 @@ bool ParserKQLDistinct::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
 
     expr = getExprFromToken(pos);
 
-    Tokens tokens(expr.data(), expr.data() + expr.size(), 0, true);
+    Tokens tokens(expr.c_str(), expr.c_str() + expr.size());
     IParser::Pos new_pos(tokens, pos.max_depth, pos.max_backtracks);
 
     if (!ParserNotEmptyExpressionList(false).parse(new_pos, select_expression_list, expected))

--- a/src/Parsers/Kusto/ParserKQLExtend.cpp
+++ b/src/Parsers/Kusto/ParserKQLExtend.cpp
@@ -22,7 +22,7 @@ bool ParserKQLExtend ::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
 
     String except_str;
     String new_extend_str;
-    Tokens ntokens(extend_expr.data(), extend_expr.data() + extend_expr.size(), 0, true);
+    Tokens ntokens(extend_expr.c_str(), extend_expr.c_str() + extend_expr.size());
     IParser::Pos npos(ntokens, pos.max_depth, pos.max_backtracks);
 
     String alias;
@@ -76,7 +76,7 @@ bool ParserKQLExtend ::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
     apply_alias();
 
     String expr = std::format("SELECT * {}, {} from prev", except_str, new_extend_str);
-    Tokens tokens(expr.data(), expr.data() + expr.size(), 0, true);
+    Tokens tokens(expr.c_str(), expr.c_str() + expr.size());
     IParser::Pos new_pos(tokens, pos.max_depth, pos.max_backtracks);
 
     if (!ParserSelectQuery().parse(new_pos, select_query, expected))

--- a/src/Parsers/Kusto/ParserKQLFilter.cpp
+++ b/src/Parsers/Kusto/ParserKQLFilter.cpp
@@ -13,7 +13,7 @@ bool ParserKQLFilter::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
     String expr = getExprFromToken(pos);
     ASTPtr where_expression;
 
-    Tokens token_filter(expr.data(), expr.data() + expr.size(), 0, true);
+    Tokens token_filter(expr.c_str(), expr.c_str() + expr.size());
     IParser::Pos pos_filter(token_filter, pos.max_depth, pos.max_backtracks);
     if (!ParserExpressionWithOptionalAlias(false).parse(pos_filter, where_expression, expected))
         return false;

--- a/src/Parsers/Kusto/ParserKQLLimit.cpp
+++ b/src/Parsers/Kusto/ParserKQLLimit.cpp
@@ -13,7 +13,7 @@ bool ParserKQLLimit::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
 
     auto expr = getExprFromToken(pos);
 
-    Tokens tokens(expr.data(), expr.data() + expr.size(), 0, true);
+    Tokens tokens(expr.c_str(), expr.c_str() + expr.size());
     IParser::Pos new_pos(tokens, pos.max_depth, pos.max_backtracks);
 
     if (!ParserExpressionWithOptionalAlias(false).parse(new_pos, limit_length, expected))

--- a/src/Parsers/Kusto/ParserKQLMVExpand.cpp
+++ b/src/Parsers/Kusto/ParserKQLMVExpand.cpp
@@ -298,7 +298,7 @@ bool ParserKQLMVExpand::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
         return false;
 
     const String setting_str = "enable_unaligned_array_join = 1";
-    Tokens token_settings(setting_str.data(), setting_str.data() + setting_str.size(), 0, true);
+    Tokens token_settings(setting_str.c_str(), setting_str.c_str() + setting_str.size());
     IParser::Pos pos_settings(token_settings, pos.max_depth, pos.max_backtracks);
 
     if (!ParserSetQuery(true).parse(pos_settings, setting, expected))

--- a/src/Parsers/Kusto/ParserKQLMakeSeries.cpp
+++ b/src/Parsers/Kusto/ParserKQLMakeSeries.cpp
@@ -173,7 +173,7 @@ bool ParserKQLMakeSeries ::makeSeries(KQLMakeSeries & kql_make_series, ASTPtr & 
 
     auto date_type_cast = [&](String & src)
     {
-        Tokens tokens(src.data(), src.data() + src.size(), 0, true);
+        Tokens tokens(src.c_str(), src.c_str() + src.size());
         IParser::Pos pos(tokens, max_depth, max_backtracks);
         String res;
         while (isValidKQLPos(pos))
@@ -200,7 +200,7 @@ bool ParserKQLMakeSeries ::makeSeries(KQLMakeSeries & kql_make_series, ASTPtr & 
     auto get_group_expression_alias = [&]
     {
         std::vector<String> group_expression_tokens;
-        Tokens tokens(group_expression.data(), group_expression.data() + group_expression.size(), 0, true);
+        Tokens tokens(group_expression.c_str(), group_expression.c_str() + group_expression.size());
         IParser::Pos pos(tokens, max_depth, max_backtracks);
         while (isValidKQLPos(pos))
         {
@@ -413,7 +413,7 @@ bool ParserKQLMakeSeries ::parseImpl(Pos & pos, ASTPtr & node, Expected & expect
 
     makeSeries(kql_make_series, node, pos.max_depth, pos.max_backtracks);
 
-    Tokens token_main_query(kql_make_series.main_query.data(), kql_make_series.main_query.data() + kql_make_series.main_query.size(), 0, true);
+    Tokens token_main_query(kql_make_series.main_query.c_str(), kql_make_series.main_query.c_str() + kql_make_series.main_query.size());
     IParser::Pos pos_main_query(token_main_query, pos.max_depth, pos.max_backtracks);
 
     if (!ParserNotEmptyExpressionList(true).parse(pos_main_query, select_expression_list, expected))

--- a/src/Parsers/Kusto/ParserKQLPrint.cpp
+++ b/src/Parsers/Kusto/ParserKQLPrint.cpp
@@ -9,7 +9,7 @@ bool ParserKQLPrint::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
     ASTPtr select_expression_list;
     const String expr = getExprFromToken(pos);
 
-    Tokens tokens(expr.data(), expr.data() + expr.size(), 0, true);
+    Tokens tokens(expr.c_str(), expr.c_str() + expr.size());
     IParser::Pos new_pos(tokens, pos.max_depth, pos.max_backtracks);
 
     if (!ParserNotEmptyExpressionList(true).parse(new_pos, select_expression_list, expected))

--- a/src/Parsers/Kusto/ParserKQLProject.cpp
+++ b/src/Parsers/Kusto/ParserKQLProject.cpp
@@ -11,7 +11,7 @@ bool ParserKQLProject ::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
 
     expr = getExprFromToken(pos);
 
-    Tokens tokens(expr.data(), expr.data() + expr.size(), 0, true);
+    Tokens tokens(expr.c_str(), expr.c_str() + expr.size());
     IParser::Pos new_pos(tokens, pos.max_depth, pos.max_backtracks);
 
     if (!ParserNotEmptyExpressionList(false).parse(new_pos, select_expression_list, expected))

--- a/src/Parsers/Kusto/ParserKQLQuery.cpp
+++ b/src/Parsers/Kusto/ParserKQLQuery.cpp
@@ -37,7 +37,7 @@ bool ParserKQLBase::parseByString(String expr, ASTPtr & node, uint32_t max_depth
 {
     Expected expected;
 
-    Tokens tokens(expr.data(), expr.data() + expr.size(), 0, true);
+    Tokens tokens(expr.c_str(), expr.c_str() + expr.size());
     IParser::Pos pos(tokens, max_depth, max_backtracks);
     return parse(pos, node, expected);
 }
@@ -45,7 +45,7 @@ bool ParserKQLBase::parseByString(String expr, ASTPtr & node, uint32_t max_depth
 bool ParserKQLBase::parseSQLQueryByString(ParserPtr && parser, String & query, ASTPtr & select_node, uint32_t max_depth, uint32_t max_backtracks)
 {
     Expected expected;
-    Tokens token_subquery(query.data(), query.data() + query.size(), 0, true);
+    Tokens token_subquery(query.c_str(), query.c_str() + query.size());
     IParser::Pos pos_subquery(token_subquery, max_depth, max_backtracks);
     if (!parser->parse(pos_subquery, select_node, expected))
         return false;
@@ -123,7 +123,7 @@ bool ParserKQLBase::setSubQuerySource(ASTPtr & select_query, ASTPtr & source, bo
 
 String ParserKQLBase::getExprFromToken(const String & text, uint32_t max_depth, uint32_t max_backtracks)
 {
-    Tokens tokens(text.data(), text.data() + text.size(), 0, true);
+    Tokens tokens(text.c_str(), text.c_str() + text.size());
     IParser::Pos pos(tokens, max_depth, max_backtracks);
 
     return getExprFromToken(pos);
@@ -522,7 +522,7 @@ bool ParserKQLQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
                 --last_pos;
 
             String sub_query = std::format("({})", String(operation_pos.front().second->begin, last_pos->end));
-            Tokens token_subquery(sub_query.data(), sub_query.data() + sub_query.size(), 0, true);
+            Tokens token_subquery(sub_query.c_str(), sub_query.c_str() + sub_query.size());
             IParser::Pos pos_subquery(token_subquery, pos.max_depth, pos.max_backtracks);
 
             if (!ParserKQLSubquery().parse(pos_subquery, tables, expected))
@@ -543,7 +543,7 @@ bool ParserKQLQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
             auto oprator = getOperator(op_str);
             if (oprator)
             {
-                Tokens token_clause(op_calsue.data(), op_calsue.data() + op_calsue.size(), 0, true);
+                Tokens token_clause(op_calsue.c_str(), op_calsue.c_str() + op_calsue.size());
                 IParser::Pos pos_clause(token_clause, pos.max_depth, pos.max_backtracks);
                 if (!oprator->parse(pos_clause, node, expected))
                     return false;
@@ -576,7 +576,7 @@ bool ParserKQLQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
     if (!node->as<ASTSelectQuery>()->select())
     {
         auto expr = String("*");
-        Tokens tokens(expr.data(), expr.data() + expr.size(), 0, true);
+        Tokens tokens(expr.c_str(), expr.c_str() + expr.size());
         IParser::Pos new_pos(tokens, pos.max_depth, pos.max_backtracks);
         if (!std::make_unique<ParserKQLProject>()->parse(new_pos, node, expected))
             return false;

--- a/src/Parsers/Kusto/ParserKQLSort.cpp
+++ b/src/Parsers/Kusto/ParserKQLSort.cpp
@@ -18,7 +18,7 @@ bool ParserKQLSort::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
 
     auto expr = getExprFromToken(pos);
 
-    Tokens tokens(expr.data(), expr.data() + expr.size(), 0, true);
+    Tokens tokens(expr.c_str(), expr.c_str() + expr.size());
     IParser::Pos new_pos(tokens, pos.max_depth, pos.max_backtracks);
 
     auto pos_backup = new_pos;

--- a/src/Parsers/Kusto/ParserKQLStatement.cpp
+++ b/src/Parsers/Kusto/ParserKQLStatement.cpp
@@ -2,12 +2,12 @@
 #include <Parsers/ASTSelectWithUnionQuery.h>
 #include <Parsers/CommonParsers.h>
 #include <Parsers/IParserBase.h>
+#include <Parsers/Kusto/KustoFunctions/KQLFunctionFactory.h>
 #include <Parsers/Kusto/ParserKQLQuery.h>
 #include <Parsers/Kusto/ParserKQLStatement.h>
 #include <Parsers/Kusto/Utilities.h>
 #include <Parsers/ParserSetQuery.h>
 #include <Parsers/ASTLiteral.h>
-
 
 namespace DB
 {
@@ -63,8 +63,6 @@ bool ParserKQLWithUnionQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & exp
 
 bool ParserKQLTableFunction::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
 {
-    /// TODO: This code is idiotic, see https://github.com/ClickHouse/ClickHouse/issues/61742
-
     ParserToken lparen(TokenType::OpeningRoundBracket);
 
     ASTPtr string_literal;
@@ -103,16 +101,13 @@ bool ParserKQLTableFunction::parseImpl(Pos & pos, ASTPtr & node, Expected & expe
         ++pos;
     }
 
-    Tokens tokens_kql(kql_statement.data(), kql_statement.data() + kql_statement.size(), 0, true);
-    IParser::Pos pos_kql(tokens_kql, pos.max_depth, pos.max_backtracks);
-
+    Tokens token_kql(kql_statement.data(), kql_statement.data() + kql_statement.size());
+    IParser::Pos pos_kql(token_kql, pos.max_depth, pos.max_backtracks);
     Expected kql_expected;
     kql_expected.enable_highlighting = false;
     if (!ParserKQLWithUnionQuery().parse(pos_kql, node, kql_expected))
         return false;
-
     ++pos;
     return true;
 }
-
 }

--- a/src/Parsers/Kusto/ParserKQLStatement.h
+++ b/src/Parsers/Kusto/ParserKQLStatement.h
@@ -45,7 +45,7 @@ protected:
 class ParserKQLTableFunction : public IParserBase
 {
 protected:
-    const char * getName() const override { return "KQL function"; }
+    const char * getName() const override { return "KQL() function"; }
     bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
 };
 

--- a/src/Parsers/Kusto/ParserKQLSummarize.cpp
+++ b/src/Parsers/Kusto/ParserKQLSummarize.cpp
@@ -194,7 +194,7 @@ bool ParserKQLSummarize::parseImpl(Pos & pos, ASTPtr & node, Expected & expected
 
     String converted_columns = getExprFromToken(expr_columns, pos.max_depth, pos.max_backtracks);
 
-    Tokens token_converted_columns(converted_columns.data(), converted_columns.data() + converted_columns.size(), 0, true);
+    Tokens token_converted_columns(converted_columns.c_str(), converted_columns.c_str() + converted_columns.size());
     IParser::Pos pos_converted_columns(token_converted_columns, pos.max_depth, pos.max_backtracks);
 
     if (!ParserNotEmptyExpressionList(true).parse(pos_converted_columns, select_expression_list, expected))
@@ -206,7 +206,7 @@ bool ParserKQLSummarize::parseImpl(Pos & pos, ASTPtr & node, Expected & expected
     {
         String converted_groupby = getExprFromToken(expr_groupby, pos.max_depth, pos.max_backtracks);
 
-        Tokens token_converted_groupby(converted_groupby.data(), converted_groupby.data() + converted_groupby.size(), 0, true);
+        Tokens token_converted_groupby(converted_groupby.c_str(), converted_groupby.c_str() + converted_groupby.size());
         IParser::Pos postoken_converted_groupby(token_converted_groupby, pos.max_depth, pos.max_backtracks);
 
         if (!ParserNotEmptyExpressionList(false).parse(postoken_converted_groupby, group_expression_list, expected))

--- a/src/Parsers/TokenIterator.h
+++ b/src/Parsers/TokenIterator.h
@@ -21,7 +21,6 @@ class Tokens
 {
 private:
     std::vector<Token> data;
-    size_t max_pos = 0;
     Lexer lexer;
     bool skip_insignificant;
 
@@ -36,16 +35,10 @@ public:
         while (true)
         {
             if (index < data.size())
-            {
-                max_pos = std::max(max_pos, index);
                 return data[index];
-            }
 
             if (!data.empty() && data.back().isEnd())
-            {
-                max_pos = data.size() - 1;
                 return data.back();
-            }
 
             Token token = lexer.nextToken();
 
@@ -58,12 +51,7 @@ public:
     {
         if (data.empty())
             return (*this)[0];
-        return data[max_pos];
-    }
-
-    void reset()
-    {
-        max_pos = 0;
+        return data.back();
     }
 };
 

--- a/src/Parsers/parseQuery.cpp
+++ b/src/Parsers/parseQuery.cpp
@@ -4,7 +4,6 @@
 #include <Parsers/ParserQuery.h>
 #include <Parsers/ASTInsertQuery.h>
 #include <Parsers/ASTExplainQuery.h>
-#include <Parsers/CommonParsers.h>
 #include <Parsers/Lexer.h>
 #include <Parsers/TokenIterator.h>
 #include <Common/StringUtils.h>
@@ -286,33 +285,6 @@ ASTPtr tryParseQuery(
     }
 
     Expected expected;
-
-    /** A shortcut - if Lexer found invalid tokens, fail early without full parsing.
-      * But there are certain cases when invalid tokens are permitted:
-      * 1. INSERT queries can have arbitrary data after the FORMAT clause, that is parsed by a different parser.
-      * 2. It can also be the case when there are multiple queries separated by semicolons, and the first queries are ok
-      * while subsequent queries have syntax errors.
-      *
-      * This shortcut is needed to avoid complex backtracking in case of obviously erroneous queries.
-      */
-    IParser::Pos lookahead(token_iterator);
-    if (!ParserKeyword(Keyword::INSERT_INTO).ignore(lookahead))
-    {
-        while (lookahead->type != TokenType::Semicolon && lookahead->type != TokenType::EndOfStream)
-        {
-            if (lookahead->isError())
-            {
-                out_error_message = getLexicalErrorMessage(query_begin, all_queries_end, *lookahead, hilite, query_description);
-                return nullptr;
-            }
-
-            ++lookahead;
-        }
-
-        /// We should not spoil the info about maximum parsed position in the original iterator.
-        tokens.reset();
-    }
-
     ASTPtr res;
     const bool parse_res = parser.parse(token_iterator, res, expected);
     const auto last_token = token_iterator.max();

--- a/tests/queries/0_stateless/02366_kql_create_table.sql
+++ b/tests/queries/0_stateless/02366_kql_create_table.sql
@@ -1,8 +1,8 @@
 DROP TABLE IF EXISTS Customers;
 CREATE TABLE Customers
-(
+(    
     FirstName Nullable(String),
-    LastName String,
+    LastName String, 
     Occupation String,
     Education String,
     Age Nullable(UInt8)
@@ -10,20 +10,20 @@ CREATE TABLE Customers
 
 INSERT INTO Customers VALUES  ('Theodore','Diaz','Skilled Manual','Bachelors',28),('Stephanie','Cox','Management abcd defg','Bachelors',33),('Peter','Nara','Skilled Manual','Graduate Degree',26),('Latoya','Shen','Professional','Graduate Degree',25),('Apple','','Skilled Manual','Bachelors',28),(NULL,'why','Professional','Partial College',38);
 Select '-- test create table --' ;
-Select * from kql($$Customers|project FirstName$$) limit 1;;
+Select * from kql(Customers|project FirstName) limit 1;;
 DROP TABLE IF EXISTS kql_table1;
-CREATE TABLE kql_table1 ENGINE = Memory AS select *, now() as new_column From kql($$Customers | project LastName | filter LastName=='Diaz'$$);
+CREATE TABLE kql_table1 ENGINE = Memory AS select *, now() as new_column From kql(Customers | project LastName | filter LastName=='Diaz');
 select LastName from kql_table1 limit 1;
 DROP TABLE IF EXISTS kql_table2;
 CREATE TABLE kql_table2
-(
+(    
     FirstName Nullable(String),
-    LastName String,
+    LastName String, 
     Age Nullable(UInt8)
 ) ENGINE = Memory;
-INSERT INTO kql_table2 select * from kql($$Customers|project FirstName,LastName,Age | filter FirstName=='Theodore'$$);
+INSERT INTO kql_table2 select * from kql(Customers|project FirstName,LastName,Age | filter FirstName=='Theodore');
 select * from kql_table2 limit 1;
--- select * from kql($$Customers | where FirstName !in ("test", "test2")$$);
+-- select * from kql(Customers | where FirstName !in ("test", "test2"));
 DROP TABLE IF EXISTS Customers;
 DROP TABLE IF EXISTS kql_table1;
 DROP TABLE IF EXISTS kql_table2;

--- a/tests/queries/0_stateless/03015_parser_shortcut_lexer_errors.reference
+++ b/tests/queries/0_stateless/03015_parser_shortcut_lexer_errors.reference
@@ -1,1 +1,0 @@
-Syntax error

--- a/tests/queries/0_stateless/03015_parser_shortcut_lexer_errors.sh
+++ b/tests/queries/0_stateless/03015_parser_shortcut_lexer_errors.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
-# shellcheck source=../shell_config.sh
-. "$CUR_DIR"/../shell_config.sh
-
-$CLICKHOUSE_LOCAL --query "SELECT((((((((((SELECT(((((((((SELECT((((((((((SELECT(((((((((SELECT((((((((((SELECT(((((((((SELECT 1+)))))))))))))))))))))))))))))))))))))))))))))))))))))))))'" 2>&1 | grep -o -F 'Syntax error'


### PR DESCRIPTION
Reverts ClickHouse/ClickHouse#61500

Breaks `clickhouse-keeper-client` parsing
Made `02922_deduplication_with_zero_copy` flaky

close https://github.com/ClickHouse/ClickHouse/issues/65486