### PR TITLE
Query cache: Improve handling of system table names in literals

### DIFF
--- a/src/Interpreters/Cache/QueryCache.cpp
+++ b/src/Interpreters/Cache/QueryCache.cpp
@@ -112,7 +112,7 @@ struct HasSystemTablesMatcher
                     if (const auto * expression_list = function_children[0]->as<ASTExpressionList>())
                     {
                         const ASTs & expression_list_children = expression_list->children;
-                        if (!expression_list_children.empty())
+                        if (expression_list_children.size() >= 2)
                         {
                             if (const auto * literal = expression_list_children[1]->as<ASTLiteral>())
                             {

--- a/tests/queries/0_stateless/02494_query_cache_system_tables.sql
+++ b/tests/queries/0_stateless/02494_query_cache_system_tables.sql
@@ -44,9 +44,16 @@ SELECT * SETTINGS use_query_cache = 1;
 SELECT * FROM information_schema.tables SETTINGS use_query_cache = 1; -- { serverError QUERY_CACHE_USED_WITH_SYSTEM_TABLE }
 SELECT * FROM INFORMATION_SCHEMA.TABLES SETTINGS use_query_cache = 1; -- { serverError QUERY_CACHE_USED_WITH_SYSTEM_TABLE }
 
+-- Issue #69010: A system table name appears as a literal. That's okay and must not throw.
+DROP TABLE IF EXISTS tab;
+CREATE TABLE tab (uid Int16, name String) ENGINE = Memory;
+SELECT * FROM tab WHERE name = 'system.one' SETTINGS use_query_cache = true;
+DROP TABLE tab;
+
 -- System tables can be "hidden" inside e.g. table functions
 SELECT * FROM clusterAllReplicas('test_shard_localhost', system.one) SETTINGS use_query_cache = 1; -- {serverError QUERY_CACHE_USED_WITH_SYSTEM_TABLE }
 SELECT * FROM clusterAllReplicas('test_shard_localhost', 'system.one') SETTINGS use_query_cache = 1; -- {serverError QUERY_CACHE_USED_WITH_SYSTEM_TABLE }
+-- Note how in the previous query ^^ 'system.one' is also a literal. ClusterAllReplicas gets special handling.
 
 -- Criminal edge case that a user creates a table named "system". The query cache must not reject queries against it.
 DROP TABLE IF EXISTS system;
@@ -60,5 +67,4 @@ CREATE TABLE system.system (c UInt64) ENGINE = Memory;
 SElECT * FROM system.system SETTINGS use_query_cache = 1; -- { serverError QUERY_CACHE_USED_WITH_SYSTEM_TABLE }
 DROP TABLE system.system;
 
--- Cleanup
 SYSTEM DROP QUERY CACHE;


### PR DESCRIPTION
Resolves #69010

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
SELECT queries run with setting `use_query_cache = 1` are no longer rejected if the name of a system table appears as a literal, e.g. `SELECT * FROM users WHERE name = 'system.metrics' SETTINGS use_query_cache = true;` now works.