### PR TITLE
Fix bug if parquet query contains In decimal column filter

### DIFF
--- a/src/Processors/Formats/Impl/ParquetBlockInputFormat.cpp
+++ b/src/Processors/Formats/Impl/ParquetBlockInputFormat.cpp
@@ -54,16 +54,16 @@ namespace ErrorCodes
         }                                                              \
     } while (false)
 
-static Field createDecimalField(const Int256 & value, UInt64 precision_value, UInt64 scale)
+static Field createDecimalField(const Int256 & value, UInt32 precision, UInt32 scale)
 {
-    if (precision_value <= DecimalUtils::max_precision<Decimal32>)
-        return Field(DecimalField<Decimal32>(Decimal32(static_cast<Int32>(value)), static_cast<UInt32>(scale)));
-    else if (precision_value <= DecimalUtils::max_precision<Decimal64>)
-        return  Field(DecimalField<Decimal64>(Decimal64(static_cast<Int64>(value)), static_cast<UInt32>(scale)));
-    else if (precision_value <= DecimalUtils::max_precision<Decimal128>)
-        return  Field(DecimalField<Decimal128>(Decimal128(static_cast<Int128>(value)), static_cast<UInt32>(scale)));
+    if (precision <= DecimalUtils::max_precision<Decimal32>)
+        return DecimalField(Decimal32(static_cast<Int32>(value)), scale);
+    else if (precision <= DecimalUtils::max_precision<Decimal64>)
+        return DecimalField(Decimal64(static_cast<Int64>(value)), scale);
+    else if (precision <= DecimalUtils::max_precision<Decimal128>)
+        return  DecimalField(Decimal128(static_cast<Int128>(value)), scale);
 
-    return Field(DecimalField<Decimal256>(Decimal256(value), static_cast<UInt32>(scale)));
+    return DecimalField(Decimal256(value), scale);
 }
 
 /// Decode min/max value from column chunk statistics.


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

Fix bug if parquet query contains In decimal column filter after https://github.com/ClickHouse/ClickHouse/pull/68135

Closes https://github.com/ClickHouse/ClickHouse/issues/68403


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---ci_include_fuzzer--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
