### PR TITLE
[Green CI] Fix crash in DistributedAsyncInsert when connection is empty

### DIFF
--- a/src/Client/ConnectionPoolWithFailover.h
+++ b/src/Client/ConnectionPoolWithFailover.h
@@ -42,6 +42,7 @@ public:
             size_t max_error_cap = DBMS_CONNECTION_POOL_WITH_FAILOVER_MAX_ERROR_COUNT);
 
     using Entry = IConnectionPool::Entry;
+    using PoolWithFailoverBase<IConnectionPool>::isTryResultInvalid;
 
     /** Allocates connection to work. */
     Entry get(const ConnectionTimeouts & timeouts) override;

--- a/src/Common/PoolWithFailoverBase.h
+++ b/src/Common/PoolWithFailoverBase.h
@@ -116,6 +116,12 @@ public:
             const TryGetEntryFunc & try_get_entry,
             const GetPriorityFunc & get_priority);
 
+    // Returns if the TryResult provided is an invalid one that cannot be used. Used to prevent logical errors.
+    bool isTryResultInvalid(const TryResult & result, bool skip_read_only_replicas) const
+    {
+        return result.entry.isNull() || !result.is_usable || (skip_read_only_replicas && result.is_readonly);
+    }
+
     size_t getPoolSize() const { return nested_pools.size(); }
 
 protected:
