### PR TITLE
fix rank functions description

### DIFF
--- a/docs/en/sql-reference/window-functions/dense_rank.md
+++ b/docs/en/sql-reference/window-functions/dense_rank.md
@@ -15,8 +15,8 @@ The [rank](./rank.md) function provides the same behaviour, but with gaps in ran
 Alias: `denseRank` (case-sensitive)
 
 ```sql
-dense_rank (column_name)
-  OVER ([[PARTITION BY grouping_column] [ORDER BY sorting_column] 
+dense_rank ()
+  OVER ([[PARTITION BY grouping_column] [ORDER BY sorting_column]
         [ROWS or RANGE expression_to_bound_rows_withing_the_group]] | [window_name])
 FROM table_name
 WINDOW window_name as ([[PARTITION BY grouping_column] [ORDER BY sorting_column])
@@ -55,7 +55,7 @@ INSERT INTO salaries FORMAT Values
 ```
 
 ```sql
-SELECT player, salary, 
+SELECT player, salary,
        dense_rank() OVER (ORDER BY salary DESC) AS dense_rank
 FROM salaries;
 ```

--- a/docs/en/sql-reference/window-functions/percent_rank.md
+++ b/docs/en/sql-reference/window-functions/percent_rank.md
@@ -13,8 +13,8 @@ returns the relative rank (i.e. percentile) of rows within a window partition.
 Alias: `percentRank` (case-sensitive)
 
 ```sql
-percent_rank (column_name)
-  OVER ([[PARTITION BY grouping_column] [ORDER BY sorting_column] 
+percent_rank ()
+  OVER ([[PARTITION BY grouping_column] [ORDER BY sorting_column]
         [RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING]] | [window_name])
 FROM table_name
 WINDOW window_name as ([PARTITION BY grouping_column] [ORDER BY sorting_column] RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)
@@ -50,7 +50,7 @@ INSERT INTO salaries FORMAT Values
 ```
 
 ```sql
-SELECT player, salary, 
+SELECT player, salary,
        percent_rank() OVER (ORDER BY salary DESC) AS percent_rank
 FROM salaries;
 ```

--- a/docs/en/sql-reference/window-functions/rank.md
+++ b/docs/en/sql-reference/window-functions/rank.md
@@ -9,13 +9,13 @@ sidebar_position: 6
 Ranks the current row within its partition with gaps. In other words, if the value of any row it encounters is equal to the value of a previous row then it will receive the same rank as that previous row.
 The rank of the next row is then equal to the rank of the previous row plus a gap equal to the number of times the previous rank was given.
 
-The [dense_rank](./dense_rank.md) function provides the same behaviour but without gaps in ranking. 
+The [dense_rank](./dense_rank.md) function provides the same behaviour but without gaps in ranking.
 
 **Syntax**
 
 ```sql
-rank (column_name)
-  OVER ([[PARTITION BY grouping_column] [ORDER BY sorting_column] 
+rank ()
+  OVER ([[PARTITION BY grouping_column] [ORDER BY sorting_column]
         [ROWS or RANGE expression_to_bound_rows_withing_the_group]] | [window_name])
 FROM table_name
 WINDOW window_name as ([[PARTITION BY grouping_column] [ORDER BY sorting_column])
@@ -54,7 +54,7 @@ INSERT INTO salaries FORMAT Values
 ```
 
 ```sql
-SELECT player, salary, 
+SELECT player, salary,
        rank() OVER (ORDER BY salary DESC) AS rank
 FROM salaries;
 ```


### PR DESCRIPTION
rank() / dense_rank() / percent_rank() don't accept argument (column_name), they are calculated from a frame.

### Changelog category (leave one):
- Documentation (changelog entry is not required)
