### PR TITLE
Add cancel reason CANCELLED_BY_ERROR

### DIFF
--- a/src/Backups/BackupCoordinationStageSync.cpp
+++ b/src/Backups/BackupCoordinationStageSync.cpp
@@ -21,6 +21,8 @@ namespace ErrorCodes
 {
     extern const int FAILED_TO_SYNC_BACKUP_OR_RESTORE;
     extern const int LOGICAL_ERROR;
+    extern const int QUERY_WAS_CANCELLED;
+    extern const int QUERY_WAS_CANCELLED_BY_CLIENT;
 }
 
 namespace
@@ -692,7 +694,12 @@ void BackupCoordinationStageSync::cancelQueryIfError()
     if (!exception)
         return;
 
-    process_list_element->cancelQuery(CancelReason::CANCELLED_BY_USER, exception);
+    auto code = getExceptionErrorCode(exception);
+    auto cancel_reason = ((code == ErrorCodes::QUERY_WAS_CANCELLED) || (code == ErrorCodes::QUERY_WAS_CANCELLED_BY_CLIENT))
+        ? CancelReason::CANCELLED_BY_USER
+        : CancelReason::CANCELLED_BY_ERROR;
+
+    process_list_element->cancelQuery(cancel_reason, exception);
 
     state_changed.notify_all();
 }
@@ -747,7 +754,7 @@ void BackupCoordinationStageSync::cancelQueryIfDisconnectedTooLong()
     /// we don't want the watching thread to try waiting here for retries or a reconnection).
     /// Also we don't set the `state.host_with_error` field here because `state.host_with_error` can only be set
     /// AFTER creating the 'error' node (see the comment for `State`).
-    process_list_element->cancelQuery(CancelReason::CANCELLED_BY_USER, exception);
+    process_list_element->cancelQuery(CancelReason::CANCELLED_BY_ERROR, exception);
 
     state_changed.notify_all();
 }

--- a/src/Interpreters/ProcessList.cpp
+++ b/src/Interpreters/ProcessList.cpp
@@ -464,12 +464,11 @@ CancellationCode QueryStatus::cancelQuery(CancelReason reason, std::exception_pt
         if (is_killed)
             return CancellationCode::CancelSent;
 
+        LOG_TRACE(getLogger("ProcessList"), "Cancelling the query (reason: {})", reason);
+
         is_killed = true;
-
-        if (!cancellation_exception)
-            cancellation_exception = exception;
-
         cancel_reason = reason;
+        cancellation_exception = exception;
     }
 
     std::vector<ExecutorHolderPtr> executors_snapshot;

--- a/src/Interpreters/ProcessList.h
+++ b/src/Interpreters/ProcessList.h
@@ -48,6 +48,9 @@ enum CancelReason
     UNDEFINED,
     TIMEOUT,
     CANCELLED_BY_USER,
+
+    /// CANCELLED_BY_ERROR means that there were parallel processes/threads and some of them failed,
+    /// so we cancel other processes/threads with this cancel reason.
     CANCELLED_BY_ERROR,
 };
 

--- a/src/Interpreters/ProcessList.h
+++ b/src/Interpreters/ProcessList.h
@@ -48,6 +48,7 @@ enum CancelReason
     UNDEFINED,
     TIMEOUT,
     CANCELLED_BY_USER,
+    CANCELLED_BY_ERROR,
 };
 
 /** Information of process list element.


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add cancel reason `CANCELLED_BY_ERROR`.

This PR is an improvement after https://github.com/ClickHouse/ClickHouse/pull/69880