### PR TITLE
Prohibit `ALTER TABLE ... ADD INDEX ... TYPE` inverted if setting = 0

### DIFF
--- a/src/Storages/AlterCommands.cpp
+++ b/src/Storages/AlterCommands.cpp
@@ -1142,6 +1142,16 @@ bool AlterCommands::hasFullTextIndex(const StorageInMemoryMetadata & metadata)
     return false;
 }
 
+bool AlterCommands::hasLegacyInvertedIndex(const StorageInMemoryMetadata & metadata)
+{
+    for (const auto & index : metadata.secondary_indices)
+    {
+        if (index.type == INVERTED_INDEX_NAME)
+            return true;
+    }
+    return false;
+}
+
 bool AlterCommands::hasVectorSimilarityIndex(const StorageInMemoryMetadata & metadata)
 {
     for (const auto & index : metadata.secondary_indices)

--- a/src/Storages/AlterCommands.h
+++ b/src/Storages/AlterCommands.h
@@ -235,8 +235,9 @@ public:
     /// additional mutation command (MATERIALIZE_TTL) will be returned.
     MutationCommands getMutationCommands(StorageInMemoryMetadata metadata, bool materialize_ttl, ContextPtr context, bool with_alters=false) const;
 
-    /// Check if commands have any full-text index
+    /// Check if commands have any full-text index or a (legacy) inverted index
     static bool hasFullTextIndex(const StorageInMemoryMetadata & metadata);
+    static bool hasLegacyInvertedIndex(const StorageInMemoryMetadata & metadata);
 
     /// Check if commands have any vector similarity index
     static bool hasVectorSimilarityIndex(const StorageInMemoryMetadata & metadata);

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -3230,6 +3230,10 @@ void MergeTreeData::checkAlterIsPossible(const AlterCommands & commands, Context
         throw Exception(ErrorCodes::SUPPORT_IS_DISABLED,
                 "Experimental full-text index feature is not enabled (turn on setting 'allow_experimental_full_text_index')");
 
+    if (AlterCommands::hasLegacyInvertedIndex(new_metadata) && !settings.allow_experimental_inverted_index)
+        throw Exception(ErrorCodes::SUPPORT_IS_DISABLED,
+                "Experimental inverted index feature is not enabled (turn on setting 'allow_experimental_inverted_index')");
+
     if (AlterCommands::hasVectorSimilarityIndex(new_metadata) && !settings.allow_experimental_vector_similarity_index)
         throw Exception(ErrorCodes::SUPPORT_IS_DISABLED,
             "Experimental vector similarity index is disabled (turn on setting 'allow_experimental_vector_similarity_index')");

--- a/tests/queries/0_stateless/02346_inverted_index_experimental_flag.sql
+++ b/tests/queries/0_stateless/02346_inverted_index_experimental_flag.sql
@@ -1,16 +1,60 @@
--- Tests that the inverted index can only be supported when allow_experimental_full_text_index = 1.
-
-SET allow_experimental_full_text_index = 0;
+-- Tests that CREATE TABLE and ADD INDEX respect settings 'allow_experimental_full_text_index' and `allow_experimental_inverted_index`
 
 DROP TABLE IF EXISTS tab;
-CREATE TABLE tab
-(
-    `key` UInt64,
-    `str` String
-)
-ENGINE = MergeTree
-ORDER BY key;
 
-ALTER TABLE tab ADD INDEX inv_idx(str) TYPE full_text(0); -- { serverError SUPPORT_IS_DISABLED }
+-- Test CREATE TABLE + full_text index setting
 
+SET allow_experimental_full_text_index = 0;
+CREATE TABLE tab (id UInt32, str String, INDEX idx str TYPE full_text(0)) ENGINE = MergeTree ORDER BY tuple(); -- { serverError SUPPORT_IS_DISABLED }
+CREATE TABLE tab (id UInt32, str String, INDEX idx str TYPE inverted(0)) ENGINE = MergeTree ORDER BY tuple(); -- { serverError ILLEGAL_INDEX }
+
+SET allow_experimental_full_text_index = 1;
+CREATE TABLE tab (id UInt32, str String, INDEX idx str TYPE full_text(0)) ENGINE = MergeTree ORDER BY tuple();
+CREATE TABLE tab (id UInt32, str String, INDEX idx str TYPE inverted(0)) ENGINE = MergeTree ORDER BY tuple(); -- { serverError ILLEGAL_INDEX }
 DROP TABLE tab;
+
+SET allow_experimental_full_text_index = 0; -- reset to default
+
+-- Test CREATE TABLE + inverted index setting
+
+SET allow_experimental_inverted_index = 0;
+CREATE TABLE tab (id UInt32, str String, INDEX idx str TYPE full_text(0)) ENGINE = MergeTree ORDER BY tuple(); -- { serverError SUPPORT_IS_DISABLED }
+CREATE TABLE tab (id UInt32, str String, INDEX idx str TYPE inverted(0)) ENGINE = MergeTree ORDER BY tuple(); -- { serverError ILLEGAL_INDEX }
+
+SET allow_experimental_inverted_index = 1;
+CREATE TABLE tab (id UInt32, str String, INDEX idx str TYPE full_text(0)) ENGINE = MergeTree ORDER BY tuple(); -- { serverError SUPPORT_IS_DISABLED }
+CREATE TABLE tab (id UInt32, str String, INDEX idx str TYPE inverted(0)) ENGINE = MergeTree ORDER BY tuple();
+DROP TABLE tab;
+
+SET allow_experimental_inverted_index = 0; -- reset to default
+
+-- Test ADD INDEX + full_text index setting
+
+SET allow_experimental_full_text_index = 0;
+CREATE TABLE tab (id UInt32, str String) ENGINE = MergeTree ORDER BY tuple();
+ALTER TABLE tab ADD INDEX idx1 str TYPE full_text(0);  -- { serverError SUPPORT_IS_DISABLED }
+ALTER TABLE tab ADD INDEX idx2 str TYPE inverted(0); -- { serverError SUPPORT_IS_DISABLED }
+DROP TABLE tab;
+
+SET allow_experimental_full_text_index = 1;
+CREATE TABLE tab (id UInt32, str String) ENGINE = MergeTree ORDER BY tuple();
+ALTER TABLE tab ADD INDEX idx1 str TYPE full_text(0);
+ALTER TABLE tab ADD INDEX idx2 str TYPE inverted(0); -- { serverError SUPPORT_IS_DISABLED }
+DROP TABLE tab;
+SET allow_experimental_full_text_index = 0; -- reset to default
+
+
+-- Test ADD INDEX + inverted index setting
+
+SET allow_experimental_inverted_index = 0;
+CREATE TABLE tab (id UInt32, str String) ENGINE = MergeTree ORDER BY tuple();
+ALTER TABLE tab ADD INDEX idx1 str TYPE full_text(0);  -- { serverError SUPPORT_IS_DISABLED }
+ALTER TABLE tab ADD INDEX idx2 str TYPE inverted(0); -- { serverError SUPPORT_IS_DISABLED }
+DROP TABLE tab;
+
+SET allow_experimental_inverted_index = 1;
+CREATE TABLE tab (id UInt32, str String) ENGINE = MergeTree ORDER BY tuple();
+ALTER TABLE tab ADD INDEX idx1 str TYPE full_text(0); -- { serverError SUPPORT_IS_DISABLED }
+ALTER TABLE tab ADD INDEX idx2 str TYPE inverted(0);
+DROP TABLE tab;
+SET allow_experimental_inverted_index = 0; -- reset to default


### PR DESCRIPTION
Full-text indexes and (legacy) inverted indexes can only be added if settings `enable_full_text_index` respectively `enable_inverted_index` are enabled. This applies to `CREATE TABLE` and `ALTER TABLE ... ADD INDEX`.

Unfortunately, there was a loophole ... `ALTER TABLE ... ADD INDEX` worked even if `enable_full_text_index = 0`. This PR fixes this.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)