### PR TITLE
Minor: Make `CaseSensitiveness` an enum class

### DIFF
--- a/src/AggregateFunctions/AggregateFunctionAnalysisOfVariance.cpp
+++ b/src/AggregateFunctions/AggregateFunctionAnalysisOfVariance.cpp
@@ -118,10 +118,10 @@ AggregateFunctionPtr createAggregateFunctionAnalysisOfVariance(const std::string
 void registerAggregateFunctionAnalysisOfVariance(AggregateFunctionFactory & factory)
 {
     AggregateFunctionProperties properties = { .is_order_dependent = false };
-    factory.registerFunction("analysisOfVariance", {createAggregateFunctionAnalysisOfVariance, properties}, AggregateFunctionFactory::CaseInsensitive);
+    factory.registerFunction("analysisOfVariance", {createAggregateFunctionAnalysisOfVariance, properties}, AggregateFunctionFactory::Case::Insensitive);
 
     /// This is widely used term
-    factory.registerAlias("anova", "analysisOfVariance", AggregateFunctionFactory::CaseInsensitive);
+    factory.registerAlias("anova", "analysisOfVariance", AggregateFunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/AggregateFunctions/AggregateFunctionAny.cpp
+++ b/src/AggregateFunctions/AggregateFunctionAny.cpp
@@ -361,9 +361,9 @@ void registerAggregateFunctionsAny(AggregateFunctionFactory & factory)
     AggregateFunctionProperties default_properties = {.returns_default_when_only_null = false, .is_order_dependent = true};
 
     factory.registerFunction("any", {createAggregateFunctionAny, default_properties});
-    factory.registerAlias("any_value", "any", AggregateFunctionFactory::CaseInsensitive);
-    factory.registerAlias("first_value", "any", AggregateFunctionFactory::CaseInsensitive);
+    factory.registerAlias("any_value", "any", AggregateFunctionFactory::Case::Insensitive);
+    factory.registerAlias("first_value", "any", AggregateFunctionFactory::Case::Insensitive);
     factory.registerFunction("anyLast", {createAggregateFunctionAnyLast, default_properties});
-    factory.registerAlias("last_value", "anyLast", AggregateFunctionFactory::CaseInsensitive);
+    factory.registerAlias("last_value", "anyLast", AggregateFunctionFactory::Case::Insensitive);
 }
 }

--- a/src/AggregateFunctions/AggregateFunctionAnyRespectNulls.cpp
+++ b/src/AggregateFunctions/AggregateFunctionAnyRespectNulls.cpp
@@ -221,11 +221,11 @@ void registerAggregateFunctionsAnyRespectNulls(AggregateFunctionFactory & factor
         = {.returns_default_when_only_null = false, .is_order_dependent = true, .is_window_function = true};
 
     factory.registerFunction("any_respect_nulls", {createAggregateFunctionAnyRespectNulls, default_properties_for_respect_nulls});
-    factory.registerAlias("any_value_respect_nulls", "any_respect_nulls", AggregateFunctionFactory::CaseInsensitive);
-    factory.registerAlias("first_value_respect_nulls", "any_respect_nulls", AggregateFunctionFactory::CaseInsensitive);
+    factory.registerAlias("any_value_respect_nulls", "any_respect_nulls", AggregateFunctionFactory::Case::Insensitive);
+    factory.registerAlias("first_value_respect_nulls", "any_respect_nulls", AggregateFunctionFactory::Case::Insensitive);
 
     factory.registerFunction("anyLast_respect_nulls", {createAggregateFunctionAnyLastRespectNulls, default_properties_for_respect_nulls});
-    factory.registerAlias("last_value_respect_nulls", "anyLast_respect_nulls", AggregateFunctionFactory::CaseInsensitive);
+    factory.registerAlias("last_value_respect_nulls", "anyLast_respect_nulls", AggregateFunctionFactory::Case::Insensitive);
 
     /// Must happen after registering any and anyLast
     factory.registerNullsActionTransformation("any", "any_respect_nulls");

--- a/src/AggregateFunctions/AggregateFunctionAvg.cpp
+++ b/src/AggregateFunctions/AggregateFunctionAvg.cpp
@@ -46,6 +46,6 @@ AggregateFunctionPtr createAggregateFunctionAvg(const std::string & name, const 
 
 void registerAggregateFunctionAvg(AggregateFunctionFactory & factory)
 {
-    factory.registerFunction("avg", createAggregateFunctionAvg, AggregateFunctionFactory::CaseInsensitive);
+    factory.registerFunction("avg", createAggregateFunctionAvg, AggregateFunctionFactory::Case::Insensitive);
 }
 }

--- a/src/AggregateFunctions/AggregateFunctionBitwise.cpp
+++ b/src/AggregateFunctions/AggregateFunctionBitwise.cpp
@@ -234,9 +234,9 @@ void registerAggregateFunctionsBitwise(AggregateFunctionFactory & factory)
     factory.registerFunction("groupBitXor", createAggregateFunctionBitwise<AggregateFunctionGroupBitXorData>);
 
     /// Aliases for compatibility with MySQL.
-    factory.registerAlias("BIT_OR", "groupBitOr", AggregateFunctionFactory::CaseInsensitive);
-    factory.registerAlias("BIT_AND", "groupBitAnd", AggregateFunctionFactory::CaseInsensitive);
-    factory.registerAlias("BIT_XOR", "groupBitXor", AggregateFunctionFactory::CaseInsensitive);
+    factory.registerAlias("BIT_OR", "groupBitOr", AggregateFunctionFactory::Case::Insensitive);
+    factory.registerAlias("BIT_AND", "groupBitAnd", AggregateFunctionFactory::Case::Insensitive);
+    factory.registerAlias("BIT_XOR", "groupBitXor", AggregateFunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/AggregateFunctions/AggregateFunctionCorr.cpp
+++ b/src/AggregateFunctions/AggregateFunctionCorr.cpp
@@ -9,7 +9,7 @@ template <typename T1, typename T2> using AggregateFunctionCorr = AggregateFunct
 
 void registerAggregateFunctionsStatisticsCorr(AggregateFunctionFactory & factory)
 {
-    factory.registerFunction("corr", createAggregateFunctionStatisticsBinary<AggregateFunctionCorr, StatisticsFunctionKind::corr>, AggregateFunctionFactory::CaseInsensitive);
+    factory.registerFunction("corr", createAggregateFunctionStatisticsBinary<AggregateFunctionCorr, StatisticsFunctionKind::corr>, AggregateFunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/AggregateFunctions/AggregateFunctionCount.cpp
+++ b/src/AggregateFunctions/AggregateFunctionCount.cpp
@@ -37,7 +37,7 @@ AggregateFunctionPtr createAggregateFunctionCount(const std::string & name, cons
 void registerAggregateFunctionCount(AggregateFunctionFactory & factory)
 {
     AggregateFunctionProperties properties = { .returns_default_when_only_null = true, .is_order_dependent = false };
-    factory.registerFunction("count", {createAggregateFunctionCount, properties}, AggregateFunctionFactory::CaseInsensitive);
+    factory.registerFunction("count", {createAggregateFunctionCount, properties}, AggregateFunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/AggregateFunctions/AggregateFunctionCovar.cpp
+++ b/src/AggregateFunctions/AggregateFunctionCovar.cpp
@@ -13,8 +13,8 @@ void registerAggregateFunctionsStatisticsCovar(AggregateFunctionFactory & factor
     factory.registerFunction("covarPop", createAggregateFunctionStatisticsBinary<AggregateFunctionCovar, StatisticsFunctionKind::covarPop>);
 
     /// Synonyms for compatibility.
-    factory.registerAlias("COVAR_SAMP", "covarSamp", AggregateFunctionFactory::CaseInsensitive);
-    factory.registerAlias("COVAR_POP", "covarPop", AggregateFunctionFactory::CaseInsensitive);
+    factory.registerAlias("COVAR_SAMP", "covarSamp", AggregateFunctionFactory::Case::Insensitive);
+    factory.registerAlias("COVAR_POP", "covarPop", AggregateFunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/AggregateFunctions/AggregateFunctionFactory.cpp
+++ b/src/AggregateFunctions/AggregateFunctionFactory.cpp
@@ -29,7 +29,7 @@ const String & getAggregateFunctionCanonicalNameIfAny(const String & name)
     return AggregateFunctionFactory::instance().getCanonicalNameIfAny(name);
 }
 
-void AggregateFunctionFactory::registerFunction(const String & name, Value creator_with_properties, CaseSensitiveness case_sensitiveness)
+void AggregateFunctionFactory::registerFunction(const String & name, Value creator_with_properties, Case case_sensitiveness)
 {
     if (creator_with_properties.creator == nullptr)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "AggregateFunctionFactory: "
@@ -39,7 +39,7 @@ void AggregateFunctionFactory::registerFunction(const String & name, Value creat
         throw Exception(ErrorCodes::LOGICAL_ERROR, "AggregateFunctionFactory: the aggregate function name '{}' is not unique",
             name);
 
-    if (case_sensitiveness == CaseInsensitive)
+    if (case_sensitiveness == Case::Insensitive)
     {
         auto key = Poco::toLower(name);
         if (!case_insensitive_aggregate_functions.emplace(key, creator_with_properties).second)

--- a/src/AggregateFunctions/AggregateFunctionFactory.h
+++ b/src/AggregateFunctions/AggregateFunctionFactory.h
@@ -60,7 +60,7 @@ public:
     void registerFunction(
         const String & name,
         Value creator,
-        CaseSensitiveness case_sensitiveness = CaseSensitive);
+        Case case_sensitiveness = Case::Sensitive);
 
     /// Register how to transform from one aggregate function to other based on NullsAction
     /// Registers them both ways:

--- a/src/AggregateFunctions/AggregateFunctionGroupArray.cpp
+++ b/src/AggregateFunctions/AggregateFunctionGroupArray.cpp
@@ -840,8 +840,8 @@ void registerAggregateFunctionGroupArray(AggregateFunctionFactory & factory)
     AggregateFunctionProperties properties = { .returns_default_when_only_null = false, .is_order_dependent = true };
 
     factory.registerFunction("groupArray", { createAggregateFunctionGroupArray<false>, properties });
-    factory.registerAlias("array_agg", "groupArray", AggregateFunctionFactory::CaseInsensitive);
-    factory.registerAliasUnchecked("array_concat_agg", "groupArrayArray", AggregateFunctionFactory::CaseInsensitive);
+    factory.registerAlias("array_agg", "groupArray", AggregateFunctionFactory::Case::Insensitive);
+    factory.registerAliasUnchecked("array_concat_agg", "groupArrayArray", AggregateFunctionFactory::Case::Insensitive);
     factory.registerFunction("groupArraySample", { createAggregateFunctionGroupArraySample, properties });
     factory.registerFunction("groupArrayLast", { createAggregateFunctionGroupArray<true>, properties });
 }

--- a/src/AggregateFunctions/AggregateFunctionGroupConcat.cpp
+++ b/src/AggregateFunctions/AggregateFunctionGroupConcat.cpp
@@ -277,7 +277,7 @@ void registerAggregateFunctionGroupConcat(AggregateFunctionFactory & factory)
     AggregateFunctionProperties properties = { .returns_default_when_only_null = false, .is_order_dependent = true };
 
     factory.registerFunction("groupConcat", { createAggregateFunctionGroupConcat, properties });
-    factory.registerAlias("group_concat", "groupConcat", AggregateFunctionFactory::CaseInsensitive);
+    factory.registerAlias("group_concat", "groupConcat", AggregateFunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/AggregateFunctions/AggregateFunctionKolmogorovSmirnovTest.cpp
+++ b/src/AggregateFunctions/AggregateFunctionKolmogorovSmirnovTest.cpp
@@ -350,7 +350,7 @@ AggregateFunctionPtr createAggregateFunctionKolmogorovSmirnovTest(
 
 void registerAggregateFunctionKolmogorovSmirnovTest(AggregateFunctionFactory & factory)
 {
-    factory.registerFunction("kolmogorovSmirnovTest", createAggregateFunctionKolmogorovSmirnovTest, AggregateFunctionFactory::CaseInsensitive);
+    factory.registerFunction("kolmogorovSmirnovTest", createAggregateFunctionKolmogorovSmirnovTest, AggregateFunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/AggregateFunctions/AggregateFunctionSecondMoment.cpp
+++ b/src/AggregateFunctions/AggregateFunctionSecondMoment.cpp
@@ -15,11 +15,11 @@ void registerAggregateFunctionsStatisticsSecondMoment(AggregateFunctionFactory &
     factory.registerFunction("stddevPop", createAggregateFunctionStatisticsUnary<AggregateFunctionSecondMoment, StatisticsFunctionKind::stddevPop>);
 
     /// Synonyms for compatibility.
-    factory.registerAlias("VAR_SAMP", "varSamp", AggregateFunctionFactory::CaseInsensitive);
-    factory.registerAlias("VAR_POP", "varPop", AggregateFunctionFactory::CaseInsensitive);
-    factory.registerAlias("STDDEV_SAMP", "stddevSamp", AggregateFunctionFactory::CaseInsensitive);
-    factory.registerAlias("STDDEV_POP", "stddevPop", AggregateFunctionFactory::CaseInsensitive);
-    factory.registerAlias("STD", "stddevPop", AggregateFunctionFactory::CaseInsensitive);
+    factory.registerAlias("VAR_SAMP", "varSamp", AggregateFunctionFactory::Case::Insensitive);
+    factory.registerAlias("VAR_POP", "varPop", AggregateFunctionFactory::Case::Insensitive);
+    factory.registerAlias("STDDEV_SAMP", "stddevSamp", AggregateFunctionFactory::Case::Insensitive);
+    factory.registerAlias("STDDEV_POP", "stddevPop", AggregateFunctionFactory::Case::Insensitive);
+    factory.registerAlias("STD", "stddevPop", AggregateFunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/AggregateFunctions/AggregateFunctionSum.cpp
+++ b/src/AggregateFunctions/AggregateFunctionSum.cpp
@@ -72,7 +72,7 @@ AggregateFunctionPtr createAggregateFunctionSum(const std::string & name, const 
 
 void registerAggregateFunctionSum(AggregateFunctionFactory & factory)
 {
-    factory.registerFunction("sum", createAggregateFunctionSum<AggregateFunctionSumSimple>, AggregateFunctionFactory::CaseInsensitive);
+    factory.registerFunction("sum", createAggregateFunctionSum<AggregateFunctionSumSimple>, AggregateFunctionFactory::Case::Insensitive);
     factory.registerFunction("sumWithOverflow", createAggregateFunctionSum<AggregateFunctionSumWithOverflow>);
     factory.registerFunction("sumKahan", createAggregateFunctionSum<AggregateFunctionSumKahan>);
 }

--- a/src/AggregateFunctions/AggregateFunctionTopK.cpp
+++ b/src/AggregateFunctions/AggregateFunctionTopK.cpp
@@ -535,9 +535,9 @@ void registerAggregateFunctionTopK(AggregateFunctionFactory & factory)
 
     factory.registerFunction("topK", { createAggregateFunctionTopK<false, false>, properties });
     factory.registerFunction("topKWeighted", { createAggregateFunctionTopK<true, false>, properties });
-    factory.registerFunction("approx_top_k", { createAggregateFunctionTopK<false, true>, properties }, AggregateFunctionFactory::CaseInsensitive);
-    factory.registerFunction("approx_top_sum", { createAggregateFunctionTopK<true, true>, properties }, AggregateFunctionFactory::CaseInsensitive);
-    factory.registerAlias("approx_top_count", "approx_top_k", AggregateFunctionFactory::CaseInsensitive);
+    factory.registerFunction("approx_top_k", { createAggregateFunctionTopK<false, true>, properties }, AggregateFunctionFactory::Case::Insensitive);
+    factory.registerFunction("approx_top_sum", { createAggregateFunctionTopK<true, true>, properties }, AggregateFunctionFactory::Case::Insensitive);
+    factory.registerAlias("approx_top_count", "approx_top_k", AggregateFunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/AggregateFunctions/AggregateFunctionsMinMax.cpp
+++ b/src/AggregateFunctions/AggregateFunctionsMinMax.cpp
@@ -195,8 +195,8 @@ AggregateFunctionPtr createAggregateFunctionMinMax(
 
 void registerAggregateFunctionsMinMax(AggregateFunctionFactory & factory)
 {
-    factory.registerFunction("min", createAggregateFunctionMinMax<true>, AggregateFunctionFactory::CaseInsensitive);
-    factory.registerFunction("max", createAggregateFunctionMinMax<false>, AggregateFunctionFactory::CaseInsensitive);
+    factory.registerFunction("min", createAggregateFunctionMinMax<true>, AggregateFunctionFactory::Case::Insensitive);
+    factory.registerFunction("max", createAggregateFunctionMinMax<false>, AggregateFunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Common/IFactoryWithAliases.h
+++ b/src/Common/IFactoryWithAliases.h
@@ -39,16 +39,16 @@ protected:
 
 public:
     /// For compatibility with SQL, it's possible to specify that certain function name is case insensitive.
-    enum CaseSensitiveness
+    enum Case
     {
-        CaseSensitive,
-        CaseInsensitive
+        Sensitive,
+        Insensitive
     };
 
     /** Register additional name for value
       * real_name have to be already registered.
       */
-    void registerAlias(const String & alias_name, const String & real_name, CaseSensitiveness case_sensitiveness = CaseSensitive)
+    void registerAlias(const String & alias_name, const String & real_name, Case case_sensitiveness = Sensitive)
     {
         const auto & creator_map = getMap();
         const auto & case_insensitive_creator_map = getCaseInsensitiveMap();
@@ -66,12 +66,12 @@ public:
     }
 
     /// We need sure the real_name exactly exists when call the function directly.
-    void registerAliasUnchecked(const String & alias_name, const String & real_name, CaseSensitiveness case_sensitiveness = CaseSensitive)
+    void registerAliasUnchecked(const String & alias_name, const String & real_name, Case case_sensitiveness = Sensitive)
     {
         String alias_name_lowercase = Poco::toLower(alias_name);
         const String factory_name = getFactoryName();
 
-        if (case_sensitiveness == CaseInsensitive)
+        if (case_sensitiveness == Insensitive)
         {
             if (!case_insensitive_aliases.emplace(alias_name_lowercase, real_name).second)
                 throw Exception(ErrorCodes::LOGICAL_ERROR, "{}: case insensitive alias name '{}' is not unique", factory_name, alias_name);

--- a/src/DataTypes/DataTypeDate.cpp
+++ b/src/DataTypes/DataTypeDate.cpp
@@ -17,7 +17,7 @@ SerializationPtr DataTypeDate::doGetDefaultSerialization() const
 
 void registerDataTypeDate(DataTypeFactory & factory)
 {
-    factory.registerSimpleDataType("Date", [] { return DataTypePtr(std::make_shared<DataTypeDate>()); }, DataTypeFactory::CaseInsensitive);
+    factory.registerSimpleDataType("Date", [] { return DataTypePtr(std::make_shared<DataTypeDate>()); }, DataTypeFactory::Case::Insensitive);
 }
 
 }

--- a/src/DataTypes/DataTypeDate32.cpp
+++ b/src/DataTypes/DataTypeDate32.cpp
@@ -24,7 +24,7 @@ Field DataTypeDate32::getDefault() const
 void registerDataTypeDate32(DataTypeFactory & factory)
 {
     factory.registerSimpleDataType(
-        "Date32", [] { return DataTypePtr(std::make_shared<DataTypeDate32>()); }, DataTypeFactory::CaseInsensitive);
+        "Date32", [] { return DataTypePtr(std::make_shared<DataTypeDate32>()); }, DataTypeFactory::Case::Insensitive);
 }
 
 }

--- a/src/DataTypes/DataTypeDomainBool.cpp
+++ b/src/DataTypes/DataTypeDomainBool.cpp
@@ -15,8 +15,8 @@ void registerDataTypeDomainBool(DataTypeFactory & factory)
                 std::make_unique<DataTypeCustomFixedName>("Bool"), std::make_unique<SerializationBool>(type->getDefaultSerialization())));
     });
 
-    factory.registerAlias("bool", "Bool", DataTypeFactory::CaseInsensitive);
-    factory.registerAlias("boolean", "Bool", DataTypeFactory::CaseInsensitive);
+    factory.registerAlias("bool", "Bool", DataTypeFactory::Case::Insensitive);
+    factory.registerAlias("boolean", "Bool", DataTypeFactory::Case::Insensitive);
 }
 
 }

--- a/src/DataTypes/DataTypeEnum.cpp
+++ b/src/DataTypes/DataTypeEnum.cpp
@@ -318,7 +318,7 @@ void registerDataTypeEnum(DataTypeFactory & factory)
     factory.registerDataType("Enum", create);
 
     /// MySQL
-    factory.registerAlias("ENUM", "Enum", DataTypeFactory::CaseInsensitive);
+    factory.registerAlias("ENUM", "Enum", DataTypeFactory::Case::Insensitive);
 }
 
 }

--- a/src/DataTypes/DataTypeFactory.cpp
+++ b/src/DataTypes/DataTypeFactory.cpp
@@ -175,7 +175,7 @@ DataTypePtr DataTypeFactory::getCustom(DataTypeCustomDescPtr customization) cons
 }
 
 
-void DataTypeFactory::registerDataType(const String & family_name, Value creator, CaseSensitiveness case_sensitiveness)
+void DataTypeFactory::registerDataType(const String & family_name, Value creator, Case case_sensitiveness)
 {
     if (creator == nullptr)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "DataTypeFactory: the data type family {} has been provided  a null constructor", family_name);
@@ -189,12 +189,12 @@ void DataTypeFactory::registerDataType(const String & family_name, Value creator
         throw Exception(ErrorCodes::LOGICAL_ERROR, "DataTypeFactory: the data type family name '{}' is not unique",
             family_name);
 
-    if (case_sensitiveness == CaseInsensitive
+    if (case_sensitiveness == Case::Insensitive
         && !case_insensitive_data_types.emplace(family_name_lowercase, creator).second)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "DataTypeFactory: the case insensitive data type family name '{}' is not unique", family_name);
 }
 
-void DataTypeFactory::registerSimpleDataType(const String & name, SimpleCreator creator, CaseSensitiveness case_sensitiveness)
+void DataTypeFactory::registerSimpleDataType(const String & name, SimpleCreator creator, Case case_sensitiveness)
 {
     if (creator == nullptr)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "DataTypeFactory: the data type {} has been provided  a null constructor",
@@ -208,7 +208,7 @@ void DataTypeFactory::registerSimpleDataType(const String & name, SimpleCreator 
     }, case_sensitiveness);
 }
 
-void DataTypeFactory::registerDataTypeCustom(const String & family_name, CreatorWithCustom creator, CaseSensitiveness case_sensitiveness)
+void DataTypeFactory::registerDataTypeCustom(const String & family_name, CreatorWithCustom creator, Case case_sensitiveness)
 {
     registerDataType(family_name, [creator](const ASTPtr & ast)
     {
@@ -219,7 +219,7 @@ void DataTypeFactory::registerDataTypeCustom(const String & family_name, Creator
     }, case_sensitiveness);
 }
 
-void DataTypeFactory::registerSimpleDataTypeCustom(const String & name, SimpleCreatorWithCustom creator, CaseSensitiveness case_sensitiveness)
+void DataTypeFactory::registerSimpleDataTypeCustom(const String & name, SimpleCreatorWithCustom creator, Case case_sensitiveness)
 {
     registerDataTypeCustom(name, [name, creator](const ASTPtr & ast)
     {

--- a/src/DataTypes/DataTypeFactory.h
+++ b/src/DataTypes/DataTypeFactory.h
@@ -41,16 +41,16 @@ public:
     DataTypePtr tryGet(const ASTPtr & ast) const;
 
     /// Register a type family by its name.
-    void registerDataType(const String & family_name, Value creator, CaseSensitiveness case_sensitiveness = CaseSensitive);
+    void registerDataType(const String & family_name, Value creator, Case case_sensitiveness = Case::Sensitive);
 
     /// Register a simple data type, that have no parameters.
-    void registerSimpleDataType(const String & name, SimpleCreator creator, CaseSensitiveness case_sensitiveness = CaseSensitive);
+    void registerSimpleDataType(const String & name, SimpleCreator creator, Case case_sensitiveness = Case::Sensitive);
 
     /// Register a customized type family
-    void registerDataTypeCustom(const String & family_name, CreatorWithCustom creator, CaseSensitiveness case_sensitiveness = CaseSensitive);
+    void registerDataTypeCustom(const String & family_name, CreatorWithCustom creator, Case case_sensitiveness = Case::Sensitive);
 
     /// Register a simple customized data type
-    void registerSimpleDataTypeCustom(const String & name, SimpleCreatorWithCustom creator, CaseSensitiveness case_sensitiveness = CaseSensitive);
+    void registerSimpleDataTypeCustom(const String & name, SimpleCreatorWithCustom creator, Case case_sensitiveness = Case::Sensitive);
 
 private:
     template <bool nullptr_on_error>

--- a/src/DataTypes/DataTypeFixedString.cpp
+++ b/src/DataTypes/DataTypeFixedString.cpp
@@ -64,7 +64,7 @@ void registerDataTypeFixedString(DataTypeFactory & factory)
     factory.registerDataType("FixedString", create);
 
     /// Compatibility alias.
-    factory.registerAlias("BINARY", "FixedString", DataTypeFactory::CaseInsensitive);
+    factory.registerAlias("BINARY", "FixedString", DataTypeFactory::Case::Insensitive);
 }
 
 }

--- a/src/DataTypes/DataTypeIPv4andIPv6.cpp
+++ b/src/DataTypes/DataTypeIPv4andIPv6.cpp
@@ -9,9 +9,9 @@ namespace DB
 void registerDataTypeIPv4andIPv6(DataTypeFactory & factory)
 {
     factory.registerSimpleDataType("IPv4", [] { return DataTypePtr(std::make_shared<DataTypeIPv4>()); });
-    factory.registerAlias("INET4", "IPv4", DataTypeFactory::CaseInsensitive);
+    factory.registerAlias("INET4", "IPv4", DataTypeFactory::Case::Insensitive);
     factory.registerSimpleDataType("IPv6", [] { return DataTypePtr(std::make_shared<DataTypeIPv6>()); });
-    factory.registerAlias("INET6", "IPv6", DataTypeFactory::CaseInsensitive);
+    factory.registerAlias("INET6", "IPv6", DataTypeFactory::Case::Insensitive);
 }
 
 }

--- a/src/DataTypes/DataTypeObject.cpp
+++ b/src/DataTypes/DataTypeObject.cpp
@@ -76,7 +76,7 @@ void registerDataTypeObject(DataTypeFactory & factory)
     factory.registerDataType("Object", create);
     factory.registerSimpleDataType("JSON",
         [] { return std::make_shared<DataTypeObject>("JSON", false); },
-        DataTypeFactory::CaseInsensitive);
+        DataTypeFactory::Case::Insensitive);
 }
 
 }

--- a/src/DataTypes/DataTypeString.cpp
+++ b/src/DataTypes/DataTypeString.cpp
@@ -62,38 +62,38 @@ void registerDataTypeString(DataTypeFactory & factory)
 
     /// These synonims are added for compatibility.
 
-    factory.registerAlias("CHAR", "String", DataTypeFactory::CaseInsensitive);
-    factory.registerAlias("NCHAR", "String", DataTypeFactory::CaseInsensitive);
-    factory.registerAlias("CHARACTER", "String", DataTypeFactory::CaseInsensitive);
-    factory.registerAlias("VARCHAR", "String", DataTypeFactory::CaseInsensitive);
-    factory.registerAlias("NVARCHAR", "String", DataTypeFactory::CaseInsensitive);
-    factory.registerAlias("VARCHAR2", "String", DataTypeFactory::CaseInsensitive); /// Oracle
-    factory.registerAlias("TEXT", "String", DataTypeFactory::CaseInsensitive);
-    factory.registerAlias("TINYTEXT", "String", DataTypeFactory::CaseInsensitive);
-    factory.registerAlias("MEDIUMTEXT", "String", DataTypeFactory::CaseInsensitive);
-    factory.registerAlias("LONGTEXT", "String", DataTypeFactory::CaseInsensitive);
-    factory.registerAlias("BLOB", "String", DataTypeFactory::CaseInsensitive);
-    factory.registerAlias("CLOB", "String", DataTypeFactory::CaseInsensitive);
-    factory.registerAlias("TINYBLOB", "String", DataTypeFactory::CaseInsensitive);
-    factory.registerAlias("MEDIUMBLOB", "String", DataTypeFactory::CaseInsensitive);
-    factory.registerAlias("LONGBLOB", "String", DataTypeFactory::CaseInsensitive);
-    factory.registerAlias("BYTEA", "String", DataTypeFactory::CaseInsensitive); /// PostgreSQL
+    factory.registerAlias("CHAR", "String", DataTypeFactory::Case::Insensitive);
+    factory.registerAlias("NCHAR", "String", DataTypeFactory::Case::Insensitive);
+    factory.registerAlias("CHARACTER", "String", DataTypeFactory::Case::Insensitive);
+    factory.registerAlias("VARCHAR", "String", DataTypeFactory::Case::Insensitive);
+    factory.registerAlias("NVARCHAR", "String", DataTypeFactory::Case::Insensitive);
+    factory.registerAlias("VARCHAR2", "String", DataTypeFactory::Case::Insensitive); /// Oracle
+    factory.registerAlias("TEXT", "String", DataTypeFactory::Case::Insensitive);
+    factory.registerAlias("TINYTEXT", "String", DataTypeFactory::Case::Insensitive);
+    factory.registerAlias("MEDIUMTEXT", "String", DataTypeFactory::Case::Insensitive);
+    factory.registerAlias("LONGTEXT", "String", DataTypeFactory::Case::Insensitive);
+    factory.registerAlias("BLOB", "String", DataTypeFactory::Case::Insensitive);
+    factory.registerAlias("CLOB", "String", DataTypeFactory::Case::Insensitive);
+    factory.registerAlias("TINYBLOB", "String", DataTypeFactory::Case::Insensitive);
+    factory.registerAlias("MEDIUMBLOB", "String", DataTypeFactory::Case::Insensitive);
+    factory.registerAlias("LONGBLOB", "String", DataTypeFactory::Case::Insensitive);
+    factory.registerAlias("BYTEA", "String", DataTypeFactory::Case::Insensitive); /// PostgreSQL
 
-    factory.registerAlias("CHARACTER LARGE OBJECT", "String", DataTypeFactory::CaseInsensitive);
-    factory.registerAlias("CHARACTER VARYING", "String", DataTypeFactory::CaseInsensitive);
-    factory.registerAlias("CHAR LARGE OBJECT", "String", DataTypeFactory::CaseInsensitive);
-    factory.registerAlias("CHAR VARYING", "String", DataTypeFactory::CaseInsensitive);
-    factory.registerAlias("NATIONAL CHAR", "String", DataTypeFactory::CaseInsensitive);
-    factory.registerAlias("NATIONAL CHARACTER", "String", DataTypeFactory::CaseInsensitive);
-    factory.registerAlias("NATIONAL CHARACTER LARGE OBJECT", "String", DataTypeFactory::CaseInsensitive);
-    factory.registerAlias("NATIONAL CHARACTER VARYING", "String", DataTypeFactory::CaseInsensitive);
-    factory.registerAlias("NATIONAL CHAR VARYING", "String", DataTypeFactory::CaseInsensitive);
-    factory.registerAlias("NCHAR VARYING", "String", DataTypeFactory::CaseInsensitive);
-    factory.registerAlias("NCHAR LARGE OBJECT", "String", DataTypeFactory::CaseInsensitive);
-    factory.registerAlias("BINARY LARGE OBJECT", "String", DataTypeFactory::CaseInsensitive);
-    factory.registerAlias("BINARY VARYING", "String", DataTypeFactory::CaseInsensitive);
-    factory.registerAlias("VARBINARY", "String", DataTypeFactory::CaseInsensitive);
-    factory.registerAlias("GEOMETRY", "String", DataTypeFactory::CaseInsensitive); //mysql
+    factory.registerAlias("CHARACTER LARGE OBJECT", "String", DataTypeFactory::Case::Insensitive);
+    factory.registerAlias("CHARACTER VARYING", "String", DataTypeFactory::Case::Insensitive);
+    factory.registerAlias("CHAR LARGE OBJECT", "String", DataTypeFactory::Case::Insensitive);
+    factory.registerAlias("CHAR VARYING", "String", DataTypeFactory::Case::Insensitive);
+    factory.registerAlias("NATIONAL CHAR", "String", DataTypeFactory::Case::Insensitive);
+    factory.registerAlias("NATIONAL CHARACTER", "String", DataTypeFactory::Case::Insensitive);
+    factory.registerAlias("NATIONAL CHARACTER LARGE OBJECT", "String", DataTypeFactory::Case::Insensitive);
+    factory.registerAlias("NATIONAL CHARACTER VARYING", "String", DataTypeFactory::Case::Insensitive);
+    factory.registerAlias("NATIONAL CHAR VARYING", "String", DataTypeFactory::Case::Insensitive);
+    factory.registerAlias("NCHAR VARYING", "String", DataTypeFactory::Case::Insensitive);
+    factory.registerAlias("NCHAR LARGE OBJECT", "String", DataTypeFactory::Case::Insensitive);
+    factory.registerAlias("BINARY LARGE OBJECT", "String", DataTypeFactory::Case::Insensitive);
+    factory.registerAlias("BINARY VARYING", "String", DataTypeFactory::Case::Insensitive);
+    factory.registerAlias("VARBINARY", "String", DataTypeFactory::Case::Insensitive);
+    factory.registerAlias("GEOMETRY", "String", DataTypeFactory::Case::Insensitive); //mysql
 
 }
 }

--- a/src/DataTypes/DataTypesDecimal.cpp
+++ b/src/DataTypes/DataTypesDecimal.cpp
@@ -364,15 +364,15 @@ template class DataTypeDecimal<Decimal256>;
 
 void registerDataTypeDecimal(DataTypeFactory & factory)
 {
-    factory.registerDataType("Decimal32", createExact<Decimal32>, DataTypeFactory::CaseInsensitive);
-    factory.registerDataType("Decimal64", createExact<Decimal64>, DataTypeFactory::CaseInsensitive);
-    factory.registerDataType("Decimal128", createExact<Decimal128>, DataTypeFactory::CaseInsensitive);
-    factory.registerDataType("Decimal256", createExact<Decimal256>, DataTypeFactory::CaseInsensitive);
+    factory.registerDataType("Decimal32", createExact<Decimal32>, DataTypeFactory::Case::Insensitive);
+    factory.registerDataType("Decimal64", createExact<Decimal64>, DataTypeFactory::Case::Insensitive);
+    factory.registerDataType("Decimal128", createExact<Decimal128>, DataTypeFactory::Case::Insensitive);
+    factory.registerDataType("Decimal256", createExact<Decimal256>, DataTypeFactory::Case::Insensitive);
 
-    factory.registerDataType("Decimal", create, DataTypeFactory::CaseInsensitive);
-    factory.registerAlias("DEC", "Decimal", DataTypeFactory::CaseInsensitive);
-    factory.registerAlias("NUMERIC", "Decimal", DataTypeFactory::CaseInsensitive);
-    factory.registerAlias("FIXED", "Decimal", DataTypeFactory::CaseInsensitive);
+    factory.registerDataType("Decimal", create, DataTypeFactory::Case::Insensitive);
+    factory.registerAlias("DEC", "Decimal", DataTypeFactory::Case::Insensitive);
+    factory.registerAlias("NUMERIC", "Decimal", DataTypeFactory::Case::Insensitive);
+    factory.registerAlias("FIXED", "Decimal", DataTypeFactory::Case::Insensitive);
 }
 
 }

--- a/src/DataTypes/DataTypesNumber.cpp
+++ b/src/DataTypes/DataTypesNumber.cpp
@@ -65,41 +65,41 @@ void registerDataTypeNumbers(DataTypeFactory & factory)
 
     /// These synonyms are added for compatibility.
 
-    factory.registerAlias("TINYINT", "Int8", DataTypeFactory::CaseInsensitive);
-    factory.registerAlias("INT1", "Int8", DataTypeFactory::CaseInsensitive);
-    factory.registerAlias("BYTE", "Int8", DataTypeFactory::CaseInsensitive);
-    factory.registerAlias("TINYINT SIGNED", "Int8", DataTypeFactory::CaseInsensitive);
-    factory.registerAlias("INT1 SIGNED", "Int8", DataTypeFactory::CaseInsensitive);
-    factory.registerAlias("SMALLINT", "Int16", DataTypeFactory::CaseInsensitive);
-    factory.registerAlias("SMALLINT SIGNED", "Int16", DataTypeFactory::CaseInsensitive);
-    factory.registerAlias("INT", "Int32", DataTypeFactory::CaseInsensitive);
-    factory.registerAlias("INTEGER", "Int32", DataTypeFactory::CaseInsensitive);
-    factory.registerAlias("MEDIUMINT", "Int32", DataTypeFactory::CaseInsensitive);
-    factory.registerAlias("MEDIUMINT SIGNED", "Int32", DataTypeFactory::CaseInsensitive);
-    factory.registerAlias("INT SIGNED", "Int32", DataTypeFactory::CaseInsensitive);
-    factory.registerAlias("INTEGER SIGNED", "Int32", DataTypeFactory::CaseInsensitive);
-    factory.registerAlias("BIGINT", "Int64", DataTypeFactory::CaseInsensitive);
-    factory.registerAlias("SIGNED", "Int64", DataTypeFactory::CaseInsensitive);
-    factory.registerAlias("BIGINT SIGNED", "Int64", DataTypeFactory::CaseInsensitive);
-    factory.registerAlias("TIME", "Int64", DataTypeFactory::CaseInsensitive);
+    factory.registerAlias("TINYINT", "Int8", DataTypeFactory::Case::Insensitive);
+    factory.registerAlias("INT1", "Int8", DataTypeFactory::Case::Insensitive);
+    factory.registerAlias("BYTE", "Int8", DataTypeFactory::Case::Insensitive);
+    factory.registerAlias("TINYINT SIGNED", "Int8", DataTypeFactory::Case::Insensitive);
+    factory.registerAlias("INT1 SIGNED", "Int8", DataTypeFactory::Case::Insensitive);
+    factory.registerAlias("SMALLINT", "Int16", DataTypeFactory::Case::Insensitive);
+    factory.registerAlias("SMALLINT SIGNED", "Int16", DataTypeFactory::Case::Insensitive);
+    factory.registerAlias("INT", "Int32", DataTypeFactory::Case::Insensitive);
+    factory.registerAlias("INTEGER", "Int32", DataTypeFactory::Case::Insensitive);
+    factory.registerAlias("MEDIUMINT", "Int32", DataTypeFactory::Case::Insensitive);
+    factory.registerAlias("MEDIUMINT SIGNED", "Int32", DataTypeFactory::Case::Insensitive);
+    factory.registerAlias("INT SIGNED", "Int32", DataTypeFactory::Case::Insensitive);
+    factory.registerAlias("INTEGER SIGNED", "Int32", DataTypeFactory::Case::Insensitive);
+    factory.registerAlias("BIGINT", "Int64", DataTypeFactory::Case::Insensitive);
+    factory.registerAlias("SIGNED", "Int64", DataTypeFactory::Case::Insensitive);
+    factory.registerAlias("BIGINT SIGNED", "Int64", DataTypeFactory::Case::Insensitive);
+    factory.registerAlias("TIME", "Int64", DataTypeFactory::Case::Insensitive);
 
-    factory.registerAlias("TINYINT UNSIGNED", "UInt8", DataTypeFactory::CaseInsensitive);
-    factory.registerAlias("INT1 UNSIGNED", "UInt8", DataTypeFactory::CaseInsensitive);
-    factory.registerAlias("SMALLINT UNSIGNED", "UInt16", DataTypeFactory::CaseInsensitive);
-    factory.registerAlias("YEAR", "UInt16", DataTypeFactory::CaseInsensitive);
-    factory.registerAlias("MEDIUMINT UNSIGNED", "UInt32", DataTypeFactory::CaseInsensitive);
-    factory.registerAlias("INT UNSIGNED", "UInt32", DataTypeFactory::CaseInsensitive);
-    factory.registerAlias("INTEGER UNSIGNED", "UInt32", DataTypeFactory::CaseInsensitive);
-    factory.registerAlias("UNSIGNED", "UInt64", DataTypeFactory::CaseInsensitive);
-    factory.registerAlias("BIGINT UNSIGNED", "UInt64", DataTypeFactory::CaseInsensitive);
-    factory.registerAlias("BIT", "UInt64", DataTypeFactory::CaseInsensitive);
-    factory.registerAlias("SET", "UInt64", DataTypeFactory::CaseInsensitive);
+    factory.registerAlias("TINYINT UNSIGNED", "UInt8", DataTypeFactory::Case::Insensitive);
+    factory.registerAlias("INT1 UNSIGNED", "UInt8", DataTypeFactory::Case::Insensitive);
+    factory.registerAlias("SMALLINT UNSIGNED", "UInt16", DataTypeFactory::Case::Insensitive);
+    factory.registerAlias("YEAR", "UInt16", DataTypeFactory::Case::Insensitive);
+    factory.registerAlias("MEDIUMINT UNSIGNED", "UInt32", DataTypeFactory::Case::Insensitive);
+    factory.registerAlias("INT UNSIGNED", "UInt32", DataTypeFactory::Case::Insensitive);
+    factory.registerAlias("INTEGER UNSIGNED", "UInt32", DataTypeFactory::Case::Insensitive);
+    factory.registerAlias("UNSIGNED", "UInt64", DataTypeFactory::Case::Insensitive);
+    factory.registerAlias("BIGINT UNSIGNED", "UInt64", DataTypeFactory::Case::Insensitive);
+    factory.registerAlias("BIT", "UInt64", DataTypeFactory::Case::Insensitive);
+    factory.registerAlias("SET", "UInt64", DataTypeFactory::Case::Insensitive);
 
-    factory.registerAlias("FLOAT", "Float32", DataTypeFactory::CaseInsensitive);
-    factory.registerAlias("REAL", "Float32", DataTypeFactory::CaseInsensitive);
-    factory.registerAlias("SINGLE", "Float32", DataTypeFactory::CaseInsensitive);
-    factory.registerAlias("DOUBLE", "Float64", DataTypeFactory::CaseInsensitive);
-    factory.registerAlias("DOUBLE PRECISION", "Float64", DataTypeFactory::CaseInsensitive);
+    factory.registerAlias("FLOAT", "Float32", DataTypeFactory::Case::Insensitive);
+    factory.registerAlias("REAL", "Float32", DataTypeFactory::Case::Insensitive);
+    factory.registerAlias("SINGLE", "Float32", DataTypeFactory::Case::Insensitive);
+    factory.registerAlias("DOUBLE", "Float64", DataTypeFactory::Case::Insensitive);
+    factory.registerAlias("DOUBLE PRECISION", "Float64", DataTypeFactory::Case::Insensitive);
 }
 
 /// Explicit template instantiations.

--- a/src/DataTypes/registerDataTypeDateTime.cpp
+++ b/src/DataTypes/registerDataTypeDateTime.cpp
@@ -108,11 +108,11 @@ static DataTypePtr create64(const ASTPtr & arguments)
 
 void registerDataTypeDateTime(DataTypeFactory & factory)
 {
-    factory.registerDataType("DateTime", create, DataTypeFactory::CaseInsensitive);
-    factory.registerDataType("DateTime32", create32, DataTypeFactory::CaseInsensitive);
-    factory.registerDataType("DateTime64", create64, DataTypeFactory::CaseInsensitive);
+    factory.registerDataType("DateTime", create, DataTypeFactory::Case::Insensitive);
+    factory.registerDataType("DateTime32", create32, DataTypeFactory::Case::Insensitive);
+    factory.registerDataType("DateTime64", create64, DataTypeFactory::Case::Insensitive);
 
-    factory.registerAlias("TIMESTAMP", "DateTime", DataTypeFactory::CaseInsensitive);
+    factory.registerAlias("TIMESTAMP", "DateTime", DataTypeFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/CRC.cpp
+++ b/src/Functions/CRC.cpp
@@ -150,9 +150,9 @@ using FunctionCRC64ECMA = FunctionCRC<CRC64ECMAImpl>;
 
 REGISTER_FUNCTION(CRC)
 {
-    factory.registerFunction<FunctionCRC32ZLib>({}, FunctionFactory::CaseInsensitive);
-    factory.registerFunction<FunctionCRC32IEEE>({}, FunctionFactory::CaseInsensitive);
-    factory.registerFunction<FunctionCRC64ECMA>({}, FunctionFactory::CaseInsensitive);
+    factory.registerFunction<FunctionCRC32ZLib>({}, FunctionFactory::Case::Insensitive);
+    factory.registerFunction<FunctionCRC32IEEE>({}, FunctionFactory::Case::Insensitive);
+    factory.registerFunction<FunctionCRC64ECMA>({}, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/CastOverloadResolver.cpp
+++ b/src/Functions/CastOverloadResolver.cpp
@@ -137,10 +137,10 @@ FunctionOverloadResolverPtr createInternalCastOverloadResolver(CastType type, st
 
 REGISTER_FUNCTION(CastOverloadResolvers)
 {
-    factory.registerFunction("_CAST", [](ContextPtr context){ return CastOverloadResolverImpl::create(context, CastType::nonAccurate, true, {}); }, {}, FunctionFactory::CaseInsensitive);
+    factory.registerFunction("_CAST", [](ContextPtr context){ return CastOverloadResolverImpl::create(context, CastType::nonAccurate, true, {}); }, {}, FunctionFactory::Case::Insensitive);
     /// Note: "internal" (not affected by null preserving setting) versions of accurate cast functions are unneeded.
 
-    factory.registerFunction("CAST", [](ContextPtr context){ return CastOverloadResolverImpl::create(context, CastType::nonAccurate, false, {}); }, {}, FunctionFactory::CaseInsensitive);
+    factory.registerFunction("CAST", [](ContextPtr context){ return CastOverloadResolverImpl::create(context, CastType::nonAccurate, false, {}); }, {}, FunctionFactory::Case::Insensitive);
     factory.registerFunction("accurateCast", [](ContextPtr context){ return CastOverloadResolverImpl::create(context, CastType::accurate, false, {}); }, {});
     factory.registerFunction("accurateCastOrNull", [](ContextPtr context){ return CastOverloadResolverImpl::create(context, CastType::accurateOrNull, false, {}); }, {});
 }

--- a/src/Functions/FunctionChar.cpp
+++ b/src/Functions/FunctionChar.cpp
@@ -116,7 +116,7 @@ private:
 
 REGISTER_FUNCTION(Char)
 {
-    factory.registerFunction<FunctionChar>({}, FunctionFactory::CaseInsensitive);
+    factory.registerFunction<FunctionChar>({}, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/FunctionFQDN.cpp
+++ b/src/Functions/FunctionFQDN.cpp
@@ -46,7 +46,7 @@ public:
 
 REGISTER_FUNCTION(FQDN)
 {
-    factory.registerFunction<FunctionFQDN>({}, FunctionFactory::CaseInsensitive);
+    factory.registerFunction<FunctionFQDN>({}, FunctionFactory::Case::Insensitive);
     factory.registerAlias("fullHostName", "FQDN");
 }
 

--- a/src/Functions/FunctionFactory.cpp
+++ b/src/Functions/FunctionFactory.cpp
@@ -31,7 +31,7 @@ void FunctionFactory::registerFunction(
     const std::string & name,
     FunctionCreator creator,
     FunctionDocumentation doc,
-    CaseSensitiveness case_sensitiveness)
+    Case case_sensitiveness)
 {
     if (!functions.emplace(name, FunctionFactoryData{creator, doc}).second)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "FunctionFactory: the function name '{}' is not unique", name);
@@ -41,7 +41,7 @@ void FunctionFactory::registerFunction(
         throw Exception(ErrorCodes::LOGICAL_ERROR, "FunctionFactory: the function name '{}' is already registered as alias",
                         name);
 
-    if (case_sensitiveness == CaseInsensitive)
+    if (case_sensitiveness == Case::Insensitive)
     {
         if (!case_insensitive_functions.emplace(function_name_lowercase, FunctionFactoryData{creator, doc}).second)
             throw Exception(ErrorCodes::LOGICAL_ERROR, "FunctionFactory: the case insensitive function name '{}' is not unique",
@@ -54,7 +54,7 @@ void FunctionFactory::registerFunction(
     const std::string & name,
     FunctionSimpleCreator creator,
     FunctionDocumentation doc,
-    CaseSensitiveness case_sensitiveness)
+    Case case_sensitiveness)
 {
     registerFunction(name, [my_creator = std::move(creator)](ContextPtr context)
     {

--- a/src/Functions/FunctionFactory.h
+++ b/src/Functions/FunctionFactory.h
@@ -30,7 +30,7 @@ public:
     static FunctionFactory & instance();
 
     template <typename Function>
-    void registerFunction(FunctionDocumentation doc = {}, CaseSensitiveness case_sensitiveness = CaseSensitive)
+    void registerFunction(FunctionDocumentation doc = {}, Case case_sensitiveness = Case::Sensitive)
     {
         registerFunction<Function>(Function::name, std::move(doc), case_sensitiveness);
     }
@@ -56,13 +56,13 @@ public:
         const std::string & name,
         FunctionCreator creator,
         FunctionDocumentation doc = {},
-        CaseSensitiveness case_sensitiveness = CaseSensitive);
+        Case case_sensitiveness = Case::Sensitive);
 
     void registerFunction(
         const std::string & name,
         FunctionSimpleCreator creator,
         FunctionDocumentation doc = {},
-        CaseSensitiveness case_sensitiveness = CaseSensitive);
+        Case case_sensitiveness = Case::Sensitive);
 
     FunctionDocumentation getDocumentation(const std::string & name) const;
 
@@ -79,7 +79,7 @@ private:
     String getFactoryName() const override { return "FunctionFactory"; }
 
     template <typename Function>
-    void registerFunction(const std::string & name, FunctionDocumentation doc = {}, CaseSensitiveness case_sensitiveness = CaseSensitive)
+    void registerFunction(const std::string & name, FunctionDocumentation doc = {}, Case case_sensitiveness = Case::Sensitive)
     {
         registerFunction(name, &Function::create, std::move(doc), case_sensitiveness);
     }

--- a/src/Functions/FunctionGenerateRandomStructure.cpp
+++ b/src/Functions/FunctionGenerateRandomStructure.cpp
@@ -445,8 +445,7 @@ The function returns a value of type String.
                 {"with specified seed", "SELECT generateRandomStructure(1, 42)", "c1 UInt128"},
             },
             .categories{"Random"}
-        },
-        FunctionFactory::CaseSensitive);
+        });
 }
 
 }

--- a/src/Functions/FunctionsBinaryRepresentation.cpp
+++ b/src/Functions/FunctionsBinaryRepresentation.cpp
@@ -728,10 +728,10 @@ public:
 
 REGISTER_FUNCTION(BinaryRepr)
 {
-    factory.registerFunction<EncodeToBinaryRepresentation<HexImpl>>({}, FunctionFactory::CaseInsensitive);
-    factory.registerFunction<DecodeFromBinaryRepresentation<UnhexImpl>>({}, FunctionFactory::CaseInsensitive);
-    factory.registerFunction<EncodeToBinaryRepresentation<BinImpl>>({}, FunctionFactory::CaseInsensitive);
-    factory.registerFunction<DecodeFromBinaryRepresentation<UnbinImpl>>({}, FunctionFactory::CaseInsensitive);
+    factory.registerFunction<EncodeToBinaryRepresentation<HexImpl>>({}, FunctionFactory::Case::Insensitive);
+    factory.registerFunction<DecodeFromBinaryRepresentation<UnhexImpl>>({}, FunctionFactory::Case::Insensitive);
+    factory.registerFunction<EncodeToBinaryRepresentation<BinImpl>>({}, FunctionFactory::Case::Insensitive);
+    factory.registerFunction<DecodeFromBinaryRepresentation<UnbinImpl>>({}, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/FunctionsCodingIP.cpp
+++ b/src/Functions/FunctionsCodingIP.cpp
@@ -1169,10 +1169,10 @@ REGISTER_FUNCTION(Coding)
     factory.registerFunction<FunctionIPv6StringToNum<IPStringToNumExceptionMode::Null>>();
 
     /// MySQL compatibility aliases:
-    factory.registerAlias("INET_ATON", FunctionIPv4StringToNum<IPStringToNumExceptionMode::Throw>::name, FunctionFactory::CaseInsensitive);
-    factory.registerAlias("INET6_NTOA", FunctionIPv6NumToString::name, FunctionFactory::CaseInsensitive);
-    factory.registerAlias("INET6_ATON", FunctionIPv6StringToNum<IPStringToNumExceptionMode::Throw>::name, FunctionFactory::CaseInsensitive);
-    factory.registerAlias("INET_NTOA", NameFunctionIPv4NumToString::name, FunctionFactory::CaseInsensitive);
+    factory.registerAlias("INET_ATON", FunctionIPv4StringToNum<IPStringToNumExceptionMode::Throw>::name, FunctionFactory::Case::Insensitive);
+    factory.registerAlias("INET6_NTOA", FunctionIPv6NumToString::name, FunctionFactory::Case::Insensitive);
+    factory.registerAlias("INET6_ATON", FunctionIPv6StringToNum<IPStringToNumExceptionMode::Throw>::name, FunctionFactory::Case::Insensitive);
+    factory.registerAlias("INET_NTOA", NameFunctionIPv4NumToString::name, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/FunctionsCodingULID.cpp
+++ b/src/Functions/FunctionsCodingULID.cpp
@@ -180,8 +180,7 @@ An optional second argument can be passed to specify a timezone for the timestam
                 {"ulid", "SELECT ULIDStringToDateTime(generateULID())", ""},
                 {"timezone", "SELECT ULIDStringToDateTime(generateULID(), 'Asia/Istanbul')", ""}},
             .categories{"ULID"}
-        },
-        FunctionFactory::CaseSensitive);
+        });
 }
 
 }

--- a/src/Functions/FunctionsCodingUUID.cpp
+++ b/src/Functions/FunctionsCodingUUID.cpp
@@ -496,8 +496,8 @@ This function accepts a UUID and returns a FixedString(16) as its binary represe
 │ 612f3c40-5d3b-217e-707b-6a546a3d7b29 │ a/<@];!~p{jTj={) │ @</a];!~p{jTj={) │
 └──────────────────────────────────────┴──────────────────┴──────────────────┘
 )"}},
