### PR TITLE
Integration tests: fix ports clashing problem

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# pylint: disable=unused-argument
+# pylint: disable=broad-exception-raised
 
 import logging
 import os

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -132,7 +132,7 @@ def pytest_configure(config):
     worker_ports = os.getenv("WORKER_FREE_PORTS", None)
     if worker_ports is None:
         master_ports = get_unique_free_ports(PORTS_PER_WORKER)
-        os.environ["WORKER_FREE_PORTS"] = " ".join(([str(p) for p in master_ports]))
+        os.environ["WORKER_FREE_PORTS"] = " ".join([str(p) for p in master_ports])
 
 
 def pytest_xdist_setupnodes(config, specs):
@@ -148,4 +148,4 @@ def pytest_xdist_setupnodes(config, specs):
     for i, spec in enumerate(specs):
         start_range = i * PORTS_PER_WORKER
         per_workrer_ports = ports[start_range : start_range + PORTS_PER_WORKER]
-        spec.env["WORKER_FREE_PORTS"] = " ".join(([str(p) for p in per_workrer_ports]))
+        spec.env["WORKER_FREE_PORTS"] = " ".join([str(p) for p in per_workrer_ports])

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -2,11 +2,9 @@
 
 import logging
 import os
-import socket
-import multiprocessing
 
 import pytest  # pylint:disable=import-error; for style check
-from helpers.cluster import run_and_check
+from helpers.cluster import run_and_check, is_port_free
 from helpers.network import _NetworkManager
 
 # This is a workaround for a problem with logging in pytest [1].
@@ -114,15 +112,16 @@ def pytest_addoption(parser):
     )
 
 
-def get_n_free_ports(total):
+def get_unique_free_ports(total):
     ports = []
+    for port in range(30000, 55000):
+        if is_port_free(port) and port not in ports:
+            ports.append(port)
 
-    while len(ports) < total:
-        with socket.socket() as s:
-            s.bind(("", 0))
-            ports.append(s.getsockname()[1])
+        if len(ports) == total:
+            return ports
 
-    return ports
+    raise Exception(f"Can't collect {total} ports. Collected: {len(ports)}")
 
 
 def pytest_configure(config):
@@ -132,9 +131,8 @@ def pytest_configure(config):
     # the `pytest_xdist_setupnodes` hook is not executed
     worker_ports = os.getenv("WORKER_FREE_PORTS", None)
     if worker_ports is None:
-        os.environ["WORKER_FREE_PORTS"] = " ".join(
-            ([str(p) for p in get_n_free_ports(PORTS_PER_WORKER)])
-        )
+        master_ports = get_unique_free_ports(PORTS_PER_WORKER)
+        os.environ["WORKER_FREE_PORTS"] = " ".join(([str(p) for p in master_ports]))
 
 
 def pytest_xdist_setupnodes(config, specs):
@@ -142,18 +140,12 @@ def pytest_xdist_setupnodes(config, specs):
     # allocate pool of {PORTS_PER_WORKER} ports to each worker
 
     # Get number of xdist workers
-    num_workers = 1
-    if os.environ.get("PYTEST_XDIST_WORKER", "master") == "master":
-        num_workers = config.getoption("numprocesses", 1)
-        if num_workers == "auto":
-            num_workers = multiprocessing.cpu_count()
-
+    num_workers = len(specs)
     # Get free ports which will be distributed across workers
-    ports = get_n_free_ports(num_workers * PORTS_PER_WORKER)
+    ports = get_unique_free_ports(num_workers * PORTS_PER_WORKER)
 
     # Iterate over specs of workers and add allocated ports to env variable
     for i, spec in enumerate(specs):
         start_range = i * PORTS_PER_WORKER
-        spec.env["WORKER_FREE_PORTS"] = " ".join(
-            ([str(p) for p in ports[start_range : start_range + PORTS_PER_WORKER]])
-        )
+        per_workrer_ports = ports[start_range : start_range + PORTS_PER_WORKER]
+        spec.env["WORKER_FREE_PORTS"] = " ".join(([str(p) for p in per_workrer_ports]))

