### PR TITLE
Fix test_parallel_replicas_distributed_skip_shards flakiness

### DIFF
--- a/tests/integration/test_parallel_replicas_distributed_skip_shards/test.py
+++ b/tests/integration/test_parallel_replicas_distributed_skip_shards/test.py
@@ -53,6 +53,9 @@ def create_tables(cluster, table_name):
     node1.query(f"INSERT INTO {table_name} SELECT number, number FROM numbers(1000)")
     node2.query(f"INSERT INTO {table_name} SELECT -number, -number FROM numbers(1000)")
     node1.query(f"INSERT INTO {table_name} SELECT number, number FROM numbers(3)")
+    # need to sync replicas to have consistent result
+    node1.query(f"SYSTEM SYNC REPLICA {table_name}")
+    node2.query(f"SYSTEM SYNC REPLICA {table_name}")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
