### PR TITLE
Better IAST::format() interface

### DIFF
--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -635,11 +635,11 @@ try
                 if (is_interactive && is_default_format)
                     current_format = "TabSeparated";
             }
-            if (query_with_output->format != nullptr)
+            if (query_with_output->format_ast != nullptr)
             {
                 if (has_vertical_output_suffix)
                     throw Exception(ErrorCodes::CLIENT_OUTPUT_FORMAT_SPECIFIED, "Output format already specified");
-                const auto & id = query_with_output->format->as<ASTIdentifier &>();
+                const auto & id = query_with_output->format_ast->as<ASTIdentifier &>();
                 current_format = id.name();
             }
             else if (query_with_output->out_file)

--- a/src/Databases/DatabasesCommon.cpp
+++ b/src/Databases/DatabasesCommon.cpp
@@ -293,7 +293,7 @@ void cleanupObjectDefinitionFromTemporaryFlags(ASTCreateQuery & query)
     if (!query.isView())
         query.select = nullptr;
 
-    query.format = nullptr;
+    query.format_ast = nullptr;
     query.out_file = nullptr;
 }
 

--- a/src/Interpreters/NormalizeSelectWithUnionQueryVisitor.cpp
+++ b/src/Interpreters/NormalizeSelectWithUnionQueryVisitor.cpp
@@ -32,9 +32,9 @@ void NormalizeSelectWithUnionQueryMatcher::visit(ASTPtr & ast, Data & data)
     {
         /// The rewrite of ASTSelectWithUnionQuery may strip the format info, so
         /// we need to keep and restore it.
-        auto format = select_union->format;
+        auto format = select_union->format_ast;
         visit(*select_union, data);
-        select_union->format = format;
+        select_union->format_ast = format;
     }
 }
 

--- a/src/Interpreters/SystemLog.cpp
+++ b/src/Interpreters/SystemLog.cpp
@@ -88,6 +88,7 @@ namespace
             throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Method clone is not supported");
         }
 
+    protected:
         void formatImpl(WriteBuffer &, const FormatSettings &, FormatState &, FormatStateStacked) const override
         {
             throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Method formatImpl is not supported");

--- a/src/Interpreters/executeQuery.cpp
+++ b/src/Interpreters/executeQuery.cpp
@@ -1536,8 +1536,8 @@ std::pair<ASTPtr, BlockIO> executeQuery(
 
     if (const auto * ast_query_with_output = dynamic_cast<const ASTQueryWithOutput *>(ast.get()))
     {
-        String format_name = ast_query_with_output->format
-                ? getIdentifierName(ast_query_with_output->format)
+        String format_name = ast_query_with_output->format_ast
+                ? getIdentifierName(ast_query_with_output->format_ast)
                 : context->getDefaultFormat();
 
         if (boost::iequals(format_name, "Null"))
@@ -1747,8 +1747,8 @@ void executeQuery(
                     /* zstd_window_log = */ static_cast<int>(settings[Setting::output_format_compression_zstd_window_log]));
             }
 
-            format_name = ast_query_with_output && (ast_query_with_output->format != nullptr)
-                                    ? getIdentifierName(ast_query_with_output->format)
+            format_name = ast_query_with_output && (ast_query_with_output->format_ast != nullptr)
+                                    ? getIdentifierName(ast_query_with_output->format_ast)
                                     : context->getDefaultFormat();
 
             output_format = FormatFactory::instance().getOutputFormatParallelIfPossible(

--- a/src/Parsers/ASTAlterNamedCollectionQuery.h
+++ b/src/Parsers/ASTAlterNamedCollectionQuery.h
@@ -21,11 +21,12 @@ public:
 
     ASTPtr clone() const override;
 
-    void formatImpl(WriteBuffer & ostr, const FormatSettings & s, FormatState & state, FormatStateStacked frame) const override;
-
     ASTPtr getRewrittenASTWithoutOnCluster(const WithoutOnClusterASTRewriteParams &) const override { return removeOnCluster<ASTAlterNamedCollectionQuery>(clone()); }
 
     QueryKind getQueryKind() const override { return QueryKind::Alter; }
+
+protected:
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & s, FormatState & state, FormatStateStacked frame) const override;
 };
 
 }

