### PR TITLE
Fixing tuple/array literal parsing

### DIFF
--- a/src/Parsers/ExpressionElementParsers.cpp
+++ b/src/Parsers/ExpressionElementParsers.cpp
@@ -1299,12 +1299,17 @@ bool ParserStringLiteral::parseImpl(Pos & pos, ASTPtr & node, Expected & expecte
 template <typename Collection>
 struct CollectionOfLiteralsLayer
 {
-    explicit CollectionOfLiteralsLayer(IParser::Pos & pos) : literal_begin(pos)
+    explicit CollectionOfLiteralsLayer(IParser::Pos & pos, bool is_functional_style_ = false)
+        : literal_begin(pos)
+        , is_functional_style(is_functional_style_)
     {
+        pos.increaseDepth();
         ++pos;
     }
 
     IParser::Pos literal_begin;
+    /// Functional-style literal definition, e.g. `tuple(1, 2, 3)`, or `array(1, 2, 3)`.
+    bool is_functional_style = false;
     Collection arr;
 };
 
@@ -1316,7 +1321,6 @@ bool ParserCollectionOfLiterals<Collection>::parseImpl(Pos & pos, ASTPtr & node,
 
     std::vector<CollectionOfLiteralsLayer<Collection>> layers;
     layers.emplace_back(pos);
-    pos.increaseDepth();
 
     ParserLiteral literal_p;
 
@@ -1324,11 +1328,25 @@ bool ParserCollectionOfLiterals<Collection>::parseImpl(Pos & pos, ASTPtr & node,
     {
         if (!layers.back().arr.empty())
         {
-            if (pos->type == closing_bracket)
+            auto expected_closing = layers.back().is_functional_style ? TokenType::ClosingRoundBracket : closing_bracket;
+            if (pos->type == expected_closing)
             {
                 /// Parse one-element tuples (e.g. (1)) later as single values for backward compatibility.
-                if (std::is_same_v<Collection, Tuple> && layers.back().arr.size() == 1)
+                if (std::is_same_v<Collection, Tuple> && layers.back().arr.size() == 1 && !layers.back().is_functional_style)
+                {
+                    /// Single element inside round brackets is not a tuple, but a scalar.
+                    /// We need to merge it with the previous layer.
+                    /// Example: (1, (2)) is parsed as tuple(1, 2) instead of tuple(1, tuple(2)).
+                    if (layers.size() > 1)
+                    {
+                        layers[layers.size() - 2].arr.push_back(layers.back().arr[0]);
+                        layers.pop_back();
+                        ++pos;
+                        pos.decreaseDepth();
+                        continue;
+                    }
                     return false;
+                }
 
                 std::shared_ptr<ASTLiteral> literal = std::make_shared<ASTLiteral>(std::move(layers.back().arr));
                 literal->begin = layers.back().literal_begin;
@@ -1369,7 +1387,16 @@ bool ParserCollectionOfLiterals<Collection>::parseImpl(Pos & pos, ASTPtr & node,
         else if (pos->type == opening_bracket)
         {
             layers.emplace_back(pos);
-            pos.increaseDepth();
+        }
+        else if (pos->type == TokenType::BareWord && std::string_view(pos->begin, pos->end) == FunctionName<Collection>::value)
+        {
+            ++pos;
+            if (pos.isValid() && pos->type == TokenType::OpeningRoundBracket)
+            {
+                layers.emplace_back(pos, true);
+            }
+            else
+                return false;
         }
         else
             return false;

--- a/src/Parsers/ExpressionElementParsers.h
+++ b/src/Parsers/ExpressionElementParsers.h
@@ -317,6 +317,12 @@ protected:
 private:
     TokenType opening_bracket;
     TokenType closing_bracket;
+
+    template <typename> struct FunctionName;
+    template <> struct FunctionName<Array> { static constexpr auto value = "array"; };
+    template <> struct FunctionName<Tuple> { static constexpr auto value = "tuple"; };
+
+    std::string_view function_name = FunctionName<Collection>::value;
 };
 
 /// A tuple of literals with same type.

--- a/src/Parsers/tests/gtest_Parser.cpp
+++ b/src/Parsers/tests/gtest_Parser.cpp
@@ -675,3 +675,80 @@ INSTANTIATE_TEST_SUITE_P(
                 "WITH\n    table_1 AS\n    (\n        SELECT\n            country,\n            city,\n            c + some_derived_value AS _expr_1\n        FROM matches\n        WHERE start_date > toDate('2023-05-30')\n    ),\n    table_0 AS\n    (\n        SELECT\n            country,\n            city,\n            AVG(_expr_1) AS _expr_0,\n            MAX(_expr_1) AS aggr\n        FROM table_1\n        WHERE _expr_1 > 0\n        GROUP BY\n            country,\n            city\n    )\nSELECT\n    country,\n    city,\n    _expr_0,\n    aggr,\n    CONCAT(city, ' in ', country) AS place,\n    LEFT(country, 2) AS country_code\nFROM table_0\nORDER BY\n    aggr ASC,\n    country DESC\nLIMIT 20",
             },
         })));
+
+namespace DB { std::ostream & operator<<(std::ostream & stream, const Field & field) { return stream << field.dump(); } }
+
+template <typename ParserType, typename LiteralType>
+void testCollectionOfLiteralsParser(
+    const std::vector<std::string_view> & test_cases,
+    const std::vector<std::string_view> & negative_test_cases,
+    size_t top_level_size)
+{
+    ParserType parser;
+    auto parse_literal = [&](std::string_view text) -> std::optional<LiteralType>
+    {
+        try
+        {
+            auto ast = parseQuery(parser, text.data(), text.data() + text.size(), 0, 0, 0);
+            const auto * literal = typeid_cast<const ASTLiteral *>(ast.get());
+            if (!literal || literal->value.getType() != Field::TypeToEnum<LiteralType>::value)
+                return {};
+            return literal->value.template safeGet<LiteralType>();
+        }
+        catch (const DB::Exception & e)
+        {
+            std::cerr << e.displayText() << std::endl;
+            return {};
+        }
+    };
+
+    const auto & reference_literal = parse_literal(test_cases[0]);
+    ASSERT_TRUE(reference_literal && reference_literal->size() == top_level_size);
+
+    for (size_t i = 1; i < test_cases.size(); ++i)
+    {
+        SCOPED_TRACE(fmt::format("Test case #{}: {}", i + 1, test_cases[i]));
+        EXPECT_EQ(reference_literal, parse_literal(test_cases[i]));
+    }
+
+    for (size_t i = 0; i < negative_test_cases.size(); ++i)
+    {
+        SCOPED_TRACE(fmt::format("Negative test case #{}: {}", i + 1, negative_test_cases[i]));
+        auto negative_example = parse_literal(negative_test_cases[i]);
+        ASSERT_TRUE(negative_example);
+        EXPECT_NE(reference_literal, negative_example);
+    }
+}
+
+TEST(ParserTest, parseTupleLiterals)
+try
+{
+    testCollectionOfLiteralsParser<ParserTupleOfLiterals, Tuple>({
+        "((1, 2), (3, 4))",
+        "(((1), 2), (3, 4))",
+        "(((1, 2)), (3, 4))",
+        "(((1), 2), (((((((3))))), 4)))",
+        "(tuple(1, 2), (3, 4))",
+        "(tuple((1), (2)), (tuple(3, 4)))",
+    }, {
+        "((tuple(1), 2), (3, 4))",
+    }, 2);
+
+    // testCollectionOfLiteralsParser<ParserArrayOfLiterals, Array>({
+    //     "[[1, 2, 3]]",
+    //     "[[(1), (2), 3]]",
+    //     "[[1, (((2))), (((((3)))))]]",
+    //     "[(([1, (((2))), (((((3)))))]))]",
+    //     "[([1, 2, 3])]",
+    // }, {
+    //     "[[[1], 2, 3]]",
+    //     "[1, 2, 3]",
+    //     "[[1, (2, 3)]]",
+    //     "[[[1, 2, 3]]]",
+    // }, 1);
+}
+catch (...)
+{
+    std::cerr << getCurrentExceptionMessage(true) << std::endl;
+    throw;
+}


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):

- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
* Fix inconsistent parsing of tuple literals with extra brackets or functional style literals (e.g.  `tuple(1, 2)`) inside


Ref https://github.com/ClickHouse/ClickHouse/issues/68296

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---ci_include_fuzzer--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
