### PR TITLE
Remove duplicate checks of clang-tidy `bugprone-reserved-identifier`

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -10,7 +10,7 @@ HeaderFilterRegex: '^.*/(base|src|programs|utils)/.*(h|hpp)$'
 Checks: [
   '*',
 
-  '-abseil-*',
+  '-abseil-string-find-str-contains', # disabled to avoid a misleading suggestion (obsolete absl::StrContains() instead of C++23 std::string::contains())
 
   '-altera-*',
 

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -32,8 +32,6 @@ Checks: [
   '-bugprone-crtp-constructor-accessibility',
 
   '-cert-dcl16-c',
-  '-cert-dcl37-c',
-  '-cert-dcl51-cpp',
   '-cert-err58-cpp',
   '-cert-msc32-c',
   '-cert-msc51-cpp',

--- a/programs/disks/DisksClient.cpp
+++ b/programs/disks/DisksClient.cpp
@@ -100,7 +100,7 @@ void DiskWithPath::setPath(const String & any_path)
 String DiskWithPath::validatePathAndGetAsRelative(const String & path)
 {
     String lexically_normal_path = fs::path(path).lexically_normal();
-    if (lexically_normal_path.find("..") != std::string::npos)
+    if (lexically_normal_path.contains(".."))
         throw DB::Exception(DB::ErrorCodes::BAD_ARGUMENTS, "Path {} is not normalized", path);
 
     /// If path is absolute we should keep it as relative inside disk, so disk will look like

--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -2614,7 +2614,7 @@ bool ClientBase::addMergeTreeSettings(ASTCreateQuery & ast_create)
         || !ast_create.storage
         || !ast_create.storage->isExtendedStorageDefinition()
         || !ast_create.storage->engine
-        || ast_create.storage->engine->name.find("MergeTree") == std::string::npos)
+        || !ast_create.storage->engine->name.contains("MergeTree"))
         return false;
 
     auto all_changed = cmd_merge_tree_settings.changes();

--- a/src/Common/Config/AbstractConfigurationComparison.cpp
+++ b/src/Common/Config/AbstractConfigurationComparison.cpp
@@ -41,7 +41,7 @@ namespace
 #if defined(DEBUG_OR_SANITIZER_BUILD)
             /// Compound `ignore_keys` are not yet implemented.
             for (const auto & ignore_key : *ignore_keys)
-                chassert(ignore_key.find('.') == std::string_view::npos);
+                chassert(!ignore_key.contains('.'));
 #endif
         }
 

--- a/src/Common/FileRenamer.cpp
+++ b/src/Common/FileRenamer.cpp
@@ -38,7 +38,7 @@ String FileRenamer::generateNewFilename(const String & filename) const
 
     // Get current timestamp in microseconds
     String timestamp;
