### PR TITLE
Fix revoke of implicit grants

### DIFF
--- a/src/Interpreters/Access/InterpreterGrantQuery.cpp
+++ b/src/Interpreters/Access/InterpreterGrantQuery.cpp
@@ -190,7 +190,7 @@ namespace
         /// REVOKE SELECT ON system.* FROM user2;
         ///
         /// the query `REVOKE SELECT ON *.* FROM user1` executed by user2 should succeed.
-        if (current_user_access.getAccessRights()->containsWithGrantOption(access_to_revoke))
+        if (current_user_access.getAccessRightsWithImplicit()->containsWithGrantOption(access_to_revoke))
             return;
 
         /// Technically, this check always fails if `containsWithGrantOption` returns `false`. But we still call it to get a nice exception message.

--- a/tests/queries/0_stateless/03278_revoke_implicit_grants.sh
+++ b/tests/queries/0_stateless/03278_revoke_implicit_grants.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+user="user03278_${CLICKHOUSE_DATABASE}_$RANDOM"
+role1="role03278_1_${CLICKHOUSE_DATABASE}_$RANDOM"
+role2="role03278_2_${CLICKHOUSE_DATABASE}_$RANDOM"
+
+
+${CLICKHOUSE_CLIENT} --query "DROP USER IF EXISTS $user;";
+
+${CLICKHOUSE_CLIENT} <<EOF
+CREATE USER $user;
+CREATE ROLE $role1, $role2;
+
+GRANT SELECT ON *.* TO $role1 WITH GRANT OPTION;
+REVOKE SELECT ON test.table FROM $role1;
+
+GRANT SELECT ON *.* TO $role2 WITH GRANT OPTION;
+REVOKE SELECT ON test.table FROM $role2;
+GRANT SHOW TABLES ON default.* TO $role2;
+
+GRANT $role1 TO $user;
+EOF
+
+${CLICKHOUSE_CLIENT} --user $user --query "REVOKE ALL ON *.* FROM $role2"
+${CLICKHOUSE_CLIENT} --query "SHOW GRANTS FOR $role2"


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix the situation when a user can't run `REVOKE ALL ON *.*` because of implicit grants in the target access entity. 

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---ci_include_fuzzer--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
