### PR TITLE
Fix 02932_refreshable_materialized_views_1 flakiness

### DIFF
--- a/tests/queries/0_stateless/02932_refreshable_materialized_views_1.reference
+++ b/tests/queries/0_stateless/02932_refreshable_materialized_views_1.reference
@@ -2,7 +2,6 @@
 CREATE MATERIALIZED VIEW default.a\nREFRESH EVERY 2 SECOND\n(\n    `x` UInt64\n)\nENGINE = Memory\nAS SELECT number AS x\nFROM numbers(2)\nUNION ALL\nSELECT rand64() AS x
 <2: refreshed>	3	1	1
 <3: time difference at least>	1000
-<4: next refresh in>	2	Scheduled
 <4.1: fake clock>	Scheduled	2050-01-01 00:00:01	2050-01-01 00:00:02	1	3	3	3	0
 <4.5: altered>	Scheduled	2050-01-01 00:00:01	2052-01-01 00:00:00
 CREATE MATERIALIZED VIEW default.a\nREFRESH EVERY 2 YEAR\n(\n    `x` UInt64\n)\nENGINE = Memory\nAS SELECT x * 2 AS x\nFROM default.src

--- a/tests/queries/0_stateless/02932_refreshable_materialized_views_1.sh
+++ b/tests/queries/0_stateless/02932_refreshable_materialized_views_1.sh
@@ -50,14 +50,6 @@ done
 # to make sure the clock+timer code works at all. If it turns out flaky, increase refresh period above.
 $CLICKHOUSE_CLIENT -q "
     select '<3: time difference at least>', min2(reinterpret(now64(), 'Int64') - $start_time, 1000);"
-while :
-do
-    # Wait for status to change to Scheduled. If status = Scheduling, next_refresh_time is stale.
-    res="`$CLICKHOUSE_CLIENT -q "select '<4: next refresh in>', next_refresh_time-last_success_time, status from refreshes -- $LINENO"`"
-    echo "$res" | grep -q 'Scheduled' && break
-    sleep 0.5
-done
-echo "$res"
 
 # Create a source table from which views will read.
 $CLICKHOUSE_CLIENT -q "


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

https://s3.amazonaws.com/clickhouse-test-reports/0/26f2c5b07b2cfbbe379ed0ac402bf9160e3a279c/stateless_tests__azure__asan__[3_3].html

Just removed the check that was flaky.

(The problem was that `last_success_time` is when the refresh actually started, which may be slightly different from the scheduled timeslot. E.g. if a refresh was scheduled for 00:00:00, but actually started at 00:00:01, the next refresh will be scheduled for 00:00:00 + period, but last_success_time will be 00:00:01, so next_refersh_time - last_success_time will be period-1.)