### PR TITLE
Minimize memory copy in port headers during pipeline construction

### DIFF
--- a/src/Core/Block.h
+++ b/src/Core/Block.h
@@ -177,6 +177,7 @@ private:
     friend class ActionsDAG;
 };
 
+using ConstBlockPtr =  std::shared_ptr<const Block>;
 using BlockPtr = std::shared_ptr<Block>;
 using Blocks = std::vector<Block>;
 using BlocksList = std::list<Block>;

--- a/src/Processors/ISimpleTransform.cpp
+++ b/src/Processors/ISimpleTransform.cpp
@@ -12,6 +12,14 @@ ISimpleTransform::ISimpleTransform(Block input_header_, Block output_header_, bo
 {
 }
 
+ISimpleTransform::ISimpleTransform(ConstBlockPtr input_header_, ConstBlockPtr output_header_, bool skip_empty_chunks_)
+    : IProcessor({std::move(input_header_)}, {std::move(output_header_)})
+    , input(inputs.front())
+    , output(outputs.front())
+    , skip_empty_chunks(skip_empty_chunks_)
+{
+}
+
 ISimpleTransform::Status ISimpleTransform::prepare()
 {
     /// Check can output.

--- a/src/Processors/ISimpleTransform.h
+++ b/src/Processors/ISimpleTransform.h
@@ -38,6 +38,7 @@ protected:
 
 public:
     ISimpleTransform(Block input_header_, Block output_header_, bool skip_empty_chunks_);
+    ISimpleTransform(ConstBlockPtr input_header_, ConstBlockPtr output_header_, bool skip_empty_chunks_);
 
     virtual void transform(Chunk &) = 0;
 

--- a/src/Processors/Port.cpp
+++ b/src/Processors/Port.cpp
@@ -11,10 +11,10 @@ namespace ErrorCodes
 void connect(OutputPort & output, InputPort & input, bool reconnect)
 {
     if (!reconnect && input.state)
-        throw Exception(ErrorCodes::LOGICAL_ERROR, "Port is already connected, (header: [{}])", input.header.dumpStructure());
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Port is already connected, (header: [{}])", input.header->dumpStructure());
 
     if (!reconnect && output.state)
-        throw Exception(ErrorCodes::LOGICAL_ERROR, "Port is already connected, (header: [{}])", output.header.dumpStructure());
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Port is already connected, (header: [{}])", output.header->dumpStructure());
 
     auto out_name = output.processor ? output.getProcessor().getName() : "null";
     auto in_name = input.processor ? input.getProcessor().getName() : "null";

--- a/src/Processors/Port.h
+++ b/src/Processors/Port.h
@@ -215,9 +215,9 @@ public:
     using Data = State::Data;
 
 
-    Port(ConstBlockPtr header_) : header(header_) { } /// NOLINT
-    Port(Block && header_) : header(std::make_shared<const Block>(std::move(header_))) { } /// NOLINT
-    Port(const Block & header_) : header(std::make_shared<const Block>(std::move(header_))) { } /// NOLINT
+    Port(ConstBlockPtr header_) : header(std::move(header_)) { } // NOLINT(google-explicit-constructor)
+    Port(Block && header_) : header(std::make_shared<const Block>(std::move(header_))) { } // NOLINT(google-explicit-constructor)
+    Port(const Block & header_) : header(std::make_shared<const Block>(header_)) { } // NOLINT(google-explicit-constructor)
     Port(Block header_, IProcessor * processor_) : header(std::make_shared<const Block>(std::move(header_))), processor(processor_) { }
 
     void setUpdateInfo(UpdateInfo * info) { update_info = info; }

--- a/src/Processors/QueryPlan/ExpressionStep.cpp
+++ b/src/Processors/QueryPlan/ExpressionStep.cpp
@@ -38,7 +38,7 @@ void ExpressionStep::transformPipeline(QueryPipelineBuilder & pipeline, const Bu
 {
     auto expression = std::make_shared<ExpressionActions>(std::move(actions_dag), settings.getActionsSettings());
 
-    pipeline.addSimpleTransform([&](const Block & header)
+    pipeline.addSimpleTransform([&](const ConstBlockPtr & header)
     {
         return std::make_shared<ExpressionTransform>(header, expression);
     });
@@ -51,7 +51,7 @@ void ExpressionStep::transformPipeline(QueryPipelineBuilder & pipeline, const Bu
                 ActionsDAG::MatchColumnsMode::Name);
         auto convert_actions = std::make_shared<ExpressionActions>(std::move(convert_actions_dag), settings.getActionsSettings());
 
-        pipeline.addSimpleTransform([&](const Block & header)
+        pipeline.addSimpleTransform([&](const ConstBlockPtr & header)
         {
             return std::make_shared<ExpressionTransform>(header, convert_actions);
         });

--- a/src/Processors/Transforms/ExpressionTransform.cpp
+++ b/src/Processors/Transforms/ExpressionTransform.cpp
@@ -1,5 +1,7 @@
+#include <memory>
 #include <Processors/Transforms/ExpressionTransform.h>
 #include <Interpreters/ExpressionActions.h>
+#include <Core/Block.h>
 
 
 namespace DB
@@ -10,6 +12,12 @@ Block ExpressionTransform::transformHeader(const Block & header, const ActionsDA
     return expression.updateHeader(header);
 }
 
+
+ExpressionTransform::ExpressionTransform(const ConstBlockPtr & header_, ExpressionActionsPtr expression_)
+    : ISimpleTransform(header_, std::make_shared<const Block>(transformHeader(*header_, expression_->getActionsDAG())), false)
+    , expression(std::move(expression_))
+{
+}
 
 ExpressionTransform::ExpressionTransform(const Block & header_, ExpressionActionsPtr expression_)
     : ISimpleTransform(header_, transformHeader(header_, expression_->getActionsDAG()), false)

--- a/src/Processors/Transforms/ExpressionTransform.cpp
+++ b/src/Processors/Transforms/ExpressionTransform.cpp
@@ -1,7 +1,7 @@
-#include <memory>
 #include <Processors/Transforms/ExpressionTransform.h>
 #include <Interpreters/ExpressionActions.h>
 #include <Core/Block.h>
+#include <memory>
 
 
 namespace DB

--- a/src/Processors/Transforms/ExpressionTransform.h
+++ b/src/Processors/Transforms/ExpressionTransform.h
@@ -1,6 +1,7 @@
 #pragma once
-#include <Processors/Transforms/ExceptionKeepingTransform.h>
 #include <Processors/ISimpleTransform.h>
+#include <Processors/Transforms/ExceptionKeepingTransform.h>
+#include "Core/Block.h"
 
 namespace DB
 {
@@ -18,10 +19,8 @@ class ActionsDAG;
 class ExpressionTransform final : public ISimpleTransform
 {
 public:
-    ExpressionTransform(
-            const Block & header_,
-            ExpressionActionsPtr expression_);
-
+    ExpressionTransform(const Block & header_, ExpressionActionsPtr expression_);
+    ExpressionTransform(const ConstBlockPtr & header_, ExpressionActionsPtr expression_);
     String getName() const override { return "ExpressionTransform"; }
 
     static Block transformHeader(const Block & header, const ActionsDAG & expression);

--- a/src/Processors/Transforms/ExpressionTransform.h
+++ b/src/Processors/Transforms/ExpressionTransform.h
@@ -1,7 +1,7 @@
 #pragma once
 #include <Processors/ISimpleTransform.h>
 #include <Processors/Transforms/ExceptionKeepingTransform.h>
-#include "Core/Block.h"
+#include <Core/Block.h>
 
 namespace DB
 {

--- a/src/QueryPipeline/Pipe.h
+++ b/src/QueryPipeline/Pipe.h
@@ -1,9 +1,10 @@
 #pragma once
 
 #include <Processors/IProcessor.h>
-#include <QueryPipeline/QueryPlanResourceHolder.h>
 #include <QueryPipeline/Chain.h>
+#include <QueryPipeline/QueryPlanResourceHolder.h>
 #include <QueryPipeline/SizeLimits.h>
+#include "Core/Block.h"
 
 
 namespace DB
@@ -83,10 +84,14 @@ public:
 
     using ProcessorGetter = std::function<ProcessorPtr(const Block & header)>;
     using ProcessorGetterWithStreamKind = std::function<ProcessorPtr(const Block & header, StreamType stream_type)>;
+    using ProcessorGetterSharedHeader = std::function<ProcessorPtr(const ConstBlockPtr & header)>;
+    using ProcessorGetterSharedHeaderWithStreamKind = std::function<ProcessorPtr(const ConstBlockPtr & header, StreamType stream_type)>;
 
     /// Add transform with single input and single output for each port.
     void addSimpleTransform(const ProcessorGetter & getter);
     void addSimpleTransform(const ProcessorGetterWithStreamKind & getter);
+    void addSimpleTransform(const ProcessorGetterSharedHeader & getter);
+    void addSimpleTransform(const ProcessorGetterSharedHeaderWithStreamKind & getter);
 
     /// Add chain to every output port.
     void addChains(std::vector<Chain> chains);

--- a/src/QueryPipeline/Pipe.h
+++ b/src/QueryPipeline/Pipe.h
@@ -4,7 +4,7 @@
 #include <QueryPipeline/Chain.h>
 #include <QueryPipeline/QueryPlanResourceHolder.h>
 #include <QueryPipeline/SizeLimits.h>
-#include "Core/Block.h"
+#include <Core/Block.h>
 
 
 namespace DB

--- a/src/QueryPipeline/QueryPipelineBuilder.cpp
+++ b/src/QueryPipeline/QueryPipelineBuilder.cpp
@@ -135,6 +135,18 @@ void QueryPipelineBuilder::addSimpleTransform(const Pipe::ProcessorGetterWithStr
     pipe.addSimpleTransform(getter);
 }
 
+void QueryPipelineBuilder::addSimpleTransform(const Pipe::ProcessorGetterSharedHeader & getter)
+{
+    checkInitializedAndNotCompleted();
+    pipe.addSimpleTransform(getter);
+}
+
+void QueryPipelineBuilder::addSimpleTransform(const Pipe::ProcessorGetterSharedHeaderWithStreamKind & getter)
+{
+    checkInitializedAndNotCompleted();
+    pipe.addSimpleTransform(getter);
+}
+
 void QueryPipelineBuilder::addTransform(ProcessorPtr transform)
 {
     checkInitializedAndNotCompleted();

--- a/src/QueryPipeline/QueryPipelineBuilder.h
+++ b/src/QueryPipeline/QueryPipelineBuilder.h
@@ -64,6 +64,8 @@ public:
     /// Add transform with simple input and simple output for each port.
     void addSimpleTransform(const Pipe::ProcessorGetter & getter);
     void addSimpleTransform(const Pipe::ProcessorGetterWithStreamKind & getter);
+    void addSimpleTransform(const Pipe::ProcessorGetterSharedHeader & getter);
+    void addSimpleTransform(const Pipe::ProcessorGetterSharedHeaderWithStreamKind & getter);
     /// Add transform with getNumStreams() input ports.
     void addTransform(ProcessorPtr transform);
     void addTransform(ProcessorPtr transform, InputPort * totals, InputPort * extremes);
@@ -107,9 +109,9 @@ public:
     /// Unite several pipelines together. Result pipeline would have common_header structure.
     /// If collector is used, it will collect only newly-added processors, but not processors from pipelines.
     static QueryPipelineBuilder unitePipelines(
-            std::vector<std::unique_ptr<QueryPipelineBuilder>> pipelines,
-            size_t max_threads_limit = 0,
-            Processors * collected_processors = nullptr);
+        std::vector<std::unique_ptr<QueryPipelineBuilder>> pipelines,
+        size_t max_threads_limit = 0,
+        Processors * collected_processors = nullptr);
 
     static QueryPipelineBuilderPtr mergePipelines(
         QueryPipelineBuilderPtr left,


### PR DESCRIPTION
This PR introduces an optimization to reduce memory copying within the Port header during the construction of the pipeline graph. The core change involves modifying the header type in `Port.h` from an owning type to a `const shared_ptr<const Block>`,  which will significantly reduce memory copying when building expression on tables with huge columns.

1. The member `header` type in `Port.h` is now a `const shared_ptr<const Block>`, which allows for shared ownership and immutability. Profiling indicated that `Port` instances were frequently cloned, and this change will improve the performance.

2. `IProcessor` instances contain both `input_ports` and `output_ports`. When chaining processors using `AddSimpleTransform`, the output ports of the previous processor share the same header as the input ports of the next processor. This PR ensures that these headers can share the same reference, reducing the number of unnecessary cloning operations by `N * num_streams`.

3. The use of `const shared_ptr<const Block>` ensures stricter immutability compared to the previous implementation, providing additional safety guarantees enforced by the compiler.

4. Transitioning all occurrences to the new port header style is a substantial task. To facilitate this, the PR introduces `AddSimpleTransform` method overloads in `Pipe` and `QueryPipelineBuilder`, enabling an incremental adaptation process. An example of this implementation can be seen in `ExpressionStep::transformPipeline`, which effectively reduces header copying by num_streams times.

### Changelog category (leave one):
- Performance Improvement



### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Minimize memory copy in port headers during pipeline construction


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---ci_include_fuzzer--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
