### PR TITLE
Remove Log engine from Kafka integration tests

### DIFF
--- a/tests/integration/test_storage_kafka/test.py
+++ b/tests/integration/test_storage_kafka/test.py
@@ -4796,7 +4796,7 @@ def test_max_rows_per_message(kafka_cluster, create_query_generator):
             DROP TABLE IF EXISTS test.kafka;
             {create_query};
 
-            CREATE MATERIALIZED VIEW test.view ENGINE=MergeTree ORDER BY key, value AS
+            CREATE MATERIALIZED VIEW test.view ENGINE=MergeTree ORDER BY (key, value) AS
                 SELECT key, value FROM test.kafka;
         """
         )
@@ -4875,7 +4875,7 @@ def test_row_based_formats(kafka_cluster, create_query_generator):
 
                 {create_query};
 
-                CREATE MATERIALIZED VIEW test.view ENGINE=MergeTree ORDER BY key, value AS
+                CREATE MATERIALIZED VIEW test.view ENGINE=MergeTree ORDER BY (key, value) AS
                     SELECT key, value FROM test.{table_name};
 
                 INSERT INTO test.{table_name} SELECT number * 10 as key, number * 100 as value FROM numbers({num_rows});
@@ -4982,7 +4982,7 @@ def test_block_based_formats_2(kafka_cluster, create_query_generator):
 
                 {create_query};
 
-                CREATE MATERIALIZED VIEW test.view ENGINE=MergeTree ORDER BY key, value AS
+                CREATE MATERIALIZED VIEW test.view ENGINE=MergeTree ORDER BY (key, value) AS
                     SELECT key, value FROM test.{table_name};
 
                 INSERT INTO test.{table_name} SELECT number * 10 as key, number * 100 as value FROM numbers({num_rows}) settings max_block_size=12, optimize_trivial_insert_select=0;
@@ -5362,7 +5362,7 @@ def test_formats_errors(kafka_cluster):
                             input_format_with_names_use_header=0,
                             format_schema='key_value_message:Message';
 
-                CREATE MATERIALIZED VIEW test.view ENGINE=MergeTree ORDER BY key, value AS
+                CREATE MATERIALIZED VIEW test.view ENGINE=MergeTree ORDER BY (key, value) AS
                     SELECT key, value FROM test.{table_name};
             """
             )

--- a/tests/integration/test_storage_kafka/test.py
+++ b/tests/integration/test_storage_kafka/test.py
@@ -1019,7 +1019,7 @@ def test_kafka_formats(kafka_cluster, create_query_generator):
 
             DROP TABLE IF EXISTS test.kafka_{format_name}_mv;
 
-            CREATE MATERIALIZED VIEW test.kafka_{format_name}_mv Engine=Log AS
+            CREATE MATERIALIZED VIEW test.kafka_{format_name}_mv ENGINE=MergeTree ORDER BY tuple() AS
                 SELECT *, _topic, _partition, _offset FROM test.kafka_{format_name};
             """.format(
                 topic_name=topic_name,
@@ -2460,7 +2460,7 @@ def test_kafka_commit_on_block_write(kafka_cluster, create_query_generator):
         (generate_old_create_table_query, "kafka.*Committed offset 2.*virt2_[01]"),
         (
             generate_new_create_table_query,
-            r"kafka.*Saved offset 2[0-9]* for topic-partition \[virt2_[01]:[0-9]+",
+            r"kafka.*Saved offset 2 for topic-partition \[virt2_[01]:[0-9]+",
         ),
     ],
 )
@@ -2494,7 +2494,7 @@ def test_kafka_virtual_columns2(kafka_cluster, create_query_generator, log_line)
                 f"""
                 {create_query};
 
-                CREATE MATERIALIZED VIEW test.view Engine=Log AS
+                CREATE MATERIALIZED VIEW test.view ENGINE=MergeTree ORDER BY tuple() AS
                 SELECT value, _key, _topic, _partition, _offset, toUnixTimestamp(_timestamp), toUnixTimestamp64Milli(_timestamp_ms), _headers.name, _headers.value FROM test.kafka;
                 """
             )
@@ -2729,7 +2729,7 @@ def test_kafka_produce_key_timestamp(kafka_cluster, create_query_generator, log_
             DROP TABLE IF EXISTS test.consumer;
             {writer_create_query};
             {reader_create_query};
-            CREATE MATERIALIZED VIEW test.view Engine=Log AS
+            CREATE MATERIALIZED VIEW test.view ENGINE=MergeTree ORDER BY tuple() AS
                 SELECT key, value, inserted_key, toUnixTimestamp(inserted_timestamp), _key, _topic, _partition, _offset, toUnixTimestamp(_timestamp) FROM test.kafka;
         """
         )