--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -135,6 +135,52 @@ def get_free_port():
         return s.getsockname()[1]
 
 
+def is_port_free(port: int) -> bool:
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.bind(("", port))
+            return True
+    except socket.error:
+        return False
+
+
+class PortPoolManager:
+    """
+    This class is used for distribution of ports allocated to single pytest-xdist worker
+    It can be used by multiple ClickHouseCluster instances
+    """
+
+    # Shared between instances
+    all_ports = None
+    free_ports = None
+
+    def __init__(self):
+        self.used_ports = []
+
+        if self.all_ports is None:
+            worker_ports = os.getenv("WORKER_FREE_PORTS")
+            ports = [int(p) for p in worker_ports.split(" ")]
+
+            # Static vars
+            PortPoolManager.all_ports = ports
+            PortPoolManager.free_ports = ports
+
+    def get_port(self):
+        for port in self.free_ports:
+            if is_port_free(port):
+                self.free_ports.remove(port)
+                self.used_ports.append(port)
+                return port
+
+        raise Exception(
+            f"No free ports: {self.all_ports}",
+        )
+
+    def return_used_ports(self):
+        self.free_ports.extend(self.used_ports)
+        self.used_ports.clear()
+
+
 def retry_exception(num, delay, func, exception=Exception, *args, **kwargs):
     """
     Retry if `func()` throws, `num` times.
@@ -716,61 +762,66 @@ class ClickHouseCluster:
                 .stop()
             )
 
+        self.port_pool = PortPoolManager()
+
     @property
     def kafka_port(self):
         if self._kafka_port:
             return self._kafka_port
-        self._kafka_port = get_free_port()
+        self._kafka_port = self.port_pool.get_port()
         return self._kafka_port
 
     @property
     def schema_registry_port(self):
         if self._schema_registry_port:
             return self._schema_registry_port
-        self._schema_registry_port = get_free_port()
+        self._schema_registry_port = self.port_pool.get_port()
         return self._schema_registry_port
 
     @property
     def schema_registry_auth_port(self):
         if self._schema_registry_auth_port:
             return self._schema_registry_auth_port
-        self._schema_registry_auth_port = get_free_port()
+        self._schema_registry_auth_port = self.port_pool.get_port()
         return self._schema_registry_auth_port
 
     @property
     def kerberized_kafka_port(self):
         if self._kerberized_kafka_port:
             return self._kerberized_kafka_port
-        self._kerberized_kafka_port = get_free_port()
+        self._kerberized_kafka_port = self.port_pool.get_port()
         return self._kerberized_kafka_port
 
     @property
     def azurite_port(self):
         if self._azurite_port:
             return self._azurite_port
-        self._azurite_port = get_free_port()
+        self._azurite_port = self.port_pool.get_port()
         return self._azurite_port
 
     @property
     def mongo_port(self):
         if self._mongo_port:
             return self._mongo_port
-        self._mongo_port = get_free_port()
+        self._mongo_port = self.port_pool.get_port()
         return self._mongo_port
 
     @property
     def mongo_no_cred_port(self):
         if self._mongo_no_cred_port:
             return self._mongo_no_cred_port
-        self._mongo_no_cred_port = get_free_port()
+        self._mongo_no_cred_port = self.port_pool.get_port()
         return self._mongo_no_cred_port
 
     @property
     def redis_port(self):
         if self._redis_port:
             return self._redis_port
-        self._redis_port = get_free_port()
+        self._redis_port = self.port_pool.get_port()
         return self._redis_port
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.port_pool.return_used_ports()
 
     def print_all_docker_pieces(self):
         res_networks = subprocess.check_output(


### PR DESCRIPTION
`get_free_port`, which is called in `ClickHouseInstance` to obtain ports for docker containers, could return the same port because it is not bound instantly. Port conflicts can occur between pytest-xdist workers and even in a single thread. Fix this by:
- Allocate a pool of 50 free unique ports to each pytest-xdist worker
- In each process, sequentially allocate these ports from the pool

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [x] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---do_not_test--> Do not test
- [x] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
