### PR TITLE
Re-configure yamllint to allow document-start

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -13,5 +13,4 @@ rules:
         level: warning
     comments:
         min-spaces-from-content: 1
-    document-start:
-        present: false
+    document-start: disable


### PR DESCRIPTION
CI reported [1]:

    1:1       warning  found forbidden document start "---"  (document-start)

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/65563/27ef3066f685390227c84f31c7c95e1670f9960b/style_check.html

It was an error to forbid it, and it made only by mistake to ignore the errors.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)