### PR TITLE
Docs: Named collections with backups

### DIFF
--- a/docs/en/operations/backup.md
+++ b/docs/en/operations/backup.md
@@ -436,6 +436,10 @@ But keep in mind that:
 - If your tables are backed by S3 storage and types of the disks are different, it doesn't use `CopyObject` calls to copy parts to the destination bucket, instead, it downloads and uploads them, which is very inefficient. Prefer to use `BACKUP ... TO S3(<endpoint>)` syntax for this use-case.
 :::
 
+## Using Named Collections
+
+Named collections can be used for `BACKUP/RESTORE` parameters. See [here](./named-collections.md#named-collections-for-backups) for an example.
+
 ## Alternatives
 
 ClickHouse stores data on disk, and there are many ways to backup disks.  These are some alternatives that have been used in the past, and that may fit in well in your environment.

--- a/docs/en/operations/named-collections.md
+++ b/docs/en/operations/named-collections.md
@@ -546,3 +546,30 @@ ENGINE = Kafka(my_kafka_cluster)
 SETTINGS kafka_num_consumers = 4,
          kafka_thread_per_consumer = 1;
 ```
+
+## Named collections for backups
+
+For the description of parameters see [Backup and Restore](./backup.md).
+
+### DDL example
+
+```sql
+BACKUP default.test to S3(named_collection_s3_backups, 'directory')
+```
+
+### XML example
+
+```xml
+<clickhouse>
+    <named_collections>
+        <named_collection_s3_backups>
+            <url>https://my-s3-bucket.s3.amazonaws.com/backup-S3/</url>
+            <access_key_id>ABC123</access_key_id>
+            <secret_access_key>Abc+123</secret_access_key>
+        </named_collection_s3_backups>
+    </named_collections>
+</clickhouse>
+```
+
+
+

--- a/docs/en/operations/named-collections.md
+++ b/docs/en/operations/named-collections.md
@@ -554,7 +554,7 @@ For the description of parameters see [Backup and Restore](./backup.md).
 ### DDL example
 
 ```sql
-BACKUP default.test to S3(named_collection_s3_backups, 'directory')
+BACKUP TABLE default.test to S3(named_collection_s3_backups, 'directory')
 ```
 
 ### XML example
@@ -570,6 +570,3 @@ BACKUP default.test to S3(named_collection_s3_backups, 'directory')
     </named_collections>
 </clickhouse>
 ```
-
-
-


### PR DESCRIPTION
Documenting named collections for backups.

### Changelog category (leave one):
- Documentation (changelog entry is not required)
