### PR TITLE
[Docs] rename `filesystemFree` to `filesystemUnreserved`

### DIFF
--- a/docs/en/sql-reference/functions/other-functions.md
+++ b/docs/en/sql-reference/functions/other-functions.md
@@ -2102,14 +2102,14 @@ Result:
 └─────────────────┘
 ```
 
-## filesystemFree
+## filesystemUnreserved
 
-Returns the total amount of the free space on the filesystem hosting the database persistence. See also `filesystemAvailable`
+Returns the total amount of the free space on the filesystem hosting the database persistence. (previously `filesystemFree`). See also [`filesystemAvailable`](#filesystemavailable).
 
 **Syntax**
 
 ```sql
-filesystemFree()
+filesystemUnreserved()
 ```
 
 **Returned value**
@@ -2121,7 +2121,7 @@ filesystemFree()
 Query:
 
 ```sql
-SELECT formatReadableSize(filesystemFree()) AS "Free space";
+SELECT formatReadableSize(filesystemUnreserved()) AS "Free space";
 ```
 
 Result:

--- a/utils/check-style/aspell-ignore/en/aspell-dict.txt
+++ b/utils/check-style/aspell-ignore/en/aspell-dict.txt
@@ -1622,6 +1622,7 @@ filesystem
 filesystemAvailable
 filesystemCapacity
 filesystemFree
+filesystemUnreserved
 filesystems
 finalizeAggregation
 fips


### PR DESCRIPTION
Closes [#1951](https://github.com/ClickHouse/clickhouse-docs/issues/1951). 

Renames `filesystemFree` to `filesystemUnreserved` in the docs. See [this change](https://github.com/ClickHouse/ClickHouse/blob/da24aa06fac26bf1516320cc6e49c8927b1f600a/docs/changelogs/v22.12.1.1752-stable.md?plain=1#L41).

### Changelog category (leave one):
- Documentation (changelog entry is not required)