### PR TITLE
Add a test for #66333

### DIFF
--- a/tests/queries/0_stateless/03203_multiif_and_where_2_conditions_old_analyzer_bug.reference
+++ b/tests/queries/0_stateless/03203_multiif_and_where_2_conditions_old_analyzer_bug.reference
@@ -1,0 +1,4 @@
+this query used to be broken in old analyser:
+c1	c2	yes	true	1
+this query worked:
+c1	c2	yes	true	1

--- a/tests/queries/0_stateless/03203_multiif_and_where_2_conditions_old_analyzer_bug.reference
+++ b/tests/queries/0_stateless/03203_multiif_and_where_2_conditions_old_analyzer_bug.reference
@@ -2,3 +2,5 @@ this query used to be broken in old analyser:
 c1	c2	yes	true
 this query worked:
 yes	true
+experimental analyzer:
+c1	c2	yes	true

--- a/tests/queries/0_stateless/03203_multiif_and_where_2_conditions_old_analyzer_bug.reference
+++ b/tests/queries/0_stateless/03203_multiif_and_where_2_conditions_old_analyzer_bug.reference
@@ -1,4 +1,4 @@
 this query used to be broken in old analyser:
-c1	c2	yes	true	1
+c1	c2	yes	true
 this query worked:
-c1	c2	yes	true	1
+yes	true

--- a/tests/queries/0_stateless/03203_multiif_and_where_2_conditions_old_analyzer_bug.sql
+++ b/tests/queries/0_stateless/03203_multiif_and_where_2_conditions_old_analyzer_bug.sql
@@ -7,8 +7,8 @@ AS SELECT
 
 select 'this query used to be broken in old analyser:';
 SELECT *,
-    multiIf(column_b IN (SELECT 'c2' as someproduct), 'yes', 'no') AS condition_1,
-    multiIf(column_b  = 'c2', 'true', 'false') AS condition_2
+  multiIf(column_b IN (SELECT 'c2' as someproduct), 'yes', 'no') AS condition_1,
+  multiIf(column_b  = 'c2', 'true', 'false') AS condition_2
 FROM (SELECT column_a, column_b FROM bugcheck1)
 WHERE (condition_1 IN ('yes')) AND (condition_2 in ('true'))
 settings allow_experimental_analyzer=0;
@@ -16,8 +16,16 @@ settings allow_experimental_analyzer=0;
 select 'this query worked:';
 
 SELECT
-    multiIf(column_b IN (SELECT 'c2' as someproduct), 'yes', 'no') AS condition_1,
-    multiIf(column_b  = 'c2', 'true', 'false') AS condition_2
+  multiIf(column_b IN (SELECT 'c2' as someproduct), 'yes', 'no') AS condition_1,
+  multiIf(column_b  = 'c2', 'true', 'false') AS condition_2
 FROM (SELECT column_a, column_b FROM bugcheck1)
 WHERE (condition_1 IN ('yes')) AND (condition_2 in ('true'))
 settings allow_experimental_analyzer=0;
+
+select 'experimental analyzer:';
+SELECT *,
+  multiIf(column_b IN (SELECT 'c2' as someproduct), 'yes', 'no') AS condition_1,
+  multiIf(column_b  = 'c2', 'true', 'false') AS condition_2
+FROM (SELECT column_a, column_b FROM bugcheck1)
+WHERE (condition_1 IN ('yes')) AND (condition_2 in ('true'))
+settings allow_experimental_analyzer=1;

