### PR TITLE
Wait pool in ParallelFormattingOutputFormat::finalizeImpl

### DIFF
--- a/src/Processors/Formats/Impl/ParallelFormattingOutputFormat.cpp
+++ b/src/Processors/Formats/Impl/ParallelFormattingOutputFormat.cpp
@@ -50,6 +50,7 @@ namespace DB
             formatter->finalizeImpl();
 
         formatter->finalizeBuffers();
+        finishAndWait();
     }
 
     void ParallelFormattingOutputFormat::addChunk(Chunk chunk, ProcessingUnitType type, bool can_throw_exception)

--- a/src/Processors/Formats/Impl/ParallelFormattingOutputFormat.cpp
+++ b/src/Processors/Formats/Impl/ParallelFormattingOutputFormat.cpp
@@ -50,7 +50,7 @@ namespace DB
             formatter->finalizeImpl();
 
         formatter->finalizeBuffers();
-        finishAndWait();
+        finishAndWait(/* emergency_stop_ */ false);
     }
 
     void ParallelFormattingOutputFormat::addChunk(Chunk chunk, ProcessingUnitType type, bool can_throw_exception)
@@ -97,9 +97,9 @@ namespace DB
     }
 
 
-    void ParallelFormattingOutputFormat::finishAndWait() noexcept
+    void ParallelFormattingOutputFormat::finishAndWait(bool emergency_stop_) noexcept
     {
-        emergency_stop = true;
+        emergency_stop = emergency_stop_;
 
         {
             std::unique_lock<std::mutex> lock(mutex);

--- a/src/Processors/Formats/Impl/ParallelFormattingOutputFormat.cpp
+++ b/src/Processors/Formats/Impl/ParallelFormattingOutputFormat.cpp
@@ -99,7 +99,8 @@ namespace DB
 
     void ParallelFormattingOutputFormat::finishAndWait(bool emergency_stop_) noexcept
     {
-        emergency_stop = emergency_stop_;
+        if (emergency_stop_)
+            emergency_stop = true;
 
         {
             std::unique_lock<std::mutex> lock(mutex);

--- a/src/Processors/Formats/Impl/ParallelFormattingOutputFormat.h
+++ b/src/Processors/Formats/Impl/ParallelFormattingOutputFormat.h
@@ -127,7 +127,7 @@ public:
 
     void onCancel() noexcept override
     {
-        finishAndWait();
+        finishAndWait(/* emergency_stop_ */ true);
     }
 
     void onProgress(const Progress & value) override

--- a/src/Processors/Formats/Impl/ParallelFormattingOutputFormat.h
+++ b/src/Processors/Formats/Impl/ParallelFormattingOutputFormat.h
@@ -109,7 +109,7 @@ public:
 
     ~ParallelFormattingOutputFormat() override
     {
-        finishAndWait(/* emergency_stop_ */ true);
+        finishAndWait();
     }
 
     String getName() const override { return "ParallelFormattingOutputFormat"; }
@@ -127,7 +127,7 @@ public:
 
     void onCancel() noexcept override
     {
-        finishAndWait(/* emergency_stop_ */ true);
+        finishAndWait();
     }
 
     void onProgress(const Progress & value) override
@@ -247,7 +247,7 @@ private:
     std::deque<ProcessingUnit> processing_units;
 
     std::mutex mutex;
-    std::atomic_bool emergency_stop{false};
+    std::atomic_bool stop_flag{false};
 
     std::atomic_size_t collector_unit_number{0};
     std::atomic_size_t writer_unit_number{0};
@@ -271,7 +271,7 @@ private:
     bool collected_suffix = false;
     bool collected_finalize = false;
 
-    void finishAndWait(bool emergency_stop_) noexcept;
+    void finishAndWait() noexcept;
 
     void onBackgroundException()
     {

--- a/src/Processors/Formats/Impl/ParallelFormattingOutputFormat.h
+++ b/src/Processors/Formats/Impl/ParallelFormattingOutputFormat.h
@@ -109,7 +109,7 @@ public:
 
     ~ParallelFormattingOutputFormat() override
     {
-        finishAndWait();
+        finishAndWait(/* emergency_stop_ */ true);
     }
 
     String getName() const override { return "ParallelFormattingOutputFormat"; }
@@ -271,7 +271,7 @@ private:
     bool collected_suffix = false;
     bool collected_finalize = false;
 
-    void finishAndWait() noexcept;
+    void finishAndWait(bool emergency_stop_) noexcept;
 
     void onBackgroundException()
     {


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...


close #68791
