### PR TITLE
Fix filling of defaults after parsing into sparse columns

### DIFF
--- a/src/Processors/Transforms/AddingDefaultsTransform.cpp
+++ b/src/Processors/Transforms/AddingDefaultsTransform.cpp
@@ -9,6 +9,7 @@
 #include <Columns/ColumnsCommon.h>
 #include <Columns/ColumnDecimal.h>
 #include <Columns/ColumnConst.h>
+#include <Columns/ColumnSparse.h>
 #include <Columns/FilterDescription.h>
 
 #include <DataTypes/DataTypesNumber.h>
@@ -184,7 +185,7 @@ void AddingDefaultsTransform::transform(Chunk & chunk)
 
     std::unordered_map<size_t, MutableColumnPtr> mixed_columns;
 
-    for (const ColumnWithTypeAndName & column_def : evaluate_block)
+    for (auto & column_def : evaluate_block)
     {
         const String & column_name = column_def.name;
 
@@ -199,6 +200,9 @@ void AddingDefaultsTransform::transform(Chunk & chunk)
 
         if (!defaults_mask.empty())
         {
+            column_read.column = recursiveRemoveSparse(column_read.column);
+            column_def.column = recursiveRemoveSparse(column_def.column);
+
             /// TODO: FixedString
             if (isColumnedAsNumber(column_read.type) || isDecimal(column_read.type))
             {

--- a/tests/queries/0_stateless/03271_parse_sparse_columns_defaults.reference
+++ b/tests/queries/0_stateless/03271_parse_sparse_columns_defaults.reference
@@ -1,0 +1,4 @@
+1	false
+2	false
+all_1_1_0	Sparse
+all_2_2_0	Sparse

--- a/tests/queries/0_stateless/03271_parse_sparse_columns_defaults.sh
+++ b/tests/queries/0_stateless/03271_parse_sparse_columns_defaults.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+$CLICKHOUSE_CLIENT --query "
+    DROP TABLE IF EXISTS test_default_bool;
+
+    CREATE TABLE test_default_bool (id Int8, b Bool DEFAULT false)
+    ENGINE = MergeTree ORDER BY id
+    SETTINGS ratio_of_defaults_for_sparse_serialization = 0.9;
+"
+
+echo 'INSERT INTO test_default_bool FORMAT CSV 1,\N' | $CLICKHOUSE_CURL -sS "$CLICKHOUSE_URL" --data-binary @-
+echo 'INSERT INTO test_default_bool FORMAT CSV 2,\N' | $CLICKHOUSE_CURL -sS "$CLICKHOUSE_URL" --data-binary @-
+
+$CLICKHOUSE_CLIENT --query "
+    SELECT * FROM test_default_bool ORDER BY id;
+    SELECT name, serialization_kind FROM system.parts_columns WHERE database = currentDatabase() AND table = 'test_default_bool' AND column = 'b' AND active;
+    DROP TABLE test_default_bool;
+"


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed filling of defaults after parsing into sparse columns

Fixes #71660.

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---ci_include_fuzzer--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
