### PR TITLE
WIP: added an option to save `*.stdout` and `*.stderr` files with test res…

### DIFF
--- a/docker/test/stateless/run.sh
+++ b/docker/test/stateless/run.sh
@@ -411,9 +411,6 @@ collect_core_dumps
 
 if [[ "$SAVE_INDIVIDUAL_TEST_OUTPUT" -eq 1 ]]; then
     mkdir /test_output/stdout ||:
-    for i in $(find . -type f -name "*.stdout*" -o -name "*.stderr*")
-    do
-        mv "$i" "/test_output/stdout/$i" ||:
-    done
+    find . -type f -name "*.stdout*" -o -name "*.stderr*" -exec mv {} "/test_output/stdout/"
     tar -chf /test_output/stdout.tar /test_output/stdout ||:
 fi

--- a/docker/test/stateless/run.sh
+++ b/docker/test/stateless/run.sh
@@ -11,6 +11,7 @@ MAX_RUN_TIME=$((MAX_RUN_TIME == 0 ? 9000 : MAX_RUN_TIME))
 
 USE_DATABASE_REPLICATED=${USE_DATABASE_REPLICATED:=0}
 USE_SHARED_CATALOG=${USE_SHARED_CATALOG:=0}
+SAVE_INDIVIDUAL_TEST_OUTPUT=${SAVE_INDIVIDUAL_TEST_OUTPUT:=1}
 
 # Choose random timezone for this test run.
 #
@@ -407,3 +408,12 @@ if [[ "$USE_SHARED_CATALOG" -eq 1 ]]; then
 fi
 
 collect_core_dumps
+
+if [[ "$SAVE_INDIVIDUAL_TEST_OUTPUT" -eq 1 ]]; then
+    mkdir /test_output/stdout ||:
+    for i in 'find . -type f -name "*.stdout*" -o -name "*.stderr*"'
+    do
+        mv $i /test_output/stdout/$i ||:
+    done
+    tar -chf /test_output/stdout.tar /test_output/stdout ||:
+fi

--- a/docker/test/stateless/run.sh
+++ b/docker/test/stateless/run.sh
@@ -411,9 +411,9 @@ collect_core_dumps
 
 if [[ "$SAVE_INDIVIDUAL_TEST_OUTPUT" -eq 1 ]]; then
     mkdir /test_output/stdout ||:
-    for i in 'find . -type f -name "*.stdout*" -o -name "*.stderr*"'
+    for i in $(find . -type f -name "*.stdout*" -o -name "*.stderr*")
     do
-        mv $i /test_output/stdout/$i ||:
+        mv "$i" "/test_output/stdout/$i" ||:
     done
     tar -chf /test_output/stdout.tar /test_output/stdout ||:
 fi


### PR DESCRIPTION
added an option to save `*.stdout` and `*.stderr` files with test results to CI artifacts

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [x] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
