### PR TITLE
Fix high memory consumption on Squashing

### DIFF
--- a/src/Interpreters/Squashing.cpp
+++ b/src/Interpreters/Squashing.cpp
@@ -45,7 +45,7 @@ Chunk Squashing::squash(Chunk && input_chunk)
 
 Chunk Squashing::add(Chunk && input_chunk)
 {
-    if (!input_chunk)
+    if (!input_chunk || input_chunk.getNumRows() == 0)
         return {};
 
     /// Just read block is already enough.

--- a/tests/queries/0_stateless/03236_squashing_high_memory.sql
+++ b/tests/queries/0_stateless/03236_squashing_high_memory.sql
@@ -3,7 +3,7 @@ DROP TABLE IF EXISTS id_values;
 DROP TABLE IF EXISTS test_table;
 
 CREATE TABLE id_values ENGINE MergeTree ORDER BY id1 AS
-    SELECT arrayJoin(range(1000000)) AS id1, arrayJoin(range(1000)) AS id2;
+    SELECT arrayJoin(range(500000)) AS id1, arrayJoin(range(1000)) AS id2;
 
 SET max_memory_usage = 1G;
 

--- a/tests/queries/0_stateless/03236_squashing_high_memory.sql
+++ b/tests/queries/0_stateless/03236_squashing_high_memory.sql
@@ -6,7 +6,7 @@ DROP TABLE IF EXISTS id_values;
 DROP TABLE IF EXISTS test_table;
 
 CREATE TABLE id_values ENGINE MergeTree ORDER BY id1 AS
-    SELECT arrayJoin(range(500000)) AS id1, arrayJoin(range(1000)) AS id2;
+    SELECT arrayJoin(range(20000)) AS id1, arrayJoin(range(1000)) AS id2;
 
 SET max_memory_usage = '1G';
 

--- a/tests/queries/0_stateless/03236_squashing_high_memory.sql
+++ b/tests/queries/0_stateless/03236_squashing_high_memory.sql
@@ -5,7 +5,7 @@ DROP TABLE IF EXISTS test_table;
 CREATE TABLE id_values ENGINE MergeTree ORDER BY id1 AS
     SELECT arrayJoin(range(500000)) AS id1, arrayJoin(range(1000)) AS id2;
 
-SET max_memory_usage = 1G;
+SET max_memory_usage = '1G';
 
 CREATE TABLE test_table ENGINE MergeTree ORDER BY id AS
 SELECT id_values.id1             AS id,

--- a/tests/queries/0_stateless/03236_squashing_high_memory.sql
+++ b/tests/queries/0_stateless/03236_squashing_high_memory.sql
@@ -1,3 +1,6 @@
+-- Tags: no-fasttest
+-- reason: test requires too many rows to read
+
 DROP TABLE IF EXISTS id_values;
 
 DROP TABLE IF EXISTS test_table;

--- a/tests/queries/0_stateless/03236_squashing_high_memory.sql
+++ b/tests/queries/0_stateless/03236_squashing_high_memory.sql
@@ -1,12 +1,14 @@
 -- Tags: no-fasttest
 -- reason: test requires too many rows to read
 
+SET max_rows_to_read = '501G';
+
 DROP TABLE IF EXISTS id_values;
 
 DROP TABLE IF EXISTS test_table;
 
 CREATE TABLE id_values ENGINE MergeTree ORDER BY id1 AS
-    SELECT arrayJoin(range(20000)) AS id1, arrayJoin(range(1000)) AS id2;
+    SELECT arrayJoin(range(500000)) AS id1, arrayJoin(range(1000)) AS id2;
 
 SET max_memory_usage = '1G';
 

--- a/tests/queries/0_stateless/03236_squashing_high_memory.sql
+++ b/tests/queries/0_stateless/03236_squashing_high_memory.sql
@@ -1,4 +1,4 @@
--- Tags: no-fasttest
+-- Tags: no-fasttest, no-asan, no-tsan, no-msan, no-ubsan
 -- reason: test requires too many rows to read
 
 SET max_rows_to_read = '501G';

--- a/tests/queries/0_stateless/03236_squashing_high_memory.sql
+++ b/tests/queries/0_stateless/03236_squashing_high_memory.sql
@@ -1,0 +1,22 @@
+DROP TABLE IF EXISTS id_values;
+
+DROP TABLE IF EXISTS test_table;
+
+CREATE TABLE id_values ENGINE MergeTree ORDER BY id1 AS
+    SELECT arrayJoin(range(1000000)) AS id1, arrayJoin(range(1000)) AS id2;
+
+SET max_memory_usage = 1G;
+
+CREATE TABLE test_table ENGINE MergeTree ORDER BY id AS
+SELECT id_values.id1             AS id,
+    string_values.string_val1 AS string_val1,
+    string_values.string_val2 AS string_val2
+FROM id_values
+        JOIN (SELECT arrayJoin(range(10)) AS id1,
+                    'qwe'                AS string_val1,
+                    'asd'                AS string_val2) AS string_values
+            ON id_values.id1 = string_values.id1
+    SETTINGS join_algorithm = 'hash';
+
+DROP TABLE IF EXISTS id_values;
+DROP TABLE IF EXISTS test_table;


### PR DESCRIPTION
Fixes https://github.com/ClickHouse/ClickHouse/issues/69415, Fixes https://github.com/ClickHouse/ClickHouse/issues/68263, Fixes #69435
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)



### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed case when memory consumption was too high because of the squashing in `INSERT INTO ... SELECT` or `CREATE TABLE AS SELECT` queries

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---ci_include_fuzzer--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
