### PR TITLE
More aesthetic error messages

### DIFF
--- a/src/Functions/FunctionBase64Conversion.h
+++ b/src/Functions/FunctionBase64Conversion.h
@@ -202,7 +202,7 @@ public:
             {"value", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isStringOrFixedString), nullptr, "String or FixedString"}
         };
 
-        validateFunctionArgumentTypes(*this, arguments, mandatory_arguments);
+        validateFunctionArguments(*this, arguments, mandatory_arguments);
 
         return std::make_shared<DataTypeString>();
     }

--- a/src/Functions/FunctionHelpers.cpp
+++ b/src/Functions/FunctionHelpers.cpp
@@ -95,20 +95,6 @@ ColumnsWithTypeAndName createBlockWithNestedColumns(const ColumnsWithTypeAndName
     return res;
 }
 
-void validateArgumentType(const IFunction & func, const DataTypes & arguments,
-                          size_t argument_index, bool (* validator_func)(const IDataType &),
-                          const char * type_name)
-{
-    if (arguments.size() <= argument_index)
-        throw Exception(ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH, "Incorrect number of arguments of function {}",
-                        func.getName());
-
-    const auto & argument = arguments[argument_index];
-    if (!validator_func(*argument))
-        throw Exception(ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT, "Illegal type {} of {} argument of function {}, expected {}",
-                        argument->getName(), argument_index, func.getName(), type_name);
-}
-
 namespace
 {
 void validateArgumentsImpl(const IFunction & func,

--- a/src/Functions/FunctionHelpers.h
+++ b/src/Functions/FunctionHelpers.h
@@ -119,73 +119,60 @@ ColumnsWithTypeAndName createBlockWithNestedColumns(const ColumnsWithTypeAndName
 /// throws if there is no argument at specified index or if predicate returns false.
 void validateArgumentType(const IFunction & func, const DataTypes & arguments,
         size_t argument_index, bool (* validator_func)(const IDataType &),
-        const char * expected_type_description);
+        const char * type_name);
 
-/** Simple validator that is used in conjunction with validateFunctionArgumentTypes() to check if function arguments are as expected
- *
- * Also it is used to generate function description when arguments do not match expected ones.
- * Any field can be null:
- *  `argument_name` - if not null, reported via type check errors.
- *  `expected_type_description` - if not null, reported via type check errors.
- *  `type_validator_func` - if not null, used to validate data type of function argument.
- *  `column_validator_func` - if not null, used to validate column of function argument.
- */
+/// Expected arguments for a function. Can be used in conjunction with validateFunctionArguments() to check that the user-provided
+/// arguments match the expected arguments.
 struct FunctionArgumentDescriptor
 {
-    const char * argument_name;
+    /// The argument name, e.g. "longitude".
+    /// Should not be empty.
+    std::string_view name;
 
+    /// A function which validates the argument data type.
+    /// May be nullptr.
     using TypeValidator = bool (*)(const IDataType &);
-    TypeValidator type_validator_func;
+    TypeValidator type_validator;
+
+    /// A function which validates the argument column.
+    /// May be nullptr.
     using ColumnValidator = bool (*)(const IColumn &);
-    ColumnValidator column_validator_func;
+    ColumnValidator column_validator;
 
-    const char * expected_type_description;
+    /// The expected argument type, e.g. "const String" or "UInt64".
+    /// Should not be empty.
+    std::string_view type_name;
 
-    /** Validate argument type and column.
-     *
-     * Returns non-zero error code if:
-     *     Validator != nullptr && (Value == nullptr || Validator(*Value) == false)
-     * For:
-     *     Validator is either `type_validator_func` or `column_validator_func`
-     *     Value is either `data_type` or `column` respectively.
-     * ILLEGAL_TYPE_OF_ARGUMENT if type validation fails
-     *
-     */
+    /// Validate argument type and column.
     int isValid(const DataTypePtr & data_type, const ColumnPtr & column) const;
 };
 
 using FunctionArgumentDescriptors = std::vector<FunctionArgumentDescriptor>;
 
-/** Validate that function arguments match specification.
- *
- * Designed to simplify argument validation for functions with variable arguments
- * (e.g. depending on result type or other trait).
- * First, checks that number of arguments is as expected (including optional arguments).
- * Second, checks that mandatory args present and have valid type.
- * Third, checks optional arguments types, skipping ones that are missing.
- *
- * Please note that if you have several optional arguments, like f([a, b, c]),
- * only these calls are considered valid:
- *  f(a)
- *  f(a, b)
- *  f(a, b, c)
- *
- * But NOT these: f(a, c), f(b, c)
- * In other words you can't omit middle optional arguments (just like in regular C++).
- *
- * If any mandatory arg is missing, throw an exception, with explicit description of expected arguments.
- */
-void validateFunctionArgumentTypes(const IFunction & func, const ColumnsWithTypeAndName & arguments,
-                                   const FunctionArgumentDescriptors & mandatory_args,
-                                   const FunctionArgumentDescriptors & optional_args = {});
+/// Validates that the user-provided arguments match the expected arguments.
+///
+/// Checks that
+/// - the number of provided arguments matches the number of mandatory/optional arguments,
+/// - all mandatory arguments are present and have the right type,
+/// - optional arguments - if present - have the right type.
+///
+/// With multiple optional arguments, e.g. f([a, b, c]), provided arguments must match left-to-right. E.g. these calls are considered valid:
+///     f(a)
+///     f(a, b)
+///     f(a, b, c)
+/// but these are NOT:
+///     f(a, c)
+///     f(b, c)
+void validateFunctionArguments(const IFunction & func, const ColumnsWithTypeAndName & arguments,
+                               const FunctionArgumentDescriptors & mandatory_args,
+                               const FunctionArgumentDescriptors & optional_args = {});
 
 /// Checks if a list of array columns have equal offsets. Return a pair of nested columns and offsets if true, otherwise throw.
 std::pair<std::vector<const IColumn *>, const ColumnArray::Offset *>
 checkAndGetNestedArrayOffset(const IColumn ** columns, size_t num_arguments);
 
-/** Return ColumnNullable of src, with null map as OR-ed null maps of args columns.
-  * Or ColumnConst(ColumnNullable) if the result is always NULL or if the result is constant and always not NULL.
-  */
+/// Return ColumnNullable of src, with null map as OR-ed null maps of args columns.
+/// Or ColumnConst(ColumnNullable) if the result is always NULL or if the result is constant and always not NULL.
 ColumnPtr wrapInNullable(const ColumnPtr & src, const ColumnsWithTypeAndName & args, const DataTypePtr & result_type, size_t input_rows_count);
 
 struct NullPresence

--- a/src/Functions/FunctionHelpers.h
+++ b/src/Functions/FunctionHelpers.h
@@ -115,12 +115,6 @@ ColumnWithTypeAndName columnGetNested(const ColumnWithTypeAndName & col);
 /// column if it is nullable.
 ColumnsWithTypeAndName createBlockWithNestedColumns(const ColumnsWithTypeAndName & columns);
 
-/// Checks argument type at specified index with predicate.
-/// throws if there is no argument at specified index or if predicate returns false.
-void validateArgumentType(const IFunction & func, const DataTypes & arguments,
-        size_t argument_index, bool (* validator_func)(const IDataType &),
-        const char * type_name);
-
 /// Expected arguments for a function. Can be used in conjunction with validateFunctionArguments() to check that the user-provided
 /// arguments match the expected arguments.
 struct FunctionArgumentDescriptor

--- a/src/Functions/FunctionStringReplace.h
+++ b/src/Functions/FunctionStringReplace.h
@@ -40,7 +40,7 @@ public:
             {"replacement", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isString), nullptr, "String"}
         };
 
