### PR TITLE
[Docs] `toInt*` functions

### DIFF
--- a/docs/en/sql-reference/functions/type-conversion-functions.md
+++ b/docs/en/sql-reference/functions/type-conversion-functions.md
@@ -237,17 +237,18 @@ toInt8OrNull('abc'): ᴺᵁᴸᴸ
 ## toInt8OrDefault
 
 Like [`toInt8`](#toint8), this function converts an input value to a value of type [Int8](../data-types/int-uint.md) but returns the default value in case of an error.
+If no `default` value is passed then `0` is returned in case of an error.
 
 **Syntax**
 
 ```sql
-toInt8OrDefault(expr, def)
+toInt8OrDefault(expr[, default])
 ```
 
 **Arguments**
 
 - `expr` — Expression returning a number or a string representation of a number. [Expression](../syntax.md/#syntax-expressions) / [String](../data-types/string.md).
-- `def` — The default value to return if parsing to type `Int8` is unsuccessful. [Int8](../data-types/int-uint.md).
+- `default` (optional) — The default value to return if parsing to type `Int8` is unsuccessful. [Int8](../data-types/int-uint.md).
 
 Supported arguments:
 - Values of type (U)Int8/16/32/64/128/256.
@@ -265,7 +266,7 @@ This is not considered an error.
 
 **Returned value**
 
-- 8-bit integer value if successful, otherwise returns the default value. [Int8](../data-types/int-uint.md).
+- 8-bit integer value if successful, otherwise returns the default value if passed or `0` if not. [Int8](../data-types/int-uint.md).
 
 :::note
 - The function uses [rounding towards zero](https://en.wikipedia.org/wiki/Rounding#Rounding_towards_zero), meaning it truncates fractional digits of numbers.
@@ -486,17 +487,18 @@ toInt16OrNull('abc'): ᴺᵁᴸᴸ
 ## toInt16OrDefault
 
 Like [`toInt16`](#toint16), this function converts an input value to a value of type [Int16](../data-types/int-uint.md) but returns the default value in case of an error.
+If no `default` value is passed then `0` is returned in case of an error.
 
 **Syntax**
 
 ```sql
-toInt16OrDefault(expr, def)
+toInt16OrDefault(expr[, default])
 ```
 
 **Arguments**
 
 - `expr` — Expression returning a number or a string representation of a number. [Expression](../syntax.md/#syntax-expressions) / [String](../data-types/string.md).
-- `def` — The default value to return if parsing to type `Int16` is unsuccessful. [Int16](../data-types/int-uint.md).
+- `default` (optional) — The default value to return if parsing to type `Int16` is unsuccessful. [Int16](../data-types/int-uint.md).
 
 Supported arguments:
 - Values of type (U)Int8/16/32/64/128/256.
@@ -514,7 +516,7 @@ This is not considered an error.
 
 **Returned value**
 
-- 16-bit integer value if successful, otherwise returns the default value. [Int16](../data-types/int-uint.md).
+- 16-bit integer value if successful, otherwise returns the default value if passed or `0` if not. [Int16](../data-types/int-uint.md).
 
 :::note
 - The function uses [rounding towards zero](https://en.wikipedia.org/wiki/Rounding#Rounding_towards_zero), meaning it truncates fractional digits of numbers.
@@ -734,17 +736,18 @@ toInt32OrNull('abc'): ᴺᵁᴸᴸ
 ## toInt32OrDefault
 
 Like [`toInt32`](#toint32), this function converts an input value to a value of type [Int32](../data-types/int-uint.md) but returns the default value in case of an error.
+If no `default` value is passed then `0` is returned in case of an error.
 
 **Syntax**
 
 ```sql
-toInt32OrDefault(expr, def)
+toInt32OrDefault(expr[, default])
 ```
 
 **Arguments**
 
 - `expr` — Expression returning a number or a string representation of a number. [Expression](../syntax.md/#syntax-expressions) / [String](../data-types/string.md).
-- `def` — The default value to return if parsing to type `Int32` is unsuccessful. [Int32](../data-types/int-uint.md).
+- `default` (optional) — The default value to return if parsing to type `Int32` is unsuccessful. [Int32](../data-types/int-uint.md).
 
 Supported arguments:
 - Values of type (U)Int8/16/32/64/128/256.
@@ -762,7 +765,7 @@ This is not considered an error.
 
 **Returned value**
 
-- 32-bit integer value if successful, otherwise returns the default value. [Int32](../data-types/int-uint.md).
+- 32-bit integer value if successful, otherwise returns the default value if passed or `0` if not. [Int32](../data-types/int-uint.md).
 
 :::note
 - The function uses [rounding towards zero](https://en.wikipedia.org/wiki/Rounding#Rounding_towards_zero), meaning it truncates fractional digits of numbers.
@@ -983,17 +986,18 @@ toInt64OrNull('abc'): ᴺᵁᴸᴸ
 ## toInt64OrDefault
 
 Like [`toInt64`](#toint64), this function converts an input value to a value of type [Int64](../data-types/int-uint.md) but returns the default value in case of an error.
+If no `default` value is passed then `0` is returned in case of an error.
 
 **Syntax**
 
 ```sql
-toInt64OrDefault(expr, def)
+toInt64OrDefault(expr[, default])
 ```
 
 **Arguments**
 
 - `expr` — Expression returning a number or a string representation of a number. [Expression](../syntax.md/#syntax-expressions) / [String](../data-types/string.md).
-- `def` — The default value to return if parsing to type `Int64` is unsuccessful. [Int64](../data-types/int-uint.md).
+- `default` (optional) — The default value to return if parsing to type `Int64` is unsuccessful. [Int64](../data-types/int-uint.md).
 
 Supported arguments:
 - Values of type (U)Int8/16/32/64/128/256.
@@ -1011,7 +1015,7 @@ This is not considered an error.
 
 **Returned value**
 
-- 64-bit integer value if successful, otherwise returns the default value. [Int64](../data-types/int-uint.md).
+- 64-bit integer value if successful, otherwise returns the default value if passed or `0` if not. [Int64](../data-types/int-uint.md).
 
 :::note
 - The function uses [rounding towards zero](https://en.wikipedia.org/wiki/Rounding#Rounding_towards_zero), meaning it truncates fractional digits of numbers.
@@ -1231,17 +1235,18 @@ toInt128OrNull('abc'):  ᴺᵁᴸᴸ
 ## toInt128OrDefault
 
 Like [`toInt128`](#toint128), this function converts an input value to a value of type [Int128](../data-types/int-uint.md) but returns the default value in case of an error.
+If no `default` value is passed then `0` is returned in case of an error.
 
 **Syntax**
 
 ```sql
-toInt128OrDefault(expr, def)
+toInt128OrDefault(expr[, default])
 ```
 
 **Arguments**
 
 - `expr` — Expression returning a number or a string representation of a number. [Expression](../syntax.md/#syntax-expressions) / [String](../data-types/string.md).
-- `def` — The default value to return if parsing to type `Int128` is unsuccessful. [Int128](../data-types/int-uint.md).
+- `default` (optional) — The default value to return if parsing to type `Int128` is unsuccessful. [Int128](../data-types/int-uint.md).
 
 Supported arguments:
 - (U)Int8/16/32/64/128/256.
@@ -1259,7 +1264,7 @@ This is not considered an error.
 
 **Returned value**
 
-- 128-bit integer value if successful, otherwise returns the default value. [Int128](../data-types/int-uint.md).
+- 128-bit integer value if successful, otherwise returns the default value if passed or `0` if not. [Int128](../data-types/int-uint.md).
 
 :::note
 - The function uses [rounding towards zero](https://en.wikipedia.org/wiki/Rounding#Rounding_towards_zero), meaning it truncates fractional digits of numbers.
@@ -1479,17 +1484,18 @@ toInt256OrNull('abc'):  ᴺᵁᴸᴸ
 ## toInt256OrDefault
 
 Like [`toInt256`](#toint256), this function converts an input value to a value of type [Int256](../data-types/int-uint.md) but returns the default value in case of an error.
+If no `default` value is passed then `0` is returned in case of an error.
 
 **Syntax**
 
 ```sql
-toInt256OrDefault(expr, def)
+toInt256OrDefault(expr[, default])
 ```
 
 **Arguments**
 
 - `expr` — Expression returning a number or a string representation of a number. [Expression](../syntax.md/#syntax-expressions) / [String](../data-types/string.md).
-- `def` — The default value to return if parsing to type `Int256` is unsuccessful. [Int256](../data-types/int-uint.md).
+- `default` (optional) — The default value to return if parsing to type `Int256` is unsuccessful. [Int256](../data-types/int-uint.md).
 
 Supported arguments:
 - Values of type (U)Int8/16/32/64/128/256.
@@ -1507,7 +1513,7 @@ This is not considered an error.
 
 **Returned value**
 
-- 256-bit integer value if successful, otherwise returns the default value. [Int256](../data-types/int-uint.md).
+- 256-bit integer value if successful, otherwise returns the default value if passed or `0` if not. [Int256](../data-types/int-uint.md).
 
 :::note
 - The function uses [rounding towards zero](https://en.wikipedia.org/wiki/Rounding#Rounding_towards_zero), meaning it truncates fractional digits of numbers.

--- a/docs/en/sql-reference/functions/type-conversion-functions.md
+++ b/docs/en/sql-reference/functions/type-conversion-functions.md
@@ -571,7 +571,7 @@ Result:
 
 ## toInt32OrZero
 
-Like [`toInt32`](#toint32), this function converts an input value to a value of type [Int8](../data-types/int-uint.md) but returns `0` in case of an error.
+Like [`toInt32`](#toint32), this function converts an input value to a value of type [Int32](../data-types/int-uint.md) but returns `0` in case of an error.
 
 **Syntax**
 
@@ -767,7 +767,7 @@ SELECT toInt64('9223372036854775808') == --9223372036854775808;
 
 **Returned value**
 
-- 64-bit integer value. [Int64](../data-types/int-uint.md). [Int64](../data-types/int-uint.md).
+- 64-bit integer value. [Int64](../data-types/int-uint.md).
 
 :::note
 The function uses [rounding towards zero](https://en.wikipedia.org/wiki/Rounding#Rounding_towards_zero), meaning it truncates fractional digits of numbers.
@@ -800,7 +800,7 @@ Result:
 
 ## toInt64OrZero
 
-Like [`toInt64`](#toint64), this function converts an input value to a value of type [Int8](../data-types/int-uint.md) but returns `0` in case of an error.
+Like [`toInt64`](#toint64), this function converts an input value to a value of type [Int64](../data-types/int-uint.md) but returns `0` in case of an error.
 
 **Syntax**
 
@@ -878,7 +878,7 @@ Types for which `\N` is returned:
 
 **Returned value**
 
-- Integer value of type `Int64` if successful, otherwise `NULL`. [Int64](../data-types/int-uint.md) / [NULL](../data-types/nullable.md).
+- 64-bit integer value if successful, otherwise `NULL`. [Int64](../data-types/int-uint.md) / [NULL](../data-types/nullable.md).
 
 :::note
 The function uses [rounding towards zero](https://en.wikipedia.org/wiki/Rounding#Rounding_towards_zero), meaning it truncates fractional digits of numbers.
@@ -935,7 +935,7 @@ Types for which the default value is returned:
 
 **Returned value**
 
-- Integer value of type `Int64` if successful, otherwise returns the default value. [Int64](../data-types/int-uint.md).
+- 64-bit integer value if successful, otherwise returns the default value. [Int64](../data-types/int-uint.md).
 
 :::note
 - The function uses [rounding towards zero](https://en.wikipedia.org/wiki/Rounding#Rounding_towards_zero), meaning it truncates fractional digits of numbers.
@@ -1028,7 +1028,7 @@ Result:
 
 ## toInt128OrZero
 
-Like [`toInt128`](#toint128), this function converts an input value to a value of type [Int8](../data-types/int-uint.md) but returns `0` in case of an error.
+Like [`toInt128`](#toint128), this function converts an input value to a value of type [Int128](../data-types/int-uint.md) but returns `0` in case of an error.
 
 **Syntax**
 
@@ -1256,7 +1256,7 @@ Result:
 
 ## toInt256OrZero
 
-Like [`toInt256`](#toint256), this function converts an input value to a value of type [Int8](../data-types/int-uint.md) but returns `0` in case of an error.
+Like [`toInt256`](#toint256), this function converts an input value to a value of type [Int256](../data-types/int-uint.md) but returns `0` in case of an error.
 
 **Syntax**
 

--- a/docs/en/sql-reference/functions/type-conversion-functions.md
+++ b/docs/en/sql-reference/functions/type-conversion-functions.md
@@ -63,18 +63,19 @@ toInt8(expr)
 
 - `expr` — Expression returning a number or a string representation of a number. [Expression](../syntax.md/#syntax-expressions).
 
-Supported types:
-- (U)Int8/16/32/64/128/256
-- Float*
-- String representations of (U)Int8/16/32/128/256
+Supported arguments:
+- Values of type (U)Int8/16/32/64/128/256.
+- Values of type Float32/64.
+- String representations of (U)Int8/16/32/128/256.
 
-Unsupported types:
-- Float values `NaN` and `Inf` throw an exception.
-- String representations of binary and hexadecimal values, e.g. `SELECT toInt8('0xc0fe');`
+Unsupported arguments:
+- String representations of Float32/64 values, including `NaN` and `Inf`.
+- String representations of binary and hexadecimal values, e.g. `SELECT toInt8('0xc0fe');`.
 
 :::note
-If the input value cannot be represented within the bounds of [Int8](../data-types/int-uint.md), the result over or under flows. This is not considered an error.  
-For example: `SELECT toInt8(128) == -128;`, `SELECT toInt8(128.0) == -128;`,  `SELECT toInt8('128') == -128;`.
+If the input value cannot be represented within the bounds of [Int8](../data-types/int-uint.md), overflow or underflow of the result occurs. 
+This is not considered an error.  
+For example: `SELECT toInt8(128) == -128;`.
 :::
 
 **Returned value**
@@ -93,15 +94,18 @@ Query:
 SELECT
     toInt8(-8),
     toInt8(-8.8),
-    toInt8('-8');
+    toInt8('-8')
+FORMAT vertical;
 ```
 
 Result:
 
 ```response
-   ┌─toInt8(-8)─┬─toInt8(-8.8)─┬─toInt8('-8')─┐
-1. │         -8 │           -8 │           -8 │
-   └────────────┴──────────────┴──────────────┘
+Row 1:
+──────
+toInt8(-8):   -8
+toInt8(-8.8): -8
+toInt8('-8'): -8
 ```
 
 **See also**
@@ -124,14 +128,17 @@ toInt8OrZero(x)
 
 - `x` — A String representation of a number. [String](../data-types/string.md).
 
-Supported types:
-- String representations of (U)Int8/16/32/128/256
+Supported arguments:
+- String representations of (U)Int8/16/32/128/256.
 
-Types for which `0` is returned:
-- String representations of ordinary Float32/64 values.
-- String representations of Float values `NaN` and `Inf`.
+Unsupported arguments (return `0`):
+- String representations of ordinary Float32/64 values, including `NaN` and `Inf`.
 - String representations of binary and hexadecimal values, e.g. `SELECT toInt8OrZero('0xc0fe');`.
-- If the input value cannot be represented within the bounds of [Int8](../data-types/int-uint.md), and the result over or under flows.
+
+:::note
+If the input value cannot be represented within the bounds of [Int8](../data-types/int-uint.md), overflow or underflow of the result occurs.
+This is not considered an error.
+:::
 
 **Returned value**
 
@@ -148,15 +155,17 @@ Query:
 ``` sql
 SELECT
     toInt8OrZero('-8'),
-    toInt8OrZero('abc');
+    toInt8OrZero('abc')
+FORMAT vertical;
 ```
 
 Result:
 
 ```response
-   ┌─toInt8OrZero('-8')─┬─toInt8OrZero('abc')─┐
-1. │                 -8 │                   0 │
-   └────────────────────┴─────────────────────┘
+Row 1:
+──────
+toInt8OrZero('-8'):  -8
+toInt8OrZero('abc'): 0
 ```
 
 **See also**
@@ -167,7 +176,7 @@ Result:
 
 ## toInt8OrNull
 
-Like [`toInt8`](#toint8), takes an argument of type [String](../data-types/string.md) and tries to parse it to type [`Int8`](../data-types/int-uint.md). If unsuccessful, returns [`NULL`](../data-types/nullable.md).
+Like [`toInt8`](#toint8), this function converts an input value to a value of type [Int8](../data-types/int-uint.md) but returns `NULL` in case of an error.
 
 **Syntax**
 
@@ -179,14 +188,17 @@ toInt8OrNull(x)
 
 - `x` — A String representation of a number. [String](../data-types/string.md).
 
-Supported types:
-- String representations of (U)Int8/16/32/128/256
+Supported arguments:
+- String representations of (U)Int8/16/32/128/256.
 
-Types for which `\N` is returned:
-- String representations of ordinary Float32/64 values.
-- String representations of Float values `NaN` and `Inf`.
+Unsupported arguments (return `\N`)
+- String representations of Float32/64 values, including `NaN` and `Inf`.
 - String representations of binary and hexadecimal values, e.g. `SELECT toInt8OrNull('0xc0fe');`.
-- If the input value cannot be represented within the bounds of [Int8](../data-types/int-uint.md), and the result over or under flows.
+
+:::note
+If the input value cannot be represented within the bounds of [Int8](../data-types/int-uint.md), overflow or underflow of the result occurs.
+This is not considered an error.
+:::
 
 **Returned value**
 
@@ -201,15 +213,19 @@ The function uses [rounding towards zero](https://en.wikipedia.org/wiki/Rounding
 Query:
 
 ``` sql
-SELECT toInt8OrNull('-8'), toInt8OrNull('abc');
+SELECT
+    toInt8OrNull('-8'),
+    toInt8OrNull('abc')
+FORMAT vertical;
 ```
 
 Result:
 
 ```response
-   ┌─toInt8OrNull('-8')─┬─toInt8OrNull('abc')─┐
-1. │                 -8 │                ᴺᵁᴸᴸ │
-   └────────────────────┴─────────────────────┘
+Row 1:
+──────
+toInt8OrNull('-8'):  -8
+toInt8OrNull('abc'): ᴺᵁᴸᴸ
 ```
 
 **See also**
@@ -233,15 +249,19 @@ toInt8OrDefault(expr, def)
 - `expr` — Expression returning a number or a string representation of a number. [Expression](../syntax.md/#syntax-expressions) / [String](../data-types/string.md).
 - `def` — The default value to return if parsing to type `Int8` is unsuccessful. [Int8](../data-types/int-uint.md).
 
-Supported types:
-- (U)Int8/16/32/64/128/256
-- Float*
-- String representations of (U)Int8/16/32/128/256
+Supported arguments:
+- Values of type (U)Int8/16/32/64/128/256.
+- Values of type Float32/64.
+- String representations of (U)Int8/16/32/128/256.
 
-Types for which the default value is returned:
-- Float values `NaN` and `Inf` return the default value.
-- String representations of binary and hexadecimal values, e.g. `SELECT toInt8OrDefault('0xc0fe', CAST('-1', 'Int8'));`
-- If the input value cannot be represented within the bounds of [Int8](../data-types/int-uint.md) and the result over or under flows.
+Arguments for which the default value is returned:
+- String representations of Float32/64 values, including `NaN` and `Inf`.
+- String representations of binary and hexadecimal values, e.g. `SELECT toInt8OrDefault('0xc0fe', CAST('-1', 'Int8'));`.
+
+:::note
+If the input value cannot be represented within the bounds of [Int8](../data-types/int-uint.md), overflow or underflow of the result occurs.
+This is not considered an error.
+:::
 
 **Returned value**
 
@@ -259,15 +279,17 @@ Query:
 ``` sql
 SELECT
     toInt8OrDefault('-8', CAST('-1', 'Int8')),
-    toInt8OrDefault('abc', CAST('-1', 'Int8'));
+    toInt8OrDefault('abc', CAST('-1', 'Int8'))
+FORMAT vertical;
 ```
 
 Result:
 
 ```response
-   ┌─toInt8OrDefault('-8', CAST('-1', 'Int8'))─┬─toInt8OrDefault('abc', CAST('-1', 'Int8'))─┐
-1. │                                        -8 │                                         -1 │
-   └───────────────────────────────────────────┴────────────────────────────────────────────┘
+Row 1:
+──────
+toInt8OrDefault('-8', CAST('-1', 'Int8')):  -8
+toInt8OrDefault('abc', CAST('-1', 'Int8')): -1
 ```
 
 **See also**
@@ -290,18 +312,19 @@ toInt16(expr)
 
 - `expr` — Expression returning a number or a string representation of a number. [Expression](../syntax.md/#syntax-expressions).
 
-Supported types:
-- (U)Int8/16/32/64/128/256
-- Float*
-- String representations of (U)Int8/16/32/128/256
+Supported arguments:
+- Values of type (U)Int8/16/32/64/128/256.
+- Values of type Float32/64.
+- String representations of (U)Int8/16/32/128/256.
 
-Unsupported types:
-- Float values `NaN` and `Inf` throw an exception.
-- String representations of binary and hexadecimal values, e.g. `SELECT toInt16('0xc0fe');`
+Unsupported arguments:
+- String representations of Float32/64 values, including `NaN` and `Inf`.
+- String representations of binary and hexadecimal values, e.g. `SELECT toInt16('0xc0fe');`.
 
 :::note
-If the input value cannot be represented within the bounds of [Int16](../data-types/int-uint.md), the result over or under flows. This is not considered an error.  
-For example: `SELECT toInt16(32768) == -32768;`, `SELECT toInt16(32768) == -32768;`,  `SELECT toInt16('32768') == -32768;`.
+If the input value cannot be represented within the bounds of [Int16](../data-types/int-uint.md), overflow or underflow of the result occurs.
+This is not considered an error.  
+For example: `SELECT toInt16(32768) == -32768;`.
 :::
 
 **Returned value**
@@ -320,15 +343,18 @@ Query:
 SELECT
     toInt16(-16),
     toInt16(-16.16),
-    toInt16('-16');
+    toInt16('-16')
+FORMAT vertical;
 ```
 
 Result:
 
 ```response
-   ┌─toInt16(-16)─┬─toInt16(-16.16)─┬─toInt16('-16')─┐
-1. │          -16 │             -16 │            -16 │
-   └──────────────┴─────────────────┴────────────────┘
+Row 1:
+──────
+toInt16(-16):    -16
+toInt16(-16.16): -16
+toInt16('-16'):  -16
 ```
 
 **See also**
@@ -351,14 +377,17 @@ toInt16OrZero(x)
 
 - `x` — A String representation of a number. [String](../data-types/string.md).
 
-Supported types:
-- String representations of (U)Int8/16/32/128/256
+Supported arguments:
+- String representations of (U)Int8/16/32/128/256.
 
-Types for which `0` is returned:
-- String representations of ordinary Float32/64 values.
-- String representations of Float values `NaN` and `Inf`.
+Unsupported arguments (return `0`):
+- String representations of Float32/64 values, including `NaN` and `Inf`.
 - String representations of binary and hexadecimal values, e.g. `SELECT toInt16OrZero('0xc0fe');`.
-- If the input value cannot be represented within the bounds of [Int16](../data-types/int-uint.md) and the result over or under flows.
+
+:::note
+If the input value cannot be represented within the bounds of [Int16](../data-types/int-uint.md), overflow or underflow of the result occurs.
+This is not considered as an error.
+:::
 
 **Returned value**
 
@@ -375,15 +404,17 @@ Query:
 ``` sql
 SELECT
     toInt16OrZero('-16'),
-    toInt16OrZero('abc');
+    toInt16OrZero('abc')
+FORMAT vertical;
 ```
 
 Result:
 
 ```response
-   ┌─toInt16OrZero('-16')─┬─toInt16OrZero('abc')─┐
-1. │                  -16 │                    0 │
-   └──────────────────────┴──────────────────────┘
+Row 1:
+──────
+toInt16OrZero('-16'): -16
+toInt16OrZero('abc'): 0
 ```
 
 **See also**
@@ -394,7 +425,7 @@ Result:
 
 ## toInt16OrNull
 
-Like [`toInt16`](#toint16), takes an argument of type [String](../data-types/string.md) and tries to parse it to type [`Int16`](../data-types/int-uint.md). If unsuccessful, returns [`NULL`](../data-types/nullable.md).
+Like [`toInt16`](#toint16), this function converts an input value to a value of type [Int16](../data-types/int-uint.md) but returns `NULL` in case of an error.
 
 **Syntax**
 
@@ -406,14 +437,17 @@ toInt16OrNull(x)
 
 - `x` — A String representation of a number. [String](../data-types/string.md).
 
-Supported types:
-- String representations of (U)Int8/16/32/128/256
+Supported arguments:
+- String representations of (U)Int8/16/32/128/256.
 
-Types for which `\N` is returned:
-- String representations of ordinary Float32/64 values.
-- String representations of Float values `NaN` and `Inf`.
+Unsupported arguments (return `\N`)
+- String representations of Float32/64 values, including `NaN` and `Inf`.
 - String representations of binary and hexadecimal values, e.g. `SELECT toInt16OrNull('0xc0fe');`.
-- If the input value cannot be represented within the bounds of [Int16](../data-types/int-uint.md) and the result over or under flows.
+
+:::note
+If the input value cannot be represented within the bounds of [Int16](../data-types/int-uint.md), overflow or underflow of the result occurs. 
+This is not considered an error.
+:::
 
 **Returned value**
 
@@ -430,15 +464,17 @@ Query:
 ``` sql
 SELECT
     toInt16OrNull('-16'),
-    toInt16OrNull('abc');
+    toInt16OrNull('abc')
+FORMAT vertical;
 ```
 
 Result:
 
 ```response
-   ┌─toInt16OrNull('-16')─┬─toInt16OrNull('abc')─┐
-1. │                  -16 │                 ᴺᵁᴸᴸ │
-   └──────────────────────┴──────────────────────┘
+Row 1:
+──────
+toInt16OrNull('-16'): -16
+toInt16OrNull('abc'): ᴺᵁᴸᴸ
 ```
 
 **See also**
@@ -449,7 +485,7 @@ Result:
 
 ## toInt16OrDefault
 
-Like [`toInt16`](#toint16), takes an argument of type [String](../data-types/string.md) and tries to parse it to type [`Int16`](../data-types/int-uint.md). If unsuccessful, returns the default type value.
+Like [`toInt16`](#toint16), this function converts an input value to a value of type [Int16](../data-types/int-uint.md) but returns the default value in case of an error.
 
 **Syntax**
 
@@ -462,15 +498,19 @@ toInt16OrDefault(expr, def)
 - `expr` — Expression returning a number or a string representation of a number. [Expression](../syntax.md/#syntax-expressions) / [String](../data-types/string.md).
 - `def` — The default value to return if parsing to type `Int16` is unsuccessful. [Int8](../data-types/int-uint.md).
 
-Supported types:
-- (U)Int8/16/32/64/128/256
-- Float*
-- String representations of (U)Int8/16/32/128/256
+Supported arguments:
+- Values of type (U)Int8/16/32/64/128/256.
+- Values of type Float32/64.
+- String representations of (U)Int8/16/32/128/256.
 
-Types for which the default value is returned:
-- Float values `NaN` and `Inf` return the default value.
-- String representations of binary and hexadecimal values, e.g. `SELECT toInt16OrDefault('0xc0fe', CAST('-1', 'Int16'));`
-- If the input value cannot be represented within the bounds of [Int16](../data-types/int-uint.md) and the result over or under flows.
+Arguments for which the default value is returned:
+- String representations of Float32/64 values, including `NaN` and `Inf`.
+- String representations of binary and hexadecimal values, e.g. `SELECT toInt16OrDefault('0xc0fe', CAST('-1', 'Int16'));`.
+
+:::note
+If the input value cannot be represented within the bounds of [Int16](../data-types/int-uint.md), overflow or underflow of the result occurs. 
+This is not considered an error.
+:::
 
 **Returned value**
 
@@ -486,15 +526,19 @@ Types for which the default value is returned:
 Query:
 
 ``` sql
-SELECT toInt16OrDefault('-16', cast('-1' as Int16)), toInt16OrDefault('abc', cast('-1' as Int16));
+SELECT
+    toInt16OrDefault('-16', CAST('-1', 'Int16')),
+    toInt16OrDefault('abc', CAST('-1', 'Int16'))
+FORMAT vertical;
 ```
 
 Result:
 
 ```response
-   ┌─toInt16OrDefault('-16', CAST('-1', 'Int16'))─┬─toInt16OrDefault('abc', CAST('-1', 'Int16'))─┐
-1. │                                          -16 │                                           -1 │
-   └──────────────────────────────────────────────┴──────────────────────────────────────────────┘
+Row 1:
+──────
+toInt16OrDefault('-16', CAST('-1', 'Int16')): -16
+toInt16OrDefault('abc', CAST('-1', 'Int16')): -1
 ```
 
 **See also**
@@ -517,23 +561,19 @@ toInt32(expr)
 
 - `expr` — Expression returning a number or a string representation of a number. [Expression](../syntax.md/#syntax-expressions).
 
-Supported types:
-- (U)Int8/16/32/64/128/256
-- Float*
-- String representations of (U)Int8/16/32/128/256
+Supported arguments:
+- Values of type (U)Int8/16/32/64/128/256.
+- Values of type Float32/64.
+- String representations of (U)Int8/16/32/128/256.
 
-Unsupported types:
-- Float values `NaN` and `Inf` throw an exception.
-- String representations of binary and hexadecimal values, e.g. `SELECT toInt32('0xc0fe');`
+Unsupported arguments:
+- String representations of Float32/64 values, including `NaN` and `Inf`.
+- String representations of binary and hexadecimal values, e.g. `SELECT toInt32('0xc0fe');`.
 
 :::note
-If the input value cannot be represented within the bounds of [Int32](../data-types/int-uint.md), the result over or under flows. This is not considered an error.  
-For example: 
-```
-SELECT toInt32(2147483648) == -2147483648;
-SELECT toInt32(2147483648.0) == -2147483648;
-SELECT toInt32('2147483648') == -2147483648;
-```
+If the input value cannot be represented within the bounds of [Int32](../data-types/int-uint.md), the result over or under flows. 
+This is not considered an error.  
+For example: `SELECT toInt32(2147483648) == -2147483648;`
 :::
 
 **Returned value**
@@ -553,14 +593,17 @@ SELECT
     toInt32(-32),
     toInt32(-32.32),
     toInt32('-32')
+FORMAT vertical;
 ```
 
 Result:
 
 ```response
-   ┌─toInt32(-32)─┬─toInt32(-32.32)─┬─toInt32('-32')─┐
-1. │          -32 │             -32 │            -32 │
-   └──────────────┴─────────────────┴────────────────┘
+Row 1:
+──────
+toInt32(-32):    -32
+toInt32(-32.32): -32
+toInt32('-32'):  -32
 ```
 
 **See also**
@@ -583,15 +626,17 @@ toInt32OrZero(x)
 
 - `x` — A String representation of a number. [String](../data-types/string.md).
 
-Supported types:
-- String representations of (U)Int8/16/32/128/256
+Supported arguments:
+- String representations of (U)Int8/16/32/128/256.
 
-Types for which `0` is returned:
-- String representations of ordinary Float32/64 values.
-- String representations of Float values `NaN` and `Inf`.
+Unsupported arguments (return `0`):
+- String representations of Float32/64 values, including `NaN` and `Inf`.
 - String representations of binary and hexadecimal values, e.g. `SELECT toInt32OrZero('0xc0fe');`.
-- If the input value cannot be represented within the bounds of [Int32](../data-types/int-uint.md) and the result over or under flows.
 
+:::note
+If the input value cannot be represented within the bounds of [Int32](../data-types/int-uint.md), overflow or underflow of the result occurs. 
+This is not considered an error.
+:::
 
 **Returned value**
 
@@ -606,15 +651,19 @@ The function uses [rounding towards zero](https://en.wikipedia.org/wiki/Rounding
 Query:
 
 ``` sql
-SELECT toInt32OrZero('-32'), toInt32OrZero('abc');
+SELECT
+    toInt32OrZero('-32'),
+    toInt32OrZero('abc')
+FORMAT vertical;
 ```
 
 Result:
 
 ```response
-   ┌─toInt32OrZero('-32')─┬─toInt32OrZero('abc')─┐
-1. │                  -32 │                    0 │
-   └──────────────────────┴──────────────────────┘
+Row 1:
+──────
+toInt32OrZero('-32'): -32
+toInt32OrZero('abc'): 0
 ```
 **See also**
 
@@ -624,7 +673,7 @@ Result:
 
 ## toInt32OrNull
 
-Like [`toInt32`](#toint32), takes an argument of type [String](../data-types/string.md) and tries to parse it to type [`Int32`](../data-types/int-uint.md). If unsuccessful, returns [`NULL`](../data-types/nullable.md).
+Like [`toInt32`](#toint32), this function converts an input value to a value of type [Int32](../data-types/int-uint.md) but returns `NULL` in case of an error.
 
 **Syntax**
 
@@ -636,14 +685,17 @@ toInt32OrNull(x)
 
 - `x` — A String representation of a number. [String](../data-types/string.md).
 
-Supported types:
-- String representations of (U)Int8/16/32/128/256
+Supported arguments:
+- String representations of (U)Int8/16/32/128/256.
 
-Types for which `\N` is returned:
-- String representations of ordinary Float32/64 values.
-- String representations of Float values `NaN` and `Inf`.
+Unsupported arguments (return `\N`)
+- String representations of Float32/64 values, including `NaN` and `Inf`.
 - String representations of binary and hexadecimal values, e.g. `SELECT toInt32OrNull('0xc0fe');`.
-- If the input value cannot be represented within the bounds of [Int32](../data-types/int-uint.md) and the result over or under flows.
+
+:::note
+If the input value cannot be represented within the bounds of [Int32](../data-types/int-uint.md), overflow or underflow of the result occurs. 
+This is not considered an error.
+:::
 
 **Returned value**
 
@@ -658,15 +710,19 @@ The function uses [rounding towards zero](https://en.wikipedia.org/wiki/Rounding
 Query:
 
 ``` sql
-SELECT toInt32OrNull('-32'), toInt32OrNull('abc');
+SELECT
+    toInt32OrNull('-32'),
+    toInt32OrNull('abc')
+FORMAT vertical;
 ```
 
 Result:
 
 ```response
-   ┌─toInt32OrNull('-32')─┬─toInt32OrNull('abc')─┐
-1. │                  -32 │                 ᴺᵁᴸᴸ │
-   └──────────────────────┴──────────────────────┘
+Row 1:
+──────
+toInt32OrNull('-32'): -32
+toInt32OrNull('abc'): ᴺᵁᴸᴸ
 ```
 
 **See also**
@@ -677,7 +733,7 @@ Result:
 
 ## toInt32OrDefault
 
-Like [`toInt32`](#toint32), takes an argument of type [String](../data-types/string.md) and tries to parse it to type [`Int32`](../data-types/int-uint.md). If unsuccessful, returns the default type value.
+Like [`toInt32`](#toint32), this function converts an input value to a value of type [Int32](../data-types/int-uint.md) but returns the default value in case of an error.
 
 **Syntax**
 
@@ -690,15 +746,19 @@ toInt32OrDefault(expr, def)
 - `expr` — Expression returning a number or a string representation of a number. [Expression](../syntax.md/#syntax-expressions) / [String](../data-types/string.md).
 - `def` — The default value to return if parsing to type `Int32` is unsuccessful. [Int32](../data-types/int-uint.md).
 
-Supported types:
-- (U)Int8/16/32/64/128/256
-- Float*
-- String representations of (U)Int8/16/32/128/256
+Supported arguments:
+- Values of type (U)Int8/16/32/64/128/256.
+- Values of type Float32/64.
+- String representations of (U)Int8/16/32/128/256.
 
-Types for which the default value is returned:
-- Float values `NaN` and `Inf` return the default value.
-- String representations of binary and hexadecimal values, e.g. `SELECT toInt32OrDefault('0xc0fe', CAST('-1', 'Int32'));`
-- If the input value cannot be represented within the bounds of [Int32](../data-types/int-uint.md) and the result over or under flows.
+Arguments for which the default value is returned:
+- String representations of Float32/64 values, including `NaN` and `Inf`.
+- String representations of binary and hexadecimal values, e.g. `SELECT toInt32OrDefault('0xc0fe', CAST('-1', 'Int32'));`.
+
+:::note
+If the input value cannot be represented within the bounds of [Int32](../data-types/int-uint.md), overflow or underflow of the result occurs. 
+This is not considered an error.
+:::
 
 **Returned value**
 
@@ -714,15 +774,19 @@ Types for which the default value is returned:
 Query:
 
 ``` sql
-SELECT toInt32OrDefault('-32', cast('-1' as Int32)), toInt32OrDefault('abc', cast('-1' as Int32));
+SELECT
+    toInt32OrDefault('-32', CAST('-1', 'Int32')),
+    toInt32OrDefault('abc', CAST('-1', 'Int32'))
+FORMAT vertical;
 ```
 
 Result:
 
 ```response
-   ┌─toInt32OrDefault('-32', CAST('-1', 'Int32'))─┬─toInt32OrDefault('abc', CAST('-1', 'Int32'))─┐
-1. │                                          -32 │                                           -1 │
-   └──────────────────────────────────────────────┴──────────────────────────────────────────────┘
+Row 1:
+──────
+toInt32OrDefault('-32', CAST('-1', 'Int32')): -32
+toInt32OrDefault('abc', CAST('-1', 'Int32')): -1
 ```
 
 **See also**
@@ -745,24 +809,19 @@ toInt64(expr)
 
 - `expr` — Expression returning a number or a string representation of a number. [Expression](../syntax.md/#syntax-expressions).
 
-Supported types:
-- (U)Int8/16/32/64/128/256
-- Float*
-- String representations of (U)Int8/16/32/128/256
+Supported arguments:
+- Values of type (U)Int8/16/32/64/128/256.
+- Values of type Float32/64.
+- String representations of (U)Int8/16/32/128/256.
 
 Unsupported types:
-- Float values `NaN` and `Inf` throw an exception.
-- String representations of binary and hexadecimal values, e.g. `SELECT toInt64('0xc0fe');`
+- String representations of Float32/64 values, including `NaN` and `Inf`.
+- String representations of binary and hexadecimal values, e.g. `SELECT toInt64('0xc0fe');`.
 
 :::note
-If the input value cannot be represented within the bounds of [Int64](../data-types/int-uint.md), the result over or under flows. This is not considered an error.  
-For example: 
-
-```
-SELECT toInt64(9223372036854775808) == -9223372036854775808;
-SELECT toInt64(9223372036854775808.0) == -9223372036854775808;
-SELECT toInt64('9223372036854775808') == --9223372036854775808;
-```
+If the input value cannot be represented within the bounds of [Int64](../data-types/int-uint.md), the result over or under flows. 
+This is not considered an error.  
+For example: `SELECT toInt64(9223372036854775808) == -9223372036854775808;`
 :::
 
 **Returned value**
@@ -781,15 +840,18 @@ Query:
 SELECT
     toInt64(-64),
     toInt64(-64.64),
-    toInt64('-64');
+    toInt64('-64')
+FORMAT vertical;
 ```
 
 Result:
 
 ```response
-   ┌─toInt64(-64)─┬─toInt64(-64.64)─┬─toInt64('-64')─┐
-1. │          -64 │             -64 │            -64 │
-   └──────────────┴─────────────────┴────────────────┘
+Row 1:
+──────
+toInt64(-64):    -64
+toInt64(-64.64): -64
+toInt64('-64'):  -64
 ```
 
 **See also**
@@ -812,14 +874,17 @@ toInt64OrZero(x)
 
 - `x` — A String representation of a number. [String](../data-types/string.md).
 
-Supported types:
-- String representations of (U)Int8/16/32/128/256
+Supported arguments:
+- String representations of (U)Int8/16/32/128/256.
 
-Types for which `0` is returned:
-- String representations of ordinary Float32/64 values.
-- String representations of Float values `NaN` and `Inf`.
+Unsupported arguments (return `0`):
+- String representations of Float32/64 values, including `NaN` and `Inf`.
 - String representations of binary and hexadecimal values, e.g. `SELECT toInt64OrZero('0xc0fe');`.
-- If the input value cannot be represented within the bounds of [Int64](../data-types/int-uint.md) and the result over or under flows.
+
+:::note
+If the input value cannot be represented within the bounds of [Int64](../data-types/int-uint.md), overflow or underflow of the result occurs. 
+This is not considered an error.
+:::
 
 **Returned value**
 
@@ -836,15 +901,17 @@ Query:
 ``` sql
 SELECT
     toInt64OrZero('-64'),
-    toInt64OrZero('abc');
+    toInt64OrZero('abc')
+FORMAT vertical;
 ```
 
 Result:
 
 ```response
-   ┌─toInt64OrZero('-64')─┬─toInt64OrZero('abc')─┐
-1. │                  -64 │                    0 │
-   └──────────────────────┴──────────────────────┘
+Row 1:
+──────
+toInt64OrZero('-64'): -64
+toInt64OrZero('abc'): 0
 ```
 
 **See also**
@@ -855,7 +922,7 @@ Result:
 
 ## toInt64OrNull
 
-Like [`toInt64`], takes an argument of type [String](../data-types/string.md) and tries to parse it to type [`Int64`](../data-types/nullable.md). If unsuccessful, returns [`NULL`](../data-types/nullable.md).
+Like [`toInt64`](#toint64), this function converts an input value to a value of type [Int64](../data-types/int-uint.md) but returns `NULL` in case of an error.
 
 **Syntax**
 
@@ -867,14 +934,17 @@ toInt64OrNull(x)
 
 - `x` — A String representation of a number. [Expression](../syntax.md/#syntax-expressions) / [String](../data-types/string.md).
 
-Supported types:
-- String representations of (U)Int8/16/32/128/256
+Supported arguments:
+- String representations of (U)Int8/16/32/128/256.
 
-Types for which `\N` is returned:
-- String representations of ordinary Float32/64 values.
-- String representations of Float values `NaN` and `Inf`.
+Unsupported arguments (return `\N`)
+- String representations of Float32/64 values, including `NaN` and `Inf`.
 - String representations of binary and hexadecimal values, e.g. `SELECT toInt64OrNull('0xc0fe');`.
-- If the input value cannot be represented within the bounds of [Int64](../data-types/int-uint.md) and the result over or under flows.
+
+:::note
+If the input value cannot be represented within the bounds of [Int64](../data-types/int-uint.md), overflow or underflow of the result occurs. 
+This is not considered an error.
+:::
 
 **Returned value**
 
@@ -891,15 +961,17 @@ Query:
 ``` sql
 SELECT
     toInt64OrNull('-64'),
-    toInt64OrNull('abc');
+    toInt64OrNull('abc')
+FORMAT vertical;
 ```
 
 Result:
 
 ```response
-   ┌─toInt64OrNull('-64')─┬─toInt64OrNull('abc')─┐
-1. │                  -64 │                 ᴺᵁᴸᴸ │
-   └──────────────────────┴──────────────────────┘
+Row 1:
+──────
+toInt64OrNull('-64'): -64
+toInt64OrNull('abc'): ᴺᵁᴸᴸ
 ```
 
 **See also**
@@ -910,7 +982,7 @@ Result:
 
 ## toInt64OrDefault
 
-Like [`toInt64`](#toint64), takes an argument of type [String](../data-types/string.md) and tries to parse it to type [`Int64`](../data-types/nullable.md). If unsuccessful, returns the default type value.
+Like [`toInt64`](#toint64), this function converts an input value to a value of type [Int64](../data-types/int-uint.md) but returns the default value in case of an error.
 
 **Syntax**
 
@@ -923,15 +995,19 @@ toInt64OrDefault(expr, def)
 - `expr` — Expression returning a number or a string representation of a number. [Expression](../syntax.md/#syntax-expressions) / [String](../data-types/string.md).
 - `def` — The default value to return if parsing to type `Int64` is unsuccessful. [Int64](../data-types/int-uint.md).
 
-Supported types:
-- (U)Int8/16/32/64/128/256
-- Float*
-- String representations of (U)Int8/16/32/128/256
+Supported arguments:
+- Values of type (U)Int8/16/32/64/128/256.
+- Values of type Float32/64.
+- String representations of (U)Int8/16/32/128/256.
 
-Types for which the default value is returned:
-- Float values `NaN` and `Inf` return the default value.
-- String representations of binary and hexadecimal values, e.g. `SELECT toInt64OrDefault('0xc0fe', CAST('-1', 'Int64'));`
-- If the input value cannot be represented within the bounds of [Int64](../data-types/int-uint.md) and the result over or under flows.
+Arguments for which the default value is returned:
+- String representations of Float32/64 values, including `NaN` and `Inf`.
+- String representations of binary and hexadecimal values, e.g. `SELECT toInt64OrDefault('0xc0fe', CAST('-1', 'Int64'));`.
+
+:::note
+If the input value cannot be represented within the bounds of [Int64](../data-types/int-uint.md), overflow or underflow of the result occurs.
+This is not considered an error.
+:::
 
 **Returned value**
 
@@ -949,15 +1025,17 @@ Query:
 ``` sql
 SELECT
     toInt64OrDefault('-64', CAST('-1', 'Int64')),
-    toInt64OrDefault('abc', CAST('-1', 'Int64'));
+    toInt64OrDefault('abc', CAST('-1', 'Int64'))
+FORMAT vertical;
 ```
 
 Result:
 
 ```response
-   ┌─toInt64OrDefault('-64', CAST('-1', 'Int64'))─┬─toInt64OrDefault('abc', CAST('-1', 'Int64'))─┐
-1. │                                          -64 │                                           -1 │
-   └──────────────────────────────────────────────┴──────────────────────────────────────────────┘
+Row 1:
+──────
+toInt64OrDefault('-64', CAST('-1', 'Int64')): -64
+toInt64OrDefault('abc', CAST('-1', 'Int64')): -1
 ```
 
 **See also**
@@ -980,17 +1058,18 @@ toInt128(expr)
 
 - `expr` — Expression returning a number or a string representation of a number. [Expression](../syntax.md/#syntax-expressions).
 
-Supported types:
-- (U)Int8/16/32/64/128/256
-- Float*
-- String representations of (U)Int8/16/32/128/256
+Supported arguments:
+- Values of type (U)Int8/16/32/64/128/256.
+- Values of type Float32/64.
+- String representations of (U)Int8/16/32/128/256.
 
-Unsupported types:
-- Float values `NaN` and `Inf` throw an exception.
-- String representations of binary and hexadecimal values, e.g. `SELECT toInt128('0xc0fe');`
+Unsupported arguments:
+- String representations of Float32/64 values, including `NaN` and `Inf`.
+- String representations of binary and hexadecimal values, e.g. `SELECT toInt128('0xc0fe');`.
 
 :::note
-If the input value cannot be represented within the bounds of [Int128](../data-types/int-uint.md), the result over or under flows. This is not considered an error.
+If the input value cannot be represented within the bounds of [Int128](../data-types/int-uint.md), the result over or under flows. 
+This is not considered an error.
 :::
 
 **Returned value**
@@ -1009,15 +1088,18 @@ Query:
 SELECT
     toInt128(-128),
     toInt128(-128.8),
-    toInt128('-128'),
+    toInt128('-128')
+FORMAT vertical;
 ```
 
 Result:
 
 ```response
-   ┌─toInt128(-128)─┬─toInt128(-128.8)─┬─toInt128('-128')─┐
-1. │           -128 │             -128 │             -128 │
-   └────────────────┴──────────────────┴──────────────────┘
+Row 1:
+──────
+toInt128(-128):   -128
+toInt128(-128.8): -128
+toInt128('-128'): -128
 ```
 
 **See also**
@@ -1040,14 +1122,17 @@ toInt128OrZero(expr)
 
 - `expr` — Expression returning a number or a string representation of a number. [Expression](../syntax.md/#syntax-expressions) / [String](../data-types/string.md).
 
-Supported types:
-- String representations of (U)Int8/16/32/128/256
+Supported arguments:
+- String representations of (U)Int8/16/32/128/256.
 
-Types for which `0` is returned:
-- String representations of ordinary Float32/64 values.
-- String representations of Float values `NaN` and `Inf`.
+Unsupported arguments (return `0`):
+- String representations of Float32/64 values, including `NaN` and `Inf`.
 - String representations of binary and hexadecimal values, e.g. `SELECT toInt128OrZero('0xc0fe');`.
-- If the input value cannot be represented within the bounds of [Int128](../data-types/int-uint.md) and the result over or under flows.
+
+:::note
+If the input value cannot be represented within the bounds of [Int128](../data-types/int-uint.md), overflow or underflow of the result occurs.
+This is not considered an error.
+:::
 
 **Returned value**
 
@@ -1064,15 +1149,17 @@ Query:
 ``` sql
 SELECT
     toInt128OrZero('-128'),
-    toInt128OrZero('abc');
+    toInt128OrZero('abc')
+FORMAT vertical;
 ```
 
 Result:
 
 ```response
-   ┌─toInt128OrZero('-128')─┬─toInt128OrZero('abc')─┐
-1. │                   -128 │                     0 │
-   └────────────────────────┴───────────────────────┘
+Row 1:
+──────
+toInt128OrZero('-128'): -128
+toInt128OrZero('abc'):  0
 ```
 
 **See also**
@@ -1083,7 +1170,7 @@ Result:
 
 ## toInt128OrNull
 
-Like [`toInt128`](#toint128), takes an argument of type [String](../data-types/string.md) and tries to parse it to type [`Int128`](../data-types/int-uint.md). If unsuccessful, returns [`NULL`](../data-types/nullable.md).
+Like [`toInt128`](#toint128), this function converts an input value to a value of type [Int128](../data-types/int-uint.md) but returns `NULL` in case of an error.
 
 **Syntax**
 
@@ -1095,14 +1182,17 @@ toInt128OrNull(x)
 
 - `x` — A String representation of a number. [Expression](../syntax.md/#syntax-expressions) / [String](../data-types/string.md).
 
-Supported types:
-- String representations of (U)Int8/16/32/128/256
+Supported arguments:
+- String representations of (U)Int8/16/32/128/256.
 
-Types for which `\N` is returned:
-- String representations of ordinary Float32/64 values.
-- String representations of Float values `NaN` and `Inf`.
+Unsupported arguments (return `\N`)
+- String representations of Float32/64 values, including `NaN` and `Inf`.
 - String representations of binary and hexadecimal values, e.g. `SELECT toInt128OrNull('0xc0fe');`.
-- If the input value cannot be represented within the bounds of [Int128](../data-types/int-uint.md) and the result over or under flows.
+
+:::note
+If the input value cannot be represented within the bounds of [Int128](../data-types/int-uint.md), overflow or underflow of the result occurs. 
+This is not considered an error.
+:::
 
 **Returned value**
 
@@ -1119,15 +1209,17 @@ Query:
 ``` sql
 SELECT
     toInt128OrNull('-128'),
-    toInt128OrNull('abc');
+    toInt128OrNull('abc')
+FORMAT vertical;
 ```
 
 Result:
 
 ```response
-   ┌─toInt128OrNull('-128')─┬─toInt128OrNull('abc')─┐
-1. │                   -128 │                  ᴺᵁᴸᴸ │
-   └────────────────────────┴───────────────────────┘
+Row 1:
+──────
+toInt128OrNull('-128'): -128
+toInt128OrNull('abc'):  ᴺᵁᴸᴸ
 ```
 
 **See also**
@@ -1138,7 +1230,7 @@ Result:
 
 ## toInt128OrDefault
 
-Like [`toInt128`](#toint128), takes an argument of type [String](../data-types/string.md) and tries to parse it to type [`Int128`](../data-types/int-uint.md). If unsuccessful, returns the default type value.
+Like [`toInt128`](#toint128), this function converts an input value to a value of type [Int128](../data-types/int-uint.md) but returns the default value in case of an error.
 
 **Syntax**
 
@@ -1151,15 +1243,19 @@ toInt128OrDefault(expr, def)
 - `expr` — Expression returning a number or a string representation of a number. [Expression](../syntax.md/#syntax-expressions) / [String](../data-types/string.md).
 - `def` — The default value to return if parsing to type `Int128` is unsuccessful. [Int128](../data-types/int-uint.md).
 
-Supported types:
-- (U)Int8/16/32/64/128/256
-- Float*
-- String representations of (U)Int8/16/32/128/256
+Supported arguments:
+- (U)Int8/16/32/64/128/256.
+- Float32/64.
+- String representations of (U)Int8/16/32/128/256.
 
-Types for which the default value is returned:
-- Float values `NaN` and `Inf` return the default value.
-- String representations of binary and hexadecimal values, e.g. `SELECT toInt128OrDefault('0xc0fe', CAST('-1', 'Int128'));`
-- If the input value cannot be represented within the bounds of [Int128](../data-types/int-uint.md) and the result over or under flows.
+Arguments for which the default value is returned:
+- String representations of Float32/64 values, including `NaN` and `Inf`.
+- String representations of binary and hexadecimal values, e.g. `SELECT toInt128OrDefault('0xc0fe', CAST('-1', 'Int128'));`.
+
+:::note
+If the input value cannot be represented within the bounds of [Int128](../data-types/int-uint.md), overflow or underflow of the result occurs. 
+This is not considered an error.
+:::
 
 **Returned value**
 
@@ -1177,15 +1273,17 @@ Query:
 ``` sql
 SELECT
     toInt128OrDefault('-128', CAST('-1', 'Int128')),
-    toInt128OrDefault('abc', CAST('-1', 'Int128'));
+    toInt128OrDefault('abc', CAST('-1', 'Int128'))
+FORMAT vertical;
 ```
 
 Result:
 
 ```response
-   ┌─toInt128OrDefault('-128', CAST('-1', 'Int128'))─┬─toInt128OrDefault('abc', CAST('-1', 'Int128'))─┐
-1. │                                            -128 │                                             -1 │
-   └─────────────────────────────────────────────────┴────────────────────────────────────────────────┘
+Row 1:
+──────
+toInt128OrDefault('-128', CAST('-1', 'Int128')): -128
+toInt128OrDefault('abc', CAST('-1', 'Int128')):  -1
 ```
 
 **See also**
@@ -1208,17 +1306,18 @@ toInt256(expr)
 
 - `expr` — Expression returning a number or a string representation of a number. [Expression](../syntax.md/#syntax-expressions).
 
-Supported types:
-- (U)Int8/16/32/64/128/256
-- Float*
-- String representations of (U)Int8/16/32/128/256
+Supported arguments:
+- Values of type (U)Int8/16/32/64/128/256.
+- Values of type Float32/64.
+- String representations of (U)Int8/16/32/128/256.
 
-Unsupported types:
-- Float values `NaN` and `Inf` throw an exception.
-- String representations of binary and hexadecimal values, e.g. `SELECT toInt256('0xc0fe');`
+Unsupported arguments:
+- String representations of Float32/64 values, including `NaN` and `Inf`.
+- String representations of binary and hexadecimal values, e.g. `SELECT toInt256('0xc0fe');`.
 
 :::note
-If the input value cannot be represented within the bounds of [Int256](../data-types/int-uint.md), the result over or under flows. This is not considered an error.
+If the input value cannot be represented within the bounds of [Int256](../data-types/int-uint.md), the result over or under flows. 
+This is not considered an error.
 :::
 
 **Returned value**
@@ -1237,15 +1336,18 @@ Query:
 SELECT
     toInt256(-256),
     toInt256(-256.256),
-    toInt256('-256');
+    toInt256('-256')
+FORMAT vertical;
 ```
 
 Result:
 
 ```response
-   ┌─toInt256(-256)─┬─toInt256(-256.256)─┬─toInt256('-256')─┐
-1. │           -256 │               -256 │             -256 │
-   └────────────────┴────────────────────┴──────────────────┘
+Row 1:
+──────
+toInt256(-256):     -256
+toInt256(-256.256): -256
+toInt256('-256'):   -256
 ```
 
 **See also**
@@ -1268,14 +1370,17 @@ toInt256OrZero(x)
 
 - `x` — A String representation of a number. [String](../data-types/string.md).
 
-Supported types:
-- String representations of (U)Int8/16/32/128/256
+Supported arguments:
+- String representations of (U)Int8/16/32/128/256.
 
-Types for which `0` is returned:
-- String representations of ordinary Float32/64 values.
-- String representations of Float values `NaN` and `Inf`.
+Unsupported arguments (return `0`):
+- String representations of Float32/64 values, including `NaN` and `Inf`.
 - String representations of binary and hexadecimal values, e.g. `SELECT toInt256OrZero('0xc0fe');`.
-- If the input value cannot be represented within the bounds of [Int256](../data-types/int-uint.md) and the result over or under flows.
+
+:::note
+If the input value cannot be represented within the bounds of [Int256](../data-types/int-uint.md), overflow or underflow of the result occurs. 
+This is not considered an error.
+:::
 
 **Returned value**
 
@@ -1292,15 +1397,17 @@ Query:
 ``` sql
 SELECT
     toInt256OrZero('-256'),
-    toInt256OrZero('abc');
+    toInt256OrZero('abc')
+FORMAT vertical;
 ```
 
 Result:
 
 ```response
-   ┌─toInt256OrZero('-256')─┬─toInt256OrZero('abc')─┐
-1. │                   -256 │                     0 │
-   └────────────────────────┴───────────────────────┘
+Row 1:
+──────
+toInt256OrZero('-256'): -256
+toInt256OrZero('abc'):  0
 ```
 
 **See also**
@@ -1311,7 +1418,7 @@ Result:
 
 ## toInt256OrNull
 
-Like [`toInt256`](#toint256), takes an argument of type [String](../data-types/string.md) and tries to parse it to type [`Int256`](../data-types/int-uint.md). If unsuccessful, returns [`NULL`](../data-types/nullable.md).
+Like [`toInt256`](#toint256), this function converts an input value to a value of type [Int256](../data-types/int-uint.md) but returns `NULL` in case of an error.
 
 **Syntax**
 
@@ -1323,14 +1430,17 @@ toInt256OrNull(x)
 
 - `x` — A String representation of a number. [String](../data-types/string.md).
 
-Supported types:
-- String representations of (U)Int8/16/32/128/256
+Supported arguments:
+- String representations of (U)Int8/16/32/128/256.
 
-Types for which `\N` is returned:
-- String representations of ordinary Float32/64 values.
-- String representations of Float values `NaN` and `Inf`.
+Unsupported arguments (return `\N`)
+- String representations of Float32/64 values, including `NaN` and `Inf`.
 - String representations of binary and hexadecimal values, e.g. `SELECT toInt256OrNull('0xc0fe');`.
-- If the input value cannot be represented within the bounds of [Int256](../data-types/int-uint.md) and the result over or under flows.
+
+:::note
+If the input value cannot be represented within the bounds of [Int256](../data-types/int-uint.md), overflow or underflow of the result occurs. 
+This is not considered an error.
+:::
 
 **Returned value**
 
@@ -1347,15 +1457,17 @@ Query:
 ``` sql
 SELECT
     toInt256OrNull('-256'),
-    toInt256OrNull('abc');
+    toInt256OrNull('abc')
+FORMAT vertical;
 ```
 
 Result:
 
 ```response
-   ┌─toInt256OrNull('-256')─┬─toInt256OrNull('abc')─┐
-1. │                   -256 │                  ᴺᵁᴸᴸ  │
-   └────────────────────────┴───────────────────────┘
+Row 1:
+──────
+toInt256OrNull('-256'): -256
+toInt256OrNull('abc'):  ᴺᵁᴸᴸ
 ```
 
 **See also**
@@ -1366,7 +1478,7 @@ Result:
 
 ## toInt256OrDefault
 
-Like [`toInt256`](#toint256), takes an argument of type [String](../data-types/string.md) and tries to parse it to type [`Int256`](../data-types/int-uint.md). If unsuccessful, returns the default type value.
+Like [`toInt256`](#toint256), this function converts an input value to a value of type [Int256](../data-types/int-uint.md) but returns the default value in case of an error.
 
 **Syntax**
 
@@ -1379,15 +1491,19 @@ toInt256OrDefault(expr, def)
 - `expr` — Expression returning a number or a string representation of a number. [Expression](../syntax.md/#syntax-expressions) / [String](../data-types/string.md).
 - `def` — The default value to return if parsing to type `Int256` is unsuccessful. [Int256](../data-types/int-uint.md).
 
-Supported types:
-- (U)Int8/16/32/64/128/256
-- Float*
-- String representations of (U)Int8/16/32/128/256
+Supported arguments:
+- Values of type (U)Int8/16/32/64/128/256.
+- Values of type Float32/64.
+- String representations of (U)Int8/16/32/128/256.
 
-Types for which the default value is returned:
-- Float values `NaN` and `Inf` return the default value.
+Arguments for which the default value is returned:
+- String representations of Float32/64 values, including `NaN` and `Inf`
 - String representations of binary and hexadecimal values, e.g. `SELECT toInt256OrDefault('0xc0fe', CAST('-1', 'Int256'));`
-- If the input value cannot be represented within the bounds of [Int256](../data-types/int-uint.md) and the result over or under flows.
+
+:::note
+If the input value cannot be represented within the bounds of [Int256](../data-types/int-uint.md), overflow or underflow of the result occurs.
+This is not considered an error.
+:::
 
 **Returned value**
 
@@ -1405,15 +1521,17 @@ Query:
 ``` sql
 SELECT
     toInt256OrDefault('-256', CAST('-1', 'Int256')),
-    toInt256OrDefault('abc', CAST('-1', 'Int256'));
+    toInt256OrDefault('abc', CAST('-1', 'Int256'))
+FORMAT vertical;
 ```
 
 Result:
 
 ```response
-   ┌─toInt256OrDefault('-256', CAST('-1', 'Int256'))─┬─toInt256OrDefault('abc', CAST('-1', 'Int256'))─┐
-1. │                                            -256 │                                             -1 │
-   └─────────────────────────────────────────────────┴────────────────────────────────────────────────┘
+Row 1:
+──────
+toInt256OrDefault('-256', CAST('-1', 'Int256')): -256
+toInt256OrDefault('abc', CAST('-1', 'Int256')):  -1
 ```
 
 **See also**

--- a/docs/en/sql-reference/functions/type-conversion-functions.md
+++ b/docs/en/sql-reference/functions/type-conversion-functions.md
@@ -496,7 +496,7 @@ toInt16OrDefault(expr, def)
 **Arguments**
 
 - `expr` — Expression returning a number or a string representation of a number. [Expression](../syntax.md/#syntax-expressions) / [String](../data-types/string.md).
-- `def` — The default value to return if parsing to type `Int16` is unsuccessful. [Int8](../data-types/int-uint.md).
+- `def` — The default value to return if parsing to type `Int16` is unsuccessful. [Int16](../data-types/int-uint.md).
 
 Supported arguments:
 - Values of type (U)Int8/16/32/64/128/256.

--- a/docs/en/sql-reference/functions/type-conversion-functions.md
+++ b/docs/en/sql-reference/functions/type-conversion-functions.md
@@ -236,7 +236,7 @@ toInt8OrNull('abc'): ᴺᵁᴸᴸ
 
 ## toInt8OrDefault
 
-Like [`toInt8`](#toint8), takes an argument of type [String](../data-types/string.md) and tries to parse it to type [`Int8`](../data-types/int-uint.md). If unsuccessful, returns the default type value.
+Like [`toInt8`](#toint8), this function converts an input value to a value of type [Int8](../data-types/int-uint.md) but returns the default value in case of an error.
 
 **Syntax**
 

--- a/docs/en/sql-reference/functions/type-conversion-functions.md
+++ b/docs/en/sql-reference/functions/type-conversion-functions.md
@@ -51,7 +51,7 @@ SETTINGS cast_keep_nullable = 1
 
 ## toInt8
 
-Converts an input value to a value of type `Int8`.
+Converts an input value to a value of type [`Int8`](../data-types/int-uint.md). Throws an exception in case of an error.
 
 **Syntax**
 
@@ -61,10 +61,20 @@ toInt8(expr)
 
 **Arguments**
 
-- `expr` — Expression returning a number or a string with the decimal representation of a number. [Expression](../syntax.md/#syntax-expressions).
+- `expr` — Expression returning a number or a string representation of a number. [Expression](../syntax.md/#syntax-expressions).
+
+Supported types:
+- (U)Int8/16/32/64/128/256
+- Float*
+- String representations of (U)Int8/16/32/128/256
+
+Unsupported types:
+- Float values `NaN` and `Inf` throw an exception.
+- String representations of binary and hexadecimal values, e.g. `SELECT toInt8('0xc0fe');`
 
 :::note
-Binary, octal, and hexadecimal representations of numbers are not supported. Leading zeroes are stripped.
+If the input value cannot be represented within the bounds of [Int8](../data-types/int-uint.md), the result over or under flows. This is not considered an error.  
+For example: `SELECT toInt8(128) == -128;`, `SELECT toInt8(128.0) == -128;`,  `SELECT toInt8('128') == -128;`.
 :::
 
 **Returned value**
@@ -72,11 +82,7 @@ Binary, octal, and hexadecimal representations of numbers are not supported. Lea
 - 8-bit integer value. [Int8](../data-types/int-uint.md).
 
 :::note
-Function uses [rounding towards zero](https://en.wikipedia.org/wiki/Rounding#Rounding_towards_zero), meaning it truncates fractional digits of numbers.
-:::
-
-:::danger
-An exception is thrown for [NaN and Inf](../data-types/float.md/#data_type-float-nan-inf) arguments. Keep in mind [numeric conversions issues](#common-issues-with-data-conversion), when using this function.
+The function uses [rounding towards zero](https://en.wikipedia.org/wiki/Rounding#Rounding_towards_zero), meaning it truncates fractional digits of numbers.
 :::
 
 **Example**
@@ -106,32 +112,33 @@ Result:
 
 ## toInt8OrZero
 
-Like [`toInt8`](#toint8), it takes an argument of type [String](../data-types/string.md) and tries to parse it to type `Int8`. If unsuccessful, returns `0`.
+Like [`toInt8`](#toint8), this function converts an input value to a value of type [Int8](../data-types/int-uint.md) but returns `0` in case of an error.
 
 **Syntax**
 
 ```sql
-toInt8OrZero(expr)
+toInt8OrZero(x)
 ```
 
 **Arguments**
 
-- `expr` — Expression returning a number or a string with the decimal representation of a number. [Expression](../syntax.md/#syntax-expressions) / [String](../data-types/string.md).
+- `x` — A String representation of a number. [String](../data-types/string.md).
 
-:::note
-Binary, octal, and hexadecimal representations of numbers are not supported. Leading zeroes are stripped.
-:::
+Supported types:
+- String representations of (U)Int8/16/32/128/256
+
+Types for which `0` is returned:
+- String representations of ordinary Float32/64 values.
+- String representations of Float values `NaN` and `Inf`.
+- String representations of binary and hexadecimal values, e.g. `SELECT toInt8OrZero('0xc0fe');`.
+- If the input value cannot be represented within the bounds of [toInt16](../data-types/int-uint.md), and the result over or under flows.
 
 **Returned value**
 
 - 8-bit integer value if successful, otherwise `0`. [Int8](../data-types/int-uint.md).
 
 :::note
-Function uses [rounding towards zero](https://en.wikipedia.org/wiki/Rounding#Rounding_towards_zero), meaning it truncates fractional digits of numbers. 
-:::
-
-:::danger
-An exception is thrown for [NaN and Inf](../data-types/float.md/#data_type-float-nan-inf) arguments. Keep in mind [numeric conversions issues](#common-issues-with-data-conversion), when using this function.
+The function uses [rounding towards zero](https://en.wikipedia.org/wiki/Rounding#Rounding_towards_zero), meaning it truncates fractional digits of numbers. 
 :::
 
 **Example**
@@ -160,32 +167,33 @@ Result:
 
 ## toInt8OrNull
 
-Like [`toInt8`](#toint8), takes an argument of type [String](../data-types/string.md) and tries to parse it to type `Int8`. If unsuccessful, returns `NULL`.
+Like [`toInt8`](#toint8), takes an argument of type [String](../data-types/string.md) and tries to parse it to type [`Int8`](../data-types/int-uint.md). If unsuccessful, returns [`NULL`](../data-types/nullable.md).
 
 **Syntax**
 
 ```sql
-toInt8OrNull(expr)
+toInt8OrNull(x)
 ```
 
 **Arguments**
 
-- `expr` — Expression returning a number or a string with the decimal representation of a number. [Expression](../syntax.md/#syntax-expressions) / [String](../data-types/string.md).
+- `x` — A String representation of a number. [String](../data-types/string.md).
 
-:::note
-Binary, octal, and hexadecimal representations of numbers are not supported. Leading zeroes are stripped.
-:::
+Supported types:
+- String representations of (U)Int8/16/32/128/256
+
+Types for which `\N` is returned:
+- String representations of ordinary Float32/64 values.
+- String representations of Float values `NaN` and `Inf`.
+- String representations of binary and hexadecimal values, e.g. `SELECT toInt8OrNull('0xc0fe');`.
+- If the input value cannot be represented within the bounds of [Int16](../data-types/int-uint.md), and the result over or under flows.
 
 **Returned value**
 
 - 8-bit integer value if successful, otherwise `NULL`. [Int8](../data-types/int-uint.md) / [NULL](../data-types/nullable.md).
 
 :::note
-Function uses [rounding towards zero](https://en.wikipedia.org/wiki/Rounding#Rounding_towards_zero), meaning it truncates fractional digits of numbers.
-:::
-
-:::danger
-An exception is thrown for [NaN and Inf](../data-types/float.md/#data_type-float-nan-inf) arguments. Keep in mind [numeric conversions issues](#common-issues-with-data-conversion), when using this function.
+The function uses [rounding towards zero](https://en.wikipedia.org/wiki/Rounding#Rounding_towards_zero), meaning it truncates fractional digits of numbers.
 :::
 
 **Example**
@@ -212,7 +220,7 @@ Result:
 
 ## toInt8OrDefault
 
-Like [`toInt8`](#toint8), takes an argument of type [String](../data-types/string.md) and tries to parse it to type `Int8`. If unsuccessful, returns the default type value.
+Like [`toInt8`](#toint8), takes an argument of type [String](../data-types/string.md) and tries to parse it to type [`Int8`](../data-types/int-uint.md). If unsuccessful, returns the default type value.
 
 **Syntax**
 
@@ -222,24 +230,26 @@ toInt8OrDefault(expr, def)
 
 **Arguments**
 
-- `expr` — Expression returning a number or a string with the decimal representation of a number. [Expression](../syntax.md/#syntax-expressions) / [String](../data-types/string.md).
+- `expr` — Expression returning a number or a string representation of a number. [Expression](../syntax.md/#syntax-expressions) / [String](../data-types/string.md).
 - `def` — The default value to return if parsing to type `Int8` is unsuccessful. [Int8](../data-types/int-uint.md).
 
-:::note
-Binary, octal, and hexadecimal representations of numbers are not supported. Leading zeroes are stripped.
-:::
+Supported types:
+- (U)Int8/16/32/64/128/256
+- Float*
+- String representations of (U)Int8/16/32/128/256
+
+Types for which the default value is returned:
+- Float values `NaN` and `Inf` return the default value.
+- String representations of binary and hexadecimal values, e.g. `SELECT toInt8OrDefault('0xc0fe', CAST('-1', 'Int8'));`
+- If the input value cannot be represented within the bounds of [Int8](../data-types/int-uint.md) and the result over or under flows.
 
 **Returned value**
 
 - 8-bit integer value if successful, otherwise returns the default value. [Int8](../data-types/int-uint.md).
 
 :::note
-- Function uses [rounding towards zero](https://en.wikipedia.org/wiki/Rounding#Rounding_towards_zero), meaning it truncates fractional digits of numbers.
+- The function uses [rounding towards zero](https://en.wikipedia.org/wiki/Rounding#Rounding_towards_zero), meaning it truncates fractional digits of numbers.
 - The default value type should be the same as the cast type.
-:::
-
-:::danger
-An exception is thrown for [NaN and Inf](../data-types/float.md/#data_type-float-nan-inf) arguments. Keep in mind [numeric conversions issues](#common-issues-with-data-conversion), when using this function.
 :::
 
 **Example**
@@ -268,7 +278,7 @@ Result:
 
 ## toInt16
 
-Converts an input value to a value of type `Int16`.
+Converts an input value to a value of type [`Int16`](../data-types/int-uint.md). Throws an exception in case of an error.
 
 **Syntax**
 
@@ -278,10 +288,20 @@ toInt16(expr)
 
 **Arguments**
 
-- `expr` — Expression returning a number or a string with the decimal representation of a number. [Expression](../syntax.md/#syntax-expressions).
+- `expr` — Expression returning a number or a string representation of a number. [Expression](../syntax.md/#syntax-expressions).
+
+Supported types:
+- (U)Int8/16/32/64/128/256
+- Float*
+- String representations of (U)Int8/16/32/128/256
+
+Unsupported types:
+- Float values `NaN` and `Inf` throw an exception.
+- String representations of binary and hexadecimal values, e.g. `SELECT toInt16('0xc0fe');`
 
 :::note
-Binary, octal, and hexadecimal representations of numbers are not supported. Leading zeroes are stripped.
+If the input value cannot be represented within the bounds of [toInt16](../data-types/int-uint.md), the result over or under flows. This is not considered an error.  
+For example: `SELECT toInt16(32768) == -32768;`, `SELECT toInt16(32768) == -32768;`,  `SELECT toInt16('32768') == -32768;`.
 :::
 
 **Returned value**
@@ -289,11 +309,7 @@ Binary, octal, and hexadecimal representations of numbers are not supported. Lea
 - 16-bit integer value. [Int16](../data-types/int-uint.md).
 
 :::note
-Function uses [rounding towards zero](https://en.wikipedia.org/wiki/Rounding#Rounding_towards_zero), meaning it truncates fractional digits of numbers.
-:::
-
-:::danger
-An exception is thrown for [NaN and Inf](../data-types/float.md/#data_type-float-nan-inf) arguments. Keep in mind [numeric conversions issues](#common-issues-with-data-conversion), when using this function.
+The function uses [rounding towards zero](https://en.wikipedia.org/wiki/Rounding#Rounding_towards_zero), meaning it truncates fractional digits of numbers.
 :::
 
 **Example**
@@ -323,32 +339,33 @@ Result:
 
 ## toInt16OrZero
 
-Like [`toInt16`](#toint16), takes an argument of type [String](../data-types/string.md) and tries to parse it to type `Int16`. If unsuccessful, returns `0`.
+Like [`toInt16`](#toint16), this function converts an input value to a value of type [Int16](../data-types/int-uint.md) but returns `0` in case of an error.
 
 **Syntax**
 
 ```sql
-toInt16OrZero(expr)
+toInt16OrZero(x)
 ```
 
 **Arguments**
 
-- `expr` — Expression returning a number or a string with the decimal representation of a number. [Expression](../syntax.md/#syntax-expressions) / [String](../data-types/string.md).
+- `x` — A String representation of a number. [String](../data-types/string.md).
 
-:::note
-Binary, octal, and hexadecimal representations of numbers are not supported. Leading zeroes are stripped.
-:::
+Supported types:
+- String representations of (U)Int8/16/32/128/256
+
+Types for which `0` is returned:
+- String representations of ordinary Float32/64 values.
+- String representations of Float values `NaN` and `Inf`.
+- String representations of binary and hexadecimal values, e.g. `SELECT toInt16OrZero('0xc0fe');`.
+- If the input value cannot be represented within the bounds of [Int16](../data-types/int-uint.md) and the result over or under flows.
 
 **Returned value**
 
 - 16-bit integer value if successful, otherwise `0`. [Int16](../data-types/int-uint.md).
 
 :::note
-Function uses [rounding towards zero](https://en.wikipedia.org/wiki/Rounding#Rounding_towards_zero), meaning it truncates fractional digits of numbers.
-:::
-
-:::danger
-An exception is thrown for [NaN and Inf](../data-types/float.md/#data_type-float-nan-inf) arguments. Keep in mind [numeric conversions issues](#common-issues-with-data-conversion), when using this function.
+The function uses [rounding towards zero](https://en.wikipedia.org/wiki/Rounding#Rounding_towards_zero), meaning it truncates fractional digits of numbers.
 :::
 
 **Example**
@@ -377,32 +394,33 @@ Result:
 
 ## toInt16OrNull
 
-Like [`toInt16`](#toint16), takes an argument of type [String](../data-types/string.md) and tries to parse it to type `Int16`. If unsuccessful, returns `NULL`.
+Like [`toInt16`](#toint16), takes an argument of type [String](../data-types/string.md) and tries to parse it to type [`Int16`](../data-types/int-uint.md). If unsuccessful, returns [`NULL`](../data-types/nullable.md).
 
 **Syntax**
 
 ```sql
-toInt16OrNull(expr)
+toInt16OrNull(x)
 ```
 
 **Arguments**
 
-- `expr` — Expression returning a number or a string with the decimal representation of a number. [Expression](../syntax.md/#syntax-expressions) / [String](../data-types/string.md).
+- `x` — A String representation of a number. [String](../data-types/string.md).
 
-:::note
-Binary, octal, and hexadecimal representations of numbers are not supported. Leading zeroes are stripped.
-:::
+Supported types:
+- String representations of (U)Int8/16/32/128/256
+
+Types for which `\N` is returned:
+- String representations of ordinary Float32/64 values.
+- String representations of Float values `NaN` and `Inf`.
+- String representations of binary and hexadecimal values, e.g. `SELECT toInt16OrNull('0xc0fe');`.
+- If the input value cannot be represented within the bounds of [Int16](../data-types/int-uint.md) and the result over or under flows.
 
 **Returned value**
 
 - 16-bit integer value if successful, otherwise `NULL`. [Int16](../data-types/int-uint.md) / [NULL](../data-types/nullable.md).
 
 :::note
-Function uses [rounding towards zero](https://en.wikipedia.org/wiki/Rounding#Rounding_towards_zero), meaning it truncates fractional digits of numbers.
-:::
-
-:::danger
-An exception is thrown for [NaN and Inf](../data-types/float.md/#data_type-float-nan-inf) arguments. Keep in mind [numeric conversions issues](#common-issues-with-data-conversion), when using this function.
+The function uses [rounding towards zero](https://en.wikipedia.org/wiki/Rounding#Rounding_towards_zero), meaning it truncates fractional digits of numbers.
 :::
 
 **Example**
@@ -431,7 +449,7 @@ Result:
 
 ## toInt16OrDefault
 
-Like [`toInt16`](#toint16), takes an argument of type [String](../data-types/string.md) and tries to parse it to type `Int16`. If unsuccessful, returns the default type value.
+Like [`toInt16`](#toint16), takes an argument of type [String](../data-types/string.md) and tries to parse it to type [`Int16`](../data-types/int-uint.md). If unsuccessful, returns the default type value.
 
 **Syntax**
 
@@ -441,24 +459,26 @@ toInt16OrDefault(expr, def)
 
 **Arguments**
 
-- `expr` — Expression returning a number or a string with the decimal representation of a number. [Expression](../syntax.md/#syntax-expressions) / [String](../data-types/string.md).
+- `expr` — Expression returning a number or a string representation of a number. [Expression](../syntax.md/#syntax-expressions) / [String](../data-types/string.md).
 - `def` — The default value to return if parsing to type `Int16` is unsuccessful. [Int8](../data-types/int-uint.md).
 
-:::note
-Binary, octal, and hexadecimal representations of numbers are not supported. Leading zeroes are stripped.
-:::
+Supported types:
+- (U)Int8/16/32/64/128/256
+- Float*
+- String representations of (U)Int8/16/32/128/256
+
+Types for which the default value is returned:
+- Float values `NaN` and `Inf` return the default value.
+- String representations of binary and hexadecimal values, e.g. `SELECT toInt16OrDefault('0xc0fe', CAST('-1', 'Int16'));`
+- If the input value cannot be represented within the bounds of [Int16](../data-types/int-uint.md) and the result over or under flows.
 
 **Returned value**
 
 - 16-bit integer value if successful, otherwise returns the default value. [Int16](../data-types/int-uint.md).
 
 :::note
-- Function uses [rounding towards zero](https://en.wikipedia.org/wiki/Rounding#Rounding_towards_zero), meaning it truncates fractional digits of numbers.
+- The function uses [rounding towards zero](https://en.wikipedia.org/wiki/Rounding#Rounding_towards_zero), meaning it truncates fractional digits of numbers.
 - The default value type should be the same as the cast type.
-:::
-
-:::danger
-An exception is thrown for [NaN and Inf](../data-types/float.md/#data_type-float-nan-inf) arguments. Keep in mind [numeric conversions issues](#common-issues-with-data-conversion), when using this function.
 :::
 
 **Example**
@@ -485,7 +505,7 @@ Result:
 
 ## toInt32
 
-Converts an input value to a value of type `Int32`.
+Converts an input value to a value of type [`Int32`](../data-types/int-uint.md). Throws an exception in case of an error.
 
 **Syntax**
 
@@ -495,10 +515,25 @@ toInt32(expr)
 
 **Arguments**
 
-- `expr` — Expression returning a number or a string with the decimal representation of a number. [Expression](../syntax.md/#syntax-expressions).
+- `expr` — Expression returning a number or a string representation of a number. [Expression](../syntax.md/#syntax-expressions).
+
+Supported types:
+- (U)Int8/16/32/64/128/256
+- Float*
+- String representations of (U)Int8/16/32/128/256
+
+Unsupported types:
+- Float values `NaN` and `Inf` throw an exception.
+- String representations of binary and hexadecimal values, e.g. `SELECT toInt32('0xc0fe');`
 
 :::note
-Binary, octal, and hexadecimal representations of numbers are not supported. Leading zeroes are stripped.
+If the input value cannot be represented within the bounds of [toInt16](../data-types/int-uint.md), the result over or under flows. This is not considered an error.  
+For example: 
+```
+SELECT toInt32(2147483648) == -2147483648;
+SELECT toInt32(2147483648.0) == -2147483648;
+SELECT toInt32('2147483648') == -2147483648;
+```
 :::
 
 **Returned value**
@@ -506,11 +541,7 @@ Binary, octal, and hexadecimal representations of numbers are not supported. Lea
 - 32-bit integer value. [Int32](../data-types/int-uint.md).
 
 :::note
-Function uses [rounding towards zero](https://en.wikipedia.org/wiki/Rounding#Rounding_towards_zero), meaning it truncates fractional digits of numbers.
-:::
-
-:::danger
-An exception is thrown for [NaN and Inf](../data-types/float.md/#data_type-float-nan-inf) arguments. Keep in mind [numeric conversions issues](#common-issues-with-data-conversion), when using this function.
+The function uses [rounding towards zero](https://en.wikipedia.org/wiki/Rounding#Rounding_towards_zero), meaning it truncates fractional digits of numbers.
 :::
 
 **Example**
@@ -540,32 +571,34 @@ Result:
 
 ## toInt32OrZero
 
-Like [`toInt32`](#toint32), takes an argument of type [String](../data-types/string.md) and tries to parse it to type `Int32`. If unsuccessful, returns `0`.
+Like [`toInt32`](#toint32), this function converts an input value to a value of type [Int8](../data-types/int-uint.md) but returns `0` in case of an error.
 
 **Syntax**
 
 ```sql
-toInt32OrZero(expr)
+toInt32OrZero(x)
 ```
 
 **Arguments**
 
-- `expr` — Expression returning a number or a string with the decimal representation of a number. [Expression](../syntax.md/#syntax-expressions) / [String](../data-types/string.md).
+- `x` — A String representation of a number. [String](../data-types/string.md).
 
-:::note
-Binary, octal, and hexadecimal representations of numbers are not supported. Leading zeroes are stripped.
-:::
+Supported types:
+- String representations of (U)Int8/16/32/128/256
+
+Types for which `0` is returned:
+- String representations of ordinary Float32/64 values.
+- String representations of Float values `NaN` and `Inf`.
+- String representations of binary and hexadecimal values, e.g. `SELECT toInt32OrZero('0xc0fe');`.
+- If the input value cannot be represented within the bounds of [Int32](../data-types/int-uint.md) and the result over or under flows.
+
 
 **Returned value**
 
 - 32-bit integer value if successful, otherwise `0`. [Int32](../data-types/int-uint.md)
 
 :::note
-Function uses [rounding towards zero](https://en.wikipedia.org/wiki/Rounding#Rounding_towards_zero), meaning it truncate fractional digits of numbers.
-:::
-
-:::danger
-An exception is thrown for [NaN and Inf](../data-types/float.md/#data_type-float-nan-inf) arguments. Keep in mind [numeric conversions issues](#common-issues-with-data-conversion), when using this function.
+The function uses [rounding towards zero](https://en.wikipedia.org/wiki/Rounding#Rounding_towards_zero), meaning it truncate fractional digits of numbers.
 :::
 
 **Example**
@@ -588,35 +621,36 @@ Result:
 - [`toInt32`](#toint32).
 - [`toInt32OrNull`](#toint32ornull).
 - [`toInt32OrDefault`](#toint32ordefault).
-- 
+
 ## toInt32OrNull
 
-Like [`toInt32`](#toint32), takes an argument of type [String](../data-types/string.md) and tries to parse it to type `Int32`. If unsuccessful, returns `NULL`.
+Like [`toInt32`](#toint32), takes an argument of type [String](../data-types/string.md) and tries to parse it to type [`Int32`](../data-types/int-uint.md). If unsuccessful, returns [`NULL`](../data-types/nullable.md).
 
 **Syntax**
 
 ```sql
-toInt32OrNull(expr)
+toInt32OrNull(x)
 ```
 
 **Arguments**
 
-- `expr` — Expression returning a number or a string with the decimal representation of a number. [Expression](../syntax.md/#syntax-expressions) / [String](../data-types/string.md).
+- `x` — A String representation of a number. [String](../data-types/string.md).
 
-:::note
-Binary, octal, and hexadecimal representations of numbers are not supported. Leading zeroes are stripped.
-:::
+Supported types:
+- String representations of (U)Int8/16/32/128/256
+
+Types for which `\N` is returned:
+- String representations of ordinary Float32/64 values.
+- String representations of Float values `NaN` and `Inf`.
+- String representations of binary and hexadecimal values, e.g. `SELECT toInt32OrNull('0xc0fe');`.
+- If the input value cannot be represented within the bounds of [Int32](../data-types/int-uint.md) and the result over or under flows.
 
 **Returned value**
 
 - 32-bit integer value if successful, otherwise `NULL`. [Int32](../data-types/int-uint.md) / [NULL](../data-types/nullable.md).
 
 :::note
-Function uses [rounding towards zero](https://en.wikipedia.org/wiki/Rounding#Rounding_towards_zero), meaning it truncates fractional digits of numbers.
-:::
-
-:::danger
-An exception is thrown for [NaN and Inf](../data-types/float.md/#data_type-float-nan-inf) arguments. Keep in mind [numeric conversions issues](#common-issues-with-data-conversion), when using this function.
+The function uses [rounding towards zero](https://en.wikipedia.org/wiki/Rounding#Rounding_towards_zero), meaning it truncates fractional digits of numbers.
 :::
 
 **Example**
@@ -643,7 +677,7 @@ Result:
 
 ## toInt32OrDefault
 
-Like [`toInt32`](#toint32), takes an argument of type [String](../data-types/string.md) and tries to parse it to type `Int32`. If unsuccessful, returns the default type value.
+Like [`toInt32`](#toint32), takes an argument of type [String](../data-types/string.md) and tries to parse it to type [`Int32`](../data-types/int-uint.md). If unsuccessful, returns the default type value.
 
 **Syntax**
 
@@ -653,24 +687,26 @@ toInt32OrDefault(expr, def)
 
 **Arguments**
 
-- `expr` — Expression returning a number or a string with the decimal representation of a number. [Expression](../syntax.md/#syntax-expressions) / [String](../data-types/string.md).
+- `expr` — Expression returning a number or a string representation of a number. [Expression](../syntax.md/#syntax-expressions) / [String](../data-types/string.md).
 - `def` — The default value to return if parsing to type `Int32` is unsuccessful. [Int32](../data-types/int-uint.md).
 
-:::note
-Binary, octal, and hexadecimal representations of numbers are not supported. Leading zeroes are stripped.
-:::
+Supported types:
+- (U)Int8/16/32/64/128/256
+- Float*
+- String representations of (U)Int8/16/32/128/256
+
+Types for which the default value is returned:
+- Float values `NaN` and `Inf` return the default value.
+- String representations of binary and hexadecimal values, e.g. `SELECT toInt32OrDefault('0xc0fe', CAST('-1', 'Int32'));`
+- If the input value cannot be represented within the bounds of [Int32](../data-types/int-uint.md) and the result over or under flows.
 
 **Returned value**
 
 - 32-bit integer value if successful, otherwise returns the default value. [Int32](../data-types/int-uint.md).
 
 :::note
-- Function uses [rounding towards zero](https://en.wikipedia.org/wiki/Rounding#Rounding_towards_zero), meaning it truncates fractional digits of numbers.
+- The function uses [rounding towards zero](https://en.wikipedia.org/wiki/Rounding#Rounding_towards_zero), meaning it truncates fractional digits of numbers.
 - The default value type should be the same as the cast type.
-  :::
-
-:::danger
-An exception is thrown for [NaN and Inf](../data-types/float.md/#data_type-float-nan-inf) arguments. Keep in mind [numeric conversions issues](#common-issues-with-data-conversion), when using this function.
 :::
 
 **Example**
@@ -697,7 +733,7 @@ Result:
 
 ## toInt64
 
-Converts an input value to a value of type `Int64`.
+Converts an input value to a value of type [`Int64`](../data-types/int-uint.md). Throws an exception in case of an error.
 
 **Syntax**
 
@@ -707,10 +743,26 @@ toInt64(expr)
 
 **Arguments**
 
-- `expr` — Expression returning a number or a string with the decimal representation of a number. [Expression](../syntax.md/#syntax-expressions).
+- `expr` — Expression returning a number or a string representation of a number. [Expression](../syntax.md/#syntax-expressions).
+
+Supported types:
+- (U)Int8/16/32/64/128/256
+- Float*
+- String representations of (U)Int8/16/32/128/256
+
+Unsupported types:
+- Float values `NaN` and `Inf` throw an exception.
+- String representations of binary and hexadecimal values, e.g. `SELECT toInt64('0xc0fe');`
 
 :::note
-Binary, octal, and hexadecimal representations of numbers are not supported. Leading zeroes are stripped.
+If the input value cannot be represented within the bounds of [Int16](../data-types/int-uint.md), the result over or under flows. This is not considered an error.  
+For example: 
+
+```
+SELECT toInt64(9223372036854775808) == -9223372036854775808;
+SELECT toInt64(9223372036854775808.0) == -9223372036854775808;
+SELECT toInt64('9223372036854775808') == --9223372036854775808;
+```
 :::
 
 **Returned value**
@@ -718,11 +770,7 @@ Binary, octal, and hexadecimal representations of numbers are not supported. Lea
 - 64-bit integer value. [Int64](../data-types/int-uint.md). [Int64](../data-types/int-uint.md).
 
 :::note
-Function uses [rounding towards zero](https://en.wikipedia.org/wiki/Rounding#Rounding_towards_zero), meaning it truncates fractional digits of numbers.
-:::
-
-:::danger
-An exception is thrown for [NaN and Inf](../data-types/float.md/#data_type-float-nan-inf) arguments. Keep in mind [numeric conversions issues](#common-issues-with-data-conversion), when using this function.
+The function uses [rounding towards zero](https://en.wikipedia.org/wiki/Rounding#Rounding_towards_zero), meaning it truncates fractional digits of numbers.
 :::
 
 **Example**
@@ -752,32 +800,33 @@ Result:
 
 ## toInt64OrZero
 
-Like [`toInt64`](#toint64), takes an argument of type [String](../data-types/string.md) and tries to parse it to type `Int64`. If unsuccessful, returns `0`.
+Like [`toInt64`](#toint64), this function converts an input value to a value of type [Int8](../data-types/int-uint.md) but returns `0` in case of an error.
 
 **Syntax**
 
 ```sql
-toInt64OrZero(expr)
+toInt64OrZero(x)
 ```
 
 **Arguments**
 
-- `expr` — Expression returning a number or a string with the decimal representation of a number. [Expression](../syntax.md/#syntax-expressions) / [String](../data-types/string.md).
+- `x` — A String representation of a number. [String](../data-types/string.md).
 
-:::note
-Binary, octal, and hexadecimal representations of numbers are not supported. Leading zeroes are stripped.
-:::
+Supported types:
+- String representations of (U)Int8/16/32/128/256
+
+Types for which `0` is returned:
+- String representations of ordinary Float32/64 values.
+- String representations of Float values `NaN` and `Inf`.
+- String representations of binary and hexadecimal values, e.g. `SELECT toInt64OrZero('0xc0fe');`.
+- If the input value cannot be represented within the bounds of [Int64](../data-types/int-uint.md) and the result over or under flows.
 
 **Returned value**
 
 - 64-bit integer value if successful, otherwise `0`. [Int64](../data-types/int-uint.md).
 
 :::note
-Function uses [rounding towards zero](https://en.wikipedia.org/wiki/Rounding#Rounding_towards_zero), meaning it truncates fractional digits of numbers.
-:::
-
-:::danger
-An exception is thrown for [NaN and Inf](../data-types/float.md/#data_type-float-nan-inf) arguments. Keep in mind [numeric conversions issues](#common-issues-with-data-conversion), when using this function.
+The function uses [rounding towards zero](https://en.wikipedia.org/wiki/Rounding#Rounding_towards_zero), meaning it truncates fractional digits of numbers.
 :::
 
 **Example**
@@ -806,32 +855,33 @@ Result:
 
 ## toInt64OrNull
 
-Like [`toInt64`], takes an argument of type [String](../data-types/string.md) and tries to parse it to type `Int64`. If unsuccessful, returns `NULL`.
+Like [`toInt64`], takes an argument of type [String](../data-types/string.md) and tries to parse it to type [`Int64`](../data-types/nullable.md). If unsuccessful, returns [`NULL`](../data-types/nullable.md).
 
 **Syntax**
 
 ```sql
-toInt64OrNull(expr)
+toInt64OrNull(x)
 ```
 
 **Arguments**
 
-- `expr` — Expression returning a number or a string with the decimal representation of a number. [Expression](../syntax.md/#syntax-expressions) / [String](../data-types/string.md).
+- `x` — A String representation of a number. [Expression](../syntax.md/#syntax-expressions) / [String](../data-types/string.md).
 
-:::note
-Binary, octal, and hexadecimal representations of numbers are not supported. Leading zeroes are stripped.
-:::
+Supported types:
+- String representations of (U)Int8/16/32/128/256
+
+Types for which `\N` is returned:
+- String representations of ordinary Float32/64 values.
+- String representations of Float values `NaN` and `Inf`.
+- String representations of binary and hexadecimal values, e.g. `SELECT toInt64OrNull('0xc0fe');`.
+- If the input value cannot be represented within the bounds of [Int64](../data-types/int-uint.md) and the result over or under flows.
 
 **Returned value**
 
 - Integer value of type `Int64` if successful, otherwise `NULL`. [Int64](../data-types/int-uint.md) / [NULL](../data-types/nullable.md).
 
 :::note
-Function uses [rounding towards zero](https://en.wikipedia.org/wiki/Rounding#Rounding_towards_zero), meaning it truncates fractional digits of numbers.
-:::
-
-:::danger
-An exception is thrown for [NaN and Inf](../data-types/float.md/#data_type-float-nan-inf) arguments. Keep in mind [numeric conversions issues](#common-issues-with-data-conversion), when using this function.
+The function uses [rounding towards zero](https://en.wikipedia.org/wiki/Rounding#Rounding_towards_zero), meaning it truncates fractional digits of numbers.
 :::
 
 **Example**
@@ -860,7 +910,7 @@ Result:
 
 ## toInt64OrDefault
 
-Like [`toInt64`](#toint64), takes an argument of type [String](../data-types/string.md) and tries to parse it to type `Int64`. If unsuccessful, returns the default type value.
+Like [`toInt64`](#toint64), takes an argument of type [String](../data-types/string.md) and tries to parse it to type [`Int64`](../data-types/nullable.md). If unsuccessful, returns the default type value.
 
 **Syntax**
 
@@ -870,24 +920,26 @@ toInt64OrDefault(expr, def)
 
 **Arguments**
 
-- `expr` — Expression returning a number or a string with the decimal representation of a number. [Expression](../syntax.md/#syntax-expressions) / [String](../data-types/string.md).
+- `expr` — Expression returning a number or a string representation of a number. [Expression](../syntax.md/#syntax-expressions) / [String](../data-types/string.md).
 - `def` — The default value to return if parsing to type `Int64` is unsuccessful. [Int64](../data-types/int-uint.md).
 
-:::note
-Binary, octal, and hexadecimal representations of numbers are not supported. Leading zeroes are stripped.
-:::
+Supported types:
+- (U)Int8/16/32/64/128/256
+- Float*
+- String representations of (U)Int8/16/32/128/256
+
+Types for which the default value is returned:
+- Float values `NaN` and `Inf` return the default value.
+- String representations of binary and hexadecimal values, e.g. `SELECT toInt64OrDefault('0xc0fe', CAST('-1', 'Int64'));`
+- If the input value cannot be represented within the bounds of [Int64](../data-types/int-uint.md) and the result over or under flows.
 
 **Returned value**
 
 - Integer value of type `Int64` if successful, otherwise returns the default value. [Int64](../data-types/int-uint.md).
 
 :::note
-- Function uses [rounding towards zero](https://en.wikipedia.org/wiki/Rounding#Rounding_towards_zero), meaning it truncates fractional digits of numbers.
+- The function uses [rounding towards zero](https://en.wikipedia.org/wiki/Rounding#Rounding_towards_zero), meaning it truncates fractional digits of numbers.
 - The default value type should be the same as the cast type.
-  :::
-
-:::danger
-An exception is thrown for [NaN and Inf](../data-types/float.md/#data_type-float-nan-inf) arguments. Keep in mind [numeric conversions issues](#common-issues-with-data-conversion), when using this function.
 :::
 
 **Example**
@@ -916,7 +968,7 @@ Result:
 
 ## toInt128
 
-Converts an input value to a value of type `Int128`.
+Converts an input value to a value of type [`Int128`](../data-types/int-uint.md). Throws an exception in case of an error.
 
 **Syntax**
 
@@ -926,10 +978,19 @@ toInt128(expr)
 
 **Arguments**
 
-- `expr` — Expression returning a number or a string with the decimal representation of a number. [Expression](../syntax.md/#syntax-expressions).
+- `expr` — Expression returning a number or a string representation of a number. [Expression](../syntax.md/#syntax-expressions).
+
+Supported types:
+- (U)Int8/16/32/64/128/256
+- Float*
+- String representations of (U)Int8/16/32/128/256
+
+Unsupported types:
+- Float values `NaN` and `Inf` throw an exception.
+- String representations of binary and hexadecimal values, e.g. `SELECT toInt128('0xc0fe');`
 
 :::note
-Binary, octal, and hexadecimal representations of numbers are not supported. Leading zeroes are stripped.
+If the input value cannot be represented within the bounds of [Int128](../data-types/int-uint.md), the result over or under flows. This is not considered an error.
 :::
 
 **Returned value**
@@ -937,11 +998,7 @@ Binary, octal, and hexadecimal representations of numbers are not supported. Lea
 - 128-bit integer value. [Int128](../data-types/int-uint.md).
 
 :::note
-Function uses [rounding towards zero](https://en.wikipedia.org/wiki/Rounding#Rounding_towards_zero), meaning it truncates fractional digits of numbers.
-:::
-
-:::danger
-An exception is thrown for [NaN and Inf](../data-types/float.md/#data_type-float-nan-inf) arguments. Keep in mind [numeric conversions issues](#common-issues-with-data-conversion), when using this function.
+The function uses [rounding towards zero](https://en.wikipedia.org/wiki/Rounding#Rounding_towards_zero), meaning it truncates fractional digits of numbers.
 :::
 
 **Example**
@@ -971,7 +1028,7 @@ Result:
 
 ## toInt128OrZero
 
-Like [`toInt128`](#toint128), takes an argument of type [String](../data-types/string.md) and tries to parse it to type `Int128`. If unsuccessful, returns `0`.
+Like [`toInt128`](#toint128), this function converts an input value to a value of type [Int8](../data-types/int-uint.md) but returns `0` in case of an error.
 
 **Syntax**
 
@@ -981,22 +1038,23 @@ toInt128OrZero(expr)
 
 **Arguments**
 
-- `expr` — Expression returning a number or a string with the decimal representation of a number. [Expression](../syntax.md/#syntax-expressions) / [String](../data-types/string.md).
+- `expr` — Expression returning a number or a string representation of a number. [Expression](../syntax.md/#syntax-expressions) / [String](../data-types/string.md).
 
-:::note
-Binary, octal, and hexadecimal representations of numbers are not supported. Leading zeroes are stripped.
-:::
+Supported types:
+- String representations of (U)Int8/16/32/128/256
+
+Types for which `0` is returned:
+- String representations of ordinary Float32/64 values.
+- String representations of Float values `NaN` and `Inf`.
+- String representations of binary and hexadecimal values, e.g. `SELECT toInt128OrZero('0xc0fe');`.
+- If the input value cannot be represented within the bounds of [Int128](../data-types/int-uint.md) and the result over or under flows.
 
 **Returned value**
 
 - 128-bit integer value if successful, otherwise `0`. [Int128](../data-types/int-uint.md).
 
 :::note
-Function uses [rounding towards zero](https://en.wikipedia.org/wiki/Rounding#Rounding_towards_zero), meaning it truncates fractional digits of numbers.
-:::
-
-:::danger
-An exception is thrown for [NaN and Inf](../data-types/float.md/#data_type-float-nan-inf) arguments. Keep in mind [numeric conversions issues](#common-issues-with-data-conversion), when using this function.
+The function uses [rounding towards zero](https://en.wikipedia.org/wiki/Rounding#Rounding_towards_zero), meaning it truncates fractional digits of numbers.
 :::
 
 **Example**
@@ -1025,32 +1083,33 @@ Result:
 
 ## toInt128OrNull
 
-Like [`toInt128`](#toint128), takes an argument of type [String](../data-types/string.md) and tries to parse it to type `Int128`. If unsuccessful, returns `NULL`.
+Like [`toInt128`](#toint128), takes an argument of type [String](../data-types/string.md) and tries to parse it to type [`Int128`](../data-types/int-uint.md). If unsuccessful, returns [`NULL`](../data-types/nullable.md).
 
 **Syntax**
 
 ```sql
-toInt128OrNull(expr)
+toInt128OrNull(x)
 ```
 
 **Arguments**
 
-- `expr` — Expression returning a number or a string with the decimal representation of a number. [Expression](../syntax.md/#syntax-expressions) / [String](../data-types/string.md).
+- `x` — A String representation of a number. [Expression](../syntax.md/#syntax-expressions) / [String](../data-types/string.md).
 
-:::note
-Binary, octal, and hexadecimal representations of numbers are not supported. Leading zeroes are stripped.
-:::
+Supported types:
+- String representations of (U)Int8/16/32/128/256
+
+Types for which `\N` is returned:
+- String representations of ordinary Float32/64 values.
+- String representations of Float values `NaN` and `Inf`.
+- String representations of binary and hexadecimal values, e.g. `SELECT toInt128OrNull('0xc0fe');`.
+- If the input value cannot be represented within the bounds of [Int128](../data-types/int-uint.md) and the result over or under flows.
 
 **Returned value**
 
 - 128-bit integer value if successful, otherwise `NULL`. [Int128](../data-types/int-uint.md) / [NULL](../data-types/nullable.md).
 
 :::note
-Function uses [rounding towards zero](https://en.wikipedia.org/wiki/Rounding#Rounding_towards_zero), meaning it truncates fractional digits of numbers.
-:::
-
-:::danger
-An exception is thrown for [NaN and Inf](../data-types/float.md/#data_type-float-nan-inf) arguments. Keep in mind [numeric conversions issues](#common-issues-with-data-conversion), when using this function.
+The function uses [rounding towards zero](https://en.wikipedia.org/wiki/Rounding#Rounding_towards_zero), meaning it truncates fractional digits of numbers.
 :::
 
 **Example**
@@ -1079,7 +1138,7 @@ Result:
 
 ## toInt128OrDefault
 
-Like [`toInt128`](#toint128), takes an argument of type [String](../data-types/string.md) and tries to parse it to type `Int128`. If unsuccessful, returns the default type value.
+Like [`toInt128`](#toint128), takes an argument of type [String](../data-types/string.md) and tries to parse it to type [`Int128`](../data-types/int-uint.md). If unsuccessful, returns the default type value.
 
 **Syntax**
 
@@ -1089,24 +1148,26 @@ toInt128OrDefault(expr, def)
 
 **Arguments**
 
-- `expr` — Expression returning a number or a string with the decimal representation of a number. [Expression](../syntax.md/#syntax-expressions) / [String](../data-types/string.md).
+- `expr` — Expression returning a number or a string representation of a number. [Expression](../syntax.md/#syntax-expressions) / [String](../data-types/string.md).
 - `def` — The default value to return if parsing to type `Int128` is unsuccessful. [Int128](../data-types/int-uint.md).
 
-:::note
-Binary, octal, and hexadecimal representations of numbers are not supported. Leading zeroes are stripped.
-:::
+Supported types:
+- (U)Int8/16/32/64/128/256
+- Float*
+- String representations of (U)Int8/16/32/128/256
+
+Types for which the default value is returned:
+- Float values `NaN` and `Inf` return the default value.
+- String representations of binary and hexadecimal values, e.g. `SELECT toInt128OrDefault('0xc0fe', CAST('-1', 'Int128'));`
+- If the input value cannot be represented within the bounds of [Int128](../data-types/int-uint.md) and the result over or under flows.
 
 **Returned value**
 
 - 128-bit integer value if successful, otherwise returns the default value. [Int128](../data-types/int-uint.md).
 
 :::note
-- Function uses [rounding towards zero](https://en.wikipedia.org/wiki/Rounding#Rounding_towards_zero), meaning it truncates fractional digits of numbers.
+- The function uses [rounding towards zero](https://en.wikipedia.org/wiki/Rounding#Rounding_towards_zero), meaning it truncates fractional digits of numbers.
 - The default value type should be the same as the cast type.
-:::
-
-:::danger
-An exception is thrown for [NaN and Inf](../data-types/float.md/#data_type-float-nan-inf) arguments. Keep in mind [numeric conversions issues](#common-issues-with-data-conversion), when using this function.
 :::
 
 **Example**
@@ -1135,7 +1196,7 @@ Result:
 
 ## toInt256
 
-Converts an input value to a value of type `Int256`.
+Converts an input value to a value of type [`Int256`](../data-types/int-uint.md). Throws an exception in case of an error.
 
 **Syntax**
 
@@ -1145,10 +1206,19 @@ toInt256(expr)
 
 **Arguments**
 
-- `expr` — Expression returning a number or a string with the decimal representation of a number. [Expression](../syntax.md/#syntax-expressions).
+- `expr` — Expression returning a number or a string representation of a number. [Expression](../syntax.md/#syntax-expressions).
+
+Supported types:
+- (U)Int8/16/32/64/128/256
+- Float*
+- String representations of (U)Int8/16/32/128/256
+
+Unsupported types:
+- Float values `NaN` and `Inf` throw an exception.
+- String representations of binary and hexadecimal values, e.g. `SELECT toInt256('0xc0fe');`
 
 :::note
-Binary, octal, and hexadecimal representations of numbers are not supported. Leading zeroes are stripped.
+If the input value cannot be represented within the bounds of [Int256](../data-types/int-uint.md), the result over or under flows. This is not considered an error.
 :::
 
 **Returned value**
@@ -1156,11 +1226,7 @@ Binary, octal, and hexadecimal representations of numbers are not supported. Lea
 - 256-bit integer value. [Int256](../data-types/int-uint.md).
 
 :::note
-Function uses [rounding towards zero](https://en.wikipedia.org/wiki/Rounding#Rounding_towards_zero), meaning it truncates fractional digits of numbers.
-:::
-
-:::danger
-An exception is thrown for [NaN and Inf](../data-types/float.md/#data_type-float-nan-inf) arguments. Keep in mind [numeric conversions issues](#common-issues-with-data-conversion), when using this function.
+The function uses [rounding towards zero](https://en.wikipedia.org/wiki/Rounding#Rounding_towards_zero), meaning it truncates fractional digits of numbers.
 :::
 
 **Example**
@@ -1190,32 +1256,33 @@ Result:
 
 ## toInt256OrZero
 
-Like [`toInt256`](#toint256), takes an argument of type [String](../data-types/string.md) and tries to parse it to type `Int256`. If unsuccessful, returns `0`.
+Like [`toInt256`](#toint256), this function converts an input value to a value of type [Int8](../data-types/int-uint.md) but returns `0` in case of an error.
 
 **Syntax**
 
 ```sql
-toInt256OrZero(expr)
+toInt256OrZero(x)
 ```
 
 **Arguments**
 
-- `expr` — Expression returning a number or a string with the decimal representation of a number. [Expression](../syntax.md/#syntax-expressions) / [String](../data-types/string.md).
+- `x` — A String representation of a number. [String](../data-types/string.md).
 
-:::note
-Binary, octal, and hexadecimal representations of numbers are not supported. Leading zeroes are stripped.
-:::
+Supported types:
+- String representations of (U)Int8/16/32/128/256
+
+Types for which `0` is returned:
+- String representations of ordinary Float32/64 values.
+- String representations of Float values `NaN` and `Inf`.
+- String representations of binary and hexadecimal values, e.g. `SELECT toInt256OrZero('0xc0fe');`.
+- If the input value cannot be represented within the bounds of [Int256](../data-types/int-uint.md) and the result over or under flows.
 
 **Returned value**
 
 - 256-bit integer value if successful, otherwise `0`. [Int256](../data-types/int-uint.md).
 
 :::note
-Functions uses [rounding towards zero](https://en.wikipedia.org/wiki/Rounding#Rounding_towards_zero), meaning it truncates fractional digits of numbers.
-:::
-
-:::danger
-An exception is thrown for [NaN and Inf](../data-types/float.md/#data_type-float-nan-inf) arguments. Keep in mind [numeric conversions issues](#common-issues-with-data-conversion), when using this function.
+The function uses [rounding towards zero](https://en.wikipedia.org/wiki/Rounding#Rounding_towards_zero), meaning it truncates fractional digits of numbers.
 :::
 
 **Example**
@@ -1244,32 +1311,33 @@ Result:
 
 ## toInt256OrNull
 
-Like [`toInt256`](#toint256), takes an argument of type [String](../data-types/string.md) and tries to parse it to type `Int256`. If unsuccessful, returns `NULL`.
+Like [`toInt256`](#toint256), takes an argument of type [String](../data-types/string.md) and tries to parse it to type [`Int256`](../data-types/int-uint.md). If unsuccessful, returns [`NULL`](../data-types/nullable.md).
 
 **Syntax**
 
 ```sql
-toInt256OrNull(expr)
+toInt256OrNull(x)
 ```
 
 **Arguments**
 
-- `expr` — Expression returning a number or a string with the decimal representation of a number. [Expression](../syntax.md/#syntax-expressions) / [String](../data-types/string.md).
+- `x` — A String representation of a number. [String](../data-types/string.md).
 
-:::note
-Binary, octal, and hexadecimal representations of numbers are not supported. Leading zeroes are stripped.
-:::
+Supported types:
+- String representations of (U)Int8/16/32/128/256
+
+Types for which `\N` is returned:
+- String representations of ordinary Float32/64 values.
+- String representations of Float values `NaN` and `Inf`.
+- String representations of binary and hexadecimal values, e.g. `SELECT toInt256OrNull('0xc0fe');`.
+- If the input value cannot be represented within the bounds of [Int256](../data-types/int-uint.md) and the result over or under flows.
 
 **Returned value**
 
 - 256-bit integer value if successful, otherwise `NULL`. [Int256](../data-types/int-uint.md) / [NULL](../data-types/nullable.md).
 
 :::note
-Function uses [rounding towards zero](https://en.wikipedia.org/wiki/Rounding#Rounding_towards_zero), meaning it truncates fractional digits of numbers.
-:::
-
-:::danger
-An exception is thrown for [NaN and Inf](../data-types/float.md/#data_type-float-nan-inf) arguments. Keep in mind [numeric conversions issues](#common-issues-with-data-conversion), when using this function.
+The function uses [rounding towards zero](https://en.wikipedia.org/wiki/Rounding#Rounding_towards_zero), meaning it truncates fractional digits of numbers.
 :::
 
 **Example**
@@ -1298,7 +1366,7 @@ Result:
 
 ## toInt256OrDefault
 
-Like [`toInt256`](#toint256), takes an argument of type [String](../data-types/string.md) and tries to parse it to type `Int256`. If unsuccessful, returns the default type value.
+Like [`toInt256`](#toint256), takes an argument of type [String](../data-types/string.md) and tries to parse it to type [`Int256`](../data-types/int-uint.md). If unsuccessful, returns the default type value.
 
 **Syntax**
 
@@ -1308,24 +1376,26 @@ toInt256OrDefault(expr, def)
 
 **Arguments**
 
-- `expr` — Expression returning a number or a string with the decimal representation of a number. [Expression](../syntax.md/#syntax-expressions) / [String](../data-types/string.md).
+- `expr` — Expression returning a number or a string representation of a number. [Expression](../syntax.md/#syntax-expressions) / [String](../data-types/string.md).
 - `def` — The default value to return if parsing to type `Int256` is unsuccessful. [Int256](../data-types/int-uint.md).
 
-:::note
-Binary, octal, and hexadecimal representations of numbers are not supported. Leading zeroes are stripped.
-:::
+Supported types:
+- (U)Int8/16/32/64/128/256
+- Float*
+- String representations of (U)Int8/16/32/128/256
+
+Types for which the default value is returned:
+- Float values `NaN` and `Inf` return the default value.
+- String representations of binary and hexadecimal values, e.g. `SELECT toInt128OrDefault('0xc0fe', CAST('-1', 'Int256'));`
+- If the input value cannot be represented within the bounds of [Int256](../data-types/int-uint.md) and the result over or under flows.
 
 **Returned value**
 
 - 256-bit integer value if successful, otherwise returns the default value. [Int256](../data-types/int-uint.md).
 
 :::note
-- Function uses [rounding towards zero](https://en.wikipedia.org/wiki/Rounding#Rounding_towards_zero), meaning it truncates fractional digits of numbers.
+- The function uses [rounding towards zero](https://en.wikipedia.org/wiki/Rounding#Rounding_towards_zero), meaning it truncates fractional digits of numbers.
 - The default value type should be the same as the cast type.
-:::
-
-:::danger
-An exception is thrown for [NaN and Inf](../data-types/float.md/#data_type-float-nan-inf) arguments. Keep in mind [numeric conversions issues](#common-issues-with-data-conversion), when using this function.
 :::
 
 **Example**

--- a/docs/en/sql-reference/functions/type-conversion-functions.md
+++ b/docs/en/sql-reference/functions/type-conversion-functions.md
@@ -131,7 +131,7 @@ Types for which `0` is returned:
 - String representations of ordinary Float32/64 values.
 - String representations of Float values `NaN` and `Inf`.
 - String representations of binary and hexadecimal values, e.g. `SELECT toInt8OrZero('0xc0fe');`.
-- If the input value cannot be represented within the bounds of [toInt16](../data-types/int-uint.md), and the result over or under flows.
+- If the input value cannot be represented within the bounds of [Int8](../data-types/int-uint.md), and the result over or under flows.
 
 **Returned value**
 
@@ -186,7 +186,7 @@ Types for which `\N` is returned:
 - String representations of ordinary Float32/64 values.
 - String representations of Float values `NaN` and `Inf`.
 - String representations of binary and hexadecimal values, e.g. `SELECT toInt8OrNull('0xc0fe');`.
-- If the input value cannot be represented within the bounds of [Int16](../data-types/int-uint.md), and the result over or under flows.
+- If the input value cannot be represented within the bounds of [Int8](../data-types/int-uint.md), and the result over or under flows.
 
 **Returned value**
 
@@ -300,7 +300,7 @@ Unsupported types:
 - String representations of binary and hexadecimal values, e.g. `SELECT toInt16('0xc0fe');`
 
 :::note
-If the input value cannot be represented within the bounds of [toInt16](../data-types/int-uint.md), the result over or under flows. This is not considered an error.  
+If the input value cannot be represented within the bounds of [Int16](../data-types/int-uint.md), the result over or under flows. This is not considered an error.  
 For example: `SELECT toInt16(32768) == -32768;`, `SELECT toInt16(32768) == -32768;`,  `SELECT toInt16('32768') == -32768;`.
 :::
 
@@ -527,7 +527,7 @@ Unsupported types:
 - String representations of binary and hexadecimal values, e.g. `SELECT toInt32('0xc0fe');`
 
 :::note
-If the input value cannot be represented within the bounds of [toInt16](../data-types/int-uint.md), the result over or under flows. This is not considered an error.  
+If the input value cannot be represented within the bounds of [Int32](../data-types/int-uint.md), the result over or under flows. This is not considered an error.  
 For example: 
 ```
 SELECT toInt32(2147483648) == -2147483648;
@@ -755,7 +755,7 @@ Unsupported types:
 - String representations of binary and hexadecimal values, e.g. `SELECT toInt64('0xc0fe');`
 
 :::note
-If the input value cannot be represented within the bounds of [Int16](../data-types/int-uint.md), the result over or under flows. This is not considered an error.  
+If the input value cannot be represented within the bounds of [Int64](../data-types/int-uint.md), the result over or under flows. This is not considered an error.  
 For example: 
 
 ```
@@ -1386,7 +1386,7 @@ Supported types:
 
 Types for which the default value is returned:
 - Float values `NaN` and `Inf` return the default value.
-- String representations of binary and hexadecimal values, e.g. `SELECT toInt128OrDefault('0xc0fe', CAST('-1', 'Int256'));`
+- String representations of binary and hexadecimal values, e.g. `SELECT toInt256OrDefault('0xc0fe', CAST('-1', 'Int256'));`
 - If the input value cannot be represented within the bounds of [Int256](../data-types/int-uint.md) and the result over or under flows.
 
 **Returned value**

--- a/docs/en/sql-reference/functions/type-conversion-functions.md
+++ b/docs/en/sql-reference/functions/type-conversion-functions.md
@@ -49,105 +49,1308 @@ SETTINGS cast_keep_nullable = 1
 └──────────────────┴─────────────────────┴──────────────────┘
 ```
 
-## toInt(8\|16\|32\|64\|128\|256)
+## toInt8
 
-Converts an input value to a value the [Int](../data-types/int-uint.md) data type. This function family includes:
+Converts an input value to a value of type `Int8`.
 
-- `toInt8(expr)` — Converts to a value of data type `Int8`.
-- `toInt16(expr)` — Converts to a value of data type `Int16`.
-- `toInt32(expr)` — Converts to a value of data type `Int32`.
-- `toInt64(expr)` — Converts to a value of data type `Int64`.
-- `toInt128(expr)` — Converts to a value of data type `Int128`.
-- `toInt256(expr)` — Converts to a value of data type `Int256`.
+**Syntax**
+
+```sql
+toInt8(expr)
+```
 
 **Arguments**
 
-- `expr` — [Expression](../syntax.md/#syntax-expressions) returning a number or a string with the decimal representation of a number. Binary, octal, and hexadecimal representations of numbers are not supported. Leading zeroes are stripped.
+- `expr` — Expression returning a number or a string with the decimal representation of a number. [Expression](../syntax.md/#syntax-expressions).
+
+:::note
+Binary, octal, and hexadecimal representations of numbers are not supported. Leading zeroes are stripped.
+:::
 
 **Returned value**
 
-Integer value in the `Int8`, `Int16`, `Int32`, `Int64`, `Int128` or `Int256` data type.
+- 8-bit integer value. [Int8](../data-types/int-uint.md).
 
-Functions use [rounding towards zero](https://en.wikipedia.org/wiki/Rounding#Rounding_towards_zero), meaning they truncate fractional digits of numbers.
+:::note
+Function uses [rounding towards zero](https://en.wikipedia.org/wiki/Rounding#Rounding_towards_zero), meaning it truncates fractional digits of numbers.
+:::
 
-The behavior of functions for the [NaN and Inf](../data-types/float.md/#data_type-float-nan-inf) arguments is undefined. Remember about [numeric conversions issues](#common-issues-with-data-conversion), when using the functions.
+:::danger
+An exception is thrown for [NaN and Inf](../data-types/float.md/#data_type-float-nan-inf) arguments. Keep in mind [numeric conversions issues](#common-issues-with-data-conversion), when using this function.
+:::
+
+**Example**
+
+Query:
+
+```sql
+SELECT
+    toInt8(-8),
+    toInt8(-8.8),
+    toInt8('-8');
+```
+
+Result:
+
+```response
+   ┌─toInt8(-8)─┬─toInt8(-8.8)─┬─toInt8('-8')─┐
+1. │         -8 │           -8 │           -8 │
+   └────────────┴──────────────┴──────────────┘
+```
+
+**See also**
+
+- [`toInt8OrZero`](#toint8orzero).
+- [`toInt8OrNull`](#toint8ornull).
+- [`toInt8OrDefault`](#toint8ordefault).
+
+## toInt8OrZero
+
+Like [`toInt8`](#toint8), it takes an argument of type [String](../data-types/string.md) and tries to parse it to type `Int8`. If unsuccessful, returns `0`.
+
+**Syntax**
+
+```sql
+toInt8OrZero(expr)
+```
+
+**Arguments**
+
+- `expr` — Expression returning a number or a string with the decimal representation of a number. [Expression](../syntax.md/#syntax-expressions) / [String](../data-types/string.md).
+
+:::note
+Binary, octal, and hexadecimal representations of numbers are not supported. Leading zeroes are stripped.
+:::
+
+**Returned value**
+
+- 8-bit integer value if successful, otherwise `0`. [Int8](../data-types/int-uint.md).
+
+:::note
+Function uses [rounding towards zero](https://en.wikipedia.org/wiki/Rounding#Rounding_towards_zero), meaning it truncates fractional digits of numbers. 
+:::
+
+:::danger
+An exception is thrown for [NaN and Inf](../data-types/float.md/#data_type-float-nan-inf) arguments. Keep in mind [numeric conversions issues](#common-issues-with-data-conversion), when using this function.
+:::
 
 **Example**
 
 Query:
 
 ``` sql
-SELECT toInt64(nan), toInt32(32), toInt16('16'), toInt8(8.8);
+SELECT
+    toInt8OrZero('-8'),
+    toInt8OrZero('abc');
 ```
 
 Result:
 
 ```response
-┌─────────toInt64(nan)─┬─toInt32(32)─┬─toInt16('16')─┬─toInt8(8.8)─┐
-│ -9223372036854775808 │          32 │            16 │           8 │
-└──────────────────────┴─────────────┴───────────────┴─────────────┘
+   ┌─toInt8OrZero('-8')─┬─toInt8OrZero('abc')─┐
+1. │                 -8 │                   0 │
+   └────────────────────┴─────────────────────┘
 ```
 
-## toInt(8\|16\|32\|64\|128\|256)OrZero
+**See also**
 
-Takes an argument of type [String](../data-types/string.md) and tries to parse it into an Int (8 \| 16 \| 32 \| 64 \| 128 \| 256). If unsuccessful, returns `0`.
+- [`toInt8`](#toint8).
+- [`toInt8OrNull`](#toint8ornull).
+- [`toInt8OrDefault`](#toint8ordefault).
+
+## toInt8OrNull
+
+Like [`toInt8`](#toint8), takes an argument of type [String](../data-types/string.md) and tries to parse it to type `Int8`. If unsuccessful, returns `NULL`.
+
+**Syntax**
+
+```sql
+toInt8OrNull(expr)
+```
+
+**Arguments**
+
+- `expr` — Expression returning a number or a string with the decimal representation of a number. [Expression](../syntax.md/#syntax-expressions) / [String](../data-types/string.md).
+
+:::note
+Binary, octal, and hexadecimal representations of numbers are not supported. Leading zeroes are stripped.
+:::
+
+**Returned value**
+
+- 8-bit integer value if successful, otherwise `NULL`. [Int8](../data-types/int-uint.md) / [NULL](../data-types/nullable.md).
+
+:::note
+Function uses [rounding towards zero](https://en.wikipedia.org/wiki/Rounding#Rounding_towards_zero), meaning it truncates fractional digits of numbers.
+:::
+
+:::danger
+An exception is thrown for [NaN and Inf](../data-types/float.md/#data_type-float-nan-inf) arguments. Keep in mind [numeric conversions issues](#common-issues-with-data-conversion), when using this function.
+:::
 
 **Example**
 
 Query:
 
 ``` sql
-SELECT toInt64OrZero('123123'), toInt8OrZero('123qwe123');
+SELECT toInt8OrNull('-8'), toInt8OrNull('abc');
 ```
 
 Result:
 
 ```response
-┌─toInt64OrZero('123123')─┬─toInt8OrZero('123qwe123')─┐
-│                  123123 │                         0 │
-└─────────────────────────┴───────────────────────────┘
+   ┌─toInt8OrNull('-8')─┬─toInt8OrNull('abc')─┐
+1. │                 -8 │                ᴺᵁᴸᴸ │
+   └────────────────────┴─────────────────────┘
 ```
 
-## toInt(8\|16\|32\|64\|128\|256)OrNull
+**See also**
 
-It takes an argument of type String and tries to parse it into Int (8 \| 16 \| 32 \| 64 \| 128 \| 256). If unsuccessful, returns `NULL`.
+- [`toInt8`](#toint8).
+- [`toInt8OrZero`](#toint8orzero).
+- [`toInt8OrDefault`](#toint8ordefault).
+
+## toInt8OrDefault
+
+Like [`toInt8`](#toint8), takes an argument of type [String](../data-types/string.md) and tries to parse it to type `Int8`. If unsuccessful, returns the default type value.
+
+**Syntax**
+
+```sql
+toInt8OrDefault(expr, def)
+```
+
+**Arguments**
+
+- `expr` — Expression returning a number or a string with the decimal representation of a number. [Expression](../syntax.md/#syntax-expressions) / [String](../data-types/string.md).
+- `def` — The default value to return if parsing to type `Int8` is unsuccessful. [Int8](../data-types/int-uint.md).
+
+:::note
+Binary, octal, and hexadecimal representations of numbers are not supported. Leading zeroes are stripped.
+:::
+
+**Returned value**
+
+- 8-bit integer value if successful, otherwise returns the default value. [Int8](../data-types/int-uint.md).
+
+:::note
+- Function uses [rounding towards zero](https://en.wikipedia.org/wiki/Rounding#Rounding_towards_zero), meaning it truncates fractional digits of numbers.
+- The default value type should be the same as the cast type.
+:::
+
+:::danger
+An exception is thrown for [NaN and Inf](../data-types/float.md/#data_type-float-nan-inf) arguments. Keep in mind [numeric conversions issues](#common-issues-with-data-conversion), when using this function.
+:::
 
 **Example**
 
 Query:
 
 ``` sql
-SELECT toInt64OrNull('123123'), toInt8OrNull('123qwe123');
+SELECT
+    toInt8OrDefault('-8', CAST('-1', 'Int8')),
+    toInt8OrDefault('abc', CAST('-1', 'Int8'));
 ```
 
 Result:
 
 ```response
-┌─toInt64OrNull('123123')─┬─toInt8OrNull('123qwe123')─┐
-│                  123123 │                      ᴺᵁᴸᴸ │
-└─────────────────────────┴───────────────────────────┘
+   ┌─toInt8OrDefault('-8', CAST('-1', 'Int8'))─┬─toInt8OrDefault('abc', CAST('-1', 'Int8'))─┐
+1. │                                        -8 │                                         -1 │
+   └───────────────────────────────────────────┴────────────────────────────────────────────┘
 ```
 
-## toInt(8\|16\|32\|64\|128\|256)OrDefault
+**See also**
 
-It takes an argument of type String and tries to parse it into Int (8 \| 16 \| 32 \| 64 \| 128 \| 256). If unsuccessful, returns the default type value.
+- [`toInt8`](#toint8).
+- [`toInt8OrZero`](#toint8orzero).
+- [`toInt8OrNull`](#toint8orNull).
+
+## toInt16
+
+Converts an input value to a value of type `Int16`.
+
+**Syntax**
+
+```sql
+toInt16(expr)
+```
+
+**Arguments**
+
+- `expr` — Expression returning a number or a string with the decimal representation of a number. [Expression](../syntax.md/#syntax-expressions).
+
+:::note
+Binary, octal, and hexadecimal representations of numbers are not supported. Leading zeroes are stripped.
+:::
+
+**Returned value**
+
+- 16-bit integer value. [Int16](../data-types/int-uint.md).
+
+:::note
+Function uses [rounding towards zero](https://en.wikipedia.org/wiki/Rounding#Rounding_towards_zero), meaning it truncates fractional digits of numbers.
+:::
+
+:::danger
+An exception is thrown for [NaN and Inf](../data-types/float.md/#data_type-float-nan-inf) arguments. Keep in mind [numeric conversions issues](#common-issues-with-data-conversion), when using this function.
+:::
+
+**Example**
+
+Query:
+
+```sql
+SELECT
+    toInt16(-16),
+    toInt16(-16.16),
+    toInt16('-16');
+```
+
+Result:
+
+```response
+   ┌─toInt16(-16)─┬─toInt16(-16.16)─┬─toInt16('-16')─┐
+1. │          -16 │             -16 │            -16 │
+   └──────────────┴─────────────────┴────────────────┘
+```
+
+**See also**
+
+- [`toInt16OrZero`](#toint16orzero).
+- [`toInt16OrNull`](#toint16ornull).
+- [`toInt16OrDefault`](#toint16ordefault).
+
+## toInt16OrZero
+
+Like [`toInt16`](#toint16), takes an argument of type [String](../data-types/string.md) and tries to parse it to type `Int16`. If unsuccessful, returns `0`.
+
+**Syntax**
+
+```sql
+toInt16OrZero(expr)
+```
+
+**Arguments**
+
+- `expr` — Expression returning a number or a string with the decimal representation of a number. [Expression](../syntax.md/#syntax-expressions) / [String](../data-types/string.md).
+
+:::note
+Binary, octal, and hexadecimal representations of numbers are not supported. Leading zeroes are stripped.
+:::
+
+**Returned value**
+
+- 16-bit integer value if successful, otherwise `0`. [Int16](../data-types/int-uint.md).
+
+:::note
+Function uses [rounding towards zero](https://en.wikipedia.org/wiki/Rounding#Rounding_towards_zero), meaning it truncates fractional digits of numbers.
+:::
+
+:::danger
+An exception is thrown for [NaN and Inf](../data-types/float.md/#data_type-float-nan-inf) arguments. Keep in mind [numeric conversions issues](#common-issues-with-data-conversion), when using this function.
+:::
 
 **Example**
 
 Query:
 
 ``` sql
-SELECT toInt64OrDefault('123123', cast('-1' as Int64)), toInt8OrDefault('123qwe123', cast('-1' as Int8));
+SELECT
+    toInt16OrZero('-16'),
+    toInt16OrZero('abc');
 ```
 
 Result:
 
 ```response
-┌─toInt64OrDefault('123123', CAST('-1', 'Int64'))─┬─toInt8OrDefault('123qwe123', CAST('-1', 'Int8'))─┐
-│                                          123123 │                                               -1 │
-└─────────────────────────────────────────────────┴──────────────────────────────────────────────────┘
+   ┌─toInt16OrZero('-16')─┬─toInt16OrZero('abc')─┐
+1. │                  -16 │                    0 │
+   └──────────────────────┴──────────────────────┘
 ```
 
+**See also**
+
+- [`toInt16`](#toint16).
+- [`toInt16OrNull`](#toint16ornull).
+- [`toInt16OrDefault`](#toint16ordefault).
+
+## toInt16OrNull
+
+Like [`toInt16`](#toint16), takes an argument of type [String](../data-types/string.md) and tries to parse it to type `Int16`. If unsuccessful, returns `NULL`.
+
+**Syntax**
+
+```sql
+toInt16OrNull(expr)
+```
+
+**Arguments**
+
+- `expr` — Expression returning a number or a string with the decimal representation of a number. [Expression](../syntax.md/#syntax-expressions) / [String](../data-types/string.md).
+
+:::note
+Binary, octal, and hexadecimal representations of numbers are not supported. Leading zeroes are stripped.
+:::
+
+**Returned value**
+
+- 16-bit integer value if successful, otherwise `NULL`. [Int16](../data-types/int-uint.md) / [NULL](../data-types/nullable.md).
+
+:::note
+Function uses [rounding towards zero](https://en.wikipedia.org/wiki/Rounding#Rounding_towards_zero), meaning it truncates fractional digits of numbers.
+:::
+
+:::danger
+An exception is thrown for [NaN and Inf](../data-types/float.md/#data_type-float-nan-inf) arguments. Keep in mind [numeric conversions issues](#common-issues-with-data-conversion), when using this function.
+:::
+
+**Example**
+
+Query:
+
+``` sql
+SELECT
+    toInt16OrNull('-16'),
+    toInt16OrNull('abc');
+```
+
+Result:
+
+```response
+   ┌─toInt16OrNull('-16')─┬─toInt16OrNull('abc')─┐
+1. │                  -16 │                 ᴺᵁᴸᴸ │
+   └──────────────────────┴──────────────────────┘
+```
+
+**See also**
+
+- [`toInt16`](#toint16).
+- [`toInt16OrZero`](#toint16orzero).
+- [`toInt16OrDefault`](#toint16ordefault).
+
+## toInt16OrDefault
+
+Like [`toInt16`](#toint16), takes an argument of type [String](../data-types/string.md) and tries to parse it to type `Int16`. If unsuccessful, returns the default type value.
+
+**Syntax**
+
+```sql
+toInt16OrDefault(expr, def)
+```
+
+**Arguments**
+
+- `expr` — Expression returning a number or a string with the decimal representation of a number. [Expression](../syntax.md/#syntax-expressions) / [String](../data-types/string.md).
+- `def` — The default value to return if parsing to type `Int16` is unsuccessful. [Int8](../data-types/int-uint.md).
+
+:::note
+Binary, octal, and hexadecimal representations of numbers are not supported. Leading zeroes are stripped.
+:::
+
+**Returned value**
+
+- 16-bit integer value if successful, otherwise returns the default value. [Int16](../data-types/int-uint.md).
+
+:::note
+- Function uses [rounding towards zero](https://en.wikipedia.org/wiki/Rounding#Rounding_towards_zero), meaning it truncates fractional digits of numbers.
+- The default value type should be the same as the cast type.
+:::
+
+:::danger
+An exception is thrown for [NaN and Inf](../data-types/float.md/#data_type-float-nan-inf) arguments. Keep in mind [numeric conversions issues](#common-issues-with-data-conversion), when using this function.
+:::
+
+**Example**
+
+Query:
+
+``` sql
+SELECT toInt16OrDefault('-16', cast('-1' as Int16)), toInt16OrDefault('abc', cast('-1' as Int16));
+```
+
+Result:
+
+```response
+   ┌─toInt16OrDefault('-16', CAST('-1', 'Int16'))─┬─toInt16OrDefault('abc', CAST('-1', 'Int16'))─┐
+1. │                                          -16 │                                           -1 │
+   └──────────────────────────────────────────────┴──────────────────────────────────────────────┘
+```
+
+**See also**
+
+- [`toInt16`](#toint16).
+- [`toInt16OrZero`](#toint16orzero).
+- [`toInt16OrNull`](#toint16ornull).
+
+## toInt32
+
+Converts an input value to a value of type `Int32`.
+
+**Syntax**
+
+```sql
+toInt32(expr)
+```
+
+**Arguments**
+
+- `expr` — Expression returning a number or a string with the decimal representation of a number. [Expression](../syntax.md/#syntax-expressions).
+
+:::note
+Binary, octal, and hexadecimal representations of numbers are not supported. Leading zeroes are stripped.
+:::
+
+**Returned value**
+
+- 32-bit integer value. [Int32](../data-types/int-uint.md).
+
+:::note
+Function uses [rounding towards zero](https://en.wikipedia.org/wiki/Rounding#Rounding_towards_zero), meaning it truncates fractional digits of numbers.
+:::
+
+:::danger
+An exception is thrown for [NaN and Inf](../data-types/float.md/#data_type-float-nan-inf) arguments. Keep in mind [numeric conversions issues](#common-issues-with-data-conversion), when using this function.
+:::
+
+**Example**
+
+Query:
+
+```sql
+SELECT
+    toInt32(-32),
+    toInt32(-32.32),
+    toInt32('-32')
+```
+
+Result:
+
+```response
+   ┌─toInt32(-32)─┬─toInt32(-32.32)─┬─toInt32('-32')─┐
+1. │          -32 │             -32 │            -32 │
+   └──────────────┴─────────────────┴────────────────┘
+```
+
+**See also**
+
+- [`toInt32OrZero`](#toint32orzero).
+- [`toInt32OrNull`](#toint32ornull).
+- [`toInt32OrDefault`](#toint32ordefault).
+
+## toInt32OrZero
+
+Like [`toInt32`](#toint32), takes an argument of type [String](../data-types/string.md) and tries to parse it to type `Int32`. If unsuccessful, returns `0`.
+
+**Syntax**
+
+```sql
+toInt32OrZero(expr)
+```
+
+**Arguments**
+
+- `expr` — Expression returning a number or a string with the decimal representation of a number. [Expression](../syntax.md/#syntax-expressions) / [String](../data-types/string.md).
+
+:::note
+Binary, octal, and hexadecimal representations of numbers are not supported. Leading zeroes are stripped.
+:::
+
+**Returned value**
+
+- 32-bit integer value if successful, otherwise `0`. [Int32](../data-types/int-uint.md)
+
+:::note
+Function uses [rounding towards zero](https://en.wikipedia.org/wiki/Rounding#Rounding_towards_zero), meaning it truncate fractional digits of numbers.
+:::
+
+:::danger
+An exception is thrown for [NaN and Inf](../data-types/float.md/#data_type-float-nan-inf) arguments. Keep in mind [numeric conversions issues](#common-issues-with-data-conversion), when using this function.
+:::
+
+**Example**
+
+Query:
+
+``` sql
+SELECT toInt32OrZero('-32'), toInt32OrZero('abc');
+```
+
+Result:
+
+```response
+   ┌─toInt32OrZero('-32')─┬─toInt32OrZero('abc')─┐
+1. │                  -32 │                    0 │
+   └──────────────────────┴──────────────────────┘
+```
+**See also**
+
+- [`toInt32`](#toint32).
+- [`toInt32OrNull`](#toint32ornull).
+- [`toInt32OrDefault`](#toint32ordefault).
+- 
+## toInt32OrNull
+
+Like [`toInt32`](#toint32), takes an argument of type [String](../data-types/string.md) and tries to parse it to type `Int32`. If unsuccessful, returns `NULL`.
+
+**Syntax**
+
+```sql
+toInt32OrNull(expr)
+```
+
+**Arguments**
+
+- `expr` — Expression returning a number or a string with the decimal representation of a number. [Expression](../syntax.md/#syntax-expressions) / [String](../data-types/string.md).
+
+:::note
+Binary, octal, and hexadecimal representations of numbers are not supported. Leading zeroes are stripped.
+:::
+
+**Returned value**
+
+- 32-bit integer value if successful, otherwise `NULL`. [Int32](../data-types/int-uint.md) / [NULL](../data-types/nullable.md).
+
+:::note
+Function uses [rounding towards zero](https://en.wikipedia.org/wiki/Rounding#Rounding_towards_zero), meaning it truncates fractional digits of numbers.
+:::
+
+:::danger
+An exception is thrown for [NaN and Inf](../data-types/float.md/#data_type-float-nan-inf) arguments. Keep in mind [numeric conversions issues](#common-issues-with-data-conversion), when using this function.
+:::
+
+**Example**
+
+Query:
+
+``` sql
+SELECT toInt32OrNull('-32'), toInt32OrNull('abc');
+```
+
+Result:
+
+```response
+   ┌─toInt32OrNull('-32')─┬─toInt32OrNull('abc')─┐
+1. │                  -32 │                 ᴺᵁᴸᴸ │
+   └──────────────────────┴──────────────────────┘
+```
+
+**See also**
+
+- [`toInt32`](#toint32).
+- [`toInt32OrZero`](#toint32orzero).
+- [`toInt32OrDefault`](#toint32ordefault).
+
+## toInt32OrDefault
+
+Like [`toInt32`](#toint32), takes an argument of type [String](../data-types/string.md) and tries to parse it to type `Int32`. If unsuccessful, returns the default type value.
+
+**Syntax**
+
+```sql
+toInt32OrDefault(expr, def)
+```
+
+**Arguments**
+
+- `expr` — Expression returning a number or a string with the decimal representation of a number. [Expression](../syntax.md/#syntax-expressions) / [String](../data-types/string.md).
+- `def` — The default value to return if parsing to type `Int32` is unsuccessful. [Int32](../data-types/int-uint.md).
+
+:::note
+Binary, octal, and hexadecimal representations of numbers are not supported. Leading zeroes are stripped.
+:::
+
+**Returned value**
+
+- 32-bit integer value if successful, otherwise returns the default value. [Int32](../data-types/int-uint.md).
+
+:::note
+- Function uses [rounding towards zero](https://en.wikipedia.org/wiki/Rounding#Rounding_towards_zero), meaning it truncates fractional digits of numbers.
+- The default value type should be the same as the cast type.
+  :::
+
+:::danger
+An exception is thrown for [NaN and Inf](../data-types/float.md/#data_type-float-nan-inf) arguments. Keep in mind [numeric conversions issues](#common-issues-with-data-conversion), when using this function.
+:::
+
+**Example**
+
+Query:
+
+``` sql
+SELECT toInt32OrDefault('-32', cast('-1' as Int32)), toInt32OrDefault('abc', cast('-1' as Int32));
+```
+
+Result:
+
+```response
+   ┌─toInt32OrDefault('-32', CAST('-1', 'Int32'))─┬─toInt32OrDefault('abc', CAST('-1', 'Int32'))─┐
+1. │                                          -32 │                                           -1 │
+   └──────────────────────────────────────────────┴──────────────────────────────────────────────┘
+```
+
+**See also**
+
+- [`toInt32`](#toint32).
+- [`toInt32OrZero`](#toint32orzero).
+- [`toInt32OrNull`](#toint32ornull).
+
+## toInt64
+
+Converts an input value to a value of type `Int64`.
+
+**Syntax**
+
+```sql
+toInt64(expr)
+```
+
+**Arguments**
+
+- `expr` — Expression returning a number or a string with the decimal representation of a number. [Expression](../syntax.md/#syntax-expressions).
+
+:::note
+Binary, octal, and hexadecimal representations of numbers are not supported. Leading zeroes are stripped.
+:::
+
+**Returned value**
+
+- 64-bit integer value. [Int64](../data-types/int-uint.md). [Int64](../data-types/int-uint.md).
+
+:::note
+Function uses [rounding towards zero](https://en.wikipedia.org/wiki/Rounding#Rounding_towards_zero), meaning it truncates fractional digits of numbers.
+:::
+
+:::danger
+An exception is thrown for [NaN and Inf](../data-types/float.md/#data_type-float-nan-inf) arguments. Keep in mind [numeric conversions issues](#common-issues-with-data-conversion), when using this function.
+:::
+
+**Example**
+
+Query:
+
+```sql
+SELECT
+    toInt64(-64),
+    toInt64(-64.64),
+    toInt64('-64');
+```
+
+Result:
+
+```response
+   ┌─toInt64(-64)─┬─toInt64(-64.64)─┬─toInt64('-64')─┐
+1. │          -64 │             -64 │            -64 │
+   └──────────────┴─────────────────┴────────────────┘
+```
+
+**See also**
+
+- [`toInt64OrZero`](#toint64orzero).
+- [`toInt64OrNull`](#toint64ornull).
+- [`toInt64OrDefault`](#toint64ordefault).
+
+## toInt64OrZero
+
+Like [`toInt64`](#toint64), takes an argument of type [String](../data-types/string.md) and tries to parse it to type `Int64`. If unsuccessful, returns `0`.
+
+**Syntax**
+
+```sql
+toInt64OrZero(expr)
+```
+
+**Arguments**
+
+- `expr` — Expression returning a number or a string with the decimal representation of a number. [Expression](../syntax.md/#syntax-expressions) / [String](../data-types/string.md).
+
+:::note
+Binary, octal, and hexadecimal representations of numbers are not supported. Leading zeroes are stripped.
+:::
+
+**Returned value**
+
+- 64-bit integer value if successful, otherwise `0`. [Int64](../data-types/int-uint.md).
+
+:::note
+Function uses [rounding towards zero](https://en.wikipedia.org/wiki/Rounding#Rounding_towards_zero), meaning it truncates fractional digits of numbers.
+:::
+
+:::danger
+An exception is thrown for [NaN and Inf](../data-types/float.md/#data_type-float-nan-inf) arguments. Keep in mind [numeric conversions issues](#common-issues-with-data-conversion), when using this function.
+:::
+
+**Example**
+
+Query:
+
+``` sql
+SELECT
+    toInt64OrZero('-64'),
+    toInt64OrZero('abc');
+```
+
+Result:
+
+```response
+   ┌─toInt64OrZero('-64')─┬─toInt64OrZero('abc')─┐
+1. │                  -64 │                    0 │
+   └──────────────────────┴──────────────────────┘
+```
+
+**See also**
+
+- [`toInt64`](#toint64).
+- [`toInt64OrNull`](#toint64ornull).
+- [`toInt64OrDefault`](#toint64ordefault).
+
+## toInt64OrNull
+
+Like [`toInt64`], takes an argument of type [String](../data-types/string.md) and tries to parse it to type `Int64`. If unsuccessful, returns `NULL`.
+
+**Syntax**
+
+```sql
+toInt64OrNull(expr)
+```
+
+**Arguments**
+
+- `expr` — Expression returning a number or a string with the decimal representation of a number. [Expression](../syntax.md/#syntax-expressions) / [String](../data-types/string.md).
+
+:::note
+Binary, octal, and hexadecimal representations of numbers are not supported. Leading zeroes are stripped.
+:::
+
+**Returned value**
+
+- Integer value of type `Int64` if successful, otherwise `NULL`. [Int64](../data-types/int-uint.md) / [NULL](../data-types/nullable.md).
+
+:::note
+Function uses [rounding towards zero](https://en.wikipedia.org/wiki/Rounding#Rounding_towards_zero), meaning it truncates fractional digits of numbers.
+:::
+
+:::danger
+An exception is thrown for [NaN and Inf](../data-types/float.md/#data_type-float-nan-inf) arguments. Keep in mind [numeric conversions issues](#common-issues-with-data-conversion), when using this function.
+:::
+
+**Example**
+
+Query:
+
+``` sql
+SELECT
+    toInt64OrNull('-64'),
+    toInt64OrNull('abc');
+```
+
+Result:
+
+```response
+   ┌─toInt64OrNull('-64')─┬─toInt64OrNull('abc')─┐
+1. │                  -64 │                 ᴺᵁᴸᴸ │
+   └──────────────────────┴──────────────────────┘
+```
+
+**See also**
+
+- [`toInt64`](#toint64).
+- [`toInt64OrZero`](#toint64orzero).
+- [`toInt64OrDefault`](#toint64ordefault).
+
+## toInt64OrDefault
+
+Like [`toInt64`](#toint64), takes an argument of type [String](../data-types/string.md) and tries to parse it to type `Int64`. If unsuccessful, returns the default type value.
+
+**Syntax**
+
+```sql
+toInt64OrDefault(expr, def)
+```
+
+**Arguments**
+
+- `expr` — Expression returning a number or a string with the decimal representation of a number. [Expression](../syntax.md/#syntax-expressions) / [String](../data-types/string.md).
+- `def` — The default value to return if parsing to type `Int64` is unsuccessful. [Int64](../data-types/int-uint.md).
+
+:::note
+Binary, octal, and hexadecimal representations of numbers are not supported. Leading zeroes are stripped.
+:::
+
+**Returned value**
+
+- Integer value of type `Int64` if successful, otherwise returns the default value. [Int64](../data-types/int-uint.md).
+
+:::note
+- Function uses [rounding towards zero](https://en.wikipedia.org/wiki/Rounding#Rounding_towards_zero), meaning it truncates fractional digits of numbers.
+- The default value type should be the same as the cast type.
+  :::
+
+:::danger
+An exception is thrown for [NaN and Inf](../data-types/float.md/#data_type-float-nan-inf) arguments. Keep in mind [numeric conversions issues](#common-issues-with-data-conversion), when using this function.
+:::
+
+**Example**
+
+Query:
+
+``` sql
+SELECT
+    toInt64OrDefault('-64', CAST('-1', 'Int64')),
+    toInt64OrDefault('abc', CAST('-1', 'Int64'));
+```
+
+Result:
+
+```response
+   ┌─toInt64OrDefault('-64', CAST('-1', 'Int64'))─┬─toInt64OrDefault('abc', CAST('-1', 'Int64'))─┐
+1. │                                          -64 │                                           -1 │
+   └──────────────────────────────────────────────┴──────────────────────────────────────────────┘
+```
+
+**See also**
+
+- [`toInt64`](#toint64).
+- [`toInt64OrZero`](#toint64orzero).
+- [`toInt64OrNull`](#toint64ornull).
+
+## toInt128
+
+Converts an input value to a value of type `Int128`.
+
+**Syntax**
+
+```sql
+toInt128(expr)
+```
+
+**Arguments**
+
+- `expr` — Expression returning a number or a string with the decimal representation of a number. [Expression](../syntax.md/#syntax-expressions).
+
+:::note
+Binary, octal, and hexadecimal representations of numbers are not supported. Leading zeroes are stripped.
+:::
+
+**Returned value**
+
+- 128-bit integer value. [Int128](../data-types/int-uint.md).
+
+:::note
+Function uses [rounding towards zero](https://en.wikipedia.org/wiki/Rounding#Rounding_towards_zero), meaning it truncates fractional digits of numbers.
+:::
+
+:::danger
+An exception is thrown for [NaN and Inf](../data-types/float.md/#data_type-float-nan-inf) arguments. Keep in mind [numeric conversions issues](#common-issues-with-data-conversion), when using this function.
+:::
+
+**Example**
+
+Query:
+
+```sql
+SELECT
+    toInt128(-128),
+    toInt128(-128.8),
+    toInt128('-128'),
+```
+
+Result:
+
+```response
+   ┌─toInt128(-128)─┬─toInt128(-128.8)─┬─toInt128('-128')─┐
+1. │           -128 │             -128 │             -128 │
+   └────────────────┴──────────────────┴──────────────────┘
+```
+
+**See also**
+
+- [`toInt128OrZero`](#toint128orzero).
+- [`toInt128OrNull`](#toint128ornull).
+- [`toInt128OrDefault`](#toint128ordefault).
+
+## toInt128OrZero
+
+Like [`toInt128`](#toint128), takes an argument of type [String](../data-types/string.md) and tries to parse it to type `Int128`. If unsuccessful, returns `0`.
+
+**Syntax**
+
+```sql
+toInt128OrZero(expr)
+```
+
+**Arguments**
+
+- `expr` — Expression returning a number or a string with the decimal representation of a number. [Expression](../syntax.md/#syntax-expressions) / [String](../data-types/string.md).
+
+:::note
+Binary, octal, and hexadecimal representations of numbers are not supported. Leading zeroes are stripped.
+:::
+
+**Returned value**
+
+- 128-bit integer value if successful, otherwise `0`. [Int128](../data-types/int-uint.md).
+
+:::note
+Function uses [rounding towards zero](https://en.wikipedia.org/wiki/Rounding#Rounding_towards_zero), meaning it truncates fractional digits of numbers.
+:::
+
+:::danger
+An exception is thrown for [NaN and Inf](../data-types/float.md/#data_type-float-nan-inf) arguments. Keep in mind [numeric conversions issues](#common-issues-with-data-conversion), when using this function.
+:::
+
+**Example**
+
+Query:
+
+``` sql
+SELECT
+    toInt128OrZero('-128'),
+    toInt128OrZero('abc');
+```
+
+Result:
+
+```response
+   ┌─toInt128OrZero('-128')─┬─toInt128OrZero('abc')─┐
+1. │                   -128 │                     0 │
+   └────────────────────────┴───────────────────────┘
+```
+
+**See also**
+
+- [`toInt128`](#toint128).
+- [`toInt128OrNull`](#toint128ornull).
+- [`toInt128OrDefault`](#toint128ordefault).
+
+## toInt128OrNull
+
+Like [`toInt128`](#toint128), takes an argument of type [String](../data-types/string.md) and tries to parse it to type `Int128`. If unsuccessful, returns `NULL`.
+
+**Syntax**
+
+```sql
+toInt128OrNull(expr)
+```
+
+**Arguments**
+
+- `expr` — Expression returning a number or a string with the decimal representation of a number. [Expression](../syntax.md/#syntax-expressions) / [String](../data-types/string.md).
+
+:::note
+Binary, octal, and hexadecimal representations of numbers are not supported. Leading zeroes are stripped.
+:::
+
+**Returned value**
+
+- 128-bit integer value if successful, otherwise `NULL`. [Int128](../data-types/int-uint.md) / [NULL](../data-types/nullable.md).
+
+:::note
+Function uses [rounding towards zero](https://en.wikipedia.org/wiki/Rounding#Rounding_towards_zero), meaning it truncates fractional digits of numbers.
+:::
+
+:::danger
+An exception is thrown for [NaN and Inf](../data-types/float.md/#data_type-float-nan-inf) arguments. Keep in mind [numeric conversions issues](#common-issues-with-data-conversion), when using this function.
+:::
+
+**Example**
+
+Query:
+
+``` sql
+SELECT
+    toInt128OrNull('-128'),
+    toInt128OrNull('abc');
+```
+
+Result:
+
+```response
+   ┌─toInt128OrNull('-128')─┬─toInt128OrNull('abc')─┐
+1. │                   -128 │                  ᴺᵁᴸᴸ │
+   └────────────────────────┴───────────────────────┘
+```
+
+**See also**
+
+- [`toInt128`](#toint128).
+- [`toInt128OrZero`](#toint128orzero).
+- [`toInt128OrDefault`](#toint128ordefault).
+
+## toInt128OrDefault
+
+Like [`toInt128`](#toint128), takes an argument of type [String](../data-types/string.md) and tries to parse it to type `Int128`. If unsuccessful, returns the default type value.
+
+**Syntax**
+
+```sql
+toInt128OrDefault(expr, def)
+```
+
+**Arguments**
+
+- `expr` — Expression returning a number or a string with the decimal representation of a number. [Expression](../syntax.md/#syntax-expressions) / [String](../data-types/string.md).
+- `def` — The default value to return if parsing to type `Int128` is unsuccessful. [Int128](../data-types/int-uint.md).
+
+:::note
+Binary, octal, and hexadecimal representations of numbers are not supported. Leading zeroes are stripped.
+:::
+
+**Returned value**
+
+- 128-bit integer value if successful, otherwise returns the default value. [Int128](../data-types/int-uint.md).
+
+:::note
+- Function uses [rounding towards zero](https://en.wikipedia.org/wiki/Rounding#Rounding_towards_zero), meaning it truncates fractional digits of numbers.
+- The default value type should be the same as the cast type.
+:::
+
+:::danger
+An exception is thrown for [NaN and Inf](../data-types/float.md/#data_type-float-nan-inf) arguments. Keep in mind [numeric conversions issues](#common-issues-with-data-conversion), when using this function.
+:::
+
+**Example**
+
+Query:
+
+``` sql
+SELECT
+    toInt128OrDefault('-128', CAST('-1', 'Int128')),
+    toInt128OrDefault('abc', CAST('-1', 'Int128'));
+```
+
+Result:
+
+```response
+   ┌─toInt128OrDefault('-128', CAST('-1', 'Int128'))─┬─toInt128OrDefault('abc', CAST('-1', 'Int128'))─┐
+1. │                                            -128 │                                             -1 │
+   └─────────────────────────────────────────────────┴────────────────────────────────────────────────┘
+```
+
+**See also**
+
+- [`toInt128`](#toint128).
+- [`toInt128OrZero`](#toint128orzero).
+- [`toInt128OrNull`](#toint128ornull).
+
+## toInt256
+
+Converts an input value to a value of type `Int256`.
+
+**Syntax**
+
+```sql
+toInt256(expr)
+```
+
+**Arguments**
+
+- `expr` — Expression returning a number or a string with the decimal representation of a number. [Expression](../syntax.md/#syntax-expressions).
+
+:::note
+Binary, octal, and hexadecimal representations of numbers are not supported. Leading zeroes are stripped.
+:::
+
+**Returned value**
+
+- 256-bit integer value. [Int256](../data-types/int-uint.md).
+
+:::note
+Function uses [rounding towards zero](https://en.wikipedia.org/wiki/Rounding#Rounding_towards_zero), meaning it truncates fractional digits of numbers.
+:::
+
+:::danger
+An exception is thrown for [NaN and Inf](../data-types/float.md/#data_type-float-nan-inf) arguments. Keep in mind [numeric conversions issues](#common-issues-with-data-conversion), when using this function.
+:::
+
+**Example**
+
+Query:
+
+```sql
+SELECT
+    toInt256(-256),
+    toInt256(-256.256),
+    toInt256('-256');
+```
+
+Result:
+
+```response
+   ┌─toInt256(-256)─┬─toInt256(-256.256)─┬─toInt256('-256')─┐
+1. │           -256 │               -256 │             -256 │
+   └────────────────┴────────────────────┴──────────────────┘
+```
+
+**See also**
+
+- [`toInt256OrZero`](#toint256orzero).
+- [`toInt256OrNull`](#toint256ornull).
+- [`toInt256OrDefault`](#toint256ordefault).
+
+## toInt256OrZero
+
+Like [`toInt256`](#toint256), takes an argument of type [String](../data-types/string.md) and tries to parse it to type `Int256`. If unsuccessful, returns `0`.
+
+**Syntax**
+
+```sql
+toInt256OrZero(expr)
+```
+
+**Arguments**
+
+- `expr` — Expression returning a number or a string with the decimal representation of a number. [Expression](../syntax.md/#syntax-expressions) / [String](../data-types/string.md).
+
+:::note
+Binary, octal, and hexadecimal representations of numbers are not supported. Leading zeroes are stripped.
+:::
+
+**Returned value**
+
+- 256-bit integer value if successful, otherwise `0`. [Int256](../data-types/int-uint.md).
+
+:::note
+Functions uses [rounding towards zero](https://en.wikipedia.org/wiki/Rounding#Rounding_towards_zero), meaning it truncates fractional digits of numbers.
+:::
+
+:::danger
+An exception is thrown for [NaN and Inf](../data-types/float.md/#data_type-float-nan-inf) arguments. Keep in mind [numeric conversions issues](#common-issues-with-data-conversion), when using this function.
+:::
+
+**Example**
+
+Query:
+
+``` sql
+SELECT
+    toInt256OrZero('-256'),
+    toInt256OrZero('abc');
+```
+
+Result:
+
+```response
+   ┌─toInt256OrZero('-256')─┬─toInt256OrZero('abc')─┐
+1. │                   -256 │                     0 │
+   └────────────────────────┴───────────────────────┘
+```
+
+**See also**
+
+- [`toInt256`](#toint256).
+- [`toInt256OrNull`](#toint256ornull).
+- [`toInt256OrDefault`](#toint256ordefault).
+
+## toInt256OrNull
+
+Like [`toInt256`](#toint256), takes an argument of type [String](../data-types/string.md) and tries to parse it to type `Int256`. If unsuccessful, returns `NULL`.
+
+**Syntax**
+
+```sql
+toInt256OrNull(expr)
+```
+
+**Arguments**
+
+- `expr` — Expression returning a number or a string with the decimal representation of a number. [Expression](../syntax.md/#syntax-expressions) / [String](../data-types/string.md).
+
+:::note
+Binary, octal, and hexadecimal representations of numbers are not supported. Leading zeroes are stripped.
+:::
+
+**Returned value**
+
+- 256-bit integer value if successful, otherwise `NULL`. [Int256](../data-types/int-uint.md) / [NULL](../data-types/nullable.md).
+
+:::note
+Function uses [rounding towards zero](https://en.wikipedia.org/wiki/Rounding#Rounding_towards_zero), meaning it truncates fractional digits of numbers.
+:::
+
+:::danger
+An exception is thrown for [NaN and Inf](../data-types/float.md/#data_type-float-nan-inf) arguments. Keep in mind [numeric conversions issues](#common-issues-with-data-conversion), when using this function.
+:::
+
+**Example**
+
+Query:
+
+``` sql
+SELECT
+    toInt256OrNull('-256'),
+    toInt256OrNull('abc');
+```
+
+Result:
+
+```response
+   ┌─toInt256OrNull('-256')─┬─toInt256OrNull('abc')─┐
+1. │                   -256 │                  ᴺᵁᴸᴸ  │
+   └────────────────────────┴───────────────────────┘
+```
+
+**See also**
+
+- [`toInt256`](#toint256).
+- [`toInt256OrZero`](#toint256orzero).
+- [`toInt256OrDefault`](#toint256ordefault).
+
+## toInt256OrDefault
+
+Like [`toInt256`](#toint256), takes an argument of type [String](../data-types/string.md) and tries to parse it to type `Int256`. If unsuccessful, returns the default type value.
+
+**Syntax**
+
+```sql
+toInt256OrDefault(expr, def)
+```
+
+**Arguments**
+
+- `expr` — Expression returning a number or a string with the decimal representation of a number. [Expression](../syntax.md/#syntax-expressions) / [String](../data-types/string.md).
+- `def` — The default value to return if parsing to type `Int256` is unsuccessful. [Int256](../data-types/int-uint.md).
+
+:::note
+Binary, octal, and hexadecimal representations of numbers are not supported. Leading zeroes are stripped.
+:::
+
+**Returned value**
+
+- 256-bit integer value if successful, otherwise returns the default value. [Int256](../data-types/int-uint.md).
+
+:::note
+- Function uses [rounding towards zero](https://en.wikipedia.org/wiki/Rounding#Rounding_towards_zero), meaning it truncates fractional digits of numbers.
+- The default value type should be the same as the cast type.
+:::
+
+:::danger
+An exception is thrown for [NaN and Inf](../data-types/float.md/#data_type-float-nan-inf) arguments. Keep in mind [numeric conversions issues](#common-issues-with-data-conversion), when using this function.
+:::
+
+**Example**
+
+Query:
+
+``` sql
+SELECT
+    toInt256OrDefault('-256', CAST('-1', 'Int256')),
+    toInt256OrDefault('abc', CAST('-1', 'Int256'));
+```
+
+Result:
+
+```response
+   ┌─toInt256OrDefault('-256', CAST('-1', 'Int256'))─┬─toInt256OrDefault('abc', CAST('-1', 'Int256'))─┐
+1. │                                            -256 │                                             -1 │
+   └─────────────────────────────────────────────────┴────────────────────────────────────────────────┘
+```
+
+**See also**
+
+- [`toInt256`](#toint256).
+- [`toInt256OrZero`](#toint256orzero).
+- [`toInt256OrNull`](#toint256ornull).
 
 ## toUInt(8\|16\|32\|64\|256)
 
@@ -167,7 +1370,7 @@ Converts an input value to the [UInt](../data-types/int-uint.md) data type. This
 
 - Integer value in the `UInt8`, `UInt16`, `UInt32`, `UInt64` or `UInt256` data type.
 
-Functions use [rounding towards zero](https://en.wikipedia.org/wiki/Rounding#Rounding_towards_zero), meaning they truncate fractional digits of numbers.
+Functions use [rounding towards zero](https://en.wikipedia.org/wiki/Rounding#Rounding_towards_zero), meaning it truncates fractional digits of numbers.
 
 The behavior of functions for negative arguments and for the [NaN and Inf](../data-types/float.md/#data_type-float-nan-inf) arguments is undefined. If you pass a string with a negative number, for example `'-32'`, ClickHouse raises an exception. Remember about [numeric conversions issues](#common-issues-with-data-conversion), when using the functions.
 
@@ -2289,7 +3492,7 @@ Result:
 └─────────────────────┴─────────────────┴─────────────────────────────────────┘
 ```
 
-**See Also**
+**See also**
 
 - [RFC 1123](https://datatracker.ietf.org/doc/html/rfc1123)
 - [toDate](#todate)


### PR DESCRIPTION
See [#2022](https://github.com/ClickHouse/clickhouse-docs/issues/2022) for making `type conversion` functions more complete. This PR separates out `toInt*` functions and their variants. I will open `toUInt` and `toDecimal` as separate PRs to keep review manageable, this one is already quite large.  

### Changelog category (leave one):
- Documentation (changelog entry is not required)