### PR TITLE
Fix curiosities in `TimerDescriptor`

### DIFF
--- a/src/Common/TimerDescriptor.cpp
+++ b/src/Common/TimerDescriptor.cpp
@@ -94,6 +94,8 @@ void TimerDescriptor::drain() const
 
             throw ErrnoException(ErrorCodes::CANNOT_READ_FROM_SOCKET, "Cannot drain timer_fd");
         }
+
+        chassert(res == sizeof(buf));
     }
 }
 

--- a/src/Common/TimerDescriptor.cpp
+++ b/src/Common/TimerDescriptor.cpp
@@ -51,11 +51,7 @@ void TimerDescriptor::reset() const
     if (timer_fd == -1)
         return;
 
-    itimerspec spec;
-    spec.it_interval.tv_nsec = 0;
-    spec.it_interval.tv_sec = 0;
-    spec.it_value.tv_sec = 0;
-    spec.it_value.tv_nsec = 0;
+    itimerspec spec{};
 
     if (-1 == timerfd_settime(timer_fd, 0 /*relative timer */, &spec, nullptr))
         throw ErrnoException(ErrorCodes::CANNOT_SET_TIMER_PERIOD, "Cannot reset timer_fd");

--- a/src/Common/TimerDescriptor.cpp
+++ b/src/Common/TimerDescriptor.cpp
@@ -14,7 +14,6 @@ namespace ErrorCodes
 {
     extern const int CANNOT_CREATE_TIMER;
     extern const int CANNOT_SET_TIMER_PERIOD;
-    extern const int CANNOT_FCNTL;
     extern const int CANNOT_READ_FROM_SOCKET;
 }
 

--- a/src/Common/TimerDescriptor.cpp
+++ b/src/Common/TimerDescriptor.cpp
@@ -39,7 +39,6 @@ TimerDescriptor & TimerDescriptor::operator=(DB::TimerDescriptor && other) noexc
 
 TimerDescriptor::~TimerDescriptor()
 {
-    /// Do not check for result cause cannot throw exception.
     if (timer_fd != -1)
     {
         if (0 != ::close(timer_fd))

--- a/src/Common/TimerDescriptor.cpp
+++ b/src/Common/TimerDescriptor.cpp
@@ -1,10 +1,11 @@
 #if defined(OS_LINUX)
+
 #include <Common/TimerDescriptor.h>
 #include <Common/Exception.h>
 
 #include <sys/timerfd.h>
-#include <fcntl.h>
 #include <unistd.h>
+
 
 namespace DB
 {
@@ -19,15 +20,13 @@ namespace ErrorCodes
 
 TimerDescriptor::TimerDescriptor(int clockid, int flags)
 {
-    timer_fd = timerfd_create(clockid, flags);
+    timer_fd = timerfd_create(clockid, flags | TFD_NONBLOCK);
     if (timer_fd == -1)
-        throw Exception(ErrorCodes::CANNOT_CREATE_TIMER, "Cannot create timer_fd descriptor");
-
-    if (-1 == fcntl(timer_fd, F_SETFL, O_NONBLOCK))
-        throw ErrnoException(ErrorCodes::CANNOT_FCNTL, "Cannot set O_NONBLOCK for timer_fd");
+        throw ErrnoException(ErrorCodes::CANNOT_CREATE_TIMER, "Cannot create timer_fd descriptor");
 }
 
-TimerDescriptor::TimerDescriptor(TimerDescriptor && other) noexcept : timer_fd(other.timer_fd)
+TimerDescriptor::TimerDescriptor(TimerDescriptor && other) noexcept
+    : timer_fd(other.timer_fd)
 {
     other.timer_fd = -1;
 }
@@ -43,13 +42,16 @@ TimerDescriptor::~TimerDescriptor()
     /// Do not check for result cause cannot throw exception.
     if (timer_fd != -1)
     {
-        int err = close(timer_fd);
-        chassert(!err || errno == EINTR);
+        if (0 != ::close(timer_fd))
+            std::terminate();
     }
 }
 
 void TimerDescriptor::reset() const
 {
+    if (timer_fd == -1)
+        return;
+
     itimerspec spec;
     spec.it_interval.tv_nsec = 0;
     spec.it_interval.tv_sec = 0;
@@ -66,25 +68,44 @@ void TimerDescriptor::reset() const
 
 void TimerDescriptor::drain() const
 {
+    if (timer_fd == -1)
+        return;
+
     /// It is expected that socket returns 8 bytes when readable.
     /// Read in loop anyway cause signal may interrupt read call.
+
+    /// man timerfd_create:
+    /// If the timer has already expired one or more times since its settings were last modified using timerfd_settime(),
+    /// or since the last successful read(2), then the buffer given to read(2) returns an unsigned 8-byte integer (uint64_t)
+    /// containing the number of expirations that have occurred.
+    /// (The returned value is in host byte order—that is, the native byte order for integers on the host machine.)
     uint64_t buf;
     while (true)
     {
         ssize_t res = ::read(timer_fd, &buf, sizeof(buf));
         if (res < 0)
         {
+            /// man timerfd_create:
+            /// If no timer expirations have occurred at the time of the read(2),
+            /// then the call either blocks until the next timer expiration, or fails with the error EAGAIN
+            /// if the file descriptor has been made nonblocking
+            /// (via the use of the fcntl(2) F_SETFL operation to set the O_NONBLOCK flag).
             if (errno == EAGAIN)
                 break;
 
-            if (errno != EINTR)
-                throw ErrnoException(ErrorCodes::CANNOT_READ_FROM_SOCKET, "Cannot drain timer_fd");
+            /// A signal happened, need to retry.
+            if (errno == EINTR)
+                continue;
+
+            throw ErrnoException(ErrorCodes::CANNOT_READ_FROM_SOCKET, "Cannot drain timer_fd");
         }
     }
 }
 
 void TimerDescriptor::setRelative(uint64_t usec) const
 {
+    chassert(timer_fd >= 0);
+
     static constexpr uint32_t TIMER_PRECISION = 1e6;
 
     itimerspec spec;
@@ -103,4 +124,5 @@ void TimerDescriptor::setRelative(Poco::Timespan timespan) const
 }
 
 }
+
 #endif

--- a/src/Common/TimerDescriptor.cpp
+++ b/src/Common/TimerDescriptor.cpp
@@ -18,9 +18,9 @@ namespace ErrorCodes
     extern const int CANNOT_READ_FROM_SOCKET;
 }
 
-TimerDescriptor::TimerDescriptor(int clockid, int flags)
+TimerDescriptor::TimerDescriptor()
 {
-    timer_fd = timerfd_create(clockid, flags | TFD_NONBLOCK);
+    timer_fd = timerfd_create(CLOCK_MONOTONIC, TFD_NONBLOCK | TFD_CLOEXEC);
     if (timer_fd == -1)
         throw ErrnoException(ErrorCodes::CANNOT_CREATE_TIMER, "Cannot create timer_fd descriptor");
 }

--- a/src/Common/TimerDescriptor.h
+++ b/src/Common/TimerDescriptor.h
@@ -12,7 +12,7 @@ private:
     int timer_fd;
 
 public:
-    explicit TimerDescriptor(int clockid = CLOCK_MONOTONIC, int flags = 0);
+    TimerDescriptor();
     ~TimerDescriptor();
 
     TimerDescriptor(const TimerDescriptor &) = delete;

--- a/src/IO/AsynchronousReadBufferFromFile.cpp
+++ b/src/IO/AsynchronousReadBufferFromFile.cpp
@@ -93,7 +93,10 @@ void AsynchronousReadBufferFromFile::close()
         return;
 
     if (0 != ::close(fd))
+    {
+        fd = -1;
         throw Exception(ErrorCodes::CANNOT_CLOSE_FILE, "Cannot close file");
+    }
 
     fd = -1;
 }

