### PR TITLE
Don't include getauxval in sanitizer builds

### DIFF
--- a/base/glibc-compatibility/CMakeLists.txt
+++ b/base/glibc-compatibility/CMakeLists.txt
@@ -32,12 +32,12 @@ if (GLIBC_COMPATIBILITY)
         # #8 0x5622c0d6b7cd in _start (./ClickHouse/build_msan/contrib/google-protobuf-cmake/protoc+0x22c7cd) (BuildId: 6411d3c88b898ba3f7d49760555977d3e61f0741)
         #
         # The source of the issue above is that, at this point in time during __msan_init, we can't really do much as
-        # most global variables aren't initialized or available yet, so we we can't initiate the auxiliary vector.
+        # most global variables aren't initialized or available yet, so we can't initiate the auxiliary vector.
         # Normal glibc / musl getauxval doesn't have this problem since they initiate their auxval vector at the very
         # start of __libc_start_main (just keeping track of argv+argc+1), but we don't have such option (otherwise
         # this complexity of reading "/proc/self/auxv" or using __environ would not be necessary).
         #
-        # To avoid this crashes on the re-exec call (see above how it would fail when creating `aux`, and it we used
+        # To avoid this crashes on the re-exec call (see above how it would fail when creating `aux`, and if we used
         # __auxv_init_environ then it would SIGSEV on READing `__environ`) we don't include getauxval for the sanitizers
         # This means that those builds will depend on GLIBC 2.16 instead of 2.4 in x86_64
         list(REMOVE_ITEM glibc_compatibility musl/getauxval.c)

--- a/base/glibc-compatibility/CMakeLists.txt
+++ b/base/glibc-compatibility/CMakeLists.txt
@@ -8,6 +8,41 @@ if (GLIBC_COMPATIBILITY)
 
     add_headers_and_sources(glibc_compatibility .)
     add_headers_and_sources(glibc_compatibility musl)
+
+    if (SANITIZE STREQUAL "memory" OR SANITIZE STREQUAL "thread")
+        # Sanitizers are not compatible with high ASLR entropy, which is the default on modern Linux distributions, and
+        # to workaround this limitation, TSAN and MSAN (couldn't see other sanitizers doing the same), re-exec the binary
+        # without ASLR (see https://github.com/llvm/llvm-project/commit/0784b1eefa36d4acbb0dacd2d18796e26313b6c5)
+        #
+        # The problem we face is that, in order to re-exec, the sanitizer wants to use the original pathname in the call
+        # and to get its value it uses getauxval (https://github.com/llvm/llvm-project/blob/20eff684203287828d6722fc860b9d3621429542/compiler-rt/lib/sanitizer_common/sanitizer_linux_libcdep.cpp#L985-L988).
+        # Since we provide getauxval ourselves (to minimize the version dependency on runtime glibc), we are the ones
+        # being called and we fail horribly:
+        #
+        #    ==301455==ERROR: MemorySanitizer: SEGV on unknown address 0x2ffc6d721550 (pc 0x5622c1cc0073 bp 0x000000000003 sp 0x7ffc6d721530 T301455)
+        #    ==301455==The signal is caused by a WRITE memory access.
+        # #0 0x5622c1cc0073 in __auxv_init_procfs ./ClickHouse/base/glibc-compatibility/musl/getauxval.c:129:5
+        # #1 0x5622c1cbffe9 in getauxval ./ClickHouse/base/glibc-compatibility/musl/getauxval.c:240:12
+        # #2 0x5622c0d7bfb4 in __sanitizer::ReExec() crtstuff.c
+        # #3 0x5622c0df7bfc in __msan::InitShadowWithReExec(bool) crtstuff.c
+        # #4 0x5622c0d95356 in __msan_init (./ClickHouse/build_msan/contrib/google-protobuf-cmake/protoc+0x256356) (BuildId: 6411d3c88b898ba3f7d49760555977d3e61f0741)
+        # #5 0x5622c0dfe878 in msan.module_ctor main.cc
+        # #6 0x5622c1cc156c in __libc_csu_init (./ClickHouse/build_msan/contrib/google-protobuf-cmake/protoc+0x118256c) (BuildId: 6411d3c88b898ba3f7d49760555977d3e61f0741)
+        # #7 0x73dc05dd7ea3 in __libc_start_main /usr/src/debug/glibc/glibc/csu/../csu/libc-start.c:343:6
+        # #8 0x5622c0d6b7cd in _start (./ClickHouse/build_msan/contrib/google-protobuf-cmake/protoc+0x22c7cd) (BuildId: 6411d3c88b898ba3f7d49760555977d3e61f0741)
+        #
+        # The source of the issue above is that, at this point in time during __msan_init, we can't really do much as
+        # most global variables aren't initialized or available yet, so we we can't initiate the auxiliary vector.
+        # Normal glibc / musl getauxval doesn't have this problem since they initiate their auxval vector at the very
+        # start of __libc_start_main (just keeping track of argv+argc+1), but we don't have such option (otherwise
+        # this complexity of reading "/proc/self/auxv" or using __environ would not be necessary).
+        #
+        # To avoid this crashes on the re-exec call (see above how it would fail when creating `aux`, and it we used
+        # __auxv_init_environ then it would SIGSEV on READing `__environ`) we don't include getauxval for the sanitizers
+        # This means that those builds will depend on GLIBC 2.16 instead of 2.4 in x86_64
+        list(REMOVE_ITEM glibc_compatibility musl/getauxval.c)
+    endif()
+
     if (ARCH_AARCH64)
         list (APPEND glibc_compatibility_sources musl/aarch64/syscall.s musl/aarch64/longjmp.s)
         set (musl_arch_include_dir musl/aarch64)


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Remove custom getauxval on sanitizer builds. This increase the GLIBC dependency on x86, of those official builds only, to 2.16 (was 2.4)

