### PR TITLE
[Docs] add missing aliases `minMappedArrays`, `maxMappedArrays`

### DIFF
--- a/docs/en/sql-reference/aggregate-functions/reference/maxmap.md
+++ b/docs/en/sql-reference/aggregate-functions/reference/maxmap.md
@@ -5,22 +5,44 @@ sidebar_position: 165
 
 # maxMap
 
-Syntax: `maxMap(key, value)` or `maxMap(Tuple(key, value))`
-
 Calculates the maximum from `value` array according to the keys specified in the `key` array.
 
-Passing a tuple of keys and value arrays is identical to passing two arrays of keys and values.
+**Syntax**
 
-The number of elements in `key` and `value` must be the same for each row that is totaled.
+```sql
+maxMap(key, value)
+```
+or
+```sql
+maxMap(Tuple(key, value))
+```
 
-Returns a tuple of two arrays: keys and values calculated for the corresponding keys.
+Alias: `maxMappedArrays`
 
-Example:
+:::note
+- Passing a tuple of keys and value arrays is identical to passing two arrays of keys and values.
+- The number of elements in `key` and `value` must be the same for each row that is totaled.
+:::
+
+**Parameters**
+
+- `key` — Array of keys. [Array](../../data-types/array.md).
+- `value` — Array of values. [Array](../../data-types/array.md).
+
+**Returned value**
+
+- Returns a tuple of two arrays: keys in sorted order, and values calculated for the corresponding keys. [Tuple](../../data-types/tuple.md)([Array](../../data-types/array.md), [Array](../../data-types/array.md)).
+
+**Example**
+
+Query:
 
 ``` sql
 SELECT maxMap(a, b)
 FROM values('a Array(Char), b Array(Int64)', (['x', 'y'], [2, 2]), (['y', 'z'], [3, 1]))
 ```
+
+Result:
 
 ``` text
 ┌─maxMap(a, b)───────────┐

--- a/docs/en/sql-reference/aggregate-functions/reference/minmap.md
+++ b/docs/en/sql-reference/aggregate-functions/reference/minmap.md
@@ -5,22 +5,44 @@ sidebar_position: 169
 
 # minMap
 
-Syntax: `minMap(key, value)` or `minMap(Tuple(key, value))`
-
 Calculates the minimum from `value` array according to the keys specified in the `key` array.
 
-Passing a tuple of keys and value ​​arrays is identical to passing two arrays of keys and values.
+**Syntax**
 
-The number of elements in `key` and `value` must be the same for each row that is totaled.
+```sql
+`minMap(key, value)`
+```
+or
+```sql
+minMap(Tuple(key, value))
+```
 
-Returns a tuple of two arrays: keys in sorted order, and values calculated for the corresponding keys.
+Alias: `minMappedArrays`
 
-Example:
+:::note
+- Passing a tuple of keys and value arrays is identical to passing an array of keys and an array of values.
+- The number of elements in `key` and `value` must be the same for each row that is totaled.
+:::
+
+**Parameters**
+
+- `key` — Array of keys. [Array](../../data-types/array.md).
+- `value` — Array of values. [Array](../../data-types/array.md).
+
+**Returned value**
+
+- Returns a tuple of two arrays: keys in sorted order, and values calculated for the corresponding keys. [Tuple](../../data-types/tuple.md)([Array](../../data-types/array.md), [Array](../../data-types/array.md)).
+
+**Example**
+
+Query:
 
 ``` sql
 SELECT minMap(a, b)
 FROM values('a Array(Int32), b Array(Int64)', ([1, 2], [2, 2]), ([2, 3], [1, 1]))
 ```
+
+Result:
 
 ``` text
 ┌─minMap(a, b)──────┐

--- a/utils/check-style/aspell-ignore/en/aspell-dict.txt
+++ b/utils/check-style/aspell-ignore/en/aspell-dict.txt
@@ -1996,6 +1996,7 @@ maxMap
 maxintersections
 maxintersectionsposition
 maxmap
+minMappedArrays
 maxmind
 mdadm
 meanZTest
@@ -2013,6 +2014,7 @@ metrica
 metroHash
 mfedotov
 minMap
+minMappedArrays
 minSampleSizeContinuous
 minSampleSizeConversion
 mindsdb


### PR DESCRIPTION
Closes [#1982](https://github.com/ClickHouse/clickhouse-docs/issues/1982) as part of [Document all ClickHouse functions](https://github.com/ClickHouse/clickhouse-docs/issues/1833). 

- updates formatting of `minMap` and `maxMap` pages.
- adds missing aliases `minMappedArrays` and `maxMappedArrays` to the functions above.

### Changelog category (leave one):
- Documentation (changelog entry is not required)