### PR TITLE
[Docs] add missing function `protocol` to docs

### DIFF
--- a/docs/en/sql-reference/functions/url-functions.md
+++ b/docs/en/sql-reference/functions/url-functions.md
@@ -818,6 +818,40 @@ The same as above, but including query string and fragment.
 
 Example: `/top/news.html?page=2#comments`.
 
+### protocol
+
+Extracts the protocol from a URL. 
+
+**Syntax**
+
+```sql
+protocol(url)
+```
+
+**Arguments**
+
+- `url` — URL to extract protocol from. [String](../data-types/string.md).
+
+**Returned value**
+
+- Protocol, or an empty string if it cannot be determined. [String](../data-types/string.md).
+
+**Example**
+
+Query:
+
+```sql
+SELECT protocol('https://clickhouse.com/');
+```
+
+Result:
+
+```response
+┌─protocol('https://clickhouse.com/')─┐
+│ https                               │
+└─────────────────────────────────────┘
+```
+
 ### queryString
 
 Returns the query string without the initial question mark, `#` and everything after `#`.

--- a/utils/check-style/aspell-ignore/en/aspell-dict.txt
+++ b/utils/check-style/aspell-ignore/en/aspell-dict.txt
@@ -2257,6 +2257,7 @@ proleptic
 prometheus
 proportionsZTest
 proto
+protocol
 protobuf
 protobufsingle
 proxied


### PR DESCRIPTION
Adds missing `protocol` function to docs. Closes [#1997](https://github.com/ClickHouse/clickhouse-docs/issues/1997) as part of the [project](https://github.com/ClickHouse/clickhouse-docs/issues/1833) to document missing functions. 

### Changelog category (leave one):
- Documentation (changelog entry is not required)
