### PR TITLE
Demote log level for failed authentication

### DIFF
--- a/src/Access/AccessControl.cpp
+++ b/src/Access/AccessControl.cpp
@@ -608,7 +608,7 @@ AuthResult AccessControl::authenticate(const Credentials & credentials, const Po
     }
     catch (...)
     {
-        tryLogCurrentException(getLogger(), "from: " + address.toString() + ", user: " + credentials.getUserName()  + ": Authentication failed", LogsLevel::debug);
+        tryLogCurrentException(getLogger(), "from: " + address.toString() + ", user: " + credentials.getUserName()  + ": Authentication failed", LogsLevel::information);
 
         WriteBufferFromOwnString message;
         message << credentials.getUserName() << ": Authentication failed: password is incorrect, or there is no user with such name.";

--- a/src/Access/AccessControl.cpp
+++ b/src/Access/AccessControl.cpp
@@ -608,7 +608,7 @@ AuthResult AccessControl::authenticate(const Credentials & credentials, const Po
     }
     catch (...)
     {
-        tryLogCurrentException(getLogger(), "from: " + address.toString() + ", user: " + credentials.getUserName()  + ": Authentication failed");
+        tryLogCurrentException(getLogger(), "from: " + address.toString() + ", user: " + credentials.getUserName()  + ": Authentication failed", LogsLevel::information);
 
         WriteBufferFromOwnString message;
         message << credentials.getUserName() << ": Authentication failed: password is incorrect, or there is no user with such name.";
@@ -622,8 +622,9 @@ AuthResult AccessControl::authenticate(const Credentials & credentials, const Po
                 << "and deleting this file will reset the password.\n"
                 << "See also /etc/clickhouse-server/users.xml on the server where ClickHouse is installed.\n\n";
 
-        /// We use the same message for all authentication failures because we don't want to give away any unnecessary information for security reasons,
-        /// only the log will show the exact reason.
+        /// We use the same message for all authentication failures because we don't want to give away any unnecessary information for security reasons.
+        /// Only the log ((*), above) will show the exact reason. Note that (*) logs at information level instead of the default error level as
+        /// authentication failures are not an unusual event.
         throw Exception(PreformattedMessage{message.str(),
                                             "{}: Authentication failed: password is incorrect, or there is no user with such name",
                                             std::vector<std::string>{credentials.getUserName()}},

--- a/src/Access/AccessControl.cpp
+++ b/src/Access/AccessControl.cpp
@@ -608,7 +608,7 @@ AuthResult AccessControl::authenticate(const Credentials & credentials, const Po
     }
     catch (...)
     {
-        tryLogCurrentException(getLogger(), "from: " + address.toString() + ", user: " + credentials.getUserName()  + ": Authentication failed", LogsLevel::information);
+        tryLogCurrentException(getLogger(), "from: " + address.toString() + ", user: " + credentials.getUserName()  + ": Authentication failed", LogsLevel::debug);
 
         WriteBufferFromOwnString message;
         message << credentials.getUserName() << ": Authentication failed: password is incorrect, or there is no user with such name.";

--- a/src/Common/Exception.cpp
+++ b/src/Common/Exception.cpp
@@ -251,7 +251,7 @@ void Exception::setThreadFramePointers(ThreadFramePointersBase frame_pointers)
         thread_frame_pointers.frame_pointers = std::move(frame_pointers);
 }
 
-static void tryLogCurrentExceptionImpl(Poco::Logger * logger, const std::string & start_of_message)
+static void tryLogCurrentExceptionImpl(Poco::Logger * logger, const std::string & start_of_message, LogsLevel level)
 {
     if (!isLoggingEnabled())
         return;
@@ -262,14 +262,25 @@ static void tryLogCurrentExceptionImpl(Poco::Logger * logger, const std::string 
         if (!start_of_message.empty())
             message.text = fmt::format("{}: {}", start_of_message, message.text);
 
-        LOG_ERROR(logger, message);
+        switch (level)
+        {
+            case LogsLevel::none: break;
+            case LogsLevel::test: LOG_TEST(logger, message); break;
+            case LogsLevel::trace: LOG_TRACE(logger, message); break;
+            case LogsLevel::debug: LOG_DEBUG(logger, message); break;
+            case LogsLevel::information: LOG_INFO(logger, message); break;
+            case LogsLevel::warning: LOG_WARNING(logger, message); break;
+            case LogsLevel::error: LOG_ERROR(logger, message); break;
+            case LogsLevel::fatal: LOG_FATAL(logger, message); break;
+        }
+
     }
     catch (...) // NOLINT(bugprone-empty-catch)
     {
     }
 }
 
-void tryLogCurrentException(const char * log_name, const std::string & start_of_message)
+void tryLogCurrentException(const char * log_name, const std::string & start_of_message, LogsLevel level)
 {
     if (!isLoggingEnabled())
         return;
@@ -283,10 +294,10 @@ void tryLogCurrentException(const char * log_name, const std::string & start_of_
 
     /// getLogger can allocate memory too
     auto logger = getLogger(log_name);
-    tryLogCurrentExceptionImpl(logger.get(), start_of_message);
+    tryLogCurrentExceptionImpl(logger.get(), start_of_message, level);
 }
 
-void tryLogCurrentException(Poco::Logger * logger, const std::string & start_of_message)
+void tryLogCurrentException(Poco::Logger * logger, const std::string & start_of_message, LogsLevel level)
 {
     /// Under high memory pressure, new allocations throw a
     /// MEMORY_LIMIT_EXCEEDED exception.
@@ -295,17 +306,17 @@ void tryLogCurrentException(Poco::Logger * logger, const std::string & start_of_
     /// MemoryTracker until the exception will be logged.
     LockMemoryExceptionInThread lock_memory_tracker(VariableContext::Global);
 
-    tryLogCurrentExceptionImpl(logger, start_of_message);
+    tryLogCurrentExceptionImpl(logger, start_of_message, level);
 }
 
-void tryLogCurrentException(LoggerPtr logger, const std::string & start_of_message)
+void tryLogCurrentException(LoggerPtr logger, const std::string & start_of_message, LogsLevel level)
 {
-    tryLogCurrentException(logger.get(), start_of_message);
+    tryLogCurrentException(logger.get(), start_of_message, level);
 }
 
-void tryLogCurrentException(const AtomicLogger & logger, const std::string & start_of_message)
+void tryLogCurrentException(const AtomicLogger & logger, const std::string & start_of_message, LogsLevel level)
 {
-    tryLogCurrentException(logger.load(), start_of_message);
+    tryLogCurrentException(logger.load(), start_of_message, level);
 }
 
 static void getNoSpaceLeftInfoMessage(std::filesystem::path path, String & msg)

--- a/src/Common/Exception.h
+++ b/src/Common/Exception.h
@@ -7,6 +7,7 @@
 #include <Common/Logger.h>
 #include <Common/LoggingFormatStringHelpers.h>
 #include <Common/StackTrace.h>
+#include <Core/LogsLevel.h>
 
 #include <cerrno>
 #include <exception>
@@ -276,10 +277,10 @@ using Exceptions = std::vector<std::exception_ptr>;
   * Can be used in destructors in the catch-all block.
   */
 /// TODO: Logger leak constexpr overload
-void tryLogCurrentException(const char * log_name, const std::string & start_of_message = "");
-void tryLogCurrentException(Poco::Logger * logger, const std::string & start_of_message = "");
-void tryLogCurrentException(LoggerPtr logger, const std::string & start_of_message = "");
-void tryLogCurrentException(const AtomicLogger & logger, const std::string & start_of_message = "");
+void tryLogCurrentException(const char * log_name, const std::string & start_of_message = "", LogsLevel level = LogsLevel::error);
+void tryLogCurrentException(Poco::Logger * logger, const std::string & start_of_message = "", LogsLevel level = LogsLevel::error);
+void tryLogCurrentException(LoggerPtr logger, const std::string & start_of_message = "", LogsLevel level = LogsLevel::error);
+void tryLogCurrentException(const AtomicLogger & logger, const std::string & start_of_message = "", LogsLevel level = LogsLevel::error);
 
 
 /** Prints current exception in canonical format.

--- a/src/Server/TCPHandler.cpp
+++ b/src/Server/TCPHandler.cpp
@@ -1614,7 +1614,7 @@ void TCPHandler::receiveHello()
                 if (e.code() != DB::ErrorCodes::AUTHENTICATION_FAILED)
                     throw;
 
-                tryLogCurrentException(log, "SSL authentication failed, falling back to password authentication", LogsLevel::debug);
+                tryLogCurrentException(log, "SSL authentication failed, falling back to password authentication", LogsLevel::information);
                 /// ^^ Log at debug level instead of default error level as authentication failures are not an unusual event.
             }
         }

--- a/src/Server/TCPHandler.cpp
+++ b/src/Server/TCPHandler.cpp
@@ -1614,7 +1614,8 @@ void TCPHandler::receiveHello()
                 if (e.code() != DB::ErrorCodes::AUTHENTICATION_FAILED)
                     throw;
 
-                tryLogCurrentException(log, "SSL authentication failed, falling back to password authentication");
+                tryLogCurrentException(log, "SSL authentication failed, falling back to password authentication", LogsLevel::debug);
+                /// ^^ Log at debug level instead of default error level as authentication failures are not an unusual event.
             }
         }
     }


### PR DESCRIPTION
Users can have multiple authentication methods specified ([clickhouse.com/docs/en/sql-reference/statements/create/user](https://clickhouse.com/docs/en/sql-reference/statements/create/user)), e.g. password and hash-based authentication, SSL-based authentication, SSH-based certification, Kerberos authentication, LDAP authentification. During login/handshake, these methods are tried out one after another.

There was a [customer issue](https://github.com/ClickHouse/support-escalation/issues/3064) that the server logs would be filled with messages of this kind:

```
Oct 03 13:40:23 ch-server clickhouse-server[1892]: 2024.10.03 13:40:23.922654 [ 44468 ] {} <Error> Access(user directories): from: [...]], user: inserter: Authentication failed: Code: 36. DB::Exception: Credentials required. (BAD_ARGUMENTS), Stack trace (when copying this message, always include the lines below):

0. DB::Exception::Exception(DB::Exception::MessageMasked&&, int, bool) @ 0x000000000c7faf9b in /usr/bin/clickhouse
1. DB::Authentication::Require<DB::BasicCredentials>::Require(String const&) @ 0x00000000103479f1 in /usr/bin/clickhouse
2. DB::Authentication::areCredentialsValid(DB::Credentials const&, DB::AuthenticationData const&, DB::ExternalAuthenticators const&, DB::SettingsChanges&) @ 0x00000000103474a3 in /usr/bin/clickhouse
3. DB::IAccessStorage::authenticateImpl(DB::Credentials const&, Poco::Net::IPAddress const&, DB::ExternalAuthenticators const&, bool, bool, bool) const @ 0x00000000103428d7 in /usr/bin/clickhouse
4. DB::MultipleAccessStorage::authenticateImpl(DB::Credentials const&, Poco::Net::IPAddress const&, DB::ExternalAuthenticators const&, bool, bool, bool) const @ 0x000000001037986a in /usr/bin/clickhouse
5. DB::AccessControl::authenticate(DB::Credentials const&, Poco::Net::IPAddress const&) const @ 0x00000000102b4980 in /usr/bin/clickhouse
6. DB::Session::authenticate(DB::Credentials const&, Poco::Net::SocketAddress const&) @ 0x000000001169d1e3 in /usr/bin/clickhouse
7. DB::TCPHandler::receiveHello() @ 0x0000000012915e49 in /usr/bin/clickhouse
8. DB::TCPHandler::runImpl() @ 0x000000001290ad33 in /usr/bin/clickhouse
9. DB::TCPHandler::run() @ 0x00000000129246b9 in /usr/bin/clickhouse
10. Poco::Net::TCPServerConnection::start() @ 0x0000000015398172 in /usr/bin/clickhouse
11. Poco::Net::TCPServerDispatcher::run() @ 0x0000000015398f71 in /usr/bin/clickhouse
12. Poco::PooledThread::run() @ 0x0000000015491747 in /usr/bin/clickhouse
13. Poco::ThreadImpl::runnableEntry(void*) @ 0x000000001548fd7d in /usr/bin/clickhouse
14. ? @ 0x00007f57bfded609
15. ? @ 0x00007f57bfd12353
(version 24.1.5.6 (official build))

Oct 03 13:40:23 ch-server[1892]: 2024.10.03 13:40:23.922874 [ 44468 ] {} <Error> TCPHandler: SSL authentication failed, falling back to password authentication: Code: 516. DB::Exception: inserter: Authentication failed: password is incorrect, or there is no user with such name. (AUTHENTICATION_FAILED), Stack trace (when copying this message, always include the lines below):

0. DB::Exception::Exception(DB::Exception::MessageMasked&&, int, bool) @ 0x000000000c7faf9b in /usr/bin/clickhouse
1. DB::Exception::Exception(PreformattedMessage&&, int) @ 0x00000000072fffcc in /usr/bin/clickhouse
2. DB::AccessControl::authenticate(DB::Credentials const&, Poco::Net::IPAddress const&) const @ 0x00000000102b4c54 in /usr/bin/clickhouse
3. DB::Session::authenticate(DB::Credentials const&, Poco::Net::SocketAddress const&) @ 0x000000001169d1e3 in /usr/bin/clickhouse
4. DB::TCPHandler::receiveHello() @ 0x0000000012915e49 in /usr/bin/clickhouse
5. DB::TCPHandler::runImpl() @ 0x000000001290ad33 in /usr/bin/clickhouse
6. DB::TCPHandler::run() @ 0x00000000129246b9 in /usr/bin/clickhouse
7. Poco::Net::TCPServerConnection::start() @ 0x0000000015398172 in /usr/bin/clickhouse
8. Poco::Net::TCPServerDispatcher::run() @ 0x0000000015398f71 in /usr/bin/clickhouse
9. Poco::PooledThread::run() @ 0x0000000015491747 in /usr/bin/clickhouse
10. Poco::ThreadImpl::runnableEntry(void*) @ 0x000000001548fd7d in /usr/bin/clickhouse
11. ? @ 0x00007f57bfded609
12. ? @ 0x00007f57bfd12353
(version 24.1.5.6 (official build))
```

What happened is that
- a user attempts a secure connection to the server,
- the server first attempts SSL authentication (during handshake) but no authentication method of kind "ssl_certificate" (as mentioned in the [docs](https://clickhouse.com/docs/en/sql-reference/statements/create/user)) exists for the user,
- then above two exceptions are logged,
- and password-based authentication succeeds.

The fact that secure connections are not restricted to SSL authentication sounds weird but it is intentional, see [here](https://github.com/ClickHouse/ClickHouse/pull/48989).

To avoid spamming logs, this PR demotes the log level of unsuccessful authentication attempts from `ERROR` to `DEBUG`. In my view, `ERROR` is reserved for unexpected events (failing merges, out-of-memory etc.) but an unsuccessful login is "expected".

@vitlibar FYI

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
To avoid spamming the server logs, failing authentication attempts are now logged at level `DEBUG` instead of `ERROR`.