### PR TITLE
Bump libarchive to v3.7.4

### DIFF
--- a/contrib/libarchive-cmake/CMakeLists.txt
+++ b/contrib/libarchive-cmake/CMakeLists.txt
@@ -1,6 +1,6 @@
 set (LIBRARY_DIR "${ClickHouse_SOURCE_DIR}/contrib/libarchive")
 
-set(SRCS 
+set(SRCS
     "${LIBRARY_DIR}/libarchive/archive_acl.c"
     "${LIBRARY_DIR}/libarchive/archive_blake2sp_ref.c"
     "${LIBRARY_DIR}/libarchive/archive_blake2s_ref.c"
@@ -135,7 +135,7 @@ set(SRCS
 )
 
 add_library(_libarchive ${SRCS})
-target_include_directories(_libarchive PUBLIC 
+target_include_directories(_libarchive PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}
     "${LIBRARY_DIR}/libarchive"
 )
@@ -157,7 +157,7 @@ if (TARGET ch_contrib::zlib)
 endif()
 
 if (TARGET ch_contrib::zstd)
-    target_compile_definitions(_libarchive PUBLIC HAVE_ZSTD_H=1 HAVE_LIBZSTD=1 HAVE_LIBZSTD_COMPRESSOR=1)
+    target_compile_definitions(_libarchive PUBLIC HAVE_ZSTD_H=1 HAVE_LIBZSTD=1 HAVE_ZSTD_compressStream=1)
     target_link_libraries(_libarchive PRIVATE ch_contrib::zstd)
 endif()
 

--- a/contrib/libarchive-cmake/config.h
+++ b/contrib/libarchive-cmake/config.h
@@ -334,16 +334,16 @@ typedef uint64_t uintmax_t;
 /* #undef ARCHIVE_XATTR_LINUX */
 
 /* Version number of bsdcpio */
-#define BSDCPIO_VERSION_STRING "3.7.3"
+#define BSDCPIO_VERSION_STRING "3.7.4"
 
 /* Version number of bsdtar */
-#define BSDTAR_VERSION_STRING "3.7.3"
+#define BSDTAR_VERSION_STRING "3.7.4"
 
 /* Version number of bsdcat */
-#define BSDCAT_VERSION_STRING "3.7.3"
+#define BSDCAT_VERSION_STRING "3.7.4"
 
 /* Version number of bsdunzip */
-#define BSDUNZIP_VERSION_STRING "3.7.3"
+#define BSDUNZIP_VERSION_STRING "3.7.4"
 
 /* Define to 1 if you have the `acl_create_entry' function. */
 /* #undef HAVE_ACL_CREATE_ENTRY */
@@ -1094,6 +1094,9 @@ typedef uint64_t uintmax_t;
 /* Define to 1 if you have the `symlink' function. */
 #define HAVE_SYMLINK 1
 
+/* Define to 1 if you have the `sysconf' function. */
+#define HAVE_SYSCONF 1
+
 /* Define to 1 if you have the <sys/acl.h> header file. */
 /* #undef HAVE_SYS_ACL_H */
 
@@ -1293,10 +1296,10 @@ typedef uint64_t uintmax_t;
 #define ICONV_CONST
 
 /* Version number of libarchive as a single integer */
-#define LIBARCHIVE_VERSION_NUMBER "3007003"
+#define LIBARCHIVE_VERSION_NUMBER "3007004"
 
 /* Version number of libarchive */
-#define LIBARCHIVE_VERSION_STRING "3.7.3"
+#define LIBARCHIVE_VERSION_STRING "3.7.4"
 
 /* Define to 1 if `lstat' dereferences a symlink specified with a trailing
    slash. */
@@ -1350,7 +1353,7 @@ typedef uint64_t uintmax_t;
 #endif /* SAFE_TO_DEFINE_EXTENSIONS */
 
 /* Version number of package */
-#define VERSION "3.7.3"
+#define VERSION "3.7.4"
 
 /* Number of bits in a file offset, on hosts where this is settable. */
 /* #undef _FILE_OFFSET_BITS */

--- a/contrib/libarchive-cmake/config.h
+++ b/contrib/libarchive-cmake/config.h
@@ -334,16 +334,16 @@ typedef uint64_t uintmax_t;
 /* #undef ARCHIVE_XATTR_LINUX */
 
 /* Version number of bsdcpio */
-#define BSDCPIO_VERSION_STRING "3.7.2"
+#define BSDCPIO_VERSION_STRING "3.7.3"
 
 /* Version number of bsdtar */
-#define BSDTAR_VERSION_STRING "3.7.2"
+#define BSDTAR_VERSION_STRING "3.7.3"
 
 /* Version number of bsdcat */
-#define BSDCAT_VERSION_STRING "3.7.2"
+#define BSDCAT_VERSION_STRING "3.7.3"
 
 /* Version number of bsdunzip */
-#define BSDUNZIP_VERSION_STRING "3.7.2"
+#define BSDUNZIP_VERSION_STRING "3.7.3"
 
 /* Define to 1 if you have the `acl_create_entry' function. */
 /* #undef HAVE_ACL_CREATE_ENTRY */
@@ -753,6 +753,12 @@ typedef uint64_t uintmax_t;
 /* Define to 1 if you have the `pcreposix' library (-lpcreposix). */
 /* #undef HAVE_LIBPCREPOSIX */
 
+/* Define to 1 if you have the `pcre2-8' library (-lpcre2-8). */
+/* #undef HAVE_LIBPCRE2 */
+
+/* Define to 1 if you have the `pcreposix' library (-lpcre2posix). */
+/* #undef HAVE_LIBPCRE2POSIX */
+
 /* Define to 1 if you have the `xml2' library (-lxml2). */
 #define HAVE_LIBXML2 1
 
@@ -768,9 +774,8 @@ typedef uint64_t uintmax_t;
 /* Define to 1 if you have the `zstd' library (-lzstd). */
 /* #undef HAVE_LIBZSTD */
 
-/* Define to 1 if you have the `zstd' library (-lzstd) with compression
-   support. */
-/* #undef HAVE_LIBZSTD_COMPRESSOR */
+/* Define to 1 if you have the ZSTD_compressStream function. */
+/* #undef HAVE_ZSTD_compressStream */
 
 /* Define to 1 if you have the <limits.h> header file. */
 #define HAVE_LIMITS_H 1
@@ -925,6 +930,9 @@ typedef uint64_t uintmax_t;
 
 /* Define to 1 if you have the <pcreposix.h> header file. */
 /* #undef HAVE_PCREPOSIX_H */
+
+/* Define to 1 if you have the <pcre2posix.h> header file. */
+/* #undef HAVE_PCRE2POSIX_H */
 
 /* Define to 1 if you have the `pipe' function. */
 #define HAVE_PIPE 1
@@ -1285,10 +1293,10 @@ typedef uint64_t uintmax_t;
 #define ICONV_CONST
 
 /* Version number of libarchive as a single integer */
-#define LIBARCHIVE_VERSION_NUMBER "3007002"
+#define LIBARCHIVE_VERSION_NUMBER "3007003"
 
 /* Version number of libarchive */
-#define LIBARCHIVE_VERSION_STRING "3.7.2"
+#define LIBARCHIVE_VERSION_STRING "3.7.3"
 
 /* Define to 1 if `lstat' dereferences a symlink specified with a trailing
    slash. */
@@ -1342,7 +1350,7 @@ typedef uint64_t uintmax_t;
 #endif /* SAFE_TO_DEFINE_EXTENSIONS */
 
 /* Version number of package */
-#define VERSION "3.7.2"
+#define VERSION "3.7.3"
 
 /* Number of bits in a file offset, on hosts where this is settable. */
 /* #undef _FILE_OFFSET_BITS */

--- a/contrib/libarchive-cmake/config.h
+++ b/contrib/libarchive-cmake/config.h
@@ -334,13 +334,13 @@ typedef uint64_t uintmax_t;
 /* #undef ARCHIVE_XATTR_LINUX */
 
 /* Version number of bsdcpio */
-#define BSDCPIO_VERSION_STRING "3.7.0"
+#define BSDCPIO_VERSION_STRING "3.7.1"
 
 /* Version number of bsdtar */
-#define BSDTAR_VERSION_STRING "3.7.0"
+#define BSDTAR_VERSION_STRING "3.7.1"
 
 /* Version number of bsdcat */
-#define BSDCAT_VERSION_STRING "3.7.0"
+#define BSDCAT_VERSION_STRING "3.7.1"
 
 /* Define to 1 if you have the `acl_create_entry' function. */
 /* #undef HAVE_ACL_CREATE_ENTRY */
@@ -641,6 +641,9 @@ typedef uint64_t uintmax_t;
 
 /* Define to 1 if you have the `getgrnam_r' function. */
 #define HAVE_GETGRNAM_R 1
+
+/* Define to 1 if you have the `getline' function. */
+#define HAVE_GETLINE 1
 
 /* Define to 1 if platform uses `optreset` to reset `getopt` */
 #define HAVE_GETOPT_OPTRESET 1
@@ -1273,13 +1276,13 @@ typedef uint64_t uintmax_t;
 /* #undef HAVE__MKGMTIME */
 
 /* Define as const if the declaration of iconv() needs const. */
-#define ICONV_CONST 
+#define ICONV_CONST
 
 /* Version number of libarchive as a single integer */
-#define LIBARCHIVE_VERSION_NUMBER "3007000"
+#define LIBARCHIVE_VERSION_NUMBER "3007001"
 
 /* Version number of libarchive */
-#define LIBARCHIVE_VERSION_STRING "3.7.0"
+#define LIBARCHIVE_VERSION_STRING "3.7.1"
 
 /* Define to 1 if `lstat' dereferences a symlink specified with a trailing
    slash. */
@@ -1333,7 +1336,7 @@ typedef uint64_t uintmax_t;
 #endif /* SAFE_TO_DEFINE_EXTENSIONS */
 
 /* Version number of package */
-#define VERSION "3.7.0"
+#define VERSION "3.7.1"
 
 /* Number of bits in a file offset, on hosts where this is settable. */
 /* #undef _FILE_OFFSET_BITS */

--- a/contrib/libarchive-cmake/config.h
+++ b/contrib/libarchive-cmake/config.h
@@ -334,13 +334,16 @@ typedef uint64_t uintmax_t;
 /* #undef ARCHIVE_XATTR_LINUX */
 
 /* Version number of bsdcpio */
-#define BSDCPIO_VERSION_STRING "3.7.1"
+#define BSDCPIO_VERSION_STRING "3.7.2"
 
 /* Version number of bsdtar */
-#define BSDTAR_VERSION_STRING "3.7.1"
+#define BSDTAR_VERSION_STRING "3.7.2"
 
 /* Version number of bsdcat */
-#define BSDCAT_VERSION_STRING "3.7.1"
+#define BSDCAT_VERSION_STRING "3.7.2"
+
+/* Version number of bsdunzip */
+#define BSDUNZIP_VERSION_STRING "3.7.2"
 
 /* Define to 1 if you have the `acl_create_entry' function. */
 /* #undef HAVE_ACL_CREATE_ENTRY */
@@ -644,9 +647,6 @@ typedef uint64_t uintmax_t;
 
 /* Define to 1 if you have the `getline' function. */
 #define HAVE_GETLINE 1
-
-/* Define to 1 if platform uses `optreset` to reset `getopt` */
-#define HAVE_GETOPT_OPTRESET 1
 
 /* Define to 1 if you have the `getpid' function. */
 #define HAVE_GETPID 1
@@ -1032,6 +1032,12 @@ typedef uint64_t uintmax_t;
 /* Define to 1 if you have the `strrchr' function. */
 #define HAVE_STRRCHR 1
 
+/* Define to 1 if the system has the type `struct statfs'. */
+/* #undef HAVE_STRUCT_STATFS */
+
+/* Define to 1 if `f_iosize' is a member of `struct statfs'. */
+/* #undef HAVE_STRUCT_STATFS_F_IOSIZE */
+
 /* Define to 1 if `f_namemax' is a member of `struct statfs'. */
 /* #undef HAVE_STRUCT_STATFS_F_NAMEMAX */
 
@@ -1279,10 +1285,10 @@ typedef uint64_t uintmax_t;
 #define ICONV_CONST
 
 /* Version number of libarchive as a single integer */
-#define LIBARCHIVE_VERSION_NUMBER "3007001"
+#define LIBARCHIVE_VERSION_NUMBER "3007002"
 
 /* Version number of libarchive */
-#define LIBARCHIVE_VERSION_STRING "3.7.1"
+#define LIBARCHIVE_VERSION_STRING "3.7.2"
 
 /* Define to 1 if `lstat' dereferences a symlink specified with a trailing
    slash. */
@@ -1336,7 +1342,7 @@ typedef uint64_t uintmax_t;
 #endif /* SAFE_TO_DEFINE_EXTENSIONS */
 
 /* Version number of package */
-#define VERSION "3.7.1"
+#define VERSION "3.7.2"
 
 /* Number of bits in a file offset, on hosts where this is settable. */
 /* #undef _FILE_OFFSET_BITS */


### PR DESCRIPTION
Fixes
- CVE-2024-26256
- CVE-2024-37407

Earlier PR: https://github.com/ClickHouse/ClickHouse/pull/69318

(sorry, I need to bump libarchive in small increments as some related tests failed and I could not reproduce these locally)

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)