### PR TITLE
Fix `01676_clickhouse_client_autocomplete`

### DIFF
--- a/tests/queries/0_stateless/01676_clickhouse_client_autocomplete.python
+++ b/tests/queries/0_stateless/01676_clickhouse_client_autocomplete.python
@@ -10,18 +10,36 @@ DEBUG_LOG = os.path.join(
     os.path.basename(os.path.abspath(__file__)).strip(".python") + ".debuglog",
 )
 
+STATE_MAP = {
+    -1: "process did not start",
+    0: "completion was found",
+    1: "process started and said ':)'",
+    2: "completion search was started",
+    3: "completion is missing",
+}
+
 
 def run_with_timeout(func, args, timeout):
-    process = multiprocessing.Process(target=func, args=args)
-    process.start()
-    process.join(timeout)
+    for _ in range(5):
+        state = multiprocessing.Value("i", -1)
+        process = multiprocessing.Process(target=func, args=args, kwargs={"state": state})
+        process.start()
+        process.join(timeout)
 
-    if process.is_alive():
-        process.terminate()
-        print("Timeout")
+        if state.value in (0, 3):
+            return
+
+        if process.is_alive():
+            process.terminate()
+
+            if state.value == -1:
+                continue
+
+            print(f"Timeout, state: {STATE_MAP[state.value]}")
+            return
 
 
-def test_completion(program, argv, comp_word):
+def test_completion(program, argv, comp_word, state=None):
     comp_begin = comp_word[:-3]
 
     shell_pid, master = pty.fork()
@@ -41,6 +59,8 @@ def test_completion(program, argv, comp_word):
                 debug_log_fd.write(repr(output_b) + "\n")
                 debug_log_fd.flush()
 
+            state.value = 1
+
             os.write(master, b"SET " + bytes(comp_begin.encode()))
             output_b = os.read(master, 4096)
             output = output_b.decode()
@@ -55,6 +75,8 @@ def test_completion(program, argv, comp_word):
             time.sleep(0.01)
             os.write(master, b"\t")
 
+            state.value = 2
+
             output_b = os.read(master, 4096)
             output = output_b.decode()
             debug_log_fd.write(repr(output_b) + "\n")
@@ -65,6 +87,7 @@ def test_completion(program, argv, comp_word):
                 # meaning no concise completion is found
                 if "\x07" in output:
                     print(f"{comp_word}: FAIL")
+                    state.value = 3
                     return
 
                 output_b = os.read(master, 4096)
@@ -73,6 +96,7 @@ def test_completion(program, argv, comp_word):
                 debug_log_fd.flush()
 
             print(f"{comp_word}: OK")
+            state.value = 0
         finally:
             os.close(master)
             debug_log_fd.close()

--- a/tests/queries/0_stateless/01676_clickhouse_client_autocomplete.python
+++ b/tests/queries/0_stateless/01676_clickhouse_client_autocomplete.python
@@ -22,7 +22,9 @@ STATE_MAP = {
 def run_with_timeout(func, args, timeout):
     for _ in range(5):
         state = multiprocessing.Value("i", -1)
-        process = multiprocessing.Process(target=func, args=args, kwargs={"state": state})
+        process = multiprocessing.Process(
+            target=func, args=args, kwargs={"state": state}
+        )
         process.start()
         process.join(timeout)
 

--- a/tests/queries/0_stateless/01676_clickhouse_client_autocomplete.python
+++ b/tests/queries/0_stateless/01676_clickhouse_client_autocomplete.python
@@ -59,13 +59,14 @@ def test_completion(program, argv, comp_word):
             output = output_b.decode()
             debug_log_fd.write(repr(output_b) + "\n")
             debug_log_fd.flush()
-            # fail fast if there is a bell character in the output,
-            # meaning no concise completion is found
-            if "\x07" in output:
-                print(f"{comp_word}: FAIL")
-                return
 
             while not comp_word in output:
+                # fail fast if there is a bell character in the output,
+                # meaning no concise completion is found
+                if "\x07" in output:
+                    print(f"{comp_word}: FAIL")
+                    return
+
                 output_b = os.read(master, 4096)
                 output += output_b.decode()
                 debug_log_fd.write(repr(output_b) + "\n")


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixes https://github.com/ClickHouse/ClickHouse/issues/67151

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [x] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
