### PR TITLE
Fixes for killing leftovers in clikhouse-test

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -2352,6 +2352,7 @@ def run_tests_array(all_tests_with_params: Tuple[List[str], int, TestSuite, bool
                 # This is the upper level timeout
                 # It helps with completely frozen processes, like in case of gdb errors
                 def timeout_handler(signum, frame):
+                    stop_tests()
                     raise TimeoutError("Test execution timed out")
 
                 signal.signal(signal.SIGALRM, timeout_handler)

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -2657,8 +2657,8 @@ def do_run_tests(jobs, test_suite: TestSuite):
                     max_http_retries=20,
                     timeout=10,
                 )
-            except Exception:
-                print("Hung check failed")
+            except Exception as e:
+                print(f"Hung check failed: {str(e)}")
                 server_died.set()
 
             if server_died.is_set():

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -2357,7 +2357,7 @@ def run_tests_array(all_tests_with_params: Tuple[List[str], int, TestSuite, bool
             while True:
                 # This is the upper level timeout
                 # It helps with completely frozen processes, like in case of gdb errors
-                def timeout_handler(signum, frame):
+                def timeout_handler(_signum, _frame):
                     stop_tests()
                     raise TimeoutError("Test execution timed out")
 

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -408,8 +408,14 @@ def kill_process_group(pgid):
 
 
 def cleanup_child_processes(pid):
-    pgid = os.getpgid(os.getpid())
     print(f"Child processes of {pid}:")
+    try:
+        pgid = os.getpgid(os.getpid())
+    except OSError as e:
+        if e.errno == ESRCH:
+            print(f"Process {pid} does not exist. Ignoring.")
+            return
+        raise
     print(
         subprocess.check_output(
             f"pgrep --parent {pid} -a", shell=True, stderr=subprocess.STDOUT


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changes
- Ignore ESRCH while obtaining process group
- Kill tests leftovers in case of timeout
- Add exception message into "Hung check failed" message
(for details see commit messages)