### PR TITLE
Probably fix flaky test_refreshable_mv_in_replicated_db

### DIFF
--- a/src/Interpreters/InterpreterSystemQuery.cpp
+++ b/src/Interpreters/InterpreterSystemQuery.cpp
@@ -52,6 +52,7 @@
 #include <Storages/Freeze.h>
 #include <Storages/StorageFactory.h>
 #include <Storages/StorageFile.h>
+#include <Storages/StorageMaterializedView.h>
 #include <Storages/StorageURL.h>
 #include <Storages/ObjectStorage/StorageObjectStorage.h>
 #include <Storages/ObjectStorage/S3/Configuration.h>
@@ -1134,10 +1135,13 @@ void InterpreterSystemQuery::dropDatabaseReplica(ASTSystemQuery & query)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Invalid query");
 }
 
-bool InterpreterSystemQuery::trySyncReplica(IStorage * table, SyncReplicaMode sync_replica_mode, const std::unordered_set<String> & src_replicas, ContextPtr context_)
+bool InterpreterSystemQuery::trySyncReplica(StoragePtr table, SyncReplicaMode sync_replica_mode, const std::unordered_set<String> & src_replicas, ContextPtr context_)
  {
     auto table_id_ = table->getStorageID();
-    if (auto * storage_replicated = dynamic_cast<StorageReplicatedMergeTree *>(table))
+    if (auto * storage_mv = dynamic_cast<StorageMaterializedView *>(table.get()))
+        table = storage_mv->getTargetTable();
+
+    if (auto * storage_replicated = dynamic_cast<StorageReplicatedMergeTree *>(table.get()))
     {
         auto log = getLogger("InterpreterSystemQuery");
         LOG_TRACE(log, "Synchronizing entries in replica's queue with table's log and waiting for current last entry to be processed");
@@ -1161,7 +1165,7 @@ void InterpreterSystemQuery::syncReplica(ASTSystemQuery & query)
     getContext()->checkAccess(AccessType::SYSTEM_SYNC_REPLICA, table_id);
     StoragePtr table = DatabaseCatalog::instance().getTable(table_id, getContext());
     std::unordered_set<std::string> replicas(query.src_replicas.begin(), query.src_replicas.end());
-    if (!trySyncReplica(table.get(), query.sync_replica_mode, replicas, getContext()))
+    if (!trySyncReplica(table, query.sync_replica_mode, replicas, getContext()))
         throw Exception(ErrorCodes::BAD_ARGUMENTS, table_is_not_replicated.data(), table_id.getNameForLogs());
 }
 

--- a/src/Interpreters/InterpreterSystemQuery.h
+++ b/src/Interpreters/InterpreterSystemQuery.h
@@ -47,7 +47,7 @@ public:
                                           const String & database_name, const DatabasePtr & database,
                                           const ContextPtr & local_context, LoggerPtr log);
 
-    static bool trySyncReplica(IStorage * table, SyncReplicaMode sync_replica_mode, const std::unordered_set<String> & src_replicas, ContextPtr context_);
+    static bool trySyncReplica(StoragePtr table, SyncReplicaMode sync_replica_mode, const std::unordered_set<String> & src_replicas, ContextPtr context_);
 
 private:
     ASTPtr query_ptr;

--- a/src/Storages/MaterializedView/RefreshTask.cpp
+++ b/src/Storages/MaterializedView/RefreshTask.cpp
@@ -865,7 +865,7 @@ std::tuple<StoragePtr, TableLockHolder> RefreshTask::getAndLockTargetTable(const
         std::lock_guard lock(replica_sync_mutex);
         if (uuid != last_synced_inner_uuid)
         {
-            InterpreterSystemQuery::trySyncReplica(storage.get(), SyncReplicaMode::DEFAULT, {}, context);
+            InterpreterSystemQuery::trySyncReplica(storage, SyncReplicaMode::DEFAULT, {}, context);
 
             /// (Race condition: this may revert from a newer uuid to an older one. This doesn't break
             ///  anything, just causes an unnecessary sync. Should be rare.)

--- a/tests/integration/test_refreshable_mv/test.py
+++ b/tests/integration/test_refreshable_mv/test.py
@@ -103,7 +103,9 @@ def test_refreshable_mv_in_replicated_db(started_cluster):
             )
             node.query(f"system wait view re.{name}")
         # Check results.
-        rows_after = int(nodes[randint(0, 1)].query(f"select count() from re.{name}"))
+        node = nodes[randint(0, 1)]
+        node.query(f"system sync replica re.{name}")
+        rows_after = int(node.query(f"select count() from re.{name}"))
         expected = 1 if coordinated else 2
         assert rows_after - rows_before == expected
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Failed like this: https://s3.amazonaws.com/clickhouse-test-reports/70503/ea6e8ba9099f6d46a18e503ec4204eaa1b8e5f6e/integration_tests__aarch64__[4_6].html

I couldn't reproduce it but it was probably because the test was missing a SYSTEM SYNC REPLICA before expecting data inserted on one replica to show up on another replica.

(Not sure how I missed this obvious race condition in the test; in my defense, I ran the test a few hundred times before merging that PR, and it didn't fail.)