### PR TITLE
Add setting max_backup_bandwidth to backup/restore query

### DIFF
--- a/docs/en/operations/backup.md
+++ b/docs/en/operations/backup.md
@@ -90,6 +90,7 @@ The BACKUP and RESTORE statements take a list of DATABASE and TABLE names, a des
     - `storage_policy`: storage policy for the tables being restored. See [Using Multiple Block Devices for Data Storage](../engines/table-engines/mergetree-family/mergetree.md#table_engine-mergetree-multiple-volumes). This setting is only applicable to the `RESTORE` command. The specified storage policy applies only to tables with an engine from the `MergeTree` family.
     - `s3_storage_class`: the storage class used for S3 backup. For example, `STANDARD`
     - `azure_attempt_to_create_container`: when using Azure Blob Storage, whether the specified container will try to be created if it doesn't exist. Default: true.
+    - `max_backup_bandwidth`: the maximum read speed in bytes per second for a backup. Zero means unlimited.
 
 ### Usage examples
 

--- a/src/Backups/BackupSettings.cpp
+++ b/src/Backups/BackupSettings.cpp
@@ -7,6 +7,7 @@
 #include <Parsers/ASTLiteral.h>
 #include <IO/ReadHelpers.h>
 #include <Backups/SettingsFieldOptionalUUID.h>
+#include <Backups/SettingsFieldOptionalUInt64.h>
 
 namespace DB
 {
@@ -40,7 +41,8 @@ namespace ErrorCodes
     M(Bool, write_access_entities_dependents) \
     M(Bool, internal) \
     M(String, host_id) \
-    M(OptionalUUID, backup_uuid)
+    M(OptionalUUID, backup_uuid) \
+    M(OptionalUInt64, max_backup_bandwidth)
     /// M(Int64, compression_level)
 
 BackupSettings BackupSettings::fromBackupQuery(const ASTBackupQuery & query)

--- a/src/Backups/BackupSettings.h
+++ b/src/Backups/BackupSettings.h
@@ -98,6 +98,9 @@ struct BackupSettings
     /// UUID of the backup. If it's not set it will be generated randomly.
     std::optional<UUID> backup_uuid;
 
+    /// The maximum read speed in bytes per second for a backup. Zero means unlimited.
+    std::optional<UInt64> max_backup_bandwidth;
+
     static BackupSettings fromBackupQuery(const ASTBackupQuery & query);
     void copySettingsToQuery(ASTBackupQuery & query) const;
 

--- a/src/Backups/RestoreSettings.cpp
+++ b/src/Backups/RestoreSettings.cpp
@@ -9,6 +9,7 @@
 #include <Common/FieldVisitorConvertToNumber.h>
 #include <Backups/SettingsFieldOptionalUUID.h>
 #include <Backups/SettingsFieldOptionalString.h>
+#include <Backups/SettingsFieldOptionalUInt64.h>
 
 
 namespace DB
@@ -170,7 +171,8 @@ namespace
     M(Bool, internal) \
     M(String, host_id) \
     M(OptionalString, storage_policy) \
-    M(OptionalUUID, restore_uuid)
+    M(OptionalUUID, restore_uuid) \
+    M(OptionalUInt64, max_backup_bandwidth)
 
 
 RestoreSettings RestoreSettings::fromRestoreQuery(const ASTBackupQuery & query)

--- a/src/Backups/RestoreSettings.h
+++ b/src/Backups/RestoreSettings.h
@@ -155,6 +155,9 @@ struct RestoreSettings
     /// This is used to generate coordination path and for concurrency check
     std::optional<UUID> restore_uuid;
 
+    /// The maximum read speed in bytes per second for a backup. Zero means unlimited.
+    std::optional<UInt64> max_backup_bandwidth;
+
     static RestoreSettings fromRestoreQuery(const ASTBackupQuery & query);
     void copySettingsToQuery(ASTBackupQuery & query) const;
 };

--- a/src/Backups/SettingsFieldOptionalUInt64.cpp
+++ b/src/Backups/SettingsFieldOptionalUInt64.cpp
@@ -1,0 +1,40 @@
+#include <Backups/SettingsFieldOptionalUInt64.h>
+#include <Common/ErrorCodes.h>
+#include <DataTypes/DataTypesNumber.h>
+#include <Interpreters/convertFieldToType.h>
+
+namespace DB
+{
+
+namespace ErrorCodes
+{
+    extern const int CANNOT_PARSE_BACKUP_SETTINGS;
+}
+
+SettingFieldOptionalUInt64::SettingFieldOptionalUInt64(const Field & field)
+{
+    if (field.getType() == Field::Types::Null)
+    {
+        value = std::nullopt;
+        return;
+    }
+
+    if (field.getType() == Field::Types::UInt64)
+    {
+        value = field.safeGet<UInt64>();
+        return;
+    }
+
+    // 1eN is interpreted as Float64
+    if (field.getType() == Field::Types::Float64)
+    {
+        auto converted = convertFieldToType(field.safeGet<Float64>(), DataTypeUInt64());
+
+        value = converted.safeGet<UInt64>();
+        return;
+    }
+
+    throw Exception(ErrorCodes::CANNOT_PARSE_BACKUP_SETTINGS, "Cannot get UInt64 from {}", field);
+}
+
+}

--- a/src/Backups/SettingsFieldOptionalUInt64.h
+++ b/src/Backups/SettingsFieldOptionalUInt64.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <optional>
+#include <Core/SettingsFields.h>
+
+namespace DB
+{
+
+struct SettingFieldOptionalUInt64
+{
+    std::optional<UInt64> value;
+
+    explicit SettingFieldOptionalUInt64(const std::optional<UInt64> & value_) : value(value_) {}
+
+    explicit SettingFieldOptionalUInt64(const Field & field);
+
+    explicit operator Field() const { return Field(value ? toString(*value) : ""); }
+};
+
+}

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -3655,11 +3655,14 @@ ThrottlerPtr Context::getLocalWriteThrottler() const
     return throttler;
 }
 
