### PR TITLE
CI: Print stdout, stderr for docker pull command

### DIFF
--- a/tests/ci/ci_utils.py
+++ b/tests/ci/ci_utils.py
@@ -212,7 +212,7 @@ class Shell:
         return res.stdout.strip()
 
     @classmethod
-    def run(cls, command, check=False, dry_run=False):
+    def run(cls, command, check=False, dry_run=False, **kwargs):
         if dry_run:
             print(f"Dry-ryn. Would run command [{command}]")
             return ""
@@ -225,6 +225,7 @@ class Shell:
             stderr=subprocess.PIPE,
             text=True,
             check=False,
+            **kwargs,
         )
         if result.returncode == 0:
             print(f"stdout: {result.stdout.strip()}")

--- a/tests/ci/docker_images_helper.py
+++ b/tests/ci/docker_images_helper.py
@@ -3,12 +3,12 @@
 import json
 import logging
 import os
-import subprocess
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from env_helper import ROOT_DIR, DOCKER_TAG
 from get_robot_token import get_parameter_from_ssm
+from ci_utils import Shell
 
 IMAGES_FILE_PATH = Path("docker/images.json")
 
@@ -16,20 +16,14 @@ ImagesDict = Dict[str, dict]
 
 
 def docker_login(relogin: bool = True) -> None:
-    if (
-        relogin
-        or subprocess.run(  # pylint: disable=unexpected-keyword-arg
-            "docker system info | grep --quiet -E 'Username|Registry'",
-            shell=True,
-            check=False,
-        ).returncode
-        == 1
+    if relogin or not Shell.check(
+        "docker system info | grep --quiet -E 'Username|Registry'"
     ):
-        subprocess.check_output(  # pylint: disable=unexpected-keyword-arg
+        Shell.run(  # pylint: disable=unexpected-keyword-arg
             "docker login --username 'robotclickhouse' --password-stdin",
             input=get_parameter_from_ssm("dockerhub_robot_password"),
             encoding="utf-8",
-            shell=True,
+            check=True,
         )
 
 
@@ -48,14 +42,10 @@ class DockerImage:
 def pull_image(image: DockerImage) -> DockerImage:
     try:
         logging.info("Pulling image %s - start", image)
-        subprocess.check_output(
-            f"docker pull {image}",
-            stderr=subprocess.STDOUT,
-            shell=True,
-        )
+        Shell.run(f"docker pull {image}", check=True)
         logging.info("Pulling image %s - done", image)
     except Exception as ex:
-        logging.info("Got execption pulling docker %s", ex)
+        logging.info("Got exception pulling docker %s", ex)
         raise ex
     return image
 


### PR DESCRIPTION
Fix for not enough info on docker pull error:
```
INFO:root:Pulling image clickhouse/stateless-test:d303ff4944d2 - start
INFO:root:Got execption pulling docker Command 'docker pull clickhouse/stateless-test:d303ff4944d2' returned non-zero exit status 1.
Traceback (most recent call last):
  File "/home/ubuntu/actions-runner/_work/clickhouse-private/clickhouse-private/tests/ci/functional_test_check.py", line 426, in <module>
    main()
  File "/home/ubuntu/actions-runner/_work/clickhouse-private/clickhouse-private/tests/ci/functional_test_check.py", line 311, in main
    docker_image = pull_image(get_docker_image(image_name))
  File "/home/ubuntu/actions-runner/_work/clickhouse-private/clickhouse-private/tests/ci/docker_images_helper.py", line 59, in pull_image
    raise ex
  File "/home/ubuntu/actions-runner/_work/clickhouse-private/clickhouse-private/tests/ci/docker_images_helper.py", line 51, in pull_image
    subprocess.check_output(
  File "/usr/lib/python3.10/subprocess.py", line 421, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
  File "/usr/lib/python3.10/subprocess.py", line 526, in run
    raise CalledProcessError(retcode, process.args,
```

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
