### PR TITLE
Reduce inaccuracy of input_wait_elapsed_us/input_wait_elapsed_us/elapsed_us

### DIFF
--- a/src/Interpreters/ProcessorsProfileLog.h
+++ b/src/Interpreters/ProcessorsProfileLog.h
@@ -25,11 +25,11 @@ struct ProcessorProfileLogElement
     String processor_name;
 
     /// Milliseconds spend in IProcessor::work()
-    UInt32 elapsed_us{};
+    UInt64 elapsed_us{};
     /// IProcessor::NeedData
-    UInt32 input_wait_elapsed_us{};
+    UInt64 input_wait_elapsed_us{};
     /// IProcessor::PortFull
-    UInt32 output_wait_elapsed_us{};
+    UInt64 output_wait_elapsed_us{};
 
     size_t input_rows{};
     size_t input_bytes{};

--- a/src/Interpreters/executeQuery.cpp
+++ b/src/Interpreters/executeQuery.cpp
@@ -476,9 +476,9 @@ void logQueryFinish(
                     processor_elem.processor_name = processor->getName();
 
                     /// NOTE: convert this to UInt64
-                    processor_elem.elapsed_us = static_cast<UInt32>(processor->getElapsedUs());
-                    processor_elem.input_wait_elapsed_us = static_cast<UInt32>(processor->getInputWaitElapsedUs());
-                    processor_elem.output_wait_elapsed_us = static_cast<UInt32>(processor->getOutputWaitElapsedUs());
+                    processor_elem.elapsed_us = static_cast<UInt32>(processor->getElapsedNs() / 1000U);
+                    processor_elem.input_wait_elapsed_us = static_cast<UInt32>(processor->getInputWaitElapsedNs() / 1000U);
+                    processor_elem.output_wait_elapsed_us = static_cast<UInt32>(processor->getOutputWaitElapsedNs() / 1000U);
 
                     auto stats = processor->getProcessorDataStats();
                     processor_elem.input_rows = stats.input_rows;

--- a/src/Interpreters/executeQuery.cpp
+++ b/src/Interpreters/executeQuery.cpp
@@ -475,10 +475,9 @@ void logQueryFinish(
 
                     processor_elem.processor_name = processor->getName();
 
-                    /// NOTE: convert this to UInt64
-                    processor_elem.elapsed_us = static_cast<UInt32>(processor->getElapsedNs() / 1000U);
-                    processor_elem.input_wait_elapsed_us = static_cast<UInt32>(processor->getInputWaitElapsedNs() / 1000U);
-                    processor_elem.output_wait_elapsed_us = static_cast<UInt32>(processor->getOutputWaitElapsedNs() / 1000U);
+                    processor_elem.elapsed_us = static_cast<UInt64>(processor->getElapsedNs() / 1000U);
+                    processor_elem.input_wait_elapsed_us = static_cast<UInt64>(processor->getInputWaitElapsedNs() / 1000U);
+                    processor_elem.output_wait_elapsed_us = static_cast<UInt64>(processor->getOutputWaitElapsedNs() / 1000U);
 
                     auto stats = processor->getProcessorDataStats();
                     processor_elem.input_rows = stats.input_rows;

--- a/src/Processors/Executors/ExecutingGraph.cpp
+++ b/src/Processors/Executors/ExecutingGraph.cpp
@@ -292,7 +292,7 @@ bool ExecutingGraph::updateNode(uint64_t pid, Queue & queue, Queue & async_queue
                         }
                         else if (last_status == IProcessor::Status::NeedData && status != IProcessor::Status::NeedData)
                         {
-                            processor.input_wait_elapsed_us += processor.input_wait_watch.elapsedMicroseconds();
+                            processor.input_wait_elapsed_ns += processor.input_wait_watch.elapsedNanoseconds();
                         }
 
                         /// PortFull
@@ -302,7 +302,7 @@ bool ExecutingGraph::updateNode(uint64_t pid, Queue & queue, Queue & async_queue
                         }
                         else if (last_status == IProcessor::Status::PortFull && status != IProcessor::Status::PortFull)
                         {
-                            processor.output_wait_elapsed_us += processor.output_wait_watch.elapsedMicroseconds();
+                            processor.output_wait_elapsed_ns += processor.output_wait_watch.elapsedNanoseconds();
                         }
                     }
                 }

--- a/src/Processors/Executors/ExecutionThreadContext.cpp
+++ b/src/Processors/Executors/ExecutionThreadContext.cpp
@@ -103,10 +103,10 @@ bool ExecutionThreadContext::executeTask()
 
     if (profile_processors)
     {
-        UInt64 elapsed_microseconds =  execution_time_watch->elapsedMicroseconds();
-        node->processor->elapsed_us += elapsed_microseconds;
+        UInt64 elapsed_ns = execution_time_watch->elapsedNanoseconds();
+        node->processor->elapsed_ns += elapsed_ns;
         if (trace_processors)
-            span->addAttribute("execution_time_ms", elapsed_microseconds);
+            span->addAttribute("execution_time_ms", elapsed_ns / 1000U);
     }
 #ifndef NDEBUG
     execution_time_ns += execution_time_watch->elapsed();

--- a/src/Processors/IProcessor.h
+++ b/src/Processors/IProcessor.h
@@ -303,9 +303,9 @@ public:
     IQueryPlanStep * getQueryPlanStep() const { return query_plan_step; }
     size_t getQueryPlanStepGroup() const { return query_plan_step_group; }
 
-    uint64_t getElapsedUs() const { return elapsed_us; }
-    uint64_t getInputWaitElapsedUs() const { return input_wait_elapsed_us; }
-    uint64_t getOutputWaitElapsedUs() const { return output_wait_elapsed_us; }
+    uint64_t getElapsedNs() const { return elapsed_ns; }
+    uint64_t getInputWaitElapsedNs() const { return input_wait_elapsed_ns; }
+    uint64_t getOutputWaitElapsedNs() const { return output_wait_elapsed_ns; }
 
     struct ProcessorDataStats
     {
@@ -369,21 +369,21 @@ protected:
 
 private:
     /// For:
-    /// - elapsed_us
+    /// - elapsed_ns
     friend class ExecutionThreadContext;
     /// For
-    /// - input_wait_elapsed_us
-    /// - output_wait_elapsed_us
+    /// - input_wait_elapsed_ns
+    /// - output_wait_elapsed_ns
     friend class ExecutingGraph;
 
     std::string processor_description;
 
     /// For processors_profile_log
-    uint64_t elapsed_us = 0;
+    uint64_t elapsed_ns = 0;
     Stopwatch input_wait_watch;
-    uint64_t input_wait_elapsed_us = 0;
+    uint64_t input_wait_elapsed_ns = 0;
     Stopwatch output_wait_watch;
-    uint64_t output_wait_elapsed_us = 0;
+    uint64_t output_wait_elapsed_ns = 0;
 
     size_t stream_number = NO_STREAM;
 


### PR DESCRIPTION
By collecting them with nanoseconds precision, and only store them in
system.processors_profile_log in microseconds.

This should fix test `02210_processors_profile_log` failures like this one [1]:

    ExpressionTransform	999989	1	1	1	1

When the total elapsed_us is less then 1 second.

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/65920/ce417c78be566d8a616df3544e2801b845277f44/stateless_tests__release__old_analyzer__s3__databasereplicated__[1_4].html

Plus even though the table has UInt64, the type was truncated to UInt32.

### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Reduce inaccuracy of input_wait_elapsed_us/input_wait_elapsed_us/elapsed_us