### PR TITLE
Fix crash in `sqidDecode`

### DIFF
--- a/src/Functions/sqid.cpp
+++ b/src/Functions/sqid.cpp
@@ -124,7 +124,7 @@ public:
                 std::string_view sqid = col_non_const->getDataAt(i).toView();
                 std::vector<UInt64> integers = sqids.decode(String(sqid));
                 res_nested_data.insert(integers.begin(), integers.end());
-                res_offsets_data.push_back(i == 0 ? integers.size() : res_offsets_data.back() + integers.size());
+                res_offsets_data.push_back(res_offsets_data.back() + integers.size());
             }
         }
         else

--- a/src/Functions/sqid.cpp
+++ b/src/Functions/sqid.cpp
@@ -124,7 +124,7 @@ public:
                 std::string_view sqid = col_non_const->getDataAt(i).toView();
                 std::vector<UInt64> integers = sqids.decode(String(sqid));
                 res_nested_data.insert(integers.begin(), integers.end());
-                res_offsets_data.push_back(integers.size());
+                res_offsets_data.push_back(i == 0 ? integers.size() : res_offsets_data.back() + integers.size());
             }
         }
         else

--- a/tests/queries/0_stateless/02933_sqid.reference
+++ b/tests/queries/0_stateless/02933_sqid.reference
@@ -13,5 +13,6 @@ Td1EnWQo	[1,2,3,4]
 XMbT
 -- invalid sqid
 []
+-- bug 69450
 -- alias
 XMbT

--- a/tests/queries/0_stateless/02933_sqid.sql
+++ b/tests/queries/0_stateless/02933_sqid.sql
@@ -25,5 +25,12 @@ SELECT sqidEncode(toNullable(materialize(1)), toLowCardinality(materialize(2)));
 SELECT '-- invalid sqid';
 SELECT sqidDecode('invalid sqid');
 
+SELECT '-- bug 69450';
+DROP TABLE IF EXISTS tab;
+CREATE TABLE tab (id String) ENGINE = MergeTree ORDER BY id;
+INSERT INTO tab SELECT * FROM generateRandom() LIMIT 1000000;
+SELECT sqidDecode(id) FROM tab FORMAT Null;
+DROP TABLE tab;
+
 SELECT '-- alias';
 SELECT sqid(1, 2);


### PR DESCRIPTION
Resolves #69450

### Changelog category (leave one):
- Critical Bug Fix (crash, LOGICAL_ERROR, data loss, RBAC)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed a `LOGICAL_ERROR` with function `sqidDecode` (#69450)