-            .categories{"UUID"}},
-        FunctionFactory::CaseSensitive);
+            .categories{"UUID"}});
+
 
     factory.registerFunction<FunctionUUIDv7ToDateTime>(
         FunctionDocumentation{
@@ -509,8 +509,7 @@ An optional second argument can be passed to specify a timezone for the timestam
             .examples{
                 {"uuid","select UUIDv7ToDateTime(generateUUIDv7())", ""},
                 {"uuid","select generateUUIDv7() as uuid, UUIDv7ToDateTime(uuid), UUIDv7ToDateTime(uuid, 'America/New_York')", ""}},
-            .categories{"UUID"}},
-        FunctionFactory::CaseSensitive);
+            .categories{"UUID"}});
 }
 
 }

--- a/src/Functions/FunctionsConversion.cpp
+++ b/src/Functions/FunctionsConversion.cpp
@@ -5224,7 +5224,7 @@ REGISTER_FUNCTION(Conversion)
     /// MySQL compatibility alias. Cannot be registered as alias,
     /// because we don't want it to be normalized to toDate in queries,
     /// otherwise CREATE DICTIONARY query breaks.
-    factory.registerFunction("DATE", &FunctionToDate::create, {}, FunctionFactory::CaseInsensitive);
+    factory.registerFunction("DATE", &FunctionToDate::create, {}, FunctionFactory::Case::Insensitive);
 
     factory.registerFunction<FunctionToDate32>();
     factory.registerFunction<FunctionToDateTime>();

