### PR TITLE
Ensure that a valid utf8 string is used for the serialization json.

### DIFF
--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -857,9 +857,6 @@ The threshold for `totals_mode = 'auto'`.
 See the section “WITH TOTALS modifier”.
 )", 0) \
     \
-    DECLARE(Bool, use_non_utf8_chars_in_schema, false, R"(
-Allow using non utf8 chars in data schema. For testing purposes only, enabling this option in a production environment may result in data loss.
-    )", 0) \
     DECLARE(Bool, allow_suspicious_low_cardinality_types, false, R"(
 Allows or restricts using [LowCardinality](../../sql-reference/data-types/lowcardinality.md) with data types with fixed size of 8 bytes or less: numeric data types and `FixedString(8_bytes_or_less)`.
 

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -857,6 +857,9 @@ The threshold for `totals_mode = 'auto'`.
 See the section “WITH TOTALS modifier”.
 )", 0) \
     \
+    DECLARE(Bool, use_non_utf8_chars_in_schema, false, R"(
+Allow using non utf8 chars in data schema. For testing purposes only, enabling this option in a production environment may result in data loss.
+    )", 0) \
     DECLARE(Bool, allow_suspicious_low_cardinality_types, false, R"(
 Allows or restricts using [LowCardinality](../../sql-reference/data-types/lowcardinality.md) with data types with fixed size of 8 bytes or less: numeric data types and `FixedString(8_bytes_or_less)`.
 

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -65,6 +65,7 @@ static std::initializer_list<std::pair<ClickHouseVersion, SettingsChangesHistory
             {"distributed_cache_min_bytes_for_seek", false, false, "New private setting."},
             {"s3queue_migrate_old_metadata_to_buckets", false, false, "New setting."},
             {"distributed_cache_pool_behaviour_on_limit", "allocate_bypassing_pool", "wait", "Cloud only"},
+            {"use_non_utf8_chars_in_schema", false, false, "New setting."},
         }
     },
     {"24.12",

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -65,7 +65,6 @@ static std::initializer_list<std::pair<ClickHouseVersion, SettingsChangesHistory
             {"distributed_cache_min_bytes_for_seek", false, false, "New private setting."},
             {"s3queue_migrate_old_metadata_to_buckets", false, false, "New setting."},
             {"distributed_cache_pool_behaviour_on_limit", "allocate_bypassing_pool", "wait", "Cloud only"},
-            {"use_non_utf8_chars_in_schema", false, false, "New setting."},
         }
     },
     {"24.12",

--- a/src/DataTypes/Serializations/SerializationInfo.cpp
+++ b/src/DataTypes/Serializations/SerializationInfo.cpp
@@ -12,7 +12,6 @@
 #include <Poco/JSON/Stringifier.h>
 #include <Poco/JSON/Parser.h>
 
-#include <Common/logger_useful.h>
 
 namespace DB
 {
@@ -198,11 +197,6 @@ SerializationInfoByName::SerializationInfoByName(
     if (settings.isAlwaysDefault())
         return;
 
-    LOG_DEBUG(::getLogger("SerializationInfoByName"), "ADD COLUMN-----");
-    for (const auto & column : columns)
-        if (column.type->supportsSparseSerialization())
-            LOG_DEBUG(::getLogger("SerializationInfoByName"), "ADD COLUMN {}", column.name);
-
     for (const auto & column : columns)
         if (column.type->supportsSparseSerialization())
             emplace(column.name, column.type->createSerializationInfo(settings));
@@ -297,7 +291,7 @@ void SerializationInfoByName::writeJSON(WriteBuffer & out) const
     auto json_str = oss.str();
     if (!UTF8::isValidUTF8(reinterpret_cast<const UInt8 *>(json_str.data()), json_str.size()))
     {
-        throw Exception(ErrorCodes::INCORRECT_DATA, "Serialization of the JSON is not valaid utf8 string. Probably non-utf8 character was used in the schema."
+        throw Exception(ErrorCodes::INCORRECT_DATA, "Serialization of the JSON are not valaid utf8 string. Probably non-utf8 character was used in the schema."
                         "The serialization string: {}", json_str);
     }
     writeString(json_str, out);

--- a/src/DataTypes/Serializations/SerializationInfo.cpp
+++ b/src/DataTypes/Serializations/SerializationInfo.cpp
@@ -291,8 +291,7 @@ void SerializationInfoByName::writeJSON(WriteBuffer & out) const
     auto json_str = oss.str();
     if (!UTF8::isValidUTF8(reinterpret_cast<const UInt8 *>(json_str.data()), json_str.size()))
     {
-        throw Exception(ErrorCodes::INCORRECT_DATA, "Serialization of the JSON are not valaid utf8 string. Probably non-utf8 character was used in the schema."
-                        "The serialization string: {}", json_str);
+        throw Exception(ErrorCodes::INCORRECT_DATA, "JSON serialization failed because the string is not valid UTF-8. There are probably non-UTF-8 characters in the schema.");
     }
     writeString(json_str, out);
 }

--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -20,6 +20,7 @@
 #include <Common/logger_useful.h>
 #include <Common/randomSeed.h>
 #include <Common/typeid_cast.h>
+#include <Common/isValidUTF8.h>
 
 #include <Core/Defines.h>
 #include <Core/SettingsEnums.h>
@@ -143,6 +144,7 @@ namespace Setting
     extern const SettingsBool restore_replace_external_engines_to_null;
     extern const SettingsBool restore_replace_external_table_functions_to_null;
     extern const SettingsBool restore_replace_external_dictionary_source_to_null;
+    extern const SettingsBool use_non_utf8_chars_in_schema;
 }
 
 namespace ServerSetting
@@ -180,6 +182,7 @@ namespace ErrorCodes
     extern const int TOO_MANY_TABLES;
     extern const int TOO_MANY_DATABASES;
     extern const int THERE_IS_NO_COLUMN;
+    extern const int INCORRECT_DATA;
 }
 
 namespace fs = std::filesystem;
@@ -1047,15 +1050,20 @@ InterpreterCreateQuery::TableProperties InterpreterCreateQuery::getTableProperti
 void InterpreterCreateQuery::validateTableStructure(const ASTCreateQuery & create,
                                                     const InterpreterCreateQuery::TableProperties & properties) const
 {
-    /// Check for duplicates
+    /// Check for duplicates and uft8 format.
     std::set<String> all_columns;
+
+    const auto & settings = getContext()->getSettingsRef();
     for (const auto & column : properties.columns)
     {
         if (!all_columns.emplace(column.name).second)
             throw Exception(ErrorCodes::DUPLICATE_COLUMN, "Column {} already exists", backQuoteIfNeed(column.name));
-    }
 
-    const auto & settings = getContext()->getSettingsRef();
+        if (!settings[Setting::use_non_utf8_chars_in_schema] && !UTF8::isValidUTF8(reinterpret_cast<const UInt8 *>(column.name.data()), column.name.size()))
+        {
+            throw Exception(ErrorCodes::INCORRECT_DATA, "Column name contains non-utf8 characters.");
+        }
+    }
 
     /// If it's not attach and not materialized view to existing table,
     /// we need to validate data types (check for experimental or suspicious types).

--- a/tests/integration/helpers/client.py
+++ b/tests/integration/helpers/client.py
@@ -181,7 +181,11 @@ class CommandRequest:
         self, command, stdin=None, timeout=None, ignore_error=False, parse=False
     ):
         # Write data to tmp file to avoid PIPEs and execution blocking
