### PR TITLE
Fallback to system-wide metrics under cgroups

### DIFF
--- a/src/Common/AsynchronousMetrics.cpp
+++ b/src/Common/AsynchronousMetrics.cpp
@@ -103,18 +103,11 @@ AsynchronousMetrics::AsynchronousMetrics(
     if (!cgroupcpu_stat)
         openFileIfExists("/sys/fs/cgroup/cpuacct/cpuacct.stat", cgroupcpuacct_stat);
 
-    if (!cgroupcpu_stat && !cgroupcpuacct_stat)
-    {
-        /// The following metrics are not cgroup-aware and we've found cgroup-specific metric files for the similar metrics,
-        /// so we're better not reporting them at all to avoid confusion
-        openFileIfExists("/proc/loadavg", loadavg);
-        openFileIfExists("/proc/stat", proc_stat);
-        openFileIfExists("/proc/uptime", uptime);
-    }
+    openFileIfExists("/proc/loadavg", loadavg);
+    openFileIfExists("/proc/stat", proc_stat);
+    openFileIfExists("/proc/uptime", uptime);
 
-    /// The same story for memory metrics
-    if (!cgroupmem_limit_in_bytes)
-        openFileIfExists("/proc/meminfo", meminfo);
+    openFileIfExists("/proc/meminfo", meminfo);
 
     openFileIfExists("/proc/sys/vm/max_map_count", vm_max_map_count);
     openFileIfExists("/proc/self/maps", vm_maps);
@@ -965,7 +958,8 @@ void AsynchronousMetrics::update(TimePoint update_time, bool force_update)
         new_values["CGroupMaxCPU"] = { max_cpu_cgroups, "The maximum number of CPU cores according to CGroups."};
     }
 
-    if (cgroupcpu_stat || cgroupcpuacct_stat)
+    const bool cgroup_cpu_metrics_present = cgroupcpu_stat || cgroupcpuacct_stat;
+    if (cgroup_cpu_metrics_present)
     {
         try
         {
@@ -1025,7 +1019,7 @@ void AsynchronousMetrics::update(TimePoint update_time, bool force_update)
                 openFileIfExists("/sys/fs/cgroup/cpuacct/cpuacct.stat", cgroupcpuacct_stat);
         }
     }
-    else if (proc_stat)
+    if (proc_stat)
     {
         try
         {
@@ -1049,6 +1043,14 @@ void AsynchronousMetrics::update(TimePoint update_time, bool force_update)
 
                 if (name.starts_with("cpu"))
                 {
+                    if (cgroup_cpu_metrics_present)
+                    {
+                        /// Skip the CPU metrics if we already have them from cgroup
+                        ProcStatValuesCPU current_values{};
+                        current_values.read(*proc_stat);
+                        continue;
+                    }
+
                     String cpu_num_str = name.substr(strlen("cpu"));
                     UInt64 cpu_num = 0;
                     if (!cpu_num_str.empty())
@@ -1135,7 +1137,7 @@ void AsynchronousMetrics::update(TimePoint update_time, bool force_update)
 
                 Float64 num_cpus_to_normalize = max_cpu_cgroups > 0 ? max_cpu_cgroups : num_cpus;
 
-                if (num_cpus_to_normalize > 0)
+                if (num_cpus_to_normalize > 0 && !cgroup_cpu_metrics_present)
                     applyNormalizedCPUMetricsUpdate(new_values, num_cpus_to_normalize, delta_values_all_cpus, multiplier);
             }
 
@@ -1169,7 +1171,7 @@ void AsynchronousMetrics::update(TimePoint update_time, bool force_update)
             tryLogCurrentException(__PRETTY_FUNCTION__);
         }
     }
