### PR TITLE
Utilizing a Shared Parsing Pool for Multiple Parquet Streams

### DIFF
--- a/src/Formats/FormatFactory.cpp
+++ b/src/Formats/FormatFactory.cpp
@@ -315,7 +315,8 @@ InputFormatPtr FormatFactory::getInput(
     std::optional<size_t> _max_download_threads,
     bool is_remote_fs,
     CompressionMethod compression,
-    bool need_only_count) const
+    bool need_only_count,
+    SharedParsingThreadPoolPtr shared_pool) const
 {
     const auto& creators = getCreators(name);
     if (!creators.input_creator && !creators.random_access_input_creator)
@@ -388,7 +389,8 @@ InputFormatPtr FormatFactory::getInput(
             context->getReadSettings(),
             is_remote_fs,
             max_download_threads,
-            max_parsing_threads);
+            max_parsing_threads,
+            shared_pool);
     }
     else
     {

--- a/src/Formats/FormatFactory.h
+++ b/src/Formats/FormatFactory.h
@@ -46,6 +46,9 @@ using InputFormatPtr = std::shared_ptr<IInputFormat>;
 using OutputFormatPtr = std::shared_ptr<IOutputFormat>;
 using RowOutputFormatPtr = std::shared_ptr<IRowOutputFormat>;
 
+class SharedParsingThreadPool;
+using SharedParsingThreadPoolPtr = std::shared_ptr<SharedParsingThreadPool>;
+
 template <typename Allocator>
 struct Memory;
 
@@ -101,7 +104,8 @@ private:
             const ReadSettings& read_settings,
             bool is_remote_fs,
             size_t max_download_threads,
-            size_t max_parsing_threads)>;
+            size_t max_parsing_threads,
+            SharedParsingThreadPoolPtr shared_pool)>;
 
     using OutputCreator = std::function<OutputFormatPtr(
             WriteBuffer & buf,
@@ -173,7 +177,8 @@ public:
         // allows to do: buf -> parallel read -> decompression,
         // because parallel read after decompression is not possible
         CompressionMethod compression = CompressionMethod::None,
-        bool need_only_count = false) const;
+        bool need_only_count = false,
+        SharedParsingThreadPoolPtr shared_pool = {}) const;
 
     /// Checks all preconditions. Returns ordinary format if parallel formatting cannot be done.
     OutputFormatPtr getOutputFormatParallelIfPossible(

--- a/src/Formats/SharedParsingThreadPool.h
+++ b/src/Formats/SharedParsingThreadPool.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include <mutex>
+#include <Common/ThreadPool.h>
+
+namespace DB
+{
+
+/// Multiple pipelines will share this thread pool,
+/// and the total number of threads shall not exceed `max_threads`.
+/// Initially, `max_threads` should be divided among the multiple pipelines, setting `max_parsing_threads` for each pipeline.
+/// During execution, if a pipeline does not have `max_parsing_threads` tasks, it can invoke `release` to give up threads.
+/// Other pipelines can then attempt to fetch more free threads from the pool if some free threads are available.
+class SharedParsingThreadPool
+{
+public:
+    explicit SharedParsingThreadPool(size_t max_threads_, size_t num_streams)
+        : max_threads(max_threads_)
+    {
+        chassert(num_streams > 0);
+        max_parsing_threads_per_stream = std::max<size_t>(max_threads / num_streams, 1UL);
+        free_threads = 0;
+        if (max_threads > max_parsing_threads_per_stream * num_streams)
+            free_threads = max_threads - max_parsing_threads_per_stream * num_streams;
+    }
+
+    size_t getMaxParsingThreadsPerStream() const
+    {
+        return max_parsing_threads_per_stream;
+    }
+
+    size_t tryAcquire(size_t max_threads_to_acquire)
+    {
+        std::lock_guard lock(mutex);
+        size_t available_threads = std::min(max_threads_to_acquire, free_threads);
+        free_threads -= available_threads;
+        return available_threads;
+    }
+
+    void release(size_t num_threads)
+    {
+        std::lock_guard lock(mutex);
+        free_threads += num_threads;
+        chassert(free_threads <= max_threads);
+    }
+
+    std::shared_ptr<ThreadPool> getOrSetPool(std::function<std::shared_ptr<ThreadPool>(size_t)> creator)
+    {
+        std::lock_guard lock(mutex);
+        if (!pool)
+            pool = creator(max_threads);
+        return pool;
+    }
+
+private:
+    mutable std::mutex mutex;
+    std::shared_ptr<ThreadPool> pool;
+    size_t max_threads = 0;
+    size_t max_parsing_threads_per_stream = 1;
+    size_t free_threads = 0;
+};
+
+using SharedParsingThreadPoolPtr = std::shared_ptr<SharedParsingThreadPool>;
+
+}

--- a/src/Formats/SharedParsingThreadPool.h
+++ b/src/Formats/SharedParsingThreadPool.h
@@ -17,11 +17,8 @@ public:
     explicit SharedParsingThreadPool(size_t max_threads_, size_t num_streams)
         : max_threads(max_threads_)
     {
-        chassert(num_streams > 0);
-        max_parsing_threads_per_stream = std::max<size_t>(max_threads / num_streams, 1UL);
-        free_threads = 0;
-        if (max_threads > max_parsing_threads_per_stream * num_streams)
-            free_threads = max_threads - max_parsing_threads_per_stream * num_streams;
+        max_parsing_threads_per_stream = num_streams >= max_threads ? 1 : (max_threads / std::max(num_streams, 1ul));
+        free_threads = max_threads > max_parsing_threads_per_stream * num_streams ? (max_threads - max_parsing_threads_per_stream * num_streams) : 0;
     }
 
     size_t getMaxParsingThreadsPerStream() const

--- a/src/Formats/SharedParsingThreadPool.h
+++ b/src/Formats/SharedParsingThreadPool.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <mutex>
+#include "Common/CurrentMetrics.h"
 #include <Common/ThreadPool.h>
 
 namespace DB
@@ -14,47 +15,80 @@ namespace DB
 class SharedParsingThreadPool
 {
 public:
-    explicit SharedParsingThreadPool(size_t max_threads_, size_t num_streams)
-        : max_threads(max_threads_)
+    SharedParsingThreadPool(size_t max_threads_, size_t num_streams_)
+        : max_threads(max_threads_), num_streams(num_streams_)
     {
-        max_parsing_threads_per_stream = num_streams >= max_threads ? 1 : (max_threads / std::max(num_streams, 1ul));
-        free_threads = max_threads > max_parsing_threads_per_stream * num_streams ? (max_threads - max_parsing_threads_per_stream * num_streams) : 0;
+        threads_per_stream = std::max(1ul, max_threads / std::max(num_streams, 1ul));
+        max_threads = std::max(max_threads, threads_per_stream * num_streams);
+        num_threads = max_threads;
     }
 
-    size_t getMaxParsingThreadsPerStream() const
+    size_t getThreadsPerStream() const
     {
-        return max_parsing_threads_per_stream;
+        return threads_per_stream;
     }
 
-    size_t tryAcquire(size_t max_threads_to_acquire)
-    {
-        std::lock_guard lock(mutex);
-        size_t available_threads = std::min(max_threads_to_acquire, free_threads);
-        free_threads -= available_threads;
-        return available_threads;
-    }
-
-    void release(size_t num_threads)
+    void finishStream()
     {
         std::lock_guard lock(mutex);
-        free_threads += num_threads;
-        chassert(free_threads <= max_threads);
+        if (num_streams > 0)
+            num_streams--;
     }
 
-    std::shared_ptr<ThreadPool> getOrSetPool(std::function<std::shared_ptr<ThreadPool>(size_t)> creator)
+    void acquireThreads(size_t threads_to_acquire)
+    {
+        std::lock_guard guard(mutex);
+        chassert(num_threads >= threads_to_acquire);
+        num_threads -= threads_to_acquire;
+    }
+
+    void releaseThreads(size_t threads_to_release)
+    {
+        std::lock_guard guard(mutex);
+        chassert(num_threads + threads_to_release <= max_threads);
+        num_threads += threads_to_release;
+    }
+
+    size_t tryAcquireFreeThreads(size_t max_threads_to_acquire)
+    {
+        std::lock_guard lock(mutex);
+        if (num_streams * threads_per_stream < num_threads)
+        {
+            size_t acquired_threads = std::min(num_threads - num_streams * threads_per_stream, max_threads_to_acquire);
+            num_threads -= acquired_threads;
+            return acquired_threads;
+        }
+
+        return 0;
+    }
+
+    std::shared_ptr<ThreadPool> getOrSetPool(
+        CurrentMetrics::Metric metric_threads_,
+        CurrentMetrics::Metric metric_active_threads_,
+        CurrentMetrics::Metric metric_scheduled_jobs_)
     {
         std::lock_guard lock(mutex);
         if (!pool)
-            pool = creator(max_threads);
+            pool = std::make_shared<ThreadPool>(
+                metric_threads_,
+                metric_active_threads_,
+                metric_scheduled_jobs_,
+                max_threads,
+                max_threads,
+                max_threads + 1); /// avoid deadlock
         return pool;
     }
 
 private:
     mutable std::mutex mutex;
+
+    size_t max_threads;
+    size_t threads_per_stream;
+
+    size_t num_threads;
+    size_t num_streams;
+
     std::shared_ptr<ThreadPool> pool;
-    size_t max_threads = 0;
-    size_t max_parsing_threads_per_stream = 1;
-    size_t free_threads = 0;
 };
 
 using SharedParsingThreadPoolPtr = std::shared_ptr<SharedParsingThreadPool>;

--- a/src/Processors/Formats/Impl/DWARFBlockInputFormat.cpp
+++ b/src/Processors/Formats/Impl/DWARFBlockInputFormat.cpp
@@ -983,7 +983,8 @@ void registerInputFormatDWARF(FormatFactory & factory)
             const ReadSettings &,
             bool /* is_remote_fs */,
             size_t /* max_download_threads */,
-            size_t max_parsing_threads)
+            size_t max_parsing_threads,
+            SharedParsingThreadPoolPtr /* shared_pool */)
         {
             return std::make_shared<DWARFBlockInputFormat>(
                 buf,

--- a/src/Processors/Formats/Impl/ParquetBlockInputFormat.cpp
+++ b/src/Processors/Formats/Impl/ParquetBlockInputFormat.cpp
@@ -5,6 +5,7 @@
 
 #include <Common/logger_useful.h>
 #include <Common/ThreadPool.h>
+#include <Common/ThreadPoolTaskTracker.h>
 #include <Formats/FormatFactory.h>
 #include <Formats/SchemaInferenceUtils.h>
 #include <IO/ReadBufferFromMemory.h>
@@ -375,23 +376,41 @@ ParquetBlockInputFormat::ParquetBlockInputFormat(
     const Block & header_,
     const FormatSettings & format_settings_,
     size_t max_decoding_threads_,
-    size_t min_bytes_for_seek_)
+    size_t min_bytes_for_seek_,
+    SharedParsingThreadPoolPtr shared_pool_)
     : IInputFormat(header_, &buf)
     , format_settings(format_settings_)
     , skip_row_groups(format_settings.parquet.skip_row_groups)
     , max_decoding_threads(max_decoding_threads_)
     , min_bytes_for_seek(min_bytes_for_seek_)
     , pending_chunks(PendingChunk::Compare { .row_group_first = format_settings_.parquet.preserve_order })
+    , shared_pool(std::move(shared_pool_))
+    , log(getLogger("ParquetBlockInputFormat"))
 {
-    if (max_decoding_threads > 1)
+    if (shared_pool)
+    {
+        pool = shared_pool->getOrSetPool(
+            [] (size_t max_threads)
+            {
+                return std::make_shared<ThreadPool>(CurrentMetrics::ParquetDecoderThreads, CurrentMetrics::ParquetDecoderThreadsActive,
+                    CurrentMetrics::ParquetDecoderThreadsScheduled, max_threads);
+            });
+    }
+    else if (max_decoding_threads > 1)
+    {
         pool = std::make_unique<ThreadPool>(CurrentMetrics::ParquetDecoderThreads, CurrentMetrics::ParquetDecoderThreadsActive, CurrentMetrics::ParquetDecoderThreadsScheduled, max_decoding_threads);
+    }
+
+    if (pool)
+        task_tracker = std::make_unique<TaskTracker>(
+            threadPoolCallbackRunnerUnsafe<void>(*pool, "ParquetDecoder"), 0, std::make_shared<LogSeriesLimiter>(log, 1, 5));
 }
 
 ParquetBlockInputFormat::~ParquetBlockInputFormat()
 {
     is_stopped = true;
-    if (pool)
-        pool->wait();
+    if (task_tracker)
+        task_tracker->safeWaitAll();
 }
 
 void ParquetBlockInputFormat::initializeIfNeeded()
@@ -554,26 +573,18 @@ void ParquetBlockInputFormat::scheduleRowGroup(size_t row_group_batch_idx)
 
     status = RowGroupBatchState::Status::Running;
 
-    pool->scheduleOrThrowOnError(
-        [this, row_group_batch_idx, thread_group = CurrentThread::getGroup()]()
+    task_tracker->add([this, row_group_batch_idx] {
+        try
         {
-            if (thread_group)
-                CurrentThread::attachToGroupIfDetached(thread_group);
-            SCOPE_EXIT_SAFE(if (thread_group) CurrentThread::detachFromGroupIfNotDetached(););
-
-            try
-            {
-                setThreadName("ParquetDecoder");
-
-                threadFunction(row_group_batch_idx);
-            }
-            catch (...)
-            {
-                std::lock_guard lock(mutex);
-                background_exception = std::current_exception();
-                condvar.notify_all();
-            }
-        });
+            threadFunction(row_group_batch_idx);
+        }
+        catch (...)
+        {
+            std::lock_guard lock(mutex);
+            background_exception = std::current_exception();
+            condvar.notify_all();
+        }
+    });
 }
 
 void ParquetBlockInputFormat::threadFunction(size_t row_group_batch_idx)
