### PR TITLE
Do not use docker pause for Kerberos KDC container in integration tests

### DIFF
--- a/tests/integration/helpers/network.py
+++ b/tests/integration/helpers/network.py
@@ -303,6 +303,7 @@ class _NetworkManager:
         destination_port=None,
         action=None,
         probability=None,
+        protocol=None,
         custom_args=None,
     ):
         ret = []
@@ -317,7 +318,7 @@ class _NetworkManager:
                     str(probability),
                 ]
             )
-        ret.extend(["-p", "tcp"])
+        ret.extend(["-p", "tcp" if protocol is None else protocol])
         if source is not None:
             ret.extend(["-s", source])
         if destination is not None:

--- a/tests/integration/test_storage_kerberized_kafka/test.py
+++ b/tests/integration/test_storage_kerberized_kafka/test.py
@@ -171,7 +171,7 @@ def test_kafka_json_as_string_request_new_ticket_after_expiration(kafka_cluster)
 """
     assert TSV(result) == TSV(expected)
     assert instance.contains_in_log(
-        "Parsing of message (topic: kafka_json_as_string, partition: 0, offset: 1) return no rows"
+        "Parsing of message (topic: kafka_json_as_string_after_expiration, partition: 0, offset: 1) return no rows"
     )
 
 
@@ -294,7 +294,7 @@ def test_kafka_config_from_sql_named_collection(kafka_cluster):
 """
     assert TSV(result) == TSV(expected)
     assert instance.contains_in_log(
-        "Parsing of message (topic: kafka_json_as_string, partition: 0, offset: 1) return no rows"
+        "Parsing of message (topic: kafka_json_as_string_named_collection, partition: 0, offset: 1) return no rows"
     )
 
 

--- a/tests/integration/test_storage_kerberized_kafka/test.py
+++ b/tests/integration/test_storage_kerberized_kafka/test.py
@@ -207,19 +207,19 @@ def test_kafka_json_as_string_no_kdc(kafka_cluster):
 
     # temporary prevent CH - KDC communications
     with PartitionManager() as pm:
-        for other_node in ["kafka_kerberos"]:
-            for node in kafka_cluster.instances.values():
-                source = node.ip_address
-                destination = kafka_cluster.get_instance_ip(other_node)
-                logging.debug(f"partitioning source {source}, destination {destination}")
-                pm._add_rule(
-                    {
-                        "source": source,
-                        "destination": destination,
-                        "action": "REJECT",
-                        "protocol": "all"
-                    }
-                )
+        other_node = "kafka_kerberos"
+        for node in kafka_cluster.instances.values():
+            source = node.ip_address
+            destination = kafka_cluster.get_instance_ip(other_node)
+            logging.debug(f"partitioning source {source}, destination {destination}")
+            pm._add_rule(
+                {
+                    "source": source,
+                    "destination": destination,
+                    "action": "REJECT",
+                    "protocol": "all"
+                }
+            )
 
         time.sleep(45)  # wait for ticket expiration
 

