### PR TITLE
add `readonly_duration` to the `system.replicas` table

### DIFF
--- a/src/Storages/MergeTree/ReplicatedMergeTreeRestartingThread.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeRestartingThread.cpp
@@ -418,7 +418,7 @@ void ReplicatedMergeTreeRestartingThread::setNotReadonly()
 
     {
         std::lock_guard lock(storage.readonly_duration_timer_mutex);
-        storage.readonly_duration_timer->reset();
+        storage.readonly_duration_timer.reset();
     }
 }
 

--- a/src/Storages/MergeTree/ReplicatedTableStatus.h
+++ b/src/Storages/MergeTree/ReplicatedTableStatus.h
@@ -26,7 +26,7 @@ struct ReplicatedTableStatus
     UInt32 total_replicas;
     UInt32 active_replicas;
     UInt64 lost_part_count;
-    UInt64 readonly_duration;
+    UInt32 readonly_start_time;
     String last_queue_update_exception;
     /// If the error has happened fetching the info from ZooKeeper, this field will be set.
     String zookeeper_exception;

--- a/src/Storages/MergeTree/ReplicatedTableStatus.h
+++ b/src/Storages/MergeTree/ReplicatedTableStatus.h
@@ -26,6 +26,7 @@ struct ReplicatedTableStatus
     UInt32 total_replicas;
     UInt32 active_replicas;
     UInt64 lost_part_count;
+    UInt64 readonly_duration;
     String last_queue_update_exception;
     /// If the error has happened fetching the info from ZooKeeper, this field will be set.
     String zookeeper_exception;

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -1,5 +1,6 @@
 #include <Core/Defines.h>
 
+#include <optional>
 #include <ranges>
 #include <chrono>
 
