### PR TITLE
Fix REPLACE modifier formatting (forbid omitting brackets)

### DIFF
--- a/src/Parsers/ASTColumnsTransformers.cpp
+++ b/src/Parsers/ASTColumnsTransformers.cpp
@@ -323,9 +323,7 @@ void ASTColumnsReplaceTransformer::formatImpl(const FormatSettings & settings, F
 {
     settings.ostr << (settings.hilite ? hilite_keyword : "") << "REPLACE" << (is_strict ? " STRICT " : " ") << (settings.hilite ? hilite_none : "");
 
-    if (children.size() > 1)
-        settings.ostr << "(";
-
+    settings.ostr << "(";
     for (ASTs::const_iterator it = children.begin(); it != children.end(); ++it)
     {
         if (it != children.begin())
@@ -333,9 +331,7 @@ void ASTColumnsReplaceTransformer::formatImpl(const FormatSettings & settings, F
 
         (*it)->formatImpl(settings, state, frame);
     }
-
-    if (children.size() > 1)
-        settings.ostr << ")";
+    settings.ostr << ")";
 }
 
 void ASTColumnsReplaceTransformer::appendColumnName(WriteBuffer & ostr) const

--- a/tests/queries/0_stateless/01913_fix_column_transformer_replace_format.reference
+++ b/tests/queries/0_stateless/01913_fix_column_transformer_replace_format.reference
@@ -1,1 +1,1 @@
-CREATE VIEW default.my_view\n(\n    `Id` UInt32,\n    `Object.Key` Array(UInt16),\n    `Object.Value` Array(String)\n)\nAS SELECT * REPLACE arrayMap(x -> (x + 1), `Object.Key`) AS `Object.Key`\nFROM default.my_table
+CREATE VIEW default.my_view\n(\n    `Id` UInt32,\n    `Object.Key` Array(UInt16),\n    `Object.Value` Array(String)\n)\nAS SELECT * REPLACE (arrayMap(x -> (x + 1), `Object.Key`) AS `Object.Key`)\nFROM default.my_table

--- a/tests/queries/0_stateless/03220_replace_formatting.reference
+++ b/tests/queries/0_stateless/03220_replace_formatting.reference
@@ -1,0 +1,16 @@
+SELECT * REPLACE ((1 / 3) / 3 AS dummy)
+SELECT * REPLACE ((1 / 3) / 3 AS dummy)
+SELECT * REPLACE STRICT (1 AS id, 2 AS value)
+FROM
+(
+    SELECT
+        0 AS id,
+        1 AS value
+)
+SELECT * REPLACE STRICT (1 AS id, 2 AS value)
+FROM
+(
+    SELECT
+        0 AS id,
+        1 AS value
+)

--- a/tests/queries/0_stateless/03220_replace_formatting.sh
+++ b/tests/queries/0_stateless/03220_replace_formatting.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+q=$($CLICKHOUSE_FORMAT <<<"SELECT * REPLACE(1/3/3 AS dummy)")
+echo "$q"
+$CLICKHOUSE_FORMAT <<<"$q"
+
+# multiple columns
+q=$($CLICKHOUSE_FORMAT <<<"SELECT * REPLACE STRICT (1 AS id, 2 AS value) FROM (SELECT 0 id, 1 value)")
+echo "$q"
+$CLICKHOUSE_FORMAT <<<"$q"


### PR DESCRIPTION
### Changelog category (leave one):
- Backward Incompatible Change

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix REPLACE modifier formatting (forbid omitting brackets)

It is too tricky to verify does brackets required or not, i.e. "SELECT * REPLACE(1/3/3 AS dummy)" will be formatted to "SELECT * REPLACE (1/3)/3 AS dummy" which is already invalid query.

So let's simply always print them.

P.S. marked as backward incompatible, since someone may rely on it

CI: https://s3.amazonaws.com/clickhouse-test-reports/66671/e126d334087562c08e8432385c3e37ec7c9759f1/ast_fuzzer__debug_.html