### PR TITLE
Fix test `02789_reading_from_s3_with_connection_pool`

### DIFF
--- a/tests/queries/0_stateless/02789_reading_from_s3_with_connection_pool.sh
+++ b/tests/queries/0_stateless/02789_reading_from_s3_with_connection_pool.sh
@@ -14,43 +14,59 @@ SETTINGS disk = 's3_disk', min_bytes_for_wide_part = 0;
 
 INSERT INTO test_s3 SELECT number, number FROM numbers_mt(1e7);
 "
-query="SELECT a, b FROM test_s3"
-query_id=$(${CLICKHOUSE_CLIENT} --query "select queryID() from ($query) limit 1" 2>&1)
-${CLICKHOUSE_CLIENT} --query "SYSTEM FLUSH LOGS"
-${CLICKHOUSE_CLIENT} -nm --query "
-SELECT ProfileEvents['DiskConnectionsPreserved'] > 0
-FROM system.query_log
-WHERE type = 'QueryFinish'
-    AND current_database = currentDatabase()
-    AND query_id='$query_id';
-"
+
+# This (reusing connections from the pool) is not guaranteed to always happen,
+# (due to random time difference between the queries and random activity in parallel)
+# but should happen most of the time.
+
+while true
+do
+    query="SELECT a, b FROM test_s3"
+    query_id=$(${CLICKHOUSE_CLIENT} --query "select queryID() from ($query) limit 1" 2>&1)
+    ${CLICKHOUSE_CLIENT} --query "SYSTEM FLUSH LOGS"
+
+    RES=$(${CLICKHOUSE_CLIENT} -nm --query "
+    SELECT ProfileEvents['DiskConnectionsPreserved'] > 0
+    FROM system.query_log
+    WHERE type = 'QueryFinish'
+        AND current_database = currentDatabase()
+        AND query_id='$query_id';
+    ")
+
+    [[ $RES -eq 1 ]] && echo "$RES" && break;
+done
 
 
 # Test connection pool in ReadWriteBufferFromHTTP
 
-query_id=$(${CLICKHOUSE_CLIENT} -nq "
-create table mut (n int, m int, k int) engine=ReplicatedMergeTree('/test/02441/{database}/mut', '1') order by n;
-set insert_keeper_fault_injection_probability=0;
-insert into mut values (1, 2, 3), (10, 20, 30);
+while true
+do
+    query_id=$(${CLICKHOUSE_CLIENT} -nq "
+    create table mut (n int, m int, k int) engine=ReplicatedMergeTree('/test/02441/{database}/mut', '1') order by n;
+    set insert_keeper_fault_injection_probability=0;
+    insert into mut values (1, 2, 3), (10, 20, 30);
 
-system stop merges mut;
-alter table mut delete where n = 10;
+    system stop merges mut;
+    alter table mut delete where n = 10;
 
-select queryID() from(
-    -- a funny way to wait for a MUTATE_PART to be assigned
-    select sleepEachRow(2) from url('http://localhost:8123/?param_tries={1..10}&query=' || encodeURLComponent(
-        'select 1 where ''MUTATE_PART'' not in (select type from system.replication_queue where database=''' || currentDatabase() || ''' and table=''mut'')'
-        ), 'LineAsString', 's String')
-    -- queryID() will be returned for each row, since the query above doesn't return anything we need to return a fake row
-    union all
-    select 1
-) limit 1 settings max_threads=1;
-" 2>&1)
-${CLICKHOUSE_CLIENT} --query "SYSTEM FLUSH LOGS"
-${CLICKHOUSE_CLIENT} -nm --query "
-SELECT ProfileEvents['StorageConnectionsPreserved'] > 0
-FROM system.query_log
-WHERE type = 'QueryFinish'
-    AND current_database = currentDatabase()
-    AND query_id='$query_id';
-"
+    select queryID() from(
+        -- a funny way to wait for a MUTATE_PART to be assigned
+        select sleepEachRow(2) from url('http://localhost:8123/?param_tries={1..10}&query=' || encodeURLComponent(
+            'select 1 where ''MUTATE_PART'' not in (select type from system.replication_queue where database=''' || currentDatabase() || ''' and table=''mut'')'
+            ), 'LineAsString', 's String')
+        -- queryID() will be returned for each row, since the query above doesn't return anything we need to return a fake row
+        union all
+        select 1
+    ) limit 1 settings max_threads=1;
+    " 2>&1)
+    ${CLICKHOUSE_CLIENT} --query "SYSTEM FLUSH LOGS"
+    RES=$(${CLICKHOUSE_CLIENT} -nm --query "
+    SELECT ProfileEvents['StorageConnectionsPreserved'] > 0
+    FROM system.query_log
+    WHERE type = 'QueryFinish'
+        AND current_database = currentDatabase()
+        AND query_id='$query_id';
+    ")
+
+    [[ $RES -eq 1 ]] && echo "$RES" && break;
+done

--- a/tests/queries/0_stateless/02789_reading_from_s3_with_connection_pool.sh
+++ b/tests/queries/0_stateless/02789_reading_from_s3_with_connection_pool.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-distributed-cache
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


This closes #67724.


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
