### PR TITLE
Fix test_zookeeper_config_load_balancing after adding the xdist worker name to the instance

### DIFF
--- a/tests/integration/test_zookeeper_config_load_balancing/test.py
+++ b/tests/integration/test_zookeeper_config_load_balancing/test.py
@@ -71,7 +71,7 @@ def test_first_or_random(started_cluster):
                     [
                         "bash",
                         "-c",
-                        "lsof -a -i4 -i6 -itcp -w | grep 'testzookeeperconfigloadbalancing_zoo1_1.*testzookeeperconfigloadbalancing_default:2181' | grep ESTABLISHED | wc -l",
+                        "lsof -a -i4 -i6 -itcp -w | grep -P 'testzookeeperconfigloadbalancing_(gw\\d+_)?zoo1_1.*testzookeeperconfigloadbalancing_(gw\\d+_)?default:2181' | grep ESTABLISHED | wc -l",
                     ],
                     privileged=True,
                     user="root",
@@ -99,7 +99,7 @@ def test_first_or_random(started_cluster):
                     [
                         "bash",
                         "-c",
-                        "lsof -a -i4 -i6 -itcp -w | grep 'testzookeeperconfigloadbalancing_zoo1_1.*testzookeeperconfigloadbalancing_default:2181' | grep ESTABLISHED | wc -l",
+                        "lsof -a -i4 -i6 -itcp -w | grep -P 'testzookeeperconfigloadbalancing_(gw\\d+_)?zoo1_1.*testzookeeperconfigloadbalancing_(gw\\d+_)?default:2181' | grep ESTABLISHED | wc -l",
                     ],
                     privileged=True,
                     user="root",
@@ -127,7 +127,7 @@ def test_first_or_random(started_cluster):
                     [
                         "bash",
                         "-c",
-                        "lsof -a -i4 -i6 -itcp -w | grep 'testzookeeperconfigloadbalancing_zoo1_1.*testzookeeperconfigloadbalancing_default:2181' | grep ESTABLISHED | wc -l",
+                        "lsof -a -i4 -i6 -itcp -w | grep -P 'testzookeeperconfigloadbalancing_(gw\\d+_)?zoo1_1.*testzookeeperconfigloadbalancing_(gw\\d+_)?default:2181' | grep ESTABLISHED | wc -l",
                     ],
                     privileged=True,
                     user="root",
@@ -161,7 +161,7 @@ def test_in_order(started_cluster):
                     [
                         "bash",
                         "-c",
-                        "lsof -a -i4 -i6 -itcp -w | grep 'testzookeeperconfigloadbalancing_zoo1_1.*testzookeeperconfigloadbalancing_default:2181' | grep ESTABLISHED | wc -l",
+                        "lsof -a -i4 -i6 -itcp -w | grep -P 'testzookeeperconfigloadbalancing_(gw\\d+_)?zoo1_1.*testzookeeperconfigloadbalancing_(gw\\d+_)?default:2181' | grep ESTABLISHED | wc -l",
                     ],
                     privileged=True,
                     user="root",
@@ -189,7 +189,7 @@ def test_in_order(started_cluster):
                     [
                         "bash",
                         "-c",
-                        "lsof -a -i4 -i6 -itcp -w | grep 'testzookeeperconfigloadbalancing_zoo1_1.*testzookeeperconfigloadbalancing_default:2181' | grep ESTABLISHED | wc -l",
+                        "lsof -a -i4 -i6 -itcp -w | grep -P 'testzookeeperconfigloadbalancing_(gw\\d+_)?zoo1_1.*testzookeeperconfigloadbalancing_(gw\\d+_)?default:2181' | grep ESTABLISHED | wc -l",
                     ],
                     privileged=True,
                     user="root",
@@ -217,7 +217,7 @@ def test_in_order(started_cluster):
                     [
                         "bash",
                         "-c",
-                        "lsof -a -i4 -i6 -itcp -w | grep 'testzookeeperconfigloadbalancing_zoo1_1.*testzookeeperconfigloadbalancing_default:2181' | grep ESTABLISHED | wc -l",
+                        "lsof -a -i4 -i6 -itcp -w | grep -P 'testzookeeperconfigloadbalancing_(gw\\d+_)?zoo1_1.*testzookeeperconfigloadbalancing_(gw\\d+_)?default:2181' | grep ESTABLISHED | wc -l",
                     ],
                     privileged=True,
                     user="root",
