### PR TITLE
Increase timeout in 02122_join_group_by_timeout for tsan build

### DIFF
--- a/tests/queries/0_stateless/02122_join_group_by_timeout.sh
+++ b/tests/queries/0_stateless/02122_join_group_by_timeout.sh
@@ -12,6 +12,12 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 MAX_PROCESS_WAIT=5
 
+IS_SANITIZER=$($CLICKHOUSE_CLIENT -q "SELECT count() FROM system.warnings WHERE message like '%built with sanitizer%'")
+if [ "$IS_SANITIZER" -gt 0 ]; then
+    # Query may hang for more than 5 seconds, especially in tsan build
+    MAX_PROCESS_WAIT=15
+fi
+
 # TCP CLIENT: As of today (02/12/21) uses PullingAsyncPipelineExecutor
 ### Should be cancelled after 1 second and return a 159 exception (timeout)
 timeout -s KILL $MAX_PROCESS_WAIT $CLICKHOUSE_CLIENT --max_execution_time 1 -q \


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):

- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

Example 
https://s3.amazonaws.com/clickhouse-test-reports/65873/b60a0f621709a90af825ba81081bf76cbc1e534d/stateless_tests__tsan__[2_5]/clickhouse-server.log.zst 

```
2024.07.01 08:45:21.508965 [ 2933 ] {dbca536d-81c2-41ca-88ab-f18b99191076} <Debug> executeQuery: (from [::1]:47378) (comment: 02122_join_group_by_timeout.sh) SELECT a.name as n FROM ( SELECT 'Name' as name, number FROM system.numbers LIMIT 2000000 ) AS a, ( SELECT 'Name' as name2, number FROM system.numbers LIMIT 2000000 ) as b FORMAT Null SETTINGS max_execution_time = 1, timeout_overflow_mode = 'break'  (stage: Complete)
2024.07.01 08:45:24.644541 [ 2933 ] {dbca536d-81c2-41ca-88ab-f18b99191076} <Trace> Planner: Query to stage Complete
2024.07.01 08:45:24.646366 [ 2933 ] {dbca536d-81c2-41ca-88ab-f18b99191076} <Trace> Planner: Query to stage Complete
2024.07.01 08:45:24.650905 [ 2933 ] {dbca536d-81c2-41ca-88ab-f18b99191076} <Trace> Planner: Query from stage FetchColumns to stage Complete
2024.07.01 08:45:24.666125 [ 2933 ] {dbca536d-81c2-41ca-88ab-f18b99191076} <Trace> Planner: Query to stage Complete
2024.07.01 08:45:24.667823 [ 2933 ] {dbca536d-81c2-41ca-88ab-f18b99191076} <Trace> Planner: Query from stage FetchColumns to stage Complete
2024.07.01 08:45:24.669991 [ 2933 ] {dbca536d-81c2-41ca-88ab-f18b99191076} <Trace> HashJoin: Keys: , datatype: EMPTY, kind: Cross, strictness: Unspecified, right header: __table3.name2 String Const(size = 0, String(size = 1))
2024.07.01 08:45:24.671363 [ 2933 ] {dbca536d-81c2-41ca-88ab-f18b99191076} <Trace> Planner: Query from stage FetchColumns to stage Complete
2024.07.01 08:45:25.042867 [ 2933 ] {dbca536d-81c2-41ca-88ab-f18b99191076} <Error> executeQuery: Code: 210. DB::NetException: I/O error: Broken pipe, while writing to socket ([::1]:9000 -> [::1]:47378). (NETWORK_ERROR) (version 24.7.1.657) (from [::1]:47378) (comment: 02122_join_group_by_timeout.sh) (in query: SELECT a.name as n FROM ( SELECT 'Name' as name, number FROM system.numbers LIMIT 2000000 ) AS a, ( SELECT 'Name' as name2, number FROM system.numbers LIMIT 2000000 ) as b FORMAT Null SETTINGS max_execution_time = 1, timeout_overflow_mode = 'break' ), Stack trace (when copying this message, always include the lines below):
2024.07.01 08:45:25.104299 [ 2933 ] {dbca536d-81c2-41ca-88ab-f18b99191076} <Error> TCPHandler: Can't send logs to client: Code: 210. DB::NetException: I/O error: Broken pipe, while writing to socket ([::1]:9000 -> [::1]:47378). (NETWORK_ERROR), Stack trace (when copying this message, always include the lines below):
2024.07.01 08:45:25.104636 [ 2933 ] {dbca536d-81c2-41ca-88ab-f18b99191076} <Error> TCPHandler: Code: 210. DB::NetException: I/O error: Broken pipe, while writing to socket ([::1]:9000 -> [::1]:47378). (NETWORK_ERROR), Stack trace (when copying this message, always include the lines below):
2024.07.01 08:45:25.105131 [ 2933 ] {dbca536d-81c2-41ca-88ab-f18b99191076} <Warning> TCPHandler: Client has gone away.
2024.07.01 08:45:25.105280 [ 2933 ] {dbca536d-81c2-41ca-88ab-f18b99191076} <Debug> TCPHandler: Processed in 7.046463662 sec.
```


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
