### PR TITLE
Normalize named tuple arguments in agg states

### DIFF
--- a/src/AggregateFunctions/IAggregateFunction.cpp
+++ b/src/AggregateFunctions/IAggregateFunction.cpp
@@ -10,6 +10,15 @@ DataTypePtr IAggregateFunction::getStateType() const
     return std::make_shared<DataTypeAggregateFunction>(shared_from_this(), argument_types, parameters);
 }
 
+DataTypePtr IAggregateFunction::getNormalizedStateType() const
+{
+    DataTypes normalized_argument_types;
+    normalized_argument_types.reserve(argument_types.size());
+    for (const auto & arg : argument_types)
+        normalized_argument_types.emplace_back(arg->getNormalizedType());
+    return std::make_shared<DataTypeAggregateFunction>(shared_from_this(), normalized_argument_types, parameters);
+}
+
 String IAggregateFunction::getDescription() const
 {
     String description;

--- a/src/AggregateFunctions/IAggregateFunction.h
+++ b/src/AggregateFunctions/IAggregateFunction.h
@@ -73,7 +73,7 @@ public:
     virtual DataTypePtr getStateType() const;
 
     /// Same as the above but normalize state types so that variants with the same binary representation will use the same type.
-    virtual DataTypePtr getNormalizedStateType() const { return getStateType(); }
+    virtual DataTypePtr getNormalizedStateType() const;
 
     /// Returns true if two aggregate functions have the same state representation in memory and the same serialization,
     /// so state of one aggregate function can be safely used with another.

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -4453,7 +4453,7 @@ Optimize GROUP BY when all keys in block are constant
     M(Bool, legacy_column_name_of_tuple_literal, false, R"(
 List all names of element of large tuple literals in their column names instead of hash. This settings exists only for compatibility reasons. It makes sense to set to 'true', while doing rolling update of cluster from version lower than 21.7 to higher.
 )", 0) \
-    M(Bool, enable_named_columns_in_function_tuple, false, R"(
+    M(Bool, enable_named_columns_in_function_tuple, true, R"(
 Generate named tuples in function tuple() when all names are unique and can be treated as unquoted identifiers.
 Beware that this setting might currently result in broken queries. It's not recommended to use in production
 )", 0) \

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -83,7 +83,7 @@ static std::initializer_list<std::pair<ClickHouseVersion, SettingsChangesHistory
             {"input_format_binary_read_json_as_string", false, false, "Add new setting to read values of JSON type as JSON string in RowBinary input format"},
             {"min_free_disk_bytes_to_perform_insert", 0, 0, "New setting."},
             {"min_free_disk_ratio_to_perform_insert", 0.0, 0.0, "New setting."},
-            {"enable_named_columns_in_function_tuple", false, false, "Force disable the setting since it breaks queries"},
+            {"enable_named_columns_in_function_tuple", false, true, "Re-enable the setting since all known bugs are fixed"},
             {"cloud_mode_database_engine", 1, 1, "A setting for ClickHouse Cloud"},
             {"allow_experimental_shared_set_join", 1, 1, "A setting for ClickHouse Cloud"},
             {"read_through_distributed_cache", 0, 0, "A setting for ClickHouse Cloud"},

--- a/src/DataTypes/DataTypeArray.h
+++ b/src/DataTypes/DataTypeArray.h
@@ -47,8 +47,8 @@ public:
 
     Field getDefault() const override;
 
+    DataTypePtr getNormalizedType() const override { return std::make_shared<DataTypeArray>(nested->getNormalizedType()); }
     bool equals(const IDataType & rhs) const override;
-
     bool isParametric() const override { return true; }
     bool haveSubtypes() const override { return true; }
     bool cannotBeStoredInTables() const override { return nested->cannotBeStoredInTables(); }

--- a/src/DataTypes/DataTypeMap.h
+++ b/src/DataTypes/DataTypeMap.h
@@ -43,7 +43,10 @@ public:
     bool isParametric() const override { return true; }
     bool haveSubtypes() const override { return true; }
     bool hasDynamicSubcolumnsDeprecated() const override { return nested->hasDynamicSubcolumnsDeprecated(); }
-
+    DataTypePtr getNormalizedType() const override
+    {
+        return std::make_shared<DataTypeMap>(key_type->getNormalizedType(), value_type->getNormalizedType());
+    }
     const DataTypePtr & getKeyType() const { return key_type; }
     const DataTypePtr & getValueType() const { return value_type; }
     DataTypes getKeyValueTypes() const { return {key_type, value_type}; }

--- a/src/DataTypes/DataTypeTuple.cpp
+++ b/src/DataTypes/DataTypeTuple.cpp
@@ -133,6 +133,14 @@ std::string DataTypeTuple::doGetPrettyName(size_t indent) const
     return s.str();
 }
 
+DataTypePtr DataTypeTuple::getNormalizedType() const
+{
+    DataTypes normalized_elems;
+    normalized_elems.reserve(elems.size());
+    for (const auto & elem : elems)
+        normalized_elems.emplace_back(elem->getNormalizedType());
+    return std::make_shared<DataTypeTuple>(normalized_elems);
+}
 
 static inline IColumn & extractElementColumn(IColumn & column, size_t idx)
 {

--- a/src/DataTypes/DataTypeTuple.h
+++ b/src/DataTypes/DataTypeTuple.h
@@ -61,6 +61,7 @@ public:
     MutableSerializationInfoPtr createSerializationInfo(const SerializationInfoSettings & settings) const override;
     SerializationInfoPtr getSerializationInfo(const IColumn & column) const override;
 
+    DataTypePtr getNormalizedType() const override;
     const DataTypePtr & getElement(size_t i) const { return elems[i]; }
     const DataTypes & getElements() const { return elems; }
     const Strings & getElementNames() const { return names; }

--- a/src/DataTypes/IDataType.h
+++ b/src/DataTypes/IDataType.h
@@ -88,8 +88,13 @@ public:
 
     DataTypePtr getPtr() const { return shared_from_this(); }
 
-    /// Return the normalized form of the current type, currently only
-    /// converting named tuples to unnamed tuples.
+    /// Returns the normalized form of the current type, currently handling the
+    /// conversion of named tuples to unnamed tuples.
+    ///
+    /// This is useful for converting aggregate states into a normalized form with
+    /// normalized argument types. E.g, `AggregateFunction(uniq, Tuple(a int, b int))`
+    /// should be convertible to `AggregateFunction(uniq, Tuple(int, int))`, as both
+    /// have same memory layouts for state representation and the same serialization.
     virtual DataTypePtr getNormalizedType() const { return shared_from_this(); }
 
     /// Name of data type family (example: FixedString, Array).

--- a/src/DataTypes/IDataType.h
+++ b/src/DataTypes/IDataType.h
@@ -88,6 +88,10 @@ public:
 
     DataTypePtr getPtr() const { return shared_from_this(); }
 
+    /// Return the normalized form of the current type, currently only
+    /// converting named tuples to unnamed tuples.
+    virtual DataTypePtr getNormalizedType() const { return shared_from_this(); }
+
     /// Name of data type family (example: FixedString, Array).
     virtual const char * getFamilyName() const = 0;
 

--- a/tests/queries/0_stateless/03254_normalize_aggregate_states_with_named_tuple_args.reference
+++ b/tests/queries/0_stateless/03254_normalize_aggregate_states_with_named_tuple_args.reference
@@ -1,8 +1,3 @@
 {"finalizeAggregation(x)":"1","finalizeAggregation(y)":"1","finalizeAggregation(z)":"1"}
----- users:
-1	Berlin	Ksenia
-1	London	John
-2	Paris	Alice
----- users2:
 1	2
 2	1

--- a/tests/queries/0_stateless/03254_normalize_aggregate_states_with_named_tuple_args.reference
+++ b/tests/queries/0_stateless/03254_normalize_aggregate_states_with_named_tuple_args.reference
@@ -1,0 +1,8 @@
+{"finalizeAggregation(x)":"1","finalizeAggregation(y)":"1","finalizeAggregation(z)":"1"}
+---- users:
+1	Berlin	Ksenia
+1	London	John
+2	Paris	Alice
+---- users2:
+1	2
+2	1

--- a/tests/queries/0_stateless/03254_normalize_aggregate_states_with_named_tuple_args.sql
+++ b/tests/queries/0_stateless/03254_normalize_aggregate_states_with_named_tuple_args.sql
@@ -26,11 +26,7 @@ INSERT INTO users VALUES (1, 'London', 'John');
 INSERT INTO users VALUES (1, 'Berlin', 'Ksenia');
 INSERT INTO users VALUES (2, 'Paris', 'Alice');
 
-SELECT '---- users:';
-SELECT * FROM users;
-
-SELECT '---- users2:';
-SELECT id, uniqMerge(city_name_uniq) FROM users2 GROUP BY id;
+SELECT id, uniqMerge(city_name_uniq) FROM users2 GROUP BY id ORDER BY id;
 
 DROP TABLE IF EXISTS users;
 DROP TABLE IF EXISTS users2;

--- a/tests/queries/0_stateless/03254_normalize_aggregate_states_with_named_tuple_args.sql
+++ b/tests/queries/0_stateless/03254_normalize_aggregate_states_with_named_tuple_args.sql
@@ -1,0 +1,37 @@
+SET enable_analyzer = 1;
+SET enable_named_columns_in_function_tuple = 1;
+
+SELECT
+    * APPLY finalizeAggregation
+FROM
+(
+    WITH
+        (1, 2)::Tuple(a int, b int) AS nt
+    SELECT
+        uniqState(nt)::AggregateFunction(uniq, Tuple(int, int)) x,
+        uniqState([nt])::AggregateFunction(uniq, Array(Tuple(int, int))) y,
+        uniqState(map(nt, nt))::AggregateFunction(uniq, Map(Tuple(int, int), Tuple(int, int))) z
+)
+FORMAT JSONEachRow;
+
+DROP TABLE IF EXISTS users;
+DROP TABLE IF EXISTS users2;
+DROP TABLE IF EXISTS test_mv;
+
+CREATE TABLE users (id UInt8, city String, name String) ENGINE=Memory;
+CREATE TABLE users2 (id UInt8, city_name_uniq AggregateFunction(uniq, Tuple(String,String))) ENGINE=AggregatingMergeTree() ORDER BY (id);
+CREATE MATERIALIZED VIEW test_mv TO users2 AS SELECT id, uniqState((city, name)) AS city_name_uniq FROM users GROUP BY id;
+
+INSERT INTO users VALUES (1, 'London', 'John');
+INSERT INTO users VALUES (1, 'Berlin', 'Ksenia');
+INSERT INTO users VALUES (2, 'Paris', 'Alice');
+
+SELECT '---- users:';
+SELECT * FROM users;
+
+SELECT '---- users2:';
+SELECT id, uniqMerge(city_name_uniq) FROM users2 GROUP BY id;
+
+DROP TABLE IF EXISTS users;
+DROP TABLE IF EXISTS users2;
+DROP TABLE IF EXISTS test_mv;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Normalize named tuple arguments in aggregation states. This fixes #69732 .

This PR also re-enables `enable_named_columns_in_function_tuple`, as all known bugs related to it have been resolved. The only remaining exception is issue #70830, which simplifies to the following scenario:

```sql
create table x (t Tuple(a int, b int)) engine MergeTree order by ();
insert into x select (1 as a2, 2 as b2);
select * from x format JSONEachRow;

{"t":{"a":0,"b":0}}
```

Since ClickHouse does not support inserting tuples with different names (e.g., `Tuple(a2 int, b2 int)`) into a tuple structure defined as `Tuple(a int, b int)`, enabling `enable_named_columns_in_function_tuple` would naturally break this compatibility. 