### PR TITLE
[WIP] Optimize the performance of full sorting merge join by shuffling

### DIFF
--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -5803,6 +5803,14 @@ Allow to create database with Engine=MaterializedPostgreSQL(...).
     M(Bool, allow_experimental_query_deduplication, false, R"(
 Experimental data deduplication for SELECT queries based on part UUIDs
 )", 0) \
+    \
+    /** Experimental feature for moving data between shards. */ \
+    M(UInt64, shuffle_join_optimization_buckets, 0, R"(
+The number of buckets for shuffle-based full_sorting_merge join optimization. 0 - disable.
+)", 0) \
+    M(UInt64, shuffle_join_optimization_max_key, 100000000, R"(
+The maximum value of the join key. The value is used to evenly divide bucket ranges for shuffle-based full_sorting_merge join optimization.
+)", 0) \
 
     /** End of experimental features */
 

--- a/src/Interpreters/InterpreterSelectQuery.cpp
+++ b/src/Interpreters/InterpreterSelectQuery.cpp
@@ -67,6 +67,7 @@
 #include <Processors/QueryPlan/TotalsHavingStep.h>
 #include <Processors/QueryPlan/WindowStep.h>
 #include <Processors/QueryPlan/Optimizations/QueryPlanOptimizationSettings.h>
+#include <Processors/QueryPlan/ShuffleStep.h>
 #include <Processors/Sources/NullSource.h>
 #include <Processors/Sources/SourceFromSingleChunk.h>
 #include <Processors/Transforms/AggregatingTransform.h>
@@ -186,6 +187,8 @@ namespace Setting
     extern const SettingsTotalsMode totals_mode;
     extern const SettingsBool use_concurrency_control;
     extern const SettingsBool use_with_fill_by_sorting_prefix;
+    extern const SettingsUInt64 shuffle_join_optimization_buckets;
+    extern const SettingsUInt64 shuffle_join_optimization_max_key;
 }
 
 
@@ -1799,6 +1802,11 @@ void InterpreterSelectQuery::executeImpl(QueryPlan & query_plan, std::optional<P
                     if (!joined_plan)
                         throw Exception(ErrorCodes::LOGICAL_ERROR, "There is no joined plan for query");
 
+                    auto add_shuffle = [&] (QueryPlan & plan)
+                    {
+                        plan.addStep(std::make_unique<ShuffleStep>(plan.getCurrentHeader(), settings[Setting::shuffle_join_optimization_buckets], settings[Setting::shuffle_join_optimization_max_key]));
+                    };
+
                     auto add_sorting = [this] (QueryPlan & plan, const Names & key_names, JoinTableSide join_pos)
                     {
                         SortDescription order_descr;
@@ -1872,7 +1880,11 @@ void InterpreterSelectQuery::executeImpl(QueryPlan & query_plan, std::optional<P
                             if (isInnerOrRight(join_kind))
                                 left_set->setFiltering(right_set->getSet());
                         }
-
+                        if (settings[Setting::shuffle_join_optimization_buckets] > 1)
+                        {
+                            add_shuffle(query_plan);
+                            add_shuffle(*joined_plan);
+                        }
                         add_sorting(query_plan, join_clause.key_names_left, JoinTableSide::Left);
                         add_sorting(*joined_plan, join_clause.key_names_right, JoinTableSide::Right);
                     }
@@ -1883,7 +1895,9 @@ void InterpreterSelectQuery::executeImpl(QueryPlan & query_plan, std::optional<P
                         expressions.join,
                         settings[Setting::max_block_size],
                         max_streams,
-                        analysis_result.optimize_read_in_order);
+                        analysis_result.optimize_read_in_order,
+                        settings[Setting::shuffle_join_optimization_buckets],
+                        settings[Setting::shuffle_join_optimization_max_key]);
 
                     join_step->setStepDescription(fmt::format("JOIN {}", expressions.join->pipelineType()));
                     std::vector<QueryPlanPtr> plans;

--- a/src/Processors/QueryPlan/JoinStep.h
+++ b/src/Processors/QueryPlan/JoinStep.h
@@ -19,7 +19,9 @@ public:
         JoinPtr join_,
         size_t max_block_size_,
         size_t max_streams_,
