### PR TITLE
tests: fix flakiness of 03001_consider_lwd_when_merge

### DIFF
--- a/tests/queries/0_stateless/03001_consider_lwd_when_merge.sql
+++ b/tests/queries/0_stateless/03001_consider_lwd_when_merge.sql
@@ -2,7 +2,7 @@ DROP TABLE IF EXISTS lwd_merge;
 
 CREATE TABLE lwd_merge (id UInt64 CODEC(NONE))
     ENGINE = MergeTree ORDER BY id
-SETTINGS max_bytes_to_merge_at_max_space_in_pool = 80000, exclude_deleted_rows_for_part_size_in_merge = 0;
+SETTINGS max_bytes_to_merge_at_min_space_in_pool = 80000, max_bytes_to_merge_at_max_space_in_pool = 80000, exclude_deleted_rows_for_part_size_in_merge = 0;
 
 INSERT INTO lwd_merge SELECT number FROM numbers(10000);
 INSERT INTO lwd_merge SELECT number FROM numbers(10000, 10000);


### PR DESCRIPTION
Refs: https://github.com/ClickHouse/ClickHouse/blob/273c294ddf97a0542c5468a435cca817537b6f28/src/Storages/MergeTree/MergeTreeDataMergerMutator.cpp#L137-L140
CI: https://s3.amazonaws.com/clickhouse-test-reports/72606/74a566bd3688e5e88966921f93a641d144a283f5/stateless_tests__debug__s3_storage_.html

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)