### PR TITLE
Fix truncate database

### DIFF
--- a/src/Interpreters/InterpreterDropQuery.cpp
+++ b/src/Interpreters/InterpreterDropQuery.cpp
@@ -399,9 +399,8 @@ BlockIO InterpreterDropQuery::executeToDatabaseImpl(const ASTDropQuery & query, 
             if (query.if_empty)
                 throw Exception(ErrorCodes::NOT_IMPLEMENTED, "DROP IF EMPTY is not implemented for databases");
 
-            if (database->hasReplicationThread())
+            if (!truncate && database->hasReplicationThread())
                 database->stopReplication();
-
 
             if (database->shouldBeEmptyOnDetach())
             {

--- a/tests/queries/0_stateless/02842_truncate_database.reference
+++ b/tests/queries/0_stateless/02842_truncate_database.reference
@@ -20,3 +20,5 @@ source_table_stripe_log
 source_table_tiny_log
 === DICTIONARIES IN test_truncate_database ===
 dest_dictionary
+new tables
+new_table

--- a/tests/queries/0_stateless/02842_truncate_database.sql
+++ b/tests/queries/0_stateless/02842_truncate_database.sql
@@ -73,4 +73,8 @@ SELECT * FROM dest_dictionary; -- {serverError UNKNOWN_TABLE}
 SHOW TABLES FROM test_truncate_database;
 SHOW DICTIONARIES FROM test_truncate_database;
 
+CREATE TABLE new_table (x UInt16) ENGINE = ReplicatedMergeTree ORDER BY x;
+select 'new tables';
+SHOW TABLES FROM test_truncate_database;
+
 DROP DATABASE test_truncate_database;

--- a/tests/queries/0_stateless/02842_truncate_database.sql
+++ b/tests/queries/0_stateless/02842_truncate_database.sql
@@ -73,7 +73,7 @@ SELECT * FROM dest_dictionary; -- {serverError UNKNOWN_TABLE}
 SHOW TABLES FROM test_truncate_database;
 SHOW DICTIONARIES FROM test_truncate_database;
 
-CREATE TABLE new_table (x UInt16) ENGINE = ReplicatedMergeTree ORDER BY x;
+CREATE TABLE new_table (x UInt16) ENGINE = MergeTree ORDER BY x;
 select 'new tables';
 SHOW TABLES FROM test_truncate_database;
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
TRUNCATE DATABASE used to stop replication as if it was a DROP DATABASE query, it's fixed

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
