### PR TITLE
Fix ubsan issue in function sqid

### DIFF
--- a/src/Functions/sqid.cpp
+++ b/src/Functions/sqid.cpp
@@ -123,7 +123,8 @@ public:
             {
                 std::string_view sqid = col_non_const->getDataAt(i).toView();
                 std::vector<UInt64> integers = sqids.decode(String(sqid));
-                res_nested_data.insert(integers.begin(), integers.end());
+                if (!integers.empty())
+                    res_nested_data.insert(integers.begin(), integers.end());
                 res_offsets_data.push_back(res_offsets_data.back() + integers.size());
             }
         }

--- a/tests/queries/0_stateless/02933_sqid.reference
+++ b/tests/queries/0_stateless/02933_sqid.reference
@@ -5,6 +5,7 @@ XMbT	[1,2]
 86Rf07	[1,2,3]
 Td1EnWQo	[1,2,3,4]
 XMbT
+[]
 -- non-const UInt*
 Uk	[1]
 XMbT	[1,2]

--- a/tests/queries/0_stateless/02933_sqid.sql
+++ b/tests/queries/0_stateless/02933_sqid.sql
@@ -14,6 +14,7 @@ SELECT sqidEncode(1, 2) AS sqid, sqidDecode(sqid);
 SELECT sqidEncode(1, 2, 3) AS sqid, sqidDecode(sqid);
 SELECT sqidEncode(1::UInt8, 2::UInt16, 3::UInt32, 4::UInt64) AS sqid, sqidDecode(sqid);
 SELECT sqidEncode(toNullable(1), toLowCardinality(2)) AS sqid;
+SELECT sqidDecode('1');
 
 SELECT '-- non-const UInt*';
 SELECT sqidEncode(materialize(1)) AS sqid, sqidDecode(sqid);


### PR DESCRIPTION
Found by fuzzing.

The code called `PodArray::insert` with begin/end iterators of an empty `std::vector`. As per the C++ standard, both iterators are required to be equal but their exact value is arbitrary. In this case, they were both `nullptr`. `PodArray::insert` does a sanity check in debug builds (`assertNotIntersects`) which dereferences the iterators and ubsan complained. Normal builds didn't bother.

