### PR TITLE
ci: add checks for `iptables-nft` in integration test runner

### DIFF
--- a/tests/integration/runner
+++ b/tests/integration/runner
@@ -6,6 +6,7 @@ import logging
 import os
 import random
 import shlex
+import shutil
 import signal
 import string
 import subprocess
@@ -135,6 +136,47 @@ def check_args_and_update_paths(args):
         )
 
 
+def check_iptables_legacy():
+    iptables_path = shutil.which("iptables")
+
+    if iptables_path is None:
+        print("Error: 'iptables' not found in PATH")
+        sys.exit(1)  # Exit with error code 1
+
+    try:
+        file_info = os.stat(iptables_path)
+        file_info_str = str(file_info)
+
+        if "legacy" in file_info_str:
+            print(
+                "iptables is in 'legacy' mode. This is not supported. Please switch to 'nftables' mode."
+            )
+            sys.exit(1)
+
+    except FileNotFoundError:
+        print(f"Error: '{iptables_path}' not found")
+        sys.exit(1)
+
+
+def check_iptables_forward_accept(ipv6=False):
+    command = "iptables"
+    if ipv6:
+        command = "ip6tables"
+    output = os.popen(command + "-S FORWARD").read()
+
+    # Check if the output contains '-P FORWARD ACCEPT'
+    if "-P FORWARD ACCEPT" not in output:
+        print(
+            f"'{command} -P FORWARD ACCEPT' is not set. This may cause issues in tests"
+        )
+
+
+def chech_prerequisites():
+    check_iptables_legacy()
+    check_iptables_forward_accept(ipv6=False)
+    check_iptables_forward_accept(ipv6=True)
+
+
 def docker_kill_handler_handler(signum, frame):
     _, _ = signum, frame
     subprocess.check_call(
@@ -163,6 +205,9 @@ if __name__ == "__main__":
         level=logging.INFO,
         format="%(asctime)s [ %(process)d ] %(levelname)s : %(message)s (%(filename)s:%(lineno)s, %(funcName)s)",
     )