--- a/src/Functions/FunctionsHashingMisc.cpp
+++ b/src/Functions/FunctionsHashingMisc.cpp
@@ -41,8 +41,7 @@ REGISTER_FUNCTION(Hashing)
             .description="Calculates value of XXH3 64-bit hash function. Refer to https://github.com/Cyan4973/xxHash for detailed documentation.",
             .examples{{"hash", "SELECT xxh3('ClickHouse')", ""}},
             .categories{"Hash"}
-        },
-        FunctionFactory::CaseSensitive);
+        });
 
     factory.registerFunction<FunctionWyHash64>();
 

--- a/src/Functions/FunctionsLogical.cpp
+++ b/src/Functions/FunctionsLogical.cpp
@@ -29,7 +29,7 @@ REGISTER_FUNCTION(Logical)
     factory.registerFunction<FunctionAnd>();
     factory.registerFunction<FunctionOr>();
     factory.registerFunction<FunctionXor>();
-    factory.registerFunction<FunctionNot>({}, FunctionFactory::CaseInsensitive); /// Operator NOT(x) can be parsed as a function.
+    factory.registerFunction<FunctionNot>({}, FunctionFactory::Case::Insensitive); /// Operator NOT(x) can be parsed as a function.
 }
 
 namespace ErrorCodes

