### PR TITLE
Fix excessive LIST API calls to the object storage in the plain_rewritable disk

### DIFF
--- a/src/Common/CurrentMetrics.cpp
+++ b/src/Common/CurrentMetrics.cpp
@@ -183,8 +183,14 @@
     M(BuildVectorSimilarityIndexThreadsScheduled, "Number of queued or active jobs in the build vector similarity index thread pool.") \
     \
     M(DiskPlainRewritableAzureDirectoryMapSize, "Number of local-to-remote path entries in the 'plain_rewritable' in-memory map for AzureObjectStorage.") \
+    M(DiskPlainRewritableAzureFileCount, "Number of file entries in the 'plain_rewritable' in-memory map for AzureObjectStorage.") \
+    M(DiskPlainRewritableAzureUniqueFileNamesCount, "Number of unique file name entries in the 'plain_rewritable' in-memory map for AzureObjectStorage.") \
     M(DiskPlainRewritableLocalDirectoryMapSize, "Number of local-to-remote path entries in the 'plain_rewritable' in-memory map for LocalObjectStorage.") \
+    M(DiskPlainRewritableLocalFileCount, "Number of file entries in the 'plain_rewritable' in-memory map for LocalObjectStorage.") \
+    M(DiskPlainRewritableLocalUniqueFileNamesCount, "Number of unique file name entries in the 'plain_rewritable' in-memory map for LocalObjectStorage.") \
     M(DiskPlainRewritableS3DirectoryMapSize, "Number of local-to-remote path entries in the 'plain_rewritable' in-memory map for S3ObjectStorage.") \
+    M(DiskPlainRewritableS3FileCount, "Number of file entries in the 'plain_rewritable' in-memory map for S3ObjectStorage.") \
+    M(DiskPlainRewritableS3UniqueFileNamesCount, "Number of unique file name entries in the 'plain_rewritable' in-memory map for S3ObjectStorage.") \
     \
     M(MergeTreePartsLoaderThreads, "Number of threads in the MergeTree parts loader thread pool.") \
     M(MergeTreePartsLoaderThreadsActive, "Number of threads in the MergeTree parts loader thread pool running a task.") \

--- a/src/Disks/ObjectStorages/InMemoryDirectoryPathMap.h
+++ b/src/Disks/ObjectStorages/InMemoryDirectoryPathMap.h
@@ -4,6 +4,7 @@
 #include <map>
 #include <optional>
 #include <shared_mutex>
+#include <unordered_set>
 #include <base/defines.h>
 #include <Common/SharedLockGuard.h>
 #include <Common/SharedMutex.h>
@@ -29,6 +30,7 @@ struct InMemoryDirectoryPathMap
     {
         std::string path;
         time_t last_modified = 0;
+        std::unordered_set<std::string> filenames;
     };
 
     using Map = std::map<std::filesystem::path, RemotePathInfo, PathComparator>;

