### PR TITLE
Allow run query instantly in play

### DIFF
--- a/programs/server/play.html
+++ b/programs/server/play.html
@@ -522,8 +522,8 @@
     const current_url = new URL(window.location);
     const opened_locally = location.protocol == 'file:';
 
-    /// Run query instantly after page is loaded
-    const run_immediately = current_url.searchParams.get("run") == 1;
+    /// Run query instantly after page is loaded if the run parameter is present.
+    const run_immediately = !!current_url.searchParams.get("run");
 
     const server_address = current_url.searchParams.get('url');
     if (server_address) {

--- a/programs/server/play.html
+++ b/programs/server/play.html
@@ -523,7 +523,7 @@
     const opened_locally = location.protocol == 'file:';
 
     /// Run query instantly after page is loaded
-    const play_now = current_url.searchParams.get("play_now");
+    const run_immediately = current_url.searchParams.get("run");
 
     const server_address = current_url.searchParams.get('url');
     if (server_address) {
@@ -602,8 +602,8 @@
                     const title = "ClickHouse Query: " + query;
 
                     let history_url = window.location.pathname + '?user=' + encodeURIComponent(user);
-                    if (play_now) {
-                        history_url += "&play_now=" + encodeURIComponent(play_now);
+                    if (run_immediately) {
+                        history_url += "&run=" + encodeURIComponent(run_immediately);
                     }
                     if (server_address != location.origin) {
                         /// Save server's address in URL if it's not identical to the address of the play UI.
@@ -1166,7 +1166,7 @@
         });
     }
 
-    if (play_now === 'true') {
+    if (run_immediately === 'true') {
         post();
     }
 

--- a/programs/server/play.html
+++ b/programs/server/play.html
@@ -523,7 +523,7 @@
     const opened_locally = location.protocol == 'file:';
 
     /// Run query instantly after page is loaded
-    const run_immediately = current_url.searchParams.get("run");
+    const run_immediately = !!current_url.searchParams.get("run");
 
     const server_address = current_url.searchParams.get('url');
     if (server_address) {
@@ -603,7 +603,7 @@
 
                     let history_url = window.location.pathname + '?user=' + encodeURIComponent(user);
                     if (run_immediately) {
-                        history_url += "&run=" + encodeURIComponent(run_immediately);
+                        history_url += "&run=" + run_immediately;
                     }
                     if (server_address != location.origin) {
                         /// Save server's address in URL if it's not identical to the address of the play UI.

--- a/programs/server/play.html
+++ b/programs/server/play.html
@@ -522,6 +522,9 @@
     const current_url = new URL(window.location);
     const opened_locally = location.protocol == 'file:';
 
+    /// Run query instantly after page is loaded
+    const play_now = current_url.searchParams.get("play_now");
+
     const server_address = current_url.searchParams.get('url');
     if (server_address) {
         document.getElementById('url').value = server_address;
@@ -599,6 +602,9 @@
                     const title = "ClickHouse Query: " + query;
 
                     let history_url = window.location.pathname + '?user=' + encodeURIComponent(user);
+                    if (play_now) {
+                        history_url += "&play_now=" + encodeURIComponent(play_now);
+                    }
                     if (server_address != location.origin) {
                         /// Save server's address in URL if it's not identical to the address of the play UI.
                         history_url += '&url=' + encodeURIComponent(server_address);
@@ -1158,6 +1164,10 @@
         media_query_list.addEventListener('change', function(e) {
             setColorTheme(e.matches ? 'dark' : 'light');
         });
+    }
+
+    if (play_now === 'true') {
+        post();
     }
 
     document.getElementById('toggle-light').onclick = function() {

--- a/programs/server/play.html
+++ b/programs/server/play.html
@@ -523,7 +523,7 @@
     const opened_locally = location.protocol == 'file:';
 
     /// Run query instantly after page is loaded if the run parameter is present.
-    const run_immediately = !!current_url.searchParams.get("run");
+    const run_immediately = current_url.searchParams.has("run");
 
     const server_address = current_url.searchParams.get('url');
     if (server_address) {

--- a/programs/server/play.html
+++ b/programs/server/play.html
@@ -523,7 +523,7 @@
     const opened_locally = location.protocol == 'file:';
 
     /// Run query instantly after page is loaded
-    const run_immediately = !!current_url.searchParams.get("run");
+    const run_immediately = current_url.searchParams.get("run") == 1;
 
     const server_address = current_url.searchParams.get('url');
     if (server_address) {
@@ -603,7 +603,7 @@
 
                     let history_url = window.location.pathname + '?user=' + encodeURIComponent(user);
                     if (run_immediately) {
-                        history_url += "&run=" + run_immediately;
+                        history_url += "&run=" + (run_immediately ? 1 : 0);
                     }
                     if (server_address != location.origin) {
                         /// Save server's address in URL if it's not identical to the address of the play UI.
@@ -1166,7 +1166,7 @@
         });
     }
 
-    if (run_immediately === 'true') {
+    if (run_immediately) {
         post();
     }
 

--- a/programs/server/play.html
+++ b/programs/server/play.html
@@ -603,7 +603,7 @@
 
                     let history_url = window.location.pathname + '?user=' + encodeURIComponent(user);
                     if (run_immediately) {
-                        history_url += "&run=" + (run_immediately ? 1 : 0);
+                        history_url += "&run=1";
                     }
                     if (server_address != location.origin) {
                         /// Save server's address in URL if it's not identical to the address of the play UI.


### PR DESCRIPTION
Automatically execute the query after the page loads if the `run=1` parameter is present. By default, the query does not execute automatically.

Reason:

While it might be acceptable to click `Run` once or twice, it becomes tedious when using the play service frequently as a simple frontend to generate and open multiple links. This change eliminates the need to click `Run` every time.

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)





> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
