### PR TITLE
More accurate PK in-memory size calculation for cache

### DIFF
--- a/src/Storages/MergeTree/PrimaryIndexCache.h
+++ b/src/Storages/MergeTree/PrimaryIndexCache.h
@@ -24,9 +24,10 @@ struct PrimaryIndexWeightFunction
 
     size_t operator()(const PrimaryIndex & index) const
     {
-        size_t res = 0;
+        size_t res = PRIMARY_INDEX_CACHE_OVERHEAD;
+        res += index.capacity() * sizeof(PrimaryIndex::value_type);
         for (const auto & column : index)
-            res += column->byteSize();
+            res += column->allocatedBytes();
         return res;
     }
 };

--- a/tests/queries/0_stateless/03273_primary_index_cache.reference
+++ b/tests/queries/0_stateless/03273_primary_index_cache.reference
@@ -3,14 +3,14 @@ PrimaryIndexCacheBytes	0
 PrimaryIndexCacheFiles	0
 99
 0
-PrimaryIndexCacheBytes	1280
+PrimaryIndexCacheBytes	1808
 PrimaryIndexCacheFiles	2
 0
 PrimaryIndexCacheBytes	0
 PrimaryIndexCacheFiles	0
 49
 0
-PrimaryIndexCacheBytes	640
+PrimaryIndexCacheBytes	904
 PrimaryIndexCacheFiles	1
 2	160	1280
 1	80	640

--- a/tests/queries/0_stateless/03273_primary_index_cache_low_cardinality.reference
+++ b/tests/queries/0_stateless/03273_primary_index_cache_low_cardinality.reference
@@ -1,0 +1,8 @@
+PrimaryIndexCacheBytes	5556
+PrimaryIndexCacheFiles	1
+PrimaryIndexCacheBytes	0
+PrimaryIndexCacheFiles	0
+3
+PrimaryIndexCacheBytes	5556
+PrimaryIndexCacheFiles	1
+1	3	6

--- a/tests/queries/0_stateless/03273_primary_index_cache_low_cardinality.sql
+++ b/tests/queries/0_stateless/03273_primary_index_cache_low_cardinality.sql
@@ -1,0 +1,41 @@
+-- Tags: no-parallel
+
+DROP TABLE IF EXISTS t_primary_index_cache;
+
+SYSTEM DROP PRIMARY INDEX CACHE;
+
+CREATE TABLE t_primary_index_cache (a LowCardinality(String), b LowCardinality(String))
+ENGINE = MergeTree ORDER BY (a, b)
+SETTINGS use_primary_key_cache = 1, prewarm_primary_key_cache = 1, index_granularity = 8192, index_granularity_bytes = '10M', min_bytes_for_wide_part = 0;
+
+-- Insert will prewarm primary index cache
+INSERT INTO t_primary_index_cache SELECT number%10, number%11 FROM numbers(10000);
+
+-- Check cache size
+SYSTEM RELOAD ASYNCHRONOUS METRICS;
+SELECT metric, value FROM system.asynchronous_metrics WHERE metric IN ('PrimaryIndexCacheFiles', 'PrimaryIndexCacheBytes') ORDER BY metric;
+
+SYSTEM DROP PRIMARY INDEX CACHE;
+
+-- Check that cache is empty
+SYSTEM RELOAD ASYNCHRONOUS METRICS;
+SELECT metric, value FROM system.asynchronous_metrics WHERE metric IN ('PrimaryIndexCacheFiles', 'PrimaryIndexCacheBytes') ORDER BY metric;
+
+-- Trigger index reload
+SELECT max(length(a || b)) FROM t_primary_index_cache WHERE a > '1' AND b < '99' SETTINGS log_comment = '03273_reload_query';
+
+-- Check that cache size is the same as after prewarm
+SYSTEM RELOAD ASYNCHRONOUS METRICS;
+SELECT metric, value FROM system.asynchronous_metrics WHERE metric IN ('PrimaryIndexCacheFiles', 'PrimaryIndexCacheBytes') ORDER BY metric;
+
+SYSTEM FLUSH LOGS;
+
+SELECT
+    ProfileEvents['LoadedPrimaryIndexFiles'],
+    ProfileEvents['LoadedPrimaryIndexRows'],
+    ProfileEvents['LoadedPrimaryIndexBytes']
+FROM system.query_log
+WHERE log_comment = '03273_reload_query' AND current_database = currentDatabase() AND type = 'QueryFinish'
+ORDER BY event_time_microseconds;
+
+DROP TABLE t_primary_index_cache;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
PK cache was heavily underestimating it's size on one of the test instances. In particular LowCardinality columns were not including dictionary size. The fix is to use column->allocatedBytes() plus some more overhead estimates for cache entry size.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---ci_include_fuzzer--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
