### PR TITLE
[RFC] Print original query for AST formatting check on CI

### DIFF
--- a/src/Interpreters/executeQuery.cpp
+++ b/src/Interpreters/executeQuery.cpp
@@ -796,10 +796,9 @@ static std::tuple<ASTPtr, BlockIO> executeQueryImpl(
             catch (const Exception & e)
             {
                 if (e.code() == ErrorCodes::SYNTAX_ERROR)
-                    /// Don't print the original query text because it may contain sensitive data.
                     throw Exception(ErrorCodes::LOGICAL_ERROR,
-                        "Inconsistent AST formatting: the query:\n{}\ncannot parse.",
-                        formatted1);
+                        "Inconsistent AST formatting: the query:\n{}\ncannot parse query back from {}",
+                        formatted1, std::string_view(begin, end-begin));
                 else
                     throw;
             }


### PR DESCRIPTION
It may be tricky to understand the root cause of the AST formatting issue in case of syntax error, so add one knob to control this - debug_ast_formatting_print_original_query.

And CI contains core dumps anyway, so let's enable for CI.

P.S. There was concern from @al13n321 that printing original query even in debug build is not a good idea [1], hence a knob for this.

  [1]: https://github.com/ClickHouse/ClickHouse/pull/63357/files#r1674809348

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Cc: @al13n321 