### PR TITLE
Fix "Sending a batch of X files to Y (0.00 rows, 0.00 B bytes)." in case of batch restoring

### DIFF
--- a/src/Storages/Distributed/DistributedAsyncInsertBatch.cpp
+++ b/src/Storages/Distributed/DistributedAsyncInsertBatch.cpp
@@ -196,6 +196,16 @@ void DistributedAsyncInsertBatch::readText(ReadBuffer & in)
         UInt64 idx;
         in >> idx >> "\n";
         files.push_back(std::filesystem::absolute(fmt::format("{}/{}.bin", parent.path, idx)).string());
+
+        ReadBufferFromFile header_buffer(files.back());
+        const DistributedAsyncInsertHeader & header = DistributedAsyncInsertHeader::read(header_buffer, parent.log);
+        total_bytes += total_bytes;
+
+        if (header.rows)
+        {
+            total_rows += header.rows;
+            total_bytes += header.bytes;
+        }
     }
 
     recovered = true;


### PR DESCRIPTION
Previously it was always zeros.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)