### PR TITLE
[Green CI] Fix WriteBuffer destructor when finalize has failed for MergeTreeDeduplicationLog::shutdown

### DIFF
--- a/src/Storages/MergeTree/MergeTreeDeduplicationLog.cpp
+++ b/src/Storages/MergeTree/MergeTreeDeduplicationLog.cpp
@@ -341,15 +341,19 @@ void MergeTreeDeduplicationLog::shutdown()
     stopped = true;
     if (current_writer)
     {
+        /// If an error has occurred during finalize, we'd like to have the exception set for reset.
+        /// Otherwise, we'll be in a situation when a finalization didn't happen, and we didn't get
+        /// any error, causing logical error (see ~MemoryBuffer()).
         try
         {
             current_writer->finalize();
+            current_writer.reset();
         }
         catch (...)
         {
             tryLogCurrentException(__PRETTY_FUNCTION__);
+            current_writer.reset();
         }
-        current_writer.reset();
     }
 }
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

This change addresses a following issue:
* `current_writer->finalize()` is called from `MergeTreeDeduplicationLog::shutdown()`
* the call ends up in `WriteBufferFromS3::preFinalize()`
* `preFinalize()` invokes `makeSinglepartUpload()` (not necessarily, but as an example)
* the task is added to the queue
* scheduling failed for some reason (e.g. fault injected)
* the call to `current_writer->finalize()` has failed, finalization of a buffer wasn't finished and the flag `finalized` was not set in `WriteBuffer`
* exception is caught in `MergeTreeDeduplicationLog::shutdown()`, then logged
* `current_writer.reset()` is called, which leads to calling the destructor for `WriteBuffer`, but since the exception is not set, it's treated as finalization wasn't finished, but no error occurred, which leads to a logical error

Fixes #64297
