### PR TITLE
Add validation of IP addresses and domains in settings

### DIFF
--- a/base/poco/Util/CMakeLists.txt
+++ b/base/poco/Util/CMakeLists.txt
@@ -18,4 +18,4 @@ target_compile_options (_poco_util
         -Wno-zero-as-null-pointer-constant
 )
 target_include_directories (_poco_util SYSTEM PUBLIC "include")
-target_link_libraries (_poco_util PUBLIC Poco::JSON Poco::XML)
+target_link_libraries (_poco_util PUBLIC Poco::JSON Poco::XML Poco::Net)

--- a/base/poco/Util/include/Poco/Util/AbstractConfiguration.h
+++ b/base/poco/Util/include/Poco/Util/AbstractConfiguration.h
@@ -363,16 +363,13 @@ namespace Util
         std::string uncheckedExpand(const std::string & value) const;
 
         static bool isValidIPv4Address(const std::string & value);
-        /// A string value is considered to be a valid IPv4 address if it matches
-        /// "x1.x2.x3.x4", where xi - integer in range 0..255 and may have leading zeroes
+        /// IPv4 address considered valid if it is "0.0.0.0" or one of those,
+        /// defined by inet_aton() or inet_addr()
 
         static bool isValidIPv6Address(const std::string & value);
-        /// A string value is considered to be a valid IPv6 address if it matches
-        /// "x1:x2:x3:x4:x5:x6:x7:x8", where xi is hexadecimal integer and consist of 4
-        /// characters or less (but at least 1), xi may have leading zeroes. 
-        /// Letters in hexadecimal representation can be in upper case or lower case.
-        /// One or more consecutive hextets of zeroes can be replaced with "::", but
-        /// "::" can appear only once in a valid IPv6 address.
+        /// IPv6 address considered valid if it is "::" or one of those,
+        /// defined by inet_pton() with AF_INET6 flag
+        /// (in this case it may have scope id and may be surrounded by '[', ']')
 
         static bool isValidDomainName(const std::string & value);
         /// <domain> ::= <subdomain> [ "." ]

--- a/base/poco/Util/include/Poco/Util/AbstractConfiguration.h
+++ b/base/poco/Util/include/Poco/Util/AbstractConfiguration.h
@@ -241,6 +241,20 @@ namespace Util
         /// If the value contains references to other properties (${<property>}), these
         /// are expanded.
 
+        std::string getHost(const std::string & key) const;
+        /// Returns the string value of the host property with the given name.
+        /// Throws a NotFoundException if the key does not exist.
+        /// Throws a SyntaxException if the property is not a valid host (IP address or domain).
+        /// If the value contains references to other properties (${<property>}), these
+        /// are expanded.
+
+        std::string getHost(const std::string & key, const std::string & defaultValue) const;
+        /// If a property with the given key exists, returns the host property's string value,
+        /// otherwise returns the given default value.
+        /// Throws a SyntaxException if the property is not a valid host (IP address or domain).
+        /// If the value contains references to other properties (${<property>}), these
+        /// are expanded.
+
         virtual void setString(const std::string & key, const std::string & value);
         /// Sets the property with the given key to the given value.
         /// An already existing value for the key is overwritten.
@@ -339,11 +353,37 @@ namespace Util
         static bool parseBool(const std::string & value);
         void setRawWithEvent(const std::string & key, std::string value);
 
+        static void checkHostValidity(const std::string & value);
+        /// Throws a SyntaxException if the value is not a valid host (IP address or domain).
+
         virtual ~AbstractConfiguration();
 
     private:
         std::string internalExpand(const std::string & value) const;
         std::string uncheckedExpand(const std::string & value) const;
+
+        static bool isValidIPv4Address(const std::string & value);
+        /// A string value is considered to be a valid IPv4 address if it matches
+        /// "x1.x2.x3.x4", where xi - integer in range 0..255 and may have leading zeroes
+
+        static bool isValidIPv6Address(const std::string & value);
+        /// A string value is considered to be a valid IPv6 address if it matches
+        /// "x1:x2:x3:x4:x5:x6:x7:x8", where xi is hexadecimal integer and consist of 4
+        /// characters or less (but at least 1), xi may have leading zeroes. 
+        /// Letters in hexadecimal representation can be in upper case or lower case.
+        /// One or more consecutive hextets of zeroes can be replaced with "::", but
+        /// "::" can appear only once in a valid IPv6 address.
+
+        static bool isValidDomainName(const std::string & value);
+        /// <domain> ::= <subdomain> [ "." ]
+        /// <subdomain> ::= <label> | <subdomain> "." <label>
+        /// <label> ::= <letter> [ [ <ldh-str> ] <let-dig> ]
+        /// <ldh-str> ::= <let-dig-hyp> | <let-dig-hyp> <ldh-str>
+        /// <let-dig-hyp> ::= <let-dig> | "-"
+        /// <let-dig> ::= <letter> | <digit>
+        /// <letter> ::= any one of the 52 alphabetic characters A through Z in
+        /// upper case and a through z in lower case
+        /// <digit> ::= any one of the ten digits 0 through 9
 
         AbstractConfiguration(const AbstractConfiguration &);
         AbstractConfiguration & operator=(const AbstractConfiguration &);

