### PR TITLE
Fix permanent blocked distributed sends if DROP of distributed table fails

### DIFF
--- a/src/Common/ActionBlocker.h
+++ b/src/Common/ActionBlocker.h
@@ -19,7 +19,7 @@ public:
 
     /// Temporarily blocks corresponding actions (while the returned object is alive)
     friend class ActionLock;
-    ActionLock cancel() { return ActionLock(*this); }
+    [[nodiscard]] ActionLock cancel() { return ActionLock(*this); }
 
     /// Cancel the actions forever.
     void cancelForever() { ++(*counter); }

--- a/src/Storages/StorageDistributed.cpp
+++ b/src/Storages/StorageDistributed.cpp
@@ -1295,13 +1295,15 @@ void StorageDistributed::initializeFromDisk()
 
 void StorageDistributed::shutdown(bool)
 {
-    async_insert_blocker.cancelForever();
+    auto holder = async_insert_blocker.cancel();
 
     std::lock_guard lock(cluster_nodes_mutex);
 
     LOG_DEBUG(log, "Joining background threads for async INSERT");
     cluster_nodes_data.clear();
     LOG_DEBUG(log, "Background threads for async INSERT joined");
+
+    async_insert_blocker.cancelForever();
 }
 
 void StorageDistributed::drop()


### PR DESCRIPTION
The problem is that in case of exception in
StorageDistributed::drop()/shutdown() the ActionBlocker will be blocked
forever, rewrite it by using firstly temporary holder (cancel()) and
only when everything is done cancelForever()

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix permanent blocked distributed sends if DROP of distributed table fails