### PR TITLE
Fix stack overflow in JSONMergePatch function

### DIFF
--- a/src/Common/JSONParsers/RapidJSONParser.h
+++ b/src/Common/JSONParsers/RapidJSONParser.h
@@ -3,10 +3,14 @@
 #include "config.h"
 
 #if USE_RAPIDJSON
-#    include <base/types.h>
-#    include <base/defines.h>
-#    include <rapidjson/document.h>
-#    include "ElementTypes.h"
+
+/// Prevent stack overflow:
+#define RAPIDJSON_PARSE_DEFAULT_FLAGS (kParseIterativeFlag)
+
+#include <base/types.h>
+#include <base/defines.h>
+#include <rapidjson/document.h>
+#include "ElementTypes.h"
 
 namespace DB
 {

--- a/tests/queries/0_stateless/03217_json_merge_patch_stack_overflow.sql
+++ b/tests/queries/0_stateless/03217_json_merge_patch_stack_overflow.sql
@@ -1,0 +1,9 @@
+-- Tags: no-fasttest
+-- Needs rapidjson library
+SELECT JSONMergePatch(REPEAT('{"c":', 1000000)); -- { serverError BAD_ARGUMENTS }
+SELECT JSONMergePatch(REPEAT('{"c":', 100000)); -- { serverError BAD_ARGUMENTS }
+SELECT JSONMergePatch(REPEAT('{"c":', 10000)); -- { serverError BAD_ARGUMENTS }
+SELECT JSONMergePatch(REPEAT('{"c":', 1000)); -- { serverError BAD_ARGUMENTS }
+SELECT JSONMergePatch(REPEAT('{"c":', 100)); -- { serverError BAD_ARGUMENTS }
+SELECT JSONMergePatch(REPEAT('{"c":', 10)); -- { serverError BAD_ARGUMENTS }
+SELECT JSONMergePatch(REPEAT('{"c":', 1)); -- { serverError BAD_ARGUMENTS }


### PR DESCRIPTION
### Changelog category (leave one):
- Critical Bug Fix (crash, LOGICAL_ERROR, data loss, RBAC)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix potential stack overflow in `JSONMergePatch` function. Renamed this function from `jsonMergePatch` to `JSONMergePatch` because the previous name was wrong. The previous name is still kept for compatibility. Improved diagnostic of errors in the function. This closes #67304.


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
