### PR TITLE
Fix incorrect default value in docs for postgresql_connection_pool_auto_close_connection

### DIFF
--- a/docs/en/operations/settings/settings.md
+++ b/docs/en/operations/settings/settings.md
@@ -1381,7 +1381,7 @@ Default value: `2`.
 
 Close connection before returning connection to the pool.
 
-Default value: true.
+Default value: false.
 
 ## odbc_bridge_connection_pool_size {#odbc-bridge-connection-pool-size}
 


### PR DESCRIPTION


<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix incorrect default value for postgresql_connection_pool_auto_close_connection in docs. Docs say default value is true, while it's actually false in the code. Mentioned in issue #62709.

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)