### PR TITLE
Bump rocksdb to v6.23.3

### DIFF
--- a/contrib/rocksdb-cmake/CMakeLists.txt
+++ b/contrib/rocksdb-cmake/CMakeLists.txt
@@ -1,7 +1,7 @@
-option (ENABLE_ROCKSDB "Enable rocksdb library" ${ENABLE_LIBRARIES})
+option (ENABLE_ROCKSDB "Enable RocksDB" ${ENABLE_LIBRARIES})
 
 if (NOT ENABLE_ROCKSDB)
-  message (STATUS "Not using rocksdb")
+  message (STATUS "Not using RocksDB")
   return()
 endif()
 


### PR DESCRIPTION
ClickHouse's RocksDB submodule is outdated and it has a messy history. This is a first attempt to raise the version (only by a little bit) using the recommended [versioning scheme](https://clickhouse.com/docs/en/development/contrib#adding-and-maintaining-third-party-libraries) but I especially like to fine out which earlier custom patches are still necessary and which are not.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
