### PR TITLE
Organizational ENVs are not inherited implicitly in workflows

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -3,6 +3,9 @@ name: CreateRelease
 concurrency:
   group: release
 
+env:
+  PYTHONUNBUFFERED: 1
+
 'on':
   workflow_dispatch:
     inputs:

--- a/.github/workflows/docker_test_images.yml
+++ b/.github/workflows/docker_test_images.yml
@@ -1,4 +1,5 @@
 name: Build docker images
+
 'on':
   workflow_call:
     inputs:
@@ -11,6 +12,9 @@ name: Build docker images
         required: false
         type: boolean
         default: false
+
+env:
+  PYTHONUNBUFFERED: 1
 
 jobs:
   DockerBuildAarch64:

--- a/.github/workflows/reusable_build_stage.yml
+++ b/.github/workflows/reusable_build_stage.yml
@@ -1,7 +1,11 @@
 ### FIXME: merge reusable_test.yml and reusable_build.yml as they are almost identical
 #          and then merge reusable_build_stage.yml and reusable_test_stage.yml
 
+env:
+  PYTHONUNBUFFERED: 1
+
 name: BuildStageWF
+
 'on':
   workflow_call:
     inputs:

--- a/.github/workflows/reusable_test_stage.yml
+++ b/.github/workflows/reusable_test_stage.yml
@@ -1,4 +1,8 @@
+env:
+  PYTHONUNBUFFERED: 1
+
 name: StageWF
+
 'on':
   workflow_call:
     inputs:


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Despite the fact that we set the org-level workflow parameter `PYTHONUNBUFFERED`, it's not inherited in workflows

#### Note
Here's an example where it doesn't work https://github.com/ClickHouse/ClickHouse/actions/runs/11060775062/job/30732016674#step:6:4

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/


#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---ci_include_fuzzer--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [x] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
