### PR TITLE
Auxiliary autodiscovery

### DIFF
--- a/src/Interpreters/ClusterDiscovery.h
+++ b/src/Interpreters/ClusterDiscovery.h
@@ -67,6 +67,7 @@ private:
     struct ClusterInfo
     {
         const String name;
+        const String zk_name;
         const String zk_root;
         NodesInfo nodes_info;
 
@@ -88,6 +89,7 @@ private:
         String cluster_secret;
 
         ClusterInfo(const String & name_,
+                    const String & zk_name_,
                     const String & zk_root_,
                     const String & host_name,
                     const String & username_,
@@ -99,6 +101,7 @@ private:
                     bool observer_mode,
                     bool invisible)
             : name(name_)
+            , zk_name(zk_name_)
             , zk_root(zk_root_)
             , current_node(host_name + ":" + toString(port), secure, shard_id)
             , current_node_is_observer(observer_mode)

--- a/tests/integration/test_cluster_discovery/config/config.xml
+++ b/tests/integration/test_cluster_discovery/config/config.xml
@@ -1,11 +1,6 @@
 <clickhouse>
     <allow_experimental_cluster_discovery>1</allow_experimental_cluster_discovery>
     <remote_servers>
-        <test_auto_cluster>
-            <discovery>
-                <path>/clickhouse/discovery/test_auto_cluster</path>
-            </discovery>
-        </test_auto_cluster>
         <two_shards>
             <!-- just to check that there's no conflict between automatic and manual clusters -->
             <shard>

--- a/tests/integration/test_cluster_discovery/config/config_discovery_path.xml
+++ b/tests/integration/test_cluster_discovery/config/config_discovery_path.xml
@@ -1,0 +1,9 @@
+<clickhouse>
+    <remote_servers>
+        <test_auto_cluster>
+            <discovery>
+                <path>/clickhouse/discovery/test_auto_cluster</path>
+            </discovery>
+        </test_auto_cluster>
+    </remote_servers>
+</clickhouse>

--- a/tests/integration/test_cluster_discovery/config/config_discovery_path_auxiliary_keeper.xml
+++ b/tests/integration/test_cluster_discovery/config/config_discovery_path_auxiliary_keeper.xml
@@ -1,0 +1,9 @@
+<clickhouse>
+    <remote_servers>
+        <test_auto_cluster>
+            <discovery>
+                <path>zookeeper2:/clickhouse/discovery/test_auto_cluster</path>
+            </discovery>
+        </test_auto_cluster>
+    </remote_servers>
+</clickhouse>

--- a/tests/integration/test_cluster_discovery/config/config_keepers.xml
+++ b/tests/integration/test_cluster_discovery/config/config_keepers.xml
@@ -1,0 +1,24 @@
+<clickhouse>
+    <zookeeper>
+        <node index="1">
+            <host>zoo1</host>
+            <port>2181</port>
+        </node>
+        <node index="2">
+            <host>zoo2</host>
+            <port>2181</port>
+        </node>
+        <node index="3">
+            <host>zoo3</host>
+            <port>2181</port>
+        </node>
+    </zookeeper>
+    <auxiliary_zookeepers>
+        <zookeeper2>
+            <node index="1">
+                <host>zoo1</host>
+                <port>2181</port>
+            </node>
+        </zookeeper2>
+    </auxiliary_zookeepers>
+</clickhouse>

--- a/tests/integration/test_cluster_discovery/config/config_observer.xml
+++ b/tests/integration/test_cluster_discovery/config/config_observer.xml
@@ -3,7 +3,6 @@
     <remote_servers>
         <test_auto_cluster>
             <discovery>
-                <path>/clickhouse/discovery/test_auto_cluster</path>
                 <observer/>
             </discovery>
         </test_auto_cluster>

--- a/tests/integration/test_cluster_discovery/config/config_shard1.xml
+++ b/tests/integration/test_cluster_discovery/config/config_shard1.xml
@@ -3,7 +3,6 @@
     <remote_servers>
         <test_auto_cluster>
             <discovery>
-                <path>/clickhouse/discovery/test_auto_cluster</path>
                 <shard>1</shard>
             </discovery>
         </test_auto_cluster>

--- a/tests/integration/test_cluster_discovery/config/config_shard3.xml
+++ b/tests/integration/test_cluster_discovery/config/config_shard3.xml
@@ -3,7 +3,6 @@
     <remote_servers>
         <test_auto_cluster>
             <discovery>
-                <path>/clickhouse/discovery/test_auto_cluster</path>
                 <shard>3</shard>
             </discovery>
         </test_auto_cluster>

--- a/tests/integration/test_cluster_discovery/config/macros0.xml
+++ b/tests/integration/test_cluster_discovery/config/macros0.xml
@@ -1,0 +1,6 @@
+<clickhouse>
+    <macros>
+        <shard>shard0</shard>
+        <replica>replica0</replica>
+    </macros>
+</clickhouse>

--- a/tests/integration/test_cluster_discovery/config/macros1.xml
+++ b/tests/integration/test_cluster_discovery/config/macros1.xml
@@ -1,0 +1,6 @@
+<clickhouse>
+    <macros>
+        <shard>shard1</shard>
+        <replica>replica1</replica>
+    </macros>
+</clickhouse>

--- a/tests/integration/test_cluster_discovery/config/macros2.xml
+++ b/tests/integration/test_cluster_discovery/config/macros2.xml
@@ -1,0 +1,6 @@
+<clickhouse>
+    <macros>
+        <shard>shard2</shard>
+        <replica>replica2</replica>
+    </macros>
+</clickhouse>

--- a/tests/integration/test_cluster_discovery/config/macros3.xml
+++ b/tests/integration/test_cluster_discovery/config/macros3.xml
@@ -1,0 +1,6 @@
+<clickhouse>
+    <macros>
+        <shard>shard3</shard>
+        <replica>replica3</replica>
+    </macros>
+</clickhouse>

--- a/tests/integration/test_cluster_discovery/config/macros4.xml
+++ b/tests/integration/test_cluster_discovery/config/macros4.xml
@@ -1,0 +1,6 @@
+<clickhouse>
+    <macros>
+        <shard>shard4</shard>
+        <replica>replica4</replica>
+    </macros>
+</clickhouse>

--- a/tests/integration/test_cluster_discovery/config/macros_o.xml
+++ b/tests/integration/test_cluster_discovery/config/macros_o.xml
@@ -1,0 +1,6 @@
+<clickhouse>
+    <macros>
+        <shard>shard_o</shard>
+        <replica>replica_o</replica>
+    </macros>
+</clickhouse>

--- a/tests/integration/test_cluster_discovery/test.py
+++ b/tests/integration/test_cluster_discovery/test.py
@@ -119,3 +119,8 @@ def test_cluster_discovery_startup_and_stop(start_cluster):
     check_nodes_count(
         [nodes["node1"], nodes["node2"]], 2, cluster_name="two_shards", retries=1
     )
+
+    # cleanup
+    nodes["node0"].query(
+        "DROP TABLE tbl ON CLUSTER 'test_auto_cluster' SYNC"
+    )

--- a/tests/integration/test_cluster_discovery/test.py
+++ b/tests/integration/test_cluster_discovery/test.py
@@ -121,6 +121,4 @@ def test_cluster_discovery_startup_and_stop(start_cluster):
     )
 
     # cleanup
