### PR TITLE
Remove obsolete `--multiquery` parameter (follow-up to #63898), pt. VI

### DIFF
--- a/tests/queries/0_stateless/00115_shard_in_incomplete_result.sh
+++ b/tests/queries/0_stateless/00115_shard_in_incomplete_result.sh
@@ -15,6 +15,6 @@ $CLICKHOUSE_CLIENT --query="
     INSERT INTO users VALUES (1321770221388956068);
 ";
 
-for _ in {1..10}; do seq 1 10 | sed "s/.*/SELECT count() FROM (SELECT * FROM remote('127.0.0.{2,3}', ${CLICKHOUSE_DATABASE}, users) WHERE UserID IN (SELECT arrayJoin([1468013291393583084, 1321770221388956068])));/" | $CLICKHOUSE_CLIENT -n | grep -vE '^4$' && echo 'Fail!' && break; echo -n '.'; done; echo
+for _ in {1..10}; do seq 1 10 | sed "s/.*/SELECT count() FROM (SELECT * FROM remote('127.0.0.{2,3}', ${CLICKHOUSE_DATABASE}, users) WHERE UserID IN (SELECT arrayJoin([1468013291393583084, 1321770221388956068])));/" | $CLICKHOUSE_CLIENT | grep -vE '^4$' && echo 'Fail!' && break; echo -n '.'; done; echo
 
 $CLICKHOUSE_CLIENT --query="DROP TABLE users;";

--- a/tests/queries/0_stateless/00133_long_shard_memory_tracker_and_exception_safety.sh
+++ b/tests/queries/0_stateless/00133_long_shard_memory_tracker_and_exception_safety.sh
@@ -5,7 +5,7 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CURDIR"/../shell_config.sh
 
-$CLICKHOUSE_CLIENT -n --query="
+$CLICKHOUSE_CLIENT --query="
     DROP TABLE IF EXISTS numbers_100k;
     CREATE VIEW numbers_100k AS SELECT * FROM system.numbers LIMIT 100000;
 ";

--- a/tests/queries/0_stateless/00385_storage_file_and_clickhouse-local_app_long.sh
+++ b/tests/queries/0_stateless/00385_storage_file_and_clickhouse-local_app_long.sh
@@ -48,13 +48,13 @@ pack_unpack_compare "SELECT name, is_aggregate FROM system.functions" "name Stri
 echo
 # Check settings are passed correctly
 ${CLICKHOUSE_LOCAL} --max_rows_in_distinct=33 -q "SELECT name, value FROM system.settings WHERE name = 'max_rows_in_distinct'"
-${CLICKHOUSE_LOCAL} -n -q "SET max_rows_in_distinct=33; SELECT name, value FROM system.settings WHERE name = 'max_rows_in_distinct'"
+${CLICKHOUSE_LOCAL} -q "SET max_rows_in_distinct=33; SELECT name, value FROM system.settings WHERE name = 'max_rows_in_distinct'"
 ${CLICKHOUSE_LOCAL} --max_bytes_before_external_group_by=1 --max_block_size=10 -q "SELECT sum(ignore(*)) FROM (SELECT number, count() FROM numbers(1000) GROUP BY number)"
 echo
 # Check exta options, we expect zero exit code and no stderr output
-(${CLICKHOUSE_LOCAL} --ignore-error -n --echo -q "SELECT nothing_to_do();SELECT 42;" 2>/dev/null || echo "Wrong RC")
+(${CLICKHOUSE_LOCAL} --ignore-error --echo -q "SELECT nothing_to_do();SELECT 42;" 2>/dev/null || echo "Wrong RC")
 echo
-${CLICKHOUSE_LOCAL} -n -q "CREATE TABLE sophisticated_default
+${CLICKHOUSE_LOCAL} -q "CREATE TABLE sophisticated_default
 (
     a UInt8 DEFAULT 3,
     b UInt8 ALIAS a + 5,

--- a/tests/queries/0_stateless/00505_secure.sh
+++ b/tests/queries/0_stateless/00505_secure.sh
@@ -23,7 +23,7 @@ $CLICKHOUSE_CLIENT_SECURE -q "SELECT 4;"
 
 # TODO: can test only on unchanged port. Possible solutions: generate config or pass shard port via command line
 if [[ "$CLICKHOUSE_PORT_TCP_SECURE" = "$CLICKHOUSE_PORT_TCP_SECURE" ]]; then
-    cat "$CURDIR"/00505_distributed_secure.data | $CLICKHOUSE_CLIENT_SECURE -n -m
+    cat "$CURDIR"/00505_distributed_secure.data | $CLICKHOUSE_CLIENT_SECURE -m
 else
     tail -n 13 "$CURDIR"/00505_secure.reference
 fi

--- a/tests/queries/0_stateless/00531_client_ignore_error.sh
+++ b/tests/queries/0_stateless/00531_client_ignore_error.sh
@@ -5,8 +5,8 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CURDIR"/../shell_config.sh
 
-echo "SELECT 1; SELECT 2; SELECT CAST(); SELECT ';'; SELECT 3;SELECT CAST();SELECT 4;" | $CLICKHOUSE_CLIENT -n --ignore-error 2>/dev/null
-echo "SELECT CAST();" | $CLICKHOUSE_CLIENT -n --ignore-error 2>/dev/null
-echo "SELECT 5;" | $CLICKHOUSE_CLIENT -n --ignore-error
+echo "SELECT 1; SELECT 2; SELECT CAST(); SELECT ';'; SELECT 3;SELECT CAST();SELECT 4;" | $CLICKHOUSE_CLIENT --ignore-error 2>/dev/null
+echo "SELECT CAST();" | $CLICKHOUSE_CLIENT --ignore-error 2>/dev/null
+echo "SELECT 5;" | $CLICKHOUSE_CLIENT --ignore-error
 
 #$CLICKHOUSE_CLIENT -q "SELECT 'Still alive'"

--- a/tests/queries/0_stateless/00534_client_ignore_error.sh
+++ b/tests/queries/0_stateless/00534_client_ignore_error.sh
@@ -5,8 +5,8 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CURDIR"/../shell_config.sh
 
-echo "SELECT 1; SELECT 2; SELECT CAST(); SELECT ';'; SELECT 3;SELECT CAST();SELECT 4;" | $CLICKHOUSE_CLIENT -n --ignore-error 2>/dev/null
-echo "SELECT CAST();" | $CLICKHOUSE_CLIENT -n --ignore-error 2>/dev/null
-echo "SELECT 5;" | $CLICKHOUSE_CLIENT -n --ignore-error
+echo "SELECT 1; SELECT 2; SELECT CAST(); SELECT ';'; SELECT 3;SELECT CAST();SELECT 4;" | $CLICKHOUSE_CLIENT --ignore-error 2>/dev/null
+echo "SELECT CAST();" | $CLICKHOUSE_CLIENT --ignore-error 2>/dev/null
+echo "SELECT 5;" | $CLICKHOUSE_CLIENT --ignore-error
 
 #$CLICKHOUSE_CLIENT -q "SELECT 'Still alive'"

--- a/tests/queries/0_stateless/00686_client_exit_code.sh
+++ b/tests/queries/0_stateless/00686_client_exit_code.sh
@@ -8,5 +8,5 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=./mergetree_mutations.lib
 . "$CURDIR"/mergetree_mutations.lib
 
-echo "INSERT INTO test FORMAT CSV" | ${CLICKHOUSE_CLIENT} -n 2>/dev/null
+echo "INSERT INTO test FORMAT CSV" | ${CLICKHOUSE_CLIENT} 2>/dev/null
 echo $?

--- a/tests/queries/0_stateless/00705_drop_create_merge_tree.sh
+++ b/tests/queries/0_stateless/00705_drop_create_merge_tree.sh
@@ -5,8 +5,8 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CURDIR"/../shell_config.sh
 
-yes 'CREATE TABLE IF NOT EXISTS table (x UInt8) ENGINE = MergeTree ORDER BY tuple();' | head -n 1000 | $CLICKHOUSE_CLIENT --multiquery &
-yes 'DROP TABLE IF EXISTS table;' | head -n 1000 | $CLICKHOUSE_CLIENT --multiquery &
+yes 'CREATE TABLE IF NOT EXISTS table (x UInt8) ENGINE = MergeTree ORDER BY tuple();' | head -n 1000 | $CLICKHOUSE_CLIENT &
+yes 'DROP TABLE IF EXISTS table;' | head -n 1000 | $CLICKHOUSE_CLIENT &
 wait
 
 ${CLICKHOUSE_CLIENT} --query "DROP TABLE IF EXISTS table"

--- a/tests/queries/0_stateless/00731_long_merge_tree_select_opened_files.sh
+++ b/tests/queries/0_stateless/00731_long_merge_tree_select_opened_files.sh
@@ -12,7 +12,7 @@ settings="--log_queries=1 --log_query_threads=1 --log_profile_events=1 --log_que
 
 # Test insert logging on each block and checkPacket() method
 
-$CLICKHOUSE_CLIENT $settings -n -q "
+$CLICKHOUSE_CLIENT $settings -q "
 DROP TABLE IF EXISTS merge_tree_table;
 CREATE TABLE merge_tree_table (id UInt64, date Date, uid UInt32) ENGINE = MergeTree(date, id, 8192);"
 

--- a/tests/queries/0_stateless/00838_system_tables_drop_table_race.sh
+++ b/tests/queries/0_stateless/00838_system_tables_drop_table_race.sh
@@ -9,7 +9,7 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 $CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS table"
 
-seq 1 100 | sed -r -e "s/.+/CREATE TABLE table (x UInt8) ENGINE = MergeTree ORDER BY x; DROP TABLE table;/" | $CLICKHOUSE_CLIENT -n &
-seq 1 100 | sed -r -e "s/.+/SELECT * FROM system.tables WHERE database = '${CLICKHOUSE_DATABASE}' LIMIT 1000000, 1;/" | $CLICKHOUSE_CLIENT -n 2>/dev/null &
+seq 1 100 | sed -r -e "s/.+/CREATE TABLE table (x UInt8) ENGINE = MergeTree ORDER BY x; DROP TABLE table;/" | $CLICKHOUSE_CLIENT &
+seq 1 100 | sed -r -e "s/.+/SELECT * FROM system.tables WHERE database = '${CLICKHOUSE_DATABASE}' LIMIT 1000000, 1;/" | $CLICKHOUSE_CLIENT 2>/dev/null &
 
 wait

--- a/tests/queries/0_stateless/00840_long_concurrent_select_and_drop_deadlock.sh
+++ b/tests/queries/0_stateless/00840_long_concurrent_select_and_drop_deadlock.sh
@@ -27,7 +27,7 @@ function thread_drop_create()
     while [ $SECONDS -lt "$TIMELIMIT" ] && [ $it -lt 100 ];
     do
         it=$((it+1))
-        $CLICKHOUSE_CLIENT -nm -q "
+        $CLICKHOUSE_CLIENT -m -q "
             drop table if exists view_00840;
             create view view_00840 as select count(*),database,table from system.columns group by database,table;
         "

--- a/tests/queries/0_stateless/00900_long_parquet.sh
+++ b/tests/queries/0_stateless/00900_long_parquet.sh
@@ -8,11 +8,11 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CUR_DIR"/../shell_config.sh
 
 
-${CLICKHOUSE_CLIENT} -n --query="
+${CLICKHOUSE_CLIENT} --query="
     DROP TABLE IF EXISTS contributors;
     CREATE TABLE contributors (name String) ENGINE = Memory;"
 ${CLICKHOUSE_CLIENT} --query="SELECT * FROM system.contributors ORDER BY name DESC FORMAT Parquet" | ${CLICKHOUSE_CLIENT} --query="INSERT INTO contributors FORMAT Parquet"
-${CLICKHOUSE_CLIENT} -n --query="
+${CLICKHOUSE_CLIENT} --query="
     -- random results
     SELECT * FROM contributors LIMIT 10 FORMAT Null;
     DROP TABLE contributors;
@@ -21,30 +21,30 @@ ${CLICKHOUSE_CLIENT} -n --query="
     CREATE TABLE parquet_numbers (number UInt64) ENGINE = Memory;"
 # less than default block size (65k)
 ${CLICKHOUSE_CLIENT} --query="SELECT * FROM system.numbers LIMIT 10000 FORMAT Parquet" | ${CLICKHOUSE_CLIENT} --query="INSERT INTO parquet_numbers FORMAT Parquet"
-${CLICKHOUSE_CLIENT} -n --query="
+${CLICKHOUSE_CLIENT} --query="
     SELECT * FROM parquet_numbers ORDER BY number DESC LIMIT 10;
     TRUNCATE TABLE parquet_numbers;"
 
 # More than default block size
 ${CLICKHOUSE_CLIENT} --query="SELECT * FROM system.numbers LIMIT 100000 FORMAT Parquet" | ${CLICKHOUSE_CLIENT} --query="INSERT INTO parquet_numbers FORMAT Parquet"
-${CLICKHOUSE_CLIENT} -n --query="
+${CLICKHOUSE_CLIENT} --query="
     SELECT * FROM parquet_numbers ORDER BY number DESC LIMIT 10;
     TRUNCATE TABLE parquet_numbers;"
 
 ${CLICKHOUSE_CLIENT} --max_block_size=2 --query="SELECT * FROM system.numbers LIMIT 3 FORMAT Parquet" | ${CLICKHOUSE_CLIENT} --query="INSERT INTO parquet_numbers FORMAT Parquet"
-${CLICKHOUSE_CLIENT} -n --query="
+${CLICKHOUSE_CLIENT} --query="
     SELECT * FROM parquet_numbers ORDER BY number DESC LIMIT 10;
 
     TRUNCATE TABLE parquet_numbers;"
 ${CLICKHOUSE_CLIENT} --max_block_size=1 --query="SELECT * FROM system.numbers LIMIT 1000 FORMAT Parquet" | ${CLICKHOUSE_CLIENT} --query="INSERT INTO parquet_numbers FORMAT Parquet"
-${CLICKHOUSE_CLIENT} -n --query="
+${CLICKHOUSE_CLIENT} --query="
     SELECT * FROM parquet_numbers ORDER BY number DESC LIMIT 10;
     DROP TABLE parquet_numbers;
 
     DROP TABLE IF EXISTS parquet_events;
     CREATE TABLE parquet_events (event String, value UInt64, description String) ENGINE = Memory;"
 ${CLICKHOUSE_CLIENT} --query="SELECT * FROM system.events FORMAT Parquet" | ${CLICKHOUSE_CLIENT} --query="INSERT INTO parquet_events FORMAT Parquet"
-${CLICKHOUSE_CLIENT} -n --query="
+${CLICKHOUSE_CLIENT} --query="
     SELECT event, description FROM parquet_events WHERE event IN ('ContextLock', 'Query') ORDER BY event;
     DROP TABLE parquet_events;
 
@@ -78,7 +78,7 @@ ${CLICKHOUSE_CLIENT} --query="SELECT * FROM parquet_types2 ORDER BY int8 FORMAT 
 echo diff:
 diff "${CLICKHOUSE_TMP}"/parquet_all_types_1.dump "${CLICKHOUSE_TMP}"/parquet_all_types_2.dump
 
-${CLICKHOUSE_CLIENT} -n --query="
+${CLICKHOUSE_CLIENT} --query="
     TRUNCATE TABLE parquet_types2;
     INSERT INTO parquet_types3 values (       79,          81,          82,            83,          84,            85,          86,            87,              88,              89,         'str01',                  'fstr1', '2003-03-04', '2004-05-06', toDateTime64('2004-05-06 07:08:09.012', 9));"
 ${CLICKHOUSE_CLIENT} --query="SELECT * FROM parquet_types3 ORDER BY int8 FORMAT Parquet" | ${CLICKHOUSE_CLIENT} --query="INSERT INTO parquet_types2 FORMAT Parquet"
@@ -88,7 +88,7 @@ ${CLICKHOUSE_CLIENT} --query="INSERT INTO parquet_types4 values (       80,     
 ${CLICKHOUSE_CLIENT} --query="SELECT * FROM parquet_types4 ORDER BY int8 FORMAT Parquet" | ${CLICKHOUSE_CLIENT} --query="INSERT INTO parquet_types2 FORMAT Parquet"
 ${CLICKHOUSE_CLIENT} --query="SELECT * FROM parquet_types1 ORDER BY int8 FORMAT Parquet" | ${CLICKHOUSE_CLIENT} --query="INSERT INTO parquet_types4 FORMAT Parquet"
 
-${CLICKHOUSE_CLIENT} -n --query="
+${CLICKHOUSE_CLIENT} --query="
     SELECT 'dest:';
     SELECT * FROM parquet_types2 ORDER BY int8;
     SELECT 'min:';
@@ -106,7 +106,7 @@ ${CLICKHOUSE_CLIENT} --query="SELECT * FROM parquet_types5 ORDER BY int8 FORMAT 
 ${CLICKHOUSE_CLIENT} --query="SELECT * FROM parquet_types5 ORDER BY int8 FORMAT Parquet" | ${CLICKHOUSE_CLIENT} --query="INSERT INTO parquet_types6 FORMAT Parquet"
 ${CLICKHOUSE_CLIENT} --query="SELECT * FROM parquet_types1 ORDER BY int8 FORMAT Parquet" | ${CLICKHOUSE_CLIENT} --query="INSERT INTO parquet_types6 FORMAT Parquet"
 echo dest from null:
-${CLICKHOUSE_CLIENT} -n --query="
+${CLICKHOUSE_CLIENT} --query="
     SELECT * FROM parquet_types6 ORDER BY int8;
 
     DROP TABLE parquet_types5;
@@ -126,7 +126,7 @@ ${CLICKHOUSE_CLIENT} -n --query="
     INSERT INTO parquet_arrays VALUES (2, [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], []);"
 
 ${CLICKHOUSE_CLIENT} --query="SELECT * FROM parquet_arrays FORMAT Parquet" | ${CLICKHOUSE_CLIENT} --query="INSERT INTO parquet_arrays FORMAT Parquet"
-${CLICKHOUSE_CLIENT} -n --query="
+${CLICKHOUSE_CLIENT} --query="
     SELECT * FROM parquet_arrays ORDER BY id;
 
     DROP TABLE parquet_arrays;
@@ -135,7 +135,7 @@ ${CLICKHOUSE_CLIENT} -n --query="
     CREATE TABLE parquet_nullable_arrays (id UInt32, a1 Array(Nullable(UInt32)), a2 Array(Nullable(String)), a3 Array(Nullable(Decimal(4, 2)))) engine=Memory();
     INSERT INTO parquet_nullable_arrays VALUES (1, [1, Null, 2], [Null, 'Some string', Null], [0.001, Null, 42.42]), (2, [Null], [Null], [Null]), (3, [], [], []);"
 ${CLICKHOUSE_CLIENT} --query="SELECT * FROM parquet_nullable_arrays FORMAT Parquet" | ${CLICKHOUSE_CLIENT} --query="INSERT INTO parquet_nullable_arrays FORMAT Parquet"
-${CLICKHOUSE_CLIENT} -n --query="
+${CLICKHOUSE_CLIENT} --query="
     SELECT * FROM parquet_nullable_arrays ORDER BY id;
     DROP TABLE parquet_nullable_arrays;
 
@@ -143,7 +143,7 @@ ${CLICKHOUSE_CLIENT} -n --query="
     CREATE TABLE parquet_nested_arrays (a1 Array(Array(Array(UInt32))), a2 Array(Array(Array(String))), a3 Array(Array(Nullable(UInt32))), a4 Array(Array(Nullable(String)))) engine=Memory();
     INSERT INTO parquet_nested_arrays VALUES ([[[1,2,3], [1,2,3]], [[1,2,3]], [[], [1,2,3]]], [[['Some string', 'Some string'], []], [['Some string']], [[]]], [[Null, 1, 2], [Null], [1, 2], []], [['Some string', Null, 'Some string'], [Null], []]);"
 ${CLICKHOUSE_CLIENT} --query="SELECT * FROM parquet_nested_arrays FORMAT Parquet" | ${CLICKHOUSE_CLIENT} --query="INSERT INTO parquet_nested_arrays FORMAT Parquet"
-${CLICKHOUSE_CLIENT} -n --query="
+${CLICKHOUSE_CLIENT} --query="
     SELECT * FROM parquet_nested_arrays;
     DROP TABLE parquet_nested_arrays;
 
@@ -151,6 +151,6 @@ ${CLICKHOUSE_CLIENT} -n --query="
     CREATE TABLE parquet_decimal (d1 Decimal32(4), d2 Decimal64(8), d3 Decimal128(16), d4 Decimal256(32)) ENGINE = Memory;
     INSERT INTO TABLE parquet_decimal VALUES (0.123, 0.123123123, 0.123123123123, 0.123123123123123123);"
 ${CLICKHOUSE_CLIENT} --query="SELECT * FROM parquet_decimal FORMAT Arrow" | ${CLICKHOUSE_CLIENT} --query="INSERT INTO parquet_decimal FORMAT Arrow"
-${CLICKHOUSE_CLIENT} -n --query="
+${CLICKHOUSE_CLIENT} --query="
     SELECT * FROM parquet_decimal;
     DROP TABLE parquet_decimal;"

--- a/tests/queries/0_stateless/00900_long_parquet_decimal.sh
+++ b/tests/queries/0_stateless/00900_long_parquet_decimal.sh
@@ -7,7 +7,7 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CUR_DIR"/../shell_config.sh
 
-${CLICKHOUSE_CLIENT} -n --query="
+${CLICKHOUSE_CLIENT} --query="
     DROP TABLE IF EXISTS decimal;
     DROP TABLE IF EXISTS decimal2;
 
@@ -26,7 +26,7 @@ ${CLICKHOUSE_CLIENT} --query="SELECT * FROM decimal ORDER BY a, b, c, d, e, f, g
 ${CLICKHOUSE_CLIENT} --query="SELECT * FROM decimal2 ORDER BY a, b, c, d, e, f, g, h, i, j;" > "${CLICKHOUSE_TMP}"/parquet_decimal0_2.dump
 echo diff0:
 diff "${CLICKHOUSE_TMP}"/parquet_decimal0_1.dump "${CLICKHOUSE_TMP}"/parquet_decimal0_2.dump
-${CLICKHOUSE_CLIENT} -n --query="
+${CLICKHOUSE_CLIENT} --query="
     DROP TABLE IF EXISTS decimal;
     DROP TABLE IF EXISTS decimal2;
 
@@ -61,7 +61,7 @@ ${CLICKHOUSE_CLIENT} --query="SELECT * FROM decimal ORDER BY a, b, c, d, e, f, g
 ${CLICKHOUSE_CLIENT} --query="SELECT * FROM decimal2 ORDER BY a, b, c, d, e, f, g, h, i, j;" > "${CLICKHOUSE_TMP}"/parquet_decimal1_2.dump
 echo diff1:
 diff "${CLICKHOUSE_TMP}"/parquet_decimal1_1.dump "${CLICKHOUSE_TMP}"/parquet_decimal1_2.dump
-${CLICKHOUSE_CLIENT} -n --query="
+${CLICKHOUSE_CLIENT} --query="
     DROP TABLE IF EXISTS decimal;
     DROP TABLE IF EXISTS decimal2;
 
@@ -75,7 +75,7 @@ ${CLICKHOUSE_CLIENT} --query="SELECT * FROM decimal ORDER BY a, b, c, d, e, f, g
 ${CLICKHOUSE_CLIENT} --query="SELECT * FROM decimal2 ORDER BY a, b, c, d, e, f, g, h, i, j;" > "${CLICKHOUSE_TMP}"/parquet_decimal2_2.dump
 echo diff2:
 diff "${CLICKHOUSE_TMP}"/parquet_decimal2_1.dump "${CLICKHOUSE_TMP}"/parquet_decimal2_2.dump
-${CLICKHOUSE_CLIENT} -n --query="
+${CLICKHOUSE_CLIENT} --query="
     DROP TABLE IF EXISTS decimal;
     DROP TABLE IF EXISTS decimal2;
 
@@ -86,7 +86,7 @@ ${CLICKHOUSE_CLIENT} -n --query="
 ${CLICKHOUSE_CLIENT} --query="SELECT * FROM decimal ORDER BY a, b, c, d  FORMAT Parquet;" > "${CLICKHOUSE_TMP}"/parquet_decimal3_1.parquet
 ${CLICKHOUSE_CLIENT} --query="SELECT * FROM decimal ORDER BY a, b, c, d FORMAT Parquet;" | ${CLICKHOUSE_CLIENT} --query="INSERT INTO decimal2 FORMAT Parquet" 2> /dev/null
 echo nothing:
-${CLICKHOUSE_CLIENT} -n --query="
+${CLICKHOUSE_CLIENT} --query="
     SELECT * FROM decimal2 ORDER BY a, b, c, d;
     TRUNCATE TABLE decimal2;
 
@@ -94,7 +94,7 @@ ${CLICKHOUSE_CLIENT} -n --query="
 ${CLICKHOUSE_CLIENT} --query="SELECT * FROM decimal ORDER BY a, b, c, d FORMAT Parquet;" > "${CLICKHOUSE_TMP}"/parquet_decimal3_2.parquet
 ${CLICKHOUSE_CLIENT} --query="SELECT * FROM decimal ORDER BY a, b, c, d FORMAT Parquet;" | ${CLICKHOUSE_CLIENT} --query="INSERT INTO decimal2 FORMAT Parquet"
 echo nulls:
-${CLICKHOUSE_CLIENT} -n --query="
+${CLICKHOUSE_CLIENT} --query="
     SELECT * FROM decimal2 ORDER BY a, b, c, d;
     TRUNCATE TABLE decimal2;
 
@@ -104,7 +104,7 @@ ${CLICKHOUSE_CLIENT} -n --query="
 ${CLICKHOUSE_CLIENT} --query="SELECT * FROM decimal ORDER BY a, b, c, d FORMAT Parquet;" > "${CLICKHOUSE_TMP}"/parquet_decimal3_3.parquet
 ${CLICKHOUSE_CLIENT} --query="SELECT * FROM decimal ORDER BY a, b, c, d FORMAT Parquet;" | ${CLICKHOUSE_CLIENT} --query="INSERT INTO decimal2 FORMAT Parquet"
 
-${CLICKHOUSE_CLIENT} -n --query="
+${CLICKHOUSE_CLIENT} --query="
     SELECT 'full orig:';
     SELECT * FROM decimal ORDER BY a, b, c, d;
     SELECT 'full inserted:';
@@ -115,6 +115,6 @@ ${CLICKHOUSE_CLIENT} --query="SELECT * FROM decimal2 ORDER BY a, b, c, d;" > "${
 
 echo diff3:
 diff "${CLICKHOUSE_TMP}"/parquet_decimal3_1.dump "${CLICKHOUSE_TMP}"/parquet_decimal3_2.dump
-${CLICKHOUSE_CLIENT} -n --query="
+${CLICKHOUSE_CLIENT} --query="
     DROP TABLE IF EXISTS decimal;
     DROP TABLE IF EXISTS decimal2;"

--- a/tests/queries/0_stateless/00921_datetime64_compatibility_long.sh
+++ b/tests/queries/0_stateless/00921_datetime64_compatibility_long.sh
@@ -13,5 +13,5 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # ${CURDIR}/00921_datetime64_compatibility.python
 
 python3 "${CURDIR}"/00921_datetime64_compatibility_long.python \
-    | ${CLICKHOUSE_CLIENT} --ignore-error -nm --calculate_text_stack_trace 0 --log-level 'error' 2>&1 \
+    | ${CLICKHOUSE_CLIENT} --ignore-error -m --calculate_text_stack_trace 0 --log-level 'error' 2>&1 \
     | grep -v -e 'Received exception .*$' -e '^(query: ' | sed 's/^\(Code: [0-9]\+\).*$/\1/g'

--- a/tests/queries/0_stateless/00975_indices_mutation_replicated_zookeeper_long.sh
+++ b/tests/queries/0_stateless/00975_indices_mutation_replicated_zookeeper_long.sh
@@ -11,7 +11,7 @@ $CLICKHOUSE_CLIENT --query="DROP TABLE IF EXISTS indices_mutaions1;"
 $CLICKHOUSE_CLIENT --query="DROP TABLE IF EXISTS indices_mutaions2;"
 
 
-$CLICKHOUSE_CLIENT -n --query="
+$CLICKHOUSE_CLIENT --query="
 CREATE TABLE indices_mutaions1
 (
     u64 UInt64,

--- a/tests/queries/0_stateless/00991_system_parts_race_condition_long.sh
+++ b/tests/queries/0_stateless/00991_system_parts_race_condition_long.sh
@@ -22,7 +22,7 @@ function thread1()
 
 function thread2()
 {
-    while true; do $CLICKHOUSE_CLIENT -n --query "ALTER TABLE alter_table ADD COLUMN h String '0'; ALTER TABLE alter_table MODIFY COLUMN h UInt64; ALTER TABLE alter_table DROP COLUMN h;"; done
+    while true; do $CLICKHOUSE_CLIENT --query "ALTER TABLE alter_table ADD COLUMN h String '0'; ALTER TABLE alter_table MODIFY COLUMN h UInt64; ALTER TABLE alter_table DROP COLUMN h;"; done
 }
 
 function thread3()

--- a/tests/queries/0_stateless/00992_system_parts_race_condition_zookeeper_long.sh
+++ b/tests/queries/0_stateless/00992_system_parts_race_condition_zookeeper_long.sh
@@ -9,7 +9,7 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 set -e
 
-$CLICKHOUSE_CLIENT -n -q "
+$CLICKHOUSE_CLIENT -q "
     DROP TABLE IF EXISTS alter_table0;
     DROP TABLE IF EXISTS alter_table1;
 
@@ -31,7 +31,7 @@ function thread1()
 
 function thread2()
 {
-    while true; do $CLICKHOUSE_CLIENT -n --query "ALTER TABLE alter_table0 ADD COLUMN h String DEFAULT '0'; ALTER TABLE alter_table0 MODIFY COLUMN h UInt64; ALTER TABLE alter_table0 DROP COLUMN h;"; done
+    while true; do $CLICKHOUSE_CLIENT --query "ALTER TABLE alter_table0 ADD COLUMN h String DEFAULT '0'; ALTER TABLE alter_table0 MODIFY COLUMN h UInt64; ALTER TABLE alter_table0 DROP COLUMN h;"; done
 }
 
 function thread3()
@@ -87,6 +87,6 @@ check_replication_consistency "alter_table" "count(), sum(a), sum(b), round(sum(
 
 $CLICKHOUSE_CLIENT -q "SELECT table, lost_part_count FROM system.replicas WHERE database=currentDatabase() AND lost_part_count!=0";
 
-$CLICKHOUSE_CLIENT -n -q "DROP TABLE alter_table0;" 2> >(grep -F -v 'is already started to be removing by another replica right now') &
-$CLICKHOUSE_CLIENT -n -q "DROP TABLE alter_table1;" 2> >(grep -F -v 'is already started to be removing by another replica right now') &
+$CLICKHOUSE_CLIENT -q "DROP TABLE alter_table0;" 2> >(grep -F -v 'is already started to be removing by another replica right now') &
+$CLICKHOUSE_CLIENT -q "DROP TABLE alter_table1;" 2> >(grep -F -v 'is already started to be removing by another replica right now') &
 wait

--- a/tests/queries/0_stateless/01014_lazy_database_basic.sh
+++ b/tests/queries/0_stateless/01014_lazy_database_basic.sh
@@ -5,9 +5,9 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CURDIR"/../shell_config.sh
 
-${CLICKHOUSE_CLIENT} -n -q "DROP DATABASE IF EXISTS testlazy"
+${CLICKHOUSE_CLIENT} -q "DROP DATABASE IF EXISTS testlazy"
 
-${CLICKHOUSE_CLIENT} -n -q "
+${CLICKHOUSE_CLIENT} -q "
     CREATE DATABASE testlazy ENGINE = Lazy(1);
     CREATE TABLE testlazy.log (a UInt64, b UInt64) ENGINE = Log;
     CREATE TABLE testlazy.slog (a UInt64, b UInt64) ENGINE = StripeLog;
@@ -30,7 +30,7 @@ ${CLICKHOUSE_CLIENT} -q "
 
 sleep 1.5
 
-${CLICKHOUSE_CLIENT} -n -q "
+${CLICKHOUSE_CLIENT} -q "
     SELECT * FROM testlazy.log LIMIT 0; -- drop testlazy.log from cache
     RENAME TABLE testlazy.log TO testlazy.log2;
     SELECT database, name FROM system.tables WHERE database = 'testlazy';
@@ -44,7 +44,7 @@ ${CLICKHOUSE_CLIENT} -q "
 
 sleep 1.5
 
-${CLICKHOUSE_CLIENT} -n -q "
+${CLICKHOUSE_CLIENT} -q "
     INSERT INTO testlazy.log2 VALUES (1, 1);
     INSERT INTO testlazy.slog VALUES (2, 2);
     INSERT INTO testlazy.tlog VALUES (3, 3);
@@ -55,14 +55,14 @@ ${CLICKHOUSE_CLIENT} -n -q "
 
 sleep 1.5
 
-${CLICKHOUSE_CLIENT} -n -q "
+${CLICKHOUSE_CLIENT} -q "
     SELECT * FROM testlazy.log2 LIMIT 0; -- drop testlazy.log2 from cache
     DROP TABLE testlazy.log2;
 "
 
 sleep 1.5
 
-${CLICKHOUSE_CLIENT} -n -q "
+${CLICKHOUSE_CLIENT} -q "
     SELECT * FROM testlazy.slog;
     SELECT * FROM testlazy.tlog;
 "

--- a/tests/queries/0_stateless/01014_lazy_database_concurrent_recreate_reattach_and_show_tables.sh
+++ b/tests/queries/0_stateless/01014_lazy_database_concurrent_recreate_reattach_and_show_tables.sh
@@ -83,7 +83,7 @@ export -f recreate_lazy_func4;
 export -f show_tables_func;
 
 
-${CLICKHOUSE_CLIENT} -n -q "
+${CLICKHOUSE_CLIENT} -q "
     DROP DATABASE IF EXISTS $CURR_DATABASE;
     CREATE DATABASE $CURR_DATABASE ENGINE = Lazy(1);
 "

--- a/tests/queries/0_stateless/01018_ddl_dictionaries_concurrent_requrests.sh
+++ b/tests/queries/0_stateless/01018_ddl_dictionaries_concurrent_requrests.sh
@@ -7,7 +7,7 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 set -e
 
-$CLICKHOUSE_CLIENT -n -q "
+$CLICKHOUSE_CLIENT -q "
     DROP DATABASE IF EXISTS database_for_dict;
     DROP TABLE IF EXISTS table_for_dict1;
     DROP TABLE IF EXISTS table_for_dict2;
@@ -44,7 +44,7 @@ function thread3()
 
 function thread4()
 {
-    while true; do $CLICKHOUSE_CLIENT -n -q "
+    while true; do $CLICKHOUSE_CLIENT -q "
         SELECT * FROM database_for_dict.dict1 FORMAT Null;
         SELECT * FROM database_for_dict.dict2 FORMAT Null;
     " ||: ; done
@@ -52,7 +52,7 @@ function thread4()
 
 function thread5()
 {
-    while true; do $CLICKHOUSE_CLIENT -n -q "
+    while true; do $CLICKHOUSE_CLIENT -q "
         SELECT dictGetString('database_for_dict.dict1', 'value_column', toUInt64(number)) from numbers(1000) FROM FORMAT Null;
         SELECT dictGetString('database_for_dict.dict2', 'value_column', toUInt64(number)) from numbers(1000) FROM FORMAT Null;
     " ||: ; done
@@ -117,7 +117,7 @@ $CLICKHOUSE_CLIENT -q "SELECT 'Still alive'"
 $CLICKHOUSE_CLIENT -q "ATTACH DICTIONARY IF NOT EXISTS database_for_dict.dict1"
 $CLICKHOUSE_CLIENT -q "ATTACH DICTIONARY IF NOT EXISTS database_for_dict.dict2"
 
-$CLICKHOUSE_CLIENT -n -q "
+$CLICKHOUSE_CLIENT -q "
     DROP DATABASE database_for_dict;
     DROP TABLE table_for_dict1;
     DROP TABLE table_for_dict2;

--- a/tests/queries/0_stateless/01019_alter_materialized_view_atomic.sh
+++ b/tests/queries/0_stateless/01019_alter_materialized_view_atomic.sh
@@ -7,7 +7,7 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CURDIR"/../shell_config.sh
 
-$CLICKHOUSE_CLIENT --multiquery <<EOF
+$CLICKHOUSE_CLIENT <<EOF
 DROP TABLE IF EXISTS src;
 DROP TABLE IF EXISTS mv;
 

--- a/tests/queries/0_stateless/01035_avg_weighted_long.sh
+++ b/tests/queries/0_stateless/01035_avg_weighted_long.sh
@@ -28,7 +28,7 @@ exttypes=("Int128" "Int256" "UInt256")
             echo "SELECT avgWeighted(to${left}(1), to${right}(2));"
         done
     done
-) | $CLICKHOUSE_CLIENT_BINARY -nm
+) | $CLICKHOUSE_CLIENT_BINARY -m
 
 ${CLICKHOUSE_CLIENT} --server_logs_file=/dev/null --query="SELECT avgWeighted(['string'], toFloat64(0))" 2>&1 \
   | grep -c 'Code: 43. DB::Exception: .* DB::Exception:.* Types .* are non-conforming as arguments for aggregate function avgWeighted'

--- a/tests/queries/0_stateless/01053_ssd_dictionary.sh
+++ b/tests/queries/0_stateless/01053_ssd_dictionary.sh
@@ -6,7 +6,7 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CURDIR"/../shell_config.sh
 
-$CLICKHOUSE_CLIENT --allow_deprecated_database_ordinary=1 -n --query="
+$CLICKHOUSE_CLIENT --allow_deprecated_database_ordinary=1 --query="
   DROP DATABASE IF EXISTS 01053_db;
 
   CREATE DATABASE 01053_db;

--- a/tests/queries/0_stateless/01079_bad_alters_zookeeper_long.sh
+++ b/tests/queries/0_stateless/01079_bad_alters_zookeeper_long.sh
@@ -7,7 +7,7 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 $CLICKHOUSE_CLIENT --query "DROP TABLE IF EXISTS table_for_bad_alters";
 
-$CLICKHOUSE_CLIENT -n --query "CREATE TABLE table_for_bad_alters (
+$CLICKHOUSE_CLIENT --query "CREATE TABLE table_for_bad_alters (
     key UInt64,
     value1 UInt8,
     value2 String

--- a/tests/queries/0_stateless/01111_create_drop_replicated_db_stress.sh
+++ b/tests/queries/0_stateless/01111_create_drop_replicated_db_stress.sh
@@ -30,7 +30,7 @@ function drop_db()
         database=$($CLICKHOUSE_CLIENT -q "select name from system.databases where name like '${CLICKHOUSE_DATABASE}%' order by rand() limit 1")
         if [[ "$database" == "$CLICKHOUSE_DATABASE" ]]; then continue; fi
         if [ -z "$database" ]; then continue; fi
-        $CLICKHOUSE_CLIENT -n --query \
+        $CLICKHOUSE_CLIENT --query \
         "drop database if exists $database" 2>&1| grep -Fa "Exception: "
         sleep 0.$RANDOM
     done

--- a/tests/queries/0_stateless/01119_session_log.sh
+++ b/tests/queries/0_stateless/01119_session_log.sh
@@ -14,7 +14,7 @@ and interface in ('HTTP', 'TCP', 'TCP_Interserver')
 and (user != 'default' or (a=1 and b=1)) -- FIXME: we should not write uninitialized address and port (but we do sometimes)
 and event_time >= now() - interval 5 minute"
 
-$CLICKHOUSE_CLIENT -nm -q "
+$CLICKHOUSE_CLIENT -m -q "
 select * from remote('127.0.0.2', system, one, 'default', '');
 select * from remote('127.0.0.2', system, one, 'default', 'wrong password'); -- { serverError AUTHENTICATION_FAILED }
 select * from remote('127.0.0.2', system, one, 'nonexistsnt_user_1119', ''); -- { serverError AUTHENTICATION_FAILED }

--- a/tests/queries/0_stateless/01213_alter_rename_column_zookeeper_long.sh
+++ b/tests/queries/0_stateless/01213_alter_rename_column_zookeeper_long.sh
@@ -7,7 +7,7 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 $CLICKHOUSE_CLIENT --query "DROP TABLE IF EXISTS table_for_rename_replicated"
 
-$CLICKHOUSE_CLIENT -n --query "
+$CLICKHOUSE_CLIENT --query "
 CREATE TABLE table_for_rename_replicated
 (
   date Date,

--- a/tests/queries/0_stateless/01238_http_memory_tracking.sh
+++ b/tests/queries/0_stateless/01238_http_memory_tracking.sh
@@ -14,7 +14,7 @@ ${CLICKHOUSE_CLIENT} --format Null -q "CREATE USER $MISTER_USER"
 
 # This is needed to keep at least one running query for user for the time of test.
 # (1k http queries takes ~1 second, let's run for 5x more to avoid flaps)
-${CLICKHOUSE_CLIENT} --user ${MISTER_USER} --function_sleep_max_microseconds_per_block 5000000 --format Null -n <<<'SELECT sleepEachRow(1) FROM numbers(5)' &
+${CLICKHOUSE_CLIENT} --user ${MISTER_USER} --function_sleep_max_microseconds_per_block 5000000 --format Null <<<'SELECT sleepEachRow(1) FROM numbers(5)' &
 
 # ignore "yes: standard output: Broken pipe"
 yes 'SELECT 1' 2>/dev/null | {

--- a/tests/queries/0_stateless/01280_ssd_complex_key_dictionary.sh
+++ b/tests/queries/0_stateless/01280_ssd_complex_key_dictionary.sh
@@ -5,7 +5,7 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CURDIR"/../shell_config.sh
 
-$CLICKHOUSE_CLIENT -n --query="
+$CLICKHOUSE_CLIENT --query="
     DROP DATABASE IF EXISTS 01280_db;
     CREATE DATABASE 01280_db;
     DROP TABLE IF EXISTS 01280_db.table_for_dict;
@@ -39,9 +39,9 @@ $CLICKHOUSE_CLIENT -n --query="
     LIFETIME(MIN 1000 MAX 2000)
     LAYOUT(COMPLEX_KEY_SSD_CACHE(FILE_SIZE 8192 PATH '$USER_FILES_PATH/0d'));"
 
-$CLICKHOUSE_CLIENT -nq "SELECT dictHas('01280_db.ssd_dict', 'a', tuple('1')); -- { serverError 43 }"
+$CLICKHOUSE_CLIENT -q "SELECT dictHas('01280_db.ssd_dict', 'a', tuple('1')); -- { serverError 43 }"
 
-$CLICKHOUSE_CLIENT -n --query="
+$CLICKHOUSE_CLIENT --query="
     SELECT 'TEST_SMALL';
     SELECT 'VALUE FROM RAM BUFFER';
     SELECT dictGetUInt64('01280_db.ssd_dict', 'a', tuple('1', toInt32(3)));
@@ -63,9 +63,9 @@ $CLICKHOUSE_CLIENT -n --query="
     SELECT dictGetInt32('01280_db.ssd_dict', 'b', tuple('10', toInt32(-20)));
     SELECT dictGetString('01280_db.ssd_dict', 'c', tuple('10', toInt32(-20)));"
 
-$CLICKHOUSE_CLIENT -nq "SELECT dictGetUInt64('01280_db.ssd_dict', 'a', tuple(toInt32(3))); -- { serverError 53 }"
+$CLICKHOUSE_CLIENT -q "SELECT dictGetUInt64('01280_db.ssd_dict', 'a', tuple(toInt32(3))); -- { serverError 53 }"
 
-$CLICKHOUSE_CLIENT -n --query="DROP DICTIONARY 01280_db.ssd_dict;
+$CLICKHOUSE_CLIENT --query="DROP DICTIONARY 01280_db.ssd_dict;
     DROP TABLE IF EXISTS 01280_db.keys_table;
     CREATE TABLE 01280_db.keys_table
     (
@@ -122,4 +122,4 @@ $CLICKHOUSE_CLIENT -n --query="DROP DICTIONARY 01280_db.ssd_dict;
     DROP DICTIONARY IF EXISTS database_for_dict.ssd_dict;
     DROP TABLE IF EXISTS database_for_dict.keys_table;"
 
-$CLICKHOUSE_CLIENT -n --query="DROP DATABASE IF EXISTS 01280_db;"
+$CLICKHOUSE_CLIENT --query="DROP DATABASE IF EXISTS 01280_db;"

--- a/tests/queries/0_stateless/01294_lazy_database_concurrent_recreate_reattach_and_show_tables_long.sh
+++ b/tests/queries/0_stateless/01294_lazy_database_concurrent_recreate_reattach_and_show_tables_long.sh
@@ -85,7 +85,7 @@ export -f recreate_lazy_func4;
 export -f test_func;
 
 
-${CLICKHOUSE_CLIENT} -n -q "
+${CLICKHOUSE_CLIENT} -q "
     DROP DATABASE IF EXISTS $CURR_DATABASE;
     CREATE DATABASE $CURR_DATABASE ENGINE = Lazy(1);
 "

--- a/tests/queries/0_stateless/01305_replica_create_drop_zookeeper.sh
+++ b/tests/queries/0_stateless/01305_replica_create_drop_zookeeper.sh
@@ -10,7 +10,7 @@ set -e
 function thread()
 {
     while true; do
-        $CLICKHOUSE_CLIENT -n -q "DROP TABLE IF EXISTS test_table_$1 SYNC;
+        $CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS test_table_$1 SYNC;
             CREATE TABLE test_table_$1 (a UInt8) ENGINE = ReplicatedMergeTree('/clickhouse/tables/$CLICKHOUSE_TEST_ZOOKEEPER_PREFIX/alter_table', 'r_$1') ORDER BY tuple();" 2>&1 |
                 grep -vP '(^$)|(^Received exception from server)|(^\d+\. )|because the last replica of the table was dropped right now|is already started to be removing by another replica right now| were removed by another replica|Removing leftovers from table|Another replica was suddenly created|was created by another server at the same moment|was suddenly removed|some other replicas were created at the same time|^\(query: '
     done

--- a/tests/queries/0_stateless/01320_create_sync_race_condition_zookeeper.sh
+++ b/tests/queries/0_stateless/01320_create_sync_race_condition_zookeeper.sh
@@ -17,7 +17,7 @@ function thread1()
 {
     local TIMELIMIT=$((SECONDS+$1))
     while [ $SECONDS -lt "$TIMELIMIT" ]; do
-        $CLICKHOUSE_CLIENT -n --query "CREATE TABLE test_01320.r (x UInt64) ENGINE = ReplicatedMergeTree('/test/$CLICKHOUSE_TEST_ZOOKEEPER_PREFIX/table', 'r') ORDER BY x; DROP TABLE test_01320.r;"
+        $CLICKHOUSE_CLIENT --query "CREATE TABLE test_01320.r (x UInt64) ENGINE = ReplicatedMergeTree('/test/$CLICKHOUSE_TEST_ZOOKEEPER_PREFIX/table', 'r') ORDER BY x; DROP TABLE test_01320.r;"
     done
 }
 

--- a/tests/queries/0_stateless/01395_limit_more_cases.sh
+++ b/tests/queries/0_stateless/01395_limit_more_cases.sh
@@ -20,4 +20,4 @@ for OFFSET in {0..15}; do
             FROM (SELECT * FROM numbers($SIZE) LIMIT $OFFSET, $LIMIT);
         "
     done
-done | $CLICKHOUSE_CLIENT -n --max_block_size 5
+done | $CLICKHOUSE_CLIENT --max_block_size 5

--- a/tests/queries/0_stateless/01395_limit_more_cases_random.sh
+++ b/tests/queries/0_stateless/01395_limit_more_cases_random.sh
@@ -19,4 +19,4 @@ for _ in $(seq $ITERATIONS); do
                 throwIf((c != 0 OR first != 0 OR last != 0) AND (c != last - first + 1))
             FROM (SELECT * FROM numbers($SIZE) LIMIT $OFFSET, $LIMIT);
         "
-done | $CLICKHOUSE_CLIENT -n --max_block_size $(($RANDOM % 20 + 1)) | uniq
+done | $CLICKHOUSE_CLIENT --max_block_size $(($RANDOM % 20 + 1)) | uniq

--- a/tests/queries/0_stateless/01412_cache_dictionary_race.sh
+++ b/tests/queries/0_stateless/01412_cache_dictionary_race.sh
@@ -10,7 +10,7 @@ $CLICKHOUSE_CLIENT --query "DROP DATABASE IF EXISTS ordinary_db"
 
 $CLICKHOUSE_CLIENT --query "CREATE DATABASE ordinary_db"
 
-$CLICKHOUSE_CLIENT -n -q "
+$CLICKHOUSE_CLIENT -q "
 
 CREATE DICTIONARY ordinary_db.dict1
 (
@@ -35,7 +35,7 @@ function dict_get_thread()
 function drop_create_table_thread()
 {
     while true; do
-        $CLICKHOUSE_CLIENT -n --query "CREATE TABLE ordinary_db.table_for_dict_real (
+        $CLICKHOUSE_CLIENT --query "CREATE TABLE ordinary_db.table_for_dict_real (
             key_column UInt64,
             second_column UInt8,
             third_column String

--- a/tests/queries/0_stateless/01454_storagememory_data_race_challenge.sh
+++ b/tests/queries/0_stateless/01454_storagememory_data_race_challenge.sh
@@ -23,7 +23,7 @@ function f {
 function g {
   local TIMELIMIT=$((SECONDS+$1))
   for _ in $(seq 1 100); do
-    $CLICKHOUSE_CLIENT -n -q "
+    $CLICKHOUSE_CLIENT -q "
         INSERT INTO mem SELECT number FROM numbers(1000000);
         INSERT INTO mem SELECT number FROM numbers(1000000);
         INSERT INTO mem SELECT number FROM numbers(1000000);

--- a/tests/queries/0_stateless/01509_check_many_parallel_quorum_inserts_long.sh
+++ b/tests/queries/0_stateless/01509_check_many_parallel_quorum_inserts_long.sh
@@ -11,7 +11,7 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 NUM_REPLICAS=6
 
 for i in $(seq 1 $NUM_REPLICAS); do
-    $CLICKHOUSE_CLIENT -n -q "
+    $CLICKHOUSE_CLIENT -q "
         DROP TABLE IF EXISTS r$i SYNC;
         CREATE TABLE r$i (x UInt64) ENGINE = ReplicatedMergeTree('/clickhouse/tables/$CLICKHOUSE_TEST_ZOOKEEPER_PREFIX/parallel_quorum_many', 'r$i') ORDER BY x;
     "
@@ -39,12 +39,12 @@ done
 wait
 
 for i in $(seq 1 $NUM_REPLICAS); do
-    $CLICKHOUSE_CLIENT -n -q "
+    $CLICKHOUSE_CLIENT -q "
         SYSTEM SYNC REPLICA r$i;
         SELECT count(), min(x), max(x), sum(x) FROM r$i;
     "
 done
 
 for i in $(seq 1 $NUM_REPLICAS); do
-    $CLICKHOUSE_CLIENT -n -q "DROP TABLE IF EXISTS r$i SYNC;"
+    $CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS r$i SYNC;"
 done

--- a/tests/queries/0_stateless/01509_check_parallel_quorum_inserts_long.sh
+++ b/tests/queries/0_stateless/01509_check_parallel_quorum_inserts_long.sh
@@ -12,13 +12,13 @@ NUM_REPLICAS=2
 NUM_INSERTS=5
 
 for i in $(seq 1 $NUM_REPLICAS); do
-    $CLICKHOUSE_CLIENT -n -q "
+    $CLICKHOUSE_CLIENT -q "
         DROP TABLE IF EXISTS r$i;
         CREATE TABLE r$i (x UInt64) ENGINE = ReplicatedMergeTree('/clickhouse/tables/$CLICKHOUSE_TEST_ZOOKEEPER_PREFIX/parallel_quorum', 'r$i') ORDER BY x;
     "
 done
 
-$CLICKHOUSE_CLIENT -n -q "SYSTEM STOP REPLICATION QUEUES r2;"
+$CLICKHOUSE_CLIENT -q "SYSTEM STOP REPLICATION QUEUES r2;"
 
 function thread {
     $CLICKHOUSE_CLIENT --insert_quorum 2 --insert_quorum_parallel 1 --query "INSERT INTO r1 SELECT $1"
@@ -28,12 +28,12 @@ for i in $(seq 1 $NUM_INSERTS); do
     thread $i &
 done
 
-$CLICKHOUSE_CLIENT -n -q "SYSTEM START REPLICATION QUEUES r2;"
+$CLICKHOUSE_CLIENT -q "SYSTEM START REPLICATION QUEUES r2;"
 
 wait
 
 for i in $(seq 1 $NUM_REPLICAS); do
-    $CLICKHOUSE_CLIENT -n -q "
+    $CLICKHOUSE_CLIENT -q "
         SELECT count(), min(x), max(x), sum(x) FROM r$i;
         DROP TABLE IF EXISTS r$i;
 "

--- a/tests/queries/0_stateless/01563_distributed_query_finish.sh
+++ b/tests/queries/0_stateless/01563_distributed_query_finish.sh
@@ -9,7 +9,7 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CURDIR"/../shell_config.sh
 
-$CLICKHOUSE_CLIENT -nm <<EOL
+$CLICKHOUSE_CLIENT -m <<EOL
 drop table if exists dist_01247;
 drop table if exists data_01247;
 
@@ -29,7 +29,7 @@ for ((i = 0; i < 100; ++i)); do
         "--optimize_distributed_group_by_sharding_key=1"
         "--prefer_localhost_replica=0"
     )
-    $CLICKHOUSE_CLIENT "${opts[@]}" --format CSV -nm -q "select count(), * from dist_01247 group by number order by number limit 1 format Null"
+    $CLICKHOUSE_CLIENT "${opts[@]}" --format CSV -m -q "select count(), * from dist_01247 group by number order by number limit 1 format Null"
 
     # expect zero new network errors
     network_errors_after=$($CLICKHOUSE_CLIENT -q "SELECT value FROM system.errors WHERE name = 'NETWORK_ERROR'")

--- a/tests/queries/0_stateless/01732_race_condition_storage_join_long.sh
+++ b/tests/queries/0_stateless/01732_race_condition_storage_join_long.sh
@@ -11,14 +11,14 @@ set -o pipefail
 echo "
 	DROP TABLE IF EXISTS storage_join_race;
 	CREATE TABLE storage_join_race (x UInt64, y UInt64) Engine = Join(ALL, FULL, x);
-" | $CLICKHOUSE_CLIENT -n
+" | $CLICKHOUSE_CLIENT
 
 function read_thread_big()
 {
     while true; do
         echo "
             SELECT * FROM ( SELECT number AS x FROM numbers(100000) ) AS t1 ALL FULL JOIN storage_join_race USING (x) FORMAT Null;
-        " | $CLICKHOUSE_CLIENT -n
+        " | $CLICKHOUSE_CLIENT
     done
 }
 
@@ -27,7 +27,7 @@ function read_thread_small()
     while true; do
         echo "
             SELECT * FROM ( SELECT number AS x FROM numbers(10) ) AS t1 ALL FULL JOIN storage_join_race USING (x) FORMAT Null;
-        " | $CLICKHOUSE_CLIENT -n
+        " | $CLICKHOUSE_CLIENT
     done
 }
 
@@ -36,7 +36,7 @@ function read_thread_select()
     while true; do
         echo "
             SELECT * FROM storage_join_race FORMAT Null;
-        " | $CLICKHOUSE_CLIENT -n
+        " | $CLICKHOUSE_CLIENT
     done
 }
 
@@ -56,7 +56,7 @@ echo "
     INSERT INTO storage_join_race
         SELECT number AS x, sleepEachRow(0.1) + number AS y FROM numbers ($TIMEOUT * 10)
         SETTINGS function_sleep_max_microseconds_per_block = 100000000, max_block_size = 10;
-" | $CLICKHOUSE_CLIENT -n
+" | $CLICKHOUSE_CLIENT
 
 wait
 

--- a/tests/queries/0_stateless/01802_test_postgresql_protocol_with_row_policy.sh
+++ b/tests/queries/0_stateless/01802_test_postgresql_protocol_with_row_policy.sh
@@ -17,7 +17,7 @@ INSERT INTO db01802.postgresql SELECT number FROM numbers(10);
 
 SELECT 'before row policy';
 SELECT * FROM db01802.postgresql;
-" | $CLICKHOUSE_CLIENT -n
+" | $CLICKHOUSE_CLIENT
 
 
 echo "
@@ -28,7 +28,7 @@ CREATE ROW POLICY IF NOT EXISTS test_policy ON db01802.postgresql FOR SELECT USI
 
 SELECT '';
 SELECT 'after row policy with no password';
-" | $CLICKHOUSE_CLIENT -n
+" | $CLICKHOUSE_CLIENT
 
 psql --host localhost --port ${CLICKHOUSE_PORT_POSTGRESQL} db01802 --user postgresql_user -c "SELECT * FROM postgresql;"
 
@@ -40,7 +40,7 @@ GRANT SELECT(val) ON db01802.postgresql TO postgresql_user;
 CREATE ROW POLICY IF NOT EXISTS test_policy ON db01802.postgresql FOR SELECT USING val = 2 TO postgresql_user;
 
 SELECT 'after row policy with plaintext_password';
-" | $CLICKHOUSE_CLIENT -n
+" | $CLICKHOUSE_CLIENT
 
 psql "postgresql://postgresql_user:qwerty@localhost:${CLICKHOUSE_PORT_POSTGRESQL}/db01802" -c "SELECT * FROM postgresql;"
 

--- a/tests/queries/0_stateless/01810_max_part_removal_threads_long.sh
+++ b/tests/queries/0_stateless/01810_max_part_removal_threads_long.sh
@@ -17,10 +17,10 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # The number of threads removing data parts should be between 1 and 129.
 # Because max_parts_cleaning_thread_pool_size is 128 by default
 
-$CLICKHOUSE_CLIENT --allow_deprecated_database_ordinary=1 -nm -q "create database ordinary_$CLICKHOUSE_DATABASE engine=Ordinary"
+$CLICKHOUSE_CLIENT --allow_deprecated_database_ordinary=1 -m -q "create database ordinary_$CLICKHOUSE_DATABASE engine=Ordinary"
 
 # MergeTree
-$CLICKHOUSE_CLIENT -nm -q """
+$CLICKHOUSE_CLIENT -m -q """
     use ordinary_$CLICKHOUSE_DATABASE;
     drop table if exists data_01810;
 
@@ -47,7 +47,7 @@ $CLICKHOUSE_CLIENT -nm -q """
 """
 
 # ReplicatedMergeTree
-$CLICKHOUSE_CLIENT -nm -q """
+$CLICKHOUSE_CLIENT -m -q """
     use ordinary_$CLICKHOUSE_DATABASE;
     drop table if exists rep_data_01810;
 
@@ -76,4 +76,4 @@ $CLICKHOUSE_CLIENT -nm -q """
     format Null;
 """
 
-$CLICKHOUSE_CLIENT -nm -q "drop database ordinary_$CLICKHOUSE_DATABASE"
+$CLICKHOUSE_CLIENT -m -q "drop database ordinary_$CLICKHOUSE_DATABASE"

--- a/tests/queries/0_stateless/01889_postgresql_protocol_null_fields.sh
+++ b/tests/queries/0_stateless/01889_postgresql_protocol_null_fields.sh
@@ -9,6 +9,6 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 echo "
 DROP USER IF EXISTS postgresql_user;
 CREATE USER postgresql_user HOST IP '127.0.0.1' IDENTIFIED WITH no_password;
-" | $CLICKHOUSE_CLIENT -n
+" | $CLICKHOUSE_CLIENT
 
 psql --host localhost --port ${CLICKHOUSE_PORT_POSTGRESQL} ${CLICKHOUSE_DATABASE} --user postgresql_user -c "SELECT NULL;"

--- a/tests/queries/0_stateless/01900_kill_mutation_parallel_long.sh
+++ b/tests/queries/0_stateless/01900_kill_mutation_parallel_long.sh
@@ -12,7 +12,7 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CUR_DIR"/../shell_config.sh
 
-$CLICKHOUSE_CLIENT -nm -q "
+$CLICKHOUSE_CLIENT -m -q "
     drop table if exists data_01900_1;
     drop table if exists data_01900_2;
 
@@ -27,18 +27,18 @@ $CLICKHOUSE_CLIENT -nm -q "
 # so 100 mutations will be scheduled and killed later.
 for i in {1..100}; do
     echo "alter table data_01900_1 update s = 'foo_$i' where 1;"
-done | $CLICKHOUSE_CLIENT -nm
+done | $CLICKHOUSE_CLIENT -m
 
 # but these mutations should not be killed.
 (
     for i in {1..100}; do
         echo "alter table data_01900_2 update s = 'bar_$i' where 1;"
-    done | $CLICKHOUSE_CLIENT -nm --mutations_sync=1
+    done | $CLICKHOUSE_CLIENT -m --mutations_sync=1
 ) &
-$CLICKHOUSE_CLIENT --format Null -nm -q "kill mutation where table = 'data_01900_1' and database = '$CLICKHOUSE_DATABASE';"
+$CLICKHOUSE_CLIENT --format Null -m -q "kill mutation where table = 'data_01900_1' and database = '$CLICKHOUSE_DATABASE';"
 wait
 
-$CLICKHOUSE_CLIENT -nm -q "select * from data_01900_2"
+$CLICKHOUSE_CLIENT -m -q "select * from data_01900_2"
 
 $CLICKHOUSE_CLIENT -q "drop table data_01900_1"
 $CLICKHOUSE_CLIENT -q "drop table data_01900_2"

--- a/tests/queries/0_stateless/01921_concurrent_ttl_and_normal_merges_zookeeper_long.sh
+++ b/tests/queries/0_stateless/01921_concurrent_ttl_and_normal_merges_zookeeper_long.sh
@@ -18,7 +18,7 @@ done
 wait
 
 for i in $(seq 1 $NUM_REPLICAS); do
-    $CLICKHOUSE_CLIENT -n --query "CREATE TABLE ttl_table$i(
+    $CLICKHOUSE_CLIENT --query "CREATE TABLE ttl_table$i(
         key DateTime
     )
     ENGINE ReplicatedMergeTree('/test/01921_concurrent_ttl_and_normal_merges/$CLICKHOUSE_TEST_ZOOKEEPER_PREFIX/ttl_table', '$i')

--- a/tests/queries/1_stateful/00177_memory_bound_merging.sh
+++ b/tests/queries/1_stateful/00177_memory_bound_merging.sh
@@ -9,7 +9,7 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 check_replicas_read_in_order() {
     # NOTE: lack of "current_database = '$CLICKHOUSE_DATABASE'" filter is made on purpose
-    $CLICKHOUSE_CLIENT -nq "
+    $CLICKHOUSE_CLIENT -q "
         SYSTEM FLUSH LOGS;
 
         SELECT COUNT() > 0
@@ -22,7 +22,7 @@ check_replicas_read_in_order() {
 # at some point we had a bug in this logic (see https://github.com/ClickHouse/ClickHouse/pull/45892#issue-1566140414)
 test1() {
     query_id="query_id_memory_bound_merging_$RANDOM$RANDOM"
-    $CLICKHOUSE_CLIENT --query_id="$query_id" -nq "
+    $CLICKHOUSE_CLIENT --query_id="$query_id" -q "
         SET cluster_for_parallel_replicas = 'test_cluster_one_shard_three_replicas_localhost';
 
         SELECT URL, EventDate, max(URL)
@@ -39,7 +39,7 @@ test1() {
 # at some point we had a bug in this logic (see https://github.com/ClickHouse/ClickHouse/pull/45892#issue-1566140414)
 test2() {
     query_id="query_id_memory_bound_merging_$RANDOM$RANDOM"
-    $CLICKHOUSE_CLIENT --query_id="$query_id" -nq "
+    $CLICKHOUSE_CLIENT --query_id="$query_id" -q "
         SET cluster_for_parallel_replicas = 'test_cluster_one_shard_three_replicas_localhost';
 
         SELECT URL, EventDate, max(URL)
@@ -53,7 +53,7 @@ test2() {
 }
 
 test3() {
-    $CLICKHOUSE_CLIENT -nq "
+    $CLICKHOUSE_CLIENT -q "
         SET cluster_for_parallel_replicas = 'test_cluster_one_shard_three_replicas_localhost';
         SET max_threads = 16, prefer_localhost_replica = 1, read_in_order_two_level_merge_threshold = 1000, query_plan_aggregation_in_order = 1, distributed_aggregation_memory_efficient = 1;
 

--- a/tests/queries/1_stateful/00180_no_seek_avoiding_when_reading_from_cache.sh
+++ b/tests/queries/1_stateful/00180_no_seek_avoiding_when_reading_from_cache.sh
@@ -23,7 +23,7 @@ $CLICKHOUSE_CLIENT -q "SELECT * FROM hits_s3_sampled WHERE URL LIKE '%google%' O
 query_id=02906_read_from_cache_$RANDOM
 $CLICKHOUSE_CLIENT --query_id ${query_id} -q "SELECT * FROM hits_s3_sampled WHERE URL LIKE '%google%' ORDER BY EventTime LIMIT 10 FORMAT Null SETTINGS filesystem_cache_reserve_space_wait_lock_timeout_milliseconds=2000"
 
-$CLICKHOUSE_CLIENT -nq "
+$CLICKHOUSE_CLIENT -q "
   SYSTEM FLUSH LOGS;
 
   -- AsynchronousReaderIgnoredBytes = 0: no seek-avoiding happened


### PR DESCRIPTION
This PR is follow-up to https://github.com/ClickHouse/ClickHouse/pull/63898, removing the obsolete `-n`/`--multiquery` parameters from tests to avoid confusion why the parameter is still there and future cargo-cult copy-pasting of obsolete stuff into new tests.

Earlier similar PRs: 
- https://github.com/ClickHouse/ClickHouse/pull/67435
- https://github.com/ClickHouse/ClickHouse/pull/67749
- https://github.com/ClickHouse/ClickHouse/pull/67964
- https://github.com/ClickHouse/ClickHouse/pull/68407
- https://github.com/ClickHouse/ClickHouse/pull/69344

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)