### PR TITLE
CI: Fix for job filtering in PRs

### DIFF
--- a/tests/ci/ci_cache.py
+++ b/tests/ci/ci_cache.py
@@ -765,14 +765,19 @@ class CiCache:
         MAX_JOB_NUM_TO_WAIT = 3
         round_cnt = 0
 
-        # FIXME: temporary experiment: lets enable await for PR' workflows but for a shorter time
+        def _has_build_job():
+            for job in self.jobs_to_wait:
+                if CI.is_build_job(job):
+                    return True
+            return False
+
         if not is_release:
-            MAX_ROUNDS_TO_WAIT = 3
+            # in PRs we can wait only for builds, TIMEOUT*MAX_ROUNDS_TO_WAIT=100min is enough
+            MAX_ROUNDS_TO_WAIT = 2
 
         while (
-            len(self.jobs_to_wait) > MAX_JOB_NUM_TO_WAIT
-            and round_cnt < MAX_ROUNDS_TO_WAIT
-        ):
+            len(self.jobs_to_wait) > MAX_JOB_NUM_TO_WAIT or _has_build_job()
+        ) and round_cnt < MAX_ROUNDS_TO_WAIT:
             round_cnt += 1
             GHActions.print_in_group(
                 f"Wait pending jobs, round [{round_cnt}/{MAX_ROUNDS_TO_WAIT}]:",

--- a/tests/ci/ci_cache.py
+++ b/tests/ci/ci_cache.py
@@ -533,19 +533,19 @@ class CiCache:
                 job=job,
                 batch=0,
                 num_batches=job_config.num_batches,
-                release_branch=not job_config.pr_only,
+                release_branch=True,
             )
             or self.is_pending(
                 job=job,
                 batch=0,
                 num_batches=job_config.num_batches,
-                release_branch=not job_config.pr_only,
+                release_branch=True,
             )
             or self.is_failed(
                 job=job,
                 batch=0,
                 num_batches=job_config.num_batches,
-                release_branch=not job_config.pr_only,
+                release_branch=True,
             )
         )
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
