### PR TITLE
Fix overflow in StorageWindowView

### DIFF
--- a/src/Storages/WindowView/StorageWindowView.cpp
+++ b/src/Storages/WindowView/StorageWindowView.cpp
@@ -1068,9 +1068,10 @@ void StorageWindowView::threadFuncFireProc()
     if (max_watermark >= timestamp_now)
         clean_cache_task->schedule();
 
+    UInt64 next_fire_ms = static_cast<UInt64>(next_fire_signal) * 1000;
     UInt64 timestamp_ms = static_cast<UInt64>(Poco::Timestamp().epochMicroseconds()) / 1000;
     if (!shutdown_called)
-        fire_task->scheduleAfter(std::max(UInt64(0), static_cast<UInt64>(next_fire_signal) * 1000 - timestamp_ms));
+        fire_task->scheduleAfter(std::max(UInt64(0), next_fire_ms - std::min(next_fire_ms, timestamp_ms)));
 }
 
 void StorageWindowView::threadFuncFireEvent()

--- a/src/Storages/WindowView/StorageWindowView.cpp
+++ b/src/Storages/WindowView/StorageWindowView.cpp
@@ -1071,7 +1071,7 @@ void StorageWindowView::threadFuncFireProc()
     UInt64 next_fire_ms = static_cast<UInt64>(next_fire_signal) * 1000;
     UInt64 timestamp_ms = static_cast<UInt64>(Poco::Timestamp().epochMicroseconds()) / 1000;
     if (!shutdown_called)
-        fire_task->scheduleAfter(std::max(UInt64(0), next_fire_ms - std::min(next_fire_ms, timestamp_ms)));
+        fire_task->scheduleAfter(next_fire_ms - std::min(next_fire_ms, timestamp_ms));
 }
 
 void StorageWindowView::threadFuncFireEvent()


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

01053_window_view_proc_hop_to_now failed in https://s3.amazonaws.com/clickhouse-test-reports/58934/8b510a67f957c2373f4126d2884614ff7066f1b5/stateless_tests__tsan__s3_storage__[2_5].html

The output says that SELECTs from the live view never saw the data inserted into the source table. Server log doesn't have any "StorageWindowView" messages for this view, in particular this means `fire()` was never called during the ~100 seconds the view existed.

This PR fixes a possible cause: unsigned timestamp subtraction could underflow if the current second changed between the lines `timestamp_now = now()` and `timestamp_ms = static_cast<UInt64>(Poco::Timestamp().epochMicroseconds()) / 1000`, scheduling the task to run after ~UINT64_MAX milliseconds.

(But I couldn't reproduce this test failure even after adding a 100ms sleep and running the test 100 times, but didn't investigate further.)