### PR TITLE
materialized_view_deduplication performance comparison test

### DIFF
--- a/tests/performance/materialized_view_deduplication.xml
+++ b/tests/performance/materialized_view_deduplication.xml
@@ -2,7 +2,6 @@
     <settings>
         <deduplicate_blocks_in_dependent_materialized_views>1</deduplicate_blocks_in_dependent_materialized_views>
     </settings>
-
     <create_query>
         CREATE TABLE dst (`key` Int64, `value` String)
         ENGINE = MergeTree ORDER BY tuple()

--- a/tests/performance/materialized_view_deduplication.xml
+++ b/tests/performance/materialized_view_deduplication.xml
@@ -1,0 +1,34 @@
+<test>
+    <settings>
+        <deduplicate_blocks_in_dependent_materialized_views>1</deduplicate_blocks_in_dependent_materialized_views>
+    </settings>
+
+    <create_query>
+        CREATE TABLE dst (`key` Int64, `value` String)
+        ENGINE = MergeTree ORDER BY tuple()
+        SETTINGS non_replicated_deduplication_window=1000;
+    </create_query>
+    <create_query>
+        CREATE TABLE mv_dst (`key` Int64, `value` String)
+        ENGINE = MergeTree ORDER BY tuple()
+        SETTINGS non_replicated_deduplication_window=1000;
+    </create_query>
+    <create_query>
+        CREATE MATERIALIZED VIEW mv_first TO mv_dst
+        AS SELECT 0 AS key, value AS value FROM dst;
+    </create_query>
+    <create_query>
+        CREATE MATERIALIZED VIEW mv_second TO mv_dst
+        AS SELECT 0 AS key, value AS value FROM dst;
+    </create_query>
+    <fill_query>INSERT INTO dst SELECT number as key, toString(number) from numbers(1000);</fill_query>
+
+    <query>
+        INSERT INTO dst SELECT number as key, toString(number) from numbers(1000);
+    </query>
+
+    <drop_query>DROP TABLE IF EXISTS dst</drop_query>
+    <drop_query>DROP TABLE IF EXISTS mv_dst</drop_query>
+    <drop_query>DROP TABLE IF EXISTS mv_first</drop_query>
+    <drop_query>DROP TABLE IF EXISTS mv_second</drop_query>
+</test>


### PR DESCRIPTION
performance comparison test to check deduplication in MATERIALIZED VIEW's. Logic is similar to, but with a bigger insert tests/queries/0_stateless/03008_deduplication_cases_from_docs.sql

related to https://github.com/ClickHouse/ClickHouse/pull/61601

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [x] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---ci_include_fuzzer--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
