### PR TITLE
Support deletion in function `translate` 

### DIFF
--- a/docs/en/sql-reference/functions/string-replace-functions.md
+++ b/docs/en/sql-reference/functions/string-replace-functions.md
@@ -253,7 +253,7 @@ SELECT format('{} {}', 'Hello', 'World')
 
 ## translate
 
-Replaces characters in the string `s` using a one-to-one character mapping defined by `from` and `to` strings. `from` and `to` must be constant ASCII strings of the same size. Non-ASCII characters in the original string are not modified.
+Replaces characters in the string `s` using a one-to-one character mapping defined by `from` and `to` strings. `from` and `to` must be constant ASCII strings. Non-ASCII characters in the original string are not modified.
 
 **Syntax**
 

--- a/docs/en/sql-reference/functions/string-replace-functions.md
+++ b/docs/en/sql-reference/functions/string-replace-functions.md
@@ -253,7 +253,7 @@ SELECT format('{} {}', 'Hello', 'World')
 
 ## translate
 
-Replaces characters in the string `s` using a one-to-one character mapping defined by `from` and `to` strings. `from` and `to` must be constant ASCII strings. Non-ASCII characters in the original string are not modified.
+Replaces characters in the string `s` using a one-to-one character mapping defined by `from` and `to` strings. `from` and `to` must be constant ASCII strings. Non-ASCII characters in the original string are not modified. If the number of characters in `from` list is larger than the `to` list, non overlapping characters will be deleted from the input string.
 
 **Syntax**
 

--- a/src/Functions/translate.cpp
+++ b/src/Functions/translate.cpp
@@ -149,12 +149,6 @@ struct TranslateUTF8Impl
         const std::string & map_from,
         const std::string & map_to)
     {
-        auto map_from_size = UTF8::countCodePoints(reinterpret_cast<const UInt8 *>(map_from.data()), map_from.size());
-        auto map_to_size = UTF8::countCodePoints(reinterpret_cast<const UInt8 *>(map_to.data()), map_to.size());
-
-        if (map_from_size < map_to_size)
-            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Second arguments must be equal or longer than third");
-
         iota(map_ascii.data(), map_ascii.size(), UInt32(0));
 
         const UInt8 * map_from_ptr = reinterpret_cast<const UInt8 *>(map_from.data());

--- a/src/Functions/translate.cpp
+++ b/src/Functions/translate.cpp
@@ -103,8 +103,7 @@ struct TranslateImpl
             /// Technically '\0' can be mapped into other character,
             ///  so we need to process '\0' delimiter separately
             *dst++ = 0;
-            ++data_size;
-            res_offsets[i] = data_size;
+            res_offsets[i] = ++data_size;
         }
     }
 

--- a/src/Functions/translate.cpp
+++ b/src/Functions/translate.cpp
@@ -44,13 +44,18 @@ struct TranslateImpl
                 map[map_from[i]] = map_to[i];
             }
             else
+            {
+                if (!isASCII(map_from[i]))
+                    throw Exception(ErrorCodes::BAD_ARGUMENTS, "Second argument must be ASCII strings");
+
                 map[map_from[i]] = ascii_upper_bound + 1;
+            }
         }
 
         for (size_t i = map_from.size(); i < map_to.size(); ++i)
         {
-            if (!isASCII(map_from[i]))
-                throw Exception(ErrorCodes::BAD_ARGUMENTS, "Third arguments must be ASCII strings");
+            if (!isASCII(map_to[i]))
+                throw Exception(ErrorCodes::BAD_ARGUMENTS, "Third argument must be ASCII strings");
         }
     }
 

--- a/src/Functions/translate.cpp
+++ b/src/Functions/translate.cpp
@@ -45,10 +45,15 @@ struct TranslateImpl
             }
             else
             {
-                if (!isASCII(map_from[i]))
-                    throw Exception(ErrorCodes::BAD_ARGUMENTS, "Second argument must be ASCII strings");
+                while (i < map_from.size())
+                {
+                    if (!isASCII(map_from[i]))
+                        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Second argument must be ASCII strings");
 
-                map[map_from[i]] = ascii_upper_bound + 1;
+                    map[map_from[i]] = ascii_upper_bound + 1;
+                    ++i;
+                }
+                return;
             }
         }
 

--- a/tests/queries/0_stateless/02353_translate.reference
+++ b/tests/queries/0_stateless/02353_translate.reference
@@ -19,3 +19,4 @@ abc
 1A2BC
 1A2B3C
 ABC
