### PR TITLE
Revert "Exempt refreshable materialized views from ignore_empty_sql_security_in_create_view_query"

### DIFF
--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -1474,7 +1474,7 @@ BlockIO InterpreterCreateQuery::createTable(ASTCreateQuery & create)
     bool is_secondary_query = getContext()->getZooKeeperMetadataTransaction() && !getContext()->getZooKeeperMetadataTransaction()->isInitialQuery();
     auto mode = getLoadingStrictnessLevel(create.attach, /*force_attach*/ false, /*has_force_restore_data_flag*/ false, is_secondary_query || is_restore_from_backup);
 
-    if (!create.sql_security && create.supportSQLSecurity() && (create.refresh_strategy || !getContext()->getServerSettings()[ServerSetting::ignore_empty_sql_security_in_create_view_query]))
+    if (!create.sql_security && create.supportSQLSecurity() && !getContext()->getServerSettings()[ServerSetting::ignore_empty_sql_security_in_create_view_query])
         create.sql_security = std::make_shared<ASTSQLSecurity>();
 
     if (create.sql_security)

--- a/tests/queries/0_stateless/02932_refreshable_materialized_views_1.reference
+++ b/tests/queries/0_stateless/02932_refreshable_materialized_views_1.reference
@@ -1,14 +1,14 @@
 <1: created view>		a
-CREATE MATERIALIZED VIEW default.a\nREFRESH EVERY 2 SECOND\n(\n    `x` UInt64\n)\nENGINE = Memory\nDEFINER = default SQL SECURITY DEFINER\nAS SELECT number AS x\nFROM numbers(2)\nUNION ALL\nSELECT rand64() AS x
+CREATE MATERIALIZED VIEW default.a\nREFRESH EVERY 2 SECOND\n(\n    `x` UInt64\n)\nENGINE = Memory\nAS SELECT number AS x\nFROM numbers(2)\nUNION ALL\nSELECT rand64() AS x
 <2: refreshed>	3	1	1
 <3: time difference at least>	1000
 <4.1: fake clock>	Scheduled	2050-01-01 00:00:01	2050-01-01 00:00:02	1	3	3	3	0
 <4.5: altered>	Scheduled	2050-01-01 00:00:01	2052-01-01 00:00:00
-CREATE MATERIALIZED VIEW default.a\nREFRESH EVERY 2 YEAR\n(\n    `x` UInt64\n)\nENGINE = Memory\nDEFINER = default SQL SECURITY DEFINER\nAS SELECT x * 2 AS x\nFROM default.src
+CREATE MATERIALIZED VIEW default.a\nREFRESH EVERY 2 YEAR\n(\n    `x` UInt64\n)\nENGINE = Memory\nAS SELECT x * 2 AS x\nFROM default.src
 <5: no refresh>	3
 <6: refreshed>	2
 <7: refreshed>	Scheduled	2052-02-03 04:05:06	2054-01-01 00:00:00
-CREATE MATERIALIZED VIEW default.b\nREFRESH EVERY 2 YEAR DEPENDS ON default.a\n(\n    `y` Int32\n)\nENGINE = MergeTree\nORDER BY y\nSETTINGS index_granularity = 8192\nDEFINER = default SQL SECURITY DEFINER\nAS SELECT x * 10 AS y\nFROM default.a
+CREATE MATERIALIZED VIEW default.b\nREFRESH EVERY 2 YEAR DEPENDS ON default.a\n(\n    `y` Int32\n)\nENGINE = MergeTree\nORDER BY y\nSETTINGS index_granularity = 8192\nAS SELECT x * 10 AS y\nFROM default.a
 <7.5: created dependent>	2052-11-11 11:11:11
 <8: refreshed>	20
 <9: refreshed>	a	Scheduled	2054-01-01 00:00:00
@@ -26,4 +26,4 @@ CREATE MATERIALIZED VIEW default.b\nREFRESH EVERY 2 YEAR DEPENDS ON default.a\n(
 <17: chain-refreshed>	a	Scheduled	2062-01-01 00:00:00
 <17: chain-refreshed>	b	Scheduled	2062-01-01 00:00:00
 <18: removed dependency>	b	Scheduled	2062-03-03 03:03:03	2062-03-03 03:03:03	2064-01-01 00:00:00
-CREATE MATERIALIZED VIEW default.b\nREFRESH EVERY 2 YEAR\n(\n    `y` Int32\n)\nENGINE = MergeTree\nORDER BY y\nSETTINGS index_granularity = 8192\nDEFINER = default SQL SECURITY DEFINER\nAS SELECT x * 10 AS y\nFROM default.a
+CREATE MATERIALIZED VIEW default.b\nREFRESH EVERY 2 YEAR\n(\n    `y` Int32\n)\nENGINE = MergeTree\nORDER BY y\nSETTINGS index_granularity = 8192\nAS SELECT x * 10 AS y\nFROM default.a

--- a/tests/queries/0_stateless/02932_refreshable_materialized_views_2.reference
+++ b/tests/queries/0_stateless/02932_refreshable_materialized_views_2.reference
@@ -7,9 +7,9 @@
 <25: rename during refresh>	f	Running
 <27: cancelled>	f	Scheduled	cancelled
 <28: drop during refresh>	0	0
-CREATE MATERIALIZED VIEW default.g\nREFRESH EVERY 1 WEEK OFFSET 3 DAY 4 HOUR RANDOMIZE FOR 4 DAY 1 HOUR\n(\n    `x` Int64\n)\nENGINE = Memory\nDEFINER = default SQL SECURITY DEFINER\nAS SELECT 42 AS x
+CREATE MATERIALIZED VIEW default.g\nREFRESH EVERY 1 WEEK OFFSET 3 DAY 4 HOUR RANDOMIZE FOR 4 DAY 1 HOUR\n(\n    `x` Int64\n)\nENGINE = Memory\nAS SELECT 42 AS x
 <29: randomize>	1	1
-CREATE MATERIALIZED VIEW default.h\nREFRESH EVERY 1 SECOND TO default.dest\n(\n    `x` Int64\n)\nDEFINER = default SQL SECURITY DEFINER\nAS SELECT x * 10 AS x\nFROM default.src
+CREATE MATERIALIZED VIEW default.h\nREFRESH EVERY 1 SECOND TO default.dest\n(\n    `x` Int64\n)\nAS SELECT x * 10 AS x\nFROM default.src
 <30: to existing table>	10
 <31: to existing table>	10
 <31: to existing table>	20


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Revert https://github.com/ClickHouse/ClickHouse/pull/71336 , I didn't understand why. @fm4v , is there more information about it written up somewhere?