--- a/src/Parsers/ASTAlterQuery.cpp
+++ b/src/Parsers/ASTAlterQuery.cpp
@@ -82,32 +82,32 @@ void ASTAlterCommand::formatImpl(WriteBuffer & ostr, const FormatSettings & sett
     {
         ostr << (settings.hilite ? hilite_keyword : "") << "ADD COLUMN " << (if_not_exists ? "IF NOT EXISTS " : "")
                       << (settings.hilite ? hilite_none : "");
-        col_decl->formatImpl(ostr, settings, state, frame);
+        col_decl->format(ostr, settings, state, frame);
 
         if (first)
             ostr << (settings.hilite ? hilite_keyword : "") << " FIRST " << (settings.hilite ? hilite_none : "");
         else if (column) /// AFTER
         {
             ostr << (settings.hilite ? hilite_keyword : "") << " AFTER " << (settings.hilite ? hilite_none : "");
-            column->formatImpl(ostr, settings, state, frame);
+            column->format(ostr, settings, state, frame);
         }
     }
     else if (type == ASTAlterCommand::DROP_COLUMN)
     {
         ostr << (settings.hilite ? hilite_keyword : "") << (clear_column ? "CLEAR " : "DROP ") << "COLUMN "
                       << (if_exists ? "IF EXISTS " : "") << (settings.hilite ? hilite_none : "");
-        column->formatImpl(ostr, settings, state, frame);
+        column->format(ostr, settings, state, frame);
         if (partition)
         {
             ostr << (settings.hilite ? hilite_keyword : "") << " IN PARTITION " << (settings.hilite ? hilite_none : "");
-            partition->formatImpl(ostr, settings, state, frame);
+            partition->format(ostr, settings, state, frame);
         }
     }
     else if (type == ASTAlterCommand::MODIFY_COLUMN)
     {
         ostr << (settings.hilite ? hilite_keyword : "") << "MODIFY COLUMN " << (if_exists ? "IF EXISTS " : "")
                       << (settings.hilite ? hilite_none : "");
-        col_decl->formatImpl(ostr, settings, state, frame);
+        col_decl->format(ostr, settings, state, frame);
 
         if (!remove_property.empty())
         {
@@ -116,12 +116,12 @@ void ASTAlterCommand::formatImpl(WriteBuffer & ostr, const FormatSettings & sett
         else if (settings_changes)
         {
             ostr << (settings.hilite ? hilite_keyword : "") << " MODIFY SETTING " << (settings.hilite ? hilite_none : "");
-            settings_changes->formatImpl(ostr, settings, state, frame);
+            settings_changes->format(ostr, settings, state, frame);
         }
         else if (settings_resets)
         {
             ostr << (settings.hilite ? hilite_keyword : "") << " RESET SETTING " << (settings.hilite ? hilite_none : "");
-            settings_resets->formatImpl(ostr, settings, state, frame);
+            settings_resets->format(ostr, settings, state, frame);
         }
         else
         {
@@ -130,43 +130,43 @@ void ASTAlterCommand::formatImpl(WriteBuffer & ostr, const FormatSettings & sett
             else if (column) /// AFTER
             {
                 ostr << (settings.hilite ? hilite_keyword : "") << " AFTER " << (settings.hilite ? hilite_none : "");
-                column->formatImpl(ostr, settings, state, frame);
+                column->format(ostr, settings, state, frame);
             }
         }
     }
     else if (type == ASTAlterCommand::MATERIALIZE_COLUMN)
     {
         ostr << (settings.hilite ? hilite_keyword : "") << "MATERIALIZE COLUMN " << (settings.hilite ? hilite_none : "");
-        column->formatImpl(ostr, settings, state, frame);
+        column->format(ostr, settings, state, frame);
         if (partition)
         {
             ostr << (settings.hilite ? hilite_keyword : "") << " IN PARTITION " << (settings.hilite ? hilite_none : "");
-            partition->formatImpl(ostr, settings, state, frame);
+            partition->format(ostr, settings, state, frame);
         }
     }
     else if (type == ASTAlterCommand::COMMENT_COLUMN)
     {
         ostr << (settings.hilite ? hilite_keyword : "") << "COMMENT COLUMN " << (if_exists ? "IF EXISTS " : "")
                       << (settings.hilite ? hilite_none : "");
-        column->formatImpl(ostr, settings, state, frame);
+        column->format(ostr, settings, state, frame);
         ostr << " " << (settings.hilite ? hilite_none : "");
-        comment->formatImpl(ostr, settings, state, frame);
+        comment->format(ostr, settings, state, frame);
     }
     else if (type == ASTAlterCommand::MODIFY_COMMENT)
     {
         ostr << (settings.hilite ? hilite_keyword : "") << "MODIFY COMMENT" << (settings.hilite ? hilite_none : "");
         ostr << " " << (settings.hilite ? hilite_none : "");
-        comment->formatImpl(ostr, settings, state, frame);
+        comment->format(ostr, settings, state, frame);
     }
     else if (type == ASTAlterCommand::MODIFY_ORDER_BY)
     {
         ostr << (settings.hilite ? hilite_keyword : "") << "MODIFY ORDER BY " << (settings.hilite ? hilite_none : "");
-        order_by->formatImpl(ostr, settings, state, frame);
+        order_by->format(ostr, settings, state, frame);
     }
     else if (type == ASTAlterCommand::MODIFY_SAMPLE_BY)
     {
         ostr << (settings.hilite ? hilite_keyword : "") << "MODIFY SAMPLE BY " << (settings.hilite ? hilite_none : "");
-        sample_by->formatImpl(ostr, settings, state, frame);
+        sample_by->format(ostr, settings, state, frame);
     }
     else if (type == ASTAlterCommand::REMOVE_SAMPLE_BY)
     {
@@ -176,146 +176,146 @@ void ASTAlterCommand::formatImpl(WriteBuffer & ostr, const FormatSettings & sett
     {
         ostr << (settings.hilite ? hilite_keyword : "") << "ADD INDEX " << (if_not_exists ? "IF NOT EXISTS " : "")
                       << (settings.hilite ? hilite_none : "");
-        index_decl->formatImpl(ostr, settings, state, frame);
+        index_decl->format(ostr, settings, state, frame);
 
         if (first)
             ostr << (settings.hilite ? hilite_keyword : "") << " FIRST " << (settings.hilite ? hilite_none : "");
         else if (index) /// AFTER
         {
             ostr << (settings.hilite ? hilite_keyword : "") << " AFTER " << (settings.hilite ? hilite_none : "");
-            index->formatImpl(ostr, settings, state, frame);
+            index->format(ostr, settings, state, frame);
         }
     }
     else if (type == ASTAlterCommand::DROP_INDEX)
     {
         ostr << (settings.hilite ? hilite_keyword : "") << (clear_index ? "CLEAR " : "DROP ") << "INDEX "
                       << (if_exists ? "IF EXISTS " : "") << (settings.hilite ? hilite_none : "");
-        index->formatImpl(ostr, settings, state, frame);
+        index->format(ostr, settings, state, frame);
         if (partition)
         {
             ostr << (settings.hilite ? hilite_keyword : "") << " IN PARTITION " << (settings.hilite ? hilite_none : "");
-            partition->formatImpl(ostr, settings, state, frame);
+            partition->format(ostr, settings, state, frame);
         }
     }
     else if (type == ASTAlterCommand::MATERIALIZE_INDEX)
     {
         ostr << (settings.hilite ? hilite_keyword : "") << "MATERIALIZE INDEX " << (settings.hilite ? hilite_none : "");
-        index->formatImpl(ostr, settings, state, frame);
+        index->format(ostr, settings, state, frame);
         if (partition)
         {
             ostr << (settings.hilite ? hilite_keyword : "") << " IN PARTITION " << (settings.hilite ? hilite_none : "");
-            partition->formatImpl(ostr, settings, state, frame);
+            partition->format(ostr, settings, state, frame);
         }
     }
     else if (type == ASTAlterCommand::ADD_STATISTICS)
     {
         ostr << (settings.hilite ? hilite_keyword : "") << "ADD STATISTICS " << (if_not_exists ? "IF NOT EXISTS " : "")
                       << (settings.hilite ? hilite_none : "");
-        statistics_decl->formatImpl(ostr, settings, state, frame);
+        statistics_decl->format(ostr, settings, state, frame);
     }
     else if (type == ASTAlterCommand::MODIFY_STATISTICS)
     {
         ostr << (settings.hilite ? hilite_keyword : "") << "MODIFY STATISTICS "
                       << (settings.hilite ? hilite_none : "");
-        statistics_decl->formatImpl(ostr, settings, state, frame);
+        statistics_decl->format(ostr, settings, state, frame);
     }
     else if (type == ASTAlterCommand::DROP_STATISTICS)
     {
         ostr << (settings.hilite ? hilite_keyword : "") << (clear_statistics ? "CLEAR " : "DROP ") << "STATISTICS "
                       << (if_exists ? "IF EXISTS " : "") << (settings.hilite ? hilite_none : "");
-        statistics_decl->formatImpl(ostr, settings, state, frame);
+        statistics_decl->format(ostr, settings, state, frame);
         if (partition)
         {
             ostr << (settings.hilite ? hilite_keyword : "") << " IN PARTITION " << (settings.hilite ? hilite_none : "");
-            partition->formatImpl(ostr, settings, state, frame);
+            partition->format(ostr, settings, state, frame);
         }
     }
     else if (type == ASTAlterCommand::MATERIALIZE_STATISTICS)
     {
         ostr << (settings.hilite ? hilite_keyword : "") << "MATERIALIZE STATISTICS " << (settings.hilite ? hilite_none : "");
-        statistics_decl->formatImpl(ostr, settings, state, frame);
+        statistics_decl->format(ostr, settings, state, frame);
         if (partition)
         {
             ostr << (settings.hilite ? hilite_keyword : "") << " IN PARTITION " << (settings.hilite ? hilite_none : "");
-            partition->formatImpl(ostr, settings, state, frame);
+            partition->format(ostr, settings, state, frame);
         }
     }
     else if (type == ASTAlterCommand::ADD_CONSTRAINT)
     {
         ostr << (settings.hilite ? hilite_keyword : "") << "ADD CONSTRAINT " << (if_not_exists ? "IF NOT EXISTS " : "")
                       << (settings.hilite ? hilite_none : "");
-        constraint_decl->formatImpl(ostr, settings, state, frame);
+        constraint_decl->format(ostr, settings, state, frame);
     }
     else if (type == ASTAlterCommand::DROP_CONSTRAINT)
     {
         ostr << (settings.hilite ? hilite_keyword : "") << "DROP CONSTRAINT " << (if_exists ? "IF EXISTS " : "")
                       << (settings.hilite ? hilite_none : "");
-        constraint->formatImpl(ostr, settings, state, frame);
+        constraint->format(ostr, settings, state, frame);
     }
     else if (type == ASTAlterCommand::ADD_PROJECTION)
     {
         ostr << (settings.hilite ? hilite_keyword : "") << "ADD PROJECTION " << (if_not_exists ? "IF NOT EXISTS " : "")
                       << (settings.hilite ? hilite_none : "");
-        projection_decl->formatImpl(ostr, settings, state, frame);
+        projection_decl->format(ostr, settings, state, frame);
 
         if (first)
             ostr << (settings.hilite ? hilite_keyword : "") << " FIRST " << (settings.hilite ? hilite_none : "");
         else if (projection)
         {
             ostr << (settings.hilite ? hilite_keyword : "") << " AFTER " << (settings.hilite ? hilite_none : "");
-            projection->formatImpl(ostr, settings, state, frame);
+            projection->format(ostr, settings, state, frame);
         }
     }
     else if (type == ASTAlterCommand::DROP_PROJECTION)
     {
         ostr << (settings.hilite ? hilite_keyword : "") << (clear_projection ? "CLEAR " : "DROP ") << "PROJECTION "
                       << (if_exists ? "IF EXISTS " : "") << (settings.hilite ? hilite_none : "");
-        projection->formatImpl(ostr, settings, state, frame);
+        projection->format(ostr, settings, state, frame);
         if (partition)
         {
             ostr << (settings.hilite ? hilite_keyword : "") << " IN PARTITION " << (settings.hilite ? hilite_none : "");
-            partition->formatImpl(ostr, settings, state, frame);
+            partition->format(ostr, settings, state, frame);
         }
     }
     else if (type == ASTAlterCommand::MATERIALIZE_PROJECTION)
     {
         ostr << (settings.hilite ? hilite_keyword : "") << "MATERIALIZE PROJECTION " << (settings.hilite ? hilite_none : "");
-        projection->formatImpl(ostr, settings, state, frame);
+        projection->format(ostr, settings, state, frame);
         if (partition)
         {
             ostr << (settings.hilite ? hilite_keyword : "") << " IN PARTITION " << (settings.hilite ? hilite_none : "");
-            partition->formatImpl(ostr, settings, state, frame);
+            partition->format(ostr, settings, state, frame);
         }
     }
     else if (type == ASTAlterCommand::DROP_PARTITION)
     {
         ostr << (settings.hilite ? hilite_keyword : "") << (detach ? "DETACH" : "DROP") << (part ? " PART " : " PARTITION ")
                       << (settings.hilite ? hilite_none : "");
-        partition->formatImpl(ostr, settings, state, frame);
+        partition->format(ostr, settings, state, frame);
     }
     else if (type == ASTAlterCommand::DROP_DETACHED_PARTITION)
     {
         ostr << (settings.hilite ? hilite_keyword : "") << "DROP DETACHED" << (part ? " PART " : " PARTITION ")
                       << (settings.hilite ? hilite_none : "");
-        partition->formatImpl(ostr, settings, state, frame);
+        partition->format(ostr, settings, state, frame);
     }
     else if (type == ASTAlterCommand::FORGET_PARTITION)
     {
         ostr << (settings.hilite ? hilite_keyword : "") << "FORGET PARTITION "
                       << (settings.hilite ? hilite_none : "");
-        partition->formatImpl(ostr, settings, state, frame);
+        partition->format(ostr, settings, state, frame);
     }
     else if (type == ASTAlterCommand::ATTACH_PARTITION)
     {
         ostr << (settings.hilite ? hilite_keyword : "") << "ATTACH " << (part ? "PART " : "PARTITION ")
                       << (settings.hilite ? hilite_none : "");
-        partition->formatImpl(ostr, settings, state, frame);
+        partition->format(ostr, settings, state, frame);
     }
     else if (type == ASTAlterCommand::MOVE_PARTITION)
     {
         ostr << (settings.hilite ? hilite_keyword : "") << "MOVE " << (part ? "PART " : "PARTITION ")
                       << (settings.hilite ? hilite_none : "");
-        partition->formatImpl(ostr, settings, state, frame);
+        partition->format(ostr, settings, state, frame);
         ostr << " TO ";
         switch (move_destination_type)
         {
@@ -347,7 +347,7 @@ void ASTAlterCommand::formatImpl(WriteBuffer & ostr, const FormatSettings & sett
     {
         ostr << (settings.hilite ? hilite_keyword : "") << (replace ? "REPLACE" : "ATTACH") << " PARTITION "
                       << (settings.hilite ? hilite_none : "");
-        partition->formatImpl(ostr, settings, state, frame);
+        partition->format(ostr, settings, state, frame);
         ostr << (settings.hilite ? hilite_keyword : "") << " FROM " << (settings.hilite ? hilite_none : "");
         if (!from_database.empty())
         {
@@ -360,13 +360,13 @@ void ASTAlterCommand::formatImpl(WriteBuffer & ostr, const FormatSettings & sett
     {
         ostr << (settings.hilite ? hilite_keyword : "") << "FETCH " << (part ? "PART " : "PARTITION ")
                       << (settings.hilite ? hilite_none : "");
-        partition->formatImpl(ostr, settings, state, frame);
+        partition->format(ostr, settings, state, frame);
         ostr << (settings.hilite ? hilite_keyword : "") << " FROM " << (settings.hilite ? hilite_none : "") << DB::quote << from;
     }
     else if (type == ASTAlterCommand::FREEZE_PARTITION)
     {
         ostr << (settings.hilite ? hilite_keyword : "") << "FREEZE PARTITION " << (settings.hilite ? hilite_none : "");
-        partition->formatImpl(ostr, settings, state, frame);
+        partition->format(ostr, settings, state, frame);
 
         if (!with_name.empty())
         {
@@ -387,7 +387,7 @@ void ASTAlterCommand::formatImpl(WriteBuffer & ostr, const FormatSettings & sett
     else if (type == ASTAlterCommand::UNFREEZE_PARTITION)
     {
         ostr << (settings.hilite ? hilite_keyword : "") << "UNFREEZE PARTITION " << (settings.hilite ? hilite_none : "");
-        partition->formatImpl(ostr, settings, state, frame);
+        partition->format(ostr, settings, state, frame);
 
         if (!with_name.empty())
         {
@@ -412,30 +412,30 @@ void ASTAlterCommand::formatImpl(WriteBuffer & ostr, const FormatSettings & sett
         if (partition)
         {
             ostr << (settings.hilite ? hilite_keyword : "") << " IN PARTITION " << (settings.hilite ? hilite_none : "");
-            partition->formatImpl(ostr, settings, state, frame);
+            partition->format(ostr, settings, state, frame);
         }
 
         ostr << (settings.hilite ? hilite_keyword : "") << " WHERE " << (settings.hilite ? hilite_none : "");
-        predicate->formatImpl(ostr, settings, state, frame);
+        predicate->format(ostr, settings, state, frame);
     }
     else if (type == ASTAlterCommand::UPDATE)
     {
         ostr << (settings.hilite ? hilite_keyword : "") << "UPDATE " << (settings.hilite ? hilite_none : "");
-        update_assignments->formatImpl(ostr, settings, state, frame);
+        update_assignments->format(ostr, settings, state, frame);
 
         if (partition)
         {
             ostr << (settings.hilite ? hilite_keyword : "") << " IN PARTITION " << (settings.hilite ? hilite_none : "");
-            partition->formatImpl(ostr, settings, state, frame);
+            partition->format(ostr, settings, state, frame);
         }
 
         ostr << (settings.hilite ? hilite_keyword : "") << " WHERE " << (settings.hilite ? hilite_none : "");
-        predicate->formatImpl(ostr, settings, state, frame);
+        predicate->format(ostr, settings, state, frame);
     }
     else if (type == ASTAlterCommand::MODIFY_TTL)
     {
         ostr << (settings.hilite ? hilite_keyword : "") << "MODIFY TTL " << (settings.hilite ? hilite_none : "");
-        ttl->formatImpl(ostr, settings, state, frame);
+        ttl->format(ostr, settings, state, frame);
     }
     else if (type == ASTAlterCommand::REMOVE_TTL)
     {
@@ -447,49 +447,49 @@ void ASTAlterCommand::formatImpl(WriteBuffer & ostr, const FormatSettings & sett
         if (partition)
         {
             ostr << (settings.hilite ? hilite_keyword : "") << " IN PARTITION " << (settings.hilite ? hilite_none : "");
-            partition->formatImpl(ostr, settings, state, frame);
+            partition->format(ostr, settings, state, frame);
         }
     }
     else if (type == ASTAlterCommand::MODIFY_SETTING)
     {
         ostr << (settings.hilite ? hilite_keyword : "") << "MODIFY SETTING " << (settings.hilite ? hilite_none : "");
-        settings_changes->formatImpl(ostr, settings, state, frame);
+        settings_changes->format(ostr, settings, state, frame);
     }
     else if (type == ASTAlterCommand::RESET_SETTING)
     {
         ostr << (settings.hilite ? hilite_keyword : "") << "RESET SETTING " << (settings.hilite ? hilite_none : "");
-        settings_resets->formatImpl(ostr, settings, state, frame);
+        settings_resets->format(ostr, settings, state, frame);
     }
     else if (type == ASTAlterCommand::MODIFY_DATABASE_SETTING)
     {
         ostr << (settings.hilite ? hilite_keyword : "") << "MODIFY SETTING " << (settings.hilite ? hilite_none : "");
-        settings_changes->formatImpl(ostr, settings, state, frame);
+        settings_changes->format(ostr, settings, state, frame);
     }
     else if (type == ASTAlterCommand::MODIFY_QUERY)
     {
         ostr << (settings.hilite ? hilite_keyword : "") << "MODIFY QUERY" << settings.nl_or_ws
                       << (settings.hilite ? hilite_none : "");
-        select->formatImpl(ostr, settings, state, frame);
+        select->format(ostr, settings, state, frame);
     }
     else if (type == ASTAlterCommand::MODIFY_REFRESH)
     {
         ostr << (settings.hilite ? hilite_keyword : "") << "MODIFY" << settings.nl_or_ws
                       << (settings.hilite ? hilite_none : "");
-        refresh->formatImpl(ostr, settings, state, frame);
+        refresh->format(ostr, settings, state, frame);
     }
     else if (type == ASTAlterCommand::RENAME_COLUMN)
     {
         ostr << (settings.hilite ? hilite_keyword : "") << "RENAME COLUMN " << (if_exists ? "IF EXISTS " : "")
                       << (settings.hilite ? hilite_none : "");
-        column->formatImpl(ostr, settings, state, frame);
+        column->format(ostr, settings, state, frame);
 
         ostr << (settings.hilite ? hilite_keyword : "") << " TO ";
-        rename_to->formatImpl(ostr, settings, state, frame);
+        rename_to->format(ostr, settings, state, frame);
     }
     else if (type == ASTAlterCommand::MODIFY_SQL_SECURITY)
     {
         ostr << (settings.hilite ? hilite_keyword : "") << "MODIFY " << (settings.hilite ? hilite_none : "");
-        sql_security->formatImpl(ostr, settings, state, frame);
+        sql_security->format(ostr, settings, state, frame);
     }
     else if (type == ASTAlterCommand::APPLY_DELETED_MASK)
     {
@@ -498,7 +498,7 @@ void ASTAlterCommand::formatImpl(WriteBuffer & ostr, const FormatSettings & sett
         if (partition)
         {
             ostr << (settings.hilite ? hilite_keyword : "") << " IN PARTITION " << (settings.hilite ? hilite_none : "");
-            partition->formatImpl(ostr, settings, state, frame);
+            partition->format(ostr, settings, state, frame);
         }
     }
     else
@@ -641,17 +641,17 @@ void ASTAlterQuery::formatQueryImpl(WriteBuffer & ostr, const FormatSettings & s
         ostr << indent_str;
         if (database)
         {
-            database->formatImpl(ostr, settings, state, frame);
+            database->format(ostr, settings, state, frame);
             ostr << '.';
         }
 
         chassert(table);
-        table->formatImpl(ostr, settings, state, frame);
+        table->format(ostr, settings, state, frame);
     }
     else if (alter_object == AlterObjectType::DATABASE && database)
     {
         ostr << indent_str;
-        database->formatImpl(ostr, settings, state, frame);
+        database->format(ostr, settings, state, frame);
     }
 
     formatOnCluster(ostr, settings);
@@ -661,7 +661,7 @@ void ASTAlterQuery::formatQueryImpl(WriteBuffer & ostr, const FormatSettings & s
     if (settings.one_line)
     {
         frame_nested.expression_list_prepend_whitespace = true;
-        command_list->formatImpl(ostr, settings, state, frame_nested);
+        command_list->format(ostr, settings, state, frame_nested);
     }
     else
     {

--- a/src/Parsers/ASTAssignment.h
+++ b/src/Parsers/ASTAssignment.h
@@ -35,7 +35,7 @@ protected:
 
         ostr << (settings.hilite ? hilite_operator : "") << " = " << (settings.hilite ? hilite_none : "");
 
-        expression()->formatImpl(ostr, settings, state, frame);
+        expression()->format(ostr, settings, state, frame);
     }
 };
 

--- a/src/Parsers/ASTAsterisk.cpp
+++ b/src/Parsers/ASTAsterisk.cpp
@@ -31,7 +31,7 @@ void ASTAsterisk::formatImpl(WriteBuffer & ostr, const FormatSettings & settings
 {
     if (expression)
     {
-        expression->formatImpl(ostr, settings, state, frame);
+        expression->format(ostr, settings, state, frame);
         ostr << ".";
     }
 
@@ -39,7 +39,7 @@ void ASTAsterisk::formatImpl(WriteBuffer & ostr, const FormatSettings & settings
 
     if (transformers)
     {
-        transformers->formatImpl(ostr, settings, state, frame);
+        transformers->format(ostr, settings, state, frame);
     }
 }
 

--- a/src/Parsers/ASTAsterisk.h
+++ b/src/Parsers/ASTAsterisk.h
@@ -18,6 +18,7 @@ public:
 
     ASTPtr expression;
     ASTPtr transformers;
+
 protected:
     void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
 };

--- a/src/Parsers/ASTCheckQuery.h
+++ b/src/Parsers/ASTCheckQuery.h
@@ -45,18 +45,18 @@ protected:
         {
             if (database)
             {
-                database->formatImpl(ostr, settings, state, frame);
+                database->format(ostr, settings, state, frame);
                 ostr << '.';
             }
 
             chassert(table);
-            table->formatImpl(ostr, settings, state, frame);
+            table->format(ostr, settings, state, frame);
         }
 
         if (partition)
         {
             ostr << (settings.hilite ? hilite_keyword : "") << indent_str << " PARTITION " << (settings.hilite ? hilite_none : "");
-            partition->formatImpl(ostr, settings, state, frame);
+            partition->format(ostr, settings, state, frame);
         }
 
         if (!part_name.empty())

--- a/src/Parsers/ASTCollation.cpp
+++ b/src/Parsers/ASTCollation.cpp
@@ -12,7 +12,7 @@ namespace DB
     void ASTCollation::formatImpl(WriteBuffer & ostr, const FormatSettings &s, FormatState &state, FormatStateStacked frame) const
     {
         if (collation)
-            collation->formatImpl(ostr, s, state, frame);
+            collation->format(ostr, s, state, frame);
     }
 
 }

--- a/src/Parsers/ASTCollation.h
+++ b/src/Parsers/ASTCollation.h
@@ -14,6 +14,7 @@ public:
 
     ASTPtr clone() const override;
 
+protected:
     void formatImpl(WriteBuffer & ostr, const FormatSettings & s, FormatState & state, FormatStateStacked frame) const override;
 };
 

--- a/src/Parsers/ASTColumnDeclaration.cpp
+++ b/src/Parsers/ASTColumnDeclaration.cpp
@@ -71,7 +71,7 @@ void ASTColumnDeclaration::formatImpl(WriteBuffer & ostr, const FormatSettings &
     if (type)
     {
         ostr << ' ';
-        type->formatImpl(ostr, format_settings, state, frame);
+        type->format(ostr, format_settings, state, frame);
     }
 
     if (null_modifier)
@@ -86,44 +86,44 @@ void ASTColumnDeclaration::formatImpl(WriteBuffer & ostr, const FormatSettings &
         if (!ephemeral_default)
         {
             ostr << ' ';
-            default_expression->formatImpl(ostr, format_settings, state, frame);
+            default_expression->format(ostr, format_settings, state, frame);
         }
     }
 
     if (comment)
     {
         ostr << ' ' << (format_settings.hilite ? hilite_keyword : "") << "COMMENT" << (format_settings.hilite ? hilite_none : "") << ' ';
-        comment->formatImpl(ostr, format_settings, state, frame);
+        comment->format(ostr, format_settings, state, frame);
     }
 
     if (codec)
     {
         ostr << ' ';
-        codec->formatImpl(ostr, format_settings, state, frame);
+        codec->format(ostr, format_settings, state, frame);
     }
 
     if (statistics_desc)
     {
         ostr << ' ';
-        statistics_desc->formatImpl(ostr, format_settings, state, frame);
+        statistics_desc->format(ostr, format_settings, state, frame);
     }
 
     if (ttl)
     {
         ostr << ' ' << (format_settings.hilite ? hilite_keyword : "") << "TTL" << (format_settings.hilite ? hilite_none : "") << ' ';
-        ttl->formatImpl(ostr, format_settings, state, frame);
+        ttl->format(ostr, format_settings, state, frame);
     }
 
     if (collation)
     {
         ostr << ' ' << (format_settings.hilite ? hilite_keyword : "") << "COLLATE" << (format_settings.hilite ? hilite_none : "") << ' ';
-        collation->formatImpl(ostr, format_settings, state, frame);
+        collation->format(ostr, format_settings, state, frame);
     }
 
     if (settings)
     {
         ostr << ' ' << (format_settings.hilite ? hilite_keyword : "") << "SETTINGS" << (format_settings.hilite ? hilite_none : "") << ' ' << '(';
-        settings->formatImpl(ostr, format_settings, state, frame);
+        settings->format(ostr, format_settings, state, frame);
         ostr << ')';
     }
 }

--- a/src/Parsers/ASTColumnDeclaration.h
+++ b/src/Parsers/ASTColumnDeclaration.h
@@ -28,9 +28,9 @@ public:
     String getID(char delim) const override { return "ColumnDeclaration" + (delim + name); }
 
     ASTPtr clone() const override;
-    void formatImpl(WriteBuffer & ostr, const FormatSettings & format_settings, FormatState & state, FormatStateStacked frame) const override;
 
 protected:
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & format_settings, FormatState & state, FormatStateStacked frame) const override;
     void forEachPointerToChild(std::function<void(void **)> f) override;
 };
 

--- a/src/Parsers/ASTColumnsMatcher.cpp
+++ b/src/Parsers/ASTColumnsMatcher.cpp
@@ -45,7 +45,7 @@ void ASTColumnsRegexpMatcher::formatImpl(WriteBuffer & ostr, const FormatSetting
 
     if (expression)
     {
-        expression->formatImpl(ostr, settings, state, frame);
+        expression->format(ostr, settings, state, frame);
         ostr << ".";
     }
 
@@ -55,7 +55,7 @@ void ASTColumnsRegexpMatcher::formatImpl(WriteBuffer & ostr, const FormatSetting
 
     if (transformers)
     {
-        transformers->formatImpl(ostr, settings, state, frame);
+        transformers->format(ostr, settings, state, frame);
     }
 }
 
@@ -107,7 +107,7 @@ void ASTColumnsListMatcher::formatImpl(WriteBuffer & ostr, const FormatSettings 
 
     if (expression)
     {
-        expression->formatImpl(ostr, settings, state, frame);
+        expression->format(ostr, settings, state, frame);
         ostr << ".";
     }
 
@@ -119,13 +119,13 @@ void ASTColumnsListMatcher::formatImpl(WriteBuffer & ostr, const FormatSettings 
         {
             ostr << ", ";
         }
-        (*it)->formatImpl(ostr, settings, state, frame);
+        (*it)->format(ostr, settings, state, frame);
     }
     ostr << ")";
 
     if (transformers)
     {
-        transformers->formatImpl(ostr, settings, state, frame);
+        transformers->format(ostr, settings, state, frame);
     }
 }
 
@@ -171,7 +171,7 @@ void ASTQualifiedColumnsRegexpMatcher::formatImpl(WriteBuffer & ostr, const Form
 {
     ostr << (settings.hilite ? hilite_keyword : "");
 
-    qualifier->formatImpl(ostr, settings, state, frame);
+    qualifier->format(ostr, settings, state, frame);
 
     ostr << ".COLUMNS" << (settings.hilite ? hilite_none : "") << "(";
     ostr << quoteString(pattern);
@@ -179,7 +179,7 @@ void ASTQualifiedColumnsRegexpMatcher::formatImpl(WriteBuffer & ostr, const Form
 
     if (transformers)
     {
-        transformers->formatImpl(ostr, settings, state, frame);
+        transformers->format(ostr, settings, state, frame);
     }
 }
 
@@ -217,7 +217,7 @@ void ASTQualifiedColumnsListMatcher::appendColumnName(WriteBuffer & ostr) const
 void ASTQualifiedColumnsListMatcher::formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
 {
     ostr << (settings.hilite ? hilite_keyword : "");
-    qualifier->formatImpl(ostr, settings, state, frame);
+    qualifier->format(ostr, settings, state, frame);
     ostr << ".COLUMNS" << (settings.hilite ? hilite_none : "") << "(";
 
     for (ASTs::const_iterator it = column_list->children.begin(); it != column_list->children.end(); ++it)
@@ -225,13 +225,13 @@ void ASTQualifiedColumnsListMatcher::formatImpl(WriteBuffer & ostr, const Format
         if (it != column_list->children.begin())
             ostr << ", ";
 
-        (*it)->formatImpl(ostr, settings, state, frame);
+        (*it)->format(ostr, settings, state, frame);
     }
     ostr << ")";
 
     if (transformers)
     {
-        transformers->formatImpl(ostr, settings, state, frame);
+        transformers->format(ostr, settings, state, frame);
     }
 }
 

--- a/src/Parsers/ASTColumnsMatcher.h
+++ b/src/Parsers/ASTColumnsMatcher.h
@@ -24,6 +24,7 @@ public:
 
     ASTPtr expression;
     ASTPtr transformers;
+
 protected:
     void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
 
@@ -42,6 +43,7 @@ public:
     ASTPtr expression;
     ASTPtr column_list;
     ASTPtr transformers;
+
 protected:
     void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
 };
@@ -60,6 +62,7 @@ public:
 
     ASTPtr qualifier;
     ASTPtr transformers;
+
 protected:
     void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
 
@@ -78,6 +81,7 @@ public:
     ASTPtr qualifier;
     ASTPtr column_list;
     ASTPtr transformers;
+
 protected:
     void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
 };

--- a/src/Parsers/ASTColumnsTransformers.cpp
+++ b/src/Parsers/ASTColumnsTransformers.cpp
@@ -25,7 +25,7 @@ void ASTColumnsTransformerList::formatImpl(WriteBuffer & ostr, const FormatSetti
     for (const auto & child : children)
     {
         ostr << ' ';
-        child->formatImpl(ostr, settings, state, frame);
+        child->format(ostr, settings, state, frame);
     }
 }
 
@@ -54,7 +54,7 @@ void ASTColumnsApplyTransformer::formatImpl(WriteBuffer & ostr, const FormatSett
 
     if (lambda)
     {
-        lambda->formatImpl(ostr, settings, state, frame);
+        lambda->format(ostr, settings, state, frame);
     }
     else
     {
@@ -65,7 +65,7 @@ void ASTColumnsApplyTransformer::formatImpl(WriteBuffer & ostr, const FormatSett
             auto nested_frame = frame;
             nested_frame.expression_list_prepend_whitespace = false;
             ostr << "(";
-            parameters->formatImpl(ostr, settings, state, nested_frame);
+            parameters->format(ostr, settings, state, nested_frame);
             ostr << ")";
         }
     }
@@ -177,7 +177,7 @@ void ASTColumnsExceptTransformer::formatImpl(WriteBuffer & ostr, const FormatSet
         {
             ostr << ", ";
         }
-        (*it)->formatImpl(ostr, settings, state, frame);
+        (*it)->format(ostr, settings, state, frame);
     }
 
     if (pattern)
@@ -296,7 +296,7 @@ void ASTColumnsReplaceTransformer::Replacement::formatImpl(
 {
     assert(children.size() == 1);
 
-    children[0]->formatImpl(ostr, settings, state, frame);
+    children[0]->format(ostr, settings, state, frame);
     ostr << (settings.hilite ? hilite_keyword : "") << " AS " << (settings.hilite ? hilite_none : "") << backQuoteIfNeed(name);
 }
 
@@ -329,7 +329,7 @@ void ASTColumnsReplaceTransformer::formatImpl(WriteBuffer & ostr, const FormatSe
         if (it != children.begin())
             ostr << ", ";
 
-        (*it)->formatImpl(ostr, settings, state, frame);
+        (*it)->format(ostr, settings, state, frame);
     }
     ostr << ")";
 }

--- a/src/Parsers/ASTConstraintDeclaration.cpp
+++ b/src/Parsers/ASTConstraintDeclaration.cpp
@@ -23,7 +23,7 @@ void ASTConstraintDeclaration::formatImpl(WriteBuffer & ostr, const FormatSettin
 {
     ostr << backQuoteIfNeed(name);
     ostr << (s.hilite ? hilite_keyword : "") << (type == Type::CHECK ? " CHECK " : " ASSUME ") << (s.hilite ? hilite_none : "");
-    expr->formatImpl(ostr, s, state, frame);
+    expr->format(ostr, s, state, frame);
 }
 
 }

--- a/src/Parsers/ASTConstraintDeclaration.h
+++ b/src/Parsers/ASTConstraintDeclaration.h
@@ -24,12 +24,13 @@ public:
 
     ASTPtr clone() const override;
 
-    void formatImpl(WriteBuffer & ostr, const FormatSettings & s, FormatState & state, FormatStateStacked frame) const override;
-
     void forEachPointerToChild(std::function<void(void**)> f) override
     {
         f(reinterpret_cast<void **>(&expr));
     }
+
+protected:
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & s, FormatState & state, FormatStateStacked frame) const override;
 };
 
 }

--- a/src/Parsers/ASTCreateFunctionQuery.cpp
+++ b/src/Parsers/ASTCreateFunctionQuery.cpp
@@ -40,7 +40,7 @@ void ASTCreateFunctionQuery::formatImpl(WriteBuffer & ostr, const IAST::FormatSe
     formatOnCluster(ostr, settings);
 
     ostr << (settings.hilite ? hilite_keyword : "") << " AS " << (settings.hilite ? hilite_none : "");
-    function_core->formatImpl(ostr, settings, state, frame);
+    function_core->format(ostr, settings, state, frame);
 }
 
 String ASTCreateFunctionQuery::getFunctionName() const

--- a/src/Parsers/ASTCreateFunctionQuery.h
+++ b/src/Parsers/ASTCreateFunctionQuery.h
@@ -20,13 +20,14 @@ public:
 
     ASTPtr clone() const override;
 
-    void formatImpl(WriteBuffer & ostr, const FormatSettings & s, FormatState & state, FormatStateStacked frame) const override;
-
     ASTPtr getRewrittenASTWithoutOnCluster(const WithoutOnClusterASTRewriteParams &) const override { return removeOnCluster<ASTCreateFunctionQuery>(clone()); }
 
     String getFunctionName() const;
 
     QueryKind getQueryKind() const override { return QueryKind::Create; }
+
+protected:
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & s, FormatState & state, FormatStateStacked frame) const override;
 };
 
 }

--- a/src/Parsers/ASTCreateIndexQuery.cpp
+++ b/src/Parsers/ASTCreateIndexQuery.cpp
@@ -39,7 +39,7 @@ void ASTCreateIndexQuery::formatQueryImpl(WriteBuffer & ostr, const FormatSettin
     ostr << (settings.hilite ? hilite_keyword : "") << indent_str;
 
     ostr << "CREATE " << (unique ? "UNIQUE " : "") << "INDEX " << (if_not_exists ? "IF NOT EXISTS " : "");
-    index_name->formatImpl(ostr, settings, state, frame);
+    index_name->format(ostr, settings, state, frame);
     ostr << " ON ";
 
     ostr << (settings.hilite ? hilite_none : "");
@@ -48,19 +48,19 @@ void ASTCreateIndexQuery::formatQueryImpl(WriteBuffer & ostr, const FormatSettin
     {
         if (database)
         {
-            database->formatImpl(ostr, settings, state, frame);
+            database->format(ostr, settings, state, frame);
             ostr << '.';
         }
 
         chassert(table);
-        table->formatImpl(ostr, settings, state, frame);
+        table->format(ostr, settings, state, frame);
     }
 
     formatOnCluster(ostr, settings);
 
     ostr << " ";
 
-    index_decl->formatImpl(ostr, settings, state, frame);
+    index_decl->format(ostr, settings, state, frame);
 }
 
 ASTPtr ASTCreateIndexQuery::convertToASTAlterCommand() const

--- a/src/Parsers/ASTCreateNamedCollectionQuery.h
+++ b/src/Parsers/ASTCreateNamedCollectionQuery.h
@@ -20,13 +20,14 @@ public:
 
     ASTPtr clone() const override;
 
-    void formatImpl(WriteBuffer & ostr, const FormatSettings & s, FormatState & state, FormatStateStacked frame) const override;
-
     ASTPtr getRewrittenASTWithoutOnCluster(const WithoutOnClusterASTRewriteParams &) const override { return removeOnCluster<ASTCreateNamedCollectionQuery>(clone()); }
 
     QueryKind getQueryKind() const override { return QueryKind::Create; }
 
     std::string getCollectionName() const;
+
+protected:
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & s, FormatState & state, FormatStateStacked frame) const override;
 };
 
 }

--- a/src/Parsers/ASTCreateQuery.cpp
+++ b/src/Parsers/ASTCreateQuery.cpp
@@ -24,7 +24,7 @@ void ASTSQLSecurity::formatImpl(WriteBuffer & ostr, const FormatSettings & setti
         ostr << (settings.hilite ? hilite_keyword : "") << "DEFINER" << (settings.hilite ? hilite_none : "");
         ostr << " = ";
         if (definer)
-            definer->formatImpl(ostr, settings, state, frame);
+            definer->format(ostr, settings, state, frame);
         else
             ostr << "CURRENT_USER";
         ostr << " ";
@@ -74,37 +74,37 @@ void ASTStorage::formatImpl(WriteBuffer & ostr, const FormatSettings & s, Format
     if (engine)
     {
         ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << "ENGINE" << (s.hilite ? hilite_none : "") << " = ";
-        engine->formatImpl(ostr, s, state, frame);
+        engine->format(ostr, s, state, frame);
     }
     if (partition_by)
     {
         ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << "PARTITION BY " << (s.hilite ? hilite_none : "");
-        partition_by->formatImpl(ostr, s, state, frame);
+        partition_by->format(ostr, s, state, frame);
     }
     if (primary_key)
     {
         ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << "PRIMARY KEY " << (s.hilite ? hilite_none : "");
-        primary_key->formatImpl(ostr, s, state, frame);
+        primary_key->format(ostr, s, state, frame);
     }
     if (order_by)
     {
         ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << "ORDER BY " << (s.hilite ? hilite_none : "");
-        order_by->formatImpl(ostr, s, state, frame);
+        order_by->format(ostr, s, state, frame);
     }
     if (sample_by)
     {
         ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << "SAMPLE BY " << (s.hilite ? hilite_none : "");
-        sample_by->formatImpl(ostr, s, state, frame);
+        sample_by->format(ostr, s, state, frame);
     }
     if (ttl_table)
     {
         ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << "TTL " << (s.hilite ? hilite_none : "");
-        ttl_table->formatImpl(ostr, s, state, frame);
+        ttl_table->format(ostr, s, state, frame);
     }
     if (settings)
     {
         ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << "SETTINGS " << (s.hilite ? hilite_none : "");
-        settings->formatImpl(ostr, s, state, frame);
+        settings->format(ostr, s, state, frame);
     }
 }
 
@@ -124,12 +124,13 @@ public:
 
     ASTPtr clone() const override;
 
-    void formatImpl(WriteBuffer & ostr, const FormatSettings & s, FormatState & state, FormatStateStacked frame) const override;
-
     void forEachPointerToChild(std::function<void(void**)> f) override
     {
         f(reinterpret_cast<void **>(&elem));
     }
+
+protected:
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & s, FormatState & state, FormatStateStacked frame) const override;
 };
 
 ASTPtr ASTColumnsElement::clone() const
@@ -148,13 +149,13 @@ void ASTColumnsElement::formatImpl(WriteBuffer & ostr, const FormatSettings & s,
 
     if (prefix.empty())
     {
-        elem->formatImpl(ostr, s, state, frame);
+        elem->format(ostr, s, state, frame);
         return;
     }
 
     ostr << (s.hilite ? hilite_keyword : "") << prefix << (s.hilite ? hilite_none : "");
     ostr << ' ';
-    elem->formatImpl(ostr, s, state, frame);
+    elem->format(ostr, s, state, frame);
 }
 
 
@@ -226,7 +227,7 @@ void ASTColumns::formatImpl(WriteBuffer & ostr, const FormatSettings & s, Format
     if (!list.children.empty())
     {
         if (s.one_line)
-            list.formatImpl(ostr, s, state, frame);
+            list.format(ostr, s, state, frame);
         else
             list.formatImplMultiline(ostr, s, state, frame);
     }
@@ -290,7 +291,7 @@ void ASTCreateQuery::formatQueryImpl(WriteBuffer & ostr, const FormatSettings & 
             << (if_not_exists ? "IF NOT EXISTS " : "")
             << (settings.hilite ? hilite_none : "");
 
-        database->formatImpl(ostr, settings, state, frame);
+        database->format(ostr, settings, state, frame);
 
         if (uuid != UUIDHelpers::Nil)
         {
@@ -301,18 +302,18 @@ void ASTCreateQuery::formatQueryImpl(WriteBuffer & ostr, const FormatSettings & 
         formatOnCluster(ostr, settings);
 
         if (storage)
-            storage->formatImpl(ostr, settings, state, frame);
+            storage->format(ostr, settings, state, frame);
 
         if (table_overrides)
         {
             ostr << settings.nl_or_ws;
-            table_overrides->formatImpl(ostr, settings, state, frame);
+            table_overrides->format(ostr, settings, state, frame);
         }
 
         if (comment)
         {
             ostr << (settings.hilite ? hilite_keyword : "") << settings.nl_or_ws << "COMMENT " << (settings.hilite ? hilite_none : "");
-            comment->formatImpl(ostr, settings, state, frame);
+            comment->format(ostr, settings, state, frame);
         }
 
         return;
@@ -349,12 +350,12 @@ void ASTCreateQuery::formatQueryImpl(WriteBuffer & ostr, const FormatSettings & 
 
         if (database)
         {
-            database->formatImpl(ostr, settings, state, frame);
+            database->format(ostr, settings, state, frame);
             ostr << '.';
         }
 
         chassert(table);
-        table->formatImpl(ostr, settings, state, frame);
+        table->format(ostr, settings, state, frame);
 
         if (uuid != UUIDHelpers::Nil)
             ostr << (settings.hilite ? hilite_keyword : "") << " UUID " << (settings.hilite ? hilite_none : "")
@@ -391,12 +392,12 @@ void ASTCreateQuery::formatQueryImpl(WriteBuffer & ostr, const FormatSettings & 
 
         if (database)
         {
-            database->formatImpl(ostr, settings, state, frame);
+            database->format(ostr, settings, state, frame);
             ostr << '.';
         }
 
         chassert(table);
-        table->formatImpl(ostr, settings, state, frame);
+        table->format(ostr, settings, state, frame);
 
         if (uuid != UUIDHelpers::Nil)
             ostr << (settings.hilite ? hilite_keyword : "") << " UUID " << (settings.hilite ? hilite_none : "")
@@ -407,7 +408,7 @@ void ASTCreateQuery::formatQueryImpl(WriteBuffer & ostr, const FormatSettings & 
     if (refresh_strategy)
     {
         ostr << settings.nl_or_ws;
-        refresh_strategy->formatImpl(ostr, settings, state, frame);
+        refresh_strategy->format(ostr, settings, state, frame);
     }
 
     if (auto to_table_id = getTargetTableID(ViewTarget::To))
@@ -458,7 +459,7 @@ void ASTCreateQuery::formatQueryImpl(WriteBuffer & ostr, const FormatSettings & 
             frame.expression_list_always_start_on_new_line = true;
             ostr << (settings.one_line ? " (" : "\n(");
             FormatStateStacked frame_nested = frame;
-            columns_list->formatImpl(ostr, settings, state, frame_nested);
+            columns_list->format(ostr, settings, state, frame_nested);
             ostr << (settings.one_line ? ")" : "\n)");
             frame.expression_list_always_start_on_new_line = false;
         }
@@ -466,7 +467,7 @@ void ASTCreateQuery::formatQueryImpl(WriteBuffer & ostr, const FormatSettings & 
         add_empty_if_needed();
         add_clone_if_needed();
         ostr << (settings.hilite ? hilite_keyword : "") << " AS " << (settings.hilite ? hilite_none : "");
-        as_table_function->formatImpl(ostr, settings, state, frame);
+        as_table_function->format(ostr, settings, state, frame);
     }
 
     frame.expression_list_always_start_on_new_line = true;
@@ -475,7 +476,7 @@ void ASTCreateQuery::formatQueryImpl(WriteBuffer & ostr, const FormatSettings & 
     {
         ostr << (settings.one_line ? " (" : "\n(");
         FormatStateStacked frame_nested = frame;
-        columns_list->formatImpl(ostr, settings, state, frame_nested);
+        columns_list->format(ostr, settings, state, frame_nested);
         ostr << (settings.one_line ? ")" : "\n)");
     }
 
@@ -484,7 +485,7 @@ void ASTCreateQuery::formatQueryImpl(WriteBuffer & ostr, const FormatSettings & 
         ostr << (settings.one_line ? " (" : "\n(");
         FormatStateStacked frame_nested = frame;
         if (settings.one_line)
-            dictionary_attributes_list->formatImpl(ostr, settings, state, frame_nested);
+            dictionary_attributes_list->format(ostr, settings, state, frame_nested);
         else
             dictionary_attributes_list->formatImplMultiline(ostr, settings, state, frame_nested);
         ostr << (settings.one_line ? ")" : "\n)");
@@ -493,16 +494,16 @@ void ASTCreateQuery::formatQueryImpl(WriteBuffer & ostr, const FormatSettings & 
     frame.expression_list_always_start_on_new_line = false;
 
     if (storage)
-        storage->formatImpl(ostr, settings, state, frame);
+        storage->format(ostr, settings, state, frame);
 
     if (auto inner_storage = getTargetInnerEngine(ViewTarget::Inner))
     {
         ostr << " " << (settings.hilite ? hilite_keyword : "") << toStringView(Keyword::INNER) << (settings.hilite ? hilite_none : "");
-        inner_storage->formatImpl(ostr, settings, state, frame);
+        inner_storage->format(ostr, settings, state, frame);
     }
 
     if (auto to_storage = getTargetInnerEngine(ViewTarget::To))
-        to_storage->formatImpl(ostr, settings, state, frame);
+        to_storage->format(ostr, settings, state, frame);
 
     if (targets)
     {
@@ -512,7 +513,7 @@ void ASTCreateQuery::formatQueryImpl(WriteBuffer & ostr, const FormatSettings & 
     }
 
     if (dictionary)
-        dictionary->formatImpl(ostr, settings, state, frame);
+        dictionary->format(ostr, settings, state, frame);
 
     if (is_watermark_strictly_ascending)
     {
@@ -525,13 +526,13 @@ void ASTCreateQuery::formatQueryImpl(WriteBuffer & ostr, const FormatSettings & 
     else if (is_watermark_bounded)
     {
         ostr << (settings.hilite ? hilite_keyword : "") << " WATERMARK " << (settings.hilite ? hilite_none : "");
-        watermark_function->formatImpl(ostr, settings, state, frame);
+        watermark_function->format(ostr, settings, state, frame);
     }
 
     if (allowed_lateness)
     {
         ostr << (settings.hilite ? hilite_keyword : "") << " ALLOWED_LATENESS " << (settings.hilite ? hilite_none : "");
-        lateness_function->formatImpl(ostr, settings, state, frame);
+        lateness_function->format(ostr, settings, state, frame);
     }
 
     if (is_populate)
@@ -542,7 +543,7 @@ void ASTCreateQuery::formatQueryImpl(WriteBuffer & ostr, const FormatSettings & 
     if (sql_security && supportSQLSecurity() && sql_security->as<ASTSQLSecurity &>().type.has_value())
     {
         ostr << settings.nl_or_ws;
-        sql_security->formatImpl(ostr, settings, state, frame);
+        sql_security->format(ostr, settings, state, frame);
     }
 
     if (select)
@@ -550,14 +551,14 @@ void ASTCreateQuery::formatQueryImpl(WriteBuffer & ostr, const FormatSettings & 
         ostr << settings.nl_or_ws;
         ostr << (settings.hilite ? hilite_keyword : "") << "AS "
                       << (comment ? "(" : "") << (settings.hilite ? hilite_none : "");
-        select->formatImpl(ostr, settings, state, frame);
+        select->format(ostr, settings, state, frame);
         ostr << (settings.hilite ? hilite_keyword : "") << (comment ? ")" : "") << (settings.hilite ? hilite_none : "");
     }
 
     if (comment)
     {
         ostr << (settings.hilite ? hilite_keyword : "") << settings.nl_or_ws << "COMMENT " << (settings.hilite ? hilite_none : "");
-        comment->formatImpl(ostr, settings, state, frame);
+        comment->format(ostr, settings, state, frame);
     }
 }
 

--- a/src/Parsers/ASTCreateQuery.h
+++ b/src/Parsers/ASTCreateQuery.h
@@ -34,8 +34,6 @@ public:
 
     ASTPtr clone() const override;
 
-    void formatImpl(WriteBuffer & ostr, const FormatSettings & s, FormatState & state, FormatStateStacked frame) const override;
-
     bool isExtendedStorageDefinition() const;
 
     void forEachPointerToChild(std::function<void(void**)> f) override
@@ -48,6 +46,9 @@ public:
         f(reinterpret_cast<void **>(&ttl_table));
         f(reinterpret_cast<void **>(&settings));
     }
+
+protected:
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & s, FormatState & state, FormatStateStacked frame) const override;
 };
 
 
@@ -67,8 +68,6 @@ public:
 
     ASTPtr clone() const override;
 
-    void formatImpl(WriteBuffer & ostr, const FormatSettings & s, FormatState & state, FormatStateStacked frame) const override;
-
     bool empty() const
     {
         return (!columns || columns->children.empty()) && (!indices || indices->children.empty()) && (!constraints || constraints->children.empty())
@@ -84,6 +83,9 @@ public:
         f(reinterpret_cast<void **>(&projections));
         f(reinterpret_cast<void **>(&primary_key_from_columns));
     }
+
+protected:
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & s, FormatState & state, FormatStateStacked frame) const override;
 };
 
 

--- a/src/Parsers/ASTCreateResourceQuery.h
+++ b/src/Parsers/ASTCreateResourceQuery.h
@@ -36,13 +36,14 @@ public:
 
     ASTPtr clone() const override;
 
-    void formatImpl(WriteBuffer & ostr, const FormatSettings & format, FormatState & state, FormatStateStacked frame) const override;
-
     ASTPtr getRewrittenASTWithoutOnCluster(const WithoutOnClusterASTRewriteParams &) const override { return removeOnCluster<ASTCreateResourceQuery>(clone()); }
 
     String getResourceName() const;
 
     QueryKind getQueryKind() const override { return QueryKind::Create; }
+
+protected:
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & format, FormatState & state, FormatStateStacked frame) const override;
 };
 
 }

--- a/src/Parsers/ASTCreateWorkloadQuery.h
+++ b/src/Parsers/ASTCreateWorkloadQuery.h
@@ -39,8 +39,6 @@ public:
 
     ASTPtr clone() const override;
 
-    void formatImpl(WriteBuffer & ostr, const FormatSettings & format, FormatState & state, FormatStateStacked frame) const override;
-
     ASTPtr getRewrittenASTWithoutOnCluster(const WithoutOnClusterASTRewriteParams &) const override { return removeOnCluster<ASTCreateWorkloadQuery>(clone()); }
 
     String getWorkloadName() const;
@@ -48,6 +46,9 @@ public:
     String getWorkloadParent() const;
 
     QueryKind getQueryKind() const override { return QueryKind::Create; }
+
+protected:
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & format, FormatState & state, FormatStateStacked frame) const override;
 };
 
 }

--- a/src/Parsers/ASTDataType.cpp
+++ b/src/Parsers/ASTDataType.cpp
@@ -49,13 +49,13 @@ void ASTDataType::formatImpl(WriteBuffer & ostr, const FormatSettings & settings
                 if (i != 0)
                     ostr << ',';
                 ostr << indent_str;
-                arguments->children[i]->formatImpl(ostr, settings, state, frame);
+                arguments->children[i]->format(ostr, settings, state, frame);
             }
         }
         else
         {
             frame.expression_list_prepend_whitespace = false;
-            arguments->formatImpl(ostr, settings, state, frame);
+            arguments->format(ostr, settings, state, frame);
         }
 
         ostr << (settings.hilite ? hilite_function : "") << ')';

--- a/src/Parsers/ASTDataType.h
+++ b/src/Parsers/ASTDataType.h
@@ -16,6 +16,8 @@ public:
     String getID(char delim) const override;
     ASTPtr clone() const override;
     void updateTreeHashImpl(SipHash & hash_state, bool ignore_aliases) const override;
+
+protected:
     void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
 };
 

--- a/src/Parsers/ASTDatabaseOrNone.h
+++ b/src/Parsers/ASTDatabaseOrNone.h
@@ -14,6 +14,8 @@ public:
     bool isNone() const { return none; }
     String getID(char) const override { return "DatabaseOrNone"; }
     ASTPtr clone() const override { return std::make_shared<ASTDatabaseOrNone>(*this); }
+
+protected:
     void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
 };
 }

--- a/src/Parsers/ASTDeleteQuery.cpp
+++ b/src/Parsers/ASTDeleteQuery.cpp
@@ -36,23 +36,23 @@ void ASTDeleteQuery::formatQueryImpl(WriteBuffer & ostr, const FormatSettings & 
 
     if (database)
     {
-        database->formatImpl(ostr, settings, state, frame);
+        database->format(ostr, settings, state, frame);
         ostr << '.';
     }
 
     chassert(table);
-    table->formatImpl(ostr, settings, state, frame);
+    table->format(ostr, settings, state, frame);
 
     formatOnCluster(ostr, settings);
 
     if (partition)
     {
         ostr << (settings.hilite ? hilite_keyword : "") << " IN PARTITION " << (settings.hilite ? hilite_none : "");
-        partition->formatImpl(ostr, settings, state, frame);
+        partition->format(ostr, settings, state, frame);
     }
 
     ostr << (settings.hilite ? hilite_keyword : "") << " WHERE " << (settings.hilite ? hilite_none : "");
-    predicate->formatImpl(ostr, settings, state, frame);
+    predicate->format(ostr, settings, state, frame);
 }
 
 }

--- a/src/Parsers/ASTDictionary.cpp
+++ b/src/Parsers/ASTDictionary.cpp
@@ -91,7 +91,7 @@ void ASTDictionaryLayout::formatImpl(WriteBuffer & ostr,
     if (has_brackets)
         ostr << "(";
 
-    if (parameters) parameters->formatImpl(ostr, settings, state, frame);
+    if (parameters) parameters->format(ostr, settings, state, frame);
 
     if (has_brackets)
         ostr << ")";
@@ -160,7 +160,7 @@ void ASTDictionary::formatImpl(WriteBuffer & ostr, const FormatSettings & settin
     {
         ostr << (settings.hilite ? hilite_keyword : "") << settings.nl_or_ws << "PRIMARY KEY "
             << (settings.hilite ? hilite_none : "");
-        primary_key->formatImpl(ostr, settings, state, frame);
+        primary_key->format(ostr, settings, state, frame);
     }
 
     if (source)
@@ -168,32 +168,32 @@ void ASTDictionary::formatImpl(WriteBuffer & ostr, const FormatSettings & settin
         ostr << (settings.hilite ? hilite_keyword : "") << settings.nl_or_ws << "SOURCE"
             << (settings.hilite ? hilite_none : "");
         ostr << "(";
-        source->formatImpl(ostr, settings, state, frame);
+        source->format(ostr, settings, state, frame);
         ostr << ")";
     }
 
     if (lifetime)
     {
         ostr << settings.nl_or_ws;
-        lifetime->formatImpl(ostr, settings, state, frame);
+        lifetime->format(ostr, settings, state, frame);
     }
 
     if (layout)
     {
         ostr << settings.nl_or_ws;
-        layout->formatImpl(ostr, settings, state, frame);
+        layout->format(ostr, settings, state, frame);
     }
 
     if (range)
     {
         ostr << settings.nl_or_ws;
-        range->formatImpl(ostr, settings, state, frame);
+        range->format(ostr, settings, state, frame);
     }
 
     if (dict_settings)
     {
         ostr << settings.nl_or_ws;
-        dict_settings->formatImpl(ostr, settings, state, frame);
+        dict_settings->format(ostr, settings, state, frame);
     }
 }
 

--- a/src/Parsers/ASTDictionary.h
+++ b/src/Parsers/ASTDictionary.h
@@ -25,6 +25,7 @@ public:
 
     ASTPtr clone() const override;
 
+protected:
     void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
 };
 
@@ -46,12 +47,13 @@ public:
 
     ASTPtr clone() const override;
 
-    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
-
     void forEachPointerToChild(std::function<void(void**)> f) override
     {
         f(reinterpret_cast<void **>(&parameters));
     }
+
+protected:
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
 };
 
 
@@ -68,6 +70,7 @@ public:
 
     ASTPtr clone() const override;
 
+protected:
     void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
 };
 
@@ -80,6 +83,7 @@ public:
 
     ASTPtr clone() const override;
 
+protected:
     void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
 };
 
@@ -107,6 +111,7 @@ public:
 
     ASTPtr clone() const override;
 
+protected:
     void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
 };
 

--- a/src/Parsers/ASTDictionaryAttributeDeclaration.cpp
+++ b/src/Parsers/ASTDictionaryAttributeDeclaration.cpp
@@ -40,19 +40,19 @@ void ASTDictionaryAttributeDeclaration::formatImpl(WriteBuffer & ostr, const For
     if (type)
     {
         ostr << ' ';
-        type->formatImpl(ostr, settings, state, frame);
+        type->format(ostr, settings, state, frame);
     }
 
     if (default_value)
     {
         ostr << ' ' << (settings.hilite ? hilite_keyword : "") << "DEFAULT" << (settings.hilite ? hilite_none : "") << ' ';
-        default_value->formatImpl(ostr, settings, state, frame);
+        default_value->format(ostr, settings, state, frame);
     }
 
     if (expression)
     {
         ostr << ' ' << (settings.hilite ? hilite_keyword : "") << "EXPRESSION" << (settings.hilite ? hilite_none : "") << ' ';
-        expression->formatImpl(ostr, settings, state, frame);
+        expression->format(ostr, settings, state, frame);
     }
 
     if (hierarchical)

--- a/src/Parsers/ASTDictionaryAttributeDeclaration.h
+++ b/src/Parsers/ASTDictionaryAttributeDeclaration.h
@@ -30,6 +30,8 @@ public:
     String getID(char delim) const override { return "DictionaryAttributeDeclaration" + (delim + name); }
 
     ASTPtr clone() const override;
+
+protected:
     void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
 };
 

--- a/src/Parsers/ASTDropFunctionQuery.h
+++ b/src/Parsers/ASTDropFunctionQuery.h
@@ -18,11 +18,12 @@ public:
 
     ASTPtr clone() const override;
 
-    void formatImpl(WriteBuffer & ostr, const FormatSettings & s, FormatState & state, FormatStateStacked frame) const override;
-
     ASTPtr getRewrittenASTWithoutOnCluster(const WithoutOnClusterASTRewriteParams &) const override { return removeOnCluster<ASTDropFunctionQuery>(clone()); }
 
     QueryKind getQueryKind() const override { return QueryKind::Drop; }
+
+protected:
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & s, FormatState & state, FormatStateStacked frame) const override;
 };
 
 }

