### PR TITLE
[Docs] add `displayName` to docs

### DIFF
--- a/docs/en/sql-reference/functions/other-functions.md
+++ b/docs/en/sql-reference/functions/other-functions.md
@@ -3820,3 +3820,43 @@ Result:
 10. │ df │                       │
     └────┴───────────────────────┘
 ```
+
+## displayName
+
+Returns the value of `display_name` from [config](../../operations/configuration-files.md/#configuration-files) or server Fully Qualified Domain Name (FQDN) if not set.
+
+**Syntax**
+
+```sql
+displayName()
+```
+
+**Returned value**
+
+- Value of `display_name` from config or server FQDN if not set. [String](../data-types/string.md).
+
+**Example**
+
+The `display_name` can be set in `config.xml`. Taking for example a server with `display_name` configured to 'production': 
+
+```xml
+<!-- It is the name that will be shown in the clickhouse-client.
+     By default, anything with "production" will be highlighted in red in query prompt.
+-->
+<display_name>production</display_name>
+```
+
+Query:
+
+```sql
+SELECT displayName();
+```
+
+Result:
+
+```response
+┌─displayName()─┐
+│ production    │
+└───────────────┘
+```
+

--- a/utils/check-style/aspell-ignore/en/aspell-dict.txt
+++ b/utils/check-style/aspell-ignore/en/aspell-dict.txt
@@ -1526,6 +1526,7 @@ disableProtocols
 disjunction
 disjunctions
 displaySecretsInShowAndSelect
+displayName
 distro
 divideDecimal
 dmesg


### PR DESCRIPTION
Closes [#1945](https://github.com/ClickHouse/clickhouse-docs/issues/1945) as part of the [project](https://github.com/ClickHouse/clickhouse-docs/issues/1833) to document missing functions.

Adds:
- `displayName` to other-functions.
   
### Changelog category (leave one):
- Documentation (changelog entry is not required)