### PR TITLE
Replace weak reference count to select query context with strong one in StorageObjectStorageSource

### DIFF
--- a/src/Storages/ObjectStorage/StorageObjectStorageSource.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorageSource.cpp
@@ -74,10 +74,10 @@ StorageObjectStorageSource::StorageObjectStorageSource(
     , max_parsing_threads(max_parsing_threads_)
     , read_from_format_info(info)
     , create_reader_pool(std::make_shared<ThreadPool>(
-          CurrentMetrics::StorageObjectStorageThreads,
-          CurrentMetrics::StorageObjectStorageThreadsActive,
-          CurrentMetrics::StorageObjectStorageThreadsScheduled,
-          1 /* max_threads */))
+        CurrentMetrics::StorageObjectStorageThreads,
+        CurrentMetrics::StorageObjectStorageThreadsActive,
+        CurrentMetrics::StorageObjectStorageThreadsScheduled,
+        1 /* max_threads */))
     , file_iterator(file_iterator_)
     , schema_cache(StorageObjectStorage::getSchemaCache(context_, configuration->getTypeName()))
     , create_reader_scheduler(threadPoolCallbackRunnerUnsafe<ReaderHolder>(*create_reader_pool, "Reader"))
@@ -875,11 +875,11 @@ StorageObjectStorageSource::ArchiveIterator::createArchiveReader(ObjectInfoPtr o
     const auto size = object_info->metadata->size_bytes;
     return DB::createArchiveReader(
         /* path_to_archive */object_info->getPath(),
-         /* archive_read_function */[=, this]()
-         {
-             return StorageObjectStorageSource::createReadBuffer(*object_info, object_storage, getContext(), logger);
-         },
-         /* archive_size */size);
+        /* archive_read_function */[=, this]()
+        {
+            return StorageObjectStorageSource::createReadBuffer(*object_info, object_storage, getContext(), logger);
+        },
+        /* archive_size */size);
 }
 
 StorageObjectStorageSource::ObjectInfoPtr

--- a/src/Storages/ObjectStorage/StorageObjectStorageSource.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorageSource.cpp
@@ -64,20 +64,20 @@ StorageObjectStorageSource::StorageObjectStorageSource(
     size_t max_parsing_threads_,
     bool need_only_count_)
     : SourceWithKeyCondition(info.source_header, false)
-    , WithContext(context_)
     , name(std::move(name_))
     , object_storage(object_storage_)
     , configuration(configuration_)
+    , read_context(context_)
     , format_settings(format_settings_)
     , max_block_size(max_block_size_)
     , need_only_count(need_only_count_)
     , max_parsing_threads(max_parsing_threads_)
     , read_from_format_info(info)
     , create_reader_pool(std::make_shared<ThreadPool>(
-        CurrentMetrics::StorageObjectStorageThreads,
-        CurrentMetrics::StorageObjectStorageThreadsActive,
-        CurrentMetrics::StorageObjectStorageThreadsScheduled,
-        1/* max_threads */))
+          CurrentMetrics::StorageObjectStorageThreads,
+          CurrentMetrics::StorageObjectStorageThreadsActive,
+          CurrentMetrics::StorageObjectStorageThreadsScheduled,
+          1 /* max_threads */))
     , file_iterator(file_iterator_)
     , schema_cache(StorageObjectStorage::getSchemaCache(context_, configuration->getTypeName()))
     , create_reader_scheduler(threadPoolCallbackRunnerUnsafe<ReaderHolder>(*create_reader_pool, "Reader"))

--- a/src/Storages/ObjectStorage/StorageObjectStorageSource.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorageSource.cpp
@@ -77,7 +77,7 @@ StorageObjectStorageSource::StorageObjectStorageSource(
           CurrentMetrics::StorageObjectStorageThreads,
           CurrentMetrics::StorageObjectStorageThreadsActive,
           CurrentMetrics::StorageObjectStorageThreadsScheduled,
-          1 /* max_threads */))
+          1/* max_threads */))
     , file_iterator(file_iterator_)
     , schema_cache(StorageObjectStorage::getSchemaCache(context_, configuration->getTypeName()))
     , create_reader_scheduler(threadPoolCallbackRunnerUnsafe<ReaderHolder>(*create_reader_pool, "Reader"))
