### PR TITLE
Checks for ALTER ... MODIFY SETTINGS disk queires

### DIFF
--- a/src/Disks/StoragePolicy.cpp
+++ b/src/Disks/StoragePolicy.cpp
@@ -343,10 +343,10 @@ VolumePtr StoragePolicy::tryGetVolumeByName(const String & volume_name) const
 void StoragePolicy::checkCompatibleWith(const StoragePolicyPtr & new_storage_policy) const
 {
     /// Do not check volumes for temporary policy because their names are automatically generated
-    bool check_volumes = this->getName().starts_with(StoragePolicySelector::TMP_STORAGE_POLICY_PREFIX)
+    bool skip_volume_check = this->getName().starts_with(StoragePolicySelector::TMP_STORAGE_POLICY_PREFIX)
         || new_storage_policy->getName().starts_with(StoragePolicySelector::TMP_STORAGE_POLICY_PREFIX);
 
-    if (!check_volumes)
+    if (!skip_volume_check)
     {
         std::unordered_set<String> new_volume_names;
         for (const auto & volume : new_storage_policy->getVolumes())

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -3626,11 +3626,15 @@ void MergeTreeData::checkAlterIsPossible(const AlterCommands & commands, Context
         performRequiredConversions(old_header, columns_to_check_conversion, local_context);
     }
 
+    // HERE
     if (old_metadata.hasSettingsChanges())
     {
         const auto current_changes = old_metadata.getSettingsChanges()->as<const ASTSetQuery &>().changes;
         const auto & new_changes = new_metadata.settings_changes->as<const ASTSetQuery &>().changes;
         local_context->checkMergeTreeSettingsConstraints(*settings_from_storage, new_changes);
+
+        // bool found_disk_setting = false;
+        // bool found_storage_policy_setting = false;
 
         for (const auto & changed_setting : new_changes)
         {
@@ -3655,8 +3659,23 @@ void MergeTreeData::checkAlterIsPossible(const AlterCommands & commands, Context
             }
 
             if (setting_name == "storage_policy")
+            {
                 checkStoragePolicy(local_context->getStoragePolicy(new_value.safeGet<String>()));
+                // found_storage_policy_setting = true;
+            }
+            if (setting_name == "disk")
+            {
+                // TODO: check reset
+                // if (getSettings()->has("storage_policy"))
+                //     throw Exception(
+                //         ErrorCodes::BAD_ARGUMENTS,
+                //         "MergeTree settings `storage_policy` and `disk` cannot be specified at the same time");
+                checkStoragePolicy(local_context->getStoragePolicyFromDisk(new_value.safeGet<String>()));
+                // found_disk_setting = true;
+            }
         }
+
+        // if ()
 
         /// Check if it is safe to reset the settings
         for (const auto & current_setting : current_changes)

--- a/src/Storages/MergeTree/MergeTreeSettings.cpp
+++ b/src/Storages/MergeTree/MergeTreeSettings.cpp
@@ -324,7 +324,7 @@ void MergeTreeSettingsImpl::loadFromQuery(ASTStorage & storage_def, ContextPtr c
                 else if (name == "storage_policy")
                     found_storage_policy_setting = true;
 
-                if (found_disk_setting && found_storage_policy_setting)
+                if (!is_attach && found_disk_setting && found_storage_policy_setting)
                 {
                     throw Exception(
                         ErrorCodes::BAD_ARGUMENTS,

--- a/tests/integration/test_disk_configuration/configs/config.d/mergetree_settings.xml
+++ b/tests/integration/test_disk_configuration/configs/config.d/mergetree_settings.xml
@@ -1,5 +1,5 @@
 <clickhouse>
     <merge_tree>
-        <storage_policy>unknown</storage_policy>
+        <storage_policy>hybrid</storage_policy>
     </merge_tree>
 </clickhouse>

--- a/tests/integration/test_disk_configuration/configs/config.d/storage_configuration.xml
+++ b/tests/integration/test_disk_configuration/configs/config.d/storage_configuration.xml
@@ -20,6 +20,24 @@
                     </main>
                 </volumes>
             </local>
+            <s3>
+                <volumes>
+                    <s3>
+                        <disk>s3</disk>
+                    </s3>
+                </volumes>
+            </s3>
+            <hybrid>
+                <volumes>
+                    <disk_local>
+                        <disk>disk_local</disk>
+                    </disk_local>
+                    <s3>
+                        <disk>s3</disk>
+                    </s3>
+                </volumes>
+            </hybrid>
+
         </policies>
     </storage_configuration>
 </clickhouse>

--- a/tests/integration/test_disk_configuration/test.py
+++ b/tests/integration/test_disk_configuration/test.py
@@ -381,12 +381,55 @@ def test_merge_tree_setting_override(start_cluster):
         )
     )
 
+    # TODO: test ALTER storage_policy = '', disk = ''
+
+    # TODO: clear storage_policy from metadata
+    node.query(
+        f"""
+        DROP TABLE IF EXISTS {TABLE_NAME} SYNC;
+        CREATE TABLE {TABLE_NAME} (a Int32)
+        ENGINE = MergeTree()
+        ORDER BY tuple()
+        SETTINGS storage_policy = 's3';
+        ALTER TABLE {TABLE_NAME} MODIFY SETTING disk = 's3';
+    """
+    )
+
+    assert (
+        "New storage policy `local` shall contain volumes of the old storage policy `s3`"
+        in node.query_and_get_error(
+            f"""
+        DROP TABLE IF EXISTS {TABLE_NAME};
+        CREATE TABLE {TABLE_NAME} (a Int32)
+        ENGINE = MergeTree()
+        ORDER BY tuple()
+        SETTINGS storage_policy = 's3';
+        ALTER TABLE {TABLE_NAME} MODIFY SETTING storage_policy = 'local';
+    """
+        )
+    )
+
+    # Using default policy so storage_policy and disk are not set at the same time
+    assert (
+        "New storage policy `__disk_local` shall contain disks of the old storage policy `hybrid`"
+        in node.query_and_get_error(
+            f"""
+        DROP TABLE IF EXISTS {TABLE_NAME};
+        CREATE TABLE {TABLE_NAME} (a Int32)
+        ENGINE = MergeTree()
+        ORDER BY tuple();
+        ALTER TABLE {TABLE_NAME} MODIFY SETTING disk = 'disk_local';
+    """
+        )
+    )
+
     assert "Unknown storage policy" in node.query_and_get_error(
         f"""
         DROP TABLE IF EXISTS {TABLE_NAME};
         CREATE TABLE {TABLE_NAME} (a Int32)
         ENGINE = MergeTree()
-        ORDER BY tuple();
+        ORDER BY tuple()
+        SETTINGS storage_policy = 'kek';
     """
     )
 

--- a/tests/integration/test_disk_configuration/test.py
+++ b/tests/integration/test_disk_configuration/test.py
@@ -381,11 +381,10 @@ def test_merge_tree_setting_override(start_cluster):
         )
     )
 
-    # TODO: test ALTER storage_policy = '', disk = ''
-
-    # TODO: clear storage_policy from metadata
-    node.query(
-        f"""
+    assert (
+        "MergeTree settings `storage_policy` and `disk` cannot be specified at the same time"
+        in node.query_and_get_error(
+            f"""
         DROP TABLE IF EXISTS {TABLE_NAME} SYNC;
         CREATE TABLE {TABLE_NAME} (a Int32)
         ENGINE = MergeTree()
@@ -393,6 +392,21 @@ def test_merge_tree_setting_override(start_cluster):
         SETTINGS storage_policy = 's3';
         ALTER TABLE {TABLE_NAME} MODIFY SETTING disk = 's3';
     """
+        )
+    )
+
+    assert (
+        "MergeTree settings `storage_policy` and `disk` cannot be specified at the same time"
+        in node.query_and_get_error(
+            f"""
+        DROP TABLE IF EXISTS {TABLE_NAME} SYNC;
+        CREATE TABLE {TABLE_NAME} (a Int32)
+        ENGINE = MergeTree()
+        ORDER BY tuple()
+        SETTINGS disk = 's3';
+        ALTER TABLE {TABLE_NAME} MODIFY SETTING storage_policy = 's3';
+    """
+        )
     )
 
     assert (


### PR DESCRIPTION
There are two problems with `MODIFY SETTINGS disk` queries.

It is possible to create table with storage_policy and disk at the same time, but then table is created or attached the check for that case will fail:
```SQL
CREATE TABLE foo (
    `id` UInt32
)
ENGINE = MergeTree
ORDER BY id
SETTINGS storage_policy = 'object_storage'

ALTER TABLE foo (MODIFY SETTING disk = 'default')

--SETTINGS storage_policy = 'object_storage', index_granularity = 8192, disk = 'default'

CREATE TABLE foo (
    `id` UInt32
)
ENGINE = MergeTree
ORDER BY id
SETTINGS storage_policy = 'object_storage', disk = 'default'

--MergeTree settings `storage_policy` and `disk` cannot be specified at the same time
```

There are no check if storage policy created from disk contains all disks from old storage policy, but such check exists for `MODIFY SETTINGS storage_policy` query:

```SQL
CREATE TABLE foo (
    `id` UInt32
)
ENGINE = MergeTree
ORDER BY id

name:                          foo
data_paths:                    ['/var/lib/clickhouse/store/984/984c1303-08a2-4296-ba55-87996b52251a/','/var/lib/clickhouse/disks/object_storage/store/984/984c1303-08a2-4296-ba55-87996b52251a/']
storage_policy:                s3

ALTER TABLE bar (MODIFY SETTING storage_policy = 'default')

--New storage policy `default` shall contain volumes of the old storage policy `s3`. (BAD_ARGUMENTS)

ALTER TABLE foo (MODIFY SETTING disk = 'default')

name:                          foo
data_paths:                    ['/var/lib/clickhouse/store/984/984c1303-08a2-4296-ba55-87996b52251a/']
storage_policy:                __default
```

PR changes:
- Storage policy check for `MODIFY SETTINGS disk` queries is added
- It is not allowed to specify both `storage_policy` and `disk` at the same time using alter query
- Check if table has both `storage_policy` and `disk` when table is attached is disabled for backwards compatibility in case there some tables already existing with both `storage_policy` and `disk`

### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
A check if table has both `storage_policy` and `disk` set after alter query is added. A check if a new storage policy is compatible with an old one when using `disk` setting is added.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)
