### PR TITLE
Test for alter select with parallel replicas

### DIFF
--- a/tests/queries/0_stateless/03205_parallel_replicas_alter_select_ubsan.sql
+++ b/tests/queries/0_stateless/03205_parallel_replicas_alter_select_ubsan.sql
@@ -1,0 +1,35 @@
+SET alter_sync = 2;
+SET max_parallel_replicas = 3, cluster_for_parallel_replicas = 'test_cluster_one_shard_three_replicas_localhost', parallel_replicas_for_non_replicated_merge_tree = true;
+
+DROP TABLE IF EXISTS t1;
+DROP TABLE IF EXISTS t1__fuzz_26;
+
+CREATE TABLE t1__fuzz_26 (`a` Nullable(Float64), `b` Nullable(Float32), `pk` Int64) ENGINE = MergeTree ORDER BY pk;
+CREATE TABLE t1 ( a Float64, b Int64, pk String) Engine = MergeTree() ORDER BY pk;
+
+ALTER TABLE t1
+    (MODIFY COLUMN `a` Float64 TTL toDateTime(b) + toIntervalMonth(viewExplain('EXPLAIN', 'actions = 1', (
+        SELECT
+            toIntervalMonth(1),
+            2
+        FROM t1__fuzz_26
+        GROUP BY
+            toFixedString('%Prewhere%', 10),
+            toNullable(12)
+            WITH ROLLUP
+    )), 1)) settings allow_experimental_parallel_reading_from_replicas = 1; -- { serverError INCORRECT_RESULT_OF_SCALAR_SUBQUERY }
+
+ALTER TABLE t1
+    (MODIFY COLUMN `a` Float64 TTL toDateTime(b) + toIntervalMonth(viewExplain('EXPLAIN', 'actions = 1', (
+        SELECT
+            toIntervalMonth(1),
+            2
+        FROM t1__fuzz_26
+        GROUP BY
+            toFixedString('%Prewhere%', 10),
+            toNullable(12)
+            WITH ROLLUP
+    )), 1)) settings allow_experimental_parallel_reading_from_replicas = 0; -- { serverError INCORRECT_RESULT_OF_SCALAR_SUBQUERY }
+
+DROP TABLE t1;
+DROP TABLE t1__fuzz_26;


### PR DESCRIPTION
Closes https://github.com/ClickHouse/ClickHouse/issues/64935 (see [comment](https://github.com/ClickHouse/ClickHouse/issues/64935#issuecomment-2247856554))

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
