### PR TITLE
Optimize complexity of part deduplication in parallel replicas announcement

### DIFF
--- a/src/Storages/MergeTree/ParallelReplicasReadingCoordinator.cpp
+++ b/src/Storages/MergeTree/ParallelReplicasReadingCoordinator.cpp
@@ -869,7 +869,7 @@ void InOrderCoordinator<mode>::doHandleInitialAllRangesAnnouncement(InitialAllRa
     /// To get rid of duplicates
     for (auto && part: announcement.description)
     {
-        auto the_same_it = all_parts_to_read.find(Part{.description = part});
+        auto the_same_it = all_parts_to_read.find(Part{.description = part, .replicas = {}});
 
         /// We have the same part - add the info about presence on the corresponding replica to it
         if (the_same_it != all_parts_to_read.end())
@@ -882,14 +882,14 @@ void InOrderCoordinator<mode>::doHandleInitialAllRangesAnnouncement(InitialAllRa
             continue;
 
         /// Look for the first part >= current
-        auto covering_it = all_parts_to_read.lower_bound(Part{.description = part});
+        auto covering_it = all_parts_to_read.lower_bound(Part{.description = part, .replicas = {}});
 
         if (covering_it != all_parts_to_read.end())
         {
             /// Checks if other part covers this one or this one covers the other
             auto is_covered_or_covering = [&part] (const Part & other)
                 {
-                    return other.description.info.contains(part.info) ||  part.info.contains(other.description.info);
+                    return other.description.info.contains(part.info) || part.info.contains(other.description.info);
                 };
 
             if (is_covered_or_covering(*covering_it))

--- a/src/Storages/MergeTree/ParallelReplicasReadingCoordinator.cpp
+++ b/src/Storages/MergeTree/ParallelReplicasReadingCoordinator.cpp
@@ -387,8 +387,8 @@ void DefaultCoordinator::initializeReadingState(InitialAllRangesAnnouncement ann
             if (intersecting_it != known_parts.end() && !intersecting_it->description.info.isDisjoint(part.info))
                 throw Exception(ErrorCodes::LOGICAL_ERROR, "Intersecting parts found in announcement");
 
-            all_parts_to_read.push_back(Part{.description = std::move(part), .replicas = {announcement.replica_num}});
             known_parts.emplace(Part{.description = part, .replicas = {}});
+            all_parts_to_read.push_back(Part{.description = std::move(part), .replicas = {announcement.replica_num}});
         }
     }
 

--- a/src/Storages/MergeTree/ParallelReplicasReadingCoordinator.cpp
+++ b/src/Storages/MergeTree/ParallelReplicasReadingCoordinator.cpp
@@ -911,6 +911,24 @@ void InOrderCoordinator<mode>::doHandleInitialAllRangesAnnouncement(InitialAllRa
         std::sort(ranges.begin(), ranges.end());
     }
 
+#ifndef NDEBUG
+    /// Double check that there are no intersecting parts
+    {
+        auto part_it = all_parts_to_read.begin();
+        auto next_part_it = part_it;
+        if (next_part_it != all_parts_to_read.end())
+            ++next_part_it;
+        while (next_part_it != all_parts_to_read.end())
+        {
+            chassert(part_it->description.info.isDisjoint(next_part_it->description.info),
+                fmt::format("Parts {} and {} intersect",
+                    part_it->description.info.getPartNameV1(), next_part_it->description.info.getPartNameV1()));
+            ++part_it;
+            ++next_part_it;
+        }
+    }
+#endif
+
     state_initialized = true;
 
     // progress_callback is not set when local plan is used for initiator

--- a/src/Storages/MergeTree/ParallelReplicasReadingCoordinator.cpp
+++ b/src/Storages/MergeTree/ParallelReplicasReadingCoordinator.cpp
@@ -917,18 +917,15 @@ void InOrderCoordinator<mode>::doHandleInitialAllRangesAnnouncement(InitialAllRa
 #ifndef NDEBUG
     /// Double check that there are no intersecting parts
     {
-        auto part_it = all_parts_to_read.begin();
-        auto next_part_it = part_it;
-        if (next_part_it != all_parts_to_read.end())
-            ++next_part_it;
-        while (next_part_it != all_parts_to_read.end())
-        {
-            chassert(part_it->description.info.isDisjoint(next_part_it->description.info),
-                fmt::format("Parts {} and {} intersect",
-                    part_it->description.info.getPartNameV1(), next_part_it->description.info.getPartNameV1()));
-            ++part_it;
-            ++next_part_it;
-        }
+        auto intersecting_part_it = std::adjacent_find(all_parts_to_read.begin(), all_parts_to_read.end(),
+            [] (const Part & lhs, const Part & rhs)
+            {
+                return !lhs.description.info.isDisjoint(rhs.description.info);
+            });
+
+        if (intersecting_part_it != all_parts_to_read.end())
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "Parts {} and {} intersect",
+                intersecting_part_it->description.info.getPartNameV1(), std::next(intersecting_part_it)->description.info.getPartNameV1());
     }
 #endif
 


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Previously the algorithmic complexity of part deduplication logic in parallel replica announcement handling was O(n^2) which could take noticeable time for tables with many part (or partitions). This change makes the complexity O(n*log(n)) 

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---ci_include_fuzzer--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
