### PR TITLE
Make Array Field serialization consistent.

### DIFF
--- a/src/Core/Field.cpp
+++ b/src/Core/Field.cpp
@@ -106,7 +106,7 @@ Field getBinaryValue(UInt8 type, ReadBuffer & buf)
         case Field::Types::Array:
         {
             Array value;
-            readBinary(value, buf);
+            readBinaryArray(value, buf);
             return value;
         }
         case Field::Types::Tuple:
@@ -150,28 +150,22 @@ Field getBinaryValue(UInt8 type, ReadBuffer & buf)
     throw Exception(ErrorCodes::INCORRECT_DATA, "Unknown field type {}", std::to_string(type));
 }
 
-void readBinary(Array & x, ReadBuffer & buf)
+void readBinaryArray(Array & x, ReadBuffer & buf)
 {
     size_t size;
-    UInt8 type;
-    readBinary(type, buf);
     readBinary(size, buf);
 
     for (size_t index = 0; index < size; ++index)
-        x.push_back(getBinaryValue(type, buf));
+        x.push_back(readFieldBinary(buf));
 }
 
-void writeBinary(const Array & x, WriteBuffer & buf)
+void writeBinaryArray(const Array & x, WriteBuffer & buf)
 {
-    UInt8 type = Field::Types::Null;
     size_t size = x.size();
-    if (size)
-        type = x.front().getType();
-    writeBinary(type, buf);
     writeBinary(size, buf);
 
     for (const auto & elem : x)
-        Field::dispatch([&buf] (const auto & value) { FieldVisitorWriteBinary()(value, buf); }, elem);
+        writeFieldBinary(elem, buf);
 }
 
 void writeText(const Array & x, WriteBuffer & buf)
@@ -186,11 +180,7 @@ void readBinary(Tuple & x, ReadBuffer & buf)
     readBinary(size, buf);
 
     for (size_t index = 0; index < size; ++index)
-    {
-        UInt8 type;
-        readBinary(type, buf);
-        x.push_back(getBinaryValue(type, buf));
-    }
+        x.push_back(readFieldBinary(buf));
 }
 
 void writeBinary(const Tuple & x, WriteBuffer & buf)
@@ -199,11 +189,7 @@ void writeBinary(const Tuple & x, WriteBuffer & buf)
     writeBinary(size, buf);
 
     for (const auto & elem : x)
-    {
-        const UInt8 type = elem.getType();
-        writeBinary(type, buf);
-        Field::dispatch([&buf] (const auto & value) { FieldVisitorWriteBinary()(value, buf); }, elem);
-    }
+        writeFieldBinary(elem, buf);
 }
 
 void writeText(const Tuple & x, WriteBuffer & buf)
@@ -217,11 +203,7 @@ void readBinary(Map & x, ReadBuffer & buf)
     readBinary(size, buf);
 
     for (size_t index = 0; index < size; ++index)
-    {
-        UInt8 type;
-        readBinary(type, buf);
-        x.push_back(getBinaryValue(type, buf));
-    }
+        x.push_back(readFieldBinary(buf));
 }
 
 void writeBinary(const Map & x, WriteBuffer & buf)
@@ -230,11 +212,7 @@ void writeBinary(const Map & x, WriteBuffer & buf)
     writeBinary(size, buf);
 
     for (const auto & elem : x)
-    {
-        const UInt8 type = elem.getType();
-        writeBinary(type, buf);
-        Field::dispatch([&buf] (const auto & value) { FieldVisitorWriteBinary()(value, buf); }, elem);
-    }
+        writeFieldBinary(elem, buf);
 }
 
 void writeText(const Map & x, WriteBuffer & buf)
@@ -319,6 +297,19 @@ void writeFieldText(const Field & x, WriteBuffer & buf)
     buf.write(res.data(), res.size());
 }
 
+void writeFieldBinary(const Field & x, WriteBuffer & buf)
+{
+    const UInt8 type = x.getType();
+    writeBinary(type, buf);
+    Field::dispatch([&buf] (const auto & value) { FieldVisitorWriteBinary()(value, buf); }, x);
+}
+
+Field readFieldBinary(ReadBuffer & buf)
+{
+    UInt8 type;
+    readBinary(type, buf);
+    return getBinaryValue(type, buf);
+}
 
 String Field::dump() const
 {

--- a/src/Core/Field.h
+++ b/src/Core/Field.h
@@ -942,14 +942,15 @@ inline Field & Field::operator=(String && str)
 class ReadBuffer;
 class WriteBuffer;
 
-/// It is assumed that all elements of the array have the same type.
-void readBinary(Array & x, ReadBuffer & buf);
+/// Binary serialization of generic field.
+void writeFieldBinary(const Field & x, WriteBuffer & buf);
+Field readFieldBinary(ReadBuffer & buf);
+
+void readBinaryArray(Array & x, ReadBuffer & buf);
 [[noreturn]] inline void readText(Array &, ReadBuffer &) { throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Cannot read Array."); }
 [[noreturn]] inline void readQuoted(Array &, ReadBuffer &) { throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Cannot read Array."); }
 
-/// It is assumed that all elements of the array have the same type.
-/// Also write size and type into buf. UInt64 and Int64 is written in variadic size form
-void writeBinary(const Array & x, WriteBuffer & buf);
+void writeBinaryArray(const Array & x, WriteBuffer & buf);
 void writeText(const Array & x, WriteBuffer & buf);
 [[noreturn]] inline void writeQuoted(const Array &, WriteBuffer &) { throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Cannot write Array quoted."); }
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

#### Motivation

- `writeBinary(Array)` was inconsistent with `FieldVisitorWriteBinary`
- Looks like it was not used anywhere except `getBinaryValue`, which was required only for serialization of nested structures (Array, Map, Object, Tuple). So, the issue could have been possible only for Array inside another nested type, which is rare.

#### What is changed
- `writeBinary` is renamed to `writeBinaryArray`, which is consistent with  `FieldVisitorWriteBinary` now
- Added functions `writeFieldBinary`, `readFieldBinary` for generic fields.


<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---ci_include_fuzzer--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
