### PR TITLE
Silence UBSAN for integer overflows in some datetime functions

### DIFF
--- a/tests/queries/0_stateless/02477_age_date32.reference
+++ b/tests/queries/0_stateless/02477_age_date32.reference
@@ -167,6 +167,7 @@ SELECT age('day', materialize(toDate32('2015-08-18', 'UTC')), materialize(toDate
 1
 SELECT age('day', materialize(toDate('2015-08-18', 'UTC')), materialize(toDate32('2015-08-19', 'UTC')), 'UTC');
 1
+-- UBsan issue detected by fuzzer
 SELECT age('minute', toDate32(1234567890123456, 'UTC'), toDateTime64('1927-01-02 00:00:00', 3, 'UTC'), 'UTC')
 
 -196176960

--- a/tests/queries/0_stateless/02477_age_date32.reference
+++ b/tests/queries/0_stateless/02477_age_date32.reference
@@ -167,3 +167,6 @@ SELECT age('day', materialize(toDate32('2015-08-18', 'UTC')), materialize(toDate
 1
 SELECT age('day', materialize(toDate('2015-08-18', 'UTC')), materialize(toDate32('2015-08-19', 'UTC')), 'UTC');
 1
+SELECT age('minute', toDate32(1234567890123456, 'UTC'), toDateTime64('1927-01-02 00:00:00', 3, 'UTC'), 'UTC')
+
+-196176960

--- a/tests/queries/0_stateless/02477_age_date32.sql
+++ b/tests/queries/0_stateless/02477_age_date32.sql
@@ -99,3 +99,5 @@ SELECT age('day', materialize(toDate32('2015-08-18', 'UTC')), materialize(toDate
 SELECT age('day', materialize(toDateTime('2015-08-18 00:00:00', 'UTC')), materialize(toDate32('2015-08-19', 'UTC')), 'UTC');
 SELECT age('day', materialize(toDate32('2015-08-18', 'UTC')), materialize(toDate('2015-08-19', 'UTC')), 'UTC');
 SELECT age('day', materialize(toDate('2015-08-18', 'UTC')), materialize(toDate32('2015-08-19', 'UTC')), 'UTC');
+
+SELECT age('minute', toDate32(1234567890123456, 'UTC'), toDateTime64('1927-01-02 00:00:00', 3, 'UTC'), 'UTC')

--- a/tests/queries/0_stateless/02477_age_date32.sql
+++ b/tests/queries/0_stateless/02477_age_date32.sql
@@ -100,4 +100,5 @@ SELECT age('day', materialize(toDateTime('2015-08-18 00:00:00', 'UTC')), materia
 SELECT age('day', materialize(toDate32('2015-08-18', 'UTC')), materialize(toDate('2015-08-19', 'UTC')), 'UTC');
 SELECT age('day', materialize(toDate('2015-08-18', 'UTC')), materialize(toDate32('2015-08-19', 'UTC')), 'UTC');
 
+-- UBsan issue detected by fuzzer
 SELECT age('minute', toDate32(1234567890123456, 'UTC'), toDateTime64('1927-01-02 00:00:00', 3, 'UTC'), 'UTC')


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Similar to https://github.com/ClickHouse/ClickHouse/pull/66831

https://s3.amazonaws.com/clickhouse-test-reports/60669/75a84b4ab16b189c64deb1520344028bec91970b/ast_fuzzer__ubsan_.html

Query from fuzzer:
```sql
SELECT toLowCardinality(toNullable('x')), age('minute', toDate32(xxHash64([10, 10])), toDateTime64(toFixedString('1927-01-02 00:00:00', 19), 3, 'UTC')) GROUP BY    toFixedString(toFixedString(toFixedString('1927-01-02', 10), 10), 10), [xxHash64('x', 1, 1, toLowCardinality(1), [10, 23, 10])], xxHash64('x', 1, 1, toNullable(1), 1, 1, toLowCardinality(toNullable(1))) WITH ROLLUP WITH TOTALS
```