### PR TITLE
Add metrics to trace memory usage for each processor

### DIFF
--- a/src/Common/MemoryTracker.h
+++ b/src/Common/MemoryTracker.h
@@ -56,6 +56,8 @@ private:
     std::atomic<Int64> soft_limit {0};
     std::atomic<Int64> hard_limit {0};
     std::atomic<Int64> profiler_limit {0};
+    std::atomic<Int64> alloc_bytes {0};
+    std::atomic<Int64> free_bytes {0};
 
     std::atomic<Int64> rss{0};
 
@@ -118,6 +120,16 @@ public:
     Int64 get() const
     {
         return amount.load(std::memory_order_relaxed);
+    }
+
+    Int64 getAllocBytes() const
+    {
+        return alloc_bytes.load(std::memory_order_relaxed);
+    }
+
+    Int64 getFreeBytes() const
+    {
+        return free_bytes.load(std::memory_order_relaxed);
     }
 
     Int64 getRSS() const

--- a/src/Processors/Executors/ExecutionThreadContext.cpp
+++ b/src/Processors/Executors/ExecutionThreadContext.cpp
@@ -46,7 +46,19 @@ static void executeJob(ExecutingGraph::Node * node, ReadProgressCallback * read_
 {
     try
     {
+#ifndef NDEBUG
+        auto * thread_memory_tracker = CurrentThread::getMemoryTracker();
+        auto * thread_parent_memory_tracker = thread_memory_tracker->getParent();
+        auto & processor_memory_tracker = node->processor->getMemoryTracker();
+        processor_memory_tracker.setParent(thread_parent_memory_tracker);
+        thread_memory_tracker->setParent(&processor_memory_tracker);
+#endif
         node->processor->work();
+
+#ifndef NDEBUG
+        thread_memory_tracker->setParent(thread_parent_memory_tracker);
+        processor_memory_tracker.setParent(nullptr);
+#endif
 
         /// Update read progress only for source nodes.
         bool is_source = node->back_edges.empty();

--- a/src/Processors/Executors/PipelineExecutor.cpp
+++ b/src/Processors/Executors/PipelineExecutor.cpp
@@ -450,14 +450,21 @@ String PipelineExecutor::dumpPipeline() const
     {
         {
             WriteBufferFromOwnString buffer;
-            buffer << "(" << node->num_executed_jobs << " jobs";
-
+            buffer << "\njobs:" << node->num_executed_jobs << "\\l";
 #ifndef NDEBUG
-            buffer << ", execution time: " << node->execution_time_ns / 1e9 << " sec.";
-            buffer << ", preparation time: " << node->preparation_time_ns / 1e9 << " sec.";
+            buffer << "execution time: " << node->execution_time_ns / 1e9 << " sec.\\l";
+            buffer << "preparation time: " << node->preparation_time_ns / 1e9 << " sec.\\l";
+            auto processor_stats = node->processor->getProcessorDataStats();
+            buffer << "input bytes: " << processor_stats.input_bytes << "\\l";
+            buffer << "input rows: " << processor_stats.input_rows << "\\l";
+            buffer << "output bytes: " << processor_stats.output_bytes << "\\l";
+            buffer << "output rows: " << processor_stats.output_rows << "\\l";
+            buffer << "input allocated_bytes: " << processor_stats.input_allocated_bytes << "\\l";
+            buffer << "alloc bytes: " << processor_stats.alloc_bytes << "\\l";
+            buffer << "output allocated bytes: " << processor_stats.output_allocated_bytes << "\\l";
+            buffer << "free bytes: " << processor_stats.free_bytes << "\\l";
 #endif
 
-            buffer << ")";
             node->processor->setDescription(buffer.str());
         }
     }

--- a/src/Processors/IProcessor.h
+++ b/src/Processors/IProcessor.h
@@ -325,8 +325,12 @@ public:
     {
         size_t input_rows = 0;
         size_t input_bytes = 0;
+        size_t input_allocated_bytes = 0;
         size_t output_rows = 0;
         size_t output_bytes = 0;
+        size_t output_allocated_bytes = 0;
+        Int64 alloc_bytes = 0;
+        Int64 free_bytes = 0;
     };
 
     ProcessorDataStats getProcessorDataStats() const
@@ -337,13 +341,17 @@ public:
         {
             stats.input_rows += input.rows;
             stats.input_bytes += input.bytes;
+            stats.input_allocated_bytes += input.allocated_bytes;
         }
 
         for (const auto & output : outputs)
         {
             stats.output_rows += output.rows;
             stats.output_bytes += output.bytes;
+            stats.output_allocated_bytes += output.allocated_bytes;
         }
+        stats.alloc_bytes = processor_memory_tracker.getAllocBytes();
+        stats.free_bytes = processor_memory_tracker.getFreeBytes();
 
         return stats;
     }
@@ -380,6 +388,8 @@ public:
     /// This counter is used to calculate the number of rows right before AggregatingTransform.
     virtual void setRowsBeforeAggregationCounter(RowsBeforeStepCounterPtr /* counter */) { }
 
+    MemoryTracker & getMemoryTracker() { return processor_memory_tracker; }
+
 protected:
     virtual void onCancel() noexcept {}
 
@@ -412,6 +422,8 @@ private:
     size_t processor_index = 0;
     String plan_step_name;
     String plan_step_description;
+
+    MemoryTracker processor_memory_tracker;
 };
 
 

--- a/src/Processors/Port.h
+++ b/src/Processors/Port.h
@@ -258,6 +258,7 @@ protected:
     /// For processors_profile_log
     size_t rows = 0;
     size_t bytes = 0;
+    size_t allocated_bytes = 0;
 };
 
 /// Invariants:
@@ -306,6 +307,7 @@ public:
 
         rows += data->chunk.getNumRows();
         bytes += data->chunk.bytes();
+        allocated_bytes += data->chunk.allocatedBytes();
 
         return std::move(*data);
     }
@@ -432,6 +434,7 @@ public:
 
         rows += data->chunk.getNumRows();
         bytes += data->chunk.bytes();
+        allocated_bytes += data->chunk.allocatedBytes();
 
         state->push(data, flags);
     }


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- New Feature



### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Each processor has its own memory tracker.

During `prepare` and `work`, the parent of current thread's memory tracker is switched to the processor's memory tracker. These metrics are helpful to analysis the memory used by each processor when we are troubled by OOM.


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---ci_include_fuzzer--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
