### PR TITLE
parallel replicas update cluster's errors_count

### DIFF
--- a/src/Client/ConnectionPoolWithFailover.h
+++ b/src/Client/ConnectionPoolWithFailover.h
@@ -105,6 +105,11 @@ public:
         Base::updateSharedErrorCounts(shuffled_pools);
     }
 
+    void incrementErrorCount(ConnectionPoolPtr pool)
+    {
+        Base::incrementErrorCount(pool);
+    }
+
     size_t getPoolSize() const { return Base::getPoolSize(); }
 
 private:

--- a/src/Interpreters/ClusterProxy/executeQuery.cpp
+++ b/src/Interpreters/ClusterProxy/executeQuery.cpp
@@ -653,7 +653,8 @@ void executeQueryWithParallelReplicas(
             getLogger("ReadFromParallelRemoteReplicasStep"),
             std::move(storage_limits),
             std::move(pools_to_use),
-            local_replica_index);
+            local_replica_index,
+            shard.pool);
 
         auto remote_plan = std::make_unique<QueryPlan>();
         remote_plan->addStep(std::move(read_from_remote));
@@ -688,7 +689,9 @@ void executeQueryWithParallelReplicas(
             std::move(external_tables),
             getLogger("ReadFromParallelRemoteReplicasStep"),
             std::move(storage_limits),
-            std::move(pools_to_use));
+            std::move(pools_to_use),
+            std::nullopt,
+            shard.pool);
 
         query_plan.addStep(std::move(read_from_remote));
     }

--- a/src/Processors/QueryPlan/ReadFromRemote.cpp
+++ b/src/Processors/QueryPlan/ReadFromRemote.cpp
@@ -378,7 +378,8 @@ ReadFromParallelRemoteReplicasStep::ReadFromParallelRemoteReplicasStep(
     LoggerPtr log_,
     std::shared_ptr<const StorageLimitsList> storage_limits_,
     std::vector<ConnectionPoolPtr> pools_to_use_,
-    std::optional<size_t> exclude_pool_index_)
+    std::optional<size_t> exclude_pool_index_,
+    ConnectionPoolWithFailoverPtr connection_pool_with_failover_)
     : ISourceStep(std::move(header_))
     , cluster(cluster_)
     , query_ast(query_ast_)
@@ -393,6 +394,7 @@ ReadFromParallelRemoteReplicasStep::ReadFromParallelRemoteReplicasStep(
     , log(log_)
     , pools_to_use(std::move(pools_to_use_))
     , exclude_pool_index(exclude_pool_index_)
+    , connection_pool_with_failover(connection_pool_with_failover_)
 {
     chassert(cluster->getShardCount() == 1);
 
@@ -487,7 +489,8 @@ void ReadFromParallelRemoteReplicasStep::addPipeForSingeReplica(
         scalars,
         external_tables,
         stage,
-        RemoteQueryExecutor::Extension{.parallel_reading_coordinator = coordinator, .replica_info = std::move(replica_info)});
+        RemoteQueryExecutor::Extension{.parallel_reading_coordinator = coordinator, .replica_info = std::move(replica_info)},
+        connection_pool_with_failover);
 
     remote_query_executor->setLogger(log);
     remote_query_executor->setMainTable(storage_id);

--- a/src/Processors/QueryPlan/ReadFromRemote.h
+++ b/src/Processors/QueryPlan/ReadFromRemote.h
@@ -80,7 +80,8 @@ public:
         LoggerPtr log_,
         std::shared_ptr<const StorageLimitsList> storage_limits_,
         std::vector<ConnectionPoolPtr> pools_to_use,
-        std::optional<size_t> exclude_pool_index_ = std::nullopt);
+        std::optional<size_t> exclude_pool_index_ = std::nullopt,
+        ConnectionPoolWithFailoverPtr connection_pool_with_failover_ = nullptr);
 
     String getName() const override { return "ReadFromRemoteParallelReplicas"; }
 
@@ -105,6 +106,7 @@ private:
     LoggerPtr log;
     std::vector<ConnectionPoolPtr> pools_to_use;
     std::optional<size_t> exclude_pool_index;
+    ConnectionPoolWithFailoverPtr connection_pool_with_failover;
 };
 
 }