--- a/src/Parsers/ASTDropIndexQuery.cpp
+++ b/src/Parsers/ASTDropIndexQuery.cpp
@@ -34,7 +34,7 @@ void ASTDropIndexQuery::formatQueryImpl(WriteBuffer & ostr, const FormatSettings
     ostr << (settings.hilite ? hilite_keyword : "") << indent_str;
 
     ostr << "DROP INDEX " << (if_exists ? "IF EXISTS " : "");
-    index_name->formatImpl(ostr, settings, state, frame);
+    index_name->format(ostr, settings, state, frame);
     ostr << " ON ";
 
     ostr << (settings.hilite ? hilite_none : "");
@@ -43,12 +43,12 @@ void ASTDropIndexQuery::formatQueryImpl(WriteBuffer & ostr, const FormatSettings
     {
         if (database)
         {
-            database->formatImpl(ostr, settings, state, frame);
+            database->format(ostr, settings, state, frame);
             ostr << '.';
         }
 
         chassert(table);
-        table->formatImpl(ostr, settings, state, frame);
+        table->format(ostr, settings, state, frame);
     }
 
     formatOnCluster(ostr, settings);

--- a/src/Parsers/ASTDropNamedCollectionQuery.h
+++ b/src/Parsers/ASTDropNamedCollectionQuery.h
@@ -17,11 +17,12 @@ public:
 
     ASTPtr clone() const override;
 
-    void formatImpl(WriteBuffer & ostr, const FormatSettings & s, FormatState & state, FormatStateStacked frame) const override;
-
     ASTPtr getRewrittenASTWithoutOnCluster(const WithoutOnClusterASTRewriteParams &) const override { return removeOnCluster<ASTDropNamedCollectionQuery>(clone()); }
 
     QueryKind getQueryKind() const override { return QueryKind::Drop; }
+
+protected:
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & s, FormatState & state, FormatStateStacked frame) const override;
 };
 
 }

