### PR TITLE
Mark server setting `use_legacy_mongodb_integration` as obsolete

### DIFF
--- a/src/Core/ServerSettings.cpp
+++ b/src/Core/ServerSettings.cpp
@@ -201,7 +201,7 @@ namespace DB
     DECLARE(UInt64, parts_kill_delay_period_random_add, 10, "Add uniformly distributed value from 0 to x seconds to kill_delay_period to avoid thundering herd effect and subsequent DoS of ZooKeeper in case of very large number of tables. Only available in ClickHouse Cloud", 0) \
     DECLARE(UInt64, parts_killer_pool_size, 128, "Threads for cleanup of shared merge tree outdated threads. Only available in ClickHouse Cloud", 0) \
     DECLARE(UInt64, keeper_multiread_batch_size, 10'000, "Maximum size of batch for MultiRead request to [Zoo]Keeper that support batching. If set to 0, batching is disabled. Available only in ClickHouse Cloud.", 0) \
-    DECLARE(Bool, use_legacy_mongodb_integration, true, "Obsolete, has no effect", 0) \
+    DECLARE(Bool, use_legacy_mongodb_integration, true, "Obsolete, does nothing.", SettingsTierType::OBSOLETE) \
     DECLARE(Bool, send_settings_to_client, true, "Send user settings from server configuration to clients (in the server Hello message).", 0) \
     \
     DECLARE(UInt64, prefetch_threadpool_pool_size, 100, "Size of background pool for prefetches for remote object storages", 0) \

--- a/tests/queries/0_stateless/02888_obsolete_settings.reference
+++ b/tests/queries/0_stateless/02888_obsolete_settings.reference
@@ -1,4 +1,5 @@
 -- Obsolete server settings
+use_legacy_mongodb_integration
 -- Obsolete general settings
 1
 -- Obsolete merge tree settings


### PR DESCRIPTION
Prior to this PR, the setting only mentioned in its comment that it is obsolete. Now, it applies the proper obsolete flag.

Cf. https://github.com/ClickHouse/ClickHouse/pull/71997#discussion_r1882291497

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)