### PR TITLE
Improve error message DDLWorker.cpp

### DIFF
--- a/src/Interpreters/DDLWorker.cpp
+++ b/src/Interpreters/DDLWorker.cpp
@@ -1045,7 +1045,7 @@ void DDLWorker::createStatusDirs(const std::string & node_path, const ZooKeeperP
     if (is_currently_deleting)
     {
         cleanup_event->set();
-        throw Exception(ErrorCodes::UNFINISHED, "Cannot create znodes (status) for {} in keeper, "
+        throw Exception(ErrorCodes::UNFINISHED, "Cannot create znodes (status) for {} in [Zoo]Keeper, "
                         "most likely because someone is deleting it concurrently", node_path);
     }
 

--- a/src/Interpreters/DDLWorker.cpp
+++ b/src/Interpreters/DDLWorker.cpp
@@ -1045,7 +1045,7 @@ void DDLWorker::createStatusDirs(const std::string & node_path, const ZooKeeperP
     if (is_currently_deleting)
     {
         cleanup_event->set();
-        throw Exception(ErrorCodes::UNFINISHED, "Cannot create status dirs for {}, "
+        throw Exception(ErrorCodes::UNFINISHED, "Cannot create znodes (status) for {} in keeper, "
                         "most likely because someone is deleting it concurrently", node_path);
     }
 


### PR DESCRIPTION
Some users were confused by the error message and tried to find `dirs` at a local disk instead of the keeper.


### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
