### PR TITLE
[Docs] update `connectionId` alias

### DIFF
--- a/docs/en/sql-reference/functions/other-functions.md
+++ b/docs/en/sql-reference/functions/other-functions.md
@@ -3871,9 +3871,9 @@ Retrieves the connection ID of the client that submitted the current query and r
 
 ```sql
 connectionId()
-```
+``` 
 
-Alias: `connection_id`.
+Alias: `connection_id`. 
 
 **Parameters**
 
@@ -3881,7 +3881,7 @@ None.
 
 **Returned value**
 
-Returns an integer of type UInt64.
+Returns an integer of type UInt64. [UInt64](../data-types/int-uint.md).
 
 **Implementation details**
 

--- a/docs/en/sql-reference/functions/other-functions.md
+++ b/docs/en/sql-reference/functions/other-functions.md
@@ -3873,6 +3873,8 @@ Retrieves the connection ID of the client that submitted the current query and r
 connectionId()
 ```
 
+Alias: `connection_id`.
+
 **Parameters**
 
 None.
@@ -3891,40 +3893,6 @@ Query:
 
 ```sql
 SELECT connectionId();
-```
-
-```response
-0
-```
-
-## connection_id
-
-An alias of `connectionId`. Retrieves the connection ID of the client that submitted the current query and returns it as a UInt64 integer.
-
-**Syntax**
-
-```sql
-connection_id()
-```
-
-**Parameters**
-
-None.
-
-**Returned value**
-
-Returns an integer of type UInt64.
-
-**Implementation details**
-
-This function is most useful in debugging scenarios or for internal purposes within the MySQL handler. It was created for compatibility with [MySQL's `CONNECTION_ID` function](https://dev.mysql.com/doc/refman/8.0/en/information-functions.html#function_connection-id) It is not typically used in production queries.
-
-**Example**
-
-Query:
-
-```sql
-SELECT connection_id();
 ```
 
 ```response

--- a/docs/en/sql-reference/functions/other-functions.md
+++ b/docs/en/sql-reference/functions/other-functions.md
@@ -3871,9 +3871,9 @@ Retrieves the connection ID of the client that submitted the current query and r
 
 ```sql
 connectionId()
-``` 
+```
 
-Alias: `connection_id`. 
+Alias: `connection_id`.
 
 **Parameters**
 
@@ -3881,7 +3881,7 @@ None.
 
 **Returned value**
 
-Returns an integer of type UInt64. [UInt64](../data-types/int-uint.md).
+The current connection ID. [UInt64](../data-types/int-uint.md).
 
 **Implementation details**
 


### PR DESCRIPTION
Both [connection_id](https://clickhouse.com/docs/en/sql-reference/functions/other-functions#connection_id) and [connectionId](https://clickhouse.com/docs/en/sql-reference/functions/other-functions#connectionid) are currently documented. Only one needs to be.

### Changelog category (leave one):
- Documentation (changelog entry is not required)

