### PR TITLE
Fix parsing multiple globs

### DIFF
--- a/src/Common/parseGlobs.cpp
+++ b/src/Common/parseGlobs.cpp
@@ -9,10 +9,15 @@
 
 namespace DB
 {
+
 namespace ErrorCodes
 {
     extern const int BAD_ARGUMENTS;
 }
+
+static const re2::RE2 range_regex(R"({([\d]+\.\.[\d]+)})"); /// regexp for {M..N}, where M and N - non-negative integers
+static const re2::RE2 enum_regex(R"({([^{}*,]+[^{}*]*[^{}*,])})"); /// regexp for {expr1,expr2,expr3}, expr's should be without "{", "}", "*" and ","
+
 
 /* Transforms string from grep-wildcard-syntax ("{N..M}", "{a,b,c}" as in remote table function and "*", "?") to perl-regexp for using re2 library for matching
  * with such steps:
@@ -35,69 +40,81 @@ std::string makeRegexpPatternFromGlobs(const std::string & initial_str_with_glob
     }
     std::string escaped_with_globs = buf_for_escaping.str();
 
-    static const re2::RE2 range_regex(R"({([\d]+\.\.[\d]+)})"); /// regexp for {M..N}, where M and N - non-negative integers
-    static const re2::RE2 enum_regex(R"({([^{}*,]+[^{}*]*[^{}*,])})"); /// regexp for {expr1,expr2,expr3}, expr's should be without "{", "}", "*" and ","
-
     std::string_view matched;
     std::string_view input(escaped_with_globs);
-    std::ostringstream oss_for_replacing;       // STYLE_CHECK_ALLOW_STD_STRING_STREAM
+    std::ostringstream oss_for_replacing; /// STYLE_CHECK_ALLOW_STD_STRING_STREAM
     oss_for_replacing.exceptions(std::ios::failbit);
     size_t current_index = 0;
 
-    while (RE2::FindAndConsume(&input, range_regex, &matched))
+    while (true)
     {
-        std::string buffer(matched);
-        oss_for_replacing << escaped_with_globs.substr(current_index, matched.data() - escaped_with_globs.data() - current_index - 1) << '(';
+        std::string_view matched_range;
+        std::string_view matched_enum;
 
-        size_t range_begin = 0;
-        size_t range_end = 0;
-        char point;
-        ReadBufferFromString buf_range(buffer);
-        buf_range >> range_begin >> point >> point >> range_end;
+        auto did_match_range = RE2::PartialMatch(input, range_regex, &matched_range);
+        auto did_match_enum = RE2::PartialMatch(input, enum_regex, &matched_enum);
 
-        size_t range_begin_width = buffer.find('.');
-        size_t range_end_width = buffer.size() - buffer.find_last_of('.') - 1;
-        bool leading_zeros = buffer[0] == '0';
-        size_t output_width = 0;
+        if (did_match_range && did_match_enum && matched_range.data() == matched_enum.data())
+            did_match_enum = false;
 
-        if (range_begin > range_end)    //Descending Sequence {20..15} {9..01}
+        if (did_match_range && (!did_match_enum || matched_range.data() < matched_enum.data()))
         {
-            std::swap(range_begin,range_end);
-            leading_zeros = buffer[buffer.find_last_of('.')+1]=='0';
-            std::swap(range_begin_width,range_end_width);
-        }
-        if (range_begin_width == 1 && leading_zeros)
-            output_width = 1;   ///Special Case: {0..10} {0..999}
-        else
-            output_width = std::max(range_begin_width, range_end_width);
+            RE2::FindAndConsume(&input, range_regex, &matched);
+            std::string buffer(matched);
+            oss_for_replacing << escaped_with_globs.substr(current_index, matched_range.data() - escaped_with_globs.data() - current_index - 1) << '(';
 
-        if (leading_zeros)
-            oss_for_replacing << std::setfill('0') << std::setw(static_cast<int>(output_width));
-        oss_for_replacing << range_begin;
+            size_t range_begin = 0;
+            size_t range_end = 0;
+            char point;
+            ReadBufferFromString buf_range(buffer);
+            buf_range >> range_begin >> point >> point >> range_end;
 
-        for (size_t i = range_begin + 1; i <= range_end; ++i)
-        {
-            oss_for_replacing << '|';
+            size_t range_begin_width = buffer.find('.');
+            size_t range_end_width = buffer.size() - buffer.find_last_of('.') - 1;
+            bool leading_zeros = buffer[0] == '0';
+            size_t output_width = 0;
+
+            if (range_begin > range_end) /// Descending Sequence {20..15} {9..01}
+            {
+                std::swap(range_begin,range_end);
+                leading_zeros = buffer[buffer.find_last_of('.') + 1] == '0';
+                std::swap(range_begin_width,range_end_width);
+            }
+            if (range_begin_width == 1 && leading_zeros)
+                output_width = 1; /// Special Case: {0..10} {0..999}
+            else
+                output_width = std::max(range_begin_width, range_end_width);
+
             if (leading_zeros)
                 oss_for_replacing << std::setfill('0') << std::setw(static_cast<int>(output_width));
-            oss_for_replacing << i;
+            oss_for_replacing << range_begin;
+
+            for (size_t i = range_begin + 1; i <= range_end; ++i)
+            {
+                oss_for_replacing << '|';
+                if (leading_zeros)
+                    oss_for_replacing << std::setfill('0') << std::setw(static_cast<int>(output_width));
+                oss_for_replacing << i;
+            }
+
+            oss_for_replacing << ")";
+            current_index = input.data() - escaped_with_globs.data();
         }
+        else if (did_match_enum && (!did_match_range || matched_enum.data() < matched_range.data()))
+        {
+            RE2::FindAndConsume(&input, enum_regex, &matched);
+            std::string buffer(matched);
 
-        oss_for_replacing << ")";
-        current_index = input.data() - escaped_with_globs.data();
-    }
+            oss_for_replacing << escaped_with_globs.substr(current_index, matched.data() - escaped_with_globs.data() - current_index - 1) << '(';
+            std::replace(buffer.begin(), buffer.end(), ',', '|');
 
-    while (RE2::FindAndConsume(&input, enum_regex, &matched))
-    {
-        std::string buffer(matched);
+            oss_for_replacing << buffer;
+            oss_for_replacing << ")";
 
-        oss_for_replacing << escaped_with_globs.substr(current_index, matched.data() - escaped_with_globs.data() - current_index - 1) << '(';
-        std::replace(buffer.begin(), buffer.end(), ',', '|');
-
-        oss_for_replacing << buffer;
-        oss_for_replacing << ")";
-
-        current_index = input.data() - escaped_with_globs.data();
+            current_index = input.data() - escaped_with_globs.data();
+        }
+        else
+            break;
     }
 
     oss_for_replacing << escaped_with_globs.substr(current_index);
@@ -112,7 +129,7 @@ std::string makeRegexpPatternFromGlobs(const std::string & initial_str_with_glob
         }
         else if ((letter == '?') || (letter == '*'))
         {
-            buf_final_processing << "[^/]";   /// '?' is any symbol except '/'
+            buf_final_processing << "[^/]"; /// '?' is any symbol except '/'
             if (letter == '?')
                 continue;
         }
@@ -135,7 +152,7 @@ void expandSelectorGlobImpl(const std::string & path, std::vector<std::string> &
     std::string_view path_view(path);
     std::string_view matched;
 
-    // No (more) selector globs found, quit
+    /// No (more) selector globs found, quit
     if (!RE2::FindAndConsume(&path_view, selector_regex, &matched))
     {
         for_match_paths_expanded.push_back(path);
@@ -178,7 +195,7 @@ void expandSelectorGlobImpl(const std::string & path, std::vector<std::string> &
         throw Exception(ErrorCodes::BAD_ARGUMENTS,
                         "Invalid {{}} glob in path {}.", path);
 
-    // generate result: prefix/{a,b,c}/suffix -> [prefix/a/suffix, prefix/b/suffix, prefix/c/suffix]
+    /// generate result: prefix/{a,b,c}/suffix -> [prefix/a/suffix, prefix/b/suffix, prefix/c/suffix]
     std::string common_prefix = path.substr(0, anchor_positions.front());
     std::string common_suffix = path.substr(anchor_positions.back() + 1);
     for (size_t i = 1; i < anchor_positions.size(); ++i)

--- a/src/Common/tests/gtest_makeRegexpPatternFromGlobs.cpp
+++ b/src/Common/tests/gtest_makeRegexpPatternFromGlobs.cpp
@@ -7,7 +7,6 @@ using namespace DB;
 
 TEST(Common, makeRegexpPatternFromGlobs)
 {
-
     EXPECT_EQ(makeRegexpPatternFromGlobs("?"), "[^/]");
     EXPECT_EQ(makeRegexpPatternFromGlobs("*"), "[^/]*");
     EXPECT_EQ(makeRegexpPatternFromGlobs("/?"), "/[^/]");
@@ -40,6 +39,9 @@ TEST(Common, makeRegexpPatternFromGlobs)
     EXPECT_EQ(makeRegexpPatternFromGlobs("f{103..95}"), "f(95|96|97|98|99|100|101|102|103)");
     EXPECT_EQ(makeRegexpPatternFromGlobs("f{9..01}"), "f(01|02|03|04|05|06|07|08|09)");
     EXPECT_EQ(makeRegexpPatternFromGlobs("f{9..000}"), "f(000|001|002|003|004|005|006|007|008|009)");
+    EXPECT_EQ(makeRegexpPatternFromGlobs("f{1,2}{1..2}"), "f(1|2)(1|2)");
+    EXPECT_EQ(makeRegexpPatternFromGlobs("f{1..2}{1,2}"), "f(1|2)(1|2)");
+    EXPECT_EQ(makeRegexpPatternFromGlobs("f{1,2}{1,2}"), "f(1|2)(1|2)");
     EXPECT_EQ(makeRegexpPatternFromGlobs("f{1..2}{1..2}"), "f(1|2)(1|2)");
     EXPECT_EQ(makeRegexpPatternFromGlobs("f{1..1}{1..1}"), "f(1)(1)");
     EXPECT_EQ(makeRegexpPatternFromGlobs("f{0..0}{0..0}"), "f(0)(0)");


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix parsing enum glob followed by range one. Fixes https://github.com/ClickHouse/ClickHouse/issues/73473


#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---ci_include_fuzzer--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
