### PR TITLE
Prevent 03172_error_log_table_not_empty from running in parallel

### DIFF
--- a/tests/queries/0_stateless/03172_error_log_table_not_empty.sh
+++ b/tests/queries/0_stateless/03172_error_log_table_not_empty.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Tags: no-parallel
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh


### PR DESCRIPTION
Prevent 03172_error_log_table_not_empty from running in parallel

As per [this comment](https://github.com/ClickHouse/ClickHouse/pull/65604#issuecomment-2191345008), we'd rather prevent this test from running in parallel. As it was before this change we didn't have false negatives, but we may have false positives if another parallel test throws errors `111`, `222` or `333`. 

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)