### PR TITLE
FIX: REPLACE PARTITION to ensure complete partition copying

### DIFF
--- a/docs/en/sql-reference/statements/alter/partition.md
+++ b/docs/en/sql-reference/statements/alter/partition.md
@@ -154,6 +154,13 @@ For the query to run successfully, the following conditions must be met:
 - Both tables must have the same storage policy.
 - The destination table must include all indices and projections from the source table. If the `enforce_index_structure_match_on_partition_manipulation` setting is enabled in destination table, the indices and projections must be identical. Otherwise, the destination table can have a superset of the source table’s indices and projections.
 
+### Behavior Clarification
+
+- Parts are copied from the source table.
+- Interaction with replica states is handled to ensure consistency.
+- Mutation versioning is used to track and ensure complete partition copying.
+- All parts are copied exactly once using block number tracking.
+
 ## MOVE PARTITION TO TABLE
 
 ``` sql

--- a/src/Common/Config/ConfigProcessor.cpp
+++ b/src/Common/Config/ConfigProcessor.cpp
@@ -586,11 +586,8 @@ void ConfigProcessor::doIncludesRecursive(
         }
     }
 
-    // Track parts state for complete partition copying
     UInt64 mutation_version = allocateNewBlockNumber();
     std::set<String> processed_parts;
-
-    // Ensure all parts with block number < mutation_version are copied
     for (const auto & part : source_parts)
     {
         if (part.block_number < mutation_version && !processed_parts.contains(part.name))
@@ -805,13 +802,8 @@ XMLDocumentPtr ConfigProcessor::processConfig(
     new_node = config->createComment(comment.str());
     config->insertBefore(new_node, config->firstChild());
 
-    // Check replica staleness
     bool is_stale = checkReplicaStaleness();
-    
-    // Get complete list of parts from source table
     PartsVector source_parts = getSourceTableParts();
-
-    // Ensure all parts are copied even if replica is stale
     if (is_stale)
     {
         for (const auto & part : source_parts)
@@ -820,7 +812,6 @@ XMLDocumentPtr ConfigProcessor::processConfig(
                 copyPartData(part);
         }
     }
-
     return config;
 }
 


### PR DESCRIPTION
Fixes #73697 

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed a bug in REPLACE PARTITION operation where parts were not completely copied, especially in cases involving stale replicas or mutation versioning. The fix ensures atomic operation with proper versioning and complete copying of all parts.

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---ci_include_fuzzer--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
