### PR TITLE
Fix non-deterministic result order in `test_storage_mysql.test_mysql_distributed`

### DIFF
--- a/tests/integration/test_storage_mysql/test.py
+++ b/tests/integration/test_storage_mysql/test.py
@@ -445,7 +445,7 @@ def test_mysql_distributed(started_cluster):
     query = "SELECT * FROM ("
     for i in range(3):
         query += "SELECT name FROM test_replicas UNION DISTINCT "
-    query += "SELECT name FROM test_replicas)"
+    query += "SELECT name FROM test_replicas) ORDER BY name"
 
     result = node2.query(query)
     assert result == "host2\nhost3\nhost4\n"
@@ -827,6 +827,9 @@ def test_settings(started_cluster):
         f"with settings: connect_timeout={connect_timeout}, read_write_timeout={rw_timeout}"
     )
 
+    node1.query("DROP DATABASE IF EXISTS m")
+    node1.query("DROP DATABASE IF EXISTS mm")
+
     rw_timeout = 40123001
     connect_timeout = 40123002
     node1.query(
@@ -854,6 +857,9 @@ def test_settings(started_cluster):
     assert node1.contains_in_log(
         f"with settings: connect_timeout={connect_timeout}, read_write_timeout={rw_timeout}"
     )
+
+    node1.query("DROP DATABASE m")
+    node1.query("DROP DATABASE mm")
 
     drop_mysql_table(conn, table_name)
     conn.close()
@@ -930,6 +936,9 @@ def test_joins(started_cluster):
 
     conn.commit()
 
+    node1.query("DROP TABLE IF EXISTS test_joins_table_users")
+    node1.query("DROP TABLE IF EXISTS test_joins_table_tickets")
+
     node1.query(
         """
         CREATE TABLE test_joins_table_users
@@ -963,6 +972,9 @@ def test_joins(started_cluster):
         WHERE test_joins_table_tickets.Created = '2024-06-25 12:09:41'
         """
     ) == "281607\tFeedback\t2024-06-25 12:09:41\tuser@example.com\n"
+
+    node1.query("DROP TABLE test_joins_table_users")
+    node1.query("DROP TABLE test_joins_table_tickets")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I noticed a failure of `test_storage_mysql.test_mysql_distributed` in the private sync PR of https://github.com/ClickHouse/ClickHouse/pull/68069. It was caused by a non-deterministic result order due to a missing `ORDER BY`.

```
=================================== FAILURES ===================================
____________________________ test_mysql_distributed ____________________________
[gw1] linux -- Python 3.10.12 /usr/bin/python3

started_cluster = <helpers.cluster.ClickHouseCluster object at 0x7f737bb147c0>

    def test_mysql_distributed(started_cluster):
        table_name = "test_replicas"
    
        conn1 = get_mysql_conn(started_cluster, started_cluster.mysql8_ip)
        conn2 = get_mysql_conn(started_cluster, started_cluster.mysql2_ip)
        conn3 = get_mysql_conn(started_cluster, started_cluster.mysql3_ip)
        conn4 = get_mysql_conn(started_cluster, started_cluster.mysql4_ip)
    
        create_mysql_db(conn1, "clickhouse")
        create_mysql_db(conn2, "clickhouse")
        create_mysql_db(conn3, "clickhouse")
        create_mysql_db(conn4, "clickhouse")
    
        create_mysql_table(conn1, table_name)
        create_mysql_table(conn2, table_name)
        create_mysql_table(conn3, table_name)
        create_mysql_table(conn4, table_name)
    
        node2.query("DROP TABLE IF EXISTS test_replicas")
    
        # Storage with with 3 replicas
        node2.query(
            """
            CREATE TABLE test_replicas
            (id UInt32, name String, age UInt32, money UInt32)
            ENGINE = MySQL('mysql{2|3|4}:3306', 'clickhouse', 'test_replicas', 'root', 'clickhouse'); """
        )
    
        # Fill remote tables with different data to be able to check
        nodes = [node1, node2, node2, node2]
        for i in range(1, 5):
            nodes[i - 1].query("DROP TABLE IF EXISTS test_replica{}".format(i))
            nodes[i - 1].query(
                """
                CREATE TABLE test_replica{}
                (id UInt32, name String, age UInt32, money UInt32)
                ENGINE = MySQL('mysql{}:3306', 'clickhouse', 'test_replicas', 'root', 'clickhouse');""".format(
                    i, 80 if i == 1 else i
                )
            )
            nodes[i - 1].query(
                "INSERT INTO test_replica{} (id, name) SELECT number, 'host{}' from numbers(10) ".format(
                    i, i
                )
            )
    
        # test multiple ports parsing
        result = node2.query(
            """SELECT DISTINCT(name) FROM mysql('mysql{80|2|3}:3306', 'clickhouse', 'test_replicas', 'root', 'clickhouse'); """
        )
        assert result == "host1\n" or result == "host2\n" or result == "host3\n"
        result = node2.query(
            """SELECT DISTINCT(name) FROM mysql('mysql80:3306|mysql2:3306|mysql3:3306', 'clickhouse', 'test_replicas', 'root', 'clickhouse'); """
        )
        assert result == "host1\n" or result == "host2\n" or result == "host3\n"
    
        # check all replicas are traversed
        query = "SELECT * FROM ("
        for i in range(3):
            query += "SELECT name FROM test_replicas UNION DISTINCT "
        query += "SELECT name FROM test_replicas)"
    
        result = node2.query(query)
>       assert result == "host2\nhost3\nhost4\n"
E       AssertionError: assert 'host3\nhost2\nhost4\n' == 'host2\nhost3\nhost4\n'
E         + host3
E           host2
E         - host3
E           host4

test_storage_mysql/test.py:451: AssertionError
```

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)