### PR TITLE
Output an operation error for ZK Multi request failed operation into log

### DIFF
--- a/src/Common/ZooKeeper/ZooKeeper.cpp
+++ b/src/Common/ZooKeeper/ZooKeeper.cpp
@@ -1570,7 +1570,7 @@ size_t getFailedOpIndex(Coordination::Error exception_code, const Coordination::
 
 
 KeeperMultiException::KeeperMultiException(Coordination::Error exception_code, size_t failed_op_index_, const Coordination::Requests & requests_, const Coordination::Responses & responses_)
-        : KeeperException(exception_code, "Transaction failed: Op #{}, path", failed_op_index_),
+        : KeeperException(exception_code, "Transaction failed ({}): Op #{}, path", exception_code, failed_op_index_),
           requests(requests_), responses(responses_), failed_op_index(failed_op_index_)
 {
     addMessage(getPathForFirstFailedOp());


### PR DESCRIPTION
Output an operation error for ZK Multi request failed operation into log.

Before:
```
2024.08.09 15:02:38.771407 [ 405 ] {} <Error> default.test_table (ReplicatedMergeTreeRestartingThread): Couldn't start replication (table will be in readonly mode): Transaction fail
ed: Op #0, path: /clickhouse/tables/test1/replicated/replicas/node1/queue/queue-0000000018. Code: 999. Coordination::Exception: Transaction failed: Op #0
, path: /clickhouse/tables/test1/replicated/replicas/node1/queue/queue-0000000018. (KEEPER_EXCEPTION), Stack trace (when copying this message, always include the lines below):
...
```

After:
```
2024.08.09 15:02:38.771407 [ 405 ] {} <Error> default.test_table (ReplicatedMergeTreeRestartingThread): Couldn't start replication (table will be in readonly mode): Transaction fail
ed (No node): Op #0, path: /clickhouse/tables/test1/replicated/replicas/node1/queue/queue-0000000018. Code: 999. Coordination::Exception: Transaction failed (No node): Op #0
, path: /clickhouse/tables/test1/replicated/replicas/node1/queue/queue-0000000018. (KEEPER_EXCEPTION), Stack trace (when copying this message, always include the lines below):
...
```

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Output an operation error for ZK Multi request failed operation into log.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
