### PR TITLE
Revert "Keep subscriptions for all enabled roles."

### DIFF
--- a/src/Access/EnabledRoles.h
+++ b/src/Access/EnabledRoles.h
@@ -44,10 +44,9 @@ private:
     friend class RoleCache;
     explicit EnabledRoles(const Params & params_);
 
-    const Params params;
-
-    /// Called by RoleCache to store `EnabledRolesInfo` in this `EnabledRoles` after the calculation is done.
     void setRolesInfo(const std::shared_ptr<const EnabledRolesInfo> & info_, scope_guard * notifications);
+
+    const Params params;
 
     std::shared_ptr<const EnabledRolesInfo> info;
     mutable std::mutex info_mutex;

--- a/src/Access/RoleCache.cpp
+++ b/src/Access/RoleCache.cpp
@@ -61,7 +61,6 @@ RoleCache::RoleCache(const AccessControl & access_control_, int expiration_time_
 {
 }
 
-
 RoleCache::~RoleCache() = default;
 
 
@@ -72,18 +71,18 @@ RoleCache::getEnabledRoles(const std::vector<UUID> & roles, const std::vector<UU
     EnabledRoles::Params params;
     params.current_roles.insert(roles.begin(), roles.end());
     params.current_roles_with_admin_option.insert(roles_with_admin_option.begin(), roles_with_admin_option.end());
-    auto it = enabled_roles_by_params.find(params);
-    if (it != enabled_roles_by_params.end())
+    auto it = enabled_roles.find(params);
+    if (it != enabled_roles.end())
     {
-        if (auto enabled_roles = it->second.enabled_roles.lock())
-            return enabled_roles;
-        enabled_roles_by_params.erase(it);
+        auto from_cache = it->second.lock();
+        if (from_cache)
+            return from_cache;
+        enabled_roles.erase(it);
     }
 
     auto res = std::shared_ptr<EnabledRoles>(new EnabledRoles(params));
-    SubscriptionsOnRoles subscriptions_on_roles;
-    collectEnabledRoles(*res, subscriptions_on_roles, nullptr);
-    enabled_roles_by_params.emplace(std::move(params), EnabledRolesWithSubscriptions{res, std::move(subscriptions_on_roles)});
+    collectEnabledRoles(*res, nullptr);
+    enabled_roles.emplace(std::move(params), res);
     return res;
 }
 
@@ -92,23 +91,21 @@ void RoleCache::collectEnabledRoles(scope_guard * notifications)
 {
     /// `mutex` is already locked.
 
-    for (auto i = enabled_roles_by_params.begin(), e = enabled_roles_by_params.end(); i != e;)
+    for (auto i = enabled_roles.begin(), e = enabled_roles.end(); i != e;)
     {
-        auto & item = i->second;
-        if (auto enabled_roles = item.enabled_roles.lock())
-        {
-            collectEnabledRoles(*enabled_roles, item.subscriptions_on_roles, notifications);
-            ++i;
-        }
+        auto elem = i->second.lock();
+        if (!elem)
+            i = enabled_roles.erase(i);
         else
         {
-            i = enabled_roles_by_params.erase(i);
+            collectEnabledRoles(*elem, notifications);
+            ++i;
         }
     }
 }
 
 
-void RoleCache::collectEnabledRoles(EnabledRoles & enabled_roles, SubscriptionsOnRoles & subscriptions_on_roles, scope_guard * notifications)
+void RoleCache::collectEnabledRoles(EnabledRoles & enabled, scope_guard * notifications)
 {
     /// `mutex` is already locked.
 
@@ -116,57 +113,43 @@ void RoleCache::collectEnabledRoles(EnabledRoles & enabled_roles, SubscriptionsO
     auto new_info = std::make_shared<EnabledRolesInfo>();
     boost::container::flat_set<UUID> skip_ids;
 
-    /// We need to collect and keep not only enabled roles but also subscriptions for them to be able to recalculate EnabledRolesInfo when some of the roles change.
-    SubscriptionsOnRoles new_subscriptions_on_roles;
-    new_subscriptions_on_roles.reserve(subscriptions_on_roles.size());
+    auto get_role_function = [this](const UUID & id) { return getRole(id); };
 
-    auto get_role_function = [this, &subscriptions_on_roles](const UUID & id) TSA_NO_THREAD_SAFETY_ANALYSIS { return getRole(id, subscriptions_on_roles); };
-
-    for (const auto & current_role : enabled_roles.params.current_roles)
+    for (const auto & current_role : enabled.params.current_roles)
         collectRoles(*new_info, skip_ids, get_role_function, current_role, true, false);
 
-    for (const auto & current_role : enabled_roles.params.current_roles_with_admin_option)
+    for (const auto & current_role : enabled.params.current_roles_with_admin_option)
         collectRoles(*new_info, skip_ids, get_role_function, current_role, true, true);
 
-    /// Remove duplicates from `subscriptions_on_roles`.
-    std::sort(new_subscriptions_on_roles.begin(), new_subscriptions_on_roles.end());
-    new_subscriptions_on_roles.erase(std::unique(new_subscriptions_on_roles.begin(), new_subscriptions_on_roles.end()), new_subscriptions_on_roles.end());
-    subscriptions_on_roles = std::move(new_subscriptions_on_roles);
-
     /// Collect data from the collected roles.
-    enabled_roles.setRolesInfo(new_info, notifications);
+    enabled.setRolesInfo(new_info, notifications);
 }
 
 
-RolePtr RoleCache::getRole(const UUID & role_id, SubscriptionsOnRoles & subscriptions_on_roles)
+RolePtr RoleCache::getRole(const UUID & role_id)
 {
     /// `mutex` is already locked.
 
     auto role_from_cache = cache.get(role_id);
     if (role_from_cache)
-    {
-        subscriptions_on_roles.emplace_back(role_from_cache->second);
         return role_from_cache->first;
-    }
 
-    auto on_role_changed_or_removed = [this, role_id](const UUID &, const AccessEntityPtr & entity)
+    auto subscription = access_control.subscribeForChanges(role_id,
+                                                    [this, role_id](const UUID &, const AccessEntityPtr & entity)
     {
         auto changed_role = entity ? typeid_cast<RolePtr>(entity) : nullptr;
         if (changed_role)
             roleChanged(role_id, changed_role);
         else
             roleRemoved(role_id);
-    };
-
-    auto subscription_on_role = std::make_shared<scope_guard>(access_control.subscribeForChanges(role_id, on_role_changed_or_removed));
+    });
 
     auto role = access_control.tryRead<Role>(role_id);
     if (role)
     {
-        auto cache_value = Poco::SharedPtr<std::pair<RolePtr, std::shared_ptr<scope_guard>>>(
-            new std::pair<RolePtr, std::shared_ptr<scope_guard>>{role, subscription_on_role});
+        auto cache_value = Poco::SharedPtr<std::pair<RolePtr, scope_guard>>(
+            new std::pair<RolePtr, scope_guard>{role, std::move(subscription)});
         cache.add(role_id, cache_value);
-        subscriptions_on_roles.emplace_back(subscription_on_role);
         return role;
     }
 
@@ -180,7 +163,6 @@ void RoleCache::roleChanged(const UUID & role_id, const RolePtr & changed_role)
     scope_guard notifications;
 
     std::lock_guard lock{mutex};
-
     auto role_from_cache = cache.get(role_id);
     if (role_from_cache)
     {

--- a/src/Access/RoleCache.h
+++ b/src/Access/RoleCache.h
@@ -24,29 +24,15 @@ public:
         const std::vector<UUID> & current_roles_with_admin_option);
 
 private:
-    using SubscriptionsOnRoles = std::vector<std::shared_ptr<scope_guard>>;
-
-    void collectEnabledRoles(scope_guard * notifications) TSA_REQUIRES(mutex);
-    void collectEnabledRoles(EnabledRoles & enabled_roles, SubscriptionsOnRoles & subscriptions_on_roles, scope_guard * notifications) TSA_REQUIRES(mutex);
-    RolePtr getRole(const UUID & role_id, SubscriptionsOnRoles & subscriptions_on_roles) TSA_REQUIRES(mutex);
+    void collectEnabledRoles(scope_guard * notifications);
+    void collectEnabledRoles(EnabledRoles & enabled, scope_guard * notifications);
+    RolePtr getRole(const UUID & role_id);
     void roleChanged(const UUID & role_id, const RolePtr & changed_role);
     void roleRemoved(const UUID & role_id);
 
     const AccessControl & access_control;
-
-    Poco::AccessExpireCache<UUID, std::pair<RolePtr, std::shared_ptr<scope_guard>>> TSA_GUARDED_BY(mutex) cache;
-
-    struct EnabledRolesWithSubscriptions
-    {
-        std::weak_ptr<EnabledRoles> enabled_roles;
-
-        /// We need to keep subscriptions for all enabled roles to be able to recalculate EnabledRolesInfo when some of the roles change.
-        /// `cache` also keeps subscriptions but that's not enough because values can be purged from the `cache` anytime.
-        SubscriptionsOnRoles subscriptions_on_roles;
-    };
-
-    std::map<EnabledRoles::Params, EnabledRolesWithSubscriptions> TSA_GUARDED_BY(mutex) enabled_roles_by_params;
-
+    Poco::AccessExpireCache<UUID, std::pair<RolePtr, scope_guard>> cache;
+    std::map<EnabledRoles::Params, std::weak_ptr<EnabledRoles>> enabled_roles;
     mutable std::mutex mutex;
 };
 


### PR DESCRIPTION
This reverts commit 31b7e6edc64689d1d682506530a426c8f06ae1b6.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Reasons:

1. The code contains an error and does not work 
1.1.  new_subscriptions_on_roles are intact here https://github.com/ClickHouse/ClickHouse/blob/5611ef0d387e7c18a76dbcb1d1619d19ac60b501/src/Access/RoleCache.cpp#L121-L134
1. The code is not needed
2.1. The original motivation  https://github.com/ClickHouse/ClickHouse/pull/46772#discussion_r1116832141 _Because if a role expires from the cache not only it got deleted from the cache but the subscription got deleted too. And that's bad because some EnabledRoles might still depend on that role. Apparently we need to store subscriptions in EnabledRoles and not in this role cache_ is probably wrong, `collectEnabledRoles` that is called in context of `roleChanged` / `roleRemoved` provides this guarantee .

Another reason for this PR is we definitely have issues with roles, it is common knowledge that roles should be avoided, e.g. https://t.me/clickhouse_ru/383357?thread=383348
Would be exceedingly splendid to sort these issues out.

attn @vitlibar 