### PR TITLE
Fix data race in Squashing with LowCardinality

### DIFF
--- a/src/Columns/ColumnLowCardinality.h
+++ b/src/Columns/ColumnLowCardinality.h
@@ -190,6 +190,26 @@ public:
             callback(dictionary.getColumnUniquePtr());
     }
 
+    void forEachSubcolumnRecursively(RecursiveColumnCallback callback) const override
+    {
+        /** It is important to have both const and non-const versions here.
+          * The behavior of ColumnUnique::forEachSubcolumnRecursively differs between const and non-const versions.
+          * The non-const version will update a field in ColumnUnique.
+          * In the meantime, the default implementation IColumn::forEachSubcolumnRecursively uses const_cast,
+          * so when the const version is called, the field will still be mutated.
+          * This can lead to a data race if constness is expected.
+          */
+        callback(*idx.getPositionsPtr());
+        idx.getPositionsPtr()->forEachSubcolumnRecursively(callback);
+
+        /// Column doesn't own dictionary if it's shared.
+        if (!dictionary.isShared())
+        {
+            callback(*dictionary.getColumnUniquePtr());
+            dictionary.getColumnUniquePtr()->forEachSubcolumnRecursively(callback);
+        }
+    }
+
     void forEachSubcolumnRecursively(RecursiveMutableColumnCallback callback) override
     {
         callback(*idx.getPositionsPtr());


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)

Followup-for https://github.com/ClickHouse/ClickHouse/pull/72226

Example report 

<details>
<summary>Details</summary>

