### PR TITLE
Fix unused variables around WorkloadEntityStorageBase

### DIFF
--- a/src/Common/Scheduler/Workload/WorkloadEntityStorageBase.cpp
+++ b/src/Common/Scheduler/Workload/WorkloadEntityStorageBase.cpp
@@ -48,9 +48,9 @@ ASTPtr normalizeCreateWorkloadEntityQuery(const IAST & create_query)
 /// Returns a type of a workload entity `ptr`
 WorkloadEntityType getEntityType(const ASTPtr & ptr)
 {
-    if (auto * res = typeid_cast<ASTCreateWorkloadQuery *>(ptr.get()))
+    if (auto * res = typeid_cast<ASTCreateWorkloadQuery *>(ptr.get()); res)
         return WorkloadEntityType::Workload;
-    if (auto * res = typeid_cast<ASTCreateResourceQuery *>(ptr.get()))
+    if (auto * res = typeid_cast<ASTCreateResourceQuery *>(ptr.get()); res)
         return WorkloadEntityType::Resource;
     chassert(false);
     return WorkloadEntityType::MAX;
@@ -106,7 +106,7 @@ void forEachReference(
         for (const String & resource : resources)
             func(resource, res->getWorkloadName(), ReferenceType::ForResource);
     }
-    if (auto * res = typeid_cast<ASTCreateResourceQuery *>(source_entity.get()))
+    if (auto * res = typeid_cast<ASTCreateResourceQuery *>(source_entity.get()); res)
     {
         // RESOURCE has no references to be validated, we allow mentioned disks to be created later
     }


### PR DESCRIPTION
Compiling ClickHouse locally on Mac results in the following errors: 
```
/Users/nikitamikhaylov/ClickHouse/ClickHouse/src/Common/Scheduler/Workload/WorkloadEntityStorageBase.cpp:51:16: error: variable 'res' set but not used [-Werror,-Wunused-but-set-variable]
   51 |     if (auto * res = typeid_cast<ASTCreateWorkloadQuery *>(ptr.get()))
      |                ^
/Users/nikitamikhaylov/ClickHouse/ClickHouse/src/Common/Scheduler/Workload/WorkloadEntityStorageBase.cpp:53:16: error: variable 'res' set but not used [-Werror,-Wunused-but-set-variable]
   53 |     if (auto * res = typeid_cast<ASTCreateResourceQuery *>(ptr.get()))
      |                ^
/Users/nikitamikhaylov/ClickHouse/ClickHouse/src/Common/Scheduler/Workload/WorkloadEntityStorageBase.cpp:109:16: error: variable 'res' set but not used [-Werror,-Wunused-but-set-variable]
  109 |     if (auto * res = typeid_cast<ASTCreateResourceQuery *>(source_entity.get()))
```

### Changelog category (leave one):

- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---ci_include_fuzzer--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
