### PR TITLE
Ensure that llvm-symbolizer is used for symbolizing sanitizer reports

### DIFF
--- a/docker/test/base/Dockerfile
+++ b/docker/test/base/Dockerfile
@@ -35,7 +35,9 @@ ENV UBSAN_OPTIONS='print_stacktrace=1 max_allocation_size_mb=32768'
 ENV MSAN_OPTIONS='abort_on_error=1 poison_in_dtor=1 max_allocation_size_mb=32768'
 ENV LSAN_OPTIONS='max_allocation_size_mb=32768'
 
-# for external_symbolizer_path
+# for external_symbolizer_path, and also ensure that llvm-symbolizer really
+# exists (since you don't want to fallback to addr2line, it is very slow)
+RUN test -f /usr/bin/llvm-symbolizer-${LLVM_VERSION}
 RUN ln -s /usr/bin/llvm-symbolizer-${LLVM_VERSION} /usr/bin/llvm-symbolizer
 
 RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && locale-gen en_US.UTF-8

--- a/docker/test/util/Dockerfile
+++ b/docker/test/util/Dockerfile
@@ -5,14 +5,6 @@ FROM ubuntu:22.04
 ARG apt_archive="http://archive.ubuntu.com"
 RUN sed -i "s|http://archive.ubuntu.com|$apt_archive|g" /etc/apt/sources.list
 
-# FIXME: rebuild for clang 18.1.3, that contains a workaround [1] for
-# sanitizers issue [2]:
-#
-# $ git tag --contains  c2a57034eff048cd36c563c8e0051db3a70991b3 | tail -1
-# llvmorg-18.1.3
-#
-#  [1]: https://github.com/llvm/llvm-project/commit/c2a57034eff048cd36c563c8e0051db3a70991b3
-#  [2]: https://github.com/ClickHouse/ClickHouse/issues/64086
 ENV DEBIAN_FRONTEND=noninteractive LLVM_VERSION=18
 
 RUN apt-get update \


### PR DESCRIPTION
Since you don't want to fallback to addr2line:

    # addr2line
    $ time /bin/test
    set_flag_impl: Success
    set_flag_if: Success
    /usr/bin/addr2line: DWARF error: invalid or unhandled FORM value: 0x23
    ==================
    WARNING: ThreadSanitizer: data race (pid=18)
    ...
    real    3m8.580s
    user    0m21.967s
    sys     0m40.628s

    # llvm-symbolizer
    $ time ./test
    set_flag_impl: Success
    set_flag_if: Success
    ==================
    WARNING: ThreadSanitizer: data race (pid=24884)
    real    0m0.028s
    user    0m0.003s
    sys     0m0.006s

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)