### PR TITLE
Faster and less flaky 01246_buffer_flush (by using HTTP over clickhouse-client)

### DIFF
--- a/tests/queries/0_stateless/01246_buffer_flush.sh
+++ b/tests/queries/0_stateless/01246_buffer_flush.sh
@@ -7,6 +7,16 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 set -e
 
+function query()
+{
+    local query_id
+    if [[ $1 == --query_id ]]; then
+        query_id="&query_id=$2"
+        shift 2
+    fi
+    ${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}$query_id" -d "$*"
+}
+
 function wait_until()
 {
     local expr=$1 && shift
@@ -17,73 +27,68 @@ function wait_until()
 function get_buffer_delay()
 {
     local buffer_insert_id=$1 && shift
-    $CLICKHOUSE_CLIENT -nm -q "
-    SYSTEM FLUSH LOGS;
-    WITH
-        (SELECT event_time_microseconds FROM system.query_log WHERE current_database = currentDatabase() AND type = 'QueryStart' AND query_id = '$buffer_insert_id') AS begin_,
-        (SELECT max(event_time) FROM data_01256) AS end_
-    SELECT dateDiff('seconds', begin_, end_)::UInt64;
+    query "SYSTEM FLUSH LOGS"
+    query "
+        WITH
+            (SELECT event_time_microseconds FROM system.query_log WHERE current_database = '$CLICKHOUSE_DATABASE' AND type = 'QueryStart' AND query_id = '$buffer_insert_id') AS begin_,
+            (SELECT max(event_time) FROM data_01256) AS end_
+        SELECT dateDiff('seconds', begin_, end_)::UInt64
     "
 }
 
-$CLICKHOUSE_CLIENT -nm -q "
-    drop table if exists data_01256;
-    drop table if exists buffer_01256;
-
-    create table data_01256 (key UInt64, event_time DateTime(6) MATERIALIZED now64(6)) Engine=Memory();
-"
+query "drop table if exists data_01256"
+query "drop table if exists buffer_01256"
+query "create table data_01256 (key UInt64, event_time DateTime(6) MATERIALIZED now64(6)) Engine=Memory()"
 
 echo "min"
-$CLICKHOUSE_CLIENT -q "
-    create table buffer_01256 (key UInt64) Engine=Buffer(currentDatabase(), data_01256, 1,
+query "
+    create table buffer_01256 (key UInt64) Engine=Buffer($CLICKHOUSE_DATABASE, data_01256, 1,
         2, 100, /* time */
         4, 100, /* rows */
         1, 1e6  /* bytes */
     )
 "
 min_query_id=$(random_str 10)
-$CLICKHOUSE_CLIENT --query_id="$min_query_id" -q "insert into buffer_01256 select * from system.numbers limit 5"
-$CLICKHOUSE_CLIENT -q "select count() from data_01256"
-wait_until '[[ $($CLICKHOUSE_CLIENT -q "select count() from data_01256") -eq 5 ]]'
+query --query_id "$min_query_id" "insert into buffer_01256 select * from system.numbers limit 5"
+query "select count() from data_01256"
+wait_until '[[ $(query "select count() from data_01256") -eq 5 ]]'
 sec=$(get_buffer_delay "$min_query_id")
 [[ $sec -ge 2 ]] || echo "Buffer flushed too early, min_time=2, flushed after $sec sec"
 [[ $sec -lt 100 ]] || echo "Buffer flushed too late, max_time=100, flushed after $sec sec"
-$CLICKHOUSE_CLIENT -q "select count() from data_01256"
-$CLICKHOUSE_CLIENT -q "drop table buffer_01256"
+query "select count() from data_01256"
+query "drop table buffer_01256"
 
 echo "max"
-$CLICKHOUSE_CLIENT -q "
-    create table buffer_01256 (key UInt64) Engine=Buffer(currentDatabase(), data_01256, 1,
+query "
+    create table buffer_01256 (key UInt64) Engine=Buffer($CLICKHOUSE_DATABASE, data_01256, 1,
         100, 2,   /* time */
         0,   100, /* rows */
         0,   1e6  /* bytes */
-    );
+    )
 "
 max_query_id=$(random_str 10)
-$CLICKHOUSE_CLIENT --query_id="$max_query_id" -q "insert into buffer_01256 select * from system.numbers limit 5"
-$CLICKHOUSE_CLIENT -q "select count() from data_01256"
-wait_until '[[ $($CLICKHOUSE_CLIENT -q "select count() from data_01256") -eq 10 ]]'
+query --query_id "$max_query_id" "insert into buffer_01256 select * from system.numbers limit 5"
+query "select count() from data_01256"
+wait_until '[[ $(query "select count() from data_01256") -eq 10 ]]'
 sec=$(get_buffer_delay "$max_query_id")
 [[ $sec -ge 2 ]] || echo "Buffer flushed too early, max_time=2, flushed after $sec sec"
-$CLICKHOUSE_CLIENT -q "select count() from data_01256"
-$CLICKHOUSE_CLIENT -q "drop table buffer_01256"
+query "select count() from data_01256"
+query "drop table buffer_01256"
 
 echo "direct"
-$CLICKHOUSE_CLIENT -nm -q "
-    create table buffer_01256 (key UInt64) Engine=Buffer(currentDatabase(), data_01256, 1,
+query "
+    create table buffer_01256 (key UInt64) Engine=Buffer($CLICKHOUSE_DATABASE, data_01256, 1,
         100, 100, /* time */
         0,   9,   /* rows */
         0,   1e6  /* bytes */
-    );
-    insert into buffer_01256 select * from system.numbers limit 10;
-    select count() from data_01256;
+    )
 "
+query "insert into buffer_01256 select * from system.numbers limit 10"
+query "select count() from data_01256"
 
 echo "drop"
-$CLICKHOUSE_CLIENT -nm -q "
-    insert into buffer_01256 select * from system.numbers limit 10;
-    drop table if exists buffer_01256;
-    select count() from data_01256;
-"
+query "insert into buffer_01256 select * from system.numbers limit 10"
+query "drop table if exists buffer_01256"
+query "select count() from data_01256"
 
-$CLICKHOUSE_CLIENT -q "drop table data_01256"
+query "drop table data_01256"


### PR DESCRIPTION
clickhouse-client is incredibly slow with sanitizers:

This is two subsequent queries, that should be executed one, after another:

    2024.07.27 19:18:49.371354 [ 11070 ] {ywjiyfmvjd} <Debug> executeQuery: (from [::1]:47746) (comment: 01246_buffer_flush.sh) insert into buffer_01256 select * from system.numbers limit 5 (stage: Complete)
    2024.07.27 19:18:49.374647 [ 11070 ] {ywjiyfmvjd} <Debug> TCPHandler: Processed in 0.004721391 sec.

    2024.07.27 19:18:54.293488 [ 11070 ] {30d1f5f7-9594-41e3-9d54-18e1ddfe72af} <Debug> executeQuery: (from [::1]:47782) (comment: 01246_buffer_flush.sh) select count() from data_01256 (stage: Complete)

While the delay is 5 seconds between them!

Refs: https://github.com/ClickHouse/ClickHouse/issues/65745

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Fixes: https://github.com/ClickHouse/ClickHouse/issues/67307 (cc @alexey-milovidov )