### PR TITLE
Maybe fix RabbitMQ

### DIFF
--- a/docker/test/integration/runner/misc/rabbitmq/enabled_plugins
+++ b/docker/test/integration/runner/misc/rabbitmq/enabled_plugins
@@ -1,0 +1,1 @@
+[rabbitmq_consistent_hash_exchange].

--- a/docker/test/integration/runner/misc/rabbitmq/rabbitmq.conf
+++ b/docker/test/integration/runner/misc/rabbitmq/rabbitmq.conf
@@ -13,3 +13,5 @@ ssl_options.fail_if_no_peer_cert = false
 ssl_options.cacertfile = /etc/rabbitmq/ca-cert.pem
 ssl_options.certfile = /etc/rabbitmq/server-cert.pem
 ssl_options.keyfile = /etc/rabbitmq/server-key.pem
+
+vm_memory_high_watermark.absolute = 2GB

--- a/tests/integration/compose/docker_compose_rabbitmq.yml
+++ b/tests/integration/compose/docker_compose_rabbitmq.yml
@@ -1,7 +1,9 @@
 services:
     rabbitmq1:
-        image: rabbitmq:3.12.6-alpine
+        image: rabbitmq:4.0.2-alpine
         hostname: rabbitmq1
+        environment:
+            RABBITMQ_FEATURE_FLAGS: feature_flags_v2,message_containers
         expose:
             - ${RABBITMQ_PORT:-5672}
             - ${RABBITMQ_SECURE_PORT:-5671}
@@ -14,3 +16,4 @@ services:
             - /misc/rabbitmq/ca-cert.pem:/etc/rabbitmq/ca-cert.pem
             - /misc/rabbitmq/server-cert.pem:/etc/rabbitmq/server-cert.pem
             - /misc/rabbitmq/server-key.pem:/etc/rabbitmq/server-key.pem
+            - /misc/rabbitmq/enabled_plugins:/etc/rabbitmq/enabled_plugins

--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -309,7 +309,8 @@ def check_rabbitmq_is_available(rabbitmq_id, cookie, timeout=90):
                 "await_startup",
             ),
             stderr=subprocess.STDOUT,
-            timeout=timeout)
+            timeout=timeout,
+        )
         return True
     except subprocess.CalledProcessError as e:
         # Raised if the command returns a non-zero exit code
@@ -320,8 +321,9 @@ def check_rabbitmq_is_available(rabbitmq_id, cookie, timeout=90):
         raise RuntimeError(error_message)
     except subprocess.TimeoutExpired as e:
         # Raised if the command times out
-        raise RuntimeError(f"RabbitMQ startup timed out. Output: {e.output.decode(errors='replace')}")
-
+        raise RuntimeError(
+            f"RabbitMQ startup timed out. Output: {e.output.decode(errors='replace')}"
+        )
 
 
 def rabbitmq_debuginfo(rabbitmq_id, cookie):

--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -298,19 +298,30 @@ def check_postgresql_java_client_is_available(postgresql_java_client_id):
     return p.returncode == 0
 
 
-def check_rabbitmq_is_available(rabbitmq_id, cookie):
-    p = subprocess.Popen(
-        docker_exec(
-            "-e",
-            f"RABBITMQ_ERLANG_COOKIE={cookie}",
-            rabbitmq_id,
-            "rabbitmqctl",
-            "await_startup",
-        ),
-        stdout=subprocess.PIPE,
-    )
-    p.wait(timeout=60)
-    return p.returncode == 0
+def check_rabbitmq_is_available(rabbitmq_id, cookie, timeout=90):
+    try:
+        subprocess.check_output(
+            docker_exec(
+                "-e",
+                f"RABBITMQ_ERLANG_COOKIE={cookie}",
+                rabbitmq_id,
+                "rabbitmqctl",
+                "await_startup",
+            ),
+            stderr=subprocess.STDOUT,
+            timeout=timeout)
+        return True
+    except subprocess.CalledProcessError as e:
+        # Raised if the command returns a non-zero exit code
+        error_message = (
+            f"RabbitMQ startup failed with return code {e.returncode}. "
+            f"Output: {e.output.decode(errors='replace')}"
+        )
+        raise RuntimeError(error_message)
+    except subprocess.TimeoutExpired as e:
+        # Raised if the command times out
+        raise RuntimeError(f"RabbitMQ startup timed out. Output: {e.output.decode(errors='replace')}")
+
 
 
 def rabbitmq_debuginfo(rabbitmq_id, cookie):
@@ -372,22 +383,6 @@ async def nats_connect_ssl(nats_port, user, password, ssl_ctx=None):
         tls=ssl_ctx,
     )
     return nc