--- a/src/Disks/ObjectStorages/MetadataStorageFromPlainObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/MetadataStorageFromPlainObjectStorage.cpp
@@ -231,7 +231,7 @@ void MetadataStorageFromPlainObjectStorageTransaction::createEmptyMetadataFile(c
 void MetadataStorageFromPlainObjectStorageTransaction::createMetadataFile(
     const std::string & path, ObjectStorageKey /*object_key*/, uint64_t /* size_in_bytes */)
 {
-    return createEmptyMetadataFile(path);
+    createEmptyMetadataFile(path);
 }
 
 void MetadataStorageFromPlainObjectStorageTransaction::createDirectory(const std::string & path)

--- a/src/Disks/ObjectStorages/MetadataStorageFromPlainObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/MetadataStorageFromPlainObjectStorage.cpp
@@ -225,7 +225,8 @@ void MetadataStorageFromPlainObjectStorageTransaction::createEmptyMetadataFile(c
     if (metadata_storage.object_storage->isWriteOnce())
         return;
 
-    addOperation(std::make_unique<MetadataStorageFromPlainObjectStorageWriteFileOperation>(path, *metadata_storage.getPathMap()));
+    addOperation(
+        std::make_unique<MetadataStorageFromPlainObjectStorageWriteFileOperation>(path, *metadata_storage.getPathMap(), object_storage));
 }
 
 void MetadataStorageFromPlainObjectStorageTransaction::createMetadataFile(

--- a/src/Disks/ObjectStorages/MetadataStorageFromPlainObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/MetadataStorageFromPlainObjectStorage.cpp
@@ -277,7 +277,6 @@ UnlinkMetadataFileOperationOutcomePtr MetadataStorageFromPlainObjectStorageTrans
         metadata_storage.object_metadata_cache->remove(hash.get128());
     }
 
-    /// No hardlinks, so will always remove file.
     auto result = std::make_shared<UnlinkMetadataFileOperationOutcome>(UnlinkMetadataFileOperationOutcome{0});
     if (!metadata_storage.object_storage->isWriteOnce())
         addOperation(std::make_unique<MetadataStorageFromPlainObjectStorageUnlinkMetadataFileOperation>(

--- a/src/Disks/ObjectStorages/MetadataStorageFromPlainObjectStorage.h
+++ b/src/Disks/ObjectStorages/MetadataStorageFromPlainObjectStorage.h
@@ -114,22 +114,19 @@ public:
 
     const IMetadataStorage & getStorageForNonTransactionalReads() const override;
 
-    void addBlobToMetadata(const std::string & path, ObjectStorageKey object_key, uint64_t size_in_bytes) override;
+    void addBlobToMetadata(const std::string & /* path */, ObjectStorageKey /* object_key */, uint64_t /* size_in_bytes */) override
+    {
+        // Noop
+    }
 
     void setLastModified(const String &, const Poco::Timestamp &) override
     {
         /// Noop
     }
 
-    void createEmptyMetadataFile(const std::string & /* path */) override
-    {
-        /// No metadata, no need to create anything.
-    }
+    void createEmptyMetadataFile(const std::string & /* path */) override;
 
-    void createMetadataFile(const std::string & /* path */, ObjectStorageKey /* object_key */, uint64_t /* size_in_bytes */) override
-    {
-        /// Noop
-    }
+    void createMetadataFile(const std::string & /* path */, ObjectStorageKey /* object_key */, uint64_t /* size_in_bytes */) override;
 
     void createDirectory(const std::string & path) override;
 

--- a/src/Disks/ObjectStorages/MetadataStorageFromPlainObjectStorageOperations.cpp
+++ b/src/Disks/ObjectStorages/MetadataStorageFromPlainObjectStorageOperations.cpp
@@ -306,7 +306,7 @@ void MetadataStorageFromPlainObjectStorageWriteFileOperation::execute(std::uniqu
     if (it == path_map.map.end())
         LOG_TRACE(
             getLogger("MetadataStorageFromPlainObjectStorageWriteFileOperation"),
-            "Parrent dirrectory does not exist, skipping path {}",
+            "Parent dirrectory does not exist, skipping path {}",
             path);
     else
         written = it->second.filenames.emplace(path.filename()).second;
@@ -333,11 +333,6 @@ MetadataStorageFromPlainObjectStorageUnlinkMetadataFileOperation::MetadataStorag
     , remote_path(std::filesystem::path(object_storage_->generateObjectKeyForPath(path_, std::nullopt).serialize()))
     , path_map(path_map_)
 {
-    auto common_key_prefix = object_storage_->getCommonKeyPrefix();
-    chassert(remote_path.string().starts_with(common_key_prefix));
-    auto rel_path = remote_path.lexically_relative(common_key_prefix);
-    remote_parent_path = rel_path.parent_path() / "";
-    filename = rel_path.filename();
 }
 
 void MetadataStorageFromPlainObjectStorageUnlinkMetadataFileOperation::execute(std::unique_lock<SharedMutex> &)
@@ -357,7 +352,7 @@ void MetadataStorageFromPlainObjectStorageUnlinkMetadataFileOperation::execute(s
             path);
     else
     {
-        auto res = it->second.filenames.erase(filename);
+        auto res = it->second.filenames.erase(path.filename());
         unlinked = res > 0;
     }
 }
@@ -371,7 +366,7 @@ void MetadataStorageFromPlainObjectStorageUnlinkMetadataFileOperation::undo(std:
         chassert(it != path_map.map.end());
         if (it != path_map.map.end())
         {
-            it->second.filenames.emplace(filename);
+            it->second.filenames.emplace(path.filename());
         }
     }
 }

--- a/src/Disks/ObjectStorages/MetadataStorageFromPlainObjectStorageOperations.cpp
+++ b/src/Disks/ObjectStorages/MetadataStorageFromPlainObjectStorageOperations.cpp
@@ -304,7 +304,10 @@ void MetadataStorageFromPlainObjectStorageWriteFileOperation::execute(std::uniqu
     auto it = path_map.map.find(path.parent_path());
     /// Some paths (e.g., clickhouse_access_check) may not have parent directories.
     if (it == path_map.map.end())
-        LOG_TRACE(getLogger("MetadataStorageFromPlainObjectStorageWriteFileOperation"), "{}", path);
+        LOG_TRACE(
+            getLogger("MetadataStorageFromPlainObjectStorageWriteFileOperation"),
+            "Parrent dirrectory does not exist, skipping path {}",
+            path);
     else
         written = it->second.filenames.emplace(path.filename()).second;
 }
@@ -347,7 +350,12 @@ void MetadataStorageFromPlainObjectStorageUnlinkMetadataFileOperation::execute(s
 
     std::lock_guard lock(path_map.mutex);
     auto it = path_map.map.find(path.parent_path());
-    if (it != path_map.map.end())
+    if (it == path_map.map.end())
+        LOG_TRACE(
+            getLogger("MetadataStorageFromPlainObjectStorageUnlinkMetadataFileOperation"),
+            "Parent directory does not exist, skipping path {}",
+            path);
+    else
     {
         auto res = it->second.filenames.erase(filename);
         unlinked = res > 0;

--- a/src/Disks/ObjectStorages/MetadataStorageFromPlainObjectStorageOperations.h
+++ b/src/Disks/ObjectStorages/MetadataStorageFromPlainObjectStorageOperations.h
@@ -87,4 +87,38 @@ public:
     void undo(std::unique_lock<SharedMutex> & metadata_lock) override;
 };
 
+class MetadataStorageFromPlainObjectStorageWriteFileOperation final : public IMetadataOperation
+{
+private:
+    std::filesystem::path path;
+    InMemoryDirectoryPathMap & path_map;
+
+    bool written = false;
+
+public:
+    MetadataStorageFromPlainObjectStorageWriteFileOperation(const std::string & path, InMemoryDirectoryPathMap & path_map_);
+
+    void execute(std::unique_lock<SharedMutex> & metadata_lock) override;
+    void undo(std::unique_lock<SharedMutex> & metadata_lock) override;
+};
+
+class MetadataStorageFromPlainObjectStorageUnlinkMetadataFileOperation final : public IMetadataOperation
+{
+private:
+    std::filesystem::path path;
+    std::filesystem::path remote_path;
+    InMemoryDirectoryPathMap & path_map;
+
+    std::filesystem::path remote_parent_path;
+    std::string filename;
+
+    bool unlinked = false;
+
+public:
+    MetadataStorageFromPlainObjectStorageUnlinkMetadataFileOperation(
+        std::filesystem::path && path_, InMemoryDirectoryPathMap & path_map_, ObjectStoragePtr object_storage_);
+
+    void execute(std::unique_lock<SharedMutex> & metadata_lock) override;
+    void undo(std::unique_lock<SharedMutex> & metadata_lock) override;
+};
 }

--- a/src/Disks/ObjectStorages/MetadataStorageFromPlainObjectStorageOperations.h
+++ b/src/Disks/ObjectStorages/MetadataStorageFromPlainObjectStorageOperations.h
@@ -92,11 +92,13 @@ class MetadataStorageFromPlainObjectStorageWriteFileOperation final : public IMe
 private:
     std::filesystem::path path;
     InMemoryDirectoryPathMap & path_map;
+    ObjectStoragePtr object_storage;
 
     bool written = false;
 
 public:
-    MetadataStorageFromPlainObjectStorageWriteFileOperation(const std::string & path, InMemoryDirectoryPathMap & path_map_);
+    MetadataStorageFromPlainObjectStorageWriteFileOperation(
+        const std::string & path, InMemoryDirectoryPathMap & path_map_, ObjectStoragePtr object_storage_);
 
     void execute(std::unique_lock<SharedMutex> & metadata_lock) override;
     void undo(std::unique_lock<SharedMutex> & metadata_lock) override;
@@ -108,6 +110,7 @@ private:
     std::filesystem::path path;
     std::filesystem::path remote_path;
     InMemoryDirectoryPathMap & path_map;
+    ObjectStoragePtr object_storage;
 
     bool unlinked = false;
 

--- a/src/Disks/ObjectStorages/MetadataStorageFromPlainObjectStorageOperations.h
+++ b/src/Disks/ObjectStorages/MetadataStorageFromPlainObjectStorageOperations.h
@@ -109,9 +109,6 @@ private:
     std::filesystem::path remote_path;
     InMemoryDirectoryPathMap & path_map;
 
-    std::filesystem::path remote_parent_path;
-    std::string filename;
-
     bool unlinked = false;
 
 public:

--- a/src/Disks/ObjectStorages/MetadataStorageFromPlainRewritableObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/MetadataStorageFromPlainRewritableObjectStorage.cpp
@@ -95,11 +95,7 @@ void loadDirectoryTree(
 
                 auto metric = object_storage->getMetadataStorageMetrics().file_count;
                 CurrentMetrics::add(metric, filename_iterators.size());
-
-                {
-                    std::lock_guard lock(mutex);
-                    remote_path_info.filename_iterators = std::move(filename_iterators);
-                }
+                remote_path_info.filename_iterators = std::move(filename_iterators);
             });
     }
     runner.waitForAllToFinishAndRethrowFirstError();

