### PR TITLE
Minor improvements for Lemmatizers

### DIFF
--- a/src/Interpreters/Lemmatizers.cpp
+++ b/src/Interpreters/Lemmatizers.cpp
@@ -36,8 +36,10 @@ public:
 Lemmatizers::Lemmatizers(const Poco::Util::AbstractConfiguration & config)
 {
     const String prefix = "lemmatizers";
+    if (!config.has(prefix))
+        return;
+    
     Poco::Util::AbstractConfiguration::Keys keys;
-
     config.keys(prefix, keys);
 
     for (const auto & key : keys)

--- a/src/Interpreters/Lemmatizers.cpp
+++ b/src/Interpreters/Lemmatizers.cpp
@@ -36,9 +36,10 @@ public:
 Lemmatizers::Lemmatizers(const Poco::Util::AbstractConfiguration & config)
 {
     const String prefix = "lemmatizers";
+
     if (!config.has(prefix))
         return;
-    
+
     Poco::Util::AbstractConfiguration::Keys keys;
     config.keys(prefix, keys);
 

--- a/src/Interpreters/Lemmatizers.cpp
+++ b/src/Interpreters/Lemmatizers.cpp
@@ -33,25 +33,16 @@ public:
     }
 };
 
-/// Duplicate of code from StringUtils.h. Copied here for less dependencies.
-static bool startsWith(const std::string & s, const char * prefix)
-{
-    return s.size() >= strlen(prefix) && 0 == memcmp(s.data(), prefix, strlen(prefix));
-}
-
 Lemmatizers::Lemmatizers(const Poco::Util::AbstractConfiguration & config)
 {
-    String prefix = "lemmatizers";
+    const String prefix = "lemmatizers";
     Poco::Util::AbstractConfiguration::Keys keys;
-
-    if (!config.has(prefix))
-        throw Exception(ErrorCodes::INVALID_CONFIG_PARAMETER, "No lemmatizers specified in server config on prefix '{}'", prefix);
 
     config.keys(prefix, keys);
 
     for (const auto & key : keys)
     {
-        if (startsWith(key, "lemmatizer"))
+        if (key.starts_with("lemmatizer"))
         {
             const auto & lemm_name = config.getString(prefix + "." + key + ".lang", "");
             const auto & lemm_path = config.getString(prefix + "." + key + ".path", "");
@@ -81,13 +72,13 @@ Lemmatizers::LemmPtr Lemmatizers::getLemmatizer(const String & name)
     if (paths.find(name) != paths.end())
     {
         if (!std::filesystem::exists(paths[name]))
-            throw Exception(ErrorCodes::INVALID_CONFIG_PARAMETER, "Incorrect path to lemmatizer: {}", paths[name]);
+            throw Exception(ErrorCodes::INVALID_CONFIG_PARAMETER, "Path to lemmatizer does not exist: {}", paths[name]);
 
         lemmatizers[name] = std::make_shared<Lemmatizer>(paths[name]);
         return lemmatizers[name];
     }
 
-    throw Exception(ErrorCodes::INVALID_CONFIG_PARAMETER, "Lemmatizer named: '{}' is not found", name);
+    throw Exception(ErrorCodes::INVALID_CONFIG_PARAMETER, "Lemmatizer with the name '{}' was not found in the configuration", name);
 }
 
 }


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix the error in loading client suggestions and select from `system.function` when `allow_experimental_nlp_functions` setting is enabled and no lemmatizers are specified in the configuration.