### PR TITLE
Thread pool metrics

### DIFF
--- a/src/Common/CurrentMetrics.cpp
+++ b/src/Common/CurrentMetrics.cpp
@@ -75,9 +75,9 @@
     M(GlobalThread, "Number of threads in global thread pool.") \
     M(GlobalThreadActive, "Number of threads in global thread pool running a task.") \
     M(GlobalThreadScheduled, "Number of queued or active jobs in global thread pool.") \
-    M(LocalThread, "Number of threads in local thread pools. The threads in local thread pools are taken from the global thread pool.") \
-    M(LocalThreadActive, "Number of threads in local thread pools running a task.") \
-    M(LocalThreadScheduled, "Number of queued or active jobs in local thread pools.") \
+    M(LocalThread, "Obsolete. Number of threads in local thread pools. The threads in local thread pools are taken from the global thread pool.") \
+    M(LocalThreadActive, "Obsolete. Number of threads in local thread pools running a task.") \
+    M(LocalThreadScheduled, "Obsolete. Number of queued or active jobs in local thread pools.") \
     M(MergeTreeDataSelectExecutorThreads, "Number of threads in the MergeTreeDataSelectExecutor thread pool.") \
     M(MergeTreeDataSelectExecutorThreadsActive, "Number of threads in the MergeTreeDataSelectExecutor thread pool running a task.") \
     M(MergeTreeDataSelectExecutorThreadsScheduled, "Number of queued or active jobs in the MergeTreeDataSelectExecutor thread pool.") \

--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -89,11 +89,11 @@
     M(GlobalThreadPoolExpansions, "Counts the total number of times new threads have been added to the global thread pool. This metric indicates the frequency of expansions in the global thread pool to accommodate increased processing demands.") \
     M(GlobalThreadPoolShrinks, "Counts the total number of times the global thread pool has shrunk by removing threads. This occurs when the number of idle threads exceeds max_thread_pool_free_size, indicating adjustments in the global thread pool size in response to decreased thread utilization.") \
     M(GlobalThreadPoolThreadCreationMicroseconds, "Total time spent waiting for new threads to start.") \
-    M(GlobalThreadPoolLockWaitMicroseconds,  "Total time threads have spent waiting for locks in the global thread pool.") \
+    M(GlobalThreadPoolLockWaitMicroseconds, "Total time threads have spent waiting for locks in the global thread pool.") \
     M(GlobalThreadPoolJobs, "Counts the number of jobs that have been pushed to the global thread pool.") \
     M(GlobalThreadPoolJobWaitTimeMicroseconds, "Measures the elapsed time from when a job is scheduled in the thread pool to when it is picked up for execution by a worker thread. This metric helps identify delays in job processing, indicating the responsiveness of the thread pool to new tasks.") \
     M(LocalThreadPoolExpansions, "Counts the total number of times threads have been borrowed from the global thread pool to expand local thread pools.") \
-    M(LocalThreadPoolShrinks,  "Counts the total number of times threads have been returned to the global thread pool from local thread pools.") \
+    M(LocalThreadPoolShrinks, "Counts the total number of times threads have been returned to the global thread pool from local thread pools.") \
     M(LocalThreadPoolThreadCreationMicroseconds, "Total time local thread pools have spent waiting to borrow a thread from the global pool.") \
     M(LocalThreadPoolLockWaitMicroseconds, "Total time threads have spent waiting for locks in the local thread pools.") \
     M(LocalThreadPoolJobs, "Counts the number of jobs that have been pushed to the local thread pools.") \

--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -86,6 +86,18 @@
     M(NetworkReceiveBytes, "Total number of bytes received from network. Only ClickHouse-related network interaction is included, not by 3rd party libraries.") \
     M(NetworkSendBytes, "Total number of bytes send to network. Only ClickHouse-related network interaction is included, not by 3rd party libraries.") \
     \
