### PR TITLE
Disable parallel run for `01923_network_receive_time_metric_insert.sh`

### DIFF
--- a/tests/queries/0_stateless/01923_network_receive_time_metric_insert.sh
+++ b/tests/queries/0_stateless/01923_network_receive_time_metric_insert.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest
+# Tags: no-fasttest, no-parallel
 # Tag no-fasttest: needs pv
+# Tag no-parallel: reads from a system table
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/01923_network_receive_time_metric_insert.sh
+++ b/tests/queries/0_stateless/01923_network_receive_time_metric_insert.sh
@@ -13,9 +13,23 @@ ${CLICKHOUSE_CLIENT} --query "DROP TABLE IF EXISTS t; CREATE TABLE t (x UInt64) 
 seq 1 1000 | pv --quiet --rate-limit 400 | ${CLICKHOUSE_CLIENT} --query "INSERT INTO t FORMAT TSV"
 
 # We check that the value of NetworkReceiveElapsedMicroseconds correctly includes the time spent waiting data from the client.
-${CLICKHOUSE_CLIENT} --query "SYSTEM FLUSH LOGS;
-    WITH ProfileEvents['NetworkReceiveElapsedMicroseconds'] AS time
-    SELECT time >= 1000000 ? 1 : time FROM system.query_log
-        WHERE current_database = currentDatabase() AND query_kind = 'Insert' AND event_date >= yesterday() AND type = 2 ORDER BY event_time DESC LIMIT 1;"
+result=$(${CLICKHOUSE_CLIENT} --query "SYSTEM FLUSH LOGS;
+    WITH ProfileEvents['NetworkReceiveElapsedMicroseconds'] AS elapsed_us
+    SELECT elapsed_us FROM system.query_log
+    WHERE current_database = currentDatabase() AND query_kind = 'Insert' AND event_date >= yesterday() AND type = 'QueryFinish'
+    ORDER BY event_time DESC LIMIT 1;")
+
+elapsed_us=$(echo $result | sed 's/ .*//')
+
+min_elapsed_us=1000000
+if [[ "$elapsed_us" -ge "$min_elapsed_us" ]]; then
+    echo 1
+else
+    # Print debug info
+    ${CLICKHOUSE_CLIENT} --query "
+    WITH ProfileEvents['NetworkReceiveElapsedMicroseconds'] AS elapsed_us
+    SELECT query_start_time_microseconds, event_time_microseconds, query_duration_ms, elapsed_us, query FROM system.query_log
+    WHERE current_database = currentDatabase() and event_date >= yesterday() AND type = 'QueryFinish' ORDER BY query_start_time;"
+fi
 
 ${CLICKHOUSE_CLIENT} --query "DROP TABLE t"


### PR DESCRIPTION
#67432 

If run in parallel, several tests contribute to the value of the `NetworkReceiveElapsedMicroseconds` profile event. This may lead to flakiness because the query log merely flushes the difference between two snapshots regardless of which query has contributed. 

Another reason for flakiness may be the time difference between the input stream creation and the start of the insert (described in https://github.com/ClickHouse/ClickHouse/issues/66921). I'd like to try disabling parallel runs before decreasing the rate.

https://s3.amazonaws.com/clickhouse-test-reports/0/ef51c94a92b668666c49e2178b3def018b7f4d4f/stateless_tests__msan__%5B2_4%5D.html

```
% grep 01923_network_receive_time_metric_insert.sh  ~/Downloads/clickhouse-server\ \(27\).log
2024.07.30 04:17:26.091186 [ 6569 ] {} <Trace> DynamicQueryHandler: Request URI: /?query=SELECT+%27Running+test+stateless%2F01923_network_receive_time_metric_insert.sh+from+pid%3D2163%27&database=system&connect_timeout=30&receive_timeout=30&send_timeout=30&http_connection_timeout=30&http_receive_timeout=30&http_send_timeout=30&output_format_parallel_formatting=0
2024.07.30 04:17:26.107919 [ 6569 ] {c0a40da8-cd1a-449b-b90e-8d343b1836df} <Debug> executeQuery: (from [::1]:53658) SELECT 'Running test stateless/01923_network_receive_time_metric_insert.sh from pid=2163'  (stage: Complete)
2024.07.30 04:17:26.138972 [ 6579 ] {} <Trace> DynamicQueryHandler: Request URI: /?query=CREATE+DATABASE+IF+NOT+EXISTS+test_81xbjfo7&database=system&connect_timeout=30&receive_timeout=30&send_timeout=30&http_connection_timeout=30&http_receive_timeout=30&http_send_timeout=30&output_format_parallel_formatting=0&log_comment=01923_network_receive_time_metric_insert.sh
2024.07.30 04:17:26.152159 [ 6579 ] {5bdf58c4-dd1d-425b-966f-c736b98f8f57} <Debug> executeQuery: (from [::1]:53664) (comment: 01923_network_receive_time_metric_insert.sh) CREATE DATABASE IF NOT EXISTS test_81xbjfo7  (stage: Complete)
2024.07.30 04:17:30.475298 [ 6982 ] {a6136972-a6fe-4c26-a4ae-cf2eb71a404f} <Debug> executeQuery: (from [::1]:51988) (comment: 01923_network_receive_time_metric_insert.sh) DROP TABLE IF EXISTS t; (stage: Complete)
2024.07.30 04:17:30.615294 [ 6982 ] {9d1f8bd8-fd39-47fa-94af-349389389721} <Debug> executeQuery: (from [::1]:51988) (comment: 01923_network_receive_time_metric_insert.sh) CREATE TABLE t (x UInt64) ENGINE = Memory; (stage: Complete)
2024.07.30 04:17:43.807880 [ 7628 ] {054c016e-8395-41c7-9594-0540eb6d2399} <Debug> executeQuery: (from [::1]:51320) (comment: 01923_network_receive_time_metric_insert.sh) INSERT INTO t FORMAT TSV (stage: Complete)
2024.07.30 04:17:45.502056 [ 7538 ] {269911d8-75c3-4321-ad0b-d3b42bf2d870} <Debug> executeQuery: (from [::1]:51460) (comment: 01923_network_receive_time_metric_insert.sh) SYSTEM FLUSH LOGS; (stage: Complete)
2024.07.30 04:17:54.851304 [ 7538 ] {aa4f8752-7578-4360-b8ef-587a270ca235} <Debug> executeQuery: (from [::1]:51460) (comment: 01923_network_receive_time_metric_insert.sh) WITH ProfileEvents['NetworkReceiveElapsedMicroseconds'] AS time SELECT time >= 1000000 ? 1 : time FROM system.query_log WHERE current_database = currentDatabase() AND query_kind = 'Insert' AND event_date >= yesterday() AND type = 2 ORDER BY event_time DESC LIMIT 1; (stage: Complete)
2024.07.30 04:17:56.046744 [ 6676 ] {b5d0ee4d-9f6a-479f-9770-6422e73cd53b} <Debug> executeQuery: (from [::1]:38038) (comment: 01923_network_receive_time_metric_insert.sh) DROP TABLE t (stage: Complete)
```
(The time difference between the beginning of table creation and the beginning of inserts is `13s`)
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
