### PR TITLE
Fix possible overestimate memory tracking

### DIFF
--- a/src/Common/ThreadStatus.cpp
+++ b/src/Common/ThreadStatus.cpp
@@ -226,7 +226,7 @@ ThreadStatus::~ThreadStatus()
 
     chassert(!check_current_thread_on_destruction || current_thread == this);
 
-    /// Flush untracked_memory **before** switching the current_thread (to avoid losing untracked_memory)
+    /// Flush untracked_memory **right before** switching the current_thread to avoid losing untracked_memory in deleter (detachFromGroup)
     flushUntrackedMemory();
 
     /// Only change current_thread if it's currently being used by this ThreadStatus


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix possible overestimate memory tracking (difference between `MemoryTracking` and `MemoryResident` kept growing)

Before this patch the untracked_memory was dumped before reseting the current_thread which could lead to leaking some of untracked_memory in `ThreadStatus::detachFromGroup` [1].

In particular I found that the local_data (which is 136 bytes) can be "leaked" that way.

  [1]: https://github.com/ClickHouse/ClickHouse/blob/8999fdd95ea98fa083133d5cdf64ee149cd7f864/src/Interpreters/ThreadStatusExt.cpp#L292-L306

This pops up on one of clusters where I noticed that the difference between MemoryTracking and MemoryResident keeps growing over the time. the difference grows ~200KiB per second - 16.5GiB per day.

That cluster has tons MVs triggered from Buffer/Distributed (i.e. no query context), and this is indeed is the reason for leaking local_data, since in this case there is no thread group in the query, and it is created explicitly in `InterpreterInsertQuery::buildChain` [2].

  [2]: https://github.com/ClickHouse/ClickHouse/blob/20ccb638ba00103f116855afbc473950ef2b867b/src/Interpreters/InterpreterInsertQuery.cpp#L321

Fixes: #71511
Fixes: #71906
_Example of stacktrace: https://gist.github.com/azat/96a015046ebe72ddcb59bc89ca91a20e_