### PR TITLE
Allow to use `concat` function with empty arguments 

### DIFF
--- a/docs/en/sql-reference/functions/string-functions.md
+++ b/docs/en/sql-reference/functions/string-functions.md
@@ -571,7 +571,6 @@ SELECT upper('clickhouse');
 
 Converts a string to lowercase, assuming that the string contains valid UTF-8 encoded text. If this assumption is violated, no exception is thrown and the result is undefined.
 
-Does not detect the language, e.g. for Turkish the result might not be exactly correct (i/İ vs. i/I).
 
 If the length of the UTF-8 byte sequence is different for upper and lower case of a code point, the result may be incorrect for this code point.
 
@@ -579,7 +578,6 @@ If the length of the UTF-8 byte sequence is different for upper and lower case o
 
 Converts a string to uppercase, assuming that the string contains valid UTF-8 encoded text. If this assumption is violated, no exception is thrown and the result is undefined.
 
-Does not detect the language, e.g. for Turkish the result might not be exactly correct (i/İ vs. i/I).
 
 If the length of the UTF-8 byte sequence is different for upper and lower case of a code point, the result may be incorrect for this code point.
 

--- a/docs/en/sql-reference/functions/string-functions.md
+++ b/docs/en/sql-reference/functions/string-functions.md
@@ -571,6 +571,7 @@ SELECT upper('clickhouse');
 
 Converts a string to lowercase, assuming that the string contains valid UTF-8 encoded text. If this assumption is violated, no exception is thrown and the result is undefined.
 
+Does not detect the language, e.g. for Turkish the result might not be exactly correct (i/İ vs. i/I).
 
 If the length of the UTF-8 byte sequence is different for upper and lower case of a code point, the result may be incorrect for this code point.
 
@@ -734,13 +735,13 @@ concat(s1, s2, ...)
 
 **Arguments**
 
-Values of arbitrary type. Empty argument is also allowed.
+Values of arbitrary type.
 
 Arguments which are not of types [String](../data-types/string.md) or [FixedString](../data-types/fixedstring.md) are converted to strings using their default serialization. As this decreases performance, it is not recommended to use non-String/FixedString arguments.
 
 **Returned values**
 
-The String created by concatenating the arguments. If there are no arguments, the function returns empty string.
+The String created by concatenating the arguments.
 
 If any of arguments is `NULL`, the function returns `NULL`.
 

--- a/docs/en/sql-reference/functions/string-functions.md
+++ b/docs/en/sql-reference/functions/string-functions.md
@@ -734,13 +734,13 @@ concat(s1, s2, ...)
 
 **Arguments**
 
-At least one value of arbitrary type.
+Values of arbitrary type. Empty argument is also allowed.
 
 Arguments which are not of types [String](../data-types/string.md) or [FixedString](../data-types/fixedstring.md) are converted to strings using their default serialization. As this decreases performance, it is not recommended to use non-String/FixedString arguments.
 
 **Returned values**
 
-The String created by concatenating the arguments.
+The String created by concatenating the arguments. If there are no arguments, the function returns empty string.
 
 If any of arguments is `NULL`, the function returns `NULL`.
 

