### PR TITLE
Fixed typo `YSQL` in grant.md

### DIFF
--- a/docs/ru/sql-reference/statements/grant.md
+++ b/docs/ru/sql-reference/statements/grant.md
@@ -464,7 +464,7 @@ GRANT INSERT(x,y) ON db.table TO john
     - `FILE`. Уровень: `GLOBAL`
     - `URL`. Уровень: `GLOBAL`
     - `REMOTE`. Уровень: `GLOBAL`
-    - `YSQL`. Уровень: `GLOBAL`
+    - `MYSQL`. Уровень: `GLOBAL`
     - `ODBC`. Уровень: `GLOBAL`
     - `JDBC`. Уровень: `GLOBAL`
     - `HDFS`. Уровень: `GLOBAL`


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Documentation

### Changelog entry
Fixed typo `YSQL` in grant.md documentation

### Documentation entry for user-facing changes

- [x] Fixed the documentation of sources of grant in ru.