### PR TITLE
Add ability to load dashboards for system.dashboards from config

### DIFF
--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -1510,6 +1510,8 @@ try
             global_context->setMacros(std::make_unique<Macros>(*config, "macros", log));
             global_context->setExternalAuthenticatorsConfig(*config);
 
+            global_context->setDashboardsConfig(config);
+
             if (global_context->isServerCompletelyStarted())
             {
                 /// It does not make sense to reload anything before server has started.

--- a/programs/server/config.xml
+++ b/programs/server/config.xml
@@ -1297,6 +1297,31 @@
         <ttl>event_date + INTERVAL 30 DAY</ttl>
     </blob_storage_log>
 
+    <!-- Configure system.dashboards for dashboard.html.
+
+         Could have any query parameters, for which there will be an input on the page.
+         For instance an example from comments have the following:
+         - seconds
+         - rounding
+
+         NOTE: All default dashboards will be overwritten if it was set here. -->
+    <!-- Here is an example without merge() function, to make it work with readonly user -->
+    <!--
+    <dashboards>
+        <dashboard>
+            <dashboard>Overview</dashboard>
+            <title>Queries/second</title>
+            <query>
+                SELECT toStartOfInterval(event_time, INTERVAL {rounding:UInt32} SECOND)::INT AS t, avg(ProfileEvent_Query)
+                FROM system.metric_log
+                WHERE event_date >= toDate(now() - {seconds:UInt32}) AND event_time >= now() - {seconds:UInt32}
+                GROUP BY t
+                ORDER BY t WITH FILL STEP {rounding:UInt32}
+            </query>
+        </dashboard>
+    </dashboards>
+    -->
+
     <!-- <top_level_domains_path>/var/lib/clickhouse/top_level_domains/</top_level_domains_path> -->
     <!-- Custom TLD lists.
          Format: <name>/path/to/file</name>

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -373,6 +373,10 @@ struct ContextSharedPart : boost::noncopyable
     ActionLocksManagerPtr action_locks_manager;             /// Set of storages' action lockers
     OnceFlag system_logs_initialized;
     std::unique_ptr<SystemLogs> system_logs TSA_GUARDED_BY(mutex);                /// Used to log queries and operations on parts
+
+    mutable std::mutex dashboard_mutex;
+    std::optional<Context::Dashboards> dashboards;
+
     std::optional<S3SettingsByEndpoint> storage_s3_settings TSA_GUARDED_BY(mutex);   /// Settings of S3 storage
     std::vector<String> warnings TSA_GUARDED_BY(mutex);                           /// Store warning messages about server configuration.
 
@@ -4192,6 +4196,51 @@ std::vector<ISystemLog *> Context::getSystemLogs() const
     return shared->system_logs->logs;
 }
 
+std::optional<Context::Dashboards> Context::getDashboards() const
+{
+    std::lock_guard lock(shared->dashboard_mutex);
+
+    if (!shared->dashboards)
+        return {};
+    return shared->dashboards;
+}
+
+namespace
+{
+
+String trim(const String & text)
+{
+    std::string_view view(text);
+    ::trim(view, '\n');
+    return String(view);
+}
+
+}
+
+void Context::setDashboardsConfig(const ConfigurationPtr & config)
+{
+    Poco::Util::AbstractConfiguration::Keys keys;
+    config->keys("dashboards", keys);
+
+    Dashboards dashboards;
+    for (const auto & key : keys)
+    {
+        const auto & prefix = "dashboards." + key + ".";
+        dashboards.push_back({
+            { "dashboard", config->getString(prefix + "dashboard") },
+            { "title",     config->getString(prefix + "title") },
+            { "query",     trim(config->getString(prefix + "query")) },
+        });
+    }
+
+    {
+        std::lock_guard lock(shared->dashboard_mutex);
+        if (!dashboards.empty())
+            shared->dashboards.emplace(std::move(dashboards));
+        else
+            shared->dashboards.reset();
+    }
+}
 
 CompressionCodecPtr Context::chooseCompressionCodec(size_t part_size, double part_size_ratio) const
 {

--- a/src/Interpreters/Context.h
+++ b/src/Interpreters/Context.h
@@ -1141,6 +1141,10 @@ public:
 
     std::vector<ISystemLog *> getSystemLogs() const;
 
+    using Dashboards = std::vector<std::map<String, String>>;
+    std::optional<Dashboards> getDashboards() const;
+    void setDashboardsConfig(const ConfigurationPtr & config);
+
     /// Returns an object used to log operations with parts if it possible.
     /// Provide table name to make required checks.
     std::shared_ptr<PartLog> getPartLog(const String & part_database) const;

--- a/src/Storages/System/StorageSystemDashboards.h
+++ b/src/Storages/System/StorageSystemDashboards.h
@@ -22,7 +22,7 @@ public:
 protected:
     using IStorageSystemOneBlock::IStorageSystemOneBlock;
 
-    void fillData(MutableColumns & res_columns, ContextPtr, const ActionsDAG::Node *, std::vector<UInt8>) const override;
+    void fillData(MutableColumns & res_columns, ContextPtr context, const ActionsDAG::Node *, std::vector<UInt8>) const override;
 };
 
 }