@@ -7095,6 +7096,11 @@ void StorageReplicatedMergeTree::getStatus(ReplicatedTableStatus & res, bool wit
     res.active_replicas = 0;
     res.lost_part_count = 0;
     res.last_queue_update_exception = getLastQueueUpdateException();
+
+    {
+        std::lock_guard lock(readonly_duration_timer_mutex);
+        res.readonly_duration = readonly_duration_timer ? readonly_duration_timer->elapsedMilliseconds() : 0;
+    }
 
     if (with_zk_fields && !res.is_session_expired)
     {

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -1,6 +1,6 @@
 #include <Core/Defines.h>
 
-#include <optional>
+#include <atomic>
 #include <ranges>
 #include <chrono>
 
@@ -7096,11 +7096,7 @@ void StorageReplicatedMergeTree::getStatus(ReplicatedTableStatus & res, bool wit
     res.active_replicas = 0;
     res.lost_part_count = 0;
     res.last_queue_update_exception = getLastQueueUpdateException();
-
-    {
-        std::lock_guard lock(readonly_duration_timer_mutex);
-        res.readonly_duration = readonly_duration_timer ? readonly_duration_timer->elapsedMilliseconds() : 0;
-    }
+    res.readonly_start_time = readonly_start_time.load(std::memory_order_relaxed);
 
     if (with_zk_fields && !res.is_session_expired)
     {

--- a/src/Storages/StorageReplicatedMergeTree.h
+++ b/src/Storages/StorageReplicatedMergeTree.h
@@ -410,8 +410,7 @@ private:
     /// If true, the table is offline and can not be written to it.
     /// This flag is managed by RestartingThread.
     std::atomic_bool is_readonly {true};
-    std::optional<Stopwatch> readonly_duration_timer;
-    mutable std::mutex readonly_duration_timer_mutex;
+    std::atomic_uint32_t readonly_start_time{0};
 
     /// If nullopt - ZooKeeper is not available, so we don't know if there is table metadata.
     /// If false - ZooKeeper is available, but there is no table metadata. It's safe to drop table in this case.

--- a/src/Storages/StorageReplicatedMergeTree.h
+++ b/src/Storages/StorageReplicatedMergeTree.h
@@ -410,6 +410,9 @@ private:
     /// If true, the table is offline and can not be written to it.
     /// This flag is managed by RestartingThread.
     std::atomic_bool is_readonly {true};
+    std::optional<Stopwatch> readonly_duration_timer;
+    mutable std::mutex readonly_duration_timer_mutex;
+
     /// If nullopt - ZooKeeper is not available, so we don't know if there is table metadata.
     /// If false - ZooKeeper is available, but there is no table metadata. It's safe to drop table in this case.
     std::optional<bool> has_metadata_in_zookeeper;

--- a/src/Storages/System/StorageSystemReplicas.cpp
+++ b/src/Storages/System/StorageSystemReplicas.cpp
@@ -4,6 +4,7 @@
 #include <Columns/ColumnString.h>
 #include <DataTypes/DataTypeString.h>
 #include <DataTypes/DataTypesNumber.h>
+#include "DataTypes/DataTypeNullable.h"
 #include <DataTypes/DataTypeDateTime.h>
 #include <DataTypes/DataTypeMap.h>
 #include <Storages/System/StorageSystemReplicas.h>
@@ -212,6 +213,7 @@ StorageSystemReplicas::StorageSystemReplicas(const StorageID & table_id_)
         { "can_become_leader",                    std::make_shared<DataTypeUInt8>(),    "Whether the replica can be a leader."},
         { "is_readonly",                          std::make_shared<DataTypeUInt8>(),    "Whether the replica is in read-only mode. This mode is turned on if the config does not have sections with ClickHouse Keeper, "
                                                                                           "if an unknown error occurred when reinitializing sessions in ClickHouse Keeper, and during session reinitialization in ClickHouse Keeper."},
+        { "readonly_duration",                    std::make_shared<DataTypeNullable>(std::make_shared<DataTypeUInt64>()), "Duration that the replica has been readonly for, in milliseconds." },
         { "is_session_expired",                   std::make_shared<DataTypeUInt8>(),    "Whether the session with ClickHouse Keeper has expired. Basically the same as `is_readonly`."},
         { "future_parts",                         std::make_shared<DataTypeUInt32>(),   "The number of data parts that will appear as the result of INSERTs or merges that haven't been done yet."},
         { "parts_to_check",                       std::make_shared<DataTypeUInt32>(),   "The number of data parts in the queue for verification. A part is put in the verification queue if there is suspicion that it might be damaged."},
@@ -527,6 +529,10 @@ Chunk SystemReplicasSource::generate()
         res_columns[col_num++]->insert(status.is_leader);
         res_columns[col_num++]->insert(status.can_become_leader);
         res_columns[col_num++]->insert(status.is_readonly);
+        if (status.readonly_duration != 0)
+            res_columns[col_num++]->insert(status.readonly_duration);
+        else
+            res_columns[col_num++]->insertDefault();
         res_columns[col_num++]->insert(status.is_session_expired);
         res_columns[col_num++]->insert(status.queue.future_parts);
         res_columns[col_num++]->insert(status.parts_to_check);

--- a/src/Storages/System/StorageSystemReplicas.cpp
+++ b/src/Storages/System/StorageSystemReplicas.cpp
@@ -201,8 +201,8 @@ StorageSystemReplicas::StorageSystemReplicas(const StorageID & table_id_)
     : IStorage(table_id_)
     , impl(std::make_unique<StorageSystemReplicasImpl>(128))
 {
-    StorageInMemoryMetadata storage_metadata;
-    storage_metadata.setColumns(ColumnsDescription({
+
+    ColumnsDescription description = {
         { "database",                             std::make_shared<DataTypeString>(),   "Database name."},
         { "table",                                std::make_shared<DataTypeString>(),   "Table name."},
         { "engine",                               std::make_shared<DataTypeString>(),   "Table engine name."},
@@ -213,7 +213,7 @@ StorageSystemReplicas::StorageSystemReplicas(const StorageID & table_id_)
         { "can_become_leader",                    std::make_shared<DataTypeUInt8>(),    "Whether the replica can be a leader."},
         { "is_readonly",                          std::make_shared<DataTypeUInt8>(),    "Whether the replica is in read-only mode. This mode is turned on if the config does not have sections with ClickHouse Keeper, "
                                                                                           "if an unknown error occurred when reinitializing sessions in ClickHouse Keeper, and during session reinitialization in ClickHouse Keeper."},
-        { "readonly_duration",                    std::make_shared<DataTypeNullable>(std::make_shared<DataTypeUInt64>()), "Duration that the replica has been readonly for, in milliseconds." },
+        { "readonly_start_time", std::make_shared<DataTypeNullable>(std::make_shared<DataTypeDateTime>()), "The timestamp when the replica transitioned into readonly mode. Null if the replica is not in readonly mode." },
         { "is_session_expired",                   std::make_shared<DataTypeUInt8>(),    "Whether the session with ClickHouse Keeper has expired. Basically the same as `is_readonly`."},
         { "future_parts",                         std::make_shared<DataTypeUInt32>(),   "The number of data parts that will appear as the result of INSERTs or merges that haven't been done yet."},
         { "parts_to_check",                       std::make_shared<DataTypeUInt32>(),   "The number of data parts in the queue for verification. A part is put in the verification queue if there is suspicion that it might be damaged."},
@@ -245,7 +245,14 @@ StorageSystemReplicas::StorageSystemReplicas(const StorageID & table_id_)
         { "last_queue_update_exception",          std::make_shared<DataTypeString>(),   "When the queue contains broken entries. Especially important when ClickHouse breaks backward compatibility between versions and log entries written by newer versions aren't parseable by old versions."},
         { "zookeeper_exception",                  std::make_shared<DataTypeString>(),   "The last exception message, got if the error happened when fetching the info from ClickHouse Keeper."},
         { "replica_is_active",                    std::make_shared<DataTypeMap>(std::make_shared<DataTypeString>(), std::make_shared<DataTypeUInt8>()), "Map between replica name and is replica active."}
-    }));
+    };
+
+    description.setAliases({
+        {"readonly_duration", std::make_shared<DataTypeNullable>(std::make_shared<DataTypeDateTime>()), "if(isNull(readonly_start_time), NULL, now() - readonly_start_time)"},
+    });
+
+    StorageInMemoryMetadata storage_metadata;
+    storage_metadata.setColumns(description);
     setInMemoryMetadata(storage_metadata);
 }
 
@@ -529,8 +536,8 @@ Chunk SystemReplicasSource::generate()
         res_columns[col_num++]->insert(status.is_leader);
         res_columns[col_num++]->insert(status.can_become_leader);
         res_columns[col_num++]->insert(status.is_readonly);
-        if (status.readonly_duration != 0)
-            res_columns[col_num++]->insert(status.readonly_duration);
+        if (status.readonly_start_time != 0)
+            res_columns[col_num++]->insert(status.readonly_start_time);
         else
             res_columns[col_num++]->insertDefault();
         res_columns[col_num++]->insert(status.is_session_expired);

--- a/src/Storages/System/StorageSystemReplicas.cpp
+++ b/src/Storages/System/StorageSystemReplicas.cpp
@@ -4,7 +4,7 @@
 #include <Columns/ColumnString.h>
 #include <DataTypes/DataTypeString.h>
 #include <DataTypes/DataTypesNumber.h>
-#include "DataTypes/DataTypeNullable.h"
+#include <DataTypes/DataTypeNullable.h>
 #include <DataTypes/DataTypeDateTime.h>
 #include <DataTypes/DataTypeMap.h>
 #include <Storages/System/StorageSystemReplicas.h>

--- a/tests/queries/0_stateless/02117_show_create_table_system.reference
+++ b/tests/queries/0_stateless/02117_show_create_table_system.reference
@@ -867,6 +867,7 @@ CREATE TABLE system.replicas
     `is_leader` UInt8,
     `can_become_leader` UInt8,
     `is_readonly` UInt8,
+    `readonly_duration` Nullable(UInt64),
     `is_session_expired` UInt8,
     `future_parts` UInt32,
     `parts_to_check` UInt32,

--- a/tests/queries/0_stateless/02117_show_create_table_system.reference
+++ b/tests/queries/0_stateless/02117_show_create_table_system.reference
@@ -867,7 +867,7 @@ CREATE TABLE system.replicas
     `is_leader` UInt8,
     `can_become_leader` UInt8,
     `is_readonly` UInt8,
-    `readonly_duration` Nullable(UInt64),
+    `readonly_start_time` Nullable(DateTime),
     `is_session_expired` UInt8,
     `future_parts` UInt32,
     `parts_to_check` UInt32,
@@ -896,7 +896,8 @@ CREATE TABLE system.replicas
     `lost_part_count` UInt64,
     `last_queue_update_exception` String,
     `zookeeper_exception` String,
-    `replica_is_active` Map(String, UInt8)
+    `replica_is_active` Map(String, UInt8),
+    `readonly_duration` Nullable(DateTime) ALIAS if(readonly_start_time IS NULL, NULL, now() - readonly_start_time)
 )
 ENGINE = SystemReplicas
 COMMENT 'Contains information and status of all table replicas on current server. Each replica is represented by a single row.'


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add new column readonly_duration to the system.replicas table. Needed to be able to distinguish actual readonly replicas from sentinel ones in alerts.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---ci_include_fuzzer--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
