### PR TITLE
Fix parsing of incorrect data into sparse columns

### DIFF
--- a/src/Core/Block.cpp
+++ b/src/Core/Block.cpp
@@ -449,6 +449,14 @@ MutableColumns Block::cloneEmptyColumns() const
     return columns;
 }
 
+MutableColumns Block::cloneEmptyColumns(const Serializations & serializations) const
+{
+    size_t num_columns = data.size();
+    MutableColumns columns(num_columns);
+    for (size_t i = 0; i < num_columns; ++i)
+        columns[i] = data[i].type->createColumn(*serializations[i]);
+    return columns;
+}
 
 Columns Block::getColumns() const
 {

--- a/src/Core/Block.h
+++ b/src/Core/Block.h
@@ -141,6 +141,9 @@ public:
     /** Get empty columns with the same types as in block. */
     MutableColumns cloneEmptyColumns() const;
 
+    /** Get empty columns with the same types as in block and given serializations. */
+    MutableColumns cloneEmptyColumns(const Serializations & serializations) const;
+
     /** Get columns from block for mutation. Columns in block will be nullptr. */
     MutableColumns mutateColumns();
 

--- a/src/Processors/Formats/IRowInputFormat.cpp
+++ b/src/Processors/Formats/IRowInputFormat.cpp
@@ -104,12 +104,8 @@ Chunk IRowInputFormat::read()
     }
 
     const Block & header = getPort().getHeader();
-
     size_t num_columns = header.columns();
-    MutableColumns columns(num_columns);
-
-    for (size_t i = 0; i < num_columns; ++i)
-        columns[i] = header.getByPosition(i).type->createColumn(*serializations[i]);
+    MutableColumns columns = header.cloneEmptyColumns(serializations);
 
     ColumnCheckpoints checkpoints(columns.size());
     for (size_t column_idx = 0; column_idx < columns.size(); ++column_idx)

--- a/src/Processors/Formats/RowInputFormatWithDiagnosticInfo.cpp
+++ b/src/Processors/Formats/RowInputFormatWithDiagnosticInfo.cpp
@@ -44,7 +44,7 @@ std::pair<String, String> RowInputFormatWithDiagnosticInfo::getDiagnosticAndRawD
             "Buffer has gone, cannot extract information about what has been parsed.");
 
     const auto & header = getPort().getHeader();
-    MutableColumns columns = header.cloneEmptyColumns();
+    MutableColumns columns = header.cloneEmptyColumns(serializations);
 
     /// It is possible to display detailed diagnostics only if the last and next to last rows are still in the read buffer.
     size_t bytes_read_at_start_of_buffer = in->count() - in->offset();

--- a/tests/queries/0_stateless/03279_insert_sparse_parsing_error.reference
+++ b/tests/queries/0_stateless/03279_insert_sparse_parsing_error.reference
@@ -1,0 +1,6 @@
+Code: 27
+1	0	0
+2	0	0
+a	Default
+b	Sparse
+c	Sparse

--- a/tests/queries/0_stateless/03279_insert_sparse_parsing_error.sh
+++ b/tests/queries/0_stateless/03279_insert_sparse_parsing_error.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+$CLICKHOUSE_CLIENT --query "
+    DROP TABLE IF EXISTS t_insert_sparse_columns;
+
+    CREATE TABLE t_insert_sparse_columns (a UInt64, b UInt64, c UInt64)
+    ENGINE = MergeTree ORDER BY a
+    SETTINGS ratio_of_defaults_for_sparse_serialization = 0.5, enable_block_number_column = 0, enable_block_offset_column = 0;
+
+    SYSTEM STOP MERGES t_insert_sparse_columns;
+"
+
+${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&query=INSERT+INTO+t_insert_sparse_columns+FORMAT+CSV" --data-binary @- <<EOF
+1, 0, 0
+2, 0, 0
+EOF
+
+${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&query=INSERT+INTO+t_insert_sparse_columns+FORMAT+CSV" --data-binary @- <<EOF 2>&1 | grep -o "Code: 27"
+3, 0
+4, 0
+EOF
+
+$CLICKHOUSE_CLIENT --query "
+    SELECT * FROM t_insert_sparse_columns;
+    SELECT column, serialization_kind FROM system.parts_columns WHERE database = currentDatabase() AND table = 't_insert_sparse_columns' AND active ORDER BY column, serialization_kind;
+    DROP TABLE IF EXISTS t_insert_sparse_columns;
+"


### PR DESCRIPTION
### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC) or LOGICAL_ERROR

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed crash while parsing of incorrect data into sparse columns (can happen with enabled setting `enable_parsing_to_custom_serialization`).

Fixes #72868.

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---ci_include_fuzzer--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
