### PR TITLE
Disable convert OUTER JOIN to INNER JOIN optimization for non ALL JOIN strictness

### DIFF
--- a/src/Processors/QueryPlan/Optimizations/convertOuterJoinToInnerJoin.cpp
+++ b/src/Processors/QueryPlan/Optimizations/convertOuterJoinToInnerJoin.cpp
@@ -23,7 +23,10 @@ size_t tryConvertOuterJoinToInnerJoin(QueryPlan::Node * parent_node, QueryPlan::
         return 0;
 
     const auto & table_join = join->getJoin()->getTableJoin();
-    if (table_join.strictness() == JoinStrictness::Asof)
+
+    /// Any JOIN issue https://github.com/ClickHouse/ClickHouse/issues/66447
+    /// Anti JOIN issue https://github.com/ClickHouse/ClickHouse/issues/67156
+    if (table_join.strictness() != JoinStrictness::All)
         return 0;
 
     /// TODO: Support join_use_nulls

--- a/tests/queries/0_stateless/03210_convert_outer_join_to_inner_join_any_join.reference
+++ b/tests/queries/0_stateless/03210_convert_outer_join_to_inner_join_any_join.reference
@@ -1,0 +1,3 @@
+1	tx1	US
+1	tx2	US
+1	tx3	US

--- a/tests/queries/0_stateless/03210_convert_outer_join_to_inner_join_any_join.sql
+++ b/tests/queries/0_stateless/03210_convert_outer_join_to_inner_join_any_join.sql
@@ -1,0 +1,33 @@
+DROP TABLE IF EXISTS user_country;
+DROP TABLE IF EXISTS user_transactions;
+
+CREATE TABLE user_country (
+    user_id UInt64,
+    country String
+)
+ENGINE = ReplacingMergeTree
+ORDER BY user_id;
+
+CREATE TABLE user_transactions (
+    user_id UInt64,
+    transaction_id String
+)
+ENGINE = MergeTree
+ORDER BY user_id;
+
+INSERT INTO user_country (user_id, country) VALUES (1, 'US');
+INSERT INTO user_transactions (user_id, transaction_id) VALUES (1, 'tx1'), (1, 'tx2'), (1, 'tx3'), (2, 'tx1');
+
+-- Expected 3 rows, got only 1. Removing 'ANY' and adding 'FINAL' fixes
+-- the issue (but it is not always possible). Moving filter by 'country' to
+-- an outer query doesn't help. Query without filter by 'country' works
+-- as expected (returns 3 rows).
+SELECT * FROM user_transactions
+ANY LEFT JOIN user_country USING (user_id)
+WHERE
+    user_id = 1
+    AND country = 'US'
+ORDER BY ALL;
+
+DROP TABLE user_country;
+DROP TABLE user_transactions;

--- a/tests/queries/0_stateless/03211_convert_outer_join_to_inner_join_anti_join.reference
+++ b/tests/queries/0_stateless/03211_convert_outer_join_to_inner_join_anti_join.reference
@@ -1,0 +1,19 @@
+DATA
+   ┏━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━┓
+   ┃        c0 ┃        c1 ┃ c2 ┃
+   ┡━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━┩
+1. │ 826636805 │         0 │    │
+   ├───────────┼───────────┼────┤
+2. │         0 │ 150808457 │    │
+   └───────────┴───────────┴────┘
+NUMBER OF ROWS IN FIRST SHOULD BE EQUAL TO SECOND
+FISRT
+
+SECOND
+1
+TO DEBUG I TOOK JUST A SUBQUERY AND IT HAS 1 ROW
+THIRD
+1
+AND I ADDED SINGLE CONDITION THAT CONDITION <>0 THAT IS 1 IN THIRD QUERY AND IT HAS NO RESULT!!!
+FOURTH
+1

--- a/tests/queries/0_stateless/03211_convert_outer_join_to_inner_join_anti_join.sql
+++ b/tests/queries/0_stateless/03211_convert_outer_join_to_inner_join_anti_join.sql
@@ -1,0 +1,45 @@
+DROP TABLE IF EXISTS t0;
+
+CREATE TABLE t0 (c0 Int32, c1 Int32, c2 String) ENGINE = Log() ;
+INSERT INTO t0(c0, c1, c2) VALUES (826636805,0, ''), (0, 150808457, '');
+
+SELECT 'DATA';
+SELECT * FROM t0 FORMAT PrettyMonoBlock;
+
+SELECT 'NUMBER OF ROWS IN FIRST SHOULD BE EQUAL TO SECOND';
+
+
+SELECT 'FISRT';
+SELECT left.c2 FROM t0 AS left
+LEFT ANTI JOIN t0 AS right_0 ON ((left.c0)=(right_0.c1))
+WHERE (abs ((- ((sign (right_0.c1))))));
+
+SELECT 'SECOND';
+SELECT SUM(check <> 0)
+FROM
+(
+  SELECT (abs ((- ((sign (right_0.c1)))))) AS `check`
+  FROM t0 AS left
+  LEFT ANTI JOIN t0 AS right_0 ON ((left.c0)=(right_0.c1))
+);
+
+
+SELECT 'TO DEBUG I TOOK JUST A SUBQUERY AND IT HAS 1 ROW';
+
+SELECT 'THIRD';
+
+SELECT (abs ((- ((sign (right_0.c1)))))) AS `check`
+FROM t0 AS left
+LEFT ANTI JOIN t0 AS right_0 ON ((left.c0)=(right_0.c1));
+
+
+SELECT 'AND I ADDED SINGLE CONDITION THAT CONDITION <>0 THAT IS 1 IN THIRD QUERY AND IT HAS NO RESULT!!!';
+
+
+SELECT 'FOURTH';
+SELECT (abs ((- ((sign (right_0.c1)))))) AS `check`
+FROM t0 AS left
+LEFT ANTI JOIN t0 AS right_0 ON ((left.c0)=(right_0.c1))
+WHERE check <> 0;
+
+DROP TABLE t0;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
This closes https://github.com/ClickHouse/ClickHouse/issues/67156. This closes https://github.com/ClickHouse/ClickHouse/issues/66447. The bug was introduced in https://github.com/ClickHouse/ClickHouse/pull/62907.
