### PR TITLE
Support right bounded reads for ReadBufferFromHDFS and enable readBigAt in AsynchronousReadBufferFromHDFS

### DIFF
--- a/src/Disks/IO/AsynchronousBoundedReadBuffer.h
+++ b/src/Disks/IO/AsynchronousBoundedReadBuffer.h
@@ -28,7 +28,8 @@ public:
         IAsynchronousReader & reader_,
         const ReadSettings & settings_,
         AsyncReadCountersPtr async_read_counters_ = nullptr,
-        FilesystemReadPrefetchesLogPtr prefetches_log_ = nullptr);
+        FilesystemReadPrefetchesLogPtr prefetches_log_ = nullptr,
+        bool enable_read_at = false);
 
     ~AsynchronousBoundedReadBuffer() override;
 
@@ -71,6 +72,8 @@ private:
 
     AsyncReadCountersPtr async_read_counters;
     FilesystemReadPrefetchesLogPtr prefetches_log;
+
+    bool supports_read_at;
 
     struct LastPrefetchInfo
     {

--- a/src/IO/AsynchronousReader.h
+++ b/src/IO/AsynchronousReader.h
@@ -50,6 +50,7 @@ public:
         char * buf = nullptr;
         Priority priority;
         size_t ignore = 0;
+        bool supports_read_at = false;
     };
 
     struct Result

--- a/src/IO/examples/read_buffer_from_hdfs.cpp
+++ b/src/IO/examples/read_buffer_from_hdfs.cpp
@@ -1,26 +1,77 @@
 #include <memory>
-#include <string>
+#include <IO/ParallelReadBuffer.h>
+#include <IO/SharedThreadPools.h>
 #include <IO/WriteBufferFromFile.h>
 #include <IO/copyData.h>
+#include <Storages/ObjectStorage/HDFS/AsynchronousReadBufferFromHDFS.h>
 #include <Storages/ObjectStorage/HDFS/ReadBufferFromHDFS.h>
 #include <base/types.h>
-#include <Common/Config/ConfigProcessor.h>
-
 #include <Poco/Util/MapConfiguration.h>
+#include <Common/Config/ConfigProcessor.h>
+#include <Common/threadPoolCallbackRunner.h>
 
 using namespace DB;
 
-int main()
+int main(int /*argc*/, char ** argv)
 {
-    setenv("LIBHDFS3_CONF", "/path/to/hdfs-site.xml", true); /// NOLINT
-    String hdfs_uri = "hdfs://cluster_name";
-    String hdfs_file_path = "/path/to/hdfs/file";
     ConfigurationPtr config = Poco::AutoPtr(new Poco::Util::MapConfiguration());
+    auto shared_context = SharedContextHolder(Context::createShared());
+    auto global_context = Context::createGlobal(shared_context.get());
+    global_context->makeGlobalContext();
+    global_context->setConfig(config);
+
+    getIOThreadPool().initialize(100, 0, 100);
+
+
+    setenv("LIBHDFS3_CONF", "/path/to/config", true); /// NOLINT
+    String hdfs_uri = "hdfs://clustername";
+    String hdfs_file_path = "/path/to/file";
     ReadSettings read_settings;
-    ReadBufferFromHDFS read_buffer(hdfs_uri, hdfs_file_path, *config, read_settings, 2097152UL, false);
+
+    auto get_read_buffer = [&](bool async, bool prefetch, bool read_at) -> ReadBufferPtr
+    {
+        auto rb = std::make_shared<ReadBufferFromHDFS>(hdfs_uri, hdfs_file_path, *config, read_settings, 0, true);
+
+        if (async)
+        {
+            std::cout << "use async" << std::endl;
+            if (prefetch)
+                std::cout << "use prefetch" << std::endl;
+            if (read_at)
+                std::cout << "use read_at" << std::endl;
+
+            read_settings.remote_fs_prefetch = prefetch;
+            return std::make_shared<AsynchronousReadBufferFromHDFS>(
+                getThreadPoolReader(FilesystemReaderType::ASYNCHRONOUS_REMOTE_FS_READER), read_settings, rb, read_at);
+        }
+        else
+        {
+            return rb;
+        }
+    };
+
+    auto wrap_parallel_if_needed = [&](ReadBufferPtr input, bool parallel) -> ReadBufferPtr
+    {
+        if (parallel)
+        {
+            std::cout << "use parallel" << std::endl;
+            return wrapInParallelReadBufferIfSupported(
+                *input, threadPoolCallbackRunnerUnsafe<void>(getIOThreadPool().get(), "ParallelRead"), 4, 10 * 1024 * 1024, 1529522144);
+        }
+        else
+            return input;
+    };
+
+    bool async = (std::atoi(argv[1]) != 0);
+    bool prefetch = (std::atoi(argv[2]) != 0);
+    bool read_at = (std::atoi(argv[3]) != 0);
+    bool parallel = (std::atoi(argv[4]) != 0);
+    std::cout << "async: " << async << ", prefetch: " << prefetch << ", read_at: " << read_at << ", parallel: " << parallel << std::endl;
+    auto holder = get_read_buffer(async, prefetch, read_at);
+    auto rb = wrap_parallel_if_needed(holder, parallel);
 
     String download_path = "./download";
     WriteBufferFromFile write_buffer(download_path);
-    copyData(read_buffer, write_buffer);
+    copyData(*rb, write_buffer);
     return 0;
 }

