### PR TITLE
Fix sort order of the azureBlobStorageCluster table function

### DIFF
--- a/docs/en/sql-reference/table-functions/azureBlobStorageCluster.md
+++ b/docs/en/sql-reference/table-functions/azureBlobStorageCluster.md
@@ -1,6 +1,6 @@
 ---
 slug: /en/sql-reference/table-functions/azureBlobStorageCluster
-sidebar_position: 55
+sidebar_position: 15
 sidebar_label: azureBlobStorageCluster
 title: "azureBlobStorageCluster Table Function"
 ---


### PR DESCRIPTION
This has been driving me crazy for a while 😄 The table functions are listed alphabetically except for this one - so it's a trivial fix.


### Changelog category (leave one):
- Documentation (changelog entry is not required)