--- a/src/Parsers/ASTDropQuery.cpp
+++ b/src/Parsers/ASTDropQuery.cpp
@@ -69,7 +69,7 @@ void ASTDropQuery::formatQueryImpl(WriteBuffer & ostr, const FormatSettings & se
 
     if (!table && !database_and_tables && database)
     {
-        database->formatImpl(ostr, settings, state, frame);
+        database->format(ostr, settings, state, frame);
     }
     else if (database_and_tables)
     {
@@ -85,25 +85,25 @@ void ASTDropQuery::formatQueryImpl(WriteBuffer & ostr, const FormatSettings & se
 
             if (auto db = identifier->getDatabase())
             {
-                db->formatImpl(ostr, settings, state, frame);
+                db->format(ostr, settings, state, frame);
                 ostr << '.';
             }
 
             auto tb = identifier->getTable();
             chassert(tb);
-            tb->formatImpl(ostr, settings, state, frame);
+            tb->format(ostr, settings, state, frame);
         }
     }
     else
     {
         if (database)
         {
-            database->formatImpl(ostr, settings, state, frame);
+            database->format(ostr, settings, state, frame);
             ostr << '.';
         }
 
         chassert(table);
-        table->formatImpl(ostr, settings, state, frame);
+        table->format(ostr, settings, state, frame);
     }
 
     formatOnCluster(ostr, settings);

--- a/src/Parsers/ASTDropResourceQuery.h
+++ b/src/Parsers/ASTDropResourceQuery.h
@@ -18,11 +18,12 @@ public:
 
     ASTPtr clone() const override;
 
-    void formatImpl(WriteBuffer & ostr, const FormatSettings & s, FormatState & state, FormatStateStacked frame) const override;
-
     ASTPtr getRewrittenASTWithoutOnCluster(const WithoutOnClusterASTRewriteParams &) const override { return removeOnCluster<ASTDropResourceQuery>(clone()); }
 
     QueryKind getQueryKind() const override { return QueryKind::Drop; }
+
+protected:
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & s, FormatState & state, FormatStateStacked frame) const override;
 };
 
 }

--- a/src/Parsers/ASTDropWorkloadQuery.h
+++ b/src/Parsers/ASTDropWorkloadQuery.h
@@ -18,11 +18,12 @@ public:
 
     ASTPtr clone() const override;
 
-    void formatImpl(WriteBuffer & ostr, const FormatSettings & s, FormatState & state, FormatStateStacked frame) const override;
-
     ASTPtr getRewrittenASTWithoutOnCluster(const WithoutOnClusterASTRewriteParams &) const override { return removeOnCluster<ASTDropWorkloadQuery>(clone()); }
 
     QueryKind getQueryKind() const override { return QueryKind::Drop; }
+
+protected:
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & s, FormatState & state, FormatStateStacked frame) const override;
 };
 
 }

--- a/src/Parsers/ASTExplainQuery.h
+++ b/src/Parsers/ASTExplainQuery.h
@@ -119,23 +119,23 @@ protected:
         if (ast_settings)
         {
             ostr << ' ';
-            ast_settings->formatImpl(ostr, settings, state, frame);
+            ast_settings->format(ostr, settings, state, frame);
         }
 
         if (query)
         {
             ostr << settings.nl_or_ws;
-            query->formatImpl(ostr, settings, state, frame);
+            query->format(ostr, settings, state, frame);
         }
         if (table_function)
         {
             ostr << settings.nl_or_ws;
-            table_function->formatImpl(ostr, settings, state, frame);
+            table_function->format(ostr, settings, state, frame);
         }
         if (table_override)
         {
             ostr << settings.nl_or_ws;
-            table_override->formatImpl(ostr, settings, state, frame);
+            table_override->format(ostr, settings, state, frame);
         }
     }
 

--- a/src/Parsers/ASTExpressionList.cpp
+++ b/src/Parsers/ASTExpressionList.cpp
@@ -33,7 +33,7 @@ void ASTExpressionList::formatImpl(WriteBuffer & ostr, const FormatSettings & se
         if (frame.surround_each_list_element_with_parens)
             ostr << "(";
 
-        children[i]->formatImpl(ostr, settings, state, frame_nested);
+        children[i]->format(ostr, settings, state, frame_nested);
 
         if (frame.surround_each_list_element_with_parens)
             ostr << ")";
@@ -67,7 +67,7 @@ void ASTExpressionList::formatImplMultiline(WriteBuffer & ostr, const FormatSett
         if (frame.surround_each_list_element_with_parens)
             ostr << "(";
 
-        children[i]->formatImpl(ostr, settings, state, frame_nested);
+        children[i]->format(ostr, settings, state, frame_nested);
 
         if (frame.surround_each_list_element_with_parens)
             ostr << ")";

--- a/src/Parsers/ASTExpressionList.h
+++ b/src/Parsers/ASTExpressionList.h
@@ -16,10 +16,12 @@ public:
     String getID(char) const override { return "ExpressionList"; }
 
     ASTPtr clone() const override;
-    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
     void formatImplMultiline(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const;
 
     char separator;
+
+protected:
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
 };
 
 }

--- a/src/Parsers/ASTExternalDDLQuery.h
+++ b/src/Parsers/ASTExternalDDLQuery.h
@@ -33,18 +33,19 @@ public:
 
     String getID(char) const override { return "external ddl query"; }
 
-    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked stacked) const override
-    {
-        ostr << (settings.hilite ? hilite_keyword : "") << "EXTERNAL DDL FROM " << (settings.hilite ? hilite_none : "");
-        from->formatImpl(ostr, settings, state, stacked);
-        external_ddl->formatImpl(ostr, settings, state, stacked);
-    }
-
     QueryKind getQueryKind() const override { return QueryKind::ExternalDDL; }
 
     void forEachPointerToChild(std::function<void(void**)> f) override
     {
         f(reinterpret_cast<void **>(&from));
+    }
+
+protected:
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked stacked) const override
+    {
+        ostr << (settings.hilite ? hilite_keyword : "") << "EXTERNAL DDL FROM " << (settings.hilite ? hilite_none : "");
+        from->format(ostr, settings, state, stacked);
+        external_ddl->format(ostr, settings, state, stacked);
     }
 };
 

--- a/src/Parsers/ASTFunction.cpp
+++ b/src/Parsers/ASTFunction.cpp
@@ -95,7 +95,7 @@ void ASTFunction::appendColumnNameImpl(WriteBuffer & ostr) const
             FormatState state;
             FormatStateStacked frame;
             writeCString("(", ostr);
-            window_definition->formatImpl(ostr, format_settings, state, frame);
+            window_definition->format(ostr, format_settings, state, frame);
             writeCString(")", ostr);
         }
     }
@@ -119,7 +119,7 @@ void ASTFunction::finishFormatWithWindow(WriteBuffer & ostr, const FormatSetting
     else
     {
         ostr << "(";
-        window_definition->formatImpl(ostr, settings, state, frame);
+        window_definition->format(ostr, settings, state, frame);
         ostr << ")";
     }
 }
