### PR TITLE
Fix `Logical error: 'file_offset_of_buffer_end <= read_until_position'` in fs cache

### DIFF
--- a/src/Interpreters/Cache/FileCache.cpp
+++ b/src/Interpreters/Cache/FileCache.cpp
@@ -318,7 +318,29 @@ FileSegments FileCache::getImpl(const LockedKey & locked_key, const FileSegment:
 
 std::vector<FileSegment::Range> FileCache::splitRange(size_t offset, size_t size, size_t aligned_size)
 {
-    assert(size > 0);
+    chassert(size > 0);
+    chassert(size <= aligned_size);
+
+    /// Consider this example to understand why we need to account here for both `size` and `aligned_size`.
+    /// [________________]__________________] <-- requested range
+    ///                  ^                  ^
+    ///                right offset         aligned_right_offset
+    /// [_________]                           <-- last cached file segment, e.g. we have uncovered suffix of the requested range
+    /// [________________]
+    ///        size
+    /// [____________________________________]
+    ///        aligned_size
+    ///
+    /// So it is possible that we split this hole range into sub-segments by `max_file_segment_size`
+    /// and get something like this:
+    ///
+    /// [________________________]
+    ///                  ^             ^
+    ///              right_offset   right_offset + max_file_segment_size
+    /// e.g. there is no need to create sub-segment for range (right_offset + max_file_segment_size, aligned_right_offset].
+    /// Because its left offset would be bigger than right_offset.
+    /// Therefore, we set end_pos_non_included as offset+size, but remaining_size as aligned_size.
+
     std::vector<FileSegment::Range> ranges;
 
     size_t current_pos = offset;
@@ -339,42 +361,23 @@ std::vector<FileSegment::Range> FileCache::splitRange(size_t offset, size_t size
     return ranges;
 }
 
-FileSegments FileCache::splitRangeIntoFileSegments(
+FileSegments FileCache::createFileSegmentsFromRanges(
     LockedKey & locked_key,
-    size_t offset,
-    size_t size,
-    size_t aligned_size,
-    FileSegment::State state,
+    const std::vector<FileSegment::Range> & ranges,
+    size_t & file_segments_count,
     size_t file_segments_limit,
     const CreateFileSegmentSettings & create_settings)
 {
-    chassert(size > 0);
-    chassert(size <= aligned_size);
-    /// We take `size` as a soft limit and `aligned_size` as a hard limit.
-
-    auto current_pos = offset;
-    auto end_pos_non_included = offset + size;
-
-    size_t current_file_segment_size;
-    size_t remaining_size = aligned_size;
-
-    FileSegments file_segments;
-    const size_t max_size = max_file_segment_size.load();
-    while (current_pos < end_pos_non_included && (!file_segments_limit || file_segments.size() < file_segments_limit))
+    FileSegments result;
+    for (const auto & r : ranges)
     {
-        current_file_segment_size = std::min(remaining_size, max_size);
-        remaining_size -= current_file_segment_size;
-
-        auto file_segment_metadata_it = addFileSegment(
-            locked_key, current_pos, current_file_segment_size, state, create_settings, nullptr);
-        file_segments.push_back(file_segment_metadata_it->second->file_segment);
-
-        current_pos += current_file_segment_size;
+        if (file_segments_limit && file_segments_count >= file_segments_limit)
+            break;
+        auto metadata_it = addFileSegment(locked_key, r.left, r.size(), FileSegment::State::EMPTY, create_settings, nullptr);
+        result.push_back(metadata_it->second->file_segment);
+        ++file_segments_count;
     }
-
-    chassert(file_segments.size() == file_segments_limit || file_segments.back()->range().contains(offset + size - 1),
-             fmt::format("Offset: {}, size: {}, file segments: {}", offset, size, toString(file_segments)));
-    return file_segments;
+    return result;
 }
 
 void FileCache::fillHolesWithEmptyFileSegments(
@@ -448,18 +451,9 @@ void FileCache::fillHolesWithEmptyFileSegments(
         }
         else
         {
-            auto ranges = splitRange(current_pos, hole_size, hole_size);
-            FileSegments hole;
-            for (const auto & r : ranges)
-            {
-                auto metadata_it = addFileSegment(locked_key, r.left, r.size(), FileSegment::State::EMPTY, create_settings, nullptr);
-                hole.push_back(metadata_it->second->file_segment);
-                ++processed_count;
-
-                if (is_limit_reached())
-                    break;
-            }
-            file_segments.splice(it, std::move(hole));
+            const auto ranges = splitRange(current_pos, hole_size, hole_size);
+            auto hole_segments = createFileSegmentsFromRanges(locked_key, ranges, processed_count, file_segments_limit, create_settings);
+            file_segments.splice(it, std::move(hole_segments));
         }
 
         if (is_limit_reached())
@@ -493,29 +487,20 @@ void FileCache::fillHolesWithEmptyFileSegments(
         /// segmentN
 
         auto hole_size = range.right - current_pos + 1;
-        auto non_aligned_size = non_aligned_right_offset - current_pos + 1;
+        auto non_aligned_hole_size = non_aligned_right_offset - current_pos + 1;
 
         if (fill_with_detached_file_segments)
         {
             auto file_segment = std::make_shared<FileSegment>(
-                locked_key.getKey(), current_pos, hole_size, FileSegment::State::DETACHED, create_settings);
+                locked_key.getKey(), current_pos, non_aligned_hole_size, FileSegment::State::DETACHED, create_settings);
 
             file_segments.insert(file_segments.end(), file_segment);
         }
         else
         {
-            auto ranges = splitRange(current_pos, non_aligned_size, hole_size);
-            FileSegments hole;
-            for (const auto & r : ranges)
-            {
-                auto metadata_it = addFileSegment(locked_key, r.left, r.size(), FileSegment::State::EMPTY, create_settings, nullptr);
-                hole.push_back(metadata_it->second->file_segment);
-                ++processed_count;
-
-                if (is_limit_reached())
-                    break;
-            }
-            file_segments.splice(it, std::move(hole));
+            const auto ranges = splitRange(current_pos, non_aligned_hole_size, hole_size);
+            auto hole_segments = createFileSegmentsFromRanges(locked_key, ranges, processed_count, file_segments_limit, create_settings);
+            file_segments.splice(it, std::move(hole_segments));
 
             if (is_limit_reached())
                 erase_unprocessed();
@@ -548,8 +533,9 @@ FileSegmentsHolderPtr FileCache::set(
     }
     else
     {
-        file_segments = splitRangeIntoFileSegments(
-            *locked_key, offset, size, size, FileSegment::State::EMPTY, /* file_segments_limit */0, create_settings);
+        const auto ranges = splitRange(offset, size, size);
+        size_t file_segments_count = 0;
+        file_segments = createFileSegmentsFromRanges(*locked_key, ranges, file_segments_count, /* file_segments_limit */0, create_settings);
     }
 
     return std::make_unique<FileSegmentsHolder>(std::move(file_segments));
@@ -569,23 +555,27 @@ FileCache::getOrSet(
 
     assertInitialized();
 
-    FileSegment::Range range(offset, offset + size - 1);
+    FileSegment::Range initial_range(offset, offset + size - 1);
+    /// result_range is initial range, which will be adjusted according to
+    /// 1. aligned offset, alighed_end_offset
+    /// 2. max_file_segments_limit
+    FileSegment::Range result_range = initial_range;
 
-    const auto aligned_offset = roundDownToMultiple(range.left, boundary_alignment);
-    auto aligned_end_offset = std::min(roundUpToMultiple(offset + size, boundary_alignment), file_size) - 1;
+    const auto aligned_offset = roundDownToMultiple(initial_range.left, boundary_alignment);
+    auto aligned_end_offset = std::min(roundUpToMultiple(initial_range.right + 1, boundary_alignment), file_size) - 1;
 
-    chassert(aligned_offset <= range.left);
-    chassert(aligned_end_offset >= range.right);
+    chassert(aligned_offset <= initial_range.left);
+    chassert(aligned_end_offset >= initial_range.right);
 
     auto locked_key = metadata.lockKeyMetadata(key, CacheMetadata::KeyNotFoundPolicy::CREATE_EMPTY, user);
     /// Get all segments which intersect with the given range.
-    auto file_segments = getImpl(*locked_key, range, file_segments_limit);
+    auto file_segments = getImpl(*locked_key, initial_range, file_segments_limit);
 
     if (file_segments_limit)
     {
         chassert(file_segments.size() <= file_segments_limit);
         if (file_segments.size() == file_segments_limit)
-            range.right = aligned_end_offset = file_segments.back()->range().right;
+            result_range.right = aligned_end_offset = file_segments.back()->range().right;
     }
 
     /// Check case if we have uncovered prefix, e.g.
@@ -597,11 +587,11 @@ FileCache::getOrSet(
     ///   [    ]
     ///   ^----^
     ///   uncovered prefix.
-    const bool has_uncovered_prefix = file_segments.empty() || range.left < file_segments.front()->range().left;
+    const bool has_uncovered_prefix = file_segments.empty() || result_range.left < file_segments.front()->range().left;
 
-    if (aligned_offset < range.left && has_uncovered_prefix)
+    if (aligned_offset < result_range.left && has_uncovered_prefix)
     {
-        auto prefix_range = FileSegment::Range(aligned_offset, file_segments.empty() ? range.left - 1 : file_segments.front()->range().left - 1);
+        auto prefix_range = FileSegment::Range(aligned_offset, file_segments.empty() ? result_range.left - 1 : file_segments.front()->range().left - 1);
         auto prefix_file_segments = getImpl(*locked_key, prefix_range, /* file_segments_limit */0);
 
         if (prefix_file_segments.empty())
@@ -610,7 +600,7 @@ FileCache::getOrSet(
             ///   ^                     ^               ^
             ///   aligned_offset        range.left      range.right
             ///                             [___] [__________]         <-- current cache (example)
-            range.left = aligned_offset;
+            result_range.left = aligned_offset;
         }
         else
         {
@@ -621,10 +611,10 @@ FileCache::getOrSet(
             ///                  ^
             ///                  prefix_file_segments.back().right
 
-            chassert(prefix_file_segments.back()->range().right < range.left);
+            chassert(prefix_file_segments.back()->range().right < result_range.left);
             chassert(prefix_file_segments.back()->range().right >= aligned_offset);
 
-            range.left = prefix_file_segments.back()->range().right + 1;
+            result_range.left = prefix_file_segments.back()->range().right + 1;
         }
     }
 
@@ -637,11 +627,11 @@ FileCache::getOrSet(
     ///                   [___]
     ///                   ^---^
     ///                    uncovered_suffix
-    const bool has_uncovered_suffix = file_segments.empty() || file_segments.back()->range().right < range.right;
+    const bool has_uncovered_suffix = file_segments.empty() || file_segments.back()->range().right < result_range.right;
 
-    if (range.right < aligned_end_offset && has_uncovered_suffix)
+    if (result_range.right < aligned_end_offset && has_uncovered_suffix)
     {
-        auto suffix_range = FileSegment::Range(range.right, aligned_end_offset);
+        auto suffix_range = FileSegment::Range(result_range.right, aligned_end_offset);
         /// We need to get 1 file segment, so file_segments_limit = 1 here.
         auto suffix_file_segments = getImpl(*locked_key, suffix_range, /* file_segments_limit */1);
 
@@ -652,7 +642,7 @@ FileCache::getOrSet(
             ///   range.left         range.right              aligned_end_offset
             ///      [___]   [___]                                    <-- current cache (example)
 
-            range.right = aligned_end_offset;
+            result_range.right = aligned_end_offset;
         }
         else
         {
@@ -662,35 +652,33 @@ FileCache::getOrSet(
             ///      [___]   [___]          [_________]               <-- current cache (example)
             ///                             ^
             ///                             suffix_file_segments.front().left
-            range.right = suffix_file_segments.front()->range().left - 1;
+            result_range.right = suffix_file_segments.front()->range().left - 1;
         }
     }
-
-    chassert(range.left >= aligned_offset);
 
     if (file_segments.empty())
     {
-        file_segments = splitRangeIntoFileSegments(
-            *locked_key, range.left, /* size */offset + size - range.left, /* aligned_size */range.size(),
-            FileSegment::State::EMPTY, file_segments_limit, create_settings);
+        auto ranges = splitRange(result_range.left, initial_range.size() + (initial_range.left - result_range.left), result_range.size());
+        size_t file_segments_count = file_segments.size();
+        file_segments.splice(file_segments.end(), createFileSegmentsFromRanges(*locked_key, ranges, file_segments_count, file_segments_limit, create_settings));
     }
     else
     {
-        chassert(file_segments.front()->range().right >= range.left);
-        chassert(file_segments.back()->range().left <= range.right);
+        chassert(file_segments.front()->range().right >= result_range.left);
+        chassert(file_segments.back()->range().left <= result_range.right);
 
         fillHolesWithEmptyFileSegments(
-            *locked_key, file_segments, range, offset + size - 1, file_segments_limit, /* fill_with_detached */false, create_settings);
+            *locked_key, file_segments, result_range, offset + size - 1, file_segments_limit, /* fill_with_detached */false, create_settings);
 
-        if (!file_segments.front()->range().contains(range.left))
+        if (!file_segments.front()->range().contains(result_range.left))
         {
             throw Exception(ErrorCodes::LOGICAL_ERROR, "Expected {} to include {} "
                             "(end offset: {}, aligned offset: {}, aligned end offset: {})",
-                            file_segments.front()->range().toString(), offset, range.right, aligned_offset, aligned_end_offset);
+                            file_segments.front()->range().toString(), offset, result_range.right, aligned_offset, aligned_end_offset);
         }
     }
 
-    chassert(file_segments_limit ? file_segments.back()->range().left <= range.right : file_segments.back()->range().contains(range.right));
+    chassert(file_segments_limit ? file_segments.back()->range().left <= result_range.right : file_segments.back()->range().contains(result_range.right));
     chassert(!file_segments_limit || file_segments.size() <= file_segments_limit);
 
     return std::make_unique<FileSegmentsHolder>(std::move(file_segments));

--- a/src/Interpreters/Cache/FileCache.h
+++ b/src/Interpreters/Cache/FileCache.h
@@ -263,7 +263,7 @@ private:
 
     /// Split range into subranges by max_file_segment_size,
     /// each subrange size must be less or equal to max_file_segment_size.
-    std::vector<FileSegment::Range> splitRange(size_t offset, size_t size);
+    std::vector<FileSegment::Range> splitRange(size_t offset, size_t size, size_t aligned_size);
 
     /// Split range into subranges by max_file_segment_size (same as in splitRange())
     /// and create a new file segment for each subrange.
@@ -273,6 +273,7 @@ private:
         LockedKey & locked_key,
         size_t offset,
         size_t size,
+        size_t aligned_size,
         FileSegment::State state,
         size_t file_segments_limit,
         const CreateFileSegmentSettings & create_settings);
@@ -281,6 +282,7 @@ private:
         LockedKey & locked_key,
         FileSegments & file_segments,
         const FileSegment::Range & range,
+        size_t non_aligned_right_offset,
         size_t file_segments_limit,
         bool fill_with_detached_file_segments,
         const CreateFileSegmentSettings & settings);

--- a/src/Interpreters/Cache/FileCache.h
+++ b/src/Interpreters/Cache/FileCache.h
@@ -265,16 +265,10 @@ private:
     /// each subrange size must be less or equal to max_file_segment_size.
     std::vector<FileSegment::Range> splitRange(size_t offset, size_t size, size_t aligned_size);
 
-    /// Split range into subranges by max_file_segment_size (same as in splitRange())
-    /// and create a new file segment for each subrange.
-    /// If `file_segments_limit` > 0, create no more than first file_segments_limit
-    /// file segments.
-    FileSegments splitRangeIntoFileSegments(
+    FileSegments createFileSegmentsFromRanges(
         LockedKey & locked_key,
-        size_t offset,
-        size_t size,
-        size_t aligned_size,
-        FileSegment::State state,
+        const std::vector<FileSegment::Range> & ranges,
+        size_t & file_segments_count,
         size_t file_segments_limit,
         const CreateFileSegmentSettings & create_settings);
 

--- a/src/Interpreters/Cache/FileSegment.cpp
+++ b/src/Interpreters/Cache/FileSegment.cpp
@@ -1008,7 +1008,12 @@ FileSegment & FileSegmentsHolder::add(FileSegmentPtr && file_segment)
     return *file_segments.back();
 }
 
-String FileSegmentsHolder::toString()
+String FileSegmentsHolder::toString(bool with_state)
+{
+    return DB::toString(file_segments, with_state);
+}
+
+String toString(const FileSegments & file_segments, bool with_state)
 {
     String ranges;
     for (const auto & file_segment : file_segments)
@@ -1018,6 +1023,8 @@ String FileSegmentsHolder::toString()
         ranges += file_segment->range().toString();
         if (file_segment->isUnbound())
             ranges += "(unbound)";
+        if (with_state)
+            ranges += "(" + FileSegment::stateToString(file_segment->state()) + ")";
     }
     return ranges;
 }

--- a/src/Interpreters/Cache/FileSegment.h
+++ b/src/Interpreters/Cache/FileSegment.h
@@ -291,7 +291,7 @@ struct FileSegmentsHolder : private boost::noncopyable
 
     size_t size() const { return file_segments.size(); }
 
-    String toString();
+    String toString(bool with_state = false);
 
     void popFront() { completeAndPopFrontImpl(); }
 
@@ -316,5 +316,7 @@ private:
 };
 
 using FileSegmentsHolderPtr = std::unique_ptr<FileSegmentsHolder>;
+
+String toString(const FileSegments & file_segments, bool with_state = false);
 
 }

--- a/tests/config/config.d/storage_conf.xml
+++ b/tests/config/config.d/storage_conf.xml
@@ -19,7 +19,7 @@
                 <type>cache</type>
                 <disk>s3_disk</disk>
                 <path>s3_cache/</path>
-                <max_size>100Mi</max_size>
+                <max_size>104857600</max_size>
                 <max_file_segment_size>5Mi</max_file_segment_size>
                 <cache_on_write_operations>1</cache_on_write_operations>
                 <delayed_cleanup_interval_ms>100</delayed_cleanup_interval_ms>

--- a/tests/config/config.d/storage_conf.xml
+++ b/tests/config/config.d/storage_conf.xml
@@ -19,7 +19,8 @@
                 <type>cache</type>
                 <disk>s3_disk</disk>
                 <path>s3_cache/</path>
-                <max_size>104857600</max_size>
+                <max_size>100Mi</max_size>
+                <max_file_segment_size>5Mi</max_file_segment_size>
                 <cache_on_write_operations>1</cache_on_write_operations>
                 <delayed_cleanup_interval_ms>100</delayed_cleanup_interval_ms>
                 <cache_policy>LRU</cache_policy>


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix `Logical error: 'file_offset_of_buffer_end <= read_until_position'` in filesystem cache. Closes https://github.com/ClickHouse/ClickHouse/issues/57508.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---do_not_test--> Do not test
- [x] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