@@ -300,7 +306,7 @@ PoolWithFailoverBase<TNestedPool>::getMany(
         throw DB::NetException(DB::ErrorCodes::ALL_CONNECTION_TRIES_FAILED,
                 "All connection tries failed. Log: \n\n{}\n", fail_messages);
 
-    std::erase_if(try_results, [&](const TryResult & r) { return r.entry.isNull() || !r.is_usable || (skip_read_only_replicas && r.is_readonly); });
+    std::erase_if(try_results, [&](const TryResult & r) { return isTryResultInvalid(r, skip_read_only_replicas); });
 
     /// Sort so that preferred items are near the beginning.
     std::stable_sort(
@@ -321,6 +327,9 @@ PoolWithFailoverBase<TNestedPool>::getMany(
     }
     else if (up_to_date_count >= min_entries)
     {
+        if (try_results.size() < up_to_date_count)
+            throw DB::Exception(DB::ErrorCodes::LOGICAL_ERROR, "Could not find enough connections for up-to-date results. Got: {}, needed: {}", try_results.size(), up_to_date_count);
+
         /// There is enough up-to-date entries.
         try_results.resize(up_to_date_count);
     }

--- a/src/Storages/Distributed/DistributedAsyncInsertBatch.cpp
+++ b/src/Storages/Distributed/DistributedAsyncInsertBatch.cpp
@@ -245,6 +245,9 @@ void DistributedAsyncInsertBatch::sendBatch(const SettingsChanges & settings_cha
                 connection = std::move(result.front().entry);
                 compression_expected = connection->getCompression() == Protocol::Compression::Enable;
 
+                if (connection.isNull())
+                    throw Exception(ErrorCodes::LOGICAL_ERROR, "Empty connection");
+
                 LOG_DEBUG(parent.log, "Sending a batch of {} files to {} ({} rows, {} bytes).",
                     files.size(),
                     connection->getDescription(),
@@ -302,6 +305,9 @@ void DistributedAsyncInsertBatch::sendSeparateFiles(const SettingsChanges & sett
             auto result = parent.pool->getManyCheckedForInsert(timeouts, insert_settings, PoolMode::GET_ONE, parent.storage.remote_storage.getQualifiedName());
             auto connection = std::move(result.front().entry);
             bool compression_expected = connection->getCompression() == Protocol::Compression::Enable;
+
+            if (connection.isNull())
+                throw Exception(ErrorCodes::LOGICAL_ERROR, "Empty connection");
 
             RemoteInserter remote(*connection, timeouts,
                 distributed_header.insert_query,

--- a/src/Storages/Distributed/DistributedAsyncInsertBatch.cpp
+++ b/src/Storages/Distributed/DistributedAsyncInsertBatch.cpp
@@ -28,6 +28,7 @@ namespace ErrorCodes
     extern const int TOO_MANY_PARTITIONS;
     extern const int DISTRIBUTED_TOO_MANY_PENDING_BYTES;
     extern const int ARGUMENT_OUT_OF_BOUND;
+    extern const int LOGICAL_ERROR;
 }
 
 /// Can the batch be split and send files from batch one-by-one instead?
@@ -246,7 +247,7 @@ void DistributedAsyncInsertBatch::sendBatch(const SettingsChanges & settings_cha
                 compression_expected = connection->getCompression() == Protocol::Compression::Enable;
 
                 if (connection.isNull())
-                    throw Exception(ErrorCodes::LOGICAL_ERROR, "Empty connection");
+                    throw Exception(ErrorCodes::LOGICAL_ERROR, "Got empty connection");
 
                 LOG_DEBUG(parent.log, "Sending a batch of {} files to {} ({} rows, {} bytes).",
                     files.size(),
@@ -307,7 +308,7 @@ void DistributedAsyncInsertBatch::sendSeparateFiles(const SettingsChanges & sett
             bool compression_expected = connection->getCompression() == Protocol::Compression::Enable;
 
             if (connection.isNull())
-                throw Exception(ErrorCodes::LOGICAL_ERROR, "Empty connection");
+                throw Exception(ErrorCodes::LOGICAL_ERROR, "Got empty connection");
 
             RemoteInserter remote(*connection, timeouts,
                 distributed_header.insert_query,

--- a/src/Storages/Distributed/DistributedAsyncInsertDirectoryQueue.cpp
+++ b/src/Storages/Distributed/DistributedAsyncInsertDirectoryQueue.cpp
@@ -416,7 +416,7 @@ void DistributedAsyncInsertDirectoryQueue::processFile(std::string & file_path, 
         auto connection = std::move(result.front().entry);
 
         if (connection.isNull())
-            throw Exception(ErrorCodes::LOGICAL_ERROR, "Empty connection");
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "Got empty connection");
 
         LOG_DEBUG(log, "Sending `{}` to {} ({} rows, {} bytes)",
             file_path,

--- a/src/Storages/Distributed/DistributedAsyncInsertDirectoryQueue.cpp
+++ b/src/Storages/Distributed/DistributedAsyncInsertDirectoryQueue.cpp
@@ -415,6 +415,9 @@ void DistributedAsyncInsertDirectoryQueue::processFile(std::string & file_path, 
         auto result = pool->getManyCheckedForInsert(timeouts, insert_settings, PoolMode::GET_ONE, storage.remote_storage.getQualifiedName());
         auto connection = std::move(result.front().entry);
 
+        if (connection.isNull())
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "Empty connection");
+
         LOG_DEBUG(log, "Sending `{}` to {} ({} rows, {} bytes)",
             file_path,
             connection->getDescription(),

--- a/src/Storages/Distributed/DistributedSink.cpp
+++ b/src/Storages/Distributed/DistributedSink.cpp
@@ -378,6 +378,8 @@ DistributedSink::runWritingJob(JobReplica & job, const Block & current_block, si
                     /// (anyway fallback_to_stale_replicas_for_distributed_queries=true by default)
                     auto results = shard_info.pool->getManyCheckedForInsert(timeouts, settings, PoolMode::GET_ONE, storage.remote_storage.getQualifiedName());
                     job.connection_entry = std::move(results.front().entry);
+                    if (job.connection_entry.isNull())
+                        throw Exception(ErrorCodes::LOGICAL_ERROR, "Got empty connection");
                 }
                 else
                 {

--- a/src/Storages/Distributed/DistributedSink.cpp
+++ b/src/Storages/Distributed/DistributedSink.cpp
@@ -377,9 +377,11 @@ DistributedSink::runWritingJob(JobReplica & job, const Block & current_block, si
                     /// NOTE: INSERT will also take into account max_replica_delay_for_distributed_queries
                     /// (anyway fallback_to_stale_replicas_for_distributed_queries=true by default)
                     auto results = shard_info.pool->getManyCheckedForInsert(timeouts, settings, PoolMode::GET_ONE, storage.remote_storage.getQualifiedName());
-                    job.connection_entry = std::move(results.front().entry);
-                    if (job.connection_entry.isNull())
-                        throw Exception(ErrorCodes::LOGICAL_ERROR, "Got empty connection");
+                    auto result = results.front();
+                    if (shard_info.pool->isTryResultInvalid(result, settings.distributed_insert_skip_read_only_replicas))
+                        throw Exception(ErrorCodes::LOGICAL_ERROR, "Got an invalid connection result");
+
+                    job.connection_entry = std::move(result.entry);
                 }
                 else
                 {


### PR DESCRIPTION
Fix crash in DistributedAsyncInsert when connection is empty

### Changelog category (leave one):
- Critical Bug Fix (crash, LOGICAL_ERROR, data loss, RBAC)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix crash in DistributedAsyncInsert when connection is empty

Closes https://github.com/ClickHouse/ClickHouse/issues/66740
