### PR TITLE
Fix order in 03249_dynamic_alter_consistency

### DIFF
--- a/tests/queries/0_stateless/03249_dynamic_alter_consistency.reference
+++ b/tests/queries/0_stateless/03249_dynamic_alter_consistency.reference
@@ -1,2 +1,2 @@
-600000	UInt64	false
 400000	String	true
+600000	UInt64	false

--- a/tests/queries/0_stateless/03249_dynamic_alter_consistency.sql
+++ b/tests/queries/0_stateless/03249_dynamic_alter_consistency.sql
@@ -4,6 +4,6 @@ drop table if exists test;
 create table test (d Dynamic) engine=MergeTree order by tuple() settings min_rows_for_wide_part=1, min_bytes_for_wide_part=1;
 insert into test select number < 600000 ? number::Dynamic : ('str_' || number)::Dynamic from numbers(1000000);
 alter table test modify column d Dynamic(max_types=1);
-select count(), dynamicType(d), isDynamicElementInSharedData(d) from test group by dynamicType(d), isDynamicElementInSharedData(d);
+select count(), dynamicType(d), isDynamicElementInSharedData(d) from test group by dynamicType(d), isDynamicElementInSharedData(d) order by count();
 drop table test;
 


### PR DESCRIPTION
Fix failures like
```
2024-10-07 15:53:21 Reason: result differs with reference:  
2024-10-07 15:53:21 --- /repo/tests/queries/0_stateless/03249_dynamic_alter_consistency.reference	2024-10-07 15:24:48.076630316 +0700
2024-10-07 15:53:21 +++ /repo/tests/queries/0_stateless/03249_dynamic_alter_consistency.stdout	2024-10-07 15:53:21.036045206 +0700
2024-10-07 15:53:21 @@ -1,2 +1,2 @@
2024-10-07 15:53:21 -600000	UInt64	false
2024-10-07 15:53:21  400000	String	true
2024-10-07 15:53:21 +600000	UInt64	false
2024-10-07 15:53:21 
```

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---ci_include_fuzzer--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
