### PR TITLE
Fix possible CANNOT_READ_ALL_DATA during server startup in performance tests

### DIFF
--- a/tests/performance/scripts/compare.sh
+++ b/tests/performance/scripts/compare.sh
@@ -71,6 +71,8 @@ function configure
 {
     # Use the new config for both servers, so that we can change it in a PR.
     rm right/config/config.d/text_log.xml ||:
+    # backups disk uses absolute path, and this overlaps between servers, that could lead to errors
+    rm right/config/config.d/backups.xml ||:
     cp -rv right/config left ||:
 
     # Start a temporary server to rename the tables


### PR DESCRIPTION
CI [1]:

    2024.08.04 22:09:11.646800 [ 1052 ] {} <Error> Application: Code: 33. DB::Exception: Cannot read all data. Bytes read: 0. Bytes expected: 4.: While checking access for disk backups. (CANNOT_READ_ALL_DATA), Stack trace (when copying this message, always include the lines below):

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/64955/6702acf6f2e4a0ee9697066e38006631fc7f69df/performance_comparison__aarch64__[2_4].html

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
