### PR TITLE
Disallow query cache for queries with non-throw overflow mode

### DIFF
--- a/tests/queries/0_stateless/02494_query_cache_bugs.reference
+++ b/tests/queries/0_stateless/02494_query_cache_bugs.reference
@@ -22,3 +22,24 @@ Row 1:
 ──────
 x: 1
 2
+-- Bug 67476: Queries with overflow mode != throw must not be cached by the query cache
+0
+0
+0
+0
+0
+0
+0
+0
+0
+0
+0
+0
+0
+0
+0
+0
+0
+0
+0
+0

--- a/tests/queries/0_stateless/02494_query_cache_bugs.sql
+++ b/tests/queries/0_stateless/02494_query_cache_bugs.sql
@@ -36,4 +36,32 @@ SELECT count(*) FROM system.query_cache;
 
 DROP TABLE tab;
 
+SELECT '-- Bug 67476: Queries with overflow mode != throw must not be cached by the query cache';
+
+DROP TABLE IF EXISTS tab;
+
+CREATE TABLE tab(c UInt64) ENGINE = Memory;
+
+SYSTEM DROP QUERY CACHE;
+SELECT sum(c) FROM tab SETTINGS read_overflow_mode = 'break', use_query_cache = 1;
+SELECT count(*) from system.query_cache;
+SELECT sum(c) FROM tab SETTINGS read_overflow_mode_leaf = 'break', use_query_cache = 1;
+SELECT count(*) from system.query_cache;
+SELECT sum(c) FROM tab SETTINGS group_by_overflow_mode = 'break', use_query_cache = 1;
+SELECT count(*) from system.query_cache;
+SELECT sum(c) FROM tab SETTINGS sort_overflow_mode = 'break', use_query_cache = 1;
+SELECT count(*) from system.query_cache;
+SELECT sum(c) FROM tab SETTINGS result_overflow_mode = 'break', use_query_cache = 1;
+SELECT count(*) from system.query_cache;
+SELECT sum(c) FROM tab SETTINGS timeout_overflow_mode = 'break', use_query_cache = 1;
+SELECT count(*) from system.query_cache;
+SELECT sum(c) FROM tab SETTINGS set_overflow_mode = 'break', use_query_cache = 1;
+SELECT count(*) from system.query_cache;
+SELECT sum(c) FROM tab SETTINGS join_overflow_mode = 'break', use_query_cache = 1;
+SELECT count(*) from system.query_cache;
+SELECT sum(c) FROM tab SETTINGS transfer_overflow_mode = 'break', use_query_cache = 1;
+SELECT count(*) from system.query_cache;
+SELECT sum(c) FROM tab SETTINGS distinct_overflow_mode = 'break', use_query_cache = 1;
+SELECT count(*) from system.query_cache;
+
 SYSTEM DROP QUERY CACHE;


### PR DESCRIPTION
Resolves #67476

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Usage of the query cache for queries with an overflow mode != 'throw' is now disallowed. This prevents situations where potentially truncated and incorrect query results could be stored in the query cache. (issue #67476)