### PR TITLE
Building aarch64 builds with '-no-pie' to allow better introspection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -430,7 +430,10 @@ endif()
 
 if (NOT OS_ANDROID AND OS_LINUX AND NOT ARCH_S390X AND NOT SANITIZE)
     # Slightly more efficient code can be generated
-    # Disabled for Android, because otherwise ClickHouse cannot run on Android.
+    # Using '-no-pie' builds executables with fixed addresses, resulting in slightly more efficient code
+    # and keeping binary addresses constant even with ASLR enabled.
+    # Disabled on Android as it requires PIE: https://source.android.com/docs/security/enhancements#android-5
+    # Disabled on IBM S390X due to build issues with 'no-pie'
     set (CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} -fno-pie")
     set (CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO} -fno-pie")
     set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -no-pie -Wl,-no-pie")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -433,6 +433,7 @@ if (NOT OS_ANDROID AND OS_LINUX AND NOT ARCH_S390X AND NOT SANITIZE)
     # and keeping binary addresses constant even with ASLR enabled.
     # Disabled on Android as it requires PIE: https://source.android.com/docs/security/enhancements#android-5
     # Disabled on IBM S390X due to build issues with 'no-pie'
+    # Disabled with sanitizers to avoid issues with maximum relocation size: https://github.com/ClickHouse/ClickHouse/pull/49145
     set (CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} -fno-pie")
     set (CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO} -fno-pie")
     set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -no-pie -Wl,-no-pie")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -429,7 +429,6 @@ if (NOT SANITIZE)
 endif()
 
 if (NOT OS_ANDROID AND OS_LINUX AND NOT ARCH_S390X AND NOT SANITIZE)
-    # Slightly more efficient code can be generated
     # Using '-no-pie' builds executables with fixed addresses, resulting in slightly more efficient code
     # and keeping binary addresses constant even with ASLR enabled.
     # Disabled on Android as it requires PIE: https://source.android.com/docs/security/enhancements#android-5

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -428,12 +428,14 @@ if (NOT SANITIZE)
     set (CMAKE_POSITION_INDEPENDENT_CODE OFF)
 endif()
 
-if (OS_LINUX AND NOT (ARCH_AARCH64 OR ARCH_S390X) AND NOT SANITIZE)
+if (NOT OS_ANDROID AND OS_LINUX AND NOT ARCH_S390X AND NOT SANITIZE)
     # Slightly more efficient code can be generated
-    # It's disabled for ARM because otherwise ClickHouse cannot run on Android.
+    # Disabled for Android, because otherwise ClickHouse cannot run on Android.
     set (CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} -fno-pie")
     set (CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO} -fno-pie")
     set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -no-pie -Wl,-no-pie")
+else ()
+    message (WARNING "ClickHouse is built as PIE, system.trace_log will contain invalid addresses after server restart.")
 endif ()
 
 if (ENABLE_TESTS)


### PR DESCRIPTION
By default, all modern Linux kernels have ASLR (Address Space Layout Randomization) enabled, which means the addresses of code points change every time an application starts. The ClickHouse binary for amd64 is built with no-pie to avoid this, ensuring addresses are fixed. However, for ARM, the no-pie flag is not added.

As a result, trace_log / crash_log and other tables storing numerical stacktraces and addresses cannot be directly symbolized after a ClickHouse restart because all addresses get shifted.

**Note:** While it is possible to store, guess, or calculate the base address of ClickHouse (and eventually glibc) and use some math to adjust the offsets for symbolizing, this approach is complex.

### Changelog category (leave one):
- Improvement

### Changelog entry:
Add '-no-pie' to aarch64 Linux builds to allow proper introspection and symbolizing of stacktraces after a ClickHouse restart.

### Documentation entry for user-facing changes:

Add the '-no-pie' flag to aarch64 Linux builds to ensure proper introspection and symbolizing of stacktraces after a ClickHouse restart. Also build-time warning message added to inform users about the potential issue with invalid addresses in the system.trace_log after a server restart when PIE is enabled.

P.S. Did not test the change on Android.