### PR TITLE
tests: fix 01246_buffer_flush flakiness due to slow trace_log flush

### DIFF
--- a/tests/queries/0_stateless/01246_buffer_flush.sh
+++ b/tests/queries/0_stateless/01246_buffer_flush.sh
@@ -27,7 +27,7 @@ function wait_until()
 function get_buffer_delay()
 {
     local buffer_insert_id=$1 && shift
-    query "SYSTEM FLUSH LOGS"
+    $CLICKHOUSE_CLIENT -q "SYSTEM FLUSH LOGS"
     query "
         WITH
             (SELECT event_time_microseconds FROM system.query_log WHERE current_database = '$CLICKHOUSE_DATABASE' AND type = 'QueryStart' AND query_id = '$buffer_insert_id') AS begin_,


### PR DESCRIPTION
But this, is just a "workaround" the root cause should be fixed:
- either make trace_log flushing faster (maybe adding some `-O` for some modules)
- or adding `SYSTEM FLUSH LOGS x`  (where x could be i.e. `query_log`)

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Fixes: https://github.com/ClickHouse/ClickHouse/issues/67307