### PR TITLE
Add keeper error description to the message

### DIFF
--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -800,7 +800,8 @@ void StorageReplicatedMergeTree::createNewZooKeeperNodes()
     {
         auto res = future.get();
         if (res.error != Coordination::Error::ZOK && res.error != Coordination::Error::ZNODEEXISTS)
-            throw Coordination::Exception(res.error, "Failed to create new nodes {} at {}", res.path_created, zookeeper_path);
+            throw Coordination::Exception(res.error, "Failed to create new nodes {} at {} with error {}",
+                res.path_created, zookeeper_path, Coordination::errorMessage(res.error));
     }
 }
 


### PR DESCRIPTION
Include actual Keeper error in the message for better diagnostics of failures like:

```
2024.08.02 21:41:35.252257 [ 52675 ] {} <Error> Application: Caught exception while loading metadata: Code: 722. DB::Exception: Waited job failed: Code: 695. DB::Exception: Load job 'load table test_13.test_table_replicated' failed: Code: 999. Coordination::Exception: Failed to create new nodes at /clickhouse/tables/test_13/test_table_replicated: Cannot attach table `test_13`.`test_table_replicated` from metadata file /var/lib/clickhouse/store/648/648dd7bc-ba1f-4041-ad7e-280effa755c6/test_table_replicated.sql from query ATTACH TABLE test_13.test_table_replicated UUID '50ecf916-fe7f-4b31-9d20-ecb9548ac200' (`id` UInt64, `value` String, `insert_time` DateTime) ENGINE = ReplicatedMergeTree('/clickhouse/tables/test_13/test_table_replicated', '1_replica') ORDER BY id SETTINGS index_granularity = 12584, min_bytes_for_wide_part = 0, ratio_of_defaults_for_sparse_serialization = 0., replace_long_file_name_to_hash = false, max_file_name_length = 58, min_bytes_for_full_part_storage = 0, compact_parts_max_bytes_to_buffer = 366056685, compact_parts_max_granules_to_buffer = 246, compact_parts_merge_max_bytes_to_prefetch_part = 16157210, merge_max_block_size = 4168, old_parts_lifetime = 10., prefer_fetch_merged_part_size_threshold = 9130946360, vertical_merge_algorithm_min_rows_to_activate = 1, vertical_merge_algorithm_min_columns_to_activate = 100, min_merge_bytes_to_use_direct_io = 10737418240, index_granularity_bytes = 10230481, concurrent_part_removal_threshold = 100, allow_vertical_merges_from_compact_to_wide_parts = false, cache_populated_by_fetch = false, marks_compress_block_size = 26055, primary_key_compress_block_size = 44746. (KEEPER_EXCEPTION), Stack trace (when copying this message, always include the lines below):
```

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
