### PR TITLE
Fix preparing for squashin for Dynamic and JSON columns

### DIFF
--- a/src/Columns/ColumnDynamic.cpp
+++ b/src/Columns/ColumnDynamic.cpp
@@ -1148,6 +1148,13 @@ void ColumnDynamic::prepareVariantsForSquashing(const Columns & source_columns)
     /// Add variants from this dynamic column.
     add_variants(*this);
 
+    /// It might happen that current max_dynamic_types is less then global_max_dynamic_types
+    /// but the SharedVariant is empty. For example if this block was deserialized from Native format.
+    /// In this case we should set max_dynamic_types = global_max_dynamic_types, so during squashing we
+    /// will insert new types to SharedVariant only when the global limit is reached.
+    if (getSharedVariant().empty())
+        max_dynamic_types = global_max_dynamic_types;
+
     DataTypePtr result_variant_type;
     /// Check if the number of all variants exceeds the limit.
     if (!canAddNewVariants(0, all_variants.size()))

--- a/src/Columns/ColumnObject.cpp
+++ b/src/Columns/ColumnObject.cpp
@@ -1337,6 +1337,13 @@ void ColumnObject::prepareForSquashing(const std::vector<ColumnPtr> & source_col
     /// Add dynamic paths from this object column.
     add_dynamic_paths(*this);
 
+    /// It might happen that current max_dynamic_paths is less then global_max_dynamic_paths
+    /// but the shared data is empty. For example if this block was deserialized from Native format.
+    /// In this case we should set max_dynamic_paths = global_max_dynamic_paths, so during squashing we
+    /// will insert new types to SharedVariant only when the global limit is reached.
+    if (getSharedDataPathsAndValues().first->empty())
+        max_dynamic_paths = global_max_dynamic_paths;
+
     /// Check if the number of all dynamic paths exceeds the limit.
     if (path_to_total_number_of_non_null_values.size() > max_dynamic_paths)
     {

--- a/tests/queries/0_stateless/03210_dynamic_squashing.reference
+++ b/tests/queries/0_stateless/03210_dynamic_squashing.reference
@@ -1,5 +1,5 @@
 1
-Array(UInt8)	true
+Array(UInt8)	false
 None	false
 UInt64	false
 2

--- a/tests/queries/0_stateless/03287_dynamic_and_json_squashing_fix.reference
+++ b/tests/queries/0_stateless/03287_dynamic_and_json_squashing_fix.reference
@@ -1,0 +1,4 @@
+false
+false
+[]
+[]

--- a/tests/queries/0_stateless/03287_dynamic_and_json_squashing_fix.sql
+++ b/tests/queries/0_stateless/03287_dynamic_and_json_squashing_fix.sql
@@ -1,0 +1,24 @@
+set enable_json_type=1;
+set enable_dynamic_type=1;
+
+drop table if exists src;
+drop table if exists dst;
+
+create table src (d Dynamic) engine=Memory;
+create table dst (d Dynamic) engine=MergeTree order by tuple();
+insert into src select materialize(42)::Int64;
+insert into src select 'Hello';
+insert into dst select * from remote('127.0.0.2', currentDatabase(), src);
+select isDynamicElementInSharedData(d) from dst;
+drop table src;
+drop table dst;
+
+create table src (json JSON) engine=Memory;
+create table dst (json JSON) engine=MergeTree order by tuple();
+insert into src select '{"a" : 42}';
+insert into src select '{"b" : 42}';
+insert into dst select * from remote('127.0.0.2', currentDatabase(), src);
+select JSONSharedDataPaths(json) from dst;
+drop table src;
+drop table dst;
+


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix preparing for squashin for Dynamic and JSON columns. Previously in some cases new types could be inserted into shared variant/shared data even when the limit on types/paths is not reached.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---ci_include_fuzzer--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
