### PR TITLE
CI: fix mysql containers using improper log directory

### DIFF
--- a/tests/integration/compose/docker_compose_mysql.yml
+++ b/tests/integration/compose/docker_compose_mysql.yml
@@ -5,7 +5,7 @@ services:
         environment:
             MYSQL_ROOT_PASSWORD: clickhouse
             MYSQL_ROOT_HOST: ${MYSQL_ROOT_HOST}
-            DATADIR: /mysql/
+            DATADIR: /var/log/mysql/
         expose:
             - ${MYSQL_PORT:-3306}
         command: --server_id=100
@@ -14,11 +14,11 @@ services:
             --gtid-mode="ON"
             --enforce-gtid-consistency
             --log-error-verbosity=3
-            --log-error=/mysql/error.log
+            --log-error=/var/log/mysql/error.log
             --general-log=ON
-            --general-log-file=/mysql/general.log
+            --general-log-file=/var/log/mysql/general.log
         volumes:
             - type: ${MYSQL_LOGS_FS:-tmpfs}
               source: ${MYSQL_LOGS:-}
-              target: /mysql/
+              target: /var/log/mysql/
         user: ${MYSQL_DOCKER_USER}

--- a/tests/integration/compose/docker_compose_mysql_8_0.yml
+++ b/tests/integration/compose/docker_compose_mysql_8_0.yml
@@ -4,8 +4,8 @@ services:
         restart: always
         environment:
             MYSQL_ROOT_PASSWORD: clickhouse
-            MYSQL_ROOT_HOST: ${MYSQL_ROOT_HOST}
-            DATADIR: /mysql/
+            MYSQL_ROOT_HOST: ${MYSQL8_ROOT_HOST}
+            DATADIR: /var/log/mysql/
         expose:
             - ${MYSQL8_PORT:-3306}
         command: --server_id=100 --log-bin='mysql-bin-1.log'
@@ -13,11 +13,11 @@ services:
             --default-time-zone='+3:00' --gtid-mode="ON"
             --enforce-gtid-consistency
             --log-error-verbosity=3
-            --log-error=/mysql/error.log
+            --log-error=/var/log/mysql/error.log
             --general-log=ON
-            --general-log-file=/mysql/general.log
+            --general-log-file=/var/log/mysql/general.log
         volumes:
             - type: ${MYSQL8_LOGS_FS:-tmpfs}
               source: ${MYSQL8_LOGS:-}
-              target: /mysql/
+              target: /var/log/mysql/
         user: ${MYSQL8_DOCKER_USER}


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

For some reason on my system (`Linux 22.04.1-Ubuntu SMP x86_64 GNU/Linux`) mysqld running under `mysql` user in mysql container is unable to write to `/mysql` directory, which makes corresponding tests to fail.
It seems specific for host system because under different system it apparently works.
Also `MYSQL_ROOT_HOST` env initialization is fixed for `mysql80` container.

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---ci_include_fuzzer--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
