### PR TITLE
Check setting use_json_alias_for_old_object_type in runtime

### DIFF
--- a/docs/en/operations/settings/settings.md
+++ b/docs/en/operations/settings/settings.md
@@ -5623,7 +5623,6 @@ Default value: `1GiB`.
 ## use_json_alias_for_old_object_type
 
 When enabled, `JSON` data type alias will be used to create an old [Object('json')](../../sql-reference/data-types/json.md) type instead of the new [JSON](../../sql-reference/data-types/newjson.md) type.
-This setting requires server restart to take effect when changed.
 
 Default value: `false`.
 

--- a/src/DataTypes/DataTypeObject.cpp
+++ b/src/DataTypes/DataTypeObject.cpp
@@ -1,10 +1,12 @@
 #include <DataTypes/DataTypeFactory.h>
 #include <DataTypes/DataTypeObject.h>
+#include <DataTypes/DataTypeObjectDeprecated.h>
 #include <DataTypes/Serializations/SerializationJSON.h>
 #include <DataTypes/Serializations/SerializationObjectTypedPath.h>
 #include <DataTypes/Serializations/SerializationObjectDynamicPath.h>
 #include <DataTypes/Serializations/SerializationSubObject.h>
 #include <Columns/ColumnObject.h>
+#include <Common/CurrentThread.h>
 
 #include <Parsers/IAST.h>
 #include <Parsers/ASTLiteral.h>
@@ -513,13 +515,24 @@ static DataTypePtr createObject(const ASTPtr & arguments, const DataTypeObject::
 
 static DataTypePtr createJSON(const ASTPtr & arguments)
 {
+    auto context = CurrentThread::getQueryContext();
+    if (!context)
+        context = Context::getGlobalContextInstance();
+
+    if (context->getSettingsRef().use_json_alias_for_old_object_type)
+    {
+        if (arguments && !arguments->children.empty())
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Experimental Object type doesn't support any arguments. If ypu want to use new JSON type, set setting allow_experimental_json_type = 1");
+
+        return std::make_shared<DataTypeObjectDeprecated>("JSON", false);
+    }
+
     return createObject(arguments, DataTypeObject::SchemaFormat::JSON);
 }
 
 void registerDataTypeJSON(DataTypeFactory & factory)
 {
-    if (!Context::getGlobalContextInstance()->getSettingsRef().use_json_alias_for_old_object_type)
-        factory.registerDataType("JSON", createJSON, DataTypeFactory::Case::Insensitive);
+    factory.registerDataType("JSON", createJSON, DataTypeFactory::Case::Insensitive);
 }
 
 }

--- a/src/DataTypes/DataTypeObject.cpp
+++ b/src/DataTypes/DataTypeObject.cpp
@@ -522,7 +522,7 @@ static DataTypePtr createJSON(const ASTPtr & arguments)
     if (context->getSettingsRef().use_json_alias_for_old_object_type)
     {
         if (arguments && !arguments->children.empty())
-            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Experimental Object type doesn't support any arguments. If ypu want to use new JSON type, set setting allow_experimental_json_type = 1");
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Experimental Object type doesn't support any arguments. If you want to use new JSON type, set setting allow_experimental_json_type = 1");
 
         return std::make_shared<DataTypeObjectDeprecated>("JSON", false);
     }

--- a/src/DataTypes/DataTypeObjectDeprecated.cpp
+++ b/src/DataTypes/DataTypeObjectDeprecated.cpp
@@ -78,10 +78,6 @@ static DataTypePtr create(const ASTPtr & arguments)
 void registerDataTypeObjectDeprecated(DataTypeFactory & factory)
 {
     factory.registerDataType("Object", create);
-    if (Context::getGlobalContextInstance()->getSettingsRef().use_json_alias_for_old_object_type)
-        factory.registerSimpleDataType("JSON",
-            [] { return std::make_shared<DataTypeObjectDeprecated>("JSON", false); },
-            DataTypeFactory::Case::Insensitive);
 }
 
 }

--- a/tests/queries/0_stateless/03230_json_alias_new_old_types.reference
+++ b/tests/queries/0_stateless/03230_json_alias_new_old_types.reference
@@ -1,0 +1,2 @@
+{"a":42}	JSON
+{"a":42}	Object(\'json\')

--- a/tests/queries/0_stateless/03230_json_alias_new_old_types.reference
+++ b/tests/queries/0_stateless/03230_json_alias_new_old_types.reference
@@ -1,2 +1,2 @@
-{"a":42}	JSON
+{"a":"42"}	JSON
 {"a":42}	Object(\'json\')

--- a/tests/queries/0_stateless/03230_json_alias_new_old_types.sql
+++ b/tests/queries/0_stateless/03230_json_alias_new_old_types.sql
@@ -1,0 +1,8 @@
+set allow_experimental_object_type=1;
+set allow_experimental_json_type=1;
+set use_json_alias_for_old_object_type=0;
+select '{"a" : 42}'::JSON as json, toTypeName(json);
+set use_json_alias_for_old_object_type=1;
+select '{"a" : 42}'::JSON as json, toTypeName(json);
+select '{"a" : 42}'::JSON(max_dynamic_paths=100) as json, toTypeName(json); -- {serverError BAD_ARGUMENTS}
+

--- a/tests/queries/0_stateless/03230_json_alias_new_old_types.sql
+++ b/tests/queries/0_stateless/03230_json_alias_new_old_types.sql
@@ -1,7 +1,7 @@
 set allow_experimental_object_type=1;
 set allow_experimental_json_type=1;
 set use_json_alias_for_old_object_type=0;
-select '{"a" : 42}'::JSON as json, toTypeName(json);
+select materialize('{"a" : 42}')::JSON as json, toTypeName(json);
 set use_json_alias_for_old_object_type=1;
 select '{"a" : 42}'::JSON as json, toTypeName(json);
 select '{"a" : 42}'::JSON(max_dynamic_paths=100) as json, toTypeName(json); -- {serverError BAD_ARGUMENTS}


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Don't require server restart to apply changes in setting `use_json_alias_for_old_object_type` 

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---ci_include_fuzzer--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
