### PR TITLE
Fix flaky 00157_cache_dictionary

### DIFF
--- a/tests/queries/1_stateful/00157_cache_dictionary.sql
+++ b/tests/queries/1_stateful/00157_cache_dictionary.sql
@@ -10,7 +10,7 @@ SAMPLE BY intHash32(UserID)
 SETTINGS storage_policy = 'default';
 
 INSERT INTO test.hits_1m SELECT * FROM test.hits LIMIT 1000000
-    SETTINGS min_insert_block_size_rows = 0, min_insert_block_size_bytes = 0, max_block_size = 8192, max_insert_threads = 1, max_threads = 1;
+SETTINGS min_insert_block_size_rows = 0, min_insert_block_size_bytes = 0, max_block_size = 8192, max_insert_threads = 1, max_threads = 1, max_parallel_replicas=1;
 
 CREATE DATABASE IF NOT EXISTS db_dict;
 DROP DICTIONARY IF EXISTS db_dict.cache_hits;


### PR DESCRIPTION
Disable parallel replicas on INSERT to avoid hitting `max_estimated_execution_time`

https://s3.amazonaws.com/clickhouse-test-reports/0/379d5518321525234b8aa85282fd406a92e150c2/stateful_tests__msan__parallelreplicas_.html

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---ci_include_fuzzer--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
