### PR TITLE
Startup scripts: additional testing

### DIFF
--- a/tests/integration/test_startup_scripts/configs/config.d/startup_scripts1.xml
+++ b/tests/integration/test_startup_scripts/configs/config.d/startup_scripts1.xml
@@ -1,0 +1,27 @@
+<clickhouse>
+    <startup_scripts>
+        <scripts>
+            <query>CREATE ROLE OR REPLACE testrole</query>
+        </scripts>
+        <scripts>
+            <query>GRANT CREATE USER, ALTER USER, DROP USER, SHOW USERS, SHOW CREATE USER ON *.* TO 'testrole' WITH GRANT OPTION;</query>
+        </scripts>
+        <scripts>
+            <query>CREATE TABLE TestTable_1 (id UInt64) ENGINE=TinyLog</query>
+        </scripts>
+        <scripts>
+            <query>CREATE TABLE TestTable_2 (id UInt64) ENGINE=TinyLog</query>
+            <condition>SELECT 1;</condition>
+        </scripts>
+        <scripts>
+            <query>CREATE TABLE TestTable_3 (id UInt64) ENGINE=TinyLog</query>
+            <condition>SELECT 0 /* false condition */;</condition>
+        </scripts>
+        <scripts>
+            <query>CREATE TABLE TestTable_4 (id UInt64) ENGINE=TinyLog</query>
+        </scripts>
+        <scripts>
+            <query>SELECT * FROM system.query_log LIMIT 1</query>
+        </scripts>
+    </startup_scripts>
+</clickhouse>

--- a/tests/integration/test_startup_scripts/configs/config.d/startup_scripts2.xml
+++ b/tests/integration/test_startup_scripts/configs/config.d/startup_scripts2.xml
@@ -1,0 +1,20 @@
+<clickhouse>
+    <startup_scripts>
+        <scripts>
+            <query>CREATE ROLE OR REPLACE testrole</query>
+        </scripts>
+        <scripts>
+            <query>GRANT CREATE USER, ALTER USER, DROP USER, SHOW USERS, SHOW CREATE USER ON *.* TO 'testrole' WITH GRANT OPTION;</query>
+        </scripts>
+        <scripts>
+            <query>CREATE TABLE TestTable_1 (id UInt64) ENGINE=TinyLog</query>
+        </scripts>
+        <scripts>
+            <query>CREATE TABLE TestTable_2 (id UInt64) ENGINE=TinyLog</query>
+            <condition>SELECT throwIf(1, 'exception condition')</condition>
+        </scripts>
+        <scripts>
+            <query>CREATE TABLE TestTable_3 (id UInt64) ENGINE=TinyLog</query>
+        </scripts>
+    </startup_scripts>
+</clickhouse>

--- a/tests/integration/test_startup_scripts/configs/config.d/startup_scripts3.xml
+++ b/tests/integration/test_startup_scripts/configs/config.d/startup_scripts3.xml
@@ -1,0 +1,16 @@
+<clickhouse>
+    <startup_scripts>
+        <scripts>
+            <query>CREATE ROLE OR REPLACE testrole</query>
+        </scripts>
+        <scripts>
+            <query>GRANT CREATE USER, ALTER USER, DROP USER, SHOW USERS, SHOW CREATE USER ON *.* TO 'testrole' WITH GRANT OPTION;</query>
+        </scripts>
+        <scripts>
+            <query>SELECT throwIf(1, 'exception condition')</query>
+        </scripts>
+        <scripts>
+            <query>CREATE TABLE TestTable_1 (id UInt64) ENGINE=TinyLog</query>
+        </scripts>
+    </startup_scripts>
+</clickhouse>

--- a/tests/integration/test_startup_scripts/configs/config.d/startup_scripts4.xml
+++ b/tests/integration/test_startup_scripts/configs/config.d/startup_scripts4.xml
@@ -7,11 +7,11 @@
             <query>GRANT CREATE USER, ALTER USER, DROP USER, SHOW USERS, SHOW CREATE USER ON *.* TO 'testrole' WITH GRANT OPTION;</query>
         </scripts>
         <scripts>