--- a/src/Disks/ObjectStorages/MetadataStorageFromPlainRewritableObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/MetadataStorageFromPlainRewritableObjectStorage.cpp
@@ -269,23 +269,22 @@ MetadataStorageFromPlainRewritableObjectStorage::getDirectChildrenOnDisk(const s
 {
     std::unordered_set<std::string> result;
     SharedLockGuard lock(path_map->mutex);
-    // const auto & map = path_map->map;
     const auto end_it = path_map->map.end();
     /// Directories.
     for (auto it = path_map->map.lower_bound(local_path); it != end_it; ++it)
     {
-        const auto & [k, _] = std::make_tuple(it->first.string(), it->second);
-        if (!k.starts_with(local_path.string()))
+        const auto & subdirectory = it->first.string();
+        if (!subdirectory.starts_with(local_path.string()))
             break;
 
-        auto slash_num = count(k.begin() + local_path.string().size(), k.end(), '/');
+        auto slash_num = count(subdirectory.begin() + local_path.string().size(), subdirectory.end(), '/');
         /// The directory map comparator ensures that the paths with the smallest number of
         /// hops from the local_path are iterated first. The paths do not end with '/', hence
         /// break the loop if the number of slashes to the right from the offset is greater than 0.
         if (slash_num != 0)
             break;
 
-        result.emplace(std::string(k.begin() + local_path.string().size(), k.end()) + "/");
+        result.emplace(std::string(subdirectory.begin() + local_path.string().size(), subdirectory.end()) + "/");
     }
 
     /// Files.

--- a/src/Disks/ObjectStorages/MetadataStorageFromPlainRewritableObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/MetadataStorageFromPlainRewritableObjectStorage.cpp
@@ -73,7 +73,8 @@ void loadDirectoryTree(
             if (path.substr(remote_path.string().size()) == filename)
             {
                 auto filename_it = unique_filenames.emplace(filename).first;
-                filename_iterators.emplace(filename_it);
+                [[maybe_unused]] auto inserted = filename_iterators.emplace(filename_it).second;
+                chassert(inserted);
             }
         }
 

--- a/src/Disks/ObjectStorages/MetadataStorageFromPlainRewritableObjectStorage.h
+++ b/src/Disks/ObjectStorages/MetadataStorageFromPlainRewritableObjectStorage.h
@@ -36,8 +36,6 @@ protected:
     std::string getMetadataKeyPrefix() const override { return metadata_key_prefix; }
     std::shared_ptr<InMemoryDirectoryPathMap> getPathMap() const override { return path_map; }
     void getDirectChildrenOnDisk(
-        const std::string & storage_key,
-        const RelativePathsWithMetadata & remote_paths,
         const std::string & local_path,
         std::unordered_set<std::string> & result) const;
 

--- a/src/Disks/ObjectStorages/MetadataStorageFromPlainRewritableObjectStorage.h
+++ b/src/Disks/ObjectStorages/MetadataStorageFromPlainRewritableObjectStorage.h
@@ -35,9 +35,7 @@ public:
 protected:
     std::string getMetadataKeyPrefix() const override { return metadata_key_prefix; }
     std::shared_ptr<InMemoryDirectoryPathMap> getPathMap() const override { return path_map; }
-    void getDirectChildrenOnDisk(
-        const std::string & local_path,
-        std::unordered_set<std::string> & result) const;
+    std::unordered_set<std::string> getDirectChildrenOnDisk(const std::filesystem::path & local_path) const;
 
 private:
     bool useSeparateLayoutForMetadata() const;

--- a/src/Disks/ObjectStorages/MetadataStorageMetrics.h
+++ b/src/Disks/ObjectStorages/MetadataStorageMetrics.h
@@ -13,6 +13,8 @@ struct MetadataStorageMetrics
     const ProfileEvents::Event directory_removed = ProfileEvents::end();
 
     CurrentMetrics::Metric directory_map_size = CurrentMetrics::end();
+    CurrentMetrics::Metric unique_filenames_count = CurrentMetrics::end();
+    CurrentMetrics::Metric file_count = CurrentMetrics::end();
 
     template <typename ObjectStorage, MetadataStorageType metadata_type>
     static MetadataStorageMetrics create()

--- a/src/Disks/ObjectStorages/createMetadataStorageMetrics.h
+++ b/src/Disks/ObjectStorages/createMetadataStorageMetrics.h
@@ -24,8 +24,14 @@ extern const Event DiskPlainRewritableS3DirectoryRemoved;
 namespace CurrentMetrics
 {
 extern const Metric DiskPlainRewritableAzureDirectoryMapSize;
+extern const Metric DiskPlainRewritableAzureUniqueFileNamesCount;
+extern const Metric DiskPlainRewritableAzureFileCount;
 extern const Metric DiskPlainRewritableLocalDirectoryMapSize;
+extern const Metric DiskPlainRewritableLocalUniqueFileNamesCount;
+extern const Metric DiskPlainRewritableLocalFileCount;
 extern const Metric DiskPlainRewritableS3DirectoryMapSize;
+extern const Metric DiskPlainRewritableS3UniqueFileNamesCount;
+extern const Metric DiskPlainRewritableS3FileCount;
 }
 
 namespace DB
@@ -38,7 +44,9 @@ inline MetadataStorageMetrics MetadataStorageMetrics::create<S3ObjectStorage, Me
     return MetadataStorageMetrics{
         .directory_created = ProfileEvents::DiskPlainRewritableS3DirectoryCreated,
         .directory_removed = ProfileEvents::DiskPlainRewritableS3DirectoryRemoved,
-        .directory_map_size = CurrentMetrics::DiskPlainRewritableS3DirectoryMapSize};
+        .directory_map_size = CurrentMetrics::DiskPlainRewritableS3DirectoryMapSize,
+        .unique_filenames_count = CurrentMetrics::DiskPlainRewritableS3UniqueFileNamesCount,
+        .file_count = CurrentMetrics::DiskPlainRewritableS3FileCount};
 }
 #endif
 
