### PR TITLE
Remove constants from StorageMerge header in Complete stage

### DIFF
--- a/src/Storages/StorageDistributed.cpp
+++ b/src/Storages/StorageDistributed.cpp
@@ -847,8 +847,11 @@ void StorageDistributed::read(
         /** For distributed tables we do not need constants in header, since we don't send them to remote servers.
           * Moreover, constants can break some functions like `hostName` that are constants only for local queries.
           */
-        for (auto & column : header)
-            column.column = column.column->convertToFullColumnIfConst();
+        if (processed_stage != QueryProcessingStage::Complete)
+        {
+            for (auto & column : header)
+                column.column = column.column->convertToFullColumnIfConst();
+        }
         modified_query_info.query = queryNodeToDistributedSelectQuery(query_tree_distributed);
 
         modified_query_info.query_tree = std::move(query_tree_distributed);

--- a/src/Storages/StorageDistributed.cpp
+++ b/src/Storages/StorageDistributed.cpp
@@ -847,11 +847,8 @@ void StorageDistributed::read(
         /** For distributed tables we do not need constants in header, since we don't send them to remote servers.
           * Moreover, constants can break some functions like `hostName` that are constants only for local queries.
           */
-        if (processed_stage != QueryProcessingStage::Complete)
-        {
-            for (auto & column : header)
-                column.column = column.column->convertToFullColumnIfConst();
-        }
+        for (auto & column : header)
+            column.column = column.column->convertToFullColumnIfConst();
         modified_query_info.query = queryNodeToDistributedSelectQuery(query_tree_distributed);
 
         modified_query_info.query_tree = std::move(query_tree_distributed);

--- a/src/Storages/StorageMerge.cpp
+++ b/src/Storages/StorageMerge.cpp
@@ -369,6 +369,14 @@ void StorageMerge::read(
     /// What will be result structure depending on query processed stage in source tables?
     Block common_header = getHeaderForProcessingStage(column_names, storage_snapshot, query_info, local_context, processed_stage);
 
+    if (local_context->getSettingsRef().allow_experimental_analyzer && processed_stage == QueryProcessingStage::Complete)
+    {
+        /// Remove constants.
+        /// For StorageDistributed some functions like `hostName` that are constants only for local queries.
+        for (auto & column : common_header)
+            column.column = column.column->convertToFullColumnIfConst();
+    }
+
     auto step = std::make_unique<ReadFromMerge>(
         column_names,
         query_info,

--- a/tests/queries/0_stateless/02563_analyzer_merge.reference
+++ b/tests/queries/0_stateless/02563_analyzer_merge.reference
@@ -1,2 +1,3 @@
 0	Value_0	02563_db	test_merge_table_1
 1	Value_1	02563_db	test_merge_table_2
+91138316-5127-45ac-9c25-4ad8779777b4	160

--- a/tests/queries/0_stateless/02563_analyzer_merge.sql
+++ b/tests/queries/0_stateless/02563_analyzer_merge.sql
@@ -35,4 +35,49 @@ SELECT id, value, _database, _table FROM 02563_db.test_merge_table ORDER BY id;
 DROP TABLE 02563_db.test_merge_table;
 DROP TABLE 02563_db.test_merge_table_1;
 DROP TABLE 02563_db.test_merge_table_2;
+
+CREATE TABLE 02563_db.t_1
+(
+    timestamp DateTime64(9),
+    a String,
+    b String
+)
+ENGINE = MergeTree
+PARTITION BY formatDateTime(toStartOfMinute(timestamp), '%Y%m%d%H', 'UTC')
+ORDER BY (timestamp, a, b);
+
+CREATE TABLE 02563_db.dist_t_1 (timestamp DateTime64(9), a String, b String) ENGINE = Distributed('test_shard_localhost', '02563_db', 't_1');
+
+CREATE TABLE 02563_db.m ENGINE = Merge('02563_db', '^dist_');
+
+INSERT INTO 02563_db.t_1 (timestamp, a, b)
+select
+    addMinutes(toDateTime64('2024-07-13 22:00:00', 9, 'UTC'), number),
+    randomString(5),
+    randomString(5)
+from numbers(30);
+
+INSERT INTO 02563_db.t_1 (timestamp, a, b)
+select
+    addMinutes(toDateTime64('2024-07-13 23:00:00', 9, 'UTC'), number),
+    randomString(5),
+    randomString(5)
+from numbers(30);
+
+INSERT INTO 02563_db.t_1 (timestamp, a, b)
+select
+    addMinutes(toDateTime64('2024-07-14 00:00:00', 9, 'UTC'), number),
+    randomString(5),
+    randomString(5)
+from numbers(100);
+
+
+SELECT '91138316-5127-45ac-9c25-4ad8779777b4',
+  count()
+FROM 02563_db.m;
+
+DROP TABLE 02563_db.t_1;
+DROP TABLE 02563_db.dist_t_1;
+DROP TABLE 02563_db.m;
+
 DROP DATABASE 02563_db;


### PR DESCRIPTION

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix error `Cannot convert column because it is non constant in source stream but must be constant in result.` for a query that reads from the `Merge` table over the `Distriburted` table with one shard.

Fixes #66565

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
