### PR TITLE
Fix `INFILE` format detection for async inserts

### DIFF
--- a/tests/queries/0_stateless/03233_async_insert_infile_format.reference
+++ b/tests/queries/0_stateless/03233_async_insert_infile_format.reference
@@ -1,2 +1,3 @@
 1	ClickHouse
 2	HelloWorld
+OK

--- a/tests/queries/0_stateless/03233_async_insert_infile_format.reference
+++ b/tests/queries/0_stateless/03233_async_insert_infile_format.reference
@@ -1,0 +1,2 @@
+1	ClickHouse
+2	HelloWorld

--- a/tests/queries/0_stateless/03233_async_insert_infile_format.sh
+++ b/tests/queries/0_stateless/03233_async_insert_infile_format.sh
@@ -20,6 +20,6 @@ ${CLICKHOUSE_CLIENT} --query "CREATE TABLE async_insert_infile_data (id UInt32, 
 ${CLICKHOUSE_CLIENT} --query "INSERT INTO async_insert_infile_data FROM INFILE '${CLICKHOUSE_TMP}/test_infile.csv' SETTINGS async_insert=1;"
 ${CLICKHOUSE_CLIENT} --query "SELECT * FROM async_insert_infile_data ORDER BY id;"
 
-${CLICKHOUSE_CLIENT} --query "INSERT INTO async_insert_infile_data FROM INFILE '${CLICKHOUSE_TMP}/test_infile.csv' FORMAT NotExists SETTINGS async_insert=1;" 2>&1 | grep -q "UNKOWN_FORMAT"
+${CLICKHOUSE_CLIENT} --query "INSERT INTO async_insert_infile_data FROM INFILE '${CLICKHOUSE_TMP}/test_infile.csv' FORMAT NotExists SETTINGS async_insert=1;" 2>&1 | grep -q "UNKNOWN_FORMAT" && echo OK || echo FAIL
 
 ${CLICKHOUSE_CLIENT} --query "DROP TABLE async_insert_infile_data SYNC;"

--- a/tests/queries/0_stateless/03233_async_insert_infile_format.sh
+++ b/tests/queries/0_stateless/03233_async_insert_infile_format.sh
@@ -20,6 +20,6 @@ ${CLICKHOUSE_CLIENT} --query "CREATE TABLE async_insert_infile_data (id UInt32, 
 ${CLICKHOUSE_CLIENT} --query "INSERT INTO async_insert_infile_data FROM INFILE '${CLICKHOUSE_TMP}/test_infile.csv' SETTINGS async_insert=1;"
 ${CLICKHOUSE_CLIENT} --query "SELECT * FROM async_insert_infile_data ORDER BY id;"
 
-${CLICKHOUSE_CLIENT} --query "INSERT INTO async_insert_infile_data FROM INFILE '${CLICKHOUSE_TMP}/test_infile.csv' FORMAT NotExists SETTINGS async_insert=1;" 2>&1 | grep -q "UNKNOWN_FORMAT" && echo OK || echo FAIL
+${CLICKHOUSE_CLIENT} --query "INSERT INTO async_insert_infile_data FROM INFILE '${CLICKHOUSE_TMP}/test_infile.csv' SETTINGS async_insert=1 FORMAT NotExists;" 2>&1 | grep -q "UNKNOWN_FORMAT" && echo OK || echo FAIL
 
 ${CLICKHOUSE_CLIENT} --query "DROP TABLE async_insert_infile_data SYNC;"

