### PR TITLE
Bump s2geometry again

### DIFF
--- a/contrib/s2geometry-cmake/CMakeLists.txt
+++ b/contrib/s2geometry-cmake/CMakeLists.txt
@@ -1,7 +1,6 @@
 option(ENABLE_S2_GEOMETRY "Enable S2 Geometry" ${ENABLE_LIBRARIES})
 
-# ARCH_S390X broke upstream, it can be re-enabled once https://github.com/google/s2geometry/pull/372 is merged
-if (NOT ENABLE_S2_GEOMETRY OR ARCH_S390X)
+if (NOT ENABLE_S2_GEOMETRY)
     message(STATUS "Not using S2 Geometry")
     return()
 endif()


### PR DESCRIPTION
Sorry for bumping s2geometry again but after the [previous PR](https://github.com/ClickHouse/ClickHouse/pull/66094) two small changes were made which will help with LLVM 16+.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)