### PR TITLE
Fix flaky test_refreshable_mv_in_replicated_db

### DIFF
--- a/tests/integration/test_refreshable_mv/test.py
+++ b/tests/integration/test_refreshable_mv/test.py
@@ -84,7 +84,9 @@ def test_refreshable_mv_in_replicated_db(started_cluster):
         for node in nodes:
             # Wait twice to make sure we wait for a refresh that started after we adjusted the clock.
             # Otherwise another refresh may start right after (because clock moved far forward).
-            node.query(f"system wait view re.{name}; system refresh view re.{name}; system wait view re.{name};")
+            node.query(
+                f"system wait view re.{name}; system refresh view re.{name}; system wait view re.{name};"
+            )
         rows_before = int(nodes[randint(0, 1)].query(f"select count() from re.{name}"))
         # Advance the clocks.
         for node in nodes:

--- a/tests/integration/test_refreshable_mv/test.py
+++ b/tests/integration/test_refreshable_mv/test.py
@@ -82,7 +82,9 @@ def test_refreshable_mv_in_replicated_db(started_cluster):
             )
         # Wait for quiescence.
         for node in nodes:
-            node.query(f"system wait view re.{name}")
+            # Wait twice to make sure we wait for a refresh that started after we adjusted the clock.
+            # Otherwise another refresh may start right after (because clock moved far forward).
+            node.query(f"system wait view re.{name}; system refresh view re.{name}; system wait view re.{name};")
         rows_before = int(nodes[randint(0, 1)].query(f"select count() from re.{name}"))
         # Advance the clocks.
         for node in nodes:


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Failed like this: https://d1k2gkhrlfqv31.cloudfront.net/clickhouse-test-reports-private/0/4bd1878694e2e52d5dc1bad44a20e7423d1fadd4/integration_tests__release__[3_4]//home/ubuntu/actions-runner/_work/_temp/test/output_dir/integration_run_parallel4_0.log

I couldn't reproduce it locally, but here's a likely fix.