### PR TITLE
SYNTAX_ERROR instead of BAD_ARGUMENTS on no_password among other authentication types

### DIFF
--- a/src/Parsers/Access/ParserCreateUserQuery.cpp
+++ b/src/Parsers/Access/ParserCreateUserQuery.cpp
@@ -276,7 +276,7 @@ namespace
             {
                 std::shared_ptr<ASTAuthenticationData> ast_authentication_data;
 
-                if (!parseAuthenticationData(aux_pos, expected, ast_authentication_data, false, true, should_parse_no_password))
+                if (!parseAuthenticationData(aux_pos, expected, ast_authentication_data, false, true, false))
                 {
                     break;
                 }

--- a/src/Parsers/Access/ParserCreateUserQuery.cpp
+++ b/src/Parsers/Access/ParserCreateUserQuery.cpp
@@ -268,6 +268,13 @@ namespace
                 authentication_methods.push_back(ast_authentication_data);
             }
 
+            // if the first authentication method parsed is of type no_password, then we should not try to parse any further
+            // as it cannot co-exist with other authentication types
+            if (authentication_methods.back()->type && authentication_methods.back()->type.value() == AuthenticationType::NO_PASSWORD)
+            {
+                return true;
+            }
+
             // Need to save current position, process comma and only update real position in case there is an authentication method after
             // the comma. Otherwise, position should not be changed as it needs to be processed by other parsers and possibly throw error
             // on trailing comma.
@@ -285,7 +292,7 @@ namespace
                 authentication_methods.push_back(ast_authentication_data);
             }
 
-            return !authentication_methods.empty();
+            return true;
         });
     }
 


### PR DESCRIPTION
**OLD**

```
arthur :) CREATE USER user2 IDENTIFIED WITH plaintext_password by '1', no_password;

CREATE USER user2 IDENTIFIED WITH plaintext_password BY '1' no_password

Query id: bb84a68c-29bb-4f7d-bcf3-5dd79a32d742


Elapsed: 0.261 sec. 

Received exception from server (version 24.11.1):
Code: 36. DB::Exception: Received from localhost:9000. DB::Exception: Authentication method 'no_password' cannot co-exist with other authentication methods. (BAD_ARGUMENTS)
```


**NEW**

```
arthur :) CREATE USER user2 IDENTIFIED WITH plaintext_password by '1', no_password;

CREATE USER user2 IDENTIFIED WITH plaintext_password BY '1' no_password

Query id: 4042b576-dfad-4aa9-ad36-791238a636c4


Elapsed: 0.342 sec. 

Received exception from server (version 24.11.1):
Code: 62. DB::Exception: Received from localhost:9000. DB::Exception: Syntax error: failed at position 62 ('no_password'): no_password;. Expected one of: PLAINTEXT_PASSWORD, SHA256_PASSWORD, DOUBLE_SHA1_PASSWORD, LDAP, KERBEROS, SSL_CERTIFICATE, BCRYPT_PASSWORD, SSH_KEY, HTTP, JWT, SHA256_HASH, DOUBLE_SHA1_HASH, BCRYPT_HASH, BY, end of query. (SYNTAX_ERROR)

```
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
More consistent exception message when parsing no_password authentication type among other authentication methods

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---ci_include_fuzzer--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