-        stdin_file = tempfile.TemporaryFile(mode="w+")
+        if isinstance(stdin, str):
+            stdin_file = tempfile.TemporaryFile(mode="w+")
+        else:
+            stdin_file = tempfile.TemporaryFile(mode="wb+")
+
         stdin_file.write(stdin)
         stdin_file.seek(0)
         self.stdout_file = tempfile.TemporaryFile()

--- a/tests/integration/test_json_encoding/configs/allow_use_non_utf8.xml
+++ b/tests/integration/test_json_encoding/configs/allow_use_non_utf8.xml
@@ -1,0 +1,3 @@
+<clickhouse>
+    <use_non_utf8_chars_in_schema>1</use_non_utf8_chars_in_schema>
+</clickhouse>

--- a/tests/integration/test_json_encoding/test.py
+++ b/tests/integration/test_json_encoding/test.py
@@ -1,0 +1,107 @@
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__)
+
+node1 = cluster.add_instance("node1", stay_alive=True)
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+        yield cluster
+
+    finally:
+        cluster.shutdown()
+
+
+def test_create_with_incorrect_encoding(started_cluster):
+    node = node1
+    test_table = "test_table"
+
+    node.query(f"DROP TABLE IF EXISTS {test_table}")
+    node.query(
+        f"""
+        CREATE TABLE `{test_table}`(
+        `привет` Int32,
+        date DateTime
+        ) ENGINE=MergeTree()
+        ORDER BY date PARTITION BY toDate(date)
+        SETTINGS ratio_of_defaults_for_sparse_serialization = 0.0
+        """.encode(
+            "cp1251"
+        )
+    )
+    node.query_and_get_error(
+        f"INSERT INTO `{test_table}` VALUES (100, '2024-11-22 10:00:00')"
+    )
+
+    assert (
+        node.query(
+            f"SELECT count() FROM system.parts WHERE table='{test_table}' and active=1;"
+        )
+        == "0\n"
+    )
+    node.restart_clickhouse()
+    assert (
+        node.query(
+            f"SELECT count() FROM system.parts WHERE table='{test_table}' and active=1;"
+        )
+        == "0\n"
+    )
+    node.query(f"DROP TABLE {test_table} SYNC")
+
+
+def test_alter_with_incorrect_encoding(started_cluster):
+    node = node1
+    test_table = "test_table"
+
+    node.query(f"DROP TABLE IF EXISTS {test_table}")
+    node.query(
+        f"""
+        CREATE TABLE `{test_table}`(
+            val UInt32
+        ) ENGINE=MergeTree()
+        ORDER BY val PARTITION BY toDate(val)
+        SETTINGS ratio_of_defaults_for_sparse_serialization = 0.0
+        """
+    )
+
+    node.query(f"INSERT INTO `{test_table}` SELECT 1;")
+    assert (
+        node.query(
+            f"SELECT count() FROM system.parts WHERE table='{test_table}' and active=1;"
+        )
+        == "1\n"
+    )
+
+    node.query_and_get_error(
+        f"ALTER TABLE {test_table} ADD COLUMN `очень_странная_кодировка` UInt32 2".encode(
+            "cp1251"
+        )
+    )
+    assert (
+        node.query(
+            f"SELECT count() FROM system.parts WHERE table='{test_table}' and active=1;"
+        )
+        == "1\n"
+    )
+
+    node.query_and_get_error(f"INSERT INTO `{test_table}` SELECT 1,1")
+    assert (
+        node.query(
+            f"SELECT count() FROM system.parts WHERE table='{test_table}' and active=1;"
+        )
+        == "1\n"
+    )
+    node.restart_clickhouse()
+
+    assert (
+        node.query(
+            f"SELECT count() FROM system.parts WHERE table='{test_table}' and active=1;"
+        )
+        == "1\n"
+    )
+    node.query(f"DROP TABLE {test_table} SYNC")