@@ -690,8 +701,23 @@ void ParquetBlockInputFormat::scheduleMoreWorkIfNeeded(std::optional<size_t> row
         ++row_group_batches_completed;
     }
 
-    if (pool)
+    if (task_tracker)
     {
+        if (shared_pool)
+        {
+            /// adjust `max_decoding_threads`
+            size_t num_remaining_tasks = row_group_batches.size() - row_group_batches_completed;
+            if (num_remaining_tasks < max_decoding_threads)
+            {
+                shared_pool->release(max_decoding_threads - num_remaining_tasks);
+                max_decoding_threads = num_remaining_tasks;
+            }
+            else
+            {
+                max_decoding_threads += shared_pool->tryAcquire(num_remaining_tasks);
+            }
+        }
+
         while (row_group_batches_started - row_group_batches_completed < max_decoding_threads &&
                row_group_batches_started < row_group_batches.size())
             scheduleRowGroup(row_group_batches_started++);
@@ -762,8 +788,8 @@ Chunk ParquetBlockInputFormat::read()
 void ParquetBlockInputFormat::resetParser()
 {
     is_stopped = true;
-    if (pool)
-        pool->wait();
+    if (task_tracker)
+        task_tracker->safeWaitAll();
 
     arrow_file.reset();
     metadata.reset();
@@ -832,7 +858,8 @@ void registerInputFormatParquet(FormatFactory & factory)
                const ReadSettings & read_settings,
                bool is_remote_fs,
                size_t /* max_download_threads */,
-               size_t max_parsing_threads)
+               size_t max_parsing_threads,
+               SharedParsingThreadPoolPtr shared_pool)
             {
                 size_t min_bytes_for_seek = is_remote_fs ? read_settings.remote_read_min_bytes_for_seek : settings.parquet.local_read_min_bytes_for_seek;
                 return std::make_shared<ParquetBlockInputFormat>(
@@ -840,7 +867,8 @@ void registerInputFormatParquet(FormatFactory & factory)
                     sample,
                     settings,
                     max_parsing_threads,
-                    min_bytes_for_seek);
+                    min_bytes_for_seek,
+                    shared_pool);
             });
     factory.markFormatSupportsSubsetOfColumns("Parquet");
 }

