### PR TITLE
[Docs] add `transactionID`, `transactionLatestSnapshot`, `transactionOldestSnapshot` 

### DIFF
--- a/docs/en/sql-reference/functions/other-functions.md
+++ b/docs/en/sql-reference/functions/other-functions.md
@@ -3860,3 +3860,45 @@ Result:
 └───────────────┘
 ```
 
+## transactionID
+
+Returns the ID of a [transaction](https://clickhouse.com/docs/en/guides/developer/transactional#transactions-commit-and-rollback).
+
+:::note
+This function is part of an experimental feature set. Enable experimental transaction support by adding this setting in `config.d/transactions.xml`:
+
+```
+<clickhouse>
+  <allow_experimental_transactions>1</allow_experimental_transactions>
+</clickhouse>
+```
+
+For more information see the page [Transactional (ACID) support](https://clickhouse.com/docs/en/guides/developer/transactional#transactions-commit-and-rollback).
+:::
+
+**Syntax**
+
+```sql
+transactionID()
+```
+
+**Returned value**
+
+- TransactionID. [String](../data-types/string.md). [Tuple](../data-types/tuple.md)([UInt64](../data-types/int-uint.md), [UInt64](../data-types/int-uint.md), [UUID](../data-types/uuid.md)).
+
+**Example**
+
+Query:
+
+```sql
+SELECT transactionID();
+```
+
+Result:
+
+```response
+┌─transactionID()──────────────────────────────┐
+│ (0,0,'00000000-0000-0000-0000-000000000000') │
+└──────────────────────────────────────────────┘
+```
+

--- a/docs/en/sql-reference/functions/other-functions.md
+++ b/docs/en/sql-reference/functions/other-functions.md
@@ -3865,7 +3865,7 @@ Result:
 Returns the ID of a [transaction](https://clickhouse.com/docs/en/guides/developer/transactional#transactions-commit-and-rollback).
 
 :::note
-This function is part of an experimental feature set. Enable experimental transaction support by adding this setting in `config.d/transactions.xml`:
+This function is part of an experimental feature set. Enable experimental transaction support by adding this setting to your configuration:
 
 ```
 <clickhouse>
@@ -3884,21 +3884,114 @@ transactionID()
 
 **Returned value**
 
-- TransactionID. [String](../data-types/string.md). [Tuple](../data-types/tuple.md)([UInt64](../data-types/int-uint.md), [UInt64](../data-types/int-uint.md), [UUID](../data-types/uuid.md)).
+- Returns a tuple consisting of `start_csn`, `local_tid` and `host_id`. [Tuple](../data-types/tuple.md).
+
+- `start_csn`: Global sequential number, the newest commit timestamp that was seen when this transaction began. [UInt64](../data-types/int-uint.md).
+- `local_tid`: Local sequential number that is unique for each transaction started by this host within a specific start_csn. [UInt64](../data-types/int-uint.md).
+- `host_id`: UUID of the host that has started this transaction. [UUID](../data-types/uuid.md).
 
 **Example**
 
 Query:
 
 ```sql
+BEGIN TRANSACTION;
 SELECT transactionID();
+ROLLBACK;
 ```
 
 Result:
 
 ```response
-┌─transactionID()──────────────────────────────┐
-│ (0,0,'00000000-0000-0000-0000-000000000000') │
-└──────────────────────────────────────────────┘
+┌─transactionID()────────────────────────────────┐
+│ (32,34,'0ee8b069-f2bb-4748-9eae-069c85b5252b') │
+└────────────────────────────────────────────────┘
 ```
 
