### PR TITLE
Fix test `test_backup_restore_on_cluster/test_disallow_concurrency`

### DIFF
--- a/tests/integration/test_backup_restore_on_cluster/test.py
+++ b/tests/integration/test_backup_restore_on_cluster/test.py
@@ -776,7 +776,6 @@ def test_system_users():
 
 def test_system_functions():
     node1.query("CREATE FUNCTION linear_equation AS (x, k, b) -> k*x + b;")
-
     node1.query("CREATE FUNCTION parity_str AS (n) -> if(n % 2, 'odd', 'even');")
 
     backup_name = new_backup_name()
@@ -816,6 +815,9 @@ def test_system_functions():
     assert node2.query("SELECT number, parity_str(number) FROM numbers(3)") == TSV(
         [[0, "even"], [1, "odd"], [2, "even"]]
     )
+
+    node1.query("DROP FUNCTION linear_equation")
+    node1.query("DROP FUNCTION parity_str")
 
 
 def test_projection():

--- a/tests/integration/test_backup_restore_on_cluster/test_disallow_concurrency.py
+++ b/tests/integration/test_backup_restore_on_cluster/test_disallow_concurrency.py
@@ -111,10 +111,10 @@ def create_and_fill_table():
         nodes[i].query(f"INSERT INTO tbl SELECT number FROM numbers(40000000)")
 
 