-ThrottlerPtr Context::getBackupsThrottler() const
+ThrottlerPtr Context::getBackupsThrottler(std::optional<UInt64> max_backup_bandwidth) const
 {
     ThrottlerPtr throttler = shared->backups_server_throttler;
-    if (auto bandwidth = getSettingsRef()[Setting::max_backup_bandwidth])
+    if (max_backup_bandwidth.has_value() || getSettingsRef()[Setting::max_backup_bandwidth])
     {
+        // Query setting takes precedence
+        auto bandwidth = max_backup_bandwidth.value_or(getSettingsRef()[Setting::max_backup_bandwidth]);
+
         std::lock_guard lock(mutex);
         if (!backups_query_throttler)
             backups_query_throttler = std::make_shared<Throttler>(bandwidth, throttler);

--- a/src/Interpreters/Context.h
+++ b/src/Interpreters/Context.h
@@ -1463,7 +1463,7 @@ public:
     ThrottlerPtr getLocalReadThrottler() const;
     ThrottlerPtr getLocalWriteThrottler() const;
 
-    ThrottlerPtr getBackupsThrottler() const;
+    ThrottlerPtr getBackupsThrottler(std::optional<UInt64> max_backup_bandwidth) const;
 
     ThrottlerPtr getMutationsThrottler() const;
     ThrottlerPtr getMergesThrottler() const;

--- a/tests/queries/0_stateless/02704_max_backup_bandwidth.sh
+++ b/tests/queries/0_stateless/02704_max_backup_bandwidth.sh
@@ -14,7 +14,7 @@ $CLICKHOUSE_CLIENT -m -q "
 $CLICKHOUSE_CLIENT -q "insert into data select * from numbers(1e6)"
 
 query_id=$(random_str 10)
-$CLICKHOUSE_CLIENT --query_id "$query_id" -q "backup table data to Disk('backups', '$CLICKHOUSE_DATABASE/data/backup1')" --max_backup_bandwidth=1M > /dev/null
+$CLICKHOUSE_CLIENT --query_id "$query_id" -q "backup table data to Disk('backups', '$CLICKHOUSE_DATABASE/data/backup1') SETTINGS max_backup_bandwidth=1e6" > /dev/null
 $CLICKHOUSE_CLIENT -m -q "
     SYSTEM FLUSH LOGS;
     SELECT


### PR DESCRIPTION
At the moment, `max_backup_bandwidth` cannot be set directly in the `BACKUP`/`RESTORE` query, it has to be set for the session, e.g., via `SET max_backup_bandwidth=N`, `clickhouse-client --max_backup_bandwidth=N` or URL parameter.

This PR allows specifying it with `BACKUP|RESTORE ... SETTINGS max_backup_bandwidth=` making it more straightforward to use.

There is a bit of a quirk where `max_backup_bandwidth` also applies to `RESTORE`. It might be more logical to have a setting `max_restore_bandwidth`. But since the setting applies to both `BACKUP` and `RESTORE` commands today when set for the session I've also added it as a query setting for both.

I thought of adding a brand new test but it felt like overkill given it would just be copying an existing test and specifying the setting differently. So I modified an existing test, hope that's ok.

### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Adds setting `max_backup_bandwidth` to the list of settings that can be specified as part of `BACKUP`/`RESTORE` queries.