### PR TITLE
Make max_bytes_before_external_sort limit depends on total query memory consumption

### DIFF
--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -2407,6 +2407,9 @@ What to do when the limit is exceeded.
     DECLARE(UInt64, prefer_external_sort_block_bytes, DEFAULT_BLOCK_SIZE * 256, R"(
 Prefer maximum block bytes for external sort, reduce the memory usage during merging.
 )", 0) \
+    DECLARE(UInt64, min_external_sort_block_bytes, "100Mi", R"(
+Minimal block size in bytes for external sort that will be dumped to disk, to avoid too many files.
+)", 0) \
     DECLARE(UInt64, max_bytes_before_external_sort, 0, R"(
 If memory usage during ORDER BY operation is exceeding this threshold in bytes, activate the 'external sorting' mode (spill data to disk). Recommended value is half of the available system memory.
 )", 0) \

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -97,6 +97,7 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
             {"allow_general_join_planning", false, true, "Allow more general join planning algorithm when hash join algorithm is enabled."},
             {"optimize_extract_common_expressions", false, false, "Introduce setting to optimize WHERE, PREWHERE, ON, HAVING and QUALIFY expressions by extracting common expressions out from disjunction of conjunctions."},
             {"max_bytes_ratio_before_external_sort", 0., 0., "New setting."},
+            {"min_external_sort_block_bytes", 0., 100_MiB, "New setting."},
             {"use_async_executor_for_materialized_views", false, false, "New setting."},
             {"http_response_headers", "", "", "New setting."},
             {"output_format_parquet_datetime_as_uint32", true, false, "Write DateTime as DateTime64(3) instead of UInt32 (these are the two Parquet types closest to DateTime)."},

--- a/src/Interpreters/MergeJoin.cpp
+++ b/src/Interpreters/MergeJoin.cpp
@@ -611,6 +611,7 @@ void MergeJoin::mergeInMemoryRightBlocks()
         /*increase_sort_description_compile_attempts=*/false,
         /*max_bytes_before_remerge_*/0,
         /*remerge_lowered_memory_bytes_ratio_*/0,
+        /*min_external_sort_block_bytes_*/0,
         /*max_bytes_before_external_sort_*/0,
         /*tmp_data_*/nullptr,
         /*min_free_disk_space_*/0));

--- a/src/Processors/QueryPlan/SortingStep.cpp
+++ b/src/Processors/QueryPlan/SortingStep.cpp
@@ -31,6 +31,7 @@ namespace DB
 namespace Setting
 {
     extern const SettingsUInt64 max_block_size;
+    extern const SettingsUInt64 min_external_sort_block_bytes;
     extern const SettingsUInt64 max_bytes_before_external_sort;
     extern const SettingsDouble max_bytes_ratio_before_external_sort;
     extern const SettingsUInt64 max_bytes_before_remerge_sort;
@@ -107,6 +108,7 @@ SortingStep::Settings::Settings(const Context & context)
     max_bytes_before_remerge = settings[Setting::max_bytes_before_remerge_sort];
     remerge_lowered_memory_bytes_ratio = settings[Setting::remerge_sort_lowered_memory_bytes_ratio];
     max_bytes_before_external_sort = getMaxBytesBeforeExternalSort(settings[Setting::max_bytes_before_external_sort], settings[Setting::max_bytes_ratio_before_external_sort]);
+    min_external_sort_block_bytes = settings[Setting::min_external_sort_block_bytes];
     tmp_data = context.getTempDataOnDisk();
     min_free_disk_space = settings[Setting::min_free_disk_space_for_temporary_data];
     max_block_bytes = settings[Setting::prefer_external_sort_block_bytes];
@@ -379,7 +381,8 @@ void SortingStep::mergeSorting(
                 increase_sort_description_compile_attempts_current,
                 sort_settings.max_bytes_before_remerge / pipeline.getNumStreams(),
                 sort_settings.remerge_lowered_memory_bytes_ratio,
-                sort_settings.max_bytes_before_external_sort,
+                sort_settings.min_external_sort_block_bytes,
+                sort_settings.max_bytes_before_external_sort / pipeline.getNumStreams(),
                 std::move(tmp_data_on_disk),
                 sort_settings.min_free_disk_space);
         });

