### PR TITLE
Fix wrong type of maximum amount of reconnect attempts to NATS server

### DIFF
--- a/docs/en/engines/table-engines/integrations/nats.md
+++ b/docs/en/engines/table-engines/integrations/nats.md
@@ -55,7 +55,7 @@ Optional parameters:
 - `nats_schema` – Parameter that must be used if the format requires a schema definition. For example, [Cap’n Proto](https://capnproto.org/) requires the path to the schema file and the name of the root `schema.capnp:Message` object.
 - `nats_num_consumers` – The number of consumers per table. Default: `1`. Specify more consumers if the throughput of one consumer is insufficient.
 - `nats_queue_group` – Name for queue group of NATS subscribers. Default is the table name.
-- `nats_max_reconnect` – Maximum amount of reconnection attempts per try to connect to NATS. Default: `5`.
+- `nats_max_reconnect` – Maximum amount of reconnection attempts per try to connect to NATS. If negative, then it will never give up trying to reconnect. Default: `5`.
 - `nats_reconnect_wait` – Amount of time in milliseconds to sleep between each reconnect attempt. Default: `5000`.
 - `nats_server_list` - Server list for connection. Can be specified to connect to NATS cluster.
 - `nats_skip_broken_messages` - NATS message parser tolerance to schema-incompatible messages per block. Default: `0`. If `nats_skip_broken_messages = N` then the engine skips *N* NATS messages that cannot be parsed (a message equals a row of data).

--- a/src/Storages/NATS/NATSSettings.h
+++ b/src/Storages/NATS/NATSSettings.h
@@ -16,7 +16,7 @@ class ASTStorage;
     M(UInt64, nats_num_consumers, 1, "The number of consumer channels per table.", 0) \
     M(String, nats_queue_group, "", "Name for queue group of NATS subscribers.", 0) \
     M(Bool, nats_secure, false, "Use SSL connection", 0) \
-    M(UInt64, nats_max_reconnect, 5, "Maximum amount of reconnection attempts.", 0) \
+    M(Int64, nats_max_reconnect, 5, "Maximum amount of reconnection attempts. If negative, then it will never give up trying to reconnect.", 0) \
     M(UInt64, nats_reconnect_wait, 2000, "Amount of time in milliseconds to sleep between each reconnect attempt.", 0) \
     M(String, nats_server_list, "", "Server list for connection", 0) \
     M(UInt64, nats_skip_broken_messages, 0, "Skip at least this number of broken messages from NATS per block", 0) \


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix wrong type of maximum amount of reconnect attempts to NATS server

### Documentation entry for user-facing changes
- [x] Documentation is written

### Motivation:
There is currently no way to set an infinite number of reconnection attempts to the NATS server, but nats-io client library [support this feature](https://docs.nats.io/using-nats/developer/connecting/reconnect): 

_* MaxReconnect int_

_MaxReconnect sets the number of reconnect attempts that will be tried before giving up. **If negative, then it will never give up trying to reconnect.** Default is 60_

I'm also suggesting to use "-1" as the default value for _nats_max_reconnect_

Thank you.