-        validateFunctionArgumentTypes(*this, arguments, args);
+        validateFunctionArguments(*this, arguments, args);
 
         return std::make_shared<DataTypeString>();
     }

--- a/src/Functions/FunctionTokens.h
+++ b/src/Functions/FunctionTokens.h
@@ -194,7 +194,7 @@ static inline void checkArgumentsWithSeparatorAndOptionalMaxSubstrings(
         {"max_substrings", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isNativeInteger), isColumnConst, "const Number"},
     };
 
-    validateFunctionArgumentTypes(func, arguments, mandatory_args, optional_args);
+    validateFunctionArguments(func, arguments, mandatory_args, optional_args);
 }
 
 static inline void checkArgumentsWithOptionalMaxSubstrings(const IFunction & func, const ColumnsWithTypeAndName & arguments)
@@ -207,7 +207,7 @@ static inline void checkArgumentsWithOptionalMaxSubstrings(const IFunction & fun
         {"max_substrings", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isNativeInteger), isColumnConst, "const Number"},
     };
 
-    validateFunctionArgumentTypes(func, arguments, mandatory_args, optional_args);
+    validateFunctionArguments(func, arguments, mandatory_args, optional_args);
 }
 
 }

--- a/src/Functions/FunctionUnixTimestamp64.h
+++ b/src/Functions/FunctionUnixTimestamp64.h
@@ -47,7 +47,7 @@ public:
         FunctionArgumentDescriptors args{
             {"value", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isDateTime64), nullptr, "DateTime64"}
         };
-        validateFunctionArgumentTypes(*this, arguments, args);
+        validateFunctionArguments(*this, arguments, args);
 
         return std::make_shared<DataTypeInt64>();
     }

--- a/src/Functions/FunctionsAES.h
+++ b/src/Functions/FunctionsAES.h
@@ -165,7 +165,7 @@ private:
             });
         }
 
-        validateFunctionArgumentTypes(*this, arguments,
+        validateFunctionArguments(*this, arguments,
             FunctionArgumentDescriptors{
                 {"mode", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isStringOrFixedString), isColumnConst, "encryption mode string"},
                 {"input", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isStringOrFixedString), {}, "plaintext"},
@@ -438,7 +438,7 @@ private:
             });
         }
 
