### PR TITLE
Increase lock_acquire_timeout_for_background_operations setting in dynamic merges tests

### DIFF
--- a/tests/queries/0_stateless/03037_dynamic_merges_1_horizontal_compact_merge_tree.sql
+++ b/tests/queries/0_stateless/03037_dynamic_merges_1_horizontal_compact_merge_tree.sql
@@ -2,7 +2,7 @@
 set allow_experimental_dynamic_type=1;
 
 drop table if exists test;
-create table test (id UInt64, d Dynamic(max_types=3)) engine=MergeTree order by id settings min_rows_for_wide_part=1000000000, min_bytes_for_wide_part=10000000000, vertical_merge_algorithm_min_columns_to_activate=10, index_granularity_bytes=10485760, index_granularity=8192, merge_max_block_size=8192, merge_max_block_size_bytes=10485760;
+create table test (id UInt64, d Dynamic(max_types=3)) engine=MergeTree order by id settings min_rows_for_wide_part=1000000000, min_bytes_for_wide_part=10000000000, vertical_merge_algorithm_min_columns_to_activate=10, index_granularity_bytes=10485760, index_granularity=8192, merge_max_block_size=8192, merge_max_block_size_bytes=10485760, lock_acquire_timeout_for_background_operations=600;
 
 system stop merges test;
 insert into test select number, number from numbers(100000);

--- a/tests/queries/0_stateless/03037_dynamic_merges_1_horizontal_compact_wide_tree.sql
+++ b/tests/queries/0_stateless/03037_dynamic_merges_1_horizontal_compact_wide_tree.sql
@@ -2,7 +2,7 @@
 set allow_experimental_dynamic_type=1;
 
 drop table if exists test;
-create table test (id UInt64, d Dynamic(max_types=3)) engine=MergeTree order by id settings min_rows_for_wide_part=1, min_bytes_for_wide_part=1, vertical_merge_algorithm_min_columns_to_activate=10, index_granularity_bytes=10485760, index_granularity=8192, merge_max_block_size=8192, merge_max_block_size_bytes=10485760;
+create table test (id UInt64, d Dynamic(max_types=3)) engine=MergeTree order by id settings min_rows_for_wide_part=1, min_bytes_for_wide_part=1, vertical_merge_algorithm_min_columns_to_activate=10, index_granularity_bytes=10485760, index_granularity=8192, merge_max_block_size=8192, merge_max_block_size_bytes=10485760, lock_acquire_timeout_for_background_operations=600;
 
 system stop merges test;
 insert into test select number, number from numbers(100000);

--- a/tests/queries/0_stateless/03037_dynamic_merges_1_vertical_compact_merge_tree.sql
+++ b/tests/queries/0_stateless/03037_dynamic_merges_1_vertical_compact_merge_tree.sql
@@ -2,7 +2,7 @@
 set allow_experimental_dynamic_type=1;
 
 drop table if exists test;
-create table test (id UInt64, d Dynamic(max_types=3)) engine=MergeTree order by id settings min_rows_for_wide_part=1000000000, min_bytes_for_wide_part=10000000000, vertical_merge_algorithm_min_rows_to_activate=1, vertical_merge_algorithm_min_columns_to_activate=1, index_granularity_bytes=10485760, index_granularity=8192, merge_max_block_size=8192, merge_max_block_size_bytes=10485760;
+create table test (id UInt64, d Dynamic(max_types=3)) engine=MergeTree order by id settings min_rows_for_wide_part=1000000000, min_bytes_for_wide_part=10000000000, vertical_merge_algorithm_min_rows_to_activate=1, vertical_merge_algorithm_min_columns_to_activate=1, index_granularity_bytes=10485760, index_granularity=8192, merge_max_block_size=8192, merge_max_block_size_bytes=10485760, lock_acquire_timeout_for_background_operations=600;
 
 system stop merges test;
 insert into test select number, number from numbers(100000);
@@ -13,7 +13,8 @@ insert into test select number, toDateTime(number) from numbers(50000);
 insert into test select number, NULL from numbers(100000);
 
 select count(), dynamicType(d) from test group by dynamicType(d) order by count(), dynamicType(d);
-system start merges test; optimize table test final;;
+system start merges test;
+optimize table test final;
 select count(), dynamicType(d) from test group by dynamicType(d) order by count(), dynamicType(d);
 
 system stop merges test;

--- a/tests/queries/0_stateless/03037_dynamic_merges_1_vertical_wide_merge_tree.sql
+++ b/tests/queries/0_stateless/03037_dynamic_merges_1_vertical_wide_merge_tree.sql
@@ -2,7 +2,7 @@
 set allow_experimental_dynamic_type=1;
 
 drop table if exists test;
