### PR TITLE
[Docs] Correct async_insert_use_adaptive_busy_timeout

### DIFF
--- a/docs/en/operations/settings/settings.md
+++ b/docs/en/operations/settings/settings.md
@@ -2045,7 +2045,7 @@ Possible values:
 - 0 - Disabled.
 - 1 - Enabled.
 
-Default value: `0`.
+Default value: `1`.
 
 ### async_insert_busy_timeout_min_ms {#async-insert-busy-timeout-min-ms}
 


### PR DESCRIPTION
Correct setting in docs found by customer in this thread: https://clickhouse-inc.slack.com/archives/C037AU5BP37/p1727842246431829

### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
[Docs] Correct async_insert_use_adaptive_busy_timeout
