### PR TITLE
Fix strange code in HostResolvePool

### DIFF
--- a/src/Common/HostResolvePool.cpp
+++ b/src/Common/HostResolvePool.cpp
@@ -253,18 +253,18 @@ void HostResolver::updateImpl(Poco::Timestamp now, std::vector<Poco::Net::IPAddr
         }
     }
 
-    for (auto & rec : merged)
+    for (auto & record : merged)
     {
-            if (!rec.failed)
-                continue;
+        if (!record.failed || !record.consecutive_fail_count)
+            continue;
 
-            /// Exponential increased time for each consecutive fail
-            auto banned_until = now - Poco::Timespan(history.totalMicroseconds() * (1ull << (rec.consecutive_fail_count - 1)));
-            if (rec.fail_time < banned_until)
-            {
-                rec.failed = false;
-                CurrentMetrics::sub(metrics.banned_count);
-            }
+        /// Exponential increased time for each consecutive fail
+        auto banned_until = now - Poco::Timespan(history.totalMicroseconds() * (1ull << (record.consecutive_fail_count - 1)));
+        if (record.fail_time < banned_until)
+        {
+            record.failed = false;
+            CurrentMetrics::sub(metrics.banned_count);
+        }
     }
 
     chassert(std::is_sorted(merged.begin(), merged.end()));


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


CC @ianton-ru 

The code is weird. First of all, it abbreviates the variable name, and this is against our code style. The code has a strange indentation. Also, it does something like exponential backoff but actually calculates the exponent.

The exponential backoff algorithm is beautiful because you don't have to calculate the exponent, you just multiply the value every time.

Nevertheless, I didn't read this code entirely, and just fixed #67705.


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
