### PR TITLE
Fix compatibility with refreshable materialized views created by old clickhouse servers

### DIFF
--- a/src/Storages/StorageMaterializedView.cpp
+++ b/src/Storages/StorageMaterializedView.cpp
@@ -228,10 +228,20 @@ StorageMaterializedView::StorageMaterializedView(
 
     if (!fixed_uuid)
     {
-        if (to_inner_uuid != UUIDHelpers::Nil)
-            throw Exception(ErrorCodes::BAD_ARGUMENTS, "TO INNER UUID is not allowed for materialized views with REFRESH without APPEND");
-        if (to_table_id.hasUUID())
-            throw Exception(ErrorCodes::BAD_ARGUMENTS, "explicit UUID is not allowed for target table of materialized view with REFRESH without APPEND");
+        if (mode >= LoadingStrictnessLevel::ATTACH)
+        {
+            /// Old versions of ClickHouse (when refreshable MV was experimental) could add useless
+            /// UUIDs to attach queries.
+            to_table_id.uuid = UUIDHelpers::Nil;
+            to_inner_uuid = UUIDHelpers::Nil;
+        }
+        else
+        {
+            if (to_inner_uuid != UUIDHelpers::Nil)
+                throw Exception(ErrorCodes::BAD_ARGUMENTS, "TO INNER UUID is not allowed for materialized views with REFRESH without APPEND");
+            if (to_table_id.hasUUID())
+                throw Exception(ErrorCodes::BAD_ARGUMENTS, "explicit UUID is not allowed for target table of materialized view with REFRESH without APPEND");
+        }
     }
 
     if (!has_inner_table)


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Refreshable materialized view creation used to add `TO INNER UUID` to the ATTACH query, same as regular materialized views. This uuid was meaningless and ignored because a new table with new uuid is created on each refresh. Then https://github.com/ClickHouse/ClickHouse/pull/60669 removed and disallowed the `TO INNER UUID`. The check was too strict and broke compatibility with refreshable MVs created by older versions of the server. After update, without this PR, the server would refuse to start:
```
2024.11.06 23:28:47.075342 [ 2944225 ] {} <Error> void DB::AsyncLoader::worker(Pool &): Code: 36. DB::Exception: TO INNER UUID is not allowed for materialized views with REFRESH without APPEND: Cannot attach table `default`.`a` from metadata file /home/ubuntu/cluster/n1/store/store/1e2/1e22fd4a-ef8b-41d7-a87c-beeb9b5a028b/a.sql from query ATTACH MATERIALIZED VIEW default.a UUID '373b8437-5be7-4124-98a7-118ac960aee4' REFRESH EVERY 1 SECOND TO INNER UUID 'b294cf65-2943-486d-9e59-16199c47b9ad' (`x` DateTime) ENGINE = Memory AS SELECT now() SETTINGS allow_experimental_refreshable_materialized_view = 1. (BAD_ARGUMENTS), Stack trace (when copying this message, always include the lines below):

0. ./contrib/llvm-project/libcxx/include/exception:141: Poco::Exception::Exception(String const&, int) @ 0x0000000014b39092
1. ./build/./src/Common/Exception.cpp:109: DB::Exception::Exception(DB::Exception::MessageMasked&&, int, bool) @ 0x000000000b68d899
2. ./src/Common/Exception.h:111: DB::Exception::Exception(PreformattedMessage&&, int) @ 0x0000000006ae8b0c
3. ./src/Common/Exception.h:129: DB::Exception::Exception<>(int, FormatStringHelperImpl<>) @ 0x0000000006af2a8b
4. ./build/./src/Storages/StorageMaterializedView.cpp:232: DB::StorageMaterializedView::StorageMaterializedView(DB::StorageID const&, std::shared_ptr<DB::Context const>, DB::ASTCreateQuery const&, DB::ColumnsDescription const&, DB::LoadingStrictnessLevel, String const&) @ 0x000000001137ea2e
5. ./contrib/llvm-project/libcxx/include/__memory/construct_at.h:35: std::shared_ptr<DB::StorageMaterializedView> std::allocate_shared[abi:v15007]<DB::StorageMaterializedView, std::allocator<DB::StorageMaterializedView>, DB::StorageID const&, std::shared_ptr<DB::Context>, DB::ASTCreateQuery const&, DB::ColumnsDescription const&, DB::LoadingStrictnessLevel const&, String const&, void>(std::allocator<DB::StorageMaterializedView> const&, DB::StorageID const&, std::shared_ptr<DB::Context>&&, DB::ASTCreateQuery const&, DB::ColumnsDescription const&, DB::L
oadingStrictnessLevel const&, String const&) @ 0x00000000113881c1
6. ./contrib/llvm-project/libcxx/include/__memory/shared_ptr.h:962: std::shared_ptr<DB::IStorage> std::__function::__policy_invoker<std::shared_ptr<DB::IStorage> (DB::StorageFactory::Arguments const&)>::__call_impl<std::__function::__default_alloc_func<DB::registerStorageMaterializedView(DB::StorageFactory&)::$_0, std::shared_ptr<DB::IStorage> (DB::StorageFactory::Arguments const&)>>(std::__function::__policy_storage const*, DB::StorageFactory::Arguments const&) @ 0x0000000011386ecb
7. ./contrib/llvm-project/libcxx/include/__functional/function.h:848: ? @ 0x00000000112e103f
8. ./build/./src/Databases/DatabaseOnDisk.cpp:133: DB::createTableFromAST(DB::ASTCreateQuery, String const&, String const&, std::shared_ptr<DB::Context>, DB::LoadingStrictnessLevel) @ 0x000000000fb67e59
9. ./build/./src/Databases/DatabaseOrdinary.cpp:312: DB::DatabaseOrdinary::loadTableFromMetadata(std::shared_ptr<DB::Context>, String const&, DB::QualifiedTableName const&, std::shared_ptr<DB::IAST> const&, DB::LoadingStrictnessLevel) @ 0x000000000fb8bffd
10. ./build/./src/Databases/DatabaseOrdinary.cpp:346: void std::__function::__policy_invoker<void (DB::AsyncLoader&, std::shared_ptr<DB::LoadJob> const&)>::__call_impl<std::__function::__default_alloc_func<DB::DatabaseOrdinary::loadTableFromMetadataAsync(DB::AsyncLoader&, std::unordered_set<std::shared_ptr<DB::LoadJob>, std::hash<std::shared_ptr<DB::LoadJob>>, std::equal_to<std::shared_ptr<DB::LoadJob>>, std::allocator<std::shared_ptr<DB::LoadJob>>>, std::shared_ptr<DB::Context>, String const&, DB::QualifiedTableName const&, std::shared_ptr<DB::IAST> const&, DB::LoadingStrictnessLevel)::$_0, void (DB::AsyncLoader&, std::shared_ptr<DB::LoadJob> const&)>>(std::__function::__policy_storage const*, DB::AsyncLoader&, std::shared_ptr<DB::LoadJob> const&) @ 0x000000000fb93cf4
11. ./contrib/llvm-project/libcxx/include/__functional/function.h:848: ? @ 0x000000000b8835e4
12. ./contrib/llvm-project/libcxx/include/__functional/function.h:848: ? @ 0x000000000b75c109
13. ./contrib/llvm-project/libcxx/include/__functional/invoke.h:359: ? @ 0x000000000b760cc2
14. ./contrib/llvm-project/libcxx/include/__functional/function.h:848: ? @ 0x000000000b759e2d
15. ./contrib/llvm-project/libcxx/include/__functional/invoke.h:359: ? @ 0x000000000b75f11b
16. ? @ 0x00007ffff7c94ac3
17. ? @ 0x00007ffff7d26850
 (version 24.11.1.1)
```

This PR allows the useless TO INNER UUID section to stay in the DB's ATTACH queries indefinitely. Hope it won't break anything down the line.

It's recommended to re-create refreshable MVs that were created back when `allow_experimental_refreshable_materialized_view` was required.