@@ -49,7 +57,9 @@ inline MetadataStorageMetrics MetadataStorageMetrics::create<AzureObjectStorage,
     return MetadataStorageMetrics{
         .directory_created = ProfileEvents::DiskPlainRewritableAzureDirectoryCreated,
         .directory_removed = ProfileEvents::DiskPlainRewritableAzureDirectoryRemoved,
-        .directory_map_size = CurrentMetrics::DiskPlainRewritableAzureDirectoryMapSize};
+        .directory_map_size = CurrentMetrics::DiskPlainRewritableAzureDirectoryMapSize,
+        .unique_filenames_count = CurrentMetrics::DiskPlainRewritableAzureUniqueFileNamesCount,
+        .file_count = CurrentMetrics::DiskPlainRewritableAzureFileCount};
 }
 #endif
 
@@ -59,7 +69,9 @@ inline MetadataStorageMetrics MetadataStorageMetrics::create<LocalObjectStorage,
     return MetadataStorageMetrics{
         .directory_created = ProfileEvents::DiskPlainRewritableLocalDirectoryCreated,
         .directory_removed = ProfileEvents::DiskPlainRewritableLocalDirectoryRemoved,
-        .directory_map_size = CurrentMetrics::DiskPlainRewritableLocalDirectoryMapSize};
+        .directory_map_size = CurrentMetrics::DiskPlainRewritableLocalDirectoryMapSize,
+        .unique_filenames_count = CurrentMetrics::DiskPlainRewritableLocalUniqueFileNamesCount,
+        .file_count = CurrentMetrics::DiskPlainRewritableLocalFileCount};
 }
 
 }


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Do not call the object storage API when listing directories, as this may be cost-inefficient. Instead, store the list of filenames in the memory. The trade-offs are increased initial load time and memory required to store filenames.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---ci_include_fuzzer--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
