### PR TITLE
Disable ThinLTO for clang-tidy builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -347,10 +347,11 @@ endif()
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fdiagnostics-absolute-paths")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fdiagnostics-absolute-paths")
 
-if (NOT ENABLE_TESTS AND NOT SANITIZE AND NOT SANITIZE_COVERAGE AND OS_LINUX)
+if (NOT ENABLE_TESTS AND NOT ENABLE_CLANG_TIDY AND NOT SANITIZE AND NOT SANITIZE_COVERAGE AND OS_LINUX)
     # https://clang.llvm.org/docs/ThinLTO.html
     # Applies to clang and linux only.
     # Disabled when building with tests or sanitizers.
+    # Also disabled with clang-tidy where we don't care about linking
     option(ENABLE_THINLTO "Clang-specific link time optimization" ON)
 endif()
 


### PR DESCRIPTION
For clang-tidy, we only care about compilation. We can't disable linking completely but this PR makes it at least a bit faster.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)