### PR TITLE
 Save writer thread id in shared mutex for debugging 

### DIFF
--- a/src/Common/SharedMutex.cpp
+++ b/src/Common/SharedMutex.cpp
@@ -31,11 +31,13 @@ void SharedMutex::lock()
             break;
     }
 
+    /// The first step of acquiring the exclusive ownership is finished.
+    /// Now we just wait until all readers release the shared ownership.
+    writer_thread_id.store(getThreadId());
+
     value |= writers;
     while (value & readers)
         futexWaitLowerFetch(state, value);
-
-    writer_thread_id.store(getThreadId());
 }
 
 bool SharedMutex::try_lock()

--- a/src/Common/SharedMutex.h
+++ b/src/Common/SharedMutex.h
@@ -38,7 +38,7 @@ private:
 
     alignas(64) std::atomic<UInt64> state;
     std::atomic<UInt32> waiters;
-    /// Is set while the lock is held in exclusive mode only to facilitate debugging
+    /// Is set while the lock is held (or is in the process of being acquired) in exclusive mode only to facilitate debugging
     std::atomic<UInt64> writer_thread_id;
 };
 

--- a/src/Common/SharedMutex.h
+++ b/src/Common/SharedMutex.h
@@ -36,6 +36,8 @@ private:
 
     alignas(64) std::atomic<UInt64> state;
     std::atomic<UInt32> waiters;
+    /// Is set while the lock is held in exclusive mode only to facilitate debugging
+    std::atomic<UInt64> writer_thread_id;
 };
 
 }

--- a/src/Common/SharedMutex.h
+++ b/src/Common/SharedMutex.h
@@ -19,6 +19,8 @@ public:
     ~SharedMutex() = default;
     SharedMutex(const SharedMutex &) = delete;
     SharedMutex & operator=(const SharedMutex &) = delete;
+    SharedMutex(SharedMutex &&) = delete;
+    SharedMutex & operator=(SharedMutex &&) = delete;
 
     // Exclusive ownership
     void lock() TSA_ACQUIRE();


### PR DESCRIPTION
- Save writer thread id when the mutex is exclusively locked to facilitate debugging
- Disable move assignment and ctor

cc @serxa 

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