+
+    chech_prerequisites()
+
     parser = argparse.ArgumentParser(description="ClickHouse integration tests runner")
 
     parser.add_argument(

--- a/tests/integration/runner
+++ b/tests/integration/runner
@@ -141,7 +141,7 @@ def check_iptables_legacy():
 
     if iptables_path is None:
         print("Error: 'iptables' not found in PATH")
-        sys.exit(1)  # Exit with error code 1
+        sys.exit(1)
 
     try:
         file_info = os.stat(iptables_path)
@@ -164,7 +164,6 @@ def check_iptables_forward_accept(ipv6=False):
         command = "ip6tables"
     output = os.popen(command + "-S FORWARD").read()
 
-    # Check if the output contains '-P FORWARD ACCEPT'
     if "-P FORWARD ACCEPT" not in output:
         print(
             f"'{command} -P FORWARD ACCEPT' is not set. This may cause issues in tests"

--- a/tests/integration/runner
+++ b/tests/integration/runner
@@ -152,7 +152,12 @@ def check_iptables_legacy():
 
         if "legacy" in file_info_str:
             print(
-                "iptables is in 'legacy' mode. This is not supported. Please switch to 'nftables' mode."
+                """
+                iptables is in 'legacy' mode. This is not supported.
+
+                Please switch to 'nftables' mode, usualy by installing `iptables-nft` or `nftables`, consult your distribution manual.
+                Or, use --ignore-iptables-legacy-check.
+                """
             )
             sys.exit(1)
 
@@ -164,7 +169,12 @@ def check_iptables_legacy():
 
         if "legacy" in file_info_str:
             print(
-                "ip6tables is in 'legacy' mode. This is not supported. Please switch to 'nftables' mode."
+                """
+                ip6tables is in 'legacy' mode. This is not supported.
+
+                Please switch to 'nftables' mode, usualy by installing `iptables-nft` or `nftables`, consult your distribution manual.
+                Or, use --ignore-iptables-legacy-check.
+                """
             )
             sys.exit(1)
 

--- a/tests/integration/runner
+++ b/tests/integration/runner
@@ -138,10 +138,13 @@ def check_args_and_update_paths(args):
 
 def check_iptables_legacy():
     iptables_path = shutil.which("iptables")
+    ip6tables_path = shutil.which("ip6tables")
 
     if iptables_path is None:
         print("Error: 'iptables' not found in PATH")
         sys.exit(1)
+    if ip6tables_path is None:
+        print("Error: 'ip6tables' not found in PATH, ignoring")
 
     try:
         file_info = os.stat(iptables_path)
@@ -153,27 +156,21 @@ def check_iptables_legacy():
             )
             sys.exit(1)
 
+        if not ip6tables_path:
+            return
+
+        file_info = os.stat(ip6tables_path)
+        file_info_str = str(file_info)
+
+        if "legacy" in file_info_str:
+            print(
+                "ip6tables is in 'legacy' mode. This is not supported. Please switch to 'nftables' mode."
+            )
+            sys.exit(1)
+
     except FileNotFoundError:
         print(f"Error: '{iptables_path}' not found")
         sys.exit(1)
-
-
-def check_iptables_forward_accept(ipv6=False):
-    command = "iptables"
-    if ipv6:
-        command = "ip6tables"
-    output = os.popen(command + "-S FORWARD").read()
-
-    if "-P FORWARD ACCEPT" not in output:
-        print(
-            f"'{command} -P FORWARD ACCEPT' is not set. This may cause issues in tests"
-        )
-
-
-def chech_prerequisites():
-    check_iptables_legacy()
-    check_iptables_forward_accept(ipv6=False)
-    check_iptables_forward_accept(ipv6=True)
 
 
 def docker_kill_handler_handler(signum, frame):
@@ -204,8 +201,6 @@ if __name__ == "__main__":
         level=logging.INFO,
         format="%(asctime)s [ %(process)d ] %(levelname)s : %(message)s (%(filename)s:%(lineno)s, %(funcName)s)",
     )
-
-    chech_prerequisites()
 
     parser = argparse.ArgumentParser(description="ClickHouse integration tests runner")
 
@@ -355,11 +350,23 @@ if __name__ == "__main__":
         help="Bind volume to this dir to use for dockerd files",
     )
 
+    parser.add_argument(
+        "--ignore-iptables-legacy-check",
+        action="store_true",
+        default=False,
+        help="Ignore iptables-legacy usage check",
+    )
+
     parser.add_argument("pytest_args", nargs="*", help="args for pytest command")
 
     args = parser.parse_args()
 
     check_args_and_update_paths(args)
+
+    if not args.ignore_iptables_legacy_check:
+        check_iptables_legacy()
+    else:
+        logging.warning("Skipping iptables-legacy check")
 
     parallel_args = ""
     if args.parallel:

--- a/tests/integration/runner
+++ b/tests/integration/runner
@@ -153,7 +153,7 @@ def check_iptables_legacy():
         if "legacy" in file_info_str:
             print(
                 """
-                iptables is in 'legacy' mode. This is not supported.
+                iptables on your host machine is in 'legacy' mode. This is not supported.
 
                 Please switch to 'nftables' mode, usualy by installing `iptables-nft` or `nftables`, consult your distribution manual.
                 Or, use --ignore-iptables-legacy-check.
@@ -170,7 +170,7 @@ def check_iptables_legacy():
         if "legacy" in file_info_str:
             print(
                 """
-                ip6tables is in 'legacy' mode. This is not supported.
+                ip6tables on your host machine is in 'legacy' mode. This is not supported.
 
                 Please switch to 'nftables' mode, usualy by installing `iptables-nft` or `nftables`, consult your distribution manual.
                 Or, use --ignore-iptables-legacy-check.


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---ci_include_fuzzer--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
