### PR TITLE
Docs: Add cp/mv to keeper client docs

### DIFF
--- a/docs/en/operations/utilities/clickhouse-keeper-client.md
+++ b/docs/en/operations/utilities/clickhouse-keeper-client.md
@@ -47,6 +47,8 @@ keeper foo bar
 
 -   `ls '[path]'` -- Lists the nodes for the given path (default: cwd)
 -   `cd '[path]'` -- Changes the working path (default `.`)
+-   `cp '<src>' '<dest>'`  -- Copies 'src' node to 'dest' path
+-   `mv '<src>' '<dest>'`  -- Moves 'src' node to the 'dest' path
 -   `exists '<path>'` -- Returns `1` if node exists, `0` otherwise
 -   `set '<path>' <value> [version]` -- Updates the node's value. Only updates if version matches (default: -1)
 -   `create '<path>' <value> [mode]` -- Creates new node with the set value

--- a/utils/check-style/aspell-ignore/en/aspell-dict.txt
+++ b/utils/check-style/aspell-ignore/en/aspell-dict.txt
@@ -2583,6 +2583,7 @@ sqlinsert
 sqlite
 sqrt
 src
+dest
 srcReplicas
 sshkey
 stackoverflow


### PR DESCRIPTION
Add cp/mv commands explanation to keeper client docs

### Changelog category (leave one):
- Documentation (changelog entry is not required)