--- a/src/Functions/concat.cpp
+++ b/src/Functions/concat.cpp
@@ -46,25 +46,30 @@ public:
 
     DataTypePtr getReturnTypeImpl(const DataTypes & arguments) const override
     {
-        if (arguments.size() < 2)
-            throw Exception(
-                ErrorCodes::TOO_FEW_ARGUMENTS_FOR_FUNCTION,
-                "Number of arguments for function {} doesn't match: passed {}, should be at least 2",
-                getName(),
-                arguments.size());
+        if (arguments.size() == 1)
+            throw Exception(ErrorCodes::TOO_FEW_ARGUMENTS_FOR_FUNCTION, "Number of arguments for function {} should not be 1", getName());
 
         return std::make_shared<DataTypeString>();
     }
 
     ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr &, size_t input_rows_count) const override
     {
+        if (arguments.empty())
+        {
+            auto res_data = ColumnString::create();
+            res_data->insertDefault();
+            return ColumnConst::create(std::move(res_data), input_rows_count);
+        }
+        else if (arguments.size() == 1)
+            return arguments[0].column;
         /// Format function is not proven to be faster for two arguments.
         /// Actually there is overhead of 2 to 5 extra instructions for each string for checking empty strings in FormatImpl.
         /// Though, benchmarks are really close, for most examples we saw executeBinary is slightly faster (0-3%).
         /// For 3 and more arguments FormatStringImpl is much faster (up to 50-60%).
-        if (arguments.size() == 2)
+        else if (arguments.size() == 2)
             return executeBinary(arguments, input_rows_count);
-        return executeFormatImpl(arguments, input_rows_count);
+        else
+            return executeFormatImpl(arguments, input_rows_count);
     }
 
 private:
@@ -209,11 +214,11 @@ public:
     {
         if (arguments.size() == 1)
             return FunctionFactory::instance().getImpl("toString", context)->build(arguments);
-        if (std::ranges::all_of(arguments, [](const auto & elem) { return isArray(elem.type); }))
+        if (!arguments.empty() && std::ranges::all_of(arguments, [](const auto & elem) { return isArray(elem.type); }))
             return FunctionFactory::instance().getImpl("arrayConcat", context)->build(arguments);
-        if (std::ranges::all_of(arguments, [](const auto & elem) { return isMap(elem.type); }))
+        if (!arguments.empty() && std::ranges::all_of(arguments, [](const auto & elem) { return isMap(elem.type); }))
             return FunctionFactory::instance().getImpl("mapConcat", context)->build(arguments);
-        if (std::ranges::all_of(arguments, [](const auto & elem) { return isTuple(elem.type); }))
+        if (!arguments.empty() && std::ranges::all_of(arguments, [](const auto & elem) { return isTuple(elem.type); }))
             return FunctionFactory::instance().getImpl("tupleConcat", context)->build(arguments);
         return std::make_unique<FunctionToFunctionBaseAdaptor>(
             FunctionConcat::create(context),
@@ -221,15 +226,8 @@ public:
             return_type);
     }
 
-    DataTypePtr getReturnTypeImpl(const DataTypes & arguments) const override
+    DataTypePtr getReturnTypeImpl(const DataTypes &) const override
     {
-        if (arguments.empty())
-            throw Exception(
-                ErrorCodes::TOO_FEW_ARGUMENTS_FOR_FUNCTION,
-                "Number of arguments for function {} doesn't match: passed {}, should be at least 1.",
-                getName(),
-                arguments.size());
-
         /// We always return Strings from concat, even if arguments were fixed strings.
         return std::make_shared<DataTypeString>();
     }

--- a/tests/queries/0_stateless/00727_concat.reference
+++ b/tests/queries/0_stateless/00727_concat.reference
@@ -72,3 +72,6 @@ foo
 \N
 \N
 Testing the alias
+-- Empty argument tests
+
+String

--- a/tests/queries/0_stateless/00727_concat.sql
+++ b/tests/queries/0_stateless/00727_concat.sql
@@ -93,4 +93,6 @@ SELECT concat(materialize(NULL :: Nullable(UInt64)));
 
 SELECT CONCAT('Testing the ', 'alias');
 
-SELECT concat();  -- { serverError TOO_FEW_ARGUMENTS_FOR_FUNCTION }
+SELECT '-- Empty argument tests';
+SELECT concat();
+select toTypeName(concat());


### PR DESCRIPTION

### Changelog category (leave one):
- Improvement



### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Allow to use `concat` function with empty arguments 
``` sql 
:) select concat(); 

SELECT concat()

Query id: 675fdc33-e454-4ed1-bec3-686f2c7beea4

   ┌─concat()─┐
1. │          │
   └──────────┘

1 row in set. Elapsed: 0.001 sec. 
```