+

--- a/tests/queries/0_stateless/02353_translate.reference
+++ b/tests/queries/0_stateless/02353_translate.reference
@@ -17,3 +17,4 @@ abc
 abc
 内码
 1A2BC
+1A2B3C

--- a/tests/queries/0_stateless/02353_translate.reference
+++ b/tests/queries/0_stateless/02353_translate.reference
@@ -18,3 +18,4 @@ abc
 内码
 1A2BC
 1A2B3C
+ABC

--- a/tests/queries/0_stateless/02353_translate.reference
+++ b/tests/queries/0_stateless/02353_translate.reference
@@ -14,3 +14,7 @@ HotelGenev
 ¿йðՅনй
 abc
 abc
+abc
+abc
+内码
+1A2BC

--- a/tests/queries/0_stateless/02353_translate.reference
+++ b/tests/queries/0_stateless/02353_translate.reference
@@ -15,6 +15,5 @@ HotelGenev
 abc
 abc
 abc
-abc
 内码
 1A2BC

--- a/tests/queries/0_stateless/02353_translate.sql
+++ b/tests/queries/0_stateless/02353_translate.sql
@@ -9,5 +9,8 @@ SELECT translateUTF8(toString(number), '1234567890', 'ዩय𐑿𐐏নՅðй¿�
 SELECT translate('abc', '', '');
 SELECT translateUTF8('abc', '', '');
 
-SELECT translate('abc', 'Ááéíóúôè', 'aaeiouoe'); -- { serverError BAD_ARGUMENTS }
-SELECT translateUTF8('abc', 'efg', ''); -- { serverError BAD_ARGUMENTS }
+SELECT translate('abc', 'Ááéíóúôè', 'aaeiouoe');
+SELECT translateUTF8('abc', 'efg', '');
+
+SELECT translateUTF8('中文内码', '中文', '');
+SELECT translate('aAbBcC', 'abc', '12');

--- a/tests/queries/0_stateless/02353_translate.sql
+++ b/tests/queries/0_stateless/02353_translate.sql
@@ -14,3 +14,6 @@ SELECT translateUTF8('abc', 'efg', '');
 
 SELECT translateUTF8('中文内码', '中文', '');
 SELECT translate('aAbBcC', 'abc', '12');
+
+SELECT translate('aAbBcC', 'abc', '1235');
+SELECT translate('aAbBcC', '中文内码', '12'); -- { serverError BAD_ARGUMENTS }

--- a/tests/queries/0_stateless/02353_translate.sql
+++ b/tests/queries/0_stateless/02353_translate.sql
@@ -16,4 +16,5 @@ SELECT translateUTF8('中文内码', '中文', '');
 SELECT translate('aAbBcC', 'abc', '12');
 
 SELECT translate('aAbBcC', 'abc', '1235');
+SELECT translate('aAbBcC', 'abc', '');
 SELECT translate('aAbBcC', '中文内码', '12'); -- { serverError BAD_ARGUMENTS }

--- a/tests/queries/0_stateless/02353_translate.sql
+++ b/tests/queries/0_stateless/02353_translate.sql
@@ -17,4 +17,5 @@ SELECT translate('aAbBcC', 'abc', '12');
 
 SELECT translate('aAbBcC', 'abc', '1235');
 SELECT translate('aAbBcC', 'abc', '');
+SELECT translate('abc', 'abc', '');
 SELECT translate('aAbBcC', '中文内码', '12'); -- { serverError BAD_ARGUMENTS }

--- a/tests/queries/0_stateless/02353_translate.sql
+++ b/tests/queries/0_stateless/02353_translate.sql
@@ -9,7 +9,7 @@ SELECT translateUTF8(toString(number), '1234567890', 'ዩय𐑿𐐏নՅðй¿�
 SELECT translate('abc', '', '');
 SELECT translateUTF8('abc', '', '');
 
-SELECT translate('abc', 'Ááéíóúôè', 'aaeiouoe');
+SELECT translate('abc', 'Ááéíóúôè', 'aaeiouoe'); -- { serverError BAD_ARGUMENTS }
 SELECT translateUTF8('abc', 'efg', '');
 
 SELECT translateUTF8('中文内码', '中文', '');


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Function `translate` now supports character deletion if the `from` argument contains more characters than the `to` argument. Example: `SELECT translate('clickhouse', 'clickhouse', 'CLICK')` now returns `CLICK`.