### PR TITLE
Increase timeout in test_short_disconnection_doesnt_stop_restore

### DIFF
--- a/tests/integration/test_backup_restore_on_cluster/test_cancel_backup.py
+++ b/tests/integration/test_backup_restore_on_cluster/test_cancel_backup.py
@@ -741,7 +741,7 @@ def test_short_disconnection_doesnt_stop_restore():
         restore_id = random_id()
         initiator.query(
             f"RESTORE TABLE tbl ON CLUSTER 'cluster' FROM {get_backup_name(backup_id)} SETTINGS id='{restore_id}' ASYNC",
-            settings={"backup_restore_failure_after_host_disconnected_for_seconds": 6},
+            settings={"backup_restore_failure_after_host_disconnected_for_seconds": 10},
         )
 
         assert get_status(initiator, restore_id=restore_id) == "RESTORING"


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Increase timeout in `test_short_disconnection_doesnt_stop_restore` (see failures: [1](https://s3.amazonaws.com/clickhouse-test-reports/0/22c961c684e32221f32fa18570f12e158f70a039/integration_tests__asan__[2_4].html), [2](https://s3.amazonaws.com/clickhouse-test-reports/0/7c3d015113b0a45b2c75d5244bf12b7099ecbfea/integration_tests__asan__[2_4].html)).
Fixes https://github.com/ClickHouse/ClickHouse/issues/72388