### PR TITLE
Allow `system drop replica zkpath` when there is another replica with the same zk path.

### DIFF
--- a/src/Interpreters/InterpreterSystemQuery.cpp
+++ b/src/Interpreters/InterpreterSystemQuery.cpp
@@ -1010,7 +1010,7 @@ void InterpreterSystemQuery::dropReplica(ASTSystemQuery & query)
                 {
                     ReplicatedTableStatus status;
                     storage_replicated->getStatus(status);
-                    if (status.zookeeper_info.path == query.replica_zk_path)
+                    if (status.replica_path == remote_replica_path)
                         throw Exception(ErrorCodes::TABLE_WAS_NOT_DROPPED,
                                         "There is a local table {}, which has the same table path in ZooKeeper. "
                                         "Please check the path in query. "

--- a/tests/integration/test_drop_replica/test.py
+++ b/tests/integration/test_drop_replica/test.py
@@ -141,11 +141,7 @@ def test_drop_replica(start_cluster):
             shard=1
         )
     )
-    assert "There is a local table" in node_1_2.query_and_get_error(
-        "SYSTEM DROP REPLICA 'node_1_1' FROM ZKPATH '/clickhouse/tables/test/{shard}/replicated/test_table'".format(
-            shard=1
-        )
-    )
+
     assert "There is a local table" in node_1_1.query_and_get_error(
         "SYSTEM DROP REPLICA 'node_1_1' FROM ZKPATH '/clickhouse/tables/test/{shard}/replicated/test_table'".format(
             shard=1
@@ -221,11 +217,16 @@ def test_drop_replica(start_cluster):
     )
     assert exists_replica_1_1 == None
 
-    node_1_2.query("SYSTEM DROP REPLICA 'node_1_1'")
-    exists_replica_1_1 = check_exists(
+    node_1_2.query("DETACH TABLE test4.test_table")
+    node_1_1.query(
+        "SYSTEM DROP REPLICA 'node_1_2' FROM ZKPATH '/clickhouse/tables/test4/{shard}/replicated/test_table'".format(
+            shard=1
+        )
+    )
+    exists_replica_1_2 = check_exists(
         zk,
         "/clickhouse/tables/test4/{shard}/replicated/test_table/replicas/{replica}".format(
-            shard=1, replica="node_1_1"
+            shard=1, replica="node_1_2"
         ),
     )
-    assert exists_replica_1_1 == None
+    assert exists_replica_1_2 == None

--- a/tests/integration/test_drop_replica/test.py
+++ b/tests/integration/test_drop_replica/test.py
@@ -221,6 +221,8 @@ def test_drop_replica(start_cluster):
     )
     assert exists_replica_1_1 == None
 
+    node_1_1.query("ATTACH DATABASE test4")
+
     node_1_2.query("DETACH TABLE test4.test_table")
     node_1_1.query(
         "SYSTEM DROP REPLICA 'node_1_2' FROM ZKPATH '/clickhouse/tables/test4/{shard}/replicated/test_table'".format(
@@ -236,5 +238,5 @@ def test_drop_replica(start_cluster):
     assert exists_replica_1_2 == None
 
     node_1_1.query("ATTACH DATABASE test")
-    for i in range(1, 5):
+    for i in range(1, 4):
         node_1_1.query("ATTACH DATABASE test{}".format(i))


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Allow system drop replica zkpath when there is another replica with the same zk path.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

## Example:
Cluster:
```
   shard1:
           - host1
           - host2
    shard2:  
           - host3
           - host4
 ```
Table: 
```
CREATE TABLE test ON CLUSTER '{cluster}' (a int) ENGINE=ReplicatedMergeTree('/tables/{shard}/table1', '{replica}') ORDER BY a;
```
And `host1` died unexpectedly. We want to cleanup the table zk metadata, but we can't do this on `host2` with `system drop replica <> from zkpath`, since `host1` and `host2` have the same path in zk. But for `host3` or `host4` it works fine.

Also, could we make a backport of this PR?

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---ci_include_fuzzer--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