--- a/src/IO/examples/read_buffer_from_hdfs.cpp
+++ b/src/IO/examples/read_buffer_from_hdfs.cpp
@@ -28,10 +28,11 @@ int main(int /*argc*/, char ** argv)
     String hdfs_file_path = "/path/to/file";
     ReadSettings read_settings;
 
-    auto get_read_buffer = [&](bool async, bool prefetch, bool read_at) -> ReadBufferPtr
+    auto get_read_buffer = [&](bool async, bool prefetch, bool read_at)
     {
         auto rb = std::make_shared<ReadBufferFromHDFS>(hdfs_uri, hdfs_file_path, *config, read_settings, 0, true);
 
+        ReadBufferPtr res;
         if (async)
         {
             std::cout << "use async" << std::endl;
@@ -41,13 +42,13 @@ int main(int /*argc*/, char ** argv)
                 std::cout << "use read_at" << std::endl;
 
             read_settings.remote_fs_prefetch = prefetch;
-            return std::make_shared<AsynchronousReadBufferFromHDFS>(
+            res = std::make_shared<AsynchronousReadBufferFromHDFS>(
                 getThreadPoolReader(FilesystemReaderType::ASYNCHRONOUS_REMOTE_FS_READER), read_settings, rb, read_at);
         }
         else
-        {
-            return rb;
-        }
+            res = rb;
+
+        return res;
     };
 
     auto wrap_parallel_if_needed = [&](ReadBufferPtr input, bool parallel) -> ReadBufferPtr
@@ -62,10 +63,10 @@ int main(int /*argc*/, char ** argv)
             return input;
     };
 
-    bool async = (std::atoi(argv[1]) != 0);
-    bool prefetch = (std::atoi(argv[2]) != 0);
-    bool read_at = (std::atoi(argv[3]) != 0);
-    bool parallel = (std::atoi(argv[4]) != 0);
+    bool async = (std::stoi(std::string(argv[1])) != 0);
+    bool prefetch = (std::stoi(std::string(argv[2])) != 0);
+    bool read_at = (std::stoi(std::string(argv[3])) != 0);
+    bool parallel = (std::stoi(std::string(argv[4])) != 0);
     std::cout << "async: " << async << ", prefetch: " << prefetch << ", read_at: " << read_at << ", parallel: " << parallel << std::endl;
     auto holder = get_read_buffer(async, prefetch, read_at);
     auto rb = wrap_parallel_if_needed(holder, parallel);

--- a/src/Storages/ObjectStorage/HDFS/AsynchronousReadBufferFromHDFS.cpp
+++ b/src/Storages/ObjectStorage/HDFS/AsynchronousReadBufferFromHDFS.cpp
@@ -270,6 +270,21 @@ size_t AsynchronousReadBufferFromHDFS::getFileOffsetOfBufferEnd() const
     return file_offset_of_buffer_end;
 }
 
+bool AsynchronousReadBufferFromHDFS::supportsRightBoundedReads() const
+{
+    return true;
+}
+
+void AsynchronousReadBufferFromHDFS::setReadUntilPosition(size_t position)
+{
+    read_until_position = position;
+}
+
+void AsynchronousReadBufferFromHDFS::setReadUntilEnd()
+{
+    read_until_position = impl->getFileSize();
+}
+
 }
 
 #endif

