### PR TITLE
[Docs] Remove cloud only badge

### DIFF
--- a/docs/en/engines/table-engines/integrations/mysql.md
+++ b/docs/en/engines/table-engines/integrations/mysql.md
@@ -4,11 +4,7 @@ sidebar_position: 138
 sidebar_label: MySQL
 ---
 
-import CloudAvailableBadge from '@theme/badges/CloudAvailableBadge';
-
 # MySQL Table Engine
-
-<CloudAvailableBadge />
 
 The MySQL engine allows you to perform `SELECT` and `INSERT` queries on data that is stored on a remote MySQL server.
 


### PR DESCRIPTION
### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Remove cloud only badge for MySQL integrations page