### PR TITLE
Add CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,31 @@
+# This CITATION.cff file was generated with cffinit.
+
+cff-version: 1.2.0
+title: "ClickHouse"
+message: "If you use this software, please cite it as below."
+type: software
+authors:
+  - family-names: "Milovidov"
+    given-names: "Alexey"
+repository-code: 'https://github.com/ClickHouse/ClickHouse'
+url: 'https://clickhouse.com'
+license: Apache-2.0
+preferred-citation:
+  type: article
+  authors:
+  - family-names: "Schulze"
+    given-names: "Robert"
+  - family-names: "Schreiber"
+    given-names: "Tom"
+  - family-names: "Yatsishin"
+    given-names: "Ilya"
+  - family-names: "Dahimene"
+    given-names: "Ryadh"
+  - family-names: "Milovidov"
+    given-names: "Alexey"
+  journal: "Proceedings of the VLDB Endowment"
+  title: "ClickHouse - Lightning Fast Analytics for Everyone"
+  year: 2024
+  volume: 17
+  issue: 12
+  doi: 10.14778/3685800.3685802


### PR DESCRIPTION
Repositories on GitHub can include a citation file. For example, [DuckDB](https://github.com/duckdb/duckdb) has such a file and it it is rendered like this: ![image](https://github.com/user-attachments/assets/d61f1e79-c5a1-40d9-a1f7-f7c2a01f38bb)

The exact format is described at
- https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-citation-files
- https://citation-file-format.github.io/#/tools-for-working-with-citationcff-files


### Changelog category (leave one):
- Not for changelog (changelog entry is not required)