### PR TITLE
Move context creation in clickhouse-client and clickhouse-local to separate function

### DIFF
--- a/programs/client/Client.h
+++ b/programs/client/Client.h
@@ -46,6 +46,8 @@ protected:
         std::vector<Arguments> & external_tables_arguments,
         std::vector<Arguments> & hosts_and_ports_arguments) override;
 
+    void createContext() override;
+
 private:
     void printChangedSettings() const;
     void showWarnings();

--- a/programs/local/LocalServer.h
+++ b/programs/local/LocalServer.h
@@ -47,9 +47,12 @@ protected:
                         const std::vector<Arguments> &, const std::vector<Arguments> &) override;
 
     void processConfig() override;
+
     void readArguments(int argc, char ** argv, Arguments & common_arguments, std::vector<Arguments> &, std::vector<Arguments> &) override;
 
     void updateLoggerLevel(const String & logs_level) override;
+
+    void createContext() override;
 
 private:
     /** Composes CREATE subquery based on passed arguments (--structure --file --table and --input-format)
@@ -65,9 +68,8 @@ private:
     void applyCmdOptions(ContextMutablePtr context);
     void applyCmdSettings(ContextMutablePtr context);
 
-    void createClientContext();
-
     ServerSettings server_settings;
+    size_t physical_server_memory;
 
     std::optional<StatusFile> status;
     std::optional<std::filesystem::path> temporary_directory_to_delete;

--- a/src/Client/ClientBase.h
+++ b/src/Client/ClientBase.h
@@ -154,6 +154,8 @@ protected:
         std::vector<Arguments> & external_tables_arguments,
         std::vector<Arguments> & hosts_and_ports_arguments) = 0;
 
+    virtual void createContext() = 0;
+
     void setInsertionTable(const ASTInsertQuery & insert_query);
 
     void addMultiquery(std::string_view query, Arguments & common_arguments) const;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Move context creation in `clickhouse-client` and `clickhouse-local` from `processOption()` / `processConfig()` to separate function `createContext()`. Context creation is not a very small task, so it's better to do it in a separate function without overloading other functions (processing either the command line or the config) with that stuff.

Follow-up to https://github.com/ClickHouse/ClickHouse/pull/67133