### PR TITLE
Detach tables permanently in cloud

### DIFF
--- a/docs/en/sql-reference/statements/detach.md
+++ b/docs/en/sql-reference/statements/detach.md
@@ -71,7 +71,7 @@ Code: 60. DB::Exception: Received from localhost:9000. DB::Exception: Table defa
 ```
 
 :::note
-In ClickHouse Cloud we recommend users use the `PERMANENTLY` clause e.g. `DETACH TABLE <table> PERMANENTLY`. If this clause is not used, tables will be reattached on cluster restart e.g. during upgrades.
+In ClickHouse Cloud users should use the `PERMANENTLY` clause e.g. `DETACH TABLE <table> PERMANENTLY`. If this clause is not used, tables will be reattached on cluster restart e.g. during upgrades.
 :::
 
 **See Also**

--- a/docs/en/sql-reference/statements/detach.md
+++ b/docs/en/sql-reference/statements/detach.md
@@ -70,6 +70,10 @@ Received exception from server (version 21.4.1):
 Code: 60. DB::Exception: Received from localhost:9000. DB::Exception: Table default.test does not exist.
 ```
 
+:::note
+In ClickHouse Cloud we recommend users use the `PERMANENTLY` clause e.g. `DETACH TABLE <table> PERMANENTLY`. If this clause is not used, tables will be reattached on cluster restart e.g. during upgrades.
+:::
+
 **See Also**
 
 - [Materialized View](../../sql-reference/statements/create/view.md#materialized)


### PR DESCRIPTION
Detach permanently in cloud due to restarts

### Changelog category (leave one):

- Documentation (changelog entry is not required)


