### PR TITLE
Fix for repeated call of ThreadPoolCallbackRunnerLocal::waitForAllToFinishAndRethrowFirstError

### DIFF
--- a/src/Common/threadPoolCallbackRunner.h
+++ b/src/Common/threadPoolCallbackRunner.h
@@ -150,7 +150,8 @@ public:
     void operator() (Callback && callback, Priority priority = {})
     {
         auto promise = std::make_shared<std::promise<Result>>();
-        auto & task = tasks.emplace_back(std::make_shared<Task>({.future = promise->get_future()}));
+        auto & task = tasks.emplace_back(std::make_shared<Task>());
+        task->future = promise->get_future();
 
         auto task_func = [task, thread_group = CurrentThread::getGroup(), my_thread_name = thread_name, my_callback = std::move(callback), promise]() mutable -> void
         {

--- a/src/Common/threadPoolCallbackRunner.h
+++ b/src/Common/threadPoolCallbackRunner.h
@@ -74,7 +74,7 @@ std::future<Result> scheduleFromThreadPoolUnsafe(T && task, ThreadPool & pool, c
 /// When creating a runner on stack, you MUST make sure that it's created (and destroyed) before local objects captured by task lambda.
 
 template <typename Result, typename PoolT = ThreadPool, typename Callback = std::function<Result()>>
-class ThreadPoolCallbackRunnerLocal
+class ThreadPoolCallbackRunnerLocal final
 {
     PoolT & pool;
     std::string thread_name;
@@ -149,9 +149,8 @@ public:
 
     void operator() (Callback && callback, Priority priority = {})
     {
-        auto & task = tasks.emplace_back(std::make_shared<Task>());
-
-        std::shared_ptr<std::promise<Result>> promise = std::make_shared<std::promise<Result>>();
+        auto promise = std::make_shared<std::promise<Result>>();
+        auto & task = tasks.emplace_back(std::make_shared<Task>({.future = promise->get_future()}));
 
         auto task_func = [task, thread_group = CurrentThread::getGroup(), my_thread_name = thread_name, my_callback = std::move(callback), promise]() mutable -> void
         {
@@ -191,8 +190,6 @@ public:
             executeCallback(*promise, my_callback);
         };
 
-        task->future = promise->get_future();
-
         try
         {
             /// Note: calling method scheduleOrThrowOnError in intentional, because we don't want to throw exceptions
@@ -222,8 +219,14 @@ public:
     void waitForAllToFinishAndRethrowFirstError()
     {
         waitForAllToFinish();
+
         for (auto & task : tasks)
-            task->future.get();
+        {
+            /// task->future may be invalid if waitForAllToFinishAndRethrowFirstError() is called multiple times
+            /// and previous call has already rethrown the exception and has not cleared tasks.
+            if (task->future.valid())
+                task->future.get();
+        }
 
         tasks.clear();
     }


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Followup for https://github.com/ClickHouse/ClickHouse/pull/73629
Fix for the case when first cal to waitForAllToFinishAndRethrowFirstError throws exception from some task, and the next call see tasks with invalid futures - those that for which .get() was already called. 

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---ci_include_fuzzer--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
