### PR TITLE
test_roles_cache integration test flakiness fix

### DIFF
--- a/tests/integration/test_role/test.py
+++ b/tests/integration/test_role/test.py
@@ -629,5 +629,6 @@ def test_roles_cache():
     check()
 
     instance.query("DROP USER " + ", ".join(users))
-    instance.query("DROP ROLE " + ", ".join(roles))
+    if roles:
+        instance.query("DROP ROLE " + ", ".join(roles))
     instance.query("DROP TABLE tbl")


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

It is expected that number or roles can be zero due to random nature of the test.
It seems it is the only issue of this kind in this test.