### PR TITLE
Limiting logging some lines about configs

### DIFF
--- a/src/Common/Config/ConfigProcessor.cpp
+++ b/src/Common/Config/ConfigProcessor.cpp
@@ -673,7 +673,9 @@ XMLDocumentPtr ConfigProcessor::processConfig(
     zkutil::ZooKeeperNodeCache * zk_node_cache,
     const zkutil::EventPtr & zk_changed_event)
 {
-    LOG_DEBUG(log, "Processing configuration file '{}'.", path);
+    const bool write_logs = is_config_changed;
+    if (write_logs)
+        LOG_DEBUG(log, "Processing configuration file '{}'.", path);
 
     XMLDocumentPtr config;
 
@@ -686,7 +688,8 @@ XMLDocumentPtr ConfigProcessor::processConfig(
         /// When we can use a config embedded in the binary.
         if (auto it = embedded_configs.find(path); it != embedded_configs.end())
         {
-            LOG_DEBUG(log, "There is no file '{}', will use embedded config.", path);
+            if (write_logs)
+                LOG_DEBUG(log, "There is no file '{}', will use embedded config.", path);
             config = dom_parser.parseMemory(it->second.data(), it->second.size());
         }
         else
@@ -700,7 +703,8 @@ XMLDocumentPtr ConfigProcessor::processConfig(
     {
         try
         {
-            LOG_DEBUG(log, "Merging configuration file '{}'.", merge_file);
+            if (write_logs)
+                LOG_DEBUG(log, "Merging configuration file '{}'.", merge_file);
 
             XMLDocumentPtr with;
             with = parseConfig(merge_file);

--- a/src/Common/Config/ConfigProcessor.cpp
+++ b/src/Common/Config/ConfigProcessor.cpp
@@ -671,10 +671,10 @@ XMLDocumentPtr ConfigProcessor::parseConfig(const std::string & config_path)
 XMLDocumentPtr ConfigProcessor::processConfig(
     bool * has_zk_includes,
     zkutil::ZooKeeperNodeCache * zk_node_cache,
-    const zkutil::EventPtr & zk_changed_event)
+    const zkutil::EventPtr & zk_changed_event,
+    bool is_config_changed)
 {
-    const bool write_logs = is_config_changed;
-    if (write_logs)
+    if (is_config_changed)
         LOG_DEBUG(log, "Processing configuration file '{}'.", path);
 
     XMLDocumentPtr config;
@@ -688,7 +688,7 @@ XMLDocumentPtr ConfigProcessor::processConfig(
         /// When we can use a config embedded in the binary.
         if (auto it = embedded_configs.find(path); it != embedded_configs.end())
         {
-            if (write_logs)
+            if (is_config_changed)
                 LOG_DEBUG(log, "There is no file '{}', will use embedded config.", path);
             config = dom_parser.parseMemory(it->second.data(), it->second.size());
         }
@@ -703,7 +703,7 @@ XMLDocumentPtr ConfigProcessor::processConfig(
     {
         try
         {
-            if (write_logs)
+            if (is_config_changed)
                 LOG_DEBUG(log, "Merging configuration file '{}'.", merge_file);
 
             XMLDocumentPtr with;
@@ -794,10 +794,10 @@ XMLDocumentPtr ConfigProcessor::processConfig(
     return config;
 }
 
-ConfigProcessor::LoadedConfig ConfigProcessor::loadConfig(bool allow_zk_includes)
+ConfigProcessor::LoadedConfig ConfigProcessor::loadConfig(bool allow_zk_includes, bool is_config_changed)
 {
     bool has_zk_includes;
-    XMLDocumentPtr config_xml = processConfig(&has_zk_includes);
+    XMLDocumentPtr config_xml = processConfig(&has_zk_includes, nullptr, nullptr, is_config_changed);
 
     if (has_zk_includes && !allow_zk_includes)
         throw Poco::Exception("Error while loading config '" + path + "': from_zk includes are not allowed!");
@@ -810,14 +810,15 @@ ConfigProcessor::LoadedConfig ConfigProcessor::loadConfig(bool allow_zk_includes
 ConfigProcessor::LoadedConfig ConfigProcessor::loadConfigWithZooKeeperIncludes(
     zkutil::ZooKeeperNodeCache & zk_node_cache,
     const zkutil::EventPtr & zk_changed_event,
-    bool fallback_to_preprocessed)
+    bool fallback_to_preprocessed,
+    bool is_config_changed)
 {
     XMLDocumentPtr config_xml;
     bool has_zk_includes;
     bool processed_successfully = false;
     try
     {
-        config_xml = processConfig(&has_zk_includes, &zk_node_cache, zk_changed_event);
+        config_xml = processConfig(&has_zk_includes, &zk_node_cache, zk_changed_event, is_config_changed);
         processed_successfully = true;
     }
     catch (const Poco::Exception & ex)

--- a/src/Common/Config/ConfigProcessor.cpp
+++ b/src/Common/Config/ConfigProcessor.cpp
@@ -673,9 +673,7 @@ XMLDocumentPtr ConfigProcessor::processConfig(
     zkutil::ZooKeeperNodeCache * zk_node_cache,
     const zkutil::EventPtr & zk_changed_event)
 {
-    const bool write_logs = is_config_changed;
-    if (write_logs)
-        LOG_DEBUG(log, "Processing configuration file '{}'.", path);
+    LOG_DEBUG(log, "Processing configuration file '{}'.", path);
 
     XMLDocumentPtr config;
 
@@ -688,8 +686,7 @@ XMLDocumentPtr ConfigProcessor::processConfig(
         /// When we can use a config embedded in the binary.
         if (auto it = embedded_configs.find(path); it != embedded_configs.end())
         {
-            if (write_logs)
-                LOG_DEBUG(log, "There is no file '{}', will use embedded config.", path);
+            LOG_DEBUG(log, "There is no file '{}', will use embedded config.", path);
             config = dom_parser.parseMemory(it->second.data(), it->second.size());
         }
         else
@@ -703,8 +700,7 @@ XMLDocumentPtr ConfigProcessor::processConfig(
     {
         try
         {
-            if (write_logs)
-                LOG_DEBUG(log, "Merging configuration file '{}'.", merge_file);
+            LOG_DEBUG(log, "Merging configuration file '{}'.", merge_file);
 
             XMLDocumentPtr with;
             with = parseConfig(merge_file);

--- a/src/Common/Config/ConfigProcessor.h
+++ b/src/Common/Config/ConfigProcessor.h
@@ -121,7 +121,7 @@ public:
 
     static inline const auto SUBSTITUTION_ATTRS = {"incl", "from_zk", "from_env"};
 
-    bool is_config_changed;
+    bool is_config_changed = true;
 private:
     const std::string path;
     std::string preprocessed_path;

--- a/src/Common/Config/ConfigProcessor.h
+++ b/src/Common/Config/ConfigProcessor.h
@@ -121,6 +121,7 @@ public:
 
     static inline const auto SUBSTITUTION_ATTRS = {"incl", "from_zk", "from_env"};
 
+    bool is_config_changed;
 private:
     const std::string path;
     std::string preprocessed_path;

--- a/src/Common/Config/ConfigProcessor.h
+++ b/src/Common/Config/ConfigProcessor.h
@@ -121,7 +121,6 @@ public:
 
     static inline const auto SUBSTITUTION_ATTRS = {"incl", "from_zk", "from_env"};
 
-    bool is_config_changed = true;
 private:
     const std::string path;
     std::string preprocessed_path;

--- a/src/Common/Config/ConfigProcessor.h
+++ b/src/Common/Config/ConfigProcessor.h
@@ -123,7 +123,6 @@ public:
 
     static inline const auto SUBSTITUTION_ATTRS = {"incl", "from_zk", "from_env"};
 
-    bool is_config_changed = true;
 private:
     const std::string path;
     std::string preprocessed_path;

--- a/src/Common/Config/ConfigProcessor.h
+++ b/src/Common/Config/ConfigProcessor.h
@@ -121,6 +121,7 @@ public:
 
     static inline const auto SUBSTITUTION_ATTRS = {"incl", "from_zk", "from_env"};
 
+    bool is_config_changed = true;
 private:
     const std::string path;
     std::string preprocessed_path;

--- a/src/Common/Config/ConfigProcessor.h
+++ b/src/Common/Config/ConfigProcessor.h
@@ -63,7 +63,8 @@ public:
     XMLDocumentPtr processConfig(
         bool * has_zk_includes = nullptr,
         zkutil::ZooKeeperNodeCache * zk_node_cache = nullptr,
-        const zkutil::EventPtr & zk_changed_event = nullptr);
+        const zkutil::EventPtr & zk_changed_event = nullptr,
+        bool is_config_changed = true);
 
     XMLDocumentPtr parseConfig(const std::string & config_path);
 
@@ -88,14 +89,15 @@ public:
     /// If allow_zk_includes is true, expect that the configuration XML can contain from_zk nodes.
     /// If it is the case, set has_zk_includes to true and don't write config-preprocessed.xml,
     /// expecting that config would be reloaded with zookeeper later.
-    LoadedConfig loadConfig(bool allow_zk_includes = false);
+    LoadedConfig loadConfig(bool allow_zk_includes = false, bool is_config_changed = true);
 
     /// If fallback_to_preprocessed is true, then if KeeperException is thrown during config
     /// processing, load the configuration from the preprocessed file.
     LoadedConfig loadConfigWithZooKeeperIncludes(
         zkutil::ZooKeeperNodeCache & zk_node_cache,
         const zkutil::EventPtr & zk_changed_event,
-        bool fallback_to_preprocessed = false);
+        bool fallback_to_preprocessed = false,
+        bool is_config_changed = true);
 
     /// Save preprocessed config to specified directory.
     /// If preprocessed_dir is empty - calculate from loaded_config.path + /preprocessed_configs/

--- a/src/Common/Config/ConfigReloader.cpp
+++ b/src/Common/Config/ConfigReloader.cpp
@@ -111,7 +111,8 @@ std::optional<ConfigProcessor::LoadedConfig> ConfigReloader::reloadIfNewer(bool 
     std::lock_guard lock(reload_mutex);
 
     FilesChangesTracker new_files = getNewFileList();
-    if (force || need_reload_from_zk || new_files.isDifferOrNewerThan(files))
+    const bool is_config_changed = new_files.isDifferOrNewerThan(files);
+    if (force || need_reload_from_zk || is_config_changed)
     {
         ConfigProcessor config_processor(config_path);
         ConfigProcessor::LoadedConfig loaded_config;
@@ -122,10 +123,10 @@ std::optional<ConfigProcessor::LoadedConfig> ConfigReloader::reloadIfNewer(bool 
 
         try
         {
-            loaded_config = config_processor.loadConfig(/* allow_zk_includes = */ true);
+            loaded_config = config_processor.loadConfig(/* allow_zk_includes = */ true, is_config_changed);
             if (loaded_config.has_zk_includes)
                 loaded_config = config_processor.loadConfigWithZooKeeperIncludes(
-                    zk_node_cache, zk_changed_event, fallback_to_preprocessed);
+                    zk_node_cache, zk_changed_event, fallback_to_preprocessed, is_config_changed);
         }
         catch (const Coordination::Exception & e)
         {

--- a/src/Common/Config/ConfigReloader.cpp
+++ b/src/Common/Config/ConfigReloader.cpp
@@ -117,8 +117,6 @@ std::optional<ConfigProcessor::LoadedConfig> ConfigReloader::reloadIfNewer(bool 
         ConfigProcessor config_processor(config_path);
         ConfigProcessor::LoadedConfig loaded_config;
 
-        config_processor.is_config_changed = new_files.isDifferOrNewerThan(files);
-
         LOG_DEBUG(log, "Loading config '{}'", config_path);
 
         try

--- a/src/Common/Config/ConfigReloader.cpp
+++ b/src/Common/Config/ConfigReloader.cpp
@@ -116,37 +116,40 @@ std::optional<ConfigProcessor::LoadedConfig> ConfigReloader::reloadIfNewer(bool 
         ConfigProcessor config_processor(config_path);
         ConfigProcessor::LoadedConfig loaded_config;
 
-        config_processor.is_config_changed = new_files.isDifferOrNewerThan(files);
-
-        LOG_DEBUG(log, "Loading config '{}'", config_path);
-
-        try
+        if (new_files.isDifferOrNewerThan(files))
         {
-            loaded_config = config_processor.loadConfig(/* allow_zk_includes = */ true);
-            if (loaded_config.has_zk_includes)
-                loaded_config = config_processor.loadConfigWithZooKeeperIncludes(
-                    zk_node_cache, zk_changed_event, fallback_to_preprocessed);
-        }
-        catch (const Coordination::Exception & e)
-        {
-            if (Coordination::isHardwareError(e.code))
-                need_reload_from_zk = true;
+            LOG_DEBUG(log, "Loading config '{}'", config_path);
 
-            if (throw_on_error)
-                throw;
+            try
+            {
+                loaded_config = config_processor.loadConfig(/* allow_zk_includes = */ true);
+                if (loaded_config.has_zk_includes)
+                    loaded_config = config_processor.loadConfigWithZooKeeperIncludes(
+                        zk_node_cache, zk_changed_event, fallback_to_preprocessed);
+            }
+            catch (const Coordination::Exception & e)
+            {
+                if (Coordination::isHardwareError(e.code))
+                    need_reload_from_zk = true;
 
-            tryLogCurrentException(log, "ZooKeeper error when loading config from '" + config_path + "'");
-            return std::nullopt;
-        }
-        catch (...)
-        {
-            if (throw_on_error)
-                throw;
+                if (throw_on_error)
+                    throw;
 
-            tryLogCurrentException(log, "Error loading config from '" + config_path + "'");
-            return std::nullopt;
+                tryLogCurrentException(log, "ZooKeeper error when loading config from '" + config_path + "'");
+                return std::nullopt;
+            }
+            catch (...)
+            {
+                if (throw_on_error)
+                    throw;
+
+                tryLogCurrentException(log, "Error loading config from '" + config_path + "'");
+                return std::nullopt;
+            }
+            config_processor.savePreprocessedConfig(loaded_config, preprocessed_dir);
         }
-        config_processor.savePreprocessedConfig(loaded_config, preprocessed_dir);
+        else
+            LOG_DEBUG(log, "Skipped config loading '{}', as it wasn't changed", config_path);
 
         /** We should remember last modification time if and only if config was successfully loaded
          * Otherwise a race condition could occur during config files update:

--- a/src/Common/Config/ConfigReloader.cpp
+++ b/src/Common/Config/ConfigReloader.cpp
@@ -116,6 +116,8 @@ std::optional<ConfigProcessor::LoadedConfig> ConfigReloader::reloadIfNewer(bool 
         ConfigProcessor config_processor(config_path);
         ConfigProcessor::LoadedConfig loaded_config;
 
+        config_processor.is_config_changed = new_files.isDifferOrNewerThan(files);
+
         LOG_DEBUG(log, "Loading config '{}'", config_path);
 
         try


### PR DESCRIPTION
Closes https://github.com/ClickHouse/ClickHouse/issues/70746

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---ci_include_fuzzer--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
