### PR TITLE
Revert "Use 1MB HTTP buffers to avoid frequent send syscalls"

### DIFF
--- a/base/poco/Net/include/Poco/Net/HTTPBasicStreamBuf.h
+++ b/base/poco/Net/include/Poco/Net/HTTPBasicStreamBuf.h
@@ -26,7 +26,7 @@ namespace Poco
 {
 namespace Net
 {
-    constexpr size_t HTTP_DEFAULT_BUFFER_SIZE = 1024 * 1024;
+    constexpr size_t HTTP_DEFAULT_BUFFER_SIZE = 8 * 1024;
 
     typedef Poco::BasicBufferedStreamBuf<char, std::char_traits<char>> HTTPBasicStreamBuf;
 

--- a/tests/integration/test_checking_s3_blobs_paranoid/test.py
+++ b/tests/integration/test_checking_s3_blobs_paranoid/test.py
@@ -300,7 +300,7 @@ def test_when_s3_broken_pipe_at_upload_is_retried(cluster, broken_s3):
         LIMIT 1000000
         SETTINGS
             s3_max_single_part_upload_size=100,
-            s3_min_upload_part_size=100000,
+            s3_min_upload_part_size=1000000,
             s3_check_objects_after_upload=0
         """,
         query_id=insert_query_id,
@@ -311,7 +311,7 @@ def test_when_s3_broken_pipe_at_upload_is_retried(cluster, broken_s3):
     )
 
     assert create_multipart == 1
-    assert upload_parts == 69
+    assert upload_parts == 7
     assert s3_errors == 3
 
     broken_s3.setup_at_part_upload(

--- a/tests/queries/0_stateless/01926_order_by_desc_limit.sql
+++ b/tests/queries/0_stateless/01926_order_by_desc_limit.sql
@@ -12,10 +12,10 @@ INSERT INTO order_by_desc SELECT number, repeat('a', 1024) FROM numbers(1024 * 3
 OPTIMIZE TABLE order_by_desc FINAL;
 
 SELECT s FROM order_by_desc ORDER BY u DESC LIMIT 10 FORMAT Null
-SETTINGS max_memory_usage = '600M';
+SETTINGS max_memory_usage = '400M';
 
 SELECT s FROM order_by_desc ORDER BY u LIMIT 10 FORMAT Null
-SETTINGS max_memory_usage = '600M';
+SETTINGS max_memory_usage = '400M';
 
 SYSTEM FLUSH LOGS;
 


### PR DESCRIPTION
Reverts ClickHouse/ClickHouse#65028
Reverts ClickHouse/ClickHouse#65466

The reason for revert is two-fold:
1. We do not know the performance impact of improvement (obviously, having x100 fewer syscalls is better, but how much better we don't know).
1. On the other side we have an increase in buffer sizes. It is especially unwanted for S3 GET requests, where write buffer is only used to send the request that is at most a few KBs in size.

Probably, we should fix frequent syscalls by removing unnecessary buffering first and then improving syscalls.