### PR TITLE
ci: add more logs in the functional tests reports

### DIFF
--- a/docker/test/util/process_functional_tests_result.py
+++ b/docker/test/util/process_functional_tests_result.py
@@ -116,7 +116,7 @@ def process_test_log(log_path, broken_tests):
             test[0],
             test[1],
             test[2],
-            "".join(test[3])[:4096].replace("\t", "\\t").replace("\n", "\\n"),
+            "".join(test[3])[:8192].replace("\t", "\\t").replace("\n", "\\n"),
         ]
         for test in test_results
     ]


### PR DESCRIPTION
Due to settings randomization 4096 is not enough even to show all settings, like here [1].

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/68139/c852bd9dbaa317423234d4f15f21d64e59be42b5/stateless_tests_flaky_check__asan_.html

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)