### PR TITLE
fix: prevent overflow error in utc timestamp conversion

### DIFF
--- a/src/Functions/UTCTimestampTransform.cpp
+++ b/src/Functions/UTCTimestampTransform.cpp
@@ -88,10 +88,20 @@ namespace
                 {
                     UInt32 date_time_val = date_time_col.getElement(i);
                     auto time_zone_offset = time_zone.timezoneOffset(date_time_val);
-                    if constexpr (toUTC)
+                    if constexpr (toUTC) {
                         result_data[i] = date_time_val - static_cast<UInt32>(time_zone_offset);
-                    else
+                        if (result_data[i] > date_time_val) {
+                            // Overflow occured
+                            result_data[i] = UINT32_MAX;
+                        }
+                    }
+                    else {
                         result_data[i] = date_time_val + static_cast<UInt32>(time_zone_offset);
+                        if (result_data[i] < date_time_val) {
+                            // Underflow occurred
+                            result_data[i] = 0;
+                        }
+                    }
                 }
                 return result_column;
             }


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix to_utc_timestamp and from_utc_timestamp over unix epoch limits.

This change will probably fix #71470 . I think the issue is due to integer overflow and I added conditional checks to detect the overflow for fixing it.