### PR TITLE
fix ODBC table with nullable fields

### DIFF
--- a/tests/integration/test_odbc_interaction/test.py
+++ b/tests/integration/test_odbc_interaction/test.py
@@ -40,6 +40,16 @@ create_table_sql_template = """
     PRIMARY KEY (`id`)) ENGINE=InnoDB;
     """
 
+create_table_sql_nullable_template = """
+    CREATE TABLE `clickhouse`.`{}` (
+        `id`   integer not null,
+        `col1` integer,
+        `col2` decimal(15,10),
+        `col3` varchar(32),
+        `col4` datetime
+        )
+    """
+
 
 def skip_test_msan(instance):
     if instance.is_built_with_memory_sanitizer():
@@ -75,6 +85,11 @@ def create_mysql_db(conn, name):
     with conn.cursor() as cursor:
         cursor.execute("DROP DATABASE IF EXISTS {}".format(name))
         cursor.execute("CREATE DATABASE {} DEFAULT CHARACTER SET 'utf8'".format(name))
+
+
+def create_mysql_nullable_table(conn, table_name):
+    with conn.cursor() as cursor:
+        cursor.execute(create_table_sql_nullable_template.format(table_name))
 
 
 def create_mysql_table(conn, table_name):
@@ -190,6 +205,46 @@ def started_cluster():
         raise ex
     finally:
         cluster.shutdown()
+
+
+def test_mysql_odbc_select_nullable(started_cluster):
+    skip_test_msan(node1)
+    mysql_setup = node1.odbc_drivers["MySQL"]
+
+    table_name = "test_insert_nullable_select"
+    conn = get_mysql_conn()
+    create_mysql_nullable_table(conn, table_name)
+    with conn.cursor() as cursor:
+        cursor.execute(
+            "INSERT INTO clickhouse.{} VALUES(1, 1, 1.23456, 'data1', '2010-01-01 00:00:00');".format(
+                table_name
+            )
+        )
+        cursor.execute(
+            "INSERT INTO clickhouse.{} VALUES(2, NULL, NULL, NULL, NULL);".format(
+                table_name
+            )
+        )
+        conn.commit()
+
+    node1.query(
+        """
+        CREATE TABLE {}(id UInt32, col1 Nullable(UInt32), col2 Nullable(Decimal(15, 10)), col3 Nullable(String), col4 Nullable(DateTime)) ENGINE = ODBC('DSN={}', 'clickhouse', '{}');
+        """.format(
+            table_name, mysql_setup["DSN"], table_name
+        )
+    )
+
+    assert (
+        node1.query(
+            "SELECT id, col1, col2, col3, col4 from {} order by id asc".format(
+                table_name
+            )
+        )
+        == "1\t1\t1.23456\tdata1\t2010-01-01 00:00:00\n2\t\\N\t\\N\t\\N\t\\N\n"
+    )
+    drop_mysql_table(conn, table_name)
+    conn.close()
 
 
 def test_mysql_simple_select_works(started_cluster):


### PR DESCRIPTION
unable to do a select on an external table with ODBC engine and nullable field
it gives the following error : 

`Code: 49. DB::Exception: Too large size (18446464152236284704)`

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
fix ODBC table with nullable fields


#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
