### PR TITLE
Fix linking after settings refactoring

### DIFF
--- a/programs/odbc-bridge/tests/CMakeLists.txt
+++ b/programs/odbc-bridge/tests/CMakeLists.txt
@@ -1,2 +1,2 @@
 clickhouse_add_executable (validate-odbc-connection-string validate-odbc-connection-string.cpp ../validateODBCConnectionString.cpp)
-target_link_libraries (validate-odbc-connection-string PRIVATE clickhouse_common_io clickhouse_common_config)
+target_link_libraries (validate-odbc-connection-string PRIVATE dbms clickhouse_functions clickhouse_common_io clickhouse_common_config)

--- a/src/Common/mysqlxx/tests/CMakeLists.txt
+++ b/src/Common/mysqlxx/tests/CMakeLists.txt
@@ -1,2 +1,2 @@
 clickhouse_add_executable (mysqlxx_pool_test mysqlxx_pool_test.cpp)
-target_link_libraries (mysqlxx_pool_test PRIVATE mysqlxx clickhouse_common_config loggers_no_text_log)
+target_link_libraries (mysqlxx_pool_test PRIVATE mysqlxx dbms clickhouse_functions clickhouse_common_config loggers_no_text_log)


### PR DESCRIPTION
The linker started to complain after #69213.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)