### PR TITLE
Fill only selected columns from system.clusters

### DIFF
--- a/src/Storages/System/StorageSystemClusters.h
+++ b/src/Storages/System/StorageSystemClusters.h
@@ -10,6 +10,7 @@ namespace DB
 
 class Context;
 class Cluster;
+class DatabaseReplicated;
 
 /** Implements system table 'clusters'
   *  that allows to obtain information about available clusters
@@ -26,8 +27,9 @@ protected:
     using IStorageSystemOneBlock::IStorageSystemOneBlock;
     using NameAndCluster = std::pair<String, std::shared_ptr<Cluster>>;
 
-    void fillData(MutableColumns & res_columns, ContextPtr context, const ActionsDAG::Node *, std::vector<UInt8>) const override;
-    static void writeCluster(MutableColumns & res_columns, const NameAndCluster & name_and_cluster, const std::vector<UInt8> & is_active);
+    void fillData(MutableColumns & res_columns, ContextPtr context, const ActionsDAG::Node *, std::vector<UInt8> columns_mask) const override;
+    static void writeCluster(MutableColumns & res_columns, const std::vector<UInt8> & columns_mask, const NameAndCluster & name_and_cluster, const DatabaseReplicated * replicated);
+    bool supportsColumnsMask() const override { return true; }
 };
 
 }


### PR DESCRIPTION
Some of them pretty heavy, i.e. is_active for ReplicatedDatabase

This should fix 02903_rmt_retriable_merge_exception flakiness [1].

 [1]: https://s3.amazonaws.com/clickhouse-test-reports/67687/89c47df559ba23d988f8af3c342e0c8d5531f4b8/fast_test.html

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fill only selected columns from system.clusters

Fixes: https://github.com/ClickHouse/ClickHouse/issues/56682