### PR TITLE
[Docs] update time window functions

### DIFF
--- a/docs/en/sql-reference/functions/time-window-functions.md
+++ b/docs/en/sql-reference/functions/time-window-functions.md
@@ -6,44 +6,120 @@ sidebar_label: Time Window
 
 # Time Window Functions
 
-Time window functions return the inclusive lower and exclusive upper bound of the corresponding window. The functions for working with WindowView are listed below:
+Time window functions return the inclusive lower and exclusive upper bound of the corresponding window. The functions for working with [WindowView](../statements/create/view.md/#window-view-experimental) are listed below:
 
 ## tumble
 
 A tumbling time window assigns records to non-overlapping, continuous windows with a fixed duration (`interval`). 
+
+**Syntax**
 
 ``` sql
 tumble(time_attr, interval [, timezone])
 ```
 
 **Arguments**
-- `time_attr` - Date and time. [DateTime](../data-types/datetime.md) data type.
-- `interval` - Window interval in [Interval](../data-types/special-data-types/interval.md) data type.
+- `time_attr` — Date and time. [DateTime](../data-types/datetime.md).
+- `interval` — Window interval in [Interval](../data-types/special-data-types/interval.md).
 - `timezone` — [Timezone name](../../operations/server-configuration-parameters/settings.md#server_configuration_parameters-timezone) (optional). 
 
 **Returned values**
 
-- The inclusive lower and exclusive upper bound of the corresponding tumbling window. [Tuple](../data-types/tuple.md)([DateTime](../data-types/datetime.md), [DateTime](../data-types/datetime.md))`.
+- The inclusive lower and exclusive upper bound of the corresponding tumbling window. [Tuple](../data-types/tuple.md)([DateTime](../data-types/datetime.md), [DateTime](../data-types/datetime.md)).
 
 **Example**
 
 Query:
 
 ``` sql
-SELECT tumble(now(), toIntervalDay('1'))
+SELECT tumble(now(), toIntervalDay('1'));
 ```
 
 Result:
 
 ``` text
 ┌─tumble(now(), toIntervalDay('1'))─────────────┐
-│ ['2020-01-01 00:00:00','2020-01-02 00:00:00'] │
+│ ('2024-07-04 00:00:00','2024-07-05 00:00:00') │
 └───────────────────────────────────────────────┘
+```
+
+## tumbleStart
+
+Returns the inclusive lower bound of the corresponding [tumbling window](#tumble).
+
+**Syntax**
+
+``` sql
+tumbleStart(bounds_tuple);
+tumbleStart(time_attr, interval [, timezone]);
+```
+
+**Arguments**
+
+- `time_attr` — Date and time. [DateTime](../data-types/datetime.md).
+- `interval` — Window interval in [Interval](../data-types/special-data-types/interval.md).
+- `timezone` — [Timezone name](../../operations/server-configuration-parameters/settings.md#server_configuration_parameters-timezone) (optional).
+
+**Returned values**
+
+- The inclusive lower bound of the corresponding tumbling window. [DateTime](../data-types/datetime.md), [Tuple](../data-types/tuple.md) or [UInt32](../data-types/int-uint.md).
+
+**Example**
+
+Query:
+
+```sql
+SELECT tumbleStart(now(), toIntervalDay('1'));
+```
+
+Result:
+
+```response
+┌─tumbleStart(now(), toIntervalDay('1'))─┐
+│                    2024-07-04 00:00:00 │
+└────────────────────────────────────────┘
+```
+
+## tumbleEnd
+
+Returns the exclusive upper bound of the corresponding [tumbling window](#tumble).
+
+**Syntax**
+
+``` sql
+tumbleEnd(bounds_tuple);
+tumbleEnd(time_attr, interval [, timezone]);
+```
+
+**Arguments**
+
+- `time_attr` — Date and time. [DateTime](../data-types/datetime.md).
+- `interval` — Window interval in [Interval](../data-types/special-data-types/interval.md).
+- `timezone` — [Timezone name](../../operations/server-configuration-parameters/settings.md#server_configuration_parameters-timezone) (optional).
+
+**Returned values**
+
+- The inclusive lower bound of the corresponding tumbling window. [DateTime](../data-types/datetime.md), [Tuple](../data-types/tuple.md) or [UInt32](../data-types/int-uint.md).
+
+**Example**
+
+Query:
+
+```sql
+SELECT tumbleEnd(now(), toIntervalDay('1'));
+```
+
+Result:
+
+```response
+┌─tumbleEnd(now(), toIntervalDay('1'))─┐
+│                  2024-07-05 00:00:00 │
+└──────────────────────────────────────┘
 ```
 
 ## hop
 
-A hopping time window has a fixed duration (`window_interval`) and hops by a specified hop interval (`hop_interval`). If the `hop_interval` is smaller than the `window_interval`, hopping windows are overlapping. Thus, records can be assigned to multiple windows. 
+A hopping time window has a fixed duration (`window_interval`) and hops by a specified hop interval (`hop_interval`). If the `hop_interval` is smaller than the `window_interval`, hopping windows are overlapping. Thus, records can be assigned to multiple windows.
 
 ``` sql
 hop(time_attr, hop_interval, window_interval [, timezone])
@@ -51,65 +127,115 @@ hop(time_attr, hop_interval, window_interval [, timezone])
 
 **Arguments**
 
-- `time_attr` - Date and time. [DateTime](../data-types/datetime.md) data type.
-- `hop_interval` - Hop interval in [Interval](../data-types/special-data-types/interval.md) data type. Should be a positive number.
-- `window_interval` - Window interval in [Interval](../data-types/special-data-types/interval.md) data type. Should be a positive number.
-- `timezone` — [Timezone name](../../operations/server-configuration-parameters/settings.md#server_configuration_parameters-timezone) (optional). 
+- `time_attr` — Date and time. [DateTime](../data-types/datetime.md).
+- `hop_interval` — Positive Hop interval. [Interval](../data-types/special-data-types/interval.md).
+- `window_interval` — Positive Window interval. [Interval](../data-types/special-data-types/interval.md).
+- `timezone` — [Timezone name](../../operations/server-configuration-parameters/settings.md#server_configuration_parameters-timezone) (optional).
 
 **Returned values**
 
-- The inclusive lower and exclusive upper bound of the corresponding hopping window. Since one record can be assigned to multiple hop windows, the function only returns the bound of the **first** window when hop function is used **without** `WINDOW VIEW`. [Tuple](../data-types/tuple.md)([DateTime](../data-types/datetime.md), [DateTime](../data-types/datetime.md))`.
+- The inclusive lower and exclusive upper bound of the corresponding hopping window. [Tuple](../data-types/tuple.md)([DateTime](../data-types/datetime.md), [DateTime](../data-types/datetime.md))`.
+
+:::note
+Since one record can be assigned to multiple hop windows, the function only returns the bound of the **first** window when hop function is used **without** `WINDOW VIEW`.
+:::
 
 **Example**
 
 Query:
 
 ``` sql
-SELECT hop(now(), INTERVAL '1' SECOND, INTERVAL '2' SECOND)
+SELECT hop(now(), INTERVAL '1' DAY, INTERVAL '2' DAY);
 ```
 
 Result:
 
 ``` text
-┌─hop(now(), toIntervalSecond('1'), toIntervalSecond('2'))──┐
-│ ('2020-01-14 16:58:22','2020-01-14 16:58:24')             │
-└───────────────────────────────────────────────────────────┘
-```
-
-## tumbleStart
-
-Returns the inclusive lower bound of the corresponding tumbling window.
-
-``` sql
-tumbleStart(bounds_tuple);
-tumbleStart(time_attr, interval [, timezone]);
-```
-
-## tumbleEnd
-
-Returns the exclusive upper bound of the corresponding tumbling window.
-
-``` sql
-tumbleEnd(bounds_tuple);
-tumbleEnd(time_attr, interval [, timezone]);
+┌─hop(now(), toIntervalDay('1'), toIntervalDay('2'))─┐
+│ ('2024-07-03 00:00:00','2024-07-05 00:00:00')      │
+└────────────────────────────────────────────────────┘
 ```
 
 ## hopStart
 
-Returns the inclusive lower bound of the corresponding hopping window.
+Returns the inclusive lower bound of the corresponding [hopping window](#hop).
+
+**Syntax**
 
 ``` sql
 hopStart(bounds_tuple);
 hopStart(time_attr, hop_interval, window_interval [, timezone]);
 ```
+**Arguments**
+
+- `time_attr` — Date and time. [DateTime](../data-types/datetime.md).
+- `hop_interval` — Positive Hop interval. [Interval](../data-types/special-data-types/interval.md).
+- `window_interval` — Positive Window interval. [Interval](../data-types/special-data-types/interval.md).
+- `timezone` — [Timezone name](../../operations/server-configuration-parameters/settings.md#server_configuration_parameters-timezone) (optional).
+
+**Returned values**
+
+- The inclusive lower bound of the corresponding hopping window. [DateTime](../data-types/datetime.md), [Tuple](../data-types/tuple.md) or [UInt32](../data-types/int-uint.md).
+
+:::note
+Since one record can be assigned to multiple hop windows, the function only returns the bound of the **first** window when hop function is used **without** `WINDOW VIEW`.
+:::
+
+**Example**
+
+Query:
+
+``` sql
+SELECT hopStart(now(), INTERVAL '1' DAY, INTERVAL '2' DAY);
+```
+
+Result:
+
+``` text
+┌─hopStart(now(), toIntervalDay('1'), toIntervalDay('2'))─┐
+│                                     2024-07-03 00:00:00 │
+└─────────────────────────────────────────────────────────┘
+```
 
 ## hopEnd
 
-Returns the exclusive upper bound of the corresponding hopping window.
+Returns the exclusive upper bound of the corresponding [hopping window](#hop).
+
+**Syntax**
 
 ``` sql
 hopEnd(bounds_tuple);
 hopEnd(time_attr, hop_interval, window_interval [, timezone]);
+```
+**Arguments**
+
+- `time_attr` — Date and time. [DateTime](../data-types/datetime.md).
+- `hop_interval` — Positive Hop interval. [Interval](../data-types/special-data-types/interval.md). 
+- `window_interval` — Positive Window interval. [Interval](../data-types/special-data-types/interval.md).
+- `timezone` — [Timezone name](../../operations/server-configuration-parameters/settings.md#server_configuration_parameters-timezone) (optional).
+
+**Returned values**
+
+- The exclusive upper bound of the corresponding hopping window. [DateTime](../data-types/datetime.md), [Tuple](../data-types/tuple.md) or [UInt32](../data-types/int-uint.md).
+
+:::note
+Since one record can be assigned to multiple hop windows, the function only returns the bound of the **first** window when hop function is used **without** `WINDOW VIEW`.
+:::
+
+**Example**
+
+Query:
+
+``` sql
+SELECT hopEnd(now(), INTERVAL '1' DAY, INTERVAL '2' DAY);
+```
+
+Result:
+
+``` text
+┌─hopEnd(now(), toIntervalDay('1'), toIntervalDay('2'))─┐
+│                                   2024-07-05 00:00:00 │
+└───────────────────────────────────────────────────────┘
 ```
 
 ## Related content

--- a/docs/en/sql-reference/functions/time-window-functions.md
+++ b/docs/en/sql-reference/functions/time-window-functions.md
@@ -50,7 +50,6 @@ Returns the inclusive lower bound of the corresponding [tumbling window](#tumble
 **Syntax**
 
 ``` sql
-tumbleStart(bounds_tuple);
 tumbleStart(time_attr, interval [, timezone]);
 ```
 
@@ -59,6 +58,8 @@ tumbleStart(time_attr, interval [, timezone]);
 - `time_attr` — Date and time. [DateTime](../data-types/datetime.md).
 - `interval` — Window interval in [Interval](../data-types/special-data-types/interval.md).
 - `timezone` — [Timezone name](../../operations/server-configuration-parameters/settings.md#server_configuration_parameters-timezone) (optional).
+
+The parameters above can also be passed to the function as a [tuple](../data-types/tuple.md).
 
 **Returned values**
 
@@ -87,7 +88,6 @@ Returns the exclusive upper bound of the corresponding [tumbling window](#tumble
 **Syntax**
 
 ``` sql
-tumbleEnd(bounds_tuple);
 tumbleEnd(time_attr, interval [, timezone]);
 ```
 
@@ -96,6 +96,8 @@ tumbleEnd(time_attr, interval [, timezone]);
 - `time_attr` — Date and time. [DateTime](../data-types/datetime.md).
 - `interval` — Window interval in [Interval](../data-types/special-data-types/interval.md).
 - `timezone` — [Timezone name](../../operations/server-configuration-parameters/settings.md#server_configuration_parameters-timezone) (optional).
+
+The parameters above can also be passed to the function as a [tuple](../data-types/tuple.md).
 
 **Returned values**
 
@@ -163,7 +165,6 @@ Returns the inclusive lower bound of the corresponding [hopping window](#hop).
 **Syntax**
 
 ``` sql
-hopStart(bounds_tuple);
 hopStart(time_attr, hop_interval, window_interval [, timezone]);
 ```
 **Arguments**
@@ -172,6 +173,8 @@ hopStart(time_attr, hop_interval, window_interval [, timezone]);
 - `hop_interval` — Positive Hop interval. [Interval](../data-types/special-data-types/interval.md).
 - `window_interval` — Positive Window interval. [Interval](../data-types/special-data-types/interval.md).
 - `timezone` — [Timezone name](../../operations/server-configuration-parameters/settings.md#server_configuration_parameters-timezone) (optional).
+
+The parameters above can also be passed to the function as a [tuple](../data-types/tuple.md).
 
 **Returned values**
 
@@ -204,7 +207,6 @@ Returns the exclusive upper bound of the corresponding [hopping window](#hop).
 **Syntax**
 
 ``` sql
-hopEnd(bounds_tuple);
 hopEnd(time_attr, hop_interval, window_interval [, timezone]);
 ```
 **Arguments**
@@ -213,6 +215,8 @@ hopEnd(time_attr, hop_interval, window_interval [, timezone]);
 - `hop_interval` — Positive Hop interval. [Interval](../data-types/special-data-types/interval.md). 
 - `window_interval` — Positive Window interval. [Interval](../data-types/special-data-types/interval.md).
 - `timezone` — [Timezone name](../../operations/server-configuration-parameters/settings.md#server_configuration_parameters-timezone) (optional).
+
+The parameters above can also be passed to the function as a [tuple](../data-types/tuple.md).
 
 **Returned values**
 
@@ -236,6 +240,7 @@ Result:
 ┌─hopEnd(now(), toIntervalDay('1'), toIntervalDay('2'))─┐
 │                                   2024-07-05 00:00:00 │
 └───────────────────────────────────────────────────────┘
+
 ```
 
 ## Related content


### PR DESCRIPTION
Closes [#2029](https://github.com/ClickHouse/clickhouse-docs/issues/2029) as part of the [functions project](https://github.com/ClickHouse/clickhouse-docs/issues/1833) to document missing / insufficiently documented functions.

- makes updates to formatting of time window functions page
- adds missing examples for `start`/`end` variants of `tumble` and `hop`.

### Changelog category (leave one):
- Documentation (changelog entry is not required)