+## transactionLatestSnapshot
+
+Returns the newest snapshot (Commit Sequence Number) of a [transaction](https://clickhouse.com/docs/en/guides/developer/transactional#transactions-commit-and-rollback) that is available for reading.
+
+:::note
+This function is part of an experimental feature set. Enable experimental transaction support by adding this setting to your configuration:
+
+```
+<clickhouse>
+  <allow_experimental_transactions>1</allow_experimental_transactions>
+</clickhouse>
+```
+
+For more information see the page [Transactional (ACID) support](https://clickhouse.com/docs/en/guides/developer/transactional#transactions-commit-and-rollback).
+:::
+
+**Syntax**
+
+```sql
+transactionLatestSnapshot()
+```
+
+**Returned value**
+
+- Returns the latest snapshot (CSN) of a transaction. [UInt64](../data-types/int-uint.md)
+
+**Example**
+
+Query:
+
+```sql
+BEGIN TRANSACTION;
+SELECT transactionLatestSnapshot();
+ROLLBACK;
+```
+
+Result:
+
+```response
+┌─transactionLatestSnapshot()─┐
+│                          32 │
+└─────────────────────────────┘
+```
+
+## transactionOldestSnapshot
+
+Returns the oldest snapshot (Commit Sequence Number) that is visible for some running [transaction](https://clickhouse.com/docs/en/guides/developer/transactional#transactions-commit-and-rollback).
+
+:::note
+This function is part of an experimental feature set. Enable experimental transaction support by adding this setting to your configuration:
+
+```
+<clickhouse>
+  <allow_experimental_transactions>1</allow_experimental_transactions>
+</clickhouse>
+```
+
+For more information see the page [Transactional (ACID) support](https://clickhouse.com/docs/en/guides/developer/transactional#transactions-commit-and-rollback).
+:::
+
+**Syntax**
+
+```sql
+transactionOldestSnapshot()
+```
+
+**Returned value**
+
+- Returns the oldest snapshot (CSN) of a transaction. [UInt64](../data-types/int-uint.md)
+
+**Example**
+
+Query:
+
+```sql
+BEGIN TRANSACTION;
+SELECT transactionLatestSnapshot();
+ROLLBACK;
+```
+
+Result:
+
+```response
+┌─transactionOldestSnapshot()─┐
+│                          32 │
+└─────────────────────────────┘
+```

--- a/utils/check-style/aspell-ignore/en/aspell-dict.txt
+++ b/utils/check-style/aspell-ignore/en/aspell-dict.txt
@@ -48,7 +48,6 @@ AutoML
 Autocompletion
 AvroConfluent
 BIGINT
-bigrams
 BIGSERIAL
 BORO
 BSON
@@ -223,7 +222,6 @@ DatabaseOrdinaryThreadsActive
 DateTime
 DateTimes
 DbCL
-deallocated
 Decrypted
 Deduplicate
 Deduplication
@@ -295,7 +293,6 @@ FilesystemMainPathUsedBytes
 FilesystemMainPathUsedINodes
 FixedString
 FlameGraph
-flameGraph
 Flink
 ForEach
 FreeBSD
@@ -977,9 +974,6 @@ TotalRowsOfMergeTreeTables
 TotalTemporaryFiles
 Tradeoff
 Transactional
-transactionID
-transactionLatestSnapshot
-transactionOldestSnapshot
 Tsai
 Tukey
 TwoColumnList
@@ -995,6 +989,8 @@ UPDATEs
 URIs
 URL
 URL's
+URLDecode
+URLEncode
 URLHash
 URLHierarchy
 URLPathHierarchy
@@ -1012,13 +1008,10 @@ UncompressedCacheBytes
 UncompressedCacheCells
 UnidirectionalEdgeIsValid
 UniqThetaSketch
-unigrams
 Updatable
 Uppercased
 Uptime
 Uptrace
-URLDecode
-URLEncode
 UserID
 Util
 VARCHAR
@@ -1224,6 +1217,7 @@ basename
 bcrypt
 benchmarking
 bfloat
+bigrams
 binlog
 bitAnd
 bitCount
@@ -1473,6 +1467,7 @@ dbeaver
 dbgen
 dbms
 ddl
+deallocated
 deallocation
 deallocations
 debian
@@ -1512,11 +1507,11 @@ deserializing
 destructor
 destructors
 detectCharset
-detectTonality
 detectLanguage
 detectLanguageMixed
 detectLanguageUnknown
 detectProgrammingLanguage
+detectTonality
 determinator
 deterministically
 dictGet
@@ -1532,8 +1527,8 @@ dictIsIn
 disableProtocols
 disjunction
 disjunctions
-displaySecretsInShowAndSelect
 displayName
+displaySecretsInShowAndSelect
 distro
 divideDecimal
 dmesg
@@ -1583,11 +1578,11 @@ evalMLMethod
 exFAT
 expiryMsec
 exponentialMovingAverage
-exponentialmovingaverage
 exponentialTimeDecayedAvg
 exponentialTimeDecayedCount
 exponentialTimeDecayedMax
 exponentialTimeDecayedSum
+exponentialmovingaverage
 expr
 exprN
 extendedVerification
@@ -1624,6 +1619,7 @@ firstSignificantSubdomainCustom
 firstSignificantSubdomainCustomRFC
 firstSignificantSubdomainRFC
 fixedstring
+flameGraph
 flamegraph
 flatbuffers
 flattenTuple
@@ -1806,8 +1802,8 @@ incrementing
 indexHint
 indexOf
 infi
-infty
 inflight
+infty
 initcap
 initcapUTF
 initialQueryID
@@ -1955,9 +1951,9 @@ loghouse
 london
 lookups
 loongarch
-lowcardinality
 lowCardinalityIndices
 lowCardinalityKeys
+lowcardinality
 lowerUTF
 lowercased
 lttb
@@ -2265,9 +2261,9 @@ proleptic
 prometheus
 proportionsZTest
 proto
-protocol
 protobuf
 protobufsingle
+protocol
 proxied
 pseudorandom
 pseudorandomize
@@ -2758,6 +2754,12 @@ topLevelDomain
 topLevelDomainRFC
 topk
 topkweighted
+transactionID
+transactionID
+transactionLatestSnapshot
+transactionLatestSnapshot
+transactionOldestSnapshot
+transactionOldestSnapshot
 transactional
 transactionally
 translateUTF
@@ -2811,6 +2813,7 @@ unescaping
 unhex
 unicode
 unidimensional
+unigrams
 unintuitive
 uniq
 uniqCombined

--- a/utils/check-style/aspell-ignore/en/aspell-dict.txt
+++ b/utils/check-style/aspell-ignore/en/aspell-dict.txt
@@ -977,6 +977,9 @@ TotalRowsOfMergeTreeTables
 TotalTemporaryFiles
 Tradeoff
 Transactional
+transactionID
+transactionLatestSnapshot
+transactionOldestSnapshot
 Tsai
 Tukey
 TwoColumnList

--- a/utils/check-style/aspell-ignore/en/aspell-dict.txt
+++ b/utils/check-style/aspell-ignore/en/aspell-dict.txt
@@ -2755,10 +2755,7 @@ topLevelDomainRFC
 topk
 topkweighted
 transactionID
-transactionID
 transactionLatestSnapshot
-transactionLatestSnapshot
-transactionOldestSnapshot
 transactionOldestSnapshot
 transactional
 transactionally


### PR DESCRIPTION
Closes [#2025](https://github.com/ClickHouse/clickhouse-docs/issues/2025) as part of [#1833](https://github.com/ClickHouse/clickhouse-docs/issues/1833) to document missing functions.

Adds:
- `transactionID`
- `transactionLatestSnapshot`
- `transactionOldestSnapshot`

### Changelog category (leave one):
- Documentation (changelog entry is not required)