```
2024.09.27 10:41:01.876670 [ 499435 ] {2b0db728-cd74-485c-b3da-50a93b865e3e} <Debug> executeQuery: (from 127.0.0.1:57580) SELECT sqidDecode('1') (stage: Complete)
/data/ch4/contrib/llvm-project/libcxx/include/__iterator/wrap_iter.h:88:16: runtime error: reference binding to null pointer of type 'unsigned long'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /data/ch4/contrib/llvm-project/libcxx/include/__iterator/wrap_iter.h:88:16
2024.09.27 10:41:01.878689 [ 499430 ] {} <Trace> BaseDaemon: Received signal -3
2024.09.27 10:41:01.878865 [ 501426 ] {} <Fatal> BaseDaemon: ########## Short fault info ############
2024.09.27 10:41:01.878910 [ 501426 ] {} <Fatal> BaseDaemon: (version 24.10.1.1, build id: 757279B158121DAACDCEC840ED67D32C8D35F085, git hash: ad2ee0fdf753986754d372a1f0af6177cbe44c0e, architecture: x86_64) (from thread 499435) Received signal -3
2024.09.27 10:41:01.878934 [ 501426 ] {} <Fatal> BaseDaemon: Signal description: sanitizer trap
2024.09.27 10:41:01.878948 [ 501426 ] {} <Fatal> BaseDaemon: Sanitizer trap.
2024.09.27 10:41:01.878984 [ 501426 ] {} <Fatal> BaseDaemon: Stack trace: 0x000055557bb14cf7 0x000055557bf90d9d 0x00005555705f36da 0x00005555705fd0f3 0x000055557946bc94 0x000055557946ba78 0x0000555579469ed4 0x00005555706107e6 0x0000555571a15a39 0x00005555855723e3 0x0000555585571a73 0x00005555855722ec 0x000055558557410d 0x000055558557599f 0x00005555871774ea 0x00005555871478d3 0x0000555587146540 0x000055558719028c 0x000055558713afaf 0x0000555587138379 0x0000555587137bec 0x00005 55587cb3a69 0x000055558827a191 0x0000555588276d4a 0x000055558827c4e0 0x000055558827bce5 0x000055558819e4ae 0x00005555887ba230 0x00005555887b42be 0x000055558ad5b38d 0x000055558ad8e473 0x000055558f3cac58 0x000055558f3cbb2f 0x000055558f329f57 0x000055558f324fb0 0x00007ffff7c9ca94 0x00007ffff7d29c3c
2024.09.27 10:41:01.879005 [ 501426 ] {} <Fatal> BaseDaemon: ########################################
2024.09.27 10:41:01.879141 [ 501426 ] {} <Fatal> BaseDaemon: (version 24.10.1.1, build id: 757279B158121DAACDCEC840ED67D32C8D35F085, git hash: ad2ee0fdf753986754d372a1f0af6177cbe44c0e) (from thread 499435) (query_id: 2b0db728-cd74-485c-b3da-50a93b865e3e) (query: SELECT sqidDecode('1')) Received signal sanitizer trap (-3)
2024.09.27 10:41:01.879196 [ 501426 ] {} <Fatal> BaseDaemon: Sanitizer trap.
2024.09.27 10:41:01.879241 [ 501426 ] {} <Fatal> BaseDaemon: Stack trace: 0x000055557bb14cf7 0x000055557bf90d9d 0x00005555705f36da 0x00005555705fd0f3 0x000055557946bc94 0x000055557946ba78 0x0000555579469ed4 0x00005555706107e6 0x0000555571a15a39 0x00005555855723e3 0x0000555585571a73 0x00005555855722ec 0x000055558557410d 0x000055558557599f 0x00005555871774ea 0x00005555871478d3 0x0000555587146540 0x000055558719028c 0x000055558713afaf 0x0000555587138379 0x0000555587137bec 0x00005 55587cb3a69 0x000055558827a191 0x0000555588276d4a 0x000055558827c4e0 0x000055558827bce5 0x000055558819e4ae 0x00005555887ba230 0x00005555887b42be 0x000055558ad5b38d 0x000055558ad8e473 0x000055558f3cac58 0x000055558f3cbb2f 0x000055558f329f57 0x000055558f324fb0 0x00007ffff7c9ca94 0x00007ffff7d29c3c
2024.09.27 10:41:01.907697 [ 501426 ] {} <Fatal> BaseDaemon: 0. /data/ch4/src/Common/StackTrace.cpp:380: StackTrace::tryCapture() @ 0x00000000265c0cf7
2024.09.27 10:41:01.936515 [ 501426 ] {} <Fatal> BaseDaemon: 1.0. inlined from /data/ch4/src/Common/StackTrace.h:48: StackTrace
2024.09.27 10:41:01.936597 [ 501426 ] {} <Fatal> BaseDaemon: 1. /data/ch4/src/Common/SignalHandlers.cpp:186: sanitizerDeathCallback() @ 0x0000000026a3cd9d
2024.09.27 10:41:02.105934 [ 501426 ] {} <Fatal> BaseDaemon: 2. __sanitizer::Die() @ 0x000000001b09f6da
2024.09.27 10:41:02.208036 [ 501426 ] {} <Fatal> BaseDaemon: 3. ? @ 0x000000001b0a90f3
2024.09.27 10:41:02.261839 [ 501426 ] {} <Fatal> BaseDaemon: 4.0. inlined from /data/ch4/contrib/llvm-project/libcxx/include/__iterator/wrap_iter.h:88: std::__wrap_iter<unsigned long*>::operator*[abi:v15007]() const
2024.09.27 10:41:02.261930 [ 501426 ] {} <Fatal> BaseDaemon: 4. /data/ch4/src/Common/PODArray.h:303: void DB::PODArrayBase<8ul, 4096ul, Allocator<false, false>, 63ul, 64ul>::assertNotIntersects<std::__wrap_iter<unsigned long*>, std::__wrap_iter<unsigned long*>>(std::__wrap_iter<unsigned long*>, std::__wrap_iter<unsigned long*>) @ 0x0000000023f17c94
2024.09.27 10:41:02.313293 [ 501426 ] {} <Fatal> BaseDaemon: 5. /data/ch4/src/Common/PODArray.h:466: void DB::PODArray<unsigned long, 4096ul, Allocator<false, false>, 63ul, 64ul>::insertPrepare<std::__wrap_iter<unsigned long*>, std::__wrap_iter<unsigned long*>>(std::__wrap_iter<unsigned long*>, std::__wrap_iter<unsigned long*>) @ 0x0000000023f17a78
2024.09.27 10:41:02.364260 [ 501426 ] {} <Fatal> BaseDaemon: 6.0. inlined from /data/ch4/src/Common/PODArray.h:476: void DB::PODArray<unsigned long, 4096ul, Allocator<false, false>, 63ul, 64ul>::insert<std::__wrap_iter<unsigned long*>, std::__wrap_iter<unsigned long*>>(std::__wrap_iter<unsigned long*>, std::__wrap_iter<unsigned long*>)
2024.09.27 10:41:02.364360 [ 501426 ] {} <Fatal> BaseDaemon: 6. /data/ch4/src/Functions/sqid.cpp:126: DB::FunctionSqidDecode::executeImpl(std::vector<DB::ColumnWithTypeAndName, std::allocator<DB::ColumnWithTypeAndName>> const&, std::shared_ptr<DB::IDataType const> const&, unsigned long) const @ 0x0000000023f15ed4
2024.09.27 10:41:02.387295 [ 501426 ] {} <Fatal> BaseDaemon: 7. /data/ch4/src/Functions/IFunction.h:448: DB::IFunction::executeImplDryRun(std::vector<DB::ColumnWithTypeAndName, std::allocator<DB::ColumnWithTypeAndName>> const&, std::shared_ptr<DB::IDataType const> const&, unsigned long) const @ 0x000000001b0bc7e6
2024.09.27 10:41:02.654555 [ 501426 ] {} <Fatal> BaseDaemon: 8. /data/ch4/src/Functions/IFunctionAdaptors.h:28: DB::FunctionToExecutableFunctionAdaptor::executeDryRunImpl(std::vector<DB::ColumnWithTypeAndName, std::allocator<DB::ColumnWithTypeAndName>> const&, std::shared_ptr<DB::IDataType const> const&, unsigned long) const @ 0x000000001c4c1a39
2024.09.27 10:41:02.681873 [ 501426 ] {} <Fatal> BaseDaemon: 9. /data/ch4/src/Functions/IFunction.cpp:245: DB::IExecutableFunction::executeWithoutLowCardinalityColumns(std::vector<DB::ColumnWithTypeAndName, std::allocator<DB::ColumnWithTypeAndName>> const&, std::shared_ptr<DB::IDataType const> const&, unsigned long, bool) const @ 0x000000003001e3e3
2024.09.27 10:41:02.708670 [ 501426 ] {} <Fatal> BaseDaemon: 10. /data/ch4/src/Functions/IFunction.cpp:159: DB::IExecutableFunction::defaultImplementationForConstantArguments(std::vector<DB::ColumnWithTypeAndName, std::allocator<DB::ColumnWithTypeAndName>> const&, std::shared_ptr<DB::IDataType const> const&, unsigned long, bool) const @ 0x000000003001da73
2024.09.27 10:41:02.736491 [ 501426 ] {} <Fatal> BaseDaemon: 11. /data/ch4/src/Functions/IFunction.cpp:237: DB::IExecutableFunction::executeWithoutLowCardinalityColumns(std::vector<DB::ColumnWithTypeAndName, std::allocator<DB::ColumnWithTypeAndName>> const&, std::shared_ptr<DB::IDataType const> const&, unsigned long, bool) const @ 0x000000003001e2ec
2024.09.27 10:41:02.766547 [ 501426 ] {} <Fatal> BaseDaemon: 12. /data/ch4/src/Functions/IFunction.cpp:303: DB::IExecutableFunction::executeWithoutSparseColumns(std::vector<DB::ColumnWithTypeAndName, std::allocator<DB::ColumnWithTypeAndName>> const&, std::shared_ptr<DB::IDataType const> const&, unsigned long, bool) const @ 0x000000003002010d
2024.09.27 10:41:02.797091 [ 501426 ] {} <Fatal> BaseDaemon: 13. /data/ch4/src/Functions/IFunction.cpp:380: DB::IExecutableFunction::execute(std::vector<DB::ColumnWithTypeAndName, std::allocator<DB::ColumnWithTypeAndName>> const&, std::shared_ptr<DB::IDataType const> const&, unsigned long, bool) const @ 0x000000003002199f
2024.09.27 10:41:02.936897 [ 501426 ] {} <Fatal> BaseDaemon: 14. /data/ch4/src/Analyzer/Resolve/QueryAnalyzer.cpp:3476: DB::QueryAnalyzer::resolveFunction(std::shared_ptr<DB::IQueryTreeNode>&, DB::IdentifierResolveScope&) @ 0x0000000031c234ea
2024.09.27 10:41:03.089695 [ 501426 ] {} <Fatal> BaseDaemon: 15. /data/ch4/src/Analyzer/Resolve/QueryAnalyzer.cpp:3776: DB::QueryAnalyzer::resolveExpressionNode(std::shared_ptr<DB::IQueryTreeNode>&, DB::IdentifierResolveScope&, bool, bool, bool) @ 0x0000000031bf38d3
2024.09.27 10:41:03.247469 [ 501426 ] {} <Fatal> BaseDaemon: 16. /data/ch4/src/Analyzer/Resolve/QueryAnalyzer.cpp:3934: DB::QueryAnalyzer::resolveExpressionNodeList(std::shared_ptr<DB::IQueryTreeNode>&, DB::IdentifierResolveScope&, bool, bool) @ 0x0000000031bf2540
2024.09.27 10:41:03.417889 [ 501426 ] {} <Fatal> BaseDaemon: 17. /data/ch4/src/Analyzer/Resolve/QueryAnalyzer.cpp:4182: DB::QueryAnalyzer::resolveProjectionExpressionNodeList(std::shared_ptr<DB::IQueryTreeNode>&, DB::IdentifierResolveScope&) @ 0x0000000031c3c28c
2024.09.27 10:41:03.584072 [ 501426 ] {} <Fatal> BaseDaemon: 18. /data/ch4/src/Analyzer/Resolve/QueryAnalyzer.cpp:5443: DB::QueryAnalyzer::resolveQuery(std::shared_ptr<DB::IQueryTreeNode> const&, DB::IdentifierResolveScope&) @ 0x0000000031be6faf
2024.09.27 10:41:03.742102 [ 501426 ] {} <Fatal> BaseDaemon: 19. /data/ch4/src/Analyzer/Resolve/QueryAnalyzer.cpp:168: DB::QueryAnalyzer::resolve(std::shared_ptr<DB::IQueryTreeNode>&, std::shared_ptr<DB::IQueryTreeNode> const&, std::shared_ptr<DB::Context const>) @ 0x0000000031be4379
2024.09.27 10:41:03.750689 [ 501426 ] {} <Fatal> BaseDaemon: 20. /data/ch4/src/Analyzer/Resolve/QueryAnalysisPass.cpp:18: DB::QueryAnalysisPass::run(std::shared_ptr<DB::IQueryTreeNode>&, std::shared_ptr<DB::Context const>) @ 0x0000000031be3bec
2024.09.27 10:41:03.789792 [ 501426 ] {} <Fatal> BaseDaemon: 21. /data/ch4/src/Analyzer/QueryTreePassManager.cpp:185: DB::QueryTreePassManager::run(std::shared_ptr<DB::IQueryTreeNode>) @ 0x000000003275fa69
2024.09.27 10:41:03.841618 [ 501426 ] {} <Fatal> BaseDaemon: 22. /data/ch4/src/Interpreters/InterpreterSelectQueryAnalyzer.cpp:142: DB::(anonymous namespace)::buildQueryTreeAndRunPasses(std::shared_ptr<DB::IAST> const&, DB::SelectQueryOptions const&, std::shared_ptr<DB::Context const> const&, std::shared_ptr<DB::IStorage> const&) @ 0x0000000032d26191
2024.09.27 10:41:03.886106 [ 501426 ] {} <Fatal> BaseDaemon: 23. /data/ch4/src/Interpreters/InterpreterSelectQueryAnalyzer.cpp:160: DB::InterpreterSelectQueryAnalyzer::InterpreterSelectQueryAnalyzer(std::shared_ptr<DB::IAST> const&, std::shared_ptr<DB::Context const> const&, DB::SelectQueryOptions const&, std::vector<String, std::allocator<String>> const&) @ 0x0000000032d22d4a
2024.09.27 10:41:03.939316 [ 501426 ] {} <Fatal> BaseDaemon: 24. /data/ch4/contrib/llvm-project/libcxx/include/__memory/unique_ptr.h:714: std::__unique_if<DB::InterpreterSelectQueryAnalyzer>::__unique_single std::make_unique[abi:v15007]<DB::InterpreterSelectQueryAnalyzer, std::shared_ptr<DB::IAST>&, std::shared_ptr<DB::Context> const&, DB::SelectQueryOptions const&>(std::shared_ptr<DB::IAST>&, std::shared_ptr<DB::Context> const&, DB::SelectQueryOptions const&) @ 0x0000000032d 284e0
2024.09.27 10:41:03.991694 [ 501426 ] {} <Fatal> BaseDaemon: 25.0. inlined from /data/ch4/src/Interpreters/InterpreterSelectQueryAnalyzer.cpp:270: operator()
2024.09.27 10:41:03.991783 [ 501426 ] {} <Fatal> BaseDaemon: 25.1. inlined from /data/ch4/contrib/llvm-project/libcxx/include/__functional/invoke.h:394: ?
2024.09.27 10:41:03.991846 [ 501426 ] {} <Fatal> BaseDaemon: 25.2. inlined from /data/ch4/contrib/llvm-project/libcxx/include/__functional/invoke.h:470: ?
2024.09.27 10:41:03.991893 [ 501426 ] {} <Fatal> BaseDaemon: 25.3. inlined from /data/ch4/contrib/llvm-project/libcxx/include/__functional/function.h:235: ?
2024.09.27 10:41:03.991939 [ 501426 ] {} <Fatal> BaseDaemon: 25. /data/ch4/contrib/llvm-project/libcxx/include/__functional/function.h:716: ? @ 0x0000000032d27ce5
2024.09.27 10:41:04.014613 [ 501426 ] {} <Fatal> BaseDaemon: 26.0. inlined from /data/ch4/contrib/llvm-project/libcxx/include/__functional/function.h:848: ?
2024.09.27 10:41:04.014702 [ 501426 ] {} <Fatal> BaseDaemon: 26.1. inlined from /data/ch4/contrib/llvm-project/libcxx/include/__functional/function.h:1197: ?
2024.09.27 10:41:04.014765 [ 501426 ] {} <Fatal> BaseDaemon: 26. /data/ch4/src/Interpreters/InterpreterFactory.cpp:362: DB::InterpreterFactory::get(std::shared_ptr<DB::IAST>&, std::shared_ptr<DB::Context>, DB::SelectQueryOptions const&) @ 0x0000000032c4a4ae
2024.09.27 10:41:04.115761 [ 501426 ] {} <Fatal> BaseDaemon: 27. /data/ch4/src/Interpreters/executeQuery.cpp:1243: DB::executeQueryImpl(char const*, char const*, std::shared_ptr<DB::Context>, DB::QueryFlags, DB::QueryProcessingStage::Enum, DB::ReadBuffer*) @ 0x0000000033266230
2024.09.27 10:41:04.227492 [ 501426 ] {} <Fatal> BaseDaemon: 28. /data/ch4/src/Interpreters/executeQuery.cpp:1474: DB::executeQuery(String const&, std::shared_ptr<DB::Context>, DB::QueryFlags, DB::QueryProcessingStage::Enum) @ 0x00000000332602be
2024.09.27 10:41:04.308275 [ 501426 ] {} <Fatal> BaseDaemon: 29. /data/ch4/src/Server/TCPHandler.cpp:587: DB::TCPHandler::runImpl() @ 0x000000003580738d
2024.09.27 10:41:04.424278 [ 501426 ] {} <Fatal> BaseDaemon: 30. /data/ch4/src/Server/TCPHandler.cpp:2520: DB::TCPHandler::run() @ 0x000000003583a473
2024.09.27 10:41:04.436610 [ 501426 ] {} <Fatal> BaseDaemon: 31. /data/ch4/base/poco/Net/src/TCPServerConnection.cpp:43: Poco::Net::TCPServerConnection::start() @ 0x0000000039e76c58
2024.09.27 10:41:04.450910 [ 501426 ] {} <Fatal> BaseDaemon: 32. /data/ch4/base/poco/Net/src/TCPServerDispatcher.cpp:115: Poco::Net::TCPServerDispatcher::run() @ 0x0000000039e77b2f
2024.09.27 10:41:04.466158 [ 501426 ] {} <Fatal> BaseDaemon: 33. /data/ch4/base/poco/Foundation/src/ThreadPool.cpp:205: Poco::PooledThread::run() @ 0x0000000039dd5f57
2024.09.27 10:41:04.481766 [ 501426 ] {} <Fatal> BaseDaemon: 34. /data/ch4/base/poco/Foundation/src/Thread_POSIX.cpp:335: Poco::ThreadImpl::runnableEntry(void*) @ 0x0000000039dd0fb0
2024.09.27 10:41:04.481850 [ 501426 ] {} <Fatal> BaseDaemon: 35. ? @ 0x00007ffff7c9ca94
2024.09.27 10:41:04.481904 [ 501426 ] {} <Fatal> BaseDaemon: 36. ? @ 0x00007ffff7d29c3c
2024.09.27 10:41:04.481952 [ 501426 ] {} <Fatal> BaseDaemon: Integrity check of the executable skipped because the reference checksum could not be read.
2024.09.27 10:41:04.482182 [ 501426 ] {} <Fatal> BaseDaemon: No settings were changed
```

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)