### PR TITLE
Fix clickhouse-test reporting 'No tests were run' after running tests

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -2281,7 +2281,6 @@ def run_tests_array(all_tests_with_params: Tuple[List[str], int, TestSuite, bool
         test_suite,
         is_concurrent,
     ) = all_tests_with_params
-    all_tests = list(all_tests)  # don't modify the original
     global stop_time
     global exit_code
     global server_died
@@ -2697,7 +2696,7 @@ def do_run_tests(jobs, test_suite: TestSuite):
     if test_suite.sequential_tests:
         run_tests_array(
             (
-                test_suite.sequential_tests,
+                list(test_suite.sequential_tests),
                 len(test_suite.sequential_tests),
                 test_suite,
                 False,

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -2281,7 +2281,7 @@ def run_tests_array(all_tests_with_params: Tuple[List[str], int, TestSuite, bool
         test_suite,
         is_concurrent,
     ) = all_tests_with_params
-    all_tests = list(all_tests) # don't modify the original
+    all_tests = list(all_tests)  # don't modify the original
     global stop_time
     global exit_code
     global server_died

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -2281,6 +2281,7 @@ def run_tests_array(all_tests_with_params: Tuple[List[str], int, TestSuite, bool
         test_suite,
         is_concurrent,
     ) = all_tests_with_params
+    all_tests = list(all_tests) # don't modify the original
     global stop_time
     global exit_code
     global server_died


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Without this, it always says "No tests were run" and exits with code 1:
```
% PATH=build/programs:$PATH CLICKHOUSE_USER_FILES=~/cluster/n1/store/user_files tests/clickhouse-test 03263_parquet_write_bloom_filter
Using queries from '/home/ubuntu/ClickHouse/tests/queries' directory
Connecting to ClickHouse server... OK
Connected to server 24.12.1.1 @ bc267d4427799ecc8d4933307dd756951d91ea11 ssett
Found 0 parallel tests and 1 sequential tests
Running 1 stateless tests (MainProcess).
03263_parquet_write_bloom_filter:                                       [ OK ]
                                                                     
1 tests passed. 0 tests skipped. 0.23 s elapsed (MainProcess).
Found 0 parallel tests and 0 sequential tests
No tests were run.
[12-03 09:13:07]~/ClickHouse [bff] 0.531s exit: 1 %
```

That's because `run_tests_array` mutated a list that was passed as an argument, and the caller didn't expect that. Oh Python.