### PR TITLE
[Docs] Remove pagination_next from settings page

### DIFF
--- a/docs/en/operations/settings/index.md
+++ b/docs/en/operations/settings/index.md
@@ -2,7 +2,6 @@
 title: "Settings Overview"
 sidebar_position: 1
 slug: /en/operations/settings/
-pagination_next: en/operations/settings/settings
 ---
 
 # Settings Overview


### PR DESCRIPTION
### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
[Docs] Remove pagination_next from settings page
