### PR TITLE
Sanity check for ttl group by when column is also assigned in set

### DIFF
--- a/src/Parsers/ExpressionElementParsers.cpp
+++ b/src/Parsers/ExpressionElementParsers.cpp
@@ -2352,7 +2352,7 @@ bool ParserTTLElement::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
 
         std::vector<String> identifiers_used_by_group_by;
 
-        for (auto & key : ttl_element->group_by_key )
+        for (auto & key : ttl_element->group_by_key)
         {
             if (key->as<ASTIdentifier>())
             {
@@ -2372,7 +2372,7 @@ bool ParserTTLElement::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
             }
         }
 
-        for (auto & assignment : ttl_element->group_by_assignments )
+        for (auto & assignment : ttl_element->group_by_assignments)
         {
             if (assignment->as<ASTAssignment>())
             {

--- a/src/Parsers/ExpressionElementParsers.cpp
+++ b/src/Parsers/ExpressionElementParsers.cpp
@@ -2349,6 +2349,40 @@ bool ParserTTLElement::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
         ttl_element->group_by_key = std::move(group_by_key->children);
         if (group_by_assignments)
             ttl_element->group_by_assignments = std::move(group_by_assignments->children);
+
+        std::vector<String> identifiers_used_by_group_by;
+
+        for (auto key  : ttl_element->group_by_key )
+        {
+            if (key->as<ASTIdentifier>())
+            {
+                identifiers_used_by_group_by.push_back(key->as<ASTIdentifier>()->getColumnName());
+            }
+            else if (key->as<ASTFunction>() && key->children.size() > 0)
+            {
+                auto expression = key->children.front();
+                for (auto key_children: expression->children)
+                {
+                    if (key_children->as<ASTIdentifier>())
+                    {
+                        identifiers_used_by_group_by.push_back(key_children->as<ASTIdentifier>()->getColumnName());
+                    }
+
+                }
+            }
+        }
+
+        for (auto assignment  : ttl_element->group_by_assignments )
+        {
+            if (assignment->as<ASTAssignment>())
+            {
+                if (std::find(identifiers_used_by_group_by.begin(), identifiers_used_by_group_by.end(),assignment->as<ASTAssignment>()->column_name) != identifiers_used_by_group_by.end())
+                {
+                    throw Exception(ErrorCodes::SYNTAX_ERROR, "It is forbidden to define column in SET sections which is already defined in GROUP BY section");
+                }
+
+            }
+        }
     }
 
     if (mode == TTLMode::RECOMPRESS)

--- a/src/Parsers/ExpressionElementParsers.cpp
+++ b/src/Parsers/ExpressionElementParsers.cpp
@@ -2352,7 +2352,7 @@ bool ParserTTLElement::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
 
         std::vector<String> identifiers_used_by_group_by;
 
-        for (auto key  : ttl_element->group_by_key )
+        for (auto & key : ttl_element->group_by_key )
         {
             if (key->as<ASTIdentifier>())
             {
@@ -2372,7 +2372,7 @@ bool ParserTTLElement::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
             }
         }
 
-        for (auto assignment  : ttl_element->group_by_assignments )
+        for (auto & assignment : ttl_element->group_by_assignments )
         {
             if (assignment->as<ASTAssignment>())
             {

--- a/tests/queries/0_stateless/03167_create_table_with_ttl_group_by_set.sql
+++ b/tests/queries/0_stateless/03167_create_table_with_ttl_group_by_set.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS sample_table;
+CREATE TABLE sample_table ( `id` UInt128 CODEC(ZSTD(1)), `value` Int64 CODEC(ZSTD(1)), `request_timestamp` DateTime64(3) CODEC(ZSTD(1))) ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/{database}/', '{replica}') ORDER BY (id, toStartOfMinute(request_timestamp), request_timestamp) TTL toDateTime(request_timestamp) + toIntervalDay(2) GROUP BY id, toStartOfMinute(request_timestamp) SET request_timestamp = max(request_timestamp) SETTINGS index_granularity = 8192; -- { clientError SYNTAX_ERROR }


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Added sanity check for ttl group by when column is also assigned in set



cc @CheSema @tavplubix 