### PR TITLE
Improve grace hash join performance by moving the smaller table to the right side

### DIFF
--- a/src/Interpreters/GraceHashJoin.cpp
+++ b/src/Interpreters/GraceHashJoin.cpp
@@ -430,6 +430,9 @@ void GraceHashJoin::initialize(const Block & sample_block)
 
 void GraceHashJoin::joinBlock(Block & block, std::shared_ptr<ExtraBlock> & not_processed)
 {
+    if (rightTableCanBeReranged())
+        tryRerangeRightTableData();
+
     if (block.rows() == 0)
     {
         hash_join->joinBlock(block, not_processed);
@@ -713,11 +716,12 @@ void GraceHashJoin::addBlockToJoinImpl(Block block)
             if (!current_block.rows())
                 return;
         }
-
         auto prev_keys_num = hash_join->getTotalRowCount();
-        hash_join->addBlockToJoin(current_block, /* check_limits = */ false);
 
-        if (!hasMemoryOverflow(hash_join))
+        hash_join->addBlockToJoin(current_block, /* check_limits = */ false);
+        size_t hash_join_total_keys = hash_join->getAndSetRightTableKeys();
+        size_t hash_join_total_bytes = hash_join->getTotalByteCount();
+        if (!hasMemoryOverflow(hash_join_total_keys, hash_join_total_bytes))
             return;
 
         current_block = {};
@@ -754,6 +758,20 @@ size_t GraceHashJoin::getNumBuckets() const
 {
     std::shared_lock lock(rehash_mutex);
     return buckets.size();
+}
+
+bool GraceHashJoin::rightTableCanBeReranged() const
+{
+    if (hash_join && getNumBuckets() <= 1)
+        return hash_join->rightTableCanBeReranged();
+    return false;
+}
+
+void GraceHashJoin::tryRerangeRightTableData()
+{
+    std::lock_guard lock(hash_join_mutex);
+    if (hash_join)
+        hash_join->tryRerangeRightTableData();
 }
 
 GraceHashJoin::Buckets GraceHashJoin::getCurrentBuckets() const

--- a/src/Interpreters/GraceHashJoin.h
+++ b/src/Interpreters/GraceHashJoin.h
@@ -84,6 +84,8 @@ public:
     /// Must be called after all @joinBlock calls.
     IBlocksStreamPtr getDelayedBlocks() override;
     bool hasDelayedBlocks() const override { return true; }
+    bool rightTableCanBeReranged() const override;
+    void tryRerangeRightTableData() override;
 
     static bool isSupported(const std::shared_ptr<TableJoin> & table_join);
 

--- a/src/Interpreters/HashJoin/HashJoin.h
+++ b/src/Interpreters/HashJoin/HashJoin.h
@@ -407,6 +407,10 @@ public:
     void materializeColumnsFromLeftBlock(Block & block) const;
     Block materializeColumnsFromRightBlock(Block block) const;
 
+    bool rightTableCanBeReranged() const override;
+    void tryRerangeRightTableData() override;
+    size_t getAndSetRightTableKeys() const;
+
 private:
     friend class NotJoinedHash;
 
@@ -489,7 +493,6 @@ private:
     void validateAdditionalFilterExpression(std::shared_ptr<ExpressionActions> additional_filter_expression);
     bool needUsedFlagsForPerRightTableRow(std::shared_ptr<TableJoin> table_join_) const;
 
-    void tryRerangeRightTableData() override;
     template <JoinKind KIND, typename Map, JoinStrictness STRICTNESS>
     void tryRerangeRightTableDataImpl(Map & map);
     void doDebugAsserts() const;

--- a/src/Interpreters/IJoin.h
+++ b/src/Interpreters/IJoin.h
@@ -122,6 +122,7 @@ public:
     /// Peek next stream of delayed joined blocks.
     virtual IBlocksStreamPtr getDelayedBlocks() { return nullptr; }
     virtual bool hasDelayedBlocks() const { return false; }
+    virtual bool rightTableCanBeReranged() const { return false; }
     virtual void tryRerangeRightTableData() {}
 
     virtual IBlocksStreamPtr

--- a/src/Processors/Transforms/JoiningTransform.cpp
+++ b/src/Processors/Transforms/JoiningTransform.cpp
@@ -351,12 +351,11 @@ void FillingRightJoinSideTransform::work()
         stop_reading = !join->addBlockToJoin(block);
     }
 