@@ -607,7 +607,7 @@ StorageObjectStorageSource::GlobIterator::GlobIterator(
         recursive = key_with_globs == "/**";
         if (auto filter_dag = VirtualColumnUtils::createPathAndFileFilterDAG(predicate, virtual_columns, local_context))
         {
-            VirtualColumnUtils::buildSetsForDAG(*filter_dag, read_context);
+            VirtualColumnUtils::buildSetsForDAG(*filter_dag, getContext());
             filter_expr = std::make_shared<ExpressionActions>(std::move(*filter_dag));
         }
     }
@@ -877,7 +877,7 @@ StorageObjectStorageSource::ArchiveIterator::createArchiveReader(ObjectInfoPtr o
         /* path_to_archive */
         object_info->getPath(),
         /* archive_read_function */ [=, this]()
-        { return StorageObjectStorageSource::createReadBuffer(*object_info, object_storage, read_context, logger); },
+        { return StorageObjectStorageSource::createReadBuffer(*object_info, object_storage, getContext(), logger); },
         /* archive_size */ size);
 }
 

--- a/src/Storages/ObjectStorage/StorageObjectStorageSource.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorageSource.cpp
@@ -77,7 +77,7 @@ StorageObjectStorageSource::StorageObjectStorageSource(
           CurrentMetrics::StorageObjectStorageThreads,
           CurrentMetrics::StorageObjectStorageThreadsActive,
           CurrentMetrics::StorageObjectStorageThreadsScheduled,
-          1/* max_threads */))
+          1 /* max_threads */))
     , file_iterator(file_iterator_)
     , schema_cache(StorageObjectStorage::getSchemaCache(context_, configuration->getTypeName()))
     , create_reader_scheduler(threadPoolCallbackRunnerUnsafe<ReaderHolder>(*create_reader_pool, "Reader"))
@@ -874,11 +874,12 @@ StorageObjectStorageSource::ArchiveIterator::createArchiveReader(ObjectInfoPtr o
 {
     const auto size = object_info->metadata->size_bytes;
     return DB::createArchiveReader(
-        /* path_to_archive */
-        object_info->getPath(),
-        /* archive_read_function */ [=, this]()
-        { return StorageObjectStorageSource::createReadBuffer(*object_info, object_storage, getContext(), logger); },
-        /* archive_size */ size);
+        /* path_to_archive */object_info->getPath(),
+         /* archive_read_function */[=, this]()
+         {
+             return StorageObjectStorageSource::createReadBuffer(*object_info, object_storage, getContext(), logger);
+         },
+         /* archive_size */size);
 }
 
 StorageObjectStorageSource::ObjectInfoPtr

--- a/src/Storages/ObjectStorage/StorageObjectStorageSource.h
+++ b/src/Storages/ObjectStorage/StorageObjectStorageSource.h
@@ -75,6 +75,7 @@ protected:
     const String name;
     ObjectStoragePtr object_storage;
     const ConfigurationPtr configuration;
+    const ContextPtr read_context;
     const std::optional<FormatSettings> format_settings;
     const UInt64 max_block_size;
     const bool need_only_count;
@@ -245,7 +246,6 @@ private:
 
     const ObjectStoragePtr object_storage;
     const ConfigurationPtr configuration;
-    const ContextPtr read_context;
     const NamesAndTypesList virtual_columns;
     const std::function<void(FileProgress)> file_progress_callback;
     const std::vector<String> keys;

--- a/src/Storages/ObjectStorage/StorageObjectStorageSource.h
+++ b/src/Storages/ObjectStorage/StorageObjectStorageSource.h
@@ -14,7 +14,7 @@ namespace DB
 
 class SchemaCache;
 
-class StorageObjectStorageSource : public SourceWithKeyCondition, WithContext
+class StorageObjectStorageSource : public SourceWithKeyCondition
 {
     friend class ObjectStorageQueueSource;
 public:
@@ -245,6 +245,7 @@ private:
 
     const ObjectStoragePtr object_storage;
     const ConfigurationPtr configuration;
+    const ContextPtr read_context;
     const NamesAndTypesList virtual_columns;
     const std::function<void(FileProgress)> file_progress_callback;
     const std::vector<String> keys;


### PR DESCRIPTION
### Changelog category:
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
We encountered problem that sometimes link to Context in a Source dies earlier than Source itself, which leads to logical error. In this we replace weak_ptr to context to shared_ptr to prevent this. 

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---ci_include_fuzzer--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
