### PR TITLE
S3Queue: fix setting diverging

### DIFF
--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueSource.h
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueSource.h
@@ -93,6 +93,14 @@ public:
         bool hasKeysForProcessor(const Processor & processor) const;
     };
 
+    struct CommitSettings
+    {
+        size_t max_processed_files_before_commit;
+        size_t max_processed_rows_before_commit;
+        size_t max_processed_bytes_before_commit;
+        size_t max_processing_time_sec_before_commit;
+    };
+
     ObjectStorageQueueSource(
         String name_,
         size_t processor_id_,
@@ -101,7 +109,7 @@ public:
         ObjectStoragePtr object_storage_,
         const ReadFromFormatInfo & read_from_format_info_,
         const std::optional<FormatSettings> & format_settings_,
-        const ObjectStorageQueueSettings & queue_settings_,
+        const CommitSettings & commit_settings_,
         std::shared_ptr<ObjectStorageQueueMetadata> files_metadata_,
         ContextPtr context_,
         size_t max_block_size_,
@@ -130,7 +138,7 @@ private:
     const ObjectStoragePtr object_storage;
     ReadFromFormatInfo read_from_format_info;
     const std::optional<FormatSettings> format_settings;
-    const ObjectStorageQueueSettings queue_settings;
+    const CommitSettings commit_settings;
     const std::shared_ptr<ObjectStorageQueueMetadata> files_metadata;
     const size_t max_block_size;
 

--- a/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp
+++ b/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp
@@ -95,20 +95,20 @@ namespace
     std::shared_ptr<ObjectStorageQueueLog> getQueueLog(
         const ObjectStoragePtr & storage,
         const ContextPtr & context,
-        const ObjectStorageQueueSettings & table_settings)
+        bool enable_logging_to_queue_log)
     {
         const auto & settings = context->getSettingsRef();
         switch (storage->getType())
         {
             case DB::ObjectStorageType::S3:
             {
-                if (table_settings.enable_logging_to_queue_log || settings[Setting::s3queue_enable_logging_to_s3queue_log])
+                if (enable_logging_to_queue_log || settings[Setting::s3queue_enable_logging_to_s3queue_log])
                     return context->getS3QueueLog();
                 return nullptr;
             }
             case DB::ObjectStorageType::Azure:
             {
-                if (table_settings.enable_logging_to_queue_log)
+                if (enable_logging_to_queue_log)
                     return context->getAzureQueueLog();
                 return nullptr;
             }
@@ -131,11 +131,20 @@ StorageObjectStorageQueue::StorageObjectStorageQueue(
     LoadingStrictnessLevel mode)
     : IStorage(table_id_)
     , WithContext(context_)
-    , queue_settings(std::move(queue_settings_))
-    , zk_path(chooseZooKeeperPath(table_id_, context_->getSettingsRef(), *queue_settings))
+    , zk_path(chooseZooKeeperPath(table_id_, context_->getSettingsRef(), *queue_settings_))
+    , enable_logging_to_queue_log(queue_settings_->enable_logging_to_queue_log)
+    , polling_min_timeout_ms(queue_settings_->polling_min_timeout_ms)
+    , polling_max_timeout_ms(queue_settings_->polling_max_timeout_ms)
+    , polling_backoff_ms(queue_settings_->polling_backoff_ms)
+    , commit_settings(CommitSettings{
+        .max_processed_files_before_commit = queue_settings_->max_processed_files_before_commit,
+        .max_processed_rows_before_commit = queue_settings_->max_processed_rows_before_commit,
+        .max_processed_bytes_before_commit = queue_settings_->max_processed_bytes_before_commit,
+        .max_processing_time_sec_before_commit = queue_settings_->max_processing_time_sec_before_commit,
+    })
     , configuration{configuration_}
     , format_settings(format_settings_)
-    , reschedule_processing_interval_ms(queue_settings->polling_min_timeout_ms)
+    , reschedule_processing_interval_ms(queue_settings_->polling_min_timeout_ms)
     , log(getLogger(fmt::format("Storage{}Queue ({})", configuration->getEngineName(), table_id_.getFullTableName())))
 {
     if (configuration->getPath().empty())
@@ -152,7 +161,7 @@ StorageObjectStorageQueue::StorageObjectStorageQueue(
     }
 
     const bool is_attach = mode > LoadingStrictnessLevel::CREATE;
-    validateSettings(*queue_settings, is_attach);
+    validateSettings(*queue_settings_, is_attach);
 
     object_storage = configuration->createObjectStorage(context_, /* is_readonly */true);
     FormatFactory::instance().checkFormatName(configuration->format);
@@ -173,10 +182,10 @@ StorageObjectStorageQueue::StorageObjectStorageQueue(
     LOG_INFO(log, "Using zookeeper path: {}", zk_path.string());
 
     auto table_metadata = ObjectStorageQueueMetadata::syncWithKeeper(
-        zk_path, *queue_settings, storage_metadata.getColumns(), configuration_->format, context_, is_attach, log);
+        zk_path, *queue_settings_, storage_metadata.getColumns(), configuration_->format, context_, is_attach, log);
 
     auto queue_metadata = std::make_unique<ObjectStorageQueueMetadata>(
-        zk_path, std::move(table_metadata), queue_settings->cleanup_interval_min_ms, queue_settings->cleanup_interval_max_ms);
+        zk_path, std::move(table_metadata), queue_settings_->cleanup_interval_min_ms, queue_settings_->cleanup_interval_max_ms);
 
     files_metadata = ObjectStorageQueueMetadataFactory::instance().getOrCreate(zk_path, std::move(queue_metadata));
 
@@ -317,7 +326,7 @@ void StorageObjectStorageQueue::read(
 void ReadFromObjectStorageQueue::initializePipeline(QueryPipelineBuilder & pipeline, const BuildQueryPipelineSettings &)
 {
     Pipes pipes;
-    const size_t adjusted_num_streams = storage->queue_settings->processing_threads_num;
+    const size_t adjusted_num_streams = storage->getTableMetadata().processing_threads_num;
 
     createIterator(nullptr);
     for (size_t i = 0; i < adjusted_num_streams; ++i)
@@ -351,9 +360,10 @@ std::shared_ptr<ObjectStorageQueueSource> StorageObjectStorageQueue::createSourc
         getName(), processor_id,
         file_iterator, configuration, object_storage,
         info, format_settings,
-        *queue_settings, files_metadata,
+        commit_settings,
+        files_metadata,
         local_context, max_block_size, shutdown_called, table_is_being_dropped,
-        getQueueLog(object_storage, local_context, *queue_settings),
+        getQueueLog(object_storage, local_context, enable_logging_to_queue_log),
         getStorageID(), log, commit_once_processed);
 }
 
@@ -400,12 +410,12 @@ void StorageObjectStorageQueue::threadFunc()
             if (streamToViews())
             {
                 /// Reset the reschedule interval.
-                reschedule_processing_interval_ms = queue_settings->polling_min_timeout_ms;
+                reschedule_processing_interval_ms = polling_min_timeout_ms;
             }
             else
             {
                 /// Increase the reschedule interval.
-                reschedule_processing_interval_ms += queue_settings->polling_backoff_ms;
+                reschedule_processing_interval_ms = std::min(polling_max_timeout_ms, reschedule_processing_interval_ms + polling_backoff_ms);
             }
 
             LOG_DEBUG(log, "Stopped streaming to {} attached views", dependencies_count);
@@ -446,6 +456,9 @@ bool StorageObjectStorageQueue::streamToViews()
 
     auto file_iterator = createFileIterator(queue_context, nullptr);
     size_t total_rows = 0;
+    const size_t processing_threads_num = getTableMetadata().processing_threads_num;
+
+    LOG_TEST(log, "Using {} processing threads", processing_threads_num);
 
     while (!shutdown_called && !file_iterator->isFinished())
     {
@@ -466,10 +479,10 @@ bool StorageObjectStorageQueue::streamToViews()
         Pipes pipes;
         std::vector<std::shared_ptr<ObjectStorageQueueSource>> sources;
 
-        pipes.reserve(queue_settings->processing_threads_num);
-        sources.reserve(queue_settings->processing_threads_num);
+        pipes.reserve(processing_threads_num);
+        sources.reserve(processing_threads_num);
 
-        for (size_t i = 0; i < queue_settings->processing_threads_num; ++i)
+        for (size_t i = 0; i < processing_threads_num; ++i)
         {
             auto source = createSource(
                 i/* processor_id */,
@@ -485,7 +498,7 @@ bool StorageObjectStorageQueue::streamToViews()
         auto pipe = Pipe::unitePipes(std::move(pipes));
 
         block_io.pipeline.complete(std::move(pipe));
-        block_io.pipeline.setNumThreads(queue_settings->processing_threads_num);
+        block_io.pipeline.setNumThreads(processing_threads_num);
         block_io.pipeline.setConcurrencyControl(queue_context->getSettingsRef()[Setting::use_concurrency_control]);
 
         std::atomic_size_t rows = 0;

--- a/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.h
+++ b/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.h
@@ -54,9 +54,14 @@ public:
 private:
     friend class ReadFromObjectStorageQueue;
     using FileIterator = ObjectStorageQueueSource::FileIterator;
+    using CommitSettings = ObjectStorageQueueSource::CommitSettings;
 
-    const std::unique_ptr<ObjectStorageQueueSettings> queue_settings;
     const fs::path zk_path;
+    const bool enable_logging_to_queue_log;
+    const size_t polling_min_timeout_ms;
+    const size_t polling_max_timeout_ms;
+    const size_t polling_backoff_ms;
+    const CommitSettings commit_settings;
 
     std::shared_ptr<ObjectStorageQueueMetadata> files_metadata;
     ConfigurationPtr configuration;
@@ -81,6 +86,7 @@ private:
     bool supportsSubcolumns() const override { return true; }
     bool supportsOptimizationToSubcolumns() const override { return false; }
     bool supportsDynamicSubcolumns() const override { return true; }
+    const ObjectStorageQueueTableMetadata & getTableMetadata() const { return files_metadata->getTableMetadata(); }
 
     std::shared_ptr<FileIterator> createFileIterator(ContextPtr local_context, const ActionsDAG::Node * predicate);
     std::shared_ptr<ObjectStorageQueueSource> createSource(

--- a/tests/integration/test_storage_s3_queue/test.py
+++ b/tests/integration/test_storage_s3_queue/test.py
@@ -2069,7 +2069,7 @@ def test_processing_threads(started_cluster):
         },
     )
 
-    assert '"processing_threads_num":32' in node.query(
+    assert '"processing_threads_num":16' in node.query(
         f"SELECT * FROM system.zookeeper WHERE path = '{keeper_path}'"
     )
 
@@ -2091,5 +2091,5 @@ def test_processing_threads(started_cluster):
     assert expected_rows == get_count()
 
     assert node.contains_in_log(
-        f"StorageS3Queue (default.{table_name}): Using 32 processing threads"
+        f"StorageS3Queue (default.{table_name}): Using 16 processing threads"
     )

--- a/tests/integration/test_storage_s3_queue/test.py
+++ b/tests/integration/test_storage_s3_queue/test.py
@@ -2046,3 +2046,50 @@ def test_bad_settings(started_cluster):
         assert False
     except Exception as e:
         assert "Ordered mode in cloud without either" in str(e)
+
+
+def test_processing_threads(started_cluster):
+    node = started_cluster.instances["node1"]
+
+    table_name = f"test_processing_threads_{uuid.uuid4().hex[:8]}"
+    dst_table_name = f"{table_name}_dst"
+    # A unique path is necessary for repeatable tests
+    keeper_path = f"/clickhouse/test_{table_name}"
+    files_path = f"{table_name}_data"
+    files_to_generate = 10
+
+    create_table(
+        started_cluster,
+        node,
+        table_name,
+        "ordered",
+        files_path,
+        additional_settings={
+            "keeper_path": keeper_path,
+        },
+    )
+
+    assert '"processing_threads_num":32' in node.query(
+        f"SELECT * FROM system.zookeeper WHERE path = '{keeper_path}'"
+    )
+
+    total_values = generate_random_files(
+        started_cluster, files_path, files_to_generate, start_ind=0, row_num=1
+    )
+
+    create_mv(node, table_name, dst_table_name)
+
+    def get_count():
+        return int(node.query(f"SELECT count() FROM {dst_table_name}"))
+
+    expected_rows = 10
+    for _ in range(20):
+        if expected_rows == get_count():
+            break
+        time.sleep(1)
+
+    assert expected_rows == get_count()
+
+    assert node.contains_in_log(
+        f"StorageS3Queue (default.{table_name}): Using 32 processing threads"
+    )


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix S3Queue table engine setting processing_threads_num not being effective in case it was deduced from the number of cpu cores on the server.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [x] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---ci_include_fuzzer--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [ ] <!---do_not_test--> Do not test
- [x] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
