### PR TITLE
Add storage encryption for named collections

### DIFF
--- a/docs/en/operations/named-collections.md
+++ b/docs/en/operations/named-collections.md
@@ -77,7 +77,7 @@ Named collections can either be stored on local disk or in ZooKeeper/Keeper. By 
 They can also be stored using encryption with the same algorithms used for [disk encryption](storing-data#encrypted-virtual-file-system),
 where `aes_128_ctr` is used by default.
 
-To configure named collections storage you need to speficy a `type`. This can be either `local` or `keeper`/`zookeeper`. For encrypted storage,
+To configure named collections storage you need to specify a `type`. This can be either `local` or `keeper`/`zookeeper`. For encrypted storage,
 you can use `local_encrypted` or `keeper_encrypted`/`zookeeper_encrypted`.
 
 To use ZooKeeper/Keeper we also need to set up a `path` (path in ZooKeeper/Keeper, where named collections will be stored) to

--- a/docs/en/operations/named-collections.md
+++ b/docs/en/operations/named-collections.md
@@ -73,13 +73,21 @@ In the above example the `password_sha256_hex` value is the hexadecimal represen
 
 ### Storage for named collections
 
-Named collections can either be stored on local disk or in zookeeper/keeper. By default local storage is used.
+Named collections can either be stored on local disk or in ZooKeeper/Keeper. By default local storage is used.
+They can also be stored using encryption with the same algorithms used for [disk encryption](storing-data#encrypted-virtual-file-system),
+where `aes_128_ctr` is used by default.
 
-To configure named collections storage in keeper and a `type` (equal to either `keeper` or `zookeeper`) and `path` (path in keeper, where named collections will be stored) to `named_collections_storage` section in configuration file:
+To configure named collections storage you need to speficy a `type`. This can be either `local` or `keeper`/`zookeeper`. For encrypted storage,
+you can use `local_encrypted` or `keeper_encrypted`/`zookeeper_encrypted`.
+
+To use ZooKeeper/Keeper we also need to set up a `path` (path in ZooKeeper/Keeper, where named collections will be stored) to
+`named_collections_storage` section in configuration file. The following example uses encryption and ZooKeeper/Keeper:
 ```
 <clickhouse>
   <named_collections_storage>
-    <type>zookeeper</type>
+    <type>zookeeper_encrypted</type>
+    <key_hex>bebec0cabebec0cabebec0cabebec0ca</key_hex>
+    <algorithm>aes_128_ctr</algorithm>
     <path>/named_collections_path/</path>
     <update_timeout_ms>1000</update_timeout_ms>
   </named_collections_storage>
@@ -315,7 +323,7 @@ The description of parameters see [postgresql](../sql-reference/table-functions/
 Parameter `addresses_expr` is used in a collection instead of `host:port`. The parameter is optional, because there are other optional ones: `host`, `hostname`, `port`. The following pseudo code explains the priority:
 
 ```sql
-CASE 
+CASE
     WHEN collection['addresses_expr'] != '' THEN collection['addresses_expr']
     WHEN collection['host'] != ''           THEN collection['host'] || ':' || if(collection['port'] != '', collection['port'], '5432')
     WHEN collection['hostname'] != ''       THEN collection['hostname'] || ':' || if(collection['port'] != '', collection['port'], '5432')
@@ -496,7 +504,7 @@ kafka_topic_list = 'kafka_topic',
 kafka_group_name = 'consumer_group',
 kafka_format = 'JSONEachRow',
 kafka_max_block_size = '1048576';
-       
+
 ```
 ### XML example
 

--- a/src/Common/NamedCollections/NamedCollectionsMetadataStorage.cpp
+++ b/src/Common/NamedCollections/NamedCollectionsMetadataStorage.cpp
@@ -628,9 +628,9 @@ std::unique_ptr<NamedCollectionsMetadataStorage> NamedCollectionsMetadataStorage
         const auto path = config.getString(named_collections_storage_config_path + ".path");
 
         std::unique_ptr<INamedCollectionsStorage> zk_storage;
-        if (storage_type == "zookeeper" || storage_type == "keeper")
+        if (!storage_type.ends_with("_encrypted"))
             zk_storage = std::make_unique<NamedCollectionsMetadataStorage::ZooKeeperStorage>(context_, path);
-        else if (storage_type == "zookeeper_encrypted" || storage_type == "keeper_encrypted")
+        else
             zk_storage = std::make_unique<NamedCollectionsMetadataStorage::ZooKeeperStorageEncrypted>(context_, path);
 
         LOG_TRACE(getLogger("NamedCollectionsMetadataStorage"),

--- a/src/Common/NamedCollections/NamedCollectionsMetadataStorage.h
+++ b/src/Common/NamedCollections/NamedCollectionsMetadataStorage.h
@@ -35,7 +35,9 @@ public:
 private:
     class INamedCollectionsStorage;
     class LocalStorage;
+    class LocalStorageEncrypted;
     class ZooKeeperStorage;
+    class ZooKeeperEncrypted;
 
     std::shared_ptr<INamedCollectionsStorage> storage;
 

--- a/src/Common/NamedCollections/NamedCollectionsMetadataStorage.h
+++ b/src/Common/NamedCollections/NamedCollectionsMetadataStorage.h
@@ -37,7 +37,7 @@ private:
     class LocalStorage;
     class LocalStorageEncrypted;
     class ZooKeeperStorage;
-    class ZooKeeperEncrypted;
+    class ZooKeeperStorageEncrypted;
 
     std::shared_ptr<INamedCollectionsStorage> storage;
 

--- a/tests/integration/test_named_collections_encrypted/configs/config.d/named_collections_encrypted.xml
+++ b/tests/integration/test_named_collections_encrypted/configs/config.d/named_collections_encrypted.xml
@@ -1,0 +1,12 @@
+<clickhouse>
+  <named_collections_storage>
+    <type>local_encrypted</type>
+    <key_hex>bebec0cabebec0cabebec0cabebec0ca</key_hex>
+  </named_collections_storage>
+
+  <named_collections>
+    <collection1>
+      <key1>value1</key1>
+    </collection1>
+  </named_collections>
+</clickhouse>

--- a/tests/integration/test_named_collections_encrypted/configs/config.d/named_collections_with_zookeeper_encrypted.xml
+++ b/tests/integration/test_named_collections_encrypted/configs/config.d/named_collections_with_zookeeper_encrypted.xml
@@ -1,0 +1,31 @@
+<clickhouse>
+  <named_collections_storage>
+    <type>zookeeper_encrypted</type>
+    <key_hex>bebec0cabebec0cabebec0cabebec0ca</key_hex>
+    <path>/named_collections_path/</path>
+    <update_timeout_ms>5000</update_timeout_ms>
+  </named_collections_storage>
+
+  <named_collections>
+    <collection1>
+      <key1>value1</key1>
+    </collection1>
+  </named_collections>
+
+  <remote_servers>
+      <replicated_nc_nodes_cluster>
+          <shard>
+              <internal_replication>true</internal_replication>
+              <replica>
+                  <host>node_with_keeper</host>
+                  <port>9000</port>
+              </replica>
+              <replica>
+                  <host>node_with_keeper_2</host>
+                  <port>9000</port>
+              </replica>
+          </shard>
+          <allow_distributed_ddl_queries>true</allow_distributed_ddl_queries>
+      </replicated_nc_nodes_cluster>
+  </remote_servers>
+</clickhouse>

--- a/tests/integration/test_named_collections_encrypted/configs/users.d/users.xml
+++ b/tests/integration/test_named_collections_encrypted/configs/users.d/users.xml
@@ -1,0 +1,17 @@
+<clickhouse>
+    <profiles>
+        <default>
+            <ignore_on_cluster_for_replicated_named_collections_queries>0</ignore_on_cluster_for_replicated_named_collections_queries>
+        </default>
+    </profiles>
+    <users>
+        <default>
+            <password></password>
+            <profile>default</profile>
+            <quota>default</quota>
+            <named_collection_control>1</named_collection_control>
+            <show_named_collections>1</show_named_collections>
+            <show_named_collections_secrets>1</show_named_collections_secrets>
+        </default>
+    </users>
+</clickhouse>

--- a/tests/integration/test_named_collections_encrypted/test.py
+++ b/tests/integration/test_named_collections_encrypted/test.py
@@ -1,0 +1,115 @@
+import logging
+import pytest
+import os
+from helpers.cluster import ClickHouseCluster
+
+SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
+NAMED_COLLECTIONS_CONFIG = os.path.join(
+    SCRIPT_DIR, "./configs/config.d/named_collections.xml"
+)
+
+ZK_PATH = "/named_collections_path"
+
+
+@pytest.fixture(scope="module")
+def cluster():
+    try:
+        cluster = ClickHouseCluster(__file__)
+        cluster.add_instance(
+            "node_encrypted",
+            main_configs=[
+                "configs/config.d/named_collections_encrypted.xml",
+            ],
+            user_configs=[
+                "configs/users.d/users.xml",
+            ],
+            stay_alive=True,
+        )
+        cluster.add_instance(
+            "node_with_keeper_encrypted",
+            main_configs=[
+                "configs/config.d/named_collections_with_zookeeper_encrypted.xml",
+            ],
+            user_configs=[
+                "configs/users.d/users.xml",
+            ],
+            stay_alive=True,
+            with_zookeeper=True,
+        )
+        cluster.add_instance(
+            "node_with_keeper_2_encrypted",
+            main_configs=[
+                "configs/config.d/named_collections_with_zookeeper_encrypted.xml",
+            ],
+            user_configs=[
+                "configs/users.d/users.xml",
+            ],
+            stay_alive=True,
+            with_zookeeper=True,
+        )
+
+        logging.info("Starting cluster...")
+        cluster.start()
+        logging.info("Cluster started")
+
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def check_encrypted_content(node, zk=None):
+    assert (
+        "collection1\ncollection2"
+        == node.query("select name from system.named_collections").strip()
+    )
+
+    assert (
+        "['key1','key2']"
+        == node.query(
+            "select mapKeys(collection) from system.named_collections where name = 'collection2'"
+        ).strip()
+    )
+
+    assert (
+        "1234\tvalue2"
+        == node.query(
+            "select collection['key1'], collection['key2'] from system.named_collections where name = 'collection2'"
+        ).strip()
+    )
+
+    # Check that the underlying storage is encrypted
+    content = zk.get(ZK_PATH + "/collection2.sql")[0] if zk is not None else open(f"{node.path}/database/named_collections/collection2.sql", "rb").read()
+
+    assert content[0:3] == b"ENC"  # file signature (aka magic number) of the encrypted file
+    assert b"key1" not in content
+    assert b"1234" not in content
+    assert b"key2" not in content
+    assert B"value2" not in content
+
+
+def test_local_storage_encrypted(cluster):
+    node = cluster.instances["node_encrypted"]
+    node.query("CREATE NAMED COLLECTION collection2 AS key1=1234, key2='value2'")
+
+    check_encrypted_content(node)
+    node.restart_clickhouse()
+    check_encrypted_content(node)
+
+    node.query("DROP NAMED COLLECTION collection2")
+
+
+def test_zookeper_storage_encrypted(cluster):
+    node1 = cluster.instances["node_with_keeper_encrypted"]
+    node2 = cluster.instances["node_with_keeper_2_encrypted"]
+    zk = cluster.get_kazoo_client("zoo1")
+
+    node1.query("CREATE NAMED COLLECTION collection2 AS key1=1234, key2='value2'")
+
+    check_encrypted_content(node1, zk)
+    check_encrypted_content(node2, zk)
+    node1.restart_clickhouse()
+    node2.restart_clickhouse()
+    check_encrypted_content(node1, zk)
+    check_encrypted_content(node2, zk)
+
+    node1.query("DROP NAMED COLLECTION collection2")

--- a/tests/integration/test_named_collections_encrypted/test.py
+++ b/tests/integration/test_named_collections_encrypted/test.py
@@ -78,13 +78,21 @@ def check_encrypted_content(node, zk=None):
     )
 
     # Check that the underlying storage is encrypted
-    content = zk.get(ZK_PATH + "/collection2.sql")[0] if zk is not None else open(f"{node.path}/database/named_collections/collection2.sql", "rb").read()
+    content = (
+        zk.get(ZK_PATH + "/collection2.sql")[0]
+        if zk is not None
+        else open(
+            f"{node.path}/database/named_collections/collection2.sql", "rb"
+        ).read()
+    )
 
-    assert content[0:3] == b"ENC"  # file signature (aka magic number) of the encrypted file
+    assert (
+        content[0:3] == b"ENC"
+    )  # file signature (aka magic number) of the encrypted file
     assert b"key1" not in content
     assert b"1234" not in content
     assert b"key2" not in content
-    assert B"value2" not in content
+    assert b"value2" not in content
 
 
 def test_local_storage_encrypted(cluster):


### PR DESCRIPTION
Add storage encryption for named collections

- Uses the same approach as for disk encryption
- Adds the new types `local_encrypted` and `keeper_encrypted`/`zookeeper_encrypted`.
- Supports the same algorithms used for [disk encryption](https://clickhouse.com/docs/en/operations/storing-data#encrypted-virtual-file-system)

Example of configurations:

```xml
<named_collections_storage>
    <type>local_encrypted</type>
    <key_hex>bebec0cabebec0cabebec0cabebec0ca</key_hex>
</named_collections_storage>
```

```xml
<named_collections_storage>
    <type>zookeeper_encrypted</type>
    <key_hex>bebec0cabebec0cabebec0cabebec0cabebec0cabebec0cabebec0cabebec0ca</key_hex>
    <algorithm>aes_256_ctr</algorithm>
    <path>/named_collections_path/</path>
    <update_timeout_ms>5000</update_timeout_ms>
</named_collections_storage>
```

Part of https://github.com/ClickHouse/clickhouse-private/issues/2375
There's another PR pending which fetches the key directly from AWS and GCP

### Changelog category (leave one):
- New Feature

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add storage encryption for named collections

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---ci_include_fuzzer--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
