### PR TITLE
Some fixes for LDAP

### DIFF
--- a/src/Access/LDAPAccessStorage.cpp
+++ b/src/Access/LDAPAccessStorage.cpp
@@ -128,7 +128,7 @@ void LDAPAccessStorage::processRoleChange(const UUID & id, const AccessEntityPtr
     {
         if (it != granted_role_names.end()) // Removed a granted role.
         {
-            const auto & old_role_name = it->second;
+            const auto old_role_name = it->second;
             applyRoleChangeNoLock(false /* revoke */, id, old_role_name);
         }
     }

--- a/src/Access/LDAPAccessStorage.cpp
+++ b/src/Access/LDAPAccessStorage.cpp
@@ -128,7 +128,7 @@ void LDAPAccessStorage::processRoleChange(const UUID & id, const AccessEntityPtr
     {
         if (it != granted_role_names.end()) // Removed a granted role.
         {
-            const auto old_role_name = it->second;
+            const auto & old_role_name = it->second;
             applyRoleChangeNoLock(false /* revoke */, id, old_role_name);
         }
     }
@@ -191,8 +191,8 @@ void LDAPAccessStorage::applyRoleChangeNoLock(bool grant, const UUID & role_id, 
     }
     else
     {
-        granted_role_names.erase(role_id);
         granted_role_ids.erase(role_name);
+        granted_role_names.erase(role_id);
     }
 }
 

--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -4716,6 +4716,9 @@ class ClickHouseInstance:
         if self.with_kerberized_hdfs:
             depends_on.append("kerberizedhdfs1")
 
+        if self.with_ldap:
+            depends_on.append("openldap")
+
         if self.with_rabbitmq:
             depends_on.append("rabbitmq1")
 

--- a/tests/integration/test_ldap_external_user_directory/test.py
+++ b/tests/integration/test_ldap_external_user_directory/test.py
@@ -48,9 +48,32 @@ ldapadd -H ldap://{host}:{port} -D "{admin_bind_dn}" -x -w {admin_password}
     assert code == 0
 
 
+def delete_ldap_group(ldap_cluster, group_cn):
+    code, (stdout, stderr) = ldap_cluster.ldap_container.exec_run(
+        [
+            "sh",
+            "-c",
+            """ldapdelete -r 'cn={group_cn},dc=example,dc=org' \
+-H ldap://{host}:{port} -D "{admin_bind_dn}" -x -w {admin_password}
+            """.format(
+                host=ldap_cluster.ldap_host,
+                port=ldap_cluster.ldap_port,
+                admin_bind_dn=LDAP_ADMIN_BIND_DN,
+                admin_password=LDAP_ADMIN_PASSWORD,
+                group_cn=group_cn,
+            ),
+        ],
+        demux=True,
+    )
+    logging.debug(
+        f"test_ldap_external_user_directory code:{code} stdout:{stdout}, stderr:{stderr}"
+    )
+    assert code == 0
+
+
 def test_authentication_pass():
     assert instance.query(
-        "select currentUser()", user="janedoe", password="qwerty"
+        "SELECT currentUser()", user="janedoe", password="qwerty"
     ) == TSV([["janedoe"]])
 
 
@@ -93,3 +116,11 @@ def test_role_mapping(ldap_cluster):
         user="johndoe",
         password="qwertz",
     ) == TSV([["role_1"], ["role_2"], ["role_3"]])
+
+    instance.query("DROP ROLE role_1")
+    instance.query("DROP ROLE role_2")
+    instance.query("DROP ROLE role_3")
+
+    delete_ldap_group(ldap_cluster, group_cn="clickhouse-role_1")
+    delete_ldap_group(ldap_cluster, group_cn="clickhouse-role_2")
+    delete_ldap_group(ldap_cluster, group_cn="clickhouse-role_3")

--- a/tests/integration/test_ldap_external_user_directory/test.py
+++ b/tests/integration/test_ldap_external_user_directory/test.py
@@ -90,6 +90,9 @@ def test_authentication_fail():
 
 
 def test_role_mapping(ldap_cluster):
+    instance.query("DROP ROLE IF EXISTS role_1")
+    instance.query("DROP ROLE IF EXISTS role_2")
+    instance.query("DROP ROLE IF EXISTS role_3")
     instance.query("CREATE ROLE role_1")
     instance.query("CREATE ROLE role_2")
     add_ldap_group(ldap_cluster, group_cn="clickhouse-role_1", member_cn="johndoe")
@@ -124,3 +127,4 @@ def test_role_mapping(ldap_cluster):
     delete_ldap_group(ldap_cluster, group_cn="clickhouse-role_1")
     delete_ldap_group(ldap_cluster, group_cn="clickhouse-role_2")
     delete_ldap_group(ldap_cluster, group_cn="clickhouse-role_3")
+    delete_ldap_group(ldap_cluster, group_cn="clickhouse-role_4")


### PR DESCRIPTION
Fix `heap-use-after-free` on DROP of LDAP-related roles (e.g. https://s3.amazonaws.com/clickhouse-test-reports/68355/80b28e33bb3d9fa3e1bbc2b1867086d8cc0a0a70/integration_tests__asan__old_analyzer__[4_6]//home/ubuntu/actions-runner/_work/_temp/test/output_dir/integration_run_parallel1_0.log)

Add missing `depends_on` in attempt to fix occasional fails of `test_ldap_external_user_directory`.

Closes #69555, maybe closes #65762

### Changelog category (leave one):
- Critical Bug Fix (crash, LOGICAL_ERROR, data loss, RBAC)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix crash on drop or rename a role that is used in LDAP external user directory


#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---ci_include_fuzzer--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
