### PR TITLE
Thread pool: move thread creation out of lock

### DIFF
--- a/src/Common/AsyncLoader.cpp
+++ b/src/Common/AsyncLoader.cpp
@@ -54,7 +54,7 @@ AsyncLoader::Pool::Pool(const AsyncLoader::PoolInitializer & init)
           init.metric_threads,
           init.metric_active_threads,
           init.metric_scheduled_threads,
-          /* max_threads = */ std::numeric_limits<size_t>::max(), // Unlimited number of threads, we do worker management ourselves
+          /* max_threads = */ ThreadPool::MAX_THEORETICAL_THREAD_COUNT, // Unlimited number of threads, we do worker management ourselves
           /* max_free_threads = */ 0, // We do not require free threads
           /* queue_size = */ 0)) // Unlimited queue to avoid blocking during worker spawning
 {}

--- a/src/Common/ThreadPool.cpp
+++ b/src/Common/ThreadPool.cpp
@@ -525,8 +525,16 @@ void ThreadPoolImpl<Thread>::finalize()
     /// Notify all threads to wake them up, so they can complete their work and exit gracefully.
     new_job_or_shutdown.notify_all();
 
-    /// Clear the thread list. This triggers the destruction of ThreadFromThreadPool objects,
-    /// and in their destructors, the threads will be joined automatically.
+    /// Join all threads before clearing the list
+    for (auto& thread_ptr : threads)
+    {
+        if (thread_ptr && thread_ptr->thread.joinable())
+        {
+            thread_ptr->thread.join();
+        }
+    }
+
+    // now it's safe to clear the threads
     threads.clear();
 }
 

--- a/src/Common/ThreadPool.cpp
+++ b/src/Common/ThreadPool.cpp
@@ -344,8 +344,8 @@ ReturnType ThreadPoolImpl<Thread>::scheduleImpl(Job job, Priority priority, std:
             }
             catch (...)
             {
-                // If thread creation fails, restore the pool capacity and return an error.
-                return on_error("cannot allocate thread slot");
+                /// Most likely this is a std::bad_alloc exception
+                return on_error("cannot emplace the thread in the pool");
             }
         }
         else // we have a thread but there is not space for that in the pool.

