### PR TITLE
Update installation options page

### DIFF
--- a/docs/en/getting-started/install.md
+++ b/docs/en/getting-started/install.md
@@ -15,7 +15,7 @@ You have four options for getting up and running with ClickHouse:
 
 - **[ClickHouse Cloud](https://clickhouse.com/cloud/):** The official ClickHouse as a service, - built by, maintained and supported by the creators of ClickHouse
 - **[Quick Install](#quick-install):** an easy-to-download binary for testing and developing with ClickHouse
-- **[Production Deployments](#available-installation-options):** ClickHouse can run on any Linux, FreeBSD, or macOS with x86-64, ARM, or PowerPC64LE CPU architecture
+- **[Production Deployments](#available-installation-options):** ClickHouse can run on any Linux, FreeBSD, or macOS with x86-64, modern ARM (ARMv8.2-A up), or PowerPC64LE CPU architecture
 - **[Docker Image](https://hub.docker.com/r/clickhouse/clickhouse-server/):** use the official Docker image in Docker Hub
 
 ## ClickHouse Cloud


### PR DESCRIPTION
Currently install page states that production builds can run on all ARM CPUs however this is not the case. Production builds are for modern ARM CPUs, requires at least feature level ARMv8.2-A. See [this comment](https://github.com/ClickHouse/ClickHouse/issues/50852#issuecomment-1586247423).

### Changelog category (leave one):
- Documentation (changelog entry is not required)