### PR TITLE
Reduced complexity of the test 02832_alter_max_sessions_for_user

### DIFF
--- a/tests/queries/0_stateless/02832_alter_max_sessions_for_user.reference
+++ b/tests/queries/0_stateless/02832_alter_max_sessions_for_user.reference
@@ -1,8 +1,7 @@
-test_alter_profile case: max_session_count 1 alter_sessions_count 1
-test_alter_profile case: max_session_count 2 alter_sessions_count 1
+test_alter_profile case: max_sessions_for_user 1
 USER_SESSION_LIMIT_EXCEEDED
-test_alter_profile case: max_session_count 1 alter_sessions_count 2
-test_alter_profile case: max_session_count 2 alter_sessions_count 2
+test_alter_profile case: max_sessions_for_user 2
+USER_SESSION_LIMIT_EXCEEDED
 READONLY
 READONLY
 READONLY

--- a/tests/queries/0_stateless/02832_alter_max_sessions_for_user.sh
+++ b/tests/queries/0_stateless/02832_alter_max_sessions_for_user.sh
@@ -5,7 +5,6 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CURDIR"/../shell_config.sh
 
-SESSION_ID_PREFIX="02832_alter_max_sessions_session_$$"
 QUERY_ID_PREFIX="02832_alter_max_sessions_query_$$"
 PROFILE="02832_alter_max_sessions_profile_$$"
 USER="02832_alter_max_sessions_user_$$"
@@ -17,48 +16,41 @@ ${CLICKHOUSE_CLIENT} -q $"DROP PROFILE IF EXISTS ${PROFILE}"
 ${CLICKHOUSE_CLIENT} -q $"CREATE SETTINGS PROFILE ${PROFILE}"
 ${CLICKHOUSE_CLIENT} -q $"CREATE USER '${USER}' SETTINGS PROFILE '${PROFILE}'"
 
-function run_sessions_set()
+function wait_for_query_to_start()
 {
-    local sessions_count="$1"
-    local session_check="$2"
-    for ((i = 1 ; i <= ${sessions_count} ; i++)); do
-        local session_id="${SESSION_ID_PREFIX}_${i}"
-        local query_id="${QUERY_ID_PREFIX}_${i}"
-        # Write only expected error text
-        # More than alter_sessions_count queries will not start.
-        ${CLICKHOUSE_CURL} -sS -X POST "${CLICKHOUSE_URL}&user=${USER}&query_id=${query_id}&session_id=${session_id}&session_check=${session_check}&session_timeout=600&function_sleep_max_microseconds_per_block=120000000" --data-binary "SELECT sleep(120)" | grep -o  -m 1 'USER_SESSION_LIMIT_EXCEEDED' &
+    while [[ $($CLICKHOUSE_CLIENT -q "SELECT count() FROM system.processes WHERE query_id = '$1'") == 0 ]]; do sleep 0.2; done
+}
+
+function test_alter_max_sessions_for_user()
+{
+    local max_sessions_for_user="$1"
+    echo $"test_alter_profile case: max_sessions_for_user ${max_sessions_for_user}"
+
+    # Step 0: Set max_sessions_for_user.
+    ${CLICKHOUSE_CLIENT} -q $"ALTER SETTINGS PROFILE ${PROFILE} SETTINGS max_sessions_for_user = ${max_sessions_for_user}"
+
+    # Step 1: Simulaneously run `max_sessions_for_user` queries. These queries should run without any problems.
+    for ((i = 1 ; i <= max_sessions_for_user ; i++)); do
+        local query_id="${QUERY_ID_PREFIX}_${i}_${max_sessions_for_user}"
+        ${CLICKHOUSE_CLIENT} --max_block_size 1 --query_id $query_id --user $USER --function_sleep_max_microseconds_per_block=120000000 -q "SELECT sleepEachRow(0.1) FROM numbers(1200)" &>/dev/null &
+        wait_for_query_to_start $query_id
     done
 
-    for ((i = 1 ; i <= ${sessions_count} ; i++)); do
-        local query_id="${QUERY_ID_PREFIX}_${i}"
-        $CLICKHOUSE_CLIENT --query "KILL QUERY WHERE query_id='$query_id' SYNC" >/dev/null
+    # Step 2: Run another `max_sessions_for_user` + 1 query. That query should fail.
+    local query_id="${QUERY_ID_PREFIX}_should_fail"
+    ${CLICKHOUSE_CLIENT} --query_id $query_id --user $USER -q "SELECT 1" 2>&1 | grep -o -m 1 'USER_SESSION_LIMIT_EXCEEDED'
+    
+    # Step 3: Stop running queries launched at step 1.
+    for ((i = 1 ; i <= max_sessions_for_user ; i++)); do
+        local query_id="${QUERY_ID_PREFIX}_${i}_${max_sessions_for_user}"
+        $CLICKHOUSE_CLIENT --query "KILL QUERY WHERE query_id='$query_id' ASYNC" >/dev/null
     done
 
     wait
 }
 
-function test_alter_profile()
-{
-    local max_session_count="$1"
-    local alter_sessions_count="$2"
-    echo $"test_alter_profile case: max_session_count ${max_session_count} alter_sessions_count ${alter_sessions_count}"
-
-    ${CLICKHOUSE_CLIENT} -q $"ALTER SETTINGS PROFILE ${PROFILE} SETTINGS max_sessions_for_user = ${max_session_count}"
-
-    # Create sessions with $max_session_count restriction
-    run_sessions_set $max_session_count 0
-
-    # Update restriction to $alter_sessions_count
-    ${CLICKHOUSE_CLIENT} -q $"ALTER SETTINGS PROFILE ${PROFILE} SETTINGS max_sessions_for_user = ${alter_sessions_count}"
-
-    # Simultaneous sessions should use max settings from profile ($alter_sessions_count)
-    run_sessions_set $max_session_count 1
-}
-
-test_alter_profile 1 1
-test_alter_profile 2 1
-test_alter_profile 1 2
-test_alter_profile 2 2
+test_alter_max_sessions_for_user 1
+test_alter_max_sessions_for_user 2
 
 ${CLICKHOUSE_CLIENT} -q "SELECT 1 SETTINGS max_sessions_for_user = 1" 2>&1 | grep -m 1 -o 'READONLY' | head -1
 ${CLICKHOUSE_CLIENT} -q $"SET max_sessions_for_user = 1 " 2>&1 | grep -o  -m 1 'READONLY' | head -1


### PR DESCRIPTION
Related to: https://github.com/ClickHouse/ClickHouse/issues/65078

This PR does:
1) Removes mixing CURL and native client queries; now only native client is used.
2) Reduces count of checks and reduces the time required for the test.
3) Adds waiting before query starts.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

