### PR TITLE
Disable random settings for `SYSTEM LOAD PRIMARY KEY` test

### DIFF
--- a/tests/queries/0_stateless/03202_system_load_primary_key.sql
+++ b/tests/queries/0_stateless/03202_system_load_primary_key.sql
@@ -1,4 +1,4 @@
--- Tags: no-parallel
+-- Tags: no-parallel, no-random-settings
 DROP TABLE IF EXISTS test;
 DROP TABLE IF EXISTS test2;
 


### PR DESCRIPTION
https://github.com/ClickHouse/ClickHouse/pull/67733/files/98ccca99f2e25883c9f18d5711ce5c61a2432ecd#r1862762961

We can't reliably run the `SYSTEM LOAD PARTITION KEY` test with random settings because `use_primary_key_cache` might be chosen, changing the expected behavior. Thus, let's disable them.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)