### PR TITLE
Reduce runtime of `lower_upper_utf8.xml`

### DIFF
--- a/tests/performance/lower_upper_utf8.xml
+++ b/tests/performance/lower_upper_utf8.xml
@@ -1,4 +1,4 @@
 <test>
-    <query>SELECT lowerUTF8(SearchPhrase) FROM hits_100m_single FORMAT Null</query>
-    <query>SELECT upperUTF8(SearchPhrase) FROM hits_100m_single FORMAT Null</query>
+    <query>SELECT lowerUTF8(SearchPhrase) FROM hits_10m_single FORMAT Null</query>
+    <query>SELECT upperUTF8(SearchPhrase) FROM hits_10m_single FORMAT Null</query>
 </test>


### PR DESCRIPTION
After PR #68523 / #65761, performance test "lower_upper_utf8.xml" started to fail:

https://s3.amazonaws.com/clickhouse-test-reports/66933/3ff9522b69ec7e51119f445152ffb9678a0f124f/performance_comparison__release__[1_4]/report.html

This PR reduces the data set size and fixes the timeout.

(One can ask why #68523 / #65761 was merged in the first place. All performance tests had a green status, but the slowdown was already visible when one checked the detailed views. My bad, sorry for missing this.)

I measured locally on the 10 mio hits table:
- previous runtime: 0.04 sec
- afterwards: 1.35 sec (I also measured the impact of #68684 but it was negligible)

Column `hits.SearchPhrase` contains a mix of ASCII / Cyrillic characters, which is the best case for the previous implementation. The previous code could only upper/lowercase ASCII / Cyrillic characters which was wrong, at least _very very_ surprising.

There was some discussion about performance (https://github.com/ClickHouse/ClickHouse/pull/65761#discussion_r1656871257) but no measurements were taken for Cyrillic characters, so we also missed to catch this early.

I think going back to the previous wrong behavior, i.e. revert #68523 / #65761, is not an option. Special paths for Cyrillic seems arbitrary (what about other languages then), I am reluctant to implement that.

Cc: @taiyang-li It would still be great if we can check how the ICU conversion can be speed up. Ideas: maybe we can save a copy by using `toUTF8(ByteSink &sink)`? Maybe we can try to build ICU with `U_CHARSET_IS_UTF8`? (see https://unicode-org.github.io/icu/userguide/strings/utf-8.html#conversion-between-utf-8-and-utf-16)?

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
