### PR TITLE
Fix 02931_rewrite_sum_column_and_constant flakiness

### DIFF
--- a/tests/queries/0_stateless/02931_rewrite_sum_column_and_constant.reference
+++ b/tests/queries/0_stateless/02931_rewrite_sum_column_and_constant.reference
@@ -245,21 +245,21 @@ EXPLAIN SYNTAX (SELECT 2 * count(uint64) - sum(uint64) From test_table);
 SELECT (2 * count(uint64)) - sum(uint64)
 FROM test_table
 SELECT sum(float64 + 2) From test_table;
-26.5
+26.875
 SELECT sum(2 + float64) From test_table;
-26.5
+26.875
 SELECT sum(float64 - 2) From test_table;
-6.5
+6.875
 SELECT sum(2 - float64) From test_table;
--6.5
+-6.875
 SELECT sum(float64) + 2 * count(float64) From test_table;
-26.5
+26.875
 SELECT 2 * count(float64) + sum(float64) From test_table;
-26.5
+26.875
 SELECT sum(float64) - 2 * count(float64) From test_table;
-6.5
+6.875
 SELECT 2 * count(float64) - sum(float64) From test_table;
--6.5
+-6.875
 EXPLAIN SYNTAX (SELECT sum(float64 + 2) From test_table);
 SELECT sum(float64) + (2 * count(float64))
 FROM test_table
@@ -375,25 +375,25 @@ EXPLAIN SYNTAX (SELECT (2 * count(uint64) - sum(uint64)) + (3 * count(uint64) - 
 SELECT ((2 * count(uint64)) - sum(uint64)) + ((3 * count(uint64)) - sum(uint64))
 FROM test_table
 SELECT sum(float64 + 2) + sum(float64 + 3) From test_table;
-58
+58.75
 SELECT sum(float64 + 2) - sum(float64 + 3) From test_table;
 -5
 SELECT sum(float64 - 2) + sum(float64 - 3) From test_table;
-8
+8.75
 SELECT sum(float64 - 2) - sum(float64 - 3) From test_table;
 5
 SELECT sum(2 - float64) - sum(3 - float64) From test_table;
 -5
 SELECT (sum(float64) + 2 * count(float64)) + (sum(float64) + 3 * count(float64)) From test_table;
-58
+58.75
 SELECT (sum(float64) + 2 * count(float64)) - (sum(float64) + 3 * count(float64)) From test_table;
 -5
 SELECT (sum(float64) - 2 * count(float64)) + (sum(float64) - 3 * count(float64)) From test_table;
-8
+8.75
 SELECT (sum(float64) - 2 * count(float64)) - (sum(float64) - 3 * count(float64)) From test_table;
 5
 SELECT (2 * count(float64) - sum(float64)) + (3 * count(float64) - sum(float64)) From test_table;
--8
+-8.75
 EXPLAIN SYNTAX (SELECT sum(float64 + 2) + sum(float64 + 3) From test_table);
 SELECT (sum(float64) + (2 * count(float64))) + (sum(float64) + (3 * count(float64)))
 FROM test_table

--- a/tests/queries/0_stateless/02931_rewrite_sum_column_and_constant.sql
+++ b/tests/queries/0_stateless/02931_rewrite_sum_column_and_constant.sql
@@ -23,11 +23,12 @@ CREATE TABLE test_table
     decimal32 Decimal32(5),
 ) ENGINE=MergeTree ORDER BY uint64;
 
-INSERT INTO test_table VALUES (1, 1.1, 1.11);
-INSERT INTO test_table VALUES (2, 2.2, 2.22);
-INSERT INTO test_table VALUES (3, 3.3, 3.33);
-INSERT INTO test_table VALUES (4, 4.4, 4.44);
-INSERT INTO test_table VALUES (5, 5.5, 5.55);
+-- Use Float64 numbers divisible by 1/16 (or some other small power of two), so that their sum doesn't depend on summation order.
+INSERT INTO test_table VALUES (1, 1.125, 1.11);
+INSERT INTO test_table VALUES (2, 2.250, 2.22);
+INSERT INTO test_table VALUES (3, 3.375, 3.33);
+INSERT INTO test_table VALUES (4, 4.500, 4.44);
+INSERT INTO test_table VALUES (5, 5.625, 5.55);
 
 -- { echoOn }
 SELECT sum(uint64 + 1 AS i) from test_table where i > 0;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Failed like this: https://s3.amazonaws.com/clickhouse-test-reports/61750/0990a820890b4ca19537907361530577a0697d7d/stateless_tests__aarch64_.html
```
2024-06-26 10:05:46  SELECT sum(float64) + 2 * count(float64) From test_table;
2024-06-26 10:05:46 -26.5
2024-06-26 10:05:46 +26.500000000000004
```
This is possible if the summation was reordered:
```
% python3 -c 'print(1.1 + 2.2 + 3.3 + 4.4 + 5.5 + 10, 10.0 + 1.1 + 2.2 + 4.4 + 3.3 + 5.5)'
26.5 26.500000000000004
```

I'm assuming the test didn't intend to check the order of summation. This PR changes the numbers such that their sum doesn't depend on order.