### PR TITLE
CMake: add check that *sanitizer builds require disabled ASLR

### DIFF
--- a/cmake/sanitize.cmake
+++ b/cmake/sanitize.cmake
@@ -10,11 +10,13 @@ set (SAN_FLAGS "${SAN_FLAGS} -g -fno-omit-frame-pointer -DSANITIZER")
 
 if (SANITIZE)
 
-    execute_process(COMMAND
-        sysctl --binary kernel.randomize_va_space
-        OUTPUT_VARIABLE RANDOMIZE_VA_SPACE)
-    if (NOT ${RANDOMIZE_VA_SPACE} STREQUAL "0")
-        message (FATAL_ERROR "Sanitizer builds require disabled address space layout randomization. Run 'sudo sysctl kernel.randomize_va_space=0' to disable it")
+    if (OS_LINUX)
+        execute_process(COMMAND
+            sysctl --binary kernel.randomize_va_space
+            OUTPUT_VARIABLE RANDOMIZE_VA_SPACE)
+        if (NOT ${RANDOMIZE_VA_SPACE} STREQUAL "0")
+            message (FATAL_ERROR "Sanitizer builds require disabled address space layout randomization. Run 'sudo sysctl kernel.randomize_va_space=0' to disable it")
+        endif()
     endif()
 
     if (SANITIZE STREQUAL "address")

--- a/cmake/sanitize.cmake
+++ b/cmake/sanitize.cmake
@@ -9,6 +9,14 @@ option (SANITIZE "Enable one of the code sanitizers" "")
 set (SAN_FLAGS "${SAN_FLAGS} -g -fno-omit-frame-pointer -DSANITIZER")
 
 if (SANITIZE)
+
+    execute_process(COMMAND
+        sysctl --binary kernel.randomize_va_space
+        OUTPUT_VARIABLE RANDOMIZE_VA_SPACE)
+    if (NOT ${RANDOMIZE_VA_SPACE} STREQUAL "0")
+        message (FATAL_ERROR "Sanitizer builds require disabled address space layout randomization. Run 'sudo sysctl kernel.randomize_va_space=0' to disable it")
+    endif()
+
     if (SANITIZE STREQUAL "address")
         set (ASAN_FLAGS "-fsanitize=address -fsanitize-address-use-after-scope")
         set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${SAN_FLAGS} ${ASAN_FLAGS}")


### PR DESCRIPTION
Sanitizer on systems with enabled ASLR lead to segfault at build time (llvm-tblgen) and runtime (clickhouse-server). This PR checks that ASLR is disabled.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)