### PR TITLE
Added New Settings for skip_busy_buffer_layers

### DIFF
--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -5808,7 +5808,8 @@ Experimental data deduplication for SELECT queries based on part UUIDs
 )", 0) \
     M(Bool, implicit_select, false, R"(
 Allow writing simple SELECT queries without the leading SELECT keyword, which makes it simple for calculator-style usage, e.g. `1 + 2` becomes a valid query.
-)", 0)
+)", 0) \
+    M(SettingBool, skip_busy_buffer_layers, false, "Skip busy buffer layers during read operations")
 
 
 // End of COMMON_SETTINGS

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -5809,7 +5809,13 @@ Experimental data deduplication for SELECT queries based on part UUIDs
     M(Bool, implicit_select, false, R"(
 Allow writing simple SELECT queries without the leading SELECT keyword, which makes it simple for calculator-style usage, e.g. `1 + 2` becomes a valid query.
 )", 0) \
-    M(SettingBool, skip_busy_buffer_layers, false, "Skip busy buffer layers during read operations")
+    M(SettingBool, skip_busy_buffer_layers, false, R"(
+    Enables skipping of busy buffer layers during read operations for StorageBuffer.
+
+    When enabled, this setting allows ClickHouse to skip buffer layers that are currently locked
+    (e.g., being written to) during read operations. This can significantly improve query performance
+    and reduce contention in high-concurrency scenarios, especially when there are frequent writes
+    to the buffer table.)" , 0 )
 
 
 // End of COMMON_SETTINGS

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -5816,8 +5816,6 @@ Allow writing simple SELECT queries without the leading SELECT keyword, which ma
     (e.g., being written to) during read operations. This can significantly improve query performance
     and reduce contention in high-concurrency scenarios, especially when there are frequent writes
     to the buffer table.)" , 0 )
-
-
 // End of COMMON_SETTINGS
 // Please add settings related to formats in FormatFactorySettingsDeclaration.h, move obsolete settings to OBSOLETE_SETTINGS and obsolete format settings to OBSOLETE_FORMAT_SETTINGS.
 

--- a/src/Storages/StorageBuffer.h
+++ b/src/Storages/StorageBuffer.h
@@ -162,6 +162,7 @@ private:
 
     StorageID destination_id;
     bool allow_materialized;
+    bool skip_busy_layers;
 
     struct Writes
     {


### PR DESCRIPTION
Resolves Issue #70584 

### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Adds setting to skip busy buffer layers which are locked during read. 

