### PR TITLE
Set exception if task cannot be scheduled in ThreadPoolCallbackRunnerLocal

### DIFF
--- a/src/Common/threadPoolCallbackRunner.h
+++ b/src/Common/threadPoolCallbackRunner.h
@@ -13,7 +13,6 @@ namespace DB
 namespace ErrorCodes
 {
 extern const int LOGICAL_ERROR;
-extern const int CANNOT_SCHEDULE_TASK;
 }
 
 /// High-order function to run callbacks (functions with 'void()' signature) somewhere asynchronously.


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix for std::logical_error thrown when task cannot be scheduled.
Found in stress tests. Example stacktrace:
```
2024.12.19 02:05:46.171833 [ 18190 ] {01f0daba-d3cc-4898-9e0e-c2c263306427} <Fatal> : Logical error: 'std::exception. Code: 1001, type: std::__1::future_error, e.what() = The associated promise has been destructed prior to the associated state becoming ready. (version 25.1.1.18724), Stack trace:

0. ./contrib/llvm-project/libcxx/include/exception:141: std::logic_error::logic_error(std::logic_error const&) @ 0x000000003f19bf4e
1. ./contrib/llvm-project/libcxx/include/future:520: std::promise<void>::~promise() @ 0x000000003f0c2373
2. ./contrib/llvm-project/libcxx/include/future:1279: std::__shared_ptr_emplace<std::packaged_task<void ()>, std::allocator<std::packaged_task<void ()>>>::__on_zero_shared() @ 0x0000000021881072
3. ./contrib/llvm-project/libcxx/include/__memory/shared_ptr.h:174: void std::__function::__policy::__large_destroy<std::__function::__default_alloc_func<DB::ThreadPoolCallbackRunnerLocal<void, ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>, std::function<void ()>>::operator()(std::function<void ()>&&, Priority)::'lambda0'(), void ()>>(void*) @ 0x0000000021884319
4. ./contrib/llvm-project/libcxx/include/__functional/function.h:819: ? @ 0x000000001c40f9f7
5. ./src/Common/threadPoolCallbackRunner.h:167: DB::ThreadPoolCallbackRunnerLocal<void, ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>, std::function<void ()>>::operator()(std::function<void ()>&&, Priority) @ 0x000000002187f6ee
...
```

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---ci_include_fuzzer--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
