### PR TITLE
tests: fix 02122_join_group_by_timeout flakiness

### DIFF
--- a/tests/queries/0_stateless/02122_join_group_by_timeout.reference
+++ b/tests/queries/0_stateless/02122_join_group_by_timeout.reference
@@ -1,4 +1,6 @@
 Code: 159
+query_duration	1
 0
+query_duration	1
 Code: 159
 0

--- a/tests/queries/0_stateless/02122_join_group_by_timeout.sh
+++ b/tests/queries/0_stateless/02122_join_group_by_timeout.sh
@@ -1,27 +1,23 @@
 #!/usr/bin/env bash
-# Tags: no-debug
-
-# no-debug: Query is canceled by timeout after max_execution_time,
-#           but sending an exception to the client may hang
-#           for more than MAX_PROCESS_WAIT seconds in a slow debug build,
-#           and test will fail.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CURDIR"/../shell_config.sh
 
-MAX_PROCESS_WAIT=5
-
-IS_SANITIZER=$($CLICKHOUSE_CLIENT -q "SELECT count() FROM system.warnings WHERE message like '%built with sanitizer%'")
-if [ "$IS_SANITIZER" -gt 0 ]; then
-    # Query may hang for more than 5 seconds, especially in tsan build
-    MAX_PROCESS_WAIT=15
+TIMEOUT=5
+IS_SANITIZER_OR_DEBUG=$($CLICKHOUSE_CLIENT -q "SELECT count() FROM system.warnings WHERE message like '%built with sanitizer%' or message like '%built in debug mode%'")
+if [ "$IS_SANITIZER_OR_DEBUG" -gt 0 ]; then
+    # Increase the timeout due to in debug/sanitizers build:
+    # - client is slow
+    # - stacktrace resolving is slow
+    TIMEOUT=15
 fi
 
 # TCP CLIENT: As of today (02/12/21) uses PullingAsyncPipelineExecutor
 ### Should be cancelled after 1 second and return a 159 exception (timeout)
-timeout -s KILL $MAX_PROCESS_WAIT $CLICKHOUSE_CLIENT --max_execution_time 1 -q \
-    "SELECT * FROM
+query_id=$(random_str 12)
+$CLICKHOUSE_CLIENT --query_id "$query_id" --max_execution_time 1 -q "
+    SELECT * FROM
     (
         SELECT a.name as n
         FROM
@@ -34,28 +30,35 @@ timeout -s KILL $MAX_PROCESS_WAIT $CLICKHOUSE_CLIENT --max_execution_time 1 -q \
         GROUP BY n
     )
     LIMIT 20
-    FORMAT Null" 2>&1 | grep -o "Code: 159" | sort | uniq
+    FORMAT Null
+" 2>&1 | grep -m1 -o "Code: 159"
+$CLICKHOUSE_CLIENT -q "system flush logs"
+${CLICKHOUSE_CURL} -q -sS "$CLICKHOUSE_URL" -d "select 'query_duration', round(query_duration_ms/1000) from system.query_log where current_database = '$CLICKHOUSE_DATABASE' and query_id = '$query_id' and type != 'QueryStart'"
+
 
 ### Should stop pulling data and return what has been generated already (return code 0)
-timeout -s KILL $MAX_PROCESS_WAIT $CLICKHOUSE_CLIENT -q \
-    "SELECT a.name as n
-     FROM
-     (
-         SELECT 'Name' as name, number FROM system.numbers LIMIT 2000000
-     ) AS a,
-     (
-         SELECT 'Name' as name2, number FROM system.numbers LIMIT 2000000
-     ) as b
-     FORMAT Null
-     SETTINGS max_execution_time = 1, timeout_overflow_mode = 'break'
-    "
+query_id=$(random_str 12)
+$CLICKHOUSE_CLIENT --query_id "$query_id" -q "
+    SELECT a.name as n
+    FROM
+    (
+        SELECT 'Name' as name, number FROM system.numbers LIMIT 2000000
+    ) AS a,
+    (
+        SELECT 'Name' as name2, number FROM system.numbers LIMIT 2000000
+    ) as b
+    FORMAT Null
+    SETTINGS max_execution_time = 1, timeout_overflow_mode = 'break'
+"
 echo $?
