### PR TITLE
Fix showing error message in ReadBufferFromS3 when retrying

### DIFF
--- a/src/IO/ReadBufferFromS3.cpp
+++ b/src/IO/ReadBufferFromS3.cpp
@@ -138,9 +138,9 @@ bool ReadBufferFromS3::nextImpl()
             next_result = impl->next();
             break;
         }
-        catch (Poco::Exception & e)
+        catch (...)
         {
-            if (!processException(e, getPosition(), attempt) || last_attempt)
+            if (!processException(getPosition(), attempt) || last_attempt)
                 throw;
 
             /// Pause before next attempt.
@@ -202,9 +202,9 @@ size_t ReadBufferFromS3::readBigAt(char * to, size_t n, size_t range_begin, cons
             /// Read remaining bytes after the end of the payload
             istr.ignore(INT64_MAX);
         }
-        catch (Poco::Exception & e)
+        catch (...)
         {
-            if (!processException(e, range_begin, attempt) || last_attempt)
+            if (!processException(range_begin, attempt) || last_attempt)
                 throw;
 
             sleepForMilliseconds(sleep_time_with_backoff_milliseconds);
@@ -219,7 +219,7 @@ size_t ReadBufferFromS3::readBigAt(char * to, size_t n, size_t range_begin, cons
     return initial_n;
 }
 
-bool ReadBufferFromS3::processException(Poco::Exception & e, size_t read_offset, size_t attempt) const
+bool ReadBufferFromS3::processException(size_t read_offset, size_t attempt) const
 {
     ProfileEvents::increment(ProfileEvents::ReadBufferFromS3RequestsErrors, 1);
 
@@ -227,10 +227,11 @@ bool ReadBufferFromS3::processException(Poco::Exception & e, size_t read_offset,
         log,
         "Caught exception while reading S3 object. Bucket: {}, Key: {}, Version: {}, Offset: {}, "
         "Attempt: {}/{}, Message: {}",
-        bucket, key, version_id.empty() ? "Latest" : version_id, read_offset, attempt, request_settings.max_single_read_retries, e.message());
+        bucket, key, version_id.empty() ? "Latest" : version_id, read_offset, attempt, request_settings.max_single_read_retries,
+        getCurrentExceptionMessage(/* with_stacktrace = */ false));
 
 
-    if (auto * s3_exception = dynamic_cast<S3Exception *>(&e))
+    if (auto * s3_exception = exception_cast<S3Exception *>(std::current_exception()))
     {
         /// It doesn't make sense to retry Access Denied or No Such Key
         if (!s3_exception->isRetryableError())
@@ -241,7 +242,7 @@ bool ReadBufferFromS3::processException(Poco::Exception & e, size_t read_offset,
     }
 
     /// It doesn't make sense to retry allocator errors
-    if (e.code() == ErrorCodes::CANNOT_ALLOCATE_MEMORY)
+    if (getCurrentExceptionCode() == ErrorCodes::CANNOT_ALLOCATE_MEMORY)
     {
         tryLogCurrentException(log);
         return false;

--- a/src/IO/ReadBufferFromS3.h
+++ b/src/IO/ReadBufferFromS3.h
@@ -86,7 +86,7 @@ private:
 
     /// Call inside catch() block if GetObject fails. Bumps metrics, logs the error.
     /// Returns true if the error looks retriable.
-    bool processException(Poco::Exception & e, size_t read_offset, size_t attempt) const;
+    bool processException(size_t read_offset, size_t attempt) const;
 
     Aws::S3::Model::GetObjectResult sendRequest(size_t attempt, size_t range_begin, std::optional<size_t> range_end_incl) const;
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix showing error message in ReadBufferFromS3 when retrying. Without this PR information about a retryable failure in `ReadBufferFromS3` could look like this:

```
2024.10.12 06:12:28.171694 [ 123 ] {9f5419b1-1062-4d48-91e5-dc8a2043e1a1} <Debug> ReadBufferFromS3: Caught exception while reading S3 object. Bucket: mybucket, Key: mergetree/aaa/bbbbbbbbbbbbbbbbbbbbbbbbbbbbb, Version: Latest, Offset: 0, Attempt: 1/4, Message:
```

So this PR fixes the empty error message.