### PR TITLE
Fix test_parallel_replicas_custom_key

### DIFF
--- a/tests/integration/test_parallel_replicas_custom_key/test.py
+++ b/tests/integration/test_parallel_replicas_custom_key/test.py
@@ -161,6 +161,9 @@ def test_parallel_replicas_custom_key_replicatedmergetree(
 
     insert_data("test_table_for_rmt", row_num, all_nodes=False)
 
+    for node in nodes:
+        node.query("SYSTEM SYNC REPLICA test_table_for_rmt LIGHTWEIGHT")
+
     expected_result = ""
     for i in range(4):
         expected_result += f"{i}\t250\n"


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

https://s3.amazonaws.com/clickhouse-test-reports/0/d555a452dc4244bfedf83404793fe6ad9f4f9b4d/integration_tests__aarch64__[5_6].html

Part was fetched after the query:
```
2024.07.10 05:46:58.987931 [ 11 ] {2a76cb66-0bb6-40c7-9d25-c93c1047ecba} <Debug> executeQuery: (from 172.16.7.8:59476, initial_query_id: e1adc287-770c-4338-b271-24bd682edbac) SELECT `__table1`.`key` AS `key`, count() AS `count()` FROM `default`.`test_table_for_rmt` AS `__table1` WHERE positiveModulo(`key`, 4) = 1 GROUP BY `__table1`.`key` ORDER BY `__table1`.`key` ASC (stage: WithMergeableStateAfterAggregationAndLimit)
2024.07.10 05:46:58.988315 [ 11 ] {2a76cb66-0bb6-40c7-9d25-c93c1047ecba} <Trace> Planner: Query to stage WithMergeableStateAfterAggregationAndLimit
2024.07.10 05:46:58.988405 [ 11 ] {2a76cb66-0bb6-40c7-9d25-c93c1047ecba} <Trace> Planner: Query from stage FetchColumns to stage WithMergeableStateAfterAggregationAndLimit
2024.07.10 05:46:58.990202 [ 700 ] {2a76cb66-0bb6-40c7-9d25-c93c1047ecba} <Trace> AggregatingTransform: Aggregated. 0 to 0 rows (from 0.00 B) in 0.001490585 sec. (0.000 rows/sec., 0.00 B/sec.)
2024.07.10 05:46:58.990219 [ 700 ] {2a76cb66-0bb6-40c7-9d25-c93c1047ecba} <Trace> Aggregator: Merging aggregated data
2024.07.10 05:46:58.990230 [ 700 ] {2a76cb66-0bb6-40c7-9d25-c93c1047ecba} <Trace> Aggregator: Statistics updated for key=11386718935834912790: new sum_of_sizes=0, median_size=0
2024.07.10 05:46:58.990409 [ 700 ] {2a76cb66-0bb6-40c7-9d25-c93c1047ecba} <Debug> MergingSortedTransform: Merge sorted 1 blocks, 0 rows in 0 sec.
2024.07.10 05:46:58.991803 [ 11 ] {2a76cb66-0bb6-40c7-9d25-c93c1047ecba} <Debug> TCPHandler: Processed in 0.004491767 sec.
2024.07.10 05:46:59.000571 [ 665 ] {} <Trace> AsynchronousMetrics: MemoryTracking: was 483.43 MiB, peak 483.48 MiB, free memory in arenas 992.00 KiB, will set to 482.13 MiB (RSS), difference: -1.30 MiB
2024.07.10 05:46:59.132827 [ 620 ] {} <Test> default.test_table_for_rmt (a60bc21a-846c-42bd-a596-f3ea128d7a1b) (Fetcher): Disk for fetch is not provided, reserving space using storage balanced reservation
2024.07.10 05:46:59.132847 [ 620 ] {} <Test> default.test_table_for_rmt (a60bc21a-846c-42bd-a596-f3ea128d7a1b) (Fetcher): Disk for fetch is not provided, reserving space using TTL rules
2024.07.10 05:46:59.132862 [ 620 ] {} <Trace> default.test_table_for_rmt (a60bc21a-846c-42bd-a596-f3ea128d7a1b): Trying to reserve 1.00 MiB using storage policy from min volume index 0
2024.07.10 05:46:59.132886 [ 620 ] {} <Trace> DiskLocal: Reserved 1.00 MiB on local disk `default`, having unreserved 81.25 GiB.
2024.07.10 05:46:59.132895 [ 620 ] {} <Trace> default.test_table_for_rmt (a60bc21a-846c-42bd-a596-f3ea128d7a1b) (Fetcher): Disk for fetch is not provided, getting disk from reservation default with type 'local'
2024.07.10 05:46:59.132910 [ 620 ] {} <Debug> default.test_table_for_rmt (a60bc21a-846c-42bd-a596-f3ea128d7a1b) (Fetcher): Downloading part all_0_0_0 onto disk default.
2024.07.10 05:46:59.133000 [ 620 ] {} <Debug> default.test_table_for_rmt (a60bc21a-846c-42bd-a596-f3ea128d7a1b) (Fetcher): Downloading files 9
2024.07.10 05:46:59.133956 [ 620 ] {} <Debug> default.test_table_for_rmt (a60bc21a-846c-42bd-a596-f3ea128d7a1b) (Fetcher): Download of part all_0_0_0 onto disk default finished.
2024.07.10 05:46:59.133988 [ 620 ] {} <Trace> default.test_table_for_rmt (a60bc21a-846c-42bd-a596-f3ea128d7a1b): Renaming temporary part tmp-fetch_all_0_0_0 to all_0_0_0 with tid (1, 1, 00000000-0000-0000-0000-000000000000).
2024.07.10 05:46:59.134087 [ 620 ] {} <Test> default.test_table_for_rmt (a60bc21a-846c-42bd-a596-f3ea128d7a1b): preparePartForCommit: inserting all_0_0_0 (state PreActive) into data_parts_indexes
2024.07.10 05:46:59.134100 [ 620 ] {} <Debug> default.test_table_for_rmt (a60bc21a-846c-42bd-a596-f3ea128d7a1b): Committing part all_0_0_0 to zookeeper
2024.07.10 05:46:59.137173 [ 668 ] {} <Trace> virtual void Coordination::ZooKeeperCreateRequest::writeImpl(WriteBuffer &) const: Creating part at path /clickhouse/tables/replicas/r4/parts/all_0_0_0
2024.07.10 05:46:59.138286 [ 620 ] {} <Debug> default.test_table_for_rmt (a60bc21a-846c-42bd-a596-f3ea128d7a1b): Part all_0_0_0 committed to zookeeper
2024.07.10 05:46:59.138357 [ 620 ] {} <Debug> default.test_table_for_rmt (a60bc21a-846c-42bd-a596-f3ea128d7a1b): Fetched part all_0_0_0 from default:/clickhouse/tables/replicas/r1
2024.07.10 05:46:59.138374 [ 620 ] {} <Test> default.test_table_for_rmt (ReplicatedMergeTreeQueue): Removing successful entry queue-0000000000 from queue with type GET_PART with virtual parts [all_0_0_0]
2024.07.10 05:46:59.138383 [ 620 ] {} <Test> default.test_table_for_rmt (ReplicatedMergeTreeQueue): Adding parts [all_0_0_0] to current parts
2024.07.10 05:46:59.138392 [ 620 ] {} <Test> default.test_table_for_rmt (ReplicatedMergeTreeQueue): Removing part all_0_0_0 from mutations (remove_part: false, remove_covered_parts: true)
```

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
