### PR TITLE
Revert "[RFC] Fix settings/current_database in system.processes for async BACKUP/RESTORE"

### DIFF
--- a/src/Backups/BackupsWorker.cpp
+++ b/src/Backups/BackupsWorker.cpp
@@ -490,8 +490,6 @@ OperationID BackupsWorker::startMakingBackup(const ASTPtr & query, const Context
 
             /// process_list_element_holder is used to make an element in ProcessList live while BACKUP is working asynchronously.
             auto process_list_element = context_in_use->getProcessListElement();
-            /// Update context to preserve query information in processlist (settings, current_database)
-            process_list_element->updateContext(context_in_use);
 
             thread_pool.scheduleOrThrowOnError(
                 [this,
@@ -855,8 +853,6 @@ OperationID BackupsWorker::startRestoring(const ASTPtr & query, ContextMutablePt
 
             /// process_list_element_holder is used to make an element in ProcessList live while RESTORE is working asynchronously.
             auto process_list_element = context_in_use->getProcessListElement();
-            /// Update context to preserve query information in processlist (settings, current_database)
-            process_list_element->updateContext(context_in_use);
 
             thread_pool.scheduleOrThrowOnError(
                 [this,

--- a/src/Interpreters/ProcessList.h
+++ b/src/Interpreters/ProcessList.h
@@ -244,9 +244,6 @@ public:
     /// Same as checkTimeLimit but it never throws
     [[nodiscard]] bool checkTimeLimitSoft();
 
-    /// Use it in case of the query left in background to execute asynchronously
-    void updateContext(ContextWeakPtr weak_context) { context = std::move(weak_context); }
-
     /// Get the reference for the start of the query. Used to synchronize with other Stopwatches
     UInt64 getQueryCPUStartTime() { return watch.getStart(); }
 };


### PR DESCRIPTION
Reverts ClickHouse/ClickHouse#68163

This is the most probably cause of a `LOGICAL_ERROR` in our [integration test](https://play.clickhouse.com/play?user=play#U0VMRUNUIGNoZWNrX3N0YXJ0X3RpbWUsIGNoZWNrX25hbWUsIHRlc3RfbmFtZSwgdGVzdF9zdGF0dXMsIGNoZWNrX3N0YXR1cywgcmVwb3J0X3VybApGUk9NIGNoZWNrcwpXSEVSRSAxCiAgICAtLSBBTkQgcHVsbF9yZXF1ZXN0X251bWJlciAhPSAwCiAgICBBTkQgdGVzdF9zdGF0dXMgIT0gJ1NLSVBQRUQnCiAgICBBTkQgdGVzdF9zdGF0dXMgIT0gJ09LJwogICAgQU5EIGNoZWNrX3N0YXR1cyAhPSAnc3VjY2VzcycKICAgIEFORCB0ZXN0X25hbWUgaWxpa2UgJyV0ZXN0X2JhY2t1cF9yZXN0b3JlX25ldy90ZXN0LnB5Ojp0ZXN0X3RlbXBvcmFyeV9kYXRhYmFzZSUnCiAgICBBTkQgY2hlY2tfc3RhcnRfdGltZSA+IHRvZGF5KCkgLSBJTlRFUlZBTCA1IERBWVMKT1JERVIgQlkgY2hlY2tfc3RhcnRfdGltZSBkZXNjLCBjaGVja19uYW1lLCB0ZXN0X25hbWU=):

```
E           helpers.client.QueryRuntimeException: Client failed! Return code: 32, stderr: [instance] 2024.08.15 04:46:09.472095 [ 9 ] {f857c866-77a8-49f6-a7ae-a184488ebc4e} <Fatal> : Logical error: 'Context has expired'.
E           [instance] 2024.08.15 04:46:09.507243 [ 9 ] {f857c866-77a8-49f6-a7ae-a184488ebc4e} <Fatal> : Stack trace (when copying this message, always include the lines below):
E           
E           0. ./contrib/llvm-project/libcxx/include/exception:141: Poco::Exception::Exception(String const&, int) @ 0x000000003404dfd4
E           1. ./build_docker/./src/Common/Exception.cpp:111: DB::Exception::Exception(DB::Exception::MessageMasked&&, int, bool) @ 0x000000001accdf09
E           2. DB::Exception::Exception(PreformattedMessage&&, int) @ 0x000000000aa10445
E           3. DB::Exception::Exception<>(int, FormatStringHelperImpl<>) @ 0x000000000aa4a4ae
E           4. DB::WithContextImpl<std::shared_ptr<DB::Context const>>::getContext() const @ 0x000000000aa562f8
E           5. ./src/Interpreters/Context.h:835: DB::PipelineExecutor::PipelineExecutor(std::shared_ptr<std::vector<std::shared_ptr<DB::IProcessor>, std::allocator<std::shared_ptr<DB::IProcessor>>>>&, std::shared_ptr<DB::QueryStatus>) @ 0x000000002d0b6fce
E           6. ./contrib/llvm-project/libcxx/include/__memory/construct_at.h:0: DB::PullingAsyncPipelineExecutor::pull(DB::Chunk&, unsigned long) @ 0x000000002d0d8a47
E           7. ./build_docker/./src/Processors/Executors/PullingAsyncPipelineExecutor.cpp:138: DB::PullingAsyncPipelineExecutor::pull(DB::Block&, unsigned long) @ 0x000000002d0d9a3f
E           8. ./build_docker/./src/Server/TCPHandler.cpp:0: DB::TCPHandler::processOrdinaryQuery() @ 0x000000002cf175bb
E           9. ./build_docker/./src/Server/TCPHandler.cpp:0: DB::TCPHandler::runImpl() @ 0x000000002cf03b0b
E           10. ./build_docker/./src/Server/TCPHandler.cpp:2486: DB::TCPHandler::run() @ 0x000000002cf35ac0
E           11. ./build_docker/./base/poco/Net/src/TCPServerConnection.cpp:57: Poco::Net::TCPServerConnection::start() @ 0x000000003422b76f
E           12. ./contrib/llvm-project/libcxx/include/__memory/unique_ptr.h:48: Poco::Net::TCPServerDispatcher::run() @ 0x000000003422c357
E           13. ./build_docker/./base/poco/Foundation/src/ThreadPool.cpp:219: Poco::PooledThread::run() @ 0x000000003412ea6b
E           14. ./base/poco/Foundation/include/Poco/SharedPtr.h:231: Poco::ThreadImpl::runnableEntry(void*) @ 0x0000000034128bc8
E           15. asan_thread_start(void*) @ 0x000000000a9c5059
E           16. ? @ 0x00007fdf9dc85ac3
E           17. ? @ 0x00007fdf9dd17850
```

cc @azat 