@@ -275,7 +275,7 @@ static bool formatNamedArgWithHiddenValue(IAST * arg, WriteBuffer & ostr, const 
     if (equal_args.size() != 2)
         return false;
 
-    equal_args[0]->formatImpl(ostr, settings, state, frame);
+    equal_args[0]->format(ostr, settings, state, frame);
     ostr << (settings.hilite ? IAST::hilite_operator : "") << " = " << (settings.hilite ? IAST::hilite_none : "");
     ostr << "'[HIDDEN]'";
 
@@ -302,7 +302,7 @@ void ASTFunction::formatImplWithoutAlias(WriteBuffer & ostr, const FormatSetting
         FormatStateStacked frame_nested = frame;
         frame_nested.need_parens = false;
         ++frame_nested.indent;
-        query->formatImpl(ostr, settings, state, frame_nested);
+        query->format(ostr, settings, state, frame_nested);
         ostr << nl_or_nothing << indent_str;
         ostr << (settings.hilite ? hilite_function : "") << ")" << (settings.hilite ? hilite_none : "");
         return;
@@ -364,7 +364,7 @@ void ASTFunction::formatImplWithoutAlias(WriteBuffer & ostr, const FormatSetting
                 if (inside_parens)
                     ostr << '(';
 
-                arguments->formatImpl(ostr, settings, state, nested_need_parens);
+                arguments->format(ostr, settings, state, nested_need_parens);
                 written = true;
 
                 if (inside_parens)
@@ -396,7 +396,7 @@ void ASTFunction::formatImplWithoutAlias(WriteBuffer & ostr, const FormatSetting
 
                 if (frame.need_parens)
                     ostr << '(';
-                arguments->formatImpl(ostr, settings, state, nested_need_parens);
+                arguments->format(ostr, settings, state, nested_need_parens);
                 ostr << (settings.hilite ? hilite_operator : "") << func[1] << (settings.hilite ? hilite_none : "");
                 if (frame.need_parens)
                     ostr << ')';
@@ -444,7 +444,7 @@ void ASTFunction::formatImplWithoutAlias(WriteBuffer & ostr, const FormatSetting
                 {
                     if (frame.need_parens)
                         ostr << '(';
-                    arguments->children[0]->formatImpl(ostr, settings, state, nested_need_parens);
+                    arguments->children[0]->format(ostr, settings, state, nested_need_parens);
                     ostr << (settings.hilite ? hilite_operator : "") << func[1] << (settings.hilite ? hilite_none : "");
 
                     bool special_hilite = settings.hilite
@@ -464,12 +464,12 @@ void ASTFunction::formatImplWithoutAlias(WriteBuffer & ostr, const FormatSetting
                     if (extra_parents_around_in_rhs)
                     {
                         ostr << '(';
-                        arguments->children[1]->formatImpl(ostr, settings, state, nested_dont_need_parens);
+                        arguments->children[1]->format(ostr, settings, state, nested_dont_need_parens);
                         ostr << ')';
                     }
 
                     if (!special_hilite && !extra_parents_around_in_rhs)
-                        arguments->children[1]->formatImpl(ostr, settings, state, nested_need_parens);
+                        arguments->children[1]->format(ostr, settings, state, nested_need_parens);
 
                     if (frame.need_parens)
                         ostr << ')';
@@ -482,9 +482,9 @@ void ASTFunction::formatImplWithoutAlias(WriteBuffer & ostr, const FormatSetting
                 if (frame.need_parens)
                     ostr << '(';
 
-                arguments->children[0]->formatImpl(ostr, settings, state, nested_need_parens);
+                arguments->children[0]->format(ostr, settings, state, nested_need_parens);
                 ostr << (settings.hilite ? hilite_operator : "") << '[' << (settings.hilite ? hilite_none : "");
-                arguments->children[1]->formatImpl(ostr, settings, state, nested_dont_need_parens);
+                arguments->children[1]->format(ostr, settings, state, nested_dont_need_parens);
                 ostr << (settings.hilite ? hilite_operator : "") << ']' << (settings.hilite ? hilite_none : "");
                 written = true;
 
@@ -532,9 +532,9 @@ void ASTFunction::formatImplWithoutAlias(WriteBuffer & ostr, const FormatSetting
                         if (frame.need_parens)
                             ostr << '(';
 
-                        arguments->children[0]->formatImpl(ostr, settings, state, nested_need_parens);
+                        arguments->children[0]->format(ostr, settings, state, nested_need_parens);
                         ostr << (settings.hilite ? hilite_operator : "") << "." << (settings.hilite ? hilite_none : "");
-                        arguments->children[1]->formatImpl(ostr, settings, state, nested_dont_need_parens);
+                        arguments->children[1]->format(ostr, settings, state, nested_dont_need_parens);
                         written = true;
 
                         if (frame.need_parens)
@@ -566,15 +566,15 @@ void ASTFunction::formatImplWithoutAlias(WriteBuffer & ostr, const FormatSetting
                     && (first_argument_function->arguments->children.size() == 1 || first_argument_function->arguments->children.empty()))
                 {
                     if (first_argument_function->arguments->children.size() == 1)
-                        first_argument_function->arguments->children[0]->formatImpl(ostr, settings, state, nested_need_parens);
+                        first_argument_function->arguments->children[0]->format(ostr, settings, state, nested_need_parens);
                     else
                         ostr << "()";
                 }
                 else
-                    first_argument->formatImpl(ostr, settings, state, nested_need_parens);
+                    first_argument->format(ostr, settings, state, nested_need_parens);
 
                 ostr << (settings.hilite ? hilite_operator : "") << " -> " << (settings.hilite ? hilite_none : "");
-                arguments->children[1]->formatImpl(ostr, settings, state, nested_need_parens);
+                arguments->children[1]->format(ostr, settings, state, nested_need_parens);
                 if (frame.need_parens || frame.list_element_index > 0)
                     ostr << ')';
                 written = true;
@@ -591,10 +591,10 @@ void ASTFunction::formatImplWithoutAlias(WriteBuffer & ostr, const FormatSetting
                 FormatStateStacked frame_nested = frame;
                 frame_nested.need_parens = false;
                 frame_nested.indent += 2;
-                arguments->children[0]->formatImpl(ostr, settings, state, frame_nested);
+                arguments->children[0]->format(ostr, settings, state, frame_nested);
                 ostr << nl_or_nothing << indent1 << (settings.hilite ? hilite_keyword : "") << (settings.one_line ? " " : "")
                               << "ELSE " << (settings.hilite ? hilite_none : "") << nl_or_nothing << indent2;
-                arguments->children[1]->formatImpl(ostr, settings, state, frame_nested);
+                arguments->children[1]->format(ostr, settings, state, frame_nested);
                 ostr << nl_or_nothing << indent0 << ")";
                 return;
             }
@@ -621,7 +621,7 @@ void ASTFunction::formatImplWithoutAlias(WriteBuffer & ostr, const FormatSetting
                             ostr << (settings.hilite ? hilite_operator : "") << func[1] << (settings.hilite ? hilite_none : "");
                         if (arguments->children[i]->as<ASTSetQuery>())
                             ostr << "SETTINGS ";
-                        arguments->children[i]->formatImpl(ostr, settings, state, nested_need_parens);
+                        arguments->children[i]->format(ostr, settings, state, nested_need_parens);
                     }
                     if (frame.need_parens)
                         ostr << ')';
@@ -640,7 +640,7 @@ void ASTFunction::formatImplWithoutAlias(WriteBuffer & ostr, const FormatSetting
                 if (arguments->children[i]->as<ASTSetQuery>())
                     ostr << "SETTINGS ";
                 nested_dont_need_parens.list_element_index = i;
-                arguments->children[i]->formatImpl(ostr, settings, state, nested_dont_need_parens);
+                arguments->children[i]->format(ostr, settings, state, nested_dont_need_parens);
             }
             ostr << (settings.hilite ? hilite_operator : "") << ']' << (settings.hilite ? hilite_none : "");
             written = true;
@@ -658,7 +658,7 @@ void ASTFunction::formatImplWithoutAlias(WriteBuffer & ostr, const FormatSetting
                 if (arguments->children[i]->as<ASTSetQuery>())
                     ostr << "SETTINGS ";
                 nested_dont_need_parens.list_element_index = i;
-                arguments->children[i]->formatImpl(ostr, settings, state, nested_dont_need_parens);
+                arguments->children[i]->format(ostr, settings, state, nested_dont_need_parens);
             }
             ostr << (settings.hilite ? hilite_operator : "") << ')' << (settings.hilite ? hilite_none : "");
             written = true;
@@ -674,7 +674,7 @@ void ASTFunction::formatImplWithoutAlias(WriteBuffer & ostr, const FormatSetting
                 if (arguments->children[i]->as<ASTSetQuery>())
                     ostr << "SETTINGS ";
                 nested_dont_need_parens.list_element_index = i;
-                arguments->children[i]->formatImpl(ostr, settings, state, nested_dont_need_parens);
+                arguments->children[i]->format(ostr, settings, state, nested_dont_need_parens);
             }
             ostr << (settings.hilite ? hilite_operator : "") << ')' << (settings.hilite ? hilite_none : "");
             written = true;
@@ -692,7 +692,7 @@ void ASTFunction::formatImplWithoutAlias(WriteBuffer & ostr, const FormatSetting
     if (parameters)
     {
         ostr << '(' << (settings.hilite ? hilite_none : "");
-        parameters->formatImpl(ostr, settings, state, nested_dont_need_parens);
+        parameters->format(ostr, settings, state, nested_dont_need_parens);
         ostr << (settings.hilite ? hilite_function : "") << ')';
     }
 
@@ -725,9 +725,9 @@ void ASTFunction::formatImplWithoutAlias(WriteBuffer & ostr, const FormatSetting
                     if (secret_arguments.are_named)
                     {
                         if (const auto * func_ast = typeid_cast<const ASTFunction *>(argument.get()))
-                            func_ast->arguments->children[0]->formatImpl(ostr, settings, state, nested_dont_need_parens);
+                            func_ast->arguments->children[0]->format(ostr, settings, state, nested_dont_need_parens);
                         else
-                            argument->formatImpl(ostr, settings, state, nested_dont_need_parens);
+                            argument->format(ostr, settings, state, nested_dont_need_parens);
                         ostr << (settings.hilite ? hilite_operator : "") << " = " << (settings.hilite ? hilite_none : "");
                     }
                     if (!secret_arguments.replacement.empty())
@@ -754,7 +754,7 @@ void ASTFunction::formatImplWithoutAlias(WriteBuffer & ostr, const FormatSetting
                             ostr << ", ";
                         auto inner_arg = function->arguments->children[j];
                         if (!formatNamedArgWithHiddenValue(inner_arg.get(), ostr, settings, state, nested_dont_need_parens))
-                            inner_arg->formatImpl(ostr, settings, state, nested_dont_need_parens);
+                            inner_arg->format(ostr, settings, state, nested_dont_need_parens);
                     }
                     ostr << ")";
                     continue;
@@ -768,7 +768,7 @@ void ASTFunction::formatImplWithoutAlias(WriteBuffer & ostr, const FormatSetting
             }
 
             nested_dont_need_parens.list_element_index = i;
-            argument->formatImpl(ostr, settings, state, nested_dont_need_parens);
+            argument->format(ostr, settings, state, nested_dont_need_parens);
         }
     }
 

--- a/src/Parsers/ASTFunctionWithKeyValueArguments.cpp
+++ b/src/Parsers/ASTFunctionWithKeyValueArguments.cpp
@@ -42,14 +42,14 @@ void ASTPair::formatImpl(WriteBuffer & ostr, const FormatSettings & settings, Fo
         WriteBufferFromOwnString temp_buf;
         FormatSettings tmp_settings(settings.one_line);
         FormatState tmp_state;
-        second->formatImpl(temp_buf, tmp_settings, tmp_state, frame);
+        second->format(temp_buf, tmp_settings, tmp_state, frame);
 
         maskURIPassword(&temp_buf.str());
         ostr << temp_buf.str();
     }
     else
     {
-        second->formatImpl(ostr, settings, state, frame);
+        second->format(ostr, settings, state, frame);
     }
 
     if (second_with_brackets)
@@ -98,7 +98,7 @@ ASTPtr ASTFunctionWithKeyValueArguments::clone() const
 void ASTFunctionWithKeyValueArguments::formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
 {
     ostr << (settings.hilite ? hilite_keyword : "") << Poco::toUpper(name) << (settings.hilite ? hilite_none : "") << (has_brackets ? "(" : "");
-    elements->formatImpl(ostr, settings, state, frame);
+    elements->format(ostr, settings, state, frame);
     ostr << (has_brackets ? ")" : "");
     ostr << (settings.hilite ? hilite_none : "");
 }

--- a/src/Parsers/ASTFunctionWithKeyValueArguments.h
+++ b/src/Parsers/ASTFunctionWithKeyValueArguments.h
@@ -30,8 +30,6 @@ public:
 
     ASTPtr clone() const override;
 
-    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
-
     bool hasSecretParts() const override;
 
     void updateTreeHashImpl(SipHash & hash_state, bool ignore_aliases) const override;
@@ -40,6 +38,9 @@ public:
     {
         f(reinterpret_cast<void **>(&second));
     }
+
+protected:
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
 };
 
 
@@ -66,9 +67,10 @@ public:
 
     ASTPtr clone() const override;
 
-    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
-
     void updateTreeHashImpl(SipHash & hash_state, bool ignore_aliases) const override;
+
+protected:
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
 };
 
 }

--- a/src/Parsers/ASTIdentifier.cpp
+++ b/src/Parsers/ASTIdentifier.cpp
@@ -125,7 +125,7 @@ void ASTIdentifier::formatImplWithoutAlias(WriteBuffer & ostr, const FormatSetti
             /// Here we also ignore children if they are empty.
             if (name_parts[i].empty() && j < children.size())
             {
-                children[j]->formatImpl(ostr, settings, state, frame);
+                children[j]->format(ostr, settings, state, frame);
                 ++j;
             }
             else
@@ -136,7 +136,7 @@ void ASTIdentifier::formatImplWithoutAlias(WriteBuffer & ostr, const FormatSetti
     {
         const auto & name = shortName();
         if (name.empty() && !children.empty())
-            children.front()->formatImpl(ostr, settings, state, frame);
+            children.front()->format(ostr, settings, state, frame);
         else
             format_element(name);
     }

--- a/src/Parsers/ASTIndexDeclaration.cpp
+++ b/src/Parsers/ASTIndexDeclaration.cpp
@@ -71,24 +71,24 @@ void ASTIndexDeclaration::formatImpl(WriteBuffer & ostr, const FormatSettings & 
             if (expr->as<ASTExpressionList>())
             {
                 ostr << "(";
-                expr->formatImpl(ostr, s, state, frame);
+                expr->format(ostr, s, state, frame);
                 ostr << ")";
             }
             else
-                expr->formatImpl(ostr, s, state, frame);
+                expr->format(ostr, s, state, frame);
         }
         else
         {
             s.writeIdentifier(ostr, name, /*ambiguous=*/false);
             ostr << " ";
-            expr->formatImpl(ostr, s, state, frame);
+            expr->format(ostr, s, state, frame);
         }
     }
 
     if (auto type = getType())
     {
         ostr << (s.hilite ? hilite_keyword : "") << " TYPE " << (s.hilite ? hilite_none : "");
-        type->formatImpl(ostr, s, state, frame);
+        type->format(ostr, s, state, frame);
     }
 
     if (granularity)

--- a/src/Parsers/ASTIndexDeclaration.h
+++ b/src/Parsers/ASTIndexDeclaration.h
@@ -25,10 +25,12 @@ public:
     String getID(char) const override { return "Index"; }
 
     ASTPtr clone() const override;
-    void formatImpl(WriteBuffer & ostr, const FormatSettings & s, FormatState & state, FormatStateStacked frame) const override;
 
     ASTPtr getExpression() const;
     std::shared_ptr<ASTFunction> getType() const;
+
+protected:
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & s, FormatState & state, FormatStateStacked frame) const override;
 
 private:
     static constexpr size_t expression_idx = 0;

--- a/src/Parsers/ASTInsertQuery.cpp
+++ b/src/Parsers/ASTInsertQuery.cpp
@@ -56,11 +56,11 @@ void ASTInsertQuery::formatImpl(WriteBuffer & ostr, const FormatSettings & setti
     if (table_function)
     {
         ostr << (settings.hilite ? hilite_keyword : "") << "FUNCTION ";
-        table_function->formatImpl(ostr, settings, state, frame);
+        table_function->format(ostr, settings, state, frame);
         if (partition_by)
         {
             ostr << " PARTITION BY ";
-            partition_by->formatImpl(ostr, settings, state, frame);
+            partition_by->format(ostr, settings, state, frame);
         }
     }
     else if (table_id)
@@ -72,18 +72,18 @@ void ASTInsertQuery::formatImpl(WriteBuffer & ostr, const FormatSettings & setti
     {
         if (database)
         {
-            database->formatImpl(ostr, settings, state, frame);
+            database->format(ostr, settings, state, frame);
             ostr << '.';
         }
 
         chassert(table);
-        table->formatImpl(ostr, settings, state, frame);
+        table->format(ostr, settings, state, frame);
     }
 
     if (columns)
     {
         ostr << " (";
-        columns->formatImpl(ostr, settings, state, frame);
+        columns->format(ostr, settings, state, frame);
         ostr << ")";
     }
 
@@ -105,7 +105,7 @@ void ASTInsertQuery::formatImpl(WriteBuffer & ostr, const FormatSettings & setti
     if (settings_ast)
     {
         ostr << (settings.hilite ? hilite_keyword : "") << settings.nl_or_ws << "SETTINGS " << (settings.hilite ? hilite_none : "");
-        settings_ast->formatImpl(ostr, settings, state, frame);
+        settings_ast->format(ostr, settings, state, frame);
     }
 
     /// Compatibility for INSERT without SETTINGS to format in oneline, i.e.:
@@ -123,7 +123,7 @@ void ASTInsertQuery::formatImpl(WriteBuffer & ostr, const FormatSettings & setti
     if (select)
     {
         ostr << delim;
-        select->formatImpl(ostr, settings, state, frame);
+        select->format(ostr, settings, state, frame);
     }
 
     if (!select)

--- a/src/Parsers/ASTInterpolateElement.cpp
+++ b/src/Parsers/ASTInterpolateElement.cpp
@@ -10,7 +10,7 @@ namespace DB
 void ASTInterpolateElement::formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
 {
         ostr << column << (settings.hilite ? hilite_keyword : "") << " AS " << (settings.hilite ? hilite_none : "");
-        expr->formatImpl(ostr, settings, state, frame);
+        expr->format(ostr, settings, state, frame);
 }
 
 }

--- a/src/Parsers/ASTKillQueryQuery.cpp
+++ b/src/Parsers/ASTKillQueryQuery.cpp
@@ -36,7 +36,7 @@ void ASTKillQueryQuery::formatQueryImpl(WriteBuffer & ostr, const FormatSettings
     if (where_expression)
     {
         ostr << (settings.hilite ? hilite_keyword : "") << " WHERE " << (settings.hilite ? hilite_none : "");
-        where_expression->formatImpl(ostr, settings, state, frame);
+        where_expression->format(ostr, settings, state, frame);
     }
 
     ostr << " " << (settings.hilite ? hilite_keyword : "") << (test ? "TEST" : (sync ? "SYNC" : "ASYNC")) << (settings.hilite ? hilite_none : "");

--- a/src/Parsers/ASTNameTypePair.cpp
+++ b/src/Parsers/ASTNameTypePair.cpp
@@ -24,7 +24,7 @@ ASTPtr ASTNameTypePair::clone() const
 void ASTNameTypePair::formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
 {
     ostr << backQuoteIfNeed(name) << ' ';
-    type->formatImpl(ostr, settings, state, frame);
+    type->format(ostr, settings, state, frame);
 }
 
 }

--- a/src/Parsers/ASTObjectTypeArgument.cpp
+++ b/src/Parsers/ASTObjectTypeArgument.cpp
@@ -39,23 +39,23 @@ void ASTObjectTypeArgument::formatImpl(WriteBuffer & ostr, const FormatSettings 
 {
     if (path_with_type)
     {
-        path_with_type->formatImpl(ostr, settings, state, frame);
+        path_with_type->format(ostr, settings, state, frame);
     }
     else if (parameter)
     {
-        parameter->formatImpl(ostr, settings, state, frame);
+        parameter->format(ostr, settings, state, frame);
     }
     else if (skip_path)
     {
         std::string indent_str = settings.one_line ? "" : std::string(4 * frame.indent, ' ');
         ostr << indent_str << "SKIP" << ' ';
-        skip_path->formatImpl(ostr, settings, state, frame);
+        skip_path->format(ostr, settings, state, frame);
     }
     else if (skip_path_regexp)
     {
         std::string indent_str = settings.one_line ? "" : std::string(4 * frame.indent, ' ');
         ostr << indent_str << "SKIP REGEXP" << ' ';
-        skip_path_regexp->formatImpl(ostr, settings, state, frame);
+        skip_path_regexp->format(ostr, settings, state, frame);
     }
 }
 

--- a/src/Parsers/ASTOptimizeQuery.cpp
+++ b/src/Parsers/ASTOptimizeQuery.cpp
@@ -11,19 +11,19 @@ void ASTOptimizeQuery::formatQueryImpl(WriteBuffer & ostr, const FormatSettings 
 
     if (database)
     {
-        database->formatImpl(ostr, settings, state, frame);
+        database->format(ostr, settings, state, frame);
         ostr << '.';
     }
 
     chassert(table);
-    table->formatImpl(ostr, settings, state, frame);
+    table->format(ostr, settings, state, frame);
 
     formatOnCluster(ostr, settings);
 
     if (partition)
     {
         ostr << (settings.hilite ? hilite_keyword : "") << " PARTITION " << (settings.hilite ? hilite_none : "");
-        partition->formatImpl(ostr, settings, state, frame);
+        partition->format(ostr, settings, state, frame);
     }
 
     if (final)
@@ -38,7 +38,7 @@ void ASTOptimizeQuery::formatQueryImpl(WriteBuffer & ostr, const FormatSettings 
     if (deduplicate_by_columns)
     {
         ostr << (settings.hilite ? hilite_keyword : "") << " BY " << (settings.hilite ? hilite_none : "");
-        deduplicate_by_columns->formatImpl(ostr, settings, state, frame);
+        deduplicate_by_columns->format(ostr, settings, state, frame);
     }
 }
 

--- a/src/Parsers/ASTOrderByElement.cpp
+++ b/src/Parsers/ASTOrderByElement.cpp
@@ -17,7 +17,7 @@ void ASTOrderByElement::updateTreeHashImpl(SipHash & hash_state, bool ignore_ali
 
 void ASTOrderByElement::formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
 {
-    children.front()->formatImpl(ostr, settings, state, frame);
+    children.front()->format(ostr, settings, state, frame);
     ostr << (settings.hilite ? hilite_keyword : "")
         << (direction == -1 ? " DESC" : " ASC")
         << (settings.hilite ? hilite_none : "");
@@ -33,7 +33,7 @@ void ASTOrderByElement::formatImpl(WriteBuffer & ostr, const FormatSettings & se
     if (auto collation = getCollation())
     {
         ostr << (settings.hilite ? hilite_keyword : "") << " COLLATE " << (settings.hilite ? hilite_none : "");
-        collation->formatImpl(ostr, settings, state, frame);
+        collation->format(ostr, settings, state, frame);
     }
 
     if (with_fill)
@@ -42,22 +42,22 @@ void ASTOrderByElement::formatImpl(WriteBuffer & ostr, const FormatSettings & se
         if (auto fill_from = getFillFrom())
         {
             ostr << (settings.hilite ? hilite_keyword : "") << " FROM " << (settings.hilite ? hilite_none : "");
-            fill_from->formatImpl(ostr, settings, state, frame);
+            fill_from->format(ostr, settings, state, frame);
         }
         if (auto fill_to = getFillTo())
         {
             ostr << (settings.hilite ? hilite_keyword : "") << " TO " << (settings.hilite ? hilite_none : "");
-            fill_to->formatImpl(ostr, settings, state, frame);
+            fill_to->format(ostr, settings, state, frame);
         }
         if (auto fill_step = getFillStep())
         {
             ostr << (settings.hilite ? hilite_keyword : "") << " STEP " << (settings.hilite ? hilite_none : "");
-            fill_step->formatImpl(ostr, settings, state, frame);
+            fill_step->format(ostr, settings, state, frame);
         }
         if (auto fill_staleness = getFillStaleness())
         {
             ostr << (settings.hilite ? hilite_keyword : "") << " STALENESS " << (settings.hilite ? hilite_none : "");
-            fill_staleness->formatImpl(ostr, settings, state, frame);
+            fill_staleness->format(ostr, settings, state, frame);
         }
     }
 }

--- a/src/Parsers/ASTOrderByElement.cpp
+++ b/src/Parsers/ASTOrderByElement.cpp
@@ -70,7 +70,7 @@ void ASTStorageOrderByElement::updateTreeHashImpl(SipHash & hash_state, bool ign
 
 void ASTStorageOrderByElement::formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
 {
-    children.front()->formatImpl(ostr, settings, state, frame);
+    children.front()->format(ostr, settings, state, frame);
 
     if (direction == -1)
         ostr << (settings.hilite ? hilite_keyword : "") << " DESC" << (settings.hilite ? hilite_none : "");

--- a/src/Parsers/ASTOrderByElement.h
+++ b/src/Parsers/ASTOrderByElement.h
@@ -55,8 +55,8 @@ public:
 
 protected:
     void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
-private:
 
+private:
     ASTPtr getChild(Child child) const
     {
         auto it = positions.find(child);

--- a/src/Parsers/ASTPartition.cpp
+++ b/src/Parsers/ASTPartition.cpp
@@ -65,7 +65,7 @@ void ASTPartition::formatImpl(WriteBuffer & ostr, const FormatSettings & setting
 {
     if (value)
     {
-        value->formatImpl(ostr, settings, state, frame);
+        value->format(ostr, settings, state, frame);
     }
     else if (all)
     {
@@ -74,7 +74,7 @@ void ASTPartition::formatImpl(WriteBuffer & ostr, const FormatSettings & setting
     else
     {
         ostr << (settings.hilite ? hilite_keyword : "") << "ID " << (settings.hilite ? hilite_none : "");
-        id->formatImpl(ostr, settings, state, frame);
+        id->format(ostr, settings, state, frame);
     }
 }
 }

--- a/src/Parsers/ASTProjectionDeclaration.cpp
+++ b/src/Parsers/ASTProjectionDeclaration.cpp
@@ -24,7 +24,7 @@ void ASTProjectionDeclaration::formatImpl(WriteBuffer & ostr, const FormatSettin
     FormatStateStacked frame_nested = frame;
     frame_nested.need_parens = false;
     ++frame_nested.indent;
-    query->formatImpl(ostr, settings, state, frame_nested);
+    query->format(ostr, settings, state, frame_nested);
     ostr << nl_or_nothing << indent_str << ")";
 }
 

--- a/src/Parsers/ASTProjectionDeclaration.h
+++ b/src/Parsers/ASTProjectionDeclaration.h
@@ -17,12 +17,14 @@ public:
     String getID(char) const override { return "Projection"; }
 
     ASTPtr clone() const override;
-    void formatImpl(WriteBuffer & ostr, const FormatSettings & s, FormatState & state, FormatStateStacked frame) const override;
 
     void forEachPointerToChild(std::function<void(void**)> f) override
     {
         f(reinterpret_cast<void **>(&query));
     }
+
+protected:
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & s, FormatState & state, FormatStateStacked frame) const override;
 };
 
 }

--- a/src/Parsers/ASTProjectionSelectQuery.cpp
+++ b/src/Parsers/ASTProjectionSelectQuery.cpp
@@ -57,18 +57,18 @@ void ASTProjectionSelectQuery::formatImpl(WriteBuffer & ostr, const FormatSettin
     if (with())
     {
         ostr << (s.hilite ? hilite_keyword : "") << indent_str << "WITH " << (s.hilite ? hilite_none : "");
-        s.one_line ? with()->formatImpl(ostr, s, state, frame) : with()->as<ASTExpressionList &>().formatImplMultiline(ostr, s, state, frame);
+        s.one_line ? with()->format(ostr, s, state, frame) : with()->as<ASTExpressionList &>().formatImplMultiline(ostr, s, state, frame);
         ostr << s.nl_or_ws;
     }
 
     ostr << (s.hilite ? hilite_keyword : "") << indent_str << "SELECT " << (s.hilite ? hilite_none : "");
 
-    s.one_line ? select()->formatImpl(ostr, s, state, frame) : select()->as<ASTExpressionList &>().formatImplMultiline(ostr, s, state, frame);
+    s.one_line ? select()->format(ostr, s, state, frame) : select()->as<ASTExpressionList &>().formatImplMultiline(ostr, s, state, frame);
 
     if (groupBy())
     {
         ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << indent_str << "GROUP BY " << (s.hilite ? hilite_none : "");
-        s.one_line ? groupBy()->formatImpl(ostr, s, state, frame) : groupBy()->as<ASTExpressionList &>().formatImplMultiline(ostr, s, state, frame);
+        s.one_line ? groupBy()->format(ostr, s, state, frame) : groupBy()->as<ASTExpressionList &>().formatImplMultiline(ostr, s, state, frame);
     }
 
     if (orderBy())
@@ -84,7 +84,7 @@ void ASTProjectionSelectQuery::formatImpl(WriteBuffer & ostr, const FormatSettin
             order_by = std::make_shared<ASTExpressionList>();
             order_by->children.push_back(orderBy());
         }
-        s.one_line ? order_by->formatImpl(ostr, s, state, frame) : order_by->as<ASTExpressionList &>().formatImplMultiline(ostr, s, state, frame);
+        s.one_line ? order_by->format(ostr, s, state, frame) : order_by->as<ASTExpressionList &>().formatImplMultiline(ostr, s, state, frame);
     }
 }
 

--- a/src/Parsers/ASTQualifiedAsterisk.cpp
+++ b/src/Parsers/ASTQualifiedAsterisk.cpp
@@ -13,12 +13,12 @@ void ASTQualifiedAsterisk::appendColumnName(WriteBuffer & ostr) const
 
 void ASTQualifiedAsterisk::formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
 {
-    qualifier->formatImpl(ostr, settings, state, frame);
+    qualifier->format(ostr, settings, state, frame);
     ostr << ".*";
 
     if (transformers)
     {
-        transformers->formatImpl(ostr, settings, state, frame);
+        transformers->format(ostr, settings, state, frame);
     }
 }
 

--- a/src/Parsers/ASTQualifiedAsterisk.h
+++ b/src/Parsers/ASTQualifiedAsterisk.h
@@ -34,6 +34,7 @@ public:
 
     ASTPtr qualifier;
     ASTPtr transformers;
+
 protected:
     void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
 };

--- a/src/Parsers/ASTQueryWithOutput.cpp
+++ b/src/Parsers/ASTQueryWithOutput.cpp
@@ -13,10 +13,10 @@ void ASTQueryWithOutput::cloneOutputOptions(ASTQueryWithOutput & cloned) const
         cloned.out_file = out_file->clone();
         cloned.children.push_back(cloned.out_file);
     }
-    if (format)
+    if (format_ast)
     {
-        cloned.format = format->clone();
-        cloned.children.push_back(cloned.format);
+        cloned.format_ast = format_ast->clone();
+        cloned.children.push_back(cloned.format_ast);
     }
     if (settings_ast)
     {
@@ -44,7 +44,7 @@ void ASTQueryWithOutput::formatImpl(WriteBuffer & ostr, const FormatSettings & s
     if (out_file)
     {
         ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << indent_str << "INTO OUTFILE " << (s.hilite ? hilite_none : "");
-        out_file->formatImpl(ostr, s, state, frame);
+        out_file->format(ostr, s, state, frame);
 
         ostr << (s.hilite ? hilite_keyword : "");
         if (is_outfile_append)
@@ -56,16 +56,16 @@ void ASTQueryWithOutput::formatImpl(WriteBuffer & ostr, const FormatSettings & s
         ostr << (s.hilite ? hilite_none : "");
     }
 
-    if (format)
+    if (format_ast)
     {
         ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << indent_str << "FORMAT " << (s.hilite ? hilite_none : "");
-        format->formatImpl(ostr, s, state, frame);
+        format_ast->format(ostr, s, state, frame);
     }
 
     if (settings_ast && assert_cast<ASTSetQuery *>(settings_ast.get())->print_in_format)
     {
         ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << indent_str << "SETTINGS " << (s.hilite ? hilite_none : "");
-        settings_ast->formatImpl(ostr, s, state, frame);
+        settings_ast->format(ostr, s, state, frame);
     }
 }
 
@@ -86,7 +86,7 @@ bool ASTQueryWithOutput::resetOutputASTIfExist(IAST & ast)
         };
 
         remove_if_exists(ast_with_output->out_file);
-        remove_if_exists(ast_with_output->format);
+        remove_if_exists(ast_with_output->format_ast);
         remove_if_exists(ast_with_output->settings_ast);
         remove_if_exists(ast_with_output->compression);
         remove_if_exists(ast_with_output->compression_level);

--- a/src/Parsers/ASTQueryWithOutput.h
+++ b/src/Parsers/ASTQueryWithOutput.h
@@ -18,12 +18,10 @@ public:
     bool is_into_outfile_with_stdout = false;
     bool is_outfile_append = false;
     bool is_outfile_truncate = false;
-    ASTPtr format;
+    ASTPtr format_ast;
     ASTPtr settings_ast;
     ASTPtr compression;
     ASTPtr compression_level;
-
-    void formatImpl(WriteBuffer & ostr, const FormatSettings & s, FormatState & state, FormatStateStacked frame) const final;
 
     /// Remove 'FORMAT <fmt> and INTO OUTFILE <file>' if exists
     static bool resetOutputASTIfExist(IAST & ast);
@@ -34,6 +32,8 @@ protected:
 
     /// Format only the query part of the AST (without output options).
     virtual void formatQueryImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const = 0;
+
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & s, FormatState & state, FormatStateStacked frame) const final;
 };
 
 

--- a/src/Parsers/ASTQueryWithTableAndOutput.h
+++ b/src/Parsers/ASTQueryWithTableAndOutput.h
@@ -58,12 +58,12 @@ protected:
 
         if (database)
         {
-            database->formatImpl(ostr, settings, state, frame);
+            database->format(ostr, settings, state, frame);
             ostr << '.';
         }
 
         chassert(table != nullptr, "Table is empty for the ASTQueryWithTableAndOutputImpl.");
-        table->formatImpl(ostr, settings, state, frame);
+        table->format(ostr, settings, state, frame);
     }
 };
 

--- a/src/Parsers/ASTRefreshStrategy.cpp
+++ b/src/Parsers/ASTRefreshStrategy.cpp
@@ -34,15 +34,15 @@ void ASTRefreshStrategy::formatImpl(
     {
         case AFTER:
             ostr << "AFTER " << (f_settings.hilite ? hilite_none : "");
-            period->formatImpl(ostr, f_settings, state, frame);
+            period->format(ostr, f_settings, state, frame);
             break;
         case EVERY:
             ostr << "EVERY " << (f_settings.hilite ? hilite_none : "");
-            period->formatImpl(ostr, f_settings, state, frame);
+            period->format(ostr, f_settings, state, frame);
             if (offset)
             {
                 ostr << (f_settings.hilite ? hilite_keyword : "") << " OFFSET " << (f_settings.hilite ? hilite_none : "");
-                offset->formatImpl(ostr, f_settings, state, frame);
+                offset->format(ostr, f_settings, state, frame);
             }
             break;
         default:
@@ -53,17 +53,17 @@ void ASTRefreshStrategy::formatImpl(
     if (spread)
     {
         ostr << (f_settings.hilite ? hilite_keyword : "") << " RANDOMIZE FOR " << (f_settings.hilite ? hilite_none : "");
-        spread->formatImpl(ostr, f_settings, state, frame);
+        spread->format(ostr, f_settings, state, frame);
     }
     if (dependencies)
     {
         ostr << (f_settings.hilite ? hilite_keyword : "") << " DEPENDS ON " << (f_settings.hilite ? hilite_none : "");
-        dependencies->formatImpl(ostr, f_settings, state, frame);
+        dependencies->format(ostr, f_settings, state, frame);
     }
     if (settings)
     {
         ostr << (f_settings.hilite ? hilite_keyword : "") << " SETTINGS " << (f_settings.hilite ? hilite_none : "");
-        settings->formatImpl(ostr, f_settings, state, frame);
+        settings->format(ostr, f_settings, state, frame);
     }
     if (append)
         ostr << (f_settings.hilite ? hilite_keyword : "") << " APPEND" << (f_settings.hilite ? hilite_none : "");

--- a/src/Parsers/ASTRefreshStrategy.h
+++ b/src/Parsers/ASTRefreshStrategy.h
@@ -30,6 +30,7 @@ public:
 
     ASTPtr clone() const override;
 
+protected:
     void formatImpl(WriteBuffer & ostr, const FormatSettings & s, FormatState & state, FormatStateStacked frame) const override;
 };
 

--- a/src/Parsers/ASTRenameQuery.h
+++ b/src/Parsers/ASTRenameQuery.h
@@ -164,9 +164,9 @@ protected:
             if (elements.at(0).if_exists)
                 ostr << (settings.hilite ? hilite_keyword : "") << "IF EXISTS " << (settings.hilite ? hilite_none : "");
 
-            elements.at(0).from.database->formatImpl(ostr, settings, state, frame);
+            elements.at(0).from.database->format(ostr, settings, state, frame);
             ostr << (settings.hilite ? hilite_keyword : "") << " TO " << (settings.hilite ? hilite_none : "");
-            elements.at(0).to.database->formatImpl(ostr, settings, state, frame);
+            elements.at(0).to.database->format(ostr, settings, state, frame);
             formatOnCluster(ostr, settings);
             return;
         }
@@ -194,23 +194,23 @@ protected:
 
             if (it->from.database)
             {
-                it->from.database->formatImpl(ostr, settings, state, frame);
+                it->from.database->format(ostr, settings, state, frame);
                 ostr << '.';
             }
 
             chassert(it->from.table);
-            it->from.table->formatImpl(ostr, settings, state, frame);
+            it->from.table->format(ostr, settings, state, frame);
 
             ostr << (settings.hilite ? hilite_keyword : "") << (exchange ? " AND " : " TO ") << (settings.hilite ? hilite_none : "");
 
             if (it->to.database)
             {
-                it->to.database->formatImpl(ostr, settings, state, frame);
+                it->to.database->format(ostr, settings, state, frame);
                 ostr << '.';
             }
 
             chassert(it->to.table);
-            it->to.table->formatImpl(ostr, settings, state, frame);
+            it->to.table->format(ostr, settings, state, frame);
 
         }
 

--- a/src/Parsers/ASTSQLSecurity.cpp
+++ b/src/Parsers/ASTSQLSecurity.cpp
@@ -15,7 +15,7 @@ void ASTSQLSecurity::formatImpl(WriteBuffer & ostr, const FormatSettings & setti
         ostr << (settings.hilite ? hilite_keyword : "") << "DEFINER" << (settings.hilite ? hilite_none : "");
         ostr << " = ";
         if (definer)
-            definer->formatImpl(ostr, settings, state, frame);
+            definer->format(ostr, settings, state, frame);
         else
             ostr << "CURRENT_USER";
         ostr << " ";

--- a/src/Parsers/ASTSQLSecurity.h
+++ b/src/Parsers/ASTSQLSecurity.h
@@ -20,6 +20,7 @@ public:
     String getID(char) const override { return "View SQL Security"; }
     ASTPtr clone() const override { return std::make_shared<ASTSQLSecurity>(*this); }
 
+protected:
     void formatImpl(WriteBuffer & ostr, const FormatSettings & s, FormatState & state, FormatStateStacked frame) const override;
 };
 

--- a/src/Parsers/ASTSampleRatio.h
+++ b/src/Parsers/ASTSampleRatio.h
@@ -31,6 +31,7 @@ public:
     static String toString(BigNum num);
     static String toString(Rational ratio);
 
+protected:
     void formatImpl(WriteBuffer & ostr, const FormatSettings &, FormatState &, FormatStateStacked) const override;
 };
 

--- a/src/Parsers/ASTSelectIntersectExceptQuery.cpp
+++ b/src/Parsers/ASTSelectIntersectExceptQuery.cpp
@@ -32,7 +32,7 @@ void ASTSelectIntersectExceptQuery::formatImpl(WriteBuffer & ostr, const FormatS
                           << settings.nl_or_ws;
         }
 
-        (*it)->formatImpl(ostr, settings, state, frame);
+        (*it)->format(ostr, settings, state, frame);
     }
 }
 

--- a/src/Parsers/ASTSelectIntersectExceptQuery.h
+++ b/src/Parsers/ASTSelectIntersectExceptQuery.h
@@ -23,8 +23,6 @@ public:
         INTERSECT_DISTINCT,
     };
 
-    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
-
     QueryKind getQueryKind() const override { return QueryKind::Select; }
 
     ASTs getListOfSelects() const;
@@ -33,6 +31,9 @@ public:
 
     /// Final operator after applying visitor.
     Operator final_operator = Operator::UNKNOWN;
+
+protected:
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
 };
 
 }

--- a/src/Parsers/ASTSelectQuery.cpp
+++ b/src/Parsers/ASTSelectQuery.cpp
@@ -71,7 +71,7 @@ void ASTSelectQuery::formatImpl(WriteBuffer & ostr, const FormatSettings & s, Fo
             ostr << (s.hilite ? hilite_keyword : "") << " RECURSIVE" << (s.hilite ? hilite_none : "");
 
         s.one_line
-            ? with()->formatImpl(ostr, s, state, frame)
+            ? with()->format(ostr, s, state, frame)
             : with()->as<ASTExpressionList &>().formatImplMultiline(ostr, s, state, frame);
         ostr << s.nl_or_ws;
     }
@@ -79,25 +79,25 @@ void ASTSelectQuery::formatImpl(WriteBuffer & ostr, const FormatSettings & s, Fo
     ostr << (s.hilite ? hilite_keyword : "") << indent_str << "SELECT" << (distinct ? " DISTINCT" : "") << (s.hilite ? hilite_none : "");
 
     s.one_line
-        ? select()->formatImpl(ostr, s, state, frame)
+        ? select()->format(ostr, s, state, frame)
         : select()->as<ASTExpressionList &>().formatImplMultiline(ostr, s, state, frame);
 
     if (tables())
     {
         ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << indent_str << "FROM" << (s.hilite ? hilite_none : "");
-        tables()->formatImpl(ostr, s, state, frame);
+        tables()->format(ostr, s, state, frame);
     }
 
     if (prewhere())
     {
         ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << indent_str << "PREWHERE " << (s.hilite ? hilite_none : "");
-        prewhere()->formatImpl(ostr, s, state, frame);
+        prewhere()->format(ostr, s, state, frame);
     }
 
     if (where())
     {
         ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << indent_str << "WHERE " << (s.hilite ? hilite_none : "");
-        where()->formatImpl(ostr, s, state, frame);
+        where()->format(ostr, s, state, frame);
     }
 
     if (!group_by_all && groupBy())
@@ -106,7 +106,7 @@ void ASTSelectQuery::formatImpl(WriteBuffer & ostr, const FormatSettings & s, Fo
         if (!group_by_with_grouping_sets)
         {
             s.one_line
-            ? groupBy()->formatImpl(ostr, s, state, frame)
+            ? groupBy()->format(ostr, s, state, frame)
             : groupBy()->as<ASTExpressionList &>().formatImplMultiline(ostr, s, state, frame);
         }
     }
@@ -123,7 +123,7 @@ void ASTSelectQuery::formatImpl(WriteBuffer & ostr, const FormatSettings & s, Fo
         ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << indent_str << (s.one_line ? "" : "    ") << "GROUPING SETS" << (s.hilite ? hilite_none : "");
         ostr << " (";
         s.one_line
-        ? groupBy()->formatImpl(ostr, s, state, nested_frame)
+        ? groupBy()->format(ostr, s, state, nested_frame)
         : groupBy()->as<ASTExpressionList &>().formatImplMultiline(ostr, s, state, nested_frame);
         ostr << ")";
     }
@@ -140,7 +140,7 @@ void ASTSelectQuery::formatImpl(WriteBuffer & ostr, const FormatSettings & s, Fo
     if (having())
     {
         ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << indent_str << "HAVING " << (s.hilite ? hilite_none : "");
-        having()->formatImpl(ostr, s, state, frame);
+        having()->format(ostr, s, state, frame);
     }
 
     if (window())
@@ -153,14 +153,14 @@ void ASTSelectQuery::formatImpl(WriteBuffer & ostr, const FormatSettings & s, Fo
     if (qualify())
     {
         ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << indent_str << "QUALIFY " << (s.hilite ? hilite_none : "");
-        qualify()->formatImpl(ostr, s, state, frame);
+        qualify()->format(ostr, s, state, frame);
     }
 
     if (!order_by_all && orderBy())
     {
         ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << indent_str << "ORDER BY" << (s.hilite ? hilite_none : "");
         s.one_line
-            ? orderBy()->formatImpl(ostr, s, state, frame)
+            ? orderBy()->format(ostr, s, state, frame)
             : orderBy()->as<ASTExpressionList &>().formatImplMultiline(ostr, s, state, frame);
 
         if (interpolate())
@@ -169,7 +169,7 @@ void ASTSelectQuery::formatImpl(WriteBuffer & ostr, const FormatSettings & s, Fo
             if (!interpolate()->children.empty())
             {
                 ostr << " (";
-                interpolate()->formatImpl(ostr, s, state, frame);
+                interpolate()->format(ostr, s, state, frame);
                 ostr << " )";
             }
         }
@@ -198,13 +198,13 @@ void ASTSelectQuery::formatImpl(WriteBuffer & ostr, const FormatSettings & s, Fo
         ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << indent_str << "LIMIT " << (s.hilite ? hilite_none : "");
         if (limitByOffset())
         {
-            limitByOffset()->formatImpl(ostr, s, state, frame);
+            limitByOffset()->format(ostr, s, state, frame);
             ostr << ", ";
         }
-        limitByLength()->formatImpl(ostr, s, state, frame);
+        limitByLength()->format(ostr, s, state, frame);
         ostr << (s.hilite ? hilite_keyword : "") << " BY" << (s.hilite ? hilite_none : "");
         s.one_line
-            ? limitBy()->formatImpl(ostr, s, state, frame)
+            ? limitBy()->format(ostr, s, state, frame)
             : limitBy()->as<ASTExpressionList &>().formatImplMultiline(ostr, s, state, frame);
     }
 
@@ -213,23 +213,23 @@ void ASTSelectQuery::formatImpl(WriteBuffer & ostr, const FormatSettings & s, Fo
         ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << indent_str << "LIMIT " << (s.hilite ? hilite_none : "");
         if (limitOffset())
         {
-            limitOffset()->formatImpl(ostr, s, state, frame);
+            limitOffset()->format(ostr, s, state, frame);
             ostr << ", ";
         }
-        limitLength()->formatImpl(ostr, s, state, frame);
+        limitLength()->format(ostr, s, state, frame);
         if (limit_with_ties)
             ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << indent_str << " WITH TIES" << (s.hilite ? hilite_none : "");
     }
     else if (limitOffset())
     {
         ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << indent_str << "OFFSET " << (s.hilite ? hilite_none : "");
-        limitOffset()->formatImpl(ostr, s, state, frame);
+        limitOffset()->format(ostr, s, state, frame);
     }
 
     if (settings() && assert_cast<ASTSetQuery *>(settings().get())->print_in_format)
     {
         ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << indent_str << "SETTINGS " << (s.hilite ? hilite_none : "");
-        settings()->formatImpl(ostr, s, state, frame);
+        settings()->format(ostr, s, state, frame);
     }
 }
 

--- a/src/Parsers/ASTSelectWithUnionQuery.cpp
+++ b/src/Parsers/ASTSelectWithUnionQuery.cpp
@@ -68,13 +68,13 @@ void ASTSelectWithUnionQuery::formatQueryImpl(WriteBuffer & ostr, const FormatSe
 
             ostr << indent_str;
             auto sub_query = std::make_shared<ASTSubquery>(*it);
-            sub_query->formatImpl(ostr, settings, state, frame);
+            sub_query->format(ostr, settings, state, frame);
         }
         else
         {
             if (it != list_of_selects->children.begin())
                 ostr << settings.nl_or_ws;
-            (*it)->formatImpl(ostr, settings, state, frame);
+            (*it)->format(ostr, settings, state, frame);
         }
     }
 }

--- a/src/Parsers/ASTSetQuery.h
+++ b/src/Parsers/ASTSetQuery.h
@@ -32,14 +32,15 @@ public:
 
     ASTPtr clone() const override { return std::make_shared<ASTSetQuery>(*this); }
 
-    void formatImpl(WriteBuffer & ostr, const FormatSettings & format, FormatState &, FormatStateStacked) const override;
-
     void updateTreeHashImpl(SipHash & hash_state, bool ignore_aliases) const override;
 
     QueryKind getQueryKind() const override { return QueryKind::Set; }
 
     void appendColumnName(WriteBuffer & ostr) const override;
     void appendColumnNameWithoutAlias(WriteBuffer & ostr) const override { appendColumnName(ostr); }
+
+protected:
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & format, FormatState &, FormatStateStacked) const override;
 };
 
 }

--- a/src/Parsers/ASTShowColumnsQuery.cpp
+++ b/src/Parsers/ASTShowColumnsQuery.cpp
@@ -39,13 +39,13 @@ void ASTShowColumnsQuery::formatQueryImpl(WriteBuffer & ostr, const FormatSettin
     if (where_expression)
     {
         ostr << (settings.hilite ? hilite_keyword : "") << " WHERE " << (settings.hilite ? hilite_none : "");
-        where_expression->formatImpl(ostr, settings, state, frame);
+        where_expression->format(ostr, settings, state, frame);
     }
 
     if (limit_length)
     {
         ostr << (settings.hilite ? hilite_keyword : "") << " LIMIT " << (settings.hilite ? hilite_none : "");
-        limit_length->formatImpl(ostr, settings, state, frame);
+        limit_length->format(ostr, settings, state, frame);
     }
 }
 

--- a/src/Parsers/ASTShowIndexesQuery.cpp
+++ b/src/Parsers/ASTShowIndexesQuery.cpp
@@ -30,7 +30,7 @@ void ASTShowIndexesQuery::formatQueryImpl(WriteBuffer & ostr, const FormatSettin
     if (where_expression)
     {
         ostr << (settings.hilite ? hilite_keyword : "") << " WHERE " << (settings.hilite ? hilite_none : "");
-        where_expression->formatImpl(ostr, settings, state, frame);
+        where_expression->format(ostr, settings, state, frame);
     }
 }
 

--- a/src/Parsers/ASTShowTablesQuery.cpp
+++ b/src/Parsers/ASTShowTablesQuery.cpp
@@ -41,7 +41,7 @@ void ASTShowTablesQuery::formatLimit(WriteBuffer & ostr, const FormatSettings & 
     if (limit_length)
     {
         ostr << (settings.hilite ? hilite_keyword : "") << " LIMIT " << (settings.hilite ? hilite_none : "");
-        limit_length->formatImpl(ostr, settings, state, frame);
+        limit_length->format(ostr, settings, state, frame);
     }
 }
 
@@ -92,7 +92,7 @@ void ASTShowTablesQuery::formatQueryImpl(WriteBuffer & ostr, const FormatSetting
         if (from)
         {
             ostr << (settings.hilite ? hilite_keyword : "") << " FROM " << (settings.hilite ? hilite_none : "");
-            from->formatImpl(ostr, settings, state, frame);
+            from->format(ostr, settings, state, frame);
         }
 
         formatLike(ostr, settings);
@@ -100,7 +100,7 @@ void ASTShowTablesQuery::formatQueryImpl(WriteBuffer & ostr, const FormatSetting
         if (where_expression)
         {
             ostr << (settings.hilite ? hilite_keyword : "") << " WHERE " << (settings.hilite ? hilite_none : "");
-            where_expression->formatImpl(ostr, settings, state, frame);
+            where_expression->format(ostr, settings, state, frame);
         }
 
         formatLimit(ostr, settings, state, frame);

--- a/src/Parsers/ASTStatisticsDeclaration.cpp
+++ b/src/Parsers/ASTStatisticsDeclaration.cpp
@@ -47,12 +47,12 @@ std::vector<String> ASTStatisticsDeclaration::getTypeNames() const
 
 void ASTStatisticsDeclaration::formatImpl(WriteBuffer & ostr, const FormatSettings & s, FormatState & state, FormatStateStacked frame) const
 {
-    columns->formatImpl(ostr, s, state, frame);
+    columns->format(ostr, s, state, frame);
     ostr << (s.hilite ? hilite_keyword : "");
     if (types)
     {
         ostr << " TYPE " << (s.hilite ? hilite_none : "");
-        types->formatImpl(ostr, s, state, frame);
+        types->format(ostr, s, state, frame);
     }
 }
 

--- a/src/Parsers/ASTStatisticsDeclaration.h
+++ b/src/Parsers/ASTStatisticsDeclaration.h
@@ -22,6 +22,8 @@ public:
     std::vector<String> getTypeNames() const;
 
     ASTPtr clone() const override;
+
+protected:
     void formatImpl(WriteBuffer & ostr, const FormatSettings & s, FormatState & state, FormatStateStacked frame) const override;
 };
 

--- a/src/Parsers/ASTSubquery.cpp
+++ b/src/Parsers/ASTSubquery.cpp
@@ -47,7 +47,7 @@ void ASTSubquery::formatImplWithoutAlias(WriteBuffer & ostr, const FormatSetting
     FormatStateStacked frame_nested = frame;
     frame_nested.need_parens = false;
     ++frame_nested.indent;
-    children[0]->formatImpl(ostr, settings, state, frame_nested);
+    children[0]->format(ostr, settings, state, frame_nested);
     ostr << nl_or_nothing << indent_str << ")";
 }
 

--- a/src/Parsers/ASTSystemQuery.cpp
+++ b/src/Parsers/ASTSystemQuery.cpp
@@ -110,12 +110,12 @@ void ASTSystemQuery::formatImpl(WriteBuffer & ostr, const FormatSettings & setti
     {
         if (database)
         {
-            database->formatImpl(ostr, settings, state, frame);
+            database->format(ostr, settings, state, frame);
             ostr << '.';
         }
 
         chassert(table);
-        table->formatImpl(ostr, settings, state, frame);
+        table->format(ostr, settings, state, frame);
         return ostr;
     };
 
@@ -227,7 +227,7 @@ void ASTSystemQuery::formatImpl(WriteBuffer & ostr, const FormatSettings & setti
             if (query_settings)
             {
                 ostr << (settings.hilite ? hilite_keyword : "") << settings.nl_or_ws << "SETTINGS " << (settings.hilite ? hilite_none : "");
-                query_settings->formatImpl(ostr, settings, state, frame);
+                query_settings->format(ostr, settings, state, frame);
             }
 
             break;

--- a/src/Parsers/ASTSystemQuery.h
+++ b/src/Parsers/ASTSystemQuery.h
@@ -181,7 +181,6 @@ public:
     QueryKind getQueryKind() const override { return QueryKind::System; }
 
 protected:
-
     void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
 };
 

--- a/src/Parsers/ASTTTLElement.cpp
+++ b/src/Parsers/ASTTTLElement.cpp
@@ -32,7 +32,7 @@ ASTPtr ASTTTLElement::clone() const
 
 void ASTTTLElement::formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
 {
-    ttl()->formatImpl(ostr, settings, state, frame);
+    ttl()->format(ostr, settings, state, frame);
     if (mode == TTLMode::MOVE)
     {
         if (destination_type == DataDestinationType::DISK)
@@ -56,7 +56,7 @@ void ASTTTLElement::formatImpl(WriteBuffer & ostr, const FormatSettings & settin
         {
             if (it != group_by_key.begin())
                 ostr << ", ";
-            (*it)->formatImpl(ostr, settings, state, frame);
+            (*it)->format(ostr, settings, state, frame);
         }
 
         if (!group_by_assignments.empty())
@@ -66,14 +66,14 @@ void ASTTTLElement::formatImpl(WriteBuffer & ostr, const FormatSettings & settin
             {
                 if (it != group_by_assignments.begin())
                     ostr << ", ";
-                (*it)->formatImpl(ostr, settings, state, frame);
+                (*it)->format(ostr, settings, state, frame);
             }
         }
     }
     else if (mode == TTLMode::RECOMPRESS)
     {
         ostr << " RECOMPRESS ";
-        recompression_codec->formatImpl(ostr, settings, state, frame);
+        recompression_codec->format(ostr, settings, state, frame);
     }
     else if (mode == TTLMode::DELETE)
     {
@@ -83,7 +83,7 @@ void ASTTTLElement::formatImpl(WriteBuffer & ostr, const FormatSettings & settin
     if (where())
     {
         ostr << " WHERE ";
-        where()->formatImpl(ostr, settings, state, frame);
+        where()->format(ostr, settings, state, frame);
     }
 }
 

--- a/src/Parsers/ASTTableOverrides.cpp
+++ b/src/Parsers/ASTTableOverrides.cpp
@@ -32,7 +32,7 @@ void ASTTableOverride::formatImpl(WriteBuffer & ostr, const FormatSettings & set
     if (is_standalone)
     {
         ostr << hl_keyword << "TABLE OVERRIDE " << hl_none;
-        ASTIdentifier(table_name).formatImpl(ostr, settings, state, frame);
+        ASTIdentifier(table_name).format(ostr, settings, state, frame);
     }
     auto override_frame = frame;
     if (is_standalone)
@@ -47,7 +47,7 @@ void ASTTableOverride::formatImpl(WriteBuffer & ostr, const FormatSettings & set
         FormatStateStacked columns_frame = override_frame;
         columns_frame.expression_list_always_start_on_new_line = true;
         ostr << indent_str << hl_keyword << "COLUMNS" << hl_none << nl_or_ws << indent_str << "(";
-        columns->formatImpl(ostr, settings, state, columns_frame);
+        columns->format(ostr, settings, state, columns_frame);
         ostr << nl_or_nothing << indent_str << ")";
         ++override_elems;
     }
@@ -60,7 +60,7 @@ void ASTTableOverride::formatImpl(WriteBuffer & ostr, const FormatSettings & set
                 ostr << (override_elems++ ? nl_or_ws : "")
                               << indent_str
                               << hl_keyword << elem_name << hl_none << ' ';
-                elem->formatImpl(ostr, settings, state, override_frame);
+                elem->format(ostr, settings, state, override_frame);
             }
         };
         format_storage_elem(storage->partition_by, "PARTITION BY");
@@ -133,7 +133,7 @@ void ASTTableOverrideList::formatImpl(WriteBuffer & ostr, const FormatSettings &
             ostr << (settings.one_line ? ", " : ",\n");
         }
 
-        (*it)->formatImpl(ostr, settings, state, frame);
+        (*it)->format(ostr, settings, state, frame);
     }
 }
 

--- a/src/Parsers/ASTTableOverrides.h
+++ b/src/Parsers/ASTTableOverrides.h
@@ -26,13 +26,15 @@ public:
     bool is_standalone = true;
     String getID(char) const override { return "TableOverride " + table_name; }
     ASTPtr clone() const override;
-    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
 
     void forEachPointerToChild(std::function<void(void**)> f) override
     {
         f(reinterpret_cast<void **>(&columns));
         f(reinterpret_cast<void **>(&storage));
     }
+
+protected:
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
 };
 
 /// List of table overrides, for example:
@@ -45,11 +47,13 @@ class ASTTableOverrideList : public IAST
 public:
     String getID(char) const override { return "TableOverrideList"; }
     ASTPtr clone() const override;
-    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
     void setTableOverride(const String & name, ASTPtr ast);
     void removeTableOverride(const String & name);
     ASTPtr tryGetTableOverride(const String & name) const;
     bool hasOverride(const String & name) const;
+
+protected:
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
 
 private:
     std::map<String, size_t> positions;

--- a/src/Parsers/ASTTablesInSelectQuery.cpp
+++ b/src/Parsers/ASTTablesInSelectQuery.cpp
@@ -134,17 +134,17 @@ void ASTTableExpression::formatImpl(WriteBuffer & ostr, const FormatSettings & s
     if (database_and_table_name)
     {
         ostr << " ";
-        database_and_table_name->formatImpl(ostr, settings, state, frame);
+        database_and_table_name->format(ostr, settings, state, frame);
     }
     else if (table_function && !(table_function->as<ASTFunction>()->prefer_subquery_to_function_formatting && subquery))
     {
         ostr << " ";
-        table_function->formatImpl(ostr, settings, state, frame);
+        table_function->format(ostr, settings, state, frame);
     }
     else if (subquery)
     {
         ostr << settings.nl_or_ws << indent_str;
-        subquery->formatImpl(ostr, settings, state, frame);
+        subquery->format(ostr, settings, state, frame);
     }
 
     if (final)
@@ -157,13 +157,13 @@ void ASTTableExpression::formatImpl(WriteBuffer & ostr, const FormatSettings & s
     {
         ostr << (settings.hilite ? hilite_keyword : "") << settings.nl_or_ws << indent_str
             << "SAMPLE " << (settings.hilite ? hilite_none : "");
-        sample_size->formatImpl(ostr, settings, state, frame);
+        sample_size->format(ostr, settings, state, frame);
 
         if (sample_offset)
         {
             ostr << (settings.hilite ? hilite_keyword : "") << ' '
                 << "OFFSET " << (settings.hilite ? hilite_none : "");
-            sample_offset->formatImpl(ostr, settings, state, frame);
+            sample_offset->format(ostr, settings, state, frame);
         }
     }
 }
@@ -252,7 +252,7 @@ void ASTTableJoin::formatImplAfterTable(WriteBuffer & ostr, const FormatSettings
     {
         ostr << (settings.hilite ? hilite_keyword : "") << " USING " << (settings.hilite ? hilite_none : "");
         ostr << "(";
-        using_expression_list->formatImpl(ostr, settings, state, frame);
+        using_expression_list->format(ostr, settings, state, frame);
         ostr << ")";
     }
     else if (on_expression)
@@ -262,7 +262,7 @@ void ASTTableJoin::formatImplAfterTable(WriteBuffer & ostr, const FormatSettings
         bool on_has_alias = !on_expression->tryGetAlias().empty();
         if (on_has_alias)
             ostr << "(";
-        on_expression->formatImpl(ostr, settings, state, frame);
+        on_expression->format(ostr, settings, state, frame);
         if (on_has_alias)
             ostr << ")";
     }
@@ -288,7 +288,7 @@ void ASTArrayJoin::formatImpl(WriteBuffer & ostr, const FormatSettings & setting
         << (kind == Kind::Left ? "LEFT " : "") << "ARRAY JOIN" << (settings.hilite ? hilite_none : "");
 
     settings.one_line
-        ? expression_list->formatImpl(ostr, settings, state, frame)
+        ? expression_list->format(ostr, settings, state, frame)
         : expression_list->as<ASTExpressionList &>().formatImplMultiline(ostr, settings, state, frame);
 }
 
@@ -300,14 +300,14 @@ void ASTTablesInSelectQueryElement::formatImpl(WriteBuffer & ostr, const FormatS
         if (table_join)
             table_join->as<ASTTableJoin &>().formatImplBeforeTable(ostr, settings, state, frame);
 
-        table_expression->formatImpl(ostr, settings, state, frame);
+        table_expression->format(ostr, settings, state, frame);
 
         if (table_join)
             table_join->as<ASTTableJoin &>().formatImplAfterTable(ostr, settings, state, frame);
     }
     else if (array_join)
     {
-        array_join->formatImpl(ostr, settings, state, frame);
+        array_join->format(ostr, settings, state, frame);
     }
 }
 
@@ -315,7 +315,7 @@ void ASTTablesInSelectQueryElement::formatImpl(WriteBuffer & ostr, const FormatS
 void ASTTablesInSelectQuery::formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
 {
     for (const auto & child : children)
-        child->formatImpl(ostr, settings, state, frame);
+        child->format(ostr, settings, state, frame);
 }
 
 }

--- a/src/Parsers/ASTTablesInSelectQuery.h
+++ b/src/Parsers/ASTTablesInSelectQuery.h
@@ -56,8 +56,10 @@ struct ASTTableExpression : public IAST
     using IAST::IAST;
     String getID(char) const override { return "TableExpression"; }
     ASTPtr clone() const override;
-    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
     void updateTreeHashImpl(SipHash & hash_state, bool ignore_aliases) const override;
+
+protected:
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
 };
 
 
@@ -78,10 +80,10 @@ struct ASTTableJoin : public IAST
 
     void formatImplBeforeTable(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const;
     void formatImplAfterTable(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const;
-    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
     void updateTreeHashImpl(SipHash & hash_state, bool ignore_aliases) const override;
 
 protected:
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
     void forEachPointerToChild(std::function<void(void **)> f) override;
 };
 
@@ -102,8 +104,10 @@ struct ASTArrayJoin : public IAST
     using IAST::IAST;
     String getID(char) const override { return "ArrayJoin"; }
     ASTPtr clone() const override;
-    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
     void updateTreeHashImpl(SipHash & hash_state, bool ignore_aliases) const override;
+
+protected:
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
 };
 
 
@@ -120,6 +124,8 @@ struct ASTTablesInSelectQueryElement : public IAST
     using IAST::IAST;
     String getID(char) const override { return "TablesInSelectQueryElement"; }
     ASTPtr clone() const override;
+
+protected:
     void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
 };
 
@@ -130,6 +136,8 @@ struct ASTTablesInSelectQuery : public IAST
     using IAST::IAST;
     String getID(char) const override { return "TablesInSelectQuery"; }
     ASTPtr clone() const override;
+
+protected:
     void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
 };
 

--- a/src/Parsers/ASTTimeInterval.h
+++ b/src/Parsers/ASTTimeInterval.h
@@ -18,6 +18,8 @@ public:
     String getID(char) const override { return "TimeInterval"; }
 
     ASTPtr clone() const override;
+
+protected:
     void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
 };
 

