### PR TITLE
Fix uncaught exception in ScatteredBlock

### DIFF
--- a/src/Interpreters/HashJoin/ScatteredBlock.h
+++ b/src/Interpreters/HashJoin/ScatteredBlock.h
@@ -302,10 +302,11 @@ struct ScatteredBlock : private boost::noncopyable
     /// Cut first `num_rows` rows from `block` in place and returns block with remaining rows
     ScatteredBlock cut(size_t num_rows)
     {
-        SCOPE_EXIT(filterBySelector());
-
         if (num_rows >= rows())
+        {
+            filterBySelector();
             return ScatteredBlock{Block{}};
+        }
 
         chassert(block);
 
@@ -314,6 +315,7 @@ struct ScatteredBlock : private boost::noncopyable
         auto remaining = ScatteredBlock{block, std::move(remaining_selector)};
 
         selector = std::move(first_num_rows);
+        filterBySelector();
 
         return remaining;
     }


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


---

`filterBySelector` was called in dtor of ScopeGuard and if memory limit exception was thrown within this call (it allocates new columns) process crashed.
Don't mark as a bug-fix because this code wasn't released yet.