### PR TITLE
Fix no-such-key in s3queue in certain case

### DIFF
--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueIFileMetadata.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueIFileMetadata.cpp
@@ -62,6 +62,15 @@ void ObjectStorageQueueIFileMetadata::FileStatus::onFailed(const std::string & e
     last_exception = exception;
 }
 
+void ObjectStorageQueueIFileMetadata::FileStatus::reset()
+{
+    state = FileStatus::State::None;
+    processing_start_time = {};
+    processing_end_time = {};
+    processed_rows = 0;
+    retries = 0;
+}
+
 void ObjectStorageQueueIFileMetadata::FileStatus::updateState(State state_)
 {
     state = state_;
@@ -243,6 +252,21 @@ bool ObjectStorageQueueIFileMetadata::setProcessing()
              processing_id_version.has_value() ? toString(processing_id_version.value()) : "None");
 
     return success;
+}
+
+void ObjectStorageQueueIFileMetadata::resetProcessing()
+{
+    auto state = file_status->state.load();
+    if (state != FileStatus::State::Processing)
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Cannot reset non-processing state: {}", state);
+
+    resetProcessingImpl();
+    file_status->reset();
+}
+
+void ObjectStorageQueueIFileMetadata::resetProcessingImpl()
+{
+    throw Exception(ErrorCodes::LOGICAL_ERROR, "resetProcessingImpl is not implemented");
 }
 
 void ObjectStorageQueueIFileMetadata::setProcessed()

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueIFileMetadata.h
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueIFileMetadata.h
@@ -22,6 +22,7 @@ public:
         void setProcessingEndTime();
         void onProcessing();
         void onProcessed();
+        void reset();
         void onFailed(const std::string & exception);
         void updateState(State state_);
 
@@ -54,6 +55,7 @@ public:
 
     bool setProcessing();
     void setProcessed();
+    void resetProcessing();
     void setFailed(const std::string & exception_message, bool reduce_retry_count, bool overwrite_status);
 
     virtual void setProcessedAtStartRequests(
@@ -78,6 +80,7 @@ public:
 protected:
     virtual std::pair<bool, FileStatus::State> setProcessingImpl() = 0;
     virtual void setProcessedImpl() = 0;
+    virtual void resetProcessingImpl();
     void setFailedNonRetriable();
     void setFailedRetriable();
 

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueSource.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueSource.cpp
@@ -49,11 +49,15 @@ ObjectStorageQueueSource::ObjectStorageQueueObjectInfo::ObjectStorageQueueObject
 ObjectStorageQueueSource::FileIterator::FileIterator(
     std::shared_ptr<ObjectStorageQueueMetadata> metadata_,
     std::unique_ptr<Source::GlobIterator> glob_iterator_,
+    ObjectStoragePtr object_storage_,
+    bool file_deletion_on_processed_enabled_,
     std::atomic<bool> & shutdown_called_,
     LoggerPtr logger_)
     : StorageObjectStorageSource::IIterator("ObjectStorageQueueIterator")
     , metadata(metadata_)
+    , object_storage(object_storage_)
     , glob_iterator(std::move(glob_iterator_))
+    , file_deletion_on_processed_enabled(file_deletion_on_processed_enabled_)
     , shutdown_called(shutdown_called_)
     , log(logger_)
 {
@@ -114,7 +118,39 @@ ObjectStorageQueueSource::Source::ObjectInfoPtr ObjectStorageQueueSource::FileIt
 
         auto file_metadata = metadata->getFileMetadata(object_info->relative_path, bucket_info);
         if (file_metadata->setProcessing())
+        {
+            if (file_deletion_on_processed_enabled
+                && !object_storage->exists(StoredObject(object_info->getPath())))
+            {
+                /// Imagine the following case:
+                /// Replica A processed fileA and deletes it afterwards.
+                /// Replica B has a list request batch (by default list batch is 1000 elements)
+                /// and this batch was collected from object storage before replica A processed fileA.
+                /// fileA could be somewhere in the middle of this batch of replica B
+                /// and replica A processed it before replica B reached fileA in this batch.
+                /// All would be alright, unless user has tracked_files_size_limit or tracked_files_ttl_limit
+                /// which could expire before replica B reached fileA in this list batch.
+                /// It would mean that replica B listed this file while it no longer
+                /// exists in object storage at the moment it wants to process it, but
+                /// because of tracked_files_size(ttl)_limit expiration - we no longer
+                /// have information in keeper that the file was actually processed before,
+                /// so replica B would successfully set itself as processor of this file in keeper
+                /// and face "The specified key does not exist" after that.
+                ///
+                /// This existance check here is enough,
+                /// only because we do applyActionAfterProcessing BEFORE setting file as processed
+                /// and because at this exact place we already successfully set file as processing,
+                /// e.g. file deletion and marking file as processed in keeper already took place.
+                ///
+                /// Note: this all applies only for Unordered mode.
+                LOG_TRACE(log, "Ignoring {} because of the race with list & delete", object_info->getPath());
+
+                file_metadata->resetProcessing();
+                continue;
+            }
+
             return std::make_shared<ObjectStorageQueueObjectInfo>(*object_info, file_metadata);
+        }
     }
     return {};
 }
