### PR TITLE
Avoid `Cannot schedule a task` error when loading parts

### DIFF
--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -2129,6 +2129,8 @@ try
 
         runner([&, my_part = part]()
         {
+            auto blocker_for_runner_thread = CannotAllocateThreadFaultInjector::blockFaultInjections();
+
             auto res = loadDataPartWithRetries(
             my_part->info, my_part->name, my_part->disk,
             DataPartState::Outdated, data_parts_mutex, loading_parts_initial_backoff_ms,

--- a/src/Storages/MergeTree/PartMetadataManagerOrdinary.cpp
+++ b/src/Storages/MergeTree/PartMetadataManagerOrdinary.cpp
@@ -11,7 +11,11 @@ namespace DB
 std::unique_ptr<ReadBuffer> PartMetadataManagerOrdinary::read(const String & file_name) const
 {
     size_t file_size = part->getDataPartStorage().getFileSize(file_name);
-    auto res = part->getDataPartStorage().readFile(file_name, getReadSettings().adjustBufferSize(file_size), file_size, std::nullopt);
+    auto read_settings = getReadSettings().adjustBufferSize(file_size);
+    /// Default read method is pread_threadpool, but there is not much point in it here.
+    read_settings.local_fs_method = LocalFSReadMethod::pread;
+
+    auto res = part->getDataPartStorage().readFile(file_name, read_settings, file_size, std::nullopt);
 
     if (isCompressedFromFileName(file_name))
         return std::make_unique<CompressedReadBufferFromFile>(std::move(res));


### PR DESCRIPTION
Fixes https://s3.amazonaws.com/clickhouse-test-reports/70114/7835b66565b481c61e535d2baee362736d2b750a/stress_test__debug_/fatal_messages.txt

```
/var/log/clickhouse-server/clickhouse-server.final.log:2024.09.30 14:13:32.972445 [ 40816 ] {} <Fatal> BaseDaemon: (version 24.10.1.857, build id: A9203E66AFE91D0AF06E8CA6A1DFF6F0CD0587CE, git hash: d106f46b94d8e82f7c32fc8f6340df57a3f64c39) (from thread 40868) Terminate called for uncaught exception:
/var/log/clickhouse-server/clickhouse-server.final.log:2024.09.30 14:13:32.972472 [ 40816 ] {} <Fatal> BaseDaemon: Code: 439. DB::Exception: Cannot schedule a task: fault injected (threads=24, jobs=0). (CANNOT_SCHEDULE_TASK), Stack trace (when copying this message, always include the lines below):
/var/log/clickhouse-server/clickhouse-server.final.log:2024.09.30 14:13:32.972525 [ 40816 ] {} <Fatal> BaseDaemon: 
/var/log/clickhouse-server/clickhouse-server.final.log:2024.09.30 14:13:32.972536 [ 40816 ] {} <Fatal> BaseDaemon: 0. /build/contrib/llvm-project/libcxx/include/exception:141: Poco::Exception::Exception(String const&, int) @ 0x00000000167b9dd2
/var/log/clickhouse-server/clickhouse-server.final.log:2024.09.30 14:13:32.972546 [ 40816 ] {} <Fatal> BaseDaemon: 1. /build/src/Common/Exception.cpp:109: DB::Exception::Exception(DB::Exception::MessageMasked&&, int, bool) @ 0x000000000c3b9e79
/var/log/clickhouse-server/clickhouse-server.final.log:2024.09.30 14:13:32.972556 [ 40816 ] {} <Fatal> BaseDaemon: 2. /build/src/Common/Exception.h:110: DB::Exception::Exception(PreformattedMessage&&, int) @ 0x00000000070bf16c
/var/log/clickhouse-server/clickhouse-server.final.log:2024.09.30 14:13:32.972572 [ 40816 ] {} <Fatal> BaseDaemon: 3. /build/src/Common/Exception.h:128: DB::Exception::Exception<String const&, unsigned long, unsigned long&>(int, FormatStringHelperImpl<std::type_identity<String const&>::type, std::type_identity<unsigned long>::type, std::type_identity<unsigned long&>::type>, String const&, unsigned long&&, unsigned long&) @ 0x000000000c4721ab
/var/log/clickhouse-server/clickhouse-server.final.log:2024.09.30 14:13:32.972584 [ 40816 ] {} <Fatal> BaseDaemon: 4. /build/src/Common/ThreadPool.cpp:202: void ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::scheduleImpl<void>(std::function<void ()>, Priority, std::optional<unsigned long>, bool)::'lambda'(String const&)::operator()(String const&) const @ 0x000000000c4741d3
/var/log/clickhouse-server/clickhouse-server.final.log:2024.09.30 14:13:32.972593 [ 40816 ] {} <Fatal> BaseDaemon: 5. /build/src/Common/ThreadPool.cpp:218: void ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::scheduleImpl<void>(std::function<void ()>, Priority, std::optional<unsigned long>, bool) @ 0x000000000c46e746
/var/log/clickhouse-server/clickhouse-server.final.log:2024.09.30 14:13:32.972604 [ 40816 ] {} <Fatal> BaseDaemon: 6. /build/src/Common/ThreadPool.cpp:325: ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::scheduleOrThrowOnError(std::function<void ()>, Priority) @ 0x000000000c46e62e
/var/log/clickhouse-server/clickhouse-server.final.log:2024.09.30 14:13:32.972617 [ 40816 ] {} <Fatal> BaseDaemon: 7. /build/src/Common/threadPoolCallbackRunner.h:59: std::function<std::future<DB::IAsynchronousReader::Result> (std::function<DB::IAsynchronousReader::Result ()>&&, Priority)> DB::threadPoolCallbackRunnerUnsafe<DB::IAsynchronousReader::Result, std::function<DB::IAsynchronousReader::Result ()>>(ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>&, String const&)::'lambda'(std::function<DB::IAsynchronousReader::Result ()>&&, Priority)::operator()(std::function<DB::IAsynchronousReader::Result ()>&&, Priority) @ 0x00000000104a129a
/var/log/clickhouse-server/clickhouse-server.final.log:2024.09.30 14:13:32.972628 [ 40816 ] {} <Fatal> BaseDaemon: 8. /build/contrib/llvm-project/libcxx/include/__functional/invoke.h:394: ? @ 0x00000000104a108f
/var/log/clickhouse-server/clickhouse-server.final.log:2024.09.30 14:13:32.972635 [ 40816 ] {} <Fatal> BaseDaemon: 9. /build/contrib/llvm-project/libcxx/include/__functional/function.h:848: ? @ 0x00000000104a02b0
/var/log/clickhouse-server/clickhouse-server.final.log:2024.09.30 14:13:32.972648 [ 40816 ] {} <Fatal> BaseDaemon: 10. /build/src/IO/AsynchronousReadBufferFromFileDescriptor.cpp:62: DB::AsynchronousReadBufferFromFileDescriptor::asyncReadInto(char*, unsigned long, Priority) @ 0x0000000010497ee2
/var/log/clickhouse-server/clickhouse-server.final.log:2024.09.30 14:13:32.972656 [ 40816 ] {} <Fatal> BaseDaemon: 11. /build/src/IO/AsynchronousReadBufferFromFileDescriptor.cpp:100: DB::AsynchronousReadBufferFromFileDescriptor::nextImpl() @ 0x00000000104981cb
/var/log/clickhouse-server/clickhouse-server.final.log:2024.09.30 14:13:32.972664 [ 40816 ] {} <Fatal> BaseDaemon: 12. /build/src/IO/ReadBuffer.h:70: DB::ReadBuffer::next() @ 0x00000000078dfffb
/var/log/clickhouse-server/clickhouse-server.final.log:2024.09.30 14:13:32.972672 [ 40816 ] {} <Fatal> BaseDaemon: 13. /build/src/IO/ReadBuffer.h:106: void DB::readEscapedStringUntilEOLInto<String>(String&, DB::ReadBuffer&) @ 0x000000000c42c38e
/var/log/clickhouse-server/clickhouse-server.final.log:2024.09.30 14:13:32.972681 [ 40816 ] {} <Fatal> BaseDaemon: 14. /build/src/Storages/MergeTree/IMergeTreeDataPart.cpp:1016: DB::IMergeTreeDataPart::loadDefaultCompressionCodec() @ 0x0000000012998873
/var/log/clickhouse-server/clickhouse-server.final.log:2024.09.30 14:13:32.972688 [ 40816 ] {} <Fatal> BaseDaemon: 15. /build/src/Storages/MergeTree/IMergeTreeDataPart.cpp:738: DB::IMergeTreeDataPart::loadColumnsChecksumsIndexes(bool, bool) @ 0x0000000012993795
/var/log/clickhouse-server/clickhouse-server.final.log:2024.09.30 14:13:32.972701 [ 40816 ] {} <Fatal> BaseDaemon: 16. /build/src/Storages/MergeTree/MergeTreeData.cpp:1472: DB::MergeTreeData::loadDataPart(DB::MergeTreePartInfo const&, String const&, std::shared_ptr<DB::IDisk> const&, DB::MergeTreeDataPartState, std::mutex&) @ 0x0000000012a41d7f
```

It started reproducing because of https://github.com/ClickHouse/ClickHouse/pull/65625

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---ci_include_fuzzer--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [ ] <!---do_not_test--> Do not test
- [x] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
