### PR TITLE
Follow-up on clickhouse-client realtime metrics display #63689

### DIFF
--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -469,7 +469,7 @@ void ClientBase::onData(Block & block, ASTPtr parsed_query)
         if (!need_render_progress && select_into_file && !select_into_file_and_stdout)
             error_stream << "\r";
         bool toggle_enabled = getClientConfiguration().getBool("enable-progress-table-toggle", true);
-        progress_table.writeTable(*tty_buf, show_progress_table.load(), toggle_enabled);
+        progress_table.writeTable(*tty_buf, progress_table_toggle_on.load(), toggle_enabled);
     }
 }
 
@@ -882,8 +882,7 @@ void ClientBase::initKeystrokeInterceptor()
     if (is_interactive && need_render_progress_table && getClientConfiguration().getBool("enable-progress-table-toggle", true))
     {
         keystroke_interceptor = std::make_unique<TerminalKeystrokeInterceptor>(in_fd, error_stream);
-        keystroke_interceptor->registerCallback(' ', [this]() { show_progress_table = !show_progress_table; });
-
+        keystroke_interceptor->registerCallback(' ', [this]() { progress_table_toggle_on = !progress_table_toggle_on; });
     }
 }
 
@@ -1414,7 +1413,7 @@ void ClientBase::onProfileEvents(Block & block)
         if (need_render_progress_table && tty_buf && !cancelled)
         {
             bool toggle_enabled = getClientConfiguration().getBool("enable-progress-table-toggle", true);
-            progress_table.writeTable(*tty_buf, show_progress_table.load(), toggle_enabled);
+            progress_table.writeTable(*tty_buf, progress_table_toggle_on.load(), toggle_enabled);
         }
 
         if (profile_events.print)
@@ -2130,6 +2129,8 @@ void ClientBase::processParsedSingleQuery(const String & full_query, const Strin
             output_stream << processed_rows << " row" << (processed_rows == 1 ? "" : "s") << " in set. ";
         output_stream << "Elapsed: " << progress_indication.elapsedSeconds() << " sec. ";
         progress_indication.writeFinalProgress();
+        bool toggle_enabled = getClientConfiguration().getBool("enable-progress-table-toggle", true);
+        bool show_progress_table = !toggle_enabled || progress_table_toggle_on;
         if (need_render_progress_table && show_progress_table)
             progress_table.writeFinalTable();
         output_stream << std::endl << std::endl;

--- a/src/Client/ClientBase.h
+++ b/src/Client/ClientBase.h
@@ -340,7 +340,7 @@ protected:
     ProgressTable progress_table;
     bool need_render_progress = true;
     bool need_render_progress_table = true;
-    std::atomic_bool show_progress_table = false;
+    std::atomic_bool progress_table_toggle_on = false;
     bool need_render_profile_events = true;
     bool written_first_block = false;
     size_t processed_rows = 0; /// How many rows have been read or written.

--- a/src/Client/ProgressTable.cpp
+++ b/src/Client/ProgressTable.cpp
@@ -357,8 +357,7 @@ void ProgressTable::updateTable(const Block & block)
 
 void ProgressTable::clearTableOutput(WriteBufferFromFileDescriptor & message)
 {
-    message << CLEAR_TO_END_OF_SCREEN;
-    message << SHOW_CURSOR;
+    message << "\r" << CLEAR_TO_END_OF_SCREEN << SHOW_CURSOR;
     message.next();
 }
 

--- a/src/Client/ProgressTable.cpp
+++ b/src/Client/ProgressTable.cpp
@@ -192,19 +192,16 @@ void writeWithWidthStrict(Out & out, std::string_view s, size_t width)
 void ProgressTable::writeTable(WriteBufferFromFileDescriptor & message, bool show_table, bool toggle_enabled)
 {
     std::lock_guard lock{mutex};
-    if (!show_table)
+    if (!show_table && toggle_enabled)
     {
         if (written_first_block)
             message << CLEAR_TO_END_OF_SCREEN;
 
-        if (toggle_enabled)
-        {
-            message << HIDE_CURSOR;
-            message << "\n";
-            message << "Press the space key to toggle the display of the progress table.";
-            message << moveUpNLines(1);
-            message.next();
-        }
+        message << HIDE_CURSOR;
+        message << "\n";
+        message << "Press the space key to toggle the display of the progress table.";
+        message << moveUpNLines(1);
+        message.next();
         return;
     }
 

--- a/src/Client/TerminalKeystrokeInterceptor.h
+++ b/src/Client/TerminalKeystrokeInterceptor.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <condition_variable>
 #include <functional>
 #include <memory>
 #include <mutex>
@@ -38,7 +39,9 @@ private:
     std::unique_ptr<std::thread> intercept_thread;
     std::unique_ptr<struct termios> orig_termios;
 
-    std::atomic_bool stop_requested = false;
+    bool stop_requested = false;
+    std::mutex stop_requested_mutex;
+    std::condition_variable stop_requested_cv;
 };
 
 }


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
clickhouse-client realtime metrics follow-up: restore cursor when Ctrl-C cancels query;  immediately stop intercepting keystrokes when the query is canceled; display the metrics table if `--progress-table` is on, and toggling is disabled.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---ci_include_fuzzer--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
