### PR TITLE
CI: Disable SQLLogic job

### DIFF
--- a/docker/test/sqllogic/Dockerfile
+++ b/docker/test/sqllogic/Dockerfile
@@ -40,6 +40,3 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 ARG sqllogic_test_repo="https://github.com/gregrahn/sqllogictest.git"
 
 RUN git clone --recursive ${sqllogic_test_repo}
-
-COPY run.sh /
-CMD ["/bin/bash", "/run.sh"]

--- a/tests/ci/ci_config.py
+++ b/tests/ci/ci_config.py
@@ -498,9 +498,10 @@ class CI:
         JobNames.SQLANCER_DEBUG: CommonJobConfigs.SQLLANCER_TEST.with_properties(
             required_builds=[BuildNames.PACKAGE_DEBUG],
         ),
-        JobNames.SQL_LOGIC_TEST: CommonJobConfigs.SQLLOGIC_TEST.with_properties(
-            required_builds=[BuildNames.PACKAGE_RELEASE],
-        ),
+        # TODO: job does not work at all, uncomment and fix
+        # JobNames.SQL_LOGIC_TEST: CommonJobConfigs.SQLLOGIC_TEST.with_properties(
+        #     required_builds=[BuildNames.PACKAGE_RELEASE],
+        # ),
         JobNames.SQLTEST: CommonJobConfigs.SQL_TEST.with_properties(
             required_builds=[BuildNames.PACKAGE_RELEASE],
         ),

--- a/tests/ci/ci_definitions.py
+++ b/tests/ci/ci_definitions.py
@@ -204,7 +204,7 @@ class JobNames(metaclass=WithIter):
     PERFORMANCE_TEST_AMD64 = "Performance Comparison (release)"
     PERFORMANCE_TEST_ARM64 = "Performance Comparison (aarch64)"
 
-    SQL_LOGIC_TEST = "Sqllogic test (release)"
+    # SQL_LOGIC_TEST = "Sqllogic test (release)"
 
     SQLANCER = "SQLancer (release)"
     SQLANCER_DEBUG = "SQLancer (debug)"

