### PR TITLE
Fix test `01172_transaction_counters`

### DIFF
--- a/programs/server/config.d/transactions.xml
+++ b/programs/server/config.d/transactions.xml
@@ -1,0 +1,1 @@
+../../../tests/config/config.d/transactions.xml

--- a/tests/queries/0_stateless/01172_transaction_counters.reference
+++ b/tests/queries/0_stateless/01172_transaction_counters.reference
@@ -16,25 +16,25 @@
 7	all_3_3_0	(0,0,'00000000-0000-0000-0000-000000000000')	0
 7	all_4_4_0	(0,0,'00000000-0000-0000-0000-000000000000')	0
 8	1
-1	1	AddPart	1	1	1	1	all_1_1_0
-2	1	Begin	1	1	1	1	
-2	1	AddPart	1	1	1	1	all_2_2_0
-2	1	Rollback	1	1	1	1	
-3	1	Begin	1	1	1	1	
-3	1	AddPart	1	1	1	1	all_3_3_0
-3	1	Commit	1	1	1	0	
-1	1	LockPart	1	1	1	1	all_2_2_0
-4	1	Begin	1	1	1	1	
-4	1	AddPart	1	1	1	1	all_4_4_0
-4	1	Commit	1	1	1	0	
-5	1	Begin	1	1	1	1	
-5	1	AddPart	1	1	1	1	all_5_5_0
-5	1	LockPart	1	1	1	1	all_1_1_0
-5	1	LockPart	1	1	1	1	all_3_3_0
-5	1	LockPart	1	1	1	1	all_4_4_0
-5	1	LockPart	1	1	1	1	all_5_5_0
-5	1	UnlockPart	1	1	1	1	all_1_1_0
-5	1	UnlockPart	1	1	1	1	all_3_3_0
-5	1	UnlockPart	1	1	1	1	all_4_4_0
-5	1	UnlockPart	1	1	1	1	all_5_5_0
-5	1	Rollback	1	1	1	1	
+1	AddPart	1	1	1	1	all_1_1_0
+2	Begin	1	1	1	1	
+2	AddPart	1	1	1	1	all_2_2_0
+2	Rollback	1	1	1	1	
+3	Begin	1	1	1	1	
+3	AddPart	1	1	1	1	all_3_3_0
+3	Commit	1	1	1	0	
+1	LockPart	1	1	1	1	all_2_2_0
+4	Begin	1	1	1	1	
+4	AddPart	1	1	1	1	all_4_4_0
+4	Commit	1	1	1	0	
+5	Begin	1	1	1	1	
+5	AddPart	1	1	1	1	all_5_5_0
+5	LockPart	1	1	1	1	all_1_1_0
+5	LockPart	1	1	1	1	all_3_3_0
+5	LockPart	1	1	1	1	all_4_4_0
+5	LockPart	1	1	1	1	all_5_5_0
+5	UnlockPart	1	1	1	1	all_1_1_0
+5	UnlockPart	1	1	1	1	all_3_3_0
+5	UnlockPart	1	1	1	1	all_4_4_0
+5	UnlockPart	1	1	1	1	all_5_5_0
+5	Rollback	1	1	1	1	

--- a/tests/queries/0_stateless/01172_transaction_counters.sql
+++ b/tests/queries/0_stateless/01172_transaction_counters.sql
@@ -42,7 +42,6 @@ rollback;
 
 system flush logs;
 select indexOf((select arraySort(groupUniqArray(tid)) from system.transactions_info_log where database=currentDatabase() and table='txn_counters'), tid),
-       (toDecimal64(now64(6), 6) - toDecimal64(event_time, 6)) < 100,
        type,
        thread_id!=0,
        length(query_id)=length(queryID()) or type='Commit' and query_id='',  -- ignore fault injection after commit


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

The test contained a comparison of wall clock time, so it is inherently wrong.
There was no comment about why it is needed.

Closes #68165

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