-        bool keep_left_read_in_order_);
+        bool keep_left_read_in_order_,
+        size_t shuffle_optimize_buckets_ = 0,
+        size_t shuffle_optimize_max_ = 0);
 
     String getName() const override { return "Join"; }
 
@@ -43,6 +45,8 @@ private:
     size_t max_block_size;
     size_t max_streams;
     bool keep_left_read_in_order;
+    size_t shuffle_optimize_buckets;
+    size_t shuffle_optimize_max;
 };
 
 /// Special step for the case when Join is already filled.

--- a/src/Processors/QueryPlan/Optimizations/optimizeReadInOrder.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeReadInOrder.cpp
@@ -19,6 +19,7 @@
 #include <Processors/QueryPlan/Optimizations/actionsDAGUtils.h>
 #include <Processors/QueryPlan/ReadFromMergeTree.h>
 #include <Processors/QueryPlan/ReadFromRemote.h>
+#include <Processors/QueryPlan/ShuffleStep.h>
 #include <Processors/QueryPlan/SortingStep.h>
 #include <Processors/QueryPlan/TotalsHavingStep.h>
 #include <Processors/QueryPlan/UnionStep.h>
@@ -97,7 +98,7 @@ QueryPlan::Node * findReadingStep(QueryPlan::Node & node, bool allow_existing_or
     if (node.children.size() != 1)
         return nullptr;
 
-    if (typeid_cast<ExpressionStep *>(step) || typeid_cast<FilterStep *>(step) || typeid_cast<ArrayJoinStep *>(step))
+    if (typeid_cast<ExpressionStep *>(step) || typeid_cast<FilterStep *>(step) || typeid_cast<ArrayJoinStep *>(step) || typeid_cast<ShuffleStep *>(step))
         return findReadingStep(*node.children.front(), allow_existing_order);
 
     if (auto * distinct = typeid_cast<DistinctStep *>(step); distinct && distinct->isPreliminary())

--- a/src/Processors/QueryPlan/ShuffleStep.cpp
+++ b/src/Processors/QueryPlan/ShuffleStep.cpp
@@ -1,0 +1,52 @@
+#include <Common/JSONBuilder.h>
+#include <IO/Operators.h>
+#include <Processors/QueryPlan/ShuffleStep.h>
+#include <Processors/ShuffleProcessor.h>
+
+namespace DB
+{
+
+static ITransformingStep::Traits getTraits()
+{
+    return ITransformingStep::Traits
+    {
+        {
+            .returns_single_stream = true,
+            .preserves_number_of_streams = true,
+            .preserves_sorting = true
+        },
+        {
+            .preserves_number_of_rows = true
+        }
+    };
+}
+
+ShuffleStep::ShuffleStep(const Header & input_header_, size_t shuffle_optimize_buckets_, size_t shuffle_optimize_max_)
+    : ITransformingStep(input_header_, input_header_, getTraits())
+    , shuffle_optimize_buckets(shuffle_optimize_buckets_)
+    , shuffle_optimize_max(shuffle_optimize_max_)
+{}
+
+void ShuffleStep::transformPipeline(QueryPipelineBuilder & pipeline, const BuildQueryPipelineSettings &)
+{
+    pipeline.resize(1);
+
+    auto shuffle = std::make_shared<ShuffleProcessor>(pipeline.getHeader(), shuffle_optimize_buckets, shuffle_optimize_max);
+    pipeline.addTransform(std::move(shuffle));
+}
+
+void ShuffleStep::describeActions(FormatSettings & settings) const
+{
+    String prefix(settings.offset, ' ');
+    settings.out << prefix << "SHUFFLE BY ID, Buckets " << shuffle_optimize_buckets << ", Max Key " << shuffle_optimize_max;
+    settings.out << '\n';
+}
+
+void ShuffleStep::describeActions(JSONBuilder::JSONMap & map) const
+{
+    map.add("Name", "SHUFFLE BY default");
+    map.add("Shuffle Optimization Buckets", shuffle_optimize_buckets);
+    map.add("Shuffle Optimization Max Key", shuffle_optimize_max);
+}
+
+}

--- a/src/Processors/QueryPlan/ShuffleStep.h
+++ b/src/Processors/QueryPlan/ShuffleStep.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <QueryPipeline/QueryPipelineBuilder.h>
+#include <Processors/QueryPlan/ITransformingStep.h>
+
+namespace DB
+{
+
+class ShuffleStep : public ITransformingStep
+{
+public:
+    ShuffleStep(const Header & input_header_, size_t shuffle_optimize_buckets, size_t shuffle_optimize_max);
+
+    String getName() const override { return "Shuffle"; }
+
+    void transformPipeline(QueryPipelineBuilder & pipeline, const BuildQueryPipelineSettings &) override;
+
+    void describeActions(JSONBuilder::JSONMap & map) const override;
+    void describeActions(FormatSettings & settings) const override;
+
+private:
+    void updateOutputHeader() override
+    {
+        output_header = input_headers.front();
+    }
+
+    size_t shuffle_optimize_buckets;
+    size_t shuffle_optimize_max;
+};
+
+}

--- a/src/Processors/QueryPlan/SortingStep.h
+++ b/src/Processors/QueryPlan/SortingStep.h
@@ -29,6 +29,7 @@ public:
         size_t min_free_disk_space = 0;
         size_t max_block_bytes = 0;
         size_t read_in_order_use_buffering = 0;
+        bool shuffle_join_optimization_enabled = false;
 
         explicit Settings(const Context & context);
         explicit Settings(size_t max_block_size_);

--- a/src/Processors/ShuffleProcessor.cpp
+++ b/src/Processors/ShuffleProcessor.cpp
@@ -1,0 +1,139 @@
+#include <Processors/ShuffleProcessor.h>
+#include <Columns/ColumnsNumber.h>
+
+namespace DB
+{
+namespace ErrorCodes
+{
+    extern const int LOGICAL_ERROR;
+}
+
+IProcessor::Status ShuffleProcessor::prepare(const PortNumbers & /*updated_inputs*/, const PortNumbers & updated_outputs)
+{
+    if (!initialized)
+    {
+        initialized = true;
+        auto & input = inputs.front();
+        input.setNeeded();
+        input_port = {.port = &input, .status = InputStatus::NotActive};
+
+        for (auto & output : outputs)
+        {
+            output_ports.push_back({.port = &output, .status = OutputStatus::NotActive});
+        }        
+    }
+
+    for (const auto & output_number : updated_outputs)
+    {
+        auto & output = output_ports[output_number];
+        if (output.port->isFinished())
+        {
+            if (output.status != OutputStatus::Finished)
+            {
+                --num_unfinished_outputs;
+                output.status = OutputStatus::Finished;
+            }
+
+            continue;
+        }
+
+        if (output.port->canPush())
+        {
+            if (output.status != OutputStatus::NeedData)
+            {
+                output.status = OutputStatus::NeedData;
+            }
+        }
+    }
+
+    if (!num_unfinished_outputs)
+    {
+        for (auto & input : inputs)
+            input.close();
+
+        return Status::Finished;
+    }
+
+    if (std::any_of(output_ports.begin(), output_ports.end(), [](const auto & output) { return output.status == OutputStatus::PortFull; }))
+    {
+        return Status::PortFull;
+    }
+
+    if (input_port.port->isFinished())
+    {
+        if (input_port.status != InputStatus::Finished)
+        {
+            input_port.status = InputStatus::Finished;
+            for (auto & output : outputs)
+            {
+                output.finish();
+            }
+            return Status::Finished;
+        }
+    }
+
+    if (input_port.port->hasData())
+    {
+        input_port.status = InputStatus::HasData;
+
+        // Shuffle input data
+        auto data = input_port.port->pullData();
+        assert(!input_port.port->hasData());
+        const auto * shuffle_column = checkAndGetColumn<ColumnUInt64>(data.chunk.getColumns()[0].get()); // todo: 未来用参数指定依据哪一列做shuffle
+        if (!shuffle_column)
+        {
+            throw Exception(
+                ErrorCodes::LOGICAL_ERROR,
+                "Shuffle column must be UInt64, but {}",
+                shuffle_column->getDataType());
+        }
+
+        for (size_t i = 0; i < thresholds.size(); ++i)
+        {
+            const auto & threshold = thresholds[i];
+            shuffle_column = checkAndGetColumn<ColumnUInt64>(data.chunk.getColumns()[0].get()); // todo: 未来用参数指定依据哪一列做shuffle
+            auto & raw_id_data = shuffle_column->getData();
+            auto range_bound = std::lower_bound(raw_id_data.begin(), raw_id_data.end(), threshold);
+            if (range_bound == raw_id_data.end())
+            {
+                // 整体数据块放入该桶
+                output_ports[i].port->pushData(std::move(data));
+                output_ports[i].status = OutputStatus::PortFull;
+                break;
+            }
+            else
+            {
+                // 部分数据块放入该桶，其余的后续阶段处理。
+                Columns source_columns = data.chunk.detachColumns();
+                Columns res_columns;                
+                size_t part_length = range_bound - raw_id_data.begin();                
+                for (auto & source_column : source_columns)
+                {
+                    res_columns.push_back(source_column->cut(0, part_length));
+                }
+                output_ports[i].port->pushData({.chunk = Chunk(res_columns, part_length), .exception = {}});
+                output_ports[i].status = OutputStatus::PortFull;
+
+                size_t remain_length = raw_id_data.end() - range_bound;
+                for (auto & source_column : source_columns)
+                {
+                    source_column = source_column->cut(part_length, remain_length);
+                }
+                data = {.chunk = Chunk(source_columns, remain_length), .exception = {}};
+            }
+        }
+        if (data.chunk.hasRows())
+        {
+            // 放入最后一桶。
+            output_ports.back().port->pushData(std::move(data));
+            output_ports.back().status = OutputStatus::PortFull;
+        }
+        return Status::PortFull;
+    }
+    else
+    {
+        return Status::NeedData;
+    }
+}
+
+}

--- a/src/Processors/ShuffleProcessor.h
+++ b/src/Processors/ShuffleProcessor.h
@@ -1,0 +1,88 @@
+#pragma once
+
+#include <Processors/IProcessor.h>
+#include <queue>
+
+
+namespace DB
+{
+
+/** Has arbitrary non zero number of inputs and arbitrary non zero number of outputs.
+  * All of them have the same structure.
+  *
+  * Pulls data from arbitrary input (whenever it is ready) and shuffle the input data into
+  * several buckets according to the value of special column(e.g. ID column), then 
+  * pushes the shuffled data to output.
+  * Doesn't do any heavy calculations.
+  * Doesn't preserve an order of data.
+  *
+  * Examples:
+  * - shuffle data by ID column into 4 buckets, push data to 4 outputs.
+  */
+class ShuffleProcessor final : public IProcessor
+{
+public:
+    ShuffleProcessor(const Block & header, size_t shuffle_optimize_buckets, size_t shuffle_optimize_max)
+        : IProcessor(InputPorts(1, header), OutputPorts(shuffle_optimize_buckets, header))
+        , num_unfinished_outputs{shuffle_optimize_buckets}
+    {
+        if (shuffle_optimize_buckets < 2)
+        {
+            throw Exception(ErrorCodes::LOGICAL_ERROR,
+                "Number of shuffle buckets must be at least 2");
+        }
+
+        if (shuffle_optimize_max < shuffle_optimize_buckets - 1)
+        {
+            throw Exception(ErrorCodes::LOGICAL_ERROR,
+                "Max key value must be at least number of shuffle buckets - 1");
+
+        }
+
+        thresholds.resize(shuffle_optimize_buckets-1);
+        for (size_t i = 1; i < shuffle_optimize_buckets; ++i)
+        {
+            thresholds[i-1] = shuffle_optimize_max * i / shuffle_optimize_buckets + 1;
+        }
+    }
+
+    String getName() const override { return "Shuffle"; }
+
+    Status prepare(const PortNumbers &, const PortNumbers &) override;
+
+private:
+    enum class OutputStatus
+    {
+        NotActive, // 未准备好
+        NeedData, // 需要数据输出，处于可输出数据的状态
+        PortFull, // 输出端口有数据未被下游处理
+        Finished, // 结束，端口关闭
+    };
+
+    enum class InputStatus
+    {
+        NotActive, // 未准备好
+        HasData, // 有输入数据待处理
+        Finished, // 结束，端口关闭
+    };
+
+    struct InputPortWithStatus
+    {
+        InputPort * port;
+        InputStatus status;
+    };
+
+    struct OutputPortWithStatus
+    {
+        OutputPort * port;
+        OutputStatus status;
+    };
+
+    bool initialized{false};
+    size_t num_unfinished_outputs;
+    InputPortWithStatus input_port;
+    std::vector<OutputPortWithStatus> output_ports;
+    std::vector<size_t> thresholds;
+};
+
+}

--- a/src/QueryPipeline/QueryPipelineBuilder.cpp
+++ b/src/QueryPipeline/QueryPipelineBuilder.cpp
@@ -378,6 +378,39 @@ std::unique_ptr<QueryPipelineBuilder> QueryPipelineBuilder::joinPipelinesYShaped
     return mergePipelines(std::move(left), std::move(right), std::move(joining), collected_processors);
 }
 