-            <query>CREATE TABLE TestTable (id UInt64) ENGINE=TinyLog</query>
-            <condition>SELECT 1;</condition>
+            <query>SELECT throwIf(1, 'exception condition')</query>
+            <condition>SELECT throwIf(1, 'exception condition')</condition>
         </scripts>
         <scripts>
-            <query>SELECT * FROM system.query_log LIMIT 1</query>
+            <query>CREATE TABLE TestTable_1 (id UInt64) ENGINE=TinyLog</query>
         </scripts>
     </startup_scripts>
 </clickhouse>

--- a/tests/integration/test_startup_scripts/configs/config.d/startup_scripts5.xml
+++ b/tests/integration/test_startup_scripts/configs/config.d/startup_scripts5.xml
@@ -1,0 +1,4 @@
+<clickhouse>
+    <startup_scripts>
+    </startup_scripts>
+</clickhouse>

--- a/tests/integration/test_startup_scripts/configs/config.d/startup_scripts6_1.xml
+++ b/tests/integration/test_startup_scripts/configs/config.d/startup_scripts6_1.xml
@@ -1,0 +1,20 @@
+<clickhouse>
+    <startup_scripts>
+        <scripts>
+            <query>CREATE TABLE TestTable_1 (id UInt64) ENGINE=TinyLog</query>
+        </scripts>
+        <scripts>
+            <query>CREATE TABLE TestTable_2 (id UInt64) ENGINE=TinyLog</query>
+            <condition>SELECT 1;</condition>
+        </scripts>
+    </startup_scripts>
+    <startup_scripts>
+        <scripts>
+            <query>CREATE TABLE TestTable_3 (id UInt64) ENGINE=TinyLog</query>
+        </scripts>
+        <scripts>
+            <query>CREATE TABLE TestTable_4 (id UInt64) ENGINE=TinyLog</query>
+            <condition>SELECT 1;</condition>
+        </scripts>
+    </startup_scripts>
+</clickhouse>

--- a/tests/integration/test_startup_scripts/configs/config.d/startup_scripts6_2.xml
+++ b/tests/integration/test_startup_scripts/configs/config.d/startup_scripts6_2.xml
@@ -1,0 +1,11 @@
+<clickhouse>
+    <startup_scripts>
+        <scripts>
+            <query>CREATE TABLE TestTable_5 (id UInt64) ENGINE=TinyLog</query>
+        </scripts>
+        <scripts>
+            <query>CREATE TABLE TestTable_6 (id UInt64) ENGINE=TinyLog</query>
+            <condition>SELECT 1;</condition>
+        </scripts>
+    </startup_scripts>
+</clickhouse>

--- a/tests/integration/test_startup_scripts/test.py
+++ b/tests/integration/test_startup_scripts/test.py
@@ -1,21 +1,100 @@
+import pytest
+
 from helpers.cluster import ClickHouseCluster
 
+cluster = ClickHouseCluster(__file__)
 
-def test_startup_scripts():
-    cluster = ClickHouseCluster(__file__)
+node = cluster.add_instance(
+    "node1",
+    main_configs=[
+        "configs/config.d/query_log.xml",
+        "configs/config.d/startup_scripts1.xml",
+    ],
+    with_zookeeper=False,
+)
 
