### PR TITLE
Turn off bad optimization

### DIFF
--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -737,7 +737,7 @@ class IColumn;
     M(Bool, query_plan_merge_expressions, true, "Allow to merge expressions in the query plan", 0) \
     M(Bool, query_plan_merge_filters, false, "Allow to merge filters in the query plan", 0) \
     M(Bool, query_plan_filter_push_down, true, "Allow to push down filter by predicate query plan step", 0) \
-    M(Bool, query_plan_convert_outer_join_to_inner_join, true, "Allow to convert OUTER JOIN to INNER JOIN if filter after JOIN always filters default values", 0) \
+    M(Bool, query_plan_convert_outer_join_to_inner_join, false, "This setting has a bug - do not use it. Allow to convert OUTER JOIN to INNER JOIN if filter after JOIN always filters default values", 0) \
     M(Bool, query_plan_optimize_prewhere, true, "Allow to push down filter to PREWHERE expression for supported storages", 0) \
     M(Bool, query_plan_execute_functions_after_sorting, true, "Allow to re-order functions after sorting", 0) \
     M(Bool, query_plan_reuse_storage_ordering_for_window_functions, true, "Allow to use the storage sorting for window functions", 0) \

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -57,6 +57,7 @@ String ClickHouseVersion::toString() const
 /// Note: please check if the key already exists to prevent duplicate entries.
 static std::initializer_list<std::pair<ClickHouseVersion, SettingsChangesHistory::SettingsChanges>> settings_changes_history_initializer =
 {
+    {"24.8", {{"query_plan_convert_outer_join_to_inner_join", true, false, "A bug was found."}}},
     {"24.7", {{"output_format_parquet_write_page_index", false, true, "Add a possibility to write page index into parquet files."},
               {"output_format_binary_encode_types_in_binary_format", false, false, "Added new setting to allow to write type names in binary format in RowBinaryWithNamesAndTypes output format"},
               {"input_format_binary_decode_types_in_binary_format", false, false, "Added new setting to allow to read type names in binary format in RowBinaryWithNamesAndTypes input format"},

--- a/tests/queries/0_stateless/03210_join_bad_optimization.reference
+++ b/tests/queries/0_stateless/03210_join_bad_optimization.reference
@@ -1,0 +1,22 @@
+DATA
+   ┏━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━┓
+   ┃        c0 ┃        c1 ┃ c2 ┃
+   ┡━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━┩
+1. │ 826636805 │         0 │    │
+   ├───────────┼───────────┼────┤
+2. │         0 │ 150808457 │    │
+   └───────────┴───────────┴────┘
+NUMBER OF ROWS IN FIRST SHOULD BE EQUAL TO SECOND
+FISRT
+
+SECOND
+1
+TO DEBUG I TOOK JUST A SUBQUERY AND IT HAS 1 ROW
+THIRD
+1
+AND I ADDED SINGLE CONDITION THAT CONDITION <>0 THAT IS 1 IN THIRD QUERY AND IT HAS NO RESULT!!!
+FOURTH
+1
+1	tx1	US	2024-07-26 04:15:55
+1	tx2	US	2024-07-26 04:15:55
+1	tx3	US	2024-07-26 04:15:55

--- a/tests/queries/0_stateless/03210_join_bad_optimization.sql
+++ b/tests/queries/0_stateless/03210_join_bad_optimization.sql
@@ -1,0 +1,81 @@
+DROP TABLE IF EXISTS t0;
+
+CREATE TABLE t0 (c0 Int32, c1 Int32, c2 String) ENGINE = Log() ;
+INSERT INTO t0(c0, c1, c2) VALUES (826636805,0, ''), (0, 150808457, '');
+
+SELECT 'DATA';
+SELECT * FROM t0 FORMAT PrettyMonoBlock;
+
+SELECT 'NUMBER OF ROWS IN FIRST SHOULD BE EQUAL TO SECOND';
+
+
+SELECT 'FISRT';
+SELECT left.c2 FROM t0 AS left
+LEFT ANTI JOIN t0 AS right_0 ON ((left.c0)=(right_0.c1))
+WHERE (abs ((- ((sign (right_0.c1))))));
+
+SELECT 'SECOND';
+SELECT SUM(check <> 0) 
+FROM 
+(
+  SELECT (abs ((- ((sign (right_0.c1)))))) AS `check`
+  FROM t0 AS left 
+  LEFT ANTI JOIN t0 AS right_0 ON ((left.c0)=(right_0.c1))
+);
+
+
+SELECT 'TO DEBUG I TOOK JUST A SUBQUERY AND IT HAS 1 ROW';
+
+SELECT 'THIRD';
+
+SELECT (abs ((- ((sign (right_0.c1)))))) AS `check` 
+FROM t0 AS left 
+LEFT ANTI JOIN t0 AS right_0 ON ((left.c0)=(right_0.c1));
+
+
+SELECT 'AND I ADDED SINGLE CONDITION THAT CONDITION <>0 THAT IS 1 IN THIRD QUERY AND IT HAS NO RESULT!!!';
+
+
+SELECT 'FOURTH';
+SELECT (abs ((- ((sign (right_0.c1)))))) AS `check` 
+FROM t0 AS left 
+LEFT ANTI JOIN t0 AS right_0 ON ((left.c0)=(right_0.c1))
+WHERE check <> 0;
+
+DROP TABLE t0;
+
+
+DROP TABLE IF EXISTS user_country;
+DROP TABLE IF EXISTS user_transactions;
+
+CREATE TABLE user_country (
+    user_id UInt64,
+    country String,
+    created_at DateTime DEFAULT now()
+)
+ENGINE = ReplacingMergeTree(created_at)
+ORDER BY user_id;
+
+CREATE TABLE user_transactions (
+    user_id UInt64,
+    transaction_id String
+)
+ENGINE = MergeTree
+ORDER BY user_id;
+
+INSERT INTO user_country (user_id, country) VALUES (1, 'US');
+INSERT INTO user_transactions (user_id, transaction_id) VALUES (1, 'tx1'), (1, 'tx2'), (1, 'tx3'), (2, 'tx1');
+
+-- Expected 3 rows, got only 1. Removing 'ANY' and adding 'FINAL' fixes
+-- the issue (but it is not always possible). Moving filter by 'country' to
+-- an outer query doesn't help. Query without filter by 'country' works
+-- as expected (returns 3 rows).
+SELECT * FROM user_transactions
+ANY LEFT JOIN user_country USING (user_id)
+WHERE
+    user_id = 1
+    AND country = 'US'
+ORDER BY ALL;
+
+DROP TABLE user_country;
+DROP TABLE user_transactions;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
The setting `query_plan_convert_outer_join_to_inner_join` is turned off. This closes #67156. This closes #66447. The bug was introduced in #62907.

CC @kitaisreal 


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