@@ -2865,7 +2865,7 @@ def test_kafka_produce_consume_avro(kafka_cluster, create_query_generator):
             {writer_create_query};
             {reader_create_query};
 
-            CREATE MATERIALIZED VIEW test.view Engine=Log AS
+            CREATE MATERIALIZED VIEW test.view ENGINE=MergeTree ORDER BY tuple() AS
                 SELECT key, value FROM test.kafka;
             """
         )
@@ -3537,7 +3537,7 @@ def test_bad_reschedule(kafka_cluster, create_query_generator):
         f"""
         {create_query};
 
-        CREATE MATERIALIZED VIEW test.destination Engine=Log AS
+        CREATE MATERIALIZED VIEW test.destination ENGINE=MergeTree ORDER BY tuple() AS
         SELECT
             key,
             now() as consume_ts,
@@ -3745,7 +3745,7 @@ def test_kafka_unavailable(kafka_cluster, create_query_generator, do_direct_read
             f"""
             {create_query};
 
-            CREATE MATERIALIZED VIEW test.destination_unavailable Engine=Log AS
+            CREATE MATERIALIZED VIEW test.destination_unavailable ENGINE=MergeTree ORDER BY tuple() AS
             SELECT
                 key,
                 now() as consume_ts,
@@ -4267,12 +4267,12 @@ def test_kafka_formats_with_broken_message(kafka_cluster, create_query_generator
             {create_query};
 
             DROP TABLE IF EXISTS test.kafka_data_{format_name}_mv;
-            CREATE MATERIALIZED VIEW test.kafka_data_{format_name}_mv Engine=Log AS
+            CREATE MATERIALIZED VIEW test.kafka_data_{format_name}_mv ENGINE=MergeTree ORDER BY tuple() AS
                 SELECT *, _topic, _partition, _offset FROM test.kafka_{format_name}
                 WHERE length(_error) = 0;
 
             DROP TABLE IF EXISTS test.kafka_errors_{format_name}_mv;
-            CREATE MATERIALIZED VIEW test.kafka_errors_{format_name}_mv Engine=Log AS
+            CREATE MATERIALIZED VIEW test.kafka_errors_{format_name}_mv ENGINE=MergeTree ORDER BY tuple() AS
                 SELECT {raw_message} as raw_message, _error as error, _topic as topic, _partition as partition, _offset as offset FROM test.kafka_{format_name}
                 WHERE length(_error) > 0;
             """
@@ -4796,7 +4796,7 @@ def test_max_rows_per_message(kafka_cluster, create_query_generator):
             DROP TABLE IF EXISTS test.kafka;
             {create_query};
 
-            CREATE MATERIALIZED VIEW test.view Engine=Log AS
+            CREATE MATERIALIZED VIEW test.view ENGINE=MergeTree ORDER BY key, value AS
                 SELECT key, value FROM test.kafka;
         """
         )
@@ -4875,7 +4875,7 @@ def test_row_based_formats(kafka_cluster, create_query_generator):
 
                 {create_query};
 
-                CREATE MATERIALIZED VIEW test.view Engine=Log AS
+                CREATE MATERIALIZED VIEW test.view ENGINE=MergeTree ORDER BY key, value AS
                     SELECT key, value FROM test.{table_name};
 
                 INSERT INTO test.{table_name} SELECT number * 10 as key, number * 100 as value FROM numbers({num_rows});
@@ -4982,7 +4982,7 @@ def test_block_based_formats_2(kafka_cluster, create_query_generator):
 
                 {create_query};
 
-                CREATE MATERIALIZED VIEW test.view Engine=Log AS
+                CREATE MATERIALIZED VIEW test.view ENGINE=MergeTree ORDER BY key, value AS
                     SELECT key, value FROM test.{table_name};
 
                 INSERT INTO test.{table_name} SELECT number * 10 as key, number * 100 as value FROM numbers({num_rows}) settings max_block_size=12, optimize_trivial_insert_select=0;
@@ -5362,7 +5362,7 @@ def test_formats_errors(kafka_cluster):
                             input_format_with_names_use_header=0,
                             format_schema='key_value_message:Message';
 
-                CREATE MATERIALIZED VIEW test.view Engine=Log AS
+                CREATE MATERIALIZED VIEW test.view ENGINE=MergeTree ORDER BY key, value AS
                     SELECT key, value FROM test.{table_name};
             """
             )


### PR DESCRIPTION
It doesn't work well when `thread_per_consumer` is used as writer can make readers starve when `shared_time_mutex` prefers writes over reads. Closes #68240

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