--- a/tests/integration/test_storage_kerberized_kafka/test.py
+++ b/tests/integration/test_storage_kerberized_kafka/test.py
@@ -259,6 +259,7 @@ def test_kafka_config_from_sql_named_collection(kafka_cluster):
 
     instance.query(
         """
+        DROP NAMED COLLECTION IF EXISTS kafka_config
         CREATE NAMED COLLECTION kafka_config AS
             kafka.security_protocol = 'SASL_PLAINTEXT',
             kafka.sasl_mechanism = 'GSSAPI',

--- a/tests/integration/test_storage_kerberized_kafka/test.py
+++ b/tests/integration/test_storage_kerberized_kafka/test.py
@@ -8,6 +8,7 @@ import logging
 from helpers.cluster import ClickHouseCluster, is_arm
 from helpers.test_tools import TSV
 from helpers.client import QueryRuntimeException
+from helpers.network import PartitionManager
 
 import json
 import subprocess
@@ -204,26 +205,39 @@ def test_kafka_json_as_string_no_kdc(kafka_cluster):
         ],
     )
 
-    kafka_cluster.pause_container("kafka_kerberos")
-    time.sleep(45)  # wait for ticket expiration
+    # temporary prevent CH - KDC communications
+    with PartitionManager() as pm:
+        for other_node in ["kafka_kerberos"]:
+            for node in kafka_cluster.instances.values():
+                source = node.ip_address
+                destination = kafka_cluster.get_instance_ip(other_node)
+                logging.debug(f"partitioning source {source}, destination {destination}")
+                pm._add_rule(
+                    {
+                        "source": source,
+                        "destination": destination,
+                        "action": "REJECT",
+                        "protocol": "all"
+                    }
+                )
 
-    instance.query(
-        """
-        CREATE TABLE test.kafka_no_kdc (field String)
-            ENGINE = Kafka
-            SETTINGS kafka_broker_list = 'kerberized_kafka1:19092',
-                     kafka_topic_list = 'kafka_json_as_string_no_kdc',
-                     kafka_group_name = 'kafka_json_as_string_no_kdc',
-                     kafka_commit_on_select = 1,
-                     kafka_format = 'JSONAsString',
-                     kafka_flush_interval_ms=1000;
-        """
-    )
+        time.sleep(45)  # wait for ticket expiration
 
-    result = instance.query("SELECT * FROM test.kafka_no_kdc;")
+        instance.query(
+            """
+            CREATE TABLE test.kafka_no_kdc (field String)
+                ENGINE = Kafka
+                SETTINGS kafka_broker_list = 'kerberized_kafka1:19092',
+                         kafka_topic_list = 'kafka_json_as_string_no_kdc',
+                         kafka_group_name = 'kafka_json_as_string_no_kdc',
+                         kafka_commit_on_select = 1,
+                         kafka_format = 'JSONAsString',
+                         kafka_flush_interval_ms=1000;
+            """
+        )
+
+        result = instance.query("SELECT * FROM test.kafka_no_kdc;")
     expected = ""
-
-    kafka_cluster.unpause_container("kafka_kerberos")
 
     assert TSV(result) == TSV(expected)
     assert instance.contains_in_log("StorageKafka (kafka_no_kdc): Nothing to commit")

--- a/tests/integration/test_storage_kerberized_kafka/test.py
+++ b/tests/integration/test_storage_kerberized_kafka/test.py
@@ -217,7 +217,7 @@ def test_kafka_json_as_string_no_kdc(kafka_cluster):
                     "source": source,
                     "destination": destination,
                     "action": "REJECT",
-                    "protocol": "all"
+                    "protocol": "all",
                 }
             )
 

--- a/tests/integration/test_storage_kerberized_kafka/test.py
+++ b/tests/integration/test_storage_kerberized_kafka/test.py
@@ -139,7 +139,7 @@ def test_kafka_json_as_string_request_new_ticket_after_expiration(kafka_cluster)
 
     kafka_produce(
         kafka_cluster,
-        "kafka_json_as_string",
+        "kafka_json_as_string_after_expiration",
         [
             '{"t": 123, "e": {"x": "woof"} }',
             "",
@@ -153,9 +153,9 @@ def test_kafka_json_as_string_request_new_ticket_after_expiration(kafka_cluster)
         CREATE TABLE test.kafka (field String)
             ENGINE = Kafka
             SETTINGS kafka_broker_list = 'kerberized_kafka1:19092',
-                     kafka_topic_list = 'kafka_json_as_string',
+                     kafka_topic_list = 'kafka_json_as_string_after_expiration',
                      kafka_commit_on_select = 1,
-                     kafka_group_name = 'kafka_json_as_string',
+                     kafka_group_name = 'kafka_json_as_string_after_expiration',
                      kafka_format = 'JSONAsString',
                      kafka_flush_interval_ms=1000;
         """
@@ -248,7 +248,7 @@ def test_kafka_json_as_string_no_kdc(kafka_cluster):
 def test_kafka_config_from_sql_named_collection(kafka_cluster):
     kafka_produce(
         kafka_cluster,
-        "kafka_json_as_string",
+        "kafka_json_as_string_named_collection",
         [
             '{"t": 123, "e": {"x": "woof"} }',
             "",
@@ -259,7 +259,7 @@ def test_kafka_config_from_sql_named_collection(kafka_cluster):
 
     instance.query(
         """
-        DROP NAMED COLLECTION IF EXISTS kafka_config
+        DROP NAMED COLLECTION IF EXISTS kafka_config;
         CREATE NAMED COLLECTION kafka_config AS
             kafka.security_protocol = 'SASL_PLAINTEXT',
             kafka.sasl_mechanism = 'GSSAPI',
@@ -270,9 +270,9 @@ def test_kafka_config_from_sql_named_collection(kafka_cluster):
             kafka.api_version_request = 'false',
 
             kafka_broker_list = 'kerberized_kafka1:19092',
-            kafka_topic_list = 'kafka_json_as_string',
+            kafka_topic_list = 'kafka_json_as_string_named_collection',
             kafka_commit_on_select = 1,
-            kafka_group_name = 'kafka_json_as_string',
+            kafka_group_name = 'kafka_json_as_string_named_collection',
             kafka_format = 'JSONAsString',
             kafka_flush_interval_ms=1000;
         """


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

Follow up to https://github.com/ClickHouse/ClickHouse/pull/66998#issuecomment-2262241599

We have a pretty rare (once per a couple of months) issue with kerberized kafka and kerberized hdfs tests. The test is based on `docker pause` to simulate Kerberos Key Distribution Center outage.
It seems that in certain cases `docker pause` does not work or container sporadically wakes up. Similar issues are known ( https://github.com/docker/for-mac/issues/6908 , complains are mostly about mac/windows  ) but not common.

This PR switches from `docker pause` to network partitioning to simulate KDC outage.