### PR TITLE
Remove log message "Table is in readonly mode" while dropping a table.

### DIFF
--- a/src/Storages/StorageReplicatedMergeTree.h
+++ b/src/Storages/StorageReplicatedMergeTree.h
@@ -404,6 +404,7 @@ private:
     /// for table.
     zkutil::ZooKeeperPtr getZooKeeperIfTableShutDown() const;
     zkutil::ZooKeeperPtr getZooKeeperAndAssertNotReadonly() const;
+    zkutil::ZooKeeperPtr getZooKeeperAndAssertNotStaticStorage() const;
     void setZooKeeper();
     String getEndpointName() const;
 
@@ -841,6 +842,9 @@ private:
 
     /// Throw an exception if the table is readonly.
     void assertNotReadonly() const;
+
+    /// Throw an exception if the table is readonly because it's a static storage.
+    void assertNotStaticStorage() const;
 
     /// Produce an imaginary part info covering all parts in the specified partition (at the call moment).
     /// Returns false if the partition doesn't exist yet.


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Remove log message `Table is in readonly mode` while dropping a table.

Before this fix we could sometimes see in the logs an error with text `Table is in readonly mode` while dropping a table, for example:
```
2024.11.20 16:06:00.382085 [ 13 ] {cf295a88-d888-4573-9fc2-0b24e55b24c9} <Debug> executeQuery: (from 172.16.1.1:55524) DROP TABLE tbl ON CLUSTER 'cluster' SYNC (stage: Complete)
2024.11.20 16:06:00.398520 [ 676 ] {} <Trace> DDLWorker: Too early to clean queue, will do it later.
2024.11.20 16:06:00.404947 [ 671 ] {} <Debug> DDLWorker: Scheduling tasks
2024.11.20 16:06:00.407837 [ 671 ] {} <Trace> DDLWorker: scheduleTasks: initialized=true, size_before_filtering=6, queue_size=6, entries=query-0000000000..query-0000000005, first_failed_task_name=none, current_tasks_size=1, last_current_task=query-0000000004, last_skipped_entry_name=none
2024.11.20 16:06:00.407931 [ 671 ] {} <Debug> DDLWorker: Will schedule 1 tasks starting from query-0000000005
2024.11.20 16:06:00.407976 [ 671 ] {} <Trace> DDLWorker: Checking task query-0000000005
2024.11.20 16:06:00.409813 [ 671 ] {} <Debug> DDLWorker: Processing task query-0000000005 (query: DROP TABLE default.tbl SYNC, backup restore: false)
2024.11.20 16:06:00.416986 [ 671 ] {} <Debug> DDLWorker: Executing query: DROP TABLE default.tbl SYNC
2024.11.20 16:06:00.417967 [ 671 ] {7e908dae-f1bd-4ed6-b662-630caa801c8a} <Debug> executeQuery: (from 0.0.0.0:0, user: , initial_query_id: cf295a88-d888-4573-9fc2-0b24e55b24c9) /* ddl_entry=query-0000000005 */ DROP TABLE default.tbl SYNC (stage: Complete)
2024.11.20 16:06:00.418260 [ 671 ] {7e908dae-f1bd-4ed6-b662-630caa801c8a} <Trace> default.tbl (cc260820-5987-4578-8465-020159de6375): Start preparing for shutdown
2024.11.20 16:06:00.418320 [ 671 ] {7e908dae-f1bd-4ed6-b662-630caa801c8a} <Information> default.tbl (cc260820-5987-4578-8465-020159de6375): Stopped being leader
2024.11.20 16:06:00.418389 [ 671 ] {7e908dae-f1bd-4ed6-b662-630caa801c8a} <Trace> default.tbl (ReplicatedMergeTreeRestartingThread): Restarting thread finished
2024.11.20 16:06:00.418436 [ 671 ] {7e908dae-f1bd-4ed6-b662-630caa801c8a} <Trace> default.tbl (cc260820-5987-4578-8465-020159de6375): Finished preparing for shutdown
2024.11.20 16:06:00.418472 [ 671 ] {7e908dae-f1bd-4ed6-b662-630caa801c8a} <Trace> default.tbl (cc260820-5987-4578-8465-020159de6375): Shutdown started
2024.11.20 16:06:00.418510 [ 671 ] {7e908dae-f1bd-4ed6-b662-630caa801c8a} <Trace> default.tbl (cc260820-5987-4578-8465-020159de6375): Will not wait for unique parts to be fetched by other replicas because shutdown called from DROP/DETACH query
2024.11.20 16:06:00.424633 [ 671 ] {7e908dae-f1bd-4ed6-b662-630caa801c8a} <Trace> default.tbl (cc260820-5987-4578-8465-020159de6375): Waiting for threads to finish
2024.11.20 16:06:00.542815 [ 379 ] {} <Error> default.tbl (cc260820-5987-4578-8465-020159de6375): void DB::StorageReplicatedMergeTree::mutationsFinalizingTask(): Code: 242. DB::Exception: Table is in readonly mode (replica path: /clickhouse/tables/tbl/replicas/node1). (TABLE_IS_READ_ONLY), Stack trace (when copying this message, always include the lines below):

0. ./contrib/llvm-project/libcxx/include/exception:141: Poco::Exception::Exception(String const&, int) @ 0x000000001fd06643
1. ./build_docker/./src/Common/Exception.cpp:109: DB::Exception::Exception(DB::Exception::MessageMasked&&, int, bool) @ 0x000000000ffad475
2. DB::Exception::Exception(PreformattedMessage&&, int) @ 0x000000000789d01e
3. DB::Exception::Exception<String const&>(int, FormatStringHelperImpl<std::type_identity<String const&>::type>, String const&) @ 0x00000000078c5640
4. ./build_docker/./src/Storages/StorageReplicatedMergeTree.cpp:5716: DB::StorageReplicatedMergeTree::assertNotReadonly() const @ 0x000000001a8ea400
5. ./build_docker/./src/Storages/StorageReplicatedMergeTree.cpp:320: DB::StorageReplicatedMergeTree::mutationsFinalizingTask() @ 0x000000001a98a080
6. ./build_docker/./src/Storages/StorageReplicatedMergeTree.cpp:419: void std::__function::__policy_invoker<void ()>::__call_impl<std::__function::__default_alloc_func<DB::StorageReplicatedMergeTree::StorageReplicatedMergeTree(DB::TableZnodeInfo const&, DB::LoadingStrictnessLevel, DB::StorageID const&, String const&, DB::StorageInMemoryMetadata const&, std::shared_ptr<DB::Context>, String const&, DB::MergeTreeData::MergingParams const&, std::unique_ptr<DB::MergeTreeSettings, std::default_delete<DB::MergeTreeSettings>>, bool)::$_4, void ()>>(std::__function::__policy_storage const*) @ 0x000000001aa46842
7. ./contrib/llvm-project/libcxx/include/__functional/function.h:848: ? @ 0x000000001751b792
8. ./build_docker/./src/Core/BackgroundSchedulePool.cpp:304: DB::BackgroundSchedulePool::threadFunction() @ 0x000000001751faae
9. ./build_docker/./src/Core/BackgroundSchedulePool.cpp:170: void std::__function::__policy_invoker<void ()>::__call_impl<std::__function::__default_alloc_func<ThreadFromGlobalPoolImpl<false, true>::ThreadFromGlobalPoolImpl<DB::BackgroundSchedulePool::BackgroundSchedulePool(unsigned long, StrongTypedef<unsigned long, CurrentMetrics::MetricTag>, StrongTypedef<unsigned long, CurrentMetrics::MetricTag>, char const*)::$_0>(DB::BackgroundSchedulePool::BackgroundSchedulePool(unsigned long, StrongTypedef<unsigned long, CurrentMetrics::MetricTag>, StrongTypedef<unsigned long, CurrentMetrics::MetricTag>, char const*)::$_0&&)::'lambda'(), void ()>>(std::__function::__policy_storage const*) @ 0x0000000017520453
10. ./contrib/llvm-project/libcxx/include/__functional/function.h:848: ? @ 0x00000000100bad7e
11. ./contrib/llvm-project/libcxx/include/__functional/invoke.h:359: ? @ 0x00000000100c2d1c
12. __tsan_thread_start_func @ 0x0000000007814f2f
13. ? @ 0x00007f254b429ac3
14. ? @ 0x00007f254b4bb850
 (version 24.11.1.2386 (official build))
2024.11.20 16:06:00.543208 [ 671 ] {7e908dae-f1bd-4ed6-b662-630caa801c8a} <Trace> default.tbl (cc260820-5987-4578-8465-020159de6375): Threads finished
2024.11.20 16:06:00.543343 [ 671 ] {7e908dae-f1bd-4ed6-b662-630caa801c8a} <Trace> default.tbl (cc260820-5987-4578-8465-020159de6375): Shutdown finished
```

A replicated table is EXPECTED to become readonly while shutting down before dropping, we shouldn't log that as an error. This PR fixes that, and also fixes flaky `test_backup_restore_on_cluster/test_cancel_backup.py::test_cancel_restore`(see [failure](https://s3.amazonaws.com/clickhouse-test-reports/0/64ea850e5bc22899e5d6870e5523e1a821c12263/integration_tests__tsan__[1_6].html)).