### PR TITLE
Output logs for integration tests, add TeePopen.terminate

### DIFF
--- a/tests/ci/integration_tests_runner.py
+++ b/tests/ci/integration_tests_runner.py
@@ -655,13 +655,12 @@ class ClickhouseIntegrationTestsRunner:
 
             log_basename = test_group_str + "_" + str(i) + ".log"
             log_path = os.path.join(self.repo_path, "tests/integration", log_basename)
-            with open(log_path, "w", encoding="utf-8") as log:
-                logging.info("Executing cmd: %s", cmd)
-                # ignore retcode, since it meaningful due to pipe to tee
-                with subprocess.Popen(cmd, shell=True, stderr=log, stdout=log) as proc:
-                    global runner_subprocess  # pylint:disable=global-statement
-                    runner_subprocess = proc
-                    proc.wait()
+            logging.info("Executing cmd: %s", cmd)
+            # ignore retcode, since it meaningful due to pipe to tee
+            with TeePopen(cmd, log_path) as proc:
+                global runner_subprocess  # pylint:disable=global-statement
+                runner_subprocess = proc
+                proc.wait()
 
             extra_logs_names = [log_basename]
             log_result_path = os.path.join(
@@ -1089,7 +1088,7 @@ def run():
 
 
 timeout_expired = False
-runner_subprocess = None  # type:Optional[subprocess.Popen]
+runner_subprocess = None  # type:Optional[TeePopen]
 
 
 def handle_sigterm(signum, _frame):
@@ -1098,7 +1097,7 @@ def handle_sigterm(signum, _frame):
     global timeout_expired  # pylint:disable=global-statement
     timeout_expired = True
     if runner_subprocess:
-        runner_subprocess.send_signal(signal.SIGTERM)
+        runner_subprocess.terminate()
 
 
 if __name__ == "__main__":

--- a/tests/ci/tee_popen.py
+++ b/tests/ci/tee_popen.py
@@ -44,9 +44,12 @@ class TeePopen:
             self.timeout,
         )
         self.send_signal(signal.SIGTERM)
+        self.timeout_exceeded = True
+        self.terminate()
+
+    def terminate(self) -> None:
         time_wait = 0
         self.terminated_by_sigterm = True
-        self.timeout_exceeded = True
         while self.process.poll() is None and time_wait < 100:
             print("wait...")
             wait = 5

--- a/tests/ci/tee_popen.py
+++ b/tests/ci/tee_popen.py
@@ -43,25 +43,24 @@ class TeePopen:
             self.process.pid,
             self.timeout,
         )
-        self.send_signal(signal.SIGTERM)
         self.timeout_exceeded = True
         self.terminate()
 
-    def terminate(self) -> None:
+    def terminate(self, wait_before_kill: int = 100) -> None:
         time_wait = 0
+        time_sleep = 5
         self.terminated_by_sigterm = True
-        while self.process.poll() is None and time_wait < 100:
-            print("wait...")
-            wait = 5
-            sleep(wait)
-            time_wait += wait
+        self.send_signal(signal.SIGTERM)
+        while self.process.poll() is None and time_wait < wait_before_kill:
+            logging.warning("Wait the process %s to terminate", self.process.pid)
+            sleep(time_sleep)
+            time_wait += time_sleep
+
+        self.terminated_by_sigkill = True
         while self.process.poll() is None:
-            logging.error(
-                "Process is still running. Send SIGKILL",
-            )
+            logging.error("Process is still running. Send SIGKILL")
             self.send_signal(signal.SIGKILL)
-            self.terminated_by_sigkill = True
-            sleep(5)
+            sleep(time_sleep)
 
     def __enter__(self) -> "TeePopen":
         self.process = Popen(


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Use TeePopen to get the integration tests output during run; Add `TeePopen.terminate` method.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---ci_include_fuzzer--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
