### PR TITLE
Forbid join algorithm randomisation for 03094_one_thousand_joins

### DIFF
--- a/tests/queries/0_stateless/03094_one_thousand_joins.sql
+++ b/tests/queries/0_stateless/03094_one_thousand_joins.sql
@@ -1,6 +1,7 @@
 -- Tags: no-fasttest, no-tsan, long
 -- (no-tsan because it has a small maximum stack size and the test would fail with TOO_DEEP_RECURSION)
 
+SET join_algorithm = 'default'; -- for 'full_sorting_merge' the query is 10x slower
 SET allow_experimental_analyzer = 1; -- old analyzer returns TOO_DEEP_SUBQUERIES
 
 -- Bug 33446, marked as 'long' because it still runs around 10 sec


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


https://s3.amazonaws.com/clickhouse-test-reports/65687/38395d031ee4235052c64b088f6344de89a39219/stress_test__debug_/hung_check.log