### PR TITLE
[WIP] Improve recreating of ephemeral nodes during ON CLUSTER RESTORE

### DIFF
--- a/src/Backups/BackupCoordinationStageSync.h
+++ b/src/Backups/BackupCoordinationStageSync.h
@@ -43,7 +43,7 @@ private:
         bool started = false;
         bool connected = false;
         std::optional<std::chrono::time_point<std::chrono::system_clock>> last_time_connected;
-        std::unordered_map<String, Sring> stage_results;
+        std::unordered_map<String, String> stage_results;
     };
 
     struct HostAndError


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Use a separate thread to track and renew "alive" nodes during `ON CLUSTER` `BACKUP` or `RESTORE`.

Earlier those "alive" nodes were recreated irregularly from time to time (for example, at the start of copying the data of each table). As a result a host could recreate its "alive" node after Keeper's failure after a big delay, and that delay could make the initiator of the `BACKUP` or `RESTORE` query decide that the whole operation failed.

A separate thread will help solving this issue and ensure that such "alive" nodes are checked and recreated often enough (e.g. once in a minute), no matter how busy the server is with copying files.