### PR TITLE
Branch-less process for binary arithmetic functions like intDiv and mod

### DIFF
--- a/src/Functions/modulo.cpp
+++ b/src/Functions/modulo.cpp
@@ -40,10 +40,18 @@ struct ModuloByConstantImpl
             if (right_nullmap)
             {
                 for (size_t i = 0; i < size; ++i)
-                    if ((*right_nullmap)[i])
-                        c[i] = ResultType();
+                {
+                    /// For better performance, try to use branch free code for numeric types(i.e. cond ? a : b --> !!cond * a + !cond * b), except floating point types because of Inf or NaN.
+                    if constexpr (std::is_integral_v<ResultType>)
+                        c[i] = (!!(*right_nullmap)[i]) * ResultType() + (!(*right_nullmap)[i]) * apply<op_case>(a, b, c, i);
                     else
-                        apply<op_case>(a, b, c, i);
+                    {
+                        if ((*right_nullmap)[i])
+                            c[i] = ResultType();
+                        else
+                            apply<op_case>(a, b, c, i);
+                    }
+                }
             }
             else
                 for (size_t i = 0; i < size; ++i)
@@ -105,12 +113,14 @@ struct ModuloByConstantImpl
 
 private:
     template <OpCase op_case>
-    static void apply(const A * __restrict a, const B * __restrict b, ResultType * __restrict c, size_t i)
+    static ResultType apply(const A * __restrict a, const B * __restrict b, ResultType * __restrict c, size_t i)
     {
         if constexpr (op_case == OpCase::Vector)
             c[i] = Op::template apply<ResultType>(a[i], b[i]);
         else
             c[i] = Op::template apply<ResultType>(*a, b[i]);
+
+        return c[i];
     }
 };
 

--- a/tests/performance/intDiv.xml
+++ b/tests/performance/intDiv.xml
@@ -2,4 +2,5 @@
     <query>SELECT count() FROM numbers(200000000) WHERE NOT ignore(intDiv(number, 1000000000))</query>
     <query>SELECT count() FROM numbers(200000000) WHERE NOT ignore(divide(number, 1000000000))</query>
     <query>SELECT count() FROM numbers(200000000) WHERE NOT ignore(toUInt32(divide(number, 1000000000)))</query>
+    <query>select intDiv((number+2), toNullable(number+1)) from system.numbers limit 100000000 format Null</query>
 </test>

--- a/tests/performance/modulo.xml
+++ b/tests/performance/modulo.xml
@@ -2,4 +2,5 @@
     <query>SELECT number % 128 FROM numbers(300000000) FORMAT Null</query>
     <query>SELECT number % 255 FROM numbers(300000000) FORMAT Null</query>
     <query>SELECT number % 256 FROM numbers(300000000) FORMAT Null</query>
+    <query>SELECT number % toNullable(number+1) FROM numbers(300000000) FORMAT Null</query>
 </test>


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Performance Improvement



### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
For better performance, try to use branch free code for numeric types for mod, intDiv etc binary Arithmetic functions, about 10% improvement.

Some tests:
This PR:
```
bigo :) select number%toNullable(number+1)  from system.numbers limit 100000000 format Null

SELECT number % toNullable(number + 1)
FROM system.numbers
LIMIT 100000000
FORMAT `Null`

Query id: f2e39673-8097-4901-b356-da295158b2b8

Ok.

0 rows in set. Elapsed: 0.464 sec. Processed 100.00 million rows, 800.00 MB (215.33 million rows/s., 1.72 GB/s.)
Peak memory usage: 4.85 MiB.

bigo :) select intDiv((number+2), toNullable(number+1)) from system.numbers limit 100000000 format Null

SELECT intDiv(number + 2, toNullable(number + 1))
FROM system.numbers
LIMIT 100000000
FORMAT `Null`

Query id: 68ccc2fe-1901-4a2b-93e9-2bff015c6781

Ok.

0 rows in set. Elapsed: 0.501 sec. Processed 100.00 million rows, 800.00 MB (199.45 million rows/s., 1.60 GB/s.)

```
Before:
```
bigo :) select number%toNullable(number+1)  from system.numbers limit 100000000 format Null

SELECT number % toNullable(number + 1)
FROM system.numbers
LIMIT 100000000
FORMAT `Null`

Query id: fe6ef3bb-2c5c-4657-ab31-e24554047643

Ok.

0 rows in set. Elapsed: 0.503 sec. Processed 100.00 million rows, 800.00 MB (198.78 million rows/s., 1.59 GB/s.)
Peak memory usage: 4.45 MiB.

bigo :) select intDiv((number+2), toNullable(number+1)) from system.numbers limit 100000000 format Null

SELECT intDiv(number + 2, toNullable(number + 1))
FROM system.numbers
LIMIT 100000000
FORMAT `Null`

Query id: 6aad59e7-6f57-48e4-b766-3a55ebd61f22

Ok.

0 rows in set. Elapsed: 0.561 sec. Processed 100.00 million rows, 800.00 MB (178.10 million rows/s., 1.42 GB/s.)

```

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---ci_include_fuzzer--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
