### PR TITLE
Return 0 or default char instead of throwing an error in bitShift functions in case of out of bounds

### DIFF
--- a/src/Functions/bitShiftLeft.cpp
+++ b/src/Functions/bitShiftLeft.cpp
@@ -25,8 +25,10 @@ struct BitShiftLeftImpl
     {
         if constexpr (is_big_int_v<B>)
             throw Exception(ErrorCodes::NOT_IMPLEMENTED, "BitShiftLeft is not implemented for big integers as second argument");
-        else if (b < 0 || static_cast<UInt256>(b) > 8 * sizeof(A))
-            throw Exception(ErrorCodes::ARGUMENT_OUT_OF_BOUND, "The number of shift positions needs to be a non-negative value and less or equal to the bit width of the value to shift");
+        else if (b < 0)
+            throw Exception(ErrorCodes::ARGUMENT_OUT_OF_BOUND, "The number of shift positions needs to be a non-negative value");
+        else if (static_cast<UInt256>(b) > 8 * sizeof(A))
+            return static_cast<Result>(0);
         else if constexpr (is_big_int_v<A>)
             return static_cast<Result>(a) << static_cast<UInt32>(b);
         else
@@ -43,9 +45,10 @@ struct BitShiftLeftImpl
             const UInt8 word_size = 8 * sizeof(*pos);
             size_t n = end - pos;
             const UInt128 bit_limit = static_cast<UInt128>(word_size) * n;
-            if (b < 0 || static_cast<decltype(bit_limit)>(b) > bit_limit)
-                throw Exception(ErrorCodes::ARGUMENT_OUT_OF_BOUND, "The number of shift positions needs to be a non-negative value and less or equal to the bit width of the value to shift");
-            if (b == bit_limit)
+            if (b < 0)
+                throw Exception(ErrorCodes::ARGUMENT_OUT_OF_BOUND, "The number of shift positions needs to be a non-negative value");
+
+            if (b == bit_limit || static_cast<decltype(bit_limit)>(b) > bit_limit)
             {
                 // insert default value
                 out_vec.push_back(0);
@@ -111,9 +114,10 @@ struct BitShiftLeftImpl
             const UInt8 word_size = 8;
             size_t n = end - pos;
             const UInt128 bit_limit = static_cast<UInt128>(word_size) * n;
-            if (b < 0 || static_cast<decltype(bit_limit)>(b) > bit_limit)
-                throw Exception(ErrorCodes::ARGUMENT_OUT_OF_BOUND, "The number of shift positions needs to be a non-negative value and less or equal to the bit width of the value to shift");
-            if (b == bit_limit)
+            if (b < 0)
+                throw Exception(ErrorCodes::ARGUMENT_OUT_OF_BOUND, "The number of shift positions needs to be a non-negative value");
+
+            if (b == bit_limit || static_cast<decltype(bit_limit)>(b) > bit_limit)
             {
                 // insert default value
                 out_vec.resize_fill(out_vec.size() + n);

--- a/src/Functions/bitShiftRight.cpp
+++ b/src/Functions/bitShiftRight.cpp
@@ -26,8 +26,10 @@ struct BitShiftRightImpl
     {
         if constexpr (is_big_int_v<B>)
             throw Exception(ErrorCodes::NOT_IMPLEMENTED, "BitShiftRight is not implemented for big integers as second argument");
-        else if (b < 0 || static_cast<UInt256>(b) > 8 * sizeof(A))
-            throw Exception(ErrorCodes::ARGUMENT_OUT_OF_BOUND, "The number of shift positions needs to be a non-negative value and less or equal to the bit width of the value to shift");
+        else if (b < 0)
+            throw Exception(ErrorCodes::ARGUMENT_OUT_OF_BOUND, "The number of shift positions needs to be a non-negative value");
+        else if (static_cast<UInt256>(b) > 8 * sizeof(A))
+            return static_cast<Result>(0);
         else if constexpr (is_big_int_v<A>)
             return static_cast<Result>(a) >> static_cast<UInt32>(b);
         else
@@ -59,9 +61,10 @@ struct BitShiftRightImpl
             const UInt8 word_size = 8;
             size_t n = end - pos;
             const UInt128 bit_limit = static_cast<UInt128>(word_size) * n;
-            if (b < 0 || static_cast<decltype(bit_limit)>(b) > bit_limit)
-                throw Exception(ErrorCodes::ARGUMENT_OUT_OF_BOUND, "The number of shift positions needs to be a non-negative value and less or equal to the bit width of the value to shift");
-            if (b == bit_limit)
+            if (b < 0)
+                throw Exception(ErrorCodes::ARGUMENT_OUT_OF_BOUND, "The number of shift positions needs to be a non-negative value");
+
+            if (b == bit_limit || static_cast<decltype(bit_limit)>(b) > bit_limit)
             {
                 /// insert default value
                 out_vec.push_back(0);
@@ -99,9 +102,10 @@ struct BitShiftRightImpl
             const UInt8 word_size = 8;
             size_t n = end - pos;
             const UInt128 bit_limit = static_cast<UInt128>(word_size) * n;
-            if (b < 0 || static_cast<decltype(bit_limit)>(b) > bit_limit)
-                throw Exception(ErrorCodes::ARGUMENT_OUT_OF_BOUND, "The number of shift positions needs to be a non-negative value and less or equal to the bit width of the value to shift");
-            if (b == bit_limit)
+            if (b < 0)
+                throw Exception(ErrorCodes::ARGUMENT_OUT_OF_BOUND, "The number of shift positions needs to be a non-negative value");
+
+            if (b == bit_limit || static_cast<decltype(bit_limit)>(b) > bit_limit)
             {
                 // insert default value
                 out_vec.resize_fill(out_vec.size() + n);

--- a/tests/queries/0_stateless/02766_bitshift_with_const_arguments.sql
+++ b/tests/queries/0_stateless/02766_bitshift_with_const_arguments.sql
@@ -10,7 +10,7 @@ DROP TABLE IF EXISTS t1;
 CREATE TABLE t0 (vkey UInt32, pkey UInt32, c0 UInt32) engine = TinyLog;
 CREATE TABLE t1 (vkey UInt32) ENGINE = AggregatingMergeTree  ORDER BY vkey;
 INSERT INTO t0 VALUES (15, 25000, 58);
-SELECT ref_5.pkey AS c_2_c2392_6 FROM t0 AS ref_5 WHERE 'J[' < multiIf(ref_5.pkey IN ( SELECT 1 ), bitShiftLeft(multiIf(ref_5.c0 > NULL, '1', ')'), 40), NULL); -- { serverError ARGUMENT_OUT_OF_BOUND }
+SELECT ref_5.pkey AS c_2_c2392_6 FROM t0 AS ref_5 WHERE 'J[' < multiIf(ref_5.pkey IN ( SELECT 1 ), bitShiftLeft(multiIf(ref_5.c0 > NULL, '1', ')'), 40), NULL);
 DROP TABLE t0;
 DROP TABLE t1;
 

--- a/tests/queries/0_stateless/03198_bit_shift_throws_error_for_out_of_bounds.reference
+++ b/tests/queries/0_stateless/03198_bit_shift_throws_error_for_out_of_bounds.reference
@@ -1,3 +1,9 @@
 -- bitShiftRight
+0
+
+\0\0\0\0\0\0\0\0
 -- bitShiftLeft
+0
+
+\0\0\0\0\0\0\0\0
 OK

--- a/tests/queries/0_stateless/03198_bit_shift_throws_error_for_out_of_bounds.sql
+++ b/tests/queries/0_stateless/03198_bit_shift_throws_error_for_out_of_bounds.sql
@@ -1,17 +1,17 @@
 SELECT '-- bitShiftRight';
 SELECT bitShiftRight(1, -1); -- { serverError ARGUMENT_OUT_OF_BOUND }
-SELECT bitShiftRight(toUInt8(1), 8 + 1); -- { serverError ARGUMENT_OUT_OF_BOUND }
+SELECT bitShiftRight(toUInt8(1), 8 + 1);
 SELECT bitShiftRight('hola', -1); -- { serverError ARGUMENT_OUT_OF_BOUND }
-SELECT bitShiftRight('hola', 4 * 8 + 1); -- { serverError ARGUMENT_OUT_OF_BOUND }
+SELECT bitShiftRight('hola', 4 * 8 + 1);
 SELECT bitShiftRight(toFixedString('hola', 8), -1); -- { serverError ARGUMENT_OUT_OF_BOUND }
-SELECT bitShiftRight(toFixedString('hola', 8),  8 * 8 + 1); -- { serverError ARGUMENT_OUT_OF_BOUND }
+SELECT bitShiftRight(toFixedString('hola', 8),  8 * 8 + 1);
 
 SELECT '-- bitShiftLeft';
 SELECT bitShiftLeft(1, -1); -- { serverError ARGUMENT_OUT_OF_BOUND }
-SELECT bitShiftLeft(toUInt8(1), 8 + 1); -- { serverError ARGUMENT_OUT_OF_BOUND }
+SELECT bitShiftLeft(toUInt8(1), 8 + 1);
 SELECT bitShiftLeft('hola', -1); -- { serverError ARGUMENT_OUT_OF_BOUND }
-SELECT bitShiftLeft('hola', 4 * 8 + 1); -- { serverError ARGUMENT_OUT_OF_BOUND }
+SELECT bitShiftLeft('hola', 4 * 8 + 1);
 SELECT bitShiftLeft(toFixedString('hola', 8), -1); -- { serverError ARGUMENT_OUT_OF_BOUND }
-SELECT bitShiftLeft(toFixedString('hola', 8),  8 * 8 + 1); -- { serverError ARGUMENT_OUT_OF_BOUND }
+SELECT bitShiftLeft(toFixedString('hola', 8),  8 * 8 + 1);
 
 SELECT 'OK';


### PR DESCRIPTION
Return 0 or default char instead of throwing an error in bitShift functions in case of out of bounds

Originally [we decided](https://github.com/ClickHouse/ClickHouse/pull/65838#issuecomment-2197185680) to throw an exception for out of bounds, but we've agreed on going with a compromise solution where we report 0 the same way as MySQL and SQLite.

Close #71559 

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Return 0 or default char instead of throwing an error in bitShift functions in case of out of bounds

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---ci_include_fuzzer--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
