### PR TITLE
no-tsan in 02735_parquet_encoder

### DIFF
--- a/tests/queries/0_stateless/02735_parquet_encoder.sql
+++ b/tests/queries/0_stateless/02735_parquet_encoder.sql
@@ -1,4 +1,4 @@
--- Tags: no-fasttest, no-parallel, no-tsan
+-- Tags: no-fasttest, no-parallel, no-tsan, no-msan
 
 set output_format_parquet_use_custom_encoder = 1;
 set output_format_parquet_row_group_size = 1000;

--- a/tests/queries/0_stateless/02735_parquet_encoder.sql
+++ b/tests/queries/0_stateless/02735_parquet_encoder.sql
@@ -1,4 +1,4 @@
--- Tags: no-fasttest, no-parallel
+-- Tags: no-fasttest, no-parallel, no-tsan
 
 set output_format_parquet_use_custom_encoder = 1;
 set output_format_parquet_row_group_size = 1000;

--- a/tests/queries/0_stateless/02735_parquet_encoder.sql
+++ b/tests/queries/0_stateless/02735_parquet_encoder.sql
@@ -1,4 +1,4 @@
--- Tags: long, no-fasttest, no-parallel, no-tsan, no-msan
+-- Tags: long, no-fasttest, no-parallel, no-tsan, no-msan, no-asan
 
 set output_format_parquet_use_custom_encoder = 1;
 set output_format_parquet_row_group_size = 1000;

--- a/tests/queries/0_stateless/02735_parquet_encoder.sql
+++ b/tests/queries/0_stateless/02735_parquet_encoder.sql
@@ -1,4 +1,4 @@
--- Tags: no-fasttest, no-parallel, no-tsan, no-msan
+-- Tags: long, no-fasttest, no-parallel, no-tsan, no-msan
 
 set output_format_parquet_use_custom_encoder = 1;
 set output_format_parquet_row_group_size = 1000;


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

Failed like this: https://s3.amazonaws.com/clickhouse-test-reports/68918/89359c1e6b22d8a0a2ad5e56c5201c8b99c72b67/stateless_tests__tsan__s3_storage__[1_3].html (test_result.txt says that 02735_parquet_encoder timed out).

The test does two 1M-row queries, which took a few minutes each in this run. (Idk why so slow and how consistent it is. Would be good to repro and profile.)