--- a/src/Processors/Formats/Impl/ParquetBlockInputFormat.h
+++ b/src/Processors/Formats/Impl/ParquetBlockInputFormat.h
@@ -2,9 +2,11 @@
 #include "config.h"
 #if USE_PARQUET
 
+#include "Common/logger_useful.h"
 #include <Processors/Formats/IInputFormat.h>
 #include <Processors/Formats/ISchemaReader.h>
 #include <Formats/FormatSettings.h>
+#include <Formats/SharedParsingThreadPool.h>
 #include <Storages/MergeTree/KeyCondition.h>
 
 namespace parquet { class FileMetaData; }
@@ -17,6 +19,7 @@ namespace DB
 
 class ArrowColumnToCHColumn;
 class ParquetRecordReader;
+class TaskTracker;
 
 // Parquet files contain a metadata block with the following information:
 //  * list of columns,
@@ -53,7 +56,8 @@ public:
         const Block & header,
         const FormatSettings & format_settings,
         size_t max_decoding_threads,
-        size_t min_bytes_for_seek);
+        size_t min_bytes_for_seek,
+        SharedParsingThreadPoolPtr shared_pool);
 
     ~ParquetBlockInputFormat() override;
 
@@ -280,7 +284,11 @@ private:
 
     // These are only used when max_decoding_threads > 1.
     size_t row_group_batches_started = 0;
