### PR TITLE
Use `readFile` instead of direct `ReadBufferFromS3` when copying to S3

### DIFF
--- a/src/IO/S3/copyS3File.cpp
+++ b/src/IO/S3/copyS3File.cpp
@@ -915,6 +915,7 @@ void copyS3File(
 
     if (!settings[S3RequestSetting::allow_native_copy])
     {
+        LOG_TRACE(getLogger("copyS3File"), "Native copy is disable for {}", src_bucket);
         fallback_method();
         return;
     }

--- a/src/IO/S3/copyS3File.cpp
+++ b/src/IO/S3/copyS3File.cpp
@@ -891,7 +891,7 @@ void copyS3File(
     const ReadSettings & read_settings,
     BlobStorageLogWriterPtr blob_storage_log,
     ThreadPoolCallbackRunnerUnsafe<void> schedule,
-    const std::optional<CreateReadBuffer>& fallback_file_reader,
+    const CreateReadBuffer& fallback_file_reader,
     const std::optional<std::map<String, String>> & object_metadata)
 {
     if (!dest_s3_client)
@@ -899,14 +899,9 @@ void copyS3File(
 
     std::function<void()> fallback_method = [&] mutable
     {
-        auto create_read_buffer
-            = [&] mutable -> std::unique_ptr<SeekableReadBuffer> {
-                if (fallback_file_reader)
-                    return (*fallback_file_reader)();
-                return std::make_unique<ReadBufferFromS3>(src_s3_client, src_bucket, src_key, "", settings, read_settings); };
 
         copyDataToS3File(
-            create_read_buffer,
+            fallback_file_reader,
             src_offset,
             src_size,
             dest_s3_client,

--- a/src/IO/S3/copyS3File.cpp
+++ b/src/IO/S3/copyS3File.cpp
@@ -915,7 +915,7 @@ void copyS3File(
 
     if (!settings[S3RequestSetting::allow_native_copy])
     {
-        LOG_TRACE(getLogger("copyS3File"), "Native copy is disable for {}", src_bucket);
+        LOG_TRACE(getLogger("copyS3File"), "Native copy is disable for {}", src_key);
         fallback_method();
         return;
     }

--- a/src/IO/S3/copyS3File.h
+++ b/src/IO/S3/copyS3File.h
@@ -43,7 +43,7 @@ void copyS3File(
     const ReadSettings & read_settings,
     BlobStorageLogWriterPtr blob_storage_log,
     ThreadPoolCallbackRunnerUnsafe<void> schedule,
-    const std::optional<CreateReadBuffer>& fallback_file_reader = std::nullopt,
+    const CreateReadBuffer& fallback_file_reader,
     const std::optional<std::map<String, String>> & object_metadata = std::nullopt);
 
 /// Copies data from any seekable source to S3.

--- a/src/IO/S3/copyS3File.h
+++ b/src/IO/S3/copyS3File.h
@@ -42,9 +42,9 @@ void copyS3File(
     const S3::S3RequestSettings & settings,
     const ReadSettings & read_settings,
     BlobStorageLogWriterPtr blob_storage_log,
-    const std::optional<std::map<String, String>> & object_metadata = std::nullopt,
-    ThreadPoolCallbackRunnerUnsafe<void> schedule_ = {},
-    bool for_disk_s3 = false);
+    ThreadPoolCallbackRunnerUnsafe<void> schedule,
+    const std::optional<CreateReadBuffer>& fallback_file_reader = std::nullopt,
+    const std::optional<std::map<String, String>> & object_metadata = std::nullopt);
 
 /// Copies data from any seekable source to S3.
 /// The same functionality can be done by using the function copyData() and the class WriteBufferFromS3
@@ -60,9 +60,8 @@ void copyDataToS3File(
     const String & dest_key,
     const S3::S3RequestSettings & settings,
     BlobStorageLogWriterPtr blob_storage_log,
-    const std::optional<std::map<String, String>> & object_metadata = std::nullopt,
-    ThreadPoolCallbackRunnerUnsafe<void> schedule_ = {},
-    bool for_disk_s3 = false);
+    ThreadPoolCallbackRunnerUnsafe<void> schedule,
+    const std::optional<std::map<String, String>> & object_metadata = std::nullopt);
 
 }
 

--- a/tests/integration/test_backup_restore_s3/configs/throttling_disks.xml
+++ b/tests/integration/test_backup_restore_s3/configs/throttling_disks.xml
@@ -1,0 +1,36 @@
+<clickhouse>
+    <storage_configuration>
+       <disks>
+           <s3_native_copy>
+               <type>s3</type>
+               <endpoint>http://minio1:9001/root/data/disks/s3_native_copy</endpoint>
+                <access_key_id>minio</access_key_id>
+                <secret_access_key>minio123</secret_access_key>
+               <s3_allow_native_copy>true</s3_allow_native_copy>
+           </s3_native_copy>
+           <s3_no_native_copy>
+               <type>s3</type>
+               <endpoint>http://minio1:9001/root/data/disks/s3_no_native_copy</endpoint>
+                <access_key_id>minio</access_key_id>
+                <secret_access_key>minio123</secret_access_key>
+               <s3_allow_native_copy>false</s3_allow_native_copy>
+           </s3_no_native_copy>
+       </disks>
+        <policies>
+            <s3_native_copy>
+                <volumes>
+                    <main>
+                        <disk>s3_native_copy</disk>
+                    </main>
+                </volumes>
+            </s3_native_copy>
+            <s3_no_native_copy>
+                <volumes>
+                    <main>
+                        <disk>s3_no_native_copy</disk>
+                    </main>
+                </volumes>
+            </s3_no_native_copy>
+        </policies>
+   </storage_configuration>
+</clickhouse>

--- a/tests/integration/test_backup_restore_s3/test_throttling.py
+++ b/tests/integration/test_backup_restore_s3/test_throttling.py
@@ -1,0 +1,86 @@
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+from helpers.s3_tools import list_s3_objects
+from helpers.utility import random_string
+from minio.deleteobjects import DeleteObject
+
+cluster = ClickHouseCluster(__file__)
+node = cluster.add_instance(
+    "node",
+    main_configs=[
+        "configs/throttling_disks.xml",
+    ],
+    stay_alive=True,
+    with_minio=True,
+)
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+@pytest.mark.parametrize(
+    "storage_policy", ["default", "s3_native_copy", "s3_no_native_copy"]
+)
+@pytest.mark.parametrize("allow_s3_native_copy", [0, 1])
+def test_backup_scheduler_settings(
+    started_cluster, storage_policy, allow_s3_native_copy
+):
+
+    minio = cluster.minio_client
+    s3_objects = list_s3_objects(minio, cluster.minio_bucket, prefix="")
+    assert (
+        len(
+            list(
+                minio.remove_objects(
+                    cluster.minio_bucket,
+                    [DeleteObject(obj) for obj in s3_objects],
+                )
+            )
+        )
+        == 0
+    )
+
+    table_name = f"test_s3_storage_class_{storage_policy}_{allow_s3_native_copy}"
+
+    node.query(f"CREATE OR REPLACE RESOURCE network_read (READ DISK {storage_policy})")
+    node.query(f"CREATE OR REPLACE WORKLOAD backup SETTINGS max_requests = 10")
+
+    query_id = f"{storage_policy}_{allow_s3_native_copy}_{random_string(10)}"
+    node.query(
+        f"""
+            CREATE TABLE {table_name}
+            (
+                `id` UInt64,
+                `value` String
+            )
+            ENGINE = MergeTree
+            ORDER BY id
+            SETTINGS storage_policy='{storage_policy}';
+        """,
+    )
+
+    node.query(
+        f"""
+            INSERT INTO {table_name} VALUES (1, 'a');
+        """,
+    )
+
+    result = node.query(
+        f"""
+            BACKUP TABLE {table_name} TO S3('http://{cluster.minio_host}:{cluster.minio_port}/{cluster.minio_bucket}/data', 'minio', 'minio123')
+            SETTINGS s3_storage_class='STANDARD', allow_s3_native_copy={allow_s3_native_copy}, workload='backup';
+        """,
+        query_id=query_id,
+    )
+
+    lst = list(minio.list_objects(cluster.minio_bucket, "data/.backup"))
+    assert lst[0].storage_class == "STANDARD"
+
+    node.query(f"DROP TABLE {table_name} SYNC")

--- a/tests/integration/test_backup_restore_s3/test_throttling.py
+++ b/tests/integration/test_backup_restore_s3/test_throttling.py
@@ -1,9 +1,9 @@
 import pytest
+from minio.deleteobjects import DeleteObject
 
 from helpers.cluster import ClickHouseCluster
 from helpers.s3_tools import list_s3_objects
 from helpers.utility import random_string
-from minio.deleteobjects import DeleteObject
 
 cluster = ClickHouseCluster(__file__)
 node = cluster.add_instance(


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Respect IO scheduling settings when writing backups across clouds

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---ci_include_fuzzer--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