--- a/tests/queries/0_stateless/03203_multiif_and_where_2_conditions_old_analyzer_bug.sql
+++ b/tests/queries/0_stateless/03203_multiif_and_where_2_conditions_old_analyzer_bug.sql
@@ -1,0 +1,42 @@
+CREATE OR REPLACE TABLE bugcheck1
+ENGINE = MergeTree
+ORDER BY tuple()
+AS SELECT
+    'c1' as column_a,
+    'c2' as column_b;
+
+select 'this query used to be broken in old analyser:';
+SELECT
+    *,
+      multiIf(column_b IN (
+        SELECT 'c2' as someproduct
+    ), 'yes', 'no') AS condition_1,
+    multiIf(column_b  = 'c2', 'true', 'false') AS condition_2,
+  --condition in WHERE is true
+  (condition_1 IN ('yes')) AND (condition_2 in ('true')) as cond
+FROM
+(
+    SELECT column_a, column_b
+    FROM bugcheck1
+)
+WHERE (condition_1 IN ('yes')) AND (condition_2 in ('true'))
+settings allow_experimental_analyzer=0;
+
+select 'this query worked:';
+SELECT
+    *,
+      multiIf(column_b IN (
+        SELECT 'c2' as someproduct
+    ), 'yes', 'no') AS condition_1,
+    multiIf(column_b  = 'c2', 'true', 'false') AS condition_2,
+  --condition in WHERE is true
+  (condition_1 IN ('yes')) AND (condition_2 in ('true')) as cond
+FROM
+(
+    SELECT column_a, column_b
+    FROM bugcheck1
+)
+--the next line is the only difference:
+-- WHERE (condition_1 IN ('yes')) AND (condition_2 in ('true'))
+WHERE (condition_2 in ('true'))
+settings allow_experimental_analyzer=0;

--- a/tests/queries/0_stateless/03203_multiif_and_where_2_conditions_old_analyzer_bug.sql
+++ b/tests/queries/0_stateless/03203_multiif_and_where_2_conditions_old_analyzer_bug.sql
@@ -6,37 +6,18 @@ AS SELECT
     'c2' as column_b;
 
 select 'this query used to be broken in old analyser:';
-SELECT
-    *,
-      multiIf(column_b IN (
-        SELECT 'c2' as someproduct
-    ), 'yes', 'no') AS condition_1,
-    multiIf(column_b  = 'c2', 'true', 'false') AS condition_2,
-  --condition in WHERE is true
-  (condition_1 IN ('yes')) AND (condition_2 in ('true')) as cond
-FROM
-(
-    SELECT column_a, column_b
-    FROM bugcheck1
-)
+SELECT *,
+    multiIf(column_b IN (SELECT 'c2' as someproduct), 'yes', 'no') AS condition_1,
+    multiIf(column_b  = 'c2', 'true', 'false') AS condition_2
+FROM (SELECT column_a, column_b FROM bugcheck1)
 WHERE (condition_1 IN ('yes')) AND (condition_2 in ('true'))
 settings allow_experimental_analyzer=0;
 
 select 'this query worked:';
+
 SELECT
-    *,
-      multiIf(column_b IN (
-        SELECT 'c2' as someproduct
-    ), 'yes', 'no') AS condition_1,
-    multiIf(column_b  = 'c2', 'true', 'false') AS condition_2,
-  --condition in WHERE is true
-  (condition_1 IN ('yes')) AND (condition_2 in ('true')) as cond
-FROM
-(
-    SELECT column_a, column_b
-    FROM bugcheck1
-)
---the next line is the only difference:
--- WHERE (condition_1 IN ('yes')) AND (condition_2 in ('true'))
-WHERE (condition_2 in ('true'))
+    multiIf(column_b IN (SELECT 'c2' as someproduct), 'yes', 'no') AS condition_1,
+    multiIf(column_b  = 'c2', 'true', 'false') AS condition_2
+FROM (SELECT column_a, column_b FROM bugcheck1)
+WHERE (condition_1 IN ('yes')) AND (condition_2 in ('true'))
 settings allow_experimental_analyzer=0;

--- a/tests/queries/0_stateless/03203_multiif_and_where_2_conditions_old_analyzer_bug.sql
+++ b/tests/queries/0_stateless/03203_multiif_and_where_2_conditions_old_analyzer_bug.sql
@@ -1,4 +1,6 @@
-CREATE OR REPLACE TABLE bugcheck1
+DROP TABLE IF EXISTS bugcheck1;
+
+CREATE TABLE bugcheck1
 ENGINE = MergeTree
 ORDER BY tuple()
 AS SELECT
@@ -29,3 +31,5 @@ SELECT *,
 FROM (SELECT column_a, column_b FROM bugcheck1)
 WHERE (condition_1 IN ('yes')) AND (condition_2 in ('true'))
 settings allow_experimental_analyzer=1;
+
+DROP TABLE bugcheck1;


### PR DESCRIPTION
added a stateless test to check if an analyser bug described in https://github.com/ClickHouse/ClickHouse/issues/66333 is still happening.

Example of this query failing on [24.6.2.17](https://fiddle.clickhouse.com/65eebd83-31f4-484b-82a2-07f7c1605d94)

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [x] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
