### PR TITLE
Insert into table function s3 respect query settings

### DIFF
--- a/src/Disks/ObjectStorages/S3/diskSettings.cpp
+++ b/src/Disks/ObjectStorages/S3/diskSettings.cpp
@@ -92,12 +92,26 @@ std::unique_ptr<S3::Client> getClient(
             "Region should be explicitly specified for directory buckets");
     }
 
+    const Settings & local_settings = context->getSettingsRef();
+
+    int s3_max_redirects = static_cast<int>(global_settings[Setting::s3_max_redirects]);
+    if (!for_disk_s3 && local_settings.isChanged("s3_max_redirects"))
+        s3_max_redirects = static_cast<int>(local_settings[Setting::s3_max_redirects]);
+
+    int s3_retry_attempts = static_cast<int>(global_settings[Setting::s3_retry_attempts]);
+    if (!for_disk_s3 && local_settings.isChanged("s3_retry_attempts"))
+        s3_retry_attempts = static_cast<int>(local_settings[Setting::s3_retry_attempts]);
+
+    bool enable_s3_requests_logging = global_settings[Setting::enable_s3_requests_logging];
+    if (!for_disk_s3 && local_settings.isChanged("enable_s3_requests_logging"))
+        enable_s3_requests_logging = local_settings[Setting::enable_s3_requests_logging];
+
     S3::PocoHTTPClientConfiguration client_configuration = S3::ClientFactory::instance().createClientConfiguration(
         auth_settings.region,
         context->getRemoteHostFilter(),
-        static_cast<int>(global_settings[Setting::s3_max_redirects]),
-        static_cast<int>(global_settings[Setting::s3_retry_attempts]),
-        global_settings[Setting::enable_s3_requests_logging],
+        s3_max_redirects,
+        s3_retry_attempts,
+        enable_s3_requests_logging,
         for_disk_s3,
         request_settings.get_request_throttler,
         request_settings.put_request_throttler,


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):

- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
* Insert into table function s3 respect query settings