-        validateFunctionArgumentTypes(*this, arguments,
+        validateFunctionArguments(*this, arguments,
             FunctionArgumentDescriptors{
                 {"mode", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isStringOrFixedString), isColumnConst, "decryption mode string"},
                 {"input", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isStringOrFixedString), {}, "ciphertext"},

--- a/src/Functions/FunctionsConversion.cpp
+++ b/src/Functions/FunctionsConversion.cpp
@@ -2020,7 +2020,7 @@ public:
 
     DataTypePtr getReturnTypeImplRemovedNullable(const ColumnsWithTypeAndName & arguments) const
     {
-        FunctionArgumentDescriptors mandatory_args = {{"Value", nullptr, nullptr, nullptr}};
+        FunctionArgumentDescriptors mandatory_args = {{"Value", nullptr, nullptr, "any type"}};
         FunctionArgumentDescriptors optional_args;
 
         if constexpr (to_decimal)
@@ -2049,7 +2049,7 @@ public:
             optional_args.push_back({"timezone", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isString), nullptr, "String"});
         }
 
-        validateFunctionArgumentTypes(*this, arguments, mandatory_args, optional_args);
+            validateFunctionArguments(*this, arguments, mandatory_args, optional_args);
 
         if constexpr (std::is_same_v<ToDataType, DataTypeInterval>)
         {
@@ -2390,7 +2390,7 @@ public:
 
         if (isDateTime64<Name, ToDataType>(arguments))
         {
-            validateFunctionArgumentTypes(*this, arguments,
+            validateFunctionArguments(*this, arguments,
                 FunctionArgumentDescriptors{{"string", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isStringOrFixedString), nullptr, "String or FixedString"}},
                 // optional
                 FunctionArgumentDescriptors{

--- a/src/Functions/FunctionsRound.h
+++ b/src/Functions/FunctionsRound.h
@@ -647,7 +647,7 @@ public:
         FunctionArgumentDescriptors optional_args{
             {"N", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isNativeInteger), nullptr, "The number of decimal places to round to"},
         };
-        validateFunctionArgumentTypes(*this, arguments, mandatory_args, optional_args);
+        validateFunctionArguments(*this, arguments, mandatory_args, optional_args);
 
         return arguments[0].type;
     }

--- a/src/Functions/JSONArrayLength.cpp
+++ b/src/Functions/JSONArrayLength.cpp
@@ -48,7 +48,7 @@ namespace
                 {"json", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isString), nullptr, "String"},
             };
 
-            validateFunctionArgumentTypes(*this, arguments, args);
+            validateFunctionArguments(*this, arguments, args);
             return std::make_shared<DataTypeNullable>(std::make_shared<DataTypeUInt64>());
         }
 

--- a/src/Functions/URL/URLHierarchy.cpp
+++ b/src/Functions/URL/URLHierarchy.cpp
@@ -32,7 +32,7 @@ public:
             {"URL", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isString), nullptr, "String"},
         };
 
-        validateFunctionArgumentTypes(func, arguments, mandatory_args);
+        validateFunctionArguments(func, arguments, mandatory_args);
     }
 
     static constexpr auto strings_argument_position = 0uz;

--- a/src/Functions/URL/URLPathHierarchy.cpp
+++ b/src/Functions/URL/URLPathHierarchy.cpp
@@ -30,7 +30,7 @@ public:
             {"URL", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isString), nullptr, "String"},
         };
 
-        validateFunctionArgumentTypes(func, arguments, mandatory_args);
+        validateFunctionArguments(func, arguments, mandatory_args);
     }
 
     static constexpr auto strings_argument_position = 0uz;

--- a/src/Functions/URL/extractURLParameterNames.cpp
+++ b/src/Functions/URL/extractURLParameterNames.cpp
@@ -30,7 +30,7 @@ public:
             {"URL", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isString), nullptr, "String"},
         };
 
-        validateFunctionArgumentTypes(func, arguments, mandatory_args);
+        validateFunctionArguments(func, arguments, mandatory_args);
     }
 
     static constexpr auto strings_argument_position = 0uz;

--- a/src/Functions/URL/extractURLParameters.cpp
+++ b/src/Functions/URL/extractURLParameters.cpp
@@ -31,7 +31,7 @@ public:
             {"URL", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isString), nullptr, "String"},
         };
 
-        validateFunctionArgumentTypes(func, arguments, mandatory_args);
+        validateFunctionArguments(func, arguments, mandatory_args);
     }
 
     void init(const ColumnsWithTypeAndName & /*arguments*/, bool /*max_substrings_includes_remaining_string*/) {}

--- a/src/Functions/array/arrayJaccardIndex.cpp
+++ b/src/Functions/array/arrayJaccardIndex.cpp
@@ -87,7 +87,7 @@ public:
             {"array_1", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isArray), nullptr, "Array"},
             {"array_2", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isArray), nullptr, "Array"},
         };
-        validateFunctionArgumentTypes(*this, arguments, args);
+        validateFunctionArguments(*this, arguments, args);
         return std::make_shared<DataTypeNumber<ResultType>>();
     }
 