-create table test (id UInt64, d Dynamic(max_types=3)) engine=MergeTree order by id settings min_rows_for_wide_part=1, min_bytes_for_wide_part=1, vertical_merge_algorithm_min_rows_to_activate=1, vertical_merge_algorithm_min_columns_to_activate=1, index_granularity_bytes=10485760, index_granularity=8192, merge_max_block_size=8192, merge_max_block_size_bytes=10485760;
+create table test (id UInt64, d Dynamic(max_types=3)) engine=MergeTree order by id settings min_rows_for_wide_part=1, min_bytes_for_wide_part=1, vertical_merge_algorithm_min_rows_to_activate=1, vertical_merge_algorithm_min_columns_to_activate=1, index_granularity_bytes=10485760, index_granularity=8192, merge_max_block_size=8192, merge_max_block_size_bytes=10485760, lock_acquire_timeout_for_background_operations=600;
 
 system stop merges test;
 insert into test select number, number from numbers(100000);

--- a/tests/queries/0_stateless/03037_dynamic_merges_2_horizontal_compact_merge_tree.sql
+++ b/tests/queries/0_stateless/03037_dynamic_merges_2_horizontal_compact_merge_tree.sql
@@ -3,7 +3,7 @@
 set allow_experimental_dynamic_type = 1;
 
 drop table if exists test;
-create table test (id UInt64, d Dynamic) engine=MergeTree order by id settings min_rows_for_wide_part=1000000000, min_bytes_for_wide_part=10000000000;
+create table test (id UInt64, d Dynamic) engine=MergeTree order by id settings min_rows_for_wide_part=1000000000, min_bytes_for_wide_part=10000000000, lock_acquire_timeout_for_background_operations=600;
 system stop merges test;
 insert into test select number, number from numbers(1000000);
 insert into test select number, 'str_' || toString(number) from numbers(1000000, 1000000);

--- a/tests/queries/0_stateless/03037_dynamic_merges_2_horizontal_wide_merge_tree.sql
+++ b/tests/queries/0_stateless/03037_dynamic_merges_2_horizontal_wide_merge_tree.sql
@@ -3,7 +3,7 @@
 set allow_experimental_dynamic_type = 1;
 
 drop table if exists test;
-create table test (id UInt64, d Dynamic) engine=MergeTree order by id settings min_rows_for_wide_part=1, min_bytes_for_wide_part=1;
+create table test (id UInt64, d Dynamic) engine=MergeTree order by id settings min_rows_for_wide_part=1, min_bytes_for_wide_part=1, lock_acquire_timeout_for_background_operations=600;
 system stop merges test;
 insert into test select number, number from numbers(1000000);
 insert into test select number, 'str_' || toString(number) from numbers(1000000, 1000000);

--- a/tests/queries/0_stateless/03037_dynamic_merges_2_vertical_compact_merge_tree.sql
+++ b/tests/queries/0_stateless/03037_dynamic_merges_2_vertical_compact_merge_tree.sql
@@ -3,7 +3,7 @@
 set allow_experimental_dynamic_type = 1;
 
 drop table if exists test;
-create table test (id UInt64, d Dynamic) engine=MergeTree order by id settings min_rows_for_wide_part=1000000000, min_bytes_for_wide_part=10000000000, vertical_merge_algorithm_min_rows_to_activate=1, vertical_merge_algorithm_min_columns_to_activate=1;
+create table test (id UInt64, d Dynamic) engine=MergeTree order by id settings min_rows_for_wide_part=1000000000, min_bytes_for_wide_part=10000000000, vertical_merge_algorithm_min_rows_to_activate=1, vertical_merge_algorithm_min_columns_to_activate=1, lock_acquire_timeout_for_background_operations=600;
 system stop merges test;
 insert into test select number, number from numbers(1000000);
 insert into test select number, 'str_' || toString(number) from numbers(1000000, 1000000);

--- a/tests/queries/0_stateless/03037_dynamic_merges_2_vertical_wide_merge_tree.sql
+++ b/tests/queries/0_stateless/03037_dynamic_merges_2_vertical_wide_merge_tree.sql
@@ -3,7 +3,7 @@
 set allow_experimental_dynamic_type = 1;
 
 drop table if exists test;
