### PR TITLE
Fix data race in ProfileEvents::Counters::setParent().

### DIFF
--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -959,6 +959,15 @@ Counters::Counters(VariableContext level_, Counters * parent_)
     counters = counters_holder.get();
 }
 
+Counters::Counters(Counters && src) noexcept
+    : counters(std::exchange(src.counters, nullptr))
+    , counters_holder(std::move(src.counters_holder))
+    , parent(src.parent.exchange(nullptr))
+    , trace_profile_events(src.trace_profile_events)
+    , level(src.level)
+{
+}
+
 void Counters::resetCounters()
 {
     if (counters)

--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -970,7 +970,7 @@ void Counters::resetCounters()
 
 void Counters::reset()
 {
-    parent = nullptr;
+    setParent(nullptr);
     resetCounters();
 }
 

--- a/src/Common/ProfileEvents.h
+++ b/src/Common/ProfileEvents.h
@@ -74,6 +74,8 @@ namespace ProfileEvents
         explicit Counters(Counter * allocated_counters) noexcept
             : counters(allocated_counters), parent(nullptr), level(VariableContext::Global) {}
 
+        Counters(Counters && src) noexcept;
+
         Counter & operator[] (Event event)
         {
             return counters[event];

--- a/src/Common/ProfileEvents.h
+++ b/src/Common/ProfileEvents.h
@@ -60,7 +60,7 @@ namespace ProfileEvents
         Counter * counters = nullptr;
         std::unique_ptr<Counter[]> counters_holder;
         /// Used to propagate increments
-        Counters * parent = nullptr;
+        std::atomic<Counters *> parent = {};
         bool trace_profile_events = false;
 
     public:
@@ -114,13 +114,13 @@ namespace ProfileEvents
         /// Get parent (thread unsafe)
         Counters * getParent()
         {
-            return parent;
+            return parent.load(std::memory_order_relaxed);
         }
 
         /// Set parent (thread unsafe)
         void setParent(Counters * parent_)
         {
-            parent = parent_;
+            parent.store(parent_, std::memory_order_relaxed);
         }
 
         void setTraceProfileEvents(bool value)


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix data race in `ProfileEvents::Counters::setParent()`. This PR fixes https://github.com/ClickHouse/ClickHouse/issues/60376