+$CLICKHOUSE_CLIENT -q "system flush logs"
+${CLICKHOUSE_CURL} -q -sS "$CLICKHOUSE_URL" -d "select 'query_duration', round(query_duration_ms/1000) from system.query_log where current_database = '$CLICKHOUSE_DATABASE' and query_id = '$query_id' and type != 'QueryStart'"
 
 
 # HTTP CLIENT: As of today (02/12/21) uses PullingPipelineExecutor
 ### Should be cancelled after 1 second and return a 159 exception (timeout)
-${CLICKHOUSE_CURL} -q --max-time $MAX_PROCESS_WAIT -sS "$CLICKHOUSE_URL&max_execution_time=1" -d \
-    "SELECT * FROM
+${CLICKHOUSE_CURL} -q --max-time $TIMEOUT -sS "$CLICKHOUSE_URL&max_execution_time=1" -d "
+    SELECT * FROM
     (
         SELECT a.name as n
         FROM
@@ -68,12 +71,13 @@ ${CLICKHOUSE_CURL} -q --max-time $MAX_PROCESS_WAIT -sS "$CLICKHOUSE_URL&max_exec
         GROUP BY n
     )
     LIMIT 20
-    FORMAT Null" 2>&1 | grep -o "Code: 159" | sort | uniq
+    FORMAT Null
+" 2>&1 | grep -o "Code: 159" | sort | uniq
 
 
 ### Should stop pulling data and return what has been generated already (return code 0)
-${CLICKHOUSE_CURL} -q --max-time $MAX_PROCESS_WAIT -sS "$CLICKHOUSE_URL" -d \
-    "SELECT a.name as n
+${CLICKHOUSE_CURL} -q --max-time $TIMEOUT -sS "$CLICKHOUSE_URL" -d "
+    SELECT a.name as n
           FROM
           (
               SELECT 'Name' as name, number FROM system.numbers LIMIT 2000000
@@ -83,5 +87,5 @@ ${CLICKHOUSE_CURL} -q --max-time $MAX_PROCESS_WAIT -sS "$CLICKHOUSE_URL" -d \
           ) as b
           FORMAT Null
           SETTINGS max_execution_time = 1, timeout_overflow_mode = 'break'
-    "
+"
 echo $?


### PR DESCRIPTION
CI found [1] failure of the test:

    2024-08-11 21:06:07 /usr/share/clickhouse-test/queries/0_stateless/02122_join_group_by_timeout.sh: line 51: 52614 Killed                  timeout -s KILL $MAX_PROCESS_WAIT $CLICKHOUSE_CLIENT -q "SELECT a.name as n

And the problem is not the server, but the client, since query executed for ~1 second:

    2024.08.11 21:06:02.284318 [ 49232 ] {ba989ee2-f615-49ca-bcd8-31b3916aeb2c} <Debug> executeQuery: (from [::1]:54144) (comment: 02122_join_group_by_timeout.sh) SELECT a.name as n FROM ( SELECT 'Name' as name, number FROM system.numbers LIMIT 2000000 ) AS a, ( SELECT 'Name' as name2, number FROM system.numbers LIMIT 2000000 ) as b FORMAT Null SETTINGS max_execution_time = 1, timeout_overflow_mode = 'break'  (stage: Complete)
    2024.08.11 21:06:03.331249 [ 49232 ] {ba989ee2-f615-49ca-bcd8-31b3916aeb2c} <Debug> executeQuery: Read 517104 rows, 3.95 MiB in 1.072023 sec., 482362.78512681165 rows/sec., 3.68 MiB/sec.

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/67134/18da3f0ab63da1eef9396627d0dfd56cf5356f65/stateless_tests__msan__[1_4].html

So instead of using timeout, let's use time from the system.query_log instead.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)