### PR TITLE
We use `aarch64` everywhere in code, so the vars should reflect it

### DIFF
--- a/tests/ci/ci_config.py
+++ b/tests/ci/ci_config.py
@@ -51,11 +51,11 @@ class CI:
 
     TAG_CONFIGS = {
         Tags.DO_NOT_TEST_LABEL: LabelConfig(run_jobs=[JobNames.STYLE_CHECK]),
-        Tags.CI_SET_ARM: LabelConfig(
+        Tags.CI_SET_AARCH64: LabelConfig(
             run_jobs=[
                 JobNames.STYLE_CHECK,
                 BuildNames.PACKAGE_AARCH64,
-                JobNames.INTEGRATION_TEST_ARM,
+                JobNames.INTEGRATION_TEST_AARCH64,
             ]
         ),
         Tags.CI_SET_REQUIRED: LabelConfig(
@@ -95,16 +95,16 @@ class CI:
                 static_binary_name="aarch64",
                 additional_pkgs=True,
             ),
-            runner_type=Runners.BUILDER_ARM,
+            runner_type=Runners.BUILDER_AARCH64,
         ),
-        BuildNames.PACKAGE_ARM_ASAN: CommonJobConfigs.BUILD.with_properties(
+        BuildNames.PACKAGE_AARCH64_ASAN: CommonJobConfigs.BUILD.with_properties(
             build_config=BuildConfig(
-                name=BuildNames.PACKAGE_ARM_ASAN,
+                name=BuildNames.PACKAGE_AARCH64_ASAN,
                 compiler="clang-18-aarch64",
                 sanitizer="address",
                 package_type="deb",
             ),
-            runner_type=Runners.BUILDER_ARM,
+            runner_type=Runners.BUILDER_AARCH64,
         ),
         BuildNames.PACKAGE_ASAN: CommonJobConfigs.BUILD.with_properties(
             build_config=BuildConfig(
@@ -276,16 +276,16 @@ class CI:
         JobNames.INSTALL_TEST_AMD: CommonJobConfigs.INSTALL_TEST.with_properties(
             required_builds=[BuildNames.PACKAGE_RELEASE]
         ),
-        JobNames.INSTALL_TEST_ARM: CommonJobConfigs.INSTALL_TEST.with_properties(
+        JobNames.INSTALL_TEST_AARCH64: CommonJobConfigs.INSTALL_TEST.with_properties(
             required_builds=[BuildNames.PACKAGE_AARCH64],
-            runner_type=Runners.STYLE_CHECKER_ARM,
+            runner_type=Runners.STYLE_CHECKER_AARCH64,
         ),
         JobNames.STATEFUL_TEST_ASAN: CommonJobConfigs.STATEFUL_TEST.with_properties(
             required_builds=[BuildNames.PACKAGE_ASAN]
         ),
-        JobNames.STATEFUL_TEST_ARM_ASAN: CommonJobConfigs.STATEFUL_TEST.with_properties(
-            required_builds=[BuildNames.PACKAGE_ARM_ASAN],
-            runner_type=Runners.FUNC_TESTER_ARM,
+        JobNames.STATEFUL_TEST_AARCH64_ASAN: CommonJobConfigs.STATEFUL_TEST.with_properties(
+            required_builds=[BuildNames.PACKAGE_AARCH64_ASAN],
+            runner_type=Runners.FUNC_TESTER_AARCH64,
         ),
         JobNames.STATEFUL_TEST_TSAN: CommonJobConfigs.STATEFUL_TEST.with_properties(
             required_builds=[BuildNames.PACKAGE_TSAN]
@@ -307,7 +307,7 @@ class CI:
         ),
         JobNames.STATEFUL_TEST_AARCH64: CommonJobConfigs.STATEFUL_TEST.with_properties(
             required_builds=[BuildNames.PACKAGE_AARCH64],
-            runner_type=Runners.FUNC_TESTER_ARM,
+            runner_type=Runners.FUNC_TESTER_AARCH64,
         ),
         JobNames.STATEFUL_TEST_PARALLEL_REPL_RELEASE: CommonJobConfigs.STATEFUL_TEST.with_properties(
             required_builds=[BuildNames.PACKAGE_RELEASE]
@@ -335,10 +335,10 @@ class CI:
         JobNames.STATELESS_TEST_ASAN: CommonJobConfigs.STATELESS_TEST.with_properties(
             required_builds=[BuildNames.PACKAGE_ASAN], num_batches=2
         ),
-        JobNames.STATELESS_TEST_ARM_ASAN: CommonJobConfigs.STATELESS_TEST.with_properties(
-            required_builds=[BuildNames.PACKAGE_ARM_ASAN],
+        JobNames.STATELESS_TEST_AARCH64_ASAN: CommonJobConfigs.STATELESS_TEST.with_properties(
+            required_builds=[BuildNames.PACKAGE_AARCH64_ASAN],
             num_batches=2,
-            runner_type=Runners.FUNC_TESTER_ARM,
+            runner_type=Runners.FUNC_TESTER_AARCH64,
         ),
         JobNames.STATELESS_TEST_TSAN: CommonJobConfigs.STATELESS_TEST.with_properties(
             required_builds=[BuildNames.PACKAGE_TSAN], num_batches=4
@@ -360,7 +360,7 @@ class CI:
         ),
         JobNames.STATELESS_TEST_AARCH64: CommonJobConfigs.STATELESS_TEST.with_properties(
             required_builds=[BuildNames.PACKAGE_AARCH64],
-            runner_type=Runners.FUNC_TESTER_ARM,
+            runner_type=Runners.FUNC_TESTER_AARCH64,
         ),
         JobNames.STATELESS_TEST_OLD_ANALYZER_S3_REPLICATED_RELEASE: CommonJobConfigs.STATELESS_TEST.with_properties(
             required_builds=[BuildNames.PACKAGE_RELEASE], num_batches=2
@@ -432,10 +432,10 @@ class CI:
             num_batches=6,
             timeout=9000,  # the job timed out with default value (7200)
         ),
-        JobNames.INTEGRATION_TEST_ARM: CommonJobConfigs.INTEGRATION_TEST.with_properties(
+        JobNames.INTEGRATION_TEST_AARCH64: CommonJobConfigs.INTEGRATION_TEST.with_properties(
             required_builds=[BuildNames.PACKAGE_AARCH64],
             num_batches=6,
-            runner_type=Runners.FUNC_TESTER_ARM,
+            runner_type=Runners.FUNC_TESTER_AARCH64,
         ),
         JobNames.INTEGRATION_TEST: CommonJobConfigs.INTEGRATION_TEST.with_properties(
             required_builds=[BuildNames.PACKAGE_RELEASE],
@@ -453,10 +453,10 @@ class CI:
             required_builds=[BuildNames.PACKAGE_RELEASE],
             required_on_release_branch=True,
         ),
-        JobNames.COMPATIBILITY_TEST_ARM: CommonJobConfigs.COMPATIBILITY_TEST.with_properties(
+        JobNames.COMPATIBILITY_TEST_AARCH64: CommonJobConfigs.COMPATIBILITY_TEST.with_properties(
             required_builds=[BuildNames.PACKAGE_AARCH64],
             required_on_release_branch=True,
-            runner_type=Runners.STYLE_CHECKER_ARM,
+            runner_type=Runners.STYLE_CHECKER_AARCH64,
         ),
         JobNames.UNIT_TEST: CommonJobConfigs.UNIT_TEST.with_properties(
             required_builds=[BuildNames.BINARY_RELEASE],
@@ -499,22 +499,22 @@ class CI:
             required_builds=[BuildNames.BINARY_RELEASE],
             run_by_labels=[Labels.JEPSEN_TEST],
             run_command="jepsen_check.py keeper",
-            runner_type=Runners.STYLE_CHECKER_ARM,
+            runner_type=Runners.STYLE_CHECKER_AARCH64,
         ),
         JobNames.JEPSEN_SERVER: JobConfig(
             required_builds=[BuildNames.BINARY_RELEASE],
             run_by_labels=[Labels.JEPSEN_TEST],
             run_command="jepsen_check.py server",
-            runner_type=Runners.STYLE_CHECKER_ARM,
+            runner_type=Runners.STYLE_CHECKER_AARCH64,
         ),
         JobNames.PERFORMANCE_TEST_AMD64: CommonJobConfigs.PERF_TESTS.with_properties(
             required_builds=[BuildNames.PACKAGE_RELEASE], num_batches=4
         ),
-        JobNames.PERFORMANCE_TEST_ARM64: CommonJobConfigs.PERF_TESTS.with_properties(
+        JobNames.PERFORMANCE_TEST_AARCH64: CommonJobConfigs.PERF_TESTS.with_properties(
             required_builds=[BuildNames.PACKAGE_AARCH64],
             num_batches=4,
             run_by_labels=[Labels.PR_PERFORMANCE],
-            runner_type=Runners.FUNC_TESTER_ARM,
+            runner_type=Runners.FUNC_TESTER_AARCH64,
         ),
         JobNames.SQLANCER: CommonJobConfigs.SQLLANCER_TEST.with_properties(
             required_builds=[BuildNames.PACKAGE_RELEASE],
@@ -532,9 +532,9 @@ class CI:
         JobNames.CLICKBENCH_TEST: CommonJobConfigs.CLICKBENCH_TEST.with_properties(
             required_builds=[BuildNames.PACKAGE_RELEASE],
         ),
-        JobNames.CLICKBENCH_TEST_ARM: CommonJobConfigs.CLICKBENCH_TEST.with_properties(
+        JobNames.CLICKBENCH_TEST_AARCH64: CommonJobConfigs.CLICKBENCH_TEST.with_properties(
             required_builds=[BuildNames.PACKAGE_AARCH64],
-            runner_type=Runners.FUNC_TESTER_ARM,
+            runner_type=Runners.FUNC_TESTER_AARCH64,
         ),
         JobNames.LIBFUZZER_TEST: JobConfig(
             required_builds=[BuildNames.FUZZERS],
@@ -572,7 +572,7 @@ class CI:
         ),
         JobNames.STYLE_CHECK: JobConfig(
             run_always=True,
-            runner_type=Runners.STYLE_CHECKER_ARM,
+            runner_type=Runners.STYLE_CHECKER_AARCH64,
         ),
         JobNames.BUGFIX_VALIDATE: JobConfig(
             run_by_labels=[Labels.PR_BUGFIX, Labels.PR_CRITICAL_BUGFIX],

--- a/tests/ci/ci_definitions.py
+++ b/tests/ci/ci_definitions.py
@@ -58,11 +58,11 @@ class Runners(metaclass=WithIter):
     """
 
     BUILDER = "builder"
-    BUILDER_ARM = "builder-aarch64"
+    BUILDER_AARCH64 = "builder-aarch64"
     STYLE_CHECKER = "style-checker"
-    STYLE_CHECKER_ARM = "style-checker-aarch64"
+    STYLE_CHECKER_AARCH64 = "style-checker-aarch64"
     FUNC_TESTER = "func-tester"
-    FUNC_TESTER_ARM = "func-tester-aarch64"
+    FUNC_TESTER_AARCH64 = "func-tester-aarch64"
     FUZZER_UNIT_TESTER = "fuzzer-unit-tester"
 
 
@@ -78,7 +78,7 @@ class Tags(metaclass=WithIter):
     # to upload all binaries from build jobs
     UPLOAD_ALL_ARTIFACTS = "upload_all"
     CI_SET_SYNC = "ci_set_sync"
-    CI_SET_ARM = "ci_set_arm"
+    CI_SET_AARCH64 = "ci_set_aarch64"
     CI_SET_REQUIRED = "ci_set_required"
     CI_SET_BUILDS = "ci_set_builds"
 
@@ -106,7 +106,7 @@ class BuildNames(metaclass=WithIter):
     PACKAGE_MSAN = "package_msan"
     PACKAGE_DEBUG = "package_debug"
     PACKAGE_AARCH64 = "package_aarch64"
-    PACKAGE_ARM_ASAN = "package_aarch64_asan"
+    PACKAGE_AARCH64_ASAN = "package_aarch64_asan"
     PACKAGE_RELEASE_COVERAGE = "package_release_coverage"
     BINARY_RELEASE = "binary_release"
     BINARY_TIDY = "binary_tidy"
@@ -134,14 +134,14 @@ class JobNames(metaclass=WithIter):
     DOCKER_SERVER = "Docker server image"
     DOCKER_KEEPER = "Docker keeper image"
     INSTALL_TEST_AMD = "Install packages (release)"
-    INSTALL_TEST_ARM = "Install packages (aarch64)"
+    INSTALL_TEST_AARCH64 = "Install packages (aarch64)"
 
     STATELESS_TEST_DEBUG = "Stateless tests (debug)"
     STATELESS_TEST_RELEASE = "Stateless tests (release)"
     STATELESS_TEST_RELEASE_COVERAGE = "Stateless tests (coverage)"
     STATELESS_TEST_AARCH64 = "Stateless tests (aarch64)"
     STATELESS_TEST_ASAN = "Stateless tests (asan)"
-    STATELESS_TEST_ARM_ASAN = "Stateless tests (aarch64, asan)"
+    STATELESS_TEST_AARCH64_ASAN = "Stateless tests (aarch64, asan)"
     STATELESS_TEST_TSAN = "Stateless tests (tsan)"
     STATELESS_TEST_MSAN = "Stateless tests (msan)"
     STATELESS_TEST_UBSAN = "Stateless tests (ubsan)"
@@ -158,7 +158,7 @@ class JobNames(metaclass=WithIter):
     STATEFUL_TEST_RELEASE_COVERAGE = "Stateful tests (coverage)"
     STATEFUL_TEST_AARCH64 = "Stateful tests (aarch64)"
     STATEFUL_TEST_ASAN = "Stateful tests (asan)"
-    STATEFUL_TEST_ARM_ASAN = "Stateful tests (aarch64, asan)"
+    STATEFUL_TEST_AARCH64_ASAN = "Stateful tests (aarch64, asan)"
     STATEFUL_TEST_TSAN = "Stateful tests (tsan)"
     STATEFUL_TEST_MSAN = "Stateful tests (msan)"
     STATEFUL_TEST_UBSAN = "Stateful tests (ubsan)"
@@ -181,7 +181,7 @@ class JobNames(metaclass=WithIter):
     INTEGRATION_TEST_ASAN = "Integration tests (asan)"
     INTEGRATION_TEST_ASAN_OLD_ANALYZER = "Integration tests (asan, old analyzer)"
     INTEGRATION_TEST_TSAN = "Integration tests (tsan)"
-    INTEGRATION_TEST_ARM = "Integration tests (aarch64)"
+    INTEGRATION_TEST_AARCH64 = "Integration tests (aarch64)"
     INTEGRATION_TEST_FLAKY = "Integration tests flaky check (asan)"
 
     UPGRADE_TEST_DEBUG = "Upgrade check (debug)"
@@ -205,7 +205,7 @@ class JobNames(metaclass=WithIter):
     JEPSEN_SERVER = "ClickHouse Server Jepsen"
 
     PERFORMANCE_TEST_AMD64 = "Performance Comparison (release)"
-    PERFORMANCE_TEST_ARM64 = "Performance Comparison (aarch64)"
+    PERFORMANCE_TEST_AARCH64 = "Performance Comparison (aarch64)"
 
     # SQL_LOGIC_TEST = "Sqllogic test (release)"
 
@@ -214,10 +214,10 @@ class JobNames(metaclass=WithIter):
     SQLTEST = "SQLTest"
 
     COMPATIBILITY_TEST = "Compatibility check (release)"
-    COMPATIBILITY_TEST_ARM = "Compatibility check (aarch64)"
+    COMPATIBILITY_TEST_AARCH64 = "Compatibility check (aarch64)"
 
     CLICKBENCH_TEST = "ClickBench (release)"
-    CLICKBENCH_TEST_ARM = "ClickBench (aarch64)"
+    CLICKBENCH_TEST_AARCH64 = "ClickBench (aarch64)"
 
     LIBFUZZER_TEST = "libFuzzer tests"
 
@@ -387,7 +387,7 @@ class CommonJobConfigs:
                 "./tests/ci/upload_result_helper.py",
             ],
         ),
-        runner_type=Runners.STYLE_CHECKER_ARM,
+        runner_type=Runners.STYLE_CHECKER_AARCH64,
         disable_await=True,
     )
     COMPATIBILITY_TEST = JobConfig(
@@ -634,8 +634,8 @@ REQUIRED_CHECKS = [
     JobNames.STATEFUL_TEST_RELEASE,
     JobNames.STATELESS_TEST_RELEASE,
     JobNames.STATELESS_TEST_ASAN,
-    JobNames.STATELESS_TEST_ARM_ASAN,
-    JobNames.STATEFUL_TEST_ARM_ASAN,
+    JobNames.STATELESS_TEST_AARCH64_ASAN,
+    JobNames.STATEFUL_TEST_AARCH64_ASAN,
     JobNames.STATELESS_TEST_FLAKY_ASAN,
     JobNames.STATEFUL_TEST_ASAN,
     JobNames.STYLE_CHECK,

--- a/tests/ci/compatibility_check.py
+++ b/tests/ci/compatibility_check.py
@@ -131,7 +131,7 @@ def main():
     check_name = args.check_name or os.getenv("CHECK_NAME")
     assert check_name
     check_glibc = True
-    # currently hardcoded to x86, don't enable for ARM
+    # currently hardcoded to x86, don't enable for AARCH64
     check_distributions = (
         "aarch64" not in check_name.lower() and "arm64" not in check_name.lower()
     )

--- a/tests/ci/test_ci_config.py
+++ b/tests/ci/test_ci_config.py
@@ -36,11 +36,11 @@ class TestCIConfig(unittest.TestCase):
             elif "binary_" in job.lower() or "package_" in job.lower():
                 if job.lower() in (
                     CI.BuildNames.PACKAGE_AARCH64,
-                    CI.BuildNames.PACKAGE_ARM_ASAN,
+                    CI.BuildNames.PACKAGE_AARCH64_ASAN,
                 ):
                     self.assertTrue(
-                        CI.JOB_CONFIGS[job].runner_type in (CI.Runners.BUILDER_ARM,),
-                        f"Job [{job}] must have [{CI.Runners.BUILDER_ARM}] runner",
+                        CI.JOB_CONFIGS[job].runner_type in (CI.Runners.BUILDER_AARCH64,),
+                        f"Job [{job}] must have [{CI.Runners.BUILDER_AARCH64}] runner",
                     )
                 else:
                     self.assertTrue(
@@ -96,7 +96,7 @@ class TestCIConfig(unittest.TestCase):
             else:
                 self.assertTrue(CI.JOB_CONFIGS[job].build_config is None)
                 if "asan" in job and "aarch" in job:
-                    expected_builds = [CI.BuildNames.PACKAGE_ARM_ASAN]
+                    expected_builds = [CI.BuildNames.PACKAGE_AARCH64_ASAN]
                 elif "asan" in job:
                     expected_builds = [CI.BuildNames.PACKAGE_ASAN]
                 elif "msan" in job:

--- a/tests/ci/test_ci_config.py
+++ b/tests/ci/test_ci_config.py
@@ -39,7 +39,8 @@ class TestCIConfig(unittest.TestCase):
                     CI.BuildNames.PACKAGE_AARCH64_ASAN,
                 ):
                     self.assertTrue(
-                        CI.JOB_CONFIGS[job].runner_type in (CI.Runners.BUILDER_AARCH64,),
+                        CI.JOB_CONFIGS[job].runner_type
+                        in (CI.Runners.BUILDER_AARCH64,),
                         f"Job [{job}] must have [{CI.Runners.BUILDER_AARCH64}] runner",
                     )
                 else:

--- a/tests/ci/test_ci_options.py
+++ b/tests/ci/test_ci_options.py
@@ -10,7 +10,7 @@ from ci_settings import CiSettings
 _TEST_BODY_1 = """
 #### Run only:
 - [ ] <!---ci_set_required--> Some Set
-- [x] <!---ci_set_arm--> Integration tests (arm64)
+- [x] <!---ci_set_aarch64--> Integration tests (aarch64)
 - [x] <!---ci_include_foo--> Integration tests
 - [x] <!---ci_include_foo_Bar--> Integration tests
 - [ ] <!---ci_include_bar--> Integration tests
@@ -150,7 +150,7 @@ class TestCIOptions(unittest.TestCase):
         self.assertFalse(ci_options.no_ci_cache)
         self.assertTrue(ci_options.no_merge_commit)
         self.assertTrue(ci_options.woolen_wolfdog)
-        self.assertEqual(ci_options.ci_sets, ["ci_set_arm"])
+        self.assertEqual(ci_options.ci_sets, ["ci_set_aarch64"])
         self.assertCountEqual(ci_options.include_keywords, ["foo", "foo_bar"])
         self.assertCountEqual(ci_options.exclude_keywords, ["foo", "foo_bar"])
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Our builds, jobs, and hosts are called aarch64, so we make the code consistent with the content.

When we want to migrate to `arm` or `arm64`, the changes should be made together.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---ci_include_fuzzer--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