--- a/tests/queries/0_stateless/03233_async_insert_infile_format.sh
+++ b/tests/queries/0_stateless/03233_async_insert_infile_format.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+function cleanup()
+{
+    [ -e "${CLICKHOUSE_TMP}"/test_infile.csv ] && rm "${CLICKHOUSE_TMP}"/test_infile.csv
+}
+
+trap cleanup EXIT
+
+cleanup
+
+echo -e "id,\"word\"\n1,\"ClickHouse\"\n2,\"HelloWorld\"" > "${CLICKHOUSE_TMP}"/test_infile.csv
+
+${CLICKHOUSE_CLIENT} --query "DROP TABLE IF EXISTS async_insert_infile_data;"
+${CLICKHOUSE_CLIENT} --query "CREATE TABLE async_insert_infile_data (id UInt32, word String) ENGINE=Memory();"
+${CLICKHOUSE_CLIENT} --query "INSERT INTO async_insert_infile_data FROM INFILE '${CLICKHOUSE_TMP}/test_infile.csv' SETTINGS async_insert=1;"
+${CLICKHOUSE_CLIENT} --query "SELECT * FROM async_insert_infile_data ORDER BY id;"
+
+${CLICKHOUSE_CLIENT} --query "INSERT INTO async_insert_infile_data FROM INFILE '${CLICKHOUSE_TMP}/test_infile.csv' FORMAT NotExists SETTINGS async_insert=1;" 2>&1 | grep -q "UNKOWN_FORMAT"
+
+${CLICKHOUSE_CLIENT} --query "DROP TABLE async_insert_infile_data SYNC;"


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
This PR addresses a discrepancy between synchronous and asynchronous inserts.
During an asynchronous insert, when no explicit `FORMAT` is provided, the file extension of the `INFILE` is not checked, and the insert fails with the following error:
```
p-172-31-8-86] 2024.09.04 04:36:40.001142 [ 3397623 ] {5097dd21-5749-47fe-9da4-34a99a28bc1c} <Error> executeQuery: Code: 73. DB::Exception: Unknown input format . (UNKNOWN_FORMAT) (version 24.9.1.1) (from 127.0.0.1:59854) (in query: INSERT INTO test_02270 FROM INFILE '02270_data.values' SETTINGS async_insert=1), Stack trace (when copying this message, always include the lines below):

0. ./contrib/llvm-project/libcxx/include/exception:141: Poco::Exception::Exception(String const&, int) @ 0x00000000143d0872
1. ./build/./src/Common/Exception.cpp:109: DB::Exception::Exception(DB::Exception::MessageMasked&&, int, bool) @ 0x000000000bbb2cd9
2. DB::Exception::Exception(PreformattedMessage&&, int) @ 0x00000000067fcaec
3. DB::Exception::Exception<String&>(int, FormatStringHelperImpl<std::type_identity<String&>::type>, String&) @ 0x0000000006824cab
4. ./build/./src/Interpreters/AsynchronousInsertQueue.cpp:318: DB::AsynchronousInsertQueue::preprocessInsertQuery(std::shared_ptr<DB::IAST> const&, std::shared_ptr<DB::Context const> const&) @ 0x0000000010142968
5. ./build/./src/Interpreters/AsynchronousInsertQueue.cpp:377: DB::AsynchronousInsertQueue::pushQueryWithBlock(std::shared_ptr<DB::IAST>, DB::Block, std::shared_ptr<DB::Context const>) @ 0x0000000010144ab7
6. ./build/./src/Server/TCPHandler.cpp:963: DB::TCPHandler::processAsyncInsertQuery(DB::AsynchronousInsertQueue&) @ 0x0000000011d8223f
7. ./build/./src/Server/TCPHandler.cpp:1019: DB::TCPHandler::processInsertQuery() @ 0x0000000011d7d7a4
8. ./build/./src/Server/TCPHandler.cpp:581: DB::TCPHandler::runImpl() @ 0x0000000011d745ca
9. ./build/./src/Server/TCPHandler.cpp:2484: DB::TCPHandler::run() @ 0x0000000011d8be79
10. ./build/./base/poco/Net/src/TCPServerConnection.cpp:43: Poco::Net::TCPServerConnection::start() @ 0x00000000144755e7
11. ./build/./base/poco/Net/src/TCPServerDispatcher.cpp:115: Poco::Net::TCPServerDispatcher::run() @ 0x0000000014475aba
12. ./build/./base/poco/Foundation/src/ThreadPool.cpp:205: Poco::PooledThread::run() @ 0x0000000014420cd2
13. ./base/poco/Foundation/src/Thread_POSIX.cpp:335: Poco::ThreadImpl::runnableEntry(void*) @ 0x000000001441e7c3
14. ? @ 0x0000727ffd694ac3
15. ? @ 0x0000727ffd726850
```
A synchronous insert works correctly (see the `02270_stdin_with_query_or_infile_data` test).

Discovered while testing #59915 

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix the INFILE format detection for asynchronous inserts. If the format is not explicitly defined in the FORMAT clause, it can be detected from the INFILE file extension.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---ci_include_fuzzer--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