@@ -628,8 +664,8 @@ void ObjectStorageQueueSource::commit(bool success, const std::string & exceptio
     {
         if (success)
         {
-            file_metadata->setProcessed();
             applyActionAfterProcessing(file_metadata->getPath());
+            file_metadata->setProcessed();
         }
         else
         {

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueSource.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueSource.cpp
@@ -137,7 +137,7 @@ ObjectStorageQueueSource::Source::ObjectInfoPtr ObjectStorageQueueSource::FileIt
                 /// so replica B would successfully set itself as processor of this file in keeper
                 /// and face "The specified key does not exist" after that.
                 ///
-                /// This existance check here is enough,
+                /// This existence check here is enough,
                 /// only because we do applyActionAfterProcessing BEFORE setting file as processed
                 /// and because at this exact place we already successfully set file as processing,
                 /// e.g. file deletion and marking file as processed in keeper already took place.

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueSource.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueSource.cpp
@@ -120,7 +120,7 @@ ObjectStorageQueueSource::Source::ObjectInfoPtr ObjectStorageQueueSource::FileIt
         if (file_metadata->setProcessing())
         {
             if (file_deletion_on_processed_enabled
-                && !object_storage->exists(StoredObject(object_info->getPath())))
+                && !object_storage->exists(StoredObject(object_info->relative_path)))
             {
                 /// Imagine the following case:
                 /// Replica A processed fileA and deletes it afterwards.

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueSource.h
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueSource.h
@@ -40,6 +40,8 @@ public:
         FileIterator(
             std::shared_ptr<ObjectStorageQueueMetadata> metadata_,
             std::unique_ptr<Source::GlobIterator> glob_iterator_,
+            ObjectStoragePtr object_storage_,
+            bool file_deletion_on_processed_enabled_,
             std::atomic<bool> & shutdown_called_,
             LoggerPtr logger_);
 
@@ -67,7 +69,9 @@ public:
         using Processor = ObjectStorageQueueMetadata::Processor;
 
         const std::shared_ptr<ObjectStorageQueueMetadata> metadata;
+        const ObjectStoragePtr object_storage;
         const std::unique_ptr<Source::GlobIterator> glob_iterator;
+        const bool file_deletion_on_processed_enabled;
 
         std::atomic<bool> & shutdown_called;
         std::mutex mutex;

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueUnorderedFileMetadata.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueUnorderedFileMetadata.cpp
@@ -100,6 +100,16 @@ void ObjectStorageQueueUnorderedFileMetadata::setProcessedAtStartRequests(
 
 void ObjectStorageQueueUnorderedFileMetadata::setProcessedImpl()
 {
+    setProcessedImpl(false);
+}
+
+void ObjectStorageQueueUnorderedFileMetadata::resetProcessingImpl()
+{
+    setProcessedImpl(true);
+}
+
+void ObjectStorageQueueUnorderedFileMetadata::setProcessedImpl(bool remove_processing_nodes_only)
+{
     /// In one zookeeper transaction do the following:
     enum RequestType
     {
@@ -124,16 +134,19 @@ void ObjectStorageQueueUnorderedFileMetadata::setProcessedImpl()
         request_index[CHECK_PROCESSING_ID_PATH] = 0;
         request_index[REMOVE_PROCESSING_ID_PATH] = 1;
         request_index[REMOVE_PROCESSING_PATH] = 2;
-        request_index[SET_PROCESSED_PATH] = 3;
+
+        if (!remove_processing_nodes_only)
+            request_index[SET_PROCESSED_PATH] = 3;
     }
-    else
+    else if (!remove_processing_nodes_only)
     {
         request_index[SET_PROCESSED_PATH] = 0;
     }
 
-    requests.push_back(
-        zkutil::makeCreateRequest(
-            processed_node_path, node_metadata.toString(), zkutil::CreateMode::Persistent));
+    if (!remove_processing_nodes_only)
+        requests.push_back(
+            zkutil::makeCreateRequest(
+                processed_node_path, node_metadata.toString(), zkutil::CreateMode::Persistent));
 
     Coordination::Responses responses;
     auto is_request_failed = [&](RequestType type)
@@ -147,6 +160,9 @@ void ObjectStorageQueueUnorderedFileMetadata::setProcessedImpl()
     const auto code = zk_client->tryMulti(requests, responses);
     if (code == Coordination::Error::ZOK)
     {
+        if (remove_processing_nodes_only)
+            return;
+
         if (max_loading_retries
             && zk_client->tryRemove(failed_node_path + ".retriable", -1) == Coordination::Error::ZOK)
         {
@@ -181,7 +197,7 @@ void ObjectStorageQueueUnorderedFileMetadata::setProcessedImpl()
         /// This is normal in case of expired session with keeper as this node is ephemeral.
         failure_reason = "Failed to remove processing path";
     }
-    else if (is_request_failed(SET_PROCESSED_PATH))
+    else if (!remove_processing_nodes_only && is_request_failed(SET_PROCESSED_PATH))
     {
         unexpected_error = true;
         failure_reason = "Cannot create a persistent node in /processed since it already exists";
@@ -192,7 +208,8 @@ void ObjectStorageQueueUnorderedFileMetadata::setProcessedImpl()
     if (unexpected_error)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "{}", failure_reason);
 
-    LOG_WARNING(log, "Cannot set file {} as processed: {}. Reason: {}", path, code, failure_reason);
+    if (!remove_processing_nodes_only)
+        LOG_WARNING(log, "Cannot set file {} as processed: {}. Reason: {}", path, code, failure_reason);
 }
 
 }

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueUnorderedFileMetadata.h
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueUnorderedFileMetadata.h
@@ -27,6 +27,9 @@ public:
 private:
     std::pair<bool, FileStatus::State> setProcessingImpl() override;
     void setProcessedImpl() override;
+    void resetProcessingImpl() override;
+
+    void setProcessedImpl(bool remove_processing_nodes_only);
 };
 
 }

--- a/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp
+++ b/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp
@@ -731,13 +731,21 @@ zkutil::ZooKeeperPtr StorageObjectStorageQueue::getZooKeeper() const
     return getContext()->getZooKeeper();
 }
 
-std::shared_ptr<StorageObjectStorageQueue::FileIterator> StorageObjectStorageQueue::createFileIterator(ContextPtr local_context, const ActionsDAG::Node * predicate)
+std::shared_ptr<StorageObjectStorageQueue::FileIterator>
+StorageObjectStorageQueue::createFileIterator(ContextPtr local_context, const ActionsDAG::Node * predicate)
 {
     auto settings = configuration->getQuerySettings(local_context);
     auto glob_iterator = std::make_unique<StorageObjectStorageSource::GlobIterator>(
-        object_storage, configuration, predicate, getVirtualsList(), local_context, nullptr, settings.list_object_keys_size, settings.throw_on_zero_files_match);
+        object_storage, configuration, predicate, getVirtualsList(), local_context,
+        nullptr, settings.list_object_keys_size, settings.throw_on_zero_files_match);
 
-    return std::make_shared<FileIterator>(files_metadata, std::move(glob_iterator), shutdown_called, log);
+    const auto & table_metadata = getTableMetadata();
+    bool file_deletion_enabled = table_metadata.getMode() == ObjectStorageQueueMode::UNORDERED
+        && table_metadata.tracked_files_ttl_sec
+        && table_metadata.tracked_files_limit;
+
+    return std::make_shared<FileIterator>(
+        files_metadata, std::move(glob_iterator), object_storage, file_deletion_enabled, shutdown_called, log);
 }
 
 ObjectStorageQueueSettings StorageObjectStorageQueue::getSettings() const

--- a/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp
+++ b/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp
@@ -741,8 +741,7 @@ StorageObjectStorageQueue::createFileIterator(ContextPtr local_context, const Ac
 
     const auto & table_metadata = getTableMetadata();
     bool file_deletion_enabled = table_metadata.getMode() == ObjectStorageQueueMode::UNORDERED
-        && table_metadata.tracked_files_ttl_sec
-        && table_metadata.tracked_files_limit;
+        && (table_metadata.tracked_files_ttl_sec || table_metadata.tracked_files_limit);
 
     return std::make_shared<FileIterator>(
         files_metadata, std::move(glob_iterator), object_storage, file_deletion_enabled, shutdown_called, log);

--- a/tests/integration/test_storage_s3_queue/test.py
+++ b/tests/integration/test_storage_s3_queue/test.py
@@ -2318,6 +2318,9 @@ def test_alter_settings(started_cluster):
 
 
 def test_list_and_delete_race(started_cluster):
+    if node.is_built_with_sanitizer():
+        # Issue does not reproduce under sanitizer
+        return
     node = started_cluster.instances["instance"]
     node_2 = started_cluster.instances["instance2"]
     table_name = f"list_and_delete_race_{generate_random_string()}"

--- a/tests/integration/test_storage_s3_queue/test.py
+++ b/tests/integration/test_storage_s3_queue/test.py
@@ -2347,7 +2347,7 @@ def test_list_and_delete_race(started_cluster):
             },
         )
 
