### PR TITLE
Fix `BACKUP ... EXCEPT TABLES` queries formatting and parsing

### DIFF
--- a/src/Parsers/ASTBackupQuery.cpp
+++ b/src/Parsers/ASTBackupQuery.cpp
@@ -46,7 +46,7 @@ namespace
         }
     }
 
-    void formatExceptTables(const std::set<DatabaseAndTableName> & except_tables, const IAST::FormatSettings & format)
+    void formatExceptTables(const std::set<DatabaseAndTableName> & except_tables, const IAST::FormatSettings & format, bool only_table_names=false)
     {
         if (except_tables.empty())
             return;
@@ -60,7 +60,7 @@ namespace
             if (std::exchange(need_comma, true))
                 format.ostr << ", ";
 
-            if (!table_name.first.empty())
+            if (!table_name.first.empty() && !only_table_names)
                 format.ostr << backQuoteIfNeed(table_name.first) << ".";
             format.ostr << backQuoteIfNeed(table_name.second);
         }
@@ -117,7 +117,7 @@ namespace
                     format.ostr << backQuoteIfNeed(element.new_database_name);
                 }
 
-                formatExceptTables(element.except_tables, format);
+                formatExceptTables(element.except_tables, format, /*only_table_names*/true);
                 break;
             }
 

--- a/tests/integration/test_backup_restore_new/test.py
+++ b/tests/integration/test_backup_restore_new/test.py
@@ -1560,6 +1560,36 @@ def test_backup_all(exclude_system_log_tables):
     instance.query("DROP USER u1")
 
 
+@pytest.mark.parametrize("include_database_name", [False, True])
+def test_backup_database_except(include_database_name):
+    create_and_fill_table()
+
+    session_id = new_session_id()
+    instance.query(
+        "CREATE TABLE test.omit_table (s String) ENGINE = MergeTree ORDER BY s",
+    )
+
+    omit_table_name = "test.omit_table" if include_database_name else "omit_table"
+    backup_name = new_backup_name()
+    backup_command = f"BACKUP DATABASE test EXCEPT TABLES {omit_table_name} TO {backup_name}"
+
+    instance.http_query(backup_command, params={"session_id": session_id})
+
+    instance.query("DROP TABLE test.table")
+    instance.query("DROP TABLE test.omit_table")
+
+    restore_command = f"RESTORE ALL FROM {backup_name}"
+
+    session_id = new_session_id()
+    instance.http_query(
+        restore_command, params={"session_id": session_id}, method="POST"
+    )
+
+    assert instance.query("SELECT count(), sum(x) FROM test.table") == "100\t4950\n"
+    assert instance.query("EXISTS TABLE test.omit_table") == "0\n"
+
+    instance.query("DROP TABLE test.table")
+
 def test_operation_id():
     create_and_fill_table(n=30)
 

--- a/tests/integration/test_backup_restore_new/test.py
+++ b/tests/integration/test_backup_restore_new/test.py
@@ -1571,7 +1571,9 @@ def test_backup_database_except(include_database_name):
 
     omit_table_name = "test.omit_table" if include_database_name else "omit_table"
     backup_name = new_backup_name()
-    backup_command = f"BACKUP DATABASE test EXCEPT TABLES {omit_table_name} TO {backup_name}"
+    backup_command = (
+        f"BACKUP DATABASE test EXCEPT TABLES {omit_table_name} TO {backup_name}"
+    )
 
     instance.http_query(backup_command, params={"session_id": session_id})
 
@@ -1589,6 +1591,7 @@ def test_backup_database_except(include_database_name):
     assert instance.query("EXISTS TABLE test.omit_table") == "0\n"
 
     instance.query("DROP TABLE test.table")
+
 
 def test_operation_id():
     create_and_fill_table(n=30)


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix failure on parsing `BACKUP DATABASE db EXCEPT TABLES db.table` queries

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---ci_include_fuzzer--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
