### PR TITLE
Fix formatting of `MOVE PARTITION ... TO TABLE ...` alter commands

### DIFF
--- a/src/Parsers/ASTAlterQuery.cpp
+++ b/src/Parsers/ASTAlterQuery.cpp
@@ -74,9 +74,7 @@ void ASTAlterCommand::formatImpl(const FormatSettings & settings, FormatState & 
     if (format_alter_commands_with_parentheses)
     {
         settings.ostr << "(";
-        closing_bracket_guard = make_scope_guard(std::function<void(void)>([&settings](){
-            settings.ostr << ")";
-        }));
+        closing_bracket_guard = make_scope_guard(std::function<void(void)>([&settings]() { settings.ostr << ")"; }));
     }
 
     if (type == ASTAlterCommand::ADD_COLUMN)

--- a/src/Parsers/ASTAlterQuery.cpp
+++ b/src/Parsers/ASTAlterQuery.cpp
@@ -70,8 +70,14 @@ ASTPtr ASTAlterCommand::clone() const
 
 void ASTAlterCommand::formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
 {
+    scope_guard closing_bracket_guard;
     if (format_alter_commands_with_parentheses)
+    {
         settings.ostr << "(";
+        closing_bracket_guard = make_scope_guard([&settings](){
+            settings.ostr << ")";
+        });
+    }
 
     if (type == ASTAlterCommand::ADD_COLUMN)
     {
@@ -498,9 +504,6 @@ void ASTAlterCommand::formatImpl(const FormatSettings & settings, FormatState & 
     }
     else
         throw Exception(ErrorCodes::UNEXPECTED_AST_STRUCTURE, "Unexpected type of ALTER");
-
-    if (format_alter_commands_with_parentheses)
-        settings.ostr << ")";
 }
 
 void ASTAlterCommand::forEachPointerToChild(std::function<void(void**)> f)

--- a/src/Parsers/ASTAlterQuery.cpp
+++ b/src/Parsers/ASTAlterQuery.cpp
@@ -74,9 +74,9 @@ void ASTAlterCommand::formatImpl(const FormatSettings & settings, FormatState & 
     if (format_alter_commands_with_parentheses)
     {
         settings.ostr << "(";
-        closing_bracket_guard = make_scope_guard([&settings](){
+        closing_bracket_guard = make_scope_guard(std::function<void(void)>([&settings](){
             settings.ostr << ")";
-        });
+        }));
     }
 
     if (type == ASTAlterCommand::ADD_COLUMN)

--- a/tests/integration/test_unambiguous_alter_commands/test.py
+++ b/tests/integration/test_unambiguous_alter_commands/test.py
@@ -43,3 +43,10 @@ ALTER TABLE a\\n    (DROP COLUMN b),\\n    (DROP COLUMN c)
 """
     result = node.query(INPUT)
     assert result == EXPECTED_OUTPUT
+
+
+def test_move_partition_to_table_command():
+    INPUT = "SELECT formatQuery('ALTER TABLE a MOVE PARTITION tuple() TO TABLE b')"
+    EXPECTED_OUTPUT = "ALTER TABLE a\\n    (MOVE  PARTITION tuple() TO TABLE b)"
+    result = node.query(INPUT)
+    assert result == EXPECTED_OUTPUT

--- a/tests/integration/test_unambiguous_alter_commands/test.py
+++ b/tests/integration/test_unambiguous_alter_commands/test.py
@@ -47,6 +47,6 @@ ALTER TABLE a\\n    (DROP COLUMN b),\\n    (DROP COLUMN c)
 
 def test_move_partition_to_table_command():
     INPUT = "SELECT formatQuery('ALTER TABLE a MOVE PARTITION tuple() TO TABLE b')"
-    EXPECTED_OUTPUT = "ALTER TABLE a\\n    (MOVE  PARTITION tuple() TO TABLE b)"
+    EXPECTED_OUTPUT = "ALTER TABLE a\\n    (MOVE PARTITION tuple() TO TABLE b)\n"
     result = node.query(INPUT)
     assert result == EXPECTED_OUTPUT


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Fix formatting of `MOVE PARTITION ... TO TABLE ...` alter commands when `format_alter_commands_with_parentheses` is enabled.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---ci_include_fuzzer--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
