### PR TITLE
Fix flakiness of async insert tests due to adaptive timeout

### DIFF
--- a/tests/queries/0_stateless/02726_async_insert_flush_queue.sql
+++ b/tests/queries/0_stateless/02726_async_insert_flush_queue.sql
@@ -6,7 +6,8 @@ CREATE TABLE t_async_inserts_flush (a UInt64) ENGINE = Memory;
 
 SET async_insert = 1;
 SET wait_for_async_insert = 0;
-SET async_insert_busy_timeout_min_ms = 1000000;
+-- Disable adaptive timeout to prevent immediate push of the first message (if the queue last push was old)
+SET async_insert_use_adaptive_busy_timeout=0;
 SET async_insert_busy_timeout_max_ms = 10000000;
 
 INSERT INTO t_async_inserts_flush VALUES (1) (2);

--- a/tests/queries/0_stateless/02884_async_insert_skip_settings.reference
+++ b/tests/queries/0_stateless/02884_async_insert_skip_settings.reference
@@ -1,5 +1,5 @@
-4
+pending to flush	4
 1
 1
 2
-1
+flush queries	1

--- a/tests/queries/0_stateless/02884_async_insert_skip_settings.sql
+++ b/tests/queries/0_stateless/02884_async_insert_skip_settings.sql
@@ -9,7 +9,8 @@ ORDER BY id;
 SET async_insert = 1;
 SET async_insert_deduplicate = 1;
 SET wait_for_async_insert = 0;
-SET async_insert_busy_timeout_min_ms = 100000;
+-- Disable adaptive timeout to prevent immediate push of the first message (if the queue last push was old)
+SET async_insert_use_adaptive_busy_timeout=0;
 SET async_insert_busy_timeout_max_ms = 1000000;
 
 SET insert_deduplication_token = '1';
@@ -30,7 +31,7 @@ INSERT INTO t_async_insert_skip_settings VALUES (2);
 
 SYSTEM FLUSH LOGS;
 
-SELECT length(entries.bytes) FROM system.asynchronous_inserts
+SELECT 'pending to flush', length(entries.bytes) FROM system.asynchronous_inserts
 WHERE database = currentDatabase() AND table = 't_async_insert_skip_settings'
 ORDER BY first_update;
 
@@ -40,7 +41,7 @@ SELECT * FROM t_async_insert_skip_settings ORDER BY id;
 
 SYSTEM FLUSH LOGS;
 
-SELECT uniqExact(flush_query_id) FROM system.asynchronous_insert_log
+SELECT 'flush queries', uniqExact(flush_query_id) FROM system.asynchronous_insert_log
 WHERE database = currentDatabase() AND table = 't_async_insert_skip_settings';
 
 DROP TABLE t_async_insert_skip_settings SYNC;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix flakiness of async insert tests due to adaptive timeout


The problem is that when adaptive timeouts are active (by default) the first insert might be immediate if the queue had been used before and has been unused for more than `async_insert_busy_timeout_max_ms` (which is possible). Disabling adaptive timeouts disables this immediate push.

Closes https://github.com/ClickHouse/ClickHouse/issues/47866 (we can open different tickets for other issues, as most of the reports are now old or incorrect)

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