-
-
-def enable_consistent_hash_plugin(rabbitmq_id, cookie):
-    p = subprocess.Popen(
-        docker_exec(
-            "-e",
-            f"RABBITMQ_ERLANG_COOKIE={cookie}",
-            rabbitmq_id,
-            "rabbitmq-plugins",
-            "enable",
-            "rabbitmq_consistent_hash_exchange",
-        ),
-        stdout=subprocess.PIPE,
-    )
-    p.communicate()
-    return p.returncode == 0
 
 
 def get_instances_dir(name):
@@ -2355,22 +2350,14 @@ class ClickHouseCluster:
         self.print_all_docker_pieces()
         self.rabbitmq_ip = self.get_instance_ip(self.rabbitmq_host)
 
-        start = time.time()
-        while time.time() - start < timeout:
-            try:
-                if check_rabbitmq_is_available(
-                    self.rabbitmq_docker_id, self.rabbitmq_cookie
-                ):
-                    logging.debug("RabbitMQ is available")
-                    if enable_consistent_hash_plugin(
-                        self.rabbitmq_docker_id, self.rabbitmq_cookie
-                    ):
-                        logging.debug("RabbitMQ consistent hash plugin is available")
-                    return True
-                time.sleep(0.5)
-            except Exception as ex:
-                logging.debug("Can't connect to RabbitMQ " + str(ex))
-                time.sleep(0.5)
+        try:
+            if check_rabbitmq_is_available(
+                self.rabbitmq_docker_id, self.rabbitmq_cookie, timeout
+            ):
+                logging.debug("RabbitMQ is available")
+                return True
+        except Exception as ex:
+            logging.debug("RabbitMQ await_startup failed", exc_info=True)
 
         try:
             with open(os.path.join(self.rabbitmq_dir, "docker.log"), "w+") as f:


### PR DESCRIPTION
### Changelog category:
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry:
Attempt to fix flaky RabbitMQ tests. Maybe closes #45160.

### Documentation entry for user-facing changes:
It seems to just time out currently – see: https://github.com/ClickHouse/ClickHouse/pull/68694#issuecomment-2390814911.