-    std::unique_ptr<ThreadPool> pool;
+    std::shared_ptr<ThreadPool> pool;
+    std::unique_ptr<TaskTracker> task_tracker;
+    SharedParsingThreadPoolPtr shared_pool;
+
+    LoggerPtr log;
 
     BlockMissingValues previous_block_missing_values;
     size_t previous_approx_bytes_read_for_chunk = 0;

--- a/src/Processors/Formats/Impl/ParquetBlockInputFormat.h
+++ b/src/Processors/Formats/Impl/ParquetBlockInputFormat.h
@@ -256,6 +256,7 @@ private:
     size_t max_decoding_threads;
     size_t min_bytes_for_seek;
     const size_t max_pending_chunks_per_row_group_batch = 2;
+    size_t additional_parsing_threads = 0;
 
     /// RandomAccessFile is thread safe, so we share it among threads.
     /// FileReader is not, so each thread creates its own.

--- a/src/Processors/Formats/Impl/ParquetBlockInputFormat.h
+++ b/src/Processors/Formats/Impl/ParquetBlockInputFormat.h
@@ -2,7 +2,7 @@
 #include "config.h"
 #if USE_PARQUET
 
-#include "Common/logger_useful.h"
+#include <Common/logger_useful.h>
 #include <Processors/Formats/IInputFormat.h>
 #include <Processors/Formats/ISchemaReader.h>
 #include <Formats/FormatSettings.h>

--- a/src/Processors/Formats/Impl/ParquetMetadataInputFormat.cpp
+++ b/src/Processors/Formats/Impl/ParquetMetadataInputFormat.cpp
@@ -503,7 +503,8 @@ void registerInputFormatParquetMetadata(FormatFactory & factory)
             const ReadSettings &,
             bool /* is_remote_fs */,
             size_t /* max_download_threads */,
-            size_t /* max_parsing_threads */)
+            size_t /* max_parsing_threads */,
+            SharedParsingThreadPoolPtr /* shared_pool */)
         {
             return std::make_shared<ParquetMetadataInputFormat>(buf, sample, settings);
         });

