### PR TITLE
[Docs] Building integration tests runner docker image for a local testing

### DIFF
--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -137,7 +137,7 @@ cd docker/test/integration/runner
 docker build -t clickhouse/integration-test-runner .
 ```
 
-Also you need to add option --network=host if you rebuild image for a local integration testsing.
+If your docker configuration doesn't allow access to public internet with docker build command you may also need to add option --network=host if you rebuild image for a local integration testsing.
 
 ### Adding new tests
 

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -130,6 +130,14 @@ docker build -t clickhouse/integration-test .
 ```
 
 The helper container used by the `runner` script is in `docker/test/integration/runner/Dockerfile`.
+It can be rebuild with 
+
+```
+cd docker/test/integration/runner
+docker build -t clickhouse/integration-test-runner .
+```
+
+Also you need to add option --network=host if you rebuild image for a local integration testsing.
 
 ### Adding new tests
 


### PR DESCRIPTION
### Changelog category:
- Documentation (changelog entry is not required)

### Changelog entry:
Add more tips how to rebuild docker image for integration test runner when launching integration tests locally

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
