### PR TITLE
Try to mitigate 02818_memory_profiler_sample_min_max_allocation_size flakiness

### DIFF
--- a/tests/queries/0_stateless/02818_memory_profiler_sample_min_max_allocation_size.sh
+++ b/tests/queries/0_stateless/02818_memory_profiler_sample_min_max_allocation_size.sh
@@ -6,7 +6,7 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../shell_config.sh
 
 query_id="${CLICKHOUSE_DATABASE}_min_max_allocation_size_$RANDOM$RANDOM"
-${CLICKHOUSE_CLIENT} --query_id="$query_id" --memory_profiler_sample_min_allocation_size=4096 --memory_profiler_sample_max_allocation_size=8192 --log_queries=1 --max_threads=1 --max_untracked_memory=0 --memory_profiler_sample_probability=1 --query "select randomPrintableASCII(number) from numbers(1000) FORMAT Null"
+${CLICKHOUSE_CLIENT} --query_id="$query_id" --memory_profiler_sample_min_allocation_size=4096 --memory_profiler_sample_max_allocation_size=16384 --log_queries=1 --max_threads=1 --max_untracked_memory=0 --memory_profiler_sample_probability=1 --query "select randomPrintableASCII(number) from numbers(1000) FORMAT Null"
 
 ${CLICKHOUSE_CLIENT} --query "SYSTEM FLUSH LOGS"
 
@@ -14,4 +14,4 @@ ${CLICKHOUSE_CLIENT} --query "SYSTEM FLUSH LOGS"
 ${CLICKHOUSE_CLIENT} --query "SELECT countDistinct(abs(size)) > 0 FROM system.trace_log where query_id='$query_id' and trace_type = 'MemorySample'"
 
 # show wrong allocations
-${CLICKHOUSE_CLIENT} --query "SELECT abs(size) FROM system.trace_log where query_id='$query_id' and trace_type = 'MemorySample' and (abs(size) > 8192 or abs(size) < 4096)"
+${CLICKHOUSE_CLIENT} --query "SELECT abs(size) FROM system.trace_log where query_id='$query_id' and trace_type = 'MemorySample' and (abs(size) > 16384 or abs(size) < 4096)"


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

Sometimes fails in release build: https://s3.amazonaws.com/clickhouse-test-reports/0/32d949d9a2e7087278e58592eadd05352fe7af38/stateless_tests__release_.html

Test expects trace_log to report at least one allocation of size [4096, 8192] for a query, but it reports none. Allocations of that size are expected for this query, e.g. when `FunctionRandomPrintableASCII::executeImpl()` adds chars and offsets to ColumnString's two PODArray-s with default initial size 4096 bytes.

I couldn't reproduce or find anything interesting in the log. One possible way for it to fail is if jemalloc's nallocx() increased all relevant allocation sizes to >8192. I don't know enough about jemalloc to tell how likely this is. Maybe it can happen if all 5 arenas for this size range are full (4096, 5120, 6144, 7168, and 8192, according to `system.jemalloc_bins`).

This PR increases 8192 to 16384 in hopes that nallocx() is much less likely to round up that far.