### PR TITLE
Remove test test_broken_projections_in_backups_1

### DIFF
--- a/src/Backups/BackupsWorker.cpp
+++ b/src/Backups/BackupsWorker.cpp
@@ -384,6 +384,7 @@ BackupsWorker::BackupsWorker(ContextMutablePtr global_context, size_t num_backup
     , allow_concurrent_backups(global_context->getConfigRef().getBool("backups.allow_concurrent_backups", true))
     , allow_concurrent_restores(global_context->getConfigRef().getBool("backups.allow_concurrent_restores", true))
     , remove_backup_files_after_failure(global_context->getConfigRef().getBool("backups.remove_backup_files_after_failure", true))
+    , test_randomize_order(global_context->getConfigRef().getBool("backups.test_randomize_order", false))
     , test_inject_sleep(global_context->getConfigRef().getBool("backups.test_inject_sleep", false))
     , log(getLogger("BackupsWorker"))
     , backup_log(global_context->getBackupLog())
@@ -713,14 +714,25 @@ void BackupsWorker::writeBackupEntries(
     bool always_single_threaded = !backup->supportsWritingInMultipleThreads();
     auto & thread_pool = getThreadPool(ThreadPoolId::BACKUP_COPY_FILES);
 
+    std::vector<size_t> writing_order;
+    if (test_randomize_order)
+    {
+        /// Randomize the order in which we write backup entries to the backup.
+        writing_order.resize(backup_entries.size());
+        std::iota(writing_order.begin(), writing_order.end(), 0);
+        std::shuffle(writing_order.begin(), writing_order.end(), thread_local_rng);
+    }
+
     ThreadPoolCallbackRunnerLocal<void> runner(thread_pool, "BackupWorker");
     for (size_t i = 0; i != backup_entries.size(); ++i)
     {
         if (failed)
             break;
 
-        auto & entry = backup_entries[i].second;
-        const auto & file_info = file_infos[i];
+        size_t index = !writing_order.empty() ? writing_order[i] : i;
+
+        auto & entry = backup_entries[index].second;
+        const auto & file_info = file_infos[index];
 
         auto job = [&]()
         {

--- a/src/Backups/BackupsWorker.h
+++ b/src/Backups/BackupsWorker.h
@@ -119,6 +119,7 @@ private:
     const bool allow_concurrent_backups;
     const bool allow_concurrent_restores;
     const bool remove_backup_files_after_failure;
+    const bool test_randomize_order;
     const bool test_inject_sleep;
 
     LoggerPtr log;

--- a/tests/integration/test_broken_projections/config.d/backups.xml
+++ b/tests/integration/test_broken_projections/config.d/backups.xml
@@ -9,5 +9,6 @@
     </storage_configuration>
     <backups>
         <allowed_disk>backups</allowed_disk>
+        <test_randomize_order>true</test_randomize_order>
     </backups>
 </clickhouse>

--- a/tests/integration/test_broken_projections/test.py
+++ b/tests/integration/test_broken_projections/test.py
@@ -148,23 +148,22 @@ def break_part(node, table, part):
     bash(node, f"rm '{part_path}/columns.txt'")
 
 
-def get_broken_projections_info(node, table, active=True):
+def get_broken_projections_info(node, table, part=None, projection=None, active=True):
+    parent_name_filter = f" AND parent_name = '{part}'" if part else ""
+    name_filter = f" AND name = '{projection}'" if projection else ""
     return node.query(
         f"""
-    SELECT parent_name, name, errors.name FROM
-    (
-        SELECT parent_name, name, exception_code
+    SELECT parent_name, name, exception
         FROM system.projection_parts
         WHERE table='{table}'
         AND database=currentDatabase()
         AND is_broken = 1
         AND active = {active}
-    ) AS parts_info
-    INNER JOIN system.errors AS errors
-    ON parts_info.exception_code = errors.code
+        {parent_name_filter}
+        {name_filter}
     ORDER BY parent_name, name
     """
-    ).strip()
+    )
 
 
 def get_projections_info(node, table):
@@ -312,8 +311,8 @@ def test_broken_ignored(cluster):
 
     # Projection 'proj1' from part all_2_2_0 will now appear in broken parts info
     # because it was marked broken during "check table" query.
-    assert "all_2_2_0\tproj1\tFILE_DOESNT_EXIST" in get_broken_projections_info(
-        node, table_name
+    assert "FILE_DOESNT_EXIST" in get_broken_projections_info(
+        node, table_name, part="all_2_2_0", projection="proj1"
     )
 
     # Check table query will also show a list of parts which have broken projections.
@@ -323,14 +322,14 @@ def test_broken_ignored(cluster):
     break_projection(node, table_name, "proj2", "all_2_2_0", "data")
 
     # It will not yet appear in broken projections info.
-    assert "proj2" not in get_broken_projections_info(node, table_name)
+    assert not get_broken_projections_info(node, table_name, projection="proj2")
 
     # Select now fails with error "File doesn't exist"
     check(node, table_name, 0, "proj2", "FILE_DOESNT_EXIST")
 
     # Projection 'proj2' from part all_2_2_0 will now appear in broken parts info.
-    assert "all_2_2_0\tproj2\tNO_FILE_IN_DATA_PART" in get_broken_projections_info(
-        node, table_name
+    assert "NO_FILE_IN_DATA_PART" in get_broken_projections_info(
+        node, table_name, part="all_2_2_0", projection="proj2"
     )
 
     # Second select works, because projection is now marked as broken.
@@ -340,7 +339,7 @@ def test_broken_ignored(cluster):
     break_projection(node, table_name, "proj2", "all_3_3_0", "data")
 
     # It will not yet appear in broken projections info.
-    assert "all_3_3_0" not in get_broken_projections_info(node, table_name)
+    assert not get_broken_projections_info(node, table_name, part="all_3_3_0")
 
     insert(node, table_name, 20, 5)
     insert(node, table_name, 25, 5)
@@ -371,8 +370,8 @@ def test_broken_ignored(cluster):
         node, table_name
     )
 
-    assert "all_3_3_0" in get_broken_projections_info(node, table_name, active=False)
-    assert "all_2_2_0" in get_broken_projections_info(node, table_name, active=True)
+    assert get_broken_projections_info(node, table_name, part="all_3_3_0", active=False)
+    assert get_broken_projections_info(node, table_name, part="all_2_2_0", active=True)
 
     # 0 because of all_2_2_0
     check(node, table_name, 0)
@@ -396,8 +395,8 @@ def test_materialize_broken_projection(cluster):
     break_projection(node, table_name, "proj1", "all_1_1_0", "metadata")
     reattach(node, table_name)
 
-    assert "all_1_1_0\tproj1\tNO_FILE_IN_DATA_PART" in get_broken_projections_info(
-        node, table_name
+    assert "NO_FILE_IN_DATA_PART" in get_broken_projections_info(
+        node, table_name, part="all_1_1_0", projection="proj1"
     )
     assert "Part all_1_1_0 has a broken projection proj1" in check_table_full(
         node, table_name
@@ -406,8 +405,8 @@ def test_materialize_broken_projection(cluster):
     break_projection(node, table_name, "proj2", "all_1_1_0", "data")
     reattach(node, table_name)
 
-    assert "all_1_1_0\tproj2\tFILE_DOESNT_EXIST" in get_broken_projections_info(
-        node, table_name
+    assert "FILE_DOESNT_EXIST" in get_broken_projections_info(
+        node, table_name, part="all_1_1_0", projection="proj2"
     )
     assert "Part all_1_1_0 has a broken projection proj2" in check_table_full(
         node, table_name
@@ -469,8 +468,8 @@ def test_broken_projections_in_backups_2(cluster):
     break_projection(node, table_name, "proj2", "all_2_2_0", "part")
     check(node, table_name, 0, "proj2", "ErrnoException")
 
-    assert "all_2_2_0\tproj2\tFILE_DOESNT_EXIST" == get_broken_projections_info(
-        node, table_name
+    assert "FILE_DOESNT_EXIST" in get_broken_projections_info(
+        node, table_name, part="all_2_2_0", projection="proj2"
     )
 
     assert "FILE_DOESNT_EXIST" in node.query_and_get_error(
@@ -524,8 +523,8 @@ def test_broken_projections_in_backups_3(cluster):
     assert "Part all_1_1_0 has a broken projection proj1" in check_table_full(
         node, table_name
     )
-    assert "all_1_1_0\tproj1\tFILE_DOESNT_EXIST" == get_broken_projections_info(
-        node, table_name
+    assert "FILE_DOESNT_EXIST" in get_broken_projections_info(
+        node, table_name, part="all_1_1_0", projection="proj1"
     )
 
     backup_name = f"b4-{get_random_string()}"
@@ -545,8 +544,11 @@ def test_broken_projections_in_backups_3(cluster):
     )
 
     check(node, table_name, 0)
-    assert "all_1_1_0\tproj1\tNO_FILE_IN_DATA_PART" == get_broken_projections_info(
-        node, table_name
+    assert (
+        "Projection directory proj1.proj does not exist while loading projections"
+        in get_broken_projections_info(
+            node, table_name, part="all_1_1_0", projection="proj1"
+        )
     )
 
 
@@ -569,7 +571,7 @@ def test_check_part_thread(cluster):
     break_projection(node, table_name, "proj2", "all_2_2_0", "data")
 
     # It will not yet appear in broken projections info.
-    assert "proj2" not in get_broken_projections_info(node, table_name)
+    assert not get_broken_projections_info(node, table_name, projection="proj2")
 
     # Select now fails with error "File doesn't exist"
     check(node, table_name, 0, "proj2", "FILE_DOESNT_EXIST", do_check_command=False)
@@ -606,15 +608,15 @@ def test_broken_on_start(cluster):
     break_projection(node, table_name, "proj2", "all_2_2_0", "data")
 
     # It will not yet appear in broken projections info.
-    assert "proj2" not in get_broken_projections_info(node, table_name)
+    assert not get_broken_projections_info(node, table_name, projection="proj2")
 
     # Select now fails with error "File doesn't exist"
     # We will mark projection as broken.
     check(node, table_name, 0, "proj2", "FILE_DOESNT_EXIST")
 
     # Projection 'proj2' from part all_2_2_0 will now appear in broken parts info.
-    assert "all_2_2_0\tproj2\tNO_FILE_IN_DATA_PART" in get_broken_projections_info(
-        node, table_name
+    assert "NO_FILE_IN_DATA_PART" in get_broken_projections_info(
+        node, table_name, part="all_2_2_0", projection="proj2"
     )
 
     # Second select works, because projection is now marked as broken.
@@ -623,7 +625,7 @@ def test_broken_on_start(cluster):
     node.restart_clickhouse()
 
     # It will not yet appear in broken projections info.
-    assert "proj2" in get_broken_projections_info(node, table_name)
+    assert get_broken_projections_info(node, table_name, projection="proj2")
 
     # Select works
     check(node, table_name, 0)
@@ -654,7 +656,7 @@ def test_mutation_with_broken_projection(cluster):
         node, table_name
     )
 
-    assert "" == get_broken_projections_info(node, table_name)
+    assert not get_broken_projections_info(node, table_name)
 
     check(node, table_name, 1)
 
@@ -662,21 +664,21 @@ def test_mutation_with_broken_projection(cluster):
     break_projection(node, table_name, "proj2", "all_2_2_0_4", "data")
 
     # It will not yet appear in broken projections info.
-    assert "proj2" not in get_broken_projections_info(node, table_name)
+    assert not get_broken_projections_info(node, table_name, projection="proj2")
 
     # Select now fails with error "File doesn't exist"
     # We will mark projection as broken.
     check(node, table_name, 0, "proj2", "FILE_DOESNT_EXIST")
 
     # Projection 'proj2' from part all_2_2_0_4 will now appear in broken parts info.
-    assert "all_2_2_0_4\tproj2\tNO_FILE_IN_DATA_PART" in get_broken_projections_info(
-        node, table_name
+    assert "NO_FILE_IN_DATA_PART" in get_broken_projections_info(
+        node, table_name, part="all_2_2_0_4", projection="proj2"
     )
 
     # Second select works, because projection is now marked as broken.
     check(node, table_name, 0)
 
-    assert "all_2_2_0_4" in get_broken_projections_info(node, table_name)
+    assert get_broken_projections_info(node, table_name, part="all_2_2_0_4")
 
     node.query(
         f"ALTER TABLE {table_name} DELETE WHERE _part == 'all_0_0_0_4' SETTINGS mutations_sync = 1"
@@ -690,14 +692,10 @@ def test_mutation_with_broken_projection(cluster):
 
     # Still broken because it was hardlinked.
     broken = get_broken_projections_info(node, table_name)
-    assert (
-        "all_2_2_0_5" in broken or "" == broken
-    )  # second could be because of a merge.
+    if broken:  # can be not broken because of a merge.
+        assert get_broken_projections_info(node, table_name, part="all_2_2_0_5")
 
-    if "" == broken:
-        check(node, table_name, 1)
-    else:
-        check(node, table_name, 0)
+    check(node, table_name, not broken)
 
     node.query(
         f"ALTER TABLE {table_name} DELETE WHERE c == 13 SETTINGS mutations_sync = 1"
@@ -710,6 +708,6 @@ def test_mutation_with_broken_projection(cluster):
     )
 
     # Not broken anymore.
-    assert "" == get_broken_projections_info(node, table_name)
+    assert not get_broken_projections_info(node, table_name)
 
     check(node, table_name, 1)


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Remove integration test `test_broken_projections_in_backups_1`

The PR fixes https://github.com/ClickHouse/ClickHouse/issues/66864