### PR TITLE
Ignore frozen_metadata.txt while traversing shadow directory from system.remote_data_paths

### DIFF
--- a/docs/en/operations/settings/settings.md
+++ b/docs/en/operations/settings/settings.md
@@ -9376,7 +9376,7 @@ Type: Bool
 
 Default value: 0
 
-Traverse shadow directory when query system.remote_data_paths
+Traverse frozen data(shadow directory) in addition to actual table data when query system.remote_data_paths
 
 ## union_default_mode {#union_default_mode}
 

--- a/docs/en/operations/settings/settings.md
+++ b/docs/en/operations/settings/settings.md
@@ -9376,7 +9376,7 @@ Type: Bool
 
 Default value: 0
 
-Traverse frozen data(shadow directory) in addition to actual table data when query system.remote_data_paths
+Traverse frozen data (shadow directory) in addition to actual table data when query `system.remote_data_paths`.
 
 ## union_default_mode {#union_default_mode}
 

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -5375,7 +5375,7 @@ Result:
 If enabled, server will ignore all DROP table queries with specified probability (for Memory and JOIN engines it will replcase DROP to TRUNCATE). Used for testing purposes
 )", 0) \
     M(Bool, traverse_shadow_remote_data_paths, false, R"(
-Traverse shadow directory when query system.remote_data_paths
+Traverse frozen data(shadow directory) in addition to actual table data when query system.remote_data_paths
 )", 0) \
     M(Bool, geo_distance_returns_float64_on_float64_arguments, true, R"(
 If all four arguments to `geoDistance`, `greatCircleDistance`, `greatCircleAngle` functions are Float64, return Float64 and use double precision for internal calculations. In previous ClickHouse versions, the functions always returned Float32.

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -5375,7 +5375,7 @@ Result:
 If enabled, server will ignore all DROP table queries with specified probability (for Memory and JOIN engines it will replcase DROP to TRUNCATE). Used for testing purposes
 )", 0) \
     M(Bool, traverse_shadow_remote_data_paths, false, R"(
-Traverse frozen data(shadow directory) in addition to actual table data when query system.remote_data_paths
+Traverse frozen data (shadow directory) in addition to actual table data when query system.remote_data_paths
 )", 0) \
     M(Bool, geo_distance_returns_float64_on_float64_arguments, true, R"(
 If all four arguments to `geoDistance`, `greatCircleDistance`, `greatCircleAngle` functions are Float64, return Float64 and use double precision for internal calculations. In previous ClickHouse versions, the functions always returned Float32.

--- a/src/Storages/System/StorageSystemRemoteDataPaths.cpp
+++ b/src/Storages/System/StorageSystemRemoteDataPaths.cpp
@@ -90,10 +90,12 @@ private:
     static bool skipPredicateForShadowDir(const String & local_path)
     {
         // `shadow/{backup_name}/revision.txt` is not an object metadata file
+        // `shadow/../{part_name}/frozen_metadata.txt` is not an object metadata file
         const auto path = fs::path(local_path);
-        return path.filename() == "revision.txt" &&
+        return (path.filename() == "revision.txt" &&
                 path.parent_path().has_parent_path() &&
-                path.parent_path().parent_path().filename() == "shadow";
+                path.parent_path().parent_path().filename() == "shadow") ||
+                path.filename() == "frozen_metadata.txt";
     }
 
     const UInt64 max_block_size;


### PR DESCRIPTION
When executing 
`select * from system.remote_data_paths SETTINGS traverse_shadow_remote_data_paths=1`
we can get a parsing error, because `frozen_metadata.txt` (zero-copy replication related) files in frozen parts do not have a object disk metadata format.

```
2024.10.10 10:14:14.842950 [ 3285 ] {d82c32cb-72b6-46a8-9de1-ef70f880acc0} <Error> executeQuery: Code: 27. DB::Exception: Cannot parse input: expected '\t' before: '%Enet\ndefaul\n': While executing SystemRemoteDataPaths. (CANNOT_PARSE_INPUT_ASSERTION_FAILED) (version 24.8.4.13 (official build)) (from [::ffff:10.1.0.73]:58040) (in query:  SELECT obj_path, obj_size FROM _system.listing_objects_from_object_storage AS object_storage LEFT ANTI JOIN remoteSecure('hosts', system.remote_data_paths) AS object_table ON object_table.remote_path = object_storage.obj_path AND object_table.disk_name = 'object_storage' SETTINGS traverse_shadow_remote_data_paths=1 FORMAT TabSeparated ), Stack trace (when copying this message, always include the lines below):

0. DB::Exception::Exception(DB::Exception::MessageMasked&&, int, bool) @ 0x000000000daffc3b
1. DB::Exception::Exception(PreformattedMessage&&, int) @ 0x0000000007e59fcc
2. DB::Exception::Exception<String&>(int, FormatStringHelperImpl<std::type_identity<String&>::type>, String&) @ 0x0000000007e83d0b
3. DB::throwAtAssertionFailed(char const*, DB::ReadBuffer&) @ 0x000000000db78809
4. DB::DiskObjectStorageMetadata::deserialize(DB::ReadBuffer&) @ 0x00000000114360b6
5. DB::MetadataStorageFromDisk::readMetadataUnlocked(String const&, std::shared_lock<DB::SharedMutex>&) const @ 0x000000001143c4cc
6. DB::MetadataStorageFromDisk::getStorageObjects(String const&) const @ 0x000000001143cd1f
7. DB::SystemRemoteDataPathsSource::generate() @ 0x000000001081e1ed
8. DB::ISource::tryGenerate() @ 0x000000001303219b
9. DB::ISource::work() @ 0x0000000013031ea7
10. DB::ExecutionThreadContext::executeTask() @ 0x000000001304b0e7
11. DB::PipelineExecutor::executeStepImpl(unsigned long, std::atomic<bool>*) @ 0x000000001303f9b0
12. void std::__function::__policy_invoker<void ()>::__call_impl<std::__function::__default_alloc_func<DB::PipelineExecutor::spawnThreads()::$_0, void ()>>(std::__function::__policy_storage const*) @ 0x000000001304106e
13. ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::worker(std::__list_iterator<ThreadFromGlobalPoolImpl<false, true>, void*>) @ 0x000000000dbd4649
14. void std::__function::__policy_invoker<void ()>::__call_impl<std::__function::__default_alloc_func<ThreadFromGlobalPoolImpl<false, true>::ThreadFromGlobalPoolImpl<void ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::scheduleImpl<void>(std::function<void ()>, Priority, std::optional<unsigned long>, bool)::'lambda0'()>(void&&)::'lambda'(), void ()>>(std::__function::__policy_storage const*) @ 0x000000000dbd8791
15. void* std::__thread_proxy[abi:v15007]<std::tuple<std::unique_ptr<std::__thread_struct, std::default_delete<std::__thread_struct>>, void ThreadPoolImpl<std::thread>::scheduleImpl<void>(std::function<void ()>, Priority, std::optional<unsigned long>, bool)::'lambda0'()>>(void*) @ 0x000000000dbd7509
16. ? @ 0x0000725a20a94ac3
17. ? @ 0x0000725a20b26850
```

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Ignore frozen_metadata.txt while traversing shadow directory from system.remote_data_paths

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---ci_include_fuzzer--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
