### PR TITLE
[Green CI] Test 00652_mergetree_mutations is flaky

### DIFF
--- a/tests/queries/0_stateless/00652_mergetree_mutations.sh
+++ b/tests/queries/0_stateless/00652_mergetree_mutations.sh
@@ -73,7 +73,7 @@ sleep 0.1
 for i in {1..10}
 do
 
-    if [ $(${CLICKHOUSE_CLIENT} --query="SELECT count() FROM system.mutations WHERE database = '$CLICKHOUSE_DATABASE' and table = 'mutations_cleaner'") -eq 2 ]; then
+    if [ "$(${CLICKHOUSE_CLIENT} --query="SELECT count() FROM system.mutations WHERE database = '$CLICKHOUSE_DATABASE' and table = 'mutations_cleaner'")" -eq 2 ]; then
         break
     fi
 

--- a/tests/queries/0_stateless/00652_mergetree_mutations.sh
+++ b/tests/queries/0_stateless/00652_mergetree_mutations.sh
@@ -89,4 +89,3 @@ done
 ${CLICKHOUSE_CLIENT} --query="SELECT mutation_id, command, is_done FROM system.mutations WHERE database = '$CLICKHOUSE_DATABASE' and table = 'mutations_cleaner' ORDER BY mutation_id"
 
 ${CLICKHOUSE_CLIENT} --query="DROP TABLE mutations_cleaner"
-

--- a/tests/queries/0_stateless/00652_mergetree_mutations.sh
+++ b/tests/queries/0_stateless/00652_mergetree_mutations.sh
@@ -70,7 +70,23 @@ sleep 1
 ${CLICKHOUSE_CLIENT} --query="INSERT INTO mutations_cleaner(x) VALUES (4)"
 sleep 0.1
 
+for i in {1..10}
+do
+
+    if [ $(${CLICKHOUSE_CLIENT} --query="SELECT count() FROM system.mutations WHERE database = '$CLICKHOUSE_DATABASE' and table = 'mutations_cleaner'") -eq 2 ]; then
+        break
+    fi
+
+    if [[ $i -eq 100 ]]; then
+        echo "Timed out while waiting for outdated mutation record to be deleted!"
+    fi
+
+    sleep 1
+    ${CLICKHOUSE_CLIENT} --query="INSERT INTO mutations_cleaner(x) VALUES (4)"  
+done
+
 # Check that the first mutation is cleaned
 ${CLICKHOUSE_CLIENT} --query="SELECT mutation_id, command, is_done FROM system.mutations WHERE database = '$CLICKHOUSE_DATABASE' and table = 'mutations_cleaner' ORDER BY mutation_id"
 
 ${CLICKHOUSE_CLIENT} --query="DROP TABLE mutations_cleaner"
+


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

Closes https://github.com/ClickHouse/ClickHouse/issues/67861

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
