### PR TITLE
Add total_bytes_with_inactive to system.tables

### DIFF
--- a/src/Storages/IStorage.h
+++ b/src/Storages/IStorage.h
@@ -718,6 +718,15 @@ public:
     /// Does not take underlying Storage (if any) into account
     virtual std::optional<UInt64> totalBytesUncompressed(const Settings &) const { return {}; }
 
+    /// If it is possible to quickly determine exact number of bytes for the table on storage:
+    /// - disk (compressed)
+    ///
+    /// Used for:
+    /// - For total_bytes_with_inactive column in system.tables
+    //
+    /// Does not takes underlying Storage (if any) into account
+    virtual std::optional<UInt64> totalBytesWithInactive(const Settings &) const { return {}; }
+
     /// Number of rows INSERTed since server start.
     ///
     /// Does not take the underlying Storage (if any) into account.

--- a/src/Storages/StorageMergeTree.cpp
+++ b/src/Storages/StorageMergeTree.cpp
@@ -317,6 +317,16 @@ std::optional<UInt64> StorageMergeTree::totalBytesUncompressed(const Settings &)
     return res;
 }
 
+std::optional<UInt64> StorageMergeTree::totalBytesWithInactive(const Settings &) const
+{
+    UInt64 res = 0;
+    auto outdated_parts = getDataPartsVectorForInternalUsage({DataPartState::Outdated});
+    for (const auto & part : outdated_parts)
+        res += part->getBytesOnDisk();
+    return res;
+}
+
+
 SinkToStoragePtr
 StorageMergeTree::write(const ASTPtr & /*query*/, const StorageMetadataPtr & metadata_snapshot, ContextPtr local_context, bool /*async_insert*/)
 {

--- a/src/Storages/StorageMergeTree.h
+++ b/src/Storages/StorageMergeTree.h
@@ -68,6 +68,7 @@ public:
     std::optional<UInt64> totalRowsByPartitionPredicate(const ActionsDAG & filter_actions_dag, ContextPtr) const override;
     std::optional<UInt64> totalBytes(const Settings &) const override;
     std::optional<UInt64> totalBytesUncompressed(const Settings &) const override;
+    std::optional<UInt64> totalBytesWithInactive(const Settings &) const override;
 
     SinkToStoragePtr write(const ASTPtr & query, const StorageMetadataPtr & /*metadata_snapshot*/, ContextPtr context, bool async_insert) override;
 

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -5711,6 +5711,15 @@ std::optional<UInt64> StorageReplicatedMergeTree::totalBytesUncompressed(const S
     return res;
 }
 
+std::optional<UInt64> StorageReplicatedMergeTree::totalBytesWithInactive(const Settings &) const
+{
+    UInt64 res = 0;
+    auto outdated_parts = getDataPartsStateRange(DataPartState::Outdated);
+    for (const auto & part : outdated_parts)
+        res += part->getBytesOnDisk();
+    return res;
+}
+
 void StorageReplicatedMergeTree::assertNotReadonly() const
 {
     if (is_readonly)

--- a/src/Storages/StorageReplicatedMergeTree.h
+++ b/src/Storages/StorageReplicatedMergeTree.h
@@ -162,6 +162,7 @@ public:
     std::optional<UInt64> totalRowsByPartitionPredicate(const ActionsDAG & filter_actions_dag, ContextPtr context) const override;
     std::optional<UInt64> totalBytes(const Settings & settings) const override;
     std::optional<UInt64> totalBytesUncompressed(const Settings & settings) const override;
+    std::optional<UInt64> totalBytesWithInactive(const Settings & settings) const override;
 
     SinkToStoragePtr write(const ASTPtr & query, const StorageMetadataPtr & /*metadata_snapshot*/, ContextPtr context, bool async_insert) override;
 

--- a/src/Storages/System/StorageSystemTables.cpp
+++ b/src/Storages/System/StorageSystemTables.cpp
@@ -179,6 +179,10 @@ StorageSystemTables::StorageSystemTables(const StorageID & table_id_)
             "Total number of uncompressed bytes, if it's possible to quickly determine the exact number "
             "of bytes from the part checksums for the table on storage, otherwise NULL (does not take underlying storage (if any) into account)."
         },
+        {"total_bytes_with_inactive", std::make_shared<DataTypeNullable>(std::make_shared<DataTypeUInt64>()),
+         "Total number of bytes with inactive parts, if it is possible to quickly determine exact number "
+         "of bytes for the table on storage, otherwise NULL (does not includes any underlying storage). "
+        },
         {"parts", std::make_shared<DataTypeNullable>(std::make_shared<DataTypeUInt64>()), "The total number of parts in this table."},
         {"active_parts", std::make_shared<DataTypeNullable>(std::make_shared<DataTypeUInt64>()), "The number of active parts in this table."},
         {"total_marks", std::make_shared<DataTypeNullable>(std::make_shared<DataTypeUInt64>()), "The total number of marks in all parts in this table."},
@@ -593,6 +597,15 @@ protected:
                     auto total_bytes_uncompressed = table->totalBytesUncompressed(settings);
                     if (total_bytes_uncompressed)
                         res_columns[res_index++]->insert(*total_bytes_uncompressed);
+                    else
+                        res_columns[res_index++]->insertDefault();
+                }
+
+                if (columns_mask[src_index++])
+                {
+                    auto total_bytes_with_inactive = table->totalBytesWithInactive(settings);
+                    if (total_bytes_with_inactive)
+                        res_columns[res_index++]->insert(*total_bytes_with_inactive);
                     else
                         res_columns[res_index++]->insertDefault();
                 }

