### PR TITLE
[Docs] add missing `mapPartialSort`, `mapPartialReverseSort` 

### DIFF
--- a/docs/en/sql-reference/functions/tuple-map-functions.md
+++ b/docs/en/sql-reference/functions/tuple-map-functions.md
@@ -600,7 +600,7 @@ mapApply(func, map)
 
 **Arguments**
 
-- `func`  - [Lambda function](../../sql-reference/functions/index.md#higher-order-functions---operator-and-lambdaparams-expr-function).
+- `func` — [Lambda function](../../sql-reference/functions/index.md#higher-order-functions---operator-and-lambdaparams-expr-function).
 - `map` — [Map](../data-types/map.md).
 
 **Returned value**
@@ -831,7 +831,39 @@ SELECT mapSort((k, v) -> v, map('key2', 2, 'key3', 1, 'key1', 3)) AS map;
 └──────────────────────────────┘
 ```
 
-For more details see the [reference](../../sql-reference/functions/array-functions.md#array_functions-sort) for `arraySort` function.
+For more details see the [reference](../../sql-reference/functions/array-functions.md#array_functions-sort) for `arraySort` function. 
+
+## mapPartialSort
+
+Sorts the elements of a map in ascending order with additional `limit` argument allowing partial sorting. 
+If the `func` function is specified, the sorting order is determined by the result of the `func` function applied to the keys and values of the map.
+
+**Syntax**
+
+```sql
+mapPartialSort([func,] limit, map)
+```
+**Arguments**
+
+- `func` – Optional function to apply to the keys and values of the map. [Lambda function](../../sql-reference/functions/index.md#higher-order-functions---operator-and-lambdaparams-expr-function).
+- `limit` – Elements in range [1..limit] are sorted. [(U)Int](../data-types/int-uint.md).
+- `map` – Map to sort. [Map](../data-types/map.md).
+
+**Returned value**
+
+- Partially sorted map. [Map](../data-types/map.md).
+
+**Example**
+
+``` sql
+SELECT mapPartialSort((k, v) -> v, 2, map('k1', 3, 'k2', 1, 'k3', 2));
+```
+
+``` text
+┌─mapPartialSort(lambda(tuple(k, v), v), 2, map('k1', 3, 'k2', 1, 'k3', 2))─┐
+│ {'k2':1,'k3':2,'k1':3}                                                    │
+└───────────────────────────────────────────────────────────────────────────┘
+```
 
 ## mapReverseSort(\[func,\], map)
 
@@ -861,3 +893,35 @@ SELECT mapReverseSort((k, v) -> v, map('key2', 2, 'key3', 1, 'key1', 3)) AS map;
 ```
 
 For more details see function [arrayReverseSort](../../sql-reference/functions/array-functions.md#array_functions-reverse-sort).
+
+## mapPartialReverseSort
+
+Sorts the elements of a map in descending order with additional `limit` argument allowing partial sorting.
+If the `func` function is specified, the sorting order is determined by the result of the `func` function applied to the keys and values of the map.
+
+**Syntax**
+
+```sql
+mapPartialReverseSort([func,] limit, map)
+```
+**Arguments**
+
+- `func` – Optional function to apply to the keys and values of the map. [Lambda function](../../sql-reference/functions/index.md#higher-order-functions---operator-and-lambdaparams-expr-function).
+- `limit` – Elements in range [1..limit] are sorted. [(U)Int](../data-types/int-uint.md).
+- `map` – Map to sort. [Map](../data-types/map.md).
+
+**Returned value**
+
+- Partially sorted map. [Map](../data-types/map.md).
+
+**Example**
+
+``` sql
+SELECT mapPartialReverseSort((k, v) -> v, 2, map('k1', 3, 'k2', 1, 'k3', 2));
+```
+
+``` text
+┌─mapPartialReverseSort(lambda(tuple(k, v), v), 2, map('k1', 3, 'k2', 1, 'k3', 2))─┐
+│ {'k1':3,'k3':2,'k2':1}                                                           │
+└──────────────────────────────────────────────────────────────────────────────────┘
+```

--- a/utils/check-style/aspell-ignore/en/aspell-dict.txt
+++ b/utils/check-style/aspell-ignore/en/aspell-dict.txt
@@ -1980,6 +1980,8 @@ mapExtractKeyLike
 mapFilter
 mapFromArrays
 mapKeys
+mapPartialReverseSort
+mapPartialSort
 mapPopulateSeries
 mapReverseSort
 mapSort


### PR DESCRIPTION
Closes [#1980](https://github.com/ClickHouse/clickhouse-docs/issues/1980) as part of the [functions project](https://github.com/ClickHouse/clickhouse-docs/issues/1833) to document missing functions. 

Adds missing:
- `mapPartialSort`
- `mapPartialReverseSort` 

### Changelog category (leave one):
- Documentation (changelog entry is not required)
