### PR TITLE
Fix cluster() for inter-server secret (preserve initial user as before)

### DIFF
--- a/src/Storages/StorageDistributed.cpp
+++ b/src/Storages/StorageDistributed.cpp
@@ -308,7 +308,8 @@ StorageDistributed::StorageDistributed(
     const DistributedSettings & distributed_settings_,
     LoadingStrictnessLevel mode,
     ClusterPtr owned_cluster_,
-    ASTPtr remote_table_function_ptr_)
+    ASTPtr remote_table_function_ptr_,
+    bool is_remote_function_)
     : IStorage(id_)
     , WithContext(context_->getGlobalContext())
     , remote_database(remote_database_)
@@ -322,6 +323,7 @@ StorageDistributed::StorageDistributed(
     , relative_data_path(relative_data_path_)
     , distributed_settings(distributed_settings_)
     , rng(randomSeed())
+    , is_remote_function(is_remote_function_)
 {
     if (!distributed_settings.flush_on_detach && distributed_settings.background_insert_batch)
         throw Exception(ErrorCodes::BAD_ARGUMENTS, "Settings flush_on_detach=0 and background_insert_batch=1 are incompatible");
@@ -869,7 +871,7 @@ void StorageDistributed::read(
         sharding_key_column_name,
         distributed_settings,
         shard_filter_generator,
-        /* is_remote_function= */ static_cast<bool>(owned_cluster));
+        is_remote_function);
 
     /// This is a bug, it is possible only when there is no shards to query, and this is handled earlier.
     if (!query_plan.isInitialized())

--- a/src/Storages/StorageDistributed.cpp
+++ b/src/Storages/StorageDistributed.cpp
@@ -373,38 +373,6 @@ StorageDistributed::StorageDistributed(
 }
 
 
-StorageDistributed::StorageDistributed(
-    const StorageID & id_,
-    const ColumnsDescription & columns_,
-    const ConstraintsDescription & constraints_,
-    ASTPtr remote_table_function_ptr_,
-    const String & cluster_name_,
-    ContextPtr context_,
-    const ASTPtr & sharding_key_,
-    const String & storage_policy_name_,
-    const String & relative_data_path_,
-    const DistributedSettings & distributed_settings_,
-    LoadingStrictnessLevel mode,
-    ClusterPtr owned_cluster_)
-    : StorageDistributed(
-        id_,
-        columns_,
-        constraints_,
-        String{},
-        String{},
-        String{},
-        cluster_name_,
-        context_,
-        sharding_key_,
-        storage_policy_name_,
-        relative_data_path_,
-        distributed_settings_,
-        mode,
-        std::move(owned_cluster_),
-        remote_table_function_ptr_)
-{
-}
-
 QueryProcessingStage::Enum StorageDistributed::getQueryProcessingStage(
     ContextPtr local_context,
     QueryProcessingStage::Enum to_stage,

--- a/src/Storages/StorageDistributed.h
+++ b/src/Storages/StorageDistributed.h
@@ -61,7 +61,8 @@ public:
         const DistributedSettings & distributed_settings_,
         LoadingStrictnessLevel mode,
         ClusterPtr owned_cluster_ = {},
-        ASTPtr remote_table_function_ptr_ = {});
+        ASTPtr remote_table_function_ptr_ = {},
+        bool is_remote_function_ = false);
 
     ~StorageDistributed() override;
 
@@ -273,6 +274,8 @@ private:
     // For random shard index generation
     mutable std::mutex rng_mutex;
     pcg64 rng;
+
+    bool is_remote_function;
 };
 
 }

--- a/src/Storages/StorageDistributed.h
+++ b/src/Storages/StorageDistributed.h
@@ -63,20 +63,6 @@ public:
         ClusterPtr owned_cluster_ = {},
         ASTPtr remote_table_function_ptr_ = {});
 
-    StorageDistributed(
-        const StorageID & id_,
-        const ColumnsDescription & columns_,
-        const ConstraintsDescription & constraints_,
-        ASTPtr remote_table_function_ptr_,
-        const String & cluster_name_,
-        ContextPtr context_,
-        const ASTPtr & sharding_key_,
-        const String & storage_policy_name_,
-        const String & relative_data_path_,
-        const DistributedSettings & distributed_settings_,
-        LoadingStrictnessLevel mode,
-        ClusterPtr owned_cluster_ = {});
-
     ~StorageDistributed() override;
 
     std::string getName() const override { return "Distributed"; }

