### PR TITLE
Fix mutations involving virtual columns by propagating virtual column…

### DIFF
--- a/src/Interpreters/MutationsInterpreter.h
+++ b/src/Interpreters/MutationsInterpreter.h
@@ -136,7 +136,8 @@ public:
             const StorageMetadataPtr & snapshot_,
             const ContextPtr & context_,
             bool apply_deleted_mask_,
-            bool can_execute_) const;
+            bool can_execute_,
+            const Names & needed_virtual_columns) const;
 
         explicit Source(StoragePtr storage_);
         Source(MergeTreeData & storage_, MergeTreeData::DataPartPtr source_part_, AlterConversionsPtr alter_conversions_);
@@ -159,6 +160,10 @@ private:
         ContextPtr context_,
         Settings settings_);
 
+    bool isVirtualColumn(const String & column_name) const;
+    Names extractVirtualColumnsFromAST(const ASTPtr & ast) const;
+
+
     void prepare(bool dry_run);
 
     void initQueryPlan(Stage & first_stage, QueryPlan & query_plan);
@@ -176,6 +181,8 @@ private:
     ContextPtr context;
     Settings settings;
     SelectQueryOptions select_limits;
+
+    Names virtual_columns_needed;
 
     LoggerPtr logger;
 

--- a/src/Storages/MergeTree/MergeTreeSequentialSource.cpp
+++ b/src/Storages/MergeTree/MergeTreeSequentialSource.cpp
@@ -39,7 +39,8 @@ public:
         std::optional<MarkRanges> mark_ranges_,
         bool apply_deleted_mask,
         bool read_with_direct_io_,
-        bool prefetch);
+        bool prefetch,
+        const Names & virtual_columns_needed);
 
     ~MergeTreeSequentialSource() override;
 
@@ -96,7 +97,8 @@ MergeTreeSequentialSource::MergeTreeSequentialSource(
     std::optional<MarkRanges> mark_ranges_,
     bool apply_deleted_mask,
     bool read_with_direct_io_,
-    bool prefetch)
+    bool prefetch,
+    const Names & virtual_columns_needed)
     : ISource(storage_snapshot_->getSampleBlockForColumns(columns_to_read_))
     , storage(storage_)
     , storage_snapshot(storage_snapshot_)
@@ -128,7 +130,6 @@ MergeTreeSequentialSource::MergeTreeSequentialSource(
 
     auto options = GetColumnsOptions(GetColumnsOptions::AllPhysical)
         .withExtendedObjects()
-        .withVirtuals()
         .withSubcolumns(storage.supportsSubcolumns());
 
     auto columns_for_reader = storage_snapshot->getColumnsByNames(options, columns_to_read);
@@ -170,7 +171,7 @@ MergeTreeSequentialSource::MergeTreeSequentialSource(
         columns_for_reader,
         storage_snapshot,
         *mark_ranges,
-        /*virtual_fields=*/ {},
+        virtual_columns_needed,
         /*uncompressed_cache=*/ {},
         mark_cache.get(),
         alter_conversions,
@@ -360,7 +361,8 @@ public:
         bool read_with_direct_io_,
         bool prefetch_,
         ContextPtr context_,
-        LoggerPtr log_)
+        LoggerPtr log_,
+        const Names virtual_columns_needed_)
         : ISourceStep(DataStream{.header = storage_snapshot_->getSampleBlockForColumns(columns_to_read_)})
         , type(type_)
         , storage(storage_)
@@ -375,6 +377,7 @@ public:
         , prefetch(prefetch_)
         , context(std::move(context_))
         , log(log_)
+        , virtual_columns_needed(virtual_columns_needed_)
     {
     }
 
@@ -419,7 +422,8 @@ public:
             filtered_rows_count,
             apply_deleted_mask,
             read_with_direct_io,
-            prefetch);
+            prefetch,
+            virtual_columns_needed);
 
         pipeline.init(Pipe(std::move(source)));
     }
@@ -438,6 +442,7 @@ private:
     const bool prefetch;
     const ContextPtr context;
     const LoggerPtr log;
+    const Names virtual_columns_needed;
 };
 
 void createReadFromPartStep(
@@ -454,7 +459,8 @@ void createReadFromPartStep(
     bool read_with_direct_io,
     bool prefetch,
     ContextPtr context,
-    LoggerPtr log)
+    LoggerPtr log,
+    const Names & virtual_columns_needed)
 {
     auto reading = std::make_unique<ReadFromPart>(
         type,
@@ -469,7 +475,8 @@ void createReadFromPartStep(
         read_with_direct_io,
         prefetch,
         std::move(context),
-        log);
+        log,
+        virtual_columns_needed);
 
     plan.addStep(std::move(reading));
 }

--- a/src/Storages/MergeTree/MergeTreeSequentialSource.h
+++ b/src/Storages/MergeTree/MergeTreeSequentialSource.h
@@ -45,6 +45,7 @@ void createReadFromPartStep(
     bool read_with_direct_io,
     bool prefetch,
     ContextPtr context,
-    LoggerPtr log);
+    LoggerPtr log,
+    const Names & virtual_columns_needed);
 
 }


### PR DESCRIPTION
…s needed

This change fixes an issue where mutations involving virtual columns (e.g., _part_offset) fail with a logical error because the virtual columns are not being read during mutation execution.

To resolve this issue, the following modifications have been made:

- **Extract Virtual Columns in `MutationsInterpreter::prepare`:**
  - Implemented helper functions `isVirtualColumn` and `extractVirtualColumnsFromAST` to identify virtual columns used in mutation conditions.
  - Collected virtual columns from mutation predicates and stored them in the `virtual_columns_needed` member variable.

- **Propagate `virtual_columns_needed` Down the Execution Pipeline:**
  - Updated `MutationsInterpreter::initQueryPlan` to pass `virtual_columns_needed` to `Source::read`.
  - Modified `MutationsInterpreter::Source::read` to accept `virtual_columns_needed` and pass it to `createReadFromPartStep`.
  - Adjusted `createReadFromPartStep` and `ReadFromPart` to handle `virtual_columns_needed`.
  - Updated `MergeTreeSequentialSource` constructor to accept `virtual_columns_needed` and use it when initializing the reader.

- **Ensure Data Reader Fills Virtual Columns:**
  - By passing `virtual_columns_needed` to the data reader, ensured that virtual columns are correctly filled during data reading.

**Testing:**

- Rebuilt ClickHouse and verified that mutations involving virtual columns execute without errors.
- Test case:

  ```sql CREATE TABLE tab (id UInt64, num UInt64) Engine = MergeTree ORDER BY id; INSERT INTO tab SELECT number, number * 2 FROM numbers(5); ALTER TABLE tab DELETE WHERE _part_offset < 3 SETTINGS mutations_sync=1; SELECT * FROM tab;

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
This change fixes an issue where mutations involving virtual columns (e.g., _part_offset) fail with a logical error because the virtual columns are not being read during mutation execution.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---ci_include_fuzzer--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
