### PR TITLE
Fix jepsen for aarch64

### DIFF
--- a/tests/ci/jepsen_check.py
+++ b/tests/ci/jepsen_check.py
@@ -241,7 +241,10 @@ def main():
     additional_data = []
     try:
         test_result = _parse_jepsen_output(jepsen_log_path)
-        if any(r.status == "FAIL" for r in test_result):
+        if len(test_result) == 0:
+            status = FAILURE
+            description = "No test results found"
+        elif any(r.status == "FAIL" for r in test_result):
             status = FAILURE
             description = "Found invalid analysis (ﾉಥ益ಥ）ﾉ ┻━┻"
 

--- a/tests/jepsen.clickhouse/project.clj
+++ b/tests/jepsen.clickhouse/project.clj
@@ -7,10 +7,13 @@
   :main jepsen.clickhouse.main
   :plugins [[lein-cljfmt "0.7.0"]]
   :dependencies [[org.clojure/clojure "1.10.1"]
-                 [jepsen "0.2.7"]
+                 [jepsen "0.2.7":exclusions [net.java.dev.jna/jna
+                                             net.java.dev.jna/jna-platform]]
                  [zookeeper-clj "0.9.4"]
                  [org.clojure/java.jdbc "0.7.12"]
                  [com.hierynomus/sshj "0.34.0"]
+                 [net.java.dev.jna/jna "5.14.0"]
+                 [net.java.dev.jna/jna-platform "5.14.0"]
                  [com.clickhouse/clickhouse-jdbc "0.3.2-patch11"]
                  [org.apache.zookeeper/zookeeper "3.6.1" :exclusions [org.slf4j/slf4j-log4j12]]]
   :repl-options {:init-ns jepsen.clickhouse-keeper.main}


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Jepsen started to use aarch64 runner making the tests crash on the start https://github.com/ClickHouse/ClickHouse/actions/runs/10682487265/job/29608482401

Seems like the problem is one of the deps which doesn't work with aarch64 in versions used by jepsen:
https://github.com/jepsen-io/jepsen/issues/539#issuecomment-1320971114

@maxknv if this doesn't work let's force x86 runners for jepsen. 

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [x] <!---ci_exclude_fast--> Exclude: Fast test
- [x] <!---ci_exclude_asan--> Exclude: All with ASAN
- [x] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---ci_include_fuzzer--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