--- a/src/Storages/ObjectStorage/HDFS/AsynchronousReadBufferFromHDFS.h
+++ b/src/Storages/ObjectStorage/HDFS/AsynchronousReadBufferFromHDFS.h
@@ -31,6 +31,12 @@ public:
 
     ~AsynchronousReadBufferFromHDFS() override;
 
+    bool supportsRightBoundedReads() const override;
+
+    void setReadUntilPosition(size_t position) override;
+
+    void setReadUntilEnd() override;
+
     off_t seek(off_t offset_, int whence) override;
 
     void prefetch(Priority priority) override;

--- a/src/Storages/ObjectStorage/HDFS/AsynchronousReadBufferFromHDFS.h
+++ b/src/Storages/ObjectStorage/HDFS/AsynchronousReadBufferFromHDFS.h
@@ -27,7 +27,8 @@ public:
     AsynchronousReadBufferFromHDFS(
         IAsynchronousReader & reader_,
         const ReadSettings & settings_,
-        std::shared_ptr<ReadBufferFromHDFS> impl_);
+        std::shared_ptr<ReadBufferFromHDFS> impl_,
+        bool enable_read_at = false);
 
     ~AsynchronousReadBufferFromHDFS() override;
 
@@ -57,6 +58,7 @@ private:
     bool hasPendingDataToRead();
 
     std::future<IAsynchronousReader::Result> asyncReadInto(char * data, size_t size, Priority priority);
+    IAsynchronousReader::Result readInto(char * data, size_t size, Priority priority);
 
     IAsynchronousReader & reader;
     Priority base_priority;
@@ -67,6 +69,7 @@ private:
     size_t file_offset_of_buffer_end = 0;
     std::optional<size_t> read_until_position;
     bool use_prefetch;
+    bool supports_read_at;
 
     LoggerPtr log;
 

--- a/src/Storages/ObjectStorage/HDFS/ReadBufferFromHDFS.cpp
+++ b/src/Storages/ObjectStorage/HDFS/ReadBufferFromHDFS.cpp
@@ -165,6 +165,19 @@ struct ReadBufferFromHDFS::ReadBufferFromHDFSImpl : public BufferWithOwnMemory<S
         return file_offset;
     }
 
+    bool supportsRightBoundedReads() const override { return true; }
+
+    void setReadUntilPosition(size_t position) override
+    {
+        read_until_position = position;
+    }
+
+    void setReadUntilEnd() override
+    {
+        read_until_position = 0;
+    }
+
+
     size_t pread(char * buffer, size_t size, size_t offset)
     {
         ResourceGuard rlock(ResourceGuard::Metrics::getIORead(), read_settings.io_scheduling.read_resource_link, size);
@@ -282,6 +295,21 @@ size_t ReadBufferFromHDFS::readBigAt(char * buffer, size_t size, size_t offset, 
 bool ReadBufferFromHDFS::supportsReadAt()
 {
     return true;
+}
+
+bool ReadBufferFromHDFS::supportsRightBoundedReads() const
+{
+    return impl->supportsRightBoundedReads();
+}
+
+void ReadBufferFromHDFS::setReadUntilPosition(size_t position)
+{
+    impl->setReadUntilPosition(position);
+}
+
+void ReadBufferFromHDFS::setReadUntilEnd()
+{
+    impl->setReadUntilEnd();
 }
 
 }

--- a/src/Storages/ObjectStorage/HDFS/ReadBufferFromHDFS.h
+++ b/src/Storages/ObjectStorage/HDFS/ReadBufferFromHDFS.h
@@ -34,6 +34,12 @@ public:
 
     ~ReadBufferFromHDFS() override;
 
+    bool supportsRightBoundedReads() const override;
+
+    void setReadUntilPosition(size_t position) override;
+
+    void setReadUntilEnd() override;
+
     bool nextImpl() override;
 
     off_t seek(off_t offset_, int whence) override;


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement



### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Support right bounded reads for ReadBufferFromHDFS, so we don't need to wrap it with BoundedReadBuffer.
Enable readBigAt in AsynchronousReadBufferFromHDFS, it may bring some performance benefits. 

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---ci_include_fuzzer--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