-    threads = 4
+    threads = 6
     total_rows = row_num * files_to_generate * (threads + 1)
 
     busy_pool = Pool(threads)

--- a/tests/integration/test_storage_s3_queue/test.py
+++ b/tests/integration/test_storage_s3_queue/test.py
@@ -5,6 +5,7 @@ import random
 import string
 import time
 import uuid
+from multiprocessing.dummy import Pool
 
 import pytest
 
@@ -205,6 +206,11 @@ def run_query(instance, query, stdin=None, settings=None):
     return result
 
 
+def random_str(length=6):
+    alphabet = string.ascii_lowercase + string.digits
+    return "".join(random.SystemRandom().choice(alphabet) for _ in range(length))
+
+
 def generate_random_files(
     started_cluster,
     files_path,
@@ -214,10 +220,18 @@ def generate_random_files(
     row_num=10,
     start_ind=0,
     bucket=None,
+    use_random_names=False,
 ):
-    files = [
-        (f"{files_path}/test_{i}.csv", i) for i in range(start_ind, start_ind + count)
-    ]
+    if use_random_names:
+        files = [
+            (f"{files_path}/{random_str(10)}.csv", i)
+            for i in range(start_ind, start_ind + count)
+        ]
+    else:
+        files = [
+            (f"{files_path}/test_{i}.csv", i)
+            for i in range(start_ind, start_ind + count)
+        ]
     files.sort(key=lambda x: x[0])
 
     print(f"Generating files: {files}")
@@ -2301,3 +2315,88 @@ def test_alter_settings(started_cluster):
 
         check_int_settings(node, int_settings)
         check_string_settings(node, string_settings)
+
+
+def test_list_and_delete_race(started_cluster):
+    node = started_cluster.instances["instance"]
+    node_2 = started_cluster.instances["instance2"]
+    table_name = f"list_and_delete_race_{generate_random_string()}"
+    dst_table_name = f"{table_name}_dst"
+    keeper_path = f"/clickhouse/test_{table_name}"
+    files_path = f"{table_name}_data"
+    files_to_generate = 1000
+    row_num = 10
+
+    for instance in [node, node_2]:
+        create_table(
+            started_cluster,
+            instance,
+            table_name,
+            "unordered",
+            files_path,
+            additional_settings={
+                "keeper_path": keeper_path,
+                "tracked_files_limit": 1,
+                "polling_max_timeout_ms": 0,
+                "processing_threads_num": 1,
+                "polling_min_timeout_ms": 200,
+                "cleanup_interval_min_ms": 0,
+                "cleanup_interval_max_ms": 0,
+                "polling_backoff_ms": 100,
+                "after_processing": "delete",
+            },
+        )
+
+    threads = 10
+    total_rows = row_num * files_to_generate * (threads + 1)
+
+    busy_pool = Pool(10)
+
+    def generate(_):
+        generate_random_files(
+            started_cluster,
+            files_path,
+            files_to_generate,
+            row_num=row_num,
+            use_random_names=True,
+        )
+
+    generate(0)
+
+    p = busy_pool.map_async(generate, range(10))
+
+    create_mv(node, table_name, dst_table_name)
+    time.sleep(2)
+    create_mv(node_2, table_name, dst_table_name)
+
+    p.wait()
+
+    def get_count(node, table_name):
+        return int(run_query(node, f"SELECT count() FROM {table_name}"))
+
+    for _ in range(150):
+        if (
+            get_count(node, dst_table_name) + get_count(node_2, dst_table_name)
+        ) == total_rows:
+            break
+        time.sleep(1)
+
+    assert (
+        get_count(node, dst_table_name) + get_count(node_2, dst_table_name)
+        == total_rows
+    )
+
+    get_query = f"SELECT column1, column2, column3 FROM {dst_table_name}"
+    res1 = [list(map(int, l.split())) for l in run_query(node, get_query).splitlines()]
+    res2 = [
+        list(map(int, l.split())) for l in run_query(node_2, get_query).splitlines()
+    ]
+
+    logging.debug(
+        f"res1 size: {len(res1)}, res2 size: {len(res2)}, total_rows: {total_rows}"
+    )
+
+    assert len(res1) + len(res2) == total_rows
+    assert node.contains_in_log(
+        "because of the race with list & delete"
+    ) or node_2.contains_in_log("because of the race with list & delete")

--- a/tests/integration/test_storage_s3_queue/test.py
+++ b/tests/integration/test_storage_s3_queue/test.py
@@ -2318,10 +2318,10 @@ def test_alter_settings(started_cluster):
 
 
 def test_list_and_delete_race(started_cluster):
+    node = started_cluster.instances["instance"]
     if node.is_built_with_sanitizer():
         # Issue does not reproduce under sanitizer
         return
-    node = started_cluster.instances["instance"]
     node_2 = started_cluster.instances["instance2"]
     table_name = f"list_and_delete_race_{generate_random_string()}"
     dst_table_name = f"{table_name}_dst"

--- a/tests/integration/test_storage_s3_queue/test.py
+++ b/tests/integration/test_storage_s3_queue/test.py
@@ -2347,10 +2347,10 @@ def test_list_and_delete_race(started_cluster):
             },
         )
 
-    threads = 10
+    threads = 4
     total_rows = row_num * files_to_generate * (threads + 1)
 
-    busy_pool = Pool(10)
+    busy_pool = Pool(threads)
 
     def generate(_):
         generate_random_files(
@@ -2363,7 +2363,7 @@ def test_list_and_delete_race(started_cluster):
 
     generate(0)
 
-    p = busy_pool.map_async(generate, range(10))
+    p = busy_pool.map_async(generate, range(threads))
 
     create_mv(node, table_name, dst_table_name)
     time.sleep(2)


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix "No such key" error in S3Queue Unordered mode with `tracked_files_limit` setting smaller than s3 files appearance rate.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [x] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---ci_include_fuzzer--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [ ] <!---do_not_test--> Do not test
- [x] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
