### PR TITLE
Check type after optimize_rewrite_aggregate_function_with_if.

### DIFF
--- a/src/Analyzer/Resolve/QueryAnalyzer.cpp
+++ b/src/Analyzer/Resolve/QueryAnalyzer.cpp
@@ -3239,13 +3239,11 @@ ProjectionNames QueryAnalyzer::resolveFunction(QueryTreeNodePtr & node, Identifi
 
         auto action = function_node_ptr->getNullsAction();
         std::string aggregate_function_name = rewriteAggregateFunctionNameIfNeeded(function_name, action, scope.context);
-        std::cerr << "==================== " << function_name << " -> " << aggregate_function_name << std::endl;
-
 
         AggregateFunctionProperties properties;
         auto aggregate_function
             = AggregateFunctionFactory::instance().get(aggregate_function_name, action, argument_types, parameters, properties);
-        std::cerr << aggregate_function->getName()  << ' ' << aggregate_function->getResultType()->getName() << std::endl;
+
         function_node.resolveAsAggregateFunction(std::move(aggregate_function));
 
         return result_projection_names;

--- a/src/Analyzer/Resolve/QueryAnalyzer.cpp
+++ b/src/Analyzer/Resolve/QueryAnalyzer.cpp
@@ -3239,11 +3239,13 @@ ProjectionNames QueryAnalyzer::resolveFunction(QueryTreeNodePtr & node, Identifi
 
         auto action = function_node_ptr->getNullsAction();
         std::string aggregate_function_name = rewriteAggregateFunctionNameIfNeeded(function_name, action, scope.context);
+        std::cerr << "==================== " << function_name << " -> " << aggregate_function_name << std::endl;
+
 
         AggregateFunctionProperties properties;
         auto aggregate_function
             = AggregateFunctionFactory::instance().get(aggregate_function_name, action, argument_types, parameters, properties);
-
+        std::cerr << aggregate_function->getName()  << ' ' << aggregate_function->getResultType()->getName() << std::endl;
         function_node.resolveAsAggregateFunction(std::move(aggregate_function));
 
         return result_projection_names;

--- a/tests/queries/0_stateless/03132_rewrite_aggregate_function_with_if_implicit_cast.reference
+++ b/tests/queries/0_stateless/03132_rewrite_aggregate_function_with_if_implicit_cast.reference
@@ -30,14 +30,14 @@ QUERY id: 0
       FUNCTION id: 15, function_name: toTypeName, function_type: ordinary, result_type: String
         ARGUMENTS
           LIST id: 16, nodes: 1
-            FUNCTION id: 2, function_name: anyIf, function_type: aggregate, result_type: Nullable(Int128)
+            FUNCTION id: 17, function_name: anyIf, function_type: aggregate, result_type: Nullable(Int128)
               ARGUMENTS
-                LIST id: 3, nodes: 2
-                  FUNCTION id: 4, function_name: _CAST, function_type: ordinary, result_type: Nullable(Int128)
+                LIST id: 18, nodes: 2
+                  FUNCTION id: 19, function_name: _CAST, function_type: ordinary, result_type: Nullable(Int128)
                     ARGUMENTS
-                      LIST id: 5, nodes: 2
+                      LIST id: 20, nodes: 2
                         COLUMN id: 6, column_name: number, result_type: UInt64, source_id: 7
-                        CONSTANT id: 8, constant_value: \'Nullable(Int128)\', constant_value_type: String
+                        CONSTANT id: 21, constant_value: \'Nullable(Int128)\', constant_value_type: String
                   FUNCTION id: 9, function_name: equals, function_type: ordinary, result_type: UInt8
                     ARGUMENTS
                       LIST id: 10, nodes: 2
@@ -50,8 +50,8 @@ QUERY id: 0
   JOIN TREE
     TABLE_FUNCTION id: 7, alias: __table1, table_function_name: numbers
       ARGUMENTS
-        LIST id: 17, nodes: 1
-          CONSTANT id: 18, constant_value: UInt64_100, constant_value_type: UInt8
+        LIST id: 22, nodes: 1
+          CONSTANT id: 23, constant_value: UInt64_100, constant_value_type: UInt8
 SELECT any(if((number % 10) = 5, CAST(NULL, 'Nullable(Int128)'), number)) AS a, toTypeName(a) FROM numbers(100) AS a;
 0	Nullable(Int128)
 EXPLAIN QUERY TREE SELECT any(if((number % 10) = 5, CAST(NULL, 'Nullable(Int128)'), number)) AS a, toTypeName(a) FROM numbers(100);
@@ -84,17 +84,17 @@ QUERY id: 0
       FUNCTION id: 17, function_name: toTypeName, function_type: ordinary, result_type: String
         ARGUMENTS
           LIST id: 18, nodes: 1
-            FUNCTION id: 2, function_name: anyIf, function_type: aggregate, result_type: Nullable(Int128)
+            FUNCTION id: 19, function_name: anyIf, function_type: aggregate, result_type: Nullable(Int128)
               ARGUMENTS
-                LIST id: 3, nodes: 2
-                  FUNCTION id: 4, function_name: _CAST, function_type: ordinary, result_type: Nullable(Int128)
+                LIST id: 20, nodes: 2
+                  FUNCTION id: 21, function_name: _CAST, function_type: ordinary, result_type: Nullable(Int128)
                     ARGUMENTS
-                      LIST id: 5, nodes: 2
+                      LIST id: 22, nodes: 2
                         COLUMN id: 6, column_name: number, result_type: UInt64, source_id: 7
-                        CONSTANT id: 8, constant_value: \'Nullable(Int128)\', constant_value_type: String
-                  FUNCTION id: 9, function_name: not, function_type: ordinary, result_type: UInt8
+                        CONSTANT id: 23, constant_value: \'Nullable(Int128)\', constant_value_type: String
+                  FUNCTION id: 24, function_name: not, function_type: ordinary, result_type: UInt8
                     ARGUMENTS
-                      LIST id: 10, nodes: 1
+                      LIST id: 25, nodes: 1
                         FUNCTION id: 11, function_name: equals, function_type: ordinary, result_type: UInt8
                           ARGUMENTS
                             LIST id: 12, nodes: 2
@@ -107,5 +107,5 @@ QUERY id: 0
   JOIN TREE
     TABLE_FUNCTION id: 7, alias: __table1, table_function_name: numbers
       ARGUMENTS
-        LIST id: 19, nodes: 1
-          CONSTANT id: 20, constant_value: UInt64_100, constant_value_type: UInt8
+        LIST id: 26, nodes: 1
+          CONSTANT id: 27, constant_value: UInt64_100, constant_value_type: UInt8

--- a/tests/queries/0_stateless/03210_optimize_rewrite_aggregate_function_with_if_return_type_bug.reference
+++ b/tests/queries/0_stateless/03210_optimize_rewrite_aggregate_function_with_if_return_type_bug.reference
@@ -1,0 +1,9 @@
+03
+AggregateFunction(count, Nullable(UInt64))
+function_name: _CAST, function_type: ordinary, result_type: AggregateFunction(count, Nullable(UInt64))
+function_name: countStateIf, function_type: aggregate, result_type: AggregateFunction(count, UInt64)
+constant_value: \'AggregateFunction(count, Nullable(UInt64))\', constant_value_type: String
+AggregateFunction(uniq, Nullable(UInt64))
+010003000000007518F0A8E7830665
+function_name: uniqState, function_type: aggregate, result_type: AggregateFunction(uniq, Nullable(UInt64))
+----

--- a/tests/queries/0_stateless/03210_optimize_rewrite_aggregate_function_with_if_return_type_bug.sql
+++ b/tests/queries/0_stateless/03210_optimize_rewrite_aggregate_function_with_if_return_type_bug.sql
@@ -1,0 +1,37 @@
+-- For function count, rewrite countState to countStateIf changes the type from AggregateFunction(count, Nullable(UInt64)) to AggregateFunction(count, UInt64)
+-- We can cast AggregateFunction(count, UInt64) back to AggregateFunction(count, Nullable(UInt64)) with additional _CAST
+select hex(countState(if(toNullable(number % 2 = 0), number, null))) from numbers(5) settings optimize_rewrite_aggregate_function_with_if=1;
+select toTypeName(countState(if(toNullable(number % 2 = 0), number, null))) from numbers(5) settings optimize_rewrite_aggregate_function_with_if=1;
+select arrayStringConcat(arraySlice(splitByString(', ', trimLeft(explain)), 2), ', ') from (explain query tree select hex(countState(if(toNullable(number % 2 = 0), number, null))) from numbers(5) settings optimize_rewrite_aggregate_function_with_if=1) where explain like '%AggregateFunction%';
+
+-- For function uniq, rewrite uniqState to uniqStateIf changes the type from AggregateFunction(uniq, Nullable(UInt64)) to AggregateFunction(uniq, UInt64)
+-- We can't cast AggregateFunction(uniq, UInt64) back to AggregateFunction(uniq, Nullable(UInt64)) so rewrite is not happening.
+select toTypeName(uniqState(if(toNullable(number % 2 = 0), number, null))) from numbers(5) settings optimize_rewrite_aggregate_function_with_if=1;
+select hex(uniqState(if(toNullable(number % 2 = 0), number, null))) from numbers(5) settings optimize_rewrite_aggregate_function_with_if=1;
+select arrayStringConcat(arraySlice(splitByString(', ', trimLeft(explain)), 2), ', ') from (explain query tree select hex(uniqState(if(toNullable(number % 2 = 0), number, null))) from numbers(5) settings optimize_rewrite_aggregate_function_with_if=1) where explain like '%AggregateFunction%';
+
+select '----';
+
+CREATE TABLE a
+(
+    `a_id` String
+)
+ENGINE = MergeTree
+PARTITION BY tuple()
+ORDER BY tuple();
+
+
+CREATE TABLE b
+(
+    `b_id` AggregateFunction(uniq, Nullable(String))
+)
+ENGINE = AggregatingMergeTree
+PARTITION BY tuple()
+ORDER BY tuple();
+
+CREATE MATERIALIZED VIEW mv TO b
+(
+    `b_id` AggregateFunction(uniq, Nullable(String))
+)
+AS SELECT uniqState(if(a_id != '', a_id, NULL)) AS b_id
+FROM a;

--- a/tests/queries/0_stateless/03210_optimize_rewrite_aggregate_function_with_if_return_type_bug.sql
+++ b/tests/queries/0_stateless/03210_optimize_rewrite_aggregate_function_with_if_return_type_bug.sql
@@ -1,3 +1,5 @@
+SET allow_experimental_analyzer = 1;
+
 -- For function count, rewrite countState to countStateIf changes the type from AggregateFunction(count, Nullable(UInt64)) to AggregateFunction(count, UInt64)
 -- We can cast AggregateFunction(count, UInt64) back to AggregateFunction(count, Nullable(UInt64)) with additional _CAST
 select hex(countState(if(toNullable(number % 2 = 0), number, null))) from numbers(5) settings optimize_rewrite_aggregate_function_with_if=1;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix error `Conversion from AggregateFunction(name, Type) to AggregateFunction(name, Nullable(Type)) is not supported`. The bug was caused by the `optimize_rewrite_aggregate_function_with_if` optimization.
Fixes #67112

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
