### PR TITLE
Fix race in `ColumnDynamic::dumpStructure()`

### DIFF
--- a/src/Columns/ColumnDynamic.h
+++ b/src/Columns/ColumnDynamic.h
@@ -319,6 +319,8 @@ public:
         variant_column_ptr = assert_cast<ColumnVariant *>(variant_column.get());
     }
 
+    void forEachSubcolumn(ColumnCallback callback) const override { callback(variant_column); }
+
     void forEachSubcolumnRecursively(RecursiveMutableColumnCallback callback) override
     {
         callback(*variant_column);

--- a/tests/queries/0_stateless/03274_dynamic_column_data_race_with_concurrent_hj.sql
+++ b/tests/queries/0_stateless/03274_dynamic_column_data_race_with_concurrent_hj.sql
@@ -1,0 +1,7 @@
+SET join_algorithm = 'parallel_hash';
+SET allow_experimental_dynamic_type = 1;
+DROP TABLE IF EXISTS t0;
+CREATE TABLE t0 (c0 Tuple(c1 Int,c2 Dynamic)) ENGINE = Memory();
+SELECT 1 FROM t0 tx JOIN t0 ty ON tx.c0 = ty.c0;
+DROP TABLE t0;
+


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed data race when `ColumnDynamic::dumpStructure()` is called concurrently e.g. in `ConcurrentHashJoin` constructor.