--- a/tests/integration/test_analyzer_compatibility/test.py
+++ b/tests/integration/test_analyzer_compatibility/test.py
@@ -43,7 +43,7 @@ def test_two_new_versions(start_cluster):
 
     query_id = str(uuid.uuid4())
     current.query(
-        "SELECT * FROM clusterAllReplicas('test_cluster_mixed', system.tables);",
+        "SELECT name FROM clusterAllReplicas('test_cluster_mixed', system.tables);",
         query_id=query_id,
     )
 
@@ -73,7 +73,7 @@ WHERE initial_query_id = '{query_id}';"""
 
     query_id = str(uuid.uuid4())
     backward.query(
-        "SELECT * FROM clusterAllReplicas('test_cluster_mixed', system.tables)",
+        "SELECT name FROM clusterAllReplicas('test_cluster_mixed', system.tables)",
         query_id=query_id,
     )
 
@@ -108,7 +108,7 @@ WHERE initial_query_id = '{query_id}';"""
     # to the remote server.
     query_id = str(uuid.uuid4())
     current.query(
-        "SELECT * FROM clusterAllReplicas('test_cluster_mixed', system.tables) SETTINGS enable_analyzer = 1;",
+        "SELECT name FROM clusterAllReplicas('test_cluster_mixed', system.tables) SETTINGS enable_analyzer = 1;",
         query_id=query_id,
     )
 

--- a/tests/queries/0_stateless/00753_system_columns_and_system_tables_long.reference
+++ b/tests/queries/0_stateless/00753_system_columns_and_system_tables_long.reference
@@ -1,12 +1,13 @@
-┌─name────────────────┬─partition_key─┬─sorting_key─┬─primary_key─┬─sampling_key─┬─storage_policy─┬─total_rows─┐
-│ check_system_tables │ name2         │ name1       │ name1       │ name1        │ default        │          0 │
-└─────────────────────┴───────────────┴─────────────┴─────────────┴──────────────┴────────────────┴────────────┘
+┌─name────────────────┬─partition_key─┬─sorting_key─┬─primary_key─┬─sampling_key─┬─storage_policy─┬─total_rows─┬─total_bytes_with_inactive─┐
+│ check_system_tables │ name2         │ name1       │ name1       │ name1        │ default        │          0 │                         0 │
+└─────────────────────┴───────────────┴─────────────┴─────────────┴──────────────┴────────────────┴────────────┴───────────────────────────┘
 ┌─name──┬─is_in_partition_key─┬─is_in_sorting_key─┬─is_in_primary_key─┬─is_in_sampling_key─┐
 │ name1 │                   0 │                 1 │                 1 │                  1 │
 │ name2 │                   1 │                 0 │                 0 │                  0 │
 │ name3 │                   0 │                 0 │                 0 │                  0 │
 └───────┴─────────────────────┴───────────────────┴───────────────────┴────────────────────┘
-3	231	1
+1	1	3	231	1	0
+3	1	6	234	2	462
 ┌─name────────────────┬─partition_key─┬─sorting_key───┬─primary_key─┬─sampling_key─┐
 │ check_system_tables │ date          │ date, version │ date        │              │
 └─────────────────────┴───────────────┴───────────────┴─────────────┴──────────────┘

--- a/tests/queries/0_stateless/00753_system_columns_and_system_tables_long.sql
+++ b/tests/queries/0_stateless/00753_system_columns_and_system_tables_long.sql
@@ -15,7 +15,7 @@ CREATE TABLE check_system_tables
     SAMPLE BY name1
     SETTINGS min_bytes_for_wide_part = 0, compress_marks = false, compress_primary_key = false, ratio_of_defaults_for_sparse_serialization = 1;
 
-SELECT name, partition_key, sorting_key, primary_key, sampling_key, storage_policy, total_rows
+SELECT name, partition_key, sorting_key, primary_key, sampling_key, storage_policy, total_rows, total_bytes_with_inactive
 FROM system.tables WHERE name = 'check_system_tables' AND database = currentDatabase()
 FORMAT PrettyCompactNoEscapes;
 
@@ -24,7 +24,12 @@ FROM system.columns WHERE table = 'check_system_tables' AND database = currentDa
 FORMAT PrettyCompactNoEscapes;
 
 INSERT INTO check_system_tables VALUES (1, 1, 1);
-SELECT total_bytes_uncompressed, total_bytes, total_rows FROM system.tables WHERE name = 'check_system_tables' AND database = currentDatabase();
+SELECT parts, active_parts, total_bytes_uncompressed, total_bytes, total_rows, total_bytes_with_inactive FROM system.tables WHERE name = 'check_system_tables' AND database = currentDatabase();
+
+INSERT INTO check_system_tables VALUES (2, 1, 3);
+OPTIMIZE TABLE check_system_tables;
+SELECT parts, active_parts, total_bytes_uncompressed, total_bytes, total_rows, total_bytes_with_inactive FROM system.tables WHERE name = 'check_system_tables' AND database = currentDatabase();
+
 
 DROP TABLE IF EXISTS check_system_tables;
 

--- a/tests/queries/0_stateless/02117_show_create_table_system.reference
+++ b/tests/queries/0_stateless/02117_show_create_table_system.reference
@@ -1113,6 +1113,7 @@ CREATE TABLE system.tables
     `total_rows` Nullable(UInt64),
     `total_bytes` Nullable(UInt64),
     `total_bytes_uncompressed` Nullable(UInt64),
+    `total_bytes_with_inactive` Nullable(UInt64),
     `parts` Nullable(UInt64),
     `active_parts` Nullable(UInt64),
     `total_marks` Nullable(UInt64),


### PR DESCRIPTION

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement



### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add total_bytes_with_inactive to system.tables to count the total bytes of inactive parts.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---ci_include_fuzzer--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