-    if (input.isFinished())
+    if (input.isFinished() && !join->supportParallelJoin())
         join->tryRerangeRightTableData();
 
     set_totals = for_totals;
 }
-
 
 DelayedJoinedBlocksWorkerTransform::DelayedJoinedBlocksWorkerTransform(
     Block output_header_,

--- a/src/Processors/Transforms/JoiningTransform.h
+++ b/src/Processors/Transforms/JoiningTransform.h
@@ -118,7 +118,6 @@ private:
     bool set_totals = false;
 };
 
-
 class DelayedBlocksTask : public ChunkInfoCloneable<DelayedBlocksTask>
 {
 public:

--- a/tests/performance/all_join_opt.xml
+++ b/tests/performance/all_join_opt.xml
@@ -5,11 +5,21 @@
     <fill_query>INSERT INTO test SELECT number % 10000, number % 10000, number % 10000 FROM numbers(10000000)</fill_query>
     <fill_query>INSERT INTO test1 SELECT number % 1000 , number % 1000, number % 1000 FROM numbers(100000)</fill_query>
 
+    <!-- test for hash join -->
     <query tag='INNER'>SELECT MAX(test1.a) FROM test INNER JOIN test1 on test.b = test1.b settings join_algorithm='hash'</query>
     <query tag='INNER'>SELECT MAX(test1.a) FROM test INNER JOIN test1 on test.b = test1.b settings join_algorithm='parallel_hash'</query>
     <query tag='LEFT'>SELECT MAX(test1.a) FROM test LEFT JOIN test1 on test.b = test1.b</query>
     <query tag='RIGHT'>SELECT MAX(test1.a) FROM test RIGHT JOIN test1 on test.b = test1.b</query>
     <query tag='FULL'>SELECT MAX(test1.a) FROM test FULL JOIN test1 on test.b = test1.b</query>
+
+    <!-- test for grace hash join -->
+    <settings>
+        <allow_experimental_join_right_table_sorting>true</allow_experimental_join_right_table_sorting>
+        <join_to_sort_maximum_table_rows>100000</join_to_sort_maximum_table_rows>
+    </settings>
+
+    <query tag='INNER'>SELECT MAX(test1.a) FROM test INNER JOIN test1 on test.b = test1.b settings join_algorithm='grace_hash'</query>
+    <query tag='LEFT'>SELECT MAX(test1.a) FROM test LEFT JOIN test1 on test.b = test1.b settings join_algorithm='grace_hash'</query>
 
     <drop_query>DROP TABLE IF EXISTS test</drop_query>
     <drop_query>DROP TABLE IF EXISTS test1</drop_query>


### PR DESCRIPTION
Improve  join performance by rerange the right table by keys, and this has been applied to hash join at pr: https://github.com/ClickHouse/ClickHouse/pull/60341,  here we make it to apply to grace hash join.

The performance test at local environment, query `SELECT MAX(test1.a) FROM test INNER JOIN test1 on test.b = test1.b settings join_algorithm='grace_hash'`, right table has `100000` rows. 

before this pr:
```
1 row in set. Elapsed: 0.471 sec. Processed 10.10 million rows, 130.88 MB (21.46 million rows/s., 278.15 MB/s.)
```

after this pr:
```
1 row in set. Elapsed: 0.360 sec. Processed 10.10 million rows, 130.88 MB (28.03 million rows/s., 363.21 MB/s.)
```
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Improve grace hash join performance by rerange the right join table by keys

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---ci_include_fuzzer--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
