### PR TITLE
add test 03248_max_parts_to_move

### DIFF
--- a/tests/queries/0_stateless/03248_max_parts_to_move.sql
+++ b/tests/queries/0_stateless/03248_max_parts_to_move.sql
@@ -1,0 +1,23 @@
+DROP TABLE IF EXISTS t;
+DROP TABLE IF EXISTS t2;
+
+CREATE TABLE t (x Int32) ENGINE = MergeTree ORDER BY x;
+CREATE TABLE t2 (x Int32) ENGINE = MergeTree ORDER BY x;
+
+SYSTEM STOP MERGES t;
+
+SET max_insert_block_size = 1;
+SET min_insert_block_size_rows = 1;
+SET max_block_size = 1;
+
+SET max_parts_to_move = 5;
+INSERT INTO t SELECT number from numbers(10);
+
+ALTER TABLE t MOVE PARTITION tuple() TO TABLE t2; -- { serverError TOO_MANY_PARTS }
+
+SET max_parts_to_move = 15;
+
+ALTER TABLE t MOVE PARTITION tuple() TO TABLE t2;
+
+DROP TABLE IF EXISTS t;
+DROP TABLE IF EXISTS t2;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...
