### PR TITLE
Reduce memory usage for some window functions

### DIFF
--- a/src/AggregateFunctions/WindowFunction.h
+++ b/src/AggregateFunctions/WindowFunction.h
@@ -12,6 +12,13 @@ extern const int BAD_ARGUMENTS;
 }
 class WindowTransform;
 
+struct RowNumber
+{
+    UInt64 block = 0;
+    UInt64 row = 0;
+
+    auto operator <=>(const RowNumber &) const = default;
+};
 
 // Interface for true window functions. It's not much of an interface, they just
 // accept the guts of WindowTransform and do 'something'. Given a small number of
@@ -32,6 +39,9 @@ public:
 
     /// Is the frame type supported by this function.
     virtual bool checkWindowFrameType(const WindowTransform * /*transform*/) const { return true; }
+
+    /// In most cases, the result should be current_row or prev_frame_start.
+    virtual RowNumber firstRequiredRowInFrame(const WindowTransform * transform) const;
 };
 
 // Runtime data for computing one window function.

--- a/src/Processors/Transforms/WindowTransform.cpp
+++ b/src/Processors/Transforms/WindowTransform.cpp
@@ -1546,7 +1546,10 @@ struct WindowFunctionRank final : public StatelessWindowFunction
 
     RowNumber firstRequiredRowInFrame(const WindowTransform * transform) const override
     {
-        return transform->peer_group_start;
+        if (transform->window_description.frame.begin_type == WindowFrame::BoundaryType::Unbounded
+            && transform->window_description.frame.end_type == WindowFrame::BoundaryType::Current)
+            return transform->peer_group_start;
+        return transform->frame_start;
     }
 };
 
@@ -1569,7 +1572,10 @@ struct WindowFunctionDenseRank final : public StatelessWindowFunction
 
     RowNumber firstRequiredRowInFrame(const WindowTransform * transform) const override
     {
-        return transform->peer_group_start;
+        if (transform->window_description.frame.begin_type == WindowFrame::BoundaryType::Unbounded
+            && transform->window_description.frame.end_type == WindowFrame::BoundaryType::Current)
+            return transform->peer_group_start;
+        return transform->frame_start;
     }
 };
 
@@ -2050,8 +2056,13 @@ struct WindowFunctionRowNumber final : public StatelessWindowFunction
     RowNumber firstRequiredRowInFrame(const WindowTransform * transform) const override
     {
         /// Current block is the only one required to be kept in memory.
-        auto [row, _] = transform->moveRowNumber(transform->current_row, -1);
-        return row;
+        if (transform->window_description.frame.begin_type == WindowFrame::BoundaryType::Unbounded
+            && transform->window_description.frame.end_type == WindowFrame::BoundaryType::Current)
+        {
+            auto [row, _] = transform->moveRowNumber(transform->current_row, -1);
+            return row;
+        }
+        return transform->frame_start;
     }
 };
 

--- a/src/Processors/Transforms/WindowTransform.cpp
+++ b/src/Processors/Transforms/WindowTransform.cpp
@@ -1522,8 +1522,8 @@ void WindowTransform::work()
         first_block_number = first_used_block;
 
         assert(next_output_block_number >= first_block_number);
-        assert(frame_start.block >= first_block_number);
-        assert(prev_frame_start.block >= first_block_number);
+        // assert(frame_start.block >= first_block_number);
+        // assert(prev_frame_start.block >= first_block_number);
         assert(current_row.block >= first_block_number);
         assert(peer_group_start.block >= first_block_number);
     }

--- a/src/Processors/Transforms/WindowTransform.cpp
+++ b/src/Processors/Transforms/WindowTransform.cpp
@@ -1084,10 +1084,9 @@ void WindowTransform::writeOutCurrentRow()
 void WindowTransform::updateFirstRequiredRow()
 {
     first_required_row = current_row;
-    for (size_t wi = 0; wi < workspaces.size(); ++wi)
+    for (auto & ws : workspaces)
     {
         RowNumber row;
-        auto & ws = workspaces[wi];
         if (ws.window_function_impl)
             row = ws.window_function_impl->firstRequiredRowInFrame(this);
         else
@@ -1547,7 +1546,8 @@ struct WindowFunctionRank final : public StatelessWindowFunction
     RowNumber firstRequiredRowInFrame(const WindowTransform * transform) const override
     {
         /// Current block is the only one required to be kept in memory.
-        return transform->current_row;
+        auto [row, _] = transform->moveRowNumber(transform->current_row, -1);
+        return row;
     }
 };
 
@@ -1571,7 +1571,8 @@ struct WindowFunctionDenseRank final : public StatelessWindowFunction
     RowNumber firstRequiredRowInFrame(const WindowTransform * transform) const override
     {
         /// Current block is the only one required to be kept in memory.
-        return transform->current_row;
+        auto [row, _] = transform->moveRowNumber(transform->current_row, -1);
+        return row;
     }
 };
 
