### PR TITLE
Fixed MaterializedPostgreSQL for subset of columns for several similar table names

### DIFF
--- a/src/Storages/PostgreSQL/PostgreSQLReplicationHandler.cpp
+++ b/src/Storages/PostgreSQL/PostgreSQLReplicationHandler.cpp
@@ -723,16 +723,21 @@ Strings PostgreSQLReplicationHandler::getTableAllowedColumns(const std::string &
     if (tables_list.empty())
         return result;
 
-    size_t table_pos = tables_list.find(table_name);
-    if (table_pos == std::string::npos)
+    size_t table_pos = 0;
+    while (true)
     {
-        return result;
+        table_pos = tables_list.find(table_name, table_pos + 1);
+        if (table_pos == std::string::npos)
+            return result;
+        if (table_pos + table_name.length() + 1 > tables_list.length())
+            return result;
+        if (tables_list[table_pos + table_name.length() + 1] == '(' ||
+            tables_list[table_pos + table_name.length() + 1] == ',' ||
+            tables_list[table_pos + table_name.length() + 1] == ' '
+        )
+            break;
     }
 
-    if (table_pos + table_name.length() + 1 > tables_list.length())
-    {
-        return result;
-    }
     String column_list = tables_list.substr(table_pos + table_name.length() + 1);
     column_list.erase(std::remove(column_list.begin(), column_list.end(), '"'), column_list.end());
     boost::trim(column_list);


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed #69092: if `materialized_postgresql_tables_list=table1(id, code),table(id,name)` (`table1` has name that is a substring for `table`)  `getTableAllowedColumns` method returns `[id, code]` for `table` before this fix.

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---ci_include_fuzzer--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