--- a/tests/integration/test_custom_dashboards/configs/config.d/overrides.xml
+++ b/tests/integration/test_custom_dashboards/configs/config.d/overrides.xml
@@ -1,0 +1,15 @@
+<clickhouse>
+    <dashboards>
+        <dashboard>
+            <dashboard>Overview</dashboard>
+            <title>Queries/second</title>
+            <query>
+                SELECT toStartOfInterval(event_time, INTERVAL {rounding:UInt32} SECOND)::INT AS t, avg(ProfileEvent_Query)
+                FROM system.metric_log
+                WHERE event_date >= toDate(now() - {seconds:UInt32}) AND event_time >= now() - {seconds:UInt32}
+                GROUP BY t
+                ORDER BY t WITH FILL STEP {rounding:UInt32}
+            </query>
+        </dashboard>
+    </dashboards>
+</clickhouse>

--- a/tests/integration/test_custom_dashboards/test.py
+++ b/tests/integration/test_custom_dashboards/test.py
@@ -1,0 +1,35 @@
+import pytest
+from helpers.cluster import ClickHouseCluster
+
+
+cluster = ClickHouseCluster(__file__)
+
+default = cluster.add_instance("default")
+custom = cluster.add_instance("custom", main_configs=["configs/config.d/overrides.xml"])
+
+
+@pytest.fixture(scope="module", autouse=True)
+def start_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def test_custom_dashboards():
+    assert int(default.query("select count()>10 from system.dashboards")) == 1
+    assert int(custom.query("select count() from system.dashboards")) == 1
+    assert (
+        default.query(
+            "select normalizeQuery(query) from system.dashboards where dashboard = 'Overview' and title = 'Queries/second'"
+        ).strip()
+        == """
+SELECT toStartOfInterval(event_time, INTERVAL {rounding:UInt32} SECOND)::INT AS t, avg(ProfileEvent_Query) FROM merge(?..) WHERE event_date >= toDate(now() - {seconds:UInt32}) AND event_time >= now() - {seconds:UInt32} GROUP BY t ORDER BY t WITH FILL STEP {rounding:UInt32}
+    """.strip()
+    )
+    custom.query(
+        "select normalizeQuery(query) from system.dashboards where dashboard = 'Overview' and title = 'Queries/second'"
+    ).strip == """
+SELECT toStartOfInterval(event_time, INTERVAL {rounding:UInt32} SECOND)::INT AS t, avg(ProfileEvent_Query) FROM system.metric_log WHERE event_date >= toDate(now() - {seconds:UInt32}) AND event_time >= now() - {seconds:UInt32} GROUP BY t ORDER BY t WITH FILL STEP {rounding:UInt32}
+    """.strip()


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add ability to load dashboards for system.dashboards from config (once set, they overrides the default dashboards preset)

One of the obvious reasons is to allow rendering them with readonly user, which is not possible right now, due to usage of merge() function there.

Another one, is to add some custom metrics.

Follow-up for: https://github.com/ClickHouse/ClickHouse/pull/56771 (cc @serxa )