### PR TITLE
Fix segfault caused by incorrectly detaching from thread group in `Aggregator`

### DIFF
--- a/src/Interpreters/Aggregator.cpp
+++ b/src/Interpreters/Aggregator.cpp
@@ -2997,7 +2997,11 @@ void Aggregator::mergeBlocks(BucketToBlocks bucket_to_blocks, AggregatedDataVari
 
         std::unique_ptr<ThreadPool> thread_pool;
         if (max_threads > 1 && total_input_rows > 100000)    /// TODO Make a custom threshold.
-            thread_pool = std::make_unique<ThreadPool>(CurrentMetrics::AggregatorThreads, CurrentMetrics::AggregatorThreadsActive, CurrentMetrics::AggregatorThreadsScheduled, max_threads);
+            thread_pool = std::make_unique<ThreadPool>(
+                CurrentMetrics::AggregatorThreads,
+                CurrentMetrics::AggregatorThreadsActive,
+                CurrentMetrics::AggregatorThreadsScheduled,
+                max_threads);
 
         for (const auto & bucket_blocks : bucket_to_blocks)
         {
@@ -3009,7 +3013,10 @@ void Aggregator::mergeBlocks(BucketToBlocks bucket_to_blocks, AggregatedDataVari
             result.aggregates_pools.push_back(std::make_shared<Arena>());
             Arena * aggregates_pool = result.aggregates_pools.back().get();
 
-            auto task = [group = CurrentThread::getGroup(), bucket, &merge_bucket, aggregates_pool]{ merge_bucket(bucket, aggregates_pool, group); };
+            /// if we don't use thread pool we don't need to attach and definitely don't want to detach from the thread group
+            /// because this thread is already attached
+            auto task = [group = thread_pool != nullptr ? CurrentThread::getGroup() : nullptr, bucket, &merge_bucket, aggregates_pool]
+            { merge_bucket(bucket, aggregates_pool, group); };
 
             if (thread_pool)
                 thread_pool->scheduleOrThrowOnError(task);


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix segfault caused by incorrectly detaching from thread group in `Aggregator`

Related failure https://s3.amazonaws.com/clickhouse-test-reports/0/e3132c12eee18b87d8b57045bb9d45b68b6683db/stress_test__debug_.html

I tried really hard to reproduce locally but I failed so I'll try to explain as best as possible.

First we check the `Fatal` log:
```
2024.07.28 17:59:31.177684 [ 27432 ] {} <Fatal> BaseDaemon: ########## Short fault info ############
2024.07.28 17:59:31.178745 [ 27432 ] {} <Fatal> BaseDaemon: (version 24.8.1.516 (official build), build id: 17A7B003AE9853F50B6405F1EA79DAFA0AE579BB, git hash: e3132c12eee18b87d8b57045bb9d45b68b6683db) (from thread 3629) Received signal 11
2024.07.28 17:59:31.179880 [ 27432 ] {} <Fatal> BaseDaemon: Signal description: Segmentation fault
2024.07.28 17:59:31.180710 [ 27432 ] {} <Fatal> BaseDaemon: Address: 0x68. Access: read. Address not mapped to object.
2024.07.28 17:59:31.189266 [ 27432 ] {} <Fatal> BaseDaemon: Stack trace: 0x000000000c423ce8 0x000000000c64aa5e 0x00007fcdac8d7520 0x00000000113ec995 0x000000001287ad7e 0x0000000012875d16 0x000000001286c5ae 0x00000000128819b9 0x0000000016099fa7 0x000000001609a47e 0x0000000016046d92 0x0000000016044aa3 0x00007fcdac929ac3 0x00007fcdac9bb850
2024.07.28 17:59:31.190443 [ 27432 ] {} <Fatal> BaseDaemon: ########################################
2024.07.28 17:59:31.192946 [ 27432 ] {} <Fatal> BaseDaemon: (version 24.8.1.516 (official build), build id: 17A7B003AE9853F50B6405F1EA79DAFA0AE579BB, git hash: e3132c12eee18b87d8b57045bb9d45b68b6683db) (from thread 3629) (no query) Received signal Segmentation fault (11)
2024.07.28 17:59:31.195301 [ 27432 ] {} <Fatal> BaseDaemon: Address: 0x68. Access: read. Address not mapped to object.
2024.07.28 17:59:31.195869 [ 27432 ] {} <Fatal> BaseDaemon: Stack trace: 0x000000000c423ce8 0x000000000c64aa5e 0x00007fcdac8d7520 0x00000000113ec995 0x000000001287ad7e 0x0000000012875d16 0x000000001286c5ae 0x00000000128819b9 0x0000000016099fa7 0x000000001609a47e 0x0000000016046d92 0x0000000016044aa3 0x00007fcdac929ac3 0x00007fcdac9bb850
2024.07.28 17:59:31.236408 [ 27432 ] {} <Fatal> BaseDaemon: 0.0. inlined from /build/src/Common/StackTrace.cpp:349: StackTrace::tryCapture()
2024.07.28 17:59:31.238836 [ 27432 ] {} <Fatal> BaseDaemon: 0. /build/src/Common/StackTrace.cpp:318: StackTrace::StackTrace(ucontext_t const&) @ 0x000000000c423ce8
2024.07.28 17:59:31.361120 [ 27432 ] {} <Fatal> BaseDaemon: 1. /build/src/Common/SignalHandlers.cpp:0: signalHandler(int, siginfo_t*, void*) @ 0x000000000c64aa5e
2024.07.28 17:59:31.364033 [ 27432 ] {} <Fatal> BaseDaemon: 2. ? @ 0x00007fcdac8d7520
2024.07.28 17:59:31.411306 [ 27432 ] {} <Fatal> BaseDaemon: 3.0. inlined from /build/contrib/llvm-project/libcxx/include/atomic:958: long std::__cxx_atomic_load[abi:v15007]<long>(std::__cxx_atomic_base_impl<long> const*, std::memory_order)
2024.07.28 17:59:31.415772 [ 27432 ] {} <Fatal> BaseDaemon: 3.1. inlined from /build/contrib/llvm-project/libcxx/include/atomic:1560: std::__atomic_base<long, false>::load[abi:v15007](std::memory_order) const
2024.07.28 17:59:31.416183 [ 27432 ] {} <Fatal> BaseDaemon: 3.2. inlined from /build/src/Common/MemoryTracker.h:122: MemoryTracker::get() const
2024.07.28 17:59:31.416660 [ 27432 ] {} <Fatal> BaseDaemon: 3. /build/src/Interpreters/ProfileEventsExt.cpp:130: ProfileEvents::getProfileEvents(String const&, std::shared_ptr<ConcurrentBoundedQueue<DB::Block>>, DB::Block&, std::unordered_map<unsigned long, ProfileEvents::Counters::Snapshot, std::hash<unsigned long>, std::equal_to<unsigned long>, std::allocator<std::pair<unsigned long const, ProfileEvents::Counters::Snapshot>>>&) @ 0x00000000113ec995
2024.07.28 17:59:31.617690 [ 27432 ] {} <Fatal> BaseDaemon: 4. /build/src/Server/TCPHandler.cpp:0: DB::TCPHandler::sendProfileEvents() @ 0x000000001287ad7e
2024.07.28 17:59:31.778138 [ 27432 ] {} <Fatal> BaseDaemon: 5. /build/src/Server/TCPHandler.cpp:1115: DB::TCPHandler::processOrdinaryQuery() @ 0x0000000012875d16
2024.07.28 17:59:31.913594 [ 27432 ] {} <Fatal> BaseDaemon: 6.0. inlined from /build/src/Server/TCPHandler.cpp:530: operator()
2024.07.28 17:59:31.917283 [ 27432 ] {} <Fatal> BaseDaemon: 6. /build/src/Server/TCPHandler.cpp:0: DB::TCPHandler::runImpl() @ 0x000000001286c5ae
2024.07.28 17:59:32.494669 [ 27432 ] {} <Fatal> BaseDaemon: 7.0. inlined from /build/contrib/llvm-project/libcxx/include/__memory/shared_ptr.h:593: shared_ptr
2024.07.28 17:59:32.495528 [ 27432 ] {} <Fatal> BaseDaemon: 7.1. inlined from /build/src/Common/logger_useful.h:23: impl::getLoggerHelper(std::shared_ptr<Poco::Logger> const&)
2024.07.28 17:59:32.495936 [ 27432 ] {} <Fatal> BaseDaemon: 7. /build/src/Server/TCPHandler.cpp:2381: DB::TCPHandler::run() @ 0x00000000128819b9
2024.07.28 17:59:32.503403 [ 27432 ] {} <Fatal> BaseDaemon: 8. /build/base/poco/Net/src/TCPServerConnection.cpp:57: Poco::Net::TCPServerConnection::start() @ 0x0000000016099fa7
2024.07.28 17:59:32.611028 [ 27432 ] {} <Fatal> BaseDaemon: 9.0. inlined from /build/contrib/llvm-project/libcxx/include/__memory/unique_ptr.h:48: std::default_delete<Poco::Net::TCPServerConnection>::operator()[abi:v15007](Poco::Net::TCPServerConnection*) const
2024.07.28 17:59:32.611472 [ 27432 ] {} <Fatal> BaseDaemon: 9.1. inlined from /build/contrib/llvm-project/libcxx/include/__memory/unique_ptr.h:305: std::unique_ptr<Poco::Net::TCPServerConnection, std::default_delete<Poco::Net::TCPServerConnection>>::reset[abi:v15007](Poco::Net::TCPServerConnection*)
2024.07.28 17:59:32.611774 [ 27432 ] {} <Fatal> BaseDaemon: 9.2. inlined from /build/contrib/llvm-project/libcxx/include/__memory/unique_ptr.h:259: ~unique_ptr
2024.07.28 17:59:32.612073 [ 27432 ] {} <Fatal> BaseDaemon: 9. /build/base/poco/Net/src/TCPServerDispatcher.cpp:116: Poco::Net::TCPServerDispatcher::run() @ 0x000000001609a47e
2024.07.28 17:59:32.623604 [ 27432 ] {} <Fatal> BaseDaemon: 10. /build/base/poco/Foundation/src/ThreadPool.cpp:219: Poco::PooledThread::run() @ 0x0000000016046d92
2024.07.28 17:59:32.705382 [ 27432 ] {} <Fatal> BaseDaemon: 11.0. inlined from /build/base/poco/Foundation/include/Poco/AutoPtr.h:77: AutoPtr
2024.07.28 17:59:32.705736 [ 27432 ] {} <Fatal> BaseDaemon: 11. /build/base/poco/Foundation/src/Thread_POSIX.cpp:332: Poco::ThreadImpl::runnableEntry(void*) @ 0x0000000016044aa3
2024.07.28 17:59:32.706030 [ 27432 ] {} <Fatal> BaseDaemon: 12. ? @ 0x00007fcdac929ac3
2024.07.28 17:59:32.706336 [ 27432 ] {} <Fatal> BaseDaemon: 13. ? @ 0x00007fcdac9bb850
2024.07.28 17:59:33.110430 [ 27432 ] {} <Fatal> BaseDaemon: Integrity check of the executable successfully passed (checksum: 6A9FDDF28B1BAD0CD7E8ED3ACF1A854C)
2024.07.28 17:59:34.491540 [ 27432 ] {} <Fatal> BaseDaemon: Report this error to https://github.com/ClickHouse/ClickHouse/issues
2024.07.28 17:59:38.293840 [ 3620 ] {} <Fatal> Application: Child process was terminated by signal 11.
```

We see that accessing `memory_tracker` from `ThreadGroup` is invalid.
In [gdb.log](https://s3.amazonaws.com/clickhouse-test-reports/0/e3132c12eee18b87d8b57045bb9d45b68b6683db/stress_test__debug_/gdb.log)  we also see that `thread_group` is actually `0x0`.

I checked what was thread doing just before segfault:
https://pastila.nl/?0037130b/eee14dfb906d55c29e39e77547a33c9f#MCtJakaVkDi9RXaSBzdrQQ==

Notice how in the logs after the line with `Aggregator: Merging partially aggregated two-level data.` there is no query id.
So that's how I found the place after which the `thread_group` was lost but I don't know how to verify if the thread pool was not used.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
