### PR TITLE
Fix logical error in PrometheusRequestHandler

### DIFF
--- a/src/Server/PrometheusRequestHandler.cpp
+++ b/src/Server/PrometheusRequestHandler.cpp
@@ -30,15 +30,8 @@ void PrometheusRequestHandler::handleRequest(HTTPServerRequest & request, HTTPSe
         response.setContentType("text/plain; version=0.0.4; charset=UTF-8");
 
         WriteBufferFromHTTPServerResponse wb(response, request.getMethod() == Poco::Net::HTTPRequest::HTTP_HEAD, keep_alive_timeout, write_event);
-        try
-        {
-            metrics_writer->write(wb);
-            wb.finalize();
-        }
-        catch (...)
-        {
-            wb.finalize();
-        }
+        metrics_writer->write(wb);
+        wb.finalize();
     }
     catch (...)
     {


### PR DESCRIPTION
### Changelog category:
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix logical error in `PrometheusRequestHandler`

```
Message: Code: 49. DB::Exception: Cannot finalize buffer after cancellation. (LOGICAL_ERROR), Stack trace (when copying this message, always include the lines below):

0. DB::Exception::Exception(DB::Exception::MessageMasked&&, int, bool)
1. DB::Exception::Exception(PreformattedMessage&&, int)
2. DB::Exception::Exception<>(int, FormatStringHelperImpl<>)
3. DB::WriteBuffer::finalize()
4. DB::PrometheusRequestHandler::handleRequest(HTTPServerRequest &, HTTPServerResponse &, const ProfileEvents::Event &)
```