-create table test (id UInt64, d Dynamic) engine=MergeTree order by id settings min_rows_for_wide_part=1, min_bytes_for_wide_part=1, vertical_merge_algorithm_min_rows_to_activate=1, vertical_merge_algorithm_min_columns_to_activate=1;
+create table test (id UInt64, d Dynamic) engine=MergeTree order by id settings min_rows_for_wide_part=1, min_bytes_for_wide_part=1, vertical_merge_algorithm_min_rows_to_activate=1, vertical_merge_algorithm_min_columns_to_activate=1, lock_acquire_timeout_for_background_operations=600;
 system stop merges test;
 insert into test select number, number from numbers(1000000);
 insert into test select number, 'str_' || toString(number) from numbers(1000000, 1000000);

--- a/tests/queries/0_stateless/03038_nested_dynamic_merges_compact_horizontal.sql
+++ b/tests/queries/0_stateless/03038_nested_dynamic_merges_compact_horizontal.sql
@@ -6,7 +6,7 @@ set allow_experimental_dynamic_type = 1;
 set enable_named_columns_in_function_tuple = 0;
 
 drop table if exists test;;
-create table test (id UInt64, d Dynamic(max_types=3)) engine=MergeTree order by id settings min_rows_for_wide_part=1000000000, min_bytes_for_wide_part=10000000000;;
+create table test (id UInt64, d Dynamic(max_types=3)) engine=MergeTree order by id settings min_rows_for_wide_part=1000000000, min_bytes_for_wide_part=10000000000, lock_acquire_timeout_for_background_operations=600;
 
 system stop merges test;
 insert into test select number, number from numbers(100000);

--- a/tests/queries/0_stateless/03038_nested_dynamic_merges_compact_vertical.sql
+++ b/tests/queries/0_stateless/03038_nested_dynamic_merges_compact_vertical.sql
@@ -6,7 +6,7 @@ set allow_experimental_dynamic_type = 1;
 set enable_named_columns_in_function_tuple = 0;
 
 drop table if exists test;;
-create table test (id UInt64, d Dynamic(max_types=3)) engine=MergeTree order by id settings min_rows_for_wide_part=1000000000, min_bytes_for_wide_part=10000000000, vertical_merge_algorithm_min_rows_to_activate=1, vertical_merge_algorithm_min_columns_to_activate=1;
+create table test (id UInt64, d Dynamic(max_types=3)) engine=MergeTree order by id settings min_rows_for_wide_part=1000000000, min_bytes_for_wide_part=10000000000, vertical_merge_algorithm_min_rows_to_activate=1, vertical_merge_algorithm_min_columns_to_activate=1, lock_acquire_timeout_for_background_operations=600;
 
 system stop merges test;
 insert into test select number, number from numbers(100000);

--- a/tests/queries/0_stateless/03038_nested_dynamic_merges_wide_horizontal.sql
+++ b/tests/queries/0_stateless/03038_nested_dynamic_merges_wide_horizontal.sql
@@ -6,7 +6,7 @@ set allow_experimental_dynamic_type = 1;
 set enable_named_columns_in_function_tuple = 0;
 
 drop table if exists test;;
-create table test (id UInt64, d Dynamic(max_types=3)) engine=MergeTree order by id settings min_rows_for_wide_part=1, min_bytes_for_wide_part=1;
+create table test (id UInt64, d Dynamic(max_types=3)) engine=MergeTree order by id settings min_rows_for_wide_part=1, min_bytes_for_wide_part=1, lock_acquire_timeout_for_background_operations=600;
 
 system stop merges test;
 insert into test select number, number from numbers(100000);

--- a/tests/queries/0_stateless/03038_nested_dynamic_merges_wide_vertical.sql
+++ b/tests/queries/0_stateless/03038_nested_dynamic_merges_wide_vertical.sql
@@ -6,7 +6,7 @@ set allow_experimental_dynamic_type = 1;
 set enable_named_columns_in_function_tuple = 0;
 
 drop table if exists test;;
-create table test (id UInt64, d Dynamic(max_types=3)) engine=MergeTree order by id settings min_rows_for_wide_part=1, min_bytes_for_wide_part=1, vertical_merge_algorithm_min_rows_to_activate=1, vertical_merge_algorithm_min_columns_to_activate=1;
+create table test (id UInt64, d Dynamic(max_types=3)) engine=MergeTree order by id settings min_rows_for_wide_part=1, min_bytes_for_wide_part=1, vertical_merge_algorithm_min_rows_to_activate=1, vertical_merge_algorithm_min_columns_to_activate=1, lock_acquire_timeout_for_background_operations=600;
 
 system stop merges test;
 insert into test select number, number from numbers(100000);


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Closes https://github.com/ClickHouse/ClickHouse/issues/67114. See https://github.com/ClickHouse/ClickHouse/issues/67114#issuecomment-2250303715

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
