### PR TITLE
Fix LocalObjectStorage trying to use mmap/io_uring and failing reads

### DIFF
--- a/src/Disks/IO/ThreadPoolRemoteFSReader.h
+++ b/src/Disks/IO/ThreadPoolRemoteFSReader.h
@@ -29,9 +29,6 @@ private:
 class RemoteFSFileDescriptor : public IAsynchronousReader::IFileDescriptor
 {
 public:
-    /// `reader_` implementation must ensure that next() places data at the start of internal_buffer,
-    /// even if there was previously a seek. I.e. seek() shouldn't leave pending data (no short seek
-    /// optimization), and nextImpl() shouldn't assign nextimpl_working_buffer_offset.
     explicit RemoteFSFileDescriptor(
         SeekableReadBuffer & reader_,
         std::shared_ptr<AsyncReadCounters> async_read_counters_)

--- a/src/IO/AsynchronousReader.h
+++ b/src/IO/AsynchronousReader.h
@@ -49,6 +49,8 @@ public:
         size_t size = 0;
         char * buf = nullptr;
         Priority priority;
+        /// Skip the first `ignore` bytes. I.e. read `size - ignore` bytes at `offset + ignore`.
+        /// The skipping is done using ReadBuffer::ignore.
         size_t ignore = 0;
     };
 

--- a/tests/queries/0_stateless/02714_local_object_storage.reference
+++ b/tests/queries/0_stateless/02714_local_object_storage.reference
@@ -1,2 +1,5 @@
 1	test
 1	test
+1	test
+1	test
+1	test

--- a/tests/queries/0_stateless/02714_local_object_storage.sql
+++ b/tests/queries/0_stateless/02714_local_object_storage.sql
@@ -14,6 +14,10 @@ SETTINGS disk = disk(
 INSERT INTO test SELECT 1, 'test';
 SELECT * FROM test;
 
+SELECT * FROM test SETTINGS min_bytes_to_use_mmap_io=1, local_filesystem_read_method='mmap';
+SELECT * FROM test SETTINGS local_filesystem_read_method='io_uring';
+SELECT * FROM test SETTINGS min_bytes_to_use_direct_io=1;
+
 DROP TABLE test SYNC;
 
 CREATE TABLE test (a Int32, b String)


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

ThreadPoolRemoteFSReader is picky about ReadBuffer implementation, but the code that provides a ReadBuffer to it is not careful about it and may pass lots of different ReadBuffer types there. This PR fixes some cases where unsupported ReadBuffer is used: local_blob_storage with mmap or io_uring or O_DIRECT. And adds debug logging if the assert still fails.

Might fix https://github.com/ClickHouse/ClickHouse/issues/66031 , but not very likely. In that case local_blob_storage was used, but, afaict from the log, mmap/io_uring/O_DIRECT weren't enabled.