### PR TITLE
Add support for query parameters for the gRPC interface

### DIFF
--- a/docs/en/interfaces/grpc.md
+++ b/docs/en/interfaces/grpc.md
@@ -14,12 +14,21 @@ ClickHouse supports [gRPC](https://grpc.io/) interface. It is an open source rem
 - authentication;
 - sessions;
 - compression;
+- query parameters;
 - parallel queries through the same channel;
 - cancellation of queries;
 - getting progress and logs;
 - external tables.
 
 The specification of the interface is described in [clickhouse_grpc.proto](https://github.com/ClickHouse/ClickHouse/blob/master/src/Server/grpc_protos/clickhouse_grpc.proto).
+
+Query parameters can be set in the Metadata fields of the Client Context, with `param_` prefix for the key, for example:
+```py
+[
+    ("param_table", "my_table"),
+    ("param_column", "my_column"),
+]
+```
 
 ## gRPC Configuration {#grpc-interface-configuration}
 
@@ -72,6 +81,7 @@ The client supports the following arguments:
 - `--query QUERY, -q QUERY` – A query to process when using non-interactive mode.
 - `--database DATABASE, -d DATABASE` – A default database. If not specified, the current database set in the server settings is used (`default` by default).
 - `--format OUTPUT_FORMAT, -f OUTPUT_FORMAT` – A result output [format](formats.md). Default value for interactive mode: `PrettyCompact`.
+- `--param PARAM` – Query parameters in `key=value` format. Can be used multiple times.
 - `--debug` – Enables showing debug information.
 
 To run the client in an interactive mode call it without `--query` argument.

--- a/src/Server/GRPCServer.cpp
+++ b/src/Server/GRPCServer.cpp
@@ -369,6 +369,11 @@ namespace
             return std::nullopt;
         }
 
+        const std::multimap<::grpc::string_ref, ::grpc::string_ref> & getClientHeaders() const
+        {
+            return grpc_context.client_metadata();
+        }
+
         void setTransportCompression(const TransportCompression & transport_compression)
         {
             grpc_context.set_compression_algorithm(transport_compression.algorithm);
@@ -871,6 +876,16 @@ namespace
         }
 
         query_context = session->makeQueryContext(std::move(client_info));
+
+        /// Extract query params from gRPC client context.
+        for (const auto & [key, value] : responder->getClientHeaders())
+        {
+            if (key.starts_with("param_"))
+            {
+                query_context->setQueryParameter(
+                    String{key.data() + 6, key.size() - 6}, String{value.data(), value.size()});
+            }
+        }
 
         /// Prepare settings.
         SettingsChanges settings_changes;

--- a/tests/integration/test_grpc_protocol/test.py
+++ b/tests/integration/test_grpc_protocol/test.py
@@ -72,6 +72,7 @@ def query_common(
     session_id="",
     stream_output=False,
     channel=None,
+    query_params={},
 ):
     if type(input_data) is not list:
         input_data = [input_data]
@@ -110,15 +111,24 @@ def query_common(
                 input_data=input_data_part, next_query_info=bool(input_data)
             )
 
+    def metadata():
+        return [("param_" + param, value) for param, value in query_params.items()]
+
     stream_input = len(input_data) > 1
     if stream_input and stream_output:
-        return list(stub.ExecuteQueryWithStreamIO(send_query_info()))
+        return list(
+            stub.ExecuteQueryWithStreamIO(send_query_info(), metadata=metadata())
+        )
     elif stream_input:
-        return [stub.ExecuteQueryWithStreamInput(send_query_info())]
+        return [
+            stub.ExecuteQueryWithStreamInput(send_query_info(), metadata=metadata())
+        ]
     elif stream_output:
-        return list(stub.ExecuteQueryWithStreamOutput(query_info()))
+        return list(
+            stub.ExecuteQueryWithStreamOutput(query_info(), metadata=metadata())
+        )
     else:
-        return [stub.ExecuteQuery(query_info())]
+        return [stub.ExecuteQuery(query_info(), metadata=metadata())]
 
 
 def query_no_errors(*args, **kwargs):
@@ -271,6 +281,24 @@ def test_insert_splitted_row():
     query("CREATE TABLE t (a UInt8) ENGINE = Memory")
     query("INSERT INTO t VALUES", input_data=["(1),(2),(", "3),(5),(4),(6)"])
     assert query("SELECT a FROM t ORDER BY a") == "1\n2\n3\n4\n5\n6\n"
+
+
+def test_query_params():
+    query(
+        r"CREATE TABLE {table:Identifier} (a UInt8) ENGINE = Memory",
+        query_params={"table": "t"},
+    )
+    query(
+        r"INSERT INTO {table:Identifier} VALUES (1),(2),(3)",
+        query_params={"table": "t"},
+    )
+    assert (
+        query(
+            r"SELECT {column:Identifier} FROM {table:Identifier} ORDER BY {column:Identifier}",
+            query_params={"table": "t", "column": "a"},
+        )
+        == "1\n2\n3\n"
+    )
 
 
 def test_output_format():


### PR DESCRIPTION
### Changelog category (leave one):
- New Feature


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add query parameters support for the gRPC interface. They can be set in the Metadata fields of the Client Context with `"param_"` prefix for the key.


### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---ci_include_fuzzer--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
