### PR TITLE
Fix context for startup scripts

### DIFF
--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -629,6 +629,7 @@ void loadStartupScripts(const Poco::Util::AbstractConfiguration & config, Contex
 
                 LOG_DEBUG(log, "Checking startup query condition `{}`", condition);
                 auto startup_context = Context::createCopy(context);
+                startup_context->makeQueryContext();
                 executeQuery(condition_read_buffer, condition_write_buffer, true, startup_context, callback, QueryFlags{ .internal = true }, std::nullopt, {});
 
                 auto result = condition_write_buffer.str();
@@ -650,6 +651,7 @@ void loadStartupScripts(const Poco::Util::AbstractConfiguration & config, Contex
 
             LOG_DEBUG(log, "Executing query `{}`", query);
             auto startup_context = Context::createCopy(context);
+            startup_context->makeQueryContext();
             executeQuery(read_buffer, write_buffer, true, startup_context, callback, QueryFlags{ .internal = true }, std::nullopt, {});
         }
     }

--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -628,7 +628,8 @@ void loadStartupScripts(const Poco::Util::AbstractConfiguration & config, Contex
                 auto condition_write_buffer = WriteBufferFromOwnString();
 
                 LOG_DEBUG(log, "Checking startup query condition `{}`", condition);
-                executeQuery(condition_read_buffer, condition_write_buffer, true, context, callback, QueryFlags{ .internal = true }, std::nullopt, {});
+                auto startup_context = Context::createCopy(context);
+                executeQuery(condition_read_buffer, condition_write_buffer, true, startup_context, callback, QueryFlags{ .internal = true }, std::nullopt, {});
 
                 auto result = condition_write_buffer.str();
 
@@ -648,7 +649,8 @@ void loadStartupScripts(const Poco::Util::AbstractConfiguration & config, Contex
             auto write_buffer = WriteBufferFromOwnString();
 
             LOG_DEBUG(log, "Executing query `{}`", query);
-            executeQuery(read_buffer, write_buffer, true, context, callback, QueryFlags{ .internal = true }, std::nullopt, {});
+            auto startup_context = Context::createCopy(context);
+            executeQuery(read_buffer, write_buffer, true, startup_context, callback, QueryFlags{ .internal = true }, std::nullopt, {});
         }
     }
     catch (...)

--- a/tests/integration/test_startup_scripts/configs/config.d/startup_scripts.xml
+++ b/tests/integration/test_startup_scripts/configs/config.d/startup_scripts.xml
@@ -13,5 +13,13 @@
         <scripts>
             <query>SELECT * FROM system.query_log LIMIT 1</query>
         </scripts>
+        <scripts>
+            <query>SELECT 1 SETTINGS skip_unavailable_shards = 1</query>
+            <condition>SELECT 1;</condition>
+        </scripts>
+        <scripts>
+            <query>SELECT 1 SETTINGS skip_unavailable_shards = 1</query>
+            <condition>SELECT 1;</condition>
+        </scripts>
     </startup_scripts>
 </clickhouse>

--- a/tests/integration/test_startup_scripts/test.py
+++ b/tests/integration/test_startup_scripts/test.py
@@ -16,6 +16,7 @@ def test_startup_scripts():
     try:
         cluster.start()
         assert node.query("SHOW TABLES") == "TestTable\n"
+        assert node.query("SELECT value, changed FROM system.settings WHERE name = 'skip_unavailable_shards'") == "0\t0\n"
 
     finally:
         cluster.shutdown()

--- a/tests/integration/test_startup_scripts/test.py
+++ b/tests/integration/test_startup_scripts/test.py
@@ -16,7 +16,12 @@ def test_startup_scripts():
     try:
         cluster.start()
         assert node.query("SHOW TABLES") == "TestTable\n"
-        assert node.query("SELECT value, changed FROM system.settings WHERE name = 'skip_unavailable_shards'") == "0\t0\n"
+        assert (
+            node.query(
+                "SELECT value, changed FROM system.settings WHERE name = 'skip_unavailable_shards'"
+            )
+            == "0\t0\n"
+        )
 
     finally:
         cluster.shutdown()


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Don't modify global settings with startup scripts. Previously, changing a setting in a startup script would change it globally.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---ci_include_fuzzer--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