--- a/src/Functions/array/arrayRandomSample.cpp
+++ b/src/Functions/array/arrayRandomSample.cpp
@@ -39,7 +39,7 @@ public:
             {"array", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isArray), nullptr, "Array"},
             {"samples", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isUInt), isColumnConst, "const UInt*"},
         };
-        validateFunctionArgumentTypes(*this, arguments, args);
+        validateFunctionArguments(*this, arguments, args);
 
         // Return an array with the same nested type as the input array
         const DataTypePtr & array_type = arguments[0].type;

--- a/src/Functions/array/arrayShingles.cpp
+++ b/src/Functions/array/arrayShingles.cpp
@@ -31,7 +31,7 @@ public:
                 {"array", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isArray), nullptr, "Array"},
                 {"length", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isInteger), nullptr, "Integer"}
             };
-            validateFunctionArgumentTypes(*this, arguments, args);
+            validateFunctionArguments(*this, arguments, args);
 
         const DataTypeArray * array_type = checkAndGetDataType<DataTypeArray>(arguments[0].type.get());
         return std::make_shared<DataTypeArray>(std::make_shared<DataTypeArray>(array_type->getNestedType()));

--- a/src/Functions/arrayStringConcat.cpp
+++ b/src/Functions/arrayStringConcat.cpp
@@ -159,7 +159,7 @@ public:
             {"separator", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isString), isColumnConst, "const String"},
         };
 
-        validateFunctionArgumentTypes(*this, arguments, mandatory_args, optional_args);
+        validateFunctionArguments(*this, arguments, mandatory_args, optional_args);
 
         return std::make_shared<DataTypeString>();
     }

--- a/src/Functions/castOrDefault.cpp
+++ b/src/Functions/castOrDefault.cpp
@@ -203,7 +203,7 @@ private:
 
     DataTypePtr getReturnTypeImpl(const ColumnsWithTypeAndName & arguments) const override
     {
-        FunctionArgumentDescriptors mandatory_args = {{"Value", nullptr, nullptr, nullptr}};
+        FunctionArgumentDescriptors mandatory_args = {{"Value", nullptr, nullptr, "any type"}};
         FunctionArgumentDescriptors optional_args;
 
         if (isDecimal(type) || isDateTime64(type))
@@ -212,9 +212,9 @@ private:
         if (isDateTimeOrDateTime64(type))
             optional_args.push_back({"timezone", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isString), isColumnConst, "const String"});
 
-        optional_args.push_back({"default_value", nullptr, nullptr, nullptr});
+        optional_args.push_back({"default_value", nullptr, nullptr, "any type"});
 
-        validateFunctionArgumentTypes(*this, arguments, mandatory_args, optional_args);
+        validateFunctionArguments(*this, arguments, mandatory_args, optional_args);
 
         size_t additional_argument_index = 1;
 

--- a/src/Functions/countMatches.h
+++ b/src/Functions/countMatches.h
@@ -38,7 +38,7 @@ public:
             {"haystack", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isStringOrFixedString), nullptr, "String or FixedString"},
             {"pattern", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isString), isColumnConst, "constant String"}
         };
-        validateFunctionArgumentTypes(*this, arguments, args);
+        validateFunctionArguments(*this, arguments, args);
 
         return std::make_shared<DataTypeUInt64>();
     }

--- a/src/Functions/dateTimeToSnowflakeID.cpp
+++ b/src/Functions/dateTimeToSnowflakeID.cpp
@@ -43,7 +43,7 @@ public:
         FunctionArgumentDescriptors optional_args{
             {"epoch", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isNativeUInt), isColumnConst, "const UInt*"}
         };
-        validateFunctionArgumentTypes(*this, arguments, args, optional_args);
+        validateFunctionArguments(*this, arguments, args, optional_args);
 
         return std::make_shared<DataTypeUInt64>();
     }
@@ -91,7 +91,7 @@ public:
         FunctionArgumentDescriptors optional_args{
             {"epoch", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isNativeUInt), isColumnConst, "const UInt*"}
         };
-        validateFunctionArgumentTypes(*this, arguments, args, optional_args);
+        validateFunctionArguments(*this, arguments, args, optional_args);
 
         return std::make_shared<DataTypeUInt64>();
     }

--- a/src/Functions/extractAll.cpp
+++ b/src/Functions/extractAll.cpp
@@ -59,7 +59,7 @@ public:
             {"pattern", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isString), isColumnConst, "const String"}
         };
 
-        validateFunctionArgumentTypes(func, arguments, mandatory_args);
+        validateFunctionArguments(func, arguments, mandatory_args);
     }
 
     static constexpr auto strings_argument_position = 0uz;

--- a/src/Functions/extractAllGroups.h
+++ b/src/Functions/extractAllGroups.h
@@ -74,7 +74,7 @@ public:
             {"haystack", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isStringOrFixedString), nullptr, "const String or const FixedString"},
             {"needle", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isStringOrFixedString), isColumnConst, "const String or const FixedString"},
         };
-        validateFunctionArgumentTypes(*this, arguments, args);
+        validateFunctionArguments(*this, arguments, args);
 
         /// Two-dimensional array of strings, each `row` of top array represents matching groups.
         return std::make_shared<DataTypeArray>(std::make_shared<DataTypeArray>(std::make_shared<DataTypeString>()));

