### PR TITLE
Remove ToC in GitHub Data example

### DIFF
--- a/docs/en/getting-started/example-datasets/github.md
+++ b/docs/en/getting-started/example-datasets/github.md
@@ -21,43 +21,6 @@ As of November 8th, 2022, each TSV is approximately the following size and numbe
 - `file_changes` - 53M - 266,051 rows
 - `line_changes` - 2.7G - 7,535,157 rows
 
-# Table of Contents
-
-- [Table of Contents](#table-of-contents)
-- [Generating the data](#generating-the-data)
-- [Downloading and inserting the data](#downloading-and-inserting-the-data)
-- [Queries](#queries)
-  - [History of a single file](#history-of-a-single-file)
-  - [Find the current active files](#find-the-current-active-files)
-  - [List files with most modifications](#list-files-with-most-modifications)
-  - [What day of the week do commits usually occur?](#what-day-of-the-week-do-commits-usually-occur)
-  - [History of subdirectory/file - number of lines, commits and contributors over time](#history-of-subdirectoryfile---number-of-lines-commits-and-contributors-over-time)
-  - [List files with maximum number of authors](#list-files-with-maximum-number-of-authors)
-  - [Oldest lines of code in the repository](#oldest-lines-of-code-in-the-repository)
-  - [Files with longest history](#files-with-longest-history)
-  - [Distribution of contributors with respect to docs and code over the month](#distribution-of-contributors-with-respect-to-docs-and-code-over-the-month)
-  - [Authors with the most diverse impact](#authors-with-the-most-diverse-impact)
-  - [Favorite files for an author](#favorite-files-for-an-author)
-  - [Largest files with lowest number of authors](#largest-files-with-lowest-number-of-authors)
-  - [Commits and lines of code distribution by time; by weekday, by author; for specific subdirectories](#commits-and-lines-of-code-distribution-by-time-by-weekday-by-author-for-specific-subdirectories)
-  - [Matrix of authors that shows what authors tends to rewrite another authors code](#matrix-of-authors-that-shows-what-authors-tends-to-rewrite-another-authors-code)
-  - [Who is the highest percentage contributor per day of week?](#who-is-the-highest-percentage-contributor-per-day-of-week)
-  - [Distribution of code age across repository](#distribution-of-code-age-across-repository)
-  - [What percentage of code for an author has been removed by other authors?](#what-percentage-of-code-for-an-author-has-been-removed-by-other-authors)
-  - [List files that were rewritten most number of times?](#list-files-that-were-rewritten-most-number-of-times)
-  - [What weekday does the code have the highest chance to stay in the repository?](#what-weekday-does-the-code-have-the-highest-chance-to-stay-in-the-repository)
-  - [Files sorted by average code age](#files-sorted-by-average-code-age)
-  - [Who tends to write more tests / CPP code / comments?](#who-tends-to-write-more-tests--cpp-code--comments)
-  - [How does an authors commits change over time with respect to code/comments percentage?](#how-does-an-authors-commits-change-over-time-with-respect-to-codecomments-percentage)
-  - [What is the average time before code will be rewritten and the median (half-life of code decay)?](#what-is-the-average-time-before-code-will-be-rewritten-and-the-median-half-life-of-code-decay)
-  - [What is the worst time to write code in sense that the code has highest chance to be re-written?](#what-is-the-worst-time-to-write-code-in-sense-that-the-code-has-highest-chance-to-be-re-written)
-  - [Which authors code is the most sticky?](#which-authors-code-is-the-most-sticky)
-  - [Most consecutive days of commits by an author](#most-consecutive-days-of-commits-by-an-author)
-  - [Line by line commit history of a file](#line-by-line-commit-history-of-a-file)
-- [Unsolved Questions](#unsolved-questions)
-  - [Git blame](#git-blame)
-- [Related Content](#related-content)
-
 # Generating the data
 
 This is optional. We distribute the data freely - see [Downloading and inserting the data](#downloading-and-inserting-the-data).


### PR DESCRIPTION
This serves no purpose, is broken and we generate one now.

### Changelog category (leave one):

- Documentation (changelog entry is not required)

