### PR TITLE
[Docs] update `singleValueOrNull`

### DIFF
--- a/docs/en/sql-reference/aggregate-functions/reference/singlevalueornull.md
+++ b/docs/en/sql-reference/aggregate-functions/reference/singlevalueornull.md
@@ -16,7 +16,7 @@ singleValueOrNull(x)
 
 **Parameters**
 
-- `x` — Column of any [data type](../../data-types/index.md).
+- `x` — Column of any [data type](../../data-types/index.md) (except [Map](../../data-types/map.md), [Array](../../data-types/array.md) or [Tuple](../../data-types/tuple) which cannot be of type [Nullable](../../data-types/nullable.md)).
 
 **Returned values**
 


### PR DESCRIPTION
Closes [#66071](https://github.com/ClickHouse/ClickHouse/issues/66071). Adds a note that parameter type cannot be any data type as Map, Array and Tuple themselves cannot be Nullable - which the return type should be.

### Changelog category (leave one):
- Documentation (changelog entry is not required)