### PR TITLE
Fix possible crash with distributed queries (likely due to async_query_sending_for_remote)

### DIFF
--- a/src/Processors/Executors/PipelineExecutor.cpp
+++ b/src/Processors/Executors/PipelineExecutor.cpp
@@ -375,7 +375,7 @@ void PipelineExecutor::spawnThreads()
             catch (...)
             {
                 /// In case of exception from executor itself, stop other threads.
-                finish();
+                cancel();
                 tasks.getThreadContext(thread_num).setException(std::current_exception());
             }
         });

--- a/src/Processors/Executors/PullingAsyncPipelineExecutor.cpp
+++ b/src/Processors/Executors/PullingAsyncPipelineExecutor.cpp
@@ -89,6 +89,9 @@ static void threadFunction(
 
         /// Finish lazy format in case of exception. Otherwise thread.join() may hung.
         data.lazy_format->finalize();
+
+        /// Do not set is_finished
+        return;
     }
 
     data.is_finished = true;

--- a/src/Processors/Executors/PullingAsyncPipelineExecutor.cpp
+++ b/src/Processors/Executors/PullingAsyncPipelineExecutor.cpp
@@ -53,6 +53,11 @@ PullingAsyncPipelineExecutor::~PullingAsyncPipelineExecutor()
 {
     try
     {
+        /// NOTE: It can be error-prone to cancel the query in destructor
+        ///
+        /// For instance RemoteQueryExecutor should be cancelled before the
+        /// worker thread destroyed, otherwise active fibers could lead to
+        /// use-after-free
         cancel();
     }
     catch (...)

--- a/src/QueryPipeline/RemoteQueryExecutor.cpp
+++ b/src/QueryPipeline/RemoteQueryExecutor.cpp
@@ -596,10 +596,11 @@ RemoteQueryExecutor::ReadResult RemoteQueryExecutor::processPacket(Packet packet
             break;
 
         case Protocol::Server::EndOfStream:
-            if (read_context)
-                read_context->cancel();
             if (!connections->hasActiveConnections())
             {
+                if (read_context)
+                    read_context->cancel();
+
                 finished = true;
                 /// TODO: Replace with Type::Finished
                 return ReadResult(Block{});

--- a/src/QueryPipeline/RemoteQueryExecutor.cpp
+++ b/src/QueryPipeline/RemoteQueryExecutor.cpp
@@ -259,7 +259,8 @@ RemoteQueryExecutor::RemoteQueryExecutor(
 ///   (i.e. current_thread), iff thread had been destroyed in between.
 RemoteQueryExecutor::~RemoteQueryExecutor()
 {
-    if (read_context && !read_context->isCancelled())
+    /// FIXME: fix it for parallel replicas (and remove "!extension")
+    if (!extension && read_context && !read_context->isCancelled())
     {
         LOG_FATAL(log, "Read context was not cancelled. This is a bug");
         abort();

--- a/src/QueryPipeline/RemoteQueryExecutor.cpp
+++ b/src/QueryPipeline/RemoteQueryExecutor.cpp
@@ -437,7 +437,8 @@ Block RemoteQueryExecutor::readBlock()
 
 RemoteQueryExecutor::ReadResult RemoteQueryExecutor::read()
 {
-    chassert(sent_query);
+    if (!sent_query)
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Query had not been sent");
 
     while (true)
     {

--- a/src/QueryPipeline/RemoteQueryExecutor.cpp
+++ b/src/QueryPipeline/RemoteQueryExecutor.cpp
@@ -466,6 +466,9 @@ RemoteQueryExecutor::ReadResult RemoteQueryExecutor::read()
 
 RemoteQueryExecutor::ReadResult RemoteQueryExecutor::readAsync()
 {
+    if (!sent_query)
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Query had not been sent");
+
 #if defined(OS_LINUX)
     if (resent_query || !read_context)
     {

--- a/src/QueryPipeline/RemoteQueryExecutor.cpp
+++ b/src/QueryPipeline/RemoteQueryExecutor.cpp
@@ -261,12 +261,14 @@ RemoteQueryExecutor::RemoteQueryExecutor(
 ///   (i.e. current_thread), iff thread had been destroyed in between.
 RemoteQueryExecutor::~RemoteQueryExecutor()
 {
+#if defined(OS_LINUX)
     /// FIXME: fix it for parallel replicas (and remove "!extension")
     if (!extension && read_context && !read_context->isCancelled())
     {
         LOG_FATAL(log, "Read context was not cancelled. This is a bug");
         abort();
     }
+#endif
 
     /** If interrupted in the middle of the loop of communication with replicas, then interrupt
       * all connections, then read and skip the remaining packets to make sure

--- a/src/QueryPipeline/RemoteQueryExecutor.cpp
+++ b/src/QueryPipeline/RemoteQueryExecutor.cpp
@@ -588,6 +588,8 @@ RemoteQueryExecutor::ReadResult RemoteQueryExecutor::processPacket(Packet packet
             break;  /// If the block is empty - we will receive other packets before EndOfStream.
 
         case Protocol::Server::Exception:
+            if (read_context)
+                read_context->cancel();
             got_exception_from_replica = true;
             packet.exception->rethrow();
             break;
@@ -649,6 +651,8 @@ RemoteQueryExecutor::ReadResult RemoteQueryExecutor::processPacket(Packet packet
             break;
 
         default:
+            if (read_context)
+                read_context->cancel();
             got_unknown_packet_from_replica = true;
             throw Exception(
                 ErrorCodes::UNKNOWN_PACKET_FROM_SERVER,

--- a/src/QueryPipeline/RemoteQueryExecutor.cpp
+++ b/src/QueryPipeline/RemoteQueryExecutor.cpp
@@ -61,6 +61,8 @@ RemoteQueryExecutor::RemoteQueryExecutor(
     , external_tables(external_tables_)
     , stage(stage_)
     , extension(extension_)
+    /// Can be overwritten by setLogger()
+    , log(getLogger("RemoteQueryExecutor"))
     , priority_func(priority_func_)
 {
 }
@@ -279,7 +281,7 @@ RemoteQueryExecutor::~RemoteQueryExecutor()
         }
         catch (...)
         {
-            tryLogCurrentException(log ? log : getLogger("RemoteQueryExecutor"));
+            tryLogCurrentException(log);
         }
     }
 }
@@ -539,8 +541,7 @@ RemoteQueryExecutor::ReadResult RemoteQueryExecutor::restartQueryWithoutDuplicat
         if (resent_query)
             throw Exception(ErrorCodes::DUPLICATED_PART_UUIDS, "Found duplicate uuids while processing query");
 
-        if (log)
-            LOG_DEBUG(log, "Found duplicate UUIDs, will retry query without those parts");
+        LOG_DEBUG(log, "Found duplicate UUIDs, will retry query without those parts");
 
         resent_query = true;
         sent_query = false;
@@ -887,8 +888,7 @@ void RemoteQueryExecutor::tryCancel(const char * reason)
     if (connections && sent_query && !finished)
     {
         connections->sendCancel();
-        if (log)
-            LOG_TRACE(log, "({}) {}", connections->dumpAddresses(), reason);
+        LOG_TRACE(log, "({}) {}", connections->dumpAddresses(), reason);
     }
 }
 

--- a/src/QueryPipeline/RemoteQueryExecutor.h
+++ b/src/QueryPipeline/RemoteQueryExecutor.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <variant>
-
 #include <Client/ConnectionPool.h>
 #include <Client/IConnections.h>
 #include <Client/ConnectionPoolWithFailover.h>
@@ -124,11 +122,12 @@ public:
     void sendQuery(ClientInfo::QueryKind query_kind = ClientInfo::QueryKind::SECONDARY_QUERY, AsyncCallback async_callback = {});
     void sendQueryUnlocked(ClientInfo::QueryKind query_kind = ClientInfo::QueryKind::SECONDARY_QUERY, AsyncCallback async_callback = {});
 
+    /// Asynchronous query sending (async_query_sending_for_remote)
+    /// Returns file descriptor which may be used for polling or -1.
     int sendQueryAsync();
 
     /// Query is resent to a replica, the query itself can be modified.
     bool resent_query { false };
-    bool recreate_read_context { false };
 
     struct ReadResult
     {
@@ -181,7 +180,8 @@ public:
 
     ReadResult read();
 
-    /// Async variant of read. Returns ready block or file descriptor which may be used for polling.
+    /// Async variant of read (async_socket_for_remote).
+    /// Returns ready block or file descriptor which may be used for polling.
     ReadResult readAsync();
 
     /// Receive all remain packets and finish query.

--- a/src/QueryPipeline/RemoteQueryExecutorReadContext.h
+++ b/src/QueryPipeline/RemoteQueryExecutorReadContext.h
@@ -22,6 +22,7 @@ namespace DB
 class MultiplexedConnections;
 class RemoteQueryExecutor;
 
+/// NOTE: This async executor is not restartable (due to pipe notifications that may overlaps)
 class RemoteQueryExecutorReadContext : public AsyncTaskExecutor
 {
 public:

--- a/src/Storages/getStructureOfRemoteTable.cpp
+++ b/src/Storages/getStructureOfRemoteTable.cpp
@@ -198,6 +198,7 @@ ColumnsDescriptionByShardNum getExtendedObjectsOfRemoteTables(
 
         executor.setPoolMode(PoolMode::GET_ONE);
         executor.setMainTable(remote_table_id);
+        executor.sendQuery();
 
         ColumnsDescription res;
         while (auto block = executor.readBlock())

--- a/src/Storages/getStructureOfRemoteTable.cpp
+++ b/src/Storages/getStructureOfRemoteTable.cpp
@@ -90,6 +90,7 @@ ColumnsDescription getStructureOfRemoteTableInShard(
 
     ParserExpression expr_parser;
 
+    executor.sendQuery();
     while (Block current = executor.readBlock())
     {
         ColumnPtr name = current.getByName("name").column;


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix possible crash with distributed queries (likely due to async_query_sending_for_remote)

Refs: https://github.com/ClickHouse/ClickHouse/issues/65942

#### CI Settings (Only check the boxes if you know what you are doing):
- [x] <!---woolen_wolfdog--> Woolen Wolfdog