### PR TITLE
Make C-z ignorance configurable (ignore_shell_suspend) in clickhouse-client

### DIFF
--- a/programs/client/clickhouse-client.xml
+++ b/programs/client/clickhouse-client.xml
@@ -53,6 +53,9 @@
     </proto_caps>
     -->
 
+    <!-- Do not send clickhouse-client to background on C-z -->
+    <!-- <ignore_shell_suspend>true</ignore_shell_suspend> -->
+
     <!--
         Settings adjustable via command-line parameters
         can take their defaults from that config file, see examples:

--- a/programs/disks/DisksApp.cpp
+++ b/programs/disks/DisksApp.cpp
@@ -247,6 +247,7 @@ void DisksApp::runInteractiveReplxx()
         suggest,
         history_file,
         /* multiline= */ false,
+        /* ignore_shell_suspend= */ false,
         query_extenders,
         query_delimiters,
         word_break_characters.c_str(),

--- a/programs/disks/DisksApp.h
+++ b/programs/disks/DisksApp.h
@@ -2,7 +2,7 @@
 
 #include <unordered_map>
 #include <vector>
-#include <Client/ReplxxLineReader.h>
+#include <Client/LineReader.h>
 #include <Loggers/Loggers.h>
 #include "DisksClient.h"
 #include "ICommand_fwd.h"

--- a/programs/disks/DisksClient.cpp
+++ b/programs/disks/DisksClient.cpp
@@ -1,6 +1,5 @@
 #include "DisksClient.h"
 #include <Client/ClientBase.h>
-#include <Client/ReplxxLineReader.h>
 #include <Disks/registerDisks.h>
 #include <Common/Config/ConfigProcessor.h>
 

--- a/programs/disks/DisksClient.h
+++ b/programs/disks/DisksClient.h
@@ -5,9 +5,8 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
-#include <Client/ReplxxLineReader.h>
 #include <Loggers/Loggers.h>
-#include "Disks/IDisk.h"
+#include <Disks/IDisk.h>
 
 #include <Interpreters/Context.h>
 #include <boost/program_options/options_description.hpp>

--- a/programs/keeper-client/KeeperClient.cpp
+++ b/programs/keeper-client/KeeperClient.cpp
@@ -314,6 +314,7 @@ void KeeperClient::runInteractiveReplxx()
         suggest,
         history_file,
         /* multiline= */ false,
+        /* ignore_shell_suspend= */ false,
         query_extenders,
         query_delimiters,
         word_break_characters,

--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -2554,6 +2554,7 @@ void ClientBase::runInteractive()
         *suggest,
         history_file,
         getClientConfiguration().has("multiline"),
+        getClientConfiguration().getBool("ignore_shell_suspend", true),
         query_extenders,
         query_delimiters,
         word_break_characters,

--- a/src/Client/ReplxxLineReader.cpp
+++ b/src/Client/ReplxxLineReader.cpp
@@ -294,6 +294,7 @@ ReplxxLineReader::ReplxxLineReader(
     Suggest & suggest,
     const String & history_file_path_,
     bool multiline_,
+    bool ignore_shell_suspend,
     Patterns extenders_,
     Patterns delimiters_,
     const char word_break_characters_[],
@@ -363,7 +364,8 @@ ReplxxLineReader::ReplxxLineReader(
     rx.bind_key(Replxx::KEY::control('P'), [this](char32_t code) { return rx.invoke(Replxx::ACTION::HISTORY_PREVIOUS, code); });
 
     /// We don't want the default, "suspend" behavior, it confuses people.
-    rx.bind_key_internal(replxx::Replxx::KEY::control('Z'), "insert_character");
+    if (ignore_shell_suspend)
+        rx.bind_key_internal(replxx::Replxx::KEY::control('Z'), "insert_character");
 
     auto commit_action = [this](char32_t code)
     {

--- a/src/Client/ReplxxLineReader.h
+++ b/src/Client/ReplxxLineReader.h
@@ -15,6 +15,7 @@ public:
         Suggest & suggest,
         const String & history_file_path,
         bool multiline,
+        bool ignore_shell_suspend,
         Patterns extenders_,
         Patterns delimiters_,
         const char word_break_characters_[],


### PR DESCRIPTION
C-z is extremely useful for some users (like myself), so provide a way to configure it in client and avoid it's ignorance in clickhouse-disks (I hope it is OK since it is not that known utility and it does not have it's own configuration, while cli option is useless, one should remember about it).

_P.S. Honestly I've never seen any interactive client that forbids C-z, so ignoring it my default looks strange to me. That said, that **I would love to change the default of this new parameter to false**_

### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Make C-z ignorance configurable (ignore_shell_suspend) in clickhouse-client

Follow-up for: #66511 (cc @alexey-milovidov )

_P.S. To gain all the power you need https://github.com/ClickHouse/ClickHouse/pull/67135 as well_