--- a/src/Functions/extractGroups.cpp
+++ b/src/Functions/extractGroups.cpp
@@ -48,7 +48,7 @@ public:
             {"haystack", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isStringOrFixedString), nullptr, "const String or const FixedString"},
             {"needle", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isStringOrFixedString), isColumnConst, "const String or const FixedString"},
         };
-        validateFunctionArgumentTypes(*this, arguments, args);
+        validateFunctionArguments(*this, arguments, args);
 
         return std::make_shared<DataTypeArray>(std::make_shared<DataTypeString>());
     }

--- a/src/Functions/formatQuery.cpp
+++ b/src/Functions/formatQuery.cpp
@@ -54,7 +54,7 @@ public:
         FunctionArgumentDescriptors args{
             {"query", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isString), nullptr, "String"}
         };
-        validateFunctionArgumentTypes(*this, arguments, args);
+        validateFunctionArguments(*this, arguments, args);
 
         DataTypePtr string_type = std::make_shared<DataTypeString>();
         if (error_handling == ErrorHandling::Null)

--- a/src/Functions/fromDaysSinceYearZero.cpp
+++ b/src/Functions/fromDaysSinceYearZero.cpp
@@ -54,7 +54,7 @@ public:
     {
         FunctionArgumentDescriptors args{{"days", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isNativeInteger), nullptr, "Integer"}};
 
-        validateFunctionArgumentTypes(*this, arguments, args);
+        validateFunctionArguments(*this, arguments, args);
 
         return std::make_shared<typename Traits::ReturnDataType>();
     }

--- a/src/Functions/generateSnowflakeID.cpp
+++ b/src/Functions/generateSnowflakeID.cpp
@@ -167,7 +167,7 @@ public:
         FunctionArgumentDescriptors optional_args{
             {"expr", nullptr, nullptr, "Arbitrary expression"}
         };
-        validateFunctionArgumentTypes(*this, arguments, mandatory_args, optional_args);
+        validateFunctionArguments(*this, arguments, mandatory_args, optional_args);
 
         return std::make_shared<DataTypeUInt64>();
     }

--- a/src/Functions/generateUUIDv4.cpp
+++ b/src/Functions/generateUUIDv4.cpp
@@ -30,9 +30,9 @@ public:
     {
         FunctionArgumentDescriptors mandatory_args;
         FunctionArgumentDescriptors optional_args{
-            {"expr", nullptr, nullptr, "Arbitrary Expression"}
+            {"expr", nullptr, nullptr, "any type"}
         };
-        validateFunctionArgumentTypes(*this, arguments, mandatory_args, optional_args);
+        validateFunctionArguments(*this, arguments, mandatory_args, optional_args);
 
         return std::make_shared<DataTypeUUID>();
     }

--- a/src/Functions/generateUUIDv7.cpp
+++ b/src/Functions/generateUUIDv7.cpp
@@ -163,7 +163,7 @@ public:
         FunctionArgumentDescriptors optional_args{
             {"expr", nullptr, nullptr, "Arbitrary expression"}
         };
-        validateFunctionArgumentTypes(*this, arguments, mandatory_args, optional_args);
+        validateFunctionArguments(*this, arguments, mandatory_args, optional_args);
 
         return std::make_shared<DataTypeUUID>();
     }

--- a/src/Functions/geohashDecode.cpp
+++ b/src/Functions/geohashDecode.cpp
@@ -38,9 +38,12 @@ public:
     bool useDefaultImplementationForConstants() const override { return true; }
     bool isSuitableForShortCircuitArgumentsExecution(const DataTypesWithConstInfo & /*arguments*/) const override { return true; }
 
-    DataTypePtr getReturnTypeImpl(const DataTypes & arguments) const override
+    DataTypePtr getReturnTypeImpl(const ColumnsWithTypeAndName & arguments) const override
     {
-        validateArgumentType(*this, arguments, 0, isStringOrFixedString, "string or fixed string");
+        FunctionArgumentDescriptors args{
+            {"encoded", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isStringOrFixedString), nullptr, "String or FixedString"}
+        };
+        validateFunctionArguments(*this, arguments, args);
 
         return std::make_shared<DataTypeTuple>(
                 DataTypes{std::make_shared<DataTypeFloat64>(), std::make_shared<DataTypeFloat64>()},

--- a/src/Functions/geohashEncode.cpp
+++ b/src/Functions/geohashEncode.cpp
@@ -17,7 +17,6 @@ namespace DB
 namespace ErrorCodes
 {
     extern const int LOGICAL_ERROR;
-    extern const int TOO_MANY_ARGUMENTS_FOR_FUNCTION;
 }
 
 namespace
@@ -40,19 +39,16 @@ public:
     bool useDefaultImplementationForConstants() const override { return true; }
     bool isSuitableForShortCircuitArgumentsExecution(const DataTypesWithConstInfo & /*arguments*/) const override { return true; }
 
-    DataTypePtr getReturnTypeImpl(const DataTypes & arguments) const override
+    DataTypePtr getReturnTypeImpl(const ColumnsWithTypeAndName & arguments) const override
     {
-        validateArgumentType(*this, arguments, 0, isFloat, "float");
-        validateArgumentType(*this, arguments, 1, isFloat, "float");
-        if (arguments.size() == 3)
-        {
-            validateArgumentType(*this, arguments, 2, isInteger, "integer");
-        }
-        if (arguments.size() > 3)
-        {
-            throw Exception(ErrorCodes::TOO_MANY_ARGUMENTS_FOR_FUNCTION, "Too many arguments for function {} expected at most 3",
-                            getName());
-        }
+        FunctionArgumentDescriptors mandatory_args{
+            {"longitude", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isFloat), nullptr, "Float*"},
+            {"latitude", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isFloat), nullptr, "Float*"}
+        };
+        FunctionArgumentDescriptors optional_args{
+            {"precision", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isInteger), nullptr, "(U)Int*"}
+        };
+        validateFunctionArguments(*this, arguments, mandatory_args, optional_args);
 
         return std::make_shared<DataTypeString>();
     }