--- a/src/Functions/FunctionsOpDate.cpp
+++ b/src/Functions/FunctionsOpDate.cpp
@@ -99,8 +99,8 @@ using FunctionSubDate = FunctionOpDate<SubDate>;
 
 REGISTER_FUNCTION(AddInterval)
 {
-    factory.registerFunction<FunctionAddDate>({}, FunctionFactory::CaseInsensitive);
-    factory.registerFunction<FunctionSubDate>({}, FunctionFactory::CaseInsensitive);
+    factory.registerFunction<FunctionAddDate>({}, FunctionFactory::Case::Insensitive);
+    factory.registerFunction<FunctionSubDate>({}, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/FunctionsRound.cpp
+++ b/src/Functions/FunctionsRound.cpp
@@ -7,16 +7,16 @@ namespace DB
 
 REGISTER_FUNCTION(Round)
 {
-    factory.registerFunction<FunctionRound>({}, FunctionFactory::CaseInsensitive);
-    factory.registerFunction<FunctionRoundBankers>({}, FunctionFactory::CaseSensitive);
-    factory.registerFunction<FunctionFloor>({}, FunctionFactory::CaseInsensitive);
-    factory.registerFunction<FunctionCeil>({}, FunctionFactory::CaseInsensitive);
-    factory.registerFunction<FunctionTrunc>({}, FunctionFactory::CaseInsensitive);
+    factory.registerFunction<FunctionRound>({}, FunctionFactory::Case::Insensitive);
+    factory.registerFunction<FunctionRoundBankers>({}, FunctionFactory::Case::Sensitive);
+    factory.registerFunction<FunctionFloor>({}, FunctionFactory::Case::Insensitive);
+    factory.registerFunction<FunctionCeil>({}, FunctionFactory::Case::Insensitive);
+    factory.registerFunction<FunctionTrunc>({}, FunctionFactory::Case::Insensitive);
     factory.registerFunction<FunctionRoundDown>();
 
     /// Compatibility aliases.
-    factory.registerAlias("ceiling", "ceil", FunctionFactory::CaseInsensitive);
-    factory.registerAlias("truncate", "trunc", FunctionFactory::CaseInsensitive);
+    factory.registerAlias("ceiling", "ceil", FunctionFactory::Case::Insensitive);
+    factory.registerAlias("truncate", "trunc", FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/FunctionsStringHashFixedString.cpp
+++ b/src/Functions/FunctionsStringHashFixedString.cpp
@@ -428,8 +428,7 @@ REGISTER_FUNCTION(HashFixedStrings)
     It returns a BLAKE3 hash as a byte array with type FixedString(32).
     )",
             .examples{{"hash", "SELECT hex(BLAKE3('ABC'))", ""}},
-            .categories{"Hash"}},
-        FunctionFactory::CaseSensitive);
+            .categories{"Hash"}});
 #    endif
 }
 #endif

--- a/src/Functions/JSONArrayLength.cpp
+++ b/src/Functions/JSONArrayLength.cpp
@@ -104,7 +104,7 @@ REGISTER_FUNCTION(JSONArrayLength)
         .description="Returns the number of elements in the outermost JSON array. The function returns NULL if input JSON string is invalid."});
 
     /// For Spark compatibility.
-    factory.registerAlias("JSON_ARRAY_LENGTH", "JSONArrayLength", FunctionFactory::CaseInsensitive);
+    factory.registerAlias("JSON_ARRAY_LENGTH", "JSONArrayLength", FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/UTCTimestamp.cpp
+++ b/src/Functions/UTCTimestamp.cpp
@@ -117,8 +117,8 @@ Example:
 )",
     .examples{
         {"typical", "SELECT UTCTimestamp();", ""}},
-    .categories{"Dates and Times"}}, FunctionFactory::CaseInsensitive);
-    factory.registerAlias("UTC_timestamp", UTCTimestampOverloadResolver::name, FunctionFactory::CaseInsensitive);
+    .categories{"Dates and Times"}}, FunctionFactory::Case::Insensitive);
+    factory.registerAlias("UTC_timestamp", UTCTimestampOverloadResolver::name, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/UTCTimestampTransform.cpp
+++ b/src/Functions/UTCTimestampTransform.cpp
@@ -144,8 +144,8 @@ REGISTER_FUNCTION(UTCTimestampTransform)
 {
     factory.registerFunction<ToUTCTimestampFunction>();
     factory.registerFunction<FromUTCTimestampFunction>();
-    factory.registerAlias("to_utc_timestamp", NameToUTCTimestamp::name, FunctionFactory::CaseInsensitive);
-    factory.registerAlias("from_utc_timestamp", NameFromUTCTimestamp::name, FunctionFactory::CaseInsensitive);
+    factory.registerAlias("to_utc_timestamp", NameToUTCTimestamp::name, FunctionFactory::Case::Insensitive);
+    factory.registerAlias("from_utc_timestamp", NameFromUTCTimestamp::name, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/abs.cpp
+++ b/src/Functions/abs.cpp
@@ -51,7 +51,7 @@ template <> struct FunctionUnaryArithmeticMonotonicity<NameAbs>
 
 REGISTER_FUNCTION(Abs)
 {
-    factory.registerFunction<FunctionAbs>({}, FunctionFactory::CaseInsensitive);
+    factory.registerFunction<FunctionAbs>({}, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/acos.cpp
+++ b/src/Functions/acos.cpp
@@ -14,7 +14,7 @@ using FunctionAcos = FunctionMathUnary<UnaryFunctionVectorized<AcosName, acos>>;
 
 REGISTER_FUNCTION(Acos)
 {
-    factory.registerFunction<FunctionAcos>({}, FunctionFactory::CaseInsensitive);
+    factory.registerFunction<FunctionAcos>({}, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/array/arrayFlatten.cpp
+++ b/src/Functions/array/arrayFlatten.cpp
@@ -123,7 +123,7 @@ private:
 REGISTER_FUNCTION(ArrayFlatten)
 {
     factory.registerFunction<ArrayFlatten>();
-    factory.registerAlias("flatten", "arrayFlatten", FunctionFactory::CaseInsensitive);
+    factory.registerAlias("flatten", "arrayFlatten", FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/array/arrayShuffle.cpp
+++ b/src/Functions/array/arrayShuffle.cpp
@@ -196,7 +196,7 @@ It is possible to override the seed to produce stable results:
                 {"explicit_seed", "SELECT arrayShuffle([1, 2, 3, 4], 41)", ""},
                 {"materialize", "SELECT arrayShuffle(materialize([1, 2, 3]), 42), arrayShuffle([1, 2, 3], 42) FROM numbers(10)", ""}},
             .categories{"Array"}},
-        FunctionFactory::CaseInsensitive);
+        FunctionFactory::Case::Insensitive);
 
     factory.registerFunction<FunctionArrayShuffleImpl<FunctionArrayPartialShuffleTraits>>(
         FunctionDocumentation{
@@ -224,7 +224,7 @@ It is possible to override the seed to produce stable results:
                 {"materialize",
                  "SELECT arrayPartialShuffle(materialize([1, 2, 3, 4]), 2, 42), arrayPartialShuffle([1, 2, 3], 2, 42) FROM numbers(10)", ""}},
             .categories{"Array"}},
-        FunctionFactory::CaseInsensitive);
+        FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/array/length.cpp
+++ b/src/Functions/array/length.cpp
@@ -100,8 +100,8 @@ It is ok to have ASCII NUL bytes in strings, and they will be counted as well.
                 },
             .categories{"String", "Array"}
         },
-        FunctionFactory::CaseInsensitive);
-    factory.registerAlias("OCTET_LENGTH", "length", FunctionFactory::CaseInsensitive);
+        FunctionFactory::Case::Insensitive);
+    factory.registerAlias("OCTET_LENGTH", "length", FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/ascii.cpp
+++ b/src/Functions/ascii.cpp
@@ -90,7 +90,7 @@ If s is empty, the result is 0. If the first character is not an ASCII character
         )",
         .examples{{"ascii", "SELECT ascii('234')", ""}},
         .categories{"String"}
-        }, FunctionFactory::CaseInsensitive);
+        }, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/asin.cpp
+++ b/src/Functions/asin.cpp
@@ -41,7 +41,7 @@ For more details, see [https://en.wikipedia.org/wiki/Inverse_trigonometric_funct
                 {"nan", "SELECT asin(1.1), asin(-2), asin(inf), asin(nan)", ""}},
             .categories{"Mathematical", "Trigonometric"}
         },
-        FunctionFactory::CaseInsensitive);
+        FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/atan.cpp
+++ b/src/Functions/atan.cpp
@@ -14,7 +14,7 @@ using FunctionAtan = FunctionMathUnary<UnaryFunctionVectorized<AtanName, atan>>;
 
 REGISTER_FUNCTION(Atan)
 {
-    factory.registerFunction<FunctionAtan>({}, FunctionFactory::CaseInsensitive);
+    factory.registerFunction<FunctionAtan>({}, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/atan2.cpp
+++ b/src/Functions/atan2.cpp
@@ -15,7 +15,7 @@ namespace
 
 REGISTER_FUNCTION(Atan2)
 {
-    factory.registerFunction<FunctionAtan2>({}, FunctionFactory::CaseInsensitive);
+    factory.registerFunction<FunctionAtan2>({}, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/base64Decode.cpp
+++ b/src/Functions/base64Decode.cpp
@@ -17,7 +17,7 @@ REGISTER_FUNCTION(Base64Decode)
     factory.registerFunction<FunctionBase64Conversion<Base64Decode<Base64Variant::Normal>>>({description, syntax, arguments, returned_value, examples, categories});
 
     /// MySQL compatibility alias.
-    factory.registerAlias("FROM_BASE64", "base64Decode", FunctionFactory::CaseInsensitive);
+    factory.registerAlias("FROM_BASE64", "base64Decode", FunctionFactory::Case::Insensitive);
 }
 }
 

--- a/src/Functions/base64Encode.cpp
+++ b/src/Functions/base64Encode.cpp
@@ -17,7 +17,7 @@ REGISTER_FUNCTION(Base64Encode)
     factory.registerFunction<FunctionBase64Conversion<Base64Encode<Base64Variant::Normal>>>({description, syntax, arguments, returned_value, examples, categories});
 
     /// MySQL compatibility alias.
-    factory.registerAlias("TO_BASE64", "base64Encode", FunctionFactory::CaseInsensitive);
+    factory.registerAlias("TO_BASE64", "base64Encode", FunctionFactory::Case::Insensitive);
 }
 }
 

