### PR TITLE
Max sessions for user tests improvements

### DIFF
--- a/tests/integration/test_profile_max_sessions_for_user/test.py
+++ b/tests/integration/test_profile_max_sessions_for_user/test.py
@@ -7,7 +7,7 @@ import pytest
 import sys
 import threading
 
-from helpers.cluster import ClickHouseCluster, run_and_check
+from helpers.cluster import ClickHouseCluster
 from helpers.test_tools import assert_logs_contain_with_retry
 from helpers.uclient import client, prompt
 
@@ -51,7 +51,7 @@ instance = cluster.add_instance(
 
 
 def get_query(name, id):
-    return f"SElECT '{name}', {id}, number from system.numbers"
+    return f"SELECT '{name}', {id}, COUNT(*) from system.numbers"
 
 
 def grpc_get_url():
@@ -90,7 +90,7 @@ def threaded_run_test(sessions):
     if len(sessions) > MAX_SESSIONS_FOR_USER:
         # High retry amount to avoid flakiness in ASAN (+Analyzer) tests
         assert_logs_contain_with_retry(
-            instance, "overflown session count", retry_count=60
+            instance, "overflown session count", retry_count=120
         )
 
     instance.query(f"KILL QUERY WHERE user='{TEST_USER}' SYNC")

--- a/tests/queries/0_stateless/02832_alter_max_sessions_for_user.sh
+++ b/tests/queries/0_stateless/02832_alter_max_sessions_for_user.sh
@@ -1,10 +1,12 @@
 #!/usr/bin/env bash
+# Tags: no-parallel
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CURDIR"/../shell_config.sh
 
 SESSION_ID_PREFIX="02832_alter_max_sessions_session_$$"
+QUERY_ID_PREFIX="02832_alter_max_sessions_query_$$"
 PROFILE="02832_alter_max_sessions_profile_$$"
 USER="02832_alter_max_sessions_user_$$"
 USER2="02832_alter_max_sessions_user_two_$$"
@@ -15,6 +17,26 @@ ${CLICKHOUSE_CLIENT} -q $"DROP PROFILE IF EXISTS ${PROFILE}"
 ${CLICKHOUSE_CLIENT} -q $"CREATE SETTINGS PROFILE ${PROFILE}"
 ${CLICKHOUSE_CLIENT} -q $"CREATE USER '${USER}' SETTINGS PROFILE '${PROFILE}'"
 
+function run_sessions_set()
+{
+    local sessions_count="$1"
+    local session_check="$2"
+    for ((i = 1 ; i <= ${sessions_count} ; i++)); do
+        local session_id="${SESSION_ID_PREFIX}_${i}"
+        local query_id="${QUERY_ID_PREFIX}_${i}"
+        # Write only expected error text
+        # More than alter_sessions_count queries will not start.
+        ${CLICKHOUSE_CURL} -sS -X POST "${CLICKHOUSE_URL}&user=${USER}&query_id=${query_id}&session_id=${session_id}&session_check=${session_check}&session_timeout=600&function_sleep_max_microseconds_per_block=120000000" --data-binary "SELECT sleep(120)" | grep -o  -m 1 'USER_SESSION_LIMIT_EXCEEDED' &
+    done
+
+    for ((i = 1 ; i <= ${sessions_count} ; i++)); do
+        local query_id="${QUERY_ID_PREFIX}_${i}"
+        $CLICKHOUSE_CLIENT --query "KILL QUERY WHERE query_id='$query_id' SYNC" >/dev/null
+    done
+
+    wait
+}
+
 function test_alter_profile()
 {
     local max_session_count="$1"
@@ -24,23 +46,13 @@ function test_alter_profile()
     ${CLICKHOUSE_CLIENT} -q $"ALTER SETTINGS PROFILE ${PROFILE} SETTINGS max_sessions_for_user = ${max_session_count}"
 
     # Create sessions with $max_session_count restriction
-    for ((i = 1 ; i <= ${max_session_count} ; i++)); do
-        local session_id="${SESSION_ID_PREFIX}_${i}"
-         # Skip output from this query 
-         ${CLICKHOUSE_CURL} -sS -X POST "${CLICKHOUSE_URL}&user=${USER}&session_id=${session_id}&session_check=0" --data-binary "SELECT 1" > /dev/null
-    done
+    run_sessions_set $max_session_count 0
 
     # Update restriction to $alter_sessions_count
     ${CLICKHOUSE_CLIENT} -q $"ALTER SETTINGS PROFILE ${PROFILE} SETTINGS max_sessions_for_user = ${alter_sessions_count}"
 
     # Simultaneous sessions should use max settings from profile ($alter_sessions_count)
-    for ((i = 1 ; i <= ${max_session_count} ; i++)); do
-        local session_id="${SESSION_ID_PREFIX}_${i}"
-        # ignore select 1, we need only errors
-        ${CLICKHOUSE_CURL} -sS -X POST "${CLICKHOUSE_URL}&user=${USER}&session_id=${session_id}&session_check=1" --data-binary "select sleep(0.3)" | grep -o  -m 1 'USER_SESSION_LIMIT_EXCEEDED' &
-    done
-
-    wait
+    run_sessions_set $max_session_count 1
 }
 
 test_alter_profile 1 1


### PR DESCRIPTION
The test flakiness was reported here:
https://github.com/ClickHouse/ClickHouse/pull/51724#issuecomment-2173793823

Actually, I was not able to reproduce the issue on my local machine, but In case of parallel test executions, there is a possibility to end the query before the next query starts in this line:
```bash
${CLICKHOUSE_CURL} -sS -X POST "${CLICKHOUSE_URL}&user=${USER}&session_id=${session_id}&session_check=1" --data-binary "select sleep(0.3)" | grep -o -m 1
```

Now the test is more reliable.
1) Prohibited to run the test in parallel
2) Sleep 120 + KILL QUERY Is used instead of `sleep (0.3)`

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

