### PR TITLE
Update 03002_part_log_rmt_fetch_mutate_error.sql

### DIFF
--- a/tests/queries/0_stateless/03002_part_log_rmt_fetch_mutate_error.sql
+++ b/tests/queries/0_stateless/03002_part_log_rmt_fetch_mutate_error.sql
@@ -4,9 +4,9 @@
 drop table if exists rmt_master;
 drop table if exists rmt_slave;
 
-create table rmt_master (key Int) engine=ReplicatedMergeTree('/clickhouse/{database}', 'master') order by tuple() settings always_fetch_merged_part=0;
+create table rmt_master (key Int) engine=ReplicatedMergeTree('/clickhouse/{database}', 'master') order by tuple() settings always_fetch_merged_part=0, old_parts_lifetime=600;
 -- prefer_fetch_merged_part_*_threshold=0, consider this table as a "slave"
-create table rmt_slave (key Int) engine=ReplicatedMergeTree('/clickhouse/{database}', 'slave') order by tuple() settings prefer_fetch_merged_part_time_threshold=0, prefer_fetch_merged_part_size_threshold=0;
+create table rmt_slave (key Int) engine=ReplicatedMergeTree('/clickhouse/{database}', 'slave') order by tuple() settings prefer_fetch_merged_part_time_threshold=0, prefer_fetch_merged_part_size_threshold=0, old_parts_lifetime=600;
 
 insert into rmt_master values (1);
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
```
2024-06-26 13:45:09 03002_part_log_rmt_fetch_mutate_error:                                  [ FAIL ] 51.42 sec. - result differs with reference: 
2024-06-26 13:45:09 --- /usr/share/clickhouse-test/queries/0_stateless/03002_part_log_rmt_fetch_mutate_error.reference	2024-06-26 12:29:51.655116830 +0900
2024-06-26 13:45:09 +++ /tmp/clickhouse-test/0_stateless/03002_part_log_rmt_fetch_mutate_error.stdout	2024-06-26 13:45:09.084816669 +0900
2024-06-26 13:45:09 @@ -5,6 +5,7 @@
2024-06-26 13:45:09  rmt_slave	MutatePart	1	0
2024-06-26 13:45:09  after
2024-06-26 13:45:09  rmt_master	NewPart	0	1
2024-06-26 13:45:09 +rmt_master	RemovePart	0	1
2024-06-26 13:45:09  rmt_master	MutatePart	0	1
2024-06-26 13:45:09  rmt_slave	DownloadPart	0	2
2024-06-26 13:45:09  rmt_slave	MutatePart	1	0
2024-06-26 13:45:09 
2024-06-26 13:45:09 
2024-06-26 13:45:09 Settings used in the test: --max_insert_threads 1 --group_by_two_level_threshold 700414 --group_by_two_level_threshold_bytes 30176464 --distributed_aggregation_memory_efficient 1 --fsync_metadata 0 --output_format_parallel_formatting 0 --input_format_parallel_parsing 1 --min_chunk_bytes_for_parallel_parsing 13996834 --max_read_buffer_size 722211 --prefer_localhost_replica 1 --max_block_size 22729 --max_joined_block_size_rows 32926 --max_threads 2 --optimize_append_index 0 --optimize_if_chain_to_multiif 0 --optimize_if_transform_strings_to_enum 0 --optimize_read_in_order 0 --optimize_or_like_chain 1 --optimize_substitute_columns 1 --enable_multiple_prewhere_read_steps 1 --read_in_order_two_level_merge_threshold 35 --optimize_aggregation_in_order 1 --aggregation_in_order_max_block_bytes 40080862 --use_uncompressed_cache 1 --min_bytes_to_use_direct_io 1 --min_bytes_to_use_mmap_io 10737418240 --local_filesystem_read_method pread --remote_filesystem_read_method read --local_filesystem_read_prefetch 0 --filesystem_cache_segments_batch_size 10 --read_from_filesystem_cache_if_exists_otherwise_bypass_cache 0 --throw_on_error_from_cache_on_write_operations 1 --remote_filesystem_read_prefetch 0 --allow_prefetched_read_pool_for_remote_filesystem 0 --filesystem_prefetch_max_memory_usage 64Mi --filesystem_prefetches_limit 10 --filesystem_prefetch_min_bytes_for_single_read_task 1Mi --filesystem_prefetch_step_marks 0 --filesystem_prefetch_step_bytes 100Mi --compile_aggregate_expressions 0 --compile_sort_description 0 --merge_tree_coarse_index_granularity 32 --optimize_distinct_in_order 1 --max_bytes_before_external_sort 10737418240 --max_bytes_before_external_group_by 10737418240 --max_bytes_before_remerge_sort 2664753463 --min_compress_block_size 2151228 --max_compress_block_size 799484 --merge_tree_compact_parts_min_granules_to_multibuffer_read 52 --optimize_sorting_by_input_stream_properties 0 --http_response_buffer_size 6030228 --http_wait_end_of_query True --enable_memory_bound_merging_of_aggregation_results 1 --min_count_to_compile_expression 0 --min_count_to_compile_aggregate_expression 0 --min_count_to_compile_sort_description 3 --session_timezone Africa/Juba --prefer_warmed_unmerged_parts_seconds 8 --use_page_cache_for_disks_without_file_cache True --page_cache_inject_eviction False --merge_tree_read_split_ranges_into_intersecting_and_non_intersecting_injection_probability 0.18 --prefer_external_sort_block_bytes 100000000 --cross_join_min_rows_to_compress 0 --cross_join_min_bytes_to_compress 100000000 --min_external_table_block_size_bytes 100000000 --max_parsing_threads 0
2024-06-26 13:45:09 
2024-06-26 13:45:09 MergeTree settings used in test: --ratio_of_defaults_for_sparse_serialization 1.0 --prefer_fetch_merged_part_size_threshold 10737418240 --vertical_merge_algorithm_min_rows_to_activate 1 --vertical_merge_algorithm_min_columns_to_activate 21 --allow_vertical_merges_from_compact_to_wide_parts 0 --min_merge_bytes_to_use_direct_io 1 --index_granularity_bytes 17154513 --merge_max_block_size 19031 --index_granularity 17987 --min_bytes_for_wide_part 0 --marks_compress_block_size 28742 --primary_key_compress_block_size 29998 --replace_long_file_name_to_hash 1 --max_file_name_length 128 --min_bytes_for_full_part_storage 0 --compact_parts_max_bytes_to_buffer 227313519 --compact_parts_max_granules_to_buffer 140 --compact_parts_merge_max_bytes_to_prefetch_part 8983102 --cache_populated_by_fetch 0 --concurrent_part_removal_threshold 100 --old_parts_lifetime 10
```
### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [x] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
