### PR TITLE
Improve performance of deserialization of aggregate functions states and format `RowBinary`

### DIFF
--- a/src/AggregateFunctions/IAggregateFunction.h
+++ b/src/AggregateFunctions/IAggregateFunction.h
@@ -14,6 +14,7 @@
 #include <Common/Exception.h>
 #include <Common/ThreadPool_fwd.h>
 
+#include <IO/ReadBuffer.h>
 #include "config.h"
 
 #include <cstddef>
@@ -176,10 +177,14 @@ public:
     /// Serializes state (to transmit it over the network, for example).
     virtual void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::optional<size_t> version = std::nullopt) const = 0; /// NOLINT
 
+    /// Devirtualize serialize call.
     virtual void serializeBatch(const PaddedPODArray<AggregateDataPtr> & data, size_t start, size_t size, WriteBuffer & buf, std::optional<size_t> version = std::nullopt) const = 0; /// NOLINT
 
     /// Deserializes state. This function is called only for empty (just created) states.
     virtual void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::optional<size_t> version = std::nullopt, Arena * arena = nullptr) const = 0; /// NOLINT
+
+    /// Devirtualize create and deserialize calls. Used in deserialization of ColumnAggregateFunction.
+    virtual void createAndDeserializeBatch(PaddedPODArray<AggregateDataPtr> & data, AggregateDataPtr __restrict place, size_t total_size_of_state, size_t limit, ReadBuffer & buf, std::optional<size_t> version, Arena * arena) const = 0;
 
     /// Returns true if a function requires Arena to handle own states (see add(), merge(), deserialize()).
     virtual bool allocatesMemoryInArena() const = 0;
@@ -477,6 +482,37 @@ public:
     {
         for (size_t i = start; i < size; ++i)
             static_cast<const Derived *>(this)->serialize(data[i], buf, version);
+    }
+
+    void createAndDeserializeBatch(
+        PaddedPODArray<AggregateDataPtr> & data,
+        AggregateDataPtr __restrict place,
+        size_t total_size_of_state,
+        size_t limit,
+        ReadBuffer & buf,
+        std::optional<size_t> version,
+        Arena * arena) const override
+    {
+        for (size_t i = 0; i < limit; ++i)
+        {
+            if (buf.eof())
+                break;
+
+            static_cast<const Derived *>(this)->create(place);
+
+            try
+            {
+                static_cast<const Derived *>(this)->deserialize(place, buf, version, arena);
+            }
+            catch (...)
+            {
+                static_cast<const Derived *>(this)->destroy(place);
+                throw;
+            }
+
+            data.push_back(place);
+            place += total_size_of_state;
+        }
     }
 
     void addBatchSparse(

--- a/src/DataTypes/Serializations/SerializationAggregateFunction.cpp
+++ b/src/DataTypes/Serializations/SerializationAggregateFunction.cpp
@@ -79,12 +79,15 @@ void SerializationAggregateFunction::deserializeBinaryBulk(IColumn & column, Rea
     size_t size_of_state = function->sizeOfData();
     size_t align_of_state = function->alignOfData();
 
+    /// Adjust the size of state to make all states aligned in vector.
+    size_t total_size_of_state = (size_of_state + align_of_state - 1) / align_of_state * align_of_state;
+    char * memory = arena.alignedAlloc(total_size_of_state * limit, align_of_state);
+    char * place = memory;
+
     for (size_t i = 0; i < limit; ++i)
     {
         if (istr.eof())
             break;
-
-        AggregateDataPtr place = arena.alignedAlloc(size_of_state, align_of_state);
 
         function->create(place);
 
@@ -99,6 +102,7 @@ void SerializationAggregateFunction::deserializeBinaryBulk(IColumn & column, Rea
         }
 
         vec.push_back(place);
+        place += total_size_of_state;
     }
 }
 

--- a/src/IO/ReadHelpers.h
+++ b/src/IO/ReadHelpers.h
@@ -110,16 +110,18 @@ inline void readChar(char & x, ReadBuffer & buf)
 template <typename T>
 inline void readPODBinary(T & x, ReadBuffer & buf)
 {
+    static constexpr size_t size = sizeof(T); /// NOLINT
+
     /// If the whole value fits in buffer do not call readStrict and copy with
     /// __builtin_memcpy since it is faster than generic memcpy for small copies.
-    if (buf.position() + sizeof(T) <= buf.buffer().end()) [[likely]]
+    if (buf.position() && buf.position() + size <= buf.buffer().end()) [[likely]]
     {
-        __builtin_memcpy(reinterpret_cast<char *>(&x), buf.position(), sizeof(T));
-        buf.position() += sizeof(T);
+        __builtin_memcpy(reinterpret_cast<char *>(&x), buf.position(), size);
+        buf.position() += size;
     }
     else
     {
-        buf.readStrict(reinterpret_cast<char *>(&x), sizeof(T)); /// NOLINT
+        buf.readStrict(reinterpret_cast<char *>(&x), size);
     }
 }
 

--- a/tests/performance/aggregate_functions_deserialization.xml
+++ b/tests/performance/aggregate_functions_deserialization.xml
@@ -1,0 +1,27 @@
+<test>
+    <create_query>
+        CREATE TABLE agg_deserialize
+        (
+            t DateTime,
+            v1 AggregateFunction(avgState, UInt64),
+            v2 AggregateFunction(argMax, UInt64, DateTime)
+        )
+        ENGINE = MergeTree() ORDER BY t
+    </create_query>
+
+    <fill_query>
+        INSERT INTO agg_deserialize SELECT
+            now() + number AS t,
+            initializeAggregation('avgState', number),
+            initializeAggregation('argMaxState', number, t)
+        FROM numbers(50000000)
+    </fill_query>
+
+    <query>SELECT v1 FROM agg_deserialize FORMAT Null</query>
+    <query>SELECT toStartOfHour(t) AS h, avgMerge(v1) FROM agg_deserialize GROUP BY h FORMAT Null</query>
+
+    <query>SELECT v2 FROM agg_deserialize FORMAT Null</query>
+    <query>SELECT toStartOfHour(t) AS h, argMaxMerge(v2) FROM agg_deserialize GROUP BY h FORMAT Null</query>
+
+    <drop_query>DROP TABLE IF EXISTS agg_deserialize</drop_query>
+</test>


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Improved performance of deserialization of states of aggregate functions (in data type `AggregateFunction` and in distributed queries). Slightly improved performance of parsing of format `RowBinary`.

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---ci_include_fuzzer--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
