### PR TITLE
Add retry policy to Remote Query Executor to be able to retry failed leaf queries.

### DIFF
--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -181,6 +181,7 @@
     M(DistributedConnectionStaleReplica, "Number of times we rejected a replica from a distributed query, because some table needed for a query had replication lag higher than the configured threshold.", ValueType::Number) \
     M(DistributedConnectionSkipReadOnlyReplica, "Number of replicas skipped during INSERT into Distributed table due to replicas being read-only", ValueType::Number) \
     M(DistributedConnectionFailAtAll, "Total count when distributed connection fails after all retries finished.", ValueType::Number) \
+    M(DistributedShardTryCount, "Number of attempts used to perform the distributed query.", ValueType::Number) \
     \
     M(HedgedRequestsChangeReplica, "Total count when timeout for changing replica expired in hedged requests.", ValueType::Number) \
     M(SuspendSendingQueryToShard, "Total count when sending query to shard was suspended when async_query_sending_for_remote is enabled.", ValueType::Number) \

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -1027,6 +1027,12 @@ Possible values:
 - 1 — `SELECT` will be executed on each shard from the underlying table of the distributed engine.
 - 2 — `SELECT` and `INSERT` will be executed on each shard from/to the underlying table of the distributed engine.
 )", 0) \
+    DECLARE(UInt64, distributed_shard_retry_count, 0, R"(
+For distributed queries, configures how many times the root executor will retry leaf executors in a shard when receiving 'too many simultaneous queries' errors
+)", 0) \
+    DECLARE(String, distributed_shard_retry_error_codes, "", R"(
+A list of error codes that trigger a retry when encountered during distributed query execution
+)", 0) \
     DECLARE(UInt64, distributed_group_by_no_merge, 0, R"(
 Do not merge aggregation states from different servers for distributed query processing, you can use this in case it is for certain that there are different keys on different shards
 

--- a/tests/integration/test_distributed_shard_retries/configs/concurrency_limits.xml
+++ b/tests/integration/test_distributed_shard_retries/configs/concurrency_limits.xml
@@ -1,0 +1,4 @@
+<!-- set a low concurrency limit for predictable concurrency errors -->
+<clickhouse>
+	<max_concurrent_queries>1</max_concurrent_queries>
+</clickhouse>

--- a/tests/integration/test_distributed_shard_retries/configs/remote_servers.xml
+++ b/tests/integration/test_distributed_shard_retries/configs/remote_servers.xml
@@ -1,0 +1,21 @@
+<clickhouse>
+    <logger>
+        <level>trace</level>
+    </logger>
+    <remote_servers>
+        <test_cluster>
+            <shard>
+                <replica>
+                    <host>node1</host>
+                    <port>9000</port>
+                </replica>
+            </shard>
+            <shard>
+                <replica>
+                    <host>node2</host>
+                    <port>9000</port>
+                </replica>
+            </shard>
+        </test_cluster>
+    </remote_servers>
+</clickhouse>

--- a/tests/integration/test_distributed_shard_retries/configs/shard_retry_config.xml
+++ b/tests/integration/test_distributed_shard_retries/configs/shard_retry_config.xml
@@ -1,0 +1,8 @@
+<clickhouse>
+    <profiles>
+        <default>
+            <distributed_shard_retry_count>5</distributed_shard_retry_count>
+            <distributed_shard_retry_error_codes>202,210</distributed_shard_retry_error_codes>
+        </default>
+    </profiles>
+</clickhouse>

--- a/tests/integration/test_distributed_shard_retries/test.py
+++ b/tests/integration/test_distributed_shard_retries/test.py
@@ -1,0 +1,104 @@
+import concurrent.futures
+from threading import Event, Thread
+
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+
+MAX_THREADS = 10
+
+cluster = ClickHouseCluster(__file__)
+node1 = cluster.add_instance(
+    "node1",
+    main_configs=["configs/remote_servers.xml"],
+    user_configs=["configs/shard_retry_config.xml"],
+)
+node2 = cluster.add_instance(
+    "node2",
+    main_configs=["configs/remote_servers.xml", "configs/concurrency_limits.xml"],
+)
+
+
+def prepare_cluster():
+    for idx, node in enumerate([node1, node2]):
+        node.query("DROP TABLE IF EXISTS local_table")
+        node.query("DROP TABLE IF EXISTS distributed_table")
+        node.query(
+            """
+            CREATE TABLE local_table(i Int64, d DateTime) ENGINE=MergeTree PARTITION BY toYYYYMMDD(d) ORDER BY d
+            """
+        )
+        node.query(
+            """CREATE TABLE distributed_table(i Int64) ENGINE = Distributed(test_cluster, default, local_table, Rand());"""
+        )
+        # Generate some sample data so sleepEachRow in do_slow_select works
+        node.query("INSERT INTO local_table VALUES ({},)".format(idx + 1))
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+        yield cluster
+
+    finally:
+        cluster.shutdown()
+
+
+def test_leaf_queries_retried(started_cluster):
+
+    prepare_cluster()
+    stop_event = Event()
+
+    def _do_slow_select():
+        while not stop_event.isSet():
+            node1.query("SELECT i, sleepEachRow(3) from local_table")
+
+    def _distributed_query():
+        return node1.query("SELECT max(i), sleep(3) FROM distributed_table")
+
+    slow_thread = Thread(target=_do_slow_select)
+    slow_thread.start()
+
+    futures = []
+    errors = []
+    results = []
+    with concurrent.futures.ThreadPoolExecutor(max_workers=MAX_THREADS) as executor:
+        for _ in range(MAX_THREADS):
+            futures.append(executor.submit(_distributed_query))
+
+        for f in futures:
+            try:
+                results.append(f.result())
+            except Exception as err:
+                errors.append(str(err))
+
+    stop_event.set()
+    slow_thread.join()
+
+    concurrency_errors = sum(
+        1 for err in errors if "TOO_MANY_SIMULTANEOUS_QUERIES" in err
+    )
+    other_errors = [err for err in errors if "TOO_MANY_SIMULTANEOUS_QUERIES" not in err]
+
+    assert len(other_errors) == 0, f"Got unexpected query errors: {other_errors}"
+    assert (
+        concurrency_errors == 0
+    ), f"Should be no 'TOO_MANY_SIMULTANEOUS_QUERIES'. Got {errors}"
+
+    assert node1.contains_in_log(
+        "StorageDistributed (distributed_table): try 1 of 6 failed due to error code 202"
+    )
+    assert len(results) > 0
+
+    assert results[0] == "2\t0\n"
+
+    node1.query("SYSTEM FLUSH LOGS")
+    assert (
+        int(
+            node1.query(
+                "SELECT max(ProfileEvents['DistributedTryCount']) FROM system.query_log"
+            )
+        )
+        > 1
+    )


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add retry policy to Remote Query Executor to be able to retry failed leaf queries.

In large clusters it's often wasteful to discard results of a distributed query if only one of the leaf queries failed.
This change allows Remote Query Executor to retry when encountering certain error codes from remote replica.

Configured by `distributed_shard_retry_count` and `distributed_shard_retry_error_codes`.