+    M(GlobalThreadPoolExpansions, "Counts the total number of times new threads have been added to the global thread pool. This metric indicates the frequency of expansions in the global thread pool to accommodate increased processing demands.") \
+    M(GlobalThreadPoolShrinks, "Counts the total number of times the global thread pool has shrunk by removing threads. This occurs when the number of idle threads exceeds max_thread_pool_free_size, indicating adjustments in the global thread pool size in response to decreased thread utilization.") \
+    M(GlobalThreadPoolThreadCreationMicroseconds, "Total time spent waiting for new threads to start.") \
+    M(GlobalThreadPoolLockWaitMicroseconds,  "Total time threads have spent waiting for locks in the global thread pool.") \
+    M(GlobalThreadPoolJobs, "Counts the number of jobs that have been pushed to the global thread pool.") \
+    M(LocalThreadPoolExpansions, "Counts the total number of times threads have been borrowed from the global thread pool to expand local thread pools.") \
+    M(LocalThreadPoolShrinks,  "Counts the total number of times threads have been returned to the global thread pool from local thread pools.") \
+    M(LocalThreadPoolThreadCreationMicroseconds, "Total time local thread pools have spent waiting to borrow a thread from the global pool.") \
+    M(LocalThreadPoolLockWaitMicroseconds, "Total time threads have spent waiting for locks in the local thread pools.") \
+    M(LocalThreadPoolJobs, "Counts the number of jobs that have been pushed to the local thread pools.") \
+    M(LocalThreadPoolBusyMicroseconds, "Total time threads have spent executing the actual work.") \
+    \
     M(DiskS3GetRequestThrottlerCount, "Number of DiskS3 GET and SELECT requests passed through throttler.") \
     M(DiskS3GetRequestThrottlerSleepMicroseconds, "Total time a query was sleeping to conform DiskS3 GET and SELECT request throttling.") \
     M(DiskS3PutRequestThrottlerCount, "Number of DiskS3 PUT, COPY, POST and LIST requests passed through throttler.") \

--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -91,12 +91,14 @@
     M(GlobalThreadPoolThreadCreationMicroseconds, "Total time spent waiting for new threads to start.") \
     M(GlobalThreadPoolLockWaitMicroseconds,  "Total time threads have spent waiting for locks in the global thread pool.") \
     M(GlobalThreadPoolJobs, "Counts the number of jobs that have been pushed to the global thread pool.") \
+    M(GlobalThreadPoolJobWaitTimeMicroseconds, "Measures the elapsed time from when a job is scheduled in the thread pool to when it is picked up for execution by a worker thread. This metric helps identify delays in job processing, indicating the responsiveness of the thread pool to new tasks.") \
     M(LocalThreadPoolExpansions, "Counts the total number of times threads have been borrowed from the global thread pool to expand local thread pools.") \
     M(LocalThreadPoolShrinks,  "Counts the total number of times threads have been returned to the global thread pool from local thread pools.") \
     M(LocalThreadPoolThreadCreationMicroseconds, "Total time local thread pools have spent waiting to borrow a thread from the global pool.") \
     M(LocalThreadPoolLockWaitMicroseconds, "Total time threads have spent waiting for locks in the local thread pools.") \
     M(LocalThreadPoolJobs, "Counts the number of jobs that have been pushed to the local thread pools.") \
     M(LocalThreadPoolBusyMicroseconds, "Total time threads have spent executing the actual work.") \
+    M(LocalThreadPoolJobWaitTimeMicroseconds, "Measures the elapsed time from when a job is scheduled in the thread pool to when it is picked up for execution by a worker thread. This metric helps identify delays in job processing, indicating the responsiveness of the thread pool to new tasks.") \
     \
     M(DiskS3GetRequestThrottlerCount, "Number of DiskS3 GET and SELECT requests passed through throttler.") \
     M(DiskS3GetRequestThrottlerSleepMicroseconds, "Total time a query was sleeping to conform DiskS3 GET and SELECT request throttling.") \

--- a/src/Common/ThreadPool.cpp
+++ b/src/Common/ThreadPool.cpp
@@ -277,7 +277,7 @@ ReturnType ThreadPoolImpl<Thread>::scheduleImpl(Job job, Priority priority, std:
     /// Wake up a free thread to run the new job.
     new_job_or_shutdown.notify_one();
 
-    ProfileEvents::increment( std::is_same_v<Thread, std::thread> ? ProfileEvents::GlobalThreadPoolJobs : ProfileEvents::LocalThreadPoolJobs);
+    ProfileEvents::increment(std::is_same_v<Thread, std::thread> ? ProfileEvents::GlobalThreadPoolJobs : ProfileEvents::LocalThreadPoolJobs);
 
     return static_cast<ReturnType>(true);
 }