--- a/src/Processors/ISource.h
+++ b/src/Processors/ISource.h
@@ -28,6 +28,7 @@ protected:
 
     virtual Chunk generate();
     virtual std::optional<Chunk> tryGenerate();
+    virtual void onFinish() {}
 
     void progress(size_t read_rows, size_t read_bytes);
 

--- a/src/Processors/Sources/PostgreSQLSource.h
+++ b/src/Processors/Sources/PostgreSQLSource.h
@@ -46,7 +46,7 @@ protected:
 
     void onStart();
     Chunk generate() override;
-    void onFinish();
+    void onFinish() override;
 
 private:
     void init(const Block & sample_block);

--- a/src/Storages/FileLog/FileLogSource.cpp
+++ b/src/Storages/FileLog/FileLogSource.cpp
@@ -49,7 +49,7 @@ FileLogSource::~FileLogSource()
     try
     {
         if (!finished)
-            onFinish();
+            close();
     }
     catch (...)
     {
@@ -57,7 +57,7 @@ FileLogSource::~FileLogSource()
     }
 }
 
-void FileLogSource::onFinish()
+void FileLogSource::close()
 {
     storage.closeFilesAndStoreMeta(start, end);
     storage.reduceStreams();
@@ -71,6 +71,9 @@ Chunk FileLogSource::generate()
 
     if (!consumer || consumer->noRecords())
     {
+        /// There is no onFinish for ISource, we call it
+        /// when no records return to close files
+        close();
         return {};
     }
 
@@ -160,6 +163,7 @@ Chunk FileLogSource::generate()
 
     if (total_rows == 0)
     {
+        close();
         return {};
     }
 

--- a/src/Storages/FileLog/FileLogSource.cpp
+++ b/src/Storages/FileLog/FileLogSource.cpp
@@ -71,9 +71,6 @@ Chunk FileLogSource::generate()
 
     if (!consumer || consumer->noRecords())
     {
-        /// There is no onFinish for ISource, we call it
-        /// when no records return to close files
-        onFinish();
         return {};
     }
 
@@ -163,7 +160,6 @@ Chunk FileLogSource::generate()
 
     if (total_rows == 0)
     {
-        onFinish();
         return {};
     }
 

--- a/src/Storages/FileLog/FileLogSource.h
+++ b/src/Storages/FileLog/FileLogSource.h
@@ -28,7 +28,7 @@ public:
 
     bool noRecords() { return !consumer || consumer->noRecords(); }
 
-    void onFinish() override;
+    void close();
 
     ~FileLogSource() override;
 

--- a/src/Storages/FileLog/FileLogSource.h
+++ b/src/Storages/FileLog/FileLogSource.h
@@ -28,7 +28,7 @@ public:
 
     bool noRecords() { return !consumer || consumer->noRecords(); }
 
-    void onFinish();
+    void onFinish() override;
 
     ~FileLogSource() override;
 

--- a/src/Storages/ObjectStorage/StorageObjectStorage.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorage.cpp
@@ -156,13 +156,13 @@ public:
             num_streams = 1;
         }
 
-        const size_t max_parsing_threads = num_streams >= max_threads ? 1 : (max_threads / std::max(num_streams, 1ul));
+        auto shared_pool = std::make_shared<SharedParsingThreadPool>(max_threads, num_streams);
 
         for (size_t i = 0; i < num_streams; ++i)
         {
             auto source = std::make_shared<StorageObjectStorageSource>(
                 getName(), object_storage, configuration, info, format_settings,
-                context, max_block_size, iterator_wrapper, max_parsing_threads, need_only_count);
+                context, max_block_size, iterator_wrapper, shared_pool, need_only_count);
 
             source->setKeyCondition(filter_actions_dag, context);
             pipes.emplace_back(std::move(source));

--- a/src/Storages/ObjectStorage/StorageObjectStorageSource.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorageSource.cpp
@@ -248,7 +248,6 @@ Chunk StorageObjectStorageSource::generate()
         reader_future = createReaderAsync();
     }
 
-    shared_pool->finishStream();
     return {};
 }
 

--- a/src/Storages/ObjectStorage/StorageObjectStorageSource.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorageSource.cpp
@@ -49,7 +49,7 @@ StorageObjectStorageSource::StorageObjectStorageSource(
     ContextPtr context_,
     UInt64 max_block_size_,
     std::shared_ptr<IIterator> file_iterator_,
-    size_t max_parsing_threads_,
+    SharedParsingThreadPoolPtr shared_pool_,
     bool need_only_count_)
     : SourceWithKeyCondition(info.source_header, false)
     , WithContext(context_)
