### PR TITLE
Use cluster table functions automatically if parallel replicas are enabled

### DIFF
--- a/src/Analyzer/Resolve/QueryAnalyzer.cpp
+++ b/src/Analyzer/Resolve/QueryAnalyzer.cpp
@@ -66,6 +66,7 @@
 #include <Analyzer/Resolve/QueryExpressionsAliasVisitor.h>
 #include <Analyzer/Resolve/ReplaceColumnsVisitor.h>
 #include <Analyzer/Resolve/TableExpressionsAliasVisitor.h>
+#include <Analyzer/Resolve/TableFunctionsWithClusterAlternativesVisitor.h>
 #include <Analyzer/Resolve/TypoCorrection.h>
 
 #include <Planner/PlannerActionsVisitor.h>

--- a/src/Analyzer/Resolve/QueryAnalyzer.cpp
+++ b/src/Analyzer/Resolve/QueryAnalyzer.cpp
@@ -5564,6 +5564,11 @@ void QueryAnalyzer::resolveQuery(const QueryTreeNodePtr & query_node, Identifier
     TableExpressionsAliasVisitor table_expressions_visitor(scope);
     table_expressions_visitor.visit(query_node_typed.getJoinTree());
 
+    TableFunctionsWithClusterAlternativesVisitor table_function_visitor;
+    table_function_visitor.visit(query_node);
+    if (!table_function_visitor.shouldReplaceWithClusterAlternatives() && scope.context->hasQueryContext())
+        scope.context->getQueryContext()->setSetting("parallel_replicas_for_cluster_engines", false);
+
     initializeQueryJoinTreeNode(query_node_typed.getJoinTree(), scope);
     scope.aliases.alias_name_to_table_expression_node = std::move(transitive_aliases);
 

--- a/src/Analyzer/Resolve/TableFunctionsWithClusterAlternativesVisitor.h
+++ b/src/Analyzer/Resolve/TableFunctionsWithClusterAlternativesVisitor.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <Analyzer/InDepthQueryTreeVisitor.h>
+#include <Analyzer/TableFunctionNode.h>
+#include <TableFunctions/TableFunctionFactory.h>
+#include <TableFunctions/TableFunctionFile.h>
+
+namespace DB
+{
+
+class TableFunctionsWithClusterAlternativesVisitor : public InDepthQueryTreeVisitor<TableFunctionsWithClusterAlternativesVisitor, /*const_visitor=*/true>
+{
+public:
+    void visitImpl(const QueryTreeNodePtr & node)
+    {
+        if (node->getNodeType() == QueryTreeNodeType::TABLE_FUNCTION)
+            ++table_function_count;
+        else if (node->getNodeType() == QueryTreeNodeType::TABLE)
+            ++table_count;
+    }
+
+    bool needChildVisit(const QueryTreeNodePtr &, const QueryTreeNodePtr &) { return true; }
+    bool shouldReplaceWithClusterAlternatives() const { return (table_count + table_function_count) == 1; }
+
+private:
+    size_t table_count = 0;
+    size_t table_function_count = 0;
+};
+
+}

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -5824,11 +5824,12 @@ Build local plan for local replica
     DECLARE(Bool, parallel_replicas_index_analysis_only_on_coordinator, true, R"(
 Index analysis done only on replica-coordinator and skipped on other replicas. Effective only with enabled parallel_replicas_local_plan
 )", BETA) \
-    \
     DECLARE(Bool, parallel_replicas_only_with_analyzer, true, R"(
 The analyzer should be enabled to use parallel replicas. With disabled analyzer query execution fallbacks to local execution, even if parallel reading from replicas is enabled. Using parallel replicas without the analyzer enabled is not supported
 )", BETA) \
-    \
+    DECLARE(Bool, parallel_replicas_for_cluster_engines, true, R"(
+Replace table function engines with their -Cluster alternatives
+)", EXPERIMENTAL) \
     DECLARE(Bool, allow_experimental_analyzer, true, R"(
 Allow new query analyzer.
 )", IMPORTANT) ALIAS(enable_analyzer) \

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -70,6 +70,7 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
         {
             {"use_page_cache_with_distributed_cache", false, false, "New setting"},
             {"use_query_condition_cache", false, false, "New setting."},
+            {"parallel_replicas_for_cluster_engines", false, true, "New setting."},
         });
         addSettingsChanges(settings_changes_history, "25.2",
         {
@@ -90,7 +91,6 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
             {"parallel_replicas_only_with_analyzer", true, true, "Parallel replicas is supported only with analyzer enabled"},
             {"s3_allow_multipart_copy", true, true, "New setting."},
             /// Release closed. Please use 25.3
-            {"parallel_replicas_for_cluster_engines", false, true, "New setting."},
         });
         addSettingsChanges(settings_changes_history, "25.1",
         {

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -139,6 +139,7 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
         addSettingsChanges(settings_changes_history, "24.12",
         {
             /// Release closed. Please use 25.1
+            {"parallel_replicas_for_cluster_engines", false, true, "New setting."},
             {"allow_experimental_database_iceberg", false, false, "New setting."},
             {"shared_merge_tree_sync_parts_on_partition_operations", 1, 1, "New setting. By default parts are always synchronized"},
             {"query_plan_join_swap_table", "false", "auto", "New setting. Right table was always chosen before."},

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -90,6 +90,7 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
             {"parallel_replicas_only_with_analyzer", true, true, "Parallel replicas is supported only with analyzer enabled"},
             {"s3_allow_multipart_copy", true, true, "New setting."},
             /// Release closed. Please use 25.3
+            {"parallel_replicas_for_cluster_engines", false, true, "New setting."},
         });
         addSettingsChanges(settings_changes_history, "25.1",
         {
@@ -139,7 +140,6 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
         addSettingsChanges(settings_changes_history, "24.12",
         {
             /// Release closed. Please use 25.1
-            {"parallel_replicas_for_cluster_engines", false, true, "New setting."},
             {"allow_experimental_database_iceberg", false, false, "New setting."},
             {"shared_merge_tree_sync_parts_on_partition_operations", 1, 1, "New setting. By default parts are always synchronized"},
             {"query_plan_join_swap_table", "false", "auto", "New setting. Right table was always chosen before."},

--- a/src/Databases/DatabaseS3.cpp
+++ b/src/Databases/DatabaseS3.cpp
@@ -138,7 +138,7 @@ StoragePtr DatabaseS3::getTableImpl(const String & name, ContextPtr context_) co
         return nullptr;
 
     /// TableFunctionS3 throws exceptions, if table cannot be created.
-    auto table_storage = table_function->execute(function, context_, name, /*cached_columns_=*/{}, /*use_global_context=*/false, /*is_insert=*/true);
+    auto table_storage = table_function->execute(function, context_, name, /*cached_columns_=*/{}, /*use_global_context=*/false, /*is_insert_query=*/true);
     if (table_storage)
         addTable(name, table_storage);
 

--- a/src/Databases/DatabaseS3.cpp
+++ b/src/Databases/DatabaseS3.cpp
@@ -138,7 +138,7 @@ StoragePtr DatabaseS3::getTableImpl(const String & name, ContextPtr context_) co
         return nullptr;
 
     /// TableFunctionS3 throws exceptions, if table cannot be created.
-    auto table_storage = table_function->execute(function, context_, name);
+    auto table_storage = table_function->execute(function, context_, name, /*cached_columns_=*/{}, /*use_global_context=*/false, /*is_insert=*/true);
     if (table_storage)
         addTable(name, table_storage);
 

--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -1924,7 +1924,7 @@ bool InterpreterCreateQuery::doCreateTable(ASTCreateQuery & create,
         /// In case of CREATE AS table_function() query we should use global context
         /// in storage creation because there will be no query context on server startup
         /// and because storage lifetime is bigger than query context lifetime.
-        res = table_function->execute(table_function_ast, getContext(), create.getTable(), properties.columns, /*use_global_context=*/true);
+        res = table_function->execute(table_function_ast, getContext(), create.getTable(), properties.columns, /*use_global_context=*/true, /*is_insert_query=*/true);
         res->renameInMemory({create.getDatabase(), create.getTable(), create.uuid});
     }
     else

--- a/src/Storages/IStorageCluster.cpp
+++ b/src/Storages/IStorageCluster.cpp
@@ -189,7 +189,7 @@ void ReadFromCluster::initializePipeline(QueryPipelineBuilder & pipeline, const 
     const auto & current_settings = new_context->getSettingsRef();
     auto timeouts = ConnectionTimeouts::getTCPTimeoutsWithFailover(current_settings);
 
-    auto max_replicas_to_use = reinterpret_cast<UInt64>(cluster->getShardsInfo().size());
+    auto max_replicas_to_use = static_cast<UInt64>(cluster->getShardsInfo().size());
     if (current_settings[Setting::max_parallel_replicas] > 1)
         max_replicas_to_use = std::min(max_replicas_to_use, current_settings[Setting::max_parallel_replicas].value);
 

--- a/src/Storages/IStorageCluster.cpp
+++ b/src/Storages/IStorageCluster.cpp
@@ -28,6 +28,7 @@
 #include <memory>
 #include <string>
 
+
 namespace DB
 {
 namespace Setting
@@ -188,7 +189,7 @@ void ReadFromCluster::initializePipeline(QueryPipelineBuilder & pipeline, const 
     const auto & current_settings = new_context->getSettingsRef();
     auto timeouts = ConnectionTimeouts::getTCPTimeoutsWithFailover(current_settings);
 
-    auto max_replicas_to_use = cluster->getShardsInfo().size();
+    auto max_replicas_to_use = reinterpret_cast<UInt64>(cluster->getShardsInfo().size());
     if (current_settings[Setting::max_parallel_replicas] > 1)
         max_replicas_to_use = std::min(max_replicas_to_use, current_settings[Setting::max_parallel_replicas].value);
 

--- a/src/Storages/IStorageCluster.cpp
+++ b/src/Storages/IStorageCluster.cpp
@@ -24,6 +24,7 @@
 #include <Storages/SelectQueryInfo.h>
 #include <Storages/StorageDictionary.h>
 
+#include <algorithm>
 #include <memory>
 #include <string>
 
@@ -35,6 +36,9 @@ namespace Setting
     extern const SettingsBool async_query_sending_for_remote;
     extern const SettingsBool async_socket_for_remote;
     extern const SettingsBool skip_unavailable_shards;
+    extern const SettingsBool parallel_replicas_local_plan;
+    extern const SettingsString cluster_for_parallel_replicas;
+    extern const SettingsNonZeroUInt64 max_parallel_replicas;
 }
 
 IStorageCluster::IStorageCluster(
@@ -183,29 +187,45 @@ void ReadFromCluster::initializePipeline(QueryPipelineBuilder & pipeline, const 
     auto new_context = updateSettings(context->getSettingsRef());
     const auto & current_settings = new_context->getSettingsRef();
     auto timeouts = ConnectionTimeouts::getTCPTimeoutsWithFailover(current_settings);
+
+    auto max_replicas_to_use = cluster->getShardsInfo().size();
+    if (current_settings[Setting::max_parallel_replicas] > 1)
+        max_replicas_to_use = std::min(max_replicas_to_use, current_settings[Setting::max_parallel_replicas].value);
+
     for (const auto & shard_info : cluster->getShardsInfo())
     {
-        auto try_results = shard_info.pool->getMany(timeouts, current_settings, PoolMode::GET_MANY);
-        for (auto & try_result : try_results)
-        {
-            auto remote_query_executor = std::make_shared<RemoteQueryExecutor>(
-                std::vector<IConnectionPool::Entry>{try_result},
-                queryToString(query_to_send),
-                getOutputHeader(),
-                new_context,
-                /*throttler=*/nullptr,
-                scalars,
-                Tables(),
-                processed_stage,
-                extension);
+        if (pipes.size() >= max_replicas_to_use)
+            break;
 
-            remote_query_executor->setLogger(log);
-            pipes.emplace_back(std::make_shared<RemoteSource>(
-                remote_query_executor,
-                add_agg_info,
-                current_settings[Setting::async_socket_for_remote],
-                current_settings[Setting::async_query_sending_for_remote]));
-        }
+        /// We're taking all replicas as shards,
+        /// so each shard will have only one address to connect to.
+        auto try_results = shard_info.pool->getMany(
+            timeouts,
+            current_settings,
+            PoolMode::GET_ONE,
+            {},
+            /*skip_unavailable_endpoints=*/true);
+
+        if (try_results.empty())
+            continue;
+
+        auto remote_query_executor = std::make_shared<RemoteQueryExecutor>(
+            std::vector<IConnectionPool::Entry>{try_results.front()},
+            queryToString(query_to_send),
+            getOutputHeader(),
+            new_context,
+            /*throttler=*/nullptr,
+            scalars,
+            Tables(),
+            processed_stage,
+            extension);
+
+        remote_query_executor->setLogger(log);
+        pipes.emplace_back(std::make_shared<RemoteSource>(
+            remote_query_executor,
+            add_agg_info,
+            current_settings[Setting::async_socket_for_remote],
+            current_settings[Setting::async_query_sending_for_remote]));
     }
 
     auto pipe = Pipe::unitePipes(std::move(pipes));

--- a/src/Storages/ObjectStorage/StorageObjectStorageCluster.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorageCluster.cpp
@@ -1,6 +1,8 @@
 #include "Storages/ObjectStorage/StorageObjectStorageCluster.h"
 
 #include <Common/Exception.h>
+#include <Common/StringUtils.h>
+
 #include <Core/Settings.h>
 #include <Formats/FormatFactory.h>
 #include <Parsers/queryToString.h>

--- a/src/Storages/ObjectStorage/StorageObjectStorageSource.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorageSource.cpp
@@ -917,7 +917,13 @@ StorageObjectStorage::ObjectInfoPtr StorageObjectStorageSource::ReadTaskIterator
 {
     size_t current_index = index.fetch_add(1, std::memory_order_relaxed);
     if (current_index >= buffer.size())
-        return nullptr;
+    {
+        auto key = callback();
+        if (key.empty())
+            return nullptr;
+
+        return std::make_shared<ObjectInfo>(key, std::nullopt);
+    }
 
     return buffer[current_index];
 }

--- a/src/Storages/ObjectStorage/StorageObjectStorageSource.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorageSource.cpp
@@ -129,16 +129,24 @@ std::shared_ptr<IObjectIterator> StorageObjectStorageSource::createFileIterator(
     const ActionsDAG::Node * predicate,
     const NamesAndTypesList & virtual_columns,
     ObjectInfos * read_keys,
-    std::function<void(FileProgress)> file_progress_callback)
+    std::function<void(FileProgress)> file_progress_callback,
+    bool ignore_archive_globs)
 {
+    const bool is_archive = configuration->isArchive();
+
     if (distributed_processing)
-        return std::make_shared<ReadTaskIterator>(local_context->getReadTaskCallback(), local_context->getSettingsRef()[Setting::max_threads]);
+    {
+        auto distributed_iterator = std::make_unique<ReadTaskIterator>(local_context->getReadTaskCallback(), local_context->getSettingsRef()[Setting::max_threads]);
+
+        if (is_archive)
+            return std::make_shared<ArchiveIterator>(object_storage, configuration, std::move(distributed_iterator), local_context, nullptr);
+
+        return distributed_iterator;
+    }
 
     if (configuration->isNamespaceWithGlobs())
         throw Exception(ErrorCodes::BAD_ARGUMENTS,
                         "Expression can not have wildcards inside {} name", configuration->getNamespaceType());
-
-    const bool is_archive = configuration->isArchive();
 
     std::unique_ptr<IObjectIterator> iterator;
     if (configuration->isPathWithGlobs())
@@ -190,7 +198,7 @@ std::shared_ptr<IObjectIterator> StorageObjectStorageSource::createFileIterator(
 
     if (is_archive)
     {
-        return std::make_shared<ArchiveIterator>(object_storage, configuration, std::move(iterator), local_context, read_keys);
+        return std::make_shared<ArchiveIterator>(object_storage, configuration, std::move(iterator), local_context, read_keys, ignore_archive_globs);
     }
 
     return iterator;
@@ -539,9 +547,8 @@ std::unique_ptr<ReadBufferFromFileBase> StorageObjectStorageSource::createReadBu
     if (!object_info.metadata)
     {
         if (!use_cache)
-        {
             return object_storage->readObject(StoredObject(object_info.getPath()), read_settings);
-        }
+
         object_info.metadata = object_storage->getObjectMetadata(object_info.getPath());
     }
 
@@ -646,6 +653,7 @@ std::unique_ptr<ReadBufferFromFileBase> StorageObjectStorageSource::createReadBu
         impl->setReadUntilEnd();
         impl->prefetch(DEFAULT_PREFETCH_PRIORITY);
     }
+
     return impl;
 }
 
@@ -828,7 +836,7 @@ StorageObjectStorage::ObjectInfoPtr StorageObjectStorageSource::KeysIterator::ne
     {
         size_t current_index = index.fetch_add(1, std::memory_order_relaxed);
         if (current_index >= keys.size())
-            return {};
+            return nullptr;
 
         auto key = keys[current_index];
 
@@ -898,8 +906,10 @@ StorageObjectStorageSource::ReadTaskIterator::ReadTaskIterator(
     for (auto & key_future : keys)
     {
         auto key = key_future.get();
-        if (!key.empty())
-            buffer.emplace_back(std::make_shared<ObjectInfo>(key, std::nullopt));
+        if (key.empty())
+            continue;
+
+        buffer.emplace_back(std::make_shared<ObjectInfo>(key, std::nullopt));
     }
 }
 
@@ -907,7 +917,7 @@ StorageObjectStorage::ObjectInfoPtr StorageObjectStorageSource::ReadTaskIterator
 {
     size_t current_index = index.fetch_add(1, std::memory_order_relaxed);
     if (current_index >= buffer.size())
-        return std::make_shared<ObjectInfo>(callback());
+        return nullptr;
 
     return buffer[current_index];
 }
@@ -938,7 +948,7 @@ StorageObjectStorageSource::ArchiveIterator::ArchiveIterator(
     ConfigurationPtr configuration_,
     std::unique_ptr<IObjectIterator> archives_iterator_,
     ContextPtr context_,
-    ObjectInfos * read_keys_)
+    ObjectInfos * read_keys_, bool ignore_archive_globs_)
     : WithContext(context_)
     , object_storage(object_storage_)
     , is_path_in_archive_with_globs(configuration_->isPathInArchiveWithGlobs())
@@ -947,6 +957,7 @@ StorageObjectStorageSource::ArchiveIterator::ArchiveIterator(
     , log(getLogger("ArchiveIterator"))
     , path_in_archive(is_path_in_archive_with_globs ? "" : configuration_->getPathInArchive())
     , read_keys(read_keys_)
+    , ignore_archive_globs(ignore_archive_globs_)
 {
 }
 
@@ -977,12 +988,15 @@ ObjectInfoPtr StorageObjectStorageSource::ArchiveIterator::next(size_t processor
                 if (!archive_object)
                     return {};
 
+                if (!archive_object->metadata)
+                    archive_object->metadata = object_storage->getObjectMetadata(archive_object->getPath());
+
                 archive_reader = createArchiveReader(archive_object);
                 file_enumerator = archive_reader->firstFile();
                 if (!file_enumerator)
                     continue;
             }
-            else if (!file_enumerator->nextFile())
+            else if (!file_enumerator->nextFile() || ignore_archive_globs)
             {
                 file_enumerator.reset();
                 continue;

--- a/src/Storages/ObjectStorage/StorageObjectStorageSource.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorageSource.cpp
@@ -954,7 +954,8 @@ StorageObjectStorageSource::ArchiveIterator::ArchiveIterator(
     ConfigurationPtr configuration_,
     std::unique_ptr<IObjectIterator> archives_iterator_,
     ContextPtr context_,
-    ObjectInfos * read_keys_, bool ignore_archive_globs_)
+    ObjectInfos * read_keys_,
+    bool ignore_archive_globs_)
     : WithContext(context_)
     , object_storage(object_storage_)
     , is_path_in_archive_with_globs(configuration_->isPathInArchiveWithGlobs())

--- a/src/Storages/ObjectStorage/StorageObjectStorageSource.h
+++ b/src/Storages/ObjectStorage/StorageObjectStorageSource.h
@@ -257,7 +257,8 @@ public:
         ConfigurationPtr configuration_,
         std::unique_ptr<IObjectIterator> archives_iterator_,
         ContextPtr context_,
-        ObjectInfos * read_keys_, bool ignore_archive_globs_ = false);
+        ObjectInfos * read_keys_,
+        bool ignore_archive_globs_ = false);
 
     ObjectInfoPtr next(size_t processor) override;
 

--- a/src/Storages/ObjectStorage/StorageObjectStorageSource.h
+++ b/src/Storages/ObjectStorage/StorageObjectStorageSource.h
@@ -56,7 +56,8 @@ public:
         const ActionsDAG::Node * predicate,
         const NamesAndTypesList & virtual_columns,
         ObjectInfos * read_keys,
-        std::function<void(FileProgress)> file_progress_callback = {});
+        std::function<void(FileProgress)> file_progress_callback = {},
+        bool ignore_archive_globs = false);
 
     static std::string getUniqueStoragePathIdentifier(
         const Configuration & configuration,
@@ -256,7 +257,7 @@ public:
         ConfigurationPtr configuration_,
         std::unique_ptr<IObjectIterator> archives_iterator_,
         ContextPtr context_,
-        ObjectInfos * read_keys_);
+        ObjectInfos * read_keys_, bool ignore_archive_globs_ = false);
 
     ObjectInfoPtr next(size_t processor) override;
 
@@ -315,6 +316,8 @@ private:
     std::shared_ptr<IArchiveReader> archive_reader;
     /// File enumerator inside the archive.
     std::unique_ptr<IArchiveReader::FileEnumerator> file_enumerator;
+
+    bool ignore_archive_globs;
 
     std::mutex next_mutex;
 };

--- a/src/Storages/StorageFileCluster.cpp
+++ b/src/Storages/StorageFileCluster.cpp
@@ -9,7 +9,7 @@
 #include <Storages/StorageFileCluster.h>
 #include <Storages/IStorage.h>
 #include <Storages/StorageFile.h>
-#include <Storages/extractTableFunctionArgumentsFromSelectQuery.h>
+#include <Storages/extractTableFunctionFromSelectQuery.h>
 #include <Storages/VirtualColumnUtils.h>
 #include <TableFunctions/TableFunctionFileCluster.h>
 
@@ -21,7 +21,7 @@ namespace DB
 
 namespace ErrorCodes
 {
-extern const int LOGICAL_ERROR;
+    extern const int LOGICAL_ERROR;
 }
 
 StorageFileCluster::StorageFileCluster(
@@ -66,12 +66,16 @@ StorageFileCluster::StorageFileCluster(
 
 void StorageFileCluster::updateQueryToSendIfNeeded(DB::ASTPtr & query, const StorageSnapshotPtr & storage_snapshot, const DB::ContextPtr & context)
 {
-    ASTExpressionList * expression_list = extractTableFunctionArgumentsFromSelectQuery(query);
-    if (!expression_list)
+    auto * table_function = extractTableFunctionFromSelectQuery(query);
+    if (!table_function)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Expected SELECT query from table function fileCluster, got '{}'", queryToString(query));
 
     TableFunctionFileCluster::updateStructureAndFormatArgumentsIfNeeded(
-        expression_list->children, storage_snapshot->metadata->getColumns().getAll().toNamesAndTypesDescription(), format_name, context);
+        table_function,
+        storage_snapshot->metadata->getColumns().getAll().toNamesAndTypesDescription(),
+        format_name,
+        context
+    );
 }
 
 RemoteQueryExecutor::Extension StorageFileCluster::getTaskIteratorExtension(const ActionsDAG::Node * predicate, const ContextPtr & context) const

--- a/src/Storages/StorageURLCluster.cpp
+++ b/src/Storages/StorageURLCluster.cpp
@@ -19,7 +19,7 @@
 #include <Storages/IStorage.h>
 #include <Storages/SelectQueryInfo.h>
 #include <Storages/StorageURL.h>
-#include <Storages/extractTableFunctionArgumentsFromSelectQuery.h>
+#include <Storages/extractTableFunctionFromSelectQuery.h>
 #include <Storages/VirtualColumnUtils.h>
 
 #include <TableFunctions/TableFunctionURLCluster.h>
@@ -29,14 +29,15 @@
 
 namespace DB
 {
-namespace Setting
-{
-    extern const SettingsUInt64 glob_expansion_max_elements;
-}
 
 namespace ErrorCodes
 {
     extern const int LOGICAL_ERROR;
+}
+
+namespace Setting
+{
+    extern const SettingsUInt64 glob_expansion_max_elements;
 }
 
 StorageURLCluster::StorageURLCluster(
@@ -85,12 +86,20 @@ StorageURLCluster::StorageURLCluster(
 
 void StorageURLCluster::updateQueryToSendIfNeeded(ASTPtr & query, const StorageSnapshotPtr & storage_snapshot, const ContextPtr & context)
 {
-    ASTExpressionList * expression_list = extractTableFunctionArgumentsFromSelectQuery(query);
+    auto * table_function = extractTableFunctionFromSelectQuery(query);
+    if (!table_function)
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Expected SELECT query from table function urlCluster, got '{}'", queryToString(query));
+
+    auto * expression_list = table_function->arguments->as<ASTExpressionList>();
     if (!expression_list)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Expected SELECT query from table function urlCluster, got '{}'", queryToString(query));
 
     TableFunctionURLCluster::updateStructureAndFormatArgumentsIfNeeded(
-        expression_list->children, storage_snapshot->metadata->getColumns().getAll().toNamesAndTypesDescription(), format_name, context);
+        table_function,
+        storage_snapshot->metadata->getColumns().getAll().toNamesAndTypesDescription(),
+        format_name,
+        context
+    );
 }
 
 RemoteQueryExecutor::Extension StorageURLCluster::getTaskIteratorExtension(const ActionsDAG::Node * predicate, const ContextPtr & context) const

--- a/src/Storages/extractTableFunctionFromSelectQuery.cpp
+++ b/src/Storages/extractTableFunctionFromSelectQuery.cpp
@@ -1,7 +1,6 @@
-#include <Storages/extractTableFunctionArgumentsFromSelectQuery.h>
+#include <Storages/extractTableFunctionFromSelectQuery.h>
 
 #include <Parsers/ASTExpressionList.h>
-#include <Parsers/ASTFunction.h>
 #include <Parsers/ASTLiteral.h>
 #include <Parsers/ASTSelectQuery.h>
 #include <Parsers/ASTTablesInSelectQuery.h>
@@ -11,7 +10,7 @@
 namespace DB
 {
 
-ASTExpressionList * extractTableFunctionArgumentsFromSelectQuery(ASTPtr & query)
+ASTFunction * extractTableFunctionFromSelectQuery(ASTPtr & query)
 {
     auto * select_query = query->as<ASTSelectQuery>();
     if (!select_query || !select_query->tables())
@@ -22,8 +21,7 @@ ASTExpressionList * extractTableFunctionArgumentsFromSelectQuery(ASTPtr & query)
     if (!table_expression->table_function)
         return nullptr;
 
-    auto * table_function = table_expression->table_function->as<ASTFunction>();
-    return table_function->arguments->as<ASTExpressionList>();
+    return table_expression->table_function->as<ASTFunction>();
 }
 
 }

--- a/src/Storages/extractTableFunctionFromSelectQuery.h
+++ b/src/Storages/extractTableFunctionFromSelectQuery.h
@@ -2,10 +2,11 @@
 
 #include <Parsers/IAST_fwd.h>
 #include <Parsers/ASTExpressionList.h>
+#include <Parsers/ASTFunction.h>
 
 namespace DB
 {
 
-ASTExpressionList * extractTableFunctionArgumentsFromSelectQuery(ASTPtr & query);
+ASTFunction * extractTableFunctionFromSelectQuery(ASTPtr & query);
 
 }

--- a/src/TableFunctions/ITableFunction.h
+++ b/src/TableFunctions/ITableFunction.h
@@ -82,7 +82,7 @@ public:
 
     /// Create storage according to the query.
     StoragePtr
-    execute(const ASTPtr & ast_function, ContextPtr context, const std::string & table_name, ColumnsDescription cached_columns_ = {}, bool use_global_context = false, bool is_insert = false) const;
+    execute(const ASTPtr & ast_function, ContextPtr context, const std::string & table_name, ColumnsDescription cached_columns_ = {}, bool use_global_context = false, bool is_insert_query = false) const;
 
     virtual ~ITableFunction() = default;
 

--- a/src/TableFunctions/ITableFunctionCluster.h
+++ b/src/TableFunctions/ITableFunctionCluster.h
@@ -2,6 +2,7 @@
 
 #include <Interpreters/Context.h>
 #include <Interpreters/evaluateConstantExpression.h>
+#include <Parsers/ASTFunction.h>
 #include <Storages/checkAndGetLiteralArgument.h>
 #include <TableFunctions/ITableFunction.h>
 #include <TableFunctions/TableFunctionObjectStorage.h>
@@ -24,15 +25,25 @@ class ITableFunctionCluster : public Base
 public:
     String getName() const override = 0;
 
-    static void updateStructureAndFormatArgumentsIfNeeded(ASTs & args, const String & structure_, const String & format_, const ContextPtr & context)
+    static void updateStructureAndFormatArgumentsIfNeeded(ASTFunction * table_function, const String & structure_, const String & format_, const ContextPtr & context)
     {
+        auto * expression_list = table_function->arguments->as<ASTExpressionList>();
+        ASTs args = expression_list->children;
+
         if (args.empty())
             throw Exception(ErrorCodes::LOGICAL_ERROR, "Unexpected empty list of arguments for {}Cluster table function", Base::name);
 
-        ASTPtr cluster_name_arg = args.front();
-        args.erase(args.begin());
-        Base::updateStructureAndFormatArgumentsIfNeeded(args, structure_, format_, context, /*with_structure=*/true);
-        args.insert(args.begin(), cluster_name_arg);
+        if (table_function->name == Base::name)
+            Base::updateStructureAndFormatArgumentsIfNeeded(args, structure_, format_, context, /*with_structure=*/true);
+        else if (table_function->name == fmt::format("{}Cluster", Base::name))
+        {
+            ASTPtr cluster_name_arg = args.front();
+            args.erase(args.begin());
+            Base::updateStructureAndFormatArgumentsIfNeeded(args, structure_, format_, context, /*with_structure=*/true);
+            args.insert(args.begin(), cluster_name_arg);
+        }
+        else
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "Unexpected table function name: {}", table_function->name);
     }
 
     bool canBeUsedToCreateTable() const override { return false; }

--- a/src/TableFunctions/ITableFunctionFileLike.cpp
+++ b/src/TableFunctions/ITableFunctionFileLike.cpp
@@ -1,17 +1,14 @@
-#include <TableFunctions/ITableFunctionFileLike.h>
+#include <Interpreters/evaluateConstantExpression.h>
 #include <Interpreters/parseColumnsListForTableFunction.h>
 
-#include <Parsers/ASTFunction.h>
+#include <Storages/StorageFile.h>
+#include <Storages/VirtualColumnUtils.h>
+#include <Storages/checkAndGetLiteralArgument.h>
 
 #include <Common/Exception.h>
-
-#include <Storages/StorageFile.h>
-#include <Storages/checkAndGetLiteralArgument.h>
-#include <Storages/VirtualColumnUtils.h>
-
-#include <Interpreters/evaluateConstantExpression.h>
-
 #include <Formats/FormatFactory.h>
+#include <Parsers/ASTFunction.h>
+#include <TableFunctions/ITableFunctionFileLike.h>
 
 namespace DB
 {
@@ -88,7 +85,7 @@ void ITableFunctionFileLike::parseArgumentsImpl(ASTs & args, const ContextPtr & 
         compression_method = checkAndGetLiteralArgument<String>(args[3], "compression_method");
 }
 
-StoragePtr ITableFunctionFileLike::executeImpl(const ASTPtr & /*ast_function*/, ContextPtr context, const std::string & table_name, ColumnsDescription /*cached_columns*/, bool /*is_insert_query*/) const
+StoragePtr ITableFunctionFileLike::executeImpl(const ASTPtr & /*ast_function*/, ContextPtr context, const std::string & table_name, ColumnsDescription /*cached_columns*/, bool is_insert_query) const
 {
     ColumnsDescription columns;
     if (structure != "auto")
@@ -96,7 +93,7 @@ StoragePtr ITableFunctionFileLike::executeImpl(const ASTPtr & /*ast_function*/, 
     else if (!structure_hint.empty())
         columns = structure_hint;
 
-    StoragePtr storage = getStorage(filename, format, columns, context, table_name, compression_method);
+    StoragePtr storage = getStorage(filename, format, columns, context, table_name, compression_method, is_insert_query);
     storage->startup();
     return storage;
 }

--- a/src/TableFunctions/ITableFunctionFileLike.h
+++ b/src/TableFunctions/ITableFunctionFileLike.h
@@ -99,7 +99,7 @@ private:
 
     virtual StoragePtr getStorage(
         const String & source, const String & format, const ColumnsDescription & columns, ContextPtr global_context,
-        const std::string & table_name, const String & compression_method) const = 0;
+        const std::string & table_name, const String & compression_method, bool is_insert_query) const = 0;
 
     bool hasStaticStructure() const override { return structure != "auto"; }
 };

--- a/src/TableFunctions/TableFunctionFile.cpp
+++ b/src/TableFunctions/TableFunctionFile.cpp
@@ -74,7 +74,8 @@ StoragePtr TableFunctionFile::getStorage(
     const ColumnsDescription & columns,
     ContextPtr global_context,
     const std::string & table_name,
-    const std::string & compression_method_) const
+    const std::string & compression_method_,
+    bool /*is_insert_query*/) const
 {
     // For `file` table function, we are going to use format settings from the
     // query context.

--- a/src/TableFunctions/TableFunctionFile.h
+++ b/src/TableFunctions/TableFunctionFile.h
@@ -31,7 +31,7 @@ protected:
 private:
     StoragePtr getStorage(
         const String & source, const String & format_, const ColumnsDescription & columns, ContextPtr global_context,
-        const std::string & table_name, const std::string & compression_method_) const override;
+        const std::string & table_name, const std::string & compression_method_, bool) const override;
     const char * getStorageTypeName() const override { return "File"; }
 };
 

--- a/src/TableFunctions/TableFunctionFileCluster.cpp
+++ b/src/TableFunctions/TableFunctionFileCluster.cpp
@@ -16,7 +16,7 @@ namespace Setting
 
 StoragePtr TableFunctionFileCluster::getStorage(
     const String & /*source*/, const String & /*format_*/, const ColumnsDescription & columns, ContextPtr context,
-    const std::string & table_name, const String & /*compression_method_*/) const
+    const std::string & table_name, const String & /*compression_method_*/, bool /*is_insert_query*/) const
 {
     StoragePtr storage;
 

--- a/src/TableFunctions/TableFunctionFileCluster.h
+++ b/src/TableFunctions/TableFunctionFileCluster.h
@@ -27,7 +27,7 @@ public:
 protected:
     StoragePtr getStorage(
         const String & source, const String & format_, const ColumnsDescription & columns, ContextPtr global_context,
-        const std::string & table_name, const String & compression_method_) const override;
+        const std::string & table_name, const String & compression_method_, bool) const override;
 
     const char * getStorageTypeName() const override { return "FileCluster"; }
 };

--- a/src/TableFunctions/TableFunctionObjectStorage.cpp
+++ b/src/TableFunctions/TableFunctionObjectStorage.cpp
@@ -1,5 +1,8 @@
 #include "config.h"
 
+#include <Core/Settings.h>
+#include <Core/SettingsEnums.h>
+
 #include <Access/Common/AccessFlags.h>
 #include <Analyzer/FunctionNode.h>
 #include <Analyzer/TableFunctionNode.h>
@@ -20,10 +23,19 @@
 #include <Storages/ObjectStorage/Local/Configuration.h>
 #include <Storages/ObjectStorage/S3/Configuration.h>
 #include <Storages/ObjectStorage/StorageObjectStorage.h>
+#include <Storages/ObjectStorage/StorageObjectStorageCluster.h>
 
 
 namespace DB
 {
+
+namespace Setting
+{
+    extern const SettingsUInt64 allow_experimental_parallel_reading_from_replicas;
+    extern const SettingsBool parallel_replicas_for_cluster_engines;
+    extern const SettingsString cluster_for_parallel_replicas;
+    extern const SettingsParallelReplicasMode parallel_replicas_mode;
+}
 
 namespace ErrorCodes
 {
@@ -113,8 +125,9 @@ StoragePtr TableFunctionObjectStorage<Definition, Configuration>::executeImpl(
     ColumnsDescription cached_columns,
     bool is_insert_query) const
 {
-    ColumnsDescription columns;
     chassert(configuration);
+    ColumnsDescription columns;
+
     if (configuration->structure != "auto")
         columns = parseColumnsListFromString(configuration->structure, context);
     else if (!structure_hint.empty())
@@ -122,18 +135,44 @@ StoragePtr TableFunctionObjectStorage<Definition, Configuration>::executeImpl(
     else if (!cached_columns.empty())
         columns = cached_columns;
 
-    StoragePtr storage = std::make_shared<StorageObjectStorage>(
+    StoragePtr storage;
+    const auto & settings = context->getSettingsRef();
+
+    const auto parallel_replicas_cluster_name = settings[Setting::cluster_for_parallel_replicas].toString();
+    const auto can_use_parallel_replicas = !parallel_replicas_cluster_name.empty()
+        && settings[Setting::parallel_replicas_for_cluster_engines]
+        && context->canUseTaskBasedParallelReplicas()
+        && !context->isDistributed();
+
+    const auto is_secondary_query = context->getClientInfo().query_kind == ClientInfo::QueryKind::SECONDARY_QUERY;
+
+    if (can_use_parallel_replicas && !is_secondary_query)
+    {
+        storage = std::make_shared<StorageObjectStorageCluster>(
+            parallel_replicas_cluster_name,
+            configuration,
+            getObjectStorage(context, !is_insert_query),
+            StorageID(getDatabaseName(), table_name),
+            columns,
+            ConstraintsDescription{},
+            context);
+
+        storage->startup();
+        return storage;
+    }
+
+    storage = std::make_shared<StorageObjectStorage>(
         configuration,
         getObjectStorage(context, !is_insert_query),
         context,
         StorageID(getDatabaseName(), table_name),
         columns,
         ConstraintsDescription{},
-        String{},
+        /* comment */ String{},
         /* format_settings */ std::nullopt,
         /* mode */ LoadingStrictnessLevel::CREATE,
         /* distributed_processing */ false,
-        nullptr);
+        /* partition_by */ nullptr);
 
     storage->startup();
     return storage;

--- a/src/TableFunctions/TableFunctionObjectStorage.h
+++ b/src/TableFunctions/TableFunctionObjectStorage.h
@@ -7,7 +7,9 @@
 #include <Storages/ObjectStorage/StorageObjectStorageSettings.h>
 #include <Storages/VirtualColumnUtils.h>
 #include <TableFunctions/ITableFunction.h>
+
 #include "config.h"
+
 
 namespace DB
 {

--- a/src/TableFunctions/TableFunctionURL.cpp
+++ b/src/TableFunctions/TableFunctionURL.cpp
@@ -94,15 +94,16 @@ StoragePtr TableFunctionURL::getStorage(
     const std::string & table_name, const String & compression_method_, bool is_insert_query) const
 {
     const auto & settings = global_context->getSettingsRef();
+    const auto is_secondary_query = global_context->getClientInfo().query_kind == ClientInfo::QueryKind::SECONDARY_QUERY;
     const auto parallel_replicas_cluster_name = settings[Setting::cluster_for_parallel_replicas].toString();
     const auto can_use_parallel_replicas = !parallel_replicas_cluster_name.empty()
         && settings[Setting::parallel_replicas_for_cluster_engines]
         && global_context->canUseTaskBasedParallelReplicas()
-        && !global_context->isDistributed();
+        && !global_context->isDistributed()
+        && !is_secondary_query
+        && !is_insert_query;
 
-    const auto is_secondary_query = global_context->getClientInfo().query_kind == ClientInfo::QueryKind::SECONDARY_QUERY;
-
-    if (can_use_parallel_replicas && !is_secondary_query && !is_insert_query)
+    if (can_use_parallel_replicas)
     {
         return std::make_shared<StorageURLCluster>(
             global_context,

--- a/src/TableFunctions/TableFunctionURL.cpp
+++ b/src/TableFunctions/TableFunctionURL.cpp
@@ -91,7 +91,7 @@ void TableFunctionURL::parseArgumentsImpl(ASTs & args, const ContextPtr & contex
 
 StoragePtr TableFunctionURL::getStorage(
     const String & source, const String & format_, const ColumnsDescription & columns, ContextPtr global_context,
-    const std::string & table_name, const String & compression_method_) const
+    const std::string & table_name, const String & compression_method_, bool is_insert_query) const
 {
     const auto & settings = global_context->getSettingsRef();
     const auto parallel_replicas_cluster_name = settings[Setting::cluster_for_parallel_replicas].toString();
@@ -102,11 +102,11 @@ StoragePtr TableFunctionURL::getStorage(
 
     const auto is_secondary_query = global_context->getClientInfo().query_kind == ClientInfo::QueryKind::SECONDARY_QUERY;
 
-    if (can_use_parallel_replicas && !is_secondary_query)
+    if (can_use_parallel_replicas && !is_secondary_query && !is_insert_query)
     {
         return std::make_shared<StorageURLCluster>(
             global_context,
-            settings[Setting::cluster_for_parallel_replicas],
+            parallel_replicas_cluster_name,
             filename,
             format,
             compression_method,
@@ -127,7 +127,9 @@ StoragePtr TableFunctionURL::getStorage(
         global_context,
         compression_method_,
         configuration.headers,
-        configuration.http_method);
+        configuration.http_method,
+        nullptr,
+        /*distributed_processing=*/ is_secondary_query);
 }
 
 ColumnsDescription TableFunctionURL::getActualTableStructure(ContextPtr context, bool /*is_insert_query*/) const

--- a/src/TableFunctions/TableFunctionURL.cpp
+++ b/src/TableFunctions/TableFunctionURL.cpp
@@ -2,21 +2,33 @@
 
 #include "registerTableFunctions.h"
 #include <Access/Common/AccessFlags.h>
+#include <Analyzer/FunctionNode.h>
+#include <Analyzer/TableFunctionNode.h>
+#include <Core/Settings.h>
+#include <Formats/FormatFactory.h>
 #include <Interpreters/evaluateConstantExpression.h>
+#include <Interpreters/parseColumnsListForTableFunction.h>
 #include <Parsers/ASTFunction.h>
 #include <Parsers/ASTIdentifier.h>
 #include <Storages/ColumnsDescription.h>
 #include <Storages/NamedCollectionsHelpers.h>
+#include <Storages/StorageURLCluster.h>
 #include <TableFunctions/TableFunctionFactory.h>
-#include <Analyzer/FunctionNode.h>
-#include <Analyzer/TableFunctionNode.h>
-#include <Interpreters/parseColumnsListForTableFunction.h>
-#include <Formats/FormatFactory.h>
 
 #include <IO/WriteHelpers.h>
 #include <IO/WriteBufferFromVector.h>
+
+
 namespace DB
 {
+
+namespace Setting
+{
+    extern const SettingsUInt64 allow_experimental_parallel_reading_from_replicas;
+    extern const SettingsBool parallel_replicas_for_cluster_engines;
+    extern const SettingsString cluster_for_parallel_replicas;
+    extern const SettingsParallelReplicasMode parallel_replicas_mode;
+}
 
 std::vector<size_t> TableFunctionURL::skipAnalysisForArguments(const QueryTreeNodePtr & query_node_table_function, ContextPtr) const
 {
@@ -81,6 +93,29 @@ StoragePtr TableFunctionURL::getStorage(
     const String & source, const String & format_, const ColumnsDescription & columns, ContextPtr global_context,
     const std::string & table_name, const String & compression_method_) const
 {
+    const auto & settings = global_context->getSettingsRef();
+    const auto parallel_replicas_cluster_name = settings[Setting::cluster_for_parallel_replicas].toString();
+    const auto can_use_parallel_replicas = !parallel_replicas_cluster_name.empty()
+        && settings[Setting::parallel_replicas_for_cluster_engines]
+        && global_context->canUseTaskBasedParallelReplicas()
+        && !global_context->isDistributed();
+
+    const auto is_secondary_query = global_context->getClientInfo().query_kind == ClientInfo::QueryKind::SECONDARY_QUERY;
+
+    if (can_use_parallel_replicas && !is_secondary_query)
+    {
+        return std::make_shared<StorageURLCluster>(
+            global_context,
+            settings[Setting::cluster_for_parallel_replicas],
+            filename,
+            format,
+            compression_method,
+            StorageID(getDatabaseName(), table_name),
+            getActualTableStructure(global_context, /* is_insert_query */ true),
+            ConstraintsDescription{},
+            configuration);
+    }
+
     return std::make_shared<StorageURL>(
         source,
         StorageID(getDatabaseName(), table_name),

--- a/src/TableFunctions/TableFunctionURL.h
+++ b/src/TableFunctions/TableFunctionURL.h
@@ -87,7 +87,7 @@ private:
 
     StoragePtr getStorage(
         const String & source, const String & format_, const ColumnsDescription & columns, ContextPtr global_context,
-        const std::string & table_name, const String & compression_method_) const override;
+        const std::string & table_name, const String & compression_method_, bool is_insert_query) const override;
 
     const char * getStorageTypeName() const override { return "URL"; }
 

--- a/src/TableFunctions/TableFunctionURLCluster.cpp
+++ b/src/TableFunctions/TableFunctionURLCluster.cpp
@@ -10,11 +10,10 @@ StoragePtr TableFunctionURLCluster::getStorage(
     const String & /*source*/, const String & /*format_*/, const ColumnsDescription & columns, ContextPtr context,
     const std::string & table_name, const String & /*compression_method_*/) const
 {
-    StoragePtr storage;
     if (context->getClientInfo().query_kind == ClientInfo::QueryKind::SECONDARY_QUERY)
     {
         //On worker node this uri won't contain globs
-        storage = std::make_shared<StorageURL>(
+        return std::make_shared<StorageURL>(
             filename,
             StorageID(getDatabaseName(), table_name),
             format,
@@ -29,20 +28,17 @@ StoragePtr TableFunctionURLCluster::getStorage(
             nullptr,
             /*distributed_processing=*/ true);
     }
-    else
-    {
-        storage = std::make_shared<StorageURLCluster>(
-            context,
-            cluster_name,
-            filename,
-            format,
-            compression_method,
-            StorageID(getDatabaseName(), table_name),
-            getActualTableStructure(context, /* is_insert_query */ true),
-            ConstraintsDescription{},
-            configuration);
-    }
-    return storage;
+
+    return std::make_shared<StorageURLCluster>(
+        context,
+        cluster_name,
+        filename,
+        format,
+        compression_method,
+        StorageID(getDatabaseName(), table_name),
+        getActualTableStructure(context, /* is_insert_query */ true),
+        ConstraintsDescription{},
+        configuration);
 }
 
 void registerTableFunctionURLCluster(TableFunctionFactory & factory)

--- a/src/TableFunctions/TableFunctionURLCluster.cpp
+++ b/src/TableFunctions/TableFunctionURLCluster.cpp
@@ -8,7 +8,7 @@ namespace DB
 
 StoragePtr TableFunctionURLCluster::getStorage(
     const String & /*source*/, const String & /*format_*/, const ColumnsDescription & columns, ContextPtr context,
-    const std::string & table_name, const String & /*compression_method_*/) const
+    const std::string & table_name, const String & /*compression_method_*/, bool /*is_insert_query*/) const
 {
     if (context->getClientInfo().query_kind == ClientInfo::QueryKind::SECONDARY_QUERY)
     {

--- a/src/TableFunctions/TableFunctionURLCluster.h
+++ b/src/TableFunctions/TableFunctionURLCluster.h
@@ -44,7 +44,7 @@ public:
 protected:
     StoragePtr getStorage(
         const String & source, const String & format_, const ColumnsDescription & columns, ContextPtr global_context,
-        const std::string & table_name, const String & compression_method_) const override;
+        const std::string & table_name, const String & compression_method_, bool) const override;
 
     const char * getStorageTypeName() const override { return "URLCluster"; }
 };

--- a/tests/queries/0_stateless/02496_storage_s3_profile_events.sql
+++ b/tests/queries/0_stateless/02496_storage_s3_profile_events.sql
@@ -9,6 +9,7 @@ PARTITION BY a;
 INSERT INTO t_s3_events_02496 SELECT number FROM numbers(10) SETTINGS s3_truncate_on_insert=1;
 
 SET max_threads = 1;
+SET parallel_replicas_for_cluster_engines = 0;
 SELECT count() FROM s3(s3_conn, filename = 'test_02496_*', format = Parquet, structure = 'a UInt64');
 SYSTEM FLUSH LOGS query_log;
 

--- a/tests/queries/0_stateless/02789_reading_from_s3_with_connection_pool.sh
+++ b/tests/queries/0_stateless/02789_reading_from_s3_with_connection_pool.sh
@@ -42,8 +42,9 @@ done
 while true
 do
     query_id=$(${CLICKHOUSE_CLIENT} -q "
-    create table mut (n int, m int, k int) engine=ReplicatedMergeTree('/test/02441/{database}/mut', '1') order by n;
+    create table if not exists mut (n int, m int, k int) engine=ReplicatedMergeTree('/test/02441/{database}/mut', '1') order by n;
     set insert_keeper_fault_injection_probability=0;
+    set parallel_replicas_for_cluster_engines=0;
     insert into mut values (1, 2, 3), (10, 20, 30);
 
     system stop merges mut;

--- a/tests/queries/0_stateless/03237_insert_sparse_columns_mem.sh
+++ b/tests/queries/0_stateless/03237_insert_sparse_columns_mem.sh
@@ -13,7 +13,7 @@ for i in {1..250}; do
     table_structure+=", c$i String"
 done
 
-MY_CLICKHOUSE_CLIENT="$CLICKHOUSE_CLIENT --enable_parsing_to_custom_serialization 1"
+MY_CLICKHOUSE_CLIENT="$CLICKHOUSE_CLIENT --enable_parsing_to_custom_serialization 1 --parallel_replicas_for_cluster_engines 0"
 
 $MY_CLICKHOUSE_CLIENT --query "
     DROP TABLE IF EXISTS t_insert_mem;

--- a/tests/queries/0_stateless/03275_auto_cluster_functions_with_parallel_replicas.reference
+++ b/tests/queries/0_stateless/03275_auto_cluster_functions_with_parallel_replicas.reference
@@ -5,11 +5,11 @@ Expression (Project names)
 CreatingSets (Create sets before main query execution)
   Expression ((Project names + Projection))
     Filter ((WHERE + Change column names to column identifiers))
-      S3Source
+      S3(_table_function.s3)Source
   CreatingSet (Create set for subquery)
     Expression ((Project names + (Projection + Change column names to column identifiers)))
-      S3Source
+      S3(_table_function.s3)Source
 Expression ((Project names + (Projection + Change column names to column identifiers)))
   ReadFromURL
 Expression ((Project names + (Projection + Change column names to column identifiers)))
-  S3Source
+  S3(_table_function.s3)Source

--- a/tests/queries/0_stateless/03275_auto_cluster_functions_with_parallel_replicas.reference
+++ b/tests/queries/0_stateless/03275_auto_cluster_functions_with_parallel_replicas.reference
@@ -1,0 +1,15 @@
+Expression (Project names)
+  ReadFromCluster
+Expression (Project names)
+  ReadFromCluster
+CreatingSets (Create sets before main query execution)
+  Expression ((Project names + Projection))
+    Filter ((WHERE + Change column names to column identifiers))
+      S3Source
+  CreatingSet (Create set for subquery)
+    Expression ((Project names + (Projection + Change column names to column identifiers)))
+      S3Source
+Expression ((Project names + (Projection + Change column names to column identifiers)))
+  ReadFromURL
+Expression ((Project names + (Projection + Change column names to column identifiers)))
+  S3Source

--- a/tests/queries/0_stateless/03275_auto_cluster_functions_with_parallel_replicas.sql
+++ b/tests/queries/0_stateless/03275_auto_cluster_functions_with_parallel_replicas.sql
@@ -1,6 +1,7 @@
 -- Tags: no-fasttest
 -- Tag no-fasttest: Depends on Minio
 
+SET enable_analyzer=1;
 SET enable_parallel_replicas=1;
 SET max_parallel_replicas=4;
 SET cluster_for_parallel_replicas='test_cluster_two_shards';

--- a/tests/queries/0_stateless/03275_auto_cluster_functions_with_parallel_replicas.sql
+++ b/tests/queries/0_stateless/03275_auto_cluster_functions_with_parallel_replicas.sql
@@ -1,5 +1,5 @@
 -- Tags: no-fasttest
--- Tag no-fasttest: Depends on AWS
+-- Tag no-fasttest: Depends on Minio
 
 SET enable_parallel_replicas=1;
 SET max_parallel_replicas=4;

--- a/tests/queries/0_stateless/03275_auto_cluster_functions_with_parallel_replicas.sql
+++ b/tests/queries/0_stateless/03275_auto_cluster_functions_with_parallel_replicas.sql
@@ -1,0 +1,16 @@
+-- Tags: no-fasttest
+-- Tag no-fasttest: Depends on AWS
+
+SET enable_parallel_replicas=1;
+SET max_parallel_replicas=4;
+SET cluster_for_parallel_replicas='test_cluster_two_shards';
+SET parallel_replicas_for_cluster_engines=true;
+
+EXPLAIN SELECT * FROM url('http://localhost:8123');
+EXPLAIN SELECT * FROM s3('http://localhost:11111/test/a.tsv', 'TSV');
+EXPLAIN SELECT * FROM s3('http://localhost:11111/test/a.tsv', 'TSV') where c1 in (SELECT c1 FROM s3('http://localhost:11111/test/a.tsv', 'TSV'));
+
+SET parallel_replicas_for_cluster_engines=false;
+
+EXPLAIN SELECT * FROM url('http://localhost:8123');
+EXPLAIN SELECT * FROM s3('http://localhost:11111/test/a.tsv', 'TSV');


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Replace table functions with their -Cluster alternatives if parallel replicas are enabled. Fixes https://github.com/ClickHouse/ClickHouse/issues/65024

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)


#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---ci_include_fuzzer--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
