### PR TITLE
Something in the test `03001_consider_lwd_when_merge`

### DIFF
--- a/tests/queries/0_stateless/03001_consider_lwd_when_merge.sql
+++ b/tests/queries/0_stateless/03001_consider_lwd_when_merge.sql
@@ -7,12 +7,12 @@ SETTINGS max_bytes_to_merge_at_max_space_in_pool = 80000, exclude_deleted_rows_f
 INSERT INTO lwd_merge SELECT number FROM numbers(10000);
 INSERT INTO lwd_merge SELECT number FROM numbers(10000, 10000);
 
-OPTIMIZE TABLE lwd_merge;
+OPTIMIZE TABLE lwd_merge FINAL;
 SELECT count() FROM system.parts WHERE database = currentDatabase() AND table = 'lwd_merge' AND active = 1;
 
 DELETE FROM lwd_merge WHERE id % 10 > 0;
 
-OPTIMIZE TABLE lwd_merge;
+OPTIMIZE TABLE lwd_merge FINAL;
 SELECT count() FROM system.parts WHERE database = currentDatabase() AND table = 'lwd_merge' AND active = 1;
 
 ALTER TABLE lwd_merge MODIFY SETTING exclude_deleted_rows_for_part_size_in_merge = 1;
@@ -20,7 +20,7 @@ ALTER TABLE lwd_merge MODIFY SETTING exclude_deleted_rows_for_part_size_in_merge
 -- delete again because deleted rows will be counted in mutation
 DELETE FROM lwd_merge WHERE id % 100 == 0;
 
-OPTIMIZE TABLE lwd_merge;
+OPTIMIZE TABLE lwd_merge FINAL;
 SELECT count() FROM system.parts WHERE database = currentDatabase() AND table = 'lwd_merge' AND active = 1;
 
 DROP TABLE IF EXISTS lwd_merge;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
