### PR TITLE
Do not swap tables in join in case filter without index applied

### DIFF
--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -210,6 +210,10 @@
     M(ExternalJoinCompressedBytes, "Number of compressed bytes written for JOIN in external memory.", ValueType::Bytes) \
     M(ExternalJoinUncompressedBytes, "Amount of data (uncompressed, before compression) written for JOIN in external memory.", ValueType::Bytes) \
     \
+    M(JoinBuildTableRowCount, "Total number of rows in the build table for a JOIN operation.", ValueType::Number) \
+    M(JoinProbeTableRowCount, "Total number of rows in the probe table for a JOIN operation.", ValueType::Number) \
+    M(JoinResultRowCount, "Total number of rows in the result of a JOIN operation.", ValueType::Number) \
+    \
     M(SlowRead, "Number of reads from a file that were slow. This indicate system overload. Thresholds are controlled by read_backoff_* settings.", ValueType::Number) \
     M(ReadBackoff, "Number of times the number of query processing threads was lowered due to slow reads.", ValueType::Number) \
     \

--- a/src/Processors/Transforms/JoiningTransform.cpp
+++ b/src/Processors/Transforms/JoiningTransform.cpp
@@ -4,8 +4,6 @@
 
 #include <Common/logger_useful.h>
 
-
-
 namespace ProfileEvents
 {
     extern const Event JoinBuildTableRowCount;

--- a/tests/queries/0_stateless/03279_join_choose_build_table.reference
+++ b/tests/queries/0_stateless/03279_join_choose_build_table.reference
@@ -1,0 +1,5 @@
+ok	ok	ok	auto
+ok	ok	ok	auto
+ok	ok	ok	auto
+ok	ok	ok	auto
+

--- a/tests/queries/0_stateless/03279_join_choose_build_table.reference
+++ b/tests/queries/0_stateless/03279_join_choose_build_table.reference
@@ -2,4 +2,3 @@ ok	ok	ok	auto
 ok	ok	ok	auto
 ok	ok	ok	auto
 ok	ok	ok	auto
-

--- a/tests/queries/0_stateless/03279_join_choose_build_table.sql
+++ b/tests/queries/0_stateless/03279_join_choose_build_table.sql
@@ -49,7 +49,7 @@ SELECT
     if(ProfileEvents['JoinResultRowCount'] == 1000, 'ok', 'fail: ' || toString(ProfileEvents['JoinResultRowCount'])),
     Settings['query_plan_join_swap_table'],
 FROM system.query_log
-WHERE type = 'QueryFinish' AND event_date = today() AND query_kind = 'Select'
+WHERE type = 'QueryFinish' AND event_date >= yesterday() AND query_kind = 'Select' AND current_database = currentDatabase()
 AND query like '%products, sales%'
 AND log_comment = '03279_join_choose_build_table_no_idx'
 ORDER BY event_time DESC
@@ -61,7 +61,7 @@ SELECT
     if(ProfileEvents['JoinResultRowCount'] == 1000, 'ok', 'fail: ' || toString(ProfileEvents['JoinResultRowCount'])),
     Settings['query_plan_join_swap_table'],
 FROM system.query_log
-WHERE type = 'QueryFinish' AND event_date = today() AND query_kind = 'Select'
+WHERE type = 'QueryFinish' AND event_date >= yesterday() AND query_kind = 'Select' AND current_database = currentDatabase()
 AND query like '%sales, products%'
 AND log_comment = '03279_join_choose_build_table_no_idx'
 ORDER BY event_time DESC
@@ -75,7 +75,7 @@ SELECT
     if(ProfileEvents['JoinResultRowCount'] == 1000, 'ok', 'fail: ' || toString(ProfileEvents['JoinResultRowCount'])),
     Settings['query_plan_join_swap_table'],
 FROM system.query_log
-WHERE type = 'QueryFinish' AND event_date = today() AND query_kind = 'Select'
+WHERE type = 'QueryFinish' AND event_date >= yesterday() AND query_kind = 'Select' AND current_database = currentDatabase()
 AND query like '%products, sales%'
 AND log_comment = '03279_join_choose_build_table_idx'
 ORDER BY event_time DESC
@@ -87,7 +87,7 @@ SELECT
     if(ProfileEvents['JoinResultRowCount'] == 1000, 'ok', 'fail: ' || toString(ProfileEvents['JoinResultRowCount'])),
     Settings['query_plan_join_swap_table'],
 FROM system.query_log
-WHERE type = 'QueryFinish' AND event_date = today() AND query_kind = 'Select'
+WHERE type = 'QueryFinish' AND event_date >= yesterday() AND query_kind = 'Select' AND current_database = currentDatabase()
 AND query like '%sales, products%'
 AND log_comment = '03279_join_choose_build_table_idx'
 ORDER BY event_time DESC

--- a/tests/queries/0_stateless/03279_join_choose_build_table.sql
+++ b/tests/queries/0_stateless/03279_join_choose_build_table.sql
@@ -9,7 +9,8 @@ CREATE TABLE sales (
     date Date,
     amount Decimal(10, 2),
     product_id Int32
-) ENGINE = MergeTree ORDER BY id;
+) ENGINE = MergeTree ORDER BY id
+SETTINGS index_granularity = 8192, index_granularity_bytes = '10Mi';
 
 INSERT INTO sales SELECT number, '2024-05-05' + INTERVAL intDiv(number, 1000) DAY , (number + 1) % 100, number % 100_000 FROM numbers(1_000_000);
 

