### PR TITLE
Fix timeout of 02310_clickhouse_local_INSERT_progress_profile_events

### DIFF
--- a/tests/queries/0_stateless/02310_clickhouse_local_INSERT_progress_profile_events.expect
+++ b/tests/queries/0_stateless/02310_clickhouse_local_INSERT_progress_profile_events.expect
@@ -1,5 +1,5 @@
 #!/usr/bin/expect -f
-# Tags: no-debug, no-tsan, no-msan, no-asan, no-ubsan, no-s3-storage
+# Tags: no-debug, no-tsan, no-msan, no-asan, no-ubsan, no-s3-storage, no-cpu-aarch64
 # ^ it can be slower than 60 seconds
 
 # This is the regression for the concurrent access in ProgressIndication,


### PR DESCRIPTION
Addresses a timeout of `02310_clickhouse_local_INSERT_progress_profile_events`:

https://s3.amazonaws.com/clickhouse-test-reports/67904/df0dac2f5b509438cce28214b78765c46439aa8c/stateless_tests__aarch64_.html

This PR "fixes" the problem in a similar way as https://github.com/ClickHouse/ClickHouse/pull/67264

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)