--- a/src/Parsers/ASTTransactionControl.h
+++ b/src/Parsers/ASTTransactionControl.h
@@ -25,10 +25,12 @@ public:
     String getID(char /*delimiter*/) const override { return "ASTTransactionControl"; }
     ASTPtr clone() const override { return std::make_shared<ASTTransactionControl>(*this); }
 
-    void formatImpl(WriteBuffer & ostr, const FormatSettings & format, FormatState & /*state*/, FormatStateStacked /*frame*/) const override;
     void updateTreeHashImpl(SipHash & hash_state, bool ignore_aliases) const override;
 
     QueryKind getQueryKind() const override;
+
+protected:
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & format, FormatState & /*state*/, FormatStateStacked /*frame*/) const override;
 };
 
 }

--- a/src/Parsers/ASTUndropQuery.cpp
+++ b/src/Parsers/ASTUndropQuery.cpp
@@ -32,12 +32,12 @@ void ASTUndropQuery::formatQueryImpl(WriteBuffer & ostr, const FormatSettings & 
     {
         if (database)
         {
-            database->formatImpl(ostr, settings, state, frame);
+            database->format(ostr, settings, state, frame);
             ostr << '.';
         }
 
         chassert(table);
-        table->formatImpl(ostr, settings, state, frame);
+        table->format(ostr, settings, state, frame);
     }
 
     if (uuid != UUIDHelpers::Nil)

--- a/src/Parsers/ASTUseQuery.h
+++ b/src/Parsers/ASTUseQuery.h
@@ -42,7 +42,7 @@ protected:
     void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override
     {
         ostr << (settings.hilite ? hilite_keyword : "") << "USE " << (settings.hilite ? hilite_none : "");
-        database->formatImpl(ostr, settings, state, frame);
+        database->format(ostr, settings, state, frame);
     }
 };
 