-def wait_for_fail_backup(node, backup_id, backup_name):
+def wait_for_fail_backup(node, backup_id):
     expected_errors = [
         "Concurrent backups not supported",
-        f"Backup {backup_name} already exists",
+        "BACKUP_ALREADY_EXISTS",
     ]
     status = node.query(
         f"SELECT status FROM system.backups WHERE id == '{backup_id}'"
@@ -137,7 +137,7 @@ def wait_for_fail_backup(node, backup_id, backup_name):
         error = node.query(
             f"SELECT error FROM system.backups WHERE id == '{backup_id}'"
         ).rstrip("\n")
-        assert re.search(f"Backup {backup_name} already exists", error)
+        assert any([expected_error in error for expected_error in expected_errors])
         return
     else:
         assert False, "Concurrent backups both passed, when one is expected to fail"
@@ -207,10 +207,10 @@ def test_concurrent_backups_on_same_node():
 
     expected_errors = [
         "Concurrent backups not supported",
-        f"Backup {backup_name} already exists",
+        "BACKUP_ALREADY_EXISTS",
     ]
     if not error:
-        wait_for_fail_backup(nodes[0], id, backup_name)
+        wait_for_fail_backup(nodes[0], id)
 
     assert any([expected_error in error for expected_error in expected_errors])
 
@@ -257,11 +257,11 @@ def test_concurrent_backups_on_different_nodes():
 
     expected_errors = [
         "Concurrent backups not supported",
-        f"Backup {backup_name} already exists",
+        "BACKUP_ALREADY_EXISTS",
     ]
 
     if not error:
-        wait_for_fail_backup(nodes[1], id, backup_name)
+        wait_for_fail_backup(nodes[1], id)
 
     assert any([expected_error in error for expected_error in expected_errors])
 

--- a/tests/integration/test_backup_restore_on_cluster/test_disallow_concurrency.py
+++ b/tests/integration/test_backup_restore_on_cluster/test_disallow_concurrency.py
@@ -9,13 +9,13 @@ import re
 
 cluster = ClickHouseCluster(__file__)
 
-num_nodes = 10
+num_nodes = 2
 
 
 def generate_cluster_def():
     path = os.path.join(
         os.path.dirname(os.path.realpath(__file__)),
-        "./_gen/cluster_for_concurrency_test.xml",
+        "./_gen/cluster_for_test_disallow_concurrency.xml",
     )
     os.makedirs(os.path.dirname(path), exist_ok=True)
     with open(path, "w") as f:
@@ -111,22 +111,56 @@ def create_and_fill_table():
         nodes[i].query(f"INSERT INTO tbl SELECT number FROM numbers(40000000)")
 
 
-def wait_for_fail_backup(node, backup_id):
+def get_status_and_error(node, backup_or_restore_id):
+    return (
+        node.query(
+            f"SELECT status, error FROM system.backups WHERE id == '{backup_or_restore_id}'"
+        )
+        .rstrip("\n")
+        .split("\t")
+    )
+
+
+def wait_for_backup(node, backup_id):
+    assert_eq_with_retry(
+        node,
+        f"SELECT status FROM system.backups WHERE id = '{backup_id}'",
+        "BACKUP_CREATED",
+        sleep_time=2,
+        retry_count=50,
+    )
+
+
+def wait_for_restore(node, restore_id):
+    assert_eq_with_retry(
+        node,
+        f"SELECT status FROM system.backups WHERE id == '{restore_id}'",
+        "RESTORED",
+        sleep_time=2,
+        retry_count=50,
+    )
+
+
+def check_backup_error(error):
     expected_errors = [
         "Concurrent backups not supported",
         "BACKUP_ALREADY_EXISTS",
     ]
-    status = node.query(
-        f"SELECT status FROM system.backups WHERE id == '{backup_id}'"
-    ).rstrip("\n")
+    assert any([expected_error in error for expected_error in expected_errors])
+
+
+def check_restore_error(error):
+    expected_errors = [
+        "Concurrent restores not supported",
+        "Cannot restore the table default.tbl because it already contains some data",
+    ]
+    assert any([expected_error in error for expected_error in expected_errors])
+
+
+def wait_for_backup_failure(node, backup_id):
+    status, error = get_status_and_error(node, backup_id)
     # It is possible that the second backup was picked up first, and then the async backup
-    if status == "BACKUP_FAILED":
-        error = node.query(
-            f"SELECT error FROM system.backups WHERE id == '{backup_id}'"
-        ).rstrip("\n")
-        assert any([expected_error in error for expected_error in expected_errors])
-        return
-    elif status == "CREATING_BACKUP":
+    if status == "CREATING_BACKUP":
         assert_eq_with_retry(
             node,
             f"SELECT status FROM system.backups WHERE id = '{backup_id}'",
@@ -134,31 +168,17 @@ def wait_for_fail_backup(node, backup_id):
             sleep_time=2,
             retry_count=50,
         )
-        error = node.query(
-            f"SELECT error FROM system.backups WHERE id == '{backup_id}'"
-        ).rstrip("\n")
-        assert any([expected_error in error for expected_error in expected_errors])
-        return
+        status, error = get_status_and_error(node, backup_id)
+    if status == "BACKUP_FAILED":
+        check_backup_error(error)
     else:
         assert False, "Concurrent backups both passed, when one is expected to fail"
 
 
-def wait_for_fail_restore(node, restore_id):
-    expected_errors = [
-        "Concurrent restores not supported",
-        "Cannot restore the table default.tbl because it already contains some data",
-    ]
-    status = node.query(
-        f"SELECT status FROM system.backups WHERE id == '{restore_id}'"
-    ).rstrip("\n")
+def wait_for_restore_failure(node, restore_id):
+    status, error = get_status_and_error(node, restore_id)
     # It is possible that the second backup was picked up first, and then the async backup
-    if status == "RESTORE_FAILED":
-        error = node.query(
-            f"SELECT error FROM system.backups WHERE id == '{restore_id}'"
-        ).rstrip("\n")
-        assert any([expected_error in error for expected_error in expected_errors])
-        return
-    elif status == "RESTORING":
+    if status == "RESTORING":
         assert_eq_with_retry(
             node,
             f"SELECT status FROM system.backups WHERE id = '{restore_id}'",
@@ -166,14 +186,9 @@ def wait_for_fail_restore(node, restore_id):
             sleep_time=2,
             retry_count=50,
         )
-        error = node.query(
-            f"SELECT error FROM system.backups WHERE id == '{restore_id}'"
-        ).rstrip("\n")
-        assert re.search(
-            "Cannot restore the table default.tbl because it already contains some data",
-            error,
-        )
-        return
+        status, error = get_status_and_error(node, restore_id)
+    if status == "RESTORE_FAILED":
+        check_restore_error(error)
     else:
         assert False, "Concurrent restores both passed, when one is expected to fail"
 
@@ -188,39 +203,28 @@ def test_concurrent_backups_on_same_node():
 
     backup_name = new_backup_name()
 
-    id = (
+    # Backup #1.
+    id, status = (
         nodes[0]
         .query(f"BACKUP TABLE tbl ON CLUSTER 'cluster' TO {backup_name} ASYNC")
-        .split("\t")[0]
+        .rstrip("\n")
+        .split("\t")
     )
 
-    status = (
-        nodes[0]
-        .query(f"SELECT status FROM system.backups WHERE id == '{id}'")
-        .rstrip("\n")
-    )
     assert status in ["CREATING_BACKUP", "BACKUP_CREATED"]
 
-    result, error = nodes[0].query_and_get_answer_with_error(
+    # Backup #2.
+    _, error = nodes[0].query_and_get_answer_with_error(
         f"BACKUP TABLE tbl ON CLUSTER 'cluster' TO {backup_name}"
     )
 
-    expected_errors = [
-        "Concurrent backups not supported",
-        "BACKUP_ALREADY_EXISTS",
-    ]
-    if not error:
-        wait_for_fail_backup(nodes[0], id)
-
-    assert any([expected_error in error for expected_error in expected_errors])
-
-    assert_eq_with_retry(
-        nodes[0],
-        f"SELECT status FROM system.backups WHERE id = '{id}'",
-        "BACKUP_CREATED",
-        sleep_time=2,
-        retry_count=50,
-    )
+    if error:
+        # Backup #2 failed, backup #1 should be successful.
+        check_backup_error(error)
+        wait_for_backup(nodes[0], id)
+    else:
+        # Backup #2 was successful, backup #1 should fail.
+        wait_for_backup_failure(nodes[0], id)
 
     # This restore part is added to confirm creating an internal backup & restore work
     # even when a concurrent backup is stopped
@@ -238,40 +242,38 @@ def test_concurrent_backups_on_different_nodes():
 
     backup_name = new_backup_name()
 
-    id = (
-        nodes[1]
+    # Backup #1.
+    id, status = (
+        nodes[0]
         .query(f"BACKUP TABLE tbl ON CLUSTER 'cluster' TO {backup_name} ASYNC")
-        .split("\t")[0]
+        .rstrip("\n")
+        .split("\t")
     )
 
-    status = (
-        nodes[1]
-        .query(f"SELECT status FROM system.backups WHERE id == '{id}'")
-        .rstrip("\n")
-    )
     assert status in ["CREATING_BACKUP", "BACKUP_CREATED"]
 
-    result, error = nodes[0].query_and_get_answer_with_error(
+    # Backup #2.
+    _, error = nodes[1].query_and_get_answer_with_error(
         f"BACKUP TABLE tbl ON CLUSTER 'cluster' TO {backup_name}"
     )
 
-    expected_errors = [
-        "Concurrent backups not supported",
-        "BACKUP_ALREADY_EXISTS",
-    ]
+    if error:
+        # Backup #2 failed, backup #1 should be successful.
+        check_backup_error(error)
+        wait_for_backup(nodes[0], id)
+    else:
+        # Backup #2 was successful, backup #1 should fail.
+        wait_for_backup_failure(nodes[0], id)
 
-    if not error:
-        wait_for_fail_backup(nodes[1], id)
-
-    assert any([expected_error in error for expected_error in expected_errors])
-
-    assert_eq_with_retry(
-        nodes[1],
-        f"SELECT status FROM system.backups WHERE id = '{id}'",
-        "BACKUP_CREATED",
-        sleep_time=2,
-        retry_count=50,
+    # This restore part is added to confirm creating an internal backup & restore work
+    # even when a concurrent backup is stopped
+    nodes[0].query(
+        f"DROP TABLE tbl ON CLUSTER 'cluster' SYNC",
+        settings={
+            "distributed_ddl_task_timeout": 360,
+        },
     )
+    nodes[0].query(f"RESTORE TABLE tbl ON CLUSTER 'cluster' FROM {backup_name}")
 
 
 def test_concurrent_restores_on_same_node():
@@ -288,40 +290,28 @@ def test_concurrent_restores_on_same_node():
         },
     )
 
-    restore_id = (
+    # Restore #1.
+    restore_id, status = (
         nodes[0]
         .query(f"RESTORE TABLE tbl ON CLUSTER 'cluster' FROM {backup_name} ASYNC")
-        .split("\t")[0]
+        .rstrip("\n")
+        .split("\t")
     )
 
-    status = (
-        nodes[0]
-        .query(f"SELECT status FROM system.backups WHERE id == '{restore_id}'")
-        .rstrip("\n")
-    )
     assert status in ["RESTORING", "RESTORED"]
 
-    result, error = nodes[0].query_and_get_answer_with_error(
+    # Restore #2.
+    _, error = nodes[0].query_and_get_answer_with_error(
         f"RESTORE TABLE tbl ON CLUSTER 'cluster' FROM {backup_name}"
     )
 
-    expected_errors = [
-        "Concurrent restores not supported",
-        "Cannot restore the table default.tbl because it already contains some data",
-    ]
-
-    if not error:
-        wait_for_fail_restore(nodes[0], restore_id)
-
-    assert any([expected_error in error for expected_error in expected_errors])
-
-    assert_eq_with_retry(
-        nodes[0],
-        f"SELECT status FROM system.backups WHERE id == '{restore_id}'",
-        "RESTORED",
-        sleep_time=2,
-        retry_count=50,
-    )
+    if error:
+        # Restore #2 failed, restore #1 should be successful.
+        check_restore_error(error)
+        wait_for_restore(nodes[0], restore_id)
+    else:
+        # Restore #2 was successful, restore #1 should fail.
+        wait_for_restore_failure(nodes[0], restore_id)
 
 
 def test_concurrent_restores_on_different_node():
@@ -338,37 +328,25 @@ def test_concurrent_restores_on_different_node():
         },
     )
 
-    restore_id = (
+    # Restore #1.
+    restore_id, status = (
         nodes[0]
         .query(f"RESTORE TABLE tbl ON CLUSTER 'cluster' FROM {backup_name} ASYNC")
-        .split("\t")[0]
+        .rstrip("\n")
+        .split("\t")
     )
 
-    status = (
-        nodes[0]
-        .query(f"SELECT status FROM system.backups WHERE id == '{restore_id}'")
-        .rstrip("\n")
-    )
     assert status in ["RESTORING", "RESTORED"]
 
-    result, error = nodes[1].query_and_get_answer_with_error(
+    # Restore #2.
+    _, error = nodes[1].query_and_get_answer_with_error(
         f"RESTORE TABLE tbl ON CLUSTER 'cluster' FROM {backup_name}"
     )
 
-    expected_errors = [
-        "Concurrent restores not supported",
-        "Cannot restore the table default.tbl because it already contains some data",
-    ]
-
-    if not error:
-        wait_for_fail_restore(nodes[0], restore_id)
-
-    assert any([expected_error in error for expected_error in expected_errors])
-
-    assert_eq_with_retry(
-        nodes[0],
-        f"SELECT status FROM system.backups WHERE id == '{restore_id}'",
-        "RESTORED",
-        sleep_time=2,
-        retry_count=50,
-    )
+    if error:
+        # Restore #2 failed, restore #1 should be successful.
+        check_restore_error(error)
+        wait_for_restore(nodes[0], restore_id)
+    else:
+        # Restore #2 was successful, restore #1 should fail.
+        wait_for_restore_failure(nodes[0], restore_id)


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix integration test `test_backup_restore_on_cluster/test_disallow_concurrency`.

Example of failure: [https://s3.amazonaws.com/clickhouse-test-reports/0/670413a69d3ae9971d804914f52f399c702f6df7/integration_tests__asan__[3_4].html](https://s3.amazonaws.com/clickhouse-test-reports/0/670413a69d3ae9971d804914f52f399c702f6df7/integration_tests__asan__%5B3_4%5D.html)

This PR fixes https://github.com/ClickHouse/ClickHouse/issues/42719#issuecomment-2251565283