@@ -251,7 +251,7 @@ def test_nearest_hostname(started_cluster):
                     [
                         "bash",
                         "-c",
-                        "lsof -a -i4 -i6 -itcp -w | grep 'testzookeeperconfigloadbalancing_zoo1_1.*testzookeeperconfigloadbalancing_default:2181' | grep ESTABLISHED | wc -l",
+                        "lsof -a -i4 -i6 -itcp -w | grep -P 'testzookeeperconfigloadbalancing_(gw\\d+_)?zoo1_1.*testzookeeperconfigloadbalancing_(gw\\d+_)?default:2181' | grep ESTABLISHED | wc -l",
                     ],
                     privileged=True,
                     user="root",
@@ -279,7 +279,7 @@ def test_nearest_hostname(started_cluster):
                     [
                         "bash",
                         "-c",
-                        "lsof -a -i4 -i6 -itcp -w | grep 'testzookeeperconfigloadbalancing_zoo2_1.*testzookeeperconfigloadbalancing_default:2181' | grep ESTABLISHED | wc -l",
+                        "lsof -a -i4 -i6 -itcp -w | grep -P 'testzookeeperconfigloadbalancing_(gw\\d+_)?zoo2_1.*testzookeeperconfigloadbalancing_(gw\\d+_)?default:2181' | grep ESTABLISHED | wc -l",
                     ],
                     privileged=True,
                     user="root",
@@ -307,7 +307,7 @@ def test_nearest_hostname(started_cluster):
                     [
                         "bash",
                         "-c",
-                        "lsof -a -i4 -i6 -itcp -w | grep 'testzookeeperconfigloadbalancing_zoo3_1.*testzookeeperconfigloadbalancing_default:2181' | grep ESTABLISHED | wc -l",
+                        "lsof -a -i4 -i6 -itcp -w | grep -P 'testzookeeperconfigloadbalancing_(gw\\d+_)?zoo3_1.*testzookeeperconfigloadbalancing_(gw\\d+_)?default:2181' | grep ESTABLISHED | wc -l",
                     ],
                     privileged=True,
                     user="root",
@@ -341,7 +341,7 @@ def test_hostname_levenshtein_distance(started_cluster):
                     [
                         "bash",
                         "-c",
-                        "lsof -a -i4 -i6 -itcp -w | grep 'testzookeeperconfigloadbalancing_zoo1_1.*testzookeeperconfigloadbalancing_default:2181' | grep ESTABLISHED | wc -l",
+                        "lsof -a -i4 -i6 -itcp -w | grep -P 'testzookeeperconfigloadbalancing_(gw\\d+_)?zoo1_1.*testzookeeperconfigloadbalancing_(gw\\d+_)?default:2181' | grep ESTABLISHED | wc -l",
                     ],
                     privileged=True,
                     user="root",
@@ -369,7 +369,7 @@ def test_hostname_levenshtein_distance(started_cluster):
                     [
                         "bash",
                         "-c",
-                        "lsof -a -i4 -i6 -itcp -w | grep 'testzookeeperconfigloadbalancing_zoo2_1.*testzookeeperconfigloadbalancing_default:2181' | grep ESTABLISHED | wc -l",
+                        "lsof -a -i4 -i6 -itcp -w | grep -P 'testzookeeperconfigloadbalancing_(gw\\d+_)?zoo2_1.*testzookeeperconfigloadbalancing_(gw\\d+_)?default:2181' | grep ESTABLISHED | wc -l",
                     ],
                     privileged=True,
                     user="root",
@@ -397,7 +397,7 @@ def test_hostname_levenshtein_distance(started_cluster):
                     [
                         "bash",
                         "-c",
-                        "lsof -a -i4 -i6 -itcp -w | grep 'testzookeeperconfigloadbalancing_zoo3_1.*testzookeeperconfigloadbalancing_default:2181' | grep ESTABLISHED | wc -l",
+                        "lsof -a -i4 -i6 -itcp -w | grep -P 'testzookeeperconfigloadbalancing_(gw\\d+_)?zoo3_1.*testzookeeperconfigloadbalancing_(gw\\d+_)?default:2181' | grep ESTABLISHED | wc -l",
                     ],
                     privileged=True,
                     user="root",


### PR DESCRIPTION
Fix `test_zookeeper_config_load_balancing` after the changes in https://github.com/ClickHouse/ClickHouse/pull/67035

That PR added the `PYTEST_XDIST_WORKER` to both the `project_name` and the `instance_dir_name`. Since that's used in a regex in `test_zookeeper_config_load_balancing`, we need to consider that the `_gw0` (or whatever number) may be present.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)