### PR TITLE
Fix use-of-uinitialized-value

### DIFF
--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -4963,7 +4963,8 @@ void MergeTreeData::addPartContributionToColumnAndSecondaryIndexSizes(const Data
         total_column_size.add(part_column_size);
     }
 
-    auto indexes_descriptions = getInMemoryMetadataPtr()->secondary_indices;
+    const auto metadata_snapshot = getInMemoryMetadataPtr();
+    auto indexes_descriptions = metadata_snapshot->secondary_indices;
     for (const auto & index : indexes_descriptions)
     {
         IndexSize & total_secondary_index_size = secondary_index_sizes[index.name];
@@ -8605,7 +8606,9 @@ void MergeTreeData::resetSerializationHints(const DataPartsLock & /*lock*/)
         .choose_kind = true,
     };
 
-    const auto & storage_columns = getInMemoryMetadataPtr()->getColumns();
+    const auto metadata_snapshot = getInMemoryMetadataPtr();
+    const auto & storage_columns = metadata_snapshot->getColumns();
+
     serialization_hints = SerializationInfoByName(storage_columns.getAllPhysical(), settings);
     auto range = getDataPartsStateRange(DataPartState::Active);
 
@@ -8616,7 +8619,8 @@ void MergeTreeData::resetSerializationHints(const DataPartsLock & /*lock*/)
 template <typename AddedParts, typename RemovedParts>
 void MergeTreeData::updateSerializationHints(const AddedParts & added_parts, const RemovedParts & removed_parts, const DataPartsLock & /*lock*/)
 {
-    const auto & storage_columns = getInMemoryMetadataPtr()->getColumns();
+    const auto metadata_snapshot = getInMemoryMetadataPtr();
+    const auto & storage_columns = metadata_snapshot->getColumns();
 
     for (const auto & part : added_parts)
         updateSerializationHintsForPart(part, storage_columns, serialization_hints, false);


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Closes #70263.