Changes: 
- Updated to the most recent RabbitMQ version (also newer Erlang, which may improve speed).
- Disabled all plugins except the one (`rabbitmq_consistent_hash_exchange`) we really need (should improve startup speed).
- Disabled all feature flags except for a few mandatory ones (should improve startup speed).
- Introduced a memory limit for RabbitMQ (just in case).
- Simplified/refactored the Python wiring for RabbitMQ readiness checks.
- Increased the timeout from 60 to 90 seconds (in a few failures i checked, the actual startup time was about 65-70 seconds, which are outliers as it usually doesn't fail).

<details>
<summary>for the record - local run</summary>

```
$ docker run --rm --name clickhouse_integration_tests_if53wt --privileged     --dns-search='.'  --volume=$(pwd)/docker/test/integration/runner/misc/rabbitmq:/misc/rabbitmq  --volume=$(pwd)/build/programs/clickhouse-odbc-bridge:/clickhouse-odbc-bridge     --volume=$(pwd)/build/programs/clickhouse:/clickhouse     --volume=$(pwd)/build/programs/clickhouse-library-bridge:/clickhouse-library-bridge     --volume=$(pwd)/programs/server:/clickhouse-config     --volume=$(pwd)/tests/integration:/ClickHouse/tests/integration     --volume=$(pwd)/utils/backupview:/ClickHouse/utils/backupview     --volume=$(pwd)/utils/grpc-client/pb2:/ClickHouse/utils/grpc-client/pb2     --volume=/run:/run/host:ro     --volume=clickhouse_integration_tests_volume:/var/lib/docker     -e DOCKER_DOTNET_CLIENT_TAG=11de0b29a15d     -e DOCKER_HELPER_TAG=634724fd9222     -e DOCKER_BASE_TAG=2d0a5b22f529     -e DOCKER_KERBERIZED_HADOOP_TAG=5105c1c1cfaa     -e DOCKER_KERBEROS_KDC_TAG=310561e6eb75     -e DOCKER_MYSQL_GOLANG_CLIENT_TAG=a63320938f8d     -e DOCKER_MYSQL_JAVA_CLIENT_TAG=807c80c2c10c     -e DOCKER_MYSQL_JS_CLIENT_TAG=d7dd5dbc48a5     -e DOCKER_MYSQL_PHP_CLIENT_TAG=99abb5178265     -e DOCKER_NGINX_DAV_TAG=b55ac9cd7519     -e DOCKER_POSTGRESQL_JAVA_CLIENT_TAG=f81480176616     -e DOCKER_PYTHON_BOTTLE_TAG=3b7722e65ba1     -e DOCKER_CLIENT_TIMEOUT=300     -e COMPOSE_HTTP_TIMEOUT=600     -e PYTHONUNBUFFERED=1     -e PYTEST_ADDOPTS="--dist=loadfile -n 5 -rfEps --run-id=0 --color=no --durations=0 test_storage_rabbitmq/test.py"     clickhouse/integration-tests-runner:e873dae8d34a
Start tests
============================= test session starts ==============================
platform linux -- Python 3.10.12, pytest-7.4.4, pluggy-1.5.0
rootdir: /ClickHouse/tests/integration
configfile: pytest.ini
plugins: xdist-3.5.0, reportlog-0.4.0, timeout-2.2.0, random-0.2, repeat-0.9.3, order-1.0.0
timeout: 900.0s
timeout method: signal
timeout func_only: False
created: 5/5 workers
5 workers [55 items]

scheduling tests via LoadFileScheduling

test_storage_rabbitmq/test.py::test_rabbitmq_select[0] 
[gw0] [  1%] PASSED test_storage_rabbitmq/test.py::test_rabbitmq_select[0] 
test_storage_rabbitmq/test.py::test_rabbitmq_select[1] 
[gw0] [  3%] PASSED test_storage_rabbitmq/test.py::test_rabbitmq_select[1] 
test_storage_rabbitmq/test.py::test_rabbitmq_select_empty 
[gw0] [  5%] PASSED test_storage_rabbitmq/test.py::test_rabbitmq_select_empty 
test_storage_rabbitmq/test.py::test_rabbitmq_json_without_delimiter 
[gw0] [  7%] PASSED test_storage_rabbitmq/test.py::test_rabbitmq_json_without_delimiter 
test_storage_rabbitmq/test.py::test_rabbitmq_csv_with_delimiter 
[gw0] [  9%] PASSED test_storage_rabbitmq/test.py::test_rabbitmq_csv_with_delimiter 
test_storage_rabbitmq/test.py::test_rabbitmq_tsv_with_delimiter 
[gw0] [ 10%] PASSED test_storage_rabbitmq/test.py::test_rabbitmq_tsv_with_delimiter 
test_storage_rabbitmq/test.py::test_rabbitmq_macros 
[gw0] [ 12%] PASSED test_storage_rabbitmq/test.py::test_rabbitmq_macros 
test_storage_rabbitmq/test.py::test_rabbitmq_materialized_view 
[gw0] [ 14%] PASSED test_storage_rabbitmq/test.py::test_rabbitmq_materialized_view 
test_storage_rabbitmq/test.py::test_rabbitmq_materialized_view_with_subquery 
[gw0] [ 16%] PASSED test_storage_rabbitmq/test.py::test_rabbitmq_materialized_view_with_subquery 
test_storage_rabbitmq/test.py::test_rabbitmq_many_materialized_views 
[gw0] [ 18%] PASSED test_storage_rabbitmq/test.py::test_rabbitmq_many_materialized_views 
test_storage_rabbitmq/test.py::test_rabbitmq_big_message 
[gw0] [ 20%] PASSED test_storage_rabbitmq/test.py::test_rabbitmq_big_message 
test_storage_rabbitmq/test.py::test_rabbitmq_sharding_between_queues_publish 
[gw0] [ 21%] PASSED test_storage_rabbitmq/test.py::test_rabbitmq_sharding_between_queues_publish 
test_storage_rabbitmq/test.py::test_rabbitmq_mv_combo 
[gw0] [ 23%] PASSED test_storage_rabbitmq/test.py::test_rabbitmq_mv_combo 
test_storage_rabbitmq/test.py::test_rabbitmq_insert 
[gw0] [ 25%] PASSED test_storage_rabbitmq/test.py::test_rabbitmq_insert 
test_storage_rabbitmq/test.py::test_rabbitmq_insert_headers_exchange 
[gw0] [ 27%] PASSED test_storage_rabbitmq/test.py::test_rabbitmq_insert_headers_exchange 
test_storage_rabbitmq/test.py::test_rabbitmq_many_inserts 
[gw0] [ 29%] PASSED test_storage_rabbitmq/test.py::test_rabbitmq_many_inserts 
test_storage_rabbitmq/test.py::test_rabbitmq_overloaded_insert 
[gw0] [ 30%] PASSED test_storage_rabbitmq/test.py::test_rabbitmq_overloaded_insert 
test_storage_rabbitmq/test.py::test_rabbitmq_direct_exchange 
[gw0] [ 32%] PASSED test_storage_rabbitmq/test.py::test_rabbitmq_direct_exchange 
test_storage_rabbitmq/test.py::test_rabbitmq_fanout_exchange 
[gw0] [ 34%] PASSED test_storage_rabbitmq/test.py::test_rabbitmq_fanout_exchange 
test_storage_rabbitmq/test.py::test_rabbitmq_topic_exchange 
[gw0] [ 36%] PASSED test_storage_rabbitmq/test.py::test_rabbitmq_topic_exchange 
test_storage_rabbitmq/test.py::test_rabbitmq_hash_exchange 
[gw0] [ 38%] PASSED test_storage_rabbitmq/test.py::test_rabbitmq_hash_exchange 
test_storage_rabbitmq/test.py::test_rabbitmq_multiple_bindings 
[gw0] [ 40%] PASSED test_storage_rabbitmq/test.py::test_rabbitmq_multiple_bindings 
test_storage_rabbitmq/test.py::test_rabbitmq_headers_exchange 
[gw0] [ 41%] PASSED test_storage_rabbitmq/test.py::test_rabbitmq_headers_exchange 
test_storage_rabbitmq/test.py::test_rabbitmq_virtual_columns 
[gw0] [ 43%] PASSED test_storage_rabbitmq/test.py::test_rabbitmq_virtual_columns 
test_storage_rabbitmq/test.py::test_rabbitmq_virtual_columns_with_materialized_view 
[gw0] [ 45%] PASSED test_storage_rabbitmq/test.py::test_rabbitmq_virtual_columns_with_materialized_view 
test_storage_rabbitmq/test.py::test_rabbitmq_many_consumers_to_each_queue 
[gw0] [ 47%] PASSED test_storage_rabbitmq/test.py::test_rabbitmq_many_consumers_to_each_queue 
test_storage_rabbitmq/test.py::test_rabbitmq_restore_failed_connection_without_losses_1 
[gw0] [ 49%] PASSED test_storage_rabbitmq/test.py::test_rabbitmq_restore_failed_connection_without_losses_1 
test_storage_rabbitmq/test.py::test_rabbitmq_restore_failed_connection_without_losses_2 
[gw0] [ 50%] PASSED test_storage_rabbitmq/test.py::test_rabbitmq_restore_failed_connection_without_losses_2 
test_storage_rabbitmq/test.py::test_rabbitmq_commit_on_block_write 
[gw0] [ 52%] PASSED test_storage_rabbitmq/test.py::test_rabbitmq_commit_on_block_write 
test_storage_rabbitmq/test.py::test_rabbitmq_no_connection_at_startup_1 
[gw0] [ 54%] PASSED test_storage_rabbitmq/test.py::test_rabbitmq_no_connection_at_startup_1 
test_storage_rabbitmq/test.py::test_rabbitmq_no_connection_at_startup_2 
[gw0] [ 56%] PASSED test_storage_rabbitmq/test.py::test_rabbitmq_no_connection_at_startup_2 
test_storage_rabbitmq/test.py::test_rabbitmq_format_factory_settings 
[gw0] [ 58%] PASSED test_storage_rabbitmq/test.py::test_rabbitmq_format_factory_settings 
test_storage_rabbitmq/test.py::test_rabbitmq_vhost 
[gw0] [ 60%] PASSED test_storage_rabbitmq/test.py::test_rabbitmq_vhost 
test_storage_rabbitmq/test.py::test_rabbitmq_drop_table_properly 
[gw0] [ 61%] PASSED test_storage_rabbitmq/test.py::test_rabbitmq_drop_table_properly 
test_storage_rabbitmq/test.py::test_rabbitmq_queue_settings 
[gw0] [ 63%] PASSED test_storage_rabbitmq/test.py::test_rabbitmq_queue_settings 
test_storage_rabbitmq/test.py::test_rabbitmq_queue_consume 
[gw0] [ 65%] PASSED test_storage_rabbitmq/test.py::test_rabbitmq_queue_consume 
test_storage_rabbitmq/test.py::test_rabbitmq_produce_consume_avro 
[gw0] [ 67%] PASSED test_storage_rabbitmq/test.py::test_rabbitmq_produce_consume_avro 
test_storage_rabbitmq/test.py::test_rabbitmq_bad_args 
[gw0] [ 69%] PASSED test_storage_rabbitmq/test.py::test_rabbitmq_bad_args 
test_storage_rabbitmq/test.py::test_rabbitmq_issue_30691 
[gw0] [ 70%] PASSED test_storage_rabbitmq/test.py::test_rabbitmq_issue_30691 
test_storage_rabbitmq/test.py::test_rabbitmq_drop_mv 
[gw0] [ 72%] PASSED test_storage_rabbitmq/test.py::test_rabbitmq_drop_mv 
test_storage_rabbitmq/test.py::test_rabbitmq_random_detach 
[gw0] [ 74%] PASSED test_storage_rabbitmq/test.py::test_rabbitmq_random_detach 
test_storage_rabbitmq/test.py::test_rabbitmq_predefined_configuration 
[gw0] [ 76%] PASSED test_storage_rabbitmq/test.py::test_rabbitmq_predefined_configuration 
test_storage_rabbitmq/test.py::test_rabbitmq_msgpack 
[gw0] [ 78%] PASSED test_storage_rabbitmq/test.py::test_rabbitmq_msgpack 
test_storage_rabbitmq/test.py::test_rabbitmq_address 
[gw0] [ 80%] PASSED test_storage_rabbitmq/test.py::test_rabbitmq_address 
test_storage_rabbitmq/test.py::test_format_with_prefix_and_suffix 
[gw0] [ 81%] PASSED test_storage_rabbitmq/test.py::test_format_with_prefix_and_suffix 
test_storage_rabbitmq/test.py::test_max_rows_per_message 
[gw0] [ 83%] PASSED test_storage_rabbitmq/test.py::test_max_rows_per_message 
test_storage_rabbitmq/test.py::test_row_based_formats 
[gw0] [ 85%] PASSED test_storage_rabbitmq/test.py::test_row_based_formats 
test_storage_rabbitmq/test.py::test_block_based_formats_1 
[gw0] [ 87%] PASSED test_storage_rabbitmq/test.py::test_block_based_formats_1 
test_storage_rabbitmq/test.py::test_block_based_formats_2 
[gw0] [ 89%] PASSED test_storage_rabbitmq/test.py::test_block_based_formats_2 
test_storage_rabbitmq/test.py::test_rabbitmq_flush_by_block_size 
[gw0] [ 90%] PASSED test_storage_rabbitmq/test.py::test_rabbitmq_flush_by_block_size 
test_storage_rabbitmq/test.py::test_rabbitmq_flush_by_time 
[gw0] [ 92%] PASSED test_storage_rabbitmq/test.py::test_rabbitmq_flush_by_time 
test_storage_rabbitmq/test.py::test_rabbitmq_handle_error_mode_stream 
[gw0] [ 94%] PASSED test_storage_rabbitmq/test.py::test_rabbitmq_handle_error_mode_stream 
test_storage_rabbitmq/test.py::test_attach_broken_table 
[gw0] [ 96%] PASSED test_storage_rabbitmq/test.py::test_attach_broken_table 
test_storage_rabbitmq/test.py::test_rabbitmq_nack_failed_insert 
[gw0] [ 98%] PASSED test_storage_rabbitmq/test.py::test_rabbitmq_nack_failed_insert 
test_storage_rabbitmq/test.py::test_rabbitmq_reject_broken_messages 
[gw0] [100%] PASSED test_storage_rabbitmq/test.py::test_rabbitmq_reject_broken_messages 

============================== slowest durations ===============================
92.28s call     test_storage_rabbitmq/test.py::test_rabbitmq_mv_combo
78.71s call     test_storage_rabbitmq/test.py::test_rabbitmq_random_detach
64.41s call     test_storage_rabbitmq/test.py::test_rabbitmq_restore_failed_connection_without_losses_2
60.40s call     test_storage_rabbitmq/test.py::test_row_based_formats
54.99s call     test_storage_rabbitmq/test.py::test_rabbitmq_handle_error_mode_stream
40.78s call     test_storage_rabbitmq/test.py::test_rabbitmq_sharding_between_queues_publish
31.50s call     test_storage_rabbitmq/test.py::test_rabbitmq_drop_table_properly
25.07s call     test_storage_rabbitmq/test.py::test_rabbitmq_restore_failed_connection_without_losses_1
22.65s call     test_storage_rabbitmq/test.py::test_rabbitmq_hash_exchange
19.06s call     test_storage_rabbitmq/test.py::test_rabbitmq_flush_by_time
17.76s call     test_storage_rabbitmq/test.py::test_rabbitmq_many_consumers_to_each_queue
17.44s call     test_storage_rabbitmq/test.py::test_rabbitmq_overloaded_insert
17.21s call     test_storage_rabbitmq/test.py::test_block_based_formats_2
17.19s call     test_storage_rabbitmq/test.py::test_rabbitmq_topic_exchange
15.37s call     test_storage_rabbitmq/test.py::test_rabbitmq_drop_mv
13.56s call     test_storage_rabbitmq/test.py::test_rabbitmq_many_inserts
12.16s call     test_storage_rabbitmq/test.py::test_rabbitmq_multiple_bindings
11.44s call     test_storage_rabbitmq/test.py::test_rabbitmq_no_connection_at_startup_2
10.84s call     test_storage_rabbitmq/test.py::test_rabbitmq_fanout_exchange
10.69s call     test_storage_rabbitmq/test.py::test_rabbitmq_direct_exchange
9.93s call     test_storage_rabbitmq/test.py::test_rabbitmq_reject_broken_messages
8.38s call     test_storage_rabbitmq/test.py::test_attach_broken_table
7.95s setup    test_storage_rabbitmq/test.py::test_rabbitmq_select[0]
7.60s call     test_storage_rabbitmq/test.py::test_rabbitmq_queue_consume
7.37s call     test_storage_rabbitmq/test.py::test_rabbitmq_nack_failed_insert
7.08s call     test_storage_rabbitmq/test.py::test_rabbitmq_produce_consume_avro
7.02s call     test_storage_rabbitmq/test.py::test_rabbitmq_headers_exchange
6.99s call     test_storage_rabbitmq/test.py::test_rabbitmq_select[1]
6.87s call     test_storage_rabbitmq/test.py::test_rabbitmq_select[0]
6.73s call     test_storage_rabbitmq/test.py::test_rabbitmq_predefined_configuration
6.49s call     test_storage_rabbitmq/test.py::test_rabbitmq_queue_settings
6.40s call     test_storage_rabbitmq/test.py::test_rabbitmq_csv_with_delimiter
5.30s call     test_storage_rabbitmq/test.py::test_rabbitmq_big_message
5.09s call     test_storage_rabbitmq/test.py::test_rabbitmq_address
5.04s call     test_storage_rabbitmq/test.py::test_rabbitmq_msgpack
4.94s teardown test_storage_rabbitmq/test.py::test_rabbitmq_reject_broken_messages
4.27s call     test_storage_rabbitmq/test.py::test_rabbitmq_commit_on_block_write
4.23s call     test_storage_rabbitmq/test.py::test_rabbitmq_no_connection_at_startup_1
3.74s call     test_storage_rabbitmq/test.py::test_max_rows_per_message
3.65s call     test_storage_rabbitmq/test.py::test_rabbitmq_virtual_columns
3.60s call     test_storage_rabbitmq/test.py::test_rabbitmq_virtual_columns_with_materialized_view
3.26s call     test_storage_rabbitmq/test.py::test_rabbitmq_many_materialized_views
2.85s call     test_storage_rabbitmq/test.py::test_rabbitmq_format_factory_settings
2.69s call     test_storage_rabbitmq/test.py::test_rabbitmq_materialized_view
2.66s call     test_storage_rabbitmq/test.py::test_rabbitmq_insert_headers_exchange
2.61s call     test_storage_rabbitmq/test.py::test_rabbitmq_insert
2.56s call     test_storage_rabbitmq/test.py::test_block_based_formats_1
2.55s call     test_storage_rabbitmq/test.py::test_format_with_prefix_and_suffix
2.50s call     test_storage_rabbitmq/test.py::test_rabbitmq_json_without_delimiter
2.48s call     test_storage_rabbitmq/test.py::test_rabbitmq_macros
2.45s call     test_storage_rabbitmq/test.py::test_rabbitmq_materialized_view_with_subquery
2.42s call     test_storage_rabbitmq/test.py::test_rabbitmq_tsv_with_delimiter
2.14s call     test_storage_rabbitmq/test.py::test_rabbitmq_flush_by_block_size
1.46s call     test_storage_rabbitmq/test.py::test_rabbitmq_issue_30691
1.39s call     test_storage_rabbitmq/test.py::test_rabbitmq_vhost
1.39s call     test_storage_rabbitmq/test.py::test_rabbitmq_select_empty
1.33s call     test_storage_rabbitmq/test.py::test_rabbitmq_bad_args
0.58s teardown test_storage_rabbitmq/test.py::test_row_based_formats
0.29s teardown test_storage_rabbitmq/test.py::test_rabbitmq_big_message
0.28s teardown test_storage_rabbitmq/test.py::test_rabbitmq_restore_failed_connection_without_losses_1
0.23s teardown test_storage_rabbitmq/test.py::test_rabbitmq_random_detach
0.18s teardown test_storage_rabbitmq/test.py::test_block_based_formats_2
0.18s teardown test_storage_rabbitmq/test.py::test_rabbitmq_select_empty
0.18s teardown test_storage_rabbitmq/test.py::test_max_rows_per_message
0.18s teardown test_storage_rabbitmq/test.py::test_rabbitmq_restore_failed_connection_without_losses_2
0.18s teardown test_storage_rabbitmq/test.py::test_rabbitmq_predefined_configuration
0.13s teardown test_storage_rabbitmq/test.py::test_attach_broken_table
0.13s teardown test_storage_rabbitmq/test.py::test_rabbitmq_topic_exchange
0.13s teardown test_storage_rabbitmq/test.py::test_rabbitmq_flush_by_block_size
0.13s teardown test_storage_rabbitmq/test.py::test_rabbitmq_no_connection_at_startup_2
0.13s teardown test_storage_rabbitmq/test.py::test_rabbitmq_mv_combo
0.13s teardown test_storage_rabbitmq/test.py::test_rabbitmq_macros
0.13s teardown test_storage_rabbitmq/test.py::test_rabbitmq_msgpack
0.13s teardown test_storage_rabbitmq/test.py::test_rabbitmq_bad_args
0.13s teardown test_storage_rabbitmq/test.py::test_rabbitmq_commit_on_block_write
0.13s teardown test_storage_rabbitmq/test.py::test_rabbitmq_tsv_with_delimiter
0.13s teardown test_storage_rabbitmq/test.py::test_rabbitmq_select[1]
0.13s teardown test_storage_rabbitmq/test.py::test_rabbitmq_many_consumers_to_each_queue
0.13s teardown test_storage_rabbitmq/test.py::test_rabbitmq_format_factory_settings
0.13s teardown test_storage_rabbitmq/test.py::test_rabbitmq_produce_consume_avro
0.13s teardown test_storage_rabbitmq/test.py::test_rabbitmq_select[0]
0.13s teardown test_storage_rabbitmq/test.py::test_rabbitmq_drop_table_properly
0.13s teardown test_storage_rabbitmq/test.py::test_rabbitmq_drop_mv
0.13s teardown test_storage_rabbitmq/test.py::test_rabbitmq_no_connection_at_startup_1
0.13s teardown test_storage_rabbitmq/test.py::test_rabbitmq_many_materialized_views
0.13s teardown test_storage_rabbitmq/test.py::test_rabbitmq_insert_headers_exchange
0.13s teardown test_storage_rabbitmq/test.py::test_rabbitmq_virtual_columns
0.13s teardown test_storage_rabbitmq/test.py::test_rabbitmq_address
0.13s teardown test_storage_rabbitmq/test.py::test_rabbitmq_issue_30691
0.13s teardown test_storage_rabbitmq/test.py::test_rabbitmq_direct_exchange
0.13s teardown test_storage_rabbitmq/test.py::test_rabbitmq_many_inserts
0.13s teardown test_storage_rabbitmq/test.py::test_rabbitmq_materialized_view
0.13s teardown test_storage_rabbitmq/test.py::test_rabbitmq_hash_exchange
0.13s teardown test_storage_rabbitmq/test.py::test_rabbitmq_overloaded_insert
0.13s teardown test_storage_rabbitmq/test.py::test_rabbitmq_flush_by_time
0.13s teardown test_storage_rabbitmq/test.py::test_rabbitmq_headers_exchange
0.13s teardown test_storage_rabbitmq/test.py::test_rabbitmq_materialized_view_with_subquery
0.13s teardown test_storage_rabbitmq/test.py::test_rabbitmq_json_without_delimiter
0.13s teardown test_storage_rabbitmq/test.py::test_rabbitmq_handle_error_mode_stream
0.13s teardown test_storage_rabbitmq/test.py::test_rabbitmq_csv_with_delimiter
0.13s teardown test_storage_rabbitmq/test.py::test_rabbitmq_queue_consume
0.13s teardown test_storage_rabbitmq/test.py::test_rabbitmq_vhost
0.13s teardown test_storage_rabbitmq/test.py::test_rabbitmq_multiple_bindings
0.13s teardown test_storage_rabbitmq/test.py::test_rabbitmq_sharding_between_queues_publish
0.13s teardown test_storage_rabbitmq/test.py::test_rabbitmq_virtual_columns_with_materialized_view
0.13s teardown test_storage_rabbitmq/test.py::test_block_based_formats_1
0.13s teardown test_storage_rabbitmq/test.py::test_format_with_prefix_and_suffix
0.13s teardown test_storage_rabbitmq/test.py::test_rabbitmq_fanout_exchange
0.13s teardown test_storage_rabbitmq/test.py::test_rabbitmq_nack_failed_insert
0.13s teardown test_storage_rabbitmq/test.py::test_rabbitmq_queue_settings
0.13s teardown test_storage_rabbitmq/test.py::test_rabbitmq_insert

(54 durations < 0.005s hidden.  Use -vv to show these durations.)
=========================== short test summary info ============================
PASSED test_storage_rabbitmq/test.py::test_rabbitmq_select[0]
PASSED test_storage_rabbitmq/test.py::test_rabbitmq_select[1]
PASSED test_storage_rabbitmq/test.py::test_rabbitmq_select_empty
PASSED test_storage_rabbitmq/test.py::test_rabbitmq_json_without_delimiter
PASSED test_storage_rabbitmq/test.py::test_rabbitmq_csv_with_delimiter
PASSED test_storage_rabbitmq/test.py::test_rabbitmq_tsv_with_delimiter
PASSED test_storage_rabbitmq/test.py::test_rabbitmq_macros
PASSED test_storage_rabbitmq/test.py::test_rabbitmq_materialized_view
PASSED test_storage_rabbitmq/test.py::test_rabbitmq_materialized_view_with_subquery
PASSED test_storage_rabbitmq/test.py::test_rabbitmq_many_materialized_views
PASSED test_storage_rabbitmq/test.py::test_rabbitmq_big_message
PASSED test_storage_rabbitmq/test.py::test_rabbitmq_sharding_between_queues_publish
PASSED test_storage_rabbitmq/test.py::test_rabbitmq_mv_combo
PASSED test_storage_rabbitmq/test.py::test_rabbitmq_insert
PASSED test_storage_rabbitmq/test.py::test_rabbitmq_insert_headers_exchange
PASSED test_storage_rabbitmq/test.py::test_rabbitmq_many_inserts
PASSED test_storage_rabbitmq/test.py::test_rabbitmq_overloaded_insert
PASSED test_storage_rabbitmq/test.py::test_rabbitmq_direct_exchange
PASSED test_storage_rabbitmq/test.py::test_rabbitmq_fanout_exchange
PASSED test_storage_rabbitmq/test.py::test_rabbitmq_topic_exchange
PASSED test_storage_rabbitmq/test.py::test_rabbitmq_hash_exchange
PASSED test_storage_rabbitmq/test.py::test_rabbitmq_multiple_bindings
PASSED test_storage_rabbitmq/test.py::test_rabbitmq_headers_exchange
PASSED test_storage_rabbitmq/test.py::test_rabbitmq_virtual_columns
PASSED test_storage_rabbitmq/test.py::test_rabbitmq_virtual_columns_with_materialized_view
PASSED test_storage_rabbitmq/test.py::test_rabbitmq_many_consumers_to_each_queue
PASSED test_storage_rabbitmq/test.py::test_rabbitmq_restore_failed_connection_without_losses_1
PASSED test_storage_rabbitmq/test.py::test_rabbitmq_restore_failed_connection_without_losses_2
PASSED test_storage_rabbitmq/test.py::test_rabbitmq_commit_on_block_write
PASSED test_storage_rabbitmq/test.py::test_rabbitmq_no_connection_at_startup_1
PASSED test_storage_rabbitmq/test.py::test_rabbitmq_no_connection_at_startup_2
PASSED test_storage_rabbitmq/test.py::test_rabbitmq_format_factory_settings
PASSED test_storage_rabbitmq/test.py::test_rabbitmq_vhost
PASSED test_storage_rabbitmq/test.py::test_rabbitmq_drop_table_properly
PASSED test_storage_rabbitmq/test.py::test_rabbitmq_queue_settings
PASSED test_storage_rabbitmq/test.py::test_rabbitmq_queue_consume
PASSED test_storage_rabbitmq/test.py::test_rabbitmq_produce_consume_avro
PASSED test_storage_rabbitmq/test.py::test_rabbitmq_bad_args
PASSED test_storage_rabbitmq/test.py::test_rabbitmq_issue_30691
PASSED test_storage_rabbitmq/test.py::test_rabbitmq_drop_mv
PASSED test_storage_rabbitmq/test.py::test_rabbitmq_random_detach
PASSED test_storage_rabbitmq/test.py::test_rabbitmq_predefined_configuration
PASSED test_storage_rabbitmq/test.py::test_rabbitmq_msgpack
PASSED test_storage_rabbitmq/test.py::test_rabbitmq_address
PASSED test_storage_rabbitmq/test.py::test_format_with_prefix_and_suffix
PASSED test_storage_rabbitmq/test.py::test_max_rows_per_message
PASSED test_storage_rabbitmq/test.py::test_row_based_formats
PASSED test_storage_rabbitmq/test.py::test_block_based_formats_1
PASSED test_storage_rabbitmq/test.py::test_block_based_formats_2
PASSED test_storage_rabbitmq/test.py::test_rabbitmq_flush_by_block_size
PASSED test_storage_rabbitmq/test.py::test_rabbitmq_flush_by_time
PASSED test_storage_rabbitmq/test.py::test_rabbitmq_handle_error_mode_stream
PASSED test_storage_rabbitmq/test.py::test_attach_broken_table
PASSED test_storage_rabbitmq/test.py::test_rabbitmq_nack_failed_insert
PASSED test_storage_rabbitmq/test.py::test_rabbitmq_reject_broken_messages
======================== 55 passed in 818.73s (0:13:38) ========================
```
</details>