--- a/src/Common/ThreadPool.cpp
+++ b/src/Common/ThreadPool.cpp
@@ -607,18 +607,9 @@ void ThreadPoolImpl<Thread>::ThreadFromThreadPool::start(typename std::list<std:
 template <typename Thread>
 void ThreadPoolImpl<Thread>::ThreadFromThreadPool::join()
 {
-    // the thread destructed, so the capacity grows
-    parent_pool.available_threads.fetch_sub(1, std::memory_order_relaxed);
-    parent_pool.remaining_pool_capacity.fetch_add(1, std::memory_order_relaxed);
-
-    thread_state.store(ThreadState::Destructing); /// if worker was waiting for finishing the initialization - let it finish.
-
     // Ensure the thread is joined before destruction if still joinable
     if (thread.joinable())
         thread.join();
-
-    ProfileEvents::increment(
-        std::is_same_v<Thread, std::thread> ? ProfileEvents::GlobalThreadPoolShrinks : ProfileEvents::LocalThreadPoolShrinks);
 }
 
 template <typename Thread>
@@ -633,7 +624,16 @@ void ThreadPoolImpl<Thread>::ThreadFromThreadPool::removeSelfFromPoolNoPoolLock(
 template <typename Thread>
 ThreadPoolImpl<Thread>::ThreadFromThreadPool::~ThreadFromThreadPool()
 {
+    // the thread destructed, so the capacity grows
+    parent_pool.available_threads.fetch_sub(1, std::memory_order_relaxed);
+    parent_pool.remaining_pool_capacity.fetch_add(1, std::memory_order_relaxed);
+
+    thread_state.store(ThreadState::Destructing); /// if worker was waiting for finishing the initialization - let it finish.
+    
     join();
+
+    ProfileEvents::increment(
+        std::is_same_v<Thread, std::thread> ? ProfileEvents::GlobalThreadPoolShrinks : ProfileEvents::LocalThreadPoolShrinks);
 }
 
 template <typename Thread>

--- a/src/Common/ThreadPool.cpp
+++ b/src/Common/ThreadPool.cpp
@@ -552,14 +552,13 @@ void ThreadPoolImpl<Thread>::ThreadFromThreadPool::removeSelfFromPoolNoPoolLock(
         thread.detach();
 
     parent_pool.threads.erase(thread_it);
-    parent_pool.available_threads.fetch_sub(1, std::memory_order_relaxed);
-    parent_pool.remaining_pool_capacity.fetch_add(1, std::memory_order_relaxed);
 }
 
 template <typename Thread>
 ThreadPoolImpl<Thread>::ThreadFromThreadPool::~ThreadFromThreadPool()
 {
     // the thread destructed, so the capacity grows
+    parent_pool.available_threads.fetch_sub(1, std::memory_order_relaxed);
     parent_pool.remaining_pool_capacity.fetch_add(1, std::memory_order_relaxed);
 
     thread_state.store(ThreadState::Destructing); /// if worker was waiting for finishing the initialization - let it finish.

--- a/src/Common/ThreadPool.cpp
+++ b/src/Common/ThreadPool.cpp
@@ -47,7 +47,8 @@ namespace ProfileEvents
 
 }
 
-namespace {
+namespace
+{
     struct ScopedDecrement
     {
         std::atomic<int64_t>& atomic_var;

--- a/src/Common/ThreadPool.cpp
+++ b/src/Common/ThreadPool.cpp
@@ -212,14 +212,6 @@ void ThreadPoolImpl<Thread>::setQueueSize(size_t value)
 }
 
 template <typename Thread>
-std::unique_ptr<typename ThreadPoolImpl<Thread>::ThreadFromThreadPool>
-ThreadPoolImpl<Thread>::maybeStartNewThread()
-{
-    return nullptr;
-}
-
-
-template <typename Thread>
 template <typename ReturnType>
 ReturnType ThreadPoolImpl<Thread>::scheduleImpl(Job job, Priority priority, std::optional<uint64_t> wait_microseconds, bool propagate_opentelemetry_tracing_context)
 {
@@ -242,7 +234,7 @@ ReturnType ThreadPoolImpl<Thread>::scheduleImpl(Job job, Priority priority, std:
     };
 
     auto available_threads_decrement = std::make_unique<ScopedDecrement>(available_threads);
-    
+
     std::unique_ptr<ThreadFromThreadPool> new_thread;
 
     // Load the current capacity
@@ -268,7 +260,7 @@ ReturnType ThreadPoolImpl<Thread>::scheduleImpl(Job job, Priority priority, std:
                 return on_error("failed to start the thread");
             }
         }
-        else 
+        else
         {
             capacity = remaining_pool_capacity.load(std::memory_order_relaxed);
             currently_available_threads = available_threads.load(std::memory_order_relaxed);
@@ -396,13 +388,13 @@ void ThreadPoolImpl<Thread>::startNewThreadsNoLock()
                     break;
                 }
             }
-            else 
+            else
             {
                 capacity = remaining_pool_capacity.load(std::memory_order_relaxed);
             }
         }
 
-        if (!new_thread) 
+        if (!new_thread)
             break; /// failed to start more threads
 
         typename std::list<std::unique_ptr<ThreadFromThreadPool>>::iterator thread_slot;
@@ -422,7 +414,7 @@ void ThreadPoolImpl<Thread>::startNewThreadsNoLock()
             (*thread_slot)->start(thread_slot);
         }
         catch (...)
-        {   
+        {
             threads.pop_front();
             break;
         }

--- a/src/Common/ThreadPool.cpp
+++ b/src/Common/ThreadPool.cpp
@@ -629,7 +629,7 @@ ThreadPoolImpl<Thread>::ThreadFromThreadPool::~ThreadFromThreadPool()
     parent_pool.remaining_pool_capacity.fetch_add(1, std::memory_order_relaxed);
 
     thread_state.store(ThreadState::Destructing); /// if worker was waiting for finishing the initialization - let it finish.
-    
+
     join();
 
     ProfileEvents::increment(

--- a/src/Common/ThreadPool.h
+++ b/src/Common/ThreadPool.h
@@ -186,8 +186,6 @@ private:
     std::exception_ptr first_exception;
     std::stack<OnDestroyCallback> on_destroy_callbacks;
 
-    std::unique_ptr<ThreadFromThreadPool> maybeStartNewThread();
-
     template <typename ReturnType>
     ReturnType scheduleImpl(Job job, Priority priority, std::optional<uint64_t> wait_microseconds, bool propagate_opentelemetry_tracing_context = true);
 

--- a/src/Common/ThreadPool.h
+++ b/src/Common/ThreadPool.h
@@ -88,11 +88,14 @@ public:
     {
     public:
         // Constructor to initialize but not start the thread
-        explicit ThreadFromThreadPool(ThreadPoolImpl& parent_pool_, bool defer_thread_starting = false);
+        explicit ThreadFromThreadPool(ThreadPoolImpl& parent_pool_);
+
+        // Starts the internal thread.
+        void startThread(typename std::list<ThreadFromThreadPool>::iterator& it);
 
         // Starts the internal thread, and stores the new job - it will be pushed to the queue
         // by the thread itself once it starts and takes the lock for the first time.
-        void startThread(JobWithPriority new_job);
+        void startThread(typename std::list<ThreadFromThreadPool>::iterator& it, JobWithPriority new_job);
 
         // Destructor to join the thread if needed
         ~ThreadFromThreadPool();
@@ -102,6 +105,9 @@ public:
         ThreadPoolImpl& parent_pool;
         std::optional<Thread> thread;
         std::optional<JobWithPriority> new_job;
+
+        // stores the position of the thread in the parent thread pool list
+        typename std::list<ThreadFromThreadPool>::iterator& thread_it{nullopt};
 
         // remove itself from the parent pool
         void removeSelfFromPoolNoPoolLock();

--- a/src/Common/ThreadPool.h
+++ b/src/Common/ThreadPool.h
@@ -58,6 +58,8 @@ public:
         // Shift the thread state from Preparing to Running to allow the worker to start.
         void start(typename std::list<std::unique_ptr<ThreadFromThreadPool>>::iterator& it);
 
+        void join();
+
         // Destructor to join the thread if needed (shift the state to Destructing if it was not running)
         ~ThreadFromThreadPool();
 

--- a/src/Common/ThreadPool.h
+++ b/src/Common/ThreadPool.h
@@ -52,11 +52,13 @@ public:
     class ThreadFromThreadPool
     {
     public:
+        using ThreadList = std::list<std::unique_ptr<ThreadFromThreadPool>>;
+
         /// Constructor to initialize and start the thread (but not associate it with the pool)
         explicit ThreadFromThreadPool(ThreadPoolImpl& parent_pool);
 
         // Shift the thread state from Preparing to Running to allow the worker to start.
-        void start(typename std::list<std::unique_ptr<ThreadFromThreadPool>>::iterator& it);
+        void start(ThreadList::iterator& it);
 
         void join();
 
@@ -193,7 +195,7 @@ private:
     const bool shutdown_on_exception = true;
 
     boost::heap::priority_queue<JobWithPriority,boost::heap::stable<true>> jobs;
-    std::list<std::unique_ptr<ThreadFromThreadPool>> threads;
+    ThreadFromThreadPool::ThreadList threads;
     std::exception_ptr first_exception;
     std::stack<OnDestroyCallback> on_destroy_callbacks;
 

--- a/src/Common/ThreadPool.h
+++ b/src/Common/ThreadPool.h
@@ -175,7 +175,7 @@ private:
 
     // increments every time new thread joins the thread pool, or job finishes
     // decrements every time when task schedule starts
-    std::atomic<size_t> available_threads;
+    std::atomic<int> available_threads;
 
     bool shutdown = false;
     bool threads_remove_themselves = true;

--- a/src/Common/ThreadPool.h
+++ b/src/Common/ThreadPool.h
@@ -43,7 +43,7 @@ public:
     // used as 'unlimited' thread pool size
     // on linux you can not have more threads even if the RAM is unlimited
     // see https://docs.kernel.org/admin-guide/sysctl/kernel.html#threads-max
-    static constexpr int MAX_THEORETICAL_THREAD_COUNT 0x3fffffff; // ~1 billion
+    static constexpr int MAX_THEORETICAL_THREAD_COUNT = 0x3fffffff; // ~1 billion
 
     using Job = std::function<void()>;
     using Metric = CurrentMetrics::Metric;
@@ -177,14 +177,14 @@ private:
     // If positive, then more threads can be started.
     // When it comes to zero, it means that max_threads threads have already been started.
     // it can be below zero when the threadpool is shutting down
-    std::atomic<int> remaining_pool_capacity;
+    std::atomic<int64_t> remaining_pool_capacity;
 
     // Increments every time a new thread joins the thread pool or a job finishes.
     // Decrements every time a task is scheduled.
     // If positive, it means that there are more threads than jobs (and some are idle).
     // If zero, it means that every thread has a job.
     // If negative, it means that we have more jobs than threads.
-    std::atomic<int> available_threads;
+    std::atomic<int64_t> available_threads;
 
     bool shutdown = false;
     bool threads_remove_themselves = true;


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Optimized thread creation in the ThreadPool to minimize lock contention. Thread creation is now performed outside of the critical section to avoid delays in job scheduling and thread management under high load conditions. This leads to a much more responsive ClickHouse under heavy concurrent load.

### Documentation entry for user-facing changes

The thread creation process within the ThreadPool has been modified to address potential delays caused by holding a lock during thread creation. Previously, threads were created within a locked section, which could lead to significant contention and delays, especially when thread creation is slow. To mitigate this, the thread creation has been moved outside of the critical section.

Same test https://gist.github.com/filimonov/7e7adde17421d4a9f83c6fea2be8f802 - before and after the change - results are in comment below.

It looks like a clear win giving about 10% better QPS, much better response times and better threadpool and CPU usage, despite that thread creation become even slower - it's because now several thread can be created simultaneously and kernel side contetion is bigger. But now it does not block the thread pool work anymore.

P.S. I have no idea how to test it in CI/CD, but there is a change that performance tests will show something.