### PR TITLE
Support core settings in BACKUP/RESTORE query

### DIFF
--- a/docs/en/operations/backup.md
+++ b/docs/en/operations/backup.md
@@ -90,7 +90,7 @@ The BACKUP and RESTORE statements take a list of DATABASE and TABLE names, a des
     - `storage_policy`: storage policy for the tables being restored. See [Using Multiple Block Devices for Data Storage](../engines/table-engines/mergetree-family/mergetree.md#table_engine-mergetree-multiple-volumes). This setting is only applicable to the `RESTORE` command. The specified storage policy applies only to tables with an engine from the `MergeTree` family.
     - `s3_storage_class`: the storage class used for S3 backup. For example, `STANDARD`
     - `azure_attempt_to_create_container`: when using Azure Blob Storage, whether the specified container will try to be created if it doesn't exist. Default: true.
-    - `max_backup_bandwidth`: the maximum read speed in bytes per second for a backup. Zero means unlimited.
+    - [core settings](/docs/en/operations/settings/settings) can be used here too
 
 ### Usage examples
 

--- a/src/Backups/BackupSettings.cpp
+++ b/src/Backups/BackupSettings.cpp
@@ -42,7 +42,6 @@ namespace ErrorCodes
     M(Bool, internal) \
     M(String, host_id) \
     M(OptionalUUID, backup_uuid) \
-    M(OptionalUInt64, max_backup_bandwidth)
     /// M(Int64, compression_level)
 
 BackupSettings BackupSettings::fromBackupQuery(const ASTBackupQuery & query)
@@ -57,13 +56,17 @@ BackupSettings BackupSettings::fromBackupQuery(const ASTBackupQuery & query)
             if (setting.name == "compression_level")
                 res.compression_level = static_cast<int>(SettingFieldInt64{setting.value}.value);
             else
-#define GET_SETTINGS_FROM_BACKUP_QUERY_HELPER(TYPE, NAME) \
+#define GET_BACKUP_SETTINGS_FROM_QUERY(TYPE, NAME) \
             if (setting.name == #NAME) \
                 res.NAME = SettingField##TYPE{setting.value}.value; \
             else
 
-            LIST_OF_BACKUP_SETTINGS(GET_SETTINGS_FROM_BACKUP_QUERY_HELPER)
-            throw Exception(ErrorCodes::CANNOT_PARSE_BACKUP_SETTINGS, "Unknown setting {}", setting.name);
+            LIST_OF_BACKUP_SETTINGS(GET_BACKUP_SETTINGS_FROM_QUERY)
+            /// else
+            {
+                /// (if setting.name is not the name of a field of BackupSettings)
+                res.core_settings.emplace_back(setting);
+            }
         }
     }
 
@@ -92,19 +95,19 @@ void BackupSettings::copySettingsToQuery(ASTBackupQuery & query) const
     auto query_settings = std::make_shared<ASTSetQuery>();
     query_settings->is_standalone = false;
 
+    /// Copy the fields of the BackupSettings to the query.
     static const BackupSettings default_settings;
-    bool all_settings_are_default = true;
 
-#define SET_SETTINGS_IN_BACKUP_QUERY_HELPER(TYPE, NAME) \
+#define COPY_BACKUP_SETTINGS_TO_QUERY(TYPE, NAME) \
     if ((NAME) != default_settings.NAME) \