@@ -59,7 +59,7 @@ StorageObjectStorageSource::StorageObjectStorageSource(
     , format_settings(format_settings_)
     , max_block_size(max_block_size_)
     , need_only_count(need_only_count_)
-    , max_parsing_threads(max_parsing_threads_)
+    , shared_pool(std::move(shared_pool_))
     , read_from_format_info(info)
     , create_reader_pool(std::make_shared<ThreadPool>(
         CurrentMetrics::StorageObjectStorageThreads,
@@ -265,7 +265,7 @@ StorageObjectStorageSource::ReaderHolder StorageObjectStorageSource::createReade
 {
     return createReader(
         0, file_iterator, configuration, object_storage, read_from_format_info, format_settings,
-        key_condition, getContext(), &schema_cache, log, max_block_size, max_parsing_threads, need_only_count);
+        key_condition, getContext(), &schema_cache, log, max_block_size, shared_pool->getMaxParsingThreadsPerStream(), need_only_count, shared_pool);
 }
 
 StorageObjectStorageSource::ReaderHolder StorageObjectStorageSource::createReader(
@@ -281,7 +281,8 @@ StorageObjectStorageSource::ReaderHolder StorageObjectStorageSource::createReade
     const LoggerPtr & log,
     size_t max_block_size,
     size_t max_parsing_threads,
-    bool need_only_count)
+    bool need_only_count,
+    SharedParsingThreadPoolPtr shared_pool)
 {
     ObjectInfoPtr object_info;
     auto query_settings = configuration->getQuerySettings(context_);
@@ -366,7 +367,8 @@ StorageObjectStorageSource::ReaderHolder StorageObjectStorageSource::createReade
             std::nullopt,
             true/* is_remote_fs */,
             compression_method,
-            need_only_count);
+            need_only_count,
+            shared_pool);
 
         if (key_condition_)
             input_format->setKeyCondition(key_condition_);

--- a/src/Storages/ObjectStorage/StorageObjectStorageSource.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorageSource.cpp
@@ -248,6 +248,7 @@ Chunk StorageObjectStorageSource::generate()
         reader_future = createReaderAsync();
     }
 
+    shared_pool->finishStream();
     return {};
 }
 
@@ -265,7 +266,7 @@ StorageObjectStorageSource::ReaderHolder StorageObjectStorageSource::createReade
 {
     return createReader(
         0, file_iterator, configuration, object_storage, read_from_format_info, format_settings,
-        key_condition, getContext(), &schema_cache, log, max_block_size, shared_pool->getMaxParsingThreadsPerStream(), need_only_count, shared_pool);
+        key_condition, getContext(), &schema_cache, log, max_block_size, shared_pool->getThreadsPerStream(), need_only_count, shared_pool);
 }
 
 StorageObjectStorageSource::ReaderHolder StorageObjectStorageSource::createReader(

--- a/src/Storages/ObjectStorage/StorageObjectStorageSource.h
+++ b/src/Storages/ObjectStorage/StorageObjectStorageSource.h
@@ -51,6 +51,8 @@ public:
 
     Chunk generate() override;
 
+    void onFinish() override { shared_pool->finishStream(); }
+
     static std::shared_ptr<IIterator> createFileIterator(
         ConfigurationPtr configuration,
         ObjectStoragePtr object_storage,

--- a/src/Storages/ObjectStorage/StorageObjectStorageSource.h
+++ b/src/Storages/ObjectStorage/StorageObjectStorageSource.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <Common/re2.h>
+#include <Formats/SharedParsingThreadPool.h>
 #include <Interpreters/Context_fwd.h>
 #include <IO/Archives/IArchiveReader.h>
 #include <Processors/SourceWithKeyCondition.h>
@@ -39,7 +40,7 @@ public:
         ContextPtr context_,
         UInt64 max_block_size_,
         std::shared_ptr<IIterator> file_iterator_,
-        size_t max_parsing_threads_,
+        SharedParsingThreadPoolPtr shared_pool,
         bool need_only_count_);
 
     ~StorageObjectStorageSource() override;
@@ -72,7 +73,7 @@ protected:
     const std::optional<FormatSettings> format_settings;
     const UInt64 max_block_size;
     const bool need_only_count;
-    const size_t max_parsing_threads;
+    SharedParsingThreadPoolPtr shared_pool;
     const ReadFromFormatInfo read_from_format_info;
     const std::shared_ptr<ThreadPool> create_reader_pool;
 
@@ -129,7 +130,8 @@ protected:
         const LoggerPtr & log,
         size_t max_block_size,
         size_t max_parsing_threads,
-        bool need_only_count);
+        bool need_only_count,
+        SharedParsingThreadPoolPtr shared_pool = {});
 
     ReaderHolder createReader();
 

