### PR TITLE
[Feature] Add support for prewhere in parquet native reader

### DIFF
--- a/src/Processors/Formats/IInputFormat.h
+++ b/src/Processors/Formats/IInputFormat.h
@@ -66,6 +66,8 @@ public:
 
     void needOnlyCount() { need_only_count = true; }
 
+    virtual bool supportsPrewhere() const { return false; }
+
 protected:
     ReadBuffer & getReadBuffer() const { chassert(in); return *in; }
 

--- a/src/Processors/Formats/Impl/Parquet/ParquetColumnReader.h
+++ b/src/Processors/Formats/Impl/Parquet/ParquetColumnReader.h
@@ -10,6 +10,8 @@ class PageReader;
 class ColumnChunkMetaData;
 class DataPageV1;
 class DataPageV2;
+class DictionaryPage;
+class Page;
 
 }
 
@@ -19,7 +21,8 @@ namespace DB
 class ParquetColumnReader
 {
 public:
-    virtual ColumnWithTypeAndName readBatch(UInt64 rows_num, const String & name) = 0;
+    virtual ColumnWithTypeAndName readBatch(UInt64 rows_num, const String & name, const IColumn::Filter * filter) = 0;
+    virtual void skip(size_t num_values) = 0;
 
     virtual ~ParquetColumnReader() = default;
 };

--- a/src/Processors/Formats/Impl/Parquet/ParquetDataBuffer.h
+++ b/src/Processors/Formats/Impl/Parquet/ParquetDataBuffer.h
@@ -48,6 +48,12 @@ public:
         consume(bytes);
     }
 
+    void ALWAYS_INLINE skipBytes(size_t bytes)
+    {
+        checkAvaible(bytes);
+        consume(bytes);
+    }
+
     void ALWAYS_INLINE readDateTime64FromInt96(DateTime64 & dst)
     {
         static const int max_scale_num = 9;
@@ -98,6 +104,15 @@ public:
         column.getChars().back() = 0;
 
         column.getOffsets().data()[cursor] = column.getChars().size();
+        consume(value_len);
+    }
+
+    void ALWAYS_INLINE skipString()
+    {
+        checkAvaible(4);
+        auto value_len = ::arrow::util::SafeLoadAs<Int32>(getArrowData());
+        consume(4);
+        checkAvaible(value_len);
         consume(value_len);
     }
 

--- a/src/Processors/Formats/Impl/Parquet/ParquetRecordReader.h
+++ b/src/Processors/Formats/Impl/Parquet/ParquetRecordReader.h
@@ -13,6 +13,8 @@
 
 namespace DB
 {
+struct PrewhereInfo;
+struct PrewhereExprInfo;
 
 class ParquetRecordReader
 {
@@ -24,7 +26,10 @@ public:
         std::shared_ptr<::arrow::io::RandomAccessFile> arrow_file,
         const FormatSettings & format_settings,
         std::vector<int> row_groups_indices_,
-        std::shared_ptr<parquet::FileMetaData> metadata = nullptr);
+        std::shared_ptr<parquet::FileMetaData> metadata = nullptr,
+        std::shared_ptr<PrewhereInfo> prewhere_info_ = nullptr);
+
+    ~ParquetRecordReader();
 
     Chunk readChunk();
 
@@ -35,19 +40,31 @@ private:
     Block header;
 
     std::shared_ptr<parquet::RowGroupReader> cur_row_group_reader;
-    ParquetColReaders column_readers;
 
     UInt64 max_block_size;
 
-    std::vector<int> parquet_col_indice;
     std::vector<int> row_groups_indices;
-    UInt64 left_rows;
     UInt64 cur_row_group_left_rows = 0;
     int next_row_group_idx = 0;
 
     Poco::Logger * log;
 