-    { \
         query_settings->changes.emplace_back(#NAME, static_cast<Field>(SettingField##TYPE{NAME})); \
-        all_settings_are_default = false; \
-    }
 
-    LIST_OF_BACKUP_SETTINGS(SET_SETTINGS_IN_BACKUP_QUERY_HELPER)
+    LIST_OF_BACKUP_SETTINGS(COPY_BACKUP_SETTINGS_TO_QUERY)
 
-    if (all_settings_are_default)
+    /// Copy the core settings to the query too.
+    query_settings->changes.insert(query_settings->changes.end(), core_settings.begin(), core_settings.end());
+
+    if (query_settings->changes.empty())
         query_settings = nullptr;
 
     query.settings = query_settings;

--- a/src/Backups/BackupSettings.h
+++ b/src/Backups/BackupSettings.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Backups/BackupInfo.h>
+#include <Common/SettingsChanges.h>
 #include <optional>
 
 
@@ -98,8 +99,8 @@ struct BackupSettings
     /// UUID of the backup. If it's not set it will be generated randomly.
     std::optional<UUID> backup_uuid;
 
-    /// The maximum read speed in bytes per second for a backup. Zero means unlimited.
-    std::optional<UInt64> max_backup_bandwidth;
+    /// Core settings specified in the query.
+    SettingsChanges core_settings;
 
     static BackupSettings fromBackupQuery(const ASTBackupQuery & query);
     void copySettingsToQuery(ASTBackupQuery & query) const;

--- a/src/Backups/BackupsWorker.cpp
+++ b/src/Backups/BackupsWorker.cpp
@@ -120,8 +120,8 @@ namespace
     ReadSettings getReadSettingsForBackup(const ContextPtr & context, const BackupSettings & backup_settings)
     {
         auto read_settings = context->getReadSettings();
-        read_settings.remote_throttler = context->getBackupsThrottler(backup_settings.max_backup_bandwidth);
-        read_settings.local_throttler = context->getBackupsThrottler(backup_settings.max_backup_bandwidth);
+        read_settings.remote_throttler = context->getBackupsThrottler();
+        read_settings.local_throttler = context->getBackupsThrottler();
         read_settings.enable_filesystem_cache = backup_settings.read_from_filesystem_cache;
         read_settings.read_from_filesystem_cache_if_exists_otherwise_bypass_cache = backup_settings.read_from_filesystem_cache;
         return read_settings;
@@ -134,11 +134,11 @@ namespace
         return write_settings;
     }
 
-    ReadSettings getReadSettingsForRestore(const ContextPtr & context, std::optional<UInt64> max_backup_bandwidth)
+    ReadSettings getReadSettingsForRestore(const ContextPtr & context)
     {
         auto read_settings = context->getReadSettings();
-        read_settings.remote_throttler = context->getBackupsThrottler(max_backup_bandwidth);
-        read_settings.local_throttler = context->getBackupsThrottler(max_backup_bandwidth);
+        read_settings.remote_throttler = context->getBackupsThrottler();
+        read_settings.local_throttler = context->getBackupsThrottler();
         read_settings.enable_filesystem_cache = false;
         read_settings.read_from_filesystem_cache_if_exists_otherwise_bypass_cache = false;
         return read_settings;
@@ -352,8 +352,12 @@ struct BackupsWorker::BackupStarter
         , query_context(context_)
         , backup_context(Context::createCopy(query_context))
     {
-        backup_context->makeQueryContext();
         backup_settings = BackupSettings::fromBackupQuery(*backup_query);
+
+        backup_context->makeQueryContext();
+        backup_context->checkSettingsConstraints(backup_settings.core_settings, SettingSource::QUERY);
+        backup_context->applySettingsChanges(backup_settings.core_settings);
+
         backup_info = BackupInfo::fromAST(*backup_query->backup_name);
         backup_name_for_logging = backup_info.toStringForLogging();
         is_internal_backup = backup_settings.internal;
@@ -724,8 +728,12 @@ struct BackupsWorker::RestoreStarter
         , query_context(context_)
         , restore_context(Context::createCopy(query_context))
     {
-        restore_context->makeQueryContext();
         restore_settings = RestoreSettings::fromRestoreQuery(*restore_query);
+
+        restore_context->makeQueryContext();
+        restore_context->checkSettingsConstraints(restore_settings.core_settings, SettingSource::QUERY);
+        restore_context->applySettingsChanges(restore_settings.core_settings);
+
         backup_info = BackupInfo::fromAST(*restore_query->backup_name);
         backup_name_for_logging = backup_info.toStringForLogging();
         is_internal_restore = restore_settings.internal;
@@ -849,7 +857,7 @@ BackupPtr BackupsWorker::openBackupForReading(const BackupInfo & backup_info, co
     backup_open_params.allow_s3_native_copy = restore_settings.allow_s3_native_copy;
     backup_open_params.use_same_s3_credentials_for_base_backup = restore_settings.use_same_s3_credentials_for_base_backup;
     backup_open_params.use_same_password_for_base_backup = restore_settings.use_same_password_for_base_backup;
-    backup_open_params.read_settings = getReadSettingsForRestore(context, restore_settings.max_backup_bandwidth);
+    backup_open_params.read_settings = getReadSettingsForRestore(context);
     backup_open_params.write_settings = getWriteSettingsForRestore(context);
     backup_open_params.is_internal_backup = restore_settings.internal;
     auto backup = BackupFactory::instance().createBackup(backup_open_params);

--- a/src/Backups/RestoreSettings.cpp
+++ b/src/Backups/RestoreSettings.cpp
@@ -171,8 +171,7 @@ namespace
     M(Bool, internal) \
     M(String, host_id) \
     M(OptionalString, storage_policy) \
-    M(OptionalUUID, restore_uuid) \
-    M(OptionalUInt64, max_backup_bandwidth)
+    M(OptionalUUID, restore_uuid)
 
 
 RestoreSettings RestoreSettings::fromRestoreQuery(const ASTBackupQuery & query)
@@ -184,18 +183,23 @@ RestoreSettings RestoreSettings::fromRestoreQuery(const ASTBackupQuery & query)
         const auto & settings = query.settings->as<const ASTSetQuery &>().changes;
         for (const auto & setting : settings)
         {
-#define GET_SETTINGS_FROM_RESTORE_QUERY_HELPER(TYPE, NAME) \
+#define GET_RESTORE_SETTINGS_FROM_QUERY(TYPE, NAME) \
             if (setting.name == #NAME) \
                 res.NAME = SettingField##TYPE{setting.value}.value; \
             else
 
-            LIST_OF_RESTORE_SETTINGS(GET_SETTINGS_FROM_RESTORE_QUERY_HELPER)
-
+            LIST_OF_RESTORE_SETTINGS(GET_RESTORE_SETTINGS_FROM_QUERY)
+            /// else
             /// `allow_unresolved_access_dependencies` is an obsolete name.
             if (setting.name == "allow_unresolved_access_dependencies")
+            {
                 res.skip_unresolved_access_dependencies = SettingFieldBool{setting.value}.value;
+            }
             else
-                throw Exception(ErrorCodes::CANNOT_PARSE_BACKUP_SETTINGS, "Unknown setting {}", setting.name);
+            {
+                /// (if setting.name is not the name of a field of BackupSettings)
+                res.core_settings.emplace_back(setting);
+            }
         }
     }
 
@@ -213,19 +217,19 @@ void RestoreSettings::copySettingsToQuery(ASTBackupQuery & query) const
     auto query_settings = std::make_shared<ASTSetQuery>();
     query_settings->is_standalone = false;
 
+    /// Copy the fields of the RestoreSettings to the query.
     static const RestoreSettings default_settings;
-    bool all_settings_are_default = true;
 
-#define SET_SETTINGS_IN_RESTORE_QUERY_HELPER(TYPE, NAME) \
+#define COPY_RESTORE_SETTINGS_TO_QUERY(TYPE, NAME) \
     if ((NAME) != default_settings.NAME) \
-    { \
         query_settings->changes.emplace_back(#NAME, static_cast<Field>(SettingField##TYPE{NAME})); \
-        all_settings_are_default = false; \
-    }
 
-    LIST_OF_RESTORE_SETTINGS(SET_SETTINGS_IN_RESTORE_QUERY_HELPER)
+    LIST_OF_RESTORE_SETTINGS(COPY_RESTORE_SETTINGS_TO_QUERY)
 
-    if (all_settings_are_default)
+    /// Copy the core settings to the query too.
+    query_settings->changes.insert(query_settings->changes.end(), core_settings.begin(), core_settings.end());
+
+    if (query_settings->changes.empty())
         query_settings = nullptr;
 
     query.settings = query_settings;

--- a/src/Backups/RestoreSettings.h
+++ b/src/Backups/RestoreSettings.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Backups/BackupInfo.h>
+#include <Common/SettingsChanges.h>
 #include <optional>
 
 
@@ -155,8 +156,8 @@ struct RestoreSettings
     /// This is used to generate coordination path and for concurrency check
     std::optional<UUID> restore_uuid;
 
-    /// The maximum read speed in bytes per second for a backup. Zero means unlimited.
-    std::optional<UInt64> max_backup_bandwidth;
+    /// Core settings specified in the query.
+    SettingsChanges core_settings;
 
     static RestoreSettings fromRestoreQuery(const ASTBackupQuery & query);
     void copySettingsToQuery(ASTBackupQuery & query) const;

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -3725,16 +3725,13 @@ ThrottlerPtr Context::getLocalWriteThrottler() const
     return throttler;
 }
 
-ThrottlerPtr Context::getBackupsThrottler(std::optional<UInt64> max_backup_bandwidth) const
+ThrottlerPtr Context::getBackupsThrottler() const
 {
     ThrottlerPtr throttler = shared->backups_server_throttler;
-    if (max_backup_bandwidth.has_value() || getSettingsRef()[Setting::max_backup_bandwidth])
+    if (auto bandwidth = getSettingsRef()[Setting::max_backup_bandwidth])
     {
-        // Query setting takes precedence
-        auto bandwidth = max_backup_bandwidth.value_or(getSettingsRef()[Setting::max_backup_bandwidth]);
-
         std::lock_guard lock(mutex);
-        if (!backups_query_throttler)
+         if (!backups_query_throttler)
             backups_query_throttler = std::make_shared<Throttler>(bandwidth, throttler);
         throttler = backups_query_throttler;
     }

--- a/src/Interpreters/Context.h
+++ b/src/Interpreters/Context.h
@@ -1470,7 +1470,7 @@ public:
     ThrottlerPtr getLocalReadThrottler() const;
     ThrottlerPtr getLocalWriteThrottler() const;
 
-    ThrottlerPtr getBackupsThrottler(std::optional<UInt64> max_backup_bandwidth) const;
+    ThrottlerPtr getBackupsThrottler() const;
 
     ThrottlerPtr getMutationsThrottler() const;
     ThrottlerPtr getMergesThrottler() const;


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Support core settings in `BACKUP`/`RESTORE` query.

This PR is a follow-up to https://github.com/ClickHouse/ClickHouse/pull/72665, in addition to `max_backup_bandwidth` this PR allows to use any core settings in `BACKUP`/`RESTORE` query, for example

```
BACKUP ... SETTINGS base_backup = Disk('backups', 'b1'),
                    max_backup_bandwidth=1e6,
                    backup_restore_keeper_max_retries_while_initializing=30,
                    max_memory_usage=1e8
```
