### PR TITLE
Revert "Support more oss endpoints"

### DIFF
--- a/src/IO/S3/URI.cpp
+++ b/src/IO/S3/URI.cpp
@@ -37,7 +37,7 @@ URI::URI(const std::string & uri_, bool allow_archive_path_syntax)
     /// Case when bucket name represented in domain name of S3 URL.
     /// E.g. (https://bucket-name.s3.region.amazonaws.com/key)
     /// https://docs.aws.amazon.com/AmazonS3/latest/dev/VirtualHosting.html#virtual-hosted-style-access
-    static const RE2 virtual_hosted_style_pattern(R"(([^.]+)\.(s3express[\-a-z0-9]+|s3|cos|obs|.*oss[^\/]*|eos)([.\-][a-z0-9\-.:]+))");
+    static const RE2 virtual_hosted_style_pattern(R"((.+)\.(s3express[\-a-z0-9]+|s3|cos|obs|oss|eos)([.\-][a-z0-9\-.:]+))");
 
     /// Case when AWS Private Link Interface is being used
     /// E.g. (bucket.vpce-07a1cd78f1bd55c5f-j3a3vg6w.s3.us-east-1.vpce.amazonaws.com/bucket-name/key)

--- a/src/IO/tests/gtest_s3_uri.cpp
+++ b/src/IO/tests/gtest_s3_uri.cpp
@@ -204,14 +204,6 @@ TEST(S3UriTest, validPatterns)
         ASSERT_EQ("", uri.version_id);
         ASSERT_EQ(true, uri.is_virtual_hosted_style);
     }
-    {
-        S3::URI uri("https://bucket-test.cn-beijing-internal.oss-data-acc.aliyuncs.com/cc-2zeh496zqm0g6e09g");
-        ASSERT_EQ("https://cn-beijing-internal.oss-data-acc.aliyuncs.com", uri.endpoint);
-        ASSERT_EQ("bucket-test", uri.bucket);
-        ASSERT_EQ("cc-2zeh496zqm0g6e09g", uri.key);
-        ASSERT_EQ("", uri.version_id);
-        ASSERT_EQ(true, uri.is_virtual_hosted_style);
-    }
 }
 
 TEST(S3UriTest, versionIdChecks)


### PR DESCRIPTION
Reverts ClickHouse/ClickHouse#69400

Breaks s3 bucket names with dots. Ref: https://github.com/ClickHouse/ClickHouse/pull/69743