### PR TITLE
Increase lock timeout in attempt to fix 02125_many_mutations

### DIFF
--- a/src/Interpreters/MutationsInterpreter.cpp
+++ b/src/Interpreters/MutationsInterpreter.cpp
@@ -437,7 +437,7 @@ MutationsInterpreter::MutationsInterpreter(
     if (new_context->getSettingsRef()[Setting::allow_experimental_analyzer])
     {
         new_context->setSetting("allow_experimental_analyzer", false);
-        LOG_DEBUG(logger, "Will use old analyzer to prepare mutation");
+        LOG_TEST(logger, "Will use old analyzer to prepare mutation");
     }
     context = std::move(new_context);
 

--- a/tests/queries/0_stateless/02125_many_mutations.sh
+++ b/tests/queries/0_stateless/02125_many_mutations.sh
@@ -9,7 +9,7 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 $CLICKHOUSE_CLIENT -q "
 drop table if exists many_mutations;
-create table many_mutations (x UInt32, y UInt32) engine = MergeTree order by x settings number_of_mutations_to_delay = 0, number_of_mutations_to_throw = 0, max_parts_to_merge_at_once = 1;
+create table many_mutations (x UInt32, y UInt32) engine = MergeTree order by x settings number_of_mutations_to_delay = 0, number_of_mutations_to_throw = 0, max_parts_to_merge_at_once = 1, lock_acquire_timeout_for_background_operations = 300;
 insert into many_mutations values (0, 0), (1, 1);
 system stop merges many_mutations;
 select x, y from many_mutations order by x;


### PR DESCRIPTION
**Another option is to introduce setting to limit number of mutations in one batch, i.e. `mutations_batch_max_entries`, (or similar)**

Recent failures on CI [1]:

    2024.10.06 16:28:33.624022 [ 620 ] {0e953192-be08-422a-a21f-c3b6f8f5e24d} <Debug> executeQuery: (from [::1]:58814) (comment: 02125_many_mutations.sh) system start merges many_mutations; (stage: Complete)
    2024.10.06 16:28:33.624022 [ 620 ] {0e953192-be08-422a-a21f-c3b6f8f5e24d} <Debug> executeQuery: (from [::1]:58814) (comment: 02125_many_mutations.sh) system start merges many_mutations; (stage: Complete)
    2024.10.06 16:28:33.624408 [ 620 ] {0e953192-be08-422a-a21f-c3b6f8f5e24d} <Debug> TCPHandler: Processed in 0.00091483 sec.
    2024.10.06 16:28:33.624480 [ 929 ] {} <Debug> MutationsInterpreter(test_xa6pnknp.many_mutations): Will use old analyzer to prepare mutation
    ...
    2024.10.06 16:28:33.625358 [ 620 ] {d6a3f295-498f-48e2-8af7-bbec46e03a7e} <Debug> executeQuery: (from [::1]:58814) (comment: 02125_many_mutations.sh) optimize table many_mutations final SETTINGS optimize_throw_if_noop = 1; (stage: Complete)
    ...
    2024.10.06 16:28:37.765705 [ 929 ] {} <Debug> MutationsInterpreter(test_xa6pnknp.many_mutations): Will use old analyzer to prepare mutation
    2024.10.06 16:28:37.765881 [ 929 ] {} <Trace> DiskLocal: Reserved 1.00 MiB on local disk `default`, having unreserved 127.09 GiB.
    2024.10.06 16:28:37.765946 [ 620 ] {d6a3f295-498f-48e2-8af7-bbec46e03a7e} <Debug> test_xa6pnknp.many_mutations (32de70b8-ea0a-4766-ac95-8ebc7923205e): Waiting for currently running merges (1 parts are merging right now) to perform OPTIMIZE FINAL
    ...
    2024.10.06 16:28:37.968946 [ 1227 ] {32de70b8-ea0a-4766-ac95-8ebc7923205e::all_1_1_0_20001} <Debug> MutationsInterpreter(test_xa6pnknp.many_mutations): Will use old analyzer to prepare mutation
    ...
    2024.10.06 16:31:24.077825 [ 620 ] {d6a3f295-498f-48e2-8af7-bbec46e03a7e} <Information> test_xa6pnknp.many_mutations (32de70b8-ea0a-4766-ac95-8ebc7923205e): Cannot OPTIMIZE table: Timeout (120000 ms) while waiting for already running merges before running OPTIMIZE with FINAL. Cannot select pa>
    ...
    2024.10.06 16:31:33.473249 [ 1235 ] {32de70b8-ea0a-4766-ac95-8ebc7923205e::all_1_1_0_20001} <Trace> test_xa6pnknp.many_mutations (32de70b8-ea0a-4766-ac95-8ebc7923205e): Renaming temporary part tmp_mut_all_1_1_0_20001 to all_1_1_0_20001 with tid (1, 1, 00000000-0000-0000-0000-000000000000).
    ...
    2024.10.06 16:31:34.944518 [ 1268 ] {} <Trace> test_xa6pnknp.many_mutations (32de70b8-ea0a-4766-ac95-8ebc7923205e): Removing mutation: mutation_2.txt
    2024.10.06 16:31:34.945149 [ 1268 ] {} <Trace> test_xa6pnknp.many_mutations (32de70b8-ea0a-4766-ac95-8ebc7923205e): Removing mutation: mutation_3.txt

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/70358/eca9ec566a63a9046bb3f1c9373d671946a95ba4/stateless_tests__aarch64_.html

The problem is that after "start merges" all mutations will start, and
the OPTIMIZE may be blocked for too long due to too much mutations in
the queue.

Also note this is different from what https://github.com/ClickHouse/ClickHouse/pull/66911 (which decreases mutations startup time from ~0.15 to 0.01, i.e. 15x times, likely due to moving out rename from out of critical section) addresses.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Refs: https://github.com/ClickHouse/ClickHouse/issues/65589