### PR TITLE
Use peak_threads_usage instead of arrayUniq(thread_ids) in tests

### DIFF
--- a/tests/queries/0_stateless/01275_parallel_mv.reference
+++ b/tests/queries/0_stateless/01275_parallel_mv.reference
@@ -10,7 +10,7 @@ insert into testX select number from numbers(10) settings
     optimize_trivial_insert_select=0,
     max_insert_threads=0; -- { serverError FUNCTION_THROW_IF_VALUE_IS_NON_ZERO }
 system flush logs;
-select arrayUniq(thread_ids) from system.query_log where
+select peak_threads_usage from system.query_log where
     current_database = currentDatabase() and
     type != 'QueryStart' and
     query like '%insert into testX %' and
@@ -34,7 +34,7 @@ insert into testX select number from numbers(10) settings
     optimize_trivial_insert_select=0,
     max_insert_threads=16; -- { serverError FUNCTION_THROW_IF_VALUE_IS_NON_ZERO }
 system flush logs;
-select arrayUniq(thread_ids) from system.query_log where
+select peak_threads_usage from system.query_log where
     current_database = currentDatabase() and
     type != 'QueryStart' and
     query like '%insert into testX %' and
@@ -58,7 +58,7 @@ insert into testX select number from numbers(10) settings
     optimize_trivial_insert_select=1,
     max_insert_threads=0; -- { serverError FUNCTION_THROW_IF_VALUE_IS_NON_ZERO }
 system flush logs;
-select arrayUniq(thread_ids) from system.query_log where
+select peak_threads_usage from system.query_log where
     current_database = currentDatabase() and
     type != 'QueryStart' and
     query like '%insert into testX %' and
@@ -82,7 +82,7 @@ insert into testX select number from numbers(10) settings
     optimize_trivial_insert_select=1,
     max_insert_threads=16; -- { serverError FUNCTION_THROW_IF_VALUE_IS_NON_ZERO }
 system flush logs;
-select arrayUniq(thread_ids) from system.query_log where
+select peak_threads_usage from system.query_log where
     current_database = currentDatabase() and
     type != 'QueryStart' and
     query like '%insert into testX %' and
@@ -106,7 +106,7 @@ insert into testX select number from numbers(10) settings
     optimize_trivial_insert_select=0,
     max_insert_threads=0; -- { serverError FUNCTION_THROW_IF_VALUE_IS_NON_ZERO }
 system flush logs;
-select arrayUniq(thread_ids) from system.query_log where
+select peak_threads_usage from system.query_log where
     current_database = currentDatabase() and
     type != 'QueryStart' and
     query like '%insert into testX %' and
@@ -130,7 +130,7 @@ insert into testX select number from numbers(10) settings
     optimize_trivial_insert_select=0,
     max_insert_threads=16; -- { serverError FUNCTION_THROW_IF_VALUE_IS_NON_ZERO }
 system flush logs;
-select arrayUniq(thread_ids) from system.query_log where
+select peak_threads_usage from system.query_log where
     current_database = currentDatabase() and
     type != 'QueryStart' and
     query like '%insert into testX %' and
@@ -154,7 +154,7 @@ insert into testX select number from numbers(10) settings
     optimize_trivial_insert_select=1,
     max_insert_threads=0; -- { serverError FUNCTION_THROW_IF_VALUE_IS_NON_ZERO }
 system flush logs;
-select arrayUniq(thread_ids) from system.query_log where
+select peak_threads_usage from system.query_log where
     current_database = currentDatabase() and
     type != 'QueryStart' and
     query like '%insert into testX %' and
@@ -178,7 +178,7 @@ insert into testX select number from numbers(10) settings
     optimize_trivial_insert_select=1,
     max_insert_threads=16; -- { serverError FUNCTION_THROW_IF_VALUE_IS_NON_ZERO }
 system flush logs;
-select arrayUniq(thread_ids) from system.query_log where
+select peak_threads_usage from system.query_log where
     current_database = currentDatabase() and
     type != 'QueryStart' and
     query like '%insert into testX %' and

--- a/tests/queries/0_stateless/01275_parallel_mv.sql.j2
+++ b/tests/queries/0_stateless/01275_parallel_mv.sql.j2
@@ -28,7 +28,7 @@ insert into testX select number from numbers(10) settings
     optimize_trivial_insert_select={{ optimize_trivial_insert_select }},
     max_insert_threads={{ max_insert_threads }}; -- { serverError FUNCTION_THROW_IF_VALUE_IS_NON_ZERO }
 system flush logs;
-select arrayUniq(thread_ids) from system.query_log where
+select peak_threads_usage from system.query_log where
     current_database = currentDatabase() and
     type != 'QueryStart' and
     query like '%insert into testX %' and

--- a/tests/queries/0_stateless/01323_too_many_threads_bug.sql
+++ b/tests/queries/0_stateless/01323_too_many_threads_bug.sql
@@ -14,11 +14,11 @@ set log_queries = 1;
 select x from table_01323_many_parts limit 10 format Null;
 
 system flush logs;
-select arrayUniq(thread_ids) <= 4 from system.query_log where current_database = currentDatabase() AND event_date >= today() - 1 and query ilike '%select x from table_01323_many_parts%' and query not like '%system.query_log%' and type = 'QueryFinish' order by query_start_time desc limit 1;
+select peak_threads_usage <= 4 from system.query_log where current_database = currentDatabase() AND event_date >= today() - 1 and query ilike '%select x from table_01323_many_parts%' and query not like '%system.query_log%' and type = 'QueryFinish' order by query_start_time desc limit 1;
 
 select x from table_01323_many_parts order by x limit 10 format Null;
 
 system flush logs;
-select arrayUniq(thread_ids) <= 36 from system.query_log where current_database = currentDatabase() AND event_date >= today() - 1 and query ilike '%select x from table_01323_many_parts order by x%' and query not like '%system.query_log%' and type = 'QueryFinish' order by query_start_time desc limit 1;
+select peak_threads_usage <= 36 from system.query_log where current_database = currentDatabase() AND event_date >= today() - 1 and query ilike '%select x from table_01323_many_parts order by x%' and query not like '%system.query_log%' and type = 'QueryFinish' order by query_start_time desc limit 1;
 
 drop table if exists table_01323_many_parts;

--- a/tests/queries/0_stateless/02350_views_max_insert_threads.sql
+++ b/tests/queries/0_stateless/02350_views_max_insert_threads.sql
@@ -10,7 +10,7 @@ create materialized view t_mv Engine = Null AS select now() as ts, max(a) from t
 insert into t select * from numbers_mt(10e6) settings max_threads = 16, max_insert_threads=16, max_block_size=100000;
 system flush logs;
 
-select arrayUniq(thread_ids)>=16 from system.query_log where
+select peak_threads_usage>=16 from system.query_log where
     event_date >= yesterday() and
     current_database = currentDatabase() and
     type = 'QueryFinish' and


### PR DESCRIPTION
Should fix flakiness like [1].

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/66098/93afc8e6133365007488c4d8340f434f6e8a876f/stateless_tests__aarch64_.html

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Fixes: https://github.com/ClickHouse/ClickHouse/issues/66116

#### CI Settings (Only check the boxes if you know what you are doing):
- [x] <!---ci_include_stateless--> Allow: Stateless tests