### PR TITLE
Fix segfault in CascadeWriteBuffer::getResultBuffers()

### DIFF
--- a/src/IO/CascadeWriteBuffer.cpp
+++ b/src/IO/CascadeWriteBuffer.cpp
@@ -56,6 +56,9 @@ void CascadeWriteBuffer::nextImpl()
 
 CascadeWriteBuffer::WriteBufferPtrs CascadeWriteBuffer::getResultBuffers()
 {
+    if (!curr_buffer)
+        return {};
+
     /// Sync position with underlying buffer before invalidating
     curr_buffer->position() = position();
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix segfault in `CascadeWriteBuffer::getResultBuffers()`.

This segfault was found by [Stress test (ubsan)](https://s3.amazonaws.com/clickhouse-test-reports/70597/128080c24914517e4d197302d606efe89c92eb76/stress_test__ubsan_.html):
```
08:06:00.982589 [ 13738 ] {} <Fatal> BaseDaemon: ########## Short fault info ############
08:06:00.985098 [ 13738 ] {} <Fatal> BaseDaemon: (version 24.12.1.438, build id: 7952417C1E12F8525F71D47330D9A5E8C0F7A5D1, git hash: 7a30bcde8e4bae0bf8c8986868728fbb72ea817a, architecture: x86_64) (from thread 4526) Received signal 11
08:06:00.986135 [ 13738 ] {} <Fatal> BaseDaemon: Signal description: Segmentation fault
08:06:00.987328 [ 13738 ] {} <Fatal> BaseDaemon: Address: 0x8. Access: write. Address not mapped to object.
08:06:01.000599 [ 13738 ] {} <Fatal> BaseDaemon: Stack trace: 0x0000561e65bea18d 0x0000561e65ff2b18 0x00007f1b21c4f520 0x0000561e74bfca6c 0x0000561e74be0bc7 0x0000561e74be5232 0x0000561e74ce8a2c 0x0000561e785c7382 0x0000561e785c8052 0x0000561e78525d57 0x0000561e7852164e 0x00007f1b21ca1ac3 0x00007f1b21d33850
08:06:01.049993 [ 13738 ] {} <Fatal> BaseDaemon: ########################################
08:06:01.064379 [ 13738 ] {} <Fatal> BaseDaemon: (version 24.12.1.438, build id: 7952417C1E12F8525F71D47330D9A5E8C0F7A5D1, git hash: 7a30bcde8e4bae0bf8c8986868728fbb72ea817a) (from thread 4526) (query_id: 6f6bd3ae-1a0a-4430-95a1-95edea32a460) (query: SELECT greatest(toUInt8(1), toUInt8(intHash64(number))) FROM system.numbers LIMIT 500000 FORMAT RowBinary) Received signal Segmentation fault (11)
08:06:01.080352 [ 13738 ] {} <Fatal> BaseDaemon: Address: 0x8. Access: write. Address not mapped to object.
08:06:01.081956 [ 13738 ] {} <Fatal> BaseDaemon: Stack trace: 0x0000561e65bea18d 0x0000561e65ff2b18 0x00007f1b21c4f520 0x0000561e74bfca6c 0x0000561e74be0bc7 0x0000561e74be5232 0x0000561e74ce8a2c 0x0000561e785c7382 0x0000561e785c8052 0x0000561e78525d57 0x0000561e7852164e 0x00007f1b21ca1ac3 0x00007f1b21d33850
08:06:01.162105 [ 13738 ] {} <Fatal> BaseDaemon: 0.0. inlined from ./build_docker/./src/Common/StackTrace.cpp:380: StackTrace::tryCapture()
08:06:01.164521 [ 13738 ] {} <Fatal> BaseDaemon: 0. ./build_docker/./src/Common/StackTrace.cpp:349: StackTrace::StackTrace(ucontext_t const&) @ 0x00000000253f518d
08:06:01.192758 [ 13738 ] {} <Fatal> BaseDaemon: 1. ./build_docker/./src/Common/SignalHandlers.cpp:100: signalHandler(int, siginfo_t*, void*) @ 0x00000000257fdb18
08:06:01.193317 [ 13738 ] {} <Fatal> BaseDaemon: 2. ? @ 0x00007f1b21c4f520
08:06:01.217199 [ 13738 ] {} <Fatal> BaseDaemon: 3. ./build_docker/./src/IO/CascadeWriteBuffer.cpp:60: DB::CascadeWriteBuffer::getResultBuffers() @ 0x0000000034407a6c
08:06:01.300775 [ 13738 ] {} <Fatal> BaseDaemon: 4. ./build_docker/./src/Server/HTTPHandler.cpp:608: DB::HTTPHandler::trySendExceptionToClient(int, String const&, DB::HTTPServerRequest&, DB::HTTPServerResponse&, DB::HTTPHandler::Output&) @ 0x00000000343ebbc7
08:06:01.345234 [ 13738 ] {} <Fatal> BaseDaemon: 5. ./build_docker/./src/Server/HTTPHandler.cpp:755: DB::HTTPHandler::handleRequest(DB::HTTPServerRequest&, DB::HTTPServerResponse&, StrongTypedef<unsigned long, ProfileEvents::EventTag> const&) @ 0x00000000343f0232
08:06:01.360983 [ 13738 ] {} <Fatal> BaseDaemon: 6. ./build_docker/./src/Server/HTTP/HTTPServerConnection.cpp:71: DB::HTTPServerConnection::run() @ 0x00000000344f3a2c
08:06:01.370237 [ 13738 ] {} <Fatal> BaseDaemon: 7. ./build_docker/./base/poco/Net/src/TCPServerConnection.cpp:40: Poco::Net::TCPServerConnection::start() @ 0x0000000037dd2382
08:06:01.389824 [ 13738 ] {} <Fatal> BaseDaemon: 8. ./build_docker/./base/poco/Net/src/TCPServerDispatcher.cpp:115: Poco::Net::TCPServerDispatcher::run() @ 0x0000000037dd3052
08:06:01.415762 [ 13738 ] {} <Fatal> BaseDaemon: 9. ./build_docker/./base/poco/Foundation/src/ThreadPool.cpp:205: Poco::PooledThread::run() @ 0x0000000037d30d57
08:06:01.451265 [ 13738 ] {} <Fatal> BaseDaemon: 10. ./base/poco/Foundation/src/Thread_POSIX.cpp:335: Poco::ThreadImpl::runnableEntry(void*) @ 0x0000000037d2c64e
08:06:01.453013 [ 13738 ] {} <Fatal> BaseDaemon: 11. ? @ 0x00007f1b21ca1ac3
08:06:01.460771 [ 13738 ] {} <Fatal> BaseDaemon: 12. ? @ 0x00007f1b21d33850
08:06:01.461385 [ 13738 ] {} <Fatal> BaseDaemon: Integrity check of the executable skipped because the reference checksum could not be read.
08:06:01.831292 [ 13738 ] {} <Fatal> BaseDaemon: This ClickHouse version is not official and should be upgraded to the official build.
08:06:05.020858 [ 3215 ] {} <Fatal> Application: Child process was terminated by signal 11.
```