### PR TITLE
Fix test test_backup_restore_on_cluster/test.py::test_mutation

### DIFF
--- a/tests/integration/test_backup_restore_on_cluster/test.py
+++ b/tests/integration/test_backup_restore_on_cluster/test.py
@@ -1054,9 +1054,12 @@ def test_mutation():
     backup_name = new_backup_name()
     node1.query(f"BACKUP TABLE tbl ON CLUSTER 'cluster' TO {backup_name}")
 
-    assert not has_mutation_in_backup("0000000000", backup_name, "default", "tbl")
+    # mutation #0000000000: "UPDATE x=x+1 WHERE 1" could already finish before starting the backup
+    # mutation #0000000001: "UPDATE x=x+1+sleep(3) WHERE 1"
     assert has_mutation_in_backup("0000000001", backup_name, "default", "tbl")
+    # mutation #0000000002: "UPDATE x=x+1+sleep(3) WHERE 1"
     assert has_mutation_in_backup("0000000002", backup_name, "default", "tbl")
+    # mutation #0000000003: not expected
     assert not has_mutation_in_backup("0000000003", backup_name, "default", "tbl")
 
     node1.query("DROP TABLE tbl ON CLUSTER 'cluster' SYNC")


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix test `test_backup_restore_on_cluster/test.py::test_mutation`.

Example of failure: https://s3.amazonaws.com/clickhouse-test-reports/0/a9ceb0c49c996f28b9b45f5bdb2162cadcfb8c51/integration_tests__aarch64__%5B5_6%5D.html

This PR closes https://github.com/ClickHouse/ClickHouse/issues/67465