```
Logging test to /var/log/clickhouse-server/clickhouse-server.log
Logging errors to /var/log/clickhouse-server/clickhouse-server.err.log
==================
WARNING: ThreadSanitizer: data race (pid=616)
  Read of size 8 at 0x722c0095de58 by thread T2128:
    #0 boost::intrusive_ptr<DB::IColumn const>::operator->() const build_docker/./contrib/boost/boost/smart_ptr/intrusive_ptr.hpp:202:16 (clickhouse+0x1a6a1f68) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #1 DB::ColumnLowCardinality::updateHashFast(SipHash&) const build_docker/./src/Columns/ColumnLowCardinality.cpp:329:5 (clickhouse+0x1a6a1f68)
    #2 DB::DeduplicationToken::DefineSourceWithChunkHashTransform::getChunkHash(DB::Chunk const&) build_docker/./src/Processors/Transforms/DeduplicationTokenTransforms.cpp:163:17 (clickhouse+0x1c5076a2) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #3 DB::DeduplicationToken::DefineSourceWithChunkHashTransform::transform(DB::Chunk&) build_docker/./src/Processors/Transforms/DeduplicationTokenTransforms.cpp:182:30 (clickhouse+0x1c507b04) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #4 DB::ISimpleTransform::transform(DB::Chunk&, DB::Chunk&) build_docker/./src/Processors/ISimpleTransform.h:32:9 (clickhouse+0x1047b876) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #5 DB::ISimpleTransform::work() build_docker/./src/Processors/ISimpleTransform.cpp:89:9 (clickhouse+0x1c13aaa4) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #6 DB::executeJob(DB::ExecutingGraph::Node*, DB::ReadProgressCallback*) build_docker/./src/Processors/Executors/ExecutionThreadContext.cpp:49:26 (clickhouse+0x1c162506) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #7 DB::ExecutionThreadContext::executeTask() build_docker/./src/Processors/Executors/ExecutionThreadContext.cpp:98:9 (clickhouse+0x1c162506)
    #8 DB::PipelineExecutor::executeStepImpl(unsigned long, std::__1::atomic<bool>*) build_docker/./src/Processors/Executors/PipelineExecutor.cpp:289:26 (clickhouse+0x1c15212b) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #9 DB::PipelineExecutor::executeStep(std::__1::atomic<bool>*) build_docker/./src/Processors/Executors/PipelineExecutor.cpp:163:5 (clickhouse+0x1c151974) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #10 DB::PushingPipelineExecutor::finish() build_docker/./src/Processors/Executors/PushingPipelineExecutor.cpp:130:19 (clickhouse+0x1c16cb8b) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #11 DB::DistributedSink::onFinish()::$_1::operator()() const build_docker/./src/Storages/Distributed/DistributedSink.cpp:609:43 (clickhouse+0x1b436e7b) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #12 decltype(std::declval<DB::DistributedSink::onFinish()::$_1&>()()) std::__1::__invoke[abi:v15007]<DB::DistributedSink::onFinish()::$_1&>(DB::DistributedSink::onFinish()::$_1&) build_docker/./contrib/llvm-project/libcxx/include/__functional/invoke.h:394:23 (clickhouse+0x1b436e7b)
    #13 void std::__1::__invoke_void_return_wrapper<void, true>::__call<DB::DistributedSink::onFinish()::$_1&>(DB::DistributedSink::onFinish()::$_1&) build_docker/./contrib/llvm-project/libcxx/include/__functional/invoke.h:479:9 (clickhouse+0x1b436e7b)
    #14 std::__1::__function::__default_alloc_func<DB::DistributedSink::onFinish()::$_1, void ()>::operator()[abi:v15007]() build_docker/./contrib/llvm-project/libcxx/include/__functional/function.h:235:12 (clickhouse+0x1b436e7b)
    #15 void std::__1::__function::__policy_invoker<void ()>::__call_impl<std::__1::__function::__default_alloc_func<DB::DistributedSink::onFinish()::$_1, void ()>>(std::__1::__function::__policy_storage const*) build_docker/./contrib/llvm-project/libcxx/include/__functional/function.h:716:16 (clickhouse+0x1b436e7b)
    #16 std::__1::__function::__policy_func<void ()>::operator()[abi:v15007]() const build_docker/./contrib/llvm-project/libcxx/include/__functional/function.h:848:16 (clickhouse+0x1011f271) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #17 std::__1::function<void ()>::operator()() const build_docker/./contrib/llvm-project/libcxx/include/__functional/function.h:1197:12 (clickhouse+0x1011f271)
    #18 ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::worker() build_docker/./src/Common/ThreadPool.cpp:775:17 (clickhouse+0x1011f271)
    #19 decltype(*std::declval<ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*&>().*std::declval<void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&)()>()()) std::__1::__invoke[abi:v15007]<void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*&, void>(void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*&) build_docker/./contrib/llvm-project/libcxx/include/__functional/invoke.h:359:23 (clickhouse+0x10126d45) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #20 decltype(auto) std::__1::__apply_tuple_impl[abi:v15007]<void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&)(), std::__1::tuple<ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*>&, 0ul>(void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&)(), std::__1::tuple<ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*>&, std::__1::__tuple_indices<0ul>) build_docker/./contrib/llvm-project/libcxx/include/tuple:1789:1 (clickhouse+0x10126d45)
    #21 decltype(auto) std::__1::apply[abi:v15007]<void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&)(), std::__1::tuple<ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*>&>(void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&)(), std::__1::tuple<ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*>&) build_docker/./contrib/llvm-project/libcxx/include/tuple:1798:1 (clickhouse+0x10126d45)
    #22 ThreadFromGlobalPoolImpl<false, true>::ThreadFromGlobalPoolImpl<void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*>(void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&&)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*&&)::'lambda'()::operator()() build_docker/./src/Common/ThreadPool.h:311:13 (clickhouse+0x10126d45)
    #23 decltype(std::declval<void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*)()>()(std::declval<ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*>())) std::__1::__invoke[abi:v15007]<ThreadFromGlobalPoolImpl<false, true>::ThreadFromGlobalPoolImpl<void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*>(void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&&)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*&&)::'lambda'()&>(void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&&)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*&&) build_docker/./contrib/llvm-project/libcxx/include/__functional/invoke.h:394:23 (clickhouse+0x10126c61) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #24 void std::__1::__invoke_void_return_wrapper<void, true>::__call<ThreadFromGlobalPoolImpl<false, true>::ThreadFromGlobalPoolImpl<void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*>(void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&&)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*&&)::'lambda'()&>(ThreadFromGlobalPoolImpl<false, true>::ThreadFromGlobalPoolImpl<void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*>(void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&&)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*&&)::'lambda'()&) build_docker/./contrib/llvm-project/libcxx/include/__functional/invoke.h:479:9 (clickhouse+0x10126c61)
    #25 std::__1::__function::__default_alloc_func<ThreadFromGlobalPoolImpl<false, true>::ThreadFromGlobalPoolImpl<void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*>(void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&&)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*&&)::'lambda'(), void ()>::operator()[abi:v15007]() build_docker/./contrib/llvm-project/libcxx/include/__functional/function.h:235:12 (clickhouse+0x10126c61)
    #26 void std::__1::__function::__policy_invoker<void ()>::__call_impl<std::__1::__function::__default_alloc_func<ThreadFromGlobalPoolImpl<false, true>::ThreadFromGlobalPoolImpl<void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*>(void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&&)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*&&)::'lambda'(), void ()>>(std::__1::__function::__policy_storage const*) build_docker/./contrib/llvm-project/libcxx/include/__functional/function.h:716:16 (clickhouse+0x10126c61)
    #27 std::__1::__function::__policy_func<void ()>::operator()[abi:v15007]() const build_docker/./contrib/llvm-project/libcxx/include/__functional/function.h:848:16 (clickhouse+0x1011bcad) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #28 std::__1::function<void ()>::operator()() const build_docker/./contrib/llvm-project/libcxx/include/__functional/function.h:1197:12 (clickhouse+0x1011bcad)
    #29 ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool::worker() build_docker/./src/Common/ThreadPool.cpp:785:17 (clickhouse+0x1011bcad)
    #30 decltype(*std::declval<ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool*>().*std::declval<void (ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool::*)()>()()) std::__1::__invoke[abi:v15007]<void (ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool::*)(), ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool*, void>(void (ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool::*&&)(), ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool*&&) build_docker/./contrib/llvm-project/libcxx/include/__functional/invoke.h:359:23 (clickhouse+0x10123e9b) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #31 void std::__1::__thread_execute[abi:v15007]<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, void (ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool::*)(), ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool*, 2ul>(std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, void (ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool::*)(), ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool*>&, std::__1::__tuple_indices<2ul>) build_docker/./contrib/llvm-project/libcxx/include/thread:284:5 (clickhouse+0x10123e9b)
    #32 void* std::__1::__thread_proxy[abi:v15007]<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, void (ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool::*)(), ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool*>>(void*) build_docker/./contrib/llvm-project/libcxx/include/thread:295:5 (clickhouse+0x10123e9b)

  Previous write of size 8 at 0x722c0095de58 by thread T2067:
    #0 boost::intrusive_ptr<DB::IColumn const>::swap(boost::intrusive_ptr<DB::IColumn const>&) build_docker/./contrib/boost/boost/smart_ptr/intrusive_ptr.hpp:212:16 (clickhouse+0x1a7ba678) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #1 boost::intrusive_ptr<DB::IColumn const>::operator=(boost::intrusive_ptr<DB::IColumn const>&&) build_docker/./contrib/boost/boost/smart_ptr/intrusive_ptr.hpp:124:61 (clickhouse+0x1a7ba678)
    #2 COW<DB::IColumn>::immutable_ptr<DB::IColumn>::operator=(COW<DB::IColumn>::immutable_ptr<DB::IColumn>&&) build_docker/./src/Common/COW.h:141:61 (clickhouse+0x1a7ba678)
    #3 COW<DB::IColumn>::chameleon_ptr<DB::IColumn>::operator=(COW<DB::IColumn>::chameleon_ptr<DB::IColumn>&&) build_docker/./src/Common/COW.h:199:11 (clickhouse+0x1a7ba678)
    #4 DB::ColumnUnique<DB::ColumnVector<double>>::forEachSubcolumnRecursively(std::__1::function<void (DB::IColumn&)>) build_docker/./src/Columns/ColumnUnique.h:144:36 (clickhouse+0x1a7ba678)
    #5 DB::ColumnLowCardinality::forEachSubcolumnRecursively(std::__1::function<void (DB::IColumn&)>) build_docker/./src/Columns/ColumnLowCardinality.h:202:46 (clickhouse+0x1a6b8b6f) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #6 DB::IColumn::forEachSubcolumnRecursively(std::__1::function<void (DB::IColumn const&)>) const build_docker/./src/Columns/IColumn.cpp:106:33 (clickhouse+0x1aae34eb) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #7 DB::Squashing::squash(std::__1::vector<DB::Chunk, std::__1::allocator<DB::Chunk>>&&, DB::CollectionOfDerivedItems<DB::ChunkInfo>&&) build_docker/./src/Interpreters/Squashing.cpp:155:25 (clickhouse+0x194da16d) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #8 DB::Squashing::squash(DB::Chunk&&) build_docker/./src/Interpreters/Squashing.cpp:45:12 (clickhouse+0x194d951f) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #9 DB::ApplySquashingTransform::onConsume(DB::Chunk) build_docker/./src/Processors/Transforms/ApplySquashingTransform.h:35:21 (clickhouse+0x191ef9c7) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #10 DB::ExceptionKeepingTransform::work()::$_1::operator()() const build_docker/./src/Processors/Transforms/ExceptionKeepingTransform.cpp:150:51 (clickhouse+0x1c50d885) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #11 decltype(std::declval<DB::ExceptionKeepingTransform::work()::$_1&>()()) std::__1::__invoke[abi:v15007]<DB::ExceptionKeepingTransform::work()::$_1&>(DB::ExceptionKeepingTransform::work()::$_1&) build_docker/./contrib/llvm-project/libcxx/include/__functional/invoke.h:394:23 (clickhouse+0x1c50d885)
    #12 void std::__1::__invoke_void_return_wrapper<void, true>::__call<DB::ExceptionKeepingTransform::work()::$_1&>(DB::ExceptionKeepingTransform::work()::$_1&) build_docker/./contrib/llvm-project/libcxx/include/__functional/invoke.h:479:9 (clickhouse+0x1c50d885)
    #13 std::__1::__function::__default_alloc_func<DB::ExceptionKeepingTransform::work()::$_1, void ()>::operator()[abi:v15007]() build_docker/./contrib/llvm-project/libcxx/include/__functional/function.h:235:12 (clickhouse+0x1c50d885)
    #14 void std::__1::__function::__policy_invoker<void ()>::__call_impl<std::__1::__function::__default_alloc_func<DB::ExceptionKeepingTransform::work()::$_1, void ()>>(std::__1::__function::__policy_storage const*) build_docker/./contrib/llvm-project/libcxx/include/__functional/function.h:716:16 (clickhouse+0x1c50d885)
    #15 std::__1::__function::__policy_func<void ()>::operator()[abi:v15007]() const build_docker/./contrib/llvm-project/libcxx/include/__functional/function.h:848:16 (clickhouse+0x1c50d5df) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #16 std::__1::function<void ()>::operator()() const build_docker/./contrib/llvm-project/libcxx/include/__functional/function.h:1197:12 (clickhouse+0x1c50d5df)
    #17 DB::runStep(std::__1::function<void ()>, DB::ThreadStatus*, std::__1::atomic<unsigned long>*) build_docker/./src/Processors/Transforms/ExceptionKeepingTransform.cpp:114:9 (clickhouse+0x1c50d5df)
    #18 DB::ExceptionKeepingTransform::work() build_docker/./src/Processors/Transforms/ExceptionKeepingTransform.cpp:150:34 (clickhouse+0x1c50ced4) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #19 DB::ApplySquashingTransform::work() build_docker/./src/Processors/Transforms/ApplySquashingTransform.h:29:36 (clickhouse+0x191ef623) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #20 DB::executeJob(DB::ExecutingGraph::Node*, DB::ReadProgressCallback*) build_docker/./src/Processors/Executors/ExecutionThreadContext.cpp:49:26 (clickhouse+0x1c162506) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #21 DB::ExecutionThreadContext::executeTask() build_docker/./src/Processors/Executors/ExecutionThreadContext.cpp:98:9 (clickhouse+0x1c162506)
    #22 DB::PipelineExecutor::executeStepImpl(unsigned long, std::__1::atomic<bool>*) build_docker/./src/Processors/Executors/PipelineExecutor.cpp:289:26 (clickhouse+0x1c15212b) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #23 DB::PipelineExecutor::executeStep(std::__1::atomic<bool>*) build_docker/./src/Processors/Executors/PipelineExecutor.cpp:163:5 (clickhouse+0x1c151974) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #24 DB::PushingPipelineExecutor::finish() build_docker/./src/Processors/Executors/PushingPipelineExecutor.cpp:130:19 (clickhouse+0x1c16cb8b) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #25 DB::DistributedSink::onFinish()::$_1::operator()() const build_docker/./src/Storages/Distributed/DistributedSink.cpp:609:43 (clickhouse+0x1b436e7b) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #26 decltype(std::declval<DB::DistributedSink::onFinish()::$_1&>()()) std::__1::__invoke[abi:v15007]<DB::DistributedSink::onFinish()::$_1&>(DB::DistributedSink::onFinish()::$_1&) build_docker/./contrib/llvm-project/libcxx/include/__functional/invoke.h:394:23 (clickhouse+0x1b436e7b)
    #27 void std::__1::__invoke_void_return_wrapper<void, true>::__call<DB::DistributedSink::onFinish()::$_1&>(DB::DistributedSink::onFinish()::$_1&) build_docker/./contrib/llvm-project/libcxx/include/__functional/invoke.h:479:9 (clickhouse+0x1b436e7b)
    #28 std::__1::__function::__default_alloc_func<DB::DistributedSink::onFinish()::$_1, void ()>::operator()[abi:v15007]() build_docker/./contrib/llvm-project/libcxx/include/__functional/function.h:235:12 (clickhouse+0x1b436e7b)
    #29 void std::__1::__function::__policy_invoker<void ()>::__call_impl<std::__1::__function::__default_alloc_func<DB::DistributedSink::onFinish()::$_1, void ()>>(std::__1::__function::__policy_storage const*) build_docker/./contrib/llvm-project/libcxx/include/__functional/function.h:716:16 (clickhouse+0x1b436e7b)
    #30 std::__1::__function::__policy_func<void ()>::operator()[abi:v15007]() const build_docker/./contrib/llvm-project/libcxx/include/__functional/function.h:848:16 (clickhouse+0x1011f271) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #31 std::__1::function<void ()>::operator()() const build_docker/./contrib/llvm-project/libcxx/include/__functional/function.h:1197:12 (clickhouse+0x1011f271)
    #32 ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::worker() build_docker/./src/Common/ThreadPool.cpp:775:17 (clickhouse+0x1011f271)
    #33 decltype(*std::declval<ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*&>().*std::declval<void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&)()>()()) std::__1::__invoke[abi:v15007]<void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*&, void>(void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*&) build_docker/./contrib/llvm-project/libcxx/include/__functional/invoke.h:359:23 (clickhouse+0x10126d45) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #34 decltype(auto) std::__1::__apply_tuple_impl[abi:v15007]<void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&)(), std::__1::tuple<ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*>&, 0ul>(void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&)(), std::__1::tuple<ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*>&, std::__1::__tuple_indices<0ul>) build_docker/./contrib/llvm-project/libcxx/include/tuple:1789:1 (clickhouse+0x10126d45)
    #35 decltype(auto) std::__1::apply[abi:v15007]<void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&)(), std::__1::tuple<ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*>&>(void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&)(), std::__1::tuple<ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*>&) build_docker/./contrib/llvm-project/libcxx/include/tuple:1798:1 (clickhouse+0x10126d45)
    #36 ThreadFromGlobalPoolImpl<false, true>::ThreadFromGlobalPoolImpl<void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*>(void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&&)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*&&)::'lambda'()::operator()() build_docker/./src/Common/ThreadPool.h:311:13 (clickhouse+0x10126d45)
    #37 decltype(std::declval<void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*)()>()(std::declval<ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*>())) std::__1::__invoke[abi:v15007]<ThreadFromGlobalPoolImpl<false, true>::ThreadFromGlobalPoolImpl<void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*>(void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&&)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*&&)::'lambda'()&>(void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&&)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*&&) build_docker/./contrib/llvm-project/libcxx/include/__functional/invoke.h:394:23 (clickhouse+0x10126c61) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #38 void std::__1::__invoke_void_return_wrapper<void, true>::__call<ThreadFromGlobalPoolImpl<false, true>::ThreadFromGlobalPoolImpl<void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*>(void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&&)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*&&)::'lambda'()&>(ThreadFromGlobalPoolImpl<false, true>::ThreadFromGlobalPoolImpl<void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*>(void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&&)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*&&)::'lambda'()&) build_docker/./contrib/llvm-project/libcxx/include/__functional/invoke.h:479:9 (clickhouse+0x10126c61)
    #39 std::__1::__function::__default_alloc_func<ThreadFromGlobalPoolImpl<false, true>::ThreadFromGlobalPoolImpl<void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*>(void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&&)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*&&)::'lambda'(), void ()>::operator()[abi:v15007]() build_docker/./contrib/llvm-project/libcxx/include/__functional/function.h:235:12 (clickhouse+0x10126c61)
    #40 void std::__1::__function::__policy_invoker<void ()>::__call_impl<std::__1::__function::__default_alloc_func<ThreadFromGlobalPoolImpl<false, true>::ThreadFromGlobalPoolImpl<void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*>(void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&&)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*&&)::'lambda'(), void ()>>(std::__1::__function::__policy_storage const*) build_docker/./contrib/llvm-project/libcxx/include/__functional/function.h:716:16 (clickhouse+0x10126c61)
    #41 std::__1::__function::__policy_func<void ()>::operator()[abi:v15007]() const build_docker/./contrib/llvm-project/libcxx/include/__functional/function.h:848:16 (clickhouse+0x1011bcad) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #42 std::__1::function<void ()>::operator()() const build_docker/./contrib/llvm-project/libcxx/include/__functional/function.h:1197:12 (clickhouse+0x1011bcad)
    #43 ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool::worker() build_docker/./src/Common/ThreadPool.cpp:785:17 (clickhouse+0x1011bcad)
    #44 decltype(*std::declval<ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool*>().*std::declval<void (ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool::*)()>()()) std::__1::__invoke[abi:v15007]<void (ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool::*)(), ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool*, void>(void (ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool::*&&)(), ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool*&&) build_docker/./contrib/llvm-project/libcxx/include/__functional/invoke.h:359:23 (clickhouse+0x10123e9b) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #45 void std::__1::__thread_execute[abi:v15007]<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, void (ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool::*)(), ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool*, 2ul>(std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, void (ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool::*)(), ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool*>&, std::__1::__tuple_indices<2ul>) build_docker/./contrib/llvm-project/libcxx/include/thread:284:5 (clickhouse+0x10123e9b)
    #46 void* std::__1::__thread_proxy[abi:v15007]<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, void (ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool::*)(), ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool*>>(void*) build_docker/./contrib/llvm-project/libcxx/include/thread:295:5 (clickhouse+0x10123e9b)

  Location is heap block of size 176 at 0x722c0095ddf0 allocated by thread T2120:
    #0 operator new(unsigned long) <null> (clickhouse+0x793e052) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #1 COW<DB::IColumn>::mutable_ptr<DB::ColumnUnique<DB::ColumnVector<double>>> COWHelper<DB::IColumnUnique, DB::ColumnUnique<DB::ColumnVector<double>>>::create<DB::IDataType const&>(DB::IDataType const&) build_docker/./src/Common/COW.h:293:67 (clickhouse+0x17c3b62f) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #2 _ZZN2DB22DataTypeLowCardinality18createColumnUniqueERKNS_9IDataTypeEENK3$_0clIPNS_12ColumnVectorIdEEEEDaT_ build_docker/./src/DataTypes/DataTypeLowCardinality.cpp:115:16 (clickhouse+0x17c3b62f)
    #3 void DB::(anonymous namespace)::CreateColumnVector<DB::DataTypeLowCardinality::createColumnUnique(DB::IDataType const&)::$_0>::operator()<double>(TypeList<double>) build_docker/./src/DataTypes/DataTypeLowCardinality.cpp:61:26 (clickhouse+0x17c3b62f)
    #4 _ZN13TypeListUtils7forEachIN2DB12_GLOBAL__N_118CreateColumnVectorIZNS1_22DataTypeLowCardinality18createColumnUniqueERKNS1_9IDataTypeEE3$_0EEJDutjmDB8_silN4wide7integerILm128EjEENSC_ILm128EiEENSC_ILm256EjEENSC_ILm256EiEEfd8BFloat16EEEv8TypeListIJDpT0_EEOT_ build_docker/./base/base/../base/TypeList.h:30:58 (clickhouse+0x17c3b62f)
    #5 COW<DB::IColumn>::mutable_ptr<DB::IColumnUnique> DB::DataTypeLowCardinality::createColumnUniqueImpl<DB::DataTypeLowCardinality::createColumnUnique(DB::IDataType const&)::$_0>(DB::IDataType const&, DB::DataTypeLowCardinality::createColumnUnique(DB::IDataType const&)::$_0 const&) build_docker/./src/DataTypes/DataTypeLowCardinality.cpp:97:9 (clickhouse+0x17c3b62f)
    #6 DB::DataTypeLowCardinality::createColumnUnique(DB::IDataType const&) build_docker/./src/DataTypes/DataTypeLowCardinality.cpp:117:12 (clickhouse+0x17c3b62f)
    #7 DB::DataTypeLowCardinality::createColumn() const build_docker/./src/DataTypes/DataTypeLowCardinality.cpp:133:35 (clickhouse+0x17c3cdbc) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #8 COW<DB::IColumn>::immutable_ptr<DB::IColumn> std::__1::__function::__policy_invoker<COW<DB::IColumn>::immutable_ptr<DB::IColumn> (std::__1::vector<DB::ColumnWithTypeAndName, std::__1::allocator<DB::ColumnWithTypeAndName>>&, std::__1::shared_ptr<DB::IDataType const> const&, DB::ColumnNullable const*, unsigned long)>::__call_impl<std::__1::__function::__default_alloc_func<DB::(anonymous namespace)::FunctionCast::prepareUnpackDictionaries(std::__1::shared_ptr<DB::IDataType const> const&, std::__1::shared_ptr<DB::IDataType const> const&) const::'lambda0'(std::__1::vector<DB::ColumnWithTypeAndName, std::__1::allocator<DB::ColumnWithTypeAndName>>&, std::__1::shared_ptr<DB::IDataType const> const&, DB::ColumnNullable const*, unsigned long), COW<DB::IColumn>::immutable_ptr<DB::IColumn> (std::__1::vector<DB::ColumnWithTypeAndName, std::__1::allocator<DB::ColumnWithTypeAndName>>&, std::__1::shared_ptr<DB::IDataType const> const&, DB::ColumnNullable const*, unsigned long)>>(std::__1::__function::__policy_storage const*, std::__1::vector<DB::ColumnWithTypeAndName, std::__1::allocator<DB::ColumnWithTypeAndName>>&, std::__1::shared_ptr<DB::IDataType const> const&, DB::ColumnNullable const*, unsigned long) FunctionsConversion.cpp (clickhouse+0x16df0129) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #9 DB::(anonymous namespace)::ExecutableFunctionCast::executeImpl(std::__1::vector<DB::ColumnWithTypeAndName, std::__1::allocator<DB::ColumnWithTypeAndName>> const&, std::__1::shared_ptr<DB::IDataType const> const&, unsigned long) const FunctionsConversion.cpp (clickhouse+0x16ad4326) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #10 DB::IExecutableFunction::executeWithoutLowCardinalityColumns(std::__1::vector<DB::ColumnWithTypeAndName, std::__1::allocator<DB::ColumnWithTypeAndName>> const&, std::__1::shared_ptr<DB::IDataType const> const&, unsigned long, bool) const <null> (clickhouse+0x16a15e3b) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #11 DB::IExecutableFunction::executeWithoutSparseColumns(std::__1::vector<DB::ColumnWithTypeAndName, std::__1::allocator<DB::ColumnWithTypeAndName>> const&, std::__1::shared_ptr<DB::IDataType const> const&, unsigned long, bool) const <null> (clickhouse+0x16a16b16) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #12 DB::IExecutableFunction::execute(std::__1::vector<DB::ColumnWithTypeAndName, std::__1::allocator<DB::ColumnWithTypeAndName>> const&, std::__1::shared_ptr<DB::IDataType const> const&, unsigned long, bool) const <null> (clickhouse+0x16a1874e) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #13 DB::executeAction(DB::ExpressionActions::Action const&, DB::(anonymous namespace)::ExecutionContext&, bool, bool) build_docker/./src/Interpreters/ExpressionActions.cpp:636:60 (clickhouse+0x18801844) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #14 DB::ExpressionActions::execute(DB::Block&, unsigned long&, bool, bool) const build_docker/./src/Interpreters/ExpressionActions.cpp:770:13 (clickhouse+0x18801844)
    #15 DB::ExpressionTransform::transform(DB::Chunk&) build_docker/./src/Processors/Transforms/ExpressionTransform.cpp:25:17 (clickhouse+0x1c50e430) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #16 DB::ISimpleTransform::transform(DB::Chunk&, DB::Chunk&) build_docker/./src/Processors/ISimpleTransform.h:32:9 (clickhouse+0x1047b876) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #17 DB::ISimpleTransform::work() build_docker/./src/Processors/ISimpleTransform.cpp:89:9 (clickhouse+0x1c13aaa4) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #18 DB::executeJob(DB::ExecutingGraph::Node*, DB::ReadProgressCallback*) build_docker/./src/Processors/Executors/ExecutionThreadContext.cpp:49:26 (clickhouse+0x1c162506) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #19 DB::ExecutionThreadContext::executeTask() build_docker/./src/Processors/Executors/ExecutionThreadContext.cpp:98:9 (clickhouse+0x1c162506)
    #20 DB::PipelineExecutor::executeStepImpl(unsigned long, std::__1::atomic<bool>*) build_docker/./src/Processors/Executors/PipelineExecutor.cpp:289:26 (clickhouse+0x1c15212b) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #21 DB::PipelineExecutor::executeSingleThread(unsigned long) build_docker/./src/Processors/Executors/PipelineExecutor.cpp:255:5 (clickhouse+0x1c1532d2) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #22 DB::PipelineExecutor::spawnThreads()::$_0::operator()() const build_docker/./src/Processors/Executors/PipelineExecutor.cpp:403:17 (clickhouse+0x1c1532d2)
    #23 decltype(std::declval<DB::PipelineExecutor::spawnThreads()::$_0&>()()) std::__1::__invoke[abi:v15007]<DB::PipelineExecutor::spawnThreads()::$_0&>(DB::PipelineExecutor::spawnThreads()::$_0&) build_docker/./contrib/llvm-project/libcxx/include/__functional/invoke.h:394:23 (clickhouse+0x1c1532d2)
    #24 void std::__1::__invoke_void_return_wrapper<void, true>::__call<DB::PipelineExecutor::spawnThreads()::$_0&>(DB::PipelineExecutor::spawnThreads()::$_0&) build_docker/./contrib/llvm-project/libcxx/include/__functional/invoke.h:479:9 (clickhouse+0x1c1532d2)
    #25 std::__1::__function::__default_alloc_func<DB::PipelineExecutor::spawnThreads()::$_0, void ()>::operator()[abi:v15007]() build_docker/./contrib/llvm-project/libcxx/include/__functional/function.h:235:12 (clickhouse+0x1c1532d2)
    #26 void std::__1::__function::__policy_invoker<void ()>::__call_impl<std::__1::__function::__default_alloc_func<DB::PipelineExecutor::spawnThreads()::$_0, void ()>>(std::__1::__function::__policy_storage const*) build_docker/./contrib/llvm-project/libcxx/include/__functional/function.h:716:16 (clickhouse+0x1c1532d2)
    #27 std::__1::__function::__policy_func<void ()>::operator()[abi:v15007]() const build_docker/./contrib/llvm-project/libcxx/include/__functional/function.h:848:16 (clickhouse+0x1011f271) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #28 std::__1::function<void ()>::operator()() const build_docker/./contrib/llvm-project/libcxx/include/__functional/function.h:1197:12 (clickhouse+0x1011f271)
    #29 ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::worker() build_docker/./src/Common/ThreadPool.cpp:775:17 (clickhouse+0x1011f271)
    #30 decltype(*std::declval<ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*&>().*std::declval<void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&)()>()()) std::__1::__invoke[abi:v15007]<void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*&, void>(void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*&) build_docker/./contrib/llvm-project/libcxx/include/__functional/invoke.h:359:23 (clickhouse+0x10126d45) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #31 decltype(auto) std::__1::__apply_tuple_impl[abi:v15007]<void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&)(), std::__1::tuple<ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*>&, 0ul>(void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&)(), std::__1::tuple<ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*>&, std::__1::__tuple_indices<0ul>) build_docker/./contrib/llvm-project/libcxx/include/tuple:1789:1 (clickhouse+0x10126d45)
    #32 decltype(auto) std::__1::apply[abi:v15007]<void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&)(), std::__1::tuple<ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*>&>(void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&)(), std::__1::tuple<ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*>&) build_docker/./contrib/llvm-project/libcxx/include/tuple:1798:1 (clickhouse+0x10126d45)
    #33 ThreadFromGlobalPoolImpl<false, true>::ThreadFromGlobalPoolImpl<void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*>(void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&&)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*&&)::'lambda'()::operator()() build_docker/./src/Common/ThreadPool.h:311:13 (clickhouse+0x10126d45)
    #34 decltype(std::declval<void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*)()>()(std::declval<ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*>())) std::__1::__invoke[abi:v15007]<ThreadFromGlobalPoolImpl<false, true>::ThreadFromGlobalPoolImpl<void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*>(void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&&)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*&&)::'lambda'()&>(void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&&)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*&&) build_docker/./contrib/llvm-project/libcxx/include/__functional/invoke.h:394:23 (clickhouse+0x10126c61) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #35 void std::__1::__invoke_void_return_wrapper<void, true>::__call<ThreadFromGlobalPoolImpl<false, true>::ThreadFromGlobalPoolImpl<void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*>(void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&&)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*&&)::'lambda'()&>(ThreadFromGlobalPoolImpl<false, true>::ThreadFromGlobalPoolImpl<void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*>(void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&&)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*&&)::'lambda'()&) build_docker/./contrib/llvm-project/libcxx/include/__functional/invoke.h:479:9 (clickhouse+0x10126c61)
    #36 std::__1::__function::__default_alloc_func<ThreadFromGlobalPoolImpl<false, true>::ThreadFromGlobalPoolImpl<void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*>(void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&&)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*&&)::'lambda'(), void ()>::operator()[abi:v15007]() build_docker/./contrib/llvm-project/libcxx/include/__functional/function.h:235:12 (clickhouse+0x10126c61)
    #37 void std::__1::__function::__policy_invoker<void ()>::__call_impl<std::__1::__function::__default_alloc_func<ThreadFromGlobalPoolImpl<false, true>::ThreadFromGlobalPoolImpl<void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*>(void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&&)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*&&)::'lambda'(), void ()>>(std::__1::__function::__policy_storage const*) build_docker/./contrib/llvm-project/libcxx/include/__functional/function.h:716:16 (clickhouse+0x10126c61)
    #38 std::__1::__function::__policy_func<void ()>::operator()[abi:v15007]() const build_docker/./contrib/llvm-project/libcxx/include/__functional/function.h:848:16 (clickhouse+0x1011bcad) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #39 std::__1::function<void ()>::operator()() const build_docker/./contrib/llvm-project/libcxx/include/__functional/function.h:1197:12 (clickhouse+0x1011bcad)
    #40 ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool::worker() build_docker/./src/Common/ThreadPool.cpp:785:17 (clickhouse+0x1011bcad)
    #41 decltype(*std::declval<ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool*>().*std::declval<void (ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool::*)()>()()) std::__1::__invoke[abi:v15007]<void (ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool::*)(), ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool*, void>(void (ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool::*&&)(), ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool*&&) build_docker/./contrib/llvm-project/libcxx/include/__functional/invoke.h:359:23 (clickhouse+0x10123e9b) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #42 void std::__1::__thread_execute[abi:v15007]<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, void (ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool::*)(), ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool*, 2ul>(std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, void (ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool::*)(), ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool*>&, std::__1::__tuple_indices<2ul>) build_docker/./contrib/llvm-project/libcxx/include/thread:284:5 (clickhouse+0x10123e9b)
    #43 void* std::__1::__thread_proxy[abi:v15007]<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, void (ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool::*)(), ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool*>>(void*) build_docker/./contrib/llvm-project/libcxx/include/thread:295:5 (clickhouse+0x10123e9b)

  Thread T2128 'ThreadPool' (tid=38246, running) created by thread T1180 at:
    #0 pthread_create <null> (clickhouse+0x78bc4d1) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #1 std::__1::__libcpp_thread_create[abi:v15007](unsigned long*, void* (*)(void*), void*) build_docker/./contrib/llvm-project/libcxx/include/__threading_support:376:10 (clickhouse+0x1011c3f5) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #2 std::__1::thread::thread<void (ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool::*)(), ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool*, void>(void (ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool::*&&)(), ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool*&&) build_docker/./contrib/llvm-project/libcxx/include/thread:311:16 (clickhouse+0x1011c3f5)
    #3 ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool::ThreadFromThreadPool(ThreadPoolImpl<std::__1::thread>&) build_docker/./src/Common/ThreadPool.cpp:598:14 (clickhouse+0x1011b075) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #4 std::__1::__unique_if<ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool>::__unique_single std::__1::make_unique[abi:v15007]<ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool, ThreadPoolImpl<std::__1::thread>&>(ThreadPoolImpl<std::__1::thread>&) build_docker/./contrib/llvm-project/libcxx/include/__memory/unique_ptr.h:714:32 (clickhouse+0x1011cc81) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #5 void ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, Priority, std::__1::optional<unsigned long>, bool) build_docker/./src/Common/ThreadPool.cpp:284:30 (clickhouse+0x1011cc81)
    #6 ThreadPoolImpl<std::__1::thread>::scheduleOrThrow(std::__1::function<void ()>, Priority, unsigned long, bool) build_docker/./src/Common/ThreadPool.cpp:490:5 (clickhouse+0x1011fb6a) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #7 ThreadFromGlobalPoolImpl<false, true>::ThreadFromGlobalPoolImpl<void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*>(void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&&)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*&&) build_docker/./src/Common/ThreadPool.h:278:38 (clickhouse+0x1011fb6a)
    #8 ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::ThreadFromThreadPool(ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>&) build_docker/./src/Common/ThreadPool.cpp:598:14 (clickhouse+0x1011e4e4) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #9 std::__1::__unique_if<ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool>::__unique_single std::__1::make_unique[abi:v15007]<ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool, ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>&>(ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>&) build_docker/./contrib/llvm-project/libcxx/include/__memory/unique_ptr.h:714:32 (clickhouse+0x101233aa) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #10 void ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::scheduleImpl<void>(std::__1::function<void ()>, Priority, std::__1::optional<unsigned long>, bool) build_docker/./src/Common/ThreadPool.cpp:354:30 (clickhouse+0x10120e15) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #11 ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::scheduleOrThrowOnError(std::__1::function<void ()>, Priority) build_docker/./src/Common/ThreadPool.cpp:478:5 (clickhouse+0x1012046a) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #12 DB::ThreadPoolCallbackRunnerLocal<void, ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>, std::__1::function<void ()>>::operator()(std::__1::function<void ()>&&, Priority) build_docker/./src/Common/threadPoolCallbackRunner.h:167:14 (clickhouse+0x168a0f62) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #13 DB::MergeTreeData::clearPartsFromFilesystemImpl(std::__1::vector<std::__1::shared_ptr<DB::IMergeTreeDataPart const>, std::__1::allocator<std::__1::shared_ptr<DB::IMergeTreeDataPart const>>> const&, std::__1::unordered_set<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::hash<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>, std::__1::equal_to<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>>*) build_docker/./src/Storages/MergeTree/MergeTreeData.cpp:2888:13 (clickhouse+0x1b5f8b06) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #14 DB::MergeTreeData::clearPartsFromFilesystem(std::__1::vector<std::__1::shared_ptr<DB::IMergeTreeDataPart const>, std::__1::allocator<std::__1::shared_ptr<DB::IMergeTreeDataPart const>>> const&, bool, std::__1::unordered_set<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::hash<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>, std::__1::equal_to<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>>*) build_docker/./src/Storages/MergeTree/MergeTreeData.cpp:2824:9 (clickhouse+0x1b5f62e6) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #15 DB::MergeTreeData::dropAllData() build_docker/./src/Storages/MergeTree/MergeTreeData.cpp:3177:9 (clickhouse+0x1b5fe319) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #16 DB::StorageReplicatedMergeTree::drop() build_docker/./src/Storages/StorageReplicatedMergeTree.cpp:1280:5 (clickhouse+0x1ade9c3a) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #17 DB::DatabaseCatalog::dropTableFinally(DB::DatabaseCatalog::TableMarkedAsDropped const&) build_docker/./src/Interpreters/DatabaseCatalog.cpp:1400:22 (clickhouse+0x187d9ccc) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #18 DB::DatabaseCatalog::dropTablesParallel(std::__1::vector<std::__1::__list_iterator<DB::DatabaseCatalog::TableMarkedAsDropped, void*>, std::__1::allocator<std::__1::__list_iterator<DB::DatabaseCatalog::TableMarkedAsDropped, void*>>>)::$_0::operator()() const build_docker/./src/Interpreters/DatabaseCatalog.cpp:1325:17 (clickhouse+0x187e4f03) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #19 decltype(std::declval<DB::DatabaseCatalog::dropTablesParallel(std::__1::vector<std::__1::__list_iterator<DB::DatabaseCatalog::TableMarkedAsDropped, void*>, std::__1::allocator<std::__1::__list_iterator<DB::DatabaseCatalog::TableMarkedAsDropped, void*>>>)::$_0&>()()) std::__1::__invoke[abi:v15007]<DB::DatabaseCatalog::dropTablesParallel(std::__1::vector<std::__1::__list_iterator<DB::DatabaseCatalog::TableMarkedAsDropped, void*>, std::__1::allocator<std::__1::__list_iterator<DB::DatabaseCatalog::TableMarkedAsDropped, void*>>>)::$_0&>(DB::DatabaseCatalog::dropTablesParallel(std::__1::vector<std::__1::__list_iterator<DB::DatabaseCatalog::TableMarkedAsDropped, void*>, std::__1::allocator<std::__1::__list_iterator<DB::DatabaseCatalog::TableMarkedAsDropped, void*>>>)::$_0&) build_docker/./contrib/llvm-project/libcxx/include/__functional/invoke.h:394:23 (clickhouse+0x187e4f03)
    #20 void std::__1::__invoke_void_return_wrapper<void, true>::__call<DB::DatabaseCatalog::dropTablesParallel(std::__1::vector<std::__1::__list_iterator<DB::DatabaseCatalog::TableMarkedAsDropped, void*>, std::__1::allocator<std::__1::__list_iterator<DB::DatabaseCatalog::TableMarkedAsDropped, void*>>>)::$_0&>(DB::DatabaseCatalog::dropTablesParallel(std::__1::vector<std::__1::__list_iterator<DB::DatabaseCatalog::TableMarkedAsDropped, void*>, std::__1::allocator<std::__1::__list_iterator<DB::DatabaseCatalog::TableMarkedAsDropped, void*>>>)::$_0&) build_docker/./contrib/llvm-project/libcxx/include/__functional/invoke.h:479:9 (clickhouse+0x187e4f03)
    #21 std::__1::__function::__default_alloc_func<DB::DatabaseCatalog::dropTablesParallel(std::__1::vector<std::__1::__list_iterator<DB::DatabaseCatalog::TableMarkedAsDropped, void*>, std::__1::allocator<std::__1::__list_iterator<DB::DatabaseCatalog::TableMarkedAsDropped, void*>>>)::$_0, void ()>::operator()[abi:v15007]() build_docker/./contrib/llvm-project/libcxx/include/__functional/function.h:235:12 (clickhouse+0x187e4f03)
    #22 void std::__1::__function::__policy_invoker<void ()>::__call_impl<std::__1::__function::__default_alloc_func<DB::DatabaseCatalog::dropTablesParallel(std::__1::vector<std::__1::__list_iterator<DB::DatabaseCatalog::TableMarkedAsDropped, void*>, std::__1::allocator<std::__1::__list_iterator<DB::DatabaseCatalog::TableMarkedAsDropped, void*>>>)::$_0, void ()>>(std::__1::__function::__policy_storage const*) build_docker/./contrib/llvm-project/libcxx/include/__functional/function.h:716:16 (clickhouse+0x187e4f03)
    #23 std::__1::__function::__policy_func<void ()>::operator()[abi:v15007]() const build_docker/./contrib/llvm-project/libcxx/include/__functional/function.h:848:16 (clickhouse+0x168a2217) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #24 std::__1::function<void ()>::operator()() const build_docker/./contrib/llvm-project/libcxx/include/__functional/function.h:1197:12 (clickhouse+0x168a2217)
    #25 DB::ThreadPoolCallbackRunnerLocal<void, ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>, std::__1::function<void ()>>::operator()(std::__1::function<void ()>&&, Priority)::'lambda'()::operator()() build_docker/./src/Common/threadPoolCallbackRunner.h:160:20 (clickhouse+0x168a2217)
    #26 decltype(std::declval<DB::ThreadPoolCallbackRunnerLocal<void, ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>, std::__1::function<void ()>>::operator()(std::__1::function<void ()>&&, Priority)::'lambda'()&>()()) std::__1::__invoke[abi:v15007]<DB::ThreadPoolCallbackRunnerLocal<void, ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>, std::__1::function<void ()>>::operator()(std::__1::function<void ()>&&, Priority)::'lambda'()&>(DB::ThreadPoolCallbackRunnerLocal<void, ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>, std::__1::function<void ()>>::operator()(std::__1::function<void ()>&&, Priority)::'lambda'()&) build_docker/./contrib/llvm-project/libcxx/include/__functional/invoke.h:394:23 (clickhouse+0x168a211d) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #27 std::__1::__packaged_task_func<DB::ThreadPoolCallbackRunnerLocal<void, ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>, std::__1::function<void ()>>::operator()(std::__1::function<void ()>&&, Priority)::'lambda'(), std::__1::allocator<DB::ThreadPoolCallbackRunnerLocal<void, ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>, std::__1::function<void ()>>::operator()(std::__1::function<void ()>&&, Priority)::'lambda'()>, void ()>::operator()() build_docker/./contrib/llvm-project/libcxx/include/future:1694:12 (clickhouse+0x168a211d)
    #28 std::__1::__packaged_task_function<void ()>::operator()() const build_docker/./contrib/llvm-project/libcxx/include/future:1876:12 (clickhouse+0x10847254) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #29 std::__1::packaged_task<void ()>::operator()() build_docker/./contrib/llvm-project/libcxx/include/future:2068:9 (clickhouse+0x10847254)
    #30 DB::ThreadPoolCallbackRunnerLocal<void, ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>, std::__1::function<void ()>>::operator()(std::__1::function<void ()>&&, Priority)::'lambda0'()::operator()() const build_docker/./src/Common/threadPoolCallbackRunner.h:167:71 (clickhouse+0x168a31ac) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #31 decltype(std::declval<DB::ThreadPoolCallbackRunnerLocal<void, ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>, std::__1::function<void ()>>::operator()(std::__1::function<void ()>&&, Priority)::'lambda0'()&>()()) std::__1::__invoke[abi:v15007]<DB::ThreadPoolCallbackRunnerLocal<void, ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>, std::__1::function<void ()>>::operator()(std::__1::function<void ()>&&, Priority)::'lambda0'()&>(DB::ThreadPoolCallbackRunnerLocal<void, ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>, std::__1::function<void ()>>::operator()(std::__1::function<void ()>&&, Priority)::'lambda0'()&) build_docker/./contrib/llvm-project/libcxx/include/__functional/invoke.h:394:23 (clickhouse+0x168a31ac)
    #32 void std::__1::__invoke_void_return_wrapper<void, true>::__call<DB::ThreadPoolCallbackRunnerLocal<void, ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>, std::__1::function<void ()>>::operator()(std::__1::function<void ()>&&, Priority)::'lambda0'()&>(DB::ThreadPoolCallbackRunnerLocal<void, ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>, std::__1::function<void ()>>::operator()(std::__1::function<void ()>&&, Priority)::'lambda0'()&) build_docker/./contrib/llvm-project/libcxx/include/__functional/invoke.h:479:9 (clickhouse+0x168a31ac)
    #33 std::__1::__function::__default_alloc_func<DB::ThreadPoolCallbackRunnerLocal<void, ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>, std::__1::function<void ()>>::operator()(std::__1::function<void ()>&&, Priority)::'lambda0'(), void ()>::operator()[abi:v15007]() build_docker/./contrib/llvm-project/libcxx/include/__functional/function.h:235:12 (clickhouse+0x168a31ac)
    #34 void std::__1::__function::__policy_invoker<void ()>::__call_impl<std::__1::__function::__default_alloc_func<DB::ThreadPoolCallbackRunnerLocal<void, ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>, std::__1::function<void ()>>::operator()(std::__1::function<void ()>&&, Priority)::'lambda0'(), void ()>>(std::__1::__function::__policy_storage const*) build_docker/./contrib/llvm-project/libcxx/include/__functional/function.h:716:16 (clickhouse+0x168a31ac)
    #35 std::__1::__function::__policy_func<void ()>::operator()[abi:v15007]() const build_docker/./contrib/llvm-project/libcxx/include/__functional/function.h:848:16 (clickhouse+0x1011f271) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #36 std::__1::function<void ()>::operator()() const build_docker/./contrib/llvm-project/libcxx/include/__functional/function.h:1197:12 (clickhouse+0x1011f271)
    #37 ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::worker() build_docker/./src/Common/ThreadPool.cpp:775:17 (clickhouse+0x1011f271)
    #38 decltype(*std::declval<ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*&>().*std::declval<void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&)()>()()) std::__1::__invoke[abi:v15007]<void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*&, void>(void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*&) build_docker/./contrib/llvm-project/libcxx/include/__functional/invoke.h:359:23 (clickhouse+0x10126d45) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #39 decltype(auto) std::__1::__apply_tuple_impl[abi:v15007]<void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&)(), std::__1::tuple<ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*>&, 0ul>(void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&)(), std::__1::tuple<ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*>&, std::__1::__tuple_indices<0ul>) build_docker/./contrib/llvm-project/libcxx/include/tuple:1789:1 (clickhouse+0x10126d45)
    #40 decltype(auto) std::__1::apply[abi:v15007]<void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&)(), std::__1::tuple<ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*>&>(void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&)(), std::__1::tuple<ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*>&) build_docker/./contrib/llvm-project/libcxx/include/tuple:1798:1 (clickhouse+0x10126d45)
    #41 ThreadFromGlobalPoolImpl<false, true>::ThreadFromGlobalPoolImpl<void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*>(void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&&)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*&&)::'lambda'()::operator()() build_docker/./src/Common/ThreadPool.h:311:13 (clickhouse+0x10126d45)
    #42 decltype(std::declval<void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*)()>()(std::declval<ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*>())) std::__1::__invoke[abi:v15007]<ThreadFromGlobalPoolImpl<false, true>::ThreadFromGlobalPoolImpl<void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*>(void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&&)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*&&)::'lambda'()&>(void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&&)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*&&) build_docker/./contrib/llvm-project/libcxx/include/__functional/invoke.h:394:23 (clickhouse+0x10126c61) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #43 void std::__1::__invoke_void_return_wrapper<void, true>::__call<ThreadFromGlobalPoolImpl<false, true>::ThreadFromGlobalPoolImpl<void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*>(void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&&)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*&&)::'lambda'()&>(ThreadFromGlobalPoolImpl<false, true>::ThreadFromGlobalPoolImpl<void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*>(void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&&)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*&&)::'lambda'()&) build_docker/./contrib/llvm-project/libcxx/include/__functional/invoke.h:479:9 (clickhouse+0x10126c61)
    #44 std::__1::__function::__default_alloc_func<ThreadFromGlobalPoolImpl<false, true>::ThreadFromGlobalPoolImpl<void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*>(void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&&)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*&&)::'lambda'(), void ()>::operator()[abi:v15007]() build_docker/./contrib/llvm-project/libcxx/include/__functional/function.h:235:12 (clickhouse+0x10126c61)
    #45 void std::__1::__function::__policy_invoker<void ()>::__call_impl<std::__1::__function::__default_alloc_func<ThreadFromGlobalPoolImpl<false, true>::ThreadFromGlobalPoolImpl<void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*>(void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&&)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*&&)::'lambda'(), void ()>>(std::__1::__function::__policy_storage const*) build_docker/./contrib/llvm-project/libcxx/include/__functional/function.h:716:16 (clickhouse+0x10126c61)
    #46 std::__1::__function::__policy_func<void ()>::operator()[abi:v15007]() const build_docker/./contrib/llvm-project/libcxx/include/__functional/function.h:848:16 (clickhouse+0x1011bcad) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #47 std::__1::function<void ()>::operator()() const build_docker/./contrib/llvm-project/libcxx/include/__functional/function.h:1197:12 (clickhouse+0x1011bcad)
    #48 ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool::worker() build_docker/./src/Common/ThreadPool.cpp:785:17 (clickhouse+0x1011bcad)
    #49 decltype(*std::declval<ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool*>().*std::declval<void (ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool::*)()>()()) std::__1::__invoke[abi:v15007]<void (ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool::*)(), ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool*, void>(void (ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool::*&&)(), ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool*&&) build_docker/./contrib/llvm-project/libcxx/include/__functional/invoke.h:359:23 (clickhouse+0x10123e9b) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #50 void std::__1::__thread_execute[abi:v15007]<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, void (ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool::*)(), ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool*, 2ul>(std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, void (ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool::*)(), ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool*>&, std::__1::__tuple_indices<2ul>) build_docker/./contrib/llvm-project/libcxx/include/thread:284:5 (clickhouse+0x10123e9b)
    #51 void* std::__1::__thread_proxy[abi:v15007]<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, void (ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool::*)(), ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool*>>(void*) build_docker/./contrib/llvm-project/libcxx/include/thread:295:5 (clickhouse+0x10123e9b)

  Thread T2067 'ThreadPool' (tid=38176, running) created by thread T1180 at:
    #0 pthread_create <null> (clickhouse+0x78bc4d1) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #1 std::__1::__libcpp_thread_create[abi:v15007](unsigned long*, void* (*)(void*), void*) build_docker/./contrib/llvm-project/libcxx/include/__threading_support:376:10 (clickhouse+0x1011c3f5) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #2 std::__1::thread::thread<void (ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool::*)(), ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool*, void>(void (ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool::*&&)(), ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool*&&) build_docker/./contrib/llvm-project/libcxx/include/thread:311:16 (clickhouse+0x1011c3f5)
    #3 ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool::ThreadFromThreadPool(ThreadPoolImpl<std::__1::thread>&) build_docker/./src/Common/ThreadPool.cpp:598:14 (clickhouse+0x1011b075) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #4 std::__1::__unique_if<ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool>::__unique_single std::__1::make_unique[abi:v15007]<ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool, ThreadPoolImpl<std::__1::thread>&>(ThreadPoolImpl<std::__1::thread>&) build_docker/./contrib/llvm-project/libcxx/include/__memory/unique_ptr.h:714:32 (clickhouse+0x1011cc81) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #5 void ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, Priority, std::__1::optional<unsigned long>, bool) build_docker/./src/Common/ThreadPool.cpp:284:30 (clickhouse+0x1011cc81)
    #6 ThreadPoolImpl<std::__1::thread>::scheduleOrThrow(std::__1::function<void ()>, Priority, unsigned long, bool) build_docker/./src/Common/ThreadPool.cpp:490:5 (clickhouse+0x1011fb6a) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #7 ThreadFromGlobalPoolImpl<false, true>::ThreadFromGlobalPoolImpl<void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*>(void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&&)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*&&) build_docker/./src/Common/ThreadPool.h:278:38 (clickhouse+0x1011fb6a)
    #8 ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::ThreadFromThreadPool(ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>&) build_docker/./src/Common/ThreadPool.cpp:598:14 (clickhouse+0x1011e4e4) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #9 std::__1::__unique_if<ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool>::__unique_single std::__1::make_unique[abi:v15007]<ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool, ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>&>(ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>&) build_docker/./contrib/llvm-project/libcxx/include/__memory/unique_ptr.h:714:32 (clickhouse+0x10120621) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #10 void ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::scheduleImpl<void>(std::__1::function<void ()>, Priority, std::__1::optional<unsigned long>, bool) build_docker/./src/Common/ThreadPool.cpp:284:30 (clickhouse+0x10120621)
    #11 ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::scheduleOrThrowOnError(std::__1::function<void ()>, Priority) build_docker/./src/Common/ThreadPool.cpp:478:5 (clickhouse+0x1012046a) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #12 DB::ThreadPoolCallbackRunnerLocal<void, ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>, std::__1::function<void ()>>::operator()(std::__1::function<void ()>&&, Priority) build_docker/./src/Common/threadPoolCallbackRunner.h:167:14 (clickhouse+0x168a0f62) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #13 DB::MergeTreeData::clearPartsFromFilesystemImpl(std::__1::vector<std::__1::shared_ptr<DB::IMergeTreeDataPart const>, std::__1::allocator<std::__1::shared_ptr<DB::IMergeTreeDataPart const>>> const&, std::__1::unordered_set<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::hash<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>, std::__1::equal_to<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>>*) build_docker/./src/Storages/MergeTree/MergeTreeData.cpp:2888:13 (clickhouse+0x1b5f8b06) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #14 DB::MergeTreeData::clearPartsFromFilesystem(std::__1::vector<std::__1::shared_ptr<DB::IMergeTreeDataPart const>, std::__1::allocator<std::__1::shared_ptr<DB::IMergeTreeDataPart const>>> const&, bool, std::__1::unordered_set<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::hash<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>, std::__1::equal_to<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>>*) build_docker/./src/Storages/MergeTree/MergeTreeData.cpp:2824:9 (clickhouse+0x1b5f62e6) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #15 DB::MergeTreeData::dropAllData() build_docker/./src/Storages/MergeTree/MergeTreeData.cpp:3177:9 (clickhouse+0x1b5fe319) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #16 DB::StorageReplicatedMergeTree::drop() build_docker/./src/Storages/StorageReplicatedMergeTree.cpp:1280:5 (clickhouse+0x1ade9c3a) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #17 DB::DatabaseCatalog::dropTableFinally(DB::DatabaseCatalog::TableMarkedAsDropped const&) build_docker/./src/Interpreters/DatabaseCatalog.cpp:1400:22 (clickhouse+0x187d9ccc) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #18 DB::DatabaseCatalog::dropTablesParallel(std::__1::vector<std::__1::__list_iterator<DB::DatabaseCatalog::TableMarkedAsDropped, void*>, std::__1::allocator<std::__1::__list_iterator<DB::DatabaseCatalog::TableMarkedAsDropped, void*>>>)::$_0::operator()() const build_docker/./src/Interpreters/DatabaseCatalog.cpp:1325:17 (clickhouse+0x187e4f03) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #19 decltype(std::declval<DB::DatabaseCatalog::dropTablesParallel(std::__1::vector<std::__1::__list_iterator<DB::DatabaseCatalog::TableMarkedAsDropped, void*>, std::__1::allocator<std::__1::__list_iterator<DB::DatabaseCatalog::TableMarkedAsDropped, void*>>>)::$_0&>()()) std::__1::__invoke[abi:v15007]<DB::DatabaseCatalog::dropTablesParallel(std::__1::vector<std::__1::__list_iterator<DB::DatabaseCatalog::TableMarkedAsDropped, void*>, std::__1::allocator<std::__1::__list_iterator<DB::DatabaseCatalog::TableMarkedAsDropped, void*>>>)::$_0&>(DB::DatabaseCatalog::dropTablesParallel(std::__1::vector<std::__1::__list_iterator<DB::DatabaseCatalog::TableMarkedAsDropped, void*>, std::__1::allocator<std::__1::__list_iterator<DB::DatabaseCatalog::TableMarkedAsDropped, void*>>>)::$_0&) build_docker/./contrib/llvm-project/libcxx/include/__functional/invoke.h:394:23 (clickhouse+0x187e4f03)
    #20 void std::__1::__invoke_void_return_wrapper<void, true>::__call<DB::DatabaseCatalog::dropTablesParallel(std::__1::vector<std::__1::__list_iterator<DB::DatabaseCatalog::TableMarkedAsDropped, void*>, std::__1::allocator<std::__1::__list_iterator<DB::DatabaseCatalog::TableMarkedAsDropped, void*>>>)::$_0&>(DB::DatabaseCatalog::dropTablesParallel(std::__1::vector<std::__1::__list_iterator<DB::DatabaseCatalog::TableMarkedAsDropped, void*>, std::__1::allocator<std::__1::__list_iterator<DB::DatabaseCatalog::TableMarkedAsDropped, void*>>>)::$_0&) build_docker/./contrib/llvm-project/libcxx/include/__functional/invoke.h:479:9 (clickhouse+0x187e4f03)
    #21 std::__1::__function::__default_alloc_func<DB::DatabaseCatalog::dropTablesParallel(std::__1::vector<std::__1::__list_iterator<DB::DatabaseCatalog::TableMarkedAsDropped, void*>, std::__1::allocator<std::__1::__list_iterator<DB::DatabaseCatalog::TableMarkedAsDropped, void*>>>)::$_0, void ()>::operator()[abi:v15007]() build_docker/./contrib/llvm-project/libcxx/include/__functional/function.h:235:12 (clickhouse+0x187e4f03)
    #22 void std::__1::__function::__policy_invoker<void ()>::__call_impl<std::__1::__function::__default_alloc_func<DB::DatabaseCatalog::dropTablesParallel(std::__1::vector<std::__1::__list_iterator<DB::DatabaseCatalog::TableMarkedAsDropped, void*>, std::__1::allocator<std::__1::__list_iterator<DB::DatabaseCatalog::TableMarkedAsDropped, void*>>>)::$_0, void ()>>(std::__1::__function::__policy_storage const*) build_docker/./contrib/llvm-project/libcxx/include/__functional/function.h:716:16 (clickhouse+0x187e4f03)
    #23 std::__1::__function::__policy_func<void ()>::operator()[abi:v15007]() const build_docker/./contrib/llvm-project/libcxx/include/__functional/function.h:848:16 (clickhouse+0x168a2217) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #24 std::__1::function<void ()>::operator()() const build_docker/./contrib/llvm-project/libcxx/include/__functional/function.h:1197:12 (clickhouse+0x168a2217)
    #25 DB::ThreadPoolCallbackRunnerLocal<void, ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>, std::__1::function<void ()>>::operator()(std::__1::function<void ()>&&, Priority)::'lambda'()::operator()() build_docker/./src/Common/threadPoolCallbackRunner.h:160:20 (clickhouse+0x168a2217)
    #26 decltype(std::declval<DB::ThreadPoolCallbackRunnerLocal<void, ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>, std::__1::function<void ()>>::operator()(std::__1::function<void ()>&&, Priority)::'lambda'()&>()()) std::__1::__invoke[abi:v15007]<DB::ThreadPoolCallbackRunnerLocal<void, ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>, std::__1::function<void ()>>::operator()(std::__1::function<void ()>&&, Priority)::'lambda'()&>(DB::ThreadPoolCallbackRunnerLocal<void, ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>, std::__1::function<void ()>>::operator()(std::__1::function<void ()>&&, Priority)::'lambda'()&) build_docker/./contrib/llvm-project/libcxx/include/__functional/invoke.h:394:23 (clickhouse+0x168a211d) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #27 std::__1::__packaged_task_func<DB::ThreadPoolCallbackRunnerLocal<void, ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>, std::__1::function<void ()>>::operator()(std::__1::function<void ()>&&, Priority)::'lambda'(), std::__1::allocator<DB::ThreadPoolCallbackRunnerLocal<void, ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>, std::__1::function<void ()>>::operator()(std::__1::function<void ()>&&, Priority)::'lambda'()>, void ()>::operator()() build_docker/./contrib/llvm-project/libcxx/include/future:1694:12 (clickhouse+0x168a211d)
    #28 std::__1::__packaged_task_function<void ()>::operator()() const build_docker/./contrib/llvm-project/libcxx/include/future:1876:12 (clickhouse+0x10847254) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #29 std::__1::packaged_task<void ()>::operator()() build_docker/./contrib/llvm-project/libcxx/include/future:2068:9 (clickhouse+0x10847254)
    #30 DB::ThreadPoolCallbackRunnerLocal<void, ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>, std::__1::function<void ()>>::operator()(std::__1::function<void ()>&&, Priority)::'lambda0'()::operator()() const build_docker/./src/Common/threadPoolCallbackRunner.h:167:71 (clickhouse+0x168a31ac) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #31 decltype(std::declval<DB::ThreadPoolCallbackRunnerLocal<void, ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>, std::__1::function<void ()>>::operator()(std::__1::function<void ()>&&, Priority)::'lambda0'()&>()()) std::__1::__invoke[abi:v15007]<DB::ThreadPoolCallbackRunnerLocal<void, ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>, std::__1::function<void ()>>::operator()(std::__1::function<void ()>&&, Priority)::'lambda0'()&>(DB::ThreadPoolCallbackRunnerLocal<void, ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>, std::__1::function<void ()>>::operator()(std::__1::function<void ()>&&, Priority)::'lambda0'()&) build_docker/./contrib/llvm-project/libcxx/include/__functional/invoke.h:394:23 (clickhouse+0x168a31ac)
    #32 void std::__1::__invoke_void_return_wrapper<void, true>::__call<DB::ThreadPoolCallbackRunnerLocal<void, ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>, std::__1::function<void ()>>::operator()(std::__1::function<void ()>&&, Priority)::'lambda0'()&>(DB::ThreadPoolCallbackRunnerLocal<void, ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>, std::__1::function<void ()>>::operator()(std::__1::function<void ()>&&, Priority)::'lambda0'()&) build_docker/./contrib/llvm-project/libcxx/include/__functional/invoke.h:479:9 (clickhouse+0x168a31ac)
    #33 std::__1::__function::__default_alloc_func<DB::ThreadPoolCallbackRunnerLocal<void, ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>, std::__1::function<void ()>>::operator()(std::__1::function<void ()>&&, Priority)::'lambda0'(), void ()>::operator()[abi:v15007]() build_docker/./contrib/llvm-project/libcxx/include/__functional/function.h:235:12 (clickhouse+0x168a31ac)
    #34 void std::__1::__function::__policy_invoker<void ()>::__call_impl<std::__1::__function::__default_alloc_func<DB::ThreadPoolCallbackRunnerLocal<void, ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>, std::__1::function<void ()>>::operator()(std::__1::function<void ()>&&, Priority)::'lambda0'(), void ()>>(std::__1::__function::__policy_storage const*) build_docker/./contrib/llvm-project/libcxx/include/__functional/function.h:716:16 (clickhouse+0x168a31ac)
    #35 std::__1::__function::__policy_func<void ()>::operator()[abi:v15007]() const build_docker/./contrib/llvm-project/libcxx/include/__functional/function.h:848:16 (clickhouse+0x1011f271) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #36 std::__1::function<void ()>::operator()() const build_docker/./contrib/llvm-project/libcxx/include/__functional/function.h:1197:12 (clickhouse+0x1011f271)
    #37 ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::worker() build_docker/./src/Common/ThreadPool.cpp:775:17 (clickhouse+0x1011f271)
    #38 decltype(*std::declval<ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*&>().*std::declval<void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&)()>()()) std::__1::__invoke[abi:v15007]<void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*&, void>(void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*&) build_docker/./contrib/llvm-project/libcxx/include/__functional/invoke.h:359:23 (clickhouse+0x10126d45) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #39 decltype(auto) std::__1::__apply_tuple_impl[abi:v15007]<void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&)(), std::__1::tuple<ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*>&, 0ul>(void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&)(), std::__1::tuple<ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*>&, std::__1::__tuple_indices<0ul>) build_docker/./contrib/llvm-project/libcxx/include/tuple:1789:1 (clickhouse+0x10126d45)
    #40 decltype(auto) std::__1::apply[abi:v15007]<void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&)(), std::__1::tuple<ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*>&>(void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&)(), std::__1::tuple<ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*>&) build_docker/./contrib/llvm-project/libcxx/include/tuple:1798:1 (clickhouse+0x10126d45)
    #41 ThreadFromGlobalPoolImpl<false, true>::ThreadFromGlobalPoolImpl<void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*>(void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&&)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*&&)::'lambda'()::operator()() build_docker/./src/Common/ThreadPool.h:311:13 (clickhouse+0x10126d45)
    #42 decltype(std::declval<void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*)()>()(std::declval<ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*>())) std::__1::__invoke[abi:v15007]<ThreadFromGlobalPoolImpl<false, true>::ThreadFromGlobalPoolImpl<void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*>(void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&&)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*&&)::'lambda'()&>(void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&&)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*&&) build_docker/./contrib/llvm-project/libcxx/include/__functional/invoke.h:394:23 (clickhouse+0x10126c61) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #43 void std::__1::__invoke_void_return_wrapper<void, true>::__call<ThreadFromGlobalPoolImpl<false, true>::ThreadFromGlobalPoolImpl<void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*>(void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&&)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*&&)::'lambda'()&>(ThreadFromGlobalPoolImpl<false, true>::ThreadFromGlobalPoolImpl<void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*>(void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&&)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*&&)::'lambda'()&) build_docker/./contrib/llvm-project/libcxx/include/__functional/invoke.h:479:9 (clickhouse+0x10126c61)
    #44 std::__1::__function::__default_alloc_func<ThreadFromGlobalPoolImpl<false, true>::ThreadFromGlobalPoolImpl<void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*>(void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&&)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*&&)::'lambda'(), void ()>::operator()[abi:v15007]() build_docker/./contrib/llvm-project/libcxx/include/__functional/function.h:235:12 (clickhouse+0x10126c61)
    #45 void std::__1::__function::__policy_invoker<void ()>::__call_impl<std::__1::__function::__default_alloc_func<ThreadFromGlobalPoolImpl<false, true>::ThreadFromGlobalPoolImpl<void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*>(void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&&)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*&&)::'lambda'(), void ()>>(std::__1::__function::__policy_storage const*) build_docker/./contrib/llvm-project/libcxx/include/__functional/function.h:716:16 (clickhouse+0x10126c61)
    #46 std::__1::__function::__policy_func<void ()>::operator()[abi:v15007]() const build_docker/./contrib/llvm-project/libcxx/include/__functional/function.h:848:16 (clickhouse+0x1011bcad) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #47 std::__1::function<void ()>::operator()() const build_docker/./contrib/llvm-project/libcxx/include/__functional/function.h:1197:12 (clickhouse+0x1011bcad)
    #48 ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool::worker() build_docker/./src/Common/ThreadPool.cpp:785:17 (clickhouse+0x1011bcad)
    #49 decltype(*std::declval<ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool*>().*std::declval<void (ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool::*)()>()()) std::__1::__invoke[abi:v15007]<void (ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool::*)(), ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool*, void>(void (ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool::*&&)(), ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool*&&) build_docker/./contrib/llvm-project/libcxx/include/__functional/invoke.h:359:23 (clickhouse+0x10123e9b) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #50 void std::__1::__thread_execute[abi:v15007]<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, void (ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool::*)(), ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool*, 2ul>(std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, void (ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool::*)(), ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool*>&, std::__1::__tuple_indices<2ul>) build_docker/./contrib/llvm-project/libcxx/include/thread:284:5 (clickhouse+0x10123e9b)
    #51 void* std::__1::__thread_proxy[abi:v15007]<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, void (ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool::*)(), ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool*>>(void*) build_docker/./contrib/llvm-project/libcxx/include/thread:295:5 (clickhouse+0x10123e9b)

  Thread T2120 'QueryPipelineEx' (tid=38234, running) created by thread T1180 at:
    #0 pthread_create <null> (clickhouse+0x78bc4d1) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #1 std::__1::__libcpp_thread_create[abi:v15007](unsigned long*, void* (*)(void*), void*) build_docker/./contrib/llvm-project/libcxx/include/__threading_support:376:10 (clickhouse+0x1011c3f5) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #2 std::__1::thread::thread<void (ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool::*)(), ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool*, void>(void (ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool::*&&)(), ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool*&&) build_docker/./contrib/llvm-project/libcxx/include/thread:311:16 (clickhouse+0x1011c3f5)
    #3 ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool::ThreadFromThreadPool(ThreadPoolImpl<std::__1::thread>&) build_docker/./src/Common/ThreadPool.cpp:598:14 (clickhouse+0x1011b075) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #4 std::__1::__unique_if<ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool>::__unique_single std::__1::make_unique[abi:v15007]<ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool, ThreadPoolImpl<std::__1::thread>&>(ThreadPoolImpl<std::__1::thread>&) build_docker/./contrib/llvm-project/libcxx/include/__memory/unique_ptr.h:714:32 (clickhouse+0x1011cc81) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #5 void ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, Priority, std::__1::optional<unsigned long>, bool) build_docker/./src/Common/ThreadPool.cpp:284:30 (clickhouse+0x1011cc81)
    #6 ThreadPoolImpl<std::__1::thread>::scheduleOrThrow(std::__1::function<void ()>, Priority, unsigned long, bool) build_docker/./src/Common/ThreadPool.cpp:490:5 (clickhouse+0x1011fb6a) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #7 ThreadFromGlobalPoolImpl<false, true>::ThreadFromGlobalPoolImpl<void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*>(void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&&)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*&&) build_docker/./src/Common/ThreadPool.h:278:38 (clickhouse+0x1011fb6a)
    #8 ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::ThreadFromThreadPool(ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>&) build_docker/./src/Common/ThreadPool.cpp:598:14 (clickhouse+0x1011e4e4) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #9 std::__1::__unique_if<ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool>::__unique_single std::__1::make_unique[abi:v15007]<ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool, ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>&>(ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>&) build_docker/./contrib/llvm-project/libcxx/include/__memory/unique_ptr.h:714:32 (clickhouse+0x10120621) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #10 void ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::scheduleImpl<void>(std::__1::function<void ()>, Priority, std::__1::optional<unsigned long>, bool) build_docker/./src/Common/ThreadPool.cpp:284:30 (clickhouse+0x10120621)
    #11 ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::scheduleOrThrowOnError(std::__1::function<void ()>, Priority) build_docker/./src/Common/ThreadPool.cpp:478:5 (clickhouse+0x1012046a) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #12 DB::ThreadPoolCallbackRunnerLocal<void, ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>, std::__1::function<void ()>>::operator()(std::__1::function<void ()>&&, Priority) build_docker/./src/Common/threadPoolCallbackRunner.h:167:14 (clickhouse+0x168a0f62) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #13 DB::MergeTreeData::clearPartsFromFilesystemImpl(std::__1::vector<std::__1::shared_ptr<DB::IMergeTreeDataPart const>, std::__1::allocator<std::__1::shared_ptr<DB::IMergeTreeDataPart const>>> const&, std::__1::unordered_set<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::hash<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>, std::__1::equal_to<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>>*) build_docker/./src/Storages/MergeTree/MergeTreeData.cpp:2888:13 (clickhouse+0x1b5f8b06) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #14 DB::MergeTreeData::clearPartsFromFilesystem(std::__1::vector<std::__1::shared_ptr<DB::IMergeTreeDataPart const>, std::__1::allocator<std::__1::shared_ptr<DB::IMergeTreeDataPart const>>> const&, bool, std::__1::unordered_set<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::hash<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>, std::__1::equal_to<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>>*) build_docker/./src/Storages/MergeTree/MergeTreeData.cpp:2824:9 (clickhouse+0x1b5f62e6) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #15 DB::MergeTreeData::dropAllData() build_docker/./src/Storages/MergeTree/MergeTreeData.cpp:3177:9 (clickhouse+0x1b5fe319) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #16 DB::StorageReplicatedMergeTree::drop() build_docker/./src/Storages/StorageReplicatedMergeTree.cpp:1280:5 (clickhouse+0x1ade9c3a) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #17 DB::DatabaseCatalog::dropTableFinally(DB::DatabaseCatalog::TableMarkedAsDropped const&) build_docker/./src/Interpreters/DatabaseCatalog.cpp:1400:22 (clickhouse+0x187d9ccc) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #18 DB::DatabaseCatalog::dropTablesParallel(std::__1::vector<std::__1::__list_iterator<DB::DatabaseCatalog::TableMarkedAsDropped, void*>, std::__1::allocator<std::__1::__list_iterator<DB::DatabaseCatalog::TableMarkedAsDropped, void*>>>)::$_0::operator()() const build_docker/./src/Interpreters/DatabaseCatalog.cpp:1325:17 (clickhouse+0x187e4f03) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #19 decltype(std::declval<DB::DatabaseCatalog::dropTablesParallel(std::__1::vector<std::__1::__list_iterator<DB::DatabaseCatalog::TableMarkedAsDropped, void*>, std::__1::allocator<std::__1::__list_iterator<DB::DatabaseCatalog::TableMarkedAsDropped, void*>>>)::$_0&>()()) std::__1::__invoke[abi:v15007]<DB::DatabaseCatalog::dropTablesParallel(std::__1::vector<std::__1::__list_iterator<DB::DatabaseCatalog::TableMarkedAsDropped, void*>, std::__1::allocator<std::__1::__list_iterator<DB::DatabaseCatalog::TableMarkedAsDropped, void*>>>)::$_0&>(DB::DatabaseCatalog::dropTablesParallel(std::__1::vector<std::__1::__list_iterator<DB::DatabaseCatalog::TableMarkedAsDropped, void*>, std::__1::allocator<std::__1::__list_iterator<DB::DatabaseCatalog::TableMarkedAsDropped, void*>>>)::$_0&) build_docker/./contrib/llvm-project/libcxx/include/__functional/invoke.h:394:23 (clickhouse+0x187e4f03)
    #20 void std::__1::__invoke_void_return_wrapper<void, true>::__call<DB::DatabaseCatalog::dropTablesParallel(std::__1::vector<std::__1::__list_iterator<DB::DatabaseCatalog::TableMarkedAsDropped, void*>, std::__1::allocator<std::__1::__list_iterator<DB::DatabaseCatalog::TableMarkedAsDropped, void*>>>)::$_0&>(DB::DatabaseCatalog::dropTablesParallel(std::__1::vector<std::__1::__list_iterator<DB::DatabaseCatalog::TableMarkedAsDropped, void*>, std::__1::allocator<std::__1::__list_iterator<DB::DatabaseCatalog::TableMarkedAsDropped, void*>>>)::$_0&) build_docker/./contrib/llvm-project/libcxx/include/__functional/invoke.h:479:9 (clickhouse+0x187e4f03)
    #21 std::__1::__function::__default_alloc_func<DB::DatabaseCatalog::dropTablesParallel(std::__1::vector<std::__1::__list_iterator<DB::DatabaseCatalog::TableMarkedAsDropped, void*>, std::__1::allocator<std::__1::__list_iterator<DB::DatabaseCatalog::TableMarkedAsDropped, void*>>>)::$_0, void ()>::operator()[abi:v15007]() build_docker/./contrib/llvm-project/libcxx/include/__functional/function.h:235:12 (clickhouse+0x187e4f03)
    #22 void std::__1::__function::__policy_invoker<void ()>::__call_impl<std::__1::__function::__default_alloc_func<DB::DatabaseCatalog::dropTablesParallel(std::__1::vector<std::__1::__list_iterator<DB::DatabaseCatalog::TableMarkedAsDropped, void*>, std::__1::allocator<std::__1::__list_iterator<DB::DatabaseCatalog::TableMarkedAsDropped, void*>>>)::$_0, void ()>>(std::__1::__function::__policy_storage const*) build_docker/./contrib/llvm-project/libcxx/include/__functional/function.h:716:16 (clickhouse+0x187e4f03)
    #23 std::__1::__function::__policy_func<void ()>::operator()[abi:v15007]() const build_docker/./contrib/llvm-project/libcxx/include/__functional/function.h:848:16 (clickhouse+0x168a2217) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #24 std::__1::function<void ()>::operator()() const build_docker/./contrib/llvm-project/libcxx/include/__functional/function.h:1197:12 (clickhouse+0x168a2217)
    #25 DB::ThreadPoolCallbackRunnerLocal<void, ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>, std::__1::function<void ()>>::operator()(std::__1::function<void ()>&&, Priority)::'lambda'()::operator()() build_docker/./src/Common/threadPoolCallbackRunner.h:160:20 (clickhouse+0x168a2217)
    #26 decltype(std::declval<DB::ThreadPoolCallbackRunnerLocal<void, ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>, std::__1::function<void ()>>::operator()(std::__1::function<void ()>&&, Priority)::'lambda'()&>()()) std::__1::__invoke[abi:v15007]<DB::ThreadPoolCallbackRunnerLocal<void, ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>, std::__1::function<void ()>>::operator()(std::__1::function<void ()>&&, Priority)::'lambda'()&>(DB::ThreadPoolCallbackRunnerLocal<void, ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>, std::__1::function<void ()>>::operator()(std::__1::function<void ()>&&, Priority)::'lambda'()&) build_docker/./contrib/llvm-project/libcxx/include/__functional/invoke.h:394:23 (clickhouse+0x168a211d) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #27 std::__1::__packaged_task_func<DB::ThreadPoolCallbackRunnerLocal<void, ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>, std::__1::function<void ()>>::operator()(std::__1::function<void ()>&&, Priority)::'lambda'(), std::__1::allocator<DB::ThreadPoolCallbackRunnerLocal<void, ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>, std::__1::function<void ()>>::operator()(std::__1::function<void ()>&&, Priority)::'lambda'()>, void ()>::operator()() build_docker/./contrib/llvm-project/libcxx/include/future:1694:12 (clickhouse+0x168a211d)
    #28 std::__1::__packaged_task_function<void ()>::operator()() const build_docker/./contrib/llvm-project/libcxx/include/future:1876:12 (clickhouse+0x10847254) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #29 std::__1::packaged_task<void ()>::operator()() build_docker/./contrib/llvm-project/libcxx/include/future:2068:9 (clickhouse+0x10847254)
    #30 DB::ThreadPoolCallbackRunnerLocal<void, ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>, std::__1::function<void ()>>::operator()(std::__1::function<void ()>&&, Priority)::'lambda0'()::operator()() const build_docker/./src/Common/threadPoolCallbackRunner.h:167:71 (clickhouse+0x168a31ac) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #31 decltype(std::declval<DB::ThreadPoolCallbackRunnerLocal<void, ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>, std::__1::function<void ()>>::operator()(std::__1::function<void ()>&&, Priority)::'lambda0'()&>()()) std::__1::__invoke[abi:v15007]<DB::ThreadPoolCallbackRunnerLocal<void, ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>, std::__1::function<void ()>>::operator()(std::__1::function<void ()>&&, Priority)::'lambda0'()&>(DB::ThreadPoolCallbackRunnerLocal<void, ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>, std::__1::function<void ()>>::operator()(std::__1::function<void ()>&&, Priority)::'lambda0'()&) build_docker/./contrib/llvm-project/libcxx/include/__functional/invoke.h:394:23 (clickhouse+0x168a31ac)
    #32 void std::__1::__invoke_void_return_wrapper<void, true>::__call<DB::ThreadPoolCallbackRunnerLocal<void, ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>, std::__1::function<void ()>>::operator()(std::__1::function<void ()>&&, Priority)::'lambda0'()&>(DB::ThreadPoolCallbackRunnerLocal<void, ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>, std::__1::function<void ()>>::operator()(std::__1::function<void ()>&&, Priority)::'lambda0'()&) build_docker/./contrib/llvm-project/libcxx/include/__functional/invoke.h:479:9 (clickhouse+0x168a31ac)
    #33 std::__1::__function::__default_alloc_func<DB::ThreadPoolCallbackRunnerLocal<void, ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>, std::__1::function<void ()>>::operator()(std::__1::function<void ()>&&, Priority)::'lambda0'(), void ()>::operator()[abi:v15007]() build_docker/./contrib/llvm-project/libcxx/include/__functional/function.h:235:12 (clickhouse+0x168a31ac)
    #34 void std::__1::__function::__policy_invoker<void ()>::__call_impl<std::__1::__function::__default_alloc_func<DB::ThreadPoolCallbackRunnerLocal<void, ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>, std::__1::function<void ()>>::operator()(std::__1::function<void ()>&&, Priority)::'lambda0'(), void ()>>(std::__1::__function::__policy_storage const*) build_docker/./contrib/llvm-project/libcxx/include/__functional/function.h:716:16 (clickhouse+0x168a31ac)
    #35 std::__1::__function::__policy_func<void ()>::operator()[abi:v15007]() const build_docker/./contrib/llvm-project/libcxx/include/__functional/function.h:848:16 (clickhouse+0x1011f271) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #36 std::__1::function<void ()>::operator()() const build_docker/./contrib/llvm-project/libcxx/include/__functional/function.h:1197:12 (clickhouse+0x1011f271)
    #37 ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::worker() build_docker/./src/Common/ThreadPool.cpp:775:17 (clickhouse+0x1011f271)
    #38 decltype(*std::declval<ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*&>().*std::declval<void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&)()>()()) std::__1::__invoke[abi:v15007]<void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*&, void>(void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*&) build_docker/./contrib/llvm-project/libcxx/include/__functional/invoke.h:359:23 (clickhouse+0x10126d45) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #39 decltype(auto) std::__1::__apply_tuple_impl[abi:v15007]<void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&)(), std::__1::tuple<ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*>&, 0ul>(void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&)(), std::__1::tuple<ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*>&, std::__1::__tuple_indices<0ul>) build_docker/./contrib/llvm-project/libcxx/include/tuple:1789:1 (clickhouse+0x10126d45)
    #40 decltype(auto) std::__1::apply[abi:v15007]<void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&)(), std::__1::tuple<ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*>&>(void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&)(), std::__1::tuple<ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*>&) build_docker/./contrib/llvm-project/libcxx/include/tuple:1798:1 (clickhouse+0x10126d45)
    #41 ThreadFromGlobalPoolImpl<false, true>::ThreadFromGlobalPoolImpl<void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*>(void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&&)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*&&)::'lambda'()::operator()() build_docker/./src/Common/ThreadPool.h:311:13 (clickhouse+0x10126d45)
    #42 decltype(std::declval<void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*)()>()(std::declval<ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*>())) std::__1::__invoke[abi:v15007]<ThreadFromGlobalPoolImpl<false, true>::ThreadFromGlobalPoolImpl<void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*>(void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&&)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*&&)::'lambda'()&>(void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&&)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*&&) build_docker/./contrib/llvm-project/libcxx/include/__functional/invoke.h:394:23 (clickhouse+0x10126c61) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #43 void std::__1::__invoke_void_return_wrapper<void, true>::__call<ThreadFromGlobalPoolImpl<false, true>::ThreadFromGlobalPoolImpl<void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*>(void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&&)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*&&)::'lambda'()&>(ThreadFromGlobalPoolImpl<false, true>::ThreadFromGlobalPoolImpl<void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*>(void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&&)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*&&)::'lambda'()&) build_docker/./contrib/llvm-project/libcxx/include/__functional/invoke.h:479:9 (clickhouse+0x10126c61)
    #44 std::__1::__function::__default_alloc_func<ThreadFromGlobalPoolImpl<false, true>::ThreadFromGlobalPoolImpl<void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*>(void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&&)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*&&)::'lambda'(), void ()>::operator()[abi:v15007]() build_docker/./contrib/llvm-project/libcxx/include/__functional/function.h:235:12 (clickhouse+0x10126c61)
    #45 void std::__1::__function::__policy_invoker<void ()>::__call_impl<std::__1::__function::__default_alloc_func<ThreadFromGlobalPoolImpl<false, true>::ThreadFromGlobalPoolImpl<void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*>(void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&&)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*&&)::'lambda'(), void ()>>(std::__1::__function::__policy_storage const*) build_docker/./contrib/llvm-project/libcxx/include/__functional/function.h:716:16 (clickhouse+0x10126c61)
    #46 std::__1::__function::__policy_func<void ()>::operator()[abi:v15007]() const build_docker/./contrib/llvm-project/libcxx/include/__functional/function.h:848:16 (clickhouse+0x1011bcad) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #47 std::__1::function<void ()>::operator()() const build_docker/./contrib/llvm-project/libcxx/include/__functional/function.h:1197:12 (clickhouse+0x1011bcad)
    #48 ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool::worker() build_docker/./src/Common/ThreadPool.cpp:785:17 (clickhouse+0x1011bcad)
    #49 decltype(*std::declval<ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool*>().*std::declval<void (ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool::*)()>()()) std::__1::__invoke[abi:v15007]<void (ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool::*)(), ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool*, void>(void (ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool::*&&)(), ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool*&&) build_docker/./contrib/llvm-project/libcxx/include/__functional/invoke.h:359:23 (clickhouse+0x10123e9b) (BuildId: e64e25138b2313a5ed8d6ff68c9bbcf825c8d332)
    #50 void std::__1::__thread_execute[abi:v15007]<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, void (ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool::*)(), ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool*, 2ul>(std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, void (ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool::*)(), ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool*>&, std::__1::__tuple_indices<2ul>) build_docker/./contrib/llvm-project/libcxx/include/thread:284:5 (clickhouse+0x10123e9b)
    #51 void* std::__1::__thread_proxy[abi:v15007]<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, void (ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool::*)(), ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool*>>(void*) build_docker/./contrib/llvm-project/libcxx/include/thread:295:5 (clickhouse+0x10123e9b)

SUMMARY: ThreadSanitizer: data race build_docker/./contrib/boost/boost/smart_ptr/intrusive_ptr.hpp:202:16 in boost::intrusive_ptr<DB::IColumn const>::operator->() const
==================
```

</details>