--- a/src/Functions/geohashesInBox.cpp
+++ b/src/Functions/geohashesInBox.cpp
@@ -35,22 +35,25 @@ public:
 
     size_t getNumberOfArguments() const override { return 5; }
 
-    DataTypePtr getReturnTypeImpl(const DataTypes & arguments) const override
+    DataTypePtr getReturnTypeImpl(const ColumnsWithTypeAndName & arguments) const override
     {
-        validateArgumentType(*this, arguments, 0, isFloat, "float");
-        validateArgumentType(*this, arguments, 1, isFloat, "float");
-        validateArgumentType(*this, arguments, 2, isFloat, "float");
-        validateArgumentType(*this, arguments, 3, isFloat, "float");
-        validateArgumentType(*this, arguments, 4, isUInt8, "integer");
+        FunctionArgumentDescriptors args{
+            {"longitute_min", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isFloat), nullptr, "Float*"},
+            {"latitude_min", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isFloat), nullptr, "Float*"},
+            {"longitute_max", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isFloat), nullptr, "Float*"},
+            {"latitude_max", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isFloat), nullptr, "Float*"},
+            {"precision", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isUInt8), nullptr, "UInt8"}
+        };
+        validateFunctionArguments(*this, arguments, args);
 
-        if (!(arguments[0]->equals(*arguments[1]) &&
-              arguments[0]->equals(*arguments[2]) &&
-              arguments[0]->equals(*arguments[3])))
+        if (!(arguments[0].type->equals(*arguments[1].type) &&
+              arguments[0].type->equals(*arguments[2].type) &&
+              arguments[0].type->equals(*arguments[3].type)))
         {
             throw Exception(ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT,
                             "Illegal type of argument of {} all coordinate arguments must have the same type, "
-                            "instead they are:{}, {}, {}, {}.", getName(), arguments[0]->getName(),
-                            arguments[1]->getName(), arguments[2]->getName(), arguments[3]->getName());
+                            "instead they are:{}, {}, {}, {}.", getName(), arguments[0].type->getName(),
+                            arguments[1].type->getName(), arguments[2].type->getName(), arguments[3].type->getName());
         }
 
         return std::make_shared<DataTypeArray>(std::make_shared<DataTypeString>());

--- a/src/Functions/makeDate.cpp
+++ b/src/Functions/makeDate.cpp
@@ -87,7 +87,7 @@ public:
                 {mandatory_argument_names_year_month_day[1], static_cast<FunctionArgumentDescriptor::TypeValidator>(&isNumber), nullptr, "Number"},
                 {mandatory_argument_names_year_month_day[2], static_cast<FunctionArgumentDescriptor::TypeValidator>(&isNumber), nullptr, "Number"}
             };
-            validateFunctionArgumentTypes(*this, arguments, args);
+            validateFunctionArguments(*this, arguments, args);
         }
         else
         {
@@ -95,7 +95,7 @@ public:
                 {mandatory_argument_names_year_dayofyear[0], static_cast<FunctionArgumentDescriptor::TypeValidator>(&isNumber), nullptr, "Number"},
                 {mandatory_argument_names_year_dayofyear[1], static_cast<FunctionArgumentDescriptor::TypeValidator>(&isNumber), nullptr, "Number"}
             };
-            validateFunctionArgumentTypes(*this, arguments, args);
+            validateFunctionArguments(*this, arguments, args);
         }
 
         return std::make_shared<typename Traits::ReturnDataType>();
@@ -193,7 +193,7 @@ public:
             {mandatory_argument_names[0], static_cast<FunctionArgumentDescriptor::TypeValidator>(&isNumber), nullptr, "Number"}
         };
 
-        validateFunctionArgumentTypes(*this, arguments, args);
+        validateFunctionArguments(*this, arguments, args);
 
         return std::make_shared<typename Traits::ReturnDataType>();
     }
@@ -357,7 +357,7 @@ public:
             {optional_argument_names[0], static_cast<FunctionArgumentDescriptor::TypeValidator>(&isString), isColumnConst, "const String"}
         };
 