It seems it's not compatible with sanitizer re-entry to handle high-bit ASLR and it causes runtime problems even with updated LLVM libs:

```
ckHouse/build_msan/src/Server/grpc_protos/clickhouse_grpc.pb.cc /mnt/ch/ClickHouse/build_msan/src/Server/grpc_protos/clickhouse_grpc.grpc.pb.h /mnt/ch/ClickHouse/build_msan/src/Server/grpc_protos/clickhouse_grpc.grpc.pb.cc 
cd /mnt/ch/ClickHouse/build_msan/src/Server/grpc_protos && /mnt/ch/ClickHouse/build_msan/contrib/google-protobuf-cmake/protoc --cpp_out /mnt/ch/ClickHouse/build_msan/src/Server/grpc_protos --grpc_out /mnt/ch/ClickHouse/build_msan/src/Server/grpc_protos --plugin=protoc-gen-grpc=/mnt/ch/ClickHouse/build_msan/contrib/grpc-cmake/grpc_cpp_plugin -I /mnt/ch/ClickHouse/src/Server/grpc_protos /mnt/ch/ClickHouse/src/Server/grpc_protos/clickhouse_grpc.proto
MemorySanitizer:DEADLYSIGNAL
==58641==ERROR: MemorySanitizer: SEGV on unknown address 0x2ffeb6d9bbb0 (pc 0x60b9e94cd073 bp 0x000000000003 sp 0x7ffeb6d9bb90 T58641)
==58641==The signal is caused by a WRITE memory access.
    #0 0x60b9e94cd073 in __auxv_init_procfs /mnt/ch/ClickHouse/base/glibc-compatibility/musl/getauxval.c:93:5
    #1 0x60b9e94ccfe9 in getauxval /mnt/ch/ClickHouse/base/glibc-compatibility/musl/getauxval.c:204:12
    #2 0x60b9e8588fb4 in __sanitizer::ReExec() crtstuff.c
    #3 0x60b9e8604bfc in __msan::InitShadowWithReExec(bool) crtstuff.c
    #4 0x60b9e85a2356 in __msan_init (/mnt/ch/ClickHouse/build_msan/contrib/google-protobuf-cmake/protoc+0x256356) (BuildId: 752f7fa248bce2883327c13f80f808b6ac83e357)
    #5 0x60b9e860b878 in msan.module_ctor main.cc
    #6 0x60b9e94ce56c in __libc_csu_init (/mnt/ch/ClickHouse/build_msan/contrib/google-protobuf-cmake/protoc+0x118256c) (BuildId: 752f7fa248bce2883327c13f80f808b6ac83e357)
    #7 0x7a7e45b69ea3 in __libc_start_main /usr/src/debug/glibc/glibc/csu/../csu/libc-start.c:343:6
    #8 0x60b9e85787cd in _start (/mnt/ch/ClickHouse/build_msan/contrib/google-protobuf-cmake/protoc+0x22c7cd) (BuildId: 752f7fa248bce2883327c13f80f808b6ac83e357)

MemorySanitizer can not provide additional info.
SUMMARY: MemorySanitizer: SEGV /mnt/ch/ClickHouse/base/glibc-compatibility/musl/getauxval.c:93:5 in __auxv_init_procfs
==58641==ABORTING
ninja: build stopped: subcommand failed.
```


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
