### PR TITLE
Fix `Broken pipe` error for `03149_numbers_max_block_size_zero.sh`

### DIFF
--- a/tests/queries/0_stateless/03149_numbers_max_block_size_zero.sh
+++ b/tests/queries/0_stateless/03149_numbers_max_block_size_zero.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2266
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CUR_DIR"/../shell_config.sh
 
-$CLICKHOUSE_CLIENT -q "SELECT count(*) FROM numbers(10) AS a, numbers(11) AS b, numbers(12) AS c SETTINGS max_block_size = 0" 2>&1 | [ $(grep -c "Sanity check: 'max_block_size' cannot be 0. Set to default value") -gt 0 ] && echo "OK" || echo "FAIL"
+$CLICKHOUSE_CLIENT -q "SELECT count(*) FROM numbers(10) AS a, numbers(11) AS b, numbers(12) AS c SETTINGS max_block_size = 0" 2>&1 |
+    [ "$(grep -c "Sanity check: 'max_block_size' cannot be 0. Set to default value")" -gt 0 ] && echo "OK" || echo "FAIL"

--- a/tests/queries/0_stateless/03149_numbers_max_block_size_zero.sh
+++ b/tests/queries/0_stateless/03149_numbers_max_block_size_zero.sh
@@ -4,4 +4,4 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CUR_DIR"/../shell_config.sh
 
-$CLICKHOUSE_CLIENT -q "SELECT count(*) FROM numbers(10) AS a, numbers(11) AS b, numbers(12) AS c SETTINGS max_block_size = 0" 2>&1 | grep -q "Sanity check: 'max_block_size' cannot be 0. Set to default value" && echo "OK" || echo "FAIL"
+$CLICKHOUSE_CLIENT -q "SELECT count(*) FROM numbers(10) AS a, numbers(11) AS b, numbers(12) AS c SETTINGS max_block_size = 0" 2>&1 | [ $(grep -c "Sanity check: 'max_block_size' cannot be 0. Set to default value") -gt 0 ] && echo "OK" || echo "FAIL"


### PR DESCRIPTION
The error appeared while debugging
https://github.com/ClickHouse/clickhouse-private/issues/14225

Logs:
```
2024.08.16 03:06:42.063927 [ 124925 ] {fb18e22e-cb02-484e-a776-0dfc44c44636} <Error> executeQuery: Code: 210. DB::NetException: I/O error: Broken pipe, while writing to socket (127.0.0.1:9000 -> 127.0.0.1:44770). (NETWORK_ERROR) (version 24.9.1.1) (from 127.0.0.1:44770) (in query: SELECT count(*) FROM numbers(10) AS a, numbers(11) AS b, numbers(12) AS c SETTINGS max_block_size = 0), Stack trace (when copying this message, always include the lines below):

0. ./contrib/llvm-project/libcxx/include/exception:141: Poco::Exception::Exception(String const&, int) @ 0x000000001e1a6e63
1. ./build/./src/Common/Exception.cpp:111: DB::Exception::Exception(DB::Exception::MessageMasked&&, int, bool) @ 0x000000000f860295
2. ./contrib/llvm-project/libcxx/include/string:1499: DB::NetException::NetException<String, String, String>(int, FormatStringHelperImpl<std::type_identity<String>::type, std::type_identity<String>::type, std::type_identity<String>::type>, String&&, String&&, String&&) @ 0x000000000fa3c3ed
3. ./build/./src/IO/WriteBufferFromPocoSocket.cpp:0: DB::WriteBufferFromPocoSocket::nextImpl() @ 0x000000000fa3e06a
4. ./build/./src/IO/WriteBufferFromPocoSocketChunked.cpp:127: DB::WriteBufferFromPocoSocketChunked::nextImpl() @ 0x000000001a25bf6e
5. ./src/IO/WriteBuffer.h:66: DB::TCPHandler::sendProgress() @ 0x000000001a440829
6. ./build/./src/Server/TCPHandler.cpp:1161: DB::TCPHandler::processOrdinaryQuery() @ 0x000000001a43fe90
7. ./build/./src/Server/TCPHandler.cpp:0: DB::TCPHandler::runImpl() @ 0x000000001a432a35
8. ./build/./src/Server/TCPHandler.cpp:2496: DB::TCPHandler::run() @ 0x000000001a451448
9. ./build/./base/poco/Net/src/TCPServerConnection.cpp:57: Poco::Net::TCPServerConnection::start() @ 0x000000001e2b3a63
10. ./contrib/llvm-project/libcxx/include/__memory/unique_ptr.h:48: Poco::Net::TCPServerDispatcher::run() @ 0x000000001e2b42d2
11. ./build/./base/poco/Foundation/src/ThreadPool.cpp:219: Poco::PooledThread::run() @ 0x000000001e22d4e3
12. ./build/./base/poco/Foundation/src/Thread.cpp:46: Poco::(anonymous namespace)::RunnableHolder::run() @ 0x000000001e22b7b0
13. ./base/poco/Foundation/include/Poco/SharedPtr.h:231: Poco::ThreadImpl::runnableEntry(void*) @ 0x000000001e229c8a
14. __tsan_thread_start_func @ 0x0000000007411f2f
15. ? @ 0x00007ffff7c94ac3
16. ? @ 0x00007ffff7d26850
```
https://pastila.nl/?00628486/754eaf7d96fd03ceecdf1a45458867dc#B9vFn07WAielph/Z5lHbrQ==

From `man grep`:

>  -q, --quiet, --silent
> <...> Exit immediately with zero status if any match is found, even if an error was detected. <...>

When `grep -q` finds a match, it immediately exits with the status `0` and closes its side of the pipe. If the clickhouse client is still trying to send data through the pipe, it leads to `SIGPIPE` signal.

Use `grep -c` instead. It is less efficient, but the output in this test is small.

We should also revisit how we handle SIGPIPE signal, e.g. if the server should try to send logs if the client has already encountered the Broken pipe error.

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---ci_include_fuzzer--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
