### PR TITLE
Fix false "Killed by signal (output files)" in stress_tests.lib

### DIFF
--- a/tests/docker_scripts/stress_tests.lib
+++ b/tests/docker_scripts/stress_tests.lib
@@ -273,7 +273,7 @@ function check_logs_for_critical_errors()
     [ -s /test_output/no_such_key_errors.txt ] || rm /test_output/no_such_key_errors.txt
 
     # Crash
-    rg -Fa "########################################" /var/log/clickhouse-server/clickhouse-server*.log > /dev/null \
+    rg -Fa "###################""#####################" /var/log/clickhouse-server/clickhouse-server*.log > /dev/null \
         && echo -e "Killed by signal (in clickhouse-server.log)$FAIL" >> /test_output/test_results.tsv \
         || echo -e "Not crashed$OK" >> /test_output/test_results.tsv
 
@@ -285,7 +285,7 @@ function check_logs_for_critical_errors()
     # Remove file fatal_messages.txt if it's empty
     [ -s /test_output/fatal_messages.txt ] || rm /test_output/fatal_messages.txt
 
-    rg -Faz "########################################" /test_output/* > /dev/null \
+    rg -Faz "####################""####################" /test_output/* > /dev/null \
       && echo -e "Killed by signal (output files)$FAIL" >> /test_output/test_results.tsv
 
     function get_gdb_log_context()


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

In https://s3.amazonaws.com/clickhouse-test-reports/60669/011a7d20fcf8f0ddc0b13e988b6048617e183021/stateless_tests_flaky_check__asan_.html `run.log` says:
```
+ rg -Fa '########################################' /var/log/clickhouse-server/clickhouse-server.err.log /var/log/clickhouse-server/clickhouse-server.log
+ echo -e 'Not crashed\tOK\t\N\t'
+ rg -Fa ' <Fatal> ' /var/log/clickhouse-server/clickhouse-server.err.log /var/log/clickhouse-server/clickhouse-server.log
+ echo -e 'No fatal messages in clickhouse-server.log\tOK\t\N\t'
+ '[' -s /test_output/fatal_messages.txt ']'
+ rm /test_output/fatal_messages.txt
+ rg -Faz '########################################' /test_output/blob_storage_log.tsv.zst /test_output/check_status.tsv /test_output/clickhouse-server.log.zst /test_output/error_log.tsv.zst /test_output/hdfs_minicluster.log /test_output/metric_log.tsv.zst /test_output/minio_audit_logs.jsonl.zst /test_output/minio.log /test_output/minio_server_logs.jsonl.zst /test_output/query_log.tsv.zst /test_output/run.log /test_output/test_results.tsv /test_output/test_result.txt /test_output/trace-log-CPU-flamegraph.tsv.zst /test_output/trace-log-Memory-flamegraph.tsv.zst /test_output/trace-log-Real-flamegraph.tsv.zst /test_output/trace_log.tsv.zst /test_output/transactions_info_log.tsv.zst /test_output/zookeeper_log.tsv.zst
+ echo -e 'Killed by signal (output files)\tFAIL\t\N\t'
```
I.e. (1) "`rg -Fa '########################################'`" was echoed into `run.log`, then (2) another `rg -Faz '########################################'` searched `run.log` (and other files) for "`########################################`". If `run.log` happened to be flushed between these two operations, IIUC, the second search will match the first search's query string. This PR fixes it.

I didn't repro or confirm that this is the cause of this failure. But none of the other output files contains "`########################################`", so it seems likely.