### PR TITLE
Apply config updates in global context (second attempt)

### DIFF
--- a/base/poco/Util/include/Poco/Util/LayeredConfiguration.h
+++ b/base/poco/Util/include/Poco/Util/LayeredConfiguration.h
@@ -150,6 +150,9 @@ namespace Util
         /// Does nothing if the given configuration is not part of the
         /// LayeredConfiguration.
 
+        void assignConfigurations(LayeredConfiguration& pConfig);
+        /// Clear and adds all configurations from other LayeredConfiguration.
+
     protected:
         struct ConfigItem
         {

--- a/base/poco/Util/src/LayeredConfiguration.cpp
+++ b/base/poco/Util/src/LayeredConfiguration.cpp
@@ -142,6 +142,13 @@ void LayeredConfiguration::removeConfiguration(AbstractConfiguration* pConfig)
 }
 
 
+void LayeredConfiguration::assignConfigurations(LayeredConfiguration& pConfig)
+{
+	_configs.clear();
+	_configs = pConfig._configs;
+}
+
+
 LayeredConfiguration::ConfigPtr LayeredConfiguration::find(const std::string& label) const
 {
 	for (ConfigList::const_iterator it = _configs.begin(); it != _configs.end(); ++it)

--- a/docs/en/development/architecture.md
+++ b/docs/en/development/architecture.md
@@ -170,7 +170,7 @@ ClickHouse Server is based on POCO C++ Libraries and uses `Poco::Util::AbstractC
 
 Config is read from multiple files (in XML or YAML format) and merged into single `AbstractConfiguration` by `ConfigProcessor` class. Configuration is loaded at server startup and can be reloaded later if one of config files is updated, removed or added. `ConfigReloader` class is responsible for periodic monitoring of these changes and reload procedure as well. `SYSTEM RELOAD CONFIG` query also triggers config to be reloaded.
 
-For queries and subsystems other than `Server` config is accessible using `Context::getConfigRef()` method. Every subsystem that is capable of reloading its config without server restart should register itself in reload callback in `Server::main()` method. Note that if newer config has an error, most subsystems will ignore new config, log warning messages and keep working with previously loaded config. Due to the nature of `AbstractConfiguration` it is not possible to pass reference to specific section, so `String config_prefix` is usually used instead.
+For queries and subsystems other than `Server` config is accessible using `Context::getConfig()` method. Every subsystem that is capable of reloading its config without server restart should register itself in reload callback in `Server::main()` method. Note that if newer config has an error, most subsystems will ignore new config, log warning messages and keep working with previously loaded config. Due to the nature of `AbstractConfiguration` it is not possible to pass reference to specific section, so `String config_prefix` is usually used instead.
 
 ## Threads and jobs {#threads-and-jobs}
 

--- a/src/Backups/BackupEntriesCollector.cpp
+++ b/src/Backups/BackupEntriesCollector.cpp
@@ -101,15 +101,16 @@ BackupEntriesCollector::BackupEntriesCollector(
     , backup_coordination(backup_coordination_)
     , read_settings(read_settings_)
     , context(context_)
+    , config(context->getConfig())
     , process_list_element(context->getProcessListElement())
-    , collect_metadata_timeout(context->getConfigRef().getUInt64(
-          "backups.collect_metadata_timeout", context->getConfigRef().getUInt64("backups.consistent_metadata_snapshot_timeout", 600000)))
-    , attempts_to_collect_metadata_before_sleep(context->getConfigRef().getUInt("backups.attempts_to_collect_metadata_before_sleep", 2))
+    , collect_metadata_timeout(config->getUInt64(
+          "backups.collect_metadata_timeout", config->getUInt64("backups.consistent_metadata_snapshot_timeout", 600000)))
+    , attempts_to_collect_metadata_before_sleep(config->getUInt("backups.attempts_to_collect_metadata_before_sleep", 2))
     , min_sleep_before_next_attempt_to_collect_metadata(
-          context->getConfigRef().getUInt64("backups.min_sleep_before_next_attempt_to_collect_metadata", 100))
+          config->getUInt64("backups.min_sleep_before_next_attempt_to_collect_metadata", 100))
     , max_sleep_before_next_attempt_to_collect_metadata(
-          context->getConfigRef().getUInt64("backups.max_sleep_before_next_attempt_to_collect_metadata", 5000))
-    , compare_collected_metadata(context->getConfigRef().getBool("backups.compare_collected_metadata", true))
+          config->getUInt64("backups.max_sleep_before_next_attempt_to_collect_metadata", 5000))
+    , compare_collected_metadata(config->getBool("backups.compare_collected_metadata", true))
     , log(getLogger("BackupEntriesCollector"))
     , global_zookeeper_retries_info(
           context->getSettingsRef()[Setting::backup_restore_keeper_max_retries],

--- a/src/Backups/BackupEntriesCollector.h
+++ b/src/Backups/BackupEntriesCollector.h
@@ -109,6 +109,8 @@ private:
     std::shared_ptr<IBackupCoordination> backup_coordination;
     const ReadSettings read_settings;
     ContextPtr context;
+    Poco::AutoPtr<Poco::Util::AbstractConfiguration> config;
+
     QueryStatusPtr process_list_element;
 
     /// The time a BACKUP command will try to collect the metadata of tables & databases.

--- a/src/Backups/BackupIO_S3.cpp
+++ b/src/Backups/BackupIO_S3.cpp
@@ -104,7 +104,7 @@ namespace
         S3::ClientSettings client_settings{
             .use_virtual_addressing = s3_uri.is_virtual_hosted_style,
             .disable_checksum = local_settings[Setting::s3_disable_checksum],
-            .gcs_issue_compose_request = context->getConfigRef().getBool("s3.gcs_issue_compose_request", false),
+            .gcs_issue_compose_request = context->getConfig()->getBool("s3.gcs_issue_compose_request", false),
             .is_s3express_bucket = S3::isS3ExpressEndpoint(s3_uri.endpoint),
         };
 
@@ -152,7 +152,8 @@ BackupReaderS3::BackupReaderS3(
     , s3_uri(s3_uri_)
     , data_source_description{DataSourceType::ObjectStorage, ObjectStorageType::S3, MetadataStorageType::None, s3_uri.endpoint, false, false}
 {
-    s3_settings.loadFromConfig(context_->getConfigRef(), "s3", context_->getSettingsRef());
+    auto config = context_->getConfig();
+    s3_settings.loadFromConfig(*config, "s3", context_->getSettingsRef());
 
     if (auto endpoint_settings = context_->getStorageS3Settings().getSettings(
             s3_uri.uri.toString(), context_->getUserName(), /*ignore_user=*/is_internal_backup))
@@ -247,11 +248,12 @@ BackupWriterS3::BackupWriterS3(
     const ContextPtr & context_,
     bool is_internal_backup)
     : BackupWriterDefault(read_settings_, write_settings_, getLogger("BackupWriterS3"))
+    , config(context_->getConfig())
     , s3_uri(s3_uri_)
     , data_source_description{DataSourceType::ObjectStorage, ObjectStorageType::S3, MetadataStorageType::None, s3_uri.endpoint, false, false}
-    , s3_capabilities(getCapabilitiesFromConfig(context_->getConfigRef(), "s3"))
+    , s3_capabilities(getCapabilitiesFromConfig(*config, "s3"))
 {
-    s3_settings.loadFromConfig(context_->getConfigRef(), "s3", context_->getSettingsRef());
+    s3_settings.loadFromConfig(*config, "s3", context_->getSettingsRef());
 
     if (auto endpoint_settings = context_->getStorageS3Settings().getSettings(
             s3_uri.uri.toString(), context_->getUserName(), /*ignore_user=*/is_internal_backup))

--- a/src/Backups/BackupIO_S3.h
+++ b/src/Backups/BackupIO_S3.h
@@ -79,6 +79,8 @@ public:
 private:
     std::unique_ptr<ReadBuffer> readFile(const String & file_name, size_t expected_file_size) override;
 
+    Poco::AutoPtr<Poco::Util::AbstractConfiguration> config;
+
     const S3::URI s3_uri;
     const DataSourceDescription data_source_description;
     S3Settings s3_settings;

--- a/src/Backups/BackupKeeperSettings.cpp
+++ b/src/Backups/BackupKeeperSettings.cpp
@@ -29,7 +29,7 @@ BackupKeeperSettings BackupKeeperSettings::fromContext(const ContextPtr & contex
     BackupKeeperSettings keeper_settings;
 
     const auto & settings = context->getSettingsRef();
-    const auto & config = context->getConfigRef();
+    auto config = context->getConfig();
 
     keeper_settings.max_retries = settings[Setting::backup_restore_keeper_max_retries];
     keeper_settings.retry_initial_backoff_ms = std::chrono::milliseconds{settings[Setting::backup_restore_keeper_retry_initial_backoff_ms]};
@@ -40,11 +40,11 @@ BackupKeeperSettings BackupKeeperSettings::fromContext(const ContextPtr & contex
     keeper_settings.max_retries_while_handling_error = settings[Setting::backup_restore_keeper_max_retries_while_handling_error];
     keeper_settings.finish_timeout_after_error = std::chrono::seconds(settings[Setting::backup_restore_finish_timeout_after_error_sec]);
 
-    if (config.has("backups.sync_period_ms"))
-        keeper_settings.sync_period_ms = std::chrono::milliseconds{config.getUInt64("backups.sync_period_ms")};
+    if (config->has("backups.sync_period_ms"))
+        keeper_settings.sync_period_ms = std::chrono::milliseconds{config->getUInt64("backups.sync_period_ms")};
 
-    if (config.has("backups.max_attempts_after_bad_version"))
-        keeper_settings.max_attempts_after_bad_version = config.getUInt64("backups.max_attempts_after_bad_version");
+    if (config->has("backups.max_attempts_after_bad_version"))
+        keeper_settings.max_attempts_after_bad_version = config->getUInt64("backups.max_attempts_after_bad_version");
 
     keeper_settings.value_max_size = settings[Setting::backup_restore_keeper_value_max_size];
     keeper_settings.batch_size_for_multi = settings[Setting::backup_restore_batch_size_for_keeper_multi];

--- a/src/Backups/BackupsWorker.cpp
+++ b/src/Backups/BackupsWorker.cpp
@@ -295,11 +295,12 @@ private:
 
 BackupsWorker::BackupsWorker(ContextMutablePtr global_context, size_t num_backup_threads, size_t num_restore_threads)
     : thread_pools(std::make_unique<ThreadPools>(num_backup_threads, num_restore_threads))
-    , allow_concurrent_backups(global_context->getConfigRef().getBool("backups.allow_concurrent_backups", true))
-    , allow_concurrent_restores(global_context->getConfigRef().getBool("backups.allow_concurrent_restores", true))
-    , remove_backup_files_after_failure(global_context->getConfigRef().getBool("backups.remove_backup_files_after_failure", true))
-    , test_randomize_order(global_context->getConfigRef().getBool("backups.test_randomize_order", false))
-    , test_inject_sleep(global_context->getConfigRef().getBool("backups.test_inject_sleep", false))
+    , config(global_context->getConfig())
+    , allow_concurrent_backups(config->getBool("backups.allow_concurrent_backups", true))
+    , allow_concurrent_restores(config->getBool("backups.allow_concurrent_restores", true))
+    , remove_backup_files_after_failure(config->getBool("backups.remove_backup_files_after_failure", true))
+    , test_randomize_order(config->getBool("backups.test_randomize_order", false))
+    , test_inject_sleep(config->getBool("backups.test_inject_sleep", false))
     , log(getLogger("BackupsWorker"))
     , backup_log(global_context->getBackupLog())
     , process_list(global_context->getProcessList())
@@ -948,7 +949,7 @@ BackupsWorker::makeBackupCoordination(bool on_cluster, const BackupSettings & ba
 
     bool is_internal_backup = backup_settings.internal;
 
-    String root_zk_path = context->getConfigRef().getString("backups.zookeeper_path", "/clickhouse/backups");
+    String root_zk_path = config->getString("backups.zookeeper_path", "/clickhouse/backups");
     auto get_zookeeper = [global_context = context->getGlobalContext()] { return global_context->getZooKeeper(); };
     auto keeper_settings = BackupKeeperSettings::fromContext(context);
 
@@ -987,7 +988,7 @@ BackupsWorker::makeRestoreCoordination(bool on_cluster, const RestoreSettings & 
 
     bool is_internal_restore = restore_settings.internal;
 
-    String root_zk_path = context->getConfigRef().getString("backups.zookeeper_path", "/clickhouse/backups");
+    String root_zk_path = config->getString("backups.zookeeper_path", "/clickhouse/backups");
     auto get_zookeeper = [global_context = context->getGlobalContext()] { return global_context->getZooKeeper(); };
     auto keeper_settings = BackupKeeperSettings::fromContext(context);
 

--- a/src/Backups/BackupsWorker.h
+++ b/src/Backups/BackupsWorker.h
@@ -7,6 +7,7 @@
 #include <Parsers/IAST_fwd.h>
 #include <unordered_map>
 
+#include <Poco/AutoPtr.h>
 
 namespace Poco::Util { class AbstractConfiguration; }
 
@@ -136,6 +137,7 @@ private:
 
     class ThreadPools;
     std::unique_ptr<ThreadPools> thread_pools;
+    Poco::AutoPtr<Poco::Util::AbstractConfiguration> config;
 
     const bool allow_concurrent_backups;
     const bool allow_concurrent_restores;

--- a/src/Backups/RestorerFromBackup.cpp
+++ b/src/Backups/RestorerFromBackup.cpp
@@ -100,7 +100,7 @@ RestorerFromBackup::RestorerFromBackup(
     , context(context_)
     , process_list_element(context->getProcessListElement())
     , after_task_callback(after_task_callback_)
-    , create_table_timeout(context->getConfigRef().getUInt64("backups.create_table_timeout", 300000))
+    , create_table_timeout(context->getConfig()->getUInt64("backups.create_table_timeout", 300000))
     , log(getLogger("RestorerFromBackup"))
     , tables_dependencies("RestorerFromBackup")
     , thread_pool(thread_pool_)

--- a/src/Backups/registerBackupEngineAzureBlobStorage.cpp
+++ b/src/Backups/registerBackupEngineAzureBlobStorage.cpp
@@ -56,16 +56,16 @@ void registerBackupEngineAzureBlobStorage(BackupFactory & factory)
 
         if (!id_arg.empty())
         {
-            const auto & config = params.context->getConfigRef();
+            auto config = params.context->getConfig();
             auto config_prefix = "named_collections." + id_arg;
 
-            if (!config.has(config_prefix))
+            if (!config->has(config_prefix))
                 throw Exception(ErrorCodes::BAD_ARGUMENTS, "There is no collection named `{}` in config", id_arg);
 
             connection_params =
             {
-                .endpoint = AzureBlobStorage::processEndpoint(config, config_prefix),
-                .auth_method = AzureBlobStorage::getAuthMethod(config, config_prefix),
+                .endpoint = AzureBlobStorage::processEndpoint(*config, config_prefix),
+                .auth_method = AzureBlobStorage::getAuthMethod(*config, config_prefix),
                 .client_options = AzureBlobStorage::getClientOptions(*request_settings, /*for_disk=*/ true),
             };
 

--- a/src/Backups/registerBackupEngineS3.cpp
+++ b/src/Backups/registerBackupEngineS3.cpp
@@ -52,18 +52,18 @@ void registerBackupEngineS3(BackupFactory & factory)
 
         if (!id_arg.empty())
         {
-            const auto & config = params.context->getConfigRef();
+            auto config = params.context->getConfig();
             auto config_prefix = "named_collections." + id_arg;
 
-            if (!config.has(config_prefix))
+            if (!config->has(config_prefix))
                 throw Exception(ErrorCodes::BAD_ARGUMENTS, "There is no collection named `{}` in config", id_arg);
 
-            s3_uri = config.getString(config_prefix + ".url");
-            access_key_id = config.getString(config_prefix + ".access_key_id", "");
-            secret_access_key = config.getString(config_prefix + ".secret_access_key", "");
+            s3_uri = config->getString(config_prefix + ".url");
+            access_key_id = config->getString(config_prefix + ".access_key_id", "");
+            secret_access_key = config->getString(config_prefix + ".secret_access_key", "");
 
-            if (config.has(config_prefix + ".filename"))
-                s3_uri = std::filesystem::path(s3_uri) / config.getString(config_prefix + ".filename");
+            if (config->has(config_prefix + ".filename"))
+                s3_uri = std::filesystem::path(s3_uri) / config->getString(config_prefix + ".filename");
 
             if (args.size() > 1)
                 throw Exception(ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH, "Backup S3 requires 1 or 2 arguments: named_collection, [filename]");

--- a/src/Backups/registerBackupEnginesFileAndDisk.cpp
+++ b/src/Backups/registerBackupEnginesFileAndDisk.cpp
@@ -125,9 +125,9 @@ void registerBackupEnginesFileAndDisk(BackupFactory & factory)
             }
 
             path = args[0].safeGet<String>();
-            const auto & config = params.context->getConfigRef();
+            auto config = params.context->getConfig();
             const auto & data_dir = params.context->getPath();
-            checkPath(path, config, data_dir);
+            checkPath(path, *config, data_dir);
         }
         else if (engine_name == "Disk")
         {
@@ -137,8 +137,8 @@ void registerBackupEnginesFileAndDisk(BackupFactory & factory)
             }
 
             String disk_name = args[0].safeGet<String>();
-            const auto & config = params.context->getConfigRef();
-            checkDiskName(disk_name, config);
+            auto config = params.context->getConfig();
+            checkDiskName(disk_name, *config);
             path = args[1].safeGet<String>();
             disk = params.context->getDisk(disk_name);
             checkPath(disk_name, disk, path);

--- a/src/BridgeHelper/LibraryBridgeHelper.cpp
+++ b/src/BridgeHelper/LibraryBridgeHelper.cpp
@@ -17,11 +17,11 @@ namespace ServerSetting
 
 LibraryBridgeHelper::LibraryBridgeHelper(ContextPtr context_)
     : IBridgeHelper(context_)
-    , config(context_->getConfigRef())
+    , config(context_->getConfig())
     , log(getLogger("LibraryBridgeHelper"))
     , http_timeout(context_->getGlobalContext()->getSettingsRef()[Setting::http_receive_timeout].value)
-    , bridge_host(config.getString("library_bridge.host", DEFAULT_HOST))
-    , bridge_port(config.getUInt("library_bridge.port", DEFAULT_PORT))
+    , bridge_host(config->getString("library_bridge.host", DEFAULT_HOST))
+    , bridge_port(config->getUInt("library_bridge.port", DEFAULT_PORT))
     , http_timeouts(ConnectionTimeouts::getHTTPTimeouts(context_->getSettingsRef(), context_->getServerSettings()))
 {
 }

--- a/src/BridgeHelper/LibraryBridgeHelper.h
+++ b/src/BridgeHelper/LibraryBridgeHelper.h
@@ -29,7 +29,7 @@ protected:
 
     String configPrefix() const override { return "library_bridge"; }
 
-    const Poco::Util::AbstractConfiguration & getConfig() const override { return config; }
+    const Poco::Util::AbstractConfiguration & getConfig() const override { return *config; }
 
     LoggerPtr getLog() const override { return log; }
 
@@ -39,7 +39,7 @@ protected:
 
     static constexpr size_t DEFAULT_PORT = 9012;
 
-    const Poco::Util::AbstractConfiguration & config;
+    Poco::AutoPtr<Poco::Util::AbstractConfiguration> config;
     LoggerPtr log;
     const Poco::Timespan http_timeout;
     std::string bridge_host;

--- a/src/BridgeHelper/XDBCBridgeHelper.h
+++ b/src/BridgeHelper/XDBCBridgeHelper.h
@@ -69,10 +69,10 @@ public:
         , connection_string(connection_string_)
         , use_connection_pooling(use_connection_pooling_)
         , http_timeout(http_timeout_)
-        , config(context_->getGlobalContext()->getConfigRef())
+        , config(context_->getGlobalContext()->getConfig())
     {
-        bridge_host = config.getString(BridgeHelperMixin::configPrefix() + ".host", DEFAULT_HOST);
-        bridge_port = config.getUInt(BridgeHelperMixin::configPrefix() + ".port", DEFAULT_PORT);
+        bridge_host = config->getString(BridgeHelperMixin::configPrefix() + ".host", DEFAULT_HOST);
+        bridge_port = config->getUInt(BridgeHelperMixin::configPrefix() + ".port", DEFAULT_PORT);
     }
 
 protected:
@@ -126,7 +126,7 @@ protected:
 
     Poco::Timespan getHTTPTimeout() const override { return http_timeout; }
 
-    const Poco::Util::AbstractConfiguration & getConfig() const override { return config; }
+    const Poco::Util::AbstractConfiguration & getConfig() const override { return *config; }
 
     LoggerPtr getLog() const override { return log; }
 
@@ -158,7 +158,7 @@ private:
     std::string bridge_host;
     size_t bridge_port;
 
-    const Configuration & config;
+    Poco::AutoPtr<Configuration> config;
 
     std::optional<IdentifierQuotingStyle> quote_style;
     std::optional<bool> is_schema_allowed;

--- a/src/Common/NamedCollections/NamedCollectionsFactory.cpp
+++ b/src/Common/NamedCollections/NamedCollectionsFactory.cpp
@@ -234,7 +234,8 @@ bool NamedCollectionFactory::loadIfNot(std::lock_guard<std::mutex> & lock)
     auto context = Context::getGlobalContextInstance();
     metadata_storage = NamedCollectionsMetadataStorage::create(context);
 
-    loadFromConfig(context->getConfigRef(), lock);
+    auto config = context->getConfig();
+    loadFromConfig(*config, lock);
     loadFromSQL(lock);
 
     if (metadata_storage->isReplicated())

--- a/src/Common/Scheduler/Workload/createWorkloadEntityStorage.cpp
+++ b/src/Common/Scheduler/Workload/createWorkloadEntityStorage.cpp
@@ -23,10 +23,10 @@ std::unique_ptr<IWorkloadEntityStorage> createWorkloadEntityStorage(const Contex
     const String zookeeper_path_key = "workload_zookeeper_path";
     const String disk_path_key = "workload_path";
 
-    const auto & config = global_context->getConfigRef();
-    if (config.has(zookeeper_path_key))
+    auto config = global_context->getConfig();
+    if (config->has(zookeeper_path_key))
     {
-        if (config.has(disk_path_key))
+        if (config->has(disk_path_key))
         {
             throw Exception(
                 ErrorCodes::INVALID_CONFIG_PARAMETER,
@@ -34,11 +34,11 @@ std::unique_ptr<IWorkloadEntityStorage> createWorkloadEntityStorage(const Contex
                 zookeeper_path_key,
                 disk_path_key);
         }
-        return std::make_unique<WorkloadEntityKeeperStorage>(global_context, config.getString(zookeeper_path_key));
+        return std::make_unique<WorkloadEntityKeeperStorage>(global_context, config->getString(zookeeper_path_key));
     }
 
     String default_path = fs::path{global_context->getPath()} / "workload" / "";
-    String path = config.getString(disk_path_key, default_path);
+    String path = config->getString(disk_path_key, default_path);
     return std::make_unique<WorkloadEntityDiskStorage>(global_context, path);
 }
 

--- a/src/Common/tests/gtest_proxy_configuration_resolver_provider.cpp
+++ b/src/Common/tests/gtest_proxy_configuration_resolver_provider.cpp
@@ -34,10 +34,10 @@ Poco::URI https_list_proxy_server = Poco::URI("http://https_list_proxy:3128");
 TEST_F(ProxyConfigurationResolverProviderTests, EnvironmentResolverShouldBeUsedIfNoSettings)
 {
     EnvironmentProxySetter setter;
-    const auto & config = getContext().context->getConfigRef();
+    auto config = getContext().context->getConfig();
 
-    auto http_resolver = DB::ProxyConfigurationResolverProvider::get(DB::ProxyConfiguration::Protocol::HTTP, config);
-    auto https_resolver = DB::ProxyConfigurationResolverProvider::get(DB::ProxyConfiguration::Protocol::HTTPS, config);
+    auto http_resolver = DB::ProxyConfigurationResolverProvider::get(DB::ProxyConfiguration::Protocol::HTTP, *config);
+    auto https_resolver = DB::ProxyConfigurationResolverProvider::get(DB::ProxyConfiguration::Protocol::HTTPS, *config);
 
     ASSERT_TRUE(std::dynamic_pointer_cast<DB::EnvironmentProxyConfigurationResolver>(http_resolver));
     ASSERT_TRUE(std::dynamic_pointer_cast<DB::EnvironmentProxyConfigurationResolver>(https_resolver));

--- a/src/Databases/DatabaseReplicated.cpp
+++ b/src/Databases/DatabaseReplicated.cpp
@@ -152,10 +152,11 @@ DatabaseReplicated::DatabaseReplicated(
     if (zookeeper_path.front() != '/')
         zookeeper_path = "/" + zookeeper_path;
 
+    auto config = context_->getConfig();
     if (!db_settings[DatabaseReplicatedSetting::collection_name].value.empty())
-        fillClusterAuthInfo(db_settings[DatabaseReplicatedSetting::collection_name].value, context_->getConfigRef());
+        fillClusterAuthInfo(db_settings[DatabaseReplicatedSetting::collection_name].value, *config);
 
-    replica_group_name = context_->getConfigRef().getString("replica_group_name", "");
+    replica_group_name = config->getString("replica_group_name", "");
 
     if (!replica_group_name.empty() && database_name.starts_with(DatabaseReplicated::ALL_GROUPS_CLUSTER_PREFIX))
     {
@@ -933,7 +934,7 @@ void DatabaseReplicated::checkTableEngine(const ASTCreateQuery & query, ASTStora
     info.expanded_other = false;
     query_context->getMacros()->expand(maybe_replica, info);
     bool maybe_replica_macros = info.expanded_other;
-    bool enable_functional_tests_helper = getContext()->getConfigRef().has("_functional_tests_helper_database_replicated_replace_args_macros");
+    bool enable_functional_tests_helper = getContext()->getConfig()->has("_functional_tests_helper_database_replicated_replace_args_macros");
 
     if (maybe_shard_macros && maybe_replica_macros)
         return;

--- a/src/Databases/TablesLoader.cpp
+++ b/src/Databases/TablesLoader.cpp
@@ -34,7 +34,7 @@ TablesLoader::TablesLoader(ContextMutablePtr global_context_, Databases database
 
 LoadTaskPtrs TablesLoader::loadTablesAsync(LoadJobSet load_after)
 {
-    bool need_resolve_dependencies = !global_context->getConfigRef().has("ignore_table_dependencies_on_metadata_loading");
+    bool need_resolve_dependencies = !global_context->getConfig()->has("ignore_table_dependencies_on_metadata_loading");
 
     /// Load all Lazy, MySQL, PostgreSQL, SQLite, etc databases first.
     /// Note that this loading is NOT async because it should be fast and it cannot have any dependencies

--- a/src/Disks/DiskFomAST.cpp
+++ b/src/Disks/DiskFomAST.cpp
@@ -76,7 +76,7 @@ std::string getOrCreateCustomDisk(DiskConfigurationPtr config, const std::string
     if (!attach && !disk->isRemote())
     {
         static constexpr auto custom_local_disks_base_dir_in_config = "custom_local_disks_base_directory";
-        auto disk_path_expected_prefix = context->getConfigRef().getString(custom_local_disks_base_dir_in_config, "");
+        auto disk_path_expected_prefix = context->getConfig()->getString(custom_local_disks_base_dir_in_config, "");
 
         if (disk_path_expected_prefix.empty())
             throw Exception(

--- a/src/Disks/ObjectStorages/Cached/registerDiskCache.cpp
+++ b/src/Disks/ObjectStorages/Cached/registerDiskCache.cpp
@@ -54,7 +54,7 @@ void registerDiskCache(DiskFactory & factory, bool /* global_skip_access_check *
         if (custom_disk)
         {
             static constexpr auto custom_cached_disks_base_dir_in_config = "custom_cached_disks_base_directory";
-            auto custom_cached_disk_path_prefix = context->getConfigRef().getString(custom_cached_disks_base_dir_in_config, config_fs_caches_dir);
+            auto custom_cached_disk_path_prefix = context->getConfig()->getString(custom_cached_disks_base_dir_in_config, config_fs_caches_dir);
             if (custom_cached_disk_path_prefix.empty())
             {
                 if (!attach)

--- a/src/Disks/ObjectStorages/DiskObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/DiskObjectStorage.cpp
@@ -443,7 +443,8 @@ void DiskObjectStorage::startupImpl(ContextPtr context)
     LOG_INFO(log, "Starting up disk {}", name);
     object_storage->startup();
 
-    restoreMetadataIfNeeded(context->getConfigRef(), "storage_configuration.disks." + name, context);
+    auto config = context->getConfig();
+    restoreMetadataIfNeeded(*config, "storage_configuration.disks." + name, context);
 
     LOG_INFO(log, "Disk {} started up", name);
 }
@@ -544,12 +545,13 @@ bool DiskObjectStorage::supportsHardLinks() const
 DiskObjectStoragePtr DiskObjectStorage::createDiskObjectStorage()
 {
     const auto config_prefix = "storage_configuration.disks." + name;
+    auto config = Context::getGlobalContextInstance()->getConfig();
     return std::make_shared<DiskObjectStorage>(
         getName(),
         object_key_prefix,
         metadata_storage,
         object_storage,
-        Context::getGlobalContextInstance()->getConfigRef(),
+        *config,
         config_prefix);
 }
 

--- a/src/Disks/ObjectStorages/HDFS/HDFSObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/HDFS/HDFSObjectStorage.cpp
@@ -32,7 +32,7 @@ void HDFSObjectStorage::initializeHDFSFS() const
     if (initialized)
         return;
 
-    hdfs_builder = createHDFSBuilder(url, config);
+    hdfs_builder = createHDFSBuilder(url, *config);
     hdfs_fs = createHDFSFS(hdfs_builder.get());
     initialized = true;
 }
@@ -84,7 +84,7 @@ std::unique_ptr<ReadBufferFromFileBase> HDFSObjectStorage::readObject( /// NOLIN
     return std::make_unique<ReadBufferFromHDFS>(
         fs::path(url_without_path) / "",
         fs::path(data_directory) / path,
-        config,
+        *config,
         patchSettings(read_settings),
         /* read_until_position */0,
         read_settings.remote_read_buffer_use_external_buffer);
@@ -108,7 +108,7 @@ std::unique_ptr<WriteBufferFromFileBase> HDFSObjectStorage::writeObject( /// NOL
     return std::make_unique<WriteBufferFromHDFS>(
         url_without_path,
         fs::path(data_directory) / path,
-        config,
+        *config,
         settings->replication,
         patchSettings(write_settings),
         buf_size,

--- a/src/Disks/ObjectStorages/HDFS/HDFSObjectStorage.h
+++ b/src/Disks/ObjectStorages/HDFS/HDFSObjectStorage.h
@@ -35,9 +35,9 @@ public:
     HDFSObjectStorage(
         const String & hdfs_root_path_,
         SettingsPtr settings_,
-        const Poco::Util::AbstractConfiguration & config_,
+        ContextPtr context,
         bool lazy_initialize)
-        : config(config_)
+        : config(context->getConfig())
         , settings(std::move(settings_))
         , log(getLogger("HDFSObjectStorage(" + hdfs_root_path_ + ")"))
     {
@@ -117,7 +117,7 @@ private:
     void initializeHDFSFS() const;
     std::string extractObjectKeyFromURL(const StoredObject & object) const;
 
-    const Poco::Util::AbstractConfiguration & config;
+    Poco::AutoPtr<Poco::Util::AbstractConfiguration> config;
 
     mutable HDFSBuilderWrapper hdfs_builder;
     mutable HDFSFSPtr hdfs_fs;

--- a/src/Disks/ObjectStorages/ObjectStorageFactory.cpp
+++ b/src/Disks/ObjectStorages/ObjectStorageFactory.cpp
@@ -279,7 +279,7 @@ void registerHDFSObjectStorage(ObjectStorageFactory & factory)
             std::unique_ptr<HDFSObjectStorageSettings> settings = std::make_unique<HDFSObjectStorageSettings>(
                 config.getUInt64(config_prefix + ".min_bytes_for_seek", 1024 * 1024), context->getSettingsRef()[Setting::hdfs_replication]);
 
-            return createObjectStorage<HDFSObjectStorage>(ObjectStorageType::HDFS, config, config_prefix, uri, std::move(settings), config, /* lazy_initialize */false);
+            return createObjectStorage<HDFSObjectStorage>(ObjectStorageType::HDFS, config, config_prefix, uri, std::move(settings), context, /* lazy_initialize */false);
         });
 }
 #endif

--- a/src/Functions/UserDefined/createUserDefinedSQLObjectsStorage.cpp
+++ b/src/Functions/UserDefined/createUserDefinedSQLObjectsStorage.cpp
@@ -22,10 +22,10 @@ std::unique_ptr<IUserDefinedSQLObjectsStorage> createUserDefinedSQLObjectsStorag
     const String zookeeper_path_key = "user_defined_zookeeper_path";
     const String disk_path_key = "user_defined_path";
 
-    const auto & config = global_context->getConfigRef();
-    if (config.has(zookeeper_path_key))
+    auto config = global_context->getConfig();
+    if (config->has(zookeeper_path_key))
     {
-        if (config.has(disk_path_key))
+        if (config->has(disk_path_key))
         {
             throw Exception(
                 ErrorCodes::INVALID_CONFIG_PARAMETER,
@@ -33,11 +33,11 @@ std::unique_ptr<IUserDefinedSQLObjectsStorage> createUserDefinedSQLObjectsStorag
                 zookeeper_path_key,
                 disk_path_key);
         }
-        return std::make_unique<UserDefinedSQLObjectsZooKeeperStorage>(global_context, config.getString(zookeeper_path_key));
+        return std::make_unique<UserDefinedSQLObjectsZooKeeperStorage>(global_context, config->getString(zookeeper_path_key));
     }
 
     String default_path = fs::path{global_context->getPath()} / "user_defined" / "";
-    String path = config.getString(disk_path_key, default_path);
+    String path = config->getString(disk_path_key, default_path);
     return std::make_unique<UserDefinedSQLObjectsDiskStorage>(global_context, path);
 }
 

--- a/src/Functions/catboostEvaluate.cpp
+++ b/src/Functions/catboostEvaluate.cpp
@@ -50,7 +50,7 @@ public:
 
     void initBridge(const ColumnConst * name_col) const
     {
-        String library_path = getContext()->getConfigRef().getString("catboost_lib_path");
+        String library_path = getContext()->getConfig()->getString("catboost_lib_path");
         if (!std::filesystem::exists(library_path))
             throw Exception(ErrorCodes::FILE_DOESNT_EXIST, "Can't load library {}: file doesn't exist", library_path);
 

--- a/src/Functions/serverConstants.cpp
+++ b/src/Functions/serverConstants.cpp
@@ -140,7 +140,7 @@ namespace
     {
     public:
         static constexpr auto name = "displayName";
-        explicit FunctionDisplayName(ContextPtr context) : FunctionServerConstantBase(context->getConfigRef().getString("display_name", getFQDNOrHostName()), context->isDistributed()) {}
+        explicit FunctionDisplayName(ContextPtr context) : FunctionServerConstantBase(context->getConfig()->getString("display_name", getFQDNOrHostName()), context->isDistributed()) {}
         static FunctionPtr create(ContextPtr context) {return std::make_shared<FunctionDisplayName>(context); }
     };
 }

--- a/src/IO/S3/Client.cpp
+++ b/src/IO/S3/Client.cpp
@@ -986,7 +986,8 @@ PocoHTTPClientConfiguration ClientFactory::createClientConfiguration( // NOLINT
 {
     auto context = Context::getGlobalContextInstance();
     chassert(context);
-    auto proxy_configuration_resolver = ProxyConfigurationResolverProvider::get(ProxyConfiguration::protocolFromString(protocol), context->getConfigRef());
+    auto config_snapshot = context->getConfig();
+    auto proxy_configuration_resolver = ProxyConfigurationResolverProvider::get(ProxyConfiguration::protocolFromString(protocol), *config_snapshot);
 
     auto per_request_configuration = [=]{ return proxy_configuration_resolver->resolve(); };
     auto error_report = [=](const ProxyConfiguration & req) { proxy_configuration_resolver->errorReport(req); };

--- a/src/IO/S3/URI.cpp
+++ b/src/IO/S3/URI.cpp
@@ -60,7 +60,7 @@ URI::URI(const std::string & uri_, bool allow_archive_path_syntax)
     auto context = Context::getGlobalContextInstance();
     if (context)
     {
-        const auto *config = &context->getConfigRef();
+        auto config = context->getConfig();
         if (config->has("url_scheme_mappers"))
         {
             std::vector<String> config_keys;

--- a/src/Interpreters/Context.h
+++ b/src/Interpreters/Context.h
@@ -21,6 +21,7 @@
 #include <Parsers/IAST_fwd.h>
 #include <Server/HTTP/HTTPContext.h>
 #include <Storages/IStorage_fwd.h>
+#include <Poco/Util/LayeredConfiguration.h>
 
 #include "config.h"
 
@@ -614,7 +615,8 @@ public:
 
     /// Global application configuration settings.
     void setConfig(const ConfigurationPtr & config);
-    const Poco::Util::AbstractConfiguration & getConfigRef() const;
+    void setReloadedConfig(const ConfigurationPtr & config);
+    ConfigurationPtr getConfig() const;
 
     AccessControl & getAccessControl();
     const AccessControl & getAccessControl() const;

--- a/src/Interpreters/DistributedQueryStatusSource.cpp
+++ b/src/Interpreters/DistributedQueryStatusSource.cpp
@@ -144,11 +144,11 @@ ExecutionStatus DistributedQueryStatusSource::getExecutionStatus(const fs::path 
 
 ZooKeeperRetriesInfo DistributedQueryStatusSource::getRetriesInfo()
 {
-    const auto & config_ref = Context::getGlobalContextInstance()->getConfigRef();
+    auto config = Context::getGlobalContextInstance()->getConfig();
     return ZooKeeperRetriesInfo(
-        config_ref.getInt("distributed_ddl_keeper_max_retries", 5),
-        config_ref.getInt("distributed_ddl_keeper_initial_backoff_ms", 100),
-        config_ref.getInt("distributed_ddl_keeper_max_backoff_ms", 5000));
+        config->getInt("distributed_ddl_keeper_max_retries", 5),
+        config->getInt("distributed_ddl_keeper_initial_backoff_ms", 100),
+        config->getInt("distributed_ddl_keeper_max_backoff_ms", 5000));
 }
 
 std::pair<String, UInt16> DistributedQueryStatusSource::parseHostAndPort(const String & host_id)

--- a/src/Interpreters/EmbeddedDictionaries.cpp
+++ b/src/Interpreters/EmbeddedDictionaries.cpp
@@ -35,7 +35,7 @@ bool EmbeddedDictionaries::reloadDictionary(
     const bool throw_on_error,
     const bool force_reload)
 {
-    const auto & config = getContext()->getConfigRef();
+    auto config = getContext()->getConfig();
 
     bool not_initialized = dictionary.get() == nullptr;
 
@@ -43,7 +43,7 @@ bool EmbeddedDictionaries::reloadDictionary(
     {
         try
         {
-            auto new_dictionary = reload_dictionary(config);
+            auto new_dictionary = reload_dictionary(*config);
             if (new_dictionary)
                 dictionary.set(std::move(new_dictionary));
         }
@@ -127,7 +127,7 @@ EmbeddedDictionaries::EmbeddedDictionaries(
     : WithContext(context_)
     , log(getLogger("EmbeddedDictionaries"))
     , geo_dictionaries_loader(std::move(geo_dictionaries_loader_))
-    , reload_period(getContext()->getConfigRef().getInt("builtin_dictionaries_reload_interval", 3600))
+    , reload_period(getContext()->getConfig()->getInt("builtin_dictionaries_reload_interval", 3600))
 {
     reloadImpl(throw_on_error);
     reloading_thread = ThreadFromGlobalPool([this] { reloadPeriodically(); });

--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -1788,7 +1788,7 @@ bool InterpreterCreateQuery::doCreateTable(ASTCreateQuery & create,
             !getContext()->getZooKeeperMetadataTransaction()->isInitialQuery() &&
             !DatabaseCatalog::instance().hasUUIDMapping(create.uuid) &&
             Context::getGlobalContextInstance()->isServerCompletelyStarted() &&
-            Context::getGlobalContextInstance()->getConfigRef().getBool("allow_moving_table_directory_to_trash", false))
+            Context::getGlobalContextInstance()->getConfig()->getBool("allow_moving_table_directory_to_trash", false))
         {
             /// This is a secondary query from a Replicated database. It cannot be retried with another UUID, we must execute it as is.
             /// We don't have a table with this UUID (and all metadata is loaded),

--- a/src/Interpreters/TransactionLog.cpp
+++ b/src/Interpreters/TransactionLog.cpp
@@ -45,11 +45,12 @@ catch (...)
 
 TransactionLog::TransactionLog()
     : global_context(Context::getGlobalContextInstance())
+    , config(global_context->getConfig())
     , log(getLogger("TransactionLog"))
-    , zookeeper_path(global_context->getConfigRef().getString("transaction_log.zookeeper_path", "/clickhouse/txn"))
+    , zookeeper_path(config->getString("transaction_log.zookeeper_path", "/clickhouse/txn"))
     , zookeeper_path_log(zookeeper_path + "/log")
-    , fault_probability_before_commit(global_context->getConfigRef().getDouble("transaction_log.fault_probability_before_commit", 0))
-    , fault_probability_after_commit(global_context->getConfigRef().getDouble("transaction_log.fault_probability_after_commit", 0))
+    , fault_probability_before_commit(config->getDouble("transaction_log.fault_probability_before_commit", 0))
+    , fault_probability_after_commit(config->getDouble("transaction_log.fault_probability_after_commit", 0))
 {
     loadLogFromZooKeeper();
 

--- a/src/Interpreters/TransactionLog.h
+++ b/src/Interpreters/TransactionLog.h
@@ -154,6 +154,7 @@ private:
     CSN getCSNImpl(const TIDHash & tid_hash, const std::atomic<CSN> * failback_with_strict_load_csn = nullptr) const;
 
     const ContextPtr global_context;
+    Poco::AutoPtr<Poco::Util::AbstractConfiguration> config;
     LoggerPtr const log;
 
     /// The newest snapshot available for reading

--- a/src/Interpreters/evaluateConstantExpression.cpp
+++ b/src/Interpreters/evaluateConstantExpression.cpp
@@ -222,7 +222,7 @@ ASTPtr evaluateConstantExpressionForDatabaseName(const ASTPtr & node, const Cont
         {
             /// Table was created on older version of ClickHouse and CREATE contains not folded expression.
             /// Current database is not set yet during server startup, so we cannot evaluate it correctly.
-            literal.value = context->getConfigRef().getString("default_database", "default");
+            literal.value = context->getConfig()->getString("default_database", "default");
         }
         else
             literal.value = current_database;

--- a/src/Interpreters/executeQuery.cpp
+++ b/src/Interpreters/executeQuery.cpp
@@ -375,7 +375,7 @@ static UInt64 getQueryMetricLogInterval(ContextPtr context)
     const auto & settings = context->getSettingsRef();
     auto interval_milliseconds = settings[Setting::query_metric_log_interval];
     if (interval_milliseconds < 0)
-        interval_milliseconds = context->getConfigRef().getUInt64("query_metric_log.collect_interval_milliseconds", 1000);
+        interval_milliseconds = context->getConfig()->getUInt64("query_metric_log.collect_interval_milliseconds", 1000);
 
     return interval_milliseconds;
 }

--- a/src/Interpreters/loadMetadata.cpp
+++ b/src/Interpreters/loadMetadata.cpp
@@ -140,7 +140,7 @@ static void checkUnsupportedVersion(ContextMutablePtr context, const String & da
 
 static void checkIncompleteOrdinaryToAtomicConversion(ContextPtr context, const std::map<String, String> & databases)
 {
-    if (context->getConfigRef().has("allow_reserved_database_name_tmp_convert"))
+    if (context->getConfig()->has("allow_reserved_database_name_tmp_convert"))
         return;
 
     auto convert_flag_path = fs::path(context->getFlagsPath()) / "convert_ordinary_to_atomic";

--- a/src/Processors/Merges/Algorithms/Graphite.cpp
+++ b/src/Processors/Merges/Algorithms/Graphite.cpp
@@ -437,27 +437,27 @@ static const Pattern & appendGraphitePattern(
 
 void setGraphitePatternsFromConfig(ContextPtr context, const String & config_element, Graphite::Params & params)
 {
-    const auto & config = context->getConfigRef();
+    auto config = context->getConfig();
 
-    if (!config.has(config_element))
+    if (!config->has(config_element))
         throw Exception(ErrorCodes::NO_ELEMENTS_IN_CONFIG, "No '{}' element in configuration file", config_element);
 
     params.config_name = config_element;
-    params.path_column_name = config.getString(config_element + ".path_column_name", "Path");
-    params.time_column_name = config.getString(config_element + ".time_column_name", "Time");
-    params.value_column_name = config.getString(config_element + ".value_column_name", "Value");
-    params.version_column_name = config.getString(config_element + ".version_column_name", "Timestamp");
+    params.path_column_name = config->getString(config_element + ".path_column_name", "Path");
+    params.time_column_name = config->getString(config_element + ".time_column_name", "Time");
+    params.value_column_name = config->getString(config_element + ".value_column_name", "Value");
+    params.version_column_name = config->getString(config_element + ".version_column_name", "Timestamp");
 
     params.patterns_typed = false;
 
     Poco::Util::AbstractConfiguration::Keys keys;
-    config.keys(config_element, keys);
+    config->keys(config_element, keys);
 
     for (const auto & key : keys)
     {
         if (startsWith(key, "pattern"))
         {
-            if (appendGraphitePattern(config, config_element + "." + key, params.patterns, false, context).rule_type != RuleTypeAll)
+            if (appendGraphitePattern(*config, config_element + "." + key, params.patterns, false, context).rule_type != RuleTypeAll)
                 params.patterns_typed = true;
         }
         else if (key == "default")
@@ -472,8 +472,8 @@ void setGraphitePatternsFromConfig(ContextPtr context, const String & config_ele
             throw Exception(ErrorCodes::UNKNOWN_ELEMENT_IN_CONFIG, "Unknown element in config: {}", key);
     }
 
-    if (config.has(config_element + ".default"))
-        appendGraphitePattern(config, config_element + "." + ".default", params.patterns, true, context);
+    if (config->has(config_element + ".default"))
+        appendGraphitePattern(*config, config_element + "." + ".default", params.patterns, true, context);
 
     for (const auto & pattern : params.patterns)
     {

--- a/src/Server/HTTP/authenticateUserByHTTP.cpp
+++ b/src/Server/HTTP/authenticateUserByHTTP.cpp
@@ -242,7 +242,7 @@ bool authenticateUserByHTTP(
     String forwarded_address = session.getClientInfo().getLastForwardedFor();
     try
     {
-        if (!forwarded_address.empty() && global_context->getConfigRef().getBool("auth_use_forwarded_address", false))
+        if (!forwarded_address.empty() && global_context->getConfig()->getBool("auth_use_forwarded_address", false))
             session.authenticate(*current_credentials, Poco::Net::SocketAddress(forwarded_address, request.clientAddress().port()));
         else
             session.authenticate(*current_credentials, request.clientAddress());

--- a/src/Server/ReplicasStatusHandler.cpp
+++ b/src/Server/ReplicasStatusHandler.cpp
@@ -36,13 +36,13 @@ void ReplicasStatusHandler::handleRequest(HTTPServerRequest & request, HTTPServe
     {
         HTMLForm params(getContext()->getSettingsRef(), request);
 
-        const auto & config = getContext()->getConfigRef();
+        auto config = getContext()->getConfig();
 
         const MergeTreeSettings & settings = getContext()->getReplicatedMergeTreeSettings();
 
         /// Even if lag is small, output detailed information about the lag.
         bool verbose = false;
-        bool enable_verbose = config.getBool("enable_verbose_replicas_status", true);
+        bool enable_verbose = config->getBool("enable_verbose_replicas_status", true);
 
         if (params.get("verbose", "") == "1" && enable_verbose)
             verbose = true;

--- a/src/Storages/Freeze.cpp
+++ b/src/Storages/Freeze.cpp
@@ -128,9 +128,9 @@ BlockIO Unfreezer::systemUnfreeze(const String & backup_name)
 {
     LOG_DEBUG(log, "Unfreezing backup {}", escapeForFileName(backup_name));
 
-    const auto & config = local_context->getConfigRef();
+    auto config = local_context->getConfig();
     static constexpr auto config_key = "enable_system_unfreeze";
-    if (!config.getBool(config_key, false))
+    if (!config->getBool(config_key, false))
     {
         throw Exception(ErrorCodes::SUPPORT_IS_DISABLED,
                         "Support for SYSTEM UNFREEZE query is disabled. You can enable it via '{}' server setting",

--- a/src/Storages/Hive/HiveFile.cpp
+++ b/src/Storages/Hive/HiveFile.cpp
@@ -166,7 +166,8 @@ Range HiveORCFile::buildRange(const orc::ColumnStatistics * col_stats)
 
 void HiveORCFile::prepareReader()
 {
-    in = std::make_unique<ReadBufferFromHDFS>(namenode_url, path, getContext()->getGlobalContext()->getConfigRef(), getContext()->getReadSettings());
+    auto config = getContext()->getGlobalContext()->getConfig();
+    in = std::make_unique<ReadBufferFromHDFS>(namenode_url, path, *config, getContext()->getReadSettings());
     auto format_settings = getFormatSettings(getContext());
     std::atomic<int> is_stopped{0};
     auto result = arrow::adapters::orc::ORCFileReader::Open(asArrowFile(*in, format_settings, is_stopped, "ORC", ORC_MAGIC_BYTES), ArrowMemoryPool::instance());
@@ -285,7 +286,8 @@ bool HiveParquetFile::useSplitMinMaxIndex() const
 
 void HiveParquetFile::prepareReader()
 {
-    in = std::make_unique<ReadBufferFromHDFS>(namenode_url, path, getContext()->getGlobalContext()->getConfigRef(), getContext()->getReadSettings());
+    auto config = getContext()->getGlobalContext()->getConfig();
+    in = std::make_unique<ReadBufferFromHDFS>(namenode_url, path, *config, getContext()->getReadSettings());
     auto format_settings = getFormatSettings(getContext());
     std::atomic<int> is_stopped{0};
     THROW_ARROW_NOT_OK(parquet::arrow::OpenFile(asArrowFile(*in, format_settings, is_stopped, "Parquet", PARQUET_MAGIC_BYTES), ArrowMemoryPool::instance(), &reader));

--- a/src/Storages/Hive/StorageHive.cpp
+++ b/src/Storages/Hive/StorageHive.cpp
@@ -241,12 +241,13 @@ public:
                     auto get_raw_read_buf = [&]() -> std::unique_ptr<ReadBuffer>
                     {
                         bool thread_pool_read = read_settings.remote_fs_method == RemoteFSReadMethod::threadpool;
+                        auto config = getContext()->getGlobalContext()->getConfig();
                         if (thread_pool_read)
                         {
                             auto buf = std::make_unique<ReadBufferFromHDFS>(
                                 hdfs_namenode_url,
                                 current_path,
-                                getContext()->getGlobalContext()->getConfigRef(),
+                                *config,
                                 getContext()->getReadSettings(),
                                 /* read_until_position */0,
                                 /* use_external_buffer */true);
@@ -258,7 +259,7 @@ public:
                         return std::make_unique<ReadBufferFromHDFS>(
                             hdfs_namenode_url,
                             current_path,
-                            getContext()->getGlobalContext()->getConfigRef(),
+                            *config,
                             getContext()->getReadSettings());
 
                     };
@@ -853,7 +854,8 @@ void StorageHive::read(
 {
     lazyInitialize();
 
-    HDFSBuilderWrapper builder = createHDFSBuilder(hdfs_namenode_url, context_->getGlobalContext()->getConfigRef());
+    auto config = context_->getGlobalContext()->getConfig();
+    HDFSBuilderWrapper builder = createHDFSBuilder(hdfs_namenode_url, *config);
     HDFSFSPtr fs = createHDFSFS(builder.get());
     auto hive_metastore_client = HiveMetastoreClientFactory::instance().getOrCreate(hive_metastore_url);
     auto hive_table_metadata = hive_metastore_client->getTableMetadata(hive_database, hive_table);
@@ -1064,7 +1066,8 @@ StorageHive::totalRowsImpl(const Settings & settings, const ActionsDAG * filter_
 
     auto hive_metastore_client = HiveMetastoreClientFactory::instance().getOrCreate(hive_metastore_url);
     auto hive_table_metadata = hive_metastore_client->getTableMetadata(hive_database, hive_table);
-    HDFSBuilderWrapper builder = createHDFSBuilder(hdfs_namenode_url, getContext()->getGlobalContext()->getConfigRef());
+    auto config = getContext()->getGlobalContext()->getConfig();
+    HDFSBuilderWrapper builder = createHDFSBuilder(hdfs_namenode_url, *config);
     HDFSFSPtr fs = createHDFSFS(builder.get());
     HiveFiles hive_files = collectHiveFiles(settings[Setting::max_threads], filter_actions_dag, hive_table_metadata, fs, context_, prune_level);
 

--- a/src/Storages/Kafka/StorageKafka.cpp
+++ b/src/Storages/Kafka/StorageKafka.cpp
@@ -430,8 +430,9 @@ KafkaConsumerPtr StorageKafka::createKafkaConsumer(size_t consumer_number)
 }
 cppkafka::Configuration StorageKafka::getConsumerConfiguration(size_t consumer_number)
 {
+    auto config = getContext()->getConfig();
     KafkaConfigLoader::ConsumerConfigParams params{
-        {getContext()->getConfigRef(), collection_name, topics, log},
+        {*config, collection_name, topics, log},
         brokers,
         group,
         num_consumers > 1,
@@ -443,8 +444,9 @@ cppkafka::Configuration StorageKafka::getConsumerConfiguration(size_t consumer_n
 
 cppkafka::Configuration StorageKafka::getProducerConfiguration()
 {
+    auto config = getContext()->getConfig();
     KafkaConfigLoader::ProducerConfigParams params{
-        {getContext()->getConfigRef(), collection_name, topics, log},
+        {*config, collection_name, topics, log},
         brokers,
         client_id};
     return KafkaConfigLoader::getProducerConfiguration(*this, params);

--- a/src/Storages/Kafka/StorageKafka2.cpp
+++ b/src/Storages/Kafka/StorageKafka2.cpp
@@ -454,8 +454,9 @@ KafkaConsumer2Ptr StorageKafka2::createConsumer(size_t consumer_number)
 
 cppkafka::Configuration StorageKafka2::getConsumerConfiguration(size_t consumer_number)
 {
+    auto config = getContext()->getConfig();
     KafkaConfigLoader::ConsumerConfigParams params{
-        {getContext()->getConfigRef(), collection_name, topics, log},
+        {*config, collection_name, topics, log},
         brokers,
         group,
         num_consumers > 1,
@@ -470,8 +471,9 @@ cppkafka::Configuration StorageKafka2::getConsumerConfiguration(size_t consumer_
 
 cppkafka::Configuration StorageKafka2::getProducerConfiguration()
 {
+    auto config = getContext()->getConfig();
     KafkaConfigLoader::ProducerConfigParams params{
-        {getContext()->getConfigRef(), collection_name, topics, log},
+        {*config, collection_name, topics, log},
         brokers,
         client_id};
     return KafkaConfigLoader::getProducerConfiguration(*this, params);

--- a/src/Storages/MergeTree/DataPartsExchange.cpp
+++ b/src/Storages/MergeTree/DataPartsExchange.cpp
@@ -139,7 +139,7 @@ void Service::processQuery(const HTMLForm & params, ReadBuffer & /*body*/, Write
 
     LOG_TRACE(log, "Sending part {}", part_name);
 
-    static const auto test_delay = data.getContext()->getConfigRef().getUInt64("test.data_parts_exchange.delay_before_sending_part_ms", 0);
+    static const auto test_delay = data.getContext()->getConfig()->getUInt64("test.data_parts_exchange.delay_before_sending_part_ms", 0);
     if (test_delay)
         randomDelayForMaxMilliseconds(test_delay, log, "DataPartsExchange: Before sending part");
 

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -8977,7 +8977,8 @@ std::pair<MergeTreeData::MutableDataPartPtr, scope_guard> MergeTreeData::createE
 
 bool MergeTreeData::allowRemoveStaleMovingParts() const
 {
-    return ConfigHelper::getBool(getContext()->getConfigRef(), "allow_remove_stale_moving_parts", /* default_ = */ true);
+    auto config = getContext()->getConfig();
+    return ConfigHelper::getBool(*config, "allow_remove_stale_moving_parts", /* default_ = */ true);
 }
 
 CurrentlySubmergingEmergingTagger::~CurrentlySubmergingEmergingTagger()

--- a/src/Storages/NATS/StorageNATS.cpp
+++ b/src/Storages/NATS/StorageNATS.cpp
@@ -104,14 +104,15 @@ StorageNATS::StorageNATS(
     auto nats_token = getContext()->getMacros()->expand((*nats_settings)[NATSSetting::nats_token]);
     auto nats_credential_file = getContext()->getMacros()->expand((*nats_settings)[NATSSetting::nats_credential_file]);
 
+    auto config = getContext()->getConfig();
     configuration =
     {
         .url = getContext()->getMacros()->expand((*nats_settings)[NATSSetting::nats_url]),
         .servers = parseList(getContext()->getMacros()->expand((*nats_settings)[NATSSetting::nats_server_list]), ','),
-        .username = nats_username.empty() ? getContext()->getConfigRef().getString("nats.user", "") : nats_username,
-        .password = nats_password.empty() ? getContext()->getConfigRef().getString("nats.password", "") : nats_password,
-        .token = nats_token.empty() ? getContext()->getConfigRef().getString("nats.token", "") : nats_token,
-        .credential_file = nats_credential_file.empty() ? getContext()->getConfigRef().getString("nats.credential_file", "") : nats_credential_file,
+        .username = nats_username.empty() ? config->getString("nats.user", "") : nats_username,
+        .password = nats_password.empty() ? config->getString("nats.password", "") : nats_password,
+        .token = nats_token.empty() ? config->getString("nats.token", "") : nats_token,
+        .credential_file = nats_credential_file.empty() ? config->getString("nats.credential_file", "") : nats_credential_file,
         .max_reconnect = static_cast<int>((*nats_settings)[NATSSetting::nats_max_reconnect].value),
         .reconnect_wait = static_cast<int>((*nats_settings)[NATSSetting::nats_reconnect_wait].value),
         .secure = (*nats_settings)[NATSSetting::nats_secure].value

--- a/src/Storages/ObjectStorage/HDFS/Configuration.cpp
+++ b/src/Storages/ObjectStorage/HDFS/Configuration.cpp
@@ -62,8 +62,7 @@ ObjectStoragePtr StorageHDFSConfiguration::createObjectStorage( /// NOLINT
     assertInitialized();
     const auto & settings = context->getSettingsRef();
     auto hdfs_settings = std::make_unique<HDFSObjectStorageSettings>(settings[Setting::remote_read_min_bytes_for_seek], settings[Setting::hdfs_replication]);
-    return std::make_shared<HDFSObjectStorage>(
-        url, std::move(hdfs_settings), context->getConfigRef(), /* lazy_initialize */true);
+    return std::make_shared<HDFSObjectStorage>(url, std::move(hdfs_settings), context, /* lazy_initialize */true);
 }
 
 std::string StorageHDFSConfiguration::getPathWithoutGlobs() const

--- a/src/Storages/ObjectStorage/S3/Configuration.cpp
+++ b/src/Storages/ObjectStorage/S3/Configuration.cpp
@@ -131,10 +131,10 @@ ObjectStoragePtr StorageS3Configuration::createObjectStorage(ContextPtr context,
 {
     assertInitialized();
 
-    const auto & config = context->getConfigRef();
+    const auto config = context->getConfig();
     const auto & settings = context->getSettingsRef();
 
-    auto s3_settings = getSettings(config, "s3" /* config_prefix */, context, url.uri_str, settings[Setting::s3_validate_request_settings]);
+    auto s3_settings = getSettings(*config, "s3" /* config_prefix */, context, url.uri_str, settings[Setting::s3_validate_request_settings]);
 
     if (auto endpoint_settings = context->getStorageS3Settings().getSettings(url.uri.toString(), context->getUserName()))
     {
@@ -154,7 +154,7 @@ ObjectStoragePtr StorageS3Configuration::createObjectStorage(ContextPtr context,
 
     auto client = getClient(url, *s3_settings, context, /* for_disk_s3 */false);
     auto key_generator = createObjectStorageKeysGeneratorAsIsWithPrefix(url.key);
-    auto s3_capabilities = getCapabilitiesFromConfig(config, "s3");
+    auto s3_capabilities = getCapabilitiesFromConfig(*config, "s3");
 
     return std::make_shared<S3ObjectStorage>(
         std::move(client), std::move(s3_settings), url, s3_capabilities,

--- a/src/Storages/ObjectStorage/StorageObjectStorage.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorage.cpp
@@ -146,7 +146,8 @@ bool StorageObjectStorage::supportsSubsetOfColumns(const ContextPtr & context) c
 void StorageObjectStorage::Configuration::update(ObjectStoragePtr object_storage_ptr, ContextPtr context)
 {
     IObjectStorage::ApplyNewSettingsOptions options{.allow_client_change = !isStaticConfiguration()};
-    object_storage_ptr->applyNewSettings(context->getConfigRef(), getTypeName() + ".", context, options);
+    auto config = context->getConfig();
+    object_storage_ptr->applyNewSettings(*config, getTypeName() + ".", context, options);
 }
 namespace
 {
@@ -481,30 +482,29 @@ std::pair<ColumnsDescription, std::string> StorageObjectStorage::resolveSchemaAn
 
 SchemaCache & StorageObjectStorage::getSchemaCache(const ContextPtr & context, const std::string & storage_type_name)
 {
+    auto config = context->getConfig();
     if (storage_type_name == "s3")
     {
         static SchemaCache schema_cache(
-            context->getConfigRef().getUInt(
-                "schema_inference_cache_max_elements_for_s3",
-                DEFAULT_SCHEMA_CACHE_ELEMENTS));
+            config->getUInt("schema_inference_cache_max_elements_for_s3", DEFAULT_SCHEMA_CACHE_ELEMENTS));
         return schema_cache;
     }
     if (storage_type_name == "hdfs")
     {
         static SchemaCache schema_cache(
-            context->getConfigRef().getUInt("schema_inference_cache_max_elements_for_hdfs", DEFAULT_SCHEMA_CACHE_ELEMENTS));
+            config->getUInt("schema_inference_cache_max_elements_for_hdfs", DEFAULT_SCHEMA_CACHE_ELEMENTS));
         return schema_cache;
     }
     if (storage_type_name == "azure")
     {
         static SchemaCache schema_cache(
-            context->getConfigRef().getUInt("schema_inference_cache_max_elements_for_azure", DEFAULT_SCHEMA_CACHE_ELEMENTS));
+            config->getUInt("schema_inference_cache_max_elements_for_azure", DEFAULT_SCHEMA_CACHE_ELEMENTS));
         return schema_cache;
     }
     if (storage_type_name == "local")
     {
         static SchemaCache schema_cache(
-            context->getConfigRef().getUInt("schema_inference_cache_max_elements_for_local", DEFAULT_SCHEMA_CACHE_ELEMENTS));
+            config->getUInt("schema_inference_cache_max_elements_for_local", DEFAULT_SCHEMA_CACHE_ELEMENTS));
         return schema_cache;
     }
     throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Unsupported storage type: {}", storage_type_name);

--- a/src/Storages/RabbitMQ/StorageRabbitMQ.cpp
+++ b/src/Storages/RabbitMQ/StorageRabbitMQ.cpp
@@ -142,7 +142,7 @@ StorageRabbitMQ::StorageRabbitMQ(
         std::find_if(queue_settings_list.begin(), queue_settings_list.end(),
                      [](const String & name) { return name.starts_with(deadletter_exchange_setting); });
 
-    const auto & config = getContext()->getConfigRef();
+    auto config = getContext()->getConfig();
 
     std::pair<String, UInt16> parsed_address;
     auto setting_rabbitmq_username = (*rabbitmq_settings)[RabbitMQSetting::rabbitmq_username].value;
@@ -151,8 +151,8 @@ StorageRabbitMQ::StorageRabbitMQ(
 
     if ((*rabbitmq_settings)[RabbitMQSetting::rabbitmq_host_port].changed)
     {
-        username = setting_rabbitmq_username.empty() ? config.getString("rabbitmq.username", "") : setting_rabbitmq_username;
-        password = setting_rabbitmq_password.empty() ? config.getString("rabbitmq.password", "") : setting_rabbitmq_password;
+        username = setting_rabbitmq_username.empty() ? config->getString("rabbitmq.username", "") : setting_rabbitmq_username;
+        password = setting_rabbitmq_password.empty() ? config->getString("rabbitmq.password", "") : setting_rabbitmq_password;
         if (username.empty() || password.empty())
             throw Exception(
                 ErrorCodes::BAD_ARGUMENTS,
@@ -175,7 +175,7 @@ StorageRabbitMQ::StorageRabbitMQ(
         .port = parsed_address.second,
         .username = username,
         .password = password,
-        .vhost = config.getString("rabbitmq.vhost", getContext()->getMacros()->expand((*rabbitmq_settings)[RabbitMQSetting::rabbitmq_vhost])),
+        .vhost = config->getString("rabbitmq.vhost", getContext()->getMacros()->expand((*rabbitmq_settings)[RabbitMQSetting::rabbitmq_vhost])),
         .secure = (*rabbitmq_settings)[RabbitMQSetting::rabbitmq_secure].value,
         .connection_string = getContext()->getMacros()->expand((*rabbitmq_settings)[RabbitMQSetting::rabbitmq_address])
     };

--- a/src/Storages/RocksDB/StorageEmbeddedRocksDB.cpp
+++ b/src/Storages/RocksDB/StorageEmbeddedRocksDB.cpp
@@ -447,10 +447,10 @@ void StorageEmbeddedRocksDB::initDB()
     rocksdb::Options merged = base;
     rocksdb::BlockBasedTableOptions table_options;
 
-    const auto & config = getContext()->getConfigRef();
-    if (config.has("rocksdb.options"))
+    auto config = getContext()->getConfig();
+    if (config->has("rocksdb.options"))
     {
-        auto config_options = getOptionsFromConfig(config, "rocksdb.options");
+        auto config_options = getOptionsFromConfig(*config, "rocksdb.options");
         status = rocksdb::GetDBOptionsFromMap({}, merged, config_options, &merged);
         if (!status.ok())
         {
@@ -458,9 +458,9 @@ void StorageEmbeddedRocksDB::initDB()
                 rocksdb_dir, status.ToString());
         }
     }
-    if (config.has("rocksdb.column_family_options"))
+    if (config->has("rocksdb.column_family_options"))
     {
-        auto column_family_options = getOptionsFromConfig(config, "rocksdb.column_family_options");
+        auto column_family_options = getOptionsFromConfig(*config, "rocksdb.column_family_options");
         status = rocksdb::GetColumnFamilyOptionsFromMap({}, merged, column_family_options, &merged);
         if (!status.ok())
         {
@@ -468,9 +468,9 @@ void StorageEmbeddedRocksDB::initDB()
                 rocksdb_dir, status.ToString());
         }
     }
-    if (config.has("rocksdb.block_based_table_options"))
+    if (config->has("rocksdb.block_based_table_options"))
     {
-        auto block_based_table_options = getOptionsFromConfig(config, "rocksdb.block_based_table_options");
+        auto block_based_table_options = getOptionsFromConfig(*config, "rocksdb.block_based_table_options");
         status = rocksdb::GetBlockBasedTableOptionsFromMap({}, table_options, block_based_table_options, &table_options);
         if (!status.ok())
         {
@@ -479,23 +479,23 @@ void StorageEmbeddedRocksDB::initDB()
         }
     }
 
-    if (config.has("rocksdb.tables"))
+    if (config->has("rocksdb.tables"))
     {
         auto table_name = getStorageID().getTableName();
 
         Poco::Util::AbstractConfiguration::Keys keys;
-        config.keys("rocksdb.tables", keys);
+        config->keys("rocksdb.tables", keys);
 
         for (const auto & key : keys)
         {
             const String key_prefix = "rocksdb.tables." + key;
-            if (config.getString(key_prefix + ".name") != table_name)
+            if (config->getString(key_prefix + ".name") != table_name)
                 continue;
 
             String config_key = key_prefix + ".options";
-            if (config.has(config_key))
+            if (config->has(config_key))
             {
-                auto table_config_options = getOptionsFromConfig(config, config_key);
+                auto table_config_options = getOptionsFromConfig(*config, config_key);
                 status = rocksdb::GetDBOptionsFromMap({}, merged, table_config_options, &merged);
                 if (!status.ok())
                 {
@@ -505,9 +505,9 @@ void StorageEmbeddedRocksDB::initDB()
             }
 
             config_key = key_prefix + ".column_family_options";
-            if (config.has(config_key))
+            if (config->has(config_key))
             {
-                auto table_column_family_options = getOptionsFromConfig(config, config_key);
+                auto table_column_family_options = getOptionsFromConfig(*config, config_key);
                 status = rocksdb::GetColumnFamilyOptionsFromMap({}, merged, table_column_family_options, &merged);
                 if (!status.ok())
                 {
@@ -517,9 +517,9 @@ void StorageEmbeddedRocksDB::initDB()
             }
 
             config_key = key_prefix + ".block_based_table_options";
-            if (config.has(config_key))
+            if (config->has(config_key))
             {
-                auto block_based_table_options = getOptionsFromConfig(config, config_key);
+                auto block_based_table_options = getOptionsFromConfig(*config, config_key);
                 status = rocksdb::GetBlockBasedTableOptionsFromMap({}, table_options, block_based_table_options, &table_options);
                 if (!status.ok())
                 {

--- a/src/Storages/StorageDictionary.cpp
+++ b/src/Storages/StorageDictionary.cpp
@@ -198,7 +198,7 @@ void StorageDictionary::startup()
 {
     auto global_context = getContext();
 
-    bool lazy_load = global_context->getConfigRef().getBool("dictionaries_lazy_load", true);
+    bool lazy_load = global_context->getConfig()->getBool("dictionaries_lazy_load", true);
     if (!lazy_load)
     {
         const auto & external_dictionaries_loader = global_context->getExternalDictionariesLoader();
@@ -333,7 +333,7 @@ void registerStorageDictionary(StorageFactory & factory)
             auto abstract_dictionary_configuration = getDictionaryConfigurationFromAST(args.query, local_context, dictionary_id.database_name);
             auto result_storage = std::make_shared<StorageDictionary>(dictionary_id, abstract_dictionary_configuration, local_context);
 
-            bool lazy_load = local_context->getConfigRef().getBool("dictionaries_lazy_load", true);
+            bool lazy_load = local_context->getConfig()->getBool("dictionaries_lazy_load", true);
             if (args.mode <= LoadingStrictnessLevel::CREATE && !lazy_load)
             {
                 /// load() is called here to force loading the dictionary, wait until the loading is finished,

--- a/src/Storages/StorageFile.cpp
+++ b/src/Storages/StorageFile.cpp
@@ -2223,7 +2223,7 @@ void registerStorageFile(StorageFactory & factory)
 
 SchemaCache & StorageFile::getSchemaCache(const ContextPtr & context)
 {
-    static SchemaCache schema_cache(context->getConfigRef().getUInt("schema_inference_cache_max_elements_for_file", DEFAULT_SCHEMA_CACHE_ELEMENTS));
+    static SchemaCache schema_cache(context->getConfig()->getUInt("schema_inference_cache_max_elements_for_file", DEFAULT_SCHEMA_CACHE_ELEMENTS));
     return schema_cache;
 }
 

--- a/src/Storages/StorageKeeperMap.cpp
+++ b/src/Storages/StorageKeeperMap.cpp
@@ -360,7 +360,7 @@ StorageKeeperMap::StorageKeeperMap(
     , keys_limit(keys_limit_)
     , log(getLogger(fmt::format("StorageKeeperMap ({})", table_id.getNameForLogs())))
 {
-    std::string path_prefix = context_->getConfigRef().getString("keeper_map_path_prefix", "");
+    std::string path_prefix = context_->getConfig()->getString("keeper_map_path_prefix", "");
     if (path_prefix.empty())
         throw Exception(ErrorCodes::BAD_ARGUMENTS, "KeeperMap is disabled because 'keeper_map_path_prefix' config is not defined");
 
@@ -383,7 +383,7 @@ StorageKeeperMap::StorageKeeperMap(
     if (!zk_root_path.starts_with('/'))
         throw Exception(ErrorCodes::BAD_ARGUMENTS, "zk_root_path should start with '/'");
 
-    auto config_keys_limit = context_->getConfigRef().getUInt64("keeper_map_keys_limit", 0);
+    auto config_keys_limit = context_->getConfig()->getUInt64("keeper_map_keys_limit", 0);
     if (config_keys_limit != 0 && (keys_limit == 0 || keys_limit > config_keys_limit))
     {
         LOG_WARNING(

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -1606,7 +1606,7 @@ void StorageReplicatedMergeTree::paranoidCheckForCoveredPartsInZooKeeperOnStart(
     constexpr bool paranoid_check_for_covered_parts_default = false;
 #endif
 
-    bool paranoid_check_for_covered_parts = Context::getGlobalContextInstance()->getConfigRef().getBool(
+    bool paranoid_check_for_covered_parts = Context::getGlobalContextInstance()->getConfig()->getBool(
         "replicated_merge_tree_paranoid_check_on_startup", paranoid_check_for_covered_parts_default);
     if (!paranoid_check_for_covered_parts)
         return;
@@ -2477,7 +2477,7 @@ static void paranoidCheckForCoveredPartsInZooKeeper(
     constexpr bool paranoid_check_for_covered_parts_default = false;
 #endif
 
-    bool paranoid_check_for_covered_parts = Context::getGlobalContextInstance()->getConfigRef().getBool(
+    bool paranoid_check_for_covered_parts = Context::getGlobalContextInstance()->getConfig()->getBool(
         "replicated_merge_tree_paranoid_check_on_drop_range", paranoid_check_for_covered_parts_default);
     if (!paranoid_check_for_covered_parts)
         return;
@@ -3237,7 +3237,7 @@ void StorageReplicatedMergeTree::cloneReplica(const String & source_replica, Coo
     Strings active_parts = get_part_set.getParts();
 
     /// Remove local parts if source replica does not have them, because such parts will never be fetched by other replicas.
-    static const auto test_delay = getContext()->getConfigRef().getUInt64("test.clone_replica.delay_before_removing_local_parts_ms", 0);
+    static const auto test_delay = getContext()->getConfig()->getUInt64("test.clone_replica.delay_before_removing_local_parts_ms", 0);
     if (test_delay)
         randomDelayForMaxMilliseconds(test_delay, log.load(), "cloneReplica: Before removing local parts");
 

--- a/src/Storages/StorageURL.cpp
+++ b/src/Storages/StorageURL.cpp
@@ -235,7 +235,8 @@ namespace
     {
         auto protocol = protocol_string == "https" ? ProxyConfigurationResolver::Protocol::HTTPS
                                              : ProxyConfigurationResolver::Protocol::HTTP;
-        return ProxyConfigurationResolverProvider::get(protocol, Context::getGlobalContextInstance()->getConfigRef())->resolve();
+        auto config = Context::getGlobalContextInstance()->getConfig();
+        return ProxyConfigurationResolverProvider::get(protocol, *config)->resolve();
     }
 }
 
@@ -1372,7 +1373,7 @@ SinkToStoragePtr IStorageURLBase::write(const ASTPtr & query, const StorageMetad
 
 SchemaCache & IStorageURLBase::getSchemaCache(const ContextPtr & context)
 {
-    static SchemaCache schema_cache(context->getConfigRef().getUInt("schema_inference_cache_max_elements_for_url", DEFAULT_SCHEMA_CACHE_ELEMENTS));
+    static SchemaCache schema_cache(context->getConfig()->getUInt("schema_inference_cache_max_elements_for_url", DEFAULT_SCHEMA_CACHE_ELEMENTS));
     return schema_cache;
 }
 

--- a/src/Storages/System/StorageSystemServerSettings.cpp
+++ b/src/Storages/System/StorageSystemServerSettings.cpp
@@ -36,9 +36,9 @@ ColumnsDescription StorageSystemServerSettings::getColumnsDescription()
 
 void StorageSystemServerSettings::fillData(MutableColumns & res_columns, ContextPtr context, const ActionsDAG::Node *, std::vector<UInt8>) const
 {
-    const auto & config = context->getConfigRef();
+    auto config = context->getConfig();
     ServerSettings settings;
-    settings.loadSettingsFromConfig(config);
+    settings.loadSettingsFromConfig(*config);
 
     ServerSettingColumnsParams params{res_columns, context};
     settings.dumpToSystemServerSettingsColumns(params);

--- a/src/Storages/System/StorageSystemZooKeeper.cpp
+++ b/src/Storages/System/StorageSystemZooKeeper.cpp
@@ -272,7 +272,7 @@ void StorageSystemZooKeeper::read(
 
 SinkToStoragePtr StorageSystemZooKeeper::write(const ASTPtr &, const StorageMetadataPtr &, ContextPtr context, bool /*async_insert*/)
 {
-    if (!context->getConfigRef().getBool("allow_zookeeper_write", false))
+    if (!context->getConfig()->getBool("allow_zookeeper_write", false))
         throw Exception(ErrorCodes::BAD_ARGUMENTS, "Prohibit writing to system.zookeeper, unless config `allow_zookeeper_write` as true");
     Block write_header;
     write_header.insert(ColumnWithTypeAndName(std::make_shared<DataTypeString>(), "name"));

--- a/src/Storages/System/attachSystemTables.cpp
+++ b/src/Storages/System/attachSystemTables.cpp
@@ -241,7 +241,7 @@ void attachSystemTablesServer(ContextPtr context, IDatabase & system_database, b
         attach<StorageSystemZooKeeperConnection>(context, system_database, "zookeeper_connection", "Shows the information about current connections to [Zoo]Keeper (including auxiliary [ZooKeepers)");
     }
 
-    if (context->getConfigRef().getInt("allow_experimental_transactions", 0))
+    if (context->getConfig()->getInt("allow_experimental_transactions", 0))
         attach<StorageSystemTransactions>(context, system_database, "transactions", "Contains a list of transactions and their state.");
 }
 

--- a/tests/integration/test_config_not_overriding_args/configs/config_zk_include_test.xml
+++ b/tests/integration/test_config_not_overriding_args/configs/config_zk_include_test.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<clickhouse>
+  <shutdown_wait_unfinished>5</shutdown_wait_unfinished>
+  <include from_zk="/min_bytes_for_wide_part" merge="true"/>
+</clickhouse>

--- a/tests/integration/test_config_not_overriding_args/test.py
+++ b/tests/integration/test_config_not_overriding_args/test.py
@@ -1,0 +1,30 @@
+import pytest
+
+from helpers.client import QueryRuntimeException
+from helpers.cluster import ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__)
+node = cluster.add_instance(
+    "node",
+    main_configs=["configs/config_zk_include_test.xml"],
+    with_zookeeper=True,
+    extra_args="--shutdown_wait_unfinished 3",
+)
+
+
+@pytest.fixture(scope="module")
+def start_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def test_config_not_overriding_args(start_cluster):
+    assert (
+        node.query(
+            "select value from system.server_settings where name = 'shutdown_wait_unfinished'"
+        )
+        == "3\n"
+    )


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Rework configuration file reloading to properly handle reload configuration priorities and ownership. Now `Context::getConfig()`  returns an owned `Poco::Util::LayeredConfiguration` with the following priority layers:

| Configuration Type | Priority | Description |
|------------|----------|-------------|
| MapConfiguration | -200 | Server initialization arguments and settings |
| MapConfiguration | -100 | Poco application configuration (`application.*` settings) |
| XMLConfiguration | -1 | **[NEW]** Optional reloaded configuration file |
| XMLConfiguration | 0 | Main ClickHouse configuration file |
| SystemConfiguration | 100 | Poco default system properties and environment variables |

The key change is the introduction of a new XMLConfiguration layer with priority -1 that holds the reloaded configuration.

This addresses https://github.com/ClickHouse/ClickHouse/pull/34574/files#r805753489 and https://github.com/ClickHouse/ClickHouse/pull/62944#discussion_r1828099765

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---ci_include_fuzzer--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
