### PR TITLE
Enable load_metadata_asynchronously by default for FS cache

### DIFF
--- a/src/Interpreters/Cache/FileCacheSettings.h
+++ b/src/Interpreters/Cache/FileCacheSettings.h
@@ -32,7 +32,7 @@ struct FileCacheSettings
     size_t background_download_queue_size_limit = FILECACHE_DEFAULT_BACKGROUND_DOWNLOAD_QUEUE_SIZE_LIMIT;
 
     size_t load_metadata_threads = FILECACHE_DEFAULT_LOAD_METADATA_THREADS;
-    bool load_metadata_asynchronously = false;
+    bool load_metadata_asynchronously = true;
 
     bool write_cache_per_user_id_directory = false;
 


### PR DESCRIPTION
Follow up to #65736 

### Changelog category (leave one):

- Performance Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Enable loading the filesystem cache metadata asynchronously by default, so it will not block startup of the server. See #65736.

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