@@ -2052,7 +2053,8 @@ struct WindowFunctionRowNumber final : public StatelessWindowFunction
     RowNumber firstRequiredRowInFrame(const WindowTransform * transform) const override
     {
         /// Current block is the only one required to be kept in memory.
-        return transform->current_row;
+        auto [row, _] = transform->moveRowNumber(transform->current_row, -1);
+        return row;
     }
 };
 

--- a/src/Processors/Transforms/WindowTransform.cpp
+++ b/src/Processors/Transforms/WindowTransform.cpp
@@ -1513,8 +1513,7 @@ void WindowTransform::work()
     // (e.g. EXCLUDE CURRENT ROW), so we have to check both.
     updateFirstRequiredRow();
     assert(prev_frame_start <= frame_start);
-    const auto first_used_block = std::min(next_output_block_number,
-        std::min(first_required_row.block, current_row.block));
+    const auto first_used_block = std::min({next_output_block_number, first_required_row.block, current_row.block});
     if (first_block_number < first_used_block)
     {
         blocks.erase(blocks.begin(),

--- a/src/Processors/Transforms/WindowTransform.cpp
+++ b/src/Processors/Transforms/WindowTransform.cpp
@@ -1548,9 +1548,7 @@ struct WindowFunctionRank final : public StatelessWindowFunction
 
     RowNumber firstRequiredRowInFrame(const WindowTransform * transform) const override
     {
-        /// Current block is the only one required to be kept in memory.
-        auto [row, _] = transform->moveRowNumber(transform->current_row, -1);
-        return row;
+        return transform->peer_group_start;
     }
 };
 
@@ -1573,9 +1571,7 @@ struct WindowFunctionDenseRank final : public StatelessWindowFunction
 
     RowNumber firstRequiredRowInFrame(const WindowTransform * transform) const override
     {
-        /// Current block is the only one required to be kept in memory.
-        auto [row, _] = transform->moveRowNumber(transform->current_row, -1);
-        return row;
+        return transform->peer_group_start;
     }
 };
 

--- a/src/Processors/Transforms/WindowTransform.cpp
+++ b/src/Processors/Transforms/WindowTransform.cpp
@@ -1095,10 +1095,10 @@ void WindowTransform::updateFirstRequiredRow()
         else
         {
             /// For aggregate functions, if the start bound is preceding unbounded, blocks before
-            /// the current row are no longer in use, just only need to add the current row to the
-            /// same aggregation state.
+            /// the current row are no longer in use. peer_group_start may be used by other
+            /// functions
             if (window_description.frame.begin_type == WindowFrame::BoundaryType::Unbounded)
-                row = current_row;
+                row = peer_group_start;
             else
                 row = prev_frame_start;
         }
@@ -1522,8 +1522,6 @@ void WindowTransform::work()
         first_block_number = first_used_block;
 
         assert(next_output_block_number >= first_block_number);
-        // assert(frame_start.block >= first_block_number);
-        // assert(prev_frame_start.block >= first_block_number);
         assert(current_row.block >= first_block_number);
         assert(peer_group_start.block >= first_block_number);
     }

--- a/src/Processors/Transforms/WindowTransform.h
+++ b/src/Processors/Transforms/WindowTransform.h
@@ -94,7 +94,7 @@ public:
 
     void updateAggregationState();
     void writeOutCurrentRow();
