### PR TITLE
fix Kafka test

### DIFF
--- a/tests/integration/test_storage_kafka/test.py
+++ b/tests/integration/test_storage_kafka/test.py
@@ -2761,7 +2761,7 @@ def test_kafka_produce_key_timestamp(kafka_cluster, create_query_generator, log_
             )
         )
 
-        # instance.wait_for_log_line(log_line)
+        instance.wait_for_log_line(log_line)
 
         expected = """\
     1	1	k1	1577836801	k1	insert3	0	0	1577836801


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix tiny mistake, responsible for some of kafka test flaps. Example [report](https://s3.amazonaws.com/clickhouse-test-reports/0/3198aafac59c368993e7b5f49d95674cc1b1be18/integration_tests__release__[2_4].html)

Introduced https://github.com/ClickHouse/ClickHouse/commit/c0eea71ab387602ec0d760e21fc4954079552ae6 cc. @antaljanosbenjamin

There is also another issue with Kafka tests - It can be caused by some resource limits (OOM?) or smth similar #68360  [example report](https://s3.amazonaws.com/clickhouse-test-reports/0/ec6bf0d3e21ee65e0aad7d8bf0aa6c8c8fdffa5d/integration_tests__asan__old_analyzer__[6_6].html), 

```
[gw0] [ 98%] ERROR test_storage_kafka/test.py::test_system_kafka_consumers 
test_storage_kafka/test.py::test_system_kafka_consumers_rebalance Killed
```