### PR TITLE
Fix inconsistent AST formatting when a keyword is used as type name

### DIFF
--- a/src/Parsers/ParserCreateQuery.h
+++ b/src/Parsers/ParserCreateQuery.h
@@ -213,6 +213,7 @@ bool IParserColumnDeclaration<NameParser>::parseImpl(Pos & pos, ASTPtr & node, E
         return res;
     };
 
+    /// Keep this list of keywords in sync with ParserDataType::parseImpl().
     if (!null_check_without_moving()
         && !s_default.checkWithoutMoving(pos, expected)
         && !s_materialized.checkWithoutMoving(pos, expected)

--- a/tests/queries/0_stateless/01559_misplaced_codec_diagnostics.reference
+++ b/tests/queries/0_stateless/01559_misplaced_codec_diagnostics.reference
@@ -1,1 +1,0 @@
-Unknown data type family: CODEC

--- a/tests/queries/0_stateless/01559_misplaced_codec_diagnostics.sh
+++ b/tests/queries/0_stateless/01559_misplaced_codec_diagnostics.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
-# shellcheck source=../shell_config.sh
-. "$CURDIR"/../shell_config.sh
-
-${CLICKHOUSE_CLIENT} --query "CREATE TABLE t (c CODEC(NONE)) ENGINE = Memory" 2>&1 | grep -oF 'Unknown data type family: CODEC' | uniq

--- a/tests/queries/0_stateless/01559_misplaced_codec_diagnostics.sql
+++ b/tests/queries/0_stateless/01559_misplaced_codec_diagnostics.sql
@@ -1,0 +1,1 @@
+CREATE TABLE t (c CODEC(NONE)) ENGINE = Memory -- { clientError SYNTAX_ERROR }

--- a/tests/queries/0_stateless/02302_column_decl_null_before_defaul_value.sql
+++ b/tests/queries/0_stateless/02302_column_decl_null_before_defaul_value.sql
@@ -56,6 +56,6 @@ ALTER TABLE null_before ALTER COLUMN id TYPE INT NULL; -- { clientError SYNTAX_E
 select 'modify column, NULL modifier is not allowed';
 DROP TABLE IF EXISTS null_before SYNC;
 CREATE TABLE null_before (id INT NOT NULL) ENGINE=MergeTree() ORDER BY tuple();
-ALTER TABLE null_before MODIFY COLUMN id NULL DEFAULT 1; -- { serverError UNKNOWN_TYPE }
+ALTER TABLE null_before MODIFY COLUMN id NULL DEFAULT 1; -- { clientError SYNTAX_ERROR }
 
 DROP TABLE IF EXISTS null_before SYNC;

--- a/tests/queries/0_stateless/03168_inconsistent_ast_formatting.sql
+++ b/tests/queries/0_stateless/03168_inconsistent_ast_formatting.sql
@@ -1,0 +1,4 @@
+create table a (x `Null`); -- { clientError SYNTAX_ERROR }
+create table a (x f(`Null`)); -- { clientError SYNTAX_ERROR }
+create table a (x Enum8(f(`Null`, 'World', 2))); -- { clientError SYNTAX_ERROR }
+create table a (`value2` Enum8('Hello' = 1, equals(`Null`, 'World', 2), '!' = 3)); -- { clientError SYNTAX_ERROR }


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

https://s3.amazonaws.com/clickhouse-test-reports/58934/8b510a67f957c2373f4126d2884614ff7066f1b5/ast_fuzzer__debug_.html

```
create table a (x `Null`)
```
gets formatted as `create table a (x Null)`, which is then parsed as `create table a (x NULL)` (NULL interpreted as column attribute, as in `x Int8 NULL`). This PR checks the type name for for keywords, so the first query fails to parse.