### PR TITLE
Trivial optimize on ORC/Parquet string reading

### DIFF
--- a/src/Processors/Formats/Impl/ArrowColumnToCHColumn.cpp
+++ b/src/Processors/Formats/Impl/ArrowColumnToCHColumn.cpp
@@ -133,16 +133,31 @@ static ColumnWithTypeAndName readColumnWithStringData(const std::shared_ptr<arro
         std::shared_ptr<arrow::Buffer> buffer = chunk.value_data();
         const size_t chunk_length = chunk.length();
 
-        for (size_t offset_i = 0; offset_i != chunk_length; ++offset_i)
+        const size_t null_count = chunk.null_count();
+        if (null_count == 0)
         {
-            if (!chunk.IsNull(offset_i) && buffer)
+            for (size_t offset_i = 0; offset_i != chunk_length; ++offset_i)
             {
                 const auto * raw_data = buffer->data() + chunk.value_offset(offset_i);
                 column_chars_t.insert_assume_reserved(raw_data, raw_data + chunk.value_length(offset_i));
-            }
-            column_chars_t.emplace_back('\0');
+                column_chars_t.emplace_back('\0');
 
-            column_offsets.emplace_back(column_chars_t.size());
+                column_offsets.emplace_back(column_chars_t.size());
+            }
+        }
+        else
+        {
+            for (size_t offset_i = 0; offset_i != chunk_length; ++offset_i)
+            {
+                if (!chunk.IsNull(offset_i) && buffer)
+                {
+                    const auto * raw_data = buffer->data() + chunk.value_offset(offset_i);
+                    column_chars_t.insert_assume_reserved(raw_data, raw_data + chunk.value_length(offset_i));
+                }
+                column_chars_t.emplace_back('\0');
+
+                column_offsets.emplace_back(column_chars_t.size());
+            }
         }
     }
     return {std::move(internal_column), std::move(internal_type), column_name};

--- a/src/Processors/Formats/Impl/NativeORCBlockInputFormat.cpp
+++ b/src/Processors/Formats/Impl/NativeORCBlockInputFormat.cpp
@@ -1,5 +1,4 @@
 #include "NativeORCBlockInputFormat.h"
-#include "Columns/ColumnsCommon.h"
 
 #if USE_ORC
 #    include <Columns/ColumnDecimal.h>

--- a/src/Processors/Formats/Impl/NativeORCBlockInputFormat.cpp
+++ b/src/Processors/Formats/Impl/NativeORCBlockInputFormat.cpp
@@ -1,4 +1,5 @@
 #include "NativeORCBlockInputFormat.h"
+#include "Columns/ColumnsCommon.h"
 
 #if USE_ORC
 #    include <Columns/ColumnDecimal.h>


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Trivial optimize on orc string reading especially when column contains no NULLs. 

``` sql 
echo "select concat('hello world', number::String) as s from numbers(10000000) format ORC" |clickhouse-client >  str.orc
select * from file('str.orc') format NULL; 

Before
10000000 rows in set. Elapsed: 0.403 sec. Processed 10.00 million rows, 6.28 MB (24.80 million rows/s., 15.57 MB/s.)
10000000 rows in set. Elapsed: 0.400 sec. Processed 10.00 million rows, 6.28 MB (25.01 million rows/s., 15.70 MB/s.)
10000000 rows in set. Elapsed: 0.430 sec. Processed 10.00 million rows, 6.28 MB (23.27 million rows/s., 14.61 MB/s.)


After
10000000 rows in set. Elapsed: 0.361 sec. Processed 10.00 million rows, 6.28 MB (27.70 million rows/s., 17.39 MB/s.)
10000000 rows in set. Elapsed: 0.363 sec. Processed 10.00 million rows, 6.28 MB (27.55 million rows/s., 17.30 MB/s.)
10000000 rows in set. Elapsed: 0.357 sec. Processed 10.00 million rows, 6.28 MB (28.03 million rows/s., 17.60 MB/s.)

```

``` sql 
echo "select concat('hello world', number::String) as s from numbers(10000000) format Parquet" | clickhouse-client >  str.parquet
select * from file('str.parquet') format NULL; 

Before
0 rows in set. Elapsed: 0.136 sec. Processed 10.00 million rows, 4.60 MB (73.51 million rows/s., 33.82 MB/s.)
0 rows in set. Elapsed: 0.131 sec. Processed 10.00 million rows, 4.60 MB (76.40 million rows/s., 35.15 MB/s.)
0 rows in set. Elapsed: 0.132 sec. Processed 10.00 million rows, 4.60 MB (75.68 million rows/s., 34.82 MB/s.)

After
0 rows in set. Elapsed: 0.117 sec. Processed 10.00 million rows, 4.60 MB (85.68 million rows/s., 39.42 MB/s.)
0 rows in set. Elapsed: 0.113 sec. Processed 10.00 million rows, 4.60 MB (88.44 million rows/s., 40.69 MB/s.)
0 rows in set. Elapsed: 0.104 sec. Processed 10.00 million rows, 4.60 MB (95.96 million rows/s., 44.15 MB/s.)
```

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