--- a/src/Parsers/ASTViewTargets.cpp
+++ b/src/Parsers/ASTViewTargets.cpp
@@ -248,7 +248,7 @@ void ASTViewTargets::formatTarget(const ViewTarget & target, WriteBuffer & ostr,
         if (!keyword)
             throw Exception(ErrorCodes::LOGICAL_ERROR, "No prefix keyword for table engine of kind {}", toString(target.kind));
         ostr << " " << (s.hilite ? hilite_keyword : "") << toStringView(*keyword) << (s.hilite ? hilite_none : "");
-        target.inner_engine->formatImpl(ostr, s, state, frame);
+        target.inner_engine->format(ostr, s, state, frame);
     }
 }
 

--- a/src/Parsers/ASTViewTargets.h
+++ b/src/Parsers/ASTViewTargets.h
@@ -106,8 +106,6 @@ public:
 
     ASTPtr clone() const override;
 
-    void formatImpl(WriteBuffer & ostr, const FormatSettings & s, FormatState & state, FormatStateStacked frame) const override;
-
     /// Formats information only about a specific target table.
     void formatTarget(ViewTarget::Kind kind, WriteBuffer & ostr, const FormatSettings & s, FormatState & state, FormatStateStacked frame) const;
     static void formatTarget(const ViewTarget & target, WriteBuffer & ostr, const FormatSettings & s, FormatState & state, FormatStateStacked frame);