--- a/src/TableFunctions/TableFunctionRemote.cpp
+++ b/src/TableFunctions/TableFunctionRemote.cpp
@@ -306,21 +306,7 @@ StoragePtr TableFunctionRemote::executeImpl(const ASTPtr & /*ast_function*/, Con
         cached_columns = getActualTableStructure(context, is_insert_query);
 
     assert(cluster);
-    StoragePtr res = remote_table_function_ptr
-        ? std::make_shared<StorageDistributed>(
-            StorageID(getDatabaseName(), table_name),
-            cached_columns,
-            ConstraintsDescription{},
-            remote_table_function_ptr,
-            String{},
-            context,
-            sharding_key,
-            String{},
-            String{},
-            DistributedSettings{},
-            LoadingStrictnessLevel::CREATE,
-            cluster)
-        : std::make_shared<StorageDistributed>(
+    StoragePtr res = std::make_shared<StorageDistributed>(
             StorageID(getDatabaseName(), table_name),
             cached_columns,
             ConstraintsDescription{},
@@ -334,7 +320,8 @@ StoragePtr TableFunctionRemote::executeImpl(const ASTPtr & /*ast_function*/, Con
             String{},
             DistributedSettings{},
             LoadingStrictnessLevel::CREATE,
-            cluster);
+            cluster,
+            remote_table_function_ptr);
 
     res->startup();
     return res;

--- a/src/TableFunctions/TableFunctionRemote.cpp
+++ b/src/TableFunctions/TableFunctionRemote.cpp
@@ -321,7 +321,8 @@ StoragePtr TableFunctionRemote::executeImpl(const ASTPtr & /*ast_function*/, Con
             DistributedSettings{},
             LoadingStrictnessLevel::CREATE,
             cluster,
-            remote_table_function_ptr);
+            remote_table_function_ptr,
+            !is_cluster_function);
 
     res->startup();
     return res;

--- a/tests/integration/test_distributed_inter_server_secret/test.py
+++ b/tests/integration/test_distributed_inter_server_secret/test.py
@@ -418,7 +418,7 @@ def test_per_user_protocol_settings_secure_cluster(user, password):
     )
 
 
-def test_secure_cluster_distributed_over_distributed_different_users():
+def test_secure_cluster_distributed_over_distributed_different_users_remote():
     # This works because we will have initial_user='default'
     n1.query(
         "SELECT * FROM remote('n1', currentDatabase(), dist_secure)", user="new_user"
@@ -433,3 +433,16 @@ def test_secure_cluster_distributed_over_distributed_different_users():
     # and stuff).
     with pytest.raises(QueryRuntimeException):
         n1.query("SELECT * FROM dist_over_dist_secure", user="new_user")
+
+
+def test_secure_cluster_distributed_over_distributed_different_users_cluster():
+    id_ = "cluster-user"
+    n1.query(
+        f"SELECT *, '{id_}' FROM cluster(secure, currentDatabase(), dist_secure)",
+        user="nopass",
+        settings={
+            "prefer_localhost_replica": 0,
+        },
+    )
+    assert get_query_user_info(n1, id_) == [["nopass", "nopass"]] * 4
+    assert get_query_user_info(n2, id_) == [["nopass", "nopass"]] * 3

--- a/tests/integration/test_distributed_inter_server_secret/test.py
+++ b/tests/integration/test_distributed_inter_server_secret/test.py
@@ -116,10 +116,10 @@ def start_cluster():
         cluster.shutdown()
 
 
-# @return -- [user, initial_user]
+# @return -- [[user, initial_user]]
 def get_query_user_info(node, query_pattern):
     node.query("SYSTEM FLUSH LOGS")
-    return (
+    lines = (
         node.query(
             """
     SELECT user, initial_user
@@ -133,8 +133,10 @@ def get_query_user_info(node, query_pattern):
             )
         )
         .strip()
-        .split("\t")
+        .split("\n")
     )
+    lines = map(lambda x: x.split("\t"), lines)
+    return list(lines)
 
 
 # @return -- [user, initial_user]
@@ -331,19 +333,19 @@ def test_secure_disagree_insert():
 def test_user_insecure_cluster(user, password):
     id_ = "query-dist_insecure-" + user
     n1.query(f"SELECT *, '{id_}' FROM dist_insecure", user=user, password=password)
-    assert get_query_user_info(n1, id_) == [
+    assert get_query_user_info(n1, id_)[0] == [
         user,
         user,
     ]  # due to prefer_localhost_replica
-    assert get_query_user_info(n2, id_) == ["default", user]
+    assert get_query_user_info(n2, id_)[0] == ["default", user]
 
 
 @users
 def test_user_secure_cluster(user, password):
     id_ = "query-dist_secure-" + user
     n1.query(f"SELECT *, '{id_}' FROM dist_secure", user=user, password=password)
-    assert get_query_user_info(n1, id_) == [user, user]
-    assert get_query_user_info(n2, id_) == [user, user]
+    assert get_query_user_info(n1, id_)[0] == [user, user]
+    assert get_query_user_info(n2, id_)[0] == [user, user]
 
 
 @users


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix cluster() for inter-server secret (preserve initial user as before)

The behaviour of cluster() with inter-server secret had been changed in #63013,
after it started to use "default" user, and this introduces a
regression.

The intention of that patch was to adjust only remote(), since it only
it accept custom user, which should be ignored.

Fixes: https://github.com/ClickHouse/ClickHouse/issues/66287 (cc @den-crane @pufit )
Fixes: https://github.com/ClickHouse/ClickHouse/issues/66352 (cc @canhld94 )
Fixes: #63013 