--- a/tests/ci/sqllogic_test.py
+++ b/tests/ci/sqllogic_test.py
@@ -31,7 +31,7 @@ IMAGE_NAME = "clickhouse/sqllogic-test"
 
 def get_run_command(
     builds_path: Path,
-    repo_tests_path: Path,
+    repo_path: Path,
     result_path: Path,
     server_log_path: Path,
     image: DockerImage,
@@ -39,11 +39,11 @@ def get_run_command(
     return (
         f"docker run "
         f"--volume={builds_path}:/package_folder "
-        f"--volume={repo_tests_path}:/clickhouse-tests "
+        f"--volume={repo_path}:/repo "
         f"--volume={result_path}:/test_output "
         f"--volume={server_log_path}:/var/log/clickhouse-server "
         "--security-opt seccomp=unconfined "  # required to issue io_uring sys-calls
-        f"--cap-add=SYS_PTRACE {image}"
+        f"--cap-add=SYS_PTRACE {image} /repo/tests/docker_scripts/sqllogic_runner.sh"
     )
 
 
@@ -94,8 +94,6 @@ def main():
 
     docker_image = pull_image(get_docker_image(IMAGE_NAME))
 
-    repo_tests_path = repo_path / "tests"
-
     packages_path = temp_path / "packages"
     packages_path.mkdir(parents=True, exist_ok=True)
 
@@ -111,7 +109,7 @@ def main():
 
     run_command = get_run_command(  # run script inside docker
         packages_path,
-        repo_tests_path,
+        repo_path,
         result_path,
         server_log_path,
         docker_image,

--- a/tests/docker_scripts/sqllogic_runner.sh
+++ b/tests/docker_scripts/sqllogic_runner.sh
@@ -15,10 +15,10 @@ echo "Files in current directory"
 ls -la ./
 echo "Files in root directory"
 ls -la /
-echo "Files in /clickhouse-tests directory"
-ls -la /clickhouse-tests
-echo "Files in /clickhouse-tests/sqllogic directory"
-ls -la /clickhouse-tests/sqllogic
+echo "Files in /repo/tests directory"
+ls -la /repo/tests
+echo "Files in /repo/tests/sqllogic directory"
+ls -la /repo/tests/sqllogic
 echo "Files in /package_folder directory"
 ls -la /package_folder
 echo "Files in /test_output"
@@ -45,13 +45,13 @@ function run_tests()
 
     cd /test_output
 
-    /clickhouse-tests/sqllogic/runner.py --help 2>&1 \
+    /repo/tests/sqllogic/runner.py --help 2>&1 \
         | ts '%Y-%m-%d %H:%M:%S'
 
     mkdir -p /test_output/self-test
-    /clickhouse-tests/sqllogic/runner.py --log-file /test_output/runner-self-test.log \
+    /repo/tests/sqllogic/runner.py --log-file /test_output/runner-self-test.log \
         self-test \
-        --self-test-dir /clickhouse-tests/sqllogic/self-test \
+        --self-test-dir /repo/tests/sqllogic/self-test \
         --out-dir /test_output/self-test \
         2>&1 \
         | ts '%Y-%m-%d %H:%M:%S'
@@ -63,7 +63,7 @@ function run_tests()
     if [ -d /sqllogictest ]
     then
         mkdir -p /test_output/statements-test
-        /clickhouse-tests/sqllogic/runner.py \
+        /repo/tests/sqllogic/runner.py \
         --log-file /test_output/runner-statements-test.log \
         --log-level info \
             statements-test \
@@ -77,7 +77,7 @@ function run_tests()
         tar -zcvf statements-check.tar.gz statements-test 1>/dev/null
 
         mkdir -p /test_output/complete-test
-        /clickhouse-tests/sqllogic/runner.py \
+        /repo/tests/sqllogic/runner.py \
         --log-file /test_output/runner-complete-test.log \
         --log-level info \
             complete-test \


### PR DESCRIPTION
First part of the job called "self-test" fails with sqlglot parser exception:
`2024-08-22 16:16:20 Traceback (most recent call last):
2024-08-22 16:16:20   File "/repo/tests/sqllogic/runner.py", line 497, in <module>
2024-08-22 16:16:20     main()
2024-08-22 16:16:20   File "/repo/tests/sqllogic/runner.py", line 493, in main
2024-08-22 16:16:20     args.func(args)
2024-08-22 16:16:20   File "/repo/tests/sqllogic/runner.py", line 409, in calle
2024-08-22 16:16:20     runner.run_all_tests_from_dir(self_test_dir)
2024-08-22 16:16:20   File "/repo/tests/sqllogic/test_runner.py", line 570, in run_all_tests_from_dir
2024-08-22 16:16:20     self.run_all_tests_from_file(file_path, self._input_dir)
2024-08-22 16:16:20   File "/repo/tests/sqllogic/test_runner.py", line 563, in run_all_tests_from_file
2024-08-22 16:16:20     self.run_one_test(stream, test_name, test_file)
2024-08-22 16:16:20   File "/repo/tests/sqllogic/test_runner.py", line 543, in run_one_test
2024-08-22 16:16:20     for status in self.__statuses(parser, out_stream):
2024-08-22 16:16:20   File "/repo/tests/sqllogic/test_runner.py", line 344, in __statuses
2024-08-22 16:16:20     for block in parser.test_blocks():
2024-08-22 16:16:20   File "/repo/tests/sqllogic/test_parser.py", line 446, in test_blocks
2024-08-22 16:16:20     yield from self._iterate_blocks()
2024-08-22 16:16:20   File "/repo/tests/sqllogic/test_parser.py", line 437, in _iterate_blocks
2024-08-22 16:16:20     yield FileBlockBase.parse_block(self, prev, i)
2024-08-22 16:16:20   File "/repo/tests/sqllogic/test_parser.py", line 213, in parse_block
2024-08-22 16:16:20     request = FileBlockBase.convert_request(request)
2024-08-22 16:16:20   File "/repo/tests/sqllogic/test_parser.py", line 145, in convert_request
2024-08-22 16:16:20     result = sqlglot.transpile(sql, read="sqlite", write="clickhouse")[0]
2024-08-22 16:16:20   File "/usr/local/lib/python3.10/dist-packages/sqlglot/__init__.py", line 177, in transpile
2024-08-22 16:16:20     for expression in parse(sql, read, error_level=error_level)
2024-08-22 16:16:20   File "/usr/local/lib/python3.10/dist-packages/sqlglot/__init__.py", line 102, in parse
2024-08-22 16:16:20     return Dialect.get_or_raise(read or dialect).parse(sql, **opts)
2024-08-22 16:16:20   File "/usr/local/lib/python3.10/dist-packages/sqlglot/dialects/dialect.py", line 512, in parse
2024-08-22 16:16:20     return self.parser(**opts).parse(self.tokenize(sql), sql)
2024-08-22 16:16:20   File "/usr/local/lib/python3.10/dist-packages/sqlglot/parser.py", line 1234, in parse
2024-08-22 16:16:20     return self._parse(
2024-08-22 16:16:20   File "/usr/local/lib/python3.10/dist-packages/sqlglot/parser.py", line 1303, in _parse
2024-08-22 16:16:20     expressions.append(parse_method(self))
2024-08-22 16:16:20   File "/usr/local/lib/python3.10/dist-packages/sqlglot/parser.py", line 1532, in _parse_statement
2024-08-22 16:16:20     return self.STATEMENT_PARSERS[self._prev.token_type](self)
2024-08-22 16:16:20   File "/usr/local/lib/python3.10/dist-packages/sqlglot/parser.py", line 667, in <lambda>
2024-08-22 16:16:20     TokenType.CREATE: lambda self: self._parse_create(),
2024-08-22 16:16:20   File "/usr/local/lib/python3.10/dist-packages/sqlglot/parser.py", line 1676, in _parse_create
2024-08-22 16:16:20     extend_props(self._parse_properties())
2024-08-22 16:16:20   File "/usr/local/lib/python3.10/dist-packages/sqlglot/parser.py", line 1862, in _parse_properties
2024-08-22 16:16:20     prop = self._parse_property()
2024-08-22 16:16:20   File "/usr/local/lib/python3.10/dist-packages/sqlglot/parser.py", line 1802, in _parse_property
2024-08-22 16:16:20     return self.PROPERTY_PARSERS[self._prev.text.upper()](self)
2024-08-22 16:16:20   File "/usr/local/lib/python3.10/dist-packages/sqlglot/parser.py", line 837, in <lambda>
2024-08-22 16:16:20     "PRIMARY KEY": lambda self: self._parse_primary_key(in_props=True),
2024-08-22 16:16:20   File "/usr/local/lib/python3.10/dist-packages/sqlglot/parser.py", line 5033, in _parse_primary_key
2024-08-22 16:16:20     expressions = self._parse_wrapped_csv(
2024-08-22 16:16:20   File "/usr/local/lib/python3.10/dist-packages/sqlglot/parser.py", line 5834, in _parse_wrapped_csv
2024-08-22 16:16:20     return self._parse_wrapped(
2024-08-22 16:16:20   File "/usr/local/lib/python3.10/dist-packages/sqlglot/parser.py", line 5841, in _parse_wrapped
2024-08-22 16:16:20     self.raise_error("Expecting (")
2024-08-22 16:16:20   File "/usr/local/lib/python3.10/dist-packages/sqlglot/parser.py", line 1347, in raise_error
2024-08-22 16:16:20     raise error
2024-08-22 16:16:20 sqlglot.errors.ParseError: Expecting (. Line 1, Col: 76.
2024-08-22 16:16:20   CREATE TABLE t1(a INTEGER, b INTEGER) ENGINE = MergeTree() PRIMARY KEY tuple()`

second part of the job fails with timeout:
```
024-08-19T12:08:36.9107226Z + /clickhouse-tests/sqllogic/runner.py --log-file /test_output/runner-complete-test.log --log-level info complete-test --input-dir /sqllogictest --out-dir /test_output/complete-test
2024-08-19T12:08:36.9110042Z + ts '%Y-%m-%d %H:%M:%S'
2024-08-19T14:27:49.6759170Z + echo 'timeout reached'
2024-08-19T14:27:49.6773691Z timeout reached
```
wasting 2h of runtime

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [x] <!---ci_include_sqllogic--> Allow: SQLlogic
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---ci_include_fuzzer--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [x] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
