### PR TITLE
PostgreSQL source support cancel query

### DIFF
--- a/src/Processors/Sources/PostgreSQLSource.cpp
+++ b/src/Processors/Sources/PostgreSQLSource.cpp
@@ -191,6 +191,12 @@ PostgreSQLSource<T>::~PostgreSQLSource()
     {
         try
         {
+            if (stream)
+            {
+                tx->conn().cancel_query();
+                stream->close();
+            }
+
             stream.reset();
             tx.reset();
         }


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
For queries that read from `PostgreSQL`, cancel the internal `PostgreSQL` query if the ClickHouse query is finished. Otherwise, `ClickHouse` query cannot be canceled until the internal `PostgreSQL` query is finished.