-    nodes["node0"].query(
-        "DROP TABLE tbl ON CLUSTER 'test_auto_cluster' SYNC"
-    )
+    nodes["node0"].query("DROP TABLE tbl ON CLUSTER 'test_auto_cluster' SYNC")

--- a/tests/integration/test_cluster_discovery/test_auxiliary_keeper.py
+++ b/tests/integration/test_cluster_discovery/test_auxiliary_keeper.py
@@ -20,10 +20,13 @@ shard_configs = {
 nodes = {
     node_name: cluster.add_instance(
         node_name,
-        main_configs=shard_config + ["config/config_discovery_path_auxiliary_keeper.xml", "config/config_keepers.xml"],
+        main_configs=shard_config
+        + [
+            "config/config_discovery_path_auxiliary_keeper.xml",
+            "config/config_keepers.xml",
+        ],
         stay_alive=True,
         with_zookeeper=True,
-        #use_keeper=False,
     )
     for node_name, shard_config in shard_configs.items()
 }

--- a/tests/integration/test_cluster_discovery/test_auxiliary_keeper.py
+++ b/tests/integration/test_cluster_discovery/test_auxiliary_keeper.py
@@ -122,3 +122,8 @@ def test_cluster_discovery_with_auxiliary_keeper_startup_and_stop(start_cluster)
     check_nodes_count(
         [nodes["node1"], nodes["node2"]], 2, cluster_name="two_shards", retries=1
     )
+
+    # cleanup
+    nodes["node0"].query(
+        "DROP TABLE tbl ON CLUSTER 'test_auto_cluster' SYNC"
+    )

--- a/tests/integration/test_cluster_discovery/test_auxiliary_keeper.py
+++ b/tests/integration/test_cluster_discovery/test_auxiliary_keeper.py
@@ -124,6 +124,4 @@ def test_cluster_discovery_with_auxiliary_keeper_startup_and_stop(start_cluster)
     )
 
     # cleanup