--- a/src/Processors/QueryPlan/SortingStep.h
+++ b/src/Processors/QueryPlan/SortingStep.h
@@ -24,6 +24,7 @@ public:
         SizeLimits size_limits;
         size_t max_bytes_before_remerge = 0;
         float remerge_lowered_memory_bytes_ratio = 0;
+        size_t min_external_sort_block_bytes = 0;
         size_t max_bytes_before_external_sort = 0;
         TemporaryDataOnDiskScopePtr tmp_data = nullptr;
         size_t min_free_disk_space = 0;

--- a/src/Processors/Transforms/MergeSortingTransform.h
+++ b/src/Processors/Transforms/MergeSortingTransform.h
@@ -28,6 +28,7 @@ public:
         bool increase_sort_description_compile_attempts,
         size_t max_bytes_before_remerge_,
         double remerge_lowered_memory_bytes_ratio_,
+        size_t min_external_sort_block_bytes_,
         size_t max_bytes_before_external_sort_,
         TemporaryDataOnDiskScopePtr tmp_data_,
         size_t min_free_disk_space_);
@@ -44,6 +45,7 @@ protected:
 private:
     size_t max_bytes_before_remerge;
     double remerge_lowered_memory_bytes_ratio;
+    size_t min_external_sort_block_bytes;
     size_t max_bytes_before_external_sort;
     TemporaryDataOnDiskScopePtr tmp_data;
     size_t temporary_files_num = 0;

--- a/tests/queries/0_stateless/00110_external_sort.reference
+++ b/tests/queries/0_stateless/00110_external_sort.reference
@@ -1,3 +1,5 @@
+-- { echoOn }
+SELECT number FROM (SELECT number FROM system.numbers LIMIT 10000000) ORDER BY number * 1234567890123456789 LIMIT 9999990, 10 SETTINGS max_memory_usage='300Mi', max_bytes_before_external_sort='20M', min_external_sort_block_bytes='70M';
 7040546
 4327029
 1613512
@@ -8,7 +10,18 @@
 8140551
 5427034
 2713517
--
+SELECT number FROM (SELECT number FROM system.numbers LIMIT 10000000) ORDER BY number * 1234567890123456789 LIMIT 9999990, 10 SETTINGS max_memory_usage='300Mi', max_bytes_before_external_sort='10M', min_external_sort_block_bytes='10M';
+7040546
+4327029
+1613512
+8947307
+6233790
+3520273
+806756
+8140551
+5427034
+2713517
+SELECT number FROM (SELECT number FROM numbers(2097152)) ORDER BY number * 1234567890123456789 LIMIT 2097142, 10 SETTINGS max_memory_usage='300Mi', max_bytes_before_external_sort=33554432, max_block_size=1048576, min_external_sort_block_bytes='10Mi';
 440516
 1540521
 733765
@@ -19,3 +32,11 @@
 513507
 1613512
 806756
+-- This query is heavy, let's do it only once
+SYSTEM FLUSH LOGS;
+SELECT ProfileEvents['ExternalSortWritePart'] FROM system.query_log WHERE type != 'QueryStart' AND current_database = currentDatabase() AND Settings['max_bytes_before_external_sort']='20000000';
+2
+SELECT if((ProfileEvents['ExternalSortWritePart'] as x) > 10, 10, x) FROM system.query_log WHERE type != 'QueryStart' AND current_database = currentDatabase() AND Settings['max_bytes_before_external_sort']='10000000';
+10
+SELECT ProfileEvents['ExternalSortWritePart'] FROM system.query_log WHERE type != 'QueryStart' AND current_database = currentDatabase() AND Settings['max_bytes_before_external_sort']='33554432';
+1

--- a/tests/queries/0_stateless/00110_external_sort.sql
+++ b/tests/queries/0_stateless/00110_external_sort.sql
@@ -1,13 +1,14 @@
--- Tags: no-parallel, no-fasttest
+-- Tags: no-parallel, no-fasttest, no-flaky-check
 
