### PR TITLE
check-doc-aspell: Print full path to script in CI report

### DIFF
--- a/utils/check-style/check-doc-aspell
+++ b/utils/check-style/check-doc-aspell
@@ -53,7 +53,7 @@ done
 if (( STATUS != 0 )); then
     echo "====== Errors found ======"
     echo "To exclude some words add them to the dictionary file \"${ASPELL_IGNORE_PATH}/aspell-dict.txt\""
-    echo "You can also run ${0} -i to see the errors interactively and fix them or add to the dictionary file"
+    echo "You can also run '$(realpath --relative-base=${ROOT_PATH} ${0}) -i' to see the errors interactively and fix them or add to the dictionary file"
 fi
 
 exit ${STATUS}


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...