### PR TITLE
Fix 01600_parts_states_metrics_long flakiness

### DIFF
--- a/tests/queries/0_stateless/01600_parts_states_metrics_long.sh
+++ b/tests/queries/0_stateless/01600_parts_states_metrics_long.sh
@@ -27,7 +27,7 @@ verify()
             (SELECT sum(active), sum(NOT active) FROM (
                 SELECT active FROM system.parts
                 UNION ALL SELECT active FROM system.projection_parts
-                UNION ALL SELECT 1 FROM system.dropped_tables_parts
+                UNION ALL SELECT active FROM system.dropped_tables_parts
             ))"
         )
 
@@ -43,7 +43,7 @@ verify()
         SELECT sumIf(value, metric = 'PartsActive'), sumIf(value, metric = 'PartsOutdated') FROM system.metrics;
         SELECT sum(active), sum(NOT active) FROM system.parts;
         SELECT sum(active), sum(NOT active) FROM system.projection_parts;
-        SELECT count() FROM system.dropped_tables_parts;
+        SELECT sum(active), sum(NOT active) FROM system.dropped_tables_parts;
     "
 }
 


### PR DESCRIPTION
After proper debug had been added (#68265), CI found [1]:

    2024-08-16 03:14:42 +250	1410
    2024-08-16 03:14:42 +91	1311
    2024-08-16 03:14:42 +0	0
    2024-08-16 03:14:42 +256
    2024-08-16 03:14:42 +245	1406
    2024-08-16 03:14:42 +86	1309
    2024-08-16 03:14:42 +0	0
    2024-08-16 03:14:42 +256
    2024-08-16 03:14:42 +241	1412
    2024-08-16 03:14:42 +83	1315
    2024-08-16 03:14:42 +0	0
    2024-08-16 03:14:42 +256
    2024-08-16 03:14:42 +240	1428
    2024-08-16 03:14:42 +81	1331
    2024-08-16 03:14:42 +0	0
    2024-08-16 03:14:42 +256

For the second failure, let's sum up all the parts:

    > 245+1406
    1651
    > 86+1309+256
    1651

So the total counter is OK, but not the active/inactive, and the problem is that dropped parts could be also inactive.

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/0/f2e9d31cb34989362231679514802256dfd8bbbe/stateless_tests__tsan__s3_storage__%5B2_4%5D.html

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Fixes: https://github.com/ClickHouse/ClickHouse/issues/68255 (cc @alexey-milovidov @antaljanosbenjamin)
Fixes: https://github.com/ClickHouse/ClickHouse/pull/58748 (cc @yakov-olkhovskiy )