-    void updateMiniRequiredRow();
+    void updateFirstRequiredRow();
 
     Columns & inputAt(const RowNumber & x)
     {
@@ -306,8 +306,8 @@ public:
     RowNumber prev_frame_start;
     RowNumber prev_frame_end;
 
-    /// Used to release blocks safely.
-    RowNumber mini_required_row;
+    /// Rows before this can be dropped safely.
+    RowNumber first_required_row;
 
     // Comparison function for RANGE OFFSET frames. We choose the appropriate
     // overload once, based on the type of the ORDER BY column. Choosing it for

--- a/src/Processors/Transforms/WindowTransform.h
+++ b/src/Processors/Transforms/WindowTransform.h
@@ -307,7 +307,7 @@ public:
     RowNumber prev_frame_end;
 
     /// Used to release blocks safely.
-    RowNumber mini_required_row; 
+    RowNumber mini_required_row;
 
     // Comparison function for RANGE OFFSET frames. We choose the appropriate
     // overload once, based on the type of the ORDER BY column. Choosing it for

--- a/src/Processors/Transforms/WindowTransform.h
+++ b/src/Processors/Transforms/WindowTransform.h
@@ -33,15 +33,6 @@ struct WindowTransformBlock
     size_t rows = 0;
 };
 
-struct RowNumber
-{
-    UInt64 block = 0;
-    UInt64 row = 0;
-
-    auto operator <=>(const RowNumber &) const = default;
-};
-
-
 /* Computes several window functions that share the same window. The input must
  * be sorted by PARTITION BY (in any order), then by ORDER BY.
  * We need to track the following pointers:
@@ -103,6 +94,7 @@ public:
 
     void updateAggregationState();
     void writeOutCurrentRow();
+    void updateMiniRequiredRow();
 
     Columns & inputAt(const RowNumber & x)
     {
@@ -313,6 +305,9 @@ public:
     // state after we find the new frame.
     RowNumber prev_frame_start;
     RowNumber prev_frame_end;
+
+    /// Used to release blocks safely.
+    RowNumber mini_required_row; 
 
     // Comparison function for RANGE OFFSET frames. We choose the appropriate
     // overload once, based on the type of the ORDER BY column. Choosing it for

--- a/tests/queries/0_stateless/03270_window_memory_check.sql
+++ b/tests/queries/0_stateless/03270_window_memory_check.sql
@@ -1,0 +1,40 @@
+-- A test for #65647 that reduces the memory usage of some window functions.
+-- without the optimization, about 174 MiB is used.
+SELECT
+    x,
+    row_number() OVER (PARTITION BY x ORDER BY y ASC)
+FROM
+(
+    SELECT
+        number % 1 AS x,
+        number AS y
+    FROM numbers(10000000)
+)
+FORMAT `null`
+SETTINGS max_threads = 1, max_memory_usage = 104857600;
+
+SELECT
+    x,
+    rank() OVER (PARTITION BY x ORDER BY y ASC)
+FROM
+(
+    SELECT
+        number % 1 AS x,
+        number AS y
+    FROM numbers(10000000)
+)
+FORMAT `null`
+SETTINGS max_threads = 1, max_memory_usage = 104857600;
+
+SELECT
+    x,
+    dense_rank() OVER (PARTITION BY x ORDER BY y ASC)
+FROM
+(
+    SELECT
+        number % 1 AS x,
+        number AS y
+    FROM numbers(10000000)
+)
+FORMAT `null`
+SETTINGS max_threads = 1, max_memory_usage = 104857600;

--- a/tests/queries/0_stateless/03270_window_memory_check.sql
+++ b/tests/queries/0_stateless/03270_window_memory_check.sql
@@ -11,7 +11,7 @@ FROM
     FROM numbers(10000000)
 )
 FORMAT `null`
-SETTINGS max_threads = 1, max_memory_usage = 104857600;
+SETTINGS max_threads = 1, max_memory_usage = 125829120;
 
 SELECT
     x,
@@ -24,7 +24,7 @@ FROM
     FROM numbers(10000000)
 )
 FORMAT `null`
-SETTINGS max_threads = 1, max_memory_usage = 104857600;
+SETTINGS max_threads = 1, max_memory_usage = 125829120;
 
 SELECT
     x,
@@ -37,4 +37,4 @@ FROM
     FROM numbers(10000000)
 )
 FORMAT `null`
-SETTINGS max_threads = 1, max_memory_usage = 104857600;
+SETTINGS max_threads = 1, max_memory_usage = 125829120;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement




### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Drop blocks as early as possible to reduce the memory requirements.

For `row` and `xxxrank`, the window begin frame is unbouned at default. If the the partition is too large, it's too easy to cause OOM.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