--- a/src/Functions/byteSwap.cpp
+++ b/src/Functions/byteSwap.cpp
@@ -100,7 +100,7 @@ One use-case of this function is reversing IPv4s:
                 {"64-bit", "SELECT byteSwap(123294967295)", "18439412204227788800"},
             },
             .categories{"Mathematical", "Arithmetic"}},
-        FunctionFactory::CaseInsensitive);
+        FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/coalesce.cpp
+++ b/src/Functions/coalesce.cpp
@@ -180,7 +180,7 @@ private:
 
 REGISTER_FUNCTION(Coalesce)
 {
-    factory.registerFunction<FunctionCoalesce>({}, FunctionFactory::CaseInsensitive);
+    factory.registerFunction<FunctionCoalesce>({}, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/concat.cpp
+++ b/src/Functions/concat.cpp
@@ -240,7 +240,7 @@ private:
 
 REGISTER_FUNCTION(Concat)
 {
-    factory.registerFunction<ConcatOverloadResolver>({}, FunctionFactory::CaseInsensitive);
+    factory.registerFunction<ConcatOverloadResolver>({}, FunctionFactory::Case::Insensitive);
     factory.registerFunction<FunctionConcatAssumeInjective>();
 }
 

--- a/src/Functions/concatWithSeparator.cpp
+++ b/src/Functions/concatWithSeparator.cpp
@@ -193,7 +193,7 @@ The function is named “injective” if it always returns different result for 
         .categories{"String"}});
 
     /// Compatibility with Spark and MySQL:
-    factory.registerAlias("concat_ws", "concatWithSeparator", FunctionFactory::CaseInsensitive);
+    factory.registerAlias("concat_ws", "concatWithSeparator", FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/connectionId.cpp
+++ b/src/Functions/connectionId.cpp
@@ -33,8 +33,8 @@ public:
 
 REGISTER_FUNCTION(ConnectionId)
 {
-    factory.registerFunction<FunctionConnectionId>({}, FunctionFactory::CaseInsensitive);
-    factory.registerAlias("connection_id", "connectionID", FunctionFactory::CaseInsensitive);
+    factory.registerFunction<FunctionConnectionId>({}, FunctionFactory::Case::Insensitive);
+    factory.registerAlias("connection_id", "connectionID", FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/cos.cpp
+++ b/src/Functions/cos.cpp
@@ -13,7 +13,7 @@ using FunctionCos = FunctionMathUnary<UnaryFunctionVectorized<CosName, cos>>;
 
 REGISTER_FUNCTION(Cos)
 {
-    factory.registerFunction<FunctionCos>({}, FunctionFactory::CaseInsensitive);
+    factory.registerFunction<FunctionCos>({}, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/countMatches.cpp
+++ b/src/Functions/countMatches.cpp
@@ -22,8 +22,8 @@ namespace DB
 
 REGISTER_FUNCTION(CountMatches)
 {
-    factory.registerFunction<FunctionCountMatches<FunctionCountMatchesCaseSensitive>>({}, FunctionFactory::CaseSensitive);
-    factory.registerFunction<FunctionCountMatches<FunctionCountMatchesCaseInsensitive>>({}, FunctionFactory::CaseSensitive);
+    factory.registerFunction<FunctionCountMatches<FunctionCountMatchesCaseSensitive>>();
+    factory.registerFunction<FunctionCountMatches<FunctionCountMatchesCaseInsensitive>>();
 }
 
 }

--- a/src/Functions/countSubstrings.cpp
+++ b/src/Functions/countSubstrings.cpp
@@ -19,6 +19,6 @@ using FunctionCountSubstrings = FunctionsStringSearch<CountSubstringsImpl<NameCo
 
 REGISTER_FUNCTION(CountSubstrings)
 {
-    factory.registerFunction<FunctionCountSubstrings>({}, FunctionFactory::CaseInsensitive);
+    factory.registerFunction<FunctionCountSubstrings>({}, FunctionFactory::Case::Insensitive);
 }
 }

--- a/src/Functions/currentDatabase.cpp
+++ b/src/Functions/currentDatabase.cpp
@@ -54,9 +54,9 @@ public:
 REGISTER_FUNCTION(CurrentDatabase)
 {
     factory.registerFunction<FunctionCurrentDatabase>();
-    factory.registerAlias("DATABASE", FunctionCurrentDatabase::name, FunctionFactory::CaseInsensitive);
-    factory.registerAlias("SCHEMA", FunctionCurrentDatabase::name, FunctionFactory::CaseInsensitive);
-    factory.registerAlias("current_database", FunctionCurrentDatabase::name, FunctionFactory::CaseInsensitive);
+    factory.registerAlias("DATABASE", FunctionCurrentDatabase::name, FunctionFactory::Case::Insensitive);
+    factory.registerAlias("SCHEMA", FunctionCurrentDatabase::name, FunctionFactory::Case::Insensitive);
+    factory.registerAlias("current_database", FunctionCurrentDatabase::name, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/currentSchemas.cpp
+++ b/src/Functions/currentSchemas.cpp
@@ -80,8 +80,8 @@ Requires a boolean parameter, but it is ignored actually. It is required just fo
              {"common", "SELECT current_schemas(true);", "['default']"}
         }
         },
-        FunctionFactory::CaseInsensitive);
-    factory.registerAlias("current_schemas", FunctionCurrentSchemas::name, FunctionFactory::CaseInsensitive);
+        FunctionFactory::Case::Insensitive);
+    factory.registerAlias("current_schemas", FunctionCurrentSchemas::name, FunctionFactory::Case::Insensitive);
 
 }
 

--- a/src/Functions/currentUser.cpp
+++ b/src/Functions/currentUser.cpp
@@ -54,8 +54,8 @@ public:
 REGISTER_FUNCTION(CurrentUser)
 {
     factory.registerFunction<FunctionCurrentUser>();
-    factory.registerAlias("user", FunctionCurrentUser::name, FunctionFactory::CaseInsensitive);
-    factory.registerAlias("current_user", FunctionCurrentUser::name, FunctionFactory::CaseInsensitive);
+    factory.registerAlias("user", FunctionCurrentUser::name, FunctionFactory::Case::Insensitive);
+    factory.registerAlias("current_user", FunctionCurrentUser::name, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/dateDiff.cpp
+++ b/src/Functions/dateDiff.cpp
@@ -490,7 +490,7 @@ private:
 
 REGISTER_FUNCTION(DateDiff)
 {
-    factory.registerFunction<FunctionDateDiff<true>>({}, FunctionFactory::CaseInsensitive);
+    factory.registerFunction<FunctionDateDiff<true>>({}, FunctionFactory::Case::Insensitive);
     factory.registerAlias("date_diff", FunctionDateDiff<true>::name);
     factory.registerAlias("DATE_DIFF", FunctionDateDiff<true>::name);
     factory.registerAlias("timestampDiff", FunctionDateDiff<true>::name);
@@ -509,12 +509,12 @@ Example:
 )",
     .examples{
         {"typical", "SELECT timeDiff(UTCTimestamp(), now());", ""}},
-    .categories{"Dates and Times"}}, FunctionFactory::CaseInsensitive);
+    .categories{"Dates and Times"}}, FunctionFactory::Case::Insensitive);
 }
 
 REGISTER_FUNCTION(Age)
 {
-    factory.registerFunction<FunctionDateDiff<false>>({}, FunctionFactory::CaseInsensitive);
+    factory.registerFunction<FunctionDateDiff<false>>({}, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/dateName.cpp
+++ b/src/Functions/dateName.cpp
@@ -354,7 +354,7 @@ private:
 
 REGISTER_FUNCTION(DateName)
 {
-    factory.registerFunction<FunctionDateNameImpl>({}, FunctionFactory::CaseInsensitive);
+    factory.registerFunction<FunctionDateNameImpl>({}, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/date_trunc.cpp
+++ b/src/Functions/date_trunc.cpp
@@ -178,7 +178,7 @@ REGISTER_FUNCTION(DateTrunc)
     factory.registerFunction<FunctionDateTrunc>();
 
     /// Compatibility alias.
-    factory.registerAlias("DATE_TRUNC", "dateTrunc", FunctionFactory::CaseInsensitive);
+    factory.registerAlias("DATE_TRUNC", "dateTrunc", FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/degrees.cpp
+++ b/src/Functions/degrees.cpp
@@ -23,7 +23,7 @@ namespace
 
 REGISTER_FUNCTION(Degrees)
 {
-    factory.registerFunction<FunctionDegrees>({}, FunctionFactory::CaseInsensitive);
+    factory.registerFunction<FunctionDegrees>({}, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/exp.cpp
+++ b/src/Functions/exp.cpp
@@ -36,7 +36,7 @@ using FunctionExp = FunctionMathUnary<UnaryFunctionVectorized<ExpName, exp>>;
 
 REGISTER_FUNCTION(Exp)
 {
-    factory.registerFunction<FunctionExp>({}, FunctionFactory::CaseInsensitive);
+    factory.registerFunction<FunctionExp>({}, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/extractAllGroupsVertical.cpp
+++ b/src/Functions/extractAllGroupsVertical.cpp
@@ -18,7 +18,7 @@ namespace DB
 REGISTER_FUNCTION(ExtractAllGroupsVertical)
 {
     factory.registerFunction<FunctionExtractAllGroups<VerticalImpl>>();
-    factory.registerAlias("extractAllGroups", VerticalImpl::Name, FunctionFactory::CaseSensitive);
+    factory.registerAlias("extractAllGroups", VerticalImpl::Name);
 }
 
 }

--- a/src/Functions/factorial.cpp
+++ b/src/Functions/factorial.cpp
@@ -106,7 +106,7 @@ The factorial of 0 is 1. Likewise, the factorial() function returns 1 for any ne
 )",
             .examples{{"factorial", "SELECT factorial(10)", ""}},
             .categories{"Mathematical"}},
-        FunctionFactory::CaseInsensitive);
+        FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/formatDateTime.cpp
+++ b/src/Functions/formatDateTime.cpp
@@ -1834,10 +1834,10 @@ using FunctionFromUnixTimestampInJodaSyntax = FunctionFormatDateTimeImpl<NameFro
 REGISTER_FUNCTION(FormatDateTime)
 {
     factory.registerFunction<FunctionFormatDateTime>();
-    factory.registerAlias("DATE_FORMAT", FunctionFormatDateTime::name, FunctionFactory::CaseInsensitive);
+    factory.registerAlias("DATE_FORMAT", FunctionFormatDateTime::name, FunctionFactory::Case::Insensitive);
 
     factory.registerFunction<FunctionFromUnixTimestamp>();
-    factory.registerAlias("FROM_UNIXTIME", FunctionFromUnixTimestamp::name, FunctionFactory::CaseInsensitive);
+    factory.registerAlias("FROM_UNIXTIME", FunctionFromUnixTimestamp::name, FunctionFactory::Case::Insensitive);
 
     factory.registerFunction<FunctionFormatDateTimeInJodaSyntax>();
     factory.registerFunction<FunctionFromUnixTimestampInJodaSyntax>();

--- a/src/Functions/formatReadableDecimalSize.cpp
+++ b/src/Functions/formatReadableDecimalSize.cpp
@@ -29,8 +29,7 @@ Accepts the size (number of bytes). Returns a rounded size with a suffix (KB, MB
         .examples{
             {"formatReadableDecimalSize", "SELECT formatReadableDecimalSize(1000)", ""}},
         .categories{"OtherFunctions"}
-    },
-    FunctionFactory::CaseSensitive);
+    });
 }
 
 }

--- a/src/Functions/formatReadableSize.cpp
+++ b/src/Functions/formatReadableSize.cpp
@@ -22,7 +22,7 @@ namespace
 REGISTER_FUNCTION(FormatReadableSize)
 {
     factory.registerFunction<FunctionFormatReadable<Impl>>();
-    factory.registerAlias("FORMAT_BYTES", Impl::name, FunctionFactory::CaseInsensitive);
+    factory.registerAlias("FORMAT_BYTES", Impl::name, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/fromDaysSinceYearZero.cpp
+++ b/src/Functions/fromDaysSinceYearZero.cpp
@@ -125,7 +125,7 @@ The calculation is the same as in MySQL's FROM_DAYS() function.
         .examples{{"typical", "SELECT fromDaysSinceYearZero32(713569)", "2023-09-08"}},
         .categories{"Dates and Times"}});
 
-    factory.registerAlias("FROM_DAYS", FunctionFromDaysSinceYearZero<DateTraits>::name, FunctionFactory::CaseInsensitive);
+    factory.registerAlias("FROM_DAYS", FunctionFromDaysSinceYearZero<DateTraits>::name, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/generateULID.cpp
+++ b/src/Functions/generateULID.cpp
@@ -85,8 +85,7 @@ The function returns a value of type FixedString(26).
             {"ulid", "SELECT generateULID()", ""},
             {"multiple", "SELECT generateULID(1), generateULID(2)", ""}},
         .categories{"ULID"}
-    },
-    FunctionFactory::CaseSensitive);
+    });
 }
 
 }

