### PR TITLE
Actually fix false "Killed by signal (output files)" in stress_tests.lib

### DIFF
--- a/tests/docker_scripts/stress_tests.lib
+++ b/tests/docker_scripts/stress_tests.lib
@@ -272,8 +272,10 @@ function check_logs_for_critical_errors()
     # Remove file no_such_key_errors.txt if it's empty
     [ -s /test_output/no_such_key_errors.txt ] || rm /test_output/no_such_key_errors.txt
 
-    # Crash
-    rg -Fa "###################""#####################" /var/log/clickhouse-server/clickhouse-server*.log > /dev/null \
+    # Crash. This must have fewer '#'s than the command below, otherwise the command below will match
+    # the echo of this command (if set -x is enabled, and this script's stdout is sent
+    # to /test_output/run.log).
+    rg -Fa "#######################################" /var/log/clickhouse-server/clickhouse-server*.log > /dev/null \
         && echo -e "Killed by signal (in clickhouse-server.log)$FAIL" >> /test_output/test_results.tsv \
         || echo -e "Not crashed$OK" >> /test_output/test_results.tsv
 
@@ -285,7 +287,7 @@ function check_logs_for_critical_errors()
     # Remove file fatal_messages.txt if it's empty
     [ -s /test_output/fatal_messages.txt ] || rm /test_output/fatal_messages.txt
 
-    rg -Faz "####################""####################" /test_output/* > /dev/null \
+    rg -Faz "########################################" /test_output/* > /dev/null \
       && echo -e "Killed by signal (output files)$FAIL" >> /test_output/test_results.tsv
 
     function get_gdb_log_context()


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

Like https://github.com/ClickHouse/ClickHouse/pull/68638 but not broken (hopefully). Turns out `set -x` echoes `rg "#""#"` as `rg '##'`, so the trick in that PR didn't work at all. Here's an even sillier trick.