### PR TITLE
Try to fix flaky `02265_column_ttl`

### DIFF
--- a/tests/queries/0_stateless/02265_column_ttl.sql
+++ b/tests/queries/0_stateless/02265_column_ttl.sql
@@ -16,7 +16,8 @@ insert into ttl_02265 values ('2010-01-01', 2010, 'foo');
 optimize table ttl_02265 final;
 -- after, 20100101_0_0_2 will not have ttl.txt, but will have value.bin
 optimize table ttl_02265 final;
-system sync replica ttl_02265;
+system sync replica ttl_02265 STRICT;
+system sync replica ttl_02265_r2 STRICT;
 
 -- after detach/attach it will not have TTL in-memory, and will not have ttl.txt
 detach table ttl_02265;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Fix flaky `02265_column_ttl`. Closes #65719.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

I think the issue happens because r2 tries to fetch a part from r1 sometimes when r1 is already detached.

```
2024.06.20 01:49:05.072481 [ 11247 ] {b241c9ec-8c05-46ae-9738-9da9a8af5df5} <Debug> executeQuery: (from [::1]:46194) (comment: 02265_column_ttl.sql) -- after detach/attach it will not have TTL in-memory, and will not have ttl.txt
 detach table ttl_02265; (stage: Complete)
2024.06.20 01:49:05.073954 [ 11247 ] {b241c9ec-8c05-46ae-9738-9da9a8af5df5} <Information> test_x7xf7wef.ttl_02265 (a62df72b-67d0-4921-9d6f-fa7995f76078): Stopped being leader
2024.06.20 01:49:05.074262 [ 11247 ] {b241c9ec-8c05-46ae-9738-9da9a8af5df5} <Trace> test_x7xf7wef.ttl_02265 (ReplicatedMergeTreeRestartingThread): Restarting thread finished
2024.06.20 01:49:05.076772 [ 11247 ] {b241c9ec-8c05-46ae-9738-9da9a8af5df5} <Trace> test_x7xf7wef.ttl_02265 (a62df72b-67d0-4921-9d6f-fa7995f76078): Will not wait for unique parts to be fetched by other replicas because shutdown called from DROP/DETACH query
2024.06.20 01:49:05.080061 [ 11247 ] {b241c9ec-8c05-46ae-9738-9da9a8af5df5} <Trace> test_x7xf7wef.ttl_02265 (a62df72b-67d0-4921-9d6f-fa7995f76078): Waiting for threads to finish
2024.06.20 01:49:05.080733 [ 11247 ] {b241c9ec-8c05-46ae-9738-9da9a8af5df5} <Trace> test_x7xf7wef.ttl_02265 (a62df72b-67d0-4921-9d6f-fa7995f76078): Threads finished
2024.06.20 01:49:05.080941 [ 11247 ] {b241c9ec-8c05-46ae-9738-9da9a8af5df5} <Trace> test_x7xf7wef.ttl_02265 (PartMovesBetweenShardsOrchestrator): PartMovesBetweenShardsOrchestrator thread finished
2024.06.20 01:49:05.081359 [ 11247 ] {b241c9ec-8c05-46ae-9738-9da9a8af5df5} <Debug> DatabaseAtomic (test_x7xf7wef): There are 1 detached tables. Start searching non used tables.
2024.06.20 01:49:05.081619 [ 11247 ] {b241c9ec-8c05-46ae-9738-9da9a8af5df5} <Debug> DatabaseAtomic (test_x7xf7wef): Found 0 non used tables in detached tables.
2024.06.20 01:49:05.082076 [ 11247 ] {b241c9ec-8c05-46ae-9738-9da9a8af5df5} <Debug> DatabaseAtomic (test_x7xf7wef): There are 1 detached tables. Start searching non used tables.
2024.06.20 01:49:05.082347 [ 11247 ] {b241c9ec-8c05-46ae-9738-9da9a8af5df5} <Debug> DatabaseAtomic (test_x7xf7wef): Found 1 non used tables in detached tables.

2024.06.20 01:49:05.190761 [ 11199 ] {} <Error> InterserverIOHTTPHandler: Code: 221. DB::Exception: No interserver IO endpoint named DataPartsExchange:default:/clickhouse/tables/test_x7xf7wef/ttl_02265/replicas/r1. (NO_SUCH_INTERSERVER_IO_ENDPOINT), Stack trace (when copying this message, always include the lines below):
2024.06.20 01:49:05.205825 [ 1565 ] {} <Debug> ReadWriteBufferFromHTTP: Failed to make request to 'http://ee3b0eedc531:9009/?endpoint=DataPartsExchange%3Adefault%3A%2Fclickhouse%2Ftables%2Ftest_x7xf7wef%2Fttl_02265%2Freplicas%2Fr1&part=20100101_1_1_2&client_protocol_version=8&compress=false&remote_fs_metadata=s3' redirect to 'http://ee3b0eedc531:9009/?endpoint=DataPartsExchange%3Adefault%3A%2Fclickhouse%2Ftables%2Ftest_x7xf7wef%2Fttl_02265%2Freplicas%2Fr1&part=20100101_1_1_2&client_protocol_version=8&compress=false&remote_fs_metadata=s3'. Error: 'DB::HTTPException: Received error from remote server http://ee3b0eedc531:9009/?endpoint=DataPartsExchange%3Adefault%3A%2Fclickhouse%2Ftables%2Ftest_x7xf7wef%2Fttl_02265%2Freplicas%2Fr1&part=20100101_1_1_2&client_protocol_version=8&compress=false&remote_fs_metadata=s3. HTTP status code: 500 Internal Server Error, body: Code: 221. DB::Exception: No interserver IO endpoint named DataPartsExchange:default:/clickhouse/tables/test_x7xf7wef/ttl_02265/replicas/r1. (NO_SUCH_INTERSERVER_IO_ENDPOINT), Stack trace (when copying this message, always include the lines below):
```

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