--- a/src/QueryPipeline/RemoteQueryExecutor.h
+++ b/src/QueryPipeline/RemoteQueryExecutor.h
@@ -61,7 +61,8 @@ public:
         const Scalars & scalars_ = Scalars(),
         const Tables & external_tables_ = Tables(),
         QueryProcessingStage::Enum stage_ = QueryProcessingStage::Complete,
-        std::optional<Extension> extension_ = std::nullopt);
+        std::optional<Extension> extension_ = std::nullopt,
+        ConnectionPoolWithFailoverPtr connection_pool_with_failover_ = nullptr);
 
     /// Takes already set connection.
     RemoteQueryExecutor(
@@ -343,9 +344,6 @@ private:
 
     /// Process packet for read and return data block if possible.
     ReadResult processPacket(Packet packet);
-
-    /// Reads packet by packet
-    Block readPackets();
 };
 
 }

--- a/tests/integration/test_parallel_replicas_increase_error_count/configs/remote_servers.xml
+++ b/tests/integration/test_parallel_replicas_increase_error_count/configs/remote_servers.xml
@@ -1,0 +1,22 @@
+<clickhouse>
+    <remote_servers>
+        <test_1_shard_3_replicas>
+            <shard>
+                <internal_replication>true</internal_replication>
+                <replica>
+                    <host>node1</host>
+                    <port>9000</port>
+                </replica>
+                <replica>
+                    <host>node2</host>
+                    <port>9000</port>
+                </replica>
+                <replica>
+                    <host>node3</host>
+                    <port>9000</port>
+                </replica>
+            </shard>
+        </test_1_shard_3_replicas>
+    </remote_servers>
+</clickhouse>
+

--- a/tests/integration/test_parallel_replicas_increase_error_count/test.py
+++ b/tests/integration/test_parallel_replicas_increase_error_count/test.py
@@ -1,0 +1,81 @@
+import uuid
+
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__)
+
+node1 = cluster.add_instance(
+    "node1", main_configs=["configs/remote_servers.xml"], with_zookeeper=True
+)
+node2 = cluster.add_instance(
+    "node2", main_configs=["configs/remote_servers.xml"], with_zookeeper=True
+)
+
+
+@pytest.fixture(scope="module")
+def start_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def create_tables(cluster, table_name):
+    node1.query(
+        f"CREATE TABLE {table_name} (key Int64, value String) Engine=ReplicatedMergeTree('/test_parallel_replicas/shard1/{table_name}', 'r1') ORDER BY (key)"
+    )
+    node2.query(
+        f"CREATE TABLE {table_name} (key Int64, value String) Engine=ReplicatedMergeTree('/test_parallel_replicas/shard1/{table_name}', 'r2') ORDER BY (key)"
+    )
+
+    # populate data
+    node1.query(
+        f"INSERT INTO {table_name} SELECT number % 4, number FROM numbers(1000)"
+    )
+    node1.query(
+        f"INSERT INTO {table_name} SELECT number % 4, number FROM numbers(1000, 1000)"
+    )
+    node1.query(
+        f"INSERT INTO {table_name} SELECT number % 4, number FROM numbers(2000, 1000)"
+    )
+    node1.query(
+        f"INSERT INTO {table_name} SELECT number % 4, number FROM numbers(3000, 1000)"
+    )
+    node2.query(f"SYSTEM SYNC REPLICA {table_name}")
+
+
+def test_increase_error_count(start_cluster):
+    cluster_name = "test_1_shard_3_replicas"
+    table_name = "tt"
+    create_tables(cluster_name, table_name)
+
+    expected_result = ""
+    for i in range(4):
+        expected_result += f"{i}\t1000\n"
+
+    assert (
+        node1.query(
+            f"SELECT key, count() FROM {table_name} GROUP BY key ORDER BY key",
+            settings={
+                "enable_parallel_replicas": 2,
+                "max_parallel_replicas": 3,
+                "cluster_for_parallel_replicas": cluster_name,
+            },
+        )
+        == expected_result
+    )
+
+    assert (
+        int(
+            node1.query(
+                f"SELECT errors_count FROM system.clusters WHERE cluster = 'test_1_shard_3_replicas' AND host_name = 'node3'"
+            ).strip()
+        )
+        > 0
+    )
+
+    node1.query(f"DROP TABLE {table_name} SYNC")
+    node2.query(f"DROP TABLE {table_name} SYNC")


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Parallel replicas used historical information about replica availability to improve replica selection but did not update the replica's error count when the connection was unavailable. This PR updates the replica's error count when unavailable.
