### PR TITLE
Optimize the display of large tables for issues

### DIFF
--- a/src/Processors/Formats/Impl/PrettyBlockOutputFormat.h
+++ b/src/Processors/Formats/Impl/PrettyBlockOutputFormat.h
@@ -46,7 +46,7 @@ protected:
         const Block & header, const Chunk & chunk,
         WidthsPerColumn & widths, Widths & max_padded_widths, Widths & name_widths);
 
-    void writeValueWithPadding(
+    void writeValueWithPadding(const Chunk & chunk,
         const IColumn & column, const ISerialization & serialization, size_t row_num,
         size_t value_width, size_t pad_to_width, size_t cut_to_width, bool align_right, bool is_number);
 

--- a/src/Processors/Formats/Impl/PrettyCompactBlockOutputFormat.cpp
+++ b/src/Processors/Formats/Impl/PrettyCompactBlockOutputFormat.cpp
@@ -185,7 +185,7 @@ void PrettyCompactBlockOutputFormat::writeRow(
 
         const auto & type = *header.getByPosition(j).type;
         const auto & cur_widths = widths[j].empty() ? max_widths[j] : widths[j][row_num];
-        writeValueWithPadding(*columns[j], *serializations[j], row_num, cur_widths, max_widths[j], cut_to_width, type.shouldAlignRightInPrettyFormats(), isNumber(type));
+        writeValueWithPadding(chunk, *columns[j], *serializations[j], row_num, cur_widths, max_widths[j], cut_to_width, type.shouldAlignRightInPrettyFormats(), isNumber(type));
     }
 
     writeCString(grid_symbols.bar, out);

--- a/src/Processors/Formats/Impl/PrettySpaceBlockOutputFormat.cpp
+++ b/src/Processors/Formats/Impl/PrettySpaceBlockOutputFormat.cpp
@@ -99,7 +99,7 @@ void PrettySpaceBlockOutputFormat::writeChunk(const Chunk & chunk, PortKind port
 
             const auto & type = *header.getByPosition(column).type;
             auto & cur_width = widths[column].empty() ? max_widths[column] : widths[column][row];
-            writeValueWithPadding(
+            writeValueWithPadding(chunk,
                 *columns[column], *serializations[column], row, cur_width, max_widths[column], cut_to_width, type.shouldAlignRightInPrettyFormats(), isNumber(type));
         }
         writeReadableNumberTip(chunk);


### PR DESCRIPTION
### Changelog category:
- Improvement

### Changelog entry:
...Now,the very long text when query from the clickhouse,Maybe the terminal printed not pretty.
https://github.com/ClickHouse/ClickHouse/issues/65753

### Documentation entry for user-facing changes

- Example use: A query for large create table command.
- CREATE TABLE default.tls
(
    `ip` Nullable(String),
    `data` Tuple(tls Tuple(error Nullable(String), protocol Nullable(String), result Tuple(handshake_log Tuple(client_finished Tuple(verify_data Nullable(String)), client_key_exchange Tuple(dh_params Tuple(client_private Tuple(length Nullable(Int64), value Nullable(String)), client_public Tuple(length Nullable(Int64), value Nullable(String)), generator Tuple(length Nullable(Int64), value Nullable(String)), prime Tuple(length Nullable(Int64), value Nullable(String))), ecdh_params Tuple(client_private Tuple(length Nullable(Int64), value Nullable(String)), client_public Tuple(x Tuple(length Nullable(Int64), value Nullable(String)), y Tuple(length Nullable(Int64), value Nullable(String))), curve_id Tuple(id Nullable(Int64), name Nullable(String))), rsa_params Tuple(encrypted_pre_master_secret Nullable(String), length Nullable(Int64))), key_material Tuple(master_secret Tuple(length Nullable(Int64), value Nullable(String)), pre_master_secret Tuple(length Nullable(Int64), value Nullable(String))), server_certificates Tuple(certificate Tuple(parsed Tuple(extensions Tuple(authority_info_access Tuple(issuer_urls Array(Nullable(String)), ocsp_urls Array(Nullable(String))), authority_key_id Nullable(String), basic_constraints Tuple(is_ca Nullable(Bool), max_path_len Nullable(Int64)), certificate_policies Array(Tuple(cps Array(Nullable(String)), id Nullable(String), user_notice Array(Tuple(explicit_text Nullable(String), notice_reference Array(Tuple(notice_numbers Array(Nullable(Int64)), organization Nullable(String))))))), crl_distribution_points Array(Nullable(String)), extended_key_usage Tuple(client_auth Nullable(Bool), code_signing Nullable(Bool), email_protection Nullable(Bool), ipsec_end_system Nullable(Bool), ipsec_intermediate_system_usage Nullable(Bool), ipsec_tunnel Nullable(Bool), ipsec_user Nullable(Bool), microsoft_server_gated_crypto Nullable(Bool), netscape_server_gated_crypto Nullable(Bool), ocsp_signing Nullable(Bool), server_auth Nullable(Bool), time_stamping Nullable(Bool)), issuer_alt_name Tuple(email_addresses Array(Nullable(String)), uniform_resource_identifiers Array(Nullable(String))), key_usage Tuple(certificate_sign Nullable(Bool), content_commitment Nullable(Bool), crl_sign Nullable(Bool), data_encipherment Nullable(Bool), decipher_only Nullable(Bool), digital_signature Nullable(Bool), encipher_only Nullable(Bool), key_agreement Nullable(Bool), key_encipherment Nullable(Bool), value Nullable(Int64)), signed_certificate_timestamps Array(Tuple(log_id Nullable(String), signature Nullable(String), timestamp Nullable(Int64), version Nullable(Int64))), subject_alt_name Tuple(dns_names Array(Nullable(String)), email_addresses Array(Nullable(String)), ip_addresses Array(Nullable(String)), other_names Array(Tuple(id Nullable(String), value Nullable(String))), uniform_resource_identifiers Array(Nullable(String))), subject_key_id Nullable(String)), fingerprint_md5 Nullable(String), fingerprint_sha1 Nullable(String), fingerprint_sha256 Nullable(String), issuer Tuple(common_name Array(Nullable(String)), country Array(Nullable(String)), domain_component Array(Nullable(String)), email_address Array(Nullable(String)), given_name Array(Nullable(String)), locality Array(Nullable(String)), organization Array(Nullable(String)), organizational_unit Array(Nullable(String)), postal_code Array(Nullable(String)), province Array(Nullable(String)), serial_number Array(Nullable(String)), street_address Array(Nullable(String)), surname Array(Nullable(String))), issuer_dn Nullable(String), names Array(Nullable(String)), redacted Nullable(Bool), serial_number Nullable(String), signature Tuple(self_signed Nullable(Bool), signature_algorithm Tuple(name Nullable(String), oid Nullable(String)), valid Nullable(Bool), value Nullable(String)), signature_algorithm Tuple(name Nullable(String), oid Nullable(String)), spki_subject_fingerprint Nullable(String), subject Tuple(common_name Array(Nullable(String)), country Array(Nullable(String)), domain_component Array(Nullable(String)), email_address Array(Nullable(String)), given_name Array(Nullable(String)), jurisdiction_country Array(Nullable(String)), jurisdiction_locality Array(Nullable(String)), jurisdiction_province Array(Nullable(String)), locality Array(Nullable(String)), organization Array(Nullable(String)), organizational_unit Array(Nullable(String)), postal_code Array(Nullable(String)), province Array(Nullable(String)), serial_number Array(Nullable(String)), street_address Array(Nullable(String)), surname Array(Nullable(String))), subject_dn Nullable(String), subject_key_info Tuple(ecdsa_public_key Tuple(b Nullable(String), curve Nullable(String), gx Nullable(String), gy Nullable(String), length Nullable(Int64), n Nullable(String), p Nullable(String), pub Nullable(String), x Nullable(String), y Nullable(String)), fingerprint_sha256 Nullable(String), key_algorithm Tuple(name Nullable(String)), rsa_public_key Tuple(exponent Nullable(Int64), length Nullable(Int64), modulus Nullable(String))), tbs_fingerprint Nullable(String), tbs_noct_fingerprint Nullable(String), unknown_extensions Array(Tuple(critical Nullable(Bool), id Nullable(String), value Nullable(String))), validation_level Nullable(String), validity Tuple(end Nullable(String), length Nullable(Int64), start Nullable(String)), version Nullable(Int64)), raw Nullable(String)), chain Array(Tuple(parsed Tuple(extensions Tuple(authority_info_access Tuple(issuer_urls Array(Nullable(String)), ocsp_urls Array(Nullable(String))), authority_key_id Nullable(String), basic_constraints Tuple(is_ca Nullable(Bool), max_path_len Nullable(Int64)), certificate_policies Array(Tuple(cps Array(Nullable(String)), id Nullable(String), user_notice Array(Tuple(explicit_text Nullable(String), notice_reference Array(Tuple(organization Nullable(String))))))), crl_distribution_points Array(Nullable(String)), extended_key_usage Tuple(client_auth Nullable(Bool), code_signing Nullable(Bool), ipsec_end_system Nullable(Bool), ipsec_tunnel Nullable(Bool), ipsec_user Nullable(Bool), netscape_server_gated_crypto Nullable(Bool), ocsp_signing Nullable(Bool), server_auth Nullable(Bool), unknown Array(Nullable(String))), issuer_alt_name Tuple(email_addresses Array(Nullable(String))), key_usage Tuple(certificate_sign Nullable(Bool), content_commitment Nullable(Bool), crl_sign Nullable(Bool), digital_signature Nullable(Bool), key_encipherment Nullable(Bool), value Nullable(Int64)), name_constraints Tuple(critical Nullable(Bool), excluded_ip_addresses Array(Tuple(begin Nullable(String), cidr Nullable(String), end Nullable(String), mask Nullable(String))), excluded_names Array(Nullable(String)), permitted_directory_names Array(Tuple(organizational_unit Array(Nullable(String)))), permitted_names Array(Nullable(String))), signed_certificate_timestamps Array(Tuple(log_id Nullable(String), signature Nullable(String), timestamp Nullable(Int64), version Nullable(Int64))), subject_alt_name Tuple(directory_names Array(Tuple(common_name Array(Nullable(String)))), dns_names Array(Nullable(String)), email_addresses Array(Nullable(String)), ip_addresses Array(Nullable(String)), uniform_resource_identifiers Array(Nullable(String))), subject_key_id Nullable(String)), fingerprint_md5 Nullable(String), fingerprint_sha1 Nullable(String), fingerprint_sha256 Nullable(String), issuer Tuple(common_name Array(Nullable(String)), country Array(Nullable(String)), domain_component Array(Nullable(String)), email_address Array(Nullable(String)), locality Array(Nullable(String)), organization Array(Nullable(String)), organizational_unit Array(Nullable(String)), province Array(Nullable(String))), issuer_dn Nullable(String), names Array(Nullable(String)), redacted Nullable(Bool), serial_number Nullable(String), signature Tuple(self_signed Nullable(Bool), signature_algorithm Tuple(name Nullable(String), oid Nullable(String)), valid Nullable(Bool), value Nullable(String)), signature_algorithm Tuple(name Nullable(String), oid Nullable(String)), spki_subject_fingerprint Nullable(String), subject Tuple(common_name Array(Nullable(String)), country Array(Nullable(String)), domain_component Array(Nullable(String)), email_address Array(Nullable(String)), locality Array(Nullable(String)), organization Array(Nullable(String)), organizational_unit Array(Nullable(String)), postal_code Array(Nullable(String)), province Array(Nullable(String)), serial_number Array(Nullable(String)), street_address Array(Nullable(String))), subject_dn Nullable(String), subject_key_info Tuple(ecdsa_public_key Tuple(b Nullable(String), curve Nullable(String), gx Nullable(String), gy Nullable(String), length Nullable(Int64), n Nullable(String), p Nullable(String), pub Nullable(String), x Nullable(String), y Nullable(String)), fingerprint_sha256 Nullable(String), key_algorithm Tuple(name Nullable(String)), rsa_public_key Tuple(exponent Nullable(Int64), length Nullable(Int64), modulus Nullable(String))), tbs_fingerprint Nullable(String), tbs_noct_fingerprint Nullable(String), unknown_extensions Array(Tuple(critical Nullable(Bool), id Nullable(String), value Nullable(String))), validation_level Nullable(String), validity Tuple(end Nullable(String), length Nullable(Int64), start Nullable(String)), version Nullable(Int64)), raw Nullable(String))), validation Tuple(browser_error Nullable(String), browser_trusted Nullable(Bool))), server_finished Tuple(verify_data Nullable(String)), server_hello Tuple(cipher_suite Tuple(hex Nullable(String), name Nullable(String), value Nullable(Int64)), compression_method Nullable(Int64), extended_master_secret Nullable(Bool), heartbeat Nullable(Bool), ocsp_stapling Nullable(Bool), random Nullable(String), secure_renegotiation Nullable(Bool), session_id Nullable(String), ticket Nullable(Bool), version Tuple(name Nullable(String), value Nullable(Int64))), server_key_exchange Tuple(dh_params Tuple(generator Tuple(length Nullable(Int64), value Nullable(String)), prime Tuple(length Nullable(Int64), value Nullable(String)), server_public Tuple(length Nullable(Int64), value Nullable(String))), digest Nullable(String), ecdh_params Tuple(curve_id Tuple(id Nullable(Int64), name Nullable(String)), server_public Tuple(x Tuple(length Nullable(Int64), value Nullable(String)), y Tuple(length Nullable(Int64), value Nullable(String)))), signature Tuple(raw Nullable(String), signature_and_hash_type Tuple(hash_algorithm Nullable(String), signature_algorithm Nullable(String)), tls_version Tuple(name Nullable(String), value Nullable(Int64)), type Nullable(String), valid Nullable(Bool))))), status Nullable(String), timestamp Nullable(String)))
)
ENGINE = MergeTree
ORDER BY tuple()
SETTINGS index_granularity = 8192

![image](https://github.com/user-attachments/assets/456eb071-4627-4fa5-989b-defc01937428)

-->