### PR TITLE
Remove unused placeholder from exception message string

### DIFF
--- a/src/Access/AccessControl.cpp
+++ b/src/Access/AccessControl.cpp
@@ -623,7 +623,7 @@ AuthResult AccessControl::authenticate(const Credentials & credentials, const Po
         /// We use the same message for all authentication failures because we don't want to give away any unnecessary information for security reasons,
         /// only the log will show the exact reason.
         throw Exception(PreformattedMessage{message.str(),
-                                            "{}: Authentication failed: password is incorrect, or there is no user with such name.",
+                                            "{}: Authentication failed: password is incorrect, or there is no user with such name",
                                             std::vector<std::string>{credentials.getUserName()}},
                         ErrorCodes::AUTHENTICATION_FAILED);
     }

--- a/src/Access/AccessControl.cpp
+++ b/src/Access/AccessControl.cpp
@@ -609,7 +609,7 @@ AuthResult AccessControl::authenticate(const Credentials & credentials, const Po
         tryLogCurrentException(getLogger(), "from: " + address.toString() + ", user: " + credentials.getUserName()  + ": Authentication failed");
 
         WriteBufferFromOwnString message;
-        message << credentials.getUserName() << ": Authentication failed: password is incorrect, or there is no user with such name";
+        message << credentials.getUserName() << ": Authentication failed: password is incorrect, or there is no user with such name.";
 
         /// Better exception message for usability.
         /// It is typical when users install ClickHouse, type some password and instantly forget it.

--- a/src/Access/AccessControl.cpp
+++ b/src/Access/AccessControl.cpp
@@ -609,7 +609,7 @@ AuthResult AccessControl::authenticate(const Credentials & credentials, const Po
         tryLogCurrentException(getLogger(), "from: " + address.toString() + ", user: " + credentials.getUserName()  + ": Authentication failed");
 
         WriteBufferFromOwnString message;
-        message << credentials.getUserName() << ": Authentication failed: password is incorrect, or there is no user with such name.";
+        message << credentials.getUserName() << ": Authentication failed: password is incorrect, or there is no user with such name";
 
         /// Better exception message for usability.
         /// It is typical when users install ClickHouse, type some password and instantly forget it.

--- a/src/Access/AccessControl.cpp
+++ b/src/Access/AccessControl.cpp
@@ -623,7 +623,7 @@ AuthResult AccessControl::authenticate(const Credentials & credentials, const Po
         /// We use the same message for all authentication failures because we don't want to give away any unnecessary information for security reasons,
         /// only the log will show the exact reason.
         throw Exception(PreformattedMessage{message.str(),
-                                            "{}: Authentication failed: password is incorrect, or there is no user with such name.{}",
+                                            "{}: Authentication failed: password is incorrect, or there is no user with such name.",
                                             std::vector<std::string>{credentials.getUserName()}},
                         ErrorCodes::AUTHENTICATION_FAILED);
     }


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

`
Code: 516. DB::Exception: Received from localhost:9000. DB::Exception: user_31013ca4_7d11_11ef_929f_3f03d916124a: Authentication failed: password is incorrect, or there is no user with such name.. (AUTHENTICATION_FAILED)
`

I did not like two dots in the end of the exception message, and I think it is because of an empty placeholder, but I am not sure. Maybe something else supposed to be there.
