### PR TITLE
S3: Do not match directory itself with trailing wildcard

### DIFF
--- a/src/Storages/ObjectStorage/StorageObjectStorageSource.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorageSource.cpp
@@ -552,7 +552,7 @@ StorageObjectStorage::ObjectInfoPtr StorageObjectStorageSource::IIterator::next(
 
     if (object_info)
     {
-        LOG_TEST(logger, "Next key: {}", object_info->getFileName());
+        LOG_TEST(logger, "Next key: {}", object_info->getPath());
     }
 
     return object_info;
@@ -658,7 +658,7 @@ StorageObjectStorage::ObjectInfoPtr StorageObjectStorageSource::GlobIterator::ne
             new_batch = std::move(result.value());
             for (auto it = new_batch.begin(); it != new_batch.end();)
             {
-                if (!recursive && !re2::RE2::FullMatch((*it)->getPath(), *matcher))
+                if (!recursive && (!re2::RE2::FullMatch((*it)->getPath(), *matcher) || (*it)->getFileName().empty()))
                     it = new_batch.erase(it);
                 else
                     ++it;


### PR DESCRIPTION
When reading from S3 with a trailing wildcard, ClickHouse will often fail to read the correct data (see examples below). The reason is that when a path ends in `/*`, the first match will be the directory itself and not the first file. This causes all kinds of problems further up the code.

This PR fixes it by only matching objects with a filename that is not empty. 

I was thinking of writing an integration test for this, but I'm doing my development on macOS, and the integration tests don't run there. I could probably get this all set up on a VM, but I'm not sure how much time that would take, and this is a pretty simple fix.

### Example queries (before)
Here, it returns 0 rows and no error (it works without the LIMIT but will eventually also throw an error):
```sql
SELECT *
FROM s3('https://clickhouse-public-datasets.s3.amazonaws.com/wikistat/**/*', NOSIGN)
LIMIT 1

Query id: 57d81ccb-4ba9-40b3-989a-8253f9c37c9b

Ok.

0 rows in set. Elapsed: 8.357 sec.
```

Here, it returns an error but doesn't read the data it could:
```sql
SELECT *
FROM s3('https://datasets-documentation.s3.eu-west-3.amazonaws.com/amazon_reviews/*', NOSIGN)
LIMIT 1

Query id: 7a4c5505-94dd-41df-ac9a-ed45cb6909cb


Elapsed: 0.345 sec.

Received exception:
Code: 499. DB::Exception: Failed to get object info: No response body.. HTTP response code: 403: The data format cannot be detected by the contents of the files. You can specify the format manually: (in file/uri amazon_reviews/). (S3_ERROR)
```

### Example queries (after)
```sql
SELECT *
FROM s3('https://clickhouse-public-datasets.s3.amazonaws.com/wikistat/**/*', NOSIGN)
LIMIT 1

Query id: b9005894-29a9-4f07-a0b3-ffa0c79068d5

   ┌─c1────────────────┐
1. │ aa Main_Page 12 0 │
   └───────────────────┘

1 row in set. Elapsed: 8.809 sec.
```

```sql
SELECT *
FROM s3('https://datasets-documentation.s3.eu-west-3.amazonaws.com/amazon_reviews/*', NOSIGN)
LIMIT 1

Query id: 820c9c5b-4bad-4ff6-9328-3d094d1a011f

   ┌─review_date─┬─marketplace─┬─customer_id─┬─review_id─────┬─product_id─┬─product_parent─┬─product_title────────────────────────────────────────────┬─product_category─┬─star_rating─┬─helpful_votes─┬─total_votes─┬─vine──┬─verified_purchase─┬─review_headline─┬─review_body────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
1. │        9305 │ US          │    53096571 │ RHL4UW17ZK72A │ 0521314925 │      980601331 │ Invention and Evolution:Design in Nature and Engineering │ Books            │           5 │             9 │           9 │ false │ false             │ BUY THIS BOOK!  │ This is a beautiful book.  French talks about energy, form, mechanism, and economy in natural and man-made things.  He compares birds to planes in terms of fuel-capacity, energy  conversion efficiency, drag, etc.  He compares suspension   bridges and dinosaurs.  He provides examples of neat   inventions and the thought that has gone into them (every-  thing from steam-catapults to toy cars to grommets).  This  is &quot;How Things Work&quot; for the non-moron crowd. │
   └─────────────┴─────────────┴─────────────┴───────────────┴────────────┴────────────────┴──────────────────────────────────────────────────────────┴──────────────────┴─────────────┴───────────────┴─────────────┴───────┴───────────────────┴─────────────────┴────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘

1 row in set. Elapsed: 4.771 sec.
```

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix reading files from a path in object storage with a trailing wildcard.