@@ -118,6 +116,7 @@ public:
     static std::optional<Keyword> getKeywordForInnerStorage(ViewTarget::Kind kind);
 
 protected:
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & s, FormatState & state, FormatStateStacked frame) const override;
     void forEachPointerToChild(std::function<void(void**)> f) override;
 };
 

--- a/src/Parsers/ASTWatchQuery.h
+++ b/src/Parsers/ASTWatchQuery.h
@@ -48,12 +48,12 @@ protected:
 
         if (database)
         {
-            database->formatImpl(ostr, settings, state, frame);
+            database->format(ostr, settings, state, frame);
             ostr << '.';
         }
 
         chassert(table);
-        table->formatImpl(ostr, settings, state, frame);
+        table->format(ostr, settings, state, frame);
 
         if (is_watch_events)
         {
@@ -63,7 +63,7 @@ protected:
         if (limit_length)
         {
             ostr << (settings.hilite ? hilite_keyword : "") << settings.nl_or_ws << indent_str << "LIMIT " << (settings.hilite ? hilite_none : "");
-            limit_length->formatImpl(ostr, settings, state, frame);
+            limit_length->format(ostr, settings, state, frame);
         }
     }
 };

--- a/src/Parsers/ASTWindowDefinition.cpp
+++ b/src/Parsers/ASTWindowDefinition.cpp
@@ -73,7 +73,7 @@ void ASTWindowDefinition::formatImpl(WriteBuffer & ostr, const FormatSettings & 
         }
 
         ostr << "PARTITION BY ";
-        partition_by->formatImpl(ostr, settings, state, format_frame);
+        partition_by->format(ostr, settings, state, format_frame);
 
         need_space = true;
     }
@@ -86,7 +86,7 @@ void ASTWindowDefinition::formatImpl(WriteBuffer & ostr, const FormatSettings & 
         }
 
         ostr << "ORDER BY ";
-        order_by->formatImpl(ostr, settings, state, format_frame);
+        order_by->format(ostr, settings, state, format_frame);
 
         need_space = true;
     }
@@ -109,7 +109,7 @@ void ASTWindowDefinition::formatImpl(WriteBuffer & ostr, const FormatSettings & 
         }
         else
         {
-            frame_begin_offset->formatImpl(ostr, settings, state, format_frame);
+            frame_begin_offset->format(ostr, settings, state, format_frame);
             ostr << " "
                 << (!frame_begin_preceding ? "FOLLOWING" : "PRECEDING");
         }
@@ -124,7 +124,7 @@ void ASTWindowDefinition::formatImpl(WriteBuffer & ostr, const FormatSettings & 
         }
         else
         {
-            frame_end_offset->formatImpl(ostr, settings, state, format_frame);
+            frame_end_offset->format(ostr, settings, state, format_frame);
             ostr << " "
                 << (!frame_end_preceding ? "FOLLOWING" : "PRECEDING");
         }
@@ -162,7 +162,7 @@ void ASTWindowListElement::formatImpl(WriteBuffer & ostr, const FormatSettings &
 {
     ostr << backQuoteIfNeed(name);
     ostr << " AS (";
-    definition->formatImpl(ostr, settings, state, frame);
+    definition->format(ostr, settings, state, frame);
     ostr << ")";
 }
 

--- a/src/Parsers/ASTWindowDefinition.h
+++ b/src/Parsers/ASTWindowDefinition.h
@@ -29,9 +29,10 @@ struct ASTWindowDefinition : public IAST
 
     String getID(char delimiter) const override;
 
-    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
-
     std::string getDefaultWindowName() const;
+
+protected:
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
 };
 
 struct ASTWindowListElement : public IAST
@@ -45,6 +46,7 @@ struct ASTWindowListElement : public IAST
 
     String getID(char delimiter) const override;
 
+protected:
     void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
 };
 

--- a/src/Parsers/ASTWithAlias.h
+++ b/src/Parsers/ASTWithAlias.h
@@ -30,14 +30,14 @@ public:
     String tryGetAlias() const override { return alias; }
     void setAlias(const String & to) override { alias = to; }
 
-    /// Calls formatImplWithoutAlias, and also outputs an alias. If necessary, encloses the entire expression in brackets.
-    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const final;
-
     void updateTreeHashImpl(SipHash & hash_state, bool ignore_aliases) const override;
 
     virtual void formatImplWithoutAlias(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const = 0;
 
 protected:
+    /// Calls formatImplWithoutAlias, and also outputs an alias. If necessary, encloses the entire expression in brackets.
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const final;
+
     virtual void appendColumnNameImpl(WriteBuffer & ostr) const = 0;
 };
 

--- a/src/Parsers/Access/ASTCheckGrantQuery.h
+++ b/src/Parsers/Access/ASTCheckGrantQuery.h
@@ -17,9 +17,11 @@ public:
 
     String getID(char) const override;
     ASTPtr clone() const override;
-    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
     void replaceEmptyDatabase(const String & current_database);
     QueryKind getQueryKind() const override { return QueryKind::Check; }
+
+protected:
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
 };
 
 }

--- a/src/Parsers/Access/ASTCreateQuotaQuery.h
+++ b/src/Parsers/Access/ASTCreateQuotaQuery.h
@@ -53,10 +53,13 @@ public:
 
     String getID(char) const override;
     ASTPtr clone() const override;
-    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
     void replaceCurrentUserTag(const String & current_user_name) const;
     ASTPtr getRewrittenASTWithoutOnCluster(const WithoutOnClusterASTRewriteParams &) const override { return removeOnCluster<ASTCreateQuotaQuery>(clone()); }
 
     QueryKind getQueryKind() const override { return QueryKind::Create; }
+
+protected:
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
 };
+
 }

--- a/src/Parsers/Access/ASTCreateRoleQuery.h
+++ b/src/Parsers/Access/ASTCreateRoleQuery.h
@@ -41,9 +41,12 @@ public:
 
     String getID(char) const override;
     ASTPtr clone() const override;
-    void formatImpl(WriteBuffer & ostr, const FormatSettings & format, FormatState &, FormatStateStacked) const override;
     ASTPtr getRewrittenASTWithoutOnCluster(const WithoutOnClusterASTRewriteParams &) const override { return removeOnCluster<ASTCreateRoleQuery>(clone()); }
 
     QueryKind getQueryKind() const override { return QueryKind::Create; }
+
+protected:
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & format, FormatState &, FormatStateStacked) const override;
 };
+
 }

--- a/src/Parsers/Access/ASTCreateRowPolicyQuery.h
+++ b/src/Parsers/Access/ASTCreateRowPolicyQuery.h
@@ -47,12 +47,15 @@ public:
 
     String getID(char) const override;
     ASTPtr clone() const override;
-    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
     ASTPtr getRewrittenASTWithoutOnCluster(const WithoutOnClusterASTRewriteParams &) const override { return removeOnCluster<ASTCreateRowPolicyQuery>(clone()); }
 
     void replaceCurrentUserTag(const String & current_user_name) const;
     void replaceEmptyDatabase(const String & current_database) const;
 
     QueryKind getQueryKind() const override { return QueryKind::Create; }
+
+protected:
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
 };
+
 }

--- a/src/Parsers/Access/ASTCreateSettingsProfileQuery.h
+++ b/src/Parsers/Access/ASTCreateSettingsProfileQuery.h
@@ -46,10 +46,12 @@ public:
 
     String getID(char) const override;
     ASTPtr clone() const override;
-    void formatImpl(WriteBuffer & ostr, const FormatSettings & format, FormatState &, FormatStateStacked) const override;
     void replaceCurrentUserTag(const String & current_user_name) const;
     ASTPtr getRewrittenASTWithoutOnCluster(const WithoutOnClusterASTRewriteParams &) const override { return removeOnCluster<ASTCreateSettingsProfileQuery>(clone()); }
     QueryKind getQueryKind() const override { return QueryKind::Create; }
+
+protected:
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & format, FormatState &, FormatStateStacked) const override;
 };
 
 }

--- a/src/Parsers/Access/ASTCreateUserQuery.h
+++ b/src/Parsers/Access/ASTCreateUserQuery.h
@@ -73,9 +73,12 @@ public:
 
     String getID(char) const override;
     ASTPtr clone() const override;
-    void formatImpl(WriteBuffer & ostr, const FormatSettings & format, FormatState &, FormatStateStacked) const override;
     ASTPtr getRewrittenASTWithoutOnCluster(const WithoutOnClusterASTRewriteParams &) const override { return removeOnCluster<ASTCreateUserQuery>(clone()); }
 
     QueryKind getQueryKind() const override { return QueryKind::Create; }
+
+protected:
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & format, FormatState &, FormatStateStacked) const override;
 };
+
 }

--- a/src/Parsers/Access/ASTDropAccessEntityQuery.h
+++ b/src/Parsers/Access/ASTDropAccessEntityQuery.h
@@ -26,11 +26,14 @@ public:
 
     String getID(char) const override;
     ASTPtr clone() const override;
-    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
     ASTPtr getRewrittenASTWithoutOnCluster(const WithoutOnClusterASTRewriteParams &) const override { return removeOnCluster<ASTDropAccessEntityQuery>(clone()); }
 
     void replaceEmptyDatabase(const String & current_database) const;
 
     QueryKind getQueryKind() const override { return QueryKind::Drop; }
+
+protected:
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
 };
+
 }

--- a/src/Parsers/Access/ASTGrantQuery.h
+++ b/src/Parsers/Access/ASTGrantQuery.h
@@ -32,10 +32,13 @@ public:
 
     String getID(char) const override;
     ASTPtr clone() const override;
-    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
     void replaceEmptyDatabase(const String & current_database);
     void replaceCurrentUserTag(const String & current_user_name) const;
     ASTPtr getRewrittenASTWithoutOnCluster(const WithoutOnClusterASTRewriteParams &) const override { return removeOnCluster<ASTGrantQuery>(clone()); }
     QueryKind getQueryKind() const override { return is_revoke ? QueryKind::Revoke : QueryKind::Grant; }
+
+protected:
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
 };
+
 }

--- a/src/Parsers/Access/ASTMoveAccessEntityQuery.h
+++ b/src/Parsers/Access/ASTMoveAccessEntityQuery.h
@@ -22,11 +22,14 @@ public:
 
     String getID(char) const override;
     ASTPtr clone() const override;
-    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
     ASTPtr getRewrittenASTWithoutOnCluster(const WithoutOnClusterASTRewriteParams &) const override { return removeOnCluster<ASTMoveAccessEntityQuery>(clone()); }
 
     void replaceEmptyDatabase(const String & current_database) const;
 
     QueryKind getQueryKind() const override { return QueryKind::Move; }
+
+protected:
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
 };
+
 }

--- a/src/Parsers/Access/ASTPublicSSHKey.h
+++ b/src/Parsers/Access/ASTPublicSSHKey.h
@@ -19,6 +19,8 @@ public:
     {}
     String getID(char) const override { return "PublicSSHKey"; }
     ASTPtr clone() const override { return std::make_shared<ASTPublicSSHKey>(*this); }
+
+protected:
     void formatImpl(WriteBuffer & ostr, const FormatSettings &, FormatState &, FormatStateStacked) const override;
 };
 

--- a/src/Parsers/Access/ASTRolesOrUsersSet.h
+++ b/src/Parsers/Access/ASTRolesOrUsersSet.h
@@ -30,6 +30,9 @@ public:
 
     String getID(char) const override { return "RolesOrUsersSet"; }
     ASTPtr clone() const override { return std::make_shared<ASTRolesOrUsersSet>(*this); }
+
+protected:
     void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
 };
+
 }

--- a/src/Parsers/Access/ASTRowPolicyName.h
+++ b/src/Parsers/Access/ASTRowPolicyName.h
@@ -19,10 +19,12 @@ public:
 
     String getID(char) const override { return "RowPolicyName"; }
     ASTPtr clone() const override { return std::make_shared<ASTRowPolicyName>(*this); }
-    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
     ASTPtr getRewrittenASTWithoutOnCluster(const WithoutOnClusterASTRewriteParams &) const override { return removeOnCluster<ASTRowPolicyName>(clone()); }
 
     void replaceEmptyDatabase(const String & current_database);
+
+protected:
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
 };
 
 
@@ -41,10 +43,12 @@ public:
 
     String getID(char) const override { return "RowPolicyNames"; }
     ASTPtr clone() const override { return std::make_shared<ASTRowPolicyNames>(*this); }
-    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
     ASTPtr getRewrittenASTWithoutOnCluster(const WithoutOnClusterASTRewriteParams &) const override { return removeOnCluster<ASTRowPolicyNames>(clone()); }
 
     void replaceEmptyDatabase(const String & current_database);
+
+protected:
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
 
 private:
     String tableOrAsterisk(const String & table_name) const;

--- a/src/Parsers/Access/ASTSetRoleQuery.h
+++ b/src/Parsers/Access/ASTSetRoleQuery.h
@@ -26,8 +26,11 @@ public:
 
     String getID(char) const override;
     ASTPtr clone() const override;
-    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
 
     QueryKind getQueryKind() const override { return QueryKind::Set; }
+
+protected:
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
 };
+
 }

--- a/src/Parsers/Access/ASTSettingsProfileElement.h
+++ b/src/Parsers/Access/ASTSettingsProfileElement.h
@@ -25,6 +25,8 @@ public:
 
     String getID(char) const override { return "SettingsProfileElement"; }
     ASTPtr clone() const override { return std::make_shared<ASTSettingsProfileElement>(*this); }
+
+protected:
     void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
 };
 
@@ -44,11 +46,13 @@ public:
 
     String getID(char) const override { return "SettingsProfileElements"; }
     ASTPtr clone() const override;
-    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
 
     void setUseInheritKeyword(bool use_inherit_keyword_);
 
     void add(ASTSettingsProfileElements && other);
+
+protected:
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
 };
 
 /* Represents a clause used to alter settings or profiles assigned to a user or a role or another profile.
@@ -71,9 +75,11 @@ public:
 
     String getID(char) const override;
     ASTPtr clone() const override;
-    void formatImpl(WriteBuffer & ostr, const FormatSettings & format, FormatState &, FormatStateStacked) const override;
 
     void add(ASTAlterSettingsProfileElements && other);
+
+protected:
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & format, FormatState &, FormatStateStacked) const override;
 };
 
 }

--- a/src/Parsers/Access/ASTUserNameWithHost.h
+++ b/src/Parsers/Access/ASTUserNameWithHost.h
@@ -26,8 +26,10 @@ public:
     explicit ASTUserNameWithHost(const String & name_) : base_name(name_) {}
     String getID(char) const override { return "UserNameWithHost"; }
     ASTPtr clone() const override { return std::make_shared<ASTUserNameWithHost>(*this); }
-    void formatImpl(WriteBuffer & ostr, const FormatSettings &, FormatState &, FormatStateStacked) const override;
     void replace(String name_);
+
+protected:
+    void formatImpl(WriteBuffer & ostr, const FormatSettings &, FormatState &, FormatStateStacked) const override;
 };
 
 
@@ -48,6 +50,8 @@ public:
 
     String getID(char) const override { return "UserNamesWithHost"; }
     ASTPtr clone() const override { return std::make_shared<ASTUserNamesWithHost>(*this); }
+
+protected:
     void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
 };
 

--- a/src/Parsers/IAST.h
+++ b/src/Parsers/IAST.h
@@ -259,9 +259,9 @@ public:
         formatImpl(ostr, settings, state, FormatStateStacked());
     }
 
-    virtual void formatImpl(WriteBuffer & /*ostr*/, const FormatSettings & /*settings*/, FormatState & /*state*/, FormatStateStacked /*frame*/) const
+    void format(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
     {
-        throw Exception(ErrorCodes::LOGICAL_ERROR, "Unknown element in AST: {}", getID());
+        formatImpl(ostr, settings, state, std::move(frame));
     }
 
     /// Secrets are displayed regarding show_secrets, then SensitiveDataMasker is applied.
@@ -351,6 +351,11 @@ public:
     static const char * hilite_none;
 
 protected:
+    virtual void formatImpl(WriteBuffer & /*ostr*/, const FormatSettings & /*settings*/, FormatState & /*state*/, FormatStateStacked /*frame*/) const
+    {
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Unknown element in AST: {}", getID());
+    }
+
     bool childrenHaveSecretParts() const;
 
     /// Some AST classes have naked pointers to children elements as members.

--- a/src/Parsers/ParserQueryWithOutput.cpp
+++ b/src/Parsers/ParserQueryWithOutput.cpp
@@ -180,15 +180,15 @@ bool ParserQueryWithOutput::parseImpl(Pos & pos, ASTPtr & node, Expected & expec
 
     for (size_t i = 0; i < 2; ++i)
     {
-        if (!query_with_output.format && s_format.ignore(pos, expected))
+        if (!query_with_output.format_ast && s_format.ignore(pos, expected))
         {
             ParserIdentifier format_p;
 
-            if (!format_p.parse(pos, query_with_output.format, expected))
+            if (!format_p.parse(pos, query_with_output.format_ast, expected))
                 return false;
-            setIdentifierSpecial(query_with_output.format);
+            setIdentifierSpecial(query_with_output.format_ast);
 
-            query_with_output.children.push_back(query_with_output.format);
+            query_with_output.children.push_back(query_with_output.format_ast);
         }
         else if (!query_with_output.settings_ast && s_settings.ignore(pos, expected))
         {

--- a/src/Parsers/TablePropertiesQueriesASTs.h
+++ b/src/Parsers/TablePropertiesQueriesASTs.h
@@ -99,7 +99,7 @@ protected:
     {
         ostr << (settings.hilite ? hilite_keyword : "") << ASTExistsDatabaseQueryIDAndQueryNames::Query
                     << " " << (settings.hilite ? hilite_none : "");
-        database->formatImpl(ostr, settings, state, frame);
+        database->format(ostr, settings, state, frame);
     }
 
     QueryKind getQueryKind() const override { return QueryKind::Exists; }
@@ -121,7 +121,7 @@ protected:
     {
         ostr << (settings.hilite ? hilite_keyword : "") << ASTShowCreateDatabaseQueryIDAndQueryNames::Query
                       << " " << (settings.hilite ? hilite_none : "");
-        database->formatImpl(ostr, settings, state, frame);
+        database->format(ostr, settings, state, frame);
     }
 };
 
@@ -152,7 +152,7 @@ protected:
     {
         ostr << (settings.hilite ? hilite_keyword : "")
                       << "DESCRIBE TABLE" << (settings.hilite ? hilite_none : "");
-        table_expression->formatImpl(ostr, settings, state, frame);
+        table_expression->format(ostr, settings, state, frame);
     }
 
 };

--- a/src/Server/GRPCServer.cpp
+++ b/src/Server/GRPCServer.cpp
@@ -936,9 +936,9 @@ namespace
         /// Choose output format.
         query_context->setDefaultFormat(query_info.output_format());
         if (const auto * ast_query_with_output = dynamic_cast<const ASTQueryWithOutput *>(ast.get());
-            ast_query_with_output && ast_query_with_output->format)
+            ast_query_with_output && ast_query_with_output->format_ast)
         {
-            output_format = getIdentifierName(ast_query_with_output->format);
+            output_format = getIdentifierName(ast_query_with_output->format_ast);
         }
         if (output_format.empty())
             output_format = query_context->getDefaultFormat();

--- a/src/Storages/ColumnsDescription.cpp
+++ b/src/Storages/ColumnsDescription.cpp
@@ -123,7 +123,7 @@ String formatASTStateAware(IAST & ast, IAST::FormatState & state)
 {
     WriteBufferFromOwnString buf;
     IAST::FormatSettings settings(true, false);
-    ast.formatImpl(buf, settings, state, IAST::FormatStateStacked());
+    ast.format(buf, settings, state, IAST::FormatStateStacked());
     return buf.str();
 }
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Better IAST::format() interface:
- `IAST::formatImpl()` is now protected, and `IAST::format()` is called instead.
- class `IAST::FormattingBuffer` was added as preparation for https://github.com/ClickHouse/ClickHouse/pull/45649

This is part 2 of https://github.com/ClickHouse/ClickHouse/pull/45649