### PR TITLE
CI: BuildReport and CheckReadyForMerge impovements

### DIFF
--- a/tests/ci/ci.py
+++ b/tests/ci/ci.py
@@ -1110,12 +1110,13 @@ def main() -> int:
             ci_cache.print_status()
 
         if IS_CI and not pr_info.is_merge_queue:
-            # wait for pending jobs to be finished, await_jobs is a long blocking call
-            ci_cache.await_pending_jobs(pr_info.is_release)
 
             if pr_info.is_release:
                 print("Release/master: CI Cache add pending records for all todo jobs")
                 ci_cache.push_pending_all(pr_info.is_release)
+
+            # wait for pending jobs to be finished, await_jobs is a long blocking call
+            ci_cache.await_pending_jobs(pr_info.is_release)
 
         # conclude results
         result["git_ref"] = git_ref

--- a/tests/ci/ci_cache.py
+++ b/tests/ci/ci_cache.py
@@ -638,7 +638,14 @@ class CiCache:
         pushes pending records for all jobs that supposed to be run
         """
         for job, job_config in self.jobs_to_do.items():
-            if not job_config.has_digest() or job_config.disable_await:
+            if (
+                job in self.jobs_to_wait
+                or not job_config.has_digest()
+                or job_config.disable_await
+            ):
+                # 1. "job in self.jobs_to_wait" - this job already has a pending record in cache
+                # 2. "not job_config.has_digest()" - cache is not used for these jobs
+                # 3. "job_config.disable_await" - await is explicitly disabled
                 continue
             pending_state = PendingState(time.time(), run_url=GITHUB_RUN_URL)
             assert job_config.batches
@@ -899,3 +906,87 @@ class CiCache:
                 self.jobs_to_wait[job] = job_config
 
         return self
+
+
+if __name__ == "__main__":
+    # for testing
+    job_digest = {
+        "package_release": "bbbd3519d1",
+        "package_aarch64": "bbbd3519d1",
+        "package_asan": "bbbd3519d1",
+        "package_ubsan": "bbbd3519d1",
+        "package_tsan": "bbbd3519d1",
+        "package_msan": "bbbd3519d1",
+        "package_debug": "bbbd3519d1",
+        "package_release_coverage": "bbbd3519d1",
+        "binary_release": "bbbd3519d1",
+        "binary_tidy": "bbbd3519d1",
+        "binary_darwin": "bbbd3519d1",
+        "binary_aarch64": "bbbd3519d1",
+        "binary_aarch64_v80compat": "bbbd3519d1",
+        "binary_freebsd": "bbbd3519d1",
+        "binary_darwin_aarch64": "bbbd3519d1",
+        "binary_ppc64le": "bbbd3519d1",
+        "binary_amd64_compat": "bbbd3519d1",
+        "binary_amd64_musl": "bbbd3519d1",
+        "binary_riscv64": "bbbd3519d1",
+        "binary_s390x": "bbbd3519d1",
+        "binary_loongarch64": "bbbd3519d1",
+        "Builds": "f5dffeecb8",
+        "Install packages (release)": "ba0c89660e",
+        "Install packages (aarch64)": "ba0c89660e",
+        "Stateful tests (asan)": "32a9a1aba9",
+        "Stateful tests (tsan)": "32a9a1aba9",
+        "Stateful tests (msan)": "32a9a1aba9",
+        "Stateful tests (ubsan)": "32a9a1aba9",
+        "Stateful tests (debug)": "32a9a1aba9",
+        "Stateful tests (release)": "32a9a1aba9",
+        "Stateful tests (coverage)": "32a9a1aba9",
+        "Stateful tests (aarch64)": "32a9a1aba9",
+        "Stateful tests (release, ParallelReplicas)": "32a9a1aba9",
+        "Stateful tests (debug, ParallelReplicas)": "32a9a1aba9",
+        "Stateless tests (asan)": "deb6778b88",
+        "Stateless tests (tsan)": "deb6778b88",
+        "Stateless tests (msan)": "deb6778b88",
+        "Stateless tests (ubsan)": "deb6778b88",
+        "Stateless tests (debug)": "deb6778b88",
+        "Stateless tests (release)": "deb6778b88",
+        "Stateless tests (coverage)": "deb6778b88",
+        "Stateless tests (aarch64)": "deb6778b88",
+        "Stateless tests (release, old analyzer, s3, DatabaseReplicated)": "deb6778b88",
+        "Stateless tests (debug, s3 storage)": "deb6778b88",
+        "Stateless tests (tsan, s3 storage)": "deb6778b88",
+        "Stress test (debug)": "aa298abf10",
+        "Stress test (tsan)": "aa298abf10",
+        "Upgrade check (debug)": "5ce4d3ee02",
+        "Integration tests (asan, old analyzer)": "42e58be3aa",
+        "Integration tests (tsan)": "42e58be3aa",
+        "Integration tests (aarch64)": "42e58be3aa",
+        "Integration tests flaky check (asan)": "42e58be3aa",
+        "Compatibility check (release)": "ecb69d8c4b",
+        "Compatibility check (aarch64)": "ecb69d8c4b",
+        "Unit tests (release)": "09d00b702e",
+        "Unit tests (asan)": "09d00b702e",
+        "Unit tests (msan)": "09d00b702e",
+        "Unit tests (tsan)": "09d00b702e",
+        "Unit tests (ubsan)": "09d00b702e",
+        "AST fuzzer (debug)": "c38ebf947f",
+        "AST fuzzer (asan)": "c38ebf947f",
+        "AST fuzzer (msan)": "c38ebf947f",
+        "AST fuzzer (tsan)": "c38ebf947f",
+        "AST fuzzer (ubsan)": "c38ebf947f",
+        "Stateless tests flaky check (asan)": "deb6778b88",
+        "Performance Comparison (release)": "a8a7179258",
+        "ClickBench (release)": "45c07c4aa6",
+        "ClickBench (aarch64)": "45c07c4aa6",
+        "Docker server image": "6a24d5b187",
+        "Docker keeper image": "6a24d5b187",
+        "Docs check": "4764154c62",
+        "Fast test": "cb269133f2",
+        "Style check": "ffffffffff",
+        "Stateful tests (ubsan, ParallelReplicas)": "32a9a1aba9",
+        "Stress test (msan)": "aa298abf10",
+        "Upgrade check (asan)": "5ce4d3ee02",
+    }
+    ci_cache = CiCache(job_digests=job_digest, cache_enabled=True, s3=S3Helper())
+    ci_cache.update()

--- a/tests/ci/ci_definitions.py
+++ b/tests/ci/ci_definitions.py
@@ -351,6 +351,8 @@ class JobConfig:
     run_by_label: str = ""
     # to run always regardless of the job digest or/and label
     run_always: bool = False
+    # disables CI await for a given job
+    disable_await: bool = False
     # if the job needs to be run on the release branch, including master (building packages, docker server).
     # NOTE: Subsequent runs on the same branch with the similar digest are still considered skip-able.
     required_on_release_branch: bool = False
@@ -395,6 +397,7 @@ class CommonJobConfigs:
             ],
         ),
         runner_type=Runners.STYLE_CHECKER_ARM,
+        disable_await=True,
     )
     COMPATIBILITY_TEST = JobConfig(
         job_name_keyword="compatibility",

--- a/tests/ci/merge_pr.py
+++ b/tests/ci/merge_pr.py
@@ -254,11 +254,14 @@ def main():
         statuses = get_commit_filtered_statuses(commit)
 
         has_failed_statuses = False
+        has_native_failed_status = False
         for status in statuses:
             print(f"Check status [{status.context}], [{status.state}]")
             if CI.is_required(status.context) and status.state != SUCCESS:
                 print(f"WARNING: Failed status [{status.context}], [{status.state}]")
                 has_failed_statuses = True
+                if status.context != CI.StatusNames.SYNC:
+                    has_native_failed_status = True
 
         if args.wf_status == SUCCESS or has_failed_statuses:
             # set Mergeable check if workflow is successful (green)
@@ -280,7 +283,7 @@ def main():
             print(
                 "Workflow failed but no failed statuses found (died runner?) - cannot set Mergeable Check status"
             )
-        if args.wf_status == SUCCESS and not has_failed_statuses:
+        if args.wf_status == SUCCESS and not has_native_failed_status:
             sys.exit(0)
         else:
             sys.exit(1)

--- a/tests/ci/test_ci_config.py
+++ b/tests/ci/test_ci_config.py
@@ -587,11 +587,11 @@ class TestCIConfig(unittest.TestCase):
         for job, job_config in ci_cache.jobs_to_do.items():
             if job in MOCK_AFFECTED_JOBS:
                 MOCK_REQUIRED_BUILDS += job_config.required_builds
-            elif job not in MOCK_AFFECTED_JOBS:
+            elif job not in MOCK_AFFECTED_JOBS and not job_config.disable_await:
                 ci_cache.jobs_to_wait[job] = job_config
 
         for job, job_config in ci_cache.jobs_to_do.items():
-            if job_config.reference_job_name:
+            if job_config.reference_job_name or job_config.disable_await:
                 # jobs with reference_job_name in config are not supposed to have records in the cache - continue
                 continue
             if job in MOCK_AFFECTED_JOBS:
@@ -624,11 +624,73 @@ class TestCIConfig(unittest.TestCase):
             + MOCK_AFFECTED_JOBS
             + MOCK_REQUIRED_BUILDS
         )
+        self.assertTrue(CI.JobNames.BUILD_CHECK not in ci_cache.jobs_to_wait, "We must never await on Builds Report")
         self.assertCountEqual(
             list(ci_cache.jobs_to_wait),
-            [
-                CI.JobNames.BUILD_CHECK,
-            ]
-            + MOCK_REQUIRED_BUILDS,
+            MOCK_REQUIRED_BUILDS,
+        )
+        self.assertCountEqual(list(ci_cache.jobs_to_do), expected_to_do)
+
+    def test_ci_py_filters_not_affected_jobs_in_prs_no_builds(self):
+        """
+        checks ci.py filters not affected jobs in PRs, no builds required
+        """
+        settings = CiSettings()
+        settings.no_ci_cache = True
+        pr_info = PRInfo(github_event=_TEST_EVENT_JSON)
+        pr_info.event_type = EventType.PULL_REQUEST
+        pr_info.number = 123
+        assert pr_info.is_pr
+        ci_cache = CIPY._configure_jobs(
+            S3Helper(), pr_info, settings, skip_jobs=False, dry_run=True
+        )
+        self.assertTrue(not ci_cache.jobs_to_skip, "Must be no jobs in skip list")
+        assert not ci_cache.jobs_to_wait
+        assert not ci_cache.jobs_to_skip
+
+        MOCK_AFFECTED_JOBS = [
+            CI.JobNames.DOCS_CHECK,
+        ]
+        MOCK_REQUIRED_BUILDS = []
+
+        # pretend there are pending jobs that we need to wait
+        for job, job_config in ci_cache.jobs_to_do.items():
+            if job in MOCK_AFFECTED_JOBS:
+                if job_config.required_builds:
+                    MOCK_REQUIRED_BUILDS += job_config.required_builds
+            elif job not in MOCK_AFFECTED_JOBS and not job_config.disable_await:
+                ci_cache.jobs_to_wait[job] = job_config
+
+        for job, job_config in ci_cache.jobs_to_do.items():
+            if job_config.reference_job_name or job_config.disable_await:
+                # jobs with reference_job_name in config are not supposed to have records in the cache - continue
+                continue
+            if job in MOCK_AFFECTED_JOBS:
+                continue
+            for batch in range(job_config.num_batches):
+                # add any record into cache
+                record = CiCache.Record(
+                    record_type=random.choice(
+                        [
+                            CiCache.RecordType.FAILED,
+                            CiCache.RecordType.PENDING,
+                            CiCache.RecordType.SUCCESSFUL,
+                        ]
+                    ),
+                    job_name=job,
+                    job_digest=ci_cache.job_digests[job],
+                    batch=batch,
+                    num_batches=job_config.num_batches,
+                    release_branch=True,
+                )
+                for record_t_, records_ in ci_cache.records.items():
+                    if record_t_.value == CiCache.RecordType.FAILED.value:
+                        records_[record.to_str_key()] = record
+
+        ci_cache.filter_out_not_affected_jobs()
+        expected_to_do = MOCK_AFFECTED_JOBS + MOCK_REQUIRED_BUILDS
+        self.assertCountEqual(
+            list(ci_cache.jobs_to_wait),
+            MOCK_REQUIRED_BUILDS,
         )
         self.assertCountEqual(list(ci_cache.jobs_to_do), expected_to_do)

--- a/tests/ci/test_ci_config.py
+++ b/tests/ci/test_ci_config.py
@@ -624,7 +624,10 @@ class TestCIConfig(unittest.TestCase):
             + MOCK_AFFECTED_JOBS
             + MOCK_REQUIRED_BUILDS
         )
-        self.assertTrue(CI.JobNames.BUILD_CHECK not in ci_cache.jobs_to_wait, "We must never await on Builds Report")
+        self.assertTrue(
+            CI.JobNames.BUILD_CHECK not in ci_cache.jobs_to_wait,
+            "We must never await on Builds Report",
+        )
         self.assertCountEqual(
             list(ci_cache.jobs_to_wait),
             MOCK_REQUIRED_BUILDS,

--- a/tests/ci/test_ci_config.py
+++ b/tests/ci/test_ci_config.py
@@ -652,7 +652,7 @@ class TestCIConfig(unittest.TestCase):
         assert not ci_cache.jobs_to_skip
 
         MOCK_AFFECTED_JOBS = [
-            CI.JobNames.DOCS_CHECK,
+            CI.JobNames.FAST_TEST,
         ]
         MOCK_REQUIRED_BUILDS = []
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

- Never await in CI on BuildReport - just redo (await can be longer)
- Remove BuildReport if no build jobs in workflow (for instance: Docs change)
- Do not fail CheckReadyForMerge job if the only non-green status is Cloud Sync

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
