### PR TITLE
fix switched ja `MaterializedPostgreSQL` and `MaterializedMySQL` links in docs

### DIFF
--- a/docs/ja/cloud/manage/integrations.md
+++ b/docs/ja/cloud/manage/integrations.md
@@ -28,5 +28,5 @@ Looker StudioをClickHouse Cloudに接続するには、[MySQLインターフェ
 
 以下のインテグレーション機能は現在、ClickHouse Cloudでは利用できません。これらはエクスペリメンタルな機能であるため、アプリケーションでこれらの機能をサポートする必要がある場合は、support@clickhouse.comまでご連絡ください。
 
-- [MaterializedPostgreSQL](/ja/engines/database-engines/materialized-mysql)
-- [MaterializedMySQL](/ja/engines/table-engines/integrations/materialized-postgresql)
+- [MaterializedPostgreSQL](/ja/engines/table-engines/integrations/materialized-postgresql)
+- [MaterializedMySQL](/ja/engines/database-engines/materialized-mysql)


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
Documentation (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
fix switched ja MaterializedPostgreSQL and MaterializedMySQL links in docs