### PR TITLE
Fix `test_keeper_snapshots`

### DIFF
--- a/tests/integration/test_keeper_snapshots/test.py
+++ b/tests/integration/test_keeper_snapshots/test.py
@@ -189,7 +189,7 @@ def test_invalid_snapshot(started_cluster):
                 f"/var/lib/clickhouse/coordination/snapshots/{last_snapshot}",
             ]
         )
-        node.start_clickhouse(expected_to_fail=True)
+        node.start_clickhouse(start_wait_sec=120, expected_to_fail=True)
         assert node.contains_in_log(
             "Aborting because of failure to load from latest snapshot with index"
         )


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

For some reason generating stacktrace during abort takes a long time for TSAN build (more than a minute)
```
2024.06.19 19:27:10.385486 [ 1658 ] {} <Trace> BaseDaemon: Received signal 6
2024.06.19 19:27:10.386214 [ 2270 ] {} <Fatal> BaseDaemon: ########## Short fault info ############
2024.06.19 19:27:10.386413 [ 2270 ] {} <Fatal> BaseDaemon: (version 24.6.1.4346 (official build), build id: 228E3CCAB8B6E356AF6CF1030A82C35D51BB7E50, git hash: e442a1fdba6599b0e9535f522b2f8fd904b21d6d) (from thread 1641) Received signal 6
2024.06.19 19:27:10.386567 [ 2270 ] {} <Fatal> BaseDaemon: Signal description: Aborted
2024.06.19 19:27:10.386627 [ 2270 ] {} <Fatal> BaseDaemon:
2024.06.19 19:27:10.386734 [ 2270 ] {} <Fatal> BaseDaemon: Stack trace: 0x0000558ac8ec29fd 0x0000558ac91fa69b 0x0000558ac11d98f6 0x0000558ac11d9e16 0x00007fb6b8369520 0x00007fb6b83bd9fd 0x00007fb6b8369476 0x00007fb6b834f7f3 0x0000558ac11d84ff 0x0000558ad4142573 0x0000558ad409c643 0x0000558ad40736d3 0x0000558ad0aade26 0x0000558ac9092614 0x0000558ad73a961f 0x0000558ac9080b26 0x0000558ad73c7d41 0x0000558ac907d956 0x0000558ac1250b45 0x00007fb6b8350d90 0x00007fb6b8350e40 0x0000558ac11ab02e
2024.06.19 19:27:10.386829 [ 2270 ] {} <Fatal> BaseDaemon: ########################################
2024.06.19 19:27:10.386945 [ 2270 ] {} <Fatal> BaseDaemon: (version 24.6.1.4346 (official build), build id: 228E3CCAB8B6E356AF6CF1030A82C35D51BB7E50, git hash: e442a1fdba6599b0e9535f522b2f8fd904b21d6d) (from thread 1641) (no query) Received signal Aborted (6)
2024.06.19 19:27:10.387029 [ 2270 ] {} <Fatal> BaseDaemon:
2024.06.19 19:27:10.387078 [ 2270 ] {} <Fatal> BaseDaemon: Stack trace: 0x0000558ac8ec29fd 0x0000558ac91fa69b 0x0000558ac11d98f6 0x0000558ac11d9e16 0x00007fb6b8369520 0x00007fb6b83bd9fd 0x00007fb6b8369476 0x00007fb6b834f7f3 0x0000558ac11d84ff 0x0000558ad4142573 0x0000558ad409c643 0x0000558ad40736d3 0x0000558ad0aade26 0x0000558ac9092614 0x0000558ad73a961f 0x0000558ac9080b26 0x0000558ad73c7d41 0x0000558ac907d956 0x0000558ac1250b45 0x00007fb6b8350d90 0x00007fb6b8350e40 0x0000558ac11ab02e
2024.06.19 19:27:10.578848 [ 2270 ] {} <Fatal> BaseDaemon: 0.0. inlined from ./build_docker/./src/Common/StackTrace.cpp:349: StackTrace::tryCapture()
2024.06.19 19:27:10.579027 [ 2270 ] {} <Fatal> BaseDaemon: 0. ./build_docker/./src/Common/StackTrace.cpp:318: StackTrace::StackTrace(ucontext_t const&) @ 0x000000000ef4b9fd
2024.06.19 19:27:10.999038 [ 2270 ] {} <Fatal> BaseDaemon: 1. ./build_docker/./src/Daemon/BaseDaemon.cpp:0: signalHandler(int, siginfo_t*, void*) @ 0x000000000f28369b
2024.06.19 19:27:24.268493 [ 2270 ] {} <Fatal> BaseDaemon: 2. __tsan::CallUserSignalHandler(__tsan::ThreadState*, bool, bool, int, __sanitizer::__sanitizer_siginfo*, void*) @ 0x00000000072628f6
2024.06.19 19:27:36.562420 [ 2270 ] {} <Fatal> BaseDaemon: 3. sighandler(int, __sanitizer::__sanitizer_siginfo*, void*) @ 0x0000000007262e16
2024.06.19 19:27:36.562535 [ 2270 ] {} <Fatal> BaseDaemon: 4. ? @ 0x00007fb6b8369520
2024.06.19 19:27:36.562583 [ 2270 ] {} <Fatal> BaseDaemon: 5. ? @ 0x00007fb6b83bd9fd
2024.06.19 19:27:36.562626 [ 2270 ] {} <Fatal> BaseDaemon: 6. ? @ 0x00007fb6b8369476
2024.06.19 19:27:36.562667 [ 2270 ] {} <Fatal> BaseDaemon: 7. ? @ 0x00007fb6b834f7f3
2024.06.19 19:27:48.444326 [ 2270 ] {} <Fatal> BaseDaemon: 8. ___interceptor_abort @ 0x00000000072614ff
2024.06.19 19:27:48.761453 [ 2270 ] {} <Fatal> BaseDaemon: 9. ./build_docker/./src/Coordination/KeeperStateMachine.cpp:0: DB::KeeperStateMachine::init() @ 0x000000001a1cb573
2024.06.19 19:27:49.209070 [ 2270 ] {} <Fatal> BaseDaemon: 10. ./build_docker/./src/Coordination/KeeperServer.cpp:444: DB::KeeperServer::startup(Poco::Util::AbstractConfiguration const&, bool) @ 0x000000001a125643
2024.06.19 19:27:49.594621 [ 2270 ] {} <Fatal> BaseDaemon: 11. ./build_docker/./src/Coordination/KeeperDispatcher.cpp:0: DB::KeeperDispatcher::initialize(Poco::Util::AbstractConfiguration const&, bool, bool, std::shared_ptr<DB::Macros const> const&) @ 0x000000001a0fc6d3
2024.06.19 19:27:51.185296 [ 2270 ] {} <Fatal> BaseDaemon: 12.0. inlined from ./contrib/llvm-project/libcxx/include/__memory/shared_ptr.h:701: ~shared_ptr
2024.06.19 19:27:51.185412 [ 2270 ] {} <Fatal> BaseDaemon: 12. ./build_docker/./src/Interpreters/Context.cpp:3544: DB::Context::initializeKeeperDispatcher(bool) const @ 0x0000000016b36e26
2024.06.19 19:27:51.648782 [ 2270 ] {} <Fatal> BaseDaemon: 13.0. inlined from ./contrib/llvm-project/libcxx/include/__memory/shared_ptr.h:815: std::shared_ptr<DB::Context>::operator->[abi:v15000]() const
2024.06.19 19:27:51.648923 [ 2270 ] {} <Fatal> BaseDaemon: 13. ./build_docker/./programs/server/Server.cpp:1715: DB::Server::main(std::vector<String, std::allocator<String>> const&) @ 0x000000000f11b614
2024.06.19 19:27:51.745950 [ 2270 ] {} <Fatal> BaseDaemon: 14. ./build_docker/./base/poco/Util/src/Application.cpp:0: Poco::Util::Application::run() @ 0x000000001d43261f
2024.06.19 19:27:52.650892 [ 2270 ] {} <Fatal> BaseDaemon: 15. ./build_docker/./programs/server/Server.cpp:0: DB::Server::run() @ 0x000000000f109b26
2024.06.19 19:27:52.680985 [ 2270 ] {} <Fatal> BaseDaemon: 16. ./build_docker/./base/poco/Util/src/ServerApplication.cpp:0: Poco::Util::ServerApplication::run(int, char**) @ 0x000000001d450d41
2024.06.19 19:27:53.548610 [ 2270 ] {} <Fatal> BaseDaemon: 17. ./build_docker/./programs/server/Server.cpp:0: mainEntryClickHouseServer(int, char**) @ 0x000000000f106956
2024.06.19 19:27:53.574286 [ 2270 ] {} <Fatal> BaseDaemon: 18. ./build_docker/./programs/main.cpp:0: main @ 0x00000000072d9b45
2024.06.19 19:27:53.574382 [ 2270 ] {} <Fatal> BaseDaemon: 19. ? @ 0x00007fb6b8350d90
2024.06.19 19:27:53.574428 [ 2270 ] {} <Fatal> BaseDaemon: 20. ? @ 0x00007fb6b8350e40
2024.06.19 19:28:05.488053 [ 2270 ] {} <Fatal> BaseDaemon: 21. _start @ 0x000000000723402e
2024.06.19 19:28:06.741684 [ 2270 ] {} <Fatal> BaseDaemon: Integrity check of the executable successfully passed (checksum: FFA92A3D3FAA22C7FCECAA6D24153202)
2024.06.19 19:28:06.741838 [ 2270 ] {} <Information> SentryWriter: Not sending crash report
2024.06.19 19:28:06.741881 [ 2270 ] {} <Fatal> BaseDaemon: Report this error to https://github.com/ClickHouse/ClickHouse/issues
```

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