-    void loadNextRowGroup();
+    struct ChunkReader {
+        Block sample_block;
+        std::vector<int> col_indice;
+        ParquetColReaders column_readers;
+
+        void init(ParquetRecordReader &record_reader);
+        Columns readBatch(size_t num_rows, const IColumn::Filter * filter);
+        void skip(size_t num_rows);
+    };
+
+    ChunkReader active_chunk_reader;
+    ChunkReader lazy_chunk_reader;
+    std::shared_ptr<PrewhereInfo> prewhere_info;
+    std::shared_ptr<PrewhereExprInfo> prewhere_actions;
+
+    bool loadNextRowGroup();
     Int64 getTotalRows(const parquet::FileMetaData & meta_data);
 };
 

--- a/src/Processors/Formats/Impl/Parquet/ParquetRecordReader.h
+++ b/src/Processors/Formats/Impl/Parquet/ParquetRecordReader.h
@@ -49,7 +49,8 @@ private:
 
     Poco::Logger * log;
 
-    struct ChunkReader {
+    struct ChunkReader
+    {
         Block sample_block;
         std::vector<int> col_indice;
         ParquetColReaders column_readers;

--- a/src/Processors/Formats/Impl/ParquetBlockInputFormat.cpp
+++ b/src/Processors/Formats/Impl/ParquetBlockInputFormat.cpp
@@ -522,7 +522,9 @@ void ParquetBlockInputFormat::initializeRowGroupBatchReader(size_t row_group_bat
             reader_properties,
             arrow_file,
             format_settings,
-            row_group_batch.row_groups_idxs);
+            row_group_batch.row_groups_idxs,
+            nullptr,
+            prewhere_info);
     }
     else
     {

--- a/src/Processors/Formats/Impl/ParquetBlockInputFormat.h
+++ b/src/Processors/Formats/Impl/ParquetBlockInputFormat.h
@@ -65,6 +65,8 @@ public:
 
     size_t getApproxBytesReadForChunk() const override { return previous_approx_bytes_read_for_chunk; }
 
+    bool supportsPrewhere() const override { return format_settings.parquet.use_native_reader; }
+
 private:
     Chunk read() override;
 

--- a/src/Processors/SourceWithKeyCondition.h
+++ b/src/Processors/SourceWithKeyCondition.h
@@ -15,6 +15,7 @@ class SourceWithKeyCondition : public ISource
 protected:
     /// Represents pushed down filters in source
     std::shared_ptr<const KeyCondition> key_condition;
+    PrewhereInfoPtr prewhere_info;
 
     void setKeyConditionImpl(const ActionsDAGPtr & filter_actions_dag, ContextPtr context, const Block & keys)
     {
@@ -34,5 +35,7 @@ public:
 
     /// Set key_condition created by filter_actions_dag and context.
     virtual void setKeyCondition(const ActionsDAGPtr & /*filter_actions_dag*/, ContextPtr /*context*/) { }
+
+    void setPrewhereInfo(const PrewhereInfoPtr & prewhere_) { prewhere_info = prewhere_; }
 };
 }

--- a/src/Storages/StorageFile.h
+++ b/src/Storages/StorageFile.h
@@ -98,6 +98,8 @@ public:
 
     bool supportsPartitionBy() const override { return true; }
 
+    bool supportsPrewhere() const override { return true; }
+
     struct ArchiveInfo
     {
         std::vector<std::string> paths_to_archives;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- New Feature

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add support for prewhere in parquet native reader (StorageFile is supported)

### Documentation entry for user-facing changes

When reading a Parquet file, if the prewhere_info is provided, the Parquet native reader should:

1. Read the columns with the prewhere predicate (active columns) .
2. Filter the result and get the filter mask.
3. Read the remaining columns (lazy columns) and filter the page using the filter mask. If no row is selected in the page, it should skip the page.
4. Build the final result chunk

A performance benchmark will be added here later.

TODO: 
- [ ] Currently, only explicit use of PREWHERE in SQL is supported. Automatic moving of some predicates to prewhere clause based on column sizes should be supported. This can reuse the logic from the merge tree i guess. 

- [ ] Support other storage engines

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
