### PR TITLE
Functions `[a-g]*`: Iterate over `input_rows_count` where appropriate

### DIFF
--- a/src/Functions/acosh.cpp
+++ b/src/Functions/acosh.cpp
@@ -5,11 +5,12 @@ namespace DB
 {
 namespace
 {
-    struct AcoshName
-    {
-        static constexpr auto name = "acosh";
-    };
-    using FunctionAcosh = FunctionMathUnary<UnaryFunctionVectorized<AcoshName, acosh>>;
+
+struct AcoshName
+{
+    static constexpr auto name = "acosh";
+};
+using FunctionAcosh = FunctionMathUnary<UnaryFunctionVectorized<AcoshName, acosh>>;
 
 }
 

--- a/src/Functions/addMicroseconds.cpp
+++ b/src/Functions/addMicroseconds.cpp
@@ -6,6 +6,7 @@ namespace DB
 {
 
 using FunctionAddMicroseconds = FunctionDateOrDateTimeAddInterval<AddMicrosecondsImpl>;
+
 REGISTER_FUNCTION(AddMicroseconds)
 {
     factory.registerFunction<FunctionAddMicroseconds>();

--- a/src/Functions/addMilliseconds.cpp
+++ b/src/Functions/addMilliseconds.cpp
@@ -6,6 +6,7 @@ namespace DB
 {
 
 using FunctionAddMilliseconds = FunctionDateOrDateTimeAddInterval<AddMillisecondsImpl>;
+
 REGISTER_FUNCTION(AddMilliseconds)
 {
     factory.registerFunction<FunctionAddMilliseconds>();

--- a/src/Functions/addNanoseconds.cpp
+++ b/src/Functions/addNanoseconds.cpp
@@ -6,6 +6,7 @@ namespace DB
 {
 
 using FunctionAddNanoseconds = FunctionDateOrDateTimeAddInterval<AddNanosecondsImpl>;
+
 REGISTER_FUNCTION(AddNanoseconds)
 {
     factory.registerFunction<FunctionAddNanoseconds>();

--- a/src/Functions/aes_encrypt_mysql.cpp
+++ b/src/Functions/aes_encrypt_mysql.cpp
@@ -7,7 +7,6 @@
 
 namespace DB
 {
-
 namespace
 {
 

--- a/src/Functions/appendTrailingCharIfAbsent.cpp
+++ b/src/Functions/appendTrailingCharIfAbsent.cpp
@@ -57,7 +57,7 @@ private:
     bool useDefaultImplementationForConstants() const override { return true; }
     ColumnNumbers getArgumentsThatAreAlwaysConstant() const override { return {1}; }
 
-    ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr &, size_t /*input_rows_count*/) const override
+    ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr &, size_t input_rows_count) const override
     {
         const auto & column = arguments[0].column;
         const auto & column_char = arguments[1].column;
@@ -80,14 +80,13 @@ private:
             auto & dst_data = col_res->getChars();
             auto & dst_offsets = col_res->getOffsets();
 
-            const auto size = src_offsets.size();
-            dst_data.resize(src_data.size() + size);
-            dst_offsets.resize(size);
+            dst_data.resize(src_data.size() + input_rows_count);
+            dst_offsets.resize(input_rows_count);
 
             ColumnString::Offset src_offset{};
             ColumnString::Offset dst_offset{};
 
-            for (const auto i : collections::range(0, size))
+            for (size_t i = 0; i < input_rows_count; ++i)
             {
                 const auto src_length = src_offsets[i] - src_offset;
                 memcpySmallAllowReadWriteOverflow15(&dst_data[dst_offset], &src_data[src_offset], src_length);

--- a/src/Functions/ascii.cpp
+++ b/src/Functions/ascii.cpp
@@ -45,9 +45,7 @@ struct AsciiImpl
         size_t size = data.size() / n;
 
         for (size_t i = 0; i < size; ++i)
-        {
             res[i] = doAscii(data, i * n, n);
-        }
     }
 
     [[noreturn]] static void array(const ColumnString::Offsets & /*offsets*/, PaddedPODArray<ReturnType> & /*res*/)

--- a/src/Functions/asinh.cpp
+++ b/src/Functions/asinh.cpp
@@ -5,11 +5,12 @@ namespace DB
 {
 namespace
 {
-    struct AsinhName
-    {
-        static constexpr auto name = "asinh";
-    };
-    using FunctionAsinh = FunctionMathUnary<UnaryFunctionVectorized<AsinhName, asinh>>;
+
+struct AsinhName
+{
+    static constexpr auto name = "asinh";
+};
+using FunctionAsinh = FunctionMathUnary<UnaryFunctionVectorized<AsinhName, asinh>>;
 
 }
 

--- a/src/Functions/atan2.cpp
+++ b/src/Functions/atan2.cpp
@@ -5,11 +5,12 @@ namespace DB
 {
 namespace
 {
-    struct Atan2Name
-    {
-        static constexpr auto name = "atan2";
-    };
-    using FunctionAtan2 = FunctionMathBinaryFloat64<BinaryFunctionVectorized<Atan2Name, atan2>>;
+
+struct Atan2Name
+{
+    static constexpr auto name = "atan2";
+};
+using FunctionAtan2 = FunctionMathBinaryFloat64<BinaryFunctionVectorized<Atan2Name, atan2>>;
 
 }
 

--- a/src/Functions/atanh.cpp
+++ b/src/Functions/atanh.cpp
@@ -5,11 +5,12 @@ namespace DB
 {
 namespace
 {
-    struct AtanhName
-    {
-        static constexpr auto name = "atanh";
-    };
-    using FunctionAtanh = FunctionMathUnary<UnaryFunctionVectorized<AtanhName, atanh>>;
+
+struct AtanhName
+{
+    static constexpr auto name = "atanh";
+};
+using FunctionAtanh = FunctionMathUnary<UnaryFunctionVectorized<AtanhName, atanh>>;
 
 }
 

--- a/src/Functions/base58Encode.cpp
+++ b/src/Functions/base58Encode.cpp
@@ -3,8 +3,10 @@
 
 namespace DB
 {
+
 REGISTER_FUNCTION(Base58Encode)
 {
     factory.registerFunction<FunctionBase58Conversion<Base58Encode>>();
 }
+
 }

--- a/src/Functions/base64Decode.cpp
+++ b/src/Functions/base64Decode.cpp
@@ -5,6 +5,7 @@
 
 namespace DB
 {
+
 REGISTER_FUNCTION(Base64Decode)
 {
     FunctionDocumentation::Description description = R"(Accepts a String and decodes it from base64, according to RFC 4648 (https://datatracker.ietf.org/doc/html/rfc4648#section-4). Throws an exception in case of an error. Alias: FROM_BASE64.)";
@@ -19,6 +20,7 @@ REGISTER_FUNCTION(Base64Decode)
     /// MySQL compatibility alias.
     factory.registerAlias("FROM_BASE64", "base64Decode", FunctionFactory::Case::Insensitive);
 }
+
 }
 
 #endif

--- a/src/Functions/base64Encode.cpp
+++ b/src/Functions/base64Encode.cpp
@@ -5,6 +5,7 @@
 
 namespace DB
 {
+
 REGISTER_FUNCTION(Base64Encode)
 {
     FunctionDocumentation::Description description = R"(Encodes a String as base64, according to RFC 4648 (https://datatracker.ietf.org/doc/html/rfc4648#section-4). Alias: TO_BASE64.)";
@@ -19,6 +20,7 @@ REGISTER_FUNCTION(Base64Encode)
     /// MySQL compatibility alias.
     factory.registerAlias("TO_BASE64", "base64Encode", FunctionFactory::Case::Insensitive);
 }
+
 }
 
 #endif

--- a/src/Functions/base64URLDecode.cpp
+++ b/src/Functions/base64URLDecode.cpp
@@ -5,6 +5,7 @@
 
 namespace DB
 {
+
 REGISTER_FUNCTION(Base64URLDecode)
 {
     FunctionDocumentation::Description description = R"(Accepts a base64-encoded URL and decodes it from base64 with URL-specific modifications, according to RFC 4648 (https://datatracker.ietf.org/doc/html/rfc4648#section-5).)";
@@ -16,6 +17,7 @@ REGISTER_FUNCTION(Base64URLDecode)
 
     factory.registerFunction<FunctionBase64Conversion<Base64Decode<Base64Variant::URL>>>({description, syntax, arguments, returned_value, examples, categories});
 }
+
 }
 
 #endif

--- a/src/Functions/base64URLEncode.cpp
+++ b/src/Functions/base64URLEncode.cpp
@@ -5,6 +5,7 @@
 
 namespace DB
 {
+
 REGISTER_FUNCTION(Base64URLEncode)
 {
     FunctionDocumentation::Description description = R"(Encodes an URL (String or FixedString) as base64 with URL-specific modifications, according to RFC 4648 (https://datatracker.ietf.org/doc/html/rfc4648#section-5).)";
@@ -16,6 +17,7 @@ REGISTER_FUNCTION(Base64URLEncode)
 
     factory.registerFunction<FunctionBase64Conversion<Base64Encode<Base64Variant::URL>>>({description, syntax, arguments, returned_value, examples, categories});
 }
+
 }
 
 #endif

--- a/src/Functions/byteSize.cpp
+++ b/src/Functions/byteSize.cpp
@@ -67,11 +67,11 @@ public:
             const IColumn * column = arguments[arg_num].column.get();
 
             if (arg_num == 0)
-                for (size_t row_num = 0; row_num < input_rows_count; ++row_num)
-                    vec_res[row_num] = column->byteSizeAt(row_num);
+                for (size_t row = 0; row < input_rows_count; ++row)
+                    vec_res[row] = column->byteSizeAt(row);
             else
-                for (size_t row_num = 0; row_num < input_rows_count; ++row_num)
-                    vec_res[row_num] += column->byteSizeAt(row_num);
+                for (size_t row = 0; row < input_rows_count; ++row)
+                    vec_res[row] += column->byteSizeAt(row);
         }
 
         return result_col;

--- a/src/Functions/byteSwap.cpp
+++ b/src/Functions/byteSwap.cpp
@@ -10,6 +10,7 @@ extern const int NOT_IMPLEMENTED;
 
 namespace
 {
+
 template <typename T>
 requires std::is_integral_v<T>
 T byteSwap(T x)

--- a/src/Functions/caseWithExpression.cpp
+++ b/src/Functions/caseWithExpression.cpp
@@ -98,8 +98,7 @@ public:
 
         /// Execute transform.
         ColumnsWithTypeAndName transform_args{args.front(), src_array_col, dst_array_col, args.back()};
-        return FunctionFactory::instance().get("transform", context)->build(transform_args)
-            ->execute(transform_args, result_type, input_rows_count);
+        return FunctionFactory::instance().get("transform", context)->build(transform_args)->execute(transform_args, result_type, input_rows_count);
     }
 
 private:

--- a/src/Functions/convertCharset.cpp
+++ b/src/Functions/convertCharset.cpp
@@ -88,7 +88,8 @@ private:
 
     static void convert(const String & from_charset, const String & to_charset,
         const ColumnString::Chars & from_chars, const ColumnString::Offsets & from_offsets,
-        ColumnString::Chars & to_chars, ColumnString::Offsets & to_offsets)
+        ColumnString::Chars & to_chars, ColumnString::Offsets & to_offsets,
+        size_t input_rows_count)
     {
         auto converter_from = getConverter(from_charset);
         auto converter_to = getConverter(to_charset);
@@ -96,12 +97,11 @@ private:
         ColumnString::Offset current_from_offset = 0;
         ColumnString::Offset current_to_offset = 0;
 
-        size_t size = from_offsets.size();
-        to_offsets.resize(size);
+        to_offsets.resize(input_rows_count);
 
         PODArray<UChar> uchars;
 
-        for (size_t i = 0; i < size; ++i)
+        for (size_t i = 0; i < input_rows_count; ++i)
         {
             size_t from_string_size = from_offsets[i] - current_from_offset - 1;
 
@@ -184,7 +184,7 @@ public:
     bool useDefaultImplementationForConstants() const override { return true; }
     ColumnNumbers getArgumentsThatAreAlwaysConstant() const override { return {1, 2}; }
 
-    ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr &, size_t /*input_rows_count*/) const override
+    ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr &, size_t input_rows_count) const override
     {
         const ColumnWithTypeAndName & arg_from = arguments[0];
         const ColumnWithTypeAndName & arg_charset_from = arguments[1];
@@ -204,7 +204,7 @@ public:
         if (const ColumnString * col_from = checkAndGetColumn<ColumnString>(arg_from.column.get()))
         {
             auto col_to = ColumnString::create();
-            convert(charset_from, charset_to, col_from->getChars(), col_from->getOffsets(), col_to->getChars(), col_to->getOffsets());
+            convert(charset_from, charset_to, col_from->getChars(), col_from->getOffsets(), col_to->getChars(), col_to->getOffsets(), input_rows_count);
             return col_to;
         }
         else

--- a/src/Functions/cosh.cpp
+++ b/src/Functions/cosh.cpp
@@ -5,11 +5,12 @@ namespace DB
 {
 namespace
 {
-    struct CoshName
-    {
-        static constexpr auto name = "cosh";
-    };
-    using FunctionCosh = FunctionMathUnary<UnaryFunctionVectorized<CoshName, cosh>>;
+
+struct CoshName
+{
+    static constexpr auto name = "cosh";
+};
+using FunctionCosh = FunctionMathUnary<UnaryFunctionVectorized<CoshName, cosh>>;
 
 }
 

--- a/src/Functions/countSubstringsCaseInsensitiveUTF8.cpp
+++ b/src/Functions/countSubstringsCaseInsensitiveUTF8.cpp
@@ -13,8 +13,7 @@ struct NameCountSubstringsCaseInsensitiveUTF8
     static constexpr auto name = "countSubstringsCaseInsensitiveUTF8";
 };
 
-using FunctionCountSubstringsCaseInsensitiveUTF8 = FunctionsStringSearch<
-        CountSubstringsImpl<NameCountSubstringsCaseInsensitiveUTF8, PositionCaseInsensitiveUTF8>>;
+using FunctionCountSubstringsCaseInsensitiveUTF8 = FunctionsStringSearch<CountSubstringsImpl<NameCountSubstringsCaseInsensitiveUTF8, PositionCaseInsensitiveUTF8>>;
 
 }
 

--- a/src/Functions/dateName.cpp
+++ b/src/Functions/dateName.cpp
@@ -109,14 +109,14 @@ public:
     ColumnPtr executeImpl(
         const ColumnsWithTypeAndName & arguments,
         const DataTypePtr & result_type,
-        [[maybe_unused]] size_t input_rows_count) const override
+        size_t input_rows_count) const override
     {
         ColumnPtr res;
 
-        if (!((res = executeType<DataTypeDate>(arguments, result_type))
-            || (res = executeType<DataTypeDate32>(arguments, result_type))
-            || (res = executeType<DataTypeDateTime>(arguments, result_type))
-            || (res = executeType<DataTypeDateTime64>(arguments, result_type))))
+        if (!((res = executeType<DataTypeDate>(arguments, result_type, input_rows_count))
+            || (res = executeType<DataTypeDate32>(arguments, result_type, input_rows_count))
+            || (res = executeType<DataTypeDateTime>(arguments, result_type, input_rows_count))
+            || (res = executeType<DataTypeDateTime64>(arguments, result_type, input_rows_count))))
             throw Exception(
                 ErrorCodes::ILLEGAL_COLUMN,
                 "Illegal column {} of function {}, must be Date or DateTime.",
@@ -127,7 +127,7 @@ public:
     }
 
     template <typename DataType>
-    ColumnPtr executeType(const ColumnsWithTypeAndName & arguments, const DataTypePtr &) const
+    ColumnPtr executeType(const ColumnsWithTypeAndName & arguments, const DataTypePtr &, size_t input_rows_count) const
     {
         auto * times = checkAndGetColumn<typename DataType::ColumnType>(arguments[1].column.get());
         if (!times)
@@ -144,7 +144,7 @@ public:
         String date_part = date_part_column->getValue<String>();
 
         const DateLUTImpl * time_zone_tmp;
-        if (std::is_same_v<DataType, DataTypeDateTime64> || std::is_same_v<DataType, DataTypeDateTime>)
+        if constexpr (std::is_same_v<DataType, DataTypeDateTime64> || std::is_same_v<DataType, DataTypeDateTime>)
             time_zone_tmp = &extractTimeZoneFromFunctionArguments(arguments, 2, 1);
         else
             time_zone_tmp = &DateLUT::instance();
@@ -175,7 +175,7 @@ public:
         using TimeType = DateTypeToTimeType<DataType>;
         callOnDatePartWriter<TimeType>(date_part, [&](const auto & writer)
         {
-            for (size_t i = 0; i < times_data.size(); ++i)
+            for (size_t i = 0; i < input_rows_count; ++i)
             {
                 if constexpr (std::is_same_v<DataType, DataTypeDateTime64>)
                 {

--- a/src/Functions/degrees.cpp
+++ b/src/Functions/degrees.cpp
@@ -7,18 +7,20 @@ namespace DB
 {
 namespace
 {
-    struct DegreesName
-    {
-        static constexpr auto name = "degrees";
-    };
 
-    Float64 degrees(Float64 r)
-    {
-        Float64 degrees = r * (180 / M_PI);
-        return degrees;
-    }
+struct DegreesName
+{
+    static constexpr auto name = "degrees";
+};
 
-    using FunctionDegrees = FunctionMathUnary<UnaryFunctionVectorized<DegreesName, degrees>>;
+Float64 degrees(Float64 r)
+{
+    Float64 degrees = r * (180 / M_PI);
+    return degrees;
+}
+
+using FunctionDegrees = FunctionMathUnary<UnaryFunctionVectorized<DegreesName, degrees>>;
+
 }
 
 REGISTER_FUNCTION(Degrees)

--- a/src/Functions/filesystem.cpp
+++ b/src/Functions/filesystem.cpp
@@ -91,7 +91,7 @@ public:
 
                 auto col_res = ColumnVector<UInt64>::create(col_str->size());
                 auto & data = col_res->getData();
-                for (size_t i = 0; i < col_str->size(); ++i)
+                for (size_t i = 0; i < input_rows_count; ++i)
                 {
                     auto disk_name = col_str->getDataAt(i).toString();
                     if (auto it = disk_map.find(disk_name); it != disk_map.end())

--- a/src/Functions/formatDateTime.cpp
+++ b/src/Functions/formatDateTime.cpp
@@ -848,7 +848,7 @@ public:
         return std::make_shared<DataTypeString>();
     }
 
-    ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type, [[maybe_unused]] size_t input_rows_count) const override
+    ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type, size_t input_rows_count) const override
     {
         ColumnPtr res;
         if constexpr (support_integer == SupportInteger::Yes)
@@ -862,17 +862,17 @@ public:
                 if (!castType(arguments[0].type.get(), [&](const auto & type)
                     {
                         using FromDataType = std::decay_t<decltype(type)>;
-                        if (!(res = executeType<FromDataType>(arguments, result_type)))
+                        if (!(res = executeType<FromDataType>(arguments, result_type, input_rows_count)))
                             throw Exception(ErrorCodes::ILLEGAL_COLUMN,
                                 "Illegal column {} of function {}, must be Integer, Date, Date32, DateTime or DateTime64.",
                                 arguments[0].column->getName(), getName());
                         return true;
                     }))
                 {
-                    if (!((res = executeType<DataTypeDate>(arguments, result_type))
-                        || (res = executeType<DataTypeDate32>(arguments, result_type))
-                        || (res = executeType<DataTypeDateTime>(arguments, result_type))
-                        || (res = executeType<DataTypeDateTime64>(arguments, result_type))))
+                    if (!((res = executeType<DataTypeDate>(arguments, result_type, input_rows_count))
+                        || (res = executeType<DataTypeDate32>(arguments, result_type, input_rows_count))
+                        || (res = executeType<DataTypeDateTime>(arguments, result_type, input_rows_count))
+                        || (res = executeType<DataTypeDateTime64>(arguments, result_type, input_rows_count))))
                         throw Exception(ErrorCodes::ILLEGAL_COLUMN,
                             "Illegal column {} of function {}, must be Integer or DateTime.",
                             arguments[0].column->getName(), getName());
@@ -881,10 +881,10 @@ public:
         }
         else
         {
-            if (!((res = executeType<DataTypeDate>(arguments, result_type))
-                || (res = executeType<DataTypeDate32>(arguments, result_type))
-                || (res = executeType<DataTypeDateTime>(arguments, result_type))
-                || (res = executeType<DataTypeDateTime64>(arguments, result_type))))
+            if (!((res = executeType<DataTypeDate>(arguments, result_type, input_rows_count))
+                || (res = executeType<DataTypeDate32>(arguments, result_type, input_rows_count))
+                || (res = executeType<DataTypeDateTime>(arguments, result_type, input_rows_count))
+                || (res = executeType<DataTypeDateTime64>(arguments, result_type, input_rows_count))))
                 throw Exception(ErrorCodes::ILLEGAL_COLUMN,
                     "Illegal column {} of function {}, must be Date or DateTime.",
                     arguments[0].column->getName(), getName());
@@ -894,7 +894,7 @@ public:
     }
 
     template <typename DataType>
-    ColumnPtr executeType(const ColumnsWithTypeAndName & arguments, const DataTypePtr &) const
+    ColumnPtr executeType(const ColumnsWithTypeAndName & arguments, const DataTypePtr &, size_t input_rows_count) const
     {
         auto non_const_datetime = arguments[0].column->convertToFullColumnIfConst();
         auto * times = checkAndGetColumn<typename DataType::ColumnType>(non_const_datetime.get());
@@ -955,13 +955,11 @@ public:
         else
             time_zone = &DateLUT::instance();
 
-        const auto & vec = times->getData();
-
         auto col_res = ColumnString::create();
         auto & res_data = col_res->getChars();
         auto & res_offsets = col_res->getOffsets();
-        res_data.resize(vec.size() * (out_template_size + 1));
-        res_offsets.resize(vec.size());
+        res_data.resize(input_rows_count * (out_template_size + 1));
+        res_offsets.resize(input_rows_count);
 
         if constexpr (format_syntax == FormatSyntax::MySQL)
         {
@@ -990,9 +988,11 @@ public:
             }
         }
 
+        const auto & vec = times->getData();
+
         auto * begin = reinterpret_cast<char *>(res_data.data());
         auto * pos = begin;
-        for (size_t i = 0; i < vec.size(); ++i)
+        for (size_t i = 0; i < input_rows_count; ++i)
         {
             if (!const_time_zone_column && arguments.size() > 2)
             {

--- a/src/Functions/formatQuery.cpp
+++ b/src/Functions/formatQuery.cpp
@@ -75,7 +75,7 @@ public:
         if (const ColumnString * col_query_string = checkAndGetColumn<ColumnString>(col_query.get()))
         {
             auto col_res = ColumnString::create();
-            formatVector(col_query_string->getChars(), col_query_string->getOffsets(), col_res->getChars(), col_res->getOffsets(), col_null_map);
+            formatVector(col_query_string->getChars(), col_query_string->getOffsets(), col_res->getChars(), col_res->getOffsets(), col_null_map, input_rows_count);
 
             if (error_handling == ErrorHandling::Null)
                 return ColumnNullable::create(std::move(col_res), std::move(col_null_map));
@@ -92,16 +92,16 @@ private:
         const ColumnString::Offsets & offsets,
         ColumnString::Chars & res_data,
         ColumnString::Offsets & res_offsets,
-        ColumnUInt8::MutablePtr & res_null_map) const
+        ColumnUInt8::MutablePtr & res_null_map,
+        size_t input_rows_count) const
     {
-        const size_t size = offsets.size();
-        res_offsets.resize(size);
+        res_offsets.resize(input_rows_count);
         res_data.resize(data.size());
 
         size_t prev_offset = 0;
         size_t res_data_size = 0;
 
-        for (size_t i = 0; i < size; ++i)
+        for (size_t i = 0; i < input_rows_count; ++i)
         {
             const char * begin = reinterpret_cast<const char *>(&data[prev_offset]);
             const char * end = begin + offsets[i] - prev_offset - 1;

--- a/src/Functions/formatReadable.h
+++ b/src/Functions/formatReadable.h
@@ -55,19 +55,19 @@ public:
 
     bool useDefaultImplementationForConstants() const override { return true; }
 
-    ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr &, size_t /*input_rows_count*/) const override
+    ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr &, size_t input_rows_count) const override
     {
         ColumnPtr res;
-        if (!((res = executeType<UInt8>(arguments))
-            || (res = executeType<UInt16>(arguments))
-            || (res = executeType<UInt32>(arguments))
-            || (res = executeType<UInt64>(arguments))
-            || (res = executeType<Int8>(arguments))
-            || (res = executeType<Int16>(arguments))
-            || (res = executeType<Int32>(arguments))
-            || (res = executeType<Int64>(arguments))
-            || (res = executeType<Float32>(arguments))
-            || (res = executeType<Float64>(arguments))))
+        if (!((res = executeType<UInt8>(arguments, input_rows_count))
+            || (res = executeType<UInt16>(arguments, input_rows_count))
+            || (res = executeType<UInt32>(arguments, input_rows_count))
+            || (res = executeType<UInt64>(arguments, input_rows_count))
+            || (res = executeType<Int8>(arguments, input_rows_count))
+            || (res = executeType<Int16>(arguments, input_rows_count))
+            || (res = executeType<Int32>(arguments, input_rows_count))
+            || (res = executeType<Int64>(arguments, input_rows_count))
+            || (res = executeType<Float32>(arguments, input_rows_count))
+            || (res = executeType<Float64>(arguments, input_rows_count))))
             throw Exception(ErrorCodes::ILLEGAL_COLUMN, "Illegal column {} of argument of function {}",
                             arguments[0].column->getName(), getName());
 
@@ -76,7 +76,7 @@ public:
 
 private:
     template <typename T>
-    ColumnPtr executeType(const ColumnsWithTypeAndName & arguments) const
+    ColumnPtr executeType(const ColumnsWithTypeAndName & arguments, size_t input_rows_count) const
     {
         if (const ColumnVector<T> * col_from = checkAndGetColumn<ColumnVector<T>>(arguments[0].column.get()))
         {
@@ -85,13 +85,12 @@ private:
             const typename ColumnVector<T>::Container & vec_from = col_from->getData();
             ColumnString::Chars & data_to = col_to->getChars();
             ColumnString::Offsets & offsets_to = col_to->getOffsets();
-            size_t size = vec_from.size();
-            data_to.resize(size * 2);
-            offsets_to.resize(size);
+            data_to.resize(input_rows_count * 2);
+            offsets_to.resize(input_rows_count);
 
             WriteBufferFromVector<ColumnString::Chars> buf_to(data_to);
 
-            for (size_t i = 0; i < size; ++i)
+            for (size_t i = 0; i < input_rows_count; ++i)
             {
                 Impl::format(static_cast<double>(vec_from[i]), buf_to);
                 writeChar(0, buf_to);

--- a/src/Functions/transform.cpp
+++ b/src/Functions/transform.cpp
@@ -138,8 +138,7 @@ namespace
             }
         }
 
-        ColumnPtr executeImpl(
-            const ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type, size_t input_rows_count) const override
+        ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type, size_t input_rows_count) const override
         {
             std::call_once(once, [&] { initialize(arguments, result_type); });
 


### PR DESCRIPTION
Some functions (especially older ones) iterate over the size of one of their input arguments. It is more correct to iterate over `input_rows_count`. This PR corrects this for functions `[a-g]*`. I'll try to fix the remaining ones separately.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)