### PR TITLE
Fix check in `test_postgresql_replica_database_engine_2`

### DIFF
--- a/tests/integration/helpers/postgres_utility.py
+++ b/tests/integration/helpers/postgres_utility.py
@@ -348,7 +348,9 @@ def assert_nested_table_is_created(
     # It may lead to error `Unknown table expression identifier...`
     while True:
         try:
-            instance.query(f"SELECT * FROM `{materialized_database}`.`{table}` LIMIT 1 FORMAT Null")
+            instance.query(
+                f"SELECT * FROM `{materialized_database}`.`{table}` LIMIT 1 FORMAT Null"
+            )
             break
         except Exception:
             time.sleep(0.2)

--- a/tests/integration/helpers/postgres_utility.py
+++ b/tests/integration/helpers/postgres_utility.py
@@ -343,16 +343,20 @@ def assert_nested_table_is_created(
         table = schema_name + "." + table_name
 
     print(f"Checking table {table} exists in {materialized_database}")
+
+    # Check based on `system.tables` is not enough, because tables appear there before they are loaded.
+    # It may lead to error `Unknown table expression identifier...`
+    while True:
+        try:
+            instance.query(f"SELECT * FROM `{materialized_database}`.`{table}` LIMIT 1 FORMAT Null")
+            break
+        except Exception:
+            time.sleep(0.2)
+            continue
+
     database_tables = instance.query(
         f"SHOW TABLES FROM `{materialized_database}` WHERE name = '{table}'"
     )
-
-    while table not in database_tables:
-        time.sleep(0.2)
-        database_tables = instance.query(
-            f"SHOW TABLES FROM `{materialized_database}` WHERE name = '{table}'"
-        )
-
     assert table in database_tables
 
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Failure example: https://s3.amazonaws.com/clickhouse-test-reports/72278/c3a32cc215f837decfeca933cd5c760879b2bb98/integration_tests__tsan__[6_6]//home/ubuntu/actions-runner/_work/_temp/test/output_dir/integration_run_parallel3_0.log