### PR TITLE
Documenting MergeTree's ttl_only_drop_parts setting, and updating ref…

### DIFF
--- a/docs/en/engines/table-engines/mergetree-family/mergetree.md
+++ b/docs/en/engines/table-engines/mergetree-family/mergetree.md
@@ -684,8 +684,7 @@ If you perform the `SELECT` query between merges, you may get expired data. To a
 
 **See Also**
 
-- [ttl_only_drop_parts](/docs/en/operations/settings/settings.md/#ttl_only_drop_parts) setting
-
+- [ttl_only_drop_parts](/docs/en/operations/settings/merge-tree-settings#ttl_only_drop_parts) setting
 
 ## Disk types
 

--- a/docs/en/operations/settings/merge-tree-settings.md
+++ b/docs/en/operations/settings/merge-tree-settings.md
@@ -78,6 +78,16 @@ If `min_merge_bytes_to_use_direct_io = 0`, then direct I/O is disabled.
 
 Default value: `10 * 1024 * 1024 * 1024` bytes.
 
+## ttl_only_drop_parts
+
+Controls whether data parts are fully dropped in MergeTree tables when all rows in that part have expired according to their `TTL` settings.
+
+When `ttl_only_drop_parts` is disabled (by default), only the rows that have expired based on their TTL settings are removed.
+
+When `ttl_only_drop_parts` is enabled, the entire part is dropped if all rows in that part have expired according to their `TTL` settings.
+
+Default value: 0.
+
 ## merge_with_ttl_timeout
 
 Minimum delay in seconds before repeating a merge with delete TTL.


### PR DESCRIPTION
Documenting MergeTree's ttl_only_drop_parts setting, and updating reference to it.

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Documenting MergeTree’s ttl_only_drop_parts setting, and updating reference to it.