### PR TITLE
Avoid detached covered-by-broken part duplicates

### DIFF
--- a/src/Storages/MergeTree/IMergeTreeDataPart.cpp
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.cpp
@@ -2063,6 +2063,7 @@ DataPartStoragePtr IMergeTreeDataPart::makeCloneInDetached(const String & prefix
     IDataPartStorage::ClonePartParams params
     {
         .copy_instead_of_hardlink = isStoredOnRemoteDiskWithZeroCopySupport() && storage.supportsReplication() && storage_settings->allow_remote_fs_zero_copy_replication,
+        .keep_metadata_version = prefix == "covered-by-broken",
         .make_source_readonly = true,
         .external_transaction = disk_transaction
     };

--- a/tests/integration/test_covered_by_broken_exists/test.py
+++ b/tests/integration/test_covered_by_broken_exists/test.py
@@ -40,7 +40,7 @@ def wait_merged_part(table, part_name, retries=100):
 
 
 def test_make_clone_covered_by_broken_detached_dir_exists(started_cluster):
-    q("DROP TABLE IF EXISTS test_make_clone_cvbdde")
+    q("DROP TABLE IF EXISTS test_make_clone_cvbdde SYNC")
 
     q(
         "CREATE TABLE test_make_clone_cvbdde(n int, m String) ENGINE=ReplicatedMergeTree('/test_make_clone_cvbdde', '1') ORDER BY n SETTINGS old_parts_lifetime=3600, min_age_to_force_merge_seconds=1, min_age_to_force_merge_on_partition_only=0"

--- a/tests/integration/test_covered_by_broken_exists/test.py
+++ b/tests/integration/test_covered_by_broken_exists/test.py
@@ -1,0 +1,103 @@
+import pytest
+import logging
+import time
+from helpers.cluster import ClickHouseCluster
+from helpers.test_tools import TSV
+from helpers.test_tools import assert_eq_with_retry
+
+cluster = ClickHouseCluster(__file__)
+node1 = cluster.add_instance("node1", stay_alive=True, with_zookeeper=True)
+node2 = cluster.add_instance("node2", with_zookeeper=True)
+
+instance = node1
+q = node1.query
+
+path_to_data = "/var/lib/clickhouse/"
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def wait_merged_part(table, part_name, retries=100):
+    q("OPTIMIZE TABLE {} FINAL".format(table))
+    for i in range(retries):
+        result = q(
+            "SELECT name FROM system.parts where table='{}' AND name='{}'".format(
+                table, part_name
+            )
+        )
+        if result:
+            return True
+        time.sleep(0.5)
+    else:
+        return False
+
+
+def test_make_clone_covered_by_broken_detached_dir_exists(started_cluster):
+    q("DROP TABLE IF EXISTS test_make_clone_cvbdde")
+
+    q(
+        "CREATE TABLE test_make_clone_cvbdde(n int, m String) ENGINE=ReplicatedMergeTree('/test_make_clone_cvbdde', '1') ORDER BY n SETTINGS old_parts_lifetime=3600, min_age_to_force_merge_seconds=1, min_age_to_force_merge_on_partition_only=0"
+    )
+    path = path_to_data + "data/default/test_make_clone_cvbdde/"
+
+    q("INSERT INTO test_make_clone_cvbdde VALUES (0, 'hbl')")
+
+    q("INSERT INTO test_make_clone_cvbdde VALUES (1, 'hbl')")
+    if not (wait_merged_part("test_make_clone_cvbdde", "all_0_1_1")):
+        assert False, "Part all_0_1_1 doesn't appeared in system.parts"
+
+    q("INSERT INTO test_make_clone_cvbdde VALUES (2, 'hbl')")
+    if not (wait_merged_part("test_make_clone_cvbdde", "all_0_2_2")):
+        assert False, "Part all_0_2_2 doesn't appeared in system.parts"
+
+    q("INSERT INTO test_make_clone_cvbdde VALUES (3, 'hbl')")
+    if not (wait_merged_part("test_make_clone_cvbdde", "all_0_3_3")):
+        assert False, "Part all_0_3_3 doesn't appeared in system.parts"
+
+    res = str(instance.exec_in_container(["ls", path]).strip().split("\n"))
+
+    # broke the merged parts
+    instance.exec_in_container(
+        [
+            "bash",
+            "-c",
+            "echo 'broken' > {}".format(path + "all_0_1_1/data.bin"),
+        ]
+    )
+
+    instance.exec_in_container(
+        [
+            "bash",
+            "-c",
+            "echo 'broken' > {}".format(path + "all_0_2_2/data.bin"),
+        ]
+    )
+
+    instance.exec_in_container(
+        [
+            "bash",
+            "-c",
+            "echo 'broken' > {}".format(path + "all_0_3_3/data.bin"),
+        ]
+    )
+
+    instance.restart_clickhouse(kill=True)
+
+    assert [
+        "broken-on-start_all_0_1_1",
+        "broken-on-start_all_0_2_2",
+        "broken-on-start_all_0_3_3",
+        "covered-by-broken_all_0_0_0",
+        "covered-by-broken_all_1_1_0",
+        "covered-by-broken_all_2_2_0",
+        "covered-by-broken_all_3_3_0",
+    ] == sorted(
+        instance.exec_in_container(["ls", path + "detached/"]).strip().split("\n")
+    )


### PR DESCRIPTION
Problem:
When a broken part is found during the startup, it will clone the parts which are covered by the broken part, to the detached directory (with the 'covered-by-broken' prefix). A part may be covered by multiple merged parts, which will result in multiple clones, which leads to path conflicts and further attempts to clone to the try-n directory. If n exceeds 9, the clone is abandoned and the table is marked as read-only.

pull#41981 tried fixed the problem, but the fix is incomplete. The metadata_version.txt file is deleted during covered-by-broken clone. As a result, looksLikeBrokenDetachedPartHasTheSameContent finds differences during part comparison.

Fix:
covered-by-broken retain metadata_version.txt file when cloning

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
After unexpected restart, fail to start replication of ReplicatedMergeTree due to abnormal handling of covered-by-broken part.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [x] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---ci_include_fuzzer--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