-    node = cluster.add_instance(
-        "node",
-        main_configs=[
-            "configs/config.d/query_log.xml",
-            "configs/config.d/startup_scripts.xml",
-        ],
-        with_zookeeper=False,
+node2 = cluster.add_instance(
+    "node2",
+    main_configs=[
+        "configs/config.d/query_log.xml",
+        "configs/config.d/startup_scripts2.xml",
+    ],
+    with_zookeeper=False,
+)
+
+node3 = cluster.add_instance(
+    "node3",
+    main_configs=[
+        "configs/config.d/query_log.xml",
+        "configs/config.d/startup_scripts3.xml",
+    ],
+    with_zookeeper=False,
+)
+
+node4 = cluster.add_instance(
+    "node4",
+    main_configs=[
+        "configs/config.d/query_log.xml",
+        "configs/config.d/startup_scripts4.xml",
+    ],
+    with_zookeeper=False,
+)
+node5 = cluster.add_instance(
+    "node5",
+    main_configs=[
+        "configs/config.d/query_log.xml",
+        "configs/config.d/startup_scripts5.xml",
+    ],
+    with_zookeeper=False,
+)
+node6 = cluster.add_instance(
+    "node6",
+    main_configs=[
+        "configs/config.d/query_log.xml",
+        "configs/config.d/startup_scripts6_1.xml",
+        "configs/config.d/startup_scripts6_2.xml",
+    ],
+    with_zookeeper=False,
+)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def start_cluster():
+    cluster.start()
+    yield cluster
+    cluster.shutdown()
+
+
+def test_startup_scripts_1():
+    # no exceptions
+    assert node.query("SHOW TABLES") == "TestTable_1\nTestTable_2\nTestTable_4\n"
+
+
+def test_startup_scripts_2():
+    # exception in condition
+    assert node2.query("SHOW TABLES") == "TestTable_1\nTestTable_3\n"
+
+
+def test_startup_scripts_3():
+    # exception in query
+    assert node3.query("SHOW TABLES") == "TestTable_1\n"
+
+
+def test_startup_scripts_4():
+    # exception in condition and query
+    assert node4.query("SHOW TABLES") == "TestTable_1\n"
+
+
+def test_startup_scripts_5():
+    # empty startup_scripts
+    assert node5.query("SHOW TABLES") == ""
+
+
+def test_startup_scripts_6():
+    # two <startup_scripts> sections and two files
+    # result:
+    # 'TestTable_5\nTestTable_6\n'
+    assert (
+        node6.query("SHOW TABLES")
+        == "TestTable_1\nTestTable_2\nTestTable_3\nTestTable_4\nTestTable_5\nTestTable_6\n"
     )
-
-    try:
-        cluster.start()
-        assert node.query("SHOW TABLES") == "TestTable\n"
-
-    finally:
-        cluster.shutdown()


### PR DESCRIPTION
Add tests for https://github.com/ClickHouse/ClickHouse/pull/64889

Some bugs found:
Based on the documentation, I expect that if a query or condition fails, it should not interrupt the following queries.
https://github.com/ClickHouse/ClickHouse/pull/64889/files#diff-d2e747ae0a36585e0d9cc9aac704cf3068b600dcc63a9baff4d6c0281c1d38faR24

**test_startup_scripts_2**
If exception is thrown in condition, this query and following queries are not executed.
```
FAILED test_startup_scripts/test.py::test_startup_scripts_2 - AssertionError: assert 'TestTable_1\n' == 'TestTable_1\nTestTable_3\n'
  
    TestTable_1
  - TestTable_3
```
**test_startup_scripts_3**
If exception is thrown in script, this query and following queries are not executed.
```
FAILED test_startup_scripts/test.py::test_startup_scripts_3 - AssertionError: assert '' == 'TestTable_1\n'
  
  - TestTable_1
```

**test_startup_scripts_4**
Same as above but exception in both script and query
```
FAILED test_startup_scripts/test.py::test_startup_scripts_4 - AssertionError: assert '' == 'TestTable_1\n'
  
  - TestTable_1
```

**test_startup_scripts_6**
In cases where we have two separate config files with `<startup_scripts>` sections, I expect both of them to be executed in any order. However, currently only the last one is being executed.
```
FAILED test_startup_scripts/test.py::test_startup_scripts_6 - AssertionError: assert 'TestTable_5\nTestTable_6\n' == 'TestTable_1\nTestTable_2\nTestTable_3\nTestTable_4\n'
  
Only last config ix executed:
'TestTable_5\nTestTable_6\n'
```

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [x] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [x] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