--- a/src/Common/tests/gtest_config_host_validation.cpp
+++ b/src/Common/tests/gtest_config_host_validation.cpp
@@ -1,0 +1,69 @@
+#include <Poco/AutoPtr.h>
+#include <Poco/DOM/DOMParser.h>
+#include <Poco/Util/XMLConfiguration.h>
+
+#include <gtest/gtest.h>
+
+TEST(Common, ConfigHostValidation)
+{
+    std::string xml(R"CONFIG(<clickhouse>
+    <IPv4_1>0.0.0.0</IPv4_1>
+    <IPv4_2>192.168.0.1</IPv4_2>
+    <IPv4_3>127.0.0.1</IPv4_3>
+    <IPv4_4>255.255.255.255</IPv4_4>
+    <IPv6_1>2001:0db8:85a3:0000:0000:8a2e:0370:7334</IPv6_1>
+    <IPv6_2>2001:DB8::8a2e:370:7334</IPv6_2>
+    <IPv6_3>::1</IPv6_3>
+    <IPv6_4>::</IPv6_4>
+    <Domain_1>www.example.com.</Domain_1>
+    <Domain_2>a.co</Domain_2>
+    <Domain_3>localhost</Domain_3>
+    <Domain_4>xn--fiqs8s.xn--fiqz9s</Domain_4>
+    <IPv4_Invalid_1>192.168.1.256</IPv4_Invalid_1>
+    <IPv4_Invalid_2>192.168.1.1.1</IPv4_Invalid_2>
+    <IPv4_Invalid_3>192.168.1.99999999999999999999</IPv4_Invalid_3>
+    <IPv4_Invalid_4>192.168.1.a</IPv4_Invalid_4>
+    <IPv6_Invalid_1>2001:0db8:85a3:::8a2e:0370:7334</IPv6_Invalid_1>
+    <IPv6_Invalid_2>1200::AB00:1234::2552:7777:1313</IPv6_Invalid_2>
+    <IPv6_Invalid_3>1200::AB00:1234:Q000:2552:7777:1313</IPv6_Invalid_3>
+    <IPv6_Invalid_4>1200:AB00:1234:2552:7777:1313:FFFF</IPv6_Invalid_4>
+    <Domain_Invalid_1>example.com..</Domain_Invalid_1>
+    <Domain_Invalid_2>5example.com</Domain_Invalid_2>
+    <Domain_Invalid_3>example.com-</Domain_Invalid_3>
+    <Domain_Invalid_4>exa_mple.com</Domain_Invalid_4>
+</clickhouse>)CONFIG");
+
+    Poco::XML::DOMParser dom_parser;
+    Poco::AutoPtr<Poco::XML::Document> document = dom_parser.parseString(xml);
+    Poco::AutoPtr<Poco::Util::XMLConfiguration> config = new Poco::Util::XMLConfiguration(document);
+
+    EXPECT_NO_THROW(config->getHost("IPv4_1"));
+    EXPECT_NO_THROW(config->getHost("IPv4_2"));
+    EXPECT_NO_THROW(config->getHost("IPv4_3"));
+    EXPECT_NO_THROW(config->getHost("IPv4_4"));
+
+    EXPECT_NO_THROW(config->getHost("IPv6_1"));
+    EXPECT_NO_THROW(config->getHost("IPv6_2"));
+    EXPECT_NO_THROW(config->getHost("IPv6_3"));
+    EXPECT_NO_THROW(config->getHost("IPv6_4"));
+
+    EXPECT_NO_THROW(config->getHost("Domain_1"));
+    EXPECT_NO_THROW(config->getHost("Domain_2"));
+    EXPECT_NO_THROW(config->getHost("Domain_3"));
+    EXPECT_NO_THROW(config->getHost("Domain_4"));
+
+    EXPECT_THROW(config->getHost("IPv4_Invalid_1"), Poco::SyntaxException);
+    EXPECT_THROW(config->getHost("IPv4_Invalid_2"), Poco::SyntaxException);
+    EXPECT_THROW(config->getHost("IPv4_Invalid_3"), Poco::SyntaxException);
+    EXPECT_THROW(config->getHost("IPv4_Invalid_4"), Poco::SyntaxException);
+
+    EXPECT_THROW(config->getHost("IPv6_Invalid_1"), Poco::SyntaxException);
+    EXPECT_THROW(config->getHost("IPv6_Invalid_2"), Poco::SyntaxException);
+    EXPECT_THROW(config->getHost("IPv6_Invalid_3"), Poco::SyntaxException);
+    EXPECT_THROW(config->getHost("IPv6_Invalid_4"), Poco::SyntaxException);
+
+    EXPECT_THROW(config->getHost("Domain_Invalid_1"), Poco::SyntaxException);
+    EXPECT_THROW(config->getHost("Domain_Invalid_2"), Poco::SyntaxException);
+    EXPECT_THROW(config->getHost("Domain_Invalid_3"), Poco::SyntaxException);
+    EXPECT_THROW(config->getHost("Domain_Invalid_4"), Poco::SyntaxException);
+}


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add `std::string getHost(const std::string & key) const;` method to "base/poco/Util/include/Poco/Util/AbstractConfiguration.h" which does the same as `Poco::Util::AbstractConfiguration::getString` method but  additionally does validity check to make sure value is a correct IP address or domain name.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
- Motivation: Many settings in ClickHouse's configuration file specify hosts in the form of IP addresses (12.13.14.15) or domains (mail.stanford.edu). Many similar settings exist. As of now, these settings are parsed as strings and typos cannot be detected immediately - in this case the connection to the host would silently fail.

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---ci_include_fuzzer--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
