### PR TITLE
(Run tests without catching unwind segfaults)

### DIFF
--- a/docker/test/stateless/attach_gdb.lib
+++ b/docker/test/stateless/attach_gdb.lib
@@ -20,7 +20,6 @@ handle SIGPIPE nostop noprint pass
 handle SIGTERM nostop noprint pass
 handle SIGUSR1 nostop noprint pass
 handle SIGUSR2 nostop noprint pass
-handle SIGSEGV nostop pass
 handle SIG$RTMIN nostop noprint pass
 info signals
 continue

--- a/src/Common/QueryProfiler.cpp
+++ b/src/Common/QueryProfiler.cpp
@@ -86,22 +86,22 @@ namespace
         const auto signal_context = *reinterpret_cast<ucontext_t *>(context);
         std::optional<StackTrace> stack_trace;
 
-#if defined(SANITIZER)
-        constexpr bool sanitizer = true;
-#else
-        constexpr bool sanitizer = false;
-#endif
+//#if defined(SANITIZER)
+//        constexpr bool sanitizer = true;
+//#else
+//        constexpr bool sanitizer = false;
+//#endif
 
-        asynchronous_stack_unwinding = true;
-        if (sanitizer || 0 == sigsetjmp(asynchronous_stack_unwinding_signal_jump_buffer, 1))
-        {
+        //asynchronous_stack_unwinding = true;
+        //if (sanitizer || 0 == sigsetjmp(asynchronous_stack_unwinding_signal_jump_buffer, 1))
+        //{
             stack_trace.emplace(signal_context);
-        }
-        else
-        {
-            ProfileEvents::incrementNoTrace(ProfileEvents::QueryProfilerErrors);
-        }
-        asynchronous_stack_unwinding = false;
+        //}
+        //else
+        //{
+        //    ProfileEvents::incrementNoTrace(ProfileEvents::QueryProfilerErrors);
+        //}
+        //asynchronous_stack_unwinding = false;
 
         if (stack_trace)
             TraceSender::send(trace_type, *stack_trace, {});


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

To compare with https://github.com/ClickHouse/ClickHouse/pull/65257