### PR TITLE
Fix Dynamic type creation of JSON subcolumn

### DIFF
--- a/src/DataTypes/DataTypeObject.cpp
+++ b/src/DataTypes/DataTypeObject.cpp
@@ -404,7 +404,7 @@ std::unique_ptr<ISerialization::SubstreamData> DataTypeObject::getDynamicSubcolu
     else
     {
         res = std::make_unique<SubstreamData>(std::make_shared<SerializationDynamic>());
-        res->type = std::make_shared<DataTypeDynamic>();
+        res->type = std::make_shared<DataTypeDynamic>(max_dynamic_types);
     }
 
     /// If column was provided, we should create a column for requested subcolumn.

--- a/tests/queries/0_stateless/03246_json_subcolumn_correct_type.reference
+++ b/tests/queries/0_stateless/03246_json_subcolumn_correct_type.reference
@@ -1,0 +1,5 @@
+Dynamic(max_types=1)
+Dynamic(max_types=1)
+1
+1
+1

--- a/tests/queries/0_stateless/03246_json_subcolumn_correct_type.sql
+++ b/tests/queries/0_stateless/03246_json_subcolumn_correct_type.sql
@@ -1,0 +1,7 @@
+set allow_experimental_json_type=1;
+drop table if exists test;
+create table test (json JSON(max_dynamic_types=1)) engine=Memory;
+insert into test values ('{"c0" : 1}'), ('{"c0" : 2}');
+select toTypeName(json.c0) from test;
+SELECT 1 FROM (SELECT 1 AS c0) tx FULL OUTER JOIN test ON test.json.Float32 = tx.c0;
+drop table test;

--- a/tests/queries/0_stateless/03246_json_subcolumn_correct_type.sql
+++ b/tests/queries/0_stateless/03246_json_subcolumn_correct_type.sql
@@ -1,4 +1,5 @@
 set allow_experimental_json_type=1;
+set enable_analyzer=1;
 drop table if exists test;
 create table test (json JSON(max_dynamic_types=1)) engine=Memory;
 insert into test values ('{"c0" : 1}'), ('{"c0" : 2}');


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Use correct `max_types` parameter during Dynamic type creation for JSON subcolumn.

Closes https://github.com/ClickHouse/ClickHouse/issues/69762

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---ci_include_fuzzer--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
