### PR TITLE
setup_minio: Do not add aws credentials twice

### DIFF
--- a/ci/jobs/scripts/functional_tests/setup_minio.sh
+++ b/ci/jobs/scripts/functional_tests/setup_minio.sh
@@ -120,6 +120,12 @@ setup_aws_credentials() {
   local minio_root_user=${MINIO_ROOT_USER:-clickhouse}
   local minio_root_password=${MINIO_ROOT_PASSWORD:-clickhouse}
   mkdir -p ~/.aws
+  if [[ -f ~/.aws/credentials ]]; then
+    if grep -q "^\[default\]" ~/.aws/credentials; then
+        echo "The credentials file contains a [default] section."
+        return
+    fi
+  fi
   cat <<EOT >> ~/.aws/credentials
 [default]
 aws_access_key_id=${minio_root_user}


### PR DESCRIPTION
I regularly run setup_minio.py to set up it locally. However, if two or more [default] sections are added, it breaks commands like `kubectl get pods` or any other `aws` command.

```
$ kubectl get pods
Unable to parse config file: /home/nik/.aws/credentials
Unable to connect to the server: getting credentials: exec: executable aws failed with exit code 255
```

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [x] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [x] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---ci_include_fuzzer--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [ ] <!---do_not_test--> Do not test
- [x] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [x] <!---no_merge_commit--> Disable merge-commit
- [x] <!---no_ci_cache--> Disable CI cache
