### PR TITLE
Fix possible CI failures due to slow logs proxy tables shutdown

### DIFF
--- a/tests/docker_scripts/stress_tests.lib
+++ b/tests/docker_scripts/stress_tests.lib
@@ -184,6 +184,9 @@ function stop_server()
     # Preserve the pid, since the server can hung after the PID will be deleted.
     pid="$(cat /var/run/clickhouse-server/clickhouse-server.pid)"
 
+    # FIXME: workaround for slow shutdown of Distributed tables (due to sequential tables shutdown)
+    # Refs: https://github.com/ClickHouse/ClickHouse/issues/72557
+    clickhouse client -q "SYSTEM STOP DISTRIBUTED SENDS" ||:
     clickhouse stop --max-tries "$max_tries" --do-not-kill && return
 
     if [ "$check_hang" == true ]


### PR DESCRIPTION
This tables sends data to cloud from system.*_log tables, and flush_on_detach=0 will not help if the send is already in progress.

Let's disable distributed sends as a workaround for now, until the issue will be fixed in a normal way.

CI: https://s3.amazonaws.com/clickhouse-test-reports/71406/9534a35696d8a82182d59ed24e4a604d7d11adcd/stress_test__asan_.html
Refs: https://github.com/ClickHouse/ClickHouse/issues/72557

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)