### PR TITLE
Fix `LOGICAL_ERROR` with functions `arrayMin/Max`

### DIFF
--- a/src/Functions/array/arrayAggregation.cpp
+++ b/src/Functions/array/arrayAggregation.cpp
@@ -104,7 +104,7 @@ struct ArrayAggregateImpl
 
     static DataTypePtr getReturnType(const DataTypePtr & expression_return, const DataTypePtr & /*array_element*/)
     {
-        if (aggregate_operation == AggregateOperation::max || aggregate_operation == AggregateOperation::min)
+        if (!isNumber(expression_return->getColumnType()) && (aggregate_operation == AggregateOperation::max || aggregate_operation == AggregateOperation::min))
         {
             return expression_return;
         }

--- a/src/Functions/array/arrayAggregation.cpp
+++ b/src/Functions/array/arrayAggregation.cpp
@@ -360,7 +360,7 @@ struct ArrayAggregateImpl
 
     static ColumnPtr execute(const ColumnArray & array, ColumnPtr mapped)
     {
-        if (!mapped->isNumeric() && (aggregate_operation == AggregateOperation::max || aggregate_operation == AggregateOperation::min))
+        if (!mapped->isNumeric() && !isNumber(array.getDataPtr()->getDataType()) && (aggregate_operation == AggregateOperation::max || aggregate_operation == AggregateOperation::min))
         {
             MutableColumnPtr res;
             const auto & column = array.getDataPtr();

--- a/src/Functions/array/arrayAggregation.cpp
+++ b/src/Functions/array/arrayAggregation.cpp
@@ -104,7 +104,7 @@ struct ArrayAggregateImpl
 
     static DataTypePtr getReturnType(const DataTypePtr & expression_return, const DataTypePtr & /*array_element*/)
     {
-        if (!isNumber(expression_return->getColumnType()) && (aggregate_operation == AggregateOperation::max || aggregate_operation == AggregateOperation::min))
+        if (aggregate_operation == AggregateOperation::max || aggregate_operation == AggregateOperation::min)
         {
             return expression_return;
         }

--- a/src/Functions/array/arrayAggregation.cpp
+++ b/src/Functions/array/arrayAggregation.cpp
@@ -360,7 +360,7 @@ struct ArrayAggregateImpl
 
     static ColumnPtr execute(const ColumnArray & array, ColumnPtr mapped)
     {
-        if constexpr (aggregate_operation == AggregateOperation::max || aggregate_operation == AggregateOperation::min)
+        if (!mapped->isNumeric() && (aggregate_operation == AggregateOperation::max || aggregate_operation == AggregateOperation::min))
         {
             MutableColumnPtr res;
             const auto & column = array.getDataPtr();

--- a/tests/queries/0_stateless/01602_array_aggregation.reference
+++ b/tests/queries/0_stateless/01602_array_aggregation.reference
@@ -6,6 +6,8 @@ Array min :
 [1]
 Array max :
 [3]
+Array min with function:
+[-3]
 Table array int min
 1
 0

--- a/tests/queries/0_stateless/01602_array_aggregation.reference
+++ b/tests/queries/0_stateless/01602_array_aggregation.reference
@@ -7,7 +7,7 @@ Array min :
 Array max :
 [3]
 Array min with function:
-[-3]
+-3
 Table array int min
 1
 0

--- a/tests/queries/0_stateless/01602_array_aggregation.reference
+++ b/tests/queries/0_stateless/01602_array_aggregation.reference
@@ -6,7 +6,7 @@ Array min :
 [1]
 Array max :
 [3]
-Array min with function:
+Issue #69600
 -3
 Table array int min
 1

--- a/tests/queries/0_stateless/01602_array_aggregation.sql
+++ b/tests/queries/0_stateless/01602_array_aggregation.sql
@@ -10,7 +10,7 @@ SELECT 'Array max :';
 SELECT arrayMax([[3], [1], [2]]);
 
 SELECT 'Array min with function:';
-SELECT arrayMin(x1 -> x1 * -1, [1,2,3])
+SELECT arrayMin(x1 -> x1 * -1, [1,2,3]);
 
 DROP TABLE IF EXISTS test_aggregation;
 CREATE TABLE test_aggregation (x Array(Int)) ENGINE=TinyLog;

--- a/tests/queries/0_stateless/01602_array_aggregation.sql
+++ b/tests/queries/0_stateless/01602_array_aggregation.sql
@@ -9,7 +9,7 @@ SELECT arrayMin([[3], [1], [2]]);
 SELECT 'Array max :';
 SELECT arrayMax([[3], [1], [2]]);
 
-SELECT 'Array min with function:';
+SELECT 'Issue #69600';
 SELECT arrayMin(x1 -> x1 * -1, [1,2,3]);
 
 DROP TABLE IF EXISTS test_aggregation;

--- a/tests/queries/0_stateless/01602_array_aggregation.sql
+++ b/tests/queries/0_stateless/01602_array_aggregation.sql
@@ -9,6 +9,9 @@ SELECT arrayMin([[3], [1], [2]]);
 SELECT 'Array max :';
 SELECT arrayMax([[3], [1], [2]]);
 
+SELECT 'Array min with function:';
+SELECT arrayMin(x1 -> x1 * -1, [1,2,3])
+
 DROP TABLE IF EXISTS test_aggregation;
 CREATE TABLE test_aggregation (x Array(Int)) ENGINE=TinyLog;
 


### PR DESCRIPTION
Resolves #69600

Small disclaimer: I don't really know CH codebase, or have a real C++ experience, this is my first PR, so *any* feedback or comment is more than welcome!

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed a `LOGICAL_ERROR` in functions `arrayMin` and `arrayMax` (issue #69600)