### PR TITLE
[Docs] add missing alias `fullHostName`

### DIFF
--- a/docs/en/sql-reference/functions/other-functions.md
+++ b/docs/en/sql-reference/functions/other-functions.md
@@ -86,7 +86,7 @@ Returns the fully qualified domain name of the ClickHouse server.
 fqdn();
 ```
 
-This function is case-insensitive.
+Aliases: `fullHostName`, 'FQDN'. 
 
 **Returned value**
 


### PR DESCRIPTION
Closes [#1958](https://github.com/ClickHouse/clickhouse-docs/issues/1958) which is flagged as a missing function as part of [functions project](https://github.com/ClickHouse/clickhouse-docs/issues/1833). It is an alias of already existing function `fqdn`.

- adds missing alias `fullHostName` to the documentation of `fqdn`.

### Changelog category (leave one):
- Documentation (changelog entry is not required)