### PR TITLE
Throw INVALID_GRANT for GRANT SELECT/INSERT on wildcards at column level

### DIFF
--- a/src/Access/Common/AccessRightsElement.cpp
+++ b/src/Access/Common/AccessRightsElement.cpp
@@ -237,7 +237,14 @@ void AccessRightsElement::throwIfNotGrantable() const
         return;
     auto grantable_flags = getGrantableFlags();
     if (grantable_flags)
+    {
+        if (!anyColumn() && (anyTable() || anyDatabase()))
+        {
+            // Specifying specific columns with a wildcard for a database/table is grammatically valid, but not logically valid
+            throw Exception(ErrorCodes::INVALID_GRANT, "{} on wildcards cannot be granted on the column level", access_flags.toString());
+        }
         return;
+    }
 
     if (!anyColumn())
         throw Exception(ErrorCodes::INVALID_GRANT, "{} cannot be granted on the column level", access_flags.toString());

--- a/tests/queries/0_stateless/01073_grant_and_revoke.sql
+++ b/tests/queries/0_stateless/01073_grant_and_revoke.sql
@@ -17,6 +17,9 @@ GRANT SELECT(col1) ON db3.table TO test_user_01073;
 GRANT SELECT(col1, col2) ON db4.table TO test_user_01073;
 GRANT INSERT ON *.* TO test_user_01073;
 GRANT DELETE ON *.* TO test_user_01073;
+GRANT SELECT(col1) ON *.* TO test_user_01073; -- { clientError 509 }
+GRANT SELECT(col1) ON db1.* TO test_user_01073; -- { clientError 509 }
+GRANT INSERT(col1, col2) ON db1.* TO test_user_01073; -- { clientError 509 }
 SHOW GRANTS FOR test_user_01073;
 
 SELECT 'D';


### PR DESCRIPTION
The columns were previously just ignored, resulting in overly permissive grants. Disallow such grants instead. Also affects the CHECK GRANT statement, but doesn't affect the REVOKE statement.

Fixes https://github.com/ClickHouse/ClickHouse/issues/72645. I'm not sure if this is the best approach; maybe there's a better way. This fix is probably the easiest though.

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Column-level GRANT SELECT/INSERT statements on wildcard databases/tables now throw an error.

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---ci_include_fuzzer--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
