### PR TITLE
[RFC] Simpler TimerDescriptor code (instead of drain, just re-create)

### DIFF
--- a/src/Client/ConnectionEstablisher.cpp
+++ b/src/Client/ConnectionEstablisher.cpp
@@ -126,7 +126,6 @@ ConnectionEstablisherAsync::ConnectionEstablisherAsync(
     : AsyncTaskExecutor(std::make_unique<Task>(*this))
     , connection_establisher(std::move(pool_), timeouts_, settings_, log_, table_to_check_)
 {
-    epoll.add(timeout_descriptor.getDescriptor());
 }
 
 void ConnectionEstablisherAsync::Task::run(AsyncCallback async_callback, SuspendCallback)
@@ -143,12 +142,14 @@ void ConnectionEstablisherAsync::processAsyncEvent(int fd, Poco::Timespan socket
     socket_description = description;
     epoll.add(fd, events);
     timeout_descriptor.setRelative(socket_timeout);
+    epoll.add(timeout_descriptor.getDescriptor());
     timeout = socket_timeout;
     timeout_type = type;
 }
 
 void ConnectionEstablisherAsync::clearAsyncEvent()
 {
+    epoll.remove(timeout_descriptor.getDescriptor());
     timeout_descriptor.reset();
     epoll.remove(socket_fd);
 }

--- a/src/Common/TimerDescriptor.cpp
+++ b/src/Common/TimerDescriptor.cpp
@@ -17,14 +17,12 @@ namespace ErrorCodes
 {
     extern const int CANNOT_CREATE_TIMER;
     extern const int CANNOT_SET_TIMER_PERIOD;
-    extern const int CANNOT_READ_FROM_SOCKET;
+    extern const int SYSTEM_ERROR;
 }
 
 TimerDescriptor::TimerDescriptor()
 {
-    timer_fd = timerfd_create(CLOCK_MONOTONIC, TFD_NONBLOCK | TFD_CLOEXEC);
-    if (timer_fd == -1)
-        throw ErrnoException(ErrorCodes::CANNOT_CREATE_TIMER, "Cannot create timer_fd descriptor");
+    init();
 }
 
 TimerDescriptor::TimerDescriptor(TimerDescriptor && other) noexcept
@@ -48,92 +46,22 @@ TimerDescriptor::~TimerDescriptor()
     }
 }
 
-void TimerDescriptor::reset() const
+void TimerDescriptor::reset()
 {
     if (timer_fd == -1)
         return;
 
-    itimerspec spec{};
+    if (0 != ::close(timer_fd))
+        throw ErrnoException(ErrorCodes::SYSTEM_ERROR, "Cannot close timer_fd descriptor");
 
-    if (-1 == timerfd_settime(timer_fd, 0 /*relative timer */, &spec, nullptr))
-        throw ErrnoException(ErrorCodes::CANNOT_SET_TIMER_PERIOD, "Cannot reset timer_fd");
-
-    /// Drain socket.
-    /// It may be possible that alarm happened and socket is readable.
-    drain();
+    init();
 }
 