--- a/src/Common/ThreadPool.cpp
+++ b/src/Common/ThreadPool.cpp
@@ -1,4 +1,5 @@
 #include <Common/ThreadPool.h>
+#include <Common/ProfileEvents.h>
 #include <Common/setThreadName.h>
 #include <Common/Exception.h>
 #include <Common/getNumberOfPhysicalCPUCores.h>
@@ -25,6 +26,22 @@ namespace CurrentMetrics
     extern const Metric GlobalThread;
     extern const Metric GlobalThreadActive;
     extern const Metric GlobalThreadScheduled;
+}
+
+namespace ProfileEvents
+{
+    extern const Event GlobalThreadPoolExpansions;
+    extern const Event GlobalThreadPoolShrinks;
+    extern const Event GlobalThreadPoolThreadCreationMicroseconds;
+    extern const Event GlobalThreadPoolLockWaitMicroseconds;
+    extern const Event GlobalThreadPoolJobs;
+
+    extern const Event LocalThreadPoolExpansions;
+    extern const Event LocalThreadPoolShrinks;
+    extern const Event LocalThreadPoolThreadCreationMicroseconds;
+    extern const Event LocalThreadPoolLockWaitMicroseconds;
+    extern const Event LocalThreadPoolJobs;
+    extern const Event LocalThreadPoolBusyMicroseconds;
 }
 
 class JobWithPriority