-    else if (meminfo)
+    if (meminfo)
     {
         try
         {

--- a/tests/integration/test_async_metrics_in_cgroup/test.py
+++ b/tests/integration/test_async_metrics_in_cgroup/test.py
@@ -92,4 +92,3 @@ def test_system_wide_metrics(start_cluster):
     ]:
         node2_value = get_async_metric(node2, metric)
         assert float(node2_value) > 0
-

--- a/tests/integration/test_async_metrics_in_cgroup/test.py
+++ b/tests/integration/test_async_metrics_in_cgroup/test.py
@@ -83,6 +83,12 @@ def test_system_wide_metrics(start_cluster):
     # /proc/uptime - OSUptime
     # /proc/stat - OSProcessesRunning, OSInterrupts
     # /proc/meminfo - OSMemoryTotal
-    for metric in ["LoadAverage1", "OSUptime", "OSProcessesRunning", "OSInterrupts", "OSMemoryTotal"]:
+    for metric in [
+        "LoadAverage1",
+        "OSUptime",
+        "OSProcessesRunning",
+        "OSInterrupts",
+        "OSMemoryTotal",
+    ]:
         node1_value = get_async_metric(node1, metric)
         assert float(node1_value) > 0

--- a/tests/integration/test_async_metrics_in_cgroup/test.py
+++ b/tests/integration/test_async_metrics_in_cgroup/test.py
@@ -30,7 +30,7 @@ def get_async_metric(node, metric):
         SELECT max(value)
             FROM (
             SELECT toStartOfInterval(event_time, toIntervalSecond(1)) AS t, avg(value) AS value
-                FROM system.asynchronous_metric_log
+            FROM system.asynchronous_metric_log
             WHERE event_time >= now() - 60 AND metric = '{metric}'
             GROUP BY t
             )
@@ -77,7 +77,7 @@ def test_system_wide_metrics(start_cluster):
     if node1.is_built_with_sanitizer():
         pytest.skip("Disabled for sanitizers")
 
-    run_cpu_intensive_task(node1)
+    run_cpu_intensive_task(node2)
 
     # /proc/loadavg - LoadAverage1
     # /proc/uptime - OSUptime
@@ -90,5 +90,6 @@ def test_system_wide_metrics(start_cluster):
         "OSInterrupts",
         "OSMemoryTotal",
     ]:
-        node1_value = get_async_metric(node1, metric)
-        assert float(node1_value) > 0
+        node2_value = get_async_metric(node2, metric)
+        assert float(node2_value) > 0
+

--- a/tests/integration/test_async_metrics_in_cgroup/test.py
+++ b/tests/integration/test_async_metrics_in_cgroup/test.py
@@ -54,6 +54,10 @@ def test_user_cpu_accounting(start_cluster):
     # this check is really weak, but CI is tough place and we cannot guarantee that test process will get many cpu time
     assert float(node2_cpu_time) > 2
 
+    # OSIdleTime is not available for cgroups, so it shouldn't be present
+    for node in [node1, node2]:
+        assert get_async_metric(node, "OSIdleTime") == "0"
+
 
 def test_normalized_user_cpu(start_cluster):
     if node1.is_built_with_sanitizer():
@@ -67,3 +71,18 @@ def test_normalized_user_cpu(start_cluster):
 
     node2_cpu_time = get_async_metric(node2, "OSUserTimeNormalized")
     assert float(node2_cpu_time) < 1.01
+
+
+def test_system_wide_metrics(start_cluster):
+    if node1.is_built_with_sanitizer():
+        pytest.skip("Disabled for sanitizers")
+
+    run_cpu_intensive_task(node1)
+
+    # /proc/loadavg - LoadAverage1
+    # /proc/uptime - OSUptime
+    # /proc/stat - OSProcessesRunning, OSInterrupts
+    # /proc/meminfo - OSMemoryTotal
+    for metric in ["LoadAverage1", "OSUptime", "OSProcessesRunning", "OSInterrupts", "OSMemoryTotal"]:
+        node1_value = get_async_metric(node1, metric)
+        assert float(node1_value) > 0


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
When ClickHouse runs under cgroup we will still collect system-wide asynchronous metrics related to system load, process scheduling, memory etc. They might provide useful signals when ClickHouse is the only process on the host with high resource consumption. 

---

Closes: #71733 