-void TimerDescriptor::drain() const
+void TimerDescriptor::init()
 {
+    timer_fd = timerfd_create(CLOCK_MONOTONIC, TFD_NONBLOCK | TFD_CLOEXEC);
     if (timer_fd == -1)
-        return;
-
-    /// It is expected that socket returns 8 bytes when readable.
-    /// Read in loop anyway cause signal may interrupt read call.
-
-    /// man timerfd_create:
-    /// If the timer has already expired one or more times since its settings were last modified using timerfd_settime(),
-    /// or since the last successful read(2), then the buffer given to read(2) returns an unsigned 8-byte integer (uint64_t)
-    /// containing the number of expirations that have occurred.
-    /// (The returned value is in host byte order—that is, the native byte order for integers on the host machine.)
-
-    /// Due to a bug in Linux Kernel, reading from timerfd in non-blocking mode can be still blocking.
-    /// Avoid it with polling.
-    Epoll epoll;
-    epoll.add(timer_fd);
-    epoll_event event;
-    event.data.fd = -1;
-    size_t ready_count = epoll.getManyReady(1, &event, 0);
-    if (!ready_count)
-        return;
-
-    uint64_t buf;
-    while (true)
-    {
-        ssize_t res = ::read(timer_fd, &buf, sizeof(buf));
-
-        if (res < 0)
-        {
-            /// man timerfd_create:
-            /// If no timer expirations have occurred at the time of the read(2),
-            /// then the call either blocks until the next timer expiration, or fails with the error EAGAIN
-            /// if the file descriptor has been made nonblocking
-            /// (via the use of the fcntl(2) F_SETFL operation to set the O_NONBLOCK flag).
-            if (errno == EAGAIN)
-                break;
-
-            /// A signal happened, need to retry.
-            if (errno == EINTR)
-            {
-                /** This is to help with debugging.
-                  *
-                  * Sometimes reading from timer_fd blocks, which should not happen, because we opened it in a non-blocking mode.
-                  * But it could be possible if a rogue 3rd-party library closed our file descriptor by mistake
-                  * (for example by double closing due to the lack of exception safety or if it is a crappy code in plain C)
-                  * and then another file descriptor is opened in its place.
-                  *
-                  * Let's try to get a name of this file descriptor and log it.
-                  */
-                LoggerPtr log = getLogger("TimerDescriptor");
-
-                static constexpr ssize_t max_link_path_length = 256;
-                char link_path[max_link_path_length];
-                ssize_t link_path_length = readlink(fmt::format("/proc/self/fd/{}", timer_fd).c_str(), link_path, max_link_path_length);
-                if (-1 == link_path_length)
-                    throw ErrnoException(ErrorCodes::CANNOT_READ_FROM_SOCKET, "Cannot readlink for a timer_fd {}", timer_fd);
-
-                LOG_TRACE(log, "Received EINTR while trying to drain a TimerDescriptor, fd {}: {}", timer_fd, std::string_view(link_path, link_path_length));
-
-                /// Check that it's actually a timerfd.
-                chassert(std::string_view(link_path, link_path_length).contains("timerfd"));
-                continue;
-            }
-
-            throw ErrnoException(ErrorCodes::CANNOT_READ_FROM_SOCKET, "Cannot drain timer_fd {}", timer_fd);
-        }
-
-        chassert(res == sizeof(buf));
-    }
+        throw ErrnoException(ErrorCodes::CANNOT_CREATE_TIMER, "Cannot create timer_fd descriptor");
 }
 
 void TimerDescriptor::setRelative(uint64_t usec) const

--- a/src/Common/TimerDescriptor.h
+++ b/src/Common/TimerDescriptor.h
@@ -22,10 +22,14 @@ public:
 
     int getDescriptor() const { return timer_fd; }
 
-    void reset() const;
-    void drain() const;
+    /// Invalidates the timer_fd descriptor
+    void reset();
+
     void setRelative(uint64_t usec) const;
     void setRelative(Poco::Timespan timespan) const;
+
+private:
+    void init();
 };
 
 }

--- a/src/QueryPipeline/RemoteQueryExecutorReadContext.cpp
+++ b/src/QueryPipeline/RemoteQueryExecutorReadContext.cpp
@@ -96,7 +96,7 @@ bool RemoteQueryExecutorReadContext::checkTimeout(bool blocking)
     if (is_timer_alarmed && !is_socket_ready)
     {
         /// Socket timeout. Drain it in case of error, or it may be hide by timeout exception.
-        timer.drain();
+        timer.reset();
         const String exception_message = getSocketTimeoutExceededMessageByTimeoutType(timeout_type, timeout, connection_fd_description);
         throw NetException(ErrorCodes::SOCKET_TIMEOUT, exception_message);
     }


### PR DESCRIPTION
Due to buggy timer_fd [1] is simpler to just re-create the timer_fd instead of try to keep existing fd in the correct state.

  [1]: https://patchwork.kernel.org/project/linux-fsdevel/patch/b4059ed0-5567-44e7-95f7-f7e4b227501c@kernel.dk/

But this invalidates the timer_fd, altough I've looked through the users, it can be tricky. So it is an open question is it better or not.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Refs: https://github.com/ClickHouse/ClickHouse/issues/37686