### PR TITLE
Fix `test_keeper_broken_logs`

### DIFF
--- a/tests/integration/test_keeper_broken_logs/test.py
+++ b/tests/integration/test_keeper_broken_logs/test.py
@@ -5,6 +5,8 @@ import pytest
 import helpers.keeper_utils as keeper_utils
 from helpers.cluster import ClickHouseCluster
 
+from multiprocessing.dummy import Pool
+
 cluster = ClickHouseCluster(__file__)
 node1 = cluster.add_instance(
     "node1",
@@ -52,14 +54,33 @@ def get_fake_zk(nodename, timeout=30.0):
     return _fake_zk_instance
 
 
+def start_clickhouse(node):
+    node.start_clickhouse()
+
+
+def clean_start():
+    nodes = [node1, node2, node3]
+    for node in nodes:
+        node.stop_clickhouse()
+
+    p = Pool(3)
+    waiters = []
+    for node in nodes:
+        node.exec_in_container(["rm", "-rf", "/var/lib/clickhouse/coordination/log"])
+        node.exec_in_container(
+            ["rm", "-rf", "/var/lib/clickhouse/coordination/snapshots"]
+        )
+        waiters.append(p.apply_async(start_clickhouse, (node,)))
+
+    for waiter in waiters:
+        waiter.wait()
+
+
 def test_single_node_broken_log(started_cluster):
+    clean_start()
     try:
         wait_nodes()
         node1_conn = get_fake_zk("node1")
-
-        # Cleanup
-        if node1_conn.exists("/test_broken_log") != None:
-            node1_conn.delete("/test_broken_log")
 
         node1_conn.create("/test_broken_log")
         for _ in range(10):
@@ -110,10 +131,12 @@ def test_single_node_broken_log(started_cluster):
         verify_nodes(node3_conn)
         assert node3_conn.get("/test_broken_log_final_node")[0] == b"somedata1"
 
-        assert (
+        node1_logs = (
             node1.exec_in_container(["ls", "/var/lib/clickhouse/coordination/log"])
-            == "changelog_1_100000.bin\nchangelog_14_100013.bin\n"
+            .strip()
+            .split("\n")
         )
+        assert len(node1_logs) == 2 and node1_logs[0] == "changelog_1_100000.bin"
         assert (
             node2.exec_in_container(["ls", "/var/lib/clickhouse/coordination/log"])
             == "changelog_1_100000.bin\n"

--- a/tests/integration/test_keeper_broken_logs/test.py
+++ b/tests/integration/test_keeper_broken_logs/test.py
@@ -1,11 +1,10 @@
 import time
+from multiprocessing.dummy import Pool
 
 import pytest
 
 import helpers.keeper_utils as keeper_utils
 from helpers.cluster import ClickHouseCluster
-
-from multiprocessing.dummy import Pool
 
 cluster = ClickHouseCluster(__file__)
 node1 = cluster.add_instance(


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Close https://github.com/ClickHouse/ClickHouse/issues/56953

It failed because Keeper got connection from somewhere after the client was closed. Not sure why it started happening (ClickHouse connections are disabled).
Luckily the test doesn't care about the exact log files so we can just check count.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---ci_include_fuzzer--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
