### PR TITLE
Integration tests: Disable repeat of tests in flaky check

### DIFF
--- a/tests/ci/integration_tests_runner.py
+++ b/tests/ci/integration_tests_runner.py
@@ -30,7 +30,8 @@ CLICKHOUSE_ODBC_BRIDGE_BINARY_PATH = "usr/bin/clickhouse-odbc-bridge"
 CLICKHOUSE_LIBRARY_BRIDGE_BINARY_PATH = "usr/bin/clickhouse-library-bridge"
 
 FLAKY_TRIES_COUNT = 10  # run whole pytest several times
-FLAKY_REPEAT_COUNT = 5  # runs test case in single module several times
+# Disable repeat of changed tests for flaky check because it doesn't support per-file runs
+FLAKY_REPEAT_COUNT = 0  # runs test case in single module several times
 MAX_TIME_SECONDS = 3600
 
 MAX_TIME_IN_SANDBOX = 20 * 60  # 20 minutes
@@ -643,7 +644,11 @@ class ClickhouseIntegrationTestsRunner:
 
             test_cmd = " ".join([shlex.quote(test) for test in sorted(test_names)])
             parallel_cmd = f" --parallel {num_workers} " if num_workers > 0 else ""
-            repeat_cmd = f" --count {repeat_count} " if repeat_count > 0 else ""
+
+            repeat_cmd = ""
+            if repeat_count:
+                repeat_cmd = f"--count {repeat_count} " if repeat_count > 0 else ""
+
             # -r -- show extra test summary:
             # -f -- (f)ailed
             # -E -- (E)rror


### PR DESCRIPTION
I like the idea of running tests multiple times in a flaky check, but the current implementation is incorrect because it runs repeated tests in the same setup block, in our case on the same CH cluster. Integration tests are designed to run in complete isolation, and with the current implementation, all tests would need to be rewritten just to make the flaky check work.

It happens simply because pytest-repeat doesn't support this:
![Screenshot from 2024-08-05 13-29-07](https://github.com/user-attachments/assets/1a355921-0f19-42a3-9302-d77b5db3cb12)
https://github.com/pytest-dev/pytest-repeat/issues/17#issuecomment-631425083

As example here is setup plan of test `test_dictionaries_update_and_reload/test.py` with argument `--count 2`. Tests are run in same setup block (on same cluster):
```
test_dictionaries_update_and_reload/test.py::test_reload_while_loading[1-2] 
SETUP    S cleanup_environment
SETUP    S pdb_history
SETUP    S tune_local_port_range
    SETUP    M started_cluster
        test_dictionaries_update_and_reload/test.py::test_reload_while_loading[1-2] (fixtures used: cleanup_environment, pdb_history, request, started_cluster, tune_local_port_range)
test_dictionaries_update_and_reload/test.py::test_reload_after_loading[1-2] 
        test_dictionaries_update_and_reload/test.py::test_reload_after_loading[1-2] (fixtures used: cleanup_environment, pdb_history, request, started_cluster, tune_local_port_range)
test_dictionaries_update_and_reload/test.py::test_reload_after_fail_by_system_reload[1-2] 
        test_dictionaries_update_and_reload/test.py::test_reload_after_fail_by_system_reload[1-2] (fixtures used: cleanup_environment, pdb_history, request, started_cluster, tune_local_port_range)
test_dictionaries_update_and_reload/test.py::test_reload_after_fail_by_timer[1-2] 
        test_dictionaries_update_and_reload/test.py::test_reload_after_fail_by_timer[1-2] (fixtures used: cleanup_environment, pdb_history, request, started_cluster, tune_local_port_range)
test_dictionaries_update_and_reload/test.py::test_reload_after_fail_in_cache_dictionary[1-2] 
        test_dictionaries_update_and_reload/test.py::test_reload_after_fail_in_cache_dictionary[1-2] (fixtures used: cleanup_environment, pdb_history, request, started_cluster, tune_local_port_range)
test_dictionaries_update_and_reload/test.py::test_reload_while_loading[2-2] 
        test_dictionaries_update_and_reload/test.py::test_reload_while_loading[2-2] (fixtures used: cleanup_environment, pdb_history, request, started_cluster, tune_local_port_range)
test_dictionaries_update_and_reload/test.py::test_reload_after_loading[2-2] 
        test_dictionaries_update_and_reload/test.py::test_reload_after_loading[2-2] (fixtures used: cleanup_environment, pdb_history, request, started_cluster, tune_local_port_range)
test_dictionaries_update_and_reload/test.py::test_reload_after_fail_by_system_reload[2-2] 
        test_dictionaries_update_and_reload/test.py::test_reload_after_fail_by_system_reload[2-2] (fixtures used: cleanup_environment, pdb_history, request, started_cluster, tune_local_port_range)
test_dictionaries_update_and_reload/test.py::test_reload_after_fail_by_timer[2-2] 
        test_dictionaries_update_and_reload/test.py::test_reload_after_fail_by_timer[2-2] (fixtures used: cleanup_environment, pdb_history, request, started_cluster, tune_local_port_range)
test_dictionaries_update_and_reload/test.py::test_reload_after_fail_in_cache_dictionary[2-2] 
        test_dictionaries_update_and_reload/test.py::test_reload_after_fail_in_cache_dictionary[2-2] (fixtures used: cleanup_environment, pdb_history, request, started_cluster, tune_local_port_range)
    TEARDOWN M started_cluster
TEARDOWN S tune_local_port_range
TEARDOWN S pdb_history
TEARDOWN S cleanup_environment

```

And here is the sample of flaky check run, first run ([1-5]) is always succesfull:
https://s3.amazonaws.com/clickhouse-test-reports/67754/e6921bfc595937ac6d2d448ac46cf2778119d509/integration_tests_flaky_check__asan_.html


I think i can fix it by myself in future, because `pytest-repeat` is only 73 lines of code https://github.com/pytest-dev/pytest-repeat/blob/main/pytest_repeat.py

@qoega @pamarcos 
https://github.com/ClickHouse/ClickHouse/pull/66986

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [x] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---do_not_test--> Do not test
- [x] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
