### PR TITLE
Fix test_replicated_database_cluster_groups

### DIFF
--- a/tests/integration/test_replicated_database_cluster_groups/test.py
+++ b/tests/integration/test_replicated_database_cluster_groups/test.py
@@ -111,7 +111,7 @@ def test_cluster_groups(started_cluster):
 
     for node in [backup_node_1, backup_node_2, main_node_2]:
         node.query("SYSTEM SYNC DATABASE REPLICA cluster_groups;")
-    
+
     assert_create_query(all_nodes, "cluster_groups.table_1", expected_1)
     assert_create_query(all_nodes, "cluster_groups.table_2", expected_2)
 

--- a/tests/integration/test_replicated_database_cluster_groups/test.py
+++ b/tests/integration/test_replicated_database_cluster_groups/test.py
@@ -109,6 +109,9 @@ def test_cluster_groups(started_cluster):
     expected_1 = "CREATE TABLE cluster_groups.table_1\\n(\\n    `d` Date,\\n    `k` UInt64\\n)\\nENGINE = ReplicatedMergeTree(\\'/clickhouse/tables/{uuid}/{shard}\\', \\'{replica}\\')\\nPARTITION BY toYYYYMM(d)\\nORDER BY k\\nSETTINGS index_granularity = 8192"
     expected_2 = "CREATE TABLE cluster_groups.table_2\\n(\\n    `d` Date,\\n    `k` UInt64\\n)\\nENGINE = ReplicatedMergeTree(\\'/clickhouse/tables/{uuid}/{shard}\\', \\'{replica}\\')\\nPARTITION BY toYYYYMM(d)\\nORDER BY k\\nSETTINGS index_granularity = 8192"
 
+    for node in [backup_node_1, backup_node_2, main_node_2]:
+        node.query("SYSTEM SYNC DATABASE REPLICA cluster_groups;")
+    
     assert_create_query(all_nodes, "cluster_groups.table_1", expected_1)
     assert_create_query(all_nodes, "cluster_groups.table_2", expected_2)
 

--- a/tests/integration/test_replicated_database_cluster_groups/test.py
+++ b/tests/integration/test_replicated_database_cluster_groups/test.py
@@ -127,3 +127,9 @@ def test_cluster_groups(started_cluster):
     main_node_1.query("SYSTEM DROP DATABASE REPLICA '1|2' FROM DATABASE cluster_groups")
 
     assert_eq_with_retry(main_node_1, cluster_query, "main_node_1\n")
+
+    # 5. Reset to the original state
+    backup_node_2.start_clickhouse()
+    main_node_2.start_clickhouse()
+    for node in all_nodes:
+        node.query("DROP DATABASE cluster_groups SYNC;")


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Closes https://github.com/ClickHouse/ClickHouse/issues/69038.
