### PR TITLE
RMT: Fix REPLACE PARTITION ALL for empty table

### DIFF
--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -8334,6 +8334,9 @@ void StorageReplicatedMergeTree::replacePartitionFrom(
     }
     LOG_INFO(log, "Will try to attach {} partitions", partitions.size());
 
+    if (partitions.empty())
+        return;
+
     const Stopwatch watch;
     ProfileEventsScope profile_events_scope;
     const auto zookeeper = getZooKeeper();


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixes https://s3.amazonaws.com/clickhouse-test-reports/0/ca2813bacf22895eed99581069d5a634bf95f3ff/stress_test__ubsan_.html

```
/build/src/Storages/StorageReplicatedMergeTree.cpp:8352:62: runtime error: variable length array bound evaluates to non-positive value 0
    #0 0x558b42ad705e in DB::StorageReplicatedMergeTree::replacePartitionFrom(std::__1::shared_ptr<DB::IStorage> const&, std::__1::shared_ptr<DB::IAST> const&, bool, std::__1::shared_ptr<DB::Context const>) build_docker/./src/Storages/StorageReplicatedMergeTree.cpp:8352:5
    #1 0x558b430e18bb in DB::MergeTreeData::alterPartition(std::__1::shared_ptr<DB::StorageInMemoryMetadata const> const&, std::__1::vector<DB::PartitionCommand, std::__1::allocator<DB::PartitionCommand>> const&, std::__1::shared_ptr<DB::Context const>) build_docker/./src/Storages/MergeTree/MergeTreeData.cpp:5620:17
    #2 0x558b404637e2 in DB::InterpreterAlterQuery::executeToTable(DB::ASTAlterQuery const&) build_docker/./src/Interpreters/InterpreterAlterQuery.cpp:245:47
    #3 0x558b40460590 in DB::InterpreterAlterQuery::execute() build_docker/./src/Interpreters/InterpreterAlterQuery.cpp:80:16
    #4 0x558b40f78862 in DB::executeQueryImpl(char const*, char const*, std::__1::shared_ptr<DB::Context>, DB::QueryFlags, DB::QueryProcessingStage::Enum, DB::ReadBuffer*) build_docker/./src/Interpreters/executeQuery.cpp:1368:40
    #5 0x558b40f7276d in DB::executeQuery(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::shared_ptr<DB::Context>, DB::QueryFlags, DB::QueryProcessingStage::Enum) build_docker/./src/Interpreters/executeQuery.cpp:1535:26
    #6 0x558b43a13a1b in DB::TCPHandler::runImpl() build_docker/./src/Server/TCPHandler.cpp:656:68
    #7 0x558b43a3e96d in DB::TCPHandler::run() build_docker/./src/Server/TCPHandler.cpp:2598:9
    #8 0x558b47524ac1 in Poco::Net::TCPServerConnection::start() build_docker/./base/poco/Net/src/TCPServerConnection.cpp:40:3
    #9 0x558b47525791 in Poco::Net::TCPServerDispatcher::run() build_docker/./base/poco/Net/src/TCPServerDispatcher.cpp:115:38
    #10 0x558b47483116 in Poco::PooledThread::run() build_docker/./base/poco/Foundation/src/ThreadPool.cpp:205:14
    #11 0x558b4747ea0d in Poco::ThreadImpl::runnableEntry(void*) build_docker/./base/poco/Foundation/src/Thread_POSIX.cpp:335:27
    #12 0x7f91b53d5ac2  (/lib/x86_64-linux-gnu/libc.so.6+0x94ac2) (BuildId: 490fef8403240c91833978d494d39e537409b92e)
    #13 0x7f91b546784f  (/lib/x86_64-linux-gnu/libc.so.6+0x12684f) (BuildId: 490fef8403240c91833978d494d39e537409b92e)
```

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---ci_include_fuzzer--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