@@ -180,14 +197,18 @@ ReturnType ThreadPoolImpl<Thread>::scheduleImpl(Job job, Priority priority, std:
     };
 
     {
+        Stopwatch watch;
         std::unique_lock lock(mutex);
+        ProfileEvents::increment(
+            std::is_same_v<Thread, std::thread> ? ProfileEvents::GlobalThreadPoolLockWaitMicroseconds : ProfileEvents::LocalThreadPoolLockWaitMicroseconds,
+            watch.elapsedMicroseconds());
 
         if (CannotAllocateThreadFaultInjector::injectFault())
             return on_error("fault injected");
 
         auto pred = [this] { return !queue_size || scheduled_jobs < queue_size || shutdown; };
 
-        if (wait_microseconds)  /// Check for optional. Condition is true if the optional is set and the value is zero.
+        if (wait_microseconds)  /// Check for optional. Condition is true if the optional is set. Even if the value is zero.
         {
             if (!job_finished.wait_for(lock, std::chrono::microseconds(*wait_microseconds), pred))
                 return on_error(fmt::format("no free thread (timeout={})", *wait_microseconds));
@@ -216,7 +237,13 @@ ReturnType ThreadPoolImpl<Thread>::scheduleImpl(Job job, Priority priority, std:
 
             try
             {
+                Stopwatch watch2;
                 threads.front() = Thread([this, it = threads.begin()] { worker(it); });
+                ProfileEvents::increment(
+                    std::is_same_v<Thread, std::thread> ? ProfileEvents::GlobalThreadPoolThreadCreationMicroseconds : ProfileEvents::LocalThreadPoolThreadCreationMicroseconds,
+                    watch2.elapsedMicroseconds());
+                ProfileEvents::increment(
+                    std::is_same_v<Thread, std::thread> ? ProfileEvents::GlobalThreadPoolExpansions : ProfileEvents::LocalThreadPoolExpansions);
             }
             catch (...)
             {
@@ -238,6 +265,8 @@ ReturnType ThreadPoolImpl<Thread>::scheduleImpl(Job job, Priority priority, std:
 
     /// Wake up a free thread to run the new job.
     new_job_or_shutdown.notify_one();
+
+    ProfileEvents::increment( std::is_same_v<Thread, std::thread> ? ProfileEvents::GlobalThreadPoolJobs : ProfileEvents::LocalThreadPoolJobs);
 
     return static_cast<ReturnType>(true);
 }
@@ -262,7 +291,14 @@ void ThreadPoolImpl<Thread>::startNewThreadsNoLock()
 
         try
         {
+            Stopwatch watch;
             threads.front() = Thread([this, it = threads.begin()] { worker(it); });
+            ProfileEvents::increment(
+                std::is_same_v<Thread, std::thread> ? ProfileEvents::GlobalThreadPoolThreadCreationMicroseconds : ProfileEvents::LocalThreadPoolThreadCreationMicroseconds,
+                watch.elapsedMicroseconds());
+            ProfileEvents::increment(
+                std::is_same_v<Thread, std::thread> ? ProfileEvents::GlobalThreadPoolExpansions : ProfileEvents::LocalThreadPoolExpansions);
+
         }
         catch (...)
         {
@@ -293,7 +329,11 @@ void ThreadPoolImpl<Thread>::scheduleOrThrow(Job job, Priority priority, uint64_
 template <typename Thread>
 void ThreadPoolImpl<Thread>::wait()
 {
+    Stopwatch watch;
     std::unique_lock lock(mutex);
+    ProfileEvents::increment(
+        std::is_same_v<Thread, std::thread> ? ProfileEvents::GlobalThreadPoolLockWaitMicroseconds : ProfileEvents::LocalThreadPoolLockWaitMicroseconds,
+        watch.elapsedMicroseconds());
     /// Signal here just in case.
     /// If threads are waiting on condition variables, but there are some jobs in the queue
     /// then it will prevent us from deadlock.
@@ -334,7 +374,11 @@ void ThreadPoolImpl<Thread>::finalize()
 
     /// Wait for all currently running jobs to finish (we don't wait for all scheduled jobs here like the function wait() does).
     for (auto & thread : threads)
+    {
         thread.join();
+        ProfileEvents::increment(
+            std::is_same_v<Thread, std::thread> ? ProfileEvents::GlobalThreadPoolShrinks : ProfileEvents::LocalThreadPoolShrinks);
+    }
 
     threads.clear();
 }
@@ -391,7 +435,11 @@ void ThreadPoolImpl<Thread>::worker(typename std::list<Thread>::iterator thread_
         std::optional<JobWithPriority> job_data;
 
         {
+            Stopwatch watch;
             std::unique_lock lock(mutex);
+            ProfileEvents::increment(
+                std::is_same_v<Thread, std::thread> ? ProfileEvents::GlobalThreadPoolLockWaitMicroseconds : ProfileEvents::LocalThreadPoolLockWaitMicroseconds,
+                watch.elapsedMicroseconds());
 
             // Finish with previous job if any
             if (job_is_done)
@@ -424,6 +472,8 @@ void ThreadPoolImpl<Thread>::worker(typename std::list<Thread>::iterator thread_
                 {
                     thread_it->detach();
                     threads.erase(thread_it);
+                    ProfileEvents::increment(
+                        std::is_same_v<Thread, std::thread> ? ProfileEvents::GlobalThreadPoolShrinks : ProfileEvents::LocalThreadPoolShrinks);
                 }
                 return;
             }
@@ -459,7 +509,22 @@ void ThreadPoolImpl<Thread>::worker(typename std::list<Thread>::iterator thread_
 
             CurrentMetrics::Increment metric_active_pool_threads(metric_active_threads);
 
-            job_data->job();
+            if constexpr (!std::is_same_v<Thread, std::thread>)
+            {
+                Stopwatch watch;
+                job_data->job();
+                // This metric is less relevant for the global thread pool, as it would show large values (time while
+                // a thread was used by local pools) and increment only when local pools are destroyed.
+                //
+                // In cases where global pool threads are used directly (without a local thread pool), distinguishing
+                // them is difficult.
+                ProfileEvents::increment(ProfileEvents::LocalThreadPoolBusyMicroseconds, watch.elapsedMicroseconds());
+            }
+            else
+            {
+                job_data->job();
+            }
+
 
             if (thread_trace_context.root_span.isTraceEnabled())
             {

--- a/src/Common/ThreadPool.h
+++ b/src/Common/ThreadPool.h
@@ -131,7 +131,7 @@ private:
     bool threads_remove_themselves = true;
     const bool shutdown_on_exception = true;
 
-    boost::heap::priority_queue<JobWithPriority> jobs;
+    boost::heap::priority_queue<JobWithPriority,boost::heap::stable<true>> jobs;
     std::list<Thread> threads;
     std::exception_ptr first_exception;
     std::stack<OnDestroyCallback> on_destroy_callbacks;


### PR DESCRIPTION
### Changelog Category:
- Improvement

### Changelog Entry:
Added a new set of metrics for Thread Pool introspection, providing deeper insights into thread pool performance and behavior.

### Documentation Entry for User-Facing Changes

Several new metrics have been introduced to enhance monitoring and analysis of thread pools:

- **Obsolete Metrics:** The `LocalThread`, `LocalThreadActive`, and `LocalThreadScheduled` metrics have been marked as obsolete. This change reflects recent architectural updates that reduce the relevance of local thread pools, as discussed in [ClickHouse PR #47880](https://github.com/ClickHouse/ClickHouse/pull/47880). Users should adjust their monitoring configurations accordingly.
  
- **GlobalThreadPoolExpansions and Shrinks:** These metrics track the frequency of expansions and contractions in the global thread pool, offering visibility into how the system adapts to varying workloads.

- **Thread Creation and Lock Wait Times:** These metrics measure the time taken to start new threads and the time threads spend waiting for locks. These insights are crucial for identifying potential bottlenecks in thread management.

- **Job Wait Time:** This metric captures the time elapsed from when a job is scheduled until it is executed, providing a clear view of the responsiveness of the thread pool.

Additionally, to prevent jobs from being delayed or stuck in the queue, the job queue within the `ThreadPool` has been made stable. This ensures that jobs with the same priority are processed in the order they were added, enabling fair and timely execution. While I don't have a test showing any issues caused by the previous queue behavior (non-FIFO), the  problems with that were observed during experiments with modified code.

### Key Metrics to Monitor

- **GlobalThreadPoolThreadCreationMicroseconds:** Normally low, and even thousands of threads can created per second without delays. However, under certain conditions, thread creation can be slow, potentially due to kernel-level locks around memory maps (unconfirmed). When that metric increases is have cascading effect on lock waits & JobWaitTime, and underperforming thread pool.

- **GlobalThreadPoolExpansions and Shrinks:** Ideally, these should not happen too often, indicating that the global pool size is well-tuned for the workload.

- **GlobalThreadPoolJobs and LocalThreadPoolJobs:** Indicate the number of jobs processed by the thread pools, providing a sense of workload distribution.

- **LocalThreadPoolJobWaitTimeMicroseconds and GlobalThreadPoolJobWaitTimeMicroseconds:** These metrics signal delays in the ThreadPool queue, which could be due to locks, out-of-order execution, cpu starvation, or other factors.

- **GlobalThreadPoolLockWaitMicroseconds and LocalThreadPoolLockWaitMicroseconds:** These metrics allow for analysis of lock contention, with values proportional to the number of active threads waiting for the lock.

- **LocalThreadPoolBusyMicroseconds:** When compared to `LocalThreadPoolJobWaitTimeMicroseconds`, this metric helps assess how efficiently the thread pool is operating, highlighting the balance between useful work and thread pool maintenance overhead.

- **LocalThreadPoolThreadCreationMicroseconds** is actually time used to push the task into the GlobalThread pool (can be impacted by locks, and slow creation of the 'real' threads).

**Note:** The counter metrics will only be partially visible in the `system.query_log` under `ProfileEvents`. Specifically, only those metrics incremented in the `::scheduleImpl` method will be logged. This is because counters incremented in the `::worker` method occur before the thread status is initialized, making them visible only in the global context and not on a per-query basis.

For practical examples and test results, you can refer to the following [test](https://gist.github.com/filimonov/7e7adde17421d4a9f83c6fea2be8f802).

#### Sample Output 

```
sum(ProfileEvent_GlobalThreadPoolExpansions):                 4132
sum(ProfileEvent_GlobalThreadPoolShrinks):                    3649
sum(ProfileEvent_GlobalThreadPoolThreadCreationMicroseconds): 15043940
sum(ProfileEvent_GlobalThreadPoolLockWaitMicroseconds):       21807528619
sum(ProfileEvent_GlobalThreadPoolJobs):                       84616
sum(ProfileEvent_GlobalThreadPoolJobWaitTimeMicroseconds):    1787436966
sum(ProfileEvent_LocalThreadPoolExpansions):                  40452
sum(ProfileEvent_LocalThreadPoolShrinks):                     40452
sum(ProfileEvent_LocalThreadPoolThreadCreationMicroseconds):  3895767384
sum(ProfileEvent_LocalThreadPoolLockWaitMicroseconds):        12982962008
sum(ProfileEvent_LocalThreadPoolJobs):                        42925
sum(ProfileEvent_LocalThreadPoolBusyMicroseconds):            16998330672
sum(ProfileEvent_LocalThreadPoolJobWaitTimeMicroseconds):     13590969274
```

In that synthetic test the pool efficiency was only 55%, 45% of time was just wasted on thread pool management. 

```
SELECT
    toStartOfInterval(event_time, toIntervalMinute(10)) AS t,
    round((100 * sum(ProfileEvent_LocalThreadPoolBusyMicroseconds)) / (sum(ProfileEvent_LocalThreadPoolBusyMicroseconds) + sum(ProfileEvent_LocalThreadPoolJobWaitTimeMicroseconds)), 1) AS thread_pool_efficiency_percent
FROM system.metric_log
GROUP BY t
ORDER BY t ASC

Query id: 82d52a37-518b-4d34-b756-57f398613452

    ┌───────────────────t─┬─thread_pool_efficiency_percent─┐
 1. │ 2024-08-21 08:10:00 │                           93.4 │
 2. │ 2024-08-21 11:00:00 │                           94.1 │
 3. │ 2024-08-21 11:10:00 │                             86 │
 4. │ 2024-08-21 11:20:00 │                           74.4 │
 5. │ 2024-08-21 11:30:00 │                           45.9 │
 6. │ 2024-08-21 11:40:00 │                           68.6 │
 7. │ 2024-08-21 11:50:00 │                           95.6 │
 8. │ 2024-08-21 12:00:00 │                           43.6 │
 9. │ 2024-08-21 12:10:00 │                           40.9 │
10. │ 2024-08-21 12:20:00 │                           47.3 │
```

Another (indirect) signal of the problems is how many threads have actually task to do - just by looking on the thread names (threads which don't have an actual job are named `ThreadPool`):
```
    ┌─name────────────┬─count()─┐
 1. │ QueryPipelineEx │    2001 │
 2. │ ThreadPool      │    1777 │
 3. │ TCPHandler      │     552 │
 4. │ BgSchPool       │     512 │
 5. │ QueryPullPipeEx │     271 │
 6. │ MergeTreeIndex  │      64 │
 7. │ Fetch           │      16 │
 8. │ BgDistSchPool   │      16 │
```

Or by comparing the number of working threads, vs active threads:

```
┌───────────────now()─┬─metric────────────────┬─value─┬─description─────────────────────────────────────────────┐
1. │ 2024-08-21 16:44:19 │ Query                 │   544 │ Number of executing queries                             │
2. │ 2024-08-21 16:44:19 │ GlobalThread          │  4718 │ Number of threads in global thread pool.                │
3. │ 2024-08-21 16:44:19 │ GlobalThreadActive    │  3069 │ Number of threads in global thread pool running a task. │
4. │ 2024-08-21 16:44:19 │ GlobalThreadScheduled │  3224 │ Number of queued or active jobs in global thread pool.  │
   └─────────────────────┴───────────────────────┴───────┴─────────────────────────────────────────────────────────┘


quantiles(0.001, 0.5, 0.999)(CurrentMetric_GlobalThread):          [1323, 1836, 4891.508]
quantiles(0.001, 0.5, 0.999)(CurrentMetric_GlobalThreadActive):    [805.9999999999999, 1623, 3654.316]
quantiles(0.001, 0.5, 0.999)(CurrentMetric_GlobalThreadScheduled): [805.9999999999999, 1723, 3720.1919999999996]
```