### PR TITLE
[Docs] add `aggThrow` function

### DIFF
--- a/docs/en/sql-reference/aggregate-functions/reference/aggthrow.md
+++ b/docs/en/sql-reference/aggregate-functions/reference/aggthrow.md
@@ -1,0 +1,37 @@
+---
+slug: /en/sql-reference/aggregate-functions/reference/aggthrow
+sidebar_position: 101
+---
+
+# aggThrow
+
+This function can be used for the purpose of testing exception safety. It will throw an exception on creation with the specified probability.
+
+**Syntax**
+
+```sql
+aggThrow(throw_prob)
+```
+
+**Arguments**
+
+- `throw_prob` — Probability to throw on creation. [Float64](../../data-types/float.md).
+
+**Returned value**
+
+- An exception: `Code: 503. DB::Exception: Aggregate function aggThrow has thrown exception successfully`.
+
+**Example**
+
+Query:
+
+```sql
+SELECT number % 2 AS even, aggThrow(number) FROM numbers(10) GROUP BY even;
+```
+
+Result:
+
+```response
+Received exception:
+Code: 503. DB::Exception: Aggregate function aggThrow has thrown exception successfully: While executing AggregatingTransform. (AGGREGATE_FUNCTION_THROW)
+```

--- a/docs/en/sql-reference/aggregate-functions/reference/index.md
+++ b/docs/en/sql-reference/aggregate-functions/reference/index.md
@@ -43,6 +43,7 @@ Standard aggregate functions:
 
 ClickHouse-specific aggregate functions:
 
+- [aggThrow](../reference/aggthrow.md)
 - [analysisOfVariance](../reference/analysis_of_variance.md)
 - [any](../reference/any_respect_nulls.md)
 - [anyHeavy](../reference/anyheavy.md)

--- a/utils/check-style/aspell-ignore/en/aspell-dict.txt
+++ b/utils/check-style/aspell-ignore/en/aspell-dict.txt
@@ -1102,7 +1102,7 @@ aggregatefunction
 aggregatingmergetree
 aggregatio
 aggretate
-aggthrow  
+aggthrow
 aggThrow
 aiochclient
 allocator

--- a/utils/check-style/aspell-ignore/en/aspell-dict.txt
+++ b/utils/check-style/aspell-ignore/en/aspell-dict.txt
@@ -1102,6 +1102,8 @@ aggregatefunction
 aggregatingmergetree
 aggregatio
 aggretate
+aggthrow  
+aggThrow
 aiochclient
 allocator
 alphaTokens


### PR DESCRIPTION
Closes [#1929](https://github.com/ClickHouse/clickhouse-docs/issues/1929) as part of the [functions project](https://github.com/ClickHouse/clickhouse-docs/issues/1833) to document missing functions from the documentation.

Adds:
- `aggThrow`

### Changelog category (leave one):
- Documentation (changelog entry is not required)