-    if (rule.find("%t") != String::npos)
+    if (rule.contains("%t"))
     {
         auto now = std::chrono::system_clock::now();
         timestamp = std::to_string(timeInMicroseconds(now));

--- a/src/Common/Macros.cpp
+++ b/src/Common/Macros.cpp
@@ -53,7 +53,7 @@ String Macros::expand(const String & s,
     /// Do not allow recursion if we expand only special macros, because it will be infinite recursion
     assert(info.level == 0 || !info.expand_special_macros_only);
 
-    if (s.find('{') == String::npos)
+    if (!s.contains('{'))
         return s;
 
     if (info.level && s.size() > 65536)

--- a/src/Common/ZooKeeper/ZooKeeperCommon.cpp
+++ b/src/Common/ZooKeeper/ZooKeeperCommon.cpp
@@ -206,7 +206,7 @@ std::string ZooKeeperAuthRequest::toStringImpl(bool /*short_format*/) const
 void ZooKeeperCreateRequest::writeImpl(WriteBuffer & out) const
 {
     /// See https://github.com/ClickHouse/clickhouse-private/issues/3029
-    if (path.starts_with("/clickhouse/tables/") && path.find("/parts/") != std::string::npos)
+    if (path.starts_with("/clickhouse/tables/") && path.contains("/parts/"))
     {
         LOG_TRACE(getLogger(__PRETTY_FUNCTION__), "Creating part at path {}", path);
     }

--- a/src/Common/getNumberOfCPUCoresToUse.cpp
+++ b/src/Common/getNumberOfCPUCoresToUse.cpp
@@ -143,13 +143,13 @@ try
         std::string key = line.substr(0, pos);
         std::string val = line.substr(pos + 1);
 
-        if (key.find("physical id") != std::string::npos)
+        if (key.contains("physical id"))
         {
             cur_core_entry.first = std::stoi(val);
             continue;
         }
 
-        if (key.find("core id") != std::string::npos)
+        if (key.contains("core id"))
         {
             cur_core_entry.second = std::stoi(val);
             core_entries.insert(cur_core_entry);

--- a/src/Common/mysqlxx/PoolWithFailover.cpp
+++ b/src/Common/mysqlxx/PoolWithFailover.cpp
@@ -165,7 +165,7 @@ PoolWithFailover::Entry PoolWithFailover::get()
                 }
                 catch (const Poco::Exception & e)
                 {
-                    if (e.displayText().find("mysqlxx::Pool is full") != std::string::npos) /// NOTE: String comparison is trashy code.
+                    if (e.displayText().contains("mysqlxx::Pool is full")) /// NOTE: String comparison is trashy code.
                     {
                         full_pool = &pool;
                     }

--- a/src/Common/mysqlxx/tests/mysqlxx_pool_test.cpp
+++ b/src/Common/mysqlxx/tests/mysqlxx_pool_test.cpp
@@ -26,7 +26,7 @@ mysqlxx::Pool::Entry getWithFailover(mysqlxx::Pool & connections_pool)
         }
         catch (const Poco::Exception & e)
         {
-            if (e.displayText().find("mysqlxx::Pool is full") != std::string::npos)
+            if (e.displayText().contains("mysqlxx::Pool is full"))
             {
                 std::cerr << e.displayText() << std::endl;
             }

--- a/src/Common/parseGlobs.cpp
+++ b/src/Common/parseGlobs.cpp
@@ -46,7 +46,7 @@ std::string makeRegexpPatternFromGlobs(const std::string & initial_str_with_glob
         std::string buffer(matched);
         oss_for_replacing << escaped_with_globs.substr(current_index, matched.data() - escaped_with_globs.data() - current_index - 1) << '(';
 
-        if (buffer.find(',') == std::string::npos)
+        if (!buffer.contains(','))
         {
             size_t range_begin = 0;
             size_t range_end = 0;

--- a/src/Compression/tests/gtest_compressionCodec.cpp
+++ b/src/Compression/tests/gtest_compressionCodec.cpp
@@ -521,7 +521,7 @@ public:
 TEST_P(CodecTest, TranscodingWithDataType)
 {
     /// Gorilla can only be applied to floating point columns
-    bool codec_is_gorilla = std::get<0>(GetParam()).codec_statement.find("Gorilla") != std::string::npos;
+    bool codec_is_gorilla = std::get<0>(GetParam()).codec_statement.contains("Gorilla");
     WhichDataType which(std::get<1>(GetParam()).data_type.get());
     bool data_is_float = which.isFloat();
     if (codec_is_gorilla && !data_is_float)

--- a/src/DataTypes/Serializations/SerializationNullable.cpp
+++ b/src/DataTypes/Serializations/SerializationNullable.cpp
@@ -370,10 +370,10 @@ ReturnType  deserializeTextEscapedAndRawImpl(IColumn & column, ReadBuffer & istr
         if constexpr (!throw_exception)
             return ReturnType(false);
 
-        if (null_representation.find('\t') != std::string::npos || null_representation.find('\n') != std::string::npos)
+        if (null_representation.contains('\t') || null_representation.contains('\n'))
             throw DB::Exception(ErrorCodes::CANNOT_READ_ALL_DATA, "TSV custom null representation "
                 "containing '\\t' or '\\n' may not work correctly for large input.");
-        if (settings.tsv.crlf_end_of_line_input && null_representation.find('\r') != std::string::npos)
+        if (settings.tsv.crlf_end_of_line_input && null_representation.contains('\r'))
             throw DB::Exception(ErrorCodes::CANNOT_READ_ALL_DATA, "TSV custom null representation "
                 "containing '\\r' may not work correctly for large input.");
 
@@ -747,8 +747,7 @@ ReturnType deserializeTextCSVImpl(IColumn & column, ReadBuffer & istr, const For
         if constexpr (!throw_exception)
             return ReturnType(false);
 
-        if (null_representation.find(settings.csv.delimiter) != std::string::npos || null_representation.find('\r') != std::string::npos
-            || null_representation.find('\n') != std::string::npos)
+        if (null_representation.contains(settings.csv.delimiter) || null_representation.contains('\r') || null_representation.contains('\n'))
             throw DB::Exception(ErrorCodes::CANNOT_READ_ALL_DATA, "CSV custom null representation containing "
                                        "format_csv_delimiter, '\\r' or '\\n' may not work correctly for large input.");
 

--- a/src/Databases/DatabaseReplicated.cpp
+++ b/src/Databases/DatabaseReplicated.cpp
@@ -140,9 +140,9 @@ DatabaseReplicated::DatabaseReplicated(
 {
     if (zookeeper_path.empty() || shard_name.empty() || replica_name.empty())
         throw Exception(ErrorCodes::BAD_ARGUMENTS, "ZooKeeper path, shard and replica names must be non-empty");
-    if (shard_name.find('/') != std::string::npos || replica_name.find('/') != std::string::npos)
+    if (shard_name.contains('/') || replica_name.contains('/'))
         throw Exception(ErrorCodes::BAD_ARGUMENTS, "Shard and replica names should not contain '/'");
-    if (shard_name.find('|') != std::string::npos || replica_name.find('|') != std::string::npos)
+    if (shard_name.contains('|') || replica_name.contains('|'))
         throw Exception(ErrorCodes::BAD_ARGUMENTS, "Shard and replica names should not contain '|'");
 
     if (zookeeper_path.back() == '/')
@@ -1105,9 +1105,9 @@ BlockIO DatabaseReplicated::tryEnqueueReplicatedDDL(const ASTPtr & query, Contex
 
 static UUID getTableUUIDIfReplicated(const String & metadata, ContextPtr context)
 {
-    bool looks_like_replicated = metadata.find("Replicated") != std::string::npos;
-    bool looks_like_shared = metadata.find("Shared") != std::string::npos;
-    bool looks_like_merge_tree = metadata.find("MergeTree") != std::string::npos;
+    bool looks_like_replicated = metadata.contains("Replicated");
+    bool looks_like_shared = metadata.contains("Shared");
+    bool looks_like_merge_tree = metadata.contains("MergeTree");
     if (!(looks_like_replicated || looks_like_shared) || !looks_like_merge_tree)
         return UUIDHelpers::Nil;
 
@@ -1539,7 +1539,7 @@ void DatabaseReplicated::dropReplica(
 
     String full_replica_name = shard.empty() ? replica : getFullReplicaName(shard, replica);
 
-    if (full_replica_name.find('/') != std::string::npos)
+    if (full_replica_name.contains('/'))
         throw Exception(ErrorCodes::BAD_ARGUMENTS, "Invalid replica name, '/' is not allowed: {}", full_replica_name);
 
     auto zookeeper = Context::getGlobalContextInstance()->getZooKeeper();

--- a/src/Databases/MySQL/MaterializeMetadata.cpp
+++ b/src/Databases/MySQL/MaterializeMetadata.cpp
@@ -165,11 +165,11 @@ static bool checkSyncUserPrivImpl(const mysqlxx::PoolWithFailover::Entry & conne
             grants_query = (*block.getByPosition(0).column)[index].safeGet<String>();
             out << grants_query << "; ";
             sub_privs = grants_query.substr(0, grants_query.find(" ON "));
-            if (sub_privs.find("ALL PRIVILEGES") == std::string::npos)
+            if (!sub_privs.contains("ALL PRIVILEGES"))
             {
-                if ((sub_privs.find("RELOAD") != std::string::npos and
-                    sub_privs.find("REPLICATION SLAVE") != std::string::npos and
-                    sub_privs.find("REPLICATION CLIENT") != std::string::npos))
+                if ((sub_privs.contains("RELOAD") and
+                    sub_privs.contains("REPLICATION SLAVE") and
+                    sub_privs.contains("REPLICATION CLIENT")))
                     return true;
             }
             else

--- a/src/Databases/PostgreSQL/DatabasePostgreSQL.cpp
+++ b/src/Databases/PostgreSQL/DatabasePostgreSQL.cpp
@@ -135,8 +135,7 @@ DatabaseTablesIteratorPtr DatabasePostgreSQL::getTablesIterator(ContextPtr local
 
 bool DatabasePostgreSQL::checkPostgresTable(const String & table_name) const
 {
-    if (table_name.find('\'') != std::string::npos
-        || table_name.find('\\') != std::string::npos)
+    if (table_name.contains('\'') || table_name.contains('\\'))
     {
         throw Exception(ErrorCodes::BAD_ARGUMENTS,
             "PostgreSQL table name cannot contain single quote or backslash characters, passed {}", table_name);

--- a/src/Disks/ObjectStorages/DiskObjectStorageRemoteMetadataRestoreHelper.cpp
+++ b/src/Disks/ObjectStorages/DiskObjectStorageRemoteMetadataRestoreHelper.cpp
@@ -367,7 +367,7 @@ void DiskObjectStorageRemoteMetadataRestoreHelper::restoreFiles(IObjectStorage *
             LOG_INFO(disk->log, "Calling restore for key for disk {}", object->relative_path);
 
             /// Skip file operations objects. They will be processed separately.
-            if (object->relative_path.find("/operations/") != String::npos)
+            if (object->relative_path.contains("/operations/"))
                 continue;
 
             const auto [revision, _] = extractRevisionAndOperationFromKey(object->relative_path);
@@ -541,7 +541,7 @@ void DiskObjectStorageRemoteMetadataRestoreHelper::restoreFileOperations(IObject
         for (const auto & path : renames)
         {
             /// Skip already detached parts.
-            if (path.find("/detached/") != std::string::npos)
+            if (path.contains("/detached/"))
                 continue;
 
             /// Skip not finished parts. They shouldn't be in 'detached' directory, because CH wouldn't be able to finish processing them.

--- a/src/Formats/CapnProtoSchema.cpp
+++ b/src/Formats/CapnProtoSchema.cpp
@@ -43,10 +43,10 @@ capnp::StructSchema CapnProtoSchemaParser::getMessageSchema(const FormatSchemaIn
         /// That's not good to determine the type of error by its description, but
         /// this is the only way to do it here, because kj doesn't specify the type of error.
         auto description = std::string_view(e.getDescription().cStr());
-        if (description.find("No such file or directory") != String::npos || description.find("no such directory") != String::npos || description.find("no such file") != String::npos)
+        if (description.contains("No such file or directory") || description.contains("no such directory") || description.contains("no such file"))
             throw Exception(ErrorCodes::FILE_DOESNT_EXIST, "Cannot open CapnProto schema, file {} doesn't exists", schema_info.absoluteSchemaPath());
 
-        if (description.find("Parse error") != String::npos)
+        if (description.contains("Parse error"))
             throw Exception(ErrorCodes::CANNOT_PARSE_CAPN_PROTO_SCHEMA, "Cannot parse CapnProto schema {}:{}", schema_info.schemaPath(), e.getLine());
 
         throw Exception(ErrorCodes::UNKNOWN_EXCEPTION,

--- a/src/Functions/FunctionsConversion.h
+++ b/src/Functions/FunctionsConversion.h
@@ -2473,8 +2473,7 @@ public:
 
             if (!isStringOrFixedString(arguments[0].type))
             {
-                if (this->getName().find("OrZero") != std::string::npos ||
-                    this->getName().find("OrNull") != std::string::npos)
+                if (this->getName().contains("OrZero") || this->getName().contains("OrNull"))
                     throw Exception(ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT, "Illegal type {} of first argument of function {}. "
                             "Conversion functions with postfix 'OrZero' or 'OrNull' should take String argument",
                             arguments[0].type->getName(), getName());

--- a/src/IO/CompressionMethod.cpp
+++ b/src/IO/CompressionMethod.cpp
@@ -58,21 +58,21 @@ CompressionMethod chooseHTTPCompressionMethod(const std::string & list)
 {
     /// The compression methods are ordered from most to least preferred.
 
-    if (std::string::npos != list.find("zstd"))
+    if (list.contains("zstd"))
         return CompressionMethod::Zstd;
-    if (std::string::npos != list.find("br"))
+    if (list.contains("br"))
         return CompressionMethod::Brotli;
-    if (std::string::npos != list.find("lz4"))
+    if (list.contains("lz4"))
         return CompressionMethod::Lz4;
-    if (std::string::npos != list.find("snappy"))
+    if (list.contains("snappy"))
         return CompressionMethod::Snappy;
-    if (std::string::npos != list.find("gzip"))
+    if (list.contains("gzip"))
         return CompressionMethod::Gzip;
-    if (std::string::npos != list.find("deflate"))
+    if (list.contains("deflate"))
         return CompressionMethod::Zlib;
-    if (std::string::npos != list.find("xz"))
+    if (list.contains("xz"))
         return CompressionMethod::Xz;
-    if (std::string::npos != list.find("bz2"))
+    if (list.contains("bz2"))
         return CompressionMethod::Bzip2;
     return CompressionMethod::None;
 }

--- a/src/IO/S3/Client.cpp
+++ b/src/IO/S3/Client.cpp
@@ -156,10 +156,10 @@ namespace
 
 ProviderType deduceProviderType(const std::string & url)
 {
-    if (url.find(".amazonaws.com") != std::string::npos)
+    if (url.contains(".amazonaws.com"))
         return ProviderType::AWS;
 
-    if (url.find("storage.googleapis.com") != std::string::npos)
+    if (url.contains("storage.googleapis.com"))
         return ProviderType::GCS;
 
     return ProviderType::UNKNOWN;

--- a/src/IO/S3/URI.cpp
+++ b/src/IO/S3/URI.cpp
@@ -99,7 +99,7 @@ URI::URI(const std::string & uri_, bool allow_archive_path_syntax)
     /// '?' can not be used as a wildcard, otherwise it will be ambiguous.
     /// If no "versionId" in the http parameter, '?' can be used as a wildcard.
     /// It is necessary to encode '?' to avoid deletion during parsing path.
-    if (!has_version_id && uri_.find('?') != String::npos)
+    if (!has_version_id && uri_.contains('?'))
     {
         String uri_with_question_mark_encode;
         Poco::URI::encode(uri_, "?", uri_with_question_mark_encode);

--- a/src/Interpreters/Cluster.cpp
+++ b/src/Interpreters/Cluster.cpp
@@ -383,7 +383,7 @@ void Clusters::updateClusters(const Poco::Util::AbstractConfiguration & new_conf
             continue;
         }
 
-        if (key.find('.') != String::npos)
+        if (key.contains('.'))
             throw Exception(ErrorCodes::SYNTAX_ERROR, "Cluster names with dots are not supported: '{}'", key);
 
         /// If old config is set and cluster config wasn't changed, don't update this cluster.

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -3893,7 +3893,7 @@ zkutil::ZooKeeperPtr Context::getAuxiliaryZooKeeper(const String & name) const
     auto zookeeper = shared->auxiliary_zookeepers.find(name);
     if (zookeeper == shared->auxiliary_zookeepers.end())
     {
-        if (name.find(':') != std::string::npos || name.find('/') != std::string::npos)
+        if (name.contains(':') || name.contains('/'))
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "Invalid auxiliary ZooKeeper name {}: ':' and '/' are not allowed", name);
 
         const auto & config = shared->auxiliary_zookeepers_config ? *shared->auxiliary_zookeepers_config : getConfigRef();

--- a/src/Interpreters/GatherFunctionQuantileVisitor.cpp
+++ b/src/Interpreters/GatherFunctionQuantileVisitor.cpp
@@ -71,12 +71,12 @@ void GatherFunctionQuantileData::FuseQuantileAggregatesData::addFuncNode(ASTPtr 
     if (arguments.size() != (need_two_args ? 2 : 1))
         return;
 
-    if (arguments[0]->getColumnName().find(',') != std::string::npos)
+    if (arguments[0]->getColumnName().contains(','))
         return;
     String arg_name = arguments[0]->getColumnName();
     if (need_two_args)
     {
-        if (arguments[1]->getColumnName().find(',') != std::string::npos)
+        if (arguments[1]->getColumnName().contains(','))
             return;
         arg_name += "," + arguments[1]->getColumnName();
     }

--- a/src/Interpreters/MySQL/InterpretersMySQLDDLQuery.cpp
+++ b/src/Interpreters/MySQL/InterpretersMySQLDDLQuery.cpp
@@ -103,7 +103,7 @@ NamesAndTypesList getColumnsList(const ASTExpressionList * columns_definition)
             if (is_unsigned)
             {
                 /// For example(in MySQL): CREATE TABLE test(column_name INT NOT NULL ... UNSIGNED)
-                if (type_name_upper.find("INT") != String::npos && !endsWith(type_name_upper, "SIGNED")
+                if (type_name_upper.contains("INT") && !endsWith(type_name_upper, "SIGNED")
                     && !endsWith(type_name_upper, "UNSIGNED"))
                     data_type_node->name = type_name_upper + " UNSIGNED";
             }
@@ -115,7 +115,7 @@ NamesAndTypesList getColumnsList(const ASTExpressionList * columns_definition)
             /// For example ENUM('a', 'b', 'c') -> ENUM('a'=1, 'b'=2, 'c'=3)
             /// Elements on a position further than 32767 are assigned negative values, starting with -32768.
             /// Note: Enum would be transformed to Enum8 if number of elements is less then 128, otherwise it would be transformed to Enum16.
-            if (type_name_upper.find("ENUM") != String::npos)
+            if (type_name_upper.contains("ENUM"))
             {
                 UInt16 i = 0;
                 for (ASTPtr & child : data_type_node->arguments->children)

--- a/src/Interpreters/MySQL/tests/gtest_create_rewritten.cpp
+++ b/src/Interpreters/MySQL/tests/gtest_create_rewritten.cpp
@@ -62,7 +62,7 @@ TEST(MySQLCreateRewritten, ColumnsDataType)
             MATERIALIZEDMYSQL_TABLE_COLUMNS + ") ENGINE = "
             "ReplacingMergeTree(_version) PARTITION BY intDiv(key, 4294967) ORDER BY tuple(key)");
 
-        if (Poco::toUpper(test_type).find("INT") != std::string::npos)
+        if (Poco::toUpper(test_type).contains("INT"))
         {
             EXPECT_EQ(queryToString(tryRewrittenCreateQuery(
                 "CREATE TABLE `test_database`.`test_table_1`(`key` INT NOT NULL PRIMARY KEY, test " + test_type + " UNSIGNED)", context_holder.context)),

--- a/src/Parsers/Kusto/KustoFunctions/KQLDateTimeFunctions.cpp
+++ b/src/Parsers/Kusto/KustoFunctions/KQLDateTimeFunctions.cpp
@@ -331,7 +331,7 @@ bool FormatDateTime::convertImpl(String & out, IParser::Pos & pos)
             i = i + arg.size();
         }
     }
-    if (decimal > 0 && formatspecifier.find('.') != String::npos)
+    if (decimal > 0 && formatspecifier.contains('.'))
     {
         out = std::format(
             "concat("

--- a/src/Parsers/ParserDataType.cpp
+++ b/src/Parsers/ParserDataType.cpp
@@ -189,7 +189,7 @@ bool ParserDataType::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
         if (ParserKeyword(Keyword::PRECISION).ignore(pos))
             type_name_suffix = toStringView(Keyword::PRECISION);
     }
-    else if (type_name_upper.find("INT") != std::string::npos)
+    else if (type_name_upper.contains("INT"))
     {
         /// Support SIGNED and UNSIGNED integer type modifiers for compatibility with MySQL
         if (ParserKeyword(Keyword::SIGNED).ignore(pos, expected))

--- a/src/Processors/Formats/Impl/CSVRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/CSVRowInputFormat.cpp
@@ -34,7 +34,7 @@ namespace
             return;
         }
         constexpr std::string_view bad_delimiters = " \t\"'.UL";
-        if (bad_delimiters.find(delimiter) != std::string_view::npos)
+        if (bad_delimiters.contains(delimiter))
             throw Exception(
                 ErrorCodes::BAD_ARGUMENTS,
                 "CSV format may not work correctly with delimiter '{}'. Try use CustomSeparated format instead",

--- a/src/Processors/Merges/Algorithms/Graphite.cpp
+++ b/src/Processors/Merges/Algorithms/Graphite.cpp
@@ -93,7 +93,7 @@ inline static const Patterns & selectPatternsForMetricType(const Graphite::Param
     if (params.patterns_typed)
     {
         std::string_view path_view = path;
-        if (path_view.find("?"sv) == std::string::npos)
+        if (!path_view.contains("?"sv))
             return params.patterns_plain;
         return params.patterns_tagged;
     }

--- a/src/Server/HTTPHandlerFactory.h
+++ b/src/Server/HTTPHandlerFactory.h
@@ -90,7 +90,7 @@ public:
     {
         addFilter([](const auto & request)
         {
-            return (request.getURI().find('?') != std::string::npos
+            return (request.getURI().contains('?')
                 && (request.getMethod() == Poco::Net::HTTPRequest::HTTP_GET
                 || request.getMethod() == Poco::Net::HTTPRequest::HTTP_HEAD))
                 || request.getMethod() == Poco::Net::HTTPRequest::HTTP_OPTIONS

--- a/src/Server/HTTPHandlerRequestFilter.h
+++ b/src/Server/HTTPHandlerRequestFilter.h
@@ -78,7 +78,7 @@ static inline auto emptyQueryStringFilter()
     return [](const HTTPServerRequest & request)
     {
         const auto & uri = request.getURI();
-        return std::string::npos == uri.find('?');
+        return !uri.contains('?');
     };
 }
 

--- a/src/Server/PostgreSQLHandler.cpp
+++ b/src/Server/PostgreSQLHandler.cpp
@@ -281,7 +281,7 @@ void PostgreSQLHandler::processQuery()
         }
 
         bool psycopg2_cond = query->query == "BEGIN" || query->query == "COMMIT"; // psycopg2 starts and ends queries with BEGIN/COMMIT commands
-        bool jdbc_cond = query->query.find("SET extra_float_digits") != String::npos || query->query.find("SET application_name") != String::npos; // jdbc starts with setting this parameter
+        bool jdbc_cond = query->query.contains("SET extra_float_digits") || query->query.contains("SET application_name"); // jdbc starts with setting this parameter
         if (psycopg2_cond || jdbc_cond)
         {
             message_transport->send(

--- a/src/Storages/ColumnsDescription.cpp
+++ b/src/Storages/ColumnsDescription.cpp
@@ -970,7 +970,7 @@ std::vector<String> ColumnsDescription::getAllRegisteredNames() const
     names.reserve(columns.size());
     for (const auto & column : columns)
     {
-        if (column.name.find('.') == std::string::npos)
+        if (!column.name.contains('.'))
             names.push_back(column.name);
     }
     return names;

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -6466,7 +6466,7 @@ DetachedPartsInfo MergeTreeData::getDetachedParts() const
 
 void MergeTreeData::validateDetachedPartName(const String & name)
 {
-    if (name.find('/') != std::string::npos || name == "." || name == "..")
+    if (name.contains('/') || name == "." || name == "..")
         throw DB::Exception(ErrorCodes::INCORRECT_FILE_NAME, "Invalid part name '{}'", name);
 
     if (startsWith(name, "attaching_") || startsWith(name, "deleting_"))

--- a/src/Storages/MergeTree/MergeTreeIndexGranularityInfo.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexGranularityInfo.cpp
@@ -69,7 +69,7 @@ MarkType::MarkType(bool adaptive_, bool compressed_, MergeTreeDataPartType::Valu
 
 bool MarkType::isMarkFileExtension(std::string_view extension)
 {
-    return extension.find("mrk") != std::string_view::npos;
+    return extension.contains("mrk");
 }
 
 std::string MarkType::getFileExtension() const

--- a/src/Storages/MergeTree/registerStorageMergeTree.cpp
+++ b/src/Storages/MergeTree/registerStorageMergeTree.cpp
@@ -515,7 +515,7 @@ static StoragePtr create(const StorageFactory::Arguments & args)
         if (zookeeper_info.replica_name.empty())
             throw Exception(ErrorCodes::NO_REPLICA_NAME_GIVEN, "No replica name in config{}", verbose_help_message);
         // '\t' and '\n' will interrupt parsing 'source replica' in ReplicatedMergeTreeLogEntryData::readText
-        if (zookeeper_info.replica_name.find('\t') != String::npos || zookeeper_info.replica_name.find('\n') != String::npos)
+        if (zookeeper_info.replica_name.contains('\t') || zookeeper_info.replica_name.contains('\n'))
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "Replica name must not contain '\\t' or '\\n'");
 
         arg_cnt = engine_args.size(); /// Update `arg_cnt` here because extractZooKeeperPathAndReplicaNameFromEngineArgs() could add arguments.

--- a/src/Storages/PostgreSQL/MaterializedPostgreSQLConsumer.cpp
+++ b/src/Storages/PostgreSQL/MaterializedPostgreSQLConsumer.cpp
@@ -943,7 +943,7 @@ bool MaterializedPostgreSQLConsumer::consume()
         /// https://github.com/postgres/postgres/blob/master/src/backend/replication/pgoutput/pgoutput.c#L1128
         /// So at some point will get out of limit and then they will be cleaned.
         std::string error_message = e.what();
-        if (error_message.find("out of relcache_callback_list slots") == std::string::npos)
+        if (!error_message.contains("out of relcache_callback_list slots"))
             tryLogCurrentException(__PRETTY_FUNCTION__);
 
         connection->tryUpdateConnection();

--- a/src/Storages/StorageFile.cpp
+++ b/src/Storages/StorageFile.cpp
@@ -385,7 +385,7 @@ Strings StorageFile::getPathsList(const String & table_path, const String & user
     String path = fs::absolute(fs_table_path).lexically_normal(); /// Normalize path.
     bool can_be_directory = true;
 
-    if (path.find(PartitionedSink::PARTITION_ID_WILDCARD) != std::string::npos)
+    if (path.contains(PartitionedSink::PARTITION_ID_WILDCARD))
     {
         paths.push_back(path);
     }
@@ -1976,7 +1976,7 @@ SinkToStoragePtr StorageFile::write(
     if (context->getSettingsRef()[Setting::engine_file_truncate_on_insert])
         flags |= O_TRUNC;
 
-    bool has_wildcards = path_for_partitioned_write.find(PartitionedSink::PARTITION_ID_WILDCARD) != String::npos;
+    bool has_wildcards = path_for_partitioned_write.contains(PartitionedSink::PARTITION_ID_WILDCARD);
     const auto * insert_query = dynamic_cast<const ASTInsertQuery *>(query.get());
     bool is_partitioned_implementation = insert_query && insert_query->partition_by && has_wildcards;
 

--- a/src/Storages/StorageURL.cpp
+++ b/src/Storages/StorageURL.cpp
@@ -116,7 +116,7 @@ static const std::vector<std::shared_ptr<re2::RE2>> optional_regex_keys = {
 
 bool urlWithGlobs(const String & uri)
 {
-    return (uri.find('{') != std::string::npos && uri.find('}') != std::string::npos) || uri.find('|') != std::string::npos;
+    return (uri.contains('{') && uri.contains('}')) || uri.contains('|');
 }
 
 String getSampleURI(String uri, ContextPtr context)
@@ -1338,7 +1338,7 @@ SinkToStoragePtr IStorageURLBase::write(const ASTPtr & query, const StorageMetad
     if (http_method.empty())
         http_method = Poco::Net::HTTPRequest::HTTP_POST;
 
-    bool has_wildcards = uri.find(PartitionedSink::PARTITION_ID_WILDCARD) != String::npos;
+    bool has_wildcards = uri.contains(PartitionedSink::PARTITION_ID_WILDCARD);
     const auto * insert_query = dynamic_cast<const ASTInsertQuery *>(query.get());
     auto partition_by_ast = insert_query ? (insert_query->partition_by ? insert_query->partition_by : partition_by) : nullptr;
     bool is_partitioned_implementation = partition_by_ast && has_wildcards;

--- a/src/Storages/System/StorageSystemZooKeeper.cpp
+++ b/src/Storages/System/StorageSystemZooKeeper.cpp
@@ -141,7 +141,7 @@ public:
             String path = block.getByPosition(2).column->getDataAt(i).toString();
 
             /// We don't expect a "name" contains a path.
-            if (name.find('/') != std::string::npos)
+            if (name.contains('/'))
             {
                 throw Exception(ErrorCodes::BAD_ARGUMENTS, "Column `name` should not contain '/'");
             }


### PR DESCRIPTION
This PR originally removed clang-tidy checks `cert-dcl37-c` and `-cert-dcl51-cpp` which are duplicates of `bugprone-reserved-identifier` that was removed in #72360.

I then thought: why not remove `-abseil-*` as well. These checks did not find misuse of abseil in the code base. `abseil-string-find-str-contains` complains about `string::find`, so I converted these to `string::contains`. The suggestion it makes is misleading, so I disabled this specific check.

Finally, Google Test is bumped to the latest HEAD.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)