### PR TITLE
Improve logging in minio tests

### DIFF
--- a/tests/integration/compose/docker_compose_minio.yml
+++ b/tests/integration/compose/docker_compose_minio.yml
@@ -39,6 +39,10 @@ services:
     depends_on:
       - proxy1
       - proxy2
+    volumes:
+      - type: ${RESOLVER_LOGS_FS:-tmpfs}
+        source: ${RESOLVER_LOGS:-}
+        target: /var/log/resolver
 
 volumes:
   data1-1:

--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -3000,6 +3000,7 @@ class ClickHouseCluster:
                 os.mkdir(self.minio_dir)
                 if self.minio_certs_dir is None:
                     os.mkdir(os.path.join(self.minio_dir, "certs"))
+                    os.mkdir(os.path.join(self.minio_dir, "certs", "CAs"))
                 else:
                     shutil.copytree(
                         os.path.join(self.base_dir, self.minio_certs_dir),

--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -563,6 +563,7 @@ class ClickHouseCluster:
         self.minio_redirect_ip = None
         self.minio_redirect_port = 8080
         self.minio_docker_id = self.get_instance_docker_id(self.minio_host)
+        self.resolver_logs_dir = os.path.join(self.instances_dir, "resolver")
 
         self.spark_session = None
 
@@ -1445,6 +1446,8 @@ class ClickHouseCluster:
         env_variables["MINIO_DATA_DIR"] = self.minio_data_dir
         env_variables["MINIO_PORT"] = str(self.minio_port)
         env_variables["SSL_CERT_FILE"] = p.join(self.base_dir, cert_d, "public.crt")
+        env_variables["RESOLVER_LOGS"] = self.resolver_logs_dir
+        env_variables["RESOLVER_LOGS_FS"] = "bind"
 
         self.base_cmd.extend(
             ["--file", p.join(docker_compose_yml_dir, "docker_compose_minio.yml")]
@@ -3004,6 +3007,9 @@ class ClickHouseCluster:
                     )
                 os.mkdir(self.minio_data_dir)
                 os.chmod(self.minio_data_dir, stat.S_IRWXU | stat.S_IRWXO)
+
+                os.makedirs(self.resolver_logs_dir)
+                os.chmod(self.resolver_logs_dir, stat.S_IRWXU | stat.S_IRWXO)
 
                 minio_start_cmd = self.base_minio_cmd + common_opts
 

--- a/tests/integration/helpers/mock_servers.py
+++ b/tests/integration/helpers/mock_servers.py
@@ -31,9 +31,23 @@ def start_mock_servers(cluster, script_dir, mocks, timeout=100):
             server_name,
         )
 
+        logs_dir = (
+            "/var/log/resolver"
+            if container == "resolver"
+            else "/var/log/clickhouse-server"
+        )
+        log_file = os.path.join(logs_dir, os.path.splitext(server_name)[0] + ".log")
+        err_log_file = os.path.join(
+            logs_dir, os.path.splitext(server_name)[0] + ".err.log"
+        )
+
         cluster.exec_in_container(
             container_id,
-            ["python3", server_name, str(port)],
+            [
+                "bash",
+                "-c",
+                f"python3 {server_name} {port} >{log_file} 2>{err_log_file}",
+            ],
             detach=True,
         )
 

--- a/tests/integration/test_merge_tree_s3/s3_mocks/no_delete_objects.py
+++ b/tests/integration/test_merge_tree_s3/s3_mocks/no_delete_objects.py
@@ -80,7 +80,6 @@ class RequestHandler(http.server.BaseHTTPRequestHandler):
             self.send_header(k, v)
         self.end_headers()
         self.wfile.write(r.content)
-        self.wfile.close()
 
 
 class ThreadedHTTPServer(socketserver.ThreadingMixIn, http.server.HTTPServer):

--- a/tests/integration/test_merge_tree_s3/s3_mocks/unstable_proxy.py
+++ b/tests/integration/test_merge_tree_s3/s3_mocks/unstable_proxy.py
@@ -70,7 +70,6 @@ class RequestHandler(http.server.BaseHTTPRequestHandler):
         if random.random() < 0.25 and len(r.content) > 1024 * 1024:
             r.content = r.content[: len(r.content) // 2]
         self.wfile.write(r.content)
-        self.wfile.close()
 
 
 class ThreadedHTTPServer(socketserver.ThreadingMixIn, http.server.HTTPServer):

--- a/tests/integration/test_storage_s3/s3_mocks/no_list_objects.py
+++ b/tests/integration/test_storage_s3/s3_mocks/no_list_objects.py
@@ -110,7 +110,6 @@ class RequestHandler(http.server.BaseHTTPRequestHandler):
             self.send_header(k, v)
         self.end_headers()
         self.wfile.write(r.content)
-        self.wfile.close()
 
 
 class ThreadedHTTPServer(socketserver.ThreadingMixIn, http.server.HTTPServer):


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add logging for mock HTTP servers used in minio integration tests.

Follow-up to https://github.com/ClickHouse/ClickHouse/pull/70786