--- a/src/Storages/StorageFile.cpp
+++ b/src/Storages/StorageFile.cpp
@@ -1293,7 +1293,10 @@ Chunk StorageFileSource::generate()
                     {
                         auto archive = files_iterator->next();
                         if (archive.empty())
+                        {
+                            shared_pool->finishStream();
                             return {};
+                        }
 
                         auto file_stat = getFileStat(archive, storage->use_table_fd, storage->table_fd, storage->getName());
                         if (getContext()->getSettingsRef().engine_file_skip_empty_files && file_stat.st_size == 0)
@@ -1321,7 +1324,10 @@ Chunk StorageFileSource::generate()
                             {
                                 auto archive = files_iterator->next();
                                 if (archive.empty())
+                                {
+                                    shared_pool->finishStream();
                                     return {};
+                                }
 
                                 current_archive_stat = getFileStat(archive, storage->use_table_fd, storage->table_fd, storage->getName());
                                 if (getContext()->getSettingsRef().engine_file_skip_empty_files && current_archive_stat.st_size == 0)
@@ -1367,7 +1373,10 @@ Chunk StorageFileSource::generate()
                 {
                     current_path = files_iterator->next();
                     if (current_path.empty())
+                    {
+                        shared_pool->finishStream();
                         return {};
+                    }
                 }
 
                 /// Special case for distributed format. Defaults are not needed here.
@@ -1397,7 +1406,7 @@ Chunk StorageFileSource::generate()
 
             input_format = FormatFactory::instance().getInput(
                 storage->format_name, *read_buf, block_for_format, getContext(), max_block_size, storage->format_settings,
-                shared_pool->getMaxParsingThreadsPerStream(), std::nullopt, /*is_remote_fs*/ false, CompressionMethod::None, need_only_count, shared_pool);
+                shared_pool->getThreadsPerStream(), std::nullopt, /*is_remote_fs*/ false, CompressionMethod::None, need_only_count, shared_pool);
 
             if (key_condition)
                 input_format->setKeyCondition(key_condition);

--- a/src/Storages/StorageFile.cpp
+++ b/src/Storages/StorageFile.cpp
@@ -1169,7 +1169,8 @@ StorageFileSource::StorageFileSource(
     UInt64 max_block_size_,
     FilesIteratorPtr files_iterator_,
     std::unique_ptr<ReadBuffer> read_buf_,
-    bool need_only_count_)
+    bool need_only_count_,
+    SharedParsingThreadPoolPtr shared_pool_)
     : SourceWithKeyCondition(info.source_header, false), WithContext(context_)
     , storage(std::move(storage_))
     , files_iterator(std::move(files_iterator_))
