### PR TITLE
Skip parallel for `test_storage_kerberized_kafka`

### DIFF
--- a/tests/integration/parallel_skip.json
+++ b/tests/integration/parallel_skip.json
@@ -161,5 +161,10 @@
   "test_storage_kafka/test.py::test_system_kafka_consumers_rebalance",
   "test_storage_kafka/test.py::test_system_kafka_consumers_rebalance_mv",
   "test_storage_kafka/test.py::test_formats_errors",
-  "test_storage_kafka/test.py::test_multiple_read_in_materialized_views"
+  "test_storage_kafka/test.py::test_multiple_read_in_materialized_views",
+
+  "test_storage_kerberized_kafka/test.py::test_kafka_json_as_string",
+  "test_storage_kerberized_kafka/test.py::test_kafka_json_as_string_request_new_ticket_after_expiration",
+  "test_storage_kerberized_kafka/test.py::test_kafka_json_as_string_no_kdc",
+  "test_storage_kerberized_kafka/test.py::test_kafka_config_from_sql_named_collection"
 ]


### PR DESCRIPTION
Continues #67315

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