--- a/tests/queries/0_stateless/03279_join_choose_build_table.sql
+++ b/tests/queries/0_stateless/03279_join_choose_build_table.sql
@@ -1,0 +1,97 @@
+
+DROP TABLE IF EXISTS products;
+DROP TABLE IF EXISTS sales;
+
+SET allow_experimental_analyzer = 1;
+
+CREATE TABLE sales (
+    id Int32,
+    date Date,
+    amount Decimal(10, 2),
+    product_id Int32
+) ENGINE = MergeTree ORDER BY id;
+
+INSERT INTO sales SELECT number, '2024-05-05' + INTERVAL intDiv(number, 1000) DAY , (number + 1) % 100, number % 100_000 FROM numbers(1_000_000);
+
+CREATE TABLE products (id Int32, name String) ENGINE = MergeTree ORDER BY id;
+INSERT INTO products SELECT number, 'product ' || toString(number) FROM numbers(100_000);
+
+SET query_plan_join_swap_table = 'auto';
+
+SELECT * FROM products, sales
+WHERE sales.product_id = products.id AND date = '2024-05-07'
+SETTINGS log_comment = '03279_join_choose_build_table_no_idx' FORMAT Null;
+
+SELECT * FROM sales, products
+WHERE sales.product_id = products.id AND date = '2024-05-07'
+SETTINGS log_comment = '03279_join_choose_build_table_no_idx' FORMAT Null;
+
+SET mutations_sync = 2;
+ALTER TABLE sales ADD INDEX date_idx date TYPE minmax GRANULARITY 1;
+ALTER TABLE sales MATERIALIZE INDEX date_idx;
+
+SELECT * FROM products, sales
+WHERE sales.product_id = products.id AND date = '2024-05-07'
+SETTINGS log_comment = '03279_join_choose_build_table_idx' FORMAT Null;
+
+SELECT * FROM sales, products
+WHERE sales.product_id = products.id AND date = '2024-05-07'
+SETTINGS log_comment = '03279_join_choose_build_table_idx' FORMAT Null;
+
+SYSTEM FLUSH LOGS;
+
+-- condtitions are pushed down, but no filter by index applied
+-- build table is as it's written in query
+
+SELECT
+    if(ProfileEvents['JoinBuildTableRowCount'] BETWEEN 100 AND 2000, 'ok', 'fail: ' || toString(ProfileEvents['JoinBuildTableRowCount'])),
+    if(ProfileEvents['JoinProbeTableRowCount'] BETWEEN 90_000 AND 110_000, 'ok', 'fail: ' || toString(ProfileEvents['JoinProbeTableRowCount'])),
+    if(ProfileEvents['JoinResultRowCount'] == 1000, 'ok', 'fail: ' || toString(ProfileEvents['JoinResultRowCount'])),
+    Settings['query_plan_join_swap_table'],
+FROM system.query_log
+WHERE type = 'QueryFinish' AND event_date = today() AND query_kind = 'Select'
+AND query like '%products, sales%'
+AND log_comment = '03279_join_choose_build_table_no_idx'
+ORDER BY event_time DESC
+LIMIT 1;
+
+SELECT
+    if(ProfileEvents['JoinBuildTableRowCount'] BETWEEN 90_000 AND 110_000, 'ok', 'fail: ' || toString(ProfileEvents['JoinBuildTableRowCount'])),
+    if(ProfileEvents['JoinProbeTableRowCount'] BETWEEN 100 AND 2000, 'ok', 'fail: ' || toString(ProfileEvents['JoinProbeTableRowCount'])),
+    if(ProfileEvents['JoinResultRowCount'] == 1000, 'ok', 'fail: ' || toString(ProfileEvents['JoinResultRowCount'])),
+    Settings['query_plan_join_swap_table'],
+FROM system.query_log
+WHERE type = 'QueryFinish' AND event_date = today() AND query_kind = 'Select'
+AND query like '%sales, products%'
+AND log_comment = '03279_join_choose_build_table_no_idx'
+ORDER BY event_time DESC
+LIMIT 1;
+
+-- after adding index, optimizer can choose best table order
+
+SELECT
+    if(ProfileEvents['JoinBuildTableRowCount'] BETWEEN 100 AND 2000, 'ok', 'fail: ' || toString(ProfileEvents['JoinBuildTableRowCount'])),
+    if(ProfileEvents['JoinProbeTableRowCount'] BETWEEN 90_000 AND 110_000, 'ok', 'fail: ' || toString(ProfileEvents['JoinProbeTableRowCount'])),
+    if(ProfileEvents['JoinResultRowCount'] == 1000, 'ok', 'fail: ' || toString(ProfileEvents['JoinResultRowCount'])),
+    Settings['query_plan_join_swap_table'],
+FROM system.query_log
+WHERE type = 'QueryFinish' AND event_date = today() AND query_kind = 'Select'
+AND query like '%products, sales%'
+AND log_comment = '03279_join_choose_build_table_idx'
+ORDER BY event_time DESC
+LIMIT 1;
+
+SELECT
+    if(ProfileEvents['JoinBuildTableRowCount'] BETWEEN 100 AND 2000, 'ok', 'fail: ' || toString(ProfileEvents['JoinBuildTableRowCount'])),
+    if(ProfileEvents['JoinProbeTableRowCount'] BETWEEN 90_000 AND 110_000, 'ok', 'fail: ' || toString(ProfileEvents['JoinProbeTableRowCount'])),
+    if(ProfileEvents['JoinResultRowCount'] == 1000, 'ok', 'fail: ' || toString(ProfileEvents['JoinResultRowCount'])),
+    Settings['query_plan_join_swap_table'],
+FROM system.query_log
+WHERE type = 'QueryFinish' AND event_date = today() AND query_kind = 'Select'
+AND query like '%sales, products%'
+AND log_comment = '03279_join_choose_build_table_idx'
+ORDER BY event_time DESC
+LIMIT 1;
+
+DROP TABLE IF EXISTS products;
+DROP TABLE IF EXISTS sales;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):

- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Added `JoinBuildTableRowCount/JoinProbeTableRowCount/JoinResultRowCount` profile events

_note_: "Do not swap tables in join in case filter without index applied" is for unreleased feature, so not mentioned in changelog