--- a/src/IO/MMapReadBufferFromFile.cpp
+++ b/src/IO/MMapReadBufferFromFile.cpp
@@ -77,7 +77,10 @@ void MMapReadBufferFromFile::close()
     finish();
 
     if (0 != ::close(fd))
+    {
+        fd = -1;
         throw Exception(ErrorCodes::CANNOT_CLOSE_FILE, "Cannot close file");
+    }
 
     fd = -1;
     metric_increment.destroy();

--- a/src/IO/MMappedFile.cpp
+++ b/src/IO/MMappedFile.cpp
@@ -69,7 +69,10 @@ void MMappedFile::close()
     finish();
 
     if (0 != ::close(fd))
+    {
+        fd = -1;
         throw Exception(ErrorCodes::CANNOT_CLOSE_FILE, "Cannot close file");
+    }
 
     fd = -1;
     metric_increment.destroy();

--- a/src/IO/OpenedFile.cpp
+++ b/src/IO/OpenedFile.cpp
@@ -67,11 +67,13 @@ void OpenedFile::close()
         return;
 
     if (0 != ::close(fd))
+    {
+        fd = -1;
         throw Exception(ErrorCodes::CANNOT_CLOSE_FILE, "Cannot close file");
+    }
 
     fd = -1;
     metric_increment.destroy();
 }
 
 }
-

--- a/src/IO/ReadBufferFromFile.cpp
+++ b/src/IO/ReadBufferFromFile.cpp
@@ -88,7 +88,10 @@ void ReadBufferFromFile::close()
         return;
 
     if (0 != ::close(fd))
+    {
+        fd = -1;
         throw Exception(ErrorCodes::CANNOT_CLOSE_FILE, "Cannot close file");
+    }
 
     fd = -1;
     metric_increment.destroy();

--- a/src/IO/WriteBufferFromFile.cpp
+++ b/src/IO/WriteBufferFromFile.cpp
@@ -116,7 +116,10 @@ void WriteBufferFromFile::close()
         finalize();
 
     if (0 != ::close(fd))
+    {
+        fd = -1;
         throw Exception(ErrorCodes::CANNOT_CLOSE_FILE, "Cannot close file");
+    }
 
     fd = -1;
     metric_increment.destroy();

--- a/src/QueryPipeline/RemoteQueryExecutor.h
+++ b/src/QueryPipeline/RemoteQueryExecutor.h
@@ -8,7 +8,6 @@
 #include <Storages/IStorage_fwd.h>
 #include <Interpreters/Context.h>
 #include <Interpreters/StorageID.h>
-#include <Common/TimerDescriptor.h>
 #include <sys/types.h>
 
 

--- a/src/QueryPipeline/RemoteQueryExecutorReadContext.h
+++ b/src/QueryPipeline/RemoteQueryExecutorReadContext.h
@@ -69,7 +69,7 @@ private:
     /// * timer is a timerfd descriptor to manually check socket timeout
     /// * pipe_fd is a pipe we use to cancel query and socket polling by executor.
     /// We put those descriptors into our own epoll which is used by external executor.
-    TimerDescriptor timer{CLOCK_MONOTONIC, 0};
+    TimerDescriptor timer;
     Poco::Timespan timeout;
     AsyncEventTimeoutType timeout_type;
     std::atomic_bool is_timer_alarmed = false;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

A lot of suspicious errors since 2022: https://github.com/ClickHouse/ClickHouse/issues/37686
And I, indeed, found a lot of potential bugs in the code. But they are most likely not related.



> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
