### PR TITLE
Fix something around clang-tidy

### DIFF
--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -2731,8 +2731,7 @@ void Server::createInterserverServers(
 
 void Server::stopServers(
     std::vector<ProtocolServerAdapter> & servers,
-    const ServerType & server_type
-) const
+    const ServerType & server_type) const
 {
     LoggerRawPtr log = &logger();
 

--- a/programs/server/Server.h
+++ b/programs/server/Server.h
@@ -129,8 +129,7 @@ private:
 
     void stopServers(
         std::vector<ProtocolServerAdapter> & servers,
-        const ServerType & server_type
-    ) const;
+        const ServerType & server_type) const;
 };
 
 }

--- a/src/Databases/IDatabase.h
+++ b/src/Databases/IDatabase.h
@@ -6,7 +6,6 @@
 #include <Interpreters/executeQuery.h>
 #include <Parsers/IAST_fwd.h>
 #include <QueryPipeline/BlockIO.h>
-#include <Storages/IStorage.h>
 #include <Storages/IStorage_fwd.h>
 #include <base/types.h>
 #include <Common/AsyncLoader.h>

--- a/src/Storages/MergeTree/AlterConversions.h
+++ b/src/Storages/MergeTree/AlterConversions.h
@@ -8,7 +8,6 @@
 namespace DB
 {
 
-
 /// Alter conversions which should be applied on-fly for part.
 /// Built from of the most recent mutation commands for part.
 /// Now only ALTER RENAME COLUMN is applied.

--- a/src/Storages/MergeTree/MergeTreeDataMergerMutator.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataMergerMutator.cpp
@@ -118,11 +118,11 @@ UInt64 MergeTreeDataMergerMutator::getMaxSourcePartSizeForMutation() const
         occupied >= data_settings->max_number_of_mutations_for_replica)
         return 0;
 
-    /// DataPart can be store only at one disk. Get maximum reservable free space at all disks.
+    /// A DataPart can be stored only at a single disk. Get the maximum reservable free space at all disks.
     UInt64 disk_space = data.getStoragePolicy()->getMaxUnreservedFreeSpace();
     auto max_tasks_count = data.getContext()->getMergeMutateExecutor()->getMaxTasksCount();
 
-    /// Allow mutations only if there are enough threads, leave free threads for merges else
+    /// Allow mutations only if there are enough threads, otherwise, leave free threads for merges.
     if (occupied <= 1
         || max_tasks_count - occupied >= data_settings->number_of_free_entries_in_pool_to_execute_mutation)
         return static_cast<UInt64>(disk_space / DISK_USAGE_COEFFICIENT_TO_RESERVE);

--- a/src/Storages/StorageMergeTree.h
+++ b/src/Storages/StorageMergeTree.h
@@ -211,7 +211,6 @@ private:
         bool optimize_skip_merged_partitions = false,
         SelectPartsDecision * select_decision_out = nullptr);
 
-
     MergeMutateSelectedEntryPtr selectPartsToMutate(
         const StorageMetadataPtr & metadata_snapshot, PreformattedMessage & disable_reason,
         TableLockHolder & table_lock_holder, std::unique_lock<std::mutex> & currently_processing_in_background_mutex_lock);
@@ -310,6 +309,7 @@ private:
     };
 
 protected:
+    /// Collect mutations that have to be applied on the fly: currently they are only RENAME COLUMN.
     MutationCommands getAlterMutationCommandsForPart(const DataPartPtr & part) const override;
 };
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


See https://s3.amazonaws.com/clickhouse-builds/PRs/66630/29d3f9598d58aa6010509fbf4e2344cefd4cef24/binary_tidy/build_log.log


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
