### PR TITLE
Fix copy/paste error 

### DIFF
--- a/src/Storages/AlterCommands.cpp
+++ b/src/Storages/AlterCommands.cpp
@@ -1496,7 +1496,7 @@ void AlterCommands::validate(const StoragePtr & table, ContextPtr context) const
                 if (command.to_remove == AlterCommand::RemoveProperty::CODEC && column_from_table.codec == nullptr)
                     throw Exception(
                         ErrorCodes::BAD_ARGUMENTS,
-                        "Column {} doesn't have TTL, cannot remove it",
+                        "Column {} doesn't have CODEC, cannot remove it",
                         backQuote(column_name));
                 if (command.to_remove == AlterCommand::RemoveProperty::COMMENT && column_from_table.comment.empty())
                     throw Exception(


### PR DESCRIPTION
fixes: https://github.com/ClickHouse/ClickHouse/issues/70752

I don't see an easy way to add a test for an error message, also it has a little sense, so I'd rather not.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