-        validateFunctionArgumentTypes(*this, arguments, mandatory_args, optional_args);
+        validateFunctionArguments(*this, arguments, mandatory_args, optional_args);
 
         /// Optional timezone argument
         std::string timezone;
@@ -440,7 +440,7 @@ public:
             {optional_argument_names[2], static_cast<FunctionArgumentDescriptor::TypeValidator>(&isString), isColumnConst, "const String"}
         };
 
-        validateFunctionArgumentTypes(*this, arguments, mandatory_args, optional_args);
+            validateFunctionArguments(*this, arguments, mandatory_args, optional_args);
 
         if (arguments.size() >= mandatory_argument_names.size() + 1)
         {
@@ -572,7 +572,7 @@ public:
             {optional_argument_names[0], static_cast<FunctionArgumentDescriptor::TypeValidator>(&isString), isColumnConst, "const String"}
         };
 
-        validateFunctionArgumentTypes(*this, arguments, mandatory_args, optional_args);
+        validateFunctionArguments(*this, arguments, mandatory_args, optional_args);
 
         /// Optional timezone argument
         std::string timezone;
@@ -652,7 +652,7 @@ public:
             {optional_argument_names[0], static_cast<FunctionArgumentDescriptor::TypeValidator>(&isString), isColumnConst, "const String"}
         };
 
-        validateFunctionArgumentTypes(*this, arguments, mandatory_args, optional_args);
+        validateFunctionArguments(*this, arguments, mandatory_args, optional_args);
 
         /// Optional precision argument
         auto precision = DEFAULT_PRECISION;

--- a/src/Functions/parseDateTime.cpp
+++ b/src/Functions/parseDateTime.cpp
@@ -589,7 +589,7 @@ namespace
                 {"timezone", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isString), &isColumnConst, "const String"}
             };
 
-            validateFunctionArgumentTypes(*this, arguments, mandatory_args, optional_args);
+            validateFunctionArguments(*this, arguments, mandatory_args, optional_args);
 
             String time_zone_name = getTimeZone(arguments).getTimeZone();
             DataTypePtr date_type = std::make_shared<DataTypeDateTime>(time_zone_name);

--- a/src/Functions/parseReadableSize.cpp
+++ b/src/Functions/parseReadableSize.cpp
@@ -68,7 +68,7 @@ public:
         {
             {"readable_size", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isString), nullptr, "String"},
         };
-        validateFunctionArgumentTypes(*this, arguments, args);
+        validateFunctionArguments(*this, arguments, args);
         DataTypePtr return_type = std::make_shared<DataTypeUInt64>();
         if constexpr (error_handling == ErrorHandling::Null)
             return std::make_shared<DataTypeNullable>(return_type);

--- a/src/Functions/regexpExtract.cpp
+++ b/src/Functions/regexpExtract.cpp
@@ -54,7 +54,7 @@ public:
         if (arguments.size() == 3)
             args.emplace_back(FunctionArgumentDescriptor{"index", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isInteger), nullptr, "Integer"});
 
-        validateFunctionArgumentTypes(*this, arguments, args);
+        validateFunctionArguments(*this, arguments, args);
 
         return std::make_shared<DataTypeString>();
     }

--- a/src/Functions/repeat.cpp
+++ b/src/Functions/repeat.cpp
@@ -201,7 +201,7 @@ public:
             {"n", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isInteger), nullptr, "Integer"},
         };
 
-        validateFunctionArgumentTypes(*this, arguments, args);
+        validateFunctionArguments(*this, arguments, args);
 
         return std::make_shared<DataTypeString>();
     }

--- a/src/Functions/seriesDecomposeSTL.cpp
+++ b/src/Functions/seriesDecomposeSTL.cpp
@@ -45,7 +45,7 @@ public:
             {"time_series", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isArray), nullptr, "Array"},
             {"period", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isNativeUInt), nullptr, "Unsigned Integer"},
         };
-        validateFunctionArgumentTypes(*this, arguments, args);
+        validateFunctionArguments(*this, arguments, args);
 
         return std::make_shared<DataTypeArray>(std::make_shared<DataTypeArray>(std::make_shared<DataTypeFloat32>()));
     }

--- a/src/Functions/seriesOutliersDetectTukey.cpp
+++ b/src/Functions/seriesOutliersDetectTukey.cpp
@@ -51,7 +51,7 @@ public:
             {"max_percentile", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isFloat), isColumnConst, "Number"},
             {"k", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isNativeNumber), isColumnConst, "Number"}};
 
-        validateFunctionArgumentTypes(*this, arguments, mandatory_args, optional_args);
+        validateFunctionArguments(*this, arguments, mandatory_args, optional_args);
 
         return std::make_shared<DataTypeArray>(std::make_shared<DataTypeFloat64>());
     }

--- a/src/Functions/seriesPeriodDetectFFT.cpp
+++ b/src/Functions/seriesPeriodDetectFFT.cpp
@@ -53,7 +53,7 @@ public:
     DataTypePtr getReturnTypeImpl(const ColumnsWithTypeAndName & arguments) const override
     {
         FunctionArgumentDescriptors args{{"time_series", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isArray), nullptr, "Array"}};
