### PR TITLE
Fix completion of RESTORE ON CLUSTER

### DIFF
--- a/src/Backups/RestorerFromBackup.cpp
+++ b/src/Backups/RestorerFromBackup.cpp
@@ -222,10 +222,19 @@ void RestorerFromBackup::setStage(const String & new_stage, const String & messa
     if (restore_coordination)
     {
         restore_coordination->setStage(new_stage, message);
-        if (new_stage == Stage::FINDING_TABLES_IN_BACKUP)
-            restore_coordination->waitForStage(new_stage, on_cluster_first_sync_timeout);
-        else
-            restore_coordination->waitForStage(new_stage);
+
+        /// The initiator of a RESTORE ON CLUSTER query waits for other hosts to complete their work (see waitForStage(Stage::COMPLETED) in BackupsWorker::doRestore),
+        /// but other hosts shouldn't wait for each others' completion. (That's simply unnecessary and also
+        /// the initiator may start cleaning up (e.g. removing restore-coordination ZooKeeper nodes) once all other hosts are in Stage::COMPLETED.)
+        bool need_wait = (new_stage != Stage::COMPLETED);
+
+        if (need_wait)
+        {
+            if (new_stage == Stage::FINDING_TABLES_IN_BACKUP)
+                restore_coordination->waitForStage(new_stage, on_cluster_first_sync_timeout);
+            else
+                restore_coordination->waitForStage(new_stage);
+        }
     }
 }
 


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix completion of `RESTORE ON CLUSTER` command.

Earlier a successful `RESTORE ON CLUSTER` command could report a strange error like
```
2024-08-01 09:27:17 [bddf5c5a7246] 2024.07.31 16:27:17.588871 [ 57944 ] {c18a7374-c6ce-41d1-a79f-b9d1b5b86d2b} <Error> virtual DB::RestoreCoordinationRemote::~RestoreCoordinationRemote(): Code: 999. Coordination::Exception: Transaction failed: Op #2, path: /clickhouse/backups/restore-902fb5c1-c654-4574-bcfe-57a439165a36/stage. (KEEPER_EXCEPTION)
```

This PR closes https://github.com/ClickHouse/ClickHouse/issues/67644