### PR TITLE
Speed up `replaceRegexp(All|One)` if the pattern is trivial

### DIFF
--- a/docs/en/sql-reference/functions/string-replace-functions.md
+++ b/docs/en/sql-reference/functions/string-replace-functions.md
@@ -34,7 +34,7 @@ Alias: `replace`.
 
 Replaces the first occurrence of the substring matching the regular expression `pattern` (in [re2 syntax](https://github.com/google/re2/wiki/Syntax)) in `haystack` by the `replacement` string.
 
-`replacement` can containing substitutions `\0-\9`.
+`replacement` can contain substitutions `\0-\9`.
 Substitutions `\1-\9` correspond to the 1st to 9th capturing group (submatch), substitution `\0` corresponds to the entire match.
 
 To use a verbatim `\` character in the `pattern` or `replacement` strings, escape it using `\`.

--- a/src/Functions/ReplaceRegexpImpl.h
+++ b/src/Functions/ReplaceRegexpImpl.h
@@ -48,41 +48,56 @@ struct ReplaceRegexpImpl
 
     static constexpr int max_captures = 10;
 
-    static Instructions createInstructions(std::string_view replacement, int num_captures)
+    /// The replacement string references must not contain non-existing capturing groups.
+    static void checkSubstitutions(std::string_view replacement, int num_captures)
     {
-        Instructions instructions;
-
-        String literals;
         for (size_t i = 0; i < replacement.size(); ++i)
         {
             if (replacement[i] == '\\' && i + 1 < replacement.size())
             {
-                if (isNumericASCII(replacement[i + 1])) /// Substitution
+                if (isNumericASCII(replacement[i + 1])) /// substitution
+                {
+                    int substitution_num = replacement[i + 1] - '0';
+                    if (substitution_num >= num_captures)
+                        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Substitution '\\{}' in replacement argument is invalid, regexp has only {} capturing groups", substitution_num, num_captures - 1);
+                }
+            }
+        }
+    }
+
+    static Instructions createInstructions(std::string_view replacement, int num_captures)
+    {
+        checkSubstitutions(replacement, num_captures);
+
+        Instructions instructions;
+
+        String literals;
+        literals.reserve(replacement.size());
+
+        for (size_t i = 0; i < replacement.size(); ++i)
+        {
+            if (replacement[i] == '\\' && i + 1 < replacement.size())
+            {
+                if (isNumericASCII(replacement[i + 1])) /// substitution
                 {
                     if (!literals.empty())
                     {
                         instructions.emplace_back(literals);
                         literals = "";
                     }
-                    instructions.emplace_back(replacement[i + 1] - '0');
+                    int substitution_num = replacement[i + 1] - '0';
+                    instructions.emplace_back(substitution_num);
                 }
                 else
-                    literals += replacement[i + 1]; /// Escaping
+                    literals += replacement[i + 1]; /// escaping
                 ++i;
             }
             else
-                literals += replacement[i]; /// Plain character
+                literals += replacement[i]; /// plain character
         }
 
         if (!literals.empty())
             instructions.emplace_back(literals);
-
-        for (const auto & instr : instructions)
-            if (instr.substitution_num >= num_captures)
-                throw Exception(
-                    ErrorCodes::BAD_ARGUMENTS,
-                    "Id {} in replacement string is an invalid substitution, regexp has only {} capturing groups",
-                    instr.substitution_num, num_captures - 1);
 
         return instructions;
     }
@@ -124,7 +139,7 @@ struct ReplaceRegexpImpl
                 {
                     std::string_view replacement;
                     if (instr.substitution_num >= 0)
-                        replacement = std::string_view(matches[instr.substitution_num].data(), matches[instr.substitution_num].size());
+                        replacement = {matches[instr.substitution_num].data(), matches[instr.substitution_num].size()};
                     else
                         replacement = instr.literal;
                     res_data.resize(res_data.size() + replacement.size());
@@ -179,19 +194,15 @@ struct ReplaceRegexpImpl
         res_offsets.resize(haystack_size);
 
         re2::RE2::Options regexp_options;
-        /// Don't write error messages to stderr.
-        regexp_options.set_log_errors(false);
+        regexp_options.set_log_errors(false); /// don't write error messages to stderr
 
         re2::RE2 searcher(needle, regexp_options);
-
         if (!searcher.ok())
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "The pattern argument is not a valid re2 pattern: {}", searcher.error());
 
         int num_captures = std::min(searcher.NumberOfCapturingGroups() + 1, max_captures);
-
         Instructions instructions = createInstructions(replacement, num_captures);
 
-        /// Cannot perform search for whole columns. Will process each string separately.
         for (size_t i = 0; i < haystack_size; ++i)
         {
             size_t from = i > 0 ? haystack_offsets[i - 1] : 0;
@@ -221,10 +232,8 @@ struct ReplaceRegexpImpl
         res_offsets.resize(haystack_size);
 
         re2::RE2::Options regexp_options;
-        /// Don't write error messages to stderr.
-        regexp_options.set_log_errors(false);
+        regexp_options.set_log_errors(false); /// don't write error messages to stderr
 
-        /// Cannot perform search for whole columns. Will process each string separately.
         for (size_t i = 0; i < haystack_size; ++i)
         {
             size_t hs_from = i > 0 ? haystack_offsets[i - 1] : 0;
@@ -242,6 +251,7 @@ struct ReplaceRegexpImpl
             re2::RE2 searcher(needle, regexp_options);
             if (!searcher.ok())
                 throw Exception(ErrorCodes::BAD_ARGUMENTS, "The pattern argument is not a valid re2 pattern: {}", searcher.error());
+
             int num_captures = std::min(searcher.NumberOfCapturingGroups() + 1, max_captures);
             Instructions instructions = createInstructions(replacement, num_captures);
 
@@ -270,17 +280,14 @@ struct ReplaceRegexpImpl
         res_offsets.resize(haystack_size);
 
         re2::RE2::Options regexp_options;
-        /// Don't write error messages to stderr.
-        regexp_options.set_log_errors(false);
+        regexp_options.set_log_errors(false); /// don't write error messages to stderr
 
         re2::RE2 searcher(needle, regexp_options);
-
         if (!searcher.ok())
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "The pattern argument is not a valid re2 pattern: {}", searcher.error());
 
         int num_captures = std::min(searcher.NumberOfCapturingGroups() + 1, max_captures);
 
-        /// Cannot perform search for whole columns. Will process each string separately.
         for (size_t i = 0; i < haystack_size; ++i)
         {
             size_t hs_from = i > 0 ? haystack_offsets[i - 1] : 0;
@@ -290,8 +297,9 @@ struct ReplaceRegexpImpl
             size_t repl_from = i > 0 ? replacement_offsets[i - 1] : 0;
             const char * repl_data = reinterpret_cast<const char *>(replacement_data.data() + repl_from);
             const size_t repl_length = static_cast<unsigned>(replacement_offsets[i] - repl_from - 1);
+            std::string_view replacement(repl_data, repl_length);
 
-            Instructions instructions = createInstructions(std::string_view(repl_data, repl_length), num_captures);
+            Instructions instructions = createInstructions(replacement, num_captures);
 
             processString(hs_data, hs_length, res_data, res_offset, searcher, num_captures, instructions);
             res_offsets[i] = res_offset;
@@ -317,10 +325,8 @@ struct ReplaceRegexpImpl
         res_offsets.resize(haystack_size);
 
         re2::RE2::Options regexp_options;
-        /// Don't write error messages to stderr.
-        regexp_options.set_log_errors(false);
+        regexp_options.set_log_errors(false); /// don't write error messages to stderr
 
-        /// Cannot perform search for whole columns. Will process each string separately.
         for (size_t i = 0; i < haystack_size; ++i)
         {
             size_t hs_from = i > 0 ? haystack_offsets[i - 1] : 0;
@@ -338,12 +344,14 @@ struct ReplaceRegexpImpl
             size_t repl_from = i > 0 ? replacement_offsets[i - 1] : 0;
             const char * repl_data = reinterpret_cast<const char *>(replacement_data.data() + repl_from);
             const size_t repl_length = static_cast<unsigned>(replacement_offsets[i] - repl_from - 1);
+            std::string_view replacement(repl_data, repl_length);
 
             re2::RE2 searcher(needle, regexp_options);
             if (!searcher.ok())
                 throw Exception(ErrorCodes::BAD_ARGUMENTS, "The pattern argument is not a valid re2 pattern: {}", searcher.error());
+
             int num_captures = std::min(searcher.NumberOfCapturingGroups() + 1, max_captures);
-            Instructions instructions = createInstructions(std::string_view(repl_data, repl_length), num_captures);
+            Instructions instructions = createInstructions(replacement, num_captures);
 
             processString(hs_data, hs_length, res_data, res_offset, searcher, num_captures, instructions);
             res_offsets[i] = res_offset;
@@ -367,16 +375,13 @@ struct ReplaceRegexpImpl
         res_offsets.resize(haystack_size);
 
         re2::RE2::Options regexp_options;
-        /// Don't write error messages to stderr.
-        regexp_options.set_log_errors(false);
+        regexp_options.set_log_errors(false); /// don't write error messages to stderr
 
         re2::RE2 searcher(needle, regexp_options);
-
         if (!searcher.ok())
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "The pattern argument is not a valid re2 pattern: {}", searcher.error());
 
         int num_captures = std::min(searcher.NumberOfCapturingGroups() + 1, max_captures);
-
         Instructions instructions = createInstructions(replacement, num_captures);
 
         for (size_t i = 0; i < haystack_size; ++i)

--- a/tests/performance/replaceRegexp_fallback.xml
+++ b/tests/performance/replaceRegexp_fallback.xml
@@ -1,0 +1,12 @@
+<!-- Tests functions replaceRegexpAll and replaceRegexpOne with trivial patterns. These trigger internally a fallback to simple string replacement -->>
+<!-- _materialize_ because the shortcut is only implemented for non-const haystack + const needle + const replacement strings -->>
+<test>
+    <!-- trivial pattern -->>
+    <query>WITH 'Many years later as he faced the firing squad, Colonel Aureliano Buendia was to remember that distant afternoon when his father took him to discover ice.' AS s SELECT replaceRegexpAll(materialize(s), ' ', '\n') AS w FROM numbers(5000000) FORMAT Null</query>
+    <query>WITH 'Many years later as he faced the firing squad, Colonel Aureliano Buendia was to remember that distant afternoon when his father took him to discover ice.' AS s SELECT replaceRegexpOne(materialize(s), ' ', '\n') AS w FROM numbers(5000000) FORMAT Null</query>
+
+    <!-- non-trivial patterns -->>
+    <!-- deliberately testing with fewer rows to keep runtimes reasonable -->>
+    <query>WITH 'Many years later as he faced the firing squad, Colonel Aureliano Buendia was to remember that distant afternoon when his father took him to discover ice.' AS s SELECT replaceRegexpAll(materialize(s), '\s+', '\\0\n') AS w FROM numbers(500000) FORMAT Null</query>
+    <query>WITH 'Many years later as he faced the firing squad, Colonel Aureliano Buendia was to remember that distant afternoon when his father took him to discover ice.' AS s SELECT replaceRegexpOne(materialize(s), '\s+', '\\0\n') AS w FROM numbers(500000) FORMAT Null</query>
+</test>

--- a/tests/queries/0_stateless/02864_replace_regexp_string_fallback.reference
+++ b/tests/queries/0_stateless/02864_replace_regexp_string_fallback.reference
@@ -1,0 +1,1 @@
+Hello	l	x	Hexlo	Hexxo

--- a/tests/queries/0_stateless/02864_replace_regexp_string_fallback.sql
+++ b/tests/queries/0_stateless/02864_replace_regexp_string_fallback.sql
@@ -1,0 +1,11 @@
+-- Tests functions replaceRegexpAll and replaceRegexpOne with trivial patterns. These trigger internally a fallback to simple string replacement.
+
+-- _materialize_ because the shortcut is only implemented for non-const haystack + const needle + const replacement strings
+
+SELECT 'Hello' AS haystack, 'l' AS needle, 'x' AS replacement, replaceRegexpOne(materialize(haystack), needle, replacement), replaceRegexpAll(materialize(haystack), needle, replacement);
+
+-- negative tests
+
+-- Even if the fallback is used, invalid substitutions must throw an exception.
+SELECT 'Hello' AS haystack, 'l' AS needle, '\\1' AS replacement, replaceRegexpOne(materialize(haystack), needle, replacement); -- { serverError BAD_ARGUMENTS }
+SELECT 'Hello' AS haystack, 'l' AS needle, '\\1' AS replacement, replaceRegexpAll(materialize(haystack), needle, replacement); -- { serverError BAD_ARGUMENTS }


### PR DESCRIPTION
The idea is to transform `replaceRegexp(One|All)` into `replace(One|All)` if the pattern is trivial.

This PR is a continuation of #62436 but compared to the original implementation, `ReplaceRegexpImpl` keeps using re2 instead of OptimizedRegularExpression to keep the code overall simple and maintainable.

Measurements with haystack `Many years later as he faced the firing squad, Colonel Aureliano Buendia was to remember that distant afternoon when his father took him to discover ice.` on 5 mio rows

- and complex pattern `\s+` and replacement `\\0\n`
    - replaceRegexpAll: 13.67 sec
    - replaceRegexpOne: 0.628 sec

- and trivial pattern ` ` (space) and replacement `\n`:
    - replaceRegexpAll: 1.63 sec
    - replaceRegexpOne: 0.16 sec

Courtesy to @taiyang-li !

### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Functions `replaceRegexpAll` and `replaceRegexpOne` are now significantly faster if the pattern is trivial, i.e. contains no metacharacters, pattern classes, flags, grouping characters etc. (Thanks to Taiyang Li)