### PR TITLE
minor typo fix for example intersect SQL

### DIFF
--- a/docs/en/sql-reference/statements/select/intersect.md
+++ b/docs/en/sql-reference/statements/select/intersect.md
@@ -29,7 +29,7 @@ The condition could be any expression based on your requirements.
 Here is a simple example that intersects the numbers 1 to 10 with the numbers 3 to 8:
 
 ```sql
-SELECT number FROM numbers(1,10) INTERSECT SELECT number FROM numbers(3,6);
+SELECT number FROM numbers(1,10) INTERSECT SELECT number FROM numbers(3,8);
 ```
 
 Result:

--- a/docs/ru/sql-reference/statements/select/intersect.md
+++ b/docs/ru/sql-reference/statements/select/intersect.md
@@ -29,7 +29,7 @@ FROM table2
 Запрос:
 
 ``` sql
-SELECT number FROM numbers(1,10) INTERSECT SELECT number FROM numbers(3,6);
+SELECT number FROM numbers(1,10) INTERSECT SELECT number FROM numbers(3,8);
 ```
 
 Результат:


### PR DESCRIPTION
### Changelog category (leave one):
- Documentation (changelog entry is not required)

Minor fix to intersect docs for both "en" and "ru" where SQL example had a mistyped number.
