### PR TITLE
Attempt to fix flakiness of some window view tests

### DIFF
--- a/tests/queries/0_stateless/01052_window_view_proc_tumble_to_now.sh
+++ b/tests/queries/0_stateless/01052_window_view_proc_tumble_to_now.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Tags: no-random-settings, no-parallel
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/01053_window_view_proc_hop_to_now.sh
+++ b/tests/queries/0_stateless/01053_window_view_proc_hop_to_now.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Tags: no-random-settings, no-parallel
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/01054_window_view_proc_tumble_to.sh
+++ b/tests/queries/0_stateless/01054_window_view_proc_tumble_to.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Tags: no-random-settings, no-parallel
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/01055_window_view_proc_hop_to.sh
+++ b/tests/queries/0_stateless/01055_window_view_proc_hop_to.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Tags: no-random-settings, no-parallel
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/01075_window_view_proc_tumble_to_now_populate.sh
+++ b/tests/queries/0_stateless/01075_window_view_proc_tumble_to_now_populate.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Tags: no-random-settings, no-parallel
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh


### PR DESCRIPTION
Fixes https://github.com/ClickHouse/ClickHouse/issues/66887 (maybe)

This was frustrating. The test *should* work if the feature works the way the [docs](https://clickhouse.com/docs/en/sql-reference/statements/create/view#window-view-experimental) describe it ... I studied for many hours the log output of sporadically failing runs of 01075_window_view_proc_tumble_to_now_populate to understand why the view does not always update the destination table but the logs don't give a clue. The failure did not reproduce locally. Then had an idea yesterday (https://github.com/ClickHouse/ClickHouse/pull/67097) but turned out it was misguided. Studied the logs more today, still no clue.

I am now following in the footsteps of https://github.com/ClickHouse/ClickHouse/pull/44438 and hope this will stabilize the tests.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)