-        validateFunctionArgumentTypes(*this, arguments, args);
+        validateFunctionArguments(*this, arguments, args);
 
         return std::make_shared<DataTypeFloat64>();
     }

--- a/src/Functions/snowflake.cpp
+++ b/src/Functions/snowflake.cpp
@@ -64,7 +64,7 @@ public:
         FunctionArgumentDescriptors args{
             {"value", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isDateTime), nullptr, "DateTime"}
         };
-        validateFunctionArgumentTypes(*this, arguments, args);
+        validateFunctionArguments(*this, arguments, args);
 
         return std::make_shared<DataTypeInt64>();
     }
@@ -121,7 +121,7 @@ public:
         FunctionArgumentDescriptors optional_args{
             {"time_zone", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isString), nullptr, "String"}
         };
-        validateFunctionArgumentTypes(*this, arguments, mandatory_args, optional_args);
+        validateFunctionArguments(*this, arguments, mandatory_args, optional_args);
 
         String timezone;
         if (arguments.size() == 2)
@@ -190,7 +190,7 @@ public:
         FunctionArgumentDescriptors args{
             {"value", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isDateTime64), nullptr, "DateTime64"}
         };
-        validateFunctionArgumentTypes(*this, arguments, args);
+        validateFunctionArguments(*this, arguments, args);
 
         return std::make_shared<DataTypeInt64>();
     }
@@ -255,7 +255,7 @@ public:
         FunctionArgumentDescriptors optional_args{
             {"time_zone", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isString), nullptr, "String"}
         };
-        validateFunctionArgumentTypes(*this, arguments, mandatory_args, optional_args);
+        validateFunctionArguments(*this, arguments, mandatory_args, optional_args);
 
         String timezone;
         if (arguments.size() == 2)

--- a/src/Functions/snowflakeIDToDateTime.cpp
+++ b/src/Functions/snowflakeIDToDateTime.cpp
@@ -56,7 +56,7 @@ public:
             {"epoch", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isNativeUInt), isColumnConst, "const UInt*"},
             {"time_zone", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isString), nullptr, "String"}
         };
-        validateFunctionArgumentTypes(*this, arguments, args, optional_args);
+        validateFunctionArguments(*this, arguments, args, optional_args);
 
         String timezone;
         if (arguments.size() == 3)
@@ -127,7 +127,7 @@ public:
             {"epoch", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isNativeUInt), isColumnConst, "const UInt*"},
             {"time_zone", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isString), nullptr, "String"}
         };
-        validateFunctionArgumentTypes(*this, arguments, args, optional_args);
+        validateFunctionArguments(*this, arguments, args, optional_args);
 
         String timezone;
         if (arguments.size() == 3)

--- a/src/Functions/space.cpp
+++ b/src/Functions/space.cpp
@@ -48,7 +48,7 @@ public:
             {"n", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isInteger), nullptr, "Integer"}
         };
 
-        validateFunctionArgumentTypes(*this, arguments, args);
+            validateFunctionArguments(*this, arguments, args);
 
         return std::make_shared<DataTypeString>();
     }

--- a/src/Functions/sqid.cpp
+++ b/src/Functions/sqid.cpp
@@ -100,7 +100,7 @@ public:
         FunctionArgumentDescriptors args{
             {"sqid", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isString), nullptr, "String"}
         };
-        validateFunctionArgumentTypes(*this, arguments, args);
+        validateFunctionArguments(*this, arguments, args);
 
         return std::make_shared<DataTypeArray>(std::make_shared<DataTypeUInt64>());
     }

--- a/src/Functions/timestamp.cpp
+++ b/src/Functions/timestamp.cpp
@@ -46,7 +46,7 @@ public:
         FunctionArgumentDescriptors optional_args{
             {"time", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isString), nullptr, "String"}
         };
-        validateFunctionArgumentTypes(*this, arguments, mandatory_args, optional_args);
+        validateFunctionArguments(*this, arguments, mandatory_args, optional_args);
 
         return std::make_shared<DataTypeDateTime64>(DATETIME_SCALE);
     }

--- a/src/Functions/toDecimalString.cpp
+++ b/src/Functions/toDecimalString.cpp
@@ -43,7 +43,7 @@ public:
             {"precision", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isNativeInteger), &isColumnConst, "const Integer"}
         };
 
-        validateFunctionArgumentTypes(*this, arguments, mandatory_args, {});
+        validateFunctionArguments(*this, arguments, mandatory_args, {});
 
         return std::make_shared<DataTypeString>();
     }


### PR DESCRIPTION
Original motivation was this bad error message (missing commas):

```
Incorrect number of arguments for function generateSnowflakeID provided 2 (UInt8, DateTime64(3)), expected 0 to 1 (, ['expr' : Arbitrary expression])
```

The comma is fixed now. In this particular error message, we also no longer print input and expected types (which was distraction).

While at it, I converted the few usages of `validateArgumentType` to `validateFunctionArgumentTypes` and removed `validateArgumentType`.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)