-    nodes["node0"].query(
-        "DROP TABLE tbl ON CLUSTER 'test_auto_cluster' SYNC"
-    )
+    nodes["node0"].query("DROP TABLE tbl ON CLUSTER 'test_auto_cluster' SYNC")


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Use auxiliary keepers for cluster autodiscovery

### Documentation entry for user-facing changes
[Cluster autodicovery feature](https://clickhouse.com/docs/en/operations/cluster-discovery) did not work with auxiliary keepers:
```
2024.11.14 10:41:23.511057 [ 658 ] {} <Error> ZooKeeperClient: Code: 999. Coordination::Exception: Path must begin with /, got path 'zookeeper2:/clickhouse/discovery/test_auto_cluster/shards'. (KEEPER_EXCEPTION), Stack trace (when copying this message, always include the lines below):

0. ./contrib/llvm-project/libcxx/include/exception:141: Poco::Exception::Exception(String const&, int) @ 0x000000001439dbf2
1. /home/iantonspb/ch-build/./src/Common/Exception.cpp:109: DB::Exception::Exception(DB::Exception::MessageMasked&&, int, bool) @ 0x000000000b4d19b9
2. DB::Exception::Exception(PreformattedMessage&&, int) @ 0x000000000691ef0c
3. DB::Exception::Exception<String&>(int, FormatStringHelperImpl<std::type_identity<String&>::type>, String&) @ 0x000000000693876b
4. ./src/Common/ZooKeeper/IKeeper.h:512: Coordination::Exception::Exception<String&>(Coordination::Error, FormatStringHelperImpl<std::type_identity<String&>::type>, String&) @ 0x00000000111bb2ab
5. /home/iantonspb/ch-build/./src/Common/ZooKeeper/IKeeper.cpp:96: Coordination::addRootPath(String&, String const&) @ 0x000000001243eeeb
6. /home/iantonspb/ch-build/./src/Common/ZooKeeper/ZooKeeperImpl.cpp:758: Coordination::ZooKeeper::sendThread() @ 0x000000001249c1ac
7. /home/iantonspb/ch-build/./src/Common/ZooKeeper/ZooKeeperImpl.cpp:406: void std::__function::__policy_invoker<void ()>::__call_impl<std::__function::__default_alloc_func<ThreadFromGlobalPoolImpl<true, true>::ThreadFromGlobalPoolImpl<Coordination::ZooKeeper::ZooKeeper(std::vector<zkutil::ShuffleHost, std::allocator<zkutil::ShuffleHost>> const&, zkutil::ZooKeeperArgs const&, std::shared_ptr<DB::ZooKeeperLog>)::$_0>(Coordination::ZooKeeper::ZooKeeper(std::vector<zkutil::ShuffleHost, std::allocator<zkutil::ShuffleHost>> const&, zkutil::ZooKeeperArgs const&, std::shared_ptr<DB::ZooKeeperLog>)::$_0&&)::'lambda'(), void ()>>(std::__function::__policy_storage const*) @ 0x00000000124a3047
8. ./contrib/llvm-project/libcxx/include/__functional/function.h:848: ? @ 0x000000000b59dbc3
9. ./contrib/llvm-project/libcxx/include/__functional/invoke.h:359: ? @ 0x000000000b5a2e9b
10. ? @ 0x00007f4fada05ac3
11. ? @ 0x00007f4fada97850
 (version 24.11.1.1)
```
Now it works.

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---ci_include_fuzzer--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