--- a/src/Functions/greatest.cpp
+++ b/src/Functions/greatest.cpp
@@ -65,7 +65,7 @@ using FunctionGreatest = FunctionBinaryArithmetic<GreatestImpl, NameGreatest>;
 
 REGISTER_FUNCTION(Greatest)
 {
-    factory.registerFunction<LeastGreatestOverloadResolver<LeastGreatest::Greatest, FunctionGreatest>>({}, FunctionFactory::CaseInsensitive);
+    factory.registerFunction<LeastGreatestOverloadResolver<LeastGreatest::Greatest, FunctionGreatest>>({}, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/hasSubsequence.cpp
+++ b/src/Functions/hasSubsequence.cpp
@@ -24,7 +24,7 @@ using FunctionHasSubsequence = HasSubsequenceImpl<NameHasSubsequence, HasSubsequ
 
 REGISTER_FUNCTION(hasSubsequence)
 {
-    factory.registerFunction<FunctionHasSubsequence>({}, FunctionFactory::CaseInsensitive);
+    factory.registerFunction<FunctionHasSubsequence>({}, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/hasSubsequenceCaseInsensitive.cpp
+++ b/src/Functions/hasSubsequenceCaseInsensitive.cpp
@@ -23,7 +23,7 @@ using FunctionHasSubsequenceCaseInsensitive = HasSubsequenceImpl<NameHasSubseque
 
 REGISTER_FUNCTION(hasSubsequenceCaseInsensitive)
 {
-    factory.registerFunction<FunctionHasSubsequenceCaseInsensitive>({}, FunctionFactory::CaseInsensitive);
+    factory.registerFunction<FunctionHasSubsequenceCaseInsensitive>({}, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/hasSubsequenceCaseInsensitiveUTF8.cpp
+++ b/src/Functions/hasSubsequenceCaseInsensitiveUTF8.cpp
@@ -25,7 +25,7 @@ using FunctionHasSubsequenceCaseInsensitiveUTF8 = HasSubsequenceImpl<NameHasSubs
 
 REGISTER_FUNCTION(hasSubsequenceCaseInsensitiveUTF8)
 {
-    factory.registerFunction<FunctionHasSubsequenceCaseInsensitiveUTF8>({}, FunctionFactory::CaseInsensitive);
+    factory.registerFunction<FunctionHasSubsequenceCaseInsensitiveUTF8>({}, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/hasSubsequenceUTF8.cpp
+++ b/src/Functions/hasSubsequenceUTF8.cpp
@@ -24,7 +24,7 @@ using FunctionHasSubsequenceUTF8 = HasSubsequenceImpl<NameHasSubsequenceUTF8, Ha
 
 REGISTER_FUNCTION(hasSubsequenceUTF8)
 {
-    factory.registerFunction<FunctionHasSubsequenceUTF8>({}, FunctionFactory::CaseInsensitive);
+    factory.registerFunction<FunctionHasSubsequenceUTF8>({}, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/hasToken.cpp
+++ b/src/Functions/hasToken.cpp
@@ -25,10 +25,10 @@ using FunctionHasTokenOrNull
 REGISTER_FUNCTION(HasToken)
 {
     factory.registerFunction<FunctionHasToken>(FunctionDocumentation
-        {.description="Performs lookup of needle in haystack using tokenbf_v1 index."}, FunctionFactory::CaseSensitive);
+        {.description="Performs lookup of needle in haystack using tokenbf_v1 index."});
 
     factory.registerFunction<FunctionHasTokenOrNull>(FunctionDocumentation
-        {.description="Performs lookup of needle in haystack using tokenbf_v1 index. Returns null if needle is ill-formed."}, FunctionFactory::CaseSensitive);
+        {.description="Performs lookup of needle in haystack using tokenbf_v1 index. Returns null if needle is ill-formed."});
 }
 
 }

--- a/src/Functions/hasTokenCaseInsensitive.cpp
+++ b/src/Functions/hasTokenCaseInsensitive.cpp
@@ -26,11 +26,11 @@ REGISTER_FUNCTION(HasTokenCaseInsensitive)
 {
     factory.registerFunction<FunctionHasTokenCaseInsensitive>(
         FunctionDocumentation{.description="Performs case insensitive lookup of needle in haystack using tokenbf_v1 index."},
-        DB::FunctionFactory::CaseInsensitive);
+        DB::FunctionFactory::Case::Insensitive);
 
     factory.registerFunction<FunctionHasTokenCaseInsensitiveOrNull>(
         FunctionDocumentation{.description="Performs case insensitive lookup of needle in haystack using tokenbf_v1 index. Returns null if needle is ill-formed."},
-        DB::FunctionFactory::CaseInsensitive);
+        DB::FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/hypot.cpp
+++ b/src/Functions/hypot.cpp
@@ -15,7 +15,7 @@ namespace
 
 REGISTER_FUNCTION(Hypot)
 {
-    factory.registerFunction<FunctionHypot>({}, FunctionFactory::CaseInsensitive);
+    factory.registerFunction<FunctionHypot>({}, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/if.cpp
+++ b/src/Functions/if.cpp
@@ -1309,7 +1309,7 @@ public:
 
 REGISTER_FUNCTION(If)
 {
-    factory.registerFunction<FunctionIf>({}, FunctionFactory::CaseInsensitive);
+    factory.registerFunction<FunctionIf>({}, FunctionFactory::Case::Insensitive);
 }
 
 FunctionOverloadResolverPtr createInternalFunctionIfOverloadResolver(bool allow_experimental_variant_type, bool use_variant_as_common_type)

--- a/src/Functions/ifNull.cpp
+++ b/src/Functions/ifNull.cpp
@@ -91,7 +91,7 @@ private:
 
 REGISTER_FUNCTION(IfNull)
 {
-    factory.registerFunction<FunctionIfNull>({}, FunctionFactory::CaseInsensitive);
+    factory.registerFunction<FunctionIfNull>({}, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/initcap.cpp
+++ b/src/Functions/initcap.cpp
@@ -60,7 +60,7 @@ using FunctionInitcap = FunctionStringToString<InitcapImpl, NameInitcap>;
 
 REGISTER_FUNCTION(Initcap)
 {
-    factory.registerFunction<FunctionInitcap>({}, FunctionFactory::CaseInsensitive);
+    factory.registerFunction<FunctionInitcap>({}, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/initialQueryID.cpp
+++ b/src/Functions/initialQueryID.cpp
@@ -41,6 +41,6 @@ public:
 REGISTER_FUNCTION(InitialQueryID)
 {
     factory.registerFunction<FunctionInitialQueryID>();
-    factory.registerAlias("initial_query_id", FunctionInitialQueryID::name, FunctionFactory::CaseInsensitive);
+    factory.registerAlias("initial_query_id", FunctionInitialQueryID::name, FunctionFactory::Case::Insensitive);
 }
 }

--- a/src/Functions/isNull.cpp
+++ b/src/Functions/isNull.cpp
@@ -101,7 +101,7 @@ public:
 
 REGISTER_FUNCTION(IsNull)
 {
-    factory.registerFunction<FunctionIsNull>({}, FunctionFactory::CaseInsensitive);
+    factory.registerFunction<FunctionIsNull>({}, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/keyvaluepair/extractKeyValuePairs.cpp
+++ b/src/Functions/keyvaluepair/extractKeyValuePairs.cpp
@@ -241,7 +241,7 @@ REGISTER_FUNCTION(ExtractKeyValuePairs)
             └──────────────────┘
             ```)"}
     );
-    factory.registerAlias("str_to_map", NameExtractKeyValuePairs::name, FunctionFactory::CaseInsensitive);
+    factory.registerAlias("str_to_map", NameExtractKeyValuePairs::name, FunctionFactory::Case::Insensitive);
     factory.registerAlias("mapFromString", NameExtractKeyValuePairs::name);
 }
 

--- a/src/Functions/least.cpp
+++ b/src/Functions/least.cpp
@@ -65,7 +65,7 @@ using FunctionLeast = FunctionBinaryArithmetic<LeastImpl, NameLeast>;
 
 REGISTER_FUNCTION(Least)
 {
-    factory.registerFunction<LeastGreatestOverloadResolver<LeastGreatest::Least, FunctionLeast>>({}, FunctionFactory::CaseInsensitive);
+    factory.registerFunction<LeastGreatestOverloadResolver<LeastGreatest::Least, FunctionLeast>>({}, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/left.cpp
+++ b/src/Functions/left.cpp
@@ -6,8 +6,8 @@ namespace DB
 
 REGISTER_FUNCTION(Left)
 {
-    factory.registerFunction<FunctionLeftRight<false, SubstringDirection::Left>>({}, FunctionFactory::CaseInsensitive);
-    factory.registerFunction<FunctionLeftRight<true, SubstringDirection::Left>>({}, FunctionFactory::CaseSensitive);
+    factory.registerFunction<FunctionLeftRight<false, SubstringDirection::Left>>({}, FunctionFactory::Case::Insensitive);
+    factory.registerFunction<FunctionLeftRight<true, SubstringDirection::Left>>({}, FunctionFactory::Case::Sensitive);
 }
 
 }

--- a/src/Functions/lengthUTF8.cpp
+++ b/src/Functions/lengthUTF8.cpp
@@ -83,8 +83,8 @@ REGISTER_FUNCTION(LengthUTF8)
     factory.registerFunction<FunctionLengthUTF8>();
 
     /// Compatibility aliases.
-    factory.registerAlias("CHAR_LENGTH", "lengthUTF8", FunctionFactory::CaseInsensitive);
-    factory.registerAlias("CHARACTER_LENGTH", "lengthUTF8", FunctionFactory::CaseInsensitive);
+    factory.registerAlias("CHAR_LENGTH", "lengthUTF8", FunctionFactory::Case::Insensitive);
+    factory.registerAlias("CHARACTER_LENGTH", "lengthUTF8", FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/locate.cpp
+++ b/src/Functions/locate.cpp
@@ -29,6 +29,6 @@ REGISTER_FUNCTION(Locate)
     FunctionDocumentation::Categories doc_categories = {"String search"};
 
 
-    factory.registerFunction<FunctionLocate>({doc_description, doc_syntax, doc_arguments, doc_returned_value, doc_examples, doc_categories}, FunctionFactory::CaseInsensitive);
+    factory.registerFunction<FunctionLocate>({doc_description, doc_syntax, doc_arguments, doc_returned_value, doc_examples, doc_categories}, FunctionFactory::Case::Insensitive);
 }
 }

--- a/src/Functions/log.cpp
+++ b/src/Functions/log.cpp
@@ -34,8 +34,8 @@ using FunctionLog = FunctionMathUnary<UnaryFunctionVectorized<LogName, log>>;
 
 REGISTER_FUNCTION(Log)
 {
-    factory.registerFunction<FunctionLog>({}, FunctionFactory::CaseInsensitive);
-    factory.registerAlias("ln", "log", FunctionFactory::CaseInsensitive);
+    factory.registerFunction<FunctionLog>({}, FunctionFactory::Case::Insensitive);
+    factory.registerAlias("ln", "log", FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/log10.cpp
+++ b/src/Functions/log10.cpp
@@ -13,7 +13,7 @@ using FunctionLog10 = FunctionMathUnary<UnaryFunctionVectorized<Log10Name, log10
 
 REGISTER_FUNCTION(Log10)
 {
-    factory.registerFunction<FunctionLog10>({}, FunctionFactory::CaseInsensitive);
+    factory.registerFunction<FunctionLog10>({}, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/log2.cpp
+++ b/src/Functions/log2.cpp
@@ -13,7 +13,7 @@ using FunctionLog2 = FunctionMathUnary<UnaryFunctionVectorized<Log2Name, log2>>;
 
 REGISTER_FUNCTION(Log2)
 {
-    factory.registerFunction<FunctionLog2>({}, FunctionFactory::CaseInsensitive);
+    factory.registerFunction<FunctionLog2>({}, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/lower.cpp
+++ b/src/Functions/lower.cpp
@@ -19,8 +19,8 @@ using FunctionLower = FunctionStringToString<LowerUpperImpl<'A', 'Z'>, NameLower
 
 REGISTER_FUNCTION(Lower)
 {
-    factory.registerFunction<FunctionLower>({}, FunctionFactory::CaseInsensitive);
-    factory.registerAlias("lcase", NameLower::name, FunctionFactory::CaseInsensitive);
+    factory.registerFunction<FunctionLower>({}, FunctionFactory::Case::Insensitive);
+    factory.registerAlias("lcase", NameLower::name, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/makeDate.cpp
+++ b/src/Functions/makeDate.cpp
@@ -724,7 +724,7 @@ public:
 
 REGISTER_FUNCTION(MakeDate)
 {
-    factory.registerFunction<FunctionMakeDate<DateTraits>>({}, FunctionFactory::CaseInsensitive);
+    factory.registerFunction<FunctionMakeDate<DateTraits>>({}, FunctionFactory::Case::Insensitive);
     factory.registerFunction<FunctionMakeDate<Date32Traits>>();
     factory.registerFunction<FunctionMakeDateTime>();
     factory.registerFunction<FunctionMakeDateTime64>();

--- a/src/Functions/match.cpp
+++ b/src/Functions/match.cpp
@@ -20,7 +20,7 @@ using FunctionMatch = FunctionsStringSearch<MatchImpl<NameMatch, MatchTraits::Sy
 REGISTER_FUNCTION(Match)
 {
     factory.registerFunction<FunctionMatch>();
-    factory.registerAlias("REGEXP_MATCHES", NameMatch::name, FunctionFactory::CaseInsensitive);
+    factory.registerAlias("REGEXP_MATCHES", NameMatch::name, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/mathConstants.cpp
+++ b/src/Functions/mathConstants.cpp
@@ -44,7 +44,7 @@ REGISTER_FUNCTION(E)
 
 REGISTER_FUNCTION(Pi)
 {
-    factory.registerFunction<FunctionPi>({}, FunctionFactory::CaseInsensitive);
+    factory.registerFunction<FunctionPi>({}, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/max2.cpp
+++ b/src/Functions/max2.cpp
@@ -21,6 +21,6 @@ namespace
 
 REGISTER_FUNCTION(Max2)
 {
-    factory.registerFunction<FunctionMax2>({}, FunctionFactory::CaseInsensitive);
+    factory.registerFunction<FunctionMax2>({}, FunctionFactory::Case::Insensitive);
 }
 }

--- a/src/Functions/min2.cpp
+++ b/src/Functions/min2.cpp
@@ -22,6 +22,6 @@ namespace
 
 REGISTER_FUNCTION(Min2)
 {
-    factory.registerFunction<FunctionMin2>({}, FunctionFactory::CaseInsensitive);
+    factory.registerFunction<FunctionMin2>({}, FunctionFactory::Case::Insensitive);
 }
 }

--- a/src/Functions/modulo.cpp
+++ b/src/Functions/modulo.cpp
@@ -155,7 +155,7 @@ using FunctionModulo = BinaryArithmeticOverloadResolver<ModuloImpl, NameModulo, 
 REGISTER_FUNCTION(Modulo)
 {
     factory.registerFunction<FunctionModulo>();
-    factory.registerAlias("mod", "modulo", FunctionFactory::CaseInsensitive);
+    factory.registerAlias("mod", "modulo", FunctionFactory::Case::Insensitive);
 }
 
 struct NameModuloLegacy { static constexpr auto name = "moduloLegacy"; };
@@ -183,11 +183,11 @@ In other words, the function returning the modulus (modulo) in the terms of Modu
         )",
             .examples{{"positiveModulo", "SELECT positiveModulo(-1, 10);", ""}},
             .categories{"Arithmetic"}},
-        FunctionFactory::CaseInsensitive);
+        FunctionFactory::Case::Insensitive);
 
-    factory.registerAlias("positive_modulo", "positiveModulo", FunctionFactory::CaseInsensitive);
+    factory.registerAlias("positive_modulo", "positiveModulo", FunctionFactory::Case::Insensitive);
     /// Compatibility with Spark:
-    factory.registerAlias("pmod", "positiveModulo", FunctionFactory::CaseInsensitive);
+    factory.registerAlias("pmod", "positiveModulo", FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/monthName.cpp
+++ b/src/Functions/monthName.cpp
@@ -74,7 +74,7 @@ private:
 
 REGISTER_FUNCTION(MonthName)
 {
-    factory.registerFunction<FunctionMonthName>({}, FunctionFactory::CaseInsensitive);
+    factory.registerFunction<FunctionMonthName>({}, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/now.cpp
+++ b/src/Functions/now.cpp
@@ -138,8 +138,8 @@ private:
 
 REGISTER_FUNCTION(Now)
 {
-    factory.registerFunction<NowOverloadResolver>({}, FunctionFactory::CaseInsensitive);
-    factory.registerAlias("current_timestamp", NowOverloadResolver::name, FunctionFactory::CaseInsensitive);
+    factory.registerFunction<NowOverloadResolver>({}, FunctionFactory::Case::Insensitive);
+    factory.registerAlias("current_timestamp", NowOverloadResolver::name, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/now64.cpp
+++ b/src/Functions/now64.cpp
@@ -170,7 +170,7 @@ private:
 
 REGISTER_FUNCTION(Now64)
 {
-    factory.registerFunction<Now64OverloadResolver>({}, FunctionFactory::CaseInsensitive);
+    factory.registerFunction<Now64OverloadResolver>({}, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/nullIf.cpp
+++ b/src/Functions/nullIf.cpp
@@ -69,7 +69,7 @@ public:
 
 REGISTER_FUNCTION(NullIf)
 {
-    factory.registerFunction<FunctionNullIf>({}, FunctionFactory::CaseInsensitive);
+    factory.registerFunction<FunctionNullIf>({}, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/padString.cpp
+++ b/src/Functions/padString.cpp
@@ -335,8 +335,8 @@ REGISTER_FUNCTION(PadString)
     factory.registerFunction<FunctionPadString<true, false>>();  /// rightPad
     factory.registerFunction<FunctionPadString<true, true>>();   /// rightPadUTF8
 
-    factory.registerAlias("lpad", "leftPad", FunctionFactory::CaseInsensitive);
-    factory.registerAlias("rpad", "rightPad", FunctionFactory::CaseInsensitive);
+    factory.registerAlias("lpad", "leftPad", FunctionFactory::Case::Insensitive);
+    factory.registerAlias("rpad", "rightPad", FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/parseDateTime.cpp
+++ b/src/Functions/parseDateTime.cpp
@@ -2098,10 +2098,10 @@ namespace
 REGISTER_FUNCTION(ParseDateTime)
 {
     factory.registerFunction<FunctionParseDateTime>();
-    factory.registerAlias("TO_UNIXTIME", FunctionParseDateTime::name, FunctionFactory::CaseInsensitive);
+    factory.registerAlias("TO_UNIXTIME", FunctionParseDateTime::name, FunctionFactory::Case::Insensitive);
     factory.registerFunction<FunctionParseDateTimeOrZero>();
     factory.registerFunction<FunctionParseDateTimeOrNull>();
-    factory.registerAlias("str_to_date", FunctionParseDateTimeOrNull::name, FunctionFactory::CaseInsensitive);
+    factory.registerAlias("str_to_date", FunctionParseDateTimeOrNull::name, FunctionFactory::Case::Insensitive);
 
     factory.registerFunction<FunctionParseDateTimeInJodaSyntax>();
     factory.registerFunction<FunctionParseDateTimeInJodaSyntaxOrZero>();

--- a/src/Functions/position.cpp
+++ b/src/Functions/position.cpp
@@ -19,6 +19,6 @@ using FunctionPosition = FunctionsStringSearch<PositionImpl<NamePosition, Positi
 
 REGISTER_FUNCTION(Position)
 {
-    factory.registerFunction<FunctionPosition>({}, FunctionFactory::CaseInsensitive);
+    factory.registerFunction<FunctionPosition>({}, FunctionFactory::Case::Insensitive);
 }
 }

--- a/src/Functions/positionCaseInsensitive.cpp
+++ b/src/Functions/positionCaseInsensitive.cpp
@@ -20,6 +20,6 @@ using FunctionPositionCaseInsensitive = FunctionsStringSearch<PositionImpl<NameP
 REGISTER_FUNCTION(PositionCaseInsensitive)
 {
     factory.registerFunction<FunctionPositionCaseInsensitive>();
-    factory.registerAlias("instr", NamePositionCaseInsensitive::name, FunctionFactory::CaseInsensitive);
+    factory.registerAlias("instr", NamePositionCaseInsensitive::name, FunctionFactory::Case::Insensitive);
 }
 }

--- a/src/Functions/pow.cpp
+++ b/src/Functions/pow.cpp
@@ -13,8 +13,8 @@ using FunctionPow = FunctionMathBinaryFloat64<BinaryFunctionVectorized<PowName, 
 
 REGISTER_FUNCTION(Pow)
 {
-    factory.registerFunction<FunctionPow>({}, FunctionFactory::CaseInsensitive);
-    factory.registerAlias("power", "pow", FunctionFactory::CaseInsensitive);
+    factory.registerFunction<FunctionPow>({}, FunctionFactory::Case::Insensitive);
+    factory.registerAlias("power", "pow", FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/queryID.cpp
+++ b/src/Functions/queryID.cpp
@@ -41,6 +41,6 @@ public:
 REGISTER_FUNCTION(QueryID)
 {
     factory.registerFunction<FunctionQueryID>();
-    factory.registerAlias("query_id", FunctionQueryID::name, FunctionFactory::CaseInsensitive);
+    factory.registerAlias("query_id", FunctionQueryID::name, FunctionFactory::Case::Insensitive);
 }
 }

--- a/src/Functions/radians.cpp
+++ b/src/Functions/radians.cpp
@@ -23,7 +23,7 @@ namespace
 
 REGISTER_FUNCTION(Radians)
 {
-    factory.registerFunction<FunctionRadians>({}, FunctionFactory::CaseInsensitive);
+    factory.registerFunction<FunctionRadians>({}, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/rand.cpp
+++ b/src/Functions/rand.cpp
@@ -13,7 +13,7 @@ using FunctionRand = FunctionRandom<UInt32, NameRand>;
 
 REGISTER_FUNCTION(Rand)
 {
-    factory.registerFunction<FunctionRand>({}, FunctionFactory::CaseInsensitive);
+    factory.registerFunction<FunctionRand>({}, FunctionFactory::Case::Insensitive);
     factory.registerAlias("rand32", NameRand::name);
 }
 

--- a/src/Functions/regexpExtract.cpp
+++ b/src/Functions/regexpExtract.cpp
@@ -253,7 +253,7 @@ REGISTER_FUNCTION(RegexpExtract)
         FunctionDocumentation{.description="Extracts the first string in haystack that matches the regexp pattern and corresponds to the regex group index."});
 
     /// For Spark compatibility.
-    factory.registerAlias("REGEXP_EXTRACT", "regexpExtract", FunctionFactory::CaseInsensitive);
+    factory.registerAlias("REGEXP_EXTRACT", "regexpExtract", FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/repeat.cpp
+++ b/src/Functions/repeat.cpp
@@ -278,7 +278,7 @@ public:
 
 REGISTER_FUNCTION(Repeat)
 {
-    factory.registerFunction<FunctionRepeat>({}, FunctionFactory::CaseInsensitive);
+    factory.registerFunction<FunctionRepeat>({}, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/replaceAll.cpp
+++ b/src/Functions/replaceAll.cpp
@@ -20,7 +20,7 @@ using FunctionReplaceAll = FunctionStringReplace<ReplaceStringImpl<NameReplaceAl
 REGISTER_FUNCTION(ReplaceAll)
 {
     factory.registerFunction<FunctionReplaceAll>();
-    factory.registerAlias("replace", NameReplaceAll::name, FunctionFactory::CaseInsensitive);
+    factory.registerAlias("replace", NameReplaceAll::name, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/replaceRegexpAll.cpp
+++ b/src/Functions/replaceRegexpAll.cpp
@@ -20,7 +20,7 @@ using FunctionReplaceRegexpAll = FunctionStringReplace<ReplaceRegexpImpl<NameRep
 REGISTER_FUNCTION(ReplaceRegexpAll)
 {
     factory.registerFunction<FunctionReplaceRegexpAll>();
-    factory.registerAlias("REGEXP_REPLACE", NameReplaceRegexpAll::name, FunctionFactory::CaseInsensitive);
+    factory.registerAlias("REGEXP_REPLACE", NameReplaceRegexpAll::name, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/reverse.cpp
+++ b/src/Functions/reverse.cpp
@@ -113,7 +113,7 @@ private:
 
 REGISTER_FUNCTION(Reverse)
 {
-    factory.registerFunction<ReverseOverloadResolver>({}, FunctionFactory::CaseInsensitive);
+    factory.registerFunction<ReverseOverloadResolver>({}, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/right.cpp
+++ b/src/Functions/right.cpp
@@ -6,8 +6,8 @@ namespace DB
 
 REGISTER_FUNCTION(Right)
 {
-    factory.registerFunction<FunctionLeftRight<false, SubstringDirection::Right>>({}, FunctionFactory::CaseInsensitive);
-    factory.registerFunction<FunctionLeftRight<true, SubstringDirection::Right>>({}, FunctionFactory::CaseSensitive);
+    factory.registerFunction<FunctionLeftRight<false, SubstringDirection::Right>>({}, FunctionFactory::Case::Insensitive);
+    factory.registerFunction<FunctionLeftRight<true, SubstringDirection::Right>>({}, FunctionFactory::Case::Sensitive);
 }
 
 }

--- a/src/Functions/serverConstants.cpp
+++ b/src/Functions/serverConstants.cpp
@@ -206,12 +206,12 @@ REGISTER_FUNCTION(Uptime)
 
 REGISTER_FUNCTION(Version)
 {
-    factory.registerFunction<FunctionVersion>({}, FunctionFactory::CaseInsensitive);
+    factory.registerFunction<FunctionVersion>({}, FunctionFactory::Case::Insensitive);
 }
 
 REGISTER_FUNCTION(Revision)
 {
-    factory.registerFunction<FunctionRevision>({}, FunctionFactory::CaseInsensitive);
+    factory.registerFunction<FunctionRevision>({}, FunctionFactory::Case::Insensitive);
 }
 
 REGISTER_FUNCTION(ZooKeeperSessionUptime)
@@ -237,8 +237,7 @@ Returns the value of `display_name` from config or server FQDN if not set.
 )",
             .examples{{"displayName", "SELECT displayName();", ""}},
             .categories{"Constant", "Miscellaneous"}
-        },
-        FunctionFactory::CaseSensitive);
+        });
 }
 
 

--- a/src/Functions/sign.cpp
+++ b/src/Functions/sign.cpp
@@ -44,7 +44,7 @@ struct FunctionUnaryArithmeticMonotonicity<NameSign>
 
 REGISTER_FUNCTION(Sign)
 {
-    factory.registerFunction<FunctionSign>({}, FunctionFactory::CaseInsensitive);
+    factory.registerFunction<FunctionSign>({}, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/sin.cpp
+++ b/src/Functions/sin.cpp
@@ -21,7 +21,7 @@ REGISTER_FUNCTION(Sin)
             .returned_value = "The sine of x.",
             .examples = {{.name = "simple", .query = "SELECT sin(1.23)", .result = "0.9424888019316975"}},
             .categories{"Mathematical", "Trigonometric"}},
-        FunctionFactory::CaseInsensitive);
+        FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/soundex.cpp
+++ b/src/Functions/soundex.cpp
@@ -112,7 +112,7 @@ struct NameSoundex
 REGISTER_FUNCTION(Soundex)
 {
     factory.registerFunction<FunctionStringToString<SoundexImpl, NameSoundex>>(
-        FunctionDocumentation{.description="Returns Soundex code of a string."}, FunctionFactory::CaseInsensitive);
+        FunctionDocumentation{.description="Returns Soundex code of a string."}, FunctionFactory::Case::Insensitive);
 }
 
 

--- a/src/Functions/space.cpp
+++ b/src/Functions/space.cpp
@@ -173,7 +173,7 @@ public:
 
 REGISTER_FUNCTION(Space)
 {
-    factory.registerFunction<FunctionSpace>({}, FunctionFactory::CaseInsensitive);
+    factory.registerFunction<FunctionSpace>({}, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/sqrt.cpp
+++ b/src/Functions/sqrt.cpp
@@ -13,7 +13,7 @@ using FunctionSqrt = FunctionMathUnary<UnaryFunctionVectorized<SqrtName, sqrt>>;
 
 REGISTER_FUNCTION(Sqrt)
 {
-    factory.registerFunction<FunctionSqrt>({}, FunctionFactory::CaseInsensitive);
+    factory.registerFunction<FunctionSqrt>({}, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/structureToFormatSchema.cpp
+++ b/src/Functions/structureToFormatSchema.cpp
@@ -116,8 +116,7 @@ Function that converts ClickHouse table structure to CapnProto format schema
 "}"},
             },
             .categories{"Other"}
-        },
-        FunctionFactory::CaseSensitive);
+        });
 }
 
 
@@ -138,8 +137,7 @@ Function that converts ClickHouse table structure to Protobuf format schema
 "}"},
             },
             .categories{"Other"}
-        },
-        FunctionFactory::CaseSensitive);
+        });
 }
 
 }

--- a/src/Functions/substring.cpp
+++ b/src/Functions/substring.cpp
@@ -201,12 +201,12 @@ public:
 
 REGISTER_FUNCTION(Substring)
 {
-    factory.registerFunction<FunctionSubstring<false>>({}, FunctionFactory::CaseInsensitive);
-    factory.registerAlias("substr", "substring", FunctionFactory::CaseInsensitive); // MySQL alias
-    factory.registerAlias("mid", "substring", FunctionFactory::CaseInsensitive); /// MySQL alias
-    factory.registerAlias("byteSlice", "substring", FunctionFactory::CaseInsensitive); /// resembles PostgreSQL's get_byte function, similar to ClickHouse's bitSlice
+    factory.registerFunction<FunctionSubstring<false>>({}, FunctionFactory::Case::Insensitive);
+    factory.registerAlias("substr", "substring", FunctionFactory::Case::Insensitive); // MySQL alias
+    factory.registerAlias("mid", "substring", FunctionFactory::Case::Insensitive); /// MySQL alias
+    factory.registerAlias("byteSlice", "substring", FunctionFactory::Case::Insensitive); /// resembles PostgreSQL's get_byte function, similar to ClickHouse's bitSlice
 
-    factory.registerFunction<FunctionSubstring<true>>({}, FunctionFactory::CaseSensitive);
+    factory.registerFunction<FunctionSubstring<true>>();
 }
 
 }

--- a/src/Functions/substringIndex.cpp
+++ b/src/Functions/substringIndex.cpp
@@ -314,7 +314,7 @@ REGISTER_FUNCTION(SubstringIndex)
     factory.registerFunction<FunctionSubstringIndex<false>>(); /// substringIndex
     factory.registerFunction<FunctionSubstringIndex<true>>(); /// substringIndexUTF8
 
-    factory.registerAlias("SUBSTRING_INDEX", "substringIndex", FunctionFactory::CaseInsensitive);
+    factory.registerAlias("SUBSTRING_INDEX", "substringIndex", FunctionFactory::Case::Insensitive);
 }
 
 

--- a/src/Functions/synonyms.cpp
+++ b/src/Functions/synonyms.cpp
@@ -121,7 +121,7 @@ public:
 
 REGISTER_FUNCTION(Synonyms)
 {
-    factory.registerFunction<FunctionSynonyms>({}, FunctionFactory::CaseInsensitive);
+    factory.registerFunction<FunctionSynonyms>({}, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/tan.cpp
+++ b/src/Functions/tan.cpp
@@ -13,7 +13,7 @@ using FunctionTan = FunctionMathUnary<UnaryFunctionVectorized<TanName, tan>>;
 
 REGISTER_FUNCTION(Tan)
 {
-    factory.registerFunction<FunctionTan>({}, FunctionFactory::CaseInsensitive);
+    factory.registerFunction<FunctionTan>({}, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/tanh.cpp
+++ b/src/Functions/tanh.cpp
@@ -39,7 +39,7 @@ using FunctionTanh = FunctionMathUnary<UnaryFunctionVectorized<TanhName, tanh>>;
 
 REGISTER_FUNCTION(Tanh)
 {
-    factory.registerFunction<FunctionTanh>({}, FunctionFactory::CaseInsensitive);
+    factory.registerFunction<FunctionTanh>({}, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/timestamp.cpp
+++ b/src/Functions/timestamp.cpp
@@ -187,7 +187,7 @@ If the second argument 'expr_time' is provided, it adds the specified time to th
             {"timestamp", "SELECT timestamp('2013-12-31 12:00:00')", "2013-12-31 12:00:00.000000"},
             {"timestamp", "SELECT timestamp('2013-12-31 12:00:00', '12:00:00.11')", "2014-01-01 00:00:00.110000"},
         },
-        .categories{"DateTime"}}, FunctionFactory::CaseInsensitive);
+        .categories{"DateTime"}}, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/toCustomWeek.cpp
+++ b/src/Functions/toCustomWeek.cpp
@@ -21,8 +21,8 @@ REGISTER_FUNCTION(ToCustomWeek)
     factory.registerFunction<FunctionToLastDayOfWeek>();
 
     /// Compatibility aliases for mysql.
-    factory.registerAlias("week", "toWeek", FunctionFactory::CaseInsensitive);
-    factory.registerAlias("yearweek", "toYearWeek", FunctionFactory::CaseInsensitive);
+    factory.registerAlias("week", "toWeek", FunctionFactory::Case::Insensitive);
+    factory.registerAlias("yearweek", "toYearWeek", FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/toDayOfMonth.cpp
+++ b/src/Functions/toDayOfMonth.cpp
@@ -14,8 +14,8 @@ REGISTER_FUNCTION(ToDayOfMonth)
     factory.registerFunction<FunctionToDayOfMonth>();
 
     /// MySQL compatibility alias.
-    factory.registerAlias("DAY", "toDayOfMonth", FunctionFactory::CaseInsensitive);
-    factory.registerAlias("DAYOFMONTH", "toDayOfMonth", FunctionFactory::CaseInsensitive);
+    factory.registerAlias("DAY", "toDayOfMonth", FunctionFactory::Case::Insensitive);
+    factory.registerAlias("DAYOFMONTH", "toDayOfMonth", FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/toDayOfWeek.cpp
+++ b/src/Functions/toDayOfWeek.cpp
@@ -13,7 +13,7 @@ REGISTER_FUNCTION(ToDayOfWeek)
     factory.registerFunction<FunctionToDayOfWeek>();
 
     /// MySQL compatibility alias.
-    factory.registerAlias("DAYOFWEEK", "toDayOfWeek", FunctionFactory::CaseInsensitive);
+    factory.registerAlias("DAYOFWEEK", "toDayOfWeek", FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/toDayOfYear.cpp
+++ b/src/Functions/toDayOfYear.cpp
@@ -14,7 +14,7 @@ REGISTER_FUNCTION(ToDayOfYear)
     factory.registerFunction<FunctionToDayOfYear>();
 
     /// MySQL compatibility alias.
-    factory.registerAlias("DAYOFYEAR", "toDayOfYear", FunctionFactory::CaseInsensitive);
+    factory.registerAlias("DAYOFYEAR", "toDayOfYear", FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/toDaysSinceYearZero.cpp
+++ b/src/Functions/toDaysSinceYearZero.cpp
@@ -20,7 +20,7 @@ The calculation is the same as in MySQL's TO_DAYS() function.
         .categories{"Dates and Times"}});
 
     /// MySQL compatibility alias.
-    factory.registerAlias("TO_DAYS", FunctionToDaysSinceYearZero::name, FunctionFactory::CaseInsensitive);
+    factory.registerAlias("TO_DAYS", FunctionToDaysSinceYearZero::name, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/toDecimalString.cpp
+++ b/src/Functions/toDecimalString.cpp
@@ -273,7 +273,7 @@ second argument is the desired number of digits in fractional part. Returns Stri
         )",
             .examples{{"toDecimalString", "SELECT toDecimalString(2.1456,2)", ""}},
             .categories{"String"}
-        }, FunctionFactory::CaseInsensitive);
+        }, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/toHour.cpp
+++ b/src/Functions/toHour.cpp
@@ -14,7 +14,7 @@ REGISTER_FUNCTION(ToHour)
     factory.registerFunction<FunctionToHour>();
 
     /// MySQL compatibility alias.
-    factory.registerAlias("HOUR", "toHour", FunctionFactory::CaseInsensitive);
+    factory.registerAlias("HOUR", "toHour", FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/toLastDayOfMonth.cpp
+++ b/src/Functions/toLastDayOfMonth.cpp
@@ -13,7 +13,7 @@ REGISTER_FUNCTION(ToLastDayOfMonth)
     factory.registerFunction<FunctionToLastDayOfMonth>();
 
     /// MySQL compatibility alias.
-    factory.registerAlias("LAST_DAY", "toLastDayOfMonth", FunctionFactory::CaseInsensitive);
+    factory.registerAlias("LAST_DAY", "toLastDayOfMonth", FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/toMillisecond.cpp
+++ b/src/Functions/toMillisecond.cpp
@@ -27,7 +27,7 @@ Returns the millisecond component (0-999) of a date with time.
             );
 
     /// MySQL compatibility alias.
-    factory.registerAlias("MILLISECOND", "toMillisecond", FunctionFactory::CaseInsensitive);
+    factory.registerAlias("MILLISECOND", "toMillisecond", FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/toMinute.cpp
+++ b/src/Functions/toMinute.cpp
@@ -14,7 +14,7 @@ REGISTER_FUNCTION(ToMinute)
     factory.registerFunction<FunctionToMinute>();
 
     /// MySQL compatibility alias.
-    factory.registerAlias("MINUTE", "toMinute", FunctionFactory::CaseInsensitive);
+    factory.registerAlias("MINUTE", "toMinute", FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/toMonth.cpp
+++ b/src/Functions/toMonth.cpp
@@ -13,7 +13,7 @@ REGISTER_FUNCTION(ToMonth)
 {
     factory.registerFunction<FunctionToMonth>();
     /// MySQL compatibility alias.
-    factory.registerAlias("MONTH", "toMonth", FunctionFactory::CaseInsensitive);
+    factory.registerAlias("MONTH", "toMonth", FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/toQuarter.cpp
+++ b/src/Functions/toQuarter.cpp
@@ -13,7 +13,7 @@ REGISTER_FUNCTION(ToQuarter)
 {
     factory.registerFunction<FunctionToQuarter>();
     /// MySQL compatibility alias.
-    factory.registerAlias("QUARTER", "toQuarter", FunctionFactory::CaseInsensitive);
+    factory.registerAlias("QUARTER", "toQuarter", FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/toSecond.cpp
+++ b/src/Functions/toSecond.cpp
@@ -14,7 +14,7 @@ REGISTER_FUNCTION(ToSecond)
     factory.registerFunction<FunctionToSecond>();
 
     /// MySQL compatibility alias.
-    factory.registerAlias("SECOND", "toSecond", FunctionFactory::CaseInsensitive);
+    factory.registerAlias("SECOND", "toSecond", FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/toYear.cpp
+++ b/src/Functions/toYear.cpp
@@ -14,7 +14,7 @@ REGISTER_FUNCTION(ToYear)
     factory.registerFunction<FunctionToYear>();
 
     /// MySQL compatibility alias.
-    factory.registerAlias("YEAR", "toYear", FunctionFactory::CaseInsensitive);
+    factory.registerAlias("YEAR", "toYear", FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/today.cpp
+++ b/src/Functions/today.cpp
@@ -84,8 +84,8 @@ public:
 REGISTER_FUNCTION(Today)
 {
     factory.registerFunction<TodayOverloadResolver>();
-    factory.registerAlias("current_date", TodayOverloadResolver::name, FunctionFactory::CaseInsensitive);
-    factory.registerAlias("curdate", TodayOverloadResolver::name, FunctionFactory::CaseInsensitive);
+    factory.registerAlias("current_date", TodayOverloadResolver::name, FunctionFactory::Case::Insensitive);
+    factory.registerAlias("curdate", TodayOverloadResolver::name, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/upper.cpp
+++ b/src/Functions/upper.cpp
@@ -18,8 +18,8 @@ using FunctionUpper = FunctionStringToString<LowerUpperImpl<'a', 'z'>, NameUpper
 
 REGISTER_FUNCTION(Upper)
 {
-    factory.registerFunction<FunctionUpper>({}, FunctionFactory::CaseInsensitive);
-    factory.registerAlias("ucase", FunctionUpper::name, FunctionFactory::CaseInsensitive);
+    factory.registerFunction<FunctionUpper>({}, FunctionFactory::Case::Insensitive);
+    factory.registerAlias("ucase", FunctionUpper::name, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/vectorFunctions.cpp
+++ b/src/Functions/vectorFunctions.cpp
@@ -1576,9 +1576,9 @@ using TupleOrArrayFunctionCosineDistance = TupleOrArrayFunction<CosineDistanceTr
 REGISTER_FUNCTION(VectorFunctions)
 {
     factory.registerFunction<FunctionTuplePlus>();
-    factory.registerAlias("vectorSum", FunctionTuplePlus::name, FunctionFactory::CaseInsensitive);
+    factory.registerAlias("vectorSum", FunctionTuplePlus::name, FunctionFactory::Case::Insensitive);
     factory.registerFunction<FunctionTupleMinus>();
-    factory.registerAlias("vectorDifference", FunctionTupleMinus::name, FunctionFactory::CaseInsensitive);
+    factory.registerAlias("vectorDifference", FunctionTupleMinus::name, FunctionFactory::Case::Insensitive);
     factory.registerFunction<FunctionTupleMultiply>();
     factory.registerFunction<FunctionTupleDivide>();
     factory.registerFunction<FunctionTupleModulo>();
@@ -1652,7 +1652,7 @@ If the types of the first interval (or the interval in the tuple) and the second
     factory.registerFunction<FunctionTupleIntDivOrZeroByNumber>();
 
     factory.registerFunction<TupleOrArrayFunctionDotProduct>();
-    factory.registerAlias("scalarProduct", TupleOrArrayFunctionDotProduct::name, FunctionFactory::CaseInsensitive);
+    factory.registerAlias("scalarProduct", TupleOrArrayFunctionDotProduct::name, FunctionFactory::Case::Insensitive);
 
     factory.registerFunction<TupleOrArrayFunctionL1Norm>();
     factory.registerFunction<TupleOrArrayFunctionL2Norm>();
@@ -1660,11 +1660,11 @@ If the types of the first interval (or the interval in the tuple) and the second
     factory.registerFunction<TupleOrArrayFunctionLinfNorm>();
     factory.registerFunction<TupleOrArrayFunctionLpNorm>();
 
-    factory.registerAlias("normL1", TupleOrArrayFunctionL1Norm::name, FunctionFactory::CaseInsensitive);
-    factory.registerAlias("normL2", TupleOrArrayFunctionL2Norm::name, FunctionFactory::CaseInsensitive);
-    factory.registerAlias("normL2Squared", TupleOrArrayFunctionL2SquaredNorm::name, FunctionFactory::CaseInsensitive);
-    factory.registerAlias("normLinf", TupleOrArrayFunctionLinfNorm::name, FunctionFactory::CaseInsensitive);
-    factory.registerAlias("normLp", FunctionLpNorm::name, FunctionFactory::CaseInsensitive);
+    factory.registerAlias("normL1", TupleOrArrayFunctionL1Norm::name, FunctionFactory::Case::Insensitive);
+    factory.registerAlias("normL2", TupleOrArrayFunctionL2Norm::name, FunctionFactory::Case::Insensitive);
+    factory.registerAlias("normL2Squared", TupleOrArrayFunctionL2SquaredNorm::name, FunctionFactory::Case::Insensitive);
+    factory.registerAlias("normLinf", TupleOrArrayFunctionLinfNorm::name, FunctionFactory::Case::Insensitive);
+    factory.registerAlias("normLp", FunctionLpNorm::name, FunctionFactory::Case::Insensitive);
 
     factory.registerFunction<TupleOrArrayFunctionL1Distance>();
     factory.registerFunction<TupleOrArrayFunctionL2Distance>();
@@ -1672,21 +1672,21 @@ If the types of the first interval (or the interval in the tuple) and the second
     factory.registerFunction<TupleOrArrayFunctionLinfDistance>();
     factory.registerFunction<TupleOrArrayFunctionLpDistance>();
 
-    factory.registerAlias("distanceL1", FunctionL1Distance::name, FunctionFactory::CaseInsensitive);
-    factory.registerAlias("distanceL2", FunctionL2Distance::name, FunctionFactory::CaseInsensitive);
-    factory.registerAlias("distanceL2Squared", FunctionL2SquaredDistance::name, FunctionFactory::CaseInsensitive);
-    factory.registerAlias("distanceLinf", FunctionLinfDistance::name, FunctionFactory::CaseInsensitive);
-    factory.registerAlias("distanceLp", FunctionLpDistance::name, FunctionFactory::CaseInsensitive);
+    factory.registerAlias("distanceL1", FunctionL1Distance::name, FunctionFactory::Case::Insensitive);
+    factory.registerAlias("distanceL2", FunctionL2Distance::name, FunctionFactory::Case::Insensitive);
+    factory.registerAlias("distanceL2Squared", FunctionL2SquaredDistance::name, FunctionFactory::Case::Insensitive);
+    factory.registerAlias("distanceLinf", FunctionLinfDistance::name, FunctionFactory::Case::Insensitive);
+    factory.registerAlias("distanceLp", FunctionLpDistance::name, FunctionFactory::Case::Insensitive);
 
     factory.registerFunction<FunctionL1Normalize>();
     factory.registerFunction<FunctionL2Normalize>();
     factory.registerFunction<FunctionLinfNormalize>();
     factory.registerFunction<FunctionLpNormalize>();
 
-    factory.registerAlias("normalizeL1", FunctionL1Normalize::name, FunctionFactory::CaseInsensitive);
-    factory.registerAlias("normalizeL2", FunctionL2Normalize::name, FunctionFactory::CaseInsensitive);
-    factory.registerAlias("normalizeLinf", FunctionLinfNormalize::name, FunctionFactory::CaseInsensitive);
-    factory.registerAlias("normalizeLp", FunctionLpNormalize::name, FunctionFactory::CaseInsensitive);
+    factory.registerAlias("normalizeL1", FunctionL1Normalize::name, FunctionFactory::Case::Insensitive);
+    factory.registerAlias("normalizeL2", FunctionL2Normalize::name, FunctionFactory::Case::Insensitive);
+    factory.registerAlias("normalizeLinf", FunctionLinfNormalize::name, FunctionFactory::Case::Insensitive);
+    factory.registerAlias("normalizeLp", FunctionLpNormalize::name, FunctionFactory::Case::Insensitive);
 
     factory.registerFunction<TupleOrArrayFunctionCosineDistance>();
 }

--- a/src/Functions/widthBucket.cpp
+++ b/src/Functions/widthBucket.cpp
@@ -287,7 +287,7 @@ Result:
         .categories{"Mathematical"},
     });
 
-    factory.registerAlias("width_bucket", "widthBucket", FunctionFactory::CaseInsensitive);
+    factory.registerAlias("width_bucket", "widthBucket", FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Processors/Transforms/WindowTransform.cpp
+++ b/src/Processors/Transforms/WindowTransform.cpp
@@ -2716,42 +2716,42 @@ void registerWindowFunctions(AggregateFunctionFactory & factory)
         {
             return std::make_shared<WindowFunctionRank>(name, argument_types,
                 parameters);
-        }, properties}, AggregateFunctionFactory::CaseInsensitive);
+        }, properties}, AggregateFunctionFactory::Case::Insensitive);
 
     factory.registerFunction("dense_rank", {[](const std::string & name,
             const DataTypes & argument_types, const Array & parameters, const Settings *)
         {
             return std::make_shared<WindowFunctionDenseRank>(name, argument_types,
                 parameters);
-        }, properties}, AggregateFunctionFactory::CaseInsensitive);
+        }, properties}, AggregateFunctionFactory::Case::Insensitive);
 
     factory.registerFunction("percent_rank", {[](const std::string & name,
             const DataTypes & argument_types, const Array & parameters, const Settings *)
         {
             return std::make_shared<WindowFunctionPercentRank>(name, argument_types,
                 parameters);
-        }, properties}, AggregateFunctionFactory::CaseInsensitive);
+        }, properties}, AggregateFunctionFactory::Case::Insensitive);
 
     factory.registerFunction("row_number", {[](const std::string & name,
             const DataTypes & argument_types, const Array & parameters, const Settings *)
         {
             return std::make_shared<WindowFunctionRowNumber>(name, argument_types,
                 parameters);
-        }, properties}, AggregateFunctionFactory::CaseInsensitive);
+        }, properties}, AggregateFunctionFactory::Case::Insensitive);
 
     factory.registerFunction("ntile", {[](const std::string & name,
             const DataTypes & argument_types, const Array & parameters, const Settings *)
         {
             return std::make_shared<WindowFunctionNtile>(name, argument_types,
                 parameters);
-        }, properties}, AggregateFunctionFactory::CaseInsensitive);
+        }, properties}, AggregateFunctionFactory::Case::Insensitive);
 
     factory.registerFunction("nth_value", {[](const std::string & name,
             const DataTypes & argument_types, const Array & parameters, const Settings *)
         {
             return std::make_shared<WindowFunctionNthValue>(
                 name, argument_types, parameters);
-        }, properties}, AggregateFunctionFactory::CaseInsensitive);
+        }, properties}, AggregateFunctionFactory::Case::Insensitive);
 
     factory.registerFunction("lagInFrame", {[](const std::string & name,
             const DataTypes & argument_types, const Array & parameters, const Settings *)

--- a/src/TableFunctions/TableFunctionFactory.cpp
+++ b/src/TableFunctions/TableFunctionFactory.cpp
@@ -19,17 +19,17 @@ namespace ErrorCodes
 }
 
 void TableFunctionFactory::registerFunction(
-    const std::string & name, Value value, CaseSensitiveness case_sensitiveness)
+    const std::string & name, Value value, Case case_sensitiveness)
 {
     if (!table_functions.emplace(name, value).second)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "TableFunctionFactory: the table function name '{}' is not unique", name);
 
-    if (case_sensitiveness == CaseInsensitive
+    if (case_sensitiveness == Case::Insensitive
         && !case_insensitive_table_functions.emplace(Poco::toLower(name), value).second)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "TableFunctionFactory: "
                         "the case insensitive table function name '{}' is not unique", name);
 
-    KnownTableFunctionNames::instance().add(name, (case_sensitiveness == CaseInsensitive));
+    KnownTableFunctionNames::instance().add(name, (case_sensitiveness == Case::Insensitive));
 }
 
 TableFunctionPtr TableFunctionFactory::get(

--- a/src/TableFunctions/TableFunctionFactory.h
+++ b/src/TableFunctions/TableFunctionFactory.h
@@ -48,10 +48,10 @@ public:
     void registerFunction(
         const std::string & name,
         Value value,
-        CaseSensitiveness case_sensitiveness = CaseSensitive);
+        Case case_sensitiveness = Case::Sensitive);
 
     template <typename Function>
-    void registerFunction(TableFunctionProperties properties = {}, CaseSensitiveness case_sensitiveness = CaseSensitive)
+    void registerFunction(TableFunctionProperties properties = {}, Case case_sensitiveness = Case::Sensitive)
     {
         auto creator = []() -> TableFunctionPtr { return std::make_shared<Function>(); };
         registerFunction(Function::name,

--- a/src/TableFunctions/TableFunctionFormat.cpp
+++ b/src/TableFunctions/TableFunctionFormat.cpp
@@ -219,7 +219,7 @@ Result:
 
 void registerTableFunctionFormat(TableFunctionFactory & factory)
 {
-    factory.registerFunction<TableFunctionFormat>({format_table_function_documentation, false}, TableFunctionFactory::CaseInsensitive);
+    factory.registerFunction<TableFunctionFormat>({format_table_function_documentation, false}, TableFunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/TableFunctions/TableFunctionValues.cpp
+++ b/src/TableFunctions/TableFunctionValues.cpp
@@ -174,7 +174,7 @@ StoragePtr TableFunctionValues::executeImpl(const ASTPtr & ast_function, Context
 
 void registerTableFunctionValues(TableFunctionFactory & factory)
 {
-    factory.registerFunction<TableFunctionValues>({.documentation = {}, .allow_readonly = true}, TableFunctionFactory::CaseInsensitive);
+    factory.registerFunction<TableFunctionValues>({.documentation = {}, .allow_readonly = true}, TableFunctionFactory::Case::Insensitive);
 }
 
 }


### PR DESCRIPTION
While re-implementing https://github.com/ClickHouse/ClickHouse/pull/55035 (which is currently removed with https://github.com/ClickHouse/ClickHouse/pull/66630), I got slightly annoyed that `CaseSensitiveness` is an `enum`. This PR makes it an `enum class`.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)