### PR TITLE
Remove too long unit test

### DIFF
--- a/src/IO/tests/gtest_archive_reader_and_writer.cpp
+++ b/src/IO/tests/gtest_archive_reader_and_writer.cpp
@@ -492,48 +492,6 @@ TEST_P(ArchiveReaderAndWriterTest, ManyFilesOnDisk)
     }
 }
 
-TEST_P(ArchiveReaderAndWriterTest, LargeFile)
-{
-    /// Make an archive.
-    std::string_view contents = "The contents of a.txt\n";
-    int times = 10000000;
-    {
-        auto writer = createArchiveWriter(getPathToArchive());
-        {
-            auto out = writer->writeFile("a.txt", times * contents.size());
-            for (int i = 0; i < times; i++)
-                writeString(contents, *out);
-            out->finalize();
-        }
-        writer->finalize();
-    }
-
-    /// Read the archive.
-    auto reader = createArchiveReader(getPathToArchive());
-
-    ASSERT_TRUE(reader->fileExists("a.txt"));
-
-    auto file_info = reader->getFileInfo("a.txt");
-    EXPECT_EQ(file_info.uncompressed_size, contents.size() * times);
-    EXPECT_GT(file_info.compressed_size, 0);
-
-    {
-        auto in = reader->readFile("a.txt", /*throw_on_not_found=*/true);
-        for (int i = 0; i < times; i++)
-            ASSERT_TRUE(checkString(String(contents), *in));
-    }
-
-    {
-        /// Use an enumerator.
-        auto enumerator = reader->firstFile();
-        ASSERT_NE(enumerator, nullptr);
-        EXPECT_EQ(enumerator->getFileName(), "a.txt");
-        EXPECT_EQ(enumerator->getFileInfo().uncompressed_size, contents.size() * times);
-        EXPECT_GT(enumerator->getFileInfo().compressed_size, 0);
-        EXPECT_FALSE(enumerator->nextFile());
-    }
-}
-
 TEST(TarArchiveReaderTest, FileExists)
 {
     String archive_path = "archive.tar";


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Closes #67167.

Unit tests are intended to test internal interfaces in the code, not end-to-end functionality (that's what functional and integration tests are for) or performance (that's what performance tests are for).

Usually, we prefer functional tests; they are much more beneficial for comparable efforts.


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
