### PR TITLE
Try to fix exception logging in destructors of static objects

### DIFF
--- a/programs/odbc-bridge/tests/CMakeLists.txt
+++ b/programs/odbc-bridge/tests/CMakeLists.txt
@@ -1,2 +1,2 @@
 clickhouse_add_executable (validate-odbc-connection-string validate-odbc-connection-string.cpp ../validateODBCConnectionString.cpp)
-target_link_libraries (validate-odbc-connection-string PRIVATE clickhouse_common_io)
+target_link_libraries (validate-odbc-connection-string PRIVATE clickhouse_common_io clickhouse_common_config)

--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -309,9 +309,16 @@ public:
 
 ClientBase::~ClientBase()
 {
-    writeSignalIDtoSignalPipe(SignalListener::StopThread);
-    signal_listener_thread.join();
-    HandledSignals::instance().reset();
+    try
+    {
+        writeSignalIDtoSignalPipe(SignalListener::StopThread);
+        signal_listener_thread.join();
+        HandledSignals::instance().reset();
+    }
+    catch (...)
+    {
+        tryLogCurrentException(__PRETTY_FUNCTION__);
+    }
 }
 
 ClientBase::ClientBase(

--- a/src/Common/FailPoint.cpp
+++ b/src/Common/FailPoint.cpp
@@ -59,6 +59,7 @@ static struct InitFiu
     ONCE(execute_query_calling_empty_set_result_func_on_exception) \
     ONCE(receive_timeout_on_table_status_response) \
     REGULAR(keepermap_fail_drop_data) \
+    REGULAR(lazy_pipe_fds_fail_close) \
 
 
 namespace FailPoints

--- a/src/Common/PipeFDs.cpp
+++ b/src/Common/PipeFDs.cpp
@@ -1,18 +1,22 @@
 #include <Common/PipeFDs.h>
 #include <Common/Exception.h>
 #include <Common/formatReadable.h>
+#include <Common/FailPoint.h>
 
 #include <Common/logger_useful.h>
 #include <base/errnoToString.h>
 
 #include <unistd.h>
 #include <fcntl.h>
-#include <string>
 #include <algorithm>
-
 
 namespace DB
 {
+
+namespace FailPoints
+{
+    extern const char lazy_pipe_fds_fail_close[];
+}
 
 namespace ErrorCodes
 {
@@ -42,6 +46,11 @@ void LazyPipeFDs::open()
 
 void LazyPipeFDs::close()
 {
+    fiu_do_on(FailPoints::lazy_pipe_fds_fail_close,
+    {
+        throw Exception(ErrorCodes::CANNOT_PIPE, "Manually triggered exception on close");
+    });
+
     for (int & fd : fds_rw)
     {
         if (fd < 0)

--- a/src/Common/PipeFDs.h
+++ b/src/Common/PipeFDs.h
@@ -1,8 +1,5 @@
 #pragma once
 
-#include <cstddef>
-
-
 namespace DB
 {
 

--- a/src/Common/SignalHandlers.cpp
+++ b/src/Common/SignalHandlers.cpp
@@ -605,7 +605,14 @@ void HandledSignals::reset()
 
 HandledSignals::~HandledSignals()
 {
-    reset();
+    try
+    {
+        reset();
+    }
+    catch (...)
+    {
+        tryLogCurrentException(__PRETTY_FUNCTION__);
+    }
 };
 
 HandledSignals & HandledSignals::instance()

--- a/src/Common/StackTrace.cpp
+++ b/src/Common/StackTrace.cpp
@@ -4,7 +4,6 @@
 #include <base/constexpr_helpers.h>
 #include <base/demangle.h>
 
-#include "Common/PipeFDs.h"
 #include <Common/scope_guard_safe.h>
 #include <Common/Dwarf.h>
 #include <Common/Elf.h>
@@ -496,8 +495,6 @@ using StackTraceCacheBase = std::map<StackTraceTriple, CacheEntryPtr, std::less<
 
 struct StackTraceCache : public StackTraceCacheBase
 {
-    using StackTraceCacheBase::StackTraceCacheBase;
-
     ~StackTraceCache()
     {
         can_use_cache = false;

--- a/src/Common/examples/CMakeLists.txt
+++ b/src/Common/examples/CMakeLists.txt
@@ -1,14 +1,14 @@
 clickhouse_add_executable (hashes_test hashes_test.cpp)
-target_link_libraries (hashes_test PRIVATE clickhouse_common_io ch_contrib::cityhash)
+target_link_libraries (hashes_test PRIVATE clickhouse_common_io clickhouse_common_config ch_contrib::cityhash)
 if (TARGET OpenSSL::Crypto)
     target_link_libraries (hashes_test PRIVATE OpenSSL::Crypto)
 endif()
 
 clickhouse_add_executable (sip_hash_perf sip_hash_perf.cpp)
-target_link_libraries (sip_hash_perf PRIVATE clickhouse_common_io)
+target_link_libraries (sip_hash_perf PRIVATE clickhouse_common_io clickhouse_common_config)
 
 clickhouse_add_executable (small_table small_table.cpp)
-target_link_libraries (small_table PRIVATE clickhouse_common_io)
+target_link_libraries (small_table PRIVATE clickhouse_common_io clickhouse_common_config)
 
 clickhouse_add_executable (parallel_aggregation parallel_aggregation.cpp)
 target_link_libraries (parallel_aggregation PRIVATE dbms clickhouse_functions)
@@ -17,13 +17,13 @@ clickhouse_add_executable (parallel_aggregation2 parallel_aggregation2.cpp)
 target_link_libraries (parallel_aggregation2 PRIVATE dbms clickhouse_functions)
 
 clickhouse_add_executable (int_hashes_perf int_hashes_perf.cpp)
-target_link_libraries (int_hashes_perf PRIVATE clickhouse_common_io)
+target_link_libraries (int_hashes_perf PRIVATE clickhouse_common_io clickhouse_common_config)
 
 clickhouse_add_executable (compact_array compact_array.cpp)
-target_link_libraries (compact_array PRIVATE clickhouse_common_io)
+target_link_libraries (compact_array PRIVATE clickhouse_common_io clickhouse_common_config)
 
 clickhouse_add_executable (radix_sort radix_sort.cpp)
-target_link_libraries (radix_sort PRIVATE clickhouse_common_io ch_contrib::pdqsort)
+target_link_libraries (radix_sort PRIVATE clickhouse_common_io clickhouse_common_config ch_contrib::pdqsort)
 
 clickhouse_add_executable (arena_with_free_lists arena_with_free_lists.cpp)
 target_link_libraries (arena_with_free_lists PRIVATE dbms)
@@ -33,46 +33,46 @@ target_link_libraries (lru_hash_map_perf PRIVATE dbms)
 
 if (OS_LINUX)
     clickhouse_add_executable (thread_creation_latency thread_creation_latency.cpp)
-    target_link_libraries (thread_creation_latency PRIVATE clickhouse_common_io)
+    target_link_libraries (thread_creation_latency PRIVATE clickhouse_common_io clickhouse_common_config)
 endif()
 
 clickhouse_add_executable (array_cache array_cache.cpp)
-target_link_libraries (array_cache PRIVATE clickhouse_common_io)
+target_link_libraries (array_cache PRIVATE clickhouse_common_io clickhouse_common_config)
 
 clickhouse_add_executable (space_saving space_saving.cpp)
-target_link_libraries (space_saving PRIVATE clickhouse_common_io)
+target_link_libraries (space_saving PRIVATE clickhouse_common_io clickhouse_common_config)
 
 clickhouse_add_executable (integer_hash_tables_benchmark integer_hash_tables_benchmark.cpp)
 target_link_libraries (integer_hash_tables_benchmark PRIVATE dbms ch_contrib::abseil_swiss_tables ch_contrib::sparsehash)
 
 clickhouse_add_executable (cow_columns cow_columns.cpp)
-target_link_libraries (cow_columns PRIVATE clickhouse_common_io)
+target_link_libraries (cow_columns PRIVATE clickhouse_common_io clickhouse_common_config)
 
 clickhouse_add_executable (cow_compositions cow_compositions.cpp)
-target_link_libraries (cow_compositions PRIVATE clickhouse_common_io)
+target_link_libraries (cow_compositions PRIVATE clickhouse_common_io clickhouse_common_config)
 
 clickhouse_add_executable (stopwatch stopwatch.cpp)
-target_link_libraries (stopwatch PRIVATE clickhouse_common_io)
+target_link_libraries (stopwatch PRIVATE clickhouse_common_io clickhouse_common_config)
 
 clickhouse_add_executable (symbol_index symbol_index.cpp)
-target_link_libraries (symbol_index PRIVATE clickhouse_common_io)
+target_link_libraries (symbol_index PRIVATE clickhouse_common_io clickhouse_common_config)
 
 clickhouse_add_executable (chaos_sanitizer chaos_sanitizer.cpp)
-target_link_libraries (chaos_sanitizer PRIVATE clickhouse_common_io)
+target_link_libraries (chaos_sanitizer PRIVATE clickhouse_common_io clickhouse_common_config)
 
 if (OS_LINUX)
     clickhouse_add_executable (memory_statistics_os_perf memory_statistics_os_perf.cpp)
-    target_link_libraries (memory_statistics_os_perf PRIVATE clickhouse_common_io)
+    target_link_libraries (memory_statistics_os_perf PRIVATE clickhouse_common_io clickhouse_common_config)
 endif()
 
 clickhouse_add_executable (procfs_metrics_provider_perf procfs_metrics_provider_perf.cpp)
-target_link_libraries (procfs_metrics_provider_perf PRIVATE clickhouse_common_io)
+target_link_libraries (procfs_metrics_provider_perf PRIVATE clickhouse_common_io clickhouse_common_config)
 
 clickhouse_add_executable (average average.cpp)
-target_link_libraries (average PRIVATE clickhouse_common_io)
+target_link_libraries (average PRIVATE clickhouse_common_io clickhouse_common_config)
 
 clickhouse_add_executable (shell_command_inout shell_command_inout.cpp)
-target_link_libraries (shell_command_inout PRIVATE clickhouse_common_io)
+target_link_libraries (shell_command_inout PRIVATE clickhouse_common_io clickhouse_common_config)
 
 clickhouse_add_executable (executable_udf executable_udf.cpp)
 target_link_libraries (executable_udf PRIVATE dbms)
@@ -91,4 +91,4 @@ if (ENABLE_SSL)
 endif()
 
 clickhouse_add_executable (check_pointer_valid check_pointer_valid.cpp)
-target_link_libraries (check_pointer_valid PRIVATE clickhouse_common_io)
+target_link_libraries (check_pointer_valid PRIVATE clickhouse_common_io clickhouse_common_config)

--- a/src/Common/mysqlxx/tests/CMakeLists.txt
+++ b/src/Common/mysqlxx/tests/CMakeLists.txt
@@ -1,2 +1,2 @@
 clickhouse_add_executable (mysqlxx_pool_test mysqlxx_pool_test.cpp)
-target_link_libraries (mysqlxx_pool_test PRIVATE mysqlxx)
+target_link_libraries (mysqlxx_pool_test PRIVATE mysqlxx clickhouse_common_config)

--- a/src/Compression/examples/CMakeLists.txt
+++ b/src/Compression/examples/CMakeLists.txt
@@ -1,2 +1,2 @@
 clickhouse_add_executable (compressed_buffer compressed_buffer.cpp)
-target_link_libraries (compressed_buffer PRIVATE clickhouse_common_io clickhouse_compression)
+target_link_libraries (compressed_buffer PRIVATE clickhouse_common_io clickhouse_common_config clickhouse_compression)

--- a/src/Core/examples/CMakeLists.txt
+++ b/src/Core/examples/CMakeLists.txt
@@ -1,8 +1,8 @@
 clickhouse_add_executable (string_pool string_pool.cpp)
-target_link_libraries (string_pool PRIVATE clickhouse_common_io ch_contrib::sparsehash)
+target_link_libraries (string_pool PRIVATE clickhouse_common_io clickhouse_common_config ch_contrib::sparsehash)
 
 clickhouse_add_executable (field field.cpp)
 target_link_libraries (field PRIVATE dbms)
 
 clickhouse_add_executable (string_ref_hash string_ref_hash.cpp)
-target_link_libraries (string_ref_hash PRIVATE clickhouse_common_io)
+target_link_libraries (string_ref_hash PRIVATE clickhouse_common_io clickhouse_common_config)

--- a/src/Daemon/BaseDaemon.cpp
+++ b/src/Daemon/BaseDaemon.cpp
@@ -146,10 +146,19 @@ BaseDaemon::BaseDaemon() = default;
 
 BaseDaemon::~BaseDaemon()
 {
-    writeSignalIDtoSignalPipe(SignalListener::StopThread);
-    signal_listener_thread.join();
-    HandledSignals::instance().reset();
-    SentryWriter::resetInstance();
+    try
+    {
+        writeSignalIDtoSignalPipe(SignalListener::StopThread);
+        signal_listener_thread.join();
+        HandledSignals::instance().reset();
+        SentryWriter::resetInstance();
+    }
+    catch (...)
+    {
+        tryLogCurrentException(&logger());
+    }
+
+    OwnSplitChannel::disableLogging();
 }
 
 

--- a/src/IO/examples/CMakeLists.txt
+++ b/src/IO/examples/CMakeLists.txt
@@ -1,77 +1,77 @@
 clickhouse_add_executable (read_buffer read_buffer.cpp)
-target_link_libraries (read_buffer PRIVATE clickhouse_common_io)
+target_link_libraries (read_buffer PRIVATE clickhouse_common_io clickhouse_common_config)
 
 clickhouse_add_executable (read_buffer_perf read_buffer_perf.cpp)
-target_link_libraries (read_buffer_perf PRIVATE clickhouse_common_io)
+target_link_libraries (read_buffer_perf PRIVATE clickhouse_common_io clickhouse_common_config)
 
 clickhouse_add_executable (read_float_perf read_float_perf.cpp)
-target_link_libraries (read_float_perf PRIVATE clickhouse_common_io)
+target_link_libraries (read_float_perf PRIVATE clickhouse_common_io clickhouse_common_config)
 
 clickhouse_add_executable (write_buffer write_buffer.cpp)
-target_link_libraries (write_buffer PRIVATE clickhouse_common_io)
+target_link_libraries (write_buffer PRIVATE clickhouse_common_io clickhouse_common_config)
 
 clickhouse_add_executable (write_buffer_perf write_buffer_perf.cpp)
-target_link_libraries (write_buffer_perf PRIVATE clickhouse_common_io)
+target_link_libraries (write_buffer_perf PRIVATE clickhouse_common_io clickhouse_common_config)
 
 clickhouse_add_executable (valid_utf8_perf valid_utf8_perf.cpp)
-target_link_libraries (valid_utf8_perf PRIVATE clickhouse_common_io)
+target_link_libraries (valid_utf8_perf PRIVATE clickhouse_common_io clickhouse_common_config)
 
 clickhouse_add_executable (valid_utf8 valid_utf8.cpp)
-target_link_libraries (valid_utf8 PRIVATE clickhouse_common_io)
+target_link_libraries (valid_utf8 PRIVATE clickhouse_common_io clickhouse_common_config)
 
 clickhouse_add_executable (var_uint var_uint.cpp)
-target_link_libraries (var_uint PRIVATE clickhouse_common_io)
+target_link_libraries (var_uint PRIVATE clickhouse_common_io clickhouse_common_config)
 
 clickhouse_add_executable (read_escaped_string read_escaped_string.cpp)
-target_link_libraries (read_escaped_string PRIVATE clickhouse_common_io)
+target_link_libraries (read_escaped_string PRIVATE clickhouse_common_io clickhouse_common_config)
 
 clickhouse_add_executable (parse_int_perf parse_int_perf.cpp)
-target_link_libraries (parse_int_perf PRIVATE clickhouse_common_io)
+target_link_libraries (parse_int_perf PRIVATE clickhouse_common_io clickhouse_common_config)
 
 clickhouse_add_executable (parse_int_perf2 parse_int_perf2.cpp)
-target_link_libraries (parse_int_perf2 PRIVATE clickhouse_common_io)
+target_link_libraries (parse_int_perf2 PRIVATE clickhouse_common_io clickhouse_common_config)
 
 clickhouse_add_executable (read_write_int read_write_int.cpp)
-target_link_libraries (read_write_int PRIVATE clickhouse_common_io)
+target_link_libraries (read_write_int PRIVATE clickhouse_common_io clickhouse_common_config)
 
 clickhouse_add_executable (o_direct_and_dirty_pages o_direct_and_dirty_pages.cpp)
-target_link_libraries (o_direct_and_dirty_pages PRIVATE clickhouse_common_io)
+target_link_libraries (o_direct_and_dirty_pages PRIVATE clickhouse_common_io clickhouse_common_config)
 
 clickhouse_add_executable (io_operators io_operators.cpp)
-target_link_libraries (io_operators PRIVATE clickhouse_common_io)
+target_link_libraries (io_operators PRIVATE clickhouse_common_io clickhouse_common_config)
 
 clickhouse_add_executable (write_int write_int.cpp)
-target_link_libraries (write_int PRIVATE clickhouse_common_io)
+target_link_libraries (write_int PRIVATE clickhouse_common_io clickhouse_common_config)
 
 clickhouse_add_executable (zlib_buffers zlib_buffers.cpp)
-target_link_libraries (zlib_buffers PRIVATE clickhouse_common_io)
+target_link_libraries (zlib_buffers PRIVATE clickhouse_common_io clickhouse_common_config)
 
 clickhouse_add_executable (lzma_buffers lzma_buffers.cpp)
-target_link_libraries (lzma_buffers PRIVATE clickhouse_common_io)
+target_link_libraries (lzma_buffers PRIVATE clickhouse_common_io clickhouse_common_config)
 
 clickhouse_add_executable (limit_read_buffer limit_read_buffer.cpp)
-target_link_libraries (limit_read_buffer PRIVATE clickhouse_common_io)
+target_link_libraries (limit_read_buffer PRIVATE clickhouse_common_io clickhouse_common_config)
 
 clickhouse_add_executable (limit_read_buffer2 limit_read_buffer2.cpp)
-target_link_libraries (limit_read_buffer2 PRIVATE clickhouse_common_io)
+target_link_libraries (limit_read_buffer2 PRIVATE clickhouse_common_io clickhouse_common_config)
 
 clickhouse_add_executable (parse_date_time_best_effort parse_date_time_best_effort.cpp)
-target_link_libraries (parse_date_time_best_effort PRIVATE clickhouse_common_io)
+target_link_libraries (parse_date_time_best_effort PRIVATE clickhouse_common_io clickhouse_common_config)
 
 clickhouse_add_executable (zlib_ng_bug zlib_ng_bug.cpp)
-target_link_libraries (zlib_ng_bug PRIVATE ch_contrib::zlib clickhouse_common_io)
+target_link_libraries (zlib_ng_bug PRIVATE ch_contrib::zlib clickhouse_common_io clickhouse_common_config)
 
 clickhouse_add_executable (dragonbox_test dragonbox_test.cpp)
-target_link_libraries (dragonbox_test PRIVATE ch_contrib::dragonbox_to_chars clickhouse_common_io)
+target_link_libraries (dragonbox_test PRIVATE ch_contrib::dragonbox_to_chars clickhouse_common_io clickhouse_common_config)
 
 clickhouse_add_executable (zstd_buffers zstd_buffers.cpp)
-target_link_libraries (zstd_buffers PRIVATE clickhouse_common_io)
+target_link_libraries (zstd_buffers PRIVATE clickhouse_common_io clickhouse_common_config)
 
 clickhouse_add_executable (snappy_read_buffer snappy_read_buffer.cpp)
-target_link_libraries (snappy_read_buffer PRIVATE clickhouse_common_io)
+target_link_libraries (snappy_read_buffer PRIVATE clickhouse_common_io clickhouse_common_config)
 
 clickhouse_add_executable (hadoop_snappy_read_buffer hadoop_snappy_read_buffer.cpp)
-target_link_libraries (hadoop_snappy_read_buffer PRIVATE clickhouse_common_io)
+target_link_libraries (hadoop_snappy_read_buffer PRIVATE clickhouse_common_io clickhouse_common_config)
 
 if (TARGET ch_contrib::hdfs)
     clickhouse_add_executable (read_buffer_from_hdfs read_buffer_from_hdfs.cpp)

--- a/src/Interpreters/examples/CMakeLists.txt
+++ b/src/Interpreters/examples/CMakeLists.txt
@@ -2,34 +2,34 @@ clickhouse_add_executable (hash_map hash_map.cpp)
 target_link_libraries (hash_map PRIVATE dbms clickhouse_functions ch_contrib::sparsehash)
 
 clickhouse_add_executable (hash_map_lookup hash_map_lookup.cpp)
-target_link_libraries (hash_map_lookup PRIVATE clickhouse_common_io clickhouse_compression)
+target_link_libraries (hash_map_lookup PRIVATE clickhouse_common_io clickhouse_common_config clickhouse_compression)
 
 clickhouse_add_executable (hash_map3 hash_map3.cpp)
-target_link_libraries (hash_map3 PRIVATE clickhouse_common_io clickhouse_compression ch_contrib::farmhash ch_contrib::metrohash)
+target_link_libraries (hash_map3 PRIVATE clickhouse_common_io clickhouse_common_config clickhouse_compression ch_contrib::farmhash ch_contrib::metrohash)
 
 clickhouse_add_executable (hash_map_string hash_map_string.cpp)
-target_link_libraries (hash_map_string PRIVATE clickhouse_common_io clickhouse_compression ch_contrib::sparsehash)
+target_link_libraries (hash_map_string PRIVATE clickhouse_common_io clickhouse_common_config clickhouse_compression ch_contrib::sparsehash)
 
 clickhouse_add_executable (hash_map_string_2 hash_map_string_2.cpp)
-target_link_libraries (hash_map_string_2 PRIVATE clickhouse_common_io clickhouse_compression)
+target_link_libraries (hash_map_string_2 PRIVATE clickhouse_common_io clickhouse_common_config clickhouse_compression)
 
 clickhouse_add_executable (hash_map_string_3 hash_map_string_3.cpp)
-target_link_libraries (hash_map_string_3 PRIVATE clickhouse_common_io clickhouse_compression ch_contrib::farmhash ch_contrib::metrohash)
+target_link_libraries (hash_map_string_3 PRIVATE clickhouse_common_io clickhouse_common_config clickhouse_compression ch_contrib::farmhash ch_contrib::metrohash)
 
 clickhouse_add_executable (hash_map_string_small hash_map_string_small.cpp)
-target_link_libraries (hash_map_string_small PRIVATE clickhouse_common_io clickhouse_compression ch_contrib::sparsehash)
+target_link_libraries (hash_map_string_small PRIVATE clickhouse_common_io clickhouse_common_config clickhouse_compression ch_contrib::sparsehash)
 
 clickhouse_add_executable (string_hash_map string_hash_map.cpp)
-target_link_libraries (string_hash_map PRIVATE clickhouse_common_io clickhouse_compression ch_contrib::sparsehash)
+target_link_libraries (string_hash_map PRIVATE clickhouse_common_io clickhouse_common_config clickhouse_compression ch_contrib::sparsehash)
 
 clickhouse_add_executable (string_hash_map_aggregation string_hash_map.cpp)
-target_link_libraries (string_hash_map_aggregation PRIVATE clickhouse_common_io clickhouse_compression)
+target_link_libraries (string_hash_map_aggregation PRIVATE clickhouse_common_io clickhouse_common_config clickhouse_compression)
 
 clickhouse_add_executable (string_hash_set string_hash_set.cpp)
-target_link_libraries (string_hash_set PRIVATE clickhouse_common_io clickhouse_compression)
+target_link_libraries (string_hash_set PRIVATE clickhouse_common_io clickhouse_common_config clickhouse_compression)
 
 clickhouse_add_executable (two_level_hash_map two_level_hash_map.cpp)
-target_link_libraries (two_level_hash_map PRIVATE clickhouse_common_io clickhouse_compression ch_contrib::sparsehash)
+target_link_libraries (two_level_hash_map PRIVATE clickhouse_common_io clickhouse_common_config clickhouse_compression ch_contrib::sparsehash)
 
 clickhouse_add_executable (jit_example jit_example.cpp)
 target_link_libraries (jit_example PRIVATE dbms)

--- a/src/Loggers/OwnSplitChannel.cpp
+++ b/src/Loggers/OwnSplitChannel.cpp
@@ -16,8 +16,18 @@
 namespace DB
 {
 
+static constinit std::atomic<bool> allow_logging{true};
+
+void OwnSplitChannel::disableLogging()
+{
+    allow_logging = false;
+}
+
 void OwnSplitChannel::log(const Poco::Message & msg)
 {
+    if (!allow_logging)
+        return;
+
 #ifndef WITHOUT_TEXT_LOG
     auto logs_queue = CurrentThread::getInternalTextLogsQueue();
 

--- a/src/Loggers/OwnSplitChannel.h
+++ b/src/Loggers/OwnSplitChannel.h
@@ -39,6 +39,8 @@ public:
 
     void setLevel(const std::string & name, int level);
 
+    static void disableLogging();
+
 private:
     void logSplit(const Poco::Message & msg);
     void tryLogSplit(const Poco::Message & msg);

--- a/src/Parsers/examples/CMakeLists.txt
+++ b/src/Parsers/examples/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(SRCS)
 
 clickhouse_add_executable(lexer lexer.cpp ${SRCS})
-target_link_libraries(lexer PRIVATE clickhouse_parsers)
+target_link_libraries(lexer PRIVATE clickhouse_parsers clickhouse_common_config)
 
 clickhouse_add_executable(select_parser select_parser.cpp ${SRCS} "../../Server/ServerType.cpp")
 target_link_libraries(select_parser PRIVATE dbms)

--- a/tests/integration/test_shutdown_static_destructor_failure/test.py
+++ b/tests/integration/test_shutdown_static_destructor_failure/test.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+import pytest
+from helpers.cluster import ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__)
+
+node = cluster.add_instance(
+    "node",
+    main_configs=[],
+    stay_alive=True
+)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def start_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def test_shutdown():
+    node.query("SYSTEM ENABLE FAILPOINT lazy_pipe_fds_fail_close")
+    node.stop_clickhouse()

--- a/tests/integration/test_shutdown_static_destructor_failure/test.py
+++ b/tests/integration/test_shutdown_static_destructor_failure/test.py
@@ -4,11 +4,7 @@ from helpers.cluster import ClickHouseCluster
 
 cluster = ClickHouseCluster(__file__)
 
-node = cluster.add_instance(
-    "node",
-    main_configs=[],
-    stay_alive=True
-)
+node = cluster.add_instance("node", main_configs=[], stay_alive=True)
 
 
 @pytest.fixture(scope="module", autouse=True)

--- a/utils/corrector_utf8/CMakeLists.txt
+++ b/utils/corrector_utf8/CMakeLists.txt
@@ -1,2 +1,2 @@
 clickhouse_add_executable(corrector_utf8 corrector_utf8.cpp)
-target_link_libraries(corrector_utf8 PRIVATE clickhouse_common_io)
+target_link_libraries(corrector_utf8 PRIVATE clickhouse_common_io clickhouse_common_config)


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Logging exceptions in destructor of static objects can access freed objects because we don't know in which order are the objects destroyed (e.g. `StackTraceCache` we use for generating stacktraces).
To prevent this I added couple of safeguards where:
- logging is disabled after `BaseDaemon` object is destroyed
- StackTrace doesn't use cache if the cache object is destroyed

I also noticed that we don't handle exceptions for `LazyPipeFDs::close` correctly in some places so I added a failpoint and a test.

Fix https://github.com/ClickHouse/ClickHouse/issues/67001

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