-SET max_memory_usage = 300000000;
-SET max_bytes_before_external_sort = 20000000;
 SET max_bytes_ratio_before_external_sort = 0;
-SELECT number FROM (SELECT number FROM system.numbers LIMIT 10000000) ORDER BY number * 1234567890123456789 LIMIT 9999990, 10;
 
-SELECT '-';
+-- { echoOn }
+SELECT number FROM (SELECT number FROM system.numbers LIMIT 10000000) ORDER BY number * 1234567890123456789 LIMIT 9999990, 10 SETTINGS max_memory_usage='300Mi', max_bytes_before_external_sort='20M', min_external_sort_block_bytes='70M';
+SELECT number FROM (SELECT number FROM system.numbers LIMIT 10000000) ORDER BY number * 1234567890123456789 LIMIT 9999990, 10 SETTINGS max_memory_usage='300Mi', max_bytes_before_external_sort='10M', min_external_sort_block_bytes='10M';
+SELECT number FROM (SELECT number FROM numbers(2097152)) ORDER BY number * 1234567890123456789 LIMIT 2097142, 10 SETTINGS max_memory_usage='300Mi', max_bytes_before_external_sort=33554432, max_block_size=1048576, min_external_sort_block_bytes='10Mi';
 
-SET max_bytes_before_external_sort = 33554432;
-SET max_bytes_ratio_before_external_sort = 0;
-SET max_block_size = 1048576;
-SELECT number FROM (SELECT number FROM numbers(2097152)) ORDER BY number * 1234567890123456789 LIMIT 2097142, 10;
+-- This query is heavy, let's do it only once
+SYSTEM FLUSH LOGS;
+SELECT ProfileEvents['ExternalSortWritePart'] FROM system.query_log WHERE type != 'QueryStart' AND current_database = currentDatabase() AND Settings['max_bytes_before_external_sort']='20000000';
+SELECT if((ProfileEvents['ExternalSortWritePart'] as x) > 10, 10, x) FROM system.query_log WHERE type != 'QueryStart' AND current_database = currentDatabase() AND Settings['max_bytes_before_external_sort']='10000000';
+SELECT ProfileEvents['ExternalSortWritePart'] FROM system.query_log WHERE type != 'QueryStart' AND current_database = currentDatabase() AND Settings['max_bytes_before_external_sort']='33554432';

--- a/tests/queries/0_stateless/02402_external_disk_mertrics.sql
+++ b/tests/queries/0_stateless/02402_external_disk_mertrics.sql
@@ -2,7 +2,8 @@
 
 SET max_bytes_before_external_sort = 33554432;
 SET max_bytes_ratio_before_external_sort = 0;
-set max_block_size = 1048576;
+SET min_external_sort_block_bytes = '10Mi';
+SET max_block_size = 1048576;
 
 SELECT number FROM (SELECT number FROM numbers(2097152)) ORDER BY number * 1234567890123456789 LIMIT 2097142, 10
 SETTINGS log_comment='02402_external_disk_mertrics/sort'


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Make max_bytes_before_external_sort limit depends on total query memory consumption (previously it was number of bytes in the sorting block for one sorting thread, now it has the same meaning as `max_bytes_before_external_group_by` - it is total limit for the whole query memory for all threads). Also one more setting added to control on disk block size - `min_external_sort_block_bytes`

Make max_bytes_before_external_sort more user-friendly, previously it
was number of bytes in the sorting block for one sorting thread, now it
has the same meaning as max_bytes_before_external_group_by - it is total
limit for the whole query memory for all threads.

Also one more setting added to control on disk block size -
min_external_sort_block_bytes

But, after this change the files on disk can be very small (few
kilobytes) and to avoid this, I've added separate setting to control
on-disk block size - min_external_sort_block_bytes, to avoid too many
files.

Note, that max_bytes_ratio_before_external_sort already based on the
memory consumption not the sorting block size (added in #71406)

_P.S. maybe it will be better to mark it as `Backward Incompatible Change` to highlight this change in changelogs_