### PR TITLE
Clickhouse-client supports Ctrl+D in the multiline mode

### DIFF
--- a/src/Client/LineReader.cpp
+++ b/src/Client/LineReader.cpp
@@ -153,8 +153,11 @@ LineReader::LineReader(
 
 String LineReader::readLine(const String & first_prompt, const String & second_prompt)
 {
+    static const String EMPTY_LINE = " ";
+
     String line;
     bool need_next_line = false;
+    bool is_first_line = true;
 
     while (auto status = readOneLine(need_next_line ? second_prompt : first_prompt))
     {
@@ -162,8 +165,32 @@ String LineReader::readLine(const String & first_prompt, const String & second_p
         {
             line.clear();
             need_next_line = false;
+            is_first_line = true;
             continue;
         }
+
+        if (status == COMMIT_LINE)
+        {
+            bool is_empty = input.empty();
+            trim(input);
+
+            if (!input.empty())
+                line += (line.empty() ? "" : "\n") + input;
+
+            if (!line.empty())
+                break;
+
+            if (!is_first_line || !is_empty)
+            {
+                /// To prevent the clickhouse-client from exiting.
+                line = EMPTY_LINE;
+            }
+
+            break;
+        }
+
+        is_first_line = false;
+        trim(input);
 
         if (input.empty())
         {
@@ -228,7 +255,6 @@ LineReader::InputStatus LineReader::readOneLine(const String & prompt)
             return ABORT;
     }
 
-    trim(input);
     return INPUT_LINE;
 }
 

--- a/src/Client/LineReader.cpp
+++ b/src/Client/LineReader.cpp
@@ -182,7 +182,7 @@ String LineReader::readLine(const String & first_prompt, const String & second_p
 
             if (!is_first_line || !is_empty)
             {
-                /// To prevent the clickhouse-client from exiting.
+                /// To prevent the client from exiting.
                 line = EMPTY_LINE;
             }
 

--- a/src/Client/LineReader.h
+++ b/src/Client/LineReader.h
@@ -74,6 +74,7 @@ protected:
         ABORT = 0,
         RESET_LINE,
         INPUT_LINE,
+        COMMIT_LINE,
     };
 
     const String history_file_path;

--- a/src/Client/ReplxxLineReader.cpp
+++ b/src/Client/ReplxxLineReader.cpp
@@ -32,12 +32,6 @@
 namespace
 {
 
-/// Trim ending whitespace inplace
-void rightTrim(String & s)
-{
-    s.erase(std::find_if(s.rbegin(), s.rend(), [](unsigned char ch) { return !std::isspace(ch); }).base(), s.end());
-}
-
 std::string getEditor()
 {
     const char * editor = std::getenv("EDITOR"); // NOLINT(concurrency-mt-unsafe)
@@ -384,6 +378,14 @@ ReplxxLineReader::ReplxxLineReader(
     rx.bind_key(Replxx::KEY::control('J'), commit_action);
     rx.bind_key(Replxx::KEY::ENTER, commit_action);
 
+    auto commit_immediately_action = [this](char32_t code)
+    {
+        replxx_last_is_delimiter = false;
+        commit_line = true;
+        return rx.invoke(Replxx::ACTION::COMMIT_LINE, code);
+    };
+    rx.bind_key(Replxx::KEY::control('D'), commit_immediately_action);
+
     /// By default COMPLETE_NEXT/COMPLETE_PREV was bound to C-p/C-n, re-bind
     /// to M-P/M-N (that was used for HISTORY_COMMON_PREFIX_SEARCH before, but
     /// it also bound to M-p/M-n).
@@ -494,14 +496,14 @@ ReplxxLineReader::~ReplxxLineReader()
 LineReader::InputStatus ReplxxLineReader::readOneLine(const String & prompt)
 {
     input.clear();
+    commit_line = false;
 
     const char* cinput = rx.input(prompt);
     if (cinput == nullptr)
         return (errno != EAGAIN) ? ABORT : RESET_LINE;
     input = cinput;
 
-    rightTrim(input);
-    return INPUT_LINE;
+    return commit_line ? COMMIT_LINE : INPUT_LINE;
 }
 
 void ReplxxLineReader::addToHistory(const String & line)

--- a/src/Client/ReplxxLineReader.h
+++ b/src/Client/ReplxxLineReader.h
@@ -53,6 +53,7 @@ private:
 
     std::string editor;
     bool overwrite_mode = false;
+    bool commit_line = false;
 };
 
 }

--- a/tests/queries/0_stateless/01293_client_interactive_vertical_multiline.expect
+++ b/tests/queries/0_stateless/01293_client_interactive_vertical_multiline.expect
@@ -141,5 +141,9 @@ expect "1: 1"
 expect "2: 2"
 expect ":) "
 
+send -- "SELECT 1"
+expect "│ 1 │"
+expect ":) "
+
 send -- ""
 expect eof

--- a/tests/queries/0_stateless/01293_client_interactive_vertical_singleline.expect
+++ b/tests/queries/0_stateless/01293_client_interactive_vertical_singleline.expect
@@ -62,5 +62,9 @@ expect "1: 1"
 expect "2: 2"
 expect ":) "
 
+send -- "SELECT 1"
+expect "│ 1 │"
+expect ":) "
+
 send -- ""
 expect eof


### PR DESCRIPTION
Fixes https://github.com/ClickHouse/ClickHouse/issues/71624

### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Clickhouse-client supports Ctrl+D to finish the query. Allow using Ctrl+D instead of typing a semicolon and pressing Enter. Additionally, make Ctrl+D work as Enter in the single-line mode.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---ci_include_fuzzer--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
