### PR TITLE
Fix DWARF range list parsing in stack symbolizer

### DIFF
--- a/src/Common/Dwarf.cpp
+++ b/src/Common/Dwarf.cpp
@@ -1559,8 +1559,7 @@ bool Dwarf::isAddrInRangeList(const CompilationUnit & cu,
                     auto sp_start = addr_.substr(*cu.addr_base + index_start * sizeof(uint64_t));
                     auto start = read<uint64_t>(sp_start);
 
-                    auto sp_end = addr_.substr(*cu.addr_base + index_start * sizeof(uint64_t) + length);
-                    auto end = read<uint64_t>(sp_end);
+                    auto end = start + length;
                     if (start != end && address >= start && address < end)
                     {
                         return true;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

It was decoding one of the many DWARF things incorrectly.

DWARF 5 spec:
```
DW_RLE_startx_length
This is a form of bounded location description that has two unsigned ULEB
operands. The first value is an address index (into the .debug_addr section)
that indicates the beginning of the address range. The second value is the
length of the range.
```