### PR TITLE
Try to fix deadlock in TSAN

### DIFF
--- a/tests/tsan_ignorelist.txt
+++ b/tests/tsan_ignorelist.txt
@@ -11,3 +11,4 @@
 [thread]
 # https://github.com/ClickHouse/ClickHouse/issues/55629
 fun:rd_kafka_broker_set_nodename
+src:*/Common/SignalHandlers.cpp


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

https://s3.amazonaws.com/clickhouse-test-reports/0/f21bf70030a3d5b44ad8560143ac4a6ac7de65f6/stress_test__azure__tsan_.html
https://s3.amazonaws.com/clickhouse-test-reports/0/11c86ed8844bed466e213067a4bde4bca484654b/stress_test__azure__tsan_.html

This is just a big guess but I noticed that in both stress tests where TSAN found something CH was killed with signal 9 instead of notifying signal handler about sanitizer triggering.

I tried analyzing `gdb.log` and a lot of threads are stuck on `__sanitizer::FutexWait(__sanitizer::atomic_uint32_t*, unsigned int) ()`

The most interesting thread in both cases looked like this:
```
2024-12-17 18:51:34 Thread 24 (Thread 0x7ff0309cb640 (LWP 15874) "QueryPipelineEx"):
2024-12-17 18:51:34 #0  0x0000560828ee4d7a in __sanitizer::FutexWait(__sanitizer::atomic_uint32_t*, unsigned int) ()
2024-12-17 18:51:34 #1  0x0000560828ee56aa in __sanitizer::Semaphore::Wait() ()
2024-12-17 18:51:34 #2  0x0000560828f6b4ad in __tsan::SlotLock(__tsan::ThreadState*) ()
2024-12-17 18:51:34 #3  0x0000560828f7abbc in __tsan::Acquire(__tsan::ThreadState*, unsigned long, unsigned long) ()
2024-12-17 18:51:34 #4  0x0000560828f0c6fa in __tsan::CallUserSignalHandler(__tsan::ThreadState*, bool, bool, int, __sanitizer::__sanitizer_siginfo*, void*) ()
2024-12-17 18:51:34 #5  0x0000560828f0c54b in __tsan::ProcessPendingSignalsImpl(__tsan::ThreadState*) ()
2024-12-17 18:51:34 #6  0x0000560828f5b504 in __tsan_atomic8_load ()
2024-12-17 18:51:34 #7  0x0000560831c157c0 in HandledSignals::instance () at ./build_docker/./src/Common/SignalHandlers.cpp:645
2024-12-17 18:51:34 #8  0x0000560831c24673 in sanitizerDeathCallback () at ./build_docker/./src/Common/SignalHandlers.cpp:199
2024-12-17 18:51:34 #9  0x0000560828eec1c0 in __sanitizer::Die() ()
2024-12-17 18:51:34 #10 0x0000560828f7d9ae in __tsan::OutputReport(__tsan::ThreadState*, __tsan::ScopedReport const&) ()
2024-12-17 18:51:34 #11 0x0000560828f7eb48 in __tsan::ReportRace(__tsan::ThreadState*, __tsan::RawShadow*, __tsan::Shadow, __tsan::Shadow, unsigned long) ()
2024-12-17 18:51:34 #12 0x0000560828f6f2c9 in __tsan::DoReportRace(__tsan::ThreadState*, __tsan::RawShadow*, __tsan::Shadow, __tsan::Shadow, unsigned long) ()
2024-12-17 18:51:34 #13 0x0000560828f648fe in __tsan::OnUserFree(__tsan::ThreadState*, unsigned long, unsigned long, bool) ()
2024-12-17 18:51:34 #14 0x0000560828f64706 in __tsan::user_free(__tsan::ThreadState*, unsigned long, void*, bool) ()
2024-12-17 18:51:34 #15 0x0000560828f86b79 in operator delete(void*, unsigned long) ()
2024-12-17 18:51:34 #16 0x000056083c3c0328 in DB::ColumnVector<float>::~ColumnVector (this=0x720c02cabee0) at ./src/Columns/ColumnVector.h:338
2024-12-17 18:51:34 #17 0x000056083bf4c7b1 in boost::sp_adl_block::intrusive_ptr_release<DB::IColumn, boost::sp_adl_block::thread_safe_counter> (p=<optimized out>) at ./contrib/boost/boost/smart_ptr/intrusive_ref_counter.hpp:173
2024-12-17 18:51:34 #18 boost::intrusive_ptr<DB::IColumn const>::~intrusive_ptr (this=<optimized out>) at ./contrib/boost/boost/smart_ptr/intrusive_ptr.hpp:100
2024-12-17 18:51:34 #19 COW<DB::IColumn>::chameleon_ptr<DB::IColumn>::~chameleon_ptr (this=<optimized out>) at ./src/Common/COW.h:199
2024-12-17 18:51:34 #20 DB::ColumnArray::~ColumnArray (this=0x72080126f220) at ./src/Columns/ColumnArray.h:18
2024-12-17 18:51:34 #21 DB::ColumnArray::~ColumnArray (this=0x72080126f220) at ./src/Columns/ColumnArray.h:18
....
```
What happens is that before writing to signal handler FD we fetch `HandledSignals` using `instance()` which has `static` variable inside (i.e. something that is thread-safe).
I went through the code bunch of times and don't see anything obvious why we couldn't take locks inside the death callback, but just in case let's try avoiding it.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---ci_include_fuzzer--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [ ] <!---do_not_test--> Do not test
- [x] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
