### PR TITLE
Sync changes to `ProtocolServerAdapter`

### DIFF
--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -2999,7 +2999,7 @@ void Server::updateServers(
 
     for (auto * server : all_servers)
     {
-        if (!server->isStopping())
+        if (server->supportsRuntimeReconfiguration() && !server->isStopping())
         {
             std::string port_name = server->getPortName();
             bool has_host = false;

--- a/src/Server/ProtocolServerAdapter.cpp
+++ b/src/Server/ProtocolServerAdapter.cpp
@@ -30,11 +30,13 @@ ProtocolServerAdapter::ProtocolServerAdapter(
     const std::string & listen_host_,
     const char * port_name_,
     const std::string & description_,
-    std::unique_ptr<TCPServer> tcp_server_)
+    std::unique_ptr<TCPServer> tcp_server_,
+    bool supports_runtime_reconfiguration_)
     : listen_host(listen_host_)
     , port_name(port_name_)
     , description(description_)
     , impl(std::make_unique<TCPServerAdapterImpl>(std::move(tcp_server_)))
+    , supports_runtime_reconfiguration(supports_runtime_reconfiguration_)
 {
 }
 
@@ -66,11 +68,13 @@ ProtocolServerAdapter::ProtocolServerAdapter(
     const std::string & listen_host_,
     const char * port_name_,
     const std::string & description_,
-    std::unique_ptr<GRPCServer> grpc_server_)
+    std::unique_ptr<GRPCServer> grpc_server_,
+    bool supports_runtime_reconfiguration_)
     : listen_host(listen_host_)
     , port_name(port_name_)
     , description(description_)
     , impl(std::make_unique<GRPCServerAdapterImpl>(std::move(grpc_server_)))
+    , supports_runtime_reconfiguration(supports_runtime_reconfiguration_)
 {
 }
 #endif

--- a/src/Server/ProtocolServerAdapter.h
+++ b/src/Server/ProtocolServerAdapter.h
@@ -21,10 +21,20 @@ class ProtocolServerAdapter
 public:
     ProtocolServerAdapter(ProtocolServerAdapter && src) = default;
     ProtocolServerAdapter & operator =(ProtocolServerAdapter && src) = default;
-    ProtocolServerAdapter(const std::string & listen_host_, const char * port_name_, const std::string & description_, std::unique_ptr<TCPServer> tcp_server_);
+    ProtocolServerAdapter(
+        const std::string & listen_host_,
+        const char * port_name_,
+        const std::string & description_,
+        std::unique_ptr<TCPServer> tcp_server_,
+        bool supports_runtime_reconfiguration_ = true);
 
 #if USE_GRPC
-    ProtocolServerAdapter(const std::string & listen_host_, const char * port_name_, const std::string & description_, std::unique_ptr<GRPCServer> grpc_server_);
+    ProtocolServerAdapter(
+        const std::string & listen_host_,
+        const char * port_name_,
+        const std::string & description_,
+        std::unique_ptr<GRPCServer> grpc_server_,
+        bool supports_runtime_reconfiguration_ = true);
 #endif
 
     /// Starts the server. A new thread will be created that waits for and accepts incoming connections.
@@ -45,6 +55,8 @@ public:
 
     /// Returns the port this server is listening to.
     UInt16 portNumber() const { return impl->portNumber(); }
+
+    bool supportsRuntimeReconfiguration() const { return supports_runtime_reconfiguration; }
 
     const std::string & getListenHost() const { return listen_host; }
 
@@ -72,6 +84,7 @@ private:
     std::string port_name;
     std::string description;
     std::unique_ptr<Impl> impl;
+    bool supports_runtime_reconfiguration = true;
 };
 
 }


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---ci_include_fuzzer--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
