### PR TITLE
Use non-existent address to check connection error at table creation

### DIFF
--- a/tests/integration/test_storage_rabbitmq/test.py
+++ b/tests/integration/test_storage_rabbitmq/test.py
@@ -2220,13 +2220,11 @@ def test_rabbitmq_commit_on_block_write(rabbitmq_cluster):
 
 
 def test_rabbitmq_no_connection_at_startup_1(rabbitmq_cluster):
-    # no connection when table is initialized
-    rabbitmq_cluster.pause_container("rabbitmq1")
-    instance.query_and_get_error(
+    error = instance.query_and_get_error(
         """
         CREATE TABLE test.cs (key UInt64, value UInt64)
             ENGINE = RabbitMQ
-            SETTINGS rabbitmq_host_port = 'rabbitmq1:5672',
+            SETTINGS rabbitmq_host_port = 'no_connection_at_startup:5672',
                      rabbitmq_exchange_name = 'cs',
                      rabbitmq_format = 'JSONEachRow',
                      rabbitmq_flush_interval_ms=1000,
@@ -2234,7 +2232,7 @@ def test_rabbitmq_no_connection_at_startup_1(rabbitmq_cluster):
                      rabbitmq_row_delimiter = '\\n';
     """
     )
-    rabbitmq_cluster.unpause_container("rabbitmq1")
+    assert "CANNOT_CONNECT_RABBITMQ" in error
 
 
 def test_rabbitmq_no_connection_at_startup_2(rabbitmq_cluster):


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


`docker container pause` can fail with some very strange error:

```
time="2024-07-18T07:59:54.311730065Z" level=debug msg="Calling POST /v1.42/containers/8e6b8831455b2c6f39536cdd588a50b9237985d2fc757adbb00ce841ae688631/pause"
time="2024-07-18T07:59:54.616423750Z" level=debug msg="FIXME: Got an API for which error does not match any expected type!!!: Cannot pause container 8e6b8831455b2c6f39536cdd588a50b9237985d2fc757adbb00ce841ae688631: OCI runtime pause failed: unable to freeze: unknown" error_type="*errors.errorString" module=api
time="2024-07-18T07:59:54.616462412Z" level=error msg="Handler for POST /v1.42/containers/8e6b8831455b2c6f39536cdd588a50b9237985d2fc757adbb00ce841ae688631/pause returned error: Cannot pause container 8e6b8831455b2c6f39536cdd588a50b9237985d2fc757adbb00ce841ae688631: OCI runtime pause failed: unable to freeze: unknown"
time="2024-07-18T07:59:54.616481981Z" level=debug msg="FIXME: Got an API for which error does not match any expected type!!!: Cannot pause container 8e6b8831455b2c6f39536cdd588a50b9237985d2fc757adbb00ce841ae688631: OCI runtime pause failed: unable to freeze: unknown" error_type="*errors.errorString" module=api
time="2024-07-18T07:59:54.711320169Z" level=debug msg="Name To resolve: rabbitmq1."
time="2024-07-18T07:59:54.711389656Z" level=debug msg="[resolver] lookup name rabbitmq1. present without IPv6 address"
time="2024-07-18T07:59:54.711322950Z" level=debug msg="Name To resolve: rabbitmq1."
time="2024-07-18T07:59:54.711459858Z" level=debug msg="[resolver] lookup for rabbitmq1.: IP [172.16.3.2]"
```

I think there shouldn't be any difference between using the address of a paused docker container or a completely non-existent address
### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