@@ -1180,6 +1181,7 @@ StorageFileSource::StorageFileSource(
     , block_for_format(info.format_header)
     , max_block_size(max_block_size_)
     , need_only_count(need_only_count_)
+    , shared_pool(std::move(shared_pool_))
 {
     if (!storage->use_table_fd)
     {
@@ -1393,20 +1395,9 @@ Chunk StorageFileSource::generate()
                 read_buf = createReadBuffer(current_path, file_stat, storage->use_table_fd, storage->table_fd, storage->compression_method, getContext());
             }
 
-            const Settings & settings = getContext()->getSettingsRef();
-
-            size_t file_num = 0;
-            if (storage->archive_info)
-                file_num = storage->archive_info->paths_to_archives.size();
-            else
-                file_num = storage->paths.size();
-
-            chassert(file_num > 0);
-
-            const auto max_parsing_threads = std::max<size_t>(settings.max_parsing_threads / file_num, 1UL);
             input_format = FormatFactory::instance().getInput(
                 storage->format_name, *read_buf, block_for_format, getContext(), max_block_size, storage->format_settings,
-                max_parsing_threads, std::nullopt, /*is_remote_fs*/ false, CompressionMethod::None, need_only_count);
+                shared_pool->getMaxParsingThreadsPerStream(), std::nullopt, /*is_remote_fs*/ false, CompressionMethod::None, need_only_count, shared_pool);
 
             if (key_condition)
                 input_format->setKeyCondition(key_condition);
@@ -1658,6 +1649,8 @@ void ReadFromFile::initializePipeline(QueryPipelineBuilder & pipeline, const Bui
     if (progress_callback && !storage->archive_info)
         progress_callback(FileProgress(0, storage->total_bytes_to_read));
 
+    auto shared_pool = std::make_shared<SharedParsingThreadPool>(ctx->getSettingsRef().max_parsing_threads, num_streams);
+
     for (size_t i = 0; i < num_streams; ++i)
     {
         /// In case of reading from fd we have to check whether we have already created
@@ -1675,7 +1668,8 @@ void ReadFromFile::initializePipeline(QueryPipelineBuilder & pipeline, const Bui
             max_block_size,
             files_iterator,
             std::move(read_buffer),
-            need_only_count);
+            need_only_count,
+            shared_pool);
 
         source->setKeyCondition(filter_actions_dag, ctx);
         pipes.emplace_back(std::move(source));

--- a/src/Storages/StorageFile.cpp
+++ b/src/Storages/StorageFile.cpp
@@ -1293,10 +1293,7 @@ Chunk StorageFileSource::generate()
                     {
                         auto archive = files_iterator->next();
                         if (archive.empty())
-                        {
-                            shared_pool->finishStream();
                             return {};
-                        }
 
                         auto file_stat = getFileStat(archive, storage->use_table_fd, storage->table_fd, storage->getName());
                         if (getContext()->getSettingsRef().engine_file_skip_empty_files && file_stat.st_size == 0)
@@ -1324,10 +1321,7 @@ Chunk StorageFileSource::generate()
                             {
                                 auto archive = files_iterator->next();
                                 if (archive.empty())
-                                {
-                                    shared_pool->finishStream();
                                     return {};
-                                }
 
                                 current_archive_stat = getFileStat(archive, storage->use_table_fd, storage->table_fd, storage->getName());
                                 if (getContext()->getSettingsRef().engine_file_skip_empty_files && current_archive_stat.st_size == 0)
@@ -1373,10 +1367,7 @@ Chunk StorageFileSource::generate()
                 {
                     current_path = files_iterator->next();
                     if (current_path.empty())
-                    {
-                        shared_pool->finishStream();
                         return {};
-                    }
                 }
 
                 /// Special case for distributed format. Defaults are not needed here.

--- a/src/Storages/StorageFile.h
+++ b/src/Storages/StorageFile.h
@@ -4,6 +4,7 @@
 #include <Storages/IStorage.h>
 #include <Storages/prepareReadingFromFormat.h>
 #include <Common/FileRenamer.h>
+#include <Formats/SharedParsingThreadPool.h>
 #include <IO/Archives/IArchiveReader.h>
 #include <Processors/SourceWithKeyCondition.h>
 
@@ -250,8 +251,8 @@ private:
         UInt64 max_block_size_,
         FilesIteratorPtr files_iterator_,
         std::unique_ptr<ReadBuffer> read_buf_,
-        bool need_only_count_);
-
+        bool need_only_count_,
+        SharedParsingThreadPoolPtr shared_pool);
 
     /**
       * If specified option --rename_files_after_processing and files created by TableFunctionFile
@@ -303,6 +304,7 @@ private:
     bool need_only_count = false;
     size_t total_rows_in_file = 0;
 
+    SharedParsingThreadPoolPtr shared_pool;
     std::shared_lock<std::shared_timed_mutex> shared_lock;
 };
 

--- a/src/Storages/StorageFile.h
+++ b/src/Storages/StorageFile.h
@@ -273,6 +273,8 @@ private:
 
     Chunk generate() override;
 
+    void onFinish() override { shared_pool->finishStream(); }
+
     void addNumRowsToCache(const String & path, size_t num_rows) const;
 
     std::optional<size_t> tryGetNumRowsFromCache(const String & path, time_t last_mod_time) const;

--- a/src/Storages/StorageURL.cpp
+++ b/src/Storages/StorageURL.cpp
@@ -405,10 +405,7 @@ Chunk StorageURLSource::generate()
         }
 
         if (!reader && !initialize())
-        {
-            shared_pool->finishStream();
             return {};
-        }
 
         Chunk chunk;
         if (reader->pull(chunk))

--- a/src/Storages/StorageURL.h
+++ b/src/Storages/StorageURL.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Formats/FormatSettings.h>
+#include "Formats/SharedParsingThreadPool.h"
 #include <IO/CompressionMethod.h>
 #include <IO/HTTPHeaderEntries.h>
 #include <IO/ReadWriteBufferFromHTTP.h>
@@ -175,7 +176,7 @@ public:
         UInt64 max_block_size,
         const ConnectionTimeouts & timeouts,
         CompressionMethod compression_method,
-        size_t max_parsing_threads,
+        SharedParsingThreadPoolPtr shared_pool,
         const HTTPHeaderEntries & headers_ = {},
         const URIParams & params = {},
         bool glob_url = false,

--- a/src/Storages/StorageURL.h
+++ b/src/Storages/StorageURL.h
@@ -228,6 +228,7 @@ private:
     HTTPHeaderEntries headers;
     bool need_only_count;
     size_t total_rows_in_file = 0;
+    SharedParsingThreadPoolPtr shared_pool;
 
     std::unique_ptr<ReadBuffer> read_buf;
     std::shared_ptr<IInputFormat> input_format;

--- a/src/Storages/StorageURL.h
+++ b/src/Storages/StorageURL.h
@@ -193,6 +193,8 @@ public:
 
     Chunk generate() override;
 
+    void onFinish() override { shared_pool->finishStream(); }
+
     static void setCredentials(Poco::Net::HTTPBasicCredentials & credentials, const Poco::URI & request_uri);
 
     static std::pair<Poco::URI, std::unique_ptr<ReadWriteBufferFromHTTP>> getFirstAvailableURIAndReadBuffer(

--- a/src/Storages/StorageURL.h
+++ b/src/Storages/StorageURL.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <Formats/FormatSettings.h>
-#include "Formats/SharedParsingThreadPool.h"
+#include <Formats/SharedParsingThreadPool.h>
 #include <IO/CompressionMethod.h>
 #include <IO/HTTPHeaderEntries.h>
 #include <IO/ReadWriteBufferFromHTTP.h>


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Utilizing a Shared Parsing Pool for Multiple Parquet Streams, fix #65963

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
