### PR TITLE
Unflake 02099_tsv_raw_format.sh

### DIFF
--- a/tests/queries/0_stateless/02099_tsv_raw_format_1.reference
+++ b/tests/queries/0_stateless/02099_tsv_raw_format_1.reference
@@ -109,5 +109,3 @@ UInt64	String	Date
 2
 \N
 nSome text
-b1cad4eb4be08a40387c9de70d02fcc2  -
-b1cad4eb4be08a40387c9de70d02fcc2  -

--- a/tests/queries/0_stateless/02099_tsv_raw_format_1.sh
+++ b/tests/queries/0_stateless/02099_tsv_raw_format_1.sh
@@ -46,16 +46,3 @@ echo 'nSome text' | $CLICKHOUSE_CLIENT -q "INSERT INTO test_nullable_string_0209
 
 $CLICKHOUSE_CLIENT -q "SELECT * FROM test_nullable_string_02099"
 $CLICKHOUSE_CLIENT -q "DROP TABLE test_nullable_string_02099"
-
-
-$CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS test_parallel_parsing_02099"
-$CLICKHOUSE_CLIENT -q "CREATE TABLE test_parallel_parsing_02099 (x UInt64, a Array(UInt64), s String) ENGINE=Memory()";
-$CLICKHOUSE_CLIENT -q "SELECT number AS x, range(number % 50) AS a, toString(a) AS s FROM numbers(1000000) FORMAT TSVRaw" | $CLICKHOUSE_CLIENT --input_format_parallel_parsing=0 -q "INSERT INTO test_parallel_parsing_02099 FORMAT TSVRaw"
-$CLICKHOUSE_CLIENT -q "SELECT * FROM test_parallel_parsing_02099 ORDER BY x" | md5sum
-
-$CLICKHOUSE_CLIENT -q "TRUNCATE TABLE test_parallel_parsing_02099"
-
-$CLICKHOUSE_CLIENT -q "SELECT number AS x, range(number % 50) AS a, toString(a) AS s FROM numbers(1000000) FORMAT TSVRaw" | $CLICKHOUSE_CLIENT --input_format_parallel_parsing=1 -q "INSERT INTO test_parallel_parsing_02099 FORMAT TSVRaw"
-$CLICKHOUSE_CLIENT -q "SELECT * FROM test_parallel_parsing_02099 ORDER BY x" | md5sum
-
-$CLICKHOUSE_CLIENT -q "DROP TABLE test_parallel_parsing_02099"

--- a/tests/queries/0_stateless/02099_tsv_raw_format_2.reference
+++ b/tests/queries/0_stateless/02099_tsv_raw_format_2.reference
@@ -1,0 +1,2 @@
+c8ff17885084035ea1aebd95fee2efb6  -
+c8ff17885084035ea1aebd95fee2efb6  -

--- a/tests/queries/0_stateless/02099_tsv_raw_format_2.sh
+++ b/tests/queries/0_stateless/02099_tsv_raw_format_2.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Tags: long
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+$CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS test_parallel_parsing_02099"
+$CLICKHOUSE_CLIENT -q "CREATE TABLE test_parallel_parsing_02099 (x UInt64, a Array(UInt64), s String) ENGINE=Memory()";
+$CLICKHOUSE_CLIENT -q "SELECT number AS x, range(number % 50) AS a, toString(a) AS s FROM numbers(100000) FORMAT TSVRaw" | $CLICKHOUSE_CLIENT --input_format_parallel_parsing=0 -q "INSERT INTO test_parallel_parsing_02099 FORMAT TSVRaw"
+$CLICKHOUSE_CLIENT -q "SELECT * FROM test_parallel_parsing_02099 ORDER BY x" | md5sum
+
+$CLICKHOUSE_CLIENT -q "TRUNCATE TABLE test_parallel_parsing_02099"
+
+$CLICKHOUSE_CLIENT -q "SELECT number AS x, range(number % 50) AS a, toString(a) AS s FROM numbers(100000) FORMAT TSVRaw" | $CLICKHOUSE_CLIENT --input_format_parallel_parsing=1 -q "INSERT INTO test_parallel_parsing_02099 FORMAT TSVRaw"
+$CLICKHOUSE_CLIENT -q "SELECT * FROM test_parallel_parsing_02099 ORDER BY x" | md5sum
+
+$CLICKHOUSE_CLIENT -q "DROP TABLE test_parallel_parsing_02099"
+


### PR DESCRIPTION
Resolves #67864

This test ran just really really slow.

This PR
- splits it into two (both parts had equally the same runtime before the test was killed),
- and reduces the data volume in the second test from 1 mio to 100k rows.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)