### PR TITLE
Disable `AllocatorWithMemoryTracking` for non-sanitizer builds

### DIFF
--- a/base/base/defines.h
+++ b/base/base/defines.h
@@ -87,11 +87,16 @@
 #   define ASAN_POISON_MEMORY_REGION(a, b)
 #endif
 
+#if !defined(SANITIZER_BUILD)
+#    if defined(ADDRESS_SANITIZER) || defined(THREAD_SANITIZER) || defined(MEMORY_SANITIZER) || defined(UNDEFINED_BEHAVIOR_SANITIZER)
+#        define SANITIZER_BUILD
+#    endif
+#endif
+
 /// We used to have only ABORT_ON_LOGICAL_ERROR macro, but most of its uses were actually in places where we didn't care about logical errors
 /// but wanted to check exactly if the current build type is debug or with sanitizer. This new macro is introduced to fix those places.
 #if !defined(DEBUG_OR_SANITIZER_BUILD)
-#    if !defined(NDEBUG) || defined(ADDRESS_SANITIZER) || defined(THREAD_SANITIZER) || defined(MEMORY_SANITIZER) \
-        || defined(UNDEFINED_BEHAVIOR_SANITIZER)
+#    if !defined(NDEBUG) || defined(SANITIZER_BUILD)
 #        define DEBUG_OR_SANITIZER_BUILD
 #    endif
 #endif

--- a/src/Common/AllocatorWithMemoryTracking.h
+++ b/src/Common/AllocatorWithMemoryTracking.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <base/defines.h>
+
+#if defined(SANITIZER_BUILD)
 #include <stdexcept>
 #include <cstddef>
 #include <cstdlib>
@@ -62,4 +65,10 @@ bool operator!=(const AllocatorWithMemoryTracking <T> &, const AllocatorWithMemo
 {
     return false;
 }
+#else
+#include <memory>
+
+template<typename T>
+using AllocatorWithMemoryTracking = std::allocator<T>;
+#endif
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


I understand the reason from the comment why it was defined but I see no reason why use less accurate memory tracking for non-sanitizer builds.

WDYT @alexey-milovidov 

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
