### PR TITLE
ci: use tmpfs for temporary ClickHouse files

### DIFF
--- a/tests/ci/ast_fuzzer_check.py
+++ b/tests/ci/ast_fuzzer_check.py
@@ -40,6 +40,7 @@ def get_run_command(
         "--privileged "
         "--network=host "
         f"{ci_logs_args}"
+        "--tmpfs /tmp/clickhouse "
         f"--volume={workspace_path}:/workspace "
         f"{env_str} "
         "--cap-add syslog --cap-add sys_admin --cap-add=SYS_PTRACE "

--- a/tests/ci/fast_test_check.py
+++ b/tests/ci/fast_test_check.py
@@ -37,6 +37,7 @@ def get_fasttest_cmd(
         f"-e COPY_CLICKHOUSE_BINARY_TO_OUTPUT=1 "
         f"-e SCCACHE_BUCKET={S3_BUILDS_BUCKET} -e SCCACHE_S3_KEY_PREFIX=ccache/sccache "
         "-e stage=clone_submodules "
+        "--tmpfs /tmp/clickhouse "
         f"--volume={workspace}:/fasttest-workspace --volume={repo_path}:/repo "
         f"--volume={output_path}:/test_output {image} /repo/tests/docker_scripts/fasttest_runner.sh"
     )

--- a/tests/ci/functional_test_check.py
+++ b/tests/ci/functional_test_check.py
@@ -133,6 +133,7 @@ def get_run_command(
         # For dmesg and sysctl
         "--privileged "
         f"{ci_logs_args} "
+        "--tmpfs /tmp/clickhouse "
         f"--volume={repo_path}:/repo "
         f"--volume={result_path}:/test_output "
         f"--volume={server_log_path}:/var/log/clickhouse-server "

--- a/tests/ci/sqllogic_test.py
+++ b/tests/ci/sqllogic_test.py
@@ -38,6 +38,7 @@ def get_run_command(
 ) -> str:
     return (
         f"docker run "
+        "--tmpfs /tmp/clickhouse "
         f"--volume={builds_path}:/package_folder "
         f"--volume={repo_path}:/repo "
         f"--volume={result_path}:/test_output "

--- a/tests/ci/stress_check.py
+++ b/tests/ci/stress_check.py
@@ -75,6 +75,7 @@ def get_run_command(
         # a static link, don't use S3_URL or S3_DOWNLOAD
         "-e S3_URL='https://s3.amazonaws.com/clickhouse-datasets' "
         f"{ci_logs_args}"
+        "--tmpfs /tmp/clickhouse "
         f"--volume={build_path}:/package_folder "
         f"--volume={result_path}:/test_output "
         f"--volume={repo_tests_path}/..:/repo "

--- a/tests/config/config.d/tmp.xml
+++ b/tests/config/config.d/tmp.xml
@@ -1,0 +1,3 @@
+<clickhouse>
+    <tmp_path>/tmp/clickhouse</tmp_path>
+</clickhouse>

--- a/tests/config/install.sh
+++ b/tests/config/install.sh
@@ -32,6 +32,7 @@ mkdir -p $DEST_SERVER_PATH/config.d/
 mkdir -p $DEST_SERVER_PATH/users.d/
 mkdir -p $DEST_CLIENT_PATH
 
+ln -sf $SRC_PATH/config.d/tmp.xml $DEST_SERVER_PATH/config.d/
 ln -sf $SRC_PATH/config.d/zookeeper_write.xml $DEST_SERVER_PATH/config.d/
 ln -sf $SRC_PATH/config.d/max_num_to_warn.xml $DEST_SERVER_PATH/config.d/
 ln -sf $SRC_PATH/config.d/listen.xml $DEST_SERVER_PATH/config.d/


### PR DESCRIPTION
Some tests can be flaky due to very slow disks [1]:

    2024.12.08 23:41:38.215684 [ 436 ] {168c6479-53fd-4946-8475-1adc0ba4dedb} <Debug> executeQuery: (from [::1]:38036) (comment: 00110_external_sort.sql) -- { echoOn }
     SELECT number FROM (SELECT number FROM system.numbers LIMIT 10000000) ORDER BY number * 1234567890123456789 LIMIT 9999990, 10 SETTINGS max_memory_usage='300Mi', max_bytes_before_external_sort='20M', min_external_sort_block_bytes='70M'; (stage: Complete)
    2024.12.08 23:41:40.203353 [ 2005 ] {168c6479-53fd-4946-8475-1adc0ba4dedb} <Trace> MergeSortingTransform: Will dump sorting block to disk (66.75 MiB > 19.07 MiB)
    2024.12.08 23:41:40.204872 [ 2005 ] {168c6479-53fd-4946-8475-1adc0ba4dedb} <Trace> TemporaryFileOnLocalDisk: Creating temporary file 'tmp50027017-924a-4723-83a3-221e37c78e69'
    2024.12.08 23:41:40.205973 [ 2005 ] {168c6479-53fd-4946-8475-1adc0ba4dedb} <Trace> DiskLocal: Reserved 66.78 MiB on local disk `_tmp_default`, having unreserved 125.12 GiB.
    2024.12.08 23:41:40.208425 [ 2005 ] {168c6479-53fd-4946-8475-1adc0ba4dedb} <Information> MergeSortingTransform: Sorting and writing part of data into temporary file disk(_tmp_default):///var/lib/clickhouse/tmp//tmp50027017-924a-4723-83a3-221e37c78e69
    2024.12.08 23:43:09.177947 [ 2005 ] {168c6479-53fd-4946-8475-1adc0ba4dedb} <Information> MergeSortingTransform: Done writing part of data into temporary file disk(_tmp_default):///var/lib/clickhouse/tmp//tmp50027017-924a-4723-83a3-221e37c78e69, compressed 55.08 MiB, uncompressed 69.88 MiB

Here it takes 2 minutes to write 55 MiB

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/72598/90ec40e2c1c07e8627619c8d3fbf1a298560fc11/stateless_tests_flaky_check__asan_.html

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
