### PR TITLE
fix: transform set while partition pruning only if allowed

### DIFF
--- a/src/Storages/MergeTree/KeyCondition.cpp
+++ b/src/Storages/MergeTree/KeyCondition.cpp
@@ -1158,6 +1158,7 @@ bool KeyCondition::tryPrepareSetIndex(
     const RPNBuilderFunctionTreeNode & func,
     RPNElement & out,
     size_t & out_key_column_num,
+    bool & allow_constant_transformation,
     bool & is_constant_transformed)
 {
     const auto & left_arg = func.getArgumentAt(0);
@@ -1184,7 +1185,9 @@ bool KeyCondition::tryPrepareSetIndex(
             set_transforming_chains.push_back(set_transforming_chain);
         }
         // For partition index, checking if set can be transformed to prune any partitions
-        else if (single_point && canSetValuesBeWrappedByFunctions(node, index_mapping.key_index, data_type, set_transforming_chain))
+        else if (
+            single_point && allow_constant_transformation
+            && canSetValuesBeWrappedByFunctions(node, index_mapping.key_index, data_type, set_transforming_chain))
         {
             indexes_mapping.push_back(index_mapping);
             data_types.push_back(data_type);
@@ -1954,7 +1957,7 @@ bool KeyCondition::extractAtomFromTree(const RPNBuilderTreeNode & node, RPNEleme
 
             if (functionIsInOrGlobalInOperator(func_name))
             {
-                if (tryPrepareSetIndex(func, out, key_column_num, is_constant_transformed))
+                if (tryPrepareSetIndex(func, out, key_column_num, allow_constant_transformation, is_constant_transformed))
                 {
                     key_arg_pos = 0;
                     is_set_const = true;

--- a/src/Storages/MergeTree/KeyCondition.h
+++ b/src/Storages/MergeTree/KeyCondition.h
@@ -312,6 +312,7 @@ private:
         const RPNBuilderFunctionTreeNode & func,
         RPNElement & out,
         size_t & out_key_column_num,
+        bool & allow_constant_transformation,
         bool & is_constant_transformed);
 
     /// Checks that the index can not be used.

--- a/tests/queries/0_stateless/03269_partition_key_not_in_set.reference
+++ b/tests/queries/0_stateless/03269_partition_key_not_in_set.reference
@@ -1,0 +1,13 @@
+-- Monotonic function in partition key
+48
+48
+-- Non-monotonic function in partition key
+48
+48
+-- Multiple partition columns
+50
+50
+96
+96
+98
+98

--- a/tests/queries/0_stateless/03269_partition_key_not_in_set.sql
+++ b/tests/queries/0_stateless/03269_partition_key_not_in_set.sql
@@ -1,0 +1,81 @@
+-- Related to https://github.com/ClickHouse/ClickHouse/issues/69829
+--
+-- The main goal of the test is to assert that constant transformation
+-- for set constant while partition pruning won't be performed
+-- if it's not allowed (NOT IN operator case)
+
+DROP TABLE IF EXISTS 03269_filters;
+CREATE TABLE 03269_filters (
+    id Int32,
+    dt Date
+)
+engine = MergeTree
+order by id;
+
+INSERT INTO 03269_filters
+SELECT 6, '2020-01-01'
+UNION ALL
+SELECT 38, '2021-01-01';
+
+SELECT '-- Monotonic function in partition key';
+
+DROP TABLE IF EXISTS 03269_single_monotonic;
+CREATE TABLE 03269_single_monotonic(
+    id Int32
+)
+ENGINE = MergeTree
+PARTITION BY intDiv(id, 10)
+ORDER BY id;
+
+INSERT INTO 03269_single_monotonic SELECT number FROM numbers(50);
+
+SELECT count() FROM 03269_single_monotonic WHERE id NOT IN (6, 38);
+SELECT count() FROM 03269_single_monotonic WHERE id NOT IN (
+    SELECT id FROM 03269_filters
+);
+
+DROP TABLE 03269_single_monotonic;
+
+SELECT '-- Non-monotonic function in partition key';
+
+DROP TABLE IF EXISTS 03269_single_non_monotonic;
+CREATE TABLE 03269_single_non_monotonic (
+    id Int32
+)
+ENGINE = MergeTree
+PARTITION BY id % 10
+ORDER BY id;
+
+INSERT INTO 03269_single_non_monotonic SELECT number FROM numbers(50);
+
+SELECT count() FROM 03269_single_non_monotonic WHERE id NOT IN (6, 38);
+SELECT count() FROM 03269_single_non_monotonic WHERE id NOT IN (SELECT id FROM 03269_filters);
+
+DROP TABLE 03269_single_non_monotonic;
+
+SELECT '-- Multiple partition columns';
+
+DROP TABLE IF EXISTS 03269_multiple_part_cols;
+CREATE TABLE 03269_multiple_part_cols (
+    id Int32,
+    dt Date,
+)
+ENGINE = MergeTree
+PARTITION BY (dt, intDiv(id, 10))
+ORDER BY id;
+
+INSERT INTO 03269_multiple_part_cols
+SELECT number, '2020-01-01' FROM numbers(50)
+UNION ALL
+SELECT number, '2021-01-01' FROM numbers(50);
+
+SELECT count() FROM 03269_multiple_part_cols WHERE dt NOT IN ('2020-01-01');
+SELECT count() FROM 03269_multiple_part_cols WHERE dt NOT IN (SELECT dt FROM 03269_filters WHERE dt < '2021-01-01');
+
+SELECT count() FROM 03269_multiple_part_cols WHERE id NOT IN (6, 38);
+SELECT count() FROM 03269_multiple_part_cols WHERE id NOT IN (SELECT id FROM 03269_filters);
+
+SELECT count() FROM 03269_multiple_part_cols WHERE (id, dt) NOT IN ((6, '2020-01-01'), (38, '2021-01-01'));
+SELECT count() FROM 03269_multiple_part_cols WHERE (id, dt) NOT IN (SELECT id, dt FROM 03269_filters);
+
+DROP TABLE 03269_multiple_part_cols;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Don't transform constant set in predicates over partition columns in case of NOT IN operator.

Closes #69829 

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---ci_include_fuzzer--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
