### PR TITLE
Fix clickhouse-test useless 5 second delay in case of multiple threads are used

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -2684,8 +2684,6 @@ def do_run_tests(jobs, test_suite: TestSuite):
                 if not p.is_alive():
                     processes.remove(p)
 
-            sleep(5)
-
         run_tests_array(
             (
                 test_suite.sequential_tests,


### PR DESCRIPTION
Fixes: #66411 (cc @fm4v )

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)