--- a/tests/integration/test_json_encoding/test.py
+++ b/tests/integration/test_json_encoding/test.py
@@ -5,6 +5,9 @@ from helpers.cluster import ClickHouseCluster
 cluster = ClickHouseCluster(__file__)
 
 node1 = cluster.add_instance("node1", stay_alive=True)
+node2 = cluster.add_instance(
+    "node2", main_configs=["configs/allow_use_non_utf8.xml"], stay_alive=True
+)
 
 
 @pytest.fixture(scope="module")
@@ -37,7 +40,7 @@ def test_create_with_non_utf(started_cluster):
 
 
 def test_insert_with_non_utf_encoding(started_cluster):
-    node = node1
+    node = node2
     test_table = "test_table"
 
     node.query(f"DROP TABLE IF EXISTS {test_table}")
@@ -50,8 +53,7 @@ def test_insert_with_non_utf_encoding(started_cluster):
         ORDER BY date PARTITION BY toDate(date)
         """.encode(
             "cp1251"
-        ),
-        settings={"use_non_utf8_chars_in_schema": 1},
+        )
     )
     node.query_and_get_error(
         f"INSERT INTO `{test_table}` VALUES (100, '2024-11-22 10:00:00')"
@@ -74,7 +76,7 @@ def test_insert_with_non_utf_encoding(started_cluster):
 
 
 def test_alter_with_non_utf_encoding(started_cluster):
-    node = node1
+    node = node2
     test_table = "test_table"
 
     node.query(f"DROP TABLE IF EXISTS {test_table}")


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement



### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Ensure that a valid utf8 string is used for serialization json.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

### Motivation

By now if the user used non-utf8 characters in the column name (with `Create` or `Alter`) then after restart, all parts with such column in `serialization.json` file will be `broken_on_start`,  so user should manually recover these parts by removing columns and moving parts from detached.

As @aalexfvk suggested (#72281), we got 2 options: prevent using non-utf8 characters or support other encodings with escaping methods. I believe that the first option is preferable, because
https://clickhouse.com/docs/en/install#launch
```
The terminal must use UTF-8 encoding.
```
https://clickhouse.com/docs/en/development/style#how-to-write-code
```
Use UTF-8 everywhere. Use std::string and char *. Do not use std::wstring and wchar_t. 
```

~Actually the PR won't resolve the problem fully. But it should protect from creating the parts that will be broken after restarting the server and make the issue visible for users. 
We will also make a separate with validating column names for other entities,  but it seems that at the moment the problem can only occur with objects that use json files inside.~

UPD. 
The PR introduces two restrictions:
1. Do not allow `create  table` with non utf symbols in the column name or `alter table` which adds such columns in the existing table.
2. Do not allow to insert new data in the table with invalid serialization json in parts, if such already exists. 

Related issues: https://github.com/ClickHouse/ClickHouse/issues/69329 https://github.com/ClickHouse/ClickHouse/issues/72281
<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---ci_include_fuzzer--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
