### PR TITLE
Respect `prefer_locahost_replica` in `parallel_distributed_insert_select`

### DIFF
--- a/src/Storages/StorageDistributed.cpp
+++ b/src/Storages/StorageDistributed.cpp
@@ -161,6 +161,7 @@ namespace Setting
     extern const SettingsBool optimize_skip_unused_shards;
     extern const SettingsUInt64 optimize_skip_unused_shards_limit;
     extern const SettingsUInt64 parallel_distributed_insert_select;
+    extern const SettingsBool prefer_localhost_replica;
 }
 
 namespace DistributedSetting
@@ -1030,7 +1031,7 @@ std::optional<QueryPipeline> StorageDistributed::distributedWriteBetweenDistribu
     for (size_t shard_index : collections::range(0, shards_info.size()))
     {
         const auto & shard_info = shards_info[shard_index];
-        if (shard_info.isLocal() && settings.prefer_localhost_replica)
+        if (shard_info.isLocal() && settings[Setting::prefer_localhost_replica])
         {
             InterpreterInsertQuery interpreter(
                 new_query,

--- a/src/Storages/StorageDistributed.cpp
+++ b/src/Storages/StorageDistributed.cpp
@@ -1030,7 +1030,7 @@ std::optional<QueryPipeline> StorageDistributed::distributedWriteBetweenDistribu
     for (size_t shard_index : collections::range(0, shards_info.size()))
     {
         const auto & shard_info = shards_info[shard_index];
-        if (shard_info.isLocal())
+        if (shard_info.isLocal() && settings.prefer_localhost_replica)
         {
             InterpreterInsertQuery interpreter(
                 new_query,


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Respect `prefer_locahost_replica` when building plan for distributed `INSERT ... SELECT`.

---

Currently the local part of the pipeline to execute complex insert .. select with parallel_distributed_insert_select is mixed together with remote pipelines just waiting for the remote query execution. 

So if the local pipeline takes all (or most of) threads, the remote pipelines will not be started at all for a longer time. 

The simplest possible workaround for that - to disable prefer_localhost_replica to make all subqueries executed in remote way is not possible currently, since the feature just ignores prefer_locahost_replica=0