### PR TITLE
Fix data race for Keeper snapshot queue

### DIFF
--- a/src/Common/ConcurrentBoundedQueue.h
+++ b/src/Common/ConcurrentBoundedQueue.h
@@ -1,8 +1,6 @@
 #pragma once
 
 #include <deque>
-#include <type_traits>
-#include <atomic>
 #include <condition_variable>
 #include <mutex>
 #include <optional>
@@ -200,22 +198,18 @@ public:
       */
     bool finish()
     {
-        bool was_finished_before = false;
-
         {
             std::lock_guard lock(queue_mutex);
 
             if (is_finished)
                 return true;
 
-            was_finished_before = is_finished;
             is_finished = true;
         }
 
         pop_condition.notify_all();
         push_condition.notify_all();
-
-        return was_finished_before;
+        return false;
     }
 
     /// Returns if queue is finished

--- a/src/Coordination/KeeperDispatcher.cpp
+++ b/src/Coordination/KeeperDispatcher.cpp
@@ -319,18 +319,12 @@ void KeeperDispatcher::snapshotThread()
 {
     setThreadName("KeeperSnpT");
     const auto & shutdown_called = keeper_context->isShutdownCalled();
-    while (!shutdown_called)
+    CreateSnapshotTask task;
+    while (snapshots_queue.pop(task))
     {
-        CreateSnapshotTask task;
-        if (!snapshots_queue.pop(task))
-            break;
-
         try
         {
             auto snapshot_file_info = task.create_snapshot(std::move(task.snapshot), /*execute_only_cleanup=*/shutdown_called);
-
-            if (shutdown_called)
-                break;
 
             if (!snapshot_file_info)
                 continue;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Reported by sanitizer https://s3.amazonaws.com/clickhouse-test-reports/65701/6061f2308e245ea3566646ec34748ac77bfe81af/integration_tests__tsan__[3_6]//home/ubuntu/actions-runner/_work/_temp/test/output_dir/integration_run_parallel0_0.log

Sanitizer report:
https://pastila.nl/?000496f8/ecd335218e18bf5a0c5a53e4c76d82e4#YAJpi2MzH1v+iFBOhhl4CA==

We exit early from the thread when shutdown is set, but because we don't exhaust the queue some Snapshots could end up alive after we destroy everything.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
