### PR TITLE
Adjust fast test time limit a bit

### DIFF
--- a/tests/docker_scripts/fasttest_runner.sh
+++ b/tests/docker_scripts/fasttest_runner.sh
@@ -290,7 +290,7 @@ function run_tests
         --print-time
         --report-logs-stats
         --jobs "${NPROC}"
-        --timeout 30 # We don't want slow test being introduced again in this check
+        --timeout 45 # We don't want slow test being introduced again in this check
     )
     time clickhouse-test "${test_opts[@]}" -- "$FASTTEST_FOCUS" 2>&1 \
         | ts '%Y-%m-%d %H:%M:%S' \

--- a/tests/queries/0_stateless/01383_log_broken_table.sh
+++ b/tests/queries/0_stateless/01383_log_broken_table.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Tags: no-fasttest
+# no-fasttest: Can be slow and resource intensive
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 CLICKHOUSE_CLIENT_SERVER_LOGS_LEVEL=none

--- a/tests/queries/0_stateless/01643_merge_tree_fsync_smoke.sql
+++ b/tests/queries/0_stateless/01643_merge_tree_fsync_smoke.sql
@@ -1,4 +1,5 @@
--- Tags: no-object-storage
+-- Tags: no-object-storage, no-fasttest
+-- no-fasttest: It can be slow
 
 drop table if exists data_01643;
 

--- a/tests/queries/0_stateless/02158_proportions_ztest_cmp.sh
+++ b/tests/queries/0_stateless/02158_proportions_ztest_cmp.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Tags: no-fasttest
+# no-fasttest: Python is not so fast
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/02158_ztest_cmp.sh
+++ b/tests/queries/0_stateless/02158_ztest_cmp.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Tags: no-fasttest
+# no-fasttest: Python is not so fast
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/02294_anova_cmp.sh
+++ b/tests/queries/0_stateless/02294_anova_cmp.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# no-fasttest: Python is not so fast
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/02346_fulltext_index_search.sql
+++ b/tests/queries/0_stateless/02346_fulltext_index_search.sql
@@ -1,3 +1,6 @@
+-- Tags: no-fasttest
+-- no-fasttest: It can be slow
+
 SET allow_experimental_full_text_index = 1;
 SET log_queries = 1;
 SET merge_tree_read_split_ranges_into_intersecting_and_non_intersecting_injection_probability = 0.0;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Adjust fast test time limit a bit

It seems the adjustment in https://github.com/ClickHouse/ClickHouse/pull/69781 might have been too aggressive. For some unknown reason some runs are much slower than normal and take 3x more time (same AWS machine type) than the expected ~10 seconds per test.

Ref: https://s3.amazonaws.com/clickhouse-test-reports/69743/f2e27a0aa854cbf65677699a87d246c662257333/fast_test.html

Let's adjust it to 45 seconds for now (used to be 600) until we can revisit and keep improving the fast run.