### PR TITLE
Remove ostr from structure IAST::FormatSettings.

### DIFF
--- a/programs/format/Format.cpp
+++ b/programs/format/Format.cpp
@@ -277,10 +277,10 @@ int mainEntryClickHouseFormat(int argc, char ** argv)
                     {
                         WriteBufferFromOwnString str_buf;
                         bool oneline_current_query = oneline || approx_query_length < max_line_length;
-                        IAST::FormatSettings settings(str_buf, oneline_current_query, hilite);
+                        IAST::FormatSettings settings(oneline_current_query, hilite);
                         settings.show_secrets = true;
                         settings.print_pretty_type_names = !oneline_current_query;
-                        res->format(settings);
+                        res->format(str_buf, settings);
 
                         if (insert_query_payload)
                         {
@@ -324,10 +324,10 @@ int mainEntryClickHouseFormat(int argc, char ** argv)
                     {
                         WriteBufferFromOwnString str_buf;
                         bool oneline_current_query = oneline || approx_query_length < max_line_length;
-                        IAST::FormatSettings settings(str_buf, oneline_current_query, hilite);
+                        IAST::FormatSettings settings(oneline_current_query, hilite);
                         settings.show_secrets = true;
                         settings.print_pretty_type_names = !oneline_current_query;
-                        res->format(settings);
+                        res->format(str_buf, settings);
 
                         auto res_string = str_buf.str();
                         WriteBufferFromOStream res_cout(std::cout, 4096);

--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -348,11 +348,11 @@ ASTPtr ClientBase::parseQuery(const char *& pos, const char * end, const Setting
     {
         output_stream << std::endl;
         WriteBufferFromOStream res_buf(output_stream, 4096);
-        IAST::FormatSettings format_settings(res_buf, /* one_line */ false);
+        IAST::FormatSettings format_settings(/* one_line */ false);
         format_settings.hilite = true;
         format_settings.show_secrets = true;
         format_settings.print_pretty_type_names = true;
-        res->format(format_settings);
+        res->format(res_buf, format_settings);
         res_buf.finalize();
         output_stream << std::endl << std::endl;
     }

--- a/src/Functions/formatQuery.cpp
+++ b/src/Functions/formatQuery.cpp
@@ -143,10 +143,10 @@ private:
                 throw;
             }
 
-            IAST::FormatSettings settings(buf, output_formatting == OutputFormatting::SingleLine, /*hilite*/ false);
+            IAST::FormatSettings settings(output_formatting == OutputFormatting::SingleLine, /*hilite*/ false);
             settings.show_secrets = true;
             settings.print_pretty_type_names = print_pretty_type_names;
-            ast->format(settings);
+            ast->format(buf, settings);
 
             auto formatted = buf.stringView();
 

--- a/src/Interpreters/InterpreterExplainQuery.cpp
+++ b/src/Interpreters/InterpreterExplainQuery.cpp
@@ -392,7 +392,7 @@ QueryPipeline InterpreterExplainQuery::executeImpl()
             ExplainAnalyzedSyntaxVisitor::Data data(getContext());
             ExplainAnalyzedSyntaxVisitor(data).visit(query);
 
-            ast.getExplainedQuery()->format(IAST::FormatSettings(buf, settings.oneline));
+            ast.getExplainedQuery()->format(buf, IAST::FormatSettings(settings.oneline));
             break;
         }
         case ASTExplainQuery::QueryTree:
@@ -441,7 +441,7 @@ QueryPipeline InterpreterExplainQuery::executeImpl()
                 if (need_newline)
                     buf << "\n\n";
 
-                query_tree->toAST()->format(IAST::FormatSettings(buf, false));
+                query_tree->toAST()->format(buf, IAST::FormatSettings(false));
             }
 
             break;

--- a/src/Interpreters/SystemLog.cpp
+++ b/src/Interpreters/SystemLog.cpp
@@ -88,7 +88,7 @@ namespace
             throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Method clone is not supported");
         }
 
-        void formatImpl(const FormatSettings &, FormatState &, FormatStateStacked) const override
+        void formatImpl(WriteBuffer &, const FormatSettings &, FormatState &, FormatStateStacked) const override
         {
             throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Method formatImpl is not supported");
         }

--- a/src/Interpreters/executeQuery.cpp
+++ b/src/Interpreters/executeQuery.cpp
@@ -1041,9 +1041,9 @@ static std::tuple<ASTPtr, BlockIO> executeQueryImpl(
         if (settings[Setting::enforce_strict_identifier_format])
         {
             WriteBufferFromOwnString buf;
-            IAST::FormatSettings enforce_strict_identifier_format_settings(buf, true);
+            IAST::FormatSettings enforce_strict_identifier_format_settings(true);
             enforce_strict_identifier_format_settings.enforce_strict_identifier_format = true;
-            ast->format(enforce_strict_identifier_format_settings);
+            ast->format(buf, enforce_strict_identifier_format_settings);
         }
 
         if (auto * insert_query = ast->as<ASTInsertQuery>())

--- a/src/Parsers/ASTAlterNamedCollectionQuery.cpp
+++ b/src/Parsers/ASTAlterNamedCollectionQuery.cpp
@@ -12,46 +12,46 @@ ASTPtr ASTAlterNamedCollectionQuery::clone() const
     return std::make_shared<ASTAlterNamedCollectionQuery>(*this);
 }
 
-void ASTAlterNamedCollectionQuery::formatImpl(const IAST::FormatSettings & settings, IAST::FormatState &, IAST::FormatStateStacked) const
+void ASTAlterNamedCollectionQuery::formatImpl(WriteBuffer & ostr, const IAST::FormatSettings & settings, IAST::FormatState &, IAST::FormatStateStacked) const
 {
-    settings.ostr << (settings.hilite ? hilite_keyword : "") << "ALTER NAMED COLLECTION ";
+    ostr << (settings.hilite ? hilite_keyword : "") << "ALTER NAMED COLLECTION ";
     if (if_exists)
-        settings.ostr << "IF EXISTS ";
-    settings.ostr << (settings.hilite ? hilite_identifier : "") << backQuoteIfNeed(collection_name) << (settings.hilite ? hilite_none : "");
-    formatOnCluster(settings);
+        ostr << "IF EXISTS ";
+    ostr << (settings.hilite ? hilite_identifier : "") << backQuoteIfNeed(collection_name) << (settings.hilite ? hilite_none : "");
+    formatOnCluster(ostr, settings);
     if (!changes.empty())
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << " SET " << (settings.hilite ? hilite_none : "");
+        ostr << (settings.hilite ? hilite_keyword : "") << " SET " << (settings.hilite ? hilite_none : "");
         bool first = true;
         for (const auto & change : changes)
         {
             if (!first)
-                settings.ostr << ", ";
+                ostr << ", ";
             else
                 first = false;
 
-            formatSettingName(change.name, settings.ostr);
+            formatSettingName(change.name, ostr);
             if (settings.show_secrets)
-                settings.ostr << " = " << applyVisitor(FieldVisitorToString(), change.value);
+                ostr << " = " << applyVisitor(FieldVisitorToString(), change.value);
             else
-                settings.ostr << " = '[HIDDEN]'";
+                ostr << " = '[HIDDEN]'";
             auto override_value = overridability.find(change.name);
             if (override_value != overridability.end())
-                settings.ostr << " " << (override_value->second ? "" : "NOT ") << "OVERRIDABLE";
+                ostr << " " << (override_value->second ? "" : "NOT ") << "OVERRIDABLE";
         }
     }
     if (!delete_keys.empty())
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << " DELETE " << (settings.hilite ? hilite_none : "");
+        ostr << (settings.hilite ? hilite_keyword : "") << " DELETE " << (settings.hilite ? hilite_none : "");
         bool first = true;
         for (const auto & key : delete_keys)
         {
             if (!first)
-                settings.ostr << ", ";
+                ostr << ", ";
             else
                 first = false;
 
-            formatSettingName(key, settings.ostr);
+            formatSettingName(key, ostr);
         }
     }
 }

--- a/src/Parsers/ASTAlterNamedCollectionQuery.h
+++ b/src/Parsers/ASTAlterNamedCollectionQuery.h
@@ -21,7 +21,7 @@ public:
 
     ASTPtr clone() const override;
 
-    void formatImpl(const FormatSettings & s, FormatState & state, FormatStateStacked frame) const override;
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & s, FormatState & state, FormatStateStacked frame) const override;
 
     ASTPtr getRewrittenASTWithoutOnCluster(const WithoutOnClusterASTRewriteParams &) const override { return removeOnCluster<ASTAlterNamedCollectionQuery>(clone()); }
 

--- a/src/Parsers/ASTAlterQuery.cpp
+++ b/src/Parsers/ASTAlterQuery.cpp
@@ -68,270 +68,270 @@ ASTPtr ASTAlterCommand::clone() const
     return res;
 }
 
-void ASTAlterCommand::formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
+void ASTAlterCommand::formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
 {
     scope_guard closing_bracket_guard;
     if (format_alter_commands_with_parentheses)
     {
-        settings.ostr << "(";
-        closing_bracket_guard = make_scope_guard(std::function<void(void)>([&settings]() { settings.ostr << ")"; }));
+        ostr << "(";
+        closing_bracket_guard = make_scope_guard(std::function<void(void)>([&ostr]() { ostr << ")"; }));
     }
 
     if (type == ASTAlterCommand::ADD_COLUMN)
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << "ADD COLUMN " << (if_not_exists ? "IF NOT EXISTS " : "")
+        ostr << (settings.hilite ? hilite_keyword : "") << "ADD COLUMN " << (if_not_exists ? "IF NOT EXISTS " : "")
                       << (settings.hilite ? hilite_none : "");
-        col_decl->formatImpl(settings, state, frame);
+        col_decl->formatImpl(ostr, settings, state, frame);
 
         if (first)
-            settings.ostr << (settings.hilite ? hilite_keyword : "") << " FIRST " << (settings.hilite ? hilite_none : "");
+            ostr << (settings.hilite ? hilite_keyword : "") << " FIRST " << (settings.hilite ? hilite_none : "");
         else if (column) /// AFTER
         {
-            settings.ostr << (settings.hilite ? hilite_keyword : "") << " AFTER " << (settings.hilite ? hilite_none : "");
-            column->formatImpl(settings, state, frame);
+            ostr << (settings.hilite ? hilite_keyword : "") << " AFTER " << (settings.hilite ? hilite_none : "");
+            column->formatImpl(ostr, settings, state, frame);
         }
     }
     else if (type == ASTAlterCommand::DROP_COLUMN)
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << (clear_column ? "CLEAR " : "DROP ") << "COLUMN "
+        ostr << (settings.hilite ? hilite_keyword : "") << (clear_column ? "CLEAR " : "DROP ") << "COLUMN "
                       << (if_exists ? "IF EXISTS " : "") << (settings.hilite ? hilite_none : "");
-        column->formatImpl(settings, state, frame);
+        column->formatImpl(ostr, settings, state, frame);
         if (partition)
         {
-            settings.ostr << (settings.hilite ? hilite_keyword : "") << " IN PARTITION " << (settings.hilite ? hilite_none : "");
-            partition->formatImpl(settings, state, frame);
+            ostr << (settings.hilite ? hilite_keyword : "") << " IN PARTITION " << (settings.hilite ? hilite_none : "");
+            partition->formatImpl(ostr, settings, state, frame);
         }
     }
     else if (type == ASTAlterCommand::MODIFY_COLUMN)
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << "MODIFY COLUMN " << (if_exists ? "IF EXISTS " : "")
+        ostr << (settings.hilite ? hilite_keyword : "") << "MODIFY COLUMN " << (if_exists ? "IF EXISTS " : "")
                       << (settings.hilite ? hilite_none : "");
-        col_decl->formatImpl(settings, state, frame);
+        col_decl->formatImpl(ostr, settings, state, frame);
 
         if (!remove_property.empty())
         {
-            settings.ostr << (settings.hilite ? hilite_keyword : "") << " REMOVE " << remove_property;
+            ostr << (settings.hilite ? hilite_keyword : "") << " REMOVE " << remove_property;
         }
         else if (settings_changes)
         {
-            settings.ostr << (settings.hilite ? hilite_keyword : "") << " MODIFY SETTING " << (settings.hilite ? hilite_none : "");
-            settings_changes->formatImpl(settings, state, frame);
+            ostr << (settings.hilite ? hilite_keyword : "") << " MODIFY SETTING " << (settings.hilite ? hilite_none : "");
+            settings_changes->formatImpl(ostr, settings, state, frame);
         }
         else if (settings_resets)
         {
-            settings.ostr << (settings.hilite ? hilite_keyword : "") << " RESET SETTING " << (settings.hilite ? hilite_none : "");
-            settings_resets->formatImpl(settings, state, frame);
+            ostr << (settings.hilite ? hilite_keyword : "") << " RESET SETTING " << (settings.hilite ? hilite_none : "");
+            settings_resets->formatImpl(ostr, settings, state, frame);
         }
         else
         {
             if (first)
-                settings.ostr << (settings.hilite ? hilite_keyword : "") << " FIRST " << (settings.hilite ? hilite_none : "");
+                ostr << (settings.hilite ? hilite_keyword : "") << " FIRST " << (settings.hilite ? hilite_none : "");
             else if (column) /// AFTER
             {
-                settings.ostr << (settings.hilite ? hilite_keyword : "") << " AFTER " << (settings.hilite ? hilite_none : "");
-                column->formatImpl(settings, state, frame);
+                ostr << (settings.hilite ? hilite_keyword : "") << " AFTER " << (settings.hilite ? hilite_none : "");
+                column->formatImpl(ostr, settings, state, frame);
             }
         }
     }
     else if (type == ASTAlterCommand::MATERIALIZE_COLUMN)
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << "MATERIALIZE COLUMN " << (settings.hilite ? hilite_none : "");
-        column->formatImpl(settings, state, frame);
+        ostr << (settings.hilite ? hilite_keyword : "") << "MATERIALIZE COLUMN " << (settings.hilite ? hilite_none : "");
+        column->formatImpl(ostr, settings, state, frame);
         if (partition)
         {
-            settings.ostr << (settings.hilite ? hilite_keyword : "") << " IN PARTITION " << (settings.hilite ? hilite_none : "");
-            partition->formatImpl(settings, state, frame);
+            ostr << (settings.hilite ? hilite_keyword : "") << " IN PARTITION " << (settings.hilite ? hilite_none : "");
+            partition->formatImpl(ostr, settings, state, frame);
         }
     }
     else if (type == ASTAlterCommand::COMMENT_COLUMN)
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << "COMMENT COLUMN " << (if_exists ? "IF EXISTS " : "")
+        ostr << (settings.hilite ? hilite_keyword : "") << "COMMENT COLUMN " << (if_exists ? "IF EXISTS " : "")
                       << (settings.hilite ? hilite_none : "");
-        column->formatImpl(settings, state, frame);
-        settings.ostr << " " << (settings.hilite ? hilite_none : "");
-        comment->formatImpl(settings, state, frame);
+        column->formatImpl(ostr, settings, state, frame);
+        ostr << " " << (settings.hilite ? hilite_none : "");
+        comment->formatImpl(ostr, settings, state, frame);
     }
     else if (type == ASTAlterCommand::MODIFY_COMMENT)
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << "MODIFY COMMENT" << (settings.hilite ? hilite_none : "");
-        settings.ostr << " " << (settings.hilite ? hilite_none : "");
-        comment->formatImpl(settings, state, frame);
+        ostr << (settings.hilite ? hilite_keyword : "") << "MODIFY COMMENT" << (settings.hilite ? hilite_none : "");
+        ostr << " " << (settings.hilite ? hilite_none : "");
+        comment->formatImpl(ostr, settings, state, frame);
     }
     else if (type == ASTAlterCommand::MODIFY_ORDER_BY)
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << "MODIFY ORDER BY " << (settings.hilite ? hilite_none : "");
-        order_by->formatImpl(settings, state, frame);
+        ostr << (settings.hilite ? hilite_keyword : "") << "MODIFY ORDER BY " << (settings.hilite ? hilite_none : "");
+        order_by->formatImpl(ostr, settings, state, frame);
     }
     else if (type == ASTAlterCommand::MODIFY_SAMPLE_BY)
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << "MODIFY SAMPLE BY " << (settings.hilite ? hilite_none : "");
-        sample_by->formatImpl(settings, state, frame);
+        ostr << (settings.hilite ? hilite_keyword : "") << "MODIFY SAMPLE BY " << (settings.hilite ? hilite_none : "");
+        sample_by->formatImpl(ostr, settings, state, frame);
     }
     else if (type == ASTAlterCommand::REMOVE_SAMPLE_BY)
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << "REMOVE SAMPLE BY" << (settings.hilite ? hilite_none : "");
+        ostr << (settings.hilite ? hilite_keyword : "") << "REMOVE SAMPLE BY" << (settings.hilite ? hilite_none : "");
     }
     else if (type == ASTAlterCommand::ADD_INDEX)
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << "ADD INDEX " << (if_not_exists ? "IF NOT EXISTS " : "")
+        ostr << (settings.hilite ? hilite_keyword : "") << "ADD INDEX " << (if_not_exists ? "IF NOT EXISTS " : "")
                       << (settings.hilite ? hilite_none : "");
-        index_decl->formatImpl(settings, state, frame);
+        index_decl->formatImpl(ostr, settings, state, frame);
 
         if (first)
-            settings.ostr << (settings.hilite ? hilite_keyword : "") << " FIRST " << (settings.hilite ? hilite_none : "");
+            ostr << (settings.hilite ? hilite_keyword : "") << " FIRST " << (settings.hilite ? hilite_none : "");
         else if (index) /// AFTER
         {
-            settings.ostr << (settings.hilite ? hilite_keyword : "") << " AFTER " << (settings.hilite ? hilite_none : "");
-            index->formatImpl(settings, state, frame);
+            ostr << (settings.hilite ? hilite_keyword : "") << " AFTER " << (settings.hilite ? hilite_none : "");
+            index->formatImpl(ostr, settings, state, frame);
         }
     }
     else if (type == ASTAlterCommand::DROP_INDEX)
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << (clear_index ? "CLEAR " : "DROP ") << "INDEX "
+        ostr << (settings.hilite ? hilite_keyword : "") << (clear_index ? "CLEAR " : "DROP ") << "INDEX "
                       << (if_exists ? "IF EXISTS " : "") << (settings.hilite ? hilite_none : "");
-        index->formatImpl(settings, state, frame);
+        index->formatImpl(ostr, settings, state, frame);
         if (partition)
         {
-            settings.ostr << (settings.hilite ? hilite_keyword : "") << " IN PARTITION " << (settings.hilite ? hilite_none : "");
-            partition->formatImpl(settings, state, frame);
+            ostr << (settings.hilite ? hilite_keyword : "") << " IN PARTITION " << (settings.hilite ? hilite_none : "");
+            partition->formatImpl(ostr, settings, state, frame);
         }
     }
     else if (type == ASTAlterCommand::MATERIALIZE_INDEX)
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << "MATERIALIZE INDEX " << (settings.hilite ? hilite_none : "");
-        index->formatImpl(settings, state, frame);
+        ostr << (settings.hilite ? hilite_keyword : "") << "MATERIALIZE INDEX " << (settings.hilite ? hilite_none : "");
+        index->formatImpl(ostr, settings, state, frame);
         if (partition)
         {
-            settings.ostr << (settings.hilite ? hilite_keyword : "") << " IN PARTITION " << (settings.hilite ? hilite_none : "");
-            partition->formatImpl(settings, state, frame);
+            ostr << (settings.hilite ? hilite_keyword : "") << " IN PARTITION " << (settings.hilite ? hilite_none : "");
+            partition->formatImpl(ostr, settings, state, frame);
         }
     }
     else if (type == ASTAlterCommand::ADD_STATISTICS)
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << "ADD STATISTICS " << (if_not_exists ? "IF NOT EXISTS " : "")
+        ostr << (settings.hilite ? hilite_keyword : "") << "ADD STATISTICS " << (if_not_exists ? "IF NOT EXISTS " : "")
                       << (settings.hilite ? hilite_none : "");
-        statistics_decl->formatImpl(settings, state, frame);
+        statistics_decl->formatImpl(ostr, settings, state, frame);
     }
     else if (type == ASTAlterCommand::MODIFY_STATISTICS)
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << "MODIFY STATISTICS "
+        ostr << (settings.hilite ? hilite_keyword : "") << "MODIFY STATISTICS "
                       << (settings.hilite ? hilite_none : "");
-        statistics_decl->formatImpl(settings, state, frame);
+        statistics_decl->formatImpl(ostr, settings, state, frame);
     }
     else if (type == ASTAlterCommand::DROP_STATISTICS)
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << (clear_statistics ? "CLEAR " : "DROP ") << "STATISTICS "
+        ostr << (settings.hilite ? hilite_keyword : "") << (clear_statistics ? "CLEAR " : "DROP ") << "STATISTICS "
                       << (if_exists ? "IF EXISTS " : "") << (settings.hilite ? hilite_none : "");
-        statistics_decl->formatImpl(settings, state, frame);
+        statistics_decl->formatImpl(ostr, settings, state, frame);
         if (partition)
         {
-            settings.ostr << (settings.hilite ? hilite_keyword : "") << " IN PARTITION " << (settings.hilite ? hilite_none : "");
-            partition->formatImpl(settings, state, frame);
+            ostr << (settings.hilite ? hilite_keyword : "") << " IN PARTITION " << (settings.hilite ? hilite_none : "");
+            partition->formatImpl(ostr, settings, state, frame);
         }
     }
     else if (type == ASTAlterCommand::MATERIALIZE_STATISTICS)
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << "MATERIALIZE STATISTICS " << (settings.hilite ? hilite_none : "");
-        statistics_decl->formatImpl(settings, state, frame);
+        ostr << (settings.hilite ? hilite_keyword : "") << "MATERIALIZE STATISTICS " << (settings.hilite ? hilite_none : "");
+        statistics_decl->formatImpl(ostr, settings, state, frame);
         if (partition)
         {
-            settings.ostr << (settings.hilite ? hilite_keyword : "") << " IN PARTITION " << (settings.hilite ? hilite_none : "");
-            partition->formatImpl(settings, state, frame);
+            ostr << (settings.hilite ? hilite_keyword : "") << " IN PARTITION " << (settings.hilite ? hilite_none : "");
+            partition->formatImpl(ostr, settings, state, frame);
         }
     }
     else if (type == ASTAlterCommand::ADD_CONSTRAINT)
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << "ADD CONSTRAINT " << (if_not_exists ? "IF NOT EXISTS " : "")
+        ostr << (settings.hilite ? hilite_keyword : "") << "ADD CONSTRAINT " << (if_not_exists ? "IF NOT EXISTS " : "")
                       << (settings.hilite ? hilite_none : "");
-        constraint_decl->formatImpl(settings, state, frame);
+        constraint_decl->formatImpl(ostr, settings, state, frame);
     }
     else if (type == ASTAlterCommand::DROP_CONSTRAINT)
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << "DROP CONSTRAINT " << (if_exists ? "IF EXISTS " : "")
+        ostr << (settings.hilite ? hilite_keyword : "") << "DROP CONSTRAINT " << (if_exists ? "IF EXISTS " : "")
                       << (settings.hilite ? hilite_none : "");
-        constraint->formatImpl(settings, state, frame);
+        constraint->formatImpl(ostr, settings, state, frame);
     }
     else if (type == ASTAlterCommand::ADD_PROJECTION)
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << "ADD PROJECTION " << (if_not_exists ? "IF NOT EXISTS " : "")
+        ostr << (settings.hilite ? hilite_keyword : "") << "ADD PROJECTION " << (if_not_exists ? "IF NOT EXISTS " : "")
                       << (settings.hilite ? hilite_none : "");
-        projection_decl->formatImpl(settings, state, frame);
+        projection_decl->formatImpl(ostr, settings, state, frame);
 
         if (first)
-            settings.ostr << (settings.hilite ? hilite_keyword : "") << " FIRST " << (settings.hilite ? hilite_none : "");
+            ostr << (settings.hilite ? hilite_keyword : "") << " FIRST " << (settings.hilite ? hilite_none : "");
         else if (projection)
         {
-            settings.ostr << (settings.hilite ? hilite_keyword : "") << " AFTER " << (settings.hilite ? hilite_none : "");
-            projection->formatImpl(settings, state, frame);
+            ostr << (settings.hilite ? hilite_keyword : "") << " AFTER " << (settings.hilite ? hilite_none : "");
+            projection->formatImpl(ostr, settings, state, frame);
         }
     }
     else if (type == ASTAlterCommand::DROP_PROJECTION)
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << (clear_projection ? "CLEAR " : "DROP ") << "PROJECTION "
+        ostr << (settings.hilite ? hilite_keyword : "") << (clear_projection ? "CLEAR " : "DROP ") << "PROJECTION "
                       << (if_exists ? "IF EXISTS " : "") << (settings.hilite ? hilite_none : "");
-        projection->formatImpl(settings, state, frame);
+        projection->formatImpl(ostr, settings, state, frame);
         if (partition)
         {
-            settings.ostr << (settings.hilite ? hilite_keyword : "") << " IN PARTITION " << (settings.hilite ? hilite_none : "");
-            partition->formatImpl(settings, state, frame);
+            ostr << (settings.hilite ? hilite_keyword : "") << " IN PARTITION " << (settings.hilite ? hilite_none : "");
+            partition->formatImpl(ostr, settings, state, frame);
         }
     }
     else if (type == ASTAlterCommand::MATERIALIZE_PROJECTION)
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << "MATERIALIZE PROJECTION " << (settings.hilite ? hilite_none : "");
-        projection->formatImpl(settings, state, frame);
+        ostr << (settings.hilite ? hilite_keyword : "") << "MATERIALIZE PROJECTION " << (settings.hilite ? hilite_none : "");
+        projection->formatImpl(ostr, settings, state, frame);
         if (partition)
         {
-            settings.ostr << (settings.hilite ? hilite_keyword : "") << " IN PARTITION " << (settings.hilite ? hilite_none : "");
-            partition->formatImpl(settings, state, frame);
+            ostr << (settings.hilite ? hilite_keyword : "") << " IN PARTITION " << (settings.hilite ? hilite_none : "");
+            partition->formatImpl(ostr, settings, state, frame);
         }
     }
     else if (type == ASTAlterCommand::DROP_PARTITION)
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << (detach ? "DETACH" : "DROP") << (part ? " PART " : " PARTITION ")
+        ostr << (settings.hilite ? hilite_keyword : "") << (detach ? "DETACH" : "DROP") << (part ? " PART " : " PARTITION ")
                       << (settings.hilite ? hilite_none : "");
-        partition->formatImpl(settings, state, frame);
+        partition->formatImpl(ostr, settings, state, frame);
     }
     else if (type == ASTAlterCommand::DROP_DETACHED_PARTITION)
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << "DROP DETACHED" << (part ? " PART " : " PARTITION ")
+        ostr << (settings.hilite ? hilite_keyword : "") << "DROP DETACHED" << (part ? " PART " : " PARTITION ")
                       << (settings.hilite ? hilite_none : "");
-        partition->formatImpl(settings, state, frame);
+        partition->formatImpl(ostr, settings, state, frame);
     }
     else if (type == ASTAlterCommand::FORGET_PARTITION)
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << "FORGET PARTITION "
+        ostr << (settings.hilite ? hilite_keyword : "") << "FORGET PARTITION "
                       << (settings.hilite ? hilite_none : "");
-        partition->formatImpl(settings, state, frame);
+        partition->formatImpl(ostr, settings, state, frame);
     }
     else if (type == ASTAlterCommand::ATTACH_PARTITION)
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << "ATTACH " << (part ? "PART " : "PARTITION ")
+        ostr << (settings.hilite ? hilite_keyword : "") << "ATTACH " << (part ? "PART " : "PARTITION ")
                       << (settings.hilite ? hilite_none : "");
-        partition->formatImpl(settings, state, frame);
+        partition->formatImpl(ostr, settings, state, frame);
     }
     else if (type == ASTAlterCommand::MOVE_PARTITION)
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << "MOVE " << (part ? "PART " : "PARTITION ")
+        ostr << (settings.hilite ? hilite_keyword : "") << "MOVE " << (part ? "PART " : "PARTITION ")
                       << (settings.hilite ? hilite_none : "");
-        partition->formatImpl(settings, state, frame);
-        settings.ostr << " TO ";
+        partition->formatImpl(ostr, settings, state, frame);
+        ostr << " TO ";
         switch (move_destination_type)
         {
             case DataDestinationType::DISK:
-                settings.ostr << "DISK ";
+                ostr << "DISK ";
                 break;
             case DataDestinationType::VOLUME:
-                settings.ostr << "VOLUME ";
+                ostr << "VOLUME ";
                 break;
             case DataDestinationType::TABLE:
-                settings.ostr << "TABLE ";
+                ostr << "TABLE ";
                 if (!to_database.empty())
                 {
-                    settings.ostr << (settings.hilite ? hilite_identifier : "") << backQuoteIfNeed(to_database)
+                    ostr << (settings.hilite ? hilite_identifier : "") << backQuoteIfNeed(to_database)
                                   << (settings.hilite ? hilite_none : "") << ".";
                 }
-                settings.ostr << (settings.hilite ? hilite_identifier : "") << backQuoteIfNeed(to_table)
+                ostr << (settings.hilite ? hilite_identifier : "") << backQuoteIfNeed(to_table)
                               << (settings.hilite ? hilite_none : "");
                 return;
             default:
@@ -339,165 +339,165 @@ void ASTAlterCommand::formatImpl(const FormatSettings & settings, FormatState & 
         }
         if (move_destination_type != DataDestinationType::TABLE)
         {
-            settings.ostr << quoteString(move_destination_name);
+            ostr << quoteString(move_destination_name);
         }
     }
     else if (type == ASTAlterCommand::REPLACE_PARTITION)
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << (replace ? "REPLACE" : "ATTACH") << " PARTITION "
+        ostr << (settings.hilite ? hilite_keyword : "") << (replace ? "REPLACE" : "ATTACH") << " PARTITION "
                       << (settings.hilite ? hilite_none : "");
-        partition->formatImpl(settings, state, frame);
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << " FROM " << (settings.hilite ? hilite_none : "");
+        partition->formatImpl(ostr, settings, state, frame);
+        ostr << (settings.hilite ? hilite_keyword : "") << " FROM " << (settings.hilite ? hilite_none : "");
         if (!from_database.empty())
         {
-            settings.ostr << (settings.hilite ? hilite_identifier : "") << backQuoteIfNeed(from_database)
+            ostr << (settings.hilite ? hilite_identifier : "") << backQuoteIfNeed(from_database)
                           << (settings.hilite ? hilite_none : "") << ".";
         }
-        settings.ostr << (settings.hilite ? hilite_identifier : "") << backQuoteIfNeed(from_table) << (settings.hilite ? hilite_none : "");
+        ostr << (settings.hilite ? hilite_identifier : "") << backQuoteIfNeed(from_table) << (settings.hilite ? hilite_none : "");
     }
     else if (type == ASTAlterCommand::FETCH_PARTITION)
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << "FETCH " << (part ? "PART " : "PARTITION ")
+        ostr << (settings.hilite ? hilite_keyword : "") << "FETCH " << (part ? "PART " : "PARTITION ")
                       << (settings.hilite ? hilite_none : "");
-        partition->formatImpl(settings, state, frame);
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << " FROM " << (settings.hilite ? hilite_none : "") << DB::quote << from;
+        partition->formatImpl(ostr, settings, state, frame);
+        ostr << (settings.hilite ? hilite_keyword : "") << " FROM " << (settings.hilite ? hilite_none : "") << DB::quote << from;
     }
     else if (type == ASTAlterCommand::FREEZE_PARTITION)
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << "FREEZE PARTITION " << (settings.hilite ? hilite_none : "");
-        partition->formatImpl(settings, state, frame);
+        ostr << (settings.hilite ? hilite_keyword : "") << "FREEZE PARTITION " << (settings.hilite ? hilite_none : "");
+        partition->formatImpl(ostr, settings, state, frame);
 
         if (!with_name.empty())
         {
-            settings.ostr << " " << (settings.hilite ? hilite_keyword : "") << "WITH NAME" << (settings.hilite ? hilite_none : "") << " "
+            ostr << " " << (settings.hilite ? hilite_keyword : "") << "WITH NAME" << (settings.hilite ? hilite_none : "") << " "
                           << DB::quote << with_name;
         }
     }
     else if (type == ASTAlterCommand::FREEZE_ALL)
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << "FREEZE" << (settings.hilite ? hilite_none : "");
+        ostr << (settings.hilite ? hilite_keyword : "") << "FREEZE" << (settings.hilite ? hilite_none : "");
 
         if (!with_name.empty())
         {
-            settings.ostr << " " << (settings.hilite ? hilite_keyword : "") << "WITH NAME" << (settings.hilite ? hilite_none : "") << " "
+            ostr << " " << (settings.hilite ? hilite_keyword : "") << "WITH NAME" << (settings.hilite ? hilite_none : "") << " "
                           << DB::quote << with_name;
         }
     }
     else if (type == ASTAlterCommand::UNFREEZE_PARTITION)
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << "UNFREEZE PARTITION " << (settings.hilite ? hilite_none : "");
-        partition->formatImpl(settings, state, frame);
+        ostr << (settings.hilite ? hilite_keyword : "") << "UNFREEZE PARTITION " << (settings.hilite ? hilite_none : "");
+        partition->formatImpl(ostr, settings, state, frame);
 
         if (!with_name.empty())
         {
-            settings.ostr << " " << (settings.hilite ? hilite_keyword : "") << "WITH NAME" << (settings.hilite ? hilite_none : "") << " "
+            ostr << " " << (settings.hilite ? hilite_keyword : "") << "WITH NAME" << (settings.hilite ? hilite_none : "") << " "
                           << DB::quote << with_name;
         }
     }
     else if (type == ASTAlterCommand::UNFREEZE_ALL)
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << "UNFREEZE" << (settings.hilite ? hilite_none : "");
+        ostr << (settings.hilite ? hilite_keyword : "") << "UNFREEZE" << (settings.hilite ? hilite_none : "");
 
         if (!with_name.empty())
         {
-            settings.ostr << " " << (settings.hilite ? hilite_keyword : "") << "WITH NAME" << (settings.hilite ? hilite_none : "") << " "
+            ostr << " " << (settings.hilite ? hilite_keyword : "") << "WITH NAME" << (settings.hilite ? hilite_none : "") << " "
                           << DB::quote << with_name;
         }
     }
     else if (type == ASTAlterCommand::DELETE)
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << "DELETE" << (settings.hilite ? hilite_none : "");
+        ostr << (settings.hilite ? hilite_keyword : "") << "DELETE" << (settings.hilite ? hilite_none : "");
 
         if (partition)
         {
-            settings.ostr << (settings.hilite ? hilite_keyword : "") << " IN PARTITION " << (settings.hilite ? hilite_none : "");
-            partition->formatImpl(settings, state, frame);
+            ostr << (settings.hilite ? hilite_keyword : "") << " IN PARTITION " << (settings.hilite ? hilite_none : "");
+            partition->formatImpl(ostr, settings, state, frame);
         }
 
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << " WHERE " << (settings.hilite ? hilite_none : "");
-        predicate->formatImpl(settings, state, frame);
+        ostr << (settings.hilite ? hilite_keyword : "") << " WHERE " << (settings.hilite ? hilite_none : "");
+        predicate->formatImpl(ostr, settings, state, frame);
     }
     else if (type == ASTAlterCommand::UPDATE)
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << "UPDATE " << (settings.hilite ? hilite_none : "");
-        update_assignments->formatImpl(settings, state, frame);
+        ostr << (settings.hilite ? hilite_keyword : "") << "UPDATE " << (settings.hilite ? hilite_none : "");
+        update_assignments->formatImpl(ostr, settings, state, frame);
 
         if (partition)
         {
-            settings.ostr << (settings.hilite ? hilite_keyword : "") << " IN PARTITION " << (settings.hilite ? hilite_none : "");
-            partition->formatImpl(settings, state, frame);
+            ostr << (settings.hilite ? hilite_keyword : "") << " IN PARTITION " << (settings.hilite ? hilite_none : "");
+            partition->formatImpl(ostr, settings, state, frame);
         }
 
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << " WHERE " << (settings.hilite ? hilite_none : "");
-        predicate->formatImpl(settings, state, frame);
+        ostr << (settings.hilite ? hilite_keyword : "") << " WHERE " << (settings.hilite ? hilite_none : "");
+        predicate->formatImpl(ostr, settings, state, frame);
     }
     else if (type == ASTAlterCommand::MODIFY_TTL)
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << "MODIFY TTL " << (settings.hilite ? hilite_none : "");
-        ttl->formatImpl(settings, state, frame);
+        ostr << (settings.hilite ? hilite_keyword : "") << "MODIFY TTL " << (settings.hilite ? hilite_none : "");
+        ttl->formatImpl(ostr, settings, state, frame);
     }
     else if (type == ASTAlterCommand::REMOVE_TTL)
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << "REMOVE TTL" << (settings.hilite ? hilite_none : "");
+        ostr << (settings.hilite ? hilite_keyword : "") << "REMOVE TTL" << (settings.hilite ? hilite_none : "");
     }
     else if (type == ASTAlterCommand::MATERIALIZE_TTL)
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << "MATERIALIZE TTL" << (settings.hilite ? hilite_none : "");
+        ostr << (settings.hilite ? hilite_keyword : "") << "MATERIALIZE TTL" << (settings.hilite ? hilite_none : "");
         if (partition)
         {
-            settings.ostr << (settings.hilite ? hilite_keyword : "") << " IN PARTITION " << (settings.hilite ? hilite_none : "");
-            partition->formatImpl(settings, state, frame);
+            ostr << (settings.hilite ? hilite_keyword : "") << " IN PARTITION " << (settings.hilite ? hilite_none : "");
+            partition->formatImpl(ostr, settings, state, frame);
         }
     }
     else if (type == ASTAlterCommand::MODIFY_SETTING)
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << "MODIFY SETTING " << (settings.hilite ? hilite_none : "");
-        settings_changes->formatImpl(settings, state, frame);
+        ostr << (settings.hilite ? hilite_keyword : "") << "MODIFY SETTING " << (settings.hilite ? hilite_none : "");
+        settings_changes->formatImpl(ostr, settings, state, frame);
     }
     else if (type == ASTAlterCommand::RESET_SETTING)
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << "RESET SETTING " << (settings.hilite ? hilite_none : "");
-        settings_resets->formatImpl(settings, state, frame);
+        ostr << (settings.hilite ? hilite_keyword : "") << "RESET SETTING " << (settings.hilite ? hilite_none : "");
+        settings_resets->formatImpl(ostr, settings, state, frame);
     }
     else if (type == ASTAlterCommand::MODIFY_DATABASE_SETTING)
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << "MODIFY SETTING " << (settings.hilite ? hilite_none : "");
-        settings_changes->formatImpl(settings, state, frame);
+        ostr << (settings.hilite ? hilite_keyword : "") << "MODIFY SETTING " << (settings.hilite ? hilite_none : "");
+        settings_changes->formatImpl(ostr, settings, state, frame);
     }
     else if (type == ASTAlterCommand::MODIFY_QUERY)
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << "MODIFY QUERY" << settings.nl_or_ws
+        ostr << (settings.hilite ? hilite_keyword : "") << "MODIFY QUERY" << settings.nl_or_ws
                       << (settings.hilite ? hilite_none : "");
-        select->formatImpl(settings, state, frame);
+        select->formatImpl(ostr, settings, state, frame);
     }
     else if (type == ASTAlterCommand::MODIFY_REFRESH)
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << "MODIFY" << settings.nl_or_ws
+        ostr << (settings.hilite ? hilite_keyword : "") << "MODIFY" << settings.nl_or_ws
                       << (settings.hilite ? hilite_none : "");
-        refresh->formatImpl(settings, state, frame);
+        refresh->formatImpl(ostr, settings, state, frame);
     }
     else if (type == ASTAlterCommand::RENAME_COLUMN)
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << "RENAME COLUMN " << (if_exists ? "IF EXISTS " : "")
+        ostr << (settings.hilite ? hilite_keyword : "") << "RENAME COLUMN " << (if_exists ? "IF EXISTS " : "")
                       << (settings.hilite ? hilite_none : "");
-        column->formatImpl(settings, state, frame);
+        column->formatImpl(ostr, settings, state, frame);
 
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << " TO ";
-        rename_to->formatImpl(settings, state, frame);
+        ostr << (settings.hilite ? hilite_keyword : "") << " TO ";
+        rename_to->formatImpl(ostr, settings, state, frame);
     }
     else if (type == ASTAlterCommand::MODIFY_SQL_SECURITY)
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << "MODIFY " << (settings.hilite ? hilite_none : "");
-        sql_security->formatImpl(settings, state, frame);
+        ostr << (settings.hilite ? hilite_keyword : "") << "MODIFY " << (settings.hilite ? hilite_none : "");
+        sql_security->formatImpl(ostr, settings, state, frame);
     }
     else if (type == ASTAlterCommand::APPLY_DELETED_MASK)
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << "APPLY DELETED MASK" << (settings.hilite ? hilite_none : "");
+        ostr << (settings.hilite ? hilite_keyword : "") << "APPLY DELETED MASK" << (settings.hilite ? hilite_none : "");
 
         if (partition)
         {
-            settings.ostr << (settings.hilite ? hilite_keyword : "") << " IN PARTITION " << (settings.hilite ? hilite_none : "");
-            partition->formatImpl(settings, state, frame);
+            ostr << (settings.hilite ? hilite_keyword : "") << " IN PARTITION " << (settings.hilite ? hilite_none : "");
+            partition->formatImpl(ostr, settings, state, frame);
         }
     }
     else
@@ -614,58 +614,58 @@ ASTPtr ASTAlterQuery::clone() const
     return res;
 }
 
-void ASTAlterQuery::formatQueryImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
+void ASTAlterQuery::formatQueryImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
 {
     frame.need_parens = false;
 
     std::string indent_str = settings.one_line ? "" : std::string(4u * frame.indent, ' ');
-    settings.ostr << (settings.hilite ? hilite_keyword : "") << indent_str;
+    ostr << (settings.hilite ? hilite_keyword : "") << indent_str;
 
     switch (alter_object)
     {
         case AlterObjectType::TABLE:
-            settings.ostr << "ALTER TABLE ";
+            ostr << "ALTER TABLE ";
             break;
         case AlterObjectType::DATABASE:
-            settings.ostr << "ALTER DATABASE ";
+            ostr << "ALTER DATABASE ";
             break;
         default:
             break;
     }
 
-    settings.ostr << (settings.hilite ? hilite_none : "");
+    ostr << (settings.hilite ? hilite_none : "");
 
     if (table)
     {
-        settings.ostr << indent_str;
+        ostr << indent_str;
         if (database)
         {
-            database->formatImpl(settings, state, frame);
-            settings.ostr << '.';
+            database->formatImpl(ostr, settings, state, frame);
+            ostr << '.';
         }
 
         chassert(table);
-        table->formatImpl(settings, state, frame);
+        table->formatImpl(ostr, settings, state, frame);
     }
     else if (alter_object == AlterObjectType::DATABASE && database)
     {
-        settings.ostr << indent_str;
-        database->formatImpl(settings, state, frame);
+        ostr << indent_str;
+        database->formatImpl(ostr, settings, state, frame);
     }
 
-    formatOnCluster(settings);
+    formatOnCluster(ostr, settings);
 
     FormatStateStacked frame_nested = frame;
     frame_nested.need_parens = false;
     if (settings.one_line)
     {
         frame_nested.expression_list_prepend_whitespace = true;
-        command_list->formatImpl(settings, state, frame_nested);
+        command_list->formatImpl(ostr, settings, state, frame_nested);
     }
     else
     {
         frame_nested.expression_list_always_start_on_new_line = true;
-        command_list->as<ASTExpressionList &>().formatImplMultiline(settings, state, frame_nested);
+        command_list->as<ASTExpressionList &>().formatImplMultiline(ostr, settings, state, frame_nested);
     }
 }
 

--- a/src/Parsers/ASTAlterQuery.h
+++ b/src/Parsers/ASTAlterQuery.h
@@ -226,7 +226,7 @@ public:
     static void setFormatAlterCommandsWithParentheses(bool value) { format_alter_commands_with_parentheses = value; }
 
 protected:
-    void formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
 
     void forEachPointerToChild(std::function<void(void**)> f) override;
 
@@ -273,7 +273,7 @@ public:
     QueryKind getQueryKind() const override { return QueryKind::Alter; }
 
 protected:
-    void formatQueryImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
+    void formatQueryImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
 
     bool isOneCommandTypeOnly(const ASTAlterCommand::Type & type) const;
 

--- a/src/Parsers/ASTAssignment.h
+++ b/src/Parsers/ASTAssignment.h
@@ -26,16 +26,16 @@ public:
     }
 
 protected:
-    void formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override
     {
 
-        settings.ostr << (settings.hilite ? hilite_identifier : "");
-        settings.writeIdentifier(column_name, /*ambiguous=*/false);
-        settings.ostr << (settings.hilite ? hilite_none : "");
+        ostr << (settings.hilite ? hilite_identifier : "");
+        settings.writeIdentifier(ostr, column_name, /*ambiguous=*/false);
+        ostr << (settings.hilite ? hilite_none : "");
 
-        settings.ostr << (settings.hilite ? hilite_operator : "") << " = " << (settings.hilite ? hilite_none : "");
+        ostr << (settings.hilite ? hilite_operator : "") << " = " << (settings.hilite ? hilite_none : "");
 
-        expression()->formatImpl(settings, state, frame);
+        expression()->formatImpl(ostr, settings, state, frame);
     }
 };
 

--- a/src/Parsers/ASTAsterisk.cpp
+++ b/src/Parsers/ASTAsterisk.cpp
@@ -27,19 +27,19 @@ void ASTAsterisk::appendColumnName(WriteBuffer & ostr) const
     ostr.write('*');
 }
 
-void ASTAsterisk::formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
+void ASTAsterisk::formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
 {
     if (expression)
     {
-        expression->formatImpl(settings, state, frame);
-        settings.ostr << ".";
+        expression->formatImpl(ostr, settings, state, frame);
+        ostr << ".";
     }
 
-    settings.ostr << "*";
+    ostr << "*";
 
     if (transformers)
     {
-        transformers->formatImpl(settings, state, frame);
+        transformers->formatImpl(ostr, settings, state, frame);
     }
 }
 

--- a/src/Parsers/ASTAsterisk.h
+++ b/src/Parsers/ASTAsterisk.h
@@ -19,7 +19,7 @@ public:
     ASTPtr expression;
     ASTPtr transformers;
 protected:
-    void formatImpl(const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
 };
 
 }

--- a/src/Parsers/ASTBackupQuery.h
+++ b/src/Parsers/ASTBackupQuery.h
@@ -91,7 +91,7 @@ public:
 
     String getID(char) const override;
     ASTPtr clone() const override;
-    void formatQueryImpl(const FormatSettings & fs, FormatState &, FormatStateStacked) const override;
+    void formatQueryImpl(WriteBuffer & ostr, const FormatSettings & fs, FormatState &, FormatStateStacked) const override;
     ASTPtr getRewrittenASTWithoutOnCluster(const WithoutOnClusterASTRewriteParams &) const override;
     QueryKind getQueryKind() const override;
 

--- a/src/Parsers/ASTCheckQuery.h
+++ b/src/Parsers/ASTCheckQuery.h
@@ -36,32 +36,32 @@ struct ASTCheckTableQuery : public ASTQueryWithTableAndOutput
     }
 
 protected:
-    void formatQueryImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override
+    void formatQueryImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override
     {
         std::string indent_str = settings.one_line ? "" : std::string(4 * frame.indent, ' ');
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << indent_str << "CHECK TABLE " << (settings.hilite ? hilite_none : "");
+        ostr << (settings.hilite ? hilite_keyword : "") << indent_str << "CHECK TABLE " << (settings.hilite ? hilite_none : "");
 
         if (table)
         {
             if (database)
             {
-                database->formatImpl(settings, state, frame);
-                settings.ostr << '.';
+                database->formatImpl(ostr, settings, state, frame);
+                ostr << '.';
             }
 
             chassert(table);
-            table->formatImpl(settings, state, frame);
+            table->formatImpl(ostr, settings, state, frame);
         }
 
         if (partition)
         {
-            settings.ostr << (settings.hilite ? hilite_keyword : "") << indent_str << " PARTITION " << (settings.hilite ? hilite_none : "");
-            partition->formatImpl(settings, state, frame);
+            ostr << (settings.hilite ? hilite_keyword : "") << indent_str << " PARTITION " << (settings.hilite ? hilite_none : "");
+            partition->formatImpl(ostr, settings, state, frame);
         }
 
         if (!part_name.empty())
         {
-            settings.ostr << (settings.hilite ? hilite_keyword : "") << indent_str << " PART " << (settings.hilite ? hilite_none : "")
+            ostr << (settings.hilite ? hilite_keyword : "") << indent_str << " PART " << (settings.hilite ? hilite_none : "")
                 << quoteString(part_name);
         }
     }
@@ -84,10 +84,10 @@ struct ASTCheckAllTablesQuery : public ASTQueryWithOutput
     QueryKind getQueryKind() const override { return QueryKind::Check; }
 
 protected:
-    void formatQueryImpl(const FormatSettings & settings, FormatState & /* state */, FormatStateStacked frame) const override
+    void formatQueryImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & /* state */, FormatStateStacked frame) const override
     {
         std::string indent_str = settings.one_line ? "" : std::string(4 * frame.indent, ' ');
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << indent_str << "CHECK ALL TABLES" << (settings.hilite ? hilite_none : "");
+        ostr << (settings.hilite ? hilite_keyword : "") << indent_str << "CHECK ALL TABLES" << (settings.hilite ? hilite_none : "");
     }
 };
 

--- a/src/Parsers/ASTCollation.cpp
+++ b/src/Parsers/ASTCollation.cpp
@@ -9,13 +9,10 @@ namespace DB
         return res;
     }
 
-    void ASTCollation::formatImpl(const FormatSettings &s, FormatState &state, FormatStateStacked frame) const
+    void ASTCollation::formatImpl(WriteBuffer & ostr, const FormatSettings &s, FormatState &state, FormatStateStacked frame) const
     {
         if (collation)
-        {
-            collation->formatImpl(s, state, frame);
-        }
-
+            collation->formatImpl(ostr, s, state, frame);
     }
 
 }

--- a/src/Parsers/ASTCollation.h
+++ b/src/Parsers/ASTCollation.h
@@ -14,7 +14,7 @@ public:
 
     ASTPtr clone() const override;
 
-    void formatImpl(const FormatSettings & s, FormatState & state, FormatStateStacked frame) const override;
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & s, FormatState & state, FormatStateStacked frame) const override;
 };
 
 }

--- a/src/Parsers/ASTColumnDeclaration.cpp
+++ b/src/Parsers/ASTColumnDeclaration.cpp
@@ -62,69 +62,69 @@ ASTPtr ASTColumnDeclaration::clone() const
     return res;
 }
 
-void ASTColumnDeclaration::formatImpl(const FormatSettings & format_settings, FormatState & state, FormatStateStacked frame) const
+void ASTColumnDeclaration::formatImpl(WriteBuffer & ostr, const FormatSettings & format_settings, FormatState & state, FormatStateStacked frame) const
 {
     frame.need_parens = false;
 
-    format_settings.writeIdentifier(name, /*ambiguous=*/true);
+    format_settings.writeIdentifier(ostr, name, /*ambiguous=*/true);
 
     if (type)
     {
-        format_settings.ostr << ' ';
-        type->formatImpl(format_settings, state, frame);
+        ostr << ' ';
+        type->formatImpl(ostr, format_settings, state, frame);
     }
 
     if (null_modifier)
     {
-        format_settings.ostr << ' ' << (format_settings.hilite ? hilite_keyword : "")
+        ostr << ' ' << (format_settings.hilite ? hilite_keyword : "")
                       << (*null_modifier ? "" : "NOT ") << "NULL" << (format_settings.hilite ? hilite_none : "");
     }
 
     if (default_expression)
     {
-        format_settings.ostr << ' ' << (format_settings.hilite ? hilite_keyword : "") << default_specifier << (format_settings.hilite ? hilite_none : "");
+        ostr << ' ' << (format_settings.hilite ? hilite_keyword : "") << default_specifier << (format_settings.hilite ? hilite_none : "");
         if (!ephemeral_default)
         {
-            format_settings.ostr << ' ';
-            default_expression->formatImpl(format_settings, state, frame);
+            ostr << ' ';
+            default_expression->formatImpl(ostr, format_settings, state, frame);
         }
     }
 
     if (comment)
     {
-        format_settings.ostr << ' ' << (format_settings.hilite ? hilite_keyword : "") << "COMMENT" << (format_settings.hilite ? hilite_none : "") << ' ';
-        comment->formatImpl(format_settings, state, frame);
+        ostr << ' ' << (format_settings.hilite ? hilite_keyword : "") << "COMMENT" << (format_settings.hilite ? hilite_none : "") << ' ';
+        comment->formatImpl(ostr, format_settings, state, frame);
     }
 
     if (codec)
     {
-        format_settings.ostr << ' ';
-        codec->formatImpl(format_settings, state, frame);
+        ostr << ' ';
+        codec->formatImpl(ostr, format_settings, state, frame);
     }
 
     if (statistics_desc)
     {
-        format_settings.ostr << ' ';
-        statistics_desc->formatImpl(format_settings, state, frame);
+        ostr << ' ';
+        statistics_desc->formatImpl(ostr, format_settings, state, frame);
     }
 
     if (ttl)
     {
-        format_settings.ostr << ' ' << (format_settings.hilite ? hilite_keyword : "") << "TTL" << (format_settings.hilite ? hilite_none : "") << ' ';
-        ttl->formatImpl(format_settings, state, frame);
+        ostr << ' ' << (format_settings.hilite ? hilite_keyword : "") << "TTL" << (format_settings.hilite ? hilite_none : "") << ' ';
+        ttl->formatImpl(ostr, format_settings, state, frame);
     }
 
     if (collation)
     {
-        format_settings.ostr << ' ' << (format_settings.hilite ? hilite_keyword : "") << "COLLATE" << (format_settings.hilite ? hilite_none : "") << ' ';
-        collation->formatImpl(format_settings, state, frame);
+        ostr << ' ' << (format_settings.hilite ? hilite_keyword : "") << "COLLATE" << (format_settings.hilite ? hilite_none : "") << ' ';
+        collation->formatImpl(ostr, format_settings, state, frame);
     }
 
     if (settings)
     {
-        format_settings.ostr << ' ' << (format_settings.hilite ? hilite_keyword : "") << "SETTINGS" << (format_settings.hilite ? hilite_none : "") << ' ' << '(';
-        settings->formatImpl(format_settings, state, frame);
-        format_settings.ostr << ')';
+        ostr << ' ' << (format_settings.hilite ? hilite_keyword : "") << "SETTINGS" << (format_settings.hilite ? hilite_none : "") << ' ' << '(';
+        settings->formatImpl(ostr, format_settings, state, frame);
+        ostr << ')';
     }
 }
 

--- a/src/Parsers/ASTColumnDeclaration.h
+++ b/src/Parsers/ASTColumnDeclaration.h
@@ -28,7 +28,7 @@ public:
     String getID(char delim) const override { return "ColumnDeclaration" + (delim + name); }
 
     ASTPtr clone() const override;
-    void formatImpl(const FormatSettings & format_settings, FormatState & state, FormatStateStacked frame) const override;
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & format_settings, FormatState & state, FormatStateStacked frame) const override;
 
 protected:
     void forEachPointerToChild(std::function<void(void **)> f) override;

--- a/src/Parsers/ASTColumnsMatcher.cpp
+++ b/src/Parsers/ASTColumnsMatcher.cpp
@@ -39,23 +39,23 @@ void ASTColumnsRegexpMatcher::updateTreeHashImpl(SipHash & hash_state, bool igno
     IAST::updateTreeHashImpl(hash_state, ignore_aliases);
 }
 
-void ASTColumnsRegexpMatcher::formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
+void ASTColumnsRegexpMatcher::formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
 {
-    settings.ostr << (settings.hilite ? hilite_keyword : "");
+    ostr << (settings.hilite ? hilite_keyword : "");
 
     if (expression)
     {
-        expression->formatImpl(settings, state, frame);
-        settings.ostr << ".";
+        expression->formatImpl(ostr, settings, state, frame);
+        ostr << ".";
     }
 
-    settings.ostr << "COLUMNS" << (settings.hilite ? hilite_none : "") << "(";
-    settings.ostr << quoteString(pattern);
-    settings.ostr << ")";
+    ostr << "COLUMNS" << (settings.hilite ? hilite_none : "") << "(";
+    ostr << quoteString(pattern);
+    ostr << ")";
 
     if (transformers)
     {
-        transformers->formatImpl(settings, state, frame);
+        transformers->formatImpl(ostr, settings, state, frame);
     }
 }
 
@@ -101,31 +101,31 @@ void ASTColumnsListMatcher::appendColumnName(WriteBuffer & ostr) const
     writeChar(')', ostr);
 }
 
-void ASTColumnsListMatcher::formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
+void ASTColumnsListMatcher::formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
 {
-    settings.ostr << (settings.hilite ? hilite_keyword : "");
+    ostr << (settings.hilite ? hilite_keyword : "");
 
     if (expression)
     {
-        expression->formatImpl(settings, state, frame);
-        settings.ostr << ".";
+        expression->formatImpl(ostr, settings, state, frame);
+        ostr << ".";
     }
 
-    settings.ostr << "COLUMNS" << (settings.hilite ? hilite_none : "") << "(";
+    ostr << "COLUMNS" << (settings.hilite ? hilite_none : "") << "(";
 
     for (ASTs::const_iterator it = column_list->children.begin(); it != column_list->children.end(); ++it)
     {
         if (it != column_list->children.begin())
         {
-            settings.ostr << ", ";
+            ostr << ", ";
         }
-        (*it)->formatImpl(settings, state, frame);
+        (*it)->formatImpl(ostr, settings, state, frame);
     }
-    settings.ostr << ")";
+    ostr << ")";
 
     if (transformers)
     {
-        transformers->formatImpl(settings, state, frame);
+        transformers->formatImpl(ostr, settings, state, frame);
     }
 }
 
@@ -167,19 +167,19 @@ void ASTQualifiedColumnsRegexpMatcher::updateTreeHashImpl(SipHash & hash_state, 
     IAST::updateTreeHashImpl(hash_state, ignore_aliases);
 }
 
-void ASTQualifiedColumnsRegexpMatcher::formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
+void ASTQualifiedColumnsRegexpMatcher::formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
 {
-    settings.ostr << (settings.hilite ? hilite_keyword : "");
+    ostr << (settings.hilite ? hilite_keyword : "");
 
-    qualifier->formatImpl(settings, state, frame);
+    qualifier->formatImpl(ostr, settings, state, frame);
 
-    settings.ostr << ".COLUMNS" << (settings.hilite ? hilite_none : "") << "(";
-    settings.ostr << quoteString(pattern);
-    settings.ostr << ")";
+    ostr << ".COLUMNS" << (settings.hilite ? hilite_none : "") << "(";
+    ostr << quoteString(pattern);
+    ostr << ")";
 
     if (transformers)
     {
-        transformers->formatImpl(settings, state, frame);
+        transformers->formatImpl(ostr, settings, state, frame);
     }
 }
 
@@ -214,24 +214,24 @@ void ASTQualifiedColumnsListMatcher::appendColumnName(WriteBuffer & ostr) const
     writeChar(')', ostr);
 }
 
-void ASTQualifiedColumnsListMatcher::formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
+void ASTQualifiedColumnsListMatcher::formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
 {
-    settings.ostr << (settings.hilite ? hilite_keyword : "");
-    qualifier->formatImpl(settings, state, frame);
-    settings.ostr << ".COLUMNS" << (settings.hilite ? hilite_none : "") << "(";
+    ostr << (settings.hilite ? hilite_keyword : "");
+    qualifier->formatImpl(ostr, settings, state, frame);
+    ostr << ".COLUMNS" << (settings.hilite ? hilite_none : "") << "(";
 
     for (ASTs::const_iterator it = column_list->children.begin(); it != column_list->children.end(); ++it)
     {
         if (it != column_list->children.begin())
-            settings.ostr << ", ";
+            ostr << ", ";
 
-        (*it)->formatImpl(settings, state, frame);
+        (*it)->formatImpl(ostr, settings, state, frame);
     }
-    settings.ostr << ")";
+    ostr << ")";
 
     if (transformers)
     {
-        transformers->formatImpl(settings, state, frame);
+        transformers->formatImpl(ostr, settings, state, frame);
     }
 }
 

--- a/src/Parsers/ASTColumnsMatcher.h
+++ b/src/Parsers/ASTColumnsMatcher.h
@@ -25,7 +25,7 @@ public:
     ASTPtr expression;
     ASTPtr transformers;
 protected:
-    void formatImpl(const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
 
 private:
     String pattern;
@@ -43,7 +43,7 @@ public:
     ASTPtr column_list;
     ASTPtr transformers;
 protected:
-    void formatImpl(const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
 };
 
 /// Same as ASTColumnsRegexpMatcher. Qualified identifier is first child.
@@ -61,7 +61,7 @@ public:
     ASTPtr qualifier;
     ASTPtr transformers;
 protected:
-    void formatImpl(const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
 
 private:
     String pattern;
@@ -79,7 +79,7 @@ public:
     ASTPtr column_list;
     ASTPtr transformers;
 protected:
-    void formatImpl(const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
 };
 
 }

--- a/src/Parsers/ASTColumnsTransformers.cpp
+++ b/src/Parsers/ASTColumnsTransformers.cpp
@@ -20,12 +20,12 @@ namespace ErrorCodes
     extern const int CANNOT_COMPILE_REGEXP;
 }
 
-void ASTColumnsTransformerList::formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
+void ASTColumnsTransformerList::formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
 {
     for (const auto & child : children)
     {
-        settings.ostr << ' ';
-        child->formatImpl(settings, state, frame);
+        ostr << ' ';
+        child->formatImpl(ostr, settings, state, frame);
     }
 }
 
@@ -45,33 +45,33 @@ void IASTColumnsTransformer::transform(const ASTPtr & transformer, ASTs & nodes)
     }
 }
 
-void ASTColumnsApplyTransformer::formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
+void ASTColumnsApplyTransformer::formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
 {
-    settings.ostr << (settings.hilite ? hilite_keyword : "") << "APPLY" << (settings.hilite ? hilite_none : "") << " ";
+    ostr << (settings.hilite ? hilite_keyword : "") << "APPLY" << (settings.hilite ? hilite_none : "") << " ";
 
     if (!column_name_prefix.empty())
-        settings.ostr << "(";
+        ostr << "(";
 
     if (lambda)
     {
-        lambda->formatImpl(settings, state, frame);
+        lambda->formatImpl(ostr, settings, state, frame);
     }
     else
     {
-        settings.ostr << func_name;
+        ostr << func_name;
 
         if (parameters)
         {
             auto nested_frame = frame;
             nested_frame.expression_list_prepend_whitespace = false;
-            settings.ostr << "(";
-            parameters->formatImpl(settings, state, nested_frame);
-            settings.ostr << ")";
+            ostr << "(";
+            parameters->formatImpl(ostr, settings, state, nested_frame);
+            ostr << ")";
         }
     }
 
     if (!column_name_prefix.empty())
-        settings.ostr << ", '" << column_name_prefix << "')";
+        ostr << ", '" << column_name_prefix << "')";
 }
 
 void ASTColumnsApplyTransformer::transform(ASTs & nodes) const
@@ -164,27 +164,27 @@ void ASTColumnsApplyTransformer::updateTreeHashImpl(SipHash & hash_state, bool i
     IAST::updateTreeHashImpl(hash_state, ignore_aliases);
 }
 
-void ASTColumnsExceptTransformer::formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
+void ASTColumnsExceptTransformer::formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
 {
-    settings.ostr << (settings.hilite ? hilite_keyword : "") << "EXCEPT" << (is_strict ? " STRICT " : " ") << (settings.hilite ? hilite_none : "");
+    ostr << (settings.hilite ? hilite_keyword : "") << "EXCEPT" << (is_strict ? " STRICT " : " ") << (settings.hilite ? hilite_none : "");
 
     if (children.size() > 1)
-        settings.ostr << "(";
+        ostr << "(";
 
     for (ASTs::const_iterator it = children.begin(); it != children.end(); ++it)
     {
         if (it != children.begin())
         {
-            settings.ostr << ", ";
+            ostr << ", ";
         }
-        (*it)->formatImpl(settings, state, frame);
+        (*it)->formatImpl(ostr, settings, state, frame);
     }
 
     if (pattern)
-        settings.ostr << quoteString(*pattern);
+        ostr << quoteString(*pattern);
 
     if (children.size() > 1)
-        settings.ostr << ")";
+        ostr << ")";
 }
 
 void ASTColumnsExceptTransformer::appendColumnName(WriteBuffer & ostr) const
@@ -292,12 +292,12 @@ std::shared_ptr<re2::RE2> ASTColumnsExceptTransformer::getMatcher() const
 }
 
 void ASTColumnsReplaceTransformer::Replacement::formatImpl(
-    const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
+    WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
 {
     assert(children.size() == 1);
 
-    children[0]->formatImpl(settings, state, frame);
-    settings.ostr << (settings.hilite ? hilite_keyword : "") << " AS " << (settings.hilite ? hilite_none : "") << backQuoteIfNeed(name);
+    children[0]->formatImpl(ostr, settings, state, frame);
+    ostr << (settings.hilite ? hilite_keyword : "") << " AS " << (settings.hilite ? hilite_none : "") << backQuoteIfNeed(name);
 }
 
 void ASTColumnsReplaceTransformer::Replacement::appendColumnName(WriteBuffer & ostr) const
@@ -319,19 +319,19 @@ void ASTColumnsReplaceTransformer::Replacement::updateTreeHashImpl(SipHash & has
     IAST::updateTreeHashImpl(hash_state, ignore_aliases);
 }
 
-void ASTColumnsReplaceTransformer::formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
+void ASTColumnsReplaceTransformer::formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
 {
-    settings.ostr << (settings.hilite ? hilite_keyword : "") << "REPLACE" << (is_strict ? " STRICT " : " ") << (settings.hilite ? hilite_none : "");
+    ostr << (settings.hilite ? hilite_keyword : "") << "REPLACE" << (is_strict ? " STRICT " : " ") << (settings.hilite ? hilite_none : "");
 
-    settings.ostr << "(";
+    ostr << "(";
     for (ASTs::const_iterator it = children.begin(); it != children.end(); ++it)
     {
         if (it != children.begin())
-            settings.ostr << ", ";
+            ostr << ", ";
 
-        (*it)->formatImpl(settings, state, frame);
+        (*it)->formatImpl(ostr, settings, state, frame);
     }
-    settings.ostr << ")";
+    ostr << ")";
 }
 
 void ASTColumnsReplaceTransformer::appendColumnName(WriteBuffer & ostr) const

--- a/src/Parsers/ASTColumnsTransformers.h
+++ b/src/Parsers/ASTColumnsTransformers.h
@@ -24,7 +24,7 @@ public:
     }
 
 protected:
-    void formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
 };
 
 class IASTColumnsTransformer : public IAST
@@ -62,7 +62,7 @@ public:
     String column_name_prefix;
 
 protected:
-    void formatImpl(const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
 };
 
 class ASTColumnsExceptTransformer : public IASTColumnsTransformer
@@ -83,7 +83,7 @@ public:
     void updateTreeHashImpl(SipHash & hash_state, bool ignore_aliases) const override;
 
 protected:
-    void formatImpl(const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
     std::optional<String> pattern;
 };
 
@@ -107,7 +107,7 @@ public:
         String name;
 
     protected:
-        void formatImpl(const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
+        void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
     };
 
     bool is_strict = false;
@@ -123,7 +123,7 @@ public:
     void updateTreeHashImpl(SipHash & hash_state, bool ignore_aliases) const override;
 
 protected:
-    void formatImpl(const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
 
 private:
     static void replaceChildren(ASTPtr & node, const ASTPtr & replacement, const String & name);

--- a/src/Parsers/ASTConstraintDeclaration.cpp
+++ b/src/Parsers/ASTConstraintDeclaration.cpp
@@ -19,11 +19,11 @@ ASTPtr ASTConstraintDeclaration::clone() const
     return res;
 }
 
-void ASTConstraintDeclaration::formatImpl(const FormatSettings & s, FormatState & state, FormatStateStacked frame) const
+void ASTConstraintDeclaration::formatImpl(WriteBuffer & ostr, const FormatSettings & s, FormatState & state, FormatStateStacked frame) const
 {
-    s.ostr << backQuoteIfNeed(name);
-    s.ostr << (s.hilite ? hilite_keyword : "") << (type == Type::CHECK ? " CHECK " : " ASSUME ") << (s.hilite ? hilite_none : "");
-    expr->formatImpl(s, state, frame);
+    ostr << backQuoteIfNeed(name);
+    ostr << (s.hilite ? hilite_keyword : "") << (type == Type::CHECK ? " CHECK " : " ASSUME ") << (s.hilite ? hilite_none : "");
+    expr->formatImpl(ostr, s, state, frame);
 }
 
 }

--- a/src/Parsers/ASTConstraintDeclaration.h
+++ b/src/Parsers/ASTConstraintDeclaration.h
@@ -24,7 +24,7 @@ public:
 
     ASTPtr clone() const override;
 
-    void formatImpl(const FormatSettings & s, FormatState & state, FormatStateStacked frame) const override;
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & s, FormatState & state, FormatStateStacked frame) const override;
 
     void forEachPointerToChild(std::function<void(void**)> f) override
     {

--- a/src/Parsers/ASTCreateFunctionQuery.cpp
+++ b/src/Parsers/ASTCreateFunctionQuery.cpp
@@ -21,26 +21,26 @@ ASTPtr ASTCreateFunctionQuery::clone() const
     return res;
 }
 
-void ASTCreateFunctionQuery::formatImpl(const IAST::FormatSettings & settings, IAST::FormatState & state, IAST::FormatStateStacked frame) const
+void ASTCreateFunctionQuery::formatImpl(WriteBuffer & ostr, const IAST::FormatSettings & settings, IAST::FormatState & state, IAST::FormatStateStacked frame) const
 {
-    settings.ostr << (settings.hilite ? hilite_keyword : "") << "CREATE ";
+    ostr << (settings.hilite ? hilite_keyword : "") << "CREATE ";
 
     if (or_replace)
-        settings.ostr << "OR REPLACE ";
+        ostr << "OR REPLACE ";
 
-    settings.ostr << "FUNCTION ";
+    ostr << "FUNCTION ";
 
     if (if_not_exists)
-        settings.ostr << "IF NOT EXISTS ";
+        ostr << "IF NOT EXISTS ";
 
-    settings.ostr << (settings.hilite ? hilite_none : "");
+    ostr << (settings.hilite ? hilite_none : "");
 
-    settings.ostr << (settings.hilite ? hilite_identifier : "") << backQuoteIfNeed(getFunctionName()) << (settings.hilite ? hilite_none : "");
+    ostr << (settings.hilite ? hilite_identifier : "") << backQuoteIfNeed(getFunctionName()) << (settings.hilite ? hilite_none : "");
 
-    formatOnCluster(settings);
+    formatOnCluster(ostr, settings);
 
-    settings.ostr << (settings.hilite ? hilite_keyword : "") << " AS " << (settings.hilite ? hilite_none : "");
-    function_core->formatImpl(settings, state, frame);
+    ostr << (settings.hilite ? hilite_keyword : "") << " AS " << (settings.hilite ? hilite_none : "");
+    function_core->formatImpl(ostr, settings, state, frame);
 }
 
 String ASTCreateFunctionQuery::getFunctionName() const

--- a/src/Parsers/ASTCreateFunctionQuery.h
+++ b/src/Parsers/ASTCreateFunctionQuery.h
@@ -20,7 +20,7 @@ public:
 
     ASTPtr clone() const override;
 
-    void formatImpl(const FormatSettings & s, FormatState & state, FormatStateStacked frame) const override;
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & s, FormatState & state, FormatStateStacked frame) const override;
 
     ASTPtr getRewrittenASTWithoutOnCluster(const WithoutOnClusterASTRewriteParams &) const override { return removeOnCluster<ASTCreateFunctionQuery>(clone()); }
 

--- a/src/Parsers/ASTCreateIndexQuery.cpp
+++ b/src/Parsers/ASTCreateIndexQuery.cpp
@@ -30,37 +30,37 @@ ASTPtr ASTCreateIndexQuery::clone() const
     return res;
 }
 
-void ASTCreateIndexQuery::formatQueryImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
+void ASTCreateIndexQuery::formatQueryImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
 {
     frame.need_parens = false;
 
     std::string indent_str = settings.one_line ? "" : std::string(4u * frame.indent, ' ');
 
-    settings.ostr << (settings.hilite ? hilite_keyword : "") << indent_str;
+    ostr << (settings.hilite ? hilite_keyword : "") << indent_str;
 
-    settings.ostr << "CREATE " << (unique ? "UNIQUE " : "") << "INDEX " << (if_not_exists ? "IF NOT EXISTS " : "");
-    index_name->formatImpl(settings, state, frame);
-    settings.ostr << " ON ";
+    ostr << "CREATE " << (unique ? "UNIQUE " : "") << "INDEX " << (if_not_exists ? "IF NOT EXISTS " : "");
+    index_name->formatImpl(ostr, settings, state, frame);
+    ostr << " ON ";
 
-    settings.ostr << (settings.hilite ? hilite_none : "");
+    ostr << (settings.hilite ? hilite_none : "");
 
     if (table)
     {
         if (database)
         {
-            database->formatImpl(settings, state, frame);
-            settings.ostr << '.';
+            database->formatImpl(ostr, settings, state, frame);
+            ostr << '.';
         }
 
         chassert(table);
-        table->formatImpl(settings, state, frame);
+        table->formatImpl(ostr, settings, state, frame);
     }
 
-    formatOnCluster(settings);
+    formatOnCluster(ostr, settings);
 
-    settings.ostr << " ";
+    ostr << " ";
 
-    index_decl->formatImpl(settings, state, frame);
+    index_decl->formatImpl(ostr, settings, state, frame);
 }
 
 ASTPtr ASTCreateIndexQuery::convertToASTAlterCommand() const

--- a/src/Parsers/ASTCreateIndexQuery.h
+++ b/src/Parsers/ASTCreateIndexQuery.h
@@ -37,7 +37,7 @@ public:
     ASTPtr convertToASTAlterCommand() const;
 
 protected:
-    void formatQueryImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
+    void formatQueryImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
 };
 
 }

--- a/src/Parsers/ASTCreateNamedCollectionQuery.cpp
+++ b/src/Parsers/ASTCreateNamedCollectionQuery.cpp
@@ -15,33 +15,33 @@ ASTPtr ASTCreateNamedCollectionQuery::clone() const
     return std::make_shared<ASTCreateNamedCollectionQuery>(*this);
 }
 
-void ASTCreateNamedCollectionQuery::formatImpl(const IAST::FormatSettings & settings, IAST::FormatState &, IAST::FormatStateStacked) const
+void ASTCreateNamedCollectionQuery::formatImpl(WriteBuffer & ostr, const IAST::FormatSettings & settings, IAST::FormatState &, IAST::FormatStateStacked) const
 {
-    settings.ostr << (settings.hilite ? hilite_keyword : "") << "CREATE NAMED COLLECTION ";
+    ostr << (settings.hilite ? hilite_keyword : "") << "CREATE NAMED COLLECTION ";
     if (if_not_exists)
-        settings.ostr << "IF NOT EXISTS ";
-    settings.ostr << (settings.hilite ? hilite_identifier : "") << backQuoteIfNeed(collection_name) << (settings.hilite ? hilite_none : "");
+        ostr << "IF NOT EXISTS ";
+    ostr << (settings.hilite ? hilite_identifier : "") << backQuoteIfNeed(collection_name) << (settings.hilite ? hilite_none : "");
 
-    formatOnCluster(settings);
+    formatOnCluster(ostr, settings);
 
-    settings.ostr << (settings.hilite ? hilite_keyword : "") << " AS " << (settings.hilite ? hilite_none : "");
+    ostr << (settings.hilite ? hilite_keyword : "") << " AS " << (settings.hilite ? hilite_none : "");
     bool first = true;
     for (const auto & change : changes)
     {
         if (!first)
-            settings.ostr << ", ";
+            ostr << ", ";
         else
             first = false;
 
-        formatSettingName(change.name, settings.ostr);
+        formatSettingName(change.name, ostr);
 
         if (settings.show_secrets)
-            settings.ostr << " = " << applyVisitor(FieldVisitorToString(), change.value);
+            ostr << " = " << applyVisitor(FieldVisitorToString(), change.value);
         else
-            settings.ostr << " = '[HIDDEN]'";
+            ostr << " = '[HIDDEN]'";
         auto override_value = overridability.find(change.name);
         if (override_value != overridability.end())
-            settings.ostr << " " << (override_value->second ? "" : "NOT ") << "OVERRIDABLE";
+            ostr << " " << (override_value->second ? "" : "NOT ") << "OVERRIDABLE";
     }
 }
 

--- a/src/Parsers/ASTCreateNamedCollectionQuery.h
+++ b/src/Parsers/ASTCreateNamedCollectionQuery.h
@@ -20,7 +20,7 @@ public:
 
     ASTPtr clone() const override;
 
-    void formatImpl(const FormatSettings & s, FormatState & state, FormatStateStacked frame) const override;
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & s, FormatState & state, FormatStateStacked frame) const override;
 
     ASTPtr getRewrittenASTWithoutOnCluster(const WithoutOnClusterASTRewriteParams &) const override { return removeOnCluster<ASTCreateNamedCollectionQuery>(clone()); }
 

--- a/src/Parsers/ASTCreateQuery.cpp
+++ b/src/Parsers/ASTCreateQuery.cpp
@@ -14,33 +14,33 @@
 namespace DB
 {
 
-void ASTSQLSecurity::formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
+void ASTSQLSecurity::formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
 {
     if (!type)
         return;
 
     if (definer || is_definer_current_user)
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << "DEFINER" << (settings.hilite ? hilite_none : "");
-        settings.ostr << " = ";
+        ostr << (settings.hilite ? hilite_keyword : "") << "DEFINER" << (settings.hilite ? hilite_none : "");
+        ostr << " = ";
         if (definer)
-            definer->formatImpl(settings, state, frame);
+            definer->formatImpl(ostr, settings, state, frame);
         else
-            settings.ostr << "CURRENT_USER";
-        settings.ostr << " ";
+            ostr << "CURRENT_USER";
+        ostr << " ";
     }
 
-    settings.ostr << (settings.hilite ? hilite_keyword : "") << "SQL SECURITY" << (settings.hilite ? hilite_none : "");
+    ostr << (settings.hilite ? hilite_keyword : "") << "SQL SECURITY" << (settings.hilite ? hilite_none : "");
     switch (*type)
     {
         case SQLSecurityType::INVOKER:
-            settings.ostr << " INVOKER";
+            ostr << " INVOKER";
             break;
         case SQLSecurityType::DEFINER:
-            settings.ostr << " DEFINER";
+            ostr << " DEFINER";
             break;
         case SQLSecurityType::NONE:
-            settings.ostr << " NONE";
+            ostr << " NONE";
             break;
     }
 }
@@ -69,42 +69,42 @@ ASTPtr ASTStorage::clone() const
     return res;
 }
 
-void ASTStorage::formatImpl(const FormatSettings & s, FormatState & state, FormatStateStacked frame) const
+void ASTStorage::formatImpl(WriteBuffer & ostr, const FormatSettings & s, FormatState & state, FormatStateStacked frame) const
 {
     if (engine)
     {
-        s.ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << "ENGINE" << (s.hilite ? hilite_none : "") << " = ";
-        engine->formatImpl(s, state, frame);
+        ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << "ENGINE" << (s.hilite ? hilite_none : "") << " = ";
+        engine->formatImpl(ostr, s, state, frame);
     }
     if (partition_by)
     {
-        s.ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << "PARTITION BY " << (s.hilite ? hilite_none : "");
-        partition_by->formatImpl(s, state, frame);
+        ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << "PARTITION BY " << (s.hilite ? hilite_none : "");
+        partition_by->formatImpl(ostr, s, state, frame);
     }
     if (primary_key)
     {
-        s.ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << "PRIMARY KEY " << (s.hilite ? hilite_none : "");
-        primary_key->formatImpl(s, state, frame);
+        ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << "PRIMARY KEY " << (s.hilite ? hilite_none : "");
+        primary_key->formatImpl(ostr, s, state, frame);
     }
     if (order_by)
     {
-        s.ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << "ORDER BY " << (s.hilite ? hilite_none : "");
-        order_by->formatImpl(s, state, frame);
+        ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << "ORDER BY " << (s.hilite ? hilite_none : "");
+        order_by->formatImpl(ostr, s, state, frame);
     }
     if (sample_by)
     {
-        s.ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << "SAMPLE BY " << (s.hilite ? hilite_none : "");
-        sample_by->formatImpl(s, state, frame);
+        ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << "SAMPLE BY " << (s.hilite ? hilite_none : "");
+        sample_by->formatImpl(ostr, s, state, frame);
     }
     if (ttl_table)
     {
-        s.ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << "TTL " << (s.hilite ? hilite_none : "");
-        ttl_table->formatImpl(s, state, frame);
+        ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << "TTL " << (s.hilite ? hilite_none : "");
+        ttl_table->formatImpl(ostr, s, state, frame);
     }
     if (settings)
     {
-        s.ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << "SETTINGS " << (s.hilite ? hilite_none : "");
-        settings->formatImpl(s, state, frame);
+        ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << "SETTINGS " << (s.hilite ? hilite_none : "");
+        settings->formatImpl(ostr, s, state, frame);
     }
 }
 
@@ -124,7 +124,7 @@ public:
 
     ASTPtr clone() const override;
 
-    void formatImpl(const FormatSettings & s, FormatState & state, FormatStateStacked frame) const override;
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & s, FormatState & state, FormatStateStacked frame) const override;
 
     void forEachPointerToChild(std::function<void(void**)> f) override
     {
@@ -141,20 +141,20 @@ ASTPtr ASTColumnsElement::clone() const
     return res;
 }
 
-void ASTColumnsElement::formatImpl(const FormatSettings & s, FormatState & state, FormatStateStacked frame) const
+void ASTColumnsElement::formatImpl(WriteBuffer & ostr, const FormatSettings & s, FormatState & state, FormatStateStacked frame) const
 {
     if (!elem)
         return;
 
     if (prefix.empty())
     {
-        elem->formatImpl(s, state, frame);
+        elem->formatImpl(ostr, s, state, frame);
         return;
     }
 
-    s.ostr << (s.hilite ? hilite_keyword : "") << prefix << (s.hilite ? hilite_none : "");
-    s.ostr << ' ';
-    elem->formatImpl(s, state, frame);
+    ostr << (s.hilite ? hilite_keyword : "") << prefix << (s.hilite ? hilite_none : "");
+    ostr << ' ';
+    elem->formatImpl(ostr, s, state, frame);
 }
 
 
@@ -178,7 +178,7 @@ ASTPtr ASTColumns::clone() const
     return res;
 }
 
-void ASTColumns::formatImpl(const FormatSettings & s, FormatState & state, FormatStateStacked frame) const
+void ASTColumns::formatImpl(WriteBuffer & ostr, const FormatSettings & s, FormatState & state, FormatStateStacked frame) const
 {
     ASTExpressionList list;
 
@@ -226,9 +226,9 @@ void ASTColumns::formatImpl(const FormatSettings & s, FormatState & state, Forma
     if (!list.children.empty())
     {
         if (s.one_line)
-            list.formatImpl(s, state, frame);
+            list.formatImpl(ostr, s, state, frame);
         else
-            list.formatImplMultiline(s, state, frame);
+            list.formatImplMultiline(ostr, s, state, frame);
     }
 }
 
@@ -279,40 +279,40 @@ String ASTCreateQuery::getID(char delim) const
     return res;
 }
 
-void ASTCreateQuery::formatQueryImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
+void ASTCreateQuery::formatQueryImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
 {
     frame.need_parens = false;
 
     if (database && !table)
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "")
+        ostr << (settings.hilite ? hilite_keyword : "")
             << (attach ? "ATTACH DATABASE " : "CREATE DATABASE ")
             << (if_not_exists ? "IF NOT EXISTS " : "")
             << (settings.hilite ? hilite_none : "");
 
-        database->formatImpl(settings, state, frame);
+        database->formatImpl(ostr, settings, state, frame);
 
         if (uuid != UUIDHelpers::Nil)
         {
-            settings.ostr << (settings.hilite ? hilite_keyword : "") << " UUID " << (settings.hilite ? hilite_none : "")
+            ostr << (settings.hilite ? hilite_keyword : "") << " UUID " << (settings.hilite ? hilite_none : "")
                           << quoteString(toString(uuid));
         }
 
-        formatOnCluster(settings);
+        formatOnCluster(ostr, settings);
 
         if (storage)
-            storage->formatImpl(settings, state, frame);
+            storage->formatImpl(ostr, settings, state, frame);
 
         if (table_overrides)
         {
-            settings.ostr << settings.nl_or_ws;
-            table_overrides->formatImpl(settings, state, frame);
+            ostr << settings.nl_or_ws;
+            table_overrides->formatImpl(ostr, settings, state, frame);
         }
 
         if (comment)
         {
-            settings.ostr << (settings.hilite ? hilite_keyword : "") << settings.nl_or_ws << "COMMENT " << (settings.hilite ? hilite_none : "");
-            comment->formatImpl(settings, state, frame);
+            ostr << (settings.hilite ? hilite_keyword : "") << settings.nl_or_ws << "COMMENT " << (settings.hilite ? hilite_none : "");
+            comment->formatImpl(ostr, settings, state, frame);
         }
 
         return;
@@ -340,40 +340,40 @@ void ASTCreateQuery::formatQueryImpl(const FormatSettings & settings, FormatStat
         else if (is_window_view)
             what = "WINDOW VIEW";
 
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << action << (settings.hilite ? hilite_none : "");
-        settings.ostr << " ";
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << (temporary ? "TEMPORARY " : "")
+        ostr << (settings.hilite ? hilite_keyword : "") << action << (settings.hilite ? hilite_none : "");
+        ostr << " ";
+        ostr << (settings.hilite ? hilite_keyword : "") << (temporary ? "TEMPORARY " : "")
                 << what << " "
                 << (if_not_exists ? "IF NOT EXISTS " : "")
             << (settings.hilite ? hilite_none : "");
 
         if (database)
         {
-            database->formatImpl(settings, state, frame);
-            settings.ostr << '.';
+            database->formatImpl(ostr, settings, state, frame);
+            ostr << '.';
         }
 
         chassert(table);
-        table->formatImpl(settings, state, frame);
+        table->formatImpl(ostr, settings, state, frame);
 
         if (uuid != UUIDHelpers::Nil)
-            settings.ostr << (settings.hilite ? hilite_keyword : "") << " UUID " << (settings.hilite ? hilite_none : "")
+            ostr << (settings.hilite ? hilite_keyword : "") << " UUID " << (settings.hilite ? hilite_none : "")
                           << quoteString(toString(uuid));
 
         assert(attach || !attach_from_path);
         if (attach_from_path)
-            settings.ostr << (settings.hilite ? hilite_keyword : "") << " FROM " << (settings.hilite ? hilite_none : "")
+            ostr << (settings.hilite ? hilite_keyword : "") << " FROM " << (settings.hilite ? hilite_none : "")
                           << quoteString(*attach_from_path);
 
         if (attach_as_replicated.has_value())
         {
             if (attach_as_replicated.value())
-                settings.ostr << (settings.hilite ? hilite_keyword : "") << " AS REPLICATED" << (settings.hilite ? hilite_none : "");
+                ostr << (settings.hilite ? hilite_keyword : "") << " AS REPLICATED" << (settings.hilite ? hilite_none : "");
             else
-                settings.ostr << (settings.hilite ? hilite_keyword : "") << " AS NOT REPLICATED" << (settings.hilite ? hilite_none : "");
+                ostr << (settings.hilite ? hilite_keyword : "") << " AS NOT REPLICATED" << (settings.hilite ? hilite_none : "");
         }
 
-        formatOnCluster(settings);
+        formatOnCluster(ostr, settings);
     }
     else
     {
@@ -386,33 +386,33 @@ void ASTCreateQuery::formatQueryImpl(const FormatSettings & settings, FormatStat
             action = "REPLACE";
 
         /// Always DICTIONARY
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << action << " DICTIONARY "
+        ostr << (settings.hilite ? hilite_keyword : "") << action << " DICTIONARY "
                       << (if_not_exists ? "IF NOT EXISTS " : "") << (settings.hilite ? hilite_none : "");
 
         if (database)
         {
-            database->formatImpl(settings, state, frame);
-            settings.ostr << '.';
+            database->formatImpl(ostr, settings, state, frame);
+            ostr << '.';
         }
 
         chassert(table);
-        table->formatImpl(settings, state, frame);
+        table->formatImpl(ostr, settings, state, frame);
 
         if (uuid != UUIDHelpers::Nil)
-            settings.ostr << (settings.hilite ? hilite_keyword : "") << " UUID " << (settings.hilite ? hilite_none : "")
+            ostr << (settings.hilite ? hilite_keyword : "") << " UUID " << (settings.hilite ? hilite_none : "")
                           << quoteString(toString(uuid));
-        formatOnCluster(settings);
+        formatOnCluster(ostr, settings);
     }
 
     if (refresh_strategy)
     {
-        settings.ostr << settings.nl_or_ws;
-        refresh_strategy->formatImpl(settings, state, frame);
+        ostr << settings.nl_or_ws;
+        refresh_strategy->formatImpl(ostr, settings, state, frame);
     }
 
     if (auto to_table_id = getTargetTableID(ViewTarget::To))
     {
-        settings.ostr <<  " " << (settings.hilite ? hilite_keyword : "") << toStringView(Keyword::TO)
+        ostr <<  " " << (settings.hilite ? hilite_keyword : "") << toStringView(Keyword::TO)
                       << (settings.hilite ? hilite_none : "") << " "
                       << (!to_table_id.database_name.empty() ? backQuoteIfNeed(to_table_id.database_name) + "." : "")
                       << backQuoteIfNeed(to_table_id.table_name);
@@ -420,7 +420,7 @@ void ASTCreateQuery::formatQueryImpl(const FormatSettings & settings, FormatStat
 
     if (auto to_inner_uuid = getTargetInnerUUID(ViewTarget::To); to_inner_uuid != UUIDHelpers::Nil)
     {
-        settings.ostr << " " << (settings.hilite ? hilite_keyword : "") << toStringView(Keyword::TO_INNER_UUID)
+        ostr << " " << (settings.hilite ? hilite_keyword : "") << toStringView(Keyword::TO_INNER_UUID)
                       << (settings.hilite ? hilite_none : "") << " " << quoteString(toString(to_inner_uuid));
     }
 
@@ -430,7 +430,7 @@ void ASTCreateQuery::formatQueryImpl(const FormatSettings & settings, FormatStat
         if (!should_add_empty)
             return;
         should_add_empty = false;
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << " EMPTY" << (settings.hilite ? hilite_none : "");
+        ostr << (settings.hilite ? hilite_keyword : "") << " EMPTY" << (settings.hilite ? hilite_none : "");
     };
 
     bool should_add_clone = is_clone_as;
@@ -439,14 +439,14 @@ void ASTCreateQuery::formatQueryImpl(const FormatSettings & settings, FormatStat
         if (!should_add_clone)
             return;
         should_add_clone = false;
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << " CLONE" << (settings.hilite ? hilite_none : "");
+        ostr << (settings.hilite ? hilite_keyword : "") << " CLONE" << (settings.hilite ? hilite_none : "");
     };
 
     if (!as_table.empty())
     {
         add_empty_if_needed();
         add_clone_if_needed();
-        settings.ostr
+        ostr
             << (settings.hilite ? hilite_keyword : "") << " AS " << (settings.hilite ? hilite_none : "")
             << (!as_database.empty() ? backQuoteIfNeed(as_database) + "." : "") << backQuoteIfNeed(as_table);
     }
@@ -456,108 +456,108 @@ void ASTCreateQuery::formatQueryImpl(const FormatSettings & settings, FormatStat
         if (columns_list && !columns_list->empty())
         {
             frame.expression_list_always_start_on_new_line = true;
-            settings.ostr << (settings.one_line ? " (" : "\n(");
+            ostr << (settings.one_line ? " (" : "\n(");
             FormatStateStacked frame_nested = frame;
-            columns_list->formatImpl(settings, state, frame_nested);
-            settings.ostr << (settings.one_line ? ")" : "\n)");
+            columns_list->formatImpl(ostr, settings, state, frame_nested);
+            ostr << (settings.one_line ? ")" : "\n)");
             frame.expression_list_always_start_on_new_line = false;
         }
 
         add_empty_if_needed();
         add_clone_if_needed();
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << " AS " << (settings.hilite ? hilite_none : "");
-        as_table_function->formatImpl(settings, state, frame);
+        ostr << (settings.hilite ? hilite_keyword : "") << " AS " << (settings.hilite ? hilite_none : "");
+        as_table_function->formatImpl(ostr, settings, state, frame);
     }
 
     frame.expression_list_always_start_on_new_line = true;
 
     if (columns_list && !columns_list->empty() && !as_table_function)
     {
-        settings.ostr << (settings.one_line ? " (" : "\n(");
+        ostr << (settings.one_line ? " (" : "\n(");
         FormatStateStacked frame_nested = frame;
-        columns_list->formatImpl(settings, state, frame_nested);
-        settings.ostr << (settings.one_line ? ")" : "\n)");
+        columns_list->formatImpl(ostr, settings, state, frame_nested);
+        ostr << (settings.one_line ? ")" : "\n)");
     }
 
     if (dictionary_attributes_list)
     {
-        settings.ostr << (settings.one_line ? " (" : "\n(");
+        ostr << (settings.one_line ? " (" : "\n(");
         FormatStateStacked frame_nested = frame;
         if (settings.one_line)
-            dictionary_attributes_list->formatImpl(settings, state, frame_nested);
+            dictionary_attributes_list->formatImpl(ostr, settings, state, frame_nested);
         else
-            dictionary_attributes_list->formatImplMultiline(settings, state, frame_nested);
-        settings.ostr << (settings.one_line ? ")" : "\n)");
+            dictionary_attributes_list->formatImplMultiline(ostr, settings, state, frame_nested);
+        ostr << (settings.one_line ? ")" : "\n)");
     }
 
     frame.expression_list_always_start_on_new_line = false;
 
     if (storage)
-        storage->formatImpl(settings, state, frame);
+        storage->formatImpl(ostr, settings, state, frame);
 
     if (auto inner_storage = getTargetInnerEngine(ViewTarget::Inner))
     {
-        settings.ostr << " " << (settings.hilite ? hilite_keyword : "") << toStringView(Keyword::INNER) << (settings.hilite ? hilite_none : "");
-        inner_storage->formatImpl(settings, state, frame);
+        ostr << " " << (settings.hilite ? hilite_keyword : "") << toStringView(Keyword::INNER) << (settings.hilite ? hilite_none : "");
+        inner_storage->formatImpl(ostr, settings, state, frame);
     }
 
     if (auto to_storage = getTargetInnerEngine(ViewTarget::To))
-        to_storage->formatImpl(settings, state, frame);
+        to_storage->formatImpl(ostr, settings, state, frame);
 
     if (targets)
     {
-        targets->formatTarget(ViewTarget::Data, settings, state, frame);
-        targets->formatTarget(ViewTarget::Tags, settings, state, frame);
-        targets->formatTarget(ViewTarget::Metrics, settings, state, frame);
+        targets->formatTarget(ViewTarget::Data, ostr, settings, state, frame);
+        targets->formatTarget(ViewTarget::Tags, ostr, settings, state, frame);
+        targets->formatTarget(ViewTarget::Metrics, ostr, settings, state, frame);
     }
 
     if (dictionary)
-        dictionary->formatImpl(settings, state, frame);
+        dictionary->formatImpl(ostr, settings, state, frame);
 
     if (is_watermark_strictly_ascending)
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << " WATERMARK STRICTLY_ASCENDING" << (settings.hilite ? hilite_none : "");
+        ostr << (settings.hilite ? hilite_keyword : "") << " WATERMARK STRICTLY_ASCENDING" << (settings.hilite ? hilite_none : "");
     }
     else if (is_watermark_ascending)
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << " WATERMARK ASCENDING" << (settings.hilite ? hilite_none : "");
+        ostr << (settings.hilite ? hilite_keyword : "") << " WATERMARK ASCENDING" << (settings.hilite ? hilite_none : "");
     }
     else if (is_watermark_bounded)
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << " WATERMARK " << (settings.hilite ? hilite_none : "");
-        watermark_function->formatImpl(settings, state, frame);
+        ostr << (settings.hilite ? hilite_keyword : "") << " WATERMARK " << (settings.hilite ? hilite_none : "");
+        watermark_function->formatImpl(ostr, settings, state, frame);
     }
 
     if (allowed_lateness)
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << " ALLOWED_LATENESS " << (settings.hilite ? hilite_none : "");
-        lateness_function->formatImpl(settings, state, frame);
+        ostr << (settings.hilite ? hilite_keyword : "") << " ALLOWED_LATENESS " << (settings.hilite ? hilite_none : "");
+        lateness_function->formatImpl(ostr, settings, state, frame);
     }
 
     if (is_populate)
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << " POPULATE" << (settings.hilite ? hilite_none : "");
+        ostr << (settings.hilite ? hilite_keyword : "") << " POPULATE" << (settings.hilite ? hilite_none : "");
 
     add_empty_if_needed();
 
     if (sql_security && supportSQLSecurity() && sql_security->as<ASTSQLSecurity &>().type.has_value())
     {
-        settings.ostr << settings.nl_or_ws;
-        sql_security->formatImpl(settings, state, frame);
+        ostr << settings.nl_or_ws;
+        sql_security->formatImpl(ostr, settings, state, frame);
     }
 
     if (select)
     {
-        settings.ostr << settings.nl_or_ws;
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << "AS "
+        ostr << settings.nl_or_ws;
+        ostr << (settings.hilite ? hilite_keyword : "") << "AS "
                       << (comment ? "(" : "") << (settings.hilite ? hilite_none : "");
-        select->formatImpl(settings, state, frame);
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << (comment ? ")" : "") << (settings.hilite ? hilite_none : "");
+        select->formatImpl(ostr, settings, state, frame);
+        ostr << (settings.hilite ? hilite_keyword : "") << (comment ? ")" : "") << (settings.hilite ? hilite_none : "");
     }
 
     if (comment)
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << settings.nl_or_ws << "COMMENT " << (settings.hilite ? hilite_none : "");
-        comment->formatImpl(settings, state, frame);
+        ostr << (settings.hilite ? hilite_keyword : "") << settings.nl_or_ws << "COMMENT " << (settings.hilite ? hilite_none : "");
+        comment->formatImpl(ostr, settings, state, frame);
     }
 }
 

--- a/src/Parsers/ASTCreateQuery.h
+++ b/src/Parsers/ASTCreateQuery.h
@@ -34,7 +34,7 @@ public:
 
     ASTPtr clone() const override;
 
-    void formatImpl(const FormatSettings & s, FormatState & state, FormatStateStacked frame) const override;
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & s, FormatState & state, FormatStateStacked frame) const override;
 
     bool isExtendedStorageDefinition() const;
 
@@ -67,7 +67,7 @@ public:
 
     ASTPtr clone() const override;
 
-    void formatImpl(const FormatSettings & s, FormatState & state, FormatStateStacked frame) const override;
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & s, FormatState & state, FormatStateStacked frame) const override;
 
     bool empty() const
     {
@@ -179,7 +179,7 @@ public:
     bool is_materialized_view_with_inner_table() const { return is_materialized_view && !hasTargetTableID(ViewTarget::To); }
 
 protected:
-    void formatQueryImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
+    void formatQueryImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
 
     void forEachPointerToChild(std::function<void(void**)> f) override
     {

--- a/src/Parsers/ASTCreateResourceQuery.cpp
+++ b/src/Parsers/ASTCreateResourceQuery.cpp
@@ -20,31 +20,31 @@ ASTPtr ASTCreateResourceQuery::clone() const
     return res;
 }
 
-void ASTCreateResourceQuery::formatImpl(const IAST::FormatSettings & format, IAST::FormatState &, IAST::FormatStateStacked) const
+void ASTCreateResourceQuery::formatImpl(WriteBuffer & ostr, const IAST::FormatSettings & format, IAST::FormatState &, IAST::FormatStateStacked) const
 {
-    format.ostr << (format.hilite ? hilite_keyword : "") << "CREATE ";
+    ostr << (format.hilite ? hilite_keyword : "") << "CREATE ";
 
     if (or_replace)
-        format.ostr << "OR REPLACE ";
+        ostr << "OR REPLACE ";
 
-    format.ostr << "RESOURCE ";
+    ostr << "RESOURCE ";
 
     if (if_not_exists)
-        format.ostr << "IF NOT EXISTS ";
+        ostr << "IF NOT EXISTS ";
 
-    format.ostr << (format.hilite ? hilite_none : "");
+    ostr << (format.hilite ? hilite_none : "");
 
-    format.ostr << (format.hilite ? hilite_identifier : "") << backQuoteIfNeed(getResourceName()) << (format.hilite ? hilite_none : "");
+    ostr << (format.hilite ? hilite_identifier : "") << backQuoteIfNeed(getResourceName()) << (format.hilite ? hilite_none : "");
 
-    formatOnCluster(format);
+    formatOnCluster(ostr, format);
 
-    format.ostr << " (";
+    ostr << " (";
 
     bool first = true;
     for (const auto & operation : operations)
     {
         if (!first)
-            format.ostr << ", ";
+            ostr << ", ";
         else
             first = false;
 
@@ -52,25 +52,25 @@ void ASTCreateResourceQuery::formatImpl(const IAST::FormatSettings & format, IAS
         {
             case AccessMode::Read:
             {
-                format.ostr << (format.hilite ? hilite_keyword : "") << "READ ";
+                ostr << (format.hilite ? hilite_keyword : "") << "READ ";
                 break;
             }
             case AccessMode::Write:
             {
-                format.ostr << (format.hilite ? hilite_keyword : "") << "WRITE ";
+                ostr << (format.hilite ? hilite_keyword : "") << "WRITE ";
                 break;
             }
         }
         if (operation.disk)
         {
-            format.ostr << "DISK " << (format.hilite ? hilite_none : "");
-            format.ostr << (format.hilite ? hilite_identifier : "") << backQuoteIfNeed(*operation.disk) << (format.hilite ? hilite_none : "");
+            ostr << "DISK " << (format.hilite ? hilite_none : "");
+            ostr << (format.hilite ? hilite_identifier : "") << backQuoteIfNeed(*operation.disk) << (format.hilite ? hilite_none : "");
         }
         else
-            format.ostr << "ANY DISK" << (format.hilite ? hilite_none : "");
+            ostr << "ANY DISK" << (format.hilite ? hilite_none : "");
     }
 
-    format.ostr << ")";
+    ostr << ")";
 }
 
 String ASTCreateResourceQuery::getResourceName() const

--- a/src/Parsers/ASTCreateResourceQuery.h
+++ b/src/Parsers/ASTCreateResourceQuery.h
@@ -36,7 +36,7 @@ public:
 
     ASTPtr clone() const override;
 
-    void formatImpl(const FormatSettings & format, FormatState & state, FormatStateStacked frame) const override;
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & format, FormatState & state, FormatStateStacked frame) const override;
 
     ASTPtr getRewrittenASTWithoutOnCluster(const WithoutOnClusterASTRewriteParams &) const override { return removeOnCluster<ASTCreateResourceQuery>(clone()); }
 

--- a/src/Parsers/ASTCreateWorkloadQuery.cpp
+++ b/src/Parsers/ASTCreateWorkloadQuery.cpp
@@ -27,47 +27,47 @@ ASTPtr ASTCreateWorkloadQuery::clone() const
     return res;
 }
 
-void ASTCreateWorkloadQuery::formatImpl(const IAST::FormatSettings & format, IAST::FormatState &, IAST::FormatStateStacked) const
+void ASTCreateWorkloadQuery::formatImpl(WriteBuffer & ostr, const IAST::FormatSettings & format, IAST::FormatState &, IAST::FormatStateStacked) const
 {
-    format.ostr << (format.hilite ? hilite_keyword : "") << "CREATE ";
+    ostr << (format.hilite ? hilite_keyword : "") << "CREATE ";
 
     if (or_replace)
-        format.ostr << "OR REPLACE ";
+        ostr << "OR REPLACE ";
 
-    format.ostr << "WORKLOAD ";
+    ostr << "WORKLOAD ";
 
     if (if_not_exists)
-        format.ostr << "IF NOT EXISTS ";
+        ostr << "IF NOT EXISTS ";
 
-    format.ostr << (format.hilite ? hilite_none : "");
+    ostr << (format.hilite ? hilite_none : "");
 
-    format.ostr << (format.hilite ? hilite_identifier : "") << backQuoteIfNeed(getWorkloadName()) << (format.hilite ? hilite_none : "");
+    ostr << (format.hilite ? hilite_identifier : "") << backQuoteIfNeed(getWorkloadName()) << (format.hilite ? hilite_none : "");
 
-    formatOnCluster(format);
+    formatOnCluster(ostr, format);
 
     if (hasParent())
     {
-        format.ostr << (format.hilite ? hilite_keyword : "") << " IN " << (format.hilite ? hilite_none : "");
-        format.ostr << (format.hilite ? hilite_identifier : "") << backQuoteIfNeed(getWorkloadParent()) << (format.hilite ? hilite_none : "");
+        ostr << (format.hilite ? hilite_keyword : "") << " IN " << (format.hilite ? hilite_none : "");
+        ostr << (format.hilite ? hilite_identifier : "") << backQuoteIfNeed(getWorkloadParent()) << (format.hilite ? hilite_none : "");
     }
 
     if (!changes.empty())
     {
-        format.ostr << ' ' << (format.hilite ? hilite_keyword : "") << "SETTINGS" << (format.hilite ? hilite_none : "") << ' ';
+        ostr << ' ' << (format.hilite ? hilite_keyword : "") << "SETTINGS" << (format.hilite ? hilite_none : "") << ' ';
 
         bool first = true;
 
         for (const auto & change : changes)
         {
             if (!first)
-                format.ostr << ", ";
+                ostr << ", ";
             else
                 first = false;
-            format.ostr << change.name << " = " << applyVisitor(FieldVisitorToString(), change.value);
+            ostr << change.name << " = " << applyVisitor(FieldVisitorToString(), change.value);
             if (!change.resource.empty())
             {
-                format.ostr << ' ' << (format.hilite ? hilite_keyword : "") << "FOR" << (format.hilite ? hilite_none : "") << ' ';
-                format.ostr << (format.hilite ? hilite_identifier : "") << backQuoteIfNeed(change.resource) << (format.hilite ? hilite_none : "");
+                ostr << ' ' << (format.hilite ? hilite_keyword : "") << "FOR" << (format.hilite ? hilite_none : "") << ' ';
+                ostr << (format.hilite ? hilite_identifier : "") << backQuoteIfNeed(change.resource) << (format.hilite ? hilite_none : "");
             }
         }
     }

--- a/src/Parsers/ASTCreateWorkloadQuery.h
+++ b/src/Parsers/ASTCreateWorkloadQuery.h
@@ -39,7 +39,7 @@ public:
 
     ASTPtr clone() const override;
 
-    void formatImpl(const FormatSettings & format, FormatState & state, FormatStateStacked frame) const override;
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & format, FormatState & state, FormatStateStacked frame) const override;
 
     ASTPtr getRewrittenASTWithoutOnCluster(const WithoutOnClusterASTRewriteParams &) const override { return removeOnCluster<ASTCreateWorkloadQuery>(clone()); }
 

--- a/src/Parsers/ASTDataType.cpp
+++ b/src/Parsers/ASTDataType.cpp
@@ -32,13 +32,13 @@ void ASTDataType::updateTreeHashImpl(SipHash & hash_state, bool) const
     /// Children are hashed automatically.
 }
 
-void ASTDataType::formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
+void ASTDataType::formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
 {
-    settings.ostr << (settings.hilite ? hilite_function : "") << name;
+    ostr << (settings.hilite ? hilite_function : "") << name;
 
     if (arguments && !arguments->children.empty())
     {
-        settings.ostr << '(' << (settings.hilite ? hilite_none : "");
+        ostr << '(' << (settings.hilite ? hilite_none : "");
 
         if (!settings.one_line && settings.print_pretty_type_names && name == "Tuple")
         {
@@ -47,21 +47,21 @@ void ASTDataType::formatImpl(const FormatSettings & settings, FormatState & stat
             for (size_t i = 0, size = arguments->children.size(); i < size; ++i)
             {
                 if (i != 0)
-                    settings.ostr << ',';
-                settings.ostr << indent_str;
-                arguments->children[i]->formatImpl(settings, state, frame);
+                    ostr << ',';
+                ostr << indent_str;
+                arguments->children[i]->formatImpl(ostr, settings, state, frame);
             }
         }
         else
         {
             frame.expression_list_prepend_whitespace = false;
-            arguments->formatImpl(settings, state, frame);
+            arguments->formatImpl(ostr, settings, state, frame);
         }
 
-        settings.ostr << (settings.hilite ? hilite_function : "") << ')';
+        ostr << (settings.hilite ? hilite_function : "") << ')';
     }
 
-    settings.ostr << (settings.hilite ? hilite_none : "");
+    ostr << (settings.hilite ? hilite_none : "");
 }
 
 }

--- a/src/Parsers/ASTDataType.h
+++ b/src/Parsers/ASTDataType.h
@@ -16,7 +16,7 @@ public:
     String getID(char delim) const override;
     ASTPtr clone() const override;
     void updateTreeHashImpl(SipHash & hash_state, bool ignore_aliases) const override;
-    void formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
 };
 
 template <typename... Args>

--- a/src/Parsers/ASTDatabaseOrNone.cpp
+++ b/src/Parsers/ASTDatabaseOrNone.cpp
@@ -4,14 +4,14 @@
 
 namespace DB
 {
-void ASTDatabaseOrNone::formatImpl(const FormatSettings & settings, FormatState &, FormatStateStacked) const
+void ASTDatabaseOrNone::formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState &, FormatStateStacked) const
 {
     if (none)
     {
-        settings.ostr << (settings.hilite ? IAST::hilite_keyword : "") << "NONE" << (settings.hilite ? IAST::hilite_none : "");
+        ostr << (settings.hilite ? IAST::hilite_keyword : "") << "NONE" << (settings.hilite ? IAST::hilite_none : "");
         return;
     }
-    settings.ostr << backQuoteIfNeed(database_name);
+    ostr << backQuoteIfNeed(database_name);
 }
 
 }

--- a/src/Parsers/ASTDatabaseOrNone.h
+++ b/src/Parsers/ASTDatabaseOrNone.h
@@ -14,7 +14,7 @@ public:
     bool isNone() const { return none; }
     String getID(char) const override { return "DatabaseOrNone"; }
     ASTPtr clone() const override { return std::make_shared<ASTDatabaseOrNone>(*this); }
-    void formatImpl(const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
 };
 }
 

--- a/src/Parsers/ASTDeleteQuery.cpp
+++ b/src/Parsers/ASTDeleteQuery.cpp
@@ -30,29 +30,29 @@ ASTPtr ASTDeleteQuery::clone() const
     return res;
 }
 
-void ASTDeleteQuery::formatQueryImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
+void ASTDeleteQuery::formatQueryImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
 {
-    settings.ostr << (settings.hilite ? hilite_keyword : "") << "DELETE FROM " << (settings.hilite ? hilite_none : "");
+    ostr << (settings.hilite ? hilite_keyword : "") << "DELETE FROM " << (settings.hilite ? hilite_none : "");
 
     if (database)
     {
-        database->formatImpl(settings, state, frame);
-        settings.ostr << '.';
+        database->formatImpl(ostr, settings, state, frame);
+        ostr << '.';
     }
 
     chassert(table);
-    table->formatImpl(settings, state, frame);
+    table->formatImpl(ostr, settings, state, frame);
 
-    formatOnCluster(settings);
+    formatOnCluster(ostr, settings);
 
     if (partition)
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << " IN PARTITION " << (settings.hilite ? hilite_none : "");
-        partition->formatImpl(settings, state, frame);
+        ostr << (settings.hilite ? hilite_keyword : "") << " IN PARTITION " << (settings.hilite ? hilite_none : "");
+        partition->formatImpl(ostr, settings, state, frame);
     }
 
-    settings.ostr << (settings.hilite ? hilite_keyword : "") << " WHERE " << (settings.hilite ? hilite_none : "");
-    predicate->formatImpl(settings, state, frame);
+    ostr << (settings.hilite ? hilite_keyword : "") << " WHERE " << (settings.hilite ? hilite_none : "");
+    predicate->formatImpl(ostr, settings, state, frame);
 }
 
 }

--- a/src/Parsers/ASTDeleteQuery.h
+++ b/src/Parsers/ASTDeleteQuery.h
@@ -27,7 +27,7 @@ public:
     ASTPtr predicate;
 
 protected:
-    void formatQueryImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
+    void formatQueryImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
 };
 
 }

--- a/src/Parsers/ASTDescribeCacheQuery.cpp
+++ b/src/Parsers/ASTDescribeCacheQuery.cpp
@@ -14,9 +14,9 @@ ASTPtr ASTDescribeCacheQuery::clone() const
     return res;
 }
 
-void ASTDescribeCacheQuery::formatQueryImpl(const FormatSettings & settings, FormatState &, FormatStateStacked) const
+void ASTDescribeCacheQuery::formatQueryImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState &, FormatStateStacked) const
 {
-    settings.ostr << (settings.hilite ? hilite_keyword : "") << "DESCRIBE FILESYSTEM CACHE" << (settings.hilite ? hilite_none : "")
+    ostr << (settings.hilite ? hilite_keyword : "") << "DESCRIBE FILESYSTEM CACHE" << (settings.hilite ? hilite_none : "")
         << " " << quoteString(cache_name);
 }
 

--- a/src/Parsers/ASTDescribeCacheQuery.h
+++ b/src/Parsers/ASTDescribeCacheQuery.h
@@ -15,7 +15,7 @@ public:
     ASTPtr clone() const override;
 
 protected:
-    void formatQueryImpl(const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
+    void formatQueryImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
 };
 
 }

--- a/src/Parsers/ASTDictionary.cpp
+++ b/src/Parsers/ASTDictionary.cpp
@@ -16,11 +16,12 @@ ASTPtr ASTDictionaryRange::clone() const
 }
 
 
-void ASTDictionaryRange::formatImpl(const FormatSettings & settings,
+void ASTDictionaryRange::formatImpl(WriteBuffer & ostr,
+                                    const FormatSettings & settings,
                                     FormatState &,
                                     FormatStateStacked) const
 {
-    settings.ostr << (settings.hilite ? hilite_keyword : "")
+    ostr << (settings.hilite ? hilite_keyword : "")
                   << "RANGE"
                   << (settings.hilite ? hilite_none : "")
                   << "("
@@ -44,11 +45,12 @@ ASTPtr ASTDictionaryLifetime::clone() const
 }
 
 
-void ASTDictionaryLifetime::formatImpl(const FormatSettings & settings,
+void ASTDictionaryLifetime::formatImpl(WriteBuffer & ostr,
+                                       const FormatSettings & settings,
                                        FormatState &,
                                        FormatStateStacked) const
 {
-    settings.ostr << (settings.hilite ? hilite_keyword : "")
+    ostr << (settings.hilite ? hilite_keyword : "")
                   << "LIFETIME"
                   << (settings.hilite ? hilite_none : "")
                   << "("
@@ -73,11 +75,12 @@ ASTPtr ASTDictionaryLayout::clone() const
 }
 
 
-void ASTDictionaryLayout::formatImpl(const FormatSettings & settings,
+void ASTDictionaryLayout::formatImpl(WriteBuffer & ostr,
+                                     const FormatSettings & settings,
                                      FormatState & state,
                                      FormatStateStacked frame) const
 {
-    settings.ostr << (settings.hilite ? hilite_keyword : "")
+    ostr << (settings.hilite ? hilite_keyword : "")
                   << "LAYOUT"
                   << (settings.hilite ? hilite_none : "")
                   << "("
@@ -86,14 +89,14 @@ void ASTDictionaryLayout::formatImpl(const FormatSettings & settings,
                   << (settings.hilite ? hilite_none : "");
 
     if (has_brackets)
-        settings.ostr << "(";
+        ostr << "(";
 
-    if (parameters) parameters->formatImpl(settings, state, frame);
+    if (parameters) parameters->formatImpl(ostr, settings, state, frame);
 
     if (has_brackets)
-        settings.ostr << ")";
+        ostr << ")";
 
-    settings.ostr << ")";
+    ostr << ")";
 }
 
 ASTPtr ASTDictionarySettings::clone() const
@@ -104,23 +107,24 @@ ASTPtr ASTDictionarySettings::clone() const
     return res;
 }
 
-void ASTDictionarySettings::formatImpl(const FormatSettings & settings,
-                                        FormatState &,
-                                        FormatStateStacked) const
+void ASTDictionarySettings::formatImpl(WriteBuffer & ostr,
+                                       const FormatSettings & settings,
+                                       FormatState &,
+                                       FormatStateStacked) const
 {
 
-    settings.ostr << (settings.hilite ? hilite_keyword : "")
+    ostr << (settings.hilite ? hilite_keyword : "")
                   << "SETTINGS"
                   << (settings.hilite ? hilite_none : "")
                   << "(";
     for (auto it = changes.begin(); it != changes.end(); ++it)
     {
         if (it != changes.begin())
-            settings.ostr << ", ";
+            ostr << ", ";
 
-        settings.ostr << it->name << " = " << applyVisitor(FieldVisitorToString(), it->value);
+        ostr << it->name << " = " << applyVisitor(FieldVisitorToString(), it->value);
     }
-    settings.ostr << (settings.hilite ? hilite_none : "") << ")";
+    ostr << (settings.hilite ? hilite_none : "") << ")";
 }
 
 
@@ -150,46 +154,46 @@ ASTPtr ASTDictionary::clone() const
 }
 
 
-void ASTDictionary::formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
+void ASTDictionary::formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
 {
     if (primary_key)
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << settings.nl_or_ws << "PRIMARY KEY "
+        ostr << (settings.hilite ? hilite_keyword : "") << settings.nl_or_ws << "PRIMARY KEY "
             << (settings.hilite ? hilite_none : "");
-        primary_key->formatImpl(settings, state, frame);
+        primary_key->formatImpl(ostr, settings, state, frame);
     }
 
     if (source)
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << settings.nl_or_ws << "SOURCE"
+        ostr << (settings.hilite ? hilite_keyword : "") << settings.nl_or_ws << "SOURCE"
             << (settings.hilite ? hilite_none : "");
-        settings.ostr << "(";
-        source->formatImpl(settings, state, frame);
-        settings.ostr << ")";
+        ostr << "(";
+        source->formatImpl(ostr, settings, state, frame);
+        ostr << ")";
     }
 
     if (lifetime)
     {
-        settings.ostr << settings.nl_or_ws;
-        lifetime->formatImpl(settings, state, frame);
+        ostr << settings.nl_or_ws;
+        lifetime->formatImpl(ostr, settings, state, frame);
     }
 
     if (layout)
     {
-        settings.ostr << settings.nl_or_ws;
-        layout->formatImpl(settings, state, frame);
+        ostr << settings.nl_or_ws;
+        layout->formatImpl(ostr, settings, state, frame);
     }
 
     if (range)
     {
-        settings.ostr << settings.nl_or_ws;
-        range->formatImpl(settings, state, frame);
+        ostr << settings.nl_or_ws;
+        range->formatImpl(ostr, settings, state, frame);
     }
 
     if (dict_settings)
     {
-        settings.ostr << settings.nl_or_ws;
-        dict_settings->formatImpl(settings, state, frame);
+        ostr << settings.nl_or_ws;
+        dict_settings->formatImpl(ostr, settings, state, frame);
     }
 }
 

--- a/src/Parsers/ASTDictionary.h
+++ b/src/Parsers/ASTDictionary.h
@@ -25,7 +25,7 @@ public:
 
     ASTPtr clone() const override;
 
-    void formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
 };
 
 /// AST for external dictionary layout. Has name and contain single parameter
@@ -46,7 +46,7 @@ public:
 
     ASTPtr clone() const override;
 
-    void formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
 
     void forEachPointerToChild(std::function<void(void**)> f) override
     {
@@ -68,7 +68,7 @@ public:
 
     ASTPtr clone() const override;
 
-    void formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
 };
 
 class ASTDictionarySettings : public IAST
@@ -80,7 +80,7 @@ public:
 
     ASTPtr clone() const override;
 
-    void formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
 };
 
 
@@ -107,7 +107,7 @@ public:
 
     ASTPtr clone() const override;
 
-    void formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
 };
 
 }

--- a/src/Parsers/ASTDictionaryAttributeDeclaration.cpp
+++ b/src/Parsers/ASTDictionaryAttributeDeclaration.cpp
@@ -31,41 +31,41 @@ ASTPtr ASTDictionaryAttributeDeclaration::clone() const
     return res;
 }
 
-void ASTDictionaryAttributeDeclaration::formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
+void ASTDictionaryAttributeDeclaration::formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
 {
     frame.need_parens = false;
 
-    settings.writeIdentifier(name, /*ambiguous=*/true);
+    settings.writeIdentifier(ostr, name, /*ambiguous=*/true);
 
     if (type)
     {
-        settings.ostr << ' ';
-        type->formatImpl(settings, state, frame);
+        ostr << ' ';
+        type->formatImpl(ostr, settings, state, frame);
     }
 
     if (default_value)
     {
-        settings.ostr << ' ' << (settings.hilite ? hilite_keyword : "") << "DEFAULT" << (settings.hilite ? hilite_none : "") << ' ';
-        default_value->formatImpl(settings, state, frame);
+        ostr << ' ' << (settings.hilite ? hilite_keyword : "") << "DEFAULT" << (settings.hilite ? hilite_none : "") << ' ';
+        default_value->formatImpl(ostr, settings, state, frame);
     }
 
     if (expression)
     {
-        settings.ostr << ' ' << (settings.hilite ? hilite_keyword : "") << "EXPRESSION" << (settings.hilite ? hilite_none : "") << ' ';
-        expression->formatImpl(settings, state, frame);
+        ostr << ' ' << (settings.hilite ? hilite_keyword : "") << "EXPRESSION" << (settings.hilite ? hilite_none : "") << ' ';
+        expression->formatImpl(ostr, settings, state, frame);
     }
 
     if (hierarchical)
-        settings.ostr << ' ' << (settings.hilite ? hilite_keyword : "") << "HIERARCHICAL" << (settings.hilite ? hilite_none : "");
+        ostr << ' ' << (settings.hilite ? hilite_keyword : "") << "HIERARCHICAL" << (settings.hilite ? hilite_none : "");
 
     if (bidirectional)
-        settings.ostr << ' ' << (settings.hilite ? hilite_keyword : "") << "BIDIRECTIONAL" << (settings.hilite ? hilite_none : "");
+        ostr << ' ' << (settings.hilite ? hilite_keyword : "") << "BIDIRECTIONAL" << (settings.hilite ? hilite_none : "");
 
     if (injective)
-        settings.ostr << ' ' << (settings.hilite ? hilite_keyword : "") << "INJECTIVE" << (settings.hilite ? hilite_none : "");
+        ostr << ' ' << (settings.hilite ? hilite_keyword : "") << "INJECTIVE" << (settings.hilite ? hilite_none : "");
 
     if (is_object_id)
-        settings.ostr << ' ' << (settings.hilite ? hilite_keyword : "") << "IS_OBJECT_ID" << (settings.hilite ? hilite_none : "");
+        ostr << ' ' << (settings.hilite ? hilite_keyword : "") << "IS_OBJECT_ID" << (settings.hilite ? hilite_none : "");
 }
 
 }

--- a/src/Parsers/ASTDictionaryAttributeDeclaration.h
+++ b/src/Parsers/ASTDictionaryAttributeDeclaration.h
@@ -30,7 +30,7 @@ public:
     String getID(char delim) const override { return "DictionaryAttributeDeclaration" + (delim + name); }
 
     ASTPtr clone() const override;
-    void formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
 };
 
 }

--- a/src/Parsers/ASTDropFunctionQuery.cpp
+++ b/src/Parsers/ASTDropFunctionQuery.cpp
@@ -10,16 +10,16 @@ ASTPtr ASTDropFunctionQuery::clone() const
     return std::make_shared<ASTDropFunctionQuery>(*this);
 }
 
-void ASTDropFunctionQuery::formatImpl(const IAST::FormatSettings & settings, IAST::FormatState &, IAST::FormatStateStacked) const
+void ASTDropFunctionQuery::formatImpl(WriteBuffer & ostr, const IAST::FormatSettings & settings, IAST::FormatState &, IAST::FormatStateStacked) const
 {
-    settings.ostr << (settings.hilite ? hilite_keyword : "") << "DROP FUNCTION ";
+    ostr << (settings.hilite ? hilite_keyword : "") << "DROP FUNCTION ";
 
     if (if_exists)
-        settings.ostr << "IF EXISTS ";
+        ostr << "IF EXISTS ";
 
-    settings.ostr << (settings.hilite ? hilite_none : "");
-    settings.ostr << (settings.hilite ? hilite_identifier : "") << backQuoteIfNeed(function_name) << (settings.hilite ? hilite_none : "");
-    formatOnCluster(settings);
+    ostr << (settings.hilite ? hilite_none : "");
+    ostr << (settings.hilite ? hilite_identifier : "") << backQuoteIfNeed(function_name) << (settings.hilite ? hilite_none : "");
+    formatOnCluster(ostr, settings);
 }
 
 }

--- a/src/Parsers/ASTDropFunctionQuery.h
+++ b/src/Parsers/ASTDropFunctionQuery.h
@@ -18,7 +18,7 @@ public:
 
     ASTPtr clone() const override;
 
-    void formatImpl(const FormatSettings & s, FormatState & state, FormatStateStacked frame) const override;
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & s, FormatState & state, FormatStateStacked frame) const override;
 
     ASTPtr getRewrittenASTWithoutOnCluster(const WithoutOnClusterASTRewriteParams &) const override { return removeOnCluster<ASTDropFunctionQuery>(clone()); }
 

--- a/src/Parsers/ASTDropIndexQuery.cpp
+++ b/src/Parsers/ASTDropIndexQuery.cpp
@@ -25,33 +25,33 @@ ASTPtr ASTDropIndexQuery::clone() const
     return res;
 }
 
-void ASTDropIndexQuery::formatQueryImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
+void ASTDropIndexQuery::formatQueryImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
 {
     frame.need_parens = false;
 
     std::string indent_str = settings.one_line ? "" : std::string(4u * frame.indent, ' ');
 
-    settings.ostr << (settings.hilite ? hilite_keyword : "") << indent_str;
+    ostr << (settings.hilite ? hilite_keyword : "") << indent_str;
 
-    settings.ostr << "DROP INDEX " << (if_exists ? "IF EXISTS " : "");
-    index_name->formatImpl(settings, state, frame);
-    settings.ostr << " ON ";
+    ostr << "DROP INDEX " << (if_exists ? "IF EXISTS " : "");
+    index_name->formatImpl(ostr, settings, state, frame);
+    ostr << " ON ";
 
-    settings.ostr << (settings.hilite ? hilite_none : "");
+    ostr << (settings.hilite ? hilite_none : "");
 
     if (table)
     {
         if (database)
         {
-            database->formatImpl(settings, state, frame);
-            settings.ostr << '.';
+            database->formatImpl(ostr, settings, state, frame);
+            ostr << '.';
         }
 
         chassert(table);
-        table->formatImpl(settings, state, frame);
+        table->formatImpl(ostr, settings, state, frame);
     }
 
-    formatOnCluster(settings);
+    formatOnCluster(ostr, settings);
 }
 
 ASTPtr ASTDropIndexQuery::convertToASTAlterCommand() const

--- a/src/Parsers/ASTDropIndexQuery.h
+++ b/src/Parsers/ASTDropIndexQuery.h
@@ -37,7 +37,7 @@ public:
     ASTPtr convertToASTAlterCommand() const;
 
 protected:
-    void formatQueryImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
+    void formatQueryImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
 };
 
 }

--- a/src/Parsers/ASTDropNamedCollectionQuery.cpp
+++ b/src/Parsers/ASTDropNamedCollectionQuery.cpp
@@ -10,13 +10,13 @@ ASTPtr ASTDropNamedCollectionQuery::clone() const
     return std::make_shared<ASTDropNamedCollectionQuery>(*this);
 }
 
-void ASTDropNamedCollectionQuery::formatImpl(const IAST::FormatSettings & settings, IAST::FormatState &, IAST::FormatStateStacked) const
+void ASTDropNamedCollectionQuery::formatImpl(WriteBuffer & ostr, const IAST::FormatSettings & settings, IAST::FormatState &, IAST::FormatStateStacked) const
 {
-    settings.ostr << (settings.hilite ? hilite_keyword : "") << "DROP NAMED COLLECTION ";
+    ostr << (settings.hilite ? hilite_keyword : "") << "DROP NAMED COLLECTION ";
     if (if_exists)
-        settings.ostr << "IF EXISTS ";
-    settings.ostr << (settings.hilite ? hilite_identifier : "") << backQuoteIfNeed(collection_name) << (settings.hilite ? hilite_none : "");
-    formatOnCluster(settings);
+        ostr << "IF EXISTS ";
+    ostr << (settings.hilite ? hilite_identifier : "") << backQuoteIfNeed(collection_name) << (settings.hilite ? hilite_none : "");
+    formatOnCluster(ostr, settings);
 }
 
 }

--- a/src/Parsers/ASTDropNamedCollectionQuery.h
+++ b/src/Parsers/ASTDropNamedCollectionQuery.h
@@ -17,7 +17,7 @@ public:
 
     ASTPtr clone() const override;
 
-    void formatImpl(const FormatSettings & s, FormatState & state, FormatStateStacked frame) const override;
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & s, FormatState & state, FormatStateStacked frame) const override;
 
     ASTPtr getRewrittenASTWithoutOnCluster(const WithoutOnClusterASTRewriteParams &) const override { return removeOnCluster<ASTDropNamedCollectionQuery>(clone()); }
 

--- a/src/Parsers/ASTDropQuery.h
+++ b/src/Parsers/ASTDropQuery.h
@@ -58,7 +58,7 @@ public:
     QueryKind getQueryKind() const override { return QueryKind::Drop; }
 
 protected:
-    void formatQueryImpl(const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
+    void formatQueryImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
 };
 
 }

--- a/src/Parsers/ASTDropResourceQuery.cpp
+++ b/src/Parsers/ASTDropResourceQuery.cpp
@@ -10,16 +10,16 @@ ASTPtr ASTDropResourceQuery::clone() const
     return std::make_shared<ASTDropResourceQuery>(*this);
 }
 
-void ASTDropResourceQuery::formatImpl(const IAST::FormatSettings & settings, IAST::FormatState &, IAST::FormatStateStacked) const
+void ASTDropResourceQuery::formatImpl(WriteBuffer & ostr, const IAST::FormatSettings & settings, IAST::FormatState &, IAST::FormatStateStacked) const
 {
-    settings.ostr << (settings.hilite ? hilite_keyword : "") << "DROP RESOURCE ";
+    ostr << (settings.hilite ? hilite_keyword : "") << "DROP RESOURCE ";
 
     if (if_exists)
-        settings.ostr << "IF EXISTS ";
+        ostr << "IF EXISTS ";
 
-    settings.ostr << (settings.hilite ? hilite_none : "");
-    settings.ostr << (settings.hilite ? hilite_identifier : "") << backQuoteIfNeed(resource_name) << (settings.hilite ? hilite_none : "");
-    formatOnCluster(settings);
+    ostr << (settings.hilite ? hilite_none : "");
+    ostr << (settings.hilite ? hilite_identifier : "") << backQuoteIfNeed(resource_name) << (settings.hilite ? hilite_none : "");
+    formatOnCluster(ostr, settings);
 }
 
 }

--- a/src/Parsers/ASTDropResourceQuery.h
+++ b/src/Parsers/ASTDropResourceQuery.h
@@ -18,7 +18,7 @@ public:
 
     ASTPtr clone() const override;
 
-    void formatImpl(const FormatSettings & s, FormatState & state, FormatStateStacked frame) const override;
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & s, FormatState & state, FormatStateStacked frame) const override;
 
     ASTPtr getRewrittenASTWithoutOnCluster(const WithoutOnClusterASTRewriteParams &) const override { return removeOnCluster<ASTDropResourceQuery>(clone()); }
 

--- a/src/Parsers/ASTDropWorkloadQuery.cpp
+++ b/src/Parsers/ASTDropWorkloadQuery.cpp
@@ -10,16 +10,16 @@ ASTPtr ASTDropWorkloadQuery::clone() const
     return std::make_shared<ASTDropWorkloadQuery>(*this);
 }
 
-void ASTDropWorkloadQuery::formatImpl(const IAST::FormatSettings & settings, IAST::FormatState &, IAST::FormatStateStacked) const
+void ASTDropWorkloadQuery::formatImpl(WriteBuffer & ostr, const IAST::FormatSettings & settings, IAST::FormatState &, IAST::FormatStateStacked) const
 {
-    settings.ostr << (settings.hilite ? hilite_keyword : "") << "DROP WORKLOAD ";
+    ostr << (settings.hilite ? hilite_keyword : "") << "DROP WORKLOAD ";
 
     if (if_exists)
-        settings.ostr << "IF EXISTS ";
+        ostr << "IF EXISTS ";
 
-    settings.ostr << (settings.hilite ? hilite_none : "");
-    settings.ostr << (settings.hilite ? hilite_identifier : "") << backQuoteIfNeed(workload_name) << (settings.hilite ? hilite_none : "");
-    formatOnCluster(settings);
+    ostr << (settings.hilite ? hilite_none : "");
+    ostr << (settings.hilite ? hilite_identifier : "") << backQuoteIfNeed(workload_name) << (settings.hilite ? hilite_none : "");
+    formatOnCluster(ostr, settings);
 }
 
 }

--- a/src/Parsers/ASTDropWorkloadQuery.h
+++ b/src/Parsers/ASTDropWorkloadQuery.h
@@ -18,7 +18,7 @@ public:
 
     ASTPtr clone() const override;
 
-    void formatImpl(const FormatSettings & s, FormatState & state, FormatStateStacked frame) const override;
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & s, FormatState & state, FormatStateStacked frame) const override;
 
     ASTPtr getRewrittenASTWithoutOnCluster(const WithoutOnClusterASTRewriteParams &) const override { return removeOnCluster<ASTDropWorkloadQuery>(clone()); }
 

--- a/src/Parsers/ASTExplainQuery.h
+++ b/src/Parsers/ASTExplainQuery.h
@@ -112,30 +112,30 @@ public:
     QueryKind getQueryKind() const override { return QueryKind::Explain; }
 
 protected:
-    void formatQueryImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override
+    void formatQueryImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << toString(kind) << (settings.hilite ? hilite_none : "");
+        ostr << (settings.hilite ? hilite_keyword : "") << toString(kind) << (settings.hilite ? hilite_none : "");
 
         if (ast_settings)
         {
-            settings.ostr << ' ';
-            ast_settings->formatImpl(settings, state, frame);
+            ostr << ' ';
+            ast_settings->formatImpl(ostr, settings, state, frame);
         }
 
         if (query)
         {
-            settings.ostr << settings.nl_or_ws;
-            query->formatImpl(settings, state, frame);
+            ostr << settings.nl_or_ws;
+            query->formatImpl(ostr, settings, state, frame);
         }
         if (table_function)
         {
-            settings.ostr << settings.nl_or_ws;
-            table_function->formatImpl(settings, state, frame);
+            ostr << settings.nl_or_ws;
+            table_function->formatImpl(ostr, settings, state, frame);
         }
         if (table_override)
         {
-            settings.ostr << settings.nl_or_ws;
-            table_override->formatImpl(settings, state, frame);
+            ostr << settings.nl_or_ws;
+            table_override->formatImpl(ostr, settings, state, frame);
         }
     }
 

--- a/src/Parsers/ASTExpressionList.cpp
+++ b/src/Parsers/ASTExpressionList.cpp
@@ -12,18 +12,18 @@ ASTPtr ASTExpressionList::clone() const
     return clone;
 }
 
-void ASTExpressionList::formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
+void ASTExpressionList::formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
 {
     if (frame.expression_list_prepend_whitespace)
-        settings.ostr << ' ';
+        ostr << ' ';
 
     for (size_t i = 0, size = children.size(); i < size; ++i)
     {
         if (i)
         {
             if (separator)
-                settings.ostr << separator;
-            settings.ostr << ' ';
+                ostr << separator;
+            ostr << ' ';
         }
 
         FormatStateStacked frame_nested = frame;
@@ -31,16 +31,16 @@ void ASTExpressionList::formatImpl(const FormatSettings & settings, FormatState 
         frame_nested.list_element_index = i;
 
         if (frame.surround_each_list_element_with_parens)
-            settings.ostr << "(";
+            ostr << "(";
 
-        children[i]->formatImpl(settings, state, frame_nested);
+        children[i]->formatImpl(ostr, settings, state, frame_nested);
 
         if (frame.surround_each_list_element_with_parens)
-            settings.ostr << ")";
+            ostr << ")";
     }
 }
 
-void ASTExpressionList::formatImplMultiline(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
+void ASTExpressionList::formatImplMultiline(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
 {
     ++frame.indent;
     std::string indent_str = "\n" + std::string(4 * frame.indent, ' ');
@@ -48,16 +48,16 @@ void ASTExpressionList::formatImplMultiline(const FormatSettings & settings, For
     if (frame.expression_list_prepend_whitespace)
     {
         if (!(children.size() > 1 || frame.expression_list_always_start_on_new_line))
-            settings.ostr << ' ';
+            ostr << ' ';
     }
 
     for (size_t i = 0, size = children.size(); i < size; ++i)
     {
         if (i && separator)
-            settings.ostr << separator;
+            ostr << separator;
 
         if (size > 1 || frame.expression_list_always_start_on_new_line)
-            settings.ostr << indent_str;
+            ostr << indent_str;
 
         FormatStateStacked frame_nested = frame;
         frame_nested.expression_list_always_start_on_new_line = false;
@@ -65,12 +65,12 @@ void ASTExpressionList::formatImplMultiline(const FormatSettings & settings, For
         frame_nested.list_element_index = i;
 
         if (frame.surround_each_list_element_with_parens)
-            settings.ostr << "(";
+            ostr << "(";
 
-        children[i]->formatImpl(settings, state, frame_nested);
+        children[i]->formatImpl(ostr, settings, state, frame_nested);
 
         if (frame.surround_each_list_element_with_parens)
-            settings.ostr << ")";
+            ostr << ")";
     }
 }
 

--- a/src/Parsers/ASTExpressionList.h
+++ b/src/Parsers/ASTExpressionList.h
@@ -16,8 +16,8 @@ public:
     String getID(char) const override { return "ExpressionList"; }
 
     ASTPtr clone() const override;
-    void formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
-    void formatImplMultiline(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const;
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
+    void formatImplMultiline(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const;
 
     char separator;
 };

--- a/src/Parsers/ASTExternalDDLQuery.h
+++ b/src/Parsers/ASTExternalDDLQuery.h
@@ -33,11 +33,11 @@ public:
 
     String getID(char) const override { return "external ddl query"; }
 
-    void formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked stacked) const override
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked stacked) const override
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << "EXTERNAL DDL FROM " << (settings.hilite ? hilite_none : "");
-        from->formatImpl(settings, state, stacked);
-        external_ddl->formatImpl(settings, state, stacked);
+        ostr << (settings.hilite ? hilite_keyword : "") << "EXTERNAL DDL FROM " << (settings.hilite ? hilite_none : "");
+        from->formatImpl(ostr, settings, state, stacked);
+        external_ddl->formatImpl(ostr, settings, state, stacked);
     }
 
     QueryKind getQueryKind() const override { return QueryKind::ExternalDDL; }

--- a/src/Parsers/ASTFunction.h
+++ b/src/Parsers/ASTFunction.h
@@ -82,10 +82,10 @@ public:
     bool hasSecretParts() const override;
 
 protected:
-    void formatImplWithoutAlias(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
+    void formatImplWithoutAlias(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
     void appendColumnNameImpl(WriteBuffer & ostr) const override;
 private:
-    void finishFormatWithWindow(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const;
+    void finishFormatWithWindow(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const;
 };
 
 

--- a/src/Parsers/ASTFunctionWithKeyValueArguments.cpp
+++ b/src/Parsers/ASTFunctionWithKeyValueArguments.cpp
@@ -23,39 +23,39 @@ ASTPtr ASTPair::clone() const
 }
 
 
-void ASTPair::formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
+void ASTPair::formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
 {
-    settings.ostr << (settings.hilite ? hilite_keyword : "") << Poco::toUpper(first) << " " << (settings.hilite ? hilite_none : "");
+    ostr << (settings.hilite ? hilite_keyword : "") << Poco::toUpper(first) << " " << (settings.hilite ? hilite_none : "");
 
     if (second_with_brackets)
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << "(";
+        ostr << (settings.hilite ? hilite_keyword : "") << "(";
 
     if (!settings.show_secrets && (first == "password"))
     {
         /// Hide password in the definition of a dictionary:
         /// SOURCE(CLICKHOUSE(host 'example01-01-1' port 9000 user 'default' password '[HIDDEN]' db 'default' table 'ids'))
-        settings.ostr << "'[HIDDEN]'";
+        ostr << "'[HIDDEN]'";
     }
     else if (!settings.show_secrets && (first == "uri"))
     {
         // Hide password from URI in the defention of a dictionary
         WriteBufferFromOwnString temp_buf;
-        FormatSettings tmp_settings(temp_buf, settings.one_line);
+        FormatSettings tmp_settings(settings.one_line);
         FormatState tmp_state;
-        second->formatImpl(tmp_settings, tmp_state, frame);
+        second->formatImpl(temp_buf, tmp_settings, tmp_state, frame);
 
         maskURIPassword(&temp_buf.str());
-        settings.ostr << temp_buf.str();
+        ostr << temp_buf.str();
     }
     else
     {
-        second->formatImpl(settings, state, frame);
+        second->formatImpl(ostr, settings, state, frame);
     }
 
     if (second_with_brackets)
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << ")";
+        ostr << (settings.hilite ? hilite_keyword : "") << ")";
 
-    settings.ostr << (settings.hilite ? hilite_none : "");
+    ostr << (settings.hilite ? hilite_none : "");
 }
 
 
@@ -95,12 +95,12 @@ ASTPtr ASTFunctionWithKeyValueArguments::clone() const
 }
 
 
-void ASTFunctionWithKeyValueArguments::formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
+void ASTFunctionWithKeyValueArguments::formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
 {
-    settings.ostr << (settings.hilite ? hilite_keyword : "") << Poco::toUpper(name) << (settings.hilite ? hilite_none : "") << (has_brackets ? "(" : "");
-    elements->formatImpl(settings, state, frame);
-    settings.ostr << (has_brackets ? ")" : "");
-    settings.ostr << (settings.hilite ? hilite_none : "");
+    ostr << (settings.hilite ? hilite_keyword : "") << Poco::toUpper(name) << (settings.hilite ? hilite_none : "") << (has_brackets ? "(" : "");
+    elements->formatImpl(ostr, settings, state, frame);
+    ostr << (has_brackets ? ")" : "");
+    ostr << (settings.hilite ? hilite_none : "");
 }
 
 

--- a/src/Parsers/ASTFunctionWithKeyValueArguments.h
+++ b/src/Parsers/ASTFunctionWithKeyValueArguments.h
@@ -28,7 +28,7 @@ public:
 
     ASTPtr clone() const override;
 
-    void formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
 
     bool hasSecretParts() const override;
 
@@ -64,7 +64,7 @@ public:
 
     ASTPtr clone() const override;
 
-    void formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
 
     void updateTreeHashImpl(SipHash & hash_state, bool ignore_aliases) const override;
 };

--- a/src/Parsers/ASTIdentifier.cpp
+++ b/src/Parsers/ASTIdentifier.cpp
@@ -103,13 +103,13 @@ const String & ASTIdentifier::name() const
     return full_name;
 }
 
-void ASTIdentifier::formatImplWithoutAlias(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
+void ASTIdentifier::formatImplWithoutAlias(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
 {
     auto format_element = [&](const String & elem_name)
     {
-        settings.ostr << (settings.hilite ? hilite_identifier : "");
-        settings.writeIdentifier(elem_name, /*ambiguous=*/false);
-        settings.ostr << (settings.hilite ? hilite_none : "");
+        ostr << (settings.hilite ? hilite_identifier : "");
+        settings.writeIdentifier(ostr, elem_name, /*ambiguous=*/false);
+        ostr << (settings.hilite ? hilite_none : "");
     };
 
     if (compound())
@@ -117,14 +117,14 @@ void ASTIdentifier::formatImplWithoutAlias(const FormatSettings & settings, Form
         for (size_t i = 0, j = 0, size = name_parts.size(); i < size; ++i)
         {
             if (i != 0)
-                settings.ostr << '.';
+                ostr << '.';
 
             /// Some AST rewriting code, like IdentifierSemantic::setColumnLongName,
             /// does not respect children of identifier.
             /// Here we also ignore children if they are empty.
             if (name_parts[i].empty() && j < children.size())
             {
-                children[j]->formatImpl(settings, state, frame);
+                children[j]->formatImpl(ostr, settings, state, frame);
                 ++j;
             }
             else
@@ -135,7 +135,7 @@ void ASTIdentifier::formatImplWithoutAlias(const FormatSettings & settings, Form
     {
         const auto & name = shortName();
         if (name.empty() && !children.empty())
-            children.front()->formatImpl(settings, state, frame);
+            children.front()->formatImpl(ostr, settings, state, frame);
         else
             format_element(name);
     }

--- a/src/Parsers/ASTIdentifier.h
+++ b/src/Parsers/ASTIdentifier.h
@@ -58,7 +58,7 @@ public:
 protected:
     std::shared_ptr<IdentifierSemanticImpl> semantic; /// pimpl
 
-    void formatImplWithoutAlias(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
+    void formatImplWithoutAlias(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
     void appendColumnNameImpl(WriteBuffer & ostr) const override;
 
 private:

--- a/src/Parsers/ASTIndexDeclaration.cpp
+++ b/src/Parsers/ASTIndexDeclaration.cpp
@@ -62,7 +62,7 @@ std::shared_ptr<ASTFunction> ASTIndexDeclaration::getType() const
     return func_ast;
 }
 
-void ASTIndexDeclaration::formatImpl(const FormatSettings & s, FormatState & state, FormatStateStacked frame) const
+void ASTIndexDeclaration::formatImpl(WriteBuffer & ostr, const FormatSettings & s, FormatState & state, FormatStateStacked frame) const
 {
     if (auto expr = getExpression())
     {
@@ -70,31 +70,31 @@ void ASTIndexDeclaration::formatImpl(const FormatSettings & s, FormatState & sta
         {
             if (expr->as<ASTExpressionList>())
             {
-                s.ostr << "(";
-                expr->formatImpl(s, state, frame);
-                s.ostr << ")";
+                ostr << "(";
+                expr->formatImpl(ostr, s, state, frame);
+                ostr << ")";
             }
             else
-                expr->formatImpl(s, state, frame);
+                expr->formatImpl(ostr, s, state, frame);
         }
         else
         {
-            s.writeIdentifier(name, /*ambiguous=*/false);
-            s.ostr << " ";
-            expr->formatImpl(s, state, frame);
+            s.writeIdentifier(ostr, name, /*ambiguous=*/false);
+            ostr << " ";
+            expr->formatImpl(ostr, s, state, frame);
         }
     }
 
     if (auto type = getType())
     {
-        s.ostr << (s.hilite ? hilite_keyword : "") << " TYPE " << (s.hilite ? hilite_none : "");
-        type->formatImpl(s, state, frame);
+        ostr << (s.hilite ? hilite_keyword : "") << " TYPE " << (s.hilite ? hilite_none : "");
+        type->formatImpl(ostr, s, state, frame);
     }
 
     if (granularity)
     {
-        s.ostr << (s.hilite ? hilite_keyword : "") << " GRANULARITY " << (s.hilite ? hilite_none : "");
-        s.ostr << granularity;
+        ostr << (s.hilite ? hilite_keyword : "") << " GRANULARITY " << (s.hilite ? hilite_none : "");
+        ostr << granularity;
     }
 }
 

--- a/src/Parsers/ASTIndexDeclaration.h
+++ b/src/Parsers/ASTIndexDeclaration.h
@@ -25,7 +25,7 @@ public:
     String getID(char) const override { return "Index"; }
 
     ASTPtr clone() const override;
-    void formatImpl(const FormatSettings & s, FormatState & state, FormatStateStacked frame) const override;
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & s, FormatState & state, FormatStateStacked frame) const override;
 
     ASTPtr getExpression() const;
     std::shared_ptr<ASTFunction> getType() const;

--- a/src/Parsers/ASTInsertQuery.cpp
+++ b/src/Parsers/ASTInsertQuery.cpp
@@ -46,54 +46,54 @@ void ASTInsertQuery::setTable(const String & name)
         table = std::make_shared<ASTIdentifier>(name);
 }
 
-void ASTInsertQuery::formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
+void ASTInsertQuery::formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
 {
     frame.need_parens = false;
 
-    settings.ostr << (settings.hilite ? hilite_keyword : "") << "INSERT INTO ";
+    ostr << (settings.hilite ? hilite_keyword : "") << "INSERT INTO ";
     if (table_function)
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << "FUNCTION ";
-        table_function->formatImpl(settings, state, frame);
+        ostr << (settings.hilite ? hilite_keyword : "") << "FUNCTION ";
+        table_function->formatImpl(ostr, settings, state, frame);
         if (partition_by)
         {
-            settings.ostr << " PARTITION BY ";
-            partition_by->formatImpl(settings, state, frame);
+            ostr << " PARTITION BY ";
+            partition_by->formatImpl(ostr, settings, state, frame);
         }
     }
     else if (table_id)
     {
-        settings.ostr << (settings.hilite ? hilite_none : "")
+        ostr << (settings.hilite ? hilite_none : "")
                       << (!table_id.database_name.empty() ? backQuoteIfNeed(table_id.database_name) + "." : "") << backQuoteIfNeed(table_id.table_name);
     }
     else
     {
         if (database)
         {
-            database->formatImpl(settings, state, frame);
-            settings.ostr << '.';
+            database->formatImpl(ostr, settings, state, frame);
+            ostr << '.';
         }
 
         chassert(table);
-        table->formatImpl(settings, state, frame);
+        table->formatImpl(ostr, settings, state, frame);
     }
 
     if (columns)
     {
-        settings.ostr << " (";
-        columns->formatImpl(settings, state, frame);
-        settings.ostr << ")";
+        ostr << " (";
+        columns->formatImpl(ostr, settings, state, frame);
+        ostr << ")";
     }
 
     if (infile)
     {
-        settings.ostr
+        ostr
             << (settings.hilite ? hilite_keyword : "")
             << " FROM INFILE "
             << (settings.hilite ? hilite_none : "")
             << quoteString(infile->as<ASTLiteral &>().value.safeGet<std::string>());
         if (compression)
-            settings.ostr
+            ostr
                 << (settings.hilite ? hilite_keyword : "")
                 << " COMPRESSION "
                 << (settings.hilite ? hilite_none : "")
@@ -102,8 +102,8 @@ void ASTInsertQuery::formatImpl(const FormatSettings & settings, FormatState & s
 
     if (settings_ast)
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << settings.nl_or_ws << "SETTINGS " << (settings.hilite ? hilite_none : "");
-        settings_ast->formatImpl(settings, state, frame);
+        ostr << (settings.hilite ? hilite_keyword : "") << settings.nl_or_ws << "SETTINGS " << (settings.hilite ? hilite_none : "");
+        settings_ast->formatImpl(ostr, settings, state, frame);
     }
 
     /// Compatibility for INSERT without SETTINGS to format in oneline, i.e.:
@@ -120,20 +120,20 @@ void ASTInsertQuery::formatImpl(const FormatSettings & settings, FormatState & s
 
     if (select)
     {
-        settings.ostr << delim;
-        select->formatImpl(settings, state, frame);
+        ostr << delim;
+        select->formatImpl(ostr, settings, state, frame);
     }
 
     if (!select)
     {
         if (!format.empty())
         {
-            settings.ostr << delim
+            ostr << delim
                           << (settings.hilite ? hilite_keyword : "") << "FORMAT " << (settings.hilite ? hilite_none : "") << format;
         }
         else if (!infile)
         {
-            settings.ostr << delim
+            ostr << delim
                           << (settings.hilite ? hilite_keyword : "") << "VALUES" << (settings.hilite ? hilite_none : "");
         }
     }

--- a/src/Parsers/ASTInsertQuery.h
+++ b/src/Parsers/ASTInsertQuery.h
@@ -71,7 +71,7 @@ public:
     QueryKind getQueryKind() const override { return async_insert_flush ? QueryKind::AsyncInsertFlush : QueryKind::Insert; }
 
 protected:
-    void formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
     void updateTreeHashImpl(SipHash & hash_state, bool ignore_aliases) const override;
 };
 

--- a/src/Parsers/ASTInterpolateElement.cpp
+++ b/src/Parsers/ASTInterpolateElement.cpp
@@ -7,10 +7,10 @@
 namespace DB
 {
 
-void ASTInterpolateElement::formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
+void ASTInterpolateElement::formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
 {
-        settings.ostr << column << (settings.hilite ? hilite_keyword : "") << " AS " << (settings.hilite ? hilite_none : "");
-        expr->formatImpl(settings, state, frame);
+        ostr << column << (settings.hilite ? hilite_keyword : "") << " AS " << (settings.hilite ? hilite_none : "");
+        expr->formatImpl(ostr, settings, state, frame);
 }
 
 }

--- a/src/Parsers/ASTInterpolateElement.h
+++ b/src/Parsers/ASTInterpolateElement.h
@@ -25,7 +25,7 @@ public:
 
 
 protected:
-    void formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
 };
 
 }

--- a/src/Parsers/ASTKillQueryQuery.cpp
+++ b/src/Parsers/ASTKillQueryQuery.cpp
@@ -9,37 +9,37 @@ String ASTKillQueryQuery::getID(char delim) const
     return String("KillQueryQuery") + delim + (where_expression ? where_expression->getID() : "") + delim + String(sync ? "SYNC" : "ASYNC");
 }
 
-void ASTKillQueryQuery::formatQueryImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
+void ASTKillQueryQuery::formatQueryImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
 {
-    settings.ostr << (settings.hilite ? hilite_keyword : "") << "KILL ";
+    ostr << (settings.hilite ? hilite_keyword : "") << "KILL ";
 
     switch (type)
     {
         case Type::Query:
-            settings.ostr << "QUERY";
+            ostr << "QUERY";
             break;
         case Type::Mutation:
-            settings.ostr << "MUTATION";
+            ostr << "MUTATION";
             break;
         case Type::PartMoveToShard:
-            settings.ostr << "PART_MOVE_TO_SHARD";
+            ostr << "PART_MOVE_TO_SHARD";
             break;
         case Type::Transaction:
-            settings.ostr << "TRANSACTION";
+            ostr << "TRANSACTION";
             break;
     }
 
-    settings.ostr << (settings.hilite ? hilite_none : "");
+    ostr << (settings.hilite ? hilite_none : "");
 
-    formatOnCluster(settings);
+    formatOnCluster(ostr, settings);
 
     if (where_expression)
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << " WHERE " << (settings.hilite ? hilite_none : "");
-        where_expression->formatImpl(settings, state, frame);
+        ostr << (settings.hilite ? hilite_keyword : "") << " WHERE " << (settings.hilite ? hilite_none : "");
+        where_expression->formatImpl(ostr, settings, state, frame);
     }
 
-    settings.ostr << " " << (settings.hilite ? hilite_keyword : "") << (test ? "TEST" : (sync ? "SYNC" : "ASYNC")) << (settings.hilite ? hilite_none : "");
+    ostr << " " << (settings.hilite ? hilite_keyword : "") << (test ? "TEST" : (sync ? "SYNC" : "ASYNC")) << (settings.hilite ? hilite_none : "");
 }
 
 }

--- a/src/Parsers/ASTKillQueryQuery.h
+++ b/src/Parsers/ASTKillQueryQuery.h
@@ -36,7 +36,7 @@ public:
 
     String getID(char) const override;
 
-    void formatQueryImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
+    void formatQueryImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
 
     ASTPtr getRewrittenASTWithoutOnCluster(const WithoutOnClusterASTRewriteParams &) const override
     {

--- a/src/Parsers/ASTLiteral.cpp
+++ b/src/Parsers/ASTLiteral.cpp
@@ -148,12 +148,12 @@ String FieldVisitorToStringPostgreSQL::operator() (const String & x) const
     return wb.str();
 }
 
-void ASTLiteral::formatImplWithoutAlias(const FormatSettings & settings, IAST::FormatState &, IAST::FormatStateStacked) const
+void ASTLiteral::formatImplWithoutAlias(WriteBuffer & ostr, const FormatSettings & settings, IAST::FormatState &, IAST::FormatStateStacked) const
 {
     if (settings.literal_escaping_style == LiteralEscapingStyle::Regular)
-        settings.ostr << applyVisitor(FieldVisitorToString(), value);
+        ostr << applyVisitor(FieldVisitorToString(), value);
     else
-        settings.ostr << applyVisitor(FieldVisitorToStringPostgreSQL(), value);
+        ostr << applyVisitor(FieldVisitorToStringPostgreSQL(), value);
 }
 
 }

--- a/src/Parsers/ASTLiteral.h
+++ b/src/Parsers/ASTLiteral.h
@@ -52,7 +52,7 @@ public:
     void updateTreeHashImpl(SipHash & hash_state, bool ignore_aliases) const override;
 
 protected:
-    void formatImplWithoutAlias(const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
+    void formatImplWithoutAlias(WriteBuffer & ostr, const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
 
     void appendColumnNameImpl(WriteBuffer & ostr) const override;
 

--- a/src/Parsers/ASTNameTypePair.cpp
+++ b/src/Parsers/ASTNameTypePair.cpp
@@ -21,10 +21,10 @@ ASTPtr ASTNameTypePair::clone() const
 }
 
 
-void ASTNameTypePair::formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
+void ASTNameTypePair::formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
 {
-    settings.ostr << backQuoteIfNeed(name) << ' ';
-    type->formatImpl(settings, state, frame);
+    ostr << backQuoteIfNeed(name) << ' ';
+    type->formatImpl(ostr, settings, state, frame);
 }
 
 }

--- a/src/Parsers/ASTNameTypePair.h
+++ b/src/Parsers/ASTNameTypePair.h
@@ -21,7 +21,7 @@ public:
     ASTPtr clone() const override;
 
 protected:
-    void formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
 };
 
 

--- a/src/Parsers/ASTObjectTypeArgument.cpp
+++ b/src/Parsers/ASTObjectTypeArgument.cpp
@@ -35,27 +35,27 @@ ASTPtr ASTObjectTypeArgument::clone() const
     return res;
 }
 
-void ASTObjectTypeArgument::formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
+void ASTObjectTypeArgument::formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
 {
     if (path_with_type)
     {
-        path_with_type->formatImpl(settings, state, frame);
+        path_with_type->formatImpl(ostr, settings, state, frame);
     }
     else if (parameter)
     {
-        parameter->formatImpl(settings, state, frame);
+        parameter->formatImpl(ostr, settings, state, frame);
     }
     else if (skip_path)
     {
         std::string indent_str = settings.one_line ? "" : std::string(4 * frame.indent, ' ');
-        settings.ostr << indent_str << "SKIP" << ' ';
-        skip_path->formatImpl(settings, state, frame);
+        ostr << indent_str << "SKIP" << ' ';
+        skip_path->formatImpl(ostr, settings, state, frame);
     }
     else if (skip_path_regexp)
     {
         std::string indent_str = settings.one_line ? "" : std::string(4 * frame.indent, ' ');
-        settings.ostr << indent_str << "SKIP REGEXP" << ' ';
-        skip_path_regexp->formatImpl(settings, state, frame);
+        ostr << indent_str << "SKIP REGEXP" << ' ';
+        skip_path_regexp->formatImpl(ostr, settings, state, frame);
     }
 }
 

--- a/src/Parsers/ASTObjectTypeArgument.h
+++ b/src/Parsers/ASTObjectTypeArgument.h
@@ -25,7 +25,7 @@ public:
     ASTPtr clone() const override;
 
 protected:
-    void formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
 };
 
 

--- a/src/Parsers/ASTOptimizeQuery.cpp
+++ b/src/Parsers/ASTOptimizeQuery.cpp
@@ -5,40 +5,40 @@
 namespace DB
 {
 
-void ASTOptimizeQuery::formatQueryImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
+void ASTOptimizeQuery::formatQueryImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
 {
-    settings.ostr << (settings.hilite ? hilite_keyword : "") << "OPTIMIZE TABLE " << (settings.hilite ? hilite_none : "");
+    ostr << (settings.hilite ? hilite_keyword : "") << "OPTIMIZE TABLE " << (settings.hilite ? hilite_none : "");
 
     if (database)
     {
-        database->formatImpl(settings, state, frame);
-        settings.ostr << '.';
+        database->formatImpl(ostr, settings, state, frame);
+        ostr << '.';
     }
 
     chassert(table);
-    table->formatImpl(settings, state, frame);
+    table->formatImpl(ostr, settings, state, frame);
 
-    formatOnCluster(settings);
+    formatOnCluster(ostr, settings);
 
     if (partition)
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << " PARTITION " << (settings.hilite ? hilite_none : "");
-        partition->formatImpl(settings, state, frame);
+        ostr << (settings.hilite ? hilite_keyword : "") << " PARTITION " << (settings.hilite ? hilite_none : "");
+        partition->formatImpl(ostr, settings, state, frame);
     }
 
     if (final)
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << " FINAL" << (settings.hilite ? hilite_none : "");
+        ostr << (settings.hilite ? hilite_keyword : "") << " FINAL" << (settings.hilite ? hilite_none : "");
 
     if (deduplicate)
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << " DEDUPLICATE" << (settings.hilite ? hilite_none : "");
+        ostr << (settings.hilite ? hilite_keyword : "") << " DEDUPLICATE" << (settings.hilite ? hilite_none : "");
 
     if (cleanup)
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << " CLEANUP" << (settings.hilite ? hilite_none : "");
+        ostr << (settings.hilite ? hilite_keyword : "") << " CLEANUP" << (settings.hilite ? hilite_none : "");
 
     if (deduplicate_by_columns)
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << " BY " << (settings.hilite ? hilite_none : "");
-        deduplicate_by_columns->formatImpl(settings, state, frame);
+        ostr << (settings.hilite ? hilite_keyword : "") << " BY " << (settings.hilite ? hilite_none : "");
+        deduplicate_by_columns->formatImpl(ostr, settings, state, frame);
     }
 }
 

--- a/src/Parsers/ASTOptimizeQuery.h
+++ b/src/Parsers/ASTOptimizeQuery.h
@@ -49,7 +49,7 @@ public:
         return res;
     }
 
-    void formatQueryImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
+    void formatQueryImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
 
     ASTPtr getRewrittenASTWithoutOnCluster(const WithoutOnClusterASTRewriteParams & params) const override
     {

--- a/src/Parsers/ASTOrderByElement.cpp
+++ b/src/Parsers/ASTOrderByElement.cpp
@@ -15,16 +15,16 @@ void ASTOrderByElement::updateTreeHashImpl(SipHash & hash_state, bool ignore_ali
     IAST::updateTreeHashImpl(hash_state, ignore_aliases);
 }
 
-void ASTOrderByElement::formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
+void ASTOrderByElement::formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
 {
-    children.front()->formatImpl(settings, state, frame);
-    settings.ostr << (settings.hilite ? hilite_keyword : "")
+    children.front()->formatImpl(ostr, settings, state, frame);
+    ostr << (settings.hilite ? hilite_keyword : "")
         << (direction == -1 ? " DESC" : " ASC")
         << (settings.hilite ? hilite_none : "");
 
     if (nulls_direction_was_explicitly_specified)
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "")
+        ostr << (settings.hilite ? hilite_keyword : "")
             << " NULLS "
             << (nulls_direction == direction ? "LAST" : "FIRST")
             << (settings.hilite ? hilite_none : "");
@@ -32,32 +32,32 @@ void ASTOrderByElement::formatImpl(const FormatSettings & settings, FormatState 
 
     if (auto collation = getCollation())
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << " COLLATE " << (settings.hilite ? hilite_none : "");
-        collation->formatImpl(settings, state, frame);
+        ostr << (settings.hilite ? hilite_keyword : "") << " COLLATE " << (settings.hilite ? hilite_none : "");
+        collation->formatImpl(ostr, settings, state, frame);
     }
 
     if (with_fill)
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << " WITH FILL" << (settings.hilite ? hilite_none : "");
+        ostr << (settings.hilite ? hilite_keyword : "") << " WITH FILL" << (settings.hilite ? hilite_none : "");
         if (auto fill_from = getFillFrom())
         {
-            settings.ostr << (settings.hilite ? hilite_keyword : "") << " FROM " << (settings.hilite ? hilite_none : "");
-            fill_from->formatImpl(settings, state, frame);
+            ostr << (settings.hilite ? hilite_keyword : "") << " FROM " << (settings.hilite ? hilite_none : "");
+            fill_from->formatImpl(ostr, settings, state, frame);
         }
         if (auto fill_to = getFillTo())
         {
-            settings.ostr << (settings.hilite ? hilite_keyword : "") << " TO " << (settings.hilite ? hilite_none : "");
-            fill_to->formatImpl(settings, state, frame);
+            ostr << (settings.hilite ? hilite_keyword : "") << " TO " << (settings.hilite ? hilite_none : "");
+            fill_to->formatImpl(ostr, settings, state, frame);
         }
         if (auto fill_step = getFillStep())
         {
-            settings.ostr << (settings.hilite ? hilite_keyword : "") << " STEP " << (settings.hilite ? hilite_none : "");
-            fill_step->formatImpl(settings, state, frame);
+            ostr << (settings.hilite ? hilite_keyword : "") << " STEP " << (settings.hilite ? hilite_none : "");
+            fill_step->formatImpl(ostr, settings, state, frame);
         }
         if (auto fill_staleness = getFillStaleness())
         {
-            settings.ostr << (settings.hilite ? hilite_keyword : "") << " STALENESS " << (settings.hilite ? hilite_none : "");
-            fill_staleness->formatImpl(settings, state, frame);
+            ostr << (settings.hilite ? hilite_keyword : "") << " STALENESS " << (settings.hilite ? hilite_none : "");
+            fill_staleness->formatImpl(ostr, settings, state, frame);
         }
     }
 }

--- a/src/Parsers/ASTOrderByElement.h
+++ b/src/Parsers/ASTOrderByElement.h
@@ -54,7 +54,7 @@ public:
     void updateTreeHashImpl(SipHash & hash_state, bool ignore_aliases) const override;
 
 protected:
-    void formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
 private:
 
     ASTPtr getChild(Child child) const

--- a/src/Parsers/ASTPartition.cpp
+++ b/src/Parsers/ASTPartition.cpp
@@ -61,20 +61,20 @@ ASTPtr ASTPartition::clone() const
     return res;
 }
 
-void ASTPartition::formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
+void ASTPartition::formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
 {
     if (value)
     {
-        value->formatImpl(settings, state, frame);
+        value->formatImpl(ostr, settings, state, frame);
     }
     else if (all)
     {
-        settings.ostr << "ALL";
+        ostr << "ALL";
     }
     else
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << "ID " << (settings.hilite ? hilite_none : "");
-        id->formatImpl(settings, state, frame);
+        ostr << (settings.hilite ? hilite_keyword : "") << "ID " << (settings.hilite ? hilite_none : "");
+        id->formatImpl(ostr, settings, state, frame);
     }
 }
 }

--- a/src/Parsers/ASTPartition.h
+++ b/src/Parsers/ASTPartition.h
@@ -29,7 +29,7 @@ public:
     }
 
 protected:
-    void formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
 };
 
 }

--- a/src/Parsers/ASTProjectionDeclaration.cpp
+++ b/src/Parsers/ASTProjectionDeclaration.cpp
@@ -15,17 +15,17 @@ ASTPtr ASTProjectionDeclaration::clone() const
 }
 
 
-void ASTProjectionDeclaration::formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
+void ASTProjectionDeclaration::formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
 {
-    settings.writeIdentifier(name, /*ambiguous=*/false);
+    settings.writeIdentifier(ostr, name, /*ambiguous=*/false);
     std::string indent_str = settings.one_line ? "" : std::string(4u * frame.indent, ' ');
     std::string nl_or_nothing = settings.one_line ? "" : "\n";
-    settings.ostr << settings.nl_or_ws << indent_str << "(" << nl_or_nothing;
+    ostr << settings.nl_or_ws << indent_str << "(" << nl_or_nothing;
     FormatStateStacked frame_nested = frame;
     frame_nested.need_parens = false;
     ++frame_nested.indent;
-    query->formatImpl(settings, state, frame_nested);
-    settings.ostr << nl_or_nothing << indent_str << ")";
+    query->formatImpl(ostr, settings, state, frame_nested);
+    ostr << nl_or_nothing << indent_str << ")";
 }
 
 }

--- a/src/Parsers/ASTProjectionDeclaration.h
+++ b/src/Parsers/ASTProjectionDeclaration.h
@@ -17,7 +17,7 @@ public:
     String getID(char) const override { return "Projection"; }
 
     ASTPtr clone() const override;
-    void formatImpl(const FormatSettings & s, FormatState & state, FormatStateStacked frame) const override;
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & s, FormatState & state, FormatStateStacked frame) const override;
 
     void forEachPointerToChild(std::function<void(void**)> f) override
     {

--- a/src/Parsers/ASTProjectionSelectQuery.cpp
+++ b/src/Parsers/ASTProjectionSelectQuery.cpp
@@ -48,7 +48,7 @@ ASTPtr ASTProjectionSelectQuery::clone() const
 }
 
 
-void ASTProjectionSelectQuery::formatImpl(const FormatSettings & s, FormatState & state, FormatStateStacked frame) const
+void ASTProjectionSelectQuery::formatImpl(WriteBuffer & ostr, const FormatSettings & s, FormatState & state, FormatStateStacked frame) const
 {
     frame.current_select = this;
     frame.need_parens = false;
@@ -56,26 +56,26 @@ void ASTProjectionSelectQuery::formatImpl(const FormatSettings & s, FormatState 
 
     if (with())
     {
-        s.ostr << (s.hilite ? hilite_keyword : "") << indent_str << "WITH " << (s.hilite ? hilite_none : "");
-        s.one_line ? with()->formatImpl(s, state, frame) : with()->as<ASTExpressionList &>().formatImplMultiline(s, state, frame);
-        s.ostr << s.nl_or_ws;
+        ostr << (s.hilite ? hilite_keyword : "") << indent_str << "WITH " << (s.hilite ? hilite_none : "");
+        s.one_line ? with()->formatImpl(ostr, s, state, frame) : with()->as<ASTExpressionList &>().formatImplMultiline(ostr, s, state, frame);
+        ostr << s.nl_or_ws;
     }
 
-    s.ostr << (s.hilite ? hilite_keyword : "") << indent_str << "SELECT " << (s.hilite ? hilite_none : "");
+    ostr << (s.hilite ? hilite_keyword : "") << indent_str << "SELECT " << (s.hilite ? hilite_none : "");
 
-    s.one_line ? select()->formatImpl(s, state, frame) : select()->as<ASTExpressionList &>().formatImplMultiline(s, state, frame);
+    s.one_line ? select()->formatImpl(ostr, s, state, frame) : select()->as<ASTExpressionList &>().formatImplMultiline(ostr, s, state, frame);
 
     if (groupBy())
     {
-        s.ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << indent_str << "GROUP BY " << (s.hilite ? hilite_none : "");
-        s.one_line ? groupBy()->formatImpl(s, state, frame) : groupBy()->as<ASTExpressionList &>().formatImplMultiline(s, state, frame);
+        ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << indent_str << "GROUP BY " << (s.hilite ? hilite_none : "");
+        s.one_line ? groupBy()->formatImpl(ostr, s, state, frame) : groupBy()->as<ASTExpressionList &>().formatImplMultiline(ostr, s, state, frame);
     }
 
     if (orderBy())
     {
         /// Let's convert tuple ASTFunction into ASTExpressionList, which generates consistent format
         /// between GROUP BY and ORDER BY projection definition.
-        s.ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << indent_str << "ORDER BY " << (s.hilite ? hilite_none : "");
+        ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << indent_str << "ORDER BY " << (s.hilite ? hilite_none : "");
         ASTPtr order_by;
         if (auto * func = orderBy()->as<ASTFunction>(); func && func->name == "tuple")
             order_by = func->arguments;
@@ -84,7 +84,7 @@ void ASTProjectionSelectQuery::formatImpl(const FormatSettings & s, FormatState 
             order_by = std::make_shared<ASTExpressionList>();
             order_by->children.push_back(orderBy());
         }
-        s.one_line ? order_by->formatImpl(s, state, frame) : order_by->as<ASTExpressionList &>().formatImplMultiline(s, state, frame);
+        s.one_line ? order_by->formatImpl(ostr, s, state, frame) : order_by->as<ASTExpressionList &>().formatImplMultiline(ostr, s, state, frame);
     }
 }
 

--- a/src/Parsers/ASTProjectionSelectQuery.h
+++ b/src/Parsers/ASTProjectionSelectQuery.h
@@ -45,7 +45,7 @@ public:
     ASTPtr cloneToASTSelect() const;
 
 protected:
-    void formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
 
 private:
     std::unordered_map<Expression, size_t> positions;

--- a/src/Parsers/ASTQualifiedAsterisk.cpp
+++ b/src/Parsers/ASTQualifiedAsterisk.cpp
@@ -11,14 +11,14 @@ void ASTQualifiedAsterisk::appendColumnName(WriteBuffer & ostr) const
     writeCString(".*", ostr);
 }
 
-void ASTQualifiedAsterisk::formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
+void ASTQualifiedAsterisk::formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
 {
-    qualifier->formatImpl(settings, state, frame);
-    settings.ostr << ".*";
+    qualifier->formatImpl(ostr, settings, state, frame);
+    ostr << ".*";
 
     if (transformers)
     {
-        transformers->formatImpl(settings, state, frame);
+        transformers->formatImpl(ostr, settings, state, frame);
     }
 }
 

--- a/src/Parsers/ASTQualifiedAsterisk.h
+++ b/src/Parsers/ASTQualifiedAsterisk.h
@@ -35,7 +35,7 @@ public:
     ASTPtr qualifier;
     ASTPtr transformers;
 protected:
-    void formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
 };
 
 }

--- a/src/Parsers/ASTQueryParameter.cpp
+++ b/src/Parsers/ASTQueryParameter.cpp
@@ -7,9 +7,9 @@
 namespace DB
 {
 
-void ASTQueryParameter::formatImplWithoutAlias(const FormatSettings & settings, FormatState &, FormatStateStacked) const
+void ASTQueryParameter::formatImplWithoutAlias(WriteBuffer & ostr, const FormatSettings & settings, FormatState &, FormatStateStacked) const
 {
-    settings.ostr
+    ostr
         << (settings.hilite ? hilite_substitution : "") << '{'
         << (settings.hilite ? hilite_identifier : "") << backQuoteIfNeed(name)
         << (settings.hilite ? hilite_substitution : "") << ':'

--- a/src/Parsers/ASTQueryParameter.h
+++ b/src/Parsers/ASTQueryParameter.h
@@ -24,7 +24,7 @@ public:
     void updateTreeHashImpl(SipHash & hash_state, bool ignore_aliases) const override;
 
 protected:
-    void formatImplWithoutAlias(const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
+    void formatImplWithoutAlias(WriteBuffer & ostr, const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
     void appendColumnNameImpl(WriteBuffer & ostr) const override;
 };
 

--- a/src/Parsers/ASTQueryWithOnCluster.cpp
+++ b/src/Parsers/ASTQueryWithOnCluster.cpp
@@ -26,11 +26,11 @@ bool ASTQueryWithOnCluster::parse(Pos & pos, std::string & cluster_str, Expected
 }
 
 
-void ASTQueryWithOnCluster::formatOnCluster(const IAST::FormatSettings & settings) const
+void ASTQueryWithOnCluster::formatOnCluster(WriteBuffer & ostr, const IAST::FormatSettings & settings) const
 {
     if (!cluster.empty())
     {
-        settings.ostr << (settings.hilite ? IAST::hilite_keyword : "") << " ON CLUSTER " << (settings.hilite ? IAST::hilite_none : "")
+        ostr << (settings.hilite ? IAST::hilite_keyword : "") << " ON CLUSTER " << (settings.hilite ? IAST::hilite_none : "")
         << backQuoteIfNeed(cluster);
     }
 }

--- a/src/Parsers/ASTQueryWithOnCluster.h
+++ b/src/Parsers/ASTQueryWithOnCluster.h
@@ -33,7 +33,7 @@ public:
     /// Returns a query prepared for execution on remote server
     std::string getRewrittenQueryWithoutOnCluster(const WithoutOnClusterASTRewriteParams & params = {}) const;
 
-    void formatOnCluster(const IAST::FormatSettings & settings) const;
+    void formatOnCluster(WriteBuffer & ostr, const IAST::FormatSettings & settings) const;
 
     /// Parses " CLUSTER [cluster|'cluster'] " clause
     static bool parse(Pos & pos, std::string & cluster_str, Expected & expected);

--- a/src/Parsers/ASTQueryWithOutput.cpp
+++ b/src/Parsers/ASTQueryWithOutput.cpp
@@ -35,37 +35,37 @@ void ASTQueryWithOutput::cloneOutputOptions(ASTQueryWithOutput & cloned) const
     }
 }
 
-void ASTQueryWithOutput::formatImpl(const FormatSettings & s, FormatState & state, FormatStateStacked frame) const
+void ASTQueryWithOutput::formatImpl(WriteBuffer & ostr, const FormatSettings & s, FormatState & state, FormatStateStacked frame) const
 {
-    formatQueryImpl(s, state, frame);
+    formatQueryImpl(ostr, s, state, frame);
 
     std::string indent_str = s.one_line ? "" : std::string(4u * frame.indent, ' ');
 
     if (out_file)
     {
-        s.ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << indent_str << "INTO OUTFILE " << (s.hilite ? hilite_none : "");
-        out_file->formatImpl(s, state, frame);
+        ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << indent_str << "INTO OUTFILE " << (s.hilite ? hilite_none : "");
+        out_file->formatImpl(ostr, s, state, frame);
 
-        s.ostr << (s.hilite ? hilite_keyword : "");
+        ostr << (s.hilite ? hilite_keyword : "");
         if (is_outfile_append)
-            s.ostr << " APPEND";
+            ostr << " APPEND";
         if (is_outfile_truncate)
-            s.ostr << " TRUNCATE";
+            ostr << " TRUNCATE";
         if (is_into_outfile_with_stdout)
-            s.ostr << " AND STDOUT";
-        s.ostr << (s.hilite ? hilite_none : "");
+            ostr << " AND STDOUT";
+        ostr << (s.hilite ? hilite_none : "");
     }
 
     if (format)
     {
-        s.ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << indent_str << "FORMAT " << (s.hilite ? hilite_none : "");
-        format->formatImpl(s, state, frame);
+        ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << indent_str << "FORMAT " << (s.hilite ? hilite_none : "");
+        format->formatImpl(ostr, s, state, frame);
     }
 
     if (settings_ast && assert_cast<ASTSetQuery *>(settings_ast.get())->print_in_format)
     {
-        s.ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << indent_str << "SETTINGS " << (s.hilite ? hilite_none : "");
-        settings_ast->formatImpl(s, state, frame);
+        ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << indent_str << "SETTINGS " << (s.hilite ? hilite_none : "");
+        settings_ast->formatImpl(ostr, s, state, frame);
     }
 }
 

--- a/src/Parsers/ASTQueryWithOutput.h
+++ b/src/Parsers/ASTQueryWithOutput.h
@@ -23,7 +23,7 @@ public:
     ASTPtr compression;
     ASTPtr compression_level;
 
-    void formatImpl(const FormatSettings & s, FormatState & state, FormatStateStacked frame) const final;
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & s, FormatState & state, FormatStateStacked frame) const final;
 
     /// Remove 'FORMAT <fmt> and INTO OUTFILE <file>' if exists
     static bool resetOutputASTIfExist(IAST & ast);
@@ -33,7 +33,7 @@ protected:
     void cloneOutputOptions(ASTQueryWithOutput & cloned) const;
 
     /// Format only the query part of the AST (without output options).
-    virtual void formatQueryImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const = 0;
+    virtual void formatQueryImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const = 0;
 };
 
 
@@ -54,9 +54,9 @@ public:
     }
 
 protected:
-    void formatQueryImpl(const FormatSettings & settings, FormatState &, FormatStateStacked) const override
+    void formatQueryImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState &, FormatStateStacked) const override
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "")
+        ostr << (settings.hilite ? hilite_keyword : "")
             << ASTIDAndQueryNames::Query << (settings.hilite ? hilite_none : "");
     }
 };

--- a/src/Parsers/ASTQueryWithTableAndOutput.h
+++ b/src/Parsers/ASTQueryWithTableAndOutput.h
@@ -50,20 +50,20 @@ public:
     QueryKind getQueryKind() const override { return QueryKind::Show; }
 
 protected:
-    void formatQueryImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override
+    void formatQueryImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "")
+        ostr << (settings.hilite ? hilite_keyword : "")
             << (temporary ? AstIDAndQueryNames::QueryTemporary : AstIDAndQueryNames::Query)
             << " " << (settings.hilite ? hilite_none : "");
 
         if (database)
         {
-            database->formatImpl(settings, state, frame);
-            settings.ostr << '.';
+            database->formatImpl(ostr, settings, state, frame);
+            ostr << '.';
         }
 
         chassert(table != nullptr, "Table is empty for the ASTQueryWithTableAndOutputImpl.");
-        table->formatImpl(settings, state, frame);
+        table->formatImpl(ostr, settings, state, frame);
     }
 };
 

--- a/src/Parsers/ASTRefreshStrategy.cpp
+++ b/src/Parsers/ASTRefreshStrategy.cpp
@@ -24,49 +24,49 @@ ASTPtr ASTRefreshStrategy::clone() const
 }
 
 void ASTRefreshStrategy::formatImpl(
-    const IAST::FormatSettings & f_settings, IAST::FormatState & state, IAST::FormatStateStacked frame) const
+    WriteBuffer & ostr, const IAST::FormatSettings & f_settings, IAST::FormatState & state, IAST::FormatStateStacked frame) const
 {
     frame.need_parens = false;
 
-    f_settings.ostr << (f_settings.hilite ? hilite_keyword : "") << "REFRESH " << (f_settings.hilite ? hilite_none : "");
+    ostr << (f_settings.hilite ? hilite_keyword : "") << "REFRESH " << (f_settings.hilite ? hilite_none : "");
     using enum RefreshScheduleKind;
     switch (schedule_kind)
     {
         case AFTER:
-            f_settings.ostr << "AFTER " << (f_settings.hilite ? hilite_none : "");
-            period->formatImpl(f_settings, state, frame);
+            ostr << "AFTER " << (f_settings.hilite ? hilite_none : "");
+            period->formatImpl(ostr, f_settings, state, frame);
             break;
         case EVERY:
-            f_settings.ostr << "EVERY " << (f_settings.hilite ? hilite_none : "");
-            period->formatImpl(f_settings, state, frame);
+            ostr << "EVERY " << (f_settings.hilite ? hilite_none : "");
+            period->formatImpl(ostr, f_settings, state, frame);
             if (offset)
             {
-                f_settings.ostr << (f_settings.hilite ? hilite_keyword : "") << " OFFSET " << (f_settings.hilite ? hilite_none : "");
-                offset->formatImpl(f_settings, state, frame);
+                ostr << (f_settings.hilite ? hilite_keyword : "") << " OFFSET " << (f_settings.hilite ? hilite_none : "");
+                offset->formatImpl(ostr, f_settings, state, frame);
             }
             break;
         default:
-            f_settings.ostr << (f_settings.hilite ? hilite_none : "");
+            ostr << (f_settings.hilite ? hilite_none : "");
             break;
     }
 
     if (spread)
     {
-        f_settings.ostr << (f_settings.hilite ? hilite_keyword : "") << " RANDOMIZE FOR " << (f_settings.hilite ? hilite_none : "");
-        spread->formatImpl(f_settings, state, frame);
+        ostr << (f_settings.hilite ? hilite_keyword : "") << " RANDOMIZE FOR " << (f_settings.hilite ? hilite_none : "");
+        spread->formatImpl(ostr, f_settings, state, frame);
     }
     if (dependencies)
     {
-        f_settings.ostr << (f_settings.hilite ? hilite_keyword : "") << " DEPENDS ON " << (f_settings.hilite ? hilite_none : "");
-        dependencies->formatImpl(f_settings, state, frame);
+        ostr << (f_settings.hilite ? hilite_keyword : "") << " DEPENDS ON " << (f_settings.hilite ? hilite_none : "");
+        dependencies->formatImpl(ostr, f_settings, state, frame);
     }
     if (settings)
     {
-        f_settings.ostr << (f_settings.hilite ? hilite_keyword : "") << " SETTINGS " << (f_settings.hilite ? hilite_none : "");
-        settings->formatImpl(f_settings, state, frame);
+        ostr << (f_settings.hilite ? hilite_keyword : "") << " SETTINGS " << (f_settings.hilite ? hilite_none : "");
+        settings->formatImpl(ostr, f_settings, state, frame);
     }
     if (append)
-        f_settings.ostr << (f_settings.hilite ? hilite_keyword : "") << " APPEND" << (f_settings.hilite ? hilite_none : "");
+        ostr << (f_settings.hilite ? hilite_keyword : "") << " APPEND" << (f_settings.hilite ? hilite_none : "");
 }
 
 }

--- a/src/Parsers/ASTRefreshStrategy.h
+++ b/src/Parsers/ASTRefreshStrategy.h
@@ -30,7 +30,7 @@ public:
 
     ASTPtr clone() const override;
 
-    void formatImpl(const FormatSettings & s, FormatState & state, FormatStateStacked frame) const override;
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & s, FormatState & state, FormatStateStacked frame) const override;
 };
 
 }

--- a/src/Parsers/ASTRenameQuery.h
+++ b/src/Parsers/ASTRenameQuery.h
@@ -155,66 +155,66 @@ public:
     }
 
 protected:
-    void formatQueryImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override
+    void formatQueryImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override
     {
         if (database)
         {
-            settings.ostr << (settings.hilite ? hilite_keyword : "") << "RENAME DATABASE " << (settings.hilite ? hilite_none : "");
+            ostr << (settings.hilite ? hilite_keyword : "") << "RENAME DATABASE " << (settings.hilite ? hilite_none : "");
 
             if (elements.at(0).if_exists)
-                settings.ostr << (settings.hilite ? hilite_keyword : "") << "IF EXISTS " << (settings.hilite ? hilite_none : "");
+                ostr << (settings.hilite ? hilite_keyword : "") << "IF EXISTS " << (settings.hilite ? hilite_none : "");
 
-            elements.at(0).from.database->formatImpl(settings, state, frame);
-            settings.ostr << (settings.hilite ? hilite_keyword : "") << " TO " << (settings.hilite ? hilite_none : "");
-            elements.at(0).to.database->formatImpl(settings, state, frame);
-            formatOnCluster(settings);
+            elements.at(0).from.database->formatImpl(ostr, settings, state, frame);
+            ostr << (settings.hilite ? hilite_keyword : "") << " TO " << (settings.hilite ? hilite_none : "");
+            elements.at(0).to.database->formatImpl(ostr, settings, state, frame);
+            formatOnCluster(ostr, settings);
             return;
         }
 
-        settings.ostr << (settings.hilite ? hilite_keyword : "");
+        ostr << (settings.hilite ? hilite_keyword : "");
         if (exchange && dictionary)
-            settings.ostr << "EXCHANGE DICTIONARIES ";
+            ostr << "EXCHANGE DICTIONARIES ";
         else if (exchange)
-            settings.ostr << "EXCHANGE TABLES ";
+            ostr << "EXCHANGE TABLES ";
         else if (dictionary)
-            settings.ostr << "RENAME DICTIONARY ";
+            ostr << "RENAME DICTIONARY ";
         else
-            settings.ostr << "RENAME TABLE ";
+            ostr << "RENAME TABLE ";
 
-        settings.ostr << (settings.hilite ? hilite_none : "");
+        ostr << (settings.hilite ? hilite_none : "");
 
         for (auto it = elements.cbegin(); it != elements.cend(); ++it)
         {
             if (it != elements.cbegin())
-                settings.ostr << ", ";
+                ostr << ", ";
 
             if (it->if_exists)
-                settings.ostr << (settings.hilite ? hilite_keyword : "") << "IF EXISTS " << (settings.hilite ? hilite_none : "");
+                ostr << (settings.hilite ? hilite_keyword : "") << "IF EXISTS " << (settings.hilite ? hilite_none : "");
 
 
             if (it->from.database)
             {
-                it->from.database->formatImpl(settings, state, frame);
-                settings.ostr << '.';
+                it->from.database->formatImpl(ostr, settings, state, frame);
+                ostr << '.';
             }
 
             chassert(it->from.table);
-            it->from.table->formatImpl(settings, state, frame);
+            it->from.table->formatImpl(ostr, settings, state, frame);
 
-            settings.ostr << (settings.hilite ? hilite_keyword : "") << (exchange ? " AND " : " TO ") << (settings.hilite ? hilite_none : "");
+            ostr << (settings.hilite ? hilite_keyword : "") << (exchange ? " AND " : " TO ") << (settings.hilite ? hilite_none : "");
 
             if (it->to.database)
             {
-                it->to.database->formatImpl(settings, state, frame);
-                settings.ostr << '.';
+                it->to.database->formatImpl(ostr, settings, state, frame);
+                ostr << '.';
             }
 
             chassert(it->to.table);
-            it->to.table->formatImpl(settings, state, frame);
+            it->to.table->formatImpl(ostr, settings, state, frame);
 
         }
 
-        formatOnCluster(settings);
+        formatOnCluster(ostr, settings);
     }
 
     Elements elements;

--- a/src/Parsers/ASTSQLSecurity.cpp
+++ b/src/Parsers/ASTSQLSecurity.cpp
@@ -5,33 +5,33 @@
 namespace DB
 {
 
-void ASTSQLSecurity::formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
+void ASTSQLSecurity::formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
 {
     if (!type)
         return;
 
     if (definer || is_definer_current_user)
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << "DEFINER" << (settings.hilite ? hilite_none : "");
-        settings.ostr << " = ";
+        ostr << (settings.hilite ? hilite_keyword : "") << "DEFINER" << (settings.hilite ? hilite_none : "");
+        ostr << " = ";
         if (definer)
-            definer->formatImpl(settings, state, frame);
+            definer->formatImpl(ostr, settings, state, frame);
         else
-            settings.ostr << "CURRENT_USER";
-        settings.ostr << " ";
+            ostr << "CURRENT_USER";
+        ostr << " ";
     }
 
-    settings.ostr << (settings.hilite ? hilite_keyword : "") << "SQL SECURITY" << (settings.hilite ? hilite_none : "");
+    ostr << (settings.hilite ? hilite_keyword : "") << "SQL SECURITY" << (settings.hilite ? hilite_none : "");
     switch (*type)
     {
         case SQLSecurityType::INVOKER:
-            settings.ostr << " INVOKER";
+            ostr << " INVOKER";
             break;
         case SQLSecurityType::DEFINER:
-            settings.ostr << " DEFINER";
+            ostr << " DEFINER";
             break;
         case SQLSecurityType::NONE:
-            settings.ostr << " NONE";
+            ostr << " NONE";
             break;
     }
 }

--- a/src/Parsers/ASTSQLSecurity.h
+++ b/src/Parsers/ASTSQLSecurity.h
@@ -20,7 +20,7 @@ public:
     String getID(char) const override { return "View SQL Security"; }
     ASTPtr clone() const override { return std::make_shared<ASTSQLSecurity>(*this); }
 
-    void formatImpl(const FormatSettings & s, FormatState & state, FormatStateStacked frame) const override;
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & s, FormatState & state, FormatStateStacked frame) const override;
 };
 
 }

--- a/src/Parsers/ASTSampleRatio.cpp
+++ b/src/Parsers/ASTSampleRatio.cpp
@@ -34,9 +34,9 @@ String ASTSampleRatio::toString(Rational ratio)
     return toString(ratio.numerator) + " / " + toString(ratio.denominator);
 }
 
-void ASTSampleRatio::formatImpl(const IAST::FormatSettings & settings, IAST::FormatState &, IAST::FormatStateStacked) const
+void ASTSampleRatio::formatImpl(WriteBuffer & ostr, const IAST::FormatSettings &, IAST::FormatState &, IAST::FormatStateStacked) const
 {
-    settings.ostr << toString(ratio);
+    ostr << toString(ratio);
 }
 
 }

--- a/src/Parsers/ASTSampleRatio.h
+++ b/src/Parsers/ASTSampleRatio.h
@@ -31,7 +31,7 @@ public:
     static String toString(BigNum num);
     static String toString(Rational ratio);
 
-    void formatImpl(const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
+    void formatImpl(WriteBuffer & ostr, const FormatSettings &, FormatState &, FormatStateStacked) const override;
 };
 
 inline bool operator==(const ASTSampleRatio::Rational & lhs, const ASTSampleRatio::Rational & rhs)

--- a/src/Parsers/ASTSelectIntersectExceptQuery.cpp
+++ b/src/Parsers/ASTSelectIntersectExceptQuery.cpp
@@ -18,7 +18,7 @@ ASTPtr ASTSelectIntersectExceptQuery::clone() const
     return res;
 }
 
-void ASTSelectIntersectExceptQuery::formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
+void ASTSelectIntersectExceptQuery::formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
 {
     std::string indent_str = settings.one_line ? "" : std::string(4 * frame.indent, ' ');
 
@@ -26,13 +26,13 @@ void ASTSelectIntersectExceptQuery::formatImpl(const FormatSettings & settings, 
     {
         if (it != children.begin())
         {
-            settings.ostr << settings.nl_or_ws << indent_str << (settings.hilite ? hilite_keyword : "")
+            ostr << settings.nl_or_ws << indent_str << (settings.hilite ? hilite_keyword : "")
                           << fromOperator(final_operator)
                           << (settings.hilite ? hilite_none : "")
                           << settings.nl_or_ws;
         }
 
-        (*it)->formatImpl(settings, state, frame);
+        (*it)->formatImpl(ostr, settings, state, frame);
     }
 }
 

--- a/src/Parsers/ASTSelectIntersectExceptQuery.h
+++ b/src/Parsers/ASTSelectIntersectExceptQuery.h
@@ -23,7 +23,7 @@ public:
         INTERSECT_DISTINCT,
     };
 
-    void formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
 
     QueryKind getQueryKind() const override { return QueryKind::Select; }
 

--- a/src/Parsers/ASTSelectQuery.cpp
+++ b/src/Parsers/ASTSelectQuery.cpp
@@ -54,7 +54,7 @@ void ASTSelectQuery::updateTreeHashImpl(SipHash & hash_state, bool ignore_aliase
 }
 
 
-void ASTSelectQuery::formatImpl(const FormatSettings & s, FormatState & state, FormatStateStacked frame) const
+void ASTSelectQuery::formatImpl(WriteBuffer & ostr, const FormatSettings & s, FormatState & state, FormatStateStacked frame) const
 {
     frame.current_select = this;
     frame.need_parens = false;
@@ -64,54 +64,54 @@ void ASTSelectQuery::formatImpl(const FormatSettings & s, FormatState & state, F
 
     if (with())
     {
-        s.ostr << (s.hilite ? hilite_keyword : "") << indent_str << "WITH" << (s.hilite ? hilite_none : "");
+        ostr << (s.hilite ? hilite_keyword : "") << indent_str << "WITH" << (s.hilite ? hilite_none : "");
 
         if (recursive_with)
-            s.ostr << (s.hilite ? hilite_keyword : "") << " RECURSIVE" << (s.hilite ? hilite_none : "");
+            ostr << (s.hilite ? hilite_keyword : "") << " RECURSIVE" << (s.hilite ? hilite_none : "");
 
         s.one_line
-            ? with()->formatImpl(s, state, frame)
-            : with()->as<ASTExpressionList &>().formatImplMultiline(s, state, frame);
-        s.ostr << s.nl_or_ws;
+            ? with()->formatImpl(ostr, s, state, frame)
+            : with()->as<ASTExpressionList &>().formatImplMultiline(ostr, s, state, frame);
+        ostr << s.nl_or_ws;
     }
 
-    s.ostr << (s.hilite ? hilite_keyword : "") << indent_str << "SELECT" << (distinct ? " DISTINCT" : "") << (s.hilite ? hilite_none : "");
+    ostr << (s.hilite ? hilite_keyword : "") << indent_str << "SELECT" << (distinct ? " DISTINCT" : "") << (s.hilite ? hilite_none : "");
 
     s.one_line
-        ? select()->formatImpl(s, state, frame)
-        : select()->as<ASTExpressionList &>().formatImplMultiline(s, state, frame);
+        ? select()->formatImpl(ostr, s, state, frame)
+        : select()->as<ASTExpressionList &>().formatImplMultiline(ostr, s, state, frame);
 
     if (tables())
     {
-        s.ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << indent_str << "FROM" << (s.hilite ? hilite_none : "");
-        tables()->formatImpl(s, state, frame);
+        ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << indent_str << "FROM" << (s.hilite ? hilite_none : "");
+        tables()->formatImpl(ostr, s, state, frame);
     }
 
     if (prewhere())
     {
-        s.ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << indent_str << "PREWHERE " << (s.hilite ? hilite_none : "");
-        prewhere()->formatImpl(s, state, frame);
+        ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << indent_str << "PREWHERE " << (s.hilite ? hilite_none : "");
+        prewhere()->formatImpl(ostr, s, state, frame);
     }
 
     if (where())
     {
-        s.ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << indent_str << "WHERE " << (s.hilite ? hilite_none : "");
-        where()->formatImpl(s, state, frame);
+        ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << indent_str << "WHERE " << (s.hilite ? hilite_none : "");
+        where()->formatImpl(ostr, s, state, frame);
     }
 
     if (!group_by_all && groupBy())
     {
-        s.ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << indent_str << "GROUP BY" << (s.hilite ? hilite_none : "");
+        ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << indent_str << "GROUP BY" << (s.hilite ? hilite_none : "");
         if (!group_by_with_grouping_sets)
         {
             s.one_line
-            ? groupBy()->formatImpl(s, state, frame)
-            : groupBy()->as<ASTExpressionList &>().formatImplMultiline(s, state, frame);
+            ? groupBy()->formatImpl(ostr, s, state, frame)
+            : groupBy()->as<ASTExpressionList &>().formatImplMultiline(ostr, s, state, frame);
         }
     }
 
     if (group_by_all)
-        s.ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << indent_str << "GROUP BY ALL" << (s.hilite ? hilite_none : "");
+        ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << indent_str << "GROUP BY ALL" << (s.hilite ? hilite_none : "");
 
     if (group_by_with_grouping_sets && groupBy())
     {
@@ -119,73 +119,73 @@ void ASTSelectQuery::formatImpl(const FormatSettings & s, FormatState & state, F
         nested_frame.surround_each_list_element_with_parens = true;
         nested_frame.expression_list_prepend_whitespace = false;
         nested_frame.indent++;
-        s.ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << indent_str << (s.one_line ? "" : "    ") << "GROUPING SETS" << (s.hilite ? hilite_none : "");
-        s.ostr << " (";
+        ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << indent_str << (s.one_line ? "" : "    ") << "GROUPING SETS" << (s.hilite ? hilite_none : "");
+        ostr << " (";
         s.one_line
-        ? groupBy()->formatImpl(s, state, nested_frame)
-        : groupBy()->as<ASTExpressionList &>().formatImplMultiline(s, state, nested_frame);
-        s.ostr << ")";
+        ? groupBy()->formatImpl(ostr, s, state, nested_frame)
+        : groupBy()->as<ASTExpressionList &>().formatImplMultiline(ostr, s, state, nested_frame);
+        ostr << ")";
     }
 
     if (group_by_with_rollup)
-        s.ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << indent_str << (s.one_line ? "" : "    ") << "WITH ROLLUP" << (s.hilite ? hilite_none : "");
+        ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << indent_str << (s.one_line ? "" : "    ") << "WITH ROLLUP" << (s.hilite ? hilite_none : "");
 
     if (group_by_with_cube)
-        s.ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << indent_str << (s.one_line ? "" : "    ") << "WITH CUBE" << (s.hilite ? hilite_none : "");
+        ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << indent_str << (s.one_line ? "" : "    ") << "WITH CUBE" << (s.hilite ? hilite_none : "");
 
     if (group_by_with_totals)
-        s.ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << indent_str << (s.one_line ? "" : "    ") << "WITH TOTALS" << (s.hilite ? hilite_none : "");
+        ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << indent_str << (s.one_line ? "" : "    ") << "WITH TOTALS" << (s.hilite ? hilite_none : "");
 
     if (having())
     {
-        s.ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << indent_str << "HAVING " << (s.hilite ? hilite_none : "");
-        having()->formatImpl(s, state, frame);
+        ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << indent_str << "HAVING " << (s.hilite ? hilite_none : "");
+        having()->formatImpl(ostr, s, state, frame);
     }
 
     if (window())
     {
-        s.ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << indent_str <<
+        ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << indent_str <<
             "WINDOW" << (s.hilite ? hilite_none : "");
-        window()->as<ASTExpressionList &>().formatImplMultiline(s, state, frame);
+        window()->as<ASTExpressionList &>().formatImplMultiline(ostr, s, state, frame);
     }
 
     if (qualify())
     {
-        s.ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << indent_str << "QUALIFY " << (s.hilite ? hilite_none : "");
-        qualify()->formatImpl(s, state, frame);
+        ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << indent_str << "QUALIFY " << (s.hilite ? hilite_none : "");
+        qualify()->formatImpl(ostr, s, state, frame);
     }
 
     if (!order_by_all && orderBy())
     {
-        s.ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << indent_str << "ORDER BY" << (s.hilite ? hilite_none : "");
+        ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << indent_str << "ORDER BY" << (s.hilite ? hilite_none : "");
         s.one_line
-            ? orderBy()->formatImpl(s, state, frame)
-            : orderBy()->as<ASTExpressionList &>().formatImplMultiline(s, state, frame);
+            ? orderBy()->formatImpl(ostr, s, state, frame)
+            : orderBy()->as<ASTExpressionList &>().formatImplMultiline(ostr, s, state, frame);
 
         if (interpolate())
         {
-            s.ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << indent_str << "INTERPOLATE" << (s.hilite ? hilite_none : "");
+            ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << indent_str << "INTERPOLATE" << (s.hilite ? hilite_none : "");
             if (!interpolate()->children.empty())
             {
-                s.ostr << " (";
-                interpolate()->formatImpl(s, state, frame);
-                s.ostr << " )";
+                ostr << " (";
+                interpolate()->formatImpl(ostr, s, state, frame);
+                ostr << " )";
             }
         }
     }
 
     if (order_by_all)
     {
-        s.ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << indent_str << "ORDER BY ALL" << (s.hilite ? hilite_none : "");
+        ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << indent_str << "ORDER BY ALL" << (s.hilite ? hilite_none : "");
 
         auto * elem = orderBy()->children[0]->as<ASTOrderByElement>();
-        s.ostr << (s.hilite ? hilite_keyword : "")
+        ostr << (s.hilite ? hilite_keyword : "")
                << (elem->direction == -1 ? " DESC" : " ASC")
                << (s.hilite ? hilite_none : "");
 
         if (elem->nulls_direction_was_explicitly_specified)
         {
-            s.ostr << (s.hilite ? hilite_keyword : "")
+            ostr << (s.hilite ? hilite_keyword : "")
                    << " NULLS "
                    << (elem->nulls_direction == elem->direction ? "LAST" : "FIRST")
                    << (s.hilite ? hilite_none : "");
@@ -194,41 +194,41 @@ void ASTSelectQuery::formatImpl(const FormatSettings & s, FormatState & state, F
 
     if (limitByLength())
     {
-        s.ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << indent_str << "LIMIT " << (s.hilite ? hilite_none : "");
+        ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << indent_str << "LIMIT " << (s.hilite ? hilite_none : "");
         if (limitByOffset())
         {
-            limitByOffset()->formatImpl(s, state, frame);
-            s.ostr << ", ";
+            limitByOffset()->formatImpl(ostr, s, state, frame);
+            ostr << ", ";
         }
-        limitByLength()->formatImpl(s, state, frame);
-        s.ostr << (s.hilite ? hilite_keyword : "") << " BY" << (s.hilite ? hilite_none : "");
+        limitByLength()->formatImpl(ostr, s, state, frame);
+        ostr << (s.hilite ? hilite_keyword : "") << " BY" << (s.hilite ? hilite_none : "");
         s.one_line
-            ? limitBy()->formatImpl(s, state, frame)
-            : limitBy()->as<ASTExpressionList &>().formatImplMultiline(s, state, frame);
+            ? limitBy()->formatImpl(ostr, s, state, frame)
+            : limitBy()->as<ASTExpressionList &>().formatImplMultiline(ostr, s, state, frame);
     }
 
     if (limitLength())
     {
-        s.ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << indent_str << "LIMIT " << (s.hilite ? hilite_none : "");
+        ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << indent_str << "LIMIT " << (s.hilite ? hilite_none : "");
         if (limitOffset())
         {
-            limitOffset()->formatImpl(s, state, frame);
-            s.ostr << ", ";
+            limitOffset()->formatImpl(ostr, s, state, frame);
+            ostr << ", ";
         }
-        limitLength()->formatImpl(s, state, frame);
+        limitLength()->formatImpl(ostr, s, state, frame);
         if (limit_with_ties)
-            s.ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << indent_str << " WITH TIES" << (s.hilite ? hilite_none : "");
+            ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << indent_str << " WITH TIES" << (s.hilite ? hilite_none : "");
     }
     else if (limitOffset())
     {
-        s.ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << indent_str << "OFFSET " << (s.hilite ? hilite_none : "");
-        limitOffset()->formatImpl(s, state, frame);
+        ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << indent_str << "OFFSET " << (s.hilite ? hilite_none : "");
+        limitOffset()->formatImpl(ostr, s, state, frame);
     }
 
     if (settings() && assert_cast<ASTSetQuery *>(settings().get())->print_in_format)
     {
-        s.ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << indent_str << "SETTINGS " << (s.hilite ? hilite_none : "");
-        settings()->formatImpl(s, state, frame);
+        ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << indent_str << "SETTINGS " << (s.hilite ? hilite_none : "");
+        settings()->formatImpl(ostr, s, state, frame);
     }
 }
 

--- a/src/Parsers/ASTSelectQuery.h
+++ b/src/Parsers/ASTSelectQuery.h
@@ -152,7 +152,7 @@ public:
     bool hasQueryParameters() const;
 
 protected:
-    void formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
 
 private:
     std::unordered_map<Expression, size_t> positions;

--- a/src/Parsers/ASTSelectWithUnionQuery.cpp
+++ b/src/Parsers/ASTSelectWithUnionQuery.cpp
@@ -27,7 +27,7 @@ ASTPtr ASTSelectWithUnionQuery::clone() const
 }
 
 
-void ASTSelectWithUnionQuery::formatQueryImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
+void ASTSelectWithUnionQuery::formatQueryImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
 {
     std::string indent_str = settings.one_line ? "" : std::string(4 * frame.indent, ' ');
 
@@ -57,24 +57,24 @@ void ASTSelectWithUnionQuery::formatQueryImpl(const FormatSettings & settings, F
     for (ASTs::const_iterator it = list_of_selects->children.begin(); it != list_of_selects->children.end(); ++it)
     {
         if (it != list_of_selects->children.begin())
-            settings.ostr << settings.nl_or_ws << indent_str << (settings.hilite ? hilite_keyword : "")
+            ostr << settings.nl_or_ws << indent_str << (settings.hilite ? hilite_keyword : "")
                           << mode_to_str((is_normalized) ? union_mode : list_of_modes[it - list_of_selects->children.begin() - 1])
                           << (settings.hilite ? hilite_none : "");
 
         if (auto * /*node*/ _ = (*it)->as<ASTSelectWithUnionQuery>())
         {
             if (it != list_of_selects->children.begin())
-                settings.ostr << settings.nl_or_ws;
+                ostr << settings.nl_or_ws;
 
-            settings.ostr << indent_str;
+            ostr << indent_str;
             auto sub_query = std::make_shared<ASTSubquery>(*it);
-            sub_query->formatImpl(settings, state, frame);
+            sub_query->formatImpl(ostr, settings, state, frame);
         }
         else
         {
             if (it != list_of_selects->children.begin())
-                settings.ostr << settings.nl_or_ws;
-            (*it)->formatImpl(settings, state, frame);
+                ostr << settings.nl_or_ws;
+            (*it)->formatImpl(ostr, settings, state, frame);
         }
     }
 }

--- a/src/Parsers/ASTSelectWithUnionQuery.h
+++ b/src/Parsers/ASTSelectWithUnionQuery.h
@@ -15,7 +15,7 @@ public:
 
     ASTPtr clone() const override;
 
-    void formatQueryImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
+    void formatQueryImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
 
     QueryKind getQueryKind() const override { return QueryKind::Select; }
 

--- a/src/Parsers/ASTSetQuery.cpp
+++ b/src/Parsers/ASTSetQuery.cpp
@@ -66,48 +66,48 @@ void ASTSetQuery::updateTreeHashImpl(SipHash & hash_state, bool /*ignore_aliases
     }
 }
 
-void ASTSetQuery::formatImpl(const FormatSettings & format, FormatState &, FormatStateStacked) const
+void ASTSetQuery::formatImpl(WriteBuffer & ostr, const FormatSettings & format, FormatState &, FormatStateStacked) const
 {
     if (is_standalone)
-        format.ostr << (format.hilite ? hilite_keyword : "") << "SET " << (format.hilite ? hilite_none : "");
+        ostr << (format.hilite ? hilite_keyword : "") << "SET " << (format.hilite ? hilite_none : "");
 
     bool first = true;
 
     for (const auto & change : changes)
     {
         if (!first)
-            format.ostr << ", ";
+            ostr << ", ";
         else
             first = false;
 
-        formatSettingName(change.name, format.ostr);
+        formatSettingName(change.name, ostr);
         CustomType custom;
         if (!format.show_secrets && change.value.tryGet<CustomType>(custom) && custom.isSecret())
-            format.ostr << " = " << custom.toString(false);
+            ostr << " = " << custom.toString(false);
         else
-            format.ostr << " = " << applyVisitor(FieldVisitorToSetting(), change.value);
+            ostr << " = " << applyVisitor(FieldVisitorToSetting(), change.value);
     }
 
     for (const auto & setting_name : default_settings)
     {
         if (!first)
-            format.ostr << ", ";
+            ostr << ", ";
         else
             first = false;
 
-        formatSettingName(setting_name, format.ostr);
-        format.ostr << " = DEFAULT";
+        formatSettingName(setting_name, ostr);
+        ostr << " = DEFAULT";
     }
 
     for (const auto & [name, value] : query_parameters)
     {
         if (!first)
-            format.ostr << ", ";
+            ostr << ", ";
         else
             first = false;
 
-        formatSettingName(QUERY_PARAMETER_NAME_PREFIX + name, format.ostr);
-        format.ostr << " = " << quoteString(value);
+        formatSettingName(QUERY_PARAMETER_NAME_PREFIX + name, ostr);
+        ostr << " = " << quoteString(value);
     }
 }
 

--- a/src/Parsers/ASTSetQuery.h
+++ b/src/Parsers/ASTSetQuery.h
@@ -32,7 +32,7 @@ public:
 
     ASTPtr clone() const override { return std::make_shared<ASTSetQuery>(*this); }
 
-    void formatImpl(const FormatSettings & format, FormatState &, FormatStateStacked) const override;
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & format, FormatState &, FormatStateStacked) const override;
 
     void updateTreeHashImpl(SipHash & hash_state, bool ignore_aliases) const override;
 

--- a/src/Parsers/ASTShowColumnsQuery.cpp
+++ b/src/Parsers/ASTShowColumnsQuery.cpp
@@ -15,22 +15,22 @@ ASTPtr ASTShowColumnsQuery::clone() const
     return res;
 }
 
-void ASTShowColumnsQuery::formatQueryImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
+void ASTShowColumnsQuery::formatQueryImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
 {
-    settings.ostr << (settings.hilite ? hilite_keyword : "")
+    ostr << (settings.hilite ? hilite_keyword : "")
                   << "SHOW "
                   << (extended ? "EXTENDED " : "")
                   << (full ? "FULL " : "")
                   << "COLUMNS"
                   << (settings.hilite ? hilite_none : "");
 
-    settings.ostr << (settings.hilite ? hilite_keyword : "") << " FROM " << (settings.hilite ? hilite_none : "") << backQuoteIfNeed(table);
+    ostr << (settings.hilite ? hilite_keyword : "") << " FROM " << (settings.hilite ? hilite_none : "") << backQuoteIfNeed(table);
     if (!database.empty())
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << " FROM " << (settings.hilite ? hilite_none : "") << backQuoteIfNeed(database);
+        ostr << (settings.hilite ? hilite_keyword : "") << " FROM " << (settings.hilite ? hilite_none : "") << backQuoteIfNeed(database);
 
 
     if (!like.empty())
-        settings.ostr << (settings.hilite ? hilite_keyword : "")
+        ostr << (settings.hilite ? hilite_keyword : "")
                       << (not_like ? " NOT" : "")
                       << (case_insensitive_like ? " ILIKE " : " LIKE")
                       << (settings.hilite ? hilite_none : "")
@@ -38,14 +38,14 @@ void ASTShowColumnsQuery::formatQueryImpl(const FormatSettings & settings, Forma
 
     if (where_expression)
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << " WHERE " << (settings.hilite ? hilite_none : "");
-        where_expression->formatImpl(settings, state, frame);
+        ostr << (settings.hilite ? hilite_keyword : "") << " WHERE " << (settings.hilite ? hilite_none : "");
+        where_expression->formatImpl(ostr, settings, state, frame);
     }
 
     if (limit_length)
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << " LIMIT " << (settings.hilite ? hilite_none : "");
-        limit_length->formatImpl(settings, state, frame);
+        ostr << (settings.hilite ? hilite_keyword : "") << " LIMIT " << (settings.hilite ? hilite_none : "");
+        limit_length->formatImpl(ostr, settings, state, frame);
     }
 }
 

--- a/src/Parsers/ASTShowColumnsQuery.h
+++ b/src/Parsers/ASTShowColumnsQuery.h
@@ -28,7 +28,7 @@ public:
     QueryKind getQueryKind() const override { return QueryKind::Show; }
 
 protected:
-    void formatQueryImpl(const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
+    void formatQueryImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
 };
 
 }

--- a/src/Parsers/ASTShowFunctionsQuery.cpp
+++ b/src/Parsers/ASTShowFunctionsQuery.cpp
@@ -13,12 +13,12 @@ ASTPtr ASTShowFunctionsQuery::clone() const
     return res;
 }
 
-void ASTShowFunctionsQuery::formatQueryImpl(const FormatSettings & settings, FormatState &, FormatStateStacked) const
+void ASTShowFunctionsQuery::formatQueryImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState &, FormatStateStacked) const
 {
-    settings.ostr << (settings.hilite ? hilite_keyword : "") << "SHOW FUNCTIONS" << (settings.hilite ? hilite_none : "");
+    ostr << (settings.hilite ? hilite_keyword : "") << "SHOW FUNCTIONS" << (settings.hilite ? hilite_none : "");
 
     if (!like.empty())
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << (case_insensitive_like ? " ILIKE " : " LIKE ")
+        ostr << (settings.hilite ? hilite_keyword : "") << (case_insensitive_like ? " ILIKE " : " LIKE ")
                       << (settings.hilite ? hilite_none : "") << DB::quote << like;
 }
 

--- a/src/Parsers/ASTShowFunctionsQuery.h
+++ b/src/Parsers/ASTShowFunctionsQuery.h
@@ -17,7 +17,7 @@ public:
     QueryKind getQueryKind() const override { return QueryKind::Show; }
 
 protected:
-    void formatQueryImpl(const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
+    void formatQueryImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
 };
 
 }

--- a/src/Parsers/ASTShowIndexesQuery.cpp
+++ b/src/Parsers/ASTShowIndexesQuery.cpp
@@ -15,22 +15,22 @@ ASTPtr ASTShowIndexesQuery::clone() const
     return res;
 }
 
-void ASTShowIndexesQuery::formatQueryImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
+void ASTShowIndexesQuery::formatQueryImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
 {
-    settings.ostr << (settings.hilite ? hilite_keyword : "")
+    ostr << (settings.hilite ? hilite_keyword : "")
                   << "SHOW "
                   << (extended ? "EXTENDED " : "")
                   << "INDEXES"
                   << (settings.hilite ? hilite_none : "");
 
-    settings.ostr << (settings.hilite ? hilite_keyword : "") << " FROM " << (settings.hilite ? hilite_none : "") << backQuoteIfNeed(table);
+    ostr << (settings.hilite ? hilite_keyword : "") << " FROM " << (settings.hilite ? hilite_none : "") << backQuoteIfNeed(table);
     if (!database.empty())
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << " FROM " << (settings.hilite ? hilite_none : "") << backQuoteIfNeed(database);
+        ostr << (settings.hilite ? hilite_keyword : "") << " FROM " << (settings.hilite ? hilite_none : "") << backQuoteIfNeed(database);
 
     if (where_expression)
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << " WHERE " << (settings.hilite ? hilite_none : "");
-        where_expression->formatImpl(settings, state, frame);
+        ostr << (settings.hilite ? hilite_keyword : "") << " WHERE " << (settings.hilite ? hilite_none : "");
+        where_expression->formatImpl(ostr, settings, state, frame);
     }
 }
 

--- a/src/Parsers/ASTShowIndexesQuery.h
+++ b/src/Parsers/ASTShowIndexesQuery.h
@@ -22,7 +22,7 @@ public:
     QueryKind getQueryKind() const override { return QueryKind::Show; }
 
 protected:
-    void formatQueryImpl(const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
+    void formatQueryImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
 };
 
 }

--- a/src/Parsers/ASTShowSettingQuery.cpp
+++ b/src/Parsers/ASTShowSettingQuery.cpp
@@ -16,9 +16,9 @@ ASTPtr ASTShowSettingQuery::clone() const
     return res;
 }
 
-void ASTShowSettingQuery::formatQueryImpl(const FormatSettings & settings, FormatState &, FormatStateStacked) const
+void ASTShowSettingQuery::formatQueryImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState &, FormatStateStacked) const
 {
-    settings.ostr << (settings.hilite ? hilite_keyword : "") << "SHOW SETTING " << (settings.hilite ? hilite_none : "")
+    ostr << (settings.hilite ? hilite_keyword : "") << "SHOW SETTING " << (settings.hilite ? hilite_none : "")
                   << backQuoteIfNeed(setting_name);
 }
 

--- a/src/Parsers/ASTShowSettingQuery.h
+++ b/src/Parsers/ASTShowSettingQuery.h
@@ -21,7 +21,7 @@ public:
     QueryKind getQueryKind() const override { return QueryKind::Show; }
 
 protected:
-    void formatQueryImpl(const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
+    void formatQueryImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
 
 private:
     String setting_name;

--- a/src/Parsers/ASTShowTablesQuery.cpp
+++ b/src/Parsers/ASTShowTablesQuery.cpp
@@ -25,10 +25,10 @@ String ASTShowTablesQuery::getFrom() const
     return name;
 }
 
-void ASTShowTablesQuery::formatLike(const FormatSettings & settings) const
+void ASTShowTablesQuery::formatLike(WriteBuffer & ostr, const FormatSettings & settings) const
 {
     if (!like.empty())
-        settings.ostr
+        ostr
             << (settings.hilite ? hilite_keyword : "")
             << (not_like ? " NOT" : "")
             << (case_insensitive_like ? " ILIKE " : " LIKE ")
@@ -36,74 +36,74 @@ void ASTShowTablesQuery::formatLike(const FormatSettings & settings) const
             << DB::quote << like;
 }
 
-void ASTShowTablesQuery::formatLimit(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
+void ASTShowTablesQuery::formatLimit(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
 {
     if (limit_length)
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << " LIMIT " << (settings.hilite ? hilite_none : "");
-        limit_length->formatImpl(settings, state, frame);
+        ostr << (settings.hilite ? hilite_keyword : "") << " LIMIT " << (settings.hilite ? hilite_none : "");
+        limit_length->formatImpl(ostr, settings, state, frame);
     }
 }
 
-void ASTShowTablesQuery::formatQueryImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
+void ASTShowTablesQuery::formatQueryImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
 {
     if (databases)
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << "SHOW DATABASES" << (settings.hilite ? hilite_none : "");
-        formatLike(settings);
-        formatLimit(settings, state, frame);
+        ostr << (settings.hilite ? hilite_keyword : "") << "SHOW DATABASES" << (settings.hilite ? hilite_none : "");
+        formatLike(ostr, settings);
+        formatLimit(ostr, settings, state, frame);
 
     }
     else if (clusters)
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << "SHOW CLUSTERS" << (settings.hilite ? hilite_none : "");
-        formatLike(settings);
-        formatLimit(settings, state, frame);
+        ostr << (settings.hilite ? hilite_keyword : "") << "SHOW CLUSTERS" << (settings.hilite ? hilite_none : "");
+        formatLike(ostr, settings);
+        formatLimit(ostr, settings, state, frame);
 
     }
     else if (cluster)
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << "SHOW CLUSTER" << (settings.hilite ? hilite_none : "");
-        settings.ostr << " " << backQuoteIfNeed(cluster_str);
+        ostr << (settings.hilite ? hilite_keyword : "") << "SHOW CLUSTER" << (settings.hilite ? hilite_none : "");
+        ostr << " " << backQuoteIfNeed(cluster_str);
     }
     else if (caches)
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << "SHOW FILESYSTEM CACHES" << (settings.hilite ? hilite_none : "");
-        formatLike(settings);
-        formatLimit(settings, state, frame);
+        ostr << (settings.hilite ? hilite_keyword : "") << "SHOW FILESYSTEM CACHES" << (settings.hilite ? hilite_none : "");
+        formatLike(ostr, settings);
+        formatLimit(ostr, settings, state, frame);
     }
     else if (m_settings)
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << "SHOW " << (changed ? "CHANGED " : "") << "SETTINGS" <<
+        ostr << (settings.hilite ? hilite_keyword : "") << "SHOW " << (changed ? "CHANGED " : "") << "SETTINGS" <<
             (settings.hilite ? hilite_none : "");
-        formatLike(settings);
+        formatLike(ostr, settings);
     }
     else if (merges)
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << "SHOW MERGES" << (settings.hilite ? hilite_none : "");
-        formatLike(settings);
-        formatLimit(settings, state, frame);
+        ostr << (settings.hilite ? hilite_keyword : "") << "SHOW MERGES" << (settings.hilite ? hilite_none : "");
+        formatLike(ostr, settings);
+        formatLimit(ostr, settings, state, frame);
     }
     else
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << "SHOW " << (temporary ? "TEMPORARY " : "") <<
+        ostr << (settings.hilite ? hilite_keyword : "") << "SHOW " << (temporary ? "TEMPORARY " : "") <<
              (dictionaries ? "DICTIONARIES" : "TABLES") << (settings.hilite ? hilite_none : "");
 
         if (from)
         {
-            settings.ostr << (settings.hilite ? hilite_keyword : "") << " FROM " << (settings.hilite ? hilite_none : "");
-            from->formatImpl(settings, state, frame);
+            ostr << (settings.hilite ? hilite_keyword : "") << " FROM " << (settings.hilite ? hilite_none : "");
+            from->formatImpl(ostr, settings, state, frame);
         }
 
-        formatLike(settings);
+        formatLike(ostr, settings);
 
         if (where_expression)
         {
-            settings.ostr << (settings.hilite ? hilite_keyword : "") << " WHERE " << (settings.hilite ? hilite_none : "");
-            where_expression->formatImpl(settings, state, frame);
+            ostr << (settings.hilite ? hilite_keyword : "") << " WHERE " << (settings.hilite ? hilite_none : "");
+            where_expression->formatImpl(ostr, settings, state, frame);
         }
 
-        formatLimit(settings, state, frame);
+        formatLimit(ostr, settings, state, frame);
     }
 }
 

--- a/src/Parsers/ASTShowTablesQuery.h
+++ b/src/Parsers/ASTShowTablesQuery.h
@@ -43,9 +43,9 @@ public:
     String getFrom() const;
 
 protected:
-    void formatLike(const FormatSettings & settings) const;
-    void formatLimit(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const;
-    void formatQueryImpl(const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
+    void formatLike(WriteBuffer & ostr, const FormatSettings & settings) const;
+    void formatLimit(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const;
+    void formatQueryImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
 };
 
 }

--- a/src/Parsers/ASTStatisticsDeclaration.cpp
+++ b/src/Parsers/ASTStatisticsDeclaration.cpp
@@ -45,14 +45,14 @@ std::vector<String> ASTStatisticsDeclaration::getTypeNames() const
 
 }
 
-void ASTStatisticsDeclaration::formatImpl(const FormatSettings & s, FormatState & state, FormatStateStacked frame) const
+void ASTStatisticsDeclaration::formatImpl(WriteBuffer & ostr, const FormatSettings & s, FormatState & state, FormatStateStacked frame) const
 {
-    columns->formatImpl(s, state, frame);
-    s.ostr << (s.hilite ? hilite_keyword : "");
+    columns->formatImpl(ostr, s, state, frame);
+    ostr << (s.hilite ? hilite_keyword : "");
     if (types)
     {
-        s.ostr << " TYPE " << (s.hilite ? hilite_none : "");
-        types->formatImpl(s, state, frame);
+        ostr << " TYPE " << (s.hilite ? hilite_none : "");
+        types->formatImpl(ostr, s, state, frame);
     }
 }
 

--- a/src/Parsers/ASTStatisticsDeclaration.h
+++ b/src/Parsers/ASTStatisticsDeclaration.h
@@ -22,7 +22,7 @@ public:
     std::vector<String> getTypeNames() const;
 
     ASTPtr clone() const override;
-    void formatImpl(const FormatSettings & s, FormatState & state, FormatStateStacked frame) const override;
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & s, FormatState & state, FormatStateStacked frame) const override;
 };
 
 }

--- a/src/Parsers/ASTSubquery.cpp
+++ b/src/Parsers/ASTSubquery.cpp
@@ -25,7 +25,7 @@ void ASTSubquery::appendColumnNameImpl(WriteBuffer & ostr) const
     }
 }
 
-void ASTSubquery::formatImplWithoutAlias(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
+void ASTSubquery::formatImplWithoutAlias(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
 {
     /// NOTE: due to trickery of filling cte_name (in interpreters) it is hard
     /// to print it without newline (for !oneline case), since if nl_or_ws
@@ -34,21 +34,21 @@ void ASTSubquery::formatImplWithoutAlias(const FormatSettings & settings, Format
     ///   (select 1 in ((select 1) as sub))
     if (!cte_name.empty())
     {
-        settings.ostr << (settings.hilite ? hilite_identifier : "");
-        settings.writeIdentifier(cte_name, /*ambiguous=*/false);
-        settings.ostr << (settings.hilite ? hilite_none : "");
+        ostr << (settings.hilite ? hilite_identifier : "");
+        settings.writeIdentifier(ostr, cte_name, /*ambiguous=*/false);
+        ostr << (settings.hilite ? hilite_none : "");
         return;
     }
 
     std::string indent_str = settings.one_line ? "" : std::string(4u * frame.indent, ' ');
     std::string nl_or_nothing = settings.one_line ? "" : "\n";
 
-    settings.ostr << "(" << nl_or_nothing;
+    ostr << "(" << nl_or_nothing;
     FormatStateStacked frame_nested = frame;
     frame_nested.need_parens = false;
     ++frame_nested.indent;
-    children[0]->formatImpl(settings, state, frame_nested);
-    settings.ostr << nl_or_nothing << indent_str << ")";
+    children[0]->formatImpl(ostr, settings, state, frame_nested);
+    ostr << nl_or_nothing << indent_str << ")";
 }
 
 void ASTSubquery::updateTreeHashImpl(SipHash & hash_state, bool ignore_aliases) const

--- a/src/Parsers/ASTSubquery.h
+++ b/src/Parsers/ASTSubquery.h
@@ -38,7 +38,7 @@ public:
     String tryGetAlias() const override;
 
 protected:
-    void formatImplWithoutAlias(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
+    void formatImplWithoutAlias(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
     void appendColumnNameImpl(WriteBuffer & ostr) const override;
 };
 

--- a/src/Parsers/ASTSystemQuery.h
+++ b/src/Parsers/ASTSystemQuery.h
@@ -182,7 +182,7 @@ public:
 
 protected:
 
-    void formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
 };
 
 

--- a/src/Parsers/ASTTTLElement.cpp
+++ b/src/Parsers/ASTTTLElement.cpp
@@ -30,50 +30,50 @@ ASTPtr ASTTTLElement::clone() const
     return clone;
 }
 
-void ASTTTLElement::formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
+void ASTTTLElement::formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
 {
-    ttl()->formatImpl(settings, state, frame);
+    ttl()->formatImpl(ostr, settings, state, frame);
     if (mode == TTLMode::MOVE)
     {
         if (destination_type == DataDestinationType::DISK)
-            settings.ostr << " TO DISK ";
+            ostr << " TO DISK ";
         else if (destination_type == DataDestinationType::VOLUME)
-            settings.ostr << " TO VOLUME ";
+            ostr << " TO VOLUME ";
         else
             throw Exception(ErrorCodes::LOGICAL_ERROR,
                 "Unsupported destination type {} for TTL MOVE",
                     magic_enum::enum_name(destination_type));
 
         if (if_exists)
-            settings.ostr << "IF EXISTS ";
+            ostr << "IF EXISTS ";
 
-        settings.ostr << quoteString(destination_name);
+        ostr << quoteString(destination_name);
     }
     else if (mode == TTLMode::GROUP_BY)
     {
-        settings.ostr << " GROUP BY ";
+        ostr << " GROUP BY ";
         for (const auto * it = group_by_key.begin(); it != group_by_key.end(); ++it)
         {
             if (it != group_by_key.begin())
-                settings.ostr << ", ";
-            (*it)->formatImpl(settings, state, frame);
+                ostr << ", ";
+            (*it)->formatImpl(ostr, settings, state, frame);
         }
 
         if (!group_by_assignments.empty())
         {
-            settings.ostr << " SET ";
+            ostr << " SET ";
             for (const auto * it = group_by_assignments.begin(); it != group_by_assignments.end(); ++it)
             {
                 if (it != group_by_assignments.begin())
-                    settings.ostr << ", ";
-                (*it)->formatImpl(settings, state, frame);
+                    ostr << ", ";
+                (*it)->formatImpl(ostr, settings, state, frame);
             }
         }
     }
     else if (mode == TTLMode::RECOMPRESS)
     {
-        settings.ostr << " RECOMPRESS ";
-        recompression_codec->formatImpl(settings, state, frame);
+        ostr << " RECOMPRESS ";
+        recompression_codec->formatImpl(ostr, settings, state, frame);
     }
     else if (mode == TTLMode::DELETE)
     {
@@ -82,8 +82,8 @@ void ASTTTLElement::formatImpl(const FormatSettings & settings, FormatState & st
 
     if (where())
     {
-        settings.ostr << " WHERE ";
-        where()->formatImpl(settings, state, frame);
+        ostr << " WHERE ";
+        where()->formatImpl(ostr, settings, state, frame);
     }
 }
 

--- a/src/Parsers/ASTTTLElement.h
+++ b/src/Parsers/ASTTTLElement.h
@@ -44,7 +44,7 @@ public:
     void setWhere(ASTPtr && ast) { setExpression(where_expr_pos, std::forward<ASTPtr>(ast)); }
 
 protected:
-    void formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
 
 private:
     int ttl_expr_pos;

--- a/src/Parsers/ASTTableOverrides.cpp
+++ b/src/Parsers/ASTTableOverrides.cpp
@@ -22,7 +22,7 @@ ASTPtr ASTTableOverride::clone() const
     return res;
 }
 
-void ASTTableOverride::formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
+void ASTTableOverride::formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
 {
     String nl_or_nothing = settings.one_line ? "" : "\n";
     String nl_or_ws = settings.one_line ? " " : "\n";
@@ -31,14 +31,14 @@ void ASTTableOverride::formatImpl(const FormatSettings & settings, FormatState &
 
     if (is_standalone)
     {
-        settings.ostr << hl_keyword << "TABLE OVERRIDE " << hl_none;
-        ASTIdentifier(table_name).formatImpl(settings, state, frame);
+        ostr << hl_keyword << "TABLE OVERRIDE " << hl_none;
+        ASTIdentifier(table_name).formatImpl(ostr, settings, state, frame);
     }
     auto override_frame = frame;
     if (is_standalone)
     {
         ++override_frame.indent;
-        settings.ostr << nl_or_ws << '(' << nl_or_nothing;
+        ostr << nl_or_ws << '(' << nl_or_nothing;
     }
     String indent_str = settings.one_line ? "" : String(4 * override_frame.indent, ' ');
     size_t override_elems = 0;
@@ -46,9 +46,9 @@ void ASTTableOverride::formatImpl(const FormatSettings & settings, FormatState &
     {
         FormatStateStacked columns_frame = override_frame;
         columns_frame.expression_list_always_start_on_new_line = true;
-        settings.ostr << indent_str << hl_keyword << "COLUMNS" << hl_none << nl_or_ws << indent_str << "(";
-        columns->formatImpl(settings, state, columns_frame);
-        settings.ostr << nl_or_nothing << indent_str << ")";
+        ostr << indent_str << hl_keyword << "COLUMNS" << hl_none << nl_or_ws << indent_str << "(";
+        columns->formatImpl(ostr, settings, state, columns_frame);
+        ostr << nl_or_nothing << indent_str << ")";
         ++override_elems;
     }
     if (storage)
@@ -57,10 +57,10 @@ void ASTTableOverride::formatImpl(const FormatSettings & settings, FormatState &
         {
             if (elem)
             {
-                settings.ostr << (override_elems++ ? nl_or_ws : "")
+                ostr << (override_elems++ ? nl_or_ws : "")
                               << indent_str
                               << hl_keyword << elem_name << hl_none << ' ';
-                elem->formatImpl(settings, state, override_frame);
+                elem->formatImpl(ostr, settings, state, override_frame);
             }
         };
         format_storage_elem(storage->partition_by, "PARTITION BY");
@@ -71,7 +71,7 @@ void ASTTableOverride::formatImpl(const FormatSettings & settings, FormatState &
     }
 
     if (is_standalone)
-        settings.ostr << nl_or_nothing << ')';
+        ostr << nl_or_nothing << ')';
 }
 
 ASTPtr ASTTableOverrideList::clone() const
@@ -121,19 +121,19 @@ bool ASTTableOverrideList::hasOverride(const String & name) const
     return positions.contains(name);
 }
 
-void ASTTableOverrideList::formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
+void ASTTableOverrideList::formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
 {
     if (frame.expression_list_prepend_whitespace)
-        settings.ostr << ' ';
+        ostr << ' ';
 
     for (ASTs::const_iterator it = children.begin(); it != children.end(); ++it)
     {
         if (it != children.begin())
         {
-            settings.ostr << (settings.one_line ? ", " : ",\n");
+            ostr << (settings.one_line ? ", " : ",\n");
         }
 
-        (*it)->formatImpl(settings, state, frame);
+        (*it)->formatImpl(ostr, settings, state, frame);
     }
 }
 

--- a/src/Parsers/ASTTableOverrides.h
+++ b/src/Parsers/ASTTableOverrides.h
@@ -26,7 +26,7 @@ public:
     bool is_standalone = true;
     String getID(char) const override { return "TableOverride " + table_name; }
     ASTPtr clone() const override;
-    void formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
 
     void forEachPointerToChild(std::function<void(void**)> f) override
     {
@@ -45,7 +45,7 @@ class ASTTableOverrideList : public IAST
 public:
     String getID(char) const override { return "TableOverrideList"; }
     ASTPtr clone() const override;
-    void formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
     void setTableOverride(const String & name, ASTPtr ast);
     void removeTableOverride(const String & name);
     ASTPtr tryGetTableOverride(const String & name) const;

--- a/src/Parsers/ASTTablesInSelectQuery.cpp
+++ b/src/Parsers/ASTTablesInSelectQuery.cpp
@@ -126,57 +126,57 @@ ASTPtr ASTTablesInSelectQuery::clone() const
 #undef CLONE
 
 
-void ASTTableExpression::formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
+void ASTTableExpression::formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
 {
     frame.current_select = this;
     std::string indent_str = settings.one_line ? "" : std::string(4 * frame.indent, ' ');
 
     if (database_and_table_name)
     {
-        settings.ostr << " ";
-        database_and_table_name->formatImpl(settings, state, frame);
+        ostr << " ";
+        database_and_table_name->formatImpl(ostr, settings, state, frame);
     }
     else if (table_function && !(table_function->as<ASTFunction>()->prefer_subquery_to_function_formatting && subquery))
     {
-        settings.ostr << " ";
-        table_function->formatImpl(settings, state, frame);
+        ostr << " ";
+        table_function->formatImpl(ostr, settings, state, frame);
     }
     else if (subquery)
     {
-        settings.ostr << settings.nl_or_ws << indent_str;
-        subquery->formatImpl(settings, state, frame);
+        ostr << settings.nl_or_ws << indent_str;
+        subquery->formatImpl(ostr, settings, state, frame);
     }
 
     if (final)
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << settings.nl_or_ws << indent_str
+        ostr << (settings.hilite ? hilite_keyword : "") << settings.nl_or_ws << indent_str
             << "FINAL" << (settings.hilite ? hilite_none : "");
     }
 
     if (sample_size)
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << settings.nl_or_ws << indent_str
+        ostr << (settings.hilite ? hilite_keyword : "") << settings.nl_or_ws << indent_str
             << "SAMPLE " << (settings.hilite ? hilite_none : "");
-        sample_size->formatImpl(settings, state, frame);
+        sample_size->formatImpl(ostr, settings, state, frame);
 
         if (sample_offset)
         {
-            settings.ostr << (settings.hilite ? hilite_keyword : "") << ' '
+            ostr << (settings.hilite ? hilite_keyword : "") << ' '
                 << "OFFSET " << (settings.hilite ? hilite_none : "");
-            sample_offset->formatImpl(settings, state, frame);
+            sample_offset->formatImpl(ostr, settings, state, frame);
         }
     }
 }
 
 
-void ASTTableJoin::formatImplBeforeTable(const FormatSettings & settings, FormatState &, FormatStateStacked frame) const
+void ASTTableJoin::formatImplBeforeTable(WriteBuffer & ostr, const FormatSettings & settings, FormatState &, FormatStateStacked frame) const
 {
-    settings.ostr << (settings.hilite ? hilite_keyword : "");
+    ostr << (settings.hilite ? hilite_keyword : "");
     std::string indent_str = settings.one_line ? "" : std::string(4 * frame.indent, ' ');
 
     if (kind != JoinKind::Comma)
     {
-        settings.ostr << settings.nl_or_ws << indent_str;
+        ostr << settings.nl_or_ws << indent_str;
     }
 
     switch (locality)
@@ -185,7 +185,7 @@ void ASTTableJoin::formatImplBeforeTable(const FormatSettings & settings, Format
         case JoinLocality::Local:
             break;
         case JoinLocality::Global:
-            settings.ostr << "GLOBAL ";
+            ostr << "GLOBAL ";
             break;
     }
 
@@ -197,19 +197,19 @@ void ASTTableJoin::formatImplBeforeTable(const FormatSettings & settings, Format
                 break;
             case JoinStrictness::RightAny:
             case JoinStrictness::Any:
-                settings.ostr << "ANY ";
+                ostr << "ANY ";
                 break;
             case JoinStrictness::All:
-                settings.ostr << "ALL ";
+                ostr << "ALL ";
                 break;
             case JoinStrictness::Asof:
-                settings.ostr << "ASOF ";
+                ostr << "ASOF ";
                 break;
             case JoinStrictness::Semi:
-                settings.ostr << "SEMI ";
+                ostr << "SEMI ";
                 break;
             case JoinStrictness::Anti:
-                settings.ostr << "ANTI ";
+                ostr << "ANTI ";
                 break;
         }
     }
@@ -217,105 +217,105 @@ void ASTTableJoin::formatImplBeforeTable(const FormatSettings & settings, Format
     switch (kind)
     {
         case JoinKind::Inner:
-            settings.ostr << "INNER JOIN";
+            ostr << "INNER JOIN";
             break;
         case JoinKind::Left:
-            settings.ostr << "LEFT JOIN";
+            ostr << "LEFT JOIN";
             break;
         case JoinKind::Right:
-            settings.ostr << "RIGHT JOIN";
+            ostr << "RIGHT JOIN";
             break;
         case JoinKind::Full:
-            settings.ostr << "FULL OUTER JOIN";
+            ostr << "FULL OUTER JOIN";
             break;
         case JoinKind::Cross:
-            settings.ostr << "CROSS JOIN";
+            ostr << "CROSS JOIN";
             break;
         case JoinKind::Comma:
-            settings.ostr << ",";
+            ostr << ",";
             break;
         case JoinKind::Paste:
-            settings.ostr << "PASTE JOIN";
+            ostr << "PASTE JOIN";
             break;
     }
 
-    settings.ostr << (settings.hilite ? hilite_none : "");
+    ostr << (settings.hilite ? hilite_none : "");
 }
 
 
-void ASTTableJoin::formatImplAfterTable(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
+void ASTTableJoin::formatImplAfterTable(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
 {
     frame.need_parens = false;
     frame.expression_list_prepend_whitespace = false;
 
     if (using_expression_list)
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << " USING " << (settings.hilite ? hilite_none : "");
-        settings.ostr << "(";
-        using_expression_list->formatImpl(settings, state, frame);
-        settings.ostr << ")";
+        ostr << (settings.hilite ? hilite_keyword : "") << " USING " << (settings.hilite ? hilite_none : "");
+        ostr << "(";
+        using_expression_list->formatImpl(ostr, settings, state, frame);
+        ostr << ")";
     }
     else if (on_expression)
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << " ON " << (settings.hilite ? hilite_none : "");
+        ostr << (settings.hilite ? hilite_keyword : "") << " ON " << (settings.hilite ? hilite_none : "");
         /// If there is an alias for the whole expression parens should be added, otherwise it will be invalid syntax
         bool on_has_alias = !on_expression->tryGetAlias().empty();
         if (on_has_alias)
-            settings.ostr << "(";
-        on_expression->formatImpl(settings, state, frame);
+            ostr << "(";
+        on_expression->formatImpl(ostr, settings, state, frame);
         if (on_has_alias)
-            settings.ostr << ")";
+            ostr << ")";
     }
 }
 
 
-void ASTTableJoin::formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
+void ASTTableJoin::formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
 {
-    formatImplBeforeTable(settings, state, frame);
-    settings.ostr << " ...";
-    formatImplAfterTable(settings, state, frame);
+    formatImplBeforeTable(ostr, settings, state, frame);
+    ostr << " ...";
+    formatImplAfterTable(ostr, settings, state, frame);
 }
 
 
-void ASTArrayJoin::formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
+void ASTArrayJoin::formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
 {
     std::string indent_str = settings.one_line ? "" : std::string(4 * frame.indent, ' ');
     frame.expression_list_prepend_whitespace = true;
 
-    settings.ostr << (settings.hilite ? hilite_keyword : "")
+    ostr << (settings.hilite ? hilite_keyword : "")
         << settings.nl_or_ws
         << indent_str
         << (kind == Kind::Left ? "LEFT " : "") << "ARRAY JOIN" << (settings.hilite ? hilite_none : "");
 
     settings.one_line
-        ? expression_list->formatImpl(settings, state, frame)
-        : expression_list->as<ASTExpressionList &>().formatImplMultiline(settings, state, frame);
+        ? expression_list->formatImpl(ostr, settings, state, frame)
+        : expression_list->as<ASTExpressionList &>().formatImplMultiline(ostr, settings, state, frame);
 }
 
 
-void ASTTablesInSelectQueryElement::formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
+void ASTTablesInSelectQueryElement::formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
 {
     if (table_expression)
     {
         if (table_join)
-            table_join->as<ASTTableJoin &>().formatImplBeforeTable(settings, state, frame);
+            table_join->as<ASTTableJoin &>().formatImplBeforeTable(ostr, settings, state, frame);
 
-        table_expression->formatImpl(settings, state, frame);
+        table_expression->formatImpl(ostr, settings, state, frame);
 
         if (table_join)
-            table_join->as<ASTTableJoin &>().formatImplAfterTable(settings, state, frame);
+            table_join->as<ASTTableJoin &>().formatImplAfterTable(ostr, settings, state, frame);
     }
     else if (array_join)
     {
-        array_join->formatImpl(settings, state, frame);
+        array_join->formatImpl(ostr, settings, state, frame);
     }
 }
 
 
-void ASTTablesInSelectQuery::formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
+void ASTTablesInSelectQuery::formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
 {
     for (const auto & child : children)
-        child->formatImpl(settings, state, frame);
+        child->formatImpl(ostr, settings, state, frame);
 }
 
 }

--- a/src/Parsers/ASTTablesInSelectQuery.h
+++ b/src/Parsers/ASTTablesInSelectQuery.h
@@ -56,7 +56,7 @@ struct ASTTableExpression : public IAST
     using IAST::IAST;
     String getID(char) const override { return "TableExpression"; }
     ASTPtr clone() const override;
-    void formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
     void updateTreeHashImpl(SipHash & hash_state, bool ignore_aliases) const override;
 };
 
@@ -76,9 +76,9 @@ struct ASTTableJoin : public IAST
     String getID(char) const override { return "TableJoin"; }
     ASTPtr clone() const override;
 
-    void formatImplBeforeTable(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const;
-    void formatImplAfterTable(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const;
-    void formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
+    void formatImplBeforeTable(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const;
+    void formatImplAfterTable(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const;
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
     void updateTreeHashImpl(SipHash & hash_state, bool ignore_aliases) const override;
 
 protected:
@@ -102,7 +102,7 @@ struct ASTArrayJoin : public IAST
     using IAST::IAST;
     String getID(char) const override { return "ArrayJoin"; }
     ASTPtr clone() const override;
-    void formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
     void updateTreeHashImpl(SipHash & hash_state, bool ignore_aliases) const override;
 };
 
@@ -120,7 +120,7 @@ struct ASTTablesInSelectQueryElement : public IAST
     using IAST::IAST;
     String getID(char) const override { return "TablesInSelectQueryElement"; }
     ASTPtr clone() const override;
-    void formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
 };
 
 
@@ -130,7 +130,7 @@ struct ASTTablesInSelectQuery : public IAST
     using IAST::IAST;
     String getID(char) const override { return "TablesInSelectQuery"; }
     ASTPtr clone() const override;
-    void formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
 };
 
 }

--- a/src/Parsers/ASTTimeInterval.cpp
+++ b/src/Parsers/ASTTimeInterval.cpp
@@ -12,16 +12,16 @@ ASTPtr ASTTimeInterval::clone() const
     return std::make_shared<ASTTimeInterval>(*this);
 }
 
-void ASTTimeInterval::formatImpl(const FormatSettings & f_settings, FormatState &, FormatStateStacked frame) const
+void ASTTimeInterval::formatImpl(WriteBuffer & ostr, const FormatSettings & f_settings, FormatState &, FormatStateStacked frame) const
 {
     frame.need_parens = false;
 
     for (bool is_first = true; auto [kind, value] : interval.toIntervals())
     {
         if (!std::exchange(is_first, false))
-            f_settings.ostr << ' ';
-        f_settings.ostr << value << ' ';
-        f_settings.ostr << (f_settings.hilite ? hilite_keyword : "") << kind.toKeyword() << (f_settings.hilite ? hilite_none : "");
+            ostr << ' ';
+        ostr << value << ' ';
+        ostr << (f_settings.hilite ? hilite_keyword : "") << kind.toKeyword() << (f_settings.hilite ? hilite_none : "");
     }
 }
 

--- a/src/Parsers/ASTTimeInterval.h
+++ b/src/Parsers/ASTTimeInterval.h
@@ -18,7 +18,7 @@ public:
     String getID(char) const override { return "TimeInterval"; }
 
     ASTPtr clone() const override;
-    void formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
 };
 
 }

--- a/src/Parsers/ASTTransactionControl.cpp
+++ b/src/Parsers/ASTTransactionControl.cpp
@@ -5,21 +5,21 @@
 namespace DB
 {
 
-void ASTTransactionControl::formatImpl(const FormatSettings & format /*state*/, FormatState &, FormatStateStacked /*frame*/) const
+void ASTTransactionControl::formatImpl(WriteBuffer & ostr, const FormatSettings & format /*state*/, FormatState &, FormatStateStacked /*frame*/) const
 {
     switch (action)
     {
         case BEGIN:
-            format.ostr << (format.hilite ? hilite_keyword : "") << "BEGIN TRANSACTION" << (format.hilite ? hilite_none : "");
+            ostr << (format.hilite ? hilite_keyword : "") << "BEGIN TRANSACTION" << (format.hilite ? hilite_none : "");
             break;
         case COMMIT:
-            format.ostr << (format.hilite ? hilite_keyword : "") << "COMMIT" << (format.hilite ? hilite_none : "");
+            ostr << (format.hilite ? hilite_keyword : "") << "COMMIT" << (format.hilite ? hilite_none : "");
             break;
         case ROLLBACK:
-            format.ostr << (format.hilite ? hilite_keyword : "") << "ROLLBACK" << (format.hilite ? hilite_none : "");
+            ostr << (format.hilite ? hilite_keyword : "") << "ROLLBACK" << (format.hilite ? hilite_none : "");
             break;
         case SET_SNAPSHOT:
-            format.ostr << (format.hilite ? hilite_keyword : "") << "SET TRANSACTION SNAPSHOT " << (format.hilite ? hilite_none : "") << snapshot;
+            ostr << (format.hilite ? hilite_keyword : "") << "SET TRANSACTION SNAPSHOT " << (format.hilite ? hilite_none : "") << snapshot;
             break;
     }
 }

--- a/src/Parsers/ASTTransactionControl.h
+++ b/src/Parsers/ASTTransactionControl.h
@@ -25,7 +25,7 @@ public:
     String getID(char /*delimiter*/) const override { return "ASTTransactionControl"; }
     ASTPtr clone() const override { return std::make_shared<ASTTransactionControl>(*this); }
 
-    void formatImpl(const FormatSettings & format, FormatState & /*state*/, FormatStateStacked /*frame*/) const override;
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & format, FormatState & /*state*/, FormatStateStacked /*frame*/) const override;
     void updateTreeHashImpl(SipHash & hash_state, bool ignore_aliases) const override;
 
     QueryKind getQueryKind() const override;

--- a/src/Parsers/ASTUndropQuery.cpp
+++ b/src/Parsers/ASTUndropQuery.cpp
@@ -19,9 +19,9 @@ ASTPtr ASTUndropQuery::clone() const
     return res;
 }
 
-void ASTUndropQuery::formatQueryImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
+void ASTUndropQuery::formatQueryImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
 {
-    settings.ostr << (settings.hilite ? hilite_keyword : "")
+    ostr << (settings.hilite ? hilite_keyword : "")
         << "UNDROP TABLE"
         << (settings.hilite ? hilite_none : "")
         << " ";
@@ -32,19 +32,19 @@ void ASTUndropQuery::formatQueryImpl(const FormatSettings & settings, FormatStat
     {
         if (database)
         {
-            database->formatImpl(settings, state, frame);
-            settings.ostr << '.';
+            database->formatImpl(ostr, settings, state, frame);
+            ostr << '.';
         }
 
         chassert(table);
-        table->formatImpl(settings, state, frame);
+        table->formatImpl(ostr, settings, state, frame);
     }
 
     if (uuid != UUIDHelpers::Nil)
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << " UUID " << (settings.hilite ? hilite_none : "")
+        ostr << (settings.hilite ? hilite_keyword : "") << " UUID " << (settings.hilite ? hilite_none : "")
             << quoteString(toString(uuid));
 
-    formatOnCluster(settings);
+    formatOnCluster(ostr, settings);
 }
 
 }

--- a/src/Parsers/ASTUndropQuery.h
+++ b/src/Parsers/ASTUndropQuery.h
@@ -24,7 +24,7 @@ public:
     QueryKind getQueryKind() const override { return QueryKind::Undrop; }
 
 protected:
-    void formatQueryImpl(const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
+    void formatQueryImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
 };
 
 }

--- a/src/Parsers/ASTUseQuery.h
+++ b/src/Parsers/ASTUseQuery.h
@@ -39,10 +39,10 @@ public:
     QueryKind getQueryKind() const override { return QueryKind::Use; }
 
 protected:
-    void formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << "USE " << (settings.hilite ? hilite_none : "");
-        database->formatImpl(settings, state, frame);
+        ostr << (settings.hilite ? hilite_keyword : "") << "USE " << (settings.hilite ? hilite_none : "");
+        database->formatImpl(ostr, settings, state, frame);
     }
 };
 

--- a/src/Parsers/ASTViewTargets.cpp
+++ b/src/Parsers/ASTViewTargets.cpp
@@ -204,29 +204,29 @@ ASTPtr ASTViewTargets::clone() const
     return res;
 }
 
-void ASTViewTargets::formatImpl(const FormatSettings & s, FormatState & state, FormatStateStacked frame) const
+void ASTViewTargets::formatImpl(WriteBuffer & ostr, const FormatSettings & s, FormatState & state, FormatStateStacked frame) const
 {
     for (const auto & target : targets)
-        formatTarget(target, s, state, frame);
+        formatTarget(target, ostr, s, state, frame);
 }
 
-void ASTViewTargets::formatTarget(ViewTarget::Kind kind, const FormatSettings & s, FormatState & state, FormatStateStacked frame) const
+void ASTViewTargets::formatTarget(ViewTarget::Kind kind, WriteBuffer & ostr, const FormatSettings & s, FormatState & state, FormatStateStacked frame) const
 {
     for (const auto & target : targets)
     {
         if (target.kind == kind)
-            formatTarget(target, s, state, frame);
+            formatTarget(target, ostr, s, state, frame);
     }
 }
 
-void ASTViewTargets::formatTarget(const ViewTarget & target, const FormatSettings & s, FormatState & state, FormatStateStacked frame)
+void ASTViewTargets::formatTarget(const ViewTarget & target, WriteBuffer & ostr, const FormatSettings & s, FormatState & state, FormatStateStacked frame)
 {
     if (target.table_id)
     {
         auto keyword = getKeywordForTableID(target.kind);
         if (!keyword)
             throw Exception(ErrorCodes::LOGICAL_ERROR, "No keyword for table name of kind {}", toString(target.kind));
-        s.ostr <<  " " << (s.hilite ? hilite_keyword : "") << toStringView(*keyword)
+        ostr <<  " " << (s.hilite ? hilite_keyword : "") << toStringView(*keyword)
                << (s.hilite ? hilite_none : "") << " "
                << (!target.table_id.database_name.empty() ? backQuoteIfNeed(target.table_id.database_name) + "." : "")
                << backQuoteIfNeed(target.table_id.table_name);
@@ -237,7 +237,7 @@ void ASTViewTargets::formatTarget(const ViewTarget & target, const FormatSetting
         auto keyword = getKeywordForInnerUUID(target.kind);
         if (!keyword)
             throw Exception(ErrorCodes::LOGICAL_ERROR, "No prefix keyword for inner UUID of kind {}", toString(target.kind));
-        s.ostr << " " << (s.hilite ? hilite_keyword : "") << toStringView(*keyword)
+        ostr << " " << (s.hilite ? hilite_keyword : "") << toStringView(*keyword)
                << (s.hilite ? hilite_none : "") << " " << quoteString(toString(target.inner_uuid));
     }
 
@@ -246,8 +246,8 @@ void ASTViewTargets::formatTarget(const ViewTarget & target, const FormatSetting
         auto keyword = getKeywordForInnerStorage(target.kind);
         if (!keyword)
             throw Exception(ErrorCodes::LOGICAL_ERROR, "No prefix keyword for table engine of kind {}", toString(target.kind));
-        s.ostr << " " << (s.hilite ? hilite_keyword : "") << toStringView(*keyword) << (s.hilite ? hilite_none : "");
-        target.inner_engine->formatImpl(s, state, frame);
+        ostr << " " << (s.hilite ? hilite_keyword : "") << toStringView(*keyword) << (s.hilite ? hilite_none : "");
+        target.inner_engine->formatImpl(ostr, s, state, frame);
     }
 }
 

--- a/src/Parsers/ASTViewTargets.h
+++ b/src/Parsers/ASTViewTargets.h
@@ -106,11 +106,11 @@ public:
 
     ASTPtr clone() const override;
 
-    void formatImpl(const FormatSettings & s, FormatState & state, FormatStateStacked frame) const override;
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & s, FormatState & state, FormatStateStacked frame) const override;
 
     /// Formats information only about a specific target table.
-    void formatTarget(ViewTarget::Kind kind, const FormatSettings & s, FormatState & state, FormatStateStacked frame) const;
-    static void formatTarget(const ViewTarget & target, const FormatSettings & s, FormatState & state, FormatStateStacked frame);
+    void formatTarget(ViewTarget::Kind kind, WriteBuffer & ostr, const FormatSettings & s, FormatState & state, FormatStateStacked frame) const;
+    static void formatTarget(const ViewTarget & target, WriteBuffer & ostr, const FormatSettings & s, FormatState & state, FormatStateStacked frame);
 
     /// Helper functions for class ParserViewTargets. Returns a prefix keyword matching a specified target kind.
     static std::optional<Keyword> getKeywordForTableID(ViewTarget::Kind kind);

--- a/src/Parsers/ASTWatchQuery.h
+++ b/src/Parsers/ASTWatchQuery.h
@@ -40,30 +40,30 @@ public:
     QueryKind getQueryKind() const override { return QueryKind::Create; }
 
 protected:
-    void formatQueryImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override
+    void formatQueryImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override
     {
         std::string indent_str = settings.one_line ? "" : std::string(4 * frame.indent, ' ');
 
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << "WATCH " << (settings.hilite ? hilite_none : "");
+        ostr << (settings.hilite ? hilite_keyword : "") << "WATCH " << (settings.hilite ? hilite_none : "");
 
         if (database)
         {
-            database->formatImpl(settings, state, frame);
-            settings.ostr << '.';
+            database->formatImpl(ostr, settings, state, frame);
+            ostr << '.';
         }
 
         chassert(table);
-        table->formatImpl(settings, state, frame);
+        table->formatImpl(ostr, settings, state, frame);
 
         if (is_watch_events)
         {
-            settings.ostr << " " << (settings.hilite ? hilite_keyword : "") << "EVENTS" << (settings.hilite ? hilite_none : "");
+            ostr << " " << (settings.hilite ? hilite_keyword : "") << "EVENTS" << (settings.hilite ? hilite_none : "");
         }
 
         if (limit_length)
         {
-            settings.ostr << (settings.hilite ? hilite_keyword : "") << settings.nl_or_ws << indent_str << "LIMIT " << (settings.hilite ? hilite_none : "");
-            limit_length->formatImpl(settings, state, frame);
+            ostr << (settings.hilite ? hilite_keyword : "") << settings.nl_or_ws << indent_str << "LIMIT " << (settings.hilite ? hilite_none : "");
+            limit_length->formatImpl(ostr, settings, state, frame);
         }
     }
 };

--- a/src/Parsers/ASTWindowDefinition.cpp
+++ b/src/Parsers/ASTWindowDefinition.cpp
@@ -52,15 +52,15 @@ String ASTWindowDefinition::getID(char) const
     return "WindowDefinition";
 }
 
-void ASTWindowDefinition::formatImpl(const FormatSettings & settings,
-    FormatState & state, FormatStateStacked format_frame) const
+void ASTWindowDefinition::formatImpl(WriteBuffer & ostr, const FormatSettings & settings,
+                                     FormatState & state, FormatStateStacked format_frame) const
 {
     format_frame.expression_list_prepend_whitespace = false;
     bool need_space = false;
 
     if (!parent_window_name.empty())
     {
-        settings.ostr << backQuoteIfNeed(parent_window_name);
+        ostr << backQuoteIfNeed(parent_window_name);
 
         need_space = true;
     }
@@ -69,11 +69,11 @@ void ASTWindowDefinition::formatImpl(const FormatSettings & settings,
     {
         if (need_space)
         {
-            settings.ostr << " ";
+            ostr << " ";
         }
 
-        settings.ostr << "PARTITION BY ";
-        partition_by->formatImpl(settings, state, format_frame);
+        ostr << "PARTITION BY ";
+        partition_by->formatImpl(ostr, settings, state, format_frame);
 
         need_space = true;
     }
@@ -82,11 +82,11 @@ void ASTWindowDefinition::formatImpl(const FormatSettings & settings,
     {
         if (need_space)
         {
-            settings.ostr << " ";
+            ostr << " ";
         }
 
-        settings.ostr << "ORDER BY ";
-        order_by->formatImpl(settings, state, format_frame);
+        ostr << "ORDER BY ";
+        order_by->formatImpl(ostr, settings, state, format_frame);
 
         need_space = true;
     }
@@ -94,38 +94,38 @@ void ASTWindowDefinition::formatImpl(const FormatSettings & settings,
     if (!frame_is_default)
     {
         if (need_space)
-            settings.ostr << " ";
+            ostr << " ";
 
         format_frame.need_parens = true;
 
-        settings.ostr << frame_type << " BETWEEN ";
+        ostr << frame_type << " BETWEEN ";
         if (frame_begin_type == WindowFrame::BoundaryType::Current)
         {
-            settings.ostr << "CURRENT ROW";
+            ostr << "CURRENT ROW";
         }
         else if (frame_begin_type == WindowFrame::BoundaryType::Unbounded)
         {
-            settings.ostr << "UNBOUNDED PRECEDING";
+            ostr << "UNBOUNDED PRECEDING";
         }
         else
         {
-            frame_begin_offset->formatImpl(settings, state, format_frame);
-            settings.ostr << " "
+            frame_begin_offset->formatImpl(ostr, settings, state, format_frame);
+            ostr << " "
                 << (!frame_begin_preceding ? "FOLLOWING" : "PRECEDING");
         }
-        settings.ostr << " AND ";
+        ostr << " AND ";
         if (frame_end_type == WindowFrame::BoundaryType::Current)
         {
-            settings.ostr << "CURRENT ROW";
+            ostr << "CURRENT ROW";
         }
         else if (frame_end_type == WindowFrame::BoundaryType::Unbounded)
         {
-            settings.ostr << "UNBOUNDED FOLLOWING";
+            ostr << "UNBOUNDED FOLLOWING";
         }
         else
         {
-            frame_end_offset->formatImpl(settings, state, format_frame);
-            settings.ostr << " "
+            frame_end_offset->formatImpl(ostr, settings, state, format_frame);
+            ostr << " "
                 << (!frame_end_preceding ? "FOLLOWING" : "PRECEDING");
         }
     }
@@ -134,10 +134,10 @@ void ASTWindowDefinition::formatImpl(const FormatSettings & settings,
 std::string ASTWindowDefinition::getDefaultWindowName() const
 {
     WriteBufferFromOwnString ostr;
-    FormatSettings settings{ostr, true /* one_line */};
+    FormatSettings settings{true /* one_line */};
     FormatState state;
     FormatStateStacked format_frame;
-    formatImpl(settings, state, format_frame);
+    formatImpl(ostr, settings, state, format_frame);
     return ostr.str();
 }
 
@@ -157,13 +157,13 @@ String ASTWindowListElement::getID(char) const
     return "WindowListElement";
 }
 
-void ASTWindowListElement::formatImpl(const FormatSettings & settings,
-    FormatState & state, FormatStateStacked frame) const
+void ASTWindowListElement::formatImpl(WriteBuffer & ostr, const FormatSettings & settings,
+                                      FormatState & state, FormatStateStacked frame) const
 {
-    settings.ostr << backQuoteIfNeed(name);
-    settings.ostr << " AS (";
-    definition->formatImpl(settings, state, frame);
-    settings.ostr << ")";
+    ostr << backQuoteIfNeed(name);
+    ostr << " AS (";
+    definition->formatImpl(ostr, settings, state, frame);
+    ostr << ")";
 }
 
 }

--- a/src/Parsers/ASTWindowDefinition.h
+++ b/src/Parsers/ASTWindowDefinition.h
@@ -29,7 +29,7 @@ struct ASTWindowDefinition : public IAST
 
     String getID(char delimiter) const override;
 
-    void formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
 
     std::string getDefaultWindowName() const;
 };
@@ -45,7 +45,7 @@ struct ASTWindowListElement : public IAST
 
     String getID(char delimiter) const override;
 
-    void formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
 };
 
 }

--- a/src/Parsers/ASTWithAlias.cpp
+++ b/src/Parsers/ASTWithAlias.cpp
@@ -7,38 +7,38 @@
 namespace DB
 {
 
-static void writeAlias(const String & name, const ASTWithAlias::FormatSettings & settings)
+static void writeAlias(const String & name, WriteBuffer & ostr, const ASTWithAlias::FormatSettings & settings)
 {
-    settings.ostr << (settings.hilite ? IAST::hilite_keyword : "") << " AS " << (settings.hilite ? IAST::hilite_alias : "");
-    settings.writeIdentifier(name, /*ambiguous=*/false);
-    settings.ostr << (settings.hilite ? IAST::hilite_none : "");
+    ostr << (settings.hilite ? IAST::hilite_keyword : "") << " AS " << (settings.hilite ? IAST::hilite_alias : "");
+    settings.writeIdentifier(ostr, name, /*ambiguous=*/false);
+    ostr << (settings.hilite ? IAST::hilite_none : "");
 }
 
 
-void ASTWithAlias::formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
+void ASTWithAlias::formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
 {
     /// If we have previously output this node elsewhere in the query, now it is enough to output only the alias.
     /// This is needed because the query can become extraordinary large after substitution of aliases.
     if (!alias.empty() && !state.printed_asts_with_alias.emplace(frame.current_select, alias, getTreeHash(/*ignore_aliases=*/ true)).second)
     {
-        settings.ostr << (settings.hilite ? IAST::hilite_identifier : "");
-        settings.writeIdentifier(alias, /*ambiguous=*/false);
-        settings.ostr << (settings.hilite ? IAST::hilite_none : "");
+        ostr << (settings.hilite ? IAST::hilite_identifier : "");
+        settings.writeIdentifier(ostr, alias, /*ambiguous=*/false);
+        ostr << (settings.hilite ? IAST::hilite_none : "");
     }
     else
     {
         /// If there is an alias, then parentheses are required around the entire expression, including the alias.
         /// Because a record of the form `0 AS x + 0` is syntactically invalid.
         if (frame.need_parens && !alias.empty())
-            settings.ostr << '(';
+            ostr << '(';
 
-        formatImplWithoutAlias(settings, state, frame);
+        formatImplWithoutAlias(ostr, settings, state, frame);
 
         if (!alias.empty())
         {
-            writeAlias(alias, settings);
+            writeAlias(alias, ostr, settings);
             if (frame.need_parens)
-                settings.ostr << ')';
+                ostr << ')';
         }
     }
 }

--- a/src/Parsers/ASTWithAlias.h
+++ b/src/Parsers/ASTWithAlias.h
@@ -31,11 +31,11 @@ public:
     void setAlias(const String & to) override { alias = to; }
 
     /// Calls formatImplWithoutAlias, and also outputs an alias. If necessary, encloses the entire expression in brackets.
-    void formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const final;
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const final;
 
     void updateTreeHashImpl(SipHash & hash_state, bool ignore_aliases) const override;
 
-    virtual void formatImplWithoutAlias(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const = 0;
+    virtual void formatImplWithoutAlias(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const = 0;
 
 protected:
     virtual void appendColumnNameImpl(WriteBuffer & ostr) const = 0;

--- a/src/Parsers/ASTWithElement.cpp
+++ b/src/Parsers/ASTWithElement.cpp
@@ -14,16 +14,16 @@ ASTPtr ASTWithElement::clone() const
     return res;
 }
 
-void ASTWithElement::formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
+void ASTWithElement::formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
 {
     std::string indent_str = settings.one_line ? "" : std::string(4 * frame.indent, ' ');
 
-    settings.ostr << (settings.hilite ? hilite_alias : "");
-    settings.writeIdentifier(name, /*ambiguous=*/false);
-    settings.ostr << (settings.hilite ? hilite_none : "");
-    settings.ostr << (settings.hilite ? hilite_keyword : "") << " AS" << (settings.hilite ? hilite_none : "");
-    settings.ostr << settings.nl_or_ws << indent_str;
-    dynamic_cast<const ASTWithAlias &>(*subquery).formatImplWithoutAlias(settings, state, frame);
+    ostr << (settings.hilite ? hilite_alias : "");
+    settings.writeIdentifier(ostr, name, /*ambiguous=*/false);
+    ostr << (settings.hilite ? hilite_none : "");
+    ostr << (settings.hilite ? hilite_keyword : "") << " AS" << (settings.hilite ? hilite_none : "");
+    ostr << settings.nl_or_ws << indent_str;
+    dynamic_cast<const ASTWithAlias &>(*subquery).formatImplWithoutAlias(ostr, settings, state, frame);
 }
 
 }

--- a/src/Parsers/ASTWithElement.h
+++ b/src/Parsers/ASTWithElement.h
@@ -19,7 +19,7 @@ public:
     ASTPtr clone() const override;
 
 protected:
-    void formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
 };
 
 }

--- a/src/Parsers/Access/ASTAuthenticationData.cpp
+++ b/src/Parsers/Access/ASTAuthenticationData.cpp
@@ -16,10 +16,10 @@ namespace ErrorCodes
 
 namespace
 {
-    void formatValidUntil(const IAST & valid_until, const IAST::FormatSettings & settings)
+    void formatValidUntil(const IAST & valid_until, WriteBuffer & ostr, const IAST::FormatSettings & settings)
     {
-        settings.ostr << (settings.hilite ? IAST::hilite_keyword : "") << " VALID UNTIL " << (settings.hilite ? IAST::hilite_none : "");
-        valid_until.format(settings);
+        ostr << (settings.hilite ? IAST::hilite_keyword : "") << " VALID UNTIL " << (settings.hilite ? IAST::hilite_none : "");
+        valid_until.format(ostr, settings);
     }
 }
 
@@ -49,16 +49,16 @@ std::optional<String> ASTAuthenticationData::getSalt() const
     return {};
 }
 
-void ASTAuthenticationData::formatImpl(const FormatSettings & settings, FormatState &, FormatStateStacked) const
+void ASTAuthenticationData::formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState &, FormatStateStacked) const
 {
     if (type && *type == AuthenticationType::NO_PASSWORD)
     {
-        settings.ostr << (settings.hilite ? IAST::hilite_keyword : "") << " no_password"
+        ostr << (settings.hilite ? IAST::hilite_keyword : "") << " no_password"
                       << (settings.hilite ? IAST::hilite_none : "");
 
         if (valid_until)
         {
-            formatValidUntil(*valid_until, settings);
+            formatValidUntil(*valid_until, ostr, settings);
         }
 
         return;
@@ -177,52 +177,52 @@ void ASTAuthenticationData::formatImpl(const FormatSettings & settings, FormatSt
 
     if (!auth_type_name.empty())
     {
-        settings.ostr << (settings.hilite ? IAST::hilite_keyword : "") << " " << auth_type_name << (settings.hilite ? IAST::hilite_none : "");
+        ostr << (settings.hilite ? IAST::hilite_keyword : "") << " " << auth_type_name << (settings.hilite ? IAST::hilite_none : "");
     }
 
     if (!prefix.empty())
     {
-        settings.ostr << (settings.hilite ? IAST::hilite_keyword : "") << " " << prefix << (settings.hilite ? IAST::hilite_none : "");
+        ostr << (settings.hilite ? IAST::hilite_keyword : "") << " " << prefix << (settings.hilite ? IAST::hilite_none : "");
     }
 
     if (password)
     {
-        settings.ostr << " ";
-        children[0]->format(settings);
+        ostr << " ";
+        children[0]->format(ostr, settings);
     }
 
     if (salt)
     {
-        settings.ostr << " SALT ";
-        children[1]->format(settings);
+        ostr << " SALT ";
+        children[1]->format(ostr, settings);
     }
 
     if (parameter)
     {
-        settings.ostr << " ";
-        children[0]->format(settings);
+        ostr << " ";
+        children[0]->format(ostr, settings);
     }
     else if (parameters)
     {
-        settings.ostr << " ";
+        ostr << " ";
         bool need_comma = false;
         for (const auto & child : children)
         {
             if (std::exchange(need_comma, true))
-                settings.ostr << ", ";
-            child->format(settings);
+                ostr << ", ";
+            child->format(ostr, settings);
         }
     }
 
     if (scheme)
     {
-        settings.ostr << " SCHEME ";
-        children[1]->format(settings);
+        ostr << " SCHEME ";
+        children[1]->format(ostr, settings);
     }
 
     if (valid_until)
     {
-        formatValidUntil(*valid_until, settings);
+        formatValidUntil(*valid_until, ostr, settings);
     }
 
 }

--- a/src/Parsers/Access/ASTAuthenticationData.h
+++ b/src/Parsers/Access/ASTAuthenticationData.h
@@ -44,7 +44,7 @@ public:
     ASTPtr valid_until;
 
 protected:
-    void formatImpl(const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
 };
 
 }

--- a/src/Parsers/Access/ASTCheckGrantQuery.cpp
+++ b/src/Parsers/Access/ASTCheckGrantQuery.cpp
@@ -20,13 +20,13 @@ ASTPtr ASTCheckGrantQuery::clone() const
 }
 
 
-void ASTCheckGrantQuery::formatImpl(const FormatSettings & settings, FormatState &, FormatStateStacked) const
+void ASTCheckGrantQuery::formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState &, FormatStateStacked) const
 {
-    settings.ostr << (settings.hilite ? IAST::hilite_keyword : "") << "CHECK GRANT"
+    ostr << (settings.hilite ? IAST::hilite_keyword : "") << "CHECK GRANT"
                   << (settings.hilite ? IAST::hilite_none : "");
 
-    settings.ostr << " ";
-    access_rights_elements.formatElementsWithoutOptions(settings.ostr, settings.hilite);
+    ostr << " ";
+    access_rights_elements.formatElementsWithoutOptions(ostr, settings.hilite);
 }
 
 

--- a/src/Parsers/Access/ASTCheckGrantQuery.h
+++ b/src/Parsers/Access/ASTCheckGrantQuery.h
@@ -17,7 +17,7 @@ public:
 
     String getID(char) const override;
     ASTPtr clone() const override;
-    void formatImpl(const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
     void replaceEmptyDatabase(const String & current_database);
     QueryKind getQueryKind() const override { return QueryKind::Check; }
 };

--- a/src/Parsers/Access/ASTCreateQuotaQuery.cpp
+++ b/src/Parsers/Access/ASTCreateQuotaQuery.cpp
@@ -10,16 +10,16 @@ namespace DB
 {
 namespace
 {
-    void formatKeyType(const QuotaKeyType & key_type, const IAST::FormatSettings & settings)
+    void formatKeyType(const QuotaKeyType & key_type, WriteBuffer & ostr, const IAST::FormatSettings & settings)
     {
         const auto & type_info = QuotaKeyTypeInfo::get(key_type);
         if (key_type == QuotaKeyType::NONE)
         {
-            settings.ostr << (settings.hilite ? IAST::hilite_keyword : "") << " NOT KEYED" << (settings.hilite ? IAST::hilite_none : "");
+            ostr << (settings.hilite ? IAST::hilite_keyword : "") << " NOT KEYED" << (settings.hilite ? IAST::hilite_none : "");
             return;
         }
 
-        settings.ostr << (settings.hilite ? IAST::hilite_keyword : "") << " KEYED BY " << (settings.hilite ? IAST::hilite_none : "");
+        ostr << (settings.hilite ? IAST::hilite_keyword : "") << " KEYED BY " << (settings.hilite ? IAST::hilite_none : "");
 
         if (!type_info.base_types.empty())
         {
@@ -27,49 +27,49 @@ namespace
             for (const auto & base_type : type_info.base_types)
             {
                 if (std::exchange(need_comma, true))
-                    settings.ostr << ", ";
-                settings.ostr << QuotaKeyTypeInfo::get(base_type).name;
+                    ostr << ", ";
+                ostr << QuotaKeyTypeInfo::get(base_type).name;
             }
             return;
         }
 
-        settings.ostr << type_info.name;
+        ostr << type_info.name;
     }
 
 
-    void formatNames(const Strings & names, const IAST::FormatSettings & settings)
+    void formatNames(const Strings & names, WriteBuffer & ostr)
     {
-        settings.ostr << " ";
+        ostr << " ";
         bool need_comma = false;
         for (const String & name : names)
         {
             if (std::exchange(need_comma, true))
-                settings.ostr << ", ";
-            settings.ostr << backQuoteIfNeed(name);
+                ostr << ", ";
+            ostr << backQuoteIfNeed(name);
         }
     }
 
 
-    void formatRenameTo(const String & new_name, const IAST::FormatSettings & settings)
+    void formatRenameTo(const String & new_name, WriteBuffer & ostr, const IAST::FormatSettings & settings)
     {
-        settings.ostr << (settings.hilite ? IAST::hilite_keyword : "") << " RENAME TO " << (settings.hilite ? IAST::hilite_none : "")
+        ostr << (settings.hilite ? IAST::hilite_keyword : "") << " RENAME TO " << (settings.hilite ? IAST::hilite_none : "")
                       << backQuote(new_name);
     }
 
 
-    void formatLimit(QuotaType quota_type, QuotaValue max_value, const IAST::FormatSettings & settings)
+    void formatLimit(QuotaType quota_type, QuotaValue max_value, WriteBuffer & ostr)
     {
         const auto & type_info = QuotaTypeInfo::get(quota_type);
-        settings.ostr << " " << type_info.name << " = " << type_info.valueToString(max_value);
+        ostr << " " << type_info.name << " = " << type_info.valueToString(max_value);
     }
 
 
-    void formatIntervalWithLimits(const ASTCreateQuotaQuery::Limits & limits, const IAST::FormatSettings & settings)
+    void formatIntervalWithLimits(const ASTCreateQuotaQuery::Limits & limits, WriteBuffer & ostr, const IAST::FormatSettings & settings)
     {
         auto interval_kind = IntervalKind::fromAvgSeconds(limits.duration.count());
         Int64 num_intervals = limits.duration.count() / interval_kind.toAvgSeconds();
 
-        settings.ostr << (settings.hilite ? IAST::hilite_keyword : "")
+        ostr << (settings.hilite ? IAST::hilite_keyword : "")
                       << " FOR"
                       << (limits.randomize_interval ? " RANDOMIZED" : "")
                       << " INTERVAL"
@@ -81,7 +81,7 @@ namespace
 
         if (limits.drop)
         {
-            settings.ostr << (settings.hilite ? IAST::hilite_keyword : "") << " NO LIMITS" << (settings.hilite ? IAST::hilite_none : "");
+            ostr << (settings.hilite ? IAST::hilite_keyword : "") << " NO LIMITS" << (settings.hilite ? IAST::hilite_none : "");
         }
         else
         {
@@ -94,7 +94,7 @@ namespace
             }
             if (limit_found)
             {
-                settings.ostr << (settings.hilite ? IAST::hilite_keyword : "") << " MAX" << (settings.hilite ? IAST::hilite_none : "");
+                ostr << (settings.hilite ? IAST::hilite_keyword : "") << " MAX" << (settings.hilite ? IAST::hilite_none : "");
                 bool need_comma = false;
                 for (auto quota_type : collections::range(QuotaType::MAX))
                 {
@@ -102,33 +102,33 @@ namespace
                     if (limits.max[quota_type_i])
                     {
                         if (std::exchange(need_comma, true))
-                            settings.ostr << ",";
-                        formatLimit(quota_type, *limits.max[quota_type_i], settings);
+                            ostr << ",";
+                        formatLimit(quota_type, *limits.max[quota_type_i], ostr);
                     }
                 }
             }
             else
-                settings.ostr << (settings.hilite ? IAST::hilite_keyword : "") << " TRACKING ONLY" << (settings.hilite ? IAST::hilite_none : "");
+                ostr << (settings.hilite ? IAST::hilite_keyword : "") << " TRACKING ONLY" << (settings.hilite ? IAST::hilite_none : "");
         }
     }
 
-    void formatIntervalsWithLimits(const std::vector<ASTCreateQuotaQuery::Limits> & all_limits, const IAST::FormatSettings & settings)
+    void formatIntervalsWithLimits(const std::vector<ASTCreateQuotaQuery::Limits> & all_limits, WriteBuffer & ostr, const IAST::FormatSettings & settings)
     {
         bool need_comma = false;
         for (const auto & limits : all_limits)
         {
             if (need_comma)
-                settings.ostr << ",";
+                ostr << ",";
             need_comma = true;
 
-            formatIntervalWithLimits(limits, settings);
+            formatIntervalWithLimits(limits, ostr, settings);
         }
     }
 
-    void formatToRoles(const ASTRolesOrUsersSet & roles, const IAST::FormatSettings & settings)
+    void formatToRoles(const ASTRolesOrUsersSet & roles, WriteBuffer & ostr, const IAST::FormatSettings & settings)
     {
-        settings.ostr << (settings.hilite ? IAST::hilite_keyword : "") << " TO " << (settings.hilite ? IAST::hilite_none : "");
-        roles.format(settings);
+        ostr << (settings.hilite ? IAST::hilite_keyword : "") << " TO " << (settings.hilite ? IAST::hilite_none : "");
+        roles.format(ostr, settings);
     }
 }
 
@@ -150,44 +150,44 @@ ASTPtr ASTCreateQuotaQuery::clone() const
 }
 
 
-void ASTCreateQuotaQuery::formatImpl(const FormatSettings & settings, FormatState &, FormatStateStacked) const
+void ASTCreateQuotaQuery::formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState &, FormatStateStacked) const
 {
     if (attach)
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << "ATTACH QUOTA" << (settings.hilite ? hilite_none : "");
+        ostr << (settings.hilite ? hilite_keyword : "") << "ATTACH QUOTA" << (settings.hilite ? hilite_none : "");
     }
     else
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << (alter ? "ALTER QUOTA" : "CREATE QUOTA")
+        ostr << (settings.hilite ? hilite_keyword : "") << (alter ? "ALTER QUOTA" : "CREATE QUOTA")
                       << (settings.hilite ? hilite_none : "");
     }
 
     if (if_exists)
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << " IF EXISTS" << (settings.hilite ? hilite_none : "");
+        ostr << (settings.hilite ? hilite_keyword : "") << " IF EXISTS" << (settings.hilite ? hilite_none : "");
     else if (if_not_exists)
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << " IF NOT EXISTS" << (settings.hilite ? hilite_none : "");
+        ostr << (settings.hilite ? hilite_keyword : "") << " IF NOT EXISTS" << (settings.hilite ? hilite_none : "");
     else if (or_replace)
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << " OR REPLACE" << (settings.hilite ? hilite_none : "");
+        ostr << (settings.hilite ? hilite_keyword : "") << " OR REPLACE" << (settings.hilite ? hilite_none : "");
 
-    formatNames(names, settings);
+    formatNames(names, ostr);
 
     if (!storage_name.empty())
-        settings.ostr << (settings.hilite ? IAST::hilite_keyword : "")
+        ostr << (settings.hilite ? IAST::hilite_keyword : "")
                     << " IN " << (settings.hilite ? IAST::hilite_none : "")
                     << backQuoteIfNeed(storage_name);
 
-    formatOnCluster(settings);
+    formatOnCluster(ostr, settings);
 
     if (!new_name.empty())
-        formatRenameTo(new_name, settings);
+        formatRenameTo(new_name, ostr, settings);
 
     if (key_type)
-        formatKeyType(*key_type, settings);
+        formatKeyType(*key_type, ostr, settings);
 
-    formatIntervalsWithLimits(all_limits, settings);
+    formatIntervalsWithLimits(all_limits, ostr, settings);
 
     if (roles && (!roles->empty() || alter))
-        formatToRoles(*roles, settings);
+        formatToRoles(*roles, ostr, settings);
 }
 
 

--- a/src/Parsers/Access/ASTCreateQuotaQuery.h
+++ b/src/Parsers/Access/ASTCreateQuotaQuery.h
@@ -53,7 +53,7 @@ public:
 
     String getID(char) const override;
     ASTPtr clone() const override;
-    void formatImpl(const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
     void replaceCurrentUserTag(const String & current_user_name) const;
     ASTPtr getRewrittenASTWithoutOnCluster(const WithoutOnClusterASTRewriteParams &) const override { return removeOnCluster<ASTCreateQuotaQuery>(clone()); }
 

--- a/src/Parsers/Access/ASTCreateRoleQuery.cpp
+++ b/src/Parsers/Access/ASTCreateRoleQuery.cpp
@@ -8,28 +8,28 @@ namespace DB
 {
 namespace
 {
-    void formatNames(const Strings & names, const IAST::FormatSettings & settings)
+    void formatNames(const Strings & names, WriteBuffer & ostr)
     {
-        settings.ostr << " ";
+        ostr << " ";
         bool need_comma = false;
         for (const String & name : names)
         {
             if (std::exchange(need_comma, true))
-                settings.ostr << ", ";
-            settings.ostr << backQuoteIfNeed(name);
+                ostr << ", ";
+            ostr << backQuoteIfNeed(name);
         }
     }
 
-    void formatRenameTo(const String & new_name, const IAST::FormatSettings & settings)
+    void formatRenameTo(const String & new_name, WriteBuffer & ostr, const IAST::FormatSettings & settings)
     {
-        settings.ostr << (settings.hilite ? IAST::hilite_keyword : "") << " RENAME TO " << (settings.hilite ? IAST::hilite_none : "")
+        ostr << (settings.hilite ? IAST::hilite_keyword : "") << " RENAME TO " << (settings.hilite ? IAST::hilite_none : "")
                       << quoteString(new_name);
     }
 
-    void formatSettings(const ASTSettingsProfileElements & settings, const IAST::FormatSettings & format)
+    void formatSettings(const ASTSettingsProfileElements & settings, WriteBuffer & ostr, const IAST::FormatSettings & format)
     {
-        format.ostr << (format.hilite ? IAST::hilite_keyword : "") << " SETTINGS " << (format.hilite ? IAST::hilite_none : "");
-        settings.format(format);
+        ostr << (format.hilite ? IAST::hilite_keyword : "") << " SETTINGS " << (format.hilite ? IAST::hilite_none : "");
+        settings.format(ostr, format);
     }
 }
 
@@ -51,39 +51,39 @@ ASTPtr ASTCreateRoleQuery::clone() const
 }
 
 
-void ASTCreateRoleQuery::formatImpl(const FormatSettings & format, FormatState &, FormatStateStacked) const
+void ASTCreateRoleQuery::formatImpl(WriteBuffer & ostr, const FormatSettings & format, FormatState &, FormatStateStacked) const
 {
     if (attach)
     {
-        format.ostr << (format.hilite ? hilite_keyword : "") << "ATTACH ROLE" << (format.hilite ? hilite_none : "");
+        ostr << (format.hilite ? hilite_keyword : "") << "ATTACH ROLE" << (format.hilite ? hilite_none : "");
     }
     else
     {
-        format.ostr << (format.hilite ? hilite_keyword : "") << (alter ? "ALTER ROLE" : "CREATE ROLE")
+        ostr << (format.hilite ? hilite_keyword : "") << (alter ? "ALTER ROLE" : "CREATE ROLE")
                       << (format.hilite ? hilite_none : "");
     }
 
     if (if_exists)
-        format.ostr << (format.hilite ? hilite_keyword : "") << " IF EXISTS" << (format.hilite ? hilite_none : "");
+        ostr << (format.hilite ? hilite_keyword : "") << " IF EXISTS" << (format.hilite ? hilite_none : "");
     else if (if_not_exists)
-        format.ostr << (format.hilite ? hilite_keyword : "") << " IF NOT EXISTS" << (format.hilite ? hilite_none : "");
+        ostr << (format.hilite ? hilite_keyword : "") << " IF NOT EXISTS" << (format.hilite ? hilite_none : "");
     else if (or_replace)
-        format.ostr << (format.hilite ? hilite_keyword : "") << " OR REPLACE" << (format.hilite ? hilite_none : "");
+        ostr << (format.hilite ? hilite_keyword : "") << " OR REPLACE" << (format.hilite ? hilite_none : "");
 
-    formatNames(names, format);
+    formatNames(names, ostr);
 
     if (!storage_name.empty())
-        format.ostr << (format.hilite ? IAST::hilite_keyword : "")
+        ostr << (format.hilite ? IAST::hilite_keyword : "")
                     << " IN " << (format.hilite ? IAST::hilite_none : "")
                     << backQuoteIfNeed(storage_name);
 
-    formatOnCluster(format);
+    formatOnCluster(ostr, format);
 
     if (!new_name.empty())
-        formatRenameTo(new_name, format);
+        formatRenameTo(new_name, ostr, format);
 
     if (settings && (!settings->empty() || alter))
-        formatSettings(*settings, format);
+        formatSettings(*settings, ostr, format);
 }
 
 }

--- a/src/Parsers/Access/ASTCreateRoleQuery.h
+++ b/src/Parsers/Access/ASTCreateRoleQuery.h
@@ -34,7 +34,7 @@ public:
 
     String getID(char) const override;
     ASTPtr clone() const override;
-    void formatImpl(const FormatSettings & format, FormatState &, FormatStateStacked) const override;
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & format, FormatState &, FormatStateStacked) const override;
     ASTPtr getRewrittenASTWithoutOnCluster(const WithoutOnClusterASTRewriteParams &) const override { return removeOnCluster<ASTCreateRoleQuery>(clone()); }
 
     QueryKind getQueryKind() const override { return QueryKind::Create; }

--- a/src/Parsers/Access/ASTCreateRowPolicyQuery.h
+++ b/src/Parsers/Access/ASTCreateRowPolicyQuery.h
@@ -47,7 +47,7 @@ public:
 
     String getID(char) const override;
     ASTPtr clone() const override;
-    void formatImpl(const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
     ASTPtr getRewrittenASTWithoutOnCluster(const WithoutOnClusterASTRewriteParams &) const override { return removeOnCluster<ASTCreateRowPolicyQuery>(clone()); }
 
     void replaceCurrentUserTag(const String & current_user_name) const;

--- a/src/Parsers/Access/ASTCreateSettingsProfileQuery.cpp
+++ b/src/Parsers/Access/ASTCreateSettingsProfileQuery.cpp
@@ -9,34 +9,34 @@ namespace DB
 {
 namespace
 {
-    void formatNames(const Strings & names, const IAST::FormatSettings & settings)
+    void formatNames(const Strings & names, WriteBuffer & ostr)
     {
-        settings.ostr << " ";
+        ostr << " ";
         bool need_comma = false;
         for (const String & name : names)
         {
             if (std::exchange(need_comma, true))
-                settings.ostr << ", ";
-            settings.ostr << backQuote(name);
+                ostr << ", ";
+            ostr << backQuote(name);
         }
     }
 
-    void formatRenameTo(const String & new_name, const IAST::FormatSettings & settings)
+    void formatRenameTo(const String & new_name, WriteBuffer & ostr, const IAST::FormatSettings & settings)
     {
-        settings.ostr << (settings.hilite ? IAST::hilite_keyword : "") << " RENAME TO " << (settings.hilite ? IAST::hilite_none : "")
+        ostr << (settings.hilite ? IAST::hilite_keyword : "") << " RENAME TO " << (settings.hilite ? IAST::hilite_none : "")
                       << quoteString(new_name);
     }
 
-    void formatSettings(const ASTSettingsProfileElements & settings, const IAST::FormatSettings & format)
+    void formatSettings(const ASTSettingsProfileElements & settings, WriteBuffer & ostr, const IAST::FormatSettings & format)
     {
-        format.ostr << (format.hilite ? IAST::hilite_keyword : "") << " SETTINGS " << (format.hilite ? IAST::hilite_none : "");
-        settings.format(format);
+        ostr << (format.hilite ? IAST::hilite_keyword : "") << " SETTINGS " << (format.hilite ? IAST::hilite_none : "");
+        settings.format(ostr, format);
     }
 
-    void formatToRoles(const ASTRolesOrUsersSet & roles, const IAST::FormatSettings & settings)
+    void formatToRoles(const ASTRolesOrUsersSet & roles, WriteBuffer & ostr, const IAST::FormatSettings & settings)
     {
-        settings.ostr << (settings.hilite ? IAST::hilite_keyword : "") << " TO " << (settings.hilite ? IAST::hilite_none : "");
-        roles.format(settings);
+        ostr << (settings.hilite ? IAST::hilite_keyword : "") << " TO " << (settings.hilite ? IAST::hilite_none : "");
+        roles.format(ostr, settings);
     }
 }
 
@@ -61,42 +61,42 @@ ASTPtr ASTCreateSettingsProfileQuery::clone() const
 }
 
 
-void ASTCreateSettingsProfileQuery::formatImpl(const FormatSettings & format, FormatState &, FormatStateStacked) const
+void ASTCreateSettingsProfileQuery::formatImpl(WriteBuffer & ostr, const FormatSettings & format, FormatState &, FormatStateStacked) const
 {
     if (attach)
     {
-        format.ostr << (format.hilite ? hilite_keyword : "") << "ATTACH SETTINGS PROFILE" << (format.hilite ? hilite_none : "");
+        ostr << (format.hilite ? hilite_keyword : "") << "ATTACH SETTINGS PROFILE" << (format.hilite ? hilite_none : "");
     }
     else
     {
-        format.ostr << (format.hilite ? hilite_keyword : "") << (alter ? "ALTER SETTINGS PROFILE" : "CREATE SETTINGS PROFILE")
+        ostr << (format.hilite ? hilite_keyword : "") << (alter ? "ALTER SETTINGS PROFILE" : "CREATE SETTINGS PROFILE")
                       << (format.hilite ? hilite_none : "");
     }
 
     if (if_exists)
-        format.ostr << (format.hilite ? hilite_keyword : "") << " IF EXISTS" << (format.hilite ? hilite_none : "");
+        ostr << (format.hilite ? hilite_keyword : "") << " IF EXISTS" << (format.hilite ? hilite_none : "");
     else if (if_not_exists)
-        format.ostr << (format.hilite ? hilite_keyword : "") << " IF NOT EXISTS" << (format.hilite ? hilite_none : "");
+        ostr << (format.hilite ? hilite_keyword : "") << " IF NOT EXISTS" << (format.hilite ? hilite_none : "");
     else if (or_replace)
-        format.ostr << (format.hilite ? hilite_keyword : "") << " OR REPLACE" << (format.hilite ? hilite_none : "");
+        ostr << (format.hilite ? hilite_keyword : "") << " OR REPLACE" << (format.hilite ? hilite_none : "");
 
-    formatNames(names, format);
+    formatNames(names, ostr);
 
     if (!storage_name.empty())
-        format.ostr << (format.hilite ? IAST::hilite_keyword : "")
+        ostr << (format.hilite ? IAST::hilite_keyword : "")
                     << " IN " << (format.hilite ? IAST::hilite_none : "")
                     << backQuoteIfNeed(storage_name);
 
-    formatOnCluster(format);
+    formatOnCluster(ostr, format);
 
     if (!new_name.empty())
-        formatRenameTo(new_name, format);
+        formatRenameTo(new_name, ostr, format);
 
     if (settings && (!settings->empty() || alter))
-        formatSettings(*settings, format);
+        formatSettings(*settings, ostr, format);
 
     if (to_roles && (!to_roles->empty() || alter))
-        formatToRoles(*to_roles, format);
+        formatToRoles(*to_roles, ostr, format);
 }
 
 

--- a/src/Parsers/Access/ASTCreateSettingsProfileQuery.h
+++ b/src/Parsers/Access/ASTCreateSettingsProfileQuery.h
@@ -39,7 +39,7 @@ public:
 
     String getID(char) const override;
     ASTPtr clone() const override;
-    void formatImpl(const FormatSettings & format, FormatState &, FormatStateStacked) const override;
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & format, FormatState &, FormatStateStacked) const override;
     void replaceCurrentUserTag(const String & current_user_name) const;
     ASTPtr getRewrittenASTWithoutOnCluster(const WithoutOnClusterASTRewriteParams &) const override { return removeOnCluster<ASTCreateSettingsProfileQuery>(clone()); }
     QueryKind getQueryKind() const override { return QueryKind::Create; }

--- a/src/Parsers/Access/ASTCreateUserQuery.h
+++ b/src/Parsers/Access/ASTCreateUserQuery.h
@@ -66,7 +66,7 @@ public:
 
     String getID(char) const override;
     ASTPtr clone() const override;
-    void formatImpl(const FormatSettings & format, FormatState &, FormatStateStacked) const override;
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & format, FormatState &, FormatStateStacked) const override;
     ASTPtr getRewrittenASTWithoutOnCluster(const WithoutOnClusterASTRewriteParams &) const override { return removeOnCluster<ASTCreateUserQuery>(clone()); }
 
     QueryKind getQueryKind() const override { return QueryKind::Create; }

--- a/src/Parsers/Access/ASTDropAccessEntityQuery.cpp
+++ b/src/Parsers/Access/ASTDropAccessEntityQuery.cpp
@@ -8,14 +8,14 @@ namespace DB
 {
 namespace
 {
-    void formatNames(const Strings & names, const IAST::FormatSettings & settings)
+    void formatNames(const Strings & names, WriteBuffer & ostr)
     {
         bool need_comma = false;
         for (const auto & name : names)
         {
             if (std::exchange(need_comma, true))
-                settings.ostr << ',';
-            settings.ostr << ' ' << backQuoteIfNeed(name);
+                ostr << ',';
+            ostr << ' ' << backQuoteIfNeed(name);
         }
     }
 }
@@ -38,27 +38,27 @@ ASTPtr ASTDropAccessEntityQuery::clone() const
 }
 
 
-void ASTDropAccessEntityQuery::formatImpl(const FormatSettings & settings, FormatState &, FormatStateStacked) const
+void ASTDropAccessEntityQuery::formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState &, FormatStateStacked) const
 {
-    settings.ostr << (settings.hilite ? hilite_keyword : "")
+    ostr << (settings.hilite ? hilite_keyword : "")
                   << "DROP " << AccessEntityTypeInfo::get(type).name
                   << (if_exists ? " IF EXISTS" : "")
                   << (settings.hilite ? hilite_none : "");
 
     if (type == AccessEntityType::ROW_POLICY)
     {
-        settings.ostr << " ";
-        row_policy_names->format(settings);
+        ostr << " ";
+        row_policy_names->format(ostr, settings);
     }
     else
-        formatNames(names, settings);
+        formatNames(names, ostr);
 
     if (!storage_name.empty())
-        settings.ostr << (settings.hilite ? hilite_keyword : "")
+        ostr << (settings.hilite ? hilite_keyword : "")
                       << " FROM " << (settings.hilite ? hilite_none : "")
                       << backQuoteIfNeed(storage_name);
 
-    formatOnCluster(settings);
+    formatOnCluster(ostr, settings);
 }
 
 

--- a/src/Parsers/Access/ASTDropAccessEntityQuery.h
+++ b/src/Parsers/Access/ASTDropAccessEntityQuery.h
@@ -26,7 +26,7 @@ public:
 
     String getID(char) const override;
     ASTPtr clone() const override;
-    void formatImpl(const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
     ASTPtr getRewrittenASTWithoutOnCluster(const WithoutOnClusterASTRewriteParams &) const override { return removeOnCluster<ASTDropAccessEntityQuery>(clone()); }
 
     void replaceEmptyDatabase(const String & current_database) const;

--- a/src/Parsers/Access/ASTGrantQuery.cpp
+++ b/src/Parsers/Access/ASTGrantQuery.cpp
@@ -12,11 +12,11 @@ namespace ErrorCodes
 
 namespace
 {
-    void formatCurrentGrantsElements(const AccessRightsElements & elements, const IAST::FormatSettings & settings)
+    void formatCurrentGrantsElements(const AccessRightsElements & elements, WriteBuffer & ostr, const IAST::FormatSettings & settings)
     {
-        settings.ostr << "(";
-        elements.formatElementsWithoutOptions(settings.ostr, settings.hilite);
-        settings.ostr << ")";
+        ostr << "(";
+        elements.formatElementsWithoutOptions(ostr, settings.hilite);
+        ostr << ")";
     }
 }
 
@@ -41,9 +41,9 @@ ASTPtr ASTGrantQuery::clone() const
 }
 
 
-void ASTGrantQuery::formatImpl(const FormatSettings & settings, FormatState &, FormatStateStacked) const
+void ASTGrantQuery::formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState &, FormatStateStacked) const
 {
-    settings.ostr << (settings.hilite ? IAST::hilite_keyword : "") << (attach_mode ? "ATTACH " : "")
+    ostr << (settings.hilite ? IAST::hilite_keyword : "") << (attach_mode ? "ATTACH " : "")
                   << (settings.hilite ? hilite_keyword : "") << (is_revoke ? "REVOKE" : "GRANT")
                   << (settings.hilite ? IAST::hilite_none : "");
 
@@ -53,20 +53,20 @@ void ASTGrantQuery::formatImpl(const FormatSettings & settings, FormatState &, F
         throw Exception(ErrorCodes::LOGICAL_ERROR, "A partial revoke should be revoked, not granted");
     bool grant_option = !access_rights_elements.empty() && access_rights_elements[0].grant_option;
 
-    formatOnCluster(settings);
+    formatOnCluster(ostr, settings);
 
     if (is_revoke)
     {
         if (grant_option)
-            settings.ostr << (settings.hilite ? hilite_keyword : "") << " GRANT OPTION FOR" << (settings.hilite ? hilite_none : "");
+            ostr << (settings.hilite ? hilite_keyword : "") << " GRANT OPTION FOR" << (settings.hilite ? hilite_none : "");
         else if (admin_option)
-            settings.ostr << (settings.hilite ? hilite_keyword : "") << " ADMIN OPTION FOR" << (settings.hilite ? hilite_none : "");
+            ostr << (settings.hilite ? hilite_keyword : "") << " ADMIN OPTION FOR" << (settings.hilite ? hilite_none : "");
     }
 
-    settings.ostr << " ";
+    ostr << " ";
     if (roles)
     {
-        roles->format(settings);
+        roles->format(ostr, settings);
         if (!access_rights_elements.empty())
             throw Exception(ErrorCodes::LOGICAL_ERROR,
                             "ASTGrantQuery can contain either roles or access rights elements "
@@ -74,27 +74,27 @@ void ASTGrantQuery::formatImpl(const FormatSettings & settings, FormatState &, F
     }
     else if (current_grants)
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << "CURRENT GRANTS" << (settings.hilite ? hilite_none : "");
-        formatCurrentGrantsElements(access_rights_elements, settings);
+        ostr << (settings.hilite ? hilite_keyword : "") << "CURRENT GRANTS" << (settings.hilite ? hilite_none : "");
+        formatCurrentGrantsElements(access_rights_elements, ostr, settings);
     }
     else
     {
-        access_rights_elements.formatElementsWithoutOptions(settings.ostr, settings.hilite);
+        access_rights_elements.formatElementsWithoutOptions(ostr, settings.hilite);
     }
 
-    settings.ostr << (settings.hilite ? IAST::hilite_keyword : "") << (is_revoke ? " FROM " : " TO ")
+    ostr << (settings.hilite ? IAST::hilite_keyword : "") << (is_revoke ? " FROM " : " TO ")
                   << (settings.hilite ? IAST::hilite_none : "");
-    grantees->format(settings);
+    grantees->format(ostr, settings);
 
     if (!is_revoke)
     {
         if (grant_option)
-            settings.ostr << (settings.hilite ? hilite_keyword : "") << " WITH GRANT OPTION" << (settings.hilite ? hilite_none : "");
+            ostr << (settings.hilite ? hilite_keyword : "") << " WITH GRANT OPTION" << (settings.hilite ? hilite_none : "");
         else if (admin_option)
-            settings.ostr << (settings.hilite ? hilite_keyword : "") << " WITH ADMIN OPTION" << (settings.hilite ? hilite_none : "");
+            ostr << (settings.hilite ? hilite_keyword : "") << " WITH ADMIN OPTION" << (settings.hilite ? hilite_none : "");
 
         if (replace_access || replace_granted_roles)
-            settings.ostr << (settings.hilite ? hilite_keyword : "") << " WITH REPLACE OPTION" << (settings.hilite ? hilite_none : "");
+            ostr << (settings.hilite ? hilite_keyword : "") << " WITH REPLACE OPTION" << (settings.hilite ? hilite_none : "");
     }
 }
 

--- a/src/Parsers/Access/ASTGrantQuery.h
+++ b/src/Parsers/Access/ASTGrantQuery.h
@@ -32,7 +32,7 @@ public:
 
     String getID(char) const override;
     ASTPtr clone() const override;
-    void formatImpl(const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
     void replaceEmptyDatabase(const String & current_database);
     void replaceCurrentUserTag(const String & current_user_name) const;
     ASTPtr getRewrittenASTWithoutOnCluster(const WithoutOnClusterASTRewriteParams &) const override { return removeOnCluster<ASTGrantQuery>(clone()); }

--- a/src/Parsers/Access/ASTMoveAccessEntityQuery.cpp
+++ b/src/Parsers/Access/ASTMoveAccessEntityQuery.cpp
@@ -8,14 +8,14 @@ namespace DB
 {
 namespace
 {
-    void formatNames(const Strings & names, const IAST::FormatSettings & settings)
+    void formatNames(const Strings & names, WriteBuffer & ostr)
     {
         bool need_comma = false;
         for (const auto & name : names)
         {
             if (std::exchange(need_comma, true))
-                settings.ostr << ',';
-            settings.ostr << ' ' << backQuoteIfNeed(name);
+                ostr << ',';
+            ostr << ' ' << backQuoteIfNeed(name);
         }
     }
 }
@@ -35,25 +35,25 @@ ASTPtr ASTMoveAccessEntityQuery::clone() const
     return res;
 }
 
-void ASTMoveAccessEntityQuery::formatImpl(const FormatSettings & settings, FormatState &, FormatStateStacked) const
+void ASTMoveAccessEntityQuery::formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState &, FormatStateStacked) const
 {
-    settings.ostr << (settings.hilite ? hilite_keyword : "")
+    ostr << (settings.hilite ? hilite_keyword : "")
                   << "MOVE " << AccessEntityTypeInfo::get(type).name
                   << (settings.hilite ? hilite_none : "");
 
     if (type == AccessEntityType::ROW_POLICY)
     {
-        settings.ostr << " ";
-        row_policy_names->format(settings);
+        ostr << " ";
+        row_policy_names->format(ostr, settings);
     }
     else
-        formatNames(names, settings);
+        formatNames(names, ostr);
 
-    settings.ostr << (settings.hilite ? hilite_keyword : "")
+    ostr << (settings.hilite ? hilite_keyword : "")
                   << " TO " << (settings.hilite ? hilite_none : "")
                   << backQuoteIfNeed(storage_name);
 
-    formatOnCluster(settings);
+    formatOnCluster(ostr, settings);
 }
 
 void ASTMoveAccessEntityQuery::replaceEmptyDatabase(const String & current_database) const

--- a/src/Parsers/Access/ASTMoveAccessEntityQuery.h
+++ b/src/Parsers/Access/ASTMoveAccessEntityQuery.h
@@ -22,7 +22,7 @@ public:
 
     String getID(char) const override;
     ASTPtr clone() const override;
-    void formatImpl(const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
     ASTPtr getRewrittenASTWithoutOnCluster(const WithoutOnClusterASTRewriteParams &) const override { return removeOnCluster<ASTMoveAccessEntityQuery>(clone()); }
 
     void replaceEmptyDatabase(const String & current_database) const;

--- a/src/Parsers/Access/ASTPublicSSHKey.cpp
+++ b/src/Parsers/Access/ASTPublicSSHKey.cpp
@@ -6,12 +6,12 @@
 namespace DB
 {
 
-void ASTPublicSSHKey::formatImpl(const FormatSettings & settings, FormatState &, FormatStateStacked) const
+void ASTPublicSSHKey::formatImpl(WriteBuffer & ostr, const FormatSettings &, FormatState &, FormatStateStacked) const
 {
-    settings.ostr << "KEY ";
-    settings.ostr << backQuoteIfNeed(key_base64) << ' ';
-    settings.ostr << "TYPE ";
-    settings.ostr << backQuoteIfNeed(type);
+    ostr << "KEY ";
+    ostr << backQuoteIfNeed(key_base64) << ' ';
+    ostr << "TYPE ";
+    ostr << backQuoteIfNeed(type);
 }
 
 }

--- a/src/Parsers/Access/ASTPublicSSHKey.h
+++ b/src/Parsers/Access/ASTPublicSSHKey.h
@@ -19,7 +19,7 @@ public:
     {}
     String getID(char) const override { return "PublicSSHKey"; }
     ASTPtr clone() const override { return std::make_shared<ASTPublicSSHKey>(*this); }
-    void formatImpl(const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
+    void formatImpl(WriteBuffer & ostr, const FormatSettings &, FormatState &, FormatStateStacked) const override;
 };
 
 }

--- a/src/Parsers/Access/ASTRolesOrUsersSet.cpp
+++ b/src/Parsers/Access/ASTRolesOrUsersSet.cpp
@@ -7,25 +7,25 @@ namespace DB
 {
 namespace
 {
-    void formatNameOrID(const String & str, bool is_id, const IAST::FormatSettings & settings)
+    void formatNameOrID(const String & str, bool is_id, WriteBuffer & ostr, const IAST::FormatSettings & settings)
     {
         if (is_id)
         {
-            settings.ostr << (settings.hilite ? IAST::hilite_keyword : "") << "ID" << (settings.hilite ? IAST::hilite_none : "") << "("
+            ostr << (settings.hilite ? IAST::hilite_keyword : "") << "ID" << (settings.hilite ? IAST::hilite_none : "") << "("
                           << quoteString(str) << ")";
         }
         else
         {
-            settings.ostr << backQuoteIfNeed(str);
+            ostr << backQuoteIfNeed(str);
         }
     }
 }
 
-void ASTRolesOrUsersSet::formatImpl(const FormatSettings & settings, FormatState &, FormatStateStacked) const
+void ASTRolesOrUsersSet::formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState &, FormatStateStacked) const
 {
     if (empty())
     {
-        settings.ostr << (settings.hilite ? IAST::hilite_keyword : "") << "NONE" << (settings.hilite ? IAST::hilite_none : "");
+        ostr << (settings.hilite ? IAST::hilite_keyword : "") << "NONE" << (settings.hilite ? IAST::hilite_none : "");
         return;
     }
 
@@ -34,8 +34,8 @@ void ASTRolesOrUsersSet::formatImpl(const FormatSettings & settings, FormatState
     if (all)
     {
         if (std::exchange(need_comma, true))
-            settings.ostr << ", ";
-        settings.ostr << (settings.hilite ? IAST::hilite_keyword : "") << (use_keyword_any ? "ANY" : "ALL")
+            ostr << ", ";
+        ostr << (settings.hilite ? IAST::hilite_keyword : "") << (use_keyword_any ? "ANY" : "ALL")
                       << (settings.hilite ? IAST::hilite_none : "");
     }
     else
@@ -43,35 +43,35 @@ void ASTRolesOrUsersSet::formatImpl(const FormatSettings & settings, FormatState
         for (const auto & name : names)
         {
             if (std::exchange(need_comma, true))
-                settings.ostr << ", ";
-            formatNameOrID(name, id_mode, settings);
+                ostr << ", ";
+            formatNameOrID(name, id_mode, ostr, settings);
         }
 
         if (current_user)
         {
             if (std::exchange(need_comma, true))
-                settings.ostr << ", ";
-            settings.ostr << (settings.hilite ? IAST::hilite_keyword : "") << "CURRENT_USER" << (settings.hilite ? IAST::hilite_none : "");
+                ostr << ", ";
+            ostr << (settings.hilite ? IAST::hilite_keyword : "") << "CURRENT_USER" << (settings.hilite ? IAST::hilite_none : "");
         }
     }
 
     if (except_current_user || !except_names.empty())
     {
-        settings.ostr << (settings.hilite ? IAST::hilite_keyword : "") << " EXCEPT " << (settings.hilite ? IAST::hilite_none : "");
+        ostr << (settings.hilite ? IAST::hilite_keyword : "") << " EXCEPT " << (settings.hilite ? IAST::hilite_none : "");
         need_comma = false;
 
         for (const auto & name : except_names)
         {
             if (std::exchange(need_comma, true))
-                settings.ostr << ", ";
-            formatNameOrID(name, id_mode, settings);
+                ostr << ", ";
+            formatNameOrID(name, id_mode, ostr, settings);
         }
 
         if (except_current_user)
         {
             if (std::exchange(need_comma, true))
-                settings.ostr << ", ";
-            settings.ostr << (settings.hilite ? IAST::hilite_keyword : "") << "CURRENT_USER" << (settings.hilite ? IAST::hilite_none : "");
+                ostr << ", ";
+            ostr << (settings.hilite ? IAST::hilite_keyword : "") << "CURRENT_USER" << (settings.hilite ? IAST::hilite_none : "");
         }
     }
 }

--- a/src/Parsers/Access/ASTRolesOrUsersSet.h
+++ b/src/Parsers/Access/ASTRolesOrUsersSet.h
@@ -30,6 +30,6 @@ public:
 
     String getID(char) const override { return "RolesOrUsersSet"; }
     ASTPtr clone() const override { return std::make_shared<ASTRolesOrUsersSet>(*this); }
-    void formatImpl(const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
 };
 }

--- a/src/Parsers/Access/ASTRowPolicyName.cpp
+++ b/src/Parsers/Access/ASTRowPolicyName.cpp
@@ -11,16 +11,16 @@ namespace ErrorCodes
 }
 
 
-void ASTRowPolicyName::formatImpl(const FormatSettings & settings, FormatState &, FormatStateStacked) const
+void ASTRowPolicyName::formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState &, FormatStateStacked) const
 {
     const String & database = full_name.database;
     const String & table_name = full_name.table_name;
     const String & short_name = full_name.short_name;
-    settings.ostr << backQuoteIfNeed(short_name) << (settings.hilite ? hilite_keyword : "") << " ON "
+    ostr << backQuoteIfNeed(short_name) << (settings.hilite ? hilite_keyword : "") << " ON "
                   << (settings.hilite ? hilite_none : "") << (database.empty() ? String{} : backQuoteIfNeed(database) + ".")
                   << backQuoteIfNeed(table_name);
 
-    formatOnCluster(settings);
+    formatOnCluster(ostr, settings);
 }
 
 
@@ -36,7 +36,7 @@ String ASTRowPolicyNames::tableOrAsterisk(const String & table_name) const
 }
 
 
-void ASTRowPolicyNames::formatImpl(const FormatSettings & settings, FormatState &, FormatStateStacked) const
+void ASTRowPolicyNames::formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState &, FormatStateStacked) const
 {
     if (full_names.empty())
         throw Exception(ErrorCodes::LOGICAL_ERROR, "No names of row policies in AST");
@@ -66,19 +66,19 @@ void ASTRowPolicyNames::formatImpl(const FormatSettings & settings, FormatState 
     if (same_short_name)
     {
         const String & short_name = full_names[0].short_name;
-        settings.ostr << backQuoteIfNeed(short_name) << (settings.hilite ? hilite_keyword : "") << " ON "
+        ostr << backQuoteIfNeed(short_name) << (settings.hilite ? hilite_keyword : "") << " ON "
                       << (settings.hilite ? hilite_none : "");
 
         bool need_comma = false;
         for (const auto & full_name : full_names)
         {
             if (std::exchange(need_comma, true))
-                settings.ostr << ", ";
+                ostr << ", ";
             const String & database = full_name.database;
             const String & table_name = full_name.table_name;
             if (!database.empty())
-                settings.ostr << backQuoteIfNeed(database) + ".";
-            settings.ostr << tableOrAsterisk(table_name);
+                ostr << backQuoteIfNeed(database) + ".";
+            ostr << tableOrAsterisk(table_name);
         }
     }
     else if (same_db_and_table_name)
@@ -87,17 +87,17 @@ void ASTRowPolicyNames::formatImpl(const FormatSettings & settings, FormatState 
         for (const auto & full_name : full_names)
         {
             if (std::exchange(need_comma, true))
-                settings.ostr << ", ";
+                ostr << ", ";
             const String & short_name = full_name.short_name;
-            settings.ostr << backQuoteIfNeed(short_name);
+            ostr << backQuoteIfNeed(short_name);
         }
 
         const String & database = full_names[0].database;
         const String & table_name = full_names[0].table_name;
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << " ON " << (settings.hilite ? hilite_none : "");
+        ostr << (settings.hilite ? hilite_keyword : "") << " ON " << (settings.hilite ? hilite_none : "");
         if (!database.empty())
-            settings.ostr << backQuoteIfNeed(database) + ".";
-        settings.ostr << tableOrAsterisk(table_name);
+            ostr << backQuoteIfNeed(database) + ".";
+        ostr << tableOrAsterisk(table_name);
     }
     else
     {
@@ -105,19 +105,19 @@ void ASTRowPolicyNames::formatImpl(const FormatSettings & settings, FormatState 
         for (const auto & full_name : full_names)
         {
             if (std::exchange(need_comma, true))
-                settings.ostr << ", ";
+                ostr << ", ";
             const String & short_name = full_name.short_name;
             const String & database = full_name.database;
             const String & table_name = full_name.table_name;
-            settings.ostr << backQuoteIfNeed(short_name) << (settings.hilite ? hilite_keyword : "") << " ON "
+            ostr << backQuoteIfNeed(short_name) << (settings.hilite ? hilite_keyword : "") << " ON "
                           << (settings.hilite ? hilite_none : "");
             if (!database.empty())
-                settings.ostr << backQuoteIfNeed(database) + ".";
-            settings.ostr << tableOrAsterisk(table_name);
+                ostr << backQuoteIfNeed(database) + ".";
+            ostr << tableOrAsterisk(table_name);
         }
     }
 
-    formatOnCluster(settings);
+    formatOnCluster(ostr, settings);
 }
 
 

--- a/src/Parsers/Access/ASTRowPolicyName.h
+++ b/src/Parsers/Access/ASTRowPolicyName.h
@@ -19,7 +19,7 @@ public:
 
     String getID(char) const override { return "RowPolicyName"; }
     ASTPtr clone() const override { return std::make_shared<ASTRowPolicyName>(*this); }
-    void formatImpl(const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
     ASTPtr getRewrittenASTWithoutOnCluster(const WithoutOnClusterASTRewriteParams &) const override { return removeOnCluster<ASTRowPolicyName>(clone()); }
 
     void replaceEmptyDatabase(const String & current_database);
@@ -41,7 +41,7 @@ public:
 
     String getID(char) const override { return "RowPolicyNames"; }
     ASTPtr clone() const override { return std::make_shared<ASTRowPolicyNames>(*this); }
-    void formatImpl(const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
     ASTPtr getRewrittenASTWithoutOnCluster(const WithoutOnClusterASTRewriteParams &) const override { return removeOnCluster<ASTRowPolicyNames>(clone()); }
 
     void replaceEmptyDatabase(const String & current_database);

--- a/src/Parsers/Access/ASTSetRoleQuery.cpp
+++ b/src/Parsers/Access/ASTSetRoleQuery.cpp
@@ -26,27 +26,27 @@ ASTPtr ASTSetRoleQuery::clone() const
 }
 
 
-void ASTSetRoleQuery::formatImpl(const FormatSettings & settings, FormatState &, FormatStateStacked) const
+void ASTSetRoleQuery::formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState &, FormatStateStacked) const
 {
-    settings.ostr << (settings.hilite ? hilite_keyword : "");
+    ostr << (settings.hilite ? hilite_keyword : "");
     switch (kind)
     {
-        case Kind::SET_ROLE: settings.ostr << "SET ROLE"; break;
-        case Kind::SET_ROLE_DEFAULT: settings.ostr << "SET ROLE DEFAULT"; break;
-        case Kind::SET_DEFAULT_ROLE: settings.ostr << "SET DEFAULT ROLE"; break;
+        case Kind::SET_ROLE: ostr << "SET ROLE"; break;
+        case Kind::SET_ROLE_DEFAULT: ostr << "SET ROLE DEFAULT"; break;
+        case Kind::SET_DEFAULT_ROLE: ostr << "SET DEFAULT ROLE"; break;
     }
-    settings.ostr << (settings.hilite ? hilite_none : "");
+    ostr << (settings.hilite ? hilite_none : "");
 
     if (kind == Kind::SET_ROLE_DEFAULT)
         return;
 
-    settings.ostr << " ";
-    roles->format(settings);
+    ostr << " ";
+    roles->format(ostr, settings);
 
     if (kind == Kind::SET_ROLE)
         return;
 
-    settings.ostr << (settings.hilite ? hilite_keyword : "") << " TO " << (settings.hilite ? hilite_none : "");
-    to_users->format(settings);
+    ostr << (settings.hilite ? hilite_keyword : "") << " TO " << (settings.hilite ? hilite_none : "");
+    to_users->format(ostr, settings);
 }
 }

--- a/src/Parsers/Access/ASTSetRoleQuery.h
+++ b/src/Parsers/Access/ASTSetRoleQuery.h
@@ -26,7 +26,7 @@ public:
 
     String getID(char) const override;
     ASTPtr clone() const override;
-    void formatImpl(const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
 
     QueryKind getQueryKind() const override { return QueryKind::Set; }
 };

--- a/src/Parsers/Access/ASTSettingsProfileElement.cpp
+++ b/src/Parsers/Access/ASTSettingsProfileElement.cpp
@@ -9,46 +9,46 @@ namespace DB
 {
 namespace
 {
-    void formatProfileNameOrID(const String & str, bool is_id, const IAST::FormatSettings & settings)
+    void formatProfileNameOrID(const String & str, bool is_id, WriteBuffer & ostr, const IAST::FormatSettings & settings)
     {
         if (is_id)
         {
-            settings.ostr << (settings.hilite ? IAST::hilite_keyword : "") << "ID" << (settings.hilite ? IAST::hilite_none : "") << "("
+            ostr << (settings.hilite ? IAST::hilite_keyword : "") << "ID" << (settings.hilite ? IAST::hilite_none : "") << "("
                           << quoteString(str) << ")";
         }
         else
         {
-            settings.ostr << backQuote(str);
+            ostr << backQuote(str);
         }
     }
 }
 
-void ASTSettingsProfileElement::formatImpl(const FormatSettings & settings, FormatState &, FormatStateStacked) const
+void ASTSettingsProfileElement::formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState &, FormatStateStacked) const
 {
     if (!parent_profile.empty())
     {
-        settings.ostr << (settings.hilite ? IAST::hilite_keyword : "") << (use_inherit_keyword ? "INHERIT" : "PROFILE") << " "
+        ostr << (settings.hilite ? IAST::hilite_keyword : "") << (use_inherit_keyword ? "INHERIT" : "PROFILE") << " "
                       << (settings.hilite ? IAST::hilite_none : "");
-        formatProfileNameOrID(parent_profile, id_mode, settings);
+        formatProfileNameOrID(parent_profile, id_mode, ostr, settings);
         return;
     }
 
-    formatSettingName(setting_name, settings.ostr);
+    formatSettingName(setting_name, ostr);
 
     if (value)
     {
-        settings.ostr << " = " << applyVisitor(FieldVisitorToString{}, *value);
+        ostr << " = " << applyVisitor(FieldVisitorToString{}, *value);
     }
 
     if (min_value)
     {
-        settings.ostr << (settings.hilite ? IAST::hilite_keyword : "") << " MIN " << (settings.hilite ? IAST::hilite_none : "")
+        ostr << (settings.hilite ? IAST::hilite_keyword : "") << " MIN " << (settings.hilite ? IAST::hilite_none : "")
                       << applyVisitor(FieldVisitorToString{}, *min_value);
     }
 
     if (max_value)
     {
-        settings.ostr << (settings.hilite ? IAST::hilite_keyword : "") << " MAX " << (settings.hilite ? IAST::hilite_none : "")
+        ostr << (settings.hilite ? IAST::hilite_keyword : "") << " MAX " << (settings.hilite ? IAST::hilite_none : "")
                       << applyVisitor(FieldVisitorToString{}, *max_value);
     }
 
@@ -57,15 +57,15 @@ void ASTSettingsProfileElement::formatImpl(const FormatSettings & settings, Form
         switch (*writability)
         {
             case SettingConstraintWritability::WRITABLE:
-                settings.ostr << (settings.hilite ? IAST::hilite_keyword : "") << " WRITABLE"
+                ostr << (settings.hilite ? IAST::hilite_keyword : "") << " WRITABLE"
                             << (settings.hilite ? IAST::hilite_none : "");
                 break;
             case SettingConstraintWritability::CONST:
-                settings.ostr << (settings.hilite ? IAST::hilite_keyword : "") << " CONST"
+                ostr << (settings.hilite ? IAST::hilite_keyword : "") << " CONST"
                             << (settings.hilite ? IAST::hilite_none : "");
                 break;
             case SettingConstraintWritability::CHANGEABLE_IN_READONLY:
-                settings.ostr << (settings.hilite ? IAST::hilite_keyword : "") << " CHANGEABLE_IN_READONLY"
+                ostr << (settings.hilite ? IAST::hilite_keyword : "") << " CHANGEABLE_IN_READONLY"
                             << (settings.hilite ? IAST::hilite_none : "");
                 break;
             case SettingConstraintWritability::MAX: break;
@@ -83,11 +83,11 @@ bool ASTSettingsProfileElements::empty() const
 }
 
 
-void ASTSettingsProfileElements::formatImpl(const FormatSettings & settings, FormatState &, FormatStateStacked) const
+void ASTSettingsProfileElements::formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState &, FormatStateStacked) const
 {
     if (empty())
     {
-        settings.ostr << (settings.hilite ? IAST::hilite_keyword : "") << "NONE" << (settings.hilite ? IAST::hilite_none : "");
+        ostr << (settings.hilite ? IAST::hilite_keyword : "") << "NONE" << (settings.hilite ? IAST::hilite_none : "");
         return;
     }
 
@@ -95,10 +95,10 @@ void ASTSettingsProfileElements::formatImpl(const FormatSettings & settings, For
     for (const auto & element : elements)
     {
         if (need_comma)
-            settings.ostr << ", ";
+            ostr << ", ";
         need_comma = true;
 
-        element->format(settings);
+        element->format(ostr, settings);
     }
 }
 

--- a/src/Parsers/Access/ASTSettingsProfileElement.h
+++ b/src/Parsers/Access/ASTSettingsProfileElement.h
@@ -25,7 +25,7 @@ public:
 
     String getID(char) const override { return "SettingsProfileElement"; }
     ASTPtr clone() const override { return std::make_shared<ASTSettingsProfileElement>(*this); }
-    void formatImpl(const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
 };
 
 
@@ -41,7 +41,7 @@ public:
 
     String getID(char) const override { return "SettingsProfileElements"; }
     ASTPtr clone() const override { return std::make_shared<ASTSettingsProfileElements>(*this); }
-    void formatImpl(const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
 
     void setUseInheritKeyword(bool use_inherit_keyword_);
 };

--- a/src/Parsers/Access/ASTShowAccessEntitiesQuery.cpp
+++ b/src/Parsers/Access/ASTShowAccessEntitiesQuery.cpp
@@ -24,20 +24,20 @@ String ASTShowAccessEntitiesQuery::getID(char) const
     return fmt::format("SHOW {} query", getKeyword());
 }
 
-void ASTShowAccessEntitiesQuery::formatQueryImpl(const FormatSettings & settings, FormatState &, FormatStateStacked) const
+void ASTShowAccessEntitiesQuery::formatQueryImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState &, FormatStateStacked) const
 {
-    settings.ostr << (settings.hilite ? hilite_keyword : "") << "SHOW " << getKeyword() << (settings.hilite ? hilite_none : "");
+    ostr << (settings.hilite ? hilite_keyword : "") << "SHOW " << getKeyword() << (settings.hilite ? hilite_none : "");
 
     if (!short_name.empty())
-        settings.ostr << " " << backQuoteIfNeed(short_name);
+        ostr << " " << backQuoteIfNeed(short_name);
 
     if (database_and_table_name)
     {
         const String & database = database_and_table_name->first;
         const String & table_name = database_and_table_name->second;
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << " ON " << (settings.hilite ? hilite_none : "");
-        settings.ostr << (database.empty() ? "" : backQuoteIfNeed(database) + ".");
-        settings.ostr << (table_name.empty() ? "*" : backQuoteIfNeed(table_name));
+        ostr << (settings.hilite ? hilite_keyword : "") << " ON " << (settings.hilite ? hilite_none : "");
+        ostr << (database.empty() ? "" : backQuoteIfNeed(database) + ".");
+        ostr << (table_name.empty() ? "*" : backQuoteIfNeed(table_name));
     }
 }
 

--- a/src/Parsers/Access/ASTShowAccessEntitiesQuery.h
+++ b/src/Parsers/Access/ASTShowAccessEntitiesQuery.h
@@ -34,7 +34,7 @@ public:
     QueryKind getQueryKind() const override { return QueryKind::Show; }
 
 protected:
-    void formatQueryImpl(const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
+    void formatQueryImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
 
 private:
     String getKeyword() const;

--- a/src/Parsers/Access/ASTShowCreateAccessEntityQuery.cpp
+++ b/src/Parsers/Access/ASTShowCreateAccessEntityQuery.cpp
@@ -8,14 +8,14 @@ namespace DB
 {
 namespace
 {
-    void formatNames(const Strings & names, const IAST::FormatSettings & settings)
+    void formatNames(const Strings & names, WriteBuffer & ostr)
     {
         bool need_comma = false;
         for (const auto & name : names)
         {
             if (std::exchange(need_comma, true))
-                settings.ostr << ',';
-            settings.ostr << ' ' << backQuoteIfNeed(name);
+                ostr << ',';
+            ostr << ' ' << backQuoteIfNeed(name);
         }
     }
 }
@@ -47,29 +47,29 @@ ASTPtr ASTShowCreateAccessEntityQuery::clone() const
 }
 
 
-void ASTShowCreateAccessEntityQuery::formatQueryImpl(const FormatSettings & settings, FormatState &, FormatStateStacked) const
+void ASTShowCreateAccessEntityQuery::formatQueryImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState &, FormatStateStacked) const
 {
-    settings.ostr << (settings.hilite ? hilite_keyword : "") << "SHOW CREATE " << getKeyword() << (settings.hilite ? hilite_none : "");
+    ostr << (settings.hilite ? hilite_keyword : "") << "SHOW CREATE " << getKeyword() << (settings.hilite ? hilite_none : "");
 
     if (!names.empty())
-        formatNames(names, settings);
+        formatNames(names, ostr);
 
     if (row_policy_names)
     {
-        settings.ostr << " ";
-        row_policy_names->format(settings);
+        ostr << " ";
+        row_policy_names->format(ostr, settings);
     }
 
     if (!short_name.empty())
-        settings.ostr << " " << backQuoteIfNeed(short_name);
+        ostr << " " << backQuoteIfNeed(short_name);
 
     if (database_and_table_name)
     {
         const String & database = database_and_table_name->first;
         const String & table_name = database_and_table_name->second;
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << " ON " << (settings.hilite ? hilite_none : "");
-        settings.ostr << (database.empty() ? "" : backQuoteIfNeed(database) + ".");
-        settings.ostr << (table_name.empty() ? "*" : backQuoteIfNeed(table_name));
+        ostr << (settings.hilite ? hilite_keyword : "") << " ON " << (settings.hilite ? hilite_none : "");
+        ostr << (database.empty() ? "" : backQuoteIfNeed(database) + ".");
+        ostr << (table_name.empty() ? "*" : backQuoteIfNeed(table_name));
     }
 }
 

--- a/src/Parsers/Access/ASTShowCreateAccessEntityQuery.h
+++ b/src/Parsers/Access/ASTShowCreateAccessEntityQuery.h
@@ -44,7 +44,7 @@ public:
 
 protected:
     String getKeyword() const;
-    void formatQueryImpl(const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
+    void formatQueryImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
 };
 
 }

--- a/src/Parsers/Access/ASTShowGrantsQuery.cpp
+++ b/src/Parsers/Access/ASTShowGrantsQuery.cpp
@@ -23,9 +23,9 @@ ASTPtr ASTShowGrantsQuery::clone() const
 }
 
 
-void ASTShowGrantsQuery::formatQueryImpl(const FormatSettings & settings, FormatState &, FormatStateStacked) const
+void ASTShowGrantsQuery::formatQueryImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState &, FormatStateStacked) const
 {
-    settings.ostr << (settings.hilite ? hilite_keyword : "") << "SHOW GRANTS"
+    ostr << (settings.hilite ? hilite_keyword : "") << "SHOW GRANTS"
                   << (settings.hilite ? hilite_none : "");
 
     if (for_roles->current_user && !for_roles->all && for_roles->names.empty() && for_roles->except_names.empty()
@@ -34,20 +34,20 @@ void ASTShowGrantsQuery::formatQueryImpl(const FormatSettings & settings, Format
     }
     else
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << " FOR "
+        ostr << (settings.hilite ? hilite_keyword : "") << " FOR "
                       << (settings.hilite ? hilite_none : "");
-        for_roles->format(settings);
+        for_roles->format(ostr, settings);
     }
 
     if (with_implicit)
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << " WITH IMPLICIT"
+        ostr << (settings.hilite ? hilite_keyword : "") << " WITH IMPLICIT"
                       << (settings.hilite ? hilite_none : "");
     }
 
     if (final)
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << " FINAL"
+        ostr << (settings.hilite ? hilite_keyword : "") << " FINAL"
                       << (settings.hilite ? hilite_none : "");
     }
 }

--- a/src/Parsers/Access/ASTShowGrantsQuery.h
+++ b/src/Parsers/Access/ASTShowGrantsQuery.h
@@ -18,7 +18,7 @@ public:
 
     String getID(char) const override;
     ASTPtr clone() const override;
-    void formatQueryImpl(const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
+    void formatQueryImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
 
     QueryKind getQueryKind() const override { return QueryKind::Show; }
 };

--- a/src/Parsers/Access/ASTUserNameWithHost.cpp
+++ b/src/Parsers/Access/ASTUserNameWithHost.cpp
@@ -6,12 +6,12 @@
 namespace DB
 {
 
-void ASTUserNameWithHost::formatImpl(const FormatSettings & settings, FormatState &, FormatStateStacked) const
+void ASTUserNameWithHost::formatImpl(WriteBuffer & ostr, const FormatSettings &, FormatState &, FormatStateStacked) const
 {
-    settings.ostr << backQuoteIfNeed(base_name);
+    ostr << backQuoteIfNeed(base_name);
 
     if (!host_pattern.empty())
-        settings.ostr << "@" << backQuoteIfNeed(host_pattern);
+        ostr << "@" << backQuoteIfNeed(host_pattern);
 }
 
 String ASTUserNameWithHost::toString() const
@@ -35,15 +35,15 @@ void ASTUserNameWithHost::replace(const String name_)
 }
 
 
-void ASTUserNamesWithHost::formatImpl(const FormatSettings & settings, FormatState &, FormatStateStacked) const
+void ASTUserNamesWithHost::formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState &, FormatStateStacked) const
 {
     assert(!names.empty());
     bool need_comma = false;
     for (const auto & name : names)
     {
         if (std::exchange(need_comma, true))
-            settings.ostr << ", ";
-        name->format(settings);
+            ostr << ", ";
+        name->format(ostr, settings);
     }
 }
 

--- a/src/Parsers/Access/ASTUserNameWithHost.h
+++ b/src/Parsers/Access/ASTUserNameWithHost.h
@@ -26,7 +26,7 @@ public:
     explicit ASTUserNameWithHost(const String & name_) : base_name(name_) {}
     String getID(char) const override { return "UserNameWithHost"; }
     ASTPtr clone() const override { return std::make_shared<ASTUserNameWithHost>(*this); }
-    void formatImpl(const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
+    void formatImpl(WriteBuffer & ostr, const FormatSettings &, FormatState &, FormatStateStacked) const override;
     void replace(String name_);
 };
 
@@ -48,7 +48,7 @@ public:
 
     String getID(char) const override { return "UserNamesWithHost"; }
     ASTPtr clone() const override { return std::make_shared<ASTUserNamesWithHost>(*this); }
-    void formatImpl(const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
 };
 
 }

--- a/src/Parsers/IAST.cpp
+++ b/src/Parsers/IAST.cpp
@@ -179,12 +179,12 @@ String IAST::formatWithPossiblyHidingSensitiveData(
     IdentifierQuotingStyle identifier_quoting_style) const
 {
     WriteBufferFromOwnString buf;
-    FormatSettings settings(buf, one_line);
+    FormatSettings settings(one_line);
     settings.show_secrets = show_secrets;
     settings.print_pretty_type_names = print_pretty_type_names;
     settings.identifier_quoting_rule = identifier_quoting_rule;
     settings.identifier_quoting_style = identifier_quoting_style;
-    format(settings);
+    format(buf, settings);
     return wipeSensitiveDataAndCutToLength(buf.str(), max_length);
 }
 
@@ -221,7 +221,7 @@ String IAST::getColumnNameWithoutAlias() const
 }
 
 
-void IAST::FormatSettings::writeIdentifier(const String & name, bool ambiguous) const
+void IAST::FormatSettings::writeIdentifier(WriteBuffer & ostr, const String & name, bool ambiguous) const
 {
     checkIdentifier(name);
     bool must_quote

--- a/src/Parsers/IAST.h
+++ b/src/Parsers/IAST.h
@@ -193,7 +193,6 @@ public:
     /// Format settings.
     struct FormatSettings
     {
-        WriteBuffer & ostr;
         bool one_line;
         bool hilite;
         IdentifierQuotingRule identifier_quoting_rule;
@@ -205,7 +204,6 @@ public:
         bool enforce_strict_identifier_format;
 
         explicit FormatSettings(
-            WriteBuffer & ostr_,
             bool one_line_,
             bool hilite_ = false,
             IdentifierQuotingRule identifier_quoting_rule_ = IdentifierQuotingRule::WhenNecessary,
@@ -214,8 +212,7 @@ public:
             LiteralEscapingStyle literal_escaping_style_ = LiteralEscapingStyle::Regular,
             bool print_pretty_type_names_ = false,
             bool enforce_strict_identifier_format_ = false)
-            : ostr(ostr_)
-            , one_line(one_line_)
+            : one_line(one_line_)
             , hilite(hilite_)
             , identifier_quoting_rule(identifier_quoting_rule_)
             , identifier_quoting_style(identifier_quoting_style_)
@@ -227,9 +224,8 @@ public:
         {
         }
 
-        FormatSettings(WriteBuffer & ostr_, const FormatSettings & other)
-            : ostr(ostr_)
-            , one_line(other.one_line)
+        FormatSettings(const FormatSettings & other)
+            : one_line(other.one_line)
             , hilite(other.hilite)
             , identifier_quoting_rule(other.identifier_quoting_rule)
             , identifier_quoting_style(other.identifier_quoting_style)
@@ -241,7 +237,7 @@ public:
         {
         }
 
-        void writeIdentifier(const String & name, bool ambiguous) const;
+        void writeIdentifier(WriteBuffer & ostr, const String & name, bool ambiguous) const;
         void checkIdentifier(const String & name) const;
     };
 
@@ -270,13 +266,13 @@ public:
         const IAST * current_select = nullptr;
     };
 
-    void format(const FormatSettings & settings) const
+    void format(WriteBuffer & ostr, const FormatSettings & settings) const
     {
         FormatState state;
-        formatImpl(settings, state, FormatStateStacked());
+        formatImpl(ostr, settings, state, FormatStateStacked());
     }
 
-    virtual void formatImpl(const FormatSettings & /*settings*/, FormatState & /*state*/, FormatStateStacked /*frame*/) const
+    virtual void formatImpl(WriteBuffer & /*ostr*/, const FormatSettings & /*settings*/, FormatState & /*state*/, FormatStateStacked /*frame*/) const
     {
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Unknown element in AST: {}", getID());
     }

--- a/src/Parsers/IAST.h
+++ b/src/Parsers/IAST.h
@@ -224,19 +224,6 @@ public:
         {
         }
 
-        FormatSettings(const FormatSettings & other)
-            : one_line(other.one_line)
-            , hilite(other.hilite)
-            , identifier_quoting_rule(other.identifier_quoting_rule)
-            , identifier_quoting_style(other.identifier_quoting_style)
-            , show_secrets(other.show_secrets)
-            , nl_or_ws(other.nl_or_ws)
-            , literal_escaping_style(other.literal_escaping_style)
-            , print_pretty_type_names(other.print_pretty_type_names)
-            , enforce_strict_identifier_format(other.enforce_strict_identifier_format)
-        {
-        }
-
         void writeIdentifier(WriteBuffer & ostr, const String & name, bool ambiguous) const;
         void checkIdentifier(const String & name) const;
     };

--- a/src/Parsers/MySQL/ASTAlterCommand.h
+++ b/src/Parsers/MySQL/ASTAlterCommand.h
@@ -76,7 +76,7 @@ public:
     String getID(char delim) const override { return "AlterCommand" + (delim + std::to_string(static_cast<int>(type))); }
 
 protected:
-    void formatImpl(const FormatSettings & /*settings*/, FormatState & /*state*/, FormatStateStacked /*frame*/) const override
+    void formatImpl(WriteBuffer & /*ostr*/, const FormatSettings & /*settings*/, FormatState & /*state*/, FormatStateStacked /*frame*/) const override
     {
         throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Method formatImpl is not supported by MySQLParser::ASTAlterCommand.");
     }

--- a/src/Parsers/MySQL/ASTAlterQuery.h
+++ b/src/Parsers/MySQL/ASTAlterQuery.h
@@ -28,7 +28,7 @@ public:
     String getID(char delim) const override { return "AlterQuery" + (delim + database) + delim + table; }
 
 protected:
-    void formatImpl(const FormatSettings & /*settings*/, FormatState & /*state*/, FormatStateStacked /*frame*/) const override
+    void formatImpl(WriteBuffer & /*ostr*/, const FormatSettings & /*settings*/, FormatState & /*state*/, FormatStateStacked /*frame*/) const override
     {
         throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Method formatImpl is not supported by MySQLParser::ASTAlterQuery.");
     }

--- a/src/Parsers/MySQL/ASTCreateDefines.h
+++ b/src/Parsers/MySQL/ASTCreateDefines.h
@@ -27,7 +27,7 @@ public:
     String getID(char) const override { return "Create definitions"; }
 
 protected:
-    void formatImpl(const FormatSettings & /*settings*/, FormatState & /*state*/, FormatStateStacked /*frame*/) const override
+    void formatImpl(WriteBuffer & /*ostr*/, const FormatSettings & /*settings*/, FormatState & /*state*/, FormatStateStacked /*frame*/) const override
     {
         throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Method formatImpl is not supported by MySQLParser::ASTCreateDefines.");
     }

--- a/src/Parsers/MySQL/ASTCreateQuery.h
+++ b/src/Parsers/MySQL/ASTCreateQuery.h
@@ -32,7 +32,7 @@ public:
     String getID(char) const override { return "create query"; }
 
 protected:
-    void formatImpl(const FormatSettings & /*settings*/, FormatState & /*state*/, FormatStateStacked /*frame*/) const override
+    void formatImpl(WriteBuffer & /*ostr*/, const FormatSettings & /*settings*/, FormatState & /*state*/, FormatStateStacked /*frame*/) const override
     {
         throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Method formatImpl is not supported by MySQLParser::ASTCreateQuery.");
     }

--- a/src/Parsers/MySQL/ASTDeclareColumn.h
+++ b/src/Parsers/MySQL/ASTDeclareColumn.h
@@ -26,7 +26,7 @@ public:
     String getID(char /*delimiter*/) const override { return "Column definition"; }
 
 protected:
-    void formatImpl(const FormatSettings & /*settings*/, FormatState & /*state*/, FormatStateStacked /*frame*/) const override
+    void formatImpl(WriteBuffer & /*ostr*/, const FormatSettings & /*settings*/, FormatState & /*state*/, FormatStateStacked /*frame*/) const override
     {
         throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Method formatImpl is not supported by MySQLParser::ASTDeclareColumn.");
     }

--- a/src/Parsers/MySQL/ASTDeclareConstraint.h
+++ b/src/Parsers/MySQL/ASTDeclareConstraint.h
@@ -26,7 +26,7 @@ public:
     String getID(char /*delimiter*/) const override { return "constraint declaration"; }
 
 protected:
-    void formatImpl(const FormatSettings & /*settings*/, FormatState & /*state*/, FormatStateStacked /*frame*/) const override
+    void formatImpl(WriteBuffer & /*ostr*/, const FormatSettings & /*settings*/, FormatState & /*state*/, FormatStateStacked /*frame*/) const override
     {
         throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Method formatImpl is not supported by MySQLParser::ASTDeclareConstraint.");
     }

--- a/src/Parsers/MySQL/ASTDeclareIndex.h
+++ b/src/Parsers/MySQL/ASTDeclareIndex.h
@@ -30,7 +30,7 @@ public:
     String getID(char /*delimiter*/) const override { return "index declaration"; }
 
 protected:
-    void formatImpl(const FormatSettings & /*settings*/, FormatState & /*state*/, FormatStateStacked /*frame*/) const override
+    void formatImpl(WriteBuffer & /*ostr*/, const FormatSettings & /*settings*/, FormatState & /*state*/, FormatStateStacked /*frame*/) const override
     {
         throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Method formatImpl is not supported by MySQLParser::ASTDeclareIndex.");
     }

--- a/src/Parsers/MySQL/ASTDeclareOption.h
+++ b/src/Parsers/MySQL/ASTDeclareOption.h
@@ -38,7 +38,7 @@ public:
     String getID(char /*delimiter*/) const override { return "options declaration"; }
 
 protected:
-    void formatImpl(const FormatSettings & /*settings*/, FormatState & /*state*/, FormatStateStacked /*frame*/) const override
+    void formatImpl(WriteBuffer & /*ostr*/, const FormatSettings & /*settings*/, FormatState & /*state*/, FormatStateStacked /*frame*/) const override
     {
         throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Method formatImpl is not supported by MySQLParser::ASTDeclareOptions.");
     }

--- a/src/Parsers/MySQL/ASTDeclarePartition.h
+++ b/src/Parsers/MySQL/ASTDeclarePartition.h
@@ -28,7 +28,7 @@ public:
     String getID(char /*delimiter*/) const override { return "partition declaration"; }
 
 protected:
-    void formatImpl(const FormatSettings & /*settings*/, FormatState & /*state*/, FormatStateStacked /*frame*/) const override
+    void formatImpl(WriteBuffer & /*ostr*/, const FormatSettings & /*settings*/, FormatState & /*state*/, FormatStateStacked /*frame*/) const override
     {
         throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Method formatImpl is not supported by MySQLParser::ASTDeclarePartition.");
     }

--- a/src/Parsers/MySQL/ASTDeclarePartitionOptions.h
+++ b/src/Parsers/MySQL/ASTDeclarePartitionOptions.h
@@ -30,7 +30,7 @@ public:
     String getID(char /*delimiter*/) const override { return "partition options declaration"; }
 
 protected:
-    void formatImpl(const FormatSettings & /*settings*/, FormatState & /*state*/, FormatStateStacked /*frame*/) const override
+    void formatImpl(WriteBuffer & /*ostr*/, const FormatSettings & /*settings*/, FormatState & /*state*/, FormatStateStacked /*frame*/) const override
     {
         throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Method formatImpl is not supported by MySQLParser::ASTDeclarePartitionOptions.");
     }

--- a/src/Parsers/MySQL/ASTDeclareReference.h
+++ b/src/Parsers/MySQL/ASTDeclareReference.h
@@ -44,7 +44,7 @@ public:
     String getID(char /*delimiter*/) const override { return "subpartition declaration"; }
 
 protected:
-    void formatImpl(const FormatSettings & /*settings*/, FormatState & /*state*/, FormatStateStacked /*frame*/) const override
+    void formatImpl(WriteBuffer & /*ostr*/, const FormatSettings & /*settings*/, FormatState & /*state*/, FormatStateStacked /*frame*/) const override
     {
         throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Method formatImpl is not supported by MySQLParser::ASTDeclareReference.");
     }

--- a/src/Parsers/MySQL/ASTDeclareSubPartition.h
+++ b/src/Parsers/MySQL/ASTDeclareSubPartition.h
@@ -25,7 +25,7 @@ public:
     String getID(char /*delimiter*/) const override { return "subpartition declaration"; }
 
 protected:
-    void formatImpl(const FormatSettings & /*settings*/, FormatState & /*state*/, FormatStateStacked /*frame*/) const override
+    void formatImpl(WriteBuffer & /*ostr*/, const FormatSettings & /*settings*/, FormatState & /*state*/, FormatStateStacked /*frame*/) const override
     {
         throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Method formatImpl is not supported by MySQLParser::ASTDeclareSubPartition.");
     }

--- a/src/Parsers/MySQL/ASTDropQuery.h
+++ b/src/Parsers/MySQL/ASTDropQuery.h
@@ -45,7 +45,7 @@ public:
     String getID(char /*delim*/) const override {return "ASTDropQuery" ;}
 
 protected:
-    void formatImpl(const FormatSettings & /*settings*/, FormatState & /*state*/, FormatStateStacked /*frame*/) const override
+    void formatImpl(WriteBuffer & /*ostr*/, const FormatSettings & /*settings*/, FormatState & /*state*/, FormatStateStacked /*frame*/) const override
     {
         throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Method formatImpl is not supported by MySQLParser::ASTDropQuery.");
     }

--- a/src/Parsers/TablePropertiesQueriesASTs.h
+++ b/src/Parsers/TablePropertiesQueriesASTs.h
@@ -95,11 +95,11 @@ public:
     }
 
 protected:
-    void formatQueryImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override
+    void formatQueryImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << ASTExistsDatabaseQueryIDAndQueryNames::Query
+        ostr << (settings.hilite ? hilite_keyword : "") << ASTExistsDatabaseQueryIDAndQueryNames::Query
                     << " " << (settings.hilite ? hilite_none : "");
-        database->formatImpl(settings, state, frame);
+        database->formatImpl(ostr, settings, state, frame);
     }
 
     QueryKind getQueryKind() const override { return QueryKind::Exists; }
@@ -117,11 +117,11 @@ public:
     }
 
 protected:
-    void formatQueryImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override
+    void formatQueryImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << ASTShowCreateDatabaseQueryIDAndQueryNames::Query
+        ostr << (settings.hilite ? hilite_keyword : "") << ASTShowCreateDatabaseQueryIDAndQueryNames::Query
                       << " " << (settings.hilite ? hilite_none : "");
-        database->formatImpl(settings, state, frame);
+        database->formatImpl(ostr, settings, state, frame);
     }
 };
 
@@ -148,11 +148,11 @@ public:
     QueryKind getQueryKind() const override { return QueryKind::Describe; }
 
 protected:
-    void formatQueryImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override
+    void formatQueryImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "")
+        ostr << (settings.hilite ? hilite_keyword : "")
                       << "DESCRIBE TABLE" << (settings.hilite ? hilite_none : "");
-        table_expression->formatImpl(settings, state, frame);
+        table_expression->formatImpl(ostr, settings, state, frame);
     }
 
 };

--- a/src/Parsers/formatAST.cpp
+++ b/src/Parsers/formatAST.cpp
@@ -6,9 +6,9 @@ namespace DB
 
 void formatAST(const IAST & ast, WriteBuffer & buf, bool hilite, bool one_line, bool show_secrets)
 {
-    IAST::FormatSettings settings(buf, one_line, hilite);
+    IAST::FormatSettings settings(one_line, hilite);
     settings.show_secrets = show_secrets;
-    ast.format(settings);
+    ast.format(buf, settings);
 }
 
 String serializeAST(const IAST & ast)

--- a/src/Parsers/getInsertQuery.cpp
+++ b/src/Parsers/getInsertQuery.cpp
@@ -20,12 +20,11 @@ std::string getInsertQuery(const std::string & db_name, const std::string & tabl
 
     WriteBufferFromOwnString buf;
     IAST::FormatSettings settings(
-        /*ostr_=*/buf,
         /*one_line=*/true,
         /*hilite=*/false,
         /*identifier_quoting_rule=*/IdentifierQuotingRule::WhenNecessary,
         /*identifier_quoting_style=*/quoting);
-    query.IAST::format(settings);
+    query.IAST::format(buf, settings);
     return buf.str();
 }
 }

--- a/src/Parsers/tests/gtest_format_hiliting.cpp
+++ b/src/Parsers/tests/gtest_format_hiliting.cpp
@@ -53,8 +53,8 @@ void compare(const String & expected, const String & query)
     ASTPtr ast = parseQuery(parser, query, 0, 0, 0);
 
     WriteBufferFromOwnString write_buffer;
-    IAST::FormatSettings settings(write_buffer, true, true);
-    ast->format(settings);
+    IAST::FormatSettings settings(true, true);
+    ast->format(write_buffer, settings);
 
     ASSERT_PRED2(HiliteComparator::are_equal_with_hilites_removed, expected, write_buffer.str());
     ASSERT_PRED2(HiliteComparator::are_equal_with_hilites_and_end_without_hilite, expected, write_buffer.str());

--- a/src/Processors/QueryPlan/ReadFromRemote.cpp
+++ b/src/Processors/QueryPlan/ReadFromRemote.cpp
@@ -102,8 +102,8 @@ static String formattedAST(const ASTPtr & ast)
 
     WriteBufferFromOwnString buf;
     IAST::FormatSettings ast_format_settings(
-        /*ostr_=*/buf, /*one_line=*/true, /*hilite=*/false, /*identifier_quoting_rule=*/IdentifierQuotingRule::Always);
-    ast->format(ast_format_settings);
+        /*one_line=*/true, /*hilite=*/false, /*identifier_quoting_rule=*/IdentifierQuotingRule::Always);
+    ast->format(buf, ast_format_settings);
     return buf.str();
 }
 

--- a/src/Storages/ColumnsDescription.cpp
+++ b/src/Storages/ColumnsDescription.cpp
@@ -122,8 +122,8 @@ bool ColumnDescription::operator==(const ColumnDescription & other) const
 String formatASTStateAware(IAST & ast, IAST::FormatState & state)
 {
     WriteBufferFromOwnString buf;
-    IAST::FormatSettings settings(buf, true, false);
-    ast.formatImpl(settings, state, IAST::FormatStateStacked());
+    IAST::FormatSettings settings(true, false);
+    ast.formatImpl(buf, settings, state, IAST::FormatStateStacked());
     return buf.str();
 }
 

--- a/src/Storages/StorageDistributed.cpp
+++ b/src/Storages/StorageDistributed.cpp
@@ -1018,8 +1018,8 @@ std::optional<QueryPipeline> StorageDistributed::distributedWriteBetweenDistribu
     {
         WriteBufferFromOwnString buf;
         IAST::FormatSettings ast_format_settings(
-            /*ostr_=*/buf, /*one_line*/ true, /*hilite*/ false, /*identifier_quoting_rule_=*/IdentifierQuotingRule::Always);
-        new_query->IAST::format(ast_format_settings);
+            /*one_line*/ true, /*hilite*/ false, /*identifier_quoting_rule_=*/IdentifierQuotingRule::Always);
+        new_query->IAST::format(buf, ast_format_settings);
         new_query_str = buf.str();
     }
 
@@ -1139,8 +1139,8 @@ std::optional<QueryPipeline> StorageDistributed::distributedWriteFromClusterStor
     {
         WriteBufferFromOwnString buf;
         IAST::FormatSettings ast_format_settings(
-            /*ostr_=*/buf, /*one_line=*/true, /*hilite=*/false, /*identifier_quoting_rule=*/IdentifierQuotingRule::Always);
-        new_query->IAST::format(ast_format_settings);
+            /*one_line=*/true, /*hilite=*/false, /*identifier_quoting_rule=*/IdentifierQuotingRule::Always);
+        new_query->IAST::format(buf, ast_format_settings);
         new_query_str = buf.str();
     }
 

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -5789,8 +5789,8 @@ std::optional<QueryPipeline> StorageReplicatedMergeTree::distributedWriteFromClu
     {
         WriteBufferFromOwnString buf;
         IAST::FormatSettings ast_format_settings(
-            /*ostr_=*/buf, /*one_line=*/true, /*hilite=*/false, /*identifier_quoting_rule=*/IdentifierQuotingRule::Always);
-        query.IAST::format(ast_format_settings);
+            /*one_line=*/true, /*hilite=*/false, /*identifier_quoting_rule=*/IdentifierQuotingRule::Always);
+        query.IAST::format(buf, ast_format_settings);
         query_str = buf.str();
     }
 

--- a/src/Storages/transformQueryForExternalDatabase.cpp
+++ b/src/Storages/transformQueryForExternalDatabase.cpp
@@ -389,7 +389,6 @@ String transformQueryForExternalDatabaseImpl(
     IdentifierQuotingRule identifier_quoting_rule = IdentifierQuotingRule::Always;
     WriteBufferFromOwnString out;
     IAST::FormatSettings settings(
-        /*ostr_=*/out,
         /*one_line=*/true,
         /*hilite=*/false,
         /*identifier_quoting_rule=*/identifier_quoting_rule,
@@ -397,7 +396,7 @@ String transformQueryForExternalDatabaseImpl(
         /*show_secrets_=*/true,
         /*literal_escaping_style=*/literal_escaping_style);
 
-    select->format(settings);
+    select->format(out, settings);
 
     return out.str();
 }


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Remove `ostr` from structure `IAST::FormatSettings`.
This is part 1 of https://github.com/ClickHouse/ClickHouse/pull/45649