### PR TITLE
Fix subnet in docker_compose_net.yml

### DIFF
--- a/tests/integration/compose/docker_compose_net.yml
+++ b/tests/integration/compose/docker_compose_net.yml
@@ -6,6 +6,6 @@ networks:
     ipam:
       config:
       - subnet: 10.0.0.0/12
-        gateway: 10.5.1.1
+        gateway: 10.0.0.1
       - subnet: 2001:3984:3989::/64
         gateway: 2001:3984:3989::1

--- a/tests/integration/compose/docker_compose_net.yml
+++ b/tests/integration/compose/docker_compose_net.yml
@@ -5,7 +5,7 @@ networks:
     enable_ipv6: true
     ipam:
       config:
-      - subnet: 10.5.0.0/12
+      - subnet: 10.0.0.0/12
         gateway: 10.5.1.1
       - subnet: 2001:3984:3989::/64
         gateway: 2001:3984:3989::1


### PR DESCRIPTION
It seems that certain docker versions do not like 10.5.0.0/12 (which does not make sense indeed).
Probably this is the cause of test_dns_cache failures in https://s3.amazonaws.com/clickhouse-test-reports/0/a129d07eb58caa153f4ddae4ef60c033f94e5965/integration_tests__tsan__%5B3_6%5D.html

```
compose.cli.errors.log_api_error: invalid network config:
invalid subnet 10.5.0.0/12: it should be 10.0.0.0/12
```

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...
