### PR TITLE
make consistent default value of max_connections

### DIFF
--- a/programs/server/config.xml
+++ b/programs/server/config.xml
@@ -267,7 +267,7 @@
 
     <!-- <listen_backlog>4096</listen_backlog> -->
 
-    <max_connections>4096</max_connections>
+    <!-- <max_connections>4096</max_connections> -->
 
     <!-- For 'Connection: keep-alive' in HTTP 1.1 -->
     <keep_alive_timeout>10</keep_alive_timeout>

--- a/programs/server/config.yaml.example
+++ b/programs/server/config.yaml.example
@@ -136,11 +136,12 @@ interserver_http_port: 9009
 # Allow multiple servers to listen on the same address:port. This is not recommended.
 # listen_reuse_port: 0
 
-# listen_backlog: 64
-max_connections: 4096
+# listen_backlog: 4096
+
+# max_connections: 4096
 
 # For 'Connection: keep-alive' in HTTP 1.1
-keep_alive_timeout: 3
+keep_alive_timeout: 10
 
 # gRPC protocol (see src/Server/grpc_protos/clickhouse_grpc.proto for the API)
 # grpc_port: 9100

--- a/src/Core/ServerSettings.cpp
+++ b/src/Core/ServerSettings.cpp
@@ -59,7 +59,7 @@ namespace DB
     DECLARE(UInt64, restore_threads, 16, "The maximum number of threads to execute RESTORE requests.", 0) \
     DECLARE(Bool, shutdown_wait_backups_and_restores, true, "If set to true ClickHouse will wait for running backups and restores to finish before shutdown.", 0) \
     DECLARE(Double, cannot_allocate_thread_fault_injection_probability, 0, "For testing purposes.", 0) \
-    DECLARE(Int32, max_connections, 1024, "Max server connections.", 0) \
+    DECLARE(Int32, max_connections, 4096, "Max server connections.", 0) \
     DECLARE(UInt32, asynchronous_metrics_update_period_s, 1, "Period in seconds for updating asynchronous metrics.", 0) \
     DECLARE(Bool, asynchronous_metrics_enable_heavy_metrics, false, "Enable the calculation of heavy asynchronous metrics.", 0) \
     DECLARE(UInt32, asynchronous_heavy_metrics_update_period_s, 120, "Period in seconds for updating heavy asynchronous metrics.", 0) \


### PR DESCRIPTION
Right now:

```sql
SELECT * FROM system.server_settings WHERE name='max_connections' ;

┌─name────────────┬─value─┬─default─┬─changed─┬
│ max_connections │ 4096  │ 1024    │       1 │
└─────────────────┴───────┴─────────┴─────────┴
```

This PR sets default max_connections to 4096 and comments out it in configs.


### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