+std::unique_ptr<QueryPipelineBuilder> QueryPipelineBuilder::joinPipelinesYShapedWithShuffle(
+    std::unique_ptr<QueryPipelineBuilder> left,
+    std::unique_ptr<QueryPipelineBuilder> right,
+    JoinPtr join,
+    const Block & out_header,
+    size_t max_block_size,
+    Processors * collected_processors)
+{
+    left->checkInitializedAndNotCompleted();
+    right->checkInitializedAndNotCompleted();
+    left->pipe.dropExtremes();
+    right->pipe.dropExtremes();
+    if (left->getNumStreams() != right->getNumStreams())
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Join with shuffle requires same number of inputs and outputs");
+    if (left->hasTotals() || right->hasTotals())
+        throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Current join algorithm is supported only for pipelines without totals");
+    Blocks inputs = {left->getHeader(), right->getHeader()};
+    for (size_t i = 0; i < left->getNumStreams(); ++i)
+    {
+        auto joining = std::make_shared<MergeJoinTransform>(join, inputs, out_header, max_block_size);
+        connect(*left->pipe.output_ports.at(i), joining->getInputs().front());
+        connect(*right->pipe.output_ports.at(i), joining->getInputs().back());
+        if (collected_processors)
+            collected_processors->emplace_back(joining);
+        left->pipe.output_ports.at(i) = &joining->getOutputs().front();
+        left->pipe.processors->emplace_back(joining);
+    }
+    left->pipe.processors->insert(left->pipe.processors->end(), right->pipe.processors->begin(), right->pipe.processors->end());
+    left->pipe.header = left->pipe.output_ports.front()->getHeader();
+    left->pipe.max_parallel_streams = std::max(left->pipe.max_parallel_streams, right->pipe.max_parallel_streams);
+    return left;
+}
+
 std::unique_ptr<QueryPipelineBuilder> QueryPipelineBuilder::joinPipelinesRightLeft(
     std::unique_ptr<QueryPipelineBuilder> left,
     std::unique_ptr<QueryPipelineBuilder> right,

--- a/src/QueryPipeline/QueryPipelineBuilder.h
+++ b/src/QueryPipeline/QueryPipelineBuilder.h
@@ -139,6 +139,14 @@ public:
         size_t max_block_size,
         Processors * collected_processors = nullptr);
 
+    static std::unique_ptr<QueryPipelineBuilder> joinPipelinesYShapedWithShuffle(
+        std::unique_ptr<QueryPipelineBuilder> left,
+        std::unique_ptr<QueryPipelineBuilder> right,
+        JoinPtr join,
+        const Block & out_header,
+        size_t max_block_size,
+        Processors * collected_processors = nullptr);
+
     /// Add other pipeline and execute it before current one.
     /// Pipeline must have empty header, it should not generate any chunk.
     /// This is used for CreatingSets.


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Improve Full Sorting Merge JOIN performance by introducing shuffling, controlled by settings `shuffle_join_optimization_buckets` and `shuffle_join_optimization_max_key`. 


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

Improve Full Sorting Merge Join performance by introducing shuffling, controlled by settings `shuffle_join_optimization_buckets` and `shuffle_join_optimization_max_key`.

Setting `shuffle_join_optimization_buckets`: the number of buckets for shuffling optimization.
Setting `shuffle_join_optimization_max_key`: the max join key value for shuffling optimization. The shuffling optimization assumes that join key is continuous sequence of UInt64.

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---ci_include_fuzzer--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
