### PR TITLE
Introduce properties for functions

### DIFF
--- a/src/AggregateFunctions/AggregateFunctionFactory.cpp
+++ b/src/AggregateFunctions/AggregateFunctionFactory.cpp
@@ -252,7 +252,7 @@ AggregateFunctionPtr AggregateFunctionFactory::getImpl(
 
 
     String extra_info;
-    if (FunctionFactory::instance().hasNameOrAlias(name))
+    if (FunctionFactory::instance().isNameOrAlias(name))
         extra_info = ". There is an ordinary function with the same name, but aggregate function is expected here";
 
     auto hints = this->getHints(name);

--- a/src/AggregateFunctions/AggregateFunctionFactory.cpp
+++ b/src/AggregateFunctions/AggregateFunctionFactory.cpp
@@ -128,7 +128,7 @@ AggregateFunctionPtr AggregateFunctionFactory::get(
     return with_original_arguments;
 }
 
-std::optional<AggregateFunctionWithProperties>
+std::optional<AggregateFunctionFactoryData>
 AggregateFunctionFactory::getAssociatedFunctionByNullsAction(const String & name, NullsAction action) const
 {
     if (action == NullsAction::RESPECT_NULLS)

--- a/src/AggregateFunctions/AggregateFunctionFactory.cpp
+++ b/src/AggregateFunctions/AggregateFunctionFactory.cpp
@@ -36,15 +36,13 @@ void AggregateFunctionFactory::registerFunction(const String & name, Value creat
             "the aggregate function {} has been provided  a null constructor", name);
 
     if (!aggregate_functions.emplace(name, creator_with_properties).second)
-        throw Exception(ErrorCodes::LOGICAL_ERROR, "AggregateFunctionFactory: the aggregate function name '{}' is not unique",
-            name);
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "AggregateFunctionFactory: the aggregate function name '{}' is not unique", name);
 
     if (case_sensitiveness == Case::Insensitive)
     {
         auto key = Poco::toLower(name);
         if (!case_insensitive_aggregate_functions.emplace(key, creator_with_properties).second)
-            throw Exception(ErrorCodes::LOGICAL_ERROR, "AggregateFunctionFactory: "
-                "the case insensitive aggregate function name '{}' is not unique", name);
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "AggregateFunctionFactory: the case insensitive aggregate function name '{}' is not unique", name);
         case_insensitive_name_mapping[key] = name;
     }
 }
@@ -58,12 +56,10 @@ void AggregateFunctionFactory::registerNullsActionTransformation(const String & 
         throw Exception(ErrorCodes::LOGICAL_ERROR, "registerNullsActionTransformation: Target aggregation '{}' not found", target_respect_nulls);
 
     if (!respect_nulls.emplace(source_ignores_nulls, target_respect_nulls).second)
-        throw Exception(
-            ErrorCodes::LOGICAL_ERROR, "registerNullsActionTransformation: Assignment from '{}' is not unique", source_ignores_nulls);
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "registerNullsActionTransformation: Assignment from '{}' is not unique", source_ignores_nulls);
 
     if (!ignore_nulls.emplace(target_respect_nulls, source_ignores_nulls).second)
-        throw Exception(
-            ErrorCodes::LOGICAL_ERROR, "registerNullsActionTransformation: Assignment from '{}' is not unique", target_respect_nulls);
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "registerNullsActionTransformation: Assignment from '{}' is not unique", target_respect_nulls);
 }
 
 static DataTypes convertLowCardinalityTypesToNested(const DataTypes & types)
@@ -101,8 +97,7 @@ AggregateFunctionPtr AggregateFunctionFactory::get(
     {
         AggregateFunctionCombinatorPtr combinator = AggregateFunctionCombinatorFactory::instance().tryFindSuffix("Null");
         if (!combinator)
-            throw Exception(ErrorCodes::LOGICAL_ERROR, "Cannot find aggregate function combinator "
-                            "to apply a function to Nullable arguments.");
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "Cannot find aggregate function combinator to apply a function to Nullable arguments.");
 
         DataTypes nested_types = combinator->transformArguments(types_without_low_cardinality);
         Array nested_parameters = combinator->transformParameters(parameters);
@@ -138,8 +133,7 @@ AggregateFunctionFactory::getAssociatedFunctionByNullsAction(const String & name
         else if (auto associated_it = aggregate_functions.find(it->second); associated_it != aggregate_functions.end())
             return {associated_it->second};
         else
-            throw Exception(
-                ErrorCodes::LOGICAL_ERROR, "Unable to find the function {} (equivalent to '{} RESPECT NULLS')", it->second, name);
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "Unable to find the function {} (equivalent to '{} RESPECT NULLS')", it->second, name);
     }
 
     if (action == NullsAction::IGNORE_NULLS)
@@ -149,8 +143,7 @@ AggregateFunctionFactory::getAssociatedFunctionByNullsAction(const String & name
             if (auto associated_it = aggregate_functions.find(it->second); associated_it != aggregate_functions.end())
                 return {associated_it->second};
             else
-                throw Exception(
-                    ErrorCodes::LOGICAL_ERROR, "Unable to find the function {} (equivalent to '{} IGNORE NULLS')", it->second, name);
+                throw Exception(ErrorCodes::LOGICAL_ERROR, "Unable to find the function {} (equivalent to '{} IGNORE NULLS')", it->second, name);
         }
         /// We don't throw for IGNORE NULLS of other functions because that's the default in CH
     }
@@ -172,11 +165,8 @@ AggregateFunctionPtr AggregateFunctionFactory::getImpl(
     bool is_case_insensitive = false;
     Value found;
 
-    /// Find by exact match.
     if (auto it = aggregate_functions.find(name); it != aggregate_functions.end())
-    {
         found = it->second;
-    }
 
     if (!found.creator)
     {
@@ -220,9 +210,7 @@ AggregateFunctionPtr AggregateFunctionFactory::getImpl(
         const std::string & combinator_name = combinator->getName();
 
         if (combinator->isForInternalUsageOnly())
-            throw Exception(ErrorCodes::UNKNOWN_AGGREGATE_FUNCTION,
-                "Aggregate function combinator '{}' is only for internal usage",
-                combinator_name);
+            throw Exception(ErrorCodes::UNKNOWN_AGGREGATE_FUNCTION,"Aggregate function combinator '{}' is only for internal usage", combinator_name);
 
         if (query_context && query_context->getSettingsRef().log_queries)
             query_context->addQueryFactoriesInfo(Context::QueryLogFactories::AggregateFunctionCombinator, combinator_name);
@@ -238,9 +226,7 @@ AggregateFunctionPtr AggregateFunctionFactory::getImpl(
 
         if (!combinator->supportsNesting() && nested_name.ends_with(combinator_name))
         {
-            throw Exception(ErrorCodes::ILLEGAL_AGGREGATION,
-                "Nested identical combinator '{}' is not supported",
-                combinator_name);
+            throw Exception(ErrorCodes::ILLEGAL_AGGREGATION, "Nested identical combinator '{}' is not supported", combinator_name);
         }
 
         DataTypes nested_types = combinator->transformArguments(argument_types);
@@ -257,8 +243,7 @@ AggregateFunctionPtr AggregateFunctionFactory::getImpl(
 
     auto hints = this->getHints(name);
     if (!hints.empty())
-        throw Exception(ErrorCodes::UNKNOWN_AGGREGATE_FUNCTION,
-                        "Unknown aggregate function {}{}. Maybe you meant: {}", name, extra_info, toString(hints));
+        throw Exception(ErrorCodes::UNKNOWN_AGGREGATE_FUNCTION, "Unknown aggregate function {}{}. Maybe you meant: {}", name, extra_info, toString(hints));
     else
         throw Exception(ErrorCodes::UNKNOWN_AGGREGATE_FUNCTION, "Unknown aggregate function {}{}", name, extra_info);
 }
@@ -275,11 +260,8 @@ std::optional<AggregateFunctionProperties> AggregateFunctionFactory::tryGetPrope
         String lower_case_name;
         bool is_case_insensitive = false;
 
-        /// Find by exact match.
         if (auto it = aggregate_functions.find(name); it != aggregate_functions.end())
-        {
             found = it->second;
-        }
 
         if (!found.creator)
         {

--- a/src/AggregateFunctions/AggregateFunctionFactory.h
+++ b/src/AggregateFunctions/AggregateFunctionFactory.h
@@ -30,18 +30,18 @@ using DataTypes = std::vector<DataTypePtr>;
  */
 using AggregateFunctionCreator = std::function<AggregateFunctionPtr(const String &, const DataTypes &, const Array &, const Settings *)>;
 
-struct AggregateFunctionWithProperties
+struct AggregateFunctionFactoryData
 {
     AggregateFunctionCreator creator;
     AggregateFunctionProperties properties;
 
-    AggregateFunctionWithProperties() = default;
-    AggregateFunctionWithProperties(const AggregateFunctionWithProperties &) = default;
-    AggregateFunctionWithProperties & operator = (const AggregateFunctionWithProperties &) = default;
+    AggregateFunctionFactoryData() = default;
+    AggregateFunctionFactoryData(const AggregateFunctionFactoryData &) = default;
+    AggregateFunctionFactoryData & operator = (const AggregateFunctionFactoryData &) = default;
 
     template <typename Creator>
-    requires (!std::is_same_v<Creator, AggregateFunctionWithProperties>)
-    AggregateFunctionWithProperties(Creator creator_, AggregateFunctionProperties properties_ = {}) /// NOLINT
+    requires (!std::is_same_v<Creator, AggregateFunctionFactoryData>)
+    AggregateFunctionFactoryData(Creator creator_, AggregateFunctionProperties properties_ = {}) /// NOLINT
         : creator(std::forward<Creator>(creator_)), properties(std::move(properties_))
     {
     }
@@ -50,7 +50,7 @@ struct AggregateFunctionWithProperties
 
 /** Creates an aggregate function by name.
   */
-class AggregateFunctionFactory final : private boost::noncopyable, public IFactoryWithAliases<AggregateFunctionWithProperties>
+class AggregateFunctionFactory final : private boost::noncopyable, public IFactoryWithAliases<AggregateFunctionFactoryData>
 {
 public:
     static AggregateFunctionFactory & instance();
@@ -99,7 +99,7 @@ private:
     ActionMap respect_nulls;
     /// Same as above for `IGNORE NULLS` modifier
     ActionMap ignore_nulls;
-    std::optional<AggregateFunctionWithProperties> getAssociatedFunctionByNullsAction(const String & name, NullsAction action) const;
+    std::optional<AggregateFunctionFactoryData> getAssociatedFunctionByNullsAction(const String & name, NullsAction action) const;
 
     /// Case insensitive aggregate functions will be additionally added here with lowercased name.
     AggregateFunctions case_insensitive_aggregate_functions;

--- a/src/AggregateFunctions/AggregateFunctionFactory.h
+++ b/src/AggregateFunctions/AggregateFunctionFactory.h
@@ -105,7 +105,6 @@ private:
     AggregateFunctions case_insensitive_aggregate_functions;
 
     const AggregateFunctions & getMap() const override { return aggregate_functions; }
-
     const AggregateFunctions & getCaseInsensitiveMap() const override { return case_insensitive_aggregate_functions; }
 
     String getFactoryName() const override { return "AggregateFunctionFactory"; }

--- a/src/AggregateFunctions/AggregateFunctionFactory.h
+++ b/src/AggregateFunctions/AggregateFunctionFactory.h
@@ -52,6 +52,7 @@ struct AggregateFunctionFactoryData
   */
 class AggregateFunctionFactory final : private boost::noncopyable, public IFactoryWithAliases<AggregateFunctionFactoryData>
 {
+    using Base = IFactoryWithAliases<AggregateFunctionFactoryData>;
 public:
     static AggregateFunctionFactory & instance();
 
@@ -94,6 +95,7 @@ private:
     using ActionMap = std::unordered_map<String, String>;
 
     AggregateFunctions aggregate_functions;
+    AggregateFunctions case_insensitive_aggregate_functions;
     /// Mapping from functions with `RESPECT NULLS` modifier to actual aggregate function names
     /// Example: `any(x) RESPECT NULLS` should be executed as function `any_respect_nulls`
     ActionMap respect_nulls;
@@ -101,14 +103,10 @@ private:
     ActionMap ignore_nulls;
     std::optional<AggregateFunctionFactoryData> getAssociatedFunctionByNullsAction(const String & name, NullsAction action) const;
 
-    /// Case insensitive aggregate functions will be additionally added here with lowercased name.
-    AggregateFunctions case_insensitive_aggregate_functions;
-
-    const AggregateFunctions & getMap() const override { return aggregate_functions; }
-    const AggregateFunctions & getCaseInsensitiveMap() const override { return case_insensitive_aggregate_functions; }
+    const Base::OriginalNameMap & getOriginalNameMap() const override { return aggregate_functions; }
+    const Base::OriginalNameMap & getOriginalCaseInsensitiveNameMap() const override { return case_insensitive_aggregate_functions; }
 
     String getFactoryName() const override { return "AggregateFunctionFactory"; }
-
 };
 
 struct AggregateUtils

--- a/src/Compression/CompressionFactory.cpp
+++ b/src/Compression/CompressionFactory.cpp
@@ -136,17 +136,14 @@ void CompressionCodecFactory::registerCompressionCodecWithType(
     CreatorWithType creator)
 {
     if (creator == nullptr)
-        throw Exception(ErrorCodes::LOGICAL_ERROR, "CompressionCodecFactory: "
-                        "the codec family {} has been provided a null constructor", family_name);
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "CompressionCodecFactory: the codec family {} has been provided a null constructor", family_name);
 
     if (!family_name_with_codec.emplace(family_name, creator).second)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "CompressionCodecFactory: the codec family name '{}' is not unique", family_name);
 
     if (byte_code)
         if (!family_code_with_codec.emplace(*byte_code, creator).second)
-            throw Exception(ErrorCodes::LOGICAL_ERROR,
-                            "CompressionCodecFactory: the codec family code '{}' is not unique",
-                            std::to_string(*byte_code));
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "CompressionCodecFactory: the codec family code '{}' is not unique", std::to_string(*byte_code));
 }
 
 void CompressionCodecFactory::registerCompressionCodec(const String & family_name, std::optional<uint8_t> byte_code, Creator creator)

--- a/src/Compression/CompressionFactory.h
+++ b/src/Compression/CompressionFactory.h
@@ -4,7 +4,6 @@
 #include <Compression/ICompressionCodec.h>
 #include <DataTypes/IDataType.h>
 #include <Parsers/IAST_fwd.h>
-#include <Common/IFactoryWithAliases.h>
 
 #include <functional>
 #include <memory>

--- a/src/DataTypes/DataTypeFactory.cpp
+++ b/src/DataTypes/DataTypeFactory.cpp
@@ -197,8 +197,7 @@ void DataTypeFactory::registerDataType(const String & family_name, Value creator
 void DataTypeFactory::registerSimpleDataType(const String & name, SimpleCreator creator, Case case_sensitiveness)
 {
     if (creator == nullptr)
-        throw Exception(ErrorCodes::LOGICAL_ERROR, "DataTypeFactory: the data type {} has been provided  a null constructor",
-            name);
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "DataTypeFactory: the data type {} has been provided  a null constructor", name);
 
     registerDataType(name, [name, creator](const ASTPtr & ast)
     {

--- a/src/DataTypes/DataTypeFactory.cpp
+++ b/src/DataTypes/DataTypeFactory.cpp
@@ -267,6 +267,32 @@ const DataTypeFactory::Value * DataTypeFactory::findCreatorByName(const String &
         throw Exception(ErrorCodes::UNKNOWN_TYPE, "Unknown data type family: {}", family_name);
 }
 
+void registerDataTypeNumbers(DataTypeFactory & factory);
+void registerDataTypeDecimal(DataTypeFactory & factory);
+void registerDataTypeDate(DataTypeFactory & factory);
+void registerDataTypeDate32(DataTypeFactory & factory);
+void registerDataTypeDateTime(DataTypeFactory & factory);
+void registerDataTypeString(DataTypeFactory & factory);
+void registerDataTypeFixedString(DataTypeFactory & factory);
+void registerDataTypeEnum(DataTypeFactory & factory);
+void registerDataTypeArray(DataTypeFactory & factory);
+void registerDataTypeTuple(DataTypeFactory & factory);
+void registerDataTypeMap(DataTypeFactory & factory);
+void registerDataTypeNullable(DataTypeFactory & factory);
+void registerDataTypeNothing(DataTypeFactory & factory);
+void registerDataTypeUUID(DataTypeFactory & factory);
+void registerDataTypeIPv4andIPv6(DataTypeFactory & factory);
+void registerDataTypeAggregateFunction(DataTypeFactory & factory);
+void registerDataTypeNested(DataTypeFactory & factory);
+void registerDataTypeInterval(DataTypeFactory & factory);
+void registerDataTypeLowCardinality(DataTypeFactory & factory);
+void registerDataTypeDomainBool(DataTypeFactory & factory);
+void registerDataTypeDomainSimpleAggregateFunction(DataTypeFactory & factory);
+void registerDataTypeDomainGeo(DataTypeFactory & factory);
+void registerDataTypeObject(DataTypeFactory & factory);
+void registerDataTypeVariant(DataTypeFactory & factory);
+void registerDataTypeDynamic(DataTypeFactory & factory);
+
 DataTypeFactory::DataTypeFactory()
 {
     registerDataTypeNumbers(*this);

--- a/src/DataTypes/DataTypeFactory.cpp
+++ b/src/DataTypes/DataTypeFactory.cpp
@@ -236,7 +236,7 @@ const DataTypeFactory::Value * DataTypeFactory::findCreatorByName(const String &
     if (CurrentThread::isInitialized())
         query_context = CurrentThread::get().getQueryContext();
     {
-        DataTypesDictionary::const_iterator it = data_types.find(family_name);
+        auto it = data_types.find(family_name);
         if (data_types.end() != it)
         {
             if (query_context && query_context->getSettingsRef().log_queries)
@@ -248,7 +248,7 @@ const DataTypeFactory::Value * DataTypeFactory::findCreatorByName(const String &
     String family_name_lowercase = Poco::toLower(family_name);
 
     {
-        DataTypesDictionary::const_iterator it = case_insensitive_data_types.find(family_name_lowercase);
+        auto it = case_insensitive_data_types.find(family_name_lowercase);
         if (case_insensitive_data_types.end() != it)
         {
             if (query_context && query_context->getSettingsRef().log_queries)

--- a/src/DataTypes/DataTypeFactory.h
+++ b/src/DataTypes/DataTypeFactory.h
@@ -76,30 +76,4 @@ private:
     String getFactoryName() const override { return "DataTypeFactory"; }
 };
 
-void registerDataTypeNumbers(DataTypeFactory & factory);
-void registerDataTypeDecimal(DataTypeFactory & factory);
-void registerDataTypeDate(DataTypeFactory & factory);
-void registerDataTypeDate32(DataTypeFactory & factory);
-void registerDataTypeDateTime(DataTypeFactory & factory);
-void registerDataTypeString(DataTypeFactory & factory);
-void registerDataTypeFixedString(DataTypeFactory & factory);
-void registerDataTypeEnum(DataTypeFactory & factory);
-void registerDataTypeArray(DataTypeFactory & factory);
-void registerDataTypeTuple(DataTypeFactory & factory);
-void registerDataTypeMap(DataTypeFactory & factory);
-void registerDataTypeNullable(DataTypeFactory & factory);
-void registerDataTypeNothing(DataTypeFactory & factory);
-void registerDataTypeUUID(DataTypeFactory & factory);
-void registerDataTypeIPv4andIPv6(DataTypeFactory & factory);
-void registerDataTypeAggregateFunction(DataTypeFactory & factory);
-void registerDataTypeNested(DataTypeFactory & factory);
-void registerDataTypeInterval(DataTypeFactory & factory);
-void registerDataTypeLowCardinality(DataTypeFactory & factory);
-void registerDataTypeDomainBool(DataTypeFactory & factory);
-void registerDataTypeDomainSimpleAggregateFunction(DataTypeFactory & factory);
-void registerDataTypeDomainGeo(DataTypeFactory & factory);
-void registerDataTypeObject(DataTypeFactory & factory);
-void registerDataTypeVariant(DataTypeFactory & factory);
-void registerDataTypeDynamic(DataTypeFactory & factory);
-
 }

--- a/src/DataTypes/DataTypeFactory.h
+++ b/src/DataTypes/DataTypeFactory.h
@@ -4,10 +4,8 @@
 #include <Common/IFactoryWithAliases.h>
 #include <DataTypes/DataTypeCustom.h>
 
-
 #include <functional>
 #include <memory>
-#include <unordered_map>
 
 
 namespace DB
@@ -21,9 +19,9 @@ using DataTypePtr = std::shared_ptr<const IDataType>;
   */
 class DataTypeFactory final : private boost::noncopyable, public IFactoryWithAliases<std::function<DataTypePtr(const ASTPtr & parameters)>>
 {
+    using Base = IFactoryWithAliases<std::function<DataTypePtr(const ASTPtr & parameters)>>;
 private:
     using SimpleCreator = std::function<DataTypePtr()>;
-    using DataTypesDictionary = std::unordered_map<String, Value>;
     using CreatorWithCustom = std::function<std::pair<DataTypePtr, DataTypeCustomDescPtr>(const ASTPtr & parameters)>;
     using SimpleCreatorWithCustom = std::function<std::pair<DataTypePtr,DataTypeCustomDescPtr>()>;
 
@@ -62,15 +60,15 @@ private:
     template <bool nullptr_on_error>
     const Value * findCreatorByName(const String & family_name) const;
 
-    DataTypesDictionary data_types;
+    using DataTypesDictionary = std::unordered_map<String, Value>;
 
-    /// Case insensitive data types will be additionally added here with lowercased name.
+    DataTypesDictionary data_types;
     DataTypesDictionary case_insensitive_data_types;
 
     DataTypeFactory();
 
-    const DataTypesDictionary & getMap() const override { return data_types; }
-    const DataTypesDictionary & getCaseInsensitiveMap() const override { return case_insensitive_data_types; }
+    const Base::OriginalNameMap & getOriginalNameMap() const override { return data_types; }
+    const Base::OriginalNameMap & getOriginalCaseInsensitiveNameMap() const override { return case_insensitive_data_types; }
 
     String getFactoryName() const override { return "DataTypeFactory"; }
 };

--- a/src/DataTypes/DataTypeFactory.h
+++ b/src/DataTypes/DataTypeFactory.h
@@ -70,7 +70,6 @@ private:
     DataTypeFactory();
 
     const DataTypesDictionary & getMap() const override { return data_types; }
-
     const DataTypesDictionary & getCaseInsensitiveMap() const override { return case_insensitive_data_types; }
 
     String getFactoryName() const override { return "DataTypeFactory"; }

--- a/src/Functions/CRC.cpp
+++ b/src/Functions/CRC.cpp
@@ -150,9 +150,9 @@ using FunctionCRC64ECMA = FunctionCRC<CRC64ECMAImpl>;
 
 REGISTER_FUNCTION(CRC)
 {
-    factory.registerFunction<FunctionCRC32ZLib>({}, FunctionFactory::Case::Insensitive);
-    factory.registerFunction<FunctionCRC32IEEE>({}, FunctionFactory::Case::Insensitive);
-    factory.registerFunction<FunctionCRC64ECMA>({}, FunctionFactory::Case::Insensitive);
+    factory.registerFunction<FunctionCRC32ZLib>({}, {}, FunctionFactory::Case::Insensitive);
+    factory.registerFunction<FunctionCRC32IEEE>({}, {}, FunctionFactory::Case::Insensitive);
+    factory.registerFunction<FunctionCRC64ECMA>({}, {}, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/CastOverloadResolver.cpp
+++ b/src/Functions/CastOverloadResolver.cpp
@@ -137,10 +137,10 @@ FunctionOverloadResolverPtr createInternalCastOverloadResolver(CastType type, st
 
 REGISTER_FUNCTION(CastOverloadResolvers)
 {
-    factory.registerFunction("_CAST", [](ContextPtr context){ return CastOverloadResolverImpl::create(context, CastType::nonAccurate, true, {}); }, {}, FunctionFactory::Case::Insensitive);
+    factory.registerFunction("_CAST", [](ContextPtr context){ return CastOverloadResolverImpl::create(context, CastType::nonAccurate, true, {}); }, {}, {}, FunctionFactory::Case::Insensitive);
     /// Note: "internal" (not affected by null preserving setting) versions of accurate cast functions are unneeded.
 
-    factory.registerFunction("CAST", [](ContextPtr context){ return CastOverloadResolverImpl::create(context, CastType::nonAccurate, false, {}); }, {}, FunctionFactory::Case::Insensitive);
+    factory.registerFunction("CAST", [](ContextPtr context){ return CastOverloadResolverImpl::create(context, CastType::nonAccurate, false, {}); }, {}, {}, FunctionFactory::Case::Insensitive);
     factory.registerFunction("accurateCast", [](ContextPtr context){ return CastOverloadResolverImpl::create(context, CastType::accurate, false, {}); }, {});
     factory.registerFunction("accurateCastOrNull", [](ContextPtr context){ return CastOverloadResolverImpl::create(context, CastType::accurateOrNull, false, {}); }, {});
 }

--- a/src/Functions/FunctionChar.cpp
+++ b/src/Functions/FunctionChar.cpp
@@ -116,7 +116,7 @@ private:
 
 REGISTER_FUNCTION(Char)
 {
-    factory.registerFunction<FunctionChar>({}, FunctionFactory::Case::Insensitive);
+    factory.registerFunction<FunctionChar>({}, {}, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/FunctionFQDN.cpp
+++ b/src/Functions/FunctionFQDN.cpp
@@ -46,7 +46,7 @@ public:
 
 REGISTER_FUNCTION(FQDN)
 {
-    factory.registerFunction<FunctionFQDN>({}, FunctionFactory::Case::Insensitive);
+    factory.registerFunction<FunctionFQDN>({}, {}, FunctionFactory::Case::Insensitive);
     factory.registerAlias("fullHostName", "FQDN");
 }
 

--- a/src/Functions/FunctionFactory.cpp
+++ b/src/Functions/FunctionFactory.cpp
@@ -1,16 +1,11 @@
 #include <Functions/FunctionFactory.h>
-
-#include <Interpreters/Context.h>
-
-#include <Common/Exception.h>
-#include <Common/CurrentThread.h>
-#include <Core/Settings.h>
-
-#include <Poco/String.h>
-
-#include <IO/WriteHelpers.h>
-
 #include <AggregateFunctions/AggregateFunctionFactory.h>
+#include <Common/CurrentThread.h>
+#include <Common/Exception.h>
+#include <Core/Settings.h>
+#include <IO/WriteHelpers.h>
+#include <Interpreters/Context.h>
+#include <Poco/String.h>
 
 
 namespace DB

--- a/src/Functions/FunctionFactory.cpp
+++ b/src/Functions/FunctionFactory.cpp
@@ -139,8 +139,7 @@ FunctionOverloadResolverPtr FunctionFactory::tryGet(
     const std::string & name,
     ContextPtr context) const
 {
-    auto impl = tryGetImpl(name, context);
-    return impl ? std::move(impl) : nullptr;
+    return tryGetImpl(name, context);
 }
 
 FunctionFactory & FunctionFactory::instance()

--- a/src/Functions/FunctionFactory.cpp
+++ b/src/Functions/FunctionFactory.cpp
@@ -142,12 +142,6 @@ FunctionOverloadResolverPtr FunctionFactory::tryGet(
     return tryGetImpl(name, context);
 }
 
-FunctionFactory & FunctionFactory::instance()
-{
-    static FunctionFactory ret;
-    return ret;
-}
-
 FunctionDocumentation FunctionFactory::getDocumentation(const std::string & name) const
 {
     auto it = functions.find(name);
@@ -155,6 +149,12 @@ FunctionDocumentation FunctionFactory::getDocumentation(const std::string & name
         throw Exception(ErrorCodes::UNKNOWN_FUNCTION, "Unknown function {}", name);
 
     return it->second.documentation;
+}
+
+FunctionFactory & FunctionFactory::instance()
+{
+    static FunctionFactory ret;
+    return ret;
 }
 
 }

--- a/src/Functions/FunctionFactory.cpp
+++ b/src/Functions/FunctionFactory.cpp
@@ -66,7 +66,7 @@ FunctionOverloadResolverPtr FunctionFactory::getImpl(
     if (!res)
     {
         String extra_info;
-        if (AggregateFunctionFactory::instance().hasNameOrAlias(name))
+        if (AggregateFunctionFactory::instance().isNameOrAlias(name))
             extra_info = ". There is an aggregate function with the same name, but ordinary function is expected here";
 
         auto hints = this->getHints(name);

--- a/src/Functions/FunctionFactory.cpp
+++ b/src/Functions/FunctionFactory.cpp
@@ -30,10 +30,10 @@ const String & getFunctionCanonicalNameIfAny(const String & name)
 void FunctionFactory::registerFunction(
     const std::string & name,
     FunctionCreator creator,
-    FunctionDocumentation doc,
+    FunctionDocumentation documentation,
     Case case_sensitiveness)
 {
-    if (!functions.emplace(name, FunctionFactoryData{creator, doc}).second)
+    if (!functions.emplace(name, FunctionFactoryData{creator, documentation}).second)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "FunctionFactory: the function name '{}' is not unique", name);
 
     String function_name_lowercase = Poco::toLower(name);
@@ -43,7 +43,7 @@ void FunctionFactory::registerFunction(
 
     if (case_sensitiveness == Case::Insensitive)
     {
-        if (!case_insensitive_functions.emplace(function_name_lowercase, FunctionFactoryData{creator, doc}).second)
+        if (!case_insensitive_functions.emplace(function_name_lowercase, FunctionFactoryData{creator, documentation}).second)
             throw Exception(ErrorCodes::LOGICAL_ERROR, "FunctionFactory: the case insensitive function name '{}' is not unique",
                 name);
         case_insensitive_name_mapping[function_name_lowercase] = name;
@@ -53,13 +53,13 @@ void FunctionFactory::registerFunction(
 void FunctionFactory::registerFunction(
     const std::string & name,
     FunctionSimpleCreator creator,
-    FunctionDocumentation doc,
+    FunctionDocumentation documentation,
     Case case_sensitiveness)
 {
     registerFunction(name, [my_creator = std::move(creator)](ContextPtr context)
     {
         return std::make_unique<FunctionToOverloadResolverAdaptor>(my_creator(context));
-    }, std::move(doc), std::move(case_sensitiveness));
+    }, std::move(documentation), std::move(case_sensitiveness));
 }
 
 

--- a/src/Functions/FunctionFactory.cpp
+++ b/src/Functions/FunctionFactory.cpp
@@ -33,14 +33,12 @@ void FunctionFactory::registerFunction(
 
     String function_name_lowercase = Poco::toLower(name);
     if (isAlias(name) || isAlias(function_name_lowercase))
-        throw Exception(ErrorCodes::LOGICAL_ERROR, "FunctionFactory: the function name '{}' is already registered as alias",
-                        name);
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "FunctionFactory: the function name '{}' is already registered as alias", name);
 
     if (case_sensitiveness == Case::Insensitive)
     {
         if (!case_insensitive_functions.emplace(function_name_lowercase, FunctionFactoryData{creator, documentation}).second)
-            throw Exception(ErrorCodes::LOGICAL_ERROR, "FunctionFactory: the case insensitive function name '{}' is not unique",
-                name);
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "FunctionFactory: the case insensitive function name '{}' is not unique", name);
         case_insensitive_name_mapping[function_name_lowercase] = name;
     }
 }

--- a/src/Functions/FunctionFactory.cpp
+++ b/src/Functions/FunctionFactory.cpp
@@ -113,13 +113,13 @@ FunctionOverloadResolverPtr FunctionFactory::tryGetImpl(
 
     auto it = functions.find(name);
     if (functions.end() != it)
-        res = it->second.first(context);
+        res = it->second.creator(context);
     else
     {
         name = Poco::toLower(name);
         it = case_insensitive_functions.find(name);
         if (case_insensitive_functions.end() != it)
-            res = it->second.first(context);
+            res = it->second.creator(context);
     }
 
     if (!res)
@@ -155,7 +155,7 @@ FunctionDocumentation FunctionFactory::getDocumentation(const std::string & name
     if (it == functions.end())
         throw Exception(ErrorCodes::UNKNOWN_FUNCTION, "Unknown function {}", name);
 
-    return it->second.second;
+    return it->second.documentation;
 }
 
 }

--- a/src/Functions/FunctionFactory.h
+++ b/src/Functions/FunctionFactory.h
@@ -31,6 +31,7 @@ struct FunctionFactoryData
   */
 class FunctionFactory : private boost::noncopyable, public IFactoryWithAliases<FunctionFactoryData>
 {
+    using Base = IFactoryWithAliases<FunctionFactoryData>;
 public:
     static FunctionFactory & instance();
 
@@ -77,8 +78,8 @@ private:
     Functions functions;
     Functions case_insensitive_functions;
 
-    const Functions & getMap() const override { return functions; }
-    const Functions & getCaseInsensitiveMap() const override { return case_insensitive_functions; }
+    const Base::OriginalNameMap & getOriginalNameMap() const override { return functions; }
+    const Base::OriginalNameMap & getOriginalCaseInsensitiveNameMap() const override { return case_insensitive_functions; }
 
     String getFactoryName() const override { return "FunctionFactory"; }
 

--- a/src/Functions/FunctionFactory.h
+++ b/src/Functions/FunctionFactory.h
@@ -30,9 +30,9 @@ public:
     static FunctionFactory & instance();
 
     template <typename Function>
-    void registerFunction(FunctionDocumentation doc = {}, Case case_sensitiveness = Case::Sensitive)
+    void registerFunction(FunctionDocumentation documentation = {}, Case case_sensitiveness = Case::Sensitive)
     {
-        registerFunction<Function>(Function::name, std::move(doc), case_sensitiveness);
+        registerFunction<Function>(Function::name, std::move(documentation), case_sensitiveness);
     }
 
     /// This function is used by YQL - innovative transactional DBMS that depends on ClickHouse by source code.
@@ -55,13 +55,13 @@ public:
     void registerFunction(
         const std::string & name,
         FunctionCreator creator,
-        FunctionDocumentation doc = {},
+        FunctionDocumentation documentation = {},
         Case case_sensitiveness = Case::Sensitive);
 
     void registerFunction(
         const std::string & name,
         FunctionSimpleCreator creator,
-        FunctionDocumentation doc = {},
+        FunctionDocumentation documentation = {},
         Case case_sensitiveness = Case::Sensitive);
 
     FunctionDocumentation getDocumentation(const std::string & name) const;
@@ -79,9 +79,9 @@ private:
     String getFactoryName() const override { return "FunctionFactory"; }
 
     template <typename Function>
-    void registerFunction(const std::string & name, FunctionDocumentation doc = {}, Case case_sensitiveness = Case::Sensitive)
+    void registerFunction(const std::string & name, FunctionDocumentation documentation = {}, Case case_sensitiveness = Case::Sensitive)
     {
-        registerFunction(name, &Function::create, std::move(doc), case_sensitiveness);
+        registerFunction(name, &Function::create, std::move(documentation), case_sensitiveness);
     }
 };
 

--- a/src/Functions/FunctionFactory.h
+++ b/src/Functions/FunctionFactory.h
@@ -23,6 +23,7 @@ struct FunctionFactoryData
 {
     FunctionCreator creator;
     FunctionDocumentation documentation;
+    FunctionProperties properties;
 };
 
 /** Creates function by name.
@@ -36,9 +37,9 @@ public:
     static FunctionFactory & instance();
 
     template <typename Function>
-    void registerFunction(FunctionDocumentation documentation = {}, Case case_sensitiveness = Case::Sensitive)
+    void registerFunction(FunctionDocumentation documentation = {}, FunctionProperties properties = {}, Case case_sensitiveness = Case::Sensitive)
     {
-        registerFunction<Function>(Function::name, std::move(documentation), case_sensitiveness);
+        registerFunction<Function>(Function::name, std::move(documentation), std::move(properties), case_sensitiveness);
     }
 
     /// Register a function by its name.
@@ -47,12 +48,14 @@ public:
         const std::string & name,
         FunctionCreator creator,
         FunctionDocumentation documentation = {},
+        FunctionProperties properties = {},
         Case case_sensitiveness = Case::Sensitive);
 
     void registerFunction(
         const std::string & name,
         FunctionSimpleCreator creator,
         FunctionDocumentation documentation = {},
+        FunctionProperties properties = {},
         Case case_sensitiveness = Case::Sensitive);
 
     bool has(const std::string & name) const;
@@ -71,6 +74,10 @@ public:
     std::vector<std::string> getAllNames() const;
 
     FunctionDocumentation getDocumentation(const std::string & name) const;
+    FunctionProperties getProperties(const std::string & name) const;
+
+    std::optional<FunctionDocumentation> tryGetDocumentation(const std::string & name) const;
+    std::optional<FunctionProperties> tryGetProperties(const std::string & name) const;
 
 private:
     using Functions = std::unordered_map<std::string, Value>;
@@ -84,10 +91,13 @@ private:
     String getFactoryName() const override { return "FunctionFactory"; }
 
     template <typename Function>
-    void registerFunction(const std::string & name, FunctionDocumentation documentation = {}, Case case_sensitiveness = Case::Sensitive)
+    void registerFunction(const std::string & name, FunctionDocumentation documentation = {}, FunctionProperties properties = {}, Case case_sensitiveness = Case::Sensitive)
     {
-        registerFunction(name, &Function::create, std::move(documentation), case_sensitiveness);
+        registerFunction(name, &Function::create, std::move(documentation), std::move(properties), case_sensitiveness);
     }
+
+    std::optional<FunctionDocumentation> tryGetDocumentationImpl(const String & name_param) const;
+    std::optional<FunctionProperties> tryGetPropertiesImpl(const String & name_param) const;
 };
 
 const String & getFunctionCanonicalNameIfAny(const String & name);

--- a/src/Functions/FunctionFactory.h
+++ b/src/Functions/FunctionFactory.h
@@ -73,7 +73,6 @@ private:
     Functions case_insensitive_functions;
 
     const Functions & getMap() const override { return functions; }
-
     const Functions & getCaseInsensitiveMap() const override { return case_insensitive_functions; }
 
     String getFactoryName() const override { return "FunctionFactory"; }

--- a/src/Functions/FunctionFactory.h
+++ b/src/Functions/FunctionFactory.h
@@ -1,11 +1,11 @@
 #pragma once
 
-#include <Interpreters/Context_fwd.h>
-#include <Common/register_objects.h>
-#include <Common/IFactoryWithAliases.h>
 #include <Common/FunctionDocumentation.h>
+#include <Common/IFactoryWithAliases.h>
+#include <Common/register_objects.h>
 #include <Functions/IFunction.h>
 #include <Functions/IFunctionAdaptors.h>
+#include <Interpreters/Context_fwd.h>
 
 #include <functional>
 #include <memory>

--- a/src/Functions/FunctionFactory.h
+++ b/src/Functions/FunctionFactory.h
@@ -35,21 +35,6 @@ public:
         registerFunction<Function>(Function::name, std::move(documentation), case_sensitiveness);
     }
 
-    /// This function is used by YQL - innovative transactional DBMS that depends on ClickHouse by source code.
-    std::vector<std::string> getAllNames() const;
-
-    bool has(const std::string & name) const;
-
-    /// Throws an exception if not found.
-    FunctionOverloadResolverPtr get(const std::string & name, ContextPtr context) const;
-
-    /// Returns nullptr if not found.
-    FunctionOverloadResolverPtr tryGet(const std::string & name, ContextPtr context) const;
-
-    /// The same methods to get developer interface implementation.
-    FunctionOverloadResolverPtr getImpl(const std::string & name, ContextPtr context) const;
-    FunctionOverloadResolverPtr tryGetImpl(const std::string & name, ContextPtr context) const;
-
     /// Register a function by its name.
     /// No locking, you must register all functions before usage of get.
     void registerFunction(
@@ -63,6 +48,21 @@ public:
         FunctionSimpleCreator creator,
         FunctionDocumentation documentation = {},
         Case case_sensitiveness = Case::Sensitive);
+
+    bool has(const std::string & name) const;
+
+    /// Throws an exception if not found.
+    FunctionOverloadResolverPtr get(const std::string & name, ContextPtr context) const;
+
+    /// Returns nullptr if not found.
+    FunctionOverloadResolverPtr tryGet(const std::string & name, ContextPtr context) const;
+
+    /// The same methods to get developer interface implementation.
+    FunctionOverloadResolverPtr getImpl(const std::string & name, ContextPtr context) const;
+    FunctionOverloadResolverPtr tryGetImpl(const std::string & name, ContextPtr context) const;
+
+    /// This function is used by YQL - innovative transactional DBMS that depends on ClickHouse by source code.
+    std::vector<std::string> getAllNames() const;
 
     FunctionDocumentation getDocumentation(const std::string & name) const;
 

--- a/src/Functions/FunctionFactory.h
+++ b/src/Functions/FunctionFactory.h
@@ -18,7 +18,12 @@ namespace DB
 
 using FunctionCreator = std::function<FunctionOverloadResolverPtr(ContextPtr)>;
 using FunctionSimpleCreator = std::function<FunctionPtr(ContextPtr)>;
-using FunctionFactoryData = std::pair<FunctionCreator, FunctionDocumentation>;
+
+struct FunctionFactoryData
+{
+    FunctionCreator creator;
+    FunctionDocumentation documentation;
+};
 
 /** Creates function by name.
   * The provided Context is guaranteed to outlive the created function. Functions may use it for

--- a/src/Functions/FunctionsBinaryRepresentation.cpp
+++ b/src/Functions/FunctionsBinaryRepresentation.cpp
@@ -728,10 +728,10 @@ public:
 
 REGISTER_FUNCTION(BinaryRepr)
 {
-    factory.registerFunction<EncodeToBinaryRepresentation<HexImpl>>({}, FunctionFactory::Case::Insensitive);
-    factory.registerFunction<DecodeFromBinaryRepresentation<UnhexImpl>>({}, FunctionFactory::Case::Insensitive);
-    factory.registerFunction<EncodeToBinaryRepresentation<BinImpl>>({}, FunctionFactory::Case::Insensitive);
-    factory.registerFunction<DecodeFromBinaryRepresentation<UnbinImpl>>({}, FunctionFactory::Case::Insensitive);
+    factory.registerFunction<EncodeToBinaryRepresentation<HexImpl>>({}, {}, FunctionFactory::Case::Insensitive);
+    factory.registerFunction<DecodeFromBinaryRepresentation<UnhexImpl>>({}, {}, FunctionFactory::Case::Insensitive);
+    factory.registerFunction<EncodeToBinaryRepresentation<BinImpl>>({}, {}, FunctionFactory::Case::Insensitive);
+    factory.registerFunction<DecodeFromBinaryRepresentation<UnbinImpl>>({}, {}, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/FunctionsConversion.cpp
+++ b/src/Functions/FunctionsConversion.cpp
@@ -5224,7 +5224,7 @@ REGISTER_FUNCTION(Conversion)
     /// MySQL compatibility alias. Cannot be registered as alias,
     /// because we don't want it to be normalized to toDate in queries,
     /// otherwise CREATE DICTIONARY query breaks.
-    factory.registerFunction("DATE", &FunctionToDate::create, {}, FunctionFactory::Case::Insensitive);
+    factory.registerFunction("DATE", &FunctionToDate::create, {}, {}, FunctionFactory::Case::Insensitive);
 
     factory.registerFunction<FunctionToDate32>();
     factory.registerFunction<FunctionToDateTime>();

--- a/src/Functions/FunctionsLogical.cpp
+++ b/src/Functions/FunctionsLogical.cpp
@@ -29,7 +29,7 @@ REGISTER_FUNCTION(Logical)
     factory.registerFunction<FunctionAnd>();
     factory.registerFunction<FunctionOr>();
     factory.registerFunction<FunctionXor>();
-    factory.registerFunction<FunctionNot>({}, FunctionFactory::Case::Insensitive); /// Operator NOT(x) can be parsed as a function.
+    factory.registerFunction<FunctionNot>({}, {}, FunctionFactory::Case::Insensitive); /// Operator NOT(x) can be parsed as a function.
 }
 
 namespace ErrorCodes

--- a/src/Functions/FunctionsOpDate.cpp
+++ b/src/Functions/FunctionsOpDate.cpp
@@ -99,8 +99,8 @@ using FunctionSubDate = FunctionOpDate<SubDate>;
 
 REGISTER_FUNCTION(AddInterval)
 {
-    factory.registerFunction<FunctionAddDate>({}, FunctionFactory::Case::Insensitive);
-    factory.registerFunction<FunctionSubDate>({}, FunctionFactory::Case::Insensitive);
+    factory.registerFunction<FunctionAddDate>({}, {}, FunctionFactory::Case::Insensitive);
+    factory.registerFunction<FunctionSubDate>({}, {}, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/FunctionsRound.cpp
+++ b/src/Functions/FunctionsRound.cpp
@@ -7,11 +7,11 @@ namespace DB
 
 REGISTER_FUNCTION(Round)
 {
-    factory.registerFunction<FunctionRound>({}, FunctionFactory::Case::Insensitive);
-    factory.registerFunction<FunctionRoundBankers>({}, FunctionFactory::Case::Sensitive);
-    factory.registerFunction<FunctionFloor>({}, FunctionFactory::Case::Insensitive);
-    factory.registerFunction<FunctionCeil>({}, FunctionFactory::Case::Insensitive);
-    factory.registerFunction<FunctionTrunc>({}, FunctionFactory::Case::Insensitive);
+    factory.registerFunction<FunctionRound>({}, {}, FunctionFactory::Case::Insensitive);
+    factory.registerFunction<FunctionRoundBankers>({}, {}, FunctionFactory::Case::Sensitive);
+    factory.registerFunction<FunctionFloor>({}, {}, FunctionFactory::Case::Insensitive);
+    factory.registerFunction<FunctionCeil>({}, {}, FunctionFactory::Case::Insensitive);
+    factory.registerFunction<FunctionTrunc>({}, {}, FunctionFactory::Case::Insensitive);
     factory.registerFunction<FunctionRoundDown>();
 
     /// Compatibility aliases.

--- a/src/Functions/IFunction.h
+++ b/src/Functions/IFunction.h
@@ -571,4 +571,8 @@ protected:
 
 using FunctionPtr = std::shared_ptr<IFunction>;
 
+struct FunctionProperties
+{
+};
+
 }

--- a/src/Functions/UTCTimestamp.cpp
+++ b/src/Functions/UTCTimestamp.cpp
@@ -117,7 +117,7 @@ Example:
 )",
     .examples{
         {"typical", "SELECT UTCTimestamp();", ""}},
-    .categories{"Dates and Times"}}, FunctionFactory::Case::Insensitive);
+    .categories{"Dates and Times"}}, {}, FunctionFactory::Case::Insensitive);
     factory.registerAlias("UTC_timestamp", UTCTimestampOverloadResolver::name, FunctionFactory::Case::Insensitive);
 }
 

--- a/src/Functions/UserDefined/ExternalUserDefinedExecutableFunctionsLoader.cpp
+++ b/src/Functions/UserDefined/ExternalUserDefinedExecutableFunctionsLoader.cpp
@@ -126,10 +126,10 @@ ExternalLoader::LoadableMutablePtr ExternalUserDefinedExecutableFunctionsLoader:
     const std::string & key_in_config,
     const std::string &) const
 {
-    if (FunctionFactory::instance().hasNameOrAlias(name))
+    if (FunctionFactory::instance().isNameOrAlias(name))
         throw Exception(ErrorCodes::FUNCTION_ALREADY_EXISTS, "The function '{}' already exists", name);
 
-    if (AggregateFunctionFactory::instance().hasNameOrAlias(name))
+    if (AggregateFunctionFactory::instance().isNameOrAlias(name))
         throw Exception(ErrorCodes::FUNCTION_ALREADY_EXISTS, "The aggregate function '{}' already exists", name);
 
     String type = config.getString(key_in_config + ".type");

--- a/src/Functions/UserDefined/UserDefinedExecutableFunctionFactory.cpp
+++ b/src/Functions/UserDefined/UserDefinedExecutableFunctionFactory.cpp
@@ -236,8 +236,8 @@ private:
 
 UserDefinedExecutableFunctionFactory & UserDefinedExecutableFunctionFactory::instance()
 {
-    static UserDefinedExecutableFunctionFactory result;
-    return result;
+    static UserDefinedExecutableFunctionFactory factory;
+    return factory;
 }
 
 FunctionOverloadResolverPtr UserDefinedExecutableFunctionFactory::get(const String & function_name, ContextPtr context, Array parameters)

--- a/src/Functions/UserDefined/UserDefinedSQLFunctionFactory.cpp
+++ b/src/Functions/UserDefined/UserDefinedSQLFunctionFactory.cpp
@@ -100,10 +100,10 @@ UserDefinedSQLFunctionFactory & UserDefinedSQLFunctionFactory::instance()
 
 void UserDefinedSQLFunctionFactory::checkCanBeRegistered(const ContextPtr & context, const String & function_name, const IAST & create_function_query)
 {
-    if (FunctionFactory::instance().hasNameOrAlias(function_name))
+    if (FunctionFactory::instance().isNameOrAlias(function_name))
         throw Exception(ErrorCodes::FUNCTION_ALREADY_EXISTS, "The function '{}' already exists", function_name);
 
-    if (AggregateFunctionFactory::instance().hasNameOrAlias(function_name))
+    if (AggregateFunctionFactory::instance().isNameOrAlias(function_name))
         throw Exception(ErrorCodes::FUNCTION_ALREADY_EXISTS, "The aggregate function '{}' already exists", function_name);
 
     if (UserDefinedExecutableFunctionFactory::instance().has(function_name, context)) /// NOLINT(readability-static-accessed-through-instance)
@@ -114,8 +114,8 @@ void UserDefinedSQLFunctionFactory::checkCanBeRegistered(const ContextPtr & cont
 
 void UserDefinedSQLFunctionFactory::checkCanBeUnregistered(const ContextPtr & context, const String & function_name)
 {
-    if (FunctionFactory::instance().hasNameOrAlias(function_name) ||
-        AggregateFunctionFactory::instance().hasNameOrAlias(function_name))
+    if (FunctionFactory::instance().isNameOrAlias(function_name) ||
+        AggregateFunctionFactory::instance().isNameOrAlias(function_name))
         throw Exception(ErrorCodes::CANNOT_DROP_FUNCTION, "Cannot drop system function '{}'", function_name);
 
     if (UserDefinedExecutableFunctionFactory::instance().has(function_name, context)) /// NOLINT(readability-static-accessed-through-instance)

--- a/src/Functions/abs.cpp
+++ b/src/Functions/abs.cpp
@@ -51,7 +51,7 @@ template <> struct FunctionUnaryArithmeticMonotonicity<NameAbs>
 
 REGISTER_FUNCTION(Abs)
 {
-    factory.registerFunction<FunctionAbs>({}, FunctionFactory::Case::Insensitive);
+    factory.registerFunction<FunctionAbs>({}, {}, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/acos.cpp
+++ b/src/Functions/acos.cpp
@@ -14,7 +14,7 @@ using FunctionAcos = FunctionMathUnary<UnaryFunctionVectorized<AcosName, acos>>;
 
 REGISTER_FUNCTION(Acos)
 {
-    factory.registerFunction<FunctionAcos>({}, FunctionFactory::Case::Insensitive);
+    factory.registerFunction<FunctionAcos>({}, {}, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/array/arrayShuffle.cpp
+++ b/src/Functions/array/arrayShuffle.cpp
@@ -196,6 +196,7 @@ It is possible to override the seed to produce stable results:
                 {"explicit_seed", "SELECT arrayShuffle([1, 2, 3, 4], 41)", ""},
                 {"materialize", "SELECT arrayShuffle(materialize([1, 2, 3]), 42), arrayShuffle([1, 2, 3], 42) FROM numbers(10)", ""}},
             .categories{"Array"}},
+        {},
         FunctionFactory::Case::Insensitive);
 
     factory.registerFunction<FunctionArrayShuffleImpl<FunctionArrayPartialShuffleTraits>>(
@@ -224,6 +225,7 @@ It is possible to override the seed to produce stable results:
                 {"materialize",
                  "SELECT arrayPartialShuffle(materialize([1, 2, 3, 4]), 2, 42), arrayPartialShuffle([1, 2, 3], 2, 42) FROM numbers(10)", ""}},
             .categories{"Array"}},
+        {},
         FunctionFactory::Case::Insensitive);
 }
 

--- a/src/Functions/array/length.cpp
+++ b/src/Functions/array/length.cpp
@@ -100,6 +100,7 @@ It is ok to have ASCII NUL bytes in strings, and they will be counted as well.
                 },
             .categories{"String", "Array"}
         },
+        {},
         FunctionFactory::Case::Insensitive);
     factory.registerAlias("OCTET_LENGTH", "length", FunctionFactory::Case::Insensitive);
 }

--- a/src/Functions/ascii.cpp
+++ b/src/Functions/ascii.cpp
@@ -90,7 +90,7 @@ If s is empty, the result is 0. If the first character is not an ASCII character
         )",
         .examples{{"ascii", "SELECT ascii('234')", ""}},
         .categories{"String"}
-        }, FunctionFactory::Case::Insensitive);
+        }, {}, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/asin.cpp
+++ b/src/Functions/asin.cpp
@@ -41,6 +41,7 @@ For more details, see [https://en.wikipedia.org/wiki/Inverse_trigonometric_funct
                 {"nan", "SELECT asin(1.1), asin(-2), asin(inf), asin(nan)", ""}},
             .categories{"Mathematical", "Trigonometric"}
         },
+        {},
         FunctionFactory::Case::Insensitive);
 }
 

--- a/src/Functions/atan.cpp
+++ b/src/Functions/atan.cpp
@@ -14,7 +14,7 @@ using FunctionAtan = FunctionMathUnary<UnaryFunctionVectorized<AtanName, atan>>;
 
 REGISTER_FUNCTION(Atan)
 {
-    factory.registerFunction<FunctionAtan>({}, FunctionFactory::Case::Insensitive);
+    factory.registerFunction<FunctionAtan>({}, {}, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/atan2.cpp
+++ b/src/Functions/atan2.cpp
@@ -15,7 +15,7 @@ namespace
 
 REGISTER_FUNCTION(Atan2)
 {
-    factory.registerFunction<FunctionAtan2>({}, FunctionFactory::Case::Insensitive);
+    factory.registerFunction<FunctionAtan2>({}, {}, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/byteSwap.cpp
+++ b/src/Functions/byteSwap.cpp
@@ -100,6 +100,7 @@ One use-case of this function is reversing IPv4s:
                 {"64-bit", "SELECT byteSwap(123294967295)", "18439412204227788800"},
             },
             .categories{"Mathematical", "Arithmetic"}},
+        {},
         FunctionFactory::Case::Insensitive);
 }
 

--- a/src/Functions/coalesce.cpp
+++ b/src/Functions/coalesce.cpp
@@ -180,7 +180,7 @@ private:
 
 REGISTER_FUNCTION(Coalesce)
 {
-    factory.registerFunction<FunctionCoalesce>({}, FunctionFactory::Case::Insensitive);
+    factory.registerFunction<FunctionCoalesce>({}, {}, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/concat.cpp
+++ b/src/Functions/concat.cpp
@@ -240,7 +240,7 @@ private:
 
 REGISTER_FUNCTION(Concat)
 {
-    factory.registerFunction<ConcatOverloadResolver>({}, FunctionFactory::Case::Insensitive);
+    factory.registerFunction<ConcatOverloadResolver>({}, {}, FunctionFactory::Case::Insensitive);
     factory.registerFunction<FunctionConcatAssumeInjective>();
 }
 

--- a/src/Functions/connectionId.cpp
+++ b/src/Functions/connectionId.cpp
@@ -33,7 +33,7 @@ public:
 
 REGISTER_FUNCTION(ConnectionId)
 {
-    factory.registerFunction<FunctionConnectionId>({}, FunctionFactory::Case::Insensitive);
+    factory.registerFunction<FunctionConnectionId>({}, {}, FunctionFactory::Case::Insensitive);
     factory.registerAlias("connection_id", "connectionID", FunctionFactory::Case::Insensitive);
 }
 

--- a/src/Functions/cos.cpp
+++ b/src/Functions/cos.cpp
@@ -13,7 +13,7 @@ using FunctionCos = FunctionMathUnary<UnaryFunctionVectorized<CosName, cos>>;
 
 REGISTER_FUNCTION(Cos)
 {
-    factory.registerFunction<FunctionCos>({}, FunctionFactory::Case::Insensitive);
+    factory.registerFunction<FunctionCos>({}, {}, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/countSubstrings.cpp
+++ b/src/Functions/countSubstrings.cpp
@@ -19,6 +19,6 @@ using FunctionCountSubstrings = FunctionsStringSearch<CountSubstringsImpl<NameCo
 
 REGISTER_FUNCTION(CountSubstrings)
 {
-    factory.registerFunction<FunctionCountSubstrings>({}, FunctionFactory::Case::Insensitive);
+    factory.registerFunction<FunctionCountSubstrings>({}, {}, FunctionFactory::Case::Insensitive);
 }
 }

--- a/src/Functions/currentSchemas.cpp
+++ b/src/Functions/currentSchemas.cpp
@@ -80,6 +80,7 @@ Requires a boolean parameter, but it is ignored actually. It is required just fo
              {"common", "SELECT current_schemas(true);", "['default']"}
         }
         },
+        {},
         FunctionFactory::Case::Insensitive);
     factory.registerAlias("current_schemas", FunctionCurrentSchemas::name, FunctionFactory::Case::Insensitive);
 

--- a/src/Functions/dateDiff.cpp
+++ b/src/Functions/dateDiff.cpp
@@ -490,7 +490,7 @@ private:
 
 REGISTER_FUNCTION(DateDiff)
 {
-    factory.registerFunction<FunctionDateDiff<true>>({}, FunctionFactory::Case::Insensitive);
+    factory.registerFunction<FunctionDateDiff<true>>({}, {}, FunctionFactory::Case::Insensitive);
     factory.registerAlias("date_diff", FunctionDateDiff<true>::name);
     factory.registerAlias("DATE_DIFF", FunctionDateDiff<true>::name);
     factory.registerAlias("timestampDiff", FunctionDateDiff<true>::name);
@@ -509,12 +509,12 @@ Example:
 )",
     .examples{
         {"typical", "SELECT timeDiff(UTCTimestamp(), now());", ""}},
-    .categories{"Dates and Times"}}, FunctionFactory::Case::Insensitive);
+    .categories{"Dates and Times"}}, {}, FunctionFactory::Case::Insensitive);
 }
 
 REGISTER_FUNCTION(Age)
 {
-    factory.registerFunction<FunctionDateDiff<false>>({}, FunctionFactory::Case::Insensitive);
+    factory.registerFunction<FunctionDateDiff<false>>({}, {}, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/dateName.cpp
+++ b/src/Functions/dateName.cpp
@@ -354,7 +354,7 @@ private:
 
 REGISTER_FUNCTION(DateName)
 {
-    factory.registerFunction<FunctionDateNameImpl>({}, FunctionFactory::Case::Insensitive);
+    factory.registerFunction<FunctionDateNameImpl>({}, {}, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/degrees.cpp
+++ b/src/Functions/degrees.cpp
@@ -23,7 +23,7 @@ namespace
 
 REGISTER_FUNCTION(Degrees)
 {
-    factory.registerFunction<FunctionDegrees>({}, FunctionFactory::Case::Insensitive);
+    factory.registerFunction<FunctionDegrees>({}, {}, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/exp.cpp
+++ b/src/Functions/exp.cpp
@@ -36,7 +36,7 @@ using FunctionExp = FunctionMathUnary<UnaryFunctionVectorized<ExpName, exp>>;
 
 REGISTER_FUNCTION(Exp)
 {
-    factory.registerFunction<FunctionExp>({}, FunctionFactory::Case::Insensitive);
+    factory.registerFunction<FunctionExp>({}, {}, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/factorial.cpp
+++ b/src/Functions/factorial.cpp
@@ -106,6 +106,7 @@ The factorial of 0 is 1. Likewise, the factorial() function returns 1 for any ne
 )",
             .examples{{"factorial", "SELECT factorial(10)", ""}},
             .categories{"Mathematical"}},
+        {},
         FunctionFactory::Case::Insensitive);
 }
 

--- a/src/Functions/greatest.cpp
+++ b/src/Functions/greatest.cpp
@@ -65,7 +65,7 @@ using FunctionGreatest = FunctionBinaryArithmetic<GreatestImpl, NameGreatest>;
 
 REGISTER_FUNCTION(Greatest)
 {
-    factory.registerFunction<LeastGreatestOverloadResolver<LeastGreatest::Greatest, FunctionGreatest>>({}, FunctionFactory::Case::Insensitive);
+    factory.registerFunction<LeastGreatestOverloadResolver<LeastGreatest::Greatest, FunctionGreatest>>({}, {}, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/hasSubsequence.cpp
+++ b/src/Functions/hasSubsequence.cpp
@@ -24,7 +24,7 @@ using FunctionHasSubsequence = HasSubsequenceImpl<NameHasSubsequence, HasSubsequ
 
 REGISTER_FUNCTION(hasSubsequence)
 {
-    factory.registerFunction<FunctionHasSubsequence>({}, FunctionFactory::Case::Insensitive);
+    factory.registerFunction<FunctionHasSubsequence>({}, {}, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/hasSubsequenceCaseInsensitive.cpp
+++ b/src/Functions/hasSubsequenceCaseInsensitive.cpp
@@ -23,7 +23,7 @@ using FunctionHasSubsequenceCaseInsensitive = HasSubsequenceImpl<NameHasSubseque
 
 REGISTER_FUNCTION(hasSubsequenceCaseInsensitive)
 {
-    factory.registerFunction<FunctionHasSubsequenceCaseInsensitive>({}, FunctionFactory::Case::Insensitive);
+    factory.registerFunction<FunctionHasSubsequenceCaseInsensitive>({}, {}, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/hasSubsequenceCaseInsensitiveUTF8.cpp
+++ b/src/Functions/hasSubsequenceCaseInsensitiveUTF8.cpp
@@ -25,7 +25,7 @@ using FunctionHasSubsequenceCaseInsensitiveUTF8 = HasSubsequenceImpl<NameHasSubs
 
 REGISTER_FUNCTION(hasSubsequenceCaseInsensitiveUTF8)
 {
-    factory.registerFunction<FunctionHasSubsequenceCaseInsensitiveUTF8>({}, FunctionFactory::Case::Insensitive);
+    factory.registerFunction<FunctionHasSubsequenceCaseInsensitiveUTF8>({}, {}, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/hasSubsequenceUTF8.cpp
+++ b/src/Functions/hasSubsequenceUTF8.cpp
@@ -24,7 +24,7 @@ using FunctionHasSubsequenceUTF8 = HasSubsequenceImpl<NameHasSubsequenceUTF8, Ha
 
 REGISTER_FUNCTION(hasSubsequenceUTF8)
 {
-    factory.registerFunction<FunctionHasSubsequenceUTF8>({}, FunctionFactory::Case::Insensitive);
+    factory.registerFunction<FunctionHasSubsequenceUTF8>({}, {}, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/hasTokenCaseInsensitive.cpp
+++ b/src/Functions/hasTokenCaseInsensitive.cpp
@@ -26,10 +26,12 @@ REGISTER_FUNCTION(HasTokenCaseInsensitive)
 {
     factory.registerFunction<FunctionHasTokenCaseInsensitive>(
         FunctionDocumentation{.description="Performs case insensitive lookup of needle in haystack using tokenbf_v1 index."},
+        {},
         DB::FunctionFactory::Case::Insensitive);
 
     factory.registerFunction<FunctionHasTokenCaseInsensitiveOrNull>(
         FunctionDocumentation{.description="Performs case insensitive lookup of needle in haystack using tokenbf_v1 index. Returns null if needle is ill-formed."},
+        {},
         DB::FunctionFactory::Case::Insensitive);
 }
 

--- a/src/Functions/hypot.cpp
+++ b/src/Functions/hypot.cpp
@@ -15,7 +15,7 @@ namespace
 
 REGISTER_FUNCTION(Hypot)
 {
-    factory.registerFunction<FunctionHypot>({}, FunctionFactory::Case::Insensitive);
+    factory.registerFunction<FunctionHypot>({}, {}, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/if.cpp
+++ b/src/Functions/if.cpp
@@ -1309,7 +1309,7 @@ public:
 
 REGISTER_FUNCTION(If)
 {
-    factory.registerFunction<FunctionIf>({}, FunctionFactory::Case::Insensitive);
+    factory.registerFunction<FunctionIf>({}, {}, FunctionFactory::Case::Insensitive);
 }
 
 FunctionOverloadResolverPtr createInternalFunctionIfOverloadResolver(bool allow_experimental_variant_type, bool use_variant_as_common_type)

--- a/src/Functions/ifNull.cpp
+++ b/src/Functions/ifNull.cpp
@@ -91,7 +91,7 @@ private:
 
 REGISTER_FUNCTION(IfNull)
 {
-    factory.registerFunction<FunctionIfNull>({}, FunctionFactory::Case::Insensitive);
+    factory.registerFunction<FunctionIfNull>({}, {}, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/initcap.cpp
+++ b/src/Functions/initcap.cpp
@@ -60,7 +60,7 @@ using FunctionInitcap = FunctionStringToString<InitcapImpl, NameInitcap>;
 
 REGISTER_FUNCTION(Initcap)
 {
-    factory.registerFunction<FunctionInitcap>({}, FunctionFactory::Case::Insensitive);
+    factory.registerFunction<FunctionInitcap>({}, {}, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/isNull.cpp
+++ b/src/Functions/isNull.cpp
@@ -112,7 +112,7 @@ private:
 
 REGISTER_FUNCTION(IsNull)
 {
-    factory.registerFunction<FunctionIsNull>({}, FunctionFactory::Case::Insensitive);
+    factory.registerFunction<FunctionIsNull>({}, {}, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/least.cpp
+++ b/src/Functions/least.cpp
@@ -65,7 +65,7 @@ using FunctionLeast = FunctionBinaryArithmetic<LeastImpl, NameLeast>;
 
 REGISTER_FUNCTION(Least)
 {
-    factory.registerFunction<LeastGreatestOverloadResolver<LeastGreatest::Least, FunctionLeast>>({}, FunctionFactory::Case::Insensitive);
+    factory.registerFunction<LeastGreatestOverloadResolver<LeastGreatest::Least, FunctionLeast>>({}, {}, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/left.cpp
+++ b/src/Functions/left.cpp
@@ -6,8 +6,8 @@ namespace DB
 
 REGISTER_FUNCTION(Left)
 {
-    factory.registerFunction<FunctionLeftRight<false, SubstringDirection::Left>>({}, FunctionFactory::Case::Insensitive);
-    factory.registerFunction<FunctionLeftRight<true, SubstringDirection::Left>>({}, FunctionFactory::Case::Sensitive);
+    factory.registerFunction<FunctionLeftRight<false, SubstringDirection::Left>>({}, {}, FunctionFactory::Case::Insensitive);
+    factory.registerFunction<FunctionLeftRight<true, SubstringDirection::Left>>({}, {}, FunctionFactory::Case::Sensitive);
 }
 
 }

--- a/src/Functions/locate.cpp
+++ b/src/Functions/locate.cpp
@@ -29,6 +29,6 @@ REGISTER_FUNCTION(Locate)
     FunctionDocumentation::Categories doc_categories = {"String search"};
 
 
-    factory.registerFunction<FunctionLocate>({doc_description, doc_syntax, doc_arguments, doc_returned_value, doc_examples, doc_categories}, FunctionFactory::Case::Insensitive);
+    factory.registerFunction<FunctionLocate>({doc_description, doc_syntax, doc_arguments, doc_returned_value, doc_examples, doc_categories}, {}, FunctionFactory::Case::Insensitive);
 }
 }

--- a/src/Functions/log.cpp
+++ b/src/Functions/log.cpp
@@ -34,7 +34,7 @@ using FunctionLog = FunctionMathUnary<UnaryFunctionVectorized<LogName, log>>;
 
 REGISTER_FUNCTION(Log)
 {
-    factory.registerFunction<FunctionLog>({}, FunctionFactory::Case::Insensitive);
+    factory.registerFunction<FunctionLog>({}, {}, FunctionFactory::Case::Insensitive);
     factory.registerAlias("ln", "log", FunctionFactory::Case::Insensitive);
 }
 

--- a/src/Functions/log10.cpp
+++ b/src/Functions/log10.cpp
@@ -13,7 +13,7 @@ using FunctionLog10 = FunctionMathUnary<UnaryFunctionVectorized<Log10Name, log10
 
 REGISTER_FUNCTION(Log10)
 {
-    factory.registerFunction<FunctionLog10>({}, FunctionFactory::Case::Insensitive);
+    factory.registerFunction<FunctionLog10>({}, {}, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/log2.cpp
+++ b/src/Functions/log2.cpp
@@ -13,7 +13,7 @@ using FunctionLog2 = FunctionMathUnary<UnaryFunctionVectorized<Log2Name, log2>>;
 
 REGISTER_FUNCTION(Log2)
 {
-    factory.registerFunction<FunctionLog2>({}, FunctionFactory::Case::Insensitive);
+    factory.registerFunction<FunctionLog2>({}, {}, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/lower.cpp
+++ b/src/Functions/lower.cpp
@@ -19,7 +19,7 @@ using FunctionLower = FunctionStringToString<LowerUpperImpl<'A', 'Z'>, NameLower
 
 REGISTER_FUNCTION(Lower)
 {
-    factory.registerFunction<FunctionLower>({}, FunctionFactory::Case::Insensitive);
+    factory.registerFunction<FunctionLower>({}, {}, FunctionFactory::Case::Insensitive);
     factory.registerAlias("lcase", NameLower::name, FunctionFactory::Case::Insensitive);
 }
 

--- a/src/Functions/makeDate.cpp
+++ b/src/Functions/makeDate.cpp
@@ -724,7 +724,7 @@ public:
 
 REGISTER_FUNCTION(MakeDate)
 {
-    factory.registerFunction<FunctionMakeDate<DateTraits>>({}, FunctionFactory::Case::Insensitive);
+    factory.registerFunction<FunctionMakeDate<DateTraits>>({}, {}, FunctionFactory::Case::Insensitive);
     factory.registerFunction<FunctionMakeDate<Date32Traits>>();
     factory.registerFunction<FunctionMakeDateTime>();
     factory.registerFunction<FunctionMakeDateTime64>();

--- a/src/Functions/mathConstants.cpp
+++ b/src/Functions/mathConstants.cpp
@@ -44,7 +44,7 @@ REGISTER_FUNCTION(E)
 
 REGISTER_FUNCTION(Pi)
 {
-    factory.registerFunction<FunctionPi>({}, FunctionFactory::Case::Insensitive);
+    factory.registerFunction<FunctionPi>({}, {}, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/max2.cpp
+++ b/src/Functions/max2.cpp
@@ -21,6 +21,6 @@ namespace
 
 REGISTER_FUNCTION(Max2)
 {
-    factory.registerFunction<FunctionMax2>({}, FunctionFactory::Case::Insensitive);
+    factory.registerFunction<FunctionMax2>({}, {}, FunctionFactory::Case::Insensitive);
 }
 }

--- a/src/Functions/min2.cpp
+++ b/src/Functions/min2.cpp
@@ -22,6 +22,6 @@ namespace
 
 REGISTER_FUNCTION(Min2)
 {
-    factory.registerFunction<FunctionMin2>({}, FunctionFactory::Case::Insensitive);
+    factory.registerFunction<FunctionMin2>({}, {}, FunctionFactory::Case::Insensitive);
 }
 }

--- a/src/Functions/modulo.cpp
+++ b/src/Functions/modulo.cpp
@@ -183,6 +183,7 @@ In other words, the function returning the modulus (modulo) in the terms of Modu
         )",
             .examples{{"positiveModulo", "SELECT positiveModulo(-1, 10);", ""}},
             .categories{"Arithmetic"}},
+        {},
         FunctionFactory::Case::Insensitive);
 
     factory.registerAlias("positive_modulo", "positiveModulo", FunctionFactory::Case::Insensitive);

--- a/src/Functions/monthName.cpp
+++ b/src/Functions/monthName.cpp
@@ -74,7 +74,7 @@ private:
 
 REGISTER_FUNCTION(MonthName)
 {
-    factory.registerFunction<FunctionMonthName>({}, FunctionFactory::Case::Insensitive);
+    factory.registerFunction<FunctionMonthName>({}, {}, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/now.cpp
+++ b/src/Functions/now.cpp
@@ -138,7 +138,7 @@ private:
 
 REGISTER_FUNCTION(Now)
 {
-    factory.registerFunction<NowOverloadResolver>({}, FunctionFactory::Case::Insensitive);
+    factory.registerFunction<NowOverloadResolver>({}, {}, FunctionFactory::Case::Insensitive);
     factory.registerAlias("current_timestamp", NowOverloadResolver::name, FunctionFactory::Case::Insensitive);
 }
 

--- a/src/Functions/now64.cpp
+++ b/src/Functions/now64.cpp
@@ -170,7 +170,7 @@ private:
 
 REGISTER_FUNCTION(Now64)
 {
-    factory.registerFunction<Now64OverloadResolver>({}, FunctionFactory::Case::Insensitive);
+    factory.registerFunction<Now64OverloadResolver>({}, {}, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/nullIf.cpp
+++ b/src/Functions/nullIf.cpp
@@ -69,7 +69,7 @@ public:
 
 REGISTER_FUNCTION(NullIf)
 {
-    factory.registerFunction<FunctionNullIf>({}, FunctionFactory::Case::Insensitive);
+    factory.registerFunction<FunctionNullIf>({}, {}, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/position.cpp
+++ b/src/Functions/position.cpp
@@ -19,6 +19,6 @@ using FunctionPosition = FunctionsStringSearch<PositionImpl<NamePosition, Positi
 
 REGISTER_FUNCTION(Position)
 {
-    factory.registerFunction<FunctionPosition>({}, FunctionFactory::Case::Insensitive);
+    factory.registerFunction<FunctionPosition>({}, {}, FunctionFactory::Case::Insensitive);
 }
 }

--- a/src/Functions/pow.cpp
+++ b/src/Functions/pow.cpp
@@ -13,7 +13,7 @@ using FunctionPow = FunctionMathBinaryFloat64<BinaryFunctionVectorized<PowName, 
 
 REGISTER_FUNCTION(Pow)
 {
-    factory.registerFunction<FunctionPow>({}, FunctionFactory::Case::Insensitive);
+    factory.registerFunction<FunctionPow>({}, {}, FunctionFactory::Case::Insensitive);
     factory.registerAlias("power", "pow", FunctionFactory::Case::Insensitive);
 }
 

--- a/src/Functions/radians.cpp
+++ b/src/Functions/radians.cpp
@@ -23,7 +23,7 @@ namespace
 
 REGISTER_FUNCTION(Radians)
 {
-    factory.registerFunction<FunctionRadians>({}, FunctionFactory::Case::Insensitive);
+    factory.registerFunction<FunctionRadians>({}, {}, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/rand.cpp
+++ b/src/Functions/rand.cpp
@@ -13,7 +13,7 @@ using FunctionRand = FunctionRandom<UInt32, NameRand>;
 
 REGISTER_FUNCTION(Rand)
 {
-    factory.registerFunction<FunctionRand>({}, FunctionFactory::Case::Insensitive);
+    factory.registerFunction<FunctionRand>({}, {}, FunctionFactory::Case::Insensitive);
     factory.registerAlias("rand32", NameRand::name);
 }
 

--- a/src/Functions/repeat.cpp
+++ b/src/Functions/repeat.cpp
@@ -278,7 +278,7 @@ public:
 
 REGISTER_FUNCTION(Repeat)
 {
-    factory.registerFunction<FunctionRepeat>({}, FunctionFactory::Case::Insensitive);
+    factory.registerFunction<FunctionRepeat>({}, {}, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/reverse.cpp
+++ b/src/Functions/reverse.cpp
@@ -113,7 +113,7 @@ private:
 
 REGISTER_FUNCTION(Reverse)
 {
-    factory.registerFunction<ReverseOverloadResolver>({}, FunctionFactory::Case::Insensitive);
+    factory.registerFunction<ReverseOverloadResolver>({}, {}, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/right.cpp
+++ b/src/Functions/right.cpp
@@ -6,8 +6,8 @@ namespace DB
 
 REGISTER_FUNCTION(Right)
 {
-    factory.registerFunction<FunctionLeftRight<false, SubstringDirection::Right>>({}, FunctionFactory::Case::Insensitive);
-    factory.registerFunction<FunctionLeftRight<true, SubstringDirection::Right>>({}, FunctionFactory::Case::Sensitive);
+    factory.registerFunction<FunctionLeftRight<false, SubstringDirection::Right>>({}, {}, FunctionFactory::Case::Insensitive);
+    factory.registerFunction<FunctionLeftRight<true, SubstringDirection::Right>>({}, {}, FunctionFactory::Case::Sensitive);
 }
 
 }

--- a/src/Functions/runningConcurrency.cpp
+++ b/src/Functions/runningConcurrency.cpp
@@ -15,207 +15,207 @@
 
 namespace DB
 {
-    namespace ErrorCodes
+namespace ErrorCodes
+{
+    extern const int ILLEGAL_COLUMN;
+    extern const int ILLEGAL_TYPE_OF_ARGUMENT;
+    extern const int INCORRECT_DATA;
+}
+
+template <typename Name, typename ArgDataType, typename ConcurrencyDataType>
+class ExecutableFunctionRunningConcurrency : public IExecutableFunction
+{
+public:
+    String getName() const override
     {
-        extern const int ILLEGAL_COLUMN;
-        extern const int ILLEGAL_TYPE_OF_ARGUMENT;
-        extern const int INCORRECT_DATA;
+        return Name::name;
     }
 
-    template <typename Name, typename ArgDataType, typename ConcurrencyDataType>
-    class ExecutableFunctionRunningConcurrency : public IExecutableFunction
+    ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr &, size_t input_rows_count) const override
     {
-    public:
-        String getName() const override
+        using ColVecArg = typename ArgDataType::ColumnType;
+        const ColVecArg * col_begin = checkAndGetColumn<ColVecArg>(arguments[0].column.get());
+        const ColVecArg * col_end   = checkAndGetColumn<ColVecArg>(arguments[1].column.get());
+        if (!col_begin || !col_end)
+            throw Exception(ErrorCodes::ILLEGAL_COLUMN, "Constant columns are not supported at the moment");
+        const typename ColVecArg::Container & vec_begin = col_begin->getData();
+        const typename ColVecArg::Container & vec_end   = col_end->getData();
+
+        using ColVecConc = typename ConcurrencyDataType::ColumnType;
+        using FieldType = typename ConcurrencyDataType::FieldType;
+        typename ColVecConc::MutablePtr col_concurrency = ColVecConc::create(input_rows_count);
+        typename ColVecConc::Container & vec_concurrency = col_concurrency->getData();
+
+        std::multiset<typename ArgDataType::FieldType> ongoing_until;
+        auto begin_serializaion = arguments[0].type->getDefaultSerialization();
+        auto end_serialization = arguments[1].type->getDefaultSerialization();
+        for (size_t i = 0; i < input_rows_count; ++i)
         {
-            return Name::name;
-        }
+            const auto begin = vec_begin[i];
+            const auto end   = vec_end[i];
 
-        ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr &, size_t input_rows_count) const override
-        {
-            using ColVecArg = typename ArgDataType::ColumnType;
-            const ColVecArg * col_begin = checkAndGetColumn<ColVecArg>(arguments[0].column.get());
-            const ColVecArg * col_end   = checkAndGetColumn<ColVecArg>(arguments[1].column.get());
-            if (!col_begin || !col_end)
-                throw Exception(ErrorCodes::ILLEGAL_COLUMN, "Constant columns are not supported at the moment");
-            const typename ColVecArg::Container & vec_begin = col_begin->getData();
-            const typename ColVecArg::Container & vec_end   = col_end->getData();
-
-            using ColVecConc = typename ConcurrencyDataType::ColumnType;
-            using FieldType = typename ConcurrencyDataType::FieldType;
-            typename ColVecConc::MutablePtr col_concurrency = ColVecConc::create(input_rows_count);
-            typename ColVecConc::Container & vec_concurrency = col_concurrency->getData();
-
-            std::multiset<typename ArgDataType::FieldType> ongoing_until;
-            auto begin_serializaion = arguments[0].type->getDefaultSerialization();
-            auto end_serialization = arguments[1].type->getDefaultSerialization();
-            for (size_t i = 0; i < input_rows_count; ++i)
+            if (unlikely(begin > end))
             {
-                const auto begin = vec_begin[i];
-                const auto end   = vec_end[i];
-
-                if (unlikely(begin > end))
-                {
-                    const FormatSettings default_format{};
-                    WriteBufferFromOwnString buf_begin, buf_end;
-                    begin_serializaion->serializeTextQuoted(*(arguments[0].column), i, buf_begin, default_format);
-                    end_serialization->serializeTextQuoted(*(arguments[1].column), i, buf_end, default_format);
-                    throw Exception(ErrorCodes::INCORRECT_DATA, "Incorrect order of events: {} > {}", buf_begin.str(), buf_end.str());
-                }
-
-                ongoing_until.insert(end);
-
-                // Erase all the elements from "ongoing_until" which
-                // are less than or equal to "begin", i.e. durations
-                // that have already ended. We consider "begin" to be
-                // inclusive, and "end" to be exclusive.
-                ongoing_until.erase(
-                    ongoing_until.begin(), ongoing_until.upper_bound(begin));
-
-                vec_concurrency[i] = static_cast<FieldType>(ongoing_until.size());
+                const FormatSettings default_format{};
+                WriteBufferFromOwnString buf_begin, buf_end;
+                begin_serializaion->serializeTextQuoted(*(arguments[0].column), i, buf_begin, default_format);
+                end_serialization->serializeTextQuoted(*(arguments[1].column), i, buf_end, default_format);
+                throw Exception(ErrorCodes::INCORRECT_DATA, "Incorrect order of events: {} > {}", buf_begin.str(), buf_end.str());
             }
 
-            return col_concurrency;
+            ongoing_until.insert(end);
+
+            // Erase all the elements from "ongoing_until" which
+            // are less than or equal to "begin", i.e. durations
+            // that have already ended. We consider "begin" to be
+            // inclusive, and "end" to be exclusive.
+            ongoing_until.erase(
+                ongoing_until.begin(), ongoing_until.upper_bound(begin));
+
+            vec_concurrency[i] = static_cast<FieldType>(ongoing_until.size());
         }
 
-        bool useDefaultImplementationForConstants() const override
-        {
-            return true;
-        }
-    };
-
-    template <typename Name, typename ArgDataType, typename ConcurrencyDataType>
-    class FunctionBaseRunningConcurrency : public IFunctionBase
-    {
-    public:
-        explicit FunctionBaseRunningConcurrency(DataTypes argument_types_, DataTypePtr return_type_)
-            : argument_types(std::move(argument_types_))
-            , return_type(std::move(return_type_)) {}
-
-        String getName() const override
-        {
-            return Name::name;
-        }
-
-        const DataTypes & getArgumentTypes() const override
-        {
-            return argument_types;
-        }
-
-        const DataTypePtr & getResultType() const override
-        {
-            return return_type;
-        }
-
-        ExecutableFunctionPtr prepare(const ColumnsWithTypeAndName &) const override
-        {
-            return std::make_unique<ExecutableFunctionRunningConcurrency<Name, ArgDataType, ConcurrencyDataType>>();
-        }
-
-        bool isStateful() const override
-        {
-            return true;
-        }
-
-        bool isSuitableForShortCircuitArgumentsExecution(const DataTypesWithConstInfo & /*arguments*/) const override { return true; }
-
-    private:
-        DataTypes argument_types;
-        DataTypePtr return_type;
-    };
-
-    template <typename Name, typename ConcurrencyDataType>
-    class RunningConcurrencyOverloadResolver : public IFunctionOverloadResolver
-    {
-        template <typename T>
-        struct TypeTag
-        {
-            using Type = T;
-        };
-
-        /// Call a polymorphic lambda with a type tag of src_type.
-        template <typename F>
-        void dispatchForSourceType(const IDataType & src_type, F && f) const
-        {
-            WhichDataType which(src_type);
-
-            switch (which.idx)
-            {
-            case TypeIndex::Date:       f(TypeTag<DataTypeDate>());       break;
-            case TypeIndex::DateTime:   f(TypeTag<DataTypeDateTime>());   break;
-            case TypeIndex::DateTime64: f(TypeTag<DataTypeDateTime64>()); break;
-            default:
-                throw Exception(ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT, "Arguments for function {} must be Date, DateTime, or DateTime64.", getName());
-            }
-        }
-
-    public:
-        static constexpr auto name = Name::name;
-
-        static FunctionOverloadResolverPtr create(ContextPtr)
-        {
-            return std::make_unique<RunningConcurrencyOverloadResolver<Name, ConcurrencyDataType>>();
-        }
-
-        String getName() const override
-        {
-            return Name::name;
-        }
-
-        FunctionBasePtr buildImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr & return_type) const override
-        {
-            // The type of the second argument must match with that of the first one.
-            if (unlikely(!arguments[1].type->equals(*(arguments[0].type))))
-            {
-                throw Exception(ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT, "Function {} must be called with two arguments having the same type.", getName());
-            }
-
-            DataTypes argument_types = { arguments[0].type, arguments[1].type };
-            FunctionBasePtr base;
-            dispatchForSourceType(*(arguments[0].type), [&](auto arg_type_tag) // Throws when the type is inappropriate.
-            {
-                using Tag = decltype(arg_type_tag);
-                using ArgDataType = typename Tag::Type;
-
-                base = std::make_unique<FunctionBaseRunningConcurrency<Name, ArgDataType, ConcurrencyDataType>>(argument_types, return_type);
-            });
-
-            return base;
-        }
-
-        DataTypePtr getReturnTypeImpl(const DataTypes &) const override
-        {
-            return std::make_shared<ConcurrencyDataType>();
-        }
-
-        size_t getNumberOfArguments() const override
-        {
-            return 2;
-        }
-
-        bool isInjective(const ColumnsWithTypeAndName &) const override
-        {
-            return false;
-        }
-
-        bool isStateful() const override
-        {
-            return true;
-        }
-
-        bool useDefaultImplementationForNulls() const override
-        {
-            return false;
-        }
-    };
-
-    struct NameRunningConcurrency
-    {
-        static constexpr auto name = "runningConcurrency";
-    };
-
-    REGISTER_FUNCTION(RunningConcurrency)
-    {
-        factory.registerFunction<RunningConcurrencyOverloadResolver<NameRunningConcurrency, DataTypeUInt32>>();
+        return col_concurrency;
     }
+
+    bool useDefaultImplementationForConstants() const override
+    {
+        return true;
+    }
+};
+
+template <typename Name, typename ArgDataType, typename ConcurrencyDataType>
+class FunctionBaseRunningConcurrency : public IFunctionBase
+{
+public:
+    explicit FunctionBaseRunningConcurrency(DataTypes argument_types_, DataTypePtr return_type_)
+        : argument_types(std::move(argument_types_))
+        , return_type(std::move(return_type_)) {}
+
+    String getName() const override
+    {
+        return Name::name;
+    }
+
+    const DataTypes & getArgumentTypes() const override
+    {
+        return argument_types;
+    }
+
+    const DataTypePtr & getResultType() const override
+    {
+        return return_type;
+    }
+
+    ExecutableFunctionPtr prepare(const ColumnsWithTypeAndName &) const override
+    {
+        return std::make_unique<ExecutableFunctionRunningConcurrency<Name, ArgDataType, ConcurrencyDataType>>();
+    }
+
+    bool isStateful() const override
+    {
+        return true;
+    }
+
+    bool isSuitableForShortCircuitArgumentsExecution(const DataTypesWithConstInfo & /*arguments*/) const override { return true; }
+
+private:
+    DataTypes argument_types;
+    DataTypePtr return_type;
+};
+
+template <typename Name, typename ConcurrencyDataType>
+class RunningConcurrencyOverloadResolver : public IFunctionOverloadResolver
+{
+    template <typename T>
+    struct TypeTag
+    {
+        using Type = T;
+    };
+
+    /// Call a polymorphic lambda with a type tag of src_type.
+    template <typename F>
+    void dispatchForSourceType(const IDataType & src_type, F && f) const
+    {
+        WhichDataType which(src_type);
+
+        switch (which.idx)
+        {
+        case TypeIndex::Date:       f(TypeTag<DataTypeDate>());       break;
+        case TypeIndex::DateTime:   f(TypeTag<DataTypeDateTime>());   break;
+        case TypeIndex::DateTime64: f(TypeTag<DataTypeDateTime64>()); break;
+        default:
+            throw Exception(ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT, "Arguments for function {} must be Date, DateTime, or DateTime64.", getName());
+        }
+    }
+
+public:
+    static constexpr auto name = Name::name;
+
+    static FunctionOverloadResolverPtr create(ContextPtr)
+    {
+        return std::make_unique<RunningConcurrencyOverloadResolver<Name, ConcurrencyDataType>>();
+    }
+
+    String getName() const override
+    {
+        return Name::name;
+    }
+
+    FunctionBasePtr buildImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr & return_type) const override
+    {
+        // The type of the second argument must match with that of the first one.
+        if (unlikely(!arguments[1].type->equals(*(arguments[0].type))))
+        {
+            throw Exception(ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT, "Function {} must be called with two arguments having the same type.", getName());
+        }
+
+        DataTypes argument_types = { arguments[0].type, arguments[1].type };
+        FunctionBasePtr base;
+        dispatchForSourceType(*(arguments[0].type), [&](auto arg_type_tag) // Throws when the type is inappropriate.
+        {
+            using Tag = decltype(arg_type_tag);
+            using ArgDataType = typename Tag::Type;
+
+            base = std::make_unique<FunctionBaseRunningConcurrency<Name, ArgDataType, ConcurrencyDataType>>(argument_types, return_type);
+        });
+
+        return base;
+    }
+
+    DataTypePtr getReturnTypeImpl(const DataTypes &) const override
+    {
+        return std::make_shared<ConcurrencyDataType>();
+    }
+
+    size_t getNumberOfArguments() const override
+    {
+        return 2;
+    }
+
+    bool isInjective(const ColumnsWithTypeAndName &) const override
+    {
+        return false;
+    }
+
+    bool isStateful() const override
+    {
+        return true;
+    }
+
+    bool useDefaultImplementationForNulls() const override
+    {
+        return false;
+    }
+};
+
+struct NameRunningConcurrency
+{
+    static constexpr auto name = "runningConcurrency";
+};
+
+REGISTER_FUNCTION(RunningConcurrency)
+{
+    factory.registerFunction<RunningConcurrencyOverloadResolver<NameRunningConcurrency, DataTypeUInt32>>();
+}
 }

--- a/src/Functions/serverConstants.cpp
+++ b/src/Functions/serverConstants.cpp
@@ -206,12 +206,12 @@ REGISTER_FUNCTION(Uptime)
 
 REGISTER_FUNCTION(Version)
 {
-    factory.registerFunction<FunctionVersion>({}, FunctionFactory::Case::Insensitive);
+    factory.registerFunction<FunctionVersion>({}, {}, FunctionFactory::Case::Insensitive);
 }
 
 REGISTER_FUNCTION(Revision)
 {
-    factory.registerFunction<FunctionRevision>({}, FunctionFactory::Case::Insensitive);
+    factory.registerFunction<FunctionRevision>({}, {}, FunctionFactory::Case::Insensitive);
 }
 
 REGISTER_FUNCTION(ZooKeeperSessionUptime)

--- a/src/Functions/sign.cpp
+++ b/src/Functions/sign.cpp
@@ -44,7 +44,7 @@ struct FunctionUnaryArithmeticMonotonicity<NameSign>
 
 REGISTER_FUNCTION(Sign)
 {
-    factory.registerFunction<FunctionSign>({}, FunctionFactory::Case::Insensitive);
+    factory.registerFunction<FunctionSign>({}, {}, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/sin.cpp
+++ b/src/Functions/sin.cpp
@@ -21,6 +21,7 @@ REGISTER_FUNCTION(Sin)
             .returned_value = "The sine of x.",
             .examples = {{.name = "simple", .query = "SELECT sin(1.23)", .result = "0.9424888019316975"}},
             .categories{"Mathematical", "Trigonometric"}},
+        {},
         FunctionFactory::Case::Insensitive);
 }
 

--- a/src/Functions/soundex.cpp
+++ b/src/Functions/soundex.cpp
@@ -112,7 +112,7 @@ struct NameSoundex
 REGISTER_FUNCTION(Soundex)
 {
     factory.registerFunction<FunctionStringToString<SoundexImpl, NameSoundex>>(
-        FunctionDocumentation{.description="Returns Soundex code of a string."}, FunctionFactory::Case::Insensitive);
+        FunctionDocumentation{.description="Returns Soundex code of a string."}, {}, FunctionFactory::Case::Insensitive);
 }
 
 

--- a/src/Functions/space.cpp
+++ b/src/Functions/space.cpp
@@ -173,7 +173,7 @@ public:
 
 REGISTER_FUNCTION(Space)
 {
-    factory.registerFunction<FunctionSpace>({}, FunctionFactory::Case::Insensitive);
+    factory.registerFunction<FunctionSpace>({}, {}, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/sqrt.cpp
+++ b/src/Functions/sqrt.cpp
@@ -13,7 +13,7 @@ using FunctionSqrt = FunctionMathUnary<UnaryFunctionVectorized<SqrtName, sqrt>>;
 
 REGISTER_FUNCTION(Sqrt)
 {
-    factory.registerFunction<FunctionSqrt>({}, FunctionFactory::Case::Insensitive);
+    factory.registerFunction<FunctionSqrt>({}, {}, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/substring.cpp
+++ b/src/Functions/substring.cpp
@@ -201,7 +201,7 @@ public:
 
 REGISTER_FUNCTION(Substring)
 {
-    factory.registerFunction<FunctionSubstring<false>>({}, FunctionFactory::Case::Insensitive);
+    factory.registerFunction<FunctionSubstring<false>>({}, {}, FunctionFactory::Case::Insensitive);
     factory.registerAlias("substr", "substring", FunctionFactory::Case::Insensitive); // MySQL alias
     factory.registerAlias("mid", "substring", FunctionFactory::Case::Insensitive); /// MySQL alias
     factory.registerAlias("byteSlice", "substring", FunctionFactory::Case::Insensitive); /// resembles PostgreSQL's get_byte function, similar to ClickHouse's bitSlice

--- a/src/Functions/synonyms.cpp
+++ b/src/Functions/synonyms.cpp
@@ -121,7 +121,7 @@ public:
 
 REGISTER_FUNCTION(Synonyms)
 {
-    factory.registerFunction<FunctionSynonyms>({}, FunctionFactory::Case::Insensitive);
+    factory.registerFunction<FunctionSynonyms>({}, {}, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/tan.cpp
+++ b/src/Functions/tan.cpp
@@ -13,7 +13,7 @@ using FunctionTan = FunctionMathUnary<UnaryFunctionVectorized<TanName, tan>>;
 
 REGISTER_FUNCTION(Tan)
 {
-    factory.registerFunction<FunctionTan>({}, FunctionFactory::Case::Insensitive);
+    factory.registerFunction<FunctionTan>({}, {}, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/tanh.cpp
+++ b/src/Functions/tanh.cpp
@@ -39,7 +39,7 @@ using FunctionTanh = FunctionMathUnary<UnaryFunctionVectorized<TanhName, tanh>>;
 
 REGISTER_FUNCTION(Tanh)
 {
-    factory.registerFunction<FunctionTanh>({}, FunctionFactory::Case::Insensitive);
+    factory.registerFunction<FunctionTanh>({}, {}, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/timestamp.cpp
+++ b/src/Functions/timestamp.cpp
@@ -187,7 +187,7 @@ If the second argument 'expr_time' is provided, it adds the specified time to th
             {"timestamp", "SELECT timestamp('2013-12-31 12:00:00')", "2013-12-31 12:00:00.000000"},
             {"timestamp", "SELECT timestamp('2013-12-31 12:00:00', '12:00:00.11')", "2014-01-01 00:00:00.110000"},
         },
-        .categories{"DateTime"}}, FunctionFactory::Case::Insensitive);
+        .categories{"DateTime"}}, {}, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/toDecimalString.cpp
+++ b/src/Functions/toDecimalString.cpp
@@ -273,7 +273,7 @@ second argument is the desired number of digits in fractional part. Returns Stri
         )",
             .examples{{"toDecimalString", "SELECT toDecimalString(2.1456,2)", ""}},
             .categories{"String"}
-        }, FunctionFactory::Case::Insensitive);
+        }, {}, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/upper.cpp
+++ b/src/Functions/upper.cpp
@@ -18,7 +18,7 @@ using FunctionUpper = FunctionStringToString<LowerUpperImpl<'a', 'z'>, NameUpper
 
 REGISTER_FUNCTION(Upper)
 {
-    factory.registerFunction<FunctionUpper>({}, FunctionFactory::Case::Insensitive);
+    factory.registerFunction<FunctionUpper>({}, {}, FunctionFactory::Case::Insensitive);
     factory.registerAlias("ucase", FunctionUpper::name, FunctionFactory::Case::Insensitive);
 }
 

--- a/src/Storages/ColumnsDescription.h
+++ b/src/Storages/ColumnsDescription.h
@@ -10,6 +10,7 @@
 #include <Common/SettingsChanges.h>
 #include <Storages/StatisticsDescription.h>
 #include <Common/Exception.h>
+#include <Common/IFactoryWithAliases.h>
 
 #include <boost/multi_index/member.hpp>
 #include <boost/multi_index/mem_fun.hpp>

--- a/src/Storages/System/StorageSystemFunctions.cpp
+++ b/src/Storages/System/StorageSystemFunctions.cpp
@@ -16,6 +16,11 @@
 namespace DB
 {
 
+namespace ErrorCodes
+{
+    extern const int LOGICAL_ERROR;
+}
+
 enum class FunctionOrigin : int8_t
 {
     SYSTEM = 0,
@@ -67,13 +72,15 @@ namespace
             }
             else
             {
-                auto documentation = factory.getDocumentation(name);
-                res_columns[6]->insert(documentation.description);
-                res_columns[7]->insert(documentation.syntax);
-                res_columns[8]->insert(documentation.argumentsAsString());
-                res_columns[9]->insert(documentation.returned_value);
-                res_columns[10]->insert(documentation.examplesAsString());
-                res_columns[11]->insert(documentation.categoriesAsString());
+                auto documentation = factory.tryGetDocumentation(name);
+                if (!documentation)
+                    throw Exception(ErrorCodes::LOGICAL_ERROR, "Function {} not found in FunctionFactory", name);
+                res_columns[6]->insert(documentation->description);
+                res_columns[7]->insert(documentation->syntax);
+                res_columns[8]->insert(documentation->argumentsAsString());
+                res_columns[9]->insert(documentation->returned_value);
+                res_columns[10]->insert(documentation->examplesAsString());
+                res_columns[11]->insert(documentation->categoriesAsString());
             }
         }
         else

--- a/src/Storages/System/StorageSystemTableFunctions.cpp
+++ b/src/Storages/System/StorageSystemTableFunctions.cpp
@@ -28,10 +28,11 @@ void StorageSystemTableFunctions::fillData(MutableColumns & res_columns, Context
     {
         res_columns[0]->insert(function_name);
 
+        auto documentation = factory.tryGetDocumentation(function_name);
         auto properties = factory.tryGetProperties(function_name);
         if (properties)
         {
-            res_columns[1]->insert(properties->documentation.description);
+            res_columns[1]->insert(documentation->description);
             res_columns[2]->insert(properties->allow_readonly);
         }
         else

--- a/src/TableFunctions/ITableFunction.h
+++ b/src/TableFunctions/ITableFunction.h
@@ -4,7 +4,6 @@
 #include <Storages/IStorage_fwd.h>
 #include <Storages/ColumnsDescription.h>
 #include <Access/Common/AccessType.h>
-#include <Common/FunctionDocumentation.h>
 #include <Analyzer/IQueryTreeNode.h>
 
 #include <memory>
@@ -97,8 +96,6 @@ private:
 /// Properties of table function that are independent of argument types and parameters.
 struct TableFunctionProperties
 {
-    FunctionDocumentation documentation;
-
     /** It is determined by the possibility of modifying any data or making requests to arbitrary hostnames.
       *
       * If users can make a request to an arbitrary hostname, they can get the info from the internal network

--- a/src/TableFunctions/TableFunctionExplain.cpp
+++ b/src/TableFunctions/TableFunctionExplain.cpp
@@ -193,7 +193,7 @@ InterpreterExplainQuery TableFunctionExplain::getInterpreter(ContextPtr context)
 
 void registerTableFunctionExplain(TableFunctionFactory & factory)
 {
-    factory.registerFunction<TableFunctionExplain>({.documentation = {
+    factory.registerFunction<TableFunctionExplain>({
             .description=R"(
                 Returns result of EXPLAIN query.
                 The function should not be called directly but can be invoked via `SELECT * FROM (EXPLAIN <query>)`.
@@ -202,7 +202,7 @@ void registerTableFunctionExplain(TableFunctionFactory & factory)
                 [example:1]
                 )",
             .examples={{"1", "SELECT explain FROM (EXPLAIN AST SELECT * FROM system.numbers) WHERE explain LIKE '%Asterisk%'", ""}}
-        }});
+        });
 }
 
 }

--- a/src/TableFunctions/TableFunctionFactory.cpp
+++ b/src/TableFunctions/TableFunctionFactory.cpp
@@ -88,9 +88,34 @@ bool TableFunctionFactory::isTableFunctionName(const std::string & name) const
     return table_functions.contains(name);
 }
 
+std::optional<FunctionDocumentation> TableFunctionFactory::tryGetDocumentation(const String & name) const
+{
+    return tryGetDocumentationImpl(name);
+}
+
 std::optional<TableFunctionProperties> TableFunctionFactory::tryGetProperties(const String & name) const
 {
     return tryGetPropertiesImpl(name);
+}
+
+std::optional<FunctionDocumentation> TableFunctionFactory::tryGetDocumentationImpl(const String & name_param) const
+{
+    String name = getAliasToOrName(name_param);
+    Value found;
+
+    /// Find by exact match.
+    if (auto it = table_functions.find(name); it != table_functions.end())
+    {
+        found = it->second;
+    }
+
+    if (auto jt = case_insensitive_table_functions.find(Poco::toLower(name)); jt != case_insensitive_table_functions.end())
+        found = jt->second;
+
+    if (found.creator)
+        return found.documentation;
+
+    return {};
 }
 
 std::optional<TableFunctionProperties> TableFunctionFactory::tryGetPropertiesImpl(const String & name_param) const

--- a/src/TableFunctions/TableFunctionFactory.cpp
+++ b/src/TableFunctions/TableFunctionFactory.cpp
@@ -26,8 +26,7 @@ void TableFunctionFactory::registerFunction(
 
     if (case_sensitiveness == Case::Insensitive
         && !case_insensitive_table_functions.emplace(Poco::toLower(name), value).second)
-        throw Exception(ErrorCodes::LOGICAL_ERROR, "TableFunctionFactory: "
-                        "the case insensitive table function name '{}' is not unique", name);
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "TableFunctionFactory: the case insensitive table function name '{}' is not unique", name);
 
     KnownTableFunctionNames::instance().add(name, (case_sensitiveness == Case::Insensitive));
 }
@@ -103,11 +102,8 @@ std::optional<FunctionDocumentation> TableFunctionFactory::tryGetDocumentationIm
     String name = getAliasToOrName(name_param);
     Value found;
 
-    /// Find by exact match.
     if (auto it = table_functions.find(name); it != table_functions.end())
-    {
         found = it->second;
-    }
 
     if (auto jt = case_insensitive_table_functions.find(Poco::toLower(name)); jt != case_insensitive_table_functions.end())
         found = jt->second;
@@ -123,11 +119,8 @@ std::optional<TableFunctionProperties> TableFunctionFactory::tryGetPropertiesImp
     String name = getAliasToOrName(name_param);
     Value found;
 
-    /// Find by exact match.
     if (auto it = table_functions.find(name); it != table_functions.end())
-    {
         found = it->second;
-    }
 
     if (auto jt = case_insensitive_table_functions.find(Poco::toLower(name)); jt != case_insensitive_table_functions.end())
         found = jt->second;

--- a/src/TableFunctions/TableFunctionFactory.h
+++ b/src/TableFunctions/TableFunctionFactory.h
@@ -22,19 +22,8 @@ using TableFunctionCreator = std::function<TableFunctionPtr()>;
 struct TableFunctionFactoryData
 {
     TableFunctionCreator creator;
-    FunctionDocumentation documentation;
-    TableFunctionProperties properties;
-
-    TableFunctionFactoryData() = default;
-    TableFunctionFactoryData(const TableFunctionFactoryData &) = default;
-    TableFunctionFactoryData & operator = (const TableFunctionFactoryData &) = default;
-
-    template <typename Creator>
-        requires (!std::is_same_v<Creator, TableFunctionFactoryData>)
-    TableFunctionFactoryData(Creator creator_, FunctionDocumentation documentation_ = {}, TableFunctionProperties properties_ = {}) /// NOLINT
-        : creator(std::forward<Creator>(creator_)), documentation(std::move(documentation_)), properties(std::move(properties_))
-    {
-    }
+    FunctionDocumentation documentation = {};
+    TableFunctionProperties properties = {};
 };
 
 

--- a/src/TableFunctions/TableFunctionFactory.h
+++ b/src/TableFunctions/TableFunctionFactory.h
@@ -73,7 +73,6 @@ private:
     using TableFunctions = std::unordered_map<std::string, Value>;
 
     const TableFunctions & getMap() const override { return table_functions; }
-
     const TableFunctions & getCaseInsensitiveMap() const override { return case_insensitive_table_functions; }
 
     String getFactoryName() const override { return "TableFunctionFactory"; }

--- a/src/TableFunctions/TableFunctionFactory.h
+++ b/src/TableFunctions/TableFunctionFactory.h
@@ -21,8 +21,8 @@ using TableFunctionCreator = std::function<TableFunctionPtr()>;
 struct TableFunctionFactoryData
 {
     TableFunctionCreator creator;
-    TableFunctionProperties properties;
 
+    TableFunctionProperties properties;
     TableFunctionFactoryData() = default;
     TableFunctionFactoryData(const TableFunctionFactoryData &) = default;
     TableFunctionFactoryData & operator = (const TableFunctionFactoryData &) = default;
@@ -40,6 +40,7 @@ struct TableFunctionFactoryData
   */
 class TableFunctionFactory final: private boost::noncopyable, public IFactoryWithAliases<TableFunctionFactoryData>
 {
+    using Base = IFactoryWithAliases<TableFunctionFactoryData>;
 public:
     static TableFunctionFactory & instance();
 
@@ -72,15 +73,15 @@ public:
 private:
     using TableFunctions = std::unordered_map<std::string, Value>;
 
-    const TableFunctions & getMap() const override { return table_functions; }
-    const TableFunctions & getCaseInsensitiveMap() const override { return case_insensitive_table_functions; }
+    TableFunctions table_functions;
+    TableFunctions case_insensitive_table_functions;
+
+    const Base::OriginalNameMap & getOriginalNameMap() const override { return table_functions; }
+    const Base::OriginalNameMap & getOriginalCaseInsensitiveNameMap() const override { return case_insensitive_table_functions; }
 
     String getFactoryName() const override { return "TableFunctionFactory"; }
 
     std::optional<TableFunctionProperties> tryGetPropertiesImpl(const String & name) const;
-
-    TableFunctions table_functions;
-    TableFunctions case_insensitive_table_functions;
 };
 
 }

--- a/src/TableFunctions/TableFunctionFileCluster.cpp
+++ b/src/TableFunctions/TableFunctionFileCluster.cpp
@@ -54,11 +54,11 @@ StoragePtr TableFunctionFileCluster::getStorage(
 void registerTableFunctionFileCluster(TableFunctionFactory & factory)
 {
     factory.registerFunction<TableFunctionFileCluster>(
-        {.documentation = {
+        {
             .description=R"(This table function is used for distributed reading of files in cluster nodes filesystems.)",
             .examples{{"fileCluster", "SELECT * from fileCluster('my_cluster', 'file{1,2}.csv');", ""}},
             .categories{"File"}},
-        .allow_readonly = false});
+        {.allow_readonly = false});
 }
 
 }

--- a/src/TableFunctions/TableFunctionFormat.cpp
+++ b/src/TableFunctions/TableFunctionFormat.cpp
@@ -219,7 +219,7 @@ Result:
 
 void registerTableFunctionFormat(TableFunctionFactory & factory)
 {
-    factory.registerFunction<TableFunctionFormat>({format_table_function_documentation, false}, TableFunctionFactory::Case::Insensitive);
+    factory.registerFunction<TableFunctionFormat>(format_table_function_documentation, {}, TableFunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/TableFunctions/TableFunctionFuzzJSON.cpp
+++ b/src/TableFunctions/TableFunctionFuzzJSON.cpp
@@ -51,10 +51,9 @@ StoragePtr TableFunctionFuzzJSON::executeImpl(
 void registerTableFunctionFuzzJSON(TableFunctionFactory & factory)
 {
     factory.registerFunction<TableFunctionFuzzJSON>(
-        {.documentation
-         = {.description = "Perturbs a JSON string with random variations.",
-            .returned_value = "A table object with a a single column containing perturbed JSON strings."},
-         .allow_readonly = true});
+        {.description = "Perturbs a JSON string with random variations.",
+         .returned_value = "A table object with a a single column containing perturbed JSON strings."},
+        {.allow_readonly = true});
 }
 
 }

--- a/src/TableFunctions/TableFunctionFuzzQuery.cpp
+++ b/src/TableFunctions/TableFunctionFuzzQuery.cpp
@@ -45,10 +45,10 @@ StoragePtr TableFunctionFuzzQuery::executeImpl(
 void registerTableFunctionFuzzQuery(TableFunctionFactory & factory)
 {
     factory.registerFunction<TableFunctionFuzzQuery>(
-        {.documentation
-         = {.description = "Perturbs a query string with random variations.",
-            .returned_value = "A table object with a single column containing perturbed query strings."},
-         .allow_readonly = true});
+        {.description = "Perturbs a query string with random variations.",
+         .returned_value = "A table object with a single column containing perturbed query strings."},
+        {.allow_readonly = true}
+    );
 }
 
 }

--- a/src/TableFunctions/TableFunctionGenerateRandom.cpp
+++ b/src/TableFunctions/TableFunctionGenerateRandom.cpp
@@ -164,7 +164,7 @@ StoragePtr TableFunctionGenerateRandom::executeImpl(const ASTPtr & /*ast_functio
 
 void registerTableFunctionGenerate(TableFunctionFactory & factory)
 {
-    factory.registerFunction<TableFunctionGenerateRandom>({.documentation = {}, .allow_readonly = true});
+    factory.registerFunction<TableFunctionGenerateRandom>({}, {.allow_readonly = true});
 }
 
 }

--- a/src/TableFunctions/TableFunctionGenerateSeries.cpp
+++ b/src/TableFunctions/TableFunctionGenerateSeries.cpp
@@ -111,8 +111,8 @@ UInt64 TableFunctionGenerateSeries<alias_num>::evaluateArgument(ContextPtr conte
 
 void registerTableFunctionGenerateSeries(TableFunctionFactory & factory)
 {
-    factory.registerFunction<TableFunctionGenerateSeries<0>>({.documentation = {}, .allow_readonly = true});
-    factory.registerFunction<TableFunctionGenerateSeries<1>>({.documentation = {}, .allow_readonly = true});
+    factory.registerFunction<TableFunctionGenerateSeries<0>>({}, {.allow_readonly = true});
+    factory.registerFunction<TableFunctionGenerateSeries<1>>({}, {.allow_readonly = true});
 }
 
 }

--- a/src/TableFunctions/TableFunctionLoop.cpp
+++ b/src/TableFunctions/TableFunctionLoop.cpp
@@ -140,16 +140,15 @@ namespace DB
     void registerTableFunctionLoop(TableFunctionFactory & factory)
     {
         factory.registerFunction<TableFunctionLoop>(
-                {.documentation
-                = {.description=R"(The table function can be used to continuously output query results in an infinite loop.)",
-                                .examples{{"loop", "SELECT * FROM loop((numbers(3)) LIMIT 7", "0"
+                {.description=R"(The table function can be used to continuously output query results in an infinite loop.)",
+                 .examples{{"loop", "SELECT * FROM loop((numbers(3)) LIMIT 7", "0"
                                                                                               "1"
                                                                                               "2"
                                                                                               "0"
                                                                                               "1"
                                                                                               "2"
                                                                                               "0"}}
-                        }});
+                        });
     }
 
 }

--- a/src/TableFunctions/TableFunctionMergeTreeIndex.cpp
+++ b/src/TableFunctions/TableFunctionMergeTreeIndex.cpp
@@ -192,15 +192,13 @@ StoragePtr TableFunctionMergeTreeIndex::executeImpl(
 void registerTableFunctionMergeTreeIndex(TableFunctionFactory & factory)
 {
     factory.registerFunction<TableFunctionMergeTreeIndex>(
-    {
-        .documentation =
         {
             .description = "Represents the contents of index and marks files of MergeTree tables. It can be used for introspection",
             .examples = {{"mergeTreeIndex", "SELECT * FROM mergeTreeIndex(currentDatabase(), mt_table, with_marks = true)", ""}},
             .categories = {"Other"},
         },
-        .allow_readonly = true,
-    });
+        {.allow_readonly = true}
+    );
 }
 
 }

--- a/src/TableFunctions/TableFunctionNull.cpp
+++ b/src/TableFunctions/TableFunctionNull.cpp
@@ -88,7 +88,7 @@ StoragePtr TableFunctionNull::executeImpl(const ASTPtr & /*ast_function*/, Conte
 
 void registerTableFunctionNull(TableFunctionFactory & factory)
 {
-    factory.registerFunction<TableFunctionNull>({.documentation = {}, .allow_readonly = true});
+    factory.registerFunction<TableFunctionNull>({}, {.allow_readonly = true});
 }
 
 }

--- a/src/TableFunctions/TableFunctionNumbers.cpp
+++ b/src/TableFunctions/TableFunctionNumbers.cpp
@@ -121,8 +121,8 @@ UInt64 TableFunctionNumbers<multithreaded>::evaluateArgument(ContextPtr context,
 
 void registerTableFunctionNumbers(TableFunctionFactory & factory)
 {
-    factory.registerFunction<TableFunctionNumbers<true>>({.documentation = {}, .allow_readonly = true});
-    factory.registerFunction<TableFunctionNumbers<false>>({.documentation = {}, .allow_readonly = true});
+    factory.registerFunction<TableFunctionNumbers<true>>({}, {.allow_readonly = true});
+    factory.registerFunction<TableFunctionNumbers<false>>({}, {.allow_readonly = true});
 }
 
 }

--- a/src/TableFunctions/TableFunctionObjectStorage.cpp
+++ b/src/TableFunctions/TableFunctionObjectStorage.cpp
@@ -129,79 +129,58 @@ void registerTableFunctionObjectStorage(TableFunctionFactory & factory)
     UNUSED(factory);
 #if USE_AWS_S3
     factory.registerFunction<TableFunctionObjectStorage<S3Definition, StorageS3Configuration>>(
-    {
-        .documentation =
         {
             .description=R"(The table function can be used to read the data stored on AWS S3.)",
-            .examples{{"s3", "SELECT * FROM s3(url, access_key_id, secret_access_key)", ""}
+            .examples{{"s3", "SELECT * FROM s3(url, access_key_id, secret_access_key)", ""}},
+            .categories{"DataLake"}
         },
-        .categories{"DataLake"}},
-        .allow_readonly = false
-    });
+        {.allow_readonly = false}
+    );
 
     factory.registerFunction<TableFunctionObjectStorage<GCSDefinition, StorageS3Configuration>>(
-    {
-        .documentation =
         {
             .description=R"(The table function can be used to read the data stored on GCS.)",
-            .examples{{"gcs", "SELECT * FROM gcs(url, access_key_id, secret_access_key)", ""}
+            .examples{{"gcs", "SELECT * FROM gcs(url, access_key_id, secret_access_key)", ""}},
+            .categories{"DataLake"}
         },
-        .categories{"DataLake"}},
-        .allow_readonly = false
-    });
+        {.allow_readonly = false}
+    );
 
     factory.registerFunction<TableFunctionObjectStorage<COSNDefinition, StorageS3Configuration>>(
-    {
-        .documentation =
         {
             .description=R"(The table function can be used to read the data stored on COSN.)",
-            .examples{{"cosn", "SELECT * FROM cosn(url, access_key_id, secret_access_key)", ""}
+            .examples{{"cosn", "SELECT * FROM cosn(url, access_key_id, secret_access_key)", ""}},
+            .categories{"DataLake"}
         },
-        .categories{"DataLake"}},
-        .allow_readonly = false
-    });
+        {.allow_readonly = false}
+    );
     factory.registerFunction<TableFunctionObjectStorage<OSSDefinition, StorageS3Configuration>>(
-    {
-        .documentation =
         {
             .description=R"(The table function can be used to read the data stored on OSS.)",
-            .examples{{"oss", "SELECT * FROM oss(url, access_key_id, secret_access_key)", ""}
+            .examples{{"oss", "SELECT * FROM oss(url, access_key_id, secret_access_key)", ""}},
+            .categories{"DataLake"}
         },
-        .categories{"DataLake"}},
-        .allow_readonly = false
-    });
+        {.allow_readonly = false}
+    );
 #endif
 
 #if USE_AZURE_BLOB_STORAGE
     factory.registerFunction<TableFunctionObjectStorage<AzureDefinition, StorageAzureConfiguration>>(
-    {
-        .documentation =
         {
             .description=R"(The table function can be used to read the data stored on Azure Blob Storage.)",
-            .examples{
-            {
-                "azureBlobStorage",
-                "SELECT * FROM  azureBlobStorage(connection_string|storage_account_url, container_name, blobpath, "
-                "[account_name, account_key, format, compression, structure])", ""
-            }}
+            .examples{{"azureBlobStorage", "SELECT * FROM  azureBlobStorage(connection_string|storage_account_url, container_name, blobpath, " "[account_name, account_key, format, compression, structure])", ""}}
         },
-        .allow_readonly = false
-    });
+        {.allow_readonly = false}
+    );
 #endif
 #if USE_HDFS
     factory.registerFunction<TableFunctionObjectStorage<HDFSDefinition, StorageHDFSConfiguration>>(
-    {
-        .documentation =
         {
             .description=R"(The table function can be used to read the data stored on HDFS virtual filesystem.)",
-            .examples{
-            {
-                "hdfs",
-                "SELECT * FROM  hdfs(url, format, compression, structure])", ""
-            }}
+            .examples{{"hdfs", "SELECT * FROM  hdfs(url, format, compression, structure])", ""}}
         },
-        .allow_readonly = false
-    });
+        {.allow_readonly = false}
+    );
 #endif
 }
 

--- a/src/TableFunctions/TableFunctionObjectStorageCluster.cpp
+++ b/src/TableFunctions/TableFunctionObjectStorageCluster.cpp
@@ -67,37 +67,34 @@ void registerTableFunctionObjectStorageCluster(TableFunctionFactory & factory)
 {
 #if USE_AWS_S3
     factory.registerFunction<TableFunctionS3Cluster>(
-    {
-        .documentation = {
+        {
             .description=R"(The table function can be used to read the data stored on S3 in parallel for many nodes in a specified cluster.)",
-            .examples{{"s3Cluster", "SELECT * FROM  s3Cluster(cluster, url, format, structure)", ""}}},
-            .allow_readonly = false
-        }
+            .examples{{"s3Cluster", "SELECT * FROM  s3Cluster(cluster, url, format, structure)", ""}}
+        },
+        {.allow_readonly = false}
     );
 #endif
 
 #if USE_AZURE_BLOB_STORAGE
     factory.registerFunction<TableFunctionAzureBlobCluster>(
-    {
-        .documentation = {
+        {
             .description=R"(The table function can be used to read the data stored on Azure Blob Storage in parallel for many nodes in a specified cluster.)",
             .examples{{
                 "azureBlobStorageCluster",
                 "SELECT * FROM  azureBlobStorageCluster(cluster, connection_string|storage_account_url, container_name, blobpath, "
-                "[account_name, account_key, format, compression, structure])", ""}}},
-            .allow_readonly = false
-        }
+                "[account_name, account_key, format, compression, structure])", ""}}
+        },
+        {.allow_readonly = false}
     );
 #endif
 
 #if USE_HDFS
     factory.registerFunction<TableFunctionHDFSCluster>(
-    {
-        .documentation = {
+        {
             .description=R"(The table function can be used to read the data stored on HDFS in parallel for many nodes in a specified cluster.)",
-            .examples{{"HDFSCluster", "SELECT * FROM HDFSCluster(cluster_name, uri, format)", ""}}},
-            .allow_readonly = false
-        }
+            .examples{{"HDFSCluster", "SELECT * FROM HDFSCluster(cluster_name, uri, format)", ""}}
+        },
+        {.allow_readonly = false}
     );
 #endif
 

--- a/src/TableFunctions/TableFunctionRemote.cpp
+++ b/src/TableFunctions/TableFunctionRemote.cpp
@@ -362,8 +362,8 @@ TableFunctionRemote::TableFunctionRemote(const std::string & name_, bool secure_
 
 void registerTableFunctionRemote(TableFunctionFactory & factory)
 {
-    factory.registerFunction("remote", [] () -> TableFunctionPtr { return std::make_shared<TableFunctionRemote>("remote"); });
-    factory.registerFunction("remoteSecure", [] () -> TableFunctionPtr { return std::make_shared<TableFunctionRemote>("remote", /* secure = */ true); });
+    factory.registerFunction("remote", {.creator = [] () -> TableFunctionPtr { return std::make_shared<TableFunctionRemote>("remote"); }});
+    factory.registerFunction("remoteSecure", {.creator = [] () -> TableFunctionPtr { return std::make_shared<TableFunctionRemote>("remote", /* secure = */ true); }});
     factory.registerFunction("cluster", {[] () -> TableFunctionPtr { return std::make_shared<TableFunctionRemote>("cluster"); }, {}, {.allow_readonly = true}});
     factory.registerFunction("clusterAllReplicas", {[] () -> TableFunctionPtr { return std::make_shared<TableFunctionRemote>("clusterAllReplicas"); }, {}, {.allow_readonly = true}});
 }

--- a/src/TableFunctions/TableFunctionRemote.cpp
+++ b/src/TableFunctions/TableFunctionRemote.cpp
@@ -364,8 +364,8 @@ void registerTableFunctionRemote(TableFunctionFactory & factory)
 {
     factory.registerFunction("remote", [] () -> TableFunctionPtr { return std::make_shared<TableFunctionRemote>("remote"); });
     factory.registerFunction("remoteSecure", [] () -> TableFunctionPtr { return std::make_shared<TableFunctionRemote>("remote", /* secure = */ true); });
-    factory.registerFunction("cluster", {[] () -> TableFunctionPtr { return std::make_shared<TableFunctionRemote>("cluster"); }, {.documentation = {}, .allow_readonly = true}});
-    factory.registerFunction("clusterAllReplicas", {[] () -> TableFunctionPtr { return std::make_shared<TableFunctionRemote>("clusterAllReplicas"); }, {.documentation = {}, .allow_readonly = true}});
+    factory.registerFunction("cluster", {[] () -> TableFunctionPtr { return std::make_shared<TableFunctionRemote>("cluster"); }, {}, {.allow_readonly = true}});
+    factory.registerFunction("clusterAllReplicas", {[] () -> TableFunctionPtr { return std::make_shared<TableFunctionRemote>("clusterAllReplicas"); }, {}, {.allow_readonly = true}});
 }
 
 }

--- a/src/TableFunctions/TableFunctionValues.cpp
+++ b/src/TableFunctions/TableFunctionValues.cpp
@@ -174,7 +174,7 @@ StoragePtr TableFunctionValues::executeImpl(const ASTPtr & ast_function, Context
 
 void registerTableFunctionValues(TableFunctionFactory & factory)
 {
-    factory.registerFunction<TableFunctionValues>({.documentation = {}, .allow_readonly = true}, TableFunctionFactory::Case::Insensitive);
+    factory.registerFunction<TableFunctionValues>({}, {.allow_readonly = true}, TableFunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/TableFunctions/TableFunctionView.cpp
+++ b/src/TableFunctions/TableFunctionView.cpp
@@ -69,7 +69,7 @@ StoragePtr TableFunctionView::executeImpl(
 
 void registerTableFunctionView(TableFunctionFactory & factory)
 {
-    factory.registerFunction<TableFunctionView>({.documentation = {}, .allow_readonly = true});
+    factory.registerFunction<TableFunctionView>({}, {.allow_readonly = true});
 }
 
 }

--- a/src/TableFunctions/TableFunctionViewIfPermitted.cpp
+++ b/src/TableFunctions/TableFunctionViewIfPermitted.cpp
@@ -151,7 +151,7 @@ bool TableFunctionViewIfPermitted::isPermitted(const ContextPtr & context, const
 
 void registerTableFunctionViewIfPermitted(TableFunctionFactory & factory)
 {
-    factory.registerFunction<TableFunctionViewIfPermitted>({.documentation = {}, .allow_readonly = true});
+    factory.registerFunction<TableFunctionViewIfPermitted>({}, {.allow_readonly = true});
 }
 
 }

--- a/src/TableFunctions/TableFunctionZeros.cpp
+++ b/src/TableFunctions/TableFunctionZeros.cpp
@@ -87,7 +87,7 @@ UInt64 TableFunctionZeros<multithreaded>::evaluateArgument(ContextPtr context, A
 
 void registerTableFunctionZeros(TableFunctionFactory & factory)
 {
-    factory.registerFunction<TableFunctionZeros<true>>({.documentation = {
+    factory.registerFunction<TableFunctionZeros<true>>({
             .description=R"(
                 Generates a stream of zeros (a table with one column 'zero' of type 'UInt8') of specified size.
                 This table function is used in performance tests, where you want to spend as little time as possible to data generation while testing some other parts of queries.
@@ -97,9 +97,9 @@ void registerTableFunctionZeros(TableFunctionFactory & factory)
                 This query will test the speed of `randomPrintableASCII` function using single thread.
                 See also the `system.zeros` table.)",
             .examples={{"1", "SELECT count() FROM zeros(100000000) WHERE NOT ignore(randomPrintableASCII(10))", ""}}
-    }});
+    });
 
-    factory.registerFunction<TableFunctionZeros<false>>({.documentation = {
+    factory.registerFunction<TableFunctionZeros<false>>({
             .description=R"(
                 Generates a stream of zeros (a table with one column 'zero' of type 'UInt8') of specified size.
                 This table function is used in performance tests, where you want to spend as little time as possible to data generation while testing some other parts of queries.
@@ -110,7 +110,7 @@ void registerTableFunctionZeros(TableFunctionFactory & factory)
                 See also the `system.zeros` table.
                 )",
             .examples={{"1", "SELECT count() FROM zeros_mt(1000000000) WHERE NOT ignore(randomPrintableASCII(10))", ""}}
-    }});
+    });
 }
 
 }

--- a/src/TableFunctions/registerDataLakeTableFunctions.cpp
+++ b/src/TableFunctions/registerDataLakeTableFunctions.cpp
@@ -5,63 +5,56 @@ namespace DB
 {
 
 #if USE_AWS_S3
-#if USE_AVRO
+#  if USE_AVRO
 void registerTableFunctionIceberg(TableFunctionFactory & factory)
 {
     factory.registerFunction<TableFunctionIceberg>(
-    {
-        .documentation =
         {
             .description=R"(The table function can be used to read the Iceberg table stored on object store.)",
             .examples{{"iceberg", "SELECT * FROM iceberg(url, access_key_id, secret_access_key)", ""}},
             .categories{"DataLake"}
         },
-        .allow_readonly = false
-    });
+        {.allow_readonly = false}
+    );
 }
-#endif
+#  endif
 
-#if USE_PARQUET
+#  if USE_PARQUET
 void registerTableFunctionDeltaLake(TableFunctionFactory & factory)
 {
     factory.registerFunction<TableFunctionDeltaLake>(
-    {
-        .documentation =
         {
             .description=R"(The table function can be used to read the DeltaLake table stored on object store.)",
             .examples{{"deltaLake", "SELECT * FROM deltaLake(url, access_key_id, secret_access_key)", ""}},
             .categories{"DataLake"}
         },
-        .allow_readonly = false
-    });
+        {.allow_readonly = false}
+    );
 }
-#endif
+#  endif
 
 void registerTableFunctionHudi(TableFunctionFactory & factory)
 {
     factory.registerFunction<TableFunctionHudi>(
-    {
-        .documentation =
         {
             .description=R"(The table function can be used to read the Hudi table stored on object store.)",
             .examples{{"hudi", "SELECT * FROM hudi(url, access_key_id, secret_access_key)", ""}},
             .categories{"DataLake"}
         },
-        .allow_readonly = false
-    });
+        {.allow_readonly = false}
+    );
 }
 #endif
 
-void registerDataLakeTableFunctions(TableFunctionFactory & factory)
+void registerDataLakeTableFunctions([[maybe_unused]] TableFunctionFactory & factory)
 {
-    UNUSED(factory);
 #if USE_AWS_S3
-#if USE_AVRO
+#  if USE_AVRO
     registerTableFunctionIceberg(factory);
-#endif
-#if USE_PARQUET
+#  endif
+#  if USE_PARQUET
     registerTableFunctionDeltaLake(factory);
-#endif
+#  endif
     registerTableFunctionHudi(factory);
 #endif
 }


### PR DESCRIPTION
This PR is preparation for a re-implementation of #55035 after it was removed with #66630.

In the previous implementation, system table `system.functions` relied on virtual function `IFunction::isDeterministic` to fill field `is_deterministic` in the system table. In order to call `IFunction::isDeterministic`, the function had to be instantiated. In certain situations, function instantiation could throw an exception, e.g. because a dictionary is not initialized. This is actually all good and expected, and the system table had a try-catch that would fill in a dummy value in this case. But then there was also stateless test `02815_no_throw_in_simple_queries` which runs a simple query under environment variable `CLICKHOUSE_TERMINATE_ON_ANY_EXCEPTION=1`. The test uses clickHouse-local which internally queries `system.functions` to provide SQL syntax highlighting and completion. This led to an exception thrown and caught internally, but the test still failed - I guess rightfully as simple queries should throw no exceptions at all (even if they are handled). #66630 then removed the previous implementation.

A future PR will re-implement `system.functions.is_deterministic` using *function properties*, similar to what we already have for table functions (--> table function properties) and aggregation functions (--> aggregation function properties). These can be queried without instantiating the function.

This PR introduces the necessary infrastructure for this but does not add actually function properties yet.

Reviewer note: the individual commits are small, self-contained, and they have commit messages. For mental sanity, better check them instead of checking the whole PR at once.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)