### PR TITLE
Fix dropping named collection in local storage

### DIFF
--- a/src/Common/NamedCollections/NamedCollectionsMetadataStorage.cpp
+++ b/src/Common/NamedCollections/NamedCollectionsMetadataStorage.cpp
@@ -169,9 +169,13 @@ public:
     }
 
 private:
-    std::string getPath(const std::string & path) const
+    std::string getPath(const std::string & file_name) const
     {
-        return fs::path(root_path) / path;
+        const auto file_name_as_path = fs::path(file_name);
+        if (file_name_as_path.is_absolute())
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "Filename {} cannot be an absolute path!", file_name);
+
+        return fs::path(root_path) / file_name_as_path;
     }
 
     /// Delete .tmp files. They could be left undeleted in case of
@@ -320,9 +324,13 @@ private:
         return zookeeper_client;
     }
 
-    std::string getPath(const std::string & path) const
+    std::string getPath(const std::string & file_name) const
     {
-        return fs::path(root_path) / path;
+        const auto file_name_as_path = fs::path(file_name);
+        if (file_name_as_path.is_absolute())
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "Filename {} cannot be an absolute path!", file_name);
+
+        return fs::path(root_path) / file_name_as_path;
     }
 };
 

--- a/src/Common/NamedCollections/NamedCollectionsMetadataStorage.cpp
+++ b/src/Common/NamedCollections/NamedCollectionsMetadataStorage.cpp
@@ -173,7 +173,7 @@ private:
     {
         const auto file_name_as_path = fs::path(file_name);
         if (file_name_as_path.is_absolute())
-            throw Exception(ErrorCodes::LOGICAL_ERROR, "Filename {} cannot be an absolute path!", file_name);
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "Filename {} cannot be an absolute path", file_name);
 
         return fs::path(root_path) / file_name_as_path;
     }
@@ -328,7 +328,7 @@ private:
     {
         const auto file_name_as_path = fs::path(file_name);
         if (file_name_as_path.is_absolute())
-            throw Exception(ErrorCodes::LOGICAL_ERROR, "Filename {} cannot be an absolute path!", file_name);
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "Filename {} cannot be an absolute path", file_name);
 
         return fs::path(root_path) / file_name_as_path;
     }


### PR DESCRIPTION
It was introduced in https://github.com/ClickHouse/ClickHouse/pull/64574. Closes https://github.com/ClickHouse/ClickHouse/issues/66596.
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Fix removing named collections in local storage.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
