### PR TITLE
[WIP] Improve join performance using data prefetch

### DIFF
--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -1859,6 +1859,8 @@ Possible values:
     M(UInt64, join_output_by_rowlist_perkey_rows_threshold, 5, R"(
 The lower limit of per-key average rows in the right table to determine whether to output by row list in hash join.
 )", 0) \
+    M(UInt64, prefetch_ahead_distance, 100, R"(Empirical prefetch look ahead distance.)", 0) \
+    M(UInt64, prefetch_small_loop_size, 5, R"(The lower limit of join key size in the right table to determine whether to data prefetch.)", 0) \
     M(JoinStrictness, join_default_strictness, JoinStrictness::All, R"(
 Sets default strictness for [JOIN clauses](../../sql-reference/statements/select/join.md/#select-join).
 

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -96,6 +96,8 @@ static std::initializer_list<std::pair<ClickHouseVersion, SettingsChangesHistory
             {"distributed_cache_read_alignment", 0, 0, "A setting for ClickHouse Cloud"},
             {"distributed_cache_max_unacked_inflight_packets", 10, 10, "A setting for ClickHouse Cloud"},
             {"distributed_cache_data_packet_ack_window", 5, 5, "A setting for ClickHouse Cloud"},
+            {"prefetch_ahead_distance", 0, 100, "Empirical prefetch look ahead distance"},
+            {"prefetch_small_loop_size", 0, 5, "The lower limit of join key size in the right table to determine whether to data prefetch"}
         }
     },
     {"24.9",

--- a/src/Interpreters/HashJoin/AddedColumns.h
+++ b/src/Interpreters/HashJoin/AddedColumns.h
@@ -68,6 +68,8 @@ public:
         , rows_to_add(left_block.rows())
         , join_data_avg_perkey_rows(join.getJoinedData()->avgPerKeyRows())
         , output_by_row_list_threshold(join.getTableJoin().outputByRowListPerkeyRowsThreshold())
+        , prefetch_ahead_distance(join.getTableJoin().prefetchAheadDistance())
+        , prefetch_small_loop_size(join.getTableJoin().prefetchSmallLoopSize())
         , join_data_sorted(join.getJoinedData()->sorted)
         , is_join_get(is_join_get_)
     {
@@ -150,6 +152,8 @@ public:
     bool output_by_row_list = false;
     size_t join_data_avg_perkey_rows = 0;
     size_t output_by_row_list_threshold = 0;
+    size_t prefetch_ahead_distance = 0;
+    size_t prefetch_small_loop_size = 0;
     bool join_data_sorted = false;
     IColumn::Filter filter;
 

--- a/src/Interpreters/TableJoin.cpp
+++ b/src/Interpreters/TableJoin.cpp
@@ -47,6 +47,8 @@ namespace Setting
     extern const SettingsJoinAlgorithm join_algorithm;
     extern const SettingsUInt64 join_on_disk_max_files_to_merge;
     extern const SettingsUInt64 join_output_by_rowlist_perkey_rows_threshold;
+    extern const SettingsUInt64 prefetch_ahead_distance;
+    extern const SettingsUInt64 prefetch_small_loop_size;
     extern const SettingsOverflowMode join_overflow_mode;
     extern const SettingsUInt64 join_to_sort_maximum_table_rows;
     extern const SettingsUInt64 join_to_sort_minimum_perkey_rows;

--- a/src/Interpreters/TableJoin.cpp
+++ b/src/Interpreters/TableJoin.cpp
@@ -139,6 +139,8 @@ TableJoin::TableJoin(const Settings & settings, VolumePtr tmp_volume_, Temporary
     , output_by_rowlist_perkey_rows_threshold(settings[Setting::join_output_by_rowlist_perkey_rows_threshold])
     , sort_right_minimum_perkey_rows(settings[Setting::join_to_sort_minimum_perkey_rows])
     , sort_right_maximum_table_rows(settings[Setting::join_to_sort_maximum_table_rows])
+    , prefetch_ahead_distance(settings[Setting::prefetch_ahead_distance])
+    , prefetch_small_loop_size(settings[Setting::prefetch_small_loop_size])
     , allow_join_sorting(settings[Setting::allow_experimental_join_right_table_sorting])
     , max_memory_usage(settings[Setting::max_memory_usage])
     , tmp_volume(tmp_volume_)

--- a/src/Interpreters/TableJoin.h
+++ b/src/Interpreters/TableJoin.h
@@ -151,6 +151,8 @@ private:
     const size_t output_by_rowlist_perkey_rows_threshold = 0;
     const size_t sort_right_minimum_perkey_rows = 0;
     const size_t sort_right_maximum_table_rows = 0;
+    const size_t prefetch_ahead_distance = 0;
+    const size_t prefetch_small_loop_size = 0;
     const bool allow_join_sorting = false;
 
     /// Value if setting max_memory_usage for query, can be used when max_bytes_in_join is not specified.
@@ -302,6 +304,8 @@ public:
     size_t outputByRowListPerkeyRowsThreshold() const { return output_by_rowlist_perkey_rows_threshold; }
     size_t sortRightMinimumPerkeyRows() const { return sort_right_minimum_perkey_rows; }
     size_t sortRightMaximumTableRows() const { return sort_right_maximum_table_rows; }
+    size_t prefetchAheadDistance() const { return prefetch_ahead_distance; }
+    size_t prefetchSmallLoopSize() const { return prefetch_small_loop_size; }
     bool allowJoinSorting() const { return allow_join_sorting; }
     size_t defaultMaxBytes() const { return default_max_bytes; }
     size_t maxJoinedBlockRows() const { return max_joined_block_rows; }


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Improve the Join Performance by using Data Prefetch (implemented by `__builtin_prefetch`)

I have tested on TPC-H benchmark （50G）

Before this PR：
[0.929, 0.766, 1.150, 0.864, 1.871, 0.062, 1.536, 3.372, 12.635, 1.234, 0.313, 0.681, 7.336, 0.605, 0.131, 0.268, 0.701, 2.656, 2.395, 0.273, 4.926, 1.322, ]
Total time：45.7s

After this PR：
[0.951, 0.667, 1.053, 0.766, 1.754, 0.061, 1.386, 2.908, 11.594, 1.084, 0.301, 0.740, 5.421, 0.530, 0.138, 0.247, 0.628, 2.701, 2.490, 0.269, 4.391, 1.511, ]
Total time: 41.3s

According to the total time, it can oabtain about 10% performance improvement

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
