### PR TITLE
Add shell script example to UDF page

### DIFF
--- a/docs/en/sql-reference/functions/udf.md
+++ b/docs/en/sql-reference/functions/udf.md
@@ -32,7 +32,50 @@ A function configuration contains the following settings:
 
 The command must read arguments from `STDIN` and must output the result to `STDOUT`. The command must process arguments iteratively. That is after processing a chunk of arguments it must wait for the next chunk.
 
-**Example**
+## Examples
+
+**Inline script**
+
+Creating `test_function_sum` manually specifying `execute_direct` to `0` using XML configuration.
+File `test_function.xml` (`/etc/clickhouse-server/test_function.xml` with default path settings).
+```xml
+<functions>
+    <function>
+        <type>executable</type>
+        <name>test_function_sum</name>
+        <return_type>UInt64</return_type>
+        <argument>
+            <type>UInt64</type>
+            <name>lhs</name>
+        </argument>
+        <argument>
+            <type>UInt64</type>
+            <name>rhs</name>
+        </argument>
+        <format>TabSeparated</format>
+        <command>cd /; clickhouse-local --input-format TabSeparated --output-format TabSeparated --structure 'x UInt64, y UInt64' --query "SELECT x + y FROM table"</command>
+        <execute_direct>0</execute_direct>
+    </function>
+</functions>
+```
+
+Query:
+
+``` sql
+SELECT test_function_sum(2, 2);
+```
+
+Result:
+
+``` text
+┌─test_function_sum(2, 2)─┐
+│                       4 │
+└─────────────────────────┘
+```
+
+**Python script**
+
+Reads a value from `STDIN` and returns it as a string:
 
 Creating `test_function` using XML configuration.
 File `test_function.xml` (`/etc/clickhouse-server/test_function.xml` with default path settings).
@@ -79,42 +122,7 @@ Result:
 └─────────────────────────┘
 ```
 
-Creating `test_function_sum` manually specifying `execute_direct` to `0` using XML configuration.
-File `test_function.xml` (`/etc/clickhouse-server/test_function.xml` with default path settings).
-```xml
-<functions>
-    <function>
-        <type>executable</type>
-        <name>test_function_sum</name>
-        <return_type>UInt64</return_type>
-        <argument>
-            <type>UInt64</type>
-            <name>lhs</name>
-        </argument>
-        <argument>
-            <type>UInt64</type>
-            <name>rhs</name>
-        </argument>
-        <format>TabSeparated</format>
-        <command>cd /; clickhouse-local --input-format TabSeparated --output-format TabSeparated --structure 'x UInt64, y UInt64' --query "SELECT x + y FROM table"</command>
-        <execute_direct>0</execute_direct>
-    </function>
-</functions>
-```
-
-Query:
-
-``` sql
-SELECT test_function_sum(2, 2);
-```
-
-Result:
-
-``` text
-┌─test_function_sum(2, 2)─┐
-│                       4 │
-└─────────────────────────┘
-```
+Read two values from `STDIN` and returns their sum as a JSON object:
 
 Creating `test_function_sum_json` with named arguments and format [JSONEachRow](../../interfaces/formats.md#jsoneachrow) using XML configuration.
 File `test_function.xml` (`/etc/clickhouse-server/test_function.xml` with default path settings).
@@ -171,6 +179,8 @@ Result:
 └──────────────────────────────┘
 ```
 
+Use parameters in `command` setting:
+
 Executable user defined functions can take constant parameters configured in `command` setting (works only for user defined functions with `executable` type). It also requires the `execute_direct` option (to ensure no shell argument expansion vulnerability).
 File `test_function_parameter_python.xml` (`/etc/clickhouse-server/test_function_parameter_python.xml` with default path settings).
 ```xml
@@ -215,6 +225,62 @@ Result:
 │ Parameter 1 value 2                  │
 └──────────────────────────────────────┘
 ```
+
+**Shell script**
+
+Shell script that multiplies each value by 2:
+
+Executable user defined functions can be used with shell script.
+File `test_function_shell.xml` (`/etc/clickhouse-server/test_function_shell.xml` with default path settings).
+```xml
+<functions>
+    <function>
+        <type>executable</type>
+        <name>test_shell</name>
+        <return_type>String</return_type>
+        <argument>
+            <type>UInt8</type>
+            <name>value</name>
+        </argument>
+        <format>TabSeparated</format>
+        <command>test_shell.sh</command>
+    </function>
+</functions>
+```
+
+Script file inside `user_scripts` folder `test_shell.sh` (`/var/lib/clickhouse/user_scripts/test_shell.sh` with default path settings).
+
+```bash
+#!/bin/bash
+
+while read read_data;
+    do printf "$(expr $read_data \* 2)\n";
+done
+```
+
+Query:
+
+``` sql
+SELECT test_shell(number) FROM numbers(10);
+```
+
+Result:
+
+``` text
+    ┌─test_shell(number)─┐
+ 1. │ 0                  │
+ 2. │ 2                  │
+ 3. │ 4                  │
+ 4. │ 6                  │
+ 5. │ 8                  │
+ 6. │ 10                 │
+ 7. │ 12                 │
+ 8. │ 14                 │
+ 9. │ 16                 │
+10. │ 18                 │
+    └────────────────────┘
+```
+
 
 ## Error Handling
 


### PR DESCRIPTION
In response to https://github.com/ClickHouse/clickhouse-docs/issues/1908 to add a shell script example to UDF. 

**Changelog category (leave one):**
    Documentation (changelog entry is not required)