### PR TITLE
Add system.dropped_tables_projection_parts_columns (and respect dropped projection parts in 01600_parts_states_metrics_long)

### DIFF
--- a/src/Storages/System/StorageSystemDroppedTablesProjectionParts.h
+++ b/src/Storages/System/StorageSystemDroppedTablesProjectionParts.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <Storages/System/StorageSystemProjectionParts.h>
+#include <Storages/System/StorageSystemDroppedTablesParts.h>
+
+
+namespace DB
+{
+
+class Context;
+
+
+/** Implements system table 'dropped_tables_projection_parts' which allows to get information about data parts for dropped but not yet removed tables.
+  */
+class StorageSystemDroppedTablesProjectionParts final : public StorageSystemProjectionParts
+{
+public:
+    explicit StorageSystemDroppedTablesProjectionParts(const StorageID & table_id) : StorageSystemProjectionParts(table_id) {}
+
+    std::string getName() const override { return "SystemDroppedTablesProjectionParts"; }
+protected:
+    std::unique_ptr<StoragesInfoStreamBase> getStoragesInfoStream(std::optional<ActionsDAG>, std::optional<ActionsDAG> filter, ContextPtr context) override
+    {
+        return std::make_unique<StoragesDroppedInfoStream>(std::move(filter), context);
+    }
+};
+
+}

--- a/src/Storages/System/StorageSystemProjectionParts.h
+++ b/src/Storages/System/StorageSystemProjectionParts.h
@@ -11,7 +11,7 @@ class Context;
 
 /** Implements system table 'projection_parts' which allows to get information about projection parts for tables of MergeTree family.
   */
-class StorageSystemProjectionParts final : public StorageSystemPartsBase
+class StorageSystemProjectionParts : public StorageSystemPartsBase
 {
 public:
     explicit StorageSystemProjectionParts(const StorageID & table_id_);

--- a/src/Storages/System/attachSystemTables.cpp
+++ b/src/Storages/System/attachSystemTables.cpp
@@ -87,6 +87,7 @@
 #include <Storages/System/StorageSystemSchemaInferenceCache.h>
 #include <Storages/System/StorageSystemDroppedTables.h>
 #include <Storages/System/StorageSystemDroppedTablesParts.h>
+#include <Storages/System/StorageSystemDroppedTablesProjectionParts.h>
 #include <Storages/System/StorageSystemZooKeeperConnection.h>
 #include <Storages/System/StorageSystemJemalloc.h>
 #include <Storages/System/StorageSystemScheduler.h>
@@ -172,6 +173,7 @@ void attachSystemTablesServer(ContextPtr context, IDatabase & system_database, b
     attach<StorageSystemSchemaInferenceCache>(context, system_database, "schema_inference_cache", "Contains information about all cached file schemas.");
     attach<StorageSystemDroppedTables>(context, system_database, "dropped_tables", "Contains a list of tables which were dropped from Atomic databases but not completely removed yet.");
     attachNoDescription<StorageSystemDroppedTablesParts>(context, system_database, "dropped_tables_parts", "Contains parts of system.dropped_tables tables ");
+    attachNoDescription<StorageSystemDroppedTablesProjectionParts>(context, system_database, "dropped_tables_projection_parts", "Contains projection parts of system.dropped_tables tables ");
     attach<StorageSystemScheduler>(context, system_database, "scheduler", "Contains information and status for scheduling nodes residing on the local server.");
     attach<StorageSystemDNSCache>(context, system_database, "dns_cache", "Contains information about cached DNS records.");
 #if defined(__ELF__) && !defined(OS_FREEBSD)

--- a/tests/queries/0_stateless/01600_parts_states_metrics_long.sh
+++ b/tests/queries/0_stateless/01600_parts_states_metrics_long.sh
@@ -28,6 +28,7 @@ verify()
                 SELECT active FROM system.parts
                 UNION ALL SELECT active FROM system.projection_parts
                 UNION ALL SELECT 1 FROM system.dropped_tables_parts
+                UNION ALL SELECT active FROM system.dropped_tables_projection_parts
             ))"
         )
 
@@ -44,6 +45,7 @@ verify()
         SELECT sum(active), sum(NOT active) FROM system.parts;
         SELECT sum(active), sum(NOT active) FROM system.projection_parts;
         SELECT count() FROM system.dropped_tables_parts;
+        SELECT sum(active), sum(NOT active) FROM system.dropped_tables_projection_parts;
     "
 }
 

--- a/tests/queries/0_stateless/02947_dropped_tables_projection_parts.reference
+++ b/tests/queries/0_stateless/02947_dropped_tables_projection_parts.reference
@@ -1,0 +1,4 @@
+02947_table_1	all_1_1_0
+02947_table_2	all_1_1_0
+02947_table_1	maxdate
+02947_table_2	maxdate

--- a/tests/queries/0_stateless/02947_dropped_tables_projection_parts.sql
+++ b/tests/queries/0_stateless/02947_dropped_tables_projection_parts.sql
@@ -1,0 +1,14 @@
+DROP TABLE IF EXISTS 02947_table_1;
+DROP TABLE IF EXISTS 02947_table_2;
+
+CREATE TABLE 02947_table_1 (id Int32, PROJECTION maxdate(SELECT max(id))) Engine=MergeTree() ORDER BY id;
+CREATE TABLE 02947_table_2 (id Int32, PROJECTION maxdate(SELECT max(id))) Engine=MergeTree() ORDER BY id;
+INSERT INTO 02947_table_1 VALUES (1),(2);
+INSERT INTO 02947_table_2 VALUES (3),(4);
+
+SELECT table, name FROM system.parts WHERE database = currentDatabase() AND startsWith(table, '02947_table_') ORDER BY 1, 2;
+
+SET database_atomic_wait_for_drop_and_detach_synchronously=0;
+DROP TABLE 02947_table_1;
+DROP TABLE 02947_table_2;
+SELECT table, name FROM system.dropped_tables_projection_parts WHERE database = currentDatabase() AND startsWith(table, '02947_table_') ORDER BY 1, 2;


### PR DESCRIPTION
**Blocked by: https://github.com/ClickHouse/ClickHouse/pull/68521**

### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add system.dropped_tables_projection_parts_columns

This is **mostly for tests**, since dropped projection parts could be another source of the `01600_parts_states_metrics_long` failures

Refs: https://github